### PR TITLE
feat(api): migrate integrations/slack/upload-file init+complete to api backend (wave 6 #18)

### DIFF
--- a/turbo/apps/api/src/__tests__/mocks.ts
+++ b/turbo/apps/api/src/__tests__/mocks.ts
@@ -51,6 +51,8 @@ export interface ApiTestMocks {
     };
     readonly files: {
       readonly info: AsyncMock;
+      readonly getUploadURLExternal: AsyncMock;
+      readonly completeUploadExternal: AsyncMock;
     };
     readonly fetchFile: AsyncMock;
   };
@@ -143,6 +145,8 @@ const apiTestMocks: ApiTestMocks = vi.hoisted((): ApiTestMocks => {
     },
     files: {
       info: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
+      getUploadURLExternal: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
+      completeUploadExternal: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
     },
     fetchFile: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
   };
@@ -382,6 +386,9 @@ vi.mock("@slack/web-api", () => {
         },
         files: {
           info: apiTestMocks.slack.files.info,
+          getUploadURLExternal: apiTestMocks.slack.files.getUploadURLExternal,
+          completeUploadExternal:
+            apiTestMocks.slack.files.completeUploadExternal,
         },
       };
     }),
@@ -488,6 +495,8 @@ export function resetApiTestMocks(): void {
   apiTestMocks.slack.conversations.list.mockReset();
   apiTestMocks.slack.conversations.open.mockReset();
   apiTestMocks.slack.files.info.mockReset();
+  apiTestMocks.slack.files.getUploadURLExternal.mockReset();
+  apiTestMocks.slack.files.completeUploadExternal.mockReset();
   apiTestMocks.slack.fetchFile.mockReset();
   apiTestMocks.stripe.invoices.list.mockReset();
   apiTestMocks.stripe.invoices.create.mockReset();

--- a/turbo/apps/api/src/signals/external/slack-message-client.ts
+++ b/turbo/apps/api/src/signals/external/slack-message-client.ts
@@ -77,3 +77,99 @@ export async function postMessage(
   }
   return { kind: "ok", ts: result.ok.ts, channel: result.ok.channel };
 }
+
+type GetUploadUrlResult =
+  | {
+      readonly kind: "ok";
+      readonly uploadUrl: string;
+      readonly fileId: string;
+    }
+  | { readonly kind: "slack_error"; readonly error: string };
+
+export async function getUploadUrlExternal(
+  client: WebClient,
+  args: { readonly filename: string; readonly length: number },
+): Promise<GetUploadUrlResult> {
+  const result = await safeAsync(() => {
+    return client.files.getUploadURLExternal({
+      filename: args.filename,
+      length: args.length,
+    });
+  });
+  if ("error" in result) {
+    if (isSlackPlatformError(result.error)) {
+      return { kind: "slack_error", error: result.error.data.error };
+    }
+    throw result.error;
+  }
+  if (!result.ok.ok || !result.ok.upload_url || !result.ok.file_id) {
+    return { kind: "slack_error", error: result.ok.error ?? "unknown error" };
+  }
+  return {
+    kind: "ok",
+    uploadUrl: result.ok.upload_url,
+    fileId: result.ok.file_id,
+  };
+}
+
+type CompleteUploadResult =
+  | { readonly kind: "ok" }
+  | { readonly kind: "slack_error"; readonly error: string };
+
+export async function completeUploadExternal(
+  client: WebClient,
+  args: {
+    readonly fileId: string;
+    readonly channel: string;
+    readonly threadTs?: string;
+    readonly title?: string;
+    readonly initialComment?: string;
+  },
+): Promise<CompleteUploadResult> {
+  const result = await safeAsync(() => {
+    return client.files.completeUploadExternal({
+      files: [{ id: args.fileId, title: args.title }],
+      channel_id: args.channel,
+      thread_ts: args.threadTs,
+      initial_comment: args.initialComment,
+    });
+  });
+  if ("error" in result) {
+    if (isSlackPlatformError(result.error)) {
+      return { kind: "slack_error", error: result.error.data.error };
+    }
+    throw result.error;
+  }
+  return { kind: "ok" };
+}
+
+export interface SlackFileInfo {
+  readonly id?: string;
+  readonly name?: string;
+  readonly title?: string;
+  readonly mimetype?: string;
+  readonly filetype?: string;
+  readonly size?: number;
+  readonly permalink?: string;
+}
+
+type GetFileInfoResult =
+  | { readonly kind: "ok"; readonly file: SlackFileInfo | undefined }
+  | { readonly kind: "slack_error"; readonly error: string };
+
+export async function getFileInfo(
+  client: WebClient,
+  fileId: string,
+): Promise<GetFileInfoResult> {
+  const result = await safeAsync(() => {
+    return client.files.info({ file: fileId });
+  });
+  if ("error" in result) {
+    if (isSlackPlatformError(result.error)) {
+      return { kind: "slack_error", error: result.error.data.error };
+    }
+    throw result.error;
+  }
+  const file = result.ok.file as SlackFileInfo | undefined;
+  return { kind: "ok", file };
+}

--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -51,6 +51,8 @@ import { zeroSecretsRoutes } from "./routes/zero-secrets";
 import { zeroSkillsRoutes } from "./routes/zero-skills";
 import { zeroIntegrationsSlackRoutes } from "./routes/zero-integrations-slack";
 import { zeroIntegrationsSlackMessageRoutes } from "./routes/zero-integrations-slack-message";
+import { zeroIntegrationsSlackUploadCompleteRoutes } from "./routes/zero-integrations-slack-upload-complete";
+import { zeroIntegrationsSlackUploadInitRoutes } from "./routes/zero-integrations-slack-upload-init";
 import { zeroIntegrationsTelegramRoutes } from "./routes/zero-integrations-telegram";
 import { zeroIntegrationsTelegramMessageRoutes } from "./routes/zero-integrations-telegram-message";
 import { zeroIntegrationsTelegramUploadCompleteRoutes } from "./routes/zero-integrations-telegram-upload-complete";
@@ -130,6 +132,8 @@ export const ROUTES: readonly RouteEntry[] = [
   ...zeroSlackConnectRoutes,
   ...zeroIntegrationsSlackRoutes,
   ...zeroIntegrationsSlackMessageRoutes,
+  ...zeroIntegrationsSlackUploadCompleteRoutes,
+  ...zeroIntegrationsSlackUploadInitRoutes,
   ...zeroSlackChannelsRoutes,
   ...zeroIntegrationsTelegramRoutes,
   ...zeroIntegrationsTelegramMessageRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-slack-upload-complete.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-slack-upload-complete.test.ts
@@ -1,0 +1,380 @@
+import { randomUUID } from "node:crypto";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createStore } from "ccstate";
+import { and, eq } from "drizzle-orm";
+
+import { integrationsSlackUploadCompleteContract } from "@vm0/api-contracts/contracts/integrations";
+import { runUploadedFiles } from "@vm0/db/schema/run-uploaded-file";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { writeDb$ } from "../../external/db";
+import { now } from "../../../lib/time";
+import { signSandboxJwtForTests } from "../../auth/tokens";
+import { createZeroRouteMocks } from "./helpers/zero-route-test";
+import {
+  deleteOrgMembership$,
+  seedOrgMembership$,
+  type OrgMembershipFixture,
+} from "./helpers/zero-org-membership";
+import {
+  deleteSlackIntegrationFixture$,
+  seedSlackOrgInstallation$,
+  type SlackIntegrationFixture,
+} from "./helpers/zero-integrations-slack";
+import {
+  deleteUsageInsightFixture$,
+  seedCompose$,
+  seedRun$,
+  type UsageInsightFixture,
+} from "./helpers/zero-usage-insight";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+
+function zeroToken(args: {
+  readonly userId: string;
+  readonly orgId: string;
+  readonly runId: string;
+  readonly capabilities?: readonly string[];
+}): string {
+  const seconds = Math.floor(now() / 1000);
+  return signSandboxJwtForTests({
+    scope: "zero",
+    userId: args.userId,
+    orgId: args.orgId,
+    runId: args.runId,
+    capabilities: (args.capabilities ?? ["slack:write"]) as never,
+    iat: seconds,
+    exp: seconds + 60,
+  });
+}
+
+function sandboxToken(args: {
+  readonly userId: string;
+  readonly orgId: string;
+  readonly runId: string;
+}): string {
+  const seconds = Math.floor(now() / 1000);
+  return signSandboxJwtForTests({
+    scope: "sandbox",
+    userId: args.userId,
+    orgId: args.orgId,
+    runId: args.runId,
+    iat: seconds,
+    exp: seconds + 60,
+  });
+}
+
+interface RunScopedContext {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly runId: string;
+}
+
+describe("POST /api/zero/integrations/slack/upload-file/complete", () => {
+  const slackFixtures: SlackIntegrationFixture[] = [];
+  const memberships: OrgMembershipFixture[] = [];
+  const insightFixtures: UsageInsightFixture[] = [];
+
+  function findUploadedFiles(externalId: string) {
+    const writeDb = store.set(writeDb$);
+    return writeDb
+      .select()
+      .from(runUploadedFiles)
+      .where(
+        and(
+          eq(runUploadedFiles.source, "slack"),
+          eq(runUploadedFiles.externalId, externalId),
+        ),
+      );
+  }
+
+  beforeEach(() => {
+    context.mocks.slack.files.completeUploadExternal.mockResolvedValue({
+      ok: true,
+    });
+  });
+
+  afterEach(async () => {
+    while (slackFixtures.length > 0) {
+      const fixture = slackFixtures.pop();
+      if (fixture) {
+        await store.set(
+          deleteSlackIntegrationFixture$,
+          fixture,
+          context.signal,
+        );
+      }
+    }
+    while (insightFixtures.length > 0) {
+      const fixture = insightFixtures.pop();
+      if (fixture) {
+        await store.set(deleteUsageInsightFixture$, fixture, context.signal);
+      }
+    }
+    while (memberships.length > 0) {
+      const membership = memberships.pop();
+      if (membership) {
+        await store.set(deleteOrgMembership$, membership, context.signal);
+      }
+    }
+  });
+
+  function mockSlackFileInfo(fileId: string): void {
+    context.mocks.slack.files.info.mockResolvedValue({
+      ok: true,
+      file: {
+        id: fileId,
+        name: "report.csv",
+        title: "Slack Report",
+        mimetype: "text/csv",
+        filetype: "csv",
+        size: 42,
+        permalink: `https://slack.example/files/${fileId}`,
+      },
+    });
+  }
+
+  async function seedBaseContext(): Promise<{
+    orgId: string;
+    userId: string;
+  }> {
+    const orgId = `org_${randomUUID().slice(0, 8)}`;
+    const userId = `user_${randomUUID().slice(0, 8)}`;
+    const membership = await store.set(
+      seedOrgMembership$,
+      { orgId, userId, role: "admin" },
+      context.signal,
+    );
+    memberships.push(membership);
+    insightFixtures.push({ orgId, userId });
+    return { orgId, userId };
+  }
+
+  async function seedWithInstallation(): Promise<{
+    orgId: string;
+    userId: string;
+  }> {
+    const base = await seedBaseContext();
+    const fixture = await store.set(
+      seedSlackOrgInstallation$,
+      { orgId: base.orgId },
+      context.signal,
+    );
+    slackFixtures.push(fixture);
+    return base;
+  }
+
+  async function seedRunScoped(): Promise<RunScopedContext> {
+    const base = await seedWithInstallation();
+    const { composeId } = await store.set(
+      seedCompose$,
+      { orgId: base.orgId, userId: base.userId },
+      context.signal,
+    );
+    const { runId } = await store.set(
+      seedRun$,
+      {
+        orgId: base.orgId,
+        userId: base.userId,
+        composeId,
+        triggerSource: "slack",
+      },
+      context.signal,
+    );
+    return { orgId: base.orgId, userId: base.userId, runId };
+  }
+
+  it("returns 401 when no auth token is provided", async () => {
+    const client = setupApp({ context })(
+      integrationsSlackUploadCompleteContract,
+    );
+    const response = await accept(
+      client.complete({
+        body: { fileId: "F123", channel: "C123" },
+        headers: {},
+      }),
+      [401],
+    );
+    expect(response.body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("returns 403 when sandbox token lacks slack:write", async () => {
+    const orgId = `org_${randomUUID().slice(0, 8)}`;
+    const userId = `user_${randomUUID().slice(0, 8)}`;
+    const runId = `run_${randomUUID()}`;
+    const token = sandboxToken({ userId, orgId, runId });
+
+    const client = setupApp({ context })(
+      integrationsSlackUploadCompleteContract,
+    );
+    const response = await accept(
+      client.complete({
+        body: { fileId: "F123", channel: "C123" },
+        headers: { authorization: `Bearer ${token}` },
+      }),
+      [403],
+    );
+    expect(response.body.error.message).toContain("slack:write");
+  });
+
+  it("returns 404 when no Slack installation exists for org", async () => {
+    const { orgId, userId } = await seedBaseContext();
+    const token = zeroToken({ userId, orgId, runId: `run_${randomUUID()}` });
+
+    const client = setupApp({ context })(
+      integrationsSlackUploadCompleteContract,
+    );
+    const response = await accept(
+      client.complete({
+        body: { fileId: "F123", channel: "C123" },
+        headers: { authorization: `Bearer ${token}` },
+      }),
+      [404],
+    );
+    expect(response.body.error.message).toContain("No Slack installation");
+  });
+
+  it("forwards Slack file info errors as 400 SLACK_ERROR", async () => {
+    const { orgId, userId, runId } = await seedRunScoped();
+    const fileId = `F-${randomUUID().slice(0, 8)}`;
+    const token = zeroToken({ userId, orgId, runId });
+    context.mocks.slack.files.info.mockRejectedValueOnce(
+      Object.assign(new Error("file_not_found"), {
+        data: { ok: false, error: "file_not_found" },
+      }),
+    );
+
+    const client = setupApp({ context })(
+      integrationsSlackUploadCompleteContract,
+    );
+    const response = await accept(
+      client.complete({
+        body: { fileId, channel: "C123" },
+        headers: { authorization: `Bearer ${token}` },
+      }),
+      [400],
+    );
+
+    expect(response.body.error.code).toBe("SLACK_ERROR");
+    expect(response.body.error.message).toContain("file_not_found");
+    const rows = await findUploadedFiles(fileId);
+    expect(rows).toHaveLength(0);
+  });
+
+  it("records a Slack upload for a run-scoped zero token", async () => {
+    const { orgId, userId, runId } = await seedRunScoped();
+    const fileId = `F-${randomUUID().slice(0, 8)}`;
+    mockSlackFileInfo(fileId);
+    const token = zeroToken({ userId, orgId, runId });
+
+    const client = setupApp({ context })(
+      integrationsSlackUploadCompleteContract,
+    );
+    const response = await accept(
+      client.complete({
+        body: {
+          fileId,
+          channel: "C123",
+          threadTs: "123.456",
+          title: "Quarterly report",
+          initialComment: "Uploaded from a run",
+        },
+        headers: { authorization: `Bearer ${token}` },
+      }),
+      [200],
+    );
+
+    expect(response.body).toMatchObject({
+      fileId,
+      permalink: `https://slack.example/files/${fileId}`,
+    });
+
+    expect(
+      context.mocks.slack.files.completeUploadExternal,
+    ).toHaveBeenLastCalledWith({
+      files: [{ id: fileId, title: "Quarterly report" }],
+      channel_id: "C123",
+      thread_ts: "123.456",
+      initial_comment: "Uploaded from a run",
+    });
+
+    const rows = await findUploadedFiles(fileId);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      runId,
+      source: "slack",
+      externalId: fileId,
+      userId,
+      orgId,
+      filename: "Quarterly report",
+      contentType: "text/csv",
+      sizeBytes: 42,
+      url: `https://slack.example/files/${fileId}`,
+      metadata: {
+        channel: "C123",
+        threadTs: "123.456",
+        title: "Quarterly report",
+        initialComment: "Uploaded from a run",
+        slackFile: {
+          id: fileId,
+          name: "report.csv",
+          title: "Slack Report",
+          mimetype: "text/csv",
+          filetype: "csv",
+        },
+      },
+    });
+  });
+
+  it("does not record a run association for ordinary clerk session auth", async () => {
+    const { orgId, userId } = await seedWithInstallation();
+    const fileId = `F-${randomUUID().slice(0, 8)}`;
+    mockSlackFileInfo(fileId);
+    mocks.clerk.session(userId, orgId);
+
+    const client = setupApp({ context })(
+      integrationsSlackUploadCompleteContract,
+    );
+    const response = await accept(
+      client.complete({
+        body: { fileId, channel: "C123", title: "Session upload" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toMatchObject({
+      fileId,
+      permalink: `https://slack.example/files/${fileId}`,
+    });
+
+    const rows = await findUploadedFiles(fileId);
+    expect(rows).toHaveLength(0);
+  });
+
+  it("is idempotent for repeated completion calls for the same run file", async () => {
+    const { orgId, userId, runId } = await seedRunScoped();
+    const fileId = `F-${randomUUID().slice(0, 8)}`;
+    mockSlackFileInfo(fileId);
+    const token = zeroToken({ userId, orgId, runId });
+
+    const client = setupApp({ context })(
+      integrationsSlackUploadCompleteContract,
+    );
+    const body = { fileId, channel: "C123", title: "Retry upload" };
+
+    await accept(
+      client.complete({ body, headers: { authorization: `Bearer ${token}` } }),
+      [200],
+    );
+    await accept(
+      client.complete({ body, headers: { authorization: `Bearer ${token}` } }),
+      [200],
+    );
+
+    const rows = await findUploadedFiles(fileId);
+    expect(rows).toHaveLength(1);
+  });
+});

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-slack-upload-init.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-slack-upload-init.test.ts
@@ -1,0 +1,150 @@
+import { randomUUID } from "node:crypto";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createStore } from "ccstate";
+
+import { integrationsSlackUploadInitContract } from "@vm0/api-contracts/contracts/integrations";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { now } from "../../../lib/time";
+import { signSandboxJwtForTests } from "../../auth/tokens";
+import {
+  deleteOrgMembership$,
+  seedOrgMembership$,
+  type OrgMembershipFixture,
+} from "./helpers/zero-org-membership";
+import {
+  deleteSlackIntegrationFixture$,
+  seedSlackOrgInstallation$,
+  type SlackIntegrationFixture,
+} from "./helpers/zero-integrations-slack";
+
+const context = testContext();
+const store = createStore();
+
+function zeroToken(args: {
+  readonly userId: string;
+  readonly orgId: string;
+  readonly runId: string;
+  readonly capabilities?: readonly string[];
+}): string {
+  const seconds = Math.floor(now() / 1000);
+  return signSandboxJwtForTests({
+    scope: "zero",
+    userId: args.userId,
+    orgId: args.orgId,
+    runId: args.runId,
+    capabilities: (args.capabilities ?? ["slack:write"]) as never,
+    iat: seconds,
+    exp: seconds + 60,
+  });
+}
+
+describe("POST /api/zero/integrations/slack/upload-file/init", () => {
+  const slackFixtures: SlackIntegrationFixture[] = [];
+  const memberships: OrgMembershipFixture[] = [];
+
+  beforeEach(() => {
+    context.mocks.slack.files.getUploadURLExternal.mockResolvedValue({
+      ok: true,
+      upload_url: "https://files.slack.com/upload/v1/abc",
+      file_id: "F-mock-file",
+    });
+  });
+
+  afterEach(async () => {
+    while (slackFixtures.length > 0) {
+      const fixture = slackFixtures.pop();
+      if (fixture) {
+        await store.set(
+          deleteSlackIntegrationFixture$,
+          fixture,
+          context.signal,
+        );
+      }
+    }
+    while (memberships.length > 0) {
+      const membership = memberships.pop();
+      if (membership) {
+        await store.set(deleteOrgMembership$, membership, context.signal);
+      }
+    }
+  });
+
+  async function seedWithInstallation(): Promise<{
+    orgId: string;
+    userId: string;
+  }> {
+    const orgId = `org_${randomUUID().slice(0, 8)}`;
+    const userId = `user_${randomUUID().slice(0, 8)}`;
+    const membership = await store.set(
+      seedOrgMembership$,
+      { orgId, userId, role: "admin" },
+      context.signal,
+    );
+    memberships.push(membership);
+    const fixture = await store.set(
+      seedSlackOrgInstallation$,
+      { orgId },
+      context.signal,
+    );
+    slackFixtures.push(fixture);
+    return { orgId, userId };
+  }
+
+  it("returns 401 when no auth token is provided", async () => {
+    const client = setupApp({ context })(integrationsSlackUploadInitContract);
+    const response = await accept(
+      client.init({
+        body: { filename: "report.pdf", length: 100 },
+        headers: {},
+      }),
+      [401],
+    );
+    expect(response.body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("returns a Slack-issued upload URL and file id on the happy path", async () => {
+    const { orgId, userId } = await seedWithInstallation();
+    const token = zeroToken({ userId, orgId, runId: `run_${randomUUID()}` });
+
+    const client = setupApp({ context })(integrationsSlackUploadInitContract);
+    const response = await accept(
+      client.init({
+        body: { filename: "quarterly.csv", length: 4096 },
+        headers: { authorization: `Bearer ${token}` },
+      }),
+      [200],
+    );
+
+    expect(response.body).toMatchObject({
+      uploadUrl: "https://files.slack.com/upload/v1/abc",
+      fileId: "F-mock-file",
+    });
+    expect(
+      context.mocks.slack.files.getUploadURLExternal,
+    ).toHaveBeenLastCalledWith({ filename: "quarterly.csv", length: 4096 });
+  });
+
+  it("forwards Slack platform errors as 400 SLACK_ERROR", async () => {
+    const { orgId, userId } = await seedWithInstallation();
+    const token = zeroToken({ userId, orgId, runId: `run_${randomUUID()}` });
+
+    context.mocks.slack.files.getUploadURLExternal.mockRejectedValueOnce(
+      Object.assign(new Error("invalid_filename"), {
+        data: { ok: false, error: "invalid_filename" },
+      }),
+    );
+
+    const client = setupApp({ context })(integrationsSlackUploadInitContract);
+    const response = await accept(
+      client.init({
+        body: { filename: "../bad.exe", length: 1 },
+        headers: { authorization: `Bearer ${token}` },
+      }),
+      [400],
+    );
+
+    expect(response.body.error.code).toBe("SLACK_ERROR");
+    expect(response.body.error.message).toContain("invalid_filename");
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-integrations-slack-upload-complete.ts
+++ b/turbo/apps/api/src/signals/routes/zero-integrations-slack-upload-complete.ts
@@ -1,0 +1,147 @@
+import { command } from "ccstate";
+import {
+  integrationsSlackUploadCompleteContract,
+  type SlackUploadCompleteBody,
+} from "@vm0/api-contracts/contracts/integrations";
+
+import { organizationAuthContext$ } from "../auth/auth-context";
+import { authRoute } from "../auth/auth-route";
+import { bodyResultOf } from "../context/request";
+import {
+  completeUploadExternal,
+  createSlackClient,
+  getFileInfo,
+  type SlackFileInfo,
+} from "../external/slack-message-client";
+import { recordSlackUploadedFile$ } from "../services/run-uploaded-files.service";
+import { zeroSlackOrgInstallation } from "../services/zero-slack-data.service";
+import type { RouteEntry } from "../route";
+
+const noInstallation = Object.freeze({
+  status: 404 as const,
+  body: Object.freeze({
+    error: Object.freeze({
+      message: "No Slack installation found for this organization",
+      code: "NOT_FOUND",
+    }),
+  }),
+});
+
+function buildSlackUploadMetadata(
+  body: SlackUploadCompleteBody,
+  file: SlackFileInfo | undefined,
+): Record<string, unknown> {
+  return {
+    channel: body.channel,
+    ...(body.threadTs ? { threadTs: body.threadTs } : {}),
+    ...(body.title ? { title: body.title } : {}),
+    ...(body.initialComment ? { initialComment: body.initialComment } : {}),
+    slackFile: {
+      id: file?.id ?? body.fileId,
+      name: file?.name ?? null,
+      title: file?.title ?? null,
+      mimetype: file?.mimetype ?? null,
+      filetype: file?.filetype ?? null,
+    },
+  };
+}
+
+const completeInner$ = command(async ({ get, set }, signal: AbortSignal) => {
+  const auth = get(organizationAuthContext$);
+  const runId =
+    "runId" in auth && typeof auth.runId === "string" ? auth.runId : undefined;
+
+  const bodyResult = await get(
+    bodyResultOf(integrationsSlackUploadCompleteContract.complete),
+  );
+  signal.throwIfAborted();
+  if (!bodyResult.ok) {
+    return bodyResult.response;
+  }
+  const body = bodyResult.data;
+
+  const installation = await get(
+    zeroSlackOrgInstallation({ orgId: auth.orgId }),
+  );
+  signal.throwIfAborted();
+  if (!installation) {
+    return noInstallation;
+  }
+
+  const client = createSlackClient(installation.botToken);
+
+  const completeResult = await completeUploadExternal(client, {
+    fileId: body.fileId,
+    channel: body.channel,
+    threadTs: body.threadTs,
+    title: body.title,
+    initialComment: body.initialComment,
+  });
+  signal.throwIfAborted();
+  if (completeResult.kind === "slack_error") {
+    return {
+      status: 400 as const,
+      body: {
+        error: {
+          message: `Slack API error: ${completeResult.error}`,
+          code: "SLACK_ERROR",
+        },
+      },
+    };
+  }
+
+  const infoResult = await getFileInfo(client, body.fileId);
+  signal.throwIfAborted();
+  if (infoResult.kind === "slack_error") {
+    return {
+      status: 400 as const,
+      body: {
+        error: {
+          message: `Slack API error: ${infoResult.error}`,
+          code: "SLACK_ERROR",
+        },
+      },
+    };
+  }
+  const file = infoResult.file;
+  const permalink = file?.permalink ?? "";
+
+  await set(
+    recordSlackUploadedFile$,
+    {
+      runId,
+      externalId: body.fileId,
+      userId: auth.userId,
+      orgId: auth.orgId,
+      filename: body.title ?? file?.title ?? file?.name ?? null,
+      contentType: file?.mimetype ?? null,
+      sizeBytes: file?.size ?? null,
+      url: permalink || null,
+      metadata: buildSlackUploadMetadata(body, file),
+    },
+    signal,
+  );
+  signal.throwIfAborted();
+
+  return {
+    status: 200 as const,
+    body: {
+      fileId: body.fileId,
+      permalink,
+    },
+  };
+});
+
+const slackWriteAuth = {
+  requireOrganization: true,
+  missingOrganizationStatus: 401,
+  requiredCapability: "slack:write",
+} as const;
+
+export const zeroIntegrationsSlackUploadCompleteRoutes: readonly RouteEntry[] =
+  [
+    {
+      route: integrationsSlackUploadCompleteContract.complete,
+      handler: authRoute(slackWriteAuth, completeInner$),
+    },
+  ];

--- a/turbo/apps/api/src/signals/routes/zero-integrations-slack-upload-init.ts
+++ b/turbo/apps/api/src/signals/routes/zero-integrations-slack-upload-init.ts
@@ -1,0 +1,82 @@
+import { command } from "ccstate";
+import { integrationsSlackUploadInitContract } from "@vm0/api-contracts/contracts/integrations";
+
+import { organizationAuthContext$ } from "../auth/auth-context";
+import { authRoute } from "../auth/auth-route";
+import { bodyResultOf } from "../context/request";
+import {
+  createSlackClient,
+  getUploadUrlExternal,
+} from "../external/slack-message-client";
+import { zeroSlackOrgInstallation } from "../services/zero-slack-data.service";
+import type { RouteEntry } from "../route";
+
+const noInstallation = Object.freeze({
+  status: 404 as const,
+  body: Object.freeze({
+    error: Object.freeze({
+      message: "No Slack installation found for this organization",
+      code: "NOT_FOUND",
+    }),
+  }),
+});
+
+const initInner$ = command(async ({ get }, signal: AbortSignal) => {
+  const auth = get(organizationAuthContext$);
+
+  const bodyResult = await get(
+    bodyResultOf(integrationsSlackUploadInitContract.init),
+  );
+  signal.throwIfAborted();
+  if (!bodyResult.ok) {
+    return bodyResult.response;
+  }
+
+  const installation = await get(
+    zeroSlackOrgInstallation({ orgId: auth.orgId }),
+  );
+  signal.throwIfAborted();
+  if (!installation) {
+    return noInstallation;
+  }
+
+  const client = createSlackClient(installation.botToken);
+  const result = await getUploadUrlExternal(client, {
+    filename: bodyResult.data.filename,
+    length: bodyResult.data.length,
+  });
+  signal.throwIfAborted();
+
+  if (result.kind === "slack_error") {
+    return {
+      status: 400 as const,
+      body: {
+        error: {
+          message: `Slack API error: ${result.error}`,
+          code: "SLACK_ERROR",
+        },
+      },
+    };
+  }
+
+  return {
+    status: 200 as const,
+    body: {
+      uploadUrl: result.uploadUrl,
+      fileId: result.fileId,
+    },
+  };
+});
+
+const slackWriteAuth = {
+  requireOrganization: true,
+  missingOrganizationStatus: 401,
+  requiredCapability: "slack:write",
+} as const;
+
+export const zeroIntegrationsSlackUploadInitRoutes: readonly RouteEntry[] = [
+  {
+    route: integrationsSlackUploadInitContract.init,
+    handler: authRoute(slackWriteAuth, initInner$),
+  },
+];

--- a/turbo/apps/api/src/signals/services/run-uploaded-files.service.ts
+++ b/turbo/apps/api/src/signals/services/run-uploaded-files.service.ts
@@ -270,3 +270,123 @@ export const recordTelegramUploadedFile$ = command(
     }
   },
 );
+
+interface RecordSlackUploadedFileArgs {
+  readonly runId: string | undefined;
+  readonly externalId: string;
+  readonly userId: string;
+  readonly orgId: string;
+  readonly filename: string | null;
+  readonly contentType: string | null;
+  readonly sizeBytes: number | null;
+  readonly url: string | null;
+  readonly metadata: Record<string, unknown>;
+}
+
+/**
+ * Insert (or upsert) a `run_uploaded_files` row for a Slack-delivered
+ * upload, then publish the chat-thread artifacts-changed signal if the
+ * run is linked to a thread. No-op when `runId` is undefined (sandbox
+ * callers without a run-scoped token).
+ *
+ * Mirrors recordTelegramUploadedFile$ but scoped to the `"slack"` source
+ * and allows nullable metadata fields because Slack's files.info may not
+ * surface every attribute. Idempotency contract is upsert on
+ * (runId, source, externalId).
+ */
+export const recordSlackUploadedFile$ = command(
+  async (
+    { set },
+    args: RecordSlackUploadedFileArgs,
+    signal: AbortSignal,
+  ): Promise<void> => {
+    if (!args.runId) {
+      return;
+    }
+    const writeDb = set(writeDb$);
+
+    const [run] = await writeDb
+      .select({ triggerSource: zeroRuns.triggerSource })
+      .from(zeroRuns)
+      .where(eq(zeroRuns.id, args.runId))
+      .limit(1);
+    signal.throwIfAborted();
+    const source: RunUploadedFileSource = isRunUploadedFileSource(
+      run?.triggerSource,
+    )
+      ? run.triggerSource
+      : "slack";
+
+    await writeDb
+      .insert(runUploadedFiles)
+      .values({
+        runId: args.runId,
+        source,
+        externalId: args.externalId,
+        userId: args.userId,
+        orgId: args.orgId,
+        filename: args.filename,
+        contentType: args.contentType,
+        sizeBytes: args.sizeBytes,
+        url: args.url,
+        metadata: args.metadata,
+      })
+      .onConflictDoUpdate({
+        target: [
+          runUploadedFiles.runId,
+          runUploadedFiles.source,
+          runUploadedFiles.externalId,
+        ],
+        set: {
+          userId: args.userId,
+          orgId: args.orgId,
+          filename: args.filename,
+          contentType: args.contentType,
+          sizeBytes: args.sizeBytes,
+          url: args.url,
+          metadata: args.metadata,
+          updatedAt: sql`now()`,
+        },
+      });
+    signal.throwIfAborted();
+
+    const [zeroRunThread] = await writeDb
+      .select({
+        chatThreadId: zeroRuns.chatThreadId,
+        userId: chatThreads.userId,
+      })
+      .from(zeroRuns)
+      .innerJoin(chatThreads, eq(zeroRuns.chatThreadId, chatThreads.id))
+      .where(eq(zeroRuns.id, args.runId))
+      .limit(1);
+    signal.throwIfAborted();
+
+    if (zeroRunThread?.chatThreadId) {
+      await publishUserSignal(
+        [zeroRunThread.userId],
+        `chatThreadArtifactsChanged:${zeroRunThread.chatThreadId}`,
+      );
+      signal.throwIfAborted();
+      return;
+    }
+
+    const [messageThread] = await writeDb
+      .select({
+        chatThreadId: chatMessages.chatThreadId,
+        userId: chatThreads.userId,
+      })
+      .from(chatMessages)
+      .innerJoin(chatThreads, eq(chatMessages.chatThreadId, chatThreads.id))
+      .where(eq(chatMessages.runId, args.runId))
+      .limit(1);
+    signal.throwIfAborted();
+
+    if (messageThread) {
+      await publishUserSignal(
+        [messageThread.userId],
+        `chatThreadArtifactsChanged:${messageThread.chatThreadId}`,
+      );
+      signal.throwIfAborted();
+    }
+  },
+);


### PR DESCRIPTION
## Summary

Migrates `POST /api/zero/integrations/slack/upload-file/init` and `POST /api/zero/integrations/slack/upload-file/complete` from `apps/web` to `apps/api`. Closes #12755.

**Spec correction (worth flagging up-front):** the issue body called for a "verbatim mirror of `zero-integrations-telegram-upload-init.ts`". That would have invented an R2-presigned-PUT flow that does not exist for Slack. Slack init is a thin passthrough to Slack's `files.getUploadURLExternal`; the CLI uploads directly to Slack, not to R2. The implementation follows web's actual logic instead. See the [research comment](https://github.com/vm0-ai/vm0/issues/12755#issuecomment-4420270052) on the issue for the full divergence write-up.

## Files

- `signals/external/slack-message-client.ts` — three new result-union wrappers (`getUploadUrlExternal`, `completeUploadExternal`, `getFileInfo`) so route handlers stay try/catch-free.
- `signals/routes/zero-integrations-slack-upload-init.ts` — new route using `organizationAuthContext$` + `slack:write` capability + installation lookup.
- `signals/routes/zero-integrations-slack-upload-complete.ts` — new route; calls Slack `completeUploadExternal` + `files.info` then writes via `recordSlackUploadedFile$`.
- `signals/services/run-uploaded-files.service.ts` — adds `recordSlackUploadedFile$` ccstate command alongside the existing `recordWebUploadedFile$` (rule-of-three trigger met; helper extraction can now be split into a follow-up cleanup).
- `signals/route.ts` — registers both routes alphabetically.
- `__tests__/mocks.ts` — extends the Slack WebClient mock with `files.getUploadURLExternal` and `files.completeUploadExternal`.

## Tests

- Init (3): 401 unauthenticated, happy path, Slack platform error → 400 `SLACK_ERROR`.
- Complete (7): 401, 403 (missing `slack:write`), 404 (no installation), Slack file info platform error -> 400 `SLACK_ERROR`, records-for-run, no-record-for-session, idempotent.

## Test plan

- [x] `cd turbo && pnpm -F api exec vitest run` — 1165 / 1165 passing
- [x] `cd turbo && pnpm turbo run lint --filter=api` — clean
- [x] `cd turbo && pnpm check-types` — clean
- [x] `cd turbo && pnpm format` — clean
- [x] `cd turbo && pnpm knip --workspace api` — clean
- [x] CI green (lint, test, deploy, cli-e2e)

Prior art: #12748 (slack-message migration, just merged) for the canonical Slack SDK wrapper pattern; #12752 (telegram-upload migration, now merged) for the parallel `recordTelegramUploadedFile$` shape. `apps/web` routes remain live for the wave-6 cutover sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


