### PR TITLE
refactor(api): migrate zero org domain verification

### DIFF
--- a/turbo/apps/api/src/__tests__/mocks.ts
+++ b/turbo/apps/api/src/__tests__/mocks.ts
@@ -36,6 +36,7 @@ export interface ApiTestMocks {
       readonly revokeOrganizationInvitation: AsyncMock;
       readonly deleteOrganization: AsyncMock;
       readonly updateOrganization: AsyncMock;
+      readonly updateOrganizationDomain: AsyncMock;
       readonly updateOrganizationLogo: AsyncMock;
     };
     readonly users: {
@@ -153,6 +154,8 @@ const apiTestMocks: ApiTestMocks = vi.hoisted((): ApiTestMocks => {
         vi.fn<(...args: unknown[]) => Promise<unknown>>(),
       deleteOrganization: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
       updateOrganization: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
+      updateOrganizationDomain:
+        vi.fn<(...args: unknown[]) => Promise<unknown>>(),
       updateOrganizationLogo: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
     },
     users: {
@@ -541,6 +544,7 @@ export function resetApiTestMocks(): void {
   apiTestMocks.clerk.organizations.getOrganizationMembershipList.mockReset();
   apiTestMocks.clerk.organizations.revokeOrganizationInvitation.mockReset();
   apiTestMocks.clerk.organizations.updateOrganization.mockReset();
+  apiTestMocks.clerk.organizations.updateOrganizationDomain.mockReset();
   apiTestMocks.clerk.organizations.updateOrganizationLogo.mockReset();
   apiTestMocks.clerk.users.getUserList.mockReset();
   apiTestMocks.clerk.users.getOrganizationMembershipList.mockReset();

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-org-domains.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-org-domains.test.ts
@@ -424,3 +424,178 @@ describe("DELETE /api/zero/org/domains", () => {
     ).not.toHaveBeenCalled();
   });
 });
+
+describe("PATCH /api/zero/org/domains", () => {
+  const seededFixtures: OrgMembershipFixture[] = [];
+
+  afterEach(async () => {
+    while (seededFixtures.length > 0) {
+      const fixture = seededFixtures.pop();
+      if (fixture) {
+        await store.set(deleteOrgMembership$, fixture, context.signal);
+      }
+    }
+  });
+
+  it("verifies a domain for an admin", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    seededFixtures.push(
+      await store.set(
+        seedOrgMembership$,
+        { orgId, userId, role: "admin" },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(userId, orgId, "org:admin");
+
+    const client = setupApp({ context })(zeroOrgDomainsContract);
+
+    const response = await accept(
+      client.setVerified({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { domainId: "domain_test123", verified: true },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({ message: "Domain verified" });
+    expect(
+      context.mocks.clerk.organizations.updateOrganizationDomain,
+    ).toHaveBeenCalledWith({
+      organizationId: orgId,
+      domainId: "domain_test123",
+      verified: true,
+    });
+  });
+
+  it("unverifies a domain for an admin", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    seededFixtures.push(
+      await store.set(
+        seedOrgMembership$,
+        { orgId, userId, role: "admin" },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(userId, orgId, "org:admin");
+
+    const client = setupApp({ context })(zeroOrgDomainsContract);
+
+    const response = await accept(
+      client.setVerified({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { domainId: "domain_test123", verified: false },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({ message: "Domain unverified" });
+    expect(
+      context.mocks.clerk.organizations.updateOrganizationDomain,
+    ).toHaveBeenCalledWith({
+      organizationId: orgId,
+      domainId: "domain_test123",
+      verified: false,
+    });
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    const client = setupApp({ context })(zeroOrgDomainsContract);
+
+    const response = await accept(
+      client.setVerified({
+        headers: {},
+        body: { domainId: "domain_test123", verified: true },
+      }),
+      [401],
+    );
+
+    expect(response.body.error.code).toBe("UNAUTHORIZED");
+    expect(
+      context.mocks.clerk.organizations.updateOrganizationDomain,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when the authenticated session has no organization", async () => {
+    mocks.clerk.session(`user_${randomUUID()}`, null);
+
+    const client = setupApp({ context })(zeroOrgDomainsContract);
+
+    const response = await accept(
+      client.setVerified({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { domainId: "domain_test123", verified: true },
+      }),
+      [401],
+    );
+
+    expect(response.body.error.code).toBe("UNAUTHORIZED");
+    expect(
+      context.mocks.clerk.organizations.updateOrganizationDomain,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 when caller is not an admin", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    seededFixtures.push(
+      await store.set(
+        seedOrgMembership$,
+        { orgId, userId, role: "member" },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(userId, orgId, "org:member");
+
+    const client = setupApp({ context })(zeroOrgDomainsContract);
+
+    const response = await accept(
+      client.setVerified({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { domainId: "domain_test123", verified: true },
+      }),
+      [403],
+    );
+
+    expect(response.body.error).toStrictEqual({
+      message: "Access denied",
+      code: "FORBIDDEN",
+    });
+    expect(
+      context.mocks.clerk.organizations.updateOrganizationDomain,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("rejects invalid bodies before calling Clerk", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    seededFixtures.push(
+      await store.set(
+        seedOrgMembership$,
+        { orgId, userId, role: "admin" },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(userId, orgId, "org:admin");
+
+    const app = createApp({ signal: context.signal });
+    const response = await app.request("/api/zero/org/domains", {
+      method: "PATCH",
+      headers: {
+        authorization: "Bearer clerk-session",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ domainId: "domain_test123" }),
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      error: { code: "BAD_REQUEST" },
+    });
+    expect(
+      context.mocks.clerk.organizations.updateOrganizationDomain,
+    ).not.toHaveBeenCalled();
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-org-read.ts
+++ b/turbo/apps/api/src/signals/routes/zero-org-read.ts
@@ -189,6 +189,40 @@ const removeDomainInner$ = command(async ({ get }, signal: AbortSignal) => {
   };
 });
 
+const setVerifiedDomainBody$ = bodyResultOf(zeroOrgDomainsContract.setVerified);
+
+const setVerifiedDomainInner$ = command(
+  async ({ get }, signal: AbortSignal) => {
+    const auth = get(organizationAuthContext$);
+    if (auth.orgRole !== "admin") {
+      return adminRequired;
+    }
+
+    const bodyResult = await get(setVerifiedDomainBody$);
+    signal.throwIfAborted();
+    if (!bodyResult.ok) {
+      return bodyResult.response;
+    }
+
+    const client = get(clerk$);
+    await client.organizations.updateOrganizationDomain({
+      organizationId: auth.orgId,
+      domainId: bodyResult.data.domainId,
+      verified: bodyResult.data.verified,
+    });
+    signal.throwIfAborted();
+
+    return {
+      status: 200 as const,
+      body: {
+        message: bodyResult.data.verified
+          ? "Domain verified"
+          : "Domain unverified",
+      },
+    };
+  },
+);
+
 const membersInner$ = computed(async (get) => {
   const auth = get(organizationAuthContext$);
   const body = await get(
@@ -239,6 +273,13 @@ export const zeroOrgReadRoutes: readonly RouteEntry[] = [
     handler: authRoute(
       { requireOrganization: true, missingOrganizationStatus: 401 },
       removeDomainInner$,
+    ),
+  },
+  {
+    route: zeroOrgDomainsContract.setVerified,
+    handler: authRoute(
+      { requireOrganization: true, missingOrganizationStatus: 401 },
+      setVerifiedDomainInner$,
     ),
   },
   {


### PR DESCRIPTION
## Summary
- implement API backend handling for PATCH /api/zero/org/domains
- call Clerk updateOrganizationDomain for admin verify/unverify actions
- add API integration coverage for success, auth, role, and invalid body cases

Closes #12844

## Tests
- scripts/prepare.sh
- cd turbo && pnpm format
- cd turbo && pnpm -F api exec vitest run src/signals/routes/__tests__/zero-org-domains.test.ts
- cd turbo && pnpm -F api lint
- cd turbo && pnpm -F api check-types
- cd turbo && pnpm -F @vm0/api-contracts lint
- cd turbo && pnpm -F @vm0/api-contracts check-types
- cd turbo && pnpm turbo run lint
- cd turbo && pnpm check-types
- cd turbo && pnpm knip
- cd turbo && pnpm vitest
- git diff --check