### PR TITLE
refactor(api): migrate zero secrets post route

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-secrets.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-secrets.test.ts
@@ -2,8 +2,11 @@ import { randomUUID } from "node:crypto";
 
 import { zeroSecretsContract } from "@vm0/api-contracts/contracts/zero-secrets";
 import { createStore } from "ccstate";
+import { and, eq } from "drizzle-orm";
+import { secrets } from "@vm0/db/schema/secret";
 
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { writeDb$ } from "../../external/db";
 import {
   createFixtureTracker,
   createZeroRouteMocks,
@@ -128,5 +131,261 @@ describe("GET /api/zero/secrets", () => {
     );
 
     expect(response.body).toStrictEqual({ secrets: [] });
+  });
+});
+
+describe("POST /api/zero/secrets", () => {
+  const track = createFixtureTracker<UserDataFixture>((fixture) => {
+    return store.set(deleteUserData$, fixture, context.signal);
+  });
+
+  it("returns 401 when the request is unauthenticated", async () => {
+    const client = setupApp({ context })(zeroSecretsContract);
+
+    const response = await accept(
+      client.set({
+        headers: {},
+        body: {
+          name: "MY_SECRET",
+          value: "secret-value",
+        },
+      }),
+      [401],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Not authenticated",
+        code: "UNAUTHORIZED",
+      },
+    });
+  });
+
+  it("returns 401 when the authenticated session has no organization", async () => {
+    mocks.clerk.session(`user_${randomUUID()}`, null);
+
+    const client = setupApp({ context })(zeroSecretsContract);
+
+    const response = await accept(
+      client.set({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          name: "MY_SECRET",
+          value: "secret-value",
+        },
+      }),
+      [401],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("creates a user secret and stores an encrypted value", async () => {
+    const fixture = await track(store.set(seedSecrets$, [], context.signal));
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(zeroSecretsContract);
+
+    const response = await accept(
+      client.set({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          name: "MY_SECRET",
+          value: "secret-value",
+          description: "Test secret",
+        },
+      }),
+      [200],
+    );
+
+    expect(response.body).toMatchObject({
+      name: "MY_SECRET",
+      description: "Test secret",
+      type: "user",
+    });
+    expect(response.body.id).toBeDefined();
+    expect(response.body.createdAt).toBeDefined();
+    expect(response.body.updatedAt).toBeDefined();
+    expect(response.body).not.toHaveProperty("value");
+    expect(response.body).not.toHaveProperty("encryptedValue");
+
+    const writeDb = store.set(writeDb$);
+    const rows = await writeDb
+      .select({
+        encryptedValue: secrets.encryptedValue,
+        type: secrets.type,
+      })
+      .from(secrets)
+      .where(
+        and(
+          eq(secrets.orgId, fixture.orgId),
+          eq(secrets.userId, fixture.userId),
+          eq(secrets.name, "MY_SECRET"),
+        ),
+      );
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.type).toBe("user");
+    expect(rows[0]?.encryptedValue).not.toBe("secret-value");
+  });
+
+  it("updates an existing user secret without creating a duplicate", async () => {
+    const fixture = await track(store.set(seedSecrets$, [], context.signal));
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(zeroSecretsContract);
+
+    const created = await accept(
+      client.set({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          name: "MY_SECRET",
+          value: "value-v1",
+          description: "Initial description",
+        },
+      }),
+      [200],
+    );
+
+    const updated = await accept(
+      client.set({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          name: "MY_SECRET",
+          value: "value-v2",
+          description: "Updated description",
+        },
+      }),
+      [200],
+    );
+
+    expect(updated.body.id).toBe(created.body.id);
+    expect(updated.body.name).toBe("MY_SECRET");
+    expect(updated.body.description).toBe("Updated description");
+
+    const writeDb = store.set(writeDb$);
+    const rows = await writeDb
+      .select({
+        encryptedValue: secrets.encryptedValue,
+        description: secrets.description,
+      })
+      .from(secrets)
+      .where(
+        and(
+          eq(secrets.orgId, fixture.orgId),
+          eq(secrets.userId, fixture.userId),
+          eq(secrets.name, "MY_SECRET"),
+          eq(secrets.type, "user"),
+        ),
+      );
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.description).toBe("Updated description");
+    expect(rows[0]?.encryptedValue).not.toBe("value-v2");
+  });
+
+  it("returns 400 for invalid secret names", async () => {
+    const fixture = await track(store.set(seedSecrets$, [], context.signal));
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(zeroSecretsContract);
+
+    const response = await accept(
+      client.set({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          name: "invalid name",
+          value: "secret-value",
+        },
+      }),
+      [400],
+    );
+
+    expect(response.body.error.code).toBe("BAD_REQUEST");
+  });
+
+  it("returns 400 for empty secret values", async () => {
+    const fixture = await track(store.set(seedSecrets$, [], context.signal));
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(zeroSecretsContract);
+
+    const response = await accept(
+      client.set({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          name: "MY_SECRET",
+          value: "",
+        },
+      }),
+      [400],
+    );
+
+    expect(response.body.error.code).toBe("BAD_REQUEST");
+  });
+
+  it("does not overwrite another user's secret with the same name", async () => {
+    const fixture = await track(store.set(seedSecrets$, [], context.signal));
+    const otherUserId = `user_${randomUUID()}`;
+    const writeDb = store.set(writeDb$);
+    await writeDb.insert(secrets).values({
+      orgId: fixture.orgId,
+      userId: otherUserId,
+      name: "SHARED_SECRET",
+      encryptedValue: "other-user-encrypted",
+      description: "Other user",
+      type: "user",
+    });
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(zeroSecretsContract);
+
+    const response = await accept(
+      client.set({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          name: "SHARED_SECRET",
+          value: "current-user-value",
+          description: "Current user",
+        },
+      }),
+      [200],
+    );
+
+    expect(response.body.description).toBe("Current user");
+
+    const rows = await writeDb
+      .select({
+        userId: secrets.userId,
+        encryptedValue: secrets.encryptedValue,
+        description: secrets.description,
+      })
+      .from(secrets)
+      .where(
+        and(
+          eq(secrets.orgId, fixture.orgId),
+          eq(secrets.name, "SHARED_SECRET"),
+          eq(secrets.type, "user"),
+        ),
+      );
+
+    expect(rows).toHaveLength(2);
+    expect(
+      rows.find((row) => {
+        return row.userId === otherUserId;
+      }),
+    ).toMatchObject({
+      encryptedValue: "other-user-encrypted",
+      description: "Other user",
+    });
+    expect(
+      rows.find((row) => {
+        return row.userId === fixture.userId;
+      }),
+    ).toMatchObject({
+      description: "Current user",
+    });
   });
 });

--- a/turbo/apps/api/src/signals/routes/zero-secrets.ts
+++ b/turbo/apps/api/src/signals/routes/zero-secrets.ts
@@ -9,12 +9,15 @@ import { authRoute } from "../auth/auth-route";
 import { bodyResultOf } from "../context/request";
 import type { RouteEntry } from "../route";
 import {
+  setUserSecret$,
   setUserVariable$,
   userSecrets,
   userVariables,
 } from "../services/zero-user-data.service";
 import { zeroSecretsDeleteRoutes } from "./zero-secrets-delete";
 import { zeroVariablesDeleteRoutes } from "./zero-variables-delete";
+
+const setSecretBody$ = bodyResultOf(zeroSecretsContract.set);
 
 const listSecretsInner$ = computed(async (get): Promise<unknown> => {
   const auth = get(organizationAuthContext$);
@@ -26,6 +29,32 @@ const listSecretsInner$ = computed(async (get): Promise<unknown> => {
     body,
   };
 });
+
+const setSecretInner$ = command(
+  async ({ get, set }, signal: AbortSignal): Promise<unknown> => {
+    const auth = get(organizationAuthContext$);
+    const body = await get(setSecretBody$);
+    signal.throwIfAborted();
+    if (!body.ok) {
+      return body.response;
+    }
+
+    const secret = await set(
+      setUserSecret$,
+      {
+        orgId: auth.orgId,
+        userId: auth.userId,
+        secret: body.data,
+      },
+      signal,
+    );
+
+    return {
+      status: 200 as const,
+      body: secret,
+    };
+  },
+);
 
 const listVariablesInner$ = computed(async (get): Promise<unknown> => {
   const auth = get(organizationAuthContext$);
@@ -73,6 +102,13 @@ export const zeroSecretsRoutes: readonly RouteEntry[] = [
     handler: authRoute(
       { requireOrganization: true, missingOrganizationStatus: 401 },
       listSecretsInner$,
+    ),
+  },
+  {
+    route: zeroSecretsContract.set,
+    handler: authRoute(
+      { requireOrganization: true, missingOrganizationStatus: 401 },
+      setSecretInner$,
     ),
   },
   {

--- a/turbo/apps/api/src/signals/services/zero-user-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-user-data.service.ts
@@ -15,6 +15,8 @@ import type {
 import { isSupportedRunModel } from "@vm0/api-contracts/contracts/model-providers";
 import type {
   SecretListResponse,
+  SecretResponse,
+  SetSecretRequest,
   SecretType,
 } from "@vm0/api-contracts/contracts/secrets";
 import type {
@@ -30,6 +32,7 @@ import { and, desc, eq } from "drizzle-orm";
 
 import { nowDate } from "../../lib/time";
 import { db$, writeDb$ } from "../external/db";
+import { encryptSecretValue } from "./crypto.utils";
 import { isValidTimeZone } from "../utils";
 
 const API_KEY_PREFIX_LENGTH = 12;
@@ -37,6 +40,10 @@ const API_KEY_PREFIX_LENGTH = 12;
 interface UserScopedQuery {
   readonly orgId: string;
   readonly userId: string;
+}
+
+interface SetUserSecretArgs extends UserScopedQuery {
+  readonly secret: SetSecretRequest;
 }
 
 function toStringArray(value: unknown): string[] {
@@ -421,3 +428,55 @@ export function userSecrets({
     };
   });
 }
+
+export const setUserSecret$ = command(
+  async (
+    { set },
+    args: SetUserSecretArgs,
+    signal: AbortSignal,
+  ): Promise<SecretResponse> => {
+    const encryptedValue = encryptSecretValue(args.secret.value);
+    const updatedAt = nowDate();
+    const writeDb = set(writeDb$);
+    const [row] = await writeDb
+      .insert(secrets)
+      .values({
+        orgId: args.orgId,
+        userId: args.userId,
+        name: args.secret.name,
+        encryptedValue,
+        description: args.secret.description ?? null,
+        type: "user",
+      })
+      .onConflictDoUpdate({
+        target: [secrets.orgId, secrets.userId, secrets.name, secrets.type],
+        set: {
+          encryptedValue,
+          description: args.secret.description ?? null,
+          updatedAt,
+        },
+      })
+      .returning({
+        id: secrets.id,
+        name: secrets.name,
+        description: secrets.description,
+        type: secrets.type,
+        createdAt: secrets.createdAt,
+        updatedAt: secrets.updatedAt,
+      });
+    signal.throwIfAborted();
+
+    if (!row) {
+      throw new Error("Expected user secret upsert to return a row");
+    }
+
+    return {
+      id: row.id,
+      name: row.name,
+      description: row.description,
+      type: parseSecretType(row.type),
+      createdAt: row.createdAt.toISOString(),
+      updatedAt: row.updatedAt.toISOString(),
+    };
+  },
+);


### PR DESCRIPTION
## Summary
- add the API backend handler for `POST /api/zero/secrets`
- add a ccstate user-secret upsert command that encrypts stored values and returns metadata only
- extend API route integration coverage for create, update, auth, validation, and cross-user isolation

Closes #12888

## Tests
- `pnpm -F api exec vitest src/signals/routes/__tests__/zero-secrets.test.ts`
- `pnpm -F api lint`
- `pnpm check-types`
- `git diff --check`