### PR TITLE
refactor(api): migrate zero connector deletes

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-by-type-delete.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-by-type-delete.test.ts
@@ -1,0 +1,211 @@
+import { randomUUID } from "node:crypto";
+
+import { zeroConnectorsByTypeContract } from "@vm0/api-contracts/contracts/zero-connectors";
+import { connectors } from "@vm0/db/schema/connector";
+import { secrets } from "@vm0/db/schema/secret";
+import { variables } from "@vm0/db/schema/variable";
+import { createStore } from "ccstate";
+import { and, eq } from "drizzle-orm";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { writeDb$ } from "../../external/db";
+import {
+  deleteOrgMembership$,
+  seedOrgMembership$,
+  type OrgMembershipFixture,
+} from "./helpers/zero-org-membership";
+import {
+  createFixtureTracker,
+  createZeroRouteMocks,
+} from "./helpers/zero-route-test";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+
+async function cleanupOrgData(fixture: OrgMembershipFixture): Promise<void> {
+  const writeDb = store.set(writeDb$);
+  await writeDb.delete(connectors).where(eq(connectors.orgId, fixture.orgId));
+  await writeDb.delete(secrets).where(eq(secrets.orgId, fixture.orgId));
+  await writeDb.delete(variables).where(eq(variables.orgId, fixture.orgId));
+  await store.set(deleteOrgMembership$, fixture, context.signal);
+}
+
+function seedFixture(): Promise<OrgMembershipFixture> {
+  const orgId = `org_${randomUUID()}`;
+  const userId = `user_${randomUUID()}`;
+  return store.set(seedOrgMembership$, { orgId, userId }, context.signal);
+}
+
+async function seedOAuthConnector(
+  fixture: OrgMembershipFixture,
+): Promise<void> {
+  const writeDb = store.set(writeDb$);
+  await writeDb.insert(connectors).values({
+    orgId: fixture.orgId,
+    userId: fixture.userId,
+    type: "github",
+    authMethod: "oauth",
+  });
+}
+
+async function seedAtlassianApiTokenState(
+  fixture: OrgMembershipFixture,
+): Promise<void> {
+  const writeDb = store.set(writeDb$);
+  await writeDb.insert(secrets).values({
+    orgId: fixture.orgId,
+    userId: fixture.userId,
+    name: "ATLASSIAN_TOKEN",
+    encryptedValue: "encrypted_atlassian_token",
+    type: "user",
+  });
+  await writeDb.insert(variables).values([
+    {
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      name: "ATLASSIAN_EMAIL",
+      value: "test@example.com",
+    },
+    {
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      name: "ATLASSIAN_DOMAIN",
+      value: "example",
+    },
+  ]);
+}
+
+async function remainingConnectorCount(
+  fixture: OrgMembershipFixture,
+): Promise<number> {
+  const writeDb = store.set(writeDb$);
+  const rows = await writeDb
+    .select({ id: connectors.id })
+    .from(connectors)
+    .where(
+      and(
+        eq(connectors.orgId, fixture.orgId),
+        eq(connectors.userId, fixture.userId),
+      ),
+    );
+  return rows.length;
+}
+
+async function remainingApiTokenState(
+  fixture: OrgMembershipFixture,
+): Promise<{ readonly secrets: number; readonly variables: number }> {
+  const writeDb = store.set(writeDb$);
+  const [secretRows, variableRows] = await Promise.all([
+    writeDb
+      .select({ id: secrets.id })
+      .from(secrets)
+      .where(
+        and(
+          eq(secrets.orgId, fixture.orgId),
+          eq(secrets.userId, fixture.userId),
+        ),
+      ),
+    writeDb
+      .select({ id: variables.id })
+      .from(variables)
+      .where(
+        and(
+          eq(variables.orgId, fixture.orgId),
+          eq(variables.userId, fixture.userId),
+        ),
+      ),
+  ]);
+
+  return { secrets: secretRows.length, variables: variableRows.length };
+}
+
+describe("DELETE /api/zero/connectors/:type", () => {
+  const track = createFixtureTracker<OrgMembershipFixture>(cleanupOrgData);
+
+  it("returns 401 when not authenticated", async () => {
+    const client = setupApp({ context })(zeroConnectorsByTypeContract);
+    const response = await accept(
+      client.delete({ params: { type: "github" }, headers: {} }),
+      [401],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("returns 401 when the authenticated session has no organization", async () => {
+    mocks.clerk.session(`user_${randomUUID()}`, null);
+
+    const client = setupApp({ context })(zeroConnectorsByTypeContract);
+    const response = await accept(
+      client.delete({
+        params: { type: "github" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [401],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("returns 404 when no connector state exists for that type", async () => {
+    const fixture = await track(seedFixture());
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(zeroConnectorsByTypeContract);
+    const response = await accept(
+      client.delete({
+        params: { type: "github" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [404],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Connector not found", code: "NOT_FOUND" },
+    });
+  });
+
+  it("deletes an OAuth connector row", async () => {
+    const fixture = await track(seedFixture());
+    await seedOAuthConnector(fixture);
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(zeroConnectorsByTypeContract);
+    const response = await accept(
+      client.delete({
+        params: { type: "github" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [204],
+    );
+
+    expect(response.body).toBeUndefined();
+    await expect(remainingConnectorCount(fixture)).resolves.toBe(0);
+  });
+
+  it("deletes API-token connector secrets and variables", async () => {
+    const fixture = await track(seedFixture());
+    await seedAtlassianApiTokenState(fixture);
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(zeroConnectorsByTypeContract);
+    const response = await accept(
+      client.delete({
+        params: { type: "atlassian" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [204],
+    );
+
+    expect(response.body).toBeUndefined();
+    await expect(remainingApiTokenState(fixture)).resolves.toStrictEqual({
+      secrets: 0,
+      variables: 0,
+    });
+  });
+});

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-computer-delete.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-computer-delete.test.ts
@@ -1,0 +1,252 @@
+import { randomUUID } from "node:crypto";
+
+import { zeroComputerConnectorContract } from "@vm0/api-contracts/contracts/zero-connectors";
+import { connectors } from "@vm0/db/schema/connector";
+import { secrets } from "@vm0/db/schema/secret";
+import { createStore } from "ccstate";
+import { http, HttpResponse } from "msw";
+import { and, eq } from "drizzle-orm";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { mockOptionalEnv } from "../../../lib/env";
+import { writeDb$ } from "../../external/db";
+import { server } from "../../../mocks/server";
+import { encryptSecretValue } from "../../services/crypto.utils";
+import {
+  deleteOrgMembership$,
+  seedOrgMembership$,
+  type OrgMembershipFixture,
+} from "./helpers/zero-org-membership";
+import {
+  createFixtureTracker,
+  createZeroRouteMocks,
+} from "./helpers/zero-route-test";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+
+interface NgrokDeleteCalls {
+  readonly deleteCredential: string[];
+  readonly deleteEndpoint: string[];
+  readonly deleteReservedDomain: string[];
+  readonly deleteBotUser: string[];
+}
+
+const COMPUTER_SECRET_NAMES = [
+  "COMPUTER_CONNECTOR_BRIDGE_TOKEN",
+  "COMPUTER_CONNECTOR_DOMAIN_ID",
+  "COMPUTER_CONNECTOR_DOMAIN",
+] as const;
+
+function setupNgrokDeleteMocks(): NgrokDeleteCalls {
+  const calls: NgrokDeleteCalls = {
+    deleteCredential: [],
+    deleteEndpoint: [],
+    deleteReservedDomain: [],
+    deleteBotUser: [],
+  };
+
+  server.use(
+    http.delete("https://api.ngrok.com/credentials/:id", ({ params }) => {
+      calls.deleteCredential.push(String(params.id));
+      return new HttpResponse(null, { status: 204 });
+    }),
+    http.delete("https://api.ngrok.com/endpoints/:id", ({ params }) => {
+      calls.deleteEndpoint.push(String(params.id));
+      return new HttpResponse(null, { status: 204 });
+    }),
+    http.delete("https://api.ngrok.com/reserved_domains/:id", ({ params }) => {
+      calls.deleteReservedDomain.push(String(params.id));
+      return new HttpResponse(null, { status: 204 });
+    }),
+    http.delete("https://api.ngrok.com/bot_users/:id", ({ params }) => {
+      calls.deleteBotUser.push(String(params.id));
+      return new HttpResponse(null, { status: 204 });
+    }),
+  );
+
+  return calls;
+}
+
+async function cleanupOrgData(fixture: OrgMembershipFixture): Promise<void> {
+  const writeDb = store.set(writeDb$);
+  await writeDb.delete(connectors).where(eq(connectors.orgId, fixture.orgId));
+  await writeDb.delete(secrets).where(eq(secrets.orgId, fixture.orgId));
+  await store.set(deleteOrgMembership$, fixture, context.signal);
+}
+
+function seedFixture(): Promise<OrgMembershipFixture> {
+  const orgId = `org_${randomUUID()}`;
+  const userId = `user_${randomUUID()}`;
+  return store.set(seedOrgMembership$, { orgId, userId }, context.signal);
+}
+
+async function seedComputerConnector(
+  fixture: OrgMembershipFixture,
+): Promise<void> {
+  const writeDb = store.set(writeDb$);
+  await writeDb.insert(connectors).values({
+    orgId: fixture.orgId,
+    userId: fixture.userId,
+    type: "computer",
+    authMethod: "api",
+    externalId: "bot_test_connector_123",
+    externalUsername: "cr_test_connector_456",
+    externalEmail: "ep_test_connector_789",
+  });
+  await writeDb.insert(secrets).values([
+    {
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      name: "COMPUTER_CONNECTOR_BRIDGE_TOKEN",
+      encryptedValue: encryptSecretValue("bridge-token"),
+      type: "connector",
+    },
+    {
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      name: "COMPUTER_CONNECTOR_DOMAIN_ID",
+      encryptedValue: encryptSecretValue("rd_test_connector_abc"),
+      type: "connector",
+    },
+    {
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      name: "COMPUTER_CONNECTOR_DOMAIN",
+      encryptedValue: encryptSecretValue("computer.example.com"),
+      type: "connector",
+    },
+  ]);
+}
+
+async function remainingComputerConnectorCount(
+  fixture: OrgMembershipFixture,
+): Promise<number> {
+  const writeDb = store.set(writeDb$);
+  const rows = await writeDb
+    .select({ id: connectors.id })
+    .from(connectors)
+    .where(
+      and(
+        eq(connectors.orgId, fixture.orgId),
+        eq(connectors.userId, fixture.userId),
+        eq(connectors.type, "computer"),
+      ),
+    );
+  return rows.length;
+}
+
+async function remainingComputerSecretNames(
+  fixture: OrgMembershipFixture,
+): Promise<string[]> {
+  const writeDb = store.set(writeDb$);
+  const rows = await writeDb
+    .select({ name: secrets.name })
+    .from(secrets)
+    .where(
+      and(
+        eq(secrets.orgId, fixture.orgId),
+        eq(secrets.userId, fixture.userId),
+        eq(secrets.type, "connector"),
+      ),
+    );
+  return rows
+    .map((row) => {
+      return row.name;
+    })
+    .filter((name) => {
+      return COMPUTER_SECRET_NAMES.some((secretName) => {
+        return secretName === name;
+      });
+    });
+}
+
+describe("DELETE /api/zero/connectors/computer", () => {
+  const track = createFixtureTracker<OrgMembershipFixture>(cleanupOrgData);
+
+  it("returns 401 when not authenticated", async () => {
+    const client = setupApp({ context })(zeroComputerConnectorContract);
+    const response = await accept(client.delete({ headers: {} }), [401]);
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("returns 401 when the authenticated session has no organization", async () => {
+    mocks.clerk.session(`user_${randomUUID()}`, null);
+
+    const client = setupApp({ context })(zeroComputerConnectorContract);
+    const response = await accept(
+      client.delete({ headers: { authorization: "Bearer clerk-session" } }),
+      [401],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("returns 404 when no computer connector is configured", async () => {
+    const fixture = await track(seedFixture());
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(zeroComputerConnectorContract);
+    const response = await accept(
+      client.delete({ headers: { authorization: "Bearer clerk-session" } }),
+      [404],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Computer connector not found", code: "NOT_FOUND" },
+    });
+  });
+
+  it("deletes the computer connector and ngrok resources", async () => {
+    const fixture = await track(seedFixture());
+    await seedComputerConnector(fixture);
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    mockOptionalEnv("NGROK_API_KEY", "test-ngrok-key");
+    const ngrokCalls = setupNgrokDeleteMocks();
+
+    const client = setupApp({ context })(zeroComputerConnectorContract);
+    const response = await accept(
+      client.delete({ headers: { authorization: "Bearer clerk-session" } }),
+      [204],
+    );
+
+    expect(response.body).toBeUndefined();
+    expect(ngrokCalls.deleteCredential).toStrictEqual([
+      "cr_test_connector_456",
+    ]);
+    expect(ngrokCalls.deleteEndpoint).toStrictEqual(["ep_test_connector_789"]);
+    expect(ngrokCalls.deleteReservedDomain).toStrictEqual([
+      "rd_test_connector_abc",
+    ]);
+    expect(ngrokCalls.deleteBotUser).toStrictEqual(["bot_test_connector_123"]);
+    await expect(remainingComputerConnectorCount(fixture)).resolves.toBe(0);
+    await expect(remainingComputerSecretNames(fixture)).resolves.toStrictEqual(
+      [],
+    );
+  });
+
+  it("deletes local computer connector state when ngrok is not configured", async () => {
+    const fixture = await track(seedFixture());
+    await seedComputerConnector(fixture);
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    mockOptionalEnv("NGROK_API_KEY", undefined);
+
+    const client = setupApp({ context })(zeroComputerConnectorContract);
+    const response = await accept(
+      client.delete({ headers: { authorization: "Bearer clerk-session" } }),
+      [204],
+    );
+
+    expect(response.body).toBeUndefined();
+    await expect(remainingComputerConnectorCount(fixture)).resolves.toBe(0);
+    await expect(remainingComputerSecretNames(fixture)).resolves.toStrictEqual(
+      [],
+    );
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/zero-connectors.ts
@@ -41,6 +41,7 @@ import { env, optionalEnv } from "../../lib/env";
 import { nowDate } from "../../lib/time";
 import { writeDb$ } from "../external/db";
 import {
+  deleteComputerConnector$,
   deleteZeroConnectorLocalState$,
   zeroConnectorByType,
   zeroConnectorList,
@@ -377,6 +378,47 @@ const createComputerConnectorInner$ = command(
   },
 );
 
+const deleteComputerConnectorInner$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const auth = get(organizationAuthContext$);
+    const deleted = await set(
+      deleteComputerConnector$,
+      { orgId: auth.orgId, userId: auth.userId },
+      signal,
+    );
+    signal.throwIfAborted();
+
+    if (!deleted) {
+      return notFound("Computer connector not found");
+    }
+
+    return { status: 204 as const, body: undefined };
+  },
+);
+
+const deleteConnectorByTypeInner$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const auth = get(organizationAuthContext$);
+    const params = get(pathParamsOf(zeroConnectorsByTypeContract.delete));
+    const deleted = await set(
+      deleteZeroConnectorLocalState$,
+      {
+        orgId: auth.orgId,
+        userId: auth.userId,
+        type: params.type,
+      },
+      signal,
+    );
+    signal.throwIfAborted();
+
+    if (!deleted) {
+      return notFound("Connector not found");
+    }
+
+    return { status: 204 as const, body: undefined };
+  },
+);
+
 const getScopeDiffInner$ = computed(async (get) => {
   const auth = get(organizationAuthContext$);
   const params = get(pathParamsOf(zeroConnectorScopeDiffContract.getScopeDiff));
@@ -660,6 +702,10 @@ export const zeroConnectorsRoutes: readonly RouteEntry[] = [
     handler: authRoute(connectorReadAuth, getComputerConnectorInner$),
   },
   {
+    route: zeroComputerConnectorContract.delete,
+    handler: authRoute(connectorWriteAuth, deleteComputerConnectorInner$),
+  },
+  {
     route: zeroRemoteAgentConnectorContract.create,
     handler: authRoute(connectorWriteAuth, connectRemoteAgentConnectorInner$),
   },
@@ -690,5 +736,9 @@ export const zeroConnectorsRoutes: readonly RouteEntry[] = [
   {
     route: zeroConnectorsByTypeContract.get,
     handler: authRoute(connectorReadAuth, getConnectorByTypeInner$),
+  },
+  {
+    route: zeroConnectorsByTypeContract.delete,
+    handler: authRoute(connectorWriteAuth, deleteConnectorByTypeInner$),
   },
 ];

--- a/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
@@ -30,6 +30,13 @@ import { z } from "zod";
 import { optionalEnv } from "../../lib/env";
 import { nowDate } from "../../lib/time";
 import { db$, type Db, writeDb$ } from "../external/db";
+import {
+  deleteBotUser,
+  deleteCloudEndpoint,
+  deleteCredential,
+  deleteReservedDomain,
+  safeDelete,
+} from "../external/ngrok-client";
 import { publishUserSignal } from "../external/realtime";
 import { decryptSecretValue, encryptSecretValue } from "./crypto.utils";
 import { userFeatureSwitchOverrides } from "./feature-switches.service";
@@ -48,6 +55,11 @@ type StoredConnectorRow = {
 
 const oauthScopesSchema = z.array(z.string());
 const DEFAULT_ACCESS_TOKEN_EXPIRES_IN_SECS = 3600;
+const COMPUTER_CONNECTOR_SECRET_NAMES = [
+  "COMPUTER_CONNECTOR_BRIDGE_TOKEN",
+  "COMPUTER_CONNECTOR_DOMAIN_ID",
+  "COMPUTER_CONNECTOR_DOMAIN",
+] as const;
 
 interface ExternalUserInfo {
   readonly id: string;
@@ -702,6 +714,122 @@ export const upsertOAuthConnector$ = command(
       created:
         connectorRow.createdAt.getTime() === connectorRow.updatedAt.getTime(),
     };
+  },
+);
+
+export const deleteComputerConnector$ = command(
+  async (
+    { set },
+    args: {
+      readonly orgId: string;
+      readonly userId: string;
+    },
+    signal: AbortSignal,
+  ): Promise<boolean> => {
+    const writeDb = set(writeDb$);
+
+    const [connector] = await writeDb
+      .select({
+        id: connectors.id,
+        externalId: connectors.externalId,
+        externalUsername: connectors.externalUsername,
+        externalEmail: connectors.externalEmail,
+      })
+      .from(connectors)
+      .where(
+        and(
+          eq(connectors.orgId, args.orgId),
+          eq(connectors.userId, args.userId),
+          eq(connectors.type, "computer"),
+        ),
+      )
+      .limit(1);
+    signal.throwIfAborted();
+
+    if (!connector) {
+      return false;
+    }
+
+    const apiKey = optionalEnv("NGROK_API_KEY");
+    if (apiKey) {
+      if (connector.externalUsername) {
+        await safeDelete(
+          () => {
+            return deleteCredential(apiKey, connector.externalUsername!);
+          },
+          "Credential",
+          connector.externalUsername,
+        );
+        signal.throwIfAborted();
+      }
+
+      if (connector.externalEmail) {
+        await safeDelete(
+          () => {
+            return deleteCloudEndpoint(apiKey, connector.externalEmail!);
+          },
+          "Cloud endpoint",
+          connector.externalEmail,
+        );
+        signal.throwIfAborted();
+      }
+
+      const [domainIdSecret] = await writeDb
+        .select({ encryptedValue: secrets.encryptedValue })
+        .from(secrets)
+        .where(
+          and(
+            eq(secrets.orgId, args.orgId),
+            eq(secrets.userId, args.userId),
+            eq(secrets.name, "COMPUTER_CONNECTOR_DOMAIN_ID"),
+            eq(secrets.type, "connector"),
+          ),
+        )
+        .limit(1);
+      signal.throwIfAborted();
+
+      if (domainIdSecret) {
+        const domainId = decryptSecretValue(domainIdSecret.encryptedValue);
+        await safeDelete(
+          () => {
+            return deleteReservedDomain(apiKey, domainId);
+          },
+          "Reserved domain",
+          domainId,
+        );
+        signal.throwIfAborted();
+      }
+
+      if (connector.externalId) {
+        await safeDelete(
+          () => {
+            return deleteBotUser(apiKey, connector.externalId!);
+          },
+          "Bot user",
+          connector.externalId,
+        );
+        signal.throwIfAborted();
+      }
+    }
+
+    await writeDb.delete(connectors).where(eq(connectors.id, connector.id));
+    signal.throwIfAborted();
+
+    for (const name of COMPUTER_CONNECTOR_SECRET_NAMES) {
+      await writeDb
+        .delete(secrets)
+        .where(
+          and(
+            eq(secrets.orgId, args.orgId),
+            eq(secrets.userId, args.userId),
+            eq(secrets.name, name),
+            eq(secrets.type, "connector"),
+          ),
+        );
+      signal.throwIfAborted();
+    }
+
+    return true;
   },
 );
 


### PR DESCRIPTION
## Summary
- Handle `DELETE /api/zero/connectors/:type` on the API backend with existing connector local-state cleanup.
- Handle `DELETE /api/zero/connectors/computer` on the API backend, including ngrok resource cleanup and computer connector secret removal.
- Add API integration coverage for auth, not-found, OAuth, API-token, and computer connector delete paths.

Closes #12805

## Validation
- `scripts/prepare.sh`
- `pnpm -F api exec vitest src/signals/routes/__tests__/zero-connectors-by-type-delete.test.ts src/signals/routes/__tests__/zero-connectors-computer-delete.test.ts`
- `pnpm -F api exec vitest src/signals/routes/__tests__/zero-connectors-by-type-get.test.ts src/signals/routes/__tests__/zero-connectors-computer-get.test.ts`
- `pnpm -F api exec vitest src/signals/routes/__tests__/zero-connectors-by-type-delete.test.ts src/signals/routes/__tests__/zero-connectors-computer-delete.test.ts src/signals/routes/__tests__/zero-connectors-by-type-get.test.ts src/signals/routes/__tests__/zero-connectors-computer-get.test.ts`
- `pnpm -F api exec vitest src/signals/routes/__tests__/zero-connectors-computer-delete.test.ts`
- `pnpm format`
- `pnpm turbo run lint`
- `pnpm check-types`
- `pnpm knip`
- `pnpm vitest` passed once: 984 files, 10570 tests
- A repeated `pnpm vitest` run hit one unrelated local timeout in `app/api/cron/aggregate-insights/__tests__/route.test.ts`; rerunning that file passed with 19 tests.