### PR TITLE
feat(api): migrate zero connector post routes

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-computer-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-computer-create.test.ts
@@ -1,0 +1,338 @@
+import { randomUUID } from "node:crypto";
+
+import { zeroComputerConnectorContract } from "@vm0/api-contracts/contracts/zero-connectors";
+import { connectors } from "@vm0/db/schema/connector";
+import { secrets } from "@vm0/db/schema/secret";
+import { createStore } from "ccstate";
+import { and, eq } from "drizzle-orm";
+import { http, HttpResponse } from "msw";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { mockOptionalEnv } from "../../../lib/env";
+import { server } from "../../../mocks/server";
+import { writeDb$ } from "../../external/db";
+import { decryptSecretValue } from "../../services/crypto.utils";
+import { createZeroRouteMocks } from "./helpers/zero-route-test";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+
+const COMPUTER_SECRET_NAMES = Object.freeze([
+  "COMPUTER_CONNECTOR_BRIDGE_TOKEN",
+  "COMPUTER_CONNECTOR_DOMAIN_ID",
+  "COMPUTER_CONNECTOR_DOMAIN",
+] as const);
+
+interface OrgUserFixture {
+  readonly orgId: string;
+  readonly userId: string;
+}
+
+interface NgrokCalls {
+  readonly createBotUser: string[];
+  readonly listBotUsers: string[];
+  readonly filterEndpoints: string[];
+  readonly patchEndpoint: string[];
+  readonly filterReservedDomains: string[];
+  readonly createCredential: string[];
+  readonly deleteCredential: string[];
+  readonly createEndpoint: string[];
+  readonly deleteEndpoint: string[];
+  readonly createReservedDomain: string[];
+  readonly deleteReservedDomain: string[];
+  readonly deleteBotUser: string[];
+}
+
+function uniqueOrgUser(prefix: string): OrgUserFixture {
+  return {
+    orgId: `org_${prefix}_${randomUUID().slice(0, 8)}`,
+    userId: `user_${prefix}_${randomUUID().slice(0, 8)}`,
+  };
+}
+
+async function deleteFixture(fixture: OrgUserFixture): Promise<void> {
+  const db = store.set(writeDb$);
+  await db.delete(secrets).where(eq(secrets.orgId, fixture.orgId));
+  await db.delete(connectors).where(eq(connectors.orgId, fixture.orgId));
+}
+
+function setupNgrokMocks(): NgrokCalls {
+  const calls: NgrokCalls = {
+    createBotUser: [],
+    listBotUsers: [],
+    filterEndpoints: [],
+    patchEndpoint: [],
+    filterReservedDomains: [],
+    createCredential: [],
+    deleteCredential: [],
+    createEndpoint: [],
+    deleteEndpoint: [],
+    createReservedDomain: [],
+    deleteReservedDomain: [],
+    deleteBotUser: [],
+  };
+
+  server.use(
+    http.post("https://api.ngrok.com/bot_users", async ({ request }) => {
+      const body = (await request.json()) as { name: string };
+      calls.createBotUser.push(body.name);
+      return HttpResponse.json({ id: "bot_test_123", name: body.name });
+    }),
+    http.get("https://api.ngrok.com/bot_users", ({ request }) => {
+      calls.listBotUsers.push(new URL(request.url).search);
+      return HttpResponse.json({ bot_users: [], next_page_uri: null });
+    }),
+    http.post("https://api.ngrok.com/credentials", async ({ request }) => {
+      const body = (await request.json()) as {
+        owner_id: string;
+        acl: string[];
+      };
+      calls.createCredential.push(body.owner_id);
+      return HttpResponse.json({
+        id: "cr_test_456",
+        token: "2abc_test_ngrok_authtoken",
+      });
+    }),
+    http.delete("https://api.ngrok.com/credentials/:id", ({ params }) => {
+      calls.deleteCredential.push(params.id as string);
+      return new HttpResponse(null, { status: 204 });
+    }),
+    http.get("https://api.ngrok.com/reserved_domains", ({ request }) => {
+      const url = new URL(request.url);
+      calls.filterReservedDomains.push(url.searchParams.get("filter") ?? "");
+      return HttpResponse.json({
+        reserved_domains: [],
+        next_page_uri: null,
+      });
+    }),
+    http.post("https://api.ngrok.com/reserved_domains", async ({ request }) => {
+      const body = (await request.json()) as { name: string; region: string };
+      calls.createReservedDomain.push(body.name);
+      return HttpResponse.json({
+        id: "rd_test_abc",
+        domain: `${body.name}.ngrok-free.app`,
+        region: body.region,
+        cname_target: null,
+      });
+    }),
+    http.delete("https://api.ngrok.com/reserved_domains/:id", ({ params }) => {
+      calls.deleteReservedDomain.push(params.id as string);
+      return new HttpResponse(null, { status: 204 });
+    }),
+    http.get("https://api.ngrok.com/endpoints", ({ request }) => {
+      const url = new URL(request.url);
+      calls.filterEndpoints.push(url.searchParams.get("filter") ?? "");
+      return HttpResponse.json({ endpoints: [], next_page_uri: null });
+    }),
+    http.patch("https://api.ngrok.com/endpoints/:id", ({ params }) => {
+      calls.patchEndpoint.push(params.id as string);
+      return HttpResponse.json({
+        id: params.id as string,
+        url: "https://*.patched.ngrok-free.app",
+      });
+    }),
+    http.post("https://api.ngrok.com/endpoints", async ({ request }) => {
+      const body = (await request.json()) as { url: string };
+      calls.createEndpoint.push(body.url);
+      return HttpResponse.json({ id: "ep_test_789", url: body.url });
+    }),
+    http.delete("https://api.ngrok.com/endpoints/:id", ({ params }) => {
+      calls.deleteEndpoint.push(params.id as string);
+      return new HttpResponse(null, { status: 204 });
+    }),
+    http.delete("https://api.ngrok.com/bot_users/:id", ({ params }) => {
+      calls.deleteBotUser.push(params.id as string);
+      return new HttpResponse(null, { status: 204 });
+    }),
+  );
+
+  return calls;
+}
+
+async function readConnectorSecrets(
+  fixture: OrgUserFixture,
+): Promise<Map<string, string>> {
+  const db = store.set(writeDb$);
+  const rows = await db
+    .select({ name: secrets.name, encryptedValue: secrets.encryptedValue })
+    .from(secrets)
+    .where(
+      and(
+        eq(secrets.orgId, fixture.orgId),
+        eq(secrets.userId, fixture.userId),
+        eq(secrets.type, "connector"),
+      ),
+    );
+  const values = new Map<string, string>();
+  for (const row of rows) {
+    values.set(row.name, decryptSecretValue(row.encryptedValue));
+  }
+  return values;
+}
+
+describe("POST /api/zero/connectors/computer", () => {
+  const fixtures: OrgUserFixture[] = [];
+
+  afterEach(async () => {
+    while (fixtures.length > 0) {
+      const fixture = fixtures.pop();
+      if (fixture) {
+        await deleteFixture(fixture);
+      }
+    }
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    const client = setupApp({ context })(zeroComputerConnectorContract);
+
+    const response = await accept(
+      client.create({ body: {}, headers: {} }),
+      [401],
+    );
+
+    expect(response.body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("returns 401 when the authenticated session has no organization", async () => {
+    mocks.clerk.session(`user_${randomUUID()}`, null);
+    const client = setupApp({ context })(zeroComputerConnectorContract);
+
+    const response = await accept(
+      client.create({
+        body: {},
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [401],
+    );
+
+    expect(response.body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("returns 400 when ngrok is not configured", async () => {
+    const fixture = uniqueOrgUser("zcomp-no-ngrok");
+    fixtures.push(fixture);
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    const client = setupApp({ context })(zeroComputerConnectorContract);
+
+    const response = await accept(
+      client.create({
+        body: {},
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [400],
+    );
+
+    expect(response.body.error).toStrictEqual({
+      message: "Invalid request",
+      code: "BAD_REQUEST",
+    });
+  });
+
+  it("creates a computer connector", async () => {
+    const fixture = uniqueOrgUser("zcomp-create");
+    fixtures.push(fixture);
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    mockOptionalEnv("NGROK_API_KEY", "test-ngrok-key");
+    const ngrokCalls = setupNgrokMocks();
+    const client = setupApp({ context })(zeroComputerConnectorContract);
+
+    const response = await accept(
+      client.create({
+        body: {},
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body.id).toBeDefined();
+    expect(response.body.ngrokToken).toBe("2abc_test_ngrok_authtoken");
+    expect(response.body.bridgeToken).toBeDefined();
+    expect(response.body.endpointPrefix).toContain("vm0-user-");
+    expect(response.body.domain).toContain(".ngrok-free.app");
+
+    expect(ngrokCalls.createBotUser).toHaveLength(1);
+    expect(ngrokCalls.createCredential).toStrictEqual(["bot_test_123"]);
+    expect(ngrokCalls.createReservedDomain).toHaveLength(1);
+    expect(ngrokCalls.createEndpoint).toStrictEqual([
+      `https://*.${response.body.domain}`,
+    ]);
+
+    const storedSecrets = await readConnectorSecrets(fixture);
+    for (const name of COMPUTER_SECRET_NAMES) {
+      expect(storedSecrets.has(name)).toBeTruthy();
+    }
+    expect(storedSecrets.get("COMPUTER_CONNECTOR_BRIDGE_TOKEN")).toBe(
+      response.body.bridgeToken,
+    );
+    expect(storedSecrets.get("COMPUTER_CONNECTOR_DOMAIN_ID")).toBe(
+      "rd_test_abc",
+    );
+    expect(storedSecrets.get("COMPUTER_CONNECTOR_DOMAIN")).toBe(
+      response.body.domain,
+    );
+  });
+
+  it("returns 409 when the computer connector already exists", async () => {
+    const fixture = uniqueOrgUser("zcomp-duplicate");
+    fixtures.push(fixture);
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    mockOptionalEnv("NGROK_API_KEY", "test-ngrok-key");
+    setupNgrokMocks();
+    const client = setupApp({ context })(zeroComputerConnectorContract);
+
+    await accept(
+      client.create({
+        body: {},
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    const response = await accept(
+      client.create({
+        body: {},
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [409],
+    );
+
+    expect(response.body.error).toStrictEqual({
+      message: "Resource conflict",
+      code: "CONFLICT",
+    });
+  });
+
+  it("cleans up resources when endpoint creation fails", async () => {
+    const fixture = uniqueOrgUser("zcomp-endpoint-fail");
+    fixtures.push(fixture);
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    mockOptionalEnv("NGROK_API_KEY", "test-ngrok-key");
+    const ngrokCalls = setupNgrokMocks();
+    server.use(
+      http.post("https://api.ngrok.com/endpoints", () => {
+        return HttpResponse.json({ error: "internal error" }, { status: 500 });
+      }),
+    );
+    const client = setupApp({ context })(zeroComputerConnectorContract);
+
+    await expect(
+      client.create({
+        body: {},
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+    ).rejects.toThrow();
+
+    expect(ngrokCalls.deleteCredential).toStrictEqual(["cr_test_456"]);
+    expect(ngrokCalls.deleteReservedDomain).toStrictEqual(["rd_test_abc"]);
+    expect(ngrokCalls.deleteBotUser).toStrictEqual(["bot_test_123"]);
+
+    const db = store.set(writeDb$);
+    const connectorRows = await db
+      .select({ id: connectors.id })
+      .from(connectors)
+      .where(eq(connectors.orgId, fixture.orgId));
+    expect(connectorRows).toStrictEqual([]);
+  });
+});

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-sessions-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-sessions-create.test.ts
@@ -1,0 +1,90 @@
+import { randomUUID } from "node:crypto";
+
+import { zeroConnectorSessionsContract } from "@vm0/api-contracts/contracts/zero-connectors";
+import { connectorSessions } from "@vm0/db/schema/connector-session";
+import { createStore } from "ccstate";
+import { eq } from "drizzle-orm";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { writeDb$ } from "../../external/db";
+import { createZeroRouteMocks } from "./helpers/zero-route-test";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+
+describe("POST /api/zero/connectors/:type/sessions", () => {
+  const sessionIds: string[] = [];
+
+  afterEach(async () => {
+    const db = store.set(writeDb$);
+    while (sessionIds.length > 0) {
+      const sessionId = sessionIds.pop();
+      if (sessionId) {
+        await db
+          .delete(connectorSessions)
+          .where(eq(connectorSessions.id, sessionId));
+      }
+    }
+  });
+
+  it("creates a pending connector session", async () => {
+    const userId = `user_${randomUUID()}`;
+    mocks.clerk.session(userId, `org_${randomUUID()}`);
+
+    const client = setupApp({ context })(zeroConnectorSessionsContract);
+    const response = await accept(
+      client.create({
+        params: { type: "github" },
+        body: {},
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+    sessionIds.push(response.body.id);
+
+    expect(response.body.code).toMatch(/^[A-Z0-9]{4}-[A-Z0-9]{4}$/);
+    expect(response.body.type).toBe("github");
+    expect(response.body.status).toBe("pending");
+    expect(response.body.verificationUrl).toContain(
+      "/api/connectors/github/authorize",
+    );
+    expect(response.body.verificationUrl).toContain(
+      `session=${response.body.id}`,
+    );
+    expect(response.body.expiresIn).toBe(900);
+    expect(response.body.interval).toBe(5);
+
+    const db = store.set(writeDb$);
+    const [session] = await db
+      .select({
+        code: connectorSessions.code,
+        type: connectorSessions.type,
+        userId: connectorSessions.userId,
+        status: connectorSessions.status,
+      })
+      .from(connectorSessions)
+      .where(eq(connectorSessions.id, response.body.id));
+    expect(session).toStrictEqual({
+      code: response.body.code,
+      type: "github",
+      userId,
+      status: "pending",
+    });
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    const client = setupApp({ context })(zeroConnectorSessionsContract);
+    const response = await accept(
+      client.create({
+        params: { type: "github" },
+        body: {},
+        headers: {},
+      }),
+      [401],
+    );
+
+    expect(response.body.error.code).toBe("UNAUTHORIZED");
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/zero-connectors.ts
@@ -1,7 +1,10 @@
+import { randomInt } from "node:crypto";
+
 import { command, computed } from "ccstate";
 import {
   zeroComputerConnectorContract,
   zeroConnectorAuthorizeContract,
+  zeroConnectorSessionsContract,
   zeroConnectorSessionByIdContract,
   zeroConnectorScopeDiffContract,
   zeroConnectorsByTypeContract,
@@ -31,7 +34,7 @@ import {
 import { authRoute } from "../auth/auth-route";
 import { request$ } from "../context/hono";
 import { pathParamsOf, queryOf } from "../context/request";
-import { conflict, notFound } from "../../lib/error";
+import { badRequestMessage, conflict, notFound } from "../../lib/error";
 import { env, optionalEnv } from "../../lib/env";
 import { nowDate } from "../../lib/time";
 import { writeDb$ } from "../external/db";
@@ -44,6 +47,7 @@ import {
 } from "../services/zero-connector-data.service";
 import { userFeatureSwitchOverrides } from "../services/feature-switches.service";
 import { connectRemoteAgentConnector$ } from "../services/zero-remote-agent.service";
+import { createComputerConnector$ } from "../services/zero-computer-connector.service";
 import type { RouteEntry } from "../route";
 
 const STATE_COOKIE_NAME = "connector_oauth_state";
@@ -51,6 +55,10 @@ const SESSION_COOKIE_NAME = "connector_oauth_session";
 const PKCE_COOKIE_NAME = "connector_oauth_pkce";
 const COOKIE_MAX_AGE = 15 * 60;
 const REDIRECT_STATUS = 307;
+const CONNECTOR_SESSION_TTL_SECONDS = 15 * 60;
+const CONNECTOR_SESSION_POLL_INTERVAL_SECONDS = 5;
+const CONNECTOR_SESSION_CODE_LENGTH = 8;
+const CONNECTOR_SESSION_CODE_CHARS = "ABCDEFGHJKMNPQRSTUVWXYZ23456789";
 
 const connectorReadAuth = {
   requireOrganization: true,
@@ -91,6 +99,22 @@ function generateState(): string {
   return Array.from(array, (byte) => {
     return byte.toString(16).padStart(2, "0");
   }).join("");
+}
+
+function generateConnectorSessionCode(
+  length: number = CONNECTOR_SESSION_CODE_LENGTH,
+): string {
+  let code = "";
+  for (let i = 0; i < length; i++) {
+    if (i > 0 && i % 4 === 0) {
+      code += "-";
+    }
+    code +=
+      CONNECTOR_SESSION_CODE_CHARS[
+        randomInt(CONNECTOR_SESSION_CODE_CHARS.length)
+      ];
+  }
+  return code;
 }
 
 function isRefreshOnlyConnectorType(type: ConnectorType): boolean {
@@ -320,6 +344,32 @@ const getComputerConnectorInner$ = computed(async (get) => {
   return { status: 200 as const, body: connector };
 });
 
+const createComputerConnectorInner$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const auth = get(organizationAuthContext$);
+    const result = await set(
+      createComputerConnector$,
+      { orgId: auth.orgId, userId: auth.userId },
+      signal,
+    );
+    signal.throwIfAborted();
+
+    switch (result.kind) {
+      case "created": {
+        return { status: 200 as const, body: result.connector };
+      }
+      case "bad_request": {
+        return badRequestMessage("Invalid request");
+      }
+      case "conflict": {
+        return conflict("Resource conflict");
+      }
+    }
+    const exhaustive: never = result;
+    return exhaustive;
+  },
+);
+
 const getScopeDiffInner$ = computed(async (get) => {
   const auth = get(organizationAuthContext$);
   const params = get(pathParamsOf(zeroConnectorScopeDiffContract.getScopeDiff));
@@ -499,6 +549,47 @@ const authorizeConnectorInner$ = command(
   },
 );
 
+const createConnectorSessionInner$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const auth = get(authContext$);
+    const params = get(pathParamsOf(zeroConnectorSessionsContract.create));
+    const code = generateConnectorSessionCode();
+    const expiresAt = new Date(
+      nowDate().getTime() + CONNECTOR_SESSION_TTL_SECONDS * 1000,
+    );
+    const writeDb = set(writeDb$);
+
+    const [session] = await writeDb
+      .insert(connectorSessions)
+      .values({
+        code,
+        type: params.type,
+        userId: auth.userId,
+        status: "pending",
+        expiresAt,
+      })
+      .returning({ id: connectorSessions.id });
+    signal.throwIfAborted();
+
+    if (!session) {
+      throw new Error("Failed to create connector session");
+    }
+
+    return {
+      status: 200 as const,
+      body: {
+        id: session.id,
+        code,
+        type: params.type,
+        status: "pending" as const,
+        verificationUrl: `/api/connectors/${params.type}/authorize?session=${session.id}`,
+        expiresIn: CONNECTOR_SESSION_TTL_SECONDS,
+        interval: CONNECTOR_SESSION_POLL_INTERVAL_SECONDS,
+      },
+    };
+  },
+);
+
 const getConnectorSessionByIdInner$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     const auth = get(authContext$);
@@ -550,6 +641,10 @@ const getConnectorSessionByIdInner$ = command(
 
 export const zeroConnectorsRoutes: readonly RouteEntry[] = [
   {
+    route: zeroComputerConnectorContract.create,
+    handler: authRoute(connectorWriteAuth, createComputerConnectorInner$),
+  },
+  {
     route: zeroComputerConnectorContract.get,
     handler: authRoute(connectorReadAuth, getComputerConnectorInner$),
   },
@@ -576,6 +671,10 @@ export const zeroConnectorsRoutes: readonly RouteEntry[] = [
   {
     route: zeroConnectorSessionByIdContract.get,
     handler: authRoute({}, getConnectorSessionByIdInner$),
+  },
+  {
+    route: zeroConnectorSessionsContract.create,
+    handler: authRoute({}, createConnectorSessionInner$),
   },
   {
     route: zeroConnectorsByTypeContract.get,

--- a/turbo/apps/api/src/signals/services/zero-computer-connector.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-computer-connector.service.ts
@@ -1,0 +1,352 @@
+import { createHash, randomUUID } from "node:crypto";
+
+import type { ComputerConnectorCreateResponse } from "@vm0/api-contracts/contracts/connector-schemas";
+import { connectors } from "@vm0/db/schema/connector";
+import { secrets } from "@vm0/db/schema/secret";
+import { and, eq } from "drizzle-orm";
+import { command } from "ccstate";
+
+import { optionalEnv } from "../../lib/env";
+import { logger } from "../../lib/log";
+import { nowDate } from "../../lib/time";
+import { writeDb$, type Db } from "../external/db";
+import {
+  createCredential,
+  deleteBotUser,
+  deleteCloudEndpoint,
+  deleteCredential,
+  deleteReservedDomain,
+  ensureCloudEndpoint,
+  findOrCreateBotUser,
+  findOrCreateReservedDomain,
+  safeDelete,
+} from "../external/ngrok-client";
+import { safeAsync } from "../utils";
+import { encryptSecretValue } from "./crypto.utils";
+
+const log = logger("service:computer-connector");
+
+const COMPUTER_CONNECTOR_SECRET_NAMES = Object.freeze([
+  "COMPUTER_CONNECTOR_BRIDGE_TOKEN",
+  "COMPUTER_CONNECTOR_DOMAIN_ID",
+  "COMPUTER_CONNECTOR_DOMAIN",
+] as const);
+
+interface CreateComputerConnectorArgs {
+  readonly orgId: string;
+  readonly userId: string;
+}
+
+type CreateComputerConnectorResult =
+  | {
+      readonly kind: "created";
+      readonly connector: ComputerConnectorCreateResponse;
+    }
+  | { readonly kind: "bad_request" }
+  | { readonly kind: "conflict" };
+
+interface ProvisionedRefs {
+  botUserId?: string;
+  credentialId?: string;
+  domainId?: string;
+  endpointId?: string;
+  connectorId?: string;
+}
+
+interface ProvisionContext {
+  readonly db: Db;
+  readonly args: CreateComputerConnectorArgs;
+  readonly apiKey: string;
+  readonly refs: ProvisionedRefs;
+}
+
+function connectorSlug(orgId: string): string {
+  return createHash("sha256").update(orgId).digest("hex").substring(0, 12);
+}
+
+function buildTrafficPolicy(
+  domain: string,
+  endpointPrefix: string,
+  bridgeToken: string,
+): string {
+  return JSON.stringify({
+    on_http_request: [
+      {
+        expressions: [
+          `!('x-vm0-token' in req.headers) || req.headers['x-vm0-token'][0] != '${bridgeToken}'`,
+        ],
+        actions: [{ type: "deny", config: { status_code: 403 } }],
+      },
+      {
+        actions: [
+          {
+            type: "forward-internal",
+            config: {
+              url: `https://$\{conn.server_name.split('.${domain}')[0]}.${endpointPrefix}.internal`,
+              on_error: "continue",
+            },
+          },
+          {
+            type: "custom-response",
+            config: { status_code: 502, body: "Agent offline" },
+          },
+        ],
+      },
+    ],
+  });
+}
+
+async function upsertConnectorSecret(
+  db: Db,
+  args: CreateComputerConnectorArgs,
+  name: (typeof COMPUTER_CONNECTOR_SECRET_NAMES)[number],
+  value: string,
+): Promise<void> {
+  const encryptedValue = encryptSecretValue(value);
+  await db
+    .insert(secrets)
+    .values({
+      orgId: args.orgId,
+      userId: args.userId,
+      name,
+      encryptedValue,
+      type: "connector",
+      description: `Computer connector: ${name}`,
+    })
+    .onConflictDoUpdate({
+      target: [secrets.orgId, secrets.userId, secrets.name, secrets.type],
+      set: {
+        encryptedValue,
+        description: `Computer connector: ${name}`,
+        updatedAt: nowDate(),
+      },
+    });
+}
+
+async function deleteComputerConnectorSecrets(
+  db: Db,
+  args: CreateComputerConnectorArgs,
+): Promise<void> {
+  for (const name of COMPUTER_CONNECTOR_SECRET_NAMES) {
+    await db
+      .delete(secrets)
+      .where(
+        and(
+          eq(secrets.orgId, args.orgId),
+          eq(secrets.userId, args.userId),
+          eq(secrets.name, name),
+          eq(secrets.type, "connector"),
+        ),
+      );
+  }
+}
+
+async function rollbackDbState(
+  db: Db,
+  args: CreateComputerConnectorArgs,
+  refs: ProvisionedRefs,
+): Promise<void> {
+  const result = await safeAsync(async () => {
+    await deleteComputerConnectorSecrets(db, args);
+    if (refs.connectorId) {
+      await db.delete(connectors).where(eq(connectors.id, refs.connectorId));
+    }
+  });
+  if ("error" in result) {
+    log.warn("Failed to clean up computer connector DB state", {
+      orgId: args.orgId,
+      error:
+        result.error instanceof Error
+          ? result.error.message
+          : String(result.error),
+    });
+  }
+}
+
+async function rollbackNgrokResources(
+  apiKey: string,
+  refs: ProvisionedRefs,
+): Promise<void> {
+  if (refs.endpointId) {
+    const endpointId = refs.endpointId;
+    await safeDelete(
+      () => {
+        return deleteCloudEndpoint(apiKey, endpointId);
+      },
+      "Cloud endpoint",
+      endpointId,
+      true,
+    );
+  }
+  if (refs.credentialId) {
+    const credentialId = refs.credentialId;
+    await safeDelete(
+      () => {
+        return deleteCredential(apiKey, credentialId);
+      },
+      "Credential",
+      credentialId,
+      true,
+    );
+  }
+  if (refs.domainId) {
+    const domainId = refs.domainId;
+    await safeDelete(
+      () => {
+        return deleteReservedDomain(apiKey, domainId);
+      },
+      "Reserved domain",
+      domainId,
+      true,
+    );
+  }
+  if (refs.botUserId) {
+    const botUserId = refs.botUserId;
+    await safeDelete(
+      () => {
+        return deleteBotUser(apiKey, botUserId);
+      },
+      "Bot user",
+      botUserId,
+      true,
+    );
+  }
+}
+
+async function provisionAndPersistConnector(
+  ctx: ProvisionContext,
+  signal: AbortSignal,
+): Promise<ComputerConnectorCreateResponse> {
+  const { db, args, apiKey, refs } = ctx;
+  const slug = connectorSlug(args.orgId);
+  const subdomainName = `vm0-user-${slug}`;
+  const endpointPrefix = `vm0-user-${slug}`;
+  const botUserName = `vm0-user-${slug}`;
+
+  const botUser = await findOrCreateBotUser(apiKey, botUserName);
+  signal.throwIfAborted();
+  refs.botUserId = botUser.id;
+
+  const credential = await createCredential(apiKey, botUser.id, [
+    `bind:*.${endpointPrefix}.internal`,
+  ]);
+  signal.throwIfAborted();
+  refs.credentialId = credential.id;
+
+  const reservedDomain = await findOrCreateReservedDomain(
+    apiKey,
+    subdomainName,
+    "us",
+  );
+  signal.throwIfAborted();
+  refs.domainId = reservedDomain.id;
+  const domain = reservedDomain.domain;
+
+  const bridgeToken = randomUUID();
+  const cloudEndpoint = await ensureCloudEndpoint(
+    apiKey,
+    `https://*.${domain}`,
+    buildTrafficPolicy(domain, endpointPrefix, bridgeToken),
+  );
+  signal.throwIfAborted();
+  refs.endpointId = cloudEndpoint.id;
+
+  const [connectorRow] = await db
+    .insert(connectors)
+    .values({
+      userId: args.userId,
+      orgId: args.orgId,
+      type: "computer",
+      authMethod: "api",
+      externalId: refs.botUserId,
+      externalUsername: refs.credentialId,
+      externalEmail: refs.endpointId,
+      oauthScopes: null,
+    })
+    .returning({ id: connectors.id });
+  signal.throwIfAborted();
+
+  if (!connectorRow) {
+    throw new Error("Failed to create computer connector");
+  }
+  refs.connectorId = connectorRow.id;
+
+  await upsertConnectorSecret(
+    db,
+    args,
+    "COMPUTER_CONNECTOR_BRIDGE_TOKEN",
+    bridgeToken,
+  );
+  signal.throwIfAborted();
+  await upsertConnectorSecret(
+    db,
+    args,
+    "COMPUTER_CONNECTOR_DOMAIN_ID",
+    refs.domainId,
+  );
+  signal.throwIfAborted();
+  await upsertConnectorSecret(db, args, "COMPUTER_CONNECTOR_DOMAIN", domain);
+  signal.throwIfAborted();
+
+  log.debug("Computer connector created", {
+    connectorId: connectorRow.id,
+    botUserId: refs.botUserId,
+    domain,
+  });
+
+  return {
+    id: connectorRow.id,
+    ngrokToken: credential.token,
+    bridgeToken,
+    endpointPrefix,
+    domain,
+  };
+}
+
+export const createComputerConnector$ = command(
+  async (
+    { set },
+    args: CreateComputerConnectorArgs,
+    signal: AbortSignal,
+  ): Promise<CreateComputerConnectorResult> => {
+    const db = set(writeDb$);
+
+    const [existing] = await db
+      .select({ id: connectors.id })
+      .from(connectors)
+      .where(
+        and(eq(connectors.orgId, args.orgId), eq(connectors.type, "computer")),
+      )
+      .limit(1);
+    signal.throwIfAborted();
+
+    if (existing) {
+      return { kind: "conflict" };
+    }
+
+    const apiKey = optionalEnv("NGROK_API_KEY");
+    if (!apiKey) {
+      return { kind: "bad_request" };
+    }
+
+    const refs: ProvisionedRefs = {};
+    const result = await safeAsync(() => {
+      return provisionAndPersistConnector({ db, args, apiKey, refs }, signal);
+    });
+    signal.throwIfAborted();
+
+    if ("ok" in result) {
+      return { kind: "created", connector: result.ok };
+    }
+
+    log.error("Failed to create computer connector, cleaning up", {
+      orgId: args.orgId,
+    });
+    await rollbackDbState(db, args, refs);
+    signal.throwIfAborted();
+    await rollbackNgrokResources(apiKey, refs);
+    signal.throwIfAborted();
+
+    throw result.error;
+  },
+);


### PR DESCRIPTION
## Summary
- implement API-backed connector session creation for zero connector device flow
- add API-native computer connector provisioning service with ngrok rollback and connector secret storage
- add API route tests for connector session creation and computer connector creation

Closes #12871

## Validation
- pnpm -F api exec vitest src/signals/routes/__tests__/zero-connectors-sessions-create.test.ts src/signals/routes/__tests__/zero-connectors-computer-create.test.ts
- pnpm -F api exec vitest src/signals/routes/__tests__/zero-connectors-session-by-id.test.ts src/signals/routes/__tests__/zero-connectors-computer-get.test.ts
- pnpm -F api lint
- pnpm -F api check-types
- pnpm check-types
- pnpm knip