### PR TITLE
refactor: migrate agent checkpoints route to api

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -1,6 +1,7 @@
 import type { AppRoute } from "@ts-rest/core";
 import { healthContract } from "@vm0/api-contracts/contracts/health";
 
+import { agentCheckpointsRoutes } from "./routes/agent-checkpoints-id";
 import { authMeRoutes } from "./routes/auth-me";
 import { audioTranscriptionsV1Routes } from "./routes/audio-transcriptions-v1";
 import type { SignalRouteHandler } from "./context/route";
@@ -88,6 +89,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...healthAuthProbeRoutes,
   ...internalEventConsumerTelegramTypingRoutes,
   ...usageRoutes,
+  ...agentCheckpointsRoutes,
   ...deviceTokenRoutes,
   ...zeroAgentInstructionsRoutes,
   ...zeroAgentsRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/agent-checkpoints-id.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/agent-checkpoints-id.test.ts
@@ -1,0 +1,339 @@
+import { randomUUID } from "node:crypto";
+
+import { checkpointsByIdContract } from "@vm0/api-contracts/contracts/sessions";
+import { checkpoints } from "@vm0/db/schema/checkpoint";
+import { conversations } from "@vm0/db/schema/conversation";
+import { agentRuns } from "@vm0/db/schema/agent-run";
+import type { ContextArtifact } from "@vm0/db/types";
+import { command, createStore } from "ccstate";
+import { eq } from "drizzle-orm";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { writeDb$ } from "../../external/db";
+import {
+  deleteUsageInsightFixture$,
+  seedCompose$,
+  seedRun$,
+  seedUsageInsightFixture$,
+  type UsageInsightFixture,
+} from "./helpers/zero-usage-insight";
+import {
+  createFixtureTracker,
+  createZeroRouteMocks,
+} from "./helpers/zero-route-test";
+
+const TEST_SESSION_HISTORY_HASH =
+  "ec3ac9679505be3bb8233c4ef0b39c8ee206d2c37fc8610edc19f41fbfb9661e";
+
+interface SeedCheckpointArgs {
+  readonly runId: string;
+  readonly artifactSnapshots?: ContextArtifact[] | null;
+  readonly volumeVersionsSnapshot?: {
+    readonly versions: Record<string, string>;
+  } | null;
+}
+
+interface SeedCheckpointResult {
+  readonly checkpointId: string;
+  readonly conversationId: string;
+}
+
+const seedCheckpoint$ = command(
+  async (
+    { set },
+    args: SeedCheckpointArgs,
+    signal: AbortSignal,
+  ): Promise<SeedCheckpointResult> => {
+    const db = set(writeDb$);
+    const [run] = await db
+      .select({ agentComposeVersionId: agentRuns.agentComposeVersionId })
+      .from(agentRuns)
+      .where(eq(agentRuns.id, args.runId))
+      .limit(1);
+    signal.throwIfAborted();
+    if (!run?.agentComposeVersionId) {
+      throw new Error("seedCheckpoint$: run has no compose version");
+    }
+
+    const [conversation] = await db
+      .insert(conversations)
+      .values({
+        runId: args.runId,
+        cliAgentType: "claude-code",
+        cliAgentSessionId: `test-session-${args.runId}`,
+        cliAgentSessionHistoryHash: TEST_SESSION_HISTORY_HASH,
+      })
+      .returning({ id: conversations.id });
+    signal.throwIfAborted();
+    if (!conversation) {
+      throw new Error("seedCheckpoint$: conversation insert returned no row");
+    }
+
+    const [checkpoint] = await db
+      .insert(checkpoints)
+      .values({
+        runId: args.runId,
+        conversationId: conversation.id,
+        agentComposeSnapshot: {
+          agentComposeVersionId: run.agentComposeVersionId,
+          vars: { MODE: "test" },
+          secretNames: ["API_TOKEN"],
+        },
+        artifactSnapshots: args.artifactSnapshots ?? null,
+        volumeVersionsSnapshot: args.volumeVersionsSnapshot ?? null,
+      })
+      .returning({ id: checkpoints.id });
+    signal.throwIfAborted();
+    if (!checkpoint) {
+      throw new Error("seedCheckpoint$: checkpoint insert returned no row");
+    }
+
+    return {
+      checkpointId: checkpoint.id,
+      conversationId: conversation.id,
+    };
+  },
+);
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+
+describe("GET /api/agent/checkpoints/:id", () => {
+  const track = createFixtureTracker<UsageInsightFixture>((fixture) => {
+    return store.set(deleteUsageInsightFixture$, fixture, context.signal);
+  });
+
+  it("returns 401 when the request is unauthenticated", async () => {
+    const client = setupApp({ context })(checkpointsByIdContract);
+
+    const response = await accept(
+      client.getById({ params: { id: randomUUID() }, headers: {} }),
+      [401],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("returns 401 when the authenticated session has no active organization", async () => {
+    const fixture = await track(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, null);
+    const client = setupApp({ context })(checkpointsByIdContract);
+
+    const response = await accept(
+      client.getById({
+        params: { id: randomUUID() },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [401],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("returns 404 when the checkpoint does not exist", async () => {
+    const fixture = await track(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    const client = setupApp({ context })(checkpointsByIdContract);
+
+    const response = await accept(
+      client.getById({
+        params: { id: randomUUID() },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [404],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Checkpoint not found", code: "NOT_FOUND" },
+    });
+  });
+
+  it("returns 404 when the checkpoint belongs to another user", async () => {
+    const fixture = await track(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    const compose = await store.set(
+      seedCompose$,
+      { orgId: fixture.orgId, userId: fixture.userId },
+      context.signal,
+    );
+    const { runId } = await store.set(
+      seedRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        composeId: compose.composeId,
+        status: "completed",
+      },
+      context.signal,
+    );
+    const checkpoint = await store.set(
+      seedCheckpoint$,
+      { runId },
+      context.signal,
+    );
+    mocks.clerk.session(`user_${randomUUID()}`, fixture.orgId);
+    const client = setupApp({ context })(checkpointsByIdContract);
+
+    const response = await accept(
+      client.getById({
+        params: { id: checkpoint.checkpointId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [404],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Checkpoint not found", code: "NOT_FOUND" },
+    });
+  });
+
+  it("returns 404 when the checkpoint belongs to another organization", async () => {
+    const fixture = await track(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    const compose = await store.set(
+      seedCompose$,
+      { orgId: fixture.orgId, userId: fixture.userId },
+      context.signal,
+    );
+    const { runId } = await store.set(
+      seedRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        composeId: compose.composeId,
+        status: "completed",
+      },
+      context.signal,
+    );
+    const checkpoint = await store.set(
+      seedCheckpoint$,
+      { runId },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, `org_${randomUUID()}`);
+    const client = setupApp({ context })(checkpointsByIdContract);
+
+    const response = await accept(
+      client.getById({
+        params: { id: checkpoint.checkpointId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [404],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Checkpoint not found", code: "NOT_FOUND" },
+    });
+  });
+
+  it("returns checkpoint details for the owning user and organization", async () => {
+    const fixture = await track(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    const compose = await store.set(
+      seedCompose$,
+      { orgId: fixture.orgId, userId: fixture.userId },
+      context.signal,
+    );
+    const { runId } = await store.set(
+      seedRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        composeId: compose.composeId,
+        status: "completed",
+      },
+      context.signal,
+    );
+    const checkpoint = await store.set(
+      seedCheckpoint$,
+      {
+        runId,
+        volumeVersionsSnapshot: { versions: { data: "vol-v1" } },
+      },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    const client = setupApp({ context })(checkpointsByIdContract);
+
+    const response = await accept(
+      client.getById({
+        params: { id: checkpoint.checkpointId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body.id).toBe(checkpoint.checkpointId);
+    expect(response.body.runId).toBe(runId);
+    expect(response.body.conversationId).toBe(checkpoint.conversationId);
+    expect(response.body.agentComposeSnapshot.secretNames).toStrictEqual([
+      "API_TOKEN",
+    ]);
+    expect(response.body.agentComposeSnapshot.vars).toStrictEqual({
+      MODE: "test",
+    });
+    expect(response.body.volumeVersionsSnapshot).toStrictEqual({
+      versions: { data: "vol-v1" },
+    });
+    expect(Number.isNaN(Date.parse(response.body.createdAt))).toBeFalsy();
+  });
+
+  it("projects array-shaped artifact snapshots to a record", async () => {
+    const fixture = await track(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    const compose = await store.set(
+      seedCompose$,
+      { orgId: fixture.orgId, userId: fixture.userId },
+      context.signal,
+    );
+    const { runId } = await store.set(
+      seedRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        composeId: compose.composeId,
+        status: "completed",
+      },
+      context.signal,
+    );
+    const checkpoint = await store.set(
+      seedCheckpoint$,
+      {
+        runId,
+        artifactSnapshots: [
+          { name: "frontend", version: "v-fe-1", mountPath: "/workspace/fe" },
+          { name: "backend", version: "v-be-2", mountPath: "/workspace/be" },
+        ],
+      },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    const client = setupApp({ context })(checkpointsByIdContract);
+
+    const response = await accept(
+      client.getById({
+        params: { id: checkpoint.checkpointId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body.artifactSnapshots).toStrictEqual({
+      frontend: "v-fe-1",
+      backend: "v-be-2",
+    });
+  });
+});

--- a/turbo/apps/api/src/signals/routes/agent-checkpoints-id.ts
+++ b/turbo/apps/api/src/signals/routes/agent-checkpoints-id.ts
@@ -1,0 +1,39 @@
+import { computed } from "ccstate";
+import { checkpointsByIdContract } from "@vm0/api-contracts/contracts/sessions";
+
+import { organizationAuthContext$ } from "../auth/auth-context";
+import { authRoute } from "../auth/auth-route";
+import { pathParamsOf } from "../context/request";
+import { notFound } from "../../lib/error";
+import { agentCheckpointById } from "../services/agent-checkpoints.service";
+import type { RouteEntry } from "../route";
+
+const checkpointNotFound = notFound("Checkpoint not found");
+
+const getCheckpointByIdInner$ = computed(async (get) => {
+  const auth = get(organizationAuthContext$);
+  const params = get(pathParamsOf(checkpointsByIdContract.getById));
+  const checkpoint = await get(
+    agentCheckpointById({
+      checkpointId: params.id,
+      userId: auth.userId,
+      orgId: auth.orgId,
+    }),
+  );
+
+  if (!checkpoint) {
+    return checkpointNotFound;
+  }
+
+  return { status: 200 as const, body: checkpoint };
+});
+
+export const agentCheckpointsRoutes: readonly RouteEntry[] = [
+  {
+    route: checkpointsByIdContract.getById,
+    handler: authRoute(
+      { requireOrganization: true, missingOrganizationStatus: 401 },
+      getCheckpointByIdInner$,
+    ),
+  },
+];

--- a/turbo/apps/api/src/signals/services/agent-checkpoints.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-checkpoints.service.ts
@@ -1,0 +1,122 @@
+import { computed, type Computed } from "ccstate";
+import {
+  agentComposeSnapshotSchema,
+  volumeVersionsSnapshotSchema,
+  type CheckpointResponse,
+} from "@vm0/api-contracts/contracts/sessions";
+import { agentRuns } from "@vm0/db/schema/agent-run";
+import { checkpoints } from "@vm0/db/schema/checkpoint";
+import { and, eq } from "drizzle-orm";
+
+import { db$ } from "../external/db";
+
+interface AgentCheckpointByIdArgs {
+  readonly checkpointId: string;
+  readonly userId: string;
+  readonly orgId: string;
+}
+
+interface ContextArtifactSnapshot {
+  readonly name: string;
+  readonly version?: string;
+  readonly mountPath: string;
+}
+
+function isContextArtifactSnapshot(
+  value: unknown,
+): value is ContextArtifactSnapshot {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const entry = value as Record<string, unknown>;
+  return (
+    typeof entry.name === "string" &&
+    typeof entry.mountPath === "string" &&
+    (entry.version === undefined || typeof entry.version === "string")
+  );
+}
+
+function isEmptyArtifactPayload(raw: unknown): boolean {
+  if (raw === null || raw === undefined) {
+    return true;
+  }
+  if (Array.isArray(raw)) {
+    return raw.length === 0;
+  }
+  if (typeof raw === "object") {
+    return Object.keys(raw).length === 0;
+  }
+  return false;
+}
+
+function artifactSnapshotsToRecord(
+  raw: unknown,
+): Record<string, string> | null {
+  if (isEmptyArtifactPayload(raw)) {
+    return null;
+  }
+  if (!Array.isArray(raw)) {
+    throw new Error("Invalid checkpoint: artifactSnapshots must be an array");
+  }
+
+  const result: Record<string, string> = {};
+  for (const [index, entry] of raw.entries()) {
+    if (!isContextArtifactSnapshot(entry)) {
+      throw new Error(
+        `Invalid checkpoint: artifactSnapshots[${index}] is not a valid ContextArtifact`,
+      );
+    }
+    if (entry.version === undefined) {
+      throw new Error(
+        `Invalid checkpoint: artifactSnapshots[${index}] has no version`,
+      );
+    }
+    result[entry.name] = entry.version;
+  }
+  return result;
+}
+
+export function agentCheckpointById(
+  args: AgentCheckpointByIdArgs,
+): Computed<Promise<CheckpointResponse | null>> {
+  return computed(async (get): Promise<CheckpointResponse | null> => {
+    const [row] = await get(db$)
+      .select({
+        id: checkpoints.id,
+        runId: checkpoints.runId,
+        conversationId: checkpoints.conversationId,
+        agentComposeSnapshot: checkpoints.agentComposeSnapshot,
+        artifactSnapshots: checkpoints.artifactSnapshots,
+        volumeVersionsSnapshot: checkpoints.volumeVersionsSnapshot,
+        createdAt: checkpoints.createdAt,
+      })
+      .from(checkpoints)
+      .innerJoin(agentRuns, eq(checkpoints.runId, agentRuns.id))
+      .where(
+        and(
+          eq(checkpoints.id, args.checkpointId),
+          eq(agentRuns.userId, args.userId),
+          eq(agentRuns.orgId, args.orgId),
+        ),
+      )
+      .limit(1);
+
+    if (!row) {
+      return null;
+    }
+
+    return {
+      id: row.id,
+      runId: row.runId,
+      conversationId: row.conversationId,
+      agentComposeSnapshot: agentComposeSnapshotSchema.parse(
+        row.agentComposeSnapshot,
+      ),
+      artifactSnapshots: artifactSnapshotsToRecord(row.artifactSnapshots),
+      volumeVersionsSnapshot: volumeVersionsSnapshotSchema
+        .nullable()
+        .parse(row.volumeVersionsSnapshot ?? null),
+      createdAt: row.createdAt.toISOString(),
+    };
+  });
+}


### PR DESCRIPTION
## Summary
- migrate GET /api/agent/checkpoints/:id into the apps/api signal backend
- add the API route/service wiring for agent checkpoint lookup with user and organization scoping
- add integration coverage for auth, organization scoping, not-found behavior, successful responses, and artifact snapshot projection

Fixes #12813

## Tests
- pnpm -F api exec vitest run src/signals/routes/__tests__/agent-checkpoints-id.test.ts
- pnpm -F api lint
- pnpm -F api check-types
- pnpm check-types
- git diff --check
- pre-commit hook: prettier, knip, check-types