### PR TITLE
feat: add remote agent connector

### DIFF
--- a/turbo/apps/api/src/signals/external/realtime.ts
+++ b/turbo/apps/api/src/signals/external/realtime.ts
@@ -27,6 +27,7 @@ function getRemoteAgentHostChannelName(hostId: string): string {
 
 const REMOTE_AGENT_DEVICE_APPROVED_EVENT = "approved";
 const REMOTE_AGENT_HOST_JOB_EVENT = "job";
+const REMOTE_AGENT_HOSTS_CHANGED_EVENT = "remote-agent:hosts-changed";
 
 /**
  * Publish a per-user invalidation/notification signal.
@@ -154,4 +155,10 @@ export async function publishRemoteAgentHostJobAvailable(
   );
   await channel.publish(REMOTE_AGENT_HOST_JOB_EVENT, { jobId });
   L.debug(`Published remote-agent job ${jobId} to host ${hostId}`);
+}
+
+export async function publishRemoteAgentHostsChanged(
+  userId: string,
+): Promise<void> {
+  await publishUserSignal([userId], REMOTE_AGENT_HOSTS_CHANGED_EVENT);
 }

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-remote-agent-connect.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-remote-agent-connect.test.ts
@@ -1,0 +1,136 @@
+import { randomUUID } from "node:crypto";
+
+import { zeroRemoteAgentConnectorContract } from "@vm0/api-contracts/contracts/zero-connectors";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import { connectors } from "@vm0/db/schema/connector";
+import { remoteAgentHosts } from "@vm0/db/schema/remote-agent";
+import { userFeatureSwitches } from "@vm0/db/schema/user-feature-switches";
+import { createStore } from "ccstate";
+import { and, eq } from "drizzle-orm";
+import { afterEach } from "vitest";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { nowDate } from "../../../lib/time";
+import { writeDb$ } from "../../external/db";
+import {
+  deleteOrgMembership$,
+  seedOrgMembership$,
+  type OrgMembershipFixture,
+} from "./helpers/zero-org-membership";
+import { createZeroRouteMocks } from "./helpers/zero-route-test";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+
+async function enableRemoteAgent(orgId: string, userId: string): Promise<void> {
+  const writeDb = store.set(writeDb$);
+  await writeDb.insert(userFeatureSwitches).values({
+    orgId,
+    userId,
+    switches: { [FeatureSwitchKey.RemoteAgent]: true },
+  });
+}
+
+async function seedRemoteAgentHost(args: {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly status: string;
+  readonly lastSeenAt?: Date;
+}): Promise<void> {
+  const writeDb = store.set(writeDb$);
+  const now = nowDate();
+  await writeDb.insert(remoteAgentHosts).values({
+    orgId: args.orgId,
+    userId: args.userId,
+    displayName: `host-${randomUUID()}`,
+    tokenHash: `token-${randomUUID()}`,
+    supportedBackends: ["codex"],
+    status: args.status,
+    lastSeenAt: args.lastSeenAt ?? now,
+    createdAt: now,
+    updatedAt: now,
+  });
+}
+
+async function deleteRemoteAgentConnectorFixture(
+  fixture: OrgMembershipFixture,
+): Promise<void> {
+  const writeDb = store.set(writeDb$);
+  await Promise.all([
+    writeDb.delete(connectors).where(eq(connectors.orgId, fixture.orgId)),
+    writeDb
+      .delete(remoteAgentHosts)
+      .where(eq(remoteAgentHosts.orgId, fixture.orgId)),
+    writeDb
+      .delete(userFeatureSwitches)
+      .where(
+        and(
+          eq(userFeatureSwitches.orgId, fixture.orgId),
+          eq(userFeatureSwitches.userId, fixture.userId),
+        ),
+      ),
+  ]);
+}
+
+describe("POST /api/zero/connectors/remote-agent", () => {
+  const seededFixtures: OrgMembershipFixture[] = [];
+
+  afterEach(async () => {
+    while (seededFixtures.length > 0) {
+      const fixture = seededFixtures.pop();
+      if (fixture) {
+        await deleteRemoteAgentConnectorFixture(fixture);
+        await store.set(deleteOrgMembership$, fixture, context.signal);
+      }
+    }
+  });
+
+  it("connects when the user has an online remote-agent host", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    seededFixtures.push(
+      await store.set(seedOrgMembership$, { orgId, userId }, context.signal),
+    );
+    await enableRemoteAgent(orgId, userId);
+    await seedRemoteAgentHost({ orgId, userId, status: "online" });
+    mocks.clerk.session(userId, orgId);
+
+    const client = setupApp({ context })(zeroRemoteAgentConnectorContract);
+    const response = await accept(
+      client.create({
+        body: {},
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toMatchObject({
+      type: "remote-agent",
+      authMethod: "api",
+      needsReconnect: false,
+    });
+  });
+
+  it("rejects connect when no linked host is online", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    seededFixtures.push(
+      await store.set(seedOrgMembership$, { orgId, userId }, context.signal),
+    );
+    await enableRemoteAgent(orgId, userId);
+    await seedRemoteAgentHost({ orgId, userId, status: "offline" });
+    mocks.clerk.session(userId, orgId);
+
+    const client = setupApp({ context })(zeroRemoteAgentConnectorContract);
+    const response = await accept(
+      client.create({
+        body: {},
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [409],
+    );
+
+    expect(response.body.error.code).toBe("CONFLICT");
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/zero-connectors.ts
@@ -1,22 +1,27 @@
-import { computed } from "ccstate";
+import { command, computed } from "ccstate";
 import {
   zeroComputerConnectorContract,
   zeroConnectorScopeDiffContract,
   zeroConnectorsByTypeContract,
   zeroConnectorsMainContract,
   zeroConnectorsSearchContract,
+  zeroRemoteAgentConnectorContract,
 } from "@vm0/api-contracts/contracts/zero-connectors";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import { isFeatureEnabled } from "@vm0/core/feature-switch";
 
 import { authContext$, organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
 import { pathParamsOf, queryOf } from "../context/request";
-import { notFound } from "../../lib/error";
+import { conflict, notFound } from "../../lib/error";
 import {
   zeroConnectorByType,
   zeroConnectorList,
   zeroConnectorScopeDiff,
   zeroConnectorSearch,
 } from "../services/zero-connector-data.service";
+import { userFeatureSwitchOverrides } from "../services/feature-switches.service";
+import { connectRemoteAgentConnector$ } from "../services/zero-remote-agent.service";
 import type { RouteEntry } from "../route";
 
 const connectorReadAuth = {
@@ -24,6 +29,33 @@ const connectorReadAuth = {
   missingOrganizationStatus: 401,
   requiredCapability: "connector:read",
 } as const;
+
+const connectorWriteAuth = {
+  requireOrganization: true,
+  missingOrganizationStatus: 401,
+} as const;
+
+const remoteAgentDisabled = Object.freeze({
+  status: 403 as const,
+  body: Object.freeze({
+    error: Object.freeze({
+      message: "Remote agent is not enabled",
+      code: "FORBIDDEN",
+    }),
+  }),
+});
+
+function isRemoteAgentEnabled(params: {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly overrides: Record<string, boolean>;
+}): boolean {
+  return isFeatureEnabled(FeatureSwitchKey.RemoteAgent, {
+    orgId: params.orgId,
+    userId: params.userId,
+    overrides: params.overrides,
+  });
+}
 
 const getConnectorListInner$ = computed(async (get) => {
   const auth = get(organizationAuthContext$);
@@ -96,10 +128,46 @@ const searchConnectorsInner$ = computed(async (get) => {
   return { status: 200 as const, body: { connectors: [...connectors] } };
 });
 
+const connectRemoteAgentConnectorInner$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const auth = get(organizationAuthContext$);
+    const overrides = await get(
+      userFeatureSwitchOverrides(auth.orgId, auth.userId),
+    );
+    signal.throwIfAborted();
+    if (
+      !isRemoteAgentEnabled({
+        orgId: auth.orgId,
+        userId: auth.userId,
+        overrides,
+      })
+    ) {
+      return remoteAgentDisabled;
+    }
+
+    const result = await set(
+      connectRemoteAgentConnector$,
+      { orgId: auth.orgId, userId: auth.userId },
+      signal,
+    );
+    signal.throwIfAborted();
+
+    if (result.status === "no_online_host") {
+      return conflict("Start an online remote-agent host before connecting");
+    }
+
+    return { status: 200 as const, body: result.connector };
+  },
+);
+
 export const zeroConnectorsRoutes: readonly RouteEntry[] = [
   {
     route: zeroComputerConnectorContract.get,
     handler: authRoute(connectorReadAuth, getComputerConnectorInner$),
+  },
+  {
+    route: zeroRemoteAgentConnectorContract.create,
+    handler: authRoute(connectorWriteAuth, connectRemoteAgentConnectorInner$),
   },
   {
     route: zeroConnectorsSearchContract.search,

--- a/turbo/apps/api/src/signals/services/zero-remote-agent.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-remote-agent.service.ts
@@ -1,10 +1,12 @@
 import { createHash, randomBytes, randomInt } from "crypto";
 import { command } from "ccstate";
 import { and, asc, desc, eq, inArray, isNull, or } from "drizzle-orm";
+import type { ConnectorResponse } from "@vm0/api-contracts/contracts/connector-schemas";
 import type {
   RemoteAgentBackend,
   RemoteAgentHostStatus,
 } from "@vm0/api-contracts/contracts/zero-remote-agent";
+import { connectors } from "@vm0/db/schema/connector";
 import {
   remoteAgentDeviceCodes,
   remoteAgentHosts,
@@ -17,7 +19,9 @@ import {
   createRemoteAgentDeviceRealtimeSubscription,
   createRemoteAgentHostRealtimeSubscription,
   publishRemoteAgentDeviceApproved,
+  publishRemoteAgentHostsChanged,
   publishRemoteAgentHostJobAvailable,
+  publishUserSignal,
 } from "../external/realtime";
 import { safeAsync } from "../utils";
 import { logger } from "../../lib/log";
@@ -136,6 +140,23 @@ function serializeHost(row: typeof remoteAgentHosts.$inferSelect, now: Date) {
   };
 }
 
+function serializeRemoteAgentConnector(
+  row: typeof connectors.$inferSelect,
+): ConnectorResponse {
+  return {
+    id: row.id,
+    type: "remote-agent",
+    authMethod: row.authMethod,
+    externalId: row.externalId,
+    externalUsername: row.externalUsername,
+    externalEmail: row.externalEmail,
+    oauthScopes: row.oauthScopes ? JSON.parse(row.oauthScopes) : null,
+    needsReconnect: row.needsReconnect,
+    createdAt: row.createdAt.toISOString(),
+    updatedAt: row.updatedAt.toISOString(),
+  };
+}
+
 async function publishRemoteAgentJobAvailableSafe(
   hostId: string,
   jobId: string,
@@ -149,6 +170,38 @@ async function publishRemoteAgentJobAvailableSafe(
     L.warn("Failed to publish remote-agent job notification", {
       hostId,
       jobId,
+      error: publishResult.error,
+    });
+  }
+}
+
+async function publishRemoteAgentHostsChangedSafe(
+  userId: string,
+  signal: AbortSignal,
+): Promise<void> {
+  const publishResult = await safeAsync(() => {
+    return publishRemoteAgentHostsChanged(userId);
+  });
+  signal.throwIfAborted();
+  if ("error" in publishResult) {
+    L.warn("Failed to publish remote-agent host change", {
+      userId,
+      error: publishResult.error,
+    });
+  }
+}
+
+async function publishConnectorChangedSafe(
+  userId: string,
+  signal: AbortSignal,
+): Promise<void> {
+  const publishResult = await safeAsync(() => {
+    return publishUserSignal([userId], "connector:changed");
+  });
+  signal.throwIfAborted();
+  if ("error" in publishResult) {
+    L.warn("Failed to publish connector change", {
+      userId,
       error: publishResult.error,
     });
   }
@@ -330,83 +383,105 @@ export const pollRemoteAgentDeviceCode$ = command(
     const codeHash = hashSecret(normalizeDeviceCode(params.deviceCode));
     const pollTokenHash = hashSecret(params.pollToken);
 
-    return await writeDb.transaction(async (tx) => {
-      const [row] = await tx
-        .select()
-        .from(remoteAgentDeviceCodes)
-        .where(
-          and(
-            eq(remoteAgentDeviceCodes.codeHash, codeHash),
-            eq(remoteAgentDeviceCodes.pollTokenHash, pollTokenHash),
-          ),
-        )
-        .for("update")
-        .limit(1);
-      signal.throwIfAborted();
+    const result = await writeDb.transaction(
+      async (
+        tx,
+      ): Promise<PollRemoteAgentDeviceCodeResult & { userId?: string }> => {
+        const [row] = await tx
+          .select()
+          .from(remoteAgentDeviceCodes)
+          .where(
+            and(
+              eq(remoteAgentDeviceCodes.codeHash, codeHash),
+              eq(remoteAgentDeviceCodes.pollTokenHash, pollTokenHash),
+            ),
+          )
+          .for("update")
+          .limit(1);
+        signal.throwIfAborted();
 
-      if (!row) {
-        return { status: "invalid" as const };
-      }
+        if (!row) {
+          return { status: "invalid" as const };
+        }
 
-      if (hasExpired(row.expiresAt, now) && row.status !== "consumed") {
+        if (hasExpired(row.expiresAt, now) && row.status !== "consumed") {
+          await tx
+            .update(remoteAgentDeviceCodes)
+            .set({ status: "expired", updatedAt: now })
+            .where(eq(remoteAgentDeviceCodes.id, row.id));
+          signal.throwIfAborted();
+          return { status: "expired" as const };
+        }
+
+        if (row.status === "pending") {
+          return { status: "pending" as const };
+        }
+
+        if (row.status === "consumed" && row.hostId) {
+          return {
+            status: "linked" as const,
+            hostId: row.hostId,
+            ...(row.userId ? { userId: row.userId } : {}),
+          };
+        }
+
+        if (row.status !== "approved") {
+          return { status: "expired" as const };
+        }
+
+        if (!row.orgId || !row.userId) {
+          return { status: "invalid" as const };
+        }
+
+        const hostToken = generateOpaqueToken("vm0_remote_host");
+        const [host] = await tx
+          .insert(remoteAgentHosts)
+          .values({
+            orgId: row.orgId,
+            userId: row.userId,
+            displayName: normalizeHostName(row.hostName),
+            tokenHash: hashSecret(hostToken),
+            supportedBackends: row.supportedBackends,
+            status: "online",
+            lastSeenAt: now,
+            createdAt: now,
+            updatedAt: now,
+          })
+          .returning({ id: remoteAgentHosts.id });
+        signal.throwIfAborted();
+
+        if (!host) {
+          throw new Error("Failed to link remote-agent host");
+        }
+
         await tx
           .update(remoteAgentDeviceCodes)
-          .set({ status: "expired", updatedAt: now })
+          .set({
+            status: "consumed",
+            hostId: host.id,
+            consumedAt: now,
+            updatedAt: now,
+          })
           .where(eq(remoteAgentDeviceCodes.id, row.id));
         signal.throwIfAborted();
-        return { status: "expired" as const };
-      }
 
-      if (row.status === "pending") {
-        return { status: "pending" as const };
-      }
-
-      if (row.status === "consumed" && row.hostId) {
-        return { status: "linked" as const, hostId: row.hostId };
-      }
-
-      if (row.status !== "approved") {
-        return { status: "expired" as const };
-      }
-
-      if (!row.orgId || !row.userId) {
-        return { status: "invalid" as const };
-      }
-
-      const hostToken = generateOpaqueToken("vm0_remote_host");
-      const [host] = await tx
-        .insert(remoteAgentHosts)
-        .values({
-          orgId: row.orgId,
-          userId: row.userId,
-          displayName: normalizeHostName(row.hostName),
-          tokenHash: hashSecret(hostToken),
-          supportedBackends: row.supportedBackends,
-          status: "online",
-          lastSeenAt: now,
-          createdAt: now,
-          updatedAt: now,
-        })
-        .returning({ id: remoteAgentHosts.id });
-      signal.throwIfAborted();
-
-      if (!host) {
-        throw new Error("Failed to link remote-agent host");
-      }
-
-      await tx
-        .update(remoteAgentDeviceCodes)
-        .set({
-          status: "consumed",
+        return {
+          status: "linked" as const,
           hostId: host.id,
-          consumedAt: now,
-          updatedAt: now,
-        })
-        .where(eq(remoteAgentDeviceCodes.id, row.id));
-      signal.throwIfAborted();
+          hostToken,
+          userId: row.userId,
+        };
+      },
+    );
+    signal.throwIfAborted();
 
-      return { status: "linked" as const, hostId: host.id, hostToken };
-    });
+    if (result.status === "linked" && result.userId) {
+      await publishRemoteAgentHostsChangedSafe(result.userId, signal);
+      const { userId: _userId, ...publicResult } = result;
+      return publicResult;
+    }
+
+    return result;
   },
 );
 
@@ -422,6 +497,23 @@ export const heartbeatRemoteAgentHost$ = command(
   ): Promise<{ readonly hostId: string } | null> => {
     const writeDb = set(writeDb$);
     const now = nowDate();
+    const [existing] = await writeDb
+      .select()
+      .from(remoteAgentHosts)
+      .where(
+        and(
+          eq(remoteAgentHosts.tokenHash, hashSecret(params.hostToken)),
+          isNull(remoteAgentHosts.revokedAt),
+        ),
+      )
+      .limit(1);
+    signal.throwIfAborted();
+
+    if (!existing) {
+      return null;
+    }
+
+    const wasOnline = remoteAgentHostStatus(existing, now) === "online";
     const [row] = await writeDb
       .update(remoteAgentHosts)
       .set({
@@ -431,16 +523,19 @@ export const heartbeatRemoteAgentHost$ = command(
         lastSeenAt: now,
         updatedAt: now,
       })
-      .where(
-        and(
-          eq(remoteAgentHosts.tokenHash, hashSecret(params.hostToken)),
-          isNull(remoteAgentHosts.revokedAt),
-        ),
-      )
-      .returning({ id: remoteAgentHosts.id });
+      .where(eq(remoteAgentHosts.id, existing.id))
+      .returning({ id: remoteAgentHosts.id, userId: remoteAgentHosts.userId });
     signal.throwIfAborted();
 
-    return row ? { hostId: row.id } : null;
+    if (!row) {
+      return null;
+    }
+
+    if (!wasOnline) {
+      await publishRemoteAgentHostsChangedSafe(row.userId, signal);
+    }
+
+    return { hostId: row.id };
   },
 );
 
@@ -505,6 +600,84 @@ export const listRemoteAgentHosts$ = command(
   },
 );
 
+export const connectRemoteAgentConnector$ = command(
+  async (
+    { set },
+    params: {
+      readonly orgId: string;
+      readonly userId: string;
+    },
+    signal: AbortSignal,
+  ): Promise<
+    | { readonly status: "connected"; readonly connector: ConnectorResponse }
+    | { readonly status: "no_online_host" }
+  > => {
+    const writeDb = set(writeDb$);
+    const now = nowDate();
+    const hostRows = await writeDb
+      .select()
+      .from(remoteAgentHosts)
+      .where(
+        and(
+          eq(remoteAgentHosts.orgId, params.orgId),
+          eq(remoteAgentHosts.userId, params.userId),
+          isNull(remoteAgentHosts.revokedAt),
+        ),
+      );
+    signal.throwIfAborted();
+
+    const hasOnlineHost = hostRows.some((host) => {
+      return remoteAgentHostStatus(host, now) === "online";
+    });
+    if (!hasOnlineHost) {
+      return { status: "no_online_host" as const };
+    }
+
+    const [row] = await writeDb
+      .insert(connectors)
+      .values({
+        type: "remote-agent",
+        authMethod: "api",
+        externalId: null,
+        externalUsername: null,
+        externalEmail: null,
+        oauthScopes: null,
+        tokenExpiresAt: null,
+        needsReconnect: false,
+        userId: params.userId,
+        orgId: params.orgId,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .onConflictDoUpdate({
+        target: [connectors.orgId, connectors.userId, connectors.type],
+        set: {
+          authMethod: "api",
+          externalId: null,
+          externalUsername: null,
+          externalEmail: null,
+          oauthScopes: null,
+          tokenExpiresAt: null,
+          needsReconnect: false,
+          updatedAt: now,
+        },
+      })
+      .returning();
+    signal.throwIfAborted();
+
+    if (!row) {
+      throw new Error("Failed to connect remote-agent connector");
+    }
+
+    await publishConnectorChangedSafe(params.userId, signal);
+
+    return {
+      status: "connected" as const,
+      connector: serializeRemoteAgentConnector(row),
+    };
+  },
+);
+
 export const startRemoteAgentHost$ = command(
   async (
     { set },
@@ -548,6 +721,8 @@ export const startRemoteAgentHost$ = command(
         return { status: "not_found" as const };
       }
 
+      await publishRemoteAgentHostsChangedSafe(params.userId, signal);
+
       return {
         status: "started" as const,
         hostId: host.id,
@@ -570,6 +745,8 @@ export const startRemoteAgentHost$ = command(
       throw new Error("Failed to start remote-agent host");
     }
 
+    await publishRemoteAgentHostsChangedSafe(params.userId, signal);
+
     return {
       status: "started" as const,
       hostId: host.id,
@@ -591,7 +768,7 @@ export const deleteRemoteAgentHost$ = command(
     const writeDb = set(writeDb$);
     const now = nowDate();
 
-    return await writeDb.transaction(async (tx) => {
+    const result = await writeDb.transaction(async (tx) => {
       const [host] = await tx
         .update(remoteAgentHosts)
         .set({
@@ -633,6 +810,13 @@ export const deleteRemoteAgentHost$ = command(
 
       return { status: "deleted" as const };
     });
+    signal.throwIfAborted();
+
+    if (result.status === "deleted") {
+      await publishRemoteAgentHostsChangedSafe(params.userId, signal);
+    }
+
+    return result;
   },
 );
 

--- a/turbo/apps/platform/src/mocks/handlers/api-connectors.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-connectors.ts
@@ -22,6 +22,15 @@ export function resetMockConnectors(): void {
   mockConnectors = [];
 }
 
+export function upsertMockConnector(connector: ConnectorResponse): void {
+  mockConnectors = [
+    ...mockConnectors.filter((c) => {
+      return c.type !== connector.type;
+    }),
+    connector,
+  ];
+}
+
 export const apiConnectorsHandlers = [
   mockApi(zeroConnectorsMainContract.list, ({ respond }) => {
     return respond(200, {

--- a/turbo/apps/platform/src/mocks/handlers/api-remote-agent.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-remote-agent.ts
@@ -1,0 +1,52 @@
+import {
+  zeroRemoteAgentHostsContract,
+  type RemoteAgentHost,
+} from "@vm0/api-contracts/contracts/zero-remote-agent";
+import { zeroRemoteAgentConnectorContract } from "@vm0/api-contracts/contracts/zero-connectors";
+import { mockApi } from "../msw-contract.ts";
+import { upsertMockConnector } from "./api-connectors.ts";
+
+let mockRemoteAgentHosts: RemoteAgentHost[] = [];
+
+export function setMockRemoteAgentHosts(hosts: RemoteAgentHost[]): void {
+  mockRemoteAgentHosts = hosts;
+}
+
+export function resetMockRemoteAgentHosts(): void {
+  mockRemoteAgentHosts = [];
+}
+
+export const apiRemoteAgentHandlers = [
+  mockApi(zeroRemoteAgentHostsContract.list, ({ respond }) => {
+    return respond(200, { hosts: mockRemoteAgentHosts });
+  }),
+  mockApi(zeroRemoteAgentConnectorContract.create, ({ respond }) => {
+    const hasOnlineHost = mockRemoteAgentHosts.some((host) => {
+      return host.status === "online";
+    });
+    if (!hasOnlineHost) {
+      return respond(409, {
+        error: {
+          message: "Start an online remote-agent host before connecting",
+          code: "CONFLICT",
+        },
+      });
+    }
+
+    const now = new Date().toISOString();
+    const connector = {
+      id: "00000000-0000-4000-8000-000000000000",
+      type: "remote-agent" as const,
+      authMethod: "api",
+      externalId: null,
+      externalUsername: null,
+      externalEmail: null,
+      oauthScopes: null,
+      needsReconnect: false,
+      createdAt: now,
+      updatedAt: now,
+    };
+    upsertMockConnector(connector);
+    return respond(200, connector);
+  }),
+];

--- a/turbo/apps/platform/src/mocks/handlers/index.ts
+++ b/turbo/apps/platform/src/mocks/handlers/index.ts
@@ -87,6 +87,10 @@ import {
 import { apiPermissionPoliciesHandlers } from "./api-permission-policies.ts";
 import { apiVoiceChatHandlers, resetMockVoiceChat } from "./api-voice-chat.ts";
 import { apiVoiceIoHandlers } from "./api-voice-io.ts";
+import {
+  apiRemoteAgentHandlers,
+  resetMockRemoteAgentHosts,
+} from "./api-remote-agent.ts";
 
 export const handlers = [
   ...apiConnectorsHandlers,
@@ -120,6 +124,7 @@ export const handlers = [
   ...apiQueuePositionHandlers,
   ...apiVoiceChatHandlers,
   ...apiVoiceIoHandlers,
+  ...apiRemoteAgentHandlers,
 ];
 
 export function resetAllMockHandlers(): void {
@@ -149,4 +154,5 @@ export function resetAllMockHandlers(): void {
   resetMockTeam();
   resetMockOnboardingStatus();
   resetMockVoiceChat();
+  resetMockRemoteAgentHosts();
 }

--- a/turbo/apps/platform/src/signals/zero-page/settings/__tests__/remote-agent-connector.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/__tests__/remote-agent-connector.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import { setupPage } from "../../../../__tests__/page-helper.ts";
+import { testContext } from "../../../__tests__/test-helpers.ts";
+import { setMockRemoteAgentHosts } from "../../../../mocks/handlers/api-remote-agent.ts";
+import {
+  allConnectorTypes$,
+  connectRemoteAgentConnector$,
+  permissionDialogType$,
+} from "../connectors.ts";
+
+const context = testContext();
+
+describe("remote-agent connector", () => {
+  it("is hidden when the remote-agent feature switch is disabled", async () => {
+    await setupPage({
+      context,
+      path: "/",
+      withoutRender: true,
+      featureSwitches: { [FeatureSwitchKey.RemoteAgent]: false },
+    });
+
+    const connectors = await context.store.get(allConnectorTypes$);
+
+    expect(
+      connectors.some((connector) => {
+        return connector.type === "remote-agent";
+      }),
+    ).toBeFalsy();
+  });
+
+  it("shows online remote-agent hosts without treating them as connected", async () => {
+    setMockRemoteAgentHosts([
+      {
+        id: "host-online",
+        displayName: "Work laptop",
+        supportedBackends: ["codex"],
+        status: "online",
+        lastSeenAt: "2026-05-12T00:00:00.000Z",
+        createdAt: "2026-05-12T00:00:00.000Z",
+      },
+      {
+        id: "host-closed",
+        displayName: "Old desktop",
+        supportedBackends: ["claude-code"],
+        status: "closed",
+        lastSeenAt: "2026-05-11T00:00:00.000Z",
+        createdAt: "2026-05-11T00:00:00.000Z",
+      },
+    ]);
+    await setupPage({
+      context,
+      path: "/",
+      withoutRender: true,
+      featureSwitches: { [FeatureSwitchKey.RemoteAgent]: true },
+    });
+
+    const connectors = await context.store.get(allConnectorTypes$);
+    const remoteAgent = connectors.find((connector) => {
+      return connector.type === "remote-agent";
+    });
+
+    expect(remoteAgent?.availableAuthMethods).toStrictEqual(["api"]);
+    expect(remoteAgent?.connected).toBeFalsy();
+    expect(remoteAgent?.remoteAgentHosts).toStrictEqual([
+      expect.objectContaining({
+        id: "host-online",
+        displayName: "Work laptop",
+      }),
+    ]);
+  });
+
+  it("opens the agent auth dialog after connecting from settings", async () => {
+    setMockRemoteAgentHosts([
+      {
+        id: "host-online",
+        displayName: "Work laptop",
+        supportedBackends: ["codex"],
+        status: "online",
+        lastSeenAt: "2026-05-12T00:00:00.000Z",
+        createdAt: "2026-05-12T00:00:00.000Z",
+      },
+    ]);
+    await setupPage({
+      context,
+      path: "/",
+      withoutRender: true,
+      featureSwitches: { [FeatureSwitchKey.RemoteAgent]: true },
+    });
+
+    await context.store.set(
+      connectRemoteAgentConnector$,
+      { showPermissionDialog: true },
+      context.signal,
+    );
+
+    expect(context.store.get(permissionDialogType$)).toBe("remote-agent");
+  });
+});

--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -6,10 +6,17 @@ import {
   type ConnectorType,
   type ConnectorDisplayCategory,
 } from "@vm0/connectors/connectors";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { hasRequiredScopes } from "@vm0/connectors/connector-utils";
+import {
+  zeroRemoteAgentHostsContract,
+  type RemoteAgentHost,
+  type RemoteAgentHostListResponse,
+} from "@vm0/api-contracts/contracts/zero-remote-agent";
 import {
   zeroConnectorScopeDiffContract,
   zeroConnectorsMainContract,
+  zeroRemoteAgentConnectorContract,
 } from "@vm0/api-contracts/contracts/zero-connectors";
 import {
   zeroSecretsContract,
@@ -27,7 +34,7 @@ import {
 } from "../../external/connectors.ts";
 import { apiBaseForNavigation$ } from "../../fetch.ts";
 import { zeroClient$ } from "../../api-client.ts";
-import { jsonParseOr, resetSignal, withCleanup } from "../../utils.ts";
+import { jsonParseOr, onRef, resetSignal, withCleanup } from "../../utils.ts";
 import { setAblyLoop$ } from "../../realtime.ts";
 import { localStorageSignals } from "../../external/local-storage.ts";
 import { resetPermissionDialog$ } from "./permission-dialog.ts";
@@ -36,6 +43,9 @@ import { sanitizeTokenInputRecord } from "./token-input.ts";
 const HIDDEN_CONNECTIONS_STORAGE_KEY = "vm0.connections.hiddenTypes";
 const { get$: hiddenConnectorTypesRaw$, set$: setHiddenConnectorTypes$ } =
   localStorageSignals(HIDDEN_CONNECTIONS_STORAGE_KEY);
+export const REMOTE_AGENT_CONNECTOR_TYPE =
+  "remote-agent" as const satisfies ConnectorType;
+const REMOTE_AGENT_HOSTS_CHANGED_TOPIC = "remote-agent:hosts-changed";
 
 type PostConnectOptions = {
   readonly showPermissionDialog?: boolean;
@@ -66,6 +76,134 @@ export interface ConnectorTypeWithStatus {
   scopeMismatch: boolean;
   /** True if OAuth token refresh failed and user needs to reconnect. */
   needsReconnect: boolean;
+  /** Online remote-agent hosts for the virtual remote-agent connector. */
+  remoteAgentHosts?: RemoteAgentHost[];
+}
+
+const internalReloadRemoteAgentHosts$ = state(0);
+
+export function getRemoteAgentOnlineHosts(
+  hosts: readonly RemoteAgentHost[],
+): RemoteAgentHost[] {
+  return hosts.filter((host) => {
+    return host.status === "online";
+  });
+}
+
+export const remoteAgentHosts$ = computed(
+  async (get): Promise<RemoteAgentHostListResponse> => {
+    get(internalReloadRemoteAgentHosts$);
+    const features = await get(featureSwitch$);
+    if (!features?.[FeatureSwitchKey.RemoteAgent]) {
+      return { hosts: [] };
+    }
+
+    const createClient = get(zeroClient$);
+    const client = createClient(zeroRemoteAgentHostsContract);
+    const result = await accept(client.list(), [200]);
+    return result.body as RemoteAgentHostListResponse;
+  },
+);
+
+const reloadRemoteAgentHosts$ = command(({ set }) => {
+  set(internalReloadRemoteAgentHosts$, (x) => {
+    return x + 1;
+  });
+});
+
+const reloadRemoteAgentHostsFromRealtime$ = command(({ set }) => {
+  set(reloadRemoteAgentHosts$);
+  return false;
+});
+
+const watchRemoteAgentHosts$ = command(async ({ set }, signal: AbortSignal) => {
+  set(reloadRemoteAgentHosts$);
+  await set(
+    setAblyLoop$,
+    REMOTE_AGENT_HOSTS_CHANGED_TOPIC,
+    reloadRemoteAgentHostsFromRealtime$,
+    signal,
+  );
+});
+
+export const remoteAgentHostsWatcherRef$ = onRef(
+  command(async ({ set }, _el: HTMLElement, signal: AbortSignal) => {
+    await set(watchRemoteAgentHosts$, signal);
+  }),
+);
+
+function isRemoteAgentConnector(type: ConnectorType): boolean {
+  return type === REMOTE_AGENT_CONNECTOR_TYPE;
+}
+
+function isConnectorFlagEnabled(
+  type: ConnectorType,
+  features: Record<string, boolean> | null | undefined,
+): boolean {
+  const flag = CONNECTOR_TYPES[type].featureFlag;
+  return !flag || !!features?.[flag];
+}
+
+function getAvailableAuthMethodsForConnector(
+  type: ConnectorType,
+  flagEnabled: boolean,
+): string[] {
+  const config = CONNECTOR_TYPES[type];
+  const methods = config.authMethods;
+  const availableAuthMethods: string[] = [];
+
+  if (flagEnabled && "oauth" in methods) {
+    availableAuthMethods.push("oauth");
+  }
+  if ("api-token" in methods && (flagEnabled || !config.strictFeatureFlag)) {
+    availableAuthMethods.push("api-token");
+  }
+  if (isRemoteAgentConnector(type) && flagEnabled && "api" in methods) {
+    availableAuthMethods.push("api");
+  }
+
+  return availableAuthMethods;
+}
+
+function buildConnectorTypeStatus(params: {
+  readonly type: ConnectorType;
+  readonly connector: ConnectorResponse | null;
+  readonly features: Record<string, boolean> | null | undefined;
+  readonly remoteAgentOnlineHosts: RemoteAgentHost[];
+}): ConnectorTypeWithStatus {
+  const config = CONNECTOR_TYPES[params.type];
+  const flag = config.featureFlag;
+  const isRemoteAgent = isRemoteAgentConnector(params.type);
+  const availableAuthMethods = getAvailableAuthMethodsForConnector(
+    params.type,
+    isConnectorFlagEnabled(params.type, params.features),
+  );
+  const hasApiToken = availableAuthMethods.includes("api-token");
+  const connected = params.connector !== null;
+
+  return {
+    type: params.type,
+    label:
+      flag && !hasApiToken && !isRemoteAgent
+        ? `[Experimental] ${config.label}`
+        : config.label,
+    helpText: config.helpText,
+    category: config.category,
+    tags: config.tags ?? [],
+    connected,
+    connector: params.connector,
+    availableAuthMethods,
+    scopeMismatch:
+      !isRemoteAgent &&
+      params.connector !== null &&
+      params.connector.authMethod === "oauth" &&
+      !hasRequiredScopes(params.type, params.connector.oauthScopes),
+    needsReconnect:
+      !isRemoteAgent && (params.connector?.needsReconnect ?? false),
+    ...(isRemoteAgent
+      ? { remoteAgentHosts: params.remoteAgentOnlineHosts }
+      : {}),
+  };
 }
 
 /**
@@ -112,53 +250,29 @@ export const allConnectorTypes$ = computed(async (get) => {
     }),
   );
   const features = await get(featureSwitch$);
+  const remoteAgentHostList = features?.[FeatureSwitchKey.RemoteAgent]
+    ? await get(remoteAgentHosts$)
+    : { hosts: [] };
+  const remoteAgentOnlineHosts = getRemoteAgentOnlineHosts(
+    remoteAgentHostList.hosts,
+  );
 
   const items = (Object.keys(CONNECTOR_TYPES) as ConnectorType[])
     .filter((type) => {
-      const flag = CONNECTOR_TYPES[type].featureFlag;
-      const flagEnabled = !flag || !!features?.[flag];
-      const methods = CONNECTOR_TYPES[type].authMethods;
-      // Connector visible if any auth method should be shown. api-token is
-      // always available regardless of flag unless strictFeatureFlag is set;
-      // oauth requires the per-connector flag.
-      const showOauth = flagEnabled && "oauth" in methods;
-      const showApiToken =
-        "api-token" in methods &&
-        (flagEnabled || !CONNECTOR_TYPES[type].strictFeatureFlag);
-      return showOauth || showApiToken;
+      return (
+        getAvailableAuthMethodsForConnector(
+          type,
+          isConnectorFlagEnabled(type, features),
+        ).length > 0
+      );
     })
     .map((type) => {
-      const config = CONNECTOR_TYPES[type];
-      const connector = connectorMap.get(type) ?? null;
-      const flag = CONNECTOR_TYPES[type].featureFlag;
-      const flagEnabled = !flag || !!features?.[flag];
-      const showOauth = flagEnabled && "oauth" in config.authMethods;
-      const showApiToken =
-        "api-token" in config.authMethods &&
-        (flagEnabled || !config.strictFeatureFlag);
-      const availableAuthMethods: string[] = [];
-      if (showOauth) {
-        availableAuthMethods.push("oauth");
-      }
-      if (showApiToken) {
-        availableAuthMethods.push("api-token");
-      }
-      const isExperimental = !!flag && !showApiToken;
-      return {
+      return buildConnectorTypeStatus({
         type,
-        label: isExperimental ? `[Experimental] ${config.label}` : config.label,
-        helpText: config.helpText,
-        category: config.category,
-        tags: config.tags ?? [],
-        connected: connector !== null,
-        connector,
-        availableAuthMethods,
-        scopeMismatch:
-          connector !== null &&
-          connector.authMethod === "oauth" &&
-          !hasRequiredScopes(type, connector.oauthScopes),
-        needsReconnect: connector?.needsReconnect ?? false,
-      };
+        connector: connectorMap.get(type) ?? null,
+        features,
+        remoteAgentOnlineHosts,
+      });
     });
 
   // Sort connected connectors to the top of the list
@@ -355,6 +469,47 @@ const internalJustConnectedTypes$ = state<Set<string>>(new Set());
 export const justConnectedTypes$ = computed((get) => {
   return get(internalJustConnectedTypes$);
 });
+
+export const connectRemoteAgentConnector$ = command(
+  async (
+    { get, set },
+    options: PostConnectOptions,
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const createClient = get(zeroClient$);
+    const client = createClient(zeroRemoteAgentConnectorContract, {
+      apiBase: "api",
+    });
+    await accept(
+      client.create({
+        body: {},
+        fetchOptions: { signal },
+      }),
+      [200],
+    );
+    signal.throwIfAborted();
+
+    set(internalJustConnectedTypes$, (prev) => {
+      return new Set([...prev, REMOTE_AGENT_CONNECTOR_TYPE]);
+    });
+    set(reloadConnectors$);
+    set(reloadRemoteAgentHosts$);
+
+    const hidden = new Set(get(hiddenConnectorTypes$));
+    hidden.delete(REMOTE_AGENT_CONNECTOR_TYPE);
+    set(setHiddenConnectorTypes$, JSON.stringify([...hidden]));
+
+    toast.success(
+      `${CONNECTOR_TYPES[REMOTE_AGENT_CONNECTOR_TYPE].label} connected`,
+      {
+        id: `connector-connected-${REMOTE_AGENT_CONNECTOR_TYPE}`,
+      },
+    );
+    if (options.showPermissionDialog) {
+      set(internalPermissionDialogType$, REMOTE_AGENT_CONNECTOR_TYPE);
+    }
+  },
+);
 
 /**
  * Disconnect a connector and clear its optimistic "just connected" flag.

--- a/turbo/apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx
@@ -1,4 +1,9 @@
-import { useLastResolved, useGet, useSet } from "ccstate-react";
+import {
+  useLastLoadable,
+  useLastResolved,
+  useGet,
+  useSet,
+} from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
 import { Input } from "@vm0/ui/components/ui/input";
 import { Button } from "@vm0/ui/components/ui/button";
@@ -20,9 +25,14 @@ import {
   submitApiToken$,
   setTokenFormValue$,
   clearTokenForm$,
+  connectRemoteAgentConnector$,
   tokenFormValuesFor$,
   selectedConnectorType$,
   isStandaloneMode,
+  REMOTE_AGENT_CONNECTOR_TYPE,
+  getRemoteAgentOnlineHosts,
+  remoteAgentHostsWatcherRef$,
+  remoteAgentHosts$,
   type ConnectorTypeWithStatus,
 } from "../../../../signals/zero-page/settings/connectors.ts";
 import { hasTokenInputValue } from "../../../../signals/zero-page/settings/token-input.ts";
@@ -61,6 +71,10 @@ function renderMarkdown(text: string): string {
 // ---------------------------------------------------------------------------
 
 function connectedStatusText(item: ConnectorTypeWithStatus): string {
+  if (item.type === REMOTE_AGENT_CONNECTOR_TYPE) {
+    const count = item.remoteAgentHosts?.length ?? 0;
+    return count === 1 ? "1 host online" : `${count} hosts online`;
+  }
   if (item.needsReconnect) {
     return "Connection expired";
   }
@@ -71,6 +85,14 @@ function connectedStatusText(item: ConnectorTypeWithStatus): string {
     return `Connected as @${item.connector.externalUsername}`;
   }
   return "Connected";
+}
+
+function formatRemoteAgentBackends(backends: readonly string[]): string {
+  return backends
+    .map((backend) => {
+      return backend === "claude-code" ? "Claude Code" : "Codex";
+    })
+    .join(", ");
 }
 
 type PostConnectOptions = {
@@ -178,6 +200,101 @@ function ApiTokenForm({
   );
 }
 
+function RemoteAgentConnectContent({
+  item,
+  onSuccess,
+  showPermissionDialogOnConnect,
+}: {
+  item: ConnectorTypeWithStatus;
+  onSuccess: () => void | Promise<void>;
+  showPermissionDialogOnConnect: boolean;
+}) {
+  const config = CONNECTOR_TYPES[item.type];
+  const remoteAgentConfig = config.authMethods.api;
+  const hostListLoadable = useLastLoadable(remoteAgentHosts$);
+  const watchHostsRef = useSet(remoteAgentHostsWatcherRef$);
+  const [connectLoadable, connectRemoteAgent] = useLoadableSet(
+    connectRemoteAgentConnector$,
+  );
+  const pageSignal = useGet(pageSignal$);
+  const hosts =
+    hostListLoadable.state === "hasData"
+      ? getRemoteAgentOnlineHosts(hostListLoadable.data.hosts)
+      : (item.remoteAgentHosts ?? []);
+  const loading = hostListLoadable.state === "loading";
+  const connecting = connectLoadable.state === "loading";
+  const canConnect = !item.connected && hosts.length > 0 && !connecting;
+
+  const handleConnect = onDomEventFn(async () => {
+    if (!canConnect) {
+      return;
+    }
+    await connectRemoteAgent(
+      { showPermissionDialog: showPermissionDialogOnConnect },
+      pageSignal,
+    );
+    await onSuccess();
+  });
+
+  return (
+    <div ref={watchHostsRef} className="flex flex-col gap-3">
+      {remoteAgentConfig?.helpText && (
+        <div
+          className="text-sm text-muted-foreground leading-relaxed whitespace-pre-line [&_a]:text-primary [&_a]:underline"
+          dangerouslySetInnerHTML={{
+            __html: renderMarkdown(remoteAgentConfig.helpText),
+          }}
+        />
+      )}
+
+      <div className="mt-1 flex items-center justify-between gap-3">
+        <h3 className="text-sm font-medium text-foreground">Online hosts</h3>
+        <span className="text-xs text-muted-foreground">
+          {loading ? "Checking..." : "Updates automatically"}
+        </span>
+      </div>
+
+      {loading && hosts.length === 0 ? (
+        <p className="text-sm text-muted-foreground">Loading hosts...</p>
+      ) : hosts.length === 0 ? (
+        <p className="text-sm text-muted-foreground">
+          No online hosts yet. Start one with the command above; this list
+          updates automatically.
+        </p>
+      ) : (
+        <div className="flex flex-col divide-y divide-border/50 rounded-lg border border-border/60">
+          {hosts.map((host) => {
+            return (
+              <div key={host.id} className="flex flex-col gap-1 px-3 py-2">
+                <div className="flex items-center gap-2">
+                  <span className="h-1.5 w-1.5 rounded-full bg-emerald-500" />
+                  <span className="min-w-0 truncate text-sm font-medium text-foreground">
+                    {host.displayName}
+                  </span>
+                </div>
+                <span className="text-xs text-muted-foreground">
+                  {formatRemoteAgentBackends(host.supportedBackends)}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {!item.connected && (
+        <Button
+          type="button"
+          onClick={handleConnect}
+          disabled={!canConnect}
+          className="w-full"
+        >
+          {connecting ? "Connecting..." : "Connect"}
+        </Button>
+      )}
+    </div>
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Connect modal content (OAuth button + token form, or just token form)
 // ---------------------------------------------------------------------------
@@ -202,6 +319,16 @@ function ConnectModalContent({
   const config = CONNECTOR_TYPES[item.type];
   const hasOAuth = item.availableAuthMethods.includes("oauth");
   const hasApiToken = item.availableAuthMethods.includes("api-token");
+
+  if (item.type === REMOTE_AGENT_CONNECTOR_TYPE) {
+    return (
+      <RemoteAgentConnectContent
+        item={item}
+        onSuccess={onSuccess}
+        showPermissionDialogOnConnect={showPermissionDialogOnConnect}
+      />
+    );
+  }
 
   // While OAuth is in progress, only show connecting state
   if (isPolling) {

--- a/turbo/apps/platform/src/views/zero-page/components/settings/icons/remote-agent.svg
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/icons/remote-agent.svg
@@ -1,0 +1,6 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M6.5 5.75C6.5 4.78 7.28 4 8.25 4h7.5c.97 0 1.75.78 1.75 1.75v5.5c0 .97-.78 1.75-1.75 1.75h-7.5c-.97 0-1.75-.78-1.75-1.75v-5.5Z" stroke="currentColor" stroke-width="1.6"/>
+  <path d="M9 16.5h6M12 13v3.5" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/>
+  <path d="M5 20h14" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/>
+  <path d="M9.5 8.5h.01M12 8.5h.01M14.5 8.5h.01" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
@@ -40,6 +40,7 @@ import {
   setSelectedConnectorType$,
   pollingConnectorType$,
   justConnectedTypes$,
+  REMOTE_AGENT_CONNECTOR_TYPE,
   scopeReviewType$,
   setScopeReviewType$,
   permissionDialogType$,
@@ -358,6 +359,31 @@ function GlobalConnectorCard({
       );
     }
     if (connector.connected) {
+      if (connector.type === REMOTE_AGENT_CONNECTOR_TYPE) {
+        const hosts = connector.remoteAgentHosts ?? [];
+        const names = hosts.map((host) => {
+          return host.displayName;
+        });
+        const visibleNames = names.slice(0, 2).join(", ");
+        const extra = names.length > 2 ? ` +${names.length - 2}` : "";
+        const hasOnlineHosts = names.length > 0;
+        const label = !hasOnlineHosts
+          ? "No online hosts"
+          : `${visibleNames}${extra} online`;
+        return (
+          <span
+            className="flex items-center gap-2 text-xs text-muted-foreground truncate"
+            title={hasOnlineHosts ? names.join(", ") : "No online hosts"}
+          >
+            <span
+              className={`h-1.5 w-1.5 rounded-full shrink-0 ${
+                hasOnlineHosts ? "bg-emerald-500" : "bg-muted-foreground/40"
+              }`}
+            />
+            <span className="truncate">{label}</span>
+          </span>
+        );
+      }
       return (
         <span className="flex items-center gap-2 text-xs text-muted-foreground truncate">
           <span className="h-1.5 w-1.5 rounded-full bg-emerald-500 shrink-0" />

--- a/turbo/apps/web/src/lib/zero/connector/provider-registry.ts
+++ b/turbo/apps/web/src/lib/zero/connector/provider-registry.ts
@@ -117,6 +117,7 @@ import { onyxHandler } from "./providers/onyx-handler";
 import { openaiHandler } from "./providers/openai-handler";
 import { codexOauthHandler } from "./providers/codex-oauth-handler";
 import { redditHandler } from "./providers/reddit-handler";
+import { remoteAgentHandler } from "./providers/remote-agent-handler";
 import { reporteiHandler } from "./providers/reportei-handler";
 import { serpapiHandler } from "./providers/serpapi-handler";
 import { runwayHandler } from "./providers/runway-handler";
@@ -299,6 +300,7 @@ export const PROVIDER_HANDLERS: Record<
   "outlook-calendar": outlookCalendarHandler,
   "outlook-mail": outlookMailHandler,
   reddit: redditHandler,
+  "remote-agent": remoteAgentHandler,
   reportei: reporteiHandler,
   serpapi: serpapiHandler,
   intercom: intercomHandler,

--- a/turbo/apps/web/src/lib/zero/connector/providers/remote-agent-handler.ts
+++ b/turbo/apps/web/src/lib/zero/connector/providers/remote-agent-handler.ts
@@ -1,0 +1,19 @@
+import { type ProviderHandler } from "../provider-types";
+
+export const remoteAgentHandler: ProviderHandler = {
+  buildAuthUrl() {
+    throw new Error("Remote Agent does not support OAuth");
+  },
+  exchangeCode() {
+    throw new Error("Remote Agent does not support OAuth");
+  },
+  getClientId: () => {
+    return undefined;
+  },
+  getClientSecret: () => {
+    return undefined;
+  },
+  getSecretName: () => {
+    return "REMOTE_AGENT";
+  },
+};

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -706,6 +706,7 @@ export {
   zeroConnectorSessionsContract,
   zeroConnectorSessionByIdContract,
   zeroComputerConnectorContract,
+  zeroRemoteAgentConnectorContract,
   type ConnectorSearchAuthMethod,
   type ZeroConnectorsMainContract,
   type ZeroConnectorsByTypeContract,
@@ -714,6 +715,7 @@ export {
   type ZeroConnectorSessionsContract,
   type ZeroConnectorSessionByIdContract,
   type ZeroComputerConnectorContract,
+  type ZeroRemoteAgentConnectorContract,
 } from "./zero-connectors";
 export {
   zeroOrgContract,

--- a/turbo/packages/api-contracts/src/contracts/zero-connectors.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-connectors.ts
@@ -210,6 +210,27 @@ export const zeroComputerConnectorContract = c.router({
   },
 });
 
+/**
+ * Zero contract for POST /api/zero/connectors/remote-agent
+ * Creates the remote-agent connector once the user has at least one online host.
+ */
+export const zeroRemoteAgentConnectorContract = c.router({
+  create: {
+    method: "POST",
+    path: "/api/zero/connectors/remote-agent",
+    headers: authHeadersSchema,
+    body: z.object({}).optional(),
+    responses: {
+      200: connectorResponseSchema,
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      409: apiErrorSchema,
+    },
+    summary: "Connect remote-agent connector",
+  },
+});
+
 export type ZeroConnectorsMainContract = typeof zeroConnectorsMainContract;
 export type ZeroConnectorsByTypeContract = typeof zeroConnectorsByTypeContract;
 export type ZeroConnectorScopeDiffContract =
@@ -221,3 +242,5 @@ export type ZeroConnectorSessionByIdContract =
   typeof zeroConnectorSessionByIdContract;
 export type ZeroComputerConnectorContract =
   typeof zeroComputerConnectorContract;
+export type ZeroRemoteAgentConnectorContract =
+  typeof zeroRemoteAgentConnectorContract;

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -90,6 +90,10 @@ describe("getConnectorEnvironmentMapping", () => {
   it("returns non-empty mapping for connector types that surface env vars to the sandbox", () => {
     for (const type of connectorTypeSchema.options) {
       const mapping = getConnectorEnvironmentMapping(type);
+      if (type === "remote-agent") {
+        expect(mapping).toEqual({});
+        continue;
+      }
       expect(
         Object.keys(mapping).length,
         `${type} has empty environmentMapping`,

--- a/turbo/packages/connectors/src/connectors.ts
+++ b/turbo/packages/connectors/src/connectors.ts
@@ -52,6 +52,7 @@ import { figma } from "./connectors/figma";
 import { mercury } from "./connectors/mercury";
 import { minimax } from "./connectors/minimax";
 import { reportei } from "./connectors/reportei";
+import { remoteAgent } from "./connectors/remote-agent";
 import { serpapi } from "./connectors/serpapi";
 import { salesforce } from "./connectors/salesforce";
 import { reddit } from "./connectors/reddit";
@@ -422,6 +423,7 @@ const CONNECTOR_TYPES_DEF = {
   ...mercury,
   ...minimax,
   ...reportei,
+  ...remoteAgent,
   ...serpapi,
   ...salesforce,
   ...reddit,

--- a/turbo/packages/connectors/src/connectors/remote-agent.ts
+++ b/turbo/packages/connectors/src/connectors/remote-agent.ts
@@ -1,0 +1,24 @@
+import { FeatureSwitchKey } from "../feature-switch-key";
+import type { ConnectorConfig } from "../connectors";
+
+export const remoteAgent = {
+  "remote-agent": {
+    label: "Remote Agent",
+    category: "engineering-team-execution",
+    environmentMapping: {},
+    featureFlag: FeatureSwitchKey.RemoteAgent,
+    strictFeatureFlag: true,
+    helpText:
+      "Run local Codex or Claude Code hosts, then call them from chat with `/remote-agent ${host} prompt`",
+    authMethods: {
+      api: {
+        label: "CLI Host",
+        helpText:
+          "1. Run `npx -p @vm0/cli vm0 login`\n2. Start a host with `npx -p @vm0/cli vm0 remote-agent start`\n3. Keep the host process running, then return here and click **Connect** once it appears online\n4. Run a connected host from chat with `/remote-agent ${host} prompt`",
+        secrets: {},
+      },
+    },
+    defaultAuthMethod: "api",
+    tags: ["remote", "local", "host", "codex", "claude code"],
+  },
+} as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/firewalls/index.ts
+++ b/turbo/packages/connectors/src/firewalls/index.ts
@@ -556,7 +556,8 @@ export type NonFirewallConnectorType =
   // lives in MODEL_PROVIDER_FIREWALL_CONFIGS, not here).
   | "codex-oauth"
   // Other
-  | "computer"; // not an API connector
+  | "computer" // not an API connector
+  | "remote-agent"; // virtual connector backed by vm0's remote-agent API
 
 /**
  * Compile-time exhaustiveness checks.


### PR DESCRIPTION
## Summary
- add the Remote Agent connector definition gated by the remote-agent feature switch
- show online remote-agent hosts in connector settings with Ably-driven refresh and connect only when a host is online
- persist remote-agent connector connection, open the agent authorization dialog after connect, and add API coverage for the connect endpoint

## Tests
- pnpm --filter @vm0/app test src/signals/zero-page/settings/__tests__/remote-agent-connector.test.ts
- pnpm --filter api test src/signals/routes/__tests__/zero-connectors-remote-agent-connect.test.ts
- pnpm --filter @vm0/connectors test connectors.test.ts
- pnpm --filter @vm0/app check-types
- pnpm --filter api check-types
- pnpm --filter web check-types
- pnpm --filter @vm0/connectors check-types
- pnpm --filter @vm0/api-contracts check-types