### PR TITLE
refactor(api): migrate zero org delete route

### DIFF
--- a/turbo/apps/api/src/__tests__/mocks.ts
+++ b/turbo/apps/api/src/__tests__/mocks.ts
@@ -33,6 +33,7 @@ export interface ApiTestMocks {
       readonly getOrganizationMembershipList: AsyncMock;
       readonly deleteOrganizationMembership: AsyncMock;
       readonly revokeOrganizationInvitation: AsyncMock;
+      readonly deleteOrganization: AsyncMock;
       readonly updateOrganization: AsyncMock;
       readonly updateOrganizationLogo: AsyncMock;
     };
@@ -143,6 +144,7 @@ const apiTestMocks: ApiTestMocks = vi.hoisted((): ApiTestMocks => {
         vi.fn<(...args: unknown[]) => Promise<unknown>>(),
       revokeOrganizationInvitation:
         vi.fn<(...args: unknown[]) => Promise<unknown>>(),
+      deleteOrganization: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
       updateOrganization: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
       updateOrganizationLogo: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
     },

--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -42,6 +42,7 @@ import { zeroModelProvidersRoutes } from "./routes/zero-model-providers";
 import { zeroOnboardingCompleteRoutes } from "./routes/zero-onboarding-complete";
 import { zeroOnboardingStatusRoutes } from "./routes/zero-onboarding-status";
 import { zeroOrgInviteRoutes } from "./routes/zero-org-invite";
+import { zeroOrgDeleteRoutes } from "./routes/zero-org-delete";
 import { zeroOrgLogoRoutes } from "./routes/zero-org-logo";
 import { zeroOrgMembershipRequestsRoutes } from "./routes/zero-org-membership-requests";
 import { zeroOrgReadRoutes } from "./routes/zero-org-read";
@@ -163,6 +164,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...zeroOnboardingCompleteRoutes,
   ...zeroOnboardingStatusRoutes,
   ...zeroOrgInviteRoutes,
+  ...zeroOrgDeleteRoutes,
   ...zeroOrgLogoRoutes,
   ...zeroOrgMembershipRequestsRoutes,
   ...zeroOrgReadRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-org-delete.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-org-delete.test.ts
@@ -1,0 +1,369 @@
+import { randomUUID } from "node:crypto";
+
+import { createStore } from "ccstate";
+import { and, eq } from "drizzle-orm";
+import { describe, expect, it } from "vitest";
+import { zeroOrgDeleteContract } from "@vm0/api-contracts/contracts/zero-org";
+import { orgCache } from "@vm0/db/schema/org-cache";
+import { orgMembersCache } from "@vm0/db/schema/org-members-cache";
+import { orgMembersMetadata } from "@vm0/db/schema/org-members-metadata";
+import { orgMetadata } from "@vm0/db/schema/org-metadata";
+import { slackOrgConnections } from "@vm0/db/schema/slack-org-connection";
+import { slackOrgInstallations } from "@vm0/db/schema/slack-org-installation";
+
+import { createApp } from "../../../app-factory";
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { writeDb$ } from "../../external/db";
+import {
+  createFixtureTracker,
+  createZeroRouteMocks,
+} from "./helpers/zero-route-test";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+
+interface CleanupFixture {
+  readonly orgId?: string;
+  readonly workspaceId?: string;
+}
+
+const trackCleanup = createFixtureTracker(
+  async (fixture: CleanupFixture): Promise<void> => {
+    const writeDb = store.set(writeDb$);
+    if (fixture.workspaceId) {
+      await writeDb
+        .delete(slackOrgConnections)
+        .where(eq(slackOrgConnections.slackWorkspaceId, fixture.workspaceId));
+      await writeDb
+        .delete(slackOrgInstallations)
+        .where(eq(slackOrgInstallations.slackWorkspaceId, fixture.workspaceId));
+    }
+
+    if (fixture.orgId) {
+      await writeDb
+        .delete(orgMembersMetadata)
+        .where(eq(orgMembersMetadata.orgId, fixture.orgId));
+      await writeDb
+        .delete(orgMembersCache)
+        .where(eq(orgMembersCache.orgId, fixture.orgId));
+      await writeDb
+        .delete(orgMetadata)
+        .where(eq(orgMetadata.orgId, fixture.orgId));
+      await writeDb.delete(orgCache).where(eq(orgCache.orgId, fixture.orgId));
+    }
+  },
+);
+
+function uniqueId(prefix: string): string {
+  return `${prefix}_${randomUUID().slice(0, 8)}`;
+}
+
+async function seedOrg(args: {
+  readonly userId: string;
+  readonly orgId: string;
+  readonly role: "admin" | "member";
+  readonly slug: string;
+}): Promise<void> {
+  const writeDb = store.set(writeDb$);
+  await trackCleanup(Promise.resolve({ orgId: args.orgId }));
+  await writeDb.insert(orgCache).values({
+    orgId: args.orgId,
+    slug: args.slug,
+    name: "Delete Test Org",
+  });
+  await writeDb.insert(orgMetadata).values({ orgId: args.orgId });
+  await writeDb.insert(orgMembersCache).values({
+    orgId: args.orgId,
+    userId: args.userId,
+    role: args.role,
+  });
+}
+
+async function seedMemberMetadata(
+  orgId: string,
+  userId: string,
+): Promise<void> {
+  const writeDb = store.set(writeDb$);
+  await writeDb.insert(orgMembersMetadata).values({ orgId, userId });
+}
+
+async function seedSlackConnection(args: {
+  readonly orgId: string;
+  readonly workspaceId: string;
+  readonly userId: string;
+}): Promise<void> {
+  const writeDb = store.set(writeDb$);
+  await trackCleanup(Promise.resolve({ workspaceId: args.workspaceId }));
+  await writeDb.insert(slackOrgInstallations).values({
+    slackWorkspaceId: args.workspaceId,
+    slackWorkspaceName: "Delete Test Workspace",
+    orgId: args.orgId,
+    encryptedBotToken: "encrypted-token",
+    botUserId: uniqueId("bot"),
+  });
+  await writeDb.insert(slackOrgConnections).values({
+    slackUserId: uniqueId("slack-user"),
+    slackWorkspaceId: args.workspaceId,
+    vm0UserId: args.userId,
+  });
+}
+
+function mockMemberships(userIds: readonly string[]): void {
+  context.mocks.clerk.organizations.getOrganizationMembershipList.mockResolvedValue(
+    {
+      data: userIds.map((userId) => {
+        return { publicUserData: { userId } };
+      }),
+    },
+  );
+}
+
+async function readMemberCache(
+  orgId: string,
+  userId: string,
+): Promise<typeof orgMembersCache.$inferSelect | undefined> {
+  const writeDb = store.set(writeDb$);
+  const [row] = await writeDb
+    .select()
+    .from(orgMembersCache)
+    .where(
+      and(eq(orgMembersCache.orgId, orgId), eq(orgMembersCache.userId, userId)),
+    )
+    .limit(1);
+  return row;
+}
+
+async function readMemberMetadata(
+  orgId: string,
+  userId: string,
+): Promise<typeof orgMembersMetadata.$inferSelect | undefined> {
+  const writeDb = store.set(writeDb$);
+  const [row] = await writeDb
+    .select()
+    .from(orgMembersMetadata)
+    .where(
+      and(
+        eq(orgMembersMetadata.orgId, orgId),
+        eq(orgMembersMetadata.userId, userId),
+      ),
+    )
+    .limit(1);
+  return row;
+}
+
+async function readSlackConnection(
+  workspaceId: string,
+  userId: string,
+): Promise<typeof slackOrgConnections.$inferSelect | undefined> {
+  const writeDb = store.set(writeDb$);
+  const [row] = await writeDb
+    .select()
+    .from(slackOrgConnections)
+    .where(
+      and(
+        eq(slackOrgConnections.slackWorkspaceId, workspaceId),
+        eq(slackOrgConnections.vm0UserId, userId),
+      ),
+    )
+    .limit(1);
+  return row;
+}
+
+describe("POST /api/zero/org/delete", () => {
+  it("returns 401 when unauthenticated", async () => {
+    const client = setupApp({ context })(zeroOrgDeleteContract);
+
+    const response = await accept(
+      client.delete({ headers: {}, body: { slug: "delete-test" } }),
+      [401],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("returns 401 when authenticated without an active org", async () => {
+    mocks.clerk.session(uniqueId("user"), null);
+    const client = setupApp({ context })(zeroOrgDeleteContract);
+
+    const response = await accept(
+      client.delete({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { slug: "delete-test" },
+      }),
+      [401],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("returns 400 for an invalid body", async () => {
+    const userId = uniqueId("user");
+    const orgId = uniqueId("org");
+    const slug = `org-${randomUUID().slice(0, 8)}`;
+    await seedOrg({ userId, orgId, role: "admin", slug });
+    mocks.clerk.session(userId, orgId, "org:admin");
+    const app = createApp({ signal: context.signal });
+
+    const response = await app.request("/api/zero/org/delete", {
+      method: "POST",
+      headers: {
+        authorization: "Bearer clerk-session",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({}),
+    });
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body).toMatchObject({ error: { code: "BAD_REQUEST" } });
+    expect(
+      context.mocks.clerk.organizations.deleteOrganization,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when the slug does not match the active org", async () => {
+    const userId = uniqueId("user");
+    const orgId = uniqueId("org");
+    const slug = `org-${randomUUID().slice(0, 8)}`;
+    await seedOrg({ userId, orgId, role: "admin", slug });
+    mocks.clerk.session(userId, orgId, "org:admin");
+    const client = setupApp({ context })(zeroOrgDeleteContract);
+
+    const response = await accept(
+      client.delete({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { slug: `different-${randomUUID().slice(0, 8)}` },
+      }),
+      [400],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Organization name does not match",
+        code: "BAD_REQUEST",
+      },
+    });
+    expect(
+      context.mocks.clerk.organizations.deleteOrganization,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 for non-admin members", async () => {
+    const userId = uniqueId("user");
+    const orgId = uniqueId("org");
+    const slug = `org-${randomUUID().slice(0, 8)}`;
+    await seedOrg({ userId, orgId, role: "member", slug });
+    mocks.clerk.session(userId, orgId, "org:member");
+    const client = setupApp({ context })(zeroOrgDeleteContract);
+
+    const response = await accept(
+      client.delete({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { slug },
+      }),
+      [403],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Only admins can delete the organization",
+        code: "FORBIDDEN",
+      },
+    });
+    expect(
+      context.mocks.clerk.organizations.getOrganizationMembershipList,
+    ).not.toHaveBeenCalled();
+    expect(
+      context.mocks.clerk.organizations.deleteOrganization,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when the org identity is missing", async () => {
+    const userId = uniqueId("user");
+    const orgId = uniqueId("org");
+    await trackCleanup(Promise.resolve({ orgId }));
+    await store.set(writeDb$).insert(orgMetadata).values({ orgId });
+    mocks.clerk.session(userId, orgId, "org:admin");
+    context.mocks.clerk.organizations.getOrganization.mockRejectedValue({
+      statusCode: 404,
+    });
+    const client = setupApp({ context })(zeroOrgDeleteContract);
+
+    const response = await accept(
+      client.delete({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { slug: "missing-org" },
+      }),
+      [404],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Resource not found", code: "NOT_FOUND" },
+    });
+    expect(
+      context.mocks.clerk.organizations.deleteOrganization,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("deletes the organization through Clerk and cleans member-local rows", async () => {
+    const adminUserId = uniqueId("user-admin");
+    const memberUserId = uniqueId("user-member");
+    const orgId = uniqueId("org");
+    const workspaceId = uniqueId("workspace");
+    const slug = `org-${randomUUID().slice(0, 8)}`;
+    await seedOrg({ userId: adminUserId, orgId, role: "admin", slug });
+    await store.set(writeDb$).insert(orgMembersCache).values({
+      orgId,
+      userId: memberUserId,
+      role: "member",
+    });
+    await seedMemberMetadata(orgId, adminUserId);
+    await seedMemberMetadata(orgId, memberUserId);
+    await seedSlackConnection({ orgId, workspaceId, userId: memberUserId });
+    mockMemberships([adminUserId, memberUserId]);
+    context.mocks.clerk.organizations.deleteOrganization.mockResolvedValue({});
+    mocks.clerk.session(adminUserId, orgId, "org:admin");
+    const client = setupApp({ context })(zeroOrgDeleteContract);
+
+    const response = await accept(
+      client.delete({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { slug },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      message: "Organization deleted",
+    });
+    expect(
+      context.mocks.clerk.organizations.getOrganizationMembershipList,
+    ).toHaveBeenCalledWith({ organizationId: orgId });
+    expect(
+      context.mocks.clerk.organizations.deleteOrganization,
+    ).toHaveBeenCalledWith(orgId);
+    await expect(readMemberCache(orgId, adminUserId)).resolves.toBeUndefined();
+    await expect(readMemberCache(orgId, memberUserId)).resolves.toBeUndefined();
+    await expect(
+      readMemberMetadata(orgId, adminUserId),
+    ).resolves.toBeUndefined();
+    await expect(
+      readMemberMetadata(orgId, memberUserId),
+    ).resolves.toBeUndefined();
+    await expect(
+      readSlackConnection(workspaceId, memberUserId),
+    ).resolves.toBeUndefined();
+
+    const writeDb = store.set(writeDb$);
+    const [metadata] = await writeDb
+      .select({ orgId: orgMetadata.orgId })
+      .from(orgMetadata)
+      .where(eq(orgMetadata.orgId, orgId));
+    expect(metadata?.orgId).toBe(orgId);
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-org-delete.ts
+++ b/turbo/apps/api/src/signals/routes/zero-org-delete.ts
@@ -1,0 +1,46 @@
+import { command } from "ccstate";
+import { zeroOrgDeleteContract } from "@vm0/api-contracts/contracts/zero-org";
+
+import { organizationAuthContext$ } from "../auth/auth-context";
+import { authRoute } from "../auth/auth-route";
+import { bodyResultOf } from "../context/request";
+import { deleteZeroOrg$ } from "../services/zero-org-data.service";
+import type { RouteEntry } from "../route";
+
+const deleteBody$ = bodyResultOf(zeroOrgDeleteContract.delete);
+
+const deleteInner$ = command(async ({ get, set }, signal: AbortSignal) => {
+  const auth = get(organizationAuthContext$);
+  const body = await get(deleteBody$);
+  signal.throwIfAborted();
+  if (!body.ok) {
+    return body.response;
+  }
+
+  const result = await set(
+    deleteZeroOrg$,
+    {
+      orgId: auth.orgId,
+      callerRole: auth.orgRole,
+      slug: body.data.slug,
+    },
+    signal,
+  );
+  signal.throwIfAborted();
+
+  if ("status" in result) {
+    return result;
+  }
+
+  return { status: 200 as const, body: result };
+});
+
+export const zeroOrgDeleteRoutes: readonly RouteEntry[] = [
+  {
+    route: zeroOrgDeleteContract.delete,
+    handler: authRoute(
+      { requireOrganization: true, missingOrganizationStatus: 401 },
+      deleteInner$,
+    ),
+  },
+];

--- a/turbo/apps/api/src/signals/services/zero-org-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-org-data.service.ts
@@ -18,7 +18,7 @@ import type {
 } from "@vm0/api-contracts/contracts/org-members";
 import type { User } from "@clerk/backend";
 
-import { db$, writeDb$, type Db } from "../external/db";
+import { db$, writeDb$, type Db, type ReadonlyDb } from "../external/db";
 import { clerk$ } from "../external/clerk";
 import { fetchClerkMembershipRequests } from "../external/clerk-membership-requests";
 import { badRequestMessage, conflict, notFound } from "../../lib/error";
@@ -51,6 +51,8 @@ interface OrgIdentity {
   readonly createdBy: string | null;
 }
 
+const CACHE_TTL_MS = 60_000;
+
 const forbiddenAccess = Object.freeze({
   status: 403 as const,
   body: Object.freeze({
@@ -71,11 +73,26 @@ const adminCannotLeave = Object.freeze({
   }),
 });
 
+const orgDeleteForbidden = Object.freeze({
+  status: 403 as const,
+  body: Object.freeze({
+    error: Object.freeze({
+      message: "Only admins can delete the organization",
+      code: "FORBIDDEN",
+    }),
+  }),
+});
+
 type OrgUpdateErrorResponse =
   | ReturnType<typeof badRequestMessage>
   | ReturnType<typeof conflict>
   | ReturnType<typeof notFound>
   | typeof forbiddenAccess;
+
+type OrgDeleteErrorResponse =
+  | ReturnType<typeof badRequestMessage>
+  | ReturnType<typeof notFound>
+  | typeof orgDeleteForbidden;
 
 interface UpdateZeroOrgArgs {
   readonly orgId: string;
@@ -89,6 +106,12 @@ interface LeaveZeroOrgArgs {
   readonly orgId: string;
   readonly userId: string;
   readonly role: OrgRole;
+}
+
+interface DeleteZeroOrgArgs {
+  readonly orgId: string;
+  readonly callerRole: OrgRole | undefined;
+  readonly slug: string;
 }
 
 interface ClerkUpdate {
@@ -177,6 +200,76 @@ function isClerkNotFound(error: unknown): boolean {
     Reflect.get(error, "code") === "NOT_FOUND" ||
     Reflect.get(error, "name") === "NotFoundError"
   );
+}
+
+async function getOrgIdentityForDelete(args: {
+  readonly db: ReadonlyDb;
+  readonly writeDb: Db;
+  readonly client: ReturnType<typeof clerk$.read>;
+  readonly orgId: string;
+}): Promise<OrgIdentity | null> {
+  const [cached] = await args.db
+    .select({
+      slug: orgCache.slug,
+      name: orgCache.name,
+      createdBy: orgCache.createdBy,
+      cachedAt: orgCache.cachedAt,
+    })
+    .from(orgCache)
+    .where(eq(orgCache.orgId, args.orgId))
+    .limit(1);
+
+  const now = nowDate();
+  if (cached && now.getTime() - cached.cachedAt.getTime() < CACHE_TTL_MS) {
+    return {
+      slug: cached.slug,
+      name: cached.name,
+      createdBy: cached.createdBy,
+    };
+  }
+
+  const clerkOrg = await args.client.organizations
+    .getOrganization({ organizationId: args.orgId })
+    .catch((error: unknown) => {
+      if (isClerkNotFound(error)) {
+        return null;
+      }
+      throw error;
+    });
+
+  if (!clerkOrg) {
+    return null;
+  }
+
+  const parsed = clerkOrgIdentitySchema.parse(clerkOrg);
+  if (!parsed.slug) {
+    throw new Error(`Clerk organization ${args.orgId} has no slug`);
+  }
+
+  await args.writeDb
+    .insert(orgCache)
+    .values({
+      orgId: args.orgId,
+      slug: parsed.slug,
+      name: parsed.name ?? "",
+      createdBy: parsed.createdBy ?? null,
+      cachedAt: now,
+    })
+    .onConflictDoUpdate({
+      target: orgCache.orgId,
+      set: {
+        slug: parsed.slug,
+        name: parsed.name ?? "",
+        createdBy: parsed.createdBy ?? null,
+        cachedAt: now,
+      },
+    });
+
+  return {
+    slug: parsed.slug,
+    name: parsed.name ?? "",
+    createdBy: parsed.createdBy ?? null,
+  };
 }
 
 interface ZeroOrgDetailArgs {
@@ -386,6 +479,102 @@ export const updateZeroOrg$ = command(
     }
 
     return org;
+  },
+);
+
+export const deleteZeroOrg$ = command(
+  async (
+    { get, set },
+    args: DeleteZeroOrgArgs,
+    signal: AbortSignal,
+  ): Promise<{ readonly message: string } | OrgDeleteErrorResponse> => {
+    if (args.callerRole !== "admin") {
+      return orgDeleteForbidden;
+    }
+
+    const db = get(db$);
+    const writeDb = set(writeDb$);
+    const client = get(clerk$);
+    const identity = await getOrgIdentityForDelete({
+      db,
+      writeDb,
+      client,
+      orgId: args.orgId,
+    });
+    signal.throwIfAborted();
+
+    if (!identity) {
+      return notFound("Resource not found");
+    }
+
+    if (args.slug !== identity.slug) {
+      return badRequestMessage("Organization name does not match");
+    }
+
+    const memberships =
+      await client.organizations.getOrganizationMembershipList({
+        organizationId: args.orgId,
+      });
+    signal.throwIfAborted();
+
+    const memberUserIds = memberships.data
+      .map((membership) => {
+        return membership.publicUserData?.userId;
+      })
+      .filter((userId): userId is string => {
+        return Boolean(userId);
+      });
+
+    for (const userId of memberUserIds) {
+      const [installation] = await db
+        .select({
+          slackWorkspaceId: slackOrgInstallations.slackWorkspaceId,
+        })
+        .from(slackOrgInstallations)
+        .where(eq(slackOrgInstallations.orgId, args.orgId))
+        .limit(1);
+      signal.throwIfAborted();
+
+      if (installation) {
+        await writeDb
+          .delete(slackOrgConnections)
+          .where(
+            and(
+              eq(slackOrgConnections.vm0UserId, userId),
+              eq(
+                slackOrgConnections.slackWorkspaceId,
+                installation.slackWorkspaceId,
+              ),
+            ),
+          );
+        signal.throwIfAborted();
+      }
+
+      await writeDb
+        .delete(orgMembersCache)
+        .where(
+          and(
+            eq(orgMembersCache.userId, userId),
+            eq(orgMembersCache.orgId, args.orgId),
+          ),
+        );
+      signal.throwIfAborted();
+
+      await writeDb
+        .delete(orgMembersMetadata)
+        .where(
+          and(
+            eq(orgMembersMetadata.userId, userId),
+            eq(orgMembersMetadata.orgId, args.orgId),
+          ),
+        );
+      signal.throwIfAborted();
+    }
+
+    await client.organizations.deleteOrganization(args.orgId);
+    signal.throwIfAborted();
+
+    return { message: "Organization deleted" };
   },
 );
 

--- a/turbo/packages/api-contracts/src/contracts/zero-org.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-org.ts
@@ -79,6 +79,7 @@ export const zeroOrgDeleteContract = c.router({
       400: apiErrorSchema,
       401: apiErrorSchema,
       403: apiErrorSchema,
+      404: apiErrorSchema,
       500: apiErrorSchema,
     },
     summary: "Delete the current org (zero proxy)",


### PR DESCRIPTION
## Summary
- register `POST /api/zero/org/delete` in apps/api as an authoritative command route
- add API-owned org delete service behavior matching the web route boundary
- add route integration tests for auth, validation, admin gating, Clerk delete, and member-local cleanup

## Validation
- `pnpm -F api exec vitest src/signals/routes/__tests__/zero-org-delete.test.ts`
- `pnpm -F api lint`
- `pnpm check-types`
- `git diff --check`

Closes #12879