### PR TITLE
chore: promote ably subscriber diagnostics to info

### DIFF
--- a/crates/README.md
+++ b/crates/README.md
@@ -50,6 +50,12 @@ This workspace contains Rust crates for the vm0 sandbox runtime — VM orchestra
 └──────────────────────────────────────────┘
 ```
 
+## Logging
+
+Runner Rust logs are recorded at `info` and above by default. Use `debug` or
+`trace` only for local diagnostics that are acceptable to miss in production
+logs, CI logs, and Axiom.
+
 ## TLS in Guest Binaries
 
 Guest crates (`guest-agent`, `guest-download`) **must** use system certificate roots, not bundled webpki roots. The host runs a mitmproxy transparent proxy that intercepts HTTPS traffic with its own CA certificate, which is installed into the guest's system certificate store at boot. Using bundled roots would bypass the proxy CA and cause TLS verification failures.

--- a/crates/README.md
+++ b/crates/README.md
@@ -52,9 +52,9 @@ This workspace contains Rust crates for the vm0 sandbox runtime — VM orchestra
 
 ## Logging
 
-Runner Rust logs are recorded at `info` and above by default. Use `debug` or
-`trace` only for local diagnostics that are acceptable to miss in production
-logs, CI logs, and Axiom.
+Runner Rust logs are recorded to local files, stderr, and CI at `info` and
+above by default. Axiom ingests `warn` and above. Use `debug` or `trace` only
+for local diagnostics that are acceptable to miss in production logs.
 
 ## TLS in Guest Binaries
 

--- a/crates/ably-subscriber/src/connection.rs
+++ b/crates/ably-subscriber/src/connection.rs
@@ -1216,7 +1216,7 @@ async fn handle_message(
 ) -> LoopAction {
     match msg.action {
         action::HEARTBEAT => {
-            tracing::info!("Heartbeat received");
+            tracing::trace!("Heartbeat received");
         }
         action::MESSAGE => {
             if !message_targets_channel(&msg, &p.channel) {

--- a/crates/ably-subscriber/src/connection.rs
+++ b/crates/ably-subscriber/src/connection.rs
@@ -146,7 +146,7 @@ async fn wait_for_connected(ws_read: &mut WsRead) -> Result<ProtocolMessage, Err
                     });
                 }
                 _ => {
-                    tracing::debug!(action = msg.action, "Ignoring pre-CONNECTED message");
+                    tracing::info!(action = msg.action, "Ignoring pre-CONNECTED message");
                 }
             }
         }
@@ -230,7 +230,7 @@ async fn wait_for_attach_outcome(
                     return Ok(AttachOutcome::Closed(closed_error_or_default(msg.error)));
                 }
                 _ => {
-                    tracing::debug!(action = msg.action, "Ignoring pre-ATTACHED message");
+                    tracing::info!(action = msg.action, "Ignoring pre-ATTACHED message");
                 }
             }
         }
@@ -531,7 +531,7 @@ impl RealtimeStateMachine {
         if self.connection.terminal() || self.connection == next {
             return;
         }
-        tracing::debug!(
+        tracing::info!(
             previous = ?self.connection,
             current = ?next,
             queue_events = next.queue_events(),
@@ -545,7 +545,7 @@ impl RealtimeStateMachine {
         if self.channel == next {
             return;
         }
-        tracing::debug!(
+        tracing::info!(
             previous = ?self.channel,
             current = ?next,
             "Ably channel state transition",
@@ -1216,14 +1216,14 @@ async fn handle_message(
 ) -> LoopAction {
     match msg.action {
         action::HEARTBEAT => {
-            tracing::trace!("Heartbeat received");
+            tracing::info!("Heartbeat received");
         }
         action::MESSAGE => {
             if !message_targets_channel(&msg, &p.channel) {
                 return LoopAction::Continue;
             }
             if p.lifecycle.channel != ChannelLifecycleState::Attached {
-                tracing::debug!(
+                tracing::info!(
                     channel_state = ?p.lifecycle.channel,
                     "Skipping message while channel is not attached"
                 );
@@ -1390,7 +1390,7 @@ async fn handle_message(
             }
         }
         _ => {
-            tracing::debug!(action = msg.action, "Ignoring unknown action");
+            tracing::info!(action = msg.action, "Ignoring unknown action");
         }
     }
     LoopAction::Continue


### PR DESCRIPTION
## Summary
- promote ably-subscriber low-level diagnostic logs from debug/trace to info so runner production logs can capture them
- document that runner Rust logs record info and above by default

## Tests
- cargo fmt --manifest-path crates/Cargo.toml --all --check
- cargo test --manifest-path crates/Cargo.toml -p ably-subscriber
- pre-commit cargo-clippy
- pre-commit cargo-doc

Closes #12899