### PR TITLE
refactor: migrate auth me GET to api backend

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -1,6 +1,7 @@
 import type { AppRoute } from "@ts-rest/core";
 import { healthContract } from "@vm0/api-contracts/contracts/health";
 
+import { authMeRoutes } from "./routes/auth-me";
 import { audioTranscriptionsV1Routes } from "./routes/audio-transcriptions-v1";
 import type { SignalRouteHandler } from "./context/route";
 import { chatThreadsV1Routes } from "./routes/chat-threads-v1";
@@ -81,6 +82,7 @@ export const ROUTES: readonly RouteEntry[] = [
     route: healthContract.check,
     handler: apiHealth$,
   },
+  ...authMeRoutes,
   ...healthAuthProbeRoutes,
   ...internalEventConsumerTelegramTypingRoutes,
   ...deviceTokenRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/auth-me.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/auth-me.test.ts
@@ -1,0 +1,205 @@
+import { randomUUID } from "node:crypto";
+
+import { authContract } from "@vm0/api-contracts/contracts/auth";
+import { userCache } from "@vm0/db/schema/user-cache";
+import { createStore } from "ccstate";
+import { inArray } from "drizzle-orm";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { mockNow } from "../../../lib/time";
+import { signSandboxJwtForTests } from "../../auth/tokens";
+import { writeDb$ } from "../../external/db";
+
+const NOW_MS = Date.parse("2026-05-12T04:00:00.000Z");
+const context = testContext();
+const store = createStore();
+
+function apiClient() {
+  return setupApp({ context })(authContract);
+}
+
+function authHeaders(token = "clerk-session") {
+  return { authorization: `Bearer ${token}` };
+}
+
+function currentSecond(): number {
+  return Math.floor(NOW_MS / 1000);
+}
+
+function clerkUser(userId: string, email: string) {
+  const emailId = `email_${userId}`;
+  return {
+    id: userId,
+    emailAddresses: [{ id: emailId, emailAddress: email }],
+    primaryEmailAddressId: emailId,
+  };
+}
+
+function sandboxToken(userId: string): string {
+  const nowSeconds = currentSecond();
+  return signSandboxJwtForTests({
+    scope: "sandbox",
+    userId,
+    orgId: `org_${randomUUID()}`,
+    runId: `run_${randomUUID()}`,
+    iat: nowSeconds,
+    exp: nowSeconds + 60,
+  });
+}
+
+function mockSession(userId: string): void {
+  context.mocks.clerk.authenticateRequest.mockResolvedValue({
+    isAuthenticated: true,
+    toAuth: () => {
+      return {
+        userId,
+        orgId: `org_${randomUUID()}`,
+        orgRole: "org:admin",
+      };
+    },
+  });
+}
+
+async function seedUserCache(
+  seededUserCacheIds: string[],
+  userId: string,
+  email: string,
+  cachedAt: Date,
+): Promise<void> {
+  seededUserCacheIds.push(userId);
+  const writeDb = store.set(writeDb$);
+  await writeDb
+    .insert(userCache)
+    .values({
+      userId,
+      email,
+      name: null,
+      cachedAt,
+    })
+    .onConflictDoUpdate({
+      target: userCache.userId,
+      set: { email, name: null, cachedAt },
+    });
+}
+
+beforeEach(() => {
+  mockNow(NOW_MS);
+});
+
+describe("GET /api/auth/me", () => {
+  let seededUserCacheIds: string[] = [];
+
+  afterEach(async () => {
+    if (seededUserCacheIds.length === 0) {
+      return;
+    }
+
+    const ids = seededUserCacheIds;
+    seededUserCacheIds = [];
+    const writeDb = store.set(writeDb$);
+    await writeDb.delete(userCache).where(inArray(userCache.userId, ids));
+  });
+
+  it("returns 401 when the request is unauthenticated", async () => {
+    const client = apiClient();
+
+    const response = await accept(client.me({ headers: {} }), [401]);
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Not authenticated",
+        code: "UNAUTHORIZED",
+      },
+    });
+  });
+
+  it("returns authenticated user info with email", async () => {
+    const userId = `user_${randomUUID()}`;
+    mockSession(userId);
+    context.mocks.clerk.users.getUserList.mockResolvedValue({
+      data: [clerkUser(userId, "test@example.com")],
+    });
+    const client = apiClient();
+
+    const response = await accept(client.me({ headers: authHeaders() }), [200]);
+
+    expect(response.body).toStrictEqual({
+      userId,
+      email: "test@example.com",
+    });
+    expect(context.mocks.clerk.users.getUserList).toHaveBeenCalledWith({
+      userId: [userId],
+    });
+  });
+
+  it("accepts sandbox tokens without a required capability", async () => {
+    const userId = `user_${randomUUID()}`;
+    const token = sandboxToken(userId);
+    context.mocks.clerk.users.getUserList.mockResolvedValue({
+      data: [clerkUser(userId, "sandbox@example.com")],
+    });
+    const client = apiClient();
+
+    const response = await accept(
+      client.me({ headers: authHeaders(token) }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      userId,
+      email: "sandbox@example.com",
+    });
+  });
+
+  it("uses a fresh cached email without fetching a Clerk profile", async () => {
+    const userId = `user_${randomUUID()}`;
+    const token = sandboxToken(userId);
+    await seedUserCache(
+      seededUserCacheIds,
+      userId,
+      "cached@example.com",
+      new Date(NOW_MS - 1000),
+    );
+    const client = apiClient();
+
+    const response = await accept(
+      client.me({ headers: authHeaders(token) }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      userId,
+      email: "cached@example.com",
+    });
+    expect(context.mocks.clerk.users.getUserList).not.toHaveBeenCalled();
+  });
+
+  it("resolves stale cached email from Clerk for the response", async () => {
+    const userId = `user_${randomUUID()}`;
+    const token = sandboxToken(userId);
+    await seedUserCache(
+      seededUserCacheIds,
+      userId,
+      "stale@example.com",
+      new Date(NOW_MS - 16 * 60 * 1000),
+    );
+    context.mocks.clerk.users.getUserList.mockResolvedValue({
+      data: [clerkUser(userId, "fresh@example.com")],
+    });
+    const client = apiClient();
+
+    const response = await accept(
+      client.me({ headers: authHeaders(token) }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      userId,
+      email: "fresh@example.com",
+    });
+    expect(context.mocks.clerk.users.getUserList).toHaveBeenCalledWith({
+      userId: [userId],
+    });
+  });
+});

--- a/turbo/apps/api/src/signals/routes/auth-me.ts
+++ b/turbo/apps/api/src/signals/routes/auth-me.ts
@@ -1,0 +1,85 @@
+import { computed } from "ccstate";
+import { authContract } from "@vm0/api-contracts/contracts/auth";
+import { userCache } from "@vm0/db/schema/user-cache";
+import { eq } from "drizzle-orm";
+
+import { authContext$ } from "../auth/auth-context";
+import { authRoute } from "../auth/auth-route";
+import { db$ } from "../external/db";
+import { clerk$ } from "../external/clerk";
+import { now } from "../external/time";
+import type { RouteEntry } from "../route";
+
+const USER_CACHE_TTL_MS = 15 * 60 * 1000;
+
+interface ClerkEmailAddress {
+  readonly id: string;
+  readonly emailAddress: string;
+}
+
+interface ClerkEmailProfile {
+  readonly id: string;
+  readonly emailAddresses: readonly ClerkEmailAddress[];
+  readonly primaryEmailAddressId: string | null;
+}
+
+function primaryEmail(user: ClerkEmailProfile): string | null {
+  const email = user.emailAddresses.find((candidate) => {
+    return candidate.id === user.primaryEmailAddressId;
+  });
+  return email?.emailAddress ?? null;
+}
+
+function userEmail(userId: string) {
+  return computed(async (get): Promise<string> => {
+    const db = get(db$);
+    const [cached] = await db
+      .select({
+        email: userCache.email,
+        cachedAt: userCache.cachedAt,
+      })
+      .from(userCache)
+      .where(eq(userCache.userId, userId))
+      .limit(1);
+
+    if (cached && now() - cached.cachedAt.getTime() < USER_CACHE_TTL_MS) {
+      return cached.email;
+    }
+
+    const client = get(clerk$);
+    const users = await client.users.getUserList({ userId: [userId] });
+    const user = users.data.find((candidate: ClerkEmailProfile) => {
+      return candidate.id === userId;
+    });
+    if (!user) {
+      throw new Error(`No Clerk user found for user ${userId}`);
+    }
+
+    const email = primaryEmail(user);
+    if (!email) {
+      throw new Error(`No primary email found for user ${userId}`);
+    }
+
+    return email;
+  });
+}
+
+const getAuthMeInner$ = computed(async (get): Promise<unknown> => {
+  const auth = get(authContext$);
+  const email = await get(userEmail(auth.userId));
+
+  return {
+    status: 200 as const,
+    body: {
+      userId: auth.userId,
+      email,
+    },
+  };
+});
+
+export const authMeRoutes: readonly RouteEntry[] = [
+  {
+    route: authContract.me,
+    handler: authRoute({ acceptAnySandboxCapability: true }, getAuthMeInner$),
+  },
+];


### PR DESCRIPTION
## Summary
- Register GET /api/auth/me in apps/api through authContract.me
- Use the existing API auth stack with acceptAnySandboxCapability for sandbox-token parity
- Resolve the response email from fresh user_cache rows or Clerk user profiles without adding a write path
- Add API route integration coverage for unauthenticated, Clerk session, sandbox token, fresh cache, and stale cache behavior

Closes #12818

## Validation
- pnpm -F api exec vitest run src/signals/routes/__tests__/auth-me.test.ts
- pnpm -F api lint
- pnpm exec prettier --check apps/api/src/signals/routes/auth-me.ts apps/api/src/signals/routes/__tests__/auth-me.test.ts apps/api/src/signals/route.ts
- git diff --check
- pnpm knip --cache

## Notes
- Local pnpm check-types still fails in existing api route tests with ts-rest response narrowing errors like `Property 'body' does not exist on type 'never'`; grep over the tsc output found no `auth-me` or `src/signals/route.ts` errors.
