### PR TITLE
feat(api): add callback-route hmac auth primitive (prereq for Wave 6 #19)

### DIFF
--- a/turbo/apps/api/src/lib/callback-route/__tests__/callback-route.test.ts
+++ b/turbo/apps/api/src/lib/callback-route/__tests__/callback-route.test.ts
@@ -1,0 +1,263 @@
+import { randomUUID } from "node:crypto";
+import { afterEach, describe, expect, it } from "vitest";
+import { command, createStore } from "ccstate";
+
+import { createApp } from "../../../app-factory";
+import { testContext } from "../../../__tests__/test-helpers";
+import { computeHmacSignature } from "../../event-consumer/hmac";
+import { now } from "../../time";
+import { seedAgentRunCallback$ } from "../../../signals/routes/__tests__/helpers/agent-run-callback";
+import {
+  seedCompose$,
+  seedRun$,
+} from "../../../signals/routes/__tests__/helpers/zero-usage-insight";
+import type { RouteEntry } from "../../../signals/route";
+
+import { callbackPayload$, callbackRoute } from "../callback-route";
+import { callbackTestProbeContract } from "./helpers";
+
+const PATH = "/api/__test__/callback-route-probe";
+const TEST_CALLBACK_SECRET = "test-callback-secret";
+
+const context = testContext();
+const store = createStore();
+
+const probeInner$ = command(({ get }) => {
+  const data = get(callbackPayload$);
+  return {
+    status: 200 as const,
+    body: { ok: true as const, runId: data.runId },
+  };
+});
+
+const probeRoute: RouteEntry = Object.freeze({
+  route: callbackTestProbeContract.probe,
+  handler: callbackRoute(probeInner$),
+});
+
+interface SignedHeaderOptions {
+  readonly skipSignature?: boolean;
+  readonly skipTimestamp?: boolean;
+  readonly staleTimestamp?: boolean;
+}
+
+function signedHeaders(
+  rawBody: string,
+  secret = TEST_CALLBACK_SECRET,
+  options: SignedHeaderOptions = {},
+): Record<string, string> {
+  const ts = options.staleTimestamp
+    ? Math.floor(now() / 1000) - 1000
+    : Math.floor(now() / 1000);
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+  if (!options.skipSignature) {
+    headers["X-VM0-Signature"] = computeHmacSignature(rawBody, secret, ts);
+  }
+  if (!options.skipTimestamp) {
+    headers["X-VM0-Timestamp"] = String(ts);
+  }
+  return headers;
+}
+
+async function seedCallback(): Promise<string> {
+  const orgId = `org_${randomUUID().slice(0, 8)}`;
+  const userId = `user_${randomUUID().slice(0, 8)}`;
+  const { composeId } = await store.set(
+    seedCompose$,
+    { orgId, userId },
+    context.signal,
+  );
+  const { runId } = await store.set(
+    seedRun$,
+    { orgId, userId, composeId },
+    context.signal,
+  );
+  await store.set(
+    seedAgentRunCallback$,
+    {
+      runId,
+      url: `http://localhost${PATH}`,
+      payload: {},
+    },
+    context.signal,
+  );
+  return runId;
+}
+
+describe("callbackRoute$ primitive", () => {
+  afterEach(() => {
+    // testContext()'s afterEach aborts the signal; nothing else to clean here
+    // because each test creates its own throwaway callback row.
+  });
+
+  it("returns 400 on invalid JSON body", async () => {
+    const app = createApp({
+      signal: context.signal,
+      routes: [probeRoute],
+    });
+    const rawBody = "{not-json";
+
+    const response = await app.request(PATH, {
+      method: "POST",
+      headers: signedHeaders(rawBody),
+      body: rawBody,
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toStrictEqual({
+      error: "Invalid JSON body",
+    });
+  });
+
+  it("returns 400 on missing runId", async () => {
+    const app = createApp({
+      signal: context.signal,
+      routes: [probeRoute],
+    });
+    const rawBody = JSON.stringify({ status: "completed", payload: {} });
+
+    const response = await app.request(PATH, {
+      method: "POST",
+      headers: signedHeaders(rawBody),
+      body: rawBody,
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toStrictEqual({
+      error: "Missing runId",
+    });
+  });
+
+  it("returns 404 on callback not found", async () => {
+    const app = createApp({
+      signal: context.signal,
+      routes: [probeRoute],
+    });
+    const rawBody = JSON.stringify({
+      runId: randomUUID(),
+      status: "completed",
+      payload: {},
+    });
+
+    const response = await app.request(PATH, {
+      method: "POST",
+      headers: signedHeaders(rawBody),
+      body: rawBody,
+    });
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toStrictEqual({
+      error: "Callback not found",
+    });
+  });
+
+  it("returns 401 on invalid signature", async () => {
+    const runId = await seedCallback();
+    const app = createApp({
+      signal: context.signal,
+      routes: [probeRoute],
+    });
+    const rawBody = JSON.stringify({ runId, status: "completed", payload: {} });
+
+    const response = await app.request(PATH, {
+      method: "POST",
+      headers: signedHeaders(rawBody, "wrong-secret"),
+      body: rawBody,
+    });
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toStrictEqual({
+      error: "Invalid signature",
+    });
+  });
+
+  it("returns 401 on missing X-VM0-Signature header", async () => {
+    const runId = await seedCallback();
+    const app = createApp({
+      signal: context.signal,
+      routes: [probeRoute],
+    });
+    const rawBody = JSON.stringify({ runId, status: "completed", payload: {} });
+
+    const response = await app.request(PATH, {
+      method: "POST",
+      headers: signedHeaders(rawBody, TEST_CALLBACK_SECRET, {
+        skipSignature: true,
+      }),
+      body: rawBody,
+    });
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toStrictEqual({
+      error: "Missing X-VM0-Signature header",
+    });
+  });
+
+  it("returns 401 on missing X-VM0-Timestamp header", async () => {
+    const runId = await seedCallback();
+    const app = createApp({
+      signal: context.signal,
+      routes: [probeRoute],
+    });
+    const rawBody = JSON.stringify({ runId, status: "completed", payload: {} });
+
+    const response = await app.request(PATH, {
+      method: "POST",
+      headers: signedHeaders(rawBody, TEST_CALLBACK_SECRET, {
+        skipTimestamp: true,
+      }),
+      body: rawBody,
+    });
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toStrictEqual({
+      error: "Missing X-VM0-Timestamp header",
+    });
+  });
+
+  it("returns 401 on expired timestamp", async () => {
+    const runId = await seedCallback();
+    const app = createApp({
+      signal: context.signal,
+      routes: [probeRoute],
+    });
+    const rawBody = JSON.stringify({ runId, status: "completed", payload: {} });
+
+    const response = await app.request(PATH, {
+      method: "POST",
+      headers: signedHeaders(rawBody, TEST_CALLBACK_SECRET, {
+        staleTimestamp: true,
+      }),
+      body: rawBody,
+    });
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toStrictEqual({
+      error: "Timestamp expired",
+    });
+  });
+
+  it("invokes the inner handler with the verified callback payload on success", async () => {
+    const runId = await seedCallback();
+    const app = createApp({
+      signal: context.signal,
+      routes: [probeRoute],
+    });
+    const rawBody = JSON.stringify({
+      runId,
+      status: "completed",
+      payload: { hello: "world" },
+    });
+
+    const response = await app.request(PATH, {
+      method: "POST",
+      headers: signedHeaders(rawBody),
+      body: rawBody,
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toStrictEqual({ ok: true, runId });
+  });
+});

--- a/turbo/apps/api/src/lib/callback-route/__tests__/callback-route.test.ts
+++ b/turbo/apps/api/src/lib/callback-route/__tests__/callback-route.test.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { afterEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 import { command, createStore } from "ccstate";
 
 import { createApp } from "../../../app-factory";
@@ -61,7 +61,10 @@ function signedHeaders(
   return headers;
 }
 
-async function seedCallback(): Promise<string> {
+async function seedCallback(): Promise<{
+  runId: string;
+  callbackId: string;
+}> {
   const orgId = `org_${randomUUID().slice(0, 8)}`;
   const userId = `user_${randomUUID().slice(0, 8)}`;
   const { composeId } = await store.set(
@@ -74,7 +77,7 @@ async function seedCallback(): Promise<string> {
     { orgId, userId, composeId },
     context.signal,
   );
-  await store.set(
+  const { callbackId } = await store.set(
     seedAgentRunCallback$,
     {
       runId,
@@ -83,15 +86,10 @@ async function seedCallback(): Promise<string> {
     },
     context.signal,
   );
-  return runId;
+  return { runId, callbackId };
 }
 
 describe("callbackRoute$ primitive", () => {
-  afterEach(() => {
-    // testContext()'s afterEach aborts the signal; nothing else to clean here
-    // because each test creates its own throwaway callback row.
-  });
-
   it("returns 400 on invalid JSON body", async () => {
     const app = createApp({
       signal: context.signal,
@@ -154,7 +152,7 @@ describe("callbackRoute$ primitive", () => {
   });
 
   it("returns 401 on invalid signature", async () => {
-    const runId = await seedCallback();
+    const { runId } = await seedCallback();
     const app = createApp({
       signal: context.signal,
       routes: [probeRoute],
@@ -174,7 +172,7 @@ describe("callbackRoute$ primitive", () => {
   });
 
   it("returns 401 on missing X-VM0-Signature header", async () => {
-    const runId = await seedCallback();
+    const { runId } = await seedCallback();
     const app = createApp({
       signal: context.signal,
       routes: [probeRoute],
@@ -196,7 +194,7 @@ describe("callbackRoute$ primitive", () => {
   });
 
   it("returns 401 on missing X-VM0-Timestamp header", async () => {
-    const runId = await seedCallback();
+    const { runId } = await seedCallback();
     const app = createApp({
       signal: context.signal,
       routes: [probeRoute],
@@ -218,7 +216,7 @@ describe("callbackRoute$ primitive", () => {
   });
 
   it("returns 401 on expired timestamp", async () => {
-    const runId = await seedCallback();
+    const { runId } = await seedCallback();
     const app = createApp({
       signal: context.signal,
       routes: [probeRoute],
@@ -240,12 +238,13 @@ describe("callbackRoute$ primitive", () => {
   });
 
   it("invokes the inner handler with the verified callback payload on success", async () => {
-    const runId = await seedCallback();
+    const { runId, callbackId } = await seedCallback();
     const app = createApp({
       signal: context.signal,
       routes: [probeRoute],
     });
     const rawBody = JSON.stringify({
+      callbackId,
       runId,
       status: "completed",
       payload: { hello: "world" },

--- a/turbo/apps/api/src/lib/callback-route/__tests__/helpers.ts
+++ b/turbo/apps/api/src/lib/callback-route/__tests__/helpers.ts
@@ -1,0 +1,23 @@
+import { z } from "zod";
+import { initContract } from "@ts-rest/core";
+
+const c = initContract();
+
+/**
+ * Test-only contract used by callback-route tests to register a probe handler
+ * via `createApp({ routes })`. The path is namespaced under `/api/__test__/`
+ * so it never collides with a production route.
+ */
+export const callbackTestProbeContract = c.router({
+  probe: {
+    method: "POST",
+    path: "/api/__test__/callback-route-probe",
+    body: z.unknown(),
+    responses: {
+      200: z.object({ ok: z.literal(true), runId: z.string() }),
+      400: z.object({ error: z.string() }),
+      401: z.object({ error: z.string() }),
+      404: z.object({ error: z.string() }),
+    },
+  },
+});

--- a/turbo/apps/api/src/lib/callback-route/callback-route.ts
+++ b/turbo/apps/api/src/lib/callback-route/callback-route.ts
@@ -1,0 +1,149 @@
+import { command, computed, state, type Command } from "ccstate";
+import { eq } from "drizzle-orm";
+import { agentRunCallbacks } from "@vm0/db/schema/agent-run-callback";
+
+import { request$ } from "../../signals/context/hono";
+import type { SignalRouteHandler } from "../../signals/context/route";
+import { db$ } from "../../signals/external/db";
+import { decryptSecretValue } from "../../signals/services/crypto.utils";
+import { safeJsonParse } from "../../signals/utils";
+import { verifyCallbackRequest } from "../event-consumer/verify-signature";
+
+/**
+ * Parsed and verified run-callback request data.
+ *
+ * Mirrors `apps/web/src/lib/infra/callback/verify-callback.ts#VerifiedCallback`
+ * so route handlers ported from web see the same envelope shape. Re-export
+ * with a route-specific payload generic from a consumer when needed.
+ */
+interface VerifiedCallback<P = unknown> {
+  /** Present only when the dispatcher includes callbackId (new behavior). */
+  readonly callbackId?: string;
+  readonly runId: string;
+  readonly status: "completed" | "failed" | "progress";
+  readonly result?: Record<string, unknown>;
+  readonly error?: string;
+  readonly payload: P;
+}
+
+interface CallbackErrorResponse {
+  readonly status: 400 | 401 | 404;
+  readonly body: { readonly error: string };
+}
+
+interface CallbackRequestBody {
+  readonly callbackId?: string;
+  readonly runId?: string;
+  readonly status: "completed" | "failed" | "progress";
+  readonly result?: Record<string, unknown>;
+  readonly error?: string;
+  readonly payload: unknown;
+}
+
+const callbackPayloadState$ = state<VerifiedCallback<unknown> | null>(null);
+
+/**
+ * Verified callback envelope, available inside a `callbackRoute` scope.
+ *
+ * Follows the same set/read pattern as `eventConsumerPayload$` and
+ * `authContext$`. Route handlers narrow `payload` to their route-specific
+ * shape via a local parse function — the primitive is payload-agnostic.
+ */
+export const callbackPayload$ = computed((get): VerifiedCallback<unknown> => {
+  const payload = get(callbackPayloadState$);
+  if (!payload) {
+    throw new Error("callbackPayload$ accessed outside a callbackRoute scope");
+  }
+  return payload;
+});
+
+function isCommand<T>(
+  handler$: SignalRouteHandler<T>,
+): handler$ is Command<T, [AbortSignal]> {
+  return "write" in handler$;
+}
+
+/**
+ * Wrap an inner handler with per-callback HMAC verification.
+ *
+ * Reads the raw request body (single-shot stream consumption), parses the
+ * JSON envelope, looks up the `agent_run_callbacks` row by `callbackId` (PK,
+ * preferred) or `runId` (fallback), decrypts the per-callback secret, verifies
+ * `X-VM0-Signature` / `X-VM0-Timestamp`, and exposes the verified envelope via
+ * `callbackPayload$`.
+ *
+ * Mirrors `apps/web/src/lib/infra/callback/verify-callback.ts#verifyCallback`
+ * exactly so error responses are byte-equivalent during the rollout window.
+ */
+export function callbackRoute<T>(
+  handler$: SignalRouteHandler<T>,
+): Command<Promise<T | CallbackErrorResponse>, [AbortSignal]> {
+  return command(
+    async (
+      { get, set },
+      signal: AbortSignal,
+    ): Promise<T | CallbackErrorResponse> => {
+      const req = get(request$);
+      const rawBody = await req.text();
+      signal.throwIfAborted();
+
+      const parsed = safeJsonParse(rawBody);
+      if (!parsed || typeof parsed !== "object") {
+        return { status: 400, body: { error: "Invalid JSON body" } };
+      }
+      const body = parsed as CallbackRequestBody;
+
+      if (!body.runId) {
+        return { status: 400, body: { error: "Missing runId" } };
+      }
+      const runId = body.runId;
+      const { callbackId } = body;
+
+      const db = get(db$);
+      const [record] = callbackId
+        ? await db
+            .select({ encryptedSecret: agentRunCallbacks.encryptedSecret })
+            .from(agentRunCallbacks)
+            .where(eq(agentRunCallbacks.id, callbackId))
+            .limit(1)
+        : await db
+            .select({ encryptedSecret: agentRunCallbacks.encryptedSecret })
+            .from(agentRunCallbacks)
+            .where(eq(agentRunCallbacks.runId, runId))
+            .limit(1);
+      signal.throwIfAborted();
+
+      if (!record) {
+        return { status: 404, body: { error: "Callback not found" } };
+      }
+
+      const secret = decryptSecretValue(record.encryptedSecret);
+
+      const verification = verifyCallbackRequest(
+        rawBody,
+        secret,
+        req.header("X-VM0-Signature") ?? null,
+        req.header("X-VM0-Timestamp") ?? null,
+      );
+      if (!verification.valid) {
+        return {
+          status: 401,
+          body: { error: verification.error ?? "Invalid signature" },
+        };
+      }
+
+      set(callbackPayloadState$, {
+        callbackId,
+        runId,
+        status: body.status,
+        result: body.result,
+        error: body.error,
+        payload: body.payload,
+      });
+
+      return isCommand(handler$)
+        ? await set(handler$, signal)
+        : await get(handler$);
+    },
+  );
+}


### PR DESCRIPTION
## Summary

- Adds `callbackRoute(handler$)` + `callbackPayload$` in `apps/api/src/lib/callback-route/` — per-callback HMAC verification mirroring `apps/web/src/lib/infra/callback/verify-callback.ts`. Decrypts the per-row secret from `agent_run_callbacks.encrypted_secret`, verifies `X-VM0-Signature` / `X-VM0-Timestamp`, and exposes the parsed envelope as a ccstate signal.
- Symmetric with the existing `eventConsumerRoute` wrapper (shared-secret HMAC). The two flavours now sit side-by-side in `apps/api/src/lib/`.
- Pure infra add: no production routes registered, no `@vm0/api-contracts` changes, no `apps/web` touched.

## Why

Run callbacks (telegram, slack/org, chat, github/issues, email/reply, email/trigger, voice-chat, schedule loop/cron) use a per-callback HMAC secret stored in `agent_run_callbacks.encrypted_secret`. apps/api today only ships `eventConsumerRoute` (shared-secret HMAC) — insufficient for any of these callback routes.

Wave 6 #19 (#12756, email/callbacks/reply migration) is the first run-callback migration; rather than mix the auth-primitive introduction with the route port (~1900 LOC including email outbox, Axiom, Resend, templates), this PR splits the auth primitive out so #12756 and follow-ups only pay the route-specific cost.

Refs: #12758 #12756 #12290

## What changed

- New `apps/api/src/lib/callback-route/callback-route.ts` (~140 LOC).
- New `apps/api/src/lib/callback-route/__tests__/callback-route.test.ts` (~265 LOC, 8 tests).
- New `apps/api/src/lib/callback-route/__tests__/helpers.ts` (~25 LOC) — test-only ts-rest contract used to register the probe route via `createApp({ routes })` injection.

All error-response strings (`"Invalid JSON body"`, `"Missing runId"`, `"Callback not found"`, `"Missing X-VM0-Signature header"`, `"Missing X-VM0-Timestamp header"`, `"Invalid timestamp format"`, `"Timestamp expired"`, `"Invalid signature"`) are byte-equivalent to web's `verifyCallback` so signatures generated by web's dispatcher will fail the same way against either backend during the rollout window.

## Test plan

- [x] All 8 unit tests pass — `pnpm -F api exec vitest --run src/lib/callback-route/__tests__/callback-route.test.ts`.
- [x] Coverage: 400 invalid JSON, 400 missing runId, 404 callback not found, 401 invalid signature, 401 missing signature header, 401 missing timestamp header, 401 expired timestamp, 200 happy path.
- [x] Lint passes (`pnpm turbo run lint --filter=api`).
- [x] Type-check passes (`pnpm check-types`).
- [x] Format clean (`pnpm format`).
- [x] Knip clean (`pnpm knip`).
- [ ] CI green on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)