### PR TITLE
refactor: migrate GitHub integration status to api backend

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/integrations-github-get.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations-github-get.test.ts
@@ -1,0 +1,407 @@
+import { randomUUID } from "node:crypto";
+
+import { createStore } from "ccstate";
+import { integrationsGithubContract } from "@vm0/api-contracts/contracts/integrations-github";
+import {
+  agentComposes,
+  agentComposeVersions,
+} from "@vm0/db/schema/agent-compose";
+import { connectors } from "@vm0/db/schema/connector";
+import { githubInstallations } from "@vm0/db/schema/github-installation";
+import { githubUserLinks } from "@vm0/db/schema/github-user-link";
+import { secrets } from "@vm0/db/schema/secret";
+import { variables } from "@vm0/db/schema/variable";
+import { and, eq } from "drizzle-orm";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { mockEnv, mockOptionalEnv } from "../../../lib/env";
+import { writeDb$ } from "../../external/db";
+
+const context = testContext();
+const store = createStore();
+const writeDb = store.set(writeDb$);
+
+interface GithubFixture {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly composeId: string;
+  readonly installationRowId: string;
+}
+
+interface SeedGithubFixtureOptions {
+  readonly admin?: "matching" | "none" | "other";
+  readonly composeName?: string;
+  readonly content?: Record<string, unknown>;
+}
+
+function authHeaders(): Record<string, string> {
+  return { authorization: "Bearer clerk-session" };
+}
+
+function mockSession(
+  userId: string,
+  orgId: string | null,
+  orgRole: "org:admin" | "org:member" | undefined = orgId
+    ? "org:admin"
+    : undefined,
+): void {
+  context.mocks.clerk.authenticateRequest.mockResolvedValue({
+    isAuthenticated: true,
+    toAuth: () => {
+      return {
+        userId,
+        orgId,
+        orgRole,
+      };
+    },
+  });
+}
+
+function githubUserId(): string {
+  return `gh_${randomUUID().replaceAll("-", "")}`;
+}
+
+function remoteInstallationId(): string {
+  return String(Math.floor(Math.random() * 9_000_000_000) + 1_000_000_000);
+}
+
+function variableReference(source: "secrets" | "vars", name: string): string {
+  return `$${"{{"} ${source}.${name} }}`;
+}
+
+async function seedGithubFixture(
+  options: SeedGithubFixtureOptions = {},
+): Promise<GithubFixture> {
+  const orgId = `org_${randomUUID()}`;
+  const userId = `user_${randomUUID()}`;
+  const composeId = randomUUID();
+  const composeName = options.composeName ?? `github-agent-${composeId}`;
+
+  await writeDb.insert(agentComposes).values({
+    id: composeId,
+    orgId,
+    userId,
+    name: composeName,
+  });
+
+  if (options.content) {
+    const versionId = randomUUID().replaceAll("-", "");
+    await writeDb.insert(agentComposeVersions).values({
+      id: versionId,
+      composeId,
+      content: options.content,
+      createdBy: userId,
+    });
+    await writeDb
+      .update(agentComposes)
+      .set({ headVersionId: versionId })
+      .where(eq(agentComposes.id, composeId));
+  }
+
+  const linkedGithubUserId = githubUserId();
+  const adminGithubUserId =
+    options.admin === "none"
+      ? null
+      : options.admin === "other"
+        ? githubUserId()
+        : linkedGithubUserId;
+
+  const [installation] = await writeDb
+    .insert(githubInstallations)
+    .values({
+      installationId: remoteInstallationId(),
+      adminGithubUserId,
+      defaultComposeId: composeId,
+      targetName: "vm0-test",
+      targetType: "Organization",
+    })
+    .returning({ id: githubInstallations.id });
+  if (!installation) {
+    throw new Error("Expected GitHub installation insert to return a row");
+  }
+
+  await writeDb.insert(githubUserLinks).values({
+    githubUserId: linkedGithubUserId,
+    installationId: installation.id,
+    vm0UserId: userId,
+  });
+
+  return {
+    orgId,
+    userId,
+    composeId,
+    installationRowId: installation.id,
+  };
+}
+
+async function cleanupGithubFixture(fixture: GithubFixture): Promise<void> {
+  await writeDb
+    .delete(connectors)
+    .where(
+      and(
+        eq(connectors.orgId, fixture.orgId),
+        eq(connectors.userId, fixture.userId),
+      ),
+    );
+  await writeDb
+    .delete(secrets)
+    .where(
+      and(eq(secrets.orgId, fixture.orgId), eq(secrets.userId, fixture.userId)),
+    );
+  await writeDb
+    .delete(variables)
+    .where(
+      and(
+        eq(variables.orgId, fixture.orgId),
+        eq(variables.userId, fixture.userId),
+      ),
+    );
+  await writeDb
+    .delete(githubInstallations)
+    .where(eq(githubInstallations.id, fixture.installationRowId));
+  await writeDb
+    .delete(agentComposeVersions)
+    .where(eq(agentComposeVersions.composeId, fixture.composeId));
+  await writeDb
+    .delete(agentComposes)
+    .where(eq(agentComposes.id, fixture.composeId));
+}
+
+async function seedSecret(args: {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly name: string;
+}): Promise<void> {
+  await writeDb.insert(secrets).values({
+    orgId: args.orgId,
+    userId: args.userId,
+    name: args.name,
+    encryptedValue: "encrypted-test-value",
+    type: "user",
+  });
+}
+
+async function seedVariable(args: {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly name: string;
+  readonly value: string;
+}): Promise<void> {
+  await writeDb.insert(variables).values({
+    orgId: args.orgId,
+    userId: args.userId,
+    name: args.name,
+    value: args.value,
+  });
+}
+
+async function seedGithubConnector(args: {
+  readonly orgId: string;
+  readonly userId: string;
+}): Promise<void> {
+  await writeDb.insert(connectors).values({
+    orgId: args.orgId,
+    userId: args.userId,
+    type: "github",
+    authMethod: "oauth",
+    externalId: githubUserId(),
+    externalUsername: "octocat",
+    externalEmail: "octocat@example.test",
+    oauthScopes: JSON.stringify(["repo"]),
+  });
+}
+
+describe("GET /api/integrations/github", () => {
+  const fixtures: GithubFixture[] = [];
+
+  beforeEach(() => {
+    context.mocks.clerk.authenticateRequest.mockReset();
+    context.mocks.clerk.authenticateRequest.mockResolvedValue({
+      isAuthenticated: false,
+    });
+  });
+
+  afterEach(async () => {
+    while (fixtures.length > 0) {
+      const fixture = fixtures.pop();
+      if (fixture) {
+        await cleanupGithubFixture(fixture);
+      }
+    }
+  });
+
+  it("returns 401 when no user is authenticated", async () => {
+    const client = setupApp({ context })(integrationsGithubContract);
+
+    const response = await accept(
+      client.getInstallation({ headers: {} }),
+      [401],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("returns 404 with installUrl when the authenticated user has no GitHub installation", async () => {
+    const userId = `user_${randomUUID()}`;
+    mockSession(userId, null);
+    mockEnv("VM0_API_URL", "https://api.vm0.test");
+    mockOptionalEnv("GITHUB_APP_SLUG", "vm0-test");
+    const client = setupApp({ context })(integrationsGithubContract);
+
+    const response = await accept(
+      client.getInstallation({ headers: authHeaders() }),
+      [404],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "No GitHub installation found",
+        code: "NOT_FOUND",
+      },
+      installUrl: `https://api.vm0.test/api/github/oauth/install?vm0UserId=${encodeURIComponent(
+        userId,
+      )}`,
+    });
+  });
+
+  it("returns linked installation data and agent data", async () => {
+    const fixture = await seedGithubFixture({
+      composeName: "github-support-agent",
+    });
+    fixtures.push(fixture);
+    mockSession(fixture.userId, fixture.orgId);
+    const client = setupApp({ context })(integrationsGithubContract);
+
+    const response = await accept(
+      client.getInstallation({ headers: authHeaders() }),
+      [200],
+    );
+
+    expect(response.body.installation).toMatchObject({
+      id: fixture.installationRowId,
+      status: "active",
+      targetName: "vm0-test",
+      targetType: "Organization",
+      isAdmin: true,
+    });
+    expect(response.body.installation.installationId).toBeTruthy();
+    expect(response.body.agent).toStrictEqual({
+      id: fixture.composeId,
+      name: "github-support-agent",
+    });
+    expect(response.body.environment).toStrictEqual({
+      requiredSecrets: [],
+      requiredVars: [],
+      missingSecrets: [],
+      missingVars: [],
+    });
+  });
+
+  it("returns isAdmin false when the linked GitHub user is not the installation admin", async () => {
+    const fixture = await seedGithubFixture({ admin: "other" });
+    fixtures.push(fixture);
+    mockSession(fixture.userId, fixture.orgId);
+    const client = setupApp({ context })(integrationsGithubContract);
+
+    const response = await accept(
+      client.getInstallation({ headers: authHeaders() }),
+      [200],
+    );
+
+    expect(response.body.installation.isAdmin).toBeFalsy();
+  });
+
+  it("returns isAdmin false when the installation has no admin GitHub user", async () => {
+    const fixture = await seedGithubFixture({ admin: "none" });
+    fixtures.push(fixture);
+    mockSession(fixture.userId, fixture.orgId);
+    const client = setupApp({ context })(integrationsGithubContract);
+
+    const response = await accept(
+      client.getInstallation({ headers: authHeaders() }),
+      [200],
+    );
+
+    expect(response.body.installation.isAdmin).toBeFalsy();
+  });
+
+  it("reports required and missing environment values from the default agent", async () => {
+    const fixture = await seedGithubFixture({
+      content: {
+        agents: {
+          main: {
+            env: {
+              PRESENT_SECRET: variableReference("secrets", "PRESENT_SECRET"),
+              MISSING_SECRET: variableReference("secrets", "MISSING_SECRET"),
+              GITHUB_TOKEN: variableReference("secrets", "GITHUB_TOKEN"),
+              PRESENT_VAR: variableReference("vars", "PRESENT_VAR"),
+              MISSING_VAR: variableReference("vars", "MISSING_VAR"),
+            },
+          },
+        },
+      },
+    });
+    fixtures.push(fixture);
+    await seedSecret({
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      name: "PRESENT_SECRET",
+    });
+    await seedVariable({
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      name: "PRESENT_VAR",
+      value: "ready",
+    });
+    await seedGithubConnector({
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+    });
+    mockSession(fixture.userId, fixture.orgId);
+    const client = setupApp({ context })(integrationsGithubContract);
+
+    const response = await accept(
+      client.getInstallation({ headers: authHeaders() }),
+      [200],
+    );
+
+    expect(response.body.environment.requiredSecrets).toStrictEqual(
+      expect.arrayContaining([
+        "PRESENT_SECRET",
+        "MISSING_SECRET",
+        "GITHUB_TOKEN",
+      ]),
+    );
+    expect(response.body.environment.requiredVars).toStrictEqual(
+      expect.arrayContaining(["PRESENT_VAR", "MISSING_VAR"]),
+    );
+    expect(response.body.environment.missingSecrets).toStrictEqual([
+      "MISSING_SECRET",
+    ]);
+    expect(response.body.environment.missingVars).toStrictEqual([
+      "MISSING_VAR",
+    ]);
+  });
+
+  it("returns 400 after installation lookup when active org context is missing", async () => {
+    const fixture = await seedGithubFixture();
+    fixtures.push(fixture);
+    mockSession(fixture.userId, null);
+    const client = setupApp({ context })(integrationsGithubContract);
+
+    const response = await accept(
+      client.getInstallation({ headers: authHeaders() }),
+      [400],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Explicit org context required — ensure active org in session",
+        code: "BAD_REQUEST",
+      },
+    });
+  });
+});

--- a/turbo/apps/api/src/signals/routes/integrations-github.ts
+++ b/turbo/apps/api/src/signals/routes/integrations-github.ts
@@ -1,10 +1,17 @@
 import { integrationsGithubContract } from "@vm0/api-contracts/contracts/integrations-github";
 
 import { authRoute } from "../auth/auth-route";
-import { deleteGithubInstallation$ } from "../services/integrations-github.service";
+import {
+  deleteGithubInstallation$,
+  getGithubInstallation$,
+} from "../services/integrations-github.service";
 import type { RouteEntry } from "../route";
 
 export const integrationsGithubRoutes: readonly RouteEntry[] = [
+  {
+    route: integrationsGithubContract.getInstallation,
+    handler: authRoute({}, getGithubInstallation$),
+  },
   {
     route: integrationsGithubContract.deleteInstallation,
     handler: authRoute({}, deleteGithubInstallation$),

--- a/turbo/apps/api/src/signals/services/integrations-github.service.ts
+++ b/turbo/apps/api/src/signals/services/integrations-github.service.ts
@@ -1,25 +1,53 @@
 import { Buffer } from "node:buffer";
 import { createSign } from "node:crypto";
-import { command } from "ccstate";
+import { command, computed } from "ccstate";
+import type { GithubInstallationResponse } from "@vm0/api-contracts/contracts/integrations-github";
+import { extractAndGroupVariables } from "@vm0/core/variable-expander";
+import { getConnectorProvidedSecretNames } from "@vm0/connectors/connector-utils";
+import {
+  agentComposes,
+  agentComposeVersions,
+} from "@vm0/db/schema/agent-compose";
 import { githubInstallations } from "@vm0/db/schema/github-installation";
 import { githubUserLinks } from "@vm0/db/schema/github-user-link";
 import { eq } from "drizzle-orm";
 
 import { authContext$ } from "../auth/auth-context";
-import { writeDb$ } from "../external/db";
-import { optionalEnv } from "../../lib/env";
+import { db$, writeDb$ } from "../external/db";
+import { env, optionalEnv } from "../../lib/env";
 import { logger } from "../../lib/log";
 import { now } from "../../lib/time";
+import { zeroConnectorList } from "./zero-connector-data.service";
+import { userSecrets, userVariables } from "./zero-user-data.service";
 
 const INSTALLATION_ID_RE = /^\d+$/;
 const L = logger("IntegrationsGithub");
 
 function errorResponse(
-  status: 401 | 403 | 404 | 500,
+  status: 400 | 401 | 403 | 404 | 500,
   message: string,
   code: string,
 ) {
   return { status, body: { error: { message, code } } };
+}
+
+function githubInstallUrl(userId: string): string | null {
+  if (!optionalEnv("GITHUB_APP_SLUG")) {
+    return null;
+  }
+
+  const url = new URL("/api/github/oauth/install", env("VM0_API_URL"));
+  url.searchParams.set("vm0UserId", userId);
+  return url.toString();
+}
+
+function emptyEnvironment(): GithubInstallationResponse["environment"] {
+  return {
+    requiredSecrets: [],
+    requiredVars: [],
+    missingSecrets: [],
+    missingVars: [],
+  };
 }
 
 function validateInstallationId(installationId: string): string {
@@ -182,3 +210,135 @@ export const deleteGithubInstallation$ = command(
     return { status: 200 as const, body: { ok: true as const } };
   },
 );
+
+export const getGithubInstallation$ = computed(async (get) => {
+  const auth = get(authContext$);
+  const db = get(db$);
+
+  const [result] = await db
+    .select({
+      installation: {
+        id: githubInstallations.id,
+        installationId: githubInstallations.installationId,
+        status: githubInstallations.status,
+        targetName: githubInstallations.targetName,
+        targetType: githubInstallations.targetType,
+        adminGithubUserId: githubInstallations.adminGithubUserId,
+        defaultComposeId: githubInstallations.defaultComposeId,
+      },
+      githubUserId: githubUserLinks.githubUserId,
+    })
+    .from(githubUserLinks)
+    .innerJoin(
+      githubInstallations,
+      eq(githubInstallations.id, githubUserLinks.installationId),
+    )
+    .where(eq(githubUserLinks.vm0UserId, auth.userId))
+    .limit(1);
+
+  if (!result) {
+    return {
+      status: 404 as const,
+      body: {
+        error: {
+          message: "No GitHub installation found",
+          code: "NOT_FOUND",
+        },
+        installUrl: githubInstallUrl(auth.userId),
+      },
+    };
+  }
+
+  const installation = result.installation;
+  const isAdmin =
+    installation.adminGithubUserId !== null &&
+    result.githubUserId === installation.adminGithubUserId;
+
+  const [compose] = await db
+    .select({
+      id: agentComposes.id,
+      name: agentComposes.name,
+      headVersionId: agentComposes.headVersionId,
+    })
+    .from(agentComposes)
+    .where(eq(agentComposes.id, installation.defaultComposeId))
+    .limit(1);
+
+  let environment = emptyEnvironment();
+
+  if (compose?.headVersionId) {
+    const [version] = await db
+      .select({ content: agentComposeVersions.content })
+      .from(agentComposeVersions)
+      .where(eq(agentComposeVersions.id, compose.headVersionId))
+      .limit(1);
+
+    if (version) {
+      const grouped = extractAndGroupVariables(version.content);
+      environment = {
+        requiredSecrets: grouped.secrets.map((secret) => {
+          return secret.name;
+        }),
+        requiredVars: grouped.vars.map((variable) => {
+          return variable.name;
+        }),
+        missingSecrets: [],
+        missingVars: [],
+      };
+    }
+  }
+
+  if (!auth.orgId) {
+    return errorResponse(
+      400,
+      "Explicit org context required — ensure active org in session",
+      "BAD_REQUEST",
+    );
+  }
+
+  const [secretList, variableList, connectorList] = await Promise.all([
+    get(userSecrets({ orgId: auth.orgId, userId: auth.userId })),
+    get(userVariables({ orgId: auth.orgId, userId: auth.userId })),
+    get(zeroConnectorList({ orgId: auth.orgId, userId: auth.userId })),
+  ]);
+
+  const connectorProvided = getConnectorProvidedSecretNames(
+    connectorList.connectors.map((connector) => {
+      return connector.type;
+    }),
+  );
+  const existingSecretNames = new Set([
+    ...secretList.secrets.map((secret) => {
+      return secret.name;
+    }),
+    ...connectorProvided,
+  ]);
+  const existingVarNames = new Set(
+    variableList.variables.map((variable) => {
+      return variable.name;
+    }),
+  );
+
+  const body: GithubInstallationResponse = {
+    installation: {
+      id: installation.id,
+      installationId: installation.installationId,
+      status: installation.status,
+      targetName: installation.targetName,
+      targetType: installation.targetType,
+      isAdmin,
+    },
+    agent: compose ? { id: compose.id, name: compose.name } : null,
+    environment: {
+      ...environment,
+      missingSecrets: environment.requiredSecrets.filter((name) => {
+        return !existingSecretNames.has(name);
+      }),
+      missingVars: environment.requiredVars.filter((name) => {
+        return !existingVarNames.has(name);
+      }),
+    },
+  };
+
+  return { status: 200 as const, body };
+});

--- a/turbo/packages/api-contracts/src/contracts/integrations-github.ts
+++ b/turbo/packages/api-contracts/src/contracts/integrations-github.ts
@@ -4,6 +4,43 @@ import { apiErrorSchema } from "./errors";
 
 const c = initContract();
 
+export const githubInstallationEnvironmentSchema = z.object({
+  requiredSecrets: z.array(z.string()),
+  requiredVars: z.array(z.string()),
+  missingSecrets: z.array(z.string()),
+  missingVars: z.array(z.string()),
+});
+
+export const githubInstallationResponseSchema = z.object({
+  installation: z.object({
+    id: z.string(),
+    installationId: z.string().nullable(),
+    status: z.string(),
+    targetName: z.string().nullable(),
+    targetType: z.string().nullable(),
+    isAdmin: z.boolean(),
+  }),
+  agent: z
+    .object({
+      id: z.string(),
+      name: z.string(),
+    })
+    .nullable(),
+  environment: githubInstallationEnvironmentSchema,
+});
+
+export type GithubInstallationResponse = z.infer<
+  typeof githubInstallationResponseSchema
+>;
+
+export const githubInstallationNotFoundResponseSchema = apiErrorSchema.extend({
+  installUrl: z.string().nullable(),
+});
+
+export type GithubInstallationNotFoundResponse = z.infer<
+  typeof githubInstallationNotFoundResponseSchema
+>;
+
 export const deleteGithubInstallationResponseSchema = z.object({
   ok: z.literal(true),
 });
@@ -13,6 +50,20 @@ export type DeleteGithubInstallationResponse = z.infer<
 >;
 
 export const integrationsGithubContract = c.router({
+  getInstallation: {
+    method: "GET",
+    path: "/api/integrations/github",
+    headers: authHeadersSchema,
+    responses: {
+      200: githubInstallationResponseSchema,
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      404: githubInstallationNotFoundResponseSchema,
+      500: apiErrorSchema,
+    },
+    summary: "Get the authenticated user's GitHub App installation",
+  },
+
   deleteInstallation: {
     method: "DELETE",
     path: "/api/integrations/github",


### PR DESCRIPTION
## Summary
- add the GET /api/integrations/github contract and API route registration
- implement the read-only API handler for linked GitHub installation status and environment completeness
- add API route integration coverage for auth, not-found install URL, admin state, missing org context, and required/missing environment values

Fixes #12824

## Testing
- pnpm exec vitest run src/signals/routes/__tests__/integrations-github-get.test.ts src/signals/routes/__tests__/integrations-github-delete.test.ts (from apps/api)
- pnpm -F api lint
- pnpm -F @vm0/api-contracts lint
- pnpm -F @vm0/api-contracts check-types
- pnpm exec prettier --check apps/api/src/signals/services/integrations-github.service.ts apps/api/src/signals/routes/integrations-github.ts apps/api/src/signals/routes/__tests__/integrations-github-get.test.ts packages/api-contracts/src/contracts/integrations-github.ts
- git diff --check
- pnpm knip --cache

## Notes
- pnpm -F api check-types is still blocked by the existing ts-rest test inference baseline on main; filtering the output for integrations-github/GithubInstallation/getGithubInstallation found no matching errors.