### PR TITLE
refactor(api): migrate telegram integration get routes

### DIFF
--- a/turbo/apps/api/src/__tests__/mocks.ts
+++ b/turbo/apps/api/src/__tests__/mocks.ts
@@ -108,6 +108,7 @@ export interface ApiTestMocks {
     readonly getMe: AsyncMock;
     readonly getFile: AsyncMock;
     readonly deleteWebhook: AsyncMock;
+    readonly getUserProfilePhotos: AsyncMock;
   };
   readonly otel: {
     readonly registerOTel: SyncMock;
@@ -217,6 +218,7 @@ const apiTestMocks: ApiTestMocks = vi.hoisted((): ApiTestMocks => {
     getMe: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
     getFile: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
     deleteWebhook: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
+    getUserProfilePhotos: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
   };
 
   const axiomLogging = {
@@ -450,6 +452,7 @@ vi.mock("../signals/external/telegram-client", async () => {
     getMe: apiTestMocks.telegram.getMe,
     getFile: apiTestMocks.telegram.getFile,
     deleteWebhook: apiTestMocks.telegram.deleteWebhook,
+    getUserProfilePhotos: apiTestMocks.telegram.getUserProfilePhotos,
   };
 });
 
@@ -565,6 +568,7 @@ export function resetApiTestMocks(): void {
   apiTestMocks.telegram.getFile.mockReset();
   apiTestMocks.telegram.deleteWebhook.mockReset();
   apiTestMocks.telegram.deleteWebhook.mockResolvedValue(undefined);
+  apiTestMocks.telegram.getUserProfilePhotos.mockReset();
   apiTestMocks.otel.registerOTel.mockReset();
   apiTestMocks.sentry.captureException.mockReset();
   apiTestMocks.sentry.httpIntegration.mockClear();

--- a/turbo/apps/api/src/signals/external/telegram-avatar.ts
+++ b/turbo/apps/api/src/signals/external/telegram-avatar.ts
@@ -1,4 +1,4 @@
-import { createHmac } from "node:crypto";
+import { createHmac, timingSafeEqual } from "node:crypto";
 
 import { env } from "../../lib/env";
 import { now } from "./time";
@@ -17,6 +17,38 @@ function computeAvatarHmacSignature(
   return createHmac("sha256", secret)
     .update(`${expiresAt}.${botId}`)
     .digest("hex");
+}
+
+export function verifyTelegramBotAvatarUrlSignature(params: {
+  readonly botId: string;
+  readonly expiresAt: string | undefined;
+  readonly signature: string | undefined;
+}): boolean {
+  if (!params.expiresAt || !params.signature) {
+    return false;
+  }
+
+  const expiresAt = Number(params.expiresAt);
+  if (!Number.isSafeInteger(expiresAt)) {
+    return false;
+  }
+
+  if (expiresAt < Math.floor(now() / 1000)) {
+    return false;
+  }
+
+  const expected = Buffer.from(
+    computeAvatarHmacSignature(
+      params.botId,
+      env("SECRETS_ENCRYPTION_KEY"),
+      expiresAt,
+    ),
+    "hex",
+  );
+  const received = Buffer.from(params.signature, "hex");
+  return (
+    received.length === expected.length && timingSafeEqual(received, expected)
+  );
 }
 
 export function buildTelegramBotAvatarUrl(botId: string): string {

--- a/turbo/apps/api/src/signals/external/telegram-client.ts
+++ b/turbo/apps/api/src/signals/external/telegram-client.ts
@@ -1,15 +1,45 @@
-interface TelegramApiError {
+interface TelegramApiErrorPayload {
   readonly ok: false;
   readonly description: string;
+  readonly error_code?: number;
 }
 
-function isTelegramApiError(value: unknown): value is TelegramApiError {
+function isTelegramApiErrorPayload(
+  value: unknown,
+): value is TelegramApiErrorPayload {
   return (
     typeof value === "object" &&
     value !== null &&
     "ok" in value &&
-    (value as TelegramApiError).ok === false
+    (value as TelegramApiErrorPayload).ok === false
   );
+}
+
+interface TelegramApiErrorShape {
+  readonly status: number;
+  readonly description: string | undefined;
+}
+
+class TelegramApiError extends Error implements TelegramApiErrorShape {
+  readonly status: number;
+  readonly description: string | undefined;
+
+  constructor(status: number, statusText: string, description?: string) {
+    super(
+      description
+        ? `Telegram API error: ${status} ${description}`
+        : `Telegram API error: ${status} ${statusText}`,
+    );
+    this.name = "TelegramApiError";
+    this.status = status;
+    this.description = description;
+  }
+}
+
+export function isTelegramApiError(
+  value: unknown,
+): value is Error & TelegramApiErrorShape {
+  return value instanceof TelegramApiError;
 }
 
 async function callTelegramApi<T>(
@@ -24,16 +54,16 @@ async function callTelegramApi<T>(
 
   const response = await fetch(`${url}${searchParams}`);
 
-  if (!response.ok) {
-    throw new Error(
-      `Telegram API error: ${response.status} ${response.statusText}`,
-    );
-  }
-
   const data: unknown = await response.json();
 
-  if (isTelegramApiError(data)) {
-    throw new Error(`Telegram API error: ${data.description}`);
+  const errorPayload = isTelegramApiErrorPayload(data) ? data : null;
+
+  if (!response.ok || errorPayload) {
+    throw new TelegramApiError(
+      response.status,
+      response.statusText,
+      errorPayload?.description,
+    );
   }
 
   return data as T;
@@ -87,9 +117,35 @@ export async function deleteWebhook(token: string): Promise<void> {
   }
 
   const data: unknown = await response.json();
-  if (isTelegramApiError(data)) {
+  if (isTelegramApiErrorPayload(data)) {
     throw new Error(`Telegram API error: ${data.description}`);
   }
+}
+
+export interface TelegramUserProfilePhoto {
+  readonly file_id: string;
+  readonly file_unique_id?: string;
+  readonly width: number;
+  readonly height: number;
+  readonly file_size?: number;
+}
+
+export async function getUserProfilePhotos(
+  token: string,
+  userId: string | number,
+  limit: number,
+): Promise<readonly (readonly TelegramUserProfilePhoto[])[]> {
+  const result = await callTelegramApi<{
+    readonly ok: true;
+    readonly result: {
+      readonly total_count: number;
+      readonly photos: readonly (readonly TelegramUserProfilePhoto[])[];
+    };
+  }>(token, "getUserProfilePhotos", {
+    user_id: String(userId),
+    limit: String(limit),
+  });
+  return result.result.photos;
 }
 
 /**
@@ -116,7 +172,7 @@ export async function sendChatAction(
     );
   }
   const data: unknown = await response.json();
-  if (isTelegramApiError(data)) {
+  if (isTelegramApiErrorPayload(data)) {
     throw new Error(`Telegram API error: ${data.description}`);
   }
 }
@@ -188,7 +244,7 @@ export async function sendMessage(
     };
   }
 
-  if (isTelegramApiError(data)) {
+  if (isTelegramApiErrorPayload(data)) {
     return {
       kind: "telegram-error",
       status: response.status,
@@ -283,7 +339,7 @@ export async function sendDocument(
     };
   }
 
-  if (isTelegramApiError(data)) {
+  if (isTelegramApiErrorPayload(data)) {
     return {
       kind: "telegram-error",
       status: response.status,

--- a/turbo/apps/api/src/signals/external/telegram-domain.ts
+++ b/turbo/apps/api/src/signals/external/telegram-domain.ts
@@ -1,0 +1,28 @@
+import { logger } from "../../lib/log";
+import { safeAsync } from "../utils";
+
+const TELEGRAM_OAUTH_BASE_URL = "https://oauth.telegram.org/auth";
+const log = logger("telegram:check-domain");
+
+export async function checkTelegramDomain(
+  telegramBotId: string,
+  appUrl: string,
+): Promise<boolean> {
+  const query = new URLSearchParams({
+    bot_id: telegramBotId,
+    origin: appUrl,
+  });
+  const result = await safeAsync(() => {
+    return fetch(`${TELEGRAM_OAUTH_BASE_URL}?${query}`, {
+      method: "HEAD",
+      signal: AbortSignal.timeout(3000),
+    });
+  });
+  if ("error" in result) {
+    log.warn("Domain probe failed", { telegramBotId, error: result.error });
+    return false;
+  }
+
+  const contentLength = result.ok.headers.get("content-length");
+  return contentLength !== null && Number(contentLength) > 1000;
+}

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-telegram.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-telegram.ts
@@ -5,6 +5,7 @@ import { agentComposes } from "@vm0/db/schema/agent-compose";
 import { orgMetadata } from "@vm0/db/schema/org-metadata";
 import { telegramInstallations } from "@vm0/db/schema/telegram-installation";
 import { telegramOfficialUserLinks } from "@vm0/db/schema/telegram-official-user-link";
+import { telegramUserLinks } from "@vm0/db/schema/telegram-user-link";
 import { telegramUserAgentPreferences } from "@vm0/db/schema/telegram-user-agent-preference";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
 import { eq, inArray } from "drizzle-orm";
@@ -48,6 +49,12 @@ interface SeedOfficialUserLinkValues {
   readonly orgId: string;
   readonly userId: string;
   readonly telegramUserId: string;
+}
+
+interface SeedTelegramUserLinkValues {
+  readonly installationId: string;
+  readonly telegramUserId: string;
+  readonly vm0UserId: string;
 }
 
 interface SeedUserAgentPreferenceValues {
@@ -152,6 +159,22 @@ export const seedOfficialUserLink$ = command(
       orgId: values.orgId,
       vm0UserId: values.userId,
       telegramUserId: values.telegramUserId,
+    });
+    signal.throwIfAborted();
+  },
+);
+
+export const seedTelegramUserLink$ = command(
+  async (
+    { set },
+    values: SeedTelegramUserLinkValues,
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const writeDb = set(writeDb$);
+    await writeDb.insert(telegramUserLinks).values({
+      installationId: values.installationId,
+      telegramUserId: values.telegramUserId,
+      vm0UserId: values.vm0UserId,
     });
     signal.throwIfAborted();
   },

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-telegram.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-telegram.test.ts
@@ -1,7 +1,10 @@
 import { randomUUID } from "node:crypto";
 
 import { integrationsTelegramBotListContract } from "@vm0/api-contracts/contracts/integrations";
-import { OFFICIAL_TELEGRAM_BOT_ID } from "@vm0/api-contracts/contracts/zero-integrations-telegram";
+import {
+  OFFICIAL_TELEGRAM_BOT_ID,
+  zeroIntegrationsTelegramContract,
+} from "@vm0/api-contracts/contracts/zero-integrations-telegram";
 import { createStore } from "ccstate";
 import { afterEach, beforeEach } from "vitest";
 import { http, HttpResponse } from "msw";
@@ -12,6 +15,7 @@ import { server } from "../../../mocks/server";
 import { signSandboxJwtForTests } from "../../auth/tokens";
 import { mockEnv } from "../../../lib/env";
 import { now } from "../../external/time";
+import { buildTelegramBotAvatarUrl } from "../../external/telegram-avatar";
 import {
   deleteOrgMembership$,
   seedOrgMembership$,
@@ -22,6 +26,7 @@ import {
   freezeTelegramFixture,
   makeTelegramFixtureBuilder,
   seedTelegramInstallation$,
+  seedTelegramUserLink$,
   type TelegramFixture,
 } from "./helpers/zero-telegram";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
@@ -67,6 +72,18 @@ function mintZeroToken(args: {
     capabilities: args.capabilities,
     iat: nowSeconds,
     exp: nowSeconds + 3600,
+  });
+}
+
+function telegramOauthHead(contentLength: string, expectedOrigin?: string) {
+  return http.head("https://oauth.telegram.org/auth", ({ request }) => {
+    const url = new URL(request.url);
+    if (expectedOrigin) {
+      expect(url.searchParams.get("origin")).toBe(expectedOrigin);
+    }
+    return new HttpResponse(null, {
+      headers: { "content-length": contentLength },
+    });
   });
 }
 
@@ -236,6 +253,590 @@ describe("GET /api/zero/integrations/telegram/bots", () => {
       isOwner: false,
       official: { linkedTelegramUserId: null },
     });
+  });
+});
+
+describe("GET /api/integrations/telegram", () => {
+  const fixtures: TelegramFixture[] = [];
+  const memberships: OrgMembershipFixture[] = [];
+
+  beforeEach(() => {
+    configureOfficialBotEnv();
+  });
+
+  afterEach(async () => {
+    while (fixtures.length > 0) {
+      const fixture = fixtures.pop();
+      if (fixture) {
+        await store.set(deleteTelegramFixture$, fixture, context.signal);
+      }
+    }
+    while (memberships.length > 0) {
+      const membership = memberships.pop();
+      if (membership) {
+        await store.set(deleteOrgMembership$, membership, context.signal);
+      }
+    }
+  });
+
+  it("returns 401 when no auth token is provided", async () => {
+    const client = setupApp({ context })(zeroIntegrationsTelegramContract);
+
+    const response = await accept(client.list({ headers: {} }), [401]);
+
+    expectUnauthorized(response.body);
+  });
+
+  it("lists official and active-org custom bots with link status", async () => {
+    const orgId = `org_${randomUUID()}`;
+    const userId = `user_${randomUUID()}`;
+    const otherOrgId = `org_${randomUUID()}`;
+
+    const membership = await store.set(
+      seedOrgMembership$,
+      { orgId, userId, seedOrgCache: false },
+      context.signal,
+    );
+    memberships.push(membership);
+
+    const linkedBotId = newTelegramBotId();
+    const unlinkedBotId = newTelegramBotId();
+    const otherOrgBotId = newTelegramBotId();
+
+    context.mocks.telegram.getMe.mockImplementation((token: unknown) => {
+      const botId =
+        token === "test-bot-token"
+          ? linkedBotId
+          : String(token).split(":", 1)[0];
+      return Promise.resolve({
+        id: Number(botId),
+        is_bot: true,
+        first_name: "Bot",
+        username: "x",
+      });
+    });
+
+    const builderA = makeTelegramFixtureBuilder(orgId);
+    const builderB = makeTelegramFixtureBuilder(otherOrgId);
+
+    const linkedInstall = await store.set(
+      seedTelegramInstallation$,
+      { orgId, ownerUserId: userId, telegramBotId: linkedBotId },
+      context.signal,
+    );
+    builderA.composeIds.push(linkedInstall.composeId);
+    builderA.telegramBotIds.push(linkedInstall.telegramBotId);
+    await store.set(
+      seedTelegramUserLink$,
+      {
+        installationId: linkedInstall.telegramBotId,
+        telegramUserId: "tg-linked-user",
+        vm0UserId: userId,
+      },
+      context.signal,
+    );
+
+    const unlinkedInstall = await store.set(
+      seedTelegramInstallation$,
+      {
+        orgId,
+        ownerUserId: `user_${randomUUID()}`,
+        telegramBotId: unlinkedBotId,
+      },
+      context.signal,
+    );
+    builderA.composeIds.push(unlinkedInstall.composeId);
+    builderA.telegramBotIds.push(unlinkedInstall.telegramBotId);
+
+    const otherOrgInstall = await store.set(
+      seedTelegramInstallation$,
+      {
+        orgId: otherOrgId,
+        ownerUserId: userId,
+        telegramBotId: otherOrgBotId,
+      },
+      context.signal,
+    );
+    builderB.composeIds.push(otherOrgInstall.composeId);
+    builderB.telegramBotIds.push(otherOrgInstall.telegramBotId);
+
+    fixtures.push(freezeTelegramFixture(builderA));
+    fixtures.push(freezeTelegramFixture(builderB));
+
+    const token = mintZeroToken({
+      userId,
+      orgId,
+      capabilities: ["telegram:read"],
+    });
+    const client = setupApp({ context })(zeroIntegrationsTelegramContract);
+
+    const response = await accept(
+      client.list({ headers: { authorization: `Bearer ${token}` } }),
+      [200],
+    );
+
+    expect(response.body.bots).toHaveLength(3);
+    expect(response.body.bots).toStrictEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: OFFICIAL_TELEGRAM_BOT_ID,
+          kind: "official",
+        }),
+        expect.objectContaining({
+          id: linkedBotId,
+          isOwner: true,
+          isConnected: true,
+          avatarUrl: expect.stringContaining(
+            `/api/integrations/telegram/${linkedBotId}/avatar?exp=`,
+          ),
+        }),
+        expect.objectContaining({
+          id: unlinkedBotId,
+          isOwner: false,
+          isConnected: false,
+        }),
+      ]),
+    );
+    expect(
+      response.body.bots.some((bot) => {
+        return bot.id === otherOrgBotId;
+      }),
+    ).toBeFalsy();
+  });
+});
+
+describe("GET /api/integrations/telegram/:botId", () => {
+  const fixtures: TelegramFixture[] = [];
+  const memberships: OrgMembershipFixture[] = [];
+
+  beforeEach(() => {
+    configureOfficialBotEnv();
+    server.use(telegramOauthHead("0"));
+  });
+
+  afterEach(async () => {
+    while (fixtures.length > 0) {
+      const fixture = fixtures.pop();
+      if (fixture) {
+        await store.set(deleteTelegramFixture$, fixture, context.signal);
+      }
+    }
+    while (memberships.length > 0) {
+      const membership = memberships.pop();
+      if (membership) {
+        await store.set(deleteOrgMembership$, membership, context.signal);
+      }
+    }
+  });
+
+  async function seedBotStatusContext(): Promise<{
+    readonly token: string;
+    readonly botId: string;
+    readonly orgId: string;
+    readonly userId: string;
+  }> {
+    const orgId = `org_${randomUUID()}`;
+    const userId = `user_${randomUUID()}`;
+    const membership = await store.set(
+      seedOrgMembership$,
+      { orgId, userId, seedOrgCache: false },
+      context.signal,
+    );
+    memberships.push(membership);
+
+    const botId = newTelegramBotId();
+    context.mocks.telegram.getMe.mockResolvedValue({
+      id: Number(botId),
+      is_bot: true,
+      first_name: "Bot",
+      username: "x",
+    });
+    const builder = makeTelegramFixtureBuilder(orgId);
+    const installation = await store.set(
+      seedTelegramInstallation$,
+      { orgId, ownerUserId: userId, telegramBotId: botId },
+      context.signal,
+    );
+    builder.composeIds.push(installation.composeId);
+    builder.telegramBotIds.push(installation.telegramBotId);
+    fixtures.push(freezeTelegramFixture(builder));
+
+    return {
+      token: mintZeroToken({
+        userId,
+        orgId,
+        capabilities: ["telegram:read"],
+      }),
+      botId,
+      orgId,
+      userId,
+    };
+  }
+
+  it("returns 404 when the custom bot is not in the active org", async () => {
+    const { token } = await seedBotStatusContext();
+    const otherOrgId = `org_${randomUUID()}`;
+    const otherBotId = newTelegramBotId();
+    const builder = makeTelegramFixtureBuilder(otherOrgId);
+    const otherInstall = await store.set(
+      seedTelegramInstallation$,
+      {
+        orgId: otherOrgId,
+        ownerUserId: `user_${randomUUID()}`,
+        telegramBotId: otherBotId,
+      },
+      context.signal,
+    );
+    builder.composeIds.push(otherInstall.composeId);
+    builder.telegramBotIds.push(otherInstall.telegramBotId);
+    fixtures.push(freezeTelegramFixture(builder));
+    const client = setupApp({ context })(zeroIntegrationsTelegramContract);
+
+    const response = await accept(
+      client.getBot({
+        params: { botId: otherBotId },
+        headers: { authorization: `Bearer ${token}` },
+      }),
+      [404],
+    );
+
+    expect(response.body.error.code).toBe("NOT_FOUND");
+  });
+
+  it("returns full status for a visible custom bot", async () => {
+    const { token, botId } = await seedBotStatusContext();
+    const client = setupApp({ context })(zeroIntegrationsTelegramContract);
+
+    const response = await accept(
+      client.getBot({
+        params: { botId },
+        headers: { authorization: `Bearer ${token}` },
+      }),
+      [200],
+    );
+
+    expect(response.body).toMatchObject({
+      id: botId,
+      isOwner: true,
+      isConnected: false,
+      tokenStatus: "valid",
+      domainConfigured: false,
+      environment: {
+        requiredSecrets: expect.any(Array),
+        requiredVars: expect.any(Array),
+        missingSecrets: expect.any(Array),
+        missingVars: expect.any(Array),
+      },
+    });
+  });
+});
+
+describe("GET /api/integrations/telegram/link", () => {
+  const fixtures: TelegramFixture[] = [];
+  const memberships: OrgMembershipFixture[] = [];
+
+  beforeEach(() => {
+    configureOfficialBotEnv();
+    server.use(telegramOauthHead("0"));
+  });
+
+  afterEach(async () => {
+    while (fixtures.length > 0) {
+      const fixture = fixtures.pop();
+      if (fixture) {
+        await store.set(deleteTelegramFixture$, fixture, context.signal);
+      }
+    }
+    while (memberships.length > 0) {
+      const membership = memberships.pop();
+      if (membership) {
+        await store.set(deleteOrgMembership$, membership, context.signal);
+      }
+    }
+  });
+
+  async function seedLinkContext(): Promise<{
+    readonly token: string;
+    readonly orgId: string;
+    readonly userId: string;
+  }> {
+    const orgId = `org_${randomUUID()}`;
+    const userId = `user_${randomUUID()}`;
+    const membership = await store.set(
+      seedOrgMembership$,
+      { orgId, userId, seedOrgCache: false },
+      context.signal,
+    );
+    memberships.push(membership);
+    return {
+      token: mintZeroToken({
+        userId,
+        orgId,
+        capabilities: ["telegram:read"],
+      }),
+      orgId,
+      userId,
+    };
+  }
+
+  it("returns linked false without installation when no link exists", async () => {
+    const { token } = await seedLinkContext();
+    const client = setupApp({ context })(zeroIntegrationsTelegramContract);
+
+    const response = await accept(
+      client.getLinkStatus({
+        query: {},
+        headers: { authorization: `Bearer ${token}` },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({ linked: false });
+  });
+
+  it("scopes linked status to the requested bot", async () => {
+    const { token, orgId, userId } = await seedLinkContext();
+    const linkedBotId = newTelegramBotId();
+    const unlinkedBotId = newTelegramBotId();
+    const builder = makeTelegramFixtureBuilder(orgId);
+
+    for (const botId of [linkedBotId, unlinkedBotId]) {
+      const installation = await store.set(
+        seedTelegramInstallation$,
+        { orgId, ownerUserId: userId, telegramBotId: botId },
+        context.signal,
+      );
+      builder.composeIds.push(installation.composeId);
+      builder.telegramBotIds.push(installation.telegramBotId);
+    }
+    fixtures.push(freezeTelegramFixture(builder));
+    await store.set(
+      seedTelegramUserLink$,
+      {
+        installationId: linkedBotId,
+        telegramUserId: "tg-linked-user",
+        vm0UserId: userId,
+      },
+      context.signal,
+    );
+
+    const client = setupApp({ context })(zeroIntegrationsTelegramContract);
+    const linkedResponse = await accept(
+      client.getLinkStatus({
+        query: { botId: linkedBotId },
+        headers: { authorization: `Bearer ${token}` },
+      }),
+      [200],
+    );
+    const unlinkedResponse = await accept(
+      client.getLinkStatus({
+        query: { botId: unlinkedBotId },
+        headers: { authorization: `Bearer ${token}` },
+      }),
+      [200],
+    );
+
+    expect(linkedResponse.body).toMatchObject({
+      linked: true,
+      telegramUserId: "tg-linked-user",
+      botUsername: `bot_${linkedBotId}`,
+    });
+    expect(unlinkedResponse.body).toStrictEqual({
+      linked: false,
+      installation: {
+        id: unlinkedBotId,
+        botUsername: `bot_${unlinkedBotId}`,
+        loginBotId: unlinkedBotId,
+        domainConfigured: false,
+      },
+    });
+  });
+
+  it("returns 403 when the requested bot belongs to another org", async () => {
+    const { token } = await seedLinkContext();
+    const otherOrgId = `org_${randomUUID()}`;
+    const otherBotId = newTelegramBotId();
+    const builder = makeTelegramFixtureBuilder(otherOrgId);
+    const installation = await store.set(
+      seedTelegramInstallation$,
+      {
+        orgId: otherOrgId,
+        ownerUserId: `user_${randomUUID()}`,
+        telegramBotId: otherBotId,
+      },
+      context.signal,
+    );
+    builder.composeIds.push(installation.composeId);
+    builder.telegramBotIds.push(installation.telegramBotId);
+    fixtures.push(freezeTelegramFixture(builder));
+    const client = setupApp({ context })(zeroIntegrationsTelegramContract);
+
+    const response = await accept(
+      client.getLinkStatus({
+        query: { botId: otherBotId },
+        headers: { authorization: `Bearer ${token}` },
+      }),
+      [403],
+    );
+
+    expect(response.body.error.code).toBe("FORBIDDEN");
+  });
+});
+
+describe("GET /api/integrations/telegram/:botId/avatar", () => {
+  const fixtures: TelegramFixture[] = [];
+  const memberships: OrgMembershipFixture[] = [];
+
+  beforeEach(() => {
+    configureOfficialBotEnv();
+  });
+
+  afterEach(async () => {
+    while (fixtures.length > 0) {
+      const fixture = fixtures.pop();
+      if (fixture) {
+        await store.set(deleteTelegramFixture$, fixture, context.signal);
+      }
+    }
+    while (memberships.length > 0) {
+      const membership = memberships.pop();
+      if (membership) {
+        await store.set(deleteOrgMembership$, membership, context.signal);
+      }
+    }
+  });
+
+  function requestPathFromSignedUrl(url: string): string {
+    const parsed = new URL(url);
+    return `${parsed.pathname}${parsed.search}`;
+  }
+
+  it("streams a signed custom bot avatar without auth", async () => {
+    const orgId = `org_${randomUUID()}`;
+    const userId = `user_${randomUUID()}`;
+    const membership = await store.set(
+      seedOrgMembership$,
+      { orgId, userId, seedOrgCache: false },
+      context.signal,
+    );
+    memberships.push(membership);
+
+    const botId = newTelegramBotId();
+    const builder = makeTelegramFixtureBuilder(orgId);
+    const installation = await store.set(
+      seedTelegramInstallation$,
+      { orgId, ownerUserId: userId, telegramBotId: botId },
+      context.signal,
+    );
+    builder.composeIds.push(installation.composeId);
+    builder.telegramBotIds.push(installation.telegramBotId);
+    fixtures.push(freezeTelegramFixture(builder));
+
+    const fileBytes = Buffer.from("telegram avatar bytes");
+    context.mocks.telegram.getUserProfilePhotos.mockResolvedValue([
+      [
+        {
+          file_id: "small-avatar",
+          width: 64,
+          height: 64,
+        },
+        {
+          file_id: "large-avatar",
+          width: 320,
+          height: 320,
+          file_size: fileBytes.length,
+        },
+      ],
+    ]);
+    context.mocks.telegram.getFile.mockResolvedValue({
+      file_id: "large-avatar",
+      file_size: fileBytes.length,
+      file_path: "photos/avatar.jpg",
+    });
+    server.use(
+      http.get(
+        "https://api.telegram.org/file/bottest-bot-token/photos/avatar.jpg",
+        () => {
+          return new HttpResponse(fileBytes, {
+            status: 200,
+            headers: {
+              "content-type": "image/jpeg",
+              "content-length": String(fileBytes.length),
+            },
+          });
+        },
+      ),
+    );
+
+    const app = createApp({ signal: context.signal });
+    const response = await app.request(
+      requestPathFromSignedUrl(buildTelegramBotAvatarUrl(botId)),
+    );
+
+    expect(response.status).toBe(200);
+    expect(context.mocks.telegram.getUserProfilePhotos).toHaveBeenCalledWith(
+      "test-bot-token",
+      Number(botId),
+      1,
+    );
+    expect(response.headers.get("content-type")).toBe("image/jpeg");
+    expect(response.headers.get("cache-control")).toBe("private, max-age=300");
+    const receivedBytes = Buffer.from(await response.arrayBuffer());
+    expect(receivedBytes.equals(fileBytes)).toBeTruthy();
+  });
+
+  it("returns fallback svg when Telegram has no avatar", async () => {
+    const orgId = `org_${randomUUID()}`;
+    const userId = `user_${randomUUID()}`;
+    const membership = await store.set(
+      seedOrgMembership$,
+      { orgId, userId, seedOrgCache: false },
+      context.signal,
+    );
+    memberships.push(membership);
+
+    const botId = "tg-bot-no-avatar";
+    const builder = makeTelegramFixtureBuilder(orgId);
+    const installation = await store.set(
+      seedTelegramInstallation$,
+      { orgId, ownerUserId: userId, telegramBotId: botId },
+      context.signal,
+    );
+    builder.composeIds.push(installation.composeId);
+    builder.telegramBotIds.push(installation.telegramBotId);
+    fixtures.push(freezeTelegramFixture(builder));
+    const token = mintZeroToken({
+      userId,
+      orgId,
+      capabilities: ["telegram:read"],
+    });
+    context.mocks.telegram.getUserProfilePhotos.mockResolvedValue([]);
+
+    const app = createApp({ signal: context.signal });
+    const response = await app.request(
+      `/api/integrations/telegram/${botId}/avatar`,
+      { headers: { authorization: `Bearer ${token}` } },
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toContain("image/svg+xml");
+    await expect(response.text()).resolves.toContain(
+      "Telegram bot avatar fallback",
+    );
+  });
+});
+
+describe("GET /api/integrations/telegram/auth-callback", () => {
+  it("returns the Telegram auth bridge html", async () => {
+    const app = createApp({ signal: context.signal });
+
+    const response = await app.request(
+      "/api/integrations/telegram/auth-callback",
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toContain("text/html");
+    await expect(response.text()).resolves.toContain("telegram-auth");
   });
 });
 

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-telegram-data.service.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-telegram-data.service.test.ts
@@ -169,7 +169,7 @@ describe("zeroTelegramBots service", () => {
       tokenStatus: "unknown",
       official: { configured: false },
     });
-    expect(bots[0]?.avatarUrl).toBe("");
+    expect(bots[0]?.avatarUrl).toBeNull();
   });
 
   it("uses the user's selected compose preference for the official bot agent", async () => {

--- a/turbo/apps/api/src/signals/routes/zero-integrations-telegram.ts
+++ b/turbo/apps/api/src/signals/routes/zero-integrations-telegram.ts
@@ -1,21 +1,35 @@
-import { computed } from "ccstate";
+import { command, computed } from "ccstate";
 import { initContract } from "@ts-rest/core";
 import { z } from "zod";
 import { integrationsTelegramBotListContract } from "@vm0/api-contracts/contracts/integrations";
+import { zeroIntegrationsTelegramContract } from "@vm0/api-contracts/contracts/zero-integrations-telegram";
 import { authHeadersSchema } from "@vm0/api-contracts/contracts/base";
 import { apiErrorSchema } from "@vm0/api-contracts/contracts/errors";
 
-import { organizationAuthContext$ } from "../auth/auth-context";
+import {
+  organizationAuthContext$,
+  requiredAuthContext$,
+} from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
-import { queryOf } from "../context/request";
+import { pathParamsOf, queryOf } from "../context/request";
 import { integrationsTelegramBotIdRoutes } from "./integrations-telegram-bot-id";
 import { integrationsTelegramLinkRoutes } from "./integrations-telegram-link";
-import { buildFileDownloadUrl, getFile } from "../external/telegram-client";
+import {
+  buildFileDownloadUrl,
+  getFile,
+  getUserProfilePhotos,
+  type TelegramUserProfilePhoto,
+} from "../external/telegram-client";
+import { verifyTelegramBotAvatarUrlSignature } from "../external/telegram-avatar";
 import {
   getOfficialTelegramBotConfig,
   isOfficialTelegramBotId,
 } from "../external/telegram-official";
 import {
+  telegramIntegrationBots,
+  telegramIntegrationBotStatus,
+  telegramIntegrationLinkStatus,
+  telegramBotToken,
   zeroTelegramBots,
   zeroTelegramInstallation,
 } from "../services/zero-telegram-data.service";
@@ -61,6 +75,23 @@ function errorResponse(
 }
 
 const MAX_FILE_SIZE_BYTES = 100 * 1024 * 1024;
+const MAX_AVATAR_SIZE_BYTES = 10 * 1024 * 1024;
+const FALLBACK_AVATAR_SVG = [
+  `<svg width="40" height="40" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Telegram bot avatar fallback">`,
+  `<circle cx="20" cy="20" r="20" fill="#2AABEE" fill-opacity="0.1"/>`,
+  `<svg x="10" y="10" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#2AABEE" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">`,
+  `<path d="M6 6a2 2 0 0 1 2 -2h8a2 2 0 0 1 2 2v4a2 2 0 0 1 -2 2h-8a2 2 0 0 1 -2 -2l0 -4"/>`,
+  `<path d="M12 2v2"/>`,
+  `<path d="M9 12v9"/>`,
+  `<path d="M15 12v9"/>`,
+  `<path d="M5 16l4 -2"/>`,
+  `<path d="M15 14l4 2"/>`,
+  `<path d="M9 18h6"/>`,
+  `<path d="M10 8v.01"/>`,
+  `<path d="M14 8v.01"/>`,
+  `</svg>`,
+  `</svg>`,
+].join("");
 
 function parseContentLength(value: string | null): number | undefined {
   if (!value) {
@@ -81,6 +112,49 @@ function payloadTooLargeResponse(): Response {
   );
 }
 
+function avatarPayloadTooLargeResponse(): Response {
+  return errorResponse(
+    413,
+    `Avatar exceeds maximum size of ${MAX_AVATAR_SIZE_BYTES} bytes`,
+    "PAYLOAD_TOO_LARGE",
+  );
+}
+
+function fallbackAvatarResponse(): Response {
+  const headers = new Headers();
+  headers.set("Content-Type", "image/svg+xml; charset=utf-8");
+  headers.set("Cache-Control", "private, max-age=300");
+  return new Response(FALLBACK_AVATAR_SVG, { status: 200, headers });
+}
+
+function selectLargestProfilePhoto(
+  photos: readonly TelegramUserProfilePhoto[],
+): TelegramUserProfilePhoto | null {
+  if (photos.length === 0) {
+    return null;
+  }
+
+  return photos.reduce((largest, photo) => {
+    return photo.width * photo.height > largest.width * largest.height
+      ? photo
+      : largest;
+  }, photos[0]!);
+}
+
+function telegramProfileUserId(botId: string): string | number {
+  const numericBotId = Number(botId);
+  if (Number.isSafeInteger(numericBotId) && String(numericBotId) === botId) {
+    return numericBotId;
+  }
+  return botId;
+}
+
+const telegramReadAuth = {
+  requireOrganization: true,
+  missingOrganizationStatus: 401,
+  requiredCapability: "telegram:read",
+} as const;
+
 const getTelegramBotsInner$ = computed(async (get) => {
   const auth = get(organizationAuthContext$);
   const bots = await get(
@@ -91,6 +165,52 @@ const getTelegramBotsInner$ = computed(async (get) => {
     status: 200 as const,
     body: { bots: [...bots] },
   };
+});
+
+const getIntegrationTelegramListInner$ = computed(async (get) => {
+  const auth = get(organizationAuthContext$);
+  const bots = await get(
+    telegramIntegrationBots({ orgId: auth.orgId, userId: auth.userId }),
+  );
+
+  return {
+    status: 200 as const,
+    body: { bots: [...bots] },
+  };
+});
+
+const getIntegrationTelegramBotInner$ = computed(async (get) => {
+  const auth = get(organizationAuthContext$);
+  const pathParams = get(pathParamsOf(zeroIntegrationsTelegramContract.getBot));
+  const status = await get(
+    telegramIntegrationBotStatus({
+      orgId: auth.orgId,
+      userId: auth.userId,
+      botId: pathParams.botId,
+    }),
+  );
+
+  if (!status) {
+    return {
+      status: 404 as const,
+      body: { error: { message: "Telegram bot not found", code: "NOT_FOUND" } },
+    };
+  }
+
+  return { status: 200 as const, body: status };
+});
+
+const getIntegrationTelegramLinkStatusInner$ = computed(async (get) => {
+  const auth = get(organizationAuthContext$);
+  const query = get(queryOf(zeroIntegrationsTelegramContract.getLinkStatus));
+  return await get(
+    telegramIntegrationLinkStatus({
+      orgId: auth.orgId,
+      userId: auth.userId,
+      botId: query.botId,
+      origin: query.origin,
+    }),
+  );
 });
 
 const getTelegramDownloadFileInner$ = computed(async (get) => {
@@ -174,15 +294,206 @@ const getTelegramDownloadFileInner$ = computed(async (get) => {
     });
 });
 
-const telegramReadAuth = {
-  requireOrganization: true,
-  missingOrganizationStatus: 401,
-  requiredCapability: "telegram:read",
-} as const;
+const getIntegrationTelegramAvatar$ = command(
+  async ({ get, set }, signal: AbortSignal): Promise<Response> => {
+    const pathParams = get(
+      pathParamsOf(zeroIntegrationsTelegramContract.avatar),
+    );
+    const query = get(queryOf(zeroIntegrationsTelegramContract.avatar));
+
+    let botToken: string | null = null;
+    let profileUserId: string | number = telegramProfileUserId(
+      pathParams.botId,
+    );
+
+    const hasValidSignature = verifyTelegramBotAvatarUrlSignature({
+      botId: pathParams.botId,
+      expiresAt: query.exp,
+      signature: query.sig,
+    });
+
+    if (hasValidSignature) {
+      if (isOfficialTelegramBotId(pathParams.botId)) {
+        const config = getOfficialTelegramBotConfig();
+        if (config.botToken && config.botId) {
+          botToken = config.botToken;
+          profileUserId = telegramProfileUserId(config.botId);
+        }
+      } else {
+        const installation = await get(
+          telegramBotToken({ botId: pathParams.botId }),
+        );
+        signal.throwIfAborted();
+        botToken = installation?.botToken ?? null;
+      }
+    } else {
+      const auth = await set(requiredAuthContext$, telegramReadAuth, signal);
+      signal.throwIfAborted();
+      if ("status" in auth) {
+        return new Response(JSON.stringify(auth.body), {
+          status: auth.status,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      if (isOfficialTelegramBotId(pathParams.botId)) {
+        const config = getOfficialTelegramBotConfig();
+        if (config.botToken && config.botId) {
+          botToken = config.botToken;
+          profileUserId = telegramProfileUserId(config.botId);
+        }
+      } else {
+        const installation =
+          auth.orgId === undefined
+            ? null
+            : await get(
+                telegramBotToken({
+                  botId: pathParams.botId,
+                  orgId: auth.orgId,
+                }),
+              );
+        signal.throwIfAborted();
+        botToken = installation?.botToken ?? null;
+      }
+    }
+
+    if (!botToken) {
+      return errorResponse(404, "Telegram bot not found", "NOT_FOUND");
+    }
+
+    return getUserProfilePhotos(botToken, profileUserId, 1)
+      .then(async (photos) => {
+        const photo = selectLargestProfilePhoto(photos[0] ?? []);
+        if (!photo) {
+          return fallbackAvatarResponse();
+        }
+
+        if (photo.file_size && photo.file_size > MAX_AVATAR_SIZE_BYTES) {
+          return avatarPayloadTooLargeResponse();
+        }
+
+        const file = await getFile(botToken, photo.file_id);
+        signal.throwIfAborted();
+        if (!file.file_path) {
+          return fallbackAvatarResponse();
+        }
+        if (file.file_size && file.file_size > MAX_AVATAR_SIZE_BYTES) {
+          return avatarPayloadTooLargeResponse();
+        }
+
+        const downloadResponse = await fetch(
+          buildFileDownloadUrl(botToken, file.file_path),
+          { signal },
+        );
+        signal.throwIfAborted();
+        if (!downloadResponse.ok) {
+          return errorResponse(
+            502,
+            `Failed to download avatar from Telegram: ${downloadResponse.status}`,
+            "BAD_GATEWAY",
+          );
+        }
+
+        const responseContentType =
+          downloadResponse.headers.get("content-type") ?? "";
+        if (responseContentType.includes("text/html")) {
+          return errorResponse(
+            502,
+            "Telegram returned an unexpected response",
+            "BAD_GATEWAY",
+          );
+        }
+
+        const contentLength = downloadResponse.headers.get("content-length");
+        const contentLengthBytes = parseContentLength(contentLength);
+        if (
+          contentLengthBytes !== undefined &&
+          contentLengthBytes > MAX_AVATAR_SIZE_BYTES
+        ) {
+          return avatarPayloadTooLargeResponse();
+        }
+
+        const fileName = file.file_path.split("/").pop() ?? photo.file_id;
+        const mimetype = responseContentType || inferMimetype(fileName);
+        const headers = new Headers();
+        headers.set("Content-Type", mimetype);
+        headers.set("Cache-Control", "private, max-age=300");
+        if (contentLength) {
+          headers.set("Content-Length", contentLength);
+        }
+
+        return new Response(downloadResponse.body, {
+          status: 200,
+          headers,
+        });
+      })
+      .catch(() => {
+        return errorResponse(
+          502,
+          "Failed to load Telegram bot avatar",
+          "BAD_GATEWAY",
+        );
+      });
+  },
+);
+
+const getIntegrationTelegramAuthCallback$ = computed((): Response => {
+  const html = `<!DOCTYPE html>
+<html><head><title>Telegram Auth</title></head>
+<body><script>
+(function() {
+  var params = new URLSearchParams(window.location.search);
+  if (!params.get("id")) {
+    params = new URLSearchParams(window.location.hash.replace(/^#/, ""));
+  }
+  var targetOrigin =
+    new URLSearchParams(window.location.search).get("targetOrigin") ||
+    window.location.origin;
+  var data = {};
+  ["id","first_name","last_name","username","photo_url","auth_date","hash"].forEach(function(k) {
+    var v = params.get(k);
+    if (v !== null) data[k] = v;
+  });
+  if (window.opener && data.id) {
+    window.opener.postMessage(
+      { type: "telegram-auth", data: data },
+      targetOrigin
+    );
+  }
+  window.close();
+})();
+</script></body></html>`;
+
+  return new Response(html, {
+    headers: { "Content-Type": "text/html; charset=utf-8" },
+  });
+});
 
 export const zeroIntegrationsTelegramRoutes: readonly RouteEntry[] = [
   ...integrationsTelegramLinkRoutes,
   ...integrationsTelegramBotIdRoutes,
+  {
+    route: zeroIntegrationsTelegramContract.list,
+    handler: authRoute(telegramReadAuth, getIntegrationTelegramListInner$),
+  },
+  {
+    route: zeroIntegrationsTelegramContract.getLinkStatus,
+    handler: authRoute(
+      telegramReadAuth,
+      getIntegrationTelegramLinkStatusInner$,
+    ),
+  },
+  {
+    route: zeroIntegrationsTelegramContract.authCallback,
+    handler: getIntegrationTelegramAuthCallback$,
+  },
+  {
+    route: zeroIntegrationsTelegramContract.avatar,
+    handler: getIntegrationTelegramAvatar$,
+  },
+  {
+    route: zeroIntegrationsTelegramContract.getBot,
+    handler: authRoute(telegramReadAuth, getIntegrationTelegramBotInner$),
+  },
   {
     route: integrationsTelegramBotListContract.listBots,
     handler: authRoute(telegramReadAuth, getTelegramBotsInner$),

--- a/turbo/apps/api/src/signals/services/zero-telegram-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-telegram-data.service.ts
@@ -1,8 +1,19 @@
 import { computed, type Computed } from "ccstate";
-import { agentComposes } from "@vm0/db/schema/agent-compose";
+import type {
+  TelegramBot,
+  TelegramBotStatus,
+  TelegramLinkStatusResponse,
+} from "@vm0/api-contracts/contracts/zero-integrations-telegram";
+import { getConnectorProvidedSecretNames } from "@vm0/connectors/connector-utils";
+import { extractAndGroupVariables } from "@vm0/core/variable-expander";
+import {
+  agentComposes,
+  agentComposeVersions,
+} from "@vm0/db/schema/agent-compose";
 import { orgMetadata } from "@vm0/db/schema/org-metadata";
 import { telegramInstallations } from "@vm0/db/schema/telegram-installation";
 import { telegramOfficialUserLinks } from "@vm0/db/schema/telegram-official-user-link";
+import { telegramUserLinks } from "@vm0/db/schema/telegram-user-link";
 import { telegramUserAgentPreferences } from "@vm0/db/schema/telegram-user-agent-preference";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
 import { and, desc, eq } from "drizzle-orm";
@@ -10,28 +21,19 @@ import { and, desc, eq } from "drizzle-orm";
 import { env } from "../../lib/env";
 import { db$ } from "../external/db";
 import { buildTelegramBotAvatarUrl } from "../external/telegram-avatar";
-import { getMe } from "../external/telegram-client";
+import { checkTelegramDomain } from "../external/telegram-domain";
+import { getMe, isTelegramApiError } from "../external/telegram-client";
 import {
   getOfficialTelegramBotConfig,
   OFFICIAL_TELEGRAM_BOT_ID,
 } from "../external/telegram-official";
+import { safeAsync, safeUrlParse } from "../utils";
 import { decryptSecretValue } from "./crypto.utils";
+import { zeroConnectorList } from "./zero-connector-data.service";
+import { userSecrets, userVariables } from "./zero-user-data.service";
 
-interface TelegramBotListItem {
-  readonly id: string;
-  readonly kind?: "custom" | "official";
-  readonly username: string | null;
-  readonly avatarUrl: string;
-  readonly agent: { readonly id: string; readonly name: string } | null;
-  readonly isOwner: boolean;
-  readonly isConnected: boolean;
-  readonly tokenStatus: "valid" | "invalid" | "unknown";
-  readonly official?: {
-    readonly configured: boolean;
-    readonly usesDefaultAgent: boolean;
-    readonly linkedTelegramUserId: string | null;
-  };
-}
+type TelegramBotListItem = TelegramBot;
+type TelegramInstallationRow = typeof telegramInstallations.$inferSelect;
 
 function officialUserLink(args: {
   readonly orgId: string;
@@ -58,6 +60,7 @@ function officialUserLink(args: {
 interface TelegramComposeRow {
   readonly id: string;
   readonly name: string;
+  readonly headVersionId: string | null;
 }
 
 function getOrgCompose(args: {
@@ -67,7 +70,11 @@ function getOrgCompose(args: {
   return computed(async (get) => {
     const db = get(db$);
     const [row] = await db
-      .select({ id: agentComposes.id, name: agentComposes.name })
+      .select({
+        id: agentComposes.id,
+        name: agentComposes.name,
+        headVersionId: agentComposes.headVersionId,
+      })
       .from(agentComposes)
       .where(
         and(
@@ -165,7 +172,7 @@ function buildOfficialTelegramBot(args: {
       username: config.botUsername,
       avatarUrl: hasAvatar
         ? buildTelegramBotAvatarUrl(OFFICIAL_TELEGRAM_BOT_ID)
-        : "",
+        : null,
       agent: official.compose
         ? { id: official.compose.id, name: official.compose.name }
         : null,
@@ -231,6 +238,374 @@ export function zeroTelegramBots(args: {
   });
 }
 
+function telegramUserLink(args: {
+  readonly botId: string;
+  readonly userId: string;
+}): Computed<Promise<{ readonly telegramUserId: string } | null>> {
+  return computed(async (get) => {
+    const db = get(db$);
+    const [row] = await db
+      .select({ telegramUserId: telegramUserLinks.telegramUserId })
+      .from(telegramUserLinks)
+      .where(
+        and(
+          eq(telegramUserLinks.installationId, args.botId),
+          eq(telegramUserLinks.vm0UserId, args.userId),
+        ),
+      )
+      .limit(1);
+    return row ?? null;
+  });
+}
+
+function telegramEnvironment(args: {
+  readonly compose: TelegramComposeRow | null;
+  readonly orgId: string;
+  readonly userId: string;
+}): Computed<Promise<TelegramBotStatus["environment"]>> {
+  return computed(async (get) => {
+    let requiredSecrets: string[] = [];
+    let requiredVars: string[] = [];
+
+    if (args.compose?.headVersionId) {
+      const db = get(db$);
+      const [version] = await db
+        .select({ content: agentComposeVersions.content })
+        .from(agentComposeVersions)
+        .where(eq(agentComposeVersions.id, args.compose.headVersionId))
+        .limit(1);
+
+      if (version) {
+        const grouped = extractAndGroupVariables(version.content);
+        requiredSecrets = grouped.secrets.map((secret) => {
+          return secret.name;
+        });
+        requiredVars = grouped.vars.map((variable) => {
+          return variable.name;
+        });
+      }
+    }
+
+    const [secretList, variableList, connectorList] = await Promise.all([
+      get(userSecrets({ orgId: args.orgId, userId: args.userId })),
+      get(userVariables({ orgId: args.orgId, userId: args.userId })),
+      get(zeroConnectorList({ orgId: args.orgId, userId: args.userId })),
+    ]);
+    const connectorProvided = getConnectorProvidedSecretNames(
+      connectorList.connectors.map((connector) => {
+        return connector.type;
+      }),
+    );
+    const existingSecretNames = new Set([
+      ...secretList.secrets.map((secret) => {
+        return secret.name;
+      }),
+      ...connectorProvided,
+    ]);
+    const existingVarNames = new Set(
+      variableList.variables.map((variable) => {
+        return variable.name;
+      }),
+    );
+
+    return {
+      requiredSecrets,
+      requiredVars,
+      missingSecrets: requiredSecrets.filter((name) => {
+        return !existingSecretNames.has(name);
+      }),
+      missingVars: requiredVars.filter((name) => {
+        return !existingVarNames.has(name);
+      }),
+    };
+  });
+}
+
+function customTelegramBot(args: {
+  readonly installation: TelegramInstallationRow;
+  readonly userId: string;
+}): Computed<Promise<TelegramBot>> {
+  return computed(async (get) => {
+    const [compose, userLink, tokenStatus] = await Promise.all([
+      get(
+        getOrgCompose({
+          composeId: args.installation.defaultComposeId,
+          orgId: args.installation.orgId,
+        }),
+      ),
+      get(
+        telegramUserLink({
+          botId: args.installation.telegramBotId,
+          userId: args.userId,
+        }),
+      ),
+      resolveIntegrationTokenStatus(args.installation),
+    ]);
+
+    return {
+      id: args.installation.telegramBotId,
+      username: args.installation.botUsername,
+      avatarUrl: buildTelegramBotAvatarUrl(args.installation.telegramBotId),
+      agent: compose ? { id: compose.id, name: compose.name } : null,
+      isOwner: args.installation.ownerUserId === args.userId,
+      isConnected: userLink !== null,
+      tokenStatus,
+    };
+  });
+}
+
+function customTelegramBotStatus(args: {
+  readonly installation: TelegramInstallationRow;
+  readonly userId: string;
+}): Computed<Promise<TelegramBotStatus>> {
+  return computed(async (get) => {
+    const compose = await get(
+      getOrgCompose({
+        composeId: args.installation.defaultComposeId,
+        orgId: args.installation.orgId,
+      }),
+    );
+    const [bot, environment, domainConfigured] = await Promise.all([
+      get(customTelegramBot(args)),
+      get(
+        telegramEnvironment({
+          compose,
+          orgId: args.installation.orgId,
+          userId: args.userId,
+        }),
+      ),
+      checkTelegramDomain(args.installation.telegramBotId, env("VM0_WEB_URL")),
+    ]);
+
+    return { ...bot, domainConfigured, environment };
+  });
+}
+
+function officialTelegramBotStatus(args: {
+  readonly orgId: string;
+  readonly userId: string;
+}): Computed<Promise<TelegramBotStatus>> {
+  return computed(async (get) => {
+    const config = getOfficialTelegramBotConfig();
+    const official = await get(officialCompose(args));
+    const [bot, environment, domainConfigured] = await Promise.all([
+      get(buildOfficialTelegramBot(args)),
+      get(telegramEnvironment({ compose: official.compose, ...args })),
+      config.botId
+        ? checkTelegramDomain(config.botId, env("VM0_WEB_URL"))
+        : Promise.resolve(false),
+    ]);
+
+    return { ...bot, domainConfigured, environment };
+  });
+}
+
+export function telegramIntegrationBots(args: {
+  readonly orgId: string;
+  readonly userId: string;
+}): Computed<Promise<readonly TelegramBot[]>> {
+  return computed(async (get): Promise<readonly TelegramBot[]> => {
+    const db = get(db$);
+    const installations = await db
+      .select()
+      .from(telegramInstallations)
+      .where(eq(telegramInstallations.orgId, args.orgId))
+      .orderBy(
+        desc(telegramInstallations.createdAt),
+        desc(telegramInstallations.telegramBotId),
+      );
+
+    const customBots = await Promise.all(
+      installations.map((installation) => {
+        return get(customTelegramBot({ installation, userId: args.userId }));
+      }),
+    );
+    const official = await get(buildOfficialTelegramBot(args));
+    return [official, ...customBots];
+  });
+}
+
+export function telegramIntegrationBotStatus(args: {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly botId: string;
+}): Computed<Promise<TelegramBotStatus | null>> {
+  return computed(async (get) => {
+    if (args.botId === OFFICIAL_TELEGRAM_BOT_ID) {
+      return await get(officialTelegramBotStatus(args));
+    }
+
+    const db = get(db$);
+    const [installation] = await db
+      .select()
+      .from(telegramInstallations)
+      .where(eq(telegramInstallations.telegramBotId, args.botId))
+      .limit(1);
+
+    if (!installation || installation.orgId !== args.orgId) {
+      return null;
+    }
+
+    return await get(
+      customTelegramBotStatus({ installation, userId: args.userId }),
+    );
+  });
+}
+
+type TelegramLinkStatusResult =
+  | { readonly status: 200; readonly body: TelegramLinkStatusResponse }
+  | {
+      readonly status: 403;
+      readonly body: {
+        readonly error: { readonly message: string; readonly code: string };
+      };
+    };
+
+function resolveTelegramLoginOrigin(originParam: string | undefined): string {
+  if (!originParam) {
+    return env("VM0_WEB_URL");
+  }
+
+  const originUrl = safeUrlParse(originParam);
+  if (
+    originUrl &&
+    (originUrl.protocol === "http:" || originUrl.protocol === "https:")
+  ) {
+    return originUrl.origin;
+  }
+
+  return env("VM0_WEB_URL");
+}
+
+function orgMismatchResult(): TelegramLinkStatusResult {
+  return {
+    status: 403,
+    body: {
+      error: {
+        message:
+          "This Telegram bot belongs to a different organization. Switch to the bot's organization to connect.",
+        code: "FORBIDDEN",
+      },
+    },
+  };
+}
+
+export function telegramIntegrationLinkStatus(args: {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly botId?: string;
+  readonly origin?: string;
+}): Computed<Promise<TelegramLinkStatusResult>> {
+  return computed(async (get): Promise<TelegramLinkStatusResult> => {
+    const db = get(db$);
+    const telegramLoginOrigin = resolveTelegramLoginOrigin(args.origin);
+
+    if (args.botId === OFFICIAL_TELEGRAM_BOT_ID) {
+      const userLink = await get(officialUserLink(args));
+      const config = getOfficialTelegramBotConfig();
+      if (userLink) {
+        return {
+          status: 200,
+          body: {
+            linked: true,
+            telegramUserId: userLink.telegramUserId,
+            botUsername: config.botUsername ?? "Zero",
+          },
+        };
+      }
+
+      const domainConfigured = config.botId
+        ? await checkTelegramDomain(config.botId, telegramLoginOrigin)
+        : false;
+      return {
+        status: 200,
+        body: {
+          linked: false,
+          installation: {
+            id: OFFICIAL_TELEGRAM_BOT_ID,
+            botUsername: config.botUsername ?? "Zero",
+            ...(config.botId ? { loginBotId: config.botId } : {}),
+            domainConfigured,
+          },
+        },
+      };
+    }
+
+    const [userLink] = await db
+      .select({
+        telegramUserId: telegramUserLinks.telegramUserId,
+        botUsername: telegramInstallations.botUsername,
+      })
+      .from(telegramUserLinks)
+      .innerJoin(
+        telegramInstallations,
+        eq(
+          telegramUserLinks.installationId,
+          telegramInstallations.telegramBotId,
+        ),
+      )
+      .where(
+        and(
+          eq(telegramUserLinks.vm0UserId, args.userId),
+          eq(telegramInstallations.orgId, args.orgId),
+          args.botId
+            ? eq(telegramUserLinks.installationId, args.botId)
+            : undefined,
+        ),
+      )
+      .orderBy(desc(telegramUserLinks.createdAt))
+      .limit(1);
+
+    if (userLink) {
+      return {
+        status: 200,
+        body: {
+          linked: true,
+          telegramUserId: userLink.telegramUserId,
+          botUsername: userLink.botUsername ?? undefined,
+        },
+      };
+    }
+
+    if (args.botId) {
+      const [installation] = await db
+        .select({
+          telegramBotId: telegramInstallations.telegramBotId,
+          botUsername: telegramInstallations.botUsername,
+          orgId: telegramInstallations.orgId,
+        })
+        .from(telegramInstallations)
+        .where(eq(telegramInstallations.telegramBotId, args.botId))
+        .limit(1);
+
+      if (installation) {
+        if (installation.orgId !== args.orgId) {
+          return orgMismatchResult();
+        }
+
+        const domainConfigured = await checkTelegramDomain(
+          installation.telegramBotId,
+          telegramLoginOrigin,
+        );
+        return {
+          status: 200,
+          body: {
+            linked: false,
+            installation: {
+              id: installation.telegramBotId,
+              botUsername: installation.botUsername ?? "Telegram bot",
+              loginBotId: installation.telegramBotId,
+              domainConfigured,
+            },
+          },
+        };
+      }
+    }
+
+    return { status: 200, body: { linked: false } };
+  });
+}
+
 export function zeroTelegramInstallation(args: {
   readonly orgId: string;
   readonly botId: string;
@@ -268,6 +643,42 @@ export function zeroTelegramInstallation(args: {
   });
 }
 
+export function telegramBotToken(args: {
+  readonly botId: string;
+  readonly orgId?: string;
+}): Computed<
+  Promise<{
+    readonly botToken: string;
+    readonly botUsername: string | null;
+  } | null>
+> {
+  return computed(async (get) => {
+    const db = get(db$);
+    const [row] = await db
+      .select({
+        encryptedBotToken: telegramInstallations.encryptedBotToken,
+        botUsername: telegramInstallations.botUsername,
+      })
+      .from(telegramInstallations)
+      .where(
+        and(
+          eq(telegramInstallations.telegramBotId, args.botId),
+          args.orgId ? eq(telegramInstallations.orgId, args.orgId) : undefined,
+        ),
+      )
+      .limit(1);
+
+    if (!row) {
+      return null;
+    }
+
+    return {
+      botToken: decryptSecretValue(row.encryptedBotToken),
+      botUsername: row.botUsername ?? null,
+    };
+  });
+}
+
 function resolveTokenStatus(
   encryptedBotToken: string,
 ): Promise<"valid" | "invalid" | "unknown"> {
@@ -279,4 +690,36 @@ function resolveTokenStatus(
     .catch(() => {
       return "unknown" as const;
     });
+}
+
+function isInvalidTelegramTokenError(error: unknown): boolean {
+  if (!isTelegramApiError(error)) {
+    return false;
+  }
+
+  return (
+    error.status === 401 ||
+    /unauthorized|not found/i.test(error.description ?? "")
+  );
+}
+
+async function resolveIntegrationTokenStatus(
+  installation: TelegramInstallationRow,
+): Promise<TelegramBot["tokenStatus"]> {
+  const token = decryptSecretValue(installation.encryptedBotToken);
+  const result = await safeAsync(() => {
+    return getMe(token);
+  });
+
+  if ("error" in result) {
+    if (isInvalidTelegramTokenError(result.error)) {
+      return "invalid";
+    }
+    return "unknown";
+  }
+
+  if (String(result.ok.id) !== installation.telegramBotId) {
+    return "invalid";
+  }
+  return "valid";
 }

--- a/turbo/packages/api-contracts/src/contracts/zero-integrations-telegram.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-integrations-telegram.ts
@@ -197,8 +197,41 @@ export const zeroIntegrationsTelegramContract = c.router({
     responses: {
       200: telegramLinkStatusResponseSchema,
       401: apiErrorSchema,
+      403: apiErrorSchema,
     },
     summary: "Check if the authenticated user is linked to a Telegram bot",
+  },
+  avatar: {
+    method: "GET",
+    path: "/api/integrations/telegram/:botId/avatar",
+    headers: authHeadersSchema,
+    pathParams: z.object({ botId: z.string().min(1) }),
+    query: z.object({
+      exp: z.string().optional(),
+      sig: z.string().optional(),
+    }),
+    responses: {
+      200: c.otherResponse({
+        contentType: "application/octet-stream",
+        body: z.unknown(),
+      }),
+      401: apiErrorSchema,
+      404: apiErrorSchema,
+      413: apiErrorSchema,
+      502: apiErrorSchema,
+    },
+    summary: "Proxy a Telegram bot avatar",
+  },
+  authCallback: {
+    method: "GET",
+    path: "/api/integrations/telegram/auth-callback",
+    responses: {
+      200: c.otherResponse({
+        contentType: "text/html",
+        body: z.unknown(),
+      }),
+    },
+    summary: "Return the Telegram auth callback bridge page",
   },
   link: {
     method: "POST",


### PR DESCRIPTION
## Summary
- Migrate Telegram integration GET routes onto the API backend for list, detail, link status, avatar proxy, and auth callback
- Extend the Telegram integration contract for avatar/auth-callback and link-status 403 responses
- Add API integration coverage for migrated GET behavior, signed avatar access, and auth callback HTML

Closes #12825

## Validation
- pnpm -F api exec vitest run src/signals/routes/__tests__/zero-integrations-telegram.test.ts
- pnpm -F api lint
- pnpm exec prettier --check packages/api-contracts/src/contracts/zero-integrations-telegram.ts apps/api/src/signals/external/telegram-avatar.ts apps/api/src/signals/external/telegram-client.ts apps/api/src/signals/external/telegram-domain.ts apps/api/src/signals/services/zero-telegram-data.service.ts apps/api/src/signals/routes/zero-integrations-telegram.ts apps/api/src/__tests__/mocks.ts apps/api/src/signals/routes/__tests__/zero-integrations-telegram.test.ts
- pnpm check-types
- pnpm knip --cache
- git diff --check