### PR TITLE
feat(vsock-host): add command operation router

### DIFF
--- a/crates/vsock-guest/src/command.rs
+++ b/crates/vsock-guest/src/command.rs
@@ -117,9 +117,9 @@ pub(crate) struct CommandWorkerRequest {
     command: String,
     env: Vec<(String, String)>,
     sudo: bool,
+    label: String,
     stdout: CommandOutputPolicy,
     stderr: CommandOutputPolicy,
-    label: String,
 }
 
 impl CommandWorkerRequest {
@@ -134,9 +134,9 @@ impl CommandWorkerRequest {
                 .map(|(key, value)| ((*key).to_owned(), (*value).to_owned()))
                 .collect(),
             sudo: decoded.sudo,
+            label: decoded.label.to_owned(),
             stdout: decoded.stdout,
             stderr: decoded.stderr,
-            label: decoded.label.to_owned(),
         }
     }
 }
@@ -833,9 +833,9 @@ mod tests {
             command: command.to_string(),
             env: Vec::new(),
             sudo: false,
+            label: "test".to_string(),
             stdout: CommandOutputPolicy::Capture { limit_bytes: 1024 },
             stderr: CommandOutputPolicy::Capture { limit_bytes: 1024 },
-            label: "test".to_string(),
         }
     }
 

--- a/crates/vsock-guest/tests/connection.rs
+++ b/crates/vsock-guest/tests/connection.rs
@@ -589,7 +589,7 @@ fn send_command_start_with_env(
     stderr: CommandOutputPolicy,
 ) {
     let payload =
-        vsock_proto::encode_command_start(timeout_ms, command, env, false, stdout, stderr, "test")
+        vsock_proto::encode_command_start(timeout_ms, command, env, false, "test", stdout, stderr)
             .unwrap();
     let msg = vsock_proto::encode(MSG_COMMAND_START, seq, &payload).unwrap();
     stream.write_all(&msg).unwrap();

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -99,9 +99,9 @@ pub struct CommandOperationRequest<'a> {
     pub command: &'a str,
     pub env: &'a [(&'a str, &'a str)],
     pub sudo: bool,
+    pub label: &'a str,
     pub stdout: CommandOutputPolicy,
     pub stderr: CommandOutputPolicy,
-    pub label: &'a str,
     /// Optional bounded host-side output event queue override.
     ///
     /// `None` uses the default queue capacity when either output policy
@@ -1294,13 +1294,13 @@ impl VsockHost {
                 command: request.command,
                 env: request.env,
                 sudo: request.sudo,
+                label: request.label,
                 stdout: CommandOutputPolicy::Capture {
                     limit_bytes: request.stdout_limit_bytes,
                 },
                 stderr: CommandOutputPolicy::Capture {
                     limit_bytes: request.stderr_limit_bytes,
                 },
-                label: request.label,
                 stream_queue_capacity: None,
             })
             .await?;
@@ -1326,9 +1326,9 @@ impl VsockHost {
             command: request.command,
             env: request.env,
             sudo: request.sudo,
+            label: request.label,
             stdout: request.stdout,
             stderr: request.stderr,
-            label: request.label,
             stream_queue_capacity: request.stream_queue_capacity,
         })
         .await
@@ -1735,9 +1735,9 @@ mod tests {
             command,
             env: &[],
             sudo: false,
+            label: "test-command",
             stdout: CommandOutputPolicy::Capture { limit_bytes: 1024 },
             stderr: CommandOutputPolicy::Capture { limit_bytes: 1024 },
-            label: "test-command",
             stream_queue_capacity: None,
         })
         .await
@@ -2028,13 +2028,13 @@ mod tests {
                 command: "stream",
                 env: &[],
                 sudo: false,
+                label: "default-receiver",
                 stdout: CommandOutputPolicy::Capture { limit_bytes: 1024 },
                 stderr: CommandOutputPolicy::CaptureAndStream {
                     capture_limit_bytes: 1024,
                     stream_limit_bytes: 1024,
                     chunk_limit_bytes: 16,
                 },
-                label: "default-receiver",
                 stream_queue_capacity: None,
             })
             .await
@@ -2078,9 +2078,9 @@ mod tests {
                 command: "capture",
                 env: &[],
                 sudo: false,
+                label: "unexpected-receiver",
                 stdout: CommandOutputPolicy::Capture { limit_bytes: 1024 },
                 stderr: CommandOutputPolicy::Discard,
-                label: "unexpected-receiver",
                 stream_queue_capacity: Some(1),
             })
             .await
@@ -2132,12 +2132,12 @@ mod tests {
                 command: "stream",
                 env: &[],
                 sudo: false,
+                label: "bad-policy",
                 stdout: CommandOutputPolicy::Stream {
                     limit_bytes: 1024,
                     chunk_limit_bytes: 0,
                 },
                 stderr: CommandOutputPolicy::Discard,
-                label: "bad-policy",
                 stream_queue_capacity: Some(1),
             })
             .await
@@ -2162,9 +2162,9 @@ mod tests {
                 command: "sleep 60",
                 env: &[],
                 sudo: false,
+                label: "zero-timeout",
                 stdout: CommandOutputPolicy::Capture { limit_bytes: 1024 },
                 stderr: CommandOutputPolicy::Capture { limit_bytes: 1024 },
-                label: "zero-timeout",
                 stream_queue_capacity: None,
             })
             .await
@@ -2488,9 +2488,9 @@ mod tests {
                 command: "echo ok",
                 env: &[],
                 sudo: false,
+                label: "closed",
                 stdout: CommandOutputPolicy::Capture { limit_bytes: 1024 },
                 stderr: CommandOutputPolicy::Capture { limit_bytes: 1024 },
-                label: "closed",
                 stream_queue_capacity: None,
             })
             .await

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -644,6 +644,26 @@ fn dispatch_command_result(shared: &Arc<Shared>, msg: &RawMessage) -> io::Result
     Ok(())
 }
 
+fn dispatch_command_error(shared: &Arc<Shared>, msg: &RawMessage) -> bool {
+    let operation = {
+        let mut guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
+        match &mut *guard {
+            ConnectionState::Connected { operations, .. } => operations.remove(&msg.seq),
+            ConnectionState::Closed { .. } => None,
+        }
+    };
+
+    if let Some(Operation::Command(operation)) = operation {
+        let err = vsock_proto::decode_error(&msg.payload)
+            .map(|message| io::Error::other(message.to_string()))
+            .unwrap_or_else(command_protocol_error);
+        let _ = operation.result_tx.send(Err(err));
+        return true;
+    }
+
+    false
+}
+
 /// Host-side vsock endpoint.
 ///
 /// Maintains a persistent connection to the guest agent and provides
@@ -713,6 +733,11 @@ async fn reader_loop(
                     shared.poison_connection();
                     return;
                 }
+            } else if msg.msg_type == MSG_ERROR && dispatch_command_error(&shared, &msg) {
+                // Command-operation errors are delivered through the operation
+                // result channel. Legacy request errors fall through to the
+                // pending-request dispatch below.
+                continue;
             } else if msg.msg_type == MSG_STDOUT_CHUNK && msg.seq == 0 {
                 if let Ok((pid, data)) = vsock_proto::decode_stdout_chunk(&msg.payload) {
                     let sender = {
@@ -1847,6 +1872,41 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn command_result_preserves_non_default_metadata() {
+        let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+        let handle = start_capture_operation(&host, "metadata").await;
+        let msg = read_guest_message(&mut guest, &mut decoder).await;
+        assert_eq!(msg.msg_type, MSG_COMMAND_START);
+
+        let payload = vsock_proto::encode_command_result(
+            CommandTermination::WaitFailed,
+            345,
+            CommandCapturedOutput::Discarded,
+            CommandCapturedOutput::Captured {
+                bytes: b"stderr",
+                truncated: true,
+            },
+            "wait failed",
+        )
+        .unwrap();
+        let frame = vsock_proto::encode(MSG_COMMAND_RESULT, msg.seq, &payload).unwrap();
+        guest.write_all(&frame).await.unwrap();
+
+        let result = handle.wait(Duration::from_secs(5)).await.unwrap();
+        assert_eq!(result.termination, CommandTermination::WaitFailed);
+        assert_eq!(result.duration_ms, 345);
+        assert_eq!(result.stdout, CommandOwnedCapturedOutput::Discarded);
+        assert_eq!(
+            result.stderr,
+            CommandOwnedCapturedOutput::Captured {
+                bytes: b"stderr".to_vec(),
+                truncated: true,
+            }
+        );
+        assert_eq!(result.diagnostic, "wait failed");
+    }
+
+    #[tokio::test]
     async fn command_stream_rejects_zero_capacity_without_sending_frame() {
         let (host, mut guest, mut decoder) = setup_host_and_guest().await;
         let host = Arc::new(host);
@@ -2181,6 +2241,26 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn command_error_response_completes_operation_without_timeout() {
+        let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+        let host = Arc::new(host);
+        let handle = start_capture_operation(&host, "error-response").await;
+        let msg = read_guest_message(&mut guest, &mut decoder).await;
+        assert_eq!(msg.msg_type, MSG_COMMAND_START);
+
+        let payload = vsock_proto::encode_error("command operation already active");
+        let frame = vsock_proto::encode(MSG_ERROR, msg.seq, &payload).unwrap();
+        guest.write_all(&frame).await.unwrap();
+
+        let err = handle.wait(Duration::from_secs(5)).await.unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::Other);
+        assert_eq!(err.to_string(), "command operation already active");
+        assert_eq!(operation_count(&host), 0);
+
+        assert_connection_accepts_legacy_exec(&host, &mut guest, &mut decoder).await;
+    }
+
+    #[tokio::test]
     async fn command_connection_close_wakes_result_and_stream() {
         let (host, mut guest, mut decoder) = setup_host_and_guest().await;
         let mut handle = host
@@ -2339,6 +2419,44 @@ mod tests {
         guest.write_all(&response).await.unwrap();
         let exec_result = exec_task.await.unwrap().unwrap();
         assert_eq!(exec_result.stdout, b"ok");
+    }
+
+    #[tokio::test]
+    async fn duplicate_command_result_after_completion_is_ignored() {
+        let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+        let host = Arc::new(host);
+        let handle = start_capture_operation(&host, "duplicate-result").await;
+        let msg = read_guest_message(&mut guest, &mut decoder).await;
+        assert_eq!(msg.msg_type, MSG_COMMAND_START);
+
+        send_command_result(
+            &mut guest,
+            msg.seq,
+            CommandTermination::Exited { exit_code: 0 },
+            b"first",
+            b"",
+        )
+        .await;
+        let result = handle.wait(Duration::from_secs(5)).await.unwrap();
+        assert_eq!(
+            result.stdout,
+            CommandOwnedCapturedOutput::Captured {
+                bytes: b"first".to_vec(),
+                truncated: false,
+            }
+        );
+        assert_eq!(operation_count(&host), 0);
+
+        send_command_result(
+            &mut guest,
+            msg.seq,
+            CommandTermination::Exited { exit_code: 1 },
+            b"duplicate",
+            b"",
+        )
+        .await;
+
+        assert_connection_accepts_legacy_exec(&host, &mut guest, &mut decoder).await;
     }
 
     #[tokio::test]

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -139,9 +139,6 @@ struct CommandOperation {
     result_tx: oneshot::Sender<io::Result<CommandOperationResult>>,
     stream_tx: Option<mpsc::Sender<CommandOutputEvent>>,
     stream_overflowed: bool,
-    _stdout_policy: CommandOutputPolicy,
-    _stderr_policy: CommandOutputPolicy,
-    _label: String,
 }
 
 enum Operation {
@@ -1227,9 +1224,6 @@ impl VsockHost {
             result_tx,
             stream_tx,
             stream_overflowed: false,
-            _stdout_policy: request.stdout,
-            _stderr_policy: request.stderr,
-            _label: request.label.to_string(),
         };
 
         {

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -2044,7 +2044,7 @@ mod tests {
         assert_eq!(msg.msg_type, MSG_COMMAND_START);
         assert_eq!(operation_count(&host), 1);
 
-        let err = handle.wait(Duration::from_millis(20)).await.unwrap_err();
+        let err = handle.wait(Duration::ZERO).await.unwrap_err();
         assert_eq!(err.kind(), io::ErrorKind::TimedOut);
         assert_eq!(operation_count(&host), 0);
         assert!(is_connected(&host));
@@ -2277,8 +2277,7 @@ mod tests {
         let start = read_guest_message(&mut guest, &mut decoder).await;
         assert_eq!(start.msg_type, MSG_COMMAND_START);
 
-        let cancel_task =
-            tokio::spawn(async move { handle.cancel_and_wait(Duration::from_millis(20)).await });
+        let cancel_task = tokio::spawn(async move { handle.cancel_and_wait(Duration::ZERO).await });
         let cancel = read_guest_message(&mut guest, &mut decoder).await;
         assert_eq!(cancel.msg_type, MSG_COMMAND_CANCEL);
         assert_eq!(cancel.seq, start.seq);

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -658,6 +658,12 @@ pub struct VsockHost {
 
 impl Drop for VsockHost {
     fn drop(&mut self) {
+        // Drop registration state synchronously. The shutdown below normally
+        // lets `reader_loop` observe EOF and call `close()`, but aborting the
+        // reader task can win that race. Closing here makes active command
+        // handles and stream receivers release immediately when the host is
+        // dropped.
+        self.shared.close();
         // Signal EOF on the socket so the reader_loop's `read()` and the
         // remote peer's blocking `read()` return immediately. Without this,
         // the split stream halves keep the fd alive until the reader task is
@@ -2069,6 +2075,40 @@ mod tests {
 
         drop(guest);
         let err = handle.wait(Duration::from_secs(5)).await.unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::ConnectionReset);
+        assert!(rx.recv().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn host_drop_closes_active_command_result_and_stream() {
+        let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+        let mut handle = host
+            .command_stream(CommandStreamRequest {
+                timeout_ms: 5000,
+                command: "stream",
+                env: &[],
+                sudo: false,
+                label: "host-drop",
+                stdout: CommandOutputPolicy::Stream {
+                    limit_bytes: 1024,
+                    chunk_limit_bytes: 16,
+                },
+                stderr: CommandOutputPolicy::Discard,
+                stream_capacity: 1,
+            })
+            .await
+            .unwrap();
+        let mut rx = handle.take_stream_receiver().unwrap();
+        let msg = read_guest_message(&mut guest, &mut decoder).await;
+        assert_eq!(msg.msg_type, MSG_COMMAND_START);
+
+        drop(host);
+
+        let err =
+            tokio::time::timeout(Duration::from_secs(5), handle.wait(Duration::from_secs(60)))
+                .await
+                .unwrap()
+                .unwrap_err();
         assert_eq!(err.kind(), io::ErrorKind::ConnectionReset);
         assert!(rx.recv().await.is_none());
     }

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -41,6 +41,7 @@ use vsock_proto::{
 
 const READ_BUF_SIZE: usize = 64 * 1024;
 const DEFAULT_COMMAND_CAPTURE_LIMIT_BYTES: u32 = 1024 * 1024;
+const DEFAULT_COMMAND_STREAM_CAPACITY: usize = 32;
 const MAX_COMMAND_STREAM_CAPACITY: usize = 1024;
 const COMMAND_FRAME_WRITE_NOT_STARTED: u8 = 0;
 const COMMAND_FRAME_WRITE_STARTED: u8 = 1;
@@ -101,9 +102,11 @@ pub struct CommandOperationRequest<'a> {
     pub stdout: CommandOutputPolicy,
     pub stderr: CommandOutputPolicy,
     pub label: &'a str,
-    /// Bounded host-side output event queue. Must be present iff either output
-    /// policy streams.
-    pub stream_capacity: Option<usize>,
+    /// Optional bounded host-side output event queue override.
+    ///
+    /// `None` uses the default queue capacity when either output policy
+    /// streams, and creates no queue when neither output policy streams.
+    pub stream_queue_capacity: Option<usize>,
 }
 
 /// Request parameters for a capture-only command operation helper.
@@ -127,7 +130,9 @@ pub struct CommandStreamRequest<'a> {
     pub label: &'a str,
     pub stdout: CommandOutputPolicy,
     pub stderr: CommandOutputPolicy,
-    pub stream_capacity: usize,
+    /// Optional host-side output event queue capacity override. `None` uses the
+    /// default queue capacity.
+    pub stream_queue_capacity: Option<usize>,
 }
 
 struct CommandOperation {
@@ -1164,34 +1169,39 @@ impl VsockHost {
                 "command operation requires a positive timeout; use spawn_watch for unbounded commands",
             ));
         }
-        if matches!(request.stream_capacity, Some(0)) {
+        if matches!(request.stream_queue_capacity, Some(0)) {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
-                "command stream capacity must be positive",
+                "command stream queue capacity must be positive",
             ));
         }
-        if let Some(capacity) = request.stream_capacity
+        if let Some(capacity) = request.stream_queue_capacity
             && capacity > MAX_COMMAND_STREAM_CAPACITY
         {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
-                format!("command stream capacity must be at most {MAX_COMMAND_STREAM_CAPACITY}"),
+                format!(
+                    "command stream queue capacity must be at most {MAX_COMMAND_STREAM_CAPACITY}"
+                ),
             ));
         }
         let streams_output = command_output_policy_streams(request.stdout)
             || command_output_policy_streams(request.stderr);
-        if streams_output && request.stream_capacity.is_none() {
+        if !streams_output && request.stream_queue_capacity.is_some() {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
-                "streaming output policy requires command stream capacity",
+                "command stream queue capacity requires a streaming output policy",
             ));
         }
-        if !streams_output && request.stream_capacity.is_some() {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidInput,
-                "command stream capacity requires a streaming output policy",
-            ));
-        }
+        let stream_queue_capacity = if streams_output {
+            Some(
+                request
+                    .stream_queue_capacity
+                    .unwrap_or(DEFAULT_COMMAND_STREAM_CAPACITY),
+            )
+        } else {
+            None
+        };
 
         let payload = vsock_proto::encode_command_start(
             request.timeout_ms,
@@ -1204,7 +1214,7 @@ impl VsockHost {
         )
         .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e.to_string()))?;
 
-        let (stream_tx, stream_rx) = match request.stream_capacity {
+        let (stream_tx, stream_rx) = match stream_queue_capacity {
             Some(capacity) => {
                 let (tx, rx) = mpsc::channel(capacity);
                 (Some(tx), Some(rx))
@@ -1291,7 +1301,7 @@ impl VsockHost {
                     limit_bytes: request.stderr_limit_bytes,
                 },
                 label: request.label,
-                stream_capacity: None,
+                stream_queue_capacity: None,
             })
             .await?;
         handle.wait(request.wait_timeout).await
@@ -1302,6 +1312,15 @@ impl VsockHost {
         &self,
         request: CommandStreamRequest<'_>,
     ) -> io::Result<CommandOperationHandle> {
+        if !command_output_policy_streams(request.stdout)
+            && !command_output_policy_streams(request.stderr)
+        {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "command_stream requires a streaming output policy",
+            ));
+        }
+
         self.start_command_operation(CommandOperationRequest {
             timeout_ms: request.timeout_ms,
             command: request.command,
@@ -1310,7 +1329,7 @@ impl VsockHost {
             stdout: request.stdout,
             stderr: request.stderr,
             label: request.label,
-            stream_capacity: Some(request.stream_capacity),
+            stream_queue_capacity: request.stream_queue_capacity,
         })
         .await
     }
@@ -1719,7 +1738,7 @@ mod tests {
             stdout: CommandOutputPolicy::Capture { limit_bytes: 1024 },
             stderr: CommandOutputPolicy::Capture { limit_bytes: 1024 },
             label: "test-command",
-            stream_capacity: None,
+            stream_queue_capacity: None,
         })
         .await
         .unwrap()
@@ -1955,7 +1974,7 @@ mod tests {
                     chunk_limit_bytes: 16,
                 },
                 stderr: CommandOutputPolicy::Discard,
-                stream_capacity: 0,
+                stream_queue_capacity: Some(0),
             })
             .await
         {
@@ -1985,7 +2004,7 @@ mod tests {
                     chunk_limit_bytes: 16,
                 },
                 stderr: CommandOutputPolicy::Discard,
-                stream_capacity: MAX_COMMAND_STREAM_CAPACITY + 1,
+                stream_queue_capacity: Some(MAX_COMMAND_STREAM_CAPACITY + 1),
             })
             .await
         {
@@ -1999,11 +2018,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn command_start_rejects_stream_policy_without_receiver() {
+    async fn command_start_stream_policy_uses_default_receiver() {
         let (host, mut guest, mut decoder) = setup_host_and_guest().await;
         let host = Arc::new(host);
 
-        let err = match host
+        let mut handle = host
             .start_command_operation(CommandOperationRequest {
                 timeout_ms: 5000,
                 command: "stream",
@@ -2015,18 +2034,37 @@ mod tests {
                     stream_limit_bytes: 1024,
                     chunk_limit_bytes: 16,
                 },
-                label: "missing-receiver",
-                stream_capacity: None,
+                label: "default-receiver",
+                stream_queue_capacity: None,
             })
             .await
-        {
-            Ok(_) => panic!("streaming output policy without receiver should be rejected"),
-            Err(err) => err,
-        };
-        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
-        assert_eq!(operation_count(&host), 0);
+            .unwrap();
+        let mut rx = handle.take_stream_receiver().unwrap();
 
-        assert_connection_accepts_legacy_exec(&host, &mut guest, &mut decoder).await;
+        let msg = read_guest_message(&mut guest, &mut decoder).await;
+        assert_eq!(msg.msg_type, MSG_COMMAND_START);
+        send_command_output(
+            &mut guest,
+            msg.seq,
+            1,
+            CommandOutputStream::Stderr,
+            b"default-queued",
+            false,
+        )
+        .await;
+        let event = rx.recv().await.unwrap();
+        assert_eq!(event.stream, CommandOutputStream::Stderr);
+        assert_eq!(event.chunk, b"default-queued");
+        send_command_result(
+            &mut guest,
+            msg.seq,
+            CommandTermination::Exited { exit_code: 0 },
+            b"",
+            b"",
+        )
+        .await;
+        let result = handle.wait(Duration::from_secs(5)).await.unwrap();
+        assert!(!result.stream_overflowed);
     }
 
     #[tokio::test]
@@ -2043,11 +2081,38 @@ mod tests {
                 stdout: CommandOutputPolicy::Capture { limit_bytes: 1024 },
                 stderr: CommandOutputPolicy::Discard,
                 label: "unexpected-receiver",
-                stream_capacity: Some(1),
+                stream_queue_capacity: Some(1),
             })
             .await
         {
             Ok(_) => panic!("receiver without streaming output policy should be rejected"),
+            Err(err) => err,
+        };
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+        assert_eq!(operation_count(&host), 0);
+
+        assert_connection_accepts_legacy_exec(&host, &mut guest, &mut decoder).await;
+    }
+
+    #[tokio::test]
+    async fn command_stream_rejects_non_streaming_policy() {
+        let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+        let host = Arc::new(host);
+
+        let err = match host
+            .command_stream(CommandStreamRequest {
+                timeout_ms: 5000,
+                command: "capture",
+                env: &[],
+                sudo: false,
+                label: "non-streaming-helper",
+                stdout: CommandOutputPolicy::Capture { limit_bytes: 1024 },
+                stderr: CommandOutputPolicy::Discard,
+                stream_queue_capacity: None,
+            })
+            .await
+        {
+            Ok(_) => panic!("command_stream should reject non-streaming output policies"),
             Err(err) => err,
         };
         assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
@@ -2073,7 +2138,7 @@ mod tests {
                 },
                 stderr: CommandOutputPolicy::Discard,
                 label: "bad-policy",
-                stream_capacity: Some(1),
+                stream_queue_capacity: Some(1),
             })
             .await
         {
@@ -2100,7 +2165,7 @@ mod tests {
                 stdout: CommandOutputPolicy::Capture { limit_bytes: 1024 },
                 stderr: CommandOutputPolicy::Capture { limit_bytes: 1024 },
                 label: "zero-timeout",
-                stream_capacity: None,
+                stream_queue_capacity: None,
             })
             .await
         {
@@ -2192,7 +2257,7 @@ mod tests {
                     limit_bytes: 1024,
                     chunk_limit_bytes: 16,
                 },
-                stream_capacity: 4,
+                stream_queue_capacity: Some(4),
             })
             .await
             .unwrap();
@@ -2259,7 +2324,7 @@ mod tests {
                     chunk_limit_bytes: 16,
                 },
                 stderr: CommandOutputPolicy::Discard,
-                stream_capacity: 1,
+                stream_queue_capacity: Some(1),
             })
             .await
             .unwrap();
@@ -2317,7 +2382,7 @@ mod tests {
                     chunk_limit_bytes: 16,
                 },
                 stderr: CommandOutputPolicy::Discard,
-                stream_capacity: 1,
+                stream_queue_capacity: Some(1),
             })
             .await
             .unwrap();
@@ -2395,7 +2460,7 @@ mod tests {
                     chunk_limit_bytes: 16,
                 },
                 stderr: CommandOutputPolicy::Discard,
-                stream_capacity: 1,
+                stream_queue_capacity: Some(1),
             })
             .await
             .unwrap();
@@ -2426,7 +2491,7 @@ mod tests {
                 stdout: CommandOutputPolicy::Capture { limit_bytes: 1024 },
                 stderr: CommandOutputPolicy::Capture { limit_bytes: 1024 },
                 label: "closed",
-                stream_capacity: None,
+                stream_queue_capacity: None,
             })
             .await
         {
@@ -2452,7 +2517,7 @@ mod tests {
                     chunk_limit_bytes: 16,
                 },
                 stderr: CommandOutputPolicy::Discard,
-                stream_capacity: 1,
+                stream_queue_capacity: Some(1),
             })
             .await
             .unwrap();

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -1123,6 +1123,12 @@ impl VsockHost {
         &self,
         request: CommandOperationRequest<'_>,
     ) -> io::Result<CommandOperationHandle> {
+        if request.timeout_ms == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "command operation requires a positive timeout; use spawn_watch for unbounded commands",
+            ));
+        }
         if matches!(request.stream_capacity, Some(0)) {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
@@ -1892,6 +1898,33 @@ mod tests {
             .await
         {
             Ok(_) => panic!("invalid command output policy should be rejected"),
+            Err(err) => err,
+        };
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+        assert_eq!(operation_count(&host), 0);
+
+        assert_connection_accepts_legacy_exec(&host, &mut guest, &mut decoder).await;
+    }
+
+    #[tokio::test]
+    async fn command_start_rejects_zero_timeout_without_sending_frame() {
+        let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+        let host = Arc::new(host);
+
+        let err = match host
+            .start_command_operation(CommandOperationRequest {
+                timeout_ms: 0,
+                command: "sleep 60",
+                env: &[],
+                sudo: false,
+                stdout: CommandOutputPolicy::Capture { limit_bytes: 1024 },
+                stderr: CommandOutputPolicy::Capture { limit_bytes: 1024 },
+                label: "zero-timeout",
+                stream_capacity: None,
+            })
+            .await
+        {
+            Ok(_) => panic!("zero timeout command operation should be rejected"),
             Err(err) => err,
         };
         assert_eq!(err.kind(), io::ErrorKind::InvalidInput);

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -142,6 +142,8 @@ pub struct CommandStreamRequest<'a> {
 struct CommandOperation {
     result_tx: oneshot::Sender<io::Result<CommandOperationResult>>,
     stream_tx: Option<mpsc::Sender<CommandOutputEvent>>,
+    stdout_capture: CommandCaptureState,
+    stderr_capture: CommandCaptureState,
     stdout_stream: Option<CommandStreamState>,
     stderr_stream: Option<CommandStreamState>,
     stream_overflowed: bool,
@@ -149,6 +151,11 @@ struct CommandOperation {
 
 enum Operation {
     Command(CommandOperation),
+}
+
+enum CommandCaptureState {
+    Discard,
+    Capture { limit_bytes: usize },
 }
 
 struct CommandStreamState {
@@ -586,6 +593,21 @@ fn command_output_policy_streams(policy: CommandOutputPolicy) -> bool {
     )
 }
 
+fn command_capture_state(policy: CommandOutputPolicy) -> CommandCaptureState {
+    match policy {
+        CommandOutputPolicy::Discard | CommandOutputPolicy::Stream { .. } => {
+            CommandCaptureState::Discard
+        }
+        CommandOutputPolicy::Capture { limit_bytes }
+        | CommandOutputPolicy::CaptureAndStream {
+            capture_limit_bytes: limit_bytes,
+            ..
+        } => CommandCaptureState::Capture {
+            limit_bytes: limit_bytes as usize,
+        },
+    }
+}
+
 fn command_stream_state(policy: CommandOutputPolicy) -> Option<CommandStreamState> {
     match policy {
         CommandOutputPolicy::Stream {
@@ -643,6 +665,45 @@ fn validate_command_output(
         stream.truncated = true;
     }
     Ok(())
+}
+
+fn validate_command_result_output(
+    name: &str,
+    state: &CommandCaptureState,
+    output: CommandCapturedOutput<'_>,
+) -> io::Result<()> {
+    match (state, output) {
+        (CommandCaptureState::Discard, CommandCapturedOutput::Discarded) => Ok(()),
+        (CommandCaptureState::Discard, CommandCapturedOutput::Captured { .. }) => {
+            Err(command_protocol_error(format!(
+                "command result {name} captured output for non-capturing policy",
+            )))
+        }
+        (
+            CommandCaptureState::Capture { limit_bytes },
+            CommandCapturedOutput::Captured { bytes, .. },
+        ) if bytes.len() <= *limit_bytes => Ok(()),
+        (
+            CommandCaptureState::Capture { limit_bytes },
+            CommandCapturedOutput::Captured { bytes, .. },
+        ) => Err(command_protocol_error(format!(
+            "command result {name} exceeds requested capture limit: {} > {limit_bytes}",
+            bytes.len()
+        ))),
+        (CommandCaptureState::Capture { .. }, CommandCapturedOutput::Discarded) => {
+            Err(command_protocol_error(format!(
+                "command result {name} discarded output for capturing policy",
+            )))
+        }
+    }
+}
+
+fn validate_command_result(
+    operation: &CommandOperation,
+    result: &vsock_proto::DecodedCommandResult<'_>,
+) -> io::Result<()> {
+    validate_command_result_output("stdout", &operation.stdout_capture, result.stdout)?;
+    validate_command_result_output("stderr", &operation.stderr_capture, result.stderr)
 }
 
 fn owned_captured_output(output: CommandCapturedOutput<'_>) -> CommandOwnedCapturedOutput {
@@ -720,6 +781,7 @@ fn dispatch_command_result(shared: &Arc<Shared>, msg: &RawMessage) -> io::Result
     };
 
     if let Some(Operation::Command(operation)) = operation {
+        validate_command_result(&operation, &decoded)?;
         let CommandOperation {
             result_tx,
             stream_overflowed,
@@ -1299,6 +1361,8 @@ impl VsockHost {
         let operation = CommandOperation {
             result_tx,
             stream_tx,
+            stdout_capture: command_capture_state(request.stdout),
+            stderr_capture: command_capture_state(request.stderr),
             stdout_stream: command_stream_state(request.stdout),
             stderr_stream: command_stream_state(request.stderr),
             stream_overflowed: false,
@@ -1849,6 +1913,27 @@ mod tests {
         stream.write_all(&frame).await.unwrap();
     }
 
+    async fn send_raw_command_result(stream: &mut UnixStream, seq: u32, payload: Vec<u8>) {
+        let frame = vsock_proto::encode(MSG_COMMAND_RESULT, seq, &payload).unwrap();
+        stream.write_all(&frame).await.unwrap();
+    }
+
+    async fn send_discarded_command_result(
+        stream: &mut UnixStream,
+        seq: u32,
+        termination: CommandTermination,
+    ) {
+        let payload = vsock_proto::encode_command_result(
+            termination,
+            12,
+            CommandCapturedOutput::Discarded,
+            CommandCapturedOutput::Discarded,
+            "",
+        )
+        .unwrap();
+        send_raw_command_result(stream, seq, payload).await;
+    }
+
     async fn send_command_output(
         stream: &mut UnixStream,
         seq: u32,
@@ -1997,7 +2082,19 @@ mod tests {
     #[tokio::test]
     async fn command_result_preserves_non_default_metadata() {
         let (host, mut guest, mut decoder) = setup_host_and_guest().await;
-        let handle = start_capture_operation(&host, "metadata").await;
+        let handle = host
+            .start_command_operation(CommandOperationRequest {
+                timeout_ms: 5000,
+                command: "metadata",
+                env: &[],
+                sudo: false,
+                label: "metadata",
+                stdout: CommandOutputPolicy::Discard,
+                stderr: CommandOutputPolicy::Capture { limit_bytes: 1024 },
+                stream_queue_capacity: None,
+            })
+            .await
+            .unwrap();
         let msg = read_guest_message(&mut guest, &mut decoder).await;
         assert_eq!(msg.msg_type, MSG_COMMAND_START);
 
@@ -2027,6 +2124,169 @@ mod tests {
             }
         );
         assert_eq!(result.diagnostic, "wait failed");
+    }
+
+    #[tokio::test]
+    async fn command_result_capture_for_discard_policy_poisons_connection() {
+        let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+        let handle = host
+            .start_command_operation(CommandOperationRequest {
+                timeout_ms: 5000,
+                command: "discard",
+                env: &[],
+                sudo: false,
+                label: "discard-result",
+                stdout: CommandOutputPolicy::Discard,
+                stderr: CommandOutputPolicy::Discard,
+                stream_queue_capacity: None,
+            })
+            .await
+            .unwrap();
+
+        let msg = read_guest_message(&mut guest, &mut decoder).await;
+        let payload = vsock_proto::encode_command_result(
+            CommandTermination::Exited { exit_code: 0 },
+            1,
+            CommandCapturedOutput::Captured {
+                bytes: b"unexpected",
+                truncated: false,
+            },
+            CommandCapturedOutput::Discarded,
+            "",
+        )
+        .unwrap();
+        send_raw_command_result(&mut guest, msg.seq, payload).await;
+
+        host.wait_until_closed(Duration::from_secs(5))
+            .await
+            .unwrap();
+        let err = handle.wait(Duration::from_secs(5)).await.unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::ConnectionReset);
+    }
+
+    #[tokio::test]
+    async fn command_result_over_capture_limit_poisons_connection() {
+        let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+        let handle = host
+            .start_command_operation(CommandOperationRequest {
+                timeout_ms: 5000,
+                command: "capture-limit",
+                env: &[],
+                sudo: false,
+                label: "capture-limit",
+                stdout: CommandOutputPolicy::Capture { limit_bytes: 4 },
+                stderr: CommandOutputPolicy::Discard,
+                stream_queue_capacity: None,
+            })
+            .await
+            .unwrap();
+
+        let msg = read_guest_message(&mut guest, &mut decoder).await;
+        let payload = vsock_proto::encode_command_result(
+            CommandTermination::Exited { exit_code: 0 },
+            1,
+            CommandCapturedOutput::Captured {
+                bytes: b"abcde",
+                truncated: true,
+            },
+            CommandCapturedOutput::Discarded,
+            "",
+        )
+        .unwrap();
+        send_raw_command_result(&mut guest, msg.seq, payload).await;
+
+        host.wait_until_closed(Duration::from_secs(5))
+            .await
+            .unwrap();
+        let err = handle.wait(Duration::from_secs(5)).await.unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::ConnectionReset);
+    }
+
+    #[tokio::test]
+    async fn command_result_discard_for_capture_policy_poisons_connection() {
+        let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+        let handle = host
+            .start_command_operation(CommandOperationRequest {
+                timeout_ms: 5000,
+                command: "missing-capture",
+                env: &[],
+                sudo: false,
+                label: "missing-capture",
+                stdout: CommandOutputPolicy::Capture { limit_bytes: 4 },
+                stderr: CommandOutputPolicy::Discard,
+                stream_queue_capacity: None,
+            })
+            .await
+            .unwrap();
+
+        let msg = read_guest_message(&mut guest, &mut decoder).await;
+        let payload = vsock_proto::encode_command_result(
+            CommandTermination::Exited { exit_code: 0 },
+            1,
+            CommandCapturedOutput::Discarded,
+            CommandCapturedOutput::Discarded,
+            "",
+        )
+        .unwrap();
+        send_raw_command_result(&mut guest, msg.seq, payload).await;
+
+        host.wait_until_closed(Duration::from_secs(5))
+            .await
+            .unwrap();
+        let err = handle.wait(Duration::from_secs(5)).await.unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::ConnectionReset);
+    }
+
+    #[tokio::test]
+    async fn command_result_zero_capture_limit_accepts_empty_capture() {
+        let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+        let handle = host
+            .start_command_operation(CommandOperationRequest {
+                timeout_ms: 5000,
+                command: "zero-capture",
+                env: &[],
+                sudo: false,
+                label: "zero-capture",
+                stdout: CommandOutputPolicy::Capture { limit_bytes: 0 },
+                stderr: CommandOutputPolicy::Capture { limit_bytes: 0 },
+                stream_queue_capacity: None,
+            })
+            .await
+            .unwrap();
+
+        let msg = read_guest_message(&mut guest, &mut decoder).await;
+        let payload = vsock_proto::encode_command_result(
+            CommandTermination::Exited { exit_code: 0 },
+            1,
+            CommandCapturedOutput::Captured {
+                bytes: b"",
+                truncated: true,
+            },
+            CommandCapturedOutput::Captured {
+                bytes: b"",
+                truncated: false,
+            },
+            "",
+        )
+        .unwrap();
+        send_raw_command_result(&mut guest, msg.seq, payload).await;
+
+        let result = handle.wait(Duration::from_secs(5)).await.unwrap();
+        assert_eq!(
+            result.stdout,
+            CommandOwnedCapturedOutput::Captured {
+                bytes: Vec::new(),
+                truncated: true,
+            }
+        );
+        assert_eq!(
+            result.stderr,
+            CommandOwnedCapturedOutput::Captured {
+                bytes: Vec::new(),
+                truncated: false,
+            }
+        );
+        assert!(is_connected(&host));
     }
 
     #[tokio::test]
@@ -2368,12 +2628,10 @@ mod tests {
         assert_eq!(err.chunk, b"err");
         assert!(err.truncated);
 
-        send_command_result(
+        send_discarded_command_result(
             &mut guest,
             msg.seq,
             CommandTermination::Exited { exit_code: 0 },
-            b"",
-            b"",
         )
         .await;
         let result = handle.wait(Duration::from_secs(5)).await.unwrap();
@@ -2421,12 +2679,10 @@ mod tests {
             false,
         )
         .await;
-        send_command_result(
+        send_discarded_command_result(
             &mut guest,
             msg.seq,
             CommandTermination::Exited { exit_code: 0 },
-            b"",
-            b"",
         )
         .await;
 
@@ -2640,12 +2896,10 @@ mod tests {
             false,
         )
         .await;
-        send_command_result(
+        send_discarded_command_result(
             &mut guest,
             msg.seq,
             CommandTermination::Exited { exit_code: 0 },
-            b"",
-            b"",
         )
         .await;
 

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -41,6 +41,7 @@ use vsock_proto::{
 
 const READ_BUF_SIZE: usize = 64 * 1024;
 const DEFAULT_COMMAND_CAPTURE_LIMIT_BYTES: u32 = 1024 * 1024;
+const MAX_COMMAND_STREAM_CAPACITY: usize = 1024;
 const COMMAND_FRAME_WRITE_NOT_STARTED: u8 = 0;
 const COMMAND_FRAME_WRITE_STARTED: u8 = 1;
 const COMMAND_FRAME_WRITE_COMPLETED: u8 = 2;
@@ -100,6 +101,8 @@ pub struct CommandOperationRequest<'a> {
     pub stdout: CommandOutputPolicy,
     pub stderr: CommandOutputPolicy,
     pub label: &'a str,
+    /// Bounded host-side output event queue. Must be present iff either output
+    /// policy streams.
     pub stream_capacity: Option<usize>,
 }
 
@@ -559,6 +562,13 @@ impl Shared {
 
 fn command_protocol_error(error: impl ToString) -> io::Error {
     io::Error::new(io::ErrorKind::InvalidData, error.to_string())
+}
+
+fn command_output_policy_streams(policy: CommandOutputPolicy) -> bool {
+    matches!(
+        policy,
+        CommandOutputPolicy::Stream { .. } | CommandOutputPolicy::CaptureAndStream { .. }
+    )
 }
 
 fn owned_captured_output(output: CommandCapturedOutput<'_>) -> CommandOwnedCapturedOutput {
@@ -1158,6 +1168,28 @@ impl VsockHost {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
                 "command stream capacity must be positive",
+            ));
+        }
+        if let Some(capacity) = request.stream_capacity
+            && capacity > MAX_COMMAND_STREAM_CAPACITY
+        {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("command stream capacity must be at most {MAX_COMMAND_STREAM_CAPACITY}"),
+            ));
+        }
+        let streams_output = command_output_policy_streams(request.stdout)
+            || command_output_policy_streams(request.stderr);
+        if streams_output && request.stream_capacity.is_none() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "streaming output policy requires command stream capacity",
+            ));
+        }
+        if !streams_output && request.stream_capacity.is_some() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "command stream capacity requires a streaming output policy",
             ));
         }
 
@@ -1928,6 +1960,94 @@ mod tests {
             .await
         {
             Ok(_) => panic!("zero stream capacity should be rejected"),
+            Err(err) => err,
+        };
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+        assert_eq!(operation_count(&host), 0);
+
+        assert_connection_accepts_legacy_exec(&host, &mut guest, &mut decoder).await;
+    }
+
+    #[tokio::test]
+    async fn command_stream_rejects_oversized_capacity_without_sending_frame() {
+        let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+        let host = Arc::new(host);
+
+        let err = match host
+            .command_stream(CommandStreamRequest {
+                timeout_ms: 5000,
+                command: "stream",
+                env: &[],
+                sudo: false,
+                label: "oversized-capacity",
+                stdout: CommandOutputPolicy::Stream {
+                    limit_bytes: 1024,
+                    chunk_limit_bytes: 16,
+                },
+                stderr: CommandOutputPolicy::Discard,
+                stream_capacity: MAX_COMMAND_STREAM_CAPACITY + 1,
+            })
+            .await
+        {
+            Ok(_) => panic!("oversized stream capacity should be rejected"),
+            Err(err) => err,
+        };
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+        assert_eq!(operation_count(&host), 0);
+
+        assert_connection_accepts_legacy_exec(&host, &mut guest, &mut decoder).await;
+    }
+
+    #[tokio::test]
+    async fn command_start_rejects_stream_policy_without_receiver() {
+        let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+        let host = Arc::new(host);
+
+        let err = match host
+            .start_command_operation(CommandOperationRequest {
+                timeout_ms: 5000,
+                command: "stream",
+                env: &[],
+                sudo: false,
+                stdout: CommandOutputPolicy::Capture { limit_bytes: 1024 },
+                stderr: CommandOutputPolicy::CaptureAndStream {
+                    capture_limit_bytes: 1024,
+                    stream_limit_bytes: 1024,
+                    chunk_limit_bytes: 16,
+                },
+                label: "missing-receiver",
+                stream_capacity: None,
+            })
+            .await
+        {
+            Ok(_) => panic!("streaming output policy without receiver should be rejected"),
+            Err(err) => err,
+        };
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+        assert_eq!(operation_count(&host), 0);
+
+        assert_connection_accepts_legacy_exec(&host, &mut guest, &mut decoder).await;
+    }
+
+    #[tokio::test]
+    async fn command_start_rejects_receiver_without_stream_policy() {
+        let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+        let host = Arc::new(host);
+
+        let err = match host
+            .start_command_operation(CommandOperationRequest {
+                timeout_ms: 5000,
+                command: "capture",
+                env: &[],
+                sudo: false,
+                stdout: CommandOutputPolicy::Capture { limit_bytes: 1024 },
+                stderr: CommandOutputPolicy::Discard,
+                label: "unexpected-receiver",
+                stream_capacity: Some(1),
+            })
+            .await
+        {
+            Ok(_) => panic!("receiver without streaming output policy should be rejected"),
             Err(err) => err,
         };
         assert_eq!(err.kind(), io::ErrorKind::InvalidInput);

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -304,11 +304,6 @@ pub struct CommandOperationHandle {
 }
 
 impl CommandOperationHandle {
-    /// The request sequence used for this operation.
-    pub fn seq(&self) -> Option<u32> {
-        self.seq
-    }
-
     /// Take the bounded output event receiver for streaming operations.
     pub fn take_stream_receiver(&mut self) -> Option<mpsc::Receiver<CommandOutputEvent>> {
         self.stream_rx.take()
@@ -2171,30 +2166,41 @@ mod tests {
         assert!(is_connected(&host));
 
         drop(writer_guard);
-        let read_result = tokio::time::timeout(
-            Duration::from_millis(50),
-            read_guest_message(&mut guest, &mut decoder),
-        )
-        .await;
-        assert!(read_result.is_err(), "start frame should not be written");
+        let exec_task = {
+            let host = Arc::clone(&host);
+            tokio::spawn(async move { host.exec("echo ok", 5000, &[], false).await })
+        };
+        let msg = read_guest_message(&mut guest, &mut decoder).await;
+        assert_eq!(msg.msg_type, MSG_EXEC, "start frame should not be written");
+        let payload = vsock_proto::encode_exec_result(0, b"ok", b"");
+        let response = vsock_proto::encode(MSG_EXEC_RESULT, msg.seq, &payload).unwrap();
+        guest.write_all(&response).await.unwrap();
+        let exec_result = exec_task.await.unwrap().unwrap();
+        assert_eq!(exec_result.stdout, b"ok");
         assert!(is_connected(&host));
     }
 
     #[tokio::test]
     async fn command_handle_drop_after_full_write_sends_no_cancel() {
         let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+        let host = Arc::new(host);
         let handle = start_capture_operation(&host, "drop-after-write").await;
         let msg = read_guest_message(&mut guest, &mut decoder).await;
         assert_eq!(msg.msg_type, MSG_COMMAND_START);
         drop(handle);
         assert_eq!(operation_count(&host), 0);
 
-        let read_result = tokio::time::timeout(
-            Duration::from_millis(50),
-            read_guest_message(&mut guest, &mut decoder),
-        )
-        .await;
-        assert!(read_result.is_err(), "drop must not send command cancel");
+        let exec_task = {
+            let host = Arc::clone(&host);
+            tokio::spawn(async move { host.exec("echo ok", 5000, &[], false).await })
+        };
+        let msg = read_guest_message(&mut guest, &mut decoder).await;
+        assert_eq!(msg.msg_type, MSG_EXEC, "drop must not send command cancel");
+        let payload = vsock_proto::encode_exec_result(0, b"ok", b"");
+        let response = vsock_proto::encode(MSG_EXEC_RESULT, msg.seq, &payload).unwrap();
+        guest.write_all(&response).await.unwrap();
+        let exec_result = exec_task.await.unwrap().unwrap();
+        assert_eq!(exec_result.stdout, b"ok");
         assert!(is_connected(&host));
     }
 

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -613,33 +613,22 @@ fn owned_command_result(
 }
 
 fn dispatch_command_output(shared: &Arc<Shared>, msg: &RawMessage) -> io::Result<()> {
-    let has_operation = {
-        let guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
-        match &*guard {
-            ConnectionState::Connected { operations, .. } => operations.contains_key(&msg.seq),
-            ConnectionState::Closed { .. } => false,
-        }
-    };
-    if !has_operation {
-        return Ok(());
-    }
-
-    let decoded =
-        vsock_proto::decode_command_output(&msg.payload).map_err(command_protocol_error)?;
-
     let mut guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
     if let ConnectionState::Connected { operations, .. } = &mut *guard
         && let Some(Operation::Command(operation)) = operations.get_mut(&msg.seq)
-        && let Some(tx) = operation.stream_tx.as_ref()
     {
-        match tx.try_send(owned_command_output_event(decoded)) {
-            Ok(()) => {}
-            Err(mpsc::error::TrySendError::Full(_)) => {
-                operation.stream_tx.take();
-                operation.stream_overflowed = true;
-            }
-            Err(mpsc::error::TrySendError::Closed(_)) => {
-                operation.stream_tx.take();
+        let decoded =
+            vsock_proto::decode_command_output(&msg.payload).map_err(command_protocol_error)?;
+        if let Some(tx) = operation.stream_tx.as_ref() {
+            match tx.try_send(owned_command_output_event(decoded)) {
+                Ok(()) => {}
+                Err(mpsc::error::TrySendError::Full(_)) => {
+                    operation.stream_tx.take();
+                    operation.stream_overflowed = true;
+                }
+                Err(mpsc::error::TrySendError::Closed(_)) => {
+                    operation.stream_tx.take();
+                }
             }
         }
     }
@@ -648,17 +637,21 @@ fn dispatch_command_output(shared: &Arc<Shared>, msg: &RawMessage) -> io::Result
 }
 
 fn dispatch_command_result(shared: &Arc<Shared>, msg: &RawMessage) -> io::Result<()> {
-    let operation = {
+    let (operation, decoded) = {
         let mut guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
         match &mut *guard {
-            ConnectionState::Connected { operations, .. } => operations.remove(&msg.seq),
-            ConnectionState::Closed { .. } => None,
+            ConnectionState::Connected { operations, .. } if operations.contains_key(&msg.seq) => {
+                let decoded = vsock_proto::decode_command_result(&msg.payload)
+                    .map_err(command_protocol_error)?;
+                (operations.remove(&msg.seq), decoded)
+            }
+            ConnectionState::Connected { .. } | ConnectionState::Closed { .. } => {
+                return Ok(());
+            }
         }
     };
 
     if let Some(Operation::Command(operation)) = operation {
-        let decoded =
-            vsock_proto::decode_command_result(&msg.payload).map_err(command_protocol_error)?;
         let CommandOperation {
             result_tx,
             stream_overflowed,

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -619,16 +619,15 @@ fn dispatch_command_output(shared: &Arc<Shared>, msg: &RawMessage) -> io::Result
     {
         let decoded =
             vsock_proto::decode_command_output(&msg.payload).map_err(command_protocol_error)?;
-        if let Some(tx) = operation.stream_tx.as_ref() {
-            match tx.try_send(owned_command_output_event(decoded)) {
-                Ok(()) => {}
+        if let Some(tx) = operation.stream_tx.take() {
+            match tx.try_reserve_owned() {
+                Ok(permit) => {
+                    operation.stream_tx = Some(permit.send(owned_command_output_event(decoded)));
+                }
                 Err(mpsc::error::TrySendError::Full(_)) => {
-                    operation.stream_tx.take();
                     operation.stream_overflowed = true;
                 }
-                Err(mpsc::error::TrySendError::Closed(_)) => {
-                    operation.stream_tx.take();
-                }
+                Err(mpsc::error::TrySendError::Closed(_)) => {}
             }
         }
     }

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -1205,9 +1205,9 @@ impl VsockHost {
             request.command,
             request.env,
             request.sudo,
+            request.label,
             request.stdout,
             request.stderr,
-            request.label,
         )
         .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e.to_string()))?;
 

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -296,6 +296,10 @@ impl Drop for CommandFrameWriteGuard {
 }
 
 /// Handle for a host-side command operation.
+///
+/// Dropping the handle removes the host-side registration only. It never sends
+/// `MSG_COMMAND_CANCEL`; callers that need remote cancellation must call
+/// [`CommandOperationHandle::cancel_and_wait`].
 pub struct CommandOperationHandle {
     shared: Arc<Shared>,
     seq: Option<u32>,
@@ -310,11 +314,17 @@ impl CommandOperationHandle {
     }
 
     /// Wait for the terminal command result.
+    ///
+    /// On timeout, this removes the host-side operation registration but does
+    /// not cancel the guest-side command.
     pub async fn wait(self, timeout: Duration) -> io::Result<CommandOperationResult> {
         self.wait_with_timeout(timeout, false).await
     }
 
     /// Send an explicit cancel request and wait for a cancelled terminal result.
+    ///
+    /// If the terminal result is already available before cancel is sent, this
+    /// returns that result without sending a duplicate cancel frame.
     pub async fn cancel_and_wait(
         mut self,
         timeout: Duration,
@@ -587,16 +597,15 @@ fn owned_command_result(
 }
 
 fn dispatch_command_output(shared: &Arc<Shared>, msg: &RawMessage) -> io::Result<()> {
-    let event = vsock_proto::decode_command_output(&msg.payload)
-        .map(owned_command_output_event)
-        .map_err(command_protocol_error)?;
+    let decoded =
+        vsock_proto::decode_command_output(&msg.payload).map_err(command_protocol_error)?;
 
     let mut guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
     if let ConnectionState::Connected { operations, .. } = &mut *guard
         && let Some(Operation::Command(operation)) = operations.get_mut(&msg.seq)
         && let Some(tx) = operation.stream_tx.as_ref()
     {
-        match tx.try_send(event) {
+        match tx.try_send(owned_command_output_event(decoded)) {
             Ok(()) => {}
             Err(mpsc::error::TrySendError::Full(_)) => {
                 operation.stream_tx.take();

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -613,6 +613,17 @@ fn owned_command_result(
 }
 
 fn dispatch_command_output(shared: &Arc<Shared>, msg: &RawMessage) -> io::Result<()> {
+    let has_operation = {
+        let guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
+        match &*guard {
+            ConnectionState::Connected { operations, .. } => operations.contains_key(&msg.seq),
+            ConnectionState::Closed { .. } => false,
+        }
+    };
+    if !has_operation {
+        return Ok(());
+    }
+
     let decoded =
         vsock_proto::decode_command_output(&msg.payload).map_err(command_protocol_error)?;
 
@@ -637,8 +648,6 @@ fn dispatch_command_output(shared: &Arc<Shared>, msg: &RawMessage) -> io::Result
 }
 
 fn dispatch_command_result(shared: &Arc<Shared>, msg: &RawMessage) -> io::Result<()> {
-    let decoded =
-        vsock_proto::decode_command_result(&msg.payload).map_err(command_protocol_error)?;
     let operation = {
         let mut guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
         match &mut *guard {
@@ -648,6 +657,8 @@ fn dispatch_command_result(shared: &Arc<Shared>, msg: &RawMessage) -> io::Result
     };
 
     if let Some(Operation::Command(operation)) = operation {
+        let decoded =
+            vsock_proto::decode_command_result(&msg.payload).map_err(command_protocol_error)?;
         let CommandOperation {
             result_tx,
             stream_overflowed,
@@ -2605,6 +2616,33 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn malformed_command_output_after_result_is_ignored() {
+        let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+        let host = Arc::new(host);
+        let handle = start_capture_operation(&host, "done").await;
+        let msg = read_guest_message(&mut guest, &mut decoder).await;
+        send_command_result(
+            &mut guest,
+            msg.seq,
+            CommandTermination::Exited { exit_code: 0 },
+            b"done",
+            b"",
+        )
+        .await;
+        let result = handle.wait(Duration::from_secs(5)).await.unwrap();
+        assert_eq!(
+            result.termination,
+            CommandTermination::Exited { exit_code: 0 }
+        );
+        assert_eq!(operation_count(&host), 0);
+
+        let frame = vsock_proto::encode(MSG_COMMAND_OUTPUT, msg.seq, &[0]).unwrap();
+        guest.write_all(&frame).await.unwrap();
+
+        assert_connection_accepts_legacy_exec(&host, &mut guest, &mut decoder).await;
+    }
+
+    #[tokio::test]
     async fn duplicate_command_result_after_completion_is_ignored() {
         let (host, mut guest, mut decoder) = setup_host_and_guest().await;
         let host = Arc::new(host);
@@ -2638,6 +2676,38 @@ mod tests {
             b"",
         )
         .await;
+
+        assert_connection_accepts_legacy_exec(&host, &mut guest, &mut decoder).await;
+    }
+
+    #[tokio::test]
+    async fn malformed_duplicate_command_result_after_completion_is_ignored() {
+        let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+        let host = Arc::new(host);
+        let handle = start_capture_operation(&host, "malformed-duplicate-result").await;
+        let msg = read_guest_message(&mut guest, &mut decoder).await;
+        assert_eq!(msg.msg_type, MSG_COMMAND_START);
+
+        send_command_result(
+            &mut guest,
+            msg.seq,
+            CommandTermination::Exited { exit_code: 0 },
+            b"first",
+            b"",
+        )
+        .await;
+        let result = handle.wait(Duration::from_secs(5)).await.unwrap();
+        assert_eq!(
+            result.stdout,
+            CommandOwnedCapturedOutput::Captured {
+                bytes: b"first".to_vec(),
+                truncated: false,
+            }
+        );
+        assert_eq!(operation_count(&host), 0);
+
+        let frame = vsock_proto::encode(MSG_COMMAND_RESULT, msg.seq, &[0]).unwrap();
+        guest.write_all(&frame).await.unwrap();
 
         assert_connection_accepts_legacy_exec(&host, &mut guest, &mut decoder).await;
     }

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -20,8 +20,9 @@
 
 use std::collections::HashMap;
 use std::io;
+use std::os::unix::io::RawFd;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::atomic::{AtomicU8, AtomicU32, Ordering};
 use std::time::Duration;
 
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -31,12 +32,18 @@ use tokio::task::JoinHandle;
 use tokio::time::{self, Instant};
 
 use vsock_proto::{
-    Decoder, MSG_ERROR, MSG_EXEC, MSG_EXEC_RESULT, MSG_PING, MSG_PONG, MSG_PROCESS_EXIT, MSG_READY,
-    MSG_SHUTDOWN, MSG_SHUTDOWN_ACK, MSG_SPAWN_WATCH, MSG_SPAWN_WATCH_RESULT, MSG_STDOUT_CHUNK,
-    MSG_WRITE_FILE, MSG_WRITE_FILE_RESULT, RawMessage,
+    CommandCapturedOutput, CommandOutputPolicy, CommandOutputStream, CommandTermination, Decoder,
+    MSG_COMMAND_CANCEL, MSG_COMMAND_OUTPUT, MSG_COMMAND_RESULT, MSG_COMMAND_START, MSG_ERROR,
+    MSG_EXEC, MSG_EXEC_RESULT, MSG_PING, MSG_PONG, MSG_PROCESS_EXIT, MSG_READY, MSG_SHUTDOWN,
+    MSG_SHUTDOWN_ACK, MSG_SPAWN_WATCH, MSG_SPAWN_WATCH_RESULT, MSG_STDOUT_CHUNK, MSG_WRITE_FILE,
+    MSG_WRITE_FILE_RESULT, RawMessage,
 };
 
 const READ_BUF_SIZE: usize = 64 * 1024;
+const DEFAULT_COMMAND_CAPTURE_LIMIT_BYTES: u32 = 1024 * 1024;
+const COMMAND_FRAME_WRITE_NOT_STARTED: u8 = 0;
+const COMMAND_FRAME_WRITE_STARTED: u8 = 1;
+const COMMAND_FRAME_WRITE_COMPLETED: u8 = 2;
 
 /// Result of executing a command on the guest.
 #[derive(Debug, Clone)]
@@ -53,6 +60,84 @@ pub struct ProcessExitEvent {
     pub exit_code: i32,
     pub stdout: Vec<u8>,
     pub stderr: Vec<u8>,
+}
+
+/// Owned captured output from a command operation result.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CommandOwnedCapturedOutput {
+    /// The stream was discarded by policy and therefore has no captured bytes.
+    Discarded,
+    /// The stream was captured, possibly with protocol-level truncation.
+    Captured { bytes: Vec<u8>, truncated: bool },
+}
+
+/// Terminal result for a host command operation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CommandOperationResult {
+    pub termination: CommandTermination,
+    pub duration_ms: u32,
+    pub stdout: CommandOwnedCapturedOutput,
+    pub stderr: CommandOwnedCapturedOutput,
+    pub diagnostic: String,
+    pub stream_overflowed: bool,
+}
+
+/// Streamed output event for a host command operation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CommandOutputEvent {
+    pub stream: CommandOutputStream,
+    pub output_seq: u32,
+    pub chunk: Vec<u8>,
+    pub truncated: bool,
+}
+
+/// Request parameters for starting a command operation.
+pub struct CommandOperationRequest<'a> {
+    pub timeout_ms: u32,
+    pub command: &'a str,
+    pub env: &'a [(&'a str, &'a str)],
+    pub sudo: bool,
+    pub stdout: CommandOutputPolicy,
+    pub stderr: CommandOutputPolicy,
+    pub label: &'a str,
+    pub stream_capacity: Option<usize>,
+}
+
+/// Request parameters for a capture-only command operation helper.
+pub struct CommandCaptureRequest<'a> {
+    pub timeout_ms: u32,
+    pub command: &'a str,
+    pub env: &'a [(&'a str, &'a str)],
+    pub sudo: bool,
+    pub label: &'a str,
+    pub stdout_limit_bytes: u32,
+    pub stderr_limit_bytes: u32,
+    pub wait_timeout: Duration,
+}
+
+/// Request parameters for a streaming command operation helper.
+pub struct CommandStreamRequest<'a> {
+    pub timeout_ms: u32,
+    pub command: &'a str,
+    pub env: &'a [(&'a str, &'a str)],
+    pub sudo: bool,
+    pub label: &'a str,
+    pub stdout: CommandOutputPolicy,
+    pub stderr: CommandOutputPolicy,
+    pub stream_capacity: usize,
+}
+
+struct CommandOperation {
+    result_tx: oneshot::Sender<io::Result<CommandOperationResult>>,
+    stream_tx: Option<mpsc::Sender<CommandOutputEvent>>,
+    stream_overflowed: bool,
+    _stdout_policy: CommandOutputPolicy,
+    _stderr_policy: CommandOutputPolicy,
+    _label: String,
+}
+
+enum Operation {
+    Command(CommandOperation),
 }
 
 /// Connection lifecycle, expressed as data rather than a separate atomic flag.
@@ -81,6 +166,8 @@ enum ConnectionState {
         /// Populated by `reader_loop` when it processes `spawn_watch_result`,
         /// fed by `reader_loop` when it processes `stdout_chunk`.
         stdout_senders: HashMap<u32, mpsc::UnboundedSender<Vec<u8>>>,
+        /// Active request-scoped operations: seq → operation state.
+        operations: HashMap<u32, Operation>,
         /// Cached process exit events (unsolicited, seq=0).
         exits: HashMap<u32, ProcessExitEvent>,
     },
@@ -95,6 +182,8 @@ enum ConnectionState {
 struct Shared {
     /// Serialises writes to the stream.
     writer: tokio::sync::Mutex<tokio::net::unix::OwnedWriteHalf>,
+    /// Raw fd of the underlying socket, used to poison a corrupted stream.
+    fd: RawFd,
     /// Monotonically increasing sequence number (starts at 2, skips 0).
     /// Handshake uses seq=1 before Shared is created, so post-handshake
     /// sequences start at 2 to avoid collisions.
@@ -156,6 +245,169 @@ impl PendingStdoutGuard {
 impl Drop for PendingStdoutGuard {
     fn drop(&mut self) {
         self.shared.remove_pending_stdout(self.seq);
+    }
+}
+
+struct CommandOperationRegistrationGuard {
+    shared: Arc<Shared>,
+    seq: u32,
+    disarmed: bool,
+}
+
+impl CommandOperationRegistrationGuard {
+    fn new(shared: Arc<Shared>, seq: u32) -> Self {
+        Self {
+            shared,
+            seq,
+            disarmed: false,
+        }
+    }
+
+    fn disarm(&mut self) {
+        self.disarmed = true;
+    }
+}
+
+impl Drop for CommandOperationRegistrationGuard {
+    fn drop(&mut self) {
+        if !self.disarmed {
+            self.shared.remove_operation(self.seq);
+        }
+    }
+}
+
+struct CommandFrameWriteGuard {
+    shared: Arc<Shared>,
+    state: Arc<AtomicU8>,
+}
+
+impl CommandFrameWriteGuard {
+    fn new(shared: Arc<Shared>, state: Arc<AtomicU8>) -> Self {
+        Self { shared, state }
+    }
+}
+
+impl Drop for CommandFrameWriteGuard {
+    fn drop(&mut self) {
+        if self.state.load(Ordering::Acquire) == COMMAND_FRAME_WRITE_STARTED {
+            self.shared.poison_connection();
+        }
+    }
+}
+
+/// Handle for a host-side command operation.
+pub struct CommandOperationHandle {
+    shared: Arc<Shared>,
+    seq: Option<u32>,
+    result_rx: Option<oneshot::Receiver<io::Result<CommandOperationResult>>>,
+    stream_rx: Option<mpsc::Receiver<CommandOutputEvent>>,
+}
+
+impl CommandOperationHandle {
+    /// The request sequence used for this operation.
+    pub fn seq(&self) -> Option<u32> {
+        self.seq
+    }
+
+    /// Take the bounded output event receiver for streaming operations.
+    pub fn take_stream_receiver(&mut self) -> Option<mpsc::Receiver<CommandOutputEvent>> {
+        self.stream_rx.take()
+    }
+
+    /// Wait for the terminal command result.
+    pub async fn wait(self, timeout: Duration) -> io::Result<CommandOperationResult> {
+        self.wait_with_timeout(timeout, false).await
+    }
+
+    /// Send an explicit cancel request and wait for a cancelled terminal result.
+    pub async fn cancel_and_wait(
+        mut self,
+        timeout: Duration,
+    ) -> io::Result<CommandOperationResult> {
+        if let Some(result) = self.try_take_ready_result()? {
+            return Ok(result);
+        }
+
+        let seq = self.seq.ok_or_else(|| {
+            io::Error::new(io::ErrorKind::ConnectionReset, "command operation closed")
+        })?;
+        let payload = vsock_proto::encode_command_cancel();
+        write_command_frame(&self.shared, MSG_COMMAND_CANCEL, seq, &payload).await?;
+
+        let result = self.wait_with_timeout(timeout, true).await?;
+        if result.termination == CommandTermination::Cancelled {
+            return Ok(result);
+        }
+
+        Err(io::Error::other(format!(
+            "command cancel returned terminal state: {:?}",
+            result.termination
+        )))
+    }
+
+    fn try_take_ready_result(&mut self) -> io::Result<Option<CommandOperationResult>> {
+        let Some(rx) = self.result_rx.as_mut() else {
+            return Ok(None);
+        };
+
+        match rx.try_recv() {
+            Ok(result) => {
+                self.seq = None;
+                self.result_rx = None;
+                result.map(Some)
+            }
+            Err(oneshot::error::TryRecvError::Empty) => Ok(None),
+            Err(oneshot::error::TryRecvError::Closed) => {
+                self.seq = None;
+                self.result_rx = None;
+                Err(io::Error::new(
+                    io::ErrorKind::ConnectionReset,
+                    "connection closed",
+                ))
+            }
+        }
+    }
+
+    async fn wait_with_timeout(
+        mut self,
+        timeout: Duration,
+        poison_on_timeout: bool,
+    ) -> io::Result<CommandOperationResult> {
+        let seq = self.seq.ok_or_else(|| {
+            io::Error::new(io::ErrorKind::ConnectionReset, "command operation closed")
+        })?;
+        let rx = self.result_rx.as_mut().ok_or_else(|| {
+            io::Error::new(io::ErrorKind::ConnectionReset, "command operation closed")
+        })?;
+
+        tokio::select! {
+            biased;
+            result = rx => {
+                self.seq = None;
+                self.result_rx = None;
+                result.map_err(|_| io::Error::new(
+                    io::ErrorKind::ConnectionReset,
+                    "connection closed",
+                ))?
+            }
+            _ = tokio::time::sleep(timeout) => {
+                self.shared.remove_operation(seq);
+                self.seq = None;
+                self.result_rx = None;
+                if poison_on_timeout {
+                    self.shared.poison_connection();
+                }
+                Err(io::Error::new(io::ErrorKind::TimedOut, "command operation timeout"))
+            }
+        }
+    }
+}
+
+impl Drop for CommandOperationHandle {
+    fn drop(&mut self) {
+        if let Some(seq) = self.seq.take() {
+            self.shared.remove_operation(seq);
+        }
     }
 }
 
@@ -253,10 +505,11 @@ impl Shared {
                     pending,
                     pending_stdout,
                     stdout_senders,
+                    operations,
                     exits,
                 } => {
                     *guard = ConnectionState::Closed { exits };
-                    Some((pending, pending_stdout, stdout_senders))
+                    Some((pending, pending_stdout, stdout_senders, operations))
                 }
                 closed @ ConnectionState::Closed { .. } => {
                     // Reassign the whole variant; cached `exits` preserved
@@ -272,6 +525,11 @@ impl Shared {
         }
     }
 
+    fn poison_connection(&self) {
+        self.close();
+        let _ = nix::sys::socket::shutdown(self.fd, nix::sys::socket::Shutdown::Both);
+    }
+
     fn remove_pending(&self, seq: u32) {
         let mut guard = self.state.lock().unwrap_or_else(|e| e.into_inner());
         if let ConnectionState::Connected { pending, .. } = &mut *guard {
@@ -285,6 +543,101 @@ impl Shared {
             pending_stdout.remove(&seq);
         }
     }
+
+    fn remove_operation(&self, seq: u32) {
+        let mut guard = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        if let ConnectionState::Connected { operations, .. } = &mut *guard {
+            operations.remove(&seq);
+        }
+    }
+}
+
+fn command_protocol_error(error: impl ToString) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, error.to_string())
+}
+
+fn owned_captured_output(output: CommandCapturedOutput<'_>) -> CommandOwnedCapturedOutput {
+    match output {
+        CommandCapturedOutput::Discarded => CommandOwnedCapturedOutput::Discarded,
+        CommandCapturedOutput::Captured { bytes, truncated } => {
+            CommandOwnedCapturedOutput::Captured {
+                bytes: bytes.to_vec(),
+                truncated,
+            }
+        }
+    }
+}
+
+fn owned_command_output_event(output: vsock_proto::DecodedCommandOutput<'_>) -> CommandOutputEvent {
+    CommandOutputEvent {
+        stream: output.stream,
+        output_seq: output.output_seq,
+        chunk: output.chunk.to_vec(),
+        truncated: output.truncated,
+    }
+}
+
+fn owned_command_result(
+    result: vsock_proto::DecodedCommandResult<'_>,
+    stream_overflowed: bool,
+) -> CommandOperationResult {
+    CommandOperationResult {
+        termination: result.termination,
+        duration_ms: result.duration_ms,
+        stdout: owned_captured_output(result.stdout),
+        stderr: owned_captured_output(result.stderr),
+        diagnostic: result.diagnostic.to_string(),
+        stream_overflowed,
+    }
+}
+
+fn dispatch_command_output(shared: &Arc<Shared>, msg: &RawMessage) -> io::Result<()> {
+    let event = vsock_proto::decode_command_output(&msg.payload)
+        .map(owned_command_output_event)
+        .map_err(command_protocol_error)?;
+
+    let mut guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
+    if let ConnectionState::Connected { operations, .. } = &mut *guard
+        && let Some(Operation::Command(operation)) = operations.get_mut(&msg.seq)
+        && let Some(tx) = operation.stream_tx.as_ref()
+    {
+        match tx.try_send(event) {
+            Ok(()) => {}
+            Err(mpsc::error::TrySendError::Full(_)) => {
+                operation.stream_tx.take();
+                operation.stream_overflowed = true;
+            }
+            Err(mpsc::error::TrySendError::Closed(_)) => {
+                operation.stream_tx.take();
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn dispatch_command_result(shared: &Arc<Shared>, msg: &RawMessage) -> io::Result<()> {
+    let decoded =
+        vsock_proto::decode_command_result(&msg.payload).map_err(command_protocol_error)?;
+    let operation = {
+        let mut guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
+        match &mut *guard {
+            ConnectionState::Connected { operations, .. } => operations.remove(&msg.seq),
+            ConnectionState::Closed { .. } => None,
+        }
+    };
+
+    if let Some(Operation::Command(operation)) = operation {
+        let CommandOperation {
+            result_tx,
+            stream_overflowed,
+            ..
+        } = operation;
+        let result = owned_command_result(decoded, stream_overflowed);
+        let _ = result_tx.send(Ok(result));
+    }
+
+    Ok(())
 }
 
 /// Host-side vsock endpoint.
@@ -305,7 +658,7 @@ pub struct VsockHost {
     /// unblocking the reader_loop's async read and any remote peer's
     /// blocking read. The fd itself is still owned by the read/write halves
     /// and is closed normally when they are dropped.
-    fd: std::os::unix::io::RawFd,
+    fd: RawFd,
 }
 
 impl Drop for VsockHost {
@@ -340,7 +693,17 @@ async fn reader_loop(
             Err(_) => break,
         };
         for msg in messages {
-            if msg.msg_type == MSG_STDOUT_CHUNK && msg.seq == 0 {
+            if msg.msg_type == MSG_COMMAND_OUTPUT {
+                if dispatch_command_output(&shared, &msg).is_err() {
+                    shared.poison_connection();
+                    return;
+                }
+            } else if msg.msg_type == MSG_COMMAND_RESULT {
+                if dispatch_command_result(&shared, &msg).is_err() {
+                    shared.poison_connection();
+                    return;
+                }
+            } else if msg.msg_type == MSG_STDOUT_CHUNK && msg.seq == 0 {
                 if let Ok((pid, data)) = vsock_proto::decode_stdout_chunk(&msg.payload) {
                     let sender = {
                         let guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
@@ -489,6 +852,26 @@ async fn request_raw_on_shared(
     }
 }
 
+async fn write_command_frame(
+    shared: &Arc<Shared>,
+    msg_type: u8,
+    seq: u32,
+    payload: &[u8],
+) -> io::Result<()> {
+    let data = vsock_proto::encode(msg_type, seq, payload)
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e.to_string()))?;
+    let state = Arc::new(AtomicU8::new(COMMAND_FRAME_WRITE_NOT_STARTED));
+    let guard = CommandFrameWriteGuard::new(Arc::clone(shared), Arc::clone(&state));
+
+    let mut writer = shared.writer.lock().await;
+    state.store(COMMAND_FRAME_WRITE_STARTED, Ordering::Release);
+    writer.write_all(&data).await?;
+    state.store(COMMAND_FRAME_WRITE_COMPLETED, Ordering::Release);
+    drop(guard);
+
+    Ok(())
+}
+
 async fn exec_on_shared(
     shared: &Arc<Shared>,
     command: &str,
@@ -619,11 +1002,13 @@ impl VsockHost {
 
         let shared = Arc::new(Shared {
             writer: tokio::sync::Mutex::new(write_half),
+            fd,
             seq: AtomicU32::new(2),
             state: std::sync::Mutex::new(ConnectionState::Connected {
                 pending: HashMap::new(),
                 pending_stdout: HashMap::new(),
                 stdout_senders: HashMap::new(),
+                operations: HashMap::new(),
                 exits: HashMap::new(),
             }),
             exit_notify: Notify::new(),
@@ -721,6 +1106,140 @@ impl VsockHost {
         timeout: Duration,
     ) -> io::Result<RawMessage> {
         request_raw_on_shared(&self.shared, msg_type, seq, payload, timeout).await
+    }
+
+    /// Start a request-scoped command operation using the unified command protocol.
+    pub async fn start_command_operation(
+        &self,
+        request: CommandOperationRequest<'_>,
+    ) -> io::Result<CommandOperationHandle> {
+        if matches!(request.stream_capacity, Some(0)) {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "command stream capacity must be positive",
+            ));
+        }
+
+        let payload = vsock_proto::encode_command_start(
+            request.timeout_ms,
+            request.command,
+            request.env,
+            request.sudo,
+            request.stdout,
+            request.stderr,
+            request.label,
+        )
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e.to_string()))?;
+
+        let (stream_tx, stream_rx) = match request.stream_capacity {
+            Some(capacity) => {
+                let (tx, rx) = mpsc::channel(capacity);
+                (Some(tx), Some(rx))
+            }
+            None => (None, None),
+        };
+        let (result_tx, result_rx) = oneshot::channel();
+        let seq = self.shared.next_seq();
+        let operation = CommandOperation {
+            result_tx,
+            stream_tx,
+            stream_overflowed: false,
+            _stdout_policy: request.stdout,
+            _stderr_policy: request.stderr,
+            _label: request.label.to_string(),
+        };
+
+        {
+            let mut guard = self.shared.state.lock().unwrap_or_else(|e| e.into_inner());
+            match &mut *guard {
+                ConnectionState::Closed { .. } => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::ConnectionReset,
+                        "connection closed",
+                    ));
+                }
+                ConnectionState::Connected { operations, .. } => {
+                    operations.insert(seq, Operation::Command(operation));
+                }
+            }
+        }
+
+        let mut registration_guard =
+            CommandOperationRegistrationGuard::new(Arc::clone(&self.shared), seq);
+        write_command_frame(&self.shared, MSG_COMMAND_START, seq, &payload).await?;
+        registration_guard.disarm();
+
+        Ok(CommandOperationHandle {
+            shared: Arc::clone(&self.shared),
+            seq: Some(seq),
+            result_rx: Some(result_rx),
+            stream_rx,
+        })
+    }
+
+    /// Run a capture-only command operation with default capture limits.
+    pub async fn command_capture_default(
+        &self,
+        command: &str,
+        timeout_ms: u32,
+        env: &[(&str, &str)],
+        sudo: bool,
+        label: &str,
+        wait_timeout: Duration,
+    ) -> io::Result<CommandOperationResult> {
+        self.command_capture(CommandCaptureRequest {
+            timeout_ms,
+            command,
+            env,
+            sudo,
+            label,
+            stdout_limit_bytes: DEFAULT_COMMAND_CAPTURE_LIMIT_BYTES,
+            stderr_limit_bytes: DEFAULT_COMMAND_CAPTURE_LIMIT_BYTES,
+            wait_timeout,
+        })
+        .await
+    }
+
+    /// Run a capture-only command operation with explicit stdout/stderr limits.
+    pub async fn command_capture(
+        &self,
+        request: CommandCaptureRequest<'_>,
+    ) -> io::Result<CommandOperationResult> {
+        let handle = self
+            .start_command_operation(CommandOperationRequest {
+                timeout_ms: request.timeout_ms,
+                command: request.command,
+                env: request.env,
+                sudo: request.sudo,
+                stdout: CommandOutputPolicy::Capture {
+                    limit_bytes: request.stdout_limit_bytes,
+                },
+                stderr: CommandOutputPolicy::Capture {
+                    limit_bytes: request.stderr_limit_bytes,
+                },
+                label: request.label,
+                stream_capacity: None,
+            })
+            .await?;
+        handle.wait(request.wait_timeout).await
+    }
+
+    /// Start a streaming command operation with a bounded output event receiver.
+    pub async fn command_stream(
+        &self,
+        request: CommandStreamRequest<'_>,
+    ) -> io::Result<CommandOperationHandle> {
+        self.start_command_operation(CommandOperationRequest {
+            timeout_ms: request.timeout_ms,
+            command: request.command,
+            env: request.env,
+            sudo: request.sudo,
+            stdout: request.stdout,
+            stderr: request.stderr,
+            label: request.label,
+            stream_capacity: Some(request.stream_capacity),
+        })
+        .await
     }
 
     /// Execute a command on the guest.
@@ -1084,6 +1603,103 @@ mod tests {
         }
     }
 
+    fn operation_count(host: &VsockHost) -> usize {
+        let guard = host.shared.state.lock().unwrap_or_else(|e| e.into_inner());
+        match &*guard {
+            ConnectionState::Connected { operations, .. } => operations.len(),
+            ConnectionState::Closed { .. } => 0,
+        }
+    }
+
+    fn is_connected(host: &VsockHost) -> bool {
+        let guard = host.shared.state.lock().unwrap_or_else(|e| e.into_inner());
+        matches!(&*guard, ConnectionState::Connected { .. })
+    }
+
+    async fn read_guest_message(stream: &mut UnixStream, decoder: &mut Decoder) -> RawMessage {
+        let mut buf = [0u8; 4096];
+        loop {
+            let n = stream.read(&mut buf).await.unwrap();
+            assert_ne!(n, 0, "connection closed before message");
+            let mut msgs = decoder.decode(&buf[..n]).unwrap();
+            if !msgs.is_empty() {
+                return msgs.remove(0);
+            }
+        }
+    }
+
+    async fn setup_host_and_guest() -> (VsockHost, UnixStream, Decoder) {
+        let (host_stream, mut guest) = make_pair();
+        let host_task = tokio::spawn(async move { host_from_stream(host_stream).await.unwrap() });
+        let mut decoder = Decoder::new();
+        mock_handshake(&mut guest, &mut decoder).await;
+        let host = host_task.await.unwrap();
+        (host, guest, decoder)
+    }
+
+    async fn start_capture_operation(host: &VsockHost, command: &str) -> CommandOperationHandle {
+        host.start_command_operation(CommandOperationRequest {
+            timeout_ms: 5000,
+            command,
+            env: &[],
+            sudo: false,
+            stdout: CommandOutputPolicy::Capture { limit_bytes: 1024 },
+            stderr: CommandOutputPolicy::Capture { limit_bytes: 1024 },
+            label: "test-command",
+            stream_capacity: None,
+        })
+        .await
+        .unwrap()
+    }
+
+    fn command_result_payload(
+        termination: CommandTermination,
+        stdout: &[u8],
+        stderr: &[u8],
+    ) -> Vec<u8> {
+        vsock_proto::encode_command_result(
+            termination,
+            12,
+            CommandCapturedOutput::Captured {
+                bytes: stdout,
+                truncated: false,
+            },
+            CommandCapturedOutput::Captured {
+                bytes: stderr,
+                truncated: false,
+            },
+            "",
+        )
+        .unwrap()
+    }
+
+    async fn send_command_result(
+        stream: &mut UnixStream,
+        seq: u32,
+        termination: CommandTermination,
+        stdout: &[u8],
+        stderr: &[u8],
+    ) {
+        let payload = command_result_payload(termination, stdout, stderr);
+        let frame = vsock_proto::encode(MSG_COMMAND_RESULT, seq, &payload).unwrap();
+        stream.write_all(&frame).await.unwrap();
+    }
+
+    async fn send_command_output(
+        stream: &mut UnixStream,
+        seq: u32,
+        output_seq: u32,
+        output_stream: CommandOutputStream,
+        chunk: &[u8],
+        truncated: bool,
+    ) {
+        let payload =
+            vsock_proto::encode_command_output(output_stream, output_seq, chunk, truncated)
+                .unwrap();
+        let frame = vsock_proto::encode(MSG_COMMAND_OUTPUT, seq, &payload).unwrap();
+        stream.write_all(&frame).await.unwrap();
+    }
+
     #[tokio::test]
     async fn wait_for_connection_removes_listener_socket_on_abort() {
         let unique = std::time::SystemTime::now()
@@ -1115,6 +1731,527 @@ mod tests {
             !listener.exists(),
             "aborted listener should remove its socket path"
         );
+    }
+
+    #[tokio::test]
+    async fn command_capture_sends_start_and_receives_result() {
+        let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+        let host = Arc::new(host);
+        let task = {
+            let host = Arc::clone(&host);
+            tokio::spawn(async move {
+                host.command_capture(CommandCaptureRequest {
+                    timeout_ms: 7000,
+                    command: "printf hello",
+                    env: &[("A", "B")],
+                    sudo: true,
+                    label: "capture-test",
+                    stdout_limit_bytes: 7,
+                    stderr_limit_bytes: 9,
+                    wait_timeout: Duration::from_secs(5),
+                })
+                .await
+            })
+        };
+
+        let msg = read_guest_message(&mut guest, &mut decoder).await;
+        assert_eq!(msg.msg_type, MSG_COMMAND_START);
+        let decoded = vsock_proto::decode_command_start(&msg.payload).unwrap();
+        assert_eq!(decoded.timeout_ms, 7000);
+        assert_eq!(decoded.command, "printf hello");
+        assert_eq!(decoded.env, vec![("A", "B")]);
+        assert!(decoded.sudo);
+        assert_eq!(decoded.label, "capture-test");
+        assert_eq!(
+            decoded.stdout,
+            CommandOutputPolicy::Capture { limit_bytes: 7 }
+        );
+        assert_eq!(
+            decoded.stderr,
+            CommandOutputPolicy::Capture { limit_bytes: 9 }
+        );
+
+        send_command_result(
+            &mut guest,
+            msg.seq,
+            CommandTermination::Exited { exit_code: 0 },
+            b"stdout",
+            b"stderr",
+        )
+        .await;
+
+        let result = task.await.unwrap().unwrap();
+        assert_eq!(
+            result.termination,
+            CommandTermination::Exited { exit_code: 0 }
+        );
+        assert_eq!(
+            result.stdout,
+            CommandOwnedCapturedOutput::Captured {
+                bytes: b"stdout".to_vec(),
+                truncated: false,
+            }
+        );
+        assert_eq!(
+            result.stderr,
+            CommandOwnedCapturedOutput::Captured {
+                bytes: b"stderr".to_vec(),
+                truncated: false,
+            }
+        );
+        assert_eq!(operation_count(&host), 0);
+    }
+
+    #[tokio::test]
+    async fn command_operations_dispatch_out_of_order_results_by_seq() {
+        let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+        let first = start_capture_operation(&host, "cmd-a").await;
+        let second = start_capture_operation(&host, "cmd-b").await;
+
+        let mut messages = Vec::new();
+        let mut buf = [0u8; 4096];
+        while messages.len() < 2 {
+            let n = guest.read(&mut buf).await.unwrap();
+            assert_ne!(n, 0, "connection closed before command start messages");
+            messages.extend(decoder.decode(&buf[..n]).unwrap());
+        }
+        let msg_a = messages.remove(0);
+        let msg_b = messages.remove(0);
+        assert_eq!(msg_a.msg_type, MSG_COMMAND_START);
+        assert_eq!(msg_b.msg_type, MSG_COMMAND_START);
+
+        send_command_result(
+            &mut guest,
+            msg_b.seq,
+            CommandTermination::Exited { exit_code: 2 },
+            b"b",
+            b"",
+        )
+        .await;
+        send_command_result(
+            &mut guest,
+            msg_a.seq,
+            CommandTermination::Exited { exit_code: 1 },
+            b"a",
+            b"",
+        )
+        .await;
+
+        let first = first.wait(Duration::from_secs(5)).await.unwrap();
+        let second = second.wait(Duration::from_secs(5)).await.unwrap();
+        assert_eq!(
+            first.termination,
+            CommandTermination::Exited { exit_code: 1 }
+        );
+        assert_eq!(
+            first.stdout,
+            CommandOwnedCapturedOutput::Captured {
+                bytes: b"a".to_vec(),
+                truncated: false,
+            }
+        );
+        assert_eq!(
+            second.termination,
+            CommandTermination::Exited { exit_code: 2 }
+        );
+        assert_eq!(
+            second.stdout,
+            CommandOwnedCapturedOutput::Captured {
+                bytes: b"b".to_vec(),
+                truncated: false,
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn command_stream_dispatches_stdout_stderr_and_closes_on_result() {
+        let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+        let mut handle = host
+            .command_stream(CommandStreamRequest {
+                timeout_ms: 5000,
+                command: "stream",
+                env: &[],
+                sudo: false,
+                label: "stream-test",
+                stdout: CommandOutputPolicy::Stream {
+                    limit_bytes: 1024,
+                    chunk_limit_bytes: 16,
+                },
+                stderr: CommandOutputPolicy::Stream {
+                    limit_bytes: 1024,
+                    chunk_limit_bytes: 16,
+                },
+                stream_capacity: 4,
+            })
+            .await
+            .unwrap();
+        let mut rx = handle.take_stream_receiver().unwrap();
+
+        let msg = read_guest_message(&mut guest, &mut decoder).await;
+        assert_eq!(msg.msg_type, MSG_COMMAND_START);
+        send_command_output(
+            &mut guest,
+            msg.seq,
+            1,
+            CommandOutputStream::Stdout,
+            b"out",
+            false,
+        )
+        .await;
+        send_command_output(
+            &mut guest,
+            msg.seq,
+            2,
+            CommandOutputStream::Stderr,
+            b"err",
+            true,
+        )
+        .await;
+
+        let out = rx.recv().await.unwrap();
+        assert_eq!(out.stream, CommandOutputStream::Stdout);
+        assert_eq!(out.output_seq, 1);
+        assert_eq!(out.chunk, b"out");
+        assert!(!out.truncated);
+
+        let err = rx.recv().await.unwrap();
+        assert_eq!(err.stream, CommandOutputStream::Stderr);
+        assert_eq!(err.output_seq, 2);
+        assert_eq!(err.chunk, b"err");
+        assert!(err.truncated);
+
+        send_command_result(
+            &mut guest,
+            msg.seq,
+            CommandTermination::Exited { exit_code: 0 },
+            b"",
+            b"",
+        )
+        .await;
+        let result = handle.wait(Duration::from_secs(5)).await.unwrap();
+        assert!(!result.stream_overflowed);
+        assert!(rx.recv().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn command_stream_full_channel_closes_stream_and_marks_result() {
+        let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+        let mut handle = host
+            .command_stream(CommandStreamRequest {
+                timeout_ms: 5000,
+                command: "stream",
+                env: &[],
+                sudo: false,
+                label: "stream-overflow",
+                stdout: CommandOutputPolicy::Stream {
+                    limit_bytes: 1024,
+                    chunk_limit_bytes: 16,
+                },
+                stderr: CommandOutputPolicy::Discard,
+                stream_capacity: 1,
+            })
+            .await
+            .unwrap();
+        let mut rx = handle.take_stream_receiver().unwrap();
+
+        let msg = read_guest_message(&mut guest, &mut decoder).await;
+        send_command_output(
+            &mut guest,
+            msg.seq,
+            1,
+            CommandOutputStream::Stdout,
+            b"first",
+            false,
+        )
+        .await;
+        send_command_output(
+            &mut guest,
+            msg.seq,
+            2,
+            CommandOutputStream::Stdout,
+            b"second",
+            false,
+        )
+        .await;
+        send_command_result(
+            &mut guest,
+            msg.seq,
+            CommandTermination::Exited { exit_code: 0 },
+            b"",
+            b"",
+        )
+        .await;
+
+        let first = rx.recv().await.unwrap();
+        assert_eq!(first.output_seq, 1);
+        assert_eq!(first.chunk, b"first");
+        assert!(rx.recv().await.is_none());
+
+        let result = handle.wait(Duration::from_secs(5)).await.unwrap();
+        assert!(result.stream_overflowed);
+    }
+
+    #[tokio::test]
+    async fn command_stream_dropped_receiver_does_not_block_result() {
+        let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+        let mut handle = host
+            .command_stream(CommandStreamRequest {
+                timeout_ms: 5000,
+                command: "stream",
+                env: &[],
+                sudo: false,
+                label: "stream-dropped",
+                stdout: CommandOutputPolicy::Stream {
+                    limit_bytes: 1024,
+                    chunk_limit_bytes: 16,
+                },
+                stderr: CommandOutputPolicy::Discard,
+                stream_capacity: 1,
+            })
+            .await
+            .unwrap();
+        drop(handle.take_stream_receiver());
+
+        let msg = read_guest_message(&mut guest, &mut decoder).await;
+        send_command_output(
+            &mut guest,
+            msg.seq,
+            1,
+            CommandOutputStream::Stdout,
+            b"ignored",
+            false,
+        )
+        .await;
+        send_command_result(
+            &mut guest,
+            msg.seq,
+            CommandTermination::Exited { exit_code: 0 },
+            b"",
+            b"",
+        )
+        .await;
+
+        let result = handle.wait(Duration::from_secs(5)).await.unwrap();
+        assert!(!result.stream_overflowed);
+    }
+
+    #[tokio::test]
+    async fn command_wait_timeout_cleans_operation_state() {
+        let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+        let handle = start_capture_operation(&host, "timeout").await;
+        let msg = read_guest_message(&mut guest, &mut decoder).await;
+        assert_eq!(msg.msg_type, MSG_COMMAND_START);
+        assert_eq!(operation_count(&host), 1);
+
+        let err = handle.wait(Duration::from_millis(20)).await.unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::TimedOut);
+        assert_eq!(operation_count(&host), 0);
+        assert!(is_connected(&host));
+    }
+
+    #[tokio::test]
+    async fn command_connection_close_wakes_result_and_stream() {
+        let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+        let mut handle = host
+            .command_stream(CommandStreamRequest {
+                timeout_ms: 5000,
+                command: "stream",
+                env: &[],
+                sudo: false,
+                label: "close",
+                stdout: CommandOutputPolicy::Stream {
+                    limit_bytes: 1024,
+                    chunk_limit_bytes: 16,
+                },
+                stderr: CommandOutputPolicy::Discard,
+                stream_capacity: 1,
+            })
+            .await
+            .unwrap();
+        let mut rx = handle.take_stream_receiver().unwrap();
+        let msg = read_guest_message(&mut guest, &mut decoder).await;
+        assert_eq!(msg.msg_type, MSG_COMMAND_START);
+
+        drop(guest);
+        let err = handle.wait(Duration::from_secs(5)).await.unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::ConnectionReset);
+        assert!(rx.recv().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn malformed_command_output_poisons_connection() {
+        let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+        let handle = start_capture_operation(&host, "bad-output").await;
+        let msg = read_guest_message(&mut guest, &mut decoder).await;
+        let frame = vsock_proto::encode(MSG_COMMAND_OUTPUT, msg.seq, &[0]).unwrap();
+        guest.write_all(&frame).await.unwrap();
+
+        host.wait_until_closed(Duration::from_secs(5))
+            .await
+            .unwrap();
+        let err = handle.wait(Duration::from_secs(5)).await.unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::ConnectionReset);
+    }
+
+    #[tokio::test]
+    async fn malformed_command_result_poisons_connection() {
+        let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+        let handle = start_capture_operation(&host, "bad-result").await;
+        let msg = read_guest_message(&mut guest, &mut decoder).await;
+        let frame = vsock_proto::encode(MSG_COMMAND_RESULT, msg.seq, &[0]).unwrap();
+        guest.write_all(&frame).await.unwrap();
+
+        host.wait_until_closed(Duration::from_secs(5))
+            .await
+            .unwrap();
+        let err = handle.wait(Duration::from_secs(5)).await.unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::ConnectionReset);
+    }
+
+    #[tokio::test]
+    async fn command_output_after_result_does_not_poison_or_resurrect_state() {
+        let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+        let handle = start_capture_operation(&host, "done").await;
+        let msg = read_guest_message(&mut guest, &mut decoder).await;
+        send_command_result(
+            &mut guest,
+            msg.seq,
+            CommandTermination::Exited { exit_code: 0 },
+            b"done",
+            b"",
+        )
+        .await;
+        let result = handle.wait(Duration::from_secs(5)).await.unwrap();
+        assert_eq!(
+            result.termination,
+            CommandTermination::Exited { exit_code: 0 }
+        );
+        assert_eq!(operation_count(&host), 0);
+
+        send_command_output(
+            &mut guest,
+            msg.seq,
+            1,
+            CommandOutputStream::Stdout,
+            b"late",
+            false,
+        )
+        .await;
+
+        let exec_task = tokio::spawn(async move { host.exec("echo ok", 5000, &[], false).await });
+        let exec_msg = read_guest_message(&mut guest, &mut decoder).await;
+        assert_eq!(exec_msg.msg_type, MSG_EXEC);
+        let payload = vsock_proto::encode_exec_result(0, b"ok", b"");
+        let response = vsock_proto::encode(MSG_EXEC_RESULT, exec_msg.seq, &payload).unwrap();
+        guest.write_all(&response).await.unwrap();
+        let exec_result = exec_task.await.unwrap().unwrap();
+        assert_eq!(exec_result.stdout, b"ok");
+    }
+
+    #[tokio::test]
+    async fn command_start_cancelled_before_write_does_not_poison_or_send_frame() {
+        let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+        let host = Arc::new(host);
+        let writer_guard = host.shared.writer.lock().await;
+        let task = {
+            let host = Arc::clone(&host);
+            tokio::spawn(async move { start_capture_operation(&host, "blocked").await })
+        };
+
+        tokio::time::timeout(Duration::from_secs(5), async {
+            while operation_count(&host) == 0 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .unwrap();
+        task.abort();
+        let _ = task.await;
+        assert_eq!(operation_count(&host), 0);
+        assert!(is_connected(&host));
+
+        drop(writer_guard);
+        let read_result = tokio::time::timeout(
+            Duration::from_millis(50),
+            read_guest_message(&mut guest, &mut decoder),
+        )
+        .await;
+        assert!(read_result.is_err(), "start frame should not be written");
+        assert!(is_connected(&host));
+    }
+
+    #[tokio::test]
+    async fn command_handle_drop_after_full_write_sends_no_cancel() {
+        let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+        let handle = start_capture_operation(&host, "drop-after-write").await;
+        let msg = read_guest_message(&mut guest, &mut decoder).await;
+        assert_eq!(msg.msg_type, MSG_COMMAND_START);
+        drop(handle);
+        assert_eq!(operation_count(&host), 0);
+
+        let read_result = tokio::time::timeout(
+            Duration::from_millis(50),
+            read_guest_message(&mut guest, &mut decoder),
+        )
+        .await;
+        assert!(read_result.is_err(), "drop must not send command cancel");
+        assert!(is_connected(&host));
+    }
+
+    #[tokio::test]
+    async fn command_cancel_sends_cancel_and_waits_for_cancelled_result() {
+        let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+        let handle = start_capture_operation(&host, "cancel").await;
+        let start = read_guest_message(&mut guest, &mut decoder).await;
+        assert_eq!(start.msg_type, MSG_COMMAND_START);
+
+        let cancel_task =
+            tokio::spawn(async move { handle.cancel_and_wait(Duration::from_secs(5)).await });
+        let cancel = read_guest_message(&mut guest, &mut decoder).await;
+        assert_eq!(cancel.msg_type, MSG_COMMAND_CANCEL);
+        assert_eq!(cancel.seq, start.seq);
+        vsock_proto::decode_command_cancel(&cancel.payload).unwrap();
+
+        send_command_result(
+            &mut guest,
+            start.seq,
+            CommandTermination::Cancelled,
+            b"",
+            b"",
+        )
+        .await;
+        let result = cancel_task.await.unwrap().unwrap();
+        assert_eq!(result.termination, CommandTermination::Cancelled);
+    }
+
+    #[tokio::test]
+    async fn command_cancel_result_timeout_poisons_connection() {
+        let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+        let handle = start_capture_operation(&host, "cancel-timeout").await;
+        let start = read_guest_message(&mut guest, &mut decoder).await;
+        assert_eq!(start.msg_type, MSG_COMMAND_START);
+
+        let cancel_task =
+            tokio::spawn(async move { handle.cancel_and_wait(Duration::from_millis(20)).await });
+        let cancel = read_guest_message(&mut guest, &mut decoder).await;
+        assert_eq!(cancel.msg_type, MSG_COMMAND_CANCEL);
+        assert_eq!(cancel.seq, start.seq);
+
+        let err = cancel_task.await.unwrap().unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::TimedOut);
+        host.wait_until_closed(Duration::from_secs(5))
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn command_frame_write_guard_started_drop_poisons_connection() {
+        let (host, _guest, _decoder) = setup_host_and_guest().await;
+        let state = Arc::new(AtomicU8::new(COMMAND_FRAME_WRITE_STARTED));
+        drop(CommandFrameWriteGuard::new(Arc::clone(&host.shared), state));
+        host.wait_until_closed(Duration::from_secs(5))
+            .await
+            .unwrap();
     }
 
     #[tokio::test]

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -142,11 +142,20 @@ pub struct CommandStreamRequest<'a> {
 struct CommandOperation {
     result_tx: oneshot::Sender<io::Result<CommandOperationResult>>,
     stream_tx: Option<mpsc::Sender<CommandOutputEvent>>,
+    stdout_stream: Option<CommandStreamState>,
+    stderr_stream: Option<CommandStreamState>,
     stream_overflowed: bool,
 }
 
 enum Operation {
     Command(CommandOperation),
+}
+
+struct CommandStreamState {
+    limit_bytes: usize,
+    chunk_limit_bytes: usize,
+    emitted_bytes: usize,
+    truncated: bool,
 }
 
 /// Connection lifecycle, expressed as data rather than a separate atomic flag.
@@ -577,6 +586,65 @@ fn command_output_policy_streams(policy: CommandOutputPolicy) -> bool {
     )
 }
 
+fn command_stream_state(policy: CommandOutputPolicy) -> Option<CommandStreamState> {
+    match policy {
+        CommandOutputPolicy::Stream {
+            limit_bytes,
+            chunk_limit_bytes,
+        }
+        | CommandOutputPolicy::CaptureAndStream {
+            stream_limit_bytes: limit_bytes,
+            chunk_limit_bytes,
+            ..
+        } => Some(CommandStreamState {
+            limit_bytes: limit_bytes as usize,
+            chunk_limit_bytes: chunk_limit_bytes as usize,
+            emitted_bytes: 0,
+            truncated: false,
+        }),
+        CommandOutputPolicy::Discard | CommandOutputPolicy::Capture { .. } => None,
+    }
+}
+
+fn validate_command_output(
+    operation: &mut CommandOperation,
+    output: &vsock_proto::DecodedCommandOutput<'_>,
+) -> io::Result<()> {
+    let stream = match output.stream {
+        CommandOutputStream::Stdout => &mut operation.stdout_stream,
+        CommandOutputStream::Stderr => &mut operation.stderr_stream,
+    };
+    let Some(stream) = stream else {
+        return Err(command_protocol_error(
+            "command output received for non-streaming output policy",
+        ));
+    };
+    if stream.truncated {
+        return Err(command_protocol_error(
+            "command output received after stream truncation",
+        ));
+    }
+    if output.chunk.len() > stream.chunk_limit_bytes {
+        return Err(command_protocol_error(
+            "command output chunk exceeds requested chunk limit",
+        ));
+    }
+    let emitted_bytes = stream
+        .emitted_bytes
+        .checked_add(output.chunk.len())
+        .ok_or_else(|| command_protocol_error("command output stream byte count overflow"))?;
+    if emitted_bytes > stream.limit_bytes {
+        return Err(command_protocol_error(
+            "command output exceeds requested stream limit",
+        ));
+    }
+    stream.emitted_bytes = emitted_bytes;
+    if output.truncated {
+        stream.truncated = true;
+    }
+    Ok(())
+}
+
 fn owned_captured_output(output: CommandCapturedOutput<'_>) -> CommandOwnedCapturedOutput {
     match output {
         CommandCapturedOutput::Discarded => CommandOwnedCapturedOutput::Discarded,
@@ -619,6 +687,7 @@ fn dispatch_command_output(shared: &Arc<Shared>, msg: &RawMessage) -> io::Result
     {
         let decoded =
             vsock_proto::decode_command_output(&msg.payload).map_err(command_protocol_error)?;
+        validate_command_output(operation, &decoded)?;
         if let Some(tx) = operation.stream_tx.take() {
             match tx.try_reserve_owned() {
                 Ok(permit) => {
@@ -1230,6 +1299,8 @@ impl VsockHost {
         let operation = CommandOperation {
             result_tx,
             stream_tx,
+            stdout_stream: command_stream_state(request.stdout),
+            stderr_stream: command_stream_state(request.stderr),
             stream_overflowed: false,
         };
 
@@ -2366,6 +2437,176 @@ mod tests {
 
         let result = handle.wait(Duration::from_secs(5)).await.unwrap();
         assert!(result.stream_overflowed);
+    }
+
+    #[tokio::test]
+    async fn command_output_for_non_streamed_side_poisons_connection() {
+        let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+        let handle = host
+            .command_stream(CommandStreamRequest {
+                timeout_ms: 5000,
+                command: "stream",
+                env: &[],
+                sudo: false,
+                label: "stream-side",
+                stdout: CommandOutputPolicy::Discard,
+                stderr: CommandOutputPolicy::Stream {
+                    limit_bytes: 1024,
+                    chunk_limit_bytes: 16,
+                },
+                stream_queue_capacity: Some(1),
+            })
+            .await
+            .unwrap();
+
+        let msg = read_guest_message(&mut guest, &mut decoder).await;
+        send_command_output(
+            &mut guest,
+            msg.seq,
+            1,
+            CommandOutputStream::Stdout,
+            b"unexpected",
+            false,
+        )
+        .await;
+
+        host.wait_until_closed(Duration::from_secs(5))
+            .await
+            .unwrap();
+        let err = handle.wait(Duration::from_secs(5)).await.unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::ConnectionReset);
+    }
+
+    #[tokio::test]
+    async fn command_output_over_requested_chunk_limit_poisons_connection() {
+        let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+        let handle = host
+            .command_stream(CommandStreamRequest {
+                timeout_ms: 5000,
+                command: "stream",
+                env: &[],
+                sudo: false,
+                label: "stream-limits",
+                stdout: CommandOutputPolicy::Stream {
+                    limit_bytes: 4,
+                    chunk_limit_bytes: 3,
+                },
+                stderr: CommandOutputPolicy::Discard,
+                stream_queue_capacity: Some(4),
+            })
+            .await
+            .unwrap();
+
+        let msg = read_guest_message(&mut guest, &mut decoder).await;
+        send_command_output(
+            &mut guest,
+            msg.seq,
+            1,
+            CommandOutputStream::Stdout,
+            b"abcd",
+            false,
+        )
+        .await;
+
+        host.wait_until_closed(Duration::from_secs(5))
+            .await
+            .unwrap();
+        let err = handle.wait(Duration::from_secs(5)).await.unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::ConnectionReset);
+    }
+
+    #[tokio::test]
+    async fn command_output_over_requested_stream_limit_poisons_connection() {
+        let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+        let handle = host
+            .command_stream(CommandStreamRequest {
+                timeout_ms: 5000,
+                command: "stream",
+                env: &[],
+                sudo: false,
+                label: "stream-total-limit",
+                stdout: CommandOutputPolicy::Stream {
+                    limit_bytes: 4,
+                    chunk_limit_bytes: 3,
+                },
+                stderr: CommandOutputPolicy::Discard,
+                stream_queue_capacity: Some(4),
+            })
+            .await
+            .unwrap();
+
+        let msg = read_guest_message(&mut guest, &mut decoder).await;
+        send_command_output(
+            &mut guest,
+            msg.seq,
+            1,
+            CommandOutputStream::Stdout,
+            b"abc",
+            false,
+        )
+        .await;
+        send_command_output(
+            &mut guest,
+            msg.seq,
+            2,
+            CommandOutputStream::Stdout,
+            b"de",
+            false,
+        )
+        .await;
+
+        host.wait_until_closed(Duration::from_secs(5))
+            .await
+            .unwrap();
+        let err = handle.wait(Duration::from_secs(5)).await.unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::ConnectionReset);
+    }
+
+    #[tokio::test]
+    async fn command_output_after_truncation_poisons_connection() {
+        let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+        let handle = host
+            .command_stream(CommandStreamRequest {
+                timeout_ms: 5000,
+                command: "stream",
+                env: &[],
+                sudo: false,
+                label: "stream-truncated",
+                stdout: CommandOutputPolicy::Stream {
+                    limit_bytes: 4,
+                    chunk_limit_bytes: 4,
+                },
+                stderr: CommandOutputPolicy::Discard,
+                stream_queue_capacity: Some(4),
+            })
+            .await
+            .unwrap();
+
+        let msg = read_guest_message(&mut guest, &mut decoder).await;
+        send_command_output(
+            &mut guest,
+            msg.seq,
+            1,
+            CommandOutputStream::Stdout,
+            b"",
+            true,
+        )
+        .await;
+        send_command_output(
+            &mut guest,
+            msg.seq,
+            2,
+            CommandOutputStream::Stdout,
+            b"late",
+            false,
+        )
+        .await;
+
+        host.wait_until_closed(Duration::from_secs(5))
+            .await
+            .unwrap();
+        let err = handle.wait(Duration::from_secs(5)).await.unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::ConnectionReset);
     }
 
     #[tokio::test]

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -146,6 +146,7 @@ struct CommandOperation {
     stderr_capture: CommandCaptureState,
     stdout_stream: Option<CommandStreamState>,
     stderr_stream: Option<CommandStreamState>,
+    expected_output_seq: u32,
     stream_overflowed: bool,
 }
 
@@ -632,6 +633,12 @@ fn validate_command_output(
     operation: &mut CommandOperation,
     output: &vsock_proto::DecodedCommandOutput<'_>,
 ) -> io::Result<()> {
+    if output.output_seq != operation.expected_output_seq {
+        return Err(command_protocol_error(format!(
+            "command output seq mismatch: {} != {}",
+            output.output_seq, operation.expected_output_seq
+        )));
+    }
     let stream = match output.stream {
         CommandOutputStream::Stdout => &mut operation.stdout_stream,
         CommandOutputStream::Stderr => &mut operation.stderr_stream,
@@ -664,6 +671,7 @@ fn validate_command_output(
     if output.truncated {
         stream.truncated = true;
     }
+    operation.expected_output_seq = operation.expected_output_seq.wrapping_add(1);
     Ok(())
 }
 
@@ -794,7 +802,7 @@ fn dispatch_command_result(shared: &Arc<Shared>, msg: &RawMessage) -> io::Result
     Ok(())
 }
 
-fn dispatch_command_error(shared: &Arc<Shared>, msg: &RawMessage) -> bool {
+fn dispatch_command_error(shared: &Arc<Shared>, msg: &RawMessage) -> io::Result<bool> {
     let operation = {
         let mut guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
         match &mut *guard {
@@ -806,12 +814,12 @@ fn dispatch_command_error(shared: &Arc<Shared>, msg: &RawMessage) -> bool {
     if let Some(Operation::Command(operation)) = operation {
         let err = vsock_proto::decode_error(&msg.payload)
             .map(|message| io::Error::other(message.to_string()))
-            .unwrap_or_else(command_protocol_error);
+            .map_err(command_protocol_error)?;
         let _ = operation.result_tx.send(Err(err));
-        return true;
+        return Ok(true);
     }
 
-    false
+    Ok(false)
 }
 
 /// Host-side vsock endpoint.
@@ -873,6 +881,22 @@ async fn reader_loop(
             Err(_) => break,
         };
         for msg in messages {
+            if msg.msg_type == MSG_ERROR {
+                match dispatch_command_error(&shared, &msg) {
+                    Ok(true) => {
+                        // Command-operation errors are delivered through the operation
+                        // result channel. Legacy request errors fall through to the
+                        // pending-request dispatch below.
+                        continue;
+                    }
+                    Ok(false) => {}
+                    Err(_) => {
+                        shared.poison_connection();
+                        return;
+                    }
+                }
+            }
+
             if msg.msg_type == MSG_COMMAND_OUTPUT {
                 if dispatch_command_output(&shared, &msg).is_err() {
                     shared.poison_connection();
@@ -883,11 +907,6 @@ async fn reader_loop(
                     shared.poison_connection();
                     return;
                 }
-            } else if msg.msg_type == MSG_ERROR && dispatch_command_error(&shared, &msg) {
-                // Command-operation errors are delivered through the operation
-                // result channel. Legacy request errors fall through to the
-                // pending-request dispatch below.
-                continue;
             } else if msg.msg_type == MSG_STDOUT_CHUNK && msg.seq == 0 {
                 if let Ok((pid, data)) = vsock_proto::decode_stdout_chunk(&msg.payload) {
                     let sender = {
@@ -1365,6 +1384,7 @@ impl VsockHost {
             stderr_capture: command_capture_state(request.stderr),
             stdout_stream: command_stream_state(request.stdout),
             stderr_stream: command_stream_state(request.stderr),
+            expected_output_seq: 0,
             stream_overflowed: false,
         };
 
@@ -2378,7 +2398,7 @@ mod tests {
         send_command_output(
             &mut guest,
             msg.seq,
-            1,
+            0,
             CommandOutputStream::Stderr,
             b"default-queued",
             false,
@@ -2600,7 +2620,7 @@ mod tests {
         send_command_output(
             &mut guest,
             msg.seq,
-            1,
+            0,
             CommandOutputStream::Stdout,
             b"out",
             false,
@@ -2609,7 +2629,7 @@ mod tests {
         send_command_output(
             &mut guest,
             msg.seq,
-            2,
+            1,
             CommandOutputStream::Stderr,
             b"err",
             true,
@@ -2618,13 +2638,13 @@ mod tests {
 
         let out = rx.recv().await.unwrap();
         assert_eq!(out.stream, CommandOutputStream::Stdout);
-        assert_eq!(out.output_seq, 1);
+        assert_eq!(out.output_seq, 0);
         assert_eq!(out.chunk, b"out");
         assert!(!out.truncated);
 
         let err = rx.recv().await.unwrap();
         assert_eq!(err.stream, CommandOutputStream::Stderr);
-        assert_eq!(err.output_seq, 2);
+        assert_eq!(err.output_seq, 1);
         assert_eq!(err.chunk, b"err");
         assert!(err.truncated);
 
@@ -2664,7 +2684,7 @@ mod tests {
         send_command_output(
             &mut guest,
             msg.seq,
-            1,
+            0,
             CommandOutputStream::Stdout,
             b"first",
             false,
@@ -2673,7 +2693,7 @@ mod tests {
         send_command_output(
             &mut guest,
             msg.seq,
-            2,
+            1,
             CommandOutputStream::Stdout,
             b"second",
             false,
@@ -2687,7 +2707,7 @@ mod tests {
         .await;
 
         let first = rx.recv().await.unwrap();
-        assert_eq!(first.output_seq, 1);
+        assert_eq!(first.output_seq, 0);
         assert_eq!(first.chunk, b"first");
         assert!(rx.recv().await.is_none());
 
@@ -2719,9 +2739,47 @@ mod tests {
         send_command_output(
             &mut guest,
             msg.seq,
-            1,
+            0,
             CommandOutputStream::Stdout,
             b"unexpected",
+            false,
+        )
+        .await;
+
+        host.wait_until_closed(Duration::from_secs(5))
+            .await
+            .unwrap();
+        let err = handle.wait(Duration::from_secs(5)).await.unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::ConnectionReset);
+    }
+
+    #[tokio::test]
+    async fn command_output_seq_gap_poisons_connection() {
+        let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+        let handle = host
+            .command_stream(CommandStreamRequest {
+                timeout_ms: 5000,
+                command: "stream",
+                env: &[],
+                sudo: false,
+                label: "stream-seq",
+                stdout: CommandOutputPolicy::Stream {
+                    limit_bytes: 1024,
+                    chunk_limit_bytes: 16,
+                },
+                stderr: CommandOutputPolicy::Discard,
+                stream_queue_capacity: Some(1),
+            })
+            .await
+            .unwrap();
+
+        let msg = read_guest_message(&mut guest, &mut decoder).await;
+        send_command_output(
+            &mut guest,
+            msg.seq,
+            1,
+            CommandOutputStream::Stdout,
+            b"gap",
             false,
         )
         .await;
@@ -2757,7 +2815,7 @@ mod tests {
         send_command_output(
             &mut guest,
             msg.seq,
-            1,
+            0,
             CommandOutputStream::Stdout,
             b"abcd",
             false,
@@ -2795,7 +2853,7 @@ mod tests {
         send_command_output(
             &mut guest,
             msg.seq,
-            1,
+            0,
             CommandOutputStream::Stdout,
             b"abc",
             false,
@@ -2804,7 +2862,7 @@ mod tests {
         send_command_output(
             &mut guest,
             msg.seq,
-            2,
+            1,
             CommandOutputStream::Stdout,
             b"de",
             false,
@@ -2842,7 +2900,7 @@ mod tests {
         send_command_output(
             &mut guest,
             msg.seq,
-            1,
+            0,
             CommandOutputStream::Stdout,
             b"",
             true,
@@ -2851,7 +2909,7 @@ mod tests {
         send_command_output(
             &mut guest,
             msg.seq,
-            2,
+            1,
             CommandOutputStream::Stdout,
             b"late",
             false,
@@ -2890,7 +2948,7 @@ mod tests {
         send_command_output(
             &mut guest,
             msg.seq,
-            1,
+            0,
             CommandOutputStream::Stdout,
             b"ignored",
             false,
@@ -2939,6 +2997,23 @@ mod tests {
         assert_eq!(operation_count(&host), 0);
 
         assert_connection_accepts_legacy_exec(&host, &mut guest, &mut decoder).await;
+    }
+
+    #[tokio::test]
+    async fn malformed_command_error_poisons_connection() {
+        let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+        let handle = start_capture_operation(&host, "bad-error").await;
+        let msg = read_guest_message(&mut guest, &mut decoder).await;
+        assert_eq!(msg.msg_type, MSG_COMMAND_START);
+
+        let frame = vsock_proto::encode(MSG_ERROR, msg.seq, &[0]).unwrap();
+        guest.write_all(&frame).await.unwrap();
+
+        host.wait_until_closed(Duration::from_secs(5))
+            .await
+            .unwrap();
+        let err = handle.wait(Duration::from_secs(5)).await.unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::ConnectionReset);
     }
 
     #[tokio::test]

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -653,6 +653,11 @@ fn validate_command_output(
             "command output received after stream truncation",
         ));
     }
+    if output.chunk.is_empty() && !output.truncated {
+        return Err(command_protocol_error(
+            "command output empty chunk must mark stream truncation",
+        ));
+    }
     if output.chunk.len() > stream.chunk_limit_bytes {
         return Err(command_protocol_error(
             "command output chunk exceeds requested chunk limit",
@@ -2835,6 +2840,44 @@ mod tests {
         assert!(event.truncated);
         let result = handle.wait(Duration::from_secs(5)).await.unwrap();
         assert!(!result.stream_overflowed);
+    }
+
+    #[tokio::test]
+    async fn command_output_empty_non_truncated_poisons_connection() {
+        let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+        let handle = host
+            .command_stream(CommandStreamRequest {
+                timeout_ms: 5000,
+                command: "stream",
+                env: &[],
+                sudo: false,
+                label: "stream-empty",
+                stdout: CommandOutputPolicy::Stream {
+                    limit_bytes: 1024,
+                    chunk_limit_bytes: 16,
+                },
+                stderr: CommandOutputPolicy::Discard,
+                stream_queue_capacity: Some(1),
+            })
+            .await
+            .unwrap();
+
+        let msg = read_guest_message(&mut guest, &mut decoder).await;
+        send_command_output(
+            &mut guest,
+            msg.seq,
+            0,
+            CommandOutputStream::Stdout,
+            b"",
+            false,
+        )
+        .await;
+
+        host.wait_until_closed(Duration::from_secs(5))
+            .await
+            .unwrap();
+        let err = handle.wait(Duration::from_secs(5)).await.unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::ConnectionReset);
     }
 
     #[tokio::test]

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -1701,6 +1701,34 @@ mod tests {
         stream.write_all(&frame).await.unwrap();
     }
 
+    async fn wait_for_operation_count(host: &VsockHost, expected: usize) {
+        tokio::time::timeout(Duration::from_secs(5), async {
+            while operation_count(host) != expected {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .unwrap();
+    }
+
+    async fn assert_connection_accepts_legacy_exec(
+        host: &Arc<VsockHost>,
+        guest: &mut UnixStream,
+        decoder: &mut Decoder,
+    ) {
+        let exec_task = {
+            let host = Arc::clone(host);
+            tokio::spawn(async move { host.exec("echo ok", 5000, &[], false).await })
+        };
+        let msg = read_guest_message(guest, decoder).await;
+        assert_eq!(msg.msg_type, MSG_EXEC);
+        let payload = vsock_proto::encode_exec_result(0, b"ok", b"");
+        let response = vsock_proto::encode(MSG_EXEC_RESULT, msg.seq, &payload).unwrap();
+        guest.write_all(&response).await.unwrap();
+        let exec_result = exec_task.await.unwrap().unwrap();
+        assert_eq!(exec_result.stdout, b"ok");
+    }
+
     #[tokio::test]
     async fn wait_for_connection_removes_listener_socket_on_abort() {
         let unique = std::time::SystemTime::now()
@@ -1801,6 +1829,66 @@ mod tests {
             }
         );
         assert_eq!(operation_count(&host), 0);
+    }
+
+    #[tokio::test]
+    async fn command_stream_rejects_zero_capacity_without_sending_frame() {
+        let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+        let host = Arc::new(host);
+
+        let err = match host
+            .command_stream(CommandStreamRequest {
+                timeout_ms: 5000,
+                command: "stream",
+                env: &[],
+                sudo: false,
+                label: "zero-capacity",
+                stdout: CommandOutputPolicy::Stream {
+                    limit_bytes: 1024,
+                    chunk_limit_bytes: 16,
+                },
+                stderr: CommandOutputPolicy::Discard,
+                stream_capacity: 0,
+            })
+            .await
+        {
+            Ok(_) => panic!("zero stream capacity should be rejected"),
+            Err(err) => err,
+        };
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+        assert_eq!(operation_count(&host), 0);
+
+        assert_connection_accepts_legacy_exec(&host, &mut guest, &mut decoder).await;
+    }
+
+    #[tokio::test]
+    async fn command_start_encode_error_does_not_register_or_send_frame() {
+        let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+        let host = Arc::new(host);
+
+        let err = match host
+            .start_command_operation(CommandOperationRequest {
+                timeout_ms: 5000,
+                command: "stream",
+                env: &[],
+                sudo: false,
+                stdout: CommandOutputPolicy::Stream {
+                    limit_bytes: 1024,
+                    chunk_limit_bytes: 0,
+                },
+                stderr: CommandOutputPolicy::Discard,
+                label: "bad-policy",
+                stream_capacity: Some(1),
+            })
+            .await
+        {
+            Ok(_) => panic!("invalid command output policy should be rejected"),
+            Err(err) => err,
+        };
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+        assert_eq!(operation_count(&host), 0);
+
+        assert_connection_accepts_legacy_exec(&host, &mut guest, &mut decoder).await;
     }
 
     #[tokio::test]
@@ -2080,6 +2168,34 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn command_start_after_connection_close_returns_connection_reset() {
+        let (host, guest, _decoder) = setup_host_and_guest().await;
+        drop(guest);
+        host.wait_until_closed(Duration::from_secs(5))
+            .await
+            .unwrap();
+
+        let err = match host
+            .start_command_operation(CommandOperationRequest {
+                timeout_ms: 5000,
+                command: "echo ok",
+                env: &[],
+                sudo: false,
+                stdout: CommandOutputPolicy::Capture { limit_bytes: 1024 },
+                stderr: CommandOutputPolicy::Capture { limit_bytes: 1024 },
+                label: "closed",
+                stream_capacity: None,
+            })
+            .await
+        {
+            Ok(_) => panic!("command start after connection close should fail"),
+            Err(err) => err,
+        };
+        assert_eq!(err.kind(), io::ErrorKind::ConnectionReset);
+        assert_eq!(operation_count(&host), 0);
+    }
+
+    #[tokio::test]
     async fn host_drop_closes_active_command_result_and_stream() {
         let (host, mut guest, mut decoder) = setup_host_and_guest().await;
         let mut handle = host
@@ -2268,6 +2384,65 @@ mod tests {
         .await;
         let result = cancel_task.await.unwrap().unwrap();
         assert_eq!(result.termination, CommandTermination::Cancelled);
+    }
+
+    #[tokio::test]
+    async fn command_cancel_after_terminal_result_returns_result_without_cancel_frame() {
+        let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+        let host = Arc::new(host);
+        let handle = start_capture_operation(&host, "already-done").await;
+        let start = read_guest_message(&mut guest, &mut decoder).await;
+        assert_eq!(start.msg_type, MSG_COMMAND_START);
+        send_command_result(
+            &mut guest,
+            start.seq,
+            CommandTermination::Exited { exit_code: 0 },
+            b"done",
+            b"",
+        )
+        .await;
+        wait_for_operation_count(&host, 0).await;
+
+        let result = handle
+            .cancel_and_wait(Duration::from_secs(5))
+            .await
+            .unwrap();
+        assert_eq!(
+            result.termination,
+            CommandTermination::Exited { exit_code: 0 }
+        );
+
+        assert_connection_accepts_legacy_exec(&host, &mut guest, &mut decoder).await;
+    }
+
+    #[tokio::test]
+    async fn command_cancel_non_cancelled_terminal_result_cleans_operation_without_poisoning() {
+        let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+        let host = Arc::new(host);
+        let handle = start_capture_operation(&host, "cancel-race").await;
+        let start = read_guest_message(&mut guest, &mut decoder).await;
+        assert_eq!(start.msg_type, MSG_COMMAND_START);
+
+        let cancel_task =
+            tokio::spawn(async move { handle.cancel_and_wait(Duration::from_secs(5)).await });
+        let cancel = read_guest_message(&mut guest, &mut decoder).await;
+        assert_eq!(cancel.msg_type, MSG_COMMAND_CANCEL);
+        assert_eq!(cancel.seq, start.seq);
+
+        send_command_result(
+            &mut guest,
+            start.seq,
+            CommandTermination::Exited { exit_code: 0 },
+            b"",
+            b"",
+        )
+        .await;
+        let err = cancel_task.await.unwrap().unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::Other);
+        assert_eq!(operation_count(&host), 0);
+        assert!(is_connected(&host));
+
+        assert_connection_accepts_legacy_exec(&host, &mut guest, &mut decoder).await;
     }
 
     #[tokio::test]

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -106,6 +106,8 @@ pub struct CommandOperationRequest<'a> {
     ///
     /// `None` uses the default queue capacity when either output policy
     /// streams, and creates no queue when neither output policy streams.
+    /// `Some` is valid only when stdout or stderr streams; zero and oversized
+    /// capacities are rejected.
     pub stream_queue_capacity: Option<usize>,
 }
 
@@ -130,8 +132,10 @@ pub struct CommandStreamRequest<'a> {
     pub label: &'a str,
     pub stdout: CommandOutputPolicy,
     pub stderr: CommandOutputPolicy,
-    /// Optional host-side output event queue capacity override. `None` uses the
-    /// default queue capacity.
+    /// Optional host-side output event queue capacity override.
+    ///
+    /// `None` uses the default queue capacity. Zero and oversized capacities
+    /// are rejected.
     pub stream_queue_capacity: Option<usize>,
 }
 

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -882,11 +882,11 @@ async fn reader_loop(
         };
         for msg in messages {
             if msg.msg_type == MSG_ERROR {
+                // Intercept active command-operation errors before the legacy
+                // pending-request dispatch. If no command operation owns this
+                // seq, the error falls through as a normal request response.
                 match dispatch_command_error(&shared, &msg) {
                     Ok(true) => {
-                        // Command-operation errors are delivered through the operation
-                        // result channel. Legacy request errors fall through to the
-                        // pending-request dispatch below.
                         continue;
                     }
                     Ok(false) => {}
@@ -2789,6 +2789,52 @@ mod tests {
             .unwrap();
         let err = handle.wait(Duration::from_secs(5)).await.unwrap_err();
         assert_eq!(err.kind(), io::ErrorKind::ConnectionReset);
+    }
+
+    #[tokio::test]
+    async fn command_output_zero_stream_limit_accepts_empty_truncation_marker() {
+        let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+        let mut handle = host
+            .command_stream(CommandStreamRequest {
+                timeout_ms: 5000,
+                command: "stream",
+                env: &[],
+                sudo: false,
+                label: "stream-zero-limit",
+                stdout: CommandOutputPolicy::Stream {
+                    limit_bytes: 0,
+                    chunk_limit_bytes: 16,
+                },
+                stderr: CommandOutputPolicy::Discard,
+                stream_queue_capacity: Some(1),
+            })
+            .await
+            .unwrap();
+        let mut rx = handle.take_stream_receiver().unwrap();
+
+        let msg = read_guest_message(&mut guest, &mut decoder).await;
+        send_command_output(
+            &mut guest,
+            msg.seq,
+            0,
+            CommandOutputStream::Stdout,
+            b"",
+            true,
+        )
+        .await;
+        send_discarded_command_result(
+            &mut guest,
+            msg.seq,
+            CommandTermination::Exited { exit_code: 0 },
+        )
+        .await;
+
+        let event = rx.recv().await.unwrap();
+        assert_eq!(event.output_seq, 0);
+        assert_eq!(event.chunk, b"");
+        assert!(event.truncated);
+        let result = handle.wait(Duration::from_secs(5)).await.unwrap();
+        assert!(!result.stream_overflowed);
     }
 
     #[tokio::test]

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -3462,6 +3462,7 @@ mod tests {
     #[tokio::test]
     async fn test_wait_for_exit_connection_closed() {
         let (host_stream, mut guest) = make_pair();
+        let (close_tx, close_rx) = oneshot::channel();
 
         tokio::spawn(async move {
             let mut decoder = Decoder::new();
@@ -3478,22 +3479,26 @@ mod tests {
             let resp = vsock_proto::encode(MSG_SPAWN_WATCH_RESULT, msgs[0].seq, &payload).unwrap();
             guest.write_all(&resp).await.unwrap();
 
-            // Small delay then close the connection WITHOUT sending process_exit.
-            tokio::time::sleep(Duration::from_millis(50)).await;
+            let _ = close_rx.await;
             drop(guest);
         });
 
-        let host = host_from_stream(host_stream).await.unwrap();
+        let host = Arc::new(host_from_stream(host_stream).await.unwrap());
         let (pid, _stdout_rx) = host
             .spawn_watch("long-running", 0, &[], false, false, None)
             .await
             .unwrap();
         assert_eq!(pid, 77);
 
-        let err = host
-            .wait_for_exit(77, Duration::from_secs(5))
-            .await
-            .unwrap_err();
+        let host_for_wait = Arc::clone(&host);
+        let wait_task = tokio::spawn(async move {
+            host_for_wait
+                .wait_for_exit(77, Duration::from_secs(5))
+                .await
+        });
+        close_tx.send(()).unwrap();
+
+        let err = wait_task.await.unwrap().unwrap_err();
         assert_eq!(err.kind(), io::ErrorKind::ConnectionReset);
     }
 
@@ -3642,6 +3647,7 @@ mod tests {
     #[tokio::test]
     async fn test_concurrent_exec_and_wait_exit() {
         let (host_stream, mut guest) = make_pair();
+        let (send_exit, exit_after_exec) = oneshot::channel();
 
         tokio::spawn(async move {
             let mut decoder = Decoder::new();
@@ -3670,8 +3676,7 @@ mod tests {
             let exec_resp = vsock_proto::encode(MSG_EXEC_RESULT, exec_seq, &exec_payload).unwrap();
             guest.write_all(&exec_resp).await.unwrap();
 
-            // Small delay then send process_exit
-            tokio::time::sleep(Duration::from_millis(50)).await;
+            let _ = exit_after_exec.await;
             let exit_payload = vsock_proto::encode_process_exit(50, 42, b"exited", b"");
             let exit_msg = vsock_proto::encode(MSG_PROCESS_EXIT, 0, &exit_payload).unwrap();
             guest.write_all(&exit_msg).await.unwrap();
@@ -3700,6 +3705,8 @@ mod tests {
             .unwrap();
         assert_eq!(exec_result.exit_code, 0);
         assert_eq!(exec_result.stdout, b"concurrent");
+
+        send_exit.send(()).unwrap();
 
         // wait_for_exit should also resolve
         let exit_event = wait_task.await.unwrap().unwrap();

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -2636,6 +2636,26 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn malformed_command_frames_after_handle_drop_are_ignored() {
+        let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+        let host = Arc::new(host);
+        let handle = start_capture_operation(&host, "abandoned").await;
+        let msg = read_guest_message(&mut guest, &mut decoder).await;
+        assert_eq!(msg.msg_type, MSG_COMMAND_START);
+        assert_eq!(operation_count(&host), 1);
+
+        drop(handle);
+        wait_for_operation_count(&host, 0).await;
+
+        let output_frame = vsock_proto::encode(MSG_COMMAND_OUTPUT, msg.seq, &[0]).unwrap();
+        guest.write_all(&output_frame).await.unwrap();
+        let result_frame = vsock_proto::encode(MSG_COMMAND_RESULT, msg.seq, &[0]).unwrap();
+        guest.write_all(&result_frame).await.unwrap();
+
+        assert_connection_accepts_legacy_exec(&host, &mut guest, &mut decoder).await;
+    }
+
+    #[tokio::test]
     async fn duplicate_command_result_after_completion_is_ignored() {
         let (host, mut guest, mut decoder) = setup_host_and_guest().await;
         let host = Arc::new(host);

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -2257,7 +2257,7 @@ mod tests {
                     limit_bytes: 1024,
                     chunk_limit_bytes: 16,
                 },
-                stream_queue_capacity: Some(4),
+                stream_queue_capacity: None,
             })
             .await
             .unwrap();

--- a/crates/vsock-proto/src/lib.rs
+++ b/crates/vsock-proto/src/lib.rs
@@ -626,10 +626,10 @@ pub fn encode_command_start(
         payload_len = checked_payload_len_add(payload_len, key_bytes.len())?;
         payload_len = checked_payload_len_add(payload_len, val_bytes.len())?;
     }
-    payload_len = checked_payload_len_add(payload_len, stdout_policy_len)?;
-    payload_len = checked_payload_len_add(payload_len, stderr_policy_len)?;
     payload_len = checked_payload_len_add(payload_len, 2)?;
     payload_len = checked_payload_len_add(payload_len, label_bytes.len())?;
+    payload_len = checked_payload_len_add(payload_len, stdout_policy_len)?;
+    payload_len = checked_payload_len_add(payload_len, stderr_policy_len)?;
     ensure_payload_fits_message(payload_len)?;
 
     let mut p = Vec::with_capacity(payload_len);
@@ -1806,6 +1806,38 @@ mod tests {
                 stdout: CommandOutputPolicy::Discard,
                 stderr: CommandOutputPolicy::Discard,
             }
+        );
+    }
+
+    #[test]
+    fn command_start_wire_layout_places_label_before_output_policies() {
+        let payload = encode_command_start(
+            5000,
+            "cmd",
+            &[],
+            false,
+            "abc",
+            CommandOutputPolicy::Discard,
+            CommandOutputPolicy::Capture { limit_bytes: 7 },
+        )
+        .unwrap();
+
+        let label_len_offset = 4 + 1 + 4 + "cmd".len() + 4;
+        assert_eq!(
+            &payload[label_len_offset..],
+            &[
+                0,
+                3,
+                b'a',
+                b'b',
+                b'c',
+                COMMAND_OUTPUT_POLICY_DISCARD,
+                COMMAND_OUTPUT_POLICY_CAPTURE,
+                0,
+                0,
+                0,
+                7,
+            ]
         );
     }
 

--- a/crates/vsock-proto/src/lib.rs
+++ b/crates/vsock-proto/src/lib.rs
@@ -2302,6 +2302,25 @@ mod tests {
             CommandOutputPolicy::Discard,
         )
         .unwrap();
+        let label_len_offset = 4 + 1 + 4 + "cmd".len() + 4;
+        payload.truncate(label_len_offset + 1);
+        assert!(matches!(
+            decode_command_start(&payload),
+            Err(ProtocolError::InvalidPayload(
+                "command start label_len truncated"
+            ))
+        ));
+
+        let mut payload = encode_command_start(
+            1,
+            "cmd",
+            &[],
+            false,
+            "ok",
+            CommandOutputPolicy::Discard,
+            CommandOutputPolicy::Discard,
+        )
+        .unwrap();
         let label_start = 4 + 1 + 4 + "cmd".len() + 4 + 2;
         payload.truncate(label_start + 1);
         assert!(matches!(

--- a/crates/vsock-proto/src/lib.rs
+++ b/crates/vsock-proto/src/lib.rs
@@ -36,6 +36,8 @@
 //!
 //! Command operation messages are request-scoped; host/guest dispatch layers
 //! must use a non-zero sequence number for start/output/result/cancel.
+//! `command_output.output_seq` is per command operation and starts at 0,
+//! incrementing by 1 for each output frame across stdout and stderr.
 
 /// Header size (4-byte length prefix).
 pub const HEADER_SIZE: usize = 4;
@@ -655,6 +657,9 @@ pub fn encode_command_start(
 }
 
 /// Encode command_output payload: `[1B stream][4B output_seq][1B flags][4B chunk_len][chunk]`.
+///
+/// `output_seq` starts at 0 for each command operation and increments by 1
+/// for every output frame across stdout and stderr.
 pub fn encode_command_output(
     stream: CommandOutputStream,
     output_seq: u32,

--- a/crates/vsock-proto/src/lib.rs
+++ b/crates/vsock-proto/src/lib.rs
@@ -28,7 +28,7 @@
 //! | 0x0A | H→G       | shutdown          | (empty) |
 //! | 0x0B | G→H       | shutdown_ack      | (empty) |
 //! | 0x0C | G→H       | stdout_chunk      | `[4B pid][data]` |
-//! | 0x0D | H→G       | command_start     | `[4B timeout_ms][1B flags][4B cmd_len][command][4B env_count]... [stdout_policy][stderr_policy][2B label_len][label]` |
+//! | 0x0D | H→G       | command_start     | `[4B timeout_ms][1B flags][4B cmd_len][command][4B env_count]... [2B label_len][label][stdout_policy][stderr_policy]` |
 //! | 0x0E | G→H       | command_output    | `[1B stream][4B output_seq][1B flags][4B chunk_len][chunk]` |
 //! | 0x0F | G→H       | command_result    | `[1B termination]...[4B duration_ms][stdout][stderr][2B diagnostic_len][diagnostic]` |
 //! | 0x10 | H→G       | command_cancel    | (empty) |
@@ -165,9 +165,9 @@ pub struct DecodedCommandStart<'a> {
     pub command: &'a str,
     pub env: Vec<(&'a str, &'a str)>,
     pub sudo: bool,
+    pub label: &'a str,
     pub stdout: CommandOutputPolicy,
     pub stderr: CommandOutputPolicy,
-    pub label: &'a str,
 }
 
 /// Decoded command output payload.
@@ -592,15 +592,15 @@ fn append_command_output_policy(p: &mut Vec<u8>, policy: CommandOutputPolicy) {
 /// Encode command_start payload.
 ///
 /// Wire format:
-/// `[4B timeout_ms][1B flags][4B cmd_len][command][4B env_count]... [stdout_policy][stderr_policy][2B label_len][label]`.
+/// `[4B timeout_ms][1B flags][4B cmd_len][command][4B env_count]... [2B label_len][label][stdout_policy][stderr_policy]`.
 pub fn encode_command_start(
     timeout_ms: u32,
     command: &str,
     env: &[(&str, &str)],
     sudo: bool,
+    label: &str,
     stdout: CommandOutputPolicy,
     stderr: CommandOutputPolicy,
-    label: &str,
 ) -> Result<Vec<u8>, ProtocolError> {
     let cmd = command.as_bytes();
     let label_bytes = label.as_bytes();
@@ -646,10 +646,10 @@ pub fn encode_command_start(
         p.extend_from_slice(&(val_bytes.len() as u32).to_be_bytes());
         p.extend_from_slice(val_bytes);
     }
-    append_command_output_policy(&mut p, stdout);
-    append_command_output_policy(&mut p, stderr);
     p.extend_from_slice(&label_len.to_be_bytes());
     p.extend_from_slice(label_bytes);
+    append_command_output_policy(&mut p, stdout);
+    append_command_output_policy(&mut p, stderr);
     debug_assert_eq!(p.len(), payload_len);
     Ok(p)
 }
@@ -1195,8 +1195,6 @@ pub fn decode_command_start(payload: &[u8]) -> Result<DecodedCommandStart<'_>, P
         )?;
         env.push((key, val));
     }
-    let stdout = decode_command_output_policy(payload, &mut offset)?;
-    let stderr = decode_command_output_policy(payload, &mut offset)?;
     let label_len = read_u16(payload, &mut offset, "command start label_len truncated")? as usize;
     let label = read_str(
         payload,
@@ -1205,15 +1203,17 @@ pub fn decode_command_start(payload: &[u8]) -> Result<DecodedCommandStart<'_>, P
         "command start label truncated",
         "invalid UTF-8 in label",
     )?;
+    let stdout = decode_command_output_policy(payload, &mut offset)?;
+    let stderr = decode_command_output_policy(payload, &mut offset)?;
     expect_consumed(payload, offset, "command start trailing bytes")?;
     Ok(DecodedCommandStart {
         timeout_ms,
         command,
         env,
         sudo: (flags & COMMAND_FLAG_SUDO) != 0,
+        label,
         stdout,
         stderr,
-        label,
     })
 }
 
@@ -1788,9 +1788,9 @@ mod tests {
             "echo ready",
             &[],
             false,
-            CommandOutputPolicy::Discard,
-            CommandOutputPolicy::Discard,
             "",
+            CommandOutputPolicy::Discard,
+            CommandOutputPolicy::Discard,
         )
         .unwrap();
 
@@ -1802,9 +1802,9 @@ mod tests {
                 command: "echo ready",
                 env: Vec::new(),
                 sudo: false,
+                label: "",
                 stdout: CommandOutputPolicy::Discard,
                 stderr: CommandOutputPolicy::Discard,
-                label: "",
             }
         );
     }
@@ -1816,9 +1816,9 @@ mod tests {
             "printenv",
             &[("PATH", "/usr/bin"), ("HOME", "/home/user")],
             true,
+            "setup",
             CommandOutputPolicy::Capture { limit_bytes: 0 },
             CommandOutputPolicy::Capture { limit_bytes: 4096 },
-            "setup",
         )
         .unwrap();
 
@@ -1848,12 +1848,12 @@ mod tests {
             "tail -f /tmp/log",
             &[],
             false,
+            "stream",
             CommandOutputPolicy::Stream {
                 limit_bytes: 0,
                 chunk_limit_bytes: 8192,
             },
             CommandOutputPolicy::Discard,
-            "stream",
         )
         .unwrap();
 
@@ -1875,6 +1875,7 @@ mod tests {
             "run",
             &[],
             false,
+            "combined",
             CommandOutputPolicy::CaptureAndStream {
                 capture_limit_bytes: 1024,
                 stream_limit_bytes: 2048,
@@ -1885,7 +1886,6 @@ mod tests {
                 stream_limit_bytes: 0,
                 chunk_limit_bytes: 1,
             },
-            "combined",
         )
         .unwrap();
 
@@ -2036,9 +2036,9 @@ mod tests {
             "cmd",
             &[],
             false,
-            CommandOutputPolicy::Discard,
-            CommandOutputPolicy::Discard,
             "",
+            CommandOutputPolicy::Discard,
+            CommandOutputPolicy::Discard,
         )
         .unwrap();
         payload[4] = 0x80;
@@ -2057,9 +2057,9 @@ mod tests {
             "cmd",
             &[("K", "V")],
             false,
-            CommandOutputPolicy::Discard,
-            CommandOutputPolicy::Discard,
             "ok",
+            CommandOutputPolicy::Discard,
+            CommandOutputPolicy::Discard,
         )
         .unwrap();
         payload[9] = 0xFF;
@@ -2073,9 +2073,9 @@ mod tests {
             "cmd",
             &[("K", "V")],
             false,
-            CommandOutputPolicy::Discard,
-            CommandOutputPolicy::Discard,
             "ok",
+            CommandOutputPolicy::Discard,
+            CommandOutputPolicy::Discard,
         )
         .unwrap();
         let key_offset = 4 + 1 + 4 + "cmd".len() + 4 + 4;
@@ -2090,9 +2090,9 @@ mod tests {
             "cmd",
             &[("K", "V")],
             false,
-            CommandOutputPolicy::Discard,
-            CommandOutputPolicy::Discard,
             "ok",
+            CommandOutputPolicy::Discard,
+            CommandOutputPolicy::Discard,
         )
         .unwrap();
         let val_offset = key_offset + "K".len() + 4;
@@ -2107,12 +2107,12 @@ mod tests {
             "cmd",
             &[("K", "V")],
             false,
-            CommandOutputPolicy::Discard,
-            CommandOutputPolicy::Discard,
             "ok",
+            CommandOutputPolicy::Discard,
+            CommandOutputPolicy::Discard,
         )
         .unwrap();
-        let label_offset = payload.len() - 2;
+        let label_offset = 4 + 1 + 4 + "cmd".len() + 4 + 4 + "K".len() + 4 + "V".len() + 2;
         payload[label_offset] = 0xFF;
         assert!(matches!(
             decode_command_start(&payload),
@@ -2127,9 +2127,9 @@ mod tests {
             "cmd",
             &[],
             false,
-            CommandOutputPolicy::Discard,
-            CommandOutputPolicy::Discard,
             "",
+            CommandOutputPolicy::Discard,
+            CommandOutputPolicy::Discard,
         )
         .unwrap();
         payload.push(0);
@@ -2148,9 +2148,9 @@ mod tests {
             "",
             &[],
             false,
-            CommandOutputPolicy::Discard,
-            CommandOutputPolicy::Discard,
             "",
+            CommandOutputPolicy::Discard,
+            CommandOutputPolicy::Discard,
         )
         .unwrap();
         let env_count_offset = 4 + 1 + 4;
@@ -2170,9 +2170,9 @@ mod tests {
             "cmd",
             &env,
             false,
-            CommandOutputPolicy::Discard,
-            CommandOutputPolicy::Discard,
             "",
+            CommandOutputPolicy::Discard,
+            CommandOutputPolicy::Discard,
         )
         .unwrap_err();
         assert!(matches!(
@@ -2185,9 +2185,9 @@ mod tests {
             "",
             &[],
             false,
-            CommandOutputPolicy::Discard,
-            CommandOutputPolicy::Discard,
             "",
+            CommandOutputPolicy::Discard,
+            CommandOutputPolicy::Discard,
         )
         .unwrap();
         let env_count_offset = 4 + 1 + 4;
@@ -2228,9 +2228,9 @@ mod tests {
             "cmd",
             &[("K", "V")],
             false,
-            CommandOutputPolicy::Discard,
-            CommandOutputPolicy::Discard,
             "ok",
+            CommandOutputPolicy::Discard,
+            CommandOutputPolicy::Discard,
         )
         .unwrap();
         payload.truncate(10);
@@ -2246,9 +2246,9 @@ mod tests {
             "cmd",
             &[("K", "V")],
             false,
-            CommandOutputPolicy::Discard,
-            CommandOutputPolicy::Discard,
             "ok",
+            CommandOutputPolicy::Discard,
+            CommandOutputPolicy::Discard,
         )
         .unwrap();
         let env_count_offset = 4 + 1 + 4 + "cmd".len();
@@ -2265,12 +2265,13 @@ mod tests {
             "cmd",
             &[],
             false,
-            CommandOutputPolicy::Discard,
-            CommandOutputPolicy::Discard,
             "ok",
+            CommandOutputPolicy::Discard,
+            CommandOutputPolicy::Discard,
         )
         .unwrap();
-        payload.truncate(payload.len() - 1);
+        let label_start = 4 + 1 + 4 + "cmd".len() + 4 + 2;
+        payload.truncate(label_start + 1);
         assert!(matches!(
             decode_command_start(&payload),
             Err(ProtocolError::InvalidPayload(
@@ -2286,12 +2287,12 @@ mod tests {
             "cmd",
             &[],
             false,
-            CommandOutputPolicy::Discard,
-            CommandOutputPolicy::Discard,
             "",
+            CommandOutputPolicy::Discard,
+            CommandOutputPolicy::Discard,
         )
         .unwrap();
-        let stdout_policy_offset = 4 + 1 + 4 + "cmd".len() + 4;
+        let stdout_policy_offset = 4 + 1 + 4 + "cmd".len() + 4 + 2;
         payload[stdout_policy_offset] = 0x99;
 
         let err = decode_command_start(&payload).unwrap_err();
@@ -2308,12 +2309,12 @@ mod tests {
             "cmd",
             &[],
             false,
+            "",
             CommandOutputPolicy::Stream {
                 limit_bytes: 1,
                 chunk_limit_bytes: 0,
             },
             CommandOutputPolicy::Discard,
-            "",
         )
         .unwrap_err();
         assert!(matches!(
@@ -2326,15 +2327,15 @@ mod tests {
             "cmd",
             &[],
             false,
+            "",
             CommandOutputPolicy::Stream {
                 limit_bytes: 1,
                 chunk_limit_bytes: 1,
             },
             CommandOutputPolicy::Discard,
-            "",
         )
         .unwrap();
-        let chunk_limit_offset = 4 + 1 + 4 + "cmd".len() + 4 + 1 + 4;
+        let chunk_limit_offset = 4 + 1 + 4 + "cmd".len() + 4 + 2 + 1 + 4;
         payload[chunk_limit_offset..chunk_limit_offset + 4].copy_from_slice(&0u32.to_be_bytes());
 
         let err = decode_command_start(&payload).unwrap_err();
@@ -2351,15 +2352,15 @@ mod tests {
             "cmd",
             &[],
             false,
+            "",
             CommandOutputPolicy::Stream {
                 limit_bytes: 1,
                 chunk_limit_bytes: 1,
             },
             CommandOutputPolicy::Discard,
-            "",
         )
         .unwrap();
-        let stream_chunk_limit_offset = 4 + 1 + 4 + "cmd".len() + 4 + 1 + 4;
+        let stream_chunk_limit_offset = 4 + 1 + 4 + "cmd".len() + 4 + 2 + 1 + 4;
         stream_payload.truncate(stream_chunk_limit_offset + 3);
         assert!(matches!(
             decode_command_start(&stream_payload),
@@ -2373,16 +2374,16 @@ mod tests {
             "cmd",
             &[],
             false,
+            "",
             CommandOutputPolicy::CaptureAndStream {
                 capture_limit_bytes: 1,
                 stream_limit_bytes: 1,
                 chunk_limit_bytes: 1,
             },
             CommandOutputPolicy::Discard,
-            "",
         )
         .unwrap();
-        let capture_and_stream_chunk_limit_offset = 4 + 1 + 4 + "cmd".len() + 4 + 1 + 4 + 4;
+        let capture_and_stream_chunk_limit_offset = 4 + 1 + 4 + "cmd".len() + 4 + 2 + 1 + 4 + 4;
         capture_and_stream_payload.truncate(capture_and_stream_chunk_limit_offset + 3);
         assert!(matches!(
             decode_command_start(&capture_and_stream_payload),
@@ -2615,9 +2616,9 @@ mod tests {
             &command,
             &[],
             false,
-            CommandOutputPolicy::Discard,
-            CommandOutputPolicy::Discard,
             "",
+            CommandOutputPolicy::Discard,
+            CommandOutputPolicy::Discard,
         )
         .unwrap_err();
         assert!(matches!(err, ProtocolError::MessageTooLarge(_)));
@@ -2649,9 +2650,9 @@ mod tests {
             "cmd",
             &[],
             false,
-            CommandOutputPolicy::Discard,
-            CommandOutputPolicy::Discard,
             &label,
+            CommandOutputPolicy::Discard,
+            CommandOutputPolicy::Discard,
         )
         .unwrap_err();
         assert!(matches!(


### PR DESCRIPTION
## Summary
- add host-side Command Operation types, operation table, command handle, and start/capture/stream helpers
- dispatch MSG_COMMAND_OUTPUT / MSG_COMMAND_RESULT by operation seq without blocking the reader loop
- add connection poisoning for malformed command frames, interrupted command frame writes, and cancel result timeouts
- keep legacy exec/write_file/spawn_watch paths unchanged

Closes #12690

## Tests
- cargo fmt --manifest-path crates/Cargo.toml --all -- --check
- cargo clippy --manifest-path crates/Cargo.toml -p vsock-host --all-targets --all-features -- -D warnings
- cargo test --manifest-path crates/Cargo.toml -p vsock-host --lib
- git diff --check