### PR TITLE
refactor: make guest-download scheduling slot-based

### DIFF
--- a/crates/guest-download/src/download.rs
+++ b/crates/guest-download/src/download.rs
@@ -3,13 +3,18 @@ use crate::archive;
 use crate::error::DownloadError;
 use crate::source;
 use guest_common::{log_error, log_info, log_warn, telemetry::record_sandbox_op};
+use std::any::Any;
+use std::collections::VecDeque;
 use std::fs;
+use std::path::{Component, Path, PathBuf};
+use std::sync::mpsc;
 use std::thread;
 use std::time::{Duration, Instant};
 
 const MAX_RETRIES: u32 = 3;
 const RETRY_DELAY: Duration = Duration::from_secs(1);
 const MAX_CONCURRENT: usize = 4;
+type TaskRunner = fn(DownloadTask) -> bool;
 
 #[derive(Debug, PartialEq, Eq)]
 pub(crate) struct DownloadTask {
@@ -43,10 +48,29 @@ impl DownloadTask {
     }
 }
 
+struct ActiveDownload {
+    id: usize,
+    mount_path: PathBuf,
+}
+
+struct DownloadCompletion {
+    id: usize,
+    outcome: DownloadOutcome,
+}
+
+enum DownloadOutcome {
+    Finished(bool),
+    Panicked(String),
+}
+
 /// Download all tasks in parallel using std::thread.
-/// Limits concurrency to MAX_CONCURRENT to avoid spawning too many threads.
+/// Limits concurrency to MAX_CONCURRENT and serializes overlapping mount paths.
 /// Returns true if all downloads succeeded, false if any failed.
 pub(crate) fn download_all_parallel(tasks: Vec<DownloadTask>) -> bool {
+    download_all_parallel_with_runner(tasks, run_download_task)
+}
+
+fn download_all_parallel_with_runner(tasks: Vec<DownloadTask>, task_runner: TaskRunner) -> bool {
     if tasks.is_empty() {
         return true;
     }
@@ -58,80 +82,173 @@ pub(crate) fn download_all_parallel(tasks: Vec<DownloadTask>) -> bool {
         MAX_CONCURRENT
     );
 
-    let mut all_success = true;
-    let mut tasks = tasks;
+    thread::scope(|scope| {
+        let (completion_tx, completion_rx) = mpsc::channel();
+        let mut pending = VecDeque::from(tasks);
+        let mut active = Vec::new();
+        let mut next_id = 0;
+        let mut all_success = true;
 
-    // Process in chunks to limit concurrency
-    while !tasks.is_empty() {
-        let chunk: Vec<_> = tasks.drain(..tasks.len().min(MAX_CONCURRENT)).collect();
+        start_ready_downloads(
+            scope,
+            &mut pending,
+            &mut active,
+            &completion_tx,
+            &mut next_id,
+            task_runner,
+        );
 
-        let handles: Vec<_> = chunk
-            .into_iter()
-            .map(|task| {
-                thread::spawn(move || {
-                    let start = Instant::now();
-                    log_info!(
-                        LOG_TAG,
-                        "Downloading {} from {} to {}",
-                        task.label,
-                        task.url,
-                        task.mount_path
-                    );
+        while !active.is_empty() {
+            let completion = match completion_rx.recv() {
+                Ok(completion) => completion,
+                Err(e) => {
+                    log_error!(LOG_TAG, "Download scheduler failed: {e}");
+                    return false;
+                }
+            };
 
-                    match download_with_retry(&task.url, &task.mount_path) {
-                        Ok(()) => {
-                            let elapsed = start.elapsed();
-                            record_sandbox_op(task.op_name, elapsed, true, None);
-                            log_info!(
-                                LOG_TAG,
-                                "{} downloaded in {}ms",
-                                task.label,
-                                elapsed.as_millis()
-                            );
-                            true
-                        }
-                        Err(e) if e.status_code == Some(404) && task.allow_404 => {
-                            record_sandbox_op(task.op_name, start.elapsed(), true, None);
-                            log_info!(LOG_TAG, "{} not found, skipping (first run)", task.label);
-                            true
-                        }
-                        Err(e) => {
-                            record_sandbox_op(
-                                task.op_name,
-                                start.elapsed(),
-                                false,
-                                Some(&e.message),
-                            );
-                            log_error!(LOG_TAG, "{} download failed: {}", task.label, e);
-                            false
-                        }
-                    }
-                })
-            })
-            .collect();
+            active.retain(|download| download.id != completion.id);
 
-        // Wait for this chunk to complete before starting next
-        for handle in handles {
-            match handle.join() {
-                Ok(success) => {
+            match completion.outcome {
+                DownloadOutcome::Finished(success) => {
                     if !success {
                         all_success = false;
                     }
                 }
-                Err(e) => {
-                    let msg = e
-                        .downcast_ref::<String>()
-                        .map(String::as_str)
-                        .or_else(|| e.downcast_ref::<&str>().copied())
-                        .unwrap_or("unknown");
+                DownloadOutcome::Panicked(msg) => {
                     log_error!(LOG_TAG, "Thread panicked: {msg}");
                     all_success = false;
                 }
             }
+
+            start_ready_downloads(
+                scope,
+                &mut pending,
+                &mut active,
+                &completion_tx,
+                &mut next_id,
+                task_runner,
+            );
+        }
+
+        all_success && pending.is_empty()
+    })
+}
+
+fn start_ready_downloads<'scope, 'env: 'scope>(
+    scope: &'scope thread::Scope<'scope, 'env>,
+    pending: &mut VecDeque<DownloadTask>,
+    active: &mut Vec<ActiveDownload>,
+    completion_tx: &mpsc::Sender<DownloadCompletion>,
+    next_id: &mut usize,
+    task_runner: TaskRunner,
+) {
+    while active.len() < MAX_CONCURRENT {
+        let Some((index, mount_path)) = find_startable_download(pending, active) else {
+            break;
+        };
+        let Some(task) = pending.remove(index) else {
+            log_error!(LOG_TAG, "Download scheduler selected a missing task");
+            break;
+        };
+        let id = *next_id;
+        *next_id += 1;
+        active.push(ActiveDownload { id, mount_path });
+
+        let completion_tx = completion_tx.clone();
+        scope.spawn(move || {
+            let outcome = std::panic::catch_unwind(|| task_runner(task))
+                .map(DownloadOutcome::Finished)
+                .unwrap_or_else(|e| DownloadOutcome::Panicked(panic_message(e.as_ref())));
+
+            let _ = completion_tx.send(DownloadCompletion { id, outcome });
+        });
+    }
+}
+
+fn find_startable_download(
+    pending: &VecDeque<DownloadTask>,
+    active: &[ActiveDownload],
+) -> Option<(usize, PathBuf)> {
+    pending.iter().enumerate().find_map(|(index, task)| {
+        let mount_path = normalize_mount_path(task.mount_path());
+        let has_conflict = active.iter().any(|download| {
+            mount_paths_conflict(mount_path.as_path(), download.mount_path.as_path())
+        });
+
+        (!has_conflict).then_some((index, mount_path))
+    })
+}
+
+fn normalize_mount_path(path: &str) -> PathBuf {
+    let mut components = Vec::new();
+
+    for component in Path::new(path).components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => match components.last() {
+                Some(Component::Normal(_)) => {
+                    components.pop();
+                }
+                Some(Component::RootDir | Component::Prefix(_)) => {}
+                _ => components.push(component),
+            },
+            _ => components.push(component),
         }
     }
 
-    all_success
+    let mut normalized = PathBuf::new();
+    for component in components {
+        normalized.push(component.as_os_str());
+    }
+    normalized
+}
+
+fn mount_paths_conflict(left: &Path, right: &Path) -> bool {
+    left.starts_with(right) || right.starts_with(left)
+}
+
+fn panic_message(payload: &(dyn Any + Send)) -> String {
+    payload
+        .downcast_ref::<String>()
+        .cloned()
+        .or_else(|| payload.downcast_ref::<&str>().map(|msg| (*msg).to_owned()))
+        .unwrap_or_else(|| "unknown".to_owned())
+}
+
+fn run_download_task(task: DownloadTask) -> bool {
+    let start = Instant::now();
+    log_info!(
+        LOG_TAG,
+        "Downloading {} from {} to {}",
+        task.label,
+        task.url,
+        task.mount_path
+    );
+
+    match download_with_retry(&task.url, &task.mount_path) {
+        Ok(()) => {
+            let elapsed = start.elapsed();
+            record_sandbox_op(task.op_name, elapsed, true, None);
+            log_info!(
+                LOG_TAG,
+                "{} downloaded in {}ms",
+                task.label,
+                elapsed.as_millis()
+            );
+            true
+        }
+        Err(e) if e.status_code == Some(404) && task.allow_404 => {
+            record_sandbox_op(task.op_name, start.elapsed(), true, None);
+            log_info!(LOG_TAG, "{} not found, skipping (first run)", task.label);
+            true
+        }
+        Err(e) => {
+            record_sandbox_op(task.op_name, start.elapsed(), false, Some(&e.message));
+            log_error!(LOG_TAG, "{} download failed: {}", task.label, e);
+            false
+        }
+    }
 }
 
 fn download_with_retry(url: &str, target_path: &str) -> Result<(), DownloadError> {
@@ -164,4 +281,85 @@ fn download_and_extract(url: &str, target_path: &str) -> Result<(), DownloadErro
 
     let reader = source::open_archive(url)?;
     archive::extract_tar_gz(reader, target_path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mount_paths_conflict_for_exact_and_parent_child_paths() {
+        assert!(mount_paths_conflict(
+            &normalize_mount_path("/tmp/mount"),
+            &normalize_mount_path("/tmp/mount")
+        ));
+        assert!(mount_paths_conflict(
+            &normalize_mount_path("/tmp/mount"),
+            &normalize_mount_path("/tmp/mount/child")
+        ));
+        assert!(mount_paths_conflict(
+            &normalize_mount_path("/tmp/mount/child"),
+            &normalize_mount_path("/tmp/mount")
+        ));
+    }
+
+    #[test]
+    fn mount_paths_do_not_conflict_for_siblings_or_prefix_traps() {
+        assert!(!mount_paths_conflict(
+            &normalize_mount_path("/tmp/mount-a"),
+            &normalize_mount_path("/tmp/mount-b")
+        ));
+        assert!(!mount_paths_conflict(
+            &normalize_mount_path("/tmp/foo/bar"),
+            &normalize_mount_path("/tmp/foo/barista")
+        ));
+    }
+
+    #[test]
+    fn mount_path_conflicts_use_lexical_normalization() {
+        assert!(mount_paths_conflict(
+            &normalize_mount_path("/tmp//foo/./bar/baz/.."),
+            &normalize_mount_path("/tmp/foo/bar")
+        ));
+        assert!(!mount_paths_conflict(
+            &normalize_mount_path("/tmp/foo/bar/../barista"),
+            &normalize_mount_path("/tmp/foo/bar")
+        ));
+    }
+
+    #[test]
+    fn task_panic_returns_false_without_unwinding() {
+        guest_common::log::clear_system_log_file();
+
+        fn runner(task: DownloadTask) -> bool {
+            if task.url == "panic" {
+                panic!("expected panic");
+            }
+            true
+        }
+
+        let result = std::panic::catch_unwind(|| {
+            download_all_parallel_with_runner(
+                vec![
+                    DownloadTask::new(
+                        "panic".to_owned(),
+                        "storage_download",
+                        "panic".to_owned(),
+                        "/tmp/panic".to_owned(),
+                        false,
+                    ),
+                    DownloadTask::new(
+                        "success".to_owned(),
+                        "storage_download",
+                        "success".to_owned(),
+                        "/tmp/success".to_owned(),
+                        false,
+                    ),
+                ],
+                runner,
+            )
+        });
+
+        assert!(matches!(result, Ok(false)));
+    }
 }

--- a/crates/guest-download/src/lib.rs
+++ b/crates/guest-download/src/lib.rs
@@ -50,9 +50,9 @@ pub fn run(manifest_path: &str) -> bool {
         cleanup::cleanup_stale_paths(&cleanup_paths, &preserved_paths);
     }
 
-    // Pre-create all target directories before parallel downloads.
-    // This avoids races between parent-child mount paths (e.g. /home/user/.claude
-    // and /home/user/.claude/skills/foo) when they land in the same concurrent chunk.
+    // Pre-create all target directories before downloads. This keeps directory
+    // creation independent from scheduler order; overlapping mount paths are
+    // serialized by the download scheduler during extraction.
     for task in &download_tasks {
         let mount_path = task.mount_path();
         if let Err(e) = fs::create_dir_all(mount_path) {

--- a/crates/guest-download/tests/integration.rs
+++ b/crates/guest-download/tests/integration.rs
@@ -241,13 +241,53 @@ fn wait_for_event(
     }
 }
 
+fn wait_for_events(
+    receiver: &mpsc::Receiver<String>,
+    count: usize,
+    timeout: Duration,
+) -> Result<Vec<String>, String> {
+    let deadline = Instant::now() + timeout;
+    let mut events = Vec::new();
+
+    while events.len() < count {
+        let now = Instant::now();
+        if now >= deadline {
+            return Err(format!(
+                "timed out waiting for {count} events, got {}",
+                events.len()
+            ));
+        }
+
+        match receiver.recv_timeout(deadline - now) {
+            Ok(event) => events.push(event),
+            Err(mpsc::RecvTimeoutError::Timeout) => {
+                return Err(format!(
+                    "timed out waiting for {count} events, got {}",
+                    events.len()
+                ));
+            }
+            Err(mpsc::RecvTimeoutError::Disconnected) => {
+                return Err(format!(
+                    "event channel closed after {} of {count} events",
+                    events.len()
+                ));
+            }
+        }
+    }
+
+    Ok(events)
+}
+
 struct ReleaseOnDrop {
     sender: mpsc::Sender<()>,
+    count: usize,
 }
 
 impl Drop for ReleaseOnDrop {
     fn drop(&mut self) {
-        let _ = self.sender.send(());
+        for _ in 0..self.count {
+            let _ = self.sender.send(());
+        }
     }
 }
 
@@ -583,6 +623,7 @@ fn queued_independent_download_starts_when_slot_frees() {
     let (slow_release_tx, slow_release_rx) = mpsc::channel();
     let _slow_release_guard = ReleaseOnDrop {
         sender: slow_release_tx.clone(),
+        count: 1,
     };
     let slow_release_rx = Arc::new(Mutex::new(slow_release_rx));
     let active = Arc::new(AtomicUsize::new(0));
@@ -665,6 +706,71 @@ fn queued_independent_download_starts_when_slot_frees() {
 }
 
 #[test]
+fn download_concurrency_cap_limits_initial_starts() {
+    let dir = tempfile::tempdir().unwrap();
+    let (event_tx, event_rx) = mpsc::channel();
+    let (release_tx, release_rx) = mpsc::channel();
+    let _release_guard = ReleaseOnDrop {
+        sender: release_tx.clone(),
+        count: 5,
+    };
+    let release_rx = Arc::new(Mutex::new(release_rx));
+    let mut servers = Vec::new();
+    let mut storages = Vec::new();
+
+    for i in 0..5 {
+        let server = MockServer::start();
+        let filename = format!("file_{i}.txt");
+        let content = format!("content_{i}");
+        let body = Arc::new(create_tar_gz(&[(&filename, content.as_bytes())]).unwrap());
+        let event_tx = event_tx.clone();
+        let release_rx = Arc::clone(&release_rx);
+
+        server.mock(move |when, then| {
+            when.method(GET).path("/storage.tar.gz");
+            then.respond_with(move |_req: &HttpMockRequest| {
+                let _ = event_tx.send(format!("start-{i}"));
+                release_rx
+                    .lock()
+                    .unwrap()
+                    .recv_timeout(Duration::from_secs(10))
+                    .expect("timed out waiting to release blocked request");
+                gzip_response((*body).clone())
+            });
+        });
+
+        let mount = dir.path().join(format!("mount_{i}"));
+        storages.push((
+            mount.to_str().unwrap().to_owned(),
+            server.url("/storage.tar.gz"),
+        ));
+        servers.push(server);
+    }
+
+    let storage_refs: Vec<(&str, Option<&str>)> = storages
+        .iter()
+        .map(|(mount, url)| (mount.as_str(), Some(url.as_str())))
+        .collect();
+    let manifest = write_manifest(&dir, &storage_refs, None).unwrap();
+    let manifest_path = manifest.to_str().unwrap().to_owned();
+    let handle = std::thread::spawn(move || run_guest_download(&manifest_path));
+
+    let initial_starts = wait_for_events(&event_rx, 4, Duration::from_secs(5));
+    let fifth_before_release = event_rx.recv_timeout(Duration::from_millis(300));
+    for _ in 0..5 {
+        release_tx.send(()).unwrap();
+    }
+    let result = handle.join().unwrap();
+
+    assert_eq!(initial_starts.unwrap().len(), 4);
+    assert!(matches!(
+        fifth_before_release,
+        Err(mpsc::RecvTimeoutError::Timeout)
+    ));
+    assert!(result);
+}
+
+#[test]
 fn parent_child_mount_paths_are_serialized_for_overlapping_archives() {
     let parent_server = MockServer::start();
     let child_server = MockServer::start();
@@ -682,6 +788,7 @@ fn parent_child_mount_paths_are_serialized_for_overlapping_archives() {
     let (parent_release_tx, parent_release_rx) = mpsc::channel();
     let _parent_release_guard = ReleaseOnDrop {
         sender: parent_release_tx.clone(),
+        count: 1,
     };
     let parent_release_rx = Arc::new(Mutex::new(parent_release_rx));
 

--- a/crates/guest-download/tests/integration.rs
+++ b/crates/guest-download/tests/integration.rs
@@ -1,9 +1,12 @@
 use flate2::Compression;
 use flate2::write::GzEncoder;
 use httpmock::prelude::*;
+use httpmock::{HttpMockRequest, HttpMockResponse};
 use std::io::Write;
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex, mpsc};
+use std::time::{Duration, Instant};
 use tempfile::TempDir;
 
 static RUN_ID_COUNTER: AtomicU64 = AtomicU64::new(0);
@@ -171,6 +174,81 @@ fn unique_run_id(test_name: &str) -> String {
         std::process::id(),
         RUN_ID_COUNTER.fetch_add(1, Ordering::Relaxed)
     )
+}
+
+fn gzip_response(body: Vec<u8>) -> HttpMockResponse {
+    HttpMockResponse::builder()
+        .status(200)
+        .header("content-type", "application/gzip")
+        .body(body)
+        .build()
+}
+
+struct ActiveRequestGuard {
+    active: Arc<AtomicUsize>,
+}
+
+impl Drop for ActiveRequestGuard {
+    fn drop(&mut self) {
+        self.active.fetch_sub(1, Ordering::SeqCst);
+    }
+}
+
+fn track_active_request(
+    active: &Arc<AtomicUsize>,
+    max_active: &Arc<AtomicUsize>,
+) -> ActiveRequestGuard {
+    let current = active.fetch_add(1, Ordering::SeqCst) + 1;
+    let mut observed = max_active.load(Ordering::SeqCst);
+    while current > observed {
+        match max_active.compare_exchange(observed, current, Ordering::SeqCst, Ordering::SeqCst) {
+            Ok(_) => break,
+            Err(actual) => observed = actual,
+        }
+    }
+
+    ActiveRequestGuard {
+        active: Arc::clone(active),
+    }
+}
+
+fn wait_for_event(
+    receiver: &mpsc::Receiver<String>,
+    seen: &mut Vec<String>,
+    expected: &str,
+    timeout: Duration,
+) -> Result<(), String> {
+    if seen.iter().any(|event| event == expected) {
+        return Ok(());
+    }
+
+    let deadline = Instant::now() + timeout;
+    loop {
+        let now = Instant::now();
+        if now >= deadline {
+            return Err(format!("timed out waiting for event {expected}"));
+        }
+        match receiver.recv_timeout(deadline - now) {
+            Ok(event) if event == expected => return Ok(()),
+            Ok(event) => seen.push(event),
+            Err(mpsc::RecvTimeoutError::Timeout) => {
+                return Err(format!("timed out waiting for event {expected}"));
+            }
+            Err(mpsc::RecvTimeoutError::Disconnected) => {
+                return Err(format!("event channel closed before {expected}"));
+            }
+        }
+    }
+}
+
+struct ReleaseOnDrop {
+    sender: mpsc::Sender<()>,
+}
+
+impl Drop for ReleaseOnDrop {
+    fn drop(&mut self) {
+        let _ = self.sender.send(());
+    }
 }
 
 struct RunFileCleanup {
@@ -365,7 +443,7 @@ fn single_storage_download() {
 }
 
 // ---------------------------------------------------------------------------
-// Test 2: 6 storages downloaded in parallel (exercises chunking)
+// Test 2: 6 storages downloaded with bounded parallelism
 // ---------------------------------------------------------------------------
 #[test]
 fn six_storages_parallel() {
@@ -415,12 +493,12 @@ fn six_storages_parallel() {
 }
 
 // ---------------------------------------------------------------------------
-// Test 2b: parent-child mount paths in same concurrent chunk
+// Test 2b: parent-child mount paths download successfully
 // Regression test: storages with overlapping paths (e.g. /home/user/.claude and
-// /home/user/.claude/skills/foo) must not race on directory creation.
+// /home/user/.claude/skills/foo) must remain valid when scheduled safely.
 // ---------------------------------------------------------------------------
 #[test]
-fn parent_child_mount_paths_parallel() {
+fn parent_child_mount_paths_download_successfully() {
     let server = MockServer::start();
     let dir = tempfile::tempdir().unwrap();
 
@@ -454,8 +532,6 @@ fn parent_child_mount_paths_parallel() {
             .body(&child_c_tar);
     });
 
-    // 4 tasks fill one concurrent chunk (MAX_CONCURRENT=4), ensuring parent
-    // and children are truly downloaded in parallel.
     let parent_mount = dir.path().join("claude");
     let child_a_mount = dir.path().join("claude/skills/alpha");
     let child_b_mount = dir.path().join("claude/skills/beta");
@@ -497,6 +573,176 @@ fn parent_child_mount_paths_parallel() {
     assert_eq!(
         std::fs::read_to_string(child_c_mount.join("skill.json")).unwrap(),
         "skill c"
+    );
+}
+
+#[test]
+fn queued_independent_download_starts_when_slot_frees() {
+    let dir = tempfile::tempdir().unwrap();
+    let (event_tx, event_rx) = mpsc::channel();
+    let (slow_release_tx, slow_release_rx) = mpsc::channel();
+    let _slow_release_guard = ReleaseOnDrop {
+        sender: slow_release_tx.clone(),
+    };
+    let slow_release_rx = Arc::new(Mutex::new(slow_release_rx));
+    let active = Arc::new(AtomicUsize::new(0));
+    let max_active = Arc::new(AtomicUsize::new(0));
+
+    let mut servers = Vec::new();
+    let mut storages = Vec::new();
+
+    for i in 0..5 {
+        let server = MockServer::start();
+        let filename = format!("file_{i}.txt");
+        let content = format!("content_{i}");
+        let body = Arc::new(create_tar_gz(&[(&filename, content.as_bytes())]).unwrap());
+        let event_tx = event_tx.clone();
+        let active = Arc::clone(&active);
+        let max_active = Arc::clone(&max_active);
+        let slow_release_rx = Arc::clone(&slow_release_rx);
+
+        server.mock(move |when, then| {
+            when.method(GET).path("/storage.tar.gz");
+            then.respond_with(move |_req: &HttpMockRequest| {
+                let _active_guard = track_active_request(&active, &max_active);
+                let _ = event_tx.send(format!("start-{i}"));
+                if i == 0 {
+                    slow_release_rx
+                        .lock()
+                        .unwrap()
+                        .recv_timeout(Duration::from_secs(10))
+                        .expect("timed out waiting to release slow request");
+                }
+                gzip_response((*body).clone())
+            });
+        });
+
+        let mount = dir.path().join(format!("mount_{i}"));
+        storages.push((
+            mount.to_str().unwrap().to_owned(),
+            server.url("/storage.tar.gz"),
+        ));
+        servers.push(server);
+    }
+
+    let storage_refs: Vec<(&str, Option<&str>)> = storages
+        .iter()
+        .map(|(mount, url)| (mount.as_str(), Some(url.as_str())))
+        .collect();
+    let manifest = write_manifest(&dir, &storage_refs, None).unwrap();
+    let manifest_path = manifest.to_str().unwrap().to_owned();
+    let handle = std::thread::spawn(move || run_guest_download(&manifest_path));
+
+    let mut seen_events = Vec::new();
+    let slow_started = wait_for_event(
+        &event_rx,
+        &mut seen_events,
+        "start-0",
+        Duration::from_secs(5),
+    );
+    let queued_started = wait_for_event(
+        &event_rx,
+        &mut seen_events,
+        "start-4",
+        Duration::from_secs(5),
+    );
+    slow_release_tx.send(()).unwrap();
+    let result = handle.join().unwrap();
+
+    slow_started.unwrap();
+    queued_started.unwrap();
+    assert!(result);
+    assert!(
+        max_active.load(Ordering::SeqCst) <= 4,
+        "observed more than 4 active downloads"
+    );
+
+    for i in 0..5 {
+        let mount = dir.path().join(format!("mount_{i}"));
+        let content = std::fs::read_to_string(mount.join(format!("file_{i}.txt"))).unwrap();
+        assert_eq!(content, format!("content_{i}"));
+    }
+}
+
+#[test]
+fn parent_child_mount_paths_are_serialized_for_overlapping_archives() {
+    let parent_server = MockServer::start();
+    let child_server = MockServer::start();
+    let dir = tempfile::tempdir().unwrap();
+    let parent_mount = dir.path().join("claude");
+    let child_mount = dir.path().join("claude/skills/alpha");
+    let parent_tar = create_tar_gz(&[
+        ("config.json", b"parent config"),
+        ("skills/alpha/skill.json", b"parent skill"),
+    ])
+    .unwrap();
+    let child_tar = create_tar_gz(&[("skill.json", b"child skill")]).unwrap();
+    let (parent_started_tx, parent_started_rx) = mpsc::channel();
+    let (child_started_tx, child_started_rx) = mpsc::channel();
+    let (parent_release_tx, parent_release_rx) = mpsc::channel();
+    let _parent_release_guard = ReleaseOnDrop {
+        sender: parent_release_tx.clone(),
+    };
+    let parent_release_rx = Arc::new(Mutex::new(parent_release_rx));
+
+    let parent_release_rx_for_mock = Arc::clone(&parent_release_rx);
+    let m_parent = parent_server.mock(move |when, then| {
+        when.method(GET).path("/parent.tar.gz");
+        then.respond_with(move |_req: &HttpMockRequest| {
+            parent_started_tx.send(()).unwrap();
+            parent_release_rx_for_mock
+                .lock()
+                .unwrap()
+                .recv_timeout(Duration::from_secs(10))
+                .expect("timed out waiting to release parent request");
+            gzip_response(parent_tar.clone())
+        });
+    });
+    let m_child = child_server.mock(move |when, then| {
+        when.method(GET).path("/child.tar.gz");
+        then.respond_with(move |_req: &HttpMockRequest| {
+            child_started_tx.send(()).unwrap();
+            gzip_response(child_tar.clone())
+        });
+    });
+
+    let url_parent = parent_server.url("/parent.tar.gz");
+    let url_child = child_server.url("/child.tar.gz");
+    let storages: Vec<(&str, Option<&str>)> = vec![
+        (parent_mount.to_str().unwrap(), Some(&url_parent)),
+        (child_mount.to_str().unwrap(), Some(&url_child)),
+    ];
+    let manifest = write_manifest(&dir, &storages, None).unwrap();
+    let manifest_path = manifest.to_str().unwrap().to_owned();
+    let handle = std::thread::spawn(move || run_guest_download(&manifest_path));
+
+    let parent_started = parent_started_rx.recv_timeout(Duration::from_secs(5));
+    let child_before_release = child_started_rx.recv_timeout(Duration::from_millis(300));
+    parent_release_tx.send(()).unwrap();
+    let child_after_release =
+        if matches!(child_before_release, Err(mpsc::RecvTimeoutError::Timeout)) {
+            child_started_rx.recv_timeout(Duration::from_secs(5))
+        } else {
+            Ok(())
+        };
+    let result = handle.join().unwrap();
+
+    parent_started.unwrap();
+    assert!(matches!(
+        child_before_release,
+        Err(mpsc::RecvTimeoutError::Timeout)
+    ));
+    child_after_release.unwrap();
+    assert!(result);
+    m_parent.assert();
+    m_child.assert();
+    assert_eq!(
+        std::fs::read_to_string(parent_mount.join("config.json")).unwrap(),
+        "parent config"
+    );
+    assert_eq!(
+        std::fs::read_to_string(child_mount.join("skill.json")).unwrap(),
+        "child skill"
     );
 }
 

--- a/crates/guest-download/tests/integration.rs
+++ b/crates/guest-download/tests/integration.rs
@@ -771,6 +771,102 @@ fn download_concurrency_cap_limits_initial_starts() {
 }
 
 #[test]
+fn queued_conflict_does_not_block_later_independent_download() {
+    let parent_server = MockServer::start();
+    let child_server = MockServer::start();
+    let independent_server = MockServer::start();
+    let dir = tempfile::tempdir().unwrap();
+    let parent_mount = dir.path().join("claude");
+    let child_mount = dir.path().join("claude/skills/alpha");
+    let independent_mount = dir.path().join("independent");
+    let parent_tar = create_tar_gz(&[("config.json", b"parent config")]).unwrap();
+    let child_tar = create_tar_gz(&[("skill.json", b"child skill")]).unwrap();
+    let independent_tar = create_tar_gz(&[("data.txt", b"independent data")]).unwrap();
+    let (parent_started_tx, parent_started_rx) = mpsc::channel();
+    let (child_started_tx, child_started_rx) = mpsc::channel();
+    let (independent_started_tx, independent_started_rx) = mpsc::channel();
+    let (parent_release_tx, parent_release_rx) = mpsc::channel();
+    let _parent_release_guard = ReleaseOnDrop {
+        sender: parent_release_tx.clone(),
+        count: 1,
+    };
+    let parent_release_rx = Arc::new(Mutex::new(parent_release_rx));
+
+    let parent_release_rx_for_mock = Arc::clone(&parent_release_rx);
+    parent_server.mock(move |when, then| {
+        when.method(GET).path("/parent.tar.gz");
+        then.respond_with(move |_req: &HttpMockRequest| {
+            parent_started_tx.send(()).unwrap();
+            parent_release_rx_for_mock
+                .lock()
+                .unwrap()
+                .recv_timeout(Duration::from_secs(10))
+                .expect("timed out waiting to release parent request");
+            gzip_response(parent_tar.clone())
+        });
+    });
+    child_server.mock(move |when, then| {
+        when.method(GET).path("/child.tar.gz");
+        then.respond_with(move |_req: &HttpMockRequest| {
+            child_started_tx.send(()).unwrap();
+            gzip_response(child_tar.clone())
+        });
+    });
+    independent_server.mock(move |when, then| {
+        when.method(GET).path("/independent.tar.gz");
+        then.respond_with(move |_req: &HttpMockRequest| {
+            independent_started_tx.send(()).unwrap();
+            gzip_response(independent_tar.clone())
+        });
+    });
+
+    let url_parent = parent_server.url("/parent.tar.gz");
+    let url_child = child_server.url("/child.tar.gz");
+    let url_independent = independent_server.url("/independent.tar.gz");
+    let storages: Vec<(&str, Option<&str>)> = vec![
+        (parent_mount.to_str().unwrap(), Some(&url_parent)),
+        (child_mount.to_str().unwrap(), Some(&url_child)),
+        (independent_mount.to_str().unwrap(), Some(&url_independent)),
+    ];
+    let manifest = write_manifest(&dir, &storages, None).unwrap();
+    let manifest_path = manifest.to_str().unwrap().to_owned();
+    let handle = std::thread::spawn(move || run_guest_download(&manifest_path));
+
+    let parent_started = parent_started_rx.recv_timeout(Duration::from_secs(5));
+    let independent_started = independent_started_rx.recv_timeout(Duration::from_secs(5));
+    let child_before_release = child_started_rx.recv_timeout(Duration::from_millis(300));
+    parent_release_tx.send(()).unwrap();
+    let child_after_release =
+        if matches!(child_before_release, Err(mpsc::RecvTimeoutError::Timeout)) {
+            child_started_rx.recv_timeout(Duration::from_secs(5))
+        } else {
+            Ok(())
+        };
+    let result = handle.join().unwrap();
+
+    parent_started.unwrap();
+    independent_started.unwrap();
+    assert!(matches!(
+        child_before_release,
+        Err(mpsc::RecvTimeoutError::Timeout)
+    ));
+    child_after_release.unwrap();
+    assert!(result);
+    assert_eq!(
+        std::fs::read_to_string(parent_mount.join("config.json")).unwrap(),
+        "parent config"
+    );
+    assert_eq!(
+        std::fs::read_to_string(child_mount.join("skill.json")).unwrap(),
+        "child skill"
+    );
+    assert_eq!(
+        std::fs::read_to_string(independent_mount.join("data.txt")).unwrap(),
+        "independent data"
+    );
+}
+
+#[test]
 fn parent_child_mount_paths_are_serialized_for_overlapping_archives() {
     let parent_server = MockServer::start();
     let child_server = MockServer::start();


### PR DESCRIPTION
## Summary
- replace guest-download fixed chunks with a slot-based scheduler that refills freed slots immediately
- serialize equal and ancestor/descendant mount paths before extraction
- preserve per-task retry, 404, telemetry, logging, aggregate result, and panic-to-failure behavior
- add deterministic coverage for slot refill, concurrency cap, overlapping mount serialization, path prefix traps, and task panic handling

Closes #12931

## Tests
- cargo fmt --manifest-path crates/Cargo.toml --all -- --check
- cargo test --manifest-path crates/Cargo.toml -p guest-download
- cargo clippy --manifest-path crates/Cargo.toml -p guest-download --all-targets -- -D warnings
- pre-commit: cargo-fmt, cargo-clippy, cargo-doc