### PR TITLE
refactor(api): migrate zero schedules delete route

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-schedules-delete.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-schedules-delete.test.ts
@@ -1,0 +1,213 @@
+import { randomUUID } from "node:crypto";
+
+import { zeroSchedulesByNameContract } from "@vm0/api-contracts/contracts/zero-schedules";
+import { createStore } from "ccstate";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { now } from "../../../lib/time";
+import { signSandboxJwtForTests } from "../../auth/tokens";
+import {
+  type SchedulesFixture,
+  deleteSchedulesScenario$,
+  seedSchedulesScenario$,
+} from "./helpers/zero-schedules";
+import {
+  createFixtureTracker,
+  createZeroRouteMocks,
+} from "./helpers/zero-route-test";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+
+function currentSecond(): number {
+  return Math.floor(now() / 1000);
+}
+
+function zeroTokenWithoutScheduleDelete(args: {
+  readonly userId: string;
+  readonly orgId: string;
+  readonly runId: string;
+}): string {
+  const seconds = currentSecond();
+  return signSandboxJwtForTests({
+    scope: "zero",
+    userId: args.userId,
+    orgId: args.orgId,
+    runId: args.runId,
+    capabilities: ["schedule:read"],
+    iat: seconds,
+    exp: seconds + 60,
+  });
+}
+
+describe("DELETE /api/zero/schedules/:name", () => {
+  const track = createFixtureTracker<SchedulesFixture>((fixture) => {
+    return store.set(deleteSchedulesScenario$, fixture, context.signal);
+  });
+
+  const client = () => {
+    return setupApp({ context })(zeroSchedulesByNameContract);
+  };
+
+  it("deletes a schedule and returns 204", async () => {
+    const fixture = await track(
+      store.set(
+        seedSchedulesScenario$,
+        {
+          schedules: [
+            {
+              name: "to-delete",
+              cronExpression: "0 9 * * *",
+              prompt: "Will be deleted",
+            },
+          ],
+        },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      client().delete({
+        headers: { authorization: "Bearer clerk-session" },
+        params: { name: "to-delete" },
+        query: { agentId: fixture.composeId },
+      }),
+      [204],
+    );
+
+    expect(response.body).toBeUndefined();
+
+    const repeatResponse = await accept(
+      client().delete({
+        headers: { authorization: "Bearer clerk-session" },
+        params: { name: "to-delete" },
+        query: { agentId: fixture.composeId },
+      }),
+      [404],
+    );
+    expect(repeatResponse.body).toStrictEqual({
+      error: { message: "Resource not found", code: "NOT_FOUND" },
+    });
+  });
+
+  it("returns 404 for a non-existent schedule", async () => {
+    const fixture = await track(
+      store.set(seedSchedulesScenario$, { schedules: [] }, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      client().delete({
+        headers: { authorization: "Bearer clerk-session" },
+        params: { name: "non-existent" },
+        query: { agentId: fixture.composeId },
+      }),
+      [404],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Resource not found", code: "NOT_FOUND" },
+    });
+  });
+
+  it("deletes a schedule looked up by compose agentId", async () => {
+    const fixture = await track(
+      store.set(
+        seedSchedulesScenario$,
+        {
+          schedules: [
+            {
+              name: "del-agent-id",
+              cronExpression: "0 9 * * *",
+              prompt: "Will be deleted via agentId",
+            },
+          ],
+        },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      client().delete({
+        headers: { authorization: "Bearer clerk-session" },
+        params: { name: "del-agent-id" },
+        query: { agentId: fixture.composeId },
+      }),
+      [204],
+    );
+
+    expect(response.status).toBe(204);
+  });
+
+  it("returns 400 for an invalid query", async () => {
+    const fixture = await track(
+      store.set(seedSchedulesScenario$, { schedules: [] }, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await client().delete({
+      headers: { authorization: "Bearer clerk-session" },
+      params: { name: "any" },
+      query: { agentId: "not-a-uuid" },
+    });
+    expect(response.status).toBe(400);
+    if (response.status === 400) {
+      expect(response.body.error.code).toBe("BAD_REQUEST");
+    }
+  });
+
+  it("returns 401 for unauthenticated requests", async () => {
+    const response = await accept(
+      client().delete({
+        headers: {},
+        params: { name: "any" },
+        query: { agentId: randomUUID() },
+      }),
+      [401],
+    );
+
+    expect(response.body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("returns 403 for a zero token without schedule:delete", async () => {
+    const fixture = await track(
+      store.set(
+        seedSchedulesScenario$,
+        {
+          schedules: [
+            {
+              name: "agent-cant-delete",
+              cronExpression: "0 9 * * *",
+              prompt: "Agent should not delete this",
+            },
+          ],
+        },
+        context.signal,
+      ),
+    );
+    const token = zeroTokenWithoutScheduleDelete({
+      userId: fixture.userId,
+      orgId: fixture.orgId,
+      runId: `run_${randomUUID()}`,
+    });
+
+    const response = await accept(
+      client().delete({
+        headers: { authorization: `Bearer ${token}` },
+        params: { name: "agent-cant-delete" },
+        query: { agentId: fixture.composeId },
+      }),
+      [403],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Missing required capability: schedule:delete",
+        code: "FORBIDDEN",
+      },
+    });
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-schedules.ts
+++ b/turbo/apps/api/src/signals/routes/zero-schedules.ts
@@ -1,5 +1,6 @@
 import { command, computed } from "ccstate";
 import {
+  zeroSchedulesByNameContract,
   zeroSchedulesEnableContract,
   zeroSchedulesMainContract,
 } from "@vm0/api-contracts/contracts/zero-schedules";
@@ -7,8 +8,9 @@ import {
 import { notFound } from "../../lib/error";
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
-import { bodyResultOf, pathParamsOf } from "../context/request";
+import { bodyResultOf, pathParamsOf, queryOf } from "../context/request";
 import {
+  deleteSchedule$,
   disableSchedule$,
   enableSchedule$,
   zeroScheduleList,
@@ -21,6 +23,29 @@ const listSchedulesInner$ = computed(async (get) => {
     zeroScheduleList({ orgId: auth.orgId, userId: auth.userId }),
   );
   return { status: 200 as const, body: result };
+});
+
+const deleteInner$ = command(async ({ get, set }, signal: AbortSignal) => {
+  const auth = get(organizationAuthContext$);
+  const params = get(pathParamsOf(zeroSchedulesByNameContract.delete));
+  const query = get(queryOf(zeroSchedulesByNameContract.delete));
+
+  const result = await set(
+    deleteSchedule$,
+    {
+      userId: auth.userId,
+      orgId: auth.orgId,
+      agentId: query.agentId,
+      name: params.name,
+    },
+    signal,
+  );
+  signal.throwIfAborted();
+
+  if (result.kind === "not_found") {
+    return notFound("Resource not found");
+  }
+  return { status: 204 as const, body: undefined };
 });
 
 const disableInner$ = command(async ({ get, set }, signal: AbortSignal) => {
@@ -102,6 +127,17 @@ export const zeroSchedulesRoutes: readonly RouteEntry[] = [
         requiredCapability: "schedule:read",
       },
       listSchedulesInner$,
+    ),
+  },
+  {
+    route: zeroSchedulesByNameContract.delete,
+    handler: authRoute(
+      {
+        requireOrganization: true,
+        missingOrganizationStatus: 401,
+        requiredCapability: "schedule:delete",
+      },
+      deleteInner$,
     ),
   },
   {

--- a/turbo/apps/api/src/signals/services/zero-schedules.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-schedules.service.ts
@@ -140,6 +140,10 @@ type DisableScheduleResult =
   | { readonly kind: "ok"; readonly response: ScheduleResponse }
   | { readonly kind: "not_found" };
 
+type DeleteScheduleResult =
+  | { readonly kind: "ok" }
+  | { readonly kind: "not_found" };
+
 type EnableScheduleResult =
   | { readonly kind: "ok"; readonly response: ScheduleResponse }
   | { readonly kind: "not_found" }
@@ -189,6 +193,38 @@ export const disableSchedule$ = command(
       kind: "ok",
       response: scheduleResponse(updated, ownership.displayName),
     };
+  },
+);
+
+export const deleteSchedule$ = command(
+  async (
+    { set },
+    args: ScheduleMutationArgs,
+    signal: AbortSignal,
+  ): Promise<DeleteScheduleResult> => {
+    const db = set(writeDb$);
+    const ownership = await verifyScheduleOwnership(
+      db,
+      args.userId,
+      args.orgId,
+      args.agentId,
+      args.name,
+    );
+    signal.throwIfAborted();
+    if (!ownership.ok) {
+      return { kind: "not_found" };
+    }
+
+    const [deleted] = await db
+      .delete(zeroAgentSchedules)
+      .where(eq(zeroAgentSchedules.id, ownership.schedule.id))
+      .returning({ id: zeroAgentSchedules.id });
+    signal.throwIfAborted();
+    if (!deleted) {
+      return { kind: "not_found" };
+    }
+
+    return { kind: "ok" };
   },
 );
 

--- a/turbo/packages/api-contracts/src/contracts/zero-schedules.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-schedules.ts
@@ -130,6 +130,7 @@ export const zeroSchedulesByNameContract = c.router({
     }),
     responses: {
       204: c.noBody(),
+      400: apiErrorSchema,
       401: apiErrorSchema,
       403: apiErrorSchema,
       404: apiErrorSchema,


### PR DESCRIPTION
## Summary
- register DELETE /api/zero/schedules/:name in the API backend schedules route
- add a ccstate deleteSchedule command that reuses schedule ownership verification
- add API integration coverage for success, not found, validation, unauthenticated, and zero-token capability rejection

## Validation
- pnpm -F api exec vitest run src/signals/routes/__tests__/zero-schedules-delete.test.ts
- pnpm -F api lint
- pnpm -F api check-types
- pnpm knip --workspace api
- pnpm check-types
- git diff --check

Closes #12811