### PR TITLE
refactor: migrate integrations chat message route to api

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -64,6 +64,7 @@ import { zeroMeModelProvidersUpsertRoutes } from "./routes/zero-me-model-provide
 import { zeroSecretsRoutes } from "./routes/zero-secrets";
 import { zeroSkillsRoutes } from "./routes/zero-skills";
 import { integrationsGithubRoutes } from "./routes/integrations-github";
+import { zeroIntegrationsChatMessageRoutes } from "./routes/zero-integrations-chat-message";
 import { zeroIntegrationsSlackRoutes } from "./routes/zero-integrations-slack";
 import { zeroIntegrationsSlackMessageRoutes } from "./routes/zero-integrations-slack-message";
 import { zeroIntegrationsSlackUploadCompleteRoutes } from "./routes/zero-integrations-slack-upload-complete";
@@ -179,6 +180,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...zeroSlackBrowserConnectRoutes,
   ...zeroSlackConnectRoutes,
   ...zeroSlackOauthRoutes,
+  ...zeroIntegrationsChatMessageRoutes,
   ...zeroIntegrationsSlackRoutes,
   ...zeroIntegrationsSlackMessageRoutes,
   ...zeroIntegrationsSlackUploadCompleteRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-chat-message.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-chat-message.test.ts
@@ -1,0 +1,376 @@
+import { randomUUID } from "node:crypto";
+
+import { createStore, command } from "ccstate";
+import { afterEach, describe, expect, it } from "vitest";
+import { and, eq, inArray } from "drizzle-orm";
+import { integrationsChatMessageContract } from "@vm0/api-contracts/contracts/integrations";
+import { chatMessages } from "@vm0/db/schema/chat-message";
+import { chatThreads } from "@vm0/db/schema/chat-thread";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { now } from "../../../lib/time";
+import { signSandboxJwtForTests } from "../../auth/tokens";
+import { writeDb$ } from "../../external/db";
+import {
+  deleteOrgMembership$,
+  seedOrgMembership$,
+  type OrgMembershipFixture,
+} from "./helpers/zero-org-membership";
+import {
+  deleteTeamCompose$,
+  seedTeamCompose$,
+  type TeamComposeFixture,
+} from "./helpers/zero-team";
+import {
+  deleteZeroChatThread$,
+  seedZeroChatThread$,
+  type ZeroChatThreadFixture,
+} from "./helpers/zero-chat-threads";
+
+const context = testContext();
+const store = createStore();
+
+const deleteCreatedThreads$ = command(
+  async (
+    { set },
+    threadIds: readonly string[],
+    signal: AbortSignal,
+  ): Promise<void> => {
+    if (threadIds.length === 0) {
+      return;
+    }
+    const writeDb = set(writeDb$);
+    await writeDb
+      .delete(chatMessages)
+      .where(inArray(chatMessages.chatThreadId, [...threadIds]));
+    signal.throwIfAborted();
+    await writeDb
+      .delete(chatThreads)
+      .where(inArray(chatThreads.id, [...threadIds]));
+    signal.throwIfAborted();
+  },
+);
+
+function zeroToken(args: {
+  readonly userId: string;
+  readonly orgId: string;
+  readonly runId?: string;
+  readonly capabilities?: readonly string[];
+}): string {
+  const seconds = Math.floor(now() / 1000);
+  return signSandboxJwtForTests({
+    scope: "zero",
+    userId: args.userId,
+    orgId: args.orgId,
+    runId: args.runId ?? `run_${randomUUID()}`,
+    capabilities: (args.capabilities ?? ["chat-message:write"]) as never,
+    iat: seconds,
+    exp: seconds + 60,
+  });
+}
+
+function sandboxToken(args: {
+  readonly userId: string;
+  readonly orgId: string;
+  readonly runId?: string;
+}): string {
+  const seconds = Math.floor(now() / 1000);
+  return signSandboxJwtForTests({
+    scope: "sandbox",
+    userId: args.userId,
+    orgId: args.orgId,
+    runId: args.runId ?? `run_${randomUUID()}`,
+    iat: seconds,
+    exp: seconds + 60,
+  });
+}
+
+async function messageRow(messageId: string): Promise<{
+  readonly id: string;
+  readonly chatThreadId: string;
+  readonly role: string;
+  readonly content: string | null;
+  readonly runId: string | null;
+} | null> {
+  const writeDb = store.set(writeDb$);
+  const [row] = await writeDb
+    .select({
+      id: chatMessages.id,
+      chatThreadId: chatMessages.chatThreadId,
+      role: chatMessages.role,
+      content: chatMessages.content,
+      runId: chatMessages.runId,
+    })
+    .from(chatMessages)
+    .where(eq(chatMessages.id, messageId))
+    .limit(1);
+  return row ?? null;
+}
+
+async function threadRow(threadId: string): Promise<{
+  readonly id: string;
+  readonly userId: string;
+  readonly agentComposeId: string;
+  readonly title: string | null;
+} | null> {
+  const writeDb = store.set(writeDb$);
+  const [row] = await writeDb
+    .select({
+      id: chatThreads.id,
+      userId: chatThreads.userId,
+      agentComposeId: chatThreads.agentComposeId,
+      title: chatThreads.title,
+    })
+    .from(chatThreads)
+    .where(eq(chatThreads.id, threadId))
+    .limit(1);
+  return row ?? null;
+}
+
+async function countMessagesForThread(threadId: string): Promise<number> {
+  const writeDb = store.set(writeDb$);
+  const rows = await writeDb
+    .select({ id: chatMessages.id })
+    .from(chatMessages)
+    .where(
+      and(
+        eq(chatMessages.chatThreadId, threadId),
+        eq(chatMessages.role, "assistant"),
+      ),
+    );
+  return rows.length;
+}
+
+describe("POST /api/zero/integrations/chat/message", () => {
+  const memberships: OrgMembershipFixture[] = [];
+  const teamFixtures: TeamComposeFixture[] = [];
+  const threadFixtures: ZeroChatThreadFixture[] = [];
+  const createdThreadIds: string[] = [];
+
+  afterEach(async () => {
+    await store.set(deleteCreatedThreads$, createdThreadIds, context.signal);
+    createdThreadIds.length = 0;
+    while (threadFixtures.length > 0) {
+      const fixture = threadFixtures.pop();
+      if (fixture) {
+        await store.set(deleteZeroChatThread$, fixture, context.signal);
+      }
+    }
+    while (teamFixtures.length > 0) {
+      const fixture = teamFixtures.pop();
+      if (fixture) {
+        await store.set(deleteTeamCompose$, fixture, context.signal);
+      }
+    }
+    while (memberships.length > 0) {
+      const fixture = memberships.pop();
+      if (fixture) {
+        await store.set(deleteOrgMembership$, fixture, context.signal);
+      }
+    }
+  });
+
+  async function seedAuthContext(): Promise<{
+    readonly userId: string;
+    readonly orgId: string;
+    readonly token: string;
+  }> {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    memberships.push(
+      await store.set(
+        seedOrgMembership$,
+        { orgId, userId, role: "member" },
+        context.signal,
+      ),
+    );
+    return { userId, orgId, token: zeroToken({ userId, orgId }) };
+  }
+
+  it("returns 401 when no auth token is provided", async () => {
+    const client = setupApp({ context })(integrationsChatMessageContract);
+    const response = await accept(
+      client.sendMessage({
+        headers: {},
+        body: { thread: randomUUID(), text: "hello" },
+      }),
+      [401],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("returns 403 when sandbox token lacks chat-message:write", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    const token = sandboxToken({ userId, orgId });
+
+    const client = setupApp({ context })(integrationsChatMessageContract);
+    const response = await accept(
+      client.sendMessage({
+        headers: { authorization: `Bearer ${token}` },
+        body: { thread: randomUUID(), text: "hello" },
+      }),
+      [403],
+    );
+
+    expect(response.body.error.message).toContain("chat-message:write");
+  });
+
+  it("returns 400 when neither thread nor agent is provided", async () => {
+    const auth = await seedAuthContext();
+    const client = setupApp({ context })(integrationsChatMessageContract);
+    const response = await accept(
+      client.sendMessage({
+        headers: { authorization: `Bearer ${auth.token}` },
+        body: { text: "hello" },
+      }),
+      [400],
+    );
+
+    expect(response.body.error.code).toBe("BAD_REQUEST");
+  });
+
+  it("returns 400 when both thread and agent are provided", async () => {
+    const auth = await seedAuthContext();
+    const client = setupApp({ context })(integrationsChatMessageContract);
+    const response = await accept(
+      client.sendMessage({
+        headers: { authorization: `Bearer ${auth.token}` },
+        body: { thread: randomUUID(), agent: randomUUID(), text: "hello" },
+      }),
+      [400],
+    );
+
+    expect(response.body.error.code).toBe("BAD_REQUEST");
+  });
+
+  it("returns 404 when an existing thread is not owned by the caller", async () => {
+    const auth = await seedAuthContext();
+    const foreign = await store.set(
+      seedZeroChatThread$,
+      { orgId: auth.orgId, userId: `other_${randomUUID()}` },
+      context.signal,
+    );
+    threadFixtures.push(foreign);
+
+    const client = setupApp({ context })(integrationsChatMessageContract);
+    const response = await accept(
+      client.sendMessage({
+        headers: { authorization: `Bearer ${auth.token}` },
+        body: { thread: foreign.threadId, text: "hello" },
+      }),
+      [404],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Chat thread not found", code: "NOT_FOUND" },
+    });
+  });
+
+  it("returns 404 when the requested agent does not exist in the caller org", async () => {
+    const auth = await seedAuthContext();
+    const client = setupApp({ context })(integrationsChatMessageContract);
+    const response = await accept(
+      client.sendMessage({
+        headers: { authorization: `Bearer ${auth.token}` },
+        body: { agent: randomUUID(), text: "hello" },
+      }),
+      [404],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Agent not found", code: "NOT_FOUND" },
+    });
+  });
+
+  it("inserts an assistant message into an existing thread", async () => {
+    const fixture = await store.set(seedZeroChatThread$, {}, context.signal);
+    threadFixtures.push(fixture);
+    memberships.push(
+      await store.set(
+        seedOrgMembership$,
+        { orgId: fixture.orgId, userId: fixture.userId, role: "member" },
+        context.signal,
+      ),
+    );
+
+    const client = setupApp({ context })(integrationsChatMessageContract);
+    const response = await accept(
+      client.sendMessage({
+        headers: {
+          authorization: `Bearer ${zeroToken({
+            userId: fixture.userId,
+            orgId: fixture.orgId,
+          })}`,
+        },
+        body: { thread: fixture.threadId, text: "assistant reply" },
+      }),
+      [201],
+    );
+
+    expect(response.body.threadId).toBe(fixture.threadId);
+    expect(response.body.createdAt).toBeDefined();
+    await expect(messageRow(response.body.messageId)).resolves.toStrictEqual({
+      id: response.body.messageId,
+      chatThreadId: fixture.threadId,
+      role: "assistant",
+      content: "assistant reply",
+      runId: null,
+    });
+    await expect(countMessagesForThread(fixture.threadId)).resolves.toBe(1);
+    expect(context.mocks.ably.publish).toHaveBeenCalledWith(
+      `chatThreadMessageCreated:${fixture.threadId}`,
+      null,
+    );
+    expect(context.mocks.ably.publish).toHaveBeenCalledWith(
+      "threadListChanged",
+      null,
+    );
+  });
+
+  it("creates a thread for an agent and inserts the assistant message", async () => {
+    const auth = await seedAuthContext();
+    const team = await store.set(
+      seedTeamCompose$,
+      {
+        orgId: auth.orgId,
+        userId: auth.userId,
+        composes: [{ displayName: "Agent" }],
+      },
+      context.signal,
+    );
+    teamFixtures.push(team);
+    const composeId = team.composeIds[0]!;
+
+    const client = setupApp({ context })(integrationsChatMessageContract);
+    const response = await accept(
+      client.sendMessage({
+        headers: { authorization: `Bearer ${auth.token}` },
+        body: {
+          agent: composeId,
+          title: "Incident handoff",
+          text: "Created from integration",
+        },
+      }),
+      [201],
+    );
+    createdThreadIds.push(response.body.threadId);
+
+    await expect(threadRow(response.body.threadId)).resolves.toStrictEqual({
+      id: response.body.threadId,
+      userId: auth.userId,
+      agentComposeId: composeId,
+      title: "Incident handoff",
+    });
+    await expect(messageRow(response.body.messageId)).resolves.toStrictEqual({
+      id: response.body.messageId,
+      chatThreadId: response.body.threadId,
+      role: "assistant",
+      content: "Created from integration",
+      runId: null,
+    });
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-integrations-chat-message.ts
+++ b/turbo/apps/api/src/signals/routes/zero-integrations-chat-message.ts
@@ -1,0 +1,104 @@
+import { command } from "ccstate";
+import { integrationsChatMessageContract } from "@vm0/api-contracts/contracts/integrations";
+
+import { organizationAuthContext$ } from "../auth/auth-context";
+import { authRoute } from "../auth/auth-route";
+import { bodyResultOf } from "../context/request";
+import { badRequestMessage, notFound } from "../../lib/error";
+import {
+  createChatThread$,
+  insertIntegrationChatMessage$,
+  ownedChatThreadById,
+} from "../services/zero-chat-thread.service";
+import { zeroComposeExists } from "../services/zero-compose-data.service";
+import type { RouteEntry } from "../route";
+
+const sendMessageBody$ = bodyResultOf(
+  integrationsChatMessageContract.sendMessage,
+);
+
+const sendMessageInner$ = command(async ({ get, set }, signal: AbortSignal) => {
+  const auth = get(organizationAuthContext$);
+  const body = await get(sendMessageBody$);
+  signal.throwIfAborted();
+  if (!body.ok) {
+    return body.response;
+  }
+
+  let threadId: string;
+  if (body.data.thread) {
+    const thread = await get(
+      ownedChatThreadById({
+        threadId: body.data.thread,
+        userId: auth.userId,
+      }),
+    );
+    signal.throwIfAborted();
+    if (!thread) {
+      return notFound("Chat thread not found");
+    }
+    threadId = thread.id;
+  } else {
+    const agentId = body.data.agent;
+    if (!agentId) {
+      return badRequestMessage(
+        "Exactly one of 'thread' or 'agent' must be provided",
+      );
+    }
+
+    const exists = await get(
+      zeroComposeExists({ orgId: auth.orgId, composeId: agentId }),
+    );
+    signal.throwIfAborted();
+    if (!exists) {
+      return notFound("Agent not found");
+    }
+
+    const thread = await set(
+      createChatThread$,
+      {
+        userId: auth.userId,
+        agentComposeId: agentId,
+        title: body.data.title,
+        clientThreadId: undefined,
+      },
+      signal,
+    );
+    signal.throwIfAborted();
+    threadId = thread.id;
+  }
+
+  const message = await set(
+    insertIntegrationChatMessage$,
+    {
+      chatThreadId: threadId,
+      userId: auth.userId,
+      content: body.data.text,
+    },
+    signal,
+  );
+  signal.throwIfAborted();
+
+  return {
+    status: 201 as const,
+    body: {
+      messageId: message.id,
+      threadId,
+      createdAt: message.createdAt.toISOString(),
+    },
+  };
+});
+
+export const zeroIntegrationsChatMessageRoutes: readonly RouteEntry[] = [
+  {
+    route: integrationsChatMessageContract.sendMessage,
+    handler: authRoute(
+      {
+        requireOrganization: true,
+        missingOrganizationStatus: 401,
+        requiredCapability: "chat-message:write",
+      },
+      sendMessageInner$,
+    ),
+  },
+];

--- a/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
@@ -44,7 +44,10 @@ import { z } from "zod";
 import { env } from "../../lib/env";
 import { buildFileUrl } from "../../lib/file-url";
 import { db$, writeDb$ } from "../external/db";
-import { publishThreadListChanged } from "../external/realtime";
+import {
+  publishThreadListChanged,
+  publishUserSignal,
+} from "../external/realtime";
 import { listS3Objects } from "../external/s3";
 import { userFeatureSwitchOverrides } from "./feature-switches.service";
 
@@ -806,6 +809,26 @@ export function zeroChatThreadList(args: {
   });
 }
 
+export function ownedChatThreadById(args: {
+  readonly threadId: string;
+  readonly userId: string;
+}): Computed<Promise<{ readonly id: string } | null>> {
+  return computed(async (get): Promise<{ readonly id: string } | null> => {
+    const [thread] = await get(db$)
+      .select({ id: chatThreads.id })
+      .from(chatThreads)
+      .where(
+        and(
+          eq(chatThreads.id, args.threadId),
+          eq(chatThreads.userId, args.userId),
+        ),
+      )
+      .limit(1);
+
+    return thread ?? null;
+  });
+}
+
 export function zeroChatThreadArtifacts(args: {
   readonly threadId: string;
   readonly userId: string;
@@ -1131,6 +1154,45 @@ export const createChatThread$ = command(
     }
 
     return thread;
+  },
+);
+
+export const insertIntegrationChatMessage$ = command(
+  async (
+    { set },
+    args: {
+      readonly chatThreadId: string;
+      readonly userId: string;
+      readonly content: string;
+    },
+    signal: AbortSignal,
+  ): Promise<{ readonly id: string; readonly createdAt: Date }> => {
+    const writeDb = set(writeDb$);
+    const [message] = await writeDb
+      .insert(chatMessages)
+      .values({
+        chatThreadId: args.chatThreadId,
+        role: "assistant",
+        content: args.content,
+        runId: null,
+      })
+      .returning({ id: chatMessages.id, createdAt: chatMessages.createdAt });
+    signal.throwIfAborted();
+
+    if (!message) {
+      throw new Error("Failed to insert chat message");
+    }
+
+    await publishUserSignal(
+      [args.userId],
+      `chatThreadMessageCreated:${args.chatThreadId}`,
+    );
+    signal.throwIfAborted();
+
+    await publishThreadListChanged(args.userId);
+    signal.throwIfAborted();
+
+    return message;
   },
 );
 


### PR DESCRIPTION
## Summary
- add the API backend route for POST /api/zero/integrations/chat/message
- share chat-thread lookup/message insertion helpers with realtime signal publishing
- cover auth, validation, ownership, missing agent, existing-thread, and new-thread flows with API route integration tests

Fixes #12875

## Tests
- pnpm -F api exec vitest src/signals/routes/__tests__/zero-integrations-chat-message.test.ts
- pnpm -F api lint
- pnpm -F api check-types
- pnpm turbo run lint
- pnpm check-types
- pnpm vitest (first run had one unrelated order-dependent failure in app/api/cron/process-usage-events/__tests__/route.test.ts; targeted rerun passed, second full run passed)
- pnpm knip