### PR TITLE
refactor(api): migrate github integration delete route

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -56,6 +56,7 @@ import { zeroMeModelProvidersListRoutes } from "./routes/zero-me-model-providers
 import { zeroMeModelProvidersUpsertRoutes } from "./routes/zero-me-model-providers-upsert";
 import { zeroSecretsRoutes } from "./routes/zero-secrets";
 import { zeroSkillsRoutes } from "./routes/zero-skills";
+import { integrationsGithubRoutes } from "./routes/integrations-github";
 import { zeroIntegrationsSlackRoutes } from "./routes/zero-integrations-slack";
 import { zeroIntegrationsSlackMessageRoutes } from "./routes/zero-integrations-slack-message";
 import { zeroIntegrationsSlackUploadCompleteRoutes } from "./routes/zero-integrations-slack-upload-complete";
@@ -155,6 +156,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...zeroUserModelPreferenceRoutes,
   ...zeroSecretsRoutes,
   ...zeroSkillsRoutes,
+  ...integrationsGithubRoutes,
   ...zeroSlackConnectRoutes,
   ...zeroIntegrationsSlackRoutes,
   ...zeroIntegrationsSlackMessageRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations-github-delete.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations-github-delete.test.ts
@@ -1,0 +1,265 @@
+import { Buffer } from "node:buffer";
+import { generateKeyPairSync, randomUUID } from "node:crypto";
+
+import { createStore } from "ccstate";
+import { githubInstallations } from "@vm0/db/schema/github-installation";
+import { githubUserLinks } from "@vm0/db/schema/github-user-link";
+import { eq } from "drizzle-orm";
+import { afterEach, beforeEach } from "vitest";
+import { http, HttpResponse } from "msw";
+
+import { createApp } from "../../../app-factory";
+import { testContext } from "../../../__tests__/test-helpers";
+import { server } from "../../../mocks/server";
+import { clearMockedEnv, mockOptionalEnv } from "../../../lib/env";
+import { writeDb$ } from "../../external/db";
+import {
+  deleteUsageInsightFixture$,
+  seedCompose$,
+} from "./helpers/zero-usage-insight";
+import { createZeroRouteMocks } from "./helpers/zero-route-test";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+const ROUTE_PATH = "/api/integrations/github";
+
+interface GithubInstallationFixture {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly installationRowId: string;
+}
+
+function authHeaders(): Record<string, string> {
+  return { authorization: "Bearer clerk-session" };
+}
+
+function newGithubUserId(): string {
+  return `gh_${randomUUID().replaceAll("-", "")}`;
+}
+
+function newRemoteInstallationId(): string {
+  return String(Math.floor(Math.random() * 9_000_000_000) + 1_000_000_000);
+}
+
+function newPrivateKeyBase64(): string {
+  const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+  const pem = privateKey.export({ type: "pkcs8", format: "pem" });
+  return Buffer.from(pem).toString("base64");
+}
+
+async function seedGithubInstallation(args: {
+  readonly userId?: string;
+  readonly linkedGithubUserId?: string;
+  readonly adminGithubUserId?: string | null;
+  readonly remoteInstallationId?: string | null;
+}): Promise<GithubInstallationFixture> {
+  const orgId = `org_${randomUUID()}`;
+  const userId = args.userId ?? `user_${randomUUID()}`;
+  const githubUserId = args.linkedGithubUserId ?? newGithubUserId();
+  const adminGithubUserId =
+    "adminGithubUserId" in args ? args.adminGithubUserId : githubUserId;
+  const { composeId } = await store.set(
+    seedCompose$,
+    { orgId, userId },
+    context.signal,
+  );
+  const db = store.set(writeDb$);
+
+  const [installation] = await db
+    .insert(githubInstallations)
+    .values({
+      installationId: args.remoteInstallationId ?? newRemoteInstallationId(),
+      adminGithubUserId,
+      defaultComposeId: composeId,
+    })
+    .returning({ id: githubInstallations.id });
+  if (!installation) {
+    throw new Error("Expected GitHub installation insert to return a row");
+  }
+
+  await db.insert(githubUserLinks).values({
+    githubUserId,
+    installationId: installation.id,
+    vm0UserId: userId,
+  });
+
+  return { orgId, userId, installationRowId: installation.id };
+}
+
+async function deleteGithubFixture(
+  fixture: GithubInstallationFixture,
+): Promise<void> {
+  const db = store.set(writeDb$);
+  await db
+    .delete(githubInstallations)
+    .where(eq(githubInstallations.id, fixture.installationRowId));
+  await store.set(
+    deleteUsageInsightFixture$,
+    { orgId: fixture.orgId, userId: fixture.userId },
+    context.signal,
+  );
+}
+
+async function installationExists(id: string): Promise<boolean> {
+  const [row] = await store
+    .set(writeDb$)
+    .select({ id: githubInstallations.id })
+    .from(githubInstallations)
+    .where(eq(githubInstallations.id, id))
+    .limit(1);
+  return row !== undefined;
+}
+
+describe("DELETE /api/integrations/github", () => {
+  const fixtures: GithubInstallationFixture[] = [];
+
+  beforeEach(() => {
+    clearMockedEnv();
+    context.mocks.clerk.authenticateRequest.mockReset();
+    context.mocks.clerk.authenticateRequest.mockResolvedValue({
+      isAuthenticated: false,
+    });
+  });
+
+  afterEach(async () => {
+    clearMockedEnv();
+    while (fixtures.length > 0) {
+      const fixture = fixtures.pop();
+      if (fixture) {
+        await deleteGithubFixture(fixture);
+      }
+    }
+  });
+
+  it("returns 401 when no user is authenticated", async () => {
+    const app = createApp({ signal: context.signal });
+
+    const response = await app.request(ROUTE_PATH, { method: "DELETE" });
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("returns 404 when the authenticated user has no GitHub installation", async () => {
+    mocks.clerk.session(`user_${randomUUID()}`, null);
+    const app = createApp({ signal: context.signal });
+
+    const response = await app.request(ROUTE_PATH, {
+      method: "DELETE",
+      headers: authHeaders(),
+    });
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toStrictEqual({
+      error: {
+        message: "No GitHub installation found",
+        code: "NOT_FOUND",
+      },
+    });
+  });
+
+  it("deletes the linked admin installation and returns ok", async () => {
+    const fixture = await seedGithubInstallation({});
+    fixtures.push(fixture);
+    mocks.clerk.session(fixture.userId, null);
+    const app = createApp({ signal: context.signal });
+
+    const response = await app.request(ROUTE_PATH, {
+      method: "DELETE",
+      headers: authHeaders(),
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toStrictEqual({ ok: true });
+    await expect(
+      installationExists(fixture.installationRowId),
+    ).resolves.toBeFalsy();
+  });
+
+  it("returns 403 and keeps the installation when adminGithubUserId is null", async () => {
+    const fixture = await seedGithubInstallation({ adminGithubUserId: null });
+    fixtures.push(fixture);
+    mocks.clerk.session(fixture.userId, null);
+    const app = createApp({ signal: context.signal });
+
+    const response = await app.request(ROUTE_PATH, {
+      method: "DELETE",
+      headers: authHeaders(),
+    });
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toStrictEqual({
+      error: {
+        message: "Only the installation admin can uninstall",
+        code: "FORBIDDEN",
+      },
+    });
+    await expect(
+      installationExists(fixture.installationRowId),
+    ).resolves.toBeTruthy();
+  });
+
+  it("returns 403 and keeps the installation when a non-admin user deletes", async () => {
+    const fixture = await seedGithubInstallation({
+      adminGithubUserId: newGithubUserId(),
+      linkedGithubUserId: newGithubUserId(),
+    });
+    fixtures.push(fixture);
+    mocks.clerk.session(fixture.userId, null);
+    const app = createApp({ signal: context.signal });
+
+    const response = await app.request(ROUTE_PATH, {
+      method: "DELETE",
+      headers: authHeaders(),
+    });
+
+    expect(response.status).toBe(403);
+    await expect(
+      installationExists(fixture.installationRowId),
+    ).resolves.toBeTruthy();
+  });
+
+  it("keeps local deletion authoritative when remote GitHub uninstall fails", async () => {
+    const remoteInstallationId = newRemoteInstallationId();
+    const fixture = await seedGithubInstallation({ remoteInstallationId });
+    fixtures.push(fixture);
+    mocks.clerk.session(fixture.userId, null);
+    mockOptionalEnv("GITHUB_APP_ID", "123456");
+    mockOptionalEnv("GITHUB_APP_PRIVATE_KEY", newPrivateKeyBase64());
+
+    const observed: {
+      authorization: string | null;
+      installationId: string | null;
+    } = {
+      authorization: null,
+      installationId: null,
+    };
+    server.use(
+      http.delete(
+        "https://api.github.com/app/installations/:installationId",
+        ({ params, request }) => {
+          observed.installationId = String(params.installationId);
+          observed.authorization = request.headers.get("authorization");
+          return HttpResponse.text("boom", { status: 500 });
+        },
+      ),
+    );
+
+    const app = createApp({ signal: context.signal });
+    const response = await app.request(ROUTE_PATH, {
+      method: "DELETE",
+      headers: authHeaders(),
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toStrictEqual({ ok: true });
+    expect(observed.installationId).toBe(remoteInstallationId);
+    expect(observed.authorization?.startsWith("Bearer ")).toBeTruthy();
+    await expect(
+      installationExists(fixture.installationRowId),
+    ).resolves.toBeFalsy();
+  });
+});

--- a/turbo/apps/api/src/signals/routes/integrations-github.ts
+++ b/turbo/apps/api/src/signals/routes/integrations-github.ts
@@ -1,0 +1,12 @@
+import { integrationsGithubContract } from "@vm0/api-contracts/contracts/integrations-github";
+
+import { authRoute } from "../auth/auth-route";
+import { deleteGithubInstallation$ } from "../services/integrations-github.service";
+import type { RouteEntry } from "../route";
+
+export const integrationsGithubRoutes: readonly RouteEntry[] = [
+  {
+    route: integrationsGithubContract.deleteInstallation,
+    handler: authRoute({}, deleteGithubInstallation$),
+  },
+];

--- a/turbo/apps/api/src/signals/services/integrations-github.service.ts
+++ b/turbo/apps/api/src/signals/services/integrations-github.service.ts
@@ -1,0 +1,184 @@
+import { Buffer } from "node:buffer";
+import { createSign } from "node:crypto";
+import { command } from "ccstate";
+import { githubInstallations } from "@vm0/db/schema/github-installation";
+import { githubUserLinks } from "@vm0/db/schema/github-user-link";
+import { eq } from "drizzle-orm";
+
+import { authContext$ } from "../auth/auth-context";
+import { writeDb$ } from "../external/db";
+import { optionalEnv } from "../../lib/env";
+import { logger } from "../../lib/log";
+import { now } from "../../lib/time";
+
+const INSTALLATION_ID_RE = /^\d+$/;
+const L = logger("IntegrationsGithub");
+
+function errorResponse(
+  status: 401 | 403 | 404 | 500,
+  message: string,
+  code: string,
+) {
+  return { status, body: { error: { message, code } } };
+}
+
+function validateInstallationId(installationId: string): string {
+  if (!INSTALLATION_ID_RE.test(installationId)) {
+    throw new Error(
+      `Invalid GitHub installation ID: expected numeric string, got "${installationId}"`,
+    );
+  }
+  return installationId;
+}
+
+function base64url(value: string): string {
+  return Buffer.from(value)
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+function parsePemKey(input: string): string {
+  if (!input.startsWith("-----BEGIN")) {
+    return Buffer.from(input, "base64").toString("utf8");
+  }
+
+  const match = input.match(
+    /^(-----BEGIN [^-]+-----)[\s]+([\s\S]+?)[\s]+(-----END [^-]+-----)$/,
+  );
+  if (!match) {
+    return input;
+  }
+
+  const header = match[1];
+  const bodyMatch = match[2];
+  const footer = match[3];
+  if (!header || !bodyMatch || !footer) {
+    return input;
+  }
+
+  const body = bodyMatch.replace(/\s+/g, "\n");
+  return `${header}\n${body}\n${footer}\n`;
+}
+
+function createAppJwt(appId: string, privateKeyPemOrBase64: string): string {
+  const nowSeconds = Math.floor(now() / 1000);
+  const encodedHeader = base64url(JSON.stringify({ alg: "RS256", typ: "JWT" }));
+  const encodedPayload = base64url(
+    JSON.stringify({
+      iat: nowSeconds - 60,
+      exp: nowSeconds + 600,
+      iss: appId,
+    }),
+  );
+  const signingInput = `${encodedHeader}.${encodedPayload}`;
+  const signer = createSign("RSA-SHA256");
+  signer.update(signingInput);
+  const signature = signer.sign(
+    parsePemKey(privateKeyPemOrBase64),
+    "base64url",
+  );
+
+  return `${signingInput}.${signature}`;
+}
+
+async function deleteRemoteGithubInstallation(args: {
+  readonly appId: string;
+  readonly privateKey: string;
+  readonly installationId: string;
+  readonly signal: AbortSignal;
+}): Promise<void> {
+  const installationId = validateInstallationId(args.installationId);
+  const jwt = createAppJwt(args.appId, args.privateKey);
+  const response = await fetch(
+    `https://api.github.com/app/installations/${installationId}`,
+    {
+      method: "DELETE",
+      headers: {
+        Authorization: `Bearer ${jwt}`,
+        Accept: "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+      signal: args.signal,
+    },
+  );
+
+  if (!response.ok && response.status !== 404) {
+    const body = await response.text();
+    throw new Error(
+      `Failed to delete installation: ${response.status} ${body}`,
+    );
+  }
+}
+
+async function deleteRemoteGithubInstallationIfConfigured(args: {
+  readonly installationId: string | null;
+  readonly signal: AbortSignal;
+}): Promise<void> {
+  const appId = optionalEnv("GITHUB_APP_ID");
+  const privateKey = optionalEnv("GITHUB_APP_PRIVATE_KEY");
+  if (!appId || !privateKey || !args.installationId) {
+    return;
+  }
+
+  await deleteRemoteGithubInstallation({
+    appId,
+    privateKey,
+    installationId: args.installationId,
+    signal: args.signal,
+  }).catch((error: unknown) => {
+    L.error("Failed to delete GitHub installation", { error });
+  });
+  args.signal.throwIfAborted();
+}
+
+export const deleteGithubInstallation$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const auth = get(authContext$);
+    const db = set(writeDb$);
+
+    const [result] = await db
+      .select({
+        id: githubInstallations.id,
+        githubInstallationId: githubInstallations.installationId,
+        adminGithubUserId: githubInstallations.adminGithubUserId,
+        githubUserId: githubUserLinks.githubUserId,
+      })
+      .from(githubUserLinks)
+      .innerJoin(
+        githubInstallations,
+        eq(githubInstallations.id, githubUserLinks.installationId),
+      )
+      .where(eq(githubUserLinks.vm0UserId, auth.userId))
+      .limit(1);
+    signal.throwIfAborted();
+
+    if (!result) {
+      return errorResponse(404, "No GitHub installation found", "NOT_FOUND");
+    }
+
+    if (
+      !result.adminGithubUserId ||
+      result.githubUserId !== result.adminGithubUserId
+    ) {
+      return errorResponse(
+        403,
+        "Only the installation admin can uninstall",
+        "FORBIDDEN",
+      );
+    }
+
+    await deleteRemoteGithubInstallationIfConfigured({
+      installationId: result.githubInstallationId,
+      signal,
+    });
+
+    await db
+      .delete(githubInstallations)
+      .where(eq(githubInstallations.id, result.id));
+    signal.throwIfAborted();
+
+    return { status: 200 as const, body: { ok: true as const } };
+  },
+);

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -919,6 +919,12 @@ export {
   type SendChatMessageResponse,
 } from "./integrations";
 export {
+  deleteGithubInstallationResponseSchema,
+  integrationsGithubContract,
+  type DeleteGithubInstallationResponse,
+  type IntegrationsGithubContract,
+} from "./integrations-github";
+export {
   zeroBillingStatusContract,
   zeroBillingCheckoutContract,
   zeroBillingPortalContract,

--- a/turbo/packages/api-contracts/src/contracts/integrations-github.ts
+++ b/turbo/packages/api-contracts/src/contracts/integrations-github.ts
@@ -1,0 +1,32 @@
+import { z } from "zod";
+import { authHeadersSchema, initContract } from "./base";
+import { apiErrorSchema } from "./errors";
+
+const c = initContract();
+
+export const deleteGithubInstallationResponseSchema = z.object({
+  ok: z.literal(true),
+});
+
+export type DeleteGithubInstallationResponse = z.infer<
+  typeof deleteGithubInstallationResponseSchema
+>;
+
+export const integrationsGithubContract = c.router({
+  deleteInstallation: {
+    method: "DELETE",
+    path: "/api/integrations/github",
+    headers: authHeadersSchema,
+    body: c.noBody(),
+    responses: {
+      200: deleteGithubInstallationResponseSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      404: apiErrorSchema,
+      500: apiErrorSchema,
+    },
+    summary: "Uninstall the authenticated user's GitHub App installation",
+  },
+});
+
+export type IntegrationsGithubContract = typeof integrationsGithubContract;


### PR DESCRIPTION
## Summary
- add an api-contracts contract for DELETE /api/integrations/github
- register the api backend route and service for uninstalling the authenticated user's GitHub installation
- add route-level coverage for auth, not-found, admin authorization, local deletion, and remote GitHub uninstall failure handling

## Tests
- pnpm format
- pnpm -F api exec vitest run src/signals/routes/__tests__/integrations-github-delete.test.ts
- pnpm -F api lint
- pnpm -F @vm0/api-contracts lint
- pnpm -F api check-types
- pnpm -F @vm0/api-contracts check-types
- pnpm knip --cache
- git diff --check
- pre-commit hook: pnpm check-types

Closes #12800