### PR TITLE
test: align zero runs route parity

### DIFF
--- a/turbo/apps/web/app/api/zero/runs/[id]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/runs/[id]/__tests__/route.test.ts
@@ -83,6 +83,22 @@ describe("GET /api/zero/runs/:id", () => {
     expect(response.status).toBe(401);
   });
 
+  it("should return 401 when the authenticated session has no active organization", async () => {
+    mockClerk({ userId: uniqueId("zrun-no-org"), orgId: null });
+
+    const response = await GET(
+      createTestRequest(
+        "http://localhost:3000/api/zero/runs/00000000-0000-0000-0000-000000000000",
+      ),
+    );
+    expect(response.status).toBe(401);
+
+    const data = await response.json();
+    expect(data).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
   it("should return 403 for sandbox token without agent-run:read capability", async () => {
     mockClerk({ userId: null });
     const token = await generateSandboxToken("user-1", "run-1", "org-test");

--- a/turbo/apps/web/app/api/zero/runs/[id]/cancel/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/runs/[id]/cancel/__tests__/route.test.ts
@@ -5,6 +5,13 @@ import {
   createTestRequest,
   createTestOrg,
   createTestCompose,
+  enqueueTestRun,
+  findTestQueueEntry,
+  findTestRunRecord,
+  insertTestModelUsageEventForRun,
+  findTestUsageEvent,
+  setOrgCredits,
+  getOrgCredits,
 } from "../../../../../../../src/__tests__/api-test-helpers";
 import {
   testContext,
@@ -89,6 +96,152 @@ describe("POST /api/zero/runs/:id/cancel", () => {
     expect(data.status).toBe("cancelled");
   });
 
+  it("should drain the org queue after cancelling a running run", async () => {
+    const userId = uniqueId("zcanc-drain-running");
+    const { orgId } = await setupOrg(userId);
+    const compose = await createTestCompose(`agent-${uniqueId("zcanc")}`);
+    const { runId } = await seedTestRun(userId, compose.composeId, {
+      status: "running",
+    });
+    const queued = await enqueueTestRun({
+      userId,
+      agentComposeVersionId: compose.versionId,
+      orgId,
+      composeId: compose.composeId,
+      prompt: "queued after running cancel",
+    });
+
+    await expect(findTestQueueEntry(queued.runId)).resolves.toBeDefined();
+
+    const response = await POST(
+      createTestRequest(cancelUrl(runId), { method: "POST" }),
+    );
+    expect(response.status).toBe(200);
+
+    const queuedRun = await findTestRunRecord(queued.runId);
+    expect(queuedRun?.status).toBe("pending");
+    await expect(findTestQueueEntry(queued.runId)).resolves.toBeUndefined();
+  });
+
+  it("should drain the org queue after cancelling a queued run", async () => {
+    const userId = uniqueId("zcanc-drain-queued");
+    const { orgId } = await setupOrg(userId);
+    const compose = await createTestCompose(`agent-${uniqueId("zcanc")}`);
+    const cancelled = await enqueueTestRun({
+      userId,
+      agentComposeVersionId: compose.versionId,
+      orgId,
+      composeId: compose.composeId,
+      prompt: "queued run to cancel",
+    });
+    const nextQueued = await enqueueTestRun({
+      userId,
+      agentComposeVersionId: compose.versionId,
+      orgId,
+      composeId: compose.composeId,
+      prompt: "next queued run",
+    });
+
+    const response = await POST(
+      createTestRequest(cancelUrl(cancelled.runId), { method: "POST" }),
+    );
+    expect(response.status).toBe(200);
+
+    const cancelledRun = await findTestRunRecord(cancelled.runId);
+    expect(cancelledRun?.status).toBe("cancelled");
+    await expect(findTestQueueEntry(cancelled.runId)).resolves.toBeUndefined();
+
+    const nextRun = await findTestRunRecord(nextQueued.runId);
+    expect(nextRun?.status).toBe("pending");
+    await expect(findTestQueueEntry(nextQueued.runId)).resolves.toBeUndefined();
+  });
+
+  it("should not drain the org queue when cancellation is idempotent", async () => {
+    const userId = uniqueId("zcanc-no-drain-idem");
+    const { orgId } = await setupOrg(userId);
+    const compose = await createTestCompose(`agent-${uniqueId("zcanc")}`);
+    const { runId } = await seedTestRun(userId, compose.composeId, {
+      status: "cancelled",
+      completedAt: new Date(),
+    });
+    const queued = await enqueueTestRun({
+      userId,
+      agentComposeVersionId: compose.versionId,
+      orgId,
+      composeId: compose.composeId,
+      prompt: "queued should remain queued",
+    });
+
+    const response = await POST(
+      createTestRequest(cancelUrl(runId), { method: "POST" }),
+    );
+    expect(response.status).toBe(200);
+
+    const queuedRun = await findTestRunRecord(queued.runId);
+    expect(queuedRun?.status).toBe("queued");
+    await expect(findTestQueueEntry(queued.runId)).resolves.toBeDefined();
+  });
+
+  it("should process pending usage events after cancelling a running run", async () => {
+    const userId = uniqueId("zcanc-credit-running");
+    const { orgId } = await setupOrg(userId);
+    await setOrgCredits(orgId, 1000);
+    const compose = await createTestCompose(`agent-${uniqueId("zcanc")}`);
+    const { runId } = await seedTestRun(userId, compose.composeId, {
+      status: "running",
+    });
+    const { id: usageEventId } = await insertTestModelUsageEventForRun({
+      runId,
+      orgId,
+      userId,
+      inputTokens: 5000,
+      outputTokens: 0,
+      status: "pending",
+    });
+
+    const response = await POST(
+      createTestRequest(cancelUrl(runId), { method: "POST" }),
+    );
+    expect(response.status).toBe(200);
+
+    const usageEvent = await findTestUsageEvent(usageEventId);
+    expect(usageEvent?.status).toBe("processed");
+    expect(usageEvent?.creditsCharged).toBe(1);
+    await expect(getOrgCredits(orgId)).resolves.toBe(999);
+  });
+
+  it("should not process pending usage events after cancelling a queued run", async () => {
+    const userId = uniqueId("zcanc-credit-queued");
+    const { orgId } = await setupOrg(userId);
+    await setOrgCredits(orgId, 1000);
+    const compose = await createTestCompose(`agent-${uniqueId("zcanc")}`);
+    const queued = await enqueueTestRun({
+      userId,
+      agentComposeVersionId: compose.versionId,
+      orgId,
+      composeId: compose.composeId,
+      prompt: "queued with pending usage",
+    });
+    const { id: usageEventId } = await insertTestModelUsageEventForRun({
+      runId: queued.runId,
+      orgId,
+      userId,
+      inputTokens: 5000,
+      outputTokens: 0,
+      status: "pending",
+    });
+
+    const response = await POST(
+      createTestRequest(cancelUrl(queued.runId), { method: "POST" }),
+    );
+    expect(response.status).toBe(200);
+
+    const usageEvent = await findTestUsageEvent(usageEventId);
+    expect(usageEvent?.status).toBe("pending");
+    expect(usageEvent?.creditsCharged).toBeNull();
+    await expect(getOrgCredits(orgId)).resolves.toBe(1000);
+  });
+
   it("should return 404 when run not found", async () => {
     const userId = uniqueId("zcanc-nf");
     await setupOrg(userId);
@@ -113,6 +266,25 @@ describe("POST /api/zero/runs/:id/cancel", () => {
       ),
     );
     expect(response.status).toBe(401);
+  });
+
+  it("should return 401 when the authenticated session has no active organization", async () => {
+    mockClerk({ userId: uniqueId("zcanc-no-org"), orgId: null });
+
+    const response = await POST(
+      createTestRequest(
+        "http://localhost:3000/api/zero/runs/00000000-0000-0000-0000-000000000000/cancel",
+        {
+          method: "POST",
+        },
+      ),
+    );
+    expect(response.status).toBe(401);
+
+    const data = await response.json();
+    expect(data).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
   });
 
   it("should return 403 for sandbox token without agent-run:write capability", async () => {

--- a/turbo/apps/web/app/api/zero/runs/[id]/cancel/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/runs/[id]/cancel/__tests__/route.test.ts
@@ -12,6 +12,7 @@ import {
   findTestUsageEvent,
   setOrgCredits,
   getOrgCredits,
+  insertTestUsagePricing,
 } from "../../../../../../../src/__tests__/api-test-helpers";
 import {
   testContext,
@@ -186,6 +187,13 @@ describe("POST /api/zero/runs/:id/cancel", () => {
     const userId = uniqueId("zcanc-credit-running");
     const { orgId } = await setupOrg(userId);
     await setOrgCredits(orgId, 1000);
+    await insertTestUsagePricing({
+      kind: "model",
+      provider: "claude-sonnet-4-6",
+      category: "tokens.input",
+      unitPrice: 1,
+      unitSize: 5000,
+    });
     const compose = await createTestCompose(`agent-${uniqueId("zcanc")}`);
     const { runId } = await seedTestRun(userId, compose.composeId, {
       status: "running",
@@ -214,6 +222,13 @@ describe("POST /api/zero/runs/:id/cancel", () => {
     const userId = uniqueId("zcanc-credit-queued");
     const { orgId } = await setupOrg(userId);
     await setOrgCredits(orgId, 1000);
+    await insertTestUsagePricing({
+      kind: "model",
+      provider: "claude-sonnet-4-6",
+      category: "tokens.input",
+      unitPrice: 1,
+      unitSize: 5000,
+    });
     const compose = await createTestCompose(`agent-${uniqueId("zcanc")}`);
     const queued = await enqueueTestRun({
       userId,

--- a/turbo/apps/web/app/api/zero/runs/[id]/cancel/route.ts
+++ b/turbo/apps/web/app/api/zero/runs/[id]/cancel/route.ts
@@ -14,12 +14,14 @@ import {
   drainOrgQueue,
 } from "../../../../../../src/lib/zero/zero-run-queue-service";
 import { processOrgUsageEvents } from "../../../../../../src/lib/zero/credit/usage-event-service";
+import { logger } from "../../../../../../src/lib/shared/logger";
 import {
   isNotFound,
   isBadRequest,
   isRunNotCancellable,
 } from "@vm0/api-services/errors";
-import { after } from "next/server";
+
+const log = logger("api:zero-runs:cancel");
 
 const router = tsr.router(zeroRunsCancelContract, {
   cancel: async ({ params, headers }) => {
@@ -29,6 +31,9 @@ const router = tsr.router(zeroRunsCancelContract, {
       requiredCapability: "agent-run:write",
     });
     if (isAuthError(authCtx)) return authCtx;
+    if (!authCtx.orgId) {
+      return createErrorResponse("UNAUTHORIZED", "Not authenticated");
+    }
     const { userId } = authCtx;
 
     const { org } = await resolveOrg(authCtx);
@@ -37,7 +42,7 @@ const router = tsr.router(zeroRunsCancelContract, {
       const result = await cancelRun(params.id, userId, org.orgId);
 
       if (!result.alreadyCancelled) {
-        after(async () => {
+        try {
           const shouldProcessCredits = await dispatchCancelSideEffects(
             result,
             (orgId) => {
@@ -47,7 +52,12 @@ const router = tsr.router(zeroRunsCancelContract, {
           if (shouldProcessCredits) {
             await processOrgUsageEvents(result.orgId);
           }
-        });
+        } catch (sideEffectError) {
+          log.error("Failed to dispatch run cancel side effects", {
+            runId: result.runId,
+            sideEffectError,
+          });
+        }
       }
 
       return {

--- a/turbo/apps/web/app/api/zero/runs/[id]/context/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/runs/[id]/context/__tests__/route.test.ts
@@ -11,6 +11,7 @@ import {
   uniqueId,
 } from "../../../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../../../src/__tests__/clerk-mock";
+import { generateSandboxToken } from "../../../../../../../src/lib/auth/sandbox-token";
 import type { RunContextSnapshot } from "../../../../../../../src/lib/shared/axiom/client";
 import { seedTestRun } from "../../../../../../../src/__tests__/db-test-seeders/runs";
 
@@ -148,5 +149,39 @@ describe("GET /api/zero/runs/:id/context", () => {
       ),
     );
     expect(response.status).toBe(401);
+  });
+
+  it("should return 401 when the authenticated session has no active organization", async () => {
+    mockClerk({ userId: uniqueId("zctx-no-org"), orgId: null });
+
+    const response = await GET(
+      createTestRequest(
+        "http://localhost:3000/api/zero/runs/00000000-0000-0000-0000-000000000000/context",
+      ),
+    );
+    expect(response.status).toBe(401);
+
+    const data = await response.json();
+    expect(data).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("should return 403 for sandbox token without agent-run:read capability", async () => {
+    mockClerk({ userId: null });
+    const token = await generateSandboxToken("user-1", "run-1", "org-test");
+
+    const response = await GET(
+      createTestRequest(
+        "http://localhost:3000/api/zero/runs/00000000-0000-0000-0000-000000000000/context",
+        {
+          headers: { Authorization: `Bearer ${token}` },
+        },
+      ),
+    );
+    expect(response.status).toBe(403);
+
+    const data = await response.json();
+    expect(data.error.message).toContain("agent-run:read");
   });
 });

--- a/turbo/apps/web/app/api/zero/runs/[id]/context/route.ts
+++ b/turbo/apps/web/app/api/zero/runs/[id]/context/route.ts
@@ -1,5 +1,6 @@
 import { createHandler, tsr } from "../../../../../../src/lib/ts-rest-handler";
 import { zeroRunContextContract } from "@vm0/api-contracts/contracts/zero-runs";
+import { createErrorResponse } from "@vm0/api-contracts/contracts/errors";
 import { initServices } from "../../../../../../src/lib/init-services";
 import {
   requireAuth,
@@ -17,6 +18,9 @@ const router = tsr.router(zeroRunContextContract, {
       requiredCapability: "agent-run:read",
     });
     if (isAuthError(authCtx)) return authCtx;
+    if (!authCtx.orgId) {
+      return createErrorResponse("UNAUTHORIZED", "Not authenticated");
+    }
     const { userId } = authCtx;
 
     const { org } = await resolveOrg(authCtx);

--- a/turbo/apps/web/app/api/zero/runs/[id]/network/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/runs/[id]/network/__tests__/route.test.ts
@@ -11,6 +11,7 @@ import {
   uniqueId,
 } from "../../../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../../../src/__tests__/clerk-mock";
+import { generateSandboxToken } from "../../../../../../../src/lib/auth/sandbox-token";
 import { seedTestRun } from "../../../../../../../src/__tests__/db-test-seeders/runs";
 
 const context = testContext();
@@ -153,6 +154,40 @@ describe("GET /api/zero/runs/:id/network", () => {
       ),
     );
     expect(response.status).toBe(401);
+  });
+
+  it("should return 401 when the authenticated session has no active organization", async () => {
+    mockClerk({ userId: uniqueId("znet-no-org"), orgId: null });
+
+    const response = await GET(
+      createTestRequest(
+        "http://localhost:3000/api/zero/runs/00000000-0000-0000-0000-000000000000/network",
+      ),
+    );
+    expect(response.status).toBe(401);
+
+    const data = await response.json();
+    expect(data).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("should return 403 for sandbox token without agent-run:read capability", async () => {
+    mockClerk({ userId: null });
+    const token = await generateSandboxToken("user-1", "run-1", "org-test");
+
+    const response = await GET(
+      createTestRequest(
+        "http://localhost:3000/api/zero/runs/00000000-0000-0000-0000-000000000000/network",
+        {
+          headers: { Authorization: `Bearer ${token}` },
+        },
+      ),
+    );
+    expect(response.status).toBe(403);
+
+    const data = await response.json();
+    expect(data.error.message).toContain("agent-run:read");
   });
 
   it("should set hasMore when results exceed limit", async () => {

--- a/turbo/apps/web/app/api/zero/runs/[id]/network/route.ts
+++ b/turbo/apps/web/app/api/zero/runs/[id]/network/route.ts
@@ -1,5 +1,6 @@
 import { createHandler, tsr } from "../../../../../../src/lib/ts-rest-handler";
 import { zeroRunNetworkLogsContract } from "@vm0/api-contracts/contracts/zero-runs";
+import { createErrorResponse } from "@vm0/api-contracts/contracts/errors";
 import type { AxiomNetworkEvent } from "@vm0/api-contracts/contracts/runs";
 import { initServices } from "../../../../../../src/lib/init-services";
 import {
@@ -23,6 +24,9 @@ const router = tsr.router(zeroRunNetworkLogsContract, {
       requiredCapability: "agent-run:read",
     });
     if (isAuthError(authCtx)) return authCtx;
+    if (!authCtx.orgId) {
+      return createErrorResponse("UNAUTHORIZED", "Not authenticated");
+    }
     const { userId } = authCtx;
 
     const { org } = await resolveOrg(authCtx);

--- a/turbo/apps/web/app/api/zero/runs/[id]/route.ts
+++ b/turbo/apps/web/app/api/zero/runs/[id]/route.ts
@@ -1,5 +1,6 @@
 import { createHandler, tsr } from "../../../../../src/lib/ts-rest-handler";
 import { zeroRunsByIdContract } from "@vm0/api-contracts/contracts/zero-runs";
+import { createErrorResponse } from "@vm0/api-contracts/contracts/errors";
 import { initServices } from "../../../../../src/lib/init-services";
 import {
   requireAuth,
@@ -16,6 +17,9 @@ const router = tsr.router(zeroRunsByIdContract, {
       requiredCapability: "agent-run:read",
     });
     if (isAuthError(authCtx)) return authCtx;
+    if (!authCtx.orgId) {
+      return createErrorResponse("UNAUTHORIZED", "Not authenticated");
+    }
     const { userId } = authCtx;
 
     const { org } = await resolveOrg(authCtx);

--- a/turbo/apps/web/app/api/zero/runs/[id]/runner/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/runs/[id]/runner/__tests__/route.test.ts
@@ -11,6 +11,7 @@ import {
   uniqueId,
 } from "../../../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../../../src/__tests__/clerk-mock";
+import { generateSandboxToken } from "../../../../../../../src/lib/auth/sandbox-token";
 import {
   seedTestRun,
   setTestRunSandboxReuseResult,
@@ -102,5 +103,39 @@ describe("GET /api/zero/runs/:id/runner", () => {
       ),
     );
     expect(response.status).toBe(401);
+  });
+
+  it("returns 401 when the authenticated session has no active organization", async () => {
+    mockClerk({ userId: uniqueId("zrun-no-org"), orgId: null });
+
+    const response = await GET(
+      createTestRequest(
+        "http://localhost:3000/api/zero/runs/00000000-0000-0000-0000-000000000000/runner",
+      ),
+    );
+    expect(response.status).toBe(401);
+
+    const data = await response.json();
+    expect(data).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("returns 403 for sandbox token without agent-run:read capability", async () => {
+    mockClerk({ userId: null });
+    const token = await generateSandboxToken("user-1", "run-1", "org-test");
+
+    const response = await GET(
+      createTestRequest(
+        "http://localhost:3000/api/zero/runs/00000000-0000-0000-0000-000000000000/runner",
+        {
+          headers: { Authorization: `Bearer ${token}` },
+        },
+      ),
+    );
+    expect(response.status).toBe(403);
+
+    const data = await response.json();
+    expect(data.error.message).toContain("agent-run:read");
   });
 });

--- a/turbo/apps/web/app/api/zero/runs/[id]/runner/route.ts
+++ b/turbo/apps/web/app/api/zero/runs/[id]/runner/route.ts
@@ -1,6 +1,7 @@
 import { createHandler, tsr } from "../../../../../../src/lib/ts-rest-handler";
 import { zeroRunRunnerContract } from "@vm0/api-contracts/contracts/zero-runs";
 import { sandboxReuseResultSchema } from "@vm0/api-contracts/contracts/webhooks";
+import { createErrorResponse } from "@vm0/api-contracts/contracts/errors";
 import { initServices } from "../../../../../../src/lib/init-services";
 import {
   requireAuth,
@@ -18,6 +19,9 @@ const router = tsr.router(zeroRunRunnerContract, {
       requiredCapability: "agent-run:read",
     });
     if (isAuthError(authCtx)) return authCtx;
+    if (!authCtx.orgId) {
+      return createErrorResponse("UNAUTHORIZED", "Not authenticated");
+    }
     const { userId } = authCtx;
 
     const { org } = await resolveOrg(authCtx);

--- a/turbo/apps/web/app/api/zero/runs/[id]/telemetry/agent/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/runs/[id]/telemetry/agent/__tests__/route.test.ts
@@ -71,6 +71,22 @@ describe("GET /api/zero/runs/:id/telemetry/agent", () => {
     expect(response.status).toBe(401);
   });
 
+  it("should return 401 when the authenticated session has no active organization", async () => {
+    mockClerk({ userId: uniqueId("ztele-no-org"), orgId: null });
+
+    const response = await GET(
+      createTestRequest(
+        `http://localhost:3000/api/zero/runs/${randomUUID()}/telemetry/agent?limit=10&order=desc`,
+      ),
+    );
+    expect(response.status).toBe(401);
+
+    const data = await response.json();
+    expect(data).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
   it("should return 403 for sandbox token without agent-run:read capability", async () => {
     mockClerk({ userId: null });
     const token = await generateSandboxToken("user-1", "run-1", "org-test");

--- a/turbo/apps/web/app/api/zero/runs/[id]/telemetry/agent/route.ts
+++ b/turbo/apps/web/app/api/zero/runs/[id]/telemetry/agent/route.ts
@@ -3,6 +3,7 @@ import {
   tsr,
 } from "../../../../../../../src/lib/ts-rest-handler";
 import { zeroRunAgentEventsContract } from "@vm0/api-contracts/contracts/zero-runs";
+import { createErrorResponse } from "@vm0/api-contracts/contracts/errors";
 import { initServices } from "../../../../../../../src/lib/init-services";
 import {
   requireAuth,
@@ -20,6 +21,9 @@ const router = tsr.router(zeroRunAgentEventsContract, {
       requiredCapability: "agent-run:read",
     });
     if (isAuthError(authCtx)) return authCtx;
+    if (!authCtx.orgId) {
+      return createErrorResponse("UNAUTHORIZED", "Not authenticated");
+    }
     const { userId } = authCtx;
 
     const { org } = await resolveOrg(authCtx);

--- a/turbo/apps/web/app/api/zero/runs/queue/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/runs/queue/__tests__/route.test.ts
@@ -75,6 +75,20 @@ describe("GET /api/zero/runs/queue", () => {
     expect(response.status).toBe(401);
   });
 
+  it("should return 401 when the authenticated session has no active organization", async () => {
+    mockClerk({ userId: uniqueId("zqueue-no-org"), orgId: null });
+
+    const response = await GET(
+      createTestRequest("http://localhost:3000/api/zero/runs/queue"),
+    );
+    expect(response.status).toBe(401);
+
+    const data = await response.json();
+    expect(data).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
   it("should return 403 for sandbox token without agent-run:read capability", async () => {
     mockClerk({ userId: null });
     const token = await generateSandboxToken("user-1", "run-1", "org-test");

--- a/turbo/apps/web/app/api/zero/runs/queue/route.ts
+++ b/turbo/apps/web/app/api/zero/runs/queue/route.ts
@@ -1,6 +1,7 @@
 import { createHandler, tsr } from "../../../../../src/lib/ts-rest-handler";
 import { zeroRunsQueueContract } from "@vm0/api-contracts/contracts/zero-runs";
 import { orgTierSchema } from "@vm0/api-contracts/contracts/orgs";
+import { createErrorResponse } from "@vm0/api-contracts/contracts/errors";
 import { initServices } from "../../../../../src/lib/init-services";
 import {
   requireAuth,
@@ -17,6 +18,9 @@ const router = tsr.router(zeroRunsQueueContract, {
       requiredCapability: "agent-run:read",
     });
     if (isAuthError(authCtx)) return authCtx;
+    if (!authCtx.orgId) {
+      return createErrorResponse("UNAUTHORIZED", "Not authenticated");
+    }
     const { userId } = authCtx;
 
     const { org } = await resolveOrg(authCtx);

--- a/turbo/apps/web/src/lib/infra/run/run-service.ts
+++ b/turbo/apps/web/src/lib/infra/run/run-service.ts
@@ -593,7 +593,6 @@ export async function getRunById(
 
 /**
  * Dispatch post-cancellation side effects (Ably notification, callbacks, queue drain).
- * Designed to be called inside `after()` so it runs after the response is sent.
  *
  * Returns `true` when the cancelled run was previously active (running/pending),
  * indicating the caller should also process org credits.
@@ -603,6 +602,10 @@ export async function dispatchCancelSideEffects(
   drain: (orgId: string) => Promise<void>,
 ): Promise<boolean> {
   const log = logger("service:run:cancel");
+
+  if (result.alreadyCancelled) {
+    return false;
+  }
 
   if (result.previousStatus === "running" && result.runnerGroup) {
     const published = await publishCancelNotification(
@@ -616,19 +619,17 @@ export async function dispatchCancelSideEffects(
     }
   }
 
-  const shouldDrain =
+  const shouldProcessCredits =
     result.previousStatus === "running" || result.previousStatus === "pending";
 
   await dispatchTerminalSideEffects(
     result.runId,
     "cancelled",
     "Run cancelled",
-    shouldDrain
-      ? () => {
-          return drain(result.orgId);
-        }
-      : undefined,
+    () => {
+      return drain(result.orgId);
+    },
   );
 
-  return shouldDrain;
+  return shouldProcessCredits;
 }


### PR DESCRIPTION
## Summary

- align zero runs web routes with API no-active-org 401 behavior
- add missing web sandbox capability coverage for runner, context, and network routes
- align web cancel side-effect decisions so non-idempotent cancels drain the queue while credit processing stays limited to running/pending cancels

Closes #12635

## Tests

- pnpm -F web exec vitest run 'app/api/zero/runs/[id]/__tests__/route.test.ts' 'app/api/zero/runs/[id]/runner/__tests__/route.test.ts' 'app/api/zero/runs/[id]/context/__tests__/route.test.ts' 'app/api/zero/runs/[id]/network/__tests__/route.test.ts' 'app/api/zero/runs/[id]/telemetry/agent/__tests__/route.test.ts' 'app/api/zero/runs/[id]/cancel/__tests__/route.test.ts' app/api/zero/runs/queue/__tests__/route.test.ts
- pnpm format
- pnpm turbo run lint
- pnpm check-types
- pnpm knip
- git diff --check