### PR TITLE
fix(guest-agent): bound cli stderr diagnostics

### DIFF
--- a/crates/guest-agent/src/cli.rs
+++ b/crates/guest-agent/src/cli.rs
@@ -498,11 +498,7 @@ where
             Err(_) => break,
         };
 
-        let Some(chunk) = buffer.get(..read) else {
-            break;
-        };
-
-        for &byte in chunk {
+        for &byte in buffer.iter().take(read) {
             if byte == b'\n' {
                 finish_stderr_result_line(&mut lines, &mut line, &mut line_omitted);
                 continue;

--- a/crates/guest-agent/src/cli.rs
+++ b/crates/guest-agent/src/cli.rs
@@ -542,11 +542,11 @@ pub struct CliExecutionResult {
     /// Best-effort, secret-masked stderr tail captured from the CLI.
     ///
     /// The guest agent keeps at most the last 200 stderr lines for failure
-    /// diagnostics. Lines longer than 16 KiB are replaced with an omission
-    /// marker rather than partially returned, so secret masking never has to
-    /// process a truncated secret. It may be empty if the CLI wrote no stderr
-    /// or stderr draining timed out after process exit, and it may be
-    /// incomplete if stderr reading fails.
+    /// diagnostics. Raw stderr lines longer than 16 KiB before their newline
+    /// are replaced with an omission marker rather than partially returned, so
+    /// secret masking never has to process a truncated secret. It may be empty
+    /// if the CLI wrote no stderr or stderr draining timed out after process
+    /// exit, and it may be incomplete if stderr reading fails.
     pub stderr_lines: Vec<String>,
 
     /// Highest contiguous agent event sequence whose webhook POST succeeded.

--- a/crates/guest-agent/src/cli.rs
+++ b/crates/guest-agent/src/cli.rs
@@ -544,9 +544,9 @@ pub struct CliExecutionResult {
     /// The guest agent keeps at most the last 200 stderr lines for failure
     /// diagnostics. Lines longer than 16 KiB are replaced with an omission
     /// marker rather than partially returned, so secret masking never has to
-    /// process a truncated secret. It may be empty if the CLI wrote no stderr,
-    /// the stderr collector failed, or stderr draining timed out after process
-    /// exit.
+    /// process a truncated secret. It may be empty if the CLI wrote no stderr
+    /// or stderr draining timed out after process exit, and it may be
+    /// incomplete if stderr reading fails.
     pub stderr_lines: Vec<String>,
 
     /// Highest contiguous agent event sequence whose webhook POST succeeded.

--- a/crates/guest-agent/src/cli.rs
+++ b/crates/guest-agent/src/cli.rs
@@ -465,6 +465,15 @@ fn push_stderr_result_line(lines: &mut VecDeque<String>, line: String) {
     lines.push_back(line);
 }
 
+fn push_decoded_stderr_result_line(lines: &mut VecDeque<String>, line: &[u8]) {
+    let line = String::from_utf8_lossy(line);
+    if line.len() > STDERR_RESULT_MAX_LINE_BYTES {
+        push_stderr_result_line(lines, STDERR_OMITTED_LONG_LINE.to_string());
+    } else {
+        push_stderr_result_line(lines, line.into_owned());
+    }
+}
+
 fn finish_stderr_result_line(
     lines: &mut VecDeque<String>,
     line: &mut Vec<u8>,
@@ -480,7 +489,7 @@ fn finish_stderr_result_line(
         if line.len() > STDERR_RESULT_MAX_LINE_BYTES {
             push_stderr_result_line(lines, STDERR_OMITTED_LONG_LINE.to_string());
         } else {
-            push_stderr_result_line(lines, String::from_utf8_lossy(line).into_owned());
+            push_decoded_stderr_result_line(lines, line);
         }
     }
     line.clear();
@@ -545,12 +554,13 @@ pub struct CliExecutionResult {
     /// Best-effort, secret-masked stderr tail captured from the CLI.
     ///
     /// The guest agent keeps at most the last 200 stderr lines for failure
-    /// diagnostics. Stderr lines longer than 16 KiB after CRLF normalization
-    /// are replaced with an omission marker rather than partially returned, so
-    /// secret masking never has to process a truncated secret. Invalid UTF-8 is
-    /// decoded lossily into a valid string. It may be empty if the CLI wrote no
-    /// stderr or stderr draining timed out after process exit, and it may be
-    /// incomplete if stderr reading fails.
+    /// diagnostics. Stderr lines longer than 16 KiB after CRLF normalization,
+    /// or after lossy UTF-8 decoding, are replaced with an omission marker
+    /// rather than partially returned, so secret masking never has to process a
+    /// truncated secret. Invalid UTF-8 is decoded lossily into a valid string
+    /// when the decoded diagnostic still fits the limit. It may be empty if the
+    /// CLI wrote no stderr or stderr draining timed out after process exit, and
+    /// it may be incomplete if stderr reading fails.
     pub stderr_lines: Vec<String>,
 
     /// Highest contiguous agent event sequence whose webhook POST succeeded.

--- a/crates/guest-agent/src/cli.rs
+++ b/crates/guest-agent/src/cli.rs
@@ -544,9 +544,10 @@ pub struct CliExecutionResult {
     /// The guest agent keeps at most the last 200 stderr lines for failure
     /// diagnostics. Raw stderr lines longer than 16 KiB before their newline
     /// are replaced with an omission marker rather than partially returned, so
-    /// secret masking never has to process a truncated secret. It may be empty
-    /// if the CLI wrote no stderr or stderr draining timed out after process
-    /// exit, and it may be incomplete if stderr reading fails.
+    /// secret masking never has to process a truncated secret. Invalid UTF-8 is
+    /// decoded lossily into a valid string. It may be empty if the CLI wrote no
+    /// stderr or stderr draining timed out after process exit, and it may be
+    /// incomplete if stderr reading fails.
     pub stderr_lines: Vec<String>,
 
     /// Highest contiguous agent event sequence whose webhook POST succeeded.

--- a/crates/guest-agent/src/cli.rs
+++ b/crates/guest-agent/src/cli.rs
@@ -469,14 +469,19 @@ fn finish_stderr_result_line(
     lines: &mut VecDeque<String>,
     line: &mut Vec<u8>,
     line_omitted: &mut bool,
+    strip_trailing_cr: bool,
 ) {
     if *line_omitted {
         push_stderr_result_line(lines, STDERR_OMITTED_LONG_LINE.to_string());
     } else {
-        if line.last() == Some(&b'\r') {
+        if strip_trailing_cr && line.last() == Some(&b'\r') {
             line.pop();
         }
-        push_stderr_result_line(lines, String::from_utf8_lossy(line).into_owned());
+        if line.len() > STDERR_RESULT_MAX_LINE_BYTES {
+            push_stderr_result_line(lines, STDERR_OMITTED_LONG_LINE.to_string());
+        } else {
+            push_stderr_result_line(lines, String::from_utf8_lossy(line).into_owned());
+        }
     }
     line.clear();
     *line_omitted = false;
@@ -500,7 +505,7 @@ where
 
         for &byte in buffer.iter().take(read) {
             if byte == b'\n' {
-                finish_stderr_result_line(&mut lines, &mut line, &mut line_omitted);
+                finish_stderr_result_line(&mut lines, &mut line, &mut line_omitted, true);
                 continue;
             }
 
@@ -520,7 +525,7 @@ where
     }
 
     if !line.is_empty() || line_omitted {
-        finish_stderr_result_line(&mut lines, &mut line, &mut line_omitted);
+        finish_stderr_result_line(&mut lines, &mut line, &mut line_omitted, false);
     }
 
     lines.into_iter().collect()

--- a/crates/guest-agent/src/cli.rs
+++ b/crates/guest-agent/src/cli.rs
@@ -508,7 +508,9 @@ where
                 continue;
             }
 
-            if line.len() < STDERR_RESULT_MAX_LINE_BYTES {
+            if line.len() < STDERR_RESULT_MAX_LINE_BYTES
+                || (byte == b'\r' && line.len() == STDERR_RESULT_MAX_LINE_BYTES)
+            {
                 line.push(byte);
             } else {
                 line.clear();
@@ -538,7 +540,7 @@ pub struct CliExecutionResult {
     /// Best-effort, secret-masked stderr tail captured from the CLI.
     ///
     /// The guest agent keeps at most the last 200 stderr lines for failure
-    /// diagnostics. Raw stderr lines longer than 16 KiB before their newline
+    /// diagnostics. Stderr lines longer than 16 KiB after CRLF normalization
     /// are replaced with an omission marker rather than partially returned, so
     /// secret masking never has to process a truncated secret. Invalid UTF-8 is
     /// decoded lossily into a valid string. It may be empty if the CLI wrote no

--- a/crates/guest-agent/src/cli.rs
+++ b/crates/guest-agent/src/cli.rs
@@ -10,13 +10,16 @@ use crate::paths;
 use crate::timing;
 use guest_common::telemetry::record_sandbox_op;
 use guest_common::{log_info, log_warn};
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::process::Stdio;
 use std::time::{Duration, Instant};
-use tokio::io::AsyncBufReadExt;
-use tokio::io::AsyncWriteExt;
+use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncReadExt, AsyncWriteExt};
 
 const LOG_TAG: &str = "sandbox:guest-agent";
+const STDERR_RESULT_MAX_LINES: usize = 200;
+const STDERR_RESULT_MAX_LINE_BYTES: usize = 16 * 1024;
+const STDERR_READ_BUFFER_BYTES: usize = 8 * 1024;
+const STDERR_OMITTED_LONG_LINE: &str = "[stderr line omitted: exceeded diagnostic size limit]";
 
 /// State machine driving forced CLI process-group termination. A single
 /// pinned deadline is resettable across phases; the enum value tells the
@@ -455,9 +458,102 @@ impl AckedEventPrefix {
     }
 }
 
+fn push_stderr_result_line(lines: &mut VecDeque<String>, line: String) {
+    if lines.len() == STDERR_RESULT_MAX_LINES {
+        lines.pop_front();
+    }
+    lines.push_back(line);
+}
+
+fn finish_stderr_result_line(
+    lines: &mut VecDeque<String>,
+    line: &mut Vec<u8>,
+    line_omitted: &mut bool,
+) {
+    if *line_omitted {
+        push_stderr_result_line(lines, STDERR_OMITTED_LONG_LINE.to_string());
+    } else {
+        if line.last() == Some(&b'\r') {
+            line.pop();
+        }
+        push_stderr_result_line(lines, String::from_utf8_lossy(line).into_owned());
+    }
+    line.clear();
+    *line_omitted = false;
+}
+
+async fn collect_stderr_result_tail<R>(mut stderr: R) -> Vec<String>
+where
+    R: AsyncRead + Unpin,
+{
+    let mut lines = VecDeque::with_capacity(STDERR_RESULT_MAX_LINES);
+    let mut line = Vec::with_capacity(STDERR_RESULT_MAX_LINE_BYTES.min(1024));
+    let mut line_omitted = false;
+    let mut buffer = [0u8; STDERR_READ_BUFFER_BYTES];
+
+    loop {
+        let read = match stderr.read(&mut buffer).await {
+            Ok(0) => break,
+            Ok(read) => read,
+            Err(_) => break,
+        };
+
+        let Some(chunk) = buffer.get(..read) else {
+            break;
+        };
+
+        for &byte in chunk {
+            if byte == b'\n' {
+                finish_stderr_result_line(&mut lines, &mut line, &mut line_omitted);
+                continue;
+            }
+
+            if line_omitted {
+                continue;
+            }
+
+            if line.len() < STDERR_RESULT_MAX_LINE_BYTES {
+                line.push(byte);
+            } else {
+                line.clear();
+                line_omitted = true;
+            }
+        }
+    }
+
+    if !line.is_empty() || line_omitted {
+        finish_stderr_result_line(&mut lines, &mut line, &mut line_omitted);
+    }
+
+    lines.into_iter().collect()
+}
+
+/// Result returned after the configured CLI process exits.
+///
+/// The guest agent uses this summary to report final run status and to persist
+/// the event-drain watermark consumed by host/API clients.
 pub struct CliExecutionResult {
+    /// Process exit code for the CLI.
+    ///
+    /// On Unix, signal termination is mapped to `128 + signal`, matching shell
+    /// convention, so SIGKILL is reported as `137`.
     pub exit_code: i32,
+
+    /// Best-effort, secret-masked stderr tail captured from the CLI.
+    ///
+    /// The guest agent keeps at most the last 200 stderr lines for failure
+    /// diagnostics. Overlong lines are replaced with an omission marker rather
+    /// than partially returned, so secret masking never has to process a
+    /// truncated secret. It may be empty if the CLI wrote no stderr, the stderr
+    /// collector failed, or stderr draining timed out after process exit.
     pub stderr_lines: Vec<String>,
+
+    /// Highest contiguous agent event sequence whose webhook POST succeeded.
+    ///
+    /// This is a terminal event-drain watermark, not merely the last event read
+    /// from stdout. `None` means no contiguous event prefix was acknowledged,
+    /// such as no-API mode, no emitted events, or failure before the first event
+    /// was successfully posted.
     pub last_event_sequence: Option<u32>,
 }
 
@@ -526,14 +622,7 @@ pub async fn execute_cli(
         .ok_or_else(|| AgentError::Execution("no stderr".into()))?;
 
     // Stderr collector
-    let mut stderr_handle = tokio::spawn(async move {
-        let mut lines = Vec::new();
-        let mut reader = tokio::io::BufReader::new(stderr).lines();
-        while let Ok(Some(line)) = reader.next_line().await {
-            lines.push(line);
-        }
-        lines
-    });
+    let mut stderr_handle = tokio::spawn(async move { collect_stderr_result_tail(stderr).await });
 
     // Stream stdout JSONL, racing against heartbeat and process exit.
     //
@@ -1458,6 +1547,41 @@ mod tests {
         prefix.record_success(3);
 
         assert_eq!(prefix.last_contiguous(), Some(0));
+    }
+
+    #[tokio::test]
+    async fn stderr_result_keeps_bounded_tail() {
+        let mut input = String::new();
+
+        for i in 0..(STDERR_RESULT_MAX_LINES + 2) {
+            input.push_str(&format!("line-{i}\n"));
+        }
+
+        let lines = collect_stderr_result_tail(std::io::Cursor::new(input.into_bytes())).await;
+        let expected_last = format!("line-{}", STDERR_RESULT_MAX_LINES + 1);
+        assert_eq!(lines.len(), STDERR_RESULT_MAX_LINES);
+        assert_eq!(lines.first().map(String::as_str), Some("line-2"));
+        assert_eq!(
+            lines.last().map(String::as_str),
+            Some(expected_last.as_str())
+        );
+    }
+
+    #[tokio::test]
+    async fn stderr_result_omits_overlong_line() {
+        let overlong = "s".repeat(STDERR_RESULT_MAX_LINE_BYTES + 1);
+        let input = format!("before\n{overlong}\nafter\n");
+
+        let lines = collect_stderr_result_tail(std::io::Cursor::new(input.into_bytes())).await;
+
+        assert_eq!(
+            lines,
+            vec![
+                "before".to_string(),
+                STDERR_OMITTED_LONG_LINE.to_string(),
+                "after".to_string(),
+            ]
+        );
     }
 
     // -----------------------------------------------------------------

--- a/crates/guest-agent/src/cli.rs
+++ b/crates/guest-agent/src/cli.rs
@@ -542,10 +542,11 @@ pub struct CliExecutionResult {
     /// Best-effort, secret-masked stderr tail captured from the CLI.
     ///
     /// The guest agent keeps at most the last 200 stderr lines for failure
-    /// diagnostics. Overlong lines are replaced with an omission marker rather
-    /// than partially returned, so secret masking never has to process a
-    /// truncated secret. It may be empty if the CLI wrote no stderr, the stderr
-    /// collector failed, or stderr draining timed out after process exit.
+    /// diagnostics. Lines longer than 16 KiB are replaced with an omission
+    /// marker rather than partially returned, so secret masking never has to
+    /// process a truncated secret. It may be empty if the CLI wrote no stderr,
+    /// the stderr collector failed, or stderr draining timed out after process
+    /// exit.
     pub stderr_lines: Vec<String>,
 
     /// Highest contiguous agent event sequence whose webhook POST succeeded.
@@ -1547,41 +1548,6 @@ mod tests {
         prefix.record_success(3);
 
         assert_eq!(prefix.last_contiguous(), Some(0));
-    }
-
-    #[tokio::test]
-    async fn stderr_result_keeps_bounded_tail() {
-        let mut input = String::new();
-
-        for i in 0..(STDERR_RESULT_MAX_LINES + 2) {
-            input.push_str(&format!("line-{i}\n"));
-        }
-
-        let lines = collect_stderr_result_tail(std::io::Cursor::new(input.into_bytes())).await;
-        let expected_last = format!("line-{}", STDERR_RESULT_MAX_LINES + 1);
-        assert_eq!(lines.len(), STDERR_RESULT_MAX_LINES);
-        assert_eq!(lines.first().map(String::as_str), Some("line-2"));
-        assert_eq!(
-            lines.last().map(String::as_str),
-            Some(expected_last.as_str())
-        );
-    }
-
-    #[tokio::test]
-    async fn stderr_result_omits_overlong_line() {
-        let overlong = "s".repeat(STDERR_RESULT_MAX_LINE_BYTES + 1);
-        let input = format!("before\n{overlong}\nafter\n");
-
-        let lines = collect_stderr_result_tail(std::io::Cursor::new(input.into_bytes())).await;
-
-        assert_eq!(
-            lines,
-            vec![
-                "before".to_string(),
-                STDERR_OMITTED_LONG_LINE.to_string(),
-                "after".to_string(),
-            ]
-        );
     }
 
     // -----------------------------------------------------------------

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -478,6 +478,43 @@ mod tests {
     }
 
     #[test]
+    fn cli_failure_message_preserves_exact_limits_without_omission() {
+        let _test_state_guard = lock_test_state();
+        let tmp = tempfile::tempdir().unwrap();
+        let system_log_path = tmp.path().join("system.log");
+        let _system_log_guard = SystemLogOverrideGuard::set(&system_log_path);
+
+        let exact_limit_line = "x".repeat(MAX_LOGGED_CLI_STDERR_LINE_BYTES);
+        let stderr_lines = std::iter::once(exact_limit_line.clone())
+            .chain((1..MAX_LOGGED_CLI_STDERR_LINES).map(|i| format!("line {i}")))
+            .collect::<Vec<_>>();
+
+        let msg = cli_failure_message(1, &stderr_lines);
+        assert!(
+            msg.contains(&exact_limit_line),
+            "returned error message should preserve line at exact size limit"
+        );
+        assert!(
+            !msg.contains("...[truncated]"),
+            "returned error message should not truncate line at exact size limit"
+        );
+        assert!(
+            !msg.contains("omitted"),
+            "returned error message should not report omitted lines at exact line limit"
+        );
+
+        let system_log = std::fs::read_to_string(&system_log_path).unwrap();
+        assert!(
+            system_log.contains("Captured 20 stderr lines"),
+            "system log should include stderr count, got: {system_log}"
+        );
+        assert!(
+            !system_log.contains("omitted"),
+            "system log should not report omitted lines at exact line limit"
+        );
+    }
+
+    #[test]
     fn complete_execution_creates_recovery_checkpoint_after_cli_failure() {
         let _test_state_guard = lock_test_state();
         tokio::runtime::Builder::new_current_thread()

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -528,6 +528,41 @@ mod tests {
     }
 
     #[test]
+    fn cli_failure_message_truncates_on_utf8_boundary() {
+        let _test_state_guard = lock_test_state();
+        let tmp = tempfile::tempdir().unwrap();
+        let system_log_path = tmp.path().join("system.log");
+        let _system_log_guard = SystemLogOverrideGuard::set(&system_log_path);
+
+        let prefix = "x".repeat(MAX_LOGGED_CLI_STDERR_LINE_BYTES - 1);
+        let stderr_line = format!("{prefix}é-tail");
+        let msg = cli_failure_message(1, &[stderr_line]);
+
+        assert!(
+            msg.contains(&prefix),
+            "returned error message should preserve bytes before the truncation boundary"
+        );
+        assert!(
+            msg.contains("...[truncated]"),
+            "returned error message should indicate truncation"
+        );
+        assert!(
+            !msg.contains("é-tail"),
+            "returned error message should not split or include the over-boundary character"
+        );
+
+        let system_log = std::fs::read_to_string(&system_log_path).unwrap();
+        assert!(
+            system_log.contains("...[truncated]"),
+            "system log should indicate truncation, got: {system_log}"
+        );
+        assert!(
+            !system_log.contains("é-tail"),
+            "system log should not split or include the over-boundary character"
+        );
+    }
+
+    #[test]
     fn complete_execution_creates_recovery_checkpoint_after_cli_failure() {
         let _test_state_guard = lock_test_state();
         tokio::runtime::Builder::new_current_thread()

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -226,17 +226,25 @@ fn cli_failure_message(code: i32, stderr_lines: &[String]) -> String {
     }
 
     log_info!(LOG_TAG, "Captured {} stderr lines", stderr_lines.len());
+    let has_omitted_lines = stderr_lines.len() > MAX_LOGGED_CLI_STDERR_LINES;
+    let mut message_lines = Vec::with_capacity(
+        stderr_lines.len().min(MAX_LOGGED_CLI_STDERR_LINES) + usize::from(has_omitted_lines),
+    );
     for line in stderr_lines.iter().take(MAX_LOGGED_CLI_STDERR_LINES) {
-        log_warn!(LOG_TAG, "CLI stderr: {}", truncate_cli_stderr_line(line));
+        let line = truncate_cli_stderr_line(line);
+        log_warn!(LOG_TAG, "CLI stderr: {line}");
+        message_lines.push(line.into_owned());
     }
-    if stderr_lines.len() > MAX_LOGGED_CLI_STDERR_LINES {
+    if has_omitted_lines {
+        let omitted = stderr_lines.len() - MAX_LOGGED_CLI_STDERR_LINES;
         log_warn!(
             LOG_TAG,
             "CLI stderr: omitted {} additional line(s)",
-            stderr_lines.len() - MAX_LOGGED_CLI_STDERR_LINES
+            omitted
         );
+        message_lines.push(format!("...[omitted {omitted} additional stderr line(s)]"));
     }
-    stderr_lines.join(" ")
+    message_lines.join(" ")
 }
 
 fn truncate_cli_stderr_line(line: &str) -> std::borrow::Cow<'_, str> {
@@ -434,8 +442,16 @@ mod tests {
             "returned error message should preserve stderr"
         );
         assert!(
-            msg.contains("tail"),
-            "returned error message should preserve full masked stderr"
+            msg.contains("...[truncated]"),
+            "returned error message should truncate long stderr lines"
+        );
+        assert!(
+            !msg.contains("tail"),
+            "returned error message should not include bytes after the truncation boundary"
+        );
+        assert!(
+            msg.contains("...[omitted 2 additional stderr line(s)]"),
+            "returned error message should report omitted stderr lines"
         );
 
         let system_log = std::fs::read_to_string(&system_log_path).unwrap();

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -226,23 +226,26 @@ fn cli_failure_message(code: i32, stderr_lines: &[String]) -> String {
     }
 
     log_info!(LOG_TAG, "Captured {} stderr lines", stderr_lines.len());
-    let has_omitted_lines = stderr_lines.len() > MAX_LOGGED_CLI_STDERR_LINES;
+    let omitted_lines = stderr_lines
+        .len()
+        .saturating_sub(MAX_LOGGED_CLI_STDERR_LINES);
     let mut message_lines = Vec::with_capacity(
-        stderr_lines.len().min(MAX_LOGGED_CLI_STDERR_LINES) + usize::from(has_omitted_lines),
+        stderr_lines.len().min(MAX_LOGGED_CLI_STDERR_LINES) + usize::from(omitted_lines > 0),
     );
-    for line in stderr_lines.iter().take(MAX_LOGGED_CLI_STDERR_LINES) {
+    if omitted_lines > 0 {
+        log_warn!(
+            LOG_TAG,
+            "CLI stderr: omitted {} earlier line(s)",
+            omitted_lines
+        );
+        message_lines.push(format!(
+            "...[omitted {omitted_lines} earlier stderr line(s)]"
+        ));
+    }
+    for line in stderr_lines.iter().skip(omitted_lines) {
         let line = truncate_cli_stderr_line(line);
         log_warn!(LOG_TAG, "CLI stderr: {line}");
         message_lines.push(line.into_owned());
-    }
-    if has_omitted_lines {
-        let omitted = stderr_lines.len() - MAX_LOGGED_CLI_STDERR_LINES;
-        log_warn!(
-            LOG_TAG,
-            "CLI stderr: omitted {} additional line(s)",
-            omitted
-        );
-        message_lines.push(format!("...[omitted {omitted} additional stderr line(s)]"));
     }
     message_lines.join(" ")
 }
@@ -432,11 +435,17 @@ mod tests {
         let _system_log_guard = SystemLogOverrideGuard::set(&system_log_path);
 
         let long_line = format!("{}tail", "x".repeat(MAX_LOGGED_CLI_STDERR_LINE_BYTES + 1));
-        let stderr_lines = std::iter::once("codex stderr includes ***".to_string())
+        let stderr_lines = ["prefix line 0".to_string(), "prefix line 1".to_string()]
+            .into_iter()
+            .chain(std::iter::once("codex stderr includes ***".to_string()))
             .chain(std::iter::once(long_line.clone()))
-            .chain((0..MAX_LOGGED_CLI_STDERR_LINES).map(|i| format!("extra line {i}")))
+            .chain((0..(MAX_LOGGED_CLI_STDERR_LINES - 2)).map(|i| format!("extra line {i}")))
             .collect::<Vec<_>>();
         let msg = cli_failure_message(1, &stderr_lines);
+        assert!(
+            !msg.contains("prefix line"),
+            "returned error message should omit older stderr lines"
+        );
         assert!(
             msg.contains("codex stderr includes ***"),
             "returned error message should preserve stderr"
@@ -450,14 +459,18 @@ mod tests {
             "returned error message should not include bytes after the truncation boundary"
         );
         assert!(
-            msg.contains("...[omitted 2 additional stderr line(s)]"),
-            "returned error message should report omitted stderr lines"
+            msg.contains("...[omitted 2 earlier stderr line(s)]"),
+            "returned error message should report omitted earlier stderr lines"
         );
 
         let system_log = std::fs::read_to_string(&system_log_path).unwrap();
         assert!(
             system_log.contains("Captured 22 stderr lines"),
             "system log should include stderr count, got: {system_log}"
+        );
+        assert!(
+            !system_log.contains("prefix line"),
+            "system log should omit older stderr lines"
         );
         assert!(
             system_log.contains("CLI stderr: codex stderr includes ***"),
@@ -472,8 +485,8 @@ mod tests {
             "system log should not include bytes after the truncation boundary"
         );
         assert!(
-            system_log.contains("CLI stderr: omitted 2 additional line(s)"),
-            "system log should report omitted stderr lines, got: {system_log}"
+            system_log.contains("CLI stderr: omitted 2 earlier line(s)"),
+            "system log should report omitted earlier stderr lines, got: {system_log}"
         );
     }
 

--- a/crates/guest-agent/tests/cli_stderr_exact_limit_no_newline.rs
+++ b/crates/guest-agent/tests/cli_stderr_exact_limit_no_newline.rs
@@ -1,0 +1,45 @@
+//! CLI stderr diagnostics must preserve an exact-limit final line without `\n`.
+//!
+//! This test lives in its own binary because `guest_agent::env` and
+//! `guest_agent::paths` cache values in process-wide `LazyLock`s.
+
+mod common;
+
+use guest_agent::http::HttpClient;
+use guest_agent::masker::SecretMasker;
+use std::time::Duration;
+
+#[tokio::test]
+async fn cli_failure_keeps_exact_limit_stderr_without_newline()
+-> Result<(), Box<dyn std::error::Error>> {
+    let mock = common::build_and_locate_mock()?;
+    let tmp = tempfile::tempdir()?;
+    let exact_limit_line = "x".repeat(common::CLI_STDERR_RESULT_MAX_LINE_BYTES);
+
+    unsafe {
+        common::setup_env(
+            &mock,
+            tmp.path(),
+            &format!("@fail-no-newline:{exact_limit_line}"),
+            3,
+            1,
+        )?;
+    }
+
+    let masker = SecretMasker::from_raw("");
+    let cli_result = tokio::time::timeout(
+        Duration::from_secs(5),
+        guest_agent::cli::execute_cli(
+            &masker,
+            common::spawn_dummy_heartbeat(),
+            HttpClient::for_current_env()?,
+        ),
+    )
+    .await
+    .expect("execute_cli should return promptly")?;
+
+    assert_eq!(cli_result.exit_code, 1);
+    assert_eq!(cli_result.stderr_lines, vec![exact_limit_line]);
+
+    Ok(())
+}

--- a/crates/guest-agent/tests/cli_stderr_invalid_utf8.rs
+++ b/crates/guest-agent/tests/cli_stderr_invalid_utf8.rs
@@ -1,0 +1,37 @@
+//! CLI stderr diagnostics must tolerate invalid UTF-8 bytes.
+//!
+//! This test lives in its own binary because `guest_agent::env` and
+//! `guest_agent::paths` cache values in process-wide `LazyLock`s.
+
+mod common;
+
+use guest_agent::http::HttpClient;
+use guest_agent::masker::SecretMasker;
+use std::time::Duration;
+
+#[tokio::test]
+async fn cli_failure_decodes_invalid_stderr_lossily() -> Result<(), Box<dyn std::error::Error>> {
+    let mock = common::build_and_locate_mock()?;
+    let tmp = tempfile::tempdir()?;
+
+    unsafe {
+        common::setup_env(&mock, tmp.path(), "@fail-invalid-utf8", 3, 1)?;
+    }
+
+    let masker = SecretMasker::from_raw("");
+    let cli_result = tokio::time::timeout(
+        Duration::from_secs(5),
+        guest_agent::cli::execute_cli(
+            &masker,
+            common::spawn_dummy_heartbeat(),
+            HttpClient::for_current_env()?,
+        ),
+    )
+    .await
+    .expect("execute_cli should return promptly")?;
+
+    assert_eq!(cli_result.exit_code, 1);
+    assert_eq!(cli_result.stderr_lines, vec!["invalid-\u{fffd}-stderr"]);
+
+    Ok(())
+}

--- a/crates/guest-agent/tests/cli_stderr_invalid_utf8_long.rs
+++ b/crates/guest-agent/tests/cli_stderr_invalid_utf8_long.rs
@@ -1,0 +1,41 @@
+//! CLI stderr diagnostics must bound lossy UTF-8 expansion.
+//!
+//! This test lives in its own binary because `guest_agent::env` and
+//! `guest_agent::paths` cache values in process-wide `LazyLock`s.
+
+mod common;
+
+use guest_agent::http::HttpClient;
+use guest_agent::masker::SecretMasker;
+use std::time::Duration;
+
+#[tokio::test]
+async fn cli_failure_omits_invalid_stderr_when_lossy_decode_exceeds_limit()
+-> Result<(), Box<dyn std::error::Error>> {
+    let mock = common::build_and_locate_mock()?;
+    let tmp = tempfile::tempdir()?;
+
+    unsafe {
+        common::setup_env(&mock, tmp.path(), "@fail-invalid-utf8-long", 3, 1)?;
+    }
+
+    let masker = SecretMasker::from_raw("");
+    let cli_result = tokio::time::timeout(
+        Duration::from_secs(5),
+        guest_agent::cli::execute_cli(
+            &masker,
+            common::spawn_dummy_heartbeat(),
+            HttpClient::for_current_env()?,
+        ),
+    )
+    .await
+    .expect("execute_cli should return promptly")?;
+
+    assert_eq!(cli_result.exit_code, 1);
+    assert_eq!(
+        cli_result.stderr_lines,
+        vec![common::CLI_STDERR_OMITTED_LONG_LINE]
+    );
+
+    Ok(())
+}

--- a/crates/guest-agent/tests/cli_stderr_logging.rs
+++ b/crates/guest-agent/tests/cli_stderr_logging.rs
@@ -15,10 +15,11 @@ async fn cli_failure_stderr_is_masked_in_result() -> Result<(), Box<dyn std::err
     let mock = common::build_and_locate_mock()?;
     let tmp = tempfile::tempdir()?;
     let secret = "super-secret-value";
-    let mut stderr_payload = (0..202)
+    let mut stderr_payload = (0..201)
         .map(|i| format!("line-{i}"))
         .collect::<Vec<_>>()
         .join("\n");
+    stderr_payload.push_str("\ncrlf-line\r");
     stderr_payload.push_str(&format!("\ncodex stderr includes {secret}"));
     stderr_payload.push_str(&format!("\n{}", "x".repeat(16 * 1024 + 1)));
     stderr_payload.push_str("\nafter-overlong-line");
@@ -50,6 +51,20 @@ async fn cli_failure_stderr_is_masked_in_result() -> Result<(), Box<dyn std::err
     assert!(
         !cli_result.stderr_lines.iter().any(|line| line == "line-4"),
         "stderr result should drop old lines from the bounded tail, got: {stderr}"
+    );
+    assert!(
+        cli_result
+            .stderr_lines
+            .iter()
+            .any(|line| line == "crlf-line"),
+        "stderr result should strip trailing carriage returns, got: {stderr}"
+    );
+    assert!(
+        !cli_result
+            .stderr_lines
+            .iter()
+            .any(|line| line == "crlf-line\r"),
+        "stderr result should not keep trailing carriage returns, got: {stderr}"
     );
     assert!(
         stderr.contains("codex stderr includes ***"),

--- a/crates/guest-agent/tests/cli_stderr_logging.rs
+++ b/crates/guest-agent/tests/cli_stderr_logging.rs
@@ -15,14 +15,16 @@ async fn cli_failure_stderr_is_masked_in_result() -> Result<(), Box<dyn std::err
     let mock = common::build_and_locate_mock()?;
     let tmp = tempfile::tempdir()?;
     let secret = "super-secret-value";
+    let mut stderr_payload = (0..202)
+        .map(|i| format!("line-{i}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    stderr_payload.push_str(&format!("\ncodex stderr includes {secret}"));
+    stderr_payload.push_str(&format!("\n{}", "x".repeat(16 * 1024 + 1)));
+    stderr_payload.push_str("\nafter-overlong-line");
+
     unsafe {
-        common::setup_env(
-            &mock,
-            tmp.path(),
-            &format!("@fail:codex stderr includes {secret}"),
-            3,
-            1,
-        )?;
+        common::setup_env(&mock, tmp.path(), &format!("@fail:{stderr_payload}"), 3, 1)?;
     }
 
     let encoded_secret = base64::engine::general_purpose::STANDARD.encode(secret);
@@ -39,10 +41,27 @@ async fn cli_failure_stderr_is_masked_in_result() -> Result<(), Box<dyn std::err
     .expect("execute_cli should return promptly")?;
 
     assert_eq!(cli_result.exit_code, 1);
+    assert_eq!(cli_result.stderr_lines.len(), 200);
     let stderr = cli_result.stderr_lines.join("\n");
+    assert_eq!(
+        cli_result.stderr_lines.first().map(String::as_str),
+        Some("line-5")
+    );
+    assert!(
+        !cli_result.stderr_lines.iter().any(|line| line == "line-4"),
+        "stderr result should drop old lines from the bounded tail, got: {stderr}"
+    );
     assert!(
         stderr.contains("codex stderr includes ***"),
         "stderr result should keep masked diagnostic, got: {stderr}"
+    );
+    assert!(
+        stderr.contains("[stderr line omitted: exceeded diagnostic size limit]"),
+        "stderr result should omit overlong lines, got: {stderr}"
+    );
+    assert!(
+        stderr.contains("after-overlong-line"),
+        "stderr result should recover after overlong lines, got: {stderr}"
     );
     assert!(
         !stderr.contains(secret),

--- a/crates/guest-agent/tests/cli_stderr_logging.rs
+++ b/crates/guest-agent/tests/cli_stderr_logging.rs
@@ -29,6 +29,10 @@ async fn cli_failure_stderr_is_masked_in_result() -> Result<(), Box<dyn std::err
         "exact-limit-{}",
         "x".repeat(common::CLI_STDERR_RESULT_MAX_LINE_BYTES - "exact-limit-".len())
     );
+    let exact_limit_crlf_line = format!(
+        "exact-crlf-{}",
+        "x".repeat(common::CLI_STDERR_RESULT_MAX_LINE_BYTES - "exact-crlf-".len())
+    );
     let overlong_secret_line = format!(
         "overlong-secret-prefix-{secret}-{}",
         "x".repeat(common::CLI_STDERR_RESULT_MAX_LINE_BYTES)
@@ -37,8 +41,12 @@ async fn cli_failure_stderr_is_masked_in_result() -> Result<(), Box<dyn std::err
         exact_limit_line.len(),
         common::CLI_STDERR_RESULT_MAX_LINE_BYTES
     );
+    assert_eq!(
+        exact_limit_crlf_line.len(),
+        common::CLI_STDERR_RESULT_MAX_LINE_BYTES
+    );
 
-    stderr_payload.push_str("\ncrlf-line\r");
+    stderr_payload.push_str(&format!("\n{exact_limit_crlf_line}\r"));
     stderr_payload.push_str(&format!("\n{exact_limit_line}"));
     stderr_payload.push_str(&format!("\ncodex stderr includes {secret}"));
     stderr_payload.push_str(&format!("\n{overlong_secret_line}"));
@@ -83,14 +91,14 @@ async fn cli_failure_stderr_is_masked_in_result() -> Result<(), Box<dyn std::err
         cli_result
             .stderr_lines
             .iter()
-            .any(|line| line == "crlf-line"),
+            .any(|line| line == &exact_limit_crlf_line),
         "stderr result should strip trailing carriage returns, got: {stderr}"
     );
     assert!(
         !cli_result
             .stderr_lines
             .iter()
-            .any(|line| line == "crlf-line\r"),
+            .any(|line| line == &format!("{exact_limit_crlf_line}\r")),
         "stderr result should not keep trailing carriage returns, got: {stderr}"
     );
     assert!(

--- a/crates/guest-agent/tests/cli_stderr_logging.rs
+++ b/crates/guest-agent/tests/cli_stderr_logging.rs
@@ -15,20 +15,26 @@ async fn cli_failure_stderr_is_masked_in_result() -> Result<(), Box<dyn std::err
     let mock = common::build_and_locate_mock()?;
     let tmp = tempfile::tempdir()?;
     let secret = "super-secret-value";
-    let mut stderr_payload = (0..201)
+    let mut stderr_payload = (0..(common::CLI_STDERR_RESULT_MAX_LINES + 1))
         .map(|i| format!("line-{i}"))
         .collect::<Vec<_>>()
         .join("\n");
     let exact_limit_line = format!(
         "exact-limit-{}",
-        "x".repeat(16 * 1024 - "exact-limit-".len())
+        "x".repeat(common::CLI_STDERR_RESULT_MAX_LINE_BYTES - "exact-limit-".len())
     );
-    assert_eq!(exact_limit_line.len(), 16 * 1024);
+    assert_eq!(
+        exact_limit_line.len(),
+        common::CLI_STDERR_RESULT_MAX_LINE_BYTES
+    );
 
     stderr_payload.push_str("\ncrlf-line\r");
     stderr_payload.push_str(&format!("\n{exact_limit_line}"));
     stderr_payload.push_str(&format!("\ncodex stderr includes {secret}"));
-    stderr_payload.push_str(&format!("\n{}", "x".repeat(16 * 1024 + 1)));
+    stderr_payload.push_str(&format!(
+        "\n{}",
+        "x".repeat(common::CLI_STDERR_RESULT_MAX_LINE_BYTES + 1)
+    ));
     stderr_payload.push_str("\nafter-overlong-line");
 
     unsafe {
@@ -49,7 +55,10 @@ async fn cli_failure_stderr_is_masked_in_result() -> Result<(), Box<dyn std::err
     .expect("execute_cli should return promptly")?;
 
     assert_eq!(cli_result.exit_code, 1);
-    assert_eq!(cli_result.stderr_lines.len(), 200);
+    assert_eq!(
+        cli_result.stderr_lines.len(),
+        common::CLI_STDERR_RESULT_MAX_LINES
+    );
     let stderr = cli_result.stderr_lines.join("\n");
     assert_eq!(
         cli_result.stderr_lines.first().map(String::as_str),
@@ -85,7 +94,7 @@ async fn cli_failure_stderr_is_masked_in_result() -> Result<(), Box<dyn std::err
         "stderr result should keep lines at the exact size limit, got: {stderr}"
     );
     assert!(
-        stderr.contains("[stderr line omitted: exceeded diagnostic size limit]"),
+        stderr.contains(common::CLI_STDERR_OMITTED_LONG_LINE),
         "stderr result should omit overlong lines, got: {stderr}"
     );
     assert!(

--- a/crates/guest-agent/tests/cli_stderr_logging.rs
+++ b/crates/guest-agent/tests/cli_stderr_logging.rs
@@ -23,6 +23,10 @@ async fn cli_failure_stderr_is_masked_in_result() -> Result<(), Box<dyn std::err
         "exact-limit-{}",
         "x".repeat(common::CLI_STDERR_RESULT_MAX_LINE_BYTES - "exact-limit-".len())
     );
+    let overlong_secret_line = format!(
+        "overlong-secret-prefix-{secret}-{}",
+        "x".repeat(common::CLI_STDERR_RESULT_MAX_LINE_BYTES)
+    );
     assert_eq!(
         exact_limit_line.len(),
         common::CLI_STDERR_RESULT_MAX_LINE_BYTES
@@ -31,10 +35,7 @@ async fn cli_failure_stderr_is_masked_in_result() -> Result<(), Box<dyn std::err
     stderr_payload.push_str("\ncrlf-line\r");
     stderr_payload.push_str(&format!("\n{exact_limit_line}"));
     stderr_payload.push_str(&format!("\ncodex stderr includes {secret}"));
-    stderr_payload.push_str(&format!(
-        "\n{}",
-        "x".repeat(common::CLI_STDERR_RESULT_MAX_LINE_BYTES + 1)
-    ));
+    stderr_payload.push_str(&format!("\n{overlong_secret_line}"));
     stderr_payload.push_str("\nafter-overlong-line");
 
     unsafe {
@@ -96,6 +97,10 @@ async fn cli_failure_stderr_is_masked_in_result() -> Result<(), Box<dyn std::err
     assert!(
         stderr.contains(common::CLI_STDERR_OMITTED_LONG_LINE),
         "stderr result should omit overlong lines, got: {stderr}"
+    );
+    assert!(
+        !stderr.contains("overlong-secret-prefix"),
+        "stderr result should not expose omitted overlong line content, got: {stderr}"
     );
     assert!(
         stderr.contains("after-overlong-line"),

--- a/crates/guest-agent/tests/cli_stderr_logging.rs
+++ b/crates/guest-agent/tests/cli_stderr_logging.rs
@@ -19,7 +19,14 @@ async fn cli_failure_stderr_is_masked_in_result() -> Result<(), Box<dyn std::err
         .map(|i| format!("line-{i}"))
         .collect::<Vec<_>>()
         .join("\n");
+    let exact_limit_line = format!(
+        "exact-limit-{}",
+        "x".repeat(16 * 1024 - "exact-limit-".len())
+    );
+    assert_eq!(exact_limit_line.len(), 16 * 1024);
+
     stderr_payload.push_str("\ncrlf-line\r");
+    stderr_payload.push_str(&format!("\n{exact_limit_line}"));
     stderr_payload.push_str(&format!("\ncodex stderr includes {secret}"));
     stderr_payload.push_str(&format!("\n{}", "x".repeat(16 * 1024 + 1)));
     stderr_payload.push_str("\nafter-overlong-line");
@@ -46,10 +53,10 @@ async fn cli_failure_stderr_is_masked_in_result() -> Result<(), Box<dyn std::err
     let stderr = cli_result.stderr_lines.join("\n");
     assert_eq!(
         cli_result.stderr_lines.first().map(String::as_str),
-        Some("line-5")
+        Some("line-6")
     );
     assert!(
-        !cli_result.stderr_lines.iter().any(|line| line == "line-4"),
+        !cli_result.stderr_lines.iter().any(|line| line == "line-5"),
         "stderr result should drop old lines from the bounded tail, got: {stderr}"
     );
     assert!(
@@ -69,6 +76,13 @@ async fn cli_failure_stderr_is_masked_in_result() -> Result<(), Box<dyn std::err
     assert!(
         stderr.contains("codex stderr includes ***"),
         "stderr result should keep masked diagnostic, got: {stderr}"
+    );
+    assert!(
+        cli_result
+            .stderr_lines
+            .iter()
+            .any(|line| line == &exact_limit_line),
+        "stderr result should keep lines at the exact size limit, got: {stderr}"
     );
     assert!(
         stderr.contains("[stderr line omitted: exceeded diagnostic size limit]"),

--- a/crates/guest-agent/tests/cli_stderr_logging.rs
+++ b/crates/guest-agent/tests/cli_stderr_logging.rs
@@ -16,7 +16,13 @@ async fn cli_failure_stderr_is_masked_in_result() -> Result<(), Box<dyn std::err
     let tmp = tempfile::tempdir()?;
     let secret = "super-secret-value";
     let mut stderr_payload = (0..(common::CLI_STDERR_RESULT_MAX_LINES + 1))
-        .map(|i| format!("line-{i}"))
+        .map(|i| {
+            if i == 42 {
+                String::new()
+            } else {
+                format!("line-{i}")
+            }
+        })
         .collect::<Vec<_>>()
         .join("\n");
     let exact_limit_line = format!(
@@ -68,6 +74,10 @@ async fn cli_failure_stderr_is_masked_in_result() -> Result<(), Box<dyn std::err
     assert!(
         !cli_result.stderr_lines.iter().any(|line| line == "line-5"),
         "stderr result should drop old lines from the bounded tail, got: {stderr}"
+    );
+    assert!(
+        cli_result.stderr_lines.iter().any(String::is_empty),
+        "stderr result should preserve empty stderr lines, got: {stderr}"
     );
     assert!(
         cli_result

--- a/crates/guest-agent/tests/cli_stderr_no_newline.rs
+++ b/crates/guest-agent/tests/cli_stderr_no_newline.rs
@@ -1,0 +1,43 @@
+//! CLI stderr diagnostics must include a final line even without `\n`.
+//!
+//! This test lives in its own binary because `guest_agent::env` and
+//! `guest_agent::paths` cache values in process-wide `LazyLock`s.
+
+mod common;
+
+use guest_agent::http::HttpClient;
+use guest_agent::masker::SecretMasker;
+use std::time::Duration;
+
+#[tokio::test]
+async fn cli_failure_keeps_stderr_without_newline() -> Result<(), Box<dyn std::error::Error>> {
+    let mock = common::build_and_locate_mock()?;
+    let tmp = tempfile::tempdir()?;
+
+    unsafe {
+        common::setup_env(
+            &mock,
+            tmp.path(),
+            "@fail-no-newline:partial stderr line",
+            3,
+            1,
+        )?;
+    }
+
+    let masker = SecretMasker::from_raw("");
+    let cli_result = tokio::time::timeout(
+        Duration::from_secs(5),
+        guest_agent::cli::execute_cli(
+            &masker,
+            common::spawn_dummy_heartbeat(),
+            HttpClient::for_current_env()?,
+        ),
+    )
+    .await
+    .expect("execute_cli should return promptly")?;
+
+    assert_eq!(cli_result.exit_code, 1);
+    assert_eq!(cli_result.stderr_lines, vec!["partial stderr line"]);
+
+    Ok(())
+}

--- a/crates/guest-agent/tests/cli_stderr_overlong_lone_cr_no_newline.rs
+++ b/crates/guest-agent/tests/cli_stderr_overlong_lone_cr_no_newline.rs
@@ -1,0 +1,48 @@
+//! CLI stderr diagnostics must not treat a lone final `\r` as CRLF.
+//!
+//! This test lives in its own binary because `guest_agent::env` and
+//! `guest_agent::paths` cache values in process-wide `LazyLock`s.
+
+mod common;
+
+use guest_agent::http::HttpClient;
+use guest_agent::masker::SecretMasker;
+use std::time::Duration;
+
+#[tokio::test]
+async fn cli_failure_omits_overlong_stderr_ending_in_lone_cr()
+-> Result<(), Box<dyn std::error::Error>> {
+    let mock = common::build_and_locate_mock()?;
+    let tmp = tempfile::tempdir()?;
+    let overlong_line = format!("{}\r", "x".repeat(common::CLI_STDERR_RESULT_MAX_LINE_BYTES));
+
+    unsafe {
+        common::setup_env(
+            &mock,
+            tmp.path(),
+            &format!("@fail-no-newline:{overlong_line}"),
+            3,
+            1,
+        )?;
+    }
+
+    let masker = SecretMasker::from_raw("");
+    let cli_result = tokio::time::timeout(
+        Duration::from_secs(5),
+        guest_agent::cli::execute_cli(
+            &masker,
+            common::spawn_dummy_heartbeat(),
+            HttpClient::for_current_env()?,
+        ),
+    )
+    .await
+    .expect("execute_cli should return promptly")?;
+
+    assert_eq!(cli_result.exit_code, 1);
+    assert_eq!(
+        cli_result.stderr_lines,
+        vec![common::CLI_STDERR_OMITTED_LONG_LINE]
+    );
+
+    Ok(())
+}

--- a/crates/guest-agent/tests/cli_stderr_overlong_no_newline.rs
+++ b/crates/guest-agent/tests/cli_stderr_overlong_no_newline.rs
@@ -1,0 +1,47 @@
+//! CLI stderr diagnostics must omit an overlong final line without `\n`.
+//!
+//! This test lives in its own binary because `guest_agent::env` and
+//! `guest_agent::paths` cache values in process-wide `LazyLock`s.
+
+mod common;
+
+use guest_agent::http::HttpClient;
+use guest_agent::masker::SecretMasker;
+use std::time::Duration;
+
+#[tokio::test]
+async fn cli_failure_omits_overlong_final_stderr() -> Result<(), Box<dyn std::error::Error>> {
+    let mock = common::build_and_locate_mock()?;
+    let tmp = tempfile::tempdir()?;
+    let overlong_line = "x".repeat(16 * 1024 + 1);
+
+    unsafe {
+        common::setup_env(
+            &mock,
+            tmp.path(),
+            &format!("@fail-no-newline:{overlong_line}"),
+            3,
+            1,
+        )?;
+    }
+
+    let masker = SecretMasker::from_raw("");
+    let cli_result = tokio::time::timeout(
+        Duration::from_secs(5),
+        guest_agent::cli::execute_cli(
+            &masker,
+            common::spawn_dummy_heartbeat(),
+            HttpClient::for_current_env()?,
+        ),
+    )
+    .await
+    .expect("execute_cli should return promptly")?;
+
+    assert_eq!(cli_result.exit_code, 1);
+    assert_eq!(
+        cli_result.stderr_lines,
+        vec!["[stderr line omitted: exceeded diagnostic size limit]"]
+    );
+
+    Ok(())
+}

--- a/crates/guest-agent/tests/cli_stderr_overlong_no_newline.rs
+++ b/crates/guest-agent/tests/cli_stderr_overlong_no_newline.rs
@@ -13,7 +13,7 @@ use std::time::Duration;
 async fn cli_failure_omits_overlong_final_stderr() -> Result<(), Box<dyn std::error::Error>> {
     let mock = common::build_and_locate_mock()?;
     let tmp = tempfile::tempdir()?;
-    let overlong_line = "x".repeat(16 * 1024 + 1);
+    let overlong_line = "x".repeat(common::CLI_STDERR_RESULT_MAX_LINE_BYTES + 1);
 
     unsafe {
         common::setup_env(
@@ -40,7 +40,7 @@ async fn cli_failure_omits_overlong_final_stderr() -> Result<(), Box<dyn std::er
     assert_eq!(cli_result.exit_code, 1);
     assert_eq!(
         cli_result.stderr_lines,
-        vec!["[stderr line omitted: exceeded diagnostic size limit]"]
+        vec![common::CLI_STDERR_OMITTED_LONG_LINE]
     );
 
     Ok(())

--- a/crates/guest-agent/tests/common/mod.rs
+++ b/crates/guest-agent/tests/common/mod.rs
@@ -112,6 +112,7 @@ pub fn build_and_locate_mock() -> Result<PathBuf, String> {
 /// - `@hang-after-result-deaf` → SIGKILL escalation path
 /// - `@exit-after-result` → happy path (no signal ever fires)
 /// - `@fail-no-newline:<message>` → stderr EOF without trailing newline
+/// - `@fail-invalid-utf8` → stderr bytes that are not valid UTF-8
 /// - `@stuck-tool-deaf` → forced-termination SIGKILL escalation path
 /// - `@stuck-tool-closed-stdout-deaf` → stdout EOF before forced termination
 ///

--- a/crates/guest-agent/tests/common/mod.rs
+++ b/crates/guest-agent/tests/common/mod.rs
@@ -113,6 +113,7 @@ pub fn build_and_locate_mock() -> Result<PathBuf, String> {
 /// - `@exit-after-result` → happy path (no signal ever fires)
 /// - `@fail-no-newline:<message>` → stderr EOF without trailing newline
 /// - `@fail-invalid-utf8` → stderr bytes that are not valid UTF-8
+/// - `@fail-invalid-utf8-long` → invalid UTF-8 whose lossy form exceeds the limit
 /// - `@stuck-tool-deaf` → forced-termination SIGKILL escalation path
 /// - `@stuck-tool-closed-stdout-deaf` → stdout EOF before forced termination
 ///

--- a/crates/guest-agent/tests/common/mod.rs
+++ b/crates/guest-agent/tests/common/mod.rs
@@ -100,6 +100,7 @@ pub fn build_and_locate_mock() -> Result<PathBuf, String> {
 /// - `@hang-after-result` → SIGTERM path
 /// - `@hang-after-result-deaf` → SIGKILL escalation path
 /// - `@exit-after-result` → happy path (no signal ever fires)
+/// - `@fail-no-newline:<message>` → stderr EOF without trailing newline
 /// - `@stuck-tool-deaf` → forced-termination SIGKILL escalation path
 /// - `@stuck-tool-closed-stdout-deaf` → stdout EOF before forced termination
 ///

--- a/crates/guest-agent/tests/common/mod.rs
+++ b/crates/guest-agent/tests/common/mod.rs
@@ -36,7 +36,7 @@ pub const CLEAN_EXIT: i32 = 0;
 /// `guest_agent::cli::CliExecutionResult`.
 pub const CLI_STDERR_RESULT_MAX_LINES: usize = 200;
 
-/// Documented maximum raw byte length for one returned stderr line.
+/// Documented maximum byte length for one returned stderr line after CRLF normalization.
 pub const CLI_STDERR_RESULT_MAX_LINE_BYTES: usize = 16 * 1024;
 
 /// Documented replacement for a stderr line that exceeds the diagnostic limit.

--- a/crates/guest-agent/tests/common/mod.rs
+++ b/crates/guest-agent/tests/common/mod.rs
@@ -32,6 +32,17 @@ pub const SIGKILL_EXIT: i32 = 137;
 /// Normal clean exit. Reap should never fire on this path.
 pub const CLEAN_EXIT: i32 = 0;
 
+/// Documented maximum number of stderr lines returned in
+/// `guest_agent::cli::CliExecutionResult`.
+pub const CLI_STDERR_RESULT_MAX_LINES: usize = 200;
+
+/// Documented maximum raw byte length for one returned stderr line.
+pub const CLI_STDERR_RESULT_MAX_LINE_BYTES: usize = 16 * 1024;
+
+/// Documented replacement for a stderr line that exceeds the diagnostic limit.
+pub const CLI_STDERR_OMITTED_LONG_LINE: &str =
+    "[stderr line omitted: exceeded diagnostic size limit]";
+
 /// Build the mock binary (idempotent when up to date) and resolve its
 /// filesystem path.
 ///

--- a/crates/guest-mock-claude/src/main.rs
+++ b/crates/guest-mock-claude/src/main.rs
@@ -7,6 +7,9 @@
 //!
 //! Special test prefixes:
 //!   @fail:<message>           - Output message to stderr and exit with code 1
+//!   @fail-no-newline:<message>
+//!                             - Output message to stderr without a trailing
+//!                               newline and exit with code 1
 //!   @stuck-tool               - Emit WebFetch tool_use then hang (test stuck-tool watchdog)
 //!   @stuck-tool-deaf          - Same, but ignores SIGTERM so only SIGKILL
 //!                               can terminate it
@@ -312,6 +315,13 @@ fn run_stream_json_mode(prompt: &str, session_id: &str) -> ExitCode {
 fn main() -> ExitCode {
     let args: Vec<String> = std::env::args().skip(1).collect();
     let parsed = parse_args(&args);
+
+    // Special test prefix: @fail-no-newline:<message>
+    if let Some(msg) = parsed.prompt.strip_prefix("@fail-no-newline:") {
+        eprint!("{msg}");
+        let _ = std::io::stderr().flush();
+        return ExitCode::from(1);
+    }
 
     // Special test prefix: @fail:<message>
     if let Some(msg) = parsed.prompt.strip_prefix("@fail:") {

--- a/crates/guest-mock-claude/src/main.rs
+++ b/crates/guest-mock-claude/src/main.rs
@@ -10,6 +10,8 @@
 //!   @fail-no-newline:<message>
 //!                             - Output message to stderr without a trailing
 //!                               newline and exit with code 1
+//!   @fail-invalid-utf8        - Output invalid UTF-8 bytes to stderr and exit
+//!                               with code 1
 //!   @stuck-tool               - Emit WebFetch tool_use then hang (test stuck-tool watchdog)
 //!   @stuck-tool-deaf          - Same, but ignores SIGTERM so only SIGKILL
 //!                               can terminate it
@@ -319,6 +321,13 @@ fn main() -> ExitCode {
     // Special test prefix: @fail-no-newline:<message>
     if let Some(msg) = parsed.prompt.strip_prefix("@fail-no-newline:") {
         eprint!("{msg}");
+        let _ = std::io::stderr().flush();
+        return ExitCode::from(1);
+    }
+
+    // Special test prefix: @fail-invalid-utf8
+    if parsed.prompt == "@fail-invalid-utf8" {
+        let _ = std::io::stderr().write_all(b"invalid-\xff-stderr\n");
         let _ = std::io::stderr().flush();
         return ExitCode::from(1);
     }

--- a/crates/guest-mock-claude/src/main.rs
+++ b/crates/guest-mock-claude/src/main.rs
@@ -12,6 +12,8 @@
 //!                               newline and exit with code 1
 //!   @fail-invalid-utf8        - Output invalid UTF-8 bytes to stderr and exit
 //!                               with code 1
+//!   @fail-invalid-utf8-long   - Output many invalid UTF-8 bytes to stderr and exit
+//!                               with code 1
 //!   @stuck-tool               - Emit WebFetch tool_use then hang (test stuck-tool watchdog)
 //!   @stuck-tool-deaf          - Same, but ignores SIGTERM so only SIGKILL
 //!                               can terminate it
@@ -328,6 +330,15 @@ fn main() -> ExitCode {
     // Special test prefix: @fail-invalid-utf8
     if parsed.prompt == "@fail-invalid-utf8" {
         let _ = std::io::stderr().write_all(b"invalid-\xff-stderr\n");
+        let _ = std::io::stderr().flush();
+        return ExitCode::from(1);
+    }
+
+    // Special test prefix: @fail-invalid-utf8-long
+    if parsed.prompt == "@fail-invalid-utf8-long" {
+        let invalid = vec![0xff; 16 * 1024];
+        let _ = std::io::stderr().write_all(&invalid);
+        let _ = std::io::stderr().write_all(b"\n");
         let _ = std::io::stderr().flush();
         return ExitCode::from(1);
     }


### PR DESCRIPTION
## Summary

- Document `CliExecutionResult` and its public fields.
- Make CLI stderr result collection bounded: keep a masked diagnostic tail and omit overlong lines instead of partially returning them.
- Decode invalid UTF-8 stderr lossily so diagnostics remain valid strings.
- Cover stderr masking, tail bounding, exact line-size limit, CRLF trimming, invalid UTF-8, overlong-line omission, EOF-without-newline, and overlong EOF-without-newline through `execute_cli` integration paths.

Closes #12930

## Tests

- `rm -rf /tmp/vm3-guest-agent-stderr-target && CARGO_INCREMENTAL=0 cargo clippy --manifest-path crates/Cargo.toml --target-dir /tmp/vm3-guest-agent-stderr-target -p guest-agent -p guest-mock-claude --lib --bins --tests -- -D warnings`
- `cargo test --manifest-path crates/Cargo.toml --target-dir /tmp/vm3-guest-agent-stderr-target -p guest-agent --test cli_stderr_logging`
- `cargo test --manifest-path crates/Cargo.toml --target-dir /tmp/vm3-guest-agent-stderr-target -p guest-agent --test cli_stderr_no_newline`
- `cargo test --manifest-path crates/Cargo.toml --target-dir /tmp/vm3-guest-agent-stderr-target -p guest-agent --test cli_stderr_overlong_no_newline`
- `cargo test --manifest-path crates/Cargo.toml --target-dir /tmp/vm3-guest-agent-stderr-target -p guest-agent --test cli_stderr_invalid_utf8`