### PR TITLE
refactor(api): migrate github oauth get routes

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -12,6 +12,7 @@ import { chatThreadsV1Routes } from "./routes/chat-threads-v1";
 import { deviceTokenRoutes } from "./routes/device-token";
 import { apiHealth$ } from "./routes/health";
 import { healthAuthProbeRoutes } from "./routes/health-auth-probe";
+import { githubOauthRoutes } from "./routes/github-oauth";
 import { internalEventConsumerTelegramTypingRoutes } from "./routes/internal-event-consumers-telegram-typing";
 import { logsSearchRoutes } from "./routes/logs-search";
 import { modelStatsRoutes } from "./routes/model-stats";
@@ -110,6 +111,7 @@ export const ROUTES: readonly RouteEntry[] = [
   },
   ...authMeRoutes,
   ...healthAuthProbeRoutes,
+  ...githubOauthRoutes,
   ...internalEventConsumerTelegramTypingRoutes,
   ...logsSearchRoutes,
   ...usageRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/github-oauth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/github-oauth.test.ts
@@ -1,0 +1,610 @@
+import { Buffer } from "node:buffer";
+import {
+  createHmac,
+  generateKeyPairSync,
+  randomInt,
+  randomUUID,
+} from "node:crypto";
+
+import { createStore } from "ccstate";
+import { connectors } from "@vm0/db/schema/connector";
+import { githubInstallations } from "@vm0/db/schema/github-installation";
+import { githubUserLinks } from "@vm0/db/schema/github-user-link";
+import { eq, inArray } from "drizzle-orm";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { http, HttpResponse } from "msw";
+
+import { createApp } from "../../../app-factory";
+import { mockEnv, mockOptionalEnv } from "../../../lib/env";
+import { server } from "../../../mocks/server";
+import { testContext } from "../../../__tests__/test-helpers";
+import { writeDb$ } from "../../external/db";
+import { decryptSecretValue } from "../../services/crypto.utils";
+import {
+  deleteUsageInsightFixture$,
+  seedCompose$,
+} from "./helpers/zero-usage-insight";
+
+const context = testContext();
+const store = createStore();
+const APP_ID = "123456";
+const APP_SLUG = "vm0-test";
+const TARGET_LOGIN = "test-org";
+const TARGET_TYPE = "Organization";
+
+interface ComposeFixture {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly composeId: string;
+}
+
+interface CleanupState {
+  installationIds: string[];
+  installationRowIds: string[];
+  targetIds: string[];
+  userIds: string[];
+  composeFixtures: ComposeFixture[];
+}
+
+function createCleanupState(): CleanupState {
+  return {
+    installationIds: [],
+    installationRowIds: [],
+    targetIds: [],
+    userIds: [],
+    composeFixtures: [],
+  };
+}
+
+function newPrivateKeyBase64(): string {
+  const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+  const pem = privateKey.export({ type: "pkcs8", format: "pem" });
+  return Buffer.from(pem).toString("base64");
+}
+
+function mockGithubAppEnv(
+  args: {
+    readonly slug?: boolean;
+    readonly credentials?: boolean;
+  } = {},
+): void {
+  if (args.slug !== false) {
+    mockOptionalEnv("GITHUB_APP_SLUG", APP_SLUG);
+  } else {
+    mockOptionalEnv("GITHUB_APP_SLUG", undefined);
+  }
+  if (args.credentials !== false) {
+    mockOptionalEnv("GITHUB_APP_ID", APP_ID);
+    mockOptionalEnv("GITHUB_APP_PRIVATE_KEY", newPrivateKeyBase64());
+  } else {
+    mockOptionalEnv("GITHUB_APP_ID", undefined);
+    mockOptionalEnv("GITHUB_APP_PRIVATE_KEY", undefined);
+  }
+}
+
+function newGithubUserId(): string {
+  return String(randomInt(1_000_000_000, 9_999_999_999));
+}
+
+async function appRequest(path: string): Promise<Response> {
+  const app = createApp({ signal: context.signal });
+  return await app.request(`http://api.test${path}`, { method: "GET" });
+}
+
+async function seedComposeFixture(
+  cleanup: CleanupState,
+): Promise<ComposeFixture> {
+  const orgId = `org_${randomUUID()}`;
+  const userId = `user_${randomUUID()}`;
+  const { composeId } = await store.set(
+    seedCompose$,
+    { orgId, userId },
+    context.signal,
+  );
+  const fixture = { orgId, userId, composeId };
+  cleanup.composeFixtures.push(fixture);
+  cleanup.userIds.push(userId);
+  return fixture;
+}
+
+function buildSignedState(args: {
+  readonly userId: string;
+  readonly composeId: string;
+}): string {
+  const payload = `${args.userId}:${args.composeId}`;
+  const sig = createHmac("sha256", "a".repeat(64))
+    .update(payload)
+    .digest("hex");
+  return JSON.stringify({
+    vm0UserId: args.userId,
+    composeId: args.composeId,
+    sig,
+  });
+}
+
+function mockGitHubInstallationsList(
+  installations: readonly {
+    readonly id: string;
+    readonly targetId: string;
+    readonly login?: string;
+    readonly type?: string;
+  }[],
+): void {
+  server.use(
+    http.get("https://api.github.com/app/installations", () => {
+      return HttpResponse.json(
+        installations.map((installation) => {
+          return {
+            id: Number(installation.id),
+            account: {
+              id: Number(installation.targetId),
+              login: installation.login ?? TARGET_LOGIN,
+              type: installation.type ?? TARGET_TYPE,
+            },
+          };
+        }),
+      );
+    }),
+  );
+}
+
+function mockGitHubInstallation(args: {
+  readonly installationId: string;
+  readonly targetId: string;
+  readonly login?: string;
+  readonly type?: string;
+  readonly token?: string;
+}): void {
+  server.use(
+    http.get(
+      "https://api.github.com/app/installations/:installationId",
+      ({ params }) => {
+        expect(String(params.installationId)).toBe(args.installationId);
+        return HttpResponse.json({
+          id: Number(args.installationId),
+          account: {
+            id: Number(args.targetId),
+            login: args.login ?? TARGET_LOGIN,
+            type: args.type ?? TARGET_TYPE,
+          },
+        });
+      },
+    ),
+    http.post(
+      "https://api.github.com/app/installations/:installationId/access_tokens",
+      ({ params }) => {
+        expect(String(params.installationId)).toBe(args.installationId);
+        return HttpResponse.json({
+          token: args.token ?? "ghs_test_installation_token",
+          expires_at: "2099-01-01T00:00:00Z",
+        });
+      },
+    ),
+  );
+}
+
+async function seedGithubConnector(args: {
+  readonly fixture: ComposeFixture;
+  readonly githubUserId: string;
+}): Promise<void> {
+  await store.set(writeDb$).insert(connectors).values({
+    type: "github",
+    authMethod: "oauth",
+    externalId: args.githubUserId,
+    externalUsername: "octocat",
+    userId: args.fixture.userId,
+    orgId: args.fixture.orgId,
+  });
+}
+
+async function findInstallationByRemoteId(installationId: string) {
+  return await store
+    .set(writeDb$)
+    .select()
+    .from(githubInstallations)
+    .where(eq(githubInstallations.installationId, installationId));
+}
+
+async function findInstallationByTargetId(targetId: string) {
+  return await store
+    .set(writeDb$)
+    .select()
+    .from(githubInstallations)
+    .where(eq(githubInstallations.targetId, targetId));
+}
+
+async function findLinksForUser(userId: string) {
+  return await store
+    .set(writeDb$)
+    .select()
+    .from(githubUserLinks)
+    .where(eq(githubUserLinks.vm0UserId, userId));
+}
+
+describe("GitHub OAuth API routes", () => {
+  const cleanup = createCleanupState();
+
+  beforeEach(() => {
+    mockEnv("SECRETS_ENCRYPTION_KEY", "a".repeat(64));
+    mockGithubAppEnv();
+  });
+
+  afterEach(async () => {
+    const db = store.set(writeDb$);
+    if (cleanup.installationIds.length > 0) {
+      await db
+        .delete(githubInstallations)
+        .where(
+          inArray(githubInstallations.installationId, cleanup.installationIds),
+        );
+    }
+    if (cleanup.installationRowIds.length > 0) {
+      await db
+        .delete(githubInstallations)
+        .where(inArray(githubInstallations.id, cleanup.installationRowIds));
+    }
+    if (cleanup.targetIds.length > 0) {
+      await db
+        .delete(githubInstallations)
+        .where(inArray(githubInstallations.targetId, cleanup.targetIds));
+    }
+    if (cleanup.userIds.length > 0) {
+      await db
+        .delete(githubUserLinks)
+        .where(inArray(githubUserLinks.vm0UserId, cleanup.userIds));
+      await db
+        .delete(connectors)
+        .where(inArray(connectors.userId, cleanup.userIds));
+    }
+    while (cleanup.composeFixtures.length > 0) {
+      const fixture = cleanup.composeFixtures.pop();
+      if (fixture) {
+        await store.set(
+          deleteUsageInsightFixture$,
+          { orgId: fixture.orgId, userId: fixture.userId },
+          context.signal,
+        );
+      }
+    }
+    cleanup.installationIds = [];
+    cleanup.installationRowIds = [];
+    cleanup.targetIds = [];
+    cleanup.userIds = [];
+  });
+
+  it("redirects install requests to GitHub with signed state and API callback URI", async () => {
+    mockGithubAppEnv({ credentials: false });
+
+    const response = await appRequest(
+      "/api/github/oauth/install?vm0UserId=user-1&composeId=compose-1",
+    );
+
+    expect(response.status).toBe(307);
+    const location = new URL(response.headers.get("location")!);
+    expect(location.origin).toBe("https://github.com");
+    expect(location.pathname).toBe(`/apps/${APP_SLUG}/installations/new`);
+    expect(location.searchParams.get("redirect_uri")).toBe(
+      "http://localhost:3000/api/github/oauth/callback",
+    );
+    const state = JSON.parse(location.searchParams.get("state")!) as {
+      readonly vm0UserId: string;
+      readonly composeId: string;
+      readonly sig: string;
+    };
+    expect(state.vm0UserId).toBe("user-1");
+    expect(state.composeId).toBe("compose-1");
+    expect(state.sig).toBe(
+      createHmac("sha256", "a".repeat(64))
+        .update("user-1:compose-1")
+        .digest("hex"),
+    );
+  });
+
+  it("redirects install requests to GitHub without state when no query is provided", async () => {
+    const response = await appRequest("/api/github/oauth/install");
+
+    expect(response.status).toBe(307);
+    const location = new URL(response.headers.get("location")!);
+    expect(location.origin).toBe("https://github.com");
+    expect(location.searchParams.has("state")).toBeFalsy();
+    expect(location.searchParams.get("redirect_uri")).toBe(
+      "http://localhost:3000/api/github/oauth/callback",
+    );
+  });
+
+  it("returns 503 when GitHub App slug is not configured", async () => {
+    mockOptionalEnv("GITHUB_APP_SLUG", undefined);
+
+    const response = await appRequest("/api/github/oauth/install");
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toStrictEqual({
+      error: "GitHub App integration is not configured",
+    });
+  });
+
+  it("links a local active installation during install", async () => {
+    const fixture = await seedComposeFixture(cleanup);
+    const githubUserId = newGithubUserId();
+    await seedGithubConnector({ fixture, githubUserId });
+    const [installation] = await store
+      .set(writeDb$)
+      .insert(githubInstallations)
+      .values({
+        installationId: "987654321",
+        status: "active",
+        adminGithubUserId: null,
+        defaultComposeId: fixture.composeId,
+      })
+      .returning({ id: githubInstallations.id });
+    expect(installation).toBeDefined();
+    cleanup.installationRowIds.push(installation!.id);
+
+    const response = await appRequest(
+      `/api/github/oauth/install?vm0UserId=${fixture.userId}&composeId=${fixture.composeId}`,
+    );
+
+    expect(response.status).toBe(307);
+    const location = new URL(response.headers.get("location")!);
+    expect(location.pathname).toBe("/settings");
+    expect(location.searchParams.get("tab")).toBe("integrations");
+    const links = await findLinksForUser(fixture.userId);
+    expect(links).toHaveLength(1);
+    expect(links[0]!.githubUserId).toBe(githubUserId);
+    const [linkedInstallation] = await store
+      .set(writeDb$)
+      .select({ status: githubInstallations.status })
+      .from(githubInstallations)
+      .where(eq(githubInstallations.id, links[0]!.installationId));
+    expect(linkedInstallation?.status).toBe("active");
+  });
+
+  it("creates and links a missing local installation during install from GitHub API data", async () => {
+    const fixture = await seedComposeFixture(cleanup);
+    const installationId = "123450001";
+    const targetId = newGithubUserId();
+    cleanup.installationIds.push(installationId);
+    mockGitHubInstallationsList([
+      { id: installationId, targetId, type: "User" },
+    ]);
+    mockGitHubInstallation({
+      installationId,
+      targetId,
+      type: "User",
+      token: "ghs_remote_installation_token",
+    });
+
+    const response = await appRequest(
+      `/api/github/oauth/install?vm0UserId=${fixture.userId}&composeId=${fixture.composeId}`,
+    );
+
+    expect(response.status).toBe(307);
+    expect(new URL(response.headers.get("location")!).pathname).toBe(
+      "/settings",
+    );
+    const installations = await findInstallationByRemoteId(installationId);
+    expect(installations).toHaveLength(1);
+    expect(installations[0]!.defaultComposeId).toBe(fixture.composeId);
+    expect(installations[0]!.targetId).toBe(targetId);
+    expect(installations[0]!.adminGithubUserId).toBe(targetId);
+    expect(decryptSecretValue(installations[0]!.encryptedAccessToken!)).toBe(
+      "ghs_remote_installation_token",
+    );
+    const links = await findLinksForUser(fixture.userId);
+    expect(links).toHaveLength(1);
+  });
+
+  it("redirects callback with an error when app credentials are missing", async () => {
+    mockOptionalEnv("GITHUB_APP_ID", undefined);
+    mockOptionalEnv("GITHUB_APP_PRIVATE_KEY", undefined);
+
+    const response = await appRequest("/api/github/oauth/callback");
+
+    expect(response.status).toBe(307);
+    const location = response.headers.get("location");
+    expect(location).toContain("/works?error=");
+    expect(location).toContain(
+      "GitHub%20App%20integration%20is%20not%20configured",
+    );
+  });
+
+  it("redirects callback update actions without an error", async () => {
+    const response = await appRequest(
+      "/api/github/oauth/callback?installation_id=12345&setup_action=update",
+    );
+
+    expect(response.status).toBe(307);
+    const location = response.headers.get("location");
+    expect(location).toContain("/works");
+    expect(location).not.toContain("error=");
+  });
+
+  it("redirects callback with an error for invalid JSON state", async () => {
+    const response = await appRequest(
+      "/api/github/oauth/callback?installation_id=12345&setup_action=install&state=not-json",
+    );
+
+    expect(response.status).toBe(307);
+    const location = response.headers.get("location");
+    expect(location).toContain("/works?error=");
+    expect(location).toContain("Invalid%20OAuth%20state");
+  });
+
+  it("redirects callback with an error for invalid state signature", async () => {
+    const state = JSON.stringify({
+      vm0UserId: "user-123",
+      composeId: "compose-123",
+      sig: "invalid-signature",
+    });
+
+    const response = await appRequest(
+      `/api/github/oauth/callback?installation_id=12345&setup_action=install&state=${encodeURIComponent(state)}`,
+    );
+
+    expect(response.status).toBe(307);
+    const location = response.headers.get("location");
+    expect(location).toContain("/works?error=");
+    expect(location).toContain("Invalid%20state%20signature");
+  });
+
+  it("redirects callback with an error when no default compose is configured", async () => {
+    mockEnv("VM0_DEFAULT_AGENT", "");
+
+    const response = await appRequest(
+      "/api/github/oauth/callback?installation_id=12345&setup_action=install",
+    );
+
+    expect(response.status).toBe(307);
+    const location = response.headers.get("location");
+    expect(location).toContain("/works?error=");
+    expect(location).toContain("Missing%20default%20agent");
+  });
+
+  it("creates a pending installation for request actions", async () => {
+    const fixture = await seedComposeFixture(cleanup);
+    const targetId = "777888999";
+    cleanup.targetIds.push(targetId);
+    const state = buildSignedState({
+      userId: fixture.userId,
+      composeId: fixture.composeId,
+    });
+
+    const response = await appRequest(
+      `/api/github/oauth/callback?setup_action=request&target_id=${targetId}&target_type=Organization&state=${encodeURIComponent(state)}`,
+    );
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toContain("/works?pending=true");
+    const installations = await findInstallationByTargetId(targetId);
+    expect(installations).toHaveLength(1);
+    expect(installations[0]).toMatchObject({
+      installationId: null,
+      encryptedAccessToken: null,
+      status: "pending",
+      targetId,
+      targetType: "Organization",
+      defaultComposeId: fixture.composeId,
+    });
+  });
+
+  it("redirects callback with an error when installation id is missing", async () => {
+    const fixture = await seedComposeFixture(cleanup);
+    const state = buildSignedState({
+      userId: fixture.userId,
+      composeId: fixture.composeId,
+    });
+
+    const response = await appRequest(
+      `/api/github/oauth/callback?setup_action=install&state=${encodeURIComponent(state)}`,
+    );
+
+    expect(response.status).toBe(307);
+    const location = response.headers.get("location");
+    expect(location).toContain("/works?error=");
+    expect(location).toContain("Missing%20installation%20ID");
+  });
+
+  it("creates an active installation and link on valid callback", async () => {
+    const fixture = await seedComposeFixture(cleanup);
+    const installationId = "223344556";
+    const targetId = "112233445";
+    cleanup.installationIds.push(installationId);
+    await seedGithubConnector({ fixture, githubUserId: targetId });
+    mockGitHubInstallation({
+      installationId,
+      targetId,
+      token: "ghs_callback_installation_token",
+    });
+    const state = buildSignedState({
+      userId: fixture.userId,
+      composeId: fixture.composeId,
+    });
+
+    const response = await appRequest(
+      `/api/github/oauth/callback?installation_id=${installationId}&setup_action=install&state=${encodeURIComponent(state)}`,
+    );
+
+    expect(response.status).toBe(307);
+    const location = response.headers.get("location");
+    expect(location).toContain("/works");
+    expect(location).not.toContain("error=");
+    const installations = await findInstallationByRemoteId(installationId);
+    expect(installations).toHaveLength(1);
+    expect(installations[0]).toMatchObject({
+      installationId,
+      status: "active",
+      targetType: TARGET_TYPE,
+      targetId,
+      targetName: TARGET_LOGIN,
+      defaultComposeId: fixture.composeId,
+    });
+    expect(decryptSecretValue(installations[0]!.encryptedAccessToken!)).toBe(
+      "ghs_callback_installation_token",
+    );
+    const links = await findLinksForUser(fixture.userId);
+    expect(links).toHaveLength(1);
+    expect(links[0]!.githubUserId).toBe(targetId);
+  });
+
+  it("reuses an existing installation during callback", async () => {
+    const fixture = await seedComposeFixture(cleanup);
+    const installationId = "667788990";
+    const [installation] = await store
+      .set(writeDb$)
+      .insert(githubInstallations)
+      .values({
+        installationId,
+        status: "active",
+        targetType: TARGET_TYPE,
+        targetId: "101010101",
+        defaultComposeId: fixture.composeId,
+      })
+      .returning({ id: githubInstallations.id });
+    expect(installation).toBeDefined();
+    cleanup.installationRowIds.push(installation!.id);
+    await seedGithubConnector({ fixture, githubUserId: "101010101" });
+    const state = buildSignedState({
+      userId: fixture.userId,
+      composeId: fixture.composeId,
+    });
+
+    const response = await appRequest(
+      `/api/github/oauth/callback?installation_id=${installationId}&setup_action=install&state=${encodeURIComponent(state)}`,
+    );
+
+    expect(response.status).toBe(307);
+    const installations = await findInstallationByRemoteId(installationId);
+    expect(installations).toHaveLength(1);
+    const links = await findLinksForUser(fixture.userId);
+    expect(links).toHaveLength(1);
+  });
+
+  it("returns 500 when the GitHub installation info request fails", async () => {
+    const fixture = await seedComposeFixture(cleanup);
+    const installationId = "887766554";
+    const state = buildSignedState({
+      userId: fixture.userId,
+      composeId: fixture.composeId,
+    });
+    server.use(
+      http.get(
+        "https://api.github.com/app/installations/:installationId",
+        () => {
+          return HttpResponse.json(
+            { message: "Bad credentials" },
+            { status: 401 },
+          );
+        },
+      ),
+    );
+
+    const response = await appRequest(
+      `/api/github/oauth/callback?installation_id=${installationId}&setup_action=install&state=${encodeURIComponent(state)}`,
+    );
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toStrictEqual({
+      error: "Internal server error",
+    });
+  });
+});

--- a/turbo/apps/api/src/signals/routes/github-oauth.ts
+++ b/turbo/apps/api/src/signals/routes/github-oauth.ts
@@ -90,11 +90,12 @@ const installGithubOauth$ = command(
       }
     }
 
-    const state = buildGithubOauthState({
+    const state = await buildGithubOauthState({
       vm0UserId: query.vm0UserId,
       composeId: query.composeId,
       secretsEncryptionKey: env("SECRETS_ENCRYPTION_KEY"),
     });
+    signal.throwIfAborted();
 
     const installUrl = new URL(
       `https://github.com/apps/${appSlug}/installations/new`,
@@ -132,10 +133,10 @@ const callbackGithubOauth$ = command(
     }
 
     if (
-      !isGithubOauthStateSignatureValid({
+      !(await isGithubOauthStateSignatureValid({
         state,
         secretsEncryptionKey,
-      })
+      }))
     ) {
       return worksErrorRedirect(
         "Invalid state signature. Please try installing again from the Platform.",

--- a/turbo/apps/api/src/signals/routes/github-oauth.ts
+++ b/turbo/apps/api/src/signals/routes/github-oauth.ts
@@ -1,0 +1,239 @@
+import { command } from "ccstate";
+import { githubOauthContract } from "@vm0/api-contracts/contracts/github-oauth";
+
+import { queryOf } from "../context/request";
+import { writeDb$ } from "../external/db";
+import { env, optionalEnv } from "../../lib/env";
+import {
+  buildGithubOauthState,
+  createOrActivateGithubInstallation,
+  createPendingGithubInstallation,
+  findGithubInstallationByInstallationId,
+  getGithubInstallationAccessToken,
+  getGithubInstallationInfo,
+  isGithubOauthStateSignatureValid,
+  linkGithubVm0User,
+  parseGithubOauthState,
+  tryLinkGithubFromLocalRecord,
+  tryLinkGithubFromRemoteInstallations,
+} from "../services/github-oauth.service";
+import { encryptSecretValue } from "../services/crypto.utils";
+import type { RouteEntry } from "../route";
+
+const REDIRECT_STATUS = 307;
+
+function redirectResponse(url: string): Response {
+  return new Response(null, {
+    status: REDIRECT_STATUS,
+    headers: { location: url },
+  });
+}
+
+function jsonErrorResponse(error: string, status: number): Response {
+  return new Response(JSON.stringify({ error }), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function appUrl(path: string): string {
+  return `${env("VM0_WEB_URL")}${path}`;
+}
+
+function callbackRedirectUri(): string {
+  return `${env("VM0_API_URL")}/api/github/oauth/callback`;
+}
+
+function worksErrorRedirect(message: string): Response {
+  return redirectResponse(
+    appUrl(`/works?error=${encodeURIComponent(message)}`),
+  );
+}
+
+const installGithubOauth$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const appSlug = optionalEnv("GITHUB_APP_SLUG");
+    if (!appSlug) {
+      return jsonErrorResponse("GitHub App integration is not configured", 503);
+    }
+
+    const query = get(queryOf(githubOauthContract.install));
+    const appId = optionalEnv("GITHUB_APP_ID");
+    const privateKey = optionalEnv("GITHUB_APP_PRIVATE_KEY");
+
+    if (appId && privateKey && query.vm0UserId) {
+      const db = set(writeDb$);
+      const linkedFromLocal = await tryLinkGithubFromLocalRecord({
+        db,
+        vm0UserId: query.vm0UserId,
+        signal,
+      });
+      signal.throwIfAborted();
+
+      if (linkedFromLocal) {
+        return redirectResponse(appUrl("/settings?tab=integrations"));
+      }
+
+      const linkedFromRemote = await tryLinkGithubFromRemoteInstallations({
+        db,
+        appId,
+        privateKey,
+        vm0UserId: query.vm0UserId,
+        composeId: query.composeId ?? null,
+        fallbackComposeId: env("VM0_DEFAULT_AGENT") ?? null,
+        signal,
+      });
+      signal.throwIfAborted();
+
+      if (linkedFromRemote) {
+        return redirectResponse(appUrl("/settings?tab=integrations"));
+      }
+    }
+
+    const state = buildGithubOauthState({
+      vm0UserId: query.vm0UserId,
+      composeId: query.composeId,
+      secretsEncryptionKey: env("SECRETS_ENCRYPTION_KEY"),
+    });
+
+    const installUrl = new URL(
+      `https://github.com/apps/${appSlug}/installations/new`,
+    );
+    if (state) {
+      installUrl.searchParams.set("state", state);
+    }
+    installUrl.searchParams.set("redirect_uri", callbackRedirectUri());
+
+    return redirectResponse(installUrl.toString());
+  },
+);
+
+const callbackGithubOauth$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const appId = optionalEnv("GITHUB_APP_ID");
+    const privateKey = optionalEnv("GITHUB_APP_PRIVATE_KEY");
+
+    if (!appId || !privateKey) {
+      return worksErrorRedirect("GitHub App integration is not configured");
+    }
+
+    const query = get(queryOf(githubOauthContract.callback));
+
+    if (query.setup_action === "update") {
+      return redirectResponse(appUrl("/works"));
+    }
+
+    const secretsEncryptionKey = env("SECRETS_ENCRYPTION_KEY");
+    const state = parseGithubOauthState(query.state);
+    if (!state) {
+      return worksErrorRedirect(
+        "Invalid OAuth state. Please try installing again from the Platform.",
+      );
+    }
+
+    if (
+      !isGithubOauthStateSignatureValid({
+        state,
+        secretsEncryptionKey,
+      })
+    ) {
+      return worksErrorRedirect(
+        "Invalid state signature. Please try installing again from the Platform.",
+      );
+    }
+
+    const composeId = state.composeId ?? env("VM0_DEFAULT_AGENT") ?? null;
+    if (!composeId) {
+      return worksErrorRedirect(
+        "Missing default agent. Please set VM0_DEFAULT_AGENT or select an agent before connecting GitHub.",
+      );
+    }
+
+    const db = set(writeDb$);
+
+    if (query.setup_action === "request") {
+      await createPendingGithubInstallation({
+        db,
+        targetId: query.target_id ?? null,
+        targetType: query.target_type ?? "Organization",
+        composeId,
+        signal,
+      });
+
+      return redirectResponse(appUrl("/works?pending=true"));
+    }
+
+    const installationId = query.installation_id;
+    if (!installationId) {
+      return worksErrorRedirect("Missing installation ID from GitHub");
+    }
+
+    const existing = await findGithubInstallationByInstallationId({
+      db,
+      installationId,
+      signal,
+    });
+    if (existing) {
+      if (state.vm0UserId) {
+        await linkGithubVm0User({
+          db,
+          installRecordId: existing.id,
+          vm0UserId: state.vm0UserId,
+          signal,
+        });
+      }
+      return redirectResponse(appUrl("/works"));
+    }
+
+    const installInfo = await getGithubInstallationInfo({
+      appId,
+      privateKey,
+      installationId,
+      signal,
+    });
+    signal.throwIfAborted();
+
+    const { token } = await getGithubInstallationAccessToken({
+      appId,
+      privateKey,
+      installationId,
+      signal,
+    });
+    signal.throwIfAborted();
+
+    const adminGithubUserId =
+      installInfo.targetType === "User" ? installInfo.targetId : null;
+    const installRecordId = await createOrActivateGithubInstallation({
+      db,
+      installationId,
+      installInfo,
+      encryptedAccessToken: encryptSecretValue(token),
+      adminGithubUserId,
+      composeId,
+      signal,
+    });
+
+    if (state.vm0UserId) {
+      await linkGithubVm0User({
+        db,
+        installRecordId,
+        vm0UserId: state.vm0UserId,
+        knownGithubUserId: adminGithubUserId,
+        signal,
+      });
+    }
+
+    return redirectResponse(appUrl("/works"));
+  },
+);
+
+export const githubOauthRoutes: readonly RouteEntry[] = [
+  {
+    route: githubOauthContract.install,
+    handler: installGithubOauth$,
+  },
+  {
+    route: githubOauthContract.callback,
+    handler: callbackGithubOauth$,
+  },
+];

--- a/turbo/apps/api/src/signals/services/github-oauth.service.ts
+++ b/turbo/apps/api/src/signals/services/github-oauth.service.ts
@@ -1,0 +1,546 @@
+import { Buffer } from "node:buffer";
+import { createHmac, createSign, timingSafeEqual } from "node:crypto";
+
+import { and, eq } from "drizzle-orm";
+import { connectors } from "@vm0/db/schema/connector";
+import { githubInstallations } from "@vm0/db/schema/github-installation";
+import { githubUserLinks } from "@vm0/db/schema/github-user-link";
+
+import type { Db } from "../external/db";
+import { safeAsync, safeJsonParse } from "../utils";
+import { now } from "../../lib/time";
+import { logger } from "../../lib/log";
+import { encryptSecretValue } from "./crypto.utils";
+
+const L = logger("GithubOAuth");
+const INSTALLATION_ID_RE = /^\d+$/;
+
+interface AppInstallation {
+  readonly id: number;
+  readonly account: {
+    readonly id: number;
+    readonly login: string;
+    readonly type: string;
+  };
+}
+
+interface GitHubInstallationInfo {
+  readonly targetType: string;
+  readonly targetId: string;
+  readonly targetName: string;
+}
+
+interface GithubOAuthState {
+  readonly vm0UserId: string | null;
+  readonly composeId: string | null;
+  readonly sig: string | null;
+}
+
+function validateInstallationId(installationId: string): string {
+  if (!INSTALLATION_ID_RE.test(installationId)) {
+    throw new Error(
+      `Invalid GitHub installation ID: expected numeric string, got "${installationId}"`,
+    );
+  }
+  return installationId;
+}
+
+function base64url(value: string): string {
+  return Buffer.from(value)
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+function parsePemKey(input: string): string {
+  if (!input.startsWith("-----BEGIN")) {
+    return Buffer.from(input, "base64").toString("utf8");
+  }
+
+  const match = input.match(
+    /^(-----BEGIN [^-]+-----)[\s]+([\s\S]+?)[\s]+(-----END [^-]+-----)$/,
+  );
+  if (!match) {
+    return input;
+  }
+
+  const header = match[1];
+  const body = match[2];
+  const footer = match[3];
+  if (!header || !body || !footer) {
+    return input;
+  }
+
+  return `${header}\n${body.replace(/\s+/g, "\n")}\n${footer}\n`;
+}
+
+function createAppJwt(appId: string, privateKeyPemOrBase64: string): string {
+  const nowSeconds = Math.floor(now() / 1000);
+  const encodedHeader = base64url(JSON.stringify({ alg: "RS256", typ: "JWT" }));
+  const encodedPayload = base64url(
+    JSON.stringify({
+      iat: nowSeconds - 60,
+      exp: nowSeconds + 600,
+      iss: appId,
+    }),
+  );
+  const signingInput = `${encodedHeader}.${encodedPayload}`;
+  const signer = createSign("RSA-SHA256");
+  signer.update(signingInput);
+  const signature = signer.sign(
+    parsePemKey(privateKeyPemOrBase64),
+    "base64url",
+  );
+
+  return `${signingInput}.${signature}`;
+}
+
+function githubHeaders(appId: string, privateKey: string): HeadersInit {
+  return {
+    Authorization: `Bearer ${createAppJwt(appId, privateKey)}`,
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+  };
+}
+
+async function listGithubAppInstallations(args: {
+  readonly appId: string;
+  readonly privateKey: string;
+  readonly signal: AbortSignal;
+}): Promise<readonly AppInstallation[]> {
+  const response = await fetch("https://api.github.com/app/installations", {
+    headers: githubHeaders(args.appId, args.privateKey),
+    signal: args.signal,
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(
+      `Failed to list app installations: ${response.status} ${body}`,
+    );
+  }
+
+  return (await response.json()) as AppInstallation[];
+}
+
+export async function getGithubInstallationInfo(args: {
+  readonly appId: string;
+  readonly privateKey: string;
+  readonly installationId: string;
+  readonly signal: AbortSignal;
+}): Promise<GitHubInstallationInfo> {
+  const installationId = validateInstallationId(args.installationId);
+  const response = await fetch(
+    `https://api.github.com/app/installations/${installationId}`,
+    {
+      headers: githubHeaders(args.appId, args.privateKey),
+      signal: args.signal,
+    },
+  );
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(
+      `Failed to get installation info: ${response.status} ${body}`,
+    );
+  }
+
+  const data = (await response.json()) as {
+    readonly account: {
+      readonly id: number;
+      readonly login: string;
+      readonly type: string;
+    };
+  };
+
+  return {
+    targetType: data.account.type,
+    targetId: String(data.account.id),
+    targetName: data.account.login,
+  };
+}
+
+export async function getGithubInstallationAccessToken(args: {
+  readonly appId: string;
+  readonly privateKey: string;
+  readonly installationId: string;
+  readonly signal: AbortSignal;
+}): Promise<{ readonly token: string; readonly expiresAt: string }> {
+  const installationId = validateInstallationId(args.installationId);
+  const response = await fetch(
+    `https://api.github.com/app/installations/${installationId}/access_tokens`,
+    {
+      method: "POST",
+      headers: githubHeaders(args.appId, args.privateKey),
+      signal: args.signal,
+    },
+  );
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(
+      `Failed to get installation access token: ${response.status} ${body}`,
+    );
+  }
+
+  const data = (await response.json()) as {
+    readonly token: string;
+    readonly expires_at: string;
+  };
+  return { token: data.token, expiresAt: data.expires_at };
+}
+
+export function buildGithubOauthState(args: {
+  readonly vm0UserId?: string;
+  readonly composeId?: string;
+  readonly secretsEncryptionKey: string;
+}): string {
+  const state: {
+    vm0UserId?: string;
+    composeId?: string;
+    sig?: string;
+  } = {};
+  if (args.vm0UserId) {
+    state.vm0UserId = args.vm0UserId;
+  }
+  if (args.composeId) {
+    state.composeId = args.composeId;
+  }
+  if (state.vm0UserId) {
+    const payload = `${state.vm0UserId}:${state.composeId ?? ""}`;
+    state.sig = createHmac("sha256", args.secretsEncryptionKey)
+      .update(payload)
+      .digest("hex");
+  }
+
+  return Object.keys(state).length > 0 ? JSON.stringify(state) : "";
+}
+
+export function parseGithubOauthState(
+  state: string | undefined,
+): GithubOAuthState | null {
+  if (!state) {
+    return { vm0UserId: null, composeId: null, sig: null };
+  }
+
+  const parsed = safeJsonParse(state);
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    return null;
+  }
+
+  const stateObject = parsed as {
+    readonly vm0UserId?: unknown;
+    readonly composeId?: unknown;
+    readonly sig?: unknown;
+  };
+
+  return {
+    vm0UserId:
+      typeof stateObject.vm0UserId === "string" ? stateObject.vm0UserId : null,
+    composeId:
+      typeof stateObject.composeId === "string" ? stateObject.composeId : null,
+    sig: typeof stateObject.sig === "string" ? stateObject.sig : null,
+  };
+}
+
+export function isGithubOauthStateSignatureValid(args: {
+  readonly state: GithubOAuthState;
+  readonly secretsEncryptionKey: string;
+}): boolean {
+  if (!args.state.vm0UserId) {
+    return true;
+  }
+
+  const payload = `${args.state.vm0UserId}:${args.state.composeId ?? ""}`;
+  const expectedSig = createHmac("sha256", args.secretsEncryptionKey)
+    .update(payload)
+    .digest("hex");
+
+  return (
+    args.state.sig !== null &&
+    args.state.sig.length === expectedSig.length &&
+    timingSafeEqual(Buffer.from(args.state.sig), Buffer.from(expectedSig))
+  );
+}
+
+export async function linkGithubVm0User(args: {
+  readonly db: Db;
+  readonly installRecordId: string;
+  readonly vm0UserId: string;
+  readonly knownGithubUserId?: string | null;
+  readonly signal: AbortSignal;
+}): Promise<string | null> {
+  let githubUserId = args.knownGithubUserId ?? null;
+
+  if (!githubUserId) {
+    const [connector] = await args.db
+      .select({ externalId: connectors.externalId })
+      .from(connectors)
+      .where(
+        and(
+          eq(connectors.userId, args.vm0UserId),
+          eq(connectors.type, "github"),
+        ),
+      )
+      .limit(1);
+    args.signal.throwIfAborted();
+
+    githubUserId = connector?.externalId ?? null;
+  }
+
+  if (!githubUserId) {
+    return null;
+  }
+
+  await args.db
+    .insert(githubUserLinks)
+    .values({
+      githubUserId,
+      installationId: args.installRecordId,
+      vm0UserId: args.vm0UserId,
+    })
+    .onConflictDoNothing();
+  args.signal.throwIfAborted();
+
+  return githubUserId;
+}
+
+export async function tryLinkGithubFromLocalRecord(args: {
+  readonly db: Db;
+  readonly vm0UserId: string;
+  readonly signal: AbortSignal;
+}): Promise<boolean> {
+  const [existing] = await args.db
+    .select({
+      id: githubInstallations.id,
+      adminGithubUserId: githubInstallations.adminGithubUserId,
+    })
+    .from(githubInstallations)
+    .where(eq(githubInstallations.status, "active"))
+    .limit(1);
+  args.signal.throwIfAborted();
+
+  if (!existing) {
+    return false;
+  }
+
+  const githubUserId = await linkGithubVm0User({
+    db: args.db,
+    installRecordId: existing.id,
+    vm0UserId: args.vm0UserId,
+    signal: args.signal,
+  });
+
+  if (!githubUserId) {
+    return false;
+  }
+
+  if (!existing.adminGithubUserId) {
+    await args.db
+      .update(githubInstallations)
+      .set({ adminGithubUserId: githubUserId })
+      .where(eq(githubInstallations.id, existing.id));
+    args.signal.throwIfAborted();
+  }
+
+  return true;
+}
+
+export async function tryLinkGithubFromRemoteInstallations(args: {
+  readonly db: Db;
+  readonly appId: string;
+  readonly privateKey: string;
+  readonly vm0UserId: string;
+  readonly composeId: string | null;
+  readonly fallbackComposeId: string | null;
+  readonly signal: AbortSignal;
+}): Promise<boolean> {
+  const installationsResult = await safeAsync(() => {
+    return listGithubAppInstallations({
+      appId: args.appId,
+      privateKey: args.privateKey,
+      signal: args.signal,
+    });
+  });
+  if ("error" in installationsResult) {
+    L.warn("Failed to list app installations", {
+      error: installationsResult.error,
+    });
+    return false;
+  }
+  const installations = installationsResult.ok;
+  args.signal.throwIfAborted();
+
+  if (installations.length === 0) {
+    return false;
+  }
+
+  for (const ghInstall of installations) {
+    const ghInstallationId = String(ghInstall.id);
+    const [existing] = await args.db
+      .select({ id: githubInstallations.id })
+      .from(githubInstallations)
+      .where(eq(githubInstallations.installationId, ghInstallationId))
+      .limit(1);
+    args.signal.throwIfAborted();
+
+    if (existing) {
+      const linked = await linkGithubVm0User({
+        db: args.db,
+        installRecordId: existing.id,
+        vm0UserId: args.vm0UserId,
+        signal: args.signal,
+      });
+      return linked !== null;
+    }
+  }
+
+  const ghInstall = installations[0];
+  if (!ghInstall) {
+    return false;
+  }
+
+  const resolvedComposeId = args.composeId ?? args.fallbackComposeId;
+  if (!resolvedComposeId) {
+    return false;
+  }
+
+  const ghInstallationId = String(ghInstall.id);
+  const { token } = await getGithubInstallationAccessToken({
+    appId: args.appId,
+    privateKey: args.privateKey,
+    installationId: ghInstallationId,
+    signal: args.signal,
+  });
+  args.signal.throwIfAborted();
+
+  const adminGithubUserId =
+    ghInstall.account.type === "User" ? String(ghInstall.account.id) : null;
+
+  const [newInstall] = await args.db
+    .insert(githubInstallations)
+    .values({
+      installationId: ghInstallationId,
+      encryptedAccessToken: encryptSecretValue(token),
+      status: "active",
+      targetType: ghInstall.account.type,
+      targetId: String(ghInstall.account.id),
+      targetName: ghInstall.account.login,
+      adminGithubUserId,
+      defaultComposeId: resolvedComposeId,
+    })
+    .returning({ id: githubInstallations.id });
+  args.signal.throwIfAborted();
+
+  if (!newInstall) {
+    L.error("Failed to create GitHub installation record", {
+      ghInstallationId,
+    });
+    return false;
+  }
+
+  await linkGithubVm0User({
+    db: args.db,
+    installRecordId: newInstall.id,
+    vm0UserId: args.vm0UserId,
+    knownGithubUserId: adminGithubUserId,
+    signal: args.signal,
+  });
+
+  return true;
+}
+
+export async function findGithubInstallationByInstallationId(args: {
+  readonly db: Db;
+  readonly installationId: string;
+  readonly signal: AbortSignal;
+}): Promise<{ readonly id: string } | null> {
+  const [existing] = await args.db
+    .select({ id: githubInstallations.id })
+    .from(githubInstallations)
+    .where(eq(githubInstallations.installationId, args.installationId))
+    .limit(1);
+  args.signal.throwIfAborted();
+
+  return existing ?? null;
+}
+
+export async function createPendingGithubInstallation(args: {
+  readonly db: Db;
+  readonly targetId: string | null;
+  readonly targetType: string;
+  readonly composeId: string;
+  readonly signal: AbortSignal;
+}): Promise<void> {
+  await args.db.insert(githubInstallations).values({
+    installationId: null,
+    encryptedAccessToken: null,
+    status: "pending",
+    targetId: args.targetId,
+    targetType: args.targetType,
+    defaultComposeId: args.composeId,
+  });
+  args.signal.throwIfAborted();
+}
+
+export async function createOrActivateGithubInstallation(args: {
+  readonly db: Db;
+  readonly installationId: string;
+  readonly installInfo: GitHubInstallationInfo;
+  readonly encryptedAccessToken: string;
+  readonly adminGithubUserId: string | null;
+  readonly composeId: string;
+  readonly signal: AbortSignal;
+}): Promise<string> {
+  const [pendingRecord] = await args.db
+    .select({ id: githubInstallations.id })
+    .from(githubInstallations)
+    .where(
+      and(
+        eq(githubInstallations.targetId, args.installInfo.targetId),
+        eq(githubInstallations.status, "pending"),
+      ),
+    )
+    .limit(1);
+  args.signal.throwIfAborted();
+
+  if (pendingRecord) {
+    await args.db
+      .update(githubInstallations)
+      .set({
+        status: "active",
+        installationId: args.installationId,
+        encryptedAccessToken: args.encryptedAccessToken,
+        targetType: args.installInfo.targetType,
+        targetName: args.installInfo.targetName,
+        adminGithubUserId: args.adminGithubUserId,
+        updatedAt: new Date(now()),
+      })
+      .where(eq(githubInstallations.id, pendingRecord.id));
+    args.signal.throwIfAborted();
+
+    return pendingRecord.id;
+  }
+
+  const [newInstall] = await args.db
+    .insert(githubInstallations)
+    .values({
+      installationId: args.installationId,
+      encryptedAccessToken: args.encryptedAccessToken,
+      status: "active",
+      targetType: args.installInfo.targetType,
+      targetId: args.installInfo.targetId,
+      targetName: args.installInfo.targetName,
+      adminGithubUserId: args.adminGithubUserId,
+      defaultComposeId: args.composeId,
+    })
+    .returning({ id: githubInstallations.id });
+  args.signal.throwIfAborted();
+
+  if (!newInstall) {
+    throw new Error("Expected GitHub installation insert to return a row");
+  }
+
+  return newInstall.id;
+}

--- a/turbo/apps/api/src/signals/services/github-oauth.service.ts
+++ b/turbo/apps/api/src/signals/services/github-oauth.service.ts
@@ -1,5 +1,5 @@
 import { Buffer } from "node:buffer";
-import { createHmac, createSign, timingSafeEqual } from "node:crypto";
+import { createSign, timingSafeEqual } from "node:crypto";
 
 import { and, eq } from "drizzle-orm";
 import { connectors } from "@vm0/db/schema/connector";
@@ -191,11 +191,34 @@ export async function getGithubInstallationAccessToken(args: {
   return { token: data.token, expiresAt: data.expires_at };
 }
 
-export function buildGithubOauthState(args: {
+async function createGithubOauthStateSignature(args: {
+  readonly vm0UserId: string;
+  readonly composeId: string | null;
+  readonly secretsEncryptionKey: string;
+}): Promise<string> {
+  const textEncoder = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    "raw",
+    textEncoder.encode(args.secretsEncryptionKey),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const payload = `${args.vm0UserId}:${args.composeId ?? ""}`;
+  const signature = await crypto.subtle.sign(
+    "HMAC",
+    key,
+    textEncoder.encode(payload),
+  );
+
+  return Buffer.from(signature).toString("hex");
+}
+
+export async function buildGithubOauthState(args: {
   readonly vm0UserId?: string;
   readonly composeId?: string;
   readonly secretsEncryptionKey: string;
-}): string {
+}): Promise<string> {
   const state: {
     vm0UserId?: string;
     composeId?: string;
@@ -208,10 +231,11 @@ export function buildGithubOauthState(args: {
     state.composeId = args.composeId;
   }
   if (state.vm0UserId) {
-    const payload = `${state.vm0UserId}:${state.composeId ?? ""}`;
-    state.sig = createHmac("sha256", args.secretsEncryptionKey)
-      .update(payload)
-      .digest("hex");
+    state.sig = await createGithubOauthStateSignature({
+      vm0UserId: state.vm0UserId,
+      composeId: state.composeId ?? null,
+      secretsEncryptionKey: args.secretsEncryptionKey,
+    });
   }
 
   return Object.keys(state).length > 0 ? JSON.stringify(state) : "";
@@ -244,18 +268,19 @@ export function parseGithubOauthState(
   };
 }
 
-export function isGithubOauthStateSignatureValid(args: {
+export async function isGithubOauthStateSignatureValid(args: {
   readonly state: GithubOAuthState;
   readonly secretsEncryptionKey: string;
-}): boolean {
+}): Promise<boolean> {
   if (!args.state.vm0UserId) {
     return true;
   }
 
-  const payload = `${args.state.vm0UserId}:${args.state.composeId ?? ""}`;
-  const expectedSig = createHmac("sha256", args.secretsEncryptionKey)
-    .update(payload)
-    .digest("hex");
+  const expectedSig = await createGithubOauthStateSignature({
+    vm0UserId: args.state.vm0UserId,
+    composeId: args.state.composeId,
+    secretsEncryptionKey: args.secretsEncryptionKey,
+  });
 
   return (
     args.state.sig !== null &&

--- a/turbo/packages/api-contracts/src/contracts/github-oauth.ts
+++ b/turbo/packages/api-contracts/src/contracts/github-oauth.ts
@@ -1,0 +1,50 @@
+import { z } from "zod";
+
+import { initContract } from "./base";
+
+const c = initContract();
+
+const jsonErrorSchema = z.object({ error: z.string() });
+
+export const githubOauthInstallQuerySchema = z.object({
+  vm0UserId: z.string().optional(),
+  composeId: z.string().optional(),
+});
+
+export const githubOauthCallbackQuerySchema = z.object({
+  installation_id: z.string().optional(),
+  setup_action: z.string().optional(),
+  state: z.string().optional(),
+  target_id: z.string().optional(),
+  target_type: z.string().optional(),
+});
+
+export const githubOauthContract = c.router({
+  install: {
+    method: "GET",
+    path: "/api/github/oauth/install",
+    query: githubOauthInstallQuerySchema,
+    responses: {
+      307: c.noBody(),
+      503: jsonErrorSchema,
+    },
+    summary: "Start GitHub App OAuth install",
+  },
+  callback: {
+    method: "GET",
+    path: "/api/github/oauth/callback",
+    query: githubOauthCallbackQuerySchema,
+    responses: {
+      307: c.noBody(),
+    },
+    summary: "Handle GitHub App OAuth callback",
+  },
+});
+
+export type GithubOauthContract = typeof githubOauthContract;
+export type GithubOauthInstallQuery = z.infer<
+  typeof githubOauthInstallQuerySchema
+>;
+export type GithubOauthCallbackQuery = z.infer<
+  typeof githubOauthCallbackQuerySchema
+>;

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -940,6 +940,14 @@ export {
   type IntegrationsGithubContract,
 } from "./integrations-github";
 export {
+  githubOauthContract,
+  githubOauthCallbackQuerySchema,
+  githubOauthInstallQuerySchema,
+  type GithubOauthCallbackQuery,
+  type GithubOauthContract,
+  type GithubOauthInstallQuery,
+} from "./github-oauth";
+export {
   zeroBillingStatusContract,
   zeroBillingCheckoutContract,
   zeroBillingPortalContract,


### PR DESCRIPTION
## Summary
- add API contracts and Hono route registration for GitHub App OAuth install/callback GET routes
- port GitHub App install/callback service logic to apps/api, including signed state handling, installation lookup, token persistence, pending install activation, and VM0 user linking
- add API integration coverage for redirect, linking, pending install, callback, and GitHub API failure cases

Closes #12823

## Tests
- scripts/prepare.sh
- cd turbo && pnpm -F api exec vitest run src/signals/routes/__tests__/github-oauth.test.ts
- cd turbo && pnpm -F api lint
- cd turbo && pnpm -F api check-types
- cd turbo && pnpm -F @vm0/api-contracts lint
- cd turbo && pnpm -F @vm0/api-contracts check-types
- cd turbo && pnpm check-types
- cd turbo && pnpm lint
- cd turbo && pnpm knip --no-progress
- cd turbo && pnpm vitest
- cd turbo && pnpm format