### PR TITLE
chore: tune sandbox-fc log levels

### DIFF
--- a/crates/sandbox-fc/src/balloon.rs
+++ b/crates/sandbox-fc/src/balloon.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 use std::time::Duration;
 
 use tokio::sync::watch;
-use tracing::{debug, info, warn};
+use tracing::{info, warn};
 
 use crate::api::ApiClient;
 use crate::sandbox::SandboxState;
@@ -98,7 +98,7 @@ async fn run_loop(api_sock: PathBuf, memory_mb: u32, mut state_rx: watch::Receiv
     let client = ApiClient::new(&api_sock);
     let max_inflate = memory_mb.saturating_sub(MIN_GUEST_MIB);
     if max_inflate == 0 {
-        debug!(
+        info!(
             memory_mb,
             MIN_GUEST_MIB, "balloon controller disabled: memory_mb <= MIN_GUEST_MIB"
         );
@@ -119,7 +119,6 @@ async fn run_loop(api_sock: PathBuf, memory_mb: u32, mut state_rx: watch::Receiv
                 tick_count += 1;
             }
             _ = wait_for_crash_or_stop(&mut state_rx) => {
-                debug!("balloon controller exiting: VM stopped or crashed");
                 return;
             }
         }
@@ -216,7 +215,7 @@ fn read_host_meminfo() -> Option<(u64, u64)> {
     let content = match std::fs::read_to_string("/proc/meminfo") {
         Ok(c) => c,
         Err(e) => {
-            debug!(error = %e, "failed to read /proc/meminfo");
+            warn!(error = %e, "failed to read /proc/meminfo");
             return None;
         }
     };

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -419,16 +419,14 @@ fn log_process_log_reader_join(
     result: Result<(), tokio::task::JoinError>,
     after_abort: bool,
 ) {
-    if let Err(e) = result {
-        if after_abort && e.is_cancelled() {
-            trace!(stream = stream.name(), "process log reader aborted");
-        } else {
-            warn!(
-                stream = stream.name(),
-                error = %e,
-                "process log reader task exited unexpectedly"
-            );
-        }
+    if let Err(e) = result
+        && !(after_abort && e.is_cancelled())
+    {
+        warn!(
+            stream = stream.name(),
+            error = %e,
+            "process log reader task exited unexpectedly"
+        );
     }
 }
 


### PR DESCRIPTION
## Summary

- promote visible sandbox-fc balloon configuration and host meminfo failure logs
- remove redundant process log reader abort trace after bounded drain cleanup
- keep high-volume command helper and balloon polling traces below info

Closes #12900

## Tests

- cargo fmt --manifest-path crates/Cargo.toml --all -- --check
- cargo test --manifest-path crates/Cargo.toml -p sandbox-fc
- pre-commit hook: cargo-fmt, cargo-clippy, cargo-doc