### PR TITLE
refactor(api): migrate zero realtime token route

### DIFF
--- a/turbo/apps/api/src/__tests__/app-factory.test.ts
+++ b/turbo/apps/api/src/__tests__/app-factory.test.ts
@@ -241,8 +241,9 @@ describe("createApp", () => {
       await expect(observedBody).resolves.toBe('{"hello":"world"}');
     });
 
-    it("proxies realtime token requests without stale forwarded host metadata", async () => {
+    it("proxies unmatched POST requests without stale forwarded host metadata", async () => {
       mockEnv("VM0_WEB_URL", "https://www.vm0.ai");
+      const proxyPath = "/__legacy/proxy/realtime-token";
       const captured: {
         paths: string[];
         authorization: string[];
@@ -264,7 +265,7 @@ describe("createApp", () => {
       };
       useUndiciMock()
         .get("https://www.vm0.ai")
-        .intercept({ path: "/api/zero/realtime/token", method: "POST" })
+        .intercept({ path: proxyPath, method: "POST" })
         .reply((opts) => {
           captured.paths.push(opts.path);
           captured.authorization.push(
@@ -292,7 +293,7 @@ describe("createApp", () => {
         });
 
       const app = createApp({ signal: context.signal });
-      const response = await app.request("/api/zero/realtime/token", {
+      const response = await app.request(proxyPath, {
         method: "POST",
         headers: {
           authorization: "Bearer clerk-session",
@@ -310,7 +311,7 @@ describe("createApp", () => {
       await expect(response.json()).resolves.toStrictEqual({
         token: "proxied",
       });
-      expect(captured.paths).toStrictEqual(["/api/zero/realtime/token"]);
+      expect(captured.paths).toStrictEqual([proxyPath]);
       expect(captured.authorization).toStrictEqual(["Bearer clerk-session"]);
       expect(captured.origins).toStrictEqual(["https://app.vm0.ai"]);
       await expect(Promise.all(captured.bodies)).resolves.toStrictEqual(["{}"]);

--- a/turbo/apps/api/src/__tests__/mocks.ts
+++ b/turbo/apps/api/src/__tests__/mocks.ts
@@ -20,6 +20,7 @@ export interface ApiTestMocks {
   };
   readonly ably: {
     readonly publish: AsyncMock;
+    readonly createTokenRequest: AsyncMock;
   };
   readonly clerk: {
     readonly authenticateRequest: AsyncMock;
@@ -207,6 +208,7 @@ const apiTestMocks: ApiTestMocks = vi.hoisted((): ApiTestMocks => {
   return {
     ably: {
       publish: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
+      createTokenRequest: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
     },
     axiom,
     axiomLogging,
@@ -312,7 +314,11 @@ vi.mock("ably", () => {
         return { publish: apiTestMocks.ably.publish };
       },
     };
-    readonly auth = { createTokenRequest: vi.fn() };
+    readonly auth = {
+      createTokenRequest: (...args: unknown[]): Promise<unknown> => {
+        return apiTestMocks.ably.createTokenRequest(...args);
+      },
+    };
   }
   return { default: { Rest: MockRest } };
 });
@@ -473,6 +479,7 @@ export function getApiTestMocks(): ApiTestMocks {
 export function resetApiTestMocks(): void {
   apiTestMocks.ably.publish.mockReset();
   apiTestMocks.ably.publish.mockResolvedValue(undefined);
+  apiTestMocks.ably.createTokenRequest.mockReset();
   apiTestMocks.axiom.query.mockReset();
   apiTestMocks.axiomLogging.debug.mockReset();
   apiTestMocks.axiomLogging.info.mockReset();

--- a/turbo/apps/api/src/signals/external/realtime.ts
+++ b/turbo/apps/api/src/signals/external/realtime.ts
@@ -29,6 +29,21 @@ const REMOTE_AGENT_DEVICE_APPROVED_EVENT = "approved";
 const REMOTE_AGENT_HOST_JOB_EVENT = "job";
 const REMOTE_AGENT_HOSTS_CHANGED_EVENT = "remote-agent:hosts-changed";
 
+export async function createPlatformUserRealtimeToken(
+  userId: string,
+): Promise<Ably.TokenRequest> {
+  const channelName = getUserChannelName(userId);
+  const tokenRequest = await ablyClient().auth.createTokenRequest({
+    capability: {
+      [channelName]: ["subscribe"],
+    },
+    ttl: 60 * 60 * 1000,
+    clientId: userId,
+  });
+  L.debug(`Generated platform realtime token for user:${userId}`);
+  return tokenRequest;
+}
+
 /**
  * Publish a per-user invalidation/notification signal.
  *

--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -44,6 +44,7 @@ import { zeroPermissionAccessRequestsRoutes } from "./routes/zero-permission-acc
 import { zeroPermissionPoliciesRoutes } from "./routes/zero-permission-policies";
 import { zeroPushSubscriptionsRoutes } from "./routes/zero-push-subscriptions";
 import { zeroQueuePositionRoutes } from "./routes/zero-queue-position";
+import { zeroRealtimeTokenRoutes } from "./routes/zero-realtime-token";
 import { zeroRemoteAgentRoutes } from "./routes/zero-remote-agent";
 import { zeroRunDetailRoutes } from "./routes/zero-run-detail";
 import { zeroRunsRoutes } from "./routes/zero-runs";
@@ -124,6 +125,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...zeroVoiceIoQuotaRoutes,
   ...zeroWebDownloadRoutes,
   ...zeroQueuePositionRoutes,
+  ...zeroRealtimeTokenRoutes,
   ...zeroRemoteAgentRoutes,
   ...zeroRunDetailRoutes,
   ...zeroRunsRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-realtime-token.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-realtime-token.test.ts
@@ -1,0 +1,66 @@
+import { randomUUID } from "node:crypto";
+
+import { platformRealtimeTokenContract } from "@vm0/api-contracts/contracts/realtime";
+import { describe, expect, it, beforeEach } from "vitest";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { createZeroRouteMocks } from "./helpers/zero-route-test";
+
+const context = testContext();
+const mocks = createZeroRouteMocks(context);
+
+const tokenRequest = Object.freeze({
+  keyName: "test-key",
+  timestamp: 1_700_000_000_000,
+  capability: '{"user:test-user":["subscribe"]}',
+  clientId: "test-user",
+  nonce: "test-nonce",
+  mac: "test-mac",
+});
+
+describe("POST /api/zero/realtime/token", () => {
+  beforeEach(() => {
+    context.mocks.ably.createTokenRequest.mockResolvedValue(tokenRequest);
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    const client = setupApp({ context })(platformRealtimeTokenContract);
+
+    const response = await accept(
+      client.create({ body: {}, headers: {} }),
+      [401],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Authentication required",
+        code: "UNAUTHORIZED",
+      },
+    });
+    expect(context.mocks.ably.createTokenRequest).not.toHaveBeenCalled();
+  });
+
+  it("returns a subscribe-only Ably token for the authenticated user channel", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    mocks.clerk.session(userId, orgId);
+    const client = setupApp({ context })(platformRealtimeTokenContract);
+
+    const response = await accept(
+      client.create({
+        body: {},
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual(tokenRequest);
+    expect(context.mocks.ably.createTokenRequest).toHaveBeenCalledWith({
+      capability: {
+        [`user:${userId}`]: ["subscribe"],
+      },
+      ttl: 3_600_000,
+      clientId: userId,
+    });
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-realtime-token.ts
+++ b/turbo/apps/api/src/signals/routes/zero-realtime-token.ts
@@ -1,0 +1,38 @@
+import { command } from "ccstate";
+import { platformRealtimeTokenContract } from "@vm0/api-contracts/contracts/realtime";
+
+import { requiredAuthContext$, setAuthContext$ } from "../auth/auth-context";
+import { createPlatformUserRealtimeToken } from "../external/realtime";
+import type { RouteEntry } from "../route";
+
+const unauthenticated = Object.freeze({
+  status: 401 as const,
+  body: Object.freeze({
+    error: Object.freeze({
+      message: "Authentication required",
+      code: "UNAUTHORIZED",
+    }),
+  }),
+});
+
+const createInner$ = command(async ({ set }, signal: AbortSignal) => {
+  const auth = await set(requiredAuthContext$, {}, signal);
+  signal.throwIfAborted();
+  if ("status" in auth) {
+    return unauthenticated;
+  }
+
+  set(setAuthContext$, auth);
+
+  const tokenRequest = await createPlatformUserRealtimeToken(auth.userId);
+  signal.throwIfAborted();
+
+  return { status: 200 as const, body: tokenRequest };
+});
+
+export const zeroRealtimeTokenRoutes: readonly RouteEntry[] = [
+  {
+    route: platformRealtimeTokenContract.create,
+    handler: createInner$,
+  },
+];


### PR DESCRIPTION
## Summary
- add an API-native `POST /api/zero/realtime/token` route using the shared realtime contract
- generate subscribe-only Ably token requests for the authenticated user channel in apps/api
- add integration coverage for authenticated and unauthenticated token requests
- retarget the legacy proxy-header regression to an unmatched path now that this route is API-authoritative

Closes #12884

## Validation
- `pnpm -F api exec vitest src/signals/routes/__tests__/zero-realtime-token.test.ts src/__tests__/app-factory.test.ts`
- `pnpm format`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip`
- `pnpm -F web check-types`
- `pnpm -F @vm0/cli check-types`
- pre-commit hook: prettier, knip, full `pnpm check-types`
- `git diff --check`