### PR TITLE
refactor: migrate test telegram state GET to api backend

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -76,6 +76,7 @@ import { zeroWebDownloadRoutes } from "./routes/zero-web-download";
 import { testOAuthProviderAuthorizeRoutes } from "./routes/test-oauth-provider-authorize";
 import { testOAuthProviderEchoRoutes } from "./routes/test-oauth-provider-echo";
 import { testOAuthProviderUserinfoRoutes } from "./routes/test-oauth-provider-userinfo";
+import { testTelegramStateRoutes } from "./routes/test-telegram-state";
 
 export type { SignalRouteHandler };
 
@@ -162,4 +163,5 @@ export const ROUTES: readonly RouteEntry[] = [
   ...testOAuthProviderAuthorizeRoutes,
   ...testOAuthProviderEchoRoutes,
   ...testOAuthProviderUserinfoRoutes,
+  ...testTelegramStateRoutes,
 ];

--- a/turbo/apps/api/src/signals/routes/__tests__/test-telegram-state.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/test-telegram-state.test.ts
@@ -1,0 +1,241 @@
+import { randomUUID } from "node:crypto";
+
+import { createStore } from "ccstate";
+import { eq } from "drizzle-orm";
+
+import {
+  agentComposes,
+  agentComposeVersions,
+} from "@vm0/db/schema/agent-compose";
+import { e2eTelegramMockCallLog } from "@vm0/db/schema/e2e-telegram-mock-call-log";
+import { orgMetadata } from "@vm0/db/schema/org-metadata";
+import { telegramInstallations } from "@vm0/db/schema/telegram-installation";
+import { telegramMessages } from "@vm0/db/schema/telegram-message";
+import { telegramUserLinks } from "@vm0/db/schema/telegram-user-link";
+import { zeroAgents } from "@vm0/db/schema/zero-agent";
+
+import { createApp } from "../../../app-factory";
+import { mockEnv, mockOptionalEnv } from "../../../lib/env";
+import { testContext } from "../../../__tests__/test-helpers";
+import { writeDb$ } from "../../external/db";
+import { createFixtureTracker } from "./helpers/zero-route-test";
+
+const context = testContext();
+const store = createStore();
+
+interface SeededTelegramState {
+  readonly botId: string;
+  readonly orgId: string;
+  readonly composeId: string;
+  readonly versionId: string;
+  readonly chatId: string;
+}
+
+interface TelegramStateResponse {
+  readonly installation: Record<string, unknown> | null;
+  readonly links: readonly Record<string, unknown>[];
+  readonly message_count: number;
+  readonly recent_runs: readonly Record<string, unknown>[];
+  readonly org_metadata: Record<string, unknown> | null;
+  readonly default_agent: Record<string, unknown> | null;
+  readonly default_compose: Record<string, unknown> | null;
+  readonly default_compose_version: {
+    readonly id: string;
+    readonly content_keys: readonly string[];
+  } | null;
+  readonly resolved_telegram_api_url: string | null;
+  readonly mock_calls: readonly Record<string, unknown>[];
+}
+
+function requestApp(path: string, init?: RequestInit): Promise<Response> {
+  const app = createApp({ signal: context.signal });
+  return Promise.resolve(app.request(path, init));
+}
+
+async function readJson<T>(response: Response): Promise<T> {
+  return (await response.json()) as T;
+}
+
+async function seedTelegramState(): Promise<SeededTelegramState> {
+  const writeDb = store.set(writeDb$);
+  const userId = `user_${randomUUID()}`;
+  const orgId = `org_${randomUUID()}`;
+  const botId = `bot_${randomUUID()}`;
+  const composeId = randomUUID();
+  const versionId = randomUUID().replaceAll("-", "");
+  const chatId = `chat_${randomUUID()}`;
+
+  await writeDb.insert(agentComposes).values({
+    id: composeId,
+    userId,
+    name: "telegram-state-agent",
+    orgId,
+    headVersionId: versionId,
+  });
+  await writeDb.insert(agentComposeVersions).values({
+    id: versionId,
+    composeId,
+    content: { model: "gpt-5.4", instructions: "Reply concisely" },
+    createdBy: userId,
+  });
+  await writeDb.insert(zeroAgents).values({
+    id: composeId,
+    orgId,
+    owner: userId,
+    name: "telegram-state-agent",
+  });
+  await writeDb.insert(orgMetadata).values({
+    orgId,
+    defaultAgentId: composeId,
+    tier: "free",
+  });
+  await writeDb.insert(telegramInstallations).values({
+    telegramBotId: botId,
+    botUsername: "vm0_test_bot",
+    encryptedBotToken: "encrypted-token",
+    webhookSecret: "webhook-secret",
+    defaultComposeId: composeId,
+    ownerUserId: userId,
+    orgId,
+  });
+  await writeDb.insert(telegramUserLinks).values({
+    installationId: botId,
+    telegramUserId: "telegram-user-1",
+    vm0UserId: userId,
+    dmWelcomeSent: true,
+  });
+  await writeDb.insert(telegramMessages).values({
+    installationId: botId,
+    chatId,
+    messageId: "message-1",
+    fromUserId: "telegram-user-1",
+    text: "hello from telegram",
+  });
+  await writeDb.insert(e2eTelegramMockCallLog).values({
+    method: "sendMessage",
+    botToken: "test-bot-token",
+    chatId,
+    body: "{}",
+    bodyJson: { ok: true },
+  });
+
+  return { botId, orgId, composeId, versionId, chatId };
+}
+
+async function cleanupTelegramState(state: SeededTelegramState): Promise<void> {
+  const writeDb = store.set(writeDb$);
+  await writeDb
+    .delete(e2eTelegramMockCallLog)
+    .where(eq(e2eTelegramMockCallLog.chatId, state.chatId));
+  await writeDb
+    .delete(telegramMessages)
+    .where(eq(telegramMessages.installationId, state.botId));
+  await writeDb
+    .delete(telegramUserLinks)
+    .where(eq(telegramUserLinks.installationId, state.botId));
+  await writeDb
+    .delete(telegramInstallations)
+    .where(eq(telegramInstallations.telegramBotId, state.botId));
+  await writeDb.delete(orgMetadata).where(eq(orgMetadata.orgId, state.orgId));
+  await writeDb.delete(zeroAgents).where(eq(zeroAgents.id, state.composeId));
+  await writeDb
+    .delete(agentComposeVersions)
+    .where(eq(agentComposeVersions.id, state.versionId));
+  await writeDb
+    .delete(agentComposes)
+    .where(eq(agentComposes.id, state.composeId));
+}
+
+const trackTelegramState = createFixtureTracker(cleanupTelegramState);
+
+describe("GET /api/test/telegram-state", () => {
+  it("returns 404 when the test endpoint is not allowed", async () => {
+    mockEnv("ENV", "production");
+
+    const response = await requestApp("/api/test/telegram-state?bot_id=bot-1");
+
+    expect(response.status).toBe(404);
+    await expect(response.text()).resolves.toBe("Not found");
+  });
+
+  it("returns 400 when bot_id is missing", async () => {
+    mockEnv("ENV", "development");
+
+    const response = await requestApp("/api/test/telegram-state");
+
+    expect(response.status).toBe(400);
+    await expect(readJson<{ error: string }>(response)).resolves.toStrictEqual({
+      error: "bot_id query param is required",
+    });
+  });
+
+  it("returns empty diagnostic state for an unknown bot", async () => {
+    mockEnv("ENV", "development");
+
+    const response = await requestApp(
+      `/api/test/telegram-state?bot_id=bot_${randomUUID()}`,
+    );
+
+    expect(response.status).toBe(200);
+    const body = await readJson<TelegramStateResponse>(response);
+    expect(body.installation).toBeNull();
+    expect(body.links).toStrictEqual([]);
+    expect(body.message_count).toBe(0);
+    expect(body.recent_runs).toStrictEqual([]);
+    expect(body.org_metadata).toBeNull();
+    expect(body.default_agent).toBeNull();
+    expect(body.default_compose).toBeNull();
+    expect(body.default_compose_version).toBeNull();
+    expect(body.resolved_telegram_api_url).toBeNull();
+    expect(Array.isArray(body.mock_calls)).toBeTruthy();
+  });
+
+  it("returns seeded Telegram diagnostic state", async () => {
+    mockEnv("ENV", "development");
+    mockOptionalEnv("TELEGRAM_API_URL", "https://telegram.test/bot");
+    const seeded = await trackTelegramState(seedTelegramState());
+
+    const response = await requestApp(
+      `/api/test/telegram-state?bot_id=${seeded.botId}`,
+    );
+
+    expect(response.status).toBe(200);
+    const body = await readJson<TelegramStateResponse>(response);
+    expect(body.installation).toMatchObject({
+      telegramBotId: seeded.botId,
+      orgId: seeded.orgId,
+      defaultComposeId: seeded.composeId,
+    });
+    expect(body.links).toHaveLength(1);
+    expect(body.links[0]).toMatchObject({
+      telegramUserId: "telegram-user-1",
+      dmWelcomeSent: true,
+    });
+    expect(body.message_count).toBe(1);
+    expect(body.org_metadata).toMatchObject({
+      orgId: seeded.orgId,
+      defaultAgentId: seeded.composeId,
+      tier: "free",
+    });
+    expect(body.default_agent).toMatchObject({
+      id: seeded.composeId,
+      name: "telegram-state-agent",
+      orgId: seeded.orgId,
+    });
+    expect(body.default_compose).toMatchObject({
+      id: seeded.composeId,
+      name: "telegram-state-agent",
+      headVersionId: seeded.versionId,
+    });
+    expect(body.default_compose_version).toStrictEqual({
+      id: seeded.versionId,
+      content_keys: ["model", "instructions"],
+    });
+    expect(body.resolved_telegram_api_url).toBe("https://telegram.test/bot");
+    expect(
+      body.mock_calls.some((call) => {
+        return call.chatId === seeded.chatId && call.method === "sendMessage";
+      }),
+    ).toBeTruthy();
+  });
+});

--- a/turbo/apps/api/src/signals/routes/test-telegram-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-telegram-state.ts
@@ -1,0 +1,249 @@
+import { computed } from "ccstate";
+import { desc, eq, sql } from "drizzle-orm";
+import { testTelegramStateContract } from "@vm0/api-contracts/contracts/test-telegram-state";
+import {
+  agentComposes,
+  agentComposeVersions,
+} from "@vm0/db/schema/agent-compose";
+import { agentRuns } from "@vm0/db/schema/agent-run";
+import { e2eTelegramMockCallLog } from "@vm0/db/schema/e2e-telegram-mock-call-log";
+import { orgMetadata } from "@vm0/db/schema/org-metadata";
+import { telegramInstallations } from "@vm0/db/schema/telegram-installation";
+import { telegramMessages } from "@vm0/db/schema/telegram-message";
+import { telegramUserLinks } from "@vm0/db/schema/telegram-user-link";
+import { zeroAgents } from "@vm0/db/schema/zero-agent";
+import { zeroRuns } from "@vm0/db/schema/zero-run";
+
+import { optionalEnv } from "../../lib/env";
+import { request$ } from "../context/hono";
+import { queryOf } from "../context/request";
+import { db$, type ReadonlyDb } from "../external/db";
+import type { RouteEntry } from "../route";
+import {
+  isTestEndpointAllowed,
+  testEndpointNotFoundResponse,
+} from "./test-oauth-provider-helpers";
+
+const testTelegramStateQuery$ = queryOf(testTelegramStateContract.get);
+
+function resolveTelegramApiUrlForDiagnostics(): string | null {
+  const telegramApiUrl = optionalEnv("TELEGRAM_API_URL");
+  if (telegramApiUrl) {
+    return telegramApiUrl;
+  }
+
+  const mockFlag = optionalEnv("E2E_TELEGRAM_MOCK_ENABLED");
+  const mockEnabled = mockFlag === "1" || mockFlag === "true";
+  const vercelUrl = optionalEnv("VERCEL_URL");
+  if (mockEnabled && vercelUrl) {
+    return `https://${vercelUrl}/api/test/telegram-mock/bot`;
+  }
+
+  return null;
+}
+
+async function loadInstallation(db: ReadonlyDb, botId: string) {
+  const [installation] = await db
+    .select({
+      telegramBotId: telegramInstallations.telegramBotId,
+      botUsername: telegramInstallations.botUsername,
+      orgId: telegramInstallations.orgId,
+      ownerUserId: telegramInstallations.ownerUserId,
+      defaultComposeId: telegramInstallations.defaultComposeId,
+      createdAt: telegramInstallations.createdAt,
+    })
+    .from(telegramInstallations)
+    .where(eq(telegramInstallations.telegramBotId, botId))
+    .limit(1);
+  return installation ?? null;
+}
+
+function loadLinks(db: ReadonlyDb, botId: string) {
+  return db
+    .select({
+      id: telegramUserLinks.id,
+      telegramUserId: telegramUserLinks.telegramUserId,
+      vm0UserId: telegramUserLinks.vm0UserId,
+      dmWelcomeSent: telegramUserLinks.dmWelcomeSent,
+      createdAt: telegramUserLinks.createdAt,
+    })
+    .from(telegramUserLinks)
+    .where(eq(telegramUserLinks.installationId, botId));
+}
+
+function loadRecentRuns(db: ReadonlyDb, orgId: string | undefined) {
+  if (!orgId) {
+    return [];
+  }
+  return db
+    .select({
+      id: agentRuns.id,
+      status: agentRuns.status,
+      createdAt: agentRuns.createdAt,
+      triggerSource: zeroRuns.triggerSource,
+      userId: agentRuns.userId,
+      error: agentRuns.error,
+      promptPreview: sql<string>`substring(${agentRuns.prompt}, 1, 200)`,
+    })
+    .from(agentRuns)
+    .leftJoin(zeroRuns, eq(agentRuns.id, zeroRuns.id))
+    .where(eq(agentRuns.orgId, orgId))
+    .orderBy(desc(agentRuns.createdAt))
+    .limit(50);
+}
+
+async function loadOrgMeta(db: ReadonlyDb, orgId: string | undefined) {
+  if (!orgId) {
+    return null;
+  }
+  const [row] = await db
+    .select({
+      orgId: orgMetadata.orgId,
+      defaultAgentId: orgMetadata.defaultAgentId,
+      credits: orgMetadata.credits,
+      tier: orgMetadata.tier,
+    })
+    .from(orgMetadata)
+    .where(eq(orgMetadata.orgId, orgId))
+    .limit(1);
+  return row ?? null;
+}
+
+async function loadDefaultAgent(
+  db: ReadonlyDb,
+  defaultComposeId: string | undefined,
+) {
+  if (!defaultComposeId) {
+    return null;
+  }
+  const [row] = await db
+    .select({
+      id: zeroAgents.id,
+      name: zeroAgents.name,
+      orgId: zeroAgents.orgId,
+    })
+    .from(zeroAgents)
+    .where(eq(zeroAgents.id, defaultComposeId))
+    .limit(1);
+  return row ?? null;
+}
+
+async function loadCompose(
+  db: ReadonlyDb,
+  defaultComposeId: string | undefined,
+) {
+  if (!defaultComposeId) {
+    return null;
+  }
+  const [row] = await db
+    .select({
+      id: agentComposes.id,
+      name: agentComposes.name,
+      headVersionId: agentComposes.headVersionId,
+    })
+    .from(agentComposes)
+    .where(eq(agentComposes.id, defaultComposeId))
+    .limit(1);
+  return row ?? null;
+}
+
+async function loadComposeVersion(
+  db: ReadonlyDb,
+  headVersionId: string | null | undefined,
+) {
+  if (!headVersionId) {
+    return null;
+  }
+  const [row] = await db
+    .select({
+      id: agentComposeVersions.id,
+      content: agentComposeVersions.content,
+    })
+    .from(agentComposeVersions)
+    .where(eq(agentComposeVersions.id, headVersionId))
+    .limit(1);
+  return row ?? null;
+}
+
+async function countMessages(db: ReadonlyDb, botId: string): Promise<number> {
+  const [row] = await db
+    .select({ count: sql<number>`count(*)::int` })
+    .from(telegramMessages)
+    .where(eq(telegramMessages.installationId, botId));
+  return row?.count ?? 0;
+}
+
+function loadMockCalls(db: ReadonlyDb) {
+  return db
+    .select({
+      method: e2eTelegramMockCallLog.method,
+      botToken: e2eTelegramMockCallLog.botToken,
+      chatId: e2eTelegramMockCallLog.chatId,
+      bodyJson: e2eTelegramMockCallLog.bodyJson,
+      createdAt: e2eTelegramMockCallLog.createdAt,
+    })
+    .from(e2eTelegramMockCallLog)
+    .orderBy(desc(e2eTelegramMockCallLog.createdAt))
+    .limit(50);
+}
+
+const getTestTelegramState$ = computed(async (get) => {
+  const request = get(request$);
+  if (!isTestEndpointAllowed(request)) {
+    return testEndpointNotFoundResponse();
+  }
+
+  const query = get(testTelegramStateQuery$);
+  if (!query.bot_id) {
+    return {
+      status: 400 as const,
+      body: { error: "bot_id query param is required" },
+    };
+  }
+
+  const db = get(db$);
+  const installation = await loadInstallation(db, query.bot_id);
+  const [links, recentRuns, orgMeta, defaultAgent, compose, messageCount] =
+    await Promise.all([
+      loadLinks(db, query.bot_id),
+      loadRecentRuns(db, installation?.orgId),
+      loadOrgMeta(db, installation?.orgId),
+      loadDefaultAgent(db, installation?.defaultComposeId),
+      loadCompose(db, installation?.defaultComposeId),
+      countMessages(db, query.bot_id),
+    ]);
+  const [composeVersion, mockCalls] = await Promise.all([
+    loadComposeVersion(db, compose?.headVersionId),
+    loadMockCalls(db),
+  ]);
+
+  return {
+    status: 200 as const,
+    body: {
+      installation,
+      links,
+      message_count: messageCount,
+      recent_runs: recentRuns,
+      org_metadata: orgMeta,
+      default_agent: defaultAgent,
+      default_compose: compose,
+      default_compose_version: composeVersion
+        ? {
+            id: composeVersion.id,
+            content_keys: Object.keys(
+              (composeVersion.content ?? {}) as Record<string, unknown>,
+            ),
+          }
+        : null,
+      resolved_telegram_api_url: resolveTelegramApiUrlForDiagnostics(),
+      mock_calls: mockCalls,
+    },
+  };
+});
+
+export const testTelegramStateRoutes: readonly RouteEntry[] = [
+  {
+    route: testTelegramStateContract.get,
+    handler: getTestTelegramState$,
+  },
+];

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -229,6 +229,13 @@ export {
   type TestOAuthProviderUserinfoResponse,
 } from "./test-oauth-provider-userinfo";
 export {
+  testTelegramStateContract,
+  testTelegramStateErrorSchema,
+  testTelegramStateResponseSchema,
+  type TestTelegramStateContract,
+  type TestTelegramStateResponse,
+} from "./test-telegram-state";
+export {
   cronCleanupSandboxesContract,
   cleanupResultSchema,
   cleanupResponseSchema,

--- a/turbo/packages/api-contracts/src/contracts/test-telegram-state.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-telegram-state.ts
@@ -1,0 +1,50 @@
+import { z } from "zod";
+
+import { initContract } from "./base";
+
+const c = initContract();
+
+export const testTelegramStateQuerySchema = z.object({
+  bot_id: z.string().optional(),
+});
+
+export const testTelegramStateErrorSchema = z.object({
+  error: z.string(),
+});
+
+export const testTelegramStateComposeVersionSchema = z.object({
+  id: z.string(),
+  content_keys: z.array(z.string()),
+});
+
+export const testTelegramStateResponseSchema = z.object({
+  installation: z.unknown().nullable(),
+  links: z.array(z.unknown()),
+  message_count: z.number(),
+  recent_runs: z.array(z.unknown()),
+  org_metadata: z.unknown().nullable(),
+  default_agent: z.unknown().nullable(),
+  default_compose: z.unknown().nullable(),
+  default_compose_version: testTelegramStateComposeVersionSchema.nullable(),
+  resolved_telegram_api_url: z.string().nullable(),
+  mock_calls: z.array(z.unknown()),
+});
+
+export const testTelegramStateContract = c.router({
+  get: {
+    method: "GET",
+    path: "/api/test/telegram-state",
+    query: testTelegramStateQuerySchema,
+    responses: {
+      200: testTelegramStateResponseSchema,
+      400: testTelegramStateErrorSchema,
+      404: z.string(),
+    },
+    summary: "Inspect Telegram E2E test state",
+  },
+});
+
+export type TestTelegramStateContract = typeof testTelegramStateContract;
+export type TestTelegramStateResponse = z.infer<
+  typeof testTelegramStateResponseSchema
+>;


### PR DESCRIPTION
## Summary
- Add a ts-rest contract and apps/api signal route for `GET /api/test/telegram-state`.
- Port the web route's read-only Telegram diagnostic behavior into the API backend.
- Add API route integration coverage for disabled endpoint, missing `bot_id`, empty state, and seeded diagnostic state.

Closes #12830

## Validation
- `pnpm -F api exec vitest run src/signals/routes/__tests__/test-telegram-state.test.ts`
- `pnpm -F api lint`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm exec prettier --check packages/api-contracts/src/contracts/test-telegram-state.ts packages/api-contracts/src/contracts/index.ts apps/api/src/signals/routes/test-telegram-state.ts apps/api/src/signals/routes/__tests__/test-telegram-state.test.ts apps/api/src/signals/route.ts`
- `git diff --check`
- `pnpm knip --cache`

## Known Local Typecheck Baseline
- `pnpm check-types` fails before reaching this route due to existing unrelated API client inference/typecheck failures, including `@vm0/cli src/lib/api/domains/zero-remote-agent.ts(153,31): error TS2554: Expected 1 arguments, but got 0`.
- `pnpm -F api check-types` also reports existing ts-rest test inference errors; filtered output for `test-telegram-state`, `src/signals/route.ts`, and `contracts/index.ts` returned no matches.
