### PR TITLE
test: align zero uploads route parity

### DIFF
--- a/turbo/apps/api/src/__tests__/mocks.ts
+++ b/turbo/apps/api/src/__tests__/mocks.ts
@@ -39,6 +39,7 @@ export interface ApiTestMocks {
   readonly s3: {
     readonly send: AsyncMock;
     readonly getSignedUrl: AsyncMock;
+    readonly clientConfig: SyncMock;
   };
   readonly slack: {
     readonly chat: {
@@ -207,6 +208,7 @@ const apiTestMocks: ApiTestMocks = vi.hoisted((): ApiTestMocks => {
     s3: {
       send: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
       getSignedUrl: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
+      clientConfig: vi.fn<(...args: unknown[]) => void>(),
     },
     slack,
     stripe,
@@ -263,6 +265,10 @@ vi.mock("@aws-sdk/client-s3", () => {
   }
 
   class S3Client {
+    constructor(config: unknown) {
+      apiTestMocks.s3.clientConfig(config);
+    }
+
     send(command: unknown): Promise<unknown> {
       return apiTestMocks.s3.send(command);
     }
@@ -477,6 +483,7 @@ export function resetApiTestMocks(): void {
   apiTestMocks.s3.getSignedUrl.mockResolvedValue(
     "https://r2.example.com/upload?sig=test",
   );
+  apiTestMocks.s3.clientConfig.mockReset();
   apiTestMocks.slack.chat.postMessage.mockReset();
   apiTestMocks.slack.conversations.list.mockReset();
   apiTestMocks.slack.conversations.open.mockReset();

--- a/turbo/apps/api/src/lib/env.ts
+++ b/turbo/apps/api/src/lib/env.ts
@@ -22,6 +22,10 @@ const SCHEMA = {
   R2_ACCOUNT_ID: z.string().min(1),
   R2_SECRET_ACCESS_KEY: z.string().min(1),
   R2_USER_STORAGES_BUCKET_NAME: z.string().min(1),
+  S3_ENDPOINT: z.url().optional(),
+  S3_REGION: z.string().min(1).optional(),
+  S3_FORCE_PATH_STYLE: z.enum(["true", "false"]).optional(),
+  S3_PUBLIC_ENDPOINT: z.url().optional(),
   AXIOM_TOKEN_SESSIONS: z.string().min(1),
   AXIOM_TOKEN_TELEMETRY: z.string().min(1),
   AXIOM_DATASET_SUFFIX: z.enum(["dev", "prod"]),
@@ -64,7 +68,11 @@ const SCHEMA = {
 
 const baseEnv = createEnv<undefined, typeof SCHEMA>({
   server: SCHEMA,
-  runtimeEnv: process.env,
+  runtimeEnv: {
+    ...process.env,
+    S3_PUBLIC_ENDPOINT:
+      process.env.S3_PUBLIC_ENDPOINT || process.env.S3_ENDPOINT,
+  },
   emptyStringAsUndefined: true,
 });
 

--- a/turbo/apps/api/src/signals/external/s3.ts
+++ b/turbo/apps/api/src/signals/external/s3.ts
@@ -30,15 +30,32 @@ interface S3StorageManifest {
   readonly files: readonly S3FileEntry[];
 }
 
-const s3Client$ = computed((): S3Client => {
+function createS3Client(endpoint: string): S3Client {
   return new S3Client({
-    region: "auto",
-    endpoint: `https://${env("R2_ACCOUNT_ID")}.r2.cloudflarestorage.com`,
+    region: env("S3_REGION") ?? "auto",
+    endpoint,
     credentials: {
       accessKeyId: env("R2_ACCESS_KEY_ID"),
       secretAccessKey: env("R2_SECRET_ACCESS_KEY"),
     },
+    forcePathStyle: env("S3_FORCE_PATH_STYLE") === "true",
   });
+}
+
+function defaultS3Endpoint(): string {
+  return `https://${env("R2_ACCOUNT_ID")}.r2.cloudflarestorage.com`;
+}
+
+const s3Client$ = computed((): S3Client => {
+  return createS3Client(env("S3_ENDPOINT") ?? defaultS3Endpoint());
+});
+
+const publicS3Client$ = computed((get): S3Client => {
+  const publicEndpoint = env("S3_PUBLIC_ENDPOINT");
+  if (!publicEndpoint) {
+    return get(s3Client$);
+  }
+  return createS3Client(publicEndpoint);
 });
 
 export function listS3Objects(
@@ -138,9 +155,10 @@ export function generatePresignedPutUrl(
   key: string,
   contentType: string,
   expiresIn: number,
+  usePublicEndpoint = false,
 ): Computed<Promise<string>> {
   return computed((get): Promise<string> => {
-    const client = get(s3Client$);
+    const client = get(usePublicEndpoint ? publicS3Client$ : s3Client$);
     const command = new PutObjectCommand({
       Bucket: bucket,
       Key: key,

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-uploads-prepare.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-uploads-prepare.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from "vitest";
 import { zeroUploadsContract } from "@vm0/api-contracts/contracts/zero-uploads";
 
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { mockEnv } from "../../../lib/env";
 import { now } from "../../../lib/time";
 import { signSandboxJwtForTests } from "../../auth/tokens";
 import {
@@ -155,6 +156,28 @@ describe("POST /api/zero/uploads/prepare", () => {
     expect(response.body.id).toMatch(/^[0-9a-f-]{36}$/);
   });
 
+  it("uses the public S3 endpoint for externally consumed upload URLs", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    mocks.clerk.session(userId, orgId);
+    mockEnv("S3_ENDPOINT", "http://internal-s3.example.com");
+    mockEnv("S3_PUBLIC_ENDPOINT", "http://public-s3.example.com");
+
+    const client = setupApp({ context })(zeroUploadsContract);
+    const response = await client.prepare({
+      body: validBody(),
+      headers: { authorization: "Bearer clerk-session" },
+    });
+    expect(response.status).toBe(200);
+
+    const config = context.mocks.s3.clientConfig.mock.calls[0]?.[0];
+    expect(config).toMatchObject({
+      endpoint: "http://public-s3.example.com",
+      region: "auto",
+      forcePathStyle: false,
+    });
+  });
+
   it("sanitizes filenames in the S3 key", async () => {
     const userId = `user_${randomUUID()}`;
     const orgId = `org_${randomUUID()}`;
@@ -188,11 +211,61 @@ describe("POST /api/zero/uploads/prepare", () => {
       { filename: "clip.mp3", contentType: "audio/mpeg" },
       { filename: "archive.zip", contentType: "application/zip" },
       {
+        filename: "backup.7z",
+        contentType: "application/x-7z-compressed",
+      },
+      { filename: "bundle.tar", contentType: "application/x-tar" },
+      { filename: "bundle.tgz", contentType: "application/gzip" },
+      { filename: "design.psd", contentType: "image/vnd.adobe.photoshop" },
+      { filename: "vector.ai", contentType: "application/postscript" },
+      { filename: "photo.heic", contentType: "image/heic" },
+      { filename: "scan.tiff", contentType: "image/tiff" },
+      {
         filename: "brief.docx",
         contentType:
           "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
       },
+      {
+        filename: "budget.xlsx",
+        contentType:
+          "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+      },
+      {
+        filename: "deck.pptx",
+        contentType:
+          "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+      },
+      {
+        filename: "document.pages",
+        contentType: "application/vnd.apple.pages",
+      },
+      {
+        filename: "sheet.numbers",
+        contentType: "application/vnd.apple.numbers",
+      },
+      {
+        filename: "slides.key",
+        contentType: "application/vnd.apple.keynote",
+      },
+      {
+        filename: "macro.xlsm",
+        contentType: "application/vnd.ms-excel.sheet.macroenabled.12",
+      },
+      {
+        filename: "template.potx",
+        contentType:
+          "application/vnd.openxmlformats-officedocument.presentationml.template",
+      },
       { filename: "doc.pdf", contentType: "application/pdf" },
+      { filename: "data.xml", contentType: "application/xml" },
+      { filename: "config.yaml", contentType: "application/yaml" },
+      { filename: "table.tsv", contentType: "text/tab-separated-values" },
+      {
+        filename: "events.parquet",
+        contentType: "application/vnd.apache.parquet",
+      },
+      { filename: "local.sqlite", contentType: "application/vnd.sqlite3" },
+      { filename: "book.epub", contentType: "application/epub+zip" },
     ] as const;
 
     const client = setupApp({ context })(zeroUploadsContract);

--- a/turbo/apps/api/src/signals/routes/zero-uploads-prepare.ts
+++ b/turbo/apps/api/src/signals/routes/zero-uploads-prepare.ts
@@ -43,7 +43,13 @@ const prepareUploadInner$ = command(async ({ get }, signal: AbortSignal) => {
   const bucket = env("R2_USER_STORAGES_BUCKET_NAME");
 
   const uploadUrl = await get(
-    generatePresignedPutUrl(bucket, s3Key, contentType, PUT_URL_TTL_SECONDS),
+    generatePresignedPutUrl(
+      bucket,
+      s3Key,
+      contentType,
+      PUT_URL_TTL_SECONDS,
+      true,
+    ),
   );
   signal.throwIfAborted();
   const url = buildFileUrl(auth.userId, id, sanitizedName);

--- a/turbo/apps/web/app/api/zero/uploads/complete/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/uploads/complete/__tests__/route.test.ts
@@ -15,7 +15,10 @@ import {
 } from "../../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
 import { seedTestRun } from "../../../../../../src/__tests__/db-test-seeders/runs";
-import { generateZeroToken } from "../../../../../../src/lib/auth/sandbox-token";
+import {
+  generateSandboxToken,
+  generateZeroToken,
+} from "../../../../../../src/lib/auth/sandbox-token";
 import {
   findTestRunUploadedFiles,
   findTestRunUploadedFilesByRun,
@@ -220,5 +223,28 @@ describe("POST /api/zero/uploads/complete", () => {
 
     expect(response.status).toBe(404);
     expect(await findTestRunUploadedFiles("web", fileId)).toHaveLength(0);
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockClerk({ userId: null });
+
+    const response = await POST(completeRequest({ id: randomUUID() }));
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("returns 403 for sandbox token without file:write capability", async () => {
+    mockClerk({ userId: null });
+    const token = await generateSandboxToken(user.userId, "run-1", user.orgId);
+
+    const response = await POST(completeRequest({ id: randomUUID() }, token));
+
+    expect(response.status).toBe(403);
+    const body = await response.json();
+    expect(body.error.code).toBe("FORBIDDEN");
+    expect(body.error.message).toContain("file:write");
   });
 });

--- a/turbo/apps/web/app/api/zero/uploads/complete/route.ts
+++ b/turbo/apps/web/app/api/zero/uploads/complete/route.ts
@@ -1,7 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 import { initServices } from "../../../../../src/lib/init-services";
-import { getAuthContext } from "../../../../../src/lib/auth/get-auth-context";
+import {
+  isAuthError,
+  requireAuth,
+} from "../../../../../src/lib/auth/require-auth";
 import { listS3Objects } from "../../../../../src/lib/infra/s3/s3-client";
 import { env } from "../../../../../src/env";
 import { inferMimetype } from "../../../../../src/lib/shared/mimetype";
@@ -28,12 +31,12 @@ function errorResponse(
 export async function POST(request: NextRequest) {
   initServices();
 
-  const authCtx = await getAuthContext(
+  const authCtx = await requireAuth(
     request.headers.get("authorization") ?? undefined,
     { requiredCapability: "file:write" },
   );
-  if (!authCtx) {
-    return errorResponse(401, "Not authenticated", "UNAUTHORIZED");
+  if (isAuthError(authCtx)) {
+    return NextResponse.json(authCtx.body, { status: authCtx.status });
   }
 
   const parsed = completeSchema.safeParse(

--- a/turbo/apps/web/app/api/zero/uploads/prepare/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/uploads/prepare/__tests__/route.test.ts
@@ -6,7 +6,10 @@ import {
   type UserContext,
 } from "../../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
-import { generateZeroToken } from "../../../../../../src/lib/auth/sandbox-token";
+import {
+  generateSandboxToken,
+  generateZeroToken,
+} from "../../../../../../src/lib/auth/sandbox-token";
 
 const context = testContext();
 
@@ -65,6 +68,26 @@ describe("POST /api/zero/uploads/prepare", () => {
       expect(body.uploadUrl).toBeTypeOf("string");
       expect(body.url).toBeTypeOf("string");
       expect(body.id).toBeTypeOf("string");
+    });
+
+    it("rejects sandbox token without file:write capability", async () => {
+      mockClerk({ userId: null });
+      const token = await generateSandboxToken(
+        user.userId,
+        "run-1",
+        user.orgId,
+      );
+      const response = await POST(
+        createPrepareRequest(
+          { filename: "hello.txt", contentType: "text/plain", size: 5 },
+          { authToken: token },
+        ),
+      );
+      expect(response.status).toBe(403);
+
+      const body = await response.json();
+      expect(body.error.code).toBe("FORBIDDEN");
+      expect(body.error.message).toContain("file:write");
     });
   });
 

--- a/turbo/apps/web/app/api/zero/uploads/prepare/route.ts
+++ b/turbo/apps/web/app/api/zero/uploads/prepare/route.ts
@@ -1,7 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 import { initServices } from "../../../../../src/lib/init-services";
-import { getAuthContext } from "../../../../../src/lib/auth/get-auth-context";
+import {
+  isAuthError,
+  requireAuth,
+} from "../../../../../src/lib/auth/require-auth";
 import { generatePresignedPutUrl } from "../../../../../src/lib/infra/s3/s3-client";
 import { env } from "../../../../../src/env";
 import { logger } from "../../../../../src/lib/shared/logger";
@@ -39,15 +42,12 @@ const prepareSchema = z.object({
 export async function POST(request: NextRequest) {
   initServices();
 
-  const authCtx = await getAuthContext(
+  const authCtx = await requireAuth(
     request.headers.get("authorization") ?? undefined,
     { requiredCapability: "file:write" },
   );
-  if (!authCtx) {
-    return NextResponse.json(
-      { error: { message: "Not authenticated", code: "UNAUTHORIZED" } },
-      { status: 401 },
-    );
+  if (isAuthError(authCtx)) {
+    return NextResponse.json(authCtx.body, { status: authCtx.status });
   }
   const userId = authCtx.userId;
 


### PR DESCRIPTION
## Summary
- align API zero uploads prepare with web public S3 presign endpoint handling
- add API route coverage for broader upload MIME parity and public S3 endpoint config
- align web uploads auth errors with API capability handling and cover missing file:write cases

Closes #12642

## Tests
- pnpm -F api exec vitest run src/signals/routes/__tests__/zero-uploads-prepare.test.ts src/signals/routes/__tests__/zero-uploads-complete.test.ts
- pnpm -F web exec vitest run app/api/zero/uploads/prepare/__tests__/route.test.ts app/api/zero/uploads/complete/__tests__/route.test.ts
- pnpm turbo run lint
- pnpm check-types
- pnpm knip
- pnpm vitest