### PR TITLE
refactor(api): migrate zero org update route

### DIFF
--- a/turbo/apps/api/src/__tests__/mocks.ts
+++ b/turbo/apps/api/src/__tests__/mocks.ts
@@ -30,6 +30,7 @@ export interface ApiTestMocks {
       readonly getOrganizationInvitationList: AsyncMock;
       readonly getOrganizationMembershipList: AsyncMock;
       readonly revokeOrganizationInvitation: AsyncMock;
+      readonly updateOrganization: AsyncMock;
     };
     readonly users: {
       readonly getUserList: AsyncMock;
@@ -128,6 +129,7 @@ const apiTestMocks: ApiTestMocks = vi.hoisted((): ApiTestMocks => {
         vi.fn<(...args: unknown[]) => Promise<unknown>>(),
       revokeOrganizationInvitation:
         vi.fn<(...args: unknown[]) => Promise<unknown>>(),
+      updateOrganization: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
     },
     users: {
       getUserList: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
@@ -486,6 +488,7 @@ export function resetApiTestMocks(): void {
   apiTestMocks.clerk.organizations.getOrganizationInvitationList.mockReset();
   apiTestMocks.clerk.organizations.getOrganizationMembershipList.mockReset();
   apiTestMocks.clerk.organizations.revokeOrganizationInvitation.mockReset();
+  apiTestMocks.clerk.organizations.updateOrganization.mockReset();
   apiTestMocks.clerk.users.getUserList.mockReset();
   apiTestMocks.clerk.users.getOrganizationMembershipList.mockReset();
   apiTestMocks.s3.send.mockReset();

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-org.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-org.test.ts
@@ -240,7 +240,7 @@ describe("PUT /api/zero/org", () => {
       [200],
     );
 
-    expect(response.body).toMatchObject({
+    expect(response.body).toStrictEqual({
       id: orgId,
       slug,
       name: "Updated Org",
@@ -369,10 +369,11 @@ describe("PUT /api/zero/org", () => {
       [200],
     );
 
-    expect(response.body).toMatchObject({
+    expect(response.body).toStrictEqual({
       id: orgId,
       slug: newSlug,
       name: "Test Org",
+      tier: "free",
     });
     expect(
       context.mocks.clerk.organizations.updateOrganization,
@@ -466,7 +467,7 @@ describe("PUT /api/zero/org", () => {
       [200],
     );
 
-    expect(response.body).toMatchObject({
+    expect(response.body).toStrictEqual({
       id: orgId,
       slug,
       name: "Current Org",

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-org.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-org.test.ts
@@ -105,6 +105,25 @@ async function deleteOrgComposite(
   await store.set(deleteOrgMembership$, fixture, context.signal);
 }
 
+async function readOrgCache(orgId: string): Promise<
+  | {
+      readonly slug: string;
+      readonly name: string;
+    }
+  | undefined
+> {
+  const writeDb = store.set(writeDb$);
+  const [cached] = await writeDb
+    .select({
+      slug: orgCache.slug,
+      name: orgCache.name,
+    })
+    .from(orgCache)
+    .where(eq(orgCache.orgId, orgId))
+    .limit(1);
+  return cached;
+}
+
 describe("GET /api/zero/org", () => {
   const seededFixtures: OrgMembershipFixture[] = [];
 
@@ -182,6 +201,304 @@ describe("GET /api/zero/org", () => {
     expect(response.body.id).toBe(orgId);
     expect(response.body.slug).toBe(slug);
     expect(response.body.role).toBe("admin");
+  });
+});
+
+describe("PUT /api/zero/org", () => {
+  const seededFixtures: OrgMembershipFixture[] = [];
+
+  afterEach(async () => {
+    while (seededFixtures.length > 0) {
+      const fixture = seededFixtures.pop();
+      if (fixture) {
+        await deleteOrgComposite(fixture);
+      }
+    }
+  });
+
+  it("updates org name", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    const slug = `org-${randomUUID().slice(0, 8)}`;
+    seededFixtures.push(
+      await seedOrg({ orgId, userId, role: "member", slug, name: "Old Org" }),
+    );
+    mockClerkOrganization({
+      orgId,
+      slug,
+      name: "Updated Org",
+      createdBy: userId,
+    });
+    mocks.clerk.session(userId, orgId);
+
+    const client = setupApp({ context })(zeroOrgContract);
+    const response = await accept(
+      client.update({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { name: "Updated Org" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toMatchObject({
+      id: orgId,
+      slug,
+      name: "Updated Org",
+      tier: "free",
+    });
+    expect(
+      context.mocks.clerk.organizations.updateOrganization,
+    ).toHaveBeenCalledWith(orgId, { name: "Updated Org" });
+    await expect(readOrgCache(orgId)).resolves.toMatchObject({
+      slug,
+      name: "Updated Org",
+    });
+  });
+
+  it("rejects slug update without force", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    seededFixtures.push(await seedOrg({ orgId, userId, role: "admin" }));
+    mocks.clerk.session(userId, orgId);
+
+    const client = setupApp({ context })(zeroOrgContract);
+    const response = await accept(
+      client.update({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { slug: `org-${randomUUID().slice(0, 8)}` },
+      }),
+      [400],
+    );
+
+    expect(response.body.error).toMatchObject({
+      code: "BAD_REQUEST",
+      message:
+        "Changing org slug may break existing references. Use --force to confirm.",
+    });
+    expect(
+      context.mocks.clerk.organizations.updateOrganization,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    const client = setupApp({ context })(zeroOrgContract);
+    const response = await accept(
+      client.update({ headers: {}, body: { name: "Updated Org" } }),
+      [401],
+    );
+
+    expect(response.body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("returns 400 when authenticated without an org", async () => {
+    mocks.clerk.session(`user_${randomUUID()}`, null);
+
+    const client = setupApp({ context })(zeroOrgContract);
+    const response = await accept(
+      client.update({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { name: "Updated Org" },
+      }),
+      [400],
+    );
+
+    expect(response.body.error).toMatchObject({
+      code: "BAD_REQUEST",
+      message: "No org configured. Set your org with: zero org set <slug>",
+    });
+  });
+
+  it("rejects zero tokens", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    seededFixtures.push(await seedOrg({ orgId, userId, role: "admin" }));
+    const seconds = currentSecond();
+    const token = signSandboxJwtForTests({
+      scope: "zero",
+      userId,
+      orgId,
+      runId: `run_${randomUUID()}`,
+      capabilities: [],
+      iat: seconds,
+      exp: seconds + 600,
+    });
+
+    const client = setupApp({ context })(zeroOrgContract);
+    const response = await accept(
+      client.update({
+        headers: { authorization: `Bearer ${token}` },
+        body: { name: "Updated Org" },
+      }),
+      [403],
+    );
+
+    expect(response.body.error).toMatchObject({
+      code: "FORBIDDEN",
+      message: "This endpoint is not available for sandbox tokens",
+    });
+  });
+
+  it("updates org slug with force and refreshes cache", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    const oldSlug = `org-${randomUUID().slice(0, 8)}`;
+    const newSlug = `org-${randomUUID().slice(0, 8)}`;
+    seededFixtures.push(
+      await seedOrg({
+        orgId,
+        userId,
+        role: "admin",
+        slug: oldSlug,
+        name: "Test Org",
+      }),
+    );
+    mockClerkOrganization({
+      orgId,
+      slug: newSlug,
+      name: "Test Org",
+      createdBy: userId,
+    });
+    mocks.clerk.session(userId, orgId);
+
+    const client = setupApp({ context })(zeroOrgContract);
+    const response = await accept(
+      client.update({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { slug: newSlug, force: true },
+      }),
+      [200],
+    );
+
+    expect(response.body).toMatchObject({
+      id: orgId,
+      slug: newSlug,
+      name: "Test Org",
+    });
+    expect(
+      context.mocks.clerk.organizations.updateOrganization,
+    ).toHaveBeenCalledWith(orgId, { slug: newSlug });
+    await expect(readOrgCache(orgId)).resolves.toMatchObject({
+      slug: newSlug,
+      name: "Test Org",
+    });
+  });
+
+  it("returns 409 when slug belongs to another org", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    const otherOrgId = `org_${randomUUID()}`;
+    const takenSlug = `org-${randomUUID().slice(0, 8)}`;
+    seededFixtures.push(await seedOrg({ orgId, userId, role: "admin" }));
+    seededFixtures.push(
+      await seedOrg({
+        orgId: otherOrgId,
+        userId,
+        role: "admin",
+        slug: takenSlug,
+      }),
+    );
+    mocks.clerk.session(userId, orgId);
+
+    const client = setupApp({ context })(zeroOrgContract);
+    const response = await accept(
+      client.update({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { slug: takenSlug, force: true },
+      }),
+      [409],
+    );
+
+    expect(response.body.error).toMatchObject({
+      code: "CONFLICT",
+      message: `Org "${takenSlug}" already exists`,
+    });
+    expect(
+      context.mocks.clerk.organizations.updateOrganization,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("rejects reserved slugs", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    seededFixtures.push(await seedOrg({ orgId, userId, role: "admin" }));
+    mocks.clerk.session(userId, orgId);
+
+    const client = setupApp({ context })(zeroOrgContract);
+    const response = await accept(
+      client.update({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { slug: "vm0-team", force: true },
+      }),
+      [400],
+    );
+
+    expect(response.body.error).toMatchObject({
+      code: "BAD_REQUEST",
+      message: "Org slug is reserved",
+    });
+    expect(
+      context.mocks.clerk.organizations.updateOrganization,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("returns current org data for no-op body", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    const slug = `org-${randomUUID().slice(0, 8)}`;
+    seededFixtures.push(
+      await seedOrg({
+        orgId,
+        userId,
+        role: "admin",
+        slug,
+        name: "Current Org",
+        tier: "pro",
+      }),
+    );
+    mocks.clerk.session(userId, orgId);
+
+    const client = setupApp({ context })(zeroOrgContract);
+    const response = await accept(
+      client.update({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {},
+      }),
+      [200],
+    );
+
+    expect(response.body).toMatchObject({
+      id: orgId,
+      slug,
+      name: "Current Org",
+      tier: "pro",
+    });
+    expect(
+      context.mocks.clerk.organizations.updateOrganization,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 when caller is not an org member", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    seededFixtures.push(await seedOrgCacheOnly(orgId));
+    mocks.clerk.session(userId, orgId);
+
+    const client = setupApp({ context })(zeroOrgContract);
+    const response = await accept(
+      client.update({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { name: "Updated Org" },
+      }),
+      [403],
+    );
+
+    expect(response.body.error).toMatchObject({
+      code: "FORBIDDEN",
+      message: "Access denied",
+    });
+    expect(
+      context.mocks.clerk.organizations.updateOrganization,
+    ).not.toHaveBeenCalled();
   });
 });
 

--- a/turbo/apps/api/src/signals/routes/zero-org-read.ts
+++ b/turbo/apps/api/src/signals/routes/zero-org-read.ts
@@ -6,9 +6,11 @@ import { zeroOrgMembersContract } from "@vm0/api-contracts/contracts/zero-org-me
 
 import { authContext$, organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
-import { notFound } from "../../lib/error";
+import { bodyResultOf } from "../context/request";
+import { badRequestMessage, notFound } from "../../lib/error";
 import type { RouteEntry } from "../route";
 import {
+  updateZeroOrg$,
   zeroOrgDetail$,
   zeroOrgDomainsList,
   zeroOrgList,
@@ -40,6 +42,40 @@ const getOrgInner$ = command(async ({ get, set }, signal: AbortSignal) => {
     return notFound("Organization not found");
   }
   return { status: 200 as const, body: org };
+});
+
+const updateOrgInner$ = command(async ({ get, set }, signal: AbortSignal) => {
+  const auth = get(authContext$);
+  if (!auth.orgId) {
+    return badRequestMessage(
+      "No org configured. Set your org with: zero org set <slug>",
+    );
+  }
+
+  const bodyResult = await get(bodyResultOf(zeroOrgContract.update));
+  signal.throwIfAborted();
+  if (!bodyResult.ok) {
+    return bodyResult.response;
+  }
+
+  const result = await set(
+    updateZeroOrg$,
+    {
+      orgId: auth.orgId,
+      userId: auth.userId,
+      slug: bodyResult.data.slug,
+      name: bodyResult.data.name,
+      force: bodyResult.data.force,
+    },
+    signal,
+  );
+  signal.throwIfAborted();
+
+  if ("status" in result) {
+    return result;
+  }
+
+  return { status: 200 as const, body: result };
 });
 
 const listOrgsInner$ = computed(async (get) => {
@@ -75,6 +111,10 @@ export const zeroOrgReadRoutes: readonly RouteEntry[] = [
   {
     route: zeroOrgContract.get,
     handler: authRoute({ acceptAnySandboxCapability: true }, getOrgInner$),
+  },
+  {
+    route: zeroOrgContract.update,
+    handler: authRoute({}, updateOrgInner$),
   },
   {
     route: zeroOrgListContract.list,

--- a/turbo/apps/api/src/signals/routes/zero-org-read.ts
+++ b/turbo/apps/api/src/signals/routes/zero-org-read.ts
@@ -75,7 +75,15 @@ const updateOrgInner$ = command(async ({ get, set }, signal: AbortSignal) => {
     return result;
   }
 
-  return { status: 200 as const, body: result };
+  return {
+    status: 200 as const,
+    body: {
+      id: result.id,
+      slug: result.slug,
+      name: result.name,
+      tier: result.tier,
+    },
+  };
 });
 
 const listOrgsInner$ = computed(async (get) => {

--- a/turbo/apps/api/src/signals/services/zero-org-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-org-data.service.ts
@@ -17,6 +17,7 @@ import type { User } from "@clerk/backend";
 import { db$, writeDb$ } from "../external/db";
 import { clerk$ } from "../external/clerk";
 import { fetchClerkMembershipRequests } from "../external/clerk-membership-requests";
+import { badRequestMessage, conflict, notFound } from "../../lib/error";
 import { nowDate } from "../../lib/time";
 
 const clerkOrgIdentitySchema = z.object({
@@ -44,6 +45,46 @@ interface OrgIdentity {
   readonly slug: string;
   readonly name: string;
   readonly createdBy: string | null;
+}
+
+const forbiddenAccess = Object.freeze({
+  status: 403 as const,
+  body: Object.freeze({
+    error: Object.freeze({
+      message: "Access denied",
+      code: "FORBIDDEN",
+    }),
+  }),
+});
+
+type OrgUpdateErrorResponse =
+  | ReturnType<typeof badRequestMessage>
+  | ReturnType<typeof conflict>
+  | ReturnType<typeof notFound>
+  | typeof forbiddenAccess;
+
+interface UpdateZeroOrgArgs {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly slug?: string;
+  readonly name?: string;
+  readonly force?: boolean;
+}
+
+interface ClerkUpdate {
+  slug?: string;
+  name?: string;
+}
+
+function isReservedSlug(slug: string): boolean {
+  return (
+    slug.startsWith("vm0") ||
+    slug === "system" ||
+    slug === "admin" ||
+    slug === "api" ||
+    slug === "app" ||
+    slug === "www"
+  );
 }
 
 function isClerkNotFound(error: unknown): boolean {
@@ -159,6 +200,87 @@ export const zeroOrgDetail$ = command(
       role: (membership[0]?.role as OrgRole) ?? "member",
       createdBy: identity.createdBy ?? undefined,
     };
+  },
+);
+
+export const updateZeroOrg$ = command(
+  async (
+    { get, set },
+    args: UpdateZeroOrgArgs,
+    signal: AbortSignal,
+  ): Promise<OrgResponse | OrgUpdateErrorResponse> => {
+    const db = get(db$);
+    const [membership] = await db
+      .select({ role: orgMembersCache.role })
+      .from(orgMembersCache)
+      .where(
+        and(
+          eq(orgMembersCache.orgId, args.orgId),
+          eq(orgMembersCache.userId, args.userId),
+        ),
+      )
+      .limit(1);
+    signal.throwIfAborted();
+
+    if (!membership) {
+      return forbiddenAccess;
+    }
+
+    const clerkUpdate: ClerkUpdate = {};
+
+    if (args.slug) {
+      if (!args.force) {
+        return badRequestMessage(
+          "Changing org slug may break existing references. Use --force to confirm.",
+        );
+      }
+
+      if (isReservedSlug(args.slug)) {
+        return badRequestMessage("Org slug is reserved");
+      }
+
+      const [existing] = await db
+        .select({ orgId: orgCache.orgId })
+        .from(orgCache)
+        .where(eq(orgCache.slug, args.slug))
+        .limit(1);
+      signal.throwIfAborted();
+
+      if (existing && existing.orgId !== args.orgId) {
+        return conflict(`Org "${args.slug}" already exists`);
+      }
+
+      clerkUpdate.slug = args.slug;
+    }
+
+    if (args.name) {
+      clerkUpdate.name = args.name;
+    }
+
+    if (clerkUpdate.slug || clerkUpdate.name) {
+      const client = get(clerk$);
+      await client.organizations.updateOrganization(args.orgId, clerkUpdate);
+      signal.throwIfAborted();
+
+      const writeDb = set(writeDb$);
+      await writeDb.delete(orgCache).where(eq(orgCache.orgId, args.orgId));
+      signal.throwIfAborted();
+    }
+
+    const org = await set(
+      zeroOrgDetail$,
+      { orgId: args.orgId, userId: args.userId },
+      signal,
+    );
+    signal.throwIfAborted();
+
+    if (!org) {
+      return notFound(
+        "No org configured. Set your org with: zero org set <slug>",
+      );
+    }
+
+    return org;
   },
 );
 


### PR DESCRIPTION
## Summary
- add API backend support for `PUT /api/zero/org` using the shared zero org contract
- implement org update service behavior for name/slug changes, membership checks, slug conflicts, reserved slugs, and org cache refresh
- add API integration coverage for success and error paths

Closes #12895

## Validation
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-org.test.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm format`
- `pnpm lint`
- `pnpm check-types`
- `pnpm knip`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-org.test.ts src/signals/routes/__tests__/zero-connectors-remote-agent-connect.test.ts`
- `pnpm -F web exec vitest run app/api/agent/runs/__tests__/route.test.ts app/api/cron/aggregate-insights/__tests__/route.test.ts app/api/cron/sync-skills/__tests__/route.test.ts app/api/zero/agents/__tests__/route.test.ts app/api/zero/runs/__tests__/route.test.ts app/api/internal/callbacks/telegram/__tests__/route.test.ts app/api/zero/chat/messages/__tests__/route.test.ts app/api/internal/callbacks/slack/org/__tests__/route.test.ts`
- `pnpm -F web exec vitest run --no-file-parallelism --maxWorkers=1 src/lib/zero/__tests__/build-zero-context.test.ts src/lib/zero/__tests__/run-queue-service.test.ts app/api/cron/aggregate-insights/__tests__/route.test.ts app/api/cron/cleanup-sandboxes/__tests__/route.test.ts app/api/zero/permission-access-requests/__tests__/route.test.ts app/api/zero/report-error/__tests__/route.test.ts app/api/zero/billing/status/__tests__/route.test.ts app/api/zero/chat/messages/__tests__/route.incomplete-context.test.ts app/api/zero/slack/events/__tests__/route.test.ts app/api/zero/email/inbound/__tests__/route.test.ts app/api/zero/usage/insight/__tests__/route.test.ts app/api/internal/callbacks/slack/org/__tests__/route.test.ts app/api/zero/chat-threads/[id]/artifacts/__tests__/route.test.ts app/api/agent/runs/[id]/telemetry/network/__tests__/route.test.ts`

Full `pnpm vitest` was also run after `scripts/prepare.sh`; it failed in 14 Web files with timeout/data-contamination symptoms under full-suite concurrency. The target API route tests passed, and the failed Web files passed when rerun serially as listed above.