### PR TITLE
ci: install runner image binary atomically

### DIFF
--- a/.github/scripts/prepare-runner-image.sh
+++ b/.github/scripts/prepare-runner-image.sh
@@ -91,7 +91,7 @@ UNIT="vm0-runner-${RUNNER_NAME}.service"
 # the final path.
 if ! stop_output=$(sudo systemctl stop "${UNIT}" 2>&1); then
   case "$stop_output" in
-    *"not loaded"*|*"not found"*) ;;
+    *"Unit ${UNIT} not loaded."*|*"Unit ${UNIT} could not be found."*|*"Unit ${UNIT} not found."*) ;;
     *)
       printf '%s\n' "$stop_output" >&2
       exit 1

--- a/.github/scripts/prepare-runner-image.sh
+++ b/.github/scripts/prepare-runner-image.sh
@@ -86,11 +86,10 @@ RUNNER_DIR=$2
 RUNNER_NAME=$3
 UNIT="vm0-runner-${RUNNER_NAME}.service"
 
-if [ -x "${BIN_DIR}/runner" ]; then
-  sudo "${BIN_DIR}/runner" service stop --name "${RUNNER_NAME}" --force
-else
-  sudo systemctl stop "${UNIT}" 2>/dev/null || true
-fi
+# This CI cleanup is intentionally forceful. Avoid executing the existing
+# runner binary here: a cancelled prior prepare can leave a truncated binary at
+# the final path.
+sudo systemctl stop "${UNIT}" 2>/dev/null || true
 
 if sudo systemctl is-active --quiet "${UNIT}" 2>/dev/null; then
   echo "runner service ${UNIT} is still active after stop" >&2
@@ -113,7 +112,33 @@ REMOTE_SCRIPT
     return 1
   fi
 
-  if ! ssh "$remote" sudo install -m 755 /dev/stdin "${BIN_DIR}/runner" < "${TARGET_DIR}/runner"; then
+  local tmp_runner="${BIN_DIR}/runner.${HEAD_SHA}.${host_index}.tmp"
+  if ! ssh "$remote" sudo install -m 755 /dev/stdin "${tmp_runner}" < "${TARGET_DIR}/runner"; then
+    return 1
+  fi
+
+  if ! ssh "$remote" bash -s -- "${tmp_runner}" "${BIN_DIR}/runner" "${runner_sha}" <<'REMOTE_SCRIPT'
+set -euo pipefail
+TMP_RUNNER=$1
+FINAL_RUNNER=$2
+EXPECTED_SHA=$3
+
+cleanup_tmp() {
+  sudo rm -f "${TMP_RUNNER}"
+}
+trap cleanup_tmp EXIT
+
+actual_sha=$(sudo sha256sum "${TMP_RUNNER}" | awk '{print $1}')
+if [ "${actual_sha}" != "${EXPECTED_SHA}" ]; then
+  echo "runner sha mismatch: ${actual_sha} != ${EXPECTED_SHA}" >&2
+  exit 1
+fi
+
+sudo "${TMP_RUNNER}" --version >/dev/null
+sudo mv -f "${TMP_RUNNER}" "${FINAL_RUNNER}"
+trap - EXIT
+REMOTE_SCRIPT
+  then
     return 1
   fi
 

--- a/.github/scripts/prepare-runner-image.sh
+++ b/.github/scripts/prepare-runner-image.sh
@@ -89,7 +89,15 @@ UNIT="vm0-runner-${RUNNER_NAME}.service"
 # This CI cleanup is intentionally forceful. Avoid executing the existing
 # runner binary here: a cancelled prior prepare can leave a truncated binary at
 # the final path.
-sudo systemctl stop "${UNIT}" 2>/dev/null || true
+if ! stop_output=$(sudo systemctl stop "${UNIT}" 2>&1); then
+  case "$stop_output" in
+    *"not loaded"*|*"not found"*) ;;
+    *)
+      printf '%s\n' "$stop_output" >&2
+      exit 1
+      ;;
+  esac
+fi
 
 if sudo systemctl is-active --quiet "${UNIT}" 2>/dev/null; then
   echo "runner service ${UNIT} is still active after stop" >&2


### PR DESCRIPTION
## Summary
- stop runner-image CI services with systemctl instead of executing an existing per-PR runner binary
- upload the new runner to a temporary path, verify sha256 and --version, then atomically move it into place
- prevent cancelled runner-image prepares from leaving a truncated executable at ${BIN_DIR}/runner

## Root Cause
- dev-2 had /var/lib/vm0-runner/bin/pr-12782/runner truncated at 26,476,544 bytes with missing ELF section headers
- its mtime matched the cancelled Runner Image run 25679740009, which was cancelled during the prepare step just after the runner build completed
- the old script streamed install directly to the final path, so cancellation could leave an executable but partial final file; later retries executed it before cleanup and segfaulted

## Testing
- bash -n .github/scripts/prepare-runner-image.sh
- bash .github/scripts/tests/runner-image-context-test.sh
- bash .github/scripts/tests/runner-image-manifest-test.sh
- bash .github/scripts/tests/wait-runner-image-test.sh

Note: shellcheck is not installed in this environment.