### PR TITLE
refactor(api): migrate permission access create route

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-permission-access-requests.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-permission-access-requests.test.ts
@@ -5,6 +5,7 @@ import { eq } from "drizzle-orm";
 import { beforeEach, describe, expect, it } from "vitest";
 import type { RawPermissionPolicies } from "@vm0/connectors/firewall-types";
 import {
+  permissionAccessRequestsCreateContract,
   permissionAccessRequestsListContract,
   permissionAccessRequestsResolveContract,
 } from "@vm0/api-contracts/contracts/zero-agents";
@@ -185,6 +186,10 @@ function apiClient() {
   return setupApp({ context })(permissionAccessRequestsListContract);
 }
 
+function createApiClient() {
+  return setupApp({ context })(permissionAccessRequestsCreateContract);
+}
+
 function resolveApiClient() {
   return setupApp({ context })(permissionAccessRequestsResolveContract);
 }
@@ -225,6 +230,286 @@ function mockClerkUsers(
 
 beforeEach(() => {
   mockClerkUsers([]);
+});
+
+describe("POST /api/zero/permission-access-requests", () => {
+  const track = createFixtureTracker<PermissionAccessOrgFixture>((fixture) => {
+    return store.set(deletePermissionAccessOrg$, fixture, context.signal);
+  });
+
+  it("creates a permission access request", async () => {
+    const fixture = await track(
+      store.set(seedPermissionAccessOrg$, {}, context.signal),
+    );
+    mocks.clerk.session(fixture.ownerUserId, fixture.orgId);
+
+    const response = await accept(
+      createApiClient().create({
+        headers: authHeaders(),
+        body: {
+          agentId: fixture.agentId,
+          connectorRef: "github",
+          permission: "issues:read",
+          reason: "Need to read issues",
+        },
+      }),
+      [201],
+    );
+
+    expect(response.body).toMatchObject({
+      agentId: fixture.agentId,
+      connectorRef: "github",
+      permission: "issues:read",
+      action: "allow",
+      reason: "Need to read issues",
+      status: "pending",
+      requesterUserId: fixture.ownerUserId,
+      requesterName: null,
+      resolvedBy: null,
+      resolvedAt: null,
+    });
+    expect(response.body.id).toStrictEqual(expect.any(String));
+    expect(response.body.createdAt).toStrictEqual(expect.any(String));
+  });
+
+  it("deduplicates pending requests by updating the reason", async () => {
+    const fixture = await track(
+      store.set(seedPermissionAccessOrg$, {}, context.signal),
+    );
+    mocks.clerk.session(fixture.ownerUserId, fixture.orgId);
+
+    const first = await accept(
+      createApiClient().create({
+        headers: authHeaders(),
+        body: {
+          agentId: fixture.agentId,
+          connectorRef: "github",
+          permission: "issues:read",
+          reason: "First reason",
+        },
+      }),
+      [201],
+    );
+    const second = await accept(
+      createApiClient().create({
+        headers: authHeaders(),
+        body: {
+          agentId: fixture.agentId,
+          connectorRef: "github",
+          permission: "issues:read",
+          reason: "Updated reason",
+        },
+      }),
+      [201],
+    );
+
+    expect(second.body.id).toBe(first.body.id);
+    expect(second.body.reason).toBe("Updated reason");
+  });
+
+  it("creates a request with an explicit action", async () => {
+    const fixture = await track(
+      store.set(seedPermissionAccessOrg$, {}, context.signal),
+    );
+    mocks.clerk.session(fixture.ownerUserId, fixture.orgId);
+
+    const response = await accept(
+      createApiClient().create({
+        headers: authHeaders(),
+        body: {
+          agentId: fixture.agentId,
+          connectorRef: "github",
+          permission: "issues:read",
+          action: "deny",
+          reason: "Should not read issues",
+        },
+      }),
+      [201],
+    );
+
+    expect(response.body.action).toBe("deny");
+    expect(response.body.permission).toBe("issues:read");
+  });
+
+  it("treats different actions as separate requests for deduplication", async () => {
+    const fixture = await track(
+      store.set(seedPermissionAccessOrg$, {}, context.signal),
+    );
+    mocks.clerk.session(fixture.ownerUserId, fixture.orgId);
+
+    const allow = await accept(
+      createApiClient().create({
+        headers: authHeaders(),
+        body: {
+          agentId: fixture.agentId,
+          connectorRef: "github",
+          permission: "issues:read",
+          action: "allow",
+        },
+      }),
+      [201],
+    );
+    const deny = await accept(
+      createApiClient().create({
+        headers: authHeaders(),
+        body: {
+          agentId: fixture.agentId,
+          connectorRef: "github",
+          permission: "issues:read",
+          action: "deny",
+        },
+      }),
+      [201],
+    );
+
+    expect(deny.body.id).not.toBe(allow.body.id);
+    expect(allow.body.action).toBe("allow");
+    expect(deny.body.action).toBe("deny");
+  });
+
+  it("reuses a rejected request and resets it to pending", async () => {
+    const fixture = await track(
+      store.set(seedPermissionAccessOrg$, {}, context.signal),
+    );
+    mocks.clerk.session(fixture.ownerUserId, fixture.orgId);
+
+    const created = await accept(
+      createApiClient().create({
+        headers: authHeaders(),
+        body: {
+          agentId: fixture.agentId,
+          connectorRef: "github",
+          permission: "issues:read",
+          reason: "First try",
+        },
+      }),
+      [201],
+    );
+    await accept(
+      resolveApiClient().resolve({
+        headers: authHeaders(),
+        body: { requestId: created.body.id, action: "reject" },
+      }),
+      [200],
+    );
+
+    const resent = await accept(
+      createApiClient().create({
+        headers: authHeaders(),
+        body: {
+          agentId: fixture.agentId,
+          connectorRef: "github",
+          permission: "issues:read",
+          reason: "Second try",
+        },
+      }),
+      [201],
+    );
+
+    expect(resent.body.id).toBe(created.body.id);
+    expect(resent.body.status).toBe("pending");
+    expect(resent.body.reason).toBe("Second try");
+    expect(resent.body.resolvedBy).toBeNull();
+    expect(resent.body.resolvedAt).toBeNull();
+  });
+
+  it("returns 400 for an unknown connector ref", async () => {
+    const fixture = await track(
+      store.set(seedPermissionAccessOrg$, {}, context.signal),
+    );
+    mocks.clerk.session(fixture.ownerUserId, fixture.orgId);
+
+    const response = await accept(
+      createApiClient().create({
+        headers: authHeaders(),
+        body: {
+          agentId: fixture.agentId,
+          connectorRef: "nonexistent-connector",
+          permission: "read",
+        },
+      }),
+      [400],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Unknown connector ref: nonexistent-connector",
+        code: "VALIDATION_ERROR",
+      },
+    });
+  });
+
+  it("returns 404 for a nonexistent agent", async () => {
+    const fixture = await track(
+      store.set(seedPermissionAccessOrg$, {}, context.signal),
+    );
+    mocks.clerk.session(fixture.ownerUserId, fixture.orgId);
+    const agentId = randomUUID();
+
+    const response = await accept(
+      createApiClient().create({
+        headers: authHeaders(),
+        body: {
+          agentId,
+          connectorRef: "github",
+          permission: "issues:read",
+        },
+      }),
+      [404],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: `Agent not found: ${agentId}`,
+        code: "NOT_FOUND",
+      },
+    });
+  });
+
+  it("returns 401 without auth", async () => {
+    const response = await accept(
+      createApiClient().create({
+        headers: {},
+        body: {
+          agentId: randomUUID(),
+          connectorRef: "github",
+          permission: "issues:read",
+        },
+      }),
+      [401],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("allows non-admin members to create requests", async () => {
+    const fixture = await track(
+      store.set(seedPermissionAccessOrg$, {}, context.signal),
+    );
+    const memberUserId = `user_${randomUUID()}`;
+    await store.set(
+      seedOrgMember$,
+      { orgId: fixture.orgId, userId: memberUserId, role: "member" },
+      context.signal,
+    );
+    mocks.clerk.session(memberUserId, fixture.orgId, "org:member");
+
+    const response = await accept(
+      createApiClient().create({
+        headers: authHeaders(),
+        body: {
+          agentId: fixture.agentId,
+          connectorRef: "github",
+          permission: "issues:read",
+        },
+      }),
+      [201],
+    );
+
+    expect(response.body.requesterUserId).toBe(memberUserId);
+  });
 });
 
 describe("GET /api/zero/permission-access-requests", () => {

--- a/turbo/apps/api/src/signals/routes/zero-permission-access-requests.ts
+++ b/turbo/apps/api/src/signals/routes/zero-permission-access-requests.ts
@@ -1,5 +1,6 @@
 import { command, computed } from "ccstate";
 import {
+  permissionAccessRequestsCreateContract,
   permissionAccessRequestsListContract,
   permissionAccessRequestsResolveContract,
 } from "@vm0/api-contracts/contracts/zero-agents";
@@ -8,6 +9,7 @@ import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
 import { bodyResultOf, queryOf } from "../context/request";
 import {
+  createPermissionAccessRequest$,
   listPermissionAccessRequests,
   resolvePermissionAccessRequest$,
 } from "../services/zero-permission-access-requests.service";
@@ -24,6 +26,7 @@ const missingLookupQuery = Object.freeze({
 });
 
 const listQuery$ = queryOf(permissionAccessRequestsListContract.list);
+const createBody$ = bodyResultOf(permissionAccessRequestsCreateContract.create);
 const resolveBody$ = bodyResultOf(
   permissionAccessRequestsResolveContract.resolve,
 );
@@ -49,6 +52,33 @@ const listPermissionAccessRequestsInner$ = computed(async (get) => {
 
   return { status: 200 as const, body: [...requests] };
 });
+
+const createPermissionAccessRequestInner$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const auth = get(organizationAuthContext$);
+    const bodyResult = await get(createBody$);
+    signal.throwIfAborted();
+    if (!bodyResult.ok) {
+      return bodyResult.response;
+    }
+
+    const result = await set(
+      createPermissionAccessRequest$,
+      {
+        orgId: auth.orgId,
+        userId: auth.userId,
+        request: bodyResult.data,
+      },
+      signal,
+    );
+    signal.throwIfAborted();
+
+    if ("kind" in result) {
+      return { status: 201 as const, body: result.request };
+    }
+    return result;
+  },
+);
 
 const resolvePermissionAccessRequestInner$ = command(
   async ({ get, set }, signal: AbortSignal) => {
@@ -80,6 +110,17 @@ const resolvePermissionAccessRequestInner$ = command(
 );
 
 export const zeroPermissionAccessRequestsRoutes: readonly RouteEntry[] = [
+  {
+    route: permissionAccessRequestsCreateContract.create,
+    handler: authRoute(
+      {
+        requiredCapability: "agent:write",
+        requireOrganization: true,
+        missingOrganizationStatus: 401,
+      },
+      createPermissionAccessRequestInner$,
+    ),
+  },
   {
     route: permissionAccessRequestsListContract.list,
     handler: authRoute(

--- a/turbo/apps/api/src/signals/services/zero-permission-access-requests.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-permission-access-requests.service.ts
@@ -1,8 +1,10 @@
 import { command, computed, type Computed } from "ccstate";
 import { CONNECTOR_TYPES } from "@vm0/connectors/connectors";
+import { isFirewallConnectorType } from "@vm0/connectors/firewalls";
 import type { RawPermissionPolicies } from "@vm0/connectors/firewall-types";
 import { and, eq, or } from "drizzle-orm";
 import type {
+  CreatePermissionAccessRequest,
   PermissionAccessRequestResponse,
   ResolvePermissionAccessRequest,
 } from "@vm0/api-contracts/contracts/zero-agents";
@@ -39,6 +41,12 @@ interface ListPermissionAccessRequestsArgs {
   readonly status?: string;
 }
 
+interface CreatePermissionAccessRequestArgs {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly request: CreatePermissionAccessRequest;
+}
+
 interface ResolvePermissionAccessRequestArgs {
   readonly orgId: string;
   readonly userId: string;
@@ -57,6 +65,21 @@ type AlreadyResolvedResponse = {
   };
 };
 
+type ValidationErrorResponse = {
+  readonly status: 400;
+  readonly body: {
+    readonly error: {
+      readonly message: string;
+      readonly code: "VALIDATION_ERROR";
+    };
+  };
+};
+
+type CreatePermissionAccessRequestResult =
+  | { readonly kind: "ok"; readonly request: PermissionAccessRequestResponse }
+  | ReturnType<typeof notFound>
+  | ValidationErrorResponse;
+
 type ResolvePermissionAccessRequestResult =
   | { readonly kind: "ok"; readonly request: PermissionAccessRequestResponse }
   | ReturnType<typeof notFound>
@@ -74,6 +97,18 @@ function alreadyResolved(status: string): AlreadyResolvedResponse {
       error: {
         message: `Request already resolved with status: ${status}`,
         code: "ALREADY_RESOLVED",
+      },
+    },
+  };
+}
+
+function validationError(message: string): ValidationErrorResponse {
+  return {
+    status: 400 as const,
+    body: {
+      error: {
+        message,
+        code: "VALIDATION_ERROR" as const,
       },
     },
   };
@@ -120,6 +155,84 @@ function buildReviewUrl(agentId: string, requestId: string): string {
   return `${appUrl}/agents/${agentId}/permissions?request=${requestId}`;
 }
 
+interface SlackDmTarget {
+  readonly client: ReturnType<typeof createSlackClient>;
+  readonly slackUserId: string;
+}
+
+async function resolveSlackDmTarget(
+  db: Db,
+  orgId: string,
+  userId: string,
+): Promise<SlackDmTarget | null> {
+  const [installation] = await db
+    .select()
+    .from(slackOrgInstallations)
+    .where(eq(slackOrgInstallations.orgId, orgId))
+    .limit(1);
+  if (!installation) {
+    return null;
+  }
+
+  const [connection] = await db
+    .select()
+    .from(slackOrgConnections)
+    .where(
+      and(
+        eq(slackOrgConnections.vm0UserId, userId),
+        eq(slackOrgConnections.slackWorkspaceId, installation.slackWorkspaceId),
+      ),
+    )
+    .limit(1);
+  if (!connection) {
+    return null;
+  }
+
+  return {
+    client: createSlackClient(
+      decryptSecretValue(installation.encryptedBotToken),
+    ),
+    slackUserId: connection.slackUserId,
+  };
+}
+
+async function notifyOwnerOfRequest(
+  db: Db,
+  params: {
+    readonly orgId: string;
+    readonly ownerUserId: string;
+    readonly agentId: string;
+    readonly requestId: string;
+    readonly agentDisplayName: string;
+    readonly requesterName: string;
+    readonly permission: string;
+    readonly connectorRef: string;
+    readonly action: string;
+    readonly reason?: string | null;
+  },
+): Promise<void> {
+  const target = await resolveSlackDmTarget(
+    db,
+    params.orgId,
+    params.ownerUserId,
+  );
+  if (!target) {
+    return;
+  }
+
+  const label = connectorLabel(params.connectorRef);
+  const url = buildReviewUrl(params.agentId, params.requestId);
+  const lines = [
+    `${params.requesterName} is requesting to ${params.action} "${params.permission}" on ${label} for agent ${params.agentDisplayName}.`,
+  ];
+  if (params.reason) {
+    lines.push(`Reason: ${params.reason}`);
+  }
+  lines.push(`<${url}|Review request>`);
+
+  await postMessage(target.client, target.slackUserId, lines.join("\n"));
+}
+
 async function notifyRequesterOfResolution(
   db: Db,
   params: {
@@ -134,38 +247,21 @@ async function notifyRequesterOfResolution(
     readonly resolution: ResolvePermissionAccessRequest["action"];
   },
 ): Promise<void> {
-  const [installation] = await db
-    .select()
-    .from(slackOrgInstallations)
-    .where(eq(slackOrgInstallations.orgId, params.orgId))
-    .limit(1);
-  if (!installation) {
-    return;
-  }
-
-  const [connection] = await db
-    .select()
-    .from(slackOrgConnections)
-    .where(
-      and(
-        eq(slackOrgConnections.vm0UserId, params.requesterUserId),
-        eq(slackOrgConnections.slackWorkspaceId, installation.slackWorkspaceId),
-      ),
-    )
-    .limit(1);
-  if (!connection) {
-    return;
-  }
-
-  const client = createSlackClient(
-    decryptSecretValue(installation.encryptedBotToken),
+  const target = await resolveSlackDmTarget(
+    db,
+    params.orgId,
+    params.requesterUserId,
   );
+  if (!target) {
+    return;
+  }
+
   const label = connectorLabel(params.connectorRef);
   const outcome = params.resolution === "approve" ? "approved" : "denied";
   const url = buildReviewUrl(params.agentId, params.requestId);
   await postMessage(
-    client,
-    connection.slackUserId,
+    target.client,
+    target.slackUserId,
     `Your request to ${params.action} "${params.permission}" on ${label} for agent ${params.agentDisplayName} has been ${outcome}. <${url}|View>`,
   );
 }
@@ -280,6 +376,115 @@ export function listPermissionAccessRequests(
     },
   );
 }
+
+export const createPermissionAccessRequest$ = command(
+  async (
+    { get, set },
+    args: CreatePermissionAccessRequestArgs,
+    signal: AbortSignal,
+  ): Promise<CreatePermissionAccessRequestResult> => {
+    const db = set(writeDb$);
+    const client = get(clerk$);
+    const request = args.request;
+
+    if (!isFirewallConnectorType(request.connectorRef)) {
+      return validationError(`Unknown connector ref: ${request.connectorRef}`);
+    }
+
+    const [agent] = await db
+      .select({
+        id: zeroAgents.id,
+        owner: zeroAgents.owner,
+        displayName: zeroAgents.displayName,
+      })
+      .from(zeroAgents)
+      .where(
+        and(
+          eq(zeroAgents.orgId, args.orgId),
+          eq(zeroAgents.id, request.agentId),
+          visibleZeroAgentCondition(args.userId),
+        ),
+      )
+      .limit(1);
+    signal.throwIfAborted();
+
+    if (!agent) {
+      return notFound(`Agent not found: ${request.agentId}`);
+    }
+
+    const [existing] = await db
+      .select()
+      .from(permissionAccessRequests)
+      .where(
+        and(
+          eq(permissionAccessRequests.agentId, request.agentId),
+          eq(permissionAccessRequests.connectorRef, request.connectorRef),
+          eq(permissionAccessRequests.permission, request.permission),
+          eq(permissionAccessRequests.action, request.action),
+          eq(permissionAccessRequests.requesterUserId, args.userId),
+        ),
+      )
+      .limit(1);
+    signal.throwIfAborted();
+
+    const [row] = existing
+      ? await db
+          .update(permissionAccessRequests)
+          .set({
+            reason: request.reason ?? existing.reason,
+            method: request.method ?? existing.method,
+            path: request.path ?? existing.path,
+            status: "pending",
+            resolvedBy: null,
+            resolvedAt: null,
+          })
+          .where(eq(permissionAccessRequests.id, existing.id))
+          .returning()
+      : await db
+          .insert(permissionAccessRequests)
+          .values({
+            orgId: args.orgId,
+            agentId: request.agentId,
+            requesterUserId: args.userId,
+            connectorRef: request.connectorRef,
+            permission: request.permission,
+            action: request.action,
+            method: request.method,
+            path: request.path,
+            reason: request.reason,
+          })
+          .returning();
+    signal.throwIfAborted();
+
+    if (!row) {
+      throw new Error("Permission access request create did not return a row");
+    }
+
+    log.debug(
+      `${existing ? "Reused" : "Created"} permission access request: ${row.id} for agent: ${request.agentId}`,
+    );
+
+    const requesterNames = await requesterNameMap(client, [args.userId]);
+    signal.throwIfAborted();
+
+    void notifyOwnerOfRequest(db, {
+      orgId: args.orgId,
+      ownerUserId: agent.owner,
+      agentId: request.agentId,
+      requestId: row.id,
+      agentDisplayName: agent.displayName ?? request.agentId,
+      requesterName: requesterNames.get(args.userId) ?? args.userId,
+      permission: request.permission,
+      connectorRef: request.connectorRef,
+      action: request.action,
+      reason: request.reason,
+    }).catch((error: unknown) => {
+      log.error("Failed to notify owner of permission request", { error });
+    });
+
+    return { kind: "ok", request: formatPermissionAccessRequest(row) };
+  },
+);
 
 export const resolvePermissionAccessRequest$ = command(
   async (


### PR DESCRIPTION
## Summary
- Add the API backend POST route for `/api/zero/permission-access-requests` with the same auth and org requirements as the existing web route.
- Move create-request behavior into the API service, including connector validation, visible-agent lookup, request dedupe/reset, and best-effort owner Slack notification.
- Add API integration coverage for create, dedupe, explicit action, rejected-request resend, validation/auth errors, and member requester behavior.

Closes #12883

## Validation
- `cd turbo && pnpm format`
- `cd turbo && pnpm -F api exec vitest src/signals/routes/__tests__/zero-permission-access-requests.test.ts`
- `cd turbo && pnpm -F api lint`
- `cd turbo && pnpm check-types`
- `cd turbo && pnpm turbo run lint`
- `cd turbo && pnpm knip`
- `cd turbo && pnpm -F api exec vitest` (141 files, 1307 tests)
- `git diff --check`

Known local result:
- `cd turbo && pnpm vitest` failed locally after 1179s with broad `@vm0/app` / `web` timeout and state-leakage failures (77 failed files, 322 failed tests). The targeted API suite and full `api` workspace suite passed, including the new permission-access route tests.
