### PR TITLE
fix: align zero slack channels no-org parity

### DIFF
--- a/turbo/apps/web/app/api/zero/slack/channels/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/slack/channels/__tests__/route.test.ts
@@ -29,6 +29,19 @@ describe("GET /api/zero/slack/channels", () => {
     expect(data.error.code).toBe("UNAUTHORIZED");
   });
 
+  it("returns 401 when no org is active in the session", async () => {
+    mockClerk({ userId: uniqueId("slack-no-org"), orgId: null, clerkOrgs: [] });
+
+    const request = new Request(
+      "http://localhost:3000/api/zero/slack/channels",
+    );
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(data.error.code).toBe("UNAUTHORIZED");
+  });
+
   it("returns 404 when no Slack installation exists for the org", async () => {
     await context.setupUser();
 

--- a/turbo/apps/web/app/api/zero/slack/channels/route.ts
+++ b/turbo/apps/web/app/api/zero/slack/channels/route.ts
@@ -8,6 +8,13 @@ import { slackOrgInstallations } from "@vm0/db/schema/slack-org-installation";
 import { createSlackClient } from "../../../../../src/lib/zero/slack";
 import { decryptSecretValue } from "../../../../../src/lib/shared/crypto/secrets-encryption";
 
+function unauthenticatedResponse() {
+  return NextResponse.json(
+    { error: { message: "Not authenticated", code: "UNAUTHORIZED" } },
+    { status: 401 },
+  );
+}
+
 /**
  * GET /api/zero/slack/channels
  *
@@ -19,10 +26,10 @@ export async function GET(request: Request) {
   const authHeader = request.headers.get("authorization");
   const authCtx = await getAuthContext(authHeader ?? undefined);
   if (!authCtx) {
-    return NextResponse.json(
-      { error: { message: "Not authenticated", code: "UNAUTHORIZED" } },
-      { status: 401 },
-    );
+    return unauthenticatedResponse();
+  }
+  if (!authCtx.orgId) {
+    return unauthenticatedResponse();
   }
 
   const { org } = await resolveOrg(authCtx);


### PR DESCRIPTION
## Summary

- add web coverage for authenticated no-active-org Slack channel requests
- return `401 UNAUTHORIZED` before `resolveOrg(...)` when `GET /api/zero/slack/channels` has no active org
- keep Slack installation lookup, pagination, filtering, and sorting behavior unchanged

Fixes #12639.
Refs #12610.

## Validation

- `pnpm -F web exec vitest run app/api/zero/slack/channels/__tests__/route.test.ts`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-slack-channels.test.ts`
- `pnpm -F web run lint`
- `pnpm -F web exec prettier --check app/api/zero/slack/channels/route.ts app/api/zero/slack/channels/__tests__/route.test.ts`
- `git diff --check`

## Typecheck Notes

- `pnpm -F web run check-types` still fails on existing unrelated implicit-any baseline errors in:
  - `app/api/runners/poll/route.ts`
  - `app/api/webhooks/agent/usage-event/route.ts`
  - `app/api/zero/onboarding/complete/route.ts`
  - `app/api/zero/onboarding/setup/route.ts`
  - `app/api/zero/skills/[name]/route.ts`
  - `app/api/zero/usage/runs/route.ts`
- The filtered check output has no errors in the files changed by this PR.
