### PR TITLE
test: align zero voice chat get parity

### DIFF
--- a/turbo/apps/web/app/api/zero/voice-chat/[id]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/voice-chat/[id]/__tests__/route.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 import { randomUUID } from "crypto";
 import { testContext } from "../../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
+import { insertTestVoiceChatSession } from "../../../../../../src/__tests__/db-test-seeders/voice-chat";
 import {
   getRequest,
   paramsFor,
@@ -50,6 +51,19 @@ describe("GET /api/zero/voice-chat/:id (getSession)", () => {
     expect(body.error.code).toBe("UNAUTHORIZED");
   });
 
+  it("returns 401 when authenticated without an active org", async () => {
+    mockClerk({ userId, orgId: null });
+
+    const response = await GET(
+      getRequest(`/${randomUUID()}`),
+      paramsFor(randomUUID()),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(body.error.code).toBe("UNAUTHORIZED");
+  });
+
   it("returns 404 when the feature flag is disabled (avoids leaking existence)", async () => {
     const { agentId } = await seedVoiceChatAgent(userId, orgId);
     const session = await seedVoiceChatSession({ orgId, userId, agentId });
@@ -89,6 +103,24 @@ describe("GET /api/zero/voice-chat/:id (getSession)", () => {
       paramsFor(otherSession.id),
     );
     const body = await response.json();
+    expect(response.status).toBe(404);
+    expect(body.error.code).toBe("NOT_FOUND");
+  });
+
+  it("returns 404 when the session belongs to a different org", async () => {
+    const { agentId } = await seedVoiceChatAgent(userId, orgId);
+    const sessionId = await insertTestVoiceChatSession({
+      orgId: `org_other_${randomUUID()}`,
+      userId,
+      agentId,
+    });
+
+    const response = await GET(
+      getRequest(`/${sessionId}`),
+      paramsFor(sessionId),
+    );
+    const body = await response.json();
+
     expect(response.status).toBe(404);
     expect(body.error.code).toBe("NOT_FOUND");
   });

--- a/turbo/apps/web/app/api/zero/voice-chat/[id]/tasks/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/voice-chat/[id]/tasks/__tests__/route.test.ts
@@ -3,7 +3,10 @@ import { randomUUID } from "crypto";
 import { testContext } from "../../../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../../../src/__tests__/clerk-mock";
 import { findTestZeroRun } from "../../../../../../../src/__tests__/db-test-assertions/runs";
-import { insertTestVoiceChatTask } from "../../../../../../../src/__tests__/db-test-seeders/voice-chat";
+import {
+  insertTestVoiceChatSession,
+  insertTestVoiceChatTask,
+} from "../../../../../../../src/__tests__/db-test-seeders/voice-chat";
 import {
   postRequest,
   getRequest,
@@ -161,6 +164,19 @@ describe("GET /api/zero/voice-chat/:id/tasks (listTasksForCard)", () => {
     expect(response.status).toBe(401);
   });
 
+  it("returns 401 when authenticated without an active org", async () => {
+    mockClerk({ userId, orgId: null });
+
+    const response = await GET(
+      getRequest(`/${randomUUID()}/tasks`),
+      paramsFor(randomUUID()),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(body.error.code).toBe("UNAUTHORIZED");
+  });
+
   it("returns 404 when the feature flag is disabled", async () => {
     const { agentId } = await seedVoiceChatAgent(userId, orgId);
     const session = await seedVoiceChatSession({ orgId, userId, agentId });
@@ -187,6 +203,35 @@ describe("GET /api/zero/voice-chat/:id/tasks (listTasksForCard)", () => {
       paramsFor(otherSession.id),
     );
     expect(response.status).toBe(404);
+  });
+
+  it("returns 404 when the session does not exist", async () => {
+    const response = await GET(
+      getRequest(`/${randomUUID()}/tasks`),
+      paramsFor(randomUUID()),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(body.error.code).toBe("NOT_FOUND");
+  });
+
+  it("returns 404 when the session belongs to a different org", async () => {
+    const { agentId } = await seedVoiceChatAgent(userId, orgId);
+    const sessionId = await insertTestVoiceChatSession({
+      orgId: `org_other_${randomUUID()}`,
+      userId,
+      agentId,
+    });
+
+    const response = await GET(
+      getRequest(`/${sessionId}/tasks`),
+      paramsFor(sessionId),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(body.error.code).toBe("NOT_FOUND");
   });
 
   it("returns an empty list when the session has no tasks", async () => {

--- a/turbo/apps/web/app/api/zero/voice-chat/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/voice-chat/__tests__/route.test.ts
@@ -2,7 +2,13 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 import { randomUUID } from "crypto";
 import { testContext } from "../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../src/__tests__/clerk-mock";
-import { postRequest, seedVoiceChatAgent, setupVoiceChatOrg } from "./_helpers";
+import { insertTestVoiceChatSession } from "../../../../../src/__tests__/db-test-seeders/voice-chat";
+import {
+  getRequest,
+  postRequest,
+  seedVoiceChatAgent,
+  setupVoiceChatOrg,
+} from "./_helpers";
 
 vi.mock("@vm0/core/feature-switch", async (importOriginal) => {
   const actual =
@@ -16,7 +22,7 @@ vi.mock("@vm0/core/feature-switch", async (importOriginal) => {
 const { isFeatureEnabled } = await import("@vm0/core/feature-switch");
 const mockIsFeatureEnabled = isFeatureEnabled as ReturnType<typeof vi.fn>;
 
-const { POST } = await import("../route");
+const { GET, POST } = await import("../route");
 
 const context = testContext();
 
@@ -77,5 +83,141 @@ describe("POST /api/zero/voice-chat (createSession)", () => {
     expect(body.session.summarySeq).toBe(0);
     expect(body.session.summaryVersion).toBe(0);
     expect(typeof body.session.createdAt).toBe("string");
+  });
+});
+
+describe("GET /api/zero/voice-chat (listSessions)", () => {
+  let orgId: string;
+  let userId: string;
+
+  beforeEach(async () => {
+    context.setupMocks();
+    const user = await context.setupUser();
+    userId = user.userId;
+    const org = await setupVoiceChatOrg(userId);
+    orgId = org.orgId;
+    mockIsFeatureEnabled.mockReturnValue(true);
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockClerk({ userId: null });
+
+    const response = await GET(getRequest(""));
+    const body = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("returns 401 when authenticated without an active org", async () => {
+    mockClerk({ userId, orgId: null });
+
+    const response = await GET(getRequest(""));
+    const body = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("returns 403 when the voice-chat feature flag is disabled", async () => {
+    mockIsFeatureEnabled.mockReturnValue(false);
+
+    const response = await GET(getRequest(""));
+    const body = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(body.error.code).toBe("FORBIDDEN");
+  });
+
+  it("returns an empty list when the user has no voice-chat sessions", async () => {
+    const response = await GET(getRequest(""));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({ sessions: [] });
+  });
+
+  it("returns sessions ordered by createdAt desc", async () => {
+    const { agentId } = await seedVoiceChatAgent(userId, orgId);
+    const olderId = await insertTestVoiceChatSession({
+      orgId,
+      userId,
+      agentId,
+      createdAt: new Date(Date.now() - 100_000),
+    });
+    const newerId = await insertTestVoiceChatSession({
+      orgId,
+      userId,
+      agentId,
+      createdAt: new Date(Date.now() - 10_000),
+    });
+
+    const response = await GET(getRequest(""));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.sessions).toHaveLength(2);
+    expect(body.sessions[0].id).toBe(newerId);
+    expect(body.sessions[1].id).toBe(olderId);
+  });
+
+  it("does not include sessions belonging to a different user in the same org", async () => {
+    const { agentId } = await seedVoiceChatAgent(userId, orgId);
+    const visibleId = await insertTestVoiceChatSession({
+      orgId,
+      userId,
+      agentId,
+    });
+    await insertTestVoiceChatSession({
+      orgId,
+      userId: `other-user-${randomUUID()}`,
+      agentId,
+    });
+
+    const response = await GET(getRequest(""));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.sessions).toHaveLength(1);
+    expect(body.sessions[0].id).toBe(visibleId);
+  });
+
+  it("does not include sessions belonging to a different org", async () => {
+    const { agentId } = await seedVoiceChatAgent(userId, orgId);
+    const visibleId = await insertTestVoiceChatSession({
+      orgId,
+      userId,
+      agentId,
+    });
+    await insertTestVoiceChatSession({
+      orgId: `org_other_${randomUUID()}`,
+      userId,
+      agentId,
+    });
+
+    const response = await GET(getRequest(""));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.sessions).toHaveLength(1);
+    expect(body.sessions[0].id).toBe(visibleId);
+  });
+
+  it("returns more than 50 matching sessions", async () => {
+    const { agentId } = await seedVoiceChatAgent(userId, orgId);
+    for (let index = 0; index < 51; index += 1) {
+      await insertTestVoiceChatSession({
+        orgId,
+        userId,
+        agentId,
+        createdAt: new Date(Date.now() - index * 1000),
+      });
+    }
+
+    const response = await GET(getRequest(""));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.sessions).toHaveLength(51);
   });
 });

--- a/turbo/apps/web/src/__tests__/db-test-seeders/voice-chat.ts
+++ b/turbo/apps/web/src/__tests__/db-test-seeders/voice-chat.ts
@@ -91,8 +91,9 @@ export async function simulateConcurrentVoiceChatSessionWrite(
 
 /**
  * Insert a voice-chat session directly.
- * @why-db-direct Cron tests need to construct impossible states (stuck
- * reasoner) that no public API would produce.
+ * @why-db-direct Route parity and cron tests need explicit row states
+ * (cross-org rows, bulk lists, stuck reasoner) that no public API would
+ * produce without exercising unrelated behavior.
  */
 export async function insertTestVoiceChatSession(overrides: {
   orgId: string;

--- a/turbo/apps/web/src/lib/zero/voice-chat/session-service.ts
+++ b/turbo/apps/web/src/lib/zero/voice-chat/session-service.ts
@@ -59,7 +59,6 @@ export async function getVoiceChatSession(
 export async function listVoiceChatSessions(params: {
   orgId: string;
   userId: string;
-  limit?: number;
 }): Promise<SessionRow[]> {
   const db = globalThis.services.db;
   return db
@@ -71,6 +70,5 @@ export async function listVoiceChatSessions(params: {
         eq(voiceChatSessions.userId, params.userId),
       ),
     )
-    .orderBy(desc(voiceChatSessions.createdAt))
-    .limit(params.limit ?? 50);
+    .orderBy(desc(voiceChatSessions.createdAt));
 }


### PR DESCRIPTION
Summary
- Add web route-level coverage for the zero voice-chat GET route family.
- Align web session listing with the API contract by removing the hidden 50-session cap.
- Cover auth, active-org, feature-flag, org isolation, ordering, and bulk-list behavior.

Validation
- pnpm -F web exec vitest app/api/zero/voice-chat/__tests__/route.test.ts app/api/zero/voice-chat/[id]/__tests__/route.test.ts app/api/zero/voice-chat/[id]/tasks/__tests__/route.test.ts
- pnpm -F api exec vitest src/signals/routes/__tests__/zero-voice-chat-list-sessions.test.ts src/signals/routes/__tests__/zero-voice-chat-get-session.test.ts src/signals/routes/__tests__/zero-voice-chat-list-tasks.test.ts
- pnpm format
- pnpm -F web lint
- pnpm -F web check-types
- pnpm knip --workspace web
- git diff --check

Fixes #12647