### PR TITLE
fix: align zero user preferences no-org parity

### DIFF
--- a/turbo/apps/web/app/api/zero/user-preferences/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/user-preferences/__tests__/route.test.ts
@@ -31,6 +31,25 @@ describe("GET /api/zero/user-preferences", () => {
     expect(data.error.message).toContain("Not authenticated");
   });
 
+  it("should reject authenticated requests without an active org", async () => {
+    const user = await context.setupUser();
+    mockClerk({ userId: user.userId, orgId: null });
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/zero/user-preferences",
+    );
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(data).toStrictEqual({
+      error: {
+        message: "Not authenticated",
+        code: "UNAUTHORIZED",
+      },
+    });
+  });
+
   it("should return default preferences for new user", async () => {
     const user = await context.setupUser();
     mockClerk({ userId: user.userId, orgId: user.orgId });
@@ -107,6 +126,30 @@ describe("POST /api/zero/user-preferences", () => {
 
     expect(response.status).toBe(401);
     expect(data.error.message).toContain("Not authenticated");
+  });
+
+  it("should reject authenticated requests without an active org", async () => {
+    const user = await context.setupUser();
+    mockClerk({ userId: user.userId, orgId: null });
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/zero/user-preferences",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ timezone: "America/New_York" }),
+      },
+    );
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(data).toStrictEqual({
+      error: {
+        message: "Not authenticated",
+        code: "UNAUTHORIZED",
+      },
+    });
   });
 
   it("should resolve default org when no orgId in session", async () => {

--- a/turbo/apps/web/app/api/zero/user-preferences/route.ts
+++ b/turbo/apps/web/app/api/zero/user-preferences/route.ts
@@ -13,12 +13,17 @@ import {
 } from "../../../../src/lib/zero/user/user-preferences-service";
 import { isBadRequest } from "@vm0/api-services/errors";
 
+function unauthenticatedResponse() {
+  return createErrorResponse("UNAUTHORIZED", "Not authenticated");
+}
+
 const router = tsr.router(zeroUserPreferencesContract, {
   get: async ({ headers }) => {
     initServices();
 
     const authCtx = await requireAuth(headers.authorization);
     if (isAuthError(authCtx)) return authCtx;
+    if (!authCtx.orgId) return unauthenticatedResponse();
 
     const { org } = await resolveOrg(authCtx);
 
@@ -40,6 +45,7 @@ const router = tsr.router(zeroUserPreferencesContract, {
 
     const authCtx = await requireAuth(headers.authorization);
     if (isAuthError(authCtx)) return authCtx;
+    if (!authCtx.orgId) return unauthenticatedResponse();
 
     const { org } = await resolveOrg(authCtx);
 


### PR DESCRIPTION
## Summary
- Add web route coverage for authenticated user-preferences requests without an active org.
- Return the API-matching 401 `UNAUTHORIZED` response from web GET and POST before org resolution.
- Keep default-org resolution and preference persistence behavior unchanged.

Closes #12645

## Validation
- `pnpm -F web exec vitest run app/api/zero/user-preferences/__tests__/route.test.ts` (28 passed)
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-user-preferences.test.ts` (13 passed)
- `pnpm -F web run lint`
- `pnpm -F web exec prettier --check app/api/zero/user-preferences/route.ts app/api/zero/user-preferences/__tests__/route.test.ts`
- `git diff --check`
- `pnpm -F web run check-types` failed on existing unrelated implicit-any baseline errors in app/api/runners/poll, app/api/webhooks/agent/usage-event, app/api/zero/onboarding, app/api/zero/skills, and app/api/zero/usage/runs; no errors were reported in the changed files.