### PR TITLE
test: align zero secrets and variables route parity

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-secrets.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-secrets.test.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from "node:crypto";
+
 import { zeroSecretsContract } from "@vm0/api-contracts/contracts/zero-secrets";
 import { createStore } from "ccstate";
 
@@ -32,6 +34,23 @@ describe("GET /api/zero/secrets", () => {
         message: "Not authenticated",
         code: "UNAUTHORIZED",
       },
+    });
+  });
+
+  it("returns 401 when the authenticated session has no organization", async () => {
+    mocks.clerk.session(`user_${randomUUID()}`, null);
+
+    const client = setupApp({ context })(zeroSecretsContract);
+
+    const response = await accept(
+      client.list({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [401],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
     });
   });
 

--- a/turbo/apps/web/app/api/zero/secrets/[name]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/secrets/[name]/__tests__/route.test.ts
@@ -10,6 +10,8 @@ import {
   uniqueId,
 } from "../../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
+import { findTestSecretsByOrgAndName } from "../../../../../../src/__tests__/db-test-assertions/secrets";
+import { insertTestUserSecret } from "../../../../../../src/__tests__/db-test-seeders/secrets";
 
 const context = testContext();
 
@@ -102,5 +104,104 @@ describe("DELETE /api/zero/secrets/:name", () => {
       }),
     );
     expect(response.status).toBe(401);
+  });
+
+  it("should return 401 when authenticated session has no organization", async () => {
+    mockClerk({ userId: uniqueId("zsec-del-no-org"), orgId: null });
+
+    const response = await DELETE(
+      createTestRequest(secretByNameUrl("ANY_KEY"), {
+        method: "DELETE",
+      }),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(data.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("should return 404 for a secret owned by another user", async () => {
+    const userId = uniqueId("zsec-del-cross-user");
+    const { orgId } = await setupOrg(userId);
+
+    await insertTestUserSecret({
+      orgId,
+      userId: uniqueId("zsec-del-victim"),
+      name: "OTHER_USER_SECRET",
+    });
+
+    const response = await DELETE(
+      createTestRequest(secretByNameUrl("OTHER_USER_SECRET"), {
+        method: "DELETE",
+      }),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(data.error.code).toBe("NOT_FOUND");
+
+    const victim = await findTestSecretsByOrgAndName({
+      orgId,
+      name: "OTHER_USER_SECRET",
+    });
+    expect(victim).toHaveLength(1);
+  });
+
+  it("should return 404 for a secret in another org", async () => {
+    const userId = uniqueId("zsec-del-cross-org");
+    await setupOrg(userId);
+    const victimOrgId = `org_${uniqueId("zsec-del-victim-org")}`;
+
+    await insertTestUserSecret({
+      orgId: victimOrgId,
+      userId,
+      name: "ORG_A_SECRET",
+    });
+
+    const response = await DELETE(
+      createTestRequest(secretByNameUrl("ORG_A_SECRET"), {
+        method: "DELETE",
+      }),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(data.error.code).toBe("NOT_FOUND");
+
+    const victim = await findTestSecretsByOrgAndName({
+      orgId: victimOrgId,
+      name: "ORG_A_SECRET",
+    });
+    expect(victim).toHaveLength(1);
+    expect(victim[0]?.orgId).toBe(victimOrgId);
+  });
+
+  it("should not delete non-user-type secrets", async () => {
+    const userId = uniqueId("zsec-del-type");
+    const { orgId } = await setupOrg(userId);
+
+    await insertTestUserSecret({
+      orgId,
+      userId,
+      name: "CONNECTOR_SECRET",
+      type: "connector",
+    });
+
+    const response = await DELETE(
+      createTestRequest(secretByNameUrl("CONNECTOR_SECRET"), {
+        method: "DELETE",
+      }),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(data.error.code).toBe("NOT_FOUND");
+
+    const victim = await findTestSecretsByOrgAndName({
+      orgId,
+      name: "CONNECTOR_SECRET",
+    });
+    expect(victim).toHaveLength(1);
+    expect(victim[0]?.type).toBe("connector");
   });
 });

--- a/turbo/apps/web/app/api/zero/secrets/[name]/route.ts
+++ b/turbo/apps/web/app/api/zero/secrets/[name]/route.ts
@@ -19,6 +19,9 @@ const router = tsr.router(zeroSecretsByNameContract, {
 
     const authCtx = await requireAuth(headers.authorization);
     if (isAuthError(authCtx)) return authCtx;
+    if (!authCtx.orgId) {
+      return createErrorResponse("UNAUTHORIZED", "Not authenticated");
+    }
     const { userId } = authCtx;
 
     log.debug("deleting secret", { userId, name: params.name });

--- a/turbo/apps/web/app/api/zero/secrets/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/secrets/__tests__/route.test.ts
@@ -92,6 +92,20 @@ describe("GET /api/zero/secrets", () => {
     );
     expect(response.status).toBe(401);
   });
+
+  it("should return 401 when authenticated session has no organization", async () => {
+    mockClerk({ userId: uniqueId("zsec-no-org"), orgId: null });
+
+    const response = await GET(
+      createTestRequest(secretUrl(), {
+        method: "GET",
+      }),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(data.error.code).toBe("UNAUTHORIZED");
+  });
 });
 
 describe("POST /api/zero/secrets", () => {

--- a/turbo/apps/web/app/api/zero/secrets/route.ts
+++ b/turbo/apps/web/app/api/zero/secrets/route.ts
@@ -22,6 +22,9 @@ const router = tsr.router(zeroSecretsContract, {
 
     const authCtx = await requireAuth(headers.authorization);
     if (isAuthError(authCtx)) return authCtx;
+    if (!authCtx.orgId) {
+      return createErrorResponse("UNAUTHORIZED", "Not authenticated");
+    }
     const { userId } = authCtx;
 
     const { org } = await resolveOrg(authCtx);

--- a/turbo/apps/web/app/api/zero/variables/[name]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/variables/[name]/__tests__/route.test.ts
@@ -10,6 +10,8 @@ import {
   uniqueId,
 } from "../../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
+import { findTestVariablesByOrgAndName } from "../../../../../../src/__tests__/db-test-assertions/secrets";
+import { insertTestUserVariable } from "../../../../../../src/__tests__/db-test-seeders/secrets";
 
 const context = testContext();
 
@@ -102,5 +104,77 @@ describe("DELETE /api/zero/variables/:name", () => {
       }),
     );
     expect(response.status).toBe(401);
+  });
+
+  it("should return 401 when authenticated session has no organization", async () => {
+    mockClerk({ userId: uniqueId("zvar-del-no-org"), orgId: null });
+
+    const response = await DELETE(
+      createTestRequest(variableByNameUrl("ANY_VAR"), {
+        method: "DELETE",
+      }),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(data.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("should return 404 for a variable owned by another user", async () => {
+    const userId = uniqueId("zvar-del-cross-user");
+    const { orgId } = await setupOrg(userId);
+
+    await insertTestUserVariable({
+      orgId,
+      userId: uniqueId("zvar-del-victim"),
+      name: "OTHER_USER_VAR",
+      value: "other-user",
+    });
+
+    const response = await DELETE(
+      createTestRequest(variableByNameUrl("OTHER_USER_VAR"), {
+        method: "DELETE",
+      }),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(data.error.code).toBe("NOT_FOUND");
+
+    const victim = await findTestVariablesByOrgAndName({
+      orgId,
+      name: "OTHER_USER_VAR",
+    });
+    expect(victim).toHaveLength(1);
+  });
+
+  it("should return 404 for a variable in another org", async () => {
+    const userId = uniqueId("zvar-del-cross-org");
+    await setupOrg(userId);
+    const victimOrgId = `org_${uniqueId("zvar-del-victim-org")}`;
+
+    await insertTestUserVariable({
+      orgId: victimOrgId,
+      userId,
+      name: "ORG_A_VAR",
+      value: "other-org",
+    });
+
+    const response = await DELETE(
+      createTestRequest(variableByNameUrl("ORG_A_VAR"), {
+        method: "DELETE",
+      }),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(data.error.code).toBe("NOT_FOUND");
+
+    const victim = await findTestVariablesByOrgAndName({
+      orgId: victimOrgId,
+      name: "ORG_A_VAR",
+    });
+    expect(victim).toHaveLength(1);
+    expect(victim[0]?.orgId).toBe(victimOrgId);
   });
 });

--- a/turbo/apps/web/app/api/zero/variables/[name]/route.ts
+++ b/turbo/apps/web/app/api/zero/variables/[name]/route.ts
@@ -19,6 +19,9 @@ const router = tsr.router(zeroVariablesByNameContract, {
 
     const authCtx = await requireAuth(headers.authorization);
     if (isAuthError(authCtx)) return authCtx;
+    if (!authCtx.orgId) {
+      return createErrorResponse("UNAUTHORIZED", "Not authenticated");
+    }
     const { userId } = authCtx;
 
     log.debug("deleting variable", { userId, name: params.name });

--- a/turbo/apps/web/app/api/zero/variables/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/variables/__tests__/route.test.ts
@@ -89,6 +89,20 @@ describe("GET /api/zero/variables", () => {
     );
     expect(response.status).toBe(401);
   });
+
+  it("should return 401 when authenticated session has no organization", async () => {
+    mockClerk({ userId: uniqueId("zvar-no-org"), orgId: null });
+
+    const response = await GET(
+      createTestRequest(variableUrl(), {
+        method: "GET",
+      }),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(data.error.code).toBe("UNAUTHORIZED");
+  });
 });
 
 describe("POST /api/zero/variables", () => {

--- a/turbo/apps/web/app/api/zero/variables/route.ts
+++ b/turbo/apps/web/app/api/zero/variables/route.ts
@@ -22,6 +22,9 @@ const router = tsr.router(zeroVariablesContract, {
 
     const authCtx = await requireAuth(headers.authorization);
     if (isAuthError(authCtx)) return authCtx;
+    if (!authCtx.orgId) {
+      return createErrorResponse("UNAUTHORIZED", "Not authenticated");
+    }
     const { userId } = authCtx;
 
     const { org } = await resolveOrg(authCtx);

--- a/turbo/apps/web/src/__tests__/db-test-assertions/secrets.ts
+++ b/turbo/apps/web/src/__tests__/db-test-assertions/secrets.ts
@@ -1,0 +1,39 @@
+import { and, eq } from "drizzle-orm";
+import { secrets } from "@vm0/db/schema/secret";
+import { variables } from "@vm0/db/schema/variable";
+import { initServices } from "../../lib/init-services";
+
+export async function findTestSecretsByOrgAndName(params: {
+  orgId: string;
+  name: string;
+}): Promise<
+  Array<{ id: string; orgId: string; userId: string; type: string }>
+> {
+  initServices();
+  return globalThis.services.db
+    .select({
+      id: secrets.id,
+      orgId: secrets.orgId,
+      userId: secrets.userId,
+      type: secrets.type,
+    })
+    .from(secrets)
+    .where(and(eq(secrets.orgId, params.orgId), eq(secrets.name, params.name)));
+}
+
+export async function findTestVariablesByOrgAndName(params: {
+  orgId: string;
+  name: string;
+}): Promise<Array<{ id: string; orgId: string; userId: string }>> {
+  initServices();
+  return globalThis.services.db
+    .select({
+      id: variables.id,
+      orgId: variables.orgId,
+      userId: variables.userId,
+    })
+    .from(variables)
+    .where(
+      and(eq(variables.orgId, params.orgId), eq(variables.name, params.name)),
+    );
+}

--- a/turbo/apps/web/src/__tests__/db-test-seeders/secrets.ts
+++ b/turbo/apps/web/src/__tests__/db-test-seeders/secrets.ts
@@ -1,4 +1,5 @@
 import { initServices } from "../../lib/init-services";
+import type { SecretType } from "@vm0/api-contracts/contracts/secrets";
 import { secrets } from "@vm0/db/schema/secret";
 import { variables } from "@vm0/db/schema/variable";
 import { ORG_SENTINEL_USER_ID } from "../../lib/zero/org/org-sentinel";
@@ -95,6 +96,36 @@ export async function insertTestUserModelProviderSecret(params: {
 }
 
 /**
+ * Insert a user-level secret directly in the database.
+ *
+ * @why-db-direct Route isolation tests need rows owned by another user, another
+ * org, or a non-user secret type. The public secrets API always writes the
+ * authenticated user's active-org secret with type="user".
+ */
+export async function insertTestUserSecret(params: {
+  orgId: string;
+  userId: string;
+  name: string;
+  value?: string;
+  type?: SecretType;
+}): Promise<void> {
+  initServices();
+  const { SECRETS_ENCRYPTION_KEY } = globalThis.services.env;
+  const encrypted = encryptSecretValue(
+    params.value ?? "test-secret-value",
+    SECRETS_ENCRYPTION_KEY,
+  );
+  await globalThis.services.db.insert(secrets).values({
+    name: params.name,
+    encryptedValue: encrypted,
+    type: params.type ?? "user",
+    userId: params.userId,
+    orgId: params.orgId,
+    description: "test seed",
+  });
+}
+
+/**
  * Insert an org-level sentinel variable directly in the database.
  *
  * @why-db-direct The variables API creates user-scoped variables, not
@@ -111,5 +142,28 @@ export async function insertTestOrgSentinelVariable(params: {
     value: "sentinel-test-value",
     userId: ORG_SENTINEL_USER_ID,
     orgId: params.orgId,
+  });
+}
+
+/**
+ * Insert a user-level variable directly in the database.
+ *
+ * @why-db-direct Route isolation tests need rows owned by another user or org.
+ * The public variables API always writes the authenticated user's active-org
+ * variable.
+ */
+export async function insertTestUserVariable(params: {
+  orgId: string;
+  userId: string;
+  name: string;
+  value?: string;
+}): Promise<void> {
+  initServices();
+  await globalThis.services.db.insert(variables).values({
+    name: params.name,
+    value: params.value ?? "test-variable-value",
+    userId: params.userId,
+    orgId: params.orgId,
+    description: "test seed",
   });
 }


### PR DESCRIPTION
## Summary

- Align web `GET`/`DELETE` no-active-org behavior for zero secrets and variables with the API 401 contract.
- Add API coverage for `GET /api/zero/secrets` with an authenticated user but no active org.
- Add web no-active-org and delete-isolation coverage for secrets and variables.
- Document the current scope by leaving `POST /api/zero/secrets` and `POST /api/zero/variables` unchanged because those routes are still web-owned and are not registered in the current API route inventory.

Fixes #12637

## Validation

- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-secrets.test.ts src/signals/routes/__tests__/zero-secrets-delete.test.ts src/signals/routes/__tests__/zero-variables.test.ts src/signals/routes/__tests__/zero-variables-delete.test.ts`
- `pnpm -F web exec vitest run app/api/zero/secrets/__tests__/route.test.ts 'app/api/zero/secrets/[name]/__tests__/route.test.ts' app/api/zero/variables/__tests__/route.test.ts 'app/api/zero/variables/[name]/__tests__/route.test.ts'`
- `pnpm -F api lint`
- `pnpm -F web lint`
- `pnpm -F api check-types`
- `pnpm -F web check-types`
- `pnpm knip --workspace api`
- `pnpm knip --workspace web`
- `pnpm format`
- `git diff --check`
