### PR TITLE
refactor(api): migrate zero org logo upload route

### DIFF
--- a/turbo/apps/api/src/__tests__/mocks.ts
+++ b/turbo/apps/api/src/__tests__/mocks.ts
@@ -31,6 +31,7 @@ export interface ApiTestMocks {
       readonly getOrganizationMembershipList: AsyncMock;
       readonly revokeOrganizationInvitation: AsyncMock;
       readonly updateOrganization: AsyncMock;
+      readonly updateOrganizationLogo: AsyncMock;
     };
     readonly users: {
       readonly getUserList: AsyncMock;
@@ -130,6 +131,7 @@ const apiTestMocks: ApiTestMocks = vi.hoisted((): ApiTestMocks => {
       revokeOrganizationInvitation:
         vi.fn<(...args: unknown[]) => Promise<unknown>>(),
       updateOrganization: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
+      updateOrganizationLogo: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
     },
     users: {
       getUserList: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
@@ -489,6 +491,7 @@ export function resetApiTestMocks(): void {
   apiTestMocks.clerk.organizations.getOrganizationMembershipList.mockReset();
   apiTestMocks.clerk.organizations.revokeOrganizationInvitation.mockReset();
   apiTestMocks.clerk.organizations.updateOrganization.mockReset();
+  apiTestMocks.clerk.organizations.updateOrganizationLogo.mockReset();
   apiTestMocks.clerk.users.getUserList.mockReset();
   apiTestMocks.clerk.users.getOrganizationMembershipList.mockReset();
   apiTestMocks.s3.send.mockReset();

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-org-logo.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-org-logo.test.ts
@@ -2,7 +2,10 @@ import { randomUUID } from "node:crypto";
 
 import { zeroOrgLogoContract } from "@vm0/api-contracts/contracts/zero-org-logo";
 
+import { createApp } from "../../../app-factory";
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { now } from "../../../lib/time";
+import { signSandboxJwtForTests } from "../../auth/tokens";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
 
 const context = testContext();
@@ -22,10 +25,51 @@ function mockClerkOrganizationLogo(args: ClerkOrganizationLogoFixture): void {
   });
 }
 
+function mockClerkOrganizationLogoUpload(
+  args: ClerkOrganizationLogoFixture,
+): void {
+  context.mocks.clerk.organizations.updateOrganizationLogo.mockResolvedValue({
+    id: args.orgId,
+    imageUrl: args.imageUrl,
+    hasImage: args.hasImage,
+  });
+}
+
 function clerkNotFoundError(): Error {
   const error = new Error("Organization not found");
   error.name = "NotFoundError";
   return error;
+}
+
+function clerkForbiddenError(): Error {
+  const error = new Error("Forbidden");
+  error.name = "ForbiddenError";
+  return error;
+}
+
+function currentSecond(): number {
+  return Math.floor(now() / 1000);
+}
+
+function logoForm(file: File): FormData {
+  const form = new FormData();
+  form.append("file", file);
+  return form;
+}
+
+function pngLogoFile(): File {
+  return new File([new Uint8Array([137, 80, 78, 71])], "logo.png", {
+    type: "image/png",
+  });
+}
+
+function postLogo(form: FormData, headers: HeadersInit = {}) {
+  const app = createApp({ signal: context.signal });
+  return app.request("/api/zero/org/logo", {
+    method: "POST",
+    headers,
+    body: form,
+  });
 }
 
 describe("GET /api/zero/org/logo", () => {
@@ -123,5 +167,250 @@ describe("GET /api/zero/org/logo", () => {
       message: "Org not found",
       code: "BAD_REQUEST",
     });
+  });
+});
+
+describe("POST /api/zero/org/logo", () => {
+  it("uploads the current org logo", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    mocks.clerk.session(userId, orgId, "org:admin");
+    mockClerkOrganizationLogoUpload({
+      orgId,
+      imageUrl: "https://img.clerk.test/new-logo.png",
+      hasImage: true,
+    });
+
+    const file = pngLogoFile();
+    const response = await postLogo(logoForm(file), {
+      authorization: "Bearer clerk-session",
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toStrictEqual({
+      logoUrl: "https://img.clerk.test/new-logo.png",
+      hasImage: true,
+    });
+    expect(
+      context.mocks.clerk.organizations.updateOrganizationLogo,
+    ).toHaveBeenCalledWith(orgId, { file });
+  });
+
+  it("returns null logoUrl when Clerk clears the image URL", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    mocks.clerk.session(userId, orgId, "org:admin");
+    mockClerkOrganizationLogoUpload({
+      orgId,
+      imageUrl: "",
+      hasImage: false,
+    });
+
+    const response = await postLogo(logoForm(pngLogoFile()), {
+      authorization: "Bearer clerk-session",
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toStrictEqual({
+      logoUrl: null,
+      hasImage: false,
+    });
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    const response = await postLogo(logoForm(pngLogoFile()));
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+    expect(
+      context.mocks.clerk.organizations.updateOrganizationLogo,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when the session has no active org", async () => {
+    const userId = `user_${randomUUID()}`;
+    mocks.clerk.session(userId, null);
+
+    const response = await postLogo(logoForm(pngLogoFile()), {
+      authorization: "Bearer clerk-session",
+    });
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toStrictEqual({
+      error: { message: "Org not found", code: "BAD_REQUEST" },
+    });
+    expect(
+      context.mocks.clerk.organizations.updateOrganizationLogo,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 when the current org role is not admin", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    mocks.clerk.session(userId, orgId, "org:member");
+
+    const response = await postLogo(logoForm(pngLogoFile()), {
+      authorization: "Bearer clerk-session",
+    });
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toStrictEqual({
+      error: {
+        message: "Only admins can upload the logo",
+        code: "BAD_REQUEST",
+      },
+    });
+    expect(
+      context.mocks.clerk.organizations.updateOrganizationLogo,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when no file is provided", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    mocks.clerk.session(userId, orgId, "org:admin");
+
+    const response = await postLogo(new FormData(), {
+      authorization: "Bearer clerk-session",
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toStrictEqual({
+      error: { message: "No file provided", code: "BAD_REQUEST" },
+    });
+    expect(
+      context.mocks.clerk.organizations.updateOrganizationLogo,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when the file field is not a file", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    mocks.clerk.session(userId, orgId, "org:admin");
+    const form = new FormData();
+    form.append("file", "not-a-file");
+
+    const response = await postLogo(form, {
+      authorization: "Bearer clerk-session",
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toStrictEqual({
+      error: { message: "No file provided", code: "BAD_REQUEST" },
+    });
+    expect(
+      context.mocks.clerk.organizations.updateOrganizationLogo,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when the file is too large", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    mocks.clerk.session(userId, orgId, "org:admin");
+    const file = new File([new Uint8Array(2 * 1024 * 1024 + 1)], "logo.png", {
+      type: "image/png",
+    });
+
+    const response = await postLogo(logoForm(file), {
+      authorization: "Bearer clerk-session",
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toStrictEqual({
+      error: { message: "File too large (max 2 MB)", code: "BAD_REQUEST" },
+    });
+    expect(
+      context.mocks.clerk.organizations.updateOrganizationLogo,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for unsupported file types", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    mocks.clerk.session(userId, orgId, "org:admin");
+    const file = new File(["plain"], "logo.txt", { type: "text/plain" });
+
+    const response = await postLogo(logoForm(file), {
+      authorization: "Bearer clerk-session",
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toStrictEqual({
+      error: {
+        message: "Unsupported file type: text/plain",
+        code: "BAD_REQUEST",
+      },
+    });
+    expect(
+      context.mocks.clerk.organizations.updateOrganizationLogo,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("maps Clerk not-found errors to 404", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    mocks.clerk.session(userId, orgId, "org:admin");
+    context.mocks.clerk.organizations.updateOrganizationLogo.mockRejectedValue(
+      clerkNotFoundError(),
+    );
+
+    const response = await postLogo(logoForm(pngLogoFile()), {
+      authorization: "Bearer clerk-session",
+    });
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toStrictEqual({
+      error: { message: "Org not found", code: "BAD_REQUEST" },
+    });
+  });
+
+  it("maps Clerk forbidden errors to 403", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    mocks.clerk.session(userId, orgId, "org:admin");
+    context.mocks.clerk.organizations.updateOrganizationLogo.mockRejectedValue(
+      clerkForbiddenError(),
+    );
+
+    const response = await postLogo(logoForm(pngLogoFile()), {
+      authorization: "Bearer clerk-session",
+    });
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toStrictEqual({
+      error: { message: "Access denied", code: "BAD_REQUEST" },
+    });
+  });
+
+  it("rejects zero tokens", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    const seconds = currentSecond();
+    const token = signSandboxJwtForTests({
+      scope: "zero",
+      userId,
+      orgId,
+      runId: `run_${randomUUID()}`,
+      capabilities: [],
+      iat: seconds,
+      exp: seconds + 600,
+    });
+
+    const response = await postLogo(logoForm(pngLogoFile()), {
+      authorization: `Bearer ${token}`,
+    });
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toStrictEqual({
+      error: {
+        message: "This endpoint is not available for sandbox tokens",
+        code: "FORBIDDEN",
+      },
+    });
+    expect(
+      context.mocks.clerk.organizations.updateOrganizationLogo,
+    ).not.toHaveBeenCalled();
   });
 });

--- a/turbo/apps/api/src/signals/routes/zero-org-logo.ts
+++ b/turbo/apps/api/src/signals/routes/zero-org-logo.ts
@@ -1,11 +1,14 @@
-import { computed } from "ccstate";
+import { command, computed } from "ccstate";
 import { zeroOrgLogoContract } from "@vm0/api-contracts/contracts/zero-org-logo";
 
 import { authContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
+import { request$ } from "../context/hono";
 import { clerk$ } from "../external/clerk";
 import { safeAsync } from "../utils";
 import type { RouteEntry } from "../route";
+
+const MAX_FILE_SIZE = 2 * 1024 * 1024;
 
 const orgLogoNotFound = Object.freeze({
   status: 404 as const,
@@ -17,10 +20,42 @@ const orgLogoNotFound = Object.freeze({
   }),
 });
 
+function orgLogoBadRequest(message: string) {
+  return {
+    status: 400 as const,
+    body: { error: { message, code: "BAD_REQUEST" } },
+  };
+}
+
+function orgLogoForbidden(message: string) {
+  return {
+    status: 403 as const,
+    body: { error: { message, code: "BAD_REQUEST" } },
+  };
+}
+
 function isOrgLookupNotFound(error: unknown): error is Error {
   return (
     error instanceof Error &&
     (error.name === "BadRequestError" || error.name === "NotFoundError")
+  );
+}
+
+function isOrgLookupForbidden(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    (error.name === "ForbiddenError" ||
+      Reflect.get(error, "statusCode") === 403 ||
+      Reflect.get(error, "code") === "FORBIDDEN")
+  );
+}
+
+function isAllowedLogoType(type: string): boolean {
+  return (
+    type === "image/png" ||
+    type === "image/jpeg" ||
+    type === "image/gif" ||
+    type === "image/webp"
   );
 }
 
@@ -53,9 +88,66 @@ const getOrgLogoInner$ = computed(async (get) => {
   };
 });
 
+const postOrgLogoInner$ = command(async ({ get }, signal: AbortSignal) => {
+  const auth = get(authContext$);
+  const orgId = auth.orgId;
+  if (!orgId) {
+    return orgLogoNotFound;
+  }
+
+  if (auth.orgRole !== "admin") {
+    return orgLogoForbidden("Only admins can upload the logo");
+  }
+
+  const request = get(request$);
+  const formData = await request.raw.formData();
+  signal.throwIfAborted();
+
+  const file = formData.get("file");
+  if (!file || !(file instanceof File)) {
+    return orgLogoBadRequest("No file provided");
+  }
+
+  if (file.size > MAX_FILE_SIZE) {
+    return orgLogoBadRequest("File too large (max 2 MB)");
+  }
+
+  if (!isAllowedLogoType(file.type)) {
+    return orgLogoBadRequest(`Unsupported file type: ${file.type}`);
+  }
+
+  const client = get(clerk$);
+  const result = await safeAsync(() => {
+    return client.organizations.updateOrganizationLogo(orgId, { file });
+  });
+  signal.throwIfAborted();
+
+  if ("error" in result) {
+    if (isOrgLookupNotFound(result.error)) {
+      return orgLogoNotFound;
+    }
+    if (isOrgLookupForbidden(result.error)) {
+      return orgLogoForbidden("Access denied");
+    }
+    throw result.error;
+  }
+
+  return {
+    status: 200 as const,
+    body: {
+      logoUrl: result.ok.imageUrl || null,
+      hasImage: result.ok.hasImage,
+    },
+  };
+});
+
 export const zeroOrgLogoRoutes: readonly RouteEntry[] = [
   {
     route: zeroOrgLogoContract.get,
     handler: authRoute({}, getOrgLogoInner$),
+  },
+  {
+    route: zeroOrgLogoContract.post,
+    handler: authRoute({}, postOrgLogoInner$),
   },
 ];

--- a/turbo/packages/api-contracts/src/contracts/zero-org-logo.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-org-logo.ts
@@ -12,7 +12,7 @@ export const zeroOrgLogoResponseSchema = z.object({
 export type ZeroOrgLogoResponse = z.infer<typeof zeroOrgLogoResponseSchema>;
 
 /**
- * Zero contract for GET /api/zero/org/logo
+ * Zero contract for /api/zero/org/logo
  */
 export const zeroOrgLogoContract = c.router({
   get: {
@@ -25,6 +25,22 @@ export const zeroOrgLogoContract = c.router({
       404: apiErrorSchema,
     },
     summary: "Get current organization logo",
+  },
+  post: {
+    method: "POST",
+    path: "/api/zero/org/logo",
+    headers: authHeadersSchema,
+    contentType: "multipart/form-data",
+    body: c.type<FormData>(),
+    responses: {
+      200: zeroOrgLogoResponseSchema,
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      404: apiErrorSchema,
+      500: apiErrorSchema,
+    },
+    summary: "Upload current organization logo",
   },
 });
 


### PR DESCRIPTION
## Summary

- add the API backend contract and route for `POST /api/zero/org/logo`
- upload org logos through Clerk with the legacy web validation rules
- cover multipart upload success and error paths in API route tests

Closes #12882

## Validation

- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-org-logo.test.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm format`
- `pnpm turbo run lint`
- `pnpm check-types`
- `pnpm knip`
- `git diff --check`
- `pnpm -F api exec vitest run` (2 unrelated `zero-usage-insight` top-100 truncation tests timed out under full-package concurrency)
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-usage-insight.test.ts --no-file-parallelism --maxWorkers=1`
