### PR TITLE
refactor: migrate test slack state GET to api

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -83,6 +83,7 @@ import { zeroWebDownloadRoutes } from "./routes/zero-web-download";
 import { testOAuthProviderAuthorizeRoutes } from "./routes/test-oauth-provider-authorize";
 import { testOAuthProviderEchoRoutes } from "./routes/test-oauth-provider-echo";
 import { testOAuthProviderUserinfoRoutes } from "./routes/test-oauth-provider-userinfo";
+import { testSlackStateRoutes } from "./routes/test-slack-state";
 import { testTelegramStateRoutes } from "./routes/test-telegram-state";
 
 export type { SignalRouteHandler };
@@ -177,5 +178,6 @@ export const ROUTES: readonly RouteEntry[] = [
   ...testOAuthProviderAuthorizeRoutes,
   ...testOAuthProviderEchoRoutes,
   ...testOAuthProviderUserinfoRoutes,
+  ...testSlackStateRoutes,
   ...testTelegramStateRoutes,
 ];

--- a/turbo/apps/api/src/signals/routes/__tests__/test-slack-state.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/test-slack-state.test.ts
@@ -1,0 +1,325 @@
+import { randomUUID } from "node:crypto";
+
+import { createStore } from "ccstate";
+import type { TestSlackStateResponse } from "@vm0/api-contracts/contracts/test-slack-state";
+import {
+  agentComposes,
+  agentComposeVersions,
+} from "@vm0/db/schema/agent-compose";
+import { agentRuns } from "@vm0/db/schema/agent-run";
+import { agentSessions } from "@vm0/db/schema/agent-session";
+import { e2eSlackMockCallLog } from "@vm0/db/schema/e2e-slack-mock-call-log";
+import { orgMetadata } from "@vm0/db/schema/org-metadata";
+import { slackOrgConnections } from "@vm0/db/schema/slack-org-connection";
+import { slackOrgInstallations } from "@vm0/db/schema/slack-org-installation";
+import { zeroAgents } from "@vm0/db/schema/zero-agent";
+import { zeroRuns } from "@vm0/db/schema/zero-run";
+import { describe, expect, it } from "vitest";
+import { eq, inArray } from "drizzle-orm";
+
+import { createApp } from "../../../app-factory";
+import { testContext } from "../../../__tests__/test-helpers";
+import { mockEnv, mockOptionalEnv } from "../../../lib/env";
+import { writeDb$ } from "../../external/db";
+import { createFixtureTracker } from "./helpers/zero-route-test";
+
+const context = testContext();
+const store = createStore();
+const writeDb = store.set(writeDb$);
+
+const ROUTE = "/api/test/slack-state";
+
+interface SlackStateFixture {
+  readonly teamId: string;
+  readonly orgId: string;
+  readonly userId: string;
+  readonly composeId: string;
+  readonly versionId: string;
+  readonly runId: string;
+  readonly sessionId: string;
+  readonly mockCallMethods: readonly string[];
+}
+
+function suffix(): string {
+  return randomUUID().replaceAll("-", "").slice(0, 12);
+}
+
+function requestApp(path: string, init?: RequestInit): Promise<Response> {
+  const app = createApp({ signal: context.signal });
+  return Promise.resolve(app.request(path, init));
+}
+
+async function readJson<T>(response: Response): Promise<T> {
+  return (await response.json()) as T;
+}
+
+async function seedSlackStateFixture(): Promise<SlackStateFixture> {
+  const id = suffix();
+  const teamId = `T_${id}`;
+  const orgId = `org_${id}`;
+  const userId = `user_${id}`;
+  const composeId = randomUUID();
+  const versionId = suffix();
+  const runId = randomUUID();
+  const sessionId = randomUUID();
+  const newerMockMethod = `chat.postMessage.${id}`;
+  const olderMockMethod = `users.info.${id}`;
+
+  await writeDb.insert(agentComposes).values({
+    id: composeId,
+    userId,
+    orgId,
+    name: "e2e-slack-agent",
+    headVersionId: versionId,
+  });
+  await writeDb.insert(agentComposeVersions).values({
+    id: versionId,
+    composeId,
+    content: { env: {}, prompts: [] },
+    createdBy: userId,
+  });
+  await writeDb.insert(zeroAgents).values({
+    id: composeId,
+    orgId,
+    owner: userId,
+    name: "slack-agent",
+  });
+  await writeDb.insert(orgMetadata).values({
+    orgId,
+    defaultAgentId: composeId,
+    credits: 1234,
+    tier: "pro",
+  });
+  await writeDb.insert(slackOrgInstallations).values({
+    slackWorkspaceId: teamId,
+    slackWorkspaceName: "E2E Slack Workspace",
+    orgId,
+    encryptedBotToken: "encrypted-slack-token",
+    botUserId: "U_BOT",
+    installedByUserId: userId,
+  });
+  await writeDb.insert(slackOrgConnections).values({
+    slackWorkspaceId: teamId,
+    slackUserId: "U_SLACK_USER",
+    vm0UserId: userId,
+    dmWelcomeSent: true,
+  });
+  await writeDb.insert(agentSessions).values({
+    id: sessionId,
+    userId,
+    orgId,
+    agentComposeId: composeId,
+  });
+  await writeDb.insert(agentRuns).values({
+    id: runId,
+    userId,
+    orgId,
+    sessionId,
+    status: "completed",
+    prompt: "hello from slack diagnostics",
+    error: "diagnostic error",
+    createdAt: new Date("2030-01-01T00:00:00.000Z"),
+  });
+  await writeDb.insert(zeroRuns).values({
+    id: runId,
+    triggerSource: "slack",
+  });
+  await writeDb.insert(e2eSlackMockCallLog).values([
+    {
+      method: olderMockMethod,
+      teamId,
+      channelId: "C_OLDER",
+      body: '{"text":"older"}',
+      bodyJson: { text: "older" },
+      createdAt: new Date("2030-01-01T00:00:00.000Z"),
+    },
+    {
+      method: newerMockMethod,
+      teamId,
+      channelId: "C_NEWER",
+      body: '{"text":"newer"}',
+      bodyJson: { text: "newer" },
+      createdAt: new Date("2030-01-01T00:00:01.000Z"),
+    },
+  ]);
+
+  return {
+    teamId,
+    orgId,
+    userId,
+    composeId,
+    versionId,
+    runId,
+    sessionId,
+    mockCallMethods: [newerMockMethod, olderMockMethod],
+  };
+}
+
+async function cleanupSlackStateFixture(
+  fixture: SlackStateFixture,
+): Promise<void> {
+  await writeDb
+    .delete(e2eSlackMockCallLog)
+    .where(inArray(e2eSlackMockCallLog.method, fixture.mockCallMethods));
+  await writeDb.delete(zeroRuns).where(eq(zeroRuns.id, fixture.runId));
+  await writeDb.delete(agentRuns).where(eq(agentRuns.id, fixture.runId));
+  await writeDb
+    .delete(agentSessions)
+    .where(eq(agentSessions.id, fixture.sessionId));
+  await writeDb
+    .delete(slackOrgConnections)
+    .where(eq(slackOrgConnections.slackWorkspaceId, fixture.teamId));
+  await writeDb
+    .delete(slackOrgInstallations)
+    .where(eq(slackOrgInstallations.slackWorkspaceId, fixture.teamId));
+  await writeDb.delete(orgMetadata).where(eq(orgMetadata.orgId, fixture.orgId));
+  await writeDb.delete(zeroAgents).where(eq(zeroAgents.id, fixture.composeId));
+  await writeDb
+    .delete(agentComposeVersions)
+    .where(eq(agentComposeVersions.id, fixture.versionId));
+  await writeDb
+    .delete(agentComposes)
+    .where(eq(agentComposes.id, fixture.composeId));
+}
+
+const trackSlackStateFixture = createFixtureTracker(cleanupSlackStateFixture);
+
+describe("GET /api/test/slack-state", () => {
+  it("returns 404 outside allowed test environments", async () => {
+    mockEnv("ENV", "production");
+
+    const response = await requestApp(`${ROUTE}?team_id=T_DENIED`);
+
+    expect(response.status).toBe(404);
+    await expect(response.text()).resolves.toBe("Not found");
+  });
+
+  it("requires the preview bypass secret in preview", async () => {
+    mockEnv("ENV", "preview");
+    mockOptionalEnv("VERCEL_AUTOMATION_BYPASS_SECRET", "preview-secret");
+
+    const denied = await requestApp(`${ROUTE}?team_id=T_PREVIEW`, {
+      headers: { "x-vercel-protection-bypass": "wrong" },
+    });
+    const allowed = await requestApp(`${ROUTE}?team_id=T_PREVIEW`, {
+      headers: { "x-vercel-protection-bypass": "preview-secret" },
+    });
+
+    expect(denied.status).toBe(404);
+    await expect(denied.text()).resolves.toBe("Not found");
+    expect(allowed.status).toBe(200);
+  });
+
+  it("requires team_id", async () => {
+    mockEnv("ENV", "development");
+
+    const response = await requestApp(ROUTE);
+
+    expect(response.status).toBe(400);
+    await expect(readJson(response)).resolves.toStrictEqual({
+      error: "team_id query param is required",
+    });
+  });
+
+  it("returns empty workspace diagnostics for an unknown team", async () => {
+    mockEnv("ENV", "development");
+    mockOptionalEnv("SLACK_API_URL", "https://slack.example.test/api/");
+
+    const response = await requestApp(`${ROUTE}?team_id=T_UNKNOWN`);
+    const body = await readJson<TestSlackStateResponse>(response);
+
+    expect(response.status).toBe(200);
+    expect(body.installation).toBeNull();
+    expect(body.connections).toStrictEqual([]);
+    expect(body.recent_runs).toStrictEqual([]);
+    expect(body.org_metadata).toBeNull();
+    expect(body.default_agent).toBeNull();
+    expect(body.default_compose).toBeNull();
+    expect(body.default_compose_version).toBeNull();
+    expect(body.resolved_slack_api_url).toBe("https://slack.example.test/api/");
+    expect(Array.isArray(body.mock_calls)).toBeTruthy();
+  });
+
+  it("resolves the preview Slack mock URL", async () => {
+    mockEnv("ENV", "development");
+    mockOptionalEnv("E2E_SLACK_MOCK_ENABLED", "true");
+    mockOptionalEnv("VERCEL_URL", "preview.vm0.test");
+
+    const response = await requestApp(`${ROUTE}?team_id=T_UNKNOWN`);
+    const body = await readJson<TestSlackStateResponse>(response);
+
+    expect(response.status).toBe(200);
+    expect(body.resolved_slack_api_url).toBe(
+      "https://preview.vm0.test/api/test/slack-mock/",
+    );
+  });
+
+  it("returns Slack installation diagnostics, recent runs, default agent metadata, and mock calls", async () => {
+    mockEnv("ENV", "development");
+    const fixture = await trackSlackStateFixture(seedSlackStateFixture());
+
+    const response = await requestApp(`${ROUTE}?team_id=${fixture.teamId}`);
+    const body = await readJson<TestSlackStateResponse>(response);
+
+    expect(response.status).toBe(200);
+    expect(body.installation).toMatchObject({
+      slackWorkspaceId: fixture.teamId,
+      slackWorkspaceName: "E2E Slack Workspace",
+      orgId: fixture.orgId,
+      botUserId: "U_BOT",
+      installedByUserId: fixture.userId,
+    });
+    expect(typeof body.installation?.createdAt).toBe("string");
+    expect(body.connections).toMatchObject([
+      {
+        slackUserId: "U_SLACK_USER",
+        vm0UserId: fixture.userId,
+        dmWelcomeSent: true,
+      },
+    ]);
+    expect(body.recent_runs).toMatchObject([
+      {
+        id: fixture.runId,
+        status: "completed",
+        triggerSource: "slack",
+        userId: fixture.userId,
+        error: "diagnostic error",
+        promptPreview: "hello from slack diagnostics",
+      },
+    ]);
+    expect(body.org_metadata).toStrictEqual({
+      orgId: fixture.orgId,
+      defaultAgentId: fixture.composeId,
+      credits: 1234,
+      tier: "pro",
+    });
+    expect(body.default_agent).toStrictEqual({
+      id: fixture.composeId,
+      name: "slack-agent",
+      orgId: fixture.orgId,
+    });
+    expect(body.default_compose).toStrictEqual({
+      id: fixture.composeId,
+      name: "e2e-slack-agent",
+      headVersionId: fixture.versionId,
+    });
+    expect(body.default_compose_version).toStrictEqual({
+      id: fixture.versionId,
+      content_keys: ["env", "prompts"],
+    });
+    expect(body.mock_calls.slice(0, 2)).toMatchObject([
+      {
+        method: fixture.mockCallMethods[0],
+        teamId: fixture.teamId,
+        channelId: "C_NEWER",
+        bodyJson: { text: "newer" },
+      },
+      {
+        method: fixture.mockCallMethods[1],
+        teamId: fixture.teamId,
+        channelId: "C_OLDER",
+        bodyJson: { text: "older" },
+      },
+    ]);
+  });
+});

--- a/turbo/apps/api/src/signals/routes/test-slack-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-slack-state.ts
@@ -1,0 +1,284 @@
+import { computed } from "ccstate";
+import { testSlackStateContract } from "@vm0/api-contracts/contracts/test-slack-state";
+import {
+  agentComposes,
+  agentComposeVersions,
+} from "@vm0/db/schema/agent-compose";
+import { agentRuns } from "@vm0/db/schema/agent-run";
+import { e2eSlackMockCallLog } from "@vm0/db/schema/e2e-slack-mock-call-log";
+import { orgMetadata } from "@vm0/db/schema/org-metadata";
+import { slackOrgConnections } from "@vm0/db/schema/slack-org-connection";
+import { slackOrgInstallations } from "@vm0/db/schema/slack-org-installation";
+import { zeroAgents } from "@vm0/db/schema/zero-agent";
+import { zeroRuns } from "@vm0/db/schema/zero-run";
+import { desc, eq, sql } from "drizzle-orm";
+
+import { optionalEnv } from "../../lib/env";
+import { queryOf } from "../context/request";
+import { request$ } from "../context/hono";
+import { db$, type ReadonlyDb } from "../external/db";
+import type { RouteEntry } from "../route";
+import {
+  isTestEndpointAllowed,
+  testEndpointNotFoundResponse,
+} from "./test-oauth-provider-helpers";
+
+function isoString(value: Date): string {
+  return value.toISOString();
+}
+
+function contentKeys(value: unknown): string[] {
+  if (value && typeof value === "object") {
+    return Object.keys(value);
+  }
+  return [];
+}
+
+function resolvedSlackApiUrl(): string | null {
+  const slackApiUrl = optionalEnv("SLACK_API_URL");
+  if (slackApiUrl) {
+    return slackApiUrl;
+  }
+
+  const flag = optionalEnv("E2E_SLACK_MOCK_ENABLED");
+  const mockEnabled = flag === "1" || flag === "true";
+  const vercelUrl = optionalEnv("VERCEL_URL");
+  if (mockEnabled && vercelUrl) {
+    return `https://${vercelUrl}/api/test/slack-mock/`;
+  }
+
+  return null;
+}
+
+async function slackInstallation(db: ReadonlyDb, teamId: string) {
+  return (
+    (
+      await db
+        .select({
+          slackWorkspaceId: slackOrgInstallations.slackWorkspaceId,
+          slackWorkspaceName: slackOrgInstallations.slackWorkspaceName,
+          orgId: slackOrgInstallations.orgId,
+          botUserId: slackOrgInstallations.botUserId,
+          installedByUserId: slackOrgInstallations.installedByUserId,
+          createdAt: slackOrgInstallations.createdAt,
+        })
+        .from(slackOrgInstallations)
+        .where(eq(slackOrgInstallations.slackWorkspaceId, teamId))
+        .limit(1)
+    )[0] ?? null
+  );
+}
+
+function slackConnections(db: ReadonlyDb, teamId: string) {
+  return db
+    .select({
+      id: slackOrgConnections.id,
+      slackUserId: slackOrgConnections.slackUserId,
+      vm0UserId: slackOrgConnections.vm0UserId,
+      dmWelcomeSent: slackOrgConnections.dmWelcomeSent,
+      createdAt: slackOrgConnections.createdAt,
+    })
+    .from(slackOrgConnections)
+    .where(eq(slackOrgConnections.slackWorkspaceId, teamId));
+}
+
+function recentSlackRuns(db: ReadonlyDb, orgId: string | null | undefined) {
+  if (!orgId) {
+    return [];
+  }
+
+  return db
+    .select({
+      id: agentRuns.id,
+      status: agentRuns.status,
+      createdAt: agentRuns.createdAt,
+      triggerSource: zeroRuns.triggerSource,
+      userId: agentRuns.userId,
+      error: agentRuns.error,
+      promptPreview: sql<string>`substring(${agentRuns.prompt}, 1, 200)`,
+    })
+    .from(agentRuns)
+    .leftJoin(zeroRuns, eq(agentRuns.id, zeroRuns.id))
+    .where(eq(agentRuns.orgId, orgId))
+    .orderBy(desc(agentRuns.createdAt))
+    .limit(50);
+}
+
+async function orgMetaFor(db: ReadonlyDb, orgId: string | null | undefined) {
+  if (!orgId) {
+    return null;
+  }
+
+  return (
+    (
+      await db
+        .select({
+          orgId: orgMetadata.orgId,
+          defaultAgentId: orgMetadata.defaultAgentId,
+          credits: orgMetadata.credits,
+          tier: orgMetadata.tier,
+        })
+        .from(orgMetadata)
+        .where(eq(orgMetadata.orgId, orgId))
+        .limit(1)
+    )[0] ?? null
+  );
+}
+
+async function defaultAgentFor(
+  db: ReadonlyDb,
+  defaultAgentId: string | null | undefined,
+) {
+  if (!defaultAgentId) {
+    return null;
+  }
+
+  return (
+    (
+      await db
+        .select({
+          id: zeroAgents.id,
+          name: zeroAgents.name,
+          orgId: zeroAgents.orgId,
+        })
+        .from(zeroAgents)
+        .where(eq(zeroAgents.id, defaultAgentId))
+        .limit(1)
+    )[0] ?? null
+  );
+}
+
+async function defaultComposeFor(
+  db: ReadonlyDb,
+  defaultAgentId: string | null | undefined,
+) {
+  if (!defaultAgentId) {
+    return null;
+  }
+
+  return (
+    (
+      await db
+        .select({
+          id: agentComposes.id,
+          name: agentComposes.name,
+          headVersionId: agentComposes.headVersionId,
+        })
+        .from(agentComposes)
+        .where(eq(agentComposes.id, defaultAgentId))
+        .limit(1)
+    )[0] ?? null
+  );
+}
+
+async function defaultComposeVersionFor(
+  db: ReadonlyDb,
+  headVersionId: string | null | undefined,
+) {
+  if (!headVersionId) {
+    return null;
+  }
+
+  return (
+    (
+      await db
+        .select({
+          id: agentComposeVersions.id,
+          content: agentComposeVersions.content,
+        })
+        .from(agentComposeVersions)
+        .where(eq(agentComposeVersions.id, headVersionId))
+        .limit(1)
+    )[0] ?? null
+  );
+}
+
+function recentMockCalls(db: ReadonlyDb) {
+  return db
+    .select({
+      method: e2eSlackMockCallLog.method,
+      teamId: e2eSlackMockCallLog.teamId,
+      channelId: e2eSlackMockCallLog.channelId,
+      bodyJson: e2eSlackMockCallLog.bodyJson,
+      createdAt: e2eSlackMockCallLog.createdAt,
+    })
+    .from(e2eSlackMockCallLog)
+    .orderBy(desc(e2eSlackMockCallLog.createdAt))
+    .limit(50);
+}
+
+const getSlackState$ = computed(async (get) => {
+  const request = get(request$);
+  if (!isTestEndpointAllowed(request)) {
+    return testEndpointNotFoundResponse();
+  }
+
+  const query = get(queryOf(testSlackStateContract.get));
+  if (!query.team_id) {
+    return {
+      status: 400 as const,
+      body: { error: "team_id query param is required" },
+    };
+  }
+
+  const db = get(db$);
+  const teamId = query.team_id;
+  const installationRow = await slackInstallation(db, teamId);
+  const connections = await slackConnections(db, teamId);
+  const recentRuns = await recentSlackRuns(db, installationRow?.orgId);
+  const orgMeta = await orgMetaFor(db, installationRow?.orgId);
+  const defaultAgent = await defaultAgentFor(db, orgMeta?.defaultAgentId);
+  const compose = await defaultComposeFor(db, orgMeta?.defaultAgentId);
+  const composeVersion = await defaultComposeVersionFor(
+    db,
+    compose?.headVersionId,
+  );
+  const mockCalls = await recentMockCalls(db);
+
+  return {
+    status: 200 as const,
+    body: {
+      installation: installationRow
+        ? {
+            ...installationRow,
+            createdAt: isoString(installationRow.createdAt),
+          }
+        : null,
+      connections: connections.map((connection) => {
+        return {
+          ...connection,
+          createdAt: isoString(connection.createdAt),
+        };
+      }),
+      recent_runs: recentRuns.map((run) => {
+        return {
+          ...run,
+          createdAt: isoString(run.createdAt),
+        };
+      }),
+      org_metadata: orgMeta,
+      default_agent: defaultAgent,
+      default_compose: compose,
+      default_compose_version: composeVersion
+        ? {
+            id: composeVersion.id,
+            content_keys: contentKeys(composeVersion.content),
+          }
+        : null,
+      resolved_slack_api_url: resolvedSlackApiUrl(),
+      mock_calls: mockCalls.map((call) => {
+        return {
+          ...call,
+          createdAt: isoString(call.createdAt),
+        };
+      }),
+    },
+  };
+});
+
+export const testSlackStateRoutes: readonly RouteEntry[] = [
+  {
+    route: testSlackStateContract.get,
+    handler: getSlackState$,
+  },
+];

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -229,6 +229,13 @@ export {
   type TestOAuthProviderUserinfoResponse,
 } from "./test-oauth-provider-userinfo";
 export {
+  testSlackStateContract,
+  testSlackStateErrorSchema,
+  testSlackStateResponseSchema,
+  type TestSlackStateContract,
+  type TestSlackStateResponse,
+} from "./test-slack-state";
+export {
   testTelegramStateContract,
   testTelegramStateErrorSchema,
   testTelegramStateResponseSchema,

--- a/turbo/packages/api-contracts/src/contracts/test-slack-state.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-slack-state.ts
@@ -1,0 +1,103 @@
+import { z } from "zod";
+
+import { initContract } from "./base";
+
+const c = initContract();
+
+export const testSlackStateErrorSchema = z.object({
+  error: z.string(),
+});
+
+const nullableDateStringSchema = z.string().nullable();
+
+export const testSlackStateResponseSchema = z.object({
+  installation: z
+    .object({
+      slackWorkspaceId: z.string(),
+      slackWorkspaceName: z.string().nullable(),
+      orgId: z.string().nullable(),
+      botUserId: z.string(),
+      installedByUserId: z.string().nullable(),
+      createdAt: z.string(),
+    })
+    .nullable(),
+  connections: z.array(
+    z.object({
+      id: z.string(),
+      slackUserId: z.string(),
+      vm0UserId: z.string(),
+      dmWelcomeSent: z.boolean(),
+      createdAt: z.string(),
+    }),
+  ),
+  recent_runs: z.array(
+    z.object({
+      id: z.string(),
+      status: z.string(),
+      createdAt: z.string(),
+      triggerSource: z.string().nullable(),
+      userId: z.string(),
+      error: z.string().nullable(),
+      promptPreview: z.string().nullable(),
+    }),
+  ),
+  org_metadata: z
+    .object({
+      orgId: z.string(),
+      defaultAgentId: z.string().nullable(),
+      credits: z.number(),
+      tier: z.string(),
+    })
+    .nullable(),
+  default_agent: z
+    .object({
+      id: z.string(),
+      name: z.string(),
+      orgId: z.string(),
+    })
+    .nullable(),
+  default_compose: z
+    .object({
+      id: z.string(),
+      name: z.string(),
+      headVersionId: z.string().nullable(),
+    })
+    .nullable(),
+  default_compose_version: z
+    .object({
+      id: z.string(),
+      content_keys: z.array(z.string()),
+    })
+    .nullable(),
+  resolved_slack_api_url: z.string().nullable(),
+  mock_calls: z.array(
+    z.object({
+      method: z.string(),
+      teamId: z.string().nullable(),
+      channelId: z.string().nullable(),
+      bodyJson: z.unknown(),
+      createdAt: nullableDateStringSchema,
+    }),
+  ),
+});
+
+export const testSlackStateContract = c.router({
+  get: {
+    method: "GET",
+    path: "/api/test/slack-state",
+    query: z.object({
+      team_id: z.string().optional(),
+    }),
+    responses: {
+      200: testSlackStateResponseSchema,
+      400: testSlackStateErrorSchema,
+      404: z.string(),
+    },
+    summary: "Read Slack e2e diagnostic state for a test workspace",
+  },
+});
+
+export type TestSlackStateContract = typeof testSlackStateContract;
+export type TestSlackStateResponse = z.infer<
+  typeof testSlackStateResponseSchema
+>;


### PR DESCRIPTION
## Summary

- Add a ts-rest contract and API route for `GET /api/test/slack-state`
- Mirror the legacy web diagnostic response using read-only API database access
- Add API integration coverage for guard behavior, validation, empty state, populated Slack diagnostics, mock URL resolution, and mock call ordering

Closes #12829

## Tests

- `scripts/prepare.sh`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/test-slack-state.test.ts`
- `pnpm -F api lint`
- `pnpm check-types`
- `pnpm exec prettier --check packages/api-contracts/src/contracts/test-slack-state.ts apps/api/src/signals/routes/test-slack-state.ts apps/api/src/signals/routes/__tests__/test-slack-state.test.ts packages/api-contracts/src/contracts/index.ts apps/api/src/signals/route.ts`
- `git diff --check`
