### PR TITLE
feat(api): migrate zero org logo delete route

### DIFF
--- a/turbo/apps/api/src/__tests__/mocks.ts
+++ b/turbo/apps/api/src/__tests__/mocks.ts
@@ -32,6 +32,7 @@ export interface ApiTestMocks {
       readonly getOrganizationInvitationList: AsyncMock;
       readonly getOrganizationMembershipList: AsyncMock;
       readonly deleteOrganizationMembership: AsyncMock;
+      readonly deleteOrganizationLogo: AsyncMock;
       readonly revokeOrganizationInvitation: AsyncMock;
       readonly deleteOrganization: AsyncMock;
       readonly updateOrganization: AsyncMock;
@@ -143,6 +144,7 @@ const apiTestMocks: ApiTestMocks = vi.hoisted((): ApiTestMocks => {
         vi.fn<(...args: unknown[]) => Promise<unknown>>(),
       deleteOrganizationMembership:
         vi.fn<(...args: unknown[]) => Promise<unknown>>(),
+      deleteOrganizationLogo: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
       revokeOrganizationInvitation:
         vi.fn<(...args: unknown[]) => Promise<unknown>>(),
       deleteOrganization: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
@@ -526,6 +528,7 @@ export function resetApiTestMocks(): void {
   apiTestMocks.clerk.organizations.getOrganizationDomainList.mockReset();
   apiTestMocks.clerk.organizations.getOrganizationInvitationList.mockReset();
   apiTestMocks.clerk.organizations.getOrganizationMembershipList.mockReset();
+  apiTestMocks.clerk.organizations.deleteOrganizationLogo.mockReset();
   apiTestMocks.clerk.organizations.revokeOrganizationInvitation.mockReset();
   apiTestMocks.clerk.organizations.updateOrganization.mockReset();
   apiTestMocks.clerk.organizations.updateOrganizationLogo.mockReset();

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-org-logo.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-org-logo.test.ts
@@ -35,6 +35,16 @@ function mockClerkOrganizationLogoUpload(
   });
 }
 
+function mockClerkOrganizationLogoDelete(
+  args: ClerkOrganizationLogoFixture,
+): void {
+  context.mocks.clerk.organizations.deleteOrganizationLogo.mockResolvedValue({
+    id: args.orgId,
+    imageUrl: args.imageUrl,
+    hasImage: args.hasImage,
+  });
+}
+
 function clerkNotFoundError(): Error {
   const error = new Error("Organization not found");
   error.name = "NotFoundError";
@@ -69,6 +79,14 @@ function postLogo(form: FormData, headers: HeadersInit = {}) {
     method: "POST",
     headers,
     body: form,
+  });
+}
+
+function deleteLogo(headers: HeadersInit = {}) {
+  const app = createApp({ signal: context.signal });
+  return app.request("/api/zero/org/logo", {
+    method: "DELETE",
+    headers,
   });
 }
 
@@ -411,6 +429,169 @@ describe("POST /api/zero/org/logo", () => {
     });
     expect(
       context.mocks.clerk.organizations.updateOrganizationLogo,
+    ).not.toHaveBeenCalled();
+  });
+});
+
+describe("DELETE /api/zero/org/logo", () => {
+  it("removes the current org logo", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    mocks.clerk.session(userId, orgId, "org:admin");
+    mockClerkOrganizationLogoDelete({
+      orgId,
+      imageUrl: "https://img.clerk.test/default-logo.png",
+      hasImage: true,
+    });
+
+    const response = await deleteLogo({
+      authorization: "Bearer clerk-session",
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toStrictEqual({
+      logoUrl: "https://img.clerk.test/default-logo.png",
+      hasImage: true,
+    });
+    expect(
+      context.mocks.clerk.organizations.deleteOrganizationLogo,
+    ).toHaveBeenCalledWith(orgId);
+  });
+
+  it("returns null logoUrl when Clerk clears the image URL", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    mocks.clerk.session(userId, orgId, "org:admin");
+    mockClerkOrganizationLogoDelete({
+      orgId,
+      imageUrl: "",
+      hasImage: false,
+    });
+
+    const response = await deleteLogo({
+      authorization: "Bearer clerk-session",
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toStrictEqual({
+      logoUrl: null,
+      hasImage: false,
+    });
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    const response = await deleteLogo();
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+    expect(
+      context.mocks.clerk.organizations.deleteOrganizationLogo,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when the session has no active org", async () => {
+    const userId = `user_${randomUUID()}`;
+    mocks.clerk.session(userId, null);
+
+    const response = await deleteLogo({
+      authorization: "Bearer clerk-session",
+    });
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toStrictEqual({
+      error: { message: "Org not found", code: "BAD_REQUEST" },
+    });
+    expect(
+      context.mocks.clerk.organizations.deleteOrganizationLogo,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 when the current org role is not admin", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    mocks.clerk.session(userId, orgId, "org:member");
+
+    const response = await deleteLogo({
+      authorization: "Bearer clerk-session",
+    });
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toStrictEqual({
+      error: {
+        message: "Only admins can remove the logo",
+        code: "BAD_REQUEST",
+      },
+    });
+    expect(
+      context.mocks.clerk.organizations.deleteOrganizationLogo,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("maps Clerk not-found errors to 404", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    mocks.clerk.session(userId, orgId, "org:admin");
+    context.mocks.clerk.organizations.deleteOrganizationLogo.mockRejectedValue(
+      clerkNotFoundError(),
+    );
+
+    const response = await deleteLogo({
+      authorization: "Bearer clerk-session",
+    });
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toStrictEqual({
+      error: { message: "Org not found", code: "BAD_REQUEST" },
+    });
+  });
+
+  it("maps Clerk forbidden errors to 403", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    mocks.clerk.session(userId, orgId, "org:admin");
+    context.mocks.clerk.organizations.deleteOrganizationLogo.mockRejectedValue(
+      clerkForbiddenError(),
+    );
+
+    const response = await deleteLogo({
+      authorization: "Bearer clerk-session",
+    });
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toStrictEqual({
+      error: { message: "Access denied", code: "BAD_REQUEST" },
+    });
+  });
+
+  it("rejects zero tokens", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    const seconds = currentSecond();
+    const token = signSandboxJwtForTests({
+      scope: "zero",
+      userId,
+      orgId,
+      runId: `run_${randomUUID()}`,
+      capabilities: [],
+      iat: seconds,
+      exp: seconds + 600,
+    });
+
+    const response = await deleteLogo({
+      authorization: `Bearer ${token}`,
+    });
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toStrictEqual({
+      error: {
+        message: "This endpoint is not available for sandbox tokens",
+        code: "FORBIDDEN",
+      },
+    });
+    expect(
+      context.mocks.clerk.organizations.deleteOrganizationLogo,
     ).not.toHaveBeenCalled();
   });
 });

--- a/turbo/apps/api/src/signals/routes/zero-org-logo.ts
+++ b/turbo/apps/api/src/signals/routes/zero-org-logo.ts
@@ -141,6 +141,42 @@ const postOrgLogoInner$ = command(async ({ get }, signal: AbortSignal) => {
   };
 });
 
+const deleteOrgLogoInner$ = command(async ({ get }, signal: AbortSignal) => {
+  const auth = get(authContext$);
+  const orgId = auth.orgId;
+  if (!orgId) {
+    return orgLogoNotFound;
+  }
+
+  if (auth.orgRole !== "admin") {
+    return orgLogoForbidden("Only admins can remove the logo");
+  }
+
+  const client = get(clerk$);
+  const result = await safeAsync(() => {
+    return client.organizations.deleteOrganizationLogo(orgId);
+  });
+  signal.throwIfAborted();
+
+  if ("error" in result) {
+    if (isOrgLookupNotFound(result.error)) {
+      return orgLogoNotFound;
+    }
+    if (isOrgLookupForbidden(result.error)) {
+      return orgLogoForbidden("Access denied");
+    }
+    throw result.error;
+  }
+
+  return {
+    status: 200 as const,
+    body: {
+      logoUrl: result.ok.imageUrl || null,
+      hasImage: result.ok.hasImage,
+    },
+  };
+});
+
 export const zeroOrgLogoRoutes: readonly RouteEntry[] = [
   {
     route: zeroOrgLogoContract.get,
@@ -149,5 +185,9 @@ export const zeroOrgLogoRoutes: readonly RouteEntry[] = [
   {
     route: zeroOrgLogoContract.post,
     handler: authRoute({}, postOrgLogoInner$),
+  },
+  {
+    route: zeroOrgLogoContract.delete,
+    handler: authRoute({}, deleteOrgLogoInner$),
   },
 ];

--- a/turbo/packages/api-contracts/src/contracts/zero-org-logo.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-org-logo.ts
@@ -42,6 +42,18 @@ export const zeroOrgLogoContract = c.router({
     },
     summary: "Upload current organization logo",
   },
+  delete: {
+    method: "DELETE",
+    path: "/api/zero/org/logo",
+    headers: authHeadersSchema,
+    responses: {
+      200: zeroOrgLogoResponseSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      404: apiErrorSchema,
+    },
+    summary: "Remove current organization logo",
+  },
 });
 
 export type ZeroOrgLogoContract = typeof zeroOrgLogoContract;


### PR DESCRIPTION
## Summary
- add DELETE /api/zero/org/logo to the shared ts-rest contract
- implement the API route with Clerk deleteOrganizationLogo parity behavior
- extend API Clerk mocks and org-logo integration coverage

## Validation
- pnpm -F api exec vitest src/signals/routes/__tests__/zero-org-logo.test.ts
- pnpm -F api lint
- pnpm check-types
- git diff --check

## Notes
- scripts/prepare.sh installed dependencies, then hit existing local DB drift on chat_threads.pending_message_content during migration.

Closes #12809