### PR TITLE
refactor: migrate zero usage GET routes to api

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -63,6 +63,8 @@ import { zeroTeamRoutes } from "./routes/zero-team";
 import { zeroUploadsCompleteRoutes } from "./routes/zero-uploads-complete";
 import { zeroUploadsPrepareRoutes } from "./routes/zero-uploads-prepare";
 import { zeroUsageInsightRoutes } from "./routes/zero-usage-insight";
+import { zeroUsageMembersRoutes } from "./routes/zero-usage-members";
+import { zeroUsageRunsRoutes } from "./routes/zero-usage-runs";
 import { zeroUserPreferencesRoutes } from "./routes/zero-user-preferences";
 import { zeroUserModelPreferenceRoutes } from "./routes/zero-user-model-preference";
 import { zeroVoiceChatRoutes } from "./routes/zero-voice-chat";
@@ -143,6 +145,8 @@ export const ROUTES: readonly RouteEntry[] = [
   ...zeroUploadsCompleteRoutes,
   ...zeroUploadsPrepareRoutes,
   ...zeroUsageInsightRoutes,
+  ...zeroUsageMembersRoutes,
+  ...zeroUsageRunsRoutes,
   ...chatThreadsV1Routes,
   ...audioTranscriptionsV1Routes,
   ...modelStatsRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-usage.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-usage.ts
@@ -1,0 +1,434 @@
+import { randomUUID } from "node:crypto";
+
+import { command } from "ccstate";
+import {
+  agentComposes,
+  agentComposeVersions,
+} from "@vm0/db/schema/agent-compose";
+import { agentRuns } from "@vm0/db/schema/agent-run";
+import { agentSessions } from "@vm0/db/schema/agent-session";
+import { orgMembersMetadata } from "@vm0/db/schema/org-members-metadata";
+import { orgMetadata } from "@vm0/db/schema/org-metadata";
+import { usageEvent } from "@vm0/db/schema/usage-event";
+import { userCache } from "@vm0/db/schema/user-cache";
+import { zeroAgents } from "@vm0/db/schema/zero-agent";
+import { zeroRuns } from "@vm0/db/schema/zero-run";
+import { eq, inArray } from "drizzle-orm";
+
+import { nowDate } from "../../../../lib/time";
+import { writeDb$ } from "../../../external/db";
+
+export const REALTIME_PROVIDER = "gpt-realtime-2";
+export const TRANSCRIPTION_PROVIDER = "gpt-4o-mini-transcribe";
+
+export const REALTIME_TOKEN_CATEGORIES = [
+  "tokens.input.text",
+  "tokens.input.audio",
+  "tokens.input.cached_text",
+  "tokens.input.cached_audio",
+  "tokens.output.text",
+  "tokens.output.audio",
+] as const;
+
+export const TRANSCRIPTION_TOKEN_CATEGORIES = [
+  "tokens.input.audio",
+  "tokens.input.text",
+  "tokens.output.text",
+] as const;
+
+export interface UsageFixture {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly userIds: readonly string[];
+}
+
+interface SeedUsageFixtureArgs {
+  readonly currentPeriodEnd?: Date | null;
+  readonly tier?: string;
+}
+
+interface SetCreditCapArgs {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly creditCap: number | null;
+}
+
+interface InsertUsageEventArgs {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly runId?: string | null;
+  readonly kind?: string;
+  readonly provider?: string;
+  readonly category?: string;
+  readonly quantity?: number;
+  readonly creditsCharged?: number | null;
+  readonly status?: string;
+  readonly processedAt?: Date | null;
+}
+
+interface InsertModelUsageArgs {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly runId?: string | null;
+  readonly inputTokens?: number;
+  readonly outputTokens?: number;
+  readonly cacheReadInputTokens?: number;
+  readonly cacheCreationInputTokens?: number;
+  readonly creditsCharged?: number | null;
+  readonly status?: string;
+  readonly processedAt?: Date | null;
+}
+
+interface SeedRunArgs {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly displayName?: string | null;
+  readonly prompt?: string;
+  readonly status?: string;
+  readonly triggerSource?: string;
+  readonly createdAt?: Date;
+  readonly startedAt?: Date | null;
+  readonly completedAt?: Date | null;
+}
+
+export const seedUsageFixture$ = command(
+  async (
+    { set },
+    args: SeedUsageFixtureArgs,
+    signal: AbortSignal,
+  ): Promise<UsageFixture> => {
+    const db = set(writeDb$);
+    const orgId = `org_${randomUUID()}`;
+    const userId = `user_${randomUUID()}`;
+
+    await db.insert(orgMetadata).values({
+      orgId,
+      tier: args.tier ?? "free",
+      currentPeriodEnd: args.currentPeriodEnd ?? null,
+      stripeCustomerId: args.currentPeriodEnd ? `cus_${randomUUID()}` : null,
+      stripeSubscriptionId: args.currentPeriodEnd
+        ? `sub_${randomUUID()}`
+        : null,
+      subscriptionStatus: args.currentPeriodEnd ? "active" : null,
+    });
+    signal.throwIfAborted();
+
+    return { orgId, userId, userIds: [userId] };
+  },
+);
+
+export const deleteUsageFixture$ = command(
+  async (
+    { set },
+    fixture: UsageFixture,
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const db = set(writeDb$);
+
+    const usageUserRows = await db
+      .select({ userId: usageEvent.userId })
+      .from(usageEvent)
+      .where(eq(usageEvent.orgId, fixture.orgId));
+    signal.throwIfAborted();
+
+    await db.delete(usageEvent).where(eq(usageEvent.orgId, fixture.orgId));
+    signal.throwIfAborted();
+
+    const runRows = await db
+      .select({ id: agentRuns.id, userId: agentRuns.userId })
+      .from(agentRuns)
+      .where(eq(agentRuns.orgId, fixture.orgId));
+    signal.throwIfAborted();
+    const runIds = runRows.map((row) => {
+      return row.id;
+    });
+    if (runIds.length > 0) {
+      await db.delete(agentRuns).where(inArray(agentRuns.id, runIds));
+      signal.throwIfAborted();
+    }
+
+    await db
+      .delete(agentSessions)
+      .where(eq(agentSessions.orgId, fixture.orgId));
+    signal.throwIfAborted();
+
+    const composeRows = await db
+      .select({ id: agentComposes.id })
+      .from(agentComposes)
+      .where(eq(agentComposes.orgId, fixture.orgId));
+    signal.throwIfAborted();
+    const composeIds = composeRows.map((row) => {
+      return row.id;
+    });
+    if (composeIds.length > 0) {
+      await db
+        .delete(agentComposeVersions)
+        .where(inArray(agentComposeVersions.composeId, composeIds));
+      signal.throwIfAborted();
+      await db.delete(zeroAgents).where(inArray(zeroAgents.id, composeIds));
+      signal.throwIfAborted();
+      await db
+        .delete(agentComposes)
+        .where(inArray(agentComposes.id, composeIds));
+      signal.throwIfAborted();
+    }
+
+    const memberRows = await db
+      .select({ userId: orgMembersMetadata.userId })
+      .from(orgMembersMetadata)
+      .where(eq(orgMembersMetadata.orgId, fixture.orgId));
+    signal.throwIfAborted();
+
+    await db
+      .delete(orgMembersMetadata)
+      .where(eq(orgMembersMetadata.orgId, fixture.orgId));
+    signal.throwIfAborted();
+
+    await db.delete(orgMetadata).where(eq(orgMetadata.orgId, fixture.orgId));
+    signal.throwIfAborted();
+
+    const userIds = [
+      ...new Set([
+        ...fixture.userIds,
+        ...usageUserRows.map((row) => {
+          return row.userId;
+        }),
+        ...runRows.map((row) => {
+          return row.userId;
+        }),
+        ...memberRows.map((row) => {
+          return row.userId;
+        }),
+      ]),
+    ];
+    if (userIds.length > 0) {
+      await db.delete(userCache).where(inArray(userCache.userId, userIds));
+      signal.throwIfAborted();
+    }
+  },
+);
+
+export const setMemberCreditCap$ = command(
+  async (
+    { set },
+    args: SetCreditCapArgs,
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const db = set(writeDb$);
+    await db
+      .insert(orgMembersMetadata)
+      .values({
+        orgId: args.orgId,
+        userId: args.userId,
+        creditCap: args.creditCap,
+      })
+      .onConflictDoUpdate({
+        target: [orgMembersMetadata.orgId, orgMembersMetadata.userId],
+        set: { creditCap: args.creditCap },
+      });
+    signal.throwIfAborted();
+  },
+);
+
+export const insertUsageEvent$ = command(
+  async (
+    { set },
+    args: InsertUsageEventArgs,
+    signal: AbortSignal,
+  ): Promise<string> => {
+    const db = set(writeDb$);
+    const status = args.status ?? "processed";
+    const processedAt =
+      args.processedAt !== undefined
+        ? args.processedAt
+        : status === "processed"
+          ? nowDate()
+          : null;
+    const [row] = await db
+      .insert(usageEvent)
+      .values({
+        runId: args.runId ?? null,
+        orgId: args.orgId,
+        userId: args.userId,
+        kind: args.kind ?? "connector",
+        provider: args.provider ?? "x",
+        category: args.category ?? "tweet.read",
+        quantity: args.quantity ?? 1,
+        creditsCharged: args.creditsCharged ?? null,
+        status,
+        processedAt,
+        idempotencyKey: randomUUID(),
+      })
+      .returning({ id: usageEvent.id });
+    signal.throwIfAborted();
+    if (!row) {
+      throw new Error("insertUsageEvent$: insert returned no row");
+    }
+    return row.id;
+  },
+);
+
+export const insertModelUsage$ = command(
+  async (
+    { set },
+    args: InsertModelUsageArgs,
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const db = set(writeDb$);
+    const status = args.status ?? "processed";
+    const processedAt =
+      args.processedAt !== undefined
+        ? args.processedAt
+        : status === "processed"
+          ? nowDate()
+          : null;
+    const rows: (typeof usageEvent.$inferInsert)[] = [
+      {
+        runId: args.runId ?? null,
+        orgId: args.orgId,
+        userId: args.userId,
+        kind: "model",
+        provider: "claude-sonnet-4-6",
+        category: "tokens.input",
+        quantity: args.inputTokens ?? 0,
+        creditsCharged: args.creditsCharged ?? null,
+        status,
+        processedAt,
+        idempotencyKey: randomUUID(),
+      },
+      {
+        runId: args.runId ?? null,
+        orgId: args.orgId,
+        userId: args.userId,
+        kind: "model",
+        provider: "claude-sonnet-4-6",
+        category: "tokens.output",
+        quantity: args.outputTokens ?? 0,
+        creditsCharged: null,
+        status,
+        processedAt,
+        idempotencyKey: randomUUID(),
+      },
+      {
+        runId: args.runId ?? null,
+        orgId: args.orgId,
+        userId: args.userId,
+        kind: "model",
+        provider: "claude-sonnet-4-6",
+        category: "tokens.cache_read",
+        quantity: args.cacheReadInputTokens ?? 0,
+        creditsCharged: null,
+        status,
+        processedAt,
+        idempotencyKey: randomUUID(),
+      },
+      {
+        runId: args.runId ?? null,
+        orgId: args.orgId,
+        userId: args.userId,
+        kind: "model",
+        provider: "claude-sonnet-4-6",
+        category: "tokens.cache_creation",
+        quantity: args.cacheCreationInputTokens ?? 0,
+        creditsCharged: null,
+        status,
+        processedAt,
+        idempotencyKey: randomUUID(),
+      },
+    ];
+
+    await db.insert(usageEvent).values(rows);
+    signal.throwIfAborted();
+  },
+);
+
+export const seedRun$ = command(
+  async (
+    { set },
+    args: SeedRunArgs,
+    signal: AbortSignal,
+  ): Promise<{ runId: string; composeId: string }> => {
+    const db = set(writeDb$);
+    const composeName = `usage-${randomUUID().slice(0, 8)}`;
+    const [compose] = await db
+      .insert(agentComposes)
+      .values({
+        userId: args.userId,
+        orgId: args.orgId,
+        name: composeName,
+        createdAt: args.createdAt,
+      })
+      .returning({ id: agentComposes.id });
+    signal.throwIfAborted();
+    if (!compose) {
+      throw new Error("seedRun$: compose insert returned no row");
+    }
+
+    await db.insert(zeroAgents).values({
+      id: compose.id,
+      orgId: args.orgId,
+      owner: args.userId,
+      name: composeName,
+      displayName: args.displayName ?? null,
+    });
+    signal.throwIfAborted();
+
+    const versionId = randomUUID();
+    await db.insert(agentComposeVersions).values({
+      id: versionId,
+      composeId: compose.id,
+      content: {
+        version: "1.0",
+        agents: { "test-agent": { framework: "claude-code" } },
+      },
+      createdBy: args.userId,
+    });
+    signal.throwIfAborted();
+
+    await db
+      .update(agentComposes)
+      .set({ headVersionId: versionId })
+      .where(eq(agentComposes.id, compose.id));
+    signal.throwIfAborted();
+
+    const [session] = await db
+      .insert(agentSessions)
+      .values({
+        userId: args.userId,
+        orgId: args.orgId,
+        agentComposeId: compose.id,
+      })
+      .returning({ id: agentSessions.id });
+    signal.throwIfAborted();
+    if (!session) {
+      throw new Error("seedRun$: session insert returned no row");
+    }
+
+    const [run] = await db
+      .insert(agentRuns)
+      .values({
+        userId: args.userId,
+        orgId: args.orgId,
+        agentComposeVersionId: versionId,
+        prompt: args.prompt ?? "test prompt",
+        status: args.status ?? "completed",
+        sessionId: session.id,
+        createdAt: args.createdAt,
+        startedAt: args.startedAt,
+        completedAt: args.completedAt,
+      })
+      .returning({ id: agentRuns.id });
+    signal.throwIfAborted();
+    if (!run) {
+      throw new Error("seedRun$: run insert returned no row");
+    }
+
+    await db.insert(zeroRuns).values({
+      id: run.id,
+      triggerSource: args.triggerSource ?? "cli",
+    });
+    signal.throwIfAborted();
+
+    return { runId: run.id, composeId: compose.id };
+  },
+);

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-usage-members.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-usage-members.test.ts
@@ -1,0 +1,529 @@
+import { randomUUID } from "node:crypto";
+
+import { zeroUsageMembersContract } from "@vm0/api-contracts/contracts/zero-usage";
+import { createStore } from "ccstate";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { nowDate } from "../../../lib/time";
+import {
+  createFixtureTracker,
+  createZeroRouteMocks,
+} from "./helpers/zero-route-test";
+import {
+  deleteUsageFixture$,
+  insertModelUsage$,
+  insertUsageEvent$,
+  REALTIME_PROVIDER,
+  REALTIME_TOKEN_CATEGORIES,
+  seedUsageFixture$,
+  setMemberCreditCap$,
+  TRANSCRIPTION_PROVIDER,
+  TRANSCRIPTION_TOKEN_CATEGORIES,
+  type UsageFixture,
+} from "./helpers/zero-usage";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+
+function authHeaders() {
+  return { authorization: "Bearer clerk-session" };
+}
+
+function apiClient() {
+  return setupApp({ context })(zeroUsageMembersContract);
+}
+
+function periodEndFromNow(): Date {
+  return new Date(nowDate().getTime() + 30 * 24 * 60 * 60 * 1000);
+}
+
+function userIdsFromClerkRequest(args: unknown): string[] {
+  if (typeof args !== "object" || args === null) {
+    return [];
+  }
+  const value = Reflect.get(args, "userId");
+  if (
+    Array.isArray(value) &&
+    value.every((item): item is string => {
+      return typeof item === "string";
+    })
+  ) {
+    return value;
+  }
+  return [];
+}
+
+function clerkUser(userId: string) {
+  const emailId = `email_${userId}`;
+  return {
+    id: userId,
+    primaryEmailAddressId: emailId,
+    emailAddresses: [{ id: emailId, emailAddress: `${userId}@example.com` }],
+  };
+}
+
+function mockClerkUserLookup(): void {
+  context.mocks.clerk.users.getUserList.mockImplementation((args: unknown) => {
+    return Promise.resolve({
+      data: userIdsFromClerkRequest(args).map((userId) => {
+        return clerkUser(userId);
+      }),
+    });
+  });
+}
+
+describe("GET /api/zero/usage/members", () => {
+  const track = createFixtureTracker<UsageFixture>((fixture) => {
+    return store.set(deleteUsageFixture$, fixture, context.signal);
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    const response = await accept(apiClient().get({ headers: {} }), [401]);
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("returns empty result for free tier org with no billing period", async () => {
+    const fixture = await track(
+      store.set(seedUsageFixture$, { currentPeriodEnd: null }, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      apiClient().get({ headers: authHeaders() }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({ period: null, members: [] });
+  });
+
+  it("returns aggregated usage for a single user with processed records", async () => {
+    mockClerkUserLookup();
+    const fixture = await track(
+      store.set(
+        seedUsageFixture$,
+        { currentPeriodEnd: periodEndFromNow(), tier: "pro" },
+        context.signal,
+      ),
+    );
+    await store.set(
+      setMemberCreditCap$,
+      { orgId: fixture.orgId, userId: fixture.userId, creditCap: 250 },
+      context.signal,
+    );
+    await store.set(
+      insertModelUsage$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        inputTokens: 1000,
+        outputTokens: 500,
+        cacheReadInputTokens: 200,
+        cacheCreationInputTokens: 100,
+        creditsCharged: 50,
+      },
+      context.signal,
+    );
+    await store.set(
+      insertModelUsage$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        inputTokens: 2000,
+        outputTokens: 1000,
+        cacheReadInputTokens: 300,
+        cacheCreationInputTokens: 150,
+        creditsCharged: 100,
+      },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      apiClient().get({ headers: authHeaders() }),
+      [200],
+    );
+
+    expect(response.body.period).not.toBeNull();
+    expect(response.body.members).toHaveLength(1);
+    expect(response.body.members[0]).toMatchObject({
+      userId: fixture.userId,
+      email: `${fixture.userId}@example.com`,
+      inputTokens: 3000,
+      outputTokens: 1500,
+      cacheReadInputTokens: 500,
+      cacheCreationInputTokens: 250,
+      creditsCharged: 150,
+      creditCap: 250,
+    });
+  });
+
+  it("returns separate aggregation for multiple users sorted by credits", async () => {
+    mockClerkUserLookup();
+    const fixture = await track(
+      store.set(
+        seedUsageFixture$,
+        { currentPeriodEnd: periodEndFromNow(), tier: "pro" },
+        context.signal,
+      ),
+    );
+    const user1 = `user_${randomUUID()}`;
+    const user2 = `user_${randomUUID()}`;
+    await store.set(
+      insertModelUsage$,
+      {
+        orgId: fixture.orgId,
+        userId: user1,
+        inputTokens: 1000,
+        outputTokens: 500,
+        creditsCharged: 50,
+      },
+      context.signal,
+    );
+    await store.set(
+      insertModelUsage$,
+      {
+        orgId: fixture.orgId,
+        userId: user2,
+        inputTokens: 3000,
+        outputTokens: 1500,
+        creditsCharged: 200,
+      },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      apiClient().get({ headers: authHeaders() }),
+      [200],
+    );
+
+    expect(response.body.members).toHaveLength(2);
+    expect(response.body.members[0]?.userId).toBe(user2);
+    expect(response.body.members[0]?.creditsCharged).toBe(200);
+    expect(response.body.members[1]?.userId).toBe(user1);
+    expect(response.body.members[1]?.creditsCharged).toBe(50);
+  });
+
+  it("excludes pending records from aggregation", async () => {
+    mockClerkUserLookup();
+    const fixture = await track(
+      store.set(
+        seedUsageFixture$,
+        { currentPeriodEnd: periodEndFromNow(), tier: "pro" },
+        context.signal,
+      ),
+    );
+    await store.set(
+      insertModelUsage$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        inputTokens: 1000,
+        creditsCharged: 50,
+      },
+      context.signal,
+    );
+    await store.set(
+      insertModelUsage$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        inputTokens: 5000,
+        creditsCharged: 0,
+        status: "pending",
+      },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      apiClient().get({ headers: authHeaders() }),
+      [200],
+    );
+
+    expect(response.body.members).toHaveLength(1);
+    expect(response.body.members[0]).toMatchObject({
+      inputTokens: 1000,
+      creditsCharged: 50,
+    });
+  });
+
+  it("includes processed usage_event records in member totals", async () => {
+    mockClerkUserLookup();
+    const fixture = await track(
+      store.set(
+        seedUsageFixture$,
+        { currentPeriodEnd: periodEndFromNow(), tier: "pro" },
+        context.signal,
+      ),
+    );
+    await store.set(
+      insertModelUsage$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        inputTokens: 1000,
+        outputTokens: 500,
+        cacheReadInputTokens: 200,
+        cacheCreationInputTokens: 100,
+        creditsCharged: 50,
+      },
+      context.signal,
+    );
+    await store.set(
+      insertUsageEvent$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        kind: "model",
+        provider: "claude-sonnet-4-6",
+        category: "tokens.input",
+        quantity: 300,
+        creditsCharged: 30,
+      },
+      context.signal,
+    );
+    await store.set(
+      insertUsageEvent$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        kind: "model",
+        provider: "claude-sonnet-4-6",
+        category: "tokens.output",
+        quantity: 120,
+        creditsCharged: 12,
+      },
+      context.signal,
+    );
+    await store.set(
+      insertUsageEvent$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        kind: "model",
+        provider: "claude-sonnet-4-6",
+        category: "tokens.cache_read",
+        quantity: 80,
+        creditsCharged: 8,
+      },
+      context.signal,
+    );
+    await store.set(
+      insertUsageEvent$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        kind: "model",
+        provider: "claude-sonnet-4-6",
+        category: "tokens.cache_creation",
+        quantity: 40,
+        creditsCharged: 4,
+      },
+      context.signal,
+    );
+    await store.set(
+      insertUsageEvent$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        creditsCharged: 20,
+      },
+      context.signal,
+    );
+    await store.set(
+      insertUsageEvent$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        kind: "model",
+        provider: "claude-sonnet-4-6",
+        category: "tokens.input",
+        quantity: 9999,
+        creditsCharged: 999,
+        status: "pending",
+      },
+      context.signal,
+    );
+    const eventOnlyUserId = `user_${randomUUID()}`;
+    await store.set(
+      insertUsageEvent$,
+      {
+        orgId: fixture.orgId,
+        userId: eventOnlyUserId,
+        creditsCharged: 200,
+      },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      apiClient().get({ headers: authHeaders() }),
+      [200],
+    );
+
+    expect(response.body.members).toHaveLength(2);
+    const mixedMember = response.body.members.find((member) => {
+      return member.userId === fixture.userId;
+    });
+    expect(mixedMember).toMatchObject({
+      inputTokens: 1300,
+      outputTokens: 620,
+      cacheReadInputTokens: 280,
+      cacheCreationInputTokens: 140,
+      creditsCharged: 124,
+    });
+
+    const eventOnlyMember = response.body.members.find((member) => {
+      return member.userId === eventOnlyUserId;
+    });
+    expect(eventOnlyMember).toMatchObject({
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheReadInputTokens: 0,
+      cacheCreationInputTokens: 0,
+      creditsCharged: 200,
+    });
+  });
+
+  it("rolls up Realtime and transcription categories into flat token totals", async () => {
+    mockClerkUserLookup();
+    const fixture = await track(
+      store.set(
+        seedUsageFixture$,
+        { currentPeriodEnd: periodEndFromNow(), tier: "pro" },
+        context.signal,
+      ),
+    );
+    const realtimeQuantities: Record<
+      (typeof REALTIME_TOKEN_CATEGORIES)[number],
+      number
+    > = {
+      "tokens.input.text": 100,
+      "tokens.input.audio": 200,
+      "tokens.input.cached_text": 30,
+      "tokens.input.cached_audio": 70,
+      "tokens.output.text": 40,
+      "tokens.output.audio": 60,
+    };
+    for (const category of REALTIME_TOKEN_CATEGORIES) {
+      await store.set(
+        insertUsageEvent$,
+        {
+          orgId: fixture.orgId,
+          userId: fixture.userId,
+          kind: "model",
+          provider: REALTIME_PROVIDER,
+          category,
+          quantity: realtimeQuantities[category],
+        },
+        context.signal,
+      );
+    }
+
+    const transcriptionQuantities: Record<
+      (typeof TRANSCRIPTION_TOKEN_CATEGORIES)[number],
+      number
+    > = {
+      "tokens.input.audio": 500,
+      "tokens.input.text": 25,
+      "tokens.output.text": 15,
+    };
+    for (const category of TRANSCRIPTION_TOKEN_CATEGORIES) {
+      await store.set(
+        insertUsageEvent$,
+        {
+          orgId: fixture.orgId,
+          userId: fixture.userId,
+          kind: "model",
+          provider: TRANSCRIPTION_PROVIDER,
+          category,
+          quantity: transcriptionQuantities[category],
+        },
+        context.signal,
+      );
+    }
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      apiClient().get({ headers: authHeaders() }),
+      [200],
+    );
+
+    expect(response.body.members).toHaveLength(1);
+    expect(response.body.members[0]).toMatchObject({
+      inputTokens: 825,
+      outputTokens: 115,
+      cacheReadInputTokens: 100,
+      cacheCreationInputTokens: 0,
+    });
+  });
+
+  it("uses processedAt for billing-period membership", async () => {
+    mockClerkUserLookup();
+    const periodEnd = new Date("2099-04-01T00:00:00.000Z");
+    const periodStart = new Date("2099-03-01T00:00:00.000Z");
+    const fixture = await track(
+      store.set(
+        seedUsageFixture$,
+        { currentPeriodEnd: periodEnd, tier: "pro" },
+        context.signal,
+      ),
+    );
+    await store.set(
+      insertModelUsage$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        inputTokens: 10,
+        outputTokens: 5,
+        creditsCharged: 10,
+        processedAt: periodStart,
+      },
+      context.signal,
+    );
+    await store.set(
+      insertModelUsage$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        inputTokens: 999,
+        outputTokens: 999,
+        creditsCharged: 999,
+        processedAt: periodEnd,
+      },
+      context.signal,
+    );
+    await store.set(
+      insertUsageEvent$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        kind: "model",
+        provider: "claude-sonnet-4-6",
+        category: "tokens.input",
+        quantity: 999,
+        creditsCharged: 999,
+        processedAt: periodEnd,
+      },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      apiClient().get({ headers: authHeaders() }),
+      [200],
+    );
+
+    expect(response.body.members).toHaveLength(1);
+    expect(response.body.members[0]).toMatchObject({
+      inputTokens: 10,
+      outputTokens: 5,
+      creditsCharged: 10,
+    });
+  });
+});

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-usage-runs.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-usage-runs.test.ts
@@ -1,0 +1,510 @@
+import { randomUUID } from "node:crypto";
+
+import { zeroUsageRunsContract } from "@vm0/api-contracts/contracts/zero-usage-daily";
+import { createStore } from "ccstate";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { nowDate } from "../../../lib/time";
+import {
+  createFixtureTracker,
+  createZeroRouteMocks,
+} from "./helpers/zero-route-test";
+import {
+  deleteUsageFixture$,
+  insertModelUsage$,
+  insertUsageEvent$,
+  seedRun$,
+  seedUsageFixture$,
+  type UsageFixture,
+} from "./helpers/zero-usage";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+
+function authHeaders() {
+  return { authorization: "Bearer clerk-session" };
+}
+
+function apiClient() {
+  return setupApp({ context })(zeroUsageRunsContract);
+}
+
+function userIdsFromClerkRequest(args: unknown): string[] {
+  if (typeof args !== "object" || args === null) {
+    return [];
+  }
+  const value = Reflect.get(args, "userId");
+  if (
+    Array.isArray(value) &&
+    value.every((item): item is string => {
+      return typeof item === "string";
+    })
+  ) {
+    return value;
+  }
+  return [];
+}
+
+function mockClerkUserLookup(): void {
+  context.mocks.clerk.users.getUserList.mockImplementation((args: unknown) => {
+    return Promise.resolve({
+      data: userIdsFromClerkRequest(args).map((userId) => {
+        const emailId = `email_${userId}`;
+        return {
+          id: userId,
+          primaryEmailAddressId: emailId,
+          emailAddresses: [
+            { id: emailId, emailAddress: `${userId}@example.com` },
+          ],
+        };
+      }),
+    });
+  });
+}
+
+function createdAt(minutesAgo: number): Date {
+  return new Date(nowDate().getTime() - minutesAgo * 60 * 1000);
+}
+
+describe("GET /api/zero/usage/runs", () => {
+  const track = createFixtureTracker<UsageFixture>((fixture) => {
+    return store.set(deleteUsageFixture$, fixture, context.signal);
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    const response = await accept(
+      apiClient().get({ query: {}, headers: {} }),
+      [401],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("returns 403 for non-admin users", async () => {
+    const fixture = await track(
+      store.set(seedUsageFixture$, {}, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:member");
+
+    const response = await accept(
+      apiClient().get({ query: {}, headers: authHeaders() }),
+      [403],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Only org admins can view run usage",
+        code: "FORBIDDEN",
+      },
+    });
+  });
+
+  it("returns empty result when no runs have processed usage events", async () => {
+    mockClerkUserLookup();
+    const fixture = await track(
+      store.set(seedUsageFixture$, {}, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      apiClient().get({ query: {}, headers: authHeaders() }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      runs: [],
+      pagination: { page: 1, pageSize: 20, total: 0 },
+    });
+  });
+
+  it("returns per-run records with credit totals", async () => {
+    mockClerkUserLookup();
+    const fixture = await track(
+      store.set(seedUsageFixture$, {}, context.signal),
+    );
+    const older = await store.set(
+      seedRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        createdAt: createdAt(10),
+      },
+      context.signal,
+    );
+    const newer = await store.set(
+      seedRun$,
+      { orgId: fixture.orgId, userId: fixture.userId, createdAt: createdAt(1) },
+      context.signal,
+    );
+    await store.set(
+      insertModelUsage$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        runId: older.runId,
+        inputTokens: 1000,
+        outputTokens: 500,
+        cacheReadInputTokens: 200,
+        cacheCreationInputTokens: 100,
+        creditsCharged: 50,
+      },
+      context.signal,
+    );
+    await store.set(
+      insertModelUsage$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        runId: newer.runId,
+        inputTokens: 2000,
+        outputTokens: 1000,
+        creditsCharged: 100,
+      },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      apiClient().get({ query: {}, headers: authHeaders() }),
+      [200],
+    );
+
+    expect(response.body.runs).toHaveLength(2);
+    expect(response.body.pagination.total).toBe(2);
+    expect(response.body.runs[0]?.runId).toBe(newer.runId);
+    expect(response.body.runs[0]?.creditsCharged).toBe(100);
+    expect(response.body.runs[1]?.runId).toBe(older.runId);
+    expect(response.body.runs[1]?.creditsCharged).toBe(50);
+  });
+
+  it("paginates results correctly", async () => {
+    mockClerkUserLookup();
+    const fixture = await track(
+      store.set(seedUsageFixture$, {}, context.signal),
+    );
+    for (let index = 0; index < 3; index++) {
+      const run = await store.set(
+        seedRun$,
+        {
+          orgId: fixture.orgId,
+          userId: fixture.userId,
+          createdAt: createdAt(10 - index),
+        },
+        context.signal,
+      );
+      await store.set(
+        insertModelUsage$,
+        {
+          orgId: fixture.orgId,
+          userId: fixture.userId,
+          runId: run.runId,
+          creditsCharged: (index + 1) * 10,
+        },
+        context.signal,
+      );
+    }
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response1 = await accept(
+      apiClient().get({
+        query: { page: 1, pageSize: 2 },
+        headers: authHeaders(),
+      }),
+      [200],
+    );
+    expect(response1.body.runs).toHaveLength(2);
+    expect(response1.body.pagination).toStrictEqual({
+      page: 1,
+      pageSize: 2,
+      total: 3,
+    });
+
+    const response2 = await accept(
+      apiClient().get({
+        query: { page: 2, pageSize: 2 },
+        headers: authHeaders(),
+      }),
+      [200],
+    );
+    expect(response2.body.runs).toHaveLength(1);
+    expect(response2.body.pagination.page).toBe(2);
+  });
+
+  it("filters by userIds", async () => {
+    mockClerkUserLookup();
+    const fixture = await track(
+      store.set(seedUsageFixture$, {}, context.signal),
+    );
+    const user1 = `user_${randomUUID()}`;
+    const user2 = `user_${randomUUID()}`;
+    const run1 = await store.set(
+      seedRun$,
+      { orgId: fixture.orgId, userId: user1, createdAt: createdAt(2) },
+      context.signal,
+    );
+    const run2 = await store.set(
+      seedRun$,
+      { orgId: fixture.orgId, userId: user2, createdAt: createdAt(1) },
+      context.signal,
+    );
+    await store.set(
+      insertModelUsage$,
+      {
+        orgId: fixture.orgId,
+        userId: user1,
+        runId: run1.runId,
+        creditsCharged: 50,
+      },
+      context.signal,
+    );
+    await store.set(
+      insertModelUsage$,
+      {
+        orgId: fixture.orgId,
+        userId: user2,
+        runId: run2.runId,
+        creditsCharged: 100,
+      },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      apiClient().get({
+        query: { userIds: ` ${user1}, ` },
+        headers: authHeaders(),
+      }),
+      [200],
+    );
+
+    expect(response.body.runs).toHaveLength(1);
+    expect(response.body.runs[0]?.userId).toBe(user1);
+    expect(response.body.runs[0]?.creditsCharged).toBe(50);
+  });
+
+  it("excludes runs with only pending usage events", async () => {
+    mockClerkUserLookup();
+    const fixture = await track(
+      store.set(seedUsageFixture$, {}, context.signal),
+    );
+    const processed = await store.set(
+      seedRun$,
+      { orgId: fixture.orgId, userId: fixture.userId, createdAt: createdAt(2) },
+      context.signal,
+    );
+    const pending = await store.set(
+      seedRun$,
+      { orgId: fixture.orgId, userId: fixture.userId, createdAt: createdAt(1) },
+      context.signal,
+    );
+    await store.set(
+      insertModelUsage$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        runId: processed.runId,
+        creditsCharged: 50,
+      },
+      context.signal,
+    );
+    await store.set(
+      insertModelUsage$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        runId: pending.runId,
+        creditsCharged: 0,
+        status: "pending",
+      },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      apiClient().get({ query: {}, headers: authHeaders() }),
+      [200],
+    );
+
+    expect(response.body.runs).toHaveLength(1);
+    expect(response.body.runs[0]?.runId).toBe(processed.runId);
+    expect(response.body.runs[0]?.creditsCharged).toBe(50);
+  });
+
+  it("returns run-linked usage_event records and excludes runless events", async () => {
+    mockClerkUserLookup();
+    const fixture = await track(
+      store.set(seedUsageFixture$, {}, context.signal),
+    );
+    const run = await store.set(
+      seedRun$,
+      { orgId: fixture.orgId, userId: fixture.userId },
+      context.signal,
+    );
+    await store.set(
+      insertUsageEvent$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        runId: run.runId,
+        kind: "model",
+        provider: "claude-sonnet-4-6",
+        category: "tokens.input",
+        quantity: 300,
+        creditsCharged: 30,
+      },
+      context.signal,
+    );
+    await store.set(
+      insertUsageEvent$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        runId: run.runId,
+        creditsCharged: 20,
+      },
+      context.signal,
+    );
+    await store.set(
+      insertUsageEvent$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        creditsCharged: 999,
+      },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      apiClient().get({ query: {}, headers: authHeaders() }),
+      [200],
+    );
+
+    expect(response.body.runs).toHaveLength(1);
+    expect(response.body.pagination.total).toBe(1);
+    expect(response.body.runs[0]).toMatchObject({
+      runId: run.runId,
+      model: "claude-sonnet-4-6",
+      inputTokens: 300,
+      outputTokens: 0,
+      cacheTokens: 0,
+      creditsCharged: 50,
+    });
+  });
+
+  it("sums multiple usage_event totals for the same run", async () => {
+    mockClerkUserLookup();
+    const fixture = await track(
+      store.set(seedUsageFixture$, {}, context.signal),
+    );
+    const run = await store.set(
+      seedRun$,
+      { orgId: fixture.orgId, userId: fixture.userId },
+      context.signal,
+    );
+    await store.set(
+      insertModelUsage$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        runId: run.runId,
+        inputTokens: 100,
+        outputTokens: 50,
+        cacheReadInputTokens: 20,
+        cacheCreationInputTokens: 10,
+        creditsCharged: 40,
+      },
+      context.signal,
+    );
+    await store.set(
+      insertUsageEvent$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        runId: run.runId,
+        kind: "model",
+        provider: "claude-sonnet-4-6",
+        category: "tokens.input",
+        quantity: 30,
+        creditsCharged: 3,
+      },
+      context.signal,
+    );
+    await store.set(
+      insertUsageEvent$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        runId: run.runId,
+        kind: "model",
+        provider: "claude-sonnet-4-6",
+        category: "tokens.output",
+        quantity: 70,
+        creditsCharged: 7,
+      },
+      context.signal,
+    );
+    await store.set(
+      insertUsageEvent$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        runId: run.runId,
+        kind: "model",
+        provider: "claude-sonnet-4-6",
+        category: "tokens.cache_read",
+        quantity: 11,
+        creditsCharged: 1,
+      },
+      context.signal,
+    );
+    await store.set(
+      insertUsageEvent$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        runId: run.runId,
+        kind: "model",
+        provider: "claude-sonnet-4-6",
+        category: "tokens.cache_creation",
+        quantity: 13,
+        creditsCharged: 2,
+      },
+      context.signal,
+    );
+    await store.set(
+      insertUsageEvent$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        runId: run.runId,
+        kind: "model",
+        provider: "claude-sonnet-4-6",
+        category: "tokens.input",
+        quantity: 9999,
+        creditsCharged: 999,
+        status: "pending",
+      },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      apiClient().get({ query: {}, headers: authHeaders() }),
+      [200],
+    );
+
+    expect(response.body.runs).toHaveLength(1);
+    expect(response.body.pagination.total).toBe(1);
+    expect(response.body.runs[0]).toMatchObject({
+      runId: run.runId,
+      inputTokens: 130,
+      outputTokens: 120,
+      cacheTokens: 54,
+      creditsCharged: 53,
+    });
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-usage-members.ts
+++ b/turbo/apps/api/src/signals/routes/zero-usage-members.ts
@@ -1,0 +1,26 @@
+import { command } from "ccstate";
+import { zeroUsageMembersContract } from "@vm0/api-contracts/contracts/zero-usage";
+
+import { organizationAuthContext$ } from "../auth/auth-context";
+import { authRoute } from "../auth/auth-route";
+import type { RouteEntry } from "../route";
+import { zeroUsageMembers$ } from "../services/zero-usage.service";
+
+const getUsageMembersInner$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const auth = get(organizationAuthContext$);
+    const body = await set(zeroUsageMembers$, { orgId: auth.orgId }, signal);
+    signal.throwIfAborted();
+    return { status: 200 as const, body };
+  },
+);
+
+export const zeroUsageMembersRoutes: readonly RouteEntry[] = [
+  {
+    route: zeroUsageMembersContract.get,
+    handler: authRoute(
+      { requireOrganization: true, missingOrganizationStatus: 401 },
+      getUsageMembersInner$,
+    ),
+  },
+];

--- a/turbo/apps/api/src/signals/routes/zero-usage-runs.ts
+++ b/turbo/apps/api/src/signals/routes/zero-usage-runs.ts
@@ -1,0 +1,68 @@
+import { command } from "ccstate";
+import { zeroUsageRunsContract } from "@vm0/api-contracts/contracts/zero-usage-daily";
+
+import { organizationAuthContext$ } from "../auth/auth-context";
+import { authRoute } from "../auth/auth-route";
+import { queryOf } from "../context/request";
+import type { RouteEntry } from "../route";
+import { zeroUsageRuns$ } from "../services/zero-usage.service";
+
+function forbidden() {
+  return {
+    status: 403 as const,
+    body: {
+      error: {
+        message: "Only org admins can view run usage",
+        code: "FORBIDDEN",
+      },
+    },
+  };
+}
+
+function parseUserIds(value: string | undefined): string[] | undefined {
+  return value
+    ? value
+        .split(",")
+        .map((item) => {
+          return item.trim();
+        })
+        .filter(Boolean)
+    : undefined;
+}
+
+const getUsageRunsInner$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const auth = get(organizationAuthContext$);
+    if (auth.orgRole !== "admin") {
+      return forbidden();
+    }
+
+    const query = get(queryOf(zeroUsageRunsContract.get));
+    const body = await set(
+      zeroUsageRuns$,
+      {
+        orgId: auth.orgId,
+        page: query.page,
+        pageSize: query.pageSize,
+        agentId: query.agentId,
+        userIds: parseUserIds(query.userIds),
+        dateFrom: query.dateFrom,
+        dateTo: query.dateTo,
+      },
+      signal,
+    );
+    signal.throwIfAborted();
+
+    return { status: 200 as const, body };
+  },
+);
+
+export const zeroUsageRunsRoutes: readonly RouteEntry[] = [
+  {
+    route: zeroUsageRunsContract.get,
+    handler: authRoute(
+      { requireOrganization: true, missingOrganizationStatus: 401 },
+      getUsageRunsInner$,
+    ),
+  },
+];

--- a/turbo/apps/api/src/signals/services/zero-usage-reporting-ledger.ts
+++ b/turbo/apps/api/src/signals/services/zero-usage-reporting-ledger.ts
@@ -1,0 +1,194 @@
+import { and, eq, gte, isNotNull, lt, sql } from "drizzle-orm";
+import { usageEvent } from "@vm0/db/schema/usage-event";
+
+import type { Db } from "../external/db";
+
+const MODEL_USAGE_KIND = "model";
+const TOKEN_CATEGORY_INPUT = "tokens.input";
+const TOKEN_CATEGORY_OUTPUT = "tokens.output";
+const TOKEN_CATEGORY_CACHE_READ = "tokens.cache_read";
+const TOKEN_CATEGORY_CACHE_CREATION = "tokens.cache_creation";
+
+const INPUT_TOKEN_CATEGORIES = [
+  TOKEN_CATEGORY_INPUT,
+  "tokens.input.text",
+  "tokens.input.audio",
+] as const;
+
+const OUTPUT_TOKEN_CATEGORIES = [
+  TOKEN_CATEGORY_OUTPUT,
+  "tokens.output.text",
+  "tokens.output.audio",
+] as const;
+
+const CACHE_READ_TOKEN_CATEGORIES = [
+  TOKEN_CATEGORY_CACHE_READ,
+  "tokens.input.cached_text",
+  "tokens.input.cached_audio",
+] as const;
+
+const CACHE_CREATION_TOKEN_CATEGORIES = [
+  TOKEN_CATEGORY_CACHE_CREATION,
+] as const;
+
+const ALL_CACHE_TOKEN_CATEGORIES = [
+  ...CACHE_READ_TOKEN_CATEGORIES,
+  ...CACHE_CREATION_TOKEN_CATEGORIES,
+] as const;
+
+interface BillingWindow {
+  readonly start: Date;
+  readonly end: Date;
+}
+
+interface UsageMemberTotalsRow {
+  readonly userId: string;
+  readonly inputTokens: number;
+  readonly outputTokens: number;
+  readonly cacheReadInputTokens: number;
+  readonly cacheCreationInputTokens: number;
+  readonly creditsCharged: number;
+}
+
+interface UsageRunTotalsRow {
+  readonly runId: string | null;
+  readonly inputTokens: number;
+  readonly outputTokens: number;
+  readonly cacheReadInputTokens: number;
+  readonly cacheCreationInputTokens: number;
+  readonly cacheTokens: number;
+  readonly creditsCharged: number;
+  readonly model: string | null;
+  readonly userId: string;
+}
+
+export async function getMemberUsageTotals(
+  db: Db,
+  orgId: string,
+  billingWindow: BillingWindow,
+): Promise<UsageMemberTotalsRow[]> {
+  const totalsSelect = {
+    userId: usageEvent.userId,
+    inputTokens: usageEventTokenSum(INPUT_TOKEN_CATEGORIES, "input_tokens"),
+    outputTokens: usageEventTokenSum(OUTPUT_TOKEN_CATEGORIES, "output_tokens"),
+    cacheReadInputTokens: usageEventTokenSum(
+      CACHE_READ_TOKEN_CATEGORIES,
+      "cache_read_input_tokens",
+    ),
+    cacheCreationInputTokens: usageEventTokenSum(
+      CACHE_CREATION_TOKEN_CATEGORIES,
+      "cache_creation_input_tokens",
+    ),
+    creditsCharged:
+      sql<number>`COALESCE(SUM(${usageEvent.creditsCharged}), 0)::bigint`.as(
+        "credits_charged",
+      ),
+  } satisfies Record<keyof UsageMemberTotalsRow, unknown>;
+
+  return await db
+    .select(totalsSelect)
+    .from(usageEvent)
+    .where(
+      and(
+        eq(usageEvent.orgId, orgId),
+        eq(usageEvent.status, "processed"),
+        gte(usageEvent.processedAt, billingWindow.start),
+        lt(usageEvent.processedAt, billingWindow.end),
+      ),
+    )
+    .groupBy(usageEvent.userId);
+}
+
+export function buildUsageEventRunUsageTotalsSubquery(db: Db, orgId: string) {
+  const totalsSelect = {
+    runId: usageEvent.runId,
+    inputTokens: usageEventTokenSum(INPUT_TOKEN_CATEGORIES, "input_tokens_sum"),
+    outputTokens: usageEventTokenSum(
+      OUTPUT_TOKEN_CATEGORIES,
+      "output_tokens_sum",
+    ),
+    cacheReadInputTokens: usageEventTokenSum(
+      CACHE_READ_TOKEN_CATEGORIES,
+      "cache_read_input_tokens_sum",
+    ),
+    cacheCreationInputTokens: usageEventTokenSum(
+      CACHE_CREATION_TOKEN_CATEGORIES,
+      "cache_creation_input_tokens_sum",
+    ),
+    cacheTokens: usageEventTokenSum(
+      ALL_CACHE_TOKEN_CATEGORIES,
+      "cache_tokens_sum",
+    ),
+    creditsCharged:
+      sql<number>`COALESCE(SUM(${usageEvent.creditsCharged}), 0)::bigint`.as(
+        "credits_sum",
+      ),
+    model: sql<
+      string | null
+    >`MAX(CASE WHEN ${usageEvent.kind} = ${MODEL_USAGE_KIND} THEN ${usageEvent.provider} ELSE NULL END)`.as(
+      "model",
+    ),
+    userId: sql<string>`MAX(${usageEvent.userId})`.as("user_id"),
+  } satisfies Record<keyof UsageRunTotalsRow, unknown>;
+
+  return db
+    .select(totalsSelect)
+    .from(usageEvent)
+    .where(
+      and(
+        eq(usageEvent.orgId, orgId),
+        eq(usageEvent.status, "processed"),
+        isNotNull(usageEvent.runId),
+      ),
+    )
+    .groupBy(usageEvent.runId)
+    .as("usage_event_run_usage_totals");
+}
+
+type UsageEventRunUsageTotalsSubquery = ReturnType<
+  typeof buildUsageEventRunUsageTotalsSubquery
+>;
+
+export function hasRunUsageTotals(events: UsageEventRunUsageTotalsSubquery) {
+  return isNotNull(events.runId);
+}
+
+export function mergedRunInputTokens(events: UsageEventRunUsageTotalsSubquery) {
+  return coalesceRunTotal(events.inputTokens, "input_tokens");
+}
+
+export function mergedRunOutputTokens(
+  events: UsageEventRunUsageTotalsSubquery,
+) {
+  return coalesceRunTotal(events.outputTokens, "output_tokens");
+}
+
+export function mergedRunCacheTokens(events: UsageEventRunUsageTotalsSubquery) {
+  return coalesceRunTotal(events.cacheTokens, "cache_tokens");
+}
+
+export function mergedRunCreditsCharged(
+  events: UsageEventRunUsageTotalsSubquery,
+) {
+  return coalesceRunTotal(events.creditsCharged, "credits_charged");
+}
+
+export function mergedRunModel(events: UsageEventRunUsageTotalsSubquery) {
+  return sql<string | null>`${events.model}`.as("model");
+}
+
+function usageEventTokenSum(categories: readonly string[], alias: string) {
+  const list = sql.join(
+    categories.map((category) => {
+      return sql`${category}`;
+    }),
+    sql.raw(", "),
+  );
+  return sql<number>`COALESCE(SUM(CASE WHEN ${usageEvent.kind} = ${MODEL_USAGE_KIND} AND ${usageEvent.category} IN (${list}) THEN ${usageEvent.quantity} ELSE 0 END), 0)::bigint`.as(
+    alias,
+  );
+}
+
+function coalesceRunTotal(column: unknown, alias: string) {
+  return sql<number>`COALESCE(${column}, 0)::bigint`.as(alias);
+}

--- a/turbo/apps/api/src/signals/services/zero-usage.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-usage.service.ts
@@ -1,0 +1,312 @@
+import { command } from "ccstate";
+import { and, count, desc, eq, gte, inArray, lt } from "drizzle-orm";
+import type {
+  MemberUsage,
+  UsageMembersResponse,
+} from "@vm0/api-contracts/contracts/zero-usage";
+import type { UsageRunsResponse } from "@vm0/api-contracts/contracts/zero-usage-daily";
+import {
+  agentComposes,
+  agentComposeVersions,
+} from "@vm0/db/schema/agent-compose";
+import { agentRuns } from "@vm0/db/schema/agent-run";
+import { orgMembersMetadata } from "@vm0/db/schema/org-members-metadata";
+import { userCache } from "@vm0/db/schema/user-cache";
+import { zeroAgents } from "@vm0/db/schema/zero-agent";
+import { zeroRuns } from "@vm0/db/schema/zero-run";
+import type { User } from "@clerk/backend";
+
+import { clerk$ } from "../external/clerk";
+import { writeDb$ } from "../external/db";
+import { nowDate } from "../external/time";
+import { getOrgBillingPeriod$ } from "./zero-org-billing-period.service";
+import {
+  buildUsageEventRunUsageTotalsSubquery,
+  getMemberUsageTotals,
+  hasRunUsageTotals,
+  mergedRunCacheTokens,
+  mergedRunCreditsCharged,
+  mergedRunInputTokens,
+  mergedRunModel,
+  mergedRunOutputTokens,
+} from "./zero-usage-reporting-ledger";
+
+interface UsageMembersArgs {
+  readonly orgId: string;
+}
+
+export const zeroUsageMembers$ = command(
+  async (
+    { get, set },
+    args: UsageMembersArgs,
+    signal: AbortSignal,
+  ): Promise<UsageMembersResponse> => {
+    const billingPeriod = await set(getOrgBillingPeriod$, args.orgId, signal);
+    signal.throwIfAborted();
+
+    if (!billingPeriod) {
+      return { period: null, members: [] };
+    }
+
+    const db = set(writeDb$);
+    const rows = await getMemberUsageTotals(db, args.orgId, billingPeriod);
+    signal.throwIfAborted();
+
+    if (rows.length === 0) {
+      return {
+        period: {
+          start: billingPeriod.start.toISOString(),
+          end: billingPeriod.end.toISOString(),
+        },
+        members: [],
+      };
+    }
+
+    const userIds = rows.map((row) => {
+      return row.userId;
+    });
+    const emailMap = await resolveEmails(get(clerk$), db, userIds, signal);
+
+    const capRows = await db
+      .select({
+        userId: orgMembersMetadata.userId,
+        creditCap: orgMembersMetadata.creditCap,
+      })
+      .from(orgMembersMetadata)
+      .where(
+        and(
+          eq(orgMembersMetadata.orgId, args.orgId),
+          inArray(orgMembersMetadata.userId, userIds),
+        ),
+      );
+    signal.throwIfAborted();
+
+    const capMap = new Map(
+      capRows.map((row) => {
+        return [row.userId, row.creditCap];
+      }),
+    );
+
+    const members: MemberUsage[] = rows.map((row) => {
+      return {
+        userId: row.userId,
+        email: emailMap.get(row.userId) ?? "unknown",
+        inputTokens: Number(row.inputTokens),
+        outputTokens: Number(row.outputTokens),
+        cacheReadInputTokens: Number(row.cacheReadInputTokens),
+        cacheCreationInputTokens: Number(row.cacheCreationInputTokens),
+        creditsCharged: Number(row.creditsCharged),
+        creditCap: capMap.get(row.userId) ?? null,
+      };
+    });
+
+    members.sort((a, b) => {
+      return b.creditsCharged - a.creditsCharged;
+    });
+
+    return {
+      period: {
+        start: billingPeriod.start.toISOString(),
+        end: billingPeriod.end.toISOString(),
+      },
+      members,
+    };
+  },
+);
+
+interface UsageRunsArgs {
+  readonly orgId: string;
+  readonly page: number;
+  readonly pageSize: number;
+  readonly agentId?: string;
+  readonly userIds?: readonly string[];
+  readonly dateFrom?: string;
+  readonly dateTo?: string;
+}
+
+export const zeroUsageRuns$ = command(
+  async (
+    { get, set },
+    args: UsageRunsArgs,
+    signal: AbortSignal,
+  ): Promise<UsageRunsResponse> => {
+    const db = set(writeDb$);
+    const eventUsage = buildUsageEventRunUsageTotalsSubquery(db, args.orgId);
+    const conditions = [eq(agentRuns.orgId, args.orgId)];
+
+    if (args.agentId) {
+      conditions.push(eq(agentComposes.id, args.agentId));
+    }
+    if (args.userIds && args.userIds.length > 0) {
+      conditions.push(inArray(agentRuns.userId, [...args.userIds]));
+    }
+    if (args.dateFrom) {
+      conditions.push(gte(agentRuns.createdAt, new Date(args.dateFrom)));
+    }
+    if (args.dateTo) {
+      conditions.push(lt(agentRuns.createdAt, new Date(args.dateTo)));
+    }
+
+    const [countResult] = await db
+      .select({ total: count() })
+      .from(agentRuns)
+      .leftJoin(eventUsage, eq(agentRuns.id, eventUsage.runId))
+      .leftJoin(
+        agentComposeVersions,
+        eq(agentRuns.agentComposeVersionId, agentComposeVersions.id),
+      )
+      .leftJoin(
+        agentComposes,
+        eq(agentComposeVersions.composeId, agentComposes.id),
+      )
+      .where(and(...conditions, hasRunUsageTotals(eventUsage)));
+    signal.throwIfAborted();
+
+    const offset = (args.page - 1) * args.pageSize;
+    const rows = await db
+      .select({
+        runId: agentRuns.id,
+        status: agentRuns.status,
+        createdAt: agentRuns.createdAt,
+        startedAt: agentRuns.startedAt,
+        completedAt: agentRuns.completedAt,
+        userId: agentRuns.userId,
+        prompt: agentRuns.prompt,
+        triggerSource: zeroRuns.triggerSource,
+        agentName: zeroAgents.displayName,
+        inputTokens: mergedRunInputTokens(eventUsage),
+        outputTokens: mergedRunOutputTokens(eventUsage),
+        cacheTokens: mergedRunCacheTokens(eventUsage),
+        creditsCharged: mergedRunCreditsCharged(eventUsage),
+        model: mergedRunModel(eventUsage),
+      })
+      .from(agentRuns)
+      .leftJoin(eventUsage, eq(agentRuns.id, eventUsage.runId))
+      .leftJoin(zeroRuns, eq(agentRuns.id, zeroRuns.id))
+      .leftJoin(
+        agentComposeVersions,
+        eq(agentRuns.agentComposeVersionId, agentComposeVersions.id),
+      )
+      .leftJoin(
+        agentComposes,
+        eq(agentComposeVersions.composeId, agentComposes.id),
+      )
+      .leftJoin(zeroAgents, eq(agentComposes.id, zeroAgents.id))
+      .where(and(...conditions, hasRunUsageTotals(eventUsage)))
+      .orderBy(desc(agentRuns.createdAt))
+      .limit(args.pageSize)
+      .offset(offset);
+    signal.throwIfAborted();
+
+    const uniqueUserIds = [
+      ...new Set(
+        rows.map((row) => {
+          return row.userId;
+        }),
+      ),
+    ];
+    const emailMap = await resolveEmails(
+      get(clerk$),
+      db,
+      uniqueUserIds,
+      signal,
+    );
+
+    return {
+      runs: rows.map((row) => {
+        const startedAt = row.startedAt?.toISOString() ?? null;
+        const completedAt = row.completedAt?.toISOString() ?? null;
+        const durationMs =
+          row.startedAt && row.completedAt
+            ? row.completedAt.getTime() - row.startedAt.getTime()
+            : null;
+
+        return {
+          runId: row.runId,
+          agentName: row.agentName ?? null,
+          memberEmail: emailMap.get(row.userId) ?? "unknown",
+          userId: row.userId,
+          triggerSource: row.triggerSource ?? null,
+          model: row.model ?? "unknown",
+          status: row.status,
+          prompt: row.prompt,
+          startedAt,
+          completedAt,
+          durationMs,
+          inputTokens: Number(row.inputTokens),
+          outputTokens: Number(row.outputTokens),
+          cacheTokens: Number(row.cacheTokens),
+          creditsCharged: Number(row.creditsCharged),
+          createdAt: row.createdAt.toISOString(),
+        };
+      }),
+      pagination: {
+        page: args.page,
+        pageSize: args.pageSize,
+        total: countResult?.total ?? 0,
+      },
+    };
+  },
+);
+
+type ClerkClient = ReturnType<typeof clerk$.read>;
+type WriteDb = ReturnType<typeof writeDb$.write>;
+
+function primaryEmail(user: User): string {
+  const primary = user.emailAddresses.find((email) => {
+    return email.id === user.primaryEmailAddressId;
+  });
+  return primary?.emailAddress ?? "unknown";
+}
+
+async function resolveEmails(
+  client: ClerkClient,
+  db: WriteDb,
+  userIds: readonly string[],
+  signal: AbortSignal,
+): Promise<Map<string, string>> {
+  if (userIds.length === 0) {
+    return new Map();
+  }
+
+  const cachedUsers = await db
+    .select({ userId: userCache.userId, email: userCache.email })
+    .from(userCache)
+    .where(inArray(userCache.userId, [...userIds]));
+  signal.throwIfAborted();
+
+  const emailMap = new Map(
+    cachedUsers.map((user) => {
+      return [user.userId, user.email];
+    }),
+  );
+
+  const missingIds = userIds.filter((id) => {
+    return !emailMap.has(id);
+  });
+  if (missingIds.length === 0) {
+    return emailMap;
+  }
+
+  const clerkUsers = await client.users.getUserList({
+    userId: [...missingIds],
+    limit: missingIds.length,
+  });
+  signal.throwIfAborted();
+  const now = nowDate();
+
+  for (const user of clerkUsers.data) {
+    const email = primaryEmail(user);
+    emailMap.set(user.id, email);
+    await db
+      .insert(userCache)
+      .values({ userId: user.id, email, cachedAt: now })
+      .onConflictDoUpdate({
+        target: userCache.userId,
+        set: { email, cachedAt: now },
+      });
+    signal.throwIfAborted();
+  }
+
+  return emailMap;
+}


### PR DESCRIPTION
## Summary
- Add API-native handlers for `GET /api/zero/usage/members` and `GET /api/zero/usage/runs`
- Port usage-event reporting aggregation and email/cache resolution into `apps/api` services
- Add API integration coverage for auth, free-tier behavior, member/run aggregation, filtering, pagination, Realtime/transcription token rollups, and billing-window boundaries

Closes #12838.

## Validation
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-usage-members.test.ts src/signals/routes/__tests__/zero-usage-runs.test.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm exec prettier --check apps/api/src/signals/route.ts apps/api/src/signals/routes/zero-usage-members.ts apps/api/src/signals/routes/zero-usage-runs.ts apps/api/src/signals/services/zero-usage.service.ts apps/api/src/signals/services/zero-usage-reporting-ledger.ts apps/api/src/signals/routes/__tests__/helpers/zero-usage.ts apps/api/src/signals/routes/__tests__/zero-usage-members.test.ts apps/api/src/signals/routes/__tests__/zero-usage-runs.test.ts`
- `git diff --check`

## Local environment note
- `pnpm check-types` initially failed because `apps/cli/node_modules/ably` was missing locally; `pnpm install --filter @vm0/cli --offline` restored that symlink.
- A subsequent repo-wide `pnpm check-types` reached `web#check-types` and failed with `next: not found`; `apps/web/node_modules/next` is missing locally and filtered web install stalled while downloading Next. The changed API package passes its own typecheck.