### PR TITLE
refactor: migrate zero org logo GET to api backend

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -35,6 +35,7 @@ import { zeroModelProvidersRoutes } from "./routes/zero-model-providers";
 import { zeroOnboardingCompleteRoutes } from "./routes/zero-onboarding-complete";
 import { zeroOnboardingStatusRoutes } from "./routes/zero-onboarding-status";
 import { zeroOrgInviteRoutes } from "./routes/zero-org-invite";
+import { zeroOrgLogoRoutes } from "./routes/zero-org-logo";
 import { zeroOrgMembershipRequestsRoutes } from "./routes/zero-org-membership-requests";
 import { zeroOrgReadRoutes } from "./routes/zero-org-read";
 import { zeroPermissionAccessRequestsRoutes } from "./routes/zero-permission-access-requests";
@@ -124,6 +125,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...zeroOnboardingCompleteRoutes,
   ...zeroOnboardingStatusRoutes,
   ...zeroOrgInviteRoutes,
+  ...zeroOrgLogoRoutes,
   ...zeroOrgMembershipRequestsRoutes,
   ...zeroOrgReadRoutes,
   ...zeroPermissionAccessRequestsRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-org-logo.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-org-logo.test.ts
@@ -1,0 +1,127 @@
+import { randomUUID } from "node:crypto";
+
+import { zeroOrgLogoContract } from "@vm0/api-contracts/contracts/zero-org-logo";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { createZeroRouteMocks } from "./helpers/zero-route-test";
+
+const context = testContext();
+const mocks = createZeroRouteMocks(context);
+
+interface ClerkOrganizationLogoFixture {
+  readonly orgId: string;
+  readonly imageUrl: string | null;
+  readonly hasImage: boolean;
+}
+
+function mockClerkOrganizationLogo(args: ClerkOrganizationLogoFixture): void {
+  context.mocks.clerk.organizations.getOrganization.mockResolvedValue({
+    id: args.orgId,
+    imageUrl: args.imageUrl,
+    hasImage: args.hasImage,
+  });
+}
+
+function clerkNotFoundError(): Error {
+  const error = new Error("Organization not found");
+  error.name = "NotFoundError";
+  return error;
+}
+
+describe("GET /api/zero/org/logo", () => {
+  it("returns the current org logo metadata", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    mocks.clerk.session(userId, orgId);
+    mockClerkOrganizationLogo({
+      orgId,
+      imageUrl: "https://img.clerk.test/org-logo.png",
+      hasImage: true,
+    });
+
+    const client = setupApp({ context })(zeroOrgLogoContract);
+    const response = await accept(
+      client.get({ headers: { authorization: "Bearer clerk-session" } }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      logoUrl: "https://img.clerk.test/org-logo.png",
+      hasImage: true,
+    });
+    expect(
+      context.mocks.clerk.organizations.getOrganization,
+    ).toHaveBeenCalledWith({ organizationId: orgId });
+  });
+
+  it("returns null logoUrl when Clerk has no org image URL", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    mocks.clerk.session(userId, orgId);
+    mockClerkOrganizationLogo({
+      orgId,
+      imageUrl: "",
+      hasImage: false,
+    });
+
+    const client = setupApp({ context })(zeroOrgLogoContract);
+    const response = await accept(
+      client.get({ headers: { authorization: "Bearer clerk-session" } }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      logoUrl: null,
+      hasImage: false,
+    });
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    const client = setupApp({ context })(zeroOrgLogoContract);
+    const response = await accept(client.get({ headers: {} }), [401]);
+
+    expect(response.body.error.code).toBe("UNAUTHORIZED");
+    expect(
+      context.mocks.clerk.organizations.getOrganization,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when the session has no active org", async () => {
+    const userId = `user_${randomUUID()}`;
+    mocks.clerk.session(userId, null);
+
+    const client = setupApp({ context })(zeroOrgLogoContract);
+    const response = await accept(
+      client.get({ headers: { authorization: "Bearer clerk-session" } }),
+      [404],
+    );
+
+    expect(response.body.error).toStrictEqual({
+      message: "Org not found",
+      code: "BAD_REQUEST",
+    });
+    expect(
+      context.mocks.clerk.organizations.getOrganization,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("maps Clerk not-found errors to 404", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    mocks.clerk.session(userId, orgId);
+    context.mocks.clerk.organizations.getOrganization.mockRejectedValue(
+      clerkNotFoundError(),
+    );
+
+    const client = setupApp({ context })(zeroOrgLogoContract);
+    const response = await accept(
+      client.get({ headers: { authorization: "Bearer clerk-session" } }),
+      [404],
+    );
+
+    expect(response.body.error).toStrictEqual({
+      message: "Org not found",
+      code: "BAD_REQUEST",
+    });
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-org-logo.ts
+++ b/turbo/apps/api/src/signals/routes/zero-org-logo.ts
@@ -1,0 +1,61 @@
+import { computed } from "ccstate";
+import { zeroOrgLogoContract } from "@vm0/api-contracts/contracts/zero-org-logo";
+
+import { authContext$ } from "../auth/auth-context";
+import { authRoute } from "../auth/auth-route";
+import { clerk$ } from "../external/clerk";
+import { safeAsync } from "../utils";
+import type { RouteEntry } from "../route";
+
+const orgLogoNotFound = Object.freeze({
+  status: 404 as const,
+  body: Object.freeze({
+    error: Object.freeze({
+      message: "Org not found",
+      code: "BAD_REQUEST",
+    }),
+  }),
+});
+
+function isOrgLookupNotFound(error: unknown): error is Error {
+  return (
+    error instanceof Error &&
+    (error.name === "BadRequestError" || error.name === "NotFoundError")
+  );
+}
+
+const getOrgLogoInner$ = computed(async (get) => {
+  const auth = get(authContext$);
+  if (!auth.orgId) {
+    return orgLogoNotFound;
+  }
+
+  const client = get(clerk$);
+  const result = await safeAsync(() => {
+    return client.organizations.getOrganization({
+      organizationId: auth.orgId,
+    });
+  });
+
+  if ("error" in result) {
+    if (isOrgLookupNotFound(result.error)) {
+      return orgLogoNotFound;
+    }
+    throw result.error;
+  }
+
+  return {
+    status: 200 as const,
+    body: {
+      logoUrl: result.ok.imageUrl || null,
+      hasImage: result.ok.hasImage,
+    },
+  };
+});
+
+export const zeroOrgLogoRoutes: readonly RouteEntry[] = [
+  {
+    route: zeroOrgLogoContract.get,
+    handler: authRoute({}, getOrgLogoInner$),
+  },
+];

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -723,6 +723,12 @@ export {
   type ZeroOrgLeaveContract,
   type ZeroOrgDeleteContract,
 } from "./zero-org";
+export {
+  zeroOrgLogoContract,
+  zeroOrgLogoResponseSchema,
+  type ZeroOrgLogoContract,
+  type ZeroOrgLogoResponse,
+} from "./zero-org-logo";
 export { zeroOrgListContract, type ZeroOrgListContract } from "./zero-org-list";
 export {
   zeroOrgMembersContract,

--- a/turbo/packages/api-contracts/src/contracts/zero-org-logo.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-org-logo.ts
@@ -1,0 +1,31 @@
+import { z } from "zod";
+import { authHeadersSchema, initContract } from "./base";
+import { apiErrorSchema } from "./errors";
+
+const c = initContract();
+
+export const zeroOrgLogoResponseSchema = z.object({
+  logoUrl: z.string().nullable(),
+  hasImage: z.boolean(),
+});
+
+export type ZeroOrgLogoResponse = z.infer<typeof zeroOrgLogoResponseSchema>;
+
+/**
+ * Zero contract for GET /api/zero/org/logo
+ */
+export const zeroOrgLogoContract = c.router({
+  get: {
+    method: "GET",
+    path: "/api/zero/org/logo",
+    headers: authHeadersSchema,
+    responses: {
+      200: zeroOrgLogoResponseSchema,
+      401: apiErrorSchema,
+      404: apiErrorSchema,
+    },
+    summary: "Get current organization logo",
+  },
+});
+
+export type ZeroOrgLogoContract = typeof zeroOrgLogoContract;


### PR DESCRIPTION
## Summary

- Add the `zeroOrgLogoContract` for `GET /api/zero/org/logo`
- Register an `apps/api` route that reads Clerk org logo metadata for the authenticated active org
- Add focused API route tests for success, missing image, unauthenticated, no active org, and Clerk not-found cases

Closes #12835

## Validation

- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-org-logo.test.ts` passed
- `pnpm -F api lint` passed
- `pnpm -F @vm0/api-contracts lint` passed
- `pnpm exec prettier --check packages/api-contracts/src/contracts/zero-org-logo.ts packages/api-contracts/src/contracts/index.ts apps/api/src/signals/routes/zero-org-logo.ts apps/api/src/signals/routes/__tests__/zero-org-logo.test.ts apps/api/src/signals/route.ts` passed
- `git diff --check` passed
- `pnpm -F @vm0/api-contracts check-types` passed
- `pnpm knip --cache` passed with existing configuration hints only

Typecheck notes:

- `pnpm check-types` failed in the existing `@vm0/cli` remote-agent baseline: missing `ably` module types plus related implicit-any and arity errors in `apps/cli/src/commands/zero/remote-agent/host.ts` and `apps/cli/src/lib/api/domains/zero-remote-agent.ts`.
- `pnpm -F api check-types` failed on the existing API ts-rest test inference baseline (`Property 'body' does not exist on type 'never'` across existing route tests). A filtered rerun for `zero-org-logo`, `src/signals/route.ts`, and the contracts index produced no matches.
