### PR TITLE
refactor(api): migrate zero org domains add route

### DIFF
--- a/turbo/apps/api/src/__tests__/mocks.ts
+++ b/turbo/apps/api/src/__tests__/mocks.ts
@@ -24,6 +24,7 @@ export interface ApiTestMocks {
   readonly clerk: {
     readonly authenticateRequest: AsyncMock;
     readonly organizations: {
+      readonly createOrganizationDomain: AsyncMock;
       readonly createOrganizationInvitation: AsyncMock;
       readonly getOrganization: AsyncMock;
       readonly getOrganizationDomainList: AsyncMock;
@@ -119,6 +120,8 @@ const apiTestMocks: ApiTestMocks = vi.hoisted((): ApiTestMocks => {
   const clerk = {
     authenticateRequest: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
     organizations: {
+      createOrganizationDomain:
+        vi.fn<(...args: unknown[]) => Promise<unknown>>(),
       createOrganizationInvitation:
         vi.fn<(...args: unknown[]) => Promise<unknown>>(),
       getOrganization: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
@@ -484,6 +487,7 @@ export function resetApiTestMocks(): void {
   apiTestMocks.axiomLogging.error.mockReset();
   apiTestMocks.axiomLogging.flush.mockReset();
   apiTestMocks.clerk.authenticateRequest.mockReset();
+  apiTestMocks.clerk.organizations.createOrganizationDomain.mockReset();
   apiTestMocks.clerk.organizations.createOrganizationInvitation.mockReset();
   apiTestMocks.clerk.organizations.getOrganization.mockReset();
   apiTestMocks.clerk.organizations.getOrganizationDomainList.mockReset();

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-org-domains.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-org-domains.test.ts
@@ -4,6 +4,7 @@ import { zeroOrgDomainsContract } from "@vm0/api-contracts/contracts/zero-org-do
 import { createStore } from "ccstate";
 import { afterEach } from "vitest";
 
+import { createApp } from "../../../app-factory";
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
 import {
   deleteOrgMembership$,
@@ -119,5 +120,165 @@ describe("GET /api/zero/org/domains", () => {
     );
 
     expect(response.body.error.code).toBe("FORBIDDEN");
+  });
+});
+
+describe("POST /api/zero/org/domains", () => {
+  const seededFixtures: OrgMembershipFixture[] = [];
+
+  afterEach(async () => {
+    while (seededFixtures.length > 0) {
+      const fixture = seededFixtures.pop();
+      if (fixture) {
+        await store.set(deleteOrgMembership$, fixture, context.signal);
+      }
+    }
+  });
+
+  it("adds a domain for an admin", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    seededFixtures.push(
+      await store.set(
+        seedOrgMembership$,
+        { orgId, userId, role: "admin" },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(userId, orgId, "org:admin");
+
+    const client = setupApp({ context })(zeroOrgDomainsContract);
+
+    const response = await accept(
+      client.add({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          name: "example.com",
+          enrollmentMode: "manual_invitation",
+        },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      message: "Domain example.com added",
+    });
+    expect(
+      context.mocks.clerk.organizations.createOrganizationDomain,
+    ).toHaveBeenCalledWith({
+      organizationId: orgId,
+      name: "example.com",
+      enrollmentMode: "manual_invitation",
+    });
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    const client = setupApp({ context })(zeroOrgDomainsContract);
+
+    const response = await accept(
+      client.add({
+        headers: {},
+        body: {
+          name: "example.com",
+          enrollmentMode: "manual_invitation",
+        },
+      }),
+      [401],
+    );
+
+    expect(response.body.error.code).toBe("UNAUTHORIZED");
+    expect(
+      context.mocks.clerk.organizations.createOrganizationDomain,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when the authenticated session has no organization", async () => {
+    mocks.clerk.session(`user_${randomUUID()}`, null);
+
+    const client = setupApp({ context })(zeroOrgDomainsContract);
+
+    const response = await accept(
+      client.add({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          name: "example.com",
+          enrollmentMode: "manual_invitation",
+        },
+      }),
+      [401],
+    );
+
+    expect(response.body.error.code).toBe("UNAUTHORIZED");
+    expect(
+      context.mocks.clerk.organizations.createOrganizationDomain,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 when caller is not an admin", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    seededFixtures.push(
+      await store.set(
+        seedOrgMembership$,
+        { orgId, userId, role: "member" },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(userId, orgId, "org:member");
+
+    const client = setupApp({ context })(zeroOrgDomainsContract);
+
+    const response = await accept(
+      client.add({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          name: "example.com",
+          enrollmentMode: "manual_invitation",
+        },
+      }),
+      [403],
+    );
+
+    expect(response.body.error).toStrictEqual({
+      message: "Access denied",
+      code: "FORBIDDEN",
+    });
+    expect(
+      context.mocks.clerk.organizations.createOrganizationDomain,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("rejects invalid enrollment modes before calling Clerk", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    seededFixtures.push(
+      await store.set(
+        seedOrgMembership$,
+        { orgId, userId, role: "admin" },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(userId, orgId, "org:admin");
+
+    const app = createApp({ signal: context.signal });
+    const response = await app.request("/api/zero/org/domains", {
+      method: "POST",
+      headers: {
+        authorization: "Bearer clerk-session",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        name: "example.com",
+        enrollmentMode: "invalid",
+      }),
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      error: { code: "BAD_REQUEST" },
+    });
+    expect(
+      context.mocks.clerk.organizations.createOrganizationDomain,
+    ).not.toHaveBeenCalled();
   });
 });

--- a/turbo/apps/api/src/signals/routes/zero-org-read.ts
+++ b/turbo/apps/api/src/signals/routes/zero-org-read.ts
@@ -7,6 +7,7 @@ import { zeroOrgMembersContract } from "@vm0/api-contracts/contracts/zero-org-me
 import { authContext$, organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
 import { bodyResultOf } from "../context/request";
+import { clerk$ } from "../external/clerk";
 import { badRequestMessage, notFound } from "../../lib/error";
 import type { RouteEntry } from "../route";
 import {
@@ -101,6 +102,34 @@ const listDomainsInner$ = computed(async (get) => {
   return { status: 200 as const, body };
 });
 
+const addDomainBody$ = bodyResultOf(zeroOrgDomainsContract.add);
+
+const addDomainInner$ = command(async ({ get }, signal: AbortSignal) => {
+  const auth = get(organizationAuthContext$);
+  if (auth.orgRole !== "admin") {
+    return adminRequired;
+  }
+
+  const bodyResult = await get(addDomainBody$);
+  signal.throwIfAborted();
+  if (!bodyResult.ok) {
+    return bodyResult.response;
+  }
+
+  const client = get(clerk$);
+  await client.organizations.createOrganizationDomain({
+    organizationId: auth.orgId,
+    name: bodyResult.data.name,
+    enrollmentMode: bodyResult.data.enrollmentMode,
+  });
+  signal.throwIfAborted();
+
+  return {
+    status: 200 as const,
+    body: { message: `Domain ${bodyResult.data.name} added` },
+  };
+});
+
 const membersInner$ = computed(async (get) => {
   const auth = get(organizationAuthContext$);
   const body = await get(
@@ -133,6 +162,13 @@ export const zeroOrgReadRoutes: readonly RouteEntry[] = [
     handler: authRoute(
       { requireOrganization: true, missingOrganizationStatus: 401 },
       listDomainsInner$,
+    ),
+  },
+  {
+    route: zeroOrgDomainsContract.add,
+    handler: authRoute(
+      { requireOrganization: true, missingOrganizationStatus: 401 },
+      addDomainInner$,
     ),
   },
   {

--- a/turbo/packages/api-contracts/src/contracts/zero-org-domains.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-org-domains.ts
@@ -33,6 +33,7 @@ export const zeroOrgDomainsContract = c.router({
     body: addDomainRequestSchema,
     responses: {
       200: orgMessageResponseSchema,
+      400: apiErrorSchema,
       401: apiErrorSchema,
       403: apiErrorSchema,
       500: apiErrorSchema,


### PR DESCRIPTION
## Summary

- Add API backend support for `POST /api/zero/org/domains`
- Wire the route through the existing Zero org domains contract and API route module
- Add integration coverage for success, auth, admin gating, validation, and Clerk call arguments

## Validation

- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-org-domains.test.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm format`
- `pnpm turbo run lint`
- `pnpm check-types`
- `pnpm knip`
- `git diff --check`

Closes #12880
