### PR TITLE
refactor(api): migrate usage route to api backend

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -9,6 +9,7 @@ import { apiHealth$ } from "./routes/health";
 import { healthAuthProbeRoutes } from "./routes/health-auth-probe";
 import { internalEventConsumerTelegramTypingRoutes } from "./routes/internal-event-consumers-telegram-typing";
 import { modelStatsRoutes } from "./routes/model-stats";
+import { usageRoutes } from "./routes/usage";
 import { zeroAgentInstructionsRoutes } from "./routes/zero-agent-instructions";
 import { zeroAgentsRoutes } from "./routes/zero-agents";
 import { zeroApiKeysRoutes } from "./routes/zero-api-keys";
@@ -83,6 +84,7 @@ export const ROUTES: readonly RouteEntry[] = [
   },
   ...healthAuthProbeRoutes,
   ...internalEventConsumerTelegramTypingRoutes,
+  ...usageRoutes,
   ...deviceTokenRoutes,
   ...zeroAgentInstructionsRoutes,
   ...zeroAgentsRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/usage.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/usage.test.ts
@@ -202,6 +202,32 @@ describe("GET /api/usage", () => {
     });
   });
 
+  it("treats empty date query parameters as the default range", async () => {
+    const fixture = await track(seedUsageFixture());
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    await seedCompletedRun(fixture, {
+      createdAt: new Date("2026-05-12T10:00:00.000Z"),
+      durationMs: 60_000,
+    });
+
+    const response = await accept(
+      apiClient().get({
+        query: { start_date: "", end_date: "" },
+        headers: authHeaders(),
+      }),
+      [200],
+    );
+
+    expect(response.body.period).toStrictEqual({
+      start: "2026-05-05T12:00:00.000Z",
+      end: "2026-05-12T12:00:00.000Z",
+    });
+    expect(response.body.summary).toStrictEqual({
+      total_runs: 1,
+      total_run_time_ms: 60_000,
+    });
+  });
+
   it("rejects invalid start_date format", async () => {
     const fixture = await track(seedUsageFixture());
     mocks.clerk.session(fixture.userId, fixture.orgId);

--- a/turbo/apps/api/src/signals/routes/__tests__/usage.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/usage.test.ts
@@ -1,0 +1,434 @@
+import { randomUUID } from "node:crypto";
+
+import { usageContract } from "@vm0/api-contracts/contracts/usage";
+import { agentRuns } from "@vm0/db/schema/agent-run";
+import { usageDaily } from "@vm0/db/schema/usage-daily";
+import { createStore } from "ccstate";
+import { and, eq } from "drizzle-orm";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { clearMockNow, mockNow } from "../../../lib/time";
+import { writeDb$ } from "../../external/db";
+import {
+  deleteUsageInsightFixture$,
+  seedCompose$,
+  seedRun$,
+  seedUsageInsightFixture$,
+  type UsageInsightFixture,
+} from "./helpers/zero-usage-insight";
+import {
+  createFixtureTracker,
+  createZeroRouteMocks,
+} from "./helpers/zero-route-test";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+
+const FIXED_NOW_ISO = "2026-05-12T12:00:00.000Z";
+
+interface UsageFixture extends UsageInsightFixture {
+  readonly composeId: string;
+}
+
+interface CompletedRunArgs {
+  readonly createdAt: Date;
+  readonly durationMs: number;
+}
+
+function authHeaders() {
+  return { authorization: "Bearer clerk-session" };
+}
+
+function apiClient() {
+  return setupApp({ context })(usageContract);
+}
+
+async function deleteUsageFixture(fixture: UsageFixture): Promise<void> {
+  const db = store.set(writeDb$);
+  await db
+    .delete(usageDaily)
+    .where(
+      and(
+        eq(usageDaily.orgId, fixture.orgId),
+        eq(usageDaily.userId, fixture.userId),
+      ),
+    );
+  await store.set(deleteUsageInsightFixture$, fixture, context.signal);
+}
+
+async function seedUsageFixture(): Promise<UsageFixture> {
+  const base = await store.set(
+    seedUsageInsightFixture$,
+    undefined,
+    context.signal,
+  );
+  const { composeId } = await store.set(
+    seedCompose$,
+    {
+      orgId: base.orgId,
+      userId: base.userId,
+      name: `usage-${randomUUID().slice(0, 8)}`,
+    },
+    context.signal,
+  );
+  return { ...base, composeId };
+}
+
+async function seedCompletedRun(
+  fixture: UsageFixture,
+  args: CompletedRunArgs,
+): Promise<string> {
+  const { runId } = await store.set(
+    seedRun$,
+    {
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      composeId: fixture.composeId,
+      status: "completed",
+    },
+    context.signal,
+  );
+  const db = store.set(writeDb$);
+  await db
+    .update(agentRuns)
+    .set({
+      createdAt: args.createdAt,
+      startedAt: args.createdAt,
+      completedAt: new Date(args.createdAt.getTime() + args.durationMs),
+    })
+    .where(eq(agentRuns.id, runId));
+  return runId;
+}
+
+async function findCachedUsage(
+  fixture: UsageFixture,
+  date: string,
+): Promise<{ readonly runCount: number; readonly runTimeMs: number } | null> {
+  const db = store.set(writeDb$);
+  const [row] = await db
+    .select({
+      runCount: usageDaily.runCount,
+      runTimeMs: usageDaily.runTimeMs,
+    })
+    .from(usageDaily)
+    .where(
+      and(
+        eq(usageDaily.orgId, fixture.orgId),
+        eq(usageDaily.userId, fixture.userId),
+        eq(usageDaily.date, date),
+      ),
+    )
+    .limit(1);
+  return row ?? null;
+}
+
+describe("GET /api/usage", () => {
+  const track = createFixtureTracker<UsageFixture>((fixture) => {
+    return deleteUsageFixture(fixture);
+  });
+
+  beforeEach(() => {
+    mockNow(new Date(FIXED_NOW_ISO));
+  });
+
+  afterEach(() => {
+    clearMockNow();
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    const response = await accept(
+      apiClient().get({ query: {}, headers: {} }),
+      [401],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("returns usage data with the default 7 day range", async () => {
+    const fixture = await track(seedUsageFixture());
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    await seedCompletedRun(fixture, {
+      createdAt: new Date("2026-05-12T10:00:00.000Z"),
+      durationMs: 60_000,
+    });
+    await seedCompletedRun(fixture, {
+      createdAt: new Date("2026-05-12T11:00:00.000Z"),
+      durationMs: 120_000,
+    });
+
+    const response = await accept(
+      apiClient().get({ query: {}, headers: authHeaders() }),
+      [200],
+    );
+
+    expect(response.body.period).toStrictEqual({
+      start: "2026-05-05T12:00:00.000Z",
+      end: "2026-05-12T12:00:00.000Z",
+    });
+    expect(response.body.summary).toStrictEqual({
+      total_runs: 2,
+      total_run_time_ms: 180_000,
+    });
+    expect(response.body.daily).toHaveLength(1);
+    expect(response.body.daily[0]).toStrictEqual({
+      date: "2026-05-12",
+      run_count: 2,
+      run_time_ms: 180_000,
+    });
+  });
+
+  it("accepts a custom date range", async () => {
+    const fixture = await track(seedUsageFixture());
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      apiClient().get({
+        query: {
+          start_date: "2026-05-09T12:00:00.000Z",
+          end_date: "2026-05-12T12:00:00.000Z",
+        },
+        headers: authHeaders(),
+      }),
+      [200],
+    );
+
+    expect(response.body.period).toStrictEqual({
+      start: "2026-05-09T12:00:00.000Z",
+      end: "2026-05-12T12:00:00.000Z",
+    });
+  });
+
+  it("rejects invalid start_date format", async () => {
+    const fixture = await track(seedUsageFixture());
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      apiClient().get({
+        query: { start_date: "invalid" },
+        headers: authHeaders(),
+      }),
+      [400],
+    );
+
+    expect(response.body.error.message).toContain("Invalid start_date format");
+  });
+
+  it("rejects invalid end_date format", async () => {
+    const fixture = await track(seedUsageFixture());
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      apiClient().get({
+        query: { end_date: "invalid" },
+        headers: authHeaders(),
+      }),
+      [400],
+    );
+
+    expect(response.body.error.message).toContain("Invalid end_date format");
+  });
+
+  it("rejects start_date after end_date", async () => {
+    const fixture = await track(seedUsageFixture());
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      apiClient().get({
+        query: {
+          start_date: "2026-05-12T12:00:00.000Z",
+          end_date: "2026-05-11T12:00:00.000Z",
+        },
+        headers: authHeaders(),
+      }),
+      [400],
+    );
+
+    expect(response.body.error.message).toContain(
+      "start_date must be before end_date",
+    );
+  });
+
+  it("rejects ranges exceeding 30 days", async () => {
+    const fixture = await track(seedUsageFixture());
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      apiClient().get({
+        query: {
+          start_date: "2026-04-01T12:00:00.000Z",
+          end_date: "2026-05-12T12:00:00.000Z",
+        },
+        headers: authHeaders(),
+      }),
+      [400],
+    );
+
+    expect(response.body.error.message).toContain(
+      "Time range exceeds maximum of 30 days",
+    );
+  });
+
+  it("returns daily breakdown rows and summary totals", async () => {
+    const fixture = await track(seedUsageFixture());
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    await seedCompletedRun(fixture, {
+      createdAt: new Date("2026-05-12T09:00:00.000Z"),
+      durationMs: 45_000,
+    });
+    await seedCompletedRun(fixture, {
+      createdAt: new Date("2026-05-12T10:00:00.000Z"),
+      durationMs: 15_000,
+    });
+
+    const response = await accept(
+      apiClient().get({ query: {}, headers: authHeaders() }),
+      [200],
+    );
+
+    expect(response.body.summary.total_runs).toBe(2);
+    expect(response.body.summary.total_run_time_ms).toBe(60_000);
+    for (const day of response.body.daily) {
+      expect(typeof day.date).toBe("string");
+      expect(typeof day.run_count).toBe("number");
+      expect(typeof day.run_time_ms).toBe("number");
+    }
+  });
+
+  it("calculates run times correctly with explicit timestamps", async () => {
+    const fixture = await track(seedUsageFixture());
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    await seedCompletedRun(fixture, {
+      createdAt: new Date("2026-05-12T09:00:00.000Z"),
+      durationMs: 60_000,
+    });
+    await seedCompletedRun(fixture, {
+      createdAt: new Date("2026-05-12T10:00:00.000Z"),
+      durationMs: 120_000,
+    });
+
+    const response = await accept(
+      apiClient().get({ query: {}, headers: authHeaders() }),
+      [200],
+    );
+
+    expect(response.body.summary.total_runs).toBe(2);
+    expect(response.body.summary.total_run_time_ms).toBe(180_000);
+  });
+
+  it("aggregates historical runs across multiple days", async () => {
+    const fixture = await track(seedUsageFixture());
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    await seedCompletedRun(fixture, {
+      createdAt: new Date("2026-05-08T10:00:00.000Z"),
+      durationMs: 5000,
+    });
+    await seedCompletedRun(fixture, {
+      createdAt: new Date("2026-05-09T10:00:00.000Z"),
+      durationMs: 8000,
+    });
+
+    const response = await accept(
+      apiClient().get({
+        query: {
+          start_date: "2026-05-07T00:00:00.000Z",
+          end_date: "2026-05-12T12:00:00.000Z",
+        },
+        headers: authHeaders(),
+      }),
+      [200],
+    );
+
+    expect(response.body.summary).toStrictEqual({
+      total_runs: 2,
+      total_run_time_ms: 13_000,
+    });
+    expect(response.body.daily).toStrictEqual([
+      { date: "2026-05-09", run_count: 1, run_time_ms: 8000 },
+      { date: "2026-05-08", run_count: 1, run_time_ms: 5000 },
+    ]);
+  });
+
+  it("uses agent_runs for partial start day boundaries", async () => {
+    const fixture = await track(seedUsageFixture());
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    await seedCompletedRun(fixture, {
+      createdAt: new Date("2026-05-10T08:00:00.000Z"),
+      durationMs: 3000,
+    });
+    await seedCompletedRun(fixture, {
+      createdAt: new Date("2026-05-10T14:00:00.000Z"),
+      durationMs: 5000,
+    });
+
+    const response = await accept(
+      apiClient().get({
+        query: {
+          start_date: "2026-05-10T14:00:00.000Z",
+          end_date: "2026-05-12T12:00:00.000Z",
+        },
+        headers: authHeaders(),
+      }),
+      [200],
+    );
+
+    expect(response.body.daily).toStrictEqual([
+      { date: "2026-05-10", run_count: 1, run_time_ms: 5000 },
+    ]);
+  });
+
+  it("caches computed historical results for subsequent queries", async () => {
+    const fixture = await track(seedUsageFixture());
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    await seedCompletedRun(fixture, {
+      createdAt: new Date("2026-05-08T10:00:00.000Z"),
+      durationMs: 6000,
+    });
+
+    const request = {
+      query: {
+        start_date: "2026-05-07T00:00:00.000Z",
+        end_date: "2026-05-12T12:00:00.000Z",
+      },
+      headers: authHeaders(),
+    };
+
+    const first = await accept(apiClient().get(request), [200]);
+    expect(first.body.summary.total_runs).toBe(1);
+    expect(first.body.summary.total_run_time_ms).toBe(6000);
+
+    const cached = await findCachedUsage(fixture, "2026-05-08");
+    expect(cached).toStrictEqual({ runCount: 1, runTimeMs: 6000 });
+
+    const second = await accept(apiClient().get(request), [200]);
+    expect(second.body.summary).toStrictEqual(first.body.summary);
+    expect(second.body.daily).toStrictEqual(first.body.daily);
+  });
+
+  it("only returns usage for the authenticated org", async () => {
+    const fixture = await track(seedUsageFixture());
+    const otherFixture = await track(seedUsageFixture());
+    await seedCompletedRun(fixture, {
+      createdAt: new Date("2026-05-12T10:00:00.000Z"),
+      durationMs: 5000,
+    });
+    await seedCompletedRun(otherFixture, {
+      createdAt: new Date("2026-05-12T10:00:00.000Z"),
+      durationMs: 8000,
+    });
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      apiClient().get({ query: {}, headers: authHeaders() }),
+      [200],
+    );
+
+    expect(response.body.summary).toStrictEqual({
+      total_runs: 1,
+      total_run_time_ms: 5000,
+    });
+  });
+});

--- a/turbo/apps/api/src/signals/routes/usage.ts
+++ b/turbo/apps/api/src/signals/routes/usage.ts
@@ -1,0 +1,71 @@
+import { usageContract } from "@vm0/api-contracts/contracts/usage";
+import { command } from "ccstate";
+
+import { badRequestMessage } from "../../lib/error";
+import { nowDate } from "../../lib/time";
+import { organizationAuthContext$ } from "../auth/auth-context";
+import { authRoute } from "../auth/auth-route";
+import { queryOf } from "../context/request";
+import type { RouteEntry } from "../route";
+import { usageSummary$ } from "../services/usage.service";
+
+const MAX_RANGE_MS = 30 * 24 * 60 * 60 * 1000;
+const DEFAULT_RANGE_MS = 7 * 24 * 60 * 60 * 1000;
+
+function parseDateParam(value: string): Date | null {
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+const getUsageInner$ = command(async ({ get, set }, signal: AbortSignal) => {
+  const auth = get(organizationAuthContext$);
+  const query = get(queryOf(usageContract.get));
+  const now = nowDate();
+
+  const endDate =
+    query.end_date !== undefined ? parseDateParam(query.end_date) : now;
+  if (!endDate) {
+    return badRequestMessage("Invalid end_date format. Use ISO 8601 format.");
+  }
+
+  const startDate =
+    query.start_date !== undefined
+      ? parseDateParam(query.start_date)
+      : new Date(endDate.getTime() - DEFAULT_RANGE_MS);
+  if (!startDate) {
+    return badRequestMessage("Invalid start_date format. Use ISO 8601 format.");
+  }
+
+  if (startDate >= endDate) {
+    return badRequestMessage("start_date must be before end_date");
+  }
+
+  const rangeMs = endDate.getTime() - startDate.getTime();
+  if (rangeMs > MAX_RANGE_MS) {
+    return badRequestMessage(
+      "Time range exceeds maximum of 30 days. Use --until to specify an end date.",
+    );
+  }
+
+  const body = await set(
+    usageSummary$,
+    {
+      userId: auth.userId,
+      orgId: auth.orgId,
+      now,
+      startDate,
+      endDate,
+    },
+    signal,
+  );
+  signal.throwIfAborted();
+
+  return { status: 200 as const, body };
+});
+
+export const usageRoutes: readonly RouteEntry[] = [
+  {
+    route: usageContract.get,
+    handler: authRoute({ requireOrganization: true }, getUsageInner$),
+  },
+];

--- a/turbo/apps/api/src/signals/routes/usage.ts
+++ b/turbo/apps/api/src/signals/routes/usage.ts
@@ -22,16 +22,14 @@ const getUsageInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   const query = get(queryOf(usageContract.get));
   const now = nowDate();
 
-  const endDate =
-    query.end_date !== undefined ? parseDateParam(query.end_date) : now;
+  const endDate = query.end_date ? parseDateParam(query.end_date) : now;
   if (!endDate) {
     return badRequestMessage("Invalid end_date format. Use ISO 8601 format.");
   }
 
-  const startDate =
-    query.start_date !== undefined
-      ? parseDateParam(query.start_date)
-      : new Date(endDate.getTime() - DEFAULT_RANGE_MS);
+  const startDate = query.start_date
+    ? parseDateParam(query.start_date)
+    : new Date(endDate.getTime() - DEFAULT_RANGE_MS);
   if (!startDate) {
     return badRequestMessage("Invalid start_date format. Use ISO 8601 format.");
   }

--- a/turbo/apps/api/src/signals/services/usage.service.ts
+++ b/turbo/apps/api/src/signals/services/usage.service.ts
@@ -1,0 +1,279 @@
+import type {
+  DailyUsage,
+  UsageResponse,
+} from "@vm0/api-contracts/contracts/usage";
+import { agentRuns } from "@vm0/db/schema/agent-run";
+import { usageDaily } from "@vm0/db/schema/usage-daily";
+import { command } from "ccstate";
+import { and, eq, gte, isNotNull, lt, sql } from "drizzle-orm";
+
+import { writeDb$, type Db } from "../external/db";
+
+const MS_PER_DAY = 86_400_000;
+
+interface UsageSummaryArgs {
+  readonly userId: string;
+  readonly orgId: string;
+  readonly now: Date;
+  readonly startDate: Date;
+  readonly endDate: Date;
+}
+
+interface AppendAgentRunsDailyArgs {
+  readonly daily: DailyUsage[];
+  readonly db: Db;
+  readonly summary: UsageSummaryArgs;
+  readonly from: Date;
+  readonly to: Date;
+  readonly signal: AbortSignal;
+}
+
+interface AppendHistoricalUsageArgs {
+  readonly daily: DailyUsage[];
+  readonly db: Db;
+  readonly summary: UsageSummaryArgs;
+  readonly historicalFrom: Date;
+  readonly historicalTo: Date;
+  readonly signal: AbortSignal;
+}
+
+function utcMidnight(date: Date): Date {
+  return new Date(
+    Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()),
+  );
+}
+
+async function queryAgentRunsDaily(
+  db: Db,
+  userId: string,
+  orgId: string,
+  from: Date,
+  to: Date,
+): Promise<DailyUsage[]> {
+  if (from >= to) {
+    return [];
+  }
+
+  const rows = await db
+    .select({
+      date: sql<string>`DATE(${agentRuns.createdAt})`.as("date"),
+      run_count: sql<number>`COUNT(*)::int`.as("run_count"),
+      run_time_ms:
+        sql<number>`COALESCE(SUM(EXTRACT(EPOCH FROM (${agentRuns.completedAt} - ${agentRuns.startedAt})) * 1000), 0)::bigint`.as(
+          "run_time_ms",
+        ),
+    })
+    .from(agentRuns)
+    .where(
+      and(
+        eq(agentRuns.userId, userId),
+        eq(agentRuns.orgId, orgId),
+        gte(agentRuns.createdAt, from),
+        lt(agentRuns.createdAt, to),
+        isNotNull(agentRuns.completedAt),
+      ),
+    )
+    .groupBy(sql`DATE(${agentRuns.createdAt})`);
+
+  return rows.map((row) => {
+    return {
+      date: String(row.date),
+      run_count: Number(row.run_count),
+      run_time_ms: Number(row.run_time_ms),
+    };
+  });
+}
+
+async function appendAgentRunsDaily(
+  args: AppendAgentRunsDailyArgs,
+): Promise<void> {
+  args.daily.push(
+    ...(await queryAgentRunsDaily(
+      args.db,
+      args.summary.userId,
+      args.summary.orgId,
+      args.from,
+      args.to,
+    )),
+  );
+  args.signal.throwIfAborted();
+}
+
+async function cacheUsageRows(
+  db: Db,
+  args: UsageSummaryArgs,
+  rows: readonly DailyUsage[],
+): Promise<void> {
+  await db
+    .insert(usageDaily)
+    .values(
+      rows.map((row) => {
+        return {
+          userId: args.userId,
+          orgId: args.orgId,
+          date: row.date,
+          runCount: row.run_count,
+          runTimeMs: row.run_time_ms,
+        };
+      }),
+    )
+    .onConflictDoUpdate({
+      target: [usageDaily.userId, usageDaily.orgId, usageDaily.date],
+      set: {
+        runCount: sql`excluded.run_count`,
+        runTimeMs: sql`excluded.run_time_ms`,
+        updatedAt: args.now,
+      },
+    });
+}
+
+async function appendHistoricalUsage(
+  args: AppendHistoricalUsageArgs,
+): Promise<void> {
+  const fromStr = args.historicalFrom.toISOString().split("T")[0]!;
+  const toStr = args.historicalTo.toISOString().split("T")[0]!;
+
+  const cachedRows = await args.db
+    .select({
+      date: usageDaily.date,
+      runCount: usageDaily.runCount,
+      runTimeMs: usageDaily.runTimeMs,
+    })
+    .from(usageDaily)
+    .where(
+      and(
+        eq(usageDaily.userId, args.summary.userId),
+        eq(usageDaily.orgId, args.summary.orgId),
+        gte(usageDaily.date, fromStr),
+        lt(usageDaily.date, toStr),
+      ),
+    );
+  args.signal.throwIfAborted();
+
+  const cachedDates = new Set(
+    cachedRows.map((row) => {
+      return row.date;
+    }),
+  );
+  for (const row of cachedRows) {
+    args.daily.push({
+      date: row.date,
+      run_count: row.runCount,
+      run_time_ms: Number(row.runTimeMs),
+    });
+  }
+
+  const totalDays = Math.floor(
+    (args.historicalTo.getTime() - args.historicalFrom.getTime()) / MS_PER_DAY,
+  );
+  if (cachedDates.size >= totalDays) {
+    return;
+  }
+
+  const computedRows = await queryAgentRunsDaily(
+    args.db,
+    args.summary.userId,
+    args.summary.orgId,
+    args.historicalFrom,
+    args.historicalTo,
+  );
+  args.signal.throwIfAborted();
+
+  const uncachedRows = computedRows.filter((row) => {
+    return !cachedDates.has(row.date);
+  });
+  args.daily.push(...uncachedRows);
+
+  if (uncachedRows.length > 0) {
+    await cacheUsageRows(args.db, args.summary, uncachedRows);
+    args.signal.throwIfAborted();
+  }
+}
+
+function summarizeUsage(
+  args: UsageSummaryArgs,
+  daily: DailyUsage[],
+): UsageResponse {
+  daily.sort((a, b) => {
+    return b.date.localeCompare(a.date);
+  });
+
+  let totalRuns = 0;
+  let totalRunTimeMs = 0;
+  for (const usage of daily) {
+    totalRuns += usage.run_count;
+    totalRunTimeMs += usage.run_time_ms;
+  }
+
+  return {
+    period: {
+      start: args.startDate.toISOString(),
+      end: args.endDate.toISOString(),
+    },
+    summary: {
+      total_runs: totalRuns,
+      total_run_time_ms: totalRunTimeMs,
+    },
+    daily,
+  };
+}
+
+export const usageSummary$ = command(
+  async (
+    { set },
+    args: UsageSummaryArgs,
+    signal: AbortSignal,
+  ): Promise<UsageResponse> => {
+    const db = set(writeDb$);
+    const todayMidnight = utcMidnight(args.now);
+    const startMidnight = utcMidnight(args.startDate);
+    const endMidnight = utcMidnight(args.endDate);
+
+    const historicalFrom =
+      args.startDate.getTime() === startMidnight.getTime()
+        ? startMidnight
+        : new Date(startMidnight.getTime() + MS_PER_DAY);
+    const historicalTo =
+      endMidnight < todayMidnight ? endMidnight : todayMidnight;
+
+    const daily: DailyUsage[] = [];
+
+    if (historicalFrom >= historicalTo) {
+      await appendAgentRunsDaily({
+        daily,
+        db,
+        summary: args,
+        from: args.startDate,
+        to: args.endDate,
+        signal,
+      });
+    } else {
+      await appendAgentRunsDaily({
+        daily,
+        db,
+        summary: args,
+        from: args.startDate,
+        to: historicalFrom,
+        signal,
+      });
+      await appendHistoricalUsage({
+        daily,
+        db,
+        summary: args,
+        historicalFrom,
+        historicalTo,
+        signal,
+      });
+      await appendAgentRunsDaily({
+        daily,
+        db,
+        summary: args,
+        from: historicalTo,
+        to: args.endDate,
+        signal,
+      });
+    }
+
+    return summarizeUsage(args, daily);
+  },
+);

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -930,6 +930,12 @@ export {
   type UsageInsightChatRow,
 } from "./zero-usage-insight";
 export {
+  usageContract,
+  type UsageContract,
+  type DailyUsage,
+  type UsageResponse,
+} from "./usage";
+export {
   zeroTeamContract,
   teamComposeItemSchema,
   type ZeroTeamContract,

--- a/turbo/packages/api-contracts/src/contracts/usage.ts
+++ b/turbo/packages/api-contracts/src/contracts/usage.ts
@@ -1,0 +1,46 @@
+import { z } from "zod";
+import { authHeadersSchema, initContract } from "./base";
+import { apiErrorSchema } from "./errors";
+
+const c = initContract();
+
+const dailyUsageSchema = z.object({
+  date: z.string(),
+  run_count: z.number(),
+  run_time_ms: z.number(),
+});
+
+const usageResponseSchema = z.object({
+  period: z.object({
+    start: z.string(),
+    end: z.string(),
+  }),
+  summary: z.object({
+    total_runs: z.number(),
+    total_run_time_ms: z.number(),
+  }),
+  daily: z.array(dailyUsageSchema),
+});
+
+export const usageContract = c.router({
+  get: {
+    method: "GET",
+    path: "/api/usage",
+    headers: authHeadersSchema,
+    query: z.object({
+      start_date: z.string().optional(),
+      end_date: z.string().optional(),
+    }),
+    responses: {
+      200: usageResponseSchema,
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      500: apiErrorSchema,
+    },
+    summary: "Get personal daily run usage for the signed-in user",
+  },
+});
+
+export type UsageContract = typeof usageContract;
+export type DailyUsage = z.infer<typeof dailyUsageSchema>;
+export type UsageResponse = z.infer<typeof usageResponseSchema>;


### PR DESCRIPTION
## Summary
- add the ts-rest contract and API route registration for `GET /api/usage`
- port the legacy usage aggregation and `usage_daily` cache write behavior into an API Command service
- add API route integration coverage for auth, date validation, aggregation, caching, and org isolation

Closes #12831

## Validation
- `pnpm -F api exec vitest src/signals/routes/__tests__/usage.test.ts`
- `pnpm -F api lint`
- `pnpm check-types`
- `git diff --check`