### PR TITLE
fix: remove remote-agent prompt guidance

### DIFF
--- a/turbo/apps/web/src/lib/zero/__tests__/agent-prompt.test.ts
+++ b/turbo/apps/web/src/lib/zero/__tests__/agent-prompt.test.ts
@@ -29,18 +29,4 @@ describe("buildAgentPrompt", () => {
       "Do not present a local path as something the user can open",
     );
   });
-
-  it("includes remote-agent guidance when enabled", () => {
-    const prompt = buildAgentPrompt(
-      {
-        displayName: null,
-        description: null,
-        sound: null,
-      },
-      { remoteAgentEnabled: true },
-    );
-
-    expect(prompt).toContain("zero remote-agent -h");
-    expect(prompt).toContain("remote agent");
-  });
 });

--- a/turbo/apps/web/src/lib/zero/__tests__/zero-run-service.test.ts
+++ b/turbo/apps/web/src/lib/zero/__tests__/zero-run-service.test.ts
@@ -110,18 +110,6 @@ describe("createZeroRun() — service-only parameters", () => {
       expect(run).toBeDefined();
       expect(run!.appendSystemPrompt).toContain("You are a helpful bot.");
     });
-
-    it("should include remote-agent tool guidance when remote agent is enabled", async () => {
-      await updateUserFeatureSwitches(user.orgId, user.userId, {
-        [FeatureSwitchKey.RemoteAgent]: true,
-      });
-
-      const result = await createZeroRun(baseParams());
-
-      const run = await findTestRunRecord(result.runId);
-      expect(run).toBeDefined();
-      expect(run!.appendSystemPrompt).toContain("zero remote-agent -h");
-    });
   });
 
   describe("trigger sources", () => {

--- a/turbo/apps/web/src/lib/zero/agent-prompt.ts
+++ b/turbo/apps/web/src/lib/zero/agent-prompt.ts
@@ -4,10 +4,6 @@ interface AgentIdentity {
   sound: string | null;
 }
 
-interface AgentPromptOptions {
-  remoteAgentEnabled?: boolean;
-}
-
 const TONE_INSTRUCTIONS: Readonly<Record<string, string>> = {
   professional:
     "Communicate in a clear, polished, and business-appropriate tone. Be thorough yet concise.",
@@ -22,15 +18,12 @@ const TONE_INSTRUCTIONS: Readonly<Record<string, string>> = {
 /**
  * Build the agent system prompt: identity + tools.
  */
-export function buildAgentPrompt(
-  identity: AgentIdentity,
-  options: AgentPromptOptions = {},
-): string {
+export function buildAgentPrompt(identity: AgentIdentity): string {
   const parts: string[] = [];
   if (identity.displayName || identity.description || identity.sound) {
     parts.push(buildAgentIdentityPrompt(identity));
   }
-  parts.push(buildAgentToolsPrompt(options));
+  parts.push(buildAgentToolsPrompt());
   return parts.join("\n\n");
 }
 
@@ -73,7 +66,7 @@ export const DISALLOWED_TOOLS = [
  * Build Agent Tools prompt so sandbox agents know how to use the Zero CLI.
  * Injected by createZeroRun() for all trigger paths.
  */
-function buildAgentToolsPrompt(options: AgentPromptOptions): string {
+function buildAgentToolsPrompt(): string {
   const parts = [
     "# Agent Tools",
     "You have access to the Zero CLI. Run commands with: `npx -p @vm0/cli zero <command>`",
@@ -98,12 +91,6 @@ function buildAgentToolsPrompt(options: AgentPromptOptions): string {
     "- Send a direct message to the user via web chat: `zero chat message send --help`.",
     "- Report issues to the dev team: `zero developer-support --help`. Requires a two-step consent flow: (1) call without --consent-code to get a code, (2) ask the user to type it, (3) call again with --consent-code. Never submit without the user typing the consent code.",
   ];
-
-  if (options.remoteAgentEnabled) {
-    parts.push(
-      "- Call a remote agent on the user's connected machine: `zero remote-agent -h`.",
-    );
-  }
 
   return parts.join("\n");
 }

--- a/turbo/apps/web/src/lib/zero/zero-run-service.ts
+++ b/turbo/apps/web/src/lib/zero/zero-run-service.ts
@@ -673,12 +673,7 @@ async function createZeroRunRecord(
     allowedConnectorTypes ?? [],
   );
 
-  const remoteAgentEnabled = isFeatureEnabled(FeatureSwitchKey.RemoteAgent, {
-    orgId: resolved.orgId,
-    userId: params.userId,
-    overrides: featureOverrides,
-  });
-  const agentPrompt = buildAgentPrompt(agent, { remoteAgentEnabled });
+  const agentPrompt = buildAgentPrompt(agent);
   const userInfo = buildUserInfo({
     name: cachedUser.name ?? undefined,
     email: cachedUser.email,


### PR DESCRIPTION
## Summary
- remove the remote-agent CLI guidance from the agent system prompt
- remove the now-unused prompt option and related tests

## Verification
- pnpm vitest run src/lib/zero/__tests__/agent-prompt.test.ts
- pnpm exec eslint src/lib/zero/agent-prompt.ts src/lib/zero/zero-run-service.ts src/lib/zero/__tests__/agent-prompt.test.ts src/lib/zero/__tests__/zero-run-service.test.ts --max-warnings 0
- pnpm exec prettier --check src/lib/zero/agent-prompt.ts src/lib/zero/zero-run-service.ts src/lib/zero/__tests__/agent-prompt.test.ts src/lib/zero/__tests__/zero-run-service.test.ts

## Notes
- `zero-run-service.test.ts` currently fails locally before reaching this change because the local test DB is missing `zero_agents.visibility`.
- The pre-commit full `check-types` run also fails in existing `apps/api` type/dependency errors unrelated to this change, so the commit was made with targeted checks above.