### PR TITLE
refactor: migrate slack mock test routes to api

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -102,6 +102,7 @@ import { storagesListRoutes } from "./routes/storages-list";
 import { testOAuthProviderAuthorizeRoutes } from "./routes/test-oauth-provider-authorize";
 import { testOAuthProviderEchoRoutes } from "./routes/test-oauth-provider-echo";
 import { testOAuthProviderUserinfoRoutes } from "./routes/test-oauth-provider-userinfo";
+import { testSlackMockRoutes } from "./routes/test-slack-mock";
 import { testSlackStateRoutes } from "./routes/test-slack-state";
 import { testTelegramStateRoutes } from "./routes/test-telegram-state";
 
@@ -216,6 +217,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...testOAuthProviderAuthorizeRoutes,
   ...testOAuthProviderEchoRoutes,
   ...testOAuthProviderUserinfoRoutes,
+  ...testSlackMockRoutes,
   ...testSlackStateRoutes,
   ...testTelegramStateRoutes,
 ];

--- a/turbo/apps/api/src/signals/routes/__tests__/test-slack-mock.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/test-slack-mock.test.ts
@@ -1,0 +1,241 @@
+import { createStore } from "ccstate";
+import {
+  SLACK_E2E_FIXTURES,
+  SLACK_E2E_SCOPES,
+  type TestSlackMockUsersInfoResponse,
+} from "@vm0/api-contracts/contracts/test-slack-mock";
+import { e2eSlackMockCallLog } from "@vm0/db/schema/e2e-slack-mock-call-log";
+import { afterEach, describe, expect, it } from "vitest";
+import { and, eq, inArray } from "drizzle-orm";
+
+import { createApp } from "../../../app-factory";
+import { testContext } from "../../../__tests__/test-helpers";
+import { mockEnv } from "../../../lib/env";
+import { writeDb$ } from "../../external/db";
+
+const context = testContext();
+const store = createStore();
+const writeDb = store.set(writeDb$);
+
+const BASE_ROUTE = "/api/test/slack-mock";
+const LOG_TEST_TEAM_ID = "T_TEST_SLACK_MOCK_12859";
+
+function requestApp(path: string, init?: RequestInit): Promise<Response> {
+  const app = createApp({ signal: context.signal });
+  return Promise.resolve(app.request(path, init));
+}
+
+async function readJson<T>(response: Response): Promise<T> {
+  return (await response.json()) as T;
+}
+
+async function cleanupMockCallLog(): Promise<void> {
+  await writeDb
+    .delete(e2eSlackMockCallLog)
+    .where(eq(e2eSlackMockCallLog.teamId, LOG_TEST_TEAM_ID));
+}
+
+afterEach(async () => {
+  await cleanupMockCallLog();
+});
+
+describe("POST /api/test/slack-mock/*", () => {
+  it("returns 404 outside allowed test environments", async () => {
+    mockEnv("ENV", "production");
+
+    const response = await requestApp(`${BASE_ROUTE}/auth.test`, {
+      method: "POST",
+    });
+
+    expect(response.status).toBe(404);
+    await expect(response.text()).resolves.toBe("Not found");
+  });
+
+  it("returns fixed Slack auth.test and oauth.v2.access fixture payloads", async () => {
+    mockEnv("ENV", "development");
+
+    const authResponse = await requestApp(`${BASE_ROUTE}/auth.test`, {
+      method: "POST",
+    });
+    const oauthResponse = await requestApp(`${BASE_ROUTE}/oauth.v2.access`, {
+      method: "POST",
+    });
+
+    await expect(authResponse.json()).resolves.toStrictEqual({
+      ok: true,
+      url: "https://e2e-mock.invalid/",
+      team: SLACK_E2E_FIXTURES.teamName,
+      user: "e2e-bot",
+      team_id: SLACK_E2E_FIXTURES.teamId,
+      user_id: SLACK_E2E_FIXTURES.botUserId,
+      bot_id: SLACK_E2E_FIXTURES.botId,
+    });
+    await expect(oauthResponse.json()).resolves.toStrictEqual({
+      ok: true,
+      access_token: SLACK_E2E_FIXTURES.botToken,
+      token_type: "bot",
+      scope: SLACK_E2E_SCOPES.join(","),
+      bot_user_id: SLACK_E2E_FIXTURES.botUserId,
+      app_id: SLACK_E2E_FIXTURES.appId,
+      team: {
+        id: SLACK_E2E_FIXTURES.teamId,
+        name: SLACK_E2E_FIXTURES.teamName,
+      },
+      enterprise: null,
+      authed_user: {
+        id: SLACK_E2E_FIXTURES.userUserId,
+        scope: "",
+        access_token: "",
+        token_type: "user",
+      },
+    });
+  });
+
+  it("returns fixed Slack conversation and ack payloads", async () => {
+    mockEnv("ENV", "development");
+
+    await expect(
+      requestApp(`${BASE_ROUTE}/assistant.threads.setStatus`, {
+        method: "POST",
+      }).then((response) => {
+        return response.json();
+      }),
+    ).resolves.toStrictEqual({ ok: true });
+    await expect(
+      requestApp(`${BASE_ROUTE}/views.publish`, { method: "POST" }).then(
+        (response) => {
+          return response.json();
+        },
+      ),
+    ).resolves.toStrictEqual({ ok: true });
+    await expect(
+      requestApp(`${BASE_ROUTE}/conversations.open`, { method: "POST" }).then(
+        (response) => {
+          return response.json();
+        },
+      ),
+    ).resolves.toStrictEqual({
+      ok: true,
+      channel: { id: "D_E2E_MOCK" },
+    });
+    await expect(
+      requestApp(`${BASE_ROUTE}/conversations.history`, {
+        method: "POST",
+      }).then((response) => {
+        return response.json();
+      }),
+    ).resolves.toStrictEqual({ ok: true, messages: [], has_more: false });
+    await expect(
+      requestApp(`${BASE_ROUTE}/conversations.replies`, {
+        method: "POST",
+      }).then((response) => {
+        return response.json();
+      }),
+    ).resolves.toStrictEqual({ ok: true, messages: [], has_more: false });
+  });
+
+  it("reads users.info user ids from JSON and form-encoded bodies", async () => {
+    mockEnv("ENV", "development");
+
+    const jsonResponse = await requestApp(`${BASE_ROUTE}/users.info`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ user: "U_JSON_USER" }),
+    });
+    const formResponse = await requestApp(`${BASE_ROUTE}/users.info`, {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({ user: "U_FORM_USER" }),
+    });
+
+    const jsonBody =
+      await readJson<TestSlackMockUsersInfoResponse>(jsonResponse);
+    const formBody =
+      await readJson<TestSlackMockUsersInfoResponse>(formResponse);
+
+    expect(jsonBody.user.id).toBe("U_JSON_USER");
+    expect(formBody.user.id).toBe("U_FORM_USER");
+  });
+
+  it("logs chat.postMessage and chat.postEphemeral calls", async () => {
+    mockEnv("ENV", "development");
+    await cleanupMockCallLog();
+
+    const messageResponse = await requestApp(`${BASE_ROUTE}/chat.postMessage`, {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        team_id: LOG_TEST_TEAM_ID,
+        channel: "C_TEST_FORM",
+        text: "hello from form",
+      }),
+    });
+    const ephemeralResponse = await requestApp(
+      `${BASE_ROUTE}/chat.postEphemeral`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          team_id: LOG_TEST_TEAM_ID,
+          channel_id: "C_TEST_JSON",
+          text: "hello from json",
+        }),
+      },
+    );
+
+    expect(messageResponse.status).toBe(200);
+    await expect(messageResponse.json()).resolves.toMatchObject({
+      ok: true,
+      channel: SLACK_E2E_FIXTURES.channelId,
+      message: { text: "mocked" },
+    });
+    expect(ephemeralResponse.status).toBe(200);
+    await expect(ephemeralResponse.json()).resolves.toMatchObject({
+      ok: true,
+      message_ts: expect.stringMatching(/^\d+\.000200$/),
+    });
+
+    const calls = await writeDb
+      .select({
+        method: e2eSlackMockCallLog.method,
+        teamId: e2eSlackMockCallLog.teamId,
+        channelId: e2eSlackMockCallLog.channelId,
+        bodyJson: e2eSlackMockCallLog.bodyJson,
+      })
+      .from(e2eSlackMockCallLog)
+      .where(
+        and(
+          eq(e2eSlackMockCallLog.teamId, LOG_TEST_TEAM_ID),
+          inArray(e2eSlackMockCallLog.method, [
+            "chat.postMessage",
+            "chat.postEphemeral",
+          ]),
+        ),
+      );
+
+    expect(calls).toStrictEqual(
+      expect.arrayContaining([
+        {
+          method: "chat.postMessage",
+          teamId: LOG_TEST_TEAM_ID,
+          channelId: "C_TEST_FORM",
+          bodyJson: {
+            team_id: LOG_TEST_TEAM_ID,
+            channel: "C_TEST_FORM",
+            text: "hello from form",
+          },
+        },
+        {
+          method: "chat.postEphemeral",
+          teamId: LOG_TEST_TEAM_ID,
+          channelId: "C_TEST_JSON",
+          bodyJson: {
+            team_id: LOG_TEST_TEAM_ID,
+            channel_id: "C_TEST_JSON",
+            text: "hello from json",
+          },
+        },
+      ]),
+    );
+  });
+});

--- a/turbo/apps/api/src/signals/routes/test-slack-mock.ts
+++ b/turbo/apps/api/src/signals/routes/test-slack-mock.ts
@@ -1,0 +1,282 @@
+import { command } from "ccstate";
+import {
+  SLACK_E2E_FIXTURES,
+  SLACK_E2E_SCOPES,
+  testSlackMockContract,
+} from "@vm0/api-contracts/contracts/test-slack-mock";
+import { e2eSlackMockCallLog } from "@vm0/db/schema/e2e-slack-mock-call-log";
+
+import { request$ } from "../context/hono";
+import { writeDb$, type Db } from "../external/db";
+import { now } from "../../lib/time";
+import type { RouteEntry } from "../route";
+import { safeAsync, safeJsonParse } from "../utils";
+import {
+  isTestEndpointAllowed,
+  testEndpointNotFoundResponse,
+} from "./test-oauth-provider-helpers";
+
+interface ParsedSlackMockBody {
+  readonly rawBody: string;
+  readonly bodyJson: Record<string, unknown> | null;
+  readonly teamId: string | null;
+  readonly channelId: string | null;
+  readonly userId: string | null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stringField(
+  record: Readonly<Record<string, unknown>>,
+  key: string,
+): string | null {
+  const value = record[key];
+  return typeof value === "string" ? value : null;
+}
+
+function parsedJsonBody(rawBody: string): Record<string, unknown> | null {
+  const parsed = safeJsonParse(rawBody);
+  return isRecord(parsed) ? parsed : null;
+}
+
+function parsedFormBody(rawBody: string): Record<string, unknown> {
+  const params = new URLSearchParams(rawBody);
+  const parsed: Record<string, unknown> = {};
+  for (const [key, value] of params) {
+    parsed[key] = value;
+  }
+  return parsed;
+}
+
+async function readSlackMockBody(
+  request: Request,
+  contentType: string,
+): Promise<ParsedSlackMockBody> {
+  const rawBody = await request.text();
+  const bodyJson = contentType.includes("application/json")
+    ? parsedJsonBody(rawBody)
+    : parsedFormBody(rawBody);
+
+  return {
+    rawBody,
+    bodyJson,
+    teamId: bodyJson ? stringField(bodyJson, "team_id") : null,
+    channelId: bodyJson
+      ? (stringField(bodyJson, "channel_id") ??
+        stringField(bodyJson, "channel"))
+      : null,
+    userId: bodyJson ? stringField(bodyJson, "user") : null,
+  };
+}
+
+async function logSlackMockCall(
+  db: Db,
+  method: string,
+  request: Request,
+  contentType: string,
+): Promise<void> {
+  const parsed = await readSlackMockBody(request, contentType);
+  await safeAsync(async () => {
+    await db.insert(e2eSlackMockCallLog).values({
+      method,
+      teamId: parsed.teamId,
+      channelId: parsed.channelId,
+      body: parsed.rawBody,
+      bodyJson: parsed.bodyJson,
+    });
+  });
+}
+
+function staticSlackMockHandler<T extends Record<string, unknown>>(
+  bodyFactory: () => T,
+) {
+  return command(({ get }) => {
+    const request = get(request$);
+    if (!isTestEndpointAllowed(request)) {
+      return testEndpointNotFoundResponse();
+    }
+
+    return {
+      status: 200 as const,
+      body: bodyFactory(),
+    };
+  });
+}
+
+const ok$ = staticSlackMockHandler(() => {
+  return { ok: true };
+});
+
+const authTest$ = staticSlackMockHandler(() => {
+  return {
+    ok: true,
+    url: "https://e2e-mock.invalid/",
+    team: SLACK_E2E_FIXTURES.teamName,
+    user: "e2e-bot",
+    team_id: SLACK_E2E_FIXTURES.teamId,
+    user_id: SLACK_E2E_FIXTURES.botUserId,
+    bot_id: SLACK_E2E_FIXTURES.botId,
+  };
+});
+
+const oauthV2Access$ = staticSlackMockHandler(() => {
+  return {
+    ok: true,
+    access_token: SLACK_E2E_FIXTURES.botToken,
+    token_type: "bot",
+    scope: SLACK_E2E_SCOPES.join(","),
+    bot_user_id: SLACK_E2E_FIXTURES.botUserId,
+    app_id: SLACK_E2E_FIXTURES.appId,
+    team: {
+      id: SLACK_E2E_FIXTURES.teamId,
+      name: SLACK_E2E_FIXTURES.teamName,
+    },
+    enterprise: null,
+    authed_user: {
+      id: SLACK_E2E_FIXTURES.userUserId,
+      scope: "",
+      access_token: "",
+      token_type: "user",
+    },
+  };
+});
+
+const conversationsOpen$ = staticSlackMockHandler(() => {
+  return {
+    ok: true,
+    channel: { id: "D_E2E_MOCK" },
+  };
+});
+
+const conversationMessages$ = staticSlackMockHandler(() => {
+  return { ok: true, messages: [], has_more: false };
+});
+
+const chatPostMessage$ = command(async ({ get, set }, signal: AbortSignal) => {
+  const request = get(request$);
+  if (!isTestEndpointAllowed(request)) {
+    return testEndpointNotFoundResponse();
+  }
+
+  await logSlackMockCall(
+    set(writeDb$),
+    "chat.postMessage",
+    request.raw,
+    request.header("content-type") ?? "",
+  );
+  signal.throwIfAborted();
+
+  const ts = `${Math.floor(now() / 1000)}.000100`;
+  return {
+    status: 200 as const,
+    body: {
+      ok: true,
+      channel: SLACK_E2E_FIXTURES.channelId,
+      ts,
+      message: { ts, text: "mocked" },
+    },
+  };
+});
+
+const chatPostEphemeral$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const request = get(request$);
+    if (!isTestEndpointAllowed(request)) {
+      return testEndpointNotFoundResponse();
+    }
+
+    await logSlackMockCall(
+      set(writeDb$),
+      "chat.postEphemeral",
+      request.raw,
+      request.header("content-type") ?? "",
+    );
+    signal.throwIfAborted();
+
+    return {
+      status: 200 as const,
+      body: {
+        ok: true,
+        message_ts: `${Math.floor(now() / 1000)}.000200`,
+      },
+    };
+  },
+);
+
+const usersInfo$ = command(async ({ get }, signal: AbortSignal) => {
+  const request = get(request$);
+  if (!isTestEndpointAllowed(request)) {
+    return testEndpointNotFoundResponse();
+  }
+
+  const parsed = await readSlackMockBody(
+    request.raw,
+    request.header("content-type") ?? "",
+  );
+  signal.throwIfAborted();
+
+  const userId = parsed.userId ?? SLACK_E2E_FIXTURES.userUserId;
+  return {
+    status: 200 as const,
+    body: {
+      ok: true,
+      user: {
+        id: userId,
+        name: "e2e-user",
+        real_name: "E2E User",
+        tz: "UTC",
+        tz_label: "Coordinated Universal Time",
+        profile: {
+          display_name: "e2e-user",
+          real_name: "E2E User",
+          email: "e2e@example.com",
+        },
+      },
+    },
+  };
+});
+
+export const testSlackMockRoutes: readonly RouteEntry[] = [
+  {
+    route: testSlackMockContract.assistantThreadsSetStatus,
+    handler: ok$,
+  },
+  {
+    route: testSlackMockContract.authTest,
+    handler: authTest$,
+  },
+  {
+    route: testSlackMockContract.chatPostEphemeral,
+    handler: chatPostEphemeral$,
+  },
+  {
+    route: testSlackMockContract.chatPostMessage,
+    handler: chatPostMessage$,
+  },
+  {
+    route: testSlackMockContract.conversationsHistory,
+    handler: conversationMessages$,
+  },
+  {
+    route: testSlackMockContract.conversationsOpen,
+    handler: conversationsOpen$,
+  },
+  {
+    route: testSlackMockContract.conversationsReplies,
+    handler: conversationMessages$,
+  },
+  {
+    route: testSlackMockContract.oauthV2Access,
+    handler: oauthV2Access$,
+  },
+  {
+    route: testSlackMockContract.usersInfo,
+    handler: usersInfo$,
+  },
+  {
+    route: testSlackMockContract.viewsPublish,
+    handler: ok$,
+  },
+];

--- a/turbo/apps/web/src/lib/test-endpoints/__tests__/slack-mock-fixtures-drift.test.ts
+++ b/turbo/apps/web/src/lib/test-endpoints/__tests__/slack-mock-fixtures-drift.test.ts
@@ -5,8 +5,7 @@ import { SLACK_E2E_FIXTURES } from "../slack-mock-fixtures";
 
 /**
  * Cross-file contract test: asserts the hand-maintained BATS mirror at
- * `e2e/helpers/slack-fixtures.sh` agrees with the canonical TS source in
- * `src/lib/test-endpoints/slack-mock-fixtures.ts`.
+ * `e2e/helpers/slack-fixtures.sh` agrees with the shared TS fixture values.
  *
  * This is intentionally a contract check, not a unit test of internal
  * logic (no business behavior is exercised). Because the Slack mock

--- a/turbo/apps/web/src/lib/test-endpoints/slack-mock-fixtures.ts
+++ b/turbo/apps/web/src/lib/test-endpoints/slack-mock-fixtures.ts
@@ -1,41 +1,4 @@
-/**
- * Canned Slack Web API fixture identifiers used by the e2e Slack mock
- * routes under `/api/test/slack-mock/*` and by the BATS helpers in
- * `e2e/helpers/slack.bash`.
- *
- * Keep this file the single source of truth so the two cannot drift.
- * BATS sources its copy from `e2e/helpers/slack-fixtures.sh`, which
- * mirrors these values.
- */
-export const SLACK_E2E_FIXTURES = {
-  /** Bot user in the E2E mock workspace. Matches Slack's `Uxxxxx` shape. */
-  botUserId: "U_E2E_BOT",
-  /** Default real-user stand-in for `users.info` lookups. */
-  userUserId: "U_E2E_USER",
-  /** Mock bot ID returned by `auth.test`. */
-  botId: "B_E2E_BOT",
-  /** Workspace / team ID used throughout the mock suite. */
-  teamId: "T_E2E",
-  /** Slack app ID for the mock install. */
-  appId: "A_E2E_APP",
-  /** Default channel ID used by BATS slash-command invocations. */
-  channelId: "C_E2E_MOCK",
-  /** Opaque bot token returned by the mock oauth exchange. */
-  botToken: "xoxb-e2e-test-bot-token",
-  /** Team / workspace display name. */
-  teamName: "E2E Test Team",
-} as const;
-
-export const SLACK_E2E_SCOPES = [
-  "app_mentions:read",
-  "channels:read",
-  "chat:write",
-  "chat:write.public",
-  "commands",
-  "groups:read",
-  "im:history",
-  "im:read",
-  "im:write",
-  "users:read",
-  "users:read.email",
-] as const;
+export {
+  SLACK_E2E_FIXTURES,
+  SLACK_E2E_SCOPES,
+} from "@vm0/api-contracts/contracts/test-slack-mock";

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -250,6 +250,21 @@ export {
   type TestSlackStateResponse,
 } from "./test-slack-state";
 export {
+  SLACK_E2E_FIXTURES,
+  SLACK_E2E_SCOPES,
+  testSlackMockAuthTestResponseSchema,
+  testSlackMockChatPostEphemeralResponseSchema,
+  testSlackMockChatPostMessageResponseSchema,
+  testSlackMockContract,
+  testSlackMockConversationMessagesResponseSchema,
+  testSlackMockConversationsOpenResponseSchema,
+  testSlackMockOauthAccessResponseSchema,
+  testSlackMockOkResponseSchema,
+  testSlackMockUsersInfoResponseSchema,
+  type TestSlackMockContract,
+  type TestSlackMockUsersInfoResponse,
+} from "./test-slack-mock";
+export {
   testTelegramStateContract,
   testTelegramStateErrorSchema,
   testTelegramStateResponseSchema,

--- a/turbo/packages/api-contracts/src/contracts/test-slack-mock.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-slack-mock.ts
@@ -1,0 +1,219 @@
+import { z } from "zod";
+
+import { initContract } from "./base";
+
+const c = initContract();
+
+export const SLACK_E2E_FIXTURES = {
+  botUserId: "U_E2E_BOT",
+  userUserId: "U_E2E_USER",
+  botId: "B_E2E_BOT",
+  teamId: "T_E2E",
+  appId: "A_E2E_APP",
+  channelId: "C_E2E_MOCK",
+  botToken: "xoxb-e2e-test-bot-token",
+  teamName: "E2E Test Team",
+} as const;
+
+export const SLACK_E2E_SCOPES = [
+  "app_mentions:read",
+  "channels:read",
+  "chat:write",
+  "chat:write.public",
+  "commands",
+  "groups:read",
+  "im:history",
+  "im:read",
+  "im:write",
+  "users:read",
+  "users:read.email",
+] as const;
+
+const slackMockRequestBodySchema = z.unknown().optional();
+const slackMockNotFoundSchema = z.string();
+
+export const testSlackMockOkResponseSchema = z.object({
+  ok: z.literal(true),
+});
+
+export const testSlackMockAuthTestResponseSchema =
+  testSlackMockOkResponseSchema.extend({
+    url: z.string(),
+    team: z.string(),
+    user: z.string(),
+    team_id: z.string(),
+    user_id: z.string(),
+    bot_id: z.string(),
+  });
+
+export const testSlackMockOauthAccessResponseSchema =
+  testSlackMockOkResponseSchema.extend({
+    access_token: z.string(),
+    token_type: z.literal("bot"),
+    scope: z.string(),
+    bot_user_id: z.string(),
+    app_id: z.string(),
+    team: z.object({
+      id: z.string(),
+      name: z.string(),
+    }),
+    enterprise: z.null(),
+    authed_user: z.object({
+      id: z.string(),
+      scope: z.string(),
+      access_token: z.string(),
+      token_type: z.literal("user"),
+    }),
+  });
+
+export const testSlackMockChatPostMessageResponseSchema =
+  testSlackMockOkResponseSchema.extend({
+    channel: z.string(),
+    ts: z.string(),
+    message: z.object({
+      ts: z.string(),
+      text: z.string(),
+    }),
+  });
+
+export const testSlackMockChatPostEphemeralResponseSchema =
+  testSlackMockOkResponseSchema.extend({
+    message_ts: z.string(),
+  });
+
+export const testSlackMockConversationsOpenResponseSchema =
+  testSlackMockOkResponseSchema.extend({
+    channel: z.object({
+      id: z.string(),
+    }),
+  });
+
+export const testSlackMockConversationMessagesResponseSchema =
+  testSlackMockOkResponseSchema.extend({
+    messages: z.array(z.unknown()),
+    has_more: z.literal(false),
+  });
+
+export const testSlackMockUsersInfoResponseSchema =
+  testSlackMockOkResponseSchema.extend({
+    user: z.object({
+      id: z.string(),
+      name: z.string(),
+      real_name: z.string(),
+      tz: z.string(),
+      tz_label: z.string(),
+      profile: z.object({
+        display_name: z.string(),
+        real_name: z.string(),
+        email: z.string(),
+      }),
+    }),
+  });
+
+export const testSlackMockContract = c.router({
+  assistantThreadsSetStatus: {
+    method: "POST",
+    path: "/api/test/slack-mock/assistant.threads.setStatus",
+    body: slackMockRequestBodySchema,
+    responses: {
+      200: testSlackMockOkResponseSchema,
+      404: slackMockNotFoundSchema,
+    },
+    summary: "Mock Slack assistant.threads.setStatus for e2e tests",
+  },
+  authTest: {
+    method: "POST",
+    path: "/api/test/slack-mock/auth.test",
+    body: slackMockRequestBodySchema,
+    responses: {
+      200: testSlackMockAuthTestResponseSchema,
+      404: slackMockNotFoundSchema,
+    },
+    summary: "Mock Slack auth.test for e2e tests",
+  },
+  chatPostEphemeral: {
+    method: "POST",
+    path: "/api/test/slack-mock/chat.postEphemeral",
+    body: slackMockRequestBodySchema,
+    responses: {
+      200: testSlackMockChatPostEphemeralResponseSchema,
+      404: slackMockNotFoundSchema,
+    },
+    summary: "Mock Slack chat.postEphemeral for e2e tests",
+  },
+  chatPostMessage: {
+    method: "POST",
+    path: "/api/test/slack-mock/chat.postMessage",
+    body: slackMockRequestBodySchema,
+    responses: {
+      200: testSlackMockChatPostMessageResponseSchema,
+      404: slackMockNotFoundSchema,
+    },
+    summary: "Mock Slack chat.postMessage for e2e tests",
+  },
+  conversationsHistory: {
+    method: "POST",
+    path: "/api/test/slack-mock/conversations.history",
+    body: slackMockRequestBodySchema,
+    responses: {
+      200: testSlackMockConversationMessagesResponseSchema,
+      404: slackMockNotFoundSchema,
+    },
+    summary: "Mock Slack conversations.history for e2e tests",
+  },
+  conversationsOpen: {
+    method: "POST",
+    path: "/api/test/slack-mock/conversations.open",
+    body: slackMockRequestBodySchema,
+    responses: {
+      200: testSlackMockConversationsOpenResponseSchema,
+      404: slackMockNotFoundSchema,
+    },
+    summary: "Mock Slack conversations.open for e2e tests",
+  },
+  conversationsReplies: {
+    method: "POST",
+    path: "/api/test/slack-mock/conversations.replies",
+    body: slackMockRequestBodySchema,
+    responses: {
+      200: testSlackMockConversationMessagesResponseSchema,
+      404: slackMockNotFoundSchema,
+    },
+    summary: "Mock Slack conversations.replies for e2e tests",
+  },
+  oauthV2Access: {
+    method: "POST",
+    path: "/api/test/slack-mock/oauth.v2.access",
+    body: slackMockRequestBodySchema,
+    responses: {
+      200: testSlackMockOauthAccessResponseSchema,
+      404: slackMockNotFoundSchema,
+    },
+    summary: "Mock Slack oauth.v2.access for e2e tests",
+  },
+  usersInfo: {
+    method: "POST",
+    path: "/api/test/slack-mock/users.info",
+    body: slackMockRequestBodySchema,
+    responses: {
+      200: testSlackMockUsersInfoResponseSchema,
+      404: slackMockNotFoundSchema,
+    },
+    summary: "Mock Slack users.info for e2e tests",
+  },
+  viewsPublish: {
+    method: "POST",
+    path: "/api/test/slack-mock/views.publish",
+    body: slackMockRequestBodySchema,
+    responses: {
+      200: testSlackMockOkResponseSchema,
+      404: slackMockNotFoundSchema,
+    },
+    summary: "Mock Slack views.publish for e2e tests",
+  },
+});
+
+export type TestSlackMockContract = typeof testSlackMockContract;
+export type TestSlackMockUsersInfoResponse = z.infer<
+  typeof testSlackMockUsersInfoResponseSchema
+>;


### PR DESCRIPTION
## Summary
- add shared Slack mock API contracts and fixture constants
- implement API backend handlers for the Slack mock POST endpoints
- re-export web fixtures from the shared contract and add API integration coverage

## Validation
- pnpm format
- pnpm -F api exec vitest src/signals/routes/__tests__/test-slack-mock.test.ts
- pnpm -F web exec vitest src/lib/test-endpoints/__tests__/slack-mock-fixtures-drift.test.ts
- pnpm -F api lint
- pnpm -F @vm0/api-contracts lint
- pnpm -F web lint
- pnpm -F api check-types
- pnpm check-types

Closes #12859