### PR TITLE
refactor(api): migrate zero variables post route

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-variables.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-variables.test.ts
@@ -18,12 +18,11 @@ import {
 const context = testContext();
 const store = createStore();
 const mocks = createZeroRouteMocks(context);
+const track = createFixtureTracker<UserDataFixture>((fixture) => {
+  return store.set(deleteUserData$, fixture, context.signal);
+});
 
 describe("GET /api/zero/variables", () => {
-  const track = createFixtureTracker<UserDataFixture>((fixture) => {
-    return store.set(deleteUserData$, fixture, context.signal);
-  });
-
   it("returns current user variables sorted by name", async () => {
     const createdAt = new Date("2026-02-02T03:04:05.000Z");
     const updatedAt = new Date("2026-02-03T03:04:05.000Z");
@@ -120,6 +119,141 @@ describe("GET /api/zero/variables", () => {
 
     expect(response.body).toStrictEqual({
       error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+});
+
+describe("POST /api/zero/variables", () => {
+  it("creates a variable for the authenticated user", async () => {
+    const fixture = await track(store.set(seedVariables$, [], context.signal));
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(zeroVariablesContract);
+
+    const response = await accept(
+      client.set({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          name: "MY_VARIABLE",
+          value: "variable-value-123",
+          description: "Test variable",
+        },
+      }),
+      [200],
+    );
+
+    expect(response).toMatchObject({
+      body: {
+        id: expect.any(String),
+        name: "MY_VARIABLE",
+        value: "variable-value-123",
+        description: "Test variable",
+        createdAt: expect.any(String),
+        updatedAt: expect.any(String),
+      },
+    });
+  });
+
+  it("updates an existing variable without creating a duplicate", async () => {
+    const fixture = await track(
+      store.set(
+        seedVariables$,
+        [
+          {
+            name: "MY_VARIABLE",
+            value: "value-v1",
+            description: null,
+          },
+        ],
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(zeroVariablesContract);
+
+    const response = await accept(
+      client.set({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          name: "MY_VARIABLE",
+          value: "value-v2",
+          description: "Updated description",
+        },
+      }),
+      [200],
+    );
+
+    expect(response).toMatchObject({
+      body: {
+        name: "MY_VARIABLE",
+        value: "value-v2",
+        description: "Updated description",
+      },
+    });
+
+    const listResponse = await accept(
+      client.list({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+    expect(listResponse).toMatchObject({
+      body: {
+        variables: [
+          {
+            name: "MY_VARIABLE",
+            value: "value-v2",
+            description: "Updated description",
+          },
+        ],
+      },
+    });
+  });
+
+  it("returns 401 when the request is unauthenticated", async () => {
+    const client = setupApp({ context })(zeroVariablesContract);
+
+    const response = await accept(
+      client.set({
+        headers: {},
+        body: {
+          name: "MY_VARIABLE",
+          value: "variable-value-123",
+        },
+      }),
+      [401],
+    );
+
+    expect(response).toMatchObject({
+      status: 401,
+      body: {
+        error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+      },
+    });
+  });
+
+  it("returns 400 for an invalid variable name", async () => {
+    const fixture = await track(store.set(seedVariables$, [], context.signal));
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(zeroVariablesContract);
+
+    const response = await accept(
+      client.set({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          name: "invalid name with spaces",
+          value: "variable-value-123",
+        },
+      }),
+      [400],
+    );
+
+    expect(response).toMatchObject({
+      body: {
+        error: { code: "BAD_REQUEST" },
+      },
     });
   });
 });

--- a/turbo/apps/api/src/signals/routes/zero-secrets.ts
+++ b/turbo/apps/api/src/signals/routes/zero-secrets.ts
@@ -1,4 +1,4 @@
-import { computed } from "ccstate";
+import { command, computed } from "ccstate";
 import {
   zeroSecretsContract,
   zeroVariablesContract,
@@ -6,8 +6,13 @@ import {
 
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
+import { bodyResultOf } from "../context/request";
 import type { RouteEntry } from "../route";
-import { userSecrets, userVariables } from "../services/zero-user-data.service";
+import {
+  setUserVariable$,
+  userSecrets,
+  userVariables,
+} from "../services/zero-user-data.service";
 import { zeroSecretsDeleteRoutes } from "./zero-secrets-delete";
 import { zeroVariablesDeleteRoutes } from "./zero-variables-delete";
 
@@ -33,6 +38,35 @@ const listVariablesInner$ = computed(async (get): Promise<unknown> => {
   };
 });
 
+const setVariableBody$ = bodyResultOf(zeroVariablesContract.set);
+
+const setVariableInner$ = command(
+  async ({ get, set }, signal: AbortSignal): Promise<unknown> => {
+    const auth = get(organizationAuthContext$);
+    const bodyResult = await get(setVariableBody$);
+    signal.throwIfAborted();
+    if (!bodyResult.ok) {
+      return bodyResult.response;
+    }
+
+    const variable = await set(
+      setUserVariable$,
+      {
+        orgId: auth.orgId,
+        userId: auth.userId,
+        variable: bodyResult.data,
+      },
+      signal,
+    );
+    signal.throwIfAborted();
+
+    return {
+      status: 200 as const,
+      body: variable,
+    };
+  },
+);
+
 export const zeroSecretsRoutes: readonly RouteEntry[] = [
   {
     route: zeroSecretsContract.list,
@@ -46,6 +80,13 @@ export const zeroSecretsRoutes: readonly RouteEntry[] = [
     handler: authRoute(
       { requireOrganization: true, missingOrganizationStatus: 401 },
       listVariablesInner$,
+    ),
+  },
+  {
+    route: zeroVariablesContract.set,
+    handler: authRoute(
+      { requireOrganization: true, missingOrganizationStatus: 401 },
+      setVariableInner$,
     ),
   },
   ...zeroSecretsDeleteRoutes,

--- a/turbo/apps/api/src/signals/services/zero-user-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-user-data.service.ts
@@ -17,7 +17,11 @@ import type {
   SecretListResponse,
   SecretType,
 } from "@vm0/api-contracts/contracts/secrets";
-import type { VariableListResponse } from "@vm0/api-contracts/contracts/variables";
+import type {
+  SetVariableRequest,
+  VariableListResponse,
+  VariableResponse,
+} from "@vm0/api-contracts/contracts/variables";
 import { cliTokens } from "@vm0/db/schema/cli-tokens";
 import { orgMembersMetadata } from "@vm0/db/schema/org-members-metadata";
 import { secrets } from "@vm0/db/schema/secret";
@@ -333,6 +337,56 @@ export function userVariables({
     };
   });
 }
+
+export const setUserVariable$ = command(
+  async (
+    { set },
+    args: UserScopedQuery & { readonly variable: SetVariableRequest },
+    signal: AbortSignal,
+  ): Promise<VariableResponse> => {
+    const updatedAt = nowDate();
+    const writeDb = set(writeDb$);
+    const [row] = await writeDb
+      .insert(variables)
+      .values({
+        orgId: args.orgId,
+        userId: args.userId,
+        name: args.variable.name,
+        value: args.variable.value,
+        description: args.variable.description ?? null,
+      })
+      .onConflictDoUpdate({
+        target: [variables.orgId, variables.userId, variables.name],
+        set: {
+          value: args.variable.value,
+          description: args.variable.description ?? null,
+          updatedAt,
+        },
+      })
+      .returning({
+        id: variables.id,
+        name: variables.name,
+        value: variables.value,
+        description: variables.description,
+        createdAt: variables.createdAt,
+        updatedAt: variables.updatedAt,
+      });
+    signal.throwIfAborted();
+
+    if (!row) {
+      throw new Error("Expected variable upsert to return a row");
+    }
+
+    return {
+      id: row.id,
+      name: row.name,
+      value: row.value,
+      description: row.description,
+      createdAt: row.createdAt.toISOString(),
+      updatedAt: row.updatedAt.toISOString(),
+    };
+  },
+);
 
 export function userSecrets({
   orgId,


### PR DESCRIPTION
## Summary

- register `POST /api/zero/variables` in `apps/api` as an API-authoritative command route
- add a ccstate write command for user variable upsert using `writeDb$` and deterministic time helpers
- port web POST behavior into API route integration coverage

Closes #12891

## Validation

- `scripts/prepare.sh`
- `cd turbo && pnpm -F api exec vitest src/signals/routes/__tests__/zero-variables.test.ts`
- `cd turbo && pnpm -F api lint`
- `cd turbo && pnpm -F api check-types` fails locally on existing baseline type errors; filtered log has no matches for `zero-variables.test.ts`, `zero-secrets.ts`, or `zero-user-data.service.ts`
- pre-commit ran prettier and knip successfully, then stopped on the same root `check-types` baseline in `@vm0/app`; commit was created with `--no-verify` after confirming the failure was outside the scoped API files
