### PR TITLE
refactor(api): migrate zero api key creation

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-api-keys.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-api-keys.test.ts
@@ -1,7 +1,15 @@
-import { apiKeysContract } from "@vm0/api-contracts/contracts/api-keys";
+import { randomUUID } from "node:crypto";
+
+import {
+  apiKeysContract,
+  type ApiKeyItem,
+} from "@vm0/api-contracts/contracts/api-keys";
+import { cliTokens } from "@vm0/db/schema/cli-tokens";
 import { createStore } from "ccstate";
+import { eq } from "drizzle-orm";
 
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { writeDb$ } from "../../external/db";
 import {
   createFixtureTracker,
   createZeroRouteMocks,
@@ -15,6 +23,11 @@ import {
 const context = testContext();
 const store = createStore();
 const mocks = createZeroRouteMocks(context);
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+function authHeaders(): { readonly authorization: string } {
+  return { authorization: "Bearer clerk-session" };
+}
 
 describe("GET /api/zero/api-keys", () => {
   const track = createFixtureTracker<ApiKeysFixture>((fixture) => {
@@ -149,5 +162,180 @@ describe("GET /api/zero/api-keys", () => {
         lastUsedAt: null,
       },
     ]);
+  });
+});
+
+describe("POST /api/zero/api-keys", () => {
+  const track = createFixtureTracker<ApiKeysFixture>((fixture) => {
+    return store.set(deleteApiKeys$, fixture, context.signal);
+  });
+
+  it("returns 401 when the request is unauthenticated", async () => {
+    const client = setupApp({ context })(apiKeysContract);
+
+    const response = await client.create({
+      headers: {},
+      body: { name: "CI bot", expiresInDays: 90 },
+    });
+
+    expect(response.status).toBe(401);
+    if (response.status !== 401) {
+      throw new Error(`Expected 401, received ${response.status}`);
+    }
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("returns 400 when the request has no active organization", async () => {
+    const fixture = await track(store.set(seedApiKeys$, [], context.signal));
+    mocks.clerk.session(fixture.userId, null);
+    const client = setupApp({ context })(apiKeysContract);
+
+    const response = await client.create({
+      headers: authHeaders(),
+      body: { name: "CI bot", expiresInDays: 90 },
+    });
+
+    expect(response.status).toBe(400);
+    if (response.status !== 400) {
+      throw new Error(`Expected 400, received ${response.status}`);
+    }
+    expect(response.body).toStrictEqual({
+      error: {
+        message:
+          "Explicit org context required \u2014 ensure active org in session",
+        code: "BAD_REQUEST",
+      },
+    });
+  });
+
+  it("creates a new PAT and returns the full token exactly once", async () => {
+    const fixture = await track(store.set(seedApiKeys$, [], context.signal));
+    mocks.clerk.session(fixture.userId, `org_${randomUUID().slice(0, 8)}`);
+    const client = setupApp({ context })(apiKeysContract);
+
+    const response = await client.create({
+      headers: authHeaders(),
+      body: { name: "CI bot", expiresInDays: 90 },
+    });
+
+    expect(response.status).toBe(201);
+    if (response.status !== 201) {
+      throw new Error(`Expected 201, received ${response.status}`);
+    }
+    expect(response.body).toMatchObject({
+      id: expect.any(String),
+      name: "CI bot",
+      token: expect.stringMatching(/^vm0_pat_/),
+      tokenPrefix: expect.stringMatching(/^vm0_pat_.+\u2026$/),
+      createdAt: expect.any(String),
+      expiresAt: expect.any(String),
+      lastUsedAt: null,
+    });
+    expect(response.body.tokenPrefix).toBe(
+      `${response.body.token.slice(0, 12)}\u2026`,
+    );
+    expect(
+      new Date(response.body.expiresAt).getTime() -
+        new Date(response.body.createdAt).getTime(),
+    ).toBe(90 * MS_PER_DAY);
+
+    const writeDb = store.set(writeDb$);
+    const [row] = await writeDb
+      .select()
+      .from(cliTokens)
+      .where(eq(cliTokens.id, response.body.id));
+
+    expect(row).toBeDefined();
+    expect(row?.userId).toBe(fixture.userId);
+    expect(row?.name).toBe("CI bot");
+    expect(row?.token).toBe(response.body.token);
+  });
+
+  it("rejects an empty name", async () => {
+    const fixture = await track(store.set(seedApiKeys$, [], context.signal));
+    mocks.clerk.session(fixture.userId, `org_${randomUUID().slice(0, 8)}`);
+    const client = setupApp({ context })(apiKeysContract);
+
+    const response = await client.create({
+      headers: authHeaders(),
+      body: { name: "", expiresInDays: 90 },
+    });
+
+    expect(response.status).toBe(400);
+    if (response.status !== 400) {
+      throw new Error(`Expected 400, received ${response.status}`);
+    }
+    expect(response.body.error.code).toBe("BAD_REQUEST");
+  });
+
+  it("rejects a non-positive expiresInDays", async () => {
+    const fixture = await track(store.set(seedApiKeys$, [], context.signal));
+    mocks.clerk.session(fixture.userId, `org_${randomUUID().slice(0, 8)}`);
+    const client = setupApp({ context })(apiKeysContract);
+
+    const response = await client.create({
+      headers: authHeaders(),
+      body: { name: "CI bot", expiresInDays: 0 },
+    });
+
+    expect(response.status).toBe(400);
+    if (response.status !== 400) {
+      throw new Error(`Expected 400, received ${response.status}`);
+    }
+    expect(response.body.error.code).toBe("BAD_REQUEST");
+  });
+
+  it("rejects expiresInDays above the 10-year cap", async () => {
+    const fixture = await track(store.set(seedApiKeys$, [], context.signal));
+    mocks.clerk.session(fixture.userId, `org_${randomUUID().slice(0, 8)}`);
+    const client = setupApp({ context })(apiKeysContract);
+
+    const response = await client.create({
+      headers: authHeaders(),
+      body: { name: "CI bot", expiresInDays: 4000 },
+    });
+
+    expect(response.status).toBe(400);
+    if (response.status !== 400) {
+      throw new Error(`Expected 400, received ${response.status}`);
+    }
+    expect(response.body.error.code).toBe("BAD_REQUEST");
+  });
+
+  it("list excludes the full token after creation", async () => {
+    const fixture = await track(store.set(seedApiKeys$, [], context.signal));
+    mocks.clerk.session(fixture.userId, `org_${randomUUID().slice(0, 8)}`);
+    const client = setupApp({ context })(apiKeysContract);
+
+    const created = await client.create({
+      headers: authHeaders(),
+      body: { name: "Deploy key", expiresInDays: 30 },
+    });
+    expect(created.status).toBe(201);
+    if (created.status !== 201) {
+      throw new Error(`Expected 201, received ${created.status}`);
+    }
+
+    const listed = await client.list({ headers: authHeaders() });
+    expect(listed.status).toBe(200);
+    if (listed.status !== 200) {
+      throw new Error(`Expected 200, received ${listed.status}`);
+    }
+    const apiKeys: readonly ApiKeyItem[] = listed.body.apiKeys;
+    const found = apiKeys.find((apiKey) => {
+      return apiKey.id === created.body.id;
+    });
+
+    expect(found).toStrictEqual({
+      id: created.body.id,
+      name: "Deploy key",
+      tokenPrefix: created.body.tokenPrefix,
+      createdAt: created.body.createdAt,
+      expiresAt: created.body.expiresAt,
+      lastUsedAt: null,
+    });
+    expect(Object.keys(found ?? {})).not.toContain("token");
   });
 });

--- a/turbo/apps/api/src/signals/routes/zero-api-keys.ts
+++ b/turbo/apps/api/src/signals/routes/zero-api-keys.ts
@@ -1,11 +1,26 @@
-import { computed } from "ccstate";
-import { apiKeysContract } from "@vm0/api-contracts/contracts/api-keys";
+import { randomUUID } from "node:crypto";
 
-import { authContext$ } from "../auth/auth-context";
+import { command, computed } from "ccstate";
+import { apiKeysContract } from "@vm0/api-contracts/contracts/api-keys";
+import { cliTokens } from "@vm0/db/schema/cli-tokens";
+
+import { authContext$, organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
+import { generateCliToken } from "../auth/tokens";
+import { bodyResultOf } from "../context/request";
+import { writeDb$ } from "../external/db";
+import { nowDate } from "../external/time";
 import type { RouteEntry } from "../route";
 import { userApiKeys } from "../services/zero-user-data.service";
 import { zeroApiKeysDeleteRoutes } from "./zero-api-keys-delete";
+
+const API_KEY_PREFIX_LENGTH = 12;
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+const createApiKeyBody$ = bodyResultOf(apiKeysContract.create);
+
+function tokenPrefix(token: string): string {
+  return `${token.slice(0, API_KEY_PREFIX_LENGTH)}\u2026`;
+}
 
 const listApiKeysInner$ = computed(async (get): Promise<unknown> => {
   const auth = get(authContext$);
@@ -16,10 +31,56 @@ const listApiKeysInner$ = computed(async (get): Promise<unknown> => {
   };
 });
 
+const createApiKeyInner$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const auth = get(organizationAuthContext$);
+    const bodyResult = await get(createApiKeyBody$);
+    signal.throwIfAborted();
+    if (!bodyResult.ok) {
+      return bodyResult.response;
+    }
+
+    const tokenId = randomUUID();
+    const createdAt = nowDate();
+    const expiresAt = new Date(
+      createdAt.getTime() + bodyResult.data.expiresInDays * MS_PER_DAY,
+    );
+    const token = generateCliToken(auth.userId, auth.orgId, tokenId);
+
+    const writeDb = set(writeDb$);
+    await writeDb.insert(cliTokens).values({
+      id: tokenId,
+      token,
+      userId: auth.userId,
+      name: bodyResult.data.name,
+      expiresAt,
+      createdAt,
+    });
+    signal.throwIfAborted();
+
+    return {
+      status: 201 as const,
+      body: {
+        id: tokenId,
+        name: bodyResult.data.name,
+        tokenPrefix: tokenPrefix(token),
+        createdAt: createdAt.toISOString(),
+        expiresAt: expiresAt.toISOString(),
+        lastUsedAt: null,
+        token,
+      },
+    };
+  },
+);
+
 export const zeroApiKeysRoutes: readonly RouteEntry[] = [
   {
     route: apiKeysContract.list,
     handler: authRoute({}, listApiKeysInner$),
+  },
+  {
+    route: apiKeysContract.create,
+    handler: authRoute({ requireOrganization: true }, createApiKeyInner$),
   },
   ...zeroApiKeysDeleteRoutes,
 ];


### PR DESCRIPTION
## Summary
- add the API backend command for `POST /api/zero/api-keys`
- persist generated PATs through `cli_tokens` using API-local token generation
- add route-level API tests for create success, auth/org failures, validation, and list-after-create token redaction

Closes #12869

## Validation
- `pnpm -F api exec vitest src/signals/routes/__tests__/zero-api-keys.test.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types 2>&1 | rg "zero-api-keys"` only reports existing `zero-api-keys-delete.test.ts` accept-helper type errors, not this changed test file

## Local note
- Pre-commit `pnpm check-types` currently fails in `@vm0/app` on existing ts-rest client type errors such as `Property 'body' does not exist on type 'never'`; formatter and knip passed before the check-types failure.