### PR TITLE
refactor(api): migrate permission access resolve route

### DIFF
--- a/turbo/apps/api/src/lib/require-agent-permission.ts
+++ b/turbo/apps/api/src/lib/require-agent-permission.ts
@@ -5,6 +5,8 @@ type ForbiddenResponse = {
   };
 };
 
+type AgentVisibility = "public" | "private";
+
 /**
  * Owner-OR-admin gate for per-agent write operations.
  *
@@ -14,15 +16,23 @@ export function requireAgentPermission(
   agentOwner: string,
   member: { readonly userId: string; readonly role: string },
   action: string,
+  options?: { readonly visibility?: AgentVisibility | null },
 ): ForbiddenResponse | null {
-  if (member.role === "admin" || member.userId === agentOwner) {
+  if (
+    member.userId === agentOwner ||
+    (options?.visibility !== "private" && member.role === "admin")
+  ) {
     return null;
   }
+  const ownerLabel =
+    options?.visibility === "private"
+      ? "the private agent owner"
+      : "the agent owner or org admin";
   return {
     status: 403 as const,
     body: {
       error: {
-        message: `Only the agent owner or org admin can ${action}`,
+        message: `Only ${ownerLabel} can ${action}`,
         code: "FORBIDDEN",
       },
     },

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-permission-access-requests.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-permission-access-requests.test.ts
@@ -3,7 +3,11 @@ import { randomUUID } from "node:crypto";
 import { command, createStore } from "ccstate";
 import { eq } from "drizzle-orm";
 import { beforeEach, describe, expect, it } from "vitest";
-import { permissionAccessRequestsListContract } from "@vm0/api-contracts/contracts/zero-agents";
+import type { RawPermissionPolicies } from "@vm0/connectors/firewall-types";
+import {
+  permissionAccessRequestsListContract,
+  permissionAccessRequestsResolveContract,
+} from "@vm0/api-contracts/contracts/zero-agents";
 import { agentComposes } from "@vm0/db/schema/agent-compose";
 import { orgCache } from "@vm0/db/schema/org-cache";
 import { orgMembersCache } from "@vm0/db/schema/org-members-cache";
@@ -34,6 +38,7 @@ interface SeedPermissionAccessOrgValues {
   readonly ownerUserId?: string;
   readonly ownerRole?: OrgRole;
   readonly visibility?: AgentVisibility;
+  readonly permissionPolicies?: RawPermissionPolicies;
 }
 
 interface SeedOrgMemberValues {
@@ -48,6 +53,7 @@ interface SeedAccessRequestValues {
   readonly requesterUserId: string;
   readonly connectorRef?: string;
   readonly permission?: string;
+  readonly action?: "allow" | "deny";
   readonly status?: string;
   readonly reason?: string;
   readonly method?: string;
@@ -98,6 +104,7 @@ const seedPermissionAccessOrg$ = command(
       owner: ownerUserId,
       name: agentName,
       visibility: values.visibility ?? "public",
+      permissionPolicies: values.permissionPolicies,
     });
     signal.throwIfAborted();
 
@@ -128,6 +135,7 @@ const seedAccessRequest$ = command(
         requesterUserId: values.requesterUserId,
         connectorRef: values.connectorRef ?? "github",
         permission: values.permission ?? "issues:read",
+        action: values.action,
         status: values.status ?? "pending",
         reason: values.reason,
         method: values.method,
@@ -177,8 +185,24 @@ function apiClient() {
   return setupApp({ context })(permissionAccessRequestsListContract);
 }
 
+function resolveApiClient() {
+  return setupApp({ context })(permissionAccessRequestsResolveContract);
+}
+
 function authHeaders() {
   return { authorization: "Bearer clerk-session" };
+}
+
+async function readAgentPolicies(
+  agentId: string,
+): Promise<RawPermissionPolicies | null | undefined> {
+  const db = store.set(writeDb$);
+  const [row] = await db
+    .select({ permissionPolicies: zeroAgents.permissionPolicies })
+    .from(zeroAgents)
+    .where(eq(zeroAgents.id, agentId))
+    .limit(1);
+  return row?.permissionPolicies;
 }
 
 function mockClerkUsers(
@@ -485,6 +509,327 @@ describe("GET /api/zero/permission-access-requests", () => {
       apiClient().list({
         headers: {},
         query: { agentId: randomUUID() },
+      }),
+      [401],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+});
+
+describe("PUT /api/zero/permission-access-requests", () => {
+  const track = createFixtureTracker<PermissionAccessOrgFixture>((fixture) => {
+    return store.set(deletePermissionAccessOrg$, fixture, context.signal);
+  });
+
+  it("approves a request and updates permission policies", async () => {
+    const fixture = await track(
+      store.set(seedPermissionAccessOrg$, {}, context.signal),
+    );
+    const request = await store.set(
+      seedAccessRequest$,
+      {
+        orgId: fixture.orgId,
+        agentId: fixture.agentId,
+        requesterUserId: fixture.ownerUserId,
+        connectorRef: "github",
+        permission: "issues:read",
+      },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.ownerUserId, fixture.orgId);
+
+    const response = await accept(
+      resolveApiClient().resolve({
+        headers: authHeaders(),
+        body: { requestId: request.id, action: "approve" },
+      }),
+      [200],
+    );
+
+    expect(response.body.status).toBe("approved");
+    expect(response.body.resolvedBy).toBe(fixture.ownerUserId);
+    expect(response.body.resolvedAt).toStrictEqual(expect.any(String));
+    await expect(readAgentPolicies(fixture.agentId)).resolves.toStrictEqual({
+      github: { "issues:read": "allow" },
+    });
+  });
+
+  it("approves a deny request and stores a deny policy", async () => {
+    const fixture = await track(
+      store.set(seedPermissionAccessOrg$, {}, context.signal),
+    );
+    const request = await store.set(
+      seedAccessRequest$,
+      {
+        orgId: fixture.orgId,
+        agentId: fixture.agentId,
+        requesterUserId: fixture.ownerUserId,
+        connectorRef: "github",
+        permission: "issues:read",
+        action: "deny",
+      },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.ownerUserId, fixture.orgId);
+
+    const response = await accept(
+      resolveApiClient().resolve({
+        headers: authHeaders(),
+        body: { requestId: request.id, action: "approve" },
+      }),
+      [200],
+    );
+
+    expect(response.body.status).toBe("approved");
+    await expect(readAgentPolicies(fixture.agentId)).resolves.toStrictEqual({
+      github: { "issues:read": "deny" },
+    });
+  });
+
+  it("rejects a request without updating permission policies", async () => {
+    const fixture = await track(
+      store.set(seedPermissionAccessOrg$, {}, context.signal),
+    );
+    const request = await store.set(
+      seedAccessRequest$,
+      {
+        orgId: fixture.orgId,
+        agentId: fixture.agentId,
+        requesterUserId: fixture.ownerUserId,
+        connectorRef: "github",
+        permission: "issues:read",
+      },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.ownerUserId, fixture.orgId);
+
+    const response = await accept(
+      resolveApiClient().resolve({
+        headers: authHeaders(),
+        body: { requestId: request.id, action: "reject" },
+      }),
+      [200],
+    );
+
+    expect(response.body.status).toBe("rejected");
+    await expect(readAgentPolicies(fixture.agentId)).resolves.toBeNull();
+  });
+
+  it("allows an org admin to resolve another user's agent requests", async () => {
+    const fixture = await track(
+      store.set(seedPermissionAccessOrg$, {}, context.signal),
+    );
+    const adminUserId = `user_${randomUUID()}`;
+    await store.set(
+      seedOrgMember$,
+      { orgId: fixture.orgId, userId: adminUserId, role: "admin" },
+      context.signal,
+    );
+    const request = await store.set(
+      seedAccessRequest$,
+      {
+        orgId: fixture.orgId,
+        agentId: fixture.agentId,
+        requesterUserId: fixture.ownerUserId,
+      },
+      context.signal,
+    );
+    mocks.clerk.session(adminUserId, fixture.orgId, "org:admin");
+
+    const response = await accept(
+      resolveApiClient().resolve({
+        headers: authHeaders(),
+        body: { requestId: request.id, action: "approve" },
+      }),
+      [200],
+    );
+
+    expect(response.body.status).toBe("approved");
+    expect(response.body.resolvedBy).toBe(adminUserId);
+  });
+
+  it("returns 403 for org admins resolving private agent requests they do not own", async () => {
+    const fixture = await track(
+      store.set(
+        seedPermissionAccessOrg$,
+        { visibility: "private" },
+        context.signal,
+      ),
+    );
+    const adminUserId = `user_${randomUUID()}`;
+    await store.set(
+      seedOrgMember$,
+      { orgId: fixture.orgId, userId: adminUserId, role: "admin" },
+      context.signal,
+    );
+    const request = await store.set(
+      seedAccessRequest$,
+      {
+        orgId: fixture.orgId,
+        agentId: fixture.agentId,
+        requesterUserId: fixture.ownerUserId,
+      },
+      context.signal,
+    );
+    mocks.clerk.session(adminUserId, fixture.orgId, "org:admin");
+
+    const response = await accept(
+      resolveApiClient().resolve({
+        headers: authHeaders(),
+        body: { requestId: request.id, action: "approve" },
+      }),
+      [403],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message:
+          "Only the private agent owner can resolve permission access requests",
+        code: "FORBIDDEN",
+      },
+    });
+  });
+
+  it("returns 403 for non-owner members resolving requests", async () => {
+    const fixture = await track(
+      store.set(seedPermissionAccessOrg$, {}, context.signal),
+    );
+    const memberUserId = `user_${randomUUID()}`;
+    await store.set(
+      seedOrgMember$,
+      { orgId: fixture.orgId, userId: memberUserId, role: "member" },
+      context.signal,
+    );
+    const request = await store.set(
+      seedAccessRequest$,
+      {
+        orgId: fixture.orgId,
+        agentId: fixture.agentId,
+        requesterUserId: fixture.ownerUserId,
+      },
+      context.signal,
+    );
+    mocks.clerk.session(memberUserId, fixture.orgId, "org:member");
+
+    const response = await accept(
+      resolveApiClient().resolve({
+        headers: authHeaders(),
+        body: { requestId: request.id, action: "approve" },
+      }),
+      [403],
+    );
+
+    expect(response.body.error.code).toBe("FORBIDDEN");
+  });
+
+  it("returns 404 for nonexistent requests", async () => {
+    const fixture = await track(
+      store.set(seedPermissionAccessOrg$, {}, context.signal),
+    );
+    mocks.clerk.session(fixture.ownerUserId, fixture.orgId);
+
+    const requestId = randomUUID();
+    const response = await accept(
+      resolveApiClient().resolve({
+        headers: authHeaders(),
+        body: { requestId, action: "approve" },
+      }),
+      [404],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: `Access request not found: ${requestId}`,
+        code: "NOT_FOUND",
+      },
+    });
+  });
+
+  it("returns 400 for already resolved requests", async () => {
+    const fixture = await track(
+      store.set(seedPermissionAccessOrg$, {}, context.signal),
+    );
+    const request = await store.set(
+      seedAccessRequest$,
+      {
+        orgId: fixture.orgId,
+        agentId: fixture.agentId,
+        requesterUserId: fixture.ownerUserId,
+      },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.ownerUserId, fixture.orgId);
+
+    await accept(
+      resolveApiClient().resolve({
+        headers: authHeaders(),
+        body: { requestId: request.id, action: "approve" },
+      }),
+      [200],
+    );
+    const response = await accept(
+      resolveApiClient().resolve({
+        headers: authHeaders(),
+        body: { requestId: request.id, action: "reject" },
+      }),
+      [400],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Request already resolved with status: approved",
+        code: "ALREADY_RESOLVED",
+      },
+    });
+  });
+
+  it("preserves existing permission policies when approving", async () => {
+    const fixture = await track(
+      store.set(
+        seedPermissionAccessOrg$,
+        {
+          permissionPolicies: {
+            slack: { "channels:read": "allow" },
+          },
+        },
+        context.signal,
+      ),
+    );
+    const request = await store.set(
+      seedAccessRequest$,
+      {
+        orgId: fixture.orgId,
+        agentId: fixture.agentId,
+        requesterUserId: fixture.ownerUserId,
+        connectorRef: "github",
+        permission: "issues:read",
+      },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.ownerUserId, fixture.orgId);
+
+    await accept(
+      resolveApiClient().resolve({
+        headers: authHeaders(),
+        body: { requestId: request.id, action: "approve" },
+      }),
+      [200],
+    );
+
+    await expect(readAgentPolicies(fixture.agentId)).resolves.toStrictEqual({
+      slack: { "channels:read": "allow" },
+      github: { "issues:read": "allow" },
+    });
+  });
+
+  it("returns 401 without auth", async () => {
+    const response = await accept(
+      resolveApiClient().resolve({
+        headers: {},
+        body: { requestId: randomUUID(), action: "approve" },
       }),
       [401],
     );

--- a/turbo/apps/api/src/signals/routes/zero-permission-access-requests.ts
+++ b/turbo/apps/api/src/signals/routes/zero-permission-access-requests.ts
@@ -1,10 +1,16 @@
-import { computed } from "ccstate";
-import { permissionAccessRequestsListContract } from "@vm0/api-contracts/contracts/zero-agents";
+import { command, computed } from "ccstate";
+import {
+  permissionAccessRequestsListContract,
+  permissionAccessRequestsResolveContract,
+} from "@vm0/api-contracts/contracts/zero-agents";
 
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
-import { queryOf } from "../context/request";
-import { listPermissionAccessRequests } from "../services/zero-permission-access-requests.service";
+import { bodyResultOf, queryOf } from "../context/request";
+import {
+  listPermissionAccessRequests,
+  resolvePermissionAccessRequest$,
+} from "../services/zero-permission-access-requests.service";
 import type { RouteEntry } from "../route";
 
 const missingLookupQuery = Object.freeze({
@@ -18,6 +24,9 @@ const missingLookupQuery = Object.freeze({
 });
 
 const listQuery$ = queryOf(permissionAccessRequestsListContract.list);
+const resolveBody$ = bodyResultOf(
+  permissionAccessRequestsResolveContract.resolve,
+);
 
 const listPermissionAccessRequestsInner$ = computed(async (get) => {
   const auth = get(organizationAuthContext$);
@@ -41,6 +50,35 @@ const listPermissionAccessRequestsInner$ = computed(async (get) => {
   return { status: 200 as const, body: [...requests] };
 });
 
+const resolvePermissionAccessRequestInner$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const auth = get(organizationAuthContext$);
+    const bodyResult = await get(resolveBody$);
+    signal.throwIfAborted();
+    if (!bodyResult.ok) {
+      return bodyResult.response;
+    }
+
+    const result = await set(
+      resolvePermissionAccessRequest$,
+      {
+        orgId: auth.orgId,
+        userId: auth.userId,
+        role: auth.orgRole ?? "member",
+        requestId: bodyResult.data.requestId,
+        action: bodyResult.data.action,
+      },
+      signal,
+    );
+    signal.throwIfAborted();
+
+    if ("kind" in result) {
+      return { status: 200 as const, body: result.request };
+    }
+    return result;
+  },
+);
+
 export const zeroPermissionAccessRequestsRoutes: readonly RouteEntry[] = [
   {
     route: permissionAccessRequestsListContract.list,
@@ -51,6 +89,17 @@ export const zeroPermissionAccessRequestsRoutes: readonly RouteEntry[] = [
         missingOrganizationStatus: 401,
       },
       listPermissionAccessRequestsInner$,
+    ),
+  },
+  {
+    route: permissionAccessRequestsResolveContract.resolve,
+    handler: authRoute(
+      {
+        requiredCapability: "agent:write",
+        requireOrganization: true,
+        missingOrganizationStatus: 401,
+      },
+      resolvePermissionAccessRequestInner$,
     ),
   },
 ];

--- a/turbo/apps/api/src/signals/services/zero-permission-access-requests.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-permission-access-requests.service.ts
@@ -1,14 +1,34 @@
-import { computed, type Computed } from "ccstate";
+import { command, computed, type Computed } from "ccstate";
+import { CONNECTOR_TYPES } from "@vm0/connectors/connectors";
+import type { RawPermissionPolicies } from "@vm0/connectors/firewall-types";
 import { and, eq, or } from "drizzle-orm";
-import type { PermissionAccessRequestResponse } from "@vm0/api-contracts/contracts/zero-agents";
+import type {
+  PermissionAccessRequestResponse,
+  ResolvePermissionAccessRequest,
+} from "@vm0/api-contracts/contracts/zero-agents";
 import { permissionAccessRequests } from "@vm0/db/schema/permission-access-request";
+import { slackOrgConnections } from "@vm0/db/schema/slack-org-connection";
+import { slackOrgInstallations } from "@vm0/db/schema/slack-org-installation";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
 
-import { db$ } from "../external/db";
+import { env } from "../../lib/env";
+import { notFound } from "../../lib/error";
+import { logger } from "../../lib/log";
+import { requireAgentPermission } from "../../lib/require-agent-permission";
+import { db$, writeDb$, type Db } from "../external/db";
 import { clerk$ } from "../external/clerk";
+import {
+  createSlackClient,
+  postMessage,
+} from "../external/slack-message-client";
+import { nowDate } from "../external/time";
 import type { ApiOrgRole } from "../../types/auth";
+import { decryptSecretValue } from "./crypto.utils";
 
 type PermissionAccessRequestRow = typeof permissionAccessRequests.$inferSelect;
+type ForbiddenResponse = NonNullable<ReturnType<typeof requireAgentPermission>>;
+
+const log = logger("zero-permission-access-requests");
 
 interface ListPermissionAccessRequestsArgs {
   readonly orgId: string;
@@ -19,8 +39,44 @@ interface ListPermissionAccessRequestsArgs {
   readonly status?: string;
 }
 
+interface ResolvePermissionAccessRequestArgs {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly role: string;
+  readonly requestId: string;
+  readonly action: ResolvePermissionAccessRequest["action"];
+}
+
+type AlreadyResolvedResponse = {
+  readonly status: 400;
+  readonly body: {
+    readonly error: {
+      readonly message: string;
+      readonly code: "ALREADY_RESOLVED";
+    };
+  };
+};
+
+type ResolvePermissionAccessRequestResult =
+  | { readonly kind: "ok"; readonly request: PermissionAccessRequestResponse }
+  | ReturnType<typeof notFound>
+  | ForbiddenResponse
+  | AlreadyResolvedResponse;
+
 function visibleZeroAgentCondition(userId: string) {
   return or(eq(zeroAgents.visibility, "public"), eq(zeroAgents.owner, userId));
+}
+
+function alreadyResolved(status: string): AlreadyResolvedResponse {
+  return {
+    status: 400 as const,
+    body: {
+      error: {
+        message: `Request already resolved with status: ${status}`,
+        code: "ALREADY_RESOLVED",
+      },
+    },
+  };
 }
 
 function permissionAccessRequestStatus(
@@ -34,7 +90,7 @@ function permissionAccessRequestStatus(
 
 function formatPermissionAccessRequest(
   row: PermissionAccessRequestRow,
-  nameMap: ReadonlyMap<string, string>,
+  nameMap: ReadonlyMap<string, string> = new Map(),
 ): PermissionAccessRequestResponse {
   return {
     id: row.id,
@@ -52,6 +108,66 @@ function formatPermissionAccessRequest(
     resolvedAt: row.resolvedAt?.toISOString() ?? null,
     createdAt: row.createdAt.toISOString(),
   };
+}
+
+function connectorLabel(connectorRef: string): string {
+  const config = CONNECTOR_TYPES[connectorRef as keyof typeof CONNECTOR_TYPES];
+  return config?.label ?? connectorRef;
+}
+
+function buildReviewUrl(agentId: string, requestId: string): string {
+  const appUrl = env("VM0_WEB_URL");
+  return `${appUrl}/agents/${agentId}/permissions?request=${requestId}`;
+}
+
+async function notifyRequesterOfResolution(
+  db: Db,
+  params: {
+    readonly orgId: string;
+    readonly requestId: string;
+    readonly agentId: string;
+    readonly agentDisplayName: string;
+    readonly requesterUserId: string;
+    readonly permission: string;
+    readonly connectorRef: string;
+    readonly action: string;
+    readonly resolution: ResolvePermissionAccessRequest["action"];
+  },
+): Promise<void> {
+  const [installation] = await db
+    .select()
+    .from(slackOrgInstallations)
+    .where(eq(slackOrgInstallations.orgId, params.orgId))
+    .limit(1);
+  if (!installation) {
+    return;
+  }
+
+  const [connection] = await db
+    .select()
+    .from(slackOrgConnections)
+    .where(
+      and(
+        eq(slackOrgConnections.vm0UserId, params.requesterUserId),
+        eq(slackOrgConnections.slackWorkspaceId, installation.slackWorkspaceId),
+      ),
+    )
+    .limit(1);
+  if (!connection) {
+    return;
+  }
+
+  const client = createSlackClient(
+    decryptSecretValue(installation.encryptedBotToken),
+  );
+  const label = connectorLabel(params.connectorRef);
+  const outcome = params.resolution === "approve" ? "approved" : "denied";
+  const url = buildReviewUrl(params.agentId, params.requestId);
+  await postMessage(
+    client,
+    connection.slackUserId,
+    `Your request to ${params.action} "${params.permission}" on ${label} for agent ${params.agentDisplayName} has been ${outcome}. <${url}|View>`,
+  );
 }
 
 async function requesterNameMap(
@@ -164,3 +280,117 @@ export function listPermissionAccessRequests(
     },
   );
 }
+
+export const resolvePermissionAccessRequest$ = command(
+  async (
+    { set },
+    args: ResolvePermissionAccessRequestArgs,
+    signal: AbortSignal,
+  ): Promise<ResolvePermissionAccessRequestResult> => {
+    const db = set(writeDb$);
+    const [row] = await db
+      .select({
+        request: permissionAccessRequests,
+        agentOwner: zeroAgents.owner,
+        agentDisplayName: zeroAgents.displayName,
+        agentVisibility: zeroAgents.visibility,
+      })
+      .from(permissionAccessRequests)
+      .innerJoin(
+        zeroAgents,
+        eq(permissionAccessRequests.agentId, zeroAgents.id),
+      )
+      .where(
+        and(
+          eq(permissionAccessRequests.id, args.requestId),
+          eq(permissionAccessRequests.orgId, args.orgId),
+        ),
+      )
+      .limit(1);
+    signal.throwIfAborted();
+
+    if (!row) {
+      return notFound(`Access request not found: ${args.requestId}`);
+    }
+
+    const forbidden = requireAgentPermission(
+      row.agentOwner,
+      { userId: args.userId, role: args.role },
+      "resolve permission access requests",
+      { visibility: row.agentVisibility },
+    );
+    if (forbidden) {
+      return forbidden;
+    }
+
+    const existing = row.request;
+    if (existing.status !== "pending") {
+      return alreadyResolved(existing.status);
+    }
+
+    const resolvedAt = nowDate();
+    const newStatus = args.action === "approve" ? "approved" : "rejected";
+    const [updated] = await db.transaction(async (tx) => {
+      if (args.action === "approve") {
+        const [agent] = await tx
+          .select({ permissionPolicies: zeroAgents.permissionPolicies })
+          .from(zeroAgents)
+          .where(eq(zeroAgents.id, existing.agentId))
+          .limit(1);
+
+        const currentPolicies: RawPermissionPolicies =
+          agent?.permissionPolicies ?? {};
+        const refPolicies = currentPolicies[existing.connectorRef] ?? {};
+        const updatedPolicies: RawPermissionPolicies = {
+          ...currentPolicies,
+          [existing.connectorRef]: {
+            ...refPolicies,
+            [existing.permission]: existing.action,
+          },
+        };
+
+        await tx
+          .update(zeroAgents)
+          .set({ permissionPolicies: updatedPolicies, updatedAt: resolvedAt })
+          .where(eq(zeroAgents.id, existing.agentId));
+      }
+
+      return tx
+        .update(permissionAccessRequests)
+        .set({
+          status: newStatus,
+          resolvedBy: args.userId,
+          resolvedAt,
+        })
+        .where(eq(permissionAccessRequests.id, args.requestId))
+        .returning();
+    });
+    signal.throwIfAborted();
+
+    if (!updated) {
+      return notFound(`Access request not found: ${args.requestId}`);
+    }
+
+    log.debug(
+      `Resolved permission access request: ${args.requestId} as ${newStatus}`,
+    );
+
+    void notifyRequesterOfResolution(db, {
+      orgId: args.orgId,
+      requestId: args.requestId,
+      agentId: existing.agentId,
+      agentDisplayName: row.agentDisplayName ?? existing.agentId,
+      requesterUserId: existing.requesterUserId,
+      permission: existing.permission,
+      connectorRef: existing.connectorRef,
+      action: existing.action,
+      resolution: args.action,
+    }).catch((error: unknown) => {
+      log.error("Failed to notify requester of permission resolution", {
+        error,
+      });
+    });
+
+    return { kind: "ok", request: formatPermissionAccessRequest(updated) };
+  },
+);


### PR DESCRIPTION
## Summary
- add the API backend PUT /api/zero/permission-access-requests route
- migrate resolve logic for approve/reject, policy writes, private-agent permission checks, and Slack requester notification
- add API integration coverage for success, auth, authorization, not found, already resolved, deny, reject, and policy preservation cases

Closes #12896

## Tests
- pnpm format
- pnpm -F api exec vitest src/signals/routes/__tests__/zero-permission-access-requests.test.ts
- pnpm -F api lint
- pnpm check-types
- pnpm turbo run lint
- pnpm knip
- scripts/prepare.sh
- pnpm -F api exec vitest src/signals/routes/__tests__/zero-connectors-remote-agent-connect.test.ts
- pnpm vitest
- git diff --check