### PR TITLE
ci: add runner image consumer selection

### DIFF
--- a/.github/scripts/runner-image-context.sh
+++ b/.github/scripts/runner-image-context.sh
@@ -3,14 +3,25 @@ set -euo pipefail
 
 usage() {
   cat <<'USAGE'
-Usage: runner-image-context.sh <resolve|needed|artifact-name>
+Usage: runner-image-context.sh <resolve|turbo-consumer|crates-consumer|image-inputs|needed|artifact-name>
 
 resolve:
   Computes release skip, canonical job ref, and head SHA from GitHub event env.
 
 needed:
-  Computes whether any runner image consumer needs a prepared image from
-  workflow change-detection booleans.
+  Computes runner image consumer demand and current-image selection from
+  explicit workflow selection booleans.
+
+turbo-consumer:
+  Computes whether Turbo runner E2E is a runner image consumer from the same
+  change booleans used by turbo.yml.
+
+crates-consumer:
+  Computes whether Crates runner tests are a runner image consumer from the
+  same change booleans used by crates.yml runner-build.
+
+image-inputs:
+  Computes whether current commit inputs can change the produced runner image.
 
 artifact-name:
   Computes the GitHub artifact name for a runner image manifest.
@@ -156,41 +167,123 @@ needed() {
     has_metal_hosts="true"
   fi
 
-  local turbo_needed="false"
-  if [ "${EVENT_NAME:-}" != "push" ] && {
-    is_true "${TURBO_WEB_CHANGED:-false}" ||
-    is_true "${TURBO_CLI_CHANGED:-false}" ||
-    is_true "${TURBO_CRATES_CHANGED:-false}" ||
-    is_true "${TURBO_CI_CHANGED:-false}" ||
-    is_true "${TURBO_E2E_CHANGED:-false}"
-  }; then
-    turbo_needed="true"
+  local turbo_consumer
+  turbo_consumer=$(bool "${TURBO_RUNNER_CONSUMER_NEEDED:-false}")
+  if [ "${EVENT_NAME:-}" = "push" ]; then
+    turbo_consumer="false"
   fi
 
-  local crates_needed="false"
-  if is_true "${CRATES_CI_CHANGED:-false}" ||
-    is_true "${CRATES_RUNNER_CHANGED:-false}" ||
-    is_true "${CRATES_GUEST_INIT_CHANGED:-false}" ||
-    is_true "${CRATES_GUEST_DOWNLOAD_CHANGED:-false}" ||
-    is_true "${CRATES_GUEST_AGENT_CHANGED:-false}" ||
-    is_true "${CRATES_GUEST_MOCK_CLAUDE_CHANGED:-false}" ||
-    is_true "${CRATES_GUEST_MOCK_CODEX_CHANGED:-false}" ||
-    is_true "${CRATES_GUEST_RESEED_CHANGED:-false}" ||
-    is_true "${CRATES_GUEST_WRITE_FILE_CHANGED:-false}"; then
-    crates_needed="true"
-  fi
+  local crates_consumer
+  crates_consumer=$(bool "${CRATES_RUNNER_CONSUMER_NEEDED:-false}")
 
-  local image_needed="false"
-  if [ "$release_skip" != "true" ] &&
-    [ "$has_metal_hosts" = "true" ] &&
-    { [ "$turbo_needed" = "true" ] || [ "$crates_needed" = "true" ]; }; then
-    image_needed="true"
+  local image_inputs_changed
+  image_inputs_changed=$(bool "${RUNNER_IMAGE_INPUTS_CHANGED:-false}")
+
+  local stable_reuse_enabled
+  stable_reuse_enabled=$(bool "${STABLE_RUNNER_IMAGE_REUSE_ENABLED:-false}")
+
+  local runner_consumer="false"
+  local current_image_needed="false"
+  local stable_image_allowed="false"
+  local reason="no-runner-image-consumer"
+
+  if [ "$release_skip" = "true" ]; then
+    turbo_consumer="false"
+    crates_consumer="false"
+    image_inputs_changed="false"
+    reason="release-skip"
+  elif [ "$has_metal_hosts" != "true" ]; then
+    turbo_consumer="false"
+    crates_consumer="false"
+    image_inputs_changed="false"
+    reason="no-metal-hosts"
+  else
+    if [ "$turbo_consumer" = "true" ] || [ "$crates_consumer" = "true" ]; then
+      runner_consumer="true"
+    fi
+
+    if [ "$runner_consumer" = "true" ]; then
+      if [ "$image_inputs_changed" = "true" ]; then
+        current_image_needed="true"
+        reason="runner-image-inputs-changed"
+      else
+        stable_image_allowed="true"
+        if [ "$stable_reuse_enabled" = "true" ]; then
+          reason="stable-runner-image-allowed"
+        else
+          current_image_needed="true"
+          reason="runner-image-consumer-without-stable-reuse"
+        fi
+      fi
+    fi
   fi
 
   emit "has-metal-hosts" "$has_metal_hosts"
-  emit "turbo-runner-needed" "$turbo_needed"
-  emit "crates-runner-needed" "$crates_needed"
-  emit "runner-image-needed" "$image_needed"
+  emit "turbo-runner-consumer-needed" "$turbo_consumer"
+  emit "crates-runner-consumer-needed" "$crates_consumer"
+  emit "runner-image-consumer-needed" "$runner_consumer"
+  emit "runner-image-inputs-changed" "$image_inputs_changed"
+  emit "current-runner-image-needed" "$current_image_needed"
+  emit "stable-runner-image-allowed" "$stable_image_allowed"
+  emit "image-selection-reason" "$reason"
+}
+
+turbo_consumer() {
+  local consumer="false"
+  if [ "${EVENT_NAME:-}" != "push" ] && {
+    is_true "${WEB_CHANGED:-false}" ||
+    is_true "${CLI_CHANGED:-false}" ||
+    is_true "${CRATES_CHANGED:-false}" ||
+    is_true "${CI_CHANGED:-false}" ||
+    is_true "${E2E_CHANGED:-false}"
+  }; then
+    consumer="true"
+  fi
+
+  emit "turbo-runner-consumer-needed" "$consumer"
+}
+
+crates_consumer() {
+  local consumer="false"
+  if is_true "${CI_CHANGED:-false}" ||
+    is_true "${RUNNER_CHANGED:-false}" ||
+    is_true "${GUEST_INIT_CHANGED:-false}" ||
+    is_true "${GUEST_DOWNLOAD_CHANGED:-false}" ||
+    is_true "${GUEST_AGENT_CHANGED:-false}" ||
+    is_true "${GUEST_MOCK_CLAUDE_CHANGED:-false}" ||
+    is_true "${GUEST_MOCK_CODEX_CHANGED:-false}" ||
+    is_true "${GUEST_RESEED_CHANGED:-false}" ||
+    is_true "${GUEST_WRITE_FILE_CHANGED:-false}"; then
+    consumer="true"
+  fi
+
+  emit "crates-runner-consumer-needed" "$consumer"
+}
+
+image_inputs() {
+  local crate_image_inputs_changed="false"
+  if is_true "${RUNNER_CHANGED:-false}" ||
+    is_true "${GUEST_INIT_CHANGED:-false}" ||
+    is_true "${GUEST_DOWNLOAD_CHANGED:-false}" ||
+    is_true "${GUEST_AGENT_CHANGED:-false}" ||
+    is_true "${GUEST_MOCK_CLAUDE_CHANGED:-false}" ||
+    is_true "${GUEST_MOCK_CODEX_CHANGED:-false}" ||
+    is_true "${GUEST_RESEED_CHANGED:-false}" ||
+    is_true "${GUEST_WRITE_FILE_CHANGED:-false}"; then
+    crate_image_inputs_changed="true"
+  fi
+
+  local ci_image_inputs_changed
+  ci_image_inputs_changed=$(bool "${RUNNER_IMAGE_CI_CHANGED:-false}")
+
+  local runner_image_inputs_changed="false"
+  if [ "$crate_image_inputs_changed" = "true" ] || [ "$ci_image_inputs_changed" = "true" ]; then
+    runner_image_inputs_changed="true"
+  fi
+
+  emit "crate-image-inputs-changed" "$crate_image_inputs_changed"
+  emit "ci-image-inputs-changed" "$ci_image_inputs_changed"
+  emit "runner-image-inputs-changed" "$runner_image_inputs_changed"
 }
 
 artifact_name() {
@@ -205,6 +298,9 @@ artifact_name() {
 cmd="${1:-}"
 case "$cmd" in
   resolve) resolve ;;
+  turbo-consumer) turbo_consumer ;;
+  crates-consumer) crates_consumer ;;
+  image-inputs) image_inputs ;;
   needed) needed ;;
   artifact-name) artifact_name ;;
   -h|--help|help) usage ;;

--- a/.github/scripts/runner-image-context.sh
+++ b/.github/scripts/runner-image-context.sh
@@ -158,6 +158,8 @@ resolve() {
 }
 
 needed() {
+  require_env EVENT_NAME
+
   local release_skip
   release_skip=$(bool "${RELEASE_SKIP:-false}")
 
@@ -169,7 +171,7 @@ needed() {
 
   local turbo_consumer
   turbo_consumer=$(bool "${TURBO_RUNNER_CONSUMER_NEEDED:-false}")
-  if [ "${EVENT_NAME:-}" = "push" ]; then
+  if [ "$EVENT_NAME" = "push" ]; then
     turbo_consumer="false"
   fi
 
@@ -229,8 +231,10 @@ needed() {
 }
 
 turbo_consumer() {
+  require_env EVENT_NAME
+
   local consumer="false"
-  if [ "${EVENT_NAME:-}" != "push" ] && {
+  if [ "$EVENT_NAME" != "push" ] && {
     is_true "${WEB_CHANGED:-false}" ||
     is_true "${CLI_CHANGED:-false}" ||
     is_true "${CRATES_CHANGED:-false}" ||

--- a/.github/scripts/tests/runner-image-context-test.sh
+++ b/.github/scripts/tests/runner-image-context-test.sh
@@ -83,11 +83,13 @@ assert_fails "turbo-consumer requires EVENT_NAME" \
   WEB_CHANGED=true \
   "$CONTEXT" turbo-consumer
 
-out=$(run_clean \
-  EVENT_NAME=pull_request \
-  WEB_CHANGED=true \
-  "$CONTEXT" turbo-consumer)
-assert_contains "$out" "turbo-runner-consumer-needed=true"
+for flag in WEB_CHANGED CLI_CHANGED CRATES_CHANGED CI_CHANGED E2E_CHANGED; do
+  out=$(run_clean \
+    EVENT_NAME=pull_request \
+    "${flag}=true" \
+    "$CONTEXT" turbo-consumer)
+  assert_contains "$out" "turbo-runner-consumer-needed=true"
+done
 
 out=$(run_clean \
   EVENT_NAME=push \
@@ -95,24 +97,29 @@ out=$(run_clean \
   "$CONTEXT" turbo-consumer)
 assert_contains "$out" "turbo-runner-consumer-needed=false"
 
-out=$(run_clean \
-  EVENT_NAME=pull_request \
-  E2E_CHANGED=true \
-  "$CONTEXT" turbo-consumer)
-assert_contains "$out" "turbo-runner-consumer-needed=true"
-
-out=$(run_clean \
-  RUNNER_CHANGED=true \
-  "$CONTEXT" crates-consumer)
-assert_contains "$out" "crates-runner-consumer-needed=true"
-
-out=$(run_clean \
-  GUEST_AGENT_CHANGED=true \
-  "$CONTEXT" crates-consumer)
-assert_contains "$out" "crates-runner-consumer-needed=true"
+for flag in \
+  CI_CHANGED \
+  RUNNER_CHANGED \
+  GUEST_INIT_CHANGED \
+  GUEST_DOWNLOAD_CHANGED \
+  GUEST_AGENT_CHANGED \
+  GUEST_MOCK_CLAUDE_CHANGED \
+  GUEST_MOCK_CODEX_CHANGED \
+  GUEST_RESEED_CHANGED \
+  GUEST_WRITE_FILE_CHANGED; do
+  out=$(run_clean \
+    "${flag}=true" \
+    "$CONTEXT" crates-consumer)
+  assert_contains "$out" "crates-runner-consumer-needed=true"
+done
 
 out=$(run_clean "$CONTEXT" crates-consumer)
 assert_contains "$out" "crates-runner-consumer-needed=false"
+
+out=$(run_clean "$CONTEXT" image-inputs)
+assert_contains "$out" "crate-image-inputs-changed=false"
+assert_contains "$out" "ci-image-inputs-changed=false"
+assert_contains "$out" "runner-image-inputs-changed=false"
 
 out=$(run_clean \
   RUNNER_CHANGED=true \
@@ -211,6 +218,20 @@ assert_contains "$out" "turbo-runner-consumer-needed=true"
 assert_contains "$out" "runner-image-inputs-changed=false"
 assert_contains "$out" "stable-runner-image-allowed=true"
 assert_contains "$out" "current-runner-image-needed=true"
+
+out=$(assert_needed_case "crates ci-only consumer before stable reuse" \
+  EVENT_NAME=pull_request \
+  RELEASE_SKIP=false \
+  METAL_HOSTS=dev-1 \
+  CRATES_RUNNER_CONSUMER_NEEDED=true \
+  RUNNER_IMAGE_INPUTS_CHANGED=false)
+assert_contains "$out" "turbo-runner-consumer-needed=false"
+assert_contains "$out" "crates-runner-consumer-needed=true"
+assert_contains "$out" "runner-image-consumer-needed=true"
+assert_contains "$out" "runner-image-inputs-changed=false"
+assert_contains "$out" "stable-runner-image-allowed=true"
+assert_contains "$out" "current-runner-image-needed=true"
+assert_contains "$out" "image-selection-reason=runner-image-consumer-without-stable-reuse"
 
 out=$(assert_needed_case "crates runner input" \
   EVENT_NAME=push \

--- a/.github/scripts/tests/runner-image-context-test.sh
+++ b/.github/scripts/tests/runner-image-context-test.sh
@@ -25,6 +25,14 @@ run_clean() {
   env -i PATH="$PATH" HOME="${HOME:-/tmp}" "$@"
 }
 
+assert_fails() {
+  local name=$1
+  shift
+  if run_clean "$@" >/dev/null 2>&1; then
+    fail "expected failure: ${name}"
+  fi
+}
+
 assert_no_legacy_needed_outputs() {
   local out=$1
   assert_not_prefix "$out" "turbo-runner-needed="
@@ -71,6 +79,10 @@ assert_contains "$out" "release-skip=true"
 assert_contains "$out" "skip-reason=release-please-push"
 assert_contains "$out" "job-ref="
 
+assert_fails "turbo-consumer requires EVENT_NAME" \
+  WEB_CHANGED=true \
+  "$CONTEXT" turbo-consumer
+
 out=$(run_clean \
   EVENT_NAME=pull_request \
   WEB_CHANGED=true \
@@ -115,6 +127,12 @@ out=$(run_clean \
 assert_contains "$out" "crate-image-inputs-changed=false"
 assert_contains "$out" "ci-image-inputs-changed=true"
 assert_contains "$out" "runner-image-inputs-changed=true"
+
+assert_fails "needed requires EVENT_NAME" \
+  RELEASE_SKIP=false \
+  METAL_HOSTS=dev-1 \
+  TURBO_RUNNER_CONSUMER_NEEDED=true \
+  "$CONTEXT" needed
 
 out=$(assert_needed_case "release skip" \
   EVENT_NAME=pull_request \

--- a/.github/scripts/tests/runner-image-context-test.sh
+++ b/.github/scripts/tests/runner-image-context-test.sh
@@ -14,8 +14,33 @@ assert_contains() {
   grep -qxF "$expected" <<<"$output" || fail "expected line '${expected}' in output: ${output}"
 }
 
+assert_not_prefix() {
+  local output=$1 prefix=$2
+  if grep -q "^${prefix}" <<<"$output"; then
+    fail "unexpected output prefix '${prefix}' in output: ${output}"
+  fi
+}
+
 run_clean() {
   env -i PATH="$PATH" HOME="${HOME:-/tmp}" "$@"
+}
+
+assert_no_legacy_needed_outputs() {
+  local out=$1
+  assert_not_prefix "$out" "turbo-runner-needed="
+  assert_not_prefix "$out" "crates-runner-needed="
+  assert_not_prefix "$out" "runner-image-needed="
+}
+
+assert_needed_case() {
+  local name=$1
+  shift
+  local out
+  if ! out=$(run_clean "$@" "$CONTEXT" needed); then
+    fail "needed case failed: ${name}"
+  fi
+  assert_no_legacy_needed_outputs "$out"
+  printf '%s\n' "$out"
 }
 
 out=$(run_clean EVENT_NAME=pull_request PR_NUMBER=123 HEAD_REF=feature HEAD_SHA=abc "$CONTEXT" resolve)
@@ -48,30 +73,160 @@ assert_contains "$out" "job-ref="
 
 out=$(run_clean \
   EVENT_NAME=pull_request \
+  WEB_CHANGED=true \
+  "$CONTEXT" turbo-consumer)
+assert_contains "$out" "turbo-runner-consumer-needed=true"
+
+out=$(run_clean \
+  EVENT_NAME=push \
+  WEB_CHANGED=true \
+  "$CONTEXT" turbo-consumer)
+assert_contains "$out" "turbo-runner-consumer-needed=false"
+
+out=$(run_clean \
+  EVENT_NAME=pull_request \
+  E2E_CHANGED=true \
+  "$CONTEXT" turbo-consumer)
+assert_contains "$out" "turbo-runner-consumer-needed=true"
+
+out=$(run_clean \
+  RUNNER_CHANGED=true \
+  "$CONTEXT" crates-consumer)
+assert_contains "$out" "crates-runner-consumer-needed=true"
+
+out=$(run_clean \
+  GUEST_AGENT_CHANGED=true \
+  "$CONTEXT" crates-consumer)
+assert_contains "$out" "crates-runner-consumer-needed=true"
+
+out=$(run_clean "$CONTEXT" crates-consumer)
+assert_contains "$out" "crates-runner-consumer-needed=false"
+
+out=$(run_clean \
+  RUNNER_CHANGED=true \
+  "$CONTEXT" image-inputs)
+assert_contains "$out" "crate-image-inputs-changed=true"
+assert_contains "$out" "ci-image-inputs-changed=false"
+assert_contains "$out" "runner-image-inputs-changed=true"
+
+out=$(run_clean \
+  RUNNER_IMAGE_CI_CHANGED=true \
+  "$CONTEXT" image-inputs)
+assert_contains "$out" "crate-image-inputs-changed=false"
+assert_contains "$out" "ci-image-inputs-changed=true"
+assert_contains "$out" "runner-image-inputs-changed=true"
+
+out=$(assert_needed_case "release skip" \
+  EVENT_NAME=pull_request \
+  RELEASE_SKIP=true \
+  METAL_HOSTS=dev-1 \
+  TURBO_RUNNER_CONSUMER_NEEDED=true \
+  RUNNER_IMAGE_INPUTS_CHANGED=true)
+assert_contains "$out" "has-metal-hosts=true"
+assert_contains "$out" "turbo-runner-consumer-needed=false"
+assert_contains "$out" "crates-runner-consumer-needed=false"
+assert_contains "$out" "runner-image-consumer-needed=false"
+assert_contains "$out" "runner-image-inputs-changed=false"
+assert_contains "$out" "current-runner-image-needed=false"
+assert_contains "$out" "stable-runner-image-allowed=false"
+assert_contains "$out" "image-selection-reason=release-skip"
+
+out=$(assert_needed_case "no metal hosts" \
+  EVENT_NAME=pull_request \
+  RELEASE_SKIP=false \
+  METAL_HOSTS= \
+  TURBO_RUNNER_CONSUMER_NEEDED=true \
+  RUNNER_IMAGE_INPUTS_CHANGED=true)
+assert_contains "$out" "has-metal-hosts=false"
+assert_contains "$out" "runner-image-consumer-needed=false"
+assert_contains "$out" "runner-image-inputs-changed=false"
+assert_contains "$out" "current-runner-image-needed=false"
+assert_contains "$out" "image-selection-reason=no-metal-hosts"
+
+out=$(assert_needed_case "no consumer" \
+  EVENT_NAME=pull_request \
+  RELEASE_SKIP=false \
+  METAL_HOSTS=dev-1 \
+  RUNNER_IMAGE_INPUTS_CHANGED=true)
+assert_contains "$out" "has-metal-hosts=true"
+assert_contains "$out" "turbo-runner-consumer-needed=false"
+assert_contains "$out" "crates-runner-consumer-needed=false"
+assert_contains "$out" "runner-image-consumer-needed=false"
+assert_contains "$out" "runner-image-inputs-changed=true"
+assert_contains "$out" "current-runner-image-needed=false"
+assert_contains "$out" "stable-runner-image-allowed=false"
+assert_contains "$out" "image-selection-reason=no-runner-image-consumer"
+
+out=$(assert_needed_case "turbo web-only consumer before stable reuse" \
+  EVENT_NAME=pull_request \
   RELEASE_SKIP=false \
   METAL_HOSTS=dev-1,dev-2 \
-  TURBO_WEB_CHANGED=true \
-  "$CONTEXT" needed)
-assert_contains "$out" "turbo-runner-needed=true"
-assert_contains "$out" "runner-image-needed=true"
+  TURBO_RUNNER_CONSUMER_NEEDED=true \
+  RUNNER_IMAGE_INPUTS_CHANGED=false)
+assert_contains "$out" "turbo-runner-consumer-needed=true"
+assert_contains "$out" "crates-runner-consumer-needed=false"
+assert_contains "$out" "runner-image-consumer-needed=true"
+assert_contains "$out" "runner-image-inputs-changed=false"
+assert_contains "$out" "stable-runner-image-allowed=true"
+assert_contains "$out" "current-runner-image-needed=true"
+assert_contains "$out" "image-selection-reason=runner-image-consumer-without-stable-reuse"
 
-out=$(run_clean \
+out=$(assert_needed_case "turbo cli-only consumer with stable reuse enabled" \
+  EVENT_NAME=pull_request \
+  RELEASE_SKIP=false \
+  METAL_HOSTS=dev-1 \
+  TURBO_RUNNER_CONSUMER_NEEDED=true \
+  RUNNER_IMAGE_INPUTS_CHANGED=false \
+  STABLE_RUNNER_IMAGE_REUSE_ENABLED=true)
+assert_contains "$out" "runner-image-consumer-needed=true"
+assert_contains "$out" "runner-image-inputs-changed=false"
+assert_contains "$out" "stable-runner-image-allowed=true"
+assert_contains "$out" "current-runner-image-needed=false"
+assert_contains "$out" "image-selection-reason=stable-runner-image-allowed"
+
+out=$(assert_needed_case "turbo e2e-only consumer before stable reuse" \
+  EVENT_NAME=pull_request \
+  RELEASE_SKIP=false \
+  METAL_HOSTS=dev-1 \
+  TURBO_RUNNER_CONSUMER_NEEDED=true)
+assert_contains "$out" "turbo-runner-consumer-needed=true"
+assert_contains "$out" "runner-image-inputs-changed=false"
+assert_contains "$out" "stable-runner-image-allowed=true"
+assert_contains "$out" "current-runner-image-needed=true"
+
+out=$(assert_needed_case "crates runner input" \
   EVENT_NAME=push \
   RELEASE_SKIP=false \
   METAL_HOSTS=dev-1 \
-  TURBO_WEB_CHANGED=true \
-  "$CONTEXT" needed)
-assert_contains "$out" "turbo-runner-needed=false"
-assert_contains "$out" "runner-image-needed=false"
+  CRATES_RUNNER_CONSUMER_NEEDED=true \
+  RUNNER_IMAGE_INPUTS_CHANGED=true)
+assert_contains "$out" "turbo-runner-consumer-needed=false"
+assert_contains "$out" "crates-runner-consumer-needed=true"
+assert_contains "$out" "runner-image-consumer-needed=true"
+assert_contains "$out" "runner-image-inputs-changed=true"
+assert_contains "$out" "stable-runner-image-allowed=false"
+assert_contains "$out" "current-runner-image-needed=true"
+assert_contains "$out" "image-selection-reason=runner-image-inputs-changed"
 
-out=$(run_clean \
+out=$(assert_needed_case "guest input" \
+  EVENT_NAME=pull_request \
+  RELEASE_SKIP=false \
+  METAL_HOSTS=dev-1 \
+  CRATES_RUNNER_CONSUMER_NEEDED=true \
+  RUNNER_IMAGE_INPUTS_CHANGED=true)
+assert_contains "$out" "crates-runner-consumer-needed=true"
+assert_contains "$out" "runner-image-inputs-changed=true"
+assert_contains "$out" "current-runner-image-needed=true"
+
+out=$(assert_needed_case "turbo ignored on push" \
   EVENT_NAME=push \
   RELEASE_SKIP=false \
   METAL_HOSTS=dev-1 \
-  CRATES_GUEST_AGENT_CHANGED=true \
-  "$CONTEXT" needed)
-assert_contains "$out" "crates-runner-needed=true"
-assert_contains "$out" "runner-image-needed=true"
+  TURBO_RUNNER_CONSUMER_NEEDED=true \
+  RUNNER_IMAGE_INPUTS_CHANGED=false)
+assert_contains "$out" "turbo-runner-consumer-needed=false"
+assert_contains "$out" "runner-image-consumer-needed=false"
+assert_contains "$out" "current-runner-image-needed=false"
 
 out=$(run_clean HEAD_SHA=abc JOB_REF=pr-123 "$CONTEXT" artifact-name)
 assert_contains "$out" "artifact-name=runner-image-manifest-abc-pr-123"

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -75,6 +75,7 @@ jobs:
       guest-reseed-changed: ${{ steps.detect.outputs.guest-reseed-changed }}
       guest-write-file-changed: ${{ steps.detect.outputs.guest-write-file-changed }}
       nbd-cow-changed: ${{ steps.detect.outputs.nbd-cow-changed }}
+      crates-runner-consumer-needed: ${{ steps.runner-tests.outputs.crates-runner-consumer-needed }}
       metal-host: ${{ steps.host.outputs.host }}
       metal-job-ref: ${{ steps.host.outputs.job-ref }}
       runner-image-job-ref: ${{ steps.host.outputs.image-job-ref }}
@@ -155,6 +156,20 @@ jobs:
           else
             echo "mitm-addon-turbo-changed=false" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Select runner test consumer
+        id: runner-tests
+        env:
+          CI_CHANGED: ${{ steps.detect.outputs.ci-changed }}
+          RUNNER_CHANGED: ${{ steps.detect.outputs.runner-changed }}
+          GUEST_INIT_CHANGED: ${{ steps.detect.outputs.guest-init-changed }}
+          GUEST_DOWNLOAD_CHANGED: ${{ steps.detect.outputs.guest-download-changed }}
+          GUEST_AGENT_CHANGED: ${{ steps.detect.outputs.guest-agent-changed }}
+          GUEST_MOCK_CLAUDE_CHANGED: ${{ steps.detect.outputs.guest-mock-claude-changed }}
+          GUEST_MOCK_CODEX_CHANGED: ${{ steps.detect.outputs.guest-mock-codex-changed }}
+          GUEST_RESEED_CHANGED: ${{ steps.detect.outputs.guest-reseed-changed }}
+          GUEST_WRITE_FILE_CHANGED: ${{ steps.detect.outputs.guest-write-file-changed }}
+        run: .github/scripts/runner-image-context.sh crates-consumer
 
       - name: Select metal host
         id: host
@@ -393,17 +408,8 @@ jobs:
       contents: read
     needs: [detect]
     if: |
-      needs.detect.outputs.metal-job-ref != '' && (
-        needs.detect.outputs.ci-changed == 'true' ||
-        needs.detect.outputs.runner-changed == 'true' ||
-        needs.detect.outputs.guest-init-changed == 'true' ||
-        needs.detect.outputs.guest-download-changed == 'true' ||
-        needs.detect.outputs.guest-agent-changed == 'true' ||
-        needs.detect.outputs.guest-mock-claude-changed == 'true' ||
-        needs.detect.outputs.guest-mock-codex-changed == 'true' ||
-        needs.detect.outputs.guest-reseed-changed == 'true' ||
-        needs.detect.outputs.guest-write-file-changed == 'true'
-      )
+      needs.detect.outputs.metal-job-ref != '' &&
+      needs.detect.outputs.crates-runner-consumer-needed == 'true'
     timeout-minutes: 20
     outputs:
       host: ${{ needs.detect.outputs.metal-host }}

--- a/.github/workflows/runner-image.yml
+++ b/.github/workflows/runner-image.yml
@@ -22,7 +22,13 @@ jobs:
       skip-reason: ${{ steps.identity.outputs.skip-reason }}
       job-ref: ${{ steps.identity.outputs.job-ref }}
       head-sha: ${{ steps.identity.outputs.head-sha }}
-      runner-image-needed: ${{ steps.needed.outputs.runner-image-needed }}
+      turbo-runner-consumer-needed: ${{ steps.needed.outputs.turbo-runner-consumer-needed }}
+      crates-runner-consumer-needed: ${{ steps.needed.outputs.crates-runner-consumer-needed }}
+      runner-image-consumer-needed: ${{ steps.needed.outputs.runner-image-consumer-needed }}
+      runner-image-inputs-changed: ${{ steps.needed.outputs.runner-image-inputs-changed }}
+      current-runner-image-needed: ${{ steps.needed.outputs.current-runner-image-needed }}
+      stable-runner-image-allowed: ${{ steps.needed.outputs.stable-runner-image-allowed }}
+      image-selection-reason: ${{ steps.needed.outputs.image-selection-reason }}
       artifact-name: ${{ steps.artifact.outputs.artifact-name }}
     steps:
       - uses: actions/checkout@v6
@@ -86,13 +92,13 @@ jobs:
             e2e_changed=false
           fi
 
-          {
-            echo "web-changed=${web_changed}"
-            echo "cli-changed=${cli_changed}"
-            echo "crates-changed=${crates_changed}"
-            echo "ci-changed=${ci_changed}"
-            echo "e2e-changed=${e2e_changed}"
-          } >> "$GITHUB_OUTPUT"
+          EVENT_NAME="${{ github.event_name }}" \
+          WEB_CHANGED="$web_changed" \
+          CLI_CHANGED="$cli_changed" \
+          CRATES_CHANGED="$crates_changed" \
+          CI_CHANGED="$ci_changed" \
+          E2E_CHANGED="$e2e_changed" \
+          .github/scripts/runner-image-context.sh turbo-consumer
 
       - name: Detect Crates runner image consumers
         id: crates
@@ -103,33 +109,72 @@ jobs:
           set -euo pipefail
 
           if git diff --name-only "$BASE_REF" HEAD | grep -qE "^\.github/workflows/(crates|runner-image)\.yml$|^\.github/actions/(setup-ssh-tunnel|provision)/|^\.github/scripts/|^ansible/"; then
-            echo "ci-changed=true" >> "$GITHUB_OUTPUT"
+            ci_changed=true
           else
-            echo "ci-changed=false" >> "$GITHUB_OUTPUT"
+            ci_changed=false
           fi
+          echo "ci-changed=${ci_changed}" >> "$GITHUB_OUTPUT"
 
           check_crate() {
             local crate=$1
             local output=$2
+            local var_name=$3
             local rc=0
             ./scripts/crate-changed.sh "$crate" "$BASE_REF" && rc=0 || rc=$?
             if [ "$rc" -eq 0 ]; then
+              printf -v "$var_name" '%s' "true"
               echo "${output}=true" >> "$GITHUB_OUTPUT"
             elif [ "$rc" -eq 1 ]; then
+              printf -v "$var_name" '%s' "false"
               echo "${output}=false" >> "$GITHUB_OUTPUT"
             else
               exit "$rc"
             fi
           }
 
-          check_crate runner runner-changed
-          check_crate guest-init guest-init-changed
-          check_crate guest-download guest-download-changed
-          check_crate guest-agent guest-agent-changed
-          check_crate guest-mock-claude guest-mock-claude-changed
-          check_crate guest-mock-codex guest-mock-codex-changed
-          check_crate guest-reseed guest-reseed-changed
-          check_crate guest-write-file guest-write-file-changed
+          check_crate runner runner-changed runner_changed
+          check_crate guest-init guest-init-changed guest_init_changed
+          check_crate guest-download guest-download-changed guest_download_changed
+          check_crate guest-agent guest-agent-changed guest_agent_changed
+          check_crate guest-mock-claude guest-mock-claude-changed guest_mock_claude_changed
+          check_crate guest-mock-codex guest-mock-codex-changed guest_mock_codex_changed
+          check_crate guest-reseed guest-reseed-changed guest_reseed_changed
+          check_crate guest-write-file guest-write-file-changed guest_write_file_changed
+
+          CI_CHANGED="$ci_changed" \
+          RUNNER_CHANGED="$runner_changed" \
+          GUEST_INIT_CHANGED="$guest_init_changed" \
+          GUEST_DOWNLOAD_CHANGED="$guest_download_changed" \
+          GUEST_AGENT_CHANGED="$guest_agent_changed" \
+          GUEST_MOCK_CLAUDE_CHANGED="$guest_mock_claude_changed" \
+          GUEST_MOCK_CODEX_CHANGED="$guest_mock_codex_changed" \
+          GUEST_RESEED_CHANGED="$guest_reseed_changed" \
+          GUEST_WRITE_FILE_CHANGED="$guest_write_file_changed" \
+          .github/scripts/runner-image-context.sh crates-consumer
+
+      - name: Detect runner image input changes
+        id: image-inputs
+        if: steps.identity.outputs.release-skip != 'true'
+        env:
+          BASE_REF: ${{ steps.base.outputs.base-ref }}
+        run: |
+          set -euo pipefail
+
+          runner_image_ci_changed=false
+          if git diff --name-only "$BASE_REF" HEAD | grep -qE "^\.github/workflows/(turbo|crates|runner-image)\.yml$|^\.github/actions/(setup-ssh-tunnel|provision)/|^\.github/scripts/(prepare-runner-image|runner-image-context|runner-image-manifest|wait-runner-image)\.sh$|^ansible/(ansible\.cfg|playbooks/(build-runner|provision-runner|promote-runner|rollback-runner)\.yml)$"; then
+            runner_image_ci_changed=true
+          fi
+
+          RUNNER_CHANGED="${{ steps.crates.outputs.runner-changed }}" \
+          GUEST_INIT_CHANGED="${{ steps.crates.outputs.guest-init-changed }}" \
+          GUEST_DOWNLOAD_CHANGED="${{ steps.crates.outputs.guest-download-changed }}" \
+          GUEST_AGENT_CHANGED="${{ steps.crates.outputs.guest-agent-changed }}" \
+          GUEST_MOCK_CLAUDE_CHANGED="${{ steps.crates.outputs.guest-mock-claude-changed }}" \
+          GUEST_MOCK_CODEX_CHANGED="${{ steps.crates.outputs.guest-mock-codex-changed }}" \
+          GUEST_RESEED_CHANGED="${{ steps.crates.outputs.guest-reseed-changed }}" \
+          GUEST_WRITE_FILE_CHANGED="${{ steps.crates.outputs.guest-write-file-changed }}" \
+          RUNNER_IMAGE_CI_CHANGED="$runner_image_ci_changed" \
+          .github/scripts/runner-image-context.sh image-inputs
 
       - name: Determine whether runner image is needed
         id: needed
@@ -137,25 +182,14 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           RELEASE_SKIP: ${{ steps.identity.outputs.release-skip }}
           METAL_HOSTS: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}
-          TURBO_WEB_CHANGED: ${{ steps.turbo.outputs.web-changed }}
-          TURBO_CLI_CHANGED: ${{ steps.turbo.outputs.cli-changed }}
-          TURBO_CRATES_CHANGED: ${{ steps.turbo.outputs.crates-changed }}
-          TURBO_CI_CHANGED: ${{ steps.turbo.outputs.ci-changed }}
-          TURBO_E2E_CHANGED: ${{ steps.turbo.outputs.e2e-changed }}
-          CRATES_CI_CHANGED: ${{ steps.crates.outputs.ci-changed }}
-          CRATES_RUNNER_CHANGED: ${{ steps.crates.outputs.runner-changed }}
-          CRATES_GUEST_INIT_CHANGED: ${{ steps.crates.outputs.guest-init-changed }}
-          CRATES_GUEST_DOWNLOAD_CHANGED: ${{ steps.crates.outputs.guest-download-changed }}
-          CRATES_GUEST_AGENT_CHANGED: ${{ steps.crates.outputs.guest-agent-changed }}
-          CRATES_GUEST_MOCK_CLAUDE_CHANGED: ${{ steps.crates.outputs.guest-mock-claude-changed }}
-          CRATES_GUEST_MOCK_CODEX_CHANGED: ${{ steps.crates.outputs.guest-mock-codex-changed }}
-          CRATES_GUEST_RESEED_CHANGED: ${{ steps.crates.outputs.guest-reseed-changed }}
-          CRATES_GUEST_WRITE_FILE_CHANGED: ${{ steps.crates.outputs.guest-write-file-changed }}
+          TURBO_RUNNER_CONSUMER_NEEDED: ${{ steps.turbo.outputs.turbo-runner-consumer-needed }}
+          CRATES_RUNNER_CONSUMER_NEEDED: ${{ steps.crates.outputs.crates-runner-consumer-needed }}
+          RUNNER_IMAGE_INPUTS_CHANGED: ${{ steps.image-inputs.outputs.runner-image-inputs-changed }}
         run: .github/scripts/runner-image-context.sh needed
 
       - name: Resolve manifest artifact name
         id: artifact
-        if: steps.needed.outputs.runner-image-needed == 'true'
+        if: steps.needed.outputs.current-runner-image-needed == 'true'
         env:
           HEAD_SHA: ${{ steps.identity.outputs.head-sha }}
           JOB_REF: ${{ steps.identity.outputs.job-ref }}
@@ -168,7 +202,7 @@ jobs:
     permissions:
       contents: read
     needs: [context]
-    if: needs.context.outputs.runner-image-needed == 'true'
+    if: needs.context.outputs.current-runner-image-needed == 'true'
     timeout-minutes: 25
     env:
       TARGET_TRIPLE: aarch64-unknown-linux-musl

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -82,6 +82,7 @@ jobs:
       crates-changed: ${{ steps.detect-crates.outputs.crates-changed }}
       ci-changed: ${{ steps.detect-ci.outputs.ci-changed }}
       e2e-changed: ${{ steps.detect-e2e.outputs.e2e-changed }}
+      turbo-runner-consumer-needed: ${{ steps.runner-e2e.outputs.turbo-runner-consumer-needed }}
       base-ref: ${{ steps.detect.outputs.base-ref }}
     steps:
       - uses: actions/checkout@v6
@@ -193,6 +194,17 @@ jobs:
             echo "No E2E test changes"
             echo "e2e-changed=false" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Select runner E2E consumer
+        id: runner-e2e
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          WEB_CHANGED: ${{ steps.detect.outputs.web-changed }}
+          CLI_CHANGED: ${{ steps.detect.outputs.cli-changed }}
+          CRATES_CHANGED: ${{ steps.detect-crates.outputs.crates-changed }}
+          CI_CHANGED: ${{ steps.detect-ci.outputs.ci-changed }}
+          E2E_CHANGED: ${{ steps.detect-e2e.outputs.e2e-changed }}
+        run: .github/scripts/runner-image-context.sh turbo-consumer
 
       - name: Set job-ref
         id: set-job-ref
@@ -1387,14 +1399,8 @@ jobs:
     needs: [prepare]
     timeout-minutes: 20
     if: |
-      github.event_name != 'push' &&
-      needs.prepare.outputs.job-ref != '' && (
-        needs.prepare.outputs.web-changed == 'true' ||
-        needs.prepare.outputs.cli-changed == 'true' ||
-        needs.prepare.outputs.crates-changed == 'true' ||
-        needs.prepare.outputs.ci-changed == 'true' ||
-        needs.prepare.outputs.e2e-changed == 'true'
-      )
+      needs.prepare.outputs.job-ref != '' &&
+      needs.prepare.outputs.turbo-runner-consumer-needed == 'true'
     outputs:
       bin-dir: ${{ steps.manifest.outputs.bin-dir }}
       runner-dir: ${{ steps.manifest.outputs.runner-dir }}
@@ -1477,14 +1483,8 @@ jobs:
       total-capacity: ${{ steps.start.outputs.total-capacity }}
     timeout-minutes: 2
     if: |
-      github.event_name != 'push' &&
-      needs.prepare.outputs.job-ref != '' && (
-        needs.prepare.outputs.web-changed == 'true' ||
-        needs.prepare.outputs.cli-changed == 'true' ||
-        needs.prepare.outputs.crates-changed == 'true' ||
-        needs.prepare.outputs.ci-changed == 'true' ||
-        needs.prepare.outputs.e2e-changed == 'true'
-      )
+      needs.prepare.outputs.job-ref != '' &&
+      needs.prepare.outputs.turbo-runner-consumer-needed == 'true'
     steps:
       - uses: actions/checkout@v6
 
@@ -1617,14 +1617,8 @@ jobs:
       cancel-in-progress: true
     needs: [prepare, build-cli, deploy-web]
     if: |
-      github.event_name != 'push' &&
-      needs.prepare.outputs.job-ref != '' && (
-        needs.prepare.outputs.web-changed == 'true' ||
-        needs.prepare.outputs.cli-changed == 'true' ||
-        needs.prepare.outputs.crates-changed == 'true' ||
-        needs.prepare.outputs.ci-changed == 'true' ||
-        needs.prepare.outputs.e2e-changed == 'true'
-      )
+      needs.prepare.outputs.job-ref != '' &&
+      needs.prepare.outputs.turbo-runner-consumer-needed == 'true'
     timeout-minutes: 2
     steps:
       - uses: actions/setup-node@v6
@@ -1680,14 +1674,8 @@ jobs:
         e2e-runner-bootstrap,
       ]
     if: |
-      github.event_name != 'push' &&
-      needs.prepare.outputs.job-ref != '' && (
-        needs.prepare.outputs.web-changed == 'true' ||
-        needs.prepare.outputs.cli-changed == 'true' ||
-        needs.prepare.outputs.crates-changed == 'true' ||
-        needs.prepare.outputs.ci-changed == 'true' ||
-        needs.prepare.outputs.e2e-changed == 'true'
-      )
+      needs.prepare.outputs.job-ref != '' &&
+      needs.prepare.outputs.turbo-runner-consumer-needed == 'true'
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary
- centralize Turbo and Crates runner image consumer selection in `.github/scripts/runner-image-context.sh`
- replace duplicated workflow conditions with explicit `turbo-runner-consumer-needed` and `crates-runner-consumer-needed` outputs
- split consumer demand from runner image input changes so a later stable-image reuse step can skip current-image builds safely
- remove legacy generic `runner-image-needed` naming instead of keeping compatibility aliases

Fixes #12781

## Testing
- `bash -n .github/scripts/runner-image-context.sh .github/scripts/tests/runner-image-context-test.sh`
- `.github/scripts/tests/runner-image-context-test.sh`
- `shellcheck .github/scripts/runner-image-context.sh .github/scripts/tests/runner-image-context-test.sh`
- `for test_script in .github/scripts/tests/*.sh; do bash "$test_script"; done`