### PR TITLE
fix: align zero team route parity

### DIFF
--- a/turbo/apps/web/app/api/zero/team/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/team/__tests__/route.test.ts
@@ -48,6 +48,19 @@ describe("GET /api/zero/team", () => {
     expect(data).toEqual([]);
   });
 
+  it("should return empty list when active org has no org metadata row", async () => {
+    mockClerk({
+      userId: `team-user-${randomUUID().slice(0, 8)}`,
+      orgId: `org_team_no_meta_${randomUUID().slice(0, 8)}`,
+    });
+
+    const response = await GET();
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data).toEqual([]);
+  });
+
   it("should return composes for the active org", async () => {
     const composeName = `team-test-${randomUUID().slice(0, 8)}`;
     await createTestCompose(composeName);

--- a/turbo/apps/web/app/api/zero/team/route.ts
+++ b/turbo/apps/web/app/api/zero/team/route.ts
@@ -11,8 +11,6 @@ import { initServices } from "../../../../src/lib/init-services";
 import { agentComposes } from "@vm0/db/schema/agent-compose";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
 import { getAuthContext } from "../../../../src/lib/auth/get-auth-context";
-import { resolveOrg } from "../../../../src/lib/zero/org/resolve-org";
-import { isNotFound, isForbidden } from "@vm0/api-services/errors";
 import { visibleJoinedZeroAgentCondition } from "../../../../src/lib/zero/agent-visibility";
 
 export async function GET() {
@@ -39,21 +37,6 @@ export async function GET() {
     );
   }
 
-  // Resolve org via standard path (verifies membership + applies JWT tier)
-  let resolvedOrgId: string;
-  try {
-    const { org } = await resolveOrg(authCtx);
-    resolvedOrgId = org.orgId;
-  } catch (error) {
-    if (isNotFound(error) || isForbidden(error)) {
-      return NextResponse.json(
-        { error: { message: "Organization not found", code: "NOT_FOUND" } },
-        { status: 404 },
-      );
-    }
-    throw error;
-  }
-
   const composes = await globalThis.services.db
     .select({
       id: agentComposes.id,
@@ -71,7 +54,7 @@ export async function GET() {
     .leftJoin(zeroAgents, eq(agentComposes.id, zeroAgents.id))
     .where(
       and(
-        eq(agentComposes.orgId, resolvedOrgId),
+        eq(agentComposes.orgId, authCtx.orgId),
         visibleJoinedZeroAgentCondition(authCtx.userId),
       ),
     )


### PR DESCRIPTION
## Summary

- Align the web `GET /api/zero/team` route with the API route by using the active Clerk `orgId` directly after the no-active-org check.
- Remove the web-only `resolveOrg` dependency and org-resolution 404 branch from this route.
- Add web coverage for an active org with no `org_metadata` row to document the API-equivalent active-org listing behavior.

Fixes #12640

## Validation

- `pnpm -F web exec vitest run app/api/zero/team/__tests__/route.test.ts`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-team.test.ts`
- `pnpm format`
- `pnpm -F web lint`
- `pnpm -F web check-types`
- `pnpm knip --workspace web`
- `git diff --check`
- pre-commit: `pnpm check-types` / knip / prettier / commitlint

## Note

After rebasing onto latest `origin/main`, local pre-commit initially failed because the newly added `ably` dependency was not installed in this checkout. `pnpm install --frozen-lockfile` synced dependencies without changing tracked files, and the full pre-commit check then passed.
