### PR TITLE
refactor(api): migrate runner post routes

### DIFF
--- a/turbo/apps/api/src/signals/auth/runner-auth.ts
+++ b/turbo/apps/api/src/signals/auth/runner-auth.ts
@@ -1,0 +1,80 @@
+import { timingSafeEqual } from "node:crypto";
+
+import { command } from "ccstate";
+
+import { env } from "../../lib/env";
+import { logger } from "../../lib/log";
+import { waitUntil } from "../context/wait-until";
+import {
+  cliTokenRecord,
+  updateCliTokenLastUsedAt$,
+} from "../services/auth.service";
+import { isPatToken, isSandboxToken, verifyCliToken } from "./tokens";
+
+const L = logger("RunnerAuth");
+
+const OFFICIAL_RUNNER_TOKEN_PREFIX = "vm0_official_";
+
+export type RunnerAuthContext =
+  | {
+      readonly type: "user";
+      readonly userId: string;
+    }
+  | { readonly type: "official-runner" };
+
+function validateOfficialRunnerSecret(providedSecret: string): boolean {
+  const expectedSecret = env("OFFICIAL_RUNNER_SECRET");
+  const provided = Buffer.from(providedSecret, "utf8");
+  const expected = Buffer.from(expectedSecret, "utf8");
+
+  if (provided.length !== expected.length) {
+    return false;
+  }
+
+  return timingSafeEqual(provided, expected);
+}
+
+export const runnerAuth$ = command(
+  async (
+    { get, set },
+    authHeader: string | undefined,
+    signal: AbortSignal,
+  ): Promise<RunnerAuthContext | null> => {
+    if (!authHeader?.startsWith("Bearer ")) {
+      return null;
+    }
+
+    const token = authHeader.slice("Bearer ".length);
+
+    if (isPatToken(token) || isSandboxToken(token)) {
+      const cliAuth = verifyCliToken(token);
+      if (!cliAuth) {
+        if (isSandboxToken(token)) {
+          L.debug("Rejected non-CLI sandbox JWT token on runner endpoint");
+        }
+        return null;
+      }
+
+      const resolved = await get(cliTokenRecord(cliAuth));
+      signal.throwIfAborted();
+      if (!resolved) {
+        return null;
+      }
+
+      waitUntil(set(updateCliTokenLastUsedAt$, cliAuth.tokenId, signal));
+      return { type: "user", userId: resolved.userId };
+    }
+
+    if (!token.startsWith(OFFICIAL_RUNNER_TOKEN_PREFIX)) {
+      return null;
+    }
+
+    const secret = token.slice(OFFICIAL_RUNNER_TOKEN_PREFIX.length);
+    if (!validateOfficialRunnerSecret(secret)) {
+      L.warn("Invalid official runner secret");
+      return null;
+    }
+
+    return { type: "official-runner" };
+  },
+);

--- a/turbo/apps/api/src/signals/auth/tokens.ts
+++ b/turbo/apps/api/src/signals/auth/tokens.ts
@@ -214,6 +214,24 @@ export function verifyCliToken(token: string): CliAuth | null {
   };
 }
 
+export function generateSandboxToken(
+  userId: string,
+  runId: string,
+  orgId: string,
+): string {
+  const nowSeconds = Math.floor(now() / 1000);
+  const payload: z.infer<typeof sandboxTokenPayloadSchema> = {
+    scope: "sandbox",
+    userId,
+    runId,
+    orgId,
+    iat: nowSeconds,
+    exp: nowSeconds + 2 * 60 * 60,
+  };
+
+  return SANDBOX_TOKEN_PREFIX + signJwt(payload);
+}
+
 export function generateCliToken(
   userId: string,
   orgId: string,

--- a/turbo/apps/api/src/signals/external/realtime.ts
+++ b/turbo/apps/api/src/signals/external/realtime.ts
@@ -44,6 +44,19 @@ export async function createPlatformUserRealtimeToken(
   return tokenRequest;
 }
 
+export async function createRunnerGroupRealtimeToken(
+  group: string,
+): Promise<Ably.TokenRequest> {
+  const tokenRequest = await ablyClient().auth.createTokenRequest({
+    capability: {
+      [`runner-group:${group}`]: ["subscribe"],
+    },
+    ttl: 60 * 60 * 1000,
+  });
+  L.debug(`Generated runner group realtime token for ${group}`);
+  return tokenRequest;
+}
+
 /**
  * Publish a per-user invalidation/notification signal.
  *
@@ -70,6 +83,18 @@ export async function publishUserSignal(
     }),
   );
   L.debug(`Published "${topic}" to ${userIds.length} user(s)`);
+}
+
+export async function publishRunChangedForUserSafely(
+  userId: string,
+  runId: string,
+  payload: unknown = null,
+): Promise<void> {
+  await publishUserSignal([userId], `run:changed:${runId}`, payload).catch(
+    (error: unknown) => {
+      L.warn("Failed to publish run changed signal", { runId, error });
+    },
+  );
 }
 
 /**

--- a/turbo/apps/api/src/signals/external/sandbox-op-log.ts
+++ b/turbo/apps/api/src/signals/external/sandbox-op-log.ts
@@ -1,0 +1,59 @@
+import { Axiom } from "@axiomhq/js";
+
+import { env } from "../../lib/env";
+import { logger } from "../../lib/log";
+import { singleton } from "../../lib/singleton";
+import { nowDate } from "../../lib/time";
+
+interface AxiomIngestClient {
+  readonly ingest: (
+    dataset: string,
+    events: readonly Record<string, unknown>[],
+  ) => Promise<unknown> | unknown;
+}
+
+interface SandboxOperationAttrs {
+  readonly sandboxType: "runner" | "docker" | "chat";
+  readonly actionType: string;
+  readonly durationMs: number;
+  readonly success: boolean;
+  readonly runId: string;
+  readonly dimensions?: Record<string, unknown>;
+}
+
+const telemetryAxiomClient = singleton((): Axiom => {
+  return new Axiom({ token: env("AXIOM_TOKEN_TELEMETRY") });
+});
+const L = logger("SandboxOpLog");
+
+function hasIngest(client: Axiom): client is Axiom & AxiomIngestClient {
+  return (
+    "ingest" in client &&
+    typeof (client as { readonly ingest: unknown }).ingest === "function"
+  );
+}
+
+export function recordSandboxOperation(attrs: SandboxOperationAttrs): void {
+  const client = telemetryAxiomClient();
+  if (!hasIngest(client)) {
+    return;
+  }
+
+  const dataset = `vm0-sandbox-op-log-${env("AXIOM_DATASET_SUFFIX")}`;
+  void Promise.resolve(
+    client.ingest(dataset, [
+      {
+        _time: nowDate().toISOString(),
+        source: "api",
+        op_type: attrs.actionType,
+        sandbox_type: attrs.sandboxType,
+        duration_ms: attrs.durationMs,
+        success: attrs.success,
+        run_id: attrs.runId,
+        ...attrs.dimensions,
+      },
+    ]),
+  ).catch((error: unknown) => {
+    L.warn("Failed to ingest sandbox operation log", { error });
+  });
+}

--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -18,6 +18,7 @@ import { healthAuthProbeRoutes } from "./routes/health-auth-probe";
 import { internalEventConsumerTelegramTypingRoutes } from "./routes/internal-event-consumers-telegram-typing";
 import { logsSearchRoutes } from "./routes/logs-search";
 import { modelStatsRoutes } from "./routes/model-stats";
+import { runnersRoutes } from "./routes/runners";
 import { usageRoutes } from "./routes/usage";
 import { userExportRoutes } from "./routes/user-export";
 import { zeroAgentInstructionsRoutes } from "./routes/zero-agent-instructions";
@@ -209,6 +210,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...chatThreadsV1Routes,
   ...audioTranscriptionsV1Routes,
   ...modelStatsRoutes,
+  ...runnersRoutes,
   ...testOAuthProviderAuthorizeRoutes,
   ...testOAuthProviderEchoRoutes,
   ...testOAuthProviderUserinfoRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/runners.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/runners.test.ts
@@ -1,0 +1,412 @@
+import { randomUUID } from "node:crypto";
+
+import {
+  runnersHeartbeatContract,
+  runnersJobClaimContract,
+  runnersPollContract,
+} from "@vm0/api-contracts/contracts/runners";
+import { runnerRealtimeTokenContract } from "@vm0/api-contracts/contracts/realtime";
+import { agentRuns } from "@vm0/db/schema/agent-run";
+import { cliTokens } from "@vm0/db/schema/cli-tokens";
+import { runnerJobQueue } from "@vm0/db/schema/runner-job-queue";
+import { runnerState } from "@vm0/db/schema/runner-state";
+import { createStore } from "ccstate";
+import { eq, inArray } from "drizzle-orm";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { signPatJwtForTests } from "../../auth/tokens";
+import { writeDb$ } from "../../external/db";
+import { now } from "../../external/time";
+import { encryptSecretValue } from "../../services/crypto.utils";
+import { createFixtureTracker } from "./helpers/zero-route-test";
+import {
+  deleteUsageInsightFixture$,
+  seedCompose$,
+  seedRun$,
+  seedUsageInsightFixture$,
+  type UsageInsightFixture,
+} from "./helpers/zero-usage-insight";
+
+const context = testContext();
+const store = createStore();
+
+const OFFICIAL_RUNNER_TOKEN =
+  "Bearer vm0_official_abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789";
+
+interface PatFixture {
+  readonly token: string;
+  readonly tokenId: string;
+  readonly userId: string;
+  readonly orgId: string;
+}
+
+function currentSecond(): number {
+  return Math.floor(now() / 1000);
+}
+
+function runnerHeartbeatBody(runnerId: string) {
+  return {
+    runnerId,
+    runnerName: "test-runner",
+    group: "vm0/test",
+    profiles: ["vm0/default"],
+    totalVcpu: 8,
+    totalMemoryMb: 16_384,
+    maxConcurrent: 4,
+    allocatedVcpu: 2,
+    allocatedMemoryMb: 4096,
+    runningCount: 1,
+    heldSessions: ["session-1"],
+    mode: "running" as const,
+  };
+}
+
+function storedExecutionContext(secretValue: string) {
+  return {
+    workingDir: "/workspace",
+    storageManifest: null,
+    environment: {
+      API_KEY: secretValue,
+      OTHER_VALUE: "not-a-secret",
+    },
+    resumeSession: null,
+    encryptedSecrets: encryptSecretValue(
+      JSON.stringify({
+        API_KEY: secretValue,
+        UNUSED_SECRET: "hidden",
+      }),
+    ),
+    cliAgentType: "claude-code",
+    apiStartTime: now() - 1000,
+  };
+}
+
+async function seedPatFixture(args: {
+  readonly userId: string;
+  readonly orgId: string;
+}): Promise<PatFixture> {
+  const tokenId = randomUUID();
+  const seconds = currentSecond();
+  const token = signPatJwtForTests({
+    scope: "cli",
+    userId: args.userId,
+    orgId: args.orgId,
+    tokenId,
+    iat: seconds,
+    exp: seconds + 60,
+  });
+  const db = store.set(writeDb$);
+  await db.insert(cliTokens).values({
+    id: tokenId,
+    token,
+    userId: args.userId,
+    name: "runner token",
+    expiresAt: new Date(now() + 60_000),
+  });
+
+  return { token, tokenId, userId: args.userId, orgId: args.orgId };
+}
+
+async function seedQueuedRun(args: {
+  readonly fixture: UsageInsightFixture;
+  readonly runnerGroup?: string;
+  readonly profile?: string;
+  readonly sessionId?: string | null;
+  readonly secretValue?: string;
+}): Promise<{ readonly runId: string; readonly composeVersionId: string }> {
+  const { composeId } = await store.set(
+    seedCompose$,
+    { orgId: args.fixture.orgId, userId: args.fixture.userId },
+    context.signal,
+  );
+  const { runId } = await store.set(
+    seedRun$,
+    {
+      orgId: args.fixture.orgId,
+      userId: args.fixture.userId,
+      composeId,
+      status: "pending",
+      prompt: "queued prompt",
+    },
+    context.signal,
+  );
+  const db = store.set(writeDb$);
+  const [run] = await db
+    .select({ agentComposeVersionId: agentRuns.agentComposeVersionId })
+    .from(agentRuns)
+    .where(eq(agentRuns.id, runId))
+    .limit(1);
+  await db.insert(runnerJobQueue).values({
+    runId,
+    runnerGroup: args.runnerGroup ?? "vm0/test",
+    profile: args.profile ?? "vm0/default",
+    sessionId: args.sessionId ?? null,
+    executionContext: storedExecutionContext(
+      args.secretValue ?? "super-secret",
+    ),
+    expiresAt: new Date(now() + 60_000),
+  });
+
+  return { runId, composeVersionId: run?.agentComposeVersionId ?? "" };
+}
+
+describe("POST /api/runners/*", () => {
+  const trackUsageFixture = createFixtureTracker<UsageInsightFixture>(
+    (fixture) => {
+      return store.set(deleteUsageInsightFixture$, fixture, context.signal);
+    },
+  );
+  const patFixtures: PatFixture[] = [];
+  const runnerStateIds: string[] = [];
+
+  afterEach(async () => {
+    const db = store.set(writeDb$);
+    while (patFixtures.length > 0) {
+      const fixture = patFixtures.pop();
+      if (fixture) {
+        await db.delete(cliTokens).where(eq(cliTokens.id, fixture.tokenId));
+      }
+    }
+    if (runnerStateIds.length > 0) {
+      await db
+        .delete(runnerState)
+        .where(inArray(runnerState.runnerId, [...runnerStateIds]));
+      runnerStateIds.length = 0;
+    }
+  });
+
+  it("rejects unauthenticated heartbeat requests", async () => {
+    const client = setupApp({ context })(runnersHeartbeatContract);
+    const response = await accept(
+      client.heartbeat({
+        body: runnerHeartbeatBody(randomUUID()),
+        headers: {},
+      }),
+      [401],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("records runner heartbeat and removes stale runner state", async () => {
+    const staleRunnerId = randomUUID();
+    const activeRunnerId = randomUUID();
+    runnerStateIds.push(staleRunnerId, activeRunnerId);
+    const db = store.set(writeDb$);
+    await db.insert(runnerState).values({
+      runnerId: staleRunnerId,
+      runnerName: "stale-runner",
+      runnerGroup: "vm0/test",
+      profiles: ["vm0/default"],
+      totalVcpu: 1,
+      totalMemoryMb: 512,
+      maxConcurrent: 1,
+      allocatedVcpu: 0,
+      allocatedMemoryMb: 0,
+      runningCount: 0,
+      heldSessions: [],
+      mode: "running",
+      lastSeenAt: new Date(now() - 6 * 60 * 1000),
+    });
+
+    const client = setupApp({ context })(runnersHeartbeatContract);
+    const response = await accept(
+      client.heartbeat({
+        body: runnerHeartbeatBody(activeRunnerId),
+        headers: { authorization: OFFICIAL_RUNNER_TOKEN },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({ ok: true });
+    const rows = await db
+      .select({
+        runnerId: runnerState.runnerId,
+        runnerName: runnerState.runnerName,
+        runningCount: runnerState.runningCount,
+      })
+      .from(runnerState)
+      .where(inArray(runnerState.runnerId, [staleRunnerId, activeRunnerId]));
+    expect(rows).toStrictEqual([
+      {
+        runnerId: activeRunnerId,
+        runnerName: "test-runner",
+        runningCount: 1,
+      },
+    ]);
+  });
+
+  it("returns a pending job for a runner poll", async () => {
+    const fixture = await trackUsageFixture(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    const pat = await seedPatFixture({
+      userId: fixture.userId,
+      orgId: fixture.orgId,
+    });
+    patFixtures.push(pat);
+    const queued = await seedQueuedRun({ fixture, sessionId: "session-a" });
+
+    const client = setupApp({ context })(runnersPollContract);
+    const response = await accept(
+      client.poll({
+        body: {
+          group: "vm0/test",
+          profiles: ["vm0/default"],
+          heldSessions: ["session-a"],
+        },
+        headers: { authorization: `Bearer ${pat.token}` },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      job: {
+        runId: queued.runId,
+        prompt: "queued prompt",
+        appendSystemPrompt: null,
+        agentComposeVersionId: queued.composeVersionId,
+        vars: null,
+        checkpointId: null,
+        experimentalProfile: "vm0/default",
+      },
+    });
+  });
+
+  it("claims a queued job and returns prepared execution context", async () => {
+    const fixture = await trackUsageFixture(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    const pat = await seedPatFixture({
+      userId: fixture.userId,
+      orgId: fixture.orgId,
+    });
+    patFixtures.push(pat);
+    const queued = await seedQueuedRun({
+      fixture,
+      secretValue: "runner-visible-secret",
+    });
+
+    const client = setupApp({ context })(runnersJobClaimContract);
+    const response = await accept(
+      client.claim({
+        params: { id: queued.runId },
+        body: {},
+        headers: { authorization: `Bearer ${pat.token}` },
+      }),
+      [200],
+    );
+
+    expect(response.body).toMatchObject({
+      runId: queued.runId,
+      prompt: "queued prompt",
+      workingDir: "/workspace",
+      cliAgentType: "claude-code",
+      environment: {
+        API_KEY: "runner-visible-secret",
+        OTHER_VALUE: "not-a-secret",
+      },
+      secretValues: ["runner-visible-secret"],
+    });
+    expect(response.body.sandboxToken).toMatch(/^vm0_sandbox_/);
+
+    const db = store.set(writeDb$);
+    const [run] = await db
+      .select({
+        status: agentRuns.status,
+        startedAt: agentRuns.startedAt,
+        lastHeartbeatAt: agentRuns.lastHeartbeatAt,
+      })
+      .from(agentRuns)
+      .where(eq(agentRuns.id, queued.runId));
+    expect(run?.status).toBe("running");
+    expect(run?.startedAt).toBeInstanceOf(Date);
+    expect(run?.lastHeartbeatAt).toBeInstanceOf(Date);
+
+    const remainingJobs = await db
+      .select({ runId: runnerJobQueue.runId })
+      .from(runnerJobQueue)
+      .where(eq(runnerJobQueue.runId, queued.runId));
+    expect(remainingJobs).toHaveLength(0);
+    expect(context.mocks.ably.publish).toHaveBeenCalledWith(
+      `run:changed:${queued.runId}`,
+      { status: "running" },
+    );
+  });
+
+  it("prevents a user runner from claiming another user's job", async () => {
+    const fixture = await trackUsageFixture(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    const queued = await seedQueuedRun({ fixture });
+    const pat = await seedPatFixture({
+      userId: `user_${randomUUID()}`,
+      orgId: `org_${randomUUID()}`,
+    });
+    patFixtures.push(pat);
+
+    const client = setupApp({ context })(runnersJobClaimContract);
+    const response = await accept(
+      client.claim({
+        params: { id: queued.runId },
+        body: {},
+        headers: { authorization: `Bearer ${pat.token}` },
+      }),
+      [403],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Job does not belong to user", code: "FORBIDDEN" },
+    });
+  });
+
+  it("generates a subscribe-only realtime token for a runner group", async () => {
+    const tokenRequest = {
+      keyName: "test-key",
+      timestamp: 1_700_000_000_000,
+      capability: '{"runner-group:vm0/test":["subscribe"]}',
+      nonce: "test-nonce",
+      mac: "test-mac",
+    };
+    context.mocks.ably.createTokenRequest.mockResolvedValue(tokenRequest);
+
+    const client = setupApp({ context })(runnerRealtimeTokenContract);
+    const response = await accept(
+      client.create({
+        body: { group: "vm0/test" },
+        headers: { authorization: OFFICIAL_RUNNER_TOKEN },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual(tokenRequest);
+    expect(context.mocks.ably.createTokenRequest).toHaveBeenCalledWith({
+      capability: {
+        "runner-group:vm0/test": ["subscribe"],
+      },
+      ttl: 3_600_000,
+    });
+  });
+
+  it("rejects realtime token requests for non-vm0 runner groups", async () => {
+    const client = setupApp({ context })(runnerRealtimeTokenContract);
+    const response = await accept(
+      client.create({
+        body: { group: "other/test" },
+        headers: { authorization: OFFICIAL_RUNNER_TOKEN },
+      }),
+      [403],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Official runners can only subscribe to vm0/* groups",
+        code: "FORBIDDEN",
+      },
+    });
+    expect(context.mocks.ably.createTokenRequest).not.toHaveBeenCalled();
+  });
+});

--- a/turbo/apps/api/src/signals/routes/runners.ts
+++ b/turbo/apps/api/src/signals/routes/runners.ts
@@ -1,0 +1,499 @@
+import { command } from "ccstate";
+import {
+  runnersHeartbeatContract,
+  runnersJobClaimContract,
+  runnersPollContract,
+  storedExecutionContextSchema,
+  type StoredExecutionContext,
+} from "@vm0/api-contracts/contracts/runners";
+import { runnerRealtimeTokenContract } from "@vm0/api-contracts/contracts/realtime";
+import { agentRuns } from "@vm0/db/schema/agent-run";
+import { runnerJobQueue } from "@vm0/db/schema/runner-job-queue";
+import { runnerState } from "@vm0/db/schema/runner-state";
+import { and, eq, inArray, isNull, lt, sql, type SQL } from "drizzle-orm";
+
+import { runnerAuth$, type RunnerAuthContext } from "../auth/runner-auth";
+import { authorization$ } from "../context/hono";
+import { bodyResultOf, pathParamsOf } from "../context/request";
+import { writeDb$, type Db } from "../external/db";
+import {
+  createRunnerGroupRealtimeToken,
+  publishRunChangedForUserSafely,
+} from "../external/realtime";
+import { recordSandboxOperation } from "../external/sandbox-op-log";
+import { now, nowDate } from "../external/time";
+import { badRequestMessage, conflict, notFound } from "../../lib/error";
+import { logger } from "../../lib/log";
+import { generateSandboxToken } from "../auth/tokens";
+import { decryptSecretsMap } from "../services/crypto.utils";
+import type { RouteEntry } from "../route";
+
+const L = logger("Runners");
+
+const STALE_RUNNER_THRESHOLD_MS = 5 * 60 * 1000;
+
+const unauthorizedNotAuthenticated = Object.freeze({
+  status: 401 as const,
+  body: Object.freeze({
+    error: Object.freeze({
+      message: "Not authenticated",
+      code: "UNAUTHORIZED",
+    }),
+  }),
+});
+
+const unauthorizedAuthenticationRequired = Object.freeze({
+  status: 401 as const,
+  body: Object.freeze({
+    error: Object.freeze({
+      message: "Authentication required",
+      code: "UNAUTHORIZED",
+    }),
+  }),
+});
+
+function forbidden(message: string) {
+  return {
+    status: 403 as const,
+    body: {
+      error: { message, code: "FORBIDDEN" },
+    },
+  };
+}
+
+function isOfficialRunnerGroup(group: string): boolean {
+  return group.split("/")[0] === "vm0";
+}
+
+const heartbeatBody$ = bodyResultOf(runnersHeartbeatContract.heartbeat);
+
+const heartbeatInner$ = command(async ({ get, set }, signal: AbortSignal) => {
+  const auth = await set(runnerAuth$, get(authorization$), signal);
+  signal.throwIfAborted();
+  if (!auth) {
+    return unauthorizedNotAuthenticated;
+  }
+
+  const body = await get(heartbeatBody$);
+  signal.throwIfAborted();
+  if (!body.ok) {
+    return body.response;
+  }
+
+  if (!isOfficialRunnerGroup(body.data.group)) {
+    return badRequestMessage("Invalid runner group");
+  }
+
+  const currentDate = nowDate();
+  const db = set(writeDb$);
+  await db
+    .insert(runnerState)
+    .values({
+      runnerId: body.data.runnerId,
+      runnerName: body.data.runnerName,
+      runnerGroup: body.data.group,
+      profiles: body.data.profiles,
+      totalVcpu: body.data.totalVcpu,
+      totalMemoryMb: body.data.totalMemoryMb,
+      maxConcurrent: body.data.maxConcurrent,
+      allocatedVcpu: body.data.allocatedVcpu,
+      allocatedMemoryMb: body.data.allocatedMemoryMb,
+      runningCount: body.data.runningCount,
+      heldSessions: body.data.heldSessions,
+      mode: body.data.mode,
+      lastSeenAt: currentDate,
+    })
+    .onConflictDoUpdate({
+      target: runnerState.runnerId,
+      set: {
+        runnerName: body.data.runnerName,
+        runnerGroup: body.data.group,
+        profiles: body.data.profiles,
+        totalVcpu: body.data.totalVcpu,
+        totalMemoryMb: body.data.totalMemoryMb,
+        maxConcurrent: body.data.maxConcurrent,
+        allocatedVcpu: body.data.allocatedVcpu,
+        allocatedMemoryMb: body.data.allocatedMemoryMb,
+        runningCount: body.data.runningCount,
+        heldSessions: body.data.heldSessions,
+        mode: body.data.mode,
+        lastSeenAt: currentDate,
+      },
+    });
+  signal.throwIfAborted();
+
+  await db
+    .delete(runnerState)
+    .where(
+      lt(
+        runnerState.lastSeenAt,
+        new Date(currentDate.getTime() - STALE_RUNNER_THRESHOLD_MS),
+      ),
+    );
+  signal.throwIfAborted();
+
+  return { status: 200 as const, body: { ok: true as const } };
+});
+
+const pollBody$ = bodyResultOf(runnersPollContract.poll);
+
+const pollInner$ = command(async ({ get, set }, signal: AbortSignal) => {
+  const auth = await set(runnerAuth$, get(authorization$), signal);
+  signal.throwIfAborted();
+  if (!auth) {
+    return unauthorizedAuthenticationRequired;
+  }
+
+  const body = await get(pollBody$);
+  signal.throwIfAborted();
+  if (!body.ok) {
+    return body.response;
+  }
+
+  const { group, profiles, heldSessions } = body.data;
+  const whereConditions: SQL<unknown>[] = [
+    eq(runnerJobQueue.runnerGroup, group),
+    isNull(runnerJobQueue.claimedAt),
+  ];
+
+  if (auth.type === "official-runner") {
+    if (!isOfficialRunnerGroup(group)) {
+      return forbidden("Official runners can only poll vm0/* groups");
+    }
+  } else {
+    if (!isOfficialRunnerGroup(group)) {
+      return forbidden("Only vm0/* runner groups are supported");
+    }
+    whereConditions.push(eq(agentRuns.userId, auth.userId));
+  }
+
+  if (profiles && profiles.length > 0) {
+    whereConditions.push(inArray(runnerJobQueue.profile, profiles));
+  }
+
+  const orderClauses =
+    heldSessions && heldSessions.length > 0
+      ? [
+          sql`CASE WHEN ${runnerJobQueue.sessionId} IN (${sql.join(
+            heldSessions.map((session) => {
+              return sql`${session}`;
+            }),
+            sql`, `,
+          )}) THEN 0 ELSE 1 END`,
+          runnerJobQueue.createdAt,
+        ]
+      : [runnerJobQueue.createdAt];
+
+  const db = set(writeDb$);
+  const [pendingJob] = await db
+    .select({
+      runId: runnerJobQueue.runId,
+      prompt: agentRuns.prompt,
+      appendSystemPrompt: agentRuns.appendSystemPrompt,
+      agentComposeVersionId: agentRuns.agentComposeVersionId,
+      vars: agentRuns.vars,
+      resumedFromCheckpointId: agentRuns.resumedFromCheckpointId,
+      profile: runnerJobQueue.profile,
+    })
+    .from(runnerJobQueue)
+    .innerJoin(agentRuns, eq(runnerJobQueue.runId, agentRuns.id))
+    .where(and(...whereConditions))
+    .orderBy(...orderClauses)
+    .limit(1);
+  signal.throwIfAborted();
+
+  if (!pendingJob) {
+    return { status: 200 as const, body: { job: null } };
+  }
+
+  return {
+    status: 200 as const,
+    body: {
+      job: {
+        runId: pendingJob.runId,
+        prompt: pendingJob.prompt,
+        appendSystemPrompt: pendingJob.appendSystemPrompt,
+        agentComposeVersionId: pendingJob.agentComposeVersionId,
+        vars: (pendingJob.vars as Record<string, string>) ?? null,
+        checkpointId: pendingJob.resumedFromCheckpointId ?? null,
+        experimentalProfile: pendingJob.profile,
+      },
+    },
+  };
+});
+
+const claimBody$ = bodyResultOf(runnersJobClaimContract.claim);
+
+interface ClaimableJob {
+  readonly job: typeof runnerJobQueue.$inferSelect;
+  readonly runUserId: string;
+}
+
+interface ClaimedRun {
+  readonly id: string;
+  readonly userId: string;
+  readonly orgId: string;
+  readonly prompt: string;
+  readonly appendSystemPrompt: string | null;
+  readonly agentComposeVersionId: string | null;
+  readonly vars: unknown;
+  readonly resumedFromCheckpointId: string | null;
+}
+
+type ClaimLookupResult =
+  | ClaimableJob
+  | ReturnType<typeof conflict>
+  | ReturnType<typeof notFound>;
+
+function isClaimableJob(value: ClaimLookupResult): value is ClaimableJob {
+  return "job" in value;
+}
+
+async function getClaimableJob(
+  db: Db,
+  runId: string,
+  signal: AbortSignal,
+): Promise<ClaimLookupResult> {
+  const [jobWithRun] = await db
+    .select({
+      job: runnerJobQueue,
+      runUserId: agentRuns.userId,
+    })
+    .from(runnerJobQueue)
+    .innerJoin(agentRuns, eq(runnerJobQueue.runId, agentRuns.id))
+    .where(
+      and(eq(runnerJobQueue.runId, runId), isNull(runnerJobQueue.claimedAt)),
+    )
+    .limit(1);
+  signal.throwIfAborted();
+
+  if (jobWithRun) {
+    return jobWithRun;
+  }
+
+  const [existingJob] = await db
+    .select({ runId: runnerJobQueue.runId })
+    .from(runnerJobQueue)
+    .where(eq(runnerJobQueue.runId, runId))
+    .limit(1);
+  signal.throwIfAborted();
+
+  return existingJob
+    ? conflict("Job already claimed")
+    : notFound("Job not found in queue");
+}
+
+function claimAuthorizationError(
+  auth: RunnerAuthContext,
+  jobWithRun: ClaimableJob,
+) {
+  if (auth.type === "official-runner") {
+    return isOfficialRunnerGroup(jobWithRun.job.runnerGroup)
+      ? null
+      : forbidden("Official runners can only claim jobs from vm0/* groups");
+  }
+
+  if (jobWithRun.runUserId !== auth.userId) {
+    return forbidden("Job does not belong to user");
+  }
+  return isOfficialRunnerGroup(jobWithRun.job.runnerGroup)
+    ? null
+    : forbidden("Only vm0/* runner groups are supported");
+}
+
+async function markJobClaimed(
+  db: Db,
+  runId: string,
+  claimedAt: Date,
+  signal: AbortSignal,
+) {
+  const [claimedJob] = await db
+    .update(runnerJobQueue)
+    .set({ claimedAt })
+    .where(
+      and(eq(runnerJobQueue.runId, runId), isNull(runnerJobQueue.claimedAt)),
+    )
+    .returning();
+  signal.throwIfAborted();
+  return claimedJob ?? null;
+}
+
+async function markRunRunning(
+  db: Db,
+  runId: string,
+  claimedAt: Date,
+  signal: AbortSignal,
+): Promise<ClaimedRun | null> {
+  const [run] = await db
+    .update(agentRuns)
+    .set({
+      status: "running",
+      startedAt: claimedAt,
+      lastHeartbeatAt: claimedAt,
+    })
+    .where(and(eq(agentRuns.id, runId), eq(agentRuns.status, "pending")))
+    .returning({
+      id: agentRuns.id,
+      userId: agentRuns.userId,
+      orgId: agentRuns.orgId,
+      prompt: agentRuns.prompt,
+      appendSystemPrompt: agentRuns.appendSystemPrompt,
+      agentComposeVersionId: agentRuns.agentComposeVersionId,
+      vars: agentRuns.vars,
+      resumedFromCheckpointId: agentRuns.resumedFromCheckpointId,
+    });
+  signal.throwIfAborted();
+  return run ?? null;
+}
+
+function secretValuesForRunner(
+  storedContext: StoredExecutionContext,
+): string[] | null {
+  const secretsMap = decryptSecretsMap(storedContext.encryptedSecrets);
+  if (!secretsMap) {
+    return null;
+  }
+
+  const envValues = storedContext.environment
+    ? new Set(Object.values(storedContext.environment))
+    : new Set<string>();
+  return Object.values(secretsMap).filter((value) => {
+    return envValues.has(value);
+  });
+}
+
+const claimInner$ = command(async ({ get, set }, signal: AbortSignal) => {
+  const auth = await set(runnerAuth$, get(authorization$), signal);
+  signal.throwIfAborted();
+  if (!auth) {
+    return unauthorizedNotAuthenticated;
+  }
+
+  const body = await get(claimBody$);
+  signal.throwIfAborted();
+  if (!body.ok) {
+    return body.response;
+  }
+
+  const params = get(pathParamsOf(runnersJobClaimContract.claim));
+  const runId = params.id;
+  const db = set(writeDb$);
+
+  const jobWithRun = await getClaimableJob(db, runId, signal);
+  if (!isClaimableJob(jobWithRun)) {
+    return jobWithRun;
+  }
+  const authError = claimAuthorizationError(auth, jobWithRun);
+  if (authError) {
+    return authError;
+  }
+
+  const currentTime = now();
+  const claimedAt = new Date(currentTime);
+  const claimedJob = await markJobClaimed(db, runId, claimedAt, signal);
+  if (!claimedJob) {
+    return conflict("Job was claimed by another runner");
+  }
+
+  const run = await markRunRunning(db, runId, claimedAt, signal);
+  if (!run) {
+    return notFound("Run not found");
+  }
+
+  await publishRunChangedForUserSafely(run.userId, runId, {
+    status: "running",
+  });
+  signal.throwIfAborted();
+
+  const storedContextResult = storedExecutionContextSchema.safeParse(
+    claimedJob.executionContext,
+  );
+  if (!storedContextResult.success) {
+    L.warn("Runner job missing valid execution context", { runId });
+    return badRequestMessage("Job missing execution context");
+  }
+  const storedContext = storedContextResult.data;
+
+  const sandboxToken = generateSandboxToken(run.userId, run.id, run.orgId);
+
+  if (storedContext.apiStartTime) {
+    recordSandboxOperation({
+      sandboxType: "runner",
+      actionType: "api_to_claim",
+      durationMs: currentTime - storedContext.apiStartTime,
+      success: true,
+      runId,
+    });
+  }
+
+  await db.delete(runnerJobQueue).where(eq(runnerJobQueue.runId, runId));
+  signal.throwIfAborted();
+
+  return {
+    status: 200 as const,
+    body: {
+      ...storedContext,
+      runId: run.id,
+      prompt: run.prompt,
+      appendSystemPrompt: run.appendSystemPrompt,
+      agentComposeVersionId: run.agentComposeVersionId,
+      vars: (run.vars as Record<string, string>) ?? null,
+      checkpointId: run.resumedFromCheckpointId ?? null,
+      sandboxToken,
+      secretValues: secretValuesForRunner(storedContext),
+    },
+  };
+});
+
+const runnerRealtimeTokenBody$ = bodyResultOf(
+  runnerRealtimeTokenContract.create,
+);
+
+const runnerRealtimeTokenInner$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const auth = await set(runnerAuth$, get(authorization$), signal);
+    signal.throwIfAborted();
+    if (!auth) {
+      return unauthorizedAuthenticationRequired;
+    }
+
+    const body = await get(runnerRealtimeTokenBody$);
+    signal.throwIfAborted();
+    if (!body.ok) {
+      return body.response;
+    }
+
+    const { group } = body.data;
+    if (auth.type === "official-runner") {
+      if (!isOfficialRunnerGroup(group)) {
+        return forbidden("Official runners can only subscribe to vm0/* groups");
+      }
+    } else if (!isOfficialRunnerGroup(group)) {
+      return forbidden("Only vm0/* runner groups are supported");
+    }
+
+    const tokenRequest = await createRunnerGroupRealtimeToken(group);
+    signal.throwIfAborted();
+
+    return { status: 200 as const, body: tokenRequest };
+  },
+);
+
+export const runnersRoutes: readonly RouteEntry[] = [
+  {
+    route: runnersHeartbeatContract.heartbeat,
+    handler: heartbeatInner$,
+  },
+  {
+    route: runnersPollContract.poll,
+    handler: pollInner$,
+  },
+  {
+    route: runnersJobClaimContract.claim,
+    handler: claimInner$,
+  },
+  {
+    route: runnerRealtimeTokenContract.create,
+    handler: runnerRealtimeTokenInner$,
+  },
+];

--- a/turbo/apps/api/src/signals/services/crypto.utils.ts
+++ b/turbo/apps/api/src/signals/services/crypto.utils.ts
@@ -1,6 +1,10 @@
 import { createCipheriv, createDecipheriv, randomBytes } from "node:crypto";
 
+import { z } from "zod";
+
 import { env } from "../../lib/env";
+
+const secretsMapSchema = z.record(z.string(), z.string());
 
 /**
  * Encrypt a single secret value using AES-256-GCM.
@@ -47,4 +51,16 @@ export function decryptSecretValue(encrypted: string): string {
   ]);
 
   return decrypted.toString("utf8");
+}
+
+export function decryptSecretsMap(
+  encryptedData: string | null,
+): Record<string, string> | null {
+  if (!encryptedData) {
+    return null;
+  }
+
+  return secretsMapSchema.parse(
+    JSON.parse(decryptSecretValue(encryptedData)) as unknown,
+  );
 }

--- a/turbo/packages/api-contracts/src/contracts/realtime.ts
+++ b/turbo/packages/api-contracts/src/contracts/realtime.ts
@@ -35,6 +35,7 @@ export const runnerRealtimeTokenContract = c.router({
     }),
     responses: {
       200: ablyTokenRequestSchema,
+      400: apiErrorSchema,
       401: apiErrorSchema,
       403: apiErrorSchema,
       500: apiErrorSchema,


### PR DESCRIPTION
## Summary

- Add API-native runner auth, sandbox token minting, runner realtime token creation, and sandbox op logging support.
- Register API handlers for runner heartbeat, poll, job claim, and runner realtime token routes.
- Add focused API integration coverage for heartbeat state, poll response, claim side effects/execution context, and realtime token generation.

Closes #12854

## Validation

- `pnpm -F api exec vitest src/signals/routes/__tests__/runners.test.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm check-types`