### PR TITLE
refactor(api): migrate test telegram state delete route

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/test-telegram-state.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/test-telegram-state.test.ts
@@ -1,18 +1,21 @@
 import { randomUUID } from "node:crypto";
 
 import { createStore } from "ccstate";
-import { eq } from "drizzle-orm";
+import { count, eq, inArray } from "drizzle-orm";
 
 import {
   agentComposes,
   agentComposeVersions,
 } from "@vm0/db/schema/agent-compose";
+import { agentRuns } from "@vm0/db/schema/agent-run";
+import { agentSessions } from "@vm0/db/schema/agent-session";
 import { e2eTelegramMockCallLog } from "@vm0/db/schema/e2e-telegram-mock-call-log";
 import { orgMetadata } from "@vm0/db/schema/org-metadata";
 import { telegramInstallations } from "@vm0/db/schema/telegram-installation";
 import { telegramMessages } from "@vm0/db/schema/telegram-message";
 import { telegramUserLinks } from "@vm0/db/schema/telegram-user-link";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
+import { zeroRuns } from "@vm0/db/schema/zero-run";
 
 import { createApp } from "../../../app-factory";
 import { mockEnv, mockOptionalEnv } from "../../../lib/env";
@@ -25,6 +28,7 @@ const store = createStore();
 
 interface SeededTelegramState {
   readonly botId: string;
+  readonly userId: string;
   readonly orgId: string;
   readonly composeId: string;
   readonly versionId: string;
@@ -119,11 +123,30 @@ async function seedTelegramState(): Promise<SeededTelegramState> {
     bodyJson: { ok: true },
   });
 
-  return { botId, orgId, composeId, versionId, chatId };
+  return { botId, userId, orgId, composeId, versionId, chatId };
 }
 
 async function cleanupTelegramState(state: SeededTelegramState): Promise<void> {
   const writeDb = store.set(writeDb$);
+  const runRows = await writeDb
+    .select({ id: agentRuns.id, sessionId: agentRuns.sessionId })
+    .from(agentRuns)
+    .where(eq(agentRuns.orgId, state.orgId));
+  const runIds = runRows.map((run) => {
+    return run.id;
+  });
+  if (runIds.length > 0) {
+    await writeDb.delete(zeroRuns).where(inArray(zeroRuns.id, runIds));
+    await writeDb.delete(agentRuns).where(inArray(agentRuns.id, runIds));
+  }
+  const sessionIds = runRows.map((run) => {
+    return run.sessionId;
+  });
+  if (sessionIds.length > 0) {
+    await writeDb
+      .delete(agentSessions)
+      .where(inArray(agentSessions.id, sessionIds));
+  }
   await writeDb
     .delete(e2eTelegramMockCallLog)
     .where(eq(e2eTelegramMockCallLog.chatId, state.chatId));
@@ -147,6 +170,79 @@ async function cleanupTelegramState(state: SeededTelegramState): Promise<void> {
 }
 
 const trackTelegramState = createFixtureTracker(cleanupTelegramState);
+
+async function seedRun(
+  state: SeededTelegramState,
+  triggerSource: "slack" | "telegram",
+): Promise<string> {
+  const writeDb = store.set(writeDb$);
+  const sessionId = randomUUID();
+  const runId = randomUUID();
+  await writeDb.insert(agentSessions).values({
+    id: sessionId,
+    userId: state.userId,
+    orgId: state.orgId,
+    agentComposeId: state.composeId,
+  });
+  await writeDb.insert(agentRuns).values({
+    id: runId,
+    userId: state.userId,
+    orgId: state.orgId,
+    sessionId,
+    status: "completed",
+    prompt: `${triggerSource} diagnostic run`,
+  });
+  await writeDb.insert(zeroRuns).values({
+    id: runId,
+    triggerSource,
+  });
+  return runId;
+}
+
+async function countInstallations(botId: string): Promise<number> {
+  const writeDb = store.set(writeDb$);
+  const [row] = await writeDb
+    .select({ value: count() })
+    .from(telegramInstallations)
+    .where(eq(telegramInstallations.telegramBotId, botId));
+  return row?.value ?? 0;
+}
+
+async function countLinks(botId: string): Promise<number> {
+  const writeDb = store.set(writeDb$);
+  const [row] = await writeDb
+    .select({ value: count() })
+    .from(telegramUserLinks)
+    .where(eq(telegramUserLinks.installationId, botId));
+  return row?.value ?? 0;
+}
+
+async function countMessages(botId: string): Promise<number> {
+  const writeDb = store.set(writeDb$);
+  const [row] = await writeDb
+    .select({ value: count() })
+    .from(telegramMessages)
+    .where(eq(telegramMessages.installationId, botId));
+  return row?.value ?? 0;
+}
+
+async function countAgentRuns(runId: string): Promise<number> {
+  const writeDb = store.set(writeDb$);
+  const [row] = await writeDb
+    .select({ value: count() })
+    .from(agentRuns)
+    .where(eq(agentRuns.id, runId));
+  return row?.value ?? 0;
+}
+
+async function countZeroRuns(runId: string): Promise<number> {
+  const writeDb = store.set(writeDb$);
+  const [row] = await writeDb
+    .select({ value: count() })
+    .from(zeroRuns)
+    .where(eq(zeroRuns.id, runId));
+  return row?.value ?? 0;
+}
 
 describe("GET /api/test/telegram-state", () => {
   it("returns 404 when the test endpoint is not allowed", async () => {
@@ -237,5 +333,73 @@ describe("GET /api/test/telegram-state", () => {
         return call.chatId === seeded.chatId && call.method === "sendMessage";
       }),
     ).toBeTruthy();
+  });
+});
+
+describe("DELETE /api/test/telegram-state", () => {
+  it("returns 404 when the test endpoint is not allowed", async () => {
+    mockEnv("ENV", "production");
+
+    const response = await requestApp("/api/test/telegram-state?bot_id=bot-1", {
+      method: "DELETE",
+    });
+
+    expect(response.status).toBe(404);
+    await expect(response.text()).resolves.toBe("Not found");
+  });
+
+  it("returns 400 when bot_id is missing", async () => {
+    mockEnv("ENV", "development");
+
+    const response = await requestApp("/api/test/telegram-state", {
+      method: "DELETE",
+    });
+
+    expect(response.status).toBe(400);
+    await expect(readJson<{ error: string }>(response)).resolves.toStrictEqual({
+      error: "bot_id query param is required",
+    });
+  });
+
+  it("returns ok for an unknown bot without deleting unrelated state", async () => {
+    mockEnv("ENV", "development");
+    const seeded = await trackTelegramState(seedTelegramState());
+
+    const response = await requestApp(
+      `/api/test/telegram-state?bot_id=missing_${randomUUID()}`,
+      { method: "DELETE" },
+    );
+
+    expect(response.status).toBe(200);
+    await expect(readJson<{ ok: true }>(response)).resolves.toStrictEqual({
+      ok: true,
+    });
+    await expect(countInstallations(seeded.botId)).resolves.toBe(1);
+    await expect(countLinks(seeded.botId)).resolves.toBe(1);
+    await expect(countMessages(seeded.botId)).resolves.toBe(1);
+  });
+
+  it("deletes Telegram state and only Telegram-triggered runs for the bot org", async () => {
+    mockEnv("ENV", "development");
+    const seeded = await trackTelegramState(seedTelegramState());
+    const telegramRunId = await seedRun(seeded, "telegram");
+    const slackRunId = await seedRun(seeded, "slack");
+
+    const response = await requestApp(
+      `/api/test/telegram-state?bot_id=${seeded.botId}`,
+      { method: "DELETE" },
+    );
+
+    expect(response.status).toBe(200);
+    await expect(readJson<{ ok: true }>(response)).resolves.toStrictEqual({
+      ok: true,
+    });
+    await expect(countInstallations(seeded.botId)).resolves.toBe(0);
+    await expect(countLinks(seeded.botId)).resolves.toBe(0);
+    await expect(countMessages(seeded.botId)).resolves.toBe(0);
+    await expect(countZeroRuns(telegramRunId)).resolves.toBe(0);
+    await expect(countAgentRuns(telegramRunId)).resolves.toBe(0);
+    await expect(countZeroRuns(slackRunId)).resolves.toBe(1);
+    await expect(countAgentRuns(slackRunId)).resolves.toBe(1);
   });
 });

--- a/turbo/apps/api/src/signals/routes/test-telegram-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-telegram-state.ts
@@ -1,5 +1,5 @@
-import { computed } from "ccstate";
-import { desc, eq, sql } from "drizzle-orm";
+import { command, computed } from "ccstate";
+import { and, desc, eq, inArray, sql } from "drizzle-orm";
 import { testTelegramStateContract } from "@vm0/api-contracts/contracts/test-telegram-state";
 import {
   agentComposes,
@@ -17,7 +17,7 @@ import { zeroRuns } from "@vm0/db/schema/zero-run";
 import { optionalEnv } from "../../lib/env";
 import { request$ } from "../context/hono";
 import { queryOf } from "../context/request";
-import { db$, type ReadonlyDb } from "../external/db";
+import { db$, type ReadonlyDb, writeDb$ } from "../external/db";
 import type { RouteEntry } from "../route";
 import {
   isTestEndpointAllowed,
@@ -25,6 +25,7 @@ import {
 } from "./test-oauth-provider-helpers";
 
 const testTelegramStateQuery$ = queryOf(testTelegramStateContract.get);
+const deleteTestTelegramStateQuery$ = queryOf(testTelegramStateContract.delete);
 
 function resolveTelegramApiUrlForDiagnostics(): string | null {
   const telegramApiUrl = optionalEnv("TELEGRAM_API_URL");
@@ -241,9 +242,82 @@ const getTestTelegramState$ = computed(async (get) => {
   };
 });
 
+const deleteTestTelegramState$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const request = get(request$);
+    if (!isTestEndpointAllowed(request)) {
+      return testEndpointNotFoundResponse();
+    }
+
+    const query = get(deleteTestTelegramStateQuery$);
+    if (!query.bot_id) {
+      return {
+        status: 400 as const,
+        body: { error: "bot_id query param is required" },
+      };
+    }
+
+    const botId = query.bot_id;
+    const db = set(writeDb$);
+    const [existing] = await db
+      .select({ orgId: telegramInstallations.orgId })
+      .from(telegramInstallations)
+      .where(eq(telegramInstallations.telegramBotId, botId))
+      .limit(1);
+    signal.throwIfAborted();
+
+    await db
+      .delete(telegramMessages)
+      .where(eq(telegramMessages.installationId, botId));
+    signal.throwIfAborted();
+
+    await db
+      .delete(telegramUserLinks)
+      .where(eq(telegramUserLinks.installationId, botId));
+    signal.throwIfAborted();
+
+    await db
+      .delete(telegramInstallations)
+      .where(eq(telegramInstallations.telegramBotId, botId));
+    signal.throwIfAborted();
+
+    if (existing?.orgId) {
+      const telegramAgentRuns = await db
+        .select({ id: agentRuns.id })
+        .from(agentRuns)
+        .innerJoin(zeroRuns, eq(agentRuns.id, zeroRuns.id))
+        .where(
+          and(
+            eq(agentRuns.orgId, existing.orgId),
+            eq(zeroRuns.triggerSource, "telegram"),
+          ),
+        );
+      signal.throwIfAborted();
+
+      const ids = telegramAgentRuns.map((run) => {
+        return run.id;
+      });
+
+      if (ids.length > 0) {
+        await db.delete(zeroRuns).where(inArray(zeroRuns.id, ids));
+        signal.throwIfAborted();
+
+        await db.delete(agentRuns).where(inArray(agentRuns.id, ids));
+        signal.throwIfAborted();
+      }
+    }
+
+    return { status: 200 as const, body: { ok: true as const } };
+  },
+);
+
 export const testTelegramStateRoutes: readonly RouteEntry[] = [
   {
     route: testTelegramStateContract.get,
     handler: getTestTelegramState$,
+  },
+  {
+    route: testTelegramStateContract.delete,
+    handler: deleteTestTelegramState$,
   },
 ];

--- a/turbo/packages/api-contracts/src/contracts/test-telegram-state.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-telegram-state.ts
@@ -30,6 +30,10 @@ export const testTelegramStateResponseSchema = z.object({
   mock_calls: z.array(z.unknown()),
 });
 
+export const testTelegramStateDeleteResponseSchema = z.object({
+  ok: z.literal(true),
+});
+
 export const testTelegramStateContract = c.router({
   get: {
     method: "GET",
@@ -41,6 +45,17 @@ export const testTelegramStateContract = c.router({
       404: z.string(),
     },
     summary: "Inspect Telegram E2E test state",
+  },
+  delete: {
+    method: "DELETE",
+    path: "/api/test/telegram-state",
+    query: testTelegramStateQuerySchema,
+    responses: {
+      200: testTelegramStateDeleteResponseSchema,
+      400: testTelegramStateErrorSchema,
+      404: z.string(),
+    },
+    summary: "Delete Telegram E2E test state",
   },
 });
 


### PR DESCRIPTION
Closes #12803

## Summary
- Add DELETE /api/test/telegram-state to the shared ts-rest contract.
- Implement the API backend cleanup command with test endpoint guard, bot_id validation, Telegram state cleanup, and Telegram-triggered run cleanup.
- Extend API integration tests for guard, validation, unknown bot no-op, and seeded cleanup behavior.

## Validation
- pnpm install
- pnpm -F api exec vitest run src/signals/routes/__tests__/test-telegram-state.test.ts
- pnpm format
- pnpm -F api lint
- pnpm -F api check-types
- pnpm -F @vm0/api-contracts lint
- pnpm -F @vm0/api-contracts check-types
- pnpm turbo run lint
- pnpm check-types
- pnpm knip
- git diff --check