### PR TITLE
refactor(api): migrate telegram mock route

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -106,6 +106,7 @@ import { testOAuthProviderTokenRoutes } from "./routes/test-oauth-provider-token
 import { testOAuthProviderUserinfoRoutes } from "./routes/test-oauth-provider-userinfo";
 import { testSlackMockRoutes } from "./routes/test-slack-mock";
 import { testSlackStateRoutes } from "./routes/test-slack-state";
+import { testTelegramMockRoutes } from "./routes/test-telegram-mock";
 import { testTelegramStateRoutes } from "./routes/test-telegram-state";
 
 export type { SignalRouteHandler };
@@ -223,5 +224,6 @@ export const ROUTES: readonly RouteEntry[] = [
   ...testOAuthProviderUserinfoRoutes,
   ...testSlackMockRoutes,
   ...testSlackStateRoutes,
+  ...testTelegramMockRoutes,
   ...testTelegramStateRoutes,
 ];

--- a/turbo/apps/api/src/signals/routes/__tests__/test-telegram-mock.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/test-telegram-mock.test.ts
@@ -1,0 +1,290 @@
+import { randomUUID } from "node:crypto";
+
+import { createStore } from "ccstate";
+import { desc, eq } from "drizzle-orm";
+
+import { TELEGRAM_E2E_FIXTURES } from "@vm0/core/telegram-e2e-fixtures";
+import { e2eTelegramMockCallLog } from "@vm0/db/schema/e2e-telegram-mock-call-log";
+
+import { createApp } from "../../../app-factory";
+import { mockEnv } from "../../../lib/env";
+import { testContext } from "../../../__tests__/test-helpers";
+import { writeDb$ } from "../../external/db";
+import { createFixtureTracker } from "./helpers/zero-route-test";
+
+const context = testContext();
+const store = createStore();
+
+interface TelegramOkResponse {
+  readonly ok: true;
+  readonly result: unknown;
+}
+
+interface TelegramErrorResponse {
+  readonly ok: false;
+  readonly description: string;
+}
+
+interface TelegramMessageResult {
+  readonly message_id: number;
+  readonly chat: {
+    readonly id: number;
+  };
+  readonly text?: string;
+}
+
+interface TelegramGetMeResult {
+  readonly id: number;
+  readonly is_bot: boolean;
+  readonly first_name: string;
+  readonly username: string;
+}
+
+interface TelegramFileResult {
+  readonly file_id: string;
+  readonly file_unique_id: string;
+  readonly file_path: string;
+}
+
+interface MockCallRow {
+  readonly method: string;
+  readonly botToken: string | null;
+  readonly chatId: string | null;
+  readonly body: string;
+  readonly bodyJson: unknown;
+}
+
+function requestApp(path: string, init?: RequestInit): Promise<Response> {
+  const app = createApp({ signal: context.signal });
+  return Promise.resolve(app.request(path, init));
+}
+
+async function readJson<T>(response: Response): Promise<T> {
+  return (await response.json()) as T;
+}
+
+async function latestCall(botToken: string): Promise<MockCallRow | null> {
+  const writeDb = store.set(writeDb$);
+  const [row] = await writeDb
+    .select({
+      method: e2eTelegramMockCallLog.method,
+      botToken: e2eTelegramMockCallLog.botToken,
+      chatId: e2eTelegramMockCallLog.chatId,
+      body: e2eTelegramMockCallLog.body,
+      bodyJson: e2eTelegramMockCallLog.bodyJson,
+    })
+    .from(e2eTelegramMockCallLog)
+    .where(eq(e2eTelegramMockCallLog.botToken, botToken))
+    .orderBy(desc(e2eTelegramMockCallLog.createdAt))
+    .limit(1);
+  return row ?? null;
+}
+
+async function cleanupMockCallToken(token: string): Promise<void> {
+  const writeDb = store.set(writeDb$);
+  await writeDb
+    .delete(e2eTelegramMockCallLog)
+    .where(eq(e2eTelegramMockCallLog.botToken, token));
+}
+
+const trackMockCallToken = createFixtureTracker(cleanupMockCallToken);
+
+function randomBotToken(): Promise<string> {
+  return trackMockCallToken(Promise.resolve(`123456:${randomUUID()}`));
+}
+
+describe("POST /api/test/telegram-mock/:botToken/:method", () => {
+  it("returns 404 when the test endpoint is not allowed", async () => {
+    mockEnv("ENV", "production");
+    const token = await randomBotToken();
+
+    const response = await requestApp(
+      `/api/test/telegram-mock/bot${token}/getMe`,
+      { method: "POST" },
+    );
+
+    expect(response.status).toBe(404);
+    await expect(response.text()).resolves.toBe("Not found");
+    await expect(latestCall(token)).resolves.toBeNull();
+  });
+
+  it("returns getMe fixture data and logs a stripped bot token", async () => {
+    mockEnv("ENV", "development");
+    const token = await randomBotToken();
+
+    const response = await requestApp(
+      `/api/test/telegram-mock/bot${token}/getMe`,
+      { method: "POST" },
+    );
+
+    expect(response.status).toBe(200);
+    const body = await readJson<TelegramOkResponse>(response);
+    expect(body.ok).toBeTruthy();
+    expect(body.result).toStrictEqual({
+      id: Number(TELEGRAM_E2E_FIXTURES.botId),
+      is_bot: true,
+      first_name: "VM0 E2E",
+      username: TELEGRAM_E2E_FIXTURES.botUsername,
+    } satisfies TelegramGetMeResult);
+    await expect(latestCall(token)).resolves.toMatchObject({
+      method: "getMe",
+      botToken: token,
+      chatId: null,
+      body: "",
+      bodyJson: null,
+    });
+  });
+
+  it("returns sendMessage data and stores raw and parsed body JSON", async () => {
+    mockEnv("ENV", "development");
+    const token = await randomBotToken();
+    const requestBody = { chat_id: "990010", text: "hello telegram" };
+
+    const response = await requestApp(
+      `/api/test/telegram-mock/bot${token}/sendMessage`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(requestBody),
+      },
+    );
+
+    expect(response.status).toBe(200);
+    const body = await readJson<TelegramOkResponse>(response);
+    const result = body.result as TelegramMessageResult;
+    expect(result.chat.id).toBe(990_010);
+    expect(result.text).toBe("hello telegram");
+    expect(typeof result.message_id).toBe("number");
+    await expect(latestCall(token)).resolves.toMatchObject({
+      method: "sendMessage",
+      botToken: token,
+      chatId: "990010",
+      body: JSON.stringify(requestBody),
+      bodyJson: requestBody,
+    });
+  });
+
+  it("returns editMessageText data with a numeric chat id", async () => {
+    mockEnv("ENV", "development");
+    const token = await randomBotToken();
+
+    const response = await requestApp(
+      `/api/test/telegram-mock/bot${token}/editMessageText`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ chat_id: 990_011, text: "updated" }),
+      },
+    );
+
+    expect(response.status).toBe(200);
+    const body = await readJson<TelegramOkResponse>(response);
+    const result = body.result as TelegramMessageResult;
+    expect(result.chat.id).toBe(990_011);
+    expect(result.text).toBe("updated");
+    await expect(latestCall(token)).resolves.toMatchObject({
+      method: "editMessageText",
+      botToken: token,
+      chatId: "990011",
+    });
+  });
+
+  it.each([
+    "sendChatAction",
+    "deleteMessage",
+    "deleteWebhook",
+    "setWebhook",
+    "setMyCommands",
+  ])("returns true for %s", async (method) => {
+    mockEnv("ENV", "development");
+    const token = await randomBotToken();
+
+    const response = await requestApp(
+      `/api/test/telegram-mock/bot${token}/${method}`,
+      { method: "POST" },
+    );
+
+    expect(response.status).toBe(200);
+    await expect(readJson<TelegramOkResponse>(response)).resolves.toStrictEqual(
+      {
+        ok: true,
+        result: true,
+      },
+    );
+    await expect(latestCall(token)).resolves.toMatchObject({
+      method,
+      botToken: token,
+    });
+  });
+
+  it("returns getFile data with requested file id", async () => {
+    mockEnv("ENV", "development");
+    const token = await randomBotToken();
+
+    const response = await requestApp(
+      `/api/test/telegram-mock/bot${token}/getFile`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ file_id: "custom-file" }),
+      },
+    );
+
+    expect(response.status).toBe(200);
+    const body = await readJson<TelegramOkResponse>(response);
+    expect(body.result).toStrictEqual({
+      file_id: "custom-file",
+      file_unique_id: "e2e-file-unique",
+      file_path: "photos/e2e-file.jpg",
+    } satisfies TelegramFileResult);
+  });
+
+  it("returns Telegram-style 404 for unsupported methods", async () => {
+    mockEnv("ENV", "development");
+    const token = await randomBotToken();
+
+    const response = await requestApp(
+      `/api/test/telegram-mock/bot${token}/answerCallbackQuery`,
+      { method: "POST" },
+    );
+
+    expect(response.status).toBe(404);
+    await expect(
+      readJson<TelegramErrorResponse>(response),
+    ).resolves.toStrictEqual({
+      ok: false,
+      description: "Unsupported mock method: answerCallbackQuery",
+    });
+    await expect(latestCall(token)).resolves.toMatchObject({
+      method: "answerCallbackQuery",
+      botToken: token,
+    });
+  });
+
+  it("accepts invalid JSON for supported methods and logs null body JSON", async () => {
+    mockEnv("ENV", "development");
+    const token = await randomBotToken();
+
+    const response = await requestApp(
+      `/api/test/telegram-mock/bot${token}/sendMessage`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "{not-json",
+      },
+    );
+
+    expect(response.status).toBe(200);
+    const body = await readJson<TelegramOkResponse>(response);
+    const result = body.result as TelegramMessageResult;
+    expect(result.chat.id).toBe(Number(TELEGRAM_E2E_FIXTURES.chatId));
+    expect(result.text).toBeUndefined();
+    await expect(latestCall(token)).resolves.toMatchObject({
+      method: "sendMessage",
+      botToken: token,
+      chatId: null,
+      body: "{not-json",
+      bodyJson: null,
+    });
+  });
+});

--- a/turbo/apps/api/src/signals/routes/test-telegram-mock.ts
+++ b/turbo/apps/api/src/signals/routes/test-telegram-mock.ts
@@ -1,0 +1,162 @@
+import { command } from "ccstate";
+import { testTelegramMockContract } from "@vm0/api-contracts/contracts/test-telegram-mock";
+import { TELEGRAM_E2E_FIXTURES } from "@vm0/core/telegram-e2e-fixtures";
+import { e2eTelegramMockCallLog } from "@vm0/db/schema/e2e-telegram-mock-call-log";
+
+import { now } from "../../lib/time";
+import { request$ } from "../context/hono";
+import { pathParamsOf } from "../context/request";
+import { writeDb$, type Db } from "../external/db";
+import type { RouteEntry } from "../route";
+import { safeAsync, safeJsonParse } from "../utils";
+import {
+  isTestEndpointAllowed,
+  testEndpointNotFoundResponse,
+} from "./test-oauth-provider-helpers";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function ok(result: unknown): Response {
+  return jsonResponse({ ok: true, result });
+}
+
+function stripBotPrefix(token: string): string {
+  return token.startsWith("bot") ? token.slice(3) : token;
+}
+
+function parseJsonObject(rawBody: string): Record<string, unknown> | null {
+  if (rawBody.length === 0) {
+    return null;
+  }
+
+  const parsed = safeJsonParse(rawBody);
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return null;
+  }
+  return parsed as Record<string, unknown>;
+}
+
+function readChatId(body: Record<string, unknown> | null): number {
+  const raw = body?.chat_id;
+  if (typeof raw === "number") {
+    return raw;
+  }
+  if (typeof raw === "string") {
+    const parsed = Number(raw);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+  return Number(TELEGRAM_E2E_FIXTURES.chatId);
+}
+
+function readLogChatId(body: Record<string, unknown> | null): string | null {
+  const raw = body?.chat_id;
+  if (typeof raw === "number" || typeof raw === "string") {
+    return String(raw);
+  }
+  return null;
+}
+
+async function logTelegramMockCall({
+  db,
+  method,
+  botToken,
+  rawBody,
+  bodyJson,
+}: {
+  readonly db: Db;
+  readonly method: string;
+  readonly botToken: string;
+  readonly rawBody: string;
+  readonly bodyJson: Record<string, unknown> | null;
+}): Promise<void> {
+  await safeAsync(() => {
+    return db.insert(e2eTelegramMockCallLog).values({
+      method,
+      botToken,
+      chatId: readLogChatId(bodyJson),
+      body: rawBody,
+      bodyJson,
+    });
+  });
+}
+
+const postTestTelegramMock$ = command(
+  async ({ get, set }, signal: AbortSignal): Promise<Response> => {
+    const request = get(request$);
+    if (!isTestEndpointAllowed(request)) {
+      return testEndpointNotFoundResponse();
+    }
+
+    const { botToken: rawBotToken, method } = get(
+      pathParamsOf(testTelegramMockContract.post),
+    );
+    const botToken = stripBotPrefix(rawBotToken);
+    const rawBody = await request.raw.clone().text();
+    signal.throwIfAborted();
+
+    const body = parseJsonObject(rawBody);
+    await logTelegramMockCall({
+      db: set(writeDb$),
+      method,
+      botToken,
+      rawBody,
+      bodyJson: body,
+    });
+    signal.throwIfAborted();
+
+    const chatId = readChatId(body);
+
+    switch (method) {
+      case "getMe": {
+        return ok({
+          id: Number(TELEGRAM_E2E_FIXTURES.botId),
+          is_bot: true,
+          first_name: "VM0 E2E",
+          username: TELEGRAM_E2E_FIXTURES.botUsername,
+        });
+      }
+      case "sendMessage":
+      case "editMessageText": {
+        return ok({
+          message_id: Math.floor(now() % 1_000_000_000),
+          chat: { id: chatId },
+          text: typeof body?.text === "string" ? body.text : undefined,
+        });
+      }
+      case "sendChatAction":
+      case "deleteMessage":
+      case "deleteWebhook":
+      case "setWebhook":
+      case "setMyCommands": {
+        return ok(true);
+      }
+      case "getFile": {
+        return ok({
+          file_id: String(body?.file_id ?? "e2e-file"),
+          file_unique_id: "e2e-file-unique",
+          file_path: "photos/e2e-file.jpg",
+        });
+      }
+      default: {
+        return jsonResponse(
+          { ok: false, description: `Unsupported mock method: ${method}` },
+          404,
+        );
+      }
+    }
+  },
+);
+
+export const testTelegramMockRoutes: readonly RouteEntry[] = [
+  {
+    route: testTelegramMockContract.post,
+    handler: postTestTelegramMock$,
+  },
+];

--- a/turbo/apps/web/src/lib/test-endpoints/telegram-mock-fixtures.ts
+++ b/turbo/apps/web/src/lib/test-endpoints/telegram-mock-fixtures.ts
@@ -1,13 +1,1 @@
-/**
- * Canned Telegram Bot API fixture identifiers used by the e2e Telegram mock
- * routes under `/api/test/telegram-mock/*` and by BATS helpers.
- */
-export const TELEGRAM_E2E_FIXTURES = {
-  botId: "123456",
-  botUsername: "vm0_e2e_bot",
-  botToken: "123456:e2e-test-bot-token",
-  webhookSecret: "e2e-telegram-webhook-secret",
-  telegramUserId: "99001",
-  chatId: "990010",
-  firstName: "E2E",
-} as const;
+export { TELEGRAM_E2E_FIXTURES } from "@vm0/core/telegram-e2e-fixtures";

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -272,6 +272,13 @@ export {
   type TestSlackMockUsersInfoResponse,
 } from "./test-slack-mock";
 export {
+  testTelegramMockContract,
+  testTelegramMockErrorResponseSchema,
+  testTelegramMockPathParamsSchema,
+  testTelegramMockSuccessResponseSchema,
+  type TestTelegramMockContract,
+} from "./test-telegram-mock";
+export {
   testTelegramStateContract,
   testTelegramStateErrorSchema,
   testTelegramStateResponseSchema,

--- a/turbo/packages/api-contracts/src/contracts/test-telegram-mock.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-telegram-mock.ts
@@ -1,0 +1,36 @@
+import { z } from "zod";
+
+import { initContract } from "./base";
+
+const c = initContract();
+
+export const testTelegramMockPathParamsSchema = z.object({
+  botToken: z.string(),
+  method: z.string(),
+});
+
+export const testTelegramMockSuccessResponseSchema = z.object({
+  ok: z.literal(true),
+  result: z.unknown(),
+});
+
+export const testTelegramMockErrorResponseSchema = z.object({
+  ok: z.literal(false),
+  description: z.string(),
+});
+
+export const testTelegramMockContract = c.router({
+  post: {
+    method: "POST",
+    path: "/api/test/telegram-mock/:botToken/:method",
+    pathParams: testTelegramMockPathParamsSchema,
+    body: z.unknown().optional(),
+    responses: {
+      200: testTelegramMockSuccessResponseSchema,
+      404: z.union([z.string(), testTelegramMockErrorResponseSchema]),
+    },
+    summary: "Handle Telegram Bot API E2E mock calls",
+  },
+});
+
+export type TestTelegramMockContract = typeof testTelegramMockContract;

--- a/turbo/packages/core/src/telegram-e2e-fixtures.ts
+++ b/turbo/packages/core/src/telegram-e2e-fixtures.ts
@@ -1,0 +1,13 @@
+/**
+ * Canned Telegram Bot API fixture identifiers used by the e2e Telegram mock
+ * routes under `/api/test/telegram-mock/*` and by BATS helpers.
+ */
+export const TELEGRAM_E2E_FIXTURES = {
+  botId: "123456",
+  botUsername: "vm0_e2e_bot",
+  botToken: "123456:e2e-test-bot-token",
+  webhookSecret: "e2e-telegram-webhook-secret",
+  telegramUserId: "99001",
+  chatId: "990010",
+  firstName: "E2E",
+} as const;


### PR DESCRIPTION
## Summary
- add an API-native `POST /api/test/telegram-mock/:botToken/:method` route and contract
- share Telegram E2E fixture constants through `@vm0/core` while preserving the web import path
- cover Telegram mock method behavior, guard behavior, invalid JSON, and diagnostic DB logging with API integration tests

## Testing
- `pnpm -F api exec vitest src/signals/routes/__tests__/test-telegram-mock.test.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F @vm0/core lint`
- `pnpm -F @vm0/core check-types`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F web lint`
- `pnpm -F web check-types`
- `pnpm format`
- `pnpm knip`
- pre-commit hook: `prettier`, `knip --cache`, `pnpm check-types`

Closes #12862