### PR TITLE
refactor(api): migrate zero skills create route

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-skills.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-skills.test.ts
@@ -10,6 +10,7 @@ import {
   VOLUME_ORG_USER_ID,
 } from "@vm0/core/storage-names";
 import { storages, storageVersions } from "@vm0/db/schema/storage";
+import { zeroAgents } from "@vm0/db/schema/zero-agent";
 import { zeroSkills } from "@vm0/db/schema/zero-skill";
 import { createStore } from "ccstate";
 import { and, eq } from "drizzle-orm";
@@ -177,6 +178,279 @@ function expectS3VolumeUploads(s3Key: string, versionId: string): void {
     expect.objectContaining({ path: "templates/prompt.md", size: 12 }),
   ]);
 }
+
+describe("POST /api/zero/skills", () => {
+  const track = createFixtureTracker<SkillsFixture>((fixture) => {
+    return store.set(deleteSkillsForFixture$, fixture, context.signal);
+  });
+
+  it("returns 401 when the request is unauthenticated", async () => {
+    const response = await accept(
+      listClient().create({
+        headers: {},
+        body: { name: "my-skill", files: skillFiles("# My Skill") },
+      }),
+      [401],
+    );
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("returns 401 when the authenticated session has no organization", async () => {
+    mocks.clerk.session(`user_${randomUUID()}`, null);
+
+    const response = await accept(
+      listClient().create({
+        headers: authHeaders(),
+        body: { name: "my-skill", files: skillFiles("# My Skill") },
+      }),
+      [401],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("returns 403 when an org member creates a skill", async () => {
+    const fixture = await track(
+      store.set(seedSkillsFixture$, undefined, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:member");
+
+    const response = await accept(
+      listClient().create({
+        headers: authHeaders(),
+        body: { name: "member-skill", files: skillFiles("# Member") },
+      }),
+      [403],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Only org admins can create custom skills",
+        code: "FORBIDDEN",
+      },
+    });
+  });
+
+  it("creates a skill and returns nullable metadata defaults", async () => {
+    const fixture = await track(
+      store.set(seedSkillsFixture$, undefined, context.signal),
+    );
+    context.mocks.s3.send.mockResolvedValue({});
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+
+    const response = await accept(
+      listClient().create({
+        headers: authHeaders(),
+        body: { name: "my-skill", files: skillFiles("# My Skill") },
+      }),
+      [201],
+    );
+
+    expect(response.body).toStrictEqual({
+      name: "my-skill",
+      displayName: null,
+      description: null,
+    });
+  });
+
+  it("creates a skill with metadata", async () => {
+    const fixture = await track(
+      store.set(seedSkillsFixture$, undefined, context.signal),
+    );
+    context.mocks.s3.send.mockResolvedValue({});
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+
+    const response = await accept(
+      listClient().create({
+        headers: authHeaders(),
+        body: {
+          name: "my-skill",
+          displayName: "My Skill",
+          description: "A useful skill",
+          files: skillFiles("# Content"),
+        },
+      }),
+      [201],
+    );
+
+    expect(response.body).toStrictEqual({
+      name: "my-skill",
+      displayName: "My Skill",
+      description: "A useful skill",
+    });
+  });
+
+  it("rejects duplicate skill names with 409", async () => {
+    const fixture = await track(
+      store.set(seedSkillsFixture$, undefined, context.signal),
+    );
+    await store.set(
+      seedSkill$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        name: "my-skill",
+      },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+
+    const response = await accept(
+      listClient().create({
+        headers: authHeaders(),
+        body: { name: "my-skill", files: skillFiles("# Duplicate") },
+      }),
+      [409],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: 'Skill "my-skill" already exists in this organization',
+        code: "CONFLICT",
+      },
+    });
+  });
+
+  it("rejects built-in seed skill names with 409", async () => {
+    const fixture = await track(
+      store.set(seedSkillsFixture$, undefined, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+
+    const response = await accept(
+      listClient().create({
+        headers: authHeaders(),
+        body: { name: "deep-dive", files: skillFiles("# Built in") },
+      }),
+      [409],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: 'Skill name "deep-dive" conflicts with a built-in skill',
+        code: "CONFLICT",
+      },
+    });
+  });
+
+  it("returns 400 for invalid file body", async () => {
+    const fixture = await track(
+      store.set(seedSkillsFixture$, undefined, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+
+    const response = await accept(
+      listClient().create({
+        headers: authHeaders(),
+        body: {
+          name: "invalid-skill",
+          files: [{ path: "README.md", content: "# Missing skill" }],
+        },
+      }),
+      [400],
+    );
+
+    expect(response.body.error.code).toBe("BAD_REQUEST");
+  });
+
+  it("stores the skill row and uploads a custom skill volume", async () => {
+    const fixture = await track(
+      store.set(seedSkillsFixture$, undefined, context.signal),
+    );
+    const createdAt = new Date("2026-05-12T05:00:00.000Z");
+    const skillName = "stored-skill";
+    context.mocks.s3.send.mockResolvedValue({});
+    mockNow(createdAt);
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+
+    const response = await accept(
+      listClient().create({
+        headers: authHeaders(),
+        body: {
+          name: skillName,
+          displayName: "Stored Skill",
+          description: "Stored through API",
+          files: [
+            { path: "SKILL.md", content: "# Updated Content" },
+            { path: "templates/prompt.md", content: "Use the tool" },
+          ],
+        },
+      }),
+      [201],
+    );
+
+    expect(response.body.name).toBe(skillName);
+
+    const writeDb = store.set(writeDb$);
+    const [skill] = await writeDb
+      .select()
+      .from(zeroSkills)
+      .where(
+        and(
+          eq(zeroSkills.orgId, fixture.orgId),
+          eq(zeroSkills.name, skillName),
+        ),
+      )
+      .limit(1);
+    expect(skill).toMatchObject({
+      orgId: fixture.orgId,
+      name: skillName,
+      displayName: "Stored Skill",
+      description: "Stored through API",
+      createdBy: fixture.userId,
+    });
+
+    const storageName = getCustomSkillStorageName(skillName);
+    const state = await readSkillStorageState(fixture, skillName);
+    expect(state.storage?.s3Prefix).toBe(
+      `${fixture.orgId}/volume/${storageName}`,
+    );
+    expect(state.storage?.size).toBe(29);
+    expect(state.storage?.fileCount).toBe(2);
+    expect(state.storage?.headVersionId).toBeTruthy();
+    expect(state.version?.size).toBe(29);
+    expect(state.version?.fileCount).toBe(2);
+
+    if (!state.storage?.headVersionId || !state.version) {
+      throw new Error("Expected skill storage to have a head version");
+    }
+
+    expectS3VolumeUploads(state.version.s3Key, state.storage.headVersionId);
+  });
+
+  it("does not bind a created org skill to existing agents", async () => {
+    const fixture = await track(
+      store.set(seedSkillsFixture$, undefined, context.signal),
+    );
+    const { agentId } = await store.set(
+      seedAgentForInstructions$,
+      { orgId: fixture.orgId, userId: fixture.userId },
+      context.signal,
+    );
+    context.mocks.s3.send.mockResolvedValue({});
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+
+    await accept(
+      listClient().create({
+        headers: authHeaders(),
+        body: { name: "unbound-skill", files: skillFiles("# Unbound") },
+      }),
+      [201],
+    );
+
+    const writeDb = store.set(writeDb$);
+    const [agent] = await writeDb
+      .select({ customSkills: zeroAgents.customSkills })
+      .from(zeroAgents)
+      .where(eq(zeroAgents.id, agentId))
+      .limit(1);
+    expect(agent?.customSkills).toStrictEqual([]);
+  });
+});
 
 describe("GET /api/zero/skills", () => {
   const track = createFixtureTracker<SkillsFixture>((fixture) => {

--- a/turbo/apps/api/src/signals/routes/zero-skills.ts
+++ b/turbo/apps/api/src/signals/routes/zero-skills.ts
@@ -3,14 +3,30 @@ import {
   zeroSkillsCollectionContract,
   zeroSkillsDetailContract,
 } from "@vm0/api-contracts/contracts/zero-agents";
+import { getCustomSkillStorageName } from "@vm0/core/storage-names";
+import { SEED_SKILLS } from "@vm0/core/zero-seed-skills";
+import { zeroSkills } from "@vm0/db/schema/zero-skill";
+import { and, eq } from "drizzle-orm";
 
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
 import { bodyResultOf, pathParamsOf } from "../context/request";
-import { notFound } from "../../lib/error";
+import { conflict, notFound } from "../../lib/error";
+import { writeDb$ } from "../external/db";
 import { zeroSkillList } from "../services/zero-catalog-data.service";
+import { uploadVolumeServerSide$ } from "../services/storage-volume-upload.service";
 import { updateZeroSkill$ } from "../services/zero-skill-update.service";
 import type { RouteEntry } from "../route";
+
+const createAdminRequired = Object.freeze({
+  status: 403 as const,
+  body: Object.freeze({
+    error: Object.freeze({
+      message: "Only org admins can create custom skills",
+      code: "FORBIDDEN",
+    }),
+  }),
+});
 
 const adminRequired = Object.freeze({
   status: 403 as const,
@@ -22,10 +38,76 @@ const adminRequired = Object.freeze({
   }),
 });
 
+const createSkillBody$ = bodyResultOf(zeroSkillsCollectionContract.create);
+const updateSkillBody$ = bodyResultOf(zeroSkillsDetailContract.update);
+
 const listSkillsInner$ = computed(async (get) => {
   const auth = get(organizationAuthContext$);
   const skills = await get(zeroSkillList(auth.orgId));
   return { status: 200 as const, body: [...skills] };
+});
+
+const createSkillInner$ = command(async ({ get, set }, signal: AbortSignal) => {
+  const auth = get(organizationAuthContext$);
+  if (auth.orgRole !== "admin") {
+    return createAdminRequired;
+  }
+
+  const bodyResult = await get(createSkillBody$);
+  signal.throwIfAborted();
+  if (!bodyResult.ok) {
+    return bodyResult.response;
+  }
+
+  const body = bodyResult.data;
+  if (SEED_SKILLS.includes(body.name)) {
+    return conflict(
+      `Skill name "${body.name}" conflicts with a built-in skill`,
+    );
+  }
+
+  const writeDb = set(writeDb$);
+  const [existingSkill] = await writeDb
+    .select({ id: zeroSkills.id })
+    .from(zeroSkills)
+    .where(
+      and(eq(zeroSkills.orgId, auth.orgId), eq(zeroSkills.name, body.name)),
+    )
+    .limit(1);
+  signal.throwIfAborted();
+
+  if (existingSkill) {
+    return conflict(`Skill "${body.name}" already exists in this organization`);
+  }
+
+  await writeDb.insert(zeroSkills).values({
+    orgId: auth.orgId,
+    name: body.name,
+    displayName: body.displayName ?? null,
+    description: body.description ?? null,
+    createdBy: auth.userId,
+  });
+  signal.throwIfAborted();
+
+  await set(
+    uploadVolumeServerSide$,
+    {
+      orgId: auth.orgId,
+      storageName: getCustomSkillStorageName(body.name),
+      files: body.files,
+    },
+    signal,
+  );
+  signal.throwIfAborted();
+
+  return {
+    status: 201 as const,
+    body: {
+      name: body.name,
+      displayName: body.displayName ?? null,
+      description: body.description ?? null,
+    },
+  };
 });
 
 const updateSkillInner$ = command(async ({ get, set }, signal: AbortSignal) => {
@@ -35,7 +117,7 @@ const updateSkillInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   }
 
   const params = get(pathParamsOf(zeroSkillsDetailContract.update));
-  const bodyResult = await get(bodyResultOf(zeroSkillsDetailContract.update));
+  const bodyResult = await get(updateSkillBody$);
   signal.throwIfAborted();
   if (!bodyResult.ok) {
     return bodyResult.response;
@@ -69,6 +151,17 @@ export const zeroSkillsRoutes: readonly RouteEntry[] = [
         requiredCapability: "agent:read",
       },
       listSkillsInner$,
+    ),
+  },
+  {
+    route: zeroSkillsCollectionContract.create,
+    handler: authRoute(
+      {
+        requireOrganization: true,
+        missingOrganizationStatus: 401,
+        requiredCapability: "agent:write",
+      },
+      createSkillInner$,
     ),
   },
   {

--- a/turbo/apps/web/src/lib/zero/seed-skills.ts
+++ b/turbo/apps/web/src/lib/zero/seed-skills.ts
@@ -1,46 +1,8 @@
 import { resolveSkillRef } from "@vm0/core/github-url";
+import { SEED_SKILLS } from "@vm0/core/zero-seed-skills";
 import type { skills } from "@vm0/db/schema/skill";
 
-/**
- * Default skills always included in zero agent composes.
- * Source: https://github.com/vm0-ai/the-seed
- *
- * These live server-side only so the frontend never sends stale seed skills.
- */
-export const SEED_SKILLS: readonly string[] = [
-  "deep-dive",
-  "account-reconciliation",
-  "analysis-qa",
-  "audit-readiness",
-  "brand-guidelines",
-  "campaign-strategy",
-  "competitor-matrix",
-  "contract-redline",
-  "copywriting",
-  "customer-intel",
-  "customer-reply",
-  "data-profiling",
-  "escalation-brief",
-  "flux-analysis",
-  "gaap-reporting",
-  "issue-triage",
-  "journal-entries",
-  "kb-authoring",
-  "legal-briefing",
-  "legal-risk-scoring",
-  "marketing-analytics",
-  "nda-screening",
-  "period-close",
-  "prd-writing",
-  "privacy-compliance",
-  "product-metrics",
-  "reply-templates",
-  "research-synthesis",
-  "roadmap-planning",
-  "sql-cookbook",
-  "stats-methods",
-  "status-updates",
-] as const;
+export { SEED_SKILLS };
 
 /**
  * Build skill insert values from a list of skill names.

--- a/turbo/packages/core/src/zero-seed-skills.ts
+++ b/turbo/packages/core/src/zero-seed-skills.ts
@@ -1,0 +1,40 @@
+/**
+ * Default skills always included in zero agent composes.
+ * Source: https://github.com/vm0-ai/the-seed
+ *
+ * These live server-side only so the frontend never sends stale seed skills.
+ */
+export const SEED_SKILLS: readonly string[] = [
+  "deep-dive",
+  "account-reconciliation",
+  "analysis-qa",
+  "audit-readiness",
+  "brand-guidelines",
+  "campaign-strategy",
+  "competitor-matrix",
+  "contract-redline",
+  "copywriting",
+  "customer-intel",
+  "customer-reply",
+  "data-profiling",
+  "escalation-brief",
+  "flux-analysis",
+  "gaap-reporting",
+  "issue-triage",
+  "journal-entries",
+  "kb-authoring",
+  "legal-briefing",
+  "legal-risk-scoring",
+  "marketing-analytics",
+  "nda-screening",
+  "period-close",
+  "prd-writing",
+  "privacy-compliance",
+  "product-metrics",
+  "reply-templates",
+  "research-synthesis",
+  "roadmap-planning",
+  "sql-cookbook",
+  "stats-methods",
+  "status-updates",
+] as const;


### PR DESCRIPTION
## Summary
- register `POST /api/zero/skills` in `apps/api` as an API-authoritative command
- move `SEED_SKILLS` into `@vm0/core` so api and web share the built-in skill conflict list
- port POST zero skills behavior into API route/integration coverage

Closes #12889

## Validation
- `pnpm -F api exec vitest src/signals/routes/__tests__/zero-skills.test.ts`
- `pnpm -F api lint`
- `pnpm check-types`
- pre-commit: prettier, knip, check-types