### PR TITLE
fix: align zero skills route parity

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-skills.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-skills.ts
@@ -84,6 +84,7 @@ interface SkillStorageSeed {
   readonly skillName: string;
   readonly s3Key: string;
   readonly headVersionId: string;
+  readonly type?: string;
 }
 
 export const seedSkillStorage$ = command(
@@ -100,7 +101,7 @@ export const seedSkillStorage$ = command(
       id: storageId,
       userId: VOLUME_ORG_USER_ID,
       name: storageName,
-      type: "volume",
+      type: args.type ?? "volume",
       orgId: args.orgId,
       s3Prefix: `orgs/${args.orgId}/${storageName}`,
     });

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-skills.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-skills.test.ts
@@ -266,6 +266,57 @@ describe("GET /api/zero/skills/:name", () => {
     expect(response.body.content).toBe("# Multi");
   });
 
+  it("ignores non-volume storage rows for skill content", async () => {
+    const fixture = await track(
+      store.set(seedSkillsFixture$, undefined, context.signal),
+    );
+    const skillName = "typed-skill";
+    const s3Key = `orgs/${fixture.orgId}/custom-skill@${skillName}/non-volume`;
+    await store.set(
+      seedSkill$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        name: skillName,
+        displayName: "Typed Skill",
+      },
+      context.signal,
+    );
+    await store.set(
+      seedSkillStorage$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        skillName,
+        s3Key,
+        headVersionId: `head-${randomUUID()}`,
+        type: "artifact",
+      },
+      context.signal,
+    );
+    mockSkillContent(context, {
+      s3Key,
+      content: "# Non-volume content",
+    });
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      detailClient().get({
+        headers: authHeaders(),
+        params: { name: skillName },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      name: skillName,
+      displayName: "Typed Skill",
+      description: null,
+      content: null,
+      files: null,
+    });
+  });
+
   it("returns 404 for a non-existent skill", async () => {
     const fixture = await track(
       store.set(seedSkillsFixture$, undefined, context.signal),

--- a/turbo/apps/api/src/signals/services/zero-skill-detail.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-skill-detail.service.ts
@@ -53,6 +53,7 @@ export function zeroSkillDetail(
           eq(storages.orgId, orgId),
           eq(storages.userId, VOLUME_ORG_USER_ID),
           eq(storages.name, storageName),
+          eq(storages.type, "volume"),
         ),
       )
       .limit(1);

--- a/turbo/apps/web/app/api/zero/skills/[name]/route.ts
+++ b/turbo/apps/web/app/api/zero/skills/[name]/route.ts
@@ -28,6 +28,7 @@ import { extractFileFromTar } from "../../../../../src/lib/infra/tar";
 import { env } from "../../../../../src/env";
 import { requireAdminPermission } from "../../../../../src/lib/zero/require-agent-permission";
 import { logger } from "../../../../../src/lib/shared/logger";
+import { isBadRequest } from "@vm0/api-services/errors";
 
 const log = logger("api:zero-skills:detail");
 
@@ -42,15 +43,27 @@ const router = tsr.router(zeroSkillsDetailContract, {
     });
     if (isAuthError(authCtx)) return authCtx;
 
-    const { org } = await resolveOrg(authCtx);
+    let orgId: string;
+    try {
+      const { org } = await resolveOrg(authCtx);
+      orgId = org.orgId;
+    } catch (error) {
+      if (isBadRequest(error)) {
+        return {
+          status: 401 as const,
+          body: {
+            error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+          },
+        };
+      }
+      throw error;
+    }
 
     // Look up skill metadata
     const [skill] = await globalThis.services.db
       .select()
       .from(zeroSkills)
-      .where(
-        and(eq(zeroSkills.orgId, org.orgId), eq(zeroSkills.name, params.name)),
-      )
+      .where(and(eq(zeroSkills.orgId, orgId), eq(zeroSkills.name, params.name)))
       .limit(1);
 
     if (!skill) {
@@ -72,7 +85,7 @@ const router = tsr.router(zeroSkillsDetailContract, {
       .from(storages)
       .where(
         and(
-          eq(storages.orgId, org.orgId),
+          eq(storages.orgId, orgId),
           eq(storages.userId, VOLUME_ORG_USER_ID),
           eq(storages.name, storageName),
           eq(storages.type, "volume"),

--- a/turbo/apps/web/app/api/zero/skills/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/skills/__tests__/route.test.ts
@@ -214,6 +214,22 @@ describe("Zero Skills API (org-level)", () => {
   });
 
   describe("GET /api/zero/skills", () => {
+    it("should return 401 when authenticated session has no active organization", async () => {
+      mockClerk({ userId: user.userId, orgId: null });
+
+      const response = await listSkills(
+        createTestRequest(`http://localhost:3000/api/zero/skills`, {
+          method: "GET",
+        }),
+      );
+      const data = await response.json();
+
+      expect(response.status).toBe(401);
+      expect(data).toStrictEqual({
+        error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+      });
+    });
+
     it("should return empty array when no skills", async () => {
       const response = await listSkillsReq(testCliToken);
 
@@ -252,6 +268,22 @@ describe("Zero Skills API (org-level)", () => {
   });
 
   describe("GET /api/zero/skills/:name", () => {
+    it("should return 401 when authenticated session has no active organization", async () => {
+      mockClerk({ userId: user.userId, orgId: null });
+
+      const response = await getSkill(
+        createTestRequest(`http://localhost:3000/api/zero/skills/any-skill`, {
+          method: "GET",
+        }),
+      );
+      const data = await response.json();
+
+      expect(response.status).toBe(401);
+      expect(data).toStrictEqual({
+        error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+      });
+    });
+
     it("should return skill with content", async () => {
       await postSkillReq(
         {

--- a/turbo/apps/web/app/api/zero/skills/route.ts
+++ b/turbo/apps/web/app/api/zero/skills/route.ts
@@ -13,6 +13,7 @@ import { uploadVolumeServerSide } from "../../../../src/lib/infra/storage/volume
 import { SEED_SKILLS } from "../../../../src/lib/zero/seed-skills";
 import { requireAdminPermission } from "../../../../src/lib/zero/require-agent-permission";
 import { logger } from "../../../../src/lib/shared/logger";
+import { isBadRequest } from "@vm0/api-services/errors";
 
 const log = logger("api:zero-skills");
 
@@ -25,7 +26,21 @@ const router = tsr.router(zeroSkillsCollectionContract, {
     });
     if (isAuthError(authCtx)) return authCtx;
 
-    const { org } = await resolveOrg(authCtx);
+    let orgId: string;
+    try {
+      const { org } = await resolveOrg(authCtx);
+      orgId = org.orgId;
+    } catch (error) {
+      if (isBadRequest(error)) {
+        return {
+          status: 401 as const,
+          body: {
+            error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+          },
+        };
+      }
+      throw error;
+    }
 
     const rows = await globalThis.services.db
       .select({
@@ -34,7 +49,7 @@ const router = tsr.router(zeroSkillsCollectionContract, {
         description: zeroSkills.description,
       })
       .from(zeroSkills)
-      .where(eq(zeroSkills.orgId, org.orgId));
+      .where(eq(zeroSkills.orgId, orgId));
 
     return {
       status: 200 as const,


### PR DESCRIPTION
## Summary
- align web zero skill read routes with API no-active-org behavior by returning 401 UNAUTHORIZED
- make API skill detail storage lookup ignore non-volume storage rows like the web route
- add route-level regression coverage for web no-active-org handling and API storage type filtering

## Validation
- pnpm -F web exec vitest run app/api/zero/skills/__tests__/route.test.ts
- pnpm -F api exec vitest run src/signals/routes/__tests__/zero-skills.test.ts
- pnpm prettier --write apps/web/app/api/zero/skills/route.ts apps/web/app/api/zero/skills/[name]/route.ts apps/web/app/api/zero/skills/__tests__/route.test.ts apps/api/src/signals/services/zero-skill-detail.service.ts apps/api/src/signals/routes/__tests__/helpers/zero-skills.ts apps/api/src/signals/routes/__tests__/zero-skills.test.ts
- pnpm -F web lint
- pnpm -F web check-types
- pnpm -F api lint
- pnpm -F api check-types
- git diff --check
- commit hook: prettier, knip, pnpm check-types, commitlint

Fixes #12638