### PR TITLE
refactor(api): migrate zero agents delete route

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-agents-by-id.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-agents-by-id.test.ts
@@ -2,10 +2,19 @@ import { randomUUID } from "node:crypto";
 
 import { zeroAgentsByIdContract } from "@vm0/api-contracts/contracts/zero-agents";
 import { createStore } from "ccstate";
+import { eq } from "drizzle-orm";
+import {
+  agentComposes,
+  agentComposeVersions,
+} from "@vm0/db/schema/agent-compose";
+import { agentRuns } from "@vm0/db/schema/agent-run";
+import { agentSessions } from "@vm0/db/schema/agent-session";
+import { zeroAgents } from "@vm0/db/schema/zero-agent";
 
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
 import { now } from "../../../lib/time";
 import { signSandboxJwtForTests } from "../../auth/tokens";
+import { writeDb$ } from "../../external/db";
 import {
   createFixtureTracker,
   createZeroRouteMocks,
@@ -182,5 +191,274 @@ describe("GET /api/zero/agents/:id", () => {
         code: "FORBIDDEN",
       },
     });
+  });
+});
+
+describe("DELETE /api/zero/agents/:id", () => {
+  const track = createFixtureTracker<TeamComposeFixture>((fixture) => {
+    return store.set(deleteTeamCompose$, fixture, context.signal);
+  });
+
+  it("returns 401 when the request is unauthenticated", async () => {
+    const client = setupApp({ context })(zeroAgentsByIdContract);
+    const response = await accept(
+      client.delete({ params: { id: randomUUID() }, headers: {} }),
+      [401],
+    );
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("returns 403 for a sandbox token without agent:delete capability", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    const runId = `run_${randomUUID()}`;
+    const seconds = currentSecond();
+    const token = signSandboxJwtForTests({
+      scope: "zero",
+      userId,
+      orgId,
+      runId,
+      capabilities: ["file:read"],
+      iat: seconds,
+      exp: seconds + 60,
+    });
+
+    const client = setupApp({ context })(zeroAgentsByIdContract);
+    const response = await accept(
+      client.delete({
+        params: { id: randomUUID() },
+        headers: { authorization: `Bearer ${token}` },
+      }),
+      [403],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Missing required capability: agent:delete",
+        code: "FORBIDDEN",
+      },
+    });
+  });
+
+  it("returns 404 for an unknown agent id", async () => {
+    const fixture = await track(
+      store.set(seedTeamCompose$, {}, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    const unknownId = randomUUID();
+
+    const client = setupApp({ context })(zeroAgentsByIdContract);
+    const response = await accept(
+      client.delete({
+        params: { id: unknownId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [404],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: `Agent not found: ${unknownId}`, code: "NOT_FOUND" },
+    });
+  });
+
+  it("returns 404 when the agent belongs to a different org", async () => {
+    const otherFixture = await track(
+      store.set(
+        seedTeamCompose$,
+        { composes: [{ displayName: "Other Org Agent" }] },
+        context.signal,
+      ),
+    );
+    const agentId = otherFixture.composeIds[0];
+    if (!agentId) {
+      throw new Error("Expected seeded agent");
+    }
+
+    const fixture = await track(
+      store.set(seedTeamCompose$, {}, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(zeroAgentsByIdContract);
+    const response = await accept(
+      client.delete({
+        params: { id: agentId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [404],
+    );
+    expect(response.body).toStrictEqual({
+      error: { message: `Agent not found: ${agentId}`, code: "NOT_FOUND" },
+    });
+
+    const writeDb = store.set(writeDb$);
+    const survivor = await writeDb
+      .select({ id: zeroAgents.id })
+      .from(zeroAgents)
+      .where(eq(zeroAgents.id, agentId));
+    expect(survivor).toStrictEqual([{ id: agentId }]);
+  });
+
+  it("rejects same-org members who are not the agent owner", async () => {
+    const fixture = await track(
+      store.set(seedTeamCompose$, { composes: [{}] }, context.signal),
+    );
+    const agentId = fixture.composeIds[0];
+    if (!agentId) {
+      throw new Error("Expected seeded agent");
+    }
+    mocks.clerk.session(`user_${randomUUID()}`, fixture.orgId, "org:member");
+
+    const client = setupApp({ context })(zeroAgentsByIdContract);
+    const response = await accept(
+      client.delete({
+        params: { id: agentId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [403],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Only the agent owner or org admin can delete agent",
+        code: "FORBIDDEN",
+      },
+    });
+  });
+
+  it("deletes the caller's own agent", async () => {
+    const fixture = await track(
+      store.set(seedTeamCompose$, { composes: [{}] }, context.signal),
+    );
+    const agentId = fixture.composeIds[0];
+    if (!agentId) {
+      throw new Error("Expected seeded agent");
+    }
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(zeroAgentsByIdContract);
+    const response = await accept(
+      client.delete({
+        params: { id: agentId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [204],
+    );
+    expect(response.body).toBeUndefined();
+
+    const writeDb = store.set(writeDb$);
+    await expect(
+      writeDb
+        .select({ id: zeroAgents.id })
+        .from(zeroAgents)
+        .where(eq(zeroAgents.id, agentId)),
+    ).resolves.toStrictEqual([]);
+    await expect(
+      writeDb
+        .select({ id: agentComposes.id })
+        .from(agentComposes)
+        .where(eq(agentComposes.id, agentId)),
+    ).resolves.toStrictEqual([]);
+  });
+
+  it("allows an org admin to delete another user's public agent", async () => {
+    const fixture = await track(
+      store.set(seedTeamCompose$, { composes: [{}] }, context.signal),
+    );
+    const agentId = fixture.composeIds[0];
+    if (!agentId) {
+      throw new Error("Expected seeded agent");
+    }
+    mocks.clerk.session(`user_${randomUUID()}`, fixture.orgId, "org:admin");
+
+    const client = setupApp({ context })(zeroAgentsByIdContract);
+    const response = await accept(
+      client.delete({
+        params: { id: agentId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [204],
+    );
+    expect(response.body).toBeUndefined();
+
+    const writeDb = store.set(writeDb$);
+    await expect(
+      writeDb
+        .select({ id: zeroAgents.id })
+        .from(zeroAgents)
+        .where(eq(zeroAgents.id, agentId)),
+    ).resolves.toStrictEqual([]);
+  });
+
+  it("returns 409 and preserves rows when a pending run references the agent", async () => {
+    const fixture = await track(
+      store.set(seedTeamCompose$, { composes: [{}] }, context.signal),
+    );
+    const agentId = fixture.composeIds[0];
+    if (!agentId) {
+      throw new Error("Expected seeded agent");
+    }
+    const writeDb = store.set(writeDb$);
+    const versionId = `v_${randomUUID().slice(0, 16)}`;
+    const sessionId = randomUUID();
+    const runId = randomUUID();
+    await writeDb.insert(agentComposeVersions).values({
+      id: versionId,
+      composeId: agentId,
+      content: {},
+      createdBy: fixture.userId,
+    });
+    await writeDb.insert(agentSessions).values({
+      id: sessionId,
+      userId: fixture.userId,
+      orgId: fixture.orgId,
+      agentComposeId: agentId,
+    });
+    await writeDb.insert(agentRuns).values({
+      id: runId,
+      userId: fixture.userId,
+      orgId: fixture.orgId,
+      agentComposeVersionId: versionId,
+      sessionId,
+      status: "pending",
+      prompt: "x",
+    });
+
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    const client = setupApp({ context })(zeroAgentsByIdContract);
+    const response = await accept(
+      client.delete({
+        params: { id: agentId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [409],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Cannot delete agent: agent is currently running",
+        code: "CONFLICT",
+      },
+    });
+    await expect(
+      writeDb
+        .select({ id: zeroAgents.id })
+        .from(zeroAgents)
+        .where(eq(zeroAgents.id, agentId)),
+    ).resolves.toStrictEqual([{ id: agentId }]);
+    await expect(
+      writeDb
+        .select({ id: agentRuns.id })
+        .from(agentRuns)
+        .where(eq(agentRuns.id, runId)),
+    ).resolves.toStrictEqual([{ id: runId }]);
+
+    await writeDb.delete(agentRuns).where(eq(agentRuns.id, runId));
+    await writeDb.delete(agentSessions).where(eq(agentSessions.id, sessionId));
+    await writeDb
+      .delete(agentComposeVersions)
+      .where(eq(agentComposeVersions.id, versionId));
   });
 });

--- a/turbo/apps/api/src/signals/routes/zero-agents.ts
+++ b/turbo/apps/api/src/signals/routes/zero-agents.ts
@@ -37,6 +37,7 @@ import {
   recomposeAgentIfStale$,
   serverSideZeroAgentCompose$,
 } from "../services/agent-compose.service";
+import { deleteComposeById$ } from "../services/zero-compose-data.service";
 import { userFeatureSwitchOverrides } from "../services/feature-switches.service";
 import {
   agentResponse,
@@ -612,6 +613,52 @@ const updateAgentInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   };
 });
 
+const deleteAgentInner$ = command(async ({ get, set }, signal: AbortSignal) => {
+  const auth = get(organizationAuthContext$);
+  const member = { userId: auth.userId, role: auth.orgRole ?? "member" };
+  const params = get(pathParamsOf(zeroAgentsByIdContract.delete));
+
+  const writeDb = set(writeDb$);
+  const [agent] = await writeDb
+    .select({
+      id: zeroAgents.id,
+      name: zeroAgents.name,
+      owner: zeroAgents.owner,
+      visibility: zeroAgents.visibility,
+    })
+    .from(zeroAgents)
+    .where(and(eq(zeroAgents.orgId, auth.orgId), eq(zeroAgents.id, params.id)))
+    .limit(1);
+  signal.throwIfAborted();
+
+  if (!agent) {
+    return agentNotFound(params.id);
+  }
+
+  const permissionError = requireAgentPermission(
+    agent.owner,
+    member,
+    "delete agent",
+    { visibility: agent.visibility },
+  );
+  if (permissionError) {
+    return permissionError;
+  }
+
+  const result = await set(
+    deleteComposeById$,
+    { composeId: agent.id, composeName: agent.name, orgId: auth.orgId },
+    signal,
+  );
+  signal.throwIfAborted();
+
+  if (result?.status === 409) {
+    return result;
+  }
+
+  return { status: 204 as const, body: undefined };
+});
+
 const updateAgentCustomConnectorsInner$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     const auth = get(organizationAuthContext$);
@@ -811,6 +858,12 @@ const agentWriteAuth = {
   requiredCapability: "agent:write",
 } as const;
 
+const agentDeleteAuth = {
+  requireOrganization: true,
+  missingOrganizationStatus: 401,
+  requiredCapability: "agent:delete",
+} as const;
+
 export const zeroAgentsRoutes: readonly RouteEntry[] = [
   {
     route: zeroAgentsMainContract.list,
@@ -823,6 +876,10 @@ export const zeroAgentsRoutes: readonly RouteEntry[] = [
   {
     route: zeroAgentsByIdContract.update,
     handler: authRoute(agentWriteAuth, updateAgentInner$),
+  },
+  {
+    route: zeroAgentsByIdContract.delete,
+    handler: authRoute(agentDeleteAuth, deleteAgentInner$),
   },
   {
     route: zeroUserConnectorsContract.get,

--- a/turbo/apps/api/src/signals/services/zero-compose-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-compose-data.service.ts
@@ -288,6 +288,105 @@ export const deleteCompose$ = command(
   },
 );
 
+export const deleteComposeById$ = command(
+  async (
+    { get, set },
+    args: {
+      readonly composeId: string;
+      readonly composeName: string;
+      readonly orgId: string;
+    },
+    signal: AbortSignal,
+  ): Promise<ConflictResponse | undefined> => {
+    const writeDb = set(writeDb$);
+
+    const result = await writeDb.transaction(async (tx) => {
+      const [activeRun] = await tx
+        .select({ id: agentRuns.id })
+        .from(agentRuns)
+        .innerJoin(
+          agentComposeVersions,
+          eq(agentRuns.agentComposeVersionId, agentComposeVersions.id),
+        )
+        .where(
+          and(
+            eq(agentComposeVersions.composeId, args.composeId),
+            inArray(agentRuns.status, [...ACTIVE_RUN_STATUSES]),
+          ),
+        )
+        .limit(1);
+
+      if (activeRun) {
+        return { kind: "conflict" as const };
+      }
+
+      const versionRows = await tx
+        .select({ id: agentComposeVersions.id })
+        .from(agentComposeVersions)
+        .where(eq(agentComposeVersions.composeId, args.composeId));
+
+      if (versionRows.length > 0) {
+        await tx.delete(agentRuns).where(
+          inArray(
+            agentRuns.agentComposeVersionId,
+            versionRows.map((row) => {
+              return row.id;
+            }),
+          ),
+        );
+      }
+
+      await tx
+        .delete(agentComposes)
+        .where(eq(agentComposes.id, args.composeId));
+
+      const storageName = getInstructionsStorageName(args.composeName);
+      const [storage] = await tx
+        .select({ id: storages.id, s3Prefix: storages.s3Prefix })
+        .from(storages)
+        .where(
+          and(
+            eq(storages.orgId, args.orgId),
+            eq(storages.name, storageName),
+            eq(storages.type, "volume"),
+          ),
+        )
+        .limit(1);
+
+      if (storage) {
+        await tx.delete(storages).where(eq(storages.id, storage.id));
+      }
+
+      return {
+        kind: "deleted" as const,
+        s3Prefix: storage?.s3Prefix ?? null,
+      };
+    });
+    signal.throwIfAborted();
+
+    if (result.kind === "conflict") {
+      return conflict("Cannot delete agent: agent is currently running");
+    }
+
+    if (result.s3Prefix) {
+      const bucket = env("R2_USER_STORAGES_BUCKET_NAME");
+      const objects = await get(listS3Objects(bucket, result.s3Prefix));
+      signal.throwIfAborted();
+      await get(
+        deleteS3Objects(
+          bucket,
+          objects.map((obj) => {
+            return obj.key;
+          }),
+        ),
+      );
+      signal.throwIfAborted();
+    }
+
+    return undefined;
+  },
+);
+
 export const updateComposeMetadata$ = command(
   async (
     { set },


### PR DESCRIPTION
## Summary
- add the API backend DELETE handler for `/api/zero/agents/:id` with the same auth, org scoping, permission, conflict, and cleanup behavior as the web route
- add compose deletion by known id for zero-agent callers that have already performed permission checks
- cover unauthenticated, sandbox capability, org scoping, permission, success, admin, and active-run conflict cases in API route tests

## Validation
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-agents-by-id.test.ts`
- `pnpm format`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --cache`
- `git diff --check`
- pre-commit: `pnpm knip --cache`, `pnpm check-types`

Closes #12804