### PR TITLE
refactor(api): migrate internal event consumers

### DIFF
--- a/turbo/apps/api/src/__tests__/mocks.ts
+++ b/turbo/apps/api/src/__tests__/mocks.ts
@@ -5,10 +5,13 @@ import { vi, type Mock } from "vitest";
 import { mockStripeClient } from "../signals/external/stripe-client";
 
 type AsyncMock = Mock<(...args: unknown[]) => Promise<unknown>>;
+type BooleanMock = Mock<(...args: unknown[]) => boolean>;
 type SyncMock = Mock<(...args: unknown[]) => void>;
 
 export interface ApiTestMocks {
   readonly axiom: {
+    readonly flush: AsyncMock;
+    readonly ingest: BooleanMock;
     readonly query: AsyncMock;
   };
   readonly axiomLogging: {
@@ -124,6 +127,8 @@ export interface ApiTestMocks {
 
 const apiTestMocks: ApiTestMocks = vi.hoisted((): ApiTestMocks => {
   const axiom = {
+    flush: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
+    ingest: vi.fn<(...args: unknown[]) => boolean>(),
     query: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
   };
 
@@ -476,6 +481,15 @@ vi.mock("../signals/external/axiom", () => {
     getDatasetName: (name: string) => {
       return name;
     },
+    ingestToAxiom: (
+      dataset: string,
+      events: readonly Record<string, unknown>[],
+    ) => {
+      return apiTestMocks.axiom.ingest(dataset, events);
+    },
+    flushAxiom: (options?: unknown) => {
+      return apiTestMocks.axiom.flush(options);
+    },
   };
 });
 
@@ -513,6 +527,9 @@ export function resetApiTestMocks(): void {
   apiTestMocks.ably.publish.mockReset();
   apiTestMocks.ably.publish.mockResolvedValue(undefined);
   apiTestMocks.ably.createTokenRequest.mockReset();
+  apiTestMocks.axiom.flush.mockReset();
+  apiTestMocks.axiom.ingest.mockReset();
+  apiTestMocks.axiom.ingest.mockReturnValue(true);
   apiTestMocks.axiom.query.mockReset();
   apiTestMocks.axiomLogging.debug.mockReset();
   apiTestMocks.axiomLogging.info.mockReset();

--- a/turbo/apps/api/src/signals/external/axiom-datasets.ts
+++ b/turbo/apps/api/src/signals/external/axiom-datasets.ts
@@ -9,6 +9,14 @@ function isSessionsDataset(datasetName: string | null): boolean {
   return datasetName?.includes("agent-run-events") ?? false;
 }
 
+export function getAxiomTokenEnvNameForDataset(
+  datasetName: string,
+): AxiomTokenEnvName {
+  return isSessionsDataset(datasetName)
+    ? "AXIOM_TOKEN_SESSIONS"
+    : "AXIOM_TOKEN_TELEMETRY";
+}
+
 export function getAxiomTokenEnvNameForApl(apl: string): AxiomTokenEnvName {
   return isSessionsDataset(extractDatasetFromApl(apl))
     ? "AXIOM_TOKEN_SESSIONS"

--- a/turbo/apps/api/src/signals/external/axiom.ts
+++ b/turbo/apps/api/src/signals/external/axiom.ts
@@ -1,8 +1,11 @@
 import { computed, type Computed } from "ccstate";
 import { Axiom } from "@axiomhq/js";
-import { env } from "../../lib/env";
+import { env, optionalEnv } from "../../lib/env";
 import { singleton } from "../../lib/singleton";
-import { getAxiomTokenEnvNameForApl } from "./axiom-datasets";
+import {
+  getAxiomTokenEnvNameForApl,
+  getAxiomTokenEnvNameForDataset,
+} from "./axiom-datasets";
 
 const sessionsAxiomClient = singleton(() => {
   return new Axiom({ token: env("AXIOM_TOKEN_SESSIONS") });
@@ -22,6 +25,79 @@ function axiomClientForApl(apl: string): Axiom {
     return sessionsAxiomClient();
   }
   return telemetryAxiomClient();
+}
+
+function axiomClientForDataset(dataset: string): Axiom | null {
+  const tokenEnvName = getAxiomTokenEnvNameForDataset(dataset);
+  if (!optionalEnv(tokenEnvName)) {
+    return null;
+  }
+  if (tokenEnvName === "AXIOM_TOKEN_SESSIONS") {
+    return sessionsAxiomClient();
+  }
+  return telemetryAxiomClient();
+}
+
+export function ingestToAxiom(
+  dataset: string,
+  events: readonly Record<string, unknown>[],
+): boolean {
+  const client = axiomClientForDataset(dataset);
+  if (!client) {
+    return false;
+  }
+  client.ingest(dataset, [...events]);
+  return true;
+}
+
+interface FlushAxiomOptions {
+  readonly throwOnError?: boolean;
+  readonly client?: "all" | "sessions" | "telemetry";
+}
+
+export async function flushAxiom(
+  options: FlushAxiomOptions = {},
+): Promise<void> {
+  const client = options.client ?? "all";
+  const flushes: {
+    readonly name: string;
+    readonly promise?: Promise<void>;
+  }[] = [];
+
+  if (client === "all" || client === "sessions") {
+    flushes.push({
+      name: "sessions",
+      promise: optionalEnv("AXIOM_TOKEN_SESSIONS")
+        ? sessionsAxiomClient().flush()
+        : undefined,
+    });
+  }
+  if (client === "all" || client === "telemetry") {
+    flushes.push({
+      name: "telemetry",
+      promise: optionalEnv("AXIOM_TOKEN_TELEMETRY")
+        ? telemetryAxiomClient().flush()
+        : undefined,
+    });
+  }
+
+  const results = await Promise.allSettled(
+    flushes.map((flush) => {
+      return flush.promise;
+    }),
+  );
+  const errors: unknown[] = [];
+  for (const [index, result] of results.entries()) {
+    if (result.status === "rejected") {
+      errors.push({
+        client: flushes[index]?.name ?? "unknown",
+        error: result.reason,
+      });
+    }
+  }
+  if (options.throwOnError && errors.length > 0) {
+    throw new AggregateError(errors, "Axiom flush failed");
+  }
 }
 
 // Minimal options surface — only the `noCache` knob is wired today (used by

--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -17,7 +17,10 @@ import { deviceTokenRoutes } from "./routes/device-token";
 import { apiHealth$ } from "./routes/health";
 import { healthAuthProbeRoutes } from "./routes/health-auth-probe";
 import { githubOauthRoutes } from "./routes/github-oauth";
+import { internalEventConsumerAxiomRoutes } from "./routes/internal-event-consumers-axiom";
+import { internalEventConsumerChatAssistantRoutes } from "./routes/internal-event-consumers-chat-assistant";
 import { internalEventConsumerTelegramTypingRoutes } from "./routes/internal-event-consumers-telegram-typing";
+import { internalEventConsumerVoiceChatRoutes } from "./routes/internal-event-consumers-voice-chat";
 import { logsSearchRoutes } from "./routes/logs-search";
 import { modelStatsRoutes } from "./routes/model-stats";
 import { usageRoutes } from "./routes/usage";
@@ -121,7 +124,10 @@ export const ROUTES: readonly RouteEntry[] = [
   ...authMeRoutes,
   ...healthAuthProbeRoutes,
   ...githubOauthRoutes,
+  ...internalEventConsumerAxiomRoutes,
+  ...internalEventConsumerChatAssistantRoutes,
   ...internalEventConsumerTelegramTypingRoutes,
+  ...internalEventConsumerVoiceChatRoutes,
   ...logsSearchRoutes,
   ...usageRoutes,
   ...userExportRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-voice-chat.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-voice-chat.ts
@@ -64,6 +64,7 @@ export const seedVoiceChatFixture$ = command(
 
 interface TaskSeed {
   readonly status: "pending" | "queued" | "running" | "done" | "failed";
+  readonly runId?: string | null;
   readonly prompt?: string;
   readonly result?: string | null;
   readonly assistantMessages?: readonly {
@@ -90,6 +91,7 @@ export const seedVoiceChatTask$ = command(
       callId: `call_${randomUUID()}`,
       prompt: values.prompt ?? "test",
       status: values.status,
+      ...(values.runId !== undefined ? { runId: values.runId } : {}),
       ...(values.result !== undefined ? { result: values.result } : {}),
       ...(values.assistantMessages !== undefined
         ? { assistantMessages: [...values.assistantMessages] }

--- a/turbo/apps/api/src/signals/routes/__tests__/internal-event-consumers.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/internal-event-consumers.test.ts
@@ -1,0 +1,547 @@
+import { createStore } from "ccstate";
+import { and, eq } from "drizzle-orm";
+import { beforeEach, describe, expect, it } from "vitest";
+import { chatMessages } from "@vm0/db/schema/chat-message";
+import { voiceChatTasks } from "@vm0/db/schema/voice-chat";
+
+import { createApp } from "../../../app-factory";
+import { testContext } from "../../../__tests__/test-helpers";
+import { computeHmacSignature } from "../../../lib/event-consumer/hmac";
+import { now } from "../../../lib/time";
+import { writeDb$ } from "../../external/db";
+import {
+  addRunToThread$,
+  deleteZeroChatThread$,
+  seedZeroChatThread$,
+  type ZeroChatThreadFixture,
+} from "./helpers/zero-chat-threads";
+import {
+  deleteVoiceChatFixture$,
+  seedVoiceChatFixture$,
+  seedVoiceChatTask$,
+  type VoiceChatFixture,
+} from "./helpers/zero-voice-chat";
+import { createFixtureTracker } from "./helpers/zero-route-test";
+import { seedRun$ } from "./helpers/zero-usage-insight";
+
+const SECRETS_ENCRYPTION_KEY =
+  "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+const AXIOM_PATH = "/api/internal/event-consumers/axiom";
+const CHAT_ASSISTANT_PATH = "/api/internal/event-consumers/chat-assistant";
+const VOICE_CHAT_PATH = "/api/internal/event-consumers/voice-chat";
+
+const context = testContext();
+const store = createStore();
+
+const trackChatFixture = createFixtureTracker<ZeroChatThreadFixture>(
+  (fixture) => {
+    return store.set(deleteZeroChatThread$, fixture, context.signal);
+  },
+);
+
+const trackVoiceFixture = createFixtureTracker<VoiceChatFixture>((fixture) => {
+  return store.set(deleteVoiceChatFixture$, fixture, context.signal);
+});
+
+function signedHeaders(
+  rawBody: string,
+  secret: string = SECRETS_ENCRYPTION_KEY,
+): Record<string, string> {
+  const ts = Math.floor(now() / 1000);
+  return {
+    "X-VM0-Signature": computeHmacSignature(rawBody, secret, ts),
+    "X-VM0-Timestamp": String(ts),
+    "Content-Type": "application/json",
+  };
+}
+
+function postEventConsumer(
+  path: string,
+  body: unknown,
+  secret?: string,
+): Promise<Response> {
+  const app = createApp({ signal: context.signal });
+  const rawBody = JSON.stringify(body);
+  return Promise.resolve(
+    app.request(path, {
+      method: "POST",
+      headers: signedHeaders(rawBody, secret),
+      body: rawBody,
+    }),
+  );
+}
+
+function buildAssistantEvent(
+  sequenceNumber: number,
+  text: string,
+): Record<string, unknown> {
+  return {
+    type: "assistant",
+    sequenceNumber,
+    message: {
+      id: `msg_${sequenceNumber}`,
+      content: [{ type: "text", text }],
+    },
+  };
+}
+
+function buildToolUseEvent(sequenceNumber: number): Record<string, unknown> {
+  return {
+    type: "assistant",
+    sequenceNumber,
+    message: {
+      id: `msg_${sequenceNumber}`,
+      content: [{ type: "tool_use", id: "tool_1", name: "bash", input: {} }],
+    },
+  };
+}
+
+function buildCodexAgentMessageEvent(
+  sequenceNumber: number,
+  text: string,
+): Record<string, unknown> {
+  return {
+    type: "item.completed",
+    sequenceNumber,
+    item: {
+      id: `item_${sequenceNumber}`,
+      type: "agent_message",
+      text,
+    },
+  };
+}
+
+function buildCodexCommandExecutionEvent(
+  sequenceNumber: number,
+): Record<string, unknown> {
+  return {
+    type: "item.completed",
+    sequenceNumber,
+    item: {
+      id: `cmd_${sequenceNumber}`,
+      type: "command_execution",
+      command: "ls",
+      exit_code: 0,
+      output: "README.md",
+    },
+  };
+}
+
+async function seedChatThreadRun(): Promise<
+  ZeroChatThreadFixture & { readonly runId: string }
+> {
+  const fixture = await trackChatFixture(
+    store.set(seedZeroChatThread$, {}, context.signal),
+  );
+  const { runId } = await store.set(
+    seedRun$,
+    {
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      composeId: fixture.composeId,
+    },
+    context.signal,
+  );
+  await store.set(
+    addRunToThread$,
+    { threadId: fixture.threadId, runId },
+    context.signal,
+  );
+  return { ...fixture, runId };
+}
+
+async function seedVoiceChatTaskRun(
+  status: "pending" | "queued" | "running" = "queued",
+): Promise<{
+  readonly chatFixture: ZeroChatThreadFixture;
+  readonly voiceFixture: VoiceChatFixture;
+  readonly sessionId: string;
+  readonly taskId: string;
+  readonly runId: string;
+}> {
+  const chatFixture = await trackChatFixture(
+    store.set(seedZeroChatThread$, {}, context.signal),
+  );
+  const { runId } = await store.set(
+    seedRun$,
+    {
+      orgId: chatFixture.orgId,
+      userId: chatFixture.userId,
+      composeId: chatFixture.composeId,
+      status: "queued",
+    },
+    context.signal,
+  );
+  const voiceFixture = await trackVoiceFixture(
+    store.set(
+      seedVoiceChatFixture$,
+      {
+        sessions: [{ orgId: chatFixture.orgId, userId: chatFixture.userId }],
+      },
+      context.signal,
+    ),
+  );
+  const sessionId = voiceFixture.sessionIds[0]!;
+  const taskId = await store.set(
+    seedVoiceChatTask$,
+    sessionId,
+    { status, runId },
+    context.signal,
+  );
+  return { chatFixture, voiceFixture, sessionId, taskId, runId };
+}
+
+function readAssistantMessages(runId: string): Promise<
+  readonly {
+    readonly content: string | null;
+    readonly sequenceNumber: number | null;
+    readonly runEventId: string | null;
+  }[]
+> {
+  const writeDb = store.set(writeDb$);
+  return writeDb
+    .select({
+      content: chatMessages.content,
+      sequenceNumber: chatMessages.sequenceNumber,
+      runEventId: chatMessages.runEventId,
+    })
+    .from(chatMessages)
+    .where(
+      and(eq(chatMessages.runId, runId), eq(chatMessages.role, "assistant")),
+    );
+}
+
+async function readVoiceChatTask(
+  taskId: string,
+): Promise<typeof voiceChatTasks.$inferSelect | undefined> {
+  const writeDb = store.set(writeDb$);
+  const [row] = await writeDb
+    .select()
+    .from(voiceChatTasks)
+    .where(eq(voiceChatTasks.id, taskId))
+    .limit(1);
+  return row;
+}
+
+beforeEach(() => {
+  context.mocks.ably.publish.mockResolvedValue(undefined);
+  context.mocks.axiom.flush.mockResolvedValue(undefined);
+  context.mocks.axiom.ingest.mockReturnValue(true);
+});
+
+describe("POST /api/internal/event-consumers/axiom", () => {
+  it("rejects invalid signatures", async () => {
+    const response = await postEventConsumer(
+      AXIOM_PATH,
+      { runId: "run-id", events: [], context: { userId: "u", orgId: "o" } },
+      "wrong-key",
+    );
+
+    expect(response.status).toBe(401);
+    const body = (await response.json()) as { error: string };
+    expect(body.error).toContain("Invalid signature");
+  });
+
+  it("ingests and flushes agent run events", async () => {
+    const response = await postEventConsumer(AXIOM_PATH, {
+      runId: "run_123",
+      events: [
+        { type: "assistant", sequenceNumber: 1, message: { content: [] } },
+        { type: "tool_result", sequenceNumber: 2, result: "ok" },
+      ],
+      context: { userId: "user_123", orgId: "org_123" },
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toStrictEqual({ received: 2 });
+    expect(context.mocks.axiom.ingest).toHaveBeenCalledWith(
+      "agent-run-events",
+      [
+        {
+          runId: "run_123",
+          userId: "user_123",
+          sequenceNumber: 1,
+          eventType: "assistant",
+          eventData: {
+            type: "assistant",
+            sequenceNumber: 1,
+            message: { content: [] },
+          },
+        },
+        {
+          runId: "run_123",
+          userId: "user_123",
+          sequenceNumber: 2,
+          eventType: "tool_result",
+          eventData: {
+            type: "tool_result",
+            sequenceNumber: 2,
+            result: "ok",
+          },
+        },
+      ],
+    );
+    expect(context.mocks.axiom.flush).toHaveBeenCalledWith({
+      throwOnError: true,
+      client: "sessions",
+    });
+  });
+
+  it("returns 503 when Axiom ingest is not configured", async () => {
+    context.mocks.axiom.ingest.mockReturnValue(false);
+
+    const response = await postEventConsumer(AXIOM_PATH, {
+      runId: "run_123",
+      events: [{ type: "assistant", sequenceNumber: 1 }],
+      context: { userId: "user_123", orgId: "org_123" },
+    });
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toStrictEqual({
+      error: "Axiom agent-run-events dataset is not configured",
+    });
+    expect(context.mocks.axiom.flush).not.toHaveBeenCalled();
+  });
+
+  it("returns 503 when Axiom flush fails", async () => {
+    context.mocks.axiom.flush.mockRejectedValue(new Error("flush failed"));
+
+    const response = await postEventConsumer(AXIOM_PATH, {
+      runId: "run_123",
+      events: [{ type: "assistant", sequenceNumber: 1 }],
+      context: { userId: "user_123", orgId: "org_123" },
+    });
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toStrictEqual({
+      error: "Axiom agent-run-events flush failed",
+    });
+  });
+});
+
+describe("POST /api/internal/event-consumers/chat-assistant", () => {
+  it("rejects invalid signatures", async () => {
+    const response = await postEventConsumer(
+      CHAT_ASSISTANT_PATH,
+      { runId: "run-id", events: [], context: { userId: "u", orgId: "o" } },
+      "wrong-key",
+    );
+
+    expect(response.status).toBe(401);
+  });
+
+  it("returns zero when no events contain assistant text", async () => {
+    const fixture = await seedChatThreadRun();
+
+    const response = await postEventConsumer(CHAT_ASSISTANT_PATH, {
+      runId: fixture.runId,
+      events: [buildToolUseEvent(1)],
+      context: { userId: fixture.userId, orgId: fixture.orgId },
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toStrictEqual({ processed: 0 });
+    expect(context.mocks.ably.publish).not.toHaveBeenCalled();
+  });
+
+  it("returns zero when the run is not tied to a chat thread", async () => {
+    const fixture = await trackChatFixture(
+      store.set(seedZeroChatThread$, {}, context.signal),
+    );
+    const { runId } = await store.set(
+      seedRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        composeId: fixture.composeId,
+      },
+      context.signal,
+    );
+
+    const response = await postEventConsumer(CHAT_ASSISTANT_PATH, {
+      runId,
+      events: [buildAssistantEvent(1, "Hello!")],
+      context: { userId: fixture.userId, orgId: fixture.orgId },
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toStrictEqual({ processed: 0 });
+    expect(context.mocks.ably.publish).not.toHaveBeenCalled();
+  });
+
+  it("persists Anthropic assistant text and publishes chat signals", async () => {
+    const fixture = await seedChatThreadRun();
+
+    const response = await postEventConsumer(CHAT_ASSISTANT_PATH, {
+      runId: fixture.runId,
+      events: [buildAssistantEvent(1, "Hello from the assistant!")],
+      context: { userId: fixture.userId, orgId: fixture.orgId },
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toStrictEqual({ processed: 1 });
+    await expect(readAssistantMessages(fixture.runId)).resolves.toStrictEqual([
+      {
+        content: "Hello from the assistant!",
+        sequenceNumber: 1,
+        runEventId: "msg_1",
+      },
+    ]);
+    expect(context.mocks.ably.publish).toHaveBeenCalledWith(
+      `chatThreadMessageCreated:${fixture.threadId}`,
+      null,
+    );
+    expect(context.mocks.ably.publish).toHaveBeenCalledWith(
+      "threadListChanged",
+      null,
+    );
+  });
+
+  it("persists Codex agent_message text from item.completed events", async () => {
+    const fixture = await seedChatThreadRun();
+
+    const response = await postEventConsumer(CHAT_ASSISTANT_PATH, {
+      runId: fixture.runId,
+      events: [buildCodexAgentMessageEvent(1, "Codex says hi")],
+      context: { userId: fixture.userId, orgId: fixture.orgId },
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toStrictEqual({ processed: 1 });
+    await expect(readAssistantMessages(fixture.runId)).resolves.toStrictEqual([
+      {
+        content: "Codex says hi",
+        sequenceNumber: 1,
+        runEventId: "item_1",
+      },
+    ]);
+  });
+
+  it("ignores non-agent_message Codex item.completed events", async () => {
+    const fixture = await seedChatThreadRun();
+
+    const response = await postEventConsumer(CHAT_ASSISTANT_PATH, {
+      runId: fixture.runId,
+      events: [buildCodexCommandExecutionEvent(1)],
+      context: { userId: fixture.userId, orgId: fixture.orgId },
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toStrictEqual({ processed: 0 });
+    await expect(readAssistantMessages(fixture.runId)).resolves.toStrictEqual(
+      [],
+    );
+  });
+});
+
+describe("POST /api/internal/event-consumers/voice-chat", () => {
+  it("rejects invalid signatures", async () => {
+    const response = await postEventConsumer(
+      VOICE_CHAT_PATH,
+      { runId: "run-id", events: [], context: { userId: "u", orgId: "o" } },
+      "wrong-key",
+    );
+
+    expect(response.status).toBe(401);
+  });
+
+  it("no-ops for runs unrelated to any voice-chat task", async () => {
+    const fixture = await trackChatFixture(
+      store.set(seedZeroChatThread$, {}, context.signal),
+    );
+    const { runId } = await store.set(
+      seedRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        composeId: fixture.composeId,
+      },
+      context.signal,
+    );
+
+    const response = await postEventConsumer(VOICE_CHAT_PATH, {
+      runId,
+      events: [buildAssistantEvent(1, "hello")],
+      context: { userId: fixture.userId, orgId: fixture.orgId },
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toStrictEqual({ processed: 1 });
+    expect(context.mocks.ably.publish).not.toHaveBeenCalled();
+  });
+
+  it("flips queued tasks to running and appends assistant text", async () => {
+    const fixture = await seedVoiceChatTaskRun("queued");
+
+    const response = await postEventConsumer(VOICE_CHAT_PATH, {
+      runId: fixture.runId,
+      events: [buildAssistantEvent(1, "hello")],
+      context: {
+        userId: fixture.chatFixture.userId,
+        orgId: fixture.chatFixture.orgId,
+      },
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toStrictEqual({ processed: 1 });
+    const row = await readVoiceChatTask(fixture.taskId);
+    expect(row?.status).toBe("running");
+    expect(row?.startedAt).not.toBeNull();
+    expect(row?.assistantMessages).toStrictEqual([
+      { type: "assistant", content: "hello", at: expect.any(String) },
+    ]);
+    expect(context.mocks.ably.publish).toHaveBeenCalledWith(
+      `voice-chat:${fixture.sessionId}`,
+      null,
+    );
+  });
+
+  it("keeps running status and appends subsequent assistant text", async () => {
+    const fixture = await seedVoiceChatTaskRun("queued");
+
+    await postEventConsumer(VOICE_CHAT_PATH, {
+      runId: fixture.runId,
+      events: [buildAssistantEvent(1, "one")],
+      context: {
+        userId: fixture.chatFixture.userId,
+        orgId: fixture.chatFixture.orgId,
+      },
+    });
+    await postEventConsumer(VOICE_CHAT_PATH, {
+      runId: fixture.runId,
+      events: [buildAssistantEvent(2, "two")],
+      context: {
+        userId: fixture.chatFixture.userId,
+        orgId: fixture.chatFixture.orgId,
+      },
+    });
+
+    const row = await readVoiceChatTask(fixture.taskId);
+    expect(row?.status).toBe("running");
+    expect(
+      row?.assistantMessages.map((entry) => {
+        return entry.content;
+      }),
+    ).toStrictEqual(["one", "two"]);
+  });
+
+  it("flips status without appending for tool-use-only assistant events", async () => {
+    const fixture = await seedVoiceChatTaskRun("queued");
+
+    const response = await postEventConsumer(VOICE_CHAT_PATH, {
+      runId: fixture.runId,
+      events: [buildToolUseEvent(1)],
+      context: {
+        userId: fixture.chatFixture.userId,
+        orgId: fixture.chatFixture.orgId,
+      },
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toStrictEqual({ processed: 0 });
+    const row = await readVoiceChatTask(fixture.taskId);
+    expect(row?.status).toBe("running");
+    expect(row?.assistantMessages).toStrictEqual([]);
+  });
+});

--- a/turbo/apps/api/src/signals/routes/internal-event-consumers-axiom.ts
+++ b/turbo/apps/api/src/signals/routes/internal-event-consumers-axiom.ts
@@ -1,0 +1,63 @@
+import { command } from "ccstate";
+import { internalEventConsumerAxiomContract } from "@vm0/api-contracts/contracts/internal-event-consumers";
+
+import {
+  eventConsumerPayload$,
+  eventConsumerRoute,
+} from "../../lib/event-consumer/route";
+import { flushAxiom, getDatasetName, ingestToAxiom } from "../external/axiom";
+import type { RouteEntry } from "../route";
+import { safeAsync } from "../utils";
+
+const AGENT_RUN_EVENTS_DATASET = "agent-run-events";
+
+const ingestAxiomEvents$ = command(async ({ get }, signal: AbortSignal) => {
+  const payload = get(eventConsumerPayload$);
+  signal.throwIfAborted();
+
+  const axiomEvents = payload.events.map((event) => {
+    return {
+      runId: payload.runId,
+      userId: payload.context.userId,
+      sequenceNumber: event.sequenceNumber,
+      eventType: event.type,
+      eventData: event,
+    };
+  });
+
+  const ingested = ingestToAxiom(
+    getDatasetName(AGENT_RUN_EVENTS_DATASET),
+    axiomEvents,
+  );
+  if (!ingested) {
+    return {
+      status: 503 as const,
+      body: {
+        error: "Axiom agent-run-events dataset is not configured",
+      },
+    };
+  }
+
+  const flushed = await safeAsync(() => {
+    return flushAxiom({ throwOnError: true, client: "sessions" });
+  });
+  signal.throwIfAborted();
+  if ("error" in flushed) {
+    return {
+      status: 503 as const,
+      body: { error: "Axiom agent-run-events flush failed" },
+    };
+  }
+
+  return {
+    status: 200 as const,
+    body: { received: payload.events.length },
+  };
+});
+
+export const internalEventConsumerAxiomRoutes: readonly RouteEntry[] = [
+  {
+    route: internalEventConsumerAxiomContract.ingest,
+    handler: eventConsumerRoute(ingestAxiomEvents$),
+  },
+];

--- a/turbo/apps/api/src/signals/routes/internal-event-consumers-chat-assistant.ts
+++ b/turbo/apps/api/src/signals/routes/internal-event-consumers-chat-assistant.ts
@@ -1,0 +1,128 @@
+import { command } from "ccstate";
+import { internalEventConsumerChatAssistantContract } from "@vm0/api-contracts/contracts/internal-event-consumers";
+
+import {
+  eventConsumerPayload$,
+  eventConsumerRoute,
+} from "../../lib/event-consumer/route";
+import type { AgentEvent } from "../../lib/event-consumer/verify";
+import type { RouteEntry } from "../route";
+import {
+  chatThreadForRun,
+  insertAssistantEventMessages$,
+} from "../services/zero-chat-thread.service";
+
+function recordOf(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function anthropicMessageText(event: AgentEvent): string | null {
+  const message = recordOf(event.message);
+  const content = message?.content;
+  if (!Array.isArray(content)) {
+    return null;
+  }
+
+  const parts: string[] = [];
+  for (const block of content) {
+    const record = recordOf(block);
+    if (record?.type === "text" && typeof record.text === "string") {
+      parts.push(record.text);
+    }
+  }
+  if (parts.length === 0) {
+    return null;
+  }
+  return parts.length === 1 ? parts[0]! : parts.join("\n\n");
+}
+
+function codexAgentMessageText(event: AgentEvent): string | null {
+  if (event.type !== "item.completed") {
+    return null;
+  }
+  const item = recordOf(event.item);
+  if (
+    item?.type !== "agent_message" ||
+    typeof item.text !== "string" ||
+    item.text.length === 0
+  ) {
+    return null;
+  }
+  return item.text;
+}
+
+function eventText(event: AgentEvent): string | null {
+  const fromMessage = anthropicMessageText(event);
+  if (fromMessage !== null) {
+    return fromMessage;
+  }
+  return codexAgentMessageText(event);
+}
+
+function eventMessageId(event: AgentEvent): string | undefined {
+  const message = recordOf(event.message);
+  if (typeof message?.id === "string") {
+    return message.id;
+  }
+
+  const item = recordOf(event.item);
+  if (typeof item?.id === "string") {
+    return item.id;
+  }
+
+  return undefined;
+}
+
+const processChatAssistantEvents$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const payload = get(eventConsumerPayload$);
+    signal.throwIfAborted();
+
+    const items = payload.events.flatMap((event) => {
+      const text = eventText(event);
+      if (text === null) {
+        return [];
+      }
+      return [
+        {
+          sequenceNumber: event.sequenceNumber,
+          content: text,
+          runEventId: eventMessageId(event),
+        },
+      ];
+    });
+
+    if (items.length === 0) {
+      return { status: 200 as const, body: { processed: 0 } };
+    }
+
+    const thread = await get(chatThreadForRun(payload.runId));
+    signal.throwIfAborted();
+    if (!thread) {
+      return { status: 200 as const, body: { processed: 0 } };
+    }
+
+    const written = await set(
+      insertAssistantEventMessages$,
+      {
+        runId: payload.runId,
+        threadId: thread.chatThreadId,
+        userId: thread.userId,
+        items,
+      },
+      signal,
+    );
+    signal.throwIfAborted();
+
+    return { status: 200 as const, body: { processed: written } };
+  },
+);
+
+export const internalEventConsumerChatAssistantRoutes: readonly RouteEntry[] = [
+  {
+    route: internalEventConsumerChatAssistantContract.process,
+    handler: eventConsumerRoute(processChatAssistantEvents$),
+  },
+];

--- a/turbo/apps/api/src/signals/routes/internal-event-consumers-voice-chat.ts
+++ b/turbo/apps/api/src/signals/routes/internal-event-consumers-voice-chat.ts
@@ -1,0 +1,92 @@
+import { command } from "ccstate";
+import type { VoiceChatTaskResultEntry } from "@vm0/api-contracts/contracts/zero-voice-chat";
+import { internalEventConsumerVoiceChatContract } from "@vm0/api-contracts/contracts/internal-event-consumers";
+
+import {
+  eventConsumerPayload$,
+  eventConsumerRoute,
+} from "../../lib/event-consumer/route";
+import type { AgentEvent } from "../../lib/event-consumer/verify";
+import { nowDate } from "../../lib/time";
+import { publishUserSignal } from "../external/realtime";
+import type { RouteEntry } from "../route";
+import {
+  appendVoiceChatTaskAssistantResult$,
+  markVoiceChatTaskRunningIfQueued$,
+} from "../services/zero-voice-chat.service";
+
+function recordOf(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function eventText(event: AgentEvent): string | null {
+  const message = recordOf(event.message);
+  const content = message?.content;
+  if (!Array.isArray(content)) {
+    return null;
+  }
+
+  const parts: string[] = [];
+  for (const block of content) {
+    const record = recordOf(block);
+    if (record?.type === "text" && typeof record.text === "string") {
+      parts.push(record.text);
+    }
+  }
+  if (parts.length === 0) {
+    return null;
+  }
+  return parts.length === 1 ? parts[0]! : parts.join("\n\n");
+}
+
+const processVoiceChatEvents$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const payload = get(eventConsumerPayload$);
+    signal.throwIfAborted();
+
+    const timestamp = nowDate().toISOString();
+    const entries: VoiceChatTaskResultEntry[] = payload.events.flatMap(
+      (event) => {
+        const text = eventText(event);
+        if (text === null) {
+          return [];
+        }
+        return [{ type: "assistant", content: text, at: timestamp }];
+      },
+    );
+
+    const running = await set(
+      markVoiceChatTaskRunningIfQueued$,
+      payload.runId,
+      signal,
+    );
+    signal.throwIfAborted();
+
+    const appended =
+      entries.length > 0
+        ? await set(
+            appendVoiceChatTaskAssistantResult$,
+            { runId: payload.runId, entries },
+            signal,
+          )
+        : null;
+    signal.throwIfAborted();
+
+    const touch = running ?? appended;
+    if (touch) {
+      await publishUserSignal([touch.userId], `voice-chat:${touch.sessionId}`);
+      signal.throwIfAborted();
+    }
+
+    return { status: 200 as const, body: { processed: entries.length } };
+  },
+);
+
+export const internalEventConsumerVoiceChatRoutes: readonly RouteEntry[] = [
+  {
+    route: internalEventConsumerVoiceChatContract.process,
+    handler: eventConsumerRoute(processVoiceChatEvents$),
+  },
+];

--- a/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
@@ -1196,6 +1196,85 @@ export const insertIntegrationChatMessage$ = command(
   },
 );
 
+export function chatThreadForRun(
+  runId: string,
+): Computed<
+  Promise<{ readonly chatThreadId: string; readonly userId: string } | null>
+> {
+  return computed(async (get) => {
+    const db = get(db$);
+    const [row] = await db
+      .select({
+        chatThreadId: zeroRuns.chatThreadId,
+        userId: chatThreads.userId,
+      })
+      .from(zeroRuns)
+      .innerJoin(chatThreads, eq(zeroRuns.chatThreadId, chatThreads.id))
+      .where(eq(zeroRuns.id, runId))
+      .limit(1);
+
+    if (!row?.chatThreadId) {
+      return null;
+    }
+    return { chatThreadId: row.chatThreadId, userId: row.userId };
+  });
+}
+
+export const insertAssistantEventMessages$ = command(
+  async (
+    { set },
+    args: {
+      readonly runId: string;
+      readonly threadId: string;
+      readonly userId: string;
+      readonly items: readonly {
+        readonly sequenceNumber: number;
+        readonly content: string;
+        readonly runEventId?: string;
+      }[];
+    },
+    signal: AbortSignal,
+  ): Promise<number> => {
+    if (args.items.length === 0) {
+      return 0;
+    }
+
+    const writeDb = set(writeDb$);
+    const rows = await writeDb
+      .insert(chatMessages)
+      .values(
+        args.items.map((item) => {
+          return {
+            chatThreadId: args.threadId,
+            runId: args.runId,
+            role: "assistant",
+            content: item.content,
+            sequenceNumber: item.sequenceNumber,
+            runEventId: item.runEventId ?? null,
+          };
+        }),
+      )
+      .onConflictDoNothing({
+        target: [chatMessages.runId, chatMessages.sequenceNumber],
+      })
+      .returning({ id: chatMessages.id });
+    signal.throwIfAborted();
+
+    if (rows.length > 0) {
+      await publishUserSignal(
+        [args.userId],
+        `chatThreadMessageCreated:${args.threadId}`,
+      );
+      signal.throwIfAborted();
+
+      await publishThreadListChanged(args.userId);
+      signal.throwIfAborted();
+    }
+
+    return rows.length;
+  },
+);
+
 export const deleteChatThread$ = command(
   async (
     { set },

--- a/turbo/apps/api/src/signals/services/zero-voice-chat.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-voice-chat.service.ts
@@ -1,12 +1,14 @@
-import { computed, type Computed } from "ccstate";
+import { command, computed, type Computed } from "ccstate";
 import type {
   VoiceChatSession,
   VoiceChatTask,
+  VoiceChatTaskResultEntry,
 } from "@vm0/api-contracts/contracts/zero-voice-chat";
 import { voiceChatSessions, voiceChatTasks } from "@vm0/db/schema/voice-chat";
-import { and, asc, desc, eq, inArray } from "drizzle-orm";
+import { and, asc, desc, eq, inArray, sql } from "drizzle-orm";
 
-import { db$ } from "../external/db";
+import { nowDate } from "../../lib/time";
+import { db$, writeDb$ } from "../external/db";
 
 const ACTIVE_TASK_STATUSES = ["pending", "queued", "running"] as const;
 const FINISHED_TASK_STATUSES = ["done", "failed"] as const;
@@ -137,3 +139,92 @@ export function voiceChatTaskList(
     return [...active, ...finished];
   });
 }
+
+export const markVoiceChatTaskRunningIfQueued$ = command(
+  async (
+    { set },
+    runId: string,
+    signal: AbortSignal,
+  ): Promise<{
+    readonly sessionId: string;
+    readonly userId: string;
+  } | null> => {
+    const writeDb = set(writeDb$);
+    const [row] = await writeDb
+      .update(voiceChatTasks)
+      .set({ status: "running", startedAt: nowDate() })
+      .where(
+        and(
+          eq(voiceChatTasks.runId, runId),
+          inArray(voiceChatTasks.status, ["pending", "queued"]),
+        ),
+      )
+      .returning({ sessionId: voiceChatTasks.sessionId });
+    signal.throwIfAborted();
+
+    if (!row) {
+      return null;
+    }
+
+    const [session] = await writeDb
+      .select({ userId: voiceChatSessions.userId })
+      .from(voiceChatSessions)
+      .where(eq(voiceChatSessions.id, row.sessionId))
+      .limit(1);
+    signal.throwIfAborted();
+
+    if (!session) {
+      return null;
+    }
+    return { sessionId: row.sessionId, userId: session.userId };
+  },
+);
+
+export const appendVoiceChatTaskAssistantResult$ = command(
+  async (
+    { set },
+    args: {
+      readonly runId: string;
+      readonly entries: readonly VoiceChatTaskResultEntry[];
+    },
+    signal: AbortSignal,
+  ): Promise<{
+    readonly sessionId: string;
+    readonly userId: string;
+  } | null> => {
+    if (args.entries.length === 0) {
+      return null;
+    }
+
+    const writeDb = set(writeDb$);
+    const [row] = await writeDb
+      .update(voiceChatTasks)
+      .set({
+        assistantMessages: sql`${voiceChatTasks.assistantMessages} || ${JSON.stringify([...args.entries])}::jsonb`,
+      })
+      .where(
+        and(
+          eq(voiceChatTasks.runId, args.runId),
+          inArray(voiceChatTasks.status, ["pending", "queued", "running"]),
+        ),
+      )
+      .returning({ sessionId: voiceChatTasks.sessionId });
+    signal.throwIfAborted();
+
+    if (!row) {
+      return null;
+    }
+
+    const [session] = await writeDb
+      .select({ userId: voiceChatSessions.userId })
+      .from(voiceChatSessions)
+      .where(eq(voiceChatSessions.id, row.sessionId))
+      .limit(1);
+    signal.throwIfAborted();
+
+    if (!session) {
+      return null;
+    }
+    return { sessionId: row.sessionId, userId: session.userId };
+  },
+);

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -257,6 +257,16 @@ export {
   type TestTelegramStateResponse,
 } from "./test-telegram-state";
 export {
+  internalEventConsumerAxiomContract,
+  internalEventConsumerChatAssistantContract,
+  internalEventConsumerTelegramTypingContract,
+  internalEventConsumerVoiceChatContract,
+  type InternalEventConsumerAxiomContract,
+  type InternalEventConsumerChatAssistantContract,
+  type InternalEventConsumerTelegramTypingContract,
+  type InternalEventConsumerVoiceChatContract,
+} from "./internal-event-consumers";
+export {
   cronCleanupSandboxesContract,
   cleanupResultSchema,
   cleanupResponseSchema,

--- a/turbo/packages/api-contracts/src/contracts/internal-event-consumers.ts
+++ b/turbo/packages/api-contracts/src/contracts/internal-event-consumers.ts
@@ -14,6 +14,30 @@ export const eventConsumerHeadersSchema = z.object({
   "x-vm0-timestamp": z.string().optional(),
 });
 
+export const eventConsumerEventSchema = z
+  .object({
+    type: z.string(),
+    sequenceNumber: z.number(),
+  })
+  .passthrough();
+
+export const eventConsumerPayloadSchema = z
+  .object({
+    runId: z.string(),
+    events: z.array(eventConsumerEventSchema),
+    context: z
+      .object({
+        userId: z.string(),
+        orgId: z.string(),
+      })
+      .passthrough(),
+  })
+  .passthrough();
+
+export const eventConsumerUnauthorizedSchema = z.object({
+  error: z.string(),
+});
+
 /**
  * Refresh Telegram typing indicators for all pending Telegram callbacks
  * attached to a run. Triggered by the events webhook on every batch.
@@ -30,12 +54,64 @@ export const internalEventConsumerTelegramTypingContract = c.router({
     body: z.object({ runId: z.string() }).passthrough(),
     responses: {
       200: z.object({ scheduled: z.literal(true) }),
-      401: z.object({ error: z.string() }),
+      401: eventConsumerUnauthorizedSchema,
     },
     summary:
       "Refresh Telegram typing indicators for all pending callbacks of a run",
   },
 });
 
+export const internalEventConsumerAxiomContract = c.router({
+  ingest: {
+    method: "POST",
+    path: "/api/internal/event-consumers/axiom",
+    headers: eventConsumerHeadersSchema,
+    body: eventConsumerPayloadSchema,
+    responses: {
+      200: z.object({ received: z.number() }),
+      401: eventConsumerUnauthorizedSchema,
+      503: z.object({ error: z.string() }),
+    },
+    summary: "Ingest agent run events into Axiom",
+  },
+});
+
+export const internalEventConsumerChatAssistantContract = c.router({
+  process: {
+    method: "POST",
+    path: "/api/internal/event-consumers/chat-assistant",
+    headers: eventConsumerHeadersSchema,
+    body: eventConsumerPayloadSchema,
+    responses: {
+      200: z.object({ processed: z.number() }),
+      401: eventConsumerUnauthorizedSchema,
+    },
+    summary: "Persist assistant-visible run events into chat threads",
+  },
+});
+
+export const internalEventConsumerVoiceChatContract = c.router({
+  process: {
+    method: "POST",
+    path: "/api/internal/event-consumers/voice-chat",
+    headers: eventConsumerHeadersSchema,
+    body: eventConsumerPayloadSchema,
+    responses: {
+      200: z.object({ processed: z.number() }),
+      401: eventConsumerUnauthorizedSchema,
+    },
+    summary: "Append assistant run events into voice-chat tasks",
+  },
+});
+
+export type InternalEventConsumerAxiomContract =
+  typeof internalEventConsumerAxiomContract;
+
+export type InternalEventConsumerChatAssistantContract =
+  typeof internalEventConsumerChatAssistantContract;
+
 export type InternalEventConsumerTelegramTypingContract =
   typeof internalEventConsumerTelegramTypingContract;
+
+export type InternalEventConsumerVoiceChatContract =
+  typeof internalEventConsumerVoiceChatContract;


### PR DESCRIPTION
## Summary
- add API contracts and signal routes for internal event consumer POST endpoints
- move Axiom, chat-assistant, and voice-chat consumer handling into apps/api without web proxy/shadow execution
- add API integration coverage for HMAC validation, Axiom ingestion, chat assistant events, and voice chat updates

## Tests
- pnpm -F api exec vitest src/signals/routes/__tests__/internal-event-consumers.test.ts
- pnpm -F api lint
- pnpm -F api check-types
- pnpm check-types
- git diff --check

Closes #12853