### PR TITLE
refactor(api): migrate zero org domains delete route

### DIFF
--- a/turbo/apps/api/src/__tests__/mocks.ts
+++ b/turbo/apps/api/src/__tests__/mocks.ts
@@ -26,6 +26,7 @@ export interface ApiTestMocks {
     readonly authenticateRequest: AsyncMock;
     readonly organizations: {
       readonly createOrganizationDomain: AsyncMock;
+      readonly deleteOrganizationDomain: AsyncMock;
       readonly createOrganizationInvitation: AsyncMock;
       readonly getOrganization: AsyncMock;
       readonly getOrganizationDomainList: AsyncMock;
@@ -131,6 +132,8 @@ const apiTestMocks: ApiTestMocks = vi.hoisted((): ApiTestMocks => {
     authenticateRequest: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
     organizations: {
       createOrganizationDomain:
+        vi.fn<(...args: unknown[]) => Promise<unknown>>(),
+      deleteOrganizationDomain:
         vi.fn<(...args: unknown[]) => Promise<unknown>>(),
       createOrganizationInvitation:
         vi.fn<(...args: unknown[]) => Promise<unknown>>(),
@@ -521,6 +524,7 @@ export function resetApiTestMocks(): void {
   apiTestMocks.axiomLogging.flush.mockReset();
   apiTestMocks.clerk.authenticateRequest.mockReset();
   apiTestMocks.clerk.organizations.createOrganizationDomain.mockReset();
+  apiTestMocks.clerk.organizations.deleteOrganizationDomain.mockReset();
   apiTestMocks.clerk.organizations.createOrganizationInvitation.mockReset();
   apiTestMocks.clerk.organizations.getOrganization.mockReset();
   apiTestMocks.clerk.organizations.getOrganizationDomainList.mockReset();

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-org-domains.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-org-domains.test.ts
@@ -282,3 +282,145 @@ describe("POST /api/zero/org/domains", () => {
     ).not.toHaveBeenCalled();
   });
 });
+
+describe("DELETE /api/zero/org/domains", () => {
+  const seededFixtures: OrgMembershipFixture[] = [];
+
+  afterEach(async () => {
+    while (seededFixtures.length > 0) {
+      const fixture = seededFixtures.pop();
+      if (fixture) {
+        await store.set(deleteOrgMembership$, fixture, context.signal);
+      }
+    }
+  });
+
+  it("removes a domain for an admin", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    seededFixtures.push(
+      await store.set(
+        seedOrgMembership$,
+        { orgId, userId, role: "admin" },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(userId, orgId, "org:admin");
+
+    const client = setupApp({ context })(zeroOrgDomainsContract);
+
+    const response = await accept(
+      client.remove({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { domainId: "domain_test123" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({ message: "Domain removed" });
+    expect(
+      context.mocks.clerk.organizations.deleteOrganizationDomain,
+    ).toHaveBeenCalledWith({
+      organizationId: orgId,
+      domainId: "domain_test123",
+    });
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    const client = setupApp({ context })(zeroOrgDomainsContract);
+
+    const response = await accept(
+      client.remove({
+        headers: {},
+        body: { domainId: "domain_test123" },
+      }),
+      [401],
+    );
+
+    expect(response.body.error.code).toBe("UNAUTHORIZED");
+    expect(
+      context.mocks.clerk.organizations.deleteOrganizationDomain,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when the authenticated session has no organization", async () => {
+    mocks.clerk.session(`user_${randomUUID()}`, null);
+
+    const client = setupApp({ context })(zeroOrgDomainsContract);
+
+    const response = await accept(
+      client.remove({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { domainId: "domain_test123" },
+      }),
+      [401],
+    );
+
+    expect(response.body.error.code).toBe("UNAUTHORIZED");
+    expect(
+      context.mocks.clerk.organizations.deleteOrganizationDomain,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 when caller is not an admin", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    seededFixtures.push(
+      await store.set(
+        seedOrgMembership$,
+        { orgId, userId, role: "member" },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(userId, orgId, "org:member");
+
+    const client = setupApp({ context })(zeroOrgDomainsContract);
+
+    const response = await accept(
+      client.remove({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { domainId: "domain_test123" },
+      }),
+      [403],
+    );
+
+    expect(response.body.error).toStrictEqual({
+      message: "Access denied",
+      code: "FORBIDDEN",
+    });
+    expect(
+      context.mocks.clerk.organizations.deleteOrganizationDomain,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("rejects invalid bodies before calling Clerk", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    seededFixtures.push(
+      await store.set(
+        seedOrgMembership$,
+        { orgId, userId, role: "admin" },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(userId, orgId, "org:admin");
+
+    const app = createApp({ signal: context.signal });
+    const response = await app.request("/api/zero/org/domains", {
+      method: "DELETE",
+      headers: {
+        authorization: "Bearer clerk-session",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({}),
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      error: { code: "BAD_REQUEST" },
+    });
+    expect(
+      context.mocks.clerk.organizations.deleteOrganizationDomain,
+    ).not.toHaveBeenCalled();
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-org-read.ts
+++ b/turbo/apps/api/src/signals/routes/zero-org-read.ts
@@ -162,6 +162,33 @@ const addDomainInner$ = command(async ({ get }, signal: AbortSignal) => {
   };
 });
 
+const removeDomainBody$ = bodyResultOf(zeroOrgDomainsContract.remove);
+
+const removeDomainInner$ = command(async ({ get }, signal: AbortSignal) => {
+  const auth = get(organizationAuthContext$);
+  if (auth.orgRole !== "admin") {
+    return adminRequired;
+  }
+
+  const bodyResult = await get(removeDomainBody$);
+  signal.throwIfAborted();
+  if (!bodyResult.ok) {
+    return bodyResult.response;
+  }
+
+  const client = get(clerk$);
+  await client.organizations.deleteOrganizationDomain({
+    organizationId: auth.orgId,
+    domainId: bodyResult.data.domainId,
+  });
+  signal.throwIfAborted();
+
+  return {
+    status: 200 as const,
+    body: { message: "Domain removed" },
+  };
+});
+
 const membersInner$ = computed(async (get) => {
   const auth = get(organizationAuthContext$);
   const body = await get(
@@ -205,6 +232,13 @@ export const zeroOrgReadRoutes: readonly RouteEntry[] = [
     handler: authRoute(
       { requireOrganization: true, missingOrganizationStatus: 401 },
       addDomainInner$,
+    ),
+  },
+  {
+    route: zeroOrgDomainsContract.remove,
+    handler: authRoute(
+      { requireOrganization: true, missingOrganizationStatus: 401 },
+      removeDomainInner$,
     ),
   },
   {


### PR DESCRIPTION
## Summary
- add the API-native `DELETE /api/zero/org/domains` route registration and handler
- wire Clerk domain deletion through the API route test mocks
- cover admin success, auth/org failures, member denial, and invalid body handling in route integration tests

Closes #12808

## Validation
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-org-domains.test.ts`
- `pnpm format`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- `git diff --check`
- `scripts/prepare.sh`
- `pnpm check-types`