### PR TITLE
refactor(api): migrate slack integration delete route

### DIFF
--- a/turbo/apps/api/src/__tests__/mocks.ts
+++ b/turbo/apps/api/src/__tests__/mocks.ts
@@ -66,6 +66,9 @@ export interface ApiTestMocks {
         readonly access: AsyncMock;
       };
     };
+    readonly views: {
+      readonly publish: AsyncMock;
+    };
     readonly fetchFile: AsyncMock;
   };
   readonly stripe: {
@@ -173,6 +176,9 @@ const apiTestMocks: ApiTestMocks = vi.hoisted((): ApiTestMocks => {
       v2: {
         access: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
       },
+    },
+    views: {
+      publish: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
     },
     fetchFile: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
   };
@@ -428,6 +434,9 @@ vi.mock("@slack/web-api", () => {
             access: apiTestMocks.slack.oauth.v2.access,
           },
         },
+        views: {
+          publish: apiTestMocks.slack.views.publish,
+        },
       };
     }),
   };
@@ -542,6 +551,7 @@ export function resetApiTestMocks(): void {
   apiTestMocks.slack.files.getUploadURLExternal.mockReset();
   apiTestMocks.slack.files.completeUploadExternal.mockReset();
   apiTestMocks.slack.oauth.v2.access.mockReset();
+  apiTestMocks.slack.views.publish.mockReset();
   apiTestMocks.slack.fetchFile.mockReset();
   apiTestMocks.stripe.invoices.list.mockReset();
   apiTestMocks.stripe.invoices.create.mockReset();

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-slack.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-slack.test.ts
@@ -13,7 +13,7 @@ import { secrets } from "@vm0/db/schema/secret";
 import { variables } from "@vm0/db/schema/variable";
 import { slackOrgInstallations } from "@vm0/db/schema/slack-org-installation";
 import { slackOrgConnections } from "@vm0/db/schema/slack-org-connection";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 
 import { createApp } from "../../../app-factory";
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
@@ -34,6 +34,7 @@ import {
 } from "./helpers/zero-route-test";
 import {
   deleteSlackIntegrationFixture$,
+  seedSlackOrgConnection$,
   seedSlackOrgInstallation$,
   type SlackIntegrationFixture,
 } from "./helpers/zero-integrations-slack";
@@ -365,6 +366,311 @@ describe("GET /api/zero/integrations/slack", () => {
       expect(response.body.isConnected).toBeFalsy();
       expect(response.body.environment).toBeUndefined();
     });
+  });
+});
+
+async function findSlackConnection(args: {
+  readonly workspaceId: string;
+  readonly userId: string;
+}): Promise<typeof slackOrgConnections.$inferSelect | undefined> {
+  const [connection] = await writeDb
+    .select()
+    .from(slackOrgConnections)
+    .where(
+      and(
+        eq(slackOrgConnections.slackWorkspaceId, args.workspaceId),
+        eq(slackOrgConnections.vm0UserId, args.userId),
+      ),
+    )
+    .limit(1);
+  return connection;
+}
+
+async function findSlackInstallation(
+  workspaceId: string,
+): Promise<typeof slackOrgInstallations.$inferSelect | undefined> {
+  const [installation] = await writeDb
+    .select()
+    .from(slackOrgInstallations)
+    .where(eq(slackOrgInstallations.slackWorkspaceId, workspaceId))
+    .limit(1);
+  return installation;
+}
+
+function listWorkspaceSlackConnections(
+  workspaceId: string,
+): Promise<readonly (typeof slackOrgConnections.$inferSelect)[]> {
+  return writeDb
+    .select()
+    .from(slackOrgConnections)
+    .where(eq(slackOrgConnections.slackWorkspaceId, workspaceId));
+}
+
+describe("DELETE /api/zero/integrations/slack", () => {
+  const trackSlackFixture = createFixtureTracker<SlackIntegrationFixture>(
+    (fixture) => {
+      return store.set(deleteSlackIntegrationFixture$, fixture, context.signal);
+    },
+  );
+  const mocks = createZeroRouteMocks(context);
+
+  beforeEach(() => {
+    context.mocks.slack.views.publish.mockResolvedValue({ ok: true });
+  });
+
+  async function seedDeleteContext(
+    args: {
+      readonly userId?: string;
+      readonly orgId?: string;
+      readonly withConnection?: boolean;
+    } = {},
+  ): Promise<{
+    readonly orgId: string;
+    readonly userId: string;
+    readonly workspaceId: string;
+    readonly slackUserId: string | null;
+  }> {
+    const orgId = args.orgId ?? `org_${randomUUID()}`;
+    const userId = args.userId ?? `user_${randomUUID()}`;
+    const fixture = await trackSlackFixture(
+      store.set(seedSlackOrgInstallation$, { orgId }, context.signal),
+    );
+    const connection =
+      args.withConnection === false
+        ? null
+        : await store.set(
+            seedSlackOrgConnection$,
+            {
+              slackWorkspaceId: fixture.slackWorkspaceId,
+              vm0UserId: userId,
+            },
+            context.signal,
+          );
+
+    return {
+      orgId,
+      userId,
+      workspaceId: fixture.slackWorkspaceId,
+      slackUserId: connection?.slackUserId ?? null,
+    };
+  }
+
+  it("returns 401 when unauthenticated", async () => {
+    const client = setupApp({ context })(zeroIntegrationsSlackContract);
+
+    const response = await accept(
+      client.disconnect({ headers: {}, query: {} }),
+      [401],
+    );
+
+    expect(response.body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("returns 404 when the user has no Slack connection", async () => {
+    const seeded = await seedDeleteContext({ withConnection: false });
+    mocks.clerk.session(seeded.userId, seeded.orgId);
+    const client = setupApp({ context })(zeroIntegrationsSlackContract);
+
+    const response = await accept(
+      client.disconnect({
+        headers: { authorization: "Bearer clerk-session" },
+        query: {},
+      }),
+      [404],
+    );
+
+    expect(response.body.error.code).toBe("NOT_FOUND");
+    expect(response.body.error.message).toBe("No Slack connection found");
+  });
+
+  it("deletes only the current user's connection and refreshes App Home", async () => {
+    const seeded = await seedDeleteContext();
+    const otherUserId = `user_${randomUUID()}`;
+    const otherConnection = await store.set(
+      seedSlackOrgConnection$,
+      {
+        slackWorkspaceId: seeded.workspaceId,
+        vm0UserId: otherUserId,
+      },
+      context.signal,
+    );
+    mocks.clerk.session(seeded.userId, seeded.orgId);
+    const client = setupApp({ context })(zeroIntegrationsSlackContract);
+
+    const response = await accept(
+      client.disconnect({
+        headers: { authorization: "Bearer clerk-session" },
+        query: {},
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({ ok: true });
+    await expect(
+      findSlackConnection({
+        workspaceId: seeded.workspaceId,
+        userId: seeded.userId,
+      }),
+    ).resolves.toBeUndefined();
+    await expect(
+      findSlackConnection({
+        workspaceId: seeded.workspaceId,
+        userId: otherUserId,
+      }),
+    ).resolves.toMatchObject({ slackUserId: otherConnection.slackUserId });
+    expect(context.mocks.slack.views.publish).toHaveBeenCalledWith(
+      expect.objectContaining({
+        user_id: seeded.slackUserId,
+        view: expect.objectContaining({
+          type: "home",
+          blocks: expect.arrayContaining([
+            expect.objectContaining({
+              type: "actions",
+              elements: expect.arrayContaining([
+                expect.objectContaining({ action_id: "home_login_prompt" }),
+              ]),
+            }),
+          ]),
+        }),
+      }),
+    );
+  });
+});
+
+describe("DELETE /api/zero/integrations/slack?action=uninstall", () => {
+  const trackSlackFixture = createFixtureTracker<SlackIntegrationFixture>(
+    (fixture) => {
+      return store.set(deleteSlackIntegrationFixture$, fixture, context.signal);
+    },
+  );
+  const mocks = createZeroRouteMocks(context);
+
+  beforeEach(() => {
+    context.mocks.slack.views.publish.mockResolvedValue({ ok: true });
+  });
+
+  async function seedUninstallContext(
+    args: {
+      readonly orgId?: string;
+      readonly userId?: string;
+      readonly withInstallation?: boolean;
+    } = {},
+  ): Promise<{
+    readonly orgId: string;
+    readonly userId: string;
+    readonly workspaceId: string | null;
+    readonly slackUserIds: readonly string[];
+  }> {
+    const orgId = args.orgId ?? `org_${randomUUID()}`;
+    const userId = args.userId ?? `user_${randomUUID()}`;
+    if (args.withInstallation === false) {
+      return { orgId, userId, workspaceId: null, slackUserIds: [] };
+    }
+
+    const fixture = await trackSlackFixture(
+      store.set(seedSlackOrgInstallation$, { orgId }, context.signal),
+    );
+    const firstConnection = await store.set(
+      seedSlackOrgConnection$,
+      {
+        slackWorkspaceId: fixture.slackWorkspaceId,
+        vm0UserId: userId,
+      },
+      context.signal,
+    );
+    const secondConnection = await store.set(
+      seedSlackOrgConnection$,
+      {
+        slackWorkspaceId: fixture.slackWorkspaceId,
+        vm0UserId: `user_${randomUUID()}`,
+      },
+      context.signal,
+    );
+
+    return {
+      orgId,
+      userId,
+      workspaceId: fixture.slackWorkspaceId,
+      slackUserIds: [firstConnection.slackUserId, secondConnection.slackUserId],
+    };
+  }
+
+  it("returns 403 when a non-admin tries to uninstall", async () => {
+    const seeded = await seedUninstallContext();
+    mocks.clerk.session(seeded.userId, seeded.orgId, "org:member");
+    const client = setupApp({ context })(zeroIntegrationsSlackContract);
+
+    const response = await accept(
+      client.disconnect({
+        headers: { authorization: "Bearer clerk-session" },
+        query: { action: "uninstall" },
+      }),
+      [403],
+    );
+
+    expect(response.body.error.code).toBe("FORBIDDEN");
+    expect(response.body.error.message).toBe("Admin access required");
+  });
+
+  it("returns 404 when no installation exists", async () => {
+    const seeded = await seedUninstallContext({ withInstallation: false });
+    mocks.clerk.session(seeded.userId, seeded.orgId, "org:admin");
+    const client = setupApp({ context })(zeroIntegrationsSlackContract);
+
+    const response = await accept(
+      client.disconnect({
+        headers: { authorization: "Bearer clerk-session" },
+        query: { action: "uninstall" },
+      }),
+      [404],
+    );
+
+    expect(response.body.error.code).toBe("NOT_FOUND");
+    expect(response.body.error.message).toBe("No Slack installation found");
+  });
+
+  it("publishes uninstalled App Home then deletes installation and connections", async () => {
+    const seeded = await seedUninstallContext();
+    mocks.clerk.session(seeded.userId, seeded.orgId, "org:admin");
+    const client = setupApp({ context })(zeroIntegrationsSlackContract);
+
+    const response = await accept(
+      client.disconnect({
+        headers: { authorization: "Bearer clerk-session" },
+        query: { action: "uninstall" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({ ok: true });
+    expect(context.mocks.slack.views.publish).toHaveBeenCalledTimes(2);
+    for (const slackUserId of seeded.slackUserIds) {
+      expect(context.mocks.slack.views.publish).toHaveBeenCalledWith(
+        expect.objectContaining({
+          user_id: slackUserId,
+          view: expect.objectContaining({
+            type: "home",
+            blocks: expect.arrayContaining([
+              expect.objectContaining({
+                type: "actions",
+                elements: expect.arrayContaining([
+                  expect.objectContaining({ action_id: "home_open_settings" }),
+                ]),
+              }),
+            ]),
+          }),
+        }),
+      );
+    }
+    const workspaceId = seeded.workspaceId;
+    expect(workspaceId).not.toBeNull();
+    if (workspaceId === null) {
+      throw new Error("workspaceId should be present for uninstall test");
+    }
+    await expect(findSlackInstallation(workspaceId)).resolves.toBeUndefined();
+    await expect(
+      listWorkspaceSlackConnections(workspaceId),
+    ).resolves.toStrictEqual([]);
   });
 });
 

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-slack.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-slack.test.ts
@@ -543,6 +543,11 @@ describe("DELETE /api/zero/integrations/slack?action=uninstall", () => {
       return store.set(deleteSlackIntegrationFixture$, fixture, context.signal);
     },
   );
+  const trackOrgMembership = createFixtureTracker<OrgMembershipFixture>(
+    (fixture) => {
+      return store.set(deleteOrgMembership$, fixture, context.signal);
+    },
+  );
   const mocks = createZeroRouteMocks(context);
 
   beforeEach(() => {
@@ -631,6 +636,18 @@ describe("DELETE /api/zero/integrations/slack?action=uninstall", () => {
 
   it("publishes uninstalled App Home then deletes installation and connections", async () => {
     const seeded = await seedUninstallContext();
+    await trackOrgMembership(
+      store.set(
+        seedOrgMembership$,
+        {
+          orgId: seeded.orgId,
+          userId: seeded.userId,
+          role: "admin",
+          seedOrgCache: false,
+        },
+        context.signal,
+      ),
+    );
     mocks.clerk.session(seeded.userId, seeded.orgId, "org:admin");
     const client = setupApp({ context })(zeroIntegrationsSlackContract);
 
@@ -671,6 +688,10 @@ describe("DELETE /api/zero/integrations/slack?action=uninstall", () => {
     await expect(
       listWorkspaceSlackConnections(workspaceId),
     ).resolves.toStrictEqual([]);
+    expect(context.mocks.ably.publish).toHaveBeenCalledWith(
+      "slack:changed",
+      null,
+    );
   });
 });
 

--- a/turbo/apps/api/src/signals/routes/zero-integrations-slack.ts
+++ b/turbo/apps/api/src/signals/routes/zero-integrations-slack.ts
@@ -1,6 +1,7 @@
-import { computed } from "ccstate";
+import { command, computed } from "ccstate";
 import { initContract } from "@ts-rest/core";
 import { z } from "zod";
+import type { View } from "@slack/web-api";
 import {
   slackOrgStatusSchema,
   zeroIntegrationsSlackContract,
@@ -14,7 +15,9 @@ import {
   agentComposeVersions,
 } from "@vm0/db/schema/agent-compose";
 import { orgMetadata } from "@vm0/db/schema/org-metadata";
-import { eq } from "drizzle-orm";
+import { slackOrgConnections } from "@vm0/db/schema/slack-org-connection";
+import { slackOrgInstallations } from "@vm0/db/schema/slack-org-installation";
+import { and, eq } from "drizzle-orm";
 
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
@@ -29,9 +32,12 @@ import {
   isSlackFileFetchError,
   MAX_SLACK_FILE_SIZE_BYTES,
 } from "../external/slack-file-fetcher";
-import { db$ } from "../external/db";
+import { createSlackClient } from "../external/slack-message-client";
+import { db$, writeDb$ } from "../external/db";
 import { zeroConnectorList } from "../services/zero-connector-data.service";
 import { userSecrets, userVariables } from "../services/zero-user-data.service";
+import { decryptSecretValue } from "../services/crypto.utils";
+import { env } from "../../lib/env";
 import type { RouteEntry } from "../route";
 import { safeAsync } from "../utils";
 
@@ -181,6 +187,253 @@ const getSlackStatusInner$ = computed(async (get) => {
 
   return { status: 200 as const, body };
 });
+
+function contractErrorResponse(
+  status: 403 | 404,
+  message: string,
+  code: "FORBIDDEN" | "NOT_FOUND",
+) {
+  return {
+    status,
+    body: { error: { message, code } },
+  };
+}
+
+function publishAppHome(
+  client: ReturnType<typeof createSlackClient>,
+  userId: string,
+  view: View,
+): Promise<void> {
+  return client.views.publish({ user_id: userId, view }).then(() => {
+    return undefined;
+  });
+}
+
+function buildConnectUrl(workspaceId: string, slackUserId: string): string {
+  const params = new URLSearchParams({ w: workspaceId, u: slackUserId });
+  return `${env("VM0_WEB_URL")}/settings/slack?${params.toString()}`;
+}
+
+function buildDisconnectedAppHomeView(args: {
+  readonly workspaceId: string;
+  readonly slackUserId: string;
+}): View {
+  return {
+    type: "home",
+    blocks: [
+      {
+        type: "header",
+        text: { type: "plain_text", text: "Welcome to Zero! :wave:" },
+      },
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: "Connect your AI agents to Slack and interact with them through messages.",
+        },
+      },
+      { type: "divider" },
+      {
+        type: "section",
+        text: { type: "mrkdwn", text: ":x: *Account not connected*" },
+      },
+      {
+        type: "actions",
+        elements: [
+          {
+            type: "button",
+            text: { type: "plain_text", text: "Connect" },
+            url: buildConnectUrl(args.workspaceId, args.slackUserId),
+            action_id: "home_login_prompt",
+            style: "primary",
+          },
+        ],
+      },
+    ],
+  };
+}
+
+function buildUninstalledAppHomeView(): View {
+  return {
+    type: "home",
+    blocks: [
+      {
+        type: "header",
+        text: { type: "plain_text", text: "Welcome to Zero! :wave:" },
+      },
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: "Connect your AI agents to Slack and interact with them through messages.",
+        },
+      },
+      { type: "divider" },
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: ":warning: *Zero is not installed for this workspace*\nAsk a workspace admin to install Zero from the platform.",
+        },
+      },
+      {
+        type: "actions",
+        elements: [
+          {
+            type: "button",
+            text: { type: "plain_text", text: "Open Zero Settings" },
+            url: `${env("VM0_WEB_URL")}/works`,
+            action_id: "home_open_settings",
+            style: "primary",
+          },
+        ],
+      },
+    ],
+  };
+}
+
+const deleteSlackIntegrationQuery$ = queryOf(
+  zeroIntegrationsSlackContract.disconnect,
+);
+
+const deleteSlackIntegration$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const auth = get(organizationAuthContext$);
+    const query = get(deleteSlackIntegrationQuery$);
+
+    if (query.action === "uninstall") {
+      if (auth.orgRole !== "admin") {
+        return contractErrorResponse(403, "Admin access required", "FORBIDDEN");
+      }
+
+      const db = set(writeDb$);
+      const [installation] = await db
+        .select()
+        .from(slackOrgInstallations)
+        .where(eq(slackOrgInstallations.orgId, auth.orgId))
+        .limit(1);
+      signal.throwIfAborted();
+
+      if (!installation) {
+        return contractErrorResponse(
+          404,
+          "No Slack installation found",
+          "NOT_FOUND",
+        );
+      }
+
+      const connections = await db
+        .select({ slackUserId: slackOrgConnections.slackUserId })
+        .from(slackOrgConnections)
+        .where(
+          eq(
+            slackOrgConnections.slackWorkspaceId,
+            installation.slackWorkspaceId,
+          ),
+        );
+      signal.throwIfAborted();
+
+      if (connections.length > 0) {
+        const client = createSlackClient(
+          decryptSecretValue(installation.encryptedBotToken),
+        );
+        const view = buildUninstalledAppHomeView();
+        await Promise.allSettled(
+          connections.map((connection) => {
+            return publishAppHome(client, connection.slackUserId, view);
+          }),
+        );
+        signal.throwIfAborted();
+      }
+
+      await db
+        .delete(slackOrgConnections)
+        .where(
+          eq(
+            slackOrgConnections.slackWorkspaceId,
+            installation.slackWorkspaceId,
+          ),
+        );
+      signal.throwIfAborted();
+
+      await db
+        .delete(slackOrgInstallations)
+        .where(
+          eq(
+            slackOrgInstallations.slackWorkspaceId,
+            installation.slackWorkspaceId,
+          ),
+        );
+      signal.throwIfAborted();
+
+      return { status: 200 as const, body: { ok: true } };
+    }
+
+    const db = set(writeDb$);
+    const [installation] = await db
+      .select()
+      .from(slackOrgInstallations)
+      .where(eq(slackOrgInstallations.orgId, auth.orgId))
+      .limit(1);
+    signal.throwIfAborted();
+
+    if (!installation) {
+      return contractErrorResponse(
+        404,
+        "No Slack connection found",
+        "NOT_FOUND",
+      );
+    }
+
+    const [connection] = await db
+      .select({
+        id: slackOrgConnections.id,
+        slackUserId: slackOrgConnections.slackUserId,
+      })
+      .from(slackOrgConnections)
+      .where(
+        and(
+          eq(slackOrgConnections.vm0UserId, auth.userId),
+          eq(
+            slackOrgConnections.slackWorkspaceId,
+            installation.slackWorkspaceId,
+          ),
+        ),
+      )
+      .limit(1);
+    signal.throwIfAborted();
+
+    if (!connection) {
+      return contractErrorResponse(
+        404,
+        "No Slack connection found",
+        "NOT_FOUND",
+      );
+    }
+
+    await db
+      .delete(slackOrgConnections)
+      .where(eq(slackOrgConnections.id, connection.id));
+    signal.throwIfAborted();
+
+    const client = createSlackClient(
+      decryptSecretValue(installation.encryptedBotToken),
+    );
+    await publishAppHome(
+      client,
+      connection.slackUserId,
+      buildDisconnectedAppHomeView({
+        workspaceId: installation.slackWorkspaceId,
+        slackUserId: connection.slackUserId,
+      }),
+    ).catch(() => {
+      return undefined;
+    });
+    signal.throwIfAborted();
+
+    return { status: 200 as const, body: { ok: true } };
+  },
+);
 
 function jsonErrorResponse(
   status: number,
@@ -355,6 +608,10 @@ export const zeroIntegrationsSlackRoutes: readonly RouteEntry[] = [
   {
     route: zeroIntegrationsSlackContract.getStatus,
     handler: authRoute(slackReadAuth, getSlackStatusInner$),
+  },
+  {
+    route: zeroIntegrationsSlackContract.disconnect,
+    handler: authRoute(slackReadAuth, deleteSlackIntegration$),
   },
   {
     route: slackDownloadFileContract.download,

--- a/turbo/apps/api/src/signals/routes/zero-integrations-slack.ts
+++ b/turbo/apps/api/src/signals/routes/zero-integrations-slack.ts
@@ -26,6 +26,7 @@ import {
   zeroSlackOrgInstallation,
   zeroSlackOrgStatus,
 } from "../services/zero-slack-data.service";
+import { publishSlackAdminSignal$ } from "../services/zero-slack-connect.service";
 import { getFileInfo, isSlackApiClientError } from "../../lib/slack-client";
 import {
   fetchSlackFile,
@@ -364,6 +365,13 @@ const deleteSlackIntegration$ = command(
             installation.slackWorkspaceId,
           ),
         );
+      signal.throwIfAborted();
+
+      await set(
+        publishSlackAdminSignal$,
+        { orgId: auth.orgId, topic: "slack:changed" },
+        signal,
+      );
       signal.throwIfAborted();
 
       return { status: 200 as const, body: { ok: true } };


### PR DESCRIPTION
## Summary
- register DELETE /api/zero/integrations/slack on the API backend
- migrate disconnect and admin uninstall behavior with Slack App Home refreshes
- add API integration coverage for unauthenticated, missing connection/installation, disconnect, and uninstall paths

Closes #12806

## Verification
- pnpm -F api exec vitest run src/signals/routes/__tests__/zero-integrations-slack.test.ts
- pnpm -F api lint
- pnpm -F api check-types
- pnpm -F @vm0/api-contracts lint
- pnpm -F @vm0/api-contracts check-types
- pnpm format
- pnpm turbo run lint
- pnpm check-types
- pnpm knip
- git diff --check