### PR TITLE
fix: log masked cli stderr on failure

### DIFF
--- a/crates/guest-agent/src/cli.rs
+++ b/crates/guest-agent/src/cli.rs
@@ -941,13 +941,17 @@ pub async fn execute_cli(
             Vec::new()
         },
     };
+    let masked_stderr_lines = stderr_lines
+        .into_iter()
+        .map(|line| masker.mask_string(&line))
+        .collect::<Vec<_>>();
 
     // If event loop had an error, propagate it
     event_result?;
 
     Ok(CliExecutionResult {
         exit_code,
-        stderr_lines,
+        stderr_lines: masked_stderr_lines,
         last_event_sequence,
     })
 }

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -183,17 +183,7 @@ async fn execute(
                 last_event_sequence = cli_result.last_event_sequence;
                 let code = cli_result.exit_code;
                 if code != 0 {
-                    let msg = if cli_result.stderr_lines.is_empty() {
-                        format!("Agent exited with code {code}")
-                    } else {
-                        log_info!(
-                            LOG_TAG,
-                            "Captured {} stderr lines",
-                            cli_result.stderr_lines.len()
-                        );
-                        cli_result.stderr_lines.join(" ")
-                    };
-                    (code, msg)
+                    (code, cli_failure_message(code, &cli_result.stderr_lines))
                 } else {
                     (0, String::new())
                 }
@@ -226,6 +216,18 @@ async fn execute(
         &http,
     )
     .await
+}
+
+fn cli_failure_message(code: i32, stderr_lines: &[String]) -> String {
+    if stderr_lines.is_empty() {
+        return format!("Agent exited with code {code}");
+    }
+
+    log_info!(LOG_TAG, "Captured {} stderr lines", stderr_lines.len());
+    for line in stderr_lines {
+        log_warn!(LOG_TAG, "CLI stderr: {line}");
+    }
+    stderr_lines.join(" ")
 }
 
 async fn complete_execution(
@@ -362,6 +364,41 @@ mod tests {
     use super::*;
     use httpmock::prelude::*;
     use serde_json::json;
+
+    struct SystemLogOverrideGuard;
+
+    impl SystemLogOverrideGuard {
+        fn set(path: &std::path::Path) -> Self {
+            guest_common::log::set_system_log_file(path.to_string_lossy().as_ref());
+            Self
+        }
+    }
+
+    impl Drop for SystemLogOverrideGuard {
+        fn drop(&mut self) {
+            guest_common::log::clear_system_log_file();
+        }
+    }
+
+    #[test]
+    fn cli_failure_message_logs_stderr_to_system_log() {
+        let tmp = tempfile::tempdir().unwrap();
+        let system_log_path = tmp.path().join("system.log");
+        let _system_log_guard = SystemLogOverrideGuard::set(&system_log_path);
+
+        let msg = cli_failure_message(1, &["codex stderr includes ***".to_string()]);
+        assert_eq!(msg, "codex stderr includes ***");
+
+        let system_log = std::fs::read_to_string(&system_log_path).unwrap();
+        assert!(
+            system_log.contains("Captured 1 stderr lines"),
+            "system log should include stderr count, got: {system_log}"
+        );
+        assert!(
+            system_log.contains("CLI stderr: codex stderr includes ***"),
+            "system log should include CLI stderr, got: {system_log}"
+        );
+    }
 
     #[tokio::test]
     async fn complete_execution_creates_recovery_checkpoint_after_cli_failure() {

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -393,6 +393,14 @@ mod tests {
     use httpmock::prelude::*;
     use serde_json::json;
 
+    static TEST_STATE_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    fn lock_test_state() -> std::sync::MutexGuard<'static, ()> {
+        TEST_STATE_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
     struct SystemLogOverrideGuard;
 
     impl SystemLogOverrideGuard {
@@ -410,6 +418,7 @@ mod tests {
 
     #[test]
     fn cli_failure_message_logs_stderr_to_system_log() {
+        let _test_state_guard = lock_test_state();
         let tmp = tempfile::tempdir().unwrap();
         let system_log_path = tmp.path().join("system.log");
         let _system_log_guard = SystemLogOverrideGuard::set(&system_log_path);
@@ -452,8 +461,17 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn complete_execution_creates_recovery_checkpoint_after_cli_failure() {
+    #[test]
+    fn complete_execution_creates_recovery_checkpoint_after_cli_failure() {
+        let _test_state_guard = lock_test_state();
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(complete_execution_creates_recovery_checkpoint_after_cli_failure_inner());
+    }
+
+    async fn complete_execution_creates_recovery_checkpoint_after_cli_failure_inner() {
         let server = MockServer::start();
         unsafe {
             std::env::set_var("VM0_API_URL", server.base_url());

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -20,6 +20,8 @@ use std::time::{Duration, Instant};
 use tokio_util::sync::CancellationToken;
 
 const LOG_TAG: &str = "sandbox:guest-agent";
+const MAX_LOGGED_CLI_STDERR_LINES: usize = 20;
+const MAX_LOGGED_CLI_STDERR_LINE_BYTES: usize = 4096;
 
 #[tokio::main]
 async fn main() {
@@ -224,10 +226,36 @@ fn cli_failure_message(code: i32, stderr_lines: &[String]) -> String {
     }
 
     log_info!(LOG_TAG, "Captured {} stderr lines", stderr_lines.len());
-    for line in stderr_lines {
-        log_warn!(LOG_TAG, "CLI stderr: {line}");
+    for line in stderr_lines.iter().take(MAX_LOGGED_CLI_STDERR_LINES) {
+        log_warn!(LOG_TAG, "CLI stderr: {}", truncate_cli_stderr_line(line));
+    }
+    if stderr_lines.len() > MAX_LOGGED_CLI_STDERR_LINES {
+        log_warn!(
+            LOG_TAG,
+            "CLI stderr: omitted {} additional line(s)",
+            stderr_lines.len() - MAX_LOGGED_CLI_STDERR_LINES
+        );
     }
     stderr_lines.join(" ")
+}
+
+fn truncate_cli_stderr_line(line: &str) -> std::borrow::Cow<'_, str> {
+    if line.len() <= MAX_LOGGED_CLI_STDERR_LINE_BYTES {
+        return std::borrow::Cow::Borrowed(line);
+    }
+
+    let mut cut = 0;
+    for (idx, ch) in line.char_indices() {
+        let next = idx + ch.len_utf8();
+        if next > MAX_LOGGED_CLI_STDERR_LINE_BYTES {
+            break;
+        }
+        cut = next;
+    }
+
+    let mut truncated = line[..cut].to_string();
+    truncated.push_str("...[truncated]");
+    std::borrow::Cow::Owned(truncated)
 }
 
 async fn complete_execution(
@@ -386,17 +414,41 @@ mod tests {
         let system_log_path = tmp.path().join("system.log");
         let _system_log_guard = SystemLogOverrideGuard::set(&system_log_path);
 
-        let msg = cli_failure_message(1, &["codex stderr includes ***".to_string()]);
-        assert_eq!(msg, "codex stderr includes ***");
+        let long_line = format!("{}tail", "x".repeat(MAX_LOGGED_CLI_STDERR_LINE_BYTES + 1));
+        let stderr_lines = std::iter::once("codex stderr includes ***".to_string())
+            .chain(std::iter::once(long_line.clone()))
+            .chain((0..MAX_LOGGED_CLI_STDERR_LINES).map(|i| format!("extra line {i}")))
+            .collect::<Vec<_>>();
+        let msg = cli_failure_message(1, &stderr_lines);
+        assert!(
+            msg.contains("codex stderr includes ***"),
+            "returned error message should preserve stderr"
+        );
+        assert!(
+            msg.contains("tail"),
+            "returned error message should preserve full masked stderr"
+        );
 
         let system_log = std::fs::read_to_string(&system_log_path).unwrap();
         assert!(
-            system_log.contains("Captured 1 stderr lines"),
+            system_log.contains("Captured 22 stderr lines"),
             "system log should include stderr count, got: {system_log}"
         );
         assert!(
             system_log.contains("CLI stderr: codex stderr includes ***"),
             "system log should include CLI stderr, got: {system_log}"
+        );
+        assert!(
+            system_log.contains("...[truncated]"),
+            "system log should truncate long stderr lines, got: {system_log}"
+        );
+        assert!(
+            !system_log.contains("tail"),
+            "system log should not include bytes after the truncation boundary"
+        );
+        assert!(
+            system_log.contains("CLI stderr: omitted 2 additional line(s)"),
+            "system log should report omitted stderr lines, got: {system_log}"
         );
     }
 

--- a/crates/guest-agent/tests/cli_stderr_logging.rs
+++ b/crates/guest-agent/tests/cli_stderr_logging.rs
@@ -1,0 +1,53 @@
+//! CLI stderr logging must preserve diagnostics without leaking secrets.
+//!
+//! This test lives in its own binary because `guest_agent::env` and
+//! `guest_agent::paths` cache values in process-wide `LazyLock`s.
+
+mod common;
+
+use base64::Engine;
+use guest_agent::http::HttpClient;
+use guest_agent::masker::SecretMasker;
+use std::time::Duration;
+
+#[tokio::test]
+async fn cli_failure_stderr_is_masked_in_result() -> Result<(), Box<dyn std::error::Error>> {
+    let mock = common::build_and_locate_mock()?;
+    let tmp = tempfile::tempdir()?;
+    let secret = "super-secret-value";
+    unsafe {
+        common::setup_env(
+            &mock,
+            tmp.path(),
+            &format!("@fail:codex stderr includes {secret}"),
+            3,
+            1,
+        )?;
+    }
+
+    let encoded_secret = base64::engine::general_purpose::STANDARD.encode(secret);
+    let masker = SecretMasker::from_raw(&encoded_secret);
+    let cli_result = tokio::time::timeout(
+        Duration::from_secs(5),
+        guest_agent::cli::execute_cli(
+            &masker,
+            common::spawn_dummy_heartbeat(),
+            HttpClient::for_current_env()?,
+        ),
+    )
+    .await
+    .expect("execute_cli should return promptly")?;
+
+    assert_eq!(cli_result.exit_code, 1);
+    let stderr = cli_result.stderr_lines.join("\n");
+    assert!(
+        stderr.contains("codex stderr includes ***"),
+        "stderr result should keep masked diagnostic, got: {stderr}"
+    );
+    assert!(
+        !stderr.contains(secret),
+        "stderr result leaked secret: {stderr}"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- mask captured CLI stderr before returning it from guest-agent CLI execution
- log masked CLI stderr from the outer failure handling path so system logs show diagnostics
- add regression coverage for masked stderr results and system-log emission

## Tests
- cargo fmt --manifest-path crates/Cargo.toml --all --check
- cargo test --manifest-path crates/Cargo.toml -p guest-agent --test cli_stderr_logging
- cargo test --manifest-path crates/Cargo.toml -p guest-agent --bin guest-agent cli_failure_message_logs_stderr_to_system_log
- cargo test --manifest-path crates/Cargo.toml -p guest-agent
- cargo clippy --manifest-path crates/Cargo.toml -p guest-agent --all-targets --all-features -- -D warnings