### PR TITLE
refactor(api): migrate zero developer support route

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -33,6 +33,7 @@ import { zeroComputerUseRoutes } from "./routes/zero-computer-use";
 import { zeroConnectorsRoutes } from "./routes/zero-connectors";
 import { zeroCustomConnectorsRoutes } from "./routes/zero-custom-connectors";
 import { zeroDefaultAgentRoutes } from "./routes/zero-default-agent";
+import { zeroDeveloperSupportRoutes } from "./routes/zero-developer-support";
 import { zeroFeatureSwitchesRoutes } from "./routes/zero-feature-switches";
 import { zeroInsightsRoutes } from "./routes/zero-insights";
 import { zeroLogsRoutes } from "./routes/zero-logs";
@@ -136,6 +137,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...zeroConnectorsRoutes,
   ...zeroCustomConnectorsRoutes,
   ...zeroDefaultAgentRoutes,
+  ...zeroDeveloperSupportRoutes,
   ...zeroFeatureSwitchesRoutes,
   ...zeroInsightsRoutes,
   ...zeroLogsRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-developer-support.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-developer-support.test.ts
@@ -1,0 +1,329 @@
+import { randomUUID } from "node:crypto";
+
+import { createStore } from "ccstate";
+import { beforeEach, expect } from "vitest";
+import { zeroDeveloperSupportContract } from "@vm0/api-contracts/contracts/zero-developer-support";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { mockOptionalEnv } from "../../../lib/env";
+import { now } from "../../../lib/time";
+import { signSandboxJwtForTests } from "../../auth/tokens";
+import { createFixtureTracker } from "./helpers/zero-route-test";
+import {
+  deleteOrgMembership$,
+  type OrgMembershipFixture,
+  seedOrgMembership$,
+} from "./helpers/zero-org-membership";
+import {
+  deleteUsageInsightFixture$,
+  seedCompose$,
+  seedRun$,
+  seedUsageInsightFixture$,
+  type UsageInsightFixture,
+} from "./helpers/zero-usage-insight";
+
+const context = testContext();
+const store = createStore();
+const trackUsage = createFixtureTracker<UsageInsightFixture>((fixture) => {
+  return store.set(deleteUsageInsightFixture$, fixture, context.signal);
+});
+const trackMembership = createFixtureTracker<OrgMembershipFixture>(
+  (fixture) => {
+    return store.set(deleteOrgMembership$, fixture, context.signal);
+  },
+);
+
+interface DeveloperSupportFixture extends UsageInsightFixture {
+  readonly composeId: string;
+  readonly runId: string;
+}
+
+interface RunSeedOptions {
+  readonly continuedFromSessionId?: string | null;
+}
+
+function currentSecond(): number {
+  return Math.floor(now() / 1000);
+}
+
+function zeroToken(args: {
+  readonly userId: string;
+  readonly orgId: string;
+  readonly runId: string;
+}): string {
+  const seconds = currentSecond();
+  return signSandboxJwtForTests({
+    scope: "zero",
+    userId: args.userId,
+    orgId: args.orgId,
+    runId: args.runId,
+    capabilities: [],
+    iat: seconds,
+    exp: seconds + 60,
+  });
+}
+
+function commandInput(command: unknown): Record<string, unknown> {
+  if (
+    typeof command === "object" &&
+    command !== null &&
+    "input" in command &&
+    typeof command.input === "object" &&
+    command.input !== null
+  ) {
+    return command.input as Record<string, unknown>;
+  }
+  return {};
+}
+
+function putObjectInput(): Record<string, unknown> {
+  const call = context.mocks.s3.send.mock.calls.find(([command]) => {
+    const input = commandInput(command);
+    return input.Body !== undefined && input.ContentType === "application/zip";
+  });
+  if (!call) {
+    throw new Error("expected S3 PutObjectCommand");
+  }
+  return commandInput(call[0]);
+}
+
+async function seedSupportRun(
+  options: RunSeedOptions = {},
+): Promise<DeveloperSupportFixture> {
+  const fixture = await trackUsage(
+    store.set(seedUsageInsightFixture$, undefined, context.signal),
+  );
+  await trackMembership(
+    store.set(
+      seedOrgMembership$,
+      { orgId: fixture.orgId, userId: fixture.userId },
+      context.signal,
+    ),
+  );
+  const { composeId } = await store.set(
+    seedCompose$,
+    {
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      displayName: "Support Agent",
+    },
+    context.signal,
+  );
+  const { runId } = await store.set(
+    seedRun$,
+    {
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      composeId,
+      status: "running",
+      continuedFromSessionId: options.continuedFromSessionId,
+    },
+    context.signal,
+  );
+
+  return { ...fixture, composeId, runId };
+}
+
+function client() {
+  return setupApp({ context })(zeroDeveloperSupportContract);
+}
+
+function submitDeveloperSupport(
+  token: string | undefined,
+  body: {
+    readonly title: string;
+    readonly description: string;
+    readonly consentCode?: string;
+  },
+) {
+  return client().submit({
+    headers: token ? { authorization: `Bearer ${token}` } : {},
+    body,
+  });
+}
+
+function requireConsentCode(body: {
+  readonly consentCode?: string;
+  readonly reference?: string;
+}): string {
+  if (!body.consentCode) {
+    throw new Error("expected consentCode response");
+  }
+  return body.consentCode;
+}
+
+function requireReference(body: {
+  readonly consentCode?: string;
+  readonly reference?: string;
+}): string {
+  if (!body.reference) {
+    throw new Error("expected reference response");
+  }
+  return body.reference;
+}
+
+beforeEach(() => {
+  context.mocks.clerk.authenticateRequest.mockResolvedValue({
+    isAuthenticated: false,
+  });
+  context.mocks.clerk.users.getOrganizationMembershipList.mockResolvedValue({
+    data: [],
+  });
+  context.mocks.axiom.query.mockResolvedValue([]);
+  context.mocks.s3.send.mockResolvedValue({});
+  context.mocks.s3.getSignedUrl.mockResolvedValue(
+    "https://r2.example.com/developer-support.zip?sig=test",
+  );
+  mockOptionalEnv("PLAIN_API_KEY", undefined);
+});
+
+describe("POST /api/zero/developer-support", () => {
+  it("returns 401 when unauthenticated", async () => {
+    const response = await accept(
+      submitDeveloperSupport(undefined, {
+        title: "Bug",
+        description: "Something broke",
+      }),
+      [401],
+    );
+
+    expect(response.body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("returns 403 for auth without run scope", async () => {
+    const token = zeroToken({
+      userId: `user_${randomUUID()}`,
+      orgId: `org_${randomUUID()}`,
+      runId: randomUUID(),
+    });
+
+    const response = await accept(
+      submitDeveloperSupport(token, {
+        title: "Bug",
+        description: "Something broke",
+      }),
+      [403],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "This endpoint requires a zero token with runId and orgId",
+        code: "FORBIDDEN",
+      },
+    });
+  });
+
+  it("returns RUN_NOT_FOUND for a missing run", async () => {
+    const fixture = await seedSupportRun();
+    const token = zeroToken({
+      userId: fixture.userId,
+      orgId: fixture.orgId,
+      runId: randomUUID(),
+    });
+
+    const response = await accept(
+      submitDeveloperSupport(token, {
+        title: "Bug",
+        description: "Something broke",
+      }),
+      [400],
+    );
+
+    expect(response.body.error.code).toBe("RUN_NOT_FOUND");
+  });
+
+  it("returns a deterministic consent code when consentCode is omitted", async () => {
+    const fixture = await seedSupportRun();
+    const token = zeroToken(fixture);
+
+    const first = await accept(
+      submitDeveloperSupport(token, {
+        title: "Bug",
+        description: "Something broke",
+      }),
+      [200],
+    );
+    const second = await accept(
+      submitDeveloperSupport(token, {
+        title: "Bug",
+        description: "Something broke",
+      }),
+      [200],
+    );
+
+    expect(requireConsentCode(first.body)).toMatch(/^[0-9A-F]{4}$/);
+    expect(second.body).toStrictEqual(first.body);
+  });
+
+  it("uses the same consent code across runs in the same session", async () => {
+    const sessionId = randomUUID();
+    const first = await seedSupportRun({ continuedFromSessionId: sessionId });
+    const { runId: secondRunId } = await store.set(
+      seedRun$,
+      {
+        orgId: first.orgId,
+        userId: first.userId,
+        composeId: first.composeId,
+        status: "running",
+        continuedFromSessionId: sessionId,
+      },
+      context.signal,
+    );
+
+    const firstResponse = await accept(
+      submitDeveloperSupport(zeroToken(first), {
+        title: "Bug",
+        description: "Something broke",
+      }),
+      [200],
+    );
+    const secondResponse = await accept(
+      submitDeveloperSupport(zeroToken({ ...first, runId: secondRunId }), {
+        title: "Bug",
+        description: "Something broke",
+      }),
+      [200],
+    );
+
+    expect(secondResponse.body).toStrictEqual(firstResponse.body);
+  });
+
+  it("returns INVALID_CONSENT_CODE for an invalid code", async () => {
+    const fixture = await seedSupportRun();
+    const response = await accept(
+      submitDeveloperSupport(zeroToken(fixture), {
+        title: "Bug",
+        description: "Something broke",
+        consentCode: "ZZZZ",
+      }),
+      [400],
+    );
+
+    expect(response.body.error.code).toBe("INVALID_CONSENT_CODE");
+  });
+
+  it("submits a diagnostic bundle with a valid consent code", async () => {
+    const fixture = await seedSupportRun();
+    const token = zeroToken(fixture);
+    const consent = await accept(
+      submitDeveloperSupport(token, {
+        title: "Bug",
+        description: "Something broke",
+      }),
+      [200],
+    );
+
+    const response = await accept(
+      submitDeveloperSupport(token, {
+        title: "Bug",
+        description: "Something broke",
+        consentCode: requireConsentCode(consent.body),
+      }),
+      [200],
+    );
+
+    expect(requireReference(response.body)).toMatch(/^ds-[a-f0-9]{8}$/);
+    const putInput = putObjectInput();
+    expect(putInput.Key).toContain("developer-support/");
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-developer-support.ts
+++ b/turbo/apps/api/src/signals/routes/zero-developer-support.ts
@@ -1,0 +1,87 @@
+import { command } from "ccstate";
+import { zeroDeveloperSupportContract } from "@vm0/api-contracts/contracts/zero-developer-support";
+
+import { authContext$ } from "../auth/auth-context";
+import { authRoute } from "../auth/auth-route";
+import { bodyResultOf } from "../context/request";
+import { submitZeroDeveloperSupport$ } from "../services/zero-developer-support.service";
+import type { RouteEntry } from "../route";
+
+const scopedZeroTokenRequired = Object.freeze({
+  status: 403 as const,
+  body: Object.freeze({
+    error: Object.freeze({
+      message: "This endpoint requires a zero token with runId and orgId",
+      code: "FORBIDDEN",
+    }),
+  }),
+});
+
+const runNotFound = Object.freeze({
+  status: 400 as const,
+  body: Object.freeze({
+    error: Object.freeze({
+      message: "Run not found",
+      code: "RUN_NOT_FOUND",
+    }),
+  }),
+});
+
+const invalidConsentCode = Object.freeze({
+  status: 400 as const,
+  body: Object.freeze({
+    error: Object.freeze({
+      message: "Invalid consent code",
+      code: "INVALID_CONSENT_CODE",
+    }),
+  }),
+});
+
+const submitInner$ = command(async ({ get, set }, signal: AbortSignal) => {
+  const auth = get(authContext$);
+  const bodyResult = await get(
+    bodyResultOf(zeroDeveloperSupportContract.submit),
+  );
+  signal.throwIfAborted();
+  if (!bodyResult.ok) {
+    return bodyResult.response;
+  }
+
+  const runId = "runId" in auth ? auth.runId : undefined;
+  const orgId = "orgId" in auth ? auth.orgId : undefined;
+
+  if (!runId || !orgId) {
+    return scopedZeroTokenRequired;
+  }
+
+  const result = await set(
+    submitZeroDeveloperSupport$,
+    {
+      userId: auth.userId,
+      orgId,
+      runId,
+      ...bodyResult.data,
+    },
+    signal,
+  );
+  signal.throwIfAborted();
+
+  if (result.kind === "run_not_found") {
+    return runNotFound;
+  }
+  if (result.kind === "invalid_consent_code") {
+    return invalidConsentCode;
+  }
+  if (result.kind === "consent_code") {
+    return { status: 200 as const, body: { consentCode: result.consentCode } };
+  }
+
+  return { status: 200 as const, body: { reference: result.reference } };
+});
+
+export const zeroDeveloperSupportRoutes: readonly RouteEntry[] = [
+  {
+    route: zeroDeveloperSupportContract.submit,
+    handler: authRoute({ acceptAnySandboxCapability: true }, submitInner$),
+  },
+];

--- a/turbo/apps/api/src/signals/services/zero-developer-support.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-developer-support.service.ts
@@ -1,0 +1,103 @@
+import { createHmac, hkdfSync } from "node:crypto";
+
+import { command } from "ccstate";
+import { eq } from "drizzle-orm";
+import { developerSupportBodySchema } from "@vm0/api-contracts/contracts/zero-developer-support";
+import { agentRuns } from "@vm0/db/schema/agent-run";
+import type { z } from "zod";
+
+import { env } from "../../lib/env";
+import { singleton } from "../../lib/singleton";
+import { db$ } from "../external/db";
+import { submitDiagnosticBundle } from "./diagnostic-bundle.service";
+
+type DeveloperSupportBody = z.infer<typeof developerSupportBodySchema>;
+
+interface SubmitDeveloperSupportArgs extends DeveloperSupportBody {
+  readonly userId: string;
+  readonly orgId: string;
+  readonly runId: string;
+}
+
+type SubmitDeveloperSupportResult =
+  | { readonly kind: "consent_code"; readonly consentCode: string }
+  | { readonly kind: "ok"; readonly reference: string }
+  | { readonly kind: "run_not_found" }
+  | { readonly kind: "invalid_consent_code" };
+
+const consentKey = singleton((): Buffer => {
+  const masterKey = Buffer.from(env("SECRETS_ENCRYPTION_KEY"), "hex");
+  return Buffer.from(
+    hkdfSync("sha256", masterKey, "", "developer-support-consent", 32),
+  );
+});
+
+function generateConsentCode(seed: string): string {
+  return createHmac("sha256", consentKey())
+    .update(seed)
+    .digest("hex")
+    .slice(0, 4)
+    .toUpperCase();
+}
+
+export const submitZeroDeveloperSupport$ = command(
+  async (
+    { get },
+    args: SubmitDeveloperSupportArgs,
+    signal: AbortSignal,
+  ): Promise<SubmitDeveloperSupportResult> => {
+    const db = get(db$);
+    const [run] = await db
+      .select({
+        id: agentRuns.id,
+        userId: agentRuns.userId,
+        orgId: agentRuns.orgId,
+        status: agentRuns.status,
+        error: agentRuns.error,
+        prompt: agentRuns.prompt,
+        appendSystemPrompt: agentRuns.appendSystemPrompt,
+        createdAt: agentRuns.createdAt,
+        startedAt: agentRuns.startedAt,
+        completedAt: agentRuns.completedAt,
+        lastEventSequence: agentRuns.lastEventSequence,
+        agentComposeVersionId: agentRuns.agentComposeVersionId,
+        runnerGroup: agentRuns.runnerGroup,
+        continuedFromSessionId: agentRuns.continuedFromSessionId,
+        result: agentRuns.result,
+      })
+      .from(agentRuns)
+      .where(eq(agentRuns.id, args.runId))
+      .limit(1);
+    signal.throwIfAborted();
+
+    if (!run) {
+      return { kind: "run_not_found" };
+    }
+
+    const consentSeed = run.continuedFromSessionId ?? args.runId;
+    const expectedConsentCode = generateConsentCode(consentSeed);
+
+    if (!args.consentCode) {
+      return { kind: "consent_code", consentCode: expectedConsentCode };
+    }
+
+    if (args.consentCode !== expectedConsentCode) {
+      return { kind: "invalid_consent_code" };
+    }
+
+    const { reference } = await submitDiagnosticBundle(get, {
+      title: args.title,
+      description: args.description,
+      userId: args.userId,
+      orgId: args.orgId,
+      runId: args.runId,
+      run,
+      referencePrefix: "ds",
+      s3PathPrefix: "developer-support",
+      emailSubjectPrefix: "[Developer Support]",
+    });
+    signal.throwIfAborted();
+
+    return { kind: "ok", reference };
+  },
+);


### PR DESCRIPTION
## Summary
- add the API-native `POST /api/zero/developer-support` signal route
- move developer-support consent validation and diagnostic bundle submission into an API signal service
- cover authentication, consent-code, and successful upload behavior with route integration tests

Closes #12872

## Validation
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-developer-support.test.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- `git diff --check`