### PR TITLE
refactor(api): migrate zero connector authorize routes

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-authorize.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-authorize.test.ts
@@ -1,0 +1,347 @@
+import { randomUUID } from "node:crypto";
+
+import { connectors } from "@vm0/db/schema/connector";
+import { createStore } from "ccstate";
+import { eq } from "drizzle-orm";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { createApp } from "../../../app-factory";
+import { mockOptionalEnv } from "../../../lib/env";
+import { writeDb$ } from "../../external/db";
+import { createZeroRouteMocks } from "./helpers/zero-route-test";
+import { testContext } from "../../../__tests__/test-helpers";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+
+const BASE_URL = "https://app.vm0.test";
+
+function authorizeUrl(type: string, session?: string): string {
+  const url = new URL(`/api/zero/connectors/${type}/authorize`, BASE_URL);
+  if (session) {
+    url.searchParams.set("session", session);
+  }
+  return url.toString();
+}
+
+function sessionHeaders(): HeadersInit {
+  return { cookie: "__session=opaque" };
+}
+
+function mockOAuthEnv(): void {
+  mockOptionalEnv("GH_OAUTH_CLIENT_ID", "test-client-id");
+  mockOptionalEnv("GH_OAUTH_CLIENT_SECRET", "test-client-secret");
+  mockOptionalEnv("AIRTABLE_OAUTH_CLIENT_ID", "airtable-test-client-id");
+  mockOptionalEnv(
+    "AIRTABLE_OAUTH_CLIENT_SECRET",
+    "airtable-test-client-secret",
+  );
+  mockOptionalEnv("DOCUSIGN_OAUTH_CLIENT_ID", "docusign-test-client-id");
+  mockOptionalEnv(
+    "DOCUSIGN_OAUTH_CLIENT_SECRET",
+    "docusign-test-client-secret",
+  );
+  mockOptionalEnv("DROPBOX_OAUTH_CLIENT_ID", "dropbox-test-client-id");
+  mockOptionalEnv("DROPBOX_OAUTH_CLIENT_SECRET", "dropbox-test-client-secret");
+  mockOptionalEnv("LINEAR_OAUTH_CLIENT_ID", "linear-test-client-id");
+  mockOptionalEnv("LINEAR_OAUTH_CLIENT_SECRET", "linear-test-client-secret");
+  mockOptionalEnv("MERCURY_OAUTH_CLIENT_ID", "mercury-test-client-id");
+  mockOptionalEnv("MERCURY_OAUTH_CLIENT_SECRET", "mercury-test-client-secret");
+  mockOptionalEnv("NOTION_OAUTH_CLIENT_ID", "notion-test-client-id");
+  mockOptionalEnv("NOTION_OAUTH_CLIENT_SECRET", "notion-test-client-secret");
+  mockOptionalEnv("REDDIT_OAUTH_CLIENT_ID", "reddit-test-client-id");
+  mockOptionalEnv("REDDIT_OAUTH_CLIENT_SECRET", "reddit-test-client-secret");
+  mockOptionalEnv("SLACK_CLIENT_ID", "test-slack-client-id");
+  mockOptionalEnv("SLACK_CLIENT_SECRET", "test-slack-client-secret");
+  mockOptionalEnv("STRAVA_OAUTH_CLIENT_ID", "strava-test-client-id");
+  mockOptionalEnv("STRAVA_OAUTH_CLIENT_SECRET", "strava-test-client-secret");
+  mockOptionalEnv("X_OAUTH_CLIENT_ID", "x-test-client-id");
+  mockOptionalEnv("X_OAUTH_CLIENT_SECRET", "x-test-client-secret");
+}
+
+async function requestAuthorize(
+  type: string,
+  options: { readonly session?: string; readonly authenticated?: boolean } = {},
+): Promise<Response> {
+  if (options.authenticated) {
+    mocks.clerk.session(`user_${randomUUID()}`, `org_${randomUUID()}`);
+  }
+  const app = createApp({ signal: context.signal });
+  return await app.request(authorizeUrl(type, options.session), {
+    method: "GET",
+    headers: options.authenticated ? sessionHeaders() : undefined,
+  });
+}
+
+describe("GET /api/zero/connectors/:type/authorize", () => {
+  const orgIds: string[] = [];
+
+  beforeEach(() => {
+    mockOAuthEnv();
+  });
+
+  afterEach(async () => {
+    const db = store.set(writeDb$);
+    while (orgIds.length > 0) {
+      const orgId = orgIds.pop();
+      if (orgId) {
+        await db.delete(connectors).where(eq(connectors.orgId, orgId));
+      }
+    }
+  });
+
+  it("returns 400 for an unknown connector type", async () => {
+    const response = await requestAuthorize("invalid");
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toStrictEqual({
+      error: "Unknown connector type: invalid",
+    });
+  });
+
+  it("redirects unauthenticated users to sign-in", async () => {
+    const response = await requestAuthorize("github");
+
+    expect(response.status).toBe(307);
+    const location = response.headers.get("location");
+    expect(location).not.toBeNull();
+    const url = new URL(location!);
+    expect(url.pathname).toBe("/sign-in");
+    expect(url.searchParams.get("redirect_url")).toBe(authorizeUrl("github"));
+  });
+
+  it("redirects to GitHub OAuth and sets the state cookie", async () => {
+    const response = await requestAuthorize("github", { authenticated: true });
+
+    expect(response.status).toBe(307);
+    const location = response.headers.get("location");
+    expect(location).not.toBeNull();
+    const url = new URL(location!);
+    expect(`${url.origin}${url.pathname}`).toBe(
+      "https://github.com/login/oauth/authorize",
+    );
+    expect(url.searchParams.get("client_id")).toBe("test-client-id");
+    expect(url.searchParams.get("redirect_uri")).toBe(
+      `${BASE_URL}/api/connectors/github/callback`,
+    );
+    expect(url.searchParams.get("scope")).toBe("repo project workflow");
+    expect(url.searchParams.get("state")).toMatch(/^[0-9a-f]{64}$/);
+
+    const cookies = response.headers.getSetCookie();
+    expect(
+      cookies.some((cookie) => {
+        return cookie.startsWith("connector_oauth_state=");
+      }),
+    ).toBeTruthy();
+  });
+
+  it("stores the connector session id when provided", async () => {
+    const response = await requestAuthorize("github", {
+      authenticated: true,
+      session: "session-123",
+    });
+
+    const cookies = response.headers.getSetCookie();
+    expect(
+      cookies.some((cookie) => {
+        return cookie.startsWith("connector_oauth_session=session-123");
+      }),
+    ).toBeTruthy();
+  });
+
+  it("does not set a session cookie when the query parameter is absent", async () => {
+    const response = await requestAuthorize("github", { authenticated: true });
+
+    const cookies = response.headers.getSetCookie();
+    expect(
+      cookies.some((cookie) => {
+        return cookie.startsWith("connector_oauth_session=");
+      }),
+    ).toBeFalsy();
+  });
+
+  it("returns 400 for refresh-only codex-oauth connector", async () => {
+    const response = await requestAuthorize("codex-oauth", {
+      authenticated: true,
+    });
+
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body).toStrictEqual({
+      error:
+        "codex-oauth does not use browser OAuth authorization; use the codex auth.json paste flow",
+    });
+  });
+
+  it("uses Slack user_scope rather than scope", async () => {
+    const response = await requestAuthorize("slack", { authenticated: true });
+
+    const location = response.headers.get("location");
+    expect(location).not.toBeNull();
+    const url = new URL(location!);
+    expect(`${url.origin}${url.pathname}`).toBe(
+      "https://slack.com/oauth/v2/authorize",
+    );
+    expect(url.searchParams.get("client_id")).toBe("test-slack-client-id");
+    expect(url.searchParams.get("user_scope")).toContain("channels:read");
+    expect(url.searchParams.get("scope")).toBeNull();
+  });
+
+  it("includes the Notion owner parameter", async () => {
+    const response = await requestAuthorize("notion", { authenticated: true });
+
+    const location = response.headers.get("location");
+    expect(location).not.toBeNull();
+    const url = new URL(location!);
+    expect(`${url.origin}${url.pathname}`).toBe(
+      "https://api.notion.com/v1/oauth/authorize",
+    );
+    expect(url.searchParams.get("client_id")).toBe("notion-test-client-id");
+    expect(url.searchParams.get("response_type")).toBe("code");
+    expect(url.searchParams.get("owner")).toBe("user");
+  });
+
+  it("includes DocuSign PKCE parameters", async () => {
+    const response = await requestAuthorize("docusign", {
+      authenticated: true,
+    });
+
+    const location = response.headers.get("location");
+    expect(location).not.toBeNull();
+    const url = new URL(location!);
+    expect(`${url.origin}${url.pathname}`).toBe(
+      "https://account-d.docusign.com/oauth/auth",
+    );
+    expect(url.searchParams.get("client_id")).toBe("docusign-test-client-id");
+    expect(url.searchParams.get("scope")).toContain("signature");
+    expect(url.searchParams.get("code_challenge")).toMatch(/^[A-Za-z0-9_-]+$/);
+    expect(url.searchParams.get("code_challenge_method")).toBe("S256");
+  });
+
+  it("requests permanent Reddit authorization", async () => {
+    const response = await requestAuthorize("reddit", { authenticated: true });
+
+    const location = response.headers.get("location");
+    expect(location).not.toBeNull();
+    const url = new URL(location!);
+    expect(`${url.origin}${url.pathname}`).toBe(
+      "https://www.reddit.com/api/v1/authorize",
+    );
+    expect(url.searchParams.get("client_id")).toBe("reddit-test-client-id");
+    expect(url.searchParams.get("duration")).toBe("permanent");
+    expect(url.searchParams.get("scope")).toBe("identity read");
+  });
+
+  it("sets a PKCE verifier cookie for Airtable", async () => {
+    const response = await requestAuthorize("airtable", {
+      authenticated: true,
+    });
+
+    const location = response.headers.get("location");
+    expect(location).not.toBeNull();
+    const url = new URL(location!);
+    expect(`${url.origin}${url.pathname}`).toBe(
+      "https://airtable.com/oauth2/v1/authorize",
+    );
+    expect(url.searchParams.get("client_id")).toBe("airtable-test-client-id");
+    expect(url.searchParams.get("code_challenge")).toMatch(/^[A-Za-z0-9_-]+$/);
+    expect(url.searchParams.get("code_challenge_method")).toBe("S256");
+    const cookies = response.headers.getSetCookie();
+    expect(
+      cookies.some((cookie) => {
+        return cookie.startsWith("connector_oauth_pkce=");
+      }),
+    ).toBeTruthy();
+  });
+
+  it("requests offline Dropbox authorization", async () => {
+    const response = await requestAuthorize("dropbox", {
+      authenticated: true,
+    });
+
+    const location = response.headers.get("location");
+    expect(location).not.toBeNull();
+    const url = new URL(location!);
+    expect(`${url.origin}${url.pathname}`).toBe(
+      "https://www.dropbox.com/oauth2/authorize",
+    );
+    expect(url.searchParams.get("token_access_type")).toBe("offline");
+    expect(url.searchParams.get("force_reapprove")).toBe("true");
+  });
+
+  it("uses Strava comma scopes and forced approval", async () => {
+    const response = await requestAuthorize("strava", { authenticated: true });
+
+    const location = response.headers.get("location");
+    expect(location).not.toBeNull();
+    const url = new URL(location!);
+    expect(`${url.origin}${url.pathname}`).toBe(
+      "https://www.strava.com/oauth/authorize",
+    );
+    expect(url.searchParams.get("scope")).toBe(
+      "read,profile:read_all,activity:read_all,activity:write",
+    );
+    expect(url.searchParams.get("approval_prompt")).toBe("force");
+  });
+
+  it("uses Linear user actor and consent prompt", async () => {
+    const response = await requestAuthorize("linear", { authenticated: true });
+
+    const location = response.headers.get("location");
+    expect(location).not.toBeNull();
+    const url = new URL(location!);
+    expect(`${url.origin}${url.pathname}`).toBe(
+      "https://linear.app/oauth/authorize",
+    );
+    expect(url.searchParams.get("scope")).toBe(
+      "read,write,issues:create,comments:create,timeSchedule:write",
+    );
+    expect(url.searchParams.get("actor")).toBe("user");
+    expect(url.searchParams.get("prompt")).toBe("consent");
+  });
+
+  it("includes X PKCE parameters", async () => {
+    const response = await requestAuthorize("x", { authenticated: true });
+
+    const location = response.headers.get("location");
+    expect(location).not.toBeNull();
+    const url = new URL(location!);
+    expect(`${url.origin}${url.pathname}`).toBe(
+      "https://twitter.com/i/oauth2/authorize",
+    );
+    expect(url.searchParams.get("client_id")).toBe("x-test-client-id");
+    expect(url.searchParams.get("code_challenge")).toMatch(/^[A-Za-z0-9_-]+$/);
+    expect(url.searchParams.get("code_challenge_method")).toBe("S256");
+  });
+
+  it("deletes existing local connector state before reauthorization", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    orgIds.push(orgId);
+    const db = store.set(writeDb$);
+    const [connector] = await db
+      .insert(connectors)
+      .values({ orgId, userId, type: "github", authMethod: "oauth" })
+      .returning({ id: connectors.id });
+    expect(connector).toBeDefined();
+
+    mocks.clerk.session(userId, orgId);
+    const app = createApp({ signal: context.signal });
+    const response = await app.request(authorizeUrl("github"), {
+      method: "GET",
+      headers: sessionHeaders(),
+    });
+
+    expect(response.status).toBe(307);
+    const survivors = await db
+      .select()
+      .from(connectors)
+      .where(eq(connectors.id, connector!.id));
+    expect(survivors).toHaveLength(0);
+    expect(context.mocks.ably.publish).toHaveBeenCalledWith(
+      "connector:changed",
+      null,
+    );
+  });
+});

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-authorize.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-authorize.test.ts
@@ -1,12 +1,16 @@
 import { randomUUID } from "node:crypto";
 
 import { connectors } from "@vm0/db/schema/connector";
+import { secrets } from "@vm0/db/schema/secret";
 import { createStore } from "ccstate";
 import { eq } from "drizzle-orm";
+import { http, HttpResponse } from "msw";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { createApp } from "../../../app-factory";
 import { mockOptionalEnv } from "../../../lib/env";
+import { server } from "../../../mocks/server";
+import { encryptSecretValue } from "../../services/crypto.utils";
 import { writeDb$ } from "../../external/db";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
 import { testContext } from "../../../__tests__/test-helpers";
@@ -87,6 +91,7 @@ describe("GET /api/zero/connectors/:type/authorize", () => {
       const orgId = orgIds.pop();
       if (orgId) {
         await db.delete(connectors).where(eq(connectors.orgId, orgId));
+        await db.delete(secrets).where(eq(secrets.orgId, orgId));
       }
     }
   });
@@ -343,5 +348,50 @@ describe("GET /api/zero/connectors/:type/authorize", () => {
       "connector:changed",
       null,
     );
+  });
+
+  it("best-effort revokes GitHub grants before local cleanup", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    orgIds.push(orgId);
+    const db = store.set(writeDb$);
+    const [connector] = await db
+      .insert(connectors)
+      .values({ orgId, userId, type: "github", authMethod: "oauth" })
+      .returning({ id: connectors.id });
+    expect(connector).toBeDefined();
+    await db.insert(secrets).values({
+      orgId,
+      userId,
+      name: "GITHUB_ACCESS_TOKEN",
+      type: "connector",
+      encryptedValue: encryptSecretValue("gh-access-token"),
+    });
+
+    let revokeAuthorization: string | null = null;
+    let revokeBody = "";
+    server.use(
+      http.delete(
+        "https://api.github.com/applications/test-client-id/grant",
+        async ({ request }) => {
+          revokeAuthorization = request.headers.get("authorization");
+          revokeBody = await request.text();
+          return new HttpResponse(null, { status: 204 });
+        },
+      ),
+    );
+
+    mocks.clerk.session(userId, orgId);
+    const app = createApp({ signal: context.signal });
+    const response = await app.request(authorizeUrl("github"), {
+      method: "GET",
+      headers: sessionHeaders(),
+    });
+
+    expect(response.status).toBe(307);
+    expect(revokeAuthorization).toBe(
+      `Basic ${Buffer.from("test-client-id:test-client-secret").toString("base64")}`,
+    );
+    expect(revokeBody).toContain('"access_token":"gh-access-token"');
   });
 });

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-session-by-id.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-session-by-id.test.ts
@@ -1,0 +1,175 @@
+import { randomUUID } from "node:crypto";
+
+import { zeroConnectorSessionByIdContract } from "@vm0/api-contracts/contracts/zero-connectors";
+import { connectorSessions } from "@vm0/db/schema/connector-session";
+import { createStore } from "ccstate";
+import { eq } from "drizzle-orm";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { now, nowDate } from "../../../lib/time";
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { writeDb$ } from "../../external/db";
+import { createZeroRouteMocks } from "./helpers/zero-route-test";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+
+type ConnectorSessionStatus = "pending" | "complete" | "expired" | "error";
+
+async function seedSession(args: {
+  readonly userId: string;
+  readonly type?: string;
+  readonly status?: ConnectorSessionStatus;
+  readonly expiresAt?: Date;
+  readonly completedAt?: Date;
+  readonly errorMessage?: string | null;
+}): Promise<string> {
+  const db = store.set(writeDb$);
+  const [session] = await db
+    .insert(connectorSessions)
+    .values({
+      code: randomUUID().slice(0, 9).toUpperCase(),
+      type: args.type ?? "github",
+      userId: args.userId,
+      status: args.status ?? "pending",
+      expiresAt: args.expiresAt ?? new Date(now() + 15 * 60 * 1000),
+      completedAt: args.completedAt,
+      errorMessage: args.errorMessage,
+    })
+    .returning({ id: connectorSessions.id });
+  expect(session).toBeDefined();
+  return session!.id;
+}
+
+describe("GET /api/zero/connectors/:type/sessions/:sessionId", () => {
+  const sessionIds: string[] = [];
+
+  afterEach(async () => {
+    const db = store.set(writeDb$);
+    while (sessionIds.length > 0) {
+      const id = sessionIds.pop();
+      if (id) {
+        await db.delete(connectorSessions).where(eq(connectorSessions.id, id));
+      }
+    }
+  });
+
+  it("returns pending session status", async () => {
+    const userId = `user_${randomUUID()}`;
+    const sessionId = await seedSession({ userId });
+    sessionIds.push(sessionId);
+    mocks.clerk.session(userId, `org_${randomUUID()}`);
+
+    const client = setupApp({ context })(zeroConnectorSessionByIdContract);
+    const response = await accept(
+      client.get({
+        params: { type: "github", sessionId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body.status).toBe("pending");
+  });
+
+  it("returns completed session status", async () => {
+    const userId = `user_${randomUUID()}`;
+    const sessionId = await seedSession({
+      userId,
+      status: "complete",
+      completedAt: nowDate(),
+    });
+    sessionIds.push(sessionId);
+    mocks.clerk.session(userId, `org_${randomUUID()}`);
+
+    const client = setupApp({ context })(zeroConnectorSessionByIdContract);
+    const response = await accept(
+      client.get({
+        params: { type: "github", sessionId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body.status).toBe("complete");
+  });
+
+  it("marks expired pending sessions and returns expired status", async () => {
+    const userId = `user_${randomUUID()}`;
+    const sessionId = await seedSession({
+      userId,
+      expiresAt: new Date(now() - 1000),
+    });
+    sessionIds.push(sessionId);
+    mocks.clerk.session(userId, `org_${randomUUID()}`);
+
+    const client = setupApp({ context })(zeroConnectorSessionByIdContract);
+    const response = await accept(
+      client.get({
+        params: { type: "github", sessionId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      status: "expired",
+      errorMessage: "Session has expired",
+    });
+
+    const db = store.set(writeDb$);
+    const [session] = await db
+      .select({ status: connectorSessions.status })
+      .from(connectorSessions)
+      .where(eq(connectorSessions.id, sessionId));
+    expect(session?.status).toBe("expired");
+  });
+
+  it("returns 404 for a missing session", async () => {
+    const userId = `user_${randomUUID()}`;
+    mocks.clerk.session(userId, `org_${randomUUID()}`);
+
+    const client = setupApp({ context })(zeroConnectorSessionByIdContract);
+    const response = await accept(
+      client.get({
+        params: { type: "github", sessionId: randomUUID() },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [404],
+    );
+
+    expect(response.body.error.code).toBe("NOT_FOUND");
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    const client = setupApp({ context })(zeroConnectorSessionByIdContract);
+    const response = await accept(
+      client.get({
+        params: { type: "github", sessionId: randomUUID() },
+        headers: {},
+      }),
+      [401],
+    );
+
+    expect(response.body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("does not return another user's session", async () => {
+    const ownerUserId = `user_${randomUUID()}`;
+    const sessionId = await seedSession({ userId: ownerUserId });
+    sessionIds.push(sessionId);
+    mocks.clerk.session(`user_${randomUUID()}`, `org_${randomUUID()}`);
+
+    const client = setupApp({ context })(zeroConnectorSessionByIdContract);
+    const response = await accept(
+      client.get({
+        params: { type: "github", sessionId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [404],
+    );
+
+    expect(response.body.error.code).toBe("NOT_FOUND");
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/zero-connectors.ts
@@ -1,20 +1,42 @@
 import { command, computed } from "ccstate";
 import {
   zeroComputerConnectorContract,
+  zeroConnectorAuthorizeContract,
+  zeroConnectorSessionByIdContract,
   zeroConnectorScopeDiffContract,
   zeroConnectorsByTypeContract,
   zeroConnectorsMainContract,
   zeroConnectorsSearchContract,
   zeroRemoteAgentConnectorContract,
 } from "@vm0/api-contracts/contracts/zero-connectors";
+import {
+  getConnectorOAuthConfig,
+  getConnectorOAuthEnvKeys,
+  isGoogleOAuthConnector,
+} from "@vm0/connectors/connector-utils";
+import {
+  connectorTypeSchema,
+  type ConnectorType,
+} from "@vm0/connectors/connectors";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { isFeatureEnabled } from "@vm0/core/feature-switch";
+import { connectorSessions } from "@vm0/db/schema/connector-session";
+import { and, eq } from "drizzle-orm";
 
-import { authContext$, organizationAuthContext$ } from "../auth/auth-context";
+import {
+  authContext$,
+  organizationAuthContext$,
+  requiredAuthContext$,
+} from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
+import { request$ } from "../context/hono";
 import { pathParamsOf, queryOf } from "../context/request";
 import { conflict, notFound } from "../../lib/error";
+import { env, optionalEnv } from "../../lib/env";
+import { nowDate } from "../../lib/time";
+import { writeDb$ } from "../external/db";
 import {
+  deleteZeroConnectorLocalState$,
   zeroConnectorByType,
   zeroConnectorList,
   zeroConnectorScopeDiff,
@@ -23,6 +45,12 @@ import {
 import { userFeatureSwitchOverrides } from "../services/feature-switches.service";
 import { connectRemoteAgentConnector$ } from "../services/zero-remote-agent.service";
 import type { RouteEntry } from "../route";
+
+const STATE_COOKIE_NAME = "connector_oauth_state";
+const SESSION_COOKIE_NAME = "connector_oauth_session";
+const PKCE_COOKIE_NAME = "connector_oauth_pkce";
+const COOKIE_MAX_AGE = 15 * 60;
+const REDIRECT_STATUS = 307;
 
 const connectorReadAuth = {
   requireOrganization: true,
@@ -55,6 +83,200 @@ function isRemoteAgentEnabled(params: {
     userId: params.userId,
     overrides: params.overrides,
   });
+}
+
+function generateState(): string {
+  const array = new Uint8Array(32);
+  crypto.getRandomValues(array);
+  return Array.from(array, (byte) => {
+    return byte.toString(16).padStart(2, "0");
+  }).join("");
+}
+
+function isRefreshOnlyConnectorType(type: ConnectorType): boolean {
+  return type === "codex-oauth";
+}
+
+function buildCookieHeader(
+  name: string,
+  value: string,
+  maxAge: number,
+): string {
+  const parts = [
+    `${name}=${value}`,
+    `Max-Age=${maxAge}`,
+    "Path=/",
+    "HttpOnly",
+    "SameSite=Lax",
+  ];
+  if (env("ENV") === "production") {
+    parts.push("Secure");
+  }
+  return parts.join("; ");
+}
+
+function getRequestOrigin(request: Request): string {
+  const url = new URL(request.url);
+  const forwardedHost = request.headers.get("x-forwarded-host");
+  const forwardedProto = request.headers.get("x-forwarded-proto");
+  if (forwardedHost) {
+    return `${forwardedProto ?? "https"}://${forwardedHost}`;
+  }
+  return url.origin;
+}
+
+function jsonResponse(body: unknown, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function redirectResponse(url: string): Response {
+  return new Response(null, {
+    status: REDIRECT_STATUS,
+    headers: { location: url },
+  });
+}
+
+async function base64UrlSha256(value: string): Promise<string> {
+  const data = new TextEncoder().encode(value);
+  const hash = await crypto.subtle.digest("SHA-256", data);
+  return Buffer.from(hash).toString("base64url");
+}
+
+function generateCodeVerifier(): string {
+  const array = new Uint8Array(32);
+  crypto.getRandomValues(array);
+  return Buffer.from(array).toString("base64url");
+}
+
+function codeChallenge(codeVerifier: string): Promise<string> {
+  return base64UrlSha256(codeVerifier);
+}
+
+function deterministicPkceSuffix(type: ConnectorType): string | undefined {
+  switch (type) {
+    case "canva": {
+      return "canva-pkce-verifier";
+    }
+    case "deel": {
+      return "deel-pkce-verifier";
+    }
+    case "docusign": {
+      return "docusign-pkce-verifier";
+    }
+    case "garmin-connect": {
+      return "garmin-pkce-verifier";
+    }
+    case "supabase": {
+      return "supabase-pkce-verifier";
+    }
+    case "x": {
+      return "x-pkce-verifier";
+    }
+    default: {
+      return undefined;
+    }
+  }
+}
+
+async function buildAuthorizeUrl(args: {
+  readonly type: ConnectorType;
+  readonly clientId: string;
+  readonly redirectUri: string;
+  readonly state: string;
+}): Promise<{ readonly url: string; readonly codeVerifier?: string } | null> {
+  const oauthConfig = getConnectorOAuthConfig(args.type);
+  if (!oauthConfig?.authorizationUrl) {
+    return null;
+  }
+
+  if (args.type === "github") {
+    return {
+      url: `${oauthConfig.authorizationUrl}?${new URLSearchParams({
+        client_id: args.clientId,
+        redirect_uri: args.redirectUri,
+        scope: oauthConfig.scopes.join(" "),
+        state: args.state,
+      }).toString()}`,
+    };
+  }
+
+  if (args.type === "slack") {
+    return {
+      url: `${oauthConfig.authorizationUrl}?${new URLSearchParams({
+        client_id: args.clientId,
+        redirect_uri: args.redirectUri,
+        user_scope: oauthConfig.scopes.join(","),
+        state: args.state,
+      }).toString()}`,
+    };
+  }
+
+  if (args.type === "notion") {
+    return {
+      url: `${oauthConfig.authorizationUrl}?${new URLSearchParams({
+        client_id: args.clientId,
+        redirect_uri: args.redirectUri,
+        state: args.state,
+        response_type: "code",
+        owner: "user",
+      }).toString()}`,
+    };
+  }
+
+  const params = new URLSearchParams({
+    client_id: args.clientId,
+    redirect_uri: args.redirectUri,
+    response_type: "code",
+    state: args.state,
+  });
+  if (oauthConfig.scopes.length > 0 && args.type !== "garmin-connect") {
+    const scopeSeparator =
+      args.type === "linear" || args.type === "strava" ? "," : " ";
+    params.set("scope", oauthConfig.scopes.join(scopeSeparator));
+  }
+  if (isGoogleOAuthConnector(args.type)) {
+    params.set("access_type", "offline");
+    params.set("prompt", "consent");
+  }
+  if (args.type === "outlook-calendar" || args.type === "outlook-mail") {
+    params.set("prompt", "consent");
+  }
+  if (args.type === "reddit") {
+    params.set("duration", "permanent");
+  }
+  if (args.type === "dropbox") {
+    params.set("token_access_type", "offline");
+    params.set("force_reapprove", "true");
+  }
+  if (args.type === "strava") {
+    params.set("approval_prompt", "force");
+  }
+  if (args.type === "linear") {
+    params.set("actor", "user");
+    params.set("prompt", "consent");
+  }
+
+  const pkceSuffix = deterministicPkceSuffix(args.type);
+  if (pkceSuffix) {
+    const verifier = await base64UrlSha256(`${args.state}:${pkceSuffix}`);
+    params.set("code_challenge", await codeChallenge(verifier));
+    params.set("code_challenge_method", "S256");
+  }
+
+  if (args.type === "airtable") {
+    const verifier = generateCodeVerifier();
+    params.set("code_challenge", await codeChallenge(verifier));
+    params.set("code_challenge_method", "S256");
+    return {
+      url: `${oauthConfig.authorizationUrl}?${params.toString()}`,
+      codeVerifier: verifier,
+    };
+  }
+
+  return { url: `${oauthConfig.authorizationUrl}?${params.toString()}` };
 }
 
 const getConnectorListInner$ = computed(async (get) => {
@@ -160,6 +382,172 @@ const connectRemoteAgentConnectorInner$ = command(
   },
 );
 
+const authorizeConnectorInner$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const params = get(pathParamsOf(zeroConnectorAuthorizeContract.authorize));
+    const query = get(queryOf(zeroConnectorAuthorizeContract.authorize));
+    const request = get(request$).raw;
+    const origin = getRequestOrigin(request);
+    const requestUrl = new URL(request.url);
+
+    const typeResult = connectorTypeSchema.safeParse(params.type);
+    if (!typeResult.success) {
+      return jsonResponse(
+        { error: `Unknown connector type: ${params.type}` },
+        400,
+      );
+    }
+    const type = typeResult.data;
+
+    const auth = await set(
+      requiredAuthContext$,
+      { requireOrganization: true },
+      signal,
+    );
+    signal.throwIfAborted();
+    if ("status" in auth) {
+      if (auth.status === 401) {
+        const loginUrl = new URL("/sign-in", origin);
+        const authorizeUrl = new URL(
+          `${requestUrl.pathname}${requestUrl.search}`,
+          origin,
+        );
+        loginUrl.searchParams.set("redirect_url", authorizeUrl.toString());
+        return redirectResponse(loginUrl.toString());
+      }
+      return jsonResponse(auth.body, auth.status);
+    }
+
+    if (type === "computer") {
+      return jsonResponse(
+        { error: "Computer connector does not use OAuth" },
+        400,
+      );
+    }
+
+    if (isRefreshOnlyConnectorType(type)) {
+      return jsonResponse(
+        {
+          error:
+            "codex-oauth does not use browser OAuth authorization; use the codex auth.json paste flow",
+        },
+        400,
+      );
+    }
+
+    if (!auth.orgId) {
+      return jsonResponse(
+        {
+          error: {
+            message:
+              "Explicit org context required — ensure active org in session",
+            code: "BAD_REQUEST",
+          },
+        },
+        400,
+      );
+    }
+
+    await set(
+      deleteZeroConnectorLocalState$,
+      { orgId: auth.orgId, userId: auth.userId, type },
+      signal,
+    );
+    signal.throwIfAborted();
+
+    const state = generateState();
+    const redirectUri = `${origin}/api/connectors/${type}/callback`;
+    const envKeys = getConnectorOAuthEnvKeys(type);
+    const clientId = envKeys ? optionalEnv(envKeys.clientId) : undefined;
+    if (!clientId) {
+      return jsonResponse({ error: `${type} OAuth not configured` }, 500);
+    }
+
+    const authResult = await buildAuthorizeUrl({
+      type,
+      clientId,
+      redirectUri,
+      state,
+    });
+    signal.throwIfAborted();
+    if (!authResult) {
+      return jsonResponse({ error: `${type} OAuth not configured` }, 500);
+    }
+
+    const response = redirectResponse(authResult.url);
+    response.headers.append(
+      "Set-Cookie",
+      buildCookieHeader(STATE_COOKIE_NAME, state, COOKIE_MAX_AGE),
+    );
+    if (authResult.codeVerifier) {
+      response.headers.append(
+        "Set-Cookie",
+        buildCookieHeader(
+          PKCE_COOKIE_NAME,
+          authResult.codeVerifier,
+          COOKIE_MAX_AGE,
+        ),
+      );
+    }
+    if (query.session) {
+      response.headers.append(
+        "Set-Cookie",
+        buildCookieHeader(SESSION_COOKIE_NAME, query.session, COOKIE_MAX_AGE),
+      );
+    }
+    return response;
+  },
+);
+
+const getConnectorSessionByIdInner$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const auth = get(authContext$);
+    const params = get(pathParamsOf(zeroConnectorSessionByIdContract.get));
+    const writeDb = set(writeDb$);
+
+    const [session] = await writeDb
+      .select()
+      .from(connectorSessions)
+      .where(
+        and(
+          eq(connectorSessions.id, params.sessionId),
+          eq(connectorSessions.type, params.type),
+          eq(connectorSessions.userId, auth.userId),
+        ),
+      )
+      .limit(1);
+    signal.throwIfAborted();
+
+    if (!session) {
+      return notFound("Connector session not found");
+    }
+
+    if (session.status === "pending" && nowDate() > session.expiresAt) {
+      await writeDb
+        .update(connectorSessions)
+        .set({ status: "expired" })
+        .where(eq(connectorSessions.id, session.id));
+      signal.throwIfAborted();
+
+      return {
+        status: 200 as const,
+        body: {
+          status: "expired" as const,
+          errorMessage: "Session has expired",
+        },
+      };
+    }
+
+    return {
+      status: 200 as const,
+      body: {
+        status: session.status,
+        errorMessage: session.errorMessage,
+      },
+    };
+  },
+);
+
 export const zeroConnectorsRoutes: readonly RouteEntry[] = [
   {
     route: zeroComputerConnectorContract.get,
@@ -180,6 +568,14 @@ export const zeroConnectorsRoutes: readonly RouteEntry[] = [
   {
     route: zeroConnectorScopeDiffContract.getScopeDiff,
     handler: authRoute(connectorReadAuth, getScopeDiffInner$),
+  },
+  {
+    route: zeroConnectorAuthorizeContract.authorize,
+    handler: authorizeConnectorInner$,
+  },
+  {
+    route: zeroConnectorSessionByIdContract.get,
+    handler: authRoute({}, getConnectorSessionByIdInner$),
   },
   {
     route: zeroConnectorsByTypeContract.get,

--- a/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
@@ -1,4 +1,4 @@
-import { computed, type Computed } from "ccstate";
+import { command, computed, type Computed } from "ccstate";
 import type {
   ConnectorListResponse,
   ConnectorResponse,
@@ -15,6 +15,7 @@ import {
 import {
   CONNECTOR_TYPES,
   connectorTypeSchema,
+  type ConnectorAuthMethodType,
   type ConnectorType,
 } from "@vm0/connectors/connectors";
 import { getAllFeatureStates } from "@vm0/core/feature-switch";
@@ -25,7 +26,8 @@ import { and, eq } from "drizzle-orm";
 import { z } from "zod";
 
 import { optionalEnv } from "../../lib/env";
-import { db$ } from "../external/db";
+import { db$, writeDb$ } from "../external/db";
+import { publishUserSignal } from "../external/realtime";
 import { userFeatureSwitchOverrides } from "./feature-switches.service";
 
 type StoredConnectorRow = {
@@ -318,6 +320,102 @@ export function zeroConnectorByType(args: {
     return get(apiTokenConnectorByType(args));
   });
 }
+
+export const deleteZeroConnectorLocalState$ = command(
+  async (
+    { set },
+    args: {
+      readonly orgId: string;
+      readonly userId: string;
+      readonly type: ConnectorType;
+    },
+    signal: AbortSignal,
+  ): Promise<boolean> => {
+    const writeDb = set(writeDb$);
+    let deleted = false;
+
+    const [existing] = await writeDb
+      .select({ id: connectors.id, authMethod: connectors.authMethod })
+      .from(connectors)
+      .where(
+        and(
+          eq(connectors.orgId, args.orgId),
+          eq(connectors.userId, args.userId),
+          eq(connectors.type, args.type),
+        ),
+      )
+      .limit(1);
+    signal.throwIfAborted();
+
+    if (existing) {
+      await writeDb.delete(connectors).where(eq(connectors.id, existing.id));
+      signal.throwIfAborted();
+      deleted = true;
+
+      const config = CONNECTOR_TYPES[args.type];
+      const authMethodConfig =
+        config.authMethods[existing.authMethod as ConnectorAuthMethodType];
+      const secretNames = authMethodConfig
+        ? Object.keys(authMethodConfig.secrets)
+        : [];
+
+      for (const name of secretNames) {
+        await writeDb
+          .delete(secrets)
+          .where(
+            and(
+              eq(secrets.orgId, args.orgId),
+              eq(secrets.userId, args.userId),
+              eq(secrets.name, name),
+              eq(secrets.type, "connector"),
+            ),
+          );
+        signal.throwIfAborted();
+      }
+    }
+
+    const fields = getApiTokenFieldsByType(args.type);
+    if (fields) {
+      for (const name of fields.secrets) {
+        const result = await writeDb
+          .delete(secrets)
+          .where(
+            and(
+              eq(secrets.orgId, args.orgId),
+              eq(secrets.userId, args.userId),
+              eq(secrets.name, name),
+              eq(secrets.type, "user"),
+            ),
+          )
+          .returning({ id: secrets.id });
+        signal.throwIfAborted();
+        deleted = deleted || result.length > 0;
+      }
+
+      for (const name of fields.variables) {
+        const result = await writeDb
+          .delete(variables)
+          .where(
+            and(
+              eq(variables.orgId, args.orgId),
+              eq(variables.userId, args.userId),
+              eq(variables.name, name),
+            ),
+          )
+          .returning({ id: variables.id });
+        signal.throwIfAborted();
+        deleted = deleted || result.length > 0;
+      }
+    }
+
+    if (deleted) {
+      await publishUserSignal([args.userId], "connector:changed");
+      signal.throwIfAborted();
+    }
+
+    return deleted;
+  },
+);
 
 export function zeroConnectorScopeDiff(args: {
   readonly orgId: string;

--- a/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
@@ -9,6 +9,7 @@ import {
   deriveApiTokenConnectedTypes,
   getApiTokenFieldsByType,
   getConfiguredConnectorTypes,
+  getConnectorOAuthEnvKeys,
   getConnectorProvidedSecretNames,
   getScopeDiff,
 } from "@vm0/connectors/connector-utils";
@@ -26,8 +27,9 @@ import { and, eq } from "drizzle-orm";
 import { z } from "zod";
 
 import { optionalEnv } from "../../lib/env";
-import { db$, writeDb$ } from "../external/db";
+import { db$, type Db, writeDb$ } from "../external/db";
 import { publishUserSignal } from "../external/realtime";
+import { decryptSecretValue } from "./crypto.utils";
 import { userFeatureSwitchOverrides } from "./feature-switches.service";
 
 type StoredConnectorRow = {
@@ -321,6 +323,137 @@ export function zeroConnectorByType(args: {
   });
 }
 
+function revocableConnectorAccessTokenName(
+  type: ConnectorType,
+): string | undefined {
+  switch (type) {
+    case "github": {
+      return "GITHUB_ACCESS_TOKEN";
+    }
+    case "linear": {
+      return "LINEAR_ACCESS_TOKEN";
+    }
+    case "slack": {
+      return "SLACK_ACCESS_TOKEN";
+    }
+    default: {
+      return undefined;
+    }
+  }
+}
+
+async function revokeConnectorToken(args: {
+  readonly type: ConnectorType;
+  readonly accessToken: string;
+}): Promise<void> {
+  const envKeys = getConnectorOAuthEnvKeys(args.type);
+  const clientId = envKeys ? optionalEnv(envKeys.clientId) : undefined;
+  const clientSecret = envKeys ? optionalEnv(envKeys.clientSecret) : undefined;
+  if (!clientId || !clientSecret) {
+    return;
+  }
+
+  if (args.type === "github") {
+    const credentials = Buffer.from(`${clientId}:${clientSecret}`).toString(
+      "base64",
+    );
+    const response = await fetch(
+      `https://api.github.com/applications/${clientId}/grant`,
+      {
+        method: "DELETE",
+        headers: {
+          Authorization: `Basic ${credentials}`,
+          Accept: "application/vnd.github+json",
+          "Content-Type": "application/json",
+          "X-GitHub-Api-Version": "2022-11-28",
+        },
+        body: JSON.stringify({ access_token: args.accessToken }),
+      },
+    );
+    if (!response.ok) {
+      throw new Error(`GitHub grant revocation failed: ${response.status}`);
+    }
+    return;
+  }
+
+  if (args.type === "slack") {
+    const response = await fetch("https://slack.com/api/auth.revoke", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${args.accessToken}`,
+      },
+    });
+    if (!response.ok) {
+      throw new Error(`Slack token revocation failed: ${response.status}`);
+    }
+    const data = (await response.json()) as { ok: boolean; error?: string };
+    if (!data.ok) {
+      throw new Error(data.error ?? "Slack token revocation returned ok=false");
+    }
+    return;
+  }
+
+  if (args.type === "linear") {
+    const credentials = Buffer.from(`${clientId}:${clientSecret}`).toString(
+      "base64",
+    );
+    const response = await fetch("https://api.linear.app/oauth/revoke", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        Authorization: `Basic ${credentials}`,
+      },
+      body: new URLSearchParams({
+        token: args.accessToken,
+        token_type_hint: "access_token",
+      }),
+    });
+    if (!response.ok) {
+      throw new Error(`Linear token revocation failed: ${response.status}`);
+    }
+  }
+}
+
+async function revokeExistingConnectorToken(args: {
+  readonly db: Db;
+  readonly orgId: string;
+  readonly userId: string;
+  readonly type: ConnectorType;
+  readonly signal: AbortSignal;
+}): Promise<void> {
+  const accessTokenName = revocableConnectorAccessTokenName(args.type);
+  if (!accessTokenName) {
+    return;
+  }
+
+  const [accessTokenSecret] = await args.db
+    .select({ encryptedValue: secrets.encryptedValue })
+    .from(secrets)
+    .where(
+      and(
+        eq(secrets.orgId, args.orgId),
+        eq(secrets.userId, args.userId),
+        eq(secrets.name, accessTokenName),
+        eq(secrets.type, "connector"),
+      ),
+    )
+    .limit(1);
+  args.signal.throwIfAborted();
+
+  if (!accessTokenSecret?.encryptedValue) {
+    return;
+  }
+
+  // Provider revocation is best-effort; local cleanup still owns visible state.
+  await revokeConnectorToken({
+    type: args.type,
+    accessToken: decryptSecretValue(accessTokenSecret.encryptedValue),
+  }).catch(() => {
+    return undefined;
+  });
+  args.signal.throwIfAborted();
+}
+
 export const deleteZeroConnectorLocalState$ = command(
   async (
     { set },
@@ -348,6 +481,16 @@ export const deleteZeroConnectorLocalState$ = command(
     signal.throwIfAborted();
 
     if (existing) {
+      if (existing.authMethod === "oauth") {
+        await revokeExistingConnectorToken({
+          db: writeDb,
+          orgId: args.orgId,
+          userId: args.userId,
+          type: args.type,
+          signal,
+        });
+      }
+
       await writeDb.delete(connectors).where(eq(connectors.id, existing.id));
       signal.throwIfAborted();
       deleted = true;

--- a/turbo/packages/api-contracts/src/contracts/zero-connectors.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-connectors.ts
@@ -84,6 +84,28 @@ export const zeroConnectorScopeDiffContract = c.router({
   },
 });
 
+/**
+ * Zero contract for GET /api/zero/connectors/:type/authorize
+ * Browser OAuth redirect endpoint. The API handler returns raw Response
+ * redirects so Set-Cookie and Location headers are preserved.
+ */
+export const zeroConnectorAuthorizeContract = c.router({
+  authorize: {
+    method: "GET",
+    path: "/api/zero/connectors/:type/authorize",
+    headers: authHeadersSchema,
+    pathParams: z.object({ type: z.string() }),
+    query: z.object({ session: z.string().optional() }),
+    responses: {
+      307: c.noBody(),
+      400: z.object({ error: z.string() }),
+      401: c.noBody(),
+      500: z.object({ error: z.string() }),
+    },
+    summary: "Start connector OAuth authorization (zero proxy)",
+  },
+});
+
 const connectorSearchAuthMethodSchema = z.enum(["oauth", "api-token"]);
 
 export type ConnectorSearchAuthMethod = z.infer<
@@ -235,6 +257,8 @@ export type ZeroConnectorsMainContract = typeof zeroConnectorsMainContract;
 export type ZeroConnectorsByTypeContract = typeof zeroConnectorsByTypeContract;
 export type ZeroConnectorScopeDiffContract =
   typeof zeroConnectorScopeDiffContract;
+export type ZeroConnectorAuthorizeContract =
+  typeof zeroConnectorAuthorizeContract;
 export type ZeroConnectorsSearchContract = typeof zeroConnectorsSearchContract;
 export type ZeroConnectorSessionsContract =
   typeof zeroConnectorSessionsContract;

--- a/turbo/packages/connectors/src/connector-utils.ts
+++ b/turbo/packages/connectors/src/connector-utils.ts
@@ -29,7 +29,7 @@ export function getConnectorDefaultAuthMethod(
 
 export type ConnectorEnvReader = (name: string) => string | undefined;
 
-interface ConnectorOAuthEnvKeys {
+export interface ConnectorOAuthEnvKeys {
   readonly clientId: string;
   readonly clientSecret: string;
 }
@@ -231,6 +231,12 @@ function hasConfiguredOAuth(
     ? hasEnvValue(readEnv, keys.clientId) &&
         hasEnvValue(readEnv, keys.clientSecret)
     : false;
+}
+
+export function getConnectorOAuthEnvKeys(
+  type: ConnectorType,
+): ConnectorOAuthEnvKeys | undefined {
+  return OAUTH_ENV_KEYS_BY_CONNECTOR[type];
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add API contracts and handlers for `GET /api/zero/connectors/:type/authorize` and `GET /api/zero/connectors/:type/sessions/:sessionId`.
- Preserve web OAuth redirect behavior, state/session/PKCE cookies, provider-specific auth params, and local connector cleanup before reauthorization.
- Add API integration coverage for authorize redirects and connector session status polling.

## Testing
- `pnpm -F api exec vitest src/signals/routes/__tests__/zero-connectors-authorize.test.ts src/signals/routes/__tests__/zero-connectors-session-by-id.test.ts`
- `pnpm -F api lint`
- `pnpm check-types`
- `pnpm format`
- `git diff --check`
- pre-commit: prettier, knip, check-types

Closes #12833