### PR TITLE
chore: add rustfmt config

### DIFF
--- a/crates/rustfmt.toml
+++ b/crates/rustfmt.toml
@@ -1,0 +1,2 @@
+edition = "2024"
+style_edition = "2024"


### PR DESCRIPTION
## Summary
- Add crates/rustfmt.toml for Rust 2024 formatting behavior.
- Pin both edition and style_edition to 2024 while staying on stable rustfmt options.

## Tests
- cargo fmt --manifest-path crates/Cargo.toml --all -- --check