### PR TITLE
chore: promote runner diagnostic logs

### DIFF
--- a/crates/runner/src/cmd/gc.rs
+++ b/crates/runner/src/cmd/gc.rs
@@ -773,7 +773,7 @@ async fn gc_orphaned_locks(home: &HomePaths, dry_run: bool) -> RunnerResult<u64>
                     info!("[dry-run] would remove unused lock {name}");
                     removed += 1;
                 } else if let Err(e) = tokio::fs::remove_file(&lock_path).await {
-                    tracing::debug!("cannot remove {}: {e}", lock_path.display());
+                    warn!("cannot remove {}: {e}", lock_path.display());
                 } else {
                     info!("removed unused lock {name}");
                     removed += 1;
@@ -835,7 +835,7 @@ async fn gc_job_logs(home: &HomePaths, dry_run: bool) -> RunnerResult<(u64, u64)
                 }
                 Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
                 Err(e) => {
-                    tracing::debug!("cannot remove {}: {e}", entry.path().display());
+                    warn!("cannot remove {}: {e}", entry.path().display());
                     continue;
                 }
             }
@@ -975,9 +975,7 @@ async fn gc_versions(
                 // Log and treat as inactive — the version dir will still be
                 // removed, which is preferable to silently accumulating stale
                 // versions when systemd units are already gone.
-                tracing::debug!(
-                    "version {name}: cannot check unit status ({e}), assuming inactive"
-                );
+                warn!("version {name}: cannot check unit status ({e}), assuming inactive");
             }
         }
 
@@ -992,7 +990,7 @@ async fn gc_versions(
             if let Err(e) = tokio::fs::remove_dir_all(&version_bin).await
                 && e.kind() != std::io::ErrorKind::NotFound
             {
-                tracing::debug!("cannot remove {}: {e}", version_bin.display());
+                warn!("cannot remove {}: {e}", version_bin.display());
                 continue;
             }
 
@@ -1052,12 +1050,10 @@ async fn gc_nbd_orphans(dry_run: bool) -> RunnerResult<u32> {
                     cleaned += 1;
                 }
                 super::nbd::NbdOrphanDisconnect::Locked => {
-                    tracing::debug!(
-                        "nbd{device_index}: skipping disconnect, NBD device lock is held"
-                    );
+                    info!("nbd{device_index}: skipping disconnect, NBD device lock is held");
                 }
                 super::nbd::NbdOrphanDisconnect::Changed => {
-                    tracing::debug!(
+                    info!(
                         "nbd{device_index}: skipping disconnect, device state changed since scan"
                     );
                 }

--- a/crates/runner/src/cmd/service.rs
+++ b/crates/runner/src/cmd/service.rs
@@ -401,6 +401,34 @@ struct RunnerStatusSnapshot {
     uptime: std::time::Duration,
 }
 
+#[derive(Debug)]
+enum RunnerStatusReadError {
+    Read {
+        path: PathBuf,
+        error: std::io::Error,
+    },
+    ParseJson {
+        path: PathBuf,
+        error: serde_json::Error,
+    },
+    ParseStartedAt {
+        started_at: String,
+        error: chrono::ParseError,
+    },
+}
+
+impl std::fmt::Display for RunnerStatusReadError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Read { path, error } => write!(f, "read {}: {error}", path.display()),
+            Self::ParseJson { path, error } => write!(f, "parse {}: {error}", path.display()),
+            Self::ParseStartedAt { started_at, error } => {
+                write!(f, "parse started_at {started_at:?}: {error}")
+            }
+        }
+    }
+}
+
 /// Decision from [`decide_gate`] — pure function that maps a status
 /// snapshot to the gate outcome without performing any I/O.
 #[derive(Debug, PartialEq, Eq)]
@@ -436,9 +464,12 @@ fn decide_gate(status: &RunnerStatusSnapshot) -> GateDecision {
 
 /// Read status.json at `base_dir`.
 ///
-/// Returns `None` on any I/O or parse failure — the caller should fall
-/// through to forceful stop (status unknown → cannot protect jobs).
-async fn read_runner_status(base_dir: &Path) -> Option<RunnerStatusSnapshot> {
+/// Returns an error on any I/O or parse failure — the caller should log the
+/// reason and fall through to forceful stop (status unknown → cannot protect
+/// jobs).
+async fn read_runner_status(
+    base_dir: &Path,
+) -> Result<RunnerStatusSnapshot, RunnerStatusReadError> {
     #[derive(serde::Deserialize)]
     struct StatusFile {
         mode: String,
@@ -451,25 +482,26 @@ async fn read_runner_status(base_dir: &Path) -> Option<RunnerStatusSnapshot> {
         // `sandbox_id` is present in the file but unused by the gate.
     }
     let path = base_dir.join("status.json");
-    let content = tokio::fs::read_to_string(&path)
-        .await
-        .inspect_err(|e| {
-            tracing::debug!(path = %path.display(), error = %e, "read status.json failed");
-        })
-        .ok()?;
+    let content =
+        tokio::fs::read_to_string(&path)
+            .await
+            .map_err(|error| RunnerStatusReadError::Read {
+                path: path.clone(),
+                error,
+            })?;
     let file: StatusFile = serde_json::from_str(&content)
-        .inspect_err(|e| tracing::debug!(error = %e, "parse status.json failed"))
-        .ok()?;
-    let started = chrono::DateTime::parse_from_rfc3339(&file.started_at)
-        .inspect_err(|e| {
-            tracing::debug!(started_at = %file.started_at, error = %e, "parse started_at failed");
-        })
-        .ok()?;
+        .map_err(|error| RunnerStatusReadError::ParseJson { path, error })?;
+    let started = chrono::DateTime::parse_from_rfc3339(&file.started_at).map_err(|error| {
+        RunnerStatusReadError::ParseStartedAt {
+            started_at: file.started_at.clone(),
+            error,
+        }
+    })?;
     let now = chrono::Utc::now();
     let uptime = (now - started.with_timezone(&chrono::Utc))
         .to_std()
         .unwrap_or_default();
-    Some(RunnerStatusSnapshot {
+    Ok(RunnerStatusSnapshot {
         mode: file.mode,
         run_ids: file.active_runs.into_iter().map(|r| r.run_id).collect(),
         uptime,
@@ -549,13 +581,17 @@ async fn check_active_jobs_gate(
         );
         return Ok(());
     };
-    let Some(status) = read_runner_status(&base_dir).await else {
-        warn!(
-            unit,
-            base_dir = %base_dir.display(),
-            "cannot read status.json — skipping active-jobs gate"
-        );
-        return Ok(());
+    let status = match read_runner_status(&base_dir).await {
+        Ok(status) => status,
+        Err(e) => {
+            warn!(
+                unit,
+                base_dir = %base_dir.display(),
+                error = %e,
+                "cannot read status.json — skipping active-jobs gate"
+            );
+            return Ok(());
+        }
     };
 
     match decide_gate(&status) {
@@ -777,14 +813,24 @@ async fn resume(args: ServiceResumeArgs) -> RunnerResult<()> {
     // Preflight: if status.json shows the runner is already past the
     // resumable point (Stopping = teardown in progress, Stopped = exited),
     // SIGUSR2 is too late.
-    if let Some(base_dir) = runner_base_dir(&args.name)
-        && let Some(status) = read_runner_status(&base_dir).await
-        && matches!(status.mode.as_str(), "stopping" | "stopped")
-    {
-        return Err(RunnerError::Internal(format!(
-            "{unit} is already shutting down (mode={}) — cannot resume",
-            status.mode
-        )));
+    if let Some(base_dir) = runner_base_dir(&args.name) {
+        match read_runner_status(&base_dir).await {
+            Ok(status) if matches!(status.mode.as_str(), "stopping" | "stopped") => {
+                return Err(RunnerError::Internal(format!(
+                    "{unit} is already shutting down (mode={}) — cannot resume",
+                    status.mode
+                )));
+            }
+            Ok(_) => {}
+            Err(e) => {
+                warn!(
+                    unit,
+                    base_dir = %base_dir.display(),
+                    error = %e,
+                    "cannot read status.json during resume preflight"
+                );
+            }
+        }
     }
 
     // Same race as in `drain`: the runner can exit after the preflight
@@ -1160,7 +1206,7 @@ mod tests {
     #[tokio::test]
     async fn read_runner_status_missing_file() {
         let dir = tempfile::tempdir().unwrap();
-        assert!(read_runner_status(dir.path()).await.is_none());
+        assert!(read_runner_status(dir.path()).await.is_err());
     }
 
     #[tokio::test]
@@ -1169,8 +1215,8 @@ mod tests {
         tokio::fs::write(dir.path().join("status.json"), "{}")
             .await
             .unwrap();
-        // Missing required fields → None
-        assert!(read_runner_status(dir.path()).await.is_none());
+        // Missing required fields -> parse error.
+        assert!(read_runner_status(dir.path()).await.is_err());
     }
 
     #[tokio::test]
@@ -1180,7 +1226,7 @@ mod tests {
         tokio::fs::write(dir.path().join("status.json"), s)
             .await
             .unwrap();
-        assert!(read_runner_status(dir.path()).await.is_none());
+        assert!(read_runner_status(dir.path()).await.is_err());
     }
 
     #[tokio::test]

--- a/crates/runner/src/cmd/service.rs
+++ b/crates/runner/src/cmd/service.rs
@@ -401,6 +401,17 @@ struct RunnerStatusSnapshot {
     uptime: std::time::Duration,
 }
 
+fn status_field_preview(value: &str) -> String {
+    const MAX_CHARS: usize = 128;
+    let mut chars = value.chars();
+    let preview = chars.by_ref().take(MAX_CHARS).collect::<String>();
+    if chars.next().is_some() {
+        format!("{preview}...[truncated]")
+    } else {
+        preview
+    }
+}
+
 #[derive(Debug)]
 enum RunnerStatusReadError {
     Read {
@@ -423,7 +434,11 @@ impl std::fmt::Display for RunnerStatusReadError {
             Self::Read { path, error } => write!(f, "read {}: {error}", path.display()),
             Self::ParseJson { path, error } => write!(f, "parse {}: {error}", path.display()),
             Self::ParseStartedAt { started_at, error } => {
-                write!(f, "parse started_at {started_at:?}: {error}")
+                write!(
+                    f,
+                    "parse started_at {:?}: {error}",
+                    status_field_preview(started_at)
+                )
             }
         }
     }
@@ -1202,6 +1217,24 @@ mod tests {
     // -----------------------------------------------------------------
     // status.json reader
     // -----------------------------------------------------------------
+
+    #[test]
+    fn status_field_preview_bounds_long_values_on_char_boundary() {
+        let exact = "x".repeat(128);
+        assert_eq!(status_field_preview(&exact), exact);
+
+        let long_ascii = "x".repeat(129);
+        assert_eq!(
+            status_field_preview(&long_ascii),
+            format!("{}...[truncated]", "x".repeat(128))
+        );
+
+        let long_unicode = "界".repeat(129);
+        assert_eq!(
+            status_field_preview(&long_unicode),
+            format!("{}...[truncated]", "界".repeat(128))
+        );
+    }
 
     #[tokio::test]
     async fn read_runner_status_missing_file() {

--- a/crates/runner/src/cmd/service.rs
+++ b/crates/runner/src/cmd/service.rs
@@ -1263,6 +1263,26 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn read_runner_status_malformed_long_started_at_error_is_bounded() {
+        let dir = tempfile::tempdir().unwrap();
+        let started_at = "x".repeat(512);
+        let s = format!(r#"{{"mode":"running","active_runs":[],"started_at":"{started_at}"}}"#);
+        tokio::fs::write(dir.path().join("status.json"), s)
+            .await
+            .unwrap();
+
+        let err = match read_runner_status(dir.path()).await {
+            Ok(_) => panic!("expected malformed started_at to fail"),
+            Err(err) => err,
+        };
+        let message = err.to_string();
+
+        assert!(message.contains(&"x".repeat(128)));
+        assert!(message.contains("...[truncated]"));
+        assert!(!message.contains(&"x".repeat(129)));
+    }
+
+    #[tokio::test]
     async fn read_runner_status_running_no_jobs() {
         let dir = tempfile::tempdir().unwrap();
         let s = r#"{"mode":"running","active_runs":[],"started_at":"2026-04-13T00:00:00.000Z"}"#;

--- a/crates/runner/src/cmd/start/idle_lifecycle.rs
+++ b/crates/runner/src/cmd/start/idle_lifecycle.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use sandbox::SandboxId;
 use tokio::task::JoinSet;
-use tracing::{debug, info, warn};
+use tracing::{info, warn};
 
 use crate::idle_pool::{
     DestroyOutcome, IdleDestroyJob, IdleDestroyPayload, IdlePool, IdlePoolSnapshot,
@@ -95,7 +95,7 @@ pub(super) async fn set_idle_status_snapshot(status: &StatusTracker, snapshot: I
         .set_idle_info_at_revision(snapshot.revision, snapshot.idle_vms)
         .await;
     if !applied {
-        debug!(
+        info!(
             revision = snapshot.revision,
             "ignored stale idle pool status snapshot"
         );
@@ -117,7 +117,7 @@ pub(super) async fn add_run_with_idle_status_snapshot(
         )
         .await;
     if !applied {
-        debug!(
+        info!(
             revision = snapshot.revision,
             "ignored stale idle pool status snapshot while adding active run"
         );

--- a/crates/runner/src/network_log_manager.rs
+++ b/crates/runner/src/network_log_manager.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 #[cfg(test)]
 use tokio::sync::Semaphore;
 use tokio::sync::{Mutex, Notify};
-use tracing::{debug, warn};
+use tracing::warn;
 
 use crate::ids::RunId;
 use crate::network_log_drain::{NetworkLogDrainContext, NetworkLogDrainCoordinator};
@@ -288,7 +288,7 @@ impl NetworkLogManager {
             match result {
                 Ok(Ok(())) => {}
                 Ok(Err(e)) => {
-                    debug!(path = %path.display(), error = %e, "failed to write network log");
+                    warn!(path = %path.display(), error = %e, "failed to write network log")
                 }
                 Err(e) => {
                     warn!(path = %path.display(), error = %e, "network log writer task failed");
@@ -303,12 +303,12 @@ impl NetworkLogManager {
         let notify = {
             let mut state = self.inner.state.lock().await;
             let Some(path_state) = state.pending_paths.get_mut(&path) else {
-                debug!(path = %path.display(), "network log write completed for unknown path");
+                warn!(path = %path.display(), "network log write completed for unknown path");
                 return;
             };
 
             if path_state.pending == 0 {
-                debug!(path = %path.display(), "network log pending count already zero");
+                warn!(path = %path.display(), "network log pending count already zero");
                 return;
             }
 

--- a/crates/runner/src/paths.rs
+++ b/crates/runner/src/paths.rs
@@ -51,13 +51,13 @@ pub(crate) fn short_digest(s: &str) -> String {
 /// Update a directory's mtime to now, so `runner gc` treats it as recently used.
 pub fn touch_mtime(dir: &Path) {
     let Ok(f) = std::fs::File::open(dir) else {
-        tracing::debug!("touch_mtime: cannot open {}", dir.display());
+        tracing::warn!("touch_mtime: cannot open {}", dir.display());
         return;
     };
     if let Err(e) =
         f.set_times(std::fs::FileTimes::new().set_modified(std::time::SystemTime::now()))
     {
-        tracing::debug!("touch_mtime: set_times failed for {}: {e}", dir.display());
+        tracing::warn!("touch_mtime: set_times failed for {}: {e}", dir.display());
     }
 }
 

--- a/crates/runner/src/storage_cache.rs
+++ b/crates/runner/src/storage_cache.rs
@@ -33,7 +33,7 @@ use reqwest::Client;
 use sandbox::Sandbox;
 use tokio::fs;
 use tokio::io::AsyncReadExt as _;
-use tracing::{debug, warn};
+use tracing::{info, warn};
 
 use crate::error::{RunnerError, RunnerResult};
 use crate::lock;
@@ -272,7 +272,7 @@ async fn process_one(
         }
     };
     if size > CACHE_MAX_SIZE {
-        debug!(
+        info!(
             name = %target.name,
             version = %target.version,
             size,


### PR DESCRIPTION
## Summary
- promote runner diagnostics that explain production cleanup, status, cache, and network-log failures to visible info/warn levels
- keep high-frequency/no-op GC details at debug to avoid normal-path log noise
- return structured status.json read errors so active-jobs gate and resume preflight log the concrete reason

## Tests
- cargo fmt --manifest-path crates/Cargo.toml --all --check
- cargo test --manifest-path crates/Cargo.toml -p runner --bin runner read_runner_status
- cargo test --manifest-path crates/Cargo.toml -p runner --bin runner
- cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features -- -D warnings
- pre-commit cargo-fmt / cargo-clippy / cargo-doc

Closes #12901