### PR TITLE
feat(api): migrate test oauth token route

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -98,6 +98,7 @@ import { storagesDownloadRoutes } from "./routes/storages-download";
 import { storagesListRoutes } from "./routes/storages-list";
 import { testOAuthProviderAuthorizeRoutes } from "./routes/test-oauth-provider-authorize";
 import { testOAuthProviderEchoRoutes } from "./routes/test-oauth-provider-echo";
+import { testOAuthProviderTokenRoutes } from "./routes/test-oauth-provider-token";
 import { testOAuthProviderUserinfoRoutes } from "./routes/test-oauth-provider-userinfo";
 import { testSlackStateRoutes } from "./routes/test-slack-state";
 import { testTelegramStateRoutes } from "./routes/test-telegram-state";
@@ -209,6 +210,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...modelStatsRoutes,
   ...testOAuthProviderAuthorizeRoutes,
   ...testOAuthProviderEchoRoutes,
+  ...testOAuthProviderTokenRoutes,
   ...testOAuthProviderUserinfoRoutes,
   ...testSlackStateRoutes,
   ...testTelegramStateRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/test-oauth-provider-get.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/test-oauth-provider-get.test.ts
@@ -11,11 +11,13 @@ import {
 
 const context = testContext();
 const AUTHORIZE_ROUTE = "/api/test/oauth-provider/authorize";
+const TOKEN_ROUTE = "/api/test/oauth-provider/token";
 const USERINFO_ROUTE = "/api/test/oauth-provider/userinfo";
 const ECHO_ROUTE = "/api/test/oauth-provider/echo";
 
 interface ErrorBody {
   readonly error: string;
+  readonly error_description?: string;
 }
 
 interface EchoBody {
@@ -27,6 +29,14 @@ interface UserinfoBody {
   readonly email: string;
   readonly id: string;
   readonly username: string;
+}
+
+interface TokenBody {
+  readonly access_token: string;
+  readonly refresh_token: string;
+  readonly token_type: "Bearer";
+  readonly expires_in: number;
+  readonly scope: string;
 }
 
 function requestApp(path: string, init?: RequestInit): Promise<Response> {
@@ -49,6 +59,14 @@ function validAuthorizePath(overrides: Record<string, string> = {}): string {
   });
 }
 
+function tokenRequest(body: Record<string, string>): RequestInit {
+  return {
+    method: "POST",
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams(body).toString(),
+  };
+}
+
 async function readJson<T>(response: Response): Promise<T> {
   return (await response.json()) as T;
 }
@@ -61,7 +79,7 @@ afterEach(() => {
   clearMockNow();
 });
 
-describe("GET /api/test/oauth-provider/*", () => {
+describe("/api/test/oauth-provider/*", () => {
   it("returns 404 for all scoped GET routes in production", async () => {
     mockEnv("ENV", "production");
 
@@ -75,6 +93,18 @@ describe("GET /api/test/oauth-provider/*", () => {
     await expect(userinfo.text()).resolves.toBe("Not found");
     expect(echo.status).toBe(404);
     await expect(echo.text()).resolves.toBe("Not found");
+  });
+
+  it("returns 404 for the token route in production", async () => {
+    mockEnv("ENV", "production");
+
+    const response = await requestApp(
+      TOKEN_ROUTE,
+      tokenRequest({ grant_type: "authorization_code" }),
+    );
+
+    expect(response.status).toBe(404);
+    await expect(response.text()).resolves.toBe("Not found");
   });
 
   it("requires the preview bypass secret when ENV is preview", async () => {
@@ -144,6 +174,275 @@ describe("GET /api/test/oauth-provider/*", () => {
       expect(response.status).toBe(400);
       await expect(readJson<ErrorBody>(response)).resolves.toStrictEqual({
         error: "invalid_scenario",
+      });
+    });
+  });
+
+  describe("token authorization_code", () => {
+    it("exchanges a valid authorization code for tokens", async () => {
+      mockEnv("ENV", "development");
+      mockNow(new Date("2026-05-12T00:00:00.000Z"));
+
+      const authorize = await requestApp(validAuthorizePath());
+      const location = authorize.headers.get("location");
+      expect(location).not.toBeNull();
+      const code = new URL(location ?? "").searchParams.get("code");
+      expect(code).not.toBeNull();
+
+      const response = await requestApp(
+        TOKEN_ROUTE,
+        tokenRequest({
+          grant_type: "authorization_code",
+          client_id: "test-oauth-client",
+          client_secret: "test-oauth-secret",
+          code: code ?? "",
+        }),
+      );
+
+      expect(response.status).toBe(200);
+      const body = await readJson<TokenBody>(response);
+      expect(body.access_token).toMatch(/^testoauth_at_/);
+      expect(body.refresh_token).toMatch(/^testoauth_rt_/);
+      expect(body.token_type).toBe("Bearer");
+      expect(body.expires_in).toBe(3600);
+      expect(body.scope).toBe("read");
+    });
+
+    it("rejects requests without a form body", async () => {
+      mockEnv("ENV", "development");
+
+      const response = await requestApp(TOKEN_ROUTE, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: "{}",
+      });
+
+      expect(response.status).toBe(400);
+      await expect(readJson<ErrorBody>(response)).resolves.toStrictEqual({
+        error: "invalid_request",
+        error_description: "expected form body",
+      });
+    });
+
+    it("rejects invalid client credentials", async () => {
+      mockEnv("ENV", "development");
+
+      const response = await requestApp(
+        TOKEN_ROUTE,
+        tokenRequest({
+          grant_type: "authorization_code",
+          client_id: "wrong",
+          client_secret: "wrong",
+          code: "testoauth_code_success_abc",
+        }),
+      );
+
+      expect(response.status).toBe(401);
+      await expect(readJson<ErrorBody>(response)).resolves.toStrictEqual({
+        error: "invalid_client",
+      });
+    });
+
+    it("rejects a missing authorization code", async () => {
+      mockEnv("ENV", "development");
+
+      const response = await requestApp(
+        TOKEN_ROUTE,
+        tokenRequest({
+          grant_type: "authorization_code",
+          client_id: "test-oauth-client",
+          client_secret: "test-oauth-secret",
+        }),
+      );
+
+      expect(response.status).toBe(400);
+      await expect(readJson<ErrorBody>(response)).resolves.toStrictEqual({
+        error: "invalid_request",
+        error_description: "code required",
+      });
+    });
+
+    it("rejects an invalid authorization code", async () => {
+      mockEnv("ENV", "development");
+
+      const response = await requestApp(
+        TOKEN_ROUTE,
+        tokenRequest({
+          grant_type: "authorization_code",
+          client_id: "test-oauth-client",
+          client_secret: "test-oauth-secret",
+          code: "testoauth_code_unknown_abc",
+        }),
+      );
+
+      expect(response.status).toBe(400);
+      await expect(readJson<ErrorBody>(response)).resolves.toStrictEqual({
+        error: "invalid_grant",
+        error_description: "malformed or unknown code",
+      });
+    });
+
+    it("returns 401 for a revoked authorization code", async () => {
+      mockEnv("ENV", "development");
+
+      const authorize = await requestApp(
+        validAuthorizePath({ scenario: "revoked" }),
+      );
+      const location = authorize.headers.get("location");
+      expect(location).not.toBeNull();
+      const code = new URL(location ?? "").searchParams.get("code");
+
+      const response = await requestApp(
+        TOKEN_ROUTE,
+        tokenRequest({
+          grant_type: "authorization_code",
+          client_id: "test-oauth-client",
+          client_secret: "test-oauth-secret",
+          code: code ?? "",
+        }),
+      );
+
+      expect(response.status).toBe(401);
+      await expect(readJson<ErrorBody>(response)).resolves.toStrictEqual({
+        error: "invalid_grant",
+        error_description: "token revoked",
+      });
+    });
+
+    it("returns an immediate-expiry token for expired-access scenario", async () => {
+      mockEnv("ENV", "development");
+
+      const authorize = await requestApp(
+        validAuthorizePath({ scenario: "expired-access" }),
+      );
+      const location = authorize.headers.get("location");
+      expect(location).not.toBeNull();
+      const code = new URL(location ?? "").searchParams.get("code");
+
+      const response = await requestApp(
+        TOKEN_ROUTE,
+        tokenRequest({
+          grant_type: "authorization_code",
+          client_id: "test-oauth-client",
+          client_secret: "test-oauth-secret",
+          code: code ?? "",
+        }),
+      );
+
+      expect(response.status).toBe(200);
+      const body = await readJson<TokenBody>(response);
+      expect(body.expires_in).toBe(0);
+    });
+  });
+
+  describe("token refresh_token", () => {
+    it("mints a fresh access token for a valid refresh token", async () => {
+      mockEnv("ENV", "development");
+
+      const authorize = await requestApp(validAuthorizePath());
+      const location = authorize.headers.get("location");
+      expect(location).not.toBeNull();
+      const code = new URL(location ?? "").searchParams.get("code");
+      const firstResponse = await requestApp(
+        TOKEN_ROUTE,
+        tokenRequest({
+          grant_type: "authorization_code",
+          client_id: "test-oauth-client",
+          client_secret: "test-oauth-secret",
+          code: code ?? "",
+        }),
+      );
+      const first = await readJson<TokenBody>(firstResponse);
+
+      const response = await requestApp(
+        TOKEN_ROUTE,
+        tokenRequest({
+          grant_type: "refresh_token",
+          client_id: "test-oauth-client",
+          client_secret: "test-oauth-secret",
+          refresh_token: first.refresh_token,
+        }),
+      );
+
+      expect(response.status).toBe(200);
+      const refreshed = await readJson<TokenBody>(response);
+      expect(refreshed.access_token).toMatch(/^testoauth_at_/);
+      expect(refreshed.access_token).not.toBe(first.access_token);
+    });
+
+    it("rejects an invalid-refresh scenario token", async () => {
+      mockEnv("ENV", "development");
+
+      const response = await requestApp(
+        TOKEN_ROUTE,
+        tokenRequest({
+          grant_type: "refresh_token",
+          client_id: "test-oauth-client",
+          client_secret: "test-oauth-secret",
+          refresh_token: "testoauth_rt_invalid-refresh_abc",
+        }),
+      );
+
+      expect(response.status).toBe(400);
+      await expect(readJson<ErrorBody>(response)).resolves.toStrictEqual({
+        error: "invalid_grant",
+        error_description: "refresh token rejected",
+      });
+    });
+
+    it("rejects a malformed prefixed refresh token", async () => {
+      mockEnv("ENV", "development");
+
+      const response = await requestApp(
+        TOKEN_ROUTE,
+        tokenRequest({
+          grant_type: "refresh_token",
+          client_id: "test-oauth-client",
+          client_secret: "test-oauth-secret",
+          refresh_token: "testoauth_rt_unknown_abc",
+        }),
+      );
+
+      expect(response.status).toBe(400);
+      await expect(readJson<ErrorBody>(response)).resolves.toStrictEqual({
+        error: "invalid_grant",
+        error_description: "malformed or unknown refresh token scenario",
+      });
+    });
+
+    it("accepts arbitrary opaque refresh tokens as success", async () => {
+      mockEnv("ENV", "development");
+
+      const response = await requestApp(
+        TOKEN_ROUTE,
+        tokenRequest({
+          grant_type: "refresh_token",
+          client_id: "test-oauth-client",
+          client_secret: "test-oauth-secret",
+          refresh_token: "arbitrary-opaque-token",
+        }),
+      );
+
+      expect(response.status).toBe(200);
+      const body = await readJson<TokenBody>(response);
+      expect(body.access_token).toMatch(/^testoauth_at_/);
+    });
+
+    it("rejects an unsupported grant type", async () => {
+      mockEnv("ENV", "development");
+
+      const response = await requestApp(
+        TOKEN_ROUTE,
+        tokenRequest({
+          grant_type: "password",
+          client_id: "test-oauth-client",
+          client_secret: "test-oauth-secret",
+        }),
+      );
+
+      expect(response.status).toBe(400);
+      await expect(readJson<ErrorBody>(response)).resolves.toStrictEqual({
+        error: "unsupported_grant_type",
       });
     });
   });

--- a/turbo/apps/api/src/signals/routes/test-oauth-provider-helpers.ts
+++ b/turbo/apps/api/src/signals/routes/test-oauth-provider-helpers.ts
@@ -4,6 +4,7 @@ import { env, optionalEnv } from "../../lib/env";
 import { now } from "../../lib/time";
 
 export const TEST_OAUTH_CLIENT_ID = "test-oauth-client";
+export const TEST_OAUTH_CLIENT_SECRET = "test-oauth-secret";
 
 const TEST_OAUTH_SCENARIOS = [
   "success",
@@ -12,10 +13,11 @@ const TEST_OAUTH_SCENARIOS = [
   "revoked",
 ] as const;
 
-type TestOAuthScenario = (typeof TEST_OAUTH_SCENARIOS)[number];
+export type TestOAuthScenario = (typeof TEST_OAUTH_SCENARIOS)[number];
 
 const TOKEN_PREFIX = "testoauth_";
 const ACCESS_PREFIX = `${TOKEN_PREFIX}at_`;
+const REFRESH_PREFIX = `${TOKEN_PREFIX}rt_`;
 const CODE_PREFIX = `${TOKEN_PREFIX}code_`;
 
 interface HeaderReader {
@@ -64,6 +66,10 @@ export function mintAccessToken(expiresInSecs: number): string {
   return `${ACCESS_PREFIX}${expiresAtMs}_${randomId()}`;
 }
 
+export function mintRefreshToken(scenario: TestOAuthScenario): string {
+  return `${REFRESH_PREFIX}${scenario}_${randomId()}`;
+}
+
 export function mintExpiredAccessToken(): string {
   const pastMs = now() - 1000;
   return `${ACCESS_PREFIX}${pastMs}_${randomId()}`;
@@ -71,6 +77,37 @@ export function mintExpiredAccessToken(): string {
 
 export function isTestOAuthAccessToken(value: string): boolean {
   return value.startsWith(ACCESS_PREFIX);
+}
+
+export function isTestOAuthRefreshToken(value: string): boolean {
+  return value.startsWith(REFRESH_PREFIX);
+}
+
+function parseScenarioFromToken(
+  value: string,
+  prefix: string,
+): TestOAuthScenario | null {
+  if (!value.startsWith(prefix)) {
+    return null;
+  }
+
+  const tail = value.slice(prefix.length);
+  const underscoreIdx = tail.indexOf("_");
+  if (underscoreIdx === -1) {
+    return null;
+  }
+
+  return parseTestOAuthScenario(tail.slice(0, underscoreIdx));
+}
+
+export function parseScenarioFromCode(code: string): TestOAuthScenario | null {
+  return parseScenarioFromToken(code, CODE_PREFIX);
+}
+
+export function parseScenarioFromRefreshToken(
+  refreshToken: string,
+): TestOAuthScenario | null {
+  return parseScenarioFromToken(refreshToken, REFRESH_PREFIX);
 }
 
 function parseAccessTokenExpiryMs(token: string): number | null {

--- a/turbo/apps/api/src/signals/routes/test-oauth-provider-token.ts
+++ b/turbo/apps/api/src/signals/routes/test-oauth-provider-token.ts
@@ -1,0 +1,131 @@
+import { command } from "ccstate";
+import {
+  testOAuthProviderTokenContract,
+  type TestOAuthProviderTokenResponse,
+} from "@vm0/api-contracts/contracts/test-oauth-provider-token";
+
+import { request$ } from "../context/hono";
+import type { RouteEntry } from "../route";
+import {
+  isTestEndpointAllowed,
+  isTestOAuthRefreshToken,
+  mintAccessToken,
+  mintRefreshToken,
+  parseScenarioFromCode,
+  parseScenarioFromRefreshToken,
+  TEST_OAUTH_CLIENT_ID,
+  TEST_OAUTH_CLIENT_SECRET,
+  testEndpointNotFoundResponse,
+  type TestOAuthScenario,
+} from "./test-oauth-provider-helpers";
+
+const DEFAULT_EXPIRES_IN = 3600;
+
+function mintTokensForScenario(
+  scenario: TestOAuthScenario,
+): TestOAuthProviderTokenResponse {
+  const expiresIn = scenario === "expired-access" ? 0 : DEFAULT_EXPIRES_IN;
+  return {
+    access_token: mintAccessToken(expiresIn),
+    refresh_token: mintRefreshToken(scenario),
+    token_type: "Bearer",
+    expires_in: expiresIn,
+    scope: "read",
+  };
+}
+
+function errorResponse(
+  status: 400 | 401,
+  error: string,
+  errorDescription?: string,
+) {
+  return {
+    status,
+    body: errorDescription
+      ? { error, error_description: errorDescription }
+      : { error },
+  };
+}
+
+function handleAuthorizationCode(code: string | null) {
+  if (!code) {
+    return errorResponse(400, "invalid_request", "code required");
+  }
+
+  const scenario = parseScenarioFromCode(code);
+  if (!scenario) {
+    return errorResponse(400, "invalid_grant", "malformed or unknown code");
+  }
+
+  if (scenario === "revoked") {
+    return errorResponse(401, "invalid_grant", "token revoked");
+  }
+
+  return { status: 200 as const, body: mintTokensForScenario(scenario) };
+}
+
+function handleRefreshToken(refreshToken: string | null) {
+  if (!refreshToken) {
+    return errorResponse(400, "invalid_request", "refresh_token required");
+  }
+
+  const scenario = parseScenarioFromRefreshToken(refreshToken);
+  if (!scenario && isTestOAuthRefreshToken(refreshToken)) {
+    return errorResponse(
+      400,
+      "invalid_grant",
+      "malformed or unknown refresh token scenario",
+    );
+  }
+
+  const resolved = scenario ?? "success";
+  if (resolved === "invalid-refresh" || resolved === "revoked") {
+    return errorResponse(400, "invalid_grant", "refresh token rejected");
+  }
+
+  return { status: 200 as const, body: mintTokensForScenario(resolved) };
+}
+
+const token$ = command(async ({ get }, signal: AbortSignal) => {
+  const request = get(request$);
+  if (!isTestEndpointAllowed(request)) {
+    return testEndpointNotFoundResponse();
+  }
+
+  const contentType = request.header("content-type") ?? "";
+  if (!contentType.includes("application/x-www-form-urlencoded")) {
+    return errorResponse(400, "invalid_request", "expected form body");
+  }
+
+  const text = await request.text();
+  signal.throwIfAborted();
+
+  const body = new URLSearchParams(text);
+  const grantType = body.get("grant_type");
+  const clientId = body.get("client_id");
+  const clientSecret = body.get("client_secret");
+
+  if (
+    clientId !== TEST_OAUTH_CLIENT_ID ||
+    clientSecret !== TEST_OAUTH_CLIENT_SECRET
+  ) {
+    return errorResponse(401, "invalid_client");
+  }
+
+  if (grantType === "authorization_code") {
+    return handleAuthorizationCode(body.get("code"));
+  }
+
+  if (grantType === "refresh_token") {
+    return handleRefreshToken(body.get("refresh_token"));
+  }
+
+  return errorResponse(400, "unsupported_grant_type");
+});
+
+export const testOAuthProviderTokenRoutes: readonly RouteEntry[] = [
+  {
+    route: testOAuthProviderTokenContract.token,
+    handler: token$,
+  },
+];

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -236,6 +236,13 @@ export {
   type TestOAuthProviderEchoResponse,
 } from "./test-oauth-provider-echo";
 export {
+  testOAuthProviderTokenContract,
+  testOAuthProviderTokenErrorSchema,
+  testOAuthProviderTokenResponseSchema,
+  type TestOAuthProviderTokenContract,
+  type TestOAuthProviderTokenResponse,
+} from "./test-oauth-provider-token";
+export {
   testOAuthProviderUserinfoContract,
   testOAuthProviderUserinfoErrorSchema,
   testOAuthProviderUserinfoResponseSchema,

--- a/turbo/packages/api-contracts/src/contracts/test-oauth-provider-token.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-oauth-provider-token.ts
@@ -1,0 +1,39 @@
+import { z } from "zod";
+
+import { initContract } from "./base";
+
+const c = initContract();
+
+export const testOAuthProviderTokenErrorSchema = z.object({
+  error: z.string(),
+  error_description: z.string().optional(),
+});
+
+export const testOAuthProviderTokenResponseSchema = z.object({
+  access_token: z.string(),
+  refresh_token: z.string(),
+  token_type: z.literal("Bearer"),
+  expires_in: z.number(),
+  scope: z.string(),
+});
+
+export const testOAuthProviderTokenContract = c.router({
+  token: {
+    method: "POST",
+    path: "/api/test/oauth-provider/token",
+    body: c.type<string>(),
+    responses: {
+      200: testOAuthProviderTokenResponseSchema,
+      400: testOAuthProviderTokenErrorSchema,
+      401: testOAuthProviderTokenErrorSchema,
+      404: z.string(),
+    },
+    summary: "Synthetic OAuth token endpoint for test connector flows",
+  },
+});
+
+export type TestOAuthProviderTokenContract =
+  typeof testOAuthProviderTokenContract;
+export type TestOAuthProviderTokenResponse = z.infer<
+  typeof testOAuthProviderTokenResponseSchema
+>;


### PR DESCRIPTION
## Summary
- Add the API contract and ccstate route for `POST /api/test/oauth-provider/token`.
- Share API-side synthetic OAuth token helpers for auth-code and refresh-token flows.
- Extend API route tests to cover the token route parity behavior and production guard.

Closes #12857

## Validation
- `pnpm -F api exec vitest run src/signals/routes/__tests__/test-oauth-provider-get.test.ts`
- `pnpm format`
- `pnpm -F api lint`
- `pnpm check-types`
- `pnpm knip`
- `git diff --check`
- `pnpm vitest` (fails in existing unrelated `@vm0/app` UI tests and one existing `web` provider-secret assertion; the API target test passed within the run)
