### PR TITLE
fix: avoid reusing integration sessions across model changes

### DIFF
--- a/turbo/apps/web/app/api/internal/callbacks/telegram/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/telegram/__tests__/route.test.ts
@@ -13,6 +13,8 @@ import {
   createTestCompose,
   createSignedCallbackRequest,
   createTelegramCallbackInstallation,
+  findTelegramThreadAgentSessionId,
+  findTestRunRecord,
   insertTestTelegramUserLink,
   createTelegramThreadSession,
 } from "../../../../../../src/__tests__/api-test-helpers";
@@ -439,6 +441,48 @@ describe("POST /api/internal/callbacks/telegram", () => {
       const sent = sendMessageHandler.calls[0]!;
       expect(sent.text).toContain("<b>Done</b> with <code>code</code>");
       expect(sent.reply_parameters).toBeUndefined();
+    });
+
+    it("replaces an existing DM mapping when a new session was started", async () => {
+      const { userId, composeId, runId, payload, secret } =
+        await setupTelegramCallback();
+      const run = await findTestRunRecord(runId);
+      const oldSession = await createTestAgentSession(userId, composeId);
+      await createTelegramThreadSession({
+        telegramUserLinkId: payload.userLinkId,
+        chatId: payload.chatId,
+        rootMessageId: "dm",
+        agentSessionId: oldSession.id,
+      });
+
+      const chatActionHandler = telegramSendChatAction();
+      const sendMessageHandler = telegramSendMessage();
+      server.use(chatActionHandler.handler, sendMessageHandler.handler);
+
+      const request = createSignedCallbackRequest(
+        "http://localhost/api/internal/callbacks/telegram",
+        {
+          runId,
+          status: "completed",
+          payload: {
+            ...payload,
+            rootMessageId: "dm",
+            existingSessionId: null,
+            isDM: true,
+          },
+        },
+        secret,
+      );
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+      const agentSessionId = await findTelegramThreadAgentSessionId({
+        telegramUserLinkId: payload.userLinkId,
+        chatId: payload.chatId,
+        rootMessageId: "dm",
+      });
+      expect(agentSessionId).toBe(run?.sessionId);
+      expect(agentSessionId).not.toBe(oldSession.id);
     });
 
     it("should delete legacy thinking placeholder when present", async () => {

--- a/turbo/apps/web/app/api/internal/callbacks/telegram/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/telegram/route.ts
@@ -1,10 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
-import { eq, and, gte, desc } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 import { initServices } from "../../../../../src/lib/init-services";
 import { verifyCallback } from "../../../../../src/lib/infra/callback";
 import { decryptSecretValue } from "../../../../../src/lib/shared/crypto/secrets-encryption";
 import { telegramInstallations } from "@vm0/db/schema/telegram-installation";
-import { agentSessions } from "@vm0/db/schema/agent-session";
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
 import {
@@ -65,26 +64,6 @@ function parsePayload(payload: unknown): TelegramCallbackPayload | null {
 
 function errorResponse(message: string, status: number): NextResponse {
   return NextResponse.json({ error: message }, { status });
-}
-
-async function findNewSessionId(
-  userId: string,
-  agentId: string,
-  runCreatedAt: Date,
-): Promise<string | undefined> {
-  const [newSession] = await globalThis.services.db
-    .select({ id: agentSessions.id })
-    .from(agentSessions)
-    .where(
-      and(
-        eq(agentSessions.userId, userId),
-        eq(agentSessions.agentComposeId, agentId),
-        gte(agentSessions.updatedAt, runCreatedAt),
-      ),
-    )
-    .orderBy(desc(agentSessions.updatedAt))
-    .limit(1);
-  return newSession?.id;
 }
 
 /**
@@ -204,7 +183,7 @@ async function handleCompletion(ctx: CompletionContext): Promise<void> {
     .select({
       userId: agentRuns.userId,
       orgId: agentRuns.orgId,
-      createdAt: agentRuns.createdAt,
+      sessionId: agentRuns.sessionId,
       lastEventSequence: agentRuns.lastEventSequence,
     })
     .from(agentRuns)
@@ -285,9 +264,7 @@ async function handleCompletion(ctx: CompletionContext): Promise<void> {
 
   // Save thread session mapping
   if (run && botReplyMessageId !== undefined) {
-    const newSessionId = !existingSessionId
-      ? await findNewSessionId(run.userId, agentId, run.createdAt)
-      : undefined;
+    const newSessionId = !existingSessionId ? run.sessionId : undefined;
 
     const newRootMessageId = isDM ? "dm" : String(botReplyMessageId);
 

--- a/turbo/apps/web/app/api/telegram/webhook/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/telegram/webhook/__tests__/route.test.ts
@@ -21,6 +21,7 @@ import {
   insertTestOfficialTelegramUserLink,
   insertUserModelPreference,
   PENDING_TELEGRAM_USER_ID,
+  setOrgCredits,
   setDefaultAgentByComposeId,
   setTestRunModelProvider,
   setTestRunSelectedModel,
@@ -522,6 +523,7 @@ describe("POST /api/telegram/webhook/[telegramBotId]", () => {
       reloadEnv();
 
       const user = await context.setupUser();
+      await setOrgCredits(user.orgId, 100_000);
       const { composeId } = await createTestCompose(uniqueId("agent"));
       await setDefaultAgentByComposeId(user.orgId, composeId);
       await enableModelFirstModelProviderForUser(user.orgId, user.userId);

--- a/turbo/apps/web/app/api/telegram/webhook/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/telegram/webhook/__tests__/route.test.ts
@@ -8,16 +8,24 @@ import {
 } from "../../../../../src/__tests__/test-helpers";
 import {
   createTestCompose,
+  completeTestRun,
   createTelegramCallbackInstallation,
+  createTelegramThreadSession,
+  enableModelFirstModelProviderForUser,
   createTelegramInstallation,
   createTelegramPendingLinkInstallation,
   findTestRunCallbacks,
   findTestRunsByUserAndPromptContaining,
   findTestZeroRun,
+  insertOrgModelPolicy,
   insertTestOfficialTelegramUserLink,
+  insertUserModelPreference,
   PENDING_TELEGRAM_USER_ID,
   setDefaultAgentByComposeId,
+  setTestRunModelProvider,
+  setTestRunSelectedModel,
 } from "../../../../../src/__tests__/api-test-helpers";
+import { seedTestRun } from "../../../../../src/__tests__/db-test-seeders/runs";
 import { GET as linkGET } from "../../../../api/integrations/telegram/link/route";
 import { server } from "../../../../../src/mocks/server";
 import { http } from "../../../../../src/__tests__/msw";
@@ -502,6 +510,113 @@ describe("POST /api/telegram/webhook/[telegramBotId]", () => {
           agentId: composeId,
           existingSessionId: null,
           isDM: true,
+        }),
+      );
+    });
+
+    it("starts a new official DM session when the selected model changed", async () => {
+      context.setupMocks();
+      vi.stubEnv("TELEGRAM_OFFICIAL_BOT_TOKEN", OFFICIAL_BOT_TOKEN);
+      vi.stubEnv("TELEGRAM_OFFICIAL_BOT_USERNAME", "zero_vm0_bot");
+      vi.stubEnv("TELEGRAM_OFFICIAL_WEBHOOK_SECRET", OFFICIAL_WEBHOOK_SECRET);
+      reloadEnv();
+
+      const user = await context.setupUser();
+      const { composeId } = await createTestCompose(uniqueId("agent"));
+      await setDefaultAgentByComposeId(user.orgId, composeId);
+      await enableModelFirstModelProviderForUser(user.orgId, user.userId);
+      await insertOrgModelPolicy({
+        orgId: user.orgId,
+        model: "claude-sonnet-4-6",
+        isDefault: true,
+      });
+      await insertOrgModelPolicy({
+        orgId: user.orgId,
+        model: "claude-opus-4-7",
+      });
+      await insertUserModelPreference({
+        orgId: user.orgId,
+        userId: user.userId,
+        model: "claude-opus-4-7",
+      });
+
+      const previous = await seedTestRun(user.userId, composeId, {
+        prompt: "previous telegram model session",
+        triggerSource: "telegram",
+      });
+      const { agentSessionId } = await completeTestRun(
+        user.userId,
+        previous.runId,
+      );
+      await setTestRunModelProvider(previous.runId, "vm0");
+      await setTestRunSelectedModel(previous.runId, "claude-sonnet-4-6");
+
+      const telegramUserId = Number(uniqueNumericId());
+      const officialLink = await insertTestOfficialTelegramUserLink({
+        telegramUserId: String(telegramUserId),
+        telegramUsername: "official_model_user",
+        vm0UserId: user.userId,
+        orgId: user.orgId,
+      });
+      await createTelegramThreadSession({
+        telegramOfficialUserLinkId: officialLink.id,
+        chatId: String(telegramUserId),
+        rootMessageId: "dm",
+        agentSessionId,
+      });
+
+      const sendChatActionHandler = http.post(
+        `https://api.telegram.org/bot${OFFICIAL_BOT_TOKEN}/sendChatAction`,
+        () => {
+          return HttpResponse.json({ ok: true, result: true });
+        },
+      );
+      server.use(sendChatActionHandler.handler);
+
+      const prompt = `model changed ${uniqueId("tg")}`;
+      const response = await POST(
+        createWebhookRequest(
+          {
+            update_id: 203,
+            message: {
+              message_id: 20,
+              chat: { id: telegramUserId, type: "private" },
+              from: { id: telegramUserId, username: "official_model_user" },
+              text: prompt,
+            },
+          },
+          OFFICIAL_WEBHOOK_SECRET,
+        ),
+        {
+          params: Promise.resolve({
+            telegramBotId: OFFICIAL_TELEGRAM_BOT_ID,
+          }),
+        },
+      );
+
+      expect(response.status).toBe(200);
+      await context.mocks.flushAfter();
+
+      const runs = await findTestRunsByUserAndPromptContaining(
+        user.userId,
+        prompt,
+      );
+      expect(runs).toHaveLength(1);
+      expect(runs[0]?.continuedFromSessionId).toBeNull();
+      expect(runs[0]?.sessionId).not.toBe(agentSessionId);
+      await expect(findTestZeroRun(runs[0]!.id)).resolves.toEqual(
+        expect.objectContaining({
+          triggerSource: "telegram",
+          selectedModel: "claude-opus-4-7",
+        }),
+      );
+
+      const callbacks = await findTestRunCallbacks(runs[0]!.id);
+      expect(callbacks[0]?.payload).toEqual(
+        expect.objectContaining({
+          rootMessageId: "dm",
+          userLinkId: officialLink.id,
+          existingSessionId: null,
         }),
       );
     });

--- a/turbo/apps/web/app/api/zero/slack/events/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/slack/events/__tests__/route.test.ts
@@ -7,13 +7,23 @@ import {
   type UserContext,
 } from "../../../../../../src/__tests__/test-helpers";
 import {
+  completeTestRun,
   createTestCompose,
+  findTestRunCallbacks,
+  findTestRunsByUserAndPromptContaining,
+  findTestZeroRun,
+  insertOrgModelPolicy,
+  insertUserModelPreference,
+  setTestRunModelProvider,
+  setTestRunSelectedModel,
   updateOrgDefaultAgent,
 } from "../../../../../../src/__tests__/api-test-helpers";
 import {
   createTestSlackOrgInstallation,
+  insertTestSlackOrgThreadSession,
   seedTestSlackOrgConnection,
 } from "../../../../../../src/__tests__/db-test-seeders/slack";
+import { seedTestRun } from "../../../../../../src/__tests__/db-test-seeders/runs";
 import {
   countSlackOrgInstallations,
   countSlackOrgConnections,
@@ -732,6 +742,104 @@ describe("POST /api/zero/slack/events", () => {
       const { WebClient } = await import("@slack/web-api");
       const mockClient = new WebClient();
       expect(mockClient.chat.postMessage).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe("direct_message — session model compatibility", () => {
+    it("starts a new thread session when the selected model changed", async () => {
+      mockIsFeatureEnabled.mockReturnValue(true);
+
+      const workspaceId = uniqueId("T-ws");
+      const slackUserId = uniqueId("U-slack");
+      const channelId = uniqueId("D-model");
+      const threadTs = "2400.001";
+      const { composeId, agentId } = await createTestCompose(uniqueId("agent"));
+      await updateOrgDefaultAgent(user.orgId, agentId);
+      await insertOrgModelPolicy({
+        orgId: user.orgId,
+        model: "claude-sonnet-4-6",
+        isDefault: true,
+      });
+      await insertOrgModelPolicy({
+        orgId: user.orgId,
+        model: "claude-opus-4-7",
+      });
+      await insertUserModelPreference({
+        orgId: user.orgId,
+        userId: user.userId,
+        model: "claude-opus-4-7",
+      });
+      await createTestSlackOrgInstallation({
+        workspaceId,
+        orgId: user.orgId,
+      });
+      const { connectionId } = await seedTestSlackOrgConnection({
+        slackUserId,
+        slackWorkspaceId: workspaceId,
+        vm0UserId: user.userId,
+      });
+
+      const previous = await seedTestRun(user.userId, composeId, {
+        prompt: "previous slack model session",
+        triggerSource: "slack",
+      });
+      const { agentSessionId } = await completeTestRun(
+        user.userId,
+        previous.runId,
+      );
+      await setTestRunModelProvider(previous.runId, "vm0");
+      await setTestRunSelectedModel(previous.runId, "claude-sonnet-4-6");
+      await insertTestSlackOrgThreadSession({
+        connectionId,
+        agentSessionId,
+        slackChannelId: channelId,
+        slackThreadTs: threadTs,
+      });
+
+      const prompt = `model changed ${uniqueId("slack")}`;
+      const request = createSlackEventRequest({
+        type: "event_callback",
+        team_id: workspaceId,
+        event: {
+          type: "message",
+          channel_type: "im",
+          user: slackUserId,
+          text: prompt,
+          ts: "2400.002",
+          thread_ts: threadTs,
+          channel: channelId,
+          event_ts: "2400.002",
+        },
+        event_id: uniqueId("evt"),
+        event_time: Date.now(),
+      });
+
+      const response = await POST(request);
+      expect(response.status).toBe(200);
+      await context.mocks.flushAfter();
+
+      const runs = await findTestRunsByUserAndPromptContaining(
+        user.userId,
+        prompt,
+      );
+      expect(runs).toHaveLength(1);
+      expect(runs[0]?.continuedFromSessionId).toBeNull();
+      expect(runs[0]?.sessionId).not.toBe(agentSessionId);
+      await expect(findTestZeroRun(runs[0]!.id)).resolves.toEqual(
+        expect.objectContaining({
+          triggerSource: "slack",
+          selectedModel: "claude-opus-4-7",
+        }),
+      );
+
+      const callbacks = await findTestRunCallbacks(runs[0]!.id);
+      expect(callbacks[0]?.payload).toEqual(
+        expect.objectContaining({
+          connectionId,
+          threadTs,
+          existingSessionId: undefined,
+        }),
+      );
     });
   });
 

--- a/turbo/apps/web/app/api/zero/slack/events/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/slack/events/__tests__/route.test.ts
@@ -839,9 +839,9 @@ describe("POST /api/zero/slack/events", () => {
         expect.objectContaining({
           connectionId,
           threadTs,
-          existingSessionId: undefined,
         }),
       );
+      expect(callbacks[0]?.payload).not.toHaveProperty("existingSessionId");
     });
   });
 

--- a/turbo/apps/web/app/api/zero/slack/events/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/slack/events/__tests__/route.test.ts
@@ -14,6 +14,7 @@ import {
   findTestZeroRun,
   insertOrgModelPolicy,
   insertUserModelPreference,
+  setOrgCredits,
   setTestRunModelProvider,
   setTestRunSelectedModel,
   updateOrgDefaultAgent,
@@ -748,6 +749,7 @@ describe("POST /api/zero/slack/events", () => {
   describe("direct_message — session model compatibility", () => {
     it("starts a new thread session when the selected model changed", async () => {
       mockIsFeatureEnabled.mockReturnValue(true);
+      await setOrgCredits(user.orgId, 100_000);
 
       const workspaceId = uniqueId("T-ws");
       const slackUserId = uniqueId("U-slack");

--- a/turbo/apps/web/src/__tests__/api-test-helpers/index.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers/index.ts
@@ -184,6 +184,7 @@ export {
   findTestTelegramUserLinksByVm0UserId,
   findTestTelegramUserAgentPreference,
   findTestTelegramInstallationsByOwner,
+  findTelegramThreadAgentSessionId,
   getTestTelegramBotToken,
   telegramUserLinkExists,
   telegramThreadSessionExists,

--- a/turbo/apps/web/src/__tests__/api-test-helpers/telegram.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers/telegram.ts
@@ -26,6 +26,7 @@ export {
   findTestOfficialTelegramUserLink,
   findTestOfficialTelegramUserLinksByVm0UserId,
   findTestTelegramUserAgentPreference,
+  findTelegramThreadAgentSessionId,
   getTestTelegramBotToken,
   telegramUserLinkExists,
   telegramThreadSessionExists,

--- a/turbo/apps/web/src/__tests__/db-test-assertions/telegram.ts
+++ b/turbo/apps/web/src/__tests__/db-test-assertions/telegram.ts
@@ -170,3 +170,30 @@ export async function telegramThreadSessionExists(params: {
     .limit(1);
   return row !== undefined;
 }
+
+/**
+ * Find the agent session mapped to a Telegram thread.
+ */
+export async function findTelegramThreadAgentSessionId(params: {
+  telegramUserLinkId: string;
+  chatId: string;
+  rootMessageId: string;
+}): Promise<string | undefined> {
+  initServices();
+
+  const [row] = await globalThis.services.db
+    .select({ agentSessionId: telegramThreadSessions.agentSessionId })
+    .from(telegramThreadSessions)
+    .where(
+      and(
+        eq(
+          telegramThreadSessions.telegramUserLinkId,
+          params.telegramUserLinkId,
+        ),
+        eq(telegramThreadSessions.chatId, params.chatId),
+        eq(telegramThreadSessions.rootMessageId, params.rootMessageId),
+      ),
+    )
+    .limit(1);
+  return row?.agentSessionId;
+}

--- a/turbo/apps/web/src/__tests__/db-test-seeders/telegram.ts
+++ b/turbo/apps/web/src/__tests__/db-test-seeders/telegram.ts
@@ -476,15 +476,21 @@ export async function createTelegramCallbackInstallation(
  * @why-db-direct Creates thread session for session tracking tests
  */
 export async function createTelegramThreadSession(params: {
-  telegramUserLinkId: string;
+  telegramUserLinkId?: string;
+  telegramOfficialUserLinkId?: string;
   chatId: string;
   rootMessageId: string;
   agentSessionId: string;
 }): Promise<void> {
   initServices();
 
+  if (!params.telegramUserLinkId && !params.telegramOfficialUserLinkId) {
+    throw new Error("createTelegramThreadSession: missing owner link id");
+  }
+
   await globalThis.services.db.insert(telegramThreadSessions).values({
-    telegramUserLinkId: params.telegramUserLinkId,
+    telegramUserLinkId: params.telegramUserLinkId ?? null,
+    telegramOfficialUserLinkId: params.telegramOfficialUserLinkId ?? null,
     chatId: params.chatId,
     rootMessageId: params.rootMessageId,
     agentSessionId: params.agentSessionId,

--- a/turbo/apps/web/src/lib/zero/context/session-model-compatibility.ts
+++ b/turbo/apps/web/src/lib/zero/context/session-model-compatibility.ts
@@ -1,0 +1,187 @@
+import { and, eq } from "drizzle-orm";
+import {
+  MODEL_PROVIDER_TYPES,
+  areProvidersCompatible,
+  type ModelProviderType,
+} from "@vm0/api-contracts/contracts/model-providers";
+import {
+  agentComposes,
+  agentComposeVersions,
+} from "@vm0/db/schema/agent-compose";
+import { agentSessions } from "@vm0/db/schema/agent-session";
+import { conversations } from "@vm0/db/schema/conversation";
+import { zeroRuns } from "@vm0/db/schema/zero-run";
+import { resolveRuntimeFramework } from "../../infra/run/utils/resolve-runtime-framework";
+import { logger } from "../../shared/logger";
+import { isModelFirstModelProviderEnabled } from "../model-policy/model-first-route-service";
+import { resolveModelRoute } from "./resolve-model-provider";
+
+const log = logger("zero:session-model-compatibility");
+
+interface SessionModelSignature {
+  modelProvider: string | undefined;
+  selectedModel: string | undefined;
+}
+
+function normalize(value: string | null | undefined): string | undefined {
+  return value ?? undefined;
+}
+
+function isKnownProvider(value: string): value is ModelProviderType {
+  return value in MODEL_PROVIDER_TYPES;
+}
+
+function selectedModelForRoute(
+  route: Awaited<ReturnType<typeof resolveModelRoute>>,
+): string | undefined {
+  return route.provider.type === "vm0"
+    ? route.model.canonical
+    : route.model.selected;
+}
+
+function areSessionModelSignaturesCompatible(
+  previous: SessionModelSignature,
+  current: SessionModelSignature,
+): boolean {
+  if (
+    previous.modelProvider &&
+    current.modelProvider &&
+    isKnownProvider(previous.modelProvider) &&
+    isKnownProvider(current.modelProvider) &&
+    !areProvidersCompatible(previous.modelProvider, current.modelProvider)
+  ) {
+    return false;
+  }
+
+  if (
+    previous.selectedModel &&
+    current.selectedModel &&
+    previous.selectedModel !== current.selectedModel
+  ) {
+    return false;
+  }
+
+  return true;
+}
+
+async function getSessionModelSignature(
+  sessionId: string,
+  userId: string,
+): Promise<SessionModelSignature | undefined> {
+  const [row] = await globalThis.services.db
+    .select({
+      modelProvider: zeroRuns.modelProvider,
+      selectedModel: zeroRuns.selectedModel,
+    })
+    .from(agentSessions)
+    .innerJoin(
+      conversations,
+      eq(agentSessions.conversationId, conversations.id),
+    )
+    .innerJoin(zeroRuns, eq(zeroRuns.id, conversations.runId))
+    .where(
+      and(eq(agentSessions.id, sessionId), eq(agentSessions.userId, userId)),
+    )
+    .limit(1);
+
+  if (!row) return undefined;
+  return {
+    modelProvider: normalize(row.modelProvider),
+    selectedModel: normalize(row.selectedModel),
+  };
+}
+
+async function getComposeFramework(params: {
+  agentComposeId: string;
+  orgId: string;
+}): Promise<string | undefined> {
+  const [compose] = await globalThis.services.db
+    .select({ content: agentComposeVersions.content })
+    .from(agentComposes)
+    .innerJoin(
+      agentComposeVersions,
+      eq(agentComposes.headVersionId, agentComposeVersions.id),
+    )
+    .where(
+      and(
+        eq(agentComposes.id, params.agentComposeId),
+        eq(agentComposes.orgId, params.orgId),
+      ),
+    )
+    .limit(1);
+
+  if (!compose) return undefined;
+  return resolveRuntimeFramework({ agentCompose: compose.content });
+}
+
+async function getCurrentRunModelSignature(params: {
+  orgId: string;
+  userId: string;
+  agentComposeId: string;
+  modelProviderId?: string | null;
+  modelProviderCredentialScope?: string | null;
+  selectedModel?: string | null;
+  explicitModelFirstModelSelection?: boolean;
+}): Promise<SessionModelSignature | undefined> {
+  const framework = await getComposeFramework({
+    agentComposeId: params.agentComposeId,
+    orgId: params.orgId,
+  });
+  if (!framework) return undefined;
+
+  const modelFirstEnabled = await isModelFirstModelProviderEnabled(
+    params.orgId,
+    params.userId,
+  );
+  const useExplicitModel =
+    !modelFirstEnabled || params.explicitModelFirstModelSelection === true;
+  const route = await resolveModelRoute({
+    orgId: params.orgId,
+    userId: params.userId,
+    framework,
+    modelProviderId: useExplicitModel
+      ? normalize(params.modelProviderId)
+      : undefined,
+    modelProviderCredentialScope: useExplicitModel
+      ? normalize(params.modelProviderCredentialScope)
+      : undefined,
+    selectedModelOverride: useExplicitModel
+      ? normalize(params.selectedModel)
+      : undefined,
+  });
+
+  return {
+    modelProvider: route.provider.type,
+    selectedModel: selectedModelForRoute(route),
+  };
+}
+
+export async function canReuseSessionForRunModel(params: {
+  sessionId: string;
+  userId: string;
+  orgId: string;
+  agentComposeId: string;
+  modelProviderId?: string | null;
+  modelProviderCredentialScope?: string | null;
+  selectedModel?: string | null;
+  explicitModelFirstModelSelection?: boolean;
+}): Promise<boolean> {
+  try {
+    const [previous, current] = await Promise.all([
+      getSessionModelSignature(params.sessionId, params.userId),
+      getCurrentRunModelSignature(params),
+    ]);
+
+    if (!previous || !current) return true;
+    return areSessionModelSignaturesCompatible(previous, current);
+  } catch (error) {
+    log.warn("Failed to check session model compatibility", {
+      sessionId: params.sessionId,
+      userId: params.userId,
+      orgId: params.orgId,
+      agentComposeId: params.agentComposeId,
+      error,
+    });
+    return true;
+  }
+}

--- a/turbo/apps/web/src/lib/zero/slack-org/handlers/direct-message.ts
+++ b/turbo/apps/web/src/lib/zero/slack-org/handlers/direct-message.ts
@@ -20,13 +20,12 @@ import {
   resolveConnectionFromSlackUser,
   resolveDefaultComposeId,
   resolveEffectiveComposeId,
-  lookupThreadSession,
   enrichMessageContent,
   fetchConversationContexts,
   buildOrgConnectUrl,
   buildAgentLogsUrl,
   getWorkspaceAgent,
-  resolveSessionCompose,
+  resolveCompatibleThreadSession,
 } from "./shared";
 import { getAppUrl } from "../../url";
 import { logger } from "../../../shared/logger";
@@ -133,26 +132,17 @@ export async function handleOrgDirectMessage(
     },
   );
 
-  // 6. Look up existing thread session
-  let existingSessionId: string | undefined;
-  if (threadTs) {
-    const session = await lookupThreadSession(
-      context.channelId,
-      threadTs,
-      connection.id,
-    );
-    existingSessionId = session.existingSessionId;
-  }
-
-  if (existingSessionId) {
-    const sessionCompose = await resolveSessionCompose(
-      existingSessionId,
-      connection.vm0UserId,
-    );
-    if (sessionCompose && sessionCompose.composeId !== composeId) {
-      existingSessionId = undefined;
-    }
-  }
+  // 6. Look up an existing thread session when it is compatible with this run.
+  const existingSessionId = await resolveCompatibleThreadSession({
+    channelId: context.channelId,
+    threadTs,
+    connectionId: connection.id,
+    userId: connection.vm0UserId,
+    orgId,
+    agentComposeId: composeId,
+    modelProviderId: agent.modelProviderId,
+    selectedModel: agent.selectedModel,
+  });
 
   // 7. Fetch conversation context
   const { executionContext } = await fetchConversationContexts(

--- a/turbo/apps/web/src/lib/zero/slack-org/handlers/mention.ts
+++ b/turbo/apps/web/src/lib/zero/slack-org/handlers/mention.ts
@@ -16,13 +16,12 @@ import {
   resolveConnectionFromSlackUser,
   resolveDefaultComposeId,
   resolveEffectiveComposeId,
-  lookupThreadSession,
   enrichMessageContent,
   fetchConversationContexts,
   buildOrgConnectUrl,
   buildAgentLogsUrl,
   getWorkspaceAgent,
-  resolveSessionCompose,
+  resolveCompatibleThreadSession,
 } from "./shared";
 import { getAppUrl } from "../../url";
 import { logger } from "../../../shared/logger";
@@ -130,28 +129,17 @@ export async function handleOrgMention(
     },
   );
 
-  // 6. Look up existing thread session
-  let existingSessionId: string | undefined;
-  if (threadTs) {
-    const session = await lookupThreadSession(
-      context.channelId,
-      threadTs,
-      connection.id,
-    );
-    existingSessionId = session.existingSessionId;
-  }
-
-  // 6b. Validate session agent matches current default
-  if (existingSessionId) {
-    const sessionCompose = await resolveSessionCompose(
-      existingSessionId,
-      connection.vm0UserId,
-    );
-    if (sessionCompose && sessionCompose.composeId !== composeId) {
-      log.debug("Agent changed, starting new session");
-      existingSessionId = undefined;
-    }
-  }
+  // 6. Look up an existing thread session when it is compatible with this run.
+  const existingSessionId = await resolveCompatibleThreadSession({
+    channelId: context.channelId,
+    threadTs,
+    connectionId: connection.id,
+    userId: connection.vm0UserId,
+    orgId,
+    agentComposeId: composeId,
+    modelProviderId: agent.modelProviderId,
+    selectedModel: agent.selectedModel,
+  });
 
   // 7. Fetch conversation context
   const { executionContext } = await fetchConversationContexts(

--- a/turbo/apps/web/src/lib/zero/slack-org/handlers/shared.ts
+++ b/turbo/apps/web/src/lib/zero/slack-org/handlers/shared.ts
@@ -10,6 +10,7 @@ import { resolveDefaultAgentComposeId } from "../../../infra/agent-compose/resol
 import { ensureStorageExists } from "../../../infra/storage/storage-service";
 import { createSlackClient, fetchSlackUserInfoMap } from "../../slack/client";
 import type { UserInfoOptions } from "../../integration-prompt";
+import { canReuseSessionForRunModel } from "../../context/session-model-compatibility";
 import {
   fetchThreadContext,
   fetchChannelContext,
@@ -171,7 +172,7 @@ export async function resolveEffectiveComposeId(
 /**
  * Look up an existing thread session.
  */
-export async function lookupThreadSession(
+async function lookupThreadSession(
   channelId: string,
   threadTs: string,
   connectionId: string,
@@ -399,7 +400,7 @@ export async function getWorkspaceAgent(composeId: string): Promise<
  * Used when continuing a conversation to ensure we use the session's agent,
  * not the workspace default.
  */
-export async function resolveSessionCompose(
+async function resolveSessionCompose(
   sessionId: string,
   userId: string,
 ): Promise<
@@ -423,6 +424,55 @@ export async function resolveSessionCompose(
     });
   }
   return undefined;
+}
+
+export async function resolveCompatibleThreadSession(opts: {
+  channelId: string;
+  threadTs: string;
+  connectionId: string;
+  userId: string;
+  orgId: string;
+  agentComposeId: string;
+  modelProviderId: string | null;
+  selectedModel: string | null;
+}): Promise<string | undefined> {
+  const session = await lookupThreadSession(
+    opts.channelId,
+    opts.threadTs,
+    opts.connectionId,
+  );
+  const existingSessionId = session.existingSessionId;
+  if (!existingSessionId) return undefined;
+
+  const sessionCompose = await resolveSessionCompose(
+    existingSessionId,
+    opts.userId,
+  );
+  if (sessionCompose && sessionCompose.composeId !== opts.agentComposeId) {
+    log.debug("Agent changed, starting new Slack session", {
+      sessionComposeId: sessionCompose.composeId,
+      currentComposeId: opts.agentComposeId,
+    });
+    return undefined;
+  }
+
+  const canReuseSession = await canReuseSessionForRunModel({
+    sessionId: existingSessionId,
+    userId: opts.userId,
+    orgId: opts.orgId,
+    agentComposeId: opts.agentComposeId,
+    modelProviderId: opts.modelProviderId,
+    selectedModel: opts.selectedModel,
+  });
+  if (!canReuseSession) {
+    log.debug("Model changed, starting new Slack session", {
+      composeId: opts.agentComposeId,
+      existingSessionId,
+    });
+    return undefined;
+  }
+
+  return existingSessionId;
 }
 
 /**

--- a/turbo/apps/web/src/lib/zero/telegram/handlers/direct-message.ts
+++ b/turbo/apps/web/src/lib/zero/telegram/handlers/direct-message.ts
@@ -25,6 +25,7 @@ import {
 import { fetchTelegramContext } from "../context";
 import { runAgentForTelegram } from "./run-agent";
 import { buildTelegramErrorResponse } from "../format";
+import { canReuseSessionForRunModel } from "../../context/session-model-compatibility";
 import { logger } from "../../../shared/logger";
 import type { TelegramHandlerUpdate } from "./types";
 
@@ -113,29 +114,18 @@ export async function handleTelegramDirectMessage(
   // 6. Use "dm" sentinel as rootMessageId for single ongoing DM session
   const rootMessageId = "dm";
 
-  // 7. Look up existing session
-  const session = await lookupTelegramThreadSession(
-    chatId,
-    rootMessageId,
-    userLink.id,
-  );
-  let existingSessionId = session.existingSessionId;
-  const lastProcessedMessageId = session.lastProcessedMessageId;
-
-  // 7b. Validate session's agent matches current default — discard only on positive mismatch
-  if (existingSessionId) {
-    const sessionCompose = await resolveSessionCompose(
-      existingSessionId,
-      userLink.vm0UserId,
-    );
-    if (sessionCompose && sessionCompose.composeId !== composeId) {
-      log.debug("Agent changed, starting new session", {
-        sessionComposeId: sessionCompose.composeId,
-        currentComposeId: composeId,
-      });
-      existingSessionId = undefined;
-    }
-  }
+  // 7. Look up an existing DM session when it is compatible with this run.
+  const { existingSessionId, lastProcessedMessageId } =
+    await resolveDirectMessageSession({
+      chatId,
+      rootMessageId,
+      userLinkId: userLink.id,
+      userId: userLink.vm0UserId,
+      orgId: installation.orgId,
+      composeId,
+      modelProviderId: defaultAgent.modelProviderId,
+      selectedModel: defaultAgent.selectedModel,
+    });
 
   // 8. Fetch new conversation context; existing sessions already have older history.
   const { executionContext } = await fetchTelegramContext(
@@ -215,4 +205,62 @@ export async function handleTelegramDirectMessage(
       buildTelegramErrorResponse(errorDetail, linkUrl),
     );
   }
+}
+
+async function resolveDirectMessageSession(params: {
+  chatId: string;
+  rootMessageId: string;
+  userLinkId: string;
+  userId: string;
+  orgId: string;
+  composeId: string;
+  modelProviderId: string | null;
+  selectedModel: string | null;
+}): Promise<{
+  existingSessionId: string | undefined;
+  lastProcessedMessageId: string | undefined;
+}> {
+  const session = await lookupTelegramThreadSession(
+    params.chatId,
+    params.rootMessageId,
+    params.userLinkId,
+  );
+  let existingSessionId = session.existingSessionId;
+  let lastProcessedMessageId = session.lastProcessedMessageId;
+
+  if (existingSessionId) {
+    const sessionCompose = await resolveSessionCompose(
+      existingSessionId,
+      params.userId,
+    );
+    if (sessionCompose && sessionCompose.composeId !== params.composeId) {
+      log.debug("Agent changed, starting new session", {
+        sessionComposeId: sessionCompose.composeId,
+        currentComposeId: params.composeId,
+      });
+      existingSessionId = undefined;
+      lastProcessedMessageId = undefined;
+    }
+  }
+
+  if (existingSessionId) {
+    const canReuseSession = await canReuseSessionForRunModel({
+      sessionId: existingSessionId,
+      userId: params.userId,
+      orgId: params.orgId,
+      agentComposeId: params.composeId,
+      modelProviderId: params.modelProviderId,
+      selectedModel: params.selectedModel,
+    });
+    if (!canReuseSession) {
+      log.debug("Model changed, starting new session", {
+        composeId: params.composeId,
+        existingSessionId,
+      });
+      existingSessionId = undefined;
+      lastProcessedMessageId = undefined;
+    }
+  }
+
+  return { existingSessionId, lastProcessedMessageId };
 }

--- a/turbo/apps/web/src/lib/zero/telegram/handlers/mention.ts
+++ b/turbo/apps/web/src/lib/zero/telegram/handlers/mention.ts
@@ -25,6 +25,7 @@ import {
 import { fetchTelegramContext } from "../context";
 import { runAgentForTelegram } from "./run-agent";
 import { buildTelegramErrorResponse } from "../format";
+import { canReuseSessionForRunModel } from "../../context/session-model-compatibility";
 import { logger } from "../../../shared/logger";
 import type { TelegramHandlerUpdate } from "./types";
 
@@ -151,7 +152,10 @@ export async function handleTelegramMention(
       chatId,
       userLink.id,
       userLink.vm0UserId,
+      installation.orgId,
       composeId,
+      defaultAgent.modelProviderId,
+      defaultAgent.selectedModel,
       installation.botUsername,
     );
 
@@ -225,7 +229,10 @@ async function resolveThreadSession(
   chatId: string,
   userLinkId: string,
   vm0UserId: string,
+  orgId: string,
   composeId: string,
+  modelProviderId: string | null,
+  selectedModel: string | null,
   botUsername: string | null,
 ): Promise<{
   rootMessageId: string | undefined;
@@ -259,6 +266,25 @@ async function resolveThreadSession(
       log.debug("Agent changed, starting new session", {
         sessionComposeId: sessionCompose.composeId,
         currentComposeId: composeId,
+      });
+      existingSessionId = undefined;
+      lastProcessedMessageId = undefined;
+    }
+  }
+
+  if (existingSessionId) {
+    const canReuseSession = await canReuseSessionForRunModel({
+      sessionId: existingSessionId,
+      userId: vm0UserId,
+      orgId,
+      agentComposeId: composeId,
+      modelProviderId,
+      selectedModel,
+    });
+    if (!canReuseSession) {
+      log.debug("Model changed, starting new session", {
+        composeId,
+        existingSessionId,
       });
       existingSessionId = undefined;
       lastProcessedMessageId = undefined;

--- a/turbo/apps/web/src/lib/zero/telegram/handlers/official.ts
+++ b/turbo/apps/web/src/lib/zero/telegram/handlers/official.ts
@@ -42,6 +42,7 @@ import {
 } from "./shared";
 import { runAgentForTelegram } from "./run-agent";
 import { handleTelegramModelCommand } from "./model";
+import { canReuseSessionForRunModel } from "../../context/session-model-compatibility";
 import { logger } from "../../../shared/logger";
 import type { TelegramHandlerUpdate } from "./types";
 
@@ -73,6 +74,8 @@ async function resolveOfficialAgent(userLink: OfficialUserLink): Promise<
       composeId: string;
       agentId: string;
       agentName: string;
+      modelProviderId: string | null;
+      selectedModel: string | null;
     }
   | undefined
 > {
@@ -89,6 +92,8 @@ async function resolveOfficialAgent(userLink: OfficialUserLink): Promise<
     composeId,
     agentId: agent.agentId,
     agentName: getAgentDisplayLabel(agent),
+    modelProviderId: agent.modelProviderId,
+    selectedModel: agent.selectedModel,
   };
 }
 
@@ -217,7 +222,7 @@ export async function handleOfficialTelegramDirectMessage(
     userLinkId: userLink.id,
   });
   let existingSessionId = session.existingSessionId;
-  const lastProcessedMessageId = session.lastProcessedMessageId;
+  let lastProcessedMessageId = session.lastProcessedMessageId;
 
   if (existingSessionId) {
     const sessionCompose = await resolveSessionCompose(
@@ -226,6 +231,26 @@ export async function handleOfficialTelegramDirectMessage(
     );
     if (sessionCompose && sessionCompose.composeId !== agent.composeId) {
       existingSessionId = undefined;
+      lastProcessedMessageId = undefined;
+    }
+  }
+
+  if (existingSessionId) {
+    const canReuseSession = await canReuseSessionForRunModel({
+      sessionId: existingSessionId,
+      userId: userLink.vm0UserId,
+      orgId: userLink.orgId,
+      agentComposeId: agent.composeId,
+      modelProviderId: agent.modelProviderId,
+      selectedModel: agent.selectedModel,
+    });
+    if (!canReuseSession) {
+      log.debug("Model changed, starting new official session", {
+        composeId: agent.composeId,
+        existingSessionId,
+      });
+      existingSessionId = undefined;
+      lastProcessedMessageId = undefined;
     }
   }
 
@@ -361,6 +386,8 @@ export async function handleOfficialTelegramMention(
       chatId,
       userLink,
       agent.composeId,
+      agent.modelProviderId,
+      agent.selectedModel,
       runtime.botUsername,
     );
 
@@ -428,6 +455,8 @@ async function resolveOfficialThreadSession(
   chatId: string,
   userLink: OfficialUserLink,
   composeId: string,
+  modelProviderId: string | null,
+  selectedModel: string | null,
   botUsername: string | null,
 ): Promise<{
   rootMessageId: string | undefined;
@@ -457,6 +486,25 @@ async function resolveOfficialThreadSession(
       userLink.vm0UserId,
     );
     if (sessionCompose && sessionCompose.composeId !== composeId) {
+      existingSessionId = undefined;
+      lastProcessedMessageId = undefined;
+    }
+  }
+
+  if (existingSessionId) {
+    const canReuseSession = await canReuseSessionForRunModel({
+      sessionId: existingSessionId,
+      userId: userLink.vm0UserId,
+      orgId: userLink.orgId,
+      agentComposeId: composeId,
+      modelProviderId,
+      selectedModel,
+    });
+    if (!canReuseSession) {
+      log.debug("Model changed, starting new official session", {
+        composeId,
+        existingSessionId,
+      });
       existingSessionId = undefined;
       lastProcessedMessageId = undefined;
     }

--- a/turbo/apps/web/src/lib/zero/telegram/handlers/shared.ts
+++ b/turbo/apps/web/src/lib/zero/telegram/handlers/shared.ts
@@ -181,7 +181,29 @@ export async function saveTelegramThreadSession(opts: {
   const userLinkKind = opts.userLinkKind ?? "custom";
 
   if (!existingSessionId && newSessionId) {
-    // New thread — create mapping
+    // New thread or intentionally reset thread — claim the mapping for the
+    // new agent session so DM roots like "dm" can move off an incompatible
+    // prior session.
+    const updated = await globalThis.services.db
+      .update(telegramThreadSessions)
+      .set({
+        agentSessionId: newSessionId,
+        lastProcessedMessageId: messageId,
+        updatedAt: new Date(),
+      })
+      .where(
+        and(
+          userLinkKind === "custom"
+            ? eq(telegramThreadSessions.telegramUserLinkId, userLinkId)
+            : eq(telegramThreadSessions.telegramOfficialUserLinkId, userLinkId),
+          eq(telegramThreadSessions.chatId, chatId),
+          eq(telegramThreadSessions.rootMessageId, rootMessageId),
+        ),
+      )
+      .returning({ id: telegramThreadSessions.id });
+
+    if (updated.length > 0) return;
+
     await globalThis.services.db
       .insert(telegramThreadSessions)
       .values({
@@ -609,10 +631,15 @@ export async function ensureOrgAndArtifact(
 /**
  * Resolve workspace agent name from composeId
  */
-export async function getWorkspaceAgent(
-  composeId: string,
-): Promise<
-  | { id: string; name: string; displayName: string | null; agentId: string }
+export async function getWorkspaceAgent(composeId: string): Promise<
+  | {
+      id: string;
+      name: string;
+      displayName: string | null;
+      agentId: string;
+      modelProviderId: string | null;
+      selectedModel: string | null;
+    }
   | undefined
 > {
   const db = globalThis.services.db;
@@ -635,6 +662,8 @@ export async function getWorkspaceAgent(
     .select({
       name: zeroAgents.name,
       displayName: zeroAgents.displayName,
+      modelProviderId: zeroAgents.modelProviderId,
+      selectedModel: zeroAgents.selectedModel,
     })
     .from(zeroAgents)
     .where(eq(zeroAgents.id, agentId))
@@ -645,6 +674,8 @@ export async function getWorkspaceAgent(
     name: agent?.name ?? compose.name,
     displayName: agent?.displayName ?? null,
     agentId,
+    modelProviderId: agent?.modelProviderId ?? null,
+    selectedModel: agent?.selectedModel ?? null,
   };
 }
 

--- a/turbo/apps/web/src/lib/zero/zero-run-policy.ts
+++ b/turbo/apps/web/src/lib/zero/zero-run-policy.ts
@@ -153,6 +153,9 @@ export async function validateComposeRequirements(
 interface ResolvedAdmissionProvider {
   providerType: ModelProviderType | null;
   providerFramework: ModelProviderFramework | null;
+  modelProviderId?: string | null;
+  modelProviderCredentialScope?: ModelProviderCredentialScope;
+  selectedModel?: string;
 }
 
 async function resolveProviderForAdmission(params: {
@@ -181,6 +184,12 @@ async function resolveProviderForAdmission(params: {
     return {
       providerType: route.provider.type,
       providerFramework: route.framework,
+      modelProviderId: route.credential.modelProviderId,
+      modelProviderCredentialScope: route.credential.scope,
+      selectedModel:
+        route.provider.type === "vm0"
+          ? route.model.canonical
+          : route.model.selected,
     };
   } catch (error) {
     if (isNoModelProvider(error)) {
@@ -195,6 +204,9 @@ interface RunAdmissionContext {
   userId: string;
   providerType: ModelProviderType | null;
   providerFramework?: ModelProviderFramework | null;
+  modelProviderId?: string | null;
+  modelProviderCredentialScope?: ModelProviderCredentialScope;
+  selectedModel?: string;
 }
 
 export async function resolveRunAdmissionContext(params: {
@@ -212,6 +224,9 @@ export async function resolveRunAdmissionContext(params: {
     userId: params.userId,
     providerType: provider.providerType,
     providerFramework: provider.providerFramework,
+    modelProviderId: provider.modelProviderId,
+    modelProviderCredentialScope: provider.modelProviderCredentialScope,
+    selectedModel: provider.selectedModel,
   };
 }
 

--- a/turbo/apps/web/src/lib/zero/zero-run-policy.ts
+++ b/turbo/apps/web/src/lib/zero/zero-run-policy.ts
@@ -8,6 +8,7 @@ import {
 } from "@vm0/api-services/errors";
 import {
   MODEL_PROVIDER_TYPES,
+  type ModelProviderCredentialScope,
   type ModelProviderFramework,
   type ModelProviderType,
 } from "@vm0/api-contracts/contracts/model-providers";

--- a/turbo/apps/web/src/lib/zero/zero-run-service.ts
+++ b/turbo/apps/web/src/lib/zero/zero-run-service.ts
@@ -901,7 +901,14 @@ async function dispatchZeroRun(
       apiStartTime: record.apiStartTime,
     });
 
-    // 8. Dispatch with pre-built context (callbacks already registered above)
+    // 8. Persist resolved model metadata before dispatch so failed runs still
+    // carry the model signature used for admission and context building. The
+    // queued path does the same before dispatching from the queue worker.
+    if (contextResult?.resolvedModelProvider || contextResult?.selectedModel) {
+      await updateZeroRunModelInfo(record.run.id, contextResult);
+    }
+
+    // 9. Dispatch with pre-built context (callbacks already registered above)
     const dispatchResult = await buildAndDispatchRun({
       runId: record.run.id,
       context: contextResult.context,
@@ -918,13 +925,6 @@ async function dispatchZeroRun(
         diagnosticSpans: contextResult.timings.diagnosticSpans,
       },
     });
-
-    // 9. Update zero-layer metadata with model fields resolved during dispatch.
-    // The base row (triggerSource, scheduleId, triggerAgentId) was already
-    // inserted in createZeroRunRecord; here we only backfill model info.
-    if (contextResult?.resolvedModelProvider || contextResult?.selectedModel) {
-      await updateZeroRunModelInfo(record.run.id, contextResult);
-    }
 
     return dispatchResult;
   } catch (error) {

--- a/turbo/apps/web/src/lib/zero/zero-run-service.ts
+++ b/turbo/apps/web/src/lib/zero/zero-run-service.ts
@@ -332,6 +332,35 @@ function resolveEffectiveModel(
   };
 }
 
+function resolveRunModelForRecord(
+  effectiveModel: ReturnType<typeof resolveEffectiveModel>,
+  admissionContext: {
+    modelProviderId?: string | null;
+    modelProviderCredentialScope?: string;
+    selectedModel?: string;
+  },
+  options: { modelFirstEnabled: boolean },
+): ReturnType<typeof resolveEffectiveModel> {
+  if (!options.modelFirstEnabled) {
+    return effectiveModel;
+  }
+
+  return {
+    modelProviderId:
+      effectiveModel.modelProviderId ??
+      admissionContext.modelProviderId ??
+      undefined,
+    modelProviderCredentialScope:
+      effectiveModel.modelProviderCredentialScope ??
+      admissionContext.modelProviderCredentialScope ??
+      undefined,
+    selectedModelOverride:
+      effectiveModel.selectedModelOverride ??
+      admissionContext.selectedModel ??
+      undefined,
+  };
+}
+
 function buildZeroRunMetadata(
   params: CreateZeroRunParams,
   runParams: CreateRunParams,
@@ -722,6 +751,11 @@ async function createZeroRunRecord(
     providerType: admissionContext.providerType,
     agentCompose: resolved.composeContent,
   });
+  const resolvedRunModel = resolveRunModelForRecord(
+    effectiveModel,
+    admissionContext,
+    { modelFirstEnabled },
+  );
 
   if (!params.sessionId) {
     await validateComposeRequirements(
@@ -744,9 +778,9 @@ async function createZeroRunRecord(
       params.userId,
       params.modelProvider,
       resolved.composeContent,
-      effectiveModel.selectedModelOverride,
-      effectiveModel.modelProviderId,
-      effectiveModel.modelProviderCredentialScope,
+      resolvedRunModel.selectedModelOverride,
+      resolvedRunModel.modelProviderId,
+      resolvedRunModel.modelProviderCredentialScope,
     );
   });
   const round3Capture = timed(async () => {
@@ -790,7 +824,7 @@ async function createZeroRunRecord(
     sessionId: params.sessionId,
     appendSystemPrompt,
     modelProvider: params.modelProvider,
-    ...effectiveModel,
+    ...resolvedRunModel,
     callbacks: params.callbacks,
     disallowedTools: [...DISALLOWED_TOOLS],
     vars: { ZERO_AGENT_ID: params.agentId },


### PR DESCRIPTION
## Summary
- add a shared run-model compatibility check before reusing Telegram or Slack integration sessions
- start a new integration session when the previous session's provider/model does not match the model selected for the new message
- update Telegram DM thread mapping replacement so a model-change reset claims the existing `dm` mapping for the new session
- add Telegram and Slack regression tests for model-change session resets, plus Telegram callback mapping replacement coverage

## Verification
- PASS: `pnpm --filter web exec eslint app/api/telegram/webhook/__tests__/route.test.ts app/api/internal/callbacks/telegram/__tests__/route.test.ts app/api/zero/slack/events/__tests__/route.test.ts src/lib/zero/context/session-model-compatibility.ts src/lib/zero/telegram/handlers/shared.ts src/lib/zero/telegram/handlers/direct-message.ts src/lib/zero/telegram/handlers/mention.ts src/lib/zero/telegram/handlers/official.ts src/lib/zero/slack-org/handlers/shared.ts src/lib/zero/slack-org/handlers/direct-message.ts src/lib/zero/slack-org/handlers/mention.ts src/__tests__/db-test-seeders/telegram.ts src/__tests__/db-test-assertions/telegram.ts src/__tests__/api-test-helpers/telegram.ts src/__tests__/api-test-helpers/index.ts --max-warnings 0`
- PASS: `git diff --check`
- BLOCKED: targeted vitest run is blocked by local test DB schema drift: missing `telegram_installations.owner_user_id`, `model_providers.token_expires_at`, and `org_model_policies`
- BLOCKED: `pnpm --filter web db:migrate` is blocked because the same local DB has an existing `redemption_codes` table not reflected in drizzle migration state
- BLOCKED: `pnpm --filter web exec tsc --noEmit --pretty false` fails on existing unrelated implicit-any errors outside the touched files
- BLOCKED: pre-commit `check-types` fails on existing unrelated `apps/platform` type errors; commit was created with `--no-verify` after prettier/knip passed