### PR TITLE
refactor(api): migrate zero org members delete route

### DIFF
--- a/turbo/apps/api/src/__tests__/mocks.ts
+++ b/turbo/apps/api/src/__tests__/mocks.ts
@@ -542,7 +542,9 @@ export function resetApiTestMocks(): void {
   apiTestMocks.clerk.organizations.getOrganizationInvitationList.mockReset();
   apiTestMocks.clerk.organizations.getOrganizationMembershipList.mockReset();
   apiTestMocks.clerk.organizations.deleteOrganizationLogo.mockReset();
+  apiTestMocks.clerk.organizations.deleteOrganizationMembership.mockReset();
   apiTestMocks.clerk.organizations.revokeOrganizationInvitation.mockReset();
+  apiTestMocks.clerk.organizations.deleteOrganization.mockReset();
   apiTestMocks.clerk.organizations.updateOrganization.mockReset();
   apiTestMocks.clerk.organizations.updateOrganizationLogo.mockReset();
   apiTestMocks.clerk.users.getUserList.mockReset();

--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -51,6 +51,7 @@ import { zeroOnboardingStatusRoutes } from "./routes/zero-onboarding-status";
 import { zeroOrgInviteRoutes } from "./routes/zero-org-invite";
 import { zeroOrgDeleteRoutes } from "./routes/zero-org-delete";
 import { zeroOrgLogoRoutes } from "./routes/zero-org-logo";
+import { zeroOrgMembersRoutes } from "./routes/zero-org-members";
 import { zeroOrgMembershipRequestsRoutes } from "./routes/zero-org-membership-requests";
 import { zeroOrgReadRoutes } from "./routes/zero-org-read";
 import { zeroPermissionAccessRequestsRoutes } from "./routes/zero-permission-access-requests";
@@ -181,6 +182,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...zeroOrgInviteRoutes,
   ...zeroOrgDeleteRoutes,
   ...zeroOrgLogoRoutes,
+  ...zeroOrgMembersRoutes,
   ...zeroOrgMembershipRequestsRoutes,
   ...zeroOrgReadRoutes,
   ...zeroPermissionAccessRequestsRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-org-members.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-org-members.test.ts
@@ -1,14 +1,26 @@
 import { randomUUID } from "node:crypto";
 
+import { createStore } from "ccstate";
+import { and, eq } from "drizzle-orm";
 import { zeroOrgMembersContract } from "@vm0/api-contracts/contracts/zero-org-members";
 import type { OrgMember } from "@vm0/api-contracts/contracts/org-members";
+import { orgMembersCache } from "@vm0/db/schema/org-members-cache";
+import { orgMembersMetadata } from "@vm0/db/schema/org-members-metadata";
+import { slackOrgConnections } from "@vm0/db/schema/slack-org-connection";
+import { slackOrgInstallations } from "@vm0/db/schema/slack-org-installation";
 import { http, HttpResponse } from "msw";
 
+import { createApp } from "../../../app-factory";
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
 import { server } from "../../../mocks/server";
-import { createZeroRouteMocks } from "./helpers/zero-route-test";
+import { writeDb$ } from "../../external/db";
+import {
+  createFixtureTracker,
+  createZeroRouteMocks,
+} from "./helpers/zero-route-test";
 
 const context = testContext();
+const store = createStore();
 const mocks = createZeroRouteMocks(context);
 
 interface ClerkOrgFixture {
@@ -79,6 +91,121 @@ function mockClerkUsers(users: readonly ClerkUserFixture[]): void {
   context.mocks.clerk.users.getUserList.mockResolvedValue({
     data: users.map(clerkUserPayload),
   });
+}
+
+interface CleanupFixture {
+  readonly orgId?: string;
+  readonly workspaceId?: string;
+}
+
+const trackCleanup = createFixtureTracker(
+  async (fixture: CleanupFixture): Promise<void> => {
+    const writeDb = store.set(writeDb$);
+    if (fixture.workspaceId) {
+      await writeDb
+        .delete(slackOrgConnections)
+        .where(eq(slackOrgConnections.slackWorkspaceId, fixture.workspaceId));
+      await writeDb
+        .delete(slackOrgInstallations)
+        .where(eq(slackOrgInstallations.slackWorkspaceId, fixture.workspaceId));
+    }
+
+    if (fixture.orgId) {
+      await writeDb
+        .delete(orgMembersMetadata)
+        .where(eq(orgMembersMetadata.orgId, fixture.orgId));
+      await writeDb
+        .delete(orgMembersCache)
+        .where(eq(orgMembersCache.orgId, fixture.orgId));
+    }
+  },
+);
+
+function uniqueId(prefix: string): string {
+  return `${prefix}_${randomUUID().slice(0, 8)}`;
+}
+
+async function seedMemberRows(orgId: string, userId: string): Promise<void> {
+  const writeDb = store.set(writeDb$);
+  await trackCleanup(Promise.resolve({ orgId }));
+  await writeDb.insert(orgMembersCache).values({
+    orgId,
+    userId,
+    role: "member",
+  });
+  await writeDb.insert(orgMembersMetadata).values({ orgId, userId });
+}
+
+async function seedSlackConnection(args: {
+  readonly orgId: string;
+  readonly workspaceId: string;
+  readonly userId: string;
+}): Promise<void> {
+  const writeDb = store.set(writeDb$);
+  await trackCleanup(Promise.resolve({ workspaceId: args.workspaceId }));
+  await writeDb.insert(slackOrgInstallations).values({
+    slackWorkspaceId: args.workspaceId,
+    slackWorkspaceName: "Org Members Test Workspace",
+    orgId: args.orgId,
+    encryptedBotToken: "encrypted-token",
+    botUserId: uniqueId("bot"),
+  });
+  await writeDb.insert(slackOrgConnections).values({
+    slackUserId: uniqueId("slack-user"),
+    slackWorkspaceId: args.workspaceId,
+    vm0UserId: args.userId,
+  });
+}
+
+async function readMemberCache(
+  orgId: string,
+  userId: string,
+): Promise<typeof orgMembersCache.$inferSelect | undefined> {
+  const writeDb = store.set(writeDb$);
+  const [row] = await writeDb
+    .select()
+    .from(orgMembersCache)
+    .where(
+      and(eq(orgMembersCache.orgId, orgId), eq(orgMembersCache.userId, userId)),
+    )
+    .limit(1);
+  return row;
+}
+
+async function readMemberMetadata(
+  orgId: string,
+  userId: string,
+): Promise<typeof orgMembersMetadata.$inferSelect | undefined> {
+  const writeDb = store.set(writeDb$);
+  const [row] = await writeDb
+    .select()
+    .from(orgMembersMetadata)
+    .where(
+      and(
+        eq(orgMembersMetadata.orgId, orgId),
+        eq(orgMembersMetadata.userId, userId),
+      ),
+    )
+    .limit(1);
+  return row;
+}
+
+async function readSlackConnection(
+  workspaceId: string,
+  userId: string,
+): Promise<typeof slackOrgConnections.$inferSelect | undefined> {
+  const writeDb = store.set(writeDb$);
+  const [row] = await writeDb
+    .select()
+    .from(slackOrgConnections)
+    .where(
+      and(
+        eq(slackOrgConnections.slackWorkspaceId, workspaceId),
+        eq(slackOrgConnections.vm0UserId, userId),
+      ),
+    )
+    .limit(1);
+  return row;
 }
 
 interface MembershipRequestFixture {
@@ -363,5 +490,247 @@ describe("GET /api/zero/org/members", () => {
 
     expect(response.body.membershipRequests).toStrictEqual([]);
     expect(response.body.members).toHaveLength(1);
+  });
+});
+
+describe("DELETE /api/zero/org/members", () => {
+  it("returns 401 when not authenticated", async () => {
+    const client = setupApp({ context })(zeroOrgMembersContract);
+
+    const response = await accept(
+      client.removeMember({
+        headers: {},
+        body: { email: "member@example.com" },
+      }),
+      [401],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("returns 401 when the authenticated session has no organization", async () => {
+    mocks.clerk.session(uniqueId("user"), null);
+    const client = setupApp({ context })(zeroOrgMembersContract);
+
+    const response = await accept(
+      client.removeMember({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { email: "member@example.com" },
+      }),
+      [401],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("returns 400 for an invalid body", async () => {
+    const userId = uniqueId("user");
+    const orgId = uniqueId("org");
+    mocks.clerk.session(userId, orgId, "org:admin");
+    const app = createApp({ signal: context.signal });
+
+    const response = await app.request("/api/zero/org/members", {
+      method: "DELETE",
+      headers: {
+        authorization: "Bearer clerk-session",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ email: "invalid-email" }),
+    });
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body).toMatchObject({ error: { code: "BAD_REQUEST" } });
+    expect(
+      context.mocks.clerk.organizations.deleteOrganizationMembership,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 for non-admin members", async () => {
+    const userId = uniqueId("user");
+    const orgId = uniqueId("org");
+    mocks.clerk.session(userId, orgId, "org:member");
+    const client = setupApp({ context })(zeroOrgMembersContract);
+
+    const response = await accept(
+      client.removeMember({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { email: "member@example.com" },
+      }),
+      [403],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Access denied", code: "FORBIDDEN" },
+    });
+    expect(context.mocks.clerk.users.getUserList).not.toHaveBeenCalled();
+    expect(
+      context.mocks.clerk.organizations.deleteOrganizationMembership,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when the target email does not resolve to a Clerk user", async () => {
+    const userId = uniqueId("user");
+    const orgId = uniqueId("org");
+    mocks.clerk.session(userId, orgId, "org:admin");
+    mockClerkUsers([]);
+    const client = setupApp({ context })(zeroOrgMembersContract);
+
+    const response = await accept(
+      client.removeMember({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { email: "missing@example.com" },
+      }),
+      [404],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Resource not found", code: "NOT_FOUND" },
+    });
+    expect(context.mocks.clerk.users.getUserList).toHaveBeenCalledWith({
+      emailAddress: ["missing@example.com"],
+    });
+    expect(
+      context.mocks.clerk.organizations.getOrganizationMembershipList,
+    ).not.toHaveBeenCalled();
+    expect(
+      context.mocks.clerk.organizations.deleteOrganizationMembership,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when an admin attempts to remove themselves", async () => {
+    const userId = uniqueId("user");
+    const orgId = uniqueId("org");
+    mocks.clerk.session(userId, orgId, "org:admin");
+    mockClerkUsers([
+      {
+        id: userId,
+        email: "admin@example.com",
+        firstName: null,
+        lastName: null,
+        imageUrl: "",
+      },
+    ]);
+    const client = setupApp({ context })(zeroOrgMembersContract);
+
+    const response = await accept(
+      client.removeMember({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { email: "admin@example.com" },
+      }),
+      [400],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Invalid request", code: "BAD_REQUEST" },
+    });
+    expect(
+      context.mocks.clerk.organizations.getOrganizationMembershipList,
+    ).not.toHaveBeenCalled();
+    expect(
+      context.mocks.clerk.organizations.deleteOrganizationMembership,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when the target user is not an organization member", async () => {
+    const adminUserId = uniqueId("user-admin");
+    const targetUserId = uniqueId("user-target");
+    const orgId = uniqueId("org");
+    mocks.clerk.session(adminUserId, orgId, "org:admin");
+    mockClerkUsers([
+      {
+        id: targetUserId,
+        email: "target@example.com",
+        firstName: null,
+        lastName: null,
+        imageUrl: "",
+      },
+    ]);
+    mockClerkMemberships([
+      {
+        userId: adminUserId,
+        role: "org:admin",
+        createdAtMs: 1_700_000_000_000,
+      },
+    ]);
+    const client = setupApp({ context })(zeroOrgMembersContract);
+
+    const response = await accept(
+      client.removeMember({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { email: "target@example.com" },
+      }),
+      [404],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Resource not found", code: "NOT_FOUND" },
+    });
+    expect(
+      context.mocks.clerk.organizations.deleteOrganizationMembership,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("removes a target member through Clerk and cleans member-local rows", async () => {
+    const adminUserId = uniqueId("user-admin");
+    const targetUserId = uniqueId("user-target");
+    const orgId = uniqueId("org");
+    const workspaceId = uniqueId("workspace");
+    const targetEmail = "target@example.com";
+    mocks.clerk.session(adminUserId, orgId, "org:admin");
+    mockClerkUsers([
+      {
+        id: targetUserId,
+        email: targetEmail,
+        firstName: null,
+        lastName: null,
+        imageUrl: "",
+      },
+    ]);
+    mockClerkMemberships([
+      {
+        userId: targetUserId,
+        role: "org:member",
+        createdAtMs: 1_700_000_000_000,
+      },
+    ]);
+    await seedMemberRows(orgId, targetUserId);
+    await seedSlackConnection({ orgId, workspaceId, userId: targetUserId });
+    context.mocks.clerk.organizations.deleteOrganizationMembership.mockResolvedValue(
+      {},
+    );
+    const client = setupApp({ context })(zeroOrgMembersContract);
+
+    const response = await accept(
+      client.removeMember({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { email: targetEmail },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      message: `Removed ${targetEmail} from org`,
+    });
+    expect(context.mocks.clerk.users.getUserList).toHaveBeenCalledWith({
+      emailAddress: [targetEmail],
+    });
+    expect(
+      context.mocks.clerk.organizations.getOrganizationMembershipList,
+    ).toHaveBeenCalledWith({ organizationId: orgId });
+    expect(
+      context.mocks.clerk.organizations.deleteOrganizationMembership,
+    ).toHaveBeenCalledWith({ organizationId: orgId, userId: targetUserId });
+    await expect(readMemberCache(orgId, targetUserId)).resolves.toBeUndefined();
+    await expect(
+      readMemberMetadata(orgId, targetUserId),
+    ).resolves.toBeUndefined();
+    await expect(
+      readSlackConnection(workspaceId, targetUserId),
+    ).resolves.toBeUndefined();
   });
 });

--- a/turbo/apps/api/src/signals/routes/zero-org-members.ts
+++ b/turbo/apps/api/src/signals/routes/zero-org-members.ts
@@ -1,0 +1,49 @@
+import { command } from "ccstate";
+import { zeroOrgMembersContract } from "@vm0/api-contracts/contracts/zero-org-members";
+
+import { organizationAuthContext$ } from "../auth/auth-context";
+import { authRoute } from "../auth/auth-route";
+import { bodyResultOf } from "../context/request";
+import { removeZeroOrgMember$ } from "../services/zero-org-data.service";
+import type { RouteEntry } from "../route";
+
+const removeMemberBody$ = bodyResultOf(zeroOrgMembersContract.removeMember);
+
+const removeMemberInner$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const auth = get(organizationAuthContext$);
+    const body = await get(removeMemberBody$);
+    signal.throwIfAborted();
+    if (!body.ok) {
+      return body.response;
+    }
+
+    const result = await set(
+      removeZeroOrgMember$,
+      {
+        orgId: auth.orgId,
+        callerUserId: auth.userId,
+        callerRole: auth.orgRole ?? "member",
+        email: body.data.email,
+      },
+      signal,
+    );
+    signal.throwIfAborted();
+
+    if ("status" in result) {
+      return result;
+    }
+
+    return { status: 200 as const, body: result };
+  },
+);
+
+export const zeroOrgMembersRoutes: readonly RouteEntry[] = [
+  {
+    route: zeroOrgMembersContract.removeMember,
+    handler: authRoute(
+      { requireOrganization: true, missingOrganizationStatus: 401 },
+      removeMemberInner$,
+    ),
+  },
+];

--- a/turbo/apps/api/src/signals/services/zero-org-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-org-data.service.ts
@@ -94,6 +94,11 @@ type OrgDeleteErrorResponse =
   | ReturnType<typeof notFound>
   | typeof orgDeleteForbidden;
 
+type RemoveZeroOrgMemberErrorResponse =
+  | ReturnType<typeof badRequestMessage>
+  | ReturnType<typeof notFound>
+  | typeof forbiddenAccess;
+
 interface UpdateZeroOrgArgs {
   readonly orgId: string;
   readonly userId: string;
@@ -112,6 +117,13 @@ interface DeleteZeroOrgArgs {
   readonly orgId: string;
   readonly callerRole: OrgRole | undefined;
   readonly slug: string;
+}
+
+interface RemoveZeroOrgMemberArgs {
+  readonly orgId: string;
+  readonly callerUserId: string;
+  readonly callerRole: OrgRole;
+  readonly email: string;
 }
 
 interface ClerkUpdate {
@@ -398,6 +410,61 @@ export const leaveZeroOrg$ = command(
     signal.throwIfAborted();
 
     return { message: "Left org" };
+  },
+);
+
+export const removeZeroOrgMember$ = command(
+  async (
+    { get, set },
+    args: RemoveZeroOrgMemberArgs,
+    signal: AbortSignal,
+  ): Promise<OrgMessageResponse | RemoveZeroOrgMemberErrorResponse> => {
+    if (args.callerRole !== "admin") {
+      return forbiddenAccess;
+    }
+
+    const client = get(clerk$);
+    const users = await client.users.getUserList({
+      emailAddress: [args.email],
+    });
+    signal.throwIfAborted();
+
+    const target = users.data[0];
+    if (!target) {
+      return notFound("Resource not found");
+    }
+
+    if (target.id === args.callerUserId) {
+      return badRequestMessage("Invalid request");
+    }
+
+    const memberships =
+      await client.organizations.getOrganizationMembershipList({
+        organizationId: args.orgId,
+      });
+    signal.throwIfAborted();
+
+    const membership = memberships.data.find((entry) => {
+      return entry.publicUserData?.userId === target.id;
+    });
+    if (!membership) {
+      return notFound("Resource not found");
+    }
+
+    await client.organizations.deleteOrganizationMembership({
+      organizationId: args.orgId,
+      userId: target.id,
+    });
+    signal.throwIfAborted();
+
+    await cleanupOrgMember(
+      set(writeDb$),
+      { orgId: args.orgId, userId: target.id },
+      signal,
+    );
+    signal.throwIfAborted();
+
+    return { message: `Removed ${args.email} from org` };
   },
 );
 

--- a/turbo/packages/api-contracts/src/contracts/zero-org-members.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-org-members.ts
@@ -55,6 +55,7 @@ export const zeroOrgMembersContract = c.router({
       400: apiErrorSchema,
       401: apiErrorSchema,
       403: apiErrorSchema,
+      404: apiErrorSchema,
       500: apiErrorSchema,
     },
     summary: "Remove a member from the org (zero proxy)",


### PR DESCRIPTION
## Summary
- add the API backend route for DELETE /api/zero/org/members
- move remove-member behavior into a command-backed org data service path
- add API integration coverage for auth, validation, role checks, not-found cases, self-removal, Clerk deletion, and local cleanup

## Validation
- pnpm -F api exec vitest run src/signals/routes/__tests__/zero-org-members.test.ts
- pnpm format
- pnpm -F api lint
- pnpm -F @vm0/api-contracts lint
- pnpm -F api check-types
- pnpm check-types
- pnpm knip --cache
- git diff --check

Closes #12810