### PR TITLE
fix: align zero usage insight route parity

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-usage-insight.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-usage-insight.test.ts
@@ -79,6 +79,22 @@ describe("GET /api/zero/usage/insight", () => {
     });
   });
 
+  it("returns 401 when the authenticated session has no active organization", async () => {
+    mocks.clerk.session(`user_${randomUUID()}`, null);
+
+    const response = await accept(
+      apiClient().get({
+        query: { range: "7d", groupBy: "source", tz: "UTC" },
+        headers: authHeaders(),
+      }),
+      [401],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
   it("returns 400 for invalid timezone", async () => {
     const fixture = await track(
       store.set(seedUsageInsightFixture$, undefined, context.signal),
@@ -94,6 +110,23 @@ describe("GET /api/zero/usage/insight", () => {
     );
 
     expect(response.body.error.code).toBe("BAD_REQUEST");
+  });
+
+  it("accepts timezone aliases supported by Intl.DateTimeFormat", async () => {
+    const fixture = await track(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      apiClient().get({
+        query: { range: "7d", groupBy: "source", tz: "US/Pacific" },
+        headers: authHeaders(),
+      }),
+      [200],
+    );
+
+    expect(Array.isArray(response.body.buckets)).toBeTruthy();
   });
 
   it("returns 400 when range=day is missing a date", async () => {

--- a/turbo/apps/api/src/signals/routes/zero-usage-insight.ts
+++ b/turbo/apps/api/src/signals/routes/zero-usage-insight.ts
@@ -7,18 +7,14 @@ import { authRoute } from "../auth/auth-route";
 import { queryOf } from "../context/request";
 import { zeroUsageInsight$ } from "../services/zero-usage-insight.service";
 import type { RouteEntry } from "../route";
-
-const supportedTimeZones = Object.freeze([
-  "UTC",
-  ...Intl.supportedValuesOf("timeZone"),
-]);
+import { isValidTimeZone } from "../utils";
 
 const getUsageInsightInner$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     const auth = get(organizationAuthContext$);
     const query = get(queryOf(zeroUsageInsightContract.get));
 
-    if (!supportedTimeZones.includes(query.tz)) {
+    if (!isValidTimeZone(query.tz)) {
       return badRequestMessage(`Invalid timezone: ${query.tz}`);
     }
 

--- a/turbo/apps/web/app/api/zero/usage/insight/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/usage/insight/__tests__/route.test.ts
@@ -62,11 +62,36 @@ describe("GET /api/zero/usage/insight", () => {
     expect(response.status).toBe(401);
   });
 
+  it("returns 401 when the authenticated session has no active organization", async () => {
+    const { userId } = await context.user;
+    mockClerk({ userId, orgId: null });
+
+    const response = await GET(
+      makeRequest({ range: "7d", groupBy: "source", tz: "UTC" }),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(data).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
   it("returns 400 for invalid timezone", async () => {
     const response = await GET(
       makeRequest({ range: "7d", groupBy: "source", tz: "Not/A/Timezone" }),
     );
     expect(response.status).toBe(400);
+  });
+
+  it("accepts timezone aliases supported by Intl.DateTimeFormat", async () => {
+    const response = await GET(
+      makeRequest({ range: "7d", groupBy: "source", tz: "US/Pacific" }),
+    );
+    const data = (await response.json()) as UsageInsightResponse;
+
+    expect(response.status).toBe(200);
+    expect(Array.isArray(data.buckets)).toBe(true);
   });
 
   it("returns 400 when range=day is missing a date", async () => {

--- a/turbo/apps/web/app/api/zero/usage/insight/route.ts
+++ b/turbo/apps/web/app/api/zero/usage/insight/route.ts
@@ -8,6 +8,7 @@ import {
 } from "../../../../../src/lib/auth/require-auth";
 import { resolveOrg } from "../../../../../src/lib/zero/org/resolve-org";
 import { getUsageInsight } from "../../../../../src/lib/zero/billing/usage-insight-service";
+import { isBadRequest } from "@vm0/api-services/errors";
 
 const router = tsr.router(zeroUsageInsightContract, {
   get: async ({ query, headers }) => {
@@ -16,7 +17,16 @@ const router = tsr.router(zeroUsageInsightContract, {
     const authCtx = await requireAuth(headers.authorization);
     if (isAuthError(authCtx)) return authCtx;
 
-    const { org } = await resolveOrg(authCtx);
+    let orgId: string;
+    try {
+      const { org } = await resolveOrg(authCtx);
+      orgId = org.orgId;
+    } catch (error) {
+      if (isBadRequest(error)) {
+        return createErrorResponse("UNAUTHORIZED", "Not authenticated");
+      }
+      throw error;
+    }
 
     // Validate timezone — Intl.DateTimeFormat constructor is the only standard
     // API that synchronously throws on an unrecognised IANA timezone string.
@@ -38,7 +48,7 @@ const router = tsr.router(zeroUsageInsightContract, {
       }
     }
 
-    const result = await getUsageInsight(authCtx.userId, org.orgId, {
+    const result = await getUsageInsight(authCtx.userId, orgId, {
       range: query.range,
       date: query.date,
       groupBy: query.groupBy,


### PR DESCRIPTION
## Summary
- align API timezone validation with the web route by using the shared Intl.DateTimeFormat-based helper
- return 401 from the web usage insight route when the session has no active organization
- add matching API and web regression coverage for timezone aliases and no-active-org behavior

## Validation
- pnpm -F api exec vitest run src/signals/routes/__tests__/zero-usage-insight.test.ts
- pnpm -F web exec vitest run app/api/zero/usage/insight/__tests__/route.test.ts
- pnpm prettier --write apps/api/src/signals/routes/zero-usage-insight.ts apps/api/src/signals/routes/__tests__/zero-usage-insight.test.ts apps/web/app/api/zero/usage/insight/route.ts apps/web/app/api/zero/usage/insight/__tests__/route.test.ts
- pnpm -F api lint
- pnpm -F api check-types
- pnpm -F web lint
- pnpm -F web check-types
- git diff --check

Fixes #12643