### PR TITLE
refactor(api): migrate storage write routes

### DIFF
--- a/turbo/apps/api/src/__tests__/mocks.ts
+++ b/turbo/apps/api/src/__tests__/mocks.ts
@@ -274,6 +274,14 @@ vi.mock("@aws-sdk/client-s3", () => {
     }
   }
 
+  class HeadObjectCommand {
+    readonly input: unknown;
+
+    constructor(input: unknown) {
+      this.input = input;
+    }
+  }
+
   class ListObjectsV2Command {
     readonly input: unknown;
 
@@ -311,6 +319,7 @@ vi.mock("@aws-sdk/client-s3", () => {
   return {
     DeleteObjectsCommand,
     GetObjectCommand,
+    HeadObjectCommand,
     ListObjectsV2Command,
     PutObjectCommand,
     S3Client,

--- a/turbo/apps/api/src/signals/external/s3.ts
+++ b/turbo/apps/api/src/signals/external/s3.ts
@@ -2,6 +2,7 @@ import { computed, type Computed } from "ccstate";
 import {
   DeleteObjectsCommand,
   GetObjectCommand,
+  HeadObjectCommand,
   ListObjectsV2Command,
   PutObjectCommand,
   S3Client,
@@ -9,6 +10,7 @@ import {
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 
 import { env } from "../../lib/env";
+import { safeAsync } from "../utils";
 
 interface S3Object {
   readonly key: string;
@@ -216,5 +218,51 @@ export function downloadManifest(
       downloadS3Buffer(bucket, `${s3Key}/manifest.json`),
     );
     return JSON.parse(manifestBuffer.toString("utf8")) as S3StorageManifest;
+  });
+}
+
+export function s3ObjectExists(
+  bucket: string,
+  key: string,
+): Computed<Promise<boolean>> {
+  return computed(async (get): Promise<boolean> => {
+    const client = get(s3Client$);
+    const result = await safeAsync(async () => {
+      await client.send(new HeadObjectCommand({ Bucket: bucket, Key: key }));
+    });
+    if ("ok" in result) {
+      return true;
+    }
+
+    const candidate = result.error as {
+      readonly name?: string;
+      readonly $metadata?: { readonly httpStatusCode?: number };
+    };
+    if (
+      candidate.name === "NotFound" ||
+      candidate.$metadata?.httpStatusCode === 404
+    ) {
+      return false;
+    }
+    throw result.error;
+  });
+}
+
+export function verifyS3FilesExist(
+  bucket: string,
+  s3Key: string,
+  fileCount: number,
+): Computed<Promise<boolean>> {
+  return computed(async (get): Promise<boolean> => {
+    const manifestKey = `${s3Key}/manifest.json`;
+    const archiveKey = `${s3Key}/archive.tar.gz`;
+    const [manifestExists, archiveExists] = await Promise.all([
+      get(s3ObjectExists(bucket, manifestKey)),
+      fileCount > 0
+        ? get(s3ObjectExists(bucket, archiveKey))
+        : Promise.resolve(true),
+    ]);
+
+    return manifestExists && archiveExists;
   });
 }

--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -97,8 +97,10 @@ import { zeroVoiceIoSpeechRoutes } from "./routes/zero-voice-io-speech";
 import { zeroVoiceIoSttRoutes } from "./routes/zero-voice-io-stt";
 import { zeroVoiceIoTtsRoutes } from "./routes/zero-voice-io-tts";
 import { zeroWebDownloadRoutes } from "./routes/zero-web-download";
+import { storagesCommitRoutes } from "./routes/storages-commit";
 import { storagesDownloadRoutes } from "./routes/storages-download";
 import { storagesListRoutes } from "./routes/storages-list";
+import { storagesPrepareRoutes } from "./routes/storages-prepare";
 import { testOAuthProviderAuthorizeRoutes } from "./routes/test-oauth-provider-authorize";
 import { testOAuthProviderEchoRoutes } from "./routes/test-oauth-provider-echo";
 import { testOAuthProviderUserinfoRoutes } from "./routes/test-oauth-provider-userinfo";
@@ -205,8 +207,10 @@ export const ROUTES: readonly RouteEntry[] = [
   ...zeroTeamRoutes,
   ...zeroUploadsCompleteRoutes,
   ...zeroUploadsPrepareRoutes,
+  ...storagesCommitRoutes,
   ...storagesDownloadRoutes,
   ...storagesListRoutes,
+  ...storagesPrepareRoutes,
   ...zeroUsageInsightRoutes,
   ...zeroUsageMembersRoutes,
   ...zeroUsageRunsRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/storages-write.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/storages-write.test.ts
@@ -1,0 +1,593 @@
+import { randomUUID } from "node:crypto";
+
+import {
+  MAX_FILE_SIZE_BYTES,
+  storagesCommitContract,
+  storagesPrepareContract,
+} from "@vm0/api-contracts/contracts/storages";
+import { storages, storageVersions } from "@vm0/db/schema/storage";
+import { createStore } from "ccstate";
+import { and, eq, inArray } from "drizzle-orm";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { mockEnv } from "../../../lib/env";
+import { now } from "../../../lib/time";
+import { signSandboxJwtForTests } from "../../auth/tokens";
+import { writeDb$ } from "../../external/db";
+import {
+  createFixtureTracker,
+  createZeroRouteMocks,
+} from "./helpers/zero-route-test";
+import {
+  deleteUsageInsightFixture$,
+  seedCompose$,
+  seedRun$,
+  seedUsageInsightFixture$,
+  type UsageInsightFixture,
+} from "./helpers/zero-usage-insight";
+
+const BUCKET = "test-user-storages";
+const TEST_HASH = "a".repeat(64);
+const SECOND_TEST_HASH = "b".repeat(64);
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+
+type StorageType = "volume" | "artifact";
+
+interface StorageFile {
+  readonly path: string;
+  readonly hash: string;
+  readonly size: number;
+}
+
+interface StorageOrgFixture {
+  readonly orgId: string;
+}
+
+interface AuthFixture extends StorageOrgFixture {
+  readonly userId: string;
+}
+
+interface PrepareBody {
+  readonly storageName: string;
+  readonly storageType: StorageType;
+  readonly files: StorageFile[];
+  readonly force?: boolean;
+  readonly runId?: string;
+  readonly baseVersion?: string;
+  readonly changes?: {
+    readonly added: string[];
+    readonly modified: string[];
+    readonly deleted: string[];
+  };
+}
+
+interface CommitBody {
+  readonly storageName: string;
+  readonly storageType: StorageType;
+  readonly versionId: string;
+  readonly files: StorageFile[];
+  readonly runId?: string;
+  readonly message?: string;
+}
+
+function authHeaders(): { readonly authorization: string } {
+  return { authorization: "Bearer clerk-session" };
+}
+
+function prepareClient() {
+  return setupApp({ context })(storagesPrepareContract);
+}
+
+function commitClient() {
+  return setupApp({ context })(storagesCommitContract);
+}
+
+function currentSecond(): number {
+  return Math.floor(now() / 1000);
+}
+
+function storageName(prefix: string): string {
+  return `${prefix}-${randomUUID().slice(0, 8)}`;
+}
+
+function validFile(overrides: Partial<StorageFile> = {}): StorageFile {
+  return {
+    path: "test.txt",
+    hash: TEST_HASH,
+    size: 100,
+    ...overrides,
+  };
+}
+
+function prepareBody(overrides: Partial<PrepareBody> = {}): PrepareBody {
+  return {
+    storageName: storageName("artifact"),
+    storageType: "artifact",
+    files: [validFile()],
+    ...overrides,
+  };
+}
+
+function commitBody(overrides: Partial<CommitBody>): CommitBody {
+  return {
+    storageName: storageName("artifact"),
+    storageType: "artifact",
+    versionId: "0".repeat(64),
+    files: [validFile()],
+    ...overrides,
+  };
+}
+
+function s3CommandInput(command: unknown): Record<string, unknown> {
+  if (
+    typeof command === "object" &&
+    command !== null &&
+    "input" in command &&
+    typeof command.input === "object" &&
+    command.input !== null
+  ) {
+    return command.input as Record<string, unknown>;
+  }
+  return {};
+}
+
+function s3SendInputs(): readonly Record<string, unknown>[] {
+  return context.mocks.s3.send.mock.calls.map(([command]) => {
+    return s3CommandInput(command);
+  });
+}
+
+function notFoundError(): Error & {
+  name: "NotFound";
+  readonly $metadata: { readonly httpStatusCode: 404 };
+} {
+  const error = new Error("Not found") as Error & {
+    name: "NotFound";
+    $metadata: { httpStatusCode: 404 };
+  };
+  error.name = "NotFound";
+  error.$metadata = { httpStatusCode: 404 };
+  return error;
+}
+
+async function deleteStorageOrg(fixture: StorageOrgFixture): Promise<void> {
+  const db = store.set(writeDb$);
+  const storageRows = await db
+    .select({ id: storages.id })
+    .from(storages)
+    .where(eq(storages.orgId, fixture.orgId));
+  const storageIds = storageRows.map((row) => {
+    return row.id;
+  });
+
+  await db
+    .update(storages)
+    .set({ headVersionId: null })
+    .where(eq(storages.orgId, fixture.orgId));
+
+  if (storageIds.length > 0) {
+    await db
+      .delete(storageVersions)
+      .where(inArray(storageVersions.storageId, storageIds));
+  }
+
+  await db.delete(storages).where(eq(storages.orgId, fixture.orgId));
+}
+
+const trackStorageOrg =
+  createFixtureTracker<StorageOrgFixture>(deleteStorageOrg);
+const trackUsage = createFixtureTracker<UsageInsightFixture>((fixture) => {
+  return store.set(deleteUsageInsightFixture$, fixture, context.signal);
+});
+
+async function useClerkSession(): Promise<AuthFixture> {
+  const userId = `user_${randomUUID()}`;
+  const orgId = `org_${randomUUID()}`;
+  mocks.clerk.session(userId, orgId);
+  await trackStorageOrg(Promise.resolve({ orgId }));
+  return { userId, orgId };
+}
+
+async function seedRunScopedFixture(): Promise<
+  UsageInsightFixture & { readonly runId: string }
+> {
+  const fixture = await trackUsage(
+    store.set(seedUsageInsightFixture$, undefined, context.signal),
+  );
+  const compose = await store.set(
+    seedCompose$,
+    { orgId: fixture.orgId, userId: fixture.userId },
+    context.signal,
+  );
+  const run = await store.set(
+    seedRun$,
+    {
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      composeId: compose.composeId,
+    },
+    context.signal,
+  );
+  return { ...fixture, runId: run.runId };
+}
+
+function sandboxToken(args: {
+  readonly userId: string;
+  readonly orgId: string;
+  readonly runId: string;
+}): string {
+  const seconds = currentSecond();
+  return signSandboxJwtForTests({
+    scope: "sandbox",
+    userId: args.userId,
+    orgId: args.orgId,
+    runId: args.runId,
+    iat: seconds,
+    exp: seconds + 60,
+  });
+}
+
+async function prepareOk(body: PrepareBody) {
+  const response = await accept(
+    prepareClient().prepare({ body, headers: authHeaders() }),
+    [200],
+  );
+  return response.body;
+}
+
+async function commitOk(body: CommitBody) {
+  const response = await accept(
+    commitClient().commit({ body, headers: authHeaders() }),
+    [200],
+  );
+  return response.body;
+}
+
+beforeEach(() => {
+  mockEnv("R2_USER_STORAGES_BUCKET_NAME", BUCKET);
+});
+
+describe("POST /api/storages/prepare", () => {
+  it("returns 401 when the request is unauthenticated", async () => {
+    const response = await accept(
+      prepareClient().prepare({ body: prepareBody(), headers: {} }),
+      [401],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("returns 400 for invalid request bodies", async () => {
+    await useClerkSession();
+
+    const response = await accept(
+      prepareClient().prepare({
+        body: { storageType: "artifact", files: [] } as never,
+        headers: authHeaders(),
+      }),
+      [400],
+    );
+
+    expect(response.body.error.code).toBe("BAD_REQUEST");
+    expect(response.body.error.message).toContain("storageName");
+  });
+
+  it("returns 400 when session auth has no organization context", async () => {
+    mocks.clerk.session(`user_${randomUUID()}`, null);
+
+    const response = await accept(
+      prepareClient().prepare({
+        body: prepareBody(),
+        headers: authHeaders(),
+      }),
+      [400],
+    );
+
+    expect(response.body.error.message).toContain("Explicit org context");
+  });
+
+  it("creates storage metadata and returns upload URLs", async () => {
+    const auth = await useClerkSession();
+    const name = storageName("new-storage");
+    const body = prepareBody({ storageName: name });
+
+    const response = await prepareOk(body);
+
+    expect(response.existing).toBeFalsy();
+    expect(response.uploads?.archive.key).toBe(
+      `${auth.orgId}/artifact/${name}/${response.versionId}/archive.tar.gz`,
+    );
+    expect(response.uploads?.manifest.key).toBe(
+      `${auth.orgId}/artifact/${name}/${response.versionId}/manifest.json`,
+    );
+    expect(response.uploads?.archive.presignedUrl).toMatch(/^https?:\/\//);
+
+    const db = store.set(writeDb$);
+    const [storage] = await db
+      .select()
+      .from(storages)
+      .where(and(eq(storages.orgId, auth.orgId), eq(storages.name, name)))
+      .limit(1);
+    expect(storage).toMatchObject({
+      orgId: auth.orgId,
+      userId: auth.userId,
+      name,
+      type: "artifact",
+      size: 0,
+      fileCount: 0,
+    });
+  });
+
+  it("rejects total declared file size over 100MB", async () => {
+    await useClerkSession();
+
+    const response = await accept(
+      prepareClient().prepare({
+        body: prepareBody({
+          files: [
+            validFile({ path: "one.bin", size: MAX_FILE_SIZE_BYTES }),
+            validFile({ path: "two.bin", hash: SECOND_TEST_HASH, size: 1 }),
+          ],
+        }),
+        headers: authHeaders(),
+      }),
+      [413],
+    );
+
+    expect(response.body.error.code).toBe("PAYLOAD_TOO_LARGE");
+  });
+
+  it("scopes sandbox tokens through the run organization", async () => {
+    const fixture = await seedRunScopedFixture();
+    await trackStorageOrg(Promise.resolve({ orgId: fixture.orgId }));
+    const token = sandboxToken(fixture);
+    const name = storageName("sandbox-storage");
+
+    const response = await accept(
+      prepareClient().prepare({
+        body: prepareBody({ storageName: name }),
+        headers: { authorization: `Bearer ${token}` },
+      }),
+      [200],
+    );
+
+    expect(response.body.uploads?.archive.key).toBe(
+      `${fixture.orgId}/artifact/${name}/${response.body.versionId}/archive.tar.gz`,
+    );
+  });
+
+  it("returns existing=true when the version and S3 files already exist", async () => {
+    await useClerkSession();
+    const body = prepareBody({ storageName: storageName("existing") });
+    const prepared = await prepareOk(body);
+
+    context.mocks.s3.send.mockResolvedValue({});
+    await commitOk(
+      commitBody({
+        storageName: body.storageName,
+        storageType: body.storageType,
+        versionId: prepared.versionId,
+        files: body.files,
+      }),
+    );
+
+    context.mocks.s3.getSignedUrl.mockClear();
+    context.mocks.s3.send.mockClear();
+    context.mocks.s3.send.mockResolvedValue({});
+
+    const response = await prepareOk(body);
+
+    expect(response).toStrictEqual({
+      versionId: prepared.versionId,
+      existing: true,
+    });
+    expect(context.mocks.s3.getSignedUrl).not.toHaveBeenCalled();
+  });
+
+  it("returns upload URLs when an existing DB version is missing S3 files", async () => {
+    await useClerkSession();
+    const body = prepareBody({ storageName: storageName("missing-s3") });
+    const prepared = await prepareOk(body);
+
+    context.mocks.s3.send.mockResolvedValue({});
+    await commitOk(
+      commitBody({
+        storageName: body.storageName,
+        storageType: body.storageType,
+        versionId: prepared.versionId,
+        files: body.files,
+      }),
+    );
+
+    context.mocks.s3.getSignedUrl.mockClear();
+    context.mocks.s3.send.mockClear();
+    context.mocks.s3.send.mockRejectedValueOnce(notFoundError());
+    context.mocks.s3.send.mockResolvedValue({});
+
+    const response = await prepareOk(body);
+
+    expect(response.existing).toBeFalsy();
+    expect(response.uploads?.archive.key).toContain(prepared.versionId);
+    expect(context.mocks.s3.getSignedUrl).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("POST /api/storages/commit", () => {
+  it("returns 404 when storage does not exist", async () => {
+    await useClerkSession();
+
+    const response = await accept(
+      commitClient().commit({
+        body: commitBody({ storageName: storageName("missing") }),
+        headers: authHeaders(),
+      }),
+      [404],
+    );
+
+    expect(response.body.error.message).toContain("not found");
+  });
+
+  it("returns 400 when the version id does not match the file hash", async () => {
+    await useClerkSession();
+    const body = prepareBody({ storageName: storageName("mismatch") });
+    await prepareOk(body);
+
+    const response = await accept(
+      commitClient().commit({
+        body: commitBody({
+          storageName: body.storageName,
+          storageType: body.storageType,
+          versionId: "f".repeat(64),
+          files: body.files,
+        }),
+        headers: authHeaders(),
+      }),
+      [400],
+    );
+
+    expect(response.body.error.message).toContain("Version ID mismatch");
+  });
+
+  it("returns 400 when uploaded S3 objects are missing", async () => {
+    await useClerkSession();
+    const manifestBody = prepareBody({
+      storageName: storageName("missing-manifest"),
+    });
+    const manifestPrepared = await prepareOk(manifestBody);
+
+    context.mocks.s3.send.mockRejectedValueOnce(notFoundError());
+    context.mocks.s3.send.mockResolvedValue({});
+    const missingManifest = await accept(
+      commitClient().commit({
+        body: commitBody({
+          storageName: manifestBody.storageName,
+          storageType: manifestBody.storageType,
+          versionId: manifestPrepared.versionId,
+          files: manifestBody.files,
+        }),
+        headers: authHeaders(),
+      }),
+      [400],
+    );
+    expect(missingManifest.body.error.message).toContain("Manifest");
+
+    context.mocks.s3.send.mockClear();
+    const archiveBody = prepareBody({
+      storageName: storageName("missing-archive"),
+    });
+    const archivePrepared = await prepareOk(archiveBody);
+    context.mocks.s3.send.mockResolvedValueOnce({});
+    context.mocks.s3.send.mockRejectedValueOnce(notFoundError());
+
+    const missingArchive = await accept(
+      commitClient().commit({
+        body: commitBody({
+          storageName: archiveBody.storageName,
+          storageType: archiveBody.storageType,
+          versionId: archivePrepared.versionId,
+          files: archiveBody.files,
+        }),
+        headers: authHeaders(),
+      }),
+      [400],
+    );
+
+    expect(missingArchive.body.error.message).toContain("Archive");
+  });
+
+  it("creates a storage version and updates the head pointer", async () => {
+    const auth = await useClerkSession();
+    const body = prepareBody({ storageName: storageName("commit-success") });
+    const prepared = await prepareOk(body);
+
+    context.mocks.s3.send.mockResolvedValue({});
+    const response = await commitOk(
+      commitBody({
+        storageName: body.storageName,
+        storageType: body.storageType,
+        versionId: prepared.versionId,
+        files: body.files,
+        message: "first version",
+      }),
+    );
+
+    expect(response).toMatchObject({
+      success: true,
+      versionId: prepared.versionId,
+      storageName: body.storageName,
+      size: 100,
+      fileCount: 1,
+    });
+
+    const db = store.set(writeDb$);
+    const [storage] = await db
+      .select()
+      .from(storages)
+      .where(
+        and(
+          eq(storages.orgId, auth.orgId),
+          eq(storages.name, body.storageName),
+        ),
+      )
+      .limit(1);
+    expect(storage?.headVersionId).toBe(prepared.versionId);
+    expect(storage?.size).toBe(100);
+    expect(storage?.fileCount).toBe(1);
+  });
+
+  it("skips the archive requirement for empty artifacts", async () => {
+    const auth = await useClerkSession();
+    const body = prepareBody({
+      storageName: storageName("empty-artifact"),
+      files: [],
+    });
+    const prepared = await prepareOk(body);
+
+    context.mocks.s3.send.mockResolvedValue({});
+    const response = await commitOk(
+      commitBody({
+        storageName: body.storageName,
+        storageType: body.storageType,
+        versionId: prepared.versionId,
+        files: [],
+      }),
+    );
+
+    expect(response.fileCount).toBe(0);
+    expect(response.size).toBe(0);
+    expect(s3SendInputs()).toStrictEqual([
+      {
+        Bucket: BUCKET,
+        Key: `${auth.orgId}/artifact/${body.storageName}/${prepared.versionId}/manifest.json`,
+      },
+    ]);
+  });
+
+  it("returns deduplicated=true when committing an existing version", async () => {
+    await useClerkSession();
+    const body = prepareBody({ storageName: storageName("dedupe") });
+    const prepared = await prepareOk(body);
+    const commit = commitBody({
+      storageName: body.storageName,
+      storageType: body.storageType,
+      versionId: prepared.versionId,
+      files: body.files,
+    });
+
+    context.mocks.s3.send.mockResolvedValue({});
+    await commitOk(commit);
+    context.mocks.s3.send.mockClear();
+    context.mocks.s3.send.mockResolvedValue({});
+
+    const response = await commitOk(commit);
+
+    expect(response.deduplicated).toBeTruthy();
+    expect(response.versionId).toBe(prepared.versionId);
+  });
+});

--- a/turbo/apps/api/src/signals/routes/storages-commit.ts
+++ b/turbo/apps/api/src/signals/routes/storages-commit.ts
@@ -1,0 +1,38 @@
+import { command } from "ccstate";
+import { storagesCommitContract } from "@vm0/api-contracts/contracts/storages";
+
+import { authContext$ } from "../auth/auth-context";
+import { authRoute } from "../auth/auth-route";
+import { bodyResultOf } from "../context/request";
+import type { RouteEntry } from "../route";
+import { commitStorageUploadForAuth$ } from "../services/storage-write.service";
+
+const commitBody$ = bodyResultOf(storagesCommitContract.commit);
+
+const commitStorageInner$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const auth = get(authContext$);
+    const body = await get(commitBody$);
+    signal.throwIfAborted();
+
+    if (!body.ok) {
+      return body.response;
+    }
+
+    return await set(
+      commitStorageUploadForAuth$,
+      { auth, ...body.data },
+      signal,
+    );
+  },
+);
+
+export const storagesCommitRoutes: readonly RouteEntry[] = [
+  {
+    route: storagesCommitContract.commit,
+    handler: authRoute(
+      { acceptAnySandboxCapability: true },
+      commitStorageInner$,
+    ),
+  },
+];

--- a/turbo/apps/api/src/signals/routes/storages-prepare.ts
+++ b/turbo/apps/api/src/signals/routes/storages-prepare.ts
@@ -1,0 +1,38 @@
+import { command } from "ccstate";
+import { storagesPrepareContract } from "@vm0/api-contracts/contracts/storages";
+
+import { authContext$ } from "../auth/auth-context";
+import { authRoute } from "../auth/auth-route";
+import { bodyResultOf } from "../context/request";
+import type { RouteEntry } from "../route";
+import { prepareStorageUploadForAuth$ } from "../services/storage-write.service";
+
+const prepareBody$ = bodyResultOf(storagesPrepareContract.prepare);
+
+const prepareStorageInner$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const auth = get(authContext$);
+    const body = await get(prepareBody$);
+    signal.throwIfAborted();
+
+    if (!body.ok) {
+      return body.response;
+    }
+
+    return await set(
+      prepareStorageUploadForAuth$,
+      { auth, ...body.data },
+      signal,
+    );
+  },
+);
+
+export const storagesPrepareRoutes: readonly RouteEntry[] = [
+  {
+    route: storagesPrepareContract.prepare,
+    handler: authRoute(
+      { acceptAnySandboxCapability: true },
+      prepareStorageInner$,
+    ),
+  },
+];

--- a/turbo/apps/api/src/signals/services/storage-write.service.ts
+++ b/turbo/apps/api/src/signals/services/storage-write.service.ts
@@ -1,0 +1,760 @@
+import { MAX_FILE_SIZE_BYTES } from "@vm0/api-contracts/contracts/storages";
+import { VOLUME_ORG_USER_ID } from "@vm0/core/storage-names";
+import { agentRuns } from "@vm0/db/schema/agent-run";
+import { storages, storageVersions } from "@vm0/db/schema/storage";
+import { command, type Computed } from "ccstate";
+import { and, eq } from "drizzle-orm";
+
+import { badRequestMessage, notFound } from "../../lib/error";
+import { env } from "../../lib/env";
+import { nowDate } from "../../lib/time";
+import type { AuthContext } from "../../types/auth";
+import { writeDb$, type Db } from "../external/db";
+import {
+  downloadManifest,
+  generatePresignedPutUrl,
+  s3ObjectExists,
+  verifyS3FilesExist,
+} from "../external/s3";
+import { safeAsync } from "../utils";
+import {
+  computeContentHashFromHashes,
+  type FileEntryWithHash,
+} from "./storage-content-hash.service";
+
+type StorageType = "volume" | "artifact";
+
+interface StorageChanges {
+  readonly deleted?: readonly string[];
+}
+
+interface PrepareStorageInput {
+  readonly auth: AuthContext;
+  readonly storageName: string;
+  readonly storageType: StorageType;
+  readonly files: readonly FileEntryWithHash[];
+  readonly force?: boolean;
+  readonly runId?: string;
+  readonly baseVersion?: string;
+  readonly changes?: StorageChanges;
+}
+
+interface CommitStorageInput {
+  readonly auth: AuthContext;
+  readonly storageName: string;
+  readonly storageType: StorageType;
+  readonly versionId: string;
+  readonly files: readonly FileEntryWithHash[];
+  readonly runId?: string;
+  readonly message?: string;
+}
+
+interface RuntimeOrg {
+  readonly orgId: string;
+}
+
+type StorageRow = typeof storages.$inferSelect;
+type StorageVersionRow = typeof storageVersions.$inferSelect;
+
+type SignalGetter = {
+  <T>(source: Computed<T>): T;
+  <T>(source: Computed<Promise<T>>): Promise<T>;
+};
+
+type StorageErrorResponse =
+  | ReturnType<typeof badRequestMessage>
+  | ReturnType<typeof notFound>
+  | {
+      readonly status: 413;
+      readonly body: {
+        readonly error: {
+          readonly message: string;
+          readonly code: "PAYLOAD_TOO_LARGE";
+        };
+      };
+    }
+  | {
+      readonly status: 500;
+      readonly body: {
+        readonly error: {
+          readonly message: string;
+          readonly code: "INTERNAL_ERROR";
+        };
+      };
+    };
+
+type PrepareStorageResponse =
+  | {
+      readonly status: 200;
+      readonly body: {
+        readonly versionId: string;
+        readonly existing: boolean;
+        readonly uploads?: {
+          readonly archive: {
+            readonly key: string;
+            readonly presignedUrl: string;
+          };
+          readonly manifest: {
+            readonly key: string;
+            readonly presignedUrl: string;
+          };
+        };
+      };
+    }
+  | StorageErrorResponse;
+
+type CommitStorageResponse =
+  | {
+      readonly status: 200;
+      readonly body: {
+        readonly success: true;
+        readonly versionId: string;
+        readonly storageName: string;
+        readonly size: number;
+        readonly fileCount: number;
+        readonly deduplicated?: boolean;
+      };
+    }
+  | StorageErrorResponse
+  | {
+      readonly status: 409;
+      readonly body: {
+        readonly error: {
+          readonly message: string;
+          readonly code: "S3_FILES_MISSING";
+        };
+      };
+    };
+
+function payloadTooLarge(message: string): StorageErrorResponse {
+  return {
+    status: 413,
+    body: { error: { message, code: "PAYLOAD_TOO_LARGE" } },
+  };
+}
+
+function internalError(message: string): StorageErrorResponse {
+  return {
+    status: 500,
+    body: { error: { message, code: "INTERNAL_ERROR" } },
+  };
+}
+
+function storageServiceNotConfigured(): StorageErrorResponse {
+  return internalError("Storage service is not properly configured");
+}
+
+function hasRunId(auth: AuthContext): auth is AuthContext & {
+  readonly runId: string;
+} {
+  return "runId" in auth && typeof auth.runId === "string";
+}
+
+function storageUserId(type: StorageType, userId: string): string {
+  return type === "volume" ? VOLUME_ORG_USER_ID : userId;
+}
+
+async function resolveStorageRuntimeOrg(args: {
+  readonly db: Db;
+  readonly auth: AuthContext;
+  readonly runId: string | undefined;
+  readonly signal: AbortSignal;
+}): Promise<RuntimeOrg | StorageErrorResponse> {
+  if (hasRunId(args.auth)) {
+    const [run] = await args.db
+      .select({ orgId: agentRuns.orgId })
+      .from(agentRuns)
+      .where(
+        and(
+          eq(agentRuns.id, args.auth.runId),
+          eq(agentRuns.userId, args.auth.userId),
+        ),
+      )
+      .limit(1);
+    args.signal.throwIfAborted();
+
+    return run ? { orgId: run.orgId } : notFound("Agent run not found");
+  }
+
+  if (!args.auth.orgId) {
+    return badRequestMessage(
+      "Explicit org context required — ensure active org in session",
+    );
+  }
+
+  if (args.runId) {
+    const [run] = await args.db
+      .select({ id: agentRuns.id })
+      .from(agentRuns)
+      .where(
+        and(
+          eq(agentRuns.id, args.runId),
+          eq(agentRuns.userId, args.auth.userId),
+        ),
+      )
+      .limit(1);
+    args.signal.throwIfAborted();
+
+    if (!run) {
+      return notFound("Agent run not found");
+    }
+  }
+
+  return { orgId: args.auth.orgId };
+}
+
+async function mergeWithBaseVersion(args: {
+  readonly get: SignalGetter;
+  readonly db: Db;
+  readonly bucket: string;
+  readonly storageId: string;
+  readonly files: readonly FileEntryWithHash[];
+  readonly baseVersion: string;
+  readonly changes: StorageChanges;
+  readonly signal: AbortSignal;
+}): Promise<readonly FileEntryWithHash[]> {
+  const [baseVersionRecord] = await args.db
+    .select()
+    .from(storageVersions)
+    .where(
+      and(
+        eq(storageVersions.storageId, args.storageId),
+        eq(storageVersions.id, args.baseVersion),
+      ),
+    )
+    .limit(1);
+  args.signal.throwIfAborted();
+
+  if (!baseVersionRecord) {
+    return args.files;
+  }
+
+  const baseManifest = await args.get(
+    downloadManifest(args.bucket, baseVersionRecord.s3Key),
+  );
+  args.signal.throwIfAborted();
+
+  const currentFiles = new Map(
+    args.files.map((file) => {
+      return [file.path, file];
+    }),
+  );
+  const deleted = new Set(args.changes.deleted ?? []);
+  const baseFiles = baseManifest.files.filter((file) => {
+    return !deleted.has(file.path) && !currentFiles.has(file.path);
+  });
+
+  return [...baseFiles, ...args.files];
+}
+
+function totalSize(files: readonly FileEntryWithHash[]): number {
+  return files.reduce((sum, file) => {
+    return sum + file.size;
+  }, 0);
+}
+
+async function findStorageForCommit(args: {
+  readonly db: Db;
+  readonly orgId: string;
+  readonly storageOwner: string;
+  readonly input: CommitStorageInput;
+}): Promise<StorageRow | undefined> {
+  const [storage] = await args.db
+    .select()
+    .from(storages)
+    .where(
+      and(
+        eq(storages.orgId, args.orgId),
+        eq(storages.userId, args.storageOwner),
+        eq(storages.name, args.input.storageName),
+        eq(storages.type, args.input.storageType),
+      ),
+    )
+    .limit(1);
+
+  return storage;
+}
+
+async function findStorageVersion(args: {
+  readonly db: Db;
+  readonly storageId: string;
+  readonly versionId: string;
+}): Promise<StorageVersionRow | undefined> {
+  const [version] = await args.db
+    .select()
+    .from(storageVersions)
+    .where(
+      and(
+        eq(storageVersions.storageId, args.storageId),
+        eq(storageVersions.id, args.versionId),
+      ),
+    )
+    .limit(1);
+
+  return version;
+}
+
+async function upsertStorageForPrepare(args: {
+  readonly db: Db;
+  readonly orgId: string;
+  readonly storageOwner: string;
+  readonly input: PrepareStorageInput;
+}): Promise<StorageRow | undefined> {
+  const [storage] = await args.db
+    .insert(storages)
+    .values({
+      userId: args.storageOwner,
+      orgId: args.orgId,
+      name: args.input.storageName,
+      type: args.input.storageType,
+      s3Prefix: `${args.orgId}/${args.input.storageType}/${args.input.storageName}`,
+      size: 0,
+      fileCount: 0,
+    })
+    .onConflictDoUpdate({
+      target: [storages.orgId, storages.userId, storages.name, storages.type],
+      set: { updatedAt: nowDate() },
+    })
+    .returning();
+
+  return storage;
+}
+
+async function resolvePreparedFiles(args: {
+  readonly get: SignalGetter;
+  readonly db: Db;
+  readonly bucket: string;
+  readonly storageId: string;
+  readonly input: PrepareStorageInput;
+  readonly signal: AbortSignal;
+}): Promise<readonly FileEntryWithHash[]> {
+  const baseVersion = args.input.baseVersion;
+  const changes = args.input.changes;
+  if (!baseVersion || !changes) {
+    return args.input.files;
+  }
+
+  const mergeResult = await safeAsync(() => {
+    return mergeWithBaseVersion({
+      get: args.get,
+      db: args.db,
+      bucket: args.bucket,
+      storageId: args.storageId,
+      files: args.input.files,
+      baseVersion,
+      changes,
+      signal: args.signal,
+    });
+  });
+  args.signal.throwIfAborted();
+
+  return "ok" in mergeResult ? mergeResult.ok : args.input.files;
+}
+
+async function existingStorageVersionIsReusable(args: {
+  readonly get: SignalGetter;
+  readonly db: Db;
+  readonly bucket: string;
+  readonly storageId: string;
+  readonly versionId: string;
+  readonly force: boolean | undefined;
+  readonly signal: AbortSignal;
+}): Promise<boolean> {
+  if (args.force) {
+    return false;
+  }
+
+  const existingVersion = await findStorageVersion({
+    db: args.db,
+    storageId: args.storageId,
+    versionId: args.versionId,
+  });
+  args.signal.throwIfAborted();
+
+  if (!existingVersion) {
+    return false;
+  }
+
+  const exists = await args.get(
+    verifyS3FilesExist(
+      args.bucket,
+      existingVersion.s3Key,
+      existingVersion.fileCount,
+    ),
+  );
+  args.signal.throwIfAborted();
+
+  return exists;
+}
+
+async function createStorageUploadResponse(args: {
+  readonly get: SignalGetter;
+  readonly bucket: string;
+  readonly storage: StorageRow;
+  readonly versionId: string;
+  readonly signal: AbortSignal;
+}): Promise<PrepareStorageResponse> {
+  const s3Key = `${args.storage.s3Prefix}/${args.versionId}`;
+  const archiveKey = `${s3Key}/archive.tar.gz`;
+  const manifestKey = `${s3Key}/manifest.json`;
+  const [archiveUrl, manifestUrl] = await Promise.all([
+    args.get(
+      generatePresignedPutUrl(
+        args.bucket,
+        archiveKey,
+        "application/gzip",
+        3600,
+        true,
+      ),
+    ),
+    args.get(
+      generatePresignedPutUrl(
+        args.bucket,
+        manifestKey,
+        "application/json",
+        3600,
+        true,
+      ),
+    ),
+  ]);
+  args.signal.throwIfAborted();
+
+  return {
+    status: 200,
+    body: {
+      versionId: args.versionId,
+      existing: false,
+      uploads: {
+        archive: { key: archiveKey, presignedUrl: archiveUrl },
+        manifest: { key: manifestKey, presignedUrl: manifestUrl },
+      },
+    },
+  };
+}
+
+function s3FilesMissingConflict(): Extract<
+  CommitStorageResponse,
+  { status: 409 }
+> {
+  return {
+    status: 409,
+    body: {
+      error: {
+        message: "S3 files missing for existing version - please retry upload",
+        code: "S3_FILES_MISSING",
+      },
+    },
+  };
+}
+
+async function commitExistingStorageVersion(args: {
+  readonly get: SignalGetter;
+  readonly db: Db;
+  readonly bucket: string;
+  readonly storage: StorageRow;
+  readonly version: StorageVersionRow;
+  readonly input: CommitStorageInput;
+  readonly signal: AbortSignal;
+}): Promise<CommitStorageResponse> {
+  const exists = await args.get(
+    verifyS3FilesExist(args.bucket, args.version.s3Key, args.version.fileCount),
+  );
+  args.signal.throwIfAborted();
+
+  if (!exists) {
+    return s3FilesMissingConflict();
+  }
+
+  if (args.storage.headVersionId !== args.input.versionId) {
+    await args.db
+      .update(storages)
+      .set({ headVersionId: args.input.versionId, updatedAt: nowDate() })
+      .where(eq(storages.id, args.storage.id));
+    args.signal.throwIfAborted();
+  }
+
+  return {
+    status: 200,
+    body: {
+      success: true,
+      versionId: args.input.versionId,
+      storageName: args.input.storageName,
+      size: Number(args.version.size),
+      fileCount: args.version.fileCount,
+      deduplicated: true,
+    },
+  };
+}
+
+async function verifyUploadedStorageFiles(args: {
+  readonly get: SignalGetter;
+  readonly bucket: string;
+  readonly s3Key: string;
+  readonly fileCount: number;
+  readonly signal: AbortSignal;
+}): Promise<ReturnType<typeof badRequestMessage> | null> {
+  const manifestKey = `${args.s3Key}/manifest.json`;
+  const archiveKey = `${args.s3Key}/archive.tar.gz`;
+  const [manifestExists, archiveExists] = await Promise.all([
+    args.get(s3ObjectExists(args.bucket, manifestKey)),
+    args.fileCount > 0
+      ? args.get(s3ObjectExists(args.bucket, archiveKey))
+      : Promise.resolve(true),
+  ]);
+  args.signal.throwIfAborted();
+
+  if (!manifestExists) {
+    return badRequestMessage(
+      "Manifest not uploaded - upload failed or incomplete",
+    );
+  }
+
+  if (args.fileCount > 0 && !archiveExists) {
+    return badRequestMessage(
+      "Archive not uploaded - upload failed or incomplete",
+    );
+  }
+
+  return null;
+}
+
+async function insertStorageVersionAndUpdateHead(args: {
+  readonly db: Db;
+  readonly storageId: string;
+  readonly s3Key: string;
+  readonly input: CommitStorageInput;
+  readonly size: number;
+  readonly fileCount: number;
+}): Promise<void> {
+  await args.db.transaction(async (tx) => {
+    await tx
+      .insert(storageVersions)
+      .values({
+        id: args.input.versionId,
+        storageId: args.storageId,
+        s3Key: args.s3Key,
+        size: args.size,
+        fileCount: args.fileCount,
+        message: args.input.message ?? null,
+        createdBy: args.input.runId ? "agent" : "user",
+      })
+      .onConflictDoNothing();
+
+    const [version] = await tx
+      .select({ id: storageVersions.id })
+      .from(storageVersions)
+      .where(
+        and(
+          eq(storageVersions.storageId, args.storageId),
+          eq(storageVersions.id, args.input.versionId),
+        ),
+      )
+      .limit(1);
+
+    if (!version) {
+      throw new Error(`Version ${args.input.versionId} not found after insert`);
+    }
+
+    await tx
+      .update(storages)
+      .set({
+        headVersionId: args.input.versionId,
+        size: args.size,
+        fileCount: args.fileCount,
+        updatedAt: nowDate(),
+      })
+      .where(eq(storages.id, args.storageId));
+  });
+}
+
+async function commitNewStorageVersion(args: {
+  readonly get: SignalGetter;
+  readonly db: Db;
+  readonly bucket: string;
+  readonly storage: StorageRow;
+  readonly input: CommitStorageInput;
+  readonly signal: AbortSignal;
+}): Promise<CommitStorageResponse> {
+  const s3Key = `${args.storage.s3Prefix}/${args.input.versionId}`;
+  const fileCount = args.input.files.length;
+  const uploadError = await verifyUploadedStorageFiles({
+    get: args.get,
+    bucket: args.bucket,
+    s3Key,
+    fileCount,
+    signal: args.signal,
+  });
+  if (uploadError) {
+    return uploadError;
+  }
+
+  const size = totalSize(args.input.files);
+  await insertStorageVersionAndUpdateHead({
+    db: args.db,
+    storageId: args.storage.id,
+    s3Key,
+    input: args.input,
+    size,
+    fileCount,
+  });
+  args.signal.throwIfAborted();
+
+  return {
+    status: 200,
+    body: {
+      success: true,
+      versionId: args.input.versionId,
+      storageName: args.input.storageName,
+      size,
+      fileCount,
+    },
+  };
+}
+
+export const prepareStorageUploadForAuth$ = command(
+  async (
+    { get, set },
+    args: PrepareStorageInput,
+    signal: AbortSignal,
+  ): Promise<PrepareStorageResponse> => {
+    const declaredSize = totalSize(args.files);
+    if (declaredSize > MAX_FILE_SIZE_BYTES) {
+      return payloadTooLarge(
+        "Upload rejected: total file size exceeds 100MB limit",
+      );
+    }
+
+    const writeDb = set(writeDb$);
+    const runtimeOrg = await resolveStorageRuntimeOrg({
+      db: writeDb,
+      auth: args.auth,
+      runId: args.runId,
+      signal,
+    });
+    if ("status" in runtimeOrg) {
+      return runtimeOrg;
+    }
+
+    const storageOwner = storageUserId(args.storageType, args.auth.userId);
+    const storage = await upsertStorageForPrepare({
+      db: writeDb,
+      orgId: runtimeOrg.orgId,
+      storageOwner,
+      input: args,
+    });
+    signal.throwIfAborted();
+
+    if (!storage) {
+      return internalError("Failed to create storage");
+    }
+
+    const bucket = env("R2_USER_STORAGES_BUCKET_NAME");
+    if (!bucket) {
+      return storageServiceNotConfigured();
+    }
+
+    const mergedFiles = await resolvePreparedFiles({
+      get,
+      db: writeDb,
+      bucket,
+      storageId: storage.id,
+      input: args,
+      signal,
+    });
+    const versionId = computeContentHashFromHashes(storage.id, mergedFiles);
+
+    const existingReusable = await existingStorageVersionIsReusable({
+      get,
+      db: writeDb,
+      bucket,
+      storageId: storage.id,
+      versionId,
+      force: args.force,
+      signal,
+    });
+    if (existingReusable) {
+      return { status: 200, body: { versionId, existing: true } };
+    }
+
+    return await createStorageUploadResponse({
+      get,
+      bucket,
+      storage,
+      versionId,
+      signal,
+    });
+  },
+);
+
+export const commitStorageUploadForAuth$ = command(
+  async (
+    { get, set },
+    args: CommitStorageInput,
+    signal: AbortSignal,
+  ): Promise<CommitStorageResponse> => {
+    const writeDb = set(writeDb$);
+    const runtimeOrg = await resolveStorageRuntimeOrg({
+      db: writeDb,
+      auth: args.auth,
+      runId: args.runId,
+      signal,
+    });
+    if ("status" in runtimeOrg) {
+      return runtimeOrg;
+    }
+
+    const storageOwner = storageUserId(args.storageType, args.auth.userId);
+    const storage = await findStorageForCommit({
+      db: writeDb,
+      orgId: runtimeOrg.orgId,
+      storageOwner,
+      input: args,
+    });
+    signal.throwIfAborted();
+
+    if (!storage) {
+      return notFound(`Storage "${args.storageName}" not found`);
+    }
+
+    const computedVersionId = computeContentHashFromHashes(
+      storage.id,
+      args.files,
+    );
+    if (computedVersionId !== args.versionId) {
+      return badRequestMessage("Version ID mismatch - files may have changed");
+    }
+
+    const bucket = env("R2_USER_STORAGES_BUCKET_NAME");
+    if (!bucket) {
+      return storageServiceNotConfigured();
+    }
+
+    const existingVersion = await findStorageVersion({
+      db: writeDb,
+      storageId: storage.id,
+      versionId: args.versionId,
+    });
+    signal.throwIfAborted();
+
+    if (existingVersion) {
+      return await commitExistingStorageVersion({
+        get,
+        db: writeDb,
+        bucket,
+        storage,
+        version: existingVersion,
+        input: args,
+        signal,
+      });
+    }
+
+    return await commitNewStorageVersion({
+      get,
+      db: writeDb,
+      bucket,
+      storage,
+      input: args,
+      signal,
+    });
+  },
+);


### PR DESCRIPTION
## Summary

- Add API-native `POST /api/storages/prepare` and `POST /api/storages/commit` signal routes.
- Move prepare/commit behavior into an API storage write service with sandbox org resolution, dedupe checks, S3 existence verification, and idempotent commit handling.
- Add API integration coverage for auth, validation, prepare dedupe/fallback, commit S3 checks, empty artifacts, and existing-version commits.

Fixes #12855

## Validation

- `scripts/prepare.sh`
- `pnpm -F api exec vitest src/signals/routes/__tests__/storages-write.test.ts src/signals/routes/__tests__/storages.test.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm check-types`
- `pnpm format`
- `pnpm knip --workspace api`
- pre-commit hook: prettier, knip, check-types