### PR TITLE
test: add command operation soak diagnostics

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -3651,6 +3651,7 @@ version = "0.12.1"
 dependencies = [
  "nix",
  "tokio",
+ "tracing",
  "vsock-proto",
 ]
 

--- a/crates/vsock-guest/src/command.rs
+++ b/crates/vsock-guest/src/command.rs
@@ -938,6 +938,20 @@ mod tests {
     }
 
     #[test]
+    fn registry_cancel_returns_truncated_label_preview() {
+        let registry = CommandRegistry::default();
+        let long_label = format!("{}🔥tail", "a".repeat(99));
+        let registration = registry.register(10, &long_label).unwrap();
+
+        let preview = registry.cancel(10).unwrap();
+        assert_eq!(preview, truncate_preview(&long_label));
+        assert!(preview.ends_with("..."));
+        assert!(preview.len() < long_label.len());
+        assert!(!preview.contains('🔥'));
+        assert!(registration.cancel.load(Ordering::Acquire));
+    }
+
+    #[test]
     fn command_worker_spawn_failure_returns_start_failed_and_cleans_registry() {
         let (guest, mut host) = UnixStream::pair().unwrap();
         host.set_read_timeout(Some(Duration::from_secs(3))).unwrap();

--- a/crates/vsock-guest/src/command.rs
+++ b/crates/vsock-guest/src/command.rs
@@ -819,6 +819,10 @@ fn duration_ms(started: Instant) -> u32 {
     u32::try_from(started.elapsed().as_millis()).unwrap_or(u32::MAX)
 }
 
+fn command_termination_is_notable(termination: CommandTermination) -> bool {
+    !matches!(termination, CommandTermination::Exited { exit_code: 0 })
+}
+
 fn log_command_terminal_if_notable(
     request: &CommandWorkerRequest,
     started: Instant,
@@ -829,7 +833,7 @@ fn log_command_terminal_if_notable(
 ) {
     let elapsed = started.elapsed();
     let slow = elapsed >= COMMAND_STAGE_SLOW_THRESHOLD;
-    let notable = !matches!(termination, CommandTermination::Exited { .. })
+    let notable = command_termination_is_notable(termination)
         || stdout_result.capture_truncated
         || stderr_result.capture_truncated
         || !diagnostic.is_empty();
@@ -907,6 +911,17 @@ mod tests {
             std::thread::yield_now();
         }
         panic!("command registry entry for seq={seq} was not released");
+    }
+
+    #[test]
+    fn command_termination_notable_tracks_nonzero_exit() {
+        assert!(!command_termination_is_notable(
+            CommandTermination::Exited { exit_code: 0 }
+        ));
+        assert!(command_termination_is_notable(CommandTermination::Exited {
+            exit_code: 1
+        }));
+        assert!(command_termination_is_notable(CommandTermination::TimedOut));
     }
 
     #[test]

--- a/crates/vsock-guest/src/command.rs
+++ b/crates/vsock-guest/src/command.rs
@@ -359,9 +359,10 @@ fn run_command_worker<S>(
 
     let (output_tx, output_handle) = if needs_stream {
         let (tx, rx) = mpsc::sync_channel(OUTPUT_CHANNEL_CAPACITY);
+        let label_preview = truncate_preview(&request.label);
         match spawn_output_writer(
             request.seq,
-            request.label.clone(),
+            label_preview,
             rx,
             writer.clone(),
             command_cancel.clone(),
@@ -609,7 +610,7 @@ fn stream_config(policy: CommandOutputPolicy) -> Option<BoundedStreamConfig> {
 
 fn spawn_output_writer<S>(
     seq: u32,
-    label: String,
+    label_preview: String,
     rx: Receiver<StreamEvent>,
     writer: GuestWriter,
     command_cancel: Arc<AtomicBool>,
@@ -638,8 +639,7 @@ where
                         log(
                             "ERROR",
                             &format!(
-                                "command: failed to encode output seq={seq} label={}: {e}",
-                                truncate_preview(&label)
+                                "command: failed to encode output seq={seq} label={label_preview}: {e}"
                             ),
                         );
                         command_cancel.store(true, Ordering::Release);
@@ -654,8 +654,7 @@ where
                         log(
                             "ERROR",
                             &format!(
-                                "command: failed to encode output frame seq={seq} label={}: {e}",
-                                truncate_preview(&label)
+                                "command: failed to encode output frame seq={seq} label={label_preview}: {e}"
                             ),
                         );
                         command_cancel.store(true, Ordering::Release);
@@ -667,8 +666,7 @@ where
                     log(
                         "WARN",
                         &format!(
-                            "command: failed to send output chunk seq={seq} label={}: {e}",
-                            truncate_preview(&label)
+                            "command: failed to send output chunk seq={seq} label={label_preview}: {e}"
                         ),
                     );
                     command_cancel.store(true, Ordering::Release);

--- a/crates/vsock-guest/src/command.rs
+++ b/crates/vsock-guest/src/command.rs
@@ -5,7 +5,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::{self, Receiver, SyncSender};
 use std::sync::{Arc, Mutex};
 use std::thread::JoinHandle;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use vsock_proto::{
     self, CommandCapturedOutput, CommandOutputPolicy, CommandOutputStream, CommandTermination,
@@ -37,21 +37,34 @@ const COMMAND_RESULT_DIAGNOSTIC_LEN_FIELD: usize = 2;
 const COMMAND_RESULT_MAX_DIAGNOSTIC_BYTES: usize = u16::MAX as usize;
 const COMMAND_CAPTURED_OUTPUT_OVERHEAD: usize = 1 + 1 + 4;
 const COMMAND_DISCARDED_OUTPUT_LEN: usize = 1;
+const COMMAND_STAGE_SLOW_THRESHOLD: Duration = Duration::from_secs(5);
 
 #[derive(Clone, Default)]
 pub(crate) struct CommandRegistry {
-    inner: Arc<Mutex<HashMap<u32, Arc<AtomicBool>>>>,
+    inner: Arc<Mutex<HashMap<u32, CommandRegistryEntry>>>,
+}
+
+#[derive(Clone)]
+struct CommandRegistryEntry {
+    cancel: Arc<AtomicBool>,
+    label: String,
 }
 
 impl CommandRegistry {
-    pub(crate) fn register(&self, seq: u32) -> Result<CommandRegistration, ()> {
+    pub(crate) fn register(&self, seq: u32, label: &str) -> Result<CommandRegistration, ()> {
         let mut active = self.inner.lock().unwrap_or_else(|e| e.into_inner());
         if active.contains_key(&seq) {
             return Err(());
         }
 
         let cancel = Arc::new(AtomicBool::new(false));
-        active.insert(seq, cancel.clone());
+        active.insert(
+            seq,
+            CommandRegistryEntry {
+                cancel: cancel.clone(),
+                label: label.to_string(),
+            },
+        );
         Ok(CommandRegistration {
             registry: self.clone(),
             seq,
@@ -59,20 +72,18 @@ impl CommandRegistry {
         })
     }
 
-    pub(crate) fn cancel(&self, seq: u32) -> bool {
+    pub(crate) fn cancel(&self, seq: u32) -> Option<String> {
         let active = self.inner.lock().unwrap_or_else(|e| e.into_inner());
-        let Some(cancel) = active.get(&seq) else {
-            return false;
-        };
-        cancel.store(true, Ordering::Release);
-        true
+        let cancel = active.get(&seq)?;
+        cancel.cancel.store(true, Ordering::Release);
+        Some(cancel.label.clone())
     }
 
     fn remove_if_same(&self, seq: u32, cancel: &Arc<AtomicBool>) {
         let mut active = self.inner.lock().unwrap_or_else(|e| e.into_inner());
         if active
             .get(&seq)
-            .is_some_and(|existing| Arc::ptr_eq(existing, cancel))
+            .is_some_and(|existing| Arc::ptr_eq(&existing.cancel, cancel))
         {
             active.remove(&seq);
         }
@@ -197,7 +208,7 @@ where
     S: ThreadSpawner,
 {
     let seq = request.seq;
-    let registration = match registry.register(seq) {
+    let registration = match registry.register(seq, &request.label) {
         Ok(registration) => registration,
         Err(()) => {
             return send_command_error(seq, "command operation already active", &writer);
@@ -226,6 +237,10 @@ where
         Ok(_) => Ok(()),
         Err(e) => {
             let diagnostic = format!("Failed to spawn command worker thread: {e}");
+            log(
+                "ERROR",
+                &format!("command: worker spawn failed seq={seq}: {e}"),
+            );
             send_command_result(
                 CommandResultFrame {
                     seq,
@@ -242,8 +257,14 @@ where
 }
 
 pub(crate) fn cancel_command_operation(registry: &CommandRegistry, seq: u32) {
-    if registry.cancel(seq) {
-        log("INFO", &format!("command: cancelled seq={seq}"));
+    if let Some(label) = registry.cancel(seq) {
+        log(
+            "INFO",
+            &format!(
+                "command: cancel requested seq={seq} label={}",
+                truncate_preview(&label)
+            ),
+        );
     }
 }
 
@@ -263,18 +284,6 @@ fn run_command_worker<S>(
 ) where
     S: ThreadSpawner,
 {
-    log(
-        "INFO",
-        &format!(
-            "command: label={} {} (timeout={}ms, sudo={}, {})",
-            truncate_preview(&request.label),
-            truncate_preview(&request.command),
-            request.timeout_ms,
-            request.sudo,
-            format_env_diagnostics(&request.command, &env_refs(&request.env)),
-        ),
-    );
-
     let started = Instant::now();
     if let Err(diagnostic) = validate_request(&request) {
         send_final_and_complete(
@@ -355,6 +364,7 @@ fn run_command_worker<S>(
         let (tx, rx) = mpsc::sync_channel(OUTPUT_CHANNEL_CAPACITY);
         match spawn_output_writer(
             request.seq,
+            request.label.clone(),
             rx,
             writer.clone(),
             command_cancel.clone(),
@@ -459,7 +469,11 @@ fn run_command_worker<S>(
     if completed < 2 {
         log(
             "WARN",
-            &format!("command: drain deadline reached after {DRAIN_DEADLINE_SECS}s"),
+            &format!(
+                "command: drain deadline reached seq={} label={} after {DRAIN_DEADLINE_SECS}s",
+                request.seq,
+                truncate_preview(&request.label)
+            ),
         );
     }
 
@@ -484,17 +498,13 @@ fn run_command_worker<S>(
         ),
     };
 
-    log(
-        "INFO",
-        &format!(
-            "command result: seq={}, termination={:?}, stdout_len={}, stderr_len={}, stdout_truncated={}, stderr_truncated={}",
-            request.seq,
-            termination,
-            stdout_result.captured.as_ref().map_or(0, Vec::len),
-            stderr_result.captured.as_ref().map_or(0, Vec::len),
-            stdout_result.capture_truncated,
-            stderr_result.capture_truncated,
-        ),
+    log_command_terminal_if_notable(
+        &request,
+        started,
+        termination,
+        &stdout_result,
+        &stderr_result,
+        &diagnostic,
     );
 
     send_final_and_complete(
@@ -602,6 +612,7 @@ fn stream_config(policy: CommandOutputPolicy) -> Option<BoundedStreamConfig> {
 
 fn spawn_output_writer<S>(
     seq: u32,
+    label: String,
     rx: Receiver<StreamEvent>,
     writer: GuestWriter,
     command_cancel: Arc<AtomicBool>,
@@ -627,7 +638,13 @@ where
                 ) {
                     Ok(payload) => payload,
                     Err(e) => {
-                        log("ERROR", &format!("command: failed to encode output: {e}"));
+                        log(
+                            "ERROR",
+                            &format!(
+                                "command: failed to encode output seq={seq} label={}: {e}",
+                                truncate_preview(&label)
+                            ),
+                        );
                         command_cancel.store(true, Ordering::Release);
                         drain_cancel.store(true, Ordering::Release);
                         break;
@@ -639,7 +656,10 @@ where
                     Err(e) => {
                         log(
                             "ERROR",
-                            &format!("command: failed to encode output frame: {e}"),
+                            &format!(
+                                "command: failed to encode output frame seq={seq} label={}: {e}",
+                                truncate_preview(&label)
+                            ),
                         );
                         command_cancel.store(true, Ordering::Release);
                         drain_cancel.store(true, Ordering::Release);
@@ -649,7 +669,10 @@ where
                 if let Err(e) = writer.write_frame(&frame) {
                     log(
                         "WARN",
-                        &format!("command: failed to send output chunk: {e}"),
+                        &format!(
+                            "command: failed to send output chunk seq={seq} label={}: {e}",
+                            truncate_preview(&label)
+                        ),
                     );
                     command_cancel.store(true, Ordering::Release);
                     drain_cancel.store(true, Ordering::Release);
@@ -796,6 +819,42 @@ fn duration_ms(started: Instant) -> u32 {
     u32::try_from(started.elapsed().as_millis()).unwrap_or(u32::MAX)
 }
 
+fn log_command_terminal_if_notable(
+    request: &CommandWorkerRequest,
+    started: Instant,
+    termination: CommandTermination,
+    stdout_result: &BoundedDrainResult,
+    stderr_result: &BoundedDrainResult,
+    diagnostic: &str,
+) {
+    let elapsed = started.elapsed();
+    let slow = elapsed >= COMMAND_STAGE_SLOW_THRESHOLD;
+    let notable = !matches!(termination, CommandTermination::Exited { .. })
+        || stdout_result.capture_truncated
+        || stderr_result.capture_truncated
+        || !diagnostic.is_empty();
+
+    if !slow && !notable {
+        return;
+    }
+
+    log(
+        "WARN",
+        &format!(
+            "command result: seq={} label={} elapsed_ms={} termination={:?} stdout_len={} stderr_len={} stdout_truncated={} stderr_truncated={} diagnostic_present={}",
+            request.seq,
+            truncate_preview(&request.label),
+            elapsed.as_millis(),
+            termination,
+            stdout_result.captured.as_ref().map_or(0, Vec::len),
+            stderr_result.captured.as_ref().map_or(0, Vec::len),
+            stdout_result.capture_truncated,
+            stderr_result.capture_truncated,
+            !diagnostic.is_empty(),
+        ),
+    );
+}
+
 fn join_output_writer(handle: Option<JoinHandle<()>>) {
     if let Some(handle) = handle {
         let _ = handle.join();
@@ -842,7 +901,7 @@ mod tests {
     fn wait_for_registry_release(registry: &CommandRegistry, seq: u32) {
         let deadline = Instant::now() + Duration::from_secs(3);
         while Instant::now() < deadline {
-            if registry.register(seq).is_ok() {
+            if registry.register(seq, "test").is_ok() {
                 return;
             }
             std::thread::yield_now();
@@ -853,19 +912,19 @@ mod tests {
     #[test]
     fn registry_rejects_duplicate_active_sequence_and_cleans_on_drop() {
         let registry = CommandRegistry::default();
-        let first = registry.register(7).unwrap();
-        assert!(registry.register(7).is_err());
+        let first = registry.register(7, "first").unwrap();
+        assert!(registry.register(7, "duplicate").is_err());
         drop(first);
-        assert!(registry.register(7).is_ok());
+        assert!(registry.register(7, "second").is_ok());
     }
 
     #[test]
     fn registry_cancel_sets_token_and_unknown_cancel_is_noop() {
         let registry = CommandRegistry::default();
-        let registration = registry.register(8).unwrap();
-        assert!(registry.cancel(8));
+        let registration = registry.register(8, "cancel-me").unwrap();
+        assert_eq!(registry.cancel(8).as_deref(), Some("cancel-me"));
         assert!(registration.cancel.load(Ordering::Acquire));
-        assert!(!registry.cancel(9));
+        assert!(registry.cancel(9).is_none());
     }
 
     #[test]
@@ -899,7 +958,7 @@ mod tests {
         host.set_read_timeout(Some(Duration::from_secs(3))).unwrap();
         let writer = GuestWriter::new(guest);
         let registry = CommandRegistry::default();
-        let _registration = registry.register(11).unwrap();
+        let _registration = registry.register(11, "duplicate").unwrap();
 
         start_command_operation_with_spawner(
             request(11, "echo duplicate"),

--- a/crates/vsock-guest/src/command.rs
+++ b/crates/vsock-guest/src/command.rs
@@ -47,7 +47,7 @@ pub(crate) struct CommandRegistry {
 #[derive(Clone)]
 struct CommandRegistryEntry {
     cancel: Arc<AtomicBool>,
-    label: String,
+    label_preview: String,
 }
 
 impl CommandRegistry {
@@ -62,7 +62,7 @@ impl CommandRegistry {
             seq,
             CommandRegistryEntry {
                 cancel: cancel.clone(),
-                label: label.to_string(),
+                label_preview: truncate_preview(label),
             },
         );
         Ok(CommandRegistration {
@@ -76,7 +76,7 @@ impl CommandRegistry {
         let active = self.inner.lock().unwrap_or_else(|e| e.into_inner());
         let cancel = active.get(&seq)?;
         cancel.cancel.store(true, Ordering::Release);
-        Some(cancel.label.clone())
+        Some(cancel.label_preview.clone())
     }
 
     fn remove_if_same(&self, seq: u32, cancel: &Arc<AtomicBool>) {
@@ -257,13 +257,10 @@ where
 }
 
 pub(crate) fn cancel_command_operation(registry: &CommandRegistry, seq: u32) {
-    if let Some(label) = registry.cancel(seq) {
+    if let Some(label_preview) = registry.cancel(seq) {
         log(
             "INFO",
-            &format!(
-                "command: cancel requested seq={seq} label={}",
-                truncate_preview(&label)
-            ),
+            &format!("command: cancel requested seq={seq} label={label_preview}"),
         );
     }
 }

--- a/crates/vsock-guest/src/connection.rs
+++ b/crates/vsock-guest/src/connection.rs
@@ -149,10 +149,6 @@ fn handle_connection_with_outcome(stream: UnixStream) -> io::Result<ConnectionEn
             // blocking the event loop. A blocking child process (e.g. reading a
             // pipe fd) would otherwise stall all subsequent messages.
             if msg.msg_type == MSG_COMMAND_START {
-                log(
-                    "INFO",
-                    &format!("Received: type=0x{:02X} seq={}", msg.msg_type, msg.seq),
-                );
                 if msg.seq == 0 {
                     send_command_error(0, "command start requires non-zero sequence", &writer)?;
                     continue;
@@ -166,10 +162,6 @@ fn handle_connection_with_outcome(stream: UnixStream) -> io::Result<ConnectionEn
                     command_registry.clone(),
                 )?;
             } else if msg.msg_type == MSG_COMMAND_CANCEL {
-                log(
-                    "INFO",
-                    &format!("Received: type=0x{:02X} seq={}", msg.msg_type, msg.seq),
-                );
                 if msg.seq == 0 {
                     send_command_error(0, "command cancel requires non-zero sequence", &writer)?;
                     continue;

--- a/crates/vsock-guest/src/exec.rs
+++ b/crates/vsock-guest/src/exec.rs
@@ -581,13 +581,11 @@ pub(crate) fn truncate_preview(s: &str) -> String {
     if s.len() <= COMMAND_PREVIEW_MAX_LEN {
         return s.to_string();
     }
-    // Find a safe UTF-8 boundary at or before the max length
-    let end = s
-        .char_indices()
-        .take_while(|(i, _)| *i < COMMAND_PREVIEW_MAX_LEN)
-        .last()
-        .map(|(i, c)| i + c.len_utf8())
-        .unwrap_or(COMMAND_PREVIEW_MAX_LEN);
+    // Find a safe UTF-8 boundary at or before the max length.
+    let mut end = COMMAND_PREVIEW_MAX_LEN;
+    while !s.is_char_boundary(end) {
+        end -= 1;
+    }
     format!("{}...", &s[..end])
 }
 
@@ -1019,6 +1017,18 @@ mod tests {
         assert!(result.ends_with("..."));
         // Must not panic from slicing in the middle of a UTF-8 sequence
         assert!(result.is_char_boundary(result.len() - 3));
+
+        let boundary = format!("{}🔥tail", "a".repeat(COMMAND_PREVIEW_MAX_LEN - 4));
+        assert_eq!(
+            truncate_preview(&boundary),
+            format!("{}🔥...", "a".repeat(COMMAND_PREVIEW_MAX_LEN - 4))
+        );
+
+        let crossing = format!("{}🔥tail", "a".repeat(COMMAND_PREVIEW_MAX_LEN - 1));
+        assert_eq!(
+            truncate_preview(&crossing),
+            format!("{}...", "a".repeat(COMMAND_PREVIEW_MAX_LEN - 1))
+        );
     }
 
     #[test]

--- a/crates/vsock-guest/tests/connection.rs
+++ b/crates/vsock-guest/tests/connection.rs
@@ -739,6 +739,72 @@ fn command_capture_only_stdout_stderr_success() {
 }
 
 #[test]
+fn command_repeated_short_operations_soak() {
+    let (handle, mut host_stream) = start_guest_connection();
+
+    for seq in 130..138 {
+        let expected = format!("run-{seq}");
+        send_command_start(
+            &mut host_stream,
+            seq,
+            &format!("printf {expected}"),
+            5000,
+            CommandOutputPolicy::Capture { limit_bytes: 64 },
+            CommandOutputPolicy::Capture { limit_bytes: 64 },
+        );
+        let (chunks, result) = read_command_result(&mut host_stream, seq);
+
+        assert!(chunks.is_empty());
+        assert_eq!(
+            result.termination,
+            CommandTermination::Exited { exit_code: 0 }
+        );
+        assert_eq!(result.stdout, Some(expected.into_bytes()));
+        assert_eq!(result.stderr, Some(Vec::new()));
+        assert!(!result.stdout_truncated);
+        assert!(!result.stderr_truncated);
+    }
+
+    finish_guest_connection(handle, host_stream);
+}
+
+#[test]
+fn command_large_stdout_stderr_capture_soak() {
+    let (handle, mut host_stream) = start_guest_connection();
+    let len = 32 * 1024usize;
+
+    send_command_start(
+        &mut host_stream,
+        138,
+        "head -c 32768 /dev/zero | tr '\\0' o; head -c 32768 /dev/zero | tr '\\0' e >&2",
+        5000,
+        CommandOutputPolicy::Capture {
+            limit_bytes: len as u32,
+        },
+        CommandOutputPolicy::Capture {
+            limit_bytes: len as u32,
+        },
+    );
+    let (chunks, result) = read_command_result(&mut host_stream, 138);
+
+    assert!(chunks.is_empty());
+    assert_eq!(
+        result.termination,
+        CommandTermination::Exited { exit_code: 0 }
+    );
+    let stdout = result.stdout.unwrap();
+    let stderr = result.stderr.unwrap();
+    assert_eq!(stdout.len(), len);
+    assert_eq!(stderr.len(), len);
+    assert!(stdout.iter().all(|byte| *byte == b'o'));
+    assert!(stderr.iter().all(|byte| *byte == b'e'));
+    assert!(!result.stdout_truncated);
+    assert!(!result.stderr_truncated);
+
+    finish_guest_connection(handle, host_stream);
+}
+
+#[test]
 fn command_stream_only_stdout_stderr_success() {
     let (handle, mut host_stream) = start_guest_connection();
 

--- a/crates/vsock-host/Cargo.toml
+++ b/crates/vsock-host/Cargo.toml
@@ -7,6 +7,7 @@ description = "Vsock host client for Firecracker VM communication"
 [dependencies]
 nix = { workspace = true, features = ["net"] }
 tokio = { workspace = true, features = ["net", "io-util", "time", "rt", "macros", "sync"] }
+tracing = { workspace = true }
 vsock-proto.workspace = true
 
 [lints]

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -43,6 +43,9 @@ const READ_BUF_SIZE: usize = 64 * 1024;
 const DEFAULT_COMMAND_CAPTURE_LIMIT_BYTES: u32 = 1024 * 1024;
 const DEFAULT_COMMAND_STREAM_CAPACITY: usize = 32;
 const MAX_COMMAND_STREAM_CAPACITY: usize = 1024;
+const COMMAND_LABEL_LOG_MAX_BYTES: usize = 100;
+const COMMAND_FRAME_WRITE_SLOW_THRESHOLD: Duration = Duration::from_millis(500);
+const COMMAND_STAGE_SLOW_THRESHOLD: Duration = Duration::from_secs(5);
 const COMMAND_FRAME_WRITE_NOT_STARTED: u8 = 0;
 const COMMAND_FRAME_WRITE_STARTED: u8 = 1;
 const COMMAND_FRAME_WRITE_COMPLETED: u8 = 2;
@@ -140,6 +143,7 @@ pub struct CommandStreamRequest<'a> {
 }
 
 struct CommandOperation {
+    diagnostic: CommandOperationDiagnostic,
     result_tx: oneshot::Sender<io::Result<CommandOperationResult>>,
     stream_tx: Option<mpsc::Sender<CommandOutputEvent>>,
     stdout_capture: CommandCaptureState,
@@ -148,6 +152,26 @@ struct CommandOperation {
     stderr_stream: Option<CommandStreamState>,
     expected_output_seq: u32,
     stream_overflowed: bool,
+}
+
+#[derive(Clone)]
+struct CommandOperationDiagnostic {
+    seq: u32,
+    label: String,
+    registered_at: Instant,
+    first_output_at: Option<Instant>,
+}
+
+struct CommandOperationSnapshot {
+    seq: u32,
+    label: String,
+    elapsed_ms: u128,
+}
+
+struct CommandFrameDiagnostic {
+    seq: u32,
+    label: String,
+    frame: &'static str,
 }
 
 enum Operation {
@@ -321,6 +345,93 @@ impl Drop for CommandFrameWriteGuard {
     }
 }
 
+impl CommandOperationDiagnostic {
+    fn new(seq: u32, label: &str) -> Self {
+        Self {
+            seq,
+            label: label.to_string(),
+            registered_at: Instant::now(),
+            first_output_at: None,
+        }
+    }
+
+    fn frame(&self, frame: &'static str) -> CommandFrameDiagnostic {
+        CommandFrameDiagnostic {
+            seq: self.seq,
+            label: self.label.clone(),
+            frame,
+        }
+    }
+
+    fn elapsed_ms(&self) -> u128 {
+        self.registered_at.elapsed().as_millis()
+    }
+
+    fn snapshot(&self) -> CommandOperationSnapshot {
+        CommandOperationSnapshot {
+            seq: self.seq,
+            label: self.label.clone(),
+            elapsed_ms: self.elapsed_ms(),
+        }
+    }
+
+    fn mark_first_output(&mut self) {
+        if self.first_output_at.is_some() {
+            return;
+        }
+
+        self.first_output_at = Some(Instant::now());
+        let elapsed_ms = self.elapsed_ms();
+        if elapsed_ms >= COMMAND_STAGE_SLOW_THRESHOLD.as_millis() {
+            tracing::warn!(
+                seq = self.seq,
+                label = %command_label_log(&self.label),
+                elapsed_ms,
+                "slow command operation first output"
+            );
+        }
+    }
+
+    fn log_terminal(
+        &self,
+        result: &vsock_proto::DecodedCommandResult<'_>,
+        stream_overflowed: bool,
+    ) {
+        let elapsed_ms = self.elapsed_ms();
+        let slow = elapsed_ms >= COMMAND_STAGE_SLOW_THRESHOLD.as_millis();
+        let notable = command_termination_is_notable(result.termination)
+            || command_result_has_truncation(result)
+            || stream_overflowed
+            || !result.diagnostic.is_empty();
+        if !slow && !notable {
+            return;
+        }
+
+        tracing::warn!(
+            seq = self.seq,
+            label = %command_label_log(&self.label),
+            elapsed_ms,
+            guest_duration_ms = result.duration_ms,
+            termination = ?result.termination,
+            stream_overflowed,
+            stdout_truncated = command_captured_output_truncated(result.stdout),
+            stderr_truncated = command_captured_output_truncated(result.stderr),
+            diagnostic_present = !result.diagnostic.is_empty(),
+            "command operation terminal result"
+        );
+    }
+
+    fn log_error_response(&self, error: &io::Error) {
+        tracing::warn!(
+            seq = self.seq,
+            label = %command_label_log(&self.label),
+            elapsed_ms = self.elapsed_ms(),
+            error = %error,
+            "command operation error response"
+        );
+    }
+}
+
 /// Handle for a host-side command operation.
 ///
 /// Dropping the handle removes the host-side registration only. It never sends
@@ -329,6 +440,7 @@ impl Drop for CommandFrameWriteGuard {
 pub struct CommandOperationHandle {
     shared: Arc<Shared>,
     seq: Option<u32>,
+    diagnostic: CommandOperationDiagnostic,
     result_rx: Option<oneshot::Receiver<io::Result<CommandOperationResult>>>,
     stream_rx: Option<mpsc::Receiver<CommandOutputEvent>>,
 }
@@ -363,10 +475,31 @@ impl CommandOperationHandle {
             io::Error::new(io::ErrorKind::ConnectionReset, "command operation closed")
         })?;
         let payload = vsock_proto::encode_command_cancel();
-        write_command_frame(&self.shared, MSG_COMMAND_CANCEL, seq, &payload).await?;
+        write_command_frame(
+            &self.shared,
+            MSG_COMMAND_CANCEL,
+            seq,
+            &payload,
+            Some(self.diagnostic.frame("cancel")),
+        )
+        .await?;
+        tracing::info!(
+            seq = seq,
+            label = %command_label_log(&self.diagnostic.label),
+            elapsed_ms = self.diagnostic.elapsed_ms(),
+            "command operation cancel sent"
+        );
 
+        let cancel_label = self.diagnostic.label.clone();
+        let registered_at = self.diagnostic.registered_at;
         let result = self.wait_with_timeout(timeout, true).await?;
         if result.termination == CommandTermination::Cancelled {
+            tracing::info!(
+                seq = seq,
+                label = %command_label_log(&cancel_label),
+                elapsed_ms = registered_at.elapsed().as_millis(),
+                "command operation cancel completed"
+            );
             return Ok(result);
         }
 
@@ -425,6 +558,13 @@ impl CommandOperationHandle {
                 self.shared.remove_operation(seq);
                 self.seq = None;
                 self.result_rx = None;
+                tracing::warn!(
+                    seq = seq,
+                    label = %command_label_log(&self.diagnostic.label),
+                    elapsed_ms = self.diagnostic.elapsed_ms(),
+                    poison_connection = poison_on_timeout,
+                    "command operation wait timeout"
+                );
                 if poison_on_timeout {
                     self.shared.poison_connection();
                 }
@@ -524,6 +664,10 @@ impl Shared {
     /// "cached `exits` survive a double-close" is enforced by the match
     /// binding rather than by convention.
     fn close(&self) {
+        self.close_with_reason("connection closed");
+    }
+
+    fn close_with_reason(&self, reason: &'static str) {
         let maps_to_drop = {
             let mut guard = self.state.lock().unwrap_or_else(|e| e.into_inner());
             match std::mem::replace(
@@ -539,8 +683,15 @@ impl Shared {
                     operations,
                     exits,
                 } => {
+                    let command_snapshots = command_operation_snapshots(&operations);
                     *guard = ConnectionState::Closed { exits };
-                    Some((pending, pending_stdout, stdout_senders, operations))
+                    Some((
+                        pending,
+                        pending_stdout,
+                        stdout_senders,
+                        operations,
+                        command_snapshots,
+                    ))
                 }
                 closed @ ConnectionState::Closed { .. } => {
                     // Reassign the whole variant; cached `exits` preserved
@@ -550,14 +701,18 @@ impl Shared {
                 }
             }
         };
-        if let Some(maps) = maps_to_drop {
+        if let Some((pending, pending_stdout, stdout_senders, operations, command_snapshots)) =
+            maps_to_drop
+        {
+            log_command_operations_closed(reason, &command_snapshots);
+            let maps = (pending, pending_stdout, stdout_senders, operations);
             drop(maps);
             self.exit_notify.notify_waiters();
         }
     }
 
     fn poison_connection(&self) {
-        self.close();
+        self.close_with_reason("connection poisoned");
         let _ = nix::sys::socket::shutdown(self.fd, nix::sys::socket::Shutdown::Both);
     }
 
@@ -585,6 +740,75 @@ impl Shared {
 
 fn command_protocol_error(error: impl ToString) -> io::Error {
     io::Error::new(io::ErrorKind::InvalidData, error.to_string())
+}
+
+fn command_termination_is_notable(termination: CommandTermination) -> bool {
+    !matches!(termination, CommandTermination::Exited { .. })
+}
+
+fn command_label_log(label: &str) -> String {
+    if label.len() <= COMMAND_LABEL_LOG_MAX_BYTES {
+        return label.to_string();
+    }
+
+    let end = label
+        .char_indices()
+        .take_while(|(index, _)| *index < COMMAND_LABEL_LOG_MAX_BYTES)
+        .last()
+        .map(|(index, ch)| index + ch.len_utf8())
+        .unwrap_or(COMMAND_LABEL_LOG_MAX_BYTES);
+    format!("{}...", &label[..end])
+}
+
+fn command_captured_output_truncated(output: CommandCapturedOutput<'_>) -> bool {
+    matches!(
+        output,
+        CommandCapturedOutput::Captured {
+            truncated: true,
+            ..
+        }
+    )
+}
+
+fn command_result_has_truncation(result: &vsock_proto::DecodedCommandResult<'_>) -> bool {
+    command_captured_output_truncated(result.stdout)
+        || command_captured_output_truncated(result.stderr)
+}
+
+fn command_operation_snapshots(
+    operations: &HashMap<u32, Operation>,
+) -> Vec<CommandOperationSnapshot> {
+    operations
+        .values()
+        .map(|operation| match operation {
+            Operation::Command(operation) => operation.diagnostic.snapshot(),
+        })
+        .collect()
+}
+
+fn log_command_operations_closed(reason: &'static str, operations: &[CommandOperationSnapshot]) {
+    if operations.is_empty() {
+        return;
+    }
+
+    let active_operations = operations
+        .iter()
+        .map(|operation| {
+            format!(
+                "seq={} label={} elapsed_ms={}",
+                operation.seq,
+                command_label_log(&operation.label),
+                operation.elapsed_ms
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(", ");
+    tracing::warn!(
+        reason = reason,
+        active_count = operations.len(),
+        active_operations = %active_operations,
+        "closing connection with active command operations"
+    );
 }
 
 fn command_output_policy_streams(policy: CommandOutputPolicy) -> bool {
@@ -762,6 +986,7 @@ fn dispatch_command_output(shared: &Arc<Shared>, msg: &RawMessage) -> io::Result
         let decoded =
             vsock_proto::decode_command_output(&msg.payload).map_err(command_protocol_error)?;
         validate_command_output(operation, &decoded)?;
+        operation.diagnostic.mark_first_output();
         if let Some(tx) = operation.stream_tx.take() {
             match tx.try_reserve_owned() {
                 Ok(permit) => {
@@ -795,6 +1020,9 @@ fn dispatch_command_result(shared: &Arc<Shared>, msg: &RawMessage) -> io::Result
 
     if let Some(Operation::Command(operation)) = operation {
         validate_command_result(&operation, &decoded)?;
+        operation
+            .diagnostic
+            .log_terminal(&decoded, operation.stream_overflowed);
         let CommandOperation {
             result_tx,
             stream_overflowed,
@@ -820,6 +1048,7 @@ fn dispatch_command_error(shared: &Arc<Shared>, msg: &RawMessage) -> io::Result<
         let err = vsock_proto::decode_error(&msg.payload)
             .map(|message| io::Error::other(message.to_string()))
             .map_err(command_protocol_error)?;
+        operation.diagnostic.log_error_response(&err);
         let _ = operation.result_tx.send(Err(err));
         return Ok(true);
     }
@@ -1066,15 +1295,60 @@ async fn write_command_frame(
     msg_type: u8,
     seq: u32,
     payload: &[u8],
+    diagnostic: Option<CommandFrameDiagnostic>,
 ) -> io::Result<()> {
     let data = vsock_proto::encode(msg_type, seq, payload)
         .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e.to_string()))?;
     let state = Arc::new(AtomicU8::new(COMMAND_FRAME_WRITE_NOT_STARTED));
     let guard = CommandFrameWriteGuard::new(Arc::clone(shared), Arc::clone(&state));
 
+    let wait_started_at = Instant::now();
     let mut writer = shared.writer.lock().await;
+    let wait_elapsed_ms = wait_started_at.elapsed().as_millis();
+    if wait_elapsed_ms >= COMMAND_FRAME_WRITE_SLOW_THRESHOLD.as_millis()
+        && let Some(diagnostic) = &diagnostic
+    {
+        tracing::warn!(
+            seq = diagnostic.seq,
+            label = %command_label_log(&diagnostic.label),
+            frame = diagnostic.frame,
+            wait_elapsed_ms,
+            "slow command frame writer lock wait"
+        );
+    }
+
     state.store(COMMAND_FRAME_WRITE_STARTED, Ordering::Release);
-    writer.write_all(&data).await?;
+    let write_started_at = Instant::now();
+    let result = writer.write_all(&data).await;
+    let write_elapsed_ms = write_started_at.elapsed().as_millis();
+    match result {
+        Ok(()) => {
+            if write_elapsed_ms >= COMMAND_FRAME_WRITE_SLOW_THRESHOLD.as_millis()
+                && let Some(diagnostic) = &diagnostic
+            {
+                tracing::warn!(
+                    seq = diagnostic.seq,
+                    label = %command_label_log(&diagnostic.label),
+                    frame = diagnostic.frame,
+                    write_elapsed_ms,
+                    "slow command frame write"
+                );
+            }
+        }
+        Err(e) => {
+            if let Some(diagnostic) = &diagnostic {
+                tracing::warn!(
+                    seq = diagnostic.seq,
+                    label = %command_label_log(&diagnostic.label),
+                    frame = diagnostic.frame,
+                    write_elapsed_ms,
+                    error = %e,
+                    "command frame write failed"
+                );
+            }
+            return Err(e);
+        }
+    }
     state.store(COMMAND_FRAME_WRITE_COMPLETED, Ordering::Release);
     drop(guard);
 
@@ -1382,7 +1656,9 @@ impl VsockHost {
         };
         let (result_tx, result_rx) = oneshot::channel();
         let seq = self.shared.next_seq();
+        let diagnostic = CommandOperationDiagnostic::new(seq, request.label);
         let operation = CommandOperation {
+            diagnostic: diagnostic.clone(),
             result_tx,
             stream_tx,
             stdout_capture: command_capture_state(request.stdout),
@@ -1410,12 +1686,20 @@ impl VsockHost {
 
         let mut registration_guard =
             CommandOperationRegistrationGuard::new(Arc::clone(&self.shared), seq);
-        write_command_frame(&self.shared, MSG_COMMAND_START, seq, &payload).await?;
+        write_command_frame(
+            &self.shared,
+            MSG_COMMAND_START,
+            seq,
+            &payload,
+            Some(diagnostic.frame("start")),
+        )
+        .await?;
         registration_guard.disarm();
 
         Ok(CommandOperationHandle {
             shared: Arc::clone(&self.shared),
             seq: Some(seq),
+            diagnostic,
             result_rx: Some(result_rx),
             stream_rx,
         })
@@ -1881,6 +2165,21 @@ mod tests {
         }
     }
 
+    async fn read_guest_messages(
+        stream: &mut UnixStream,
+        decoder: &mut Decoder,
+        count: usize,
+    ) -> Vec<RawMessage> {
+        let mut messages = Vec::new();
+        let mut buf = [0u8; 4096];
+        while messages.len() < count {
+            let n = stream.read(&mut buf).await.unwrap();
+            assert_ne!(n, 0, "connection closed before messages");
+            messages.extend(decoder.decode(&buf[..n]).unwrap());
+        }
+        messages
+    }
+
     async fn setup_host_and_guest() -> (VsockHost, UnixStream, Decoder) {
         let (host_stream, mut guest) = make_pair();
         let host_task = tokio::spawn(async move { host_from_stream(host_stream).await.unwrap() });
@@ -2102,6 +2401,107 @@ mod tests {
             }
         );
         assert_eq!(operation_count(&host), 0);
+    }
+
+    #[tokio::test]
+    async fn command_capture_repeated_short_operations_soak() {
+        let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+        let host = Arc::new(host);
+
+        for i in 0..8 {
+            let label = format!("repeat-{i}");
+            let handle = host
+                .start_command_operation(CommandOperationRequest {
+                    timeout_ms: 5000,
+                    command: "printf ok",
+                    env: &[],
+                    sudo: false,
+                    label: &label,
+                    stdout: CommandOutputPolicy::Capture { limit_bytes: 16 },
+                    stderr: CommandOutputPolicy::Capture { limit_bytes: 16 },
+                    stream_queue_capacity: None,
+                })
+                .await
+                .unwrap();
+
+            let msg = read_guest_message(&mut guest, &mut decoder).await;
+            assert_eq!(msg.msg_type, MSG_COMMAND_START);
+            let stdout = format!("ok-{i}");
+            send_command_result(
+                &mut guest,
+                msg.seq,
+                CommandTermination::Exited { exit_code: 0 },
+                stdout.as_bytes(),
+                b"",
+            )
+            .await;
+
+            let result = handle.wait(Duration::from_secs(5)).await.unwrap();
+            assert_eq!(
+                result.stdout,
+                CommandOwnedCapturedOutput::Captured {
+                    bytes: stdout.into_bytes(),
+                    truncated: false,
+                }
+            );
+            assert_eq!(operation_count(&host), 0);
+            assert!(is_connected(&host));
+        }
+
+        assert_connection_accepts_legacy_exec(&host, &mut guest, &mut decoder).await;
+    }
+
+    #[tokio::test]
+    async fn command_capture_large_stdout_stderr_within_limits_soak() {
+        let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+        let stdout = vec![b'o'; 64 * 1024];
+        let stderr = vec![b'e'; 64 * 1024];
+        let handle = host
+            .start_command_operation(CommandOperationRequest {
+                timeout_ms: 5000,
+                command: "large-capture",
+                env: &[],
+                sudo: false,
+                label: "large-capture",
+                stdout: CommandOutputPolicy::Capture {
+                    limit_bytes: stdout.len() as u32,
+                },
+                stderr: CommandOutputPolicy::Capture {
+                    limit_bytes: stderr.len() as u32,
+                },
+                stream_queue_capacity: None,
+            })
+            .await
+            .unwrap();
+
+        let msg = read_guest_message(&mut guest, &mut decoder).await;
+        assert_eq!(msg.msg_type, MSG_COMMAND_START);
+        send_command_result(
+            &mut guest,
+            msg.seq,
+            CommandTermination::Exited { exit_code: 0 },
+            &stdout,
+            &stderr,
+        )
+        .await;
+
+        let result = handle.wait(Duration::from_secs(5)).await.unwrap();
+        assert_eq!(
+            result.stdout,
+            CommandOwnedCapturedOutput::Captured {
+                bytes: stdout,
+                truncated: false,
+            }
+        );
+        assert_eq!(
+            result.stderr,
+            CommandOwnedCapturedOutput::Captured {
+                bytes: stderr,
+                truncated: false,
+            }
+        );
+        assert_eq!(operation_count(&host), 0);
+        assert!(is_connected(&host));
     }
 
     #[tokio::test]
@@ -2541,13 +2941,7 @@ mod tests {
         let first = start_capture_operation(&host, "cmd-a").await;
         let second = start_capture_operation(&host, "cmd-b").await;
 
-        let mut messages = Vec::new();
-        let mut buf = [0u8; 4096];
-        while messages.len() < 2 {
-            let n = guest.read(&mut buf).await.unwrap();
-            assert_ne!(n, 0, "connection closed before command start messages");
-            messages.extend(decoder.decode(&buf[..n]).unwrap());
-        }
+        let mut messages = read_guest_messages(&mut guest, &mut decoder, 2).await;
         let msg_a = messages.remove(0);
         let msg_b = messages.remove(0);
         assert_eq!(msg_a.msg_type, MSG_COMMAND_START);
@@ -2718,6 +3112,62 @@ mod tests {
 
         let result = handle.wait(Duration::from_secs(5)).await.unwrap();
         assert!(result.stream_overflowed);
+    }
+
+    #[tokio::test]
+    async fn command_stream_many_chunks_soak_does_not_block_terminal_result() {
+        let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+        let mut handle = host
+            .command_stream(CommandStreamRequest {
+                timeout_ms: 5000,
+                command: "stream-many",
+                env: &[],
+                sudo: false,
+                label: "stream-many",
+                stdout: CommandOutputPolicy::Stream {
+                    limit_bytes: 1024,
+                    chunk_limit_bytes: 16,
+                },
+                stderr: CommandOutputPolicy::Discard,
+                stream_queue_capacity: Some(2),
+            })
+            .await
+            .unwrap();
+        let mut rx = handle.take_stream_receiver().unwrap();
+
+        let msg = read_guest_message(&mut guest, &mut decoder).await;
+        assert_eq!(msg.msg_type, MSG_COMMAND_START);
+        for output_seq in 0..32 {
+            send_command_output(
+                &mut guest,
+                msg.seq,
+                output_seq,
+                CommandOutputStream::Stdout,
+                b"x",
+                false,
+            )
+            .await;
+        }
+        send_discarded_command_result(
+            &mut guest,
+            msg.seq,
+            CommandTermination::Exited { exit_code: 0 },
+        )
+        .await;
+
+        let result = handle.wait(Duration::from_secs(5)).await.unwrap();
+        assert!(result.stream_overflowed);
+        assert_eq!(operation_count(&host), 0);
+        let buffered_chunks = tokio::time::timeout(Duration::from_secs(5), async {
+            let mut count = 0;
+            while rx.recv().await.is_some() {
+                count += 1;
+            }
+            count
+        })
+        .await
+        .unwrap();
+        assert!(buffered_chunks <= 2);
     }
 
     #[tokio::test]

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -44,6 +44,7 @@ const DEFAULT_COMMAND_CAPTURE_LIMIT_BYTES: u32 = 1024 * 1024;
 const DEFAULT_COMMAND_STREAM_CAPACITY: usize = 32;
 const MAX_COMMAND_STREAM_CAPACITY: usize = 1024;
 const COMMAND_LABEL_LOG_MAX_BYTES: usize = 100;
+const COMMAND_CLOSE_ACTIVE_LOG_LIMIT: usize = 16;
 const COMMAND_FRAME_WRITE_SLOW_THRESHOLD: Duration = Duration::from_millis(500);
 const COMMAND_STAGE_SLOW_THRESHOLD: Duration = Duration::from_secs(5);
 const COMMAND_FRAME_WRITE_NOT_STARTED: u8 = 0;
@@ -743,7 +744,7 @@ fn command_protocol_error(error: impl ToString) -> io::Error {
 }
 
 fn command_termination_is_notable(termination: CommandTermination) -> bool {
-    !matches!(termination, CommandTermination::Exited { .. })
+    !matches!(termination, CommandTermination::Exited { exit_code: 0 })
 }
 
 fn command_label_log(label: &str) -> String {
@@ -793,6 +794,7 @@ fn log_command_operations_closed(reason: &'static str, operations: &[CommandOper
 
     let active_operations = operations
         .iter()
+        .take(COMMAND_CLOSE_ACTIVE_LOG_LIMIT)
         .map(|operation| {
             format!(
                 "seq={} label={} elapsed_ms={}",
@@ -803,9 +805,13 @@ fn log_command_operations_closed(reason: &'static str, operations: &[CommandOper
         })
         .collect::<Vec<_>>()
         .join(", ");
+    let active_omitted = operations
+        .len()
+        .saturating_sub(COMMAND_CLOSE_ACTIVE_LOG_LIMIT);
     tracing::warn!(
         reason = reason,
         active_count = operations.len(),
+        active_omitted,
         active_operations = %active_operations,
         "closing connection with active command operations"
     );
@@ -2151,6 +2157,17 @@ mod tests {
     fn is_connected(host: &VsockHost) -> bool {
         let guard = host.shared.state.lock().unwrap_or_else(|e| e.into_inner());
         matches!(&*guard, ConnectionState::Connected { .. })
+    }
+
+    #[test]
+    fn command_termination_notable_tracks_nonzero_exit() {
+        assert!(!command_termination_is_notable(
+            CommandTermination::Exited { exit_code: 0 }
+        ));
+        assert!(command_termination_is_notable(CommandTermination::Exited {
+            exit_code: 1
+        }));
+        assert!(command_termination_is_notable(CommandTermination::TimedOut));
     }
 
     async fn read_guest_message(stream: &mut UnixStream, decoder: &mut Decoder) -> RawMessage {

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -43,7 +43,7 @@ const READ_BUF_SIZE: usize = 64 * 1024;
 const DEFAULT_COMMAND_CAPTURE_LIMIT_BYTES: u32 = 1024 * 1024;
 const DEFAULT_COMMAND_STREAM_CAPACITY: usize = 32;
 const MAX_COMMAND_STREAM_CAPACITY: usize = 1024;
-const COMMAND_LABEL_LOG_MAX_BYTES: usize = 100;
+const COMMAND_LABEL_LOG_PREFIX_MAX_BYTES: usize = 100;
 const COMMAND_CLOSE_ACTIVE_LOG_LIMIT: usize = 16;
 const COMMAND_FRAME_WRITE_SLOW_THRESHOLD: Duration = Duration::from_millis(500);
 const COMMAND_STAGE_SLOW_THRESHOLD: Duration = Duration::from_secs(5);
@@ -165,7 +165,7 @@ struct CommandOperationDiagnostic {
 
 struct CommandOperationSnapshot {
     seq: u32,
-    label: String,
+    label_log: String,
     elapsed_ms: u128,
 }
 
@@ -176,7 +176,7 @@ struct CommandOperationCloseSnapshot {
 
 struct CommandFrameDiagnostic {
     seq: u32,
-    label: String,
+    label_log: String,
     frame: &'static str,
 }
 
@@ -364,7 +364,7 @@ impl CommandOperationDiagnostic {
     fn frame(&self, frame: &'static str) -> CommandFrameDiagnostic {
         CommandFrameDiagnostic {
             seq: self.seq,
-            label: self.label.clone(),
+            label_log: command_label_log(&self.label),
             frame,
         }
     }
@@ -376,7 +376,7 @@ impl CommandOperationDiagnostic {
     fn snapshot(&self) -> CommandOperationSnapshot {
         CommandOperationSnapshot {
             seq: self.seq,
-            label: self.label.clone(),
+            label_log: command_label_log(&self.label),
             elapsed_ms: self.elapsed_ms(),
         }
     }
@@ -391,7 +391,7 @@ impl CommandOperationDiagnostic {
         if elapsed_ms >= COMMAND_STAGE_SLOW_THRESHOLD.as_millis() {
             return Some(CommandOperationSnapshot {
                 seq: self.seq,
-                label: self.label.clone(),
+                label_log: command_label_log(&self.label),
                 elapsed_ms,
             });
         }
@@ -497,13 +497,13 @@ impl CommandOperationHandle {
             "command operation cancel sent"
         );
 
-        let cancel_label = self.diagnostic.label.clone();
+        let cancel_label_log = command_label_log(&self.diagnostic.label);
         let registered_at = self.diagnostic.registered_at;
         let result = self.wait_with_timeout(timeout, true).await?;
         if result.termination == CommandTermination::Cancelled {
             tracing::info!(
                 seq = seq,
-                label = %command_label_log(&cancel_label),
+                label = %cancel_label_log,
                 elapsed_ms = registered_at.elapsed().as_millis(),
                 "command operation cancel completed"
             );
@@ -754,11 +754,11 @@ fn command_termination_is_notable(termination: CommandTermination) -> bool {
 }
 
 fn command_label_log(label: &str) -> String {
-    if label.len() <= COMMAND_LABEL_LOG_MAX_BYTES {
+    if label.len() <= COMMAND_LABEL_LOG_PREFIX_MAX_BYTES {
         return label.to_string();
     }
 
-    let mut end = COMMAND_LABEL_LOG_MAX_BYTES;
+    let mut end = COMMAND_LABEL_LOG_PREFIX_MAX_BYTES;
     while !label.is_char_boundary(end) {
         end -= 1;
     }
@@ -808,9 +808,7 @@ fn log_command_operations_closed(reason: &'static str, snapshot: &CommandOperati
         .map(|operation| {
             format!(
                 "seq={} label={} elapsed_ms={}",
-                operation.seq,
-                command_label_log(&operation.label),
-                operation.elapsed_ms
+                operation.seq, operation.label_log, operation.elapsed_ms
             )
         })
         .collect::<Vec<_>>()
@@ -1023,7 +1021,7 @@ fn dispatch_command_output(shared: &Arc<Shared>, msg: &RawMessage) -> io::Result
     if let Some(snapshot) = first_output_slow {
         tracing::warn!(
             seq = snapshot.seq,
-            label = %command_label_log(&snapshot.label),
+            label = %snapshot.label_log,
             elapsed_ms = snapshot.elapsed_ms,
             "slow command operation first output"
         );
@@ -1350,7 +1348,7 @@ async fn write_command_frame(
     {
         tracing::warn!(
             seq = diagnostic.seq,
-            label = %command_label_log(&diagnostic.label),
+            label = %diagnostic.label_log,
             frame = diagnostic.frame,
             wait_elapsed_ms,
             "slow command frame writer lock wait"
@@ -1363,7 +1361,7 @@ async fn write_command_frame(
     {
         tracing::warn!(
             seq = diagnostic.seq,
-            label = %command_label_log(&diagnostic.label),
+            label = %diagnostic.label_log,
             frame = diagnostic.frame,
             write_elapsed_ms,
             "slow command frame write"
@@ -1374,7 +1372,7 @@ async fn write_command_frame(
         if let Some(diagnostic) = &diagnostic {
             tracing::warn!(
                 seq = diagnostic.seq,
-                label = %command_label_log(&diagnostic.label),
+                label = %diagnostic.label_log,
                 frame = diagnostic.frame,
                 write_elapsed_ms,
                 error = %e,
@@ -2215,31 +2213,34 @@ mod tests {
 
     #[test]
     fn command_label_log_truncates_at_utf8_boundary() {
-        let exact = "a".repeat(COMMAND_LABEL_LOG_MAX_BYTES);
+        let exact = "a".repeat(COMMAND_LABEL_LOG_PREFIX_MAX_BYTES);
         assert_eq!(command_label_log(&exact), exact);
 
-        let over_ascii = format!("{}b", "a".repeat(COMMAND_LABEL_LOG_MAX_BYTES));
+        let over_ascii = format!("{}b", "a".repeat(COMMAND_LABEL_LOG_PREFIX_MAX_BYTES));
         assert_eq!(
             command_label_log(&over_ascii),
-            format!("{}...", "a".repeat(COMMAND_LABEL_LOG_MAX_BYTES))
+            format!("{}...", "a".repeat(COMMAND_LABEL_LOG_PREFIX_MAX_BYTES))
         );
 
         let boundary = format!(
             "{}\u{00e9}tail",
-            "a".repeat(COMMAND_LABEL_LOG_MAX_BYTES - 2)
+            "a".repeat(COMMAND_LABEL_LOG_PREFIX_MAX_BYTES - 2)
         );
         assert_eq!(
             command_label_log(&boundary),
-            format!("{}\u{00e9}...", "a".repeat(COMMAND_LABEL_LOG_MAX_BYTES - 2))
+            format!(
+                "{}\u{00e9}...",
+                "a".repeat(COMMAND_LABEL_LOG_PREFIX_MAX_BYTES - 2)
+            )
         );
 
         let crossing = format!(
             "{}\u{00e9}tail",
-            "a".repeat(COMMAND_LABEL_LOG_MAX_BYTES - 1)
+            "a".repeat(COMMAND_LABEL_LOG_PREFIX_MAX_BYTES - 1)
         );
         assert_eq!(
             command_label_log(&crossing),
-            format!("{}...", "a".repeat(COMMAND_LABEL_LOG_MAX_BYTES - 1))
+            format!("{}...", "a".repeat(COMMAND_LABEL_LOG_PREFIX_MAX_BYTES - 1))
         );
     }
 
@@ -2254,7 +2255,7 @@ mod tests {
 
         let snapshot = diagnostic.mark_first_output().unwrap();
         assert_eq!(snapshot.seq, 9);
-        assert_eq!(snapshot.label, "slow-first-output");
+        assert_eq!(snapshot.label_log, "slow-first-output");
         assert!(snapshot.elapsed_ms >= COMMAND_STAGE_SLOW_THRESHOLD.as_millis());
         assert!(diagnostic.mark_first_output().is_none());
     }
@@ -2279,7 +2280,7 @@ mod tests {
         );
         for operation in snapshot.operations {
             assert!(operations.contains_key(&operation.seq));
-            assert!(operation.label.starts_with("operation-"));
+            assert!(operation.label_log.starts_with("operation-"));
         }
     }
 

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -169,6 +169,11 @@ struct CommandOperationSnapshot {
     elapsed_ms: u128,
 }
 
+struct CommandOperationCloseSnapshot {
+    active_count: usize,
+    operations: Vec<CommandOperationSnapshot>,
+}
+
 struct CommandFrameDiagnostic {
     seq: u32,
     label: String,
@@ -376,21 +381,22 @@ impl CommandOperationDiagnostic {
         }
     }
 
-    fn mark_first_output(&mut self) {
+    fn mark_first_output(&mut self) -> Option<CommandOperationSnapshot> {
         if self.first_output_at.is_some() {
-            return;
+            return None;
         }
 
         self.first_output_at = Some(Instant::now());
         let elapsed_ms = self.elapsed_ms();
         if elapsed_ms >= COMMAND_STAGE_SLOW_THRESHOLD.as_millis() {
-            tracing::warn!(
-                seq = self.seq,
-                label = %command_label_log(&self.label),
+            return Some(CommandOperationSnapshot {
+                seq: self.seq,
+                label: self.label.clone(),
                 elapsed_ms,
-                "slow command operation first output"
-            );
+            });
         }
+
+        None
     }
 
     fn log_terminal(
@@ -684,14 +690,14 @@ impl Shared {
                     operations,
                     exits,
                 } => {
-                    let command_snapshots = command_operation_snapshots(&operations);
+                    let command_snapshot = command_operation_close_snapshot(&operations);
                     *guard = ConnectionState::Closed { exits };
                     Some((
                         pending,
                         pending_stdout,
                         stdout_senders,
                         operations,
-                        command_snapshots,
+                        command_snapshot,
                     ))
                 }
                 closed @ ConnectionState::Closed { .. } => {
@@ -702,13 +708,13 @@ impl Shared {
                 }
             }
         };
-        if let Some((pending, pending_stdout, stdout_senders, operations, command_snapshots)) =
+        if let Some((pending, pending_stdout, stdout_senders, operations, command_snapshot)) =
             maps_to_drop
         {
-            log_command_operations_closed(reason, &command_snapshots);
             let maps = (pending, pending_stdout, stdout_senders, operations);
             drop(maps);
             self.exit_notify.notify_waiters();
+            log_command_operations_closed(reason, &command_snapshot);
         }
     }
 
@@ -776,25 +782,31 @@ fn command_result_has_truncation(result: &vsock_proto::DecodedCommandResult<'_>)
         || command_captured_output_truncated(result.stderr)
 }
 
-fn command_operation_snapshots(
+fn command_operation_close_snapshot(
     operations: &HashMap<u32, Operation>,
-) -> Vec<CommandOperationSnapshot> {
-    operations
+) -> CommandOperationCloseSnapshot {
+    let active_count = operations.len();
+    let operations = operations
         .values()
+        .take(COMMAND_CLOSE_ACTIVE_LOG_LIMIT)
         .map(|operation| match operation {
             Operation::Command(operation) => operation.diagnostic.snapshot(),
         })
-        .collect()
+        .collect();
+    CommandOperationCloseSnapshot {
+        active_count,
+        operations,
+    }
 }
 
-fn log_command_operations_closed(reason: &'static str, operations: &[CommandOperationSnapshot]) {
-    if operations.is_empty() {
+fn log_command_operations_closed(reason: &'static str, snapshot: &CommandOperationCloseSnapshot) {
+    if snapshot.active_count == 0 {
         return;
     }
 
-    let active_operations = operations
+    let active_operations = snapshot
+        .operations
         .iter()
-        .take(COMMAND_CLOSE_ACTIVE_LOG_LIMIT)
         .map(|operation| {
             format!(
                 "seq={} label={} elapsed_ms={}",
@@ -805,12 +817,12 @@ fn log_command_operations_closed(reason: &'static str, operations: &[CommandOper
         })
         .collect::<Vec<_>>()
         .join(", ");
-    let active_omitted = operations
-        .len()
-        .saturating_sub(COMMAND_CLOSE_ACTIVE_LOG_LIMIT);
+    let active_omitted = snapshot
+        .active_count
+        .saturating_sub(snapshot.operations.len());
     tracing::warn!(
         reason = reason,
-        active_count = operations.len(),
+        active_count = snapshot.active_count,
         active_omitted,
         active_operations = %active_operations,
         "closing connection with active command operations"
@@ -985,25 +997,38 @@ fn owned_command_result(
 }
 
 fn dispatch_command_output(shared: &Arc<Shared>, msg: &RawMessage) -> io::Result<()> {
-    let mut guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
-    if let ConnectionState::Connected { operations, .. } = &mut *guard
-        && let Some(Operation::Command(operation)) = operations.get_mut(&msg.seq)
+    let mut first_output_slow = None;
     {
-        let decoded =
-            vsock_proto::decode_command_output(&msg.payload).map_err(command_protocol_error)?;
-        validate_command_output(operation, &decoded)?;
-        operation.diagnostic.mark_first_output();
-        if let Some(tx) = operation.stream_tx.take() {
-            match tx.try_reserve_owned() {
-                Ok(permit) => {
-                    operation.stream_tx = Some(permit.send(owned_command_output_event(decoded)));
+        let mut guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
+        if let ConnectionState::Connected { operations, .. } = &mut *guard
+            && let Some(Operation::Command(operation)) = operations.get_mut(&msg.seq)
+        {
+            let decoded =
+                vsock_proto::decode_command_output(&msg.payload).map_err(command_protocol_error)?;
+            validate_command_output(operation, &decoded)?;
+            first_output_slow = operation.diagnostic.mark_first_output();
+            if let Some(tx) = operation.stream_tx.take() {
+                match tx.try_reserve_owned() {
+                    Ok(permit) => {
+                        operation.stream_tx =
+                            Some(permit.send(owned_command_output_event(decoded)));
+                    }
+                    Err(mpsc::error::TrySendError::Full(_)) => {
+                        operation.stream_overflowed = true;
+                    }
+                    Err(mpsc::error::TrySendError::Closed(_)) => {}
                 }
-                Err(mpsc::error::TrySendError::Full(_)) => {
-                    operation.stream_overflowed = true;
-                }
-                Err(mpsc::error::TrySendError::Closed(_)) => {}
             }
         }
+    }
+
+    if let Some(snapshot) = first_output_slow {
+        tracing::warn!(
+            seq = snapshot.seq,
+            label = %command_label_log(&snapshot.label),
+            elapsed_ms = snapshot.elapsed_ms,
+            "slow command operation first output"
+        );
     }
 
     Ok(())
@@ -1311,6 +1336,17 @@ async fn write_command_frame(
     let wait_started_at = Instant::now();
     let mut writer = shared.writer.lock().await;
     let wait_elapsed_ms = wait_started_at.elapsed().as_millis();
+    state.store(COMMAND_FRAME_WRITE_STARTED, Ordering::Release);
+    let write_started_at = Instant::now();
+    let result = writer.write_all(&data).await;
+    let write_elapsed_ms = write_started_at.elapsed().as_millis();
+    if result.is_ok() {
+        state.store(COMMAND_FRAME_WRITE_COMPLETED, Ordering::Release);
+    } else {
+        shared.poison_connection();
+    }
+    drop(writer);
+
     if wait_elapsed_ms >= COMMAND_FRAME_WRITE_SLOW_THRESHOLD.as_millis()
         && let Some(diagnostic) = &diagnostic
     {
@@ -1323,39 +1359,33 @@ async fn write_command_frame(
         );
     }
 
-    state.store(COMMAND_FRAME_WRITE_STARTED, Ordering::Release);
-    let write_started_at = Instant::now();
-    let result = writer.write_all(&data).await;
-    let write_elapsed_ms = write_started_at.elapsed().as_millis();
-    match result {
-        Ok(()) => {
-            if write_elapsed_ms >= COMMAND_FRAME_WRITE_SLOW_THRESHOLD.as_millis()
-                && let Some(diagnostic) = &diagnostic
-            {
-                tracing::warn!(
-                    seq = diagnostic.seq,
-                    label = %command_label_log(&diagnostic.label),
-                    frame = diagnostic.frame,
-                    write_elapsed_ms,
-                    "slow command frame write"
-                );
-            }
-        }
-        Err(e) => {
-            if let Some(diagnostic) = &diagnostic {
-                tracing::warn!(
-                    seq = diagnostic.seq,
-                    label = %command_label_log(&diagnostic.label),
-                    frame = diagnostic.frame,
-                    write_elapsed_ms,
-                    error = %e,
-                    "command frame write failed"
-                );
-            }
-            return Err(e);
-        }
+    if write_elapsed_ms >= COMMAND_FRAME_WRITE_SLOW_THRESHOLD.as_millis()
+        && result.is_ok()
+        && let Some(diagnostic) = &diagnostic
+    {
+        tracing::warn!(
+            seq = diagnostic.seq,
+            label = %command_label_log(&diagnostic.label),
+            frame = diagnostic.frame,
+            write_elapsed_ms,
+            "slow command frame write"
+        );
     }
-    state.store(COMMAND_FRAME_WRITE_COMPLETED, Ordering::Release);
+
+    if let Err(e) = result {
+        if let Some(diagnostic) = &diagnostic {
+            tracing::warn!(
+                seq = diagnostic.seq,
+                label = %command_label_log(&diagnostic.label),
+                frame = diagnostic.frame,
+                write_elapsed_ms,
+                error = %e,
+                "command frame write failed"
+            );
+        }
+        return Err(e);
+    }
+
     drop(guard);
 
     Ok(())

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -158,7 +158,7 @@ struct CommandOperation {
 #[derive(Clone)]
 struct CommandOperationDiagnostic {
     seq: u32,
-    label: String,
+    label_log: String,
     registered_at: Instant,
     first_output_at: Option<Instant>,
 }
@@ -355,7 +355,7 @@ impl CommandOperationDiagnostic {
     fn new(seq: u32, label: &str) -> Self {
         Self {
             seq,
-            label: label.to_string(),
+            label_log: command_label_log(label),
             registered_at: Instant::now(),
             first_output_at: None,
         }
@@ -364,7 +364,7 @@ impl CommandOperationDiagnostic {
     fn frame(&self, frame: &'static str) -> CommandFrameDiagnostic {
         CommandFrameDiagnostic {
             seq: self.seq,
-            label_log: command_label_log(&self.label),
+            label_log: self.label_log.clone(),
             frame,
         }
     }
@@ -376,7 +376,7 @@ impl CommandOperationDiagnostic {
     fn snapshot(&self) -> CommandOperationSnapshot {
         CommandOperationSnapshot {
             seq: self.seq,
-            label_log: command_label_log(&self.label),
+            label_log: self.label_log.clone(),
             elapsed_ms: self.elapsed_ms(),
         }
     }
@@ -391,7 +391,7 @@ impl CommandOperationDiagnostic {
         if elapsed_ms >= COMMAND_STAGE_SLOW_THRESHOLD.as_millis() {
             return Some(CommandOperationSnapshot {
                 seq: self.seq,
-                label_log: command_label_log(&self.label),
+                label_log: self.label_log.clone(),
                 elapsed_ms,
             });
         }
@@ -416,7 +416,7 @@ impl CommandOperationDiagnostic {
 
         tracing::warn!(
             seq = self.seq,
-            label = %command_label_log(&self.label),
+            label = %self.label_log,
             elapsed_ms,
             guest_duration_ms = result.duration_ms,
             termination = ?result.termination,
@@ -431,7 +431,7 @@ impl CommandOperationDiagnostic {
     fn log_error_response(&self, error: &io::Error) {
         tracing::warn!(
             seq = self.seq,
-            label = %command_label_log(&self.label),
+            label = %self.label_log,
             elapsed_ms = self.elapsed_ms(),
             error = %error,
             "command operation error response"
@@ -492,12 +492,12 @@ impl CommandOperationHandle {
         .await?;
         tracing::info!(
             seq = seq,
-            label = %command_label_log(&self.diagnostic.label),
+            label = %self.diagnostic.label_log,
             elapsed_ms = self.diagnostic.elapsed_ms(),
             "command operation cancel sent"
         );
 
-        let cancel_label_log = command_label_log(&self.diagnostic.label);
+        let cancel_label_log = self.diagnostic.label_log.clone();
         let registered_at = self.diagnostic.registered_at;
         let result = self.wait_with_timeout(timeout, true).await?;
         if result.termination == CommandTermination::Cancelled {
@@ -567,7 +567,7 @@ impl CommandOperationHandle {
                 self.result_rx = None;
                 tracing::warn!(
                     seq = seq,
-                    label = %command_label_log(&self.diagnostic.label),
+                    label = %self.diagnostic.label_log,
                     elapsed_ms = self.diagnostic.elapsed_ms(),
                     poison_connection = poison_on_timeout,
                     "command operation wait timeout"
@@ -2245,10 +2245,26 @@ mod tests {
     }
 
     #[test]
+    fn command_diagnostic_keeps_only_truncated_label_log() {
+        let label = format!(
+            "{}secret-tail",
+            "a".repeat(COMMAND_LABEL_LOG_PREFIX_MAX_BYTES)
+        );
+        let diagnostic = CommandOperationDiagnostic::new(7, &label);
+
+        assert_eq!(
+            diagnostic.label_log,
+            format!("{}...", "a".repeat(COMMAND_LABEL_LOG_PREFIX_MAX_BYTES))
+        );
+        assert!(!diagnostic.label_log.contains("secret-tail"));
+        assert_eq!(diagnostic.frame("start").label_log, diagnostic.label_log);
+    }
+
+    #[test]
     fn command_diagnostic_marks_only_first_slow_output() {
         let mut diagnostic = CommandOperationDiagnostic {
             seq: 9,
-            label: "slow-first-output".to_string(),
+            label_log: "slow-first-output".to_string(),
             registered_at: Instant::now() - COMMAND_STAGE_SLOW_THRESHOLD - Duration::from_millis(1),
             first_output_at: None,
         };

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -3205,15 +3205,16 @@ mod tests {
         let result = handle.wait(Duration::from_secs(5)).await.unwrap();
         assert!(result.stream_overflowed);
         assert_eq!(operation_count(&host), 0);
-        let buffered_chunks = tokio::time::timeout(Duration::from_secs(5), async {
-            let mut count = 0;
-            while rx.recv().await.is_some() {
-                count += 1;
+        let mut buffered_chunks = 0;
+        loop {
+            match rx.try_recv() {
+                Ok(_) => buffered_chunks += 1,
+                Err(tokio::sync::mpsc::error::TryRecvError::Disconnected) => break,
+                Err(tokio::sync::mpsc::error::TryRecvError::Empty) => {
+                    panic!("stream receiver should be closed after terminal result");
+                }
             }
-            count
-        })
-        .await
-        .unwrap();
+        }
         assert!(buffered_chunks <= 2);
     }
 

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -2250,7 +2250,9 @@ mod tests {
             "{}secret-tail",
             "a".repeat(COMMAND_LABEL_LOG_PREFIX_MAX_BYTES)
         );
-        let diagnostic = CommandOperationDiagnostic::new(7, &label);
+        let mut diagnostic = CommandOperationDiagnostic::new(7, &label);
+        diagnostic.registered_at =
+            Instant::now() - COMMAND_STAGE_SLOW_THRESHOLD - Duration::from_millis(1);
 
         assert_eq!(
             diagnostic.label_log,
@@ -2258,6 +2260,11 @@ mod tests {
         );
         assert!(!diagnostic.label_log.contains("secret-tail"));
         assert_eq!(diagnostic.frame("start").label_log, diagnostic.label_log);
+        assert_eq!(diagnostic.snapshot().label_log, diagnostic.label_log);
+        assert_eq!(
+            diagnostic.mark_first_output().unwrap().label_log,
+            diagnostic.label_log
+        );
     }
 
     #[test]

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -758,12 +758,10 @@ fn command_label_log(label: &str) -> String {
         return label.to_string();
     }
 
-    let end = label
-        .char_indices()
-        .take_while(|(index, _)| *index < COMMAND_LABEL_LOG_MAX_BYTES)
-        .last()
-        .map(|(index, ch)| index + ch.len_utf8())
-        .unwrap_or(COMMAND_LABEL_LOG_MAX_BYTES);
+    let mut end = COMMAND_LABEL_LOG_MAX_BYTES;
+    while !label.is_char_boundary(end) {
+        end -= 1;
+    }
     format!("{}...", &label[..end])
 }
 
@@ -2184,6 +2182,21 @@ mod tests {
         }
     }
 
+    fn command_operation_for_snapshot(seq: u32, label: &str) -> Operation {
+        let (result_tx, _result_rx) = oneshot::channel();
+        Operation::Command(CommandOperation {
+            diagnostic: CommandOperationDiagnostic::new(seq, label),
+            result_tx,
+            stream_tx: None,
+            stdout_capture: CommandCaptureState::Discard,
+            stderr_capture: CommandCaptureState::Discard,
+            stdout_stream: None,
+            stderr_stream: None,
+            expected_output_seq: 0,
+            stream_overflowed: false,
+        })
+    }
+
     fn is_connected(host: &VsockHost) -> bool {
         let guard = host.shared.state.lock().unwrap_or_else(|e| e.into_inner());
         matches!(&*guard, ConnectionState::Connected { .. })
@@ -2198,6 +2211,76 @@ mod tests {
             exit_code: 1
         }));
         assert!(command_termination_is_notable(CommandTermination::TimedOut));
+    }
+
+    #[test]
+    fn command_label_log_truncates_at_utf8_boundary() {
+        let exact = "a".repeat(COMMAND_LABEL_LOG_MAX_BYTES);
+        assert_eq!(command_label_log(&exact), exact);
+
+        let over_ascii = format!("{}b", "a".repeat(COMMAND_LABEL_LOG_MAX_BYTES));
+        assert_eq!(
+            command_label_log(&over_ascii),
+            format!("{}...", "a".repeat(COMMAND_LABEL_LOG_MAX_BYTES))
+        );
+
+        let boundary = format!(
+            "{}\u{00e9}tail",
+            "a".repeat(COMMAND_LABEL_LOG_MAX_BYTES - 2)
+        );
+        assert_eq!(
+            command_label_log(&boundary),
+            format!("{}\u{00e9}...", "a".repeat(COMMAND_LABEL_LOG_MAX_BYTES - 2))
+        );
+
+        let crossing = format!(
+            "{}\u{00e9}tail",
+            "a".repeat(COMMAND_LABEL_LOG_MAX_BYTES - 1)
+        );
+        assert_eq!(
+            command_label_log(&crossing),
+            format!("{}...", "a".repeat(COMMAND_LABEL_LOG_MAX_BYTES - 1))
+        );
+    }
+
+    #[test]
+    fn command_diagnostic_marks_only_first_slow_output() {
+        let mut diagnostic = CommandOperationDiagnostic {
+            seq: 9,
+            label: "slow-first-output".to_string(),
+            registered_at: Instant::now() - COMMAND_STAGE_SLOW_THRESHOLD - Duration::from_millis(1),
+            first_output_at: None,
+        };
+
+        let snapshot = diagnostic.mark_first_output().unwrap();
+        assert_eq!(snapshot.seq, 9);
+        assert_eq!(snapshot.label, "slow-first-output");
+        assert!(snapshot.elapsed_ms >= COMMAND_STAGE_SLOW_THRESHOLD.as_millis());
+        assert!(diagnostic.mark_first_output().is_none());
+    }
+
+    #[test]
+    fn command_operation_close_snapshot_limits_logged_operations() {
+        let active_count = COMMAND_CLOSE_ACTIVE_LOG_LIMIT + 3;
+        let mut operations = HashMap::new();
+        for seq in 0..active_count {
+            operations.insert(
+                seq as u32,
+                command_operation_for_snapshot(seq as u32, &format!("operation-{seq}")),
+            );
+        }
+
+        let snapshot = command_operation_close_snapshot(&operations);
+        assert_eq!(snapshot.active_count, active_count);
+        assert_eq!(snapshot.operations.len(), COMMAND_CLOSE_ACTIVE_LOG_LIMIT);
+        assert_eq!(
+            snapshot.active_count - snapshot.operations.len(),
+            active_count - COMMAND_CLOSE_ACTIVE_LOG_LIMIT
+        );
+        for operation in snapshot.operations {
+            assert!(operations.contains_key(&operation.seq));
+            assert!(operation.label.starts_with("operation-"));
+        }
     }
 
     async fn read_guest_message(stream: &mut UnixStream, decoder: &mut Decoder) -> RawMessage {


### PR DESCRIPTION
## Summary
- add low-noise host command operation diagnostics for slow/notable writes, results, cancellation, timeouts, and active-operation connection close
- tighten guest command operation logs to avoid routine fast-path noise while preserving seq/label diagnostics for notable paths
- add deterministic host/guest soak coverage for repeated operations, large capture output, and stream backpressure

## Tests
- cargo fmt --manifest-path crates/Cargo.toml --all -- --check
- cargo test --manifest-path crates/Cargo.toml -p vsock-host -p vsock-guest -p vsock-proto
- cargo clippy --manifest-path crates/Cargo.toml -p vsock-host -p vsock-guest -p vsock-proto --all-targets --all-features -- -D warnings
- pre-commit lefthook: cargo-doc, cargo-clippy

Closes #12692