### PR TITLE
feat(api): migrate github integration update route

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/integrations-github-patch.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations-github-patch.test.ts
@@ -1,0 +1,334 @@
+import { randomUUID } from "node:crypto";
+
+import { createStore } from "ccstate";
+import { githubInstallations } from "@vm0/db/schema/github-installation";
+import { githubUserLinks } from "@vm0/db/schema/github-user-link";
+import { eq } from "drizzle-orm";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { createApp } from "../../../app-factory";
+import { testContext } from "../../../__tests__/test-helpers";
+import { writeDb$ } from "../../external/db";
+import {
+  deleteUsageInsightFixture$,
+  seedCompose$,
+} from "./helpers/zero-usage-insight";
+import { createZeroRouteMocks } from "./helpers/zero-route-test";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+const ROUTE_PATH = "/api/integrations/github";
+
+interface GithubInstallationFixture {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly installationRowId: string;
+  readonly defaultComposeId: string;
+}
+
+function authHeaders(): Record<string, string> {
+  return { authorization: "Bearer clerk-session" };
+}
+
+function newGithubUserId(): string {
+  return `gh_${randomUUID().replaceAll("-", "")}`;
+}
+
+function newRemoteInstallationId(): string {
+  return String(Math.floor(Math.random() * 9_000_000_000) + 1_000_000_000);
+}
+
+async function seedGithubInstallation(args: {
+  readonly userId?: string;
+  readonly linkedGithubUserId?: string;
+  readonly adminGithubUserId?: string | null;
+  readonly defaultComposeName?: string;
+}): Promise<GithubInstallationFixture> {
+  const orgId = `org_${randomUUID()}`;
+  const userId = args.userId ?? `user_${randomUUID()}`;
+  const githubUserId = args.linkedGithubUserId ?? newGithubUserId();
+  const adminGithubUserId =
+    "adminGithubUserId" in args ? args.adminGithubUserId : githubUserId;
+  const { composeId } = await store.set(
+    seedCompose$,
+    {
+      orgId,
+      userId,
+      name: args.defaultComposeName,
+    },
+    context.signal,
+  );
+  const db = store.set(writeDb$);
+
+  const [installation] = await db
+    .insert(githubInstallations)
+    .values({
+      installationId: newRemoteInstallationId(),
+      adminGithubUserId,
+      defaultComposeId: composeId,
+    })
+    .returning({ id: githubInstallations.id });
+  if (!installation) {
+    throw new Error("Expected GitHub installation insert to return a row");
+  }
+
+  await db.insert(githubUserLinks).values({
+    githubUserId,
+    installationId: installation.id,
+    vm0UserId: userId,
+  });
+
+  return {
+    orgId,
+    userId,
+    installationRowId: installation.id,
+    defaultComposeId: composeId,
+  };
+}
+
+async function deleteGithubFixture(
+  fixture: GithubInstallationFixture,
+): Promise<void> {
+  const db = store.set(writeDb$);
+  await db
+    .delete(githubInstallations)
+    .where(eq(githubInstallations.id, fixture.installationRowId));
+  await store.set(
+    deleteUsageInsightFixture$,
+    { orgId: fixture.orgId, userId: fixture.userId },
+    context.signal,
+  );
+}
+
+async function seedAgent(args: {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly name: string;
+}): Promise<{ readonly composeId: string }> {
+  const { composeId } = await store.set(seedCompose$, args, context.signal);
+  return { composeId };
+}
+
+async function defaultComposeId(installationRowId: string): Promise<string> {
+  const [row] = await store
+    .set(writeDb$)
+    .select({ defaultComposeId: githubInstallations.defaultComposeId })
+    .from(githubInstallations)
+    .where(eq(githubInstallations.id, installationRowId))
+    .limit(1);
+  if (!row) {
+    throw new Error("Expected GitHub installation to exist");
+  }
+  return row.defaultComposeId;
+}
+
+function patchGithub(body: string | undefined, headers: HeadersInit = {}) {
+  const app = createApp({ signal: context.signal });
+  return app.request(ROUTE_PATH, {
+    method: "PATCH",
+    headers: {
+      "content-type": "application/json",
+      ...headers,
+    },
+    body,
+  });
+}
+
+describe("PATCH /api/integrations/github", () => {
+  const fixtures: GithubInstallationFixture[] = [];
+
+  beforeEach(() => {
+    context.mocks.clerk.authenticateRequest.mockReset();
+    context.mocks.clerk.authenticateRequest.mockResolvedValue({
+      isAuthenticated: false,
+    });
+  });
+
+  afterEach(async () => {
+    while (fixtures.length > 0) {
+      const fixture = fixtures.pop();
+      if (fixture) {
+        await deleteGithubFixture(fixture);
+      }
+    }
+  });
+
+  it("returns 401 when no user is authenticated", async () => {
+    const response = await patchGithub(
+      JSON.stringify({ agentName: "test-agent" }),
+    );
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("returns 400 when agentName is missing", async () => {
+    const fixture = await seedGithubInstallation({});
+    fixtures.push(fixture);
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await patchGithub(JSON.stringify({}), authHeaders());
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toStrictEqual({
+      error: { message: "agentName is required", code: "BAD_REQUEST" },
+    });
+  });
+
+  it("returns 400 when JSON is invalid", async () => {
+    const fixture = await seedGithubInstallation({});
+    fixtures.push(fixture);
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await patchGithub("{", authHeaders());
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toStrictEqual({
+      error: { message: "agentName is required", code: "BAD_REQUEST" },
+    });
+  });
+
+  it("returns 400 when agentName is empty", async () => {
+    const fixture = await seedGithubInstallation({});
+    fixtures.push(fixture);
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await patchGithub(
+      JSON.stringify({ agentName: "" }),
+      authHeaders(),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toStrictEqual({
+      error: { message: "agentName is required", code: "BAD_REQUEST" },
+    });
+  });
+
+  it("returns 404 when the authenticated user has no GitHub installation", async () => {
+    mocks.clerk.session(`user_${randomUUID()}`, `org_${randomUUID()}`);
+
+    const response = await patchGithub(
+      JSON.stringify({ agentName: "test-agent" }),
+      authHeaders(),
+    );
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toStrictEqual({
+      error: {
+        message: "No GitHub installation found",
+        code: "NOT_FOUND",
+      },
+    });
+  });
+
+  it("returns 403 when adminGithubUserId is null", async () => {
+    const fixture = await seedGithubInstallation({ adminGithubUserId: null });
+    fixtures.push(fixture);
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await patchGithub(
+      JSON.stringify({ agentName: "test-agent" }),
+      authHeaders(),
+    );
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toStrictEqual({
+      error: {
+        message: "Only the installation admin can change the default agent",
+        code: "FORBIDDEN",
+      },
+    });
+    await expect(defaultComposeId(fixture.installationRowId)).resolves.toBe(
+      fixture.defaultComposeId,
+    );
+  });
+
+  it("returns 403 when a non-admin user updates the installation", async () => {
+    const fixture = await seedGithubInstallation({
+      adminGithubUserId: newGithubUserId(),
+      linkedGithubUserId: newGithubUserId(),
+    });
+    fixtures.push(fixture);
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await patchGithub(
+      JSON.stringify({ agentName: "test-agent" }),
+      authHeaders(),
+    );
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toStrictEqual({
+      error: {
+        message: "Only the installation admin can change the default agent",
+        code: "FORBIDDEN",
+      },
+    });
+    await expect(defaultComposeId(fixture.installationRowId)).resolves.toBe(
+      fixture.defaultComposeId,
+    );
+  });
+
+  it("returns 400 when active org context is missing", async () => {
+    const fixture = await seedGithubInstallation({});
+    fixtures.push(fixture);
+    mocks.clerk.session(fixture.userId, null);
+
+    const response = await patchGithub(
+      JSON.stringify({ agentName: "test-agent" }),
+      authHeaders(),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toStrictEqual({
+      error: {
+        message: "Explicit org context required — ensure active org in session",
+        code: "BAD_REQUEST",
+      },
+    });
+  });
+
+  it("returns 404 when the target agent does not exist", async () => {
+    const fixture = await seedGithubInstallation({});
+    fixtures.push(fixture);
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await patchGithub(
+      JSON.stringify({ agentName: "missing-agent" }),
+      authHeaders(),
+    );
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toStrictEqual({
+      error: { message: "Agent not found", code: "NOT_FOUND" },
+    });
+    await expect(defaultComposeId(fixture.installationRowId)).resolves.toBe(
+      fixture.defaultComposeId,
+    );
+  });
+
+  it("updates the default agent", async () => {
+    const fixture = await seedGithubInstallation({});
+    fixtures.push(fixture);
+    const targetName = `github-target-${randomUUID()}`;
+    const target = await seedAgent({
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      name: targetName,
+    });
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await patchGithub(
+      JSON.stringify({ agentName: targetName }),
+      authHeaders(),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toStrictEqual({ ok: true });
+    await expect(defaultComposeId(fixture.installationRowId)).resolves.toBe(
+      target.composeId,
+    );
+  });
+});

--- a/turbo/apps/api/src/signals/routes/integrations-github.ts
+++ b/turbo/apps/api/src/signals/routes/integrations-github.ts
@@ -1,11 +1,48 @@
+import { command } from "ccstate";
 import { integrationsGithubContract } from "@vm0/api-contracts/contracts/integrations-github";
 
 import { authRoute } from "../auth/auth-route";
+import { bodyResultOf } from "../context/request";
 import {
   deleteGithubInstallation$,
   getGithubInstallation$,
+  updateGithubInstallation$,
 } from "../services/integrations-github.service";
 import type { RouteEntry } from "../route";
+
+const updateInstallationBody$ = bodyResultOf(
+  integrationsGithubContract.updateInstallation,
+);
+
+const agentNameRequired = Object.freeze({
+  status: 400 as const,
+  body: Object.freeze({
+    error: Object.freeze({
+      message: "agentName is required",
+      code: "BAD_REQUEST",
+    }),
+  }),
+});
+
+const updateGithubInstallationInner$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const body = await get(updateInstallationBody$);
+    signal.throwIfAborted();
+
+    if (!body.ok) {
+      return agentNameRequired;
+    }
+
+    const result = await set(
+      updateGithubInstallation$,
+      { agentName: body.data.agentName },
+      signal,
+    );
+    signal.throwIfAborted();
+
+    return result;
+  },
+);
 
 export const integrationsGithubRoutes: readonly RouteEntry[] = [
   {
@@ -15,5 +52,9 @@ export const integrationsGithubRoutes: readonly RouteEntry[] = [
   {
     route: integrationsGithubContract.deleteInstallation,
     handler: authRoute({}, deleteGithubInstallation$),
+  },
+  {
+    route: integrationsGithubContract.updateInstallation,
+    handler: authRoute({}, updateGithubInstallationInner$),
   },
 ];

--- a/turbo/apps/api/src/signals/services/integrations-github.service.ts
+++ b/turbo/apps/api/src/signals/services/integrations-github.service.ts
@@ -11,13 +11,13 @@ import {
 import { githubInstallations } from "@vm0/db/schema/github-installation";
 import { githubUserLinks } from "@vm0/db/schema/github-user-link";
 import { orgMetadata } from "@vm0/db/schema/org-metadata";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 
 import { authContext$ } from "../auth/auth-context";
 import { db$, writeDb$ } from "../external/db";
 import { env, optionalEnv } from "../../lib/env";
 import { logger } from "../../lib/log";
-import { now } from "../../lib/time";
+import { now, nowDate } from "../../lib/time";
 import { zeroConnectorList } from "./zero-connector-data.service";
 import { userSecrets, userVariables } from "./zero-user-data.service";
 
@@ -212,6 +212,79 @@ export const deleteGithubInstallation$ = command(
     await db
       .delete(githubInstallations)
       .where(eq(githubInstallations.id, result.id));
+    signal.throwIfAborted();
+
+    return { status: 200 as const, body: { ok: true as const } };
+  },
+);
+
+export const updateGithubInstallation$ = command(
+  async (
+    { get, set },
+    args: { readonly agentName: string },
+    signal: AbortSignal,
+  ) => {
+    const auth = get(authContext$);
+    const db = set(writeDb$);
+
+    const [result] = await db
+      .select({
+        installationId: githubInstallations.id,
+        adminGithubUserId: githubInstallations.adminGithubUserId,
+        githubUserId: githubUserLinks.githubUserId,
+      })
+      .from(githubUserLinks)
+      .innerJoin(
+        githubInstallations,
+        eq(githubInstallations.id, githubUserLinks.installationId),
+      )
+      .where(eq(githubUserLinks.vm0UserId, auth.userId))
+      .limit(1);
+    signal.throwIfAborted();
+
+    if (!result) {
+      return errorResponse(404, "No GitHub installation found", "NOT_FOUND");
+    }
+
+    if (
+      !result.adminGithubUserId ||
+      result.githubUserId !== result.adminGithubUserId
+    ) {
+      return errorResponse(
+        403,
+        "Only the installation admin can change the default agent",
+        "FORBIDDEN",
+      );
+    }
+
+    if (!auth.orgId) {
+      return errorResponse(
+        400,
+        "Explicit org context required — ensure active org in session",
+        "BAD_REQUEST",
+      );
+    }
+
+    const [compose] = await db
+      .select({ id: agentComposes.id })
+      .from(agentComposes)
+      .where(
+        and(
+          eq(agentComposes.orgId, auth.orgId),
+          eq(agentComposes.name, args.agentName),
+        ),
+      )
+      .limit(1);
+    signal.throwIfAborted();
+
+    if (!compose) {
+      return errorResponse(404, "Agent not found", "NOT_FOUND");
+    }
+
+    await db
+      .update(githubInstallations)
+      .set({ defaultComposeId: compose.id, updatedAt: nowDate() })
+      .where(eq(githubInstallations.id, result.installationId));
     signal.throwIfAborted();
 
     return { status: 200 as const, body: { ok: true as const } };

--- a/turbo/packages/api-contracts/src/contracts/integrations-github.ts
+++ b/turbo/packages/api-contracts/src/contracts/integrations-github.ts
@@ -49,6 +49,22 @@ export type DeleteGithubInstallationResponse = z.infer<
   typeof deleteGithubInstallationResponseSchema
 >;
 
+export const patchGithubInstallationBodySchema = z.object({
+  agentName: z.string().min(1),
+});
+
+export type PatchGithubInstallationBody = z.infer<
+  typeof patchGithubInstallationBodySchema
+>;
+
+export const updateGithubInstallationResponseSchema = z.object({
+  ok: z.literal(true),
+});
+
+export type UpdateGithubInstallationResponse = z.infer<
+  typeof updateGithubInstallationResponseSchema
+>;
+
 export const integrationsGithubContract = c.router({
   getInstallation: {
     method: "GET",
@@ -77,6 +93,22 @@ export const integrationsGithubContract = c.router({
       500: apiErrorSchema,
     },
     summary: "Uninstall the authenticated user's GitHub App installation",
+  },
+
+  updateInstallation: {
+    method: "PATCH",
+    path: "/api/integrations/github",
+    headers: authHeadersSchema,
+    body: patchGithubInstallationBodySchema,
+    responses: {
+      200: updateGithubInstallationResponseSchema,
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      404: apiErrorSchema,
+      500: apiErrorSchema,
+    },
+    summary: "Update the authenticated user's GitHub App installation",
   },
 });
 


### PR DESCRIPTION
## Summary
- add the typed API contract and route entry for `PATCH /api/integrations/github`
- migrate the GitHub installation default-agent update logic into `apps/api`
- cover auth, validation, admin authorization, org scoping, missing agent, and successful update cases

Closes #12840

## Validation
- `pnpm -F api exec vitest run src/signals/routes/__tests__/integrations-github-patch.test.ts`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/integrations-github-get.test.ts src/signals/routes/__tests__/integrations-github-delete.test.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `git diff --check`
- `pnpm format`
- `pnpm turbo run lint`
- `pnpm check-types`
- `pnpm knip`
- `pnpm -F web db:migrate`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-remote-agent-runs.test.ts src/signals/routes/__tests__/zero-connectors-remote-agent-connect.test.ts`
- `pnpm -F web exec vitest run app/api/cron/aggregate-insights/__tests__/route.test.ts`

## Local full-suite note
- `pnpm vitest` was run twice. The first run exposed local DB drift for remote-agent tables, resolved with `pnpm -F web db:migrate`; the affected API files then passed in isolation.
- The second and third full-suite runs failed in unrelated web/UI/cron tests with broad timeout/resource symptoms. The final run ended with 34 failed files / 92 failed tests, including `@vm0/app` UI interaction timeouts, `web` `app/api/cron/aggregate-insights`, and an unrelated Slack callback assertion. The scoped API migration tests above passed.
