### PR TITLE
refactor(api): migrate test slack state post route

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/test-slack-state.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/test-slack-state.test.ts
@@ -3,6 +3,7 @@ import { randomUUID } from "node:crypto";
 import { createStore } from "ccstate";
 import type {
   TestSlackStateDeleteResponse,
+  TestSlackStatePostResponse,
   TestSlackStateResponse,
 } from "@vm0/api-contracts/contracts/test-slack-state";
 import {
@@ -11,6 +12,7 @@ import {
 } from "@vm0/db/schema/agent-compose";
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { agentSessions } from "@vm0/db/schema/agent-session";
+import { creditExpiresRecord } from "@vm0/db/schema/credit-expires-record";
 import { e2eSlackMockCallLog } from "@vm0/db/schema/e2e-slack-mock-call-log";
 import { orgMetadata } from "@vm0/db/schema/org-metadata";
 import { slackOrgConnections } from "@vm0/db/schema/slack-org-connection";
@@ -18,7 +20,7 @@ import { slackOrgInstallations } from "@vm0/db/schema/slack-org-installation";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
 import { describe, expect, it } from "vitest";
-import { eq, inArray } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
 
 import { createApp } from "../../../app-factory";
 import { testContext } from "../../../__tests__/test-helpers";
@@ -49,6 +51,11 @@ interface SlackStateFixtureOptions {
   readonly seedNonSlackRun?: boolean;
 }
 
+interface SlackSeedFixture {
+  readonly teamId: string;
+  readonly orgId: string;
+}
+
 function suffix(): string {
   return randomUUID().replaceAll("-", "").slice(0, 12);
 }
@@ -60,6 +67,26 @@ function requestApp(path: string, init?: RequestInit): Promise<Response> {
 
 async function readJson<T>(response: Response): Promise<T> {
   return (await response.json()) as T;
+}
+
+function postSlackState(body: unknown): Promise<Response> {
+  return requestApp(ROUTE, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function mockTestUserMembership(userId: string, orgId: string): void {
+  context.mocks.clerk.users.getUserList.mockResolvedValue({
+    data: [{ id: userId }],
+  });
+  context.mocks.clerk.users.getOrganizationMembershipList.mockResolvedValue({
+    data: [
+      { createdAt: 20, organization: { id: `org_later_${suffix()}` } },
+      { createdAt: 10, organization: { id: orgId } },
+    ],
+  });
 }
 
 async function seedSlackStateFixture(
@@ -227,7 +254,41 @@ async function cleanupSlackStateFixture(
     .where(eq(agentComposes.id, fixture.composeId));
 }
 
+async function cleanupSlackSeedFixture(
+  fixture: SlackSeedFixture,
+): Promise<void> {
+  const composeRows = await writeDb
+    .select({ id: agentComposes.id })
+    .from(agentComposes)
+    .where(eq(agentComposes.orgId, fixture.orgId));
+  const composeIds = composeRows.map((compose) => {
+    return compose.id;
+  });
+
+  await writeDb
+    .delete(slackOrgConnections)
+    .where(eq(slackOrgConnections.slackWorkspaceId, fixture.teamId));
+  await writeDb
+    .delete(slackOrgInstallations)
+    .where(eq(slackOrgInstallations.slackWorkspaceId, fixture.teamId));
+  await writeDb
+    .delete(creditExpiresRecord)
+    .where(eq(creditExpiresRecord.orgId, fixture.orgId));
+  await writeDb.delete(orgMetadata).where(eq(orgMetadata.orgId, fixture.orgId));
+
+  if (composeIds.length > 0) {
+    await writeDb.delete(zeroAgents).where(inArray(zeroAgents.id, composeIds));
+    await writeDb
+      .delete(agentComposeVersions)
+      .where(inArray(agentComposeVersions.composeId, composeIds));
+    await writeDb
+      .delete(agentComposes)
+      .where(inArray(agentComposes.id, composeIds));
+  }
+}
+
 const trackSlackStateFixture = createFixtureTracker(cleanupSlackStateFixture);
+const trackSlackSeedFixture = createFixtureTracker(cleanupSlackSeedFixture);
 
 describe("GET /api/test/slack-state", () => {
   it("returns 404 outside allowed test environments", async () => {
@@ -366,6 +427,296 @@ describe("GET /api/test/slack-state", () => {
         bodyJson: { text: "older" },
       },
     ]);
+  });
+});
+
+describe("POST /api/test/slack-state", () => {
+  it("returns 404 outside allowed test environments", async () => {
+    mockEnv("ENV", "production");
+
+    const response = await postSlackState({
+      team_id: "T_DENIED",
+      slack_user_id: "U_DENIED",
+    });
+
+    expect(response.status).toBe(404);
+    await expect(response.text()).resolves.toBe("Not found");
+  });
+
+  it("requires team_id and slack_user_id", async () => {
+    mockEnv("ENV", "development");
+
+    const response = await postSlackState({ team_id: "T_MISSING_USER" });
+
+    expect(response.status).toBe(400);
+    await expect(readJson(response)).resolves.toStrictEqual({
+      error: "team_id and slack_user_id are required",
+    });
+  });
+
+  it("seeds a Slack installation without optional state", async () => {
+    mockEnv("ENV", "development");
+    const id = suffix();
+    const teamId = `T_SEED_${id}`;
+    const orgId = `org_seed_${id}`;
+    const userId = `user_seed_${id}`;
+    await trackSlackSeedFixture(Promise.resolve({ teamId, orgId }));
+    mockTestUserMembership(userId, orgId);
+
+    const response = await postSlackState({
+      team_id: teamId,
+      slack_user_id: "U_E2E_MEMBER",
+      workspace_name: "Seeded Workspace",
+      bot_user_id: "U_CUSTOM_BOT",
+      email: "seeded@example.test",
+    });
+    const body = await readJson<TestSlackStatePostResponse>(response);
+
+    expect(response.status).toBe(200);
+    expect(body).toStrictEqual({
+      ok: true,
+      team_id: teamId,
+      org_id: orgId,
+      vm0_user_id: userId,
+      connection_id: null,
+      default_agent_id: null,
+    });
+
+    const installations = await writeDb
+      .select({
+        slackWorkspaceId: slackOrgInstallations.slackWorkspaceId,
+        slackWorkspaceName: slackOrgInstallations.slackWorkspaceName,
+        orgId: slackOrgInstallations.orgId,
+        botUserId: slackOrgInstallations.botUserId,
+        botScopes: slackOrgInstallations.botScopes,
+        installedByUserId: slackOrgInstallations.installedByUserId,
+      })
+      .from(slackOrgInstallations)
+      .where(eq(slackOrgInstallations.slackWorkspaceId, teamId));
+
+    expect(installations).toStrictEqual([
+      {
+        slackWorkspaceId: teamId,
+        slackWorkspaceName: "Seeded Workspace",
+        orgId,
+        botUserId: "U_CUSTOM_BOT",
+        botScopes: "chat:write,im:write,users:read",
+        installedByUserId: userId,
+      },
+    ]);
+    await expect(
+      writeDb
+        .select({ id: slackOrgConnections.id })
+        .from(slackOrgConnections)
+        .where(eq(slackOrgConnections.slackWorkspaceId, teamId)),
+    ).resolves.toStrictEqual([]);
+  });
+
+  it("optionally seeds a Slack connection", async () => {
+    mockEnv("ENV", "development");
+    const id = suffix();
+    const teamId = `T_CONNECT_${id}`;
+    const orgId = `org_connect_${id}`;
+    const userId = `user_connect_${id}`;
+    await trackSlackSeedFixture(Promise.resolve({ teamId, orgId }));
+    mockTestUserMembership(userId, orgId);
+
+    const response = await postSlackState({
+      team_id: teamId,
+      slack_user_id: "U_E2E_CONNECTED",
+      seed_connection: true,
+    });
+    const body = await readJson<TestSlackStatePostResponse>(response);
+
+    expect(response.status).toBe(200);
+    expect(typeof body.connection_id).toBe("string");
+    expect(body.default_agent_id).toBeNull();
+    await expect(
+      writeDb
+        .select({
+          id: slackOrgConnections.id,
+          slackUserId: slackOrgConnections.slackUserId,
+          slackWorkspaceId: slackOrgConnections.slackWorkspaceId,
+          vm0UserId: slackOrgConnections.vm0UserId,
+          dmWelcomeSent: slackOrgConnections.dmWelcomeSent,
+        })
+        .from(slackOrgConnections)
+        .where(eq(slackOrgConnections.slackWorkspaceId, teamId)),
+    ).resolves.toStrictEqual([
+      {
+        id: body.connection_id,
+        slackUserId: "U_E2E_CONNECTED",
+        slackWorkspaceId: teamId,
+        vm0UserId: userId,
+        dmWelcomeSent: false,
+      },
+    ]);
+  });
+
+  it("optionally seeds the default Slack agent", async () => {
+    mockEnv("ENV", "development");
+    const id = suffix();
+    const teamId = `T_AGENT_${id}`;
+    const orgId = `org_agent_${id}`;
+    const userId = `user_agent_${id}`;
+    await trackSlackSeedFixture(Promise.resolve({ teamId, orgId }));
+    mockTestUserMembership(userId, orgId);
+
+    const response = await postSlackState({
+      team_id: teamId,
+      slack_user_id: "U_E2E_AGENT",
+      seed_default_agent: true,
+    });
+    const body = await readJson<TestSlackStatePostResponse>(response);
+
+    expect(response.status).toBe(200);
+    expect(typeof body.default_agent_id).toBe("string");
+    expect(body.connection_id).toBeNull();
+    if (!body.default_agent_id) {
+      throw new Error("Expected seeded default agent id");
+    }
+    const defaultAgentId = body.default_agent_id;
+
+    const [compose] = await writeDb
+      .select({
+        id: agentComposes.id,
+        userId: agentComposes.userId,
+        orgId: agentComposes.orgId,
+        name: agentComposes.name,
+        headVersionId: agentComposes.headVersionId,
+      })
+      .from(agentComposes)
+      .where(eq(agentComposes.id, defaultAgentId));
+    const [agent] = await writeDb
+      .select({
+        id: zeroAgents.id,
+        orgId: zeroAgents.orgId,
+        owner: zeroAgents.owner,
+        name: zeroAgents.name,
+      })
+      .from(zeroAgents)
+      .where(eq(zeroAgents.id, defaultAgentId));
+    const [metadata] = await writeDb
+      .select({
+        orgId: orgMetadata.orgId,
+        defaultAgentId: orgMetadata.defaultAgentId,
+        credits: orgMetadata.credits,
+      })
+      .from(orgMetadata)
+      .where(eq(orgMetadata.orgId, orgId));
+    const [creditGrant] = await writeDb
+      .select({
+        orgId: creditExpiresRecord.orgId,
+        source: creditExpiresRecord.source,
+        amount: creditExpiresRecord.amount,
+        remaining: creditExpiresRecord.remaining,
+      })
+      .from(creditExpiresRecord)
+      .where(eq(creditExpiresRecord.orgId, orgId));
+    const [version] = await writeDb
+      .select({
+        id: agentComposeVersions.id,
+        content: agentComposeVersions.content,
+      })
+      .from(agentComposeVersions)
+      .where(eq(agentComposeVersions.composeId, defaultAgentId));
+
+    expect(compose).toMatchObject({
+      id: defaultAgentId,
+      userId,
+      orgId,
+      name: "e2e-slack-agent",
+    });
+    expect(compose?.headVersionId).toBe(version?.id);
+    expect(agent).toStrictEqual({
+      id: defaultAgentId,
+      orgId,
+      owner: userId,
+      name: "e2e-slack-agent",
+    });
+    expect(metadata).toStrictEqual({
+      orgId,
+      defaultAgentId,
+      credits: 10_000,
+    });
+    expect(creditGrant).toStrictEqual({
+      orgId,
+      source: "starter_grant",
+      amount: 10_000,
+      remaining: 10_000,
+    });
+    expect(version?.content).toStrictEqual({
+      version: "1.0",
+      agents: {
+        "e2e-slack-agent": {
+          framework: "claude-code",
+          environment: {
+            ANTHROPIC_API_KEY: "fake-e2e-anthropic-key",
+          },
+        },
+      },
+    });
+  });
+
+  it("is idempotent for existing installations, connections, and default agents", async () => {
+    mockEnv("ENV", "development");
+    const id = suffix();
+    const teamId = `T_IDEMPOTENT_${id}`;
+    const orgId = `org_idempotent_${id}`;
+    const userId = `user_idempotent_${id}`;
+    await trackSlackSeedFixture(Promise.resolve({ teamId, orgId }));
+    mockTestUserMembership(userId, orgId);
+
+    const firstResponse = await postSlackState({
+      team_id: teamId,
+      slack_user_id: "U_E2E_IDEMPOTENT",
+      seed_connection: true,
+      seed_default_agent: true,
+    });
+    const first = await readJson<TestSlackStatePostResponse>(firstResponse);
+    const secondResponse = await postSlackState({
+      team_id: teamId,
+      slack_user_id: "U_E2E_IDEMPOTENT",
+      seed_connection: true,
+      seed_default_agent: true,
+    });
+    const second = await readJson<TestSlackStatePostResponse>(secondResponse);
+
+    expect(firstResponse.status).toBe(200);
+    expect(secondResponse.status).toBe(200);
+    expect(typeof first.connection_id).toBe("string");
+    if (!first.default_agent_id) {
+      throw new Error("Expected seeded default agent id");
+    }
+    expect(second.connection_id).toBeNull();
+    expect(second.default_agent_id).toBe(first.default_agent_id);
+
+    const installations = await writeDb
+      .select({ slackWorkspaceId: slackOrgInstallations.slackWorkspaceId })
+      .from(slackOrgInstallations)
+      .where(eq(slackOrgInstallations.slackWorkspaceId, teamId));
+    const connections = await writeDb
+      .select({ id: slackOrgConnections.id })
+      .from(slackOrgConnections)
+      .where(eq(slackOrgConnections.slackWorkspaceId, teamId));
+    const composes = await writeDb
+      .select({ id: agentComposes.id })
+      .from(agentComposes)
+      .where(
+        and(
+          eq(agentComposes.orgId, orgId),
+          eq(agentComposes.name, "e2e-slack-agent"),
+        ),
+      );
+    const starterGrants = await writeDb
+      .select({ id: creditExpiresRecord.id })
+      .from(creditExpiresRecord)
+      .where(eq(creditExpiresRecord.orgId, orgId));
+
+    expect(installations).toStrictEqual([{ slackWorkspaceId: teamId }]);
+    expect(connections).toStrictEqual([{ id: first.connection_id }]);
+    expect(composes).toStrictEqual([{ id: first.default_agent_id }]);
+    expect(starterGrants).toHaveLength(1);
   });
 });
 

--- a/turbo/apps/api/src/signals/routes/test-slack-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-slack-state.ts
@@ -1,3 +1,5 @@
+import { createHash } from "node:crypto";
+import type { createClerkClient } from "@clerk/backend";
 import { command, computed } from "ccstate";
 import { testSlackStateContract } from "@vm0/api-contracts/contracts/test-slack-state";
 import {
@@ -5,23 +7,41 @@ import {
   agentComposeVersions,
 } from "@vm0/db/schema/agent-compose";
 import { agentRuns } from "@vm0/db/schema/agent-run";
+import { creditExpiresRecord } from "@vm0/db/schema/credit-expires-record";
 import { e2eSlackMockCallLog } from "@vm0/db/schema/e2e-slack-mock-call-log";
 import { orgMetadata } from "@vm0/db/schema/org-metadata";
 import { slackOrgConnections } from "@vm0/db/schema/slack-org-connection";
 import { slackOrgInstallations } from "@vm0/db/schema/slack-org-installation";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
-import { and, desc, eq, inArray, sql } from "drizzle-orm";
+import { and, desc, eq, inArray, isNull, sql } from "drizzle-orm";
 
 import { optionalEnv } from "../../lib/env";
-import { queryOf } from "../context/request";
+import { nowDate } from "../../lib/time";
+import { bodyResultOf, queryOf } from "../context/request";
 import { request$ } from "../context/hono";
-import { db$, type ReadonlyDb, writeDb$ } from "../external/db";
+import { clerk$ } from "../external/clerk";
+import { db$, type Db, type ReadonlyDb, writeDb$ } from "../external/db";
 import type { RouteEntry } from "../route";
+import { encryptSecretValue } from "../services/crypto.utils";
 import {
   isTestEndpointAllowed,
   testEndpointNotFoundResponse,
 } from "./test-oauth-provider-helpers";
+
+const DEFAULT_TEST_EMAIL = "dev+clerk_test+serial@vm0-e2e.ai";
+const DEFAULT_WORKSPACE_NAME = "E2E Test Workspace";
+const DEFAULT_AGENT_NAME = "e2e-slack-agent";
+const STARTER_GRANT_AMOUNT = 10_000;
+const STARTER_GRANT_SOURCE = "starter_grant";
+const SLACK_BOT_SCOPES = "chat:write,im:write,users:read";
+const SLACK_E2E_FIXTURES = {
+  botUserId: "U_E2E_BOT",
+  botToken: "xoxb-e2e-test-bot-token",
+} as const;
+
+type ClerkClient = ReturnType<typeof createClerkClient>;
+type StarterGrantTx = Parameters<Parameters<Db["transaction"]>[0]>[0];
 
 function isoString(value: Date): string {
   return value.toISOString();
@@ -48,6 +68,289 @@ function resolvedSlackApiUrl(): string | null {
   }
 
   return null;
+}
+
+async function resolveTestUserId(
+  clerk: ClerkClient,
+  email: string = DEFAULT_TEST_EMAIL,
+): Promise<string> {
+  const { data: users } = await clerk.users.getUserList({
+    emailAddress: [email],
+  });
+  const userId = users[0]?.id;
+  if (!userId) {
+    throw new Error(`Test user not found for email: ${email}`);
+  }
+  return userId;
+}
+
+async function resolveTestOrgId(
+  clerk: ClerkClient,
+  userId: string,
+): Promise<string> {
+  const memberships = await clerk.users.getOrganizationMembershipList({
+    userId,
+  });
+  const sorted = [...memberships.data].sort((a, b) => {
+    return a.createdAt - b.createdAt;
+  });
+  const orgId = sorted[0]?.organization.id;
+  if (!orgId) {
+    throw new Error(`Test user ${userId} has no organization membership`);
+  }
+  return orgId;
+}
+
+interface UpsertSlackInstallationInput {
+  readonly slackWorkspaceId: string;
+  readonly slackWorkspaceName?: string;
+  readonly orgId: string | null;
+  readonly botUserId: string;
+  readonly botToken: string;
+  readonly botScopes?: string | null;
+  readonly installedByUserId?: string;
+}
+
+async function upsertSlackInstallation(
+  db: Db,
+  input: UpsertSlackInstallationInput,
+): Promise<typeof slackOrgInstallations.$inferSelect> {
+  const encryptedBotToken = encryptSecretValue(input.botToken);
+  const [row] = await db
+    .insert(slackOrgInstallations)
+    .values({
+      slackWorkspaceId: input.slackWorkspaceId,
+      slackWorkspaceName: input.slackWorkspaceName,
+      orgId: input.orgId,
+      encryptedBotToken,
+      botUserId: input.botUserId,
+      botScopes: input.botScopes ?? null,
+      installedByUserId: input.installedByUserId,
+    })
+    .onConflictDoUpdate({
+      target: slackOrgInstallations.slackWorkspaceId,
+      set: {
+        orgId: input.orgId,
+        encryptedBotToken,
+        botUserId: input.botUserId,
+      },
+    })
+    .returning();
+
+  if (!row) {
+    throw new Error("Failed to upsert Slack installation");
+  }
+  return row;
+}
+
+interface UpsertSlackConnectionInput {
+  readonly slackUserId: string;
+  readonly slackWorkspaceId: string;
+  readonly vm0UserId: string;
+}
+
+async function insertSlackConnectionIfMissing(
+  db: Db,
+  input: UpsertSlackConnectionInput,
+): Promise<string | undefined> {
+  const [row] = await db
+    .insert(slackOrgConnections)
+    .values({
+      slackUserId: input.slackUserId,
+      slackWorkspaceId: input.slackWorkspaceId,
+      vm0UserId: input.vm0UserId,
+    })
+    .onConflictDoNothing()
+    .returning({ id: slackOrgConnections.id });
+  return row?.id;
+}
+
+interface SeedDefaultAgentInput {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly name: string;
+}
+
+async function seedDefaultAgent(
+  db: Db,
+  input: SeedDefaultAgentInput,
+): Promise<{ composeId: string; versionId: string; agentId: string }> {
+  const compose = await getOrInsertCompose(db, input);
+  const composeId = compose.id;
+  const versionId = await ensureComposeVersion(
+    db,
+    composeId,
+    input.userId,
+    input.name,
+    compose.headVersionId,
+  );
+
+  await db
+    .insert(zeroAgents)
+    .values({
+      id: composeId,
+      orgId: input.orgId,
+      owner: input.userId,
+      name: input.name,
+    })
+    .onConflictDoNothing();
+
+  await db.transaction(async (tx) => {
+    await ensureStarterCreditGrant(tx, input.orgId);
+    await tx
+      .insert(orgMetadata)
+      .values({ orgId: input.orgId, defaultAgentId: composeId })
+      .onConflictDoUpdate({
+        target: orgMetadata.orgId,
+        set: { defaultAgentId: composeId, updatedAt: nowDate() },
+      });
+  });
+
+  return { composeId, versionId, agentId: composeId };
+}
+
+async function getOrInsertCompose(
+  db: Db,
+  input: SeedDefaultAgentInput,
+): Promise<{ id: string; headVersionId: string | null }> {
+  const [inserted] = await db
+    .insert(agentComposes)
+    .values({
+      userId: input.userId,
+      orgId: input.orgId,
+      name: input.name,
+    })
+    .onConflictDoNothing({
+      target: [agentComposes.orgId, agentComposes.name],
+    })
+    .returning({
+      id: agentComposes.id,
+      headVersionId: agentComposes.headVersionId,
+    });
+
+  if (inserted) {
+    return inserted;
+  }
+
+  const [existing] = await db
+    .select({
+      id: agentComposes.id,
+      headVersionId: agentComposes.headVersionId,
+    })
+    .from(agentComposes)
+    .where(
+      and(
+        eq(agentComposes.orgId, input.orgId),
+        eq(agentComposes.name, input.name),
+      ),
+    )
+    .limit(1);
+
+  if (!existing) {
+    throw new Error("Failed to resolve agent compose after conflict");
+  }
+  return existing;
+}
+
+async function ensureComposeVersion(
+  db: Db,
+  composeId: string,
+  userId: string,
+  name: string,
+  headVersionId: string | null,
+): Promise<string> {
+  if (headVersionId) {
+    return headVersionId;
+  }
+
+  const content = defaultAgentContent(name);
+  const versionId = createHash("sha256")
+    .update(JSON.stringify(content) + composeId)
+    .digest("hex");
+  await db
+    .insert(agentComposeVersions)
+    .values({
+      id: versionId,
+      composeId,
+      content,
+      createdBy: userId,
+    })
+    .onConflictDoNothing();
+
+  const [updated] = await db
+    .update(agentComposes)
+    .set({ headVersionId: versionId, updatedAt: nowDate() })
+    .where(
+      and(eq(agentComposes.id, composeId), isNull(agentComposes.headVersionId)),
+    )
+    .returning({ headVersionId: agentComposes.headVersionId });
+  if (updated?.headVersionId) {
+    return updated.headVersionId;
+  }
+
+  const [compose] = await db
+    .select({ headVersionId: agentComposes.headVersionId })
+    .from(agentComposes)
+    .where(eq(agentComposes.id, composeId))
+    .limit(1);
+  if (compose?.headVersionId) {
+    return compose.headVersionId;
+  }
+
+  throw new Error("Failed to resolve agent compose head version");
+}
+
+function defaultAgentContent(name: string) {
+  return {
+    version: "1.0",
+    agents: {
+      [name]: {
+        framework: "claude-code",
+        environment: {
+          ANTHROPIC_API_KEY: "fake-e2e-anthropic-key",
+        },
+      },
+    },
+  };
+}
+
+async function ensureStarterCreditGrant(
+  tx: StarterGrantTx,
+  orgId: string,
+): Promise<void> {
+  const [existing] = await tx
+    .select({ orgId: orgMetadata.orgId })
+    .from(orgMetadata)
+    .where(eq(orgMetadata.orgId, orgId))
+    .limit(1);
+  if (existing) {
+    return;
+  }
+
+  const expiresAt = nowDate();
+  expiresAt.setMonth(expiresAt.getMonth() + 1);
+  const inserted = await tx
+    .insert(creditExpiresRecord)
+    .values({
+      orgId,
+      source: STARTER_GRANT_SOURCE,
+      stripeInvoiceId: null,
+      amount: STARTER_GRANT_AMOUNT,
+      remaining: STARTER_GRANT_AMOUNT,
+      expiresAt,
+    })
+    .onConflictDoNothing()
+    .returning({ id: creditExpiresRecord.id });
+  if (inserted.length === 0) {
+    return;
+  }
+
+  await tx.execute(
+    sql`INSERT INTO org_metadata (org_id, credits, created_at, updated_at)
+        VALUES (${orgId}, ${STARTER_GRANT_AMOUNT}, now(), now())
+        ON CONFLICT (org_id)
+        DO UPDATE SET credits = org_metadata.credits + ${STARTER_GRANT_AMOUNT}, updated_at = now()`,
+  );
 }
 
 async function slackInstallation(db: ReadonlyDb, teamId: string) {
@@ -276,6 +579,83 @@ const getSlackState$ = computed(async (get) => {
   };
 });
 
+const postSlackStateBody$ = bodyResultOf(testSlackStateContract.post);
+
+const postSlackState$ = command(async ({ get, set }, signal: AbortSignal) => {
+  const request = get(request$);
+  if (!isTestEndpointAllowed(request)) {
+    return testEndpointNotFoundResponse();
+  }
+
+  const bodyResult = await get(postSlackStateBody$);
+  signal.throwIfAborted();
+  if (!bodyResult.ok) {
+    return bodyResult.response;
+  }
+
+  const body = bodyResult.data;
+  if (!body.team_id || !body.slack_user_id) {
+    return {
+      status: 400 as const,
+      body: { error: "team_id and slack_user_id are required" },
+    };
+  }
+
+  const clerk = get(clerk$);
+  const userId = await resolveTestUserId(
+    clerk,
+    body.email ?? DEFAULT_TEST_EMAIL,
+  );
+  signal.throwIfAborted();
+
+  const orgId = await resolveTestOrgId(clerk, userId);
+  signal.throwIfAborted();
+
+  const db = set(writeDb$);
+  await upsertSlackInstallation(db, {
+    slackWorkspaceId: body.team_id,
+    slackWorkspaceName: body.workspace_name ?? DEFAULT_WORKSPACE_NAME,
+    orgId,
+    botUserId: body.bot_user_id ?? SLACK_E2E_FIXTURES.botUserId,
+    botToken: SLACK_E2E_FIXTURES.botToken,
+    botScopes: SLACK_BOT_SCOPES,
+    installedByUserId: userId,
+  });
+  signal.throwIfAborted();
+
+  let connectionId: string | undefined;
+  if (body.seed_connection) {
+    connectionId = await insertSlackConnectionIfMissing(db, {
+      slackUserId: body.slack_user_id,
+      slackWorkspaceId: body.team_id,
+      vm0UserId: userId,
+    });
+    signal.throwIfAborted();
+  }
+
+  let defaultAgent: { composeId: string; versionId: string } | undefined;
+  if (body.seed_default_agent) {
+    defaultAgent = await seedDefaultAgent(db, {
+      orgId,
+      userId,
+      name: DEFAULT_AGENT_NAME,
+    });
+    signal.throwIfAborted();
+  }
+
+  return {
+    status: 200 as const,
+    body: {
+      ok: true as const,
+      team_id: body.team_id,
+      org_id: orgId,
+      vm0_user_id: userId,
+      connection_id: connectionId ?? null,
+      default_agent_id: defaultAgent?.composeId ?? null,
+    },
+  };
+});
+
 const deleteSlackState$ = command(async ({ get, set }, signal: AbortSignal) => {
   const request = get(request$);
   if (!isTestEndpointAllowed(request)) {
@@ -343,6 +723,10 @@ export const testSlackStateRoutes: readonly RouteEntry[] = [
   {
     route: testSlackStateContract.get,
     handler: getSlackState$,
+  },
+  {
+    route: testSlackStateContract.post,
+    handler: postSlackState$,
   },
   {
     route: testSlackStateContract.delete,

--- a/turbo/packages/api-contracts/src/contracts/test-slack-state.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-slack-state.ts
@@ -12,6 +12,25 @@ export const testSlackStateDeleteResponseSchema = z.object({
   ok: z.literal(true),
 });
 
+export const testSlackStatePostBodySchema = z.object({
+  team_id: z.string().optional(),
+  slack_user_id: z.string().optional(),
+  workspace_name: z.string().optional(),
+  bot_user_id: z.string().optional(),
+  email: z.string().optional(),
+  seed_connection: z.boolean().optional(),
+  seed_default_agent: z.boolean().optional(),
+});
+
+export const testSlackStatePostResponseSchema = z.object({
+  ok: z.literal(true),
+  team_id: z.string(),
+  org_id: z.string(),
+  vm0_user_id: z.string(),
+  connection_id: z.string().nullable(),
+  default_agent_id: z.string().nullable(),
+});
+
 const nullableDateStringSchema = z.string().nullable();
 
 export const testSlackStateResponseSchema = z.object({
@@ -99,6 +118,17 @@ export const testSlackStateContract = c.router({
     },
     summary: "Read Slack e2e diagnostic state for a test workspace",
   },
+  post: {
+    method: "POST",
+    path: "/api/test/slack-state",
+    body: testSlackStatePostBodySchema,
+    responses: {
+      200: testSlackStatePostResponseSchema,
+      400: testSlackStateErrorSchema,
+      404: z.string(),
+    },
+    summary: "Seed Slack e2e diagnostic state for a test workspace",
+  },
   delete: {
     method: "DELETE",
     path: "/api/test/slack-state",
@@ -117,6 +147,12 @@ export const testSlackStateContract = c.router({
 export type TestSlackStateContract = typeof testSlackStateContract;
 export type TestSlackStateDeleteResponse = z.infer<
   typeof testSlackStateDeleteResponseSchema
+>;
+export type TestSlackStatePostBody = z.infer<
+  typeof testSlackStatePostBodySchema
+>;
+export type TestSlackStatePostResponse = z.infer<
+  typeof testSlackStatePostResponseSchema
 >;
 export type TestSlackStateResponse = z.infer<
   typeof testSlackStateResponseSchema


### PR DESCRIPTION
## Summary
- add the `POST /api/test/slack-state` contract and API route handler
- seed Slack installations, optional Slack connections, and the default Slack agent from `apps/api`
- cover the POST behavior and idempotency with API integration tests

## Tests
- `pnpm -F api exec vitest src/signals/routes/__tests__/test-slack-state.test.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm check-types`
- `git diff --check`

Closes #12860