### PR TITLE
refactor(api): migrate model provider model update route

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-model-providers.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-model-providers.test.ts
@@ -7,6 +7,7 @@ import {
   zeroModelProvidersByTypeContract,
   zeroModelProvidersDefaultContract,
   zeroModelProvidersMainContract,
+  zeroModelProvidersUpdateModelContract,
 } from "@vm0/api-contracts/contracts/zero-model-providers";
 import { modelProviders } from "@vm0/db/schema/model-provider";
 import { secrets } from "@vm0/db/schema/secret";
@@ -169,6 +170,7 @@ async function readOrgModelProviderState(
   orgId: string,
   type: string,
 ): Promise<{
+  readonly selectedModel: string | null;
   readonly tokenExpiresAt: Date | null;
   readonly workspaceName: string | null;
   readonly planType: string | null;
@@ -178,6 +180,7 @@ async function readOrgModelProviderState(
   const writeDb = store.set(writeDb$);
   const [row] = await writeDb
     .select({
+      selectedModel: modelProviders.selectedModel,
       tokenExpiresAt: modelProviders.tokenExpiresAt,
       workspaceName: modelProviders.workspaceName,
       planType: modelProviders.planType,
@@ -825,6 +828,134 @@ describe("POST /api/zero/model-providers", () => {
     expect(blocked.body.error.message).toBe(
       'Provider "codex-oauth-token" not found',
     );
+  });
+});
+
+describe("PATCH /api/zero/model-providers/:type/model", () => {
+  const track = createFixtureTracker<OrgModelProviderFixture>((fixture) => {
+    return store.set(deleteOrgModelProviders$, fixture, context.signal);
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    const client = setupApp({ context })(zeroModelProvidersUpdateModelContract);
+
+    const response = await accept(
+      client.updateModel({
+        headers: {},
+        params: { type: "anthropic-api-key" },
+        body: { selectedModel: "claude-sonnet-4-5" },
+      }),
+      [401],
+    );
+
+    expect(response.body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("returns 401 when the authenticated session has no organization", async () => {
+    const userId = `user_${randomUUID()}`;
+    mocks.clerk.session(userId, null);
+    const client = setupApp({ context })(zeroModelProvidersUpdateModelContract);
+
+    const response = await accept(
+      client.updateModel({
+        headers: { authorization: "Bearer clerk-session" },
+        params: { type: "anthropic-api-key" },
+        body: { selectedModel: "claude-sonnet-4-5" },
+      }),
+      [401],
+    );
+
+    expect(response.body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("returns 403 for non-admin members", async () => {
+    const fixture = uniqueOrgUser("zmp-model-member");
+    await track(Promise.resolve({ orgId: fixture.orgId }));
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:member");
+    const client = setupApp({ context })(zeroModelProvidersUpdateModelContract);
+
+    const response = await accept(
+      client.updateModel({
+        headers: { authorization: "Bearer clerk-session" },
+        params: { type: "anthropic-api-key" },
+        body: { selectedModel: "claude-sonnet-4-5" },
+      }),
+      [403],
+    );
+
+    expect(response.body.error.message).toBe(
+      "Only admins can manage org model providers",
+    );
+  });
+
+  it("returns 404 when the target provider is absent", async () => {
+    const fixture = uniqueOrgUser("zmp-model-missing");
+    await track(Promise.resolve({ orgId: fixture.orgId }));
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+    const client = setupApp({ context })(zeroModelProvidersUpdateModelContract);
+
+    const response = await accept(
+      client.updateModel({
+        headers: { authorization: "Bearer clerk-session" },
+        params: { type: "anthropic-api-key" },
+        body: { selectedModel: "claude-sonnet-4-5" },
+      }),
+      [404],
+    );
+
+    expect(response.body.error.message).toBe("Resource not found");
+  });
+
+  it("updates and clears the selected model for an org provider", async () => {
+    const fixture = uniqueOrgUser("zmp-model-update");
+    await track(Promise.resolve({ orgId: fixture.orgId }));
+    const seeded = await store.set(
+      seedOrgModelProvider$,
+      {
+        orgId: fixture.orgId,
+        type: "anthropic-api-key",
+        isDefault: true,
+        selectedModel: "claude-3-5-sonnet-latest",
+        secretName: "ANTHROPIC_API_KEY",
+      },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+    const client = setupApp({ context })(zeroModelProvidersUpdateModelContract);
+
+    const updated = await accept(
+      client.updateModel({
+        headers: { authorization: "Bearer clerk-session" },
+        params: { type: "anthropic-api-key" },
+        body: { selectedModel: "claude-sonnet-4-5" },
+      }),
+      [200],
+    );
+
+    expect(updated.body.id).toBe(seeded.id);
+    expect(updated.body.type).toBe("anthropic-api-key");
+    expect(updated.body.secretName).toBe("ANTHROPIC_API_KEY");
+    expect(updated.body.authMethod).toBeNull();
+    expect(updated.body.isDefault).toBeTruthy();
+    expect(updated.body.selectedModel).toBe("claude-sonnet-4-5");
+    await expect(
+      readOrgModelProviderState(fixture.orgId, "anthropic-api-key"),
+    ).resolves.toMatchObject({ selectedModel: "claude-sonnet-4-5" });
+
+    const cleared = await accept(
+      client.updateModel({
+        headers: { authorization: "Bearer clerk-session" },
+        params: { type: "anthropic-api-key" },
+        body: {},
+      }),
+      [200],
+    );
+
+    expect(cleared.body.id).toBe(seeded.id);
+    expect(cleared.body.selectedModel).toBeNull();
+    await expect(
+      readOrgModelProviderState(fixture.orgId, "anthropic-api-key"),
+    ).resolves.toMatchObject({ selectedModel: null });
   });
 });
 

--- a/turbo/apps/api/src/signals/routes/zero-model-providers.ts
+++ b/turbo/apps/api/src/signals/routes/zero-model-providers.ts
@@ -9,6 +9,7 @@ import {
   zeroModelProvidersByTypeContract,
   zeroModelProvidersDefaultContract,
   zeroModelProvidersMainContract,
+  zeroModelProvidersUpdateModelContract,
 } from "@vm0/api-contracts/contracts/zero-model-providers";
 
 import { organizationAuthContext$ } from "../auth/auth-context";
@@ -20,6 +21,7 @@ import { userFeatureSwitchOverrides } from "../services/feature-switches.service
 import {
   deleteOrgModelProvider$,
   setOrgModelProviderDefault$,
+  updateOrgModelProviderModel$,
   upsertOrgModelProvider$,
   upsertOrgMultiAuthModelProvider$,
   upsertOrgNoSecretModelProvider$,
@@ -236,6 +238,44 @@ const setDefaultModelProviderInner$ = command(
   },
 );
 
+const updateModelProviderModelInner$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const auth = get(organizationAuthContext$);
+    if (auth.orgRole !== "admin") {
+      return adminRequired;
+    }
+
+    const params = await get(
+      pathParamsOf(zeroModelProvidersUpdateModelContract.updateModel),
+    );
+    signal.throwIfAborted();
+
+    const bodyResult = await get(
+      bodyResultOf(zeroModelProvidersUpdateModelContract.updateModel),
+    );
+    signal.throwIfAborted();
+    if (!bodyResult.ok) {
+      return bodyResult.response;
+    }
+
+    const result = await set(
+      updateOrgModelProviderModel$,
+      {
+        orgId: auth.orgId,
+        type: params.type,
+        selectedModel: bodyResult.data.selectedModel,
+      },
+      signal,
+    );
+    signal.throwIfAborted();
+
+    if (isNotFoundResponse(result)) {
+      return result;
+    }
+    return { status: 200 as const, body: toModelProviderResponse(result) };
+  },
+);
+
 const deleteModelProviderInner$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     const auth = get(organizationAuthContext$);
@@ -282,6 +322,13 @@ export const zeroModelProvidersRoutes: readonly RouteEntry[] = [
     handler: authRoute(
       { requireOrganization: true, missingOrganizationStatus: 401 },
       setDefaultModelProviderInner$,
+    ),
+  },
+  {
+    route: zeroModelProvidersUpdateModelContract.updateModel,
+    handler: authRoute(
+      { requireOrganization: true, missingOrganizationStatus: 401 },
+      updateModelProviderModelInner$,
     ),
   },
   {

--- a/turbo/apps/api/src/signals/services/zero-model-provider.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-model-provider.service.ts
@@ -1109,3 +1109,62 @@ export const setOrgModelProviderDefault$ = command(
     });
   },
 );
+
+export const updateOrgModelProviderModel$ = command(
+  async (
+    { set },
+    args: {
+      readonly orgId: string;
+      readonly type: ModelProviderType;
+      readonly selectedModel?: string;
+    },
+    signal: AbortSignal,
+  ): Promise<NotFoundResponse | ModelProviderInfo> => {
+    const writeDb = set(writeDb$);
+    const secretName = getSecretNameForType(args.type) ?? null;
+    const updatedAt = nowDate();
+
+    const [provider] = await writeDb
+      .update(modelProviders)
+      .set({
+        selectedModel: args.selectedModel ?? null,
+        updatedAt,
+      })
+      .where(
+        and(
+          eq(modelProviders.orgId, args.orgId),
+          eq(modelProviders.userId, ORG_SENTINEL_USER_ID),
+          eq(modelProviders.type, args.type),
+        ),
+      )
+      .returning();
+    signal.throwIfAborted();
+
+    if (!provider) {
+      return notFound("Resource not found");
+    }
+
+    L.debug("model provider model updated", {
+      providerId: provider.id,
+      type: args.type,
+      selectedModel: args.selectedModel,
+    });
+
+    return toModelProviderInfo({
+      id: provider.id,
+      userId: ORG_SENTINEL_USER_ID,
+      type: args.type,
+      secretName,
+      authMethod: provider.authMethod,
+      isDefault: provider.isDefault,
+      selectedModel: provider.selectedModel,
+      tokenExpiresAt: provider.tokenExpiresAt,
+      needsReconnect: provider.needsReconnect,
+      lastRefreshErrorCode: provider.lastRefreshErrorCode,
+      workspaceName: provider.workspaceName,
+      planType: provider.planType,
+      createdAt: provider.createdAt,
+      updatedAt: provider.updatedAt,
+    });
+  },
+);


### PR DESCRIPTION
## Summary

- add API backend handling for `PATCH /api/zero/model-providers/:type/model`
- add a command-backed org model provider selected-model update service
- cover auth, not-found, update, and clear behavior with API integration tests

Closes #12843

## Validation

- `pnpm -F api exec vitest src/signals/routes/__tests__/zero-model-providers.test.ts`
- `pnpm -F api lint`
- `pnpm check-types`