### PR TITLE
refactor: migrate agent sessions route to api

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -3,6 +3,7 @@ import { healthContract } from "@vm0/api-contracts/contracts/health";
 
 import { agentCheckpointsRoutes } from "./routes/agent-checkpoints-id";
 import { agentComposesByIdRoutes } from "./routes/agent-composes-id";
+import { agentSessionsRoutes } from "./routes/agent-sessions-id";
 import { authMeRoutes } from "./routes/auth-me";
 import { audioTranscriptionsV1Routes } from "./routes/audio-transcriptions-v1";
 import type { SignalRouteHandler } from "./context/route";
@@ -98,6 +99,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...usageRoutes,
   ...agentCheckpointsRoutes,
   ...agentComposesByIdRoutes,
+  ...agentSessionsRoutes,
   ...deviceTokenRoutes,
   ...zeroAgentInstructionsRoutes,
   ...zeroAgentsRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/agent-sessions-id.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/agent-sessions-id.test.ts
@@ -1,0 +1,345 @@
+import { randomUUID } from "node:crypto";
+
+import { sessionsByIdContract } from "@vm0/api-contracts/contracts/sessions";
+import {
+  agentComposes,
+  agentComposeVersions,
+} from "@vm0/db/schema/agent-compose";
+import { agentRuns } from "@vm0/db/schema/agent-run";
+import { agentSessions } from "@vm0/db/schema/agent-session";
+import type { ContextArtifact } from "@vm0/db/types";
+import { command, createStore } from "ccstate";
+import { eq } from "drizzle-orm";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { writeDb$ } from "../../external/db";
+import {
+  deleteUsageInsightFixture$,
+  seedCompose$,
+  seedRun$,
+  seedUsageInsightFixture$,
+  type UsageInsightFixture,
+} from "./helpers/zero-usage-insight";
+import {
+  createFixtureTracker,
+  createZeroRouteMocks,
+} from "./helpers/zero-route-test";
+
+const sessionIdForRun$ = command(
+  async ({ set }, runId: string, signal: AbortSignal): Promise<string> => {
+    const db = set(writeDb$);
+    const [row] = await db
+      .select({ sessionId: agentRuns.sessionId })
+      .from(agentRuns)
+      .where(eq(agentRuns.id, runId))
+      .limit(1);
+    signal.throwIfAborted();
+    if (!row) {
+      throw new Error("sessionIdForRun$: run not found");
+    }
+    return row.sessionId;
+  },
+);
+
+const updateSessionArtifacts$ = command(
+  async (
+    { set },
+    args: { readonly sessionId: string; readonly artifacts: ContextArtifact[] },
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const db = set(writeDb$);
+    await db
+      .update(agentSessions)
+      .set({ artifacts: args.artifacts })
+      .where(eq(agentSessions.id, args.sessionId));
+    signal.throwIfAborted();
+  },
+);
+
+const updateComposeHeadContent$ = command(
+  async (
+    { set },
+    args: { readonly composeId: string; readonly content: unknown },
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const db = set(writeDb$);
+    const [compose] = await db
+      .select({ headVersionId: agentComposes.headVersionId })
+      .from(agentComposes)
+      .where(eq(agentComposes.id, args.composeId))
+      .limit(1);
+    signal.throwIfAborted();
+    if (!compose?.headVersionId) {
+      throw new Error("updateComposeHeadContent$: compose head not found");
+    }
+
+    await db
+      .update(agentComposeVersions)
+      .set({ content: args.content })
+      .where(eq(agentComposeVersions.id, compose.headVersionId));
+    signal.throwIfAborted();
+  },
+);
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+
+function secretReference(name: string): string {
+  return `\${{ secrets.${name} }}`;
+}
+
+async function seedSession(
+  fixture: UsageInsightFixture,
+): Promise<{ readonly composeId: string; readonly sessionId: string }> {
+  const compose = await store.set(
+    seedCompose$,
+    { orgId: fixture.orgId, userId: fixture.userId },
+    context.signal,
+  );
+  const { runId } = await store.set(
+    seedRun$,
+    {
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      composeId: compose.composeId,
+      status: "completed",
+    },
+    context.signal,
+  );
+  const sessionId = await store.set(sessionIdForRun$, runId, context.signal);
+  return { composeId: compose.composeId, sessionId };
+}
+
+describe("GET /api/agent/sessions/:id", () => {
+  const track = createFixtureTracker<UsageInsightFixture>((fixture) => {
+    return store.set(deleteUsageInsightFixture$, fixture, context.signal);
+  });
+
+  it("returns 401 when the request is unauthenticated", async () => {
+    const client = setupApp({ context })(sessionsByIdContract);
+
+    const response = await accept(
+      client.getById({ params: { id: randomUUID() }, headers: {} }),
+      [401],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("returns 404 when the authenticated session has no active organization", async () => {
+    const fixture = await track(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, null);
+    const client = setupApp({ context })(sessionsByIdContract);
+
+    const response = await accept(
+      client.getById({
+        params: { id: randomUUID() },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [404],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Session not found", code: "NOT_FOUND" },
+    });
+  });
+
+  it("returns 404 when the session does not exist", async () => {
+    const fixture = await track(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    const client = setupApp({ context })(sessionsByIdContract);
+
+    const response = await accept(
+      client.getById({
+        params: { id: randomUUID() },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [404],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Session not found", code: "NOT_FOUND" },
+    });
+  });
+
+  it("returns 403 when the session belongs to another user", async () => {
+    const fixture = await track(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    const { sessionId } = await seedSession(fixture);
+    mocks.clerk.session(`user_${randomUUID()}`, fixture.orgId);
+    const client = setupApp({ context })(sessionsByIdContract);
+
+    const response = await accept(
+      client.getById({
+        params: { id: sessionId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [403],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "You do not have permission to access this session",
+        code: "FORBIDDEN",
+      },
+    });
+  });
+
+  it("returns 404 when the session belongs to another organization", async () => {
+    const fixture = await track(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    const { sessionId } = await seedSession(fixture);
+    mocks.clerk.session(fixture.userId, `org_${randomUUID()}`);
+    const client = setupApp({ context })(sessionsByIdContract);
+
+    const response = await accept(
+      client.getById({
+        params: { id: sessionId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [404],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Session not found", code: "NOT_FOUND" },
+    });
+  });
+
+  it("authorizes by session runtime organization rather than compose organization", async () => {
+    const composeFixture = await track(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    const runtimeFixture = await track(
+      Promise.resolve({
+        orgId: `org_${randomUUID()}`,
+        userId: composeFixture.userId,
+      }),
+    );
+    const compose = await store.set(
+      seedCompose$,
+      { orgId: composeFixture.orgId, userId: composeFixture.userId },
+      context.signal,
+    );
+    const { runId } = await store.set(
+      seedRun$,
+      {
+        orgId: runtimeFixture.orgId,
+        userId: runtimeFixture.userId,
+        composeId: compose.composeId,
+        status: "completed",
+      },
+      context.signal,
+    );
+    const sessionId = await store.set(sessionIdForRun$, runId, context.signal);
+    const client = setupApp({ context })(sessionsByIdContract);
+
+    mocks.clerk.session(runtimeFixture.userId, runtimeFixture.orgId);
+    const allowed = await accept(
+      client.getById({
+        params: { id: sessionId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+    expect(allowed.body.id).toBe(sessionId);
+
+    mocks.clerk.session(composeFixture.userId, composeFixture.orgId);
+    const denied = await accept(
+      client.getById({
+        params: { id: sessionId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [404],
+    );
+    expect(denied.body).toStrictEqual({
+      error: { message: "Session not found", code: "NOT_FOUND" },
+    });
+  });
+
+  it("returns session details with artifacts and required secret names", async () => {
+    const fixture = await track(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    const { composeId, sessionId } = await seedSession(fixture);
+    await store.set(
+      updateSessionArtifacts$,
+      {
+        sessionId,
+        artifacts: [
+          { name: "frontend", version: "v-fe-1", mountPath: "/workspace/fe" },
+          { name: "backend", version: "v-be-2", mountPath: "/workspace/be" },
+        ],
+      },
+      context.signal,
+    );
+    await store.set(
+      updateComposeHeadContent$,
+      {
+        composeId,
+        content: {
+          version: "1.0",
+          agents: {
+            "test-agent": {
+              framework: "claude-code",
+              env: {
+                API_KEY: secretReference("API_TOKEN"),
+                GITHUB_TOKEN: secretReference("GH_TOKEN"),
+              },
+            },
+          },
+        },
+      },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    const client = setupApp({ context })(sessionsByIdContract);
+
+    const response = await accept(
+      client.getById({
+        params: { id: sessionId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toMatchObject({
+      id: sessionId,
+      agentComposeId: composeId,
+      conversationId: null,
+      artifactNames: ["frontend", "backend"],
+      secretNames: ["API_TOKEN", "GH_TOKEN"],
+    });
+    expect(Number.isNaN(Date.parse(response.body.createdAt))).toBeFalsy();
+    expect(Number.isNaN(Date.parse(response.body.updatedAt))).toBeFalsy();
+  });
+
+  it("returns null secret names when the compose head has no secret references", async () => {
+    const fixture = await track(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    const { composeId, sessionId } = await seedSession(fixture);
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    const client = setupApp({ context })(sessionsByIdContract);
+
+    const response = await accept(
+      client.getById({
+        params: { id: sessionId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body.agentComposeId).toBe(composeId);
+    expect(response.body.artifactNames).toStrictEqual([]);
+    expect(response.body.secretNames).toBeNull();
+  });
+});

--- a/turbo/apps/api/src/signals/routes/agent-sessions-id.ts
+++ b/turbo/apps/api/src/signals/routes/agent-sessions-id.ts
@@ -1,0 +1,59 @@
+import { computed } from "ccstate";
+import { sessionsByIdContract } from "@vm0/api-contracts/contracts/sessions";
+
+import { authContext$ } from "../auth/auth-context";
+import { authRoute } from "../auth/auth-route";
+import { pathParamsOf } from "../context/request";
+import { notFound } from "../../lib/error";
+import { agentSessionById } from "../services/agent-sessions.service";
+import type { RouteEntry } from "../route";
+
+const sessionNotFound = notFound("Session not found");
+
+function sessionForbidden() {
+  return {
+    status: 403 as const,
+    body: {
+      error: {
+        message: "You do not have permission to access this session",
+        code: "FORBIDDEN",
+      },
+    },
+  };
+}
+
+const getSessionByIdInner$ = computed(async (get) => {
+  const auth = get(authContext$);
+  const params = get(pathParamsOf(sessionsByIdContract.getById));
+
+  if (!auth.orgId) {
+    return sessionNotFound;
+  }
+
+  const result = await get(
+    agentSessionById({
+      sessionId: params.id,
+      userId: auth.userId,
+      orgId: auth.orgId,
+    }),
+  );
+
+  switch (result.kind) {
+    case "ok": {
+      return { status: 200 as const, body: result.session };
+    }
+    case "forbidden": {
+      return sessionForbidden();
+    }
+    case "not-found": {
+      return sessionNotFound;
+    }
+  }
+});
+
+export const agentSessionsRoutes: readonly RouteEntry[] = [
+  {
+    route: sessionsByIdContract.getById,
+    handler: authRoute({}, getSessionByIdInner$),
+  },
+];

--- a/turbo/apps/api/src/signals/services/agent-sessions.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-sessions.service.ts
@@ -1,0 +1,104 @@
+import { computed, type Computed } from "ccstate";
+import type { SessionResponse } from "@vm0/api-contracts/contracts/sessions";
+import { extractAndGroupVariables } from "@vm0/core/variable-expander";
+import {
+  agentComposes,
+  agentComposeVersions,
+} from "@vm0/db/schema/agent-compose";
+import { agentSessions } from "@vm0/db/schema/agent-session";
+import { eq } from "drizzle-orm";
+
+import { db$, type ReadonlyDb } from "../external/db";
+
+interface AgentSessionByIdArgs {
+  readonly sessionId: string;
+  readonly userId: string;
+  readonly orgId: string;
+}
+
+type AgentSessionByIdResult =
+  | { readonly kind: "not-found" }
+  | { readonly kind: "forbidden" }
+  | { readonly kind: "ok"; readonly session: SessionResponse };
+
+async function secretNamesForCompose(
+  db: ReadonlyDb,
+  composeId: string,
+): Promise<string[] | null> {
+  const [compose] = await db
+    .select({ headVersionId: agentComposes.headVersionId })
+    .from(agentComposes)
+    .where(eq(agentComposes.id, composeId))
+    .limit(1);
+
+  if (!compose?.headVersionId) {
+    return null;
+  }
+
+  const [version] = await db
+    .select({ content: agentComposeVersions.content })
+    .from(agentComposeVersions)
+    .where(eq(agentComposeVersions.id, compose.headVersionId))
+    .limit(1);
+
+  if (!version) {
+    return null;
+  }
+
+  const grouped = extractAndGroupVariables(version.content);
+  const names = grouped.secrets.map((ref) => {
+    return ref.name;
+  });
+  return names.length > 0 ? names : null;
+}
+
+export function agentSessionById(
+  args: AgentSessionByIdArgs,
+): Computed<Promise<AgentSessionByIdResult>> {
+  return computed(async (get): Promise<AgentSessionByIdResult> => {
+    const db = get(db$);
+    const [session] = await db
+      .select({
+        id: agentSessions.id,
+        userId: agentSessions.userId,
+        orgId: agentSessions.orgId,
+        agentComposeId: agentSessions.agentComposeId,
+        conversationId: agentSessions.conversationId,
+        artifacts: agentSessions.artifacts,
+        createdAt: agentSessions.createdAt,
+        updatedAt: agentSessions.updatedAt,
+      })
+      .from(agentSessions)
+      .where(eq(agentSessions.id, args.sessionId))
+      .limit(1);
+
+    if (!session) {
+      return { kind: "not-found" };
+    }
+
+    if (session.userId !== args.userId) {
+      return { kind: "forbidden" };
+    }
+
+    if (session.orgId !== args.orgId) {
+      return { kind: "not-found" };
+    }
+
+    const secretNames = await secretNamesForCompose(db, session.agentComposeId);
+
+    return {
+      kind: "ok",
+      session: {
+        id: session.id,
+        agentComposeId: session.agentComposeId,
+        conversationId: session.conversationId,
+        artifactNames: session.artifacts.map((artifact) => {
+          return artifact.name;
+        }),
+        secretNames,
+        createdAt: session.createdAt.toISOString(),
+        updatedAt: session.updatedAt.toISOString(),
+      },
+    };
+  });
+}


### PR DESCRIPTION
## Summary
- add the API backend route for `GET /api/agent/sessions/:id`
- preserve the web route's auth and access semantics, including the runtime org check and HEAD compose secret extraction
- add integration coverage for auth failures, missing sessions, user/org access, runtime org authorization, artifacts, and secret names

## Testing
- `scripts/prepare.sh`
- `pnpm format`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/agent-sessions-id.test.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm check-types`
- pre-commit hook: `knip`, `check-types`

Closes #12817
