### PR TITLE
ci: speed up runner image builds

### DIFF
--- a/.github/scripts/prepare-runner-image.sh
+++ b/.github/scripts/prepare-runner-image.sh
@@ -26,20 +26,20 @@ mkdir -p "$(dirname "$MANIFEST_PATH")"
 echo "=== Cross-compiling guest binaries for ${TARGET_TRIPLE} ==="
 (
   cd crates
-  cargo build --release --target "$TARGET_TRIPLE" \
+  cargo build --profile ci --target "$TARGET_TRIPLE" \
     -p guest-agent -p guest-download -p guest-init -p guest-mock-claude -p guest-mock-codex -p guest-reseed -p guest-write-file
 )
 
 echo "=== Cross-compiling runner with embedded guests for ${TARGET_TRIPLE} ==="
 (
   cd crates
-  GUEST_AGENT_PATH="target/$TARGET_TRIPLE/release/guest-agent" \
-  GUEST_DOWNLOAD_PATH="target/$TARGET_TRIPLE/release/guest-download" \
-  GUEST_INIT_PATH="target/$TARGET_TRIPLE/release/guest-init" \
-  GUEST_MOCK_CLAUDE_PATH="target/$TARGET_TRIPLE/release/guest-mock-claude" \
-  GUEST_MOCK_CODEX_PATH="target/$TARGET_TRIPLE/release/guest-mock-codex" \
-  GUEST_RESEED_PATH="target/$TARGET_TRIPLE/release/guest-reseed" \
-  GUEST_WRITE_FILE_PATH="target/$TARGET_TRIPLE/release/guest-write-file" \
+  GUEST_AGENT_PATH="target/$TARGET_TRIPLE/ci/guest-agent" \
+  GUEST_DOWNLOAD_PATH="target/$TARGET_TRIPLE/ci/guest-download" \
+  GUEST_INIT_PATH="target/$TARGET_TRIPLE/ci/guest-init" \
+  GUEST_MOCK_CLAUDE_PATH="target/$TARGET_TRIPLE/ci/guest-mock-claude" \
+  GUEST_MOCK_CODEX_PATH="target/$TARGET_TRIPLE/ci/guest-mock-codex" \
+  GUEST_RESEED_PATH="target/$TARGET_TRIPLE/ci/guest-reseed" \
+  GUEST_WRITE_FILE_PATH="target/$TARGET_TRIPLE/ci/guest-write-file" \
   cargo build --profile ci --target "$TARGET_TRIPLE" -p runner
 )
 
@@ -49,13 +49,13 @@ sha_file() {
 
 runner_sha=$(sha_file "${TARGET_DIR}/runner")
 guest_sha_json=$(jq -n \
-  --arg guest_agent "$(sha_file "crates/target/${TARGET_TRIPLE}/release/guest-agent")" \
-  --arg guest_download "$(sha_file "crates/target/${TARGET_TRIPLE}/release/guest-download")" \
-  --arg guest_init "$(sha_file "crates/target/${TARGET_TRIPLE}/release/guest-init")" \
-  --arg guest_mock_claude "$(sha_file "crates/target/${TARGET_TRIPLE}/release/guest-mock-claude")" \
-  --arg guest_mock_codex "$(sha_file "crates/target/${TARGET_TRIPLE}/release/guest-mock-codex")" \
-  --arg guest_reseed "$(sha_file "crates/target/${TARGET_TRIPLE}/release/guest-reseed")" \
-  --arg guest_write_file "$(sha_file "crates/target/${TARGET_TRIPLE}/release/guest-write-file")" \
+  --arg guest_agent "$(sha_file "crates/target/${TARGET_TRIPLE}/ci/guest-agent")" \
+  --arg guest_download "$(sha_file "crates/target/${TARGET_TRIPLE}/ci/guest-download")" \
+  --arg guest_init "$(sha_file "crates/target/${TARGET_TRIPLE}/ci/guest-init")" \
+  --arg guest_mock_claude "$(sha_file "crates/target/${TARGET_TRIPLE}/ci/guest-mock-claude")" \
+  --arg guest_mock_codex "$(sha_file "crates/target/${TARGET_TRIPLE}/ci/guest-mock-codex")" \
+  --arg guest_reseed "$(sha_file "crates/target/${TARGET_TRIPLE}/ci/guest-reseed")" \
+  --arg guest_write_file "$(sha_file "crates/target/${TARGET_TRIPLE}/ci/guest-write-file")" \
   '{
     "guest-agent": $guest_agent,
     "guest-download": $guest_download,

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1463,7 +1463,7 @@ jobs:
         with:
           workspaces: crates -> target
           shared-key: aarch64-musl-release
-          save-if: false
+          save-if: ${{ github.event.workflow_run.head_branch == 'main' }}
 
       - name: Notify Slack - Starting
         id: slack-start
@@ -1485,10 +1485,8 @@ jobs:
         id: timer
         run: echo "start=$(date +%s)" >> "$GITHUB_OUTPUT"
 
-      # IMPORTANT: these compile settings (--release, default linker, no
-      # custom RUSTFLAGS) must match crates.yml / turbo.yml so guest binary
-      # bytes and rootfs_hash are identical across pipelines. The shared
-      # R2 template cache intentionally ignores guest binaries. See #9192.
+      # IMPORTANT: production runner releases use the release profile. The
+      # shared R2 template cache intentionally ignores guest binaries. See #9192.
       - name: Cross-compile guest binaries for ARM64
         run: |
           cd crates

--- a/.github/workflows/runner-image.yml
+++ b/.github/workflows/runner-image.yml
@@ -213,7 +213,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: crates -> target
-          shared-key: aarch64-musl-release
+          shared-key: aarch64-musl-ci
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Setup SSH via Cloudflare Tunnel

--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -90,7 +90,8 @@ lto = true
 strip = true
 codegen-units = 1
 
-# Runner-only CI profile — not used for guests (image_hash depends on --release).
+# Faster runner image build profile for CI and local dev-runner deploys.
+# Production runner releases still use the release profile.
 [profile.ci]
 inherits = "release"
 lto = "thin"

--- a/crates/README.md
+++ b/crates/README.md
@@ -70,17 +70,17 @@ cargo build --release
 # Step 1: build guest binaries
 cargo build --target aarch64-unknown-linux-musl \
   -p guest-agent -p guest-download -p guest-init -p guest-mock-claude -p guest-mock-codex -p guest-reseed -p guest-write-file \
-  --release
+  --profile ci
 
 # Step 2: build runner with embedded guests
-GUEST_AGENT_PATH=target/aarch64-unknown-linux-musl/release/guest-agent \
-GUEST_DOWNLOAD_PATH=target/aarch64-unknown-linux-musl/release/guest-download \
-GUEST_INIT_PATH=target/aarch64-unknown-linux-musl/release/guest-init \
-GUEST_MOCK_CLAUDE_PATH=target/aarch64-unknown-linux-musl/release/guest-mock-claude \
-GUEST_MOCK_CODEX_PATH=target/aarch64-unknown-linux-musl/release/guest-mock-codex \
-GUEST_RESEED_PATH=target/aarch64-unknown-linux-musl/release/guest-reseed \
-GUEST_WRITE_FILE_PATH=target/aarch64-unknown-linux-musl/release/guest-write-file \
-cargo build --target aarch64-unknown-linux-musl -p runner --release
+GUEST_AGENT_PATH=target/aarch64-unknown-linux-musl/ci/guest-agent \
+GUEST_DOWNLOAD_PATH=target/aarch64-unknown-linux-musl/ci/guest-download \
+GUEST_INIT_PATH=target/aarch64-unknown-linux-musl/ci/guest-init \
+GUEST_MOCK_CLAUDE_PATH=target/aarch64-unknown-linux-musl/ci/guest-mock-claude \
+GUEST_MOCK_CODEX_PATH=target/aarch64-unknown-linux-musl/ci/guest-mock-codex \
+GUEST_RESEED_PATH=target/aarch64-unknown-linux-musl/ci/guest-reseed \
+GUEST_WRITE_FILE_PATH=target/aarch64-unknown-linux-musl/ci/guest-write-file \
+cargo build --target aarch64-unknown-linux-musl -p runner --profile ci
 ```
 
 ## Testing

--- a/crates/README.md
+++ b/crates/README.md
@@ -66,7 +66,7 @@ Both HTTP clients in the workspace use `rustls-platform-verifier` to read from t
 cargo build
 cargo build --release
 
-# Cross-compile for aarch64 (production target)
+# Cross-compile for aarch64 with the faster CI/dev profile
 # Step 1: build guest binaries
 cargo build --target aarch64-unknown-linux-musl \
   -p guest-agent -p guest-download -p guest-init -p guest-mock-claude -p guest-mock-codex -p guest-reseed -p guest-write-file \

--- a/scripts/dev-runner.sh
+++ b/scripts/dev-runner.sh
@@ -75,21 +75,21 @@ cmd_deploy() {
   # Build guests
   log "Building guest binaries..."
   cd "$CRATES_DIR"
-  cargo build --release --target "$TARGET" \
+  cargo build --profile ci --target "$TARGET" \
     -p guest-agent -p guest-download -p guest-init -p guest-mock-claude -p guest-mock-codex -p guest-reseed -p guest-write-file
 
   # Build runner
   log "Building runner with embedded guests..."
-  GUEST_AGENT_PATH="target/$TARGET/release/guest-agent" \
-  GUEST_DOWNLOAD_PATH="target/$TARGET/release/guest-download" \
-  GUEST_INIT_PATH="target/$TARGET/release/guest-init" \
-  GUEST_MOCK_CLAUDE_PATH="target/$TARGET/release/guest-mock-claude" \
-  GUEST_MOCK_CODEX_PATH="target/$TARGET/release/guest-mock-codex" \
-  GUEST_RESEED_PATH="target/$TARGET/release/guest-reseed" \
-  GUEST_WRITE_FILE_PATH="target/$TARGET/release/guest-write-file" \
-  cargo build --release --target "$TARGET" -p runner
+  GUEST_AGENT_PATH="target/$TARGET/ci/guest-agent" \
+  GUEST_DOWNLOAD_PATH="target/$TARGET/ci/guest-download" \
+  GUEST_INIT_PATH="target/$TARGET/ci/guest-init" \
+  GUEST_MOCK_CLAUDE_PATH="target/$TARGET/ci/guest-mock-claude" \
+  GUEST_MOCK_CODEX_PATH="target/$TARGET/ci/guest-mock-codex" \
+  GUEST_RESEED_PATH="target/$TARGET/ci/guest-reseed" \
+  GUEST_WRITE_FILE_PATH="target/$TARGET/ci/guest-write-file" \
+  cargo build --profile ci --target "$TARGET" -p runner
 
-  BINARY="$CRATES_DIR/target/$TARGET/release/runner"
+  BINARY="$CRATES_DIR/target/$TARGET/ci/runner"
   log "Binary: $BINARY ($(du -h "$BINARY" | cut -f1))"
 
   # Stop old service before uploading (avoids "Text file busy").
@@ -100,7 +100,7 @@ cmd_deploy() {
   # Upload
   log "Deploying to $SSH_USER@$HOST..."
   ssh_cmd "sudo mkdir -p $REMOTE_BIN_DIR"
-  cat "$BINARY" | ssh_cmd "sudo install -m 755 /dev/stdin $REMOTE_BIN_DIR/runner"
+  ssh_cmd "sudo install -m 755 /dev/stdin $REMOTE_BIN_DIR/runner" < "$BINARY"
 
   # Setup (idempotent, downloads firecracker/kernel if missing)
   log "Running setup..."


### PR DESCRIPTION
## Summary
- Build runner-image CI guest and runner binaries with `profile.ci` instead of full `release`.
- Split runner-image rust-cache onto `aarch64-musl-ci` while keeping production release on `aarch64-musl-release`.
- Keep release-please and ansible production deployment on `--release` binaries.
- Update local dev-runner and crates README examples to use the faster CI/dev profile.

Part of #12668

## Test Plan
- `bash -n .github/scripts/prepare-runner-image.sh scripts/dev-runner.sh`
- `shellcheck .github/scripts/prepare-runner-image.sh scripts/dev-runner.sh`
- `cargo metadata --manifest-path crates/Cargo.toml --format-version 1 --no-deps`
- `git diff --check --cached`
- `actionlint .github/workflows/runner-image.yml .github/workflows/release-please.yml`