### PR TITLE
chore: tune nbd-cow log levels

### DIFF
--- a/crates/nbd-cow/src/bin/bench.rs
+++ b/crates/nbd-cow/src/bin/bench.rs
@@ -215,7 +215,6 @@ async fn run_nbd_cow_bench(
     eprintln!("  NBD module loaded, setting up NBD COW device...");
 
     let device_pool = DevicePoolHandle::new(nbd_cow::pool::DevicePoolConfig::default());
-    device_pool.warmup().await;
 
     for wl in workloads {
         let cow_path = work_dir.join("nbd-cow.img");

--- a/crates/nbd-cow/src/pool.rs
+++ b/crates/nbd-cow/src/pool.rs
@@ -183,9 +183,6 @@ impl LeaseReturnOperation {
 }
 
 enum DevicePoolCommand {
-    Warmup {
-        done: oneshot::Sender<()>,
-    },
     Acquire {
         respond_to: oneshot::Sender<Result<DeviceLease>>,
     },
@@ -236,18 +233,6 @@ impl DevicePoolHandle {
             .run(),
         );
         Self { commands }
-    }
-
-    /// Compatibility hook for older callers. Allocation is demand-only.
-    pub async fn warmup(&self) {
-        let (done, done_rx) = oneshot::channel();
-        if self
-            .commands
-            .send(DevicePoolCommand::Warmup { done })
-            .is_ok()
-        {
-            let _ = done_rx.await;
-        }
     }
 
     /// Clean up the underlying pool.
@@ -376,10 +361,6 @@ impl DevicePoolActor {
 
     async fn handle_command(&mut self, command: DevicePoolCommand) {
         match command {
-            DevicePoolCommand::Warmup { done } => {
-                self.pool.warmup();
-                let _ = done.send(());
-            }
             DevicePoolCommand::Acquire { respond_to } => {
                 self.pool.handle_acquire(respond_to);
             }
@@ -491,13 +472,6 @@ impl DevicePool {
         }
     }
 
-    /// Compatibility no-op. Allocation happens on demand.
-    fn warmup(&mut self) {
-        if self.active {
-            tracing::debug!(max_devices = self.max_devices, "device pool warmup skipped");
-        }
-    }
-
     fn handle_acquire(&mut self, respond_to: oneshot::Sender<Result<DeviceLease>>) {
         if !self.active {
             let _ = respond_to.send(Err(NbdCowError::NoFreeDevice));
@@ -564,7 +538,7 @@ impl DevicePool {
         match scan {
             Some(Ok(Ok(claim))) => {
                 if self.is_tracked(claim.index()) {
-                    tracing::debug!(
+                    tracing::warn!(
                         device_index = claim.index(),
                         "dropping scan result because index is already tracked"
                     );
@@ -746,7 +720,7 @@ impl DevicePool {
             return;
         }
         if !(self.device_appears_free)(index) {
-            tracing::debug!(
+            tracing::info!(
                 device_index = index,
                 "dropping expired NBD cooldown claim because device is not free"
             );
@@ -830,7 +804,7 @@ where
             }
             Ok(None) => {}
             Err(e) => {
-                tracing::debug!(
+                tracing::warn!(
                     device_index = i,
                     error = %e,
                     "cannot acquire NBD device lock, skipping index"
@@ -1071,19 +1045,6 @@ mod tests {
 
         drop(lease);
         assert!(weak_commands.upgrade().is_none());
-    }
-
-    #[tokio::test]
-    async fn warmup_after_cleanup_does_not_restart_pool() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        let mut pool = test_pool_for_pending_scan(dir.path());
-
-        pool.cleanup().await;
-        pool.warmup();
-
-        assert!(!pool.active);
-        assert!(pool.pending.is_empty());
-        assert!(pool.cooldown.is_empty());
     }
 
     #[tokio::test]

--- a/crates/nbd-cow/tests/integration.rs
+++ b/crates/nbd-cow/tests/integration.rs
@@ -656,32 +656,6 @@ async fn pool_release_and_reacquire_after_cooldown() {
     pool.cleanup().await;
 }
 
-/// Pool warmup should leave the public pooled-device path usable.
-#[tokio::test(flavor = "multi_thread")]
-#[ignore]
-async fn pool_warmup_allows_pooled_create() {
-    require_root!();
-    require_nbd!();
-
-    let pool = nbd_cow::pool::DevicePoolHandle::new(nbd_cow::pool::DevicePoolConfig::default());
-    pool.warmup().await;
-
-    let tmp = tempfile::tempdir().expect("tempdir");
-    let base = tmp.path().join("base.img");
-    create_test_base_image(&base);
-    let cow = tmp.path().join("cow.img");
-    let device = pool
-        .create_cow_device(&base, &cow, 64 * 1024 * 1024)
-        .await
-        .expect("create after warmup");
-
-    device
-        .destroy_with_retries(destroy_policy())
-        .await
-        .expect("destroy after warmup");
-    pool.cleanup().await;
-}
-
 /// After cleanup(), acquire must return NoFreeDevice immediately.
 /// This is a pure-logic test — no root or nbd module required.
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/sandbox-fc/src/runtime.rs
+++ b/crates/sandbox-fc/src/runtime.rs
@@ -50,7 +50,6 @@ impl FirecrackerRuntime {
 
         let t = std::time::Instant::now();
         let device_pool = DevicePoolHandle::new(DevicePoolConfig::default());
-        device_pool.warmup().await;
         info!(
             elapsed_ms = t.elapsed().as_millis() as u64,
             "runtime device pool created"

--- a/crates/sandbox-fc/src/snapshot.rs
+++ b/crates/sandbox-fc/src/snapshot.rs
@@ -1774,7 +1774,6 @@ async fn create_uncommitted_snapshot(
 
     let device_pool =
         nbd_cow::pool::DevicePoolHandle::new(nbd_cow::pool::DevicePoolConfig::default());
-    device_pool.warmup().await;
     let cow_device = device_pool
         .create_cow_device(&config.rootfs_path, &cow_file, base_size)
         .await


### PR DESCRIPTION
## Summary

- remove the no-op NBD device pool warmup API and call sites
- surface actionable NBD pool anomalies at info/warn instead of debug
- remove the obsolete warmup-only integration test

Closes #12902

## Tests

- cargo fmt --manifest-path crates/Cargo.toml --all -- --check
- cargo test --manifest-path crates/Cargo.toml -p nbd-cow --lib
- cargo clippy --manifest-path crates/Cargo.toml -p nbd-cow -p sandbox-fc --all-targets -- -D warnings
- pre-commit hook: cargo-fmt, cargo-clippy, cargo-doc