### PR TITLE
refactor(api): migrate test OAuth provider GET routes

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -68,6 +68,9 @@ import { zeroUserModelPreferenceRoutes } from "./routes/zero-user-model-preferen
 import { zeroVoiceChatRoutes } from "./routes/zero-voice-chat";
 import { zeroVoiceIoQuotaRoutes } from "./routes/zero-voice-io-quota";
 import { zeroWebDownloadRoutes } from "./routes/zero-web-download";
+import { testOAuthProviderAuthorizeRoutes } from "./routes/test-oauth-provider-authorize";
+import { testOAuthProviderEchoRoutes } from "./routes/test-oauth-provider-echo";
+import { testOAuthProviderUserinfoRoutes } from "./routes/test-oauth-provider-userinfo";
 
 export type { SignalRouteHandler };
 
@@ -146,4 +149,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...chatThreadsV1Routes,
   ...audioTranscriptionsV1Routes,
   ...modelStatsRoutes,
+  ...testOAuthProviderAuthorizeRoutes,
+  ...testOAuthProviderEchoRoutes,
+  ...testOAuthProviderUserinfoRoutes,
 ];

--- a/turbo/apps/api/src/signals/routes/__tests__/test-oauth-provider-get.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/test-oauth-provider-get.test.ts
@@ -1,0 +1,252 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { createApp } from "../../../app-factory";
+import { mockEnv, mockOptionalEnv } from "../../../lib/env";
+import { clearMockNow, mockNow } from "../../../lib/time";
+import { testContext } from "../../../__tests__/test-helpers";
+import {
+  mintAccessToken,
+  mintExpiredAccessToken,
+} from "../test-oauth-provider-helpers";
+
+const context = testContext();
+const AUTHORIZE_ROUTE = "/api/test/oauth-provider/authorize";
+const USERINFO_ROUTE = "/api/test/oauth-provider/userinfo";
+const ECHO_ROUTE = "/api/test/oauth-provider/echo";
+
+interface ErrorBody {
+  readonly error: string;
+}
+
+interface EchoBody {
+  readonly authorization: string;
+  readonly receivedAt: string;
+}
+
+interface UserinfoBody {
+  readonly email: string;
+  readonly id: string;
+  readonly username: string;
+}
+
+function requestApp(path: string, init?: RequestInit): Promise<Response> {
+  const app = createApp({ signal: context.signal });
+  return Promise.resolve(app.request(path, init));
+}
+
+function makeAuthorizePath(params: Record<string, string>): string {
+  const search = new URLSearchParams(params);
+  return `${AUTHORIZE_ROUTE}?${search.toString()}`;
+}
+
+function validAuthorizePath(overrides: Record<string, string> = {}): string {
+  return makeAuthorizePath({
+    client_id: "test-oauth-client",
+    redirect_uri: "http://localhost:3000/api/connectors/test-oauth/callback",
+    response_type: "code",
+    state: "state-123",
+    ...overrides,
+  });
+}
+
+async function readJson<T>(response: Response): Promise<T> {
+  return (await response.json()) as T;
+}
+
+function bearerHeaders(token: string): HeadersInit {
+  return { authorization: `Bearer ${token}` };
+}
+
+afterEach(() => {
+  clearMockNow();
+});
+
+describe("GET /api/test/oauth-provider/*", () => {
+  it("returns 404 for all scoped GET routes in production", async () => {
+    mockEnv("ENV", "production");
+
+    const authorize = await requestApp(validAuthorizePath());
+    const userinfo = await requestApp(USERINFO_ROUTE);
+    const echo = await requestApp(ECHO_ROUTE);
+
+    expect(authorize.status).toBe(404);
+    await expect(authorize.text()).resolves.toBe("Not found");
+    expect(userinfo.status).toBe(404);
+    await expect(userinfo.text()).resolves.toBe("Not found");
+    expect(echo.status).toBe(404);
+    await expect(echo.text()).resolves.toBe("Not found");
+  });
+
+  it("requires the preview bypass secret when ENV is preview", async () => {
+    mockEnv("ENV", "preview");
+    mockOptionalEnv("VERCEL_AUTOMATION_BYPASS_SECRET", "preview-secret");
+
+    const denied = await requestApp(validAuthorizePath(), {
+      headers: { "x-vercel-protection-bypass": "wrong-secret" },
+    });
+    const allowed = await requestApp(validAuthorizePath(), {
+      headers: { "x-vercel-protection-bypass": "preview-secret" },
+    });
+
+    expect(denied.status).toBe(404);
+    expect(allowed.status).toBe(302);
+  });
+
+  describe("authorize", () => {
+    it("returns 302 with code and state appended to redirect_uri", async () => {
+      mockEnv("ENV", "development");
+
+      const response = await requestApp(validAuthorizePath());
+
+      expect(response.status).toBe(302);
+      const location = response.headers.get("location");
+      expect(location).not.toBeNull();
+      const redirect = new URL(location ?? "");
+      expect(redirect.origin).toBe("http://localhost:3000");
+      expect(redirect.pathname).toBe("/api/connectors/test-oauth/callback");
+      expect(redirect.searchParams.get("code")).toMatch(/^testoauth_code_/);
+      expect(redirect.searchParams.get("state")).toBe("state-123");
+    });
+
+    it("rejects an invalid client_id", async () => {
+      mockEnv("ENV", "development");
+
+      const response = await requestApp(
+        validAuthorizePath({ client_id: "wrong" }),
+      );
+
+      expect(response.status).toBe(400);
+      await expect(readJson<ErrorBody>(response)).resolves.toStrictEqual({
+        error: "invalid_client",
+      });
+    });
+
+    it("rejects missing required query params", async () => {
+      mockEnv("ENV", "development");
+
+      const response = await requestApp(
+        makeAuthorizePath({ client_id: "test-oauth-client" }),
+      );
+
+      expect(response.status).toBe(400);
+      await expect(readJson<ErrorBody>(response)).resolves.toStrictEqual({
+        error: "client_id, redirect_uri, and state are required",
+      });
+    });
+
+    it("rejects an invalid scenario value", async () => {
+      mockEnv("ENV", "development");
+
+      const response = await requestApp(
+        validAuthorizePath({ scenario: "not-a-real-scenario" }),
+      );
+
+      expect(response.status).toBe(400);
+      await expect(readJson<ErrorBody>(response)).resolves.toStrictEqual({
+        error: "invalid_scenario",
+      });
+    });
+  });
+
+  describe("userinfo", () => {
+    it("returns deterministic user info with a valid Bearer token", async () => {
+      mockEnv("ENV", "development");
+      mockNow(new Date("2026-05-12T00:00:00.000Z"));
+      const token = mintAccessToken(3600);
+
+      const response = await requestApp(USERINFO_ROUTE, {
+        headers: bearerHeaders(token),
+      });
+
+      expect(response.status).toBe(200);
+      await expect(readJson<UserinfoBody>(response)).resolves.toStrictEqual({
+        id: "testoauth-user-1",
+        username: "testoauth",
+        email: "testoauth@example.com",
+      });
+    });
+
+    it("returns 401 without a Bearer token", async () => {
+      mockEnv("ENV", "development");
+
+      const response = await requestApp(USERINFO_ROUTE);
+
+      expect(response.status).toBe(401);
+      await expect(readJson<ErrorBody>(response)).resolves.toStrictEqual({
+        error: "invalid_token",
+      });
+    });
+
+    it("returns 401 with a non-test token", async () => {
+      mockEnv("ENV", "development");
+
+      const response = await requestApp(USERINFO_ROUTE, {
+        headers: bearerHeaders("not-a-testoauth-token"),
+      });
+
+      expect(response.status).toBe(401);
+      await expect(readJson<ErrorBody>(response)).resolves.toStrictEqual({
+        error: "invalid_token",
+      });
+    });
+
+    it("returns 401 for an expired access token", async () => {
+      mockEnv("ENV", "development");
+      mockNow(new Date("2026-05-12T00:00:00.000Z"));
+      const token = mintExpiredAccessToken();
+
+      const response = await requestApp(USERINFO_ROUTE, {
+        headers: bearerHeaders(token),
+      });
+
+      expect(response.status).toBe(401);
+      await expect(readJson<ErrorBody>(response)).resolves.toStrictEqual({
+        error: "expired_token",
+      });
+    });
+  });
+
+  describe("echo", () => {
+    it("echoes a valid Bearer token with deterministic receivedAt", async () => {
+      mockEnv("ENV", "development");
+      mockNow(new Date("2026-05-12T00:00:00.000Z"));
+      const token = mintAccessToken(3600);
+
+      const response = await requestApp(ECHO_ROUTE, {
+        headers: bearerHeaders(token),
+      });
+
+      expect(response.status).toBe(200);
+      await expect(readJson<EchoBody>(response)).resolves.toStrictEqual({
+        authorization: `Bearer ${token}`,
+        receivedAt: "2026-05-12T00:00:00.000Z",
+      });
+    });
+
+    it("returns 401 without a Bearer token", async () => {
+      mockEnv("ENV", "development");
+
+      const response = await requestApp(ECHO_ROUTE);
+
+      expect(response.status).toBe(401);
+      await expect(readJson<ErrorBody>(response)).resolves.toStrictEqual({
+        error: "invalid_token",
+      });
+    });
+
+    it("returns 401 for an expired access token", async () => {
+      mockEnv("ENV", "development");
+      mockNow(new Date("2026-05-12T00:00:00.000Z"));
+      const token = mintExpiredAccessToken();
+
+      const response = await requestApp(ECHO_ROUTE, {
+        headers: bearerHeaders(token),
+      });
+
+      expect(response.status).toBe(401);
+      await expect(readJson<ErrorBody>(response)).resolves.toStrictEqual({
+        error: "expired_token",
+      });
+    });
+  });
+});

--- a/turbo/apps/api/src/signals/routes/test-oauth-provider-authorize.ts
+++ b/turbo/apps/api/src/signals/routes/test-oauth-provider-authorize.ts
@@ -1,0 +1,59 @@
+import { computed } from "ccstate";
+import { testOAuthProviderAuthorizeContract } from "@vm0/api-contracts/contracts/test-oauth-provider-authorize";
+
+import { queryOf } from "../context/request";
+import { request$ } from "../context/hono";
+import type { RouteEntry } from "../route";
+import {
+  isTestEndpointAllowed,
+  mintAuthCode,
+  parseTestOAuthScenario,
+  TEST_OAUTH_CLIENT_ID,
+  testEndpointNotFoundResponse,
+} from "./test-oauth-provider-helpers";
+
+const authorize$ = computed((get) => {
+  const request = get(request$);
+  if (!isTestEndpointAllowed(request)) {
+    return testEndpointNotFoundResponse();
+  }
+
+  const query = get(queryOf(testOAuthProviderAuthorizeContract.authorize));
+  const clientId = query.client_id;
+  const redirectUri = query.redirect_uri;
+  const state = query.state;
+
+  if (!clientId || !redirectUri || !state) {
+    return {
+      status: 400 as const,
+      body: { error: "client_id, redirect_uri, and state are required" },
+    };
+  }
+
+  if (clientId !== TEST_OAUTH_CLIENT_ID) {
+    return { status: 400 as const, body: { error: "invalid_client" } };
+  }
+
+  const scenario = query.scenario
+    ? parseTestOAuthScenario(query.scenario)
+    : "success";
+  if (scenario === null) {
+    return { status: 400 as const, body: { error: "invalid_scenario" } };
+  }
+
+  const destination = new URL(redirectUri);
+  destination.searchParams.set("code", mintAuthCode(scenario));
+  destination.searchParams.set("state", state);
+
+  return new Response(null, {
+    status: 302,
+    headers: { location: destination.toString() },
+  });
+});
+
+export const testOAuthProviderAuthorizeRoutes: readonly RouteEntry[] = [
+  {
+    route: testOAuthProviderAuthorizeContract.authorize,
+    handler: authorize$,
+  },
+];

--- a/turbo/apps/api/src/signals/routes/test-oauth-provider-echo.ts
+++ b/turbo/apps/api/src/signals/routes/test-oauth-provider-echo.ts
@@ -1,0 +1,44 @@
+import { computed } from "ccstate";
+import { testOAuthProviderEchoContract } from "@vm0/api-contracts/contracts/test-oauth-provider-echo";
+
+import { nowDate } from "../../lib/time";
+import { authorization$, request$ } from "../context/hono";
+import type { RouteEntry } from "../route";
+import {
+  bearerTokenFrom,
+  isTestEndpointAllowed,
+  isTestOAuthAccessToken,
+  isTestOAuthAccessTokenExpired,
+  testEndpointNotFoundResponse,
+} from "./test-oauth-provider-helpers";
+
+const echo$ = computed((get) => {
+  const request = get(request$);
+  if (!isTestEndpointAllowed(request)) {
+    return testEndpointNotFoundResponse();
+  }
+
+  const authorization = get(authorization$) ?? "";
+  const token = bearerTokenFrom(authorization);
+  if (!token || !isTestOAuthAccessToken(token)) {
+    return { status: 401 as const, body: { error: "invalid_token" } };
+  }
+  if (isTestOAuthAccessTokenExpired(token)) {
+    return { status: 401 as const, body: { error: "expired_token" } };
+  }
+
+  return {
+    status: 200 as const,
+    body: {
+      authorization,
+      receivedAt: nowDate().toISOString(),
+    },
+  };
+});
+
+export const testOAuthProviderEchoRoutes: readonly RouteEntry[] = [
+  {
+    route: testOAuthProviderEchoContract.echo,
+    handler: echo$,
+  },
+];

--- a/turbo/apps/api/src/signals/routes/test-oauth-provider-helpers.ts
+++ b/turbo/apps/api/src/signals/routes/test-oauth-provider-helpers.ts
@@ -1,0 +1,106 @@
+import { randomBytes } from "node:crypto";
+
+import { env, optionalEnv } from "../../lib/env";
+import { now } from "../../lib/time";
+
+export const TEST_OAUTH_CLIENT_ID = "test-oauth-client";
+
+const TEST_OAUTH_SCENARIOS = [
+  "success",
+  "expired-access",
+  "invalid-refresh",
+  "revoked",
+] as const;
+
+type TestOAuthScenario = (typeof TEST_OAUTH_SCENARIOS)[number];
+
+const TOKEN_PREFIX = "testoauth_";
+const ACCESS_PREFIX = `${TOKEN_PREFIX}at_`;
+const CODE_PREFIX = `${TOKEN_PREFIX}code_`;
+
+interface HeaderReader {
+  readonly header: (name: string) => string | undefined;
+}
+
+function randomId(): string {
+  return randomBytes(16).toString("hex");
+}
+
+export function isTestEndpointAllowed(request: HeaderReader): boolean {
+  const deployEnv = env("ENV");
+
+  if (deployEnv === "development") {
+    return true;
+  }
+
+  if (deployEnv === "preview") {
+    const bypassHeader = request.header("x-vercel-protection-bypass");
+    const expectedSecret = optionalEnv("VERCEL_AUTOMATION_BYPASS_SECRET");
+    return !!expectedSecret && bypassHeader === expectedSecret;
+  }
+
+  return false;
+}
+
+export function testEndpointNotFoundResponse(): Response {
+  return new Response("Not found", { status: 404 });
+}
+
+export function parseTestOAuthScenario(
+  value: string,
+): TestOAuthScenario | null {
+  if ((TEST_OAUTH_SCENARIOS as readonly string[]).includes(value)) {
+    return value as TestOAuthScenario;
+  }
+  return null;
+}
+
+export function mintAuthCode(scenario: TestOAuthScenario): string {
+  return `${CODE_PREFIX}${scenario}_${randomId()}`;
+}
+
+export function mintAccessToken(expiresInSecs: number): string {
+  const expiresAtMs = now() + expiresInSecs * 1000;
+  return `${ACCESS_PREFIX}${expiresAtMs}_${randomId()}`;
+}
+
+export function mintExpiredAccessToken(): string {
+  const pastMs = now() - 1000;
+  return `${ACCESS_PREFIX}${pastMs}_${randomId()}`;
+}
+
+export function isTestOAuthAccessToken(value: string): boolean {
+  return value.startsWith(ACCESS_PREFIX);
+}
+
+function parseAccessTokenExpiryMs(token: string): number | null {
+  if (!token.startsWith(ACCESS_PREFIX)) {
+    return null;
+  }
+
+  const tail = token.slice(ACCESS_PREFIX.length);
+  const underscoreIdx = tail.indexOf("_");
+  if (underscoreIdx === -1) {
+    return null;
+  }
+
+  const ms = Number(tail.slice(0, underscoreIdx));
+  if (!Number.isFinite(ms)) {
+    return null;
+  }
+
+  return ms;
+}
+
+export function isTestOAuthAccessTokenExpired(token: string): boolean {
+  const expiresAt = parseAccessTokenExpiryMs(token);
+  if (expiresAt === null) {
+    return true;
+  }
+  return now() >= expiresAt;
+}
+
+export function bearerTokenFrom(authorization: string): string | undefined {
+  const match = authorization.match(/^Bearer\s+(.+)$/i);
+  return match?.[1];
+}

--- a/turbo/apps/api/src/signals/routes/test-oauth-provider-userinfo.ts
+++ b/turbo/apps/api/src/signals/routes/test-oauth-provider-userinfo.ts
@@ -1,0 +1,43 @@
+import { computed } from "ccstate";
+import { testOAuthProviderUserinfoContract } from "@vm0/api-contracts/contracts/test-oauth-provider-userinfo";
+
+import { authorization$, request$ } from "../context/hono";
+import type { RouteEntry } from "../route";
+import {
+  bearerTokenFrom,
+  isTestEndpointAllowed,
+  isTestOAuthAccessToken,
+  isTestOAuthAccessTokenExpired,
+  testEndpointNotFoundResponse,
+} from "./test-oauth-provider-helpers";
+
+const userinfo$ = computed((get) => {
+  const request = get(request$);
+  if (!isTestEndpointAllowed(request)) {
+    return testEndpointNotFoundResponse();
+  }
+
+  const token = bearerTokenFrom(get(authorization$) ?? "");
+  if (!token || !isTestOAuthAccessToken(token)) {
+    return { status: 401 as const, body: { error: "invalid_token" } };
+  }
+  if (isTestOAuthAccessTokenExpired(token)) {
+    return { status: 401 as const, body: { error: "expired_token" } };
+  }
+
+  return {
+    status: 200 as const,
+    body: {
+      id: "testoauth-user-1",
+      username: "testoauth",
+      email: "testoauth@example.com",
+    },
+  };
+});
+
+export const testOAuthProviderUserinfoRoutes: readonly RouteEntry[] = [
+  {
+    route: testOAuthProviderUserinfoContract.userinfo,
+    handler: userinfo$,
+  },
+];

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -208,6 +208,27 @@ export {
 } from "./cli-auth";
 export { authContract, type AuthContract } from "./auth";
 export {
+  testOAuthProviderAuthorizeContract,
+  testOAuthProviderAuthorizeErrorSchema,
+  testOAuthProviderAuthorizeQuerySchema,
+  type TestOAuthProviderAuthorizeContract,
+  type TestOAuthProviderAuthorizeQuery,
+} from "./test-oauth-provider-authorize";
+export {
+  testOAuthProviderEchoContract,
+  testOAuthProviderEchoErrorSchema,
+  testOAuthProviderEchoResponseSchema,
+  type TestOAuthProviderEchoContract,
+  type TestOAuthProviderEchoResponse,
+} from "./test-oauth-provider-echo";
+export {
+  testOAuthProviderUserinfoContract,
+  testOAuthProviderUserinfoErrorSchema,
+  testOAuthProviderUserinfoResponseSchema,
+  type TestOAuthProviderUserinfoContract,
+  type TestOAuthProviderUserinfoResponse,
+} from "./test-oauth-provider-userinfo";
+export {
   cronCleanupSandboxesContract,
   cleanupResultSchema,
   cleanupResponseSchema,

--- a/turbo/packages/api-contracts/src/contracts/test-oauth-provider-authorize.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-oauth-provider-authorize.ts
@@ -1,0 +1,38 @@
+import { z } from "zod";
+
+import { initContract } from "./base";
+
+const c = initContract();
+
+export const testOAuthProviderAuthorizeErrorSchema = z.object({
+  error: z.string(),
+});
+
+export const testOAuthProviderAuthorizeQuerySchema = z.object({
+  client_id: z.string().optional(),
+  redirect_uri: z.string().optional(),
+  response_type: z.string().optional(),
+  scenario: z.string().optional(),
+  scope: z.string().optional(),
+  state: z.string().optional(),
+});
+
+export const testOAuthProviderAuthorizeContract = c.router({
+  authorize: {
+    method: "GET",
+    path: "/api/test/oauth-provider/authorize",
+    query: testOAuthProviderAuthorizeQuerySchema,
+    responses: {
+      302: c.noBody(),
+      400: testOAuthProviderAuthorizeErrorSchema,
+      404: z.string(),
+    },
+    summary: "Synthetic OAuth authorize endpoint for test connector flows",
+  },
+});
+
+export type TestOAuthProviderAuthorizeContract =
+  typeof testOAuthProviderAuthorizeContract;
+export type TestOAuthProviderAuthorizeQuery = z.infer<
+  typeof testOAuthProviderAuthorizeQuerySchema
+>;

--- a/turbo/packages/api-contracts/src/contracts/test-oauth-provider-echo.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-oauth-provider-echo.ts
@@ -1,0 +1,33 @@
+import { z } from "zod";
+
+import { initContract } from "./base";
+
+const c = initContract();
+
+export const testOAuthProviderEchoErrorSchema = z.object({
+  error: z.string(),
+});
+
+export const testOAuthProviderEchoResponseSchema = z.object({
+  authorization: z.string(),
+  receivedAt: z.string(),
+});
+
+export const testOAuthProviderEchoContract = c.router({
+  echo: {
+    method: "GET",
+    path: "/api/test/oauth-provider/echo",
+    responses: {
+      200: testOAuthProviderEchoResponseSchema,
+      401: testOAuthProviderEchoErrorSchema,
+      404: z.string(),
+    },
+    summary: "Synthetic protected upstream endpoint for test connector flows",
+  },
+});
+
+export type TestOAuthProviderEchoContract =
+  typeof testOAuthProviderEchoContract;
+export type TestOAuthProviderEchoResponse = z.infer<
+  typeof testOAuthProviderEchoResponseSchema
+>;

--- a/turbo/packages/api-contracts/src/contracts/test-oauth-provider-userinfo.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-oauth-provider-userinfo.ts
@@ -1,0 +1,34 @@
+import { z } from "zod";
+
+import { initContract } from "./base";
+
+const c = initContract();
+
+export const testOAuthProviderUserinfoErrorSchema = z.object({
+  error: z.string(),
+});
+
+export const testOAuthProviderUserinfoResponseSchema = z.object({
+  email: z.string(),
+  id: z.string(),
+  username: z.string(),
+});
+
+export const testOAuthProviderUserinfoContract = c.router({
+  userinfo: {
+    method: "GET",
+    path: "/api/test/oauth-provider/userinfo",
+    responses: {
+      200: testOAuthProviderUserinfoResponseSchema,
+      401: testOAuthProviderUserinfoErrorSchema,
+      404: z.string(),
+    },
+    summary: "Synthetic OAuth userinfo endpoint for test connector flows",
+  },
+});
+
+export type TestOAuthProviderUserinfoContract =
+  typeof testOAuthProviderUserinfoContract;
+export type TestOAuthProviderUserinfoResponse = z.infer<
+  typeof testOAuthProviderUserinfoResponseSchema
+>;


### PR DESCRIPTION
## Summary
- Add API backend contracts and signal routes for GET /api/test/oauth-provider/authorize, /userinfo, and /echo
- Preserve the existing test-endpoint guard behavior for development, preview bypass, and production 404s
- Add API integration coverage for authorize, userinfo, echo, token validation, expiry, and preview protection

Closes #12828

## Validation
- pnpm format
- pnpm -F api exec vitest src/signals/routes/__tests__/test-oauth-provider-get.test.ts
- pnpm check-types
- pnpm turbo run lint
- pnpm vitest
- pnpm knip

Note: the first full pnpm vitest run had a transient unrelated web test failure in resolve-model-provider; that file passed in isolation, the related pair passed together, and the full pnpm vitest rerun passed (951 files, 10204 tests).