### PR TITLE
test: align zero voice io quota route parity

### DIFF
--- a/turbo/apps/web/app/api/zero/voice-io/quota/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/voice-io/quota/__tests__/route.test.ts
@@ -5,6 +5,7 @@ import {
 } from "../../../../../../src/__tests__/test-helpers";
 import {
   createTestOrg,
+  deleteOrgRow,
   updateOrgTier,
 } from "../../../../../../src/__tests__/api-test-helpers";
 import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
@@ -50,6 +51,22 @@ describe("GET /api/zero/voice-io/quota", () => {
     await setupOrg(userId);
     const response = await GET(createQuotaRequest());
     const body = await response.json();
+    expect(response.status).toBe(200);
+    expect(body).toEqual({
+      allowed: true,
+      count: 0,
+      limit: AUDIO_INPUT_FREE_QUOTA,
+    });
+  });
+
+  it("should default missing org metadata to the free quota", async () => {
+    const userId = uniqueId("quota-missing-metadata");
+    const { orgId } = await setupOrg(userId);
+    await deleteOrgRow(orgId);
+
+    const response = await GET(createQuotaRequest());
+    const body = await response.json();
+
     expect(response.status).toBe(200);
     expect(body).toEqual({
       allowed: true,


### PR DESCRIPTION
## Summary
- add web route coverage for missing org metadata defaulting to free voice-io quota
- keep production voice-io quota logic unchanged because API and web behavior already match

## Validation
- pnpm -F web exec vitest run app/api/zero/voice-io/quota/__tests__/route.test.ts
- pnpm -F api exec vitest run src/signals/routes/__tests__/zero-voice-io-quota.test.ts
- pnpm prettier --write apps/web/app/api/zero/voice-io/quota/__tests__/route.test.ts
- pnpm -F web lint
- pnpm -F web check-types
- git diff --check

Fixes #12648