### PR TITLE
feat(api): migrate voice io post routes

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -72,6 +72,9 @@ import { zeroUserPreferencesRoutes } from "./routes/zero-user-preferences";
 import { zeroUserModelPreferenceRoutes } from "./routes/zero-user-model-preference";
 import { zeroVoiceChatRoutes } from "./routes/zero-voice-chat";
 import { zeroVoiceIoQuotaRoutes } from "./routes/zero-voice-io-quota";
+import { zeroVoiceIoSpeechRoutes } from "./routes/zero-voice-io-speech";
+import { zeroVoiceIoSttRoutes } from "./routes/zero-voice-io-stt";
+import { zeroVoiceIoTtsRoutes } from "./routes/zero-voice-io-tts";
 import { zeroWebDownloadRoutes } from "./routes/zero-web-download";
 import { testOAuthProviderAuthorizeRoutes } from "./routes/test-oauth-provider-authorize";
 import { testOAuthProviderEchoRoutes } from "./routes/test-oauth-provider-echo";
@@ -122,6 +125,9 @@ export const ROUTES: readonly RouteEntry[] = [
   ...zeroMeModelProvidersUpsertRoutes,
   ...zeroVoiceChatRoutes,
   ...zeroVoiceIoQuotaRoutes,
+  ...zeroVoiceIoSpeechRoutes,
+  ...zeroVoiceIoSttRoutes,
+  ...zeroVoiceIoTtsRoutes,
   ...zeroWebDownloadRoutes,
   ...zeroQueuePositionRoutes,
   ...zeroRemoteAgentRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-voice-io-post.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-voice-io-post.test.ts
@@ -1,0 +1,662 @@
+import { Buffer } from "node:buffer";
+import { randomUUID } from "node:crypto";
+
+import { createApp } from "../../../app-factory";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import { orgMetadata } from "@vm0/db/schema/org-metadata";
+import { orgMembersMetadata } from "@vm0/db/schema/org-members-metadata";
+import { runUploadedFiles } from "@vm0/db/schema/run-uploaded-file";
+import { usageEvent } from "@vm0/db/schema/usage-event";
+import { usagePricing } from "@vm0/db/schema/usage-pricing";
+import { userBehaviorCount } from "@vm0/db/schema/user-behavior-count";
+import { userFeatureSwitches } from "@vm0/db/schema/user-feature-switches";
+import { HttpResponse, http } from "msw";
+import { createStore } from "ccstate";
+import { and, eq } from "drizzle-orm";
+
+import { testContext } from "../../../__tests__/test-helpers";
+import { server } from "../../../mocks/server";
+import { signSandboxJwtForTests } from "../../auth/tokens";
+import { writeDb$ } from "../../external/db";
+import { now } from "../../external/time";
+import {
+  OPENAI_AUDIO_SPEECH_URL,
+  OPENAI_AUDIO_TRANSCRIPTIONS_URL,
+  SPEECH_CONTENT_TYPE,
+  sttDailyDurationKey,
+  sttDailyRateKey,
+  TTS_CONTENT_TYPE,
+  VOICE_IO_STT_MODEL,
+  VOICE_IO_TTS_MODEL,
+  type SpeechPricing,
+} from "../../services/zero-voice-io-post.service";
+import {
+  deleteOrgMembership$,
+  seedOrgMembership$,
+} from "./helpers/zero-org-membership";
+import {
+  deleteUsageInsightFixture$,
+  seedCompose$,
+  seedRun$,
+} from "./helpers/zero-usage-insight";
+import {
+  createFixtureTracker,
+  createZeroRouteMocks,
+} from "./helpers/zero-route-test";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+const TEST_BUCKET = "test-user-storages";
+const AUDIO_INPUT_BEHAVIOR_KEY = "audio_input";
+
+interface VoiceFixture {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly pricingInserted: boolean;
+}
+
+function authHeaders() {
+  return { authorization: "Bearer clerk-session" };
+}
+
+function currentSecond(): number {
+  return Math.floor(now() / 1000);
+}
+
+function commandInput(command: unknown): Record<string, unknown> {
+  if (
+    typeof command === "object" &&
+    command !== null &&
+    "input" in command &&
+    typeof command.input === "object" &&
+    command.input !== null
+  ) {
+    return command.input as Record<string, unknown>;
+  }
+  return {};
+}
+
+function writeAscii(bytes: Uint8Array, offset: number, value: string): void {
+  for (let i = 0; i < value.length; i++) {
+    bytes[offset + i] = value.charCodeAt(i);
+  }
+}
+
+function wavBytes(durationSeconds: number): Uint8Array<ArrayBuffer> {
+  const sampleRate = 24_000;
+  const channels = 1;
+  const bitsPerSample = 16;
+  const dataSize =
+    sampleRate * channels * (bitsPerSample / 8) * durationSeconds;
+  const buffer = new ArrayBuffer(44 + dataSize);
+  const bytes = new Uint8Array(buffer);
+  const view = new DataView(buffer);
+  const byteRate = sampleRate * channels * (bitsPerSample / 8);
+  const blockAlign = channels * (bitsPerSample / 8);
+
+  writeAscii(bytes, 0, "RIFF");
+  view.setUint32(4, 36 + dataSize, true);
+  writeAscii(bytes, 8, "WAVE");
+  writeAscii(bytes, 12, "fmt ");
+  view.setUint32(16, 16, true);
+  view.setUint16(20, 1, true);
+  view.setUint16(22, channels, true);
+  view.setUint32(24, sampleRate, true);
+  view.setUint32(28, byteRate, true);
+  view.setUint16(32, blockAlign, true);
+  view.setUint16(34, bitsPerSample, true);
+  writeAscii(bytes, 36, "data");
+  view.setUint32(40, dataSize, true);
+
+  return bytes;
+}
+
+function zeroToken(args: {
+  readonly userId: string;
+  readonly orgId: string;
+  readonly runId: string;
+}): string {
+  const seconds = currentSecond();
+  return signSandboxJwtForTests({
+    scope: "zero",
+    userId: args.userId,
+    orgId: args.orgId,
+    runId: args.runId,
+    capabilities: ["file:write"],
+    iat: seconds,
+    exp: seconds + 60,
+  });
+}
+
+async function ensureSpeechPricing(): Promise<{
+  readonly pricing: SpeechPricing;
+  readonly inserted: boolean;
+}> {
+  const writeDb = store.set(writeDb$);
+  const [existing] = await writeDb
+    .select({
+      unitPrice: usagePricing.unitPrice,
+      unitSize: usagePricing.unitSize,
+    })
+    .from(usagePricing)
+    .where(
+      and(
+        eq(usagePricing.kind, "audio"),
+        eq(usagePricing.provider, VOICE_IO_TTS_MODEL),
+        eq(usagePricing.category, "output_audio_seconds"),
+      ),
+    )
+    .limit(1);
+  if (existing) {
+    return { pricing: existing, inserted: false };
+  }
+
+  const pricing = { unitPrice: 5, unitSize: 1 };
+  await writeDb.insert(usagePricing).values({
+    kind: "audio",
+    provider: VOICE_IO_TTS_MODEL,
+    category: "output_audio_seconds",
+    ...pricing,
+  });
+  return { pricing, inserted: true };
+}
+
+async function seedVoiceFixture(options: {
+  readonly audioOutputEnabled?: boolean;
+  readonly credits?: number;
+  readonly tier?: "free" | "pro" | "team";
+  readonly withPricing?: boolean;
+}): Promise<VoiceFixture> {
+  const orgId = `org_${randomUUID()}`;
+  const userId = `user_${randomUUID()}`;
+  const writeDb = store.set(writeDb$);
+
+  await store.set(
+    seedOrgMembership$,
+    { orgId, userId, role: "admin" },
+    context.signal,
+  );
+  await writeDb.insert(orgMetadata).values({
+    orgId,
+    tier: options.tier ?? "free",
+    credits: options.credits ?? 10_000,
+  });
+  await writeDb.insert(orgMembersMetadata).values({
+    orgId,
+    userId,
+    creditEnabled: true,
+  });
+
+  if (options.audioOutputEnabled) {
+    await writeDb.insert(userFeatureSwitches).values({
+      orgId,
+      userId,
+      switches: { [FeatureSwitchKey.AudioOutput]: true },
+    });
+  }
+
+  const pricingResult = options.withPricing
+    ? await ensureSpeechPricing()
+    : { pricing: null, inserted: false };
+  void pricingResult.pricing;
+
+  return { orgId, userId, pricingInserted: pricingResult.inserted };
+}
+
+async function deleteVoiceFixture(fixture: VoiceFixture): Promise<void> {
+  const writeDb = store.set(writeDb$);
+  await writeDb
+    .delete(runUploadedFiles)
+    .where(
+      and(
+        eq(runUploadedFiles.orgId, fixture.orgId),
+        eq(runUploadedFiles.userId, fixture.userId),
+      ),
+    );
+  await writeDb
+    .delete(userFeatureSwitches)
+    .where(
+      and(
+        eq(userFeatureSwitches.orgId, fixture.orgId),
+        eq(userFeatureSwitches.userId, fixture.userId),
+      ),
+    );
+  await writeDb
+    .delete(userBehaviorCount)
+    .where(
+      and(
+        eq(userBehaviorCount.orgId, fixture.orgId),
+        eq(userBehaviorCount.userId, fixture.userId),
+      ),
+    );
+  await writeDb
+    .delete(orgMembersMetadata)
+    .where(
+      and(
+        eq(orgMembersMetadata.orgId, fixture.orgId),
+        eq(orgMembersMetadata.userId, fixture.userId),
+      ),
+    );
+  await store.set(deleteUsageInsightFixture$, fixture, context.signal);
+  await writeDb.delete(orgMetadata).where(eq(orgMetadata.orgId, fixture.orgId));
+  await store.set(deleteOrgMembership$, fixture, context.signal);
+  if (fixture.pricingInserted) {
+    await writeDb
+      .delete(usagePricing)
+      .where(
+        and(
+          eq(usagePricing.kind, "audio"),
+          eq(usagePricing.provider, VOICE_IO_TTS_MODEL),
+          eq(usagePricing.category, "output_audio_seconds"),
+        ),
+      );
+  }
+}
+
+function expectedCredits(
+  durationSeconds: number,
+  pricing: SpeechPricing,
+): number {
+  return Math.ceil((durationSeconds * pricing.unitPrice) / pricing.unitSize);
+}
+
+describe("POST /api/zero/voice-io/*", () => {
+  const track = createFixtureTracker<VoiceFixture>(deleteVoiceFixture);
+
+  beforeEach(() => {
+    context.mocks.clerk.authenticateRequest.mockReset();
+    context.mocks.clerk.authenticateRequest.mockResolvedValue({
+      isAuthenticated: false,
+    });
+    context.mocks.s3.send.mockReset();
+    context.mocks.s3.send.mockResolvedValue({});
+  });
+
+  it("proxies /tts to OpenAI when audio output is enabled", async () => {
+    const fixture = await track(seedVoiceFixture({ audioOutputEnabled: true }));
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const pcm = Uint8Array.from([1, 2, 3, 4]);
+    let observedAuthorization: string | null = null;
+    let observedBody: unknown = null;
+    server.use(
+      http.post(OPENAI_AUDIO_SPEECH_URL, async ({ request }) => {
+        observedAuthorization = request.headers.get("authorization");
+        observedBody = await request.json();
+        return new HttpResponse(pcm, {
+          status: 200,
+          headers: { "content-type": TTS_CONTENT_TYPE },
+        });
+      }),
+    );
+
+    const app = createApp({ signal: context.signal });
+    const response = await app.request("/api/zero/voice-io/tts", {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({ text: "Read this aloud" }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe(TTS_CONTENT_TYPE);
+    expect(new Uint8Array(await response.arrayBuffer())).toStrictEqual(pcm);
+    expect(observedAuthorization).toBe("Bearer test-openai-key");
+    expect(observedBody).toMatchObject({
+      model: VOICE_IO_TTS_MODEL,
+      voice: "ash",
+      input: "Read this aloud",
+      response_format: "pcm",
+    });
+  });
+
+  it("blocks /tts before OpenAI when audio output is disabled", async () => {
+    const fixture = await track(seedVoiceFixture({}));
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    let calledOpenAi = false;
+    server.use(
+      http.post(OPENAI_AUDIO_SPEECH_URL, () => {
+        calledOpenAi = true;
+        return HttpResponse.json({});
+      }),
+    );
+
+    const app = createApp({ signal: context.signal });
+    const response = await app.request("/api/zero/voice-io/tts", {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({ text: "Read this aloud" }),
+    });
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toStrictEqual({
+      error: { message: "Audio output is not enabled", code: "FORBIDDEN" },
+    });
+    expect(calledOpenAi).toBeFalsy();
+  });
+
+  it("returns /tts OpenAI failures as internal errors", async () => {
+    const fixture = await track(seedVoiceFixture({ audioOutputEnabled: true }));
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    server.use(
+      http.post(OPENAI_AUDIO_SPEECH_URL, () => {
+        return HttpResponse.json(
+          { error: "rate_limit_exceeded" },
+          { status: 429 },
+        );
+      }),
+    );
+
+    const app = createApp({ signal: context.signal });
+    const response = await app.request("/api/zero/voice-io/tts", {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({ text: "Read this aloud" }),
+    });
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toStrictEqual({
+      error: {
+        message: "TTS generation failed",
+        code: "INTERNAL_SERVER_ERROR",
+      },
+    });
+  });
+
+  it("returns 401 from /stt when unauthenticated", async () => {
+    const form = new FormData();
+    form.append(
+      "file",
+      new File([wavBytes(1)], "speech.wav", { type: "audio/wav" }),
+    );
+
+    const app = createApp({ signal: context.signal });
+    const response = await app.request("/api/zero/voice-io/stt", {
+      method: "POST",
+      body: form,
+    });
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("transcribes /stt multipart audio and records quota counters", async () => {
+    const fixture = await track(seedVoiceFixture({}));
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    let observedAuthorization: string | null = null;
+    let observedFileName: string | undefined;
+    let observedFileType: string | undefined;
+    let observedModel: FormDataEntryValue | null = null;
+    let observedResponseFormat: FormDataEntryValue | null = null;
+    server.use(
+      http.post(OPENAI_AUDIO_TRANSCRIPTIONS_URL, async ({ request }) => {
+        observedAuthorization = request.headers.get("authorization");
+        const form = await request.formData();
+        const file = form.get("file");
+        if (!(file instanceof File)) {
+          return HttpResponse.json(
+            { error: { message: "missing file", code: "BAD_REQUEST" } },
+            { status: 400 },
+          );
+        }
+        observedFileName = file.name;
+        observedFileType = file.type;
+        observedModel = form.get("model");
+        observedResponseFormat = form.get("response_format");
+        return HttpResponse.json({ text: "hello from voice" });
+      }),
+    );
+
+    const form = new FormData();
+    form.append(
+      "file",
+      new File([wavBytes(2)], "speech.wav", { type: "audio/wav" }),
+    );
+    const app = createApp({ signal: context.signal });
+    const response = await app.request("/api/zero/voice-io/stt", {
+      method: "POST",
+      headers: authHeaders(),
+      body: form,
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toStrictEqual({
+      text: "hello from voice",
+    });
+    expect(observedAuthorization).toBe("Bearer test-openai-key");
+    expect(observedFileName).toBe("speech.wav");
+    expect(observedFileType).toBe("audio/wav");
+    expect(observedModel).toBe(VOICE_IO_STT_MODEL);
+    expect(observedResponseFormat).toBe("json");
+
+    const rows = await store
+      .set(writeDb$)
+      .select({
+        key: userBehaviorCount.behaviorKey,
+        count: userBehaviorCount.count,
+      })
+      .from(userBehaviorCount)
+      .where(
+        and(
+          eq(userBehaviorCount.orgId, fixture.orgId),
+          eq(userBehaviorCount.userId, fixture.userId),
+        ),
+      );
+    const counts = new Map(
+      rows.map((row): readonly [string, number] => {
+        return [row.key, row.count];
+      }),
+    );
+    expect(counts.get(AUDIO_INPUT_BEHAVIOR_KEY)).toBe(1);
+    expect(counts.get(sttDailyRateKey())).toBe(1);
+    expect(counts.get(sttDailyDurationKey())).toBe(2);
+  });
+
+  it("blocks /stt before OpenAI when the free audio quota is exhausted", async () => {
+    const fixture = await track(seedVoiceFixture({}));
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    await store.set(writeDb$).insert(userBehaviorCount).values({
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      behaviorKey: AUDIO_INPUT_BEHAVIOR_KEY,
+      count: 10,
+    });
+
+    let calledOpenAi = false;
+    server.use(
+      http.post(OPENAI_AUDIO_TRANSCRIPTIONS_URL, () => {
+        calledOpenAi = true;
+        return HttpResponse.json({ text: "should not run" });
+      }),
+    );
+    const form = new FormData();
+    form.append(
+      "file",
+      new File([wavBytes(1)], "speech.wav", { type: "audio/wav" }),
+    );
+
+    const app = createApp({ signal: context.signal });
+    const response = await app.request("/api/zero/voice-io/stt", {
+      method: "POST",
+      headers: authHeaders(),
+      body: form,
+    });
+
+    expect(response.status).toBe(402);
+    await expect(response.json()).resolves.toStrictEqual({
+      error: {
+        message:
+          "Audio input quota exceeded. Upgrade to Pro or Team for unlimited audio input.",
+        code: "AUDIO_INPUT_QUOTA_EXCEEDED",
+      },
+      quota: { count: 10, limit: 10 },
+    });
+    expect(calledOpenAi).toBeFalsy();
+  });
+
+  it("rejects unsupported /speech voices before OpenAI", async () => {
+    const fixture = await track(seedVoiceFixture({ withPricing: true }));
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    let calledOpenAi = false;
+    server.use(
+      http.post(OPENAI_AUDIO_SPEECH_URL, () => {
+        calledOpenAi = true;
+        return new HttpResponse(wavBytes(1));
+      }),
+    );
+
+    const app = createApp({ signal: context.signal });
+    const response = await app.request("/api/zero/voice-io/speech", {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({ text: "hello", voice: "unknown" }),
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toStrictEqual({
+      error: { message: "Unsupported voice: unknown", code: "BAD_REQUEST" },
+    });
+    expect(calledOpenAi).toBeFalsy();
+  });
+
+  it("generates /speech WAV files for run-scoped zero tokens", async () => {
+    const fixture = await track(seedVoiceFixture({ withPricing: true }));
+    const { pricing } = await ensureSpeechPricing();
+    const { composeId } = await store.set(
+      seedCompose$,
+      { orgId: fixture.orgId, userId: fixture.userId },
+      context.signal,
+    );
+    const { runId } = await store.set(
+      seedRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        composeId,
+        triggerSource: "web",
+      },
+      context.signal,
+    );
+
+    const wav = wavBytes(2);
+    let observedBody: unknown = null;
+    server.use(
+      http.post(OPENAI_AUDIO_SPEECH_URL, async ({ request }) => {
+        observedBody = await request.json();
+        return new HttpResponse(wav, {
+          status: 200,
+          headers: { "content-type": SPEECH_CONTENT_TYPE },
+        });
+      }),
+    );
+
+    const token = zeroToken({
+      userId: fixture.userId,
+      orgId: fixture.orgId,
+      runId,
+    });
+    const app = createApp({ signal: context.signal });
+    const response = await app.request("/api/zero/voice-io/speech", {
+      method: "POST",
+      headers: { authorization: `Bearer ${token}` },
+      body: JSON.stringify({
+        text: "make this a file",
+        voice: "marin",
+        instructions: "calm delivery",
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body).toMatchObject({
+      contentType: SPEECH_CONTENT_TYPE,
+      size: wav.byteLength,
+      durationSeconds: 2,
+      creditsCharged: expectedCredits(2, pricing),
+      model: VOICE_IO_TTS_MODEL,
+      voice: "marin",
+    });
+    expect(observedBody).toMatchObject({
+      model: VOICE_IO_TTS_MODEL,
+      voice: "marin",
+      input: "make this a file",
+      instructions: "calm delivery",
+      response_format: "wav",
+    });
+
+    if (
+      !(
+        typeof body === "object" &&
+        body !== null &&
+        "id" in body &&
+        "filename" in body
+      )
+    ) {
+      throw new Error("Expected speech response id and filename");
+    }
+    const fileId = String(body.id);
+    const filename = String(body.filename);
+    expect(filename).toBe(`voice-${fileId.slice(0, 8)}.wav`);
+
+    const putInput = commandInput(context.mocks.s3.send.mock.calls[0]?.[0]);
+    expect(putInput.Bucket).toBe(TEST_BUCKET);
+    expect(putInput.Key).toBe(
+      `uploads/${fixture.userId}/${fileId}/${filename}`,
+    );
+    expect(putInput.ContentType).toBe(SPEECH_CONTENT_TYPE);
+    const putBody = putInput.Body;
+    expect(Buffer.isBuffer(putBody)).toBeTruthy();
+    if (!Buffer.isBuffer(putBody)) {
+      throw new Error("Expected S3 put body to be a Buffer");
+    }
+    expect(new Uint8Array(putBody)).toStrictEqual(wav);
+
+    const uploadRows = await store
+      .set(writeDb$)
+      .select()
+      .from(runUploadedFiles)
+      .where(eq(runUploadedFiles.externalId, fileId));
+    expect(uploadRows).toHaveLength(1);
+    expect(uploadRows[0]).toMatchObject({
+      runId,
+      source: "web",
+      externalId: fileId,
+      userId: fixture.userId,
+      orgId: fixture.orgId,
+      filename,
+      contentType: SPEECH_CONTENT_TYPE,
+      sizeBytes: wav.byteLength,
+    });
+    expect(uploadRows[0]?.metadata).toMatchObject({
+      generatedBy: "zero-official-voice",
+      model: VOICE_IO_TTS_MODEL,
+      voice: "marin",
+      durationSeconds: 2,
+      s3Key: `uploads/${fixture.userId}/${fileId}/${filename}`,
+    });
+
+    const usageRows = await store
+      .set(writeDb$)
+      .select()
+      .from(usageEvent)
+      .where(
+        and(
+          eq(usageEvent.orgId, fixture.orgId),
+          eq(usageEvent.userId, fixture.userId),
+          eq(usageEvent.kind, "audio"),
+          eq(usageEvent.provider, VOICE_IO_TTS_MODEL),
+          eq(usageEvent.category, "output_audio_seconds"),
+        ),
+      );
+    expect(usageRows).toHaveLength(1);
+    expect(usageRows[0]).toMatchObject({
+      quantity: 2,
+      creditsCharged: expectedCredits(2, pricing),
+      status: "processed",
+      billingError: null,
+    });
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-voice-io-speech.ts
+++ b/turbo/apps/api/src/signals/routes/zero-voice-io-speech.ts
@@ -1,0 +1,157 @@
+import { command } from "ccstate";
+import { encode } from "gpt-tokenizer/encoding/o200k_base";
+import { zeroVoiceIoSpeechContract } from "@vm0/api-contracts/contracts/zero-voice-io-speech";
+
+import { organizationAuthContext$ } from "../auth/auth-context";
+import { authRoute } from "../auth/auth-route";
+import { bodyResultOf } from "../context/request";
+import { logger } from "../../lib/log";
+import type { RouteEntry } from "../route";
+import {
+  badGateway,
+  badRequest,
+  checkSpeechCredits$,
+  insufficientCredits,
+  internalError,
+  isSpeechVoice,
+  OPENAI_AUDIO_SPEECH_URL,
+  parseSpeechWavDurationSeconds,
+  recordGeneratedSpeech$,
+  serviceUnavailable,
+  SPEECH_MAX_INPUT_TOKENS,
+  SPEECH_RESPONSE_FORMAT,
+  speechPricing$,
+  VOICE_IO_TTS_MODEL,
+} from "../services/zero-voice-io-post.service";
+import { env } from "../../lib/env";
+
+const L = logger("ZeroVoiceIoSpeech");
+const speechBody$ = bodyResultOf(zeroVoiceIoSpeechContract.post);
+
+const postSpeechInner$ = command(async ({ get, set }, signal: AbortSignal) => {
+  const auth = get(organizationAuthContext$);
+  const bodyResult = await get(speechBody$);
+  signal.throwIfAborted();
+  if (!bodyResult.ok) {
+    return bodyResult.response;
+  }
+
+  const text =
+    typeof bodyResult.data.text === "string" ? bodyResult.data.text.trim() : "";
+  if (text.length === 0) {
+    return badRequest("text is required");
+  }
+
+  const voice =
+    typeof bodyResult.data.voice === "string" ? bodyResult.data.voice : "marin";
+  if (!isSpeechVoice(voice)) {
+    return badRequest(`Unsupported voice: ${voice}`);
+  }
+
+  const instructions =
+    typeof bodyResult.data.instructions === "string" &&
+    bodyResult.data.instructions.trim().length > 0
+      ? bodyResult.data.instructions.trim()
+      : undefined;
+  const tokenCount = encode(`${instructions ?? ""}\n${text}`).length;
+  if (tokenCount > SPEECH_MAX_INPUT_TOKENS) {
+    return badRequest(
+      `text and instructions exceed ${SPEECH_MAX_INPUT_TOKENS} input tokens`,
+    );
+  }
+
+  const hasCredits = await set(
+    checkSpeechCredits$,
+    { orgId: auth.orgId, userId: auth.userId },
+    signal,
+  );
+  if (!hasCredits) {
+    return insufficientCredits();
+  }
+
+  const pricing = await get(speechPricing$);
+  signal.throwIfAborted();
+  if (!pricing) {
+    return serviceUnavailable(
+      "Audio generation pricing is not configured",
+      "NOT_CONFIGURED",
+    );
+  }
+
+  const openaiResponse = await fetch(OPENAI_AUDIO_SPEECH_URL, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${env("OPENAI_API_KEY")}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      model: VOICE_IO_TTS_MODEL,
+      voice,
+      input: text,
+      ...(instructions ? { instructions } : {}),
+      response_format: SPEECH_RESPONSE_FORMAT,
+    }),
+    signal,
+  });
+  signal.throwIfAborted();
+
+  if (!openaiResponse.ok) {
+    const errorBody = await openaiResponse.text();
+    signal.throwIfAborted();
+    L.error("OpenAI speech request failed", {
+      status: openaiResponse.status,
+      body: errorBody,
+    });
+    return internalError("Speech generation failed");
+  }
+
+  const audioBytes = new Uint8Array(await openaiResponse.arrayBuffer());
+  signal.throwIfAborted();
+  if (audioBytes.byteLength === 0) {
+    return badGateway("Model returned empty audio", "NO_AUDIO_RETURNED");
+  }
+
+  const durationSeconds = parseSpeechWavDurationSeconds(audioBytes);
+  if (durationSeconds === null) {
+    L.error("Unable to parse generated WAV duration", {
+      byteLength: audioBytes.byteLength,
+    });
+    return badGateway(
+      "Could not determine generated audio duration",
+      "AUDIO_DURATION_UNKNOWN",
+    );
+  }
+
+  const runId =
+    auth.tokenType === "zero" || auth.tokenType === "sandbox"
+      ? auth.runId
+      : undefined;
+  const result = await set(
+    recordGeneratedSpeech$,
+    {
+      orgId: auth.orgId,
+      userId: auth.userId,
+      runId,
+      voice,
+      audioBytes,
+      durationSeconds,
+      pricing,
+    },
+    signal,
+  );
+
+  return { status: 200 as const, body: result };
+});
+
+export const zeroVoiceIoSpeechRoutes: readonly RouteEntry[] = [
+  {
+    route: zeroVoiceIoSpeechContract.post,
+    handler: authRoute(
+      {
+        requireOrganization: true,
+        requiredCapability: "file:write",
+      },
+      postSpeechInner$,
+    ),
+  },
+];

--- a/turbo/apps/api/src/signals/routes/zero-voice-io-stt.ts
+++ b/turbo/apps/api/src/signals/routes/zero-voice-io-stt.ts
@@ -1,0 +1,156 @@
+import { command } from "ccstate";
+import { zeroVoiceIoSttContract } from "@vm0/api-contracts/contracts/zero-voice-io-stt";
+
+import { organizationAuthContext$ } from "../auth/auth-context";
+import { authRoute } from "../auth/auth-route";
+import { request$ } from "../context/hono";
+import { logger } from "../../lib/log";
+import type { RouteEntry } from "../route";
+import { audioInputQuota } from "../services/voice-io.service";
+import {
+  badRequest,
+  getAudioDuration,
+  internalError,
+  isAllowedSttMimeType,
+  isTranscriptionBody,
+  MAX_STT_FILE_SIZE,
+  MAX_STT_REQUEST_DURATION_SECONDS,
+  OPENAI_AUDIO_TRANSCRIPTIONS_URL,
+  recordSttUsage$,
+  sttDailyPolicy$,
+  VOICE_IO_STT_MODEL,
+} from "../services/zero-voice-io-post.service";
+import { env } from "../../lib/env";
+
+const L = logger("ZeroVoiceIoStt");
+
+const postSttInner$ = command(async ({ get, set }, signal: AbortSignal) => {
+  const auth = get(organizationAuthContext$);
+  const quota = await get(audioInputQuota(auth.orgId, auth.userId));
+  signal.throwIfAborted();
+  if (!quota.allowed) {
+    return {
+      status: 402 as const,
+      body: {
+        error: {
+          message:
+            "Audio input quota exceeded. Upgrade to Pro or Team for unlimited audio input.",
+          code: "AUDIO_INPUT_QUOTA_EXCEEDED",
+        },
+        quota: { count: quota.count, limit: quota.limit },
+      },
+    };
+  }
+
+  const request = get(request$);
+  const formData = await request.raw.formData();
+  signal.throwIfAborted();
+  const file = formData.get("file");
+  if (!file || !(file instanceof File)) {
+    L.warn("STT validation rejected: no file", {
+      hasField: file !== null,
+      fieldType: typeof file,
+    });
+    return badRequest("No audio file provided");
+  }
+
+  if (file.size > MAX_STT_FILE_SIZE) {
+    L.warn("STT validation rejected: file too large", {
+      fileSize: file.size,
+      fileMime: file.type,
+    });
+    return badRequest("File too large (max 25 MB)");
+  }
+
+  const baseMimeType = file.type.split(";")[0] ?? file.type;
+  if (!isAllowedSttMimeType(baseMimeType)) {
+    L.warn("STT validation rejected: unsupported mime", {
+      fileMime: file.type,
+      baseMimeType,
+      fileSize: file.size,
+    });
+    return badRequest(
+      `Unsupported audio format: ${baseMimeType}. Supported: webm, wav, mp3, m4a, mp4, mpeg, mpga`,
+    );
+  }
+
+  const durationSeconds = await getAudioDuration(file);
+  signal.throwIfAborted();
+  if (
+    durationSeconds !== null &&
+    durationSeconds > MAX_STT_REQUEST_DURATION_SECONDS
+  ) {
+    L.warn("STT validation rejected: duration too long", {
+      durationSeconds,
+      maxSeconds: MAX_STT_REQUEST_DURATION_SECONDS,
+      fileMime: file.type,
+      fileSize: file.size,
+    });
+    return badRequest(
+      `Audio duration (${durationSeconds}s) exceeds maximum (${MAX_STT_REQUEST_DURATION_SECONDS}s)`,
+      "AUDIO_DURATION_TOO_LONG",
+    );
+  }
+
+  const policy = await set(
+    sttDailyPolicy$,
+    auth.orgId,
+    auth.userId,
+    durationSeconds ?? 0,
+    signal,
+  );
+  if ("status" in policy) {
+    return policy;
+  }
+
+  const openaiForm = new FormData();
+  openaiForm.append("file", file, file.name || "audio.webm");
+  openaiForm.append("model", VOICE_IO_STT_MODEL);
+  openaiForm.append("response_format", "json");
+
+  const openaiResponse = await fetch(OPENAI_AUDIO_TRANSCRIPTIONS_URL, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${env("OPENAI_API_KEY")}` },
+    body: openaiForm,
+    signal,
+  });
+  signal.throwIfAborted();
+
+  if (!openaiResponse.ok) {
+    const errorBody = await openaiResponse.text();
+    signal.throwIfAborted();
+    L.error("OpenAI STT API error", {
+      status: openaiResponse.status,
+      statusText: openaiResponse.statusText,
+      body: errorBody,
+      fileMime: file.type,
+      fileSize: file.size,
+      fileName: file.name,
+    });
+    return internalError("Transcription failed");
+  }
+
+  const result: unknown = await openaiResponse.json();
+  signal.throwIfAborted();
+  if (!isTranscriptionBody(result)) {
+    return internalError("Transcription failed");
+  }
+
+  await set(
+    recordSttUsage$,
+    { ...policy, orgId: auth.orgId, userId: auth.userId },
+    signal,
+  );
+
+  return { status: 200 as const, body: { text: result.text } };
+});
+
+export const zeroVoiceIoSttRoutes: readonly RouteEntry[] = [
+  {
+    route: zeroVoiceIoSttContract.post,
+    handler: authRoute(
+      { requireOrganization: true, missingOrganizationStatus: 401 },
+      postSttInner$,
+    ),
+  },
+];

--- a/turbo/apps/api/src/signals/routes/zero-voice-io-tts.ts
+++ b/turbo/apps/api/src/signals/routes/zero-voice-io-tts.ts
@@ -1,0 +1,98 @@
+import { command } from "ccstate";
+import { zeroVoiceIoTtsContract } from "@vm0/api-contracts/contracts/zero-voice-io-tts";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import { isFeatureEnabled } from "@vm0/core/feature-switch";
+
+import { organizationAuthContext$ } from "../auth/auth-context";
+import { authRoute } from "../auth/auth-route";
+import { bodyResultOf } from "../context/request";
+import { userFeatureSwitchOverrides } from "../services/feature-switches.service";
+import { logger } from "../../lib/log";
+import type { RouteEntry } from "../route";
+import {
+  badRequest,
+  forbidden,
+  internalError,
+  OPENAI_AUDIO_SPEECH_URL,
+  TTS_CONTENT_TYPE,
+  TTS_MAX_TEXT_LENGTH,
+  TTS_RESPONSE_FORMAT,
+  VOICE_IO_TTS_MODEL,
+} from "../services/zero-voice-io-post.service";
+import { env } from "../../lib/env";
+
+const L = logger("ZeroVoiceIoTts");
+const ttsBody$ = bodyResultOf(zeroVoiceIoTtsContract.post);
+
+const postTtsInner$ = command(async ({ get }, signal: AbortSignal) => {
+  const auth = get(organizationAuthContext$);
+  const overrides = await get(
+    userFeatureSwitchOverrides(auth.orgId, auth.userId),
+  );
+  signal.throwIfAborted();
+
+  const enabled = isFeatureEnabled(FeatureSwitchKey.AudioOutput, {
+    orgId: auth.orgId,
+    userId: auth.userId,
+    overrides,
+  });
+  if (!enabled) {
+    return forbidden("Audio output is not enabled");
+  }
+
+  const bodyResult = await get(ttsBody$);
+  signal.throwIfAborted();
+  if (!bodyResult.ok) {
+    return bodyResult.response;
+  }
+
+  const text =
+    typeof bodyResult.data.text === "string" ? bodyResult.data.text : "";
+  if (text.trim().length === 0) {
+    return badRequest("text is required");
+  }
+  if (text.length > TTS_MAX_TEXT_LENGTH) {
+    return badRequest(`text must be at most ${TTS_MAX_TEXT_LENGTH} characters`);
+  }
+
+  const response = await fetch(OPENAI_AUDIO_SPEECH_URL, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${env("OPENAI_API_KEY")}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      model: VOICE_IO_TTS_MODEL,
+      voice: "ash",
+      input: text,
+      response_format: TTS_RESPONSE_FORMAT,
+    }),
+    signal,
+  });
+  signal.throwIfAborted();
+
+  if (!response.ok) {
+    const errorBody = await response.text();
+    signal.throwIfAborted();
+    L.error("OpenAI TTS request failed", {
+      status: response.status,
+      body: errorBody,
+    });
+    return internalError("TTS generation failed");
+  }
+
+  return new Response(response.body, {
+    status: 200,
+    headers: { "Content-Type": TTS_CONTENT_TYPE },
+  });
+});
+
+export const zeroVoiceIoTtsRoutes: readonly RouteEntry[] = [
+  {
+    route: zeroVoiceIoTtsContract.post,
+    handler: authRoute(
+      { requireOrganization: true, missingOrganizationStatus: 401 },
+      postTtsInner$,
+    ),
+  },
+];

--- a/turbo/apps/api/src/signals/services/zero-voice-io-post.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-voice-io-post.service.ts
@@ -1,0 +1,861 @@
+import { Buffer } from "node:buffer";
+import { randomUUID } from "node:crypto";
+import { command, computed, type Computed } from "ccstate";
+import { orgTierSchema, type OrgTier } from "@vm0/api-contracts/contracts/orgs";
+import { orgMetadata } from "@vm0/db/schema/org-metadata";
+import { usageEvent } from "@vm0/db/schema/usage-event";
+import { usagePricing } from "@vm0/db/schema/usage-pricing";
+import { userBehaviorCount } from "@vm0/db/schema/user-behavior-count";
+import { and, eq, inArray, sql } from "drizzle-orm";
+
+import { buildFileUrl } from "../../lib/file-url";
+import { env } from "../../lib/env";
+import { db$, writeDb$ } from "../external/db";
+import { nowDate } from "../external/time";
+import { putS3Object } from "../external/s3";
+import { recordWebUploadedFile$ } from "./run-uploaded-files.service";
+import { processOrgUsageEvents$ } from "./zero-credit-usage.service";
+
+export const OPENAI_AUDIO_SPEECH_URL = "https://api.openai.com/v1/audio/speech";
+export const OPENAI_AUDIO_TRANSCRIPTIONS_URL =
+  "https://api.openai.com/v1/audio/transcriptions";
+export const VOICE_IO_TTS_MODEL = "gpt-4o-mini-tts";
+export const VOICE_IO_STT_MODEL = "gpt-4o-mini-transcribe";
+export const SPEECH_CONTENT_TYPE = "audio/wav";
+export const SPEECH_RESPONSE_FORMAT = "wav";
+export const TTS_RESPONSE_FORMAT = "pcm";
+export const TTS_CONTENT_TYPE = "application/octet-stream";
+export const TTS_MAX_TEXT_LENGTH = 4096;
+export const SPEECH_MAX_INPUT_TOKENS = 2000;
+export const MAX_STT_FILE_SIZE = 25 * 1024 * 1024;
+export const MAX_STT_REQUEST_DURATION_SECONDS = 5 * 60;
+
+const USAGE_KIND = "audio";
+const USAGE_PROVIDER = VOICE_IO_TTS_MODEL;
+const USAGE_CATEGORY = "output_audio_seconds";
+const AUDIO_INPUT_BEHAVIOR_KEY = "audio_input";
+const DAILY_RATE_KEY_PREFIX = "audio_input_daily";
+const DAILY_DURATION_KEY_PREFIX = "audio_input_dur";
+const MIN_SPEECH_BITRATE_BPS = 8000;
+const MAX_DURATION_READ_BYTES = 4096;
+const DEFAULT_TIMECODE_SCALE_NS = 1_000_000;
+const EBML_HEADER = [0x1a, 0x45, 0xdf, 0xa3] as const;
+
+const DAILY_RATE_LIMITS: Readonly<Record<OrgTier, number>> = {
+  free: 10,
+  pro: 300,
+  team: 500,
+};
+
+const DAILY_DURATION_LIMITS: Readonly<Record<OrgTier, number>> = {
+  free: 10 * 60,
+  pro: 200 * 60,
+  team: 500 * 60,
+};
+
+const ALLOWED_STT_MIME_TYPES = [
+  "audio/webm",
+  "audio/wav",
+  "audio/wave",
+  "audio/x-wav",
+  "audio/mpeg",
+  "audio/mp3",
+  "audio/mp4",
+  "audio/m4a",
+  "audio/x-m4a",
+  "audio/mpga",
+] as const;
+
+const SPEECH_VOICES = [
+  "alloy",
+  "ash",
+  "ballad",
+  "coral",
+  "echo",
+  "fable",
+  "nova",
+  "onyx",
+  "sage",
+  "shimmer",
+  "verse",
+  "marin",
+  "cedar",
+] as const;
+
+type ErrorStatus = 400 | 402 | 403 | 429 | 500 | 502 | 503;
+
+interface ErrorBody {
+  readonly error: {
+    readonly message: string;
+    readonly code: string;
+  };
+}
+
+interface QuotaErrorBody extends ErrorBody {
+  readonly quota: {
+    readonly count: number;
+    readonly limit: number | null;
+  };
+}
+
+type ErrorResponse = {
+  readonly status: ErrorStatus;
+  readonly body: ErrorBody | QuotaErrorBody;
+};
+
+interface SttDailyPolicy {
+  readonly orgTier: OrgTier;
+  readonly rateKey: string;
+  readonly durationKey: string;
+  readonly durationSeconds: number;
+}
+
+export interface SpeechPricing {
+  readonly unitPrice: number;
+  readonly unitSize: number;
+}
+
+interface RecordedSpeech {
+  readonly id: string;
+  readonly filename: string;
+  readonly contentType: string;
+  readonly size: number;
+  readonly url: string;
+  readonly durationSeconds: number;
+  readonly creditsCharged: number;
+  readonly model: string;
+  readonly voice: string;
+}
+
+interface CreditCheckRow extends Record<string, unknown> {
+  readonly credit_enabled: boolean | null;
+  readonly credits: string | null;
+  readonly unsettled_expired: string | null;
+}
+
+interface WavFormat {
+  readonly channels: number;
+  readonly sampleRate: number;
+  readonly bitsPerSample: number;
+}
+
+function errorBody(message: string, code: string): ErrorBody {
+  return { error: { message, code } };
+}
+
+export function badRequest(message: string, code = "BAD_REQUEST") {
+  return { status: 400 as const, body: errorBody(message, code) };
+}
+
+export function forbidden(message: string) {
+  return { status: 403 as const, body: errorBody(message, "FORBIDDEN") };
+}
+
+export function internalError(message: string) {
+  return {
+    status: 500 as const,
+    body: errorBody(message, "INTERNAL_SERVER_ERROR"),
+  };
+}
+
+export function badGateway(message: string, code: string) {
+  return { status: 502 as const, body: errorBody(message, code) };
+}
+
+export function serviceUnavailable(message: string, code: string) {
+  return { status: 503 as const, body: errorBody(message, code) };
+}
+
+export function insufficientCredits() {
+  return {
+    status: 402 as const,
+    body: errorBody(
+      "Insufficient credits. Please add credits to continue.",
+      "INSUFFICIENT_CREDITS",
+    ),
+  };
+}
+
+function quotaError(
+  status: 402 | 429,
+  message: string,
+  code: string,
+  count: number,
+  limit: number | null,
+) {
+  return {
+    status,
+    body: {
+      error: { message, code },
+      quota: { count, limit },
+    },
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+export function isTranscriptionBody(
+  value: unknown,
+): value is { readonly text: string } {
+  return isRecord(value) && typeof value.text === "string";
+}
+
+export function isAllowedSttMimeType(value: string): boolean {
+  return ALLOWED_STT_MIME_TYPES.some((mimeType) => {
+    return mimeType === value;
+  });
+}
+
+export function isSpeechVoice(value: string): boolean {
+  return SPEECH_VOICES.some((voice) => {
+    return voice === value;
+  });
+}
+
+export function sttDailyRateKey(date: Date = nowDate()): string {
+  return `${DAILY_RATE_KEY_PREFIX}_${date.toISOString().slice(0, 10)}`;
+}
+
+export function sttDailyDurationKey(date: Date = nowDate()): string {
+  return `${DAILY_DURATION_KEY_PREFIX}_${date.toISOString().slice(0, 10)}`;
+}
+
+function estimatedSpeechCredits(
+  durationSeconds: number,
+  pricing: SpeechPricing,
+): number {
+  return Math.ceil((durationSeconds * pricing.unitPrice) / pricing.unitSize);
+}
+
+function readAscii(bytes: Uint8Array, offset: number, length: number): string {
+  let text = "";
+  for (let i = 0; i < length; i++) {
+    text += String.fromCharCode(bytes[offset + i] ?? 0);
+  }
+  return text;
+}
+
+function isRiffWav(bytes: Uint8Array): boolean {
+  return readAscii(bytes, 0, 4) === "RIFF" && readAscii(bytes, 8, 4) === "WAVE";
+}
+
+function readSpeechWavFormat(
+  view: DataView,
+  chunkStart: number,
+  byteLength: number,
+): WavFormat | null {
+  if (chunkStart + 16 > byteLength) {
+    return null;
+  }
+  return {
+    channels: view.getUint16(chunkStart + 2, true),
+    sampleRate: view.getUint32(chunkStart + 4, true),
+    bitsPerSample: view.getUint16(chunkStart + 14, true),
+  };
+}
+
+function readStandardSpeechWavFormat(view: DataView): WavFormat {
+  return {
+    channels: view.getUint16(22, true),
+    sampleRate: view.getUint32(24, true),
+    bitsPerSample: view.getUint16(34, true),
+  };
+}
+
+function hasUsableWavFormat(format: WavFormat): boolean {
+  return (
+    format.channels > 0 && format.sampleRate > 0 && format.bitsPerSample > 0
+  );
+}
+
+export function parseSpeechWavDurationSeconds(
+  bytes: Uint8Array,
+): number | null {
+  if (bytes.byteLength < 44) {
+    return null;
+  }
+  if (!isRiffWav(bytes)) {
+    return null;
+  }
+
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  let format: WavFormat | null = null;
+  let dataOffset: number | null = null;
+  let offset = 12;
+
+  while (offset + 8 <= bytes.byteLength) {
+    const chunkId = readAscii(bytes, offset, 4);
+    const chunkSize = view.getUint32(offset + 4, true);
+    const chunkStart = offset + 8;
+    const chunkEnd = chunkStart + chunkSize;
+
+    if (chunkId === "fmt " && chunkSize >= 16) {
+      format =
+        readSpeechWavFormat(view, chunkStart, bytes.byteLength) ?? format;
+    } else if (chunkId === "data") {
+      dataOffset = chunkStart;
+    }
+
+    if (chunkEnd > bytes.byteLength) {
+      break;
+    }
+
+    offset = chunkEnd + (chunkSize % 2);
+  }
+
+  format = format ?? readStandardSpeechWavFormat(view);
+  if (!hasUsableWavFormat(format)) {
+    return null;
+  }
+
+  const audioBytes =
+    dataOffset !== null ? bytes.byteLength - dataOffset : bytes.byteLength - 44;
+  if (audioBytes <= 0) {
+    return null;
+  }
+
+  const bytesPerSecond =
+    format.sampleRate * format.channels * (format.bitsPerSample / 8);
+  if (!Number.isFinite(bytesPerSecond) || bytesPerSecond <= 0) {
+    return null;
+  }
+  return Math.max(1, Math.ceil(audioBytes / bytesPerSecond));
+}
+
+function sttWavDuration(buf: Uint8Array): number | null {
+  if (buf.length < 44) {
+    return null;
+  }
+  if (
+    buf[0] !== 0x52 ||
+    buf[1] !== 0x49 ||
+    buf[2] !== 0x46 ||
+    buf[3] !== 0x46
+  ) {
+    return null;
+  }
+
+  const view = new DataView(buf.buffer, buf.byteOffset, buf.length);
+  const sampleRate = view.getUint32(24, true);
+  const numChannels = view.getUint16(22, true);
+  const bitsPerSample = view.getUint16(34, true);
+  const dataSize = view.getUint32(40, true);
+
+  if (sampleRate === 0 || numChannels === 0 || bitsPerSample === 0) {
+    return null;
+  }
+  const bytesPerSecond = (sampleRate * numChannels * bitsPerSample) / 8;
+  if (bytesPerSecond === 0) {
+    return null;
+  }
+  return Math.ceil(dataSize / bytesPerSecond);
+}
+
+function estimateDurationFromSize(fileSize: number): number {
+  return Math.ceil(fileSize / (MIN_SPEECH_BITRATE_BPS / 8));
+}
+
+function vintLen(firstByte: number): number | null {
+  let mask = 0x80;
+  for (let i = 1; i <= 8; i++) {
+    if (firstByte & mask) {
+      return i;
+    }
+    mask >>= 1;
+  }
+  return null;
+}
+
+function readVint(
+  buf: Uint8Array,
+  pos: number,
+): { readonly value: number; readonly next: number } | null {
+  if (pos >= buf.length) {
+    return null;
+  }
+  const len = vintLen(buf[pos] ?? 0);
+  if (len === null || pos + len > buf.length) {
+    return null;
+  }
+
+  let value = (buf[pos] ?? 0) & ((1 << (8 - len)) - 1);
+  for (let i = 1; i < len; i++) {
+    value = (value << 8) | (buf[pos + i] ?? 0);
+  }
+  return { value, next: pos + len };
+}
+
+function readDurationFloat(
+  buf: Uint8Array,
+  valuePos: number,
+  valueSize: number,
+): number | null {
+  if (valuePos + valueSize > buf.length) {
+    return null;
+  }
+  const view = new DataView(buf.buffer, buf.byteOffset + valuePos, valueSize);
+  let value: number;
+  if (valueSize === 8) {
+    value = view.getFloat64(0, false);
+  } else if (valueSize === 4) {
+    value = view.getFloat32(0, false);
+  } else {
+    return null;
+  }
+  if (Number.isNaN(value) || value < 0) {
+    return null;
+  }
+  return value;
+}
+
+function readTimecodeScale(
+  buf: Uint8Array,
+  valuePos: number,
+  valueSize: number,
+): number | null {
+  if (valuePos + valueSize > buf.length) {
+    return null;
+  }
+  if (valueSize <= 0 || valueSize > 8) {
+    return null;
+  }
+  let scale = 0;
+  for (let i = 0; i < valueSize; i++) {
+    scale = scale * 256 + (buf[valuePos + i] ?? 0);
+  }
+  return scale > 0 ? scale : null;
+}
+
+function findDurationInInfo(
+  buf: Uint8Array,
+  dataStart: number,
+  dataLen: number,
+): number | null {
+  const end = Math.min(dataStart + dataLen, buf.length);
+  let pos = dataStart;
+  let durationInScale: number | null = null;
+  let timecodeScaleNs = DEFAULT_TIMECODE_SCALE_NS;
+
+  while (pos + 2 <= end) {
+    const idLen = vintLen(buf[pos] ?? 0);
+    if (idLen === null || pos + idLen > end) {
+      return null;
+    }
+    const sizeResult = readVint(buf, pos + idLen);
+    if (sizeResult === null) {
+      return null;
+    }
+
+    const elemStart = pos;
+    const valuePos = sizeResult.next;
+    const valueSize = sizeResult.value;
+
+    if (idLen === 2 && buf[elemStart] === 0x44 && buf[elemStart + 1] === 0x89) {
+      const value = readDurationFloat(buf, valuePos, valueSize);
+      if (value === null) {
+        return null;
+      }
+      durationInScale = value;
+    } else if (
+      idLen === 3 &&
+      buf[elemStart] === 0x2a &&
+      buf[elemStart + 1] === 0xd7 &&
+      buf[elemStart + 2] === 0xb1
+    ) {
+      const scale = readTimecodeScale(buf, valuePos, valueSize);
+      if (scale !== null) {
+        timecodeScaleNs = scale;
+      }
+    }
+
+    pos = valuePos + Math.min(valueSize, buf.length - valuePos);
+  }
+
+  if (durationInScale === null) {
+    return null;
+  }
+  return Math.ceil((durationInScale * timecodeScaleNs) / 1_000_000_000);
+}
+
+function findDurationInSegment(buf: Uint8Array, pos: number): number | null {
+  while (pos + 2 <= buf.length) {
+    const idLen = vintLen(buf[pos] ?? 0);
+    if (idLen === null || pos + idLen > buf.length) {
+      return null;
+    }
+    const sizeResult = readVint(buf, pos + idLen);
+    if (sizeResult === null) {
+      return null;
+    }
+
+    const elemStart = pos;
+    const dataPos = sizeResult.next;
+    const dataSize = sizeResult.value;
+
+    if (
+      idLen === 4 &&
+      buf[elemStart] === 0x15 &&
+      buf[elemStart + 1] === 0x49 &&
+      buf[elemStart + 2] === 0xa9 &&
+      buf[elemStart + 3] === 0x66
+    ) {
+      return findDurationInInfo(buf, dataPos, dataSize);
+    }
+
+    pos = dataPos + Math.min(dataSize, buf.length - dataPos);
+  }
+  return null;
+}
+
+function parseWebmDuration(buf: Uint8Array): number | null {
+  if (buf.length < 12) {
+    return null;
+  }
+  if (
+    buf[0] !== EBML_HEADER[0] ||
+    buf[1] !== EBML_HEADER[1] ||
+    buf[2] !== EBML_HEADER[2] ||
+    buf[3] !== EBML_HEADER[3]
+  ) {
+    return null;
+  }
+
+  let pos = 4;
+  const ebmlSize = readVint(buf, pos);
+  if (ebmlSize === null) {
+    return null;
+  }
+  pos = ebmlSize.next + ebmlSize.value;
+
+  if (pos + 4 > buf.length) {
+    return null;
+  }
+  const segIdLen = vintLen(buf[pos] ?? 0);
+  if (segIdLen === null || segIdLen !== 4) {
+    return null;
+  }
+  pos += segIdLen;
+  const segSizeLen = readVint(buf, pos);
+  if (segSizeLen === null) {
+    return null;
+  }
+  pos = segSizeLen.next;
+
+  return findDurationInSegment(buf, pos);
+}
+
+export async function getAudioDuration(file: File): Promise<number | null> {
+  const mimeType = file.type.split(";")[0] ?? file.type;
+  const buf = new Uint8Array(
+    await file
+      .slice(0, Math.min(file.size, MAX_DURATION_READ_BYTES))
+      .arrayBuffer(),
+  );
+
+  if (mimeType === "audio/webm") {
+    return parseWebmDuration(buf);
+  }
+  if (
+    mimeType === "audio/wav" ||
+    mimeType === "audio/wave" ||
+    mimeType === "audio/x-wav"
+  ) {
+    return sttWavDuration(buf);
+  }
+  return estimateDurationFromSize(file.size);
+}
+
+export const speechPricing$: Computed<Promise<SpeechPricing | null>> = computed(
+  async (get): Promise<SpeechPricing | null> => {
+    const db = get(db$);
+    const [pricing] = await db
+      .select({
+        unitPrice: usagePricing.unitPrice,
+        unitSize: usagePricing.unitSize,
+      })
+      .from(usagePricing)
+      .where(
+        and(
+          eq(usagePricing.kind, USAGE_KIND),
+          eq(usagePricing.provider, USAGE_PROVIDER),
+          eq(usagePricing.category, USAGE_CATEGORY),
+        ),
+      )
+      .limit(1);
+
+    return pricing ?? null;
+  },
+);
+
+export const checkSpeechCredits$ = command(
+  async (
+    { set },
+    args: { readonly orgId: string; readonly userId: string },
+    signal: AbortSignal,
+  ): Promise<boolean> => {
+    const writeDb = set(writeDb$);
+    const { rows } = await writeDb.execute<CreditCheckRow>(sql`
+      WITH member AS (
+        SELECT credit_enabled FROM org_members_metadata
+        WHERE org_id = ${args.orgId} AND user_id = ${args.userId}
+        LIMIT 1
+      ),
+      org AS (
+        SELECT credits FROM org_metadata
+        WHERE org_id = ${args.orgId}
+        LIMIT 1
+      ),
+      expired AS (
+        SELECT COALESCE(SUM(remaining), 0)::bigint AS total
+        FROM credit_expires_record
+        WHERE org_id = ${args.orgId}
+          AND expires_at <= now()
+          AND remaining > 0
+      )
+      SELECT
+        (SELECT credit_enabled FROM member) AS credit_enabled,
+        (SELECT credits FROM org) AS credits,
+        (SELECT total FROM expired) AS unsettled_expired
+    `);
+    signal.throwIfAborted();
+
+    const row = rows[0];
+    if (!row || row.credit_enabled === false || row.credits === null) {
+      return false;
+    }
+
+    const credits = Number(row.credits);
+    const unsettledExpired = Number(row.unsettled_expired ?? 0);
+    return credits - unsettledExpired > 0;
+  },
+);
+
+export const sttDailyPolicy$ = command(
+  async (
+    { get },
+    orgId: string,
+    userId: string,
+    durationSeconds: number,
+    signal: AbortSignal,
+  ): Promise<SttDailyPolicy | ErrorResponse> => {
+    const db = get(db$);
+    const currentDate = nowDate();
+    const rateKey = sttDailyRateKey(currentDate);
+    const durationKey = sttDailyDurationKey(currentDate);
+    const [orgRow] = await db
+      .select({ tier: orgMetadata.tier })
+      .from(orgMetadata)
+      .where(eq(orgMetadata.orgId, orgId))
+      .limit(1);
+    signal.throwIfAborted();
+
+    const orgTier = orgTierSchema.parse(orgRow?.tier ?? "free");
+    const behaviorRows = await db
+      .select({
+        key: userBehaviorCount.behaviorKey,
+        count: userBehaviorCount.count,
+      })
+      .from(userBehaviorCount)
+      .where(
+        and(
+          eq(userBehaviorCount.orgId, orgId),
+          eq(userBehaviorCount.userId, userId),
+          inArray(userBehaviorCount.behaviorKey, [rateKey, durationKey]),
+        ),
+      );
+    signal.throwIfAborted();
+
+    const counts = new Map(
+      behaviorRows.map((row): readonly [string, number] => {
+        return [row.key, row.count];
+      }),
+    );
+    const rateCount = counts.get(rateKey) ?? 0;
+    const rateLimit = DAILY_RATE_LIMITS[orgTier];
+    if (rateCount >= rateLimit) {
+      return quotaError(
+        429,
+        "Daily request rate limit exceeded",
+        "DAILY_RATE_LIMIT_EXCEEDED",
+        rateCount,
+        rateLimit,
+      );
+    }
+
+    const dailyDurationSeconds = counts.get(durationKey) ?? 0;
+    const durationLimit = DAILY_DURATION_LIMITS[orgTier];
+    if (dailyDurationSeconds + durationSeconds > durationLimit) {
+      return quotaError(
+        429,
+        "Daily audio duration limit exceeded",
+        "DAILY_DURATION_LIMIT_EXCEEDED",
+        dailyDurationSeconds,
+        durationLimit,
+      );
+    }
+
+    return { orgTier, rateKey, durationKey, durationSeconds };
+  },
+);
+
+export const recordSttUsage$ = command(
+  async (
+    { set },
+    params: SttDailyPolicy & {
+      readonly orgId: string;
+      readonly userId: string;
+    },
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const writeDb = set(writeDb$);
+    await Promise.all([
+      writeDb
+        .insert(userBehaviorCount)
+        .values({
+          orgId: params.orgId,
+          userId: params.userId,
+          behaviorKey: params.rateKey,
+          count: 1,
+        })
+        .onConflictDoUpdate({
+          target: [
+            userBehaviorCount.orgId,
+            userBehaviorCount.userId,
+            userBehaviorCount.behaviorKey,
+          ],
+          set: {
+            count: sql`${userBehaviorCount.count} + 1`,
+            lastAt: sql`now()`,
+          },
+        }),
+      writeDb
+        .insert(userBehaviorCount)
+        .values({
+          orgId: params.orgId,
+          userId: params.userId,
+          behaviorKey: params.durationKey,
+          count: params.durationSeconds,
+        })
+        .onConflictDoUpdate({
+          target: [
+            userBehaviorCount.orgId,
+            userBehaviorCount.userId,
+            userBehaviorCount.behaviorKey,
+          ],
+          set: {
+            count: sql`${userBehaviorCount.count} + ${params.durationSeconds}`,
+            lastAt: sql`now()`,
+          },
+        }),
+      params.orgTier === "free"
+        ? writeDb
+            .insert(userBehaviorCount)
+            .values({
+              orgId: params.orgId,
+              userId: params.userId,
+              behaviorKey: AUDIO_INPUT_BEHAVIOR_KEY,
+              count: 1,
+            })
+            .onConflictDoUpdate({
+              target: [
+                userBehaviorCount.orgId,
+                userBehaviorCount.userId,
+                userBehaviorCount.behaviorKey,
+              ],
+              set: {
+                count: sql`${userBehaviorCount.count} + 1`,
+                lastAt: sql`now()`,
+              },
+            })
+        : Promise.resolve(),
+    ]);
+    signal.throwIfAborted();
+  },
+);
+
+export const recordGeneratedSpeech$ = command(
+  async (
+    { get, set },
+    params: {
+      readonly orgId: string;
+      readonly userId: string;
+      readonly runId: string | undefined;
+      readonly voice: string;
+      readonly audioBytes: Uint8Array;
+      readonly durationSeconds: number;
+      readonly pricing: SpeechPricing;
+    },
+    signal: AbortSignal,
+  ): Promise<RecordedSpeech> => {
+    const writeDb = set(writeDb$);
+    const fileId = randomUUID();
+    const filename = `voice-${fileId.slice(0, 8)}.wav`;
+    const s3Key = `uploads/${params.userId}/${fileId}/${filename}`;
+    const bucket = env("R2_USER_STORAGES_BUCKET_NAME");
+    await get(
+      putS3Object(
+        bucket,
+        s3Key,
+        Buffer.from(params.audioBytes),
+        SPEECH_CONTENT_TYPE,
+      ),
+    );
+    signal.throwIfAborted();
+
+    const url = buildFileUrl(params.userId, fileId, filename);
+    await set(
+      recordWebUploadedFile$,
+      {
+        runId: params.runId,
+        externalId: fileId,
+        userId: params.userId,
+        orgId: params.orgId,
+        filename,
+        contentType: SPEECH_CONTENT_TYPE,
+        sizeBytes: params.audioBytes.byteLength,
+        url,
+        s3Key,
+        metadata: {
+          generatedBy: "zero-official-voice",
+          model: VOICE_IO_TTS_MODEL,
+          voice: params.voice,
+          durationSeconds: params.durationSeconds,
+        },
+      },
+      signal,
+    );
+    signal.throwIfAborted();
+
+    await writeDb.insert(usageEvent).values({
+      runId: null,
+      idempotencyKey: randomUUID(),
+      orgId: params.orgId,
+      userId: params.userId,
+      kind: USAGE_KIND,
+      provider: USAGE_PROVIDER,
+      category: USAGE_CATEGORY,
+      quantity: params.durationSeconds,
+    });
+    signal.throwIfAborted();
+
+    await set(processOrgUsageEvents$, params.orgId, signal);
+    signal.throwIfAborted();
+
+    return {
+      id: fileId,
+      filename,
+      contentType: SPEECH_CONTENT_TYPE,
+      size: params.audioBytes.byteLength,
+      url,
+      durationSeconds: params.durationSeconds,
+      creditsCharged: estimatedSpeechCredits(
+        params.durationSeconds,
+        params.pricing,
+      ),
+      model: VOICE_IO_TTS_MODEL,
+      voice: params.voice,
+    };
+  },
+);

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -1081,6 +1081,27 @@ export {
   type AudioInputQuotaResponse,
 } from "./zero-voice-io-quota";
 export {
+  zeroVoiceIoSpeechContract,
+  zeroVoiceIoSpeechRequestSchema,
+  zeroVoiceIoSpeechResponseSchema,
+  type ZeroVoiceIoSpeechContract,
+  type ZeroVoiceIoSpeechRequest,
+  type ZeroVoiceIoSpeechResponse,
+} from "./zero-voice-io-speech";
+export {
+  zeroVoiceIoSttContract,
+  zeroVoiceIoSttResponseSchema,
+  zeroVoiceIoSttQuotaErrorSchema,
+  type ZeroVoiceIoSttContract,
+  type ZeroVoiceIoSttResponse,
+} from "./zero-voice-io-stt";
+export {
+  zeroVoiceIoTtsContract,
+  zeroVoiceIoTtsRequestSchema,
+  type ZeroVoiceIoTtsContract,
+  type ZeroVoiceIoTtsRequest,
+} from "./zero-voice-io-tts";
+export {
   zeroVoiceChatContract,
   voiceChatItemRoleSchema,
   voiceChatTaskStatusSchema,

--- a/turbo/packages/api-contracts/src/contracts/zero-voice-io-speech.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-voice-io-speech.ts
@@ -1,0 +1,54 @@
+import { z } from "zod";
+import { authHeadersSchema, initContract } from "./base";
+import { apiErrorSchema } from "./errors";
+
+const c = initContract();
+
+export const zeroVoiceIoSpeechRequestSchema = z
+  .object({
+    text: z.unknown().optional(),
+    voice: z.unknown().optional(),
+    instructions: z.unknown().optional(),
+  })
+  .passthrough();
+
+export const zeroVoiceIoSpeechResponseSchema = z.object({
+  id: z.string(),
+  filename: z.string(),
+  contentType: z.string(),
+  size: z.number(),
+  url: z.string(),
+  durationSeconds: z.number(),
+  creditsCharged: z.number(),
+  model: z.string(),
+  voice: z.string(),
+});
+
+export type ZeroVoiceIoSpeechRequest = z.infer<
+  typeof zeroVoiceIoSpeechRequestSchema
+>;
+export type ZeroVoiceIoSpeechResponse = z.infer<
+  typeof zeroVoiceIoSpeechResponseSchema
+>;
+
+export const zeroVoiceIoSpeechContract = c.router({
+  post: {
+    method: "POST",
+    path: "/api/zero/voice-io/speech",
+    headers: authHeadersSchema,
+    body: zeroVoiceIoSpeechRequestSchema,
+    responses: {
+      200: zeroVoiceIoSpeechResponseSchema,
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      402: apiErrorSchema,
+      403: apiErrorSchema,
+      500: apiErrorSchema,
+      502: apiErrorSchema,
+      503: apiErrorSchema,
+    },
+    summary: "Generate and persist WAV speech audio",
+  },
+});
+
+export type ZeroVoiceIoSpeechContract = typeof zeroVoiceIoSpeechContract;

--- a/turbo/packages/api-contracts/src/contracts/zero-voice-io-stt.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-voice-io-stt.ts
@@ -1,0 +1,44 @@
+import { z } from "zod";
+import { authHeadersSchema, initContract } from "./base";
+import { apiErrorSchema } from "./errors";
+
+const c = initContract();
+
+export const zeroVoiceIoSttResponseSchema = z.object({
+  text: z.string(),
+});
+
+export const zeroVoiceIoSttQuotaErrorSchema = apiErrorSchema.extend({
+  quota: z
+    .object({
+      count: z.number(),
+      limit: z.number().nullable(),
+    })
+    .optional(),
+});
+
+export type ZeroVoiceIoSttResponse = z.infer<
+  typeof zeroVoiceIoSttResponseSchema
+>;
+
+export const zeroVoiceIoSttContract = c.router({
+  post: {
+    method: "POST",
+    path: "/api/zero/voice-io/stt",
+    headers: authHeadersSchema,
+    contentType: "multipart/form-data",
+    body: c.type<FormData>(),
+    responses: {
+      200: zeroVoiceIoSttResponseSchema,
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      402: zeroVoiceIoSttQuotaErrorSchema,
+      403: apiErrorSchema,
+      429: zeroVoiceIoSttQuotaErrorSchema,
+      500: apiErrorSchema,
+    },
+    summary: "Transcribe audio input",
+  },
+});
+
+export type ZeroVoiceIoSttContract = typeof zeroVoiceIoSttContract;

--- a/turbo/packages/api-contracts/src/contracts/zero-voice-io-tts.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-voice-io-tts.ts
@@ -1,0 +1,35 @@
+import { z } from "zod";
+import { authHeadersSchema, initContract } from "./base";
+import { apiErrorSchema } from "./errors";
+
+const c = initContract();
+
+export const zeroVoiceIoTtsRequestSchema = z
+  .object({
+    text: z.unknown().optional(),
+  })
+  .passthrough();
+
+export type ZeroVoiceIoTtsRequest = z.infer<typeof zeroVoiceIoTtsRequestSchema>;
+
+export const zeroVoiceIoTtsContract = c.router({
+  post: {
+    method: "POST",
+    path: "/api/zero/voice-io/tts",
+    headers: authHeadersSchema,
+    body: zeroVoiceIoTtsRequestSchema,
+    responses: {
+      200: c.otherResponse({
+        contentType: "application/octet-stream",
+        body: z.unknown(),
+      }),
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      500: apiErrorSchema,
+    },
+    summary: "Generate PCM text-to-speech audio",
+  },
+});
+
+export type ZeroVoiceIoTtsContract = typeof zeroVoiceIoTtsContract;


### PR DESCRIPTION
## Summary
- add API contracts and route registrations for POST /api/zero/voice-io/tts, /stt, and /speech
- port voice IO validation, OpenAI proxying, audio quota tracking, generated WAV upload, run artifact recording, and usage-event charging into apps/api
- add route-level API integration tests covering auth, validation, quota, OpenAI failure, and success paths

## Tests
- ./scripts/prepare.sh
- pnpm format
- pnpm -F api check-types
- pnpm -F @vm0/api-contracts check-types
- pnpm -F api lint
- pnpm -F @vm0/api-contracts lint
- pnpm -F api exec vitest run src/signals/routes/__tests__/zero-voice-io-post.test.ts
- pnpm knip --cache
- pre-commit: turbo run check-types --concurrency=1

Closes #12893