### PR TITLE
feat: add remote-agent run inspection commands

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-remote-agent-runs.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-remote-agent-runs.test.ts
@@ -1,0 +1,255 @@
+import { randomUUID } from "node:crypto";
+
+import type { RemoteAgentRunListResponse } from "@vm0/api-contracts/contracts/zero-remote-agent";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import { remoteAgentHosts, remoteAgentJobs } from "@vm0/db/schema/remote-agent";
+import { userFeatureSwitches } from "@vm0/db/schema/user-feature-switches";
+import { createStore } from "ccstate";
+import { eq } from "drizzle-orm";
+import { afterEach } from "vitest";
+
+import { createApp } from "../../../app-factory";
+import { testContext } from "../../../__tests__/test-helpers";
+import { nowDate } from "../../../lib/time";
+import { writeDb$ } from "../../external/db";
+import { ROUTES } from "../../route";
+import {
+  deleteOrgMembership$,
+  seedOrgMembership$,
+  type OrgMembershipFixture,
+} from "./helpers/zero-org-membership";
+import { createZeroRouteMocks } from "./helpers/zero-route-test";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+
+async function enableRemoteAgent(orgId: string, userId: string): Promise<void> {
+  const writeDb = store.set(writeDb$);
+  await writeDb.insert(userFeatureSwitches).values({
+    orgId,
+    userId,
+    switches: { [FeatureSwitchKey.RemoteAgent]: true },
+  });
+}
+
+async function seedRemoteAgentHost(args: {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly displayName: string;
+}): Promise<string> {
+  const writeDb = store.set(writeDb$);
+  const now = nowDate();
+  const [host] = await writeDb
+    .insert(remoteAgentHosts)
+    .values({
+      orgId: args.orgId,
+      userId: args.userId,
+      displayName: args.displayName,
+      tokenHash: `token-${randomUUID()}`,
+      supportedBackends: ["codex"],
+      status: "online",
+      lastSeenAt: now,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .returning({ id: remoteAgentHosts.id });
+
+  if (!host) {
+    throw new Error("Failed to seed remote-agent host");
+  }
+  return host.id;
+}
+
+async function seedRemoteAgentJob(args: {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly hostId?: string;
+  readonly status: "queued" | "running" | "succeeded" | "failed";
+  readonly prompt: string;
+}): Promise<string> {
+  const writeDb = store.set(writeDb$);
+  const now = nowDate();
+  const [job] = await writeDb
+    .insert(remoteAgentJobs)
+    .values({
+      orgId: args.orgId,
+      userId: args.userId,
+      hostId: args.hostId,
+      backend: args.hostId ? "codex" : null,
+      prompt: args.prompt,
+      status: args.status,
+      output: args.status === "succeeded" ? "done" : null,
+      error: args.status === "failed" ? "failed" : null,
+      exitCode: args.status === "failed" ? 1 : null,
+      startedAt: args.status === "queued" ? null : now,
+      completedAt:
+        args.status === "succeeded" || args.status === "failed" ? now : null,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .returning({ id: remoteAgentJobs.id });
+
+  if (!job) {
+    throw new Error("Failed to seed remote-agent job");
+  }
+  return job.id;
+}
+
+async function cleanupFixture(fixture: OrgMembershipFixture): Promise<void> {
+  const writeDb = store.set(writeDb$);
+  await writeDb
+    .delete(remoteAgentJobs)
+    .where(eq(remoteAgentJobs.orgId, fixture.orgId));
+  await writeDb
+    .delete(remoteAgentHosts)
+    .where(eq(remoteAgentHosts.orgId, fixture.orgId));
+  await writeDb
+    .delete(userFeatureSwitches)
+    .where(eq(userFeatureSwitches.orgId, fixture.orgId));
+  await store.set(deleteOrgMembership$, fixture, context.signal);
+}
+
+async function listRuns(query = ""): Promise<{
+  readonly status: number;
+  readonly body: RemoteAgentRunListResponse;
+}> {
+  const app = createApp({ signal: context.signal, routes: ROUTES });
+  const response = await app.request(`/api/zero/remote-agent/runs${query}`, {
+    method: "GET",
+    headers: { authorization: "Bearer clerk-session" },
+  });
+  const body = (await response.json()) as RemoteAgentRunListResponse;
+  return { status: response.status, body };
+}
+
+describe("GET /api/zero/remote-agent/runs", () => {
+  const fixtures: OrgMembershipFixture[] = [];
+
+  afterEach(async () => {
+    while (fixtures.length > 0) {
+      const fixture = fixtures.pop();
+      if (fixture) {
+        await cleanupFixture(fixture);
+      }
+    }
+  });
+
+  it("returns remote-agent runs for the current user", async () => {
+    const fixture = await store.set(
+      seedOrgMembership$,
+      { orgId: `org_${randomUUID()}`, userId: `user_${randomUUID()}` },
+      context.signal,
+    );
+    fixtures.push(fixture);
+    await enableRemoteAgent(fixture.orgId, fixture.userId);
+    const hostId = await seedRemoteAgentHost({
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      displayName: "laptop",
+    });
+    const jobId = await seedRemoteAgentJob({
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      hostId,
+      status: "succeeded",
+      prompt: "summarize logs",
+    });
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await listRuns();
+
+    expect(response.status).toBe(200);
+    expect(response.body.runs).toHaveLength(1);
+    expect(response.body.runs[0]).toMatchObject({
+      id: jobId,
+      hostId,
+      hostName: "laptop",
+      backend: "codex",
+      prompt: "summarize logs",
+      status: "succeeded",
+    });
+    expect(response.body.runs[0]).not.toHaveProperty("output");
+    expect(response.body.runs[0]).not.toHaveProperty("error");
+  });
+
+  it("filters by status and current user", async () => {
+    const fixture = await store.set(
+      seedOrgMembership$,
+      { orgId: `org_${randomUUID()}`, userId: `user_${randomUUID()}` },
+      context.signal,
+    );
+    fixtures.push(fixture);
+    await enableRemoteAgent(fixture.orgId, fixture.userId);
+    const failedJobId = await seedRemoteAgentJob({
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      status: "failed",
+      prompt: "failed prompt",
+    });
+    await seedRemoteAgentJob({
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      status: "running",
+      prompt: "running prompt",
+    });
+    await seedRemoteAgentJob({
+      orgId: fixture.orgId,
+      userId: `user_${randomUUID()}`,
+      status: "failed",
+      prompt: "other user prompt",
+    });
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await listRuns("?status=failed");
+
+    expect(response.status).toBe(200);
+    expect(
+      response.body.runs.map((run) => {
+        return run.id;
+      }),
+    ).toStrictEqual([failedJobId]);
+  });
+
+  it("filters by host name", async () => {
+    const fixture = await store.set(
+      seedOrgMembership$,
+      { orgId: `org_${randomUUID()}`, userId: `user_${randomUUID()}` },
+      context.signal,
+    );
+    fixtures.push(fixture);
+    await enableRemoteAgent(fixture.orgId, fixture.userId);
+    const laptopId = await seedRemoteAgentHost({
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      displayName: "laptop",
+    });
+    const desktopId = await seedRemoteAgentHost({
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      displayName: "desktop",
+    });
+    const desktopJobId = await seedRemoteAgentJob({
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      hostId: desktopId,
+      status: "succeeded",
+      prompt: "desktop job",
+    });
+    await seedRemoteAgentJob({
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      hostId: laptopId,
+      status: "succeeded",
+      prompt: "laptop job",
+    });
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await listRuns("?hostName=desktop");
+
+    expect(response.status).toBe(200);
+    expect(response.body.runs).toHaveLength(1);
+    expect(response.body.runs[0]?.id).toBe(desktopJobId);
+    expect(response.body.runs[0]?.hostName).toBe("desktop");
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-remote-agent.ts
+++ b/turbo/apps/api/src/signals/routes/zero-remote-agent.ts
@@ -15,7 +15,7 @@ import { isFeatureEnabled } from "@vm0/core/feature-switch";
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
 import { authorization$ } from "../context/hono";
-import { bodyResultOf, pathParamsOf } from "../context/request";
+import { bodyResultOf, pathParamsOf, queryOf } from "../context/request";
 import { userFeatureSwitchOverrides } from "../services/feature-switches.service";
 import {
   claimRemoteAgentDeviceCode$,
@@ -27,6 +27,7 @@ import {
   deleteRemoteAgentHost$,
   getRemoteAgentJob$,
   heartbeatRemoteAgentHost$,
+  listRemoteAgentJobs$,
   listRemoteAgentHosts$,
   pollRemoteAgentDeviceCode$,
   startRemoteAgentHost$,
@@ -338,6 +339,41 @@ const hostsDeleteInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   return { status: 200 as const, body: { ok: true as const } };
 });
 
+const runListQuery$ = queryOf(zeroRemoteAgentRunContract.list);
+const runListInner$ = command(async ({ get, set }, signal: AbortSignal) => {
+  const auth = get(organizationAuthContext$);
+  const overrides = await get(
+    userFeatureSwitchOverrides(auth.orgId, auth.userId),
+  );
+  signal.throwIfAborted();
+  if (
+    !isRemoteAgentEnabled({
+      orgId: auth.orgId,
+      userId: auth.userId,
+      overrides,
+    })
+  ) {
+    return remoteAgentDisabled;
+  }
+
+  const query = get(runListQuery$);
+  const result = await set(
+    listRemoteAgentJobs$,
+    {
+      orgId: auth.orgId,
+      userId: auth.userId,
+      status: query.status,
+      hostId: query.hostId,
+      hostName: query.hostName,
+      limit: query.limit,
+    },
+    signal,
+  );
+  signal.throwIfAborted();
+
+  return { status: 200 as const, body: result };
+});
+
 const runCreateBody$ = bodyResultOf(zeroRemoteAgentRunContract.create);
 const runCreateInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   const auth = get(organizationAuthContext$);
@@ -563,6 +599,10 @@ export const zeroRemoteAgentRoutes: readonly RouteEntry[] = [
   {
     route: zeroRemoteAgentHostsContract.delete,
     handler: authRoute(remoteAgentAuthOptions, hostsDeleteInner$),
+  },
+  {
+    route: zeroRemoteAgentRunContract.list,
+    handler: authRoute(remoteAgentReadAuthOptions, runListInner$),
   },
   {
     route: zeroRemoteAgentRunContract.create,

--- a/turbo/apps/api/src/signals/services/zero-remote-agent.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-remote-agent.service.ts
@@ -1,6 +1,6 @@
 import { createHash, randomBytes, randomInt } from "crypto";
 import { command } from "ccstate";
-import { and, asc, desc, eq, inArray, isNull, or } from "drizzle-orm";
+import { and, asc, desc, eq, inArray, isNull, or, type SQL } from "drizzle-orm";
 import type { ConnectorResponse } from "@vm0/api-contracts/contracts/connector-schemas";
 import type {
   RemoteAgentBackend,
@@ -62,6 +62,8 @@ type PollRemoteAgentDeviceCodeResult =
   | { readonly status: "expired" }
   | { readonly status: "invalid" };
 
+type RemoteAgentJobStatus = "queued" | "running" | "succeeded" | "failed";
+
 function generateCode(length = 8): string {
   let code = "";
   for (let i = 0; i < length; i++) {
@@ -105,13 +107,31 @@ function serializeJob(row: typeof remoteAgentJobs.$inferSelect) {
     hostId: row.hostId,
     backend: row.backend as RemoteAgentBackend | null,
     prompt: row.prompt,
-    status: row.status as "queued" | "running" | "succeeded" | "failed",
+    status: row.status as RemoteAgentJobStatus,
     output: row.output,
     error: row.error,
     exitCode: row.exitCode,
     createdAt: row.createdAt.toISOString(),
     startedAt: row.startedAt?.toISOString() ?? null,
     completedAt: row.completedAt?.toISOString() ?? null,
+  };
+}
+
+function serializeJobListItem(row: {
+  readonly job: typeof remoteAgentJobs.$inferSelect;
+  readonly hostName: string | null;
+}) {
+  return {
+    id: row.job.id,
+    hostId: row.job.hostId,
+    hostName: row.hostName,
+    backend: row.job.backend as RemoteAgentBackend | null,
+    prompt: row.job.prompt,
+    status: row.job.status as RemoteAgentJobStatus,
+    exitCode: row.job.exitCode,
+    createdAt: row.job.createdAt.toISOString(),
+    startedAt: row.job.startedAt?.toISOString() ?? null,
+    completedAt: row.job.completedAt?.toISOString() ?? null,
   };
 }
 
@@ -960,6 +980,58 @@ export const getRemoteAgentJob$ = command(
     signal.throwIfAborted();
 
     return row ? serializeJob(row) : null;
+  },
+);
+
+export const listRemoteAgentJobs$ = command(
+  async (
+    { set },
+    params: {
+      readonly orgId: string;
+      readonly userId: string;
+      readonly status?: RemoteAgentJobStatus;
+      readonly hostId?: string;
+      readonly hostName?: string;
+      readonly limit: number;
+    },
+    signal: AbortSignal,
+  ) => {
+    const writeDb = set(writeDb$);
+    const conditions: SQL[] = [
+      eq(remoteAgentJobs.orgId, params.orgId),
+      eq(remoteAgentJobs.userId, params.userId),
+    ];
+
+    if (params.status) {
+      conditions.push(eq(remoteAgentJobs.status, params.status));
+    }
+    if (params.hostId) {
+      conditions.push(eq(remoteAgentJobs.hostId, params.hostId));
+    }
+    if (params.hostName) {
+      conditions.push(eq(remoteAgentHosts.displayName, params.hostName));
+    }
+
+    const rows = await writeDb
+      .select({
+        job: remoteAgentJobs,
+        hostName: remoteAgentHosts.displayName,
+      })
+      .from(remoteAgentJobs)
+      .leftJoin(
+        remoteAgentHosts,
+        eq(remoteAgentJobs.hostId, remoteAgentHosts.id),
+      )
+      .where(and(...conditions))
+      .orderBy(desc(remoteAgentJobs.createdAt))
+      .limit(params.limit);
+    signal.throwIfAborted();
+
+    return {
+      runs: rows.map((row) => {
+        return serializeJobListItem(row);
+      }),
+    };
   },
 );
 

--- a/turbo/apps/cli/src/commands/zero/remote-agent/__tests__/remote-agent.test.ts
+++ b/turbo/apps/cli/src/commands/zero/remote-agent/__tests__/remote-agent.test.ts
@@ -17,6 +17,7 @@ describe("remote-agent command registration", () => {
     expect(subNames).toContain("list");
     expect(subNames).toContain("delete");
     expect(subNames).toContain("run");
+    expect(subNames).toContain("runs");
     expect(subNames).not.toContain("connect");
     expect(subNames).not.toContain("host");
     expect(subNames).not.toContain("kill");
@@ -36,6 +37,7 @@ describe("remote-agent command registration", () => {
     });
     expect(subNames).toContain("list");
     expect(subNames).toContain("run");
+    expect(subNames).toContain("runs");
     expect(subNames).not.toContain("start");
     expect(subNames).not.toContain("delete");
     expect(subNames).not.toContain("connect");

--- a/turbo/apps/cli/src/commands/zero/remote-agent/__tests__/runs.test.ts
+++ b/turbo/apps/cli/src/commands/zero/remote-agent/__tests__/runs.test.ts
@@ -1,0 +1,174 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { http, HttpResponse } from "msw";
+import chalk from "chalk";
+
+import { server } from "../../../../mocks/server";
+import { runsCommand } from "../runs";
+
+const runListItem = {
+  id: "job-123",
+  hostId: "host-123",
+  hostName: "laptop",
+  backend: "codex",
+  prompt: "summarize logs",
+  status: "succeeded",
+  exitCode: 0,
+  createdAt: "2026-05-12T10:00:00Z",
+  startedAt: "2026-05-12T10:00:01Z",
+  completedAt: "2026-05-12T10:00:10Z",
+};
+
+const runDetail = {
+  ...runListItem,
+  output: "done",
+  error: null,
+};
+
+describe("remote-agent runs command", () => {
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  beforeEach(() => {
+    chalk.level = 0;
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
+    process.exitCode = undefined;
+    mockExit.mockClear();
+    mockConsoleLog.mockClear();
+    mockConsoleError.mockClear();
+  });
+
+  it("lists remote-agent runs in table format", async () => {
+    server.use(
+      http.get("http://localhost:3000/api/zero/remote-agent/runs", () => {
+        return HttpResponse.json({ runs: [runListItem] });
+      }),
+    );
+
+    await runsCommand.parseAsync(["node", "cli", "list"]);
+
+    const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+    expect(logCalls).toContain("JOB ID");
+    expect(logCalls).toContain("job-123");
+    expect(logCalls).toContain("laptop");
+    expect(logCalls).toContain("succeeded");
+    expect(logCalls).toContain("summarize logs");
+  });
+
+  it("passes list filters to the API", async () => {
+    let capturedUrl: URL | undefined;
+    server.use(
+      http.get(
+        "http://localhost:3000/api/zero/remote-agent/runs",
+        ({ request }) => {
+          capturedUrl = new URL(request.url);
+          return HttpResponse.json({ runs: [] });
+        },
+      ),
+    );
+
+    await runsCommand.parseAsync([
+      "node",
+      "cli",
+      "list",
+      "--status",
+      "running",
+      "--host",
+      "laptop",
+      "--limit",
+      "10",
+    ]);
+
+    expect(capturedUrl?.searchParams.get("status")).toBe("running");
+    expect(capturedUrl?.searchParams.get("hostName")).toBe("laptop");
+    expect(capturedUrl?.searchParams.get("limit")).toBe("10");
+  });
+
+  it("prints list JSON", async () => {
+    server.use(
+      http.get("http://localhost:3000/api/zero/remote-agent/runs", () => {
+        return HttpResponse.json({ runs: [runListItem] });
+      }),
+    );
+
+    await runsCommand.parseAsync(["node", "cli", "list", "--json"]);
+
+    expect(mockConsoleLog).toHaveBeenCalledWith(
+      JSON.stringify({ runs: [runListItem] }),
+    );
+  });
+
+  it("shows remote-agent run status", async () => {
+    server.use(
+      http.get("http://localhost:3000/api/zero/remote-agent/run/:id", () => {
+        return HttpResponse.json(runDetail);
+      }),
+    );
+
+    await runsCommand.parseAsync(["node", "cli", "status", "job-123"]);
+
+    const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+    expect(logCalls).toContain("Job: job-123");
+    expect(logCalls).toContain("Status: succeeded");
+    expect(logCalls).toContain("Backend: codex");
+  });
+
+  it("prints a succeeded remote-agent run result", async () => {
+    server.use(
+      http.get("http://localhost:3000/api/zero/remote-agent/run/:id", () => {
+        return HttpResponse.json(runDetail);
+      }),
+    );
+
+    await runsCommand.parseAsync(["node", "cli", "result", "job-123"]);
+
+    expect(mockConsoleLog).toHaveBeenCalledWith("done");
+  });
+
+  it("fails result lookup for an active remote-agent run", async () => {
+    server.use(
+      http.get("http://localhost:3000/api/zero/remote-agent/run/:id", () => {
+        return HttpResponse.json({
+          ...runDetail,
+          status: "running",
+          output: null,
+          completedAt: null,
+          exitCode: null,
+        });
+      }),
+    );
+
+    await expect(async () => {
+      await runsCommand.parseAsync(["node", "cli", "result", "job-123"]);
+    }).rejects.toThrow("process.exit called");
+
+    expect(mockConsoleError).toHaveBeenCalledWith(
+      expect.stringContaining("Remote-agent job is running"),
+    );
+    expect(mockExit).toHaveBeenCalledWith(1);
+  });
+
+  it("prints failed result errors and sets exit code", async () => {
+    server.use(
+      http.get("http://localhost:3000/api/zero/remote-agent/run/:id", () => {
+        return HttpResponse.json({
+          ...runDetail,
+          status: "failed",
+          output: null,
+          error: "boom",
+          exitCode: 42,
+        });
+      }),
+    );
+
+    await runsCommand.parseAsync(["node", "cli", "result", "job-123"]);
+
+    expect(mockConsoleError).toHaveBeenCalledWith("boom");
+    expect(process.exitCode).toBe(42);
+  });
+});

--- a/turbo/apps/cli/src/commands/zero/remote-agent/index.ts
+++ b/turbo/apps/cli/src/commands/zero/remote-agent/index.ts
@@ -3,6 +3,7 @@ import { startCommand } from "./host";
 import { deleteCommand } from "./delete";
 import { listCommand } from "./list";
 import { runCommand } from "./run";
+import { runsCommand } from "./runs";
 
 export const remoteAgentCommand = new Command()
   .name("remote-agent")
@@ -10,10 +11,12 @@ export const remoteAgentCommand = new Command()
   .addCommand(startCommand)
   .addCommand(listCommand)
   .addCommand(deleteCommand)
-  .addCommand(runCommand);
+  .addCommand(runCommand)
+  .addCommand(runsCommand);
 
 export const zeroRemoteAgentCommand = new Command()
   .name("remote-agent")
   .description("Run jobs on remote-agent hosts")
   .addCommand(listCommand)
-  .addCommand(runCommand);
+  .addCommand(runCommand)
+  .addCommand(runsCommand);

--- a/turbo/apps/cli/src/commands/zero/remote-agent/runs.ts
+++ b/turbo/apps/cli/src/commands/zero/remote-agent/runs.ts
@@ -1,0 +1,246 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import type {
+  RemoteAgentJobStatus,
+  RemoteAgentRunListItem,
+  RemoteAgentRunResponse,
+} from "@vm0/api-contracts/contracts/zero-remote-agent";
+import { getRemoteAgentRun, listRemoteAgentRuns } from "../../../lib/api";
+import { withErrorHandler } from "../../../lib/command/with-error-handler";
+
+const VALID_STATUSES: readonly RemoteAgentJobStatus[] = [
+  "queued",
+  "running",
+  "succeeded",
+  "failed",
+];
+
+interface RunsListOptions {
+  status?: string;
+  host?: string;
+  hostId?: string;
+  limit?: string;
+  json?: boolean;
+}
+
+interface JsonOption {
+  json?: boolean;
+}
+
+function formatStatus(status: RemoteAgentJobStatus): string {
+  switch (status) {
+    case "queued":
+      return chalk.yellow(status);
+    case "running":
+      return chalk.green(status);
+    case "succeeded":
+      return chalk.dim(status);
+    case "failed":
+      return chalk.red(status);
+  }
+}
+
+function formatTime(value: string | null): string {
+  if (!value) return "-";
+  return new Date(value).toISOString().replace(/\.\d{3}Z$/, "Z");
+}
+
+function truncate(value: string, maxLength: number): string {
+  if (value.length <= maxLength) return value;
+  return `${value.slice(0, maxLength - 3)}...`;
+}
+
+function parseStatus(
+  value: string | undefined,
+): RemoteAgentJobStatus | undefined {
+  if (!value) return undefined;
+  if (!VALID_STATUSES.includes(value as RemoteAgentJobStatus)) {
+    throw new Error(
+      `Invalid status "${value}". Valid values: ${VALID_STATUSES.join(",")}`,
+    );
+  }
+  return value as RemoteAgentJobStatus;
+}
+
+function parseLimit(value: string | undefined): number | undefined {
+  if (!value) return undefined;
+  const limit = Number.parseInt(value, 10);
+  if (!Number.isFinite(limit) || limit < 1 || limit > 100) {
+    throw new Error("--limit must be between 1 and 100");
+  }
+  return limit;
+}
+
+function printRunTable(runs: readonly RemoteAgentRunListItem[]): void {
+  if (runs.length === 0) {
+    console.log(chalk.dim("No remote-agent runs found"));
+    console.log(chalk.dim('  Run: zero remote-agent run "your prompt"'));
+    return;
+  }
+
+  const rows = runs.map((run) => {
+    return {
+      id: run.id,
+      status: formatStatus(run.status),
+      host: run.hostName ?? run.hostId ?? "-",
+      backend: run.backend ?? "-",
+      created: formatTime(run.createdAt),
+      prompt: truncate(run.prompt.replace(/\s+/g, " "), 60),
+    };
+  });
+
+  const idWidth = Math.max(
+    "JOB ID".length,
+    ...rows.map((row) => {
+      return row.id.length;
+    }),
+  );
+  const statusWidth = Math.max(
+    "STATUS".length,
+    ...runs.map((run) => {
+      return run.status.length;
+    }),
+  );
+  const hostWidth = Math.max(
+    "HOST".length,
+    ...rows.map((row) => {
+      return row.host.length;
+    }),
+  );
+  const backendWidth = Math.max(
+    "BACKEND".length,
+    ...rows.map((row) => {
+      return row.backend.length;
+    }),
+  );
+
+  console.log(
+    chalk.dim(
+      [
+        "JOB ID".padEnd(idWidth),
+        "STATUS".padEnd(statusWidth),
+        "HOST".padEnd(hostWidth),
+        "BACKEND".padEnd(backendWidth),
+        "CREATED".padEnd(20),
+        "PROMPT",
+      ].join("  "),
+    ),
+  );
+
+  for (const row of rows) {
+    console.log(
+      [
+        row.id.padEnd(idWidth),
+        row.status.padEnd(statusWidth),
+        row.host.padEnd(hostWidth),
+        row.backend.padEnd(backendWidth),
+        row.created.padEnd(20),
+        row.prompt,
+      ].join("  "),
+    );
+  }
+}
+
+function printRunStatus(job: RemoteAgentRunResponse): void {
+  console.log(`Job: ${job.id}`);
+  console.log(`Status: ${formatStatus(job.status)}`);
+  console.log(`Host: ${job.hostId ?? "-"}`);
+  console.log(`Backend: ${job.backend ?? "-"}`);
+  console.log(`Created: ${formatTime(job.createdAt)}`);
+  console.log(`Started: ${formatTime(job.startedAt)}`);
+  console.log(`Completed: ${formatTime(job.completedAt)}`);
+  console.log(`Exit code: ${job.exitCode ?? "-"}`);
+
+  if (job.status === "succeeded" || job.status === "failed") {
+    console.log();
+    console.log(chalk.dim(`  Run: zero remote-agent runs result ${job.id}`));
+  }
+}
+
+function printRunResult(job: RemoteAgentRunResponse): void {
+  if (job.status === "queued" || job.status === "running") {
+    throw new Error(`Remote-agent job is ${job.status}`, {
+      cause: new Error(`Run: zero remote-agent runs status ${job.id}`),
+    });
+  }
+
+  if (job.status === "failed") {
+    if (job.error) {
+      console.error(chalk.red(job.error));
+    }
+    process.exitCode = job.exitCode ?? 1;
+    return;
+  }
+
+  if (job.output) {
+    console.log(job.output);
+  }
+}
+
+const listCommand = new Command()
+  .name("list")
+  .alias("ls")
+  .description("List remote-agent runs")
+  .option("--status <status>", `Filter by status: ${VALID_STATUSES.join(",")}`)
+  .option("--host <name>", "Filter by remote-agent host name")
+  .option("--host-id <id>", "Filter by remote-agent host id")
+  .option("--limit <n>", "Maximum number of results (default: 20, max: 100)")
+  .option("--json", "Output JSON")
+  .action(
+    withErrorHandler(async (options: RunsListOptions) => {
+      const result = await listRemoteAgentRuns({
+        status: parseStatus(options.status),
+        hostName: options.host,
+        hostId: options.hostId,
+        limit: parseLimit(options.limit),
+      });
+
+      if (options.json) {
+        console.log(JSON.stringify(result));
+        return;
+      }
+
+      printRunTable(result.runs);
+    }),
+  );
+
+const statusCommand = new Command()
+  .name("status")
+  .description("Show remote-agent run status")
+  .argument("<job-id>", "Remote-agent job id")
+  .option("--json", "Output JSON")
+  .action(
+    withErrorHandler(async (jobId: string, options: JsonOption) => {
+      const job = await getRemoteAgentRun(jobId);
+      if (options.json) {
+        console.log(JSON.stringify(job));
+        return;
+      }
+
+      printRunStatus(job);
+    }),
+  );
+
+const resultCommand = new Command()
+  .name("result")
+  .description("Print remote-agent run result")
+  .argument("<job-id>", "Remote-agent job id")
+  .option("--json", "Output JSON")
+  .action(
+    withErrorHandler(async (jobId: string, options: JsonOption) => {
+      const job = await getRemoteAgentRun(jobId);
+      if (options.json) {
+        console.log(JSON.stringify(job));
+        return;
+      }
+
+      printRunResult(job);
+    }),
+  );
+
+export const runsCommand = new Command()
+  .name("runs")
+  .description("List and inspect remote-agent runs")
+  .addCommand(listCommand)
+  .addCommand(statusCommand)
+  .addCommand(resultCommand);

--- a/turbo/apps/cli/src/lib/api/domains/zero-remote-agent.ts
+++ b/turbo/apps/cli/src/lib/api/domains/zero-remote-agent.ts
@@ -6,6 +6,8 @@ import type {
   RemoteAgentHostStartResponse,
   RemoteAgentRealtimeSubscription,
   RemoteAgentRunCreateResponse,
+  RemoteAgentRunListResponse,
+  RemoteAgentJobStatus,
   RemoteAgentRunResponse,
 } from "@vm0/api-contracts/contracts/zero-remote-agent";
 import {
@@ -150,7 +152,7 @@ export async function listRemoteAgentHosts(): Promise<RemoteAgentHostListRespons
   const config = await getRemoteAgentClientConfig();
   const client = initClient(zeroRemoteAgentHostsContract, config);
 
-  const result = await client.list();
+  const result = await client.list({ headers: {} });
 
   if (result.status === 200) {
     return result.body;
@@ -187,6 +189,30 @@ export async function getRemoteAgentRun(
   }
 
   handleError(result, "Failed to get remote-agent run");
+}
+
+export async function listRemoteAgentRuns(params: {
+  status?: RemoteAgentJobStatus;
+  hostId?: string;
+  hostName?: string;
+  limit?: number;
+}): Promise<RemoteAgentRunListResponse> {
+  const config = await getRemoteAgentClientConfig();
+  const client = initClient(zeroRemoteAgentRunContract, config);
+
+  const result = await client.list({
+    headers: {},
+    query: {
+      ...params,
+      limit: params.limit ?? 20,
+    },
+  });
+
+  if (result.status === 200) {
+    return result.body;
+  }
+
+  handleError(result, "Failed to list remote-agent runs");
 }
 
 export async function claimNextRemoteAgentHostJob(params: {

--- a/turbo/apps/cli/src/lib/api/index.ts
+++ b/turbo/apps/cli/src/lib/api/index.ts
@@ -196,6 +196,7 @@ export {
   createRemoteAgentHostRealtimeSubscription,
   deleteRemoteAgentHost,
   getRemoteAgentRun,
+  listRemoteAgentRuns,
   listRemoteAgentHosts,
   startRemoteAgentHost,
   sendRemoteAgentHeartbeat,

--- a/turbo/packages/api-contracts/src/contracts/zero-remote-agent.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-remote-agent.ts
@@ -75,6 +75,16 @@ export const remoteAgentRunResponseSchema = z.object({
   completedAt: z.string().nullable(),
 });
 
+export const remoteAgentRunListItemSchema = remoteAgentRunResponseSchema
+  .omit({ output: true, error: true })
+  .extend({
+    hostName: z.string().nullable(),
+  });
+
+export const remoteAgentRunListResponseSchema = z.object({
+  runs: z.array(remoteAgentRunListItemSchema),
+});
+
 export const remoteAgentHostJobNextResponseSchema = z.discriminatedUnion(
   "status",
   [
@@ -201,6 +211,23 @@ export const zeroRemoteAgentHostRealtimeContract = c.router({
 });
 
 export const zeroRemoteAgentRunContract = c.router({
+  list: {
+    method: "GET",
+    path: "/api/zero/remote-agent/runs",
+    headers: authHeadersSchema,
+    query: z.object({
+      status: remoteAgentJobStatusSchema.optional(),
+      hostId: z.string().min(1).optional(),
+      hostName: z.string().trim().min(1).max(128).optional(),
+      limit: z.coerce.number().int().min(1).max(100).default(20),
+    }),
+    responses: {
+      200: remoteAgentRunListResponseSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+    },
+    summary: "List remote-agent jobs",
+  },
   create: {
     method: "POST",
     path: "/api/zero/remote-agent/run",
@@ -341,6 +368,12 @@ export type RemoteAgentRunCreateResponse = z.infer<
 >;
 export type RemoteAgentRunResponse = z.infer<
   typeof remoteAgentRunResponseSchema
+>;
+export type RemoteAgentRunListItem = z.infer<
+  typeof remoteAgentRunListItemSchema
+>;
+export type RemoteAgentRunListResponse = z.infer<
+  typeof remoteAgentRunListResponseSchema
 >;
 export type RemoteAgentHostListResponse = z.infer<
   typeof remoteAgentHostListResponseSchema


### PR DESCRIPTION
## Summary
- add the remote-agent run list API contract, service query, and authenticated route
- add CLI commands for `zero remote-agent runs list`, `status`, and `result`
- cover the new CLI behavior and API route filtering with focused tests

## Tests
- `pnpm --filter @vm0/cli test -- src/commands/zero/remote-agent/__tests__/remote-agent.test.ts src/commands/zero/remote-agent/__tests__/runs.test.ts`
- `pnpm --filter @vm0/cli check-types`
- `pnpm --filter @vm0/api-contracts check-types`
- `pnpm --filter api lint`
- `pnpm --filter @vm0/cli lint`
- `pnpm --filter @vm0/api-contracts lint`
- `git diff --check`
- `pnpm --filter api check-types 2>&1 | rg "zero-remote-agent-runs|zero-remote-agent"` (no output; full workspace check-types is currently blocked by existing @vm0/app ts-rest errors)
- `pnpm exec vitest run src/signals/routes/__tests__/zero-remote-agent-runs.test.ts` (blocked locally: test DB lacks remote-agent tables; db:migrate is blocked by an existing storages fixture collision)