### PR TITLE
refactor(api): migrate agent runs read routes to api

### DIFF
--- a/turbo/apps/api/src/__tests__/app-factory.test.ts
+++ b/turbo/apps/api/src/__tests__/app-factory.test.ts
@@ -194,7 +194,7 @@ describe("createApp", () => {
       let observedAuthorization: string | undefined;
       useUndiciMock()
         .get("https://www.vm0.ai")
-        .intercept({ path: "/api/agent/runs?limit=5", method: "GET" })
+        .intercept({ path: "/api/legacy/fallthrough?limit=5", method: "GET" })
         .reply((opts) => {
           observedPath = opts.path;
           observedAuthorization = headerValue(opts.headers, "authorization");
@@ -208,14 +208,14 @@ describe("createApp", () => {
         });
 
       const app = createApp({ signal: context.signal });
-      const response = await app.request("/api/agent/runs?limit=5", {
+      const response = await app.request("/api/legacy/fallthrough?limit=5", {
         method: "GET",
         headers: { authorization: "Bearer legacy" },
       });
 
       expect(response.status).toBe(200);
       await expect(response.json()).resolves.toStrictEqual({ runs: [] });
-      expect(observedPath).toBe("/api/agent/runs?limit=5");
+      expect(observedPath).toBe("/api/legacy/fallthrough?limit=5");
       expect(observedAuthorization).toBe("Bearer legacy");
     });
 

--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -4,6 +4,7 @@ import { healthContract } from "@vm0/api-contracts/contracts/health";
 import { agentCheckpointsRoutes } from "./routes/agent-checkpoints-id";
 import { agentComposesByIdRoutes } from "./routes/agent-composes-id";
 import { agentComposesReadRoutes } from "./routes/agent-composes-read";
+import { agentRunsReadRoutes } from "./routes/agent-runs-read";
 import { agentSessionsRoutes } from "./routes/agent-sessions-id";
 import { authMeRoutes } from "./routes/auth-me";
 import { audioTranscriptionsV1Routes } from "./routes/audio-transcriptions-v1";
@@ -108,6 +109,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...agentCheckpointsRoutes,
   ...agentComposesReadRoutes,
   ...agentComposesByIdRoutes,
+  ...agentRunsReadRoutes,
   ...agentSessionsRoutes,
   ...deviceTokenRoutes,
   ...zeroAgentInstructionsRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/agent-runs-read.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/agent-runs-read.test.ts
@@ -1,0 +1,616 @@
+import { randomUUID } from "node:crypto";
+
+import {
+  runsByIdContract,
+  runsMainContract,
+  runsQueueContract,
+} from "@vm0/api-contracts/contracts/runs";
+import { createStore } from "ccstate";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { now } from "../../../lib/time";
+import { signSandboxJwtForTests } from "../../auth/tokens";
+import {
+  createFixtureTracker,
+  createZeroRouteMocks,
+} from "./helpers/zero-route-test";
+import {
+  deleteUsageInsightFixture$,
+  seedCompose$,
+  seedRun$,
+  seedUsageInsightFixture$,
+  type UsageInsightFixture,
+} from "./helpers/zero-usage-insight";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+
+const track = createFixtureTracker<UsageInsightFixture>((fixture) => {
+  return store.set(deleteUsageInsightFixture$, fixture, context.signal);
+});
+
+function currentSecond(): number {
+  return Math.floor(now() / 1000);
+}
+
+function sandboxToken(args: {
+  readonly userId: string;
+  readonly orgId: string;
+}): string {
+  const seconds = currentSecond();
+  return signSandboxJwtForTests({
+    scope: "sandbox",
+    userId: args.userId,
+    orgId: args.orgId,
+    runId: `run_${randomUUID()}`,
+    iat: seconds,
+    exp: seconds + 60,
+  });
+}
+
+async function createFixture(): Promise<UsageInsightFixture> {
+  const fixture = await track(
+    store.set(seedUsageInsightFixture$, undefined, context.signal),
+  );
+  mocks.clerk.session(fixture.userId, fixture.orgId);
+  return fixture;
+}
+
+async function createCompose(args: {
+  readonly fixture: UsageInsightFixture;
+  readonly name?: string;
+}): Promise<{ readonly composeId: string }> {
+  return await store.set(
+    seedCompose$,
+    {
+      orgId: args.fixture.orgId,
+      userId: args.fixture.userId,
+      name: args.name,
+    },
+    context.signal,
+  );
+}
+
+function runsClient() {
+  return setupApp({ context })(runsMainContract);
+}
+
+function runByIdClient() {
+  return setupApp({ context })(runsByIdContract);
+}
+
+function queueClient() {
+  return setupApp({ context })(runsQueueContract);
+}
+
+describe("GET /api/agent/runs", () => {
+  it("returns 401 when unauthenticated", async () => {
+    const response = await accept(
+      runsClient().list({ query: {}, headers: {} }),
+      [401],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Not authenticated",
+        code: "UNAUTHORIZED",
+      },
+    });
+  });
+
+  it("uses queued, pending, and running as the default status filter", async () => {
+    const fixture = await createFixture();
+    const compose = await createCompose({ fixture });
+
+    await store.set(
+      seedRun$,
+      {
+        ...fixture,
+        composeId: compose.composeId,
+        status: "queued",
+        prompt: "queued run",
+      },
+      context.signal,
+    );
+    await store.set(
+      seedRun$,
+      {
+        ...fixture,
+        composeId: compose.composeId,
+        status: "pending",
+        prompt: "pending run",
+      },
+      context.signal,
+    );
+    await store.set(
+      seedRun$,
+      {
+        ...fixture,
+        composeId: compose.composeId,
+        status: "running",
+        prompt: "running run",
+      },
+      context.signal,
+    );
+    await store.set(
+      seedRun$,
+      {
+        ...fixture,
+        composeId: compose.composeId,
+        status: "completed",
+        prompt: "completed run",
+      },
+      context.signal,
+    );
+
+    const response = await accept(
+      runsClient().list({
+        query: {},
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    const prompts = response.body.runs.map((run) => {
+      return run.prompt;
+    });
+    expect(prompts).toStrictEqual(
+      expect.arrayContaining(["queued run", "pending run", "running run"]),
+    );
+    expect(prompts).not.toContain("completed run");
+  });
+
+  it("returns 400 for invalid status and invalid date filters", async () => {
+    const fixture = await createFixture();
+
+    const invalidStatus = await accept(
+      runsClient().list({
+        query: { status: "running,invalid" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [400],
+    );
+    expect(invalidStatus.body.error.message).toContain(
+      "Invalid status: invalid",
+    );
+
+    const invalidSince = await accept(
+      runsClient().list({
+        query: { since: "not-a-date" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [400],
+    );
+    expect(invalidSince.body.error.message).toBe(
+      "Invalid since timestamp format",
+    );
+
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    const invalidUntil = await accept(
+      runsClient().list({
+        query: { until: "not-a-date" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [400],
+    );
+    expect(invalidUntil.body.error.message).toBe(
+      "Invalid until timestamp format",
+    );
+  });
+
+  it("filters by agent name, active org, date range, and limit", async () => {
+    const fixture = await createFixture();
+    const targetCompose = await createCompose({
+      fixture,
+      name: "target-agent",
+    });
+    const otherCompose = await createCompose({ fixture, name: "other-agent" });
+    const otherOrg = await track(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    await track(
+      Promise.resolve({ orgId: otherOrg.orgId, userId: fixture.userId }),
+    );
+    const otherOrgCompose = await store.set(
+      seedCompose$,
+      {
+        orgId: otherOrg.orgId,
+        userId: otherOrg.userId,
+        name: "target-agent",
+      },
+      context.signal,
+    );
+
+    await store.set(
+      seedRun$,
+      {
+        ...fixture,
+        composeId: targetCompose.composeId,
+        status: "running",
+        prompt: "older target",
+        createdAt: new Date("2026-05-12T00:00:00.000Z"),
+      },
+      context.signal,
+    );
+    await store.set(
+      seedRun$,
+      {
+        ...fixture,
+        composeId: targetCompose.composeId,
+        status: "running",
+        prompt: "newer target",
+        createdAt: new Date("2026-05-12T00:02:00.000Z"),
+      },
+      context.signal,
+    );
+    await store.set(
+      seedRun$,
+      {
+        ...fixture,
+        composeId: otherCompose.composeId,
+        status: "running",
+        prompt: "wrong agent",
+        createdAt: new Date("2026-05-12T00:03:00.000Z"),
+      },
+      context.signal,
+    );
+    await store.set(
+      seedRun$,
+      {
+        orgId: otherOrg.orgId,
+        userId: otherOrg.userId,
+        composeId: otherOrgCompose.composeId,
+        status: "running",
+        prompt: "wrong org",
+        createdAt: new Date("2026-05-12T00:04:00.000Z"),
+      },
+      context.signal,
+    );
+
+    const response = await accept(
+      runsClient().list({
+        query: {
+          status: "running",
+          agent: "target-agent",
+          since: "2026-05-12T00:00:30.000Z",
+          until: "2026-05-12T00:03:30.000Z",
+          limit: 1,
+        },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body.runs).toHaveLength(1);
+    expect(response.body.runs[0]?.prompt).toBe("newer target");
+    expect(response.body.runs[0]?.agentName).toBe("target-agent");
+  });
+
+  it("accepts sandbox tokens for list reads", async () => {
+    const fixture = await createFixture();
+    const compose = await createCompose({ fixture });
+    await store.set(
+      seedRun$,
+      {
+        ...fixture,
+        composeId: compose.composeId,
+        status: "running",
+        prompt: "sandbox visible",
+      },
+      context.signal,
+    );
+
+    const response = await accept(
+      runsClient().list({
+        query: { status: "running" },
+        headers: {
+          authorization: `Bearer ${sandboxToken(fixture)}`,
+        },
+      }),
+      [200],
+    );
+
+    expect(
+      response.body.runs.map((run) => {
+        return run.prompt;
+      }),
+    ).toContain("sandbox visible");
+  });
+});
+
+describe("GET /api/agent/runs/:id", () => {
+  it("returns 400 when id is not a valid UUID", async () => {
+    const fixture = await createFixture();
+
+    const response = await accept(
+      runByIdClient().getById({
+        params: { id: "2b9b2303" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [400],
+    );
+
+    expect(response.body.error.code).toBe("BAD_REQUEST");
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+  });
+
+  it("returns 404 when the run is missing, owned by another user, or in another org", async () => {
+    const fixture = await createFixture();
+    const compose = await createCompose({ fixture });
+    const otherUserId = `user_${randomUUID()}`;
+    await track(Promise.resolve({ orgId: fixture.orgId, userId: otherUserId }));
+    const otherUserRun = await store.set(
+      seedRun$,
+      {
+        orgId: fixture.orgId,
+        userId: otherUserId,
+        composeId: compose.composeId,
+        status: "running",
+      },
+      context.signal,
+    );
+    const otherOrg = await track(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    const otherOrgCompose = await store.set(
+      seedCompose$,
+      {
+        orgId: otherOrg.orgId,
+        userId: fixture.userId,
+      },
+      context.signal,
+    );
+    const otherOrgRun = await store.set(
+      seedRun$,
+      {
+        orgId: otherOrg.orgId,
+        userId: fixture.userId,
+        composeId: otherOrgCompose.composeId,
+        status: "running",
+      },
+      context.signal,
+    );
+
+    const missing = await accept(
+      runByIdClient().getById({
+        params: { id: randomUUID() },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [404],
+    );
+    expect(missing.body.error.message).toBe("Agent run not found");
+
+    const wrongUser = await accept(
+      runByIdClient().getById({
+        params: { id: otherUserRun.runId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [404],
+    );
+    expect(wrongUser.body.error.message).toBe("Agent run not found");
+
+    const wrongOrg = await accept(
+      runByIdClient().getById({
+        params: { id: otherOrgRun.runId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [404],
+    );
+    expect(wrongOrg.body.error.message).toBe("Agent run not found");
+  });
+
+  it("returns run details and accepts sandbox tokens", async () => {
+    const fixture = await createFixture();
+    const compose = await createCompose({ fixture });
+    const { runId } = await store.set(
+      seedRun$,
+      {
+        ...fixture,
+        composeId: compose.composeId,
+        status: "completed",
+        prompt: "detail prompt",
+        result: {
+          output: "done",
+          executionTimeMs: 123,
+          conversationId: randomUUID(),
+        },
+        startedAt: new Date("2026-05-12T00:00:00.000Z"),
+        completedAt: new Date("2026-05-12T00:01:00.000Z"),
+      },
+      context.signal,
+    );
+
+    const response = await accept(
+      runByIdClient().getById({
+        params: { id: runId },
+        headers: { authorization: `Bearer ${sandboxToken(fixture)}` },
+      }),
+      [200],
+    );
+
+    expect(response.body).toMatchObject({
+      runId,
+      status: "completed",
+      prompt: "detail prompt",
+      result: {
+        output: "done",
+        executionTimeMs: 123,
+      },
+      startedAt: "2026-05-12T00:00:00.000Z",
+      completedAt: "2026-05-12T00:01:00.000Z",
+    });
+  });
+});
+
+describe("GET /api/agent/runs/queue", () => {
+  it("returns 401 when unauthenticated", async () => {
+    const response = await accept(
+      queueClient().getQueue({ headers: {} }),
+      [401],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Not authenticated",
+        code: "UNAUTHORIZED",
+      },
+    });
+  });
+
+  it("returns an empty queue with concurrency context", async () => {
+    const fixture = await createFixture();
+
+    const response = await accept(
+      queueClient().getQueue({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      concurrency: {
+        tier: "free",
+        limit: 1,
+        active: 0,
+        available: 1,
+      },
+      queue: [],
+      runningTasks: [],
+      estimatedTimePerRun: null,
+    });
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+  });
+
+  it("returns FIFO queue entries with privacy filtering and prompt truncation", async () => {
+    const fixture = await createFixture();
+    const compose = await createCompose({ fixture, name: "queue-agent" });
+    const otherUserId = `user_${randomUUID()}`;
+    await track(Promise.resolve({ orgId: fixture.orgId, userId: otherUserId }));
+    const sessionId = randomUUID();
+
+    await store.set(
+      seedRun$,
+      {
+        ...fixture,
+        composeId: compose.composeId,
+        status: "queued",
+        prompt: "a".repeat(250),
+        createdAt: new Date("2026-05-12T00:00:00.000Z"),
+        continuedFromSessionId: sessionId,
+      },
+      context.signal,
+    );
+    await store.set(
+      seedRun$,
+      {
+        orgId: fixture.orgId,
+        userId: otherUserId,
+        composeId: compose.composeId,
+        status: "queued",
+        prompt: "secret prompt",
+        createdAt: new Date("2026-05-12T00:01:00.000Z"),
+      },
+      context.signal,
+    );
+
+    const response = await accept(
+      queueClient().getQueue({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body.queue).toHaveLength(2);
+    const [ownEntry, otherEntry] = response.body.queue;
+    expect(ownEntry).toMatchObject({
+      position: 1,
+      agentName: "queue-agent",
+      isOwner: true,
+      prompt: `${"a".repeat(200)}...`,
+      sessionLink: `/chat/${sessionId}`,
+    });
+    expect(otherEntry).toMatchObject({
+      position: 2,
+      agentName: null,
+      userEmail: null,
+      runId: null,
+      prompt: null,
+      triggerSource: null,
+      sessionLink: null,
+      isOwner: false,
+    });
+    expect(JSON.stringify(response.body)).not.toContain("secret prompt");
+  });
+
+  it("returns running task privacy and estimated time per run", async () => {
+    const fixture = await createFixture();
+    const compose = await createCompose({ fixture, name: "runner-agent" });
+    const otherUserId = `user_${randomUUID()}`;
+    await track(Promise.resolve({ orgId: fixture.orgId, userId: otherUserId }));
+
+    await store.set(
+      seedRun$,
+      {
+        ...fixture,
+        composeId: compose.composeId,
+        status: "running",
+        startedAt: new Date("2026-05-12T00:00:00.000Z"),
+      },
+      context.signal,
+    );
+    await store.set(
+      seedRun$,
+      {
+        orgId: fixture.orgId,
+        userId: otherUserId,
+        composeId: compose.composeId,
+        status: "running",
+        startedAt: new Date("2026-05-12T00:01:00.000Z"),
+      },
+      context.signal,
+    );
+    await store.set(
+      seedRun$,
+      {
+        ...fixture,
+        composeId: compose.composeId,
+        status: "completed",
+        startedAt: new Date("2026-05-12T00:00:00.000Z"),
+        completedAt: new Date("2026-05-12T00:01:00.000Z"),
+      },
+      context.signal,
+    );
+    await store.set(
+      seedRun$,
+      {
+        ...fixture,
+        composeId: compose.composeId,
+        status: "completed",
+        startedAt: new Date("2026-05-12T00:00:00.000Z"),
+        completedAt: new Date("2026-05-12T00:02:00.000Z"),
+      },
+      context.signal,
+    );
+
+    const response = await accept(
+      queueClient().getQueue({
+        headers: { authorization: `Bearer ${sandboxToken(fixture)}` },
+      }),
+      [200],
+    );
+
+    expect(response.body.runningTasks).toHaveLength(2);
+    expect(
+      response.body.runningTasks.some((task) => {
+        return task.isOwner && task.runId !== null;
+      }),
+    ).toBeTruthy();
+    expect(
+      response.body.runningTasks.some((task) => {
+        return !task.isOwner && task.runId === null;
+      }),
+    ).toBeTruthy();
+    expect(response.body.estimatedTimePerRun).toBe(90_000);
+  });
+});

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-usage-insight.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-usage-insight.ts
@@ -35,6 +35,11 @@ interface SeedRunArgs {
   readonly scheduleId?: string;
   readonly chatThreadId?: string;
   readonly status?: string;
+  readonly prompt?: string;
+  readonly createdAt?: Date;
+  readonly startedAt?: Date | null;
+  readonly completedAt?: Date | null;
+  readonly continuedFromSessionId?: string | null;
   readonly sandboxReuseResult?: string | null;
   readonly result?: Record<string, unknown> | null;
   readonly error?: string | null;
@@ -273,9 +278,13 @@ export const seedRun$ = command(
         userId: args.userId,
         orgId: args.orgId,
         agentComposeVersionId: versionId,
-        prompt: "test prompt",
+        prompt: args.prompt ?? "test prompt",
         status: args.status ?? "pending",
         sessionId: session.id,
+        createdAt: args.createdAt,
+        startedAt: args.startedAt,
+        completedAt: args.completedAt,
+        continuedFromSessionId: args.continuedFromSessionId,
         sandboxReuseResult: args.sandboxReuseResult ?? null,
         result: args.result ?? null,
         error: args.error ?? null,

--- a/turbo/apps/api/src/signals/routes/agent-runs-read.ts
+++ b/turbo/apps/api/src/signals/routes/agent-runs-read.ts
@@ -1,0 +1,88 @@
+import { computed } from "ccstate";
+import {
+  runsByIdContract,
+  runsMainContract,
+  runsQueueContract,
+} from "@vm0/api-contracts/contracts/runs";
+
+import { organizationAuthContext$ } from "../auth/auth-context";
+import { authRoute } from "../auth/auth-route";
+import { pathParamsOf, queryOf } from "../context/request";
+import { badRequestMessage, notFound } from "../../lib/error";
+import {
+  agentRunList,
+  zeroOrgTier,
+  zeroRunById,
+  zeroRunQueueStatus,
+} from "../services/zero-runs.service";
+import type { RouteEntry } from "../route";
+
+const agentRunReadAuth = {
+  acceptAnySandboxCapability: true,
+  requireOrganization: true,
+  missingOrganizationStatus: 401,
+} as const;
+
+const runNotFound = notFound("Agent run not found");
+
+const listRunsInner$ = computed(async (get) => {
+  const auth = get(organizationAuthContext$);
+  const query = get(queryOf(runsMainContract.list));
+  const result = await get(
+    agentRunList({
+      userId: auth.userId,
+      orgId: auth.orgId,
+      status: query.status,
+      agent: query.agent,
+      since: query.since,
+      until: query.until,
+      limit: query.limit,
+    }),
+  );
+
+  if (result.kind === "bad-request") {
+    return badRequestMessage(result.message);
+  }
+
+  return { status: 200 as const, body: result.body };
+});
+
+const getRunByIdInner$ = computed(async (get) => {
+  const auth = get(organizationAuthContext$);
+  const params = get(pathParamsOf(runsByIdContract.getById));
+  const run = await get(
+    zeroRunById({ runId: params.id, userId: auth.userId, orgId: auth.orgId }),
+  );
+  if (!run) {
+    return runNotFound;
+  }
+  return { status: 200 as const, body: run };
+});
+
+const getRunQueueInner$ = computed(async (get) => {
+  const auth = get(organizationAuthContext$);
+  const orgTier = await get(zeroOrgTier(auth.orgId));
+  const queue = await get(
+    zeroRunQueueStatus({
+      userId: auth.userId,
+      orgId: auth.orgId,
+      orgTier,
+    }),
+  );
+  return { status: 200 as const, body: queue };
+});
+
+export const agentRunsReadRoutes: readonly RouteEntry[] = [
+  {
+    route: runsQueueContract.getQueue,
+    handler: authRoute(agentRunReadAuth, getRunQueueInner$),
+  },
+  {
+    route: runsMainContract.list,
+    handler: authRoute(agentRunReadAuth, listRunsInner$),
+  },
+  {
+    route: runsByIdContract.getById,
+    handler: authRoute(agentRunReadAuth, getRunByIdInner$),
+  },
+];

--- a/turbo/apps/api/src/signals/services/zero-runs.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-runs.service.ts
@@ -4,10 +4,12 @@ import {
   type TriggerSource,
 } from "@vm0/api-contracts/contracts/logs";
 import type { OrgTier } from "@vm0/api-contracts/contracts/orgs";
-import type {
-  GetRunResponse,
-  QueueResponse,
-  RunStatus,
+import {
+  ALL_RUN_STATUSES,
+  type GetRunResponse,
+  type QueueResponse,
+  type RunStatus,
+  type RunsListResponse,
 } from "@vm0/api-contracts/contracts/runs";
 import {
   sandboxReuseResultSchema,
@@ -30,8 +32,10 @@ import {
   desc,
   eq,
   gt,
+  gte,
   inArray,
   isNotNull,
+  lte,
   or,
   sql,
 } from "drizzle-orm";
@@ -51,6 +55,10 @@ const TIER_CONCURRENCY_LIMITS = Object.freeze<Record<OrgTier, number>>({
 type ReadDb = Pick<Db, "select">;
 type QueueItem = QueueResponse["queue"][number];
 type RunningTaskItem = QueueResponse["runningTasks"][number];
+
+type RunListResult =
+  | { readonly kind: "ok"; readonly body: RunsListResponse }
+  | { readonly kind: "bad-request"; readonly message: string };
 
 interface QueuedRunRow {
   readonly id: string;
@@ -289,6 +297,105 @@ export function zeroRunById(args: {
       createdAt: run.createdAt.toISOString(),
       startedAt: run.startedAt?.toISOString(),
       completedAt: run.completedAt?.toISOString(),
+    };
+  });
+}
+
+export function agentRunList(args: {
+  readonly userId: string;
+  readonly orgId: string;
+  readonly status?: string;
+  readonly agent?: string;
+  readonly since?: string;
+  readonly until?: string;
+  readonly limit: number;
+}): Computed<Promise<RunListResult>> {
+  return computed(async (get): Promise<RunListResult> => {
+    const statusValues = args.status
+      ? args.status.split(",").map((status) => {
+          return status.trim();
+        })
+      : ["queued", "pending", "running"];
+
+    for (const status of statusValues) {
+      if (!ALL_RUN_STATUSES.includes(status as RunStatus)) {
+        return {
+          kind: "bad-request",
+          message: `Invalid status: ${status}. Valid values: ${ALL_RUN_STATUSES.join(", ")}`,
+        };
+      }
+    }
+
+    const conditions = [
+      eq(agentRuns.userId, args.userId),
+      eq(agentRuns.orgId, args.orgId),
+      inArray(agentRuns.status, statusValues as RunStatus[]),
+    ];
+
+    if (args.agent) {
+      conditions.push(eq(agentComposes.name, args.agent));
+    }
+
+    if (args.since) {
+      const sinceDate = new Date(args.since);
+      if (Number.isNaN(sinceDate.getTime())) {
+        return {
+          kind: "bad-request",
+          message: "Invalid since timestamp format",
+        };
+      }
+      conditions.push(gte(agentRuns.createdAt, sinceDate));
+    }
+
+    if (args.until) {
+      const untilDate = new Date(args.until);
+      if (Number.isNaN(untilDate.getTime())) {
+        return {
+          kind: "bad-request",
+          message: "Invalid until timestamp format",
+        };
+      }
+      conditions.push(lte(agentRuns.createdAt, untilDate));
+    }
+
+    const rows = await get(db$)
+      .select({
+        id: agentRuns.id,
+        status: agentRuns.status,
+        prompt: agentRuns.prompt,
+        appendSystemPrompt: agentRuns.appendSystemPrompt,
+        createdAt: agentRuns.createdAt,
+        startedAt: agentRuns.startedAt,
+        composeName: agentComposes.name,
+      })
+      .from(agentRuns)
+      .leftJoin(
+        agentComposeVersions,
+        eq(agentRuns.agentComposeVersionId, agentComposeVersions.id),
+      )
+      .leftJoin(
+        agentComposes,
+        eq(agentComposeVersions.composeId, agentComposes.id),
+      )
+      .where(and(...conditions))
+      .orderBy(desc(agentRuns.createdAt))
+      .limit(args.limit);
+
+    return {
+      kind: "ok",
+      body: {
+        runs: rows.map((run) => {
+          return {
+            id: run.id,
+            agentName: run.composeName ?? "unknown",
+            status: run.status as RunStatus,
+            prompt: run.prompt,
+            appendSystemPrompt: run.appendSystemPrompt,
+            createdAt: run.createdAt.toISOString(),
+            startedAt: run.startedAt?.toISOString() ?? null,
+          };
+        }),
+      },
     };
   });
 }


### PR DESCRIPTION
Closes #12815

## Summary
- add apps/api handlers for GET /api/agent/runs, /api/agent/runs/:id, and /api/agent/runs/queue
- move the list-read query into the api zero-runs service while reusing existing run detail and queue services
- add integration coverage for auth, filters, sandbox tokens, queue privacy, and route registration fallout

## Tests
- pnpm -F api exec vitest run src/signals/routes/__tests__/agent-runs-read.test.ts
- pnpm -F api exec vitest run src/__tests__/app-factory.test.ts
- pnpm -F api lint
- pnpm -F api check-types
- pnpm turbo run lint
- pnpm check-types
- pnpm format
- pnpm knip
- pnpm -F @vm0/app exec vitest run src/views/org/__tests__/org-members-tab.test.tsx

## Local Full-Suite Note
- pnpm vitest failed locally in the full monorepo run with 44 unrelated @vm0/app 5s UI timeouts; the representative timed-out file above passes when isolated, and the affected API coverage passes.