### PR TITLE
refactor(api): migrate telegram delete routes to api backend

### DIFF
--- a/turbo/apps/api/src/__tests__/mocks.ts
+++ b/turbo/apps/api/src/__tests__/mocks.ts
@@ -98,6 +98,7 @@ export interface ApiTestMocks {
   readonly telegram: {
     readonly getMe: AsyncMock;
     readonly getFile: AsyncMock;
+    readonly deleteWebhook: AsyncMock;
   };
   readonly otel: {
     readonly registerOTel: SyncMock;
@@ -196,6 +197,7 @@ const apiTestMocks: ApiTestMocks = vi.hoisted((): ApiTestMocks => {
   const telegram = {
     getMe: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
     getFile: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
+    deleteWebhook: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
   };
 
   const axiomLogging = {
@@ -418,6 +420,7 @@ vi.mock("../signals/external/telegram-client", async () => {
     ...actual,
     getMe: apiTestMocks.telegram.getMe,
     getFile: apiTestMocks.telegram.getFile,
+    deleteWebhook: apiTestMocks.telegram.deleteWebhook,
   };
 });
 
@@ -527,6 +530,8 @@ export function resetApiTestMocks(): void {
   mockStripeClient(apiTestMocks.stripe as unknown as StripeSDK);
   apiTestMocks.telegram.getMe.mockReset();
   apiTestMocks.telegram.getFile.mockReset();
+  apiTestMocks.telegram.deleteWebhook.mockReset();
+  apiTestMocks.telegram.deleteWebhook.mockResolvedValue(undefined);
   apiTestMocks.otel.registerOTel.mockReset();
   apiTestMocks.sentry.captureException.mockReset();
   apiTestMocks.sentry.httpIntegration.mockClear();

--- a/turbo/apps/api/src/signals/external/telegram-client.ts
+++ b/turbo/apps/api/src/signals/external/telegram-client.ts
@@ -74,6 +74,24 @@ export function buildFileDownloadUrl(token: string, filePath: string): string {
   return `https://api.telegram.org/file/bot${token}/${filePath}`;
 }
 
+export async function deleteWebhook(token: string): Promise<void> {
+  const response = await fetch(
+    `https://api.telegram.org/bot${token}/deleteWebhook`,
+    { method: "POST" },
+  );
+
+  if (!response.ok) {
+    throw new Error(
+      `Telegram API error: ${response.status} ${response.statusText}`,
+    );
+  }
+
+  const data: unknown = await response.json();
+  if (isTelegramApiError(data)) {
+    throw new Error(`Telegram API error: ${data.description}`);
+  }
+}
+
 /**
  * Send a chat action (e.g. typing indicator) to a Telegram chat.
  *

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations-telegram-delete.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations-telegram-delete.test.ts
@@ -1,0 +1,546 @@
+import { randomUUID } from "node:crypto";
+
+import { createStore } from "ccstate";
+import { afterEach, describe, expect, it } from "vitest";
+import { and, count, eq } from "drizzle-orm";
+import {
+  OFFICIAL_TELEGRAM_BOT_ID,
+  zeroIntegrationsTelegramContract,
+} from "@vm0/api-contracts/contracts/zero-integrations-telegram";
+import { agentSessions } from "@vm0/db/schema/agent-session";
+import { telegramInstallations } from "@vm0/db/schema/telegram-installation";
+import { telegramMessages } from "@vm0/db/schema/telegram-message";
+import { telegramOfficialUserLinks } from "@vm0/db/schema/telegram-official-user-link";
+import { telegramThreadSessions } from "@vm0/db/schema/telegram-thread-session";
+import { telegramUserLinks } from "@vm0/db/schema/telegram-user-link";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { writeDb$ } from "../../external/db";
+import {
+  deleteTelegramFixture$,
+  seedTelegramInstallation$,
+  type TelegramFixture,
+} from "./helpers/zero-telegram";
+import { createZeroRouteMocks } from "./helpers/zero-route-test";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+const AUTH_HEADERS = { authorization: "Bearer clerk-session" } as const;
+
+interface SeededBot extends TelegramFixture {
+  readonly botId: string;
+  readonly composeId: string;
+  readonly ownerUserId: string;
+}
+
+describe("DELETE /api/integrations/telegram", () => {
+  const fixtures: TelegramFixture[] = [];
+
+  afterEach(async () => {
+    while (fixtures.length > 0) {
+      const fixture = fixtures.pop();
+      if (fixture) {
+        await store.set(deleteTelegramFixture$, fixture, context.signal);
+      }
+    }
+  });
+
+  function newId(prefix: string): string {
+    return `${prefix}_${randomUUID().slice(0, 8)}`;
+  }
+
+  async function seedBot(
+    args: {
+      readonly orgId?: string;
+      readonly ownerUserId?: string;
+      readonly botId?: string;
+    } = {},
+  ): Promise<SeededBot> {
+    const orgId = args.orgId ?? newId("org");
+    const ownerUserId = args.ownerUserId ?? newId("user");
+    const botId = args.botId ?? newId("bot");
+    const installation = await store.set(
+      seedTelegramInstallation$,
+      { orgId, ownerUserId, telegramBotId: botId },
+      context.signal,
+    );
+    const fixture = {
+      orgId,
+      composeIds: [installation.composeId],
+      telegramBotIds: [botId],
+      userIds: [ownerUserId],
+      botId,
+      composeId: installation.composeId,
+      ownerUserId,
+    };
+    fixtures.push(fixture);
+    return fixture;
+  }
+
+  function client() {
+    return setupApp({ context })(zeroIntegrationsTelegramContract);
+  }
+
+  function requireInsertedRow<T>(row: T | undefined, label: string): T {
+    if (!row) {
+      throw new Error(`Failed to insert ${label}`);
+    }
+    return row;
+  }
+
+  async function insertUserLink(args: {
+    readonly installationId: string;
+    readonly userId: string;
+    readonly telegramUserId?: string;
+  }): Promise<string> {
+    const writeDb = store.set(writeDb$);
+    const [row] = await writeDb
+      .insert(telegramUserLinks)
+      .values({
+        installationId: args.installationId,
+        vm0UserId: args.userId,
+        telegramUserId: args.telegramUserId ?? newId("telegram-user"),
+      })
+      .returning({ id: telegramUserLinks.id });
+    return requireInsertedRow(row, "Telegram user link").id;
+  }
+
+  async function insertOfficialUserLink(args: {
+    readonly orgId: string;
+    readonly userId: string;
+    readonly telegramUserId?: string;
+  }): Promise<string> {
+    const writeDb = store.set(writeDb$);
+    const [row] = await writeDb
+      .insert(telegramOfficialUserLinks)
+      .values({
+        orgId: args.orgId,
+        vm0UserId: args.userId,
+        telegramUserId: args.telegramUserId ?? newId("telegram-official-user"),
+      })
+      .returning({ id: telegramOfficialUserLinks.id });
+    return requireInsertedRow(row, "official Telegram user link").id;
+  }
+
+  async function countInstallations(botId: string): Promise<number> {
+    const writeDb = store.set(writeDb$);
+    const [row] = await writeDb
+      .select({ value: count() })
+      .from(telegramInstallations)
+      .where(eq(telegramInstallations.telegramBotId, botId));
+    return row?.value ?? 0;
+  }
+
+  async function countMessages(installationId: string): Promise<number> {
+    const writeDb = store.set(writeDb$);
+    const [row] = await writeDb
+      .select({ value: count() })
+      .from(telegramMessages)
+      .where(eq(telegramMessages.installationId, installationId));
+    return row?.value ?? 0;
+  }
+
+  async function countOfficialLinks(id: string): Promise<number> {
+    const writeDb = store.set(writeDb$);
+    const [row] = await writeDb
+      .select({ value: count() })
+      .from(telegramOfficialUserLinks)
+      .where(eq(telegramOfficialUserLinks.id, id));
+    return row?.value ?? 0;
+  }
+
+  async function linkInstallationsForUser(userId: string): Promise<string[]> {
+    const writeDb = store.set(writeDb$);
+    const rows = await writeDb
+      .select({ installationId: telegramUserLinks.installationId })
+      .from(telegramUserLinks)
+      .where(eq(telegramUserLinks.vm0UserId, userId));
+    return rows
+      .map((row) => {
+        return row.installationId;
+      })
+      .sort();
+  }
+
+  async function userLinkExists(args: {
+    readonly installationId: string;
+    readonly telegramUserId: string;
+  }): Promise<boolean> {
+    const writeDb = store.set(writeDb$);
+    const [row] = await writeDb
+      .select({ id: telegramUserLinks.id })
+      .from(telegramUserLinks)
+      .where(
+        and(
+          eq(telegramUserLinks.installationId, args.installationId),
+          eq(telegramUserLinks.telegramUserId, args.telegramUserId),
+        ),
+      )
+      .limit(1);
+    return row !== undefined;
+  }
+
+  async function threadSessionExists(args: {
+    readonly userLinkId: string;
+    readonly chatId: string;
+    readonly rootMessageId: string;
+  }): Promise<boolean> {
+    const writeDb = store.set(writeDb$);
+    const [row] = await writeDb
+      .select({ id: telegramThreadSessions.id })
+      .from(telegramThreadSessions)
+      .where(
+        and(
+          eq(telegramThreadSessions.telegramUserLinkId, args.userLinkId),
+          eq(telegramThreadSessions.chatId, args.chatId),
+          eq(telegramThreadSessions.rootMessageId, args.rootMessageId),
+        ),
+      )
+      .limit(1);
+    return row !== undefined;
+  }
+
+  async function seedThreadSession(args: {
+    readonly userId: string;
+    readonly orgId: string;
+    readonly composeId: string;
+    readonly userLinkId: string;
+    readonly chatId: string;
+    readonly rootMessageId: string;
+  }): Promise<void> {
+    const writeDb = store.set(writeDb$);
+    const [session] = await writeDb
+      .insert(agentSessions)
+      .values({
+        userId: args.userId,
+        orgId: args.orgId,
+        agentComposeId: args.composeId,
+      })
+      .returning({ id: agentSessions.id });
+    const insertedSession = requireInsertedRow(session, "agent session");
+
+    await writeDb.insert(telegramThreadSessions).values({
+      telegramUserLinkId: args.userLinkId,
+      chatId: args.chatId,
+      rootMessageId: args.rootMessageId,
+      agentSessionId: insertedSession.id,
+    });
+  }
+
+  describe("DELETE /api/integrations/telegram/:botId", () => {
+    it("returns 401 when unauthenticated", async () => {
+      const response = await accept(
+        client().disconnect({
+          params: { botId: newId("bot") },
+          headers: {},
+        }),
+        [401],
+      );
+
+      expect(response.body).toStrictEqual({
+        error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+      });
+    });
+
+    it("returns 403 when uninstalling the official bot", async () => {
+      const userId = newId("user");
+      const orgId = newId("org");
+      mocks.clerk.session(userId, orgId, "org:admin");
+
+      const response = await accept(
+        client().disconnect({
+          params: { botId: OFFICIAL_TELEGRAM_BOT_ID },
+          headers: AUTH_HEADERS,
+        }),
+        [403],
+      );
+
+      expect(response.body).toStrictEqual({
+        error: {
+          message: "The official Telegram bot cannot be uninstalled",
+          code: "FORBIDDEN",
+        },
+      });
+    });
+
+    it("returns 404 for an unknown bot", async () => {
+      mocks.clerk.session(newId("user"), newId("org"), "org:admin");
+
+      const response = await accept(
+        client().disconnect({
+          params: { botId: newId("missing-bot") },
+          headers: AUTH_HEADERS,
+        }),
+        [404],
+      );
+
+      expect(response.body).toStrictEqual({
+        error: { message: "Telegram bot not found", code: "NOT_FOUND" },
+      });
+    });
+
+    it("returns 404 for a bot in another org", async () => {
+      const bot = await seedBot();
+      mocks.clerk.session(bot.ownerUserId, newId("other-org"), "org:admin");
+
+      const response = await accept(
+        client().disconnect({
+          params: { botId: bot.botId },
+          headers: AUTH_HEADERS,
+        }),
+        [404],
+      );
+
+      expect(response.body.error.code).toBe("NOT_FOUND");
+    });
+
+    it("returns 403 for a non-admin non-owner", async () => {
+      const bot = await seedBot({ ownerUserId: newId("owner") });
+      mocks.clerk.session(newId("member"), bot.orgId, "org:member");
+
+      const response = await accept(
+        client().disconnect({
+          params: { botId: bot.botId },
+          headers: AUTH_HEADERS,
+        }),
+        [403],
+      );
+
+      expect(response.body).toStrictEqual({
+        error: {
+          message: "Only the bot owner or an org admin can uninstall this bot",
+          code: "FORBIDDEN",
+        },
+      });
+    });
+
+    it("deletes the installation for the owner and removes the webhook", async () => {
+      const bot = await seedBot();
+      mocks.clerk.session(bot.ownerUserId, bot.orgId, "org:member");
+
+      const response = await client().disconnect({
+        params: { botId: bot.botId },
+        headers: AUTH_HEADERS,
+      });
+
+      expect(response.status).toBe(204);
+      expect(context.mocks.telegram.deleteWebhook).toHaveBeenCalledTimes(1);
+      expect(context.mocks.telegram.deleteWebhook).toHaveBeenCalledWith(
+        "test-bot-token",
+      );
+      await expect(countInstallations(bot.botId)).resolves.toBe(0);
+      expect(context.mocks.ably.publish).toHaveBeenCalledWith(
+        "telegram:changed",
+        null,
+      );
+    });
+
+    it("deletes the installation for an org admin", async () => {
+      const bot = await seedBot({ ownerUserId: newId("owner") });
+      mocks.clerk.session(newId("admin"), bot.orgId, "org:admin");
+
+      const response = await client().disconnect({
+        params: { botId: bot.botId },
+        headers: AUTH_HEADERS,
+      });
+
+      expect(response.status).toBe(204);
+      expect(context.mocks.telegram.deleteWebhook).toHaveBeenCalledTimes(1);
+      await expect(countInstallations(bot.botId)).resolves.toBe(0);
+    });
+
+    it("deletes the installation when webhook removal fails", async () => {
+      const bot = await seedBot();
+      mocks.clerk.session(bot.ownerUserId, bot.orgId, "org:admin");
+      context.mocks.telegram.deleteWebhook.mockRejectedValueOnce(
+        new Error("Telegram unavailable"),
+      );
+
+      const response = await client().disconnect({
+        params: { botId: bot.botId },
+        headers: AUTH_HEADERS,
+      });
+
+      expect(response.status).toBe(204);
+      expect(context.mocks.telegram.deleteWebhook).toHaveBeenCalledTimes(1);
+      await expect(countInstallations(bot.botId)).resolves.toBe(0);
+    });
+
+    it("cascades links, messages, and thread sessions for the deleted bot", async () => {
+      const bot = await seedBot();
+      const telegramUserId = "99077";
+      const userLinkId = await insertUserLink({
+        installationId: bot.botId,
+        userId: bot.ownerUserId,
+        telegramUserId,
+      });
+      const writeDb = store.set(writeDb$);
+      await writeDb.insert(telegramMessages).values({
+        installationId: bot.botId,
+        chatId: "77001",
+        messageId: "88001",
+        fromUserId: telegramUserId,
+        text: "before delete",
+      });
+      await seedThreadSession({
+        userId: bot.ownerUserId,
+        orgId: bot.orgId,
+        composeId: bot.composeId,
+        userLinkId,
+        chatId: "77001",
+        rootMessageId: "dm",
+      });
+      mocks.clerk.session(bot.ownerUserId, bot.orgId, "org:admin");
+
+      const response = await client().disconnect({
+        params: { botId: bot.botId },
+        headers: AUTH_HEADERS,
+      });
+
+      expect(response.status).toBe(204);
+      await expect(
+        userLinkExists({ installationId: bot.botId, telegramUserId }),
+      ).resolves.toBeFalsy();
+      await expect(countMessages(bot.botId)).resolves.toBe(0);
+      await expect(
+        threadSessionExists({
+          userLinkId,
+          chatId: "77001",
+          rootMessageId: "dm",
+        }),
+      ).resolves.toBeFalsy();
+    });
+  });
+
+  describe("DELETE /api/integrations/telegram/link", () => {
+    it("returns 401 when unauthenticated", async () => {
+      const response = await accept(
+        client().unlink({ query: {}, headers: {} }),
+        [401],
+      );
+
+      expect(response.body).toStrictEqual({
+        error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+      });
+    });
+
+    it("returns 404 when the user has no link", async () => {
+      mocks.clerk.session(newId("user"), newId("org"), "org:member");
+
+      const response = await accept(
+        client().unlink({ query: {}, headers: AUTH_HEADERS }),
+        [404],
+      );
+
+      expect(response.body).toStrictEqual({
+        error: { message: "No linked Telegram account", code: "NOT_FOUND" },
+      });
+    });
+
+    it("deletes the user's custom bot link", async () => {
+      const bot = await seedBot();
+      await insertUserLink({
+        installationId: bot.botId,
+        userId: bot.ownerUserId,
+        telegramUserId: "99001",
+      });
+      mocks.clerk.session(bot.ownerUserId, bot.orgId, "org:member");
+
+      const response = await client().unlink({
+        query: {},
+        headers: AUTH_HEADERS,
+      });
+
+      expect(response.status).toBe(204);
+      await expect(
+        linkInstallationsForUser(bot.ownerUserId),
+      ).resolves.toStrictEqual([]);
+      expect(context.mocks.ably.publish).toHaveBeenCalledWith(
+        "telegram:changed",
+        null,
+      );
+    });
+
+    it("deletes only the requested custom bot link when botId is provided", async () => {
+      const orgId = newId("org");
+      const userId = newId("user");
+      const firstBot = await seedBot({ orgId, ownerUserId: userId });
+      const secondBot = await seedBot({ orgId, ownerUserId: userId });
+      await insertUserLink({
+        installationId: firstBot.botId,
+        userId,
+        telegramUserId: "99011",
+      });
+      await insertUserLink({
+        installationId: secondBot.botId,
+        userId,
+        telegramUserId: "99012",
+      });
+      mocks.clerk.session(userId, orgId, "org:member");
+
+      const response = await client().unlink({
+        query: { botId: firstBot.botId },
+        headers: AUTH_HEADERS,
+      });
+
+      expect(response.status).toBe(204);
+      await expect(linkInstallationsForUser(userId)).resolves.toStrictEqual([
+        secondBot.botId,
+      ]);
+    });
+
+    it("deletes only the official link when botId is official", async () => {
+      const bot = await seedBot();
+      const officialLinkId = await insertOfficialUserLink({
+        orgId: bot.orgId,
+        userId: bot.ownerUserId,
+        telegramUserId: "99090",
+      });
+      await insertUserLink({
+        installationId: bot.botId,
+        userId: bot.ownerUserId,
+        telegramUserId: "99091",
+      });
+      mocks.clerk.session(bot.ownerUserId, bot.orgId, "org:member");
+
+      const response = await client().unlink({
+        query: { botId: OFFICIAL_TELEGRAM_BOT_ID },
+        headers: AUTH_HEADERS,
+      });
+
+      expect(response.status).toBe(204);
+      await expect(countOfficialLinks(officialLinkId)).resolves.toBe(0);
+      await expect(
+        linkInstallationsForUser(bot.ownerUserId),
+      ).resolves.toStrictEqual([bot.botId]);
+    });
+
+    it("does not delete custom links from another org", async () => {
+      const userId = newId("user");
+      const activeBot = await seedBot({ ownerUserId: userId });
+      const otherBot = await seedBot({ ownerUserId: userId });
+      await insertUserLink({
+        installationId: activeBot.botId,
+        userId,
+        telegramUserId: "99101",
+      });
+      await insertUserLink({
+        installationId: otherBot.botId,
+        userId,
+        telegramUserId: "99102",
+      });
+      mocks.clerk.session(userId, activeBot.orgId, "org:member");
+
+      const response = await client().unlink({
+        query: {},
+        headers: AUTH_HEADERS,
+      });
+
+      expect(response.status).toBe(204);
+      await expect(linkInstallationsForUser(userId)).resolves.toStrictEqual([
+        otherBot.botId,
+      ]);
+    });
+  });
+});

--- a/turbo/apps/api/src/signals/routes/integrations-telegram-bot-id.ts
+++ b/turbo/apps/api/src/signals/routes/integrations-telegram-bot-id.ts
@@ -1,0 +1,103 @@
+import { command } from "ccstate";
+import { eq } from "drizzle-orm";
+import {
+  OFFICIAL_TELEGRAM_BOT_ID,
+  zeroIntegrationsTelegramContract,
+} from "@vm0/api-contracts/contracts/zero-integrations-telegram";
+import { telegramInstallations } from "@vm0/db/schema/telegram-installation";
+
+import { organizationAuthContext$ } from "../auth/auth-context";
+import { authRoute } from "../auth/auth-route";
+import { pathParamsOf } from "../context/request";
+import { writeDb$ } from "../external/db";
+import { publishOrgSignal } from "../external/realtime";
+import { deleteWebhook } from "../external/telegram-client";
+import { decryptSecretValue } from "../services/crypto.utils";
+import { logger } from "../../lib/log";
+import { safeAsync } from "../utils";
+import type { RouteEntry } from "../route";
+
+const log = logger("api:telegram:integration-bot");
+
+function notFoundResponse() {
+  return {
+    status: 404 as const,
+    body: {
+      error: { message: "Telegram bot not found", code: "NOT_FOUND" as const },
+    },
+  };
+}
+
+function forbiddenResponse(message: string) {
+  return {
+    status: 403 as const,
+    body: { error: { message, code: "FORBIDDEN" as const } },
+  };
+}
+
+const disconnectInner$ = command(async ({ get, set }, signal: AbortSignal) => {
+  const auth = get(organizationAuthContext$);
+  const { botId } = get(
+    pathParamsOf(zeroIntegrationsTelegramContract.disconnect),
+  );
+
+  if (botId === OFFICIAL_TELEGRAM_BOT_ID) {
+    return forbiddenResponse("The official Telegram bot cannot be uninstalled");
+  }
+
+  const writeDb = set(writeDb$);
+  const [installation] = await writeDb
+    .select()
+    .from(telegramInstallations)
+    .where(eq(telegramInstallations.telegramBotId, botId))
+    .limit(1);
+  signal.throwIfAborted();
+
+  if (!installation || installation.orgId !== auth.orgId) {
+    return notFoundResponse();
+  }
+
+  if (installation.ownerUserId !== auth.userId && auth.orgRole !== "admin") {
+    return forbiddenResponse(
+      "Only the bot owner or an org admin can uninstall this bot",
+    );
+  }
+
+  const botToken = decryptSecretValue(installation.encryptedBotToken);
+  const webhookResult = await safeAsync(() => {
+    return deleteWebhook(botToken);
+  });
+  signal.throwIfAborted();
+  if ("error" in webhookResult) {
+    log.warn("Failed to remove Telegram webhook", {
+      error: webhookResult.error,
+    });
+  }
+
+  await writeDb
+    .delete(telegramInstallations)
+    .where(eq(telegramInstallations.telegramBotId, installation.telegramBotId));
+  signal.throwIfAborted();
+
+  const publishResult = await safeAsync(() => {
+    return publishOrgSignal(installation.orgId, "telegram:changed");
+  });
+  signal.throwIfAborted();
+  if ("error" in publishResult) {
+    log.warn("Failed to publish Telegram org change", {
+      error: publishResult.error,
+    });
+  }
+
+  return { status: 204 as const, body: undefined };
+});
+
+export const integrationsTelegramBotIdRoutes: readonly RouteEntry[] = [
+  {
+    route: zeroIntegrationsTelegramContract.disconnect,
+    handler: authRoute(
+      { requireOrganization: true, missingOrganizationStatus: 401 },
+      disconnectInner$,
+    ),
+  },
+];

--- a/turbo/apps/api/src/signals/routes/integrations-telegram-link.ts
+++ b/turbo/apps/api/src/signals/routes/integrations-telegram-link.ts
@@ -1,0 +1,105 @@
+import { command } from "ccstate";
+import { and, eq, inArray } from "drizzle-orm";
+import {
+  OFFICIAL_TELEGRAM_BOT_ID,
+  zeroIntegrationsTelegramContract,
+} from "@vm0/api-contracts/contracts/zero-integrations-telegram";
+import { telegramInstallations } from "@vm0/db/schema/telegram-installation";
+import { telegramOfficialUserLinks } from "@vm0/db/schema/telegram-official-user-link";
+import { telegramUserLinks } from "@vm0/db/schema/telegram-user-link";
+
+import { organizationAuthContext$ } from "../auth/auth-context";
+import { authRoute } from "../auth/auth-route";
+import { queryOf } from "../context/request";
+import { writeDb$ } from "../external/db";
+import { publishUserSignal } from "../external/realtime";
+import { logger } from "../../lib/log";
+import { safeAsync } from "../utils";
+import type { RouteEntry } from "../route";
+
+const log = logger("api:telegram:link");
+
+function noLinkedTelegramAccountResponse() {
+  return {
+    status: 404 as const,
+    body: {
+      error: {
+        message: "No linked Telegram account",
+        code: "NOT_FOUND" as const,
+      },
+    },
+  };
+}
+
+async function publishTelegramUserChanged(userId: string): Promise<void> {
+  const publishResult = await safeAsync(() => {
+    return publishUserSignal([userId], "telegram:changed");
+  });
+  if ("error" in publishResult) {
+    log.warn("Failed to publish Telegram user change", {
+      error: publishResult.error,
+    });
+  }
+}
+
+const unlinkInner$ = command(async ({ get, set }, signal: AbortSignal) => {
+  const auth = get(organizationAuthContext$);
+  const { botId } = get(queryOf(zeroIntegrationsTelegramContract.unlink));
+  const writeDb = set(writeDb$);
+
+  if (botId === OFFICIAL_TELEGRAM_BOT_ID) {
+    const deleted = await writeDb
+      .delete(telegramOfficialUserLinks)
+      .where(
+        and(
+          eq(telegramOfficialUserLinks.vm0UserId, auth.userId),
+          eq(telegramOfficialUserLinks.orgId, auth.orgId),
+        ),
+      )
+      .returning({ id: telegramOfficialUserLinks.id });
+    signal.throwIfAborted();
+
+    if (deleted.length === 0) {
+      return noLinkedTelegramAccountResponse();
+    }
+
+    await publishTelegramUserChanged(auth.userId);
+    signal.throwIfAborted();
+    return { status: 204 as const, body: undefined };
+  }
+
+  const orgInstallations = writeDb
+    .select({ telegramBotId: telegramInstallations.telegramBotId })
+    .from(telegramInstallations)
+    .where(eq(telegramInstallations.orgId, auth.orgId));
+
+  const deleted = await writeDb
+    .delete(telegramUserLinks)
+    .where(
+      and(
+        eq(telegramUserLinks.vm0UserId, auth.userId),
+        inArray(telegramUserLinks.installationId, orgInstallations),
+        botId ? eq(telegramUserLinks.installationId, botId) : undefined,
+      ),
+    )
+    .returning({ id: telegramUserLinks.id });
+  signal.throwIfAborted();
+
+  if (deleted.length === 0) {
+    return noLinkedTelegramAccountResponse();
+  }
+
+  await publishTelegramUserChanged(auth.userId);
+  signal.throwIfAborted();
+  return { status: 204 as const, body: undefined };
+});
+
+export const integrationsTelegramLinkRoutes: readonly RouteEntry[] = [
+  {
+    route: zeroIntegrationsTelegramContract.unlink,
+    handler: authRoute(
+      { requireOrganization: true, missingOrganizationStatus: 401 },
+      unlinkInner$,
+    ),
+  },
+];

--- a/turbo/apps/api/src/signals/routes/zero-integrations-telegram.ts
+++ b/turbo/apps/api/src/signals/routes/zero-integrations-telegram.ts
@@ -8,6 +8,8 @@ import { apiErrorSchema } from "@vm0/api-contracts/contracts/errors";
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
 import { queryOf } from "../context/request";
+import { integrationsTelegramBotIdRoutes } from "./integrations-telegram-bot-id";
+import { integrationsTelegramLinkRoutes } from "./integrations-telegram-link";
 import { buildFileDownloadUrl, getFile } from "../external/telegram-client";
 import {
   getOfficialTelegramBotConfig,
@@ -179,6 +181,8 @@ const telegramReadAuth = {
 } as const;
 
 export const zeroIntegrationsTelegramRoutes: readonly RouteEntry[] = [
+  ...integrationsTelegramLinkRoutes,
+  ...integrationsTelegramBotIdRoutes,
   {
     route: integrationsTelegramBotListContract.listBots,
     handler: authRoute(telegramReadAuth, getTelegramBotsInner$),


### PR DESCRIPTION
## Summary
- migrate `DELETE /api/integrations/telegram/:botId` to the API backend
- migrate `DELETE /api/integrations/telegram/link` to the API backend
- add API integration coverage for auth, org scoping, owner/admin enforcement, official bot handling, webhook best-effort cleanup, cascades, and link unlinking

Closes #12801

## Testing
- `pnpm -F api exec vitest src/signals/routes/__tests__/integrations-telegram-delete.test.ts`
- `pnpm -F api exec vitest src/signals/routes/__tests__/integrations-telegram-delete.test.ts src/signals/routes/__tests__/zero-integrations-telegram.test.ts src/signals/routes/__tests__/zero-integrations-telegram-message.test.ts src/signals/routes/__tests__/zero-integrations-telegram-upload-init.test.ts src/signals/routes/__tests__/zero-integrations-telegram-upload-complete.test.ts`
- `pnpm turbo run lint`
- `pnpm check-types`
- `pnpm format`
- `pnpm knip`
- `pnpm -F api exec vitest src/signals/routes/__tests__/zero-connectors-remote-agent-connect.test.ts`
- `pnpm -F web exec vitest app/api/cron/aggregate-insights/__tests__/route.test.ts -t "should be idempotent on rerun"`
- `pnpm vitest`
