### PR TITLE
refactor(api): migrate email unsubscribe get route

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -14,6 +14,7 @@ import { chatThreadsV1Routes } from "./routes/chat-threads-v1";
 import { connectorsTypeAuthorizeRoutes } from "./routes/connectors-type-authorize";
 import { connectorsTypeCallbackRoutes } from "./routes/connectors-type-callback";
 import { deviceTokenRoutes } from "./routes/device-token";
+import { emailUnsubscribeRoutes } from "./routes/email-unsubscribe";
 import { apiHealth$ } from "./routes/health";
 import { healthAuthProbeRoutes } from "./routes/health-auth-probe";
 import { githubOauthRoutes } from "./routes/github-oauth";
@@ -134,6 +135,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...connectorsTypeAuthorizeRoutes,
   ...connectorsTypeCallbackRoutes,
   ...deviceTokenRoutes,
+  ...emailUnsubscribeRoutes,
   ...zeroAgentInstructionsRoutes,
   ...zeroAgentsRoutes,
   ...zeroApiKeysRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/email-unsubscribe.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/email-unsubscribe.test.ts
@@ -1,0 +1,140 @@
+import { randomUUID } from "node:crypto";
+
+import { createStore } from "ccstate";
+import { describe, expect, it } from "vitest";
+import { eq } from "drizzle-orm";
+import { users } from "@vm0/db/schema/user";
+
+import { createApp } from "../../../app-factory";
+import { env } from "../../../lib/env";
+import { testContext } from "../../../__tests__/test-helpers";
+import { writeDb$ } from "../../external/db";
+import { createFixtureTracker } from "./helpers/zero-route-test";
+
+const context = testContext();
+const store = createStore();
+const ROUTE = "/api/email/unsubscribe";
+
+async function createToken(userId: string): Promise<string> {
+  const textEncoder = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    "raw",
+    textEncoder.encode(env("SECRETS_ENCRYPTION_KEY")),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const signature = await crypto.subtle.sign(
+    "HMAC",
+    key,
+    textEncoder.encode(`unsubscribe:${userId}`),
+  );
+  const hmac = Buffer.from(signature).toString("hex").slice(0, 32);
+  return `${userId}.${hmac}`;
+}
+
+async function insertUser(userId: string): Promise<void> {
+  await store
+    .set(writeDb$)
+    .insert(users)
+    .values({ id: userId, emailUnsubscribed: false });
+}
+
+async function findUser(userId: string) {
+  const [row] = await store
+    .set(writeDb$)
+    .select({ emailUnsubscribed: users.emailUnsubscribed })
+    .from(users)
+    .where(eq(users.id, userId))
+    .limit(1);
+  return row;
+}
+
+function requestUnsubscribe(token?: string): Promise<Response> {
+  const search =
+    token === undefined ? "" : `?token=${encodeURIComponent(token)}`;
+  const app = createApp({ signal: context.signal });
+  return Promise.resolve(app.request(`${ROUTE}${search}`, { method: "GET" }));
+}
+
+async function expectJsonError(
+  response: Response,
+  status: number,
+  error: string,
+): Promise<void> {
+  expect(response.status).toBe(status);
+  await expect(response.json()).resolves.toStrictEqual({ error });
+}
+
+describe("GET /api/email/unsubscribe", () => {
+  const trackUser = createFixtureTracker<string>(async (userId) => {
+    await store.set(writeDb$).delete(users).where(eq(users.id, userId));
+  });
+
+  it("returns 400 when token is missing", async () => {
+    const response = await requestUnsubscribe();
+
+    await expectJsonError(response, 400, "Missing token");
+  });
+
+  it("returns 400 when token is invalid", async () => {
+    const response = await requestUnsubscribe("bad.token");
+
+    await expectJsonError(response, 400, "Invalid token");
+  });
+
+  it("returns 400 when token signature is not hex", async () => {
+    const response = await requestUnsubscribe(
+      `user_${randomUUID()}.${"é".repeat(32)}`,
+    );
+
+    await expectJsonError(response, 400, "Invalid token");
+  });
+
+  it("unsubscribes an existing user and returns HTML confirmation", async () => {
+    const userId = `user_${randomUUID()}`;
+    await trackUser(Promise.resolve(userId));
+    await insertUser(userId);
+    const token = await createToken(userId);
+
+    const response = await requestUnsubscribe(token);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toContain("text/html");
+    const html = await response.text();
+    expect(html).toContain("You have been unsubscribed");
+    expect(html).toContain("http://localhost:3001/settings");
+    await expect(findUser(userId)).resolves.toStrictEqual({
+      emailUnsubscribed: true,
+    });
+  });
+
+  it("is idempotent when the same token is used repeatedly", async () => {
+    const userId = `user_${randomUUID()}`;
+    await trackUser(Promise.resolve(userId));
+    await insertUser(userId);
+    const token = await createToken(userId);
+
+    const firstResponse = await requestUnsubscribe(token);
+    const secondResponse = await requestUnsubscribe(token);
+
+    expect(firstResponse.status).toBe(200);
+    expect(secondResponse.status).toBe(200);
+    await expect(findUser(userId)).resolves.toStrictEqual({
+      emailUnsubscribed: true,
+    });
+  });
+
+  it("creates an unsubscribed user row when the user does not exist", async () => {
+    const userId = `user_${randomUUID()}`;
+    await trackUser(Promise.resolve(userId));
+    const token = await createToken(userId);
+
+    const response = await requestUnsubscribe(token);
+
+    expect(response.status).toBe(200);
+    await expect(findUser(userId)).resolves.toStrictEqual({
+      emailUnsubscribed: true,
+    });
+  });
+});

--- a/turbo/apps/api/src/signals/routes/email-unsubscribe.ts
+++ b/turbo/apps/api/src/signals/routes/email-unsubscribe.ts
@@ -1,0 +1,76 @@
+import { command } from "ccstate";
+import { emailUnsubscribeContract } from "@vm0/api-contracts/contracts/email-unsubscribe";
+
+import { env } from "../../lib/env";
+import { queryOf } from "../context/request";
+import {
+  unsubscribeEmailUser$,
+  verifyUnsubscribeToken,
+} from "../services/email-unsubscribe.service";
+import type { RouteEntry } from "../route";
+
+function missingTokenResponse() {
+  return { status: 400 as const, body: { error: "Missing token" } };
+}
+
+function invalidTokenResponse() {
+  return { status: 400 as const, body: { error: "Invalid token" } };
+}
+
+function confirmationHtmlResponse(): Response {
+  const appUrl = env("VM0_WEB_URL");
+  const html = `<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Unsubscribed - VM0</title>
+  <style>
+    body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; background: #f6f9fc; display: flex; align-items: center; justify-content: center; min-height: 100vh; margin: 0; }
+    .card { background: #fff; padding: 32px; border-radius: 8px; max-width: 480px; text-align: center; }
+    h1 { font-size: 20px; color: #111827; margin: 0 0 12px; }
+    p { font-size: 14px; color: #6b7280; line-height: 1.6; margin: 0 0 20px; }
+    a { color: #2563eb; text-decoration: underline; }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <h1>You have been unsubscribed</h1>
+    <p>You will no longer receive system-initiated email notifications from VM0.</p>
+    <p><a href="${appUrl}/settings">Manage notification preferences</a></p>
+  </div>
+</body>
+</html>`;
+
+  return new Response(html, {
+    status: 200,
+    headers: { "Content-Type": "text/html; charset=utf-8" },
+  });
+}
+
+const getEmailUnsubscribe$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const query = get(queryOf(emailUnsubscribeContract.get));
+    if (!query.token) {
+      return missingTokenResponse();
+    }
+
+    const userId = await verifyUnsubscribeToken(query.token);
+    signal.throwIfAborted();
+    if (!userId) {
+      return invalidTokenResponse();
+    }
+
+    await set(unsubscribeEmailUser$, userId, signal);
+    signal.throwIfAborted();
+
+    return confirmationHtmlResponse();
+  },
+);
+
+export const emailUnsubscribeRoutes: readonly RouteEntry[] = [
+  {
+    route: emailUnsubscribeContract.get,
+    handler: getEmailUnsubscribe$,
+  },
+];

--- a/turbo/apps/api/src/signals/services/email-unsubscribe.service.ts
+++ b/turbo/apps/api/src/signals/services/email-unsubscribe.service.ts
@@ -1,0 +1,73 @@
+import { timingSafeEqual } from "node:crypto";
+
+import { command } from "ccstate";
+import { users } from "@vm0/db/schema/user";
+
+import { env } from "../../lib/env";
+import { writeDb$ } from "../external/db";
+import { nowDate } from "../external/time";
+
+const SIGNATURE_HEX_LENGTH = 32;
+const SIGNATURE_HEX_PATTERN = /^[0-9a-f]{32}$/;
+const TOKEN_PAYLOAD_PREFIX = "unsubscribe:";
+
+async function createUnsubscribeTokenSignature(
+  userId: string,
+): Promise<string> {
+  const textEncoder = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    "raw",
+    textEncoder.encode(env("SECRETS_ENCRYPTION_KEY")),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const signature = await crypto.subtle.sign(
+    "HMAC",
+    key,
+    textEncoder.encode(`${TOKEN_PAYLOAD_PREFIX}${userId}`),
+  );
+
+  return Buffer.from(signature).toString("hex").slice(0, SIGNATURE_HEX_LENGTH);
+}
+
+export async function verifyUnsubscribeToken(
+  token: string,
+): Promise<string | null> {
+  const dotIndex = token.lastIndexOf(".");
+  if (dotIndex === -1) {
+    return null;
+  }
+
+  const userId = token.slice(0, dotIndex);
+  const providedHmac = token.slice(dotIndex + 1);
+
+  if (!userId || !providedHmac) {
+    return null;
+  }
+
+  const expectedHmac = await createUnsubscribeTokenSignature(userId);
+  if (!SIGNATURE_HEX_PATTERN.test(providedHmac)) {
+    return null;
+  }
+
+  const isValid = timingSafeEqual(
+    Buffer.from(providedHmac),
+    Buffer.from(expectedHmac),
+  );
+
+  return isValid ? userId : null;
+}
+
+export const unsubscribeEmailUser$ = command(
+  async ({ set }, userId: string, signal: AbortSignal): Promise<void> => {
+    await set(writeDb$)
+      .insert(users)
+      .values({ id: userId, emailUnsubscribed: true })
+      .onConflictDoUpdate({
+        target: users.id,
+        set: { emailUnsubscribed: true, updatedAt: nowDate() },
+      });
+    signal.throwIfAborted();
+  },
+);

--- a/turbo/packages/api-contracts/src/contracts/email-unsubscribe.ts
+++ b/turbo/packages/api-contracts/src/contracts/email-unsubscribe.ts
@@ -1,0 +1,32 @@
+import { z } from "zod";
+
+import { initContract } from "./base";
+
+const c = initContract();
+
+export const emailUnsubscribeQuerySchema = z.object({
+  token: z.string().optional(),
+});
+
+export const emailUnsubscribeErrorSchema = z.object({
+  error: z.string(),
+});
+
+export const emailUnsubscribeContract = c.router({
+  get: {
+    method: "GET",
+    path: "/api/email/unsubscribe",
+    query: emailUnsubscribeQuerySchema,
+    responses: {
+      200: c.otherResponse({
+        contentType: "text/html",
+        body: z.unknown(),
+      }),
+      400: emailUnsubscribeErrorSchema,
+    },
+    summary: "Unsubscribe from system email notifications",
+  },
+});
+
+export type EmailUnsubscribeContract = typeof emailUnsubscribeContract;
+export type EmailUnsubscribeQuery = z.infer<typeof emailUnsubscribeQuerySchema>;

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -214,6 +214,13 @@ export {
   type UserExportStatusResponse,
 } from "./user-export";
 export {
+  emailUnsubscribeContract,
+  emailUnsubscribeErrorSchema,
+  emailUnsubscribeQuerySchema,
+  type EmailUnsubscribeContract,
+  type EmailUnsubscribeQuery,
+} from "./email-unsubscribe";
+export {
   connectorsTypeAuthorizeContract,
   type ConnectorsTypeAuthorizeContract,
 } from "./connectors-type-authorize";


### PR DESCRIPTION
## Summary
- add the API contract and route registration for GET /api/email/unsubscribe
- verify existing unsubscribe tokens against the web HMAC format and upsert email_unsubscribed on success
- add integration coverage for missing, invalid, non-hex, existing-user, idempotent, and missing-user cases

Closes #12822

## Testing
- cd turbo && pnpm format
- cd turbo && pnpm lint
- cd turbo && pnpm check-types
- cd turbo && pnpm knip --no-progress
- cd turbo && pnpm -F api exec vitest run src/signals/routes/__tests__/email-unsubscribe.test.ts
- cd turbo && pnpm vitest