### PR TITLE
refactor(api): migrate email unsubscribe route

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/email-unsubscribe.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/email-unsubscribe.test.ts
@@ -1,13 +1,14 @@
 import { randomUUID } from "node:crypto";
 
-import { createStore } from "ccstate";
-import { describe, expect, it } from "vitest";
-import { eq } from "drizzle-orm";
+import { emailUnsubscribeContract } from "@vm0/api-contracts/contracts/email-unsubscribe";
 import { users } from "@vm0/db/schema/user";
+import { createStore } from "ccstate";
+import { eq } from "drizzle-orm";
+import { describe, expect, it } from "vitest";
 
 import { createApp } from "../../../app-factory";
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
 import { env } from "../../../lib/env";
-import { testContext } from "../../../__tests__/test-helpers";
 import { writeDb$ } from "../../external/db";
 import { createFixtureTracker } from "./helpers/zero-route-test";
 
@@ -40,7 +41,9 @@ async function insertUser(userId: string): Promise<void> {
     .values({ id: userId, emailUnsubscribed: false });
 }
 
-async function findUser(userId: string) {
+async function findUser(
+  userId: string,
+): Promise<{ readonly emailUnsubscribed: boolean } | undefined> {
   const [row] = await store
     .set(writeDb$)
     .select({ emailUnsubscribed: users.emailUnsubscribed })
@@ -50,7 +53,7 @@ async function findUser(userId: string) {
   return row;
 }
 
-function requestUnsubscribe(token?: string): Promise<Response> {
+function requestGetUnsubscribe(token?: string): Promise<Response> {
   const search =
     token === undefined ? "" : `?token=${encodeURIComponent(token)}`;
   const app = createApp({ signal: context.signal });
@@ -66,25 +69,29 @@ async function expectJsonError(
   await expect(response.json()).resolves.toStrictEqual({ error });
 }
 
+function client() {
+  return setupApp({ context })(emailUnsubscribeContract);
+}
+
 describe("GET /api/email/unsubscribe", () => {
   const trackUser = createFixtureTracker<string>(async (userId) => {
     await store.set(writeDb$).delete(users).where(eq(users.id, userId));
   });
 
   it("returns 400 when token is missing", async () => {
-    const response = await requestUnsubscribe();
+    const response = await requestGetUnsubscribe();
 
     await expectJsonError(response, 400, "Missing token");
   });
 
   it("returns 400 when token is invalid", async () => {
-    const response = await requestUnsubscribe("bad.token");
+    const response = await requestGetUnsubscribe("bad.token");
 
     await expectJsonError(response, 400, "Invalid token");
   });
 
   it("returns 400 when token signature is not hex", async () => {
-    const response = await requestUnsubscribe(
+    const response = await requestGetUnsubscribe(
       `user_${randomUUID()}.${"é".repeat(32)}`,
     );
 
@@ -97,7 +104,7 @@ describe("GET /api/email/unsubscribe", () => {
     await insertUser(userId);
     const token = await createToken(userId);
 
-    const response = await requestUnsubscribe(token);
+    const response = await requestGetUnsubscribe(token);
 
     expect(response.status).toBe(200);
     expect(response.headers.get("content-type")).toContain("text/html");
@@ -115,8 +122,8 @@ describe("GET /api/email/unsubscribe", () => {
     await insertUser(userId);
     const token = await createToken(userId);
 
-    const firstResponse = await requestUnsubscribe(token);
-    const secondResponse = await requestUnsubscribe(token);
+    const firstResponse = await requestGetUnsubscribe(token);
+    const secondResponse = await requestGetUnsubscribe(token);
 
     expect(firstResponse.status).toBe(200);
     expect(secondResponse.status).toBe(200);
@@ -130,9 +137,95 @@ describe("GET /api/email/unsubscribe", () => {
     await trackUser(Promise.resolve(userId));
     const token = await createToken(userId);
 
-    const response = await requestUnsubscribe(token);
+    const response = await requestGetUnsubscribe(token);
 
     expect(response.status).toBe(200);
+    await expect(findUser(userId)).resolves.toStrictEqual({
+      emailUnsubscribed: true,
+    });
+  });
+});
+
+describe("POST /api/email/unsubscribe", () => {
+  const trackUser = createFixtureTracker<string>(async (userId) => {
+    await store.set(writeDb$).delete(users).where(eq(users.id, userId));
+  });
+
+  it("returns 400 when token is missing", async () => {
+    const response = await accept(client().unsubscribe({ query: {} }), [400]);
+
+    expect(response.body).toStrictEqual({ error: "Missing token" });
+  });
+
+  it("returns 400 when token is invalid", async () => {
+    const response = await accept(
+      client().unsubscribe({ query: { token: "bad.token" } }),
+      [400],
+    );
+
+    expect(response.body).toStrictEqual({ error: "Invalid token" });
+  });
+
+  it("returns 400 when token signature is not hex", async () => {
+    const response = await accept(
+      client().unsubscribe({
+        query: { token: `user_${randomUUID()}.${"é".repeat(32)}` },
+      }),
+      [400],
+    );
+
+    expect(response.body).toStrictEqual({ error: "Invalid token" });
+  });
+
+  it("unsubscribes an existing user with a valid token", async () => {
+    const userId = `user_${randomUUID()}`;
+    await trackUser(Promise.resolve(userId));
+    await insertUser(userId);
+    const token = await createToken(userId);
+
+    const response = await accept(
+      client().unsubscribe({ query: { token } }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({ unsubscribed: true });
+    await expect(findUser(userId)).resolves.toStrictEqual({
+      emailUnsubscribed: true,
+    });
+  });
+
+  it("is idempotent when the same token is used repeatedly", async () => {
+    const userId = `user_${randomUUID()}`;
+    await trackUser(Promise.resolve(userId));
+    const token = await createToken(userId);
+
+    const firstResponse = await accept(
+      client().unsubscribe({ query: { token } }),
+      [200],
+    );
+    const secondResponse = await accept(
+      client().unsubscribe({ query: { token } }),
+      [200],
+    );
+
+    expect(firstResponse.body).toStrictEqual({ unsubscribed: true });
+    expect(secondResponse.body).toStrictEqual({ unsubscribed: true });
+    await expect(findUser(userId)).resolves.toStrictEqual({
+      emailUnsubscribed: true,
+    });
+  });
+
+  it("creates an unsubscribed user row when the user does not exist", async () => {
+    const userId = `user_${randomUUID()}`;
+    await trackUser(Promise.resolve(userId));
+    const token = await createToken(userId);
+
+    const response = await accept(
+      client().unsubscribe({ query: { token } }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({ unsubscribed: true });
     await expect(findUser(userId)).resolves.toStrictEqual({
       emailUnsubscribed: true,
     });

--- a/turbo/apps/api/src/signals/routes/email-unsubscribe.ts
+++ b/turbo/apps/api/src/signals/routes/email-unsubscribe.ts
@@ -68,9 +68,33 @@ const getEmailUnsubscribe$ = command(
   },
 );
 
+const postEmailUnsubscribe$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const query = get(queryOf(emailUnsubscribeContract.unsubscribe));
+    if (!query.token) {
+      return missingTokenResponse();
+    }
+
+    const userId = await verifyUnsubscribeToken(query.token);
+    signal.throwIfAborted();
+    if (!userId) {
+      return invalidTokenResponse();
+    }
+
+    await set(unsubscribeEmailUser$, userId, signal);
+    signal.throwIfAborted();
+
+    return { status: 200 as const, body: { unsubscribed: true as const } };
+  },
+);
+
 export const emailUnsubscribeRoutes: readonly RouteEntry[] = [
   {
     route: emailUnsubscribeContract.get,
     handler: getEmailUnsubscribe$,
+  },
+  {
+    route: emailUnsubscribeContract.unsubscribe,
+    handler: postEmailUnsubscribe$,
   },
 ];

--- a/turbo/apps/api/src/signals/services/email-unsubscribe.service.ts
+++ b/turbo/apps/api/src/signals/services/email-unsubscribe.service.ts
@@ -41,7 +41,6 @@ export async function verifyUnsubscribeToken(
 
   const userId = token.slice(0, dotIndex);
   const providedHmac = token.slice(dotIndex + 1);
-
   if (!userId || !providedHmac) {
     return null;
   }

--- a/turbo/packages/api-contracts/src/contracts/email-unsubscribe.ts
+++ b/turbo/packages/api-contracts/src/contracts/email-unsubscribe.ts
@@ -8,6 +8,10 @@ export const emailUnsubscribeQuerySchema = z.object({
   token: z.string().optional(),
 });
 
+export const emailUnsubscribeResponseSchema = z.object({
+  unsubscribed: z.literal(true),
+});
+
 export const emailUnsubscribeErrorSchema = z.object({
   error: z.string(),
 });
@@ -26,7 +30,22 @@ export const emailUnsubscribeContract = c.router({
     },
     summary: "Unsubscribe from system email notifications",
   },
+  unsubscribe: {
+    method: "POST",
+    path: "/api/email/unsubscribe",
+    query: emailUnsubscribeQuerySchema,
+    body: z.undefined(),
+    responses: {
+      200: emailUnsubscribeResponseSchema,
+      400: emailUnsubscribeErrorSchema,
+    },
+    summary: "Unsubscribe a user from system-initiated emails",
+  },
 });
 
 export type EmailUnsubscribeContract = typeof emailUnsubscribeContract;
 export type EmailUnsubscribeQuery = z.infer<typeof emailUnsubscribeQuerySchema>;
+export type EmailUnsubscribeResponse = z.infer<
+  typeof emailUnsubscribeResponseSchema
+>;
+export type EmailUnsubscribeError = z.infer<typeof emailUnsubscribeErrorSchema>;

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -217,8 +217,11 @@ export {
   emailUnsubscribeContract,
   emailUnsubscribeErrorSchema,
   emailUnsubscribeQuerySchema,
+  emailUnsubscribeResponseSchema,
   type EmailUnsubscribeContract,
+  type EmailUnsubscribeError,
   type EmailUnsubscribeQuery,
+  type EmailUnsubscribeResponse,
 } from "./email-unsubscribe";
 export {
   connectorsTypeAuthorizeContract,


### PR DESCRIPTION
## Summary

- Add the ts-rest contract for `POST /api/email/unsubscribe`
- Implement the API command route and API-owned unsubscribe service
- Add route integration tests for missing/invalid tokens, existing-user unsubscribe, idempotency, and missing-user creation

Fixes #12849

## Validation

- `pnpm -F api exec vitest src/signals/routes/__tests__/email-unsubscribe.test.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm check-types`
- `pnpm format`
- `pnpm knip --workspace api`