### PR TITLE
chore(rust): update dependencies

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -2824,9 +2824,9 @@ checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "sentry"
-version = "0.48.1"
+version = "0.48.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b93b3e19f45495ddd41d8222a152c48c84f6ba45abe9c69e2527e9cdea29bb5b"
+checksum = "931a20b0da02350676e3d6d3c9028d58eaa448cf42a866712eec5845a505421e"
 dependencies = [
  "cfg_aliases",
  "sentry-core",
@@ -2835,9 +2835,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-backtrace"
-version = "0.48.1"
+version = "0.48.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc84c325ace9ca2388e510fe7d6672b5d60cd8b3bd0eb4bb4ee8314c323cd686"
+checksum = "911ee36abf5b7fa335fccd5f54361ba9c16baea5f0c3bb361a687b6c195c21cf"
 dependencies = [
  "backtrace",
  "regex",
@@ -2846,9 +2846,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-core"
-version = "0.48.1"
+version = "0.48.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5f5abf20c42cb1593ec1638976e2647da55f79bccac956444c1707b6cce259a"
+checksum = "545dc562b6758d646ac19e1407f4ebc26d452111386743e03323464bc48bb2e0"
 dependencies = [
  "rand",
  "sentry-types",
@@ -2859,9 +2859,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-panic"
-version = "0.48.1"
+version = "0.48.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0260dcb52562b6a79ae7702312a26dba94b79fb5baee7301087529e5ca4e872e"
+checksum = "772d9de150c8ca910c835353c85f434457348fdd21208f9b3da3574202b1dc5d"
 dependencies = [
  "sentry-backtrace",
  "sentry-core",
@@ -2869,9 +2869,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-types"
-version = "0.48.1"
+version = "0.48.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82d8e81058ec155992191f61c7b29bfa7b2cf12012131e7cdc0678020898a7c9"
+checksum = "041359745a44dd2e14fe21b7510fe7ca8b5beffce6636a0b52e5bc7d5f736887"
 dependencies = [
  "debugid",
  "hex",


### PR DESCRIPTION
## Summary
- Updated the Rust workspace lockfile in `crates/Cargo.lock`.
- `cargo update --verbose` updated 5 packages:
  - `sentry` `0.48.1` -> `0.48.2`
  - `sentry-backtrace` `0.48.1` -> `0.48.2`
  - `sentry-core` `0.48.1` -> `0.48.2`
  - `sentry-panic` `0.48.1` -> `0.48.2`
  - `sentry-types` `0.48.1` -> `0.48.2`

## Dependencies not updated
- `crc` stayed at `3.3.0` (`3.4.0` available). Blocked by transitive requirement `crc = "~3.3"` from `crc-fast v1.9.0`.
- `crc-fast` stayed at `1.9.0` (`1.10.0` available). Blocked by transitive requirement `crc-fast = "~1.9.0"` from `aws-smithy-checksums v0.64.7`.
- `generic-array` stayed at `0.14.7` (`0.14.9` available). Blocked by transitive requirement `generic-array = "=0.14.7"` from `crypto-common v0.1.7`.

## Manual version bumps
- None. The unchanged packages are not directly constrained by this repository's `Cargo.toml` files, so there was no safe local minor/patch specifier to bump.

## Test status
- Passed: `env -u CLI_AGENT_TYPE -u CODEX_HOME CARGO_BUILD_JOBS=1 cargo test --workspace`
- Note: an initial unconstrained run hit a linker `SIGKILL` while building `runner`, then a retry with `CARGO_BUILD_JOBS=1` exposed this scheduled agent's ambient `CLI_AGENT_TYPE=codex` in `guest-agent/tests/cli_stderr_logging.rs`. The clean-env run above passed.
