### PR TITLE
chore: remove stale audit ignores

### DIFF
--- a/turbo/package.json
+++ b/turbo/package.json
@@ -47,12 +47,6 @@
         "fastestsmallesttextencoderdecoder"
       ]
     },
-    "auditConfig": {
-      "ignoreGhsas": [
-        "GHSA-gh4j-gqv2-49f6",
-        "GHSA-w5hq-g745-h8pq"
-      ]
-    },
     "overrides": {
       "fast-xml-parser": ">=5.5.7",
       "fast-xml-builder": ">=1.1.7",


### PR DESCRIPTION
## Summary
- remove stale pnpm audit GHSA ignore configuration
- keep audit behavior strict now that no advisories are muted

## Verification
- pnpm audit --audit-level high
- pnpm audit --json