### PR TITLE
chore: persist zed server in devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -45,6 +45,7 @@
     "source=claude,target=/home/vscode/.local/share/claude",
     "source=codex,target=/home/vscode/.codex",
     "source=codex-switch,target=/home/vscode/.codex-switch",
+    "source=zed-server,target=/home/vscode/.zed_server",
     "source=pki,target=/home/vscode/.pki",
     "source=cloudflared,target=/home/vscode/.cloudflared",
     "source=agent-browser,target=/home/vscode/.local/share/agent-browser"


### PR DESCRIPTION
## Summary
- add a named devcontainer volume for `/home/vscode/.zed_server`
- keep Zed server state across container rebuilds

## Tests
- python3 -m json.tool .devcontainer/devcontainer.json >/dev/null
- pre-commit: check-file-size