### PR TITLE
feat(api): migrate integrations/slack/connect post to api backend

### DIFF
--- a/turbo/apps/api/src/__tests__/mocks.ts
+++ b/turbo/apps/api/src/__tests__/mocks.ts
@@ -44,6 +44,7 @@ export interface ApiTestMocks {
   readonly slack: {
     readonly chat: {
       readonly postMessage: AsyncMock;
+      readonly postEphemeral: AsyncMock;
     };
     readonly conversations: {
       readonly list: AsyncMock;
@@ -138,6 +139,7 @@ const apiTestMocks: ApiTestMocks = vi.hoisted((): ApiTestMocks => {
   const slack = {
     chat: {
       postMessage: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
+      postEphemeral: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
     },
     conversations: {
       list: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
@@ -379,6 +381,7 @@ vi.mock("@slack/web-api", () => {
       return {
         chat: {
           postMessage: apiTestMocks.slack.chat.postMessage,
+          postEphemeral: apiTestMocks.slack.chat.postEphemeral,
         },
         conversations: {
           list: apiTestMocks.slack.conversations.list,
@@ -492,6 +495,7 @@ export function resetApiTestMocks(): void {
   );
   apiTestMocks.s3.clientConfig.mockReset();
   apiTestMocks.slack.chat.postMessage.mockReset();
+  apiTestMocks.slack.chat.postEphemeral.mockReset();
   apiTestMocks.slack.conversations.list.mockReset();
   apiTestMocks.slack.conversations.open.mockReset();
   apiTestMocks.slack.files.info.mockReset();

--- a/turbo/apps/api/src/lib/slack-connect-blocks.ts
+++ b/turbo/apps/api/src/lib/slack-connect-blocks.ts
@@ -1,0 +1,59 @@
+import type { Block, KnownBlock } from "@slack/web-api";
+
+export function buildWelcomeMessage(
+  agentName?: string,
+): (Block | KnownBlock)[] {
+  const blocks: (Block | KnownBlock)[] = [
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: ":wave: *Hi! I'm Zero.*\n\nI can connect you to AI agents to help with your tasks.",
+      },
+    },
+    {
+      type: "divider",
+    },
+  ];
+
+  if (agentName) {
+    blocks.push(
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: `*Workspace Agent*\n\u2022 \`${agentName}\``,
+        },
+      },
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: "*How to Use*\n\u2022 Just describe what you need help with",
+        },
+      },
+    );
+  } else {
+    blocks.push({
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: "_No workspace agent configured yet._",
+      },
+    });
+  }
+
+  return blocks;
+}
+
+export function buildSuccessMessage(message: string): (Block | KnownBlock)[] {
+  return [
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: `:white_check_mark: ${message}`,
+      },
+    },
+  ];
+}

--- a/turbo/apps/api/src/signals/external/slack-message-client.ts
+++ b/turbo/apps/api/src/signals/external/slack-message-client.ts
@@ -14,6 +14,10 @@ type PostMessageResult =
     }
   | { readonly kind: "slack_error"; readonly error: string };
 
+type PostEphemeralResult =
+  | { readonly kind: "ok"; readonly ts: string | undefined }
+  | { readonly kind: "slack_error"; readonly error: string };
+
 export function createSlackClient(token: string): WebClient {
   return new WebClient(token);
 }
@@ -76,6 +80,34 @@ export async function postMessage(
     throw result.error;
   }
   return { kind: "ok", ts: result.ok.ts, channel: result.ok.channel };
+}
+
+export async function postEphemeral(
+  client: WebClient,
+  options: {
+    readonly channel: string;
+    readonly user: string;
+    readonly text: string;
+    readonly threadTs?: string;
+    readonly blocks?: (Block | KnownBlock)[];
+  },
+): Promise<PostEphemeralResult> {
+  const result = await safeAsync(() => {
+    return client.chat.postEphemeral({
+      channel: options.channel,
+      user: options.user,
+      text: options.text,
+      thread_ts: options.threadTs,
+      blocks: options.blocks,
+    });
+  });
+  if ("error" in result) {
+    if (isSlackPlatformError(result.error)) {
+      return { kind: "slack_error", error: result.error.data.error };
+    }
+    throw result.error;
+  }
+  return { kind: "ok", ts: result.ok.message_ts };
 }
 
 type GetUploadUrlResult =

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-slack-connect.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-slack-connect.ts
@@ -3,20 +3,27 @@ import { randomUUID } from "node:crypto";
 import { command } from "ccstate";
 import { slackOrgConnections } from "@vm0/db/schema/slack-org-connection";
 import { slackOrgInstallations } from "@vm0/db/schema/slack-org-installation";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 
 import { writeDb$ } from "../../../external/db";
+import { encryptSecretForTests } from "./encrypt-secret";
 
 export interface SlackConnectFixture {
   readonly orgId: string;
   readonly userId: string;
   readonly slackWorkspaceId: string;
   readonly slackWorkspaceName: string;
+  readonly slackUserId: string;
 }
 
 interface SeedValues {
   readonly withConnection?: boolean;
   readonly slackWorkspaceName?: string;
+  readonly orgId?: string;
+  readonly userId?: string;
+  readonly slackWorkspaceId?: string;
+  readonly slackUserId?: string;
+  readonly installationOrgId?: string | null;
 }
 
 export const seedSlackConnectOrg$ = command(
@@ -25,31 +32,79 @@ export const seedSlackConnectOrg$ = command(
     values: SeedValues,
     signal: AbortSignal,
   ): Promise<SlackConnectFixture> => {
-    const orgId = `org_${randomUUID()}`;
-    const userId = `user_${randomUUID()}`;
-    const slackWorkspaceId = `T_${randomUUID().replace(/-/g, "").slice(0, 10)}`;
+    const orgId = values.orgId ?? `org_${randomUUID()}`;
+    const userId = values.userId ?? `user_${randomUUID()}`;
+    const slackWorkspaceId =
+      values.slackWorkspaceId ??
+      `T_${randomUUID().replace(/-/g, "").slice(0, 10)}`;
     const slackWorkspaceName = values.slackWorkspaceName ?? "Test Workspace";
+    const slackUserId =
+      values.slackUserId ?? `U_USER_${randomUUID().slice(0, 8)}`;
+    const installationOrgId =
+      values.installationOrgId === undefined ? orgId : values.installationOrgId;
     const writeDb = set(writeDb$);
 
     await writeDb.insert(slackOrgInstallations).values({
       slackWorkspaceId,
       slackWorkspaceName,
-      orgId,
-      encryptedBotToken: "encrypted-token",
+      orgId: installationOrgId,
+      encryptedBotToken: encryptSecretForTests("xoxb-test-bot-token"),
       botUserId: "U_BOT_TEST",
     });
     signal.throwIfAborted();
 
     if (values.withConnection) {
       await writeDb.insert(slackOrgConnections).values({
-        slackUserId: `U_USER_${randomUUID().slice(0, 8)}`,
+        slackUserId,
         slackWorkspaceId,
         vm0UserId: userId,
       });
       signal.throwIfAborted();
     }
 
-    return { orgId, userId, slackWorkspaceId, slackWorkspaceName };
+    return { orgId, userId, slackWorkspaceId, slackWorkspaceName, slackUserId };
+  },
+);
+
+export const findSlackOrgConnection$ = command(
+  async (
+    { set },
+    values: {
+      readonly slackWorkspaceId: string;
+      readonly slackUserId: string;
+    },
+    signal: AbortSignal,
+  ): Promise<typeof slackOrgConnections.$inferSelect | undefined> => {
+    const writeDb = set(writeDb$);
+    const [connection] = await writeDb
+      .select()
+      .from(slackOrgConnections)
+      .where(
+        and(
+          eq(slackOrgConnections.slackWorkspaceId, values.slackWorkspaceId),
+          eq(slackOrgConnections.slackUserId, values.slackUserId),
+        ),
+      )
+      .limit(1);
+    signal.throwIfAborted();
+    return connection;
+  },
+);
+
+export const findSlackOrgInstallation$ = command(
+  async (
+    { set },
+    slackWorkspaceId: string,
+    signal: AbortSignal,
+  ): Promise<typeof slackOrgInstallations.$inferSelect | undefined> => {
+    const writeDb = set(writeDb$);
+    const [installation] = await writeDb
+      .select()
+      .from(slackOrgInstallations)
+      .where(eq(slackOrgInstallations.slackWorkspaceId, slackWorkspaceId))
+      .limit(1);
+    signal.throwIfAborted();
+    return installation;
   },
 );
 

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-slack-connect.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-slack-connect.test.ts
@@ -5,6 +5,7 @@ import { createStore } from "ccstate";
 
 import { createApp } from "../../../app-factory";
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { clearAllDetached } from "../../utils";
 import {
   createFixtureTracker,
   createZeroRouteMocks,
@@ -322,6 +323,143 @@ describe("POST /api/zero/integrations/slack/connect", () => {
     );
 
     expect(response.body.role).toBe("admin");
+  });
+
+  it("sends an ephemeral Slack confirmation when channel context is provided", async () => {
+    const fixture = await track(
+      store.set(seedSlackConnectOrg$, {}, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+
+    const client = setupApp({ context })(zeroSlackConnectContract);
+    await accept(
+      client.connect({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          workspaceId: fixture.slackWorkspaceId,
+          slackUserId: fixture.slackUserId,
+          channelId: "C_TEST_CHANNEL",
+          threadTs: "1234567890.123456",
+        },
+      }),
+      [200],
+    );
+
+    await clearAllDetached();
+
+    expect(context.mocks.slack.chat.postEphemeral).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "C_TEST_CHANNEL",
+        user: fixture.slackUserId,
+        text: "You're connected!",
+        thread_ts: "1234567890.123456",
+      }),
+    );
+    expect(context.mocks.slack.chat.postMessage).not.toHaveBeenCalled();
+
+    const connection = await store.set(
+      findSlackOrgConnection$,
+      {
+        slackWorkspaceId: fixture.slackWorkspaceId,
+        slackUserId: fixture.slackUserId,
+      },
+      context.signal,
+    );
+    expect(connection?.dmWelcomeSent).toBeFalsy();
+  });
+
+  it("sends a DM welcome when no channel context is provided", async () => {
+    const fixture = await track(
+      store.set(seedSlackConnectOrg$, {}, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+
+    const client = setupApp({ context })(zeroSlackConnectContract);
+    await accept(
+      client.connect({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          workspaceId: fixture.slackWorkspaceId,
+          slackUserId: fixture.slackUserId,
+        },
+      }),
+      [200],
+    );
+
+    await clearAllDetached();
+
+    expect(context.mocks.slack.chat.postEphemeral).not.toHaveBeenCalled();
+    expect(context.mocks.slack.chat.postMessage).toHaveBeenCalledTimes(2);
+    expect(context.mocks.slack.chat.postMessage).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        channel: fixture.slackUserId,
+        text: "You're connected!",
+      }),
+    );
+    expect(context.mocks.slack.chat.postMessage).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        channel: fixture.slackUserId,
+        text: "Hi! I'm Zero.",
+        thread_ts: "mock.ts",
+      }),
+    );
+
+    const connection = await store.set(
+      findSlackOrgConnection$,
+      {
+        slackWorkspaceId: fixture.slackWorkspaceId,
+        slackUserId: fixture.slackUserId,
+      },
+      context.signal,
+    );
+    expect(connection?.dmWelcomeSent).toBeTruthy();
+  });
+
+  it("falls back to DM welcome when ephemeral Slack confirmation fails", async () => {
+    const fixture = await track(
+      store.set(seedSlackConnectOrg$, {}, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+    context.mocks.slack.chat.postEphemeral.mockRejectedValueOnce(
+      Object.assign(new Error("not_in_channel"), {
+        data: { ok: false, error: "not_in_channel" },
+      }),
+    );
+
+    const client = setupApp({ context })(zeroSlackConnectContract);
+    await accept(
+      client.connect({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          workspaceId: fixture.slackWorkspaceId,
+          slackUserId: fixture.slackUserId,
+          channelId: "C_TEST_CHANNEL",
+        },
+      }),
+      [200],
+    );
+
+    await clearAllDetached();
+
+    expect(context.mocks.slack.chat.postEphemeral).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "C_TEST_CHANNEL",
+        user: fixture.slackUserId,
+      }),
+    );
+    expect(context.mocks.slack.chat.postMessage).toHaveBeenCalledTimes(2);
+
+    const connection = await store.set(
+      findSlackOrgConnection$,
+      {
+        slackWorkspaceId: fixture.slackWorkspaceId,
+        slackUserId: fixture.slackUserId,
+      },
+      context.signal,
+    );
+    expect(connection?.dmWelcomeSent).toBeTruthy();
   });
 
   it("admin connects to an unbound workspace (binds it)", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-slack-connect.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-slack-connect.test.ts
@@ -1,6 +1,9 @@
+import { randomUUID } from "node:crypto";
+
 import { zeroSlackConnectContract } from "@vm0/api-contracts/contracts/zero-slack-connect";
 import { createStore } from "ccstate";
 
+import { createApp } from "../../../app-factory";
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
 import {
   createFixtureTracker,
@@ -8,6 +11,8 @@ import {
 } from "./helpers/zero-route-test";
 import {
   deleteSlackConnectOrg$,
+  findSlackOrgConnection$,
+  findSlackOrgInstallation$,
   seedSlackConnectOrg$,
   type SlackConnectFixture,
 } from "./helpers/zero-slack-connect";
@@ -15,6 +20,34 @@ import {
 const context = testContext();
 const store = createStore();
 const mocks = createZeroRouteMocks(context);
+const SLACK_CONNECT_PATH = "/api/zero/integrations/slack/connect";
+
+async function postRawSlackConnect(body: string): Promise<{
+  readonly status: number;
+  readonly body: unknown;
+}> {
+  const app = createApp({ signal: context.signal });
+  const response = await app.request(SLACK_CONNECT_PATH, {
+    method: "POST",
+    headers: {
+      authorization: "Bearer clerk-session",
+      "content-type": "application/json",
+    },
+    body,
+  });
+
+  return {
+    status: response.status,
+    body: await response.json(),
+  };
+}
+
+function expectErrorCode(
+  body: unknown,
+  code: string,
+): asserts body is { readonly error: { readonly message: string } } {
+  expect(body).toMatchObject({ error: { code } });
+}
 
 describe("GET /api/zero/integrations/slack/connect", () => {
   const track = createFixtureTracker<SlackConnectFixture>((fixture) => {
@@ -139,5 +172,311 @@ describe("GET /api/zero/integrations/slack/connect", () => {
     );
 
     expect(response.body.isAdmin).toBeFalsy();
+  });
+});
+
+describe("POST /api/zero/integrations/slack/connect", () => {
+  const track = createFixtureTracker<SlackConnectFixture>((fixture) => {
+    return store.set(deleteSlackConnectOrg$, fixture, context.signal);
+  });
+
+  beforeEach(() => {
+    context.mocks.slack.chat.postMessage.mockResolvedValue({
+      ok: true,
+      ts: "mock.ts",
+      channel: "D_TEST",
+    });
+    context.mocks.slack.chat.postEphemeral.mockResolvedValue({
+      ok: true,
+      message_ts: "mock.ephemeral.ts",
+    });
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    const client = setupApp({ context })(zeroSlackConnectContract);
+
+    const response = await accept(
+      client.connect({
+        headers: {},
+        body: {
+          workspaceId: "T-test",
+          slackUserId: "U-test",
+        },
+      }),
+      [401],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Not authenticated",
+        code: "UNAUTHORIZED",
+      },
+    });
+  });
+
+  it("returns 400 when body is missing required fields", async () => {
+    const fixture = await track(
+      store.set(seedSlackConnectOrg$, {}, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+
+    const response = await postRawSlackConnect("{}");
+
+    expect(response.status).toBe(400);
+    expectErrorCode(response.body, "BAD_REQUEST");
+  });
+
+  it("returns 400 when body is not valid JSON", async () => {
+    const fixture = await track(
+      store.set(seedSlackConnectOrg$, {}, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+
+    const response = await postRawSlackConnect("not-json");
+
+    expect(response.status).toBe(400);
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Invalid JSON in request body",
+        code: "BAD_REQUEST",
+      },
+    });
+  });
+
+  it("returns 404 when workspace does not exist", async () => {
+    const fixture = await track(
+      store.set(seedSlackConnectOrg$, {}, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+
+    const client = setupApp({ context })(zeroSlackConnectContract);
+    const response = await accept(
+      client.connect({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          workspaceId: "T-nonexistent",
+          slackUserId: fixture.slackUserId,
+        },
+      }),
+      [404],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Workspace not found. Please install the Slack app first.",
+        code: "NOT_FOUND",
+      },
+    });
+  });
+
+  it("member connects successfully to a bound workspace", async () => {
+    const fixture = await track(
+      store.set(seedSlackConnectOrg$, {}, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:member");
+
+    const client = setupApp({ context })(zeroSlackConnectContract);
+    const response = await accept(
+      client.connect({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          workspaceId: fixture.slackWorkspaceId,
+          slackUserId: fixture.slackUserId,
+        },
+      }),
+      [200],
+    );
+
+    expect(response.body.role).toBe("member");
+    const connection = await store.set(
+      findSlackOrgConnection$,
+      {
+        slackWorkspaceId: fixture.slackWorkspaceId,
+        slackUserId: fixture.slackUserId,
+      },
+      context.signal,
+    );
+    expect(connection).toMatchObject({
+      id: response.body.connectionId,
+      vm0UserId: fixture.userId,
+      slackWorkspaceId: fixture.slackWorkspaceId,
+    });
+  });
+
+  it("admin connects successfully to a bound workspace", async () => {
+    const fixture = await track(
+      store.set(seedSlackConnectOrg$, {}, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+
+    const client = setupApp({ context })(zeroSlackConnectContract);
+    const response = await accept(
+      client.connect({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          workspaceId: fixture.slackWorkspaceId,
+          slackUserId: fixture.slackUserId,
+        },
+      }),
+      [200],
+    );
+
+    expect(response.body.role).toBe("admin");
+  });
+
+  it("admin connects to an unbound workspace (binds it)", async () => {
+    const fixture = await track(
+      store.set(
+        seedSlackConnectOrg$,
+        { installationOrgId: null },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+
+    const client = setupApp({ context })(zeroSlackConnectContract);
+    const response = await accept(
+      client.connect({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          workspaceId: fixture.slackWorkspaceId,
+          slackUserId: fixture.slackUserId,
+        },
+      }),
+      [200],
+    );
+
+    expect(response.body.role).toBe("admin");
+    const installation = await store.set(
+      findSlackOrgInstallation$,
+      fixture.slackWorkspaceId,
+      context.signal,
+    );
+    expect(installation?.orgId).toBe(fixture.orgId);
+    expect(installation?.installedByUserId).toBe(fixture.userId);
+  });
+
+  it("returns 403 when non-admin tries to connect unbound workspace", async () => {
+    const fixture = await track(
+      store.set(
+        seedSlackConnectOrg$,
+        { installationOrgId: null },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:member");
+
+    const client = setupApp({ context })(zeroSlackConnectContract);
+    const response = await accept(
+      client.connect({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          workspaceId: fixture.slackWorkspaceId,
+          slackUserId: fixture.slackUserId,
+        },
+      }),
+      [403],
+    );
+
+    expect(response.body.error.code).toBe("FORBIDDEN");
+    expect(response.body.error.message).toContain("Only org admins");
+  });
+
+  it("returns 403 when workspace is bound to a different org", async () => {
+    const targetOrgId = `org_${randomUUID()}`;
+    const fixture = await track(
+      store.set(
+        seedSlackConnectOrg$,
+        { installationOrgId: targetOrgId },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+
+    const client = setupApp({ context })(zeroSlackConnectContract);
+    const response = await accept(
+      client.connect({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          workspaceId: fixture.slackWorkspaceId,
+          slackUserId: fixture.slackUserId,
+        },
+      }),
+      [403],
+    );
+
+    expect(response.body.error.code).toBe("FORBIDDEN");
+    const connection = await store.set(
+      findSlackOrgConnection$,
+      {
+        slackWorkspaceId: fixture.slackWorkspaceId,
+        slackUserId: fixture.slackUserId,
+      },
+      context.signal,
+    );
+    expect(connection).toBeUndefined();
+  });
+
+  it("returns 403 with switch-org message when user is member of target org but wrong active org", async () => {
+    const targetOrgId = `org_${randomUUID()}`;
+    const fixture = await track(
+      store.set(
+        seedSlackConnectOrg$,
+        { installationOrgId: targetOrgId },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:member");
+
+    const client = setupApp({ context })(zeroSlackConnectContract);
+    const response = await accept(
+      client.connect({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          workspaceId: fixture.slackWorkspaceId,
+          slackUserId: fixture.slackUserId,
+        },
+      }),
+      [403],
+    );
+
+    expect(response.body.error.message).toContain(
+      "switch to the correct organization",
+    );
+  });
+
+  it("connect is idempotent - second connect returns success", async () => {
+    const fixture = await track(
+      store.set(seedSlackConnectOrg$, {}, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+
+    const client = setupApp({ context })(zeroSlackConnectContract);
+    const first = await accept(
+      client.connect({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          workspaceId: fixture.slackWorkspaceId,
+          slackUserId: fixture.slackUserId,
+        },
+      }),
+      [200],
+    );
+    const second = await accept(
+      client.connect({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          workspaceId: fixture.slackWorkspaceId,
+          slackUserId: fixture.slackUserId,
+        },
+      }),
+      [200],
+    );
+
+    expect(second.body).toMatchObject({
+      success: true,
+      role: "admin",
+      connectionId: first.body.connectionId,
+    });
   });
 });

--- a/turbo/apps/api/src/signals/routes/zero-slack-connect.ts
+++ b/turbo/apps/api/src/signals/routes/zero-slack-connect.ts
@@ -1,10 +1,20 @@
-import { computed } from "ccstate";
+import { command, computed } from "ccstate";
 import { zeroSlackConnectContract } from "@vm0/api-contracts/contracts/zero-slack-connect";
 
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
-import { zeroSlackConnectStatus } from "../services/zero-slack-connect.service";
+import { bodyResultOf } from "../context/request";
+import { waitUntil } from "../context/wait-until";
+import { logger } from "../../lib/log";
+import {
+  connectSlackWorkspace$,
+  notifySlackConnect$,
+  publishSlackAdminSignal$,
+  zeroSlackConnectStatus,
+} from "../services/zero-slack-connect.service";
 import type { RouteEntry } from "../route";
+
+const L = logger("SlackConnect");
 
 const getSlackConnectStatusInner$ = computed(async (get) => {
   const auth = get(organizationAuthContext$);
@@ -18,12 +28,103 @@ const getSlackConnectStatusInner$ = computed(async (get) => {
   return { status: 200 as const, body };
 });
 
+const connectInner$ = command(async ({ get, set }, signal: AbortSignal) => {
+  const auth = get(organizationAuthContext$);
+  signal.throwIfAborted();
+
+  const bodyResult = await get(bodyResultOf(zeroSlackConnectContract.connect));
+  signal.throwIfAborted();
+  if (!bodyResult.ok) {
+    return bodyResult.response;
+  }
+  const body = bodyResult.data;
+
+  const result = await set(
+    connectSlackWorkspace$,
+    {
+      userId: auth.userId,
+      orgId: auth.orgId,
+      orgRole:
+        "orgRole" in auth && auth.orgRole === "admin" ? "admin" : "member",
+      workspaceId: body.workspaceId,
+      slackUserId: body.slackUserId,
+      channelId: body.channelId,
+      threadTs: body.threadTs,
+    },
+    signal,
+  );
+  signal.throwIfAborted();
+
+  if (result.kind === "not_found") {
+    return {
+      status: 404 as const,
+      body: {
+        error: { message: result.message, code: "NOT_FOUND" },
+      },
+    };
+  }
+
+  if (result.kind === "forbidden") {
+    return {
+      status: 403 as const,
+      body: {
+        error: { message: result.message, code: "FORBIDDEN" },
+      },
+    };
+  }
+
+  await set(
+    publishSlackAdminSignal$,
+    { orgId: auth.orgId, topic: "slack:changed" },
+    signal,
+  );
+  signal.throwIfAborted();
+
+  waitUntil(
+    set(
+      notifySlackConnect$,
+      {
+        installation: result.installation,
+        slackUserId: result.slackUserId,
+        channelId: result.channelId,
+        threadTs: result.threadTs,
+      },
+      signal,
+    ).catch((error: unknown) => {
+      L.error("notifySlackConnect failed", {
+        workspaceId: result.installation.slackWorkspaceId,
+        error,
+      });
+    }),
+  );
+
+  return {
+    status: 200 as const,
+    body: {
+      success: true as const,
+      connectionId: result.connectionId,
+      role: result.role,
+    },
+  };
+});
+
+const slackConnectAuth = {
+  requireOrganization: true,
+  missingOrganizationStatus: 401,
+} as const;
+
+const slackConnectWriteAuth = {
+  ...slackConnectAuth,
+  requiredCapability: "slack:write",
+} as const;
+
 export const zeroSlackConnectRoutes: readonly RouteEntry[] = [
   {
     route: zeroSlackConnectContract.getStatus,
-    handler: authRoute(
-      { requireOrganization: true, missingOrganizationStatus: 401 },
-      getSlackConnectStatusInner$,
-    ),
+    handler: authRoute(slackConnectAuth, getSlackConnectStatusInner$),
+  },
+  {
+    route: zeroSlackConnectContract.connect,
+    handler: authRoute(slackConnectWriteAuth, connectInner$),
   },
 ];

--- a/turbo/apps/api/src/signals/services/zero-slack-connect.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-slack-connect.service.ts
@@ -1,12 +1,88 @@
-import { computed, type Computed } from "ccstate";
+import { command, computed, type Computed } from "ccstate";
 import { agentComposes } from "@vm0/db/schema/agent-compose";
+import { orgMembersCache } from "@vm0/db/schema/org-members-cache";
 import { orgMetadata } from "@vm0/db/schema/org-metadata";
 import { slackOrgConnections } from "@vm0/db/schema/slack-org-connection";
 import { slackOrgInstallations } from "@vm0/db/schema/slack-org-installation";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
-import { and, eq } from "drizzle-orm";
+import { and, eq, isNull } from "drizzle-orm";
 
-import { db$ } from "../external/db";
+import {
+  buildSuccessMessage,
+  buildWelcomeMessage,
+} from "../../lib/slack-connect-blocks";
+import { publishUserSignal } from "../external/realtime";
+import {
+  createSlackClient,
+  postEphemeral,
+  postMessage,
+} from "../external/slack-message-client";
+import { nowDate } from "../external/time";
+import { db$, writeDb$, type Db } from "../external/db";
+import { decryptSecretValue } from "./crypto.utils";
+
+type SlackInstallation = typeof slackOrgInstallations.$inferSelect;
+
+type ConnectResult =
+  | { readonly kind: "not_found"; readonly message: string }
+  | { readonly kind: "forbidden"; readonly message: string }
+  | {
+      readonly kind: "ok";
+      readonly connectionId: string;
+      readonly role: "admin" | "member";
+      readonly installation: SlackInstallation;
+      readonly slackUserId: string;
+      readonly channelId?: string;
+      readonly threadTs?: string;
+    };
+
+const workspaceNotFoundMessage =
+  "Workspace not found. Please install the Slack app first.";
+const adminRequiredMessage =
+  "Only org admins can connect an unconfigured workspace. Ask your org admin to connect first.";
+const orgMismatchMessage =
+  "Your active organization doesn't match this Slack workspace. Please switch to the correct organization in the platform sidebar before connecting.";
+
+async function upsertSlackConnection(
+  writeDb: Db,
+  args: {
+    readonly slackUserId: string;
+    readonly slackWorkspaceId: string;
+    readonly vm0UserId: string;
+  },
+): Promise<string> {
+  const [connection] = await writeDb
+    .insert(slackOrgConnections)
+    .values(args)
+    .onConflictDoNothing({
+      target: [
+        slackOrgConnections.slackUserId,
+        slackOrgConnections.slackWorkspaceId,
+      ],
+    })
+    .returning({ id: slackOrgConnections.id });
+
+  if (connection) {
+    return connection.id;
+  }
+
+  const [existing] = await writeDb
+    .select({ id: slackOrgConnections.id })
+    .from(slackOrgConnections)
+    .where(
+      and(
+        eq(slackOrgConnections.slackUserId, args.slackUserId),
+        eq(slackOrgConnections.slackWorkspaceId, args.slackWorkspaceId),
+      ),
+    )
+    .limit(1);
+
+  if (!existing) {
+    throw new Error("Slack connection upsert did not return a row");
+  }
+
+  return existing.id;
+}
 
 export function zeroSlackConnectStatus(args: {
   readonly orgId: string;
@@ -71,3 +147,210 @@ export function zeroSlackConnectStatus(args: {
     };
   });
 }
+
+export const connectSlackWorkspace$ = command(
+  async (
+    { set },
+    args: {
+      readonly userId: string;
+      readonly orgId: string;
+      readonly orgRole: "admin" | "member";
+      readonly workspaceId: string;
+      readonly slackUserId: string;
+      readonly channelId?: string;
+      readonly threadTs?: string;
+    },
+    signal: AbortSignal,
+  ): Promise<ConnectResult> => {
+    const writeDb = set(writeDb$);
+    const [installation] = await writeDb
+      .select()
+      .from(slackOrgInstallations)
+      .where(eq(slackOrgInstallations.slackWorkspaceId, args.workspaceId))
+      .limit(1);
+    signal.throwIfAborted();
+
+    if (!installation) {
+      return { kind: "not_found", message: workspaceNotFoundMessage };
+    }
+
+    if (installation.orgId === null) {
+      if (args.orgRole !== "admin") {
+        return { kind: "forbidden", message: adminRequiredMessage };
+      }
+
+      const [updated] = await writeDb
+        .update(slackOrgInstallations)
+        .set({
+          orgId: args.orgId,
+          installedByUserId: args.userId,
+          updatedAt: nowDate(),
+        })
+        .where(
+          and(
+            eq(slackOrgInstallations.slackWorkspaceId, args.workspaceId),
+            isNull(slackOrgInstallations.orgId),
+          ),
+        )
+        .returning();
+      signal.throwIfAborted();
+
+      let boundInstallation = updated;
+      if (!boundInstallation) {
+        const [existing] = await writeDb
+          .select()
+          .from(slackOrgInstallations)
+          .where(eq(slackOrgInstallations.slackWorkspaceId, args.workspaceId))
+          .limit(1);
+        signal.throwIfAborted();
+        if (!existing) {
+          return { kind: "not_found", message: workspaceNotFoundMessage };
+        }
+        if (existing.orgId !== args.orgId) {
+          return { kind: "forbidden", message: orgMismatchMessage };
+        }
+        boundInstallation = existing;
+      }
+
+      const connectionId = await upsertSlackConnection(writeDb, {
+        slackUserId: args.slackUserId,
+        slackWorkspaceId: args.workspaceId,
+        vm0UserId: args.userId,
+      });
+      signal.throwIfAborted();
+
+      return {
+        kind: "ok",
+        connectionId,
+        role: "admin",
+        installation: boundInstallation,
+        slackUserId: args.slackUserId,
+        channelId: args.channelId,
+        threadTs: args.threadTs,
+      };
+    }
+
+    if (installation.orgId !== args.orgId) {
+      return { kind: "forbidden", message: orgMismatchMessage };
+    }
+
+    const connectionId = await upsertSlackConnection(writeDb, {
+      slackUserId: args.slackUserId,
+      slackWorkspaceId: args.workspaceId,
+      vm0UserId: args.userId,
+    });
+    signal.throwIfAborted();
+
+    return {
+      kind: "ok",
+      connectionId,
+      role: args.orgRole,
+      installation,
+      slackUserId: args.slackUserId,
+      channelId: args.channelId,
+      threadTs: args.threadTs,
+    };
+  },
+);
+
+export const publishSlackAdminSignal$ = command(
+  async (
+    { get },
+    args: {
+      readonly orgId: string;
+      readonly topic: string;
+      readonly payload?: unknown;
+    },
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const db = get(db$);
+    const admins = await db
+      .select({ userId: orgMembersCache.userId })
+      .from(orgMembersCache)
+      .where(
+        and(
+          eq(orgMembersCache.orgId, args.orgId),
+          eq(orgMembersCache.role, "admin"),
+        ),
+      );
+    signal.throwIfAborted();
+
+    await publishUserSignal(
+      admins.map((admin) => {
+        return admin.userId;
+      }),
+      args.topic,
+      args.payload,
+    );
+    signal.throwIfAborted();
+  },
+);
+
+export const notifySlackConnect$ = command(
+  async (
+    { set },
+    args: {
+      readonly installation: SlackInstallation;
+      readonly slackUserId: string;
+      readonly channelId?: string;
+      readonly threadTs?: string;
+    },
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const writeDb = set(writeDb$);
+    const client = createSlackClient(
+      decryptSecretValue(args.installation.encryptedBotToken),
+    );
+    const blocks = buildSuccessMessage(
+      "You're connected! :tada:\nMention `@Zero` in any channel or send a DM to start chatting with your agent.",
+    );
+
+    let sentEphemeral = false;
+    if (args.channelId) {
+      const result = await postEphemeral(client, {
+        channel: args.channelId,
+        user: args.slackUserId,
+        text: "You're connected!",
+        blocks,
+        threadTs: args.threadTs,
+      });
+      signal.throwIfAborted();
+      sentEphemeral = result.kind === "ok";
+    }
+
+    if (sentEphemeral) {
+      return;
+    }
+
+    const connectMessage = await postMessage(
+      client,
+      args.slackUserId,
+      "You're connected!",
+      { blocks },
+    );
+    signal.throwIfAborted();
+    if (connectMessage.kind !== "ok") {
+      return;
+    }
+
+    await postMessage(client, args.slackUserId, "Hi! I'm Zero.", {
+      threadTs: connectMessage.ts,
+      blocks: buildWelcomeMessage(),
+    });
+    signal.throwIfAborted();
+
+    await writeDb
+      .update(slackOrgConnections)
+      .set({ dmWelcomeSent: true })
+      .where(
+        and(
+          eq(slackOrgConnections.slackUserId, args.slackUserId),
+          eq(
+            slackOrgConnections.slackWorkspaceId,
+            args.installation.slackWorkspaceId,
+          ),
+        ),
+      );
+    signal.throwIfAborted();
+  },
+);

--- a/turbo/apps/web/src/lib/zero/context/__tests__/resolve-model-provider.test.ts
+++ b/turbo/apps/web/src/lib/zero/context/__tests__/resolve-model-provider.test.ts
@@ -846,7 +846,7 @@ describe("resolveModelProviderSecrets — model-first policy (#12130)", () => {
     await enableModelFirstModelProviderForUser(orgId, userId);
     await insertOrgModelPolicy({
       orgId,
-      model: "deepseek-v4-pro",
+      model: "gpt-5.5",
       isDefault: true,
       defaultProviderType: "vm0",
       credentialScope: "org",
@@ -860,7 +860,7 @@ describe("resolveModelProviderSecrets — model-first policy (#12130)", () => {
         false,
         undefined,
         undefined,
-        "deepseek-v4-pro",
+        "gpt-5.5",
       ),
     ).rejects.toSatisfy((err: unknown) => {
       return isBadRequest(err);


### PR DESCRIPTION
## Summary
- migrate `POST /api/zero/integrations/slack/connect` to the API backend for #12764 / #12290
- add API Slack connect service logic for workspace binding, member/admin connection upsert, Slack notification fallback, and `slack:changed` admin signal
- port Slack connect blocks and extend API route tests for auth, validation, org mismatch, unbound workspace, and idempotency
- harden the web model-provider missing-key test against VM0 key-pool cross-test pollution exposed by root vitest

## Deferred Follow-up
- #12794 tracks the remaining web-only Slack connect side effects: proactive App Home refresh and `ensureOrgArtifact`

## Tests
- `pnpm -F api exec vitest run signals/routes/__tests__/zero-slack-connect.test.ts`
- `pnpm -F api test`
- `pnpm -F api check-types`
- `pnpm -F api lint`
- `pnpm turbo run lint`
- `pnpm check-types`
- `pnpm -F web exec vitest run src/lib/zero/context/__tests__/resolve-model-provider.test.ts`
- `pnpm test`
- `pnpm knip`

Closes #12764