### PR TITLE
chore: update rootfs package versions

### DIFF
--- a/crates/runner/scripts/build-template.sh
+++ b/crates/runner/scripts/build-template.sh
@@ -111,7 +111,7 @@ CACHE_TMP_TAR=""
 
 # Pinned versions (changes here invalidate the template cache via script hash)
 GO_VERSION="1.26.3"
-CLAUDE_CODE_VERSION="2.1.138"
+CLAUDE_CODE_VERSION="2.1.139"
 CODEX_CLI_VERSION="0.130.0"
 GWS_CLI_VERSION="0.22.5"
 XURL_VERSION="1.0.3"


### PR DESCRIPTION
## Summary

Updates the pinned Claude Code CLI version used by the rootfs template build.

## Updates

- Claude Code CLI: 2.1.138 -> 2.1.139

## Notes

Checked the other pinned tool versions in `crates/runner/scripts/build-template.sh`; no newer versions were found for Go, Codex CLI, Google Workspace CLI, xurl, or agent-browser.
