### PR TITLE
refactor(api): migrate zero agent update routes to api backend

### DIFF
--- a/turbo/apps/api/src/lib/require-agent-permission.ts
+++ b/turbo/apps/api/src/lib/require-agent-permission.ts
@@ -8,7 +8,10 @@ type ForbiddenResponse = {
 type AgentVisibility = "public" | "private";
 
 /**
- * Owner-OR-admin gate for per-agent write operations.
+ * Owner/admin gate for per-agent write operations.
+ *
+ * Public agents may be modified by the owner or an org admin. Private agents
+ * may only be modified by the owner.
  *
  * Returns a 403 envelope when neither condition is met, or null to allow.
  */
@@ -18,21 +21,43 @@ export function requireAgentPermission(
   action: string,
   options?: { readonly visibility?: AgentVisibility | null },
 ): ForbiddenResponse | null {
-  if (
-    member.userId === agentOwner ||
-    (options?.visibility !== "private" && member.role === "admin")
-  ) {
+  if (member.userId === agentOwner) {
     return null;
   }
+
+  if (options?.visibility !== "private" && member.role === "admin") {
+    return null;
+  }
+
   const ownerLabel =
     options?.visibility === "private"
       ? "the private agent owner"
       : "the agent owner or org admin";
+
   return {
     status: 403 as const,
     body: {
       error: {
         message: `Only ${ownerLabel} can ${action}`,
+        code: "FORBIDDEN",
+      },
+    },
+  };
+}
+
+export function requireAdminPermission(
+  member: { readonly role: string },
+  action: string,
+): ForbiddenResponse | null {
+  if (member.role === "admin") {
+    return null;
+  }
+
+  return {
+    status: 403 as const,
+    body: {
+      error: {
+        message: `Only org admins can ${action}`,
         code: "FORBIDDEN",
       },
     },

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-skills.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-skills.ts
@@ -357,6 +357,12 @@ export const seedAgentForInstructions$ = command(
       displayName?: string | null;
       description?: string | null;
       sound?: string | null;
+      avatarUrl?: string | null;
+      customSkills?: readonly string[];
+      modelProviderId?: string | null;
+      selectedModel?: string | null;
+      preferPersonalProvider?: boolean;
+      visibility?: "public" | "private";
       framework?: AgentFramework;
       instructions?: string;
       composeContent?: unknown;
@@ -410,6 +416,12 @@ export const seedAgentForInstructions$ = command(
           displayName: args.displayName ?? null,
           description: args.description ?? null,
           sound: args.sound ?? null,
+          avatarUrl: args.avatarUrl ?? null,
+          customSkills: args.customSkills ? [...args.customSkills] : [],
+          modelProviderId: args.modelProviderId ?? null,
+          selectedModel: args.selectedModel ?? null,
+          preferPersonalProvider: args.preferPersonalProvider ?? false,
+          visibility: args.visibility ?? "public",
         })
         .onConflictDoNothing();
       signal.throwIfAborted();

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-usage-insight.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-usage-insight.ts
@@ -202,6 +202,7 @@ export const seedCompose$ = command(
       userId: string;
       name?: string;
       displayName?: string | null;
+      visibility?: "public" | "private";
     },
     signal: AbortSignal,
   ): Promise<ComposeResult> => {
@@ -223,6 +224,7 @@ export const seedCompose$ = command(
         owner: args.userId,
         name,
         displayName: args.displayName ?? null,
+        visibility: args.visibility ?? "public",
       })
       .onConflictDoNothing();
     signal.throwIfAborted();

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-agents-update.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-agents-update.test.ts
@@ -1,0 +1,495 @@
+import { randomUUID } from "node:crypto";
+
+import {
+  zeroAgentInstructionsContract,
+  zeroAgentsByIdContract,
+} from "@vm0/api-contracts/contracts/zero-agents";
+import { agentComposes } from "@vm0/db/schema/agent-compose";
+import { createStore } from "ccstate";
+import { eq } from "drizzle-orm";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { now } from "../../../lib/time";
+import { signSandboxJwtForTests } from "../../auth/tokens";
+import { writeDb$ } from "../../external/db";
+import {
+  deleteOrgModelProviders$,
+  seedOrgModelProvider$,
+  type OrgModelProviderFixture,
+} from "./helpers/zero-model-providers";
+import {
+  createFixtureTracker,
+  createZeroRouteMocks,
+} from "./helpers/zero-route-test";
+import {
+  deleteSkillsForFixture$,
+  seedAgentForInstructions$,
+  seedSkill$,
+  seedSkillsFixture$,
+  type SkillsFixture,
+} from "./helpers/zero-skills";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+
+function authHeaders() {
+  return { authorization: "Bearer clerk-session" };
+}
+
+function currentSecond(): number {
+  return Math.floor(now() / 1000);
+}
+
+function agentsClient() {
+  return setupApp({ context })(zeroAgentsByIdContract);
+}
+
+function instructionsClient() {
+  return setupApp({ context })(zeroAgentInstructionsContract);
+}
+
+function s3CommandInput(command: unknown): Record<string, unknown> {
+  if (
+    typeof command === "object" &&
+    command !== null &&
+    "input" in command &&
+    typeof command.input === "object" &&
+    command.input !== null
+  ) {
+    return command.input as Record<string, unknown>;
+  }
+  return {};
+}
+
+function s3PutInputs(): readonly Record<string, unknown>[] {
+  return context.mocks.s3.send.mock.calls.map(([command]) => {
+    return s3CommandInput(command);
+  });
+}
+
+describe("PUT /api/zero/agents/:id", () => {
+  const track = createFixtureTracker<SkillsFixture>((fixture) => {
+    return store.set(deleteSkillsForFixture$, fixture, context.signal);
+  });
+  const trackModelProviders = createFixtureTracker<OrgModelProviderFixture>(
+    (fixture) => {
+      return store.set(deleteOrgModelProviders$, fixture, context.signal);
+    },
+  );
+
+  it("returns 401 when the request is unauthenticated", async () => {
+    const response = await accept(
+      agentsClient().update({
+        params: { id: randomUUID() },
+        headers: {},
+        body: {},
+      }),
+      [401],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("returns 403 for a sandbox token without agent:write capability", async () => {
+    const seconds = currentSecond();
+    const token = signSandboxJwtForTests({
+      scope: "zero",
+      userId: `user_${randomUUID()}`,
+      orgId: `org_${randomUUID()}`,
+      runId: `run_${randomUUID()}`,
+      capabilities: ["agent:read"],
+      iat: seconds,
+      exp: seconds + 60,
+    });
+
+    const response = await accept(
+      agentsClient().update({
+        params: { id: randomUUID() },
+        headers: { authorization: `Bearer ${token}` },
+        body: {},
+      }),
+      [403],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Missing required capability: agent:write",
+        code: "FORBIDDEN",
+      },
+    });
+  });
+
+  it("updates agent metadata, validates custom skills and model selection, and preserves omitted fields", async () => {
+    const fixture = await track(
+      store.set(seedSkillsFixture$, undefined, context.signal),
+    );
+    await trackModelProviders(Promise.resolve({ orgId: fixture.orgId }));
+    await store.set(
+      seedSkill$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        name: "research-notes",
+      },
+      context.signal,
+    );
+    const provider = await store.set(
+      seedOrgModelProvider$,
+      {
+        orgId: fixture.orgId,
+        type: "anthropic-api-key",
+      },
+      context.signal,
+    );
+    const agent = await store.set(
+      seedAgentForInstructions$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        displayName: "Old Agent",
+        sound: "calm",
+        customSkills: ["old-skill"],
+      },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      agentsClient().update({
+        params: { id: agent.agentId },
+        headers: authHeaders(),
+        body: {
+          displayName: "Updated Agent",
+          customSkills: ["research-notes"],
+          modelProviderId: provider.id,
+          selectedModel: "claude-sonnet-4-6",
+          preferPersonalProvider: true,
+        },
+      }),
+      [200],
+    );
+
+    expect(response.body).toMatchObject({
+      agentId: agent.agentId,
+      ownerId: fixture.userId,
+      displayName: "Updated Agent",
+      sound: "calm",
+      customSkills: ["research-notes"],
+      modelProviderId: provider.id,
+      selectedModel: "claude-sonnet-4-6",
+      preferPersonalProvider: true,
+      visibility: "public",
+    });
+
+    const [compose] = await store
+      .set(writeDb$)
+      .select({ headVersionId: agentComposes.headVersionId })
+      .from(agentComposes)
+      .where(eq(agentComposes.id, agent.agentId));
+    expect(compose?.headVersionId).toBeTruthy();
+  });
+
+  it("preserves existing custom skills when the request omits customSkills", async () => {
+    const fixture = await track(
+      store.set(seedSkillsFixture$, undefined, context.signal),
+    );
+    const agent = await store.set(
+      seedAgentForInstructions$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        customSkills: ["existing-skill"],
+      },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      agentsClient().update({
+        params: { id: agent.agentId },
+        headers: authHeaders(),
+        body: { description: "Updated description" },
+      }),
+      [200],
+    );
+
+    expect(response.body.customSkills).toStrictEqual(["existing-skill"]);
+    expect(response.body.description).toBe("Updated description");
+  });
+
+  it("returns 400 when a requested custom skill does not exist", async () => {
+    const fixture = await track(
+      store.set(seedSkillsFixture$, undefined, context.signal),
+    );
+    const agent = await store.set(
+      seedAgentForInstructions$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+      },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      agentsClient().update({
+        params: { id: agent.agentId },
+        headers: authHeaders(),
+        body: { customSkills: ["missing-skill"] },
+      }),
+      [400],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message:
+          "Custom skill 'missing-skill' not found in this organization. Create it with 'zero skill create' first.",
+        code: "VALIDATION_ERROR",
+      },
+    });
+  });
+
+  it("returns 400 when modelProviderId is outside the organization", async () => {
+    const fixture = await track(
+      store.set(seedSkillsFixture$, undefined, context.signal),
+    );
+    const agent = await store.set(
+      seedAgentForInstructions$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+      },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    const modelProviderId = randomUUID();
+
+    const response = await accept(
+      agentsClient().update({
+        params: { id: agent.agentId },
+        headers: authHeaders(),
+        body: { modelProviderId, selectedModel: "claude-sonnet-4-6" },
+      }),
+      [400],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: `Model provider "${modelProviderId}" not found in this org`,
+        code: "BAD_REQUEST",
+      },
+    });
+  });
+
+  it("returns 403 when a non-owner member updates another user's agent", async () => {
+    const fixture = await track(
+      store.set(seedSkillsFixture$, undefined, context.signal),
+    );
+    const agent = await store.set(
+      seedAgentForInstructions$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+      },
+      context.signal,
+    );
+    mocks.clerk.session(`user_${randomUUID()}`, fixture.orgId, "org:member");
+
+    const response = await accept(
+      agentsClient().update({
+        params: { id: agent.agentId },
+        headers: authHeaders(),
+        body: { displayName: "Nope" },
+      }),
+      [403],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message:
+          "Only the agent owner or org admin can update agent configuration",
+        code: "FORBIDDEN",
+      },
+    });
+  });
+
+  it("returns 403 when private visibility is requested while the feature is disabled", async () => {
+    const fixture = await track(
+      store.set(seedSkillsFixture$, undefined, context.signal),
+    );
+    const agent = await store.set(
+      seedAgentForInstructions$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+      },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      agentsClient().update({
+        params: { id: agent.agentId },
+        headers: authHeaders(),
+        body: { visibility: "private" },
+      }),
+      [403],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Private agents are not available for this account",
+        code: "FORBIDDEN",
+      },
+    });
+  });
+
+  it("returns 404 for an unknown agent", async () => {
+    const fixture = await track(
+      store.set(seedSkillsFixture$, undefined, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    const agentId = randomUUID();
+
+    const response = await accept(
+      agentsClient().update({
+        params: { id: agentId },
+        headers: authHeaders(),
+        body: {},
+      }),
+      [404],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: `Agent not found: ${agentId}`, code: "NOT_FOUND" },
+    });
+  });
+});
+
+describe("PUT /api/zero/agents/:id/instructions", () => {
+  const track = createFixtureTracker<SkillsFixture>((fixture) => {
+    return store.set(deleteSkillsForFixture$, fixture, context.signal);
+  });
+
+  it("returns 401 when the request is unauthenticated", async () => {
+    const response = await accept(
+      instructionsClient().update({
+        params: { id: randomUUID() },
+        headers: {},
+        body: { content: "new instructions" },
+      }),
+      [401],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("updates instructions storage and preserves agent metadata", async () => {
+    const fixture = await track(
+      store.set(seedSkillsFixture$, undefined, context.signal),
+    );
+    const agent = await store.set(
+      seedAgentForInstructions$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        displayName: "Instructions Agent",
+        customSkills: ["existing-skill"],
+      },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      instructionsClient().update({
+        params: { id: agent.agentId },
+        headers: authHeaders(),
+        body: { content: "Use the updated operating notes." },
+      }),
+      [200],
+    );
+
+    expect(response.body).toMatchObject({
+      agentId: agent.agentId,
+      ownerId: fixture.userId,
+      displayName: "Instructions Agent",
+      customSkills: ["existing-skill"],
+    });
+
+    const putInputs = s3PutInputs();
+    const manifestPut = putInputs.find((input) => {
+      return String(input.Key).endsWith("/manifest.json");
+    });
+    const archivePut = putInputs.find((input) => {
+      return String(input.Key).endsWith("/archive.tar.gz");
+    });
+    expect(manifestPut?.Bucket).toBe("test-user-storages");
+    expect(archivePut?.Bucket).toBe("test-user-storages");
+
+    const manifestBody = JSON.parse(String(manifestPut?.Body)) as {
+      readonly files: readonly { readonly path: string }[];
+    };
+    const paths = manifestBody.files.map((file) => {
+      return file.path;
+    });
+    expect(paths).toStrictEqual(["CLAUDE.md", "AGENTS.md"]);
+  });
+
+  it("returns 403 when a non-owner member updates another user's instructions", async () => {
+    const fixture = await track(
+      store.set(seedSkillsFixture$, undefined, context.signal),
+    );
+    const agent = await store.set(
+      seedAgentForInstructions$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+      },
+      context.signal,
+    );
+    mocks.clerk.session(`user_${randomUUID()}`, fixture.orgId, "org:member");
+
+    const response = await accept(
+      instructionsClient().update({
+        params: { id: agent.agentId },
+        headers: authHeaders(),
+        body: { content: "not allowed" },
+      }),
+      [403],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message:
+          "Only the agent owner or org admin can update agent instructions",
+        code: "FORBIDDEN",
+      },
+    });
+  });
+
+  it("returns 404 for an unknown agent", async () => {
+    const fixture = await track(
+      store.set(seedSkillsFixture$, undefined, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    const agentId = randomUUID();
+
+    const response = await accept(
+      instructionsClient().update({
+        params: { id: agentId },
+        headers: authHeaders(),
+        body: { content: "missing" },
+      }),
+      [404],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: `Agent not found: ${agentId}`, code: "NOT_FOUND" },
+    });
+  });
+});

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-permission-policies.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-permission-policies.test.ts
@@ -202,6 +202,59 @@ describe("PUT /api/zero/permission-policies", () => {
     expect(response.body.permissionPolicies).toStrictEqual(slackAllow());
   });
 
+  it("returns 403 when an org admin updates another user's private agent", async () => {
+    const ownerFixture = uniqueOrgUser("zpp-private-owner");
+    const adminFixture = {
+      orgId: ownerFixture.orgId,
+      userId: `user_zpp-private-admin_${randomUUID().slice(0, 8)}`,
+    };
+    await store.set(
+      seedOrgMembership$,
+      {
+        orgId: ownerFixture.orgId,
+        userId: ownerFixture.userId,
+        role: "member",
+      },
+      context.signal,
+    );
+    await store.set(
+      seedOrgMembership$,
+      {
+        orgId: adminFixture.orgId,
+        userId: adminFixture.userId,
+        role: "admin",
+        seedOrgCache: false,
+      },
+      context.signal,
+    );
+    const { agentId } = await store.set(
+      seedCompose$,
+      {
+        orgId: ownerFixture.orgId,
+        userId: ownerFixture.userId,
+        visibility: "private",
+      },
+      context.signal,
+    );
+    mocks.clerk.session(adminFixture.userId, adminFixture.orgId);
+
+    const client = setupApp({ context })(zeroAgentPermissionPoliciesContract);
+    const response = await accept(
+      client.update({
+        body: { agentId, policies: slackAllow() },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [403],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Only the private agent owner can update permission policies",
+        code: "FORBIDDEN",
+      },
+    });
+  });
+
   it("returns 403 for a non-owner member", async () => {
     const ownerFixture = uniqueOrgUser("zpp-owner2");
     const memberFixture = {

--- a/turbo/apps/api/src/signals/routes/zero-agent-instructions.ts
+++ b/turbo/apps/api/src/signals/routes/zero-agent-instructions.ts
@@ -1,13 +1,26 @@
-import { computed } from "ccstate";
+import { command, computed } from "ccstate";
 import {
   zeroAgentInstructionsContract,
   zeroSkillsDetailContract,
 } from "@vm0/api-contracts/contracts/zero-agents";
+import { agentComposes } from "@vm0/db/schema/agent-compose";
+import { zeroAgents } from "@vm0/db/schema/zero-agent";
+import { and, eq } from "drizzle-orm";
 
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
-import { pathParamsOf } from "../context/request";
+import { bodyResultOf, pathParamsOf } from "../context/request";
+import { writeDb$ } from "../external/db";
 import { notFound } from "../../lib/error";
+import {
+  requireAdminPermission,
+  requireAgentPermission,
+} from "../../lib/require-agent-permission";
+import { serverSideZeroAgentCompose$ } from "../services/agent-compose.service";
+import {
+  agentResponse,
+  defaultAgentResponse,
+} from "../services/zero-agent-data.service";
 import { zeroAgentInstructions } from "../services/zero-agent-instructions.service";
 import { zeroSkillDetail } from "../services/zero-skill-detail.service";
 import type { RouteEntry } from "../route";
@@ -16,6 +29,12 @@ const agentReadAuth = {
   requireOrganization: true,
   missingOrganizationStatus: 401,
   requiredCapability: "agent:read",
+} as const;
+
+const agentWriteAuth = {
+  requireOrganization: true,
+  missingOrganizationStatus: 401,
+  requiredCapability: "agent:write",
 } as const;
 
 const getAgentInstructionsInner$ = computed(async (get) => {
@@ -27,6 +46,107 @@ const getAgentInstructionsInner$ = computed(async (get) => {
   }
   return { status: 200 as const, body: result };
 });
+
+const updateAgentInstructionsBody$ = bodyResultOf(
+  zeroAgentInstructionsContract.update,
+);
+
+const updateAgentInstructionsInner$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const auth = get(organizationAuthContext$);
+    const member = { userId: auth.userId, role: auth.orgRole ?? "member" };
+    const params = get(pathParamsOf(zeroAgentInstructionsContract.update));
+    const body = await get(updateAgentInstructionsBody$);
+    signal.throwIfAborted();
+    if (!body.ok) {
+      return body.response;
+    }
+
+    const writeDb = set(writeDb$);
+    const [compose] = await writeDb
+      .select({
+        id: agentComposes.id,
+        name: agentComposes.name,
+        owner: zeroAgents.owner,
+        visibility: zeroAgents.visibility,
+      })
+      .from(agentComposes)
+      .leftJoin(zeroAgents, eq(agentComposes.id, zeroAgents.id))
+      .where(
+        and(
+          eq(agentComposes.orgId, auth.orgId),
+          eq(agentComposes.id, params.id),
+        ),
+      )
+      .limit(1);
+    signal.throwIfAborted();
+
+    if (!compose) {
+      return notFound(`Agent not found: ${params.id}`);
+    }
+
+    const permissionError = compose.owner
+      ? requireAgentPermission(
+          compose.owner,
+          member,
+          "update agent instructions",
+          { visibility: compose.visibility },
+        )
+      : requireAdminPermission(member, "update agent instructions");
+    if (permissionError) {
+      return permissionError;
+    }
+
+    const result = await set(
+      serverSideZeroAgentCompose$,
+      {
+        userId: auth.userId,
+        orgId: auth.orgId,
+        agentComposeId: compose.id,
+        agentName: compose.name,
+        instructions: body.data.content,
+      },
+      signal,
+    );
+    signal.throwIfAborted();
+
+    const [agent] = await writeDb
+      .select({
+        agentId: zeroAgents.id,
+        owner: zeroAgents.owner,
+        displayName: zeroAgents.displayName,
+        description: zeroAgents.description,
+        sound: zeroAgents.sound,
+        avatarUrl: zeroAgents.avatarUrl,
+        permissionPolicies: zeroAgents.permissionPolicies,
+        unknownPermissionPolicies: zeroAgents.unknownPermissionPolicies,
+        customSkills: zeroAgents.customSkills,
+        modelProviderId: zeroAgents.modelProviderId,
+        selectedModel: zeroAgents.selectedModel,
+        preferPersonalProvider: zeroAgents.preferPersonalProvider,
+        visibility: zeroAgents.visibility,
+      })
+      .from(zeroAgents)
+      .where(
+        and(
+          eq(zeroAgents.orgId, auth.orgId),
+          eq(zeroAgents.name, compose.name),
+        ),
+      )
+      .limit(1);
+    signal.throwIfAborted();
+
+    return {
+      status: 200 as const,
+      body: agent
+        ? agentResponse(agent)
+        : defaultAgentResponse({
+            agentId: result.composeId,
+            ownerId: auth.userId,
+          }),
+    };
+  },
+);
 
 const getSkillDetailInner$ = computed(async (get) => {
   const auth = get(organizationAuthContext$);
@@ -42,6 +162,10 @@ export const zeroAgentInstructionsRoutes: readonly RouteEntry[] = [
   {
     route: zeroAgentInstructionsContract.get,
     handler: authRoute(agentReadAuth, getAgentInstructionsInner$),
+  },
+  {
+    route: zeroAgentInstructionsContract.update,
+    handler: authRoute(agentWriteAuth, updateAgentInstructionsInner$),
   },
   {
     route: zeroSkillsDetailContract.get,

--- a/turbo/apps/api/src/signals/routes/zero-agents.ts
+++ b/turbo/apps/api/src/signals/routes/zero-agents.ts
@@ -1,25 +1,46 @@
-import { command, computed } from "ccstate";
-import { and, eq, inArray } from "drizzle-orm";
+import { command, computed, type Computed } from "ccstate";
+import { and, count, eq, inArray } from "drizzle-orm";
+import {
+  allowsCustomModel,
+  getModels,
+  modelProviderTypeSchema,
+} from "@vm0/api-contracts/contracts/model-providers";
 import { zeroAgentCustomConnectorsContract } from "@vm0/api-contracts/contracts/zero-agent-custom-connectors";
 import {
   zeroAgentsByIdContract,
   zeroAgentsMainContract,
+  type ZeroAgentVisibility,
 } from "@vm0/api-contracts/contracts/zero-agents";
 import { zeroUserConnectorsContract } from "@vm0/api-contracts/contracts/user-connectors";
 import { connectorTypeSchema } from "@vm0/connectors/connectors";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import { isFeatureEnabled } from "@vm0/core/feature-switch";
 import { agentComposes } from "@vm0/db/schema/agent-compose";
+import { modelProviders } from "@vm0/db/schema/model-provider";
 import { orgCustomConnectors } from "@vm0/db/schema/org-custom-connector";
 import { userConnectors } from "@vm0/db/schema/user-connector";
 import { userCustomConnectors } from "@vm0/db/schema/user-custom-connector";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
+import { zeroSkills } from "@vm0/db/schema/zero-skill";
 
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
 import { bodyResultOf, pathParamsOf } from "../context/request";
-import { writeDb$ } from "../external/db";
-import { notFound } from "../../lib/error";
-import { recomposeAgentIfStale$ } from "../services/agent-compose.service";
+import { writeDb$, type Db } from "../external/db";
+import { nowDate } from "../external/time";
+import { badRequestMessage, conflict, notFound } from "../../lib/error";
 import {
+  requireAdminPermission,
+  requireAgentPermission,
+} from "../../lib/require-agent-permission";
+import {
+  recomposeAgentIfStale$,
+  serverSideZeroAgentCompose$,
+} from "../services/agent-compose.service";
+import { userFeatureSwitchOverrides } from "../services/feature-switches.service";
+import {
+  agentResponse,
+  defaultAgentResponse,
   zeroAgentDetail,
   zeroAgentEnabledConnectorTypes,
   zeroAgentEnabledCustomConnectorIds,
@@ -29,8 +50,395 @@ import {
 } from "../services/zero-agent-data.service";
 import type { RouteEntry } from "../route";
 
+const PUBLIC_AGENT_LIMIT = 7;
+
+interface AgentUpdateBody {
+  readonly displayName?: string;
+  readonly description?: string;
+  readonly sound?: string;
+  readonly avatarUrl?: string;
+  readonly customSkills?: readonly string[];
+  readonly modelProviderId?: string | null;
+  readonly selectedModel?: string | null;
+  readonly preferPersonalProvider?: boolean;
+  readonly visibility?: ZeroAgentVisibility;
+}
+
+interface ExistingAgentForUpdate {
+  readonly id: string;
+  readonly name: string;
+  readonly customSkills: readonly string[] | null;
+  readonly owner: string | null;
+  readonly visibility: ZeroAgentVisibility | null;
+}
+
+interface AgentMember {
+  readonly userId: string;
+  readonly role: string;
+}
+
+type SignalGetter = {
+  <T>(source: Computed<T>): T;
+  <T>(source: Computed<Promise<T>>): Promise<T>;
+};
+
 function agentNotFound(agentId: string) {
   return notFound(`Agent not found: ${agentId}`);
+}
+
+function forbidden(message: string) {
+  return {
+    status: 403 as const,
+    body: { error: { message, code: "FORBIDDEN" as const } },
+  };
+}
+
+function validationError(message: string) {
+  return {
+    status: 400 as const,
+    body: { error: { message, code: "VALIDATION_ERROR" as const } },
+  };
+}
+
+function publicAgentLimitError() {
+  return conflict(
+    "This organization has reached the maximum number of agents (7). Delete an existing agent before making this agent public.",
+  );
+}
+
+function buildAgentUpsertConflictSet(body: AgentUpdateBody, updatedAt: Date) {
+  return {
+    updatedAt,
+    ...(body.displayName !== undefined && { displayName: body.displayName }),
+    ...(body.description !== undefined && { description: body.description }),
+    ...(body.sound !== undefined && { sound: body.sound }),
+    ...(body.avatarUrl !== undefined && { avatarUrl: body.avatarUrl }),
+    ...(body.customSkills !== undefined && {
+      customSkills: [...body.customSkills],
+    }),
+    ...(body.modelProviderId !== undefined && {
+      modelProviderId: body.modelProviderId,
+    }),
+    ...(body.selectedModel !== undefined && {
+      selectedModel: body.selectedModel,
+    }),
+    ...(body.preferPersonalProvider !== undefined && {
+      preferPersonalProvider: body.preferPersonalProvider,
+    }),
+    ...(body.visibility !== undefined && { visibility: body.visibility }),
+  };
+}
+
+async function validateCustomSkills(
+  writeDb: Db,
+  orgId: string,
+  customSkills: readonly string[],
+) {
+  if (customSkills.length === 0) {
+    return null;
+  }
+
+  for (const name of customSkills) {
+    if (connectorTypeSchema.safeParse(name).success) {
+      return validationError(
+        `'${name}' is a built-in connector, not a custom skill. Enable it via connectors instead.`,
+      );
+    }
+  }
+
+  const existing = await writeDb
+    .select({ name: zeroSkills.name })
+    .from(zeroSkills)
+    .where(
+      and(
+        eq(zeroSkills.orgId, orgId),
+        inArray(zeroSkills.name, [...customSkills]),
+      ),
+    );
+  const existingNames = new Set(
+    existing.map((skill) => {
+      return skill.name;
+    }),
+  );
+  const missing = customSkills.find((name) => {
+    return !existingNames.has(name);
+  });
+
+  return missing
+    ? validationError(
+        `Custom skill '${missing}' not found in this organization. Create it with 'zero skill create' first.`,
+      )
+    : null;
+}
+
+async function validateModelSelection(
+  writeDb: Db,
+  orgId: string,
+  modelProviderId: string | null | undefined,
+  selectedModel: string | null | undefined,
+) {
+  if (!modelProviderId) {
+    return null;
+  }
+
+  const [provider] = await writeDb
+    .select({ type: modelProviders.type })
+    .from(modelProviders)
+    .where(
+      and(
+        eq(modelProviders.id, modelProviderId),
+        eq(modelProviders.orgId, orgId),
+      ),
+    )
+    .limit(1);
+
+  if (!provider) {
+    return badRequestMessage(
+      `Model provider "${modelProviderId}" not found in this org`,
+    );
+  }
+
+  if (!selectedModel) {
+    return null;
+  }
+
+  const parsed = modelProviderTypeSchema.safeParse(provider.type);
+  if (!parsed.success) {
+    return badRequestMessage(`Unknown model provider type "${provider.type}"`);
+  }
+
+  if (allowsCustomModel(parsed.data)) {
+    return null;
+  }
+
+  const available = getModels(parsed.data) ?? [];
+  return available.includes(selectedModel)
+    ? null
+    : badRequestMessage(
+        `Model "${selectedModel}" is not available for provider type "${parsed.data}". Available: ${available.join(", ")}`,
+      );
+}
+
+function findAgentForUpdate(
+  writeDb: Db,
+  orgId: string,
+  agentId: string,
+): Promise<ExistingAgentForUpdate | null> {
+  return writeDb
+    .select({
+      id: agentComposes.id,
+      name: agentComposes.name,
+      customSkills: zeroAgents.customSkills,
+      owner: zeroAgents.owner,
+      visibility: zeroAgents.visibility,
+    })
+    .from(agentComposes)
+    .leftJoin(zeroAgents, eq(agentComposes.id, zeroAgents.id))
+    .where(and(eq(agentComposes.orgId, orgId), eq(agentComposes.id, agentId)))
+    .limit(1)
+    .then((rows) => {
+      return rows[0] ?? null;
+    });
+}
+
+function requireAgentConfigurationPermission(
+  existing: ExistingAgentForUpdate,
+  member: AgentMember,
+) {
+  return existing.owner
+    ? requireAgentPermission(
+        existing.owner,
+        member,
+        "update agent configuration",
+        { visibility: existing.visibility },
+      )
+    : requireAdminPermission(member, "update agent configuration");
+}
+
+function visibilityOwnerError(
+  existing: ExistingAgentForUpdate,
+  member: AgentMember,
+  requestedVisibility: ZeroAgentVisibility | undefined,
+) {
+  if (
+    requestedVisibility === undefined ||
+    !existing.owner ||
+    existing.owner === member.userId
+  ) {
+    return null;
+  }
+
+  return forbidden("Only the agent owner can update agent visibility");
+}
+
+async function privateVisibilityError(args: {
+  readonly get: SignalGetter;
+  readonly orgId: string;
+  readonly userId: string;
+  readonly nextVisibility: ZeroAgentVisibility;
+  readonly signal: AbortSignal;
+}) {
+  if (args.nextVisibility !== "private") {
+    return null;
+  }
+
+  const overrides = await args.get(
+    userFeatureSwitchOverrides(args.orgId, args.userId),
+  );
+  args.signal.throwIfAborted();
+  const enabled = isFeatureEnabled(FeatureSwitchKey.PrivateAgents, {
+    orgId: args.orgId,
+    userId: args.userId,
+    overrides,
+  });
+
+  return enabled
+    ? null
+    : forbidden("Private agents are not available for this account");
+}
+
+async function publicVisibilitySlotError(args: {
+  readonly writeDb: Db;
+  readonly orgId: string;
+  readonly currentVisibility: ZeroAgentVisibility | null;
+  readonly nextVisibility: ZeroAgentVisibility;
+  readonly signal: AbortSignal;
+}) {
+  if (args.nextVisibility !== "public" || args.currentVisibility === "public") {
+    return null;
+  }
+
+  const [publicAgentCount] = await args.writeDb
+    .select({ value: count() })
+    .from(zeroAgents)
+    .where(
+      and(
+        eq(zeroAgents.orgId, args.orgId),
+        eq(zeroAgents.visibility, "public"),
+      ),
+    );
+  args.signal.throwIfAborted();
+
+  return (publicAgentCount?.value ?? 0) >= PUBLIC_AGENT_LIMIT
+    ? publicAgentLimitError()
+    : null;
+}
+
+async function validateAgentVisibilityUpdate(args: {
+  readonly get: SignalGetter;
+  readonly writeDb: Db;
+  readonly orgId: string;
+  readonly member: AgentMember;
+  readonly existing: ExistingAgentForUpdate;
+  readonly requestedVisibility: ZeroAgentVisibility | undefined;
+  readonly nextVisibility: ZeroAgentVisibility;
+  readonly signal: AbortSignal;
+}) {
+  const ownerError = visibilityOwnerError(
+    args.existing,
+    args.member,
+    args.requestedVisibility,
+  );
+  if (ownerError) {
+    return ownerError;
+  }
+
+  return (
+    (await privateVisibilityError({
+      get: args.get,
+      orgId: args.orgId,
+      userId: args.member.userId,
+      nextVisibility: args.nextVisibility,
+      signal: args.signal,
+    })) ??
+    (await publicVisibilitySlotError({
+      writeDb: args.writeDb,
+      orgId: args.orgId,
+      currentVisibility: args.existing.visibility,
+      nextVisibility: args.nextVisibility,
+      signal: args.signal,
+    }))
+  );
+}
+
+async function validateCustomSkillsForUpdate(args: {
+  readonly writeDb: Db;
+  readonly orgId: string;
+  readonly requestedCustomSkills: readonly string[] | undefined;
+  readonly customSkills: readonly string[];
+  readonly signal: AbortSignal;
+}) {
+  if (args.requestedCustomSkills === undefined) {
+    return null;
+  }
+
+  const error = await validateCustomSkills(
+    args.writeDb,
+    args.orgId,
+    args.customSkills,
+  );
+  args.signal.throwIfAborted();
+  return error;
+}
+
+function upsertZeroAgentAfterCompose(
+  writeDb: Db,
+  args: {
+    readonly composeId: string;
+    readonly orgId: string;
+    readonly name: string;
+    readonly owner: string;
+    readonly body: AgentUpdateBody;
+    readonly customSkills: readonly string[];
+    readonly visibility: ZeroAgentVisibility;
+  },
+) {
+  return writeDb
+    .insert(zeroAgents)
+    .values({
+      id: args.composeId,
+      orgId: args.orgId,
+      name: args.name,
+      owner: args.owner,
+      displayName: args.body.displayName ?? null,
+      description: args.body.description ?? null,
+      sound: args.body.sound ?? null,
+      avatarUrl: args.body.avatarUrl ?? null,
+      customSkills: [...args.customSkills],
+      modelProviderId: args.body.modelProviderId ?? null,
+      selectedModel: args.body.selectedModel ?? null,
+      preferPersonalProvider: args.body.preferPersonalProvider ?? false,
+      visibility: args.visibility,
+    })
+    .onConflictDoUpdate({
+      target: [zeroAgents.orgId, zeroAgents.name],
+      set: buildAgentUpsertConflictSet(args.body, nowDate()),
+    });
+}
+
+function readAgentForResponse(writeDb: Db, orgId: string, agentId: string) {
+  return writeDb
+    .select({
+      agentId: zeroAgents.id,
+      owner: zeroAgents.owner,
+      displayName: zeroAgents.displayName,
+      description: zeroAgents.description,
+      sound: zeroAgents.sound,
+      avatarUrl: zeroAgents.avatarUrl,
+      permissionPolicies: zeroAgents.permissionPolicies,
+      unknownPermissionPolicies: zeroAgents.unknownPermissionPolicies,
+      customSkills: zeroAgents.customSkills,
+      modelProviderId: zeroAgents.modelProviderId,
+      selectedModel: zeroAgents.selectedModel,
+      preferPersonalProvider: zeroAgents.preferPersonalProvider,
+      visibility: zeroAgents.visibility,
+    })
+    .from(zeroAgents)
+    .where(and(eq(zeroAgents.orgId, orgId), eq(zeroAgents.id, agentId)))
+    .limit(1)
+    .then((rows) => {
+      return rows[0] ?? null;
+    });
 }
 
 const listAgentsInner$ = computed(async (get) => {
@@ -106,6 +514,103 @@ const getAgentCustomConnectorsInner$ = computed(async (get) => {
 const updateAgentCustomConnectorsBody$ = bodyResultOf(
   zeroAgentCustomConnectorsContract.update,
 );
+
+const updateAgentBody$ = bodyResultOf(zeroAgentsByIdContract.update);
+
+const updateAgentInner$ = command(async ({ get, set }, signal: AbortSignal) => {
+  const auth = get(organizationAuthContext$);
+  const member = { userId: auth.userId, role: auth.orgRole ?? "member" };
+  const params = get(pathParamsOf(zeroAgentsByIdContract.update));
+  const body = await get(updateAgentBody$);
+  signal.throwIfAborted();
+  if (!body.ok) {
+    return body.response;
+  }
+
+  const writeDb = set(writeDb$);
+  const existing = await findAgentForUpdate(writeDb, auth.orgId, params.id);
+  signal.throwIfAborted();
+  if (!existing) {
+    return agentNotFound(params.id);
+  }
+
+  const permissionError = requireAgentConfigurationPermission(existing, member);
+  if (permissionError) {
+    return permissionError;
+  }
+
+  const nextVisibility =
+    body.data.visibility ?? existing.visibility ?? "public";
+  const visibilityError = await validateAgentVisibilityUpdate({
+    get,
+    writeDb,
+    orgId: auth.orgId,
+    member,
+    existing,
+    requestedVisibility: body.data.visibility,
+    nextVisibility,
+    signal,
+  });
+  if (visibilityError) {
+    return visibilityError;
+  }
+
+  const modelError = await validateModelSelection(
+    writeDb,
+    auth.orgId,
+    body.data.modelProviderId,
+    body.data.selectedModel,
+  );
+  signal.throwIfAborted();
+  if (modelError) {
+    return modelError;
+  }
+
+  const customSkills = body.data.customSkills ?? existing.customSkills ?? [];
+  const customSkillsError = await validateCustomSkillsForUpdate({
+    writeDb,
+    orgId: auth.orgId,
+    requestedCustomSkills: body.data.customSkills,
+    customSkills,
+    signal,
+  });
+  if (customSkillsError) {
+    return customSkillsError;
+  }
+
+  const result = await set(
+    serverSideZeroAgentCompose$,
+    {
+      userId: auth.userId,
+      orgId: auth.orgId,
+      agentComposeId: existing.id,
+      agentName: existing.name,
+    },
+    signal,
+  );
+  signal.throwIfAborted();
+
+  await upsertZeroAgentAfterCompose(writeDb, {
+    composeId: result.composeId,
+    orgId: auth.orgId,
+    name: result.composeName,
+    owner: auth.userId,
+    body: body.data,
+    customSkills,
+    visibility: nextVisibility,
+  });
+  signal.throwIfAborted();
+
+  const agent = await readAgentForResponse(writeDb, auth.orgId, params.id);
+  signal.throwIfAborted();
+
+  return {
+    status: 200 as const,
+    body: agent
+      ? agentResponse(agent)
+      : defaultAgentResponse({ agentId: params.id, ownerId: auth.userId }),
+  };
+});
 
 const updateAgentCustomConnectorsInner$ = command(
   async ({ get, set }, signal: AbortSignal) => {
@@ -300,6 +805,12 @@ const agentReadAuth = {
   requiredCapability: "agent:read",
 } as const;
 
+const agentWriteAuth = {
+  requireOrganization: true,
+  missingOrganizationStatus: 401,
+  requiredCapability: "agent:write",
+} as const;
+
 export const zeroAgentsRoutes: readonly RouteEntry[] = [
   {
     route: zeroAgentsMainContract.list,
@@ -308,6 +819,10 @@ export const zeroAgentsRoutes: readonly RouteEntry[] = [
   {
     route: zeroAgentsByIdContract.get,
     handler: authRoute(agentReadAuth, getAgentInner$),
+  },
+  {
+    route: zeroAgentsByIdContract.update,
+    handler: authRoute(agentWriteAuth, updateAgentInner$),
   },
   {
     route: zeroUserConnectorsContract.get,

--- a/turbo/apps/api/src/signals/services/agent-compose.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-compose.service.ts
@@ -5,7 +5,11 @@ import {
   getEligibleConnectorTypes,
 } from "@vm0/connectors/connector-utils";
 import { connectorTypeSchema } from "@vm0/connectors/connectors";
-import { getInstructionsFilename } from "@vm0/core/frameworks";
+import {
+  getInstructionsFilename,
+  SUPPORTED_FRAMEWORKS,
+} from "@vm0/core/frameworks";
+import { getInstructionsStorageName } from "@vm0/core/storage-names";
 import {
   agentComposes,
   agentComposeVersions,
@@ -14,14 +18,17 @@ import { eq } from "drizzle-orm";
 
 import { writeDb$ } from "../external/db";
 import { nowDate } from "../external/time";
+import { uploadVolumeServerSide$ } from "./storage-volume-upload.service";
 
 /**
  * Build canonical compose content for a zero agent. Pure function — same
  * inputs always yield the same output. Mirrors
  * apps/web/src/lib/zero/build-compose-content.ts so the version hash
- * computed here matches web's for shadow-compare.
+ * computed here matches the existing web route behavior.
  */
-function buildComposeContent(agentName: string): Record<string, unknown> {
+function buildZeroAgentComposeContent(
+  agentName: string,
+): Record<string, unknown> {
   const eligibleConnectorTypes = getEligibleConnectorTypes();
 
   const environment: Record<string, string> = {
@@ -57,6 +64,24 @@ function buildComposeContent(agentName: string): Record<string, unknown> {
     version: "1",
     agents: { [agentName]: agentDef },
   };
+}
+
+function instructionFilesForFramework(args: {
+  readonly content: string;
+  readonly framework?: string;
+}): readonly { readonly path: string; readonly content: string }[] {
+  const filenames = [
+    getInstructionsFilename(args.framework),
+    ...SUPPORTED_FRAMEWORKS.map((framework) => {
+      return getInstructionsFilename(framework);
+    }),
+  ].filter((entry, index, all) => {
+    return all.indexOf(entry) === index;
+  });
+
+  return filenames.map((path) => {
+    return { path, content: args.content };
+  });
 }
 
 function sortObjectKeys(obj: unknown): unknown {
@@ -121,7 +146,7 @@ export const recomposeAgentIfStale$ = command(
     },
     signal: AbortSignal,
   ): Promise<{ recomposed: boolean; versionId: string }> => {
-    const content = buildComposeContent(args.agentName);
+    const content = buildZeroAgentComposeContent(args.agentName);
     const versionId = computeComposeVersionId(content);
     if (versionId === args.currentHeadVersionId) {
       return { recomposed: false, versionId };
@@ -146,5 +171,67 @@ export const recomposeAgentIfStale$ = command(
     signal.throwIfAborted();
 
     return { recomposed: true, versionId };
+  },
+);
+
+export const serverSideZeroAgentCompose$ = command(
+  async (
+    { set },
+    args: {
+      readonly userId: string;
+      readonly orgId: string;
+      readonly agentComposeId: string;
+      readonly agentName: string;
+      readonly instructions?: string;
+    },
+    signal: AbortSignal,
+  ): Promise<{
+    readonly composeId: string;
+    readonly composeName: string;
+    readonly versionId: string;
+  }> => {
+    const content = buildZeroAgentComposeContent(args.agentName);
+
+    if (args.instructions !== undefined) {
+      await set(
+        uploadVolumeServerSide$,
+        {
+          orgId: args.orgId,
+          storageName: getInstructionsStorageName(args.agentName.toLowerCase()),
+          files: instructionFilesForFramework({
+            content: args.instructions,
+            framework: "claude-code",
+          }),
+        },
+        signal,
+      );
+      signal.throwIfAborted();
+    }
+
+    const versionId = computeComposeVersionId(content);
+    const writeDb = set(writeDb$);
+
+    await writeDb
+      .insert(agentComposeVersions)
+      .values({
+        id: versionId,
+        composeId: args.agentComposeId,
+        content,
+        createdBy: args.userId,
+      })
+      .onConflictDoNothing();
+    signal.throwIfAborted();
+
+    await writeDb
+      .update(agentComposes)
+      .set({ headVersionId: versionId, updatedAt: nowDate() })
+      .where(eq(agentComposes.id, args.agentComposeId));
+    signal.throwIfAborted();
+
+    return {
+      composeId: args.agentComposeId,
+      composeName: args.agentName,
+      versionId,
+    };
   },
 );

--- a/turbo/apps/api/src/signals/services/zero-agent-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-agent-data.service.ts
@@ -13,7 +13,7 @@ import { db$ } from "../external/db";
 
 export function agentResponse(row: {
   readonly agentId: string;
-  readonly owner: string;
+  readonly owner: string | null;
   readonly composeUserId?: string;
   readonly displayName: string | null;
   readonly description: string | null;
@@ -43,6 +43,26 @@ export function agentResponse(row: {
     selectedModel: row.selectedModel,
     preferPersonalProvider: row.preferPersonalProvider,
     visibility: row.visibility,
+  };
+}
+
+export function defaultAgentResponse(args: {
+  readonly agentId: string;
+  readonly ownerId: string;
+}): ZeroAgentResponse {
+  return {
+    agentId: args.agentId,
+    ownerId: args.ownerId,
+    displayName: null,
+    description: null,
+    sound: null,
+    avatarUrl: null,
+    permissionPolicies: null,
+    customSkills: [],
+    modelProviderId: null,
+    selectedModel: null,
+    preferPersonalProvider: false,
+    visibility: "public",
   };
 }
 

--- a/turbo/apps/api/src/signals/services/zero-permission-policies.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-permission-policies.service.ts
@@ -37,7 +37,11 @@ export const updateAgentPermissionPolicies$ = command(
     const db = set(writeDb$);
 
     const [existing] = await db
-      .select({ id: zeroAgents.id, owner: zeroAgents.owner })
+      .select({
+        id: zeroAgents.id,
+        owner: zeroAgents.owner,
+        visibility: zeroAgents.visibility,
+      })
       .from(zeroAgents)
       .where(
         and(eq(zeroAgents.orgId, args.orgId), eq(zeroAgents.id, args.agentId)),
@@ -53,6 +57,7 @@ export const updateAgentPermissionPolicies$ = command(
       existing.owner,
       { userId: args.userId, role: args.role },
       "update permission policies",
+      { visibility: existing.visibility },
     );
     if (forbidden) {
       return forbidden;


### PR DESCRIPTION
## Summary
- register API handlers for `PUT /api/zero/agents/:id` and `PUT /api/zero/agents/:id/instructions`
- move zero agent compose/instructions updates into API `Command` services without shadow compare or double-running web behavior
- align API permission handling with owner/admin/private-agent rules and add integration coverage for update and instructions flows

Closes #12894

## Tests
- `pnpm format`
- `pnpm turbo run lint`
- `pnpm check-types`
- `pnpm knip` (passes; existing configuration hints only)
- `pnpm -F api exec vitest src/signals/routes/__tests__/zero-agents-update.test.ts`
- `pnpm -F api exec vitest src/signals/routes/__tests__/zero-agents-update.test.ts src/signals/routes/__tests__/zero-agents-by-id.test.ts src/signals/routes/__tests__/zero-skills.test.ts src/signals/routes/__tests__/zero-user-connectors-update.test.ts src/signals/routes/__tests__/zero-agent-custom-connectors.test.ts`
- `pnpm vitest` (fails: 27 failed / 930 passed files, 109 failed / 10147 passed tests, 1 unhandled error; observed failures were in unrelated `@vm0/app` UI interaction suites and existing API connector coverage while the new `zero-agents-update` suite passed)
