### PR TITLE
refactor(api): migrate telegram test state seeding

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/test-telegram-state.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/test-telegram-state.test.ts
@@ -9,6 +9,7 @@ import {
 } from "@vm0/db/schema/agent-compose";
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { agentSessions } from "@vm0/db/schema/agent-session";
+import { creditExpiresRecord } from "@vm0/db/schema/credit-expires-record";
 import { e2eTelegramMockCallLog } from "@vm0/db/schema/e2e-telegram-mock-call-log";
 import { orgMetadata } from "@vm0/db/schema/org-metadata";
 import { telegramInstallations } from "@vm0/db/schema/telegram-installation";
@@ -35,6 +36,12 @@ interface SeededTelegramState {
   readonly chatId: string;
 }
 
+interface SeededTelegramPostState {
+  readonly botId: string;
+  readonly orgId: string;
+  readonly composeId: string;
+}
+
 interface TelegramStateResponse {
   readonly installation: Record<string, unknown> | null;
   readonly links: readonly Record<string, unknown>[];
@@ -49,6 +56,15 @@ interface TelegramStateResponse {
   } | null;
   readonly resolved_telegram_api_url: string | null;
   readonly mock_calls: readonly Record<string, unknown>[];
+}
+
+interface TelegramStateSeedResponse {
+  readonly ok: true;
+  readonly bot_id: string;
+  readonly org_id: string;
+  readonly vm0_user_id: string;
+  readonly user_link_id: string | null;
+  readonly default_agent_id: string;
 }
 
 function requestApp(path: string, init?: RequestInit): Promise<Response> {
@@ -169,7 +185,63 @@ async function cleanupTelegramState(state: SeededTelegramState): Promise<void> {
     .where(eq(agentComposes.id, state.composeId));
 }
 
+async function cleanupTelegramPostState(
+  state: SeededTelegramPostState,
+): Promise<void> {
+  const writeDb = store.set(writeDb$);
+  await writeDb
+    .delete(telegramMessages)
+    .where(eq(telegramMessages.installationId, state.botId));
+  await writeDb
+    .delete(telegramUserLinks)
+    .where(eq(telegramUserLinks.installationId, state.botId));
+  await writeDb
+    .delete(telegramInstallations)
+    .where(eq(telegramInstallations.telegramBotId, state.botId));
+  await writeDb
+    .delete(creditExpiresRecord)
+    .where(eq(creditExpiresRecord.orgId, state.orgId));
+  await writeDb.delete(orgMetadata).where(eq(orgMetadata.orgId, state.orgId));
+  await writeDb.delete(zeroAgents).where(eq(zeroAgents.id, state.composeId));
+  await writeDb
+    .delete(agentComposeVersions)
+    .where(eq(agentComposeVersions.composeId, state.composeId));
+  await writeDb
+    .delete(agentComposes)
+    .where(eq(agentComposes.id, state.composeId));
+}
+
 const trackTelegramState = createFixtureTracker(cleanupTelegramState);
+const trackTelegramPostState = createFixtureTracker(cleanupTelegramPostState);
+
+function mockClerkTestUser(args: {
+  readonly userId: string;
+  readonly orgId: string;
+}): void {
+  context.mocks.clerk.users.getUserList.mockResolvedValue({
+    data: [{ id: args.userId }],
+  });
+  context.mocks.clerk.users.getOrganizationMembershipList.mockResolvedValue({
+    data: [
+      {
+        createdAt: 2,
+        organization: { id: `org_ignored_${randomUUID()}` },
+      },
+      {
+        createdAt: 1,
+        organization: { id: args.orgId },
+      },
+    ],
+  });
+}
+
+function postTelegramState(body: Record<string, unknown>): Promise<Response> {
+  return requestApp("/api/test/telegram-state", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
 
 async function seedRun(
   state: SeededTelegramState,
@@ -333,6 +405,173 @@ describe("GET /api/test/telegram-state", () => {
         return call.chatId === seeded.chatId && call.method === "sendMessage";
       }),
     ).toBeTruthy();
+  });
+});
+
+describe("POST /api/test/telegram-state", () => {
+  beforeEach(() => {
+    context.mocks.clerk.users.getUserList.mockReset();
+    context.mocks.clerk.users.getOrganizationMembershipList.mockReset();
+  });
+
+  it("returns 404 when the test endpoint is not allowed", async () => {
+    mockEnv("ENV", "production");
+
+    const response = await postTelegramState({
+      bot_id: "bot-disabled",
+      telegram_user_id: "telegram-user",
+    });
+
+    expect(response.status).toBe(404);
+    await expect(response.text()).resolves.toBe("Not found");
+  });
+
+  it("returns 400 when required seed fields are missing", async () => {
+    mockEnv("ENV", "development");
+
+    const response = await postTelegramState({ bot_id: "bot-missing-user" });
+
+    expect(response.status).toBe(400);
+    await expect(readJson<{ error: string }>(response)).resolves.toStrictEqual({
+      error: "bot_id and telegram_user_id are required",
+    });
+  });
+
+  it("seeds a Telegram installation, user link, and shared default agent", async () => {
+    mockEnv("ENV", "development");
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    const botId = `bot_${randomUUID()}`;
+    const telegramUserId = `telegram_${randomUUID()}`;
+    const email = `${randomUUID()}@example.test`;
+    mockClerkTestUser({ userId, orgId });
+
+    const response = await postTelegramState({
+      bot_id: botId,
+      telegram_user_id: telegramUserId,
+      bot_username: "custom_test_bot",
+      webhook_secret: "custom-webhook-secret",
+      email,
+    });
+
+    expect(response.status).toBe(200);
+    const body = await readJson<TelegramStateSeedResponse>(response);
+    await trackTelegramPostState(
+      Promise.resolve({ botId, orgId, composeId: body.default_agent_id }),
+    );
+    expect(body).toMatchObject({
+      ok: true,
+      bot_id: botId,
+      org_id: orgId,
+      vm0_user_id: userId,
+      default_agent_id: expect.any(String),
+    });
+    expect(body.user_link_id).toStrictEqual(expect.any(String));
+    expect(context.mocks.clerk.users.getUserList).toHaveBeenCalledWith({
+      emailAddress: [email],
+    });
+
+    const writeDb = store.set(writeDb$);
+    const [installation] = await writeDb
+      .select()
+      .from(telegramInstallations)
+      .where(eq(telegramInstallations.telegramBotId, botId))
+      .limit(1);
+    expect(installation).toMatchObject({
+      telegramBotId: botId,
+      botUsername: "custom_test_bot",
+      webhookSecret: "custom-webhook-secret",
+      defaultComposeId: body.default_agent_id,
+      ownerUserId: userId,
+      orgId,
+    });
+    expect(installation?.encryptedBotToken).toContain(":");
+
+    const links = await writeDb
+      .select()
+      .from(telegramUserLinks)
+      .where(eq(telegramUserLinks.installationId, botId));
+    expect(links).toHaveLength(1);
+    expect(links[0]).toMatchObject({
+      id: body.user_link_id,
+      telegramUserId,
+      vm0UserId: userId,
+    });
+
+    const [org] = await writeDb
+      .select()
+      .from(orgMetadata)
+      .where(eq(orgMetadata.orgId, orgId))
+      .limit(1);
+    expect(org).toMatchObject({
+      orgId,
+      defaultAgentId: body.default_agent_id,
+      credits: 10_000,
+      tier: "free",
+    });
+
+    const getResponse = await requestApp(
+      `/api/test/telegram-state?bot_id=${encodeURIComponent(botId)}`,
+    );
+    expect(getResponse.status).toBe(200);
+    const getBody = await readJson<TelegramStateResponse>(getResponse);
+    expect(getBody.installation).toMatchObject({
+      telegramBotId: botId,
+      orgId,
+      defaultComposeId: body.default_agent_id,
+    });
+    expect(getBody.links).toHaveLength(1);
+    expect(getBody.default_agent).toMatchObject({
+      id: body.default_agent_id,
+      name: "e2e-slack-agent",
+      orgId,
+    });
+  });
+
+  it("keeps POST idempotent and skips link creation when requested", async () => {
+    mockEnv("ENV", "development");
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    const botId = `bot_${randomUUID()}`;
+    const telegramUserId = `telegram_${randomUUID()}`;
+    mockClerkTestUser({ userId, orgId });
+
+    const first = await postTelegramState({
+      bot_id: botId,
+      telegram_user_id: telegramUserId,
+    });
+    expect(first.status).toBe(200);
+    const firstBody = await readJson<TelegramStateSeedResponse>(first);
+    await trackTelegramPostState(
+      Promise.resolve({
+        botId,
+        orgId,
+        composeId: firstBody.default_agent_id,
+      }),
+    );
+
+    const second = await postTelegramState({
+      bot_id: botId,
+      telegram_user_id: telegramUserId,
+      seed_link: false,
+    });
+    expect(second.status).toBe(200);
+    const secondBody = await readJson<TelegramStateSeedResponse>(second);
+    expect(secondBody).toMatchObject({
+      bot_id: botId,
+      org_id: orgId,
+      vm0_user_id: userId,
+      user_link_id: null,
+      default_agent_id: firstBody.default_agent_id,
+    });
+
+    const links = await store
+      .set(writeDb$)
+      .select()
+      .from(telegramUserLinks)
+      .where(eq(telegramUserLinks.installationId, botId));
+    expect(links).toHaveLength(1);
+    expect(links[0]?.id).toBe(firstBody.user_link_id);
   });
 });
 

--- a/turbo/apps/api/src/signals/routes/test-telegram-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-telegram-state.ts
@@ -1,11 +1,14 @@
+import { createHash } from "node:crypto";
+
 import { command, computed } from "ccstate";
-import { and, desc, eq, inArray, sql } from "drizzle-orm";
+import { and, desc, eq, inArray, isNull, sql } from "drizzle-orm";
 import { testTelegramStateContract } from "@vm0/api-contracts/contracts/test-telegram-state";
 import {
   agentComposes,
   agentComposeVersions,
 } from "@vm0/db/schema/agent-compose";
 import { agentRuns } from "@vm0/db/schema/agent-run";
+import { creditExpiresRecord } from "@vm0/db/schema/credit-expires-record";
 import { e2eTelegramMockCallLog } from "@vm0/db/schema/e2e-telegram-mock-call-log";
 import { orgMetadata } from "@vm0/db/schema/org-metadata";
 import { telegramInstallations } from "@vm0/db/schema/telegram-installation";
@@ -15,10 +18,13 @@ import { zeroAgents } from "@vm0/db/schema/zero-agent";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
 
 import { optionalEnv } from "../../lib/env";
+import { clerk$ } from "../external/clerk";
 import { request$ } from "../context/hono";
 import { queryOf } from "../context/request";
-import { db$, type ReadonlyDb, writeDb$ } from "../external/db";
+import { db$, writeDb$, type Db, type ReadonlyDb } from "../external/db";
+import { nowDate } from "../external/time";
 import type { RouteEntry } from "../route";
+import { encryptSecretValue } from "../services/crypto.utils";
 import {
   isTestEndpointAllowed,
   testEndpointNotFoundResponse,
@@ -26,6 +32,29 @@ import {
 
 const testTelegramStateQuery$ = queryOf(testTelegramStateContract.get);
 const deleteTestTelegramStateQuery$ = queryOf(testTelegramStateContract.delete);
+const DEFAULT_TEST_EMAIL = "dev+clerk_test+serial@vm0-e2e.ai";
+const DEFAULT_TEST_AGENT_NAME = "e2e-slack-agent";
+const STARTER_GRANT_AMOUNT = 10_000;
+const STARTER_GRANT_SOURCE = "starter_grant";
+const TELEGRAM_E2E_FIXTURES = {
+  botUsername: "vm0_e2e_bot",
+  botToken: "123456:e2e-test-bot-token",
+  webhookSecret: "e2e-telegram-webhook-secret",
+} as const;
+
+type StarterGrantTx = Parameters<Parameters<Db["transaction"]>[0]>[0];
+
+interface SeedDefaultAgentInput {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly name: string;
+}
+
+interface DefaultAgentSeed {
+  readonly composeId: string;
+  readonly versionId: string;
+  readonly agentId: string;
+}
 
 function resolveTelegramApiUrlForDiagnostics(): string | null {
   const telegramApiUrl = optionalEnv("TELEGRAM_API_URL");
@@ -188,6 +217,237 @@ function loadMockCalls(db: ReadonlyDb) {
     .limit(50);
 }
 
+function readString(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function readOptionalString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function isSeedRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+async function insertTelegramLinkIfMissing(
+  db: Db,
+  params: {
+    readonly installationId: string;
+    readonly telegramUserId: string;
+    readonly vm0UserId: string;
+  },
+): Promise<string | null> {
+  const [existing] = await db
+    .select({ id: telegramUserLinks.id })
+    .from(telegramUserLinks)
+    .where(
+      and(
+        eq(telegramUserLinks.installationId, params.installationId),
+        eq(telegramUserLinks.telegramUserId, params.telegramUserId),
+      ),
+    )
+    .limit(1);
+  if (existing) {
+    return existing.id;
+  }
+
+  const [row] = await db
+    .insert(telegramUserLinks)
+    .values({
+      installationId: params.installationId,
+      telegramUserId: params.telegramUserId,
+      vm0UserId: params.vm0UserId,
+    })
+    .onConflictDoNothing()
+    .returning({ id: telegramUserLinks.id });
+  return row?.id ?? null;
+}
+
+async function ensureStarterCreditGrant(
+  tx: StarterGrantTx,
+  orgId: string,
+): Promise<void> {
+  const [existing] = await tx
+    .select({ orgId: orgMetadata.orgId })
+    .from(orgMetadata)
+    .where(eq(orgMetadata.orgId, orgId))
+    .limit(1);
+  if (existing) {
+    return;
+  }
+
+  const expiresAt = nowDate();
+  expiresAt.setMonth(expiresAt.getMonth() + 1);
+
+  const inserted = await tx
+    .insert(creditExpiresRecord)
+    .values({
+      orgId,
+      source: STARTER_GRANT_SOURCE,
+      stripeInvoiceId: null,
+      amount: STARTER_GRANT_AMOUNT,
+      remaining: STARTER_GRANT_AMOUNT,
+      expiresAt,
+    })
+    .onConflictDoNothing()
+    .returning({ id: creditExpiresRecord.id });
+
+  if (inserted.length === 0) {
+    return;
+  }
+
+  await tx.execute(
+    sql`INSERT INTO org_metadata (org_id, credits, created_at, updated_at)
+        VALUES (${orgId}, ${STARTER_GRANT_AMOUNT}, now(), now())
+        ON CONFLICT (org_id)
+        DO UPDATE SET credits = org_metadata.credits + ${STARTER_GRANT_AMOUNT}, updated_at = now()`,
+  );
+}
+
+function defaultAgentContent(name: string) {
+  return {
+    version: "1.0",
+    agents: {
+      [name]: {
+        framework: "claude-code",
+        environment: {
+          ANTHROPIC_API_KEY: "fake-e2e-anthropic-key",
+        },
+      },
+    },
+  };
+}
+
+async function getOrInsertCompose(
+  db: Db,
+  input: SeedDefaultAgentInput,
+): Promise<{ readonly id: string; readonly headVersionId: string | null }> {
+  const [inserted] = await db
+    .insert(agentComposes)
+    .values({
+      userId: input.userId,
+      orgId: input.orgId,
+      name: input.name,
+    })
+    .onConflictDoNothing({
+      target: [agentComposes.orgId, agentComposes.name],
+    })
+    .returning({
+      id: agentComposes.id,
+      headVersionId: agentComposes.headVersionId,
+    });
+
+  if (inserted) {
+    return inserted;
+  }
+
+  const [existing] = await db
+    .select({
+      id: agentComposes.id,
+      headVersionId: agentComposes.headVersionId,
+    })
+    .from(agentComposes)
+    .where(
+      and(
+        eq(agentComposes.orgId, input.orgId),
+        eq(agentComposes.name, input.name),
+      ),
+    )
+    .limit(1);
+
+  if (!existing) {
+    throw new Error("Failed to resolve agent compose after conflict");
+  }
+  return existing;
+}
+
+async function ensureComposeVersion(
+  db: Db,
+  composeId: string,
+  userId: string,
+  name: string,
+  headVersionId: string | null,
+): Promise<string> {
+  if (headVersionId) {
+    return headVersionId;
+  }
+
+  const content = defaultAgentContent(name);
+  const versionId = createHash("sha256")
+    .update(JSON.stringify(content) + composeId)
+    .digest("hex");
+
+  await db
+    .insert(agentComposeVersions)
+    .values({
+      id: versionId,
+      composeId,
+      content,
+      createdBy: userId,
+    })
+    .onConflictDoNothing();
+
+  const [updated] = await db
+    .update(agentComposes)
+    .set({ headVersionId: versionId, updatedAt: nowDate() })
+    .where(
+      and(eq(agentComposes.id, composeId), isNull(agentComposes.headVersionId)),
+    )
+    .returning({ headVersionId: agentComposes.headVersionId });
+  if (updated?.headVersionId) {
+    return updated.headVersionId;
+  }
+
+  const [compose] = await db
+    .select({ headVersionId: agentComposes.headVersionId })
+    .from(agentComposes)
+    .where(eq(agentComposes.id, composeId))
+    .limit(1);
+  if (compose?.headVersionId) {
+    return compose.headVersionId;
+  }
+
+  throw new Error("Failed to resolve agent compose head version");
+}
+
+async function seedDefaultAgent(
+  db: Db,
+  input: SeedDefaultAgentInput,
+): Promise<DefaultAgentSeed> {
+  const compose = await getOrInsertCompose(db, input);
+  const composeId = compose.id;
+  const versionId = await ensureComposeVersion(
+    db,
+    composeId,
+    input.userId,
+    input.name,
+    compose.headVersionId,
+  );
+
+  await db
+    .insert(zeroAgents)
+    .values({
+      id: composeId,
+      orgId: input.orgId,
+      owner: input.userId,
+      name: input.name,
+    })
+    .onConflictDoNothing();
+
+  await db.transaction(async (tx) => {
+    await ensureStarterCreditGrant(tx, input.orgId);
+    await tx
+      .insert(orgMetadata)
+      .values({ orgId: input.orgId, defaultAgentId: composeId })
+      .onConflictDoUpdate({
+        target: orgMetadata.orgId,
+        set: { defaultAgentId: composeId, updatedAt: nowDate() },
+      });
+  });
+
+  return { composeId, versionId, agentId: composeId };
+}
+
 const getTestTelegramState$ = computed(async (get) => {
   const request = get(request$);
   if (!isTestEndpointAllowed(request)) {
@@ -241,6 +501,118 @@ const getTestTelegramState$ = computed(async (get) => {
     },
   };
 });
+
+const postTestTelegramState$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const request = get(request$);
+    if (!isTestEndpointAllowed(request)) {
+      return testEndpointNotFoundResponse();
+    }
+
+    const rawBody = await request.json().catch((): null => {
+      return null;
+    });
+    signal.throwIfAborted();
+    const body = isSeedRecord(rawBody) ? rawBody : {};
+    const botId = readString(body.bot_id);
+    const telegramUserId = readString(body.telegram_user_id);
+    if (!botId || !telegramUserId) {
+      return {
+        status: 400 as const,
+        body: { error: "bot_id and telegram_user_id are required" },
+      };
+    }
+
+    const email = readOptionalString(body.email) ?? DEFAULT_TEST_EMAIL;
+    const client = get(clerk$);
+    const { data: users } = await client.users.getUserList({
+      emailAddress: [email],
+    });
+    signal.throwIfAborted();
+    const userId = users[0]?.id;
+    if (!userId) {
+      throw new Error(`Test user not found for email: ${email}`);
+    }
+
+    const memberships = await client.users.getOrganizationMembershipList({
+      userId,
+    });
+    signal.throwIfAborted();
+    const sortedMemberships = [...memberships.data].sort((a, b) => {
+      return a.createdAt - b.createdAt;
+    });
+    const orgId = sortedMemberships[0]?.organization.id;
+    if (!orgId) {
+      throw new Error(`Test user ${userId} has no organization membership`);
+    }
+
+    const db = set(writeDb$);
+    const defaultAgent = await seedDefaultAgent(db, {
+      orgId,
+      userId,
+      name: DEFAULT_TEST_AGENT_NAME,
+    });
+    signal.throwIfAborted();
+
+    const encryptedBotToken = encryptSecretValue(
+      TELEGRAM_E2E_FIXTURES.botToken,
+    );
+    await db
+      .insert(telegramInstallations)
+      .values({
+        telegramBotId: botId,
+        botUsername:
+          readOptionalString(body.bot_username) ??
+          TELEGRAM_E2E_FIXTURES.botUsername,
+        encryptedBotToken,
+        webhookSecret:
+          readOptionalString(body.webhook_secret) ??
+          TELEGRAM_E2E_FIXTURES.webhookSecret,
+        defaultComposeId: defaultAgent.composeId,
+        ownerUserId: userId,
+        orgId,
+      })
+      .onConflictDoUpdate({
+        target: telegramInstallations.telegramBotId,
+        set: {
+          botUsername:
+            readOptionalString(body.bot_username) ??
+            TELEGRAM_E2E_FIXTURES.botUsername,
+          encryptedBotToken,
+          webhookSecret:
+            readOptionalString(body.webhook_secret) ??
+            TELEGRAM_E2E_FIXTURES.webhookSecret,
+          defaultComposeId: defaultAgent.composeId,
+          ownerUserId: userId,
+          orgId,
+          updatedAt: nowDate(),
+        },
+      });
+    signal.throwIfAborted();
+
+    const linkId =
+      body.seed_link === false
+        ? null
+        : await insertTelegramLinkIfMissing(db, {
+            installationId: botId,
+            telegramUserId,
+            vm0UserId: userId,
+          });
+    signal.throwIfAborted();
+
+    return {
+      status: 200 as const,
+      body: {
+        ok: true,
+        bot_id: botId,
+        org_id: orgId,
+        vm0_user_id: userId,
+        user_link_id: linkId,
+        default_agent_id: defaultAgent.composeId,
+      },
+    };
+  },
+);
 
 const deleteTestTelegramState$ = command(
   async ({ get, set }, signal: AbortSignal) => {
@@ -315,6 +687,10 @@ export const testTelegramStateRoutes: readonly RouteEntry[] = [
   {
     route: testTelegramStateContract.get,
     handler: getTestTelegramState$,
+  },
+  {
+    route: testTelegramStateContract.post,
+    handler: postTestTelegramState$,
   },
   {
     route: testTelegramStateContract.delete,

--- a/turbo/apps/api/src/signals/routes/test-telegram-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-telegram-state.ts
@@ -50,6 +50,13 @@ interface SeedDefaultAgentInput {
   readonly name: string;
 }
 
+interface ComposeVersionInput {
+  readonly composeId: string;
+  readonly userId: string;
+  readonly name: string;
+  readonly headVersionId: string | null;
+}
+
 interface DefaultAgentSeed {
   readonly composeId: string;
   readonly versionId: string;
@@ -236,6 +243,7 @@ async function insertTelegramLinkIfMissing(
     readonly telegramUserId: string;
     readonly vm0UserId: string;
   },
+  signal: AbortSignal,
 ): Promise<string | null> {
   const [existing] = await db
     .select({ id: telegramUserLinks.id })
@@ -247,6 +255,7 @@ async function insertTelegramLinkIfMissing(
       ),
     )
     .limit(1);
+  signal.throwIfAborted();
   if (existing) {
     return existing.id;
   }
@@ -260,18 +269,21 @@ async function insertTelegramLinkIfMissing(
     })
     .onConflictDoNothing()
     .returning({ id: telegramUserLinks.id });
+  signal.throwIfAborted();
   return row?.id ?? null;
 }
 
 async function ensureStarterCreditGrant(
   tx: StarterGrantTx,
   orgId: string,
+  signal: AbortSignal,
 ): Promise<void> {
   const [existing] = await tx
     .select({ orgId: orgMetadata.orgId })
     .from(orgMetadata)
     .where(eq(orgMetadata.orgId, orgId))
     .limit(1);
+  signal.throwIfAborted();
   if (existing) {
     return;
   }
@@ -291,6 +303,7 @@ async function ensureStarterCreditGrant(
     })
     .onConflictDoNothing()
     .returning({ id: creditExpiresRecord.id });
+  signal.throwIfAborted();
 
   if (inserted.length === 0) {
     return;
@@ -302,6 +315,7 @@ async function ensureStarterCreditGrant(
         ON CONFLICT (org_id)
         DO UPDATE SET credits = org_metadata.credits + ${STARTER_GRANT_AMOUNT}, updated_at = now()`,
   );
+  signal.throwIfAborted();
 }
 
 function defaultAgentContent(name: string) {
@@ -321,6 +335,7 @@ function defaultAgentContent(name: string) {
 async function getOrInsertCompose(
   db: Db,
   input: SeedDefaultAgentInput,
+  signal: AbortSignal,
 ): Promise<{ readonly id: string; readonly headVersionId: string | null }> {
   const [inserted] = await db
     .insert(agentComposes)
@@ -336,6 +351,7 @@ async function getOrInsertCompose(
       id: agentComposes.id,
       headVersionId: agentComposes.headVersionId,
     });
+  signal.throwIfAborted();
 
   if (inserted) {
     return inserted;
@@ -354,6 +370,7 @@ async function getOrInsertCompose(
       ),
     )
     .limit(1);
+  signal.throwIfAborted();
 
   if (!existing) {
     throw new Error("Failed to resolve agent compose after conflict");
@@ -363,37 +380,40 @@ async function getOrInsertCompose(
 
 async function ensureComposeVersion(
   db: Db,
-  composeId: string,
-  userId: string,
-  name: string,
-  headVersionId: string | null,
+  input: ComposeVersionInput,
+  signal: AbortSignal,
 ): Promise<string> {
-  if (headVersionId) {
-    return headVersionId;
+  if (input.headVersionId) {
+    return input.headVersionId;
   }
 
-  const content = defaultAgentContent(name);
+  const content = defaultAgentContent(input.name);
   const versionId = createHash("sha256")
-    .update(JSON.stringify(content) + composeId)
+    .update(JSON.stringify(content) + input.composeId)
     .digest("hex");
 
   await db
     .insert(agentComposeVersions)
     .values({
       id: versionId,
-      composeId,
+      composeId: input.composeId,
       content,
-      createdBy: userId,
+      createdBy: input.userId,
     })
     .onConflictDoNothing();
+  signal.throwIfAborted();
 
   const [updated] = await db
     .update(agentComposes)
     .set({ headVersionId: versionId, updatedAt: nowDate() })
     .where(
-      and(eq(agentComposes.id, composeId), isNull(agentComposes.headVersionId)),
+      and(
+        eq(agentComposes.id, input.composeId),
+        isNull(agentComposes.headVersionId),
+      ),
     )
     .returning({ headVersionId: agentComposes.headVersionId });
+  signal.throwIfAborted();
   if (updated?.headVersionId) {
     return updated.headVersionId;
   }
@@ -401,8 +421,9 @@ async function ensureComposeVersion(
   const [compose] = await db
     .select({ headVersionId: agentComposes.headVersionId })
     .from(agentComposes)
-    .where(eq(agentComposes.id, composeId))
+    .where(eq(agentComposes.id, input.composeId))
     .limit(1);
+  signal.throwIfAborted();
   if (compose?.headVersionId) {
     return compose.headVersionId;
   }
@@ -413,16 +434,22 @@ async function ensureComposeVersion(
 async function seedDefaultAgent(
   db: Db,
   input: SeedDefaultAgentInput,
+  signal: AbortSignal,
 ): Promise<DefaultAgentSeed> {
-  const compose = await getOrInsertCompose(db, input);
+  const compose = await getOrInsertCompose(db, input, signal);
+  signal.throwIfAborted();
   const composeId = compose.id;
   const versionId = await ensureComposeVersion(
     db,
-    composeId,
-    input.userId,
-    input.name,
-    compose.headVersionId,
+    {
+      composeId,
+      userId: input.userId,
+      name: input.name,
+      headVersionId: compose.headVersionId,
+    },
+    signal,
   );
+  signal.throwIfAborted();
 
   await db
     .insert(zeroAgents)
@@ -433,9 +460,11 @@ async function seedDefaultAgent(
       name: input.name,
     })
     .onConflictDoNothing();
+  signal.throwIfAborted();
 
   await db.transaction(async (tx) => {
-    await ensureStarterCreditGrant(tx, input.orgId);
+    await ensureStarterCreditGrant(tx, input.orgId, signal);
+    signal.throwIfAborted();
     await tx
       .insert(orgMetadata)
       .values({ orgId: input.orgId, defaultAgentId: composeId })
@@ -443,7 +472,9 @@ async function seedDefaultAgent(
         target: orgMetadata.orgId,
         set: { defaultAgentId: composeId, updatedAt: nowDate() },
       });
+    signal.throwIfAborted();
   });
+  signal.throwIfAborted();
 
   return { composeId, versionId, agentId: composeId };
 }
@@ -547,11 +578,15 @@ const postTestTelegramState$ = command(
     }
 
     const db = set(writeDb$);
-    const defaultAgent = await seedDefaultAgent(db, {
-      orgId,
-      userId,
-      name: DEFAULT_TEST_AGENT_NAME,
-    });
+    const defaultAgent = await seedDefaultAgent(
+      db,
+      {
+        orgId,
+        userId,
+        name: DEFAULT_TEST_AGENT_NAME,
+      },
+      signal,
+    );
     signal.throwIfAborted();
 
     const encryptedBotToken = encryptSecretValue(
@@ -593,11 +628,15 @@ const postTestTelegramState$ = command(
     const linkId =
       body.seed_link === false
         ? null
-        : await insertTelegramLinkIfMissing(db, {
-            installationId: botId,
-            telegramUserId,
-            vm0UserId: userId,
-          });
+        : await insertTelegramLinkIfMissing(
+            db,
+            {
+              installationId: botId,
+              telegramUserId,
+              vm0UserId: userId,
+            },
+            signal,
+          );
     signal.throwIfAborted();
 
     return {

--- a/turbo/packages/api-contracts/src/contracts/test-telegram-state.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-telegram-state.ts
@@ -12,6 +12,17 @@ export const testTelegramStateErrorSchema = z.object({
   error: z.string(),
 });
 
+export const testTelegramStateSeedBodySchema = z
+  .object({
+    bot_id: z.unknown().optional(),
+    telegram_user_id: z.unknown().optional(),
+    bot_username: z.unknown().optional(),
+    webhook_secret: z.unknown().optional(),
+    email: z.unknown().optional(),
+    seed_link: z.unknown().optional(),
+  })
+  .passthrough();
+
 export const testTelegramStateComposeVersionSchema = z.object({
   id: z.string(),
   content_keys: z.array(z.string()),
@@ -32,6 +43,15 @@ export const testTelegramStateResponseSchema = z.object({
 
 export const testTelegramStateDeleteResponseSchema = z.object({
   ok: z.literal(true),
+});
+
+export const testTelegramStateSeedResponseSchema = z.object({
+  ok: z.literal(true),
+  bot_id: z.string(),
+  org_id: z.string(),
+  vm0_user_id: z.string(),
+  user_link_id: z.string().nullable(),
+  default_agent_id: z.string(),
 });
 
 export const testTelegramStateContract = c.router({
@@ -57,9 +77,26 @@ export const testTelegramStateContract = c.router({
     },
     summary: "Delete Telegram E2E test state",
   },
+  post: {
+    method: "POST",
+    path: "/api/test/telegram-state",
+    body: testTelegramStateSeedBodySchema,
+    responses: {
+      200: testTelegramStateSeedResponseSchema,
+      400: testTelegramStateErrorSchema,
+      404: z.string(),
+    },
+    summary: "Seed Telegram E2E test state",
+  },
 });
 
 export type TestTelegramStateContract = typeof testTelegramStateContract;
 export type TestTelegramStateResponse = z.infer<
   typeof testTelegramStateResponseSchema
+>;
+export type TestTelegramStateSeedBody = z.infer<
+  typeof testTelegramStateSeedBodySchema
+>;
+export type TestTelegramStateSeedResponse = z.infer<
+  typeof testTelegramStateSeedResponseSchema
 >;


### PR DESCRIPTION
## Summary
- add the POST /api/test/telegram-state contract to the existing test telegram state contract
- register an API command handler that seeds the Telegram E2E installation, optional user link, default agent, and starter credits
- extend API route tests for POST validation, seeding, idempotency, and GET observability

Closes #12863

## Validation
- pnpm -F api exec vitest src/signals/routes/__tests__/test-telegram-state.test.ts
- pnpm -F api lint
- pnpm -F @vm0/api-contracts lint
- pnpm -F @vm0/api-contracts check-types
- pnpm -F api check-types 2>&1 | rg 'test-telegram-state|testTelegramState' || true\n\nNote: full pnpm check-types / api check-types is currently blocked by the existing API ts-rest test baseline (`body` on `never` across unrelated tests). The filtered check produced no errors for the files changed here.