### PR TITLE
refactor(api): migrate zero org leave route

### DIFF
--- a/turbo/apps/api/src/__tests__/mocks.ts
+++ b/turbo/apps/api/src/__tests__/mocks.ts
@@ -29,6 +29,7 @@ export interface ApiTestMocks {
       readonly getOrganizationDomainList: AsyncMock;
       readonly getOrganizationInvitationList: AsyncMock;
       readonly getOrganizationMembershipList: AsyncMock;
+      readonly deleteOrganizationMembership: AsyncMock;
       readonly revokeOrganizationInvitation: AsyncMock;
       readonly updateOrganization: AsyncMock;
     };
@@ -126,6 +127,8 @@ const apiTestMocks: ApiTestMocks = vi.hoisted((): ApiTestMocks => {
       getOrganizationInvitationList:
         vi.fn<(...args: unknown[]) => Promise<unknown>>(),
       getOrganizationMembershipList:
+        vi.fn<(...args: unknown[]) => Promise<unknown>>(),
+      deleteOrganizationMembership:
         vi.fn<(...args: unknown[]) => Promise<unknown>>(),
       revokeOrganizationInvitation:
         vi.fn<(...args: unknown[]) => Promise<unknown>>(),

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-org.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-org.test.ts
@@ -1,11 +1,18 @@
 import { randomUUID } from "node:crypto";
 
-import { zeroOrgContract } from "@vm0/api-contracts/contracts/zero-org";
+import {
+  zeroOrgContract,
+  zeroOrgLeaveContract,
+} from "@vm0/api-contracts/contracts/zero-org";
 import { orgCache } from "@vm0/db/schema/org-cache";
+import { orgMembersCache } from "@vm0/db/schema/org-members-cache";
+import { orgMembersMetadata } from "@vm0/db/schema/org-members-metadata";
 import { orgMetadata } from "@vm0/db/schema/org-metadata";
+import { slackOrgConnections } from "@vm0/db/schema/slack-org-connection";
+import { slackOrgInstallations } from "@vm0/db/schema/slack-org-installation";
 import { createStore } from "ccstate";
-import { eq } from "drizzle-orm";
-import { afterEach } from "vitest";
+import { and, eq } from "drizzle-orm";
+import { afterEach, beforeEach } from "vitest";
 
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
 import { now } from "../../../lib/time";
@@ -101,6 +108,14 @@ async function deleteOrgComposite(
   fixture: OrgMembershipFixture,
 ): Promise<void> {
   const writeDb = store.set(writeDb$);
+  await writeDb
+    .delete(orgMembersMetadata)
+    .where(
+      and(
+        eq(orgMembersMetadata.orgId, fixture.orgId),
+        eq(orgMembersMetadata.userId, fixture.userId),
+      ),
+    );
   await writeDb.delete(orgMetadata).where(eq(orgMetadata.orgId, fixture.orgId));
   await store.set(deleteOrgMembership$, fixture, context.signal);
 }
@@ -122,6 +137,80 @@ async function readOrgCache(orgId: string): Promise<
     .where(eq(orgCache.orgId, orgId))
     .limit(1);
   return cached;
+}
+
+async function readOrgMemberCache(
+  orgId: string,
+  userId: string,
+): Promise<{ readonly role: string } | undefined> {
+  const writeDb = store.set(writeDb$);
+  const [cached] = await writeDb
+    .select({ role: orgMembersCache.role })
+    .from(orgMembersCache)
+    .where(
+      and(eq(orgMembersCache.orgId, orgId), eq(orgMembersCache.userId, userId)),
+    )
+    .limit(1);
+  return cached;
+}
+
+async function readOrgMemberMetadata(
+  orgId: string,
+  userId: string,
+): Promise<{ readonly userId: string } | undefined> {
+  const writeDb = store.set(writeDb$);
+  const [metadata] = await writeDb
+    .select({ userId: orgMembersMetadata.userId })
+    .from(orgMembersMetadata)
+    .where(
+      and(
+        eq(orgMembersMetadata.orgId, orgId),
+        eq(orgMembersMetadata.userId, userId),
+      ),
+    )
+    .limit(1);
+  return metadata;
+}
+
+function readSlackConnections(
+  workspaceId: string,
+): Promise<{ readonly vm0UserId: string }[]> {
+  const writeDb = store.set(writeDb$);
+  return writeDb
+    .select({ vm0UserId: slackOrgConnections.vm0UserId })
+    .from(slackOrgConnections)
+    .where(eq(slackOrgConnections.slackWorkspaceId, workspaceId));
+}
+
+async function seedSlackOrgConnection(
+  orgId: string,
+  userId: string,
+): Promise<string> {
+  const writeDb = store.set(writeDb$);
+  const workspaceId = `T_${randomUUID().replace(/-/g, "").slice(0, 10)}`;
+  await writeDb.insert(slackOrgInstallations).values({
+    slackWorkspaceId: workspaceId,
+    slackWorkspaceName: "Test Workspace",
+    orgId,
+    encryptedBotToken: "encrypted-token",
+    botUserId: "U_BOT",
+  });
+  await writeDb.insert(slackOrgConnections).values({
+    slackUserId: `U_${randomUUID().replace(/-/g, "").slice(0, 10)}`,
+    slackWorkspaceId: workspaceId,
+    vm0UserId: userId,
+  });
+  return workspaceId;
+}
+
+async function deleteSlackWorkspace(workspaceId: string): Promise<void> {
+  const writeDb = store.set(writeDb$);
+  await writeDb
+    .delete(slackOrgConnections)
+    .where(eq(slackOrgConnections.slackWorkspaceId, workspaceId));
+  await writeDb
+    .delete(slackOrgInstallations)
+    .where(eq(slackOrgInstallations.slackWorkspaceId, workspaceId));
 }
 
 describe("GET /api/zero/org", () => {
@@ -499,6 +588,165 @@ describe("PUT /api/zero/org", () => {
     });
     expect(
       context.mocks.clerk.organizations.updateOrganization,
+    ).not.toHaveBeenCalled();
+  });
+});
+
+describe("POST /api/zero/org/leave", () => {
+  const seededFixtures: OrgMembershipFixture[] = [];
+  const slackWorkspaces: string[] = [];
+
+  beforeEach(() => {
+    context.mocks.clerk.organizations.deleteOrganizationMembership.mockReset();
+    context.mocks.clerk.organizations.deleteOrganizationMembership.mockResolvedValue(
+      {},
+    );
+  });
+
+  afterEach(async () => {
+    while (slackWorkspaces.length > 0) {
+      const workspaceId = slackWorkspaces.pop();
+      if (workspaceId) {
+        await deleteSlackWorkspace(workspaceId);
+      }
+    }
+
+    while (seededFixtures.length > 0) {
+      const fixture = seededFixtures.pop();
+      if (fixture) {
+        await deleteOrgComposite(fixture);
+      }
+    }
+  });
+
+  it("lets a member leave the active org and cleans local membership state", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    seededFixtures.push(await seedOrg({ orgId, userId, role: "member" }));
+    const workspaceId = await seedSlackOrgConnection(orgId, userId);
+    slackWorkspaces.push(workspaceId);
+    const writeDb = store.set(writeDb$);
+    await writeDb.insert(orgMembersMetadata).values({ orgId, userId });
+    mocks.clerk.session(userId, orgId, "org:member");
+
+    const client = setupApp({ context })(zeroOrgLeaveContract);
+    const response = await accept(
+      client.leave({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {},
+      }),
+      [200],
+    );
+
+    expect(response).toMatchObject({ body: { message: "Left org" } });
+    expect(
+      context.mocks.clerk.organizations.deleteOrganizationMembership,
+    ).toHaveBeenCalledWith({ organizationId: orgId, userId });
+    await expect(readOrgMemberCache(orgId, userId)).resolves.toBeUndefined();
+    await expect(readOrgMemberMetadata(orgId, userId)).resolves.toBeUndefined();
+    await expect(readSlackConnections(workspaceId)).resolves.toHaveLength(0);
+  });
+
+  it("rejects admins", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    seededFixtures.push(await seedOrg({ orgId, userId, role: "admin" }));
+    mocks.clerk.session(userId, orgId, "org:admin");
+
+    const client = setupApp({ context })(zeroOrgLeaveContract);
+    const response = await accept(
+      client.leave({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {},
+      }),
+      [403],
+    );
+
+    expect(response).toMatchObject({
+      body: {
+        error: {
+          code: "FORBIDDEN",
+          message: "Admins cannot leave the organization",
+        },
+      },
+    });
+    expect(
+      context.mocks.clerk.organizations.deleteOrganizationMembership,
+    ).not.toHaveBeenCalled();
+    await expect(readOrgMemberCache(orgId, userId)).resolves.toMatchObject({
+      role: "admin",
+    });
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    const client = setupApp({ context })(zeroOrgLeaveContract);
+    const response = await accept(
+      client.leave({ headers: {}, body: {} }),
+      [401],
+    );
+
+    expect(response).toMatchObject({
+      body: { error: { code: "UNAUTHORIZED" } },
+    });
+  });
+
+  it("returns 400 when authenticated without an org", async () => {
+    mocks.clerk.session(`user_${randomUUID()}`, null);
+
+    const client = setupApp({ context })(zeroOrgLeaveContract);
+    const response = await accept(
+      client.leave({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {},
+      }),
+      [400],
+    );
+
+    expect(response).toMatchObject({
+      body: {
+        error: {
+          code: "BAD_REQUEST",
+          message:
+            "Explicit org context required — ensure active org in session",
+        },
+      },
+    });
+  });
+
+  it("rejects zero tokens", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    seededFixtures.push(await seedOrg({ orgId, userId, role: "member" }));
+    const seconds = currentSecond();
+    const token = signSandboxJwtForTests({
+      scope: "zero",
+      userId,
+      orgId,
+      runId: `run_${randomUUID()}`,
+      capabilities: [],
+      iat: seconds,
+      exp: seconds + 600,
+    });
+
+    const client = setupApp({ context })(zeroOrgLeaveContract);
+    const response = await accept(
+      client.leave({
+        headers: { authorization: `Bearer ${token}` },
+        body: {},
+      }),
+      [403],
+    );
+
+    expect(response).toMatchObject({
+      body: {
+        error: {
+          code: "FORBIDDEN",
+          message: "This endpoint is not available for sandbox tokens",
+        },
+      },
+    });
+    expect(
+      context.mocks.clerk.organizations.deleteOrganizationMembership,
     ).not.toHaveBeenCalled();
   });
 });

--- a/turbo/apps/api/src/signals/routes/zero-org-read.ts
+++ b/turbo/apps/api/src/signals/routes/zero-org-read.ts
@@ -1,5 +1,8 @@
 import { command, computed } from "ccstate";
-import { zeroOrgContract } from "@vm0/api-contracts/contracts/zero-org";
+import {
+  zeroOrgContract,
+  zeroOrgLeaveContract,
+} from "@vm0/api-contracts/contracts/zero-org";
 import { zeroOrgListContract } from "@vm0/api-contracts/contracts/zero-org-list";
 import { zeroOrgDomainsContract } from "@vm0/api-contracts/contracts/zero-org-domains";
 import { zeroOrgMembersContract } from "@vm0/api-contracts/contracts/zero-org-members";
@@ -10,6 +13,7 @@ import { bodyResultOf } from "../context/request";
 import { badRequestMessage, notFound } from "../../lib/error";
 import type { RouteEntry } from "../route";
 import {
+  leaveZeroOrg$,
   updateZeroOrg$,
   zeroOrgDetail$,
   zeroOrgDomainsList,
@@ -86,6 +90,34 @@ const updateOrgInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   };
 });
 
+const leaveOrgBody$ = bodyResultOf(zeroOrgLeaveContract.leave);
+
+const leaveOrgInner$ = command(async ({ get, set }, signal: AbortSignal) => {
+  const auth = get(organizationAuthContext$);
+  const bodyResult = await get(leaveOrgBody$);
+  signal.throwIfAborted();
+  if (!bodyResult.ok) {
+    return bodyResult.response;
+  }
+
+  const result = await set(
+    leaveZeroOrg$,
+    {
+      orgId: auth.orgId,
+      userId: auth.userId,
+      role: auth.orgRole ?? "member",
+    },
+    signal,
+  );
+  signal.throwIfAborted();
+
+  if ("status" in result) {
+    return result;
+  }
+
+  return { status: 200 as const, body: result };
+});
+
 const listOrgsInner$ = computed(async (get) => {
   const auth = get(authContext$);
   const body = await get(zeroOrgList(auth.userId));
@@ -123,6 +155,10 @@ export const zeroOrgReadRoutes: readonly RouteEntry[] = [
   {
     route: zeroOrgContract.update,
     handler: authRoute({}, updateOrgInner$),
+  },
+  {
+    route: zeroOrgLeaveContract.leave,
+    handler: authRoute({ requireOrganization: true }, leaveOrgInner$),
   },
   {
     route: zeroOrgListContract.list,

--- a/turbo/apps/api/src/signals/services/zero-org-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-org-data.service.ts
@@ -1,20 +1,24 @@
 import { command, computed, type Computed } from "ccstate";
-import { and, eq } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
 import { z } from "zod";
 import { orgCache } from "@vm0/db/schema/org-cache";
 import { orgMetadata } from "@vm0/db/schema/org-metadata";
 import { orgMembersCache } from "@vm0/db/schema/org-members-cache";
+import { orgMembersMetadata } from "@vm0/db/schema/org-members-metadata";
+import { slackOrgConnections } from "@vm0/db/schema/slack-org-connection";
+import { slackOrgInstallations } from "@vm0/db/schema/slack-org-installation";
 import type { OrgResponse } from "@vm0/api-contracts/contracts/orgs";
 import type { OrgListResponse } from "@vm0/api-contracts/contracts/org-list";
 import type {
   OrgDomainsResponse,
+  OrgMessageResponse,
   OrgMember,
   OrgMembersResponse,
   OrgRole,
 } from "@vm0/api-contracts/contracts/org-members";
 import type { User } from "@clerk/backend";
 
-import { db$, writeDb$ } from "../external/db";
+import { db$, writeDb$, type Db } from "../external/db";
 import { clerk$ } from "../external/clerk";
 import { fetchClerkMembershipRequests } from "../external/clerk-membership-requests";
 import { badRequestMessage, conflict, notFound } from "../../lib/error";
@@ -57,6 +61,16 @@ const forbiddenAccess = Object.freeze({
   }),
 });
 
+const adminCannotLeave = Object.freeze({
+  status: 403 as const,
+  body: Object.freeze({
+    error: Object.freeze({
+      message: "Admins cannot leave the organization",
+      code: "FORBIDDEN",
+    }),
+  }),
+});
+
 type OrgUpdateErrorResponse =
   | ReturnType<typeof badRequestMessage>
   | ReturnType<typeof conflict>
@@ -69,6 +83,12 @@ interface UpdateZeroOrgArgs {
   readonly slug?: string;
   readonly name?: string;
   readonly force?: boolean;
+}
+
+interface LeaveZeroOrgArgs {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly role: OrgRole;
 }
 
 interface ClerkUpdate {
@@ -85,6 +105,67 @@ function isReservedSlug(slug: string): boolean {
     slug === "app" ||
     slug === "www"
   );
+}
+
+async function cleanupOrgMember(
+  writeDb: Db,
+  args: Pick<LeaveZeroOrgArgs, "orgId" | "userId">,
+  signal: AbortSignal,
+): Promise<void> {
+  const [installation] = await writeDb
+    .select({ slackWorkspaceId: slackOrgInstallations.slackWorkspaceId })
+    .from(slackOrgInstallations)
+    .where(eq(slackOrgInstallations.orgId, args.orgId))
+    .limit(1);
+  signal.throwIfAborted();
+
+  if (installation) {
+    const connections = await writeDb
+      .select({ id: slackOrgConnections.id })
+      .from(slackOrgConnections)
+      .where(
+        and(
+          eq(slackOrgConnections.vm0UserId, args.userId),
+          eq(
+            slackOrgConnections.slackWorkspaceId,
+            installation.slackWorkspaceId,
+          ),
+        ),
+      );
+    signal.throwIfAborted();
+
+    if (connections.length > 0) {
+      await writeDb.delete(slackOrgConnections).where(
+        inArray(
+          slackOrgConnections.id,
+          connections.map((connection) => {
+            return connection.id;
+          }),
+        ),
+      );
+      signal.throwIfAborted();
+    }
+  }
+
+  await writeDb
+    .delete(orgMembersCache)
+    .where(
+      and(
+        eq(orgMembersCache.userId, args.userId),
+        eq(orgMembersCache.orgId, args.orgId),
+      ),
+    );
+  signal.throwIfAborted();
+
+  await writeDb
+    .delete(orgMembersMetadata)
+    .where(
+      and(
+        eq(orgMembersMetadata.userId, args.userId),
+        eq(orgMembersMetadata.orgId, args.orgId),
+      ),
+    );
+  signal.throwIfAborted();
 }
 
 function isClerkNotFound(error: unknown): boolean {
@@ -200,6 +281,30 @@ export const zeroOrgDetail$ = command(
       role: (membership[0]?.role as OrgRole) ?? "member",
       createdBy: identity.createdBy ?? undefined,
     };
+  },
+);
+
+export const leaveZeroOrg$ = command(
+  async (
+    { get, set },
+    args: LeaveZeroOrgArgs,
+    signal: AbortSignal,
+  ): Promise<OrgMessageResponse | typeof adminCannotLeave> => {
+    if (args.role === "admin") {
+      return adminCannotLeave;
+    }
+
+    const client = get(clerk$);
+    await client.organizations.deleteOrganizationMembership({
+      organizationId: args.orgId,
+      userId: args.userId,
+    });
+    signal.throwIfAborted();
+
+    await cleanupOrgMember(set(writeDb$), args, signal);
+    signal.throwIfAborted();
+
+    return { message: "Left org" };
   },
 );
 

--- a/turbo/packages/api-contracts/src/contracts/zero-org.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-org.ts
@@ -54,6 +54,7 @@ export const zeroOrgLeaveContract = c.router({
     body: z.object({}),
     responses: {
       200: orgMessageResponseSchema,
+      400: apiErrorSchema,
       401: apiErrorSchema,
       403: apiErrorSchema,
       500: apiErrorSchema,


### PR DESCRIPTION
## Summary
- Register `POST /api/zero/org/leave` in the API backend as an authoritative ccstate command route.
- Add API-native org leave behavior that rejects admins, calls Clerk membership deletion, and cleans local Slack/org membership state.
- Extend API integration coverage for success, auth failures, admin rejection, zero-token rejection, and local cleanup parity.

Closes #12881

## Validation
- `pnpm -F api exec vitest src/signals/routes/__tests__/zero-org.test.ts`
- `pnpm -F api lint`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F @vm0/api-contracts check-types`
- `git diff --check`

## Notes
- `pnpm -F api check-types` and the pre-commit root `pnpm check-types` still hit the existing ts-rest `body`/`never` type baseline outside this migration scope; no errors were reported for the new route/service/mock/contract changes, and the new test assertions avoid adding new scoped `body` access errors.