### PR TITLE
refactor: route sandbox exec through command operations

### DIFF
--- a/crates/runner/src/cmd/benchmark.rs
+++ b/crates/runner/src/cmd/benchmark.rs
@@ -3,7 +3,10 @@ use std::process::ExitCode;
 use std::time::{Duration, Instant};
 
 use clap::Args;
-use sandbox::{ExecRequest, ExecResult, RuntimeProvider, SandboxConfig, SandboxFactory, SandboxId};
+use sandbox::{
+    EXEC_OUTPUT_LIMIT_7_MIB, ExecRequest, ExecResult, RuntimeProvider, SandboxConfig,
+    SandboxFactory, SandboxId,
+};
 use tracing::{info, warn};
 
 use crate::config;
@@ -286,6 +289,7 @@ async fn run_in_sandbox(
             timeout: Duration::from_secs(args.timeout_secs),
             env: &env_refs,
             sudo: args.sudo,
+            output_limits: EXEC_OUTPUT_LIMIT_7_MIB,
         })
         .await
         .map_err(Into::into);

--- a/crates/runner/src/cmd/exec.rs
+++ b/crates/runner/src/cmd/exec.rs
@@ -125,6 +125,16 @@ pub async fn run_exec(args: ExecArgs, control: &dyn SandboxControl) -> RunnerRes
             let err = std::io::stderr();
             let _ = out.lock().write_all(&result.stdout);
             let _ = err.lock().write_all(&result.stderr);
+            if result.stdout_truncated {
+                eprintln!(
+                    "warning: remote stdout was truncated by the sandbox capture limit; use a narrower command or redirect output inside the guest"
+                );
+            }
+            if result.stderr_truncated {
+                eprintln!(
+                    "warning: remote stderr was truncated by the sandbox capture limit; use a narrower command or redirect output inside the guest"
+                );
+            }
 
             // Propagate the actual exit code for debugging utility.
             // Truncate to u8 like shells do (e.g. 256 → 0, -1 → 255).
@@ -172,6 +182,8 @@ mod tests {
             exit_code: 42,
             stdout: b"hello\n".to_vec(),
             stderr: Vec::new(),
+            stdout_truncated: false,
+            stderr_truncated: false,
         }));
 
         let result = run_exec(make_args("test-id", "echo hello"), &control)
@@ -227,12 +239,16 @@ mod tests {
             exit_code: 256,
             stdout: Vec::new(),
             stderr: Vec::new(),
+            stdout_truncated: false,
+            stderr_truncated: false,
         }));
         // -1 (0xFFFFFFFF) truncates to 255 via `as u8`
         control.push_exec_remote_result(Ok(RemoteExecResult {
             exit_code: -1,
             stdout: Vec::new(),
             stderr: Vec::new(),
+            stdout_truncated: false,
+            stderr_truncated: false,
         }));
 
         let r1 = run_exec(make_args("id", "test"), &control).await.unwrap();

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -19,7 +19,10 @@ use std::panic::AssertUnwindSafe;
 use std::time::{Duration, Instant};
 
 use futures_util::FutureExt;
-use sandbox::{ExecRequest, Sandbox, SandboxConfig, SandboxFactory, SandboxId, SpawnOutputMode};
+use sandbox::{
+    CopyFileOptions, EXEC_OUTPUT_LIMIT_1_MIB, EXEC_OUTPUT_LIMIT_64_KIB, ExecRequest, Sandbox,
+    SandboxConfig, SandboxFactory, SandboxId, SpawnOutputMode, SpawnWatchRequest,
+};
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
@@ -33,6 +36,8 @@ const EXIT_SIGKILL: i32 = 137;
 const EXIT_SIGNAL_KILL: i32 = 9;
 /// Default timeout for guest commands (5 minutes).
 const DEFAULT_EXEC_TIMEOUT: Duration = Duration::from_secs(300);
+const SMALL_GUEST_FILE_MAX_BYTES: u64 = 64 * 1024;
+const GUEST_LOG_COPY_MAX_BYTES: u64 = 64 * 1024 * 1024;
 
 use crate::error::{RunnerError, RunnerResult};
 use crate::http::HttpClient;
@@ -551,17 +556,15 @@ async fn run_in_sandbox(
     // (host-side watchdog) so neither side outlives the other.
     let t = Instant::now();
     let handle = sandbox
-        .spawn_watch(
-            &ExecRequest {
-                cmd: &agent_cmd,
-                timeout: JOB_TIMEOUT,
-                env: &env_refs,
-                sudo: false,
-            },
-            SpawnOutputMode::Stream {
+        .spawn_watch(&SpawnWatchRequest {
+            cmd: &agent_cmd,
+            timeout: JOB_TIMEOUT,
+            env: &env_refs,
+            sudo: false,
+            output: SpawnOutputMode::Stream {
                 guest_log_path: None,
             },
-        )
+        })
         .await;
 
     let mut handle = match handle {
@@ -651,6 +654,7 @@ async fn run_in_sandbox(
             timeout: Duration::from_secs(5),
             env: &[],
             sudo: true,
+            output_limits: EXEC_OUTPUT_LIMIT_64_KIB,
         };
         match sandbox.exec(&dmesg_req).await {
             Ok(dmesg) if dmesg_indicates_oom(&String::from_utf8_lossy(&dmesg.stdout)) => {
@@ -698,18 +702,12 @@ async fn run_in_sandbox(
 async fn read_guest_error_file(sandbox: &dyn Sandbox, run_id: RunId) -> Option<String> {
     // Mirror of guest-agent paths::checkpoint_error_file()
     let error_path = format!("/tmp/vm0-checkpoint-error-{run_id}");
-    let cat_cmd = format!("cat {error_path} 2>/dev/null");
     match sandbox
-        .exec(&ExecRequest {
-            cmd: &cat_cmd,
-            timeout: Duration::from_secs(5),
-            env: &[],
-            sudo: false,
-        })
+        .read_file(&error_path, SMALL_GUEST_FILE_MAX_BYTES)
         .await
     {
-        Ok(result) if result.exit_code == 0 && !result.stdout.is_empty() => {
-            let msg = String::from_utf8_lossy(&result.stdout).trim().to_string();
+        Ok(Some(bytes)) if !bytes.is_empty() => {
+            let msg = String::from_utf8_lossy(&bytes).trim().to_string();
             Some(msg).filter(|s| !s.is_empty())
         }
         _ => None,
@@ -726,18 +724,9 @@ async fn read_guest_error_file(sandbox: &dyn Sandbox, run_id: RunId) -> Option<S
 async fn read_guest_session_id(sandbox: &dyn Sandbox, run_id: RunId) -> Option<String> {
     // Mirror of guest-agent paths::session_id_file()
     let path = format!("/tmp/vm0-session-{run_id}.txt");
-    let cmd = format!("cat {path} 2>/dev/null");
-    match sandbox
-        .exec(&ExecRequest {
-            cmd: &cmd,
-            timeout: Duration::from_secs(5),
-            env: &[],
-            sudo: false,
-        })
-        .await
-    {
-        Ok(result) if result.exit_code == 0 && !result.stdout.is_empty() => {
-            let id = String::from_utf8_lossy(&result.stdout).trim().to_string();
+    match sandbox.read_file(&path, SMALL_GUEST_FILE_MAX_BYTES).await {
+        Ok(Some(bytes)) if !bytes.is_empty() => {
+            let id = String::from_utf8_lossy(&bytes).trim().to_string();
             Some(id).filter(|s| !s.is_empty())
         }
         _ => None,
@@ -860,27 +849,19 @@ async fn copy_guest_logs(sandbox: &dyn Sandbox, context: &ExecutionContext, log_
     ];
 
     for (guest_path, host_path) in &files {
-        let cat_cmd = format!("cat '{guest_path}'");
-        let result = sandbox
-            .exec(&ExecRequest {
-                cmd: &cat_cmd,
-                timeout: DEFAULT_EXEC_TIMEOUT,
-                env: &[],
-                sudo: false,
-            })
-            .await;
-
-        let output = match result {
-            Ok(r) if r.exit_code == 0 => r.stdout,
-            Ok(_) => continue,
-            Err(e) => {
-                warn!(run_id = %run_id, error = %e, path = %guest_path, "failed to read guest log");
-                continue;
-            }
-        };
-
-        if let Err(e) = tokio::fs::write(host_path, &output).await {
-            warn!(run_id = %run_id, error = %e, path = %host_path.display(), "failed to write guest log to host");
+        if let Err(e) = sandbox
+            .copy_file(
+                guest_path,
+                host_path,
+                CopyFileOptions {
+                    max_bytes: GUEST_LOG_COPY_MAX_BYTES,
+                    timeout: DEFAULT_EXEC_TIMEOUT,
+                    missing_ok: true,
+                },
+            )
+            .await
+        {
+            warn!(run_id = %run_id, error = %e, guest_path = %guest_path, host_path = %host_path.display(), "failed to copy guest log");
         }
     }
 }
@@ -903,6 +884,7 @@ pub(crate) async fn fix_guest_clock(sandbox: &dyn Sandbox) -> RunnerResult<()> {
             timeout: DEFAULT_EXEC_TIMEOUT,
             env: &[],
             sudo: true,
+            output_limits: EXEC_OUTPUT_LIMIT_64_KIB,
         })
         .await?;
     Ok(())
@@ -933,6 +915,7 @@ pub(crate) async fn reseed_guest_entropy(sandbox: &dyn Sandbox) -> RunnerResult<
             timeout: DEFAULT_EXEC_TIMEOUT,
             env: &[],
             sudo: true,
+            output_limits: EXEC_OUTPUT_LIMIT_64_KIB,
         })
         .await?;
 
@@ -985,6 +968,7 @@ async fn sync_guest_timezone(sandbox: &dyn Sandbox, context: &ExecutionContext) 
             timeout: DEFAULT_EXEC_TIMEOUT,
             env: &[],
             sudo: true,
+            output_limits: EXEC_OUTPUT_LIMIT_64_KIB,
         })
         .await
     {
@@ -1127,6 +1111,7 @@ async fn download_storages(
             timeout: DEFAULT_EXEC_TIMEOUT,
             env: &download_env,
             sudo: false,
+            output_limits: EXEC_OUTPUT_LIMIT_1_MIB,
         })
         .await?;
 
@@ -2492,11 +2477,11 @@ mod tests {
     async fn reseed_guest_entropy_fails_on_nonzero_exit() {
         let sandbox = MockSandbox::new("test");
         // guest-reseed exits with code 1 (e.g., ioctl failed).
-        sandbox.push_exec_result(Ok(ExecResult {
-            exit_code: 1,
-            stdout: Vec::new(),
-            stderr: b"RNDADDENTROPY failed: Operation not permitted".to_vec(),
-        }));
+        sandbox.push_exec_result(Ok(ExecResult::new(
+            1,
+            Vec::new(),
+            b"RNDADDENTROPY failed: Operation not permitted".to_vec(),
+        )));
         let result = reseed_guest_entropy(&sandbox).await;
         assert!(result.is_err());
         let msg = result.unwrap_err().to_string();
@@ -2544,11 +2529,7 @@ mod tests {
     #[tokio::test]
     async fn read_guest_error_file_returns_content() {
         let sandbox = MockSandbox::new("test");
-        sandbox.push_exec_result(Ok(ExecResult {
-            exit_code: 0,
-            stdout: b"checkpoint error: disk full".to_vec(),
-            stderr: Vec::new(),
-        }));
+        sandbox.push_read_file_result(Ok(Some(b"checkpoint error: disk full".to_vec())));
         let msg = read_guest_error_file(&sandbox, RunId::nil()).await;
         assert_eq!(msg.as_deref(), Some("checkpoint error: disk full"));
     }
@@ -2556,11 +2537,7 @@ mod tests {
     #[tokio::test]
     async fn read_guest_error_file_returns_none_on_missing_file() {
         let sandbox = MockSandbox::new("test");
-        sandbox.push_exec_result(Ok(ExecResult {
-            exit_code: 1, // cat fails — file not found
-            stdout: Vec::new(),
-            stderr: b"No such file".to_vec(),
-        }));
+        sandbox.push_read_file_result(Ok(None));
         let msg = read_guest_error_file(&sandbox, RunId::nil()).await;
         assert!(msg.is_none());
     }
@@ -2568,11 +2545,7 @@ mod tests {
     #[tokio::test]
     async fn read_guest_error_file_returns_none_on_empty_content() {
         let sandbox = MockSandbox::new("test");
-        sandbox.push_exec_result(Ok(ExecResult {
-            exit_code: 0,
-            stdout: b"   \n  ".to_vec(), // whitespace-only
-            stderr: Vec::new(),
-        }));
+        sandbox.push_read_file_result(Ok(Some(b"   \n  ".to_vec())));
         let msg = read_guest_error_file(&sandbox, RunId::nil()).await;
         assert!(msg.is_none());
     }
@@ -2580,7 +2553,7 @@ mod tests {
     #[tokio::test]
     async fn read_guest_error_file_returns_none_on_exec_error() {
         let sandbox = MockSandbox::new("test");
-        sandbox.push_exec_result(Err(sandbox_exec_error("vsock timeout")));
+        sandbox.push_read_file_result(Err(sandbox_exec_error("vsock timeout")));
         let msg = read_guest_error_file(&sandbox, RunId::nil()).await;
         assert!(msg.is_none());
     }
@@ -2630,11 +2603,11 @@ mod tests {
     async fn download_storages_nonzero_exit_code() {
         let sandbox = MockSandbox::new("test");
         // write_file succeeds, but exec returns non-zero.
-        sandbox.push_exec_result(Ok(ExecResult {
-            exit_code: 1,
-            stdout: Vec::new(),
-            stderr: b"download failed".to_vec(),
-        }));
+        sandbox.push_exec_result(Ok(ExecResult::new(
+            1,
+            Vec::new(),
+            b"download failed".to_vec(),
+        )));
         let ctx = minimal_context();
         let manifest = GuestDownloadManifest {
             storages: vec![],
@@ -2778,17 +2751,9 @@ mod tests {
         .await
         .unwrap();
 
-        // Queue two exec results: system log + metrics log
-        sandbox.push_exec_result(Ok(ExecResult {
-            exit_code: 0,
-            stdout: b"system log line 1\nsystem log line 2\n".to_vec(),
-            stderr: Vec::new(),
-        }));
-        sandbox.push_exec_result(Ok(ExecResult {
-            exit_code: 0,
-            stdout: b"{\"cpu\":0.5}\n".to_vec(),
-            stderr: Vec::new(),
-        }));
+        // Queue two guest-copy results: system log + metrics log.
+        sandbox.push_copy_file_result(Ok(b"system log line 1\nsystem log line 2\n".to_vec()));
+        sandbox.push_copy_file_result(Ok(b"{\"cpu\":0.5}\n".to_vec()));
 
         copy_guest_logs(&sandbox, &ctx, &log_paths).await;
 
@@ -2811,17 +2776,9 @@ mod tests {
         let sandbox = MockSandbox::new("test");
         let ctx = minimal_context();
 
-        // cat fails (file doesn't exist in guest)
-        sandbox.push_exec_result(Ok(ExecResult {
-            exit_code: 1,
-            stdout: Vec::new(),
-            stderr: b"No such file".to_vec(),
-        }));
-        sandbox.push_exec_result(Ok(ExecResult {
-            exit_code: 1,
-            stdout: Vec::new(),
-            stderr: Vec::new(),
-        }));
+        // Copy fails (file doesn't exist in guest).
+        sandbox.push_copy_file_result(Err(sandbox_exec_error("No such file")));
+        sandbox.push_copy_file_result(Err(sandbox_exec_error("No such file")));
 
         copy_guest_logs(&sandbox, &ctx, &log_paths).await;
 
@@ -2837,8 +2794,8 @@ mod tests {
         let sandbox = MockSandbox::new("test");
         let ctx = minimal_context();
 
-        sandbox.push_exec_result(Err(sandbox_exec_error("vsock down")));
-        sandbox.push_exec_result(Err(sandbox_exec_error("vsock down")));
+        sandbox.push_copy_file_result(Err(sandbox_exec_error("vsock down")));
+        sandbox.push_copy_file_result(Err(sandbox_exec_error("vsock down")));
 
         copy_guest_logs(&sandbox, &ctx, &log_paths).await;
 
@@ -3473,11 +3430,7 @@ mod tests {
 
         // First exec (fix_guest_clock) succeeds, second (reseed_guest_entropy) fails
         let sandbox = MockSandbox::new("reuse-reseed-fail");
-        sandbox.push_exec_result(Ok(ExecResult {
-            exit_code: 0,
-            stdout: Vec::new(),
-            stderr: Vec::new(),
-        }));
+        sandbox.push_exec_result(Ok(ExecResult::new(0, Vec::new(), Vec::new())));
         sandbox.push_exec_result(Err(sandbox_exec_error("reseed timeout")));
 
         let cancel = tokio_util::sync::CancellationToken::new();

--- a/crates/runner/src/paths.rs
+++ b/crates/runner/src/paths.rs
@@ -369,13 +369,28 @@ impl LogPaths {
     /// Whether `name` matches any GC-eligible log file pattern.
     ///
     /// Includes per-job logs (`network-*`, `system-*`, `metrics-*`, `proxy-*`)
-    /// and runner instance logs (`runner-*.log`).
+    /// runner instance logs (`runner-*.log`), and stale `.vm0tmp-*` copies of
+    /// those files left behind by a killed runner.
     pub fn is_gc_eligible_log(name: &str) -> bool {
+        Self::is_final_gc_eligible_log(name) || Self::is_gc_eligible_log_temp(name)
+    }
+
+    fn is_final_gc_eligible_log(name: &str) -> bool {
         (name.starts_with("network-") && name.ends_with(".jsonl"))
             || (name.starts_with("system-") && name.ends_with(".log"))
             || (name.starts_with("metrics-") && name.ends_with(".jsonl"))
             || (name.starts_with("proxy-") && name.ends_with(".jsonl"))
             || (name.starts_with("runner-") && name.ends_with(".log"))
+    }
+
+    fn is_gc_eligible_log_temp(name: &str) -> bool {
+        let Some(name) = name.strip_prefix('.') else {
+            return false;
+        };
+        let Some((base, suffix)) = name.split_once(".vm0tmp-") else {
+            return false;
+        };
+        !suffix.is_empty() && Self::is_final_gc_eligible_log(base)
     }
 }
 
@@ -565,6 +580,12 @@ mod tests {
             "proxy-550e8400-e29b-41d4-a716-446655440000.jsonl"
         ));
         assert!(LogPaths::is_gc_eligible_log("runner-2026-04-01.log"));
+        assert!(LogPaths::is_gc_eligible_log(
+            ".system-550e8400-e29b-41d4-a716-446655440000.log.vm0tmp-101-7-1"
+        ));
+        assert!(LogPaths::is_gc_eligible_log(
+            ".metrics-550e8400-e29b-41d4-a716-446655440000.jsonl.vm0tmp-101-7-2"
+        ));
     }
 
     #[test]
@@ -575,6 +596,12 @@ mod tests {
         assert!(!LogPaths::is_gc_eligible_log("system-.jsonl")); // wrong extension
         assert!(!LogPaths::is_gc_eligible_log("proxy-.log")); // wrong extension
         assert!(!LogPaths::is_gc_eligible_log("other-file.jsonl"));
+        assert!(!LogPaths::is_gc_eligible_log(
+            ".system-550e8400-e29b-41d4-a716-446655440000.log.vm0tmp-"
+        ));
+        assert!(!LogPaths::is_gc_eligible_log(
+            ".other-file.jsonl.vm0tmp-101-7-1"
+        ));
     }
 
     #[test]

--- a/crates/sandbox-fc/src/control.rs
+++ b/crates/sandbox-fc/src/control.rs
@@ -54,6 +54,8 @@ pub enum ExecResponse {
         exit_code: i32,
         stdout: String,
         stderr: String,
+        stdout_truncated: bool,
+        stderr_truncated: bool,
     },
     Error {
         error: String,
@@ -66,6 +68,7 @@ pub enum ExecResponse {
 
 /// Maximum frame size: 64 MiB (generous for large stdout/stderr).
 const MAX_FRAME_SIZE: u32 = 64 * 1024 * 1024;
+const RUNNER_EXEC_CAPTURE_LIMIT_BYTES: u32 = 7 * 1024 * 1024;
 const CONTROL_SERVER_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(1);
 const CONTROL_HANDLER_SHUTDOWN_GRACE: Duration = Duration::from_millis(250);
 
@@ -416,13 +419,24 @@ async fn execute(
     let env: &[(&str, &str)] = &[];
 
     match vsock
-        .exec(&request.command, timeout_ms, env, request.sudo)
+        .exec_capture(vsock_host::CommandCaptureRequest {
+            command: &request.command,
+            timeout_ms,
+            env,
+            sudo: request.sudo,
+            label: "runner-exec",
+            stdout_limit_bytes: RUNNER_EXEC_CAPTURE_LIMIT_BYTES,
+            stderr_limit_bytes: RUNNER_EXEC_CAPTURE_LIMIT_BYTES,
+            wait_timeout: Duration::from_millis(timeout_ms as u64 + 5000),
+        })
         .await
     {
         Ok(result) => ExecResponse::Success {
             exit_code: result.exit_code,
             stdout: BASE64.encode(&result.stdout),
             stderr: BASE64.encode(&result.stderr),
+            stdout_truncated: result.stdout_truncated,
+            stderr_truncated: result.stderr_truncated,
         },
         Err(e) => ExecResponse::Error {
             error: format!("exec failed: {e}"),
@@ -509,6 +523,8 @@ impl SandboxControl for FirecrackerControl {
                 exit_code,
                 stdout,
                 stderr,
+                stdout_truncated,
+                stderr_truncated,
             } => {
                 let stdout_bytes = BASE64
                     .decode(&stdout)
@@ -520,6 +536,8 @@ impl SandboxControl for FirecrackerControl {
                     exit_code,
                     stdout: stdout_bytes,
                     stderr: stderr_bytes,
+                    stdout_truncated,
+                    stderr_truncated,
                 })
             }
             ExecResponse::Error { error } => Err(SandboxControlError::Remote(error)),
@@ -586,7 +604,7 @@ fn resolve_control_socket_in(
 mod tests {
     use super::*;
     use tokio::sync::oneshot;
-    use vsock_proto::{Decoder, MSG_EXEC, MSG_PING, MSG_PONG, MSG_READY, RawMessage};
+    use vsock_proto::{Decoder, MSG_COMMAND_START, MSG_PING, MSG_PONG, MSG_READY, RawMessage};
 
     #[tokio::test]
     async fn exec_remote_empty_id() {
@@ -651,6 +669,8 @@ mod tests {
             exit_code: 0,
             stdout: BASE64.encode(b"hello\n"),
             stderr: BASE64.encode(b""),
+            stdout_truncated: false,
+            stderr_truncated: false,
         };
         let response_json = serde_json::to_vec(&response).unwrap();
         let decoded: ExecResponse = serde_json::from_slice(&response_json).unwrap();
@@ -659,10 +679,14 @@ mod tests {
                 exit_code,
                 stdout,
                 stderr,
+                stdout_truncated,
+                stderr_truncated,
             } => {
                 assert_eq!(exit_code, 0);
                 assert_eq!(BASE64.decode(stdout).unwrap(), b"hello\n");
                 assert_eq!(BASE64.decode(stderr).unwrap(), b"");
+                assert!(!stdout_truncated);
+                assert!(!stderr_truncated);
             }
             ExecResponse::Error { .. } => panic!("expected success"),
         }
@@ -950,7 +974,7 @@ mod tests {
             }
             let messages = decoder.decode(&buf[..n]).unwrap();
             for message in messages {
-                if message.msg_type == MSG_EXEC {
+                if message.msg_type == MSG_COMMAND_START {
                     if let Some(tx) = exec_seen.take() {
                         let _ = tx.send(());
                     }
@@ -986,6 +1010,8 @@ mod tests {
             exit_code: 0,
             stdout: BASE64.encode(b"output\n"),
             stderr: BASE64.encode(b""),
+            stdout_truncated: false,
+            stderr_truncated: false,
         };
         let json = serde_json::to_value(&resp).unwrap();
         // Untagged enum: no "type" field, just the fields directly

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -8,9 +8,9 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use sandbox::{
-    ExecRequest, ExecResult, ProcessExit, Sandbox, SandboxConfig, SandboxError,
-    SandboxIdleTransition, SandboxInvalidStateContext, SandboxOperation, SandboxOperationReason,
-    SpawnHandle,
+    CopyFileOptions, CopyFileResult, ExecRequest, ExecResult, ProcessExit, Sandbox, SandboxConfig,
+    SandboxError, SandboxIdleTransition, SandboxInvalidStateContext, SandboxOperation,
+    SandboxOperationReason, SpawnHandle, SpawnWatchRequest,
 };
 use tokio::io::{AsyncBufReadExt, AsyncRead, BufReader};
 use tokio::sync::{mpsc, watch};
@@ -1339,15 +1339,75 @@ impl Sandbox for FirecrackerSandbox {
     async fn exec(&self, request: &ExecRequest<'_>) -> sandbox::Result<ExecResult> {
         let operation = SandboxOperation::Exec;
         let guest = self.operation_guest(operation).await?;
+        let limits = request.output_limits;
 
         tokio::select! {
-            result = guest.exec(request.cmd, request.timeout_ms(), request.env, request.sudo) => {
+            result = guest.exec_capture(
+                vsock_host::CommandCaptureRequest {
+                    command: request.cmd,
+                    timeout_ms: request.timeout_ms(),
+                    env: request.env,
+                    sudo: request.sudo,
+                    label: "sandbox-exec",
+                    stdout_limit_bytes: limits.stdout_limit_bytes,
+                    stderr_limit_bytes: limits.stderr_limit_bytes,
+                    wait_timeout: Duration::from_millis(request.timeout_ms() as u64 + 5000),
+                }
+            ) => {
                 let result = result.map_err(|e| Self::operation_error(operation, e, self.has_backend_crashed()))?;
                 Ok(ExecResult {
                     exit_code: result.exit_code,
                     stdout: result.stdout,
                     stderr: result.stderr,
+                    stdout_truncated: result.stdout_truncated,
+                    stderr_truncated: result.stderr_truncated,
                 })
+            }
+            () = wait_for_backend_crash(self.state_tx.subscribe()) => {
+                Err(Self::backend_crashed_error(operation))
+            }
+        }
+    }
+
+    async fn read_file(&self, path: &str, max_bytes: u64) -> sandbox::Result<Option<Vec<u8>>> {
+        let operation = SandboxOperation::Exec;
+        let guest = self.operation_guest(operation).await?;
+
+        tokio::select! {
+            result = guest.read_file(path, max_bytes, 5000) => {
+                result.map_err(|e| Self::operation_error(operation, e, self.has_backend_crashed()))
+            }
+            () = wait_for_backend_crash(self.state_tx.subscribe()) => {
+                Err(Self::backend_crashed_error(operation))
+            }
+        }
+    }
+
+    async fn copy_file(
+        &self,
+        path: &str,
+        host_path: &Path,
+        options: CopyFileOptions,
+    ) -> sandbox::Result<CopyFileResult> {
+        let operation = SandboxOperation::Exec;
+        let guest = self.operation_guest(operation).await?;
+        let timeout_ms = u32::try_from(options.timeout.as_millis()).unwrap_or(u32::MAX);
+
+        tokio::select! {
+            result = guest.copy_file(
+                path,
+                host_path,
+                vsock_host::CopyFileOptions {
+                    max_bytes: options.max_bytes,
+                    timeout_ms,
+                    missing_ok: options.missing_ok,
+                },
+            ) => {
+                result
+                    .map(|result| CopyFileResult {
+                        bytes_copied: result.bytes_copied,
+                    })
+                    .map_err(|e| Self::operation_error(operation, e, self.has_backend_crashed()))
             }
             () = wait_for_backend_crash(self.state_tx.subscribe()) => {
                 Err(Self::backend_crashed_error(operation))
@@ -1369,11 +1429,7 @@ impl Sandbox for FirecrackerSandbox {
         }
     }
 
-    async fn spawn_watch(
-        &self,
-        request: &ExecRequest<'_>,
-        output: sandbox::SpawnOutputMode<'_>,
-    ) -> sandbox::Result<SpawnHandle> {
+    async fn spawn_watch(&self, request: &SpawnWatchRequest<'_>) -> sandbox::Result<SpawnHandle> {
         let operation = SandboxOperation::SpawnWatch;
         let guest = self.operation_guest(operation).await?;
 
@@ -1383,13 +1439,13 @@ impl Sandbox for FirecrackerSandbox {
                 request.timeout_ms(),
                 request.env,
                 request.sudo,
-                output.streams_stdout(),
-                output.guest_log_path(),
+                request.output.streams_stdout(),
+                request.output.guest_log_path(),
             ) => {
                 let (pid, stdout_rx) = result.map_err(|e| Self::operation_error(operation, e, self.has_backend_crashed()))?;
                 Ok(SpawnHandle {
                     pid,
-                    stdout_rx: output.streams_stdout().then_some(stdout_rx),
+                    stdout_rx: request.output.streams_stdout().then_some(stdout_rx),
                 })
             }
             () = wait_for_backend_crash(self.state_tx.subscribe()) => {

--- a/crates/sandbox-fc/src/snapshot.rs
+++ b/crates/sandbox-fc/src/snapshot.rs
@@ -30,6 +30,9 @@ const API_READY_TIMEOUT: Duration = Duration::from_secs(5);
 /// Timeout for waiting for the guest to connect via vsock after start.
 const VSOCK_CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
 
+/// Pre-warm should be quiet; keep diagnostics bounded and explicit.
+const PREWARM_EXEC_CAPTURE_LIMIT_BYTES: u32 = 64 * 1024;
+
 pub const SNAPSHOT_COMPLETE_MARKER_CONTENT: &[u8] = b"snapshot-complete-v1\n";
 
 use crate::factory::{DESTROY_RETRIES, DESTROY_RETRY_DELAY};
@@ -2001,7 +2004,16 @@ async fn run_with_firecracker(
     //      are fast. The snapshot captures memory + disk state, so caches
     //      populated here persist across restores.
     let prewarm_result = guest
-        .exec(inv.prewarm_script, 30_000, &[], false)
+        .exec_capture(vsock_host::CommandCaptureRequest {
+            command: inv.prewarm_script,
+            timeout_ms: 30_000,
+            env: &[],
+            sudo: false,
+            label: "snapshot-prewarm",
+            stdout_limit_bytes: PREWARM_EXEC_CAPTURE_LIMIT_BYTES,
+            stderr_limit_bytes: PREWARM_EXEC_CAPTURE_LIMIT_BYTES,
+            wait_timeout: Duration::from_millis(35_000),
+        })
         .await
         .map_err(|e| SnapshotError::Setup(format!("pre-warm exec: {e}")))?;
     if prewarm_result.exit_code != 0 {

--- a/crates/sandbox-mock/src/lib.rs
+++ b/crates/sandbox-mock/src/lib.rs
@@ -804,6 +804,20 @@ impl Sandbox for MockSandbox {
                 timeout: options.timeout,
                 missing_ok: options.missing_ok,
             });
+        if options.max_bytes == 0 {
+            return Err(SandboxError::Operation {
+                operation: SandboxOperation::Exec,
+                reason: SandboxOperationReason::Other,
+                message: "mock copy_file max_bytes must be positive".into(),
+            });
+        }
+        if options.timeout.is_zero() {
+            return Err(SandboxError::Operation {
+                operation: SandboxOperation::Exec,
+                reason: SandboxOperationReason::Other,
+                message: "mock copy_file timeout must be positive".into(),
+            });
+        }
 
         let queued = self.copy_file_results.lock_ignoring_poison().pop_front();
         let bytes = match queued {
@@ -1425,6 +1439,45 @@ mod tests {
             .unwrap_err();
 
         assert!(err.to_string().contains("exceeded 3 bytes"));
+        assert!(!path.exists());
+    }
+
+    #[tokio::test]
+    async fn sandbox_copy_file_rejects_invalid_options() {
+        let sandbox = MockSandbox::new("test-1");
+        let path = std::env::temp_dir().join(format!(
+            "sandbox-mock-copy-invalid-{}",
+            uuid::Uuid::new_v4().simple()
+        ));
+
+        let err = sandbox
+            .copy_file(
+                "/tmp/system.log",
+                &path,
+                CopyFileOptions {
+                    max_bytes: 0,
+                    timeout: Duration::from_secs(5),
+                    missing_ok: true,
+                },
+            )
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("max_bytes must be positive"));
+        assert!(!path.exists());
+
+        let err = sandbox
+            .copy_file(
+                "/tmp/system.log",
+                &path,
+                CopyFileOptions {
+                    max_bytes: 1024,
+                    timeout: Duration::ZERO,
+                    missing_ok: true,
+                },
+            )
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("timeout must be positive"));
         assert!(!path.exists());
     }
 

--- a/crates/sandbox-mock/src/lib.rs
+++ b/crates/sandbox-mock/src/lib.rs
@@ -801,7 +801,9 @@ impl Sandbox for MockSandbox {
                 message: format!("mock copy_file exceeded {} bytes", options.max_bytes),
             });
         }
-        if let Some(parent) = host_path.parent() {
+        if let Some(parent) = host_path.parent()
+            && !parent.as_os_str().is_empty()
+        {
             std::fs::create_dir_all(parent)?;
         }
         std::fs::write(host_path, &bytes)?;
@@ -1405,6 +1407,34 @@ mod tests {
 
         assert!(err.to_string().contains("exceeded 3 bytes"));
         assert!(!path.exists());
+    }
+
+    #[tokio::test]
+    async fn sandbox_copy_file_allows_relative_host_path_without_parent() {
+        let sandbox = MockSandbox::new("test-1");
+        sandbox.push_copy_file_result(Ok(b"log line\n".to_vec()));
+        let file_name = format!(
+            "sandbox-mock-copy-relative-{}",
+            uuid::Uuid::new_v4().simple()
+        );
+        let path = Path::new(&file_name);
+
+        let result = sandbox
+            .copy_file(
+                "/tmp/system.log",
+                path,
+                CopyFileOptions {
+                    max_bytes: 1024,
+                    timeout: Duration::from_secs(5),
+                    missing_ok: false,
+                },
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result.bytes_copied, 9);
+        assert_eq!(std::fs::read(path).unwrap(), b"log line\n");
+        let _ = std::fs::remove_file(path);
     }
 
     #[tokio::test]

--- a/crates/sandbox-mock/src/lib.rs
+++ b/crates/sandbox-mock/src/lib.rs
@@ -764,10 +764,29 @@ impl Sandbox for MockSandbox {
                 path: path.to_string(),
                 max_bytes,
             });
-        self.read_file_results
+        if max_bytes == 0 {
+            return Err(SandboxError::Operation {
+                operation: SandboxOperation::Exec,
+                reason: SandboxOperationReason::Other,
+                message: "mock read_file max_bytes must be positive".into(),
+            });
+        }
+
+        let result = self
+            .read_file_results
             .lock_ignoring_poison()
             .pop_front()
-            .unwrap_or(Ok(None))
+            .unwrap_or(Ok(None))?;
+        if let Some(bytes) = &result
+            && bytes.len() as u64 > max_bytes
+        {
+            return Err(SandboxError::Operation {
+                operation: SandboxOperation::Exec,
+                reason: SandboxOperationReason::Other,
+                message: format!("mock read_file exceeded {max_bytes} bytes"),
+            });
+        }
+        Ok(result)
     }
 
     async fn copy_file(
@@ -1435,6 +1454,25 @@ mod tests {
         assert_eq!(result.bytes_copied, 9);
         assert_eq!(std::fs::read(path).unwrap(), b"log line\n");
         let _ = std::fs::remove_file(path);
+    }
+
+    #[tokio::test]
+    async fn sandbox_read_file_applies_mock_max_bytes() {
+        let sandbox = MockSandbox::new("test-1");
+        sandbox.push_read_file_result(Ok(Some(b"too long".to_vec())));
+
+        let err = sandbox.read_file("/tmp/system.log", 3).await.unwrap_err();
+
+        assert!(err.to_string().contains("exceeded 3 bytes"));
+    }
+
+    #[tokio::test]
+    async fn sandbox_read_file_rejects_zero_max_bytes() {
+        let sandbox = MockSandbox::new("test-1");
+
+        let err = sandbox.read_file("/tmp/system.log", 0).await.unwrap_err();
+
+        assert!(err.to_string().contains("max_bytes must be positive"));
     }
 
     #[tokio::test]

--- a/crates/sandbox-mock/src/lib.rs
+++ b/crates/sandbox-mock/src/lib.rs
@@ -17,7 +17,7 @@
 //! ```
 
 use std::collections::VecDeque;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex, MutexGuard};
 use std::time::Duration;
 
@@ -61,6 +61,21 @@ pub struct SpawnWatchCall {
 pub struct WriteFileCall {
     pub path: String,
     pub content: Vec<u8>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ReadFileCall {
+    pub path: String,
+    pub max_bytes: u64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CopyFileCall {
+    pub path: String,
+    pub host_path: PathBuf,
+    pub max_bytes: u64,
+    pub timeout: Duration,
+    pub missing_ok: bool,
 }
 
 enum LifecycleBehavior {
@@ -524,6 +539,10 @@ pub struct MockSandbox {
     id: String,
     source_ip: String,
     exec_results: Mutex<VecDeque<Result<ExecResult>>>,
+    read_file_results: Mutex<VecDeque<Result<Option<Vec<u8>>>>>,
+    read_file_calls: Mutex<Vec<ReadFileCall>>,
+    copy_file_results: Mutex<VecDeque<Result<Vec<u8>>>>,
+    copy_file_calls: Mutex<Vec<CopyFileCall>>,
     write_file_results: Mutex<VecDeque<Result<()>>>,
     write_file_calls: Mutex<Vec<WriteFileCall>>,
     overrides: Option<Arc<MockSandboxOverrides>>,
@@ -539,6 +558,10 @@ impl MockSandbox {
             id: id.into(),
             source_ip: "10.0.0.1".into(),
             exec_results: Mutex::new(VecDeque::new()),
+            read_file_results: Mutex::new(VecDeque::new()),
+            read_file_calls: Mutex::new(Vec::new()),
+            copy_file_results: Mutex::new(VecDeque::new()),
+            copy_file_calls: Mutex::new(Vec::new()),
             write_file_results: Mutex::new(VecDeque::new()),
             write_file_calls: Mutex::new(Vec::new()),
             overrides: None,
@@ -551,6 +574,10 @@ impl MockSandbox {
             id: id.into(),
             source_ip: "10.0.0.1".into(),
             exec_results: Mutex::new(VecDeque::new()),
+            read_file_results: Mutex::new(VecDeque::new()),
+            read_file_calls: Mutex::new(Vec::new()),
+            copy_file_results: Mutex::new(VecDeque::new()),
+            copy_file_calls: Mutex::new(Vec::new()),
             write_file_results: Mutex::new(VecDeque::new()),
             write_file_calls: Mutex::new(Vec::new()),
             overrides: Some(overrides),
@@ -566,6 +593,29 @@ impl MockSandbox {
     /// Queue an exec result. Results are consumed in FIFO order.
     pub fn push_exec_result(&self, result: Result<ExecResult>) {
         self.exec_results.lock_ignoring_poison().push_back(result);
+    }
+
+    /// Queue a small file read result. Results are consumed in FIFO order.
+    pub fn push_read_file_result(&self, result: Result<Option<Vec<u8>>>) {
+        self.read_file_results
+            .lock_ignoring_poison()
+            .push_back(result);
+    }
+
+    pub fn read_file_calls(&self) -> Vec<ReadFileCall> {
+        self.read_file_calls.lock_ignoring_poison().clone()
+    }
+
+    /// Queue bytes for a guest-to-host copy. The mock writes the bytes to the
+    /// requested host path and returns the copied byte count.
+    pub fn push_copy_file_result(&self, result: Result<Vec<u8>>) {
+        self.copy_file_results
+            .lock_ignoring_poison()
+            .push_back(result);
+    }
+
+    pub fn copy_file_calls(&self) -> Vec<CopyFileCall> {
+        self.copy_file_calls.lock_ignoring_poison().clone()
     }
 
     /// Queue a write_file result. Results are consumed in FIFO order.
@@ -586,7 +636,21 @@ fn default_exec_result() -> ExecResult {
         exit_code: 0,
         stdout: Vec::new(),
         stderr: Vec::new(),
+        stdout_truncated: false,
+        stderr_truncated: false,
     }
+}
+
+fn apply_exec_output_limits(mut result: ExecResult, limits: ExecOutputLimits) -> ExecResult {
+    if result.stdout.len() > limits.stdout_limit_bytes as usize {
+        result.stdout.truncate(limits.stdout_limit_bytes as usize);
+        result.stdout_truncated = true;
+    }
+    if result.stderr.len() > limits.stderr_limit_bytes as usize {
+        result.stderr.truncate(limits.stderr_limit_bytes as usize);
+        result.stderr_truncated = true;
+    }
+    result
 }
 
 #[async_trait]
@@ -664,24 +728,86 @@ impl Sandbox for MockSandbox {
 
     async fn exec(&self, request: &ExecRequest<'_>) -> Result<ExecResult> {
         // Check pattern matchers before the FIFO queue.
-        if let Some(overrides) = &self.overrides {
+        let result = if let Some(overrides) = &self.overrides {
             let mut matchers = overrides.exec_matchers.lock_ignoring_poison();
             if let Some(idx) = matchers
                 .iter()
                 .position(|m| request.cmd.contains(&m.pattern))
             {
                 let m = matchers.remove(idx);
-                return Ok(ExecResult {
+                Ok(ExecResult {
                     exit_code: m.exit_code,
                     stdout: m.stdout,
                     stderr: m.stderr,
-                });
+                    stdout_truncated: false,
+                    stderr_truncated: false,
+                })
+            } else {
+                self.exec_results
+                    .lock_ignoring_poison()
+                    .pop_front()
+                    .unwrap_or_else(|| Ok(default_exec_result()))
             }
-        }
-        self.exec_results
+        } else {
+            self.exec_results
+                .lock_ignoring_poison()
+                .pop_front()
+                .unwrap_or_else(|| Ok(default_exec_result()))
+        }?;
+        Ok(apply_exec_output_limits(result, request.output_limits))
+    }
+
+    async fn read_file(&self, path: &str, max_bytes: u64) -> Result<Option<Vec<u8>>> {
+        self.read_file_calls
+            .lock_ignoring_poison()
+            .push(ReadFileCall {
+                path: path.to_string(),
+                max_bytes,
+            });
+        self.read_file_results
             .lock_ignoring_poison()
             .pop_front()
-            .unwrap_or_else(|| Ok(default_exec_result()))
+            .unwrap_or(Ok(None))
+    }
+
+    async fn copy_file(
+        &self,
+        path: &str,
+        host_path: &Path,
+        options: CopyFileOptions,
+    ) -> Result<CopyFileResult> {
+        self.copy_file_calls
+            .lock_ignoring_poison()
+            .push(CopyFileCall {
+                path: path.to_string(),
+                host_path: host_path.to_path_buf(),
+                max_bytes: options.max_bytes,
+                timeout: options.timeout,
+                missing_ok: options.missing_ok,
+            });
+
+        let queued = self.copy_file_results.lock_ignoring_poison().pop_front();
+        let bytes = match queued {
+            Some(result) => result?,
+            None if options.missing_ok => {
+                return Ok(CopyFileResult { bytes_copied: 0 });
+            }
+            None => Vec::new(),
+        };
+        if bytes.len() as u64 > options.max_bytes {
+            return Err(SandboxError::Operation {
+                operation: SandboxOperation::Exec,
+                reason: SandboxOperationReason::Other,
+                message: format!("mock copy_file exceeded {} bytes", options.max_bytes),
+            });
+        }
+        if let Some(parent) = host_path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        std::fs::write(host_path, &bytes)?;
+        Ok(CopyFileResult {
+            bytes_copied: bytes.len() as u64,
+        })
     }
 
     async fn write_file(&self, path: &str, content: &[u8]) -> Result<()> {
@@ -697,18 +823,14 @@ impl Sandbox for MockSandbox {
             .unwrap_or(Ok(()))
     }
 
-    async fn spawn_watch(
-        &self,
-        _request: &ExecRequest<'_>,
-        output: sandbox::SpawnOutputMode<'_>,
-    ) -> Result<SpawnHandle> {
+    async fn spawn_watch(&self, request: &SpawnWatchRequest<'_>) -> Result<SpawnHandle> {
         if let Some(overrides) = &self.overrides {
             overrides
                 .spawn_watch_calls
                 .lock_ignoring_poison()
                 .push(SpawnWatchCall {
-                    streams_stdout: output.streams_stdout(),
-                    guest_log_path: output.guest_log_path().map(str::to_owned),
+                    streams_stdout: request.output.streams_stdout(),
+                    guest_log_path: request.output.guest_log_path().map(str::to_owned),
                 });
         }
         let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
@@ -723,7 +845,7 @@ impl Sandbox for MockSandbox {
         }
         Ok(SpawnHandle {
             pid: 1,
-            stdout_rx: output.streams_stdout().then_some(rx),
+            stdout_rx: request.output.streams_stdout().then_some(rx),
         })
     }
 
@@ -1008,6 +1130,8 @@ impl SandboxControl for MockSandboxControl {
                     exit_code: 0,
                     stdout: Vec::new(),
                     stderr: Vec::new(),
+                    stdout_truncated: false,
+                    stderr_truncated: false,
                 })
             })
     }
@@ -1091,6 +1215,7 @@ mod tests {
                 timeout: Duration::from_secs(5),
                 env: &[],
                 sudo: false,
+                output_limits: EXEC_OUTPUT_LIMIT_1_MIB,
             })
             .await;
         let exec = result.unwrap();
@@ -1200,6 +1325,8 @@ mod tests {
             exit_code: 42,
             stdout: b"out".to_vec(),
             stderr: b"err".to_vec(),
+            stdout_truncated: false,
+            stderr_truncated: false,
         }));
         sandbox.push_exec_result(Err(SandboxError::Operation {
             operation: SandboxOperation::Exec,
@@ -1212,6 +1339,7 @@ mod tests {
             timeout: Duration::from_secs(5),
             env: &[],
             sudo: false,
+            output_limits: EXEC_OUTPUT_LIMIT_1_MIB,
         };
 
         // First call returns queued result.
@@ -1226,6 +1354,83 @@ mod tests {
         // Third call falls back to default (exit 0).
         let r3 = sandbox.exec(&req).await.unwrap();
         assert_eq!(r3.exit_code, 0);
+    }
+
+    #[tokio::test]
+    async fn sandbox_copy_file_missing_ok_default_does_not_write_host_file() {
+        let sandbox = MockSandbox::new("test-1");
+        let path = std::env::temp_dir().join(format!(
+            "sandbox-mock-copy-missing-{}",
+            uuid::Uuid::new_v4().simple()
+        ));
+
+        let result = sandbox
+            .copy_file(
+                "/tmp/missing.log",
+                &path,
+                CopyFileOptions {
+                    max_bytes: 1024,
+                    timeout: Duration::from_secs(5),
+                    missing_ok: true,
+                },
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result.bytes_copied, 0);
+        assert!(!path.exists());
+    }
+
+    #[tokio::test]
+    async fn sandbox_copy_file_rejects_queued_bytes_over_max() {
+        let sandbox = MockSandbox::new("test-1");
+        sandbox.push_copy_file_result(Ok(b"too long".to_vec()));
+        let path = std::env::temp_dir().join(format!(
+            "sandbox-mock-copy-over-max-{}",
+            uuid::Uuid::new_v4().simple()
+        ));
+
+        let err = sandbox
+            .copy_file(
+                "/tmp/system.log",
+                &path,
+                CopyFileOptions {
+                    max_bytes: 3,
+                    timeout: Duration::from_secs(5),
+                    missing_ok: false,
+                },
+            )
+            .await
+            .unwrap_err();
+
+        assert!(err.to_string().contains("exceeded 3 bytes"));
+        assert!(!path.exists());
+    }
+
+    #[tokio::test]
+    async fn sandbox_exec_applies_mock_capture_budget() {
+        let sandbox = MockSandbox::new("test-1");
+        sandbox.push_exec_result(Ok(ExecResult::new(
+            0,
+            b"stdout".to_vec(),
+            b"stderr".to_vec(),
+        )));
+
+        let result = sandbox
+            .exec(&ExecRequest {
+                cmd: "test",
+                timeout: Duration::from_secs(5),
+                env: &[],
+                sudo: false,
+                output_limits: ExecOutputLimits::separate(3, 4),
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(result.stdout, b"std");
+        assert!(result.stdout_truncated);
+        assert_eq!(result.stderr, b"stde");
+        assert!(result.stderr_truncated);
     }
 
     #[tokio::test]
@@ -1832,37 +2037,42 @@ mod tests {
         let mut factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));
         factory.startup().await.unwrap();
         let sandbox = factory.create(test_sandbox_config()).await.unwrap();
-        let request = ExecRequest {
-            cmd: "agent",
-            timeout: Duration::from_secs(5),
-            env: &[],
-            sudo: false,
-        };
-
         let buffered = sandbox
-            .spawn_watch(&request, SpawnOutputMode::Buffered)
+            .spawn_watch(&SpawnWatchRequest {
+                cmd: "agent",
+                timeout: Duration::from_secs(5),
+                env: &[],
+                sudo: false,
+                output: SpawnOutputMode::Buffered,
+            })
             .await
             .unwrap();
         assert!(buffered.stdout_rx.is_none());
 
         let streamed = sandbox
-            .spawn_watch(
-                &request,
-                SpawnOutputMode::Stream {
+            .spawn_watch(&SpawnWatchRequest {
+                cmd: "agent",
+                timeout: Duration::from_secs(5),
+                env: &[],
+                sudo: false,
+                output: SpawnOutputMode::Stream {
                     guest_log_path: None,
                 },
-            )
+            })
             .await
             .unwrap();
         assert!(streamed.stdout_rx.is_some());
 
         let tee = sandbox
-            .spawn_watch(
-                &request,
-                SpawnOutputMode::Stream {
+            .spawn_watch(&SpawnWatchRequest {
+                cmd: "agent",
+                timeout: Duration::from_secs(5),
+                env: &[],
+                sudo: false,
+                output: SpawnOutputMode::Stream {
                     guest_log_path: Some("/tmp/guest.log"),
                 },
-            )
+            })
             .await
             .unwrap();
         assert!(tee.stdout_rx.is_some());

--- a/crates/sandbox/src/control.rs
+++ b/crates/sandbox/src/control.rs
@@ -12,6 +12,10 @@ pub struct RemoteExecResult {
     pub stdout: Vec<u8>,
     /// Raw stderr bytes.
     pub stderr: Vec<u8>,
+    /// True when stdout exceeded the remote capture budget.
+    pub stdout_truncated: bool,
+    /// True when stderr exceeded the remote capture budget.
+    pub stderr_truncated: bool,
 }
 
 /// Errors from sandbox control operations.

--- a/crates/sandbox/src/lib.rs
+++ b/crates/sandbox/src/lib.rs
@@ -40,4 +40,8 @@ pub use sandbox::Sandbox;
 pub use snapshot::{
     PendingSnapshotPublish, SnapshotCreateConfig, SnapshotError, SnapshotOutput, SnapshotProvider,
 };
-pub use types::{ExecRequest, ExecResult, ProcessExit, SpawnHandle, SpawnOutputMode};
+pub use types::{
+    CopyFileOptions, CopyFileResult, EXEC_OUTPUT_LIMIT_1_MIB, EXEC_OUTPUT_LIMIT_7_MIB,
+    EXEC_OUTPUT_LIMIT_64_KIB, ExecOutputLimits, ExecRequest, ExecResult, ProcessExit, SpawnHandle,
+    SpawnOutputMode, SpawnWatchRequest,
+};

--- a/crates/sandbox/src/sandbox.rs
+++ b/crates/sandbox/src/sandbox.rs
@@ -23,6 +23,7 @@
 //!
 //! # Operations
 //! Once running, callers invoke [`exec`](Sandbox::exec) /
+//! [`read_file`](Sandbox::read_file) / [`copy_file`](Sandbox::copy_file) /
 //! [`write_file`](Sandbox::write_file) / [`spawn_watch`](Sandbox::spawn_watch) /
 //! [`wait_exit`](Sandbox::wait_exit) via the host-to-guest IPC channel
 //! (vsock, in the Firecracker backend). Operations race against a crash
@@ -63,6 +64,7 @@ use crate::types::{
 ///
 /// # Operations
 /// Once running, callers invoke [`exec`](Self::exec) /
+/// [`read_file`](Self::read_file) / [`copy_file`](Self::copy_file) /
 /// [`write_file`](Self::write_file) / [`spawn_watch`](Self::spawn_watch) /
 /// [`wait_exit`](Self::wait_exit) via the host-to-guest IPC channel
 /// (vsock, in the Firecracker backend). Operations race against a crash

--- a/crates/sandbox/src/sandbox.rs
+++ b/crates/sandbox/src/sandbox.rs
@@ -30,12 +30,16 @@
 //! "backend crashed" error rather than an opaque IPC timeout.
 
 use std::any::Any;
+use std::path::Path;
 use std::time::Duration;
 
 use async_trait::async_trait;
 
 use crate::error::Result;
-use crate::types::{ExecRequest, ExecResult, ProcessExit, SpawnHandle};
+use crate::types::{
+    CopyFileOptions, CopyFileResult, ExecRequest, ExecResult, ProcessExit, SpawnHandle,
+    SpawnWatchRequest,
+};
 
 /// A process-isolation environment that runs guest workloads for the runner.
 ///
@@ -182,7 +186,24 @@ pub trait Sandbox: Send + Sync + Any {
     ///
     /// Returns an error if the sandbox is not running or if the backing
     /// process crashes during execution.
+    ///
+    /// Implementations must honor the selected capture budget or report
+    /// truncation explicitly in [`ExecResult`].
     async fn exec(&self, request: &ExecRequest<'_>) -> Result<ExecResult>;
+
+    /// Read a small file from the guest.
+    ///
+    /// Missing files return `Ok(None)`. Other read failures return an error.
+    async fn read_file(&self, path: &str, max_bytes: u64) -> Result<Option<Vec<u8>>>;
+
+    /// Stream a guest file to a host path and atomically publish it on success.
+    async fn copy_file(
+        &self,
+        path: &str,
+        host_path: &Path,
+        options: CopyFileOptions,
+    ) -> Result<CopyFileResult>;
+
     /// Write `content` to `path` inside the guest, creating parent
     /// directories and truncating the file as needed. Returns an error if
     /// the sandbox is not running or if the backing process crashes.
@@ -190,15 +211,11 @@ pub trait Sandbox: Send + Sync + Any {
     /// Spawn `request.cmd` in the guest and return a handle for later
     /// supervision via [`wait_exit`](Self::wait_exit).
     ///
-    /// `output` controls whether stdout is buffered into the final
+    /// `request.output` controls whether stdout is buffered into the final
     /// [`ProcessExit`] or streamed in real time through
     /// [`SpawnHandle::stdout_rx`], optionally
     /// teeing streamed chunks into a guest-side file.
-    async fn spawn_watch(
-        &self,
-        request: &ExecRequest<'_>,
-        output: crate::SpawnOutputMode<'_>,
-    ) -> Result<SpawnHandle>;
+    async fn spawn_watch(&self, request: &SpawnWatchRequest<'_>) -> Result<SpawnHandle>;
     /// Wait for the process behind `handle` to exit, up to `timeout`.
     ///
     /// Consumes the handle. Returns an error if the sandbox is not

--- a/crates/sandbox/src/types.rs
+++ b/crates/sandbox/src/types.rs
@@ -1,12 +1,16 @@
 use std::time::Duration;
 
+/// Capture budgets for stdout/stderr returned by [`ExecRequest`].
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct ExecOutputLimits {
+    /// Maximum stdout bytes to retain in [`ExecResult::stdout`].
     pub stdout_limit_bytes: u32,
+    /// Maximum stderr bytes to retain in [`ExecResult::stderr`].
     pub stderr_limit_bytes: u32,
 }
 
 impl ExecOutputLimits {
+    /// Use the same capture budget for stdout and stderr.
     pub const fn same(limit_bytes: u32) -> Self {
         Self {
             stdout_limit_bytes: limit_bytes,
@@ -14,6 +18,7 @@ impl ExecOutputLimits {
         }
     }
 
+    /// Use separate stdout and stderr capture budgets.
     pub const fn separate(stdout_limit_bytes: u32, stderr_limit_bytes: u32) -> Self {
         Self {
             stdout_limit_bytes,
@@ -22,15 +27,24 @@ impl ExecOutputLimits {
     }
 }
 
+/// Small diagnostic output budget for helper commands.
 pub const EXEC_OUTPUT_LIMIT_64_KIB: ExecOutputLimits = ExecOutputLimits::same(64 * 1024);
+/// Default output budget for ordinary bounded guest commands.
 pub const EXEC_OUTPUT_LIMIT_1_MIB: ExecOutputLimits = ExecOutputLimits::same(1024 * 1024);
+/// Larger output budget used by interactive runner exec-style tooling.
 pub const EXEC_OUTPUT_LIMIT_7_MIB: ExecOutputLimits = ExecOutputLimits::same(7 * 1024 * 1024);
 
+/// Request for a bounded command whose output is captured in memory.
 pub struct ExecRequest<'a> {
+    /// Shell command to run inside the guest.
     pub cmd: &'a str,
+    /// Guest-side command timeout.
     pub timeout: Duration,
+    /// Environment variables passed to the command.
     pub env: &'a [(&'a str, &'a str)],
+    /// Run the command with guest-side sudo privileges.
     pub sudo: bool,
+    /// Maximum captured stdout/stderr bytes.
     pub output_limits: ExecOutputLimits,
 }
 
@@ -41,11 +55,18 @@ impl ExecRequest<'_> {
     }
 }
 
+/// Request for a watched command whose process can outlive the initial spawn
+/// request and is supervised through [`SpawnHandle`].
 pub struct SpawnWatchRequest<'a> {
+    /// Shell command to run inside the guest.
     pub cmd: &'a str,
+    /// Guest-side process timeout.
     pub timeout: Duration,
+    /// Environment variables passed to the command.
     pub env: &'a [(&'a str, &'a str)],
+    /// Run the command with guest-side sudo privileges.
     pub sudo: bool,
+    /// Buffered or streamed stdout behavior.
     pub output: SpawnOutputMode<'a>,
 }
 
@@ -60,11 +81,17 @@ fn duration_ms(timeout: Duration) -> u32 {
     u32::try_from(timeout.as_millis()).unwrap_or(u32::MAX)
 }
 
+/// Result of a bounded command execution.
 pub struct ExecResult {
+    /// Process exit code, or a synthetic code for timeout/cancel failures.
     pub exit_code: i32,
+    /// Captured stdout bytes, capped by the requested output limit.
     pub stdout: Vec<u8>,
+    /// Captured stderr bytes, capped by the requested output limit.
     pub stderr: Vec<u8>,
+    /// True when stdout exceeded the requested output limit.
     pub stdout_truncated: bool,
+    /// True when stderr exceeded the requested output limit.
     pub stderr_truncated: bool,
 }
 
@@ -80,15 +107,21 @@ impl ExecResult {
     }
 }
 
+/// Options for copying a guest file to a host path.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct CopyFileOptions {
+    /// Maximum bytes to copy before failing.
     pub max_bytes: u64,
+    /// Guest-side copy command timeout.
     pub timeout: Duration,
+    /// Treat a missing guest file as a successful zero-byte copy.
     pub missing_ok: bool,
 }
 
+/// Result of copying a guest file to a host path.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct CopyFileResult {
+    /// Number of bytes copied into the host file.
     pub bytes_copied: u64,
 }
 

--- a/crates/sandbox/src/types.rs
+++ b/crates/sandbox/src/types.rs
@@ -1,23 +1,95 @@
 use std::time::Duration;
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ExecOutputLimits {
+    pub stdout_limit_bytes: u32,
+    pub stderr_limit_bytes: u32,
+}
+
+impl ExecOutputLimits {
+    pub const fn same(limit_bytes: u32) -> Self {
+        Self {
+            stdout_limit_bytes: limit_bytes,
+            stderr_limit_bytes: limit_bytes,
+        }
+    }
+
+    pub const fn separate(stdout_limit_bytes: u32, stderr_limit_bytes: u32) -> Self {
+        Self {
+            stdout_limit_bytes,
+            stderr_limit_bytes,
+        }
+    }
+}
+
+pub const EXEC_OUTPUT_LIMIT_64_KIB: ExecOutputLimits = ExecOutputLimits::same(64 * 1024);
+pub const EXEC_OUTPUT_LIMIT_1_MIB: ExecOutputLimits = ExecOutputLimits::same(1024 * 1024);
+pub const EXEC_OUTPUT_LIMIT_7_MIB: ExecOutputLimits = ExecOutputLimits::same(7 * 1024 * 1024);
+
 pub struct ExecRequest<'a> {
     pub cmd: &'a str,
     pub timeout: Duration,
     pub env: &'a [(&'a str, &'a str)],
     pub sudo: bool,
+    pub output_limits: ExecOutputLimits,
 }
 
 impl ExecRequest<'_> {
     /// Return the timeout as whole milliseconds, saturating at `u32::MAX`.
     pub fn timeout_ms(&self) -> u32 {
-        u32::try_from(self.timeout.as_millis()).unwrap_or(u32::MAX)
+        duration_ms(self.timeout)
     }
+}
+
+pub struct SpawnWatchRequest<'a> {
+    pub cmd: &'a str,
+    pub timeout: Duration,
+    pub env: &'a [(&'a str, &'a str)],
+    pub sudo: bool,
+    pub output: SpawnOutputMode<'a>,
+}
+
+impl SpawnWatchRequest<'_> {
+    /// Return the timeout as whole milliseconds, saturating at `u32::MAX`.
+    pub fn timeout_ms(&self) -> u32 {
+        duration_ms(self.timeout)
+    }
+}
+
+fn duration_ms(timeout: Duration) -> u32 {
+    u32::try_from(timeout.as_millis()).unwrap_or(u32::MAX)
 }
 
 pub struct ExecResult {
     pub exit_code: i32,
     pub stdout: Vec<u8>,
     pub stderr: Vec<u8>,
+    pub stdout_truncated: bool,
+    pub stderr_truncated: bool,
+}
+
+impl ExecResult {
+    pub fn new(exit_code: i32, stdout: Vec<u8>, stderr: Vec<u8>) -> Self {
+        Self {
+            exit_code,
+            stdout,
+            stderr,
+            stdout_truncated: false,
+            stderr_truncated: false,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct CopyFileOptions {
+    pub max_bytes: u64,
+    pub timeout: Duration,
+    pub missing_ok: bool,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct CopyFileResult {
+    pub bytes_copied: u64,
 }
 
 pub struct SpawnHandle {
@@ -64,6 +136,7 @@ mod tests {
             timeout: Duration::from_millis(5000),
             env: &[],
             sudo: false,
+            output_limits: EXEC_OUTPUT_LIMIT_1_MIB,
         };
         assert_eq!(req.timeout_ms(), 5000);
     }
@@ -75,6 +148,7 @@ mod tests {
             timeout: Duration::ZERO,
             env: &[],
             sudo: false,
+            output_limits: EXEC_OUTPUT_LIMIT_1_MIB,
         };
         assert_eq!(req.timeout_ms(), 0);
     }
@@ -86,6 +160,7 @@ mod tests {
             timeout: Duration::from_secs(u64::MAX / 1000),
             env: &[],
             sudo: false,
+            output_limits: EXEC_OUTPUT_LIMIT_1_MIB,
         };
         assert_eq!(req.timeout_ms(), u32::MAX);
     }
@@ -97,6 +172,7 @@ mod tests {
             timeout: Duration::from_millis(u32::MAX as u64),
             env: &[],
             sudo: false,
+            output_limits: EXEC_OUTPUT_LIMIT_1_MIB,
         };
         assert_eq!(req.timeout_ms(), u32::MAX);
     }

--- a/crates/vsock-host/Cargo.toml
+++ b/crates/vsock-host/Cargo.toml
@@ -6,7 +6,7 @@ description = "Vsock host client for Firecracker VM communication"
 
 [dependencies]
 nix = { workspace = true, features = ["net"] }
-tokio = { workspace = true, features = ["net", "io-util", "time", "rt", "macros", "sync"] }
+tokio = { workspace = true, features = ["net", "io-util", "time", "rt", "macros", "sync", "fs"] }
 tracing = { workspace = true }
 vsock-proto.workspace = true
 

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -4969,6 +4969,34 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn read_file_errors_on_truncated_stdout() {
+        let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+        let read_task =
+            tokio::spawn(async move { host.read_file("/tmp/large.txt", 5, 5000).await });
+
+        let msg = read_guest_message(&mut guest, &mut decoder).await;
+        assert_eq!(msg.msg_type, MSG_COMMAND_START);
+        let payload = vsock_proto::encode_command_result(
+            CommandTermination::Exited { exit_code: 0 },
+            12,
+            CommandCapturedOutput::Captured {
+                bytes: b"hello",
+                truncated: true,
+            },
+            CommandCapturedOutput::Captured {
+                bytes: b"",
+                truncated: false,
+            },
+            "",
+        )
+        .unwrap();
+        send_raw_command_result(&mut guest, msg.seq, payload).await;
+
+        let err = read_task.await.unwrap().unwrap_err();
+        assert!(err.to_string().contains("exceeded 5 bytes"));
+    }
+
+    #[tokio::test]
     async fn copy_file_streams_to_temp_then_renames() {
         let (host, mut guest, mut decoder) = setup_host_and_guest().await;
         let unique = std::time::SystemTime::now()
@@ -5109,6 +5137,67 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn copy_file_nonzero_exit_removes_temp_without_publishing_partial_output() {
+        let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!(
+            "vsock-host-copy-nonzero-{}-{unique}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let host_path = dir.join("system.log");
+        std::fs::write(&host_path, b"old host log").unwrap();
+        let copy_path = host_path.clone();
+
+        let copy_task = tokio::spawn(async move {
+            host.copy_file(
+                "/tmp/vm0-system-run.log",
+                &copy_path,
+                CopyFileOptions {
+                    max_bytes: 1024,
+                    timeout_ms: 5000,
+                    missing_ok: false,
+                },
+            )
+            .await
+        });
+
+        let msg = read_guest_message(&mut guest, &mut decoder).await;
+        send_command_output(
+            &mut guest,
+            msg.seq,
+            0,
+            CommandOutputStream::Stdout,
+            b"partial",
+            false,
+        )
+        .await;
+        send_stream_command_result(
+            &mut guest,
+            msg.seq,
+            CommandTermination::Exited { exit_code: 1 },
+            b"read error",
+        )
+        .await;
+
+        let err = copy_task.await.unwrap().unwrap_err();
+        assert!(err.to_string().contains("read error"));
+        assert_eq!(std::fs::read(&host_path).unwrap(), b"old host log");
+        assert!(
+            std::fs::read_dir(&dir).unwrap().all(|entry| !entry
+                .unwrap()
+                .file_name()
+                .to_string_lossy()
+                .contains("vm0tmp")),
+            "failed copy temp file should be removed"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
     async fn copy_file_missing_ok_leaves_no_final_or_temp_file() {
         let (host, mut guest, mut decoder) = setup_host_and_guest().await;
         let unique = std::time::SystemTime::now()
@@ -5149,6 +5238,59 @@ mod tests {
         let result = copy_task.await.unwrap().unwrap();
         assert_eq!(result.bytes_copied, 0);
         assert!(!host_path.exists());
+        assert!(
+            std::fs::read_dir(&dir).unwrap().all(|entry| !entry
+                .unwrap()
+                .file_name()
+                .to_string_lossy()
+                .contains("vm0tmp")),
+            "missing copy temp file should be removed"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn copy_file_missing_without_missing_ok_preserves_existing_file_and_removes_temp() {
+        let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!(
+            "vsock-host-copy-missing-error-{}-{unique}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let host_path = dir.join("system.log");
+        std::fs::write(&host_path, b"old host log").unwrap();
+        let copy_path = host_path.clone();
+
+        let copy_task = tokio::spawn(async move {
+            host.copy_file(
+                "/tmp/missing.log",
+                &copy_path,
+                CopyFileOptions {
+                    max_bytes: 1024,
+                    timeout_ms: 5000,
+                    missing_ok: false,
+                },
+            )
+            .await
+        });
+
+        let msg = read_guest_message(&mut guest, &mut decoder).await;
+        assert_eq!(msg.msg_type, MSG_COMMAND_START);
+        send_stream_command_result(
+            &mut guest,
+            msg.seq,
+            CommandTermination::Exited { exit_code: 66 },
+            b"",
+        )
+        .await;
+
+        let err = copy_task.await.unwrap().unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::NotFound);
+        assert_eq!(std::fs::read(&host_path).unwrap(), b"old host log");
         assert!(
             std::fs::read_dir(&dir).unwrap().all(|entry| !entry
                 .unwrap()

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -45,13 +45,20 @@ const DEFAULT_COMMAND_CAPTURE_LIMIT_BYTES: u32 = 1024 * 1024;
 const SMALL_COMMAND_CAPTURE_LIMIT_BYTES: u32 = 64 * 1024;
 const EXEC_TIMEOUT_EXIT_CODE: i32 = 124;
 const DEFAULT_COMMAND_STREAM_CAPACITY: usize = 32;
-const MAX_COMMAND_STREAM_CAPACITY: usize = 1024;
+// Large enough for the current 64 MiB guest-log copy cap even when the guest
+// emits stream events at the command drainer's 8 KiB read granularity.
+const MAX_COMMAND_STREAM_CAPACITY: usize = 8192;
 const COPY_TEMP_CREATE_ATTEMPTS: usize = 16;
 const COMMAND_LABEL_LOG_PREFIX_MAX_BYTES: usize = 100;
 const COMMAND_CLOSE_ACTIVE_LOG_LIMIT: usize = 16;
 const COMMAND_FRAME_WRITE_SLOW_THRESHOLD: Duration = Duration::from_millis(500);
 const COMMAND_STAGE_SLOW_THRESHOLD: Duration = Duration::from_secs(5);
 const COMMAND_DROP_CANCEL_WRITE_TIMEOUT: Duration = Duration::from_secs(1);
+const COPY_FILE_STREAM_CHUNK_LIMIT: u32 = 64 * 1024;
+const COPY_FILE_STREAM_MAX_BYTES: u64 = 64 * 1024 * 1024;
+// Copying is the one built-in streaming consumer that must tolerate the host
+// reader briefly outrunning the temp-file writer without failing the command.
+const COPY_FILE_STREAM_QUEUE_CAPACITY: usize = MAX_COMMAND_STREAM_CAPACITY;
 const COMMAND_FRAME_WRITE_NOT_STARTED: u8 = 0;
 const COMMAND_FRAME_WRITE_STARTED: u8 = 1;
 const COMMAND_FRAME_WRITE_COMPLETED: u8 = 2;
@@ -2251,6 +2258,12 @@ impl VsockHost {
                 "copy_file max_bytes must be positive",
             ));
         }
+        if options.max_bytes > COPY_FILE_STREAM_MAX_BYTES {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("copy_file max_bytes must be at most {COPY_FILE_STREAM_MAX_BYTES}"),
+            ));
+        }
         let stream_limit_bytes = u32::try_from(options.max_bytes).map_err(|_| {
             io::Error::new(
                 io::ErrorKind::InvalidInput,
@@ -2328,12 +2341,12 @@ impl VsockHost {
                 label: "copy-file",
                 stdout: CommandOutputPolicy::Stream {
                     limit_bytes: stream_limit_bytes,
-                    chunk_limit_bytes: 64 * 1024,
+                    chunk_limit_bytes: COPY_FILE_STREAM_CHUNK_LIMIT,
                 },
                 stderr: CommandOutputPolicy::Capture {
                     limit_bytes: SMALL_COMMAND_CAPTURE_LIMIT_BYTES,
                 },
-                stream_queue_capacity: None,
+                stream_queue_capacity: Some(COPY_FILE_STREAM_QUEUE_CAPACITY),
             })
             .await?;
         let mut cancel_on_drop = CommandCancelOnDropGuard::new(&handle);
@@ -3116,6 +3129,35 @@ mod tests {
 
         assert!(!path.exists());
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn copy_file_stream_settings_cover_max_copy_without_queue_overflow() {
+        assert_eq!(
+            COPY_FILE_STREAM_MAX_BYTES,
+            COPY_FILE_STREAM_CHUNK_LIMIT as u64 * 1024
+        );
+        assert_eq!(COPY_FILE_STREAM_QUEUE_CAPACITY, MAX_COMMAND_STREAM_CAPACITY);
+    }
+
+    #[tokio::test]
+    async fn copy_file_rejects_max_bytes_above_stream_budget() {
+        let (host, _guest, _decoder) = setup_host_and_guest().await;
+        let err = host
+            .copy_file(
+                "/tmp/large.log",
+                Path::new("/tmp/large.log"),
+                CopyFileOptions {
+                    max_bytes: COPY_FILE_STREAM_MAX_BYTES + 1,
+                    timeout_ms: 5000,
+                    missing_ok: false,
+                },
+            )
+            .await
+            .unwrap_err();
+
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+        assert!(err.to_string().contains("copy_file max_bytes"));
     }
 
     #[tokio::test]

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -5193,31 +5193,16 @@ mod tests {
 
         let start = read_guest_message(&mut guest, &mut decoder).await;
         assert_eq!(start.msg_type, MSG_COMMAND_START);
-        send_command_output(
-            &mut guest,
-            start.seq,
-            0,
-            CommandOutputStream::Stdout,
-            b"partial",
-            false,
-        )
-        .await;
-        tokio::time::timeout(Duration::from_secs(1), async {
-            loop {
-                if std::fs::read_dir(&dir).unwrap().any(|entry| {
-                    let path = entry.unwrap().path();
-                    path.file_name()
-                        .and_then(|name| name.to_str())
-                        .is_some_and(|name| name.contains("vm0tmp"))
-                        && std::fs::read(&path).is_ok_and(|bytes| bytes == b"partial")
-                }) {
-                    return;
-                }
-                tokio::task::yield_now().await;
-            }
-        })
-        .await
-        .unwrap();
+        let temp_paths: Vec<_> = std::fs::read_dir(&dir)
+            .unwrap()
+            .map(|entry| entry.unwrap().path())
+            .filter(|path| {
+                path.file_name()
+                    .and_then(|name| name.to_str())
+                    .is_some_and(|name| name.contains("vm0tmp"))
+            })
+            .collect();
+        assert_eq!(temp_paths.len(), 1);
 
         copy_task.abort();
         assert!(copy_task.await.unwrap_err().is_cancelled());

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -51,6 +51,7 @@ const COMMAND_LABEL_LOG_PREFIX_MAX_BYTES: usize = 100;
 const COMMAND_CLOSE_ACTIVE_LOG_LIMIT: usize = 16;
 const COMMAND_FRAME_WRITE_SLOW_THRESHOLD: Duration = Duration::from_millis(500);
 const COMMAND_STAGE_SLOW_THRESHOLD: Duration = Duration::from_secs(5);
+const COMMAND_DROP_CANCEL_WRITE_TIMEOUT: Duration = Duration::from_secs(1);
 const COMMAND_FRAME_WRITE_NOT_STARTED: u8 = 0;
 const COMMAND_FRAME_WRITE_STARTED: u8 = 1;
 const COMMAND_FRAME_WRITE_COMPLETED: u8 = 2;
@@ -617,6 +618,81 @@ impl Drop for CommandOperationHandle {
         if let Some(seq) = self.seq.take() {
             self.shared.remove_operation(seq);
         }
+    }
+}
+
+struct CommandCancelOnDropGuard {
+    shared: Option<Arc<Shared>>,
+    seq: u32,
+    diagnostic: CommandOperationDiagnostic,
+}
+
+impl CommandCancelOnDropGuard {
+    fn new(handle: &CommandOperationHandle) -> Option<Self> {
+        Some(Self {
+            shared: Some(Arc::clone(&handle.shared)),
+            seq: handle.seq?,
+            diagnostic: handle.diagnostic.clone(),
+        })
+    }
+
+    fn disarm(&mut self) {
+        self.shared = None;
+    }
+}
+
+impl Drop for CommandCancelOnDropGuard {
+    fn drop(&mut self) {
+        let Some(shared) = self.shared.take() else {
+            return;
+        };
+        let seq = self.seq;
+        let diagnostic = self.diagnostic.clone();
+        let Ok(handle) = tokio::runtime::Handle::try_current() else {
+            return;
+        };
+
+        handle.spawn(async move {
+            let payload = vsock_proto::encode_command_cancel();
+            let result = tokio::time::timeout(
+                COMMAND_DROP_CANCEL_WRITE_TIMEOUT,
+                write_command_frame(
+                    &shared,
+                    MSG_COMMAND_CANCEL,
+                    seq,
+                    &payload,
+                    Some(diagnostic.frame("drop-cancel")),
+                ),
+            )
+            .await;
+            match result {
+                Ok(Ok(())) => {
+                    tracing::info!(
+                        seq = seq,
+                        label = %diagnostic.label_log,
+                        elapsed_ms = diagnostic.elapsed_ms(),
+                        "command operation cancel sent on drop"
+                    );
+                }
+                Ok(Err(err)) => {
+                    tracing::warn!(
+                        seq = seq,
+                        label = %diagnostic.label_log,
+                        elapsed_ms = diagnostic.elapsed_ms(),
+                        error = %err,
+                        "command operation cancel on drop failed"
+                    );
+                }
+                Err(_) => {
+                    tracing::warn!(
+                        seq = seq,
+                        label = %diagnostic.label_log,
+                        elapsed_ms = diagnostic.elapsed_ms(),
+                        "command operation cancel on drop timed out"
+                    );
+                }
+            }
+        });
     }
 }
 
@@ -2260,6 +2336,7 @@ impl VsockHost {
                 stream_queue_capacity: None,
             })
             .await?;
+        let mut cancel_on_drop = CommandCancelOnDropGuard::new(&handle);
         let mut stream_rx = handle.take_stream_receiver().ok_or_else(|| {
             io::Error::new(
                 io::ErrorKind::InvalidData,
@@ -2286,10 +2363,16 @@ impl VsockHost {
             Ok(Ok(())) => {}
             Ok(Err(err)) => {
                 let _ = handle.cancel_and_wait(Duration::from_secs(1)).await;
+                if let Some(cancel_on_drop) = &mut cancel_on_drop {
+                    cancel_on_drop.disarm();
+                }
                 return Err(err);
             }
             Err(_) => {
                 let _ = handle.cancel_and_wait(Duration::from_secs(1)).await;
+                if let Some(cancel_on_drop) = &mut cancel_on_drop {
+                    cancel_on_drop.disarm();
+                }
                 return Err(io::Error::new(
                     io::ErrorKind::TimedOut,
                     format!("copy_file stream drain timed out for {path}"),
@@ -2298,6 +2381,9 @@ impl VsockHost {
         };
 
         let result = handle.wait(Duration::from_secs(5)).await?;
+        if let Some(cancel_on_drop) = &mut cancel_on_drop {
+            cancel_on_drop.disarm();
+        }
         match validate_copy_command_result(path, result, missing_ok)? {
             CopyFileCommandStatus::Present => {}
             CopyFileCommandStatus::Missing => return Ok(CopyFileOutcome::Missing),
@@ -5070,6 +5156,83 @@ mod tests {
                 .to_string_lossy()
                 .contains("vm0tmp")),
             "missing copy temp file should be removed"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn copy_file_cancellation_cancels_guest_command_and_removes_temp() {
+        let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+        let host = Arc::new(host);
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!(
+            "vsock-host-copy-cancel-{}-{unique}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let host_path = dir.join("system.log");
+        let copy_path = host_path.clone();
+
+        let task_host = Arc::clone(&host);
+        let copy_task = tokio::spawn(async move {
+            task_host
+                .copy_file(
+                    "/tmp/vm0-system-run.log",
+                    &copy_path,
+                    CopyFileOptions {
+                        max_bytes: 1024,
+                        timeout_ms: 5000,
+                        missing_ok: false,
+                    },
+                )
+                .await
+        });
+
+        let start = read_guest_message(&mut guest, &mut decoder).await;
+        assert_eq!(start.msg_type, MSG_COMMAND_START);
+        send_command_output(
+            &mut guest,
+            start.seq,
+            0,
+            CommandOutputStream::Stdout,
+            b"partial",
+            false,
+        )
+        .await;
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                if std::fs::read_dir(&dir).unwrap().any(|entry| {
+                    let path = entry.unwrap().path();
+                    path.file_name()
+                        .and_then(|name| name.to_str())
+                        .is_some_and(|name| name.contains("vm0tmp"))
+                        && std::fs::read(&path).is_ok_and(|bytes| bytes == b"partial")
+                }) {
+                    return;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .unwrap();
+
+        copy_task.abort();
+        assert!(copy_task.await.unwrap_err().is_cancelled());
+
+        let cancel = read_guest_message(&mut guest, &mut decoder).await;
+        assert_eq!(cancel.msg_type, MSG_COMMAND_CANCEL);
+        assert_eq!(cancel.seq, start.seq);
+        assert!(!host_path.exists());
+        assert!(
+            std::fs::read_dir(&dir).unwrap().all(|entry| !entry
+                .unwrap()
+                .file_name()
+                .to_string_lossy()
+                .contains("vm0tmp")),
+            "cancelled copy temp file should be removed"
         );
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -23,7 +23,7 @@ use std::io;
 use std::os::unix::io::RawFd;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU8, AtomicU32, Ordering};
+use std::sync::atomic::{AtomicU8, AtomicU32, AtomicU64, Ordering};
 use std::time::Duration;
 
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -46,6 +46,7 @@ const SMALL_COMMAND_CAPTURE_LIMIT_BYTES: u32 = 64 * 1024;
 const EXEC_TIMEOUT_EXIT_CODE: i32 = 124;
 const DEFAULT_COMMAND_STREAM_CAPACITY: usize = 32;
 const MAX_COMMAND_STREAM_CAPACITY: usize = 1024;
+const COPY_TEMP_CREATE_ATTEMPTS: usize = 16;
 const COMMAND_LABEL_LOG_PREFIX_MAX_BYTES: usize = 100;
 const COMMAND_CLOSE_ACTIVE_LOG_LIMIT: usize = 16;
 const COMMAND_FRAME_WRITE_SLOW_THRESHOLD: Duration = Duration::from_millis(500);
@@ -53,6 +54,7 @@ const COMMAND_STAGE_SLOW_THRESHOLD: Duration = Duration::from_secs(5);
 const COMMAND_FRAME_WRITE_NOT_STARTED: u8 = 0;
 const COMMAND_FRAME_WRITE_STARTED: u8 = 1;
 const COMMAND_FRAME_WRITE_COMPLETED: u8 = 2;
+static COPY_TEMP_NONCE: AtomicU64 = AtomicU64::new(1);
 
 /// Result of executing a command on the guest.
 #[derive(Debug, Clone)]
@@ -671,6 +673,40 @@ impl Drop for ChunkedWriteCleanupGuard {
                 )
                 .await;
             });
+        }
+    }
+}
+
+struct HostTempFileGuard {
+    path: PathBuf,
+    active: bool,
+}
+
+impl HostTempFileGuard {
+    fn new(path: PathBuf) -> Self {
+        Self { path, active: true }
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+
+    async fn remove_now(&mut self) {
+        if self.active {
+            self.active = false;
+            remove_temp_file(&self.path).await;
+        }
+    }
+
+    fn disarm(&mut self) {
+        self.active = false;
+    }
+}
+
+impl Drop for HostTempFileGuard {
+    fn drop(&mut self) {
+        if self.active {
+            let _ = std::fs::remove_file(&self.path);
         }
     }
 }
@@ -1484,12 +1520,12 @@ fn command_result_to_exec_result(result: CommandOperationResult) -> io::Result<E
     })
 }
 
-fn copy_temp_path(host_path: &Path, seq: u32) -> PathBuf {
+fn copy_temp_path(host_path: &Path, process_id: u32, seq: u32, nonce: u64) -> PathBuf {
     let file_name = host_path
         .file_name()
         .map(|name| name.to_string_lossy())
         .unwrap_or_else(|| "copy".into());
-    host_path.with_file_name(format!(".{file_name}.vm0tmp-{seq}"))
+    host_path.with_file_name(format!(".{file_name}.vm0tmp-{process_id}-{seq}-{nonce}"))
 }
 
 async fn remove_temp_file(path: &Path) {
@@ -1498,6 +1534,33 @@ async fn remove_temp_file(path: &Path) {
         Err(err) if err.kind() == io::ErrorKind::NotFound => {}
         Err(_) => {}
     }
+}
+
+async fn create_copy_temp_file(
+    host_path: &Path,
+    seq: u32,
+) -> io::Result<(PathBuf, tokio::fs::File)> {
+    for _ in 0..COPY_TEMP_CREATE_ATTEMPTS {
+        let nonce = COPY_TEMP_NONCE.fetch_add(1, Ordering::Relaxed);
+        let temp_path = copy_temp_path(host_path, std::process::id(), seq, nonce);
+        match tokio::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&temp_path)
+            .await
+        {
+            Ok(file) => return Ok((temp_path, file)),
+            Err(err) if err.kind() == io::ErrorKind::AlreadyExists => continue,
+            Err(err) => return Err(err),
+        }
+    }
+
+    Err(io::Error::new(
+        io::ErrorKind::AlreadyExists,
+        format!(
+            "copy_file could not create a unique temp file after {COPY_TEMP_CREATE_ATTEMPTS} attempts"
+        ),
+    ))
 }
 
 async fn write_copy_stream_event(
@@ -2131,11 +2194,13 @@ impl VsockHost {
             tokio::fs::create_dir_all(parent).await?;
         }
 
-        let temp_path = copy_temp_path(host_path, self.shared.next_seq());
+        let (temp_path, temp_file) =
+            create_copy_temp_file(host_path, self.shared.next_seq()).await?;
+        let mut temp_guard = HostTempFileGuard::new(temp_path);
         let copy_result = self
             .copy_file_to_temp(
                 path,
-                &temp_path,
+                temp_file,
                 stream_limit_bytes,
                 options.timeout_ms,
                 options.missing_ok,
@@ -2143,20 +2208,23 @@ impl VsockHost {
             .await;
         match copy_result {
             Ok(CopyFileOutcome::Copied { bytes_copied }) => {
-                match tokio::fs::rename(&temp_path, host_path).await {
-                    Ok(()) => Ok(CopyFileResult { bytes_copied }),
+                match tokio::fs::rename(temp_guard.path(), host_path).await {
+                    Ok(()) => {
+                        temp_guard.disarm();
+                        Ok(CopyFileResult { bytes_copied })
+                    }
                     Err(err) => {
-                        remove_temp_file(&temp_path).await;
+                        temp_guard.remove_now().await;
                         Err(err)
                     }
                 }
             }
             Ok(CopyFileOutcome::Missing) => {
-                remove_temp_file(&temp_path).await;
+                temp_guard.remove_now().await;
                 Ok(CopyFileResult { bytes_copied: 0 })
             }
             Err(err) => {
-                remove_temp_file(&temp_path).await;
+                temp_guard.remove_now().await;
                 Err(err)
             }
         }
@@ -2165,7 +2233,7 @@ impl VsockHost {
     async fn copy_file_to_temp(
         &self,
         path: &str,
-        temp_path: &Path,
+        mut temp_file: tokio::fs::File,
         stream_limit_bytes: u32,
         timeout_ms: u32,
         missing_ok: bool,
@@ -2199,7 +2267,6 @@ impl VsockHost {
             )
         })?;
         let wait_timeout = Duration::from_millis(timeout_ms as u64 + 5000);
-        let mut temp_file = tokio::fs::File::create(temp_path).await?;
         let mut bytes_copied = 0u64;
 
         let drain_result = tokio::time::timeout(wait_timeout, async {
@@ -2903,6 +2970,66 @@ mod tests {
         .await;
         let exec_result = exec_task.await.unwrap().unwrap();
         assert_eq!(exec_result.stdout, b"ok");
+    }
+
+    #[test]
+    fn copy_temp_path_distinguishes_process_seq_and_nonce() {
+        let host_path = PathBuf::from("/tmp/system.log");
+
+        let base = copy_temp_path(&host_path, 101, 7, 1);
+        assert_ne!(base, copy_temp_path(&host_path, 102, 7, 1));
+        assert_ne!(base, copy_temp_path(&host_path, 101, 8, 1));
+        assert_ne!(base, copy_temp_path(&host_path, 101, 7, 2));
+        assert_eq!(
+            base.file_name().and_then(|name| name.to_str()),
+            Some(".system.log.vm0tmp-101-7-1")
+        );
+    }
+
+    #[tokio::test]
+    async fn create_copy_temp_file_uses_unique_paths_for_same_seq() {
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!(
+            "vsock-host-copy-temp-{}-{unique}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let host_path = dir.join("system.log");
+
+        let (first_path, first_file) = create_copy_temp_file(&host_path, 7).await.unwrap();
+        let (second_path, second_file) = create_copy_temp_file(&host_path, 7).await.unwrap();
+
+        assert_ne!(first_path, second_path);
+        assert!(first_path.exists());
+        assert!(second_path.exists());
+        drop(first_file);
+        drop(second_file);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn host_temp_file_guard_removes_temp_on_drop() {
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!(
+            "vsock-host-temp-guard-{}-{unique}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join(".system.log.vm0tmp-guard");
+        std::fs::write(&path, b"partial").unwrap();
+
+        {
+            let _guard = HostTempFileGuard::new(path.clone());
+        }
+
+        assert!(!path.exists());
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[tokio::test]

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -21,6 +21,7 @@
 use std::collections::HashMap;
 use std::io;
 use std::os::unix::io::RawFd;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU8, AtomicU32, Ordering};
 use std::time::Duration;
@@ -34,13 +35,15 @@ use tokio::time::{self, Instant};
 use vsock_proto::{
     CommandCapturedOutput, CommandOutputPolicy, CommandOutputStream, CommandTermination, Decoder,
     MSG_COMMAND_CANCEL, MSG_COMMAND_OUTPUT, MSG_COMMAND_RESULT, MSG_COMMAND_START, MSG_ERROR,
-    MSG_EXEC, MSG_EXEC_RESULT, MSG_PING, MSG_PONG, MSG_PROCESS_EXIT, MSG_READY, MSG_SHUTDOWN,
-    MSG_SHUTDOWN_ACK, MSG_SPAWN_WATCH, MSG_SPAWN_WATCH_RESULT, MSG_STDOUT_CHUNK, MSG_WRITE_FILE,
+    MSG_PING, MSG_PONG, MSG_PROCESS_EXIT, MSG_READY, MSG_SHUTDOWN, MSG_SHUTDOWN_ACK,
+    MSG_SPAWN_WATCH, MSG_SPAWN_WATCH_RESULT, MSG_STDOUT_CHUNK, MSG_WRITE_FILE,
     MSG_WRITE_FILE_RESULT, RawMessage,
 };
 
 const READ_BUF_SIZE: usize = 64 * 1024;
 const DEFAULT_COMMAND_CAPTURE_LIMIT_BYTES: u32 = 1024 * 1024;
+const SMALL_COMMAND_CAPTURE_LIMIT_BYTES: u32 = 64 * 1024;
+const EXEC_TIMEOUT_EXIT_CODE: i32 = 124;
 const DEFAULT_COMMAND_STREAM_CAPACITY: usize = 32;
 const MAX_COMMAND_STREAM_CAPACITY: usize = 1024;
 const COMMAND_LABEL_LOG_PREFIX_MAX_BYTES: usize = 100;
@@ -57,6 +60,8 @@ pub struct ExecResult {
     pub exit_code: i32,
     pub stdout: Vec<u8>,
     pub stderr: Vec<u8>,
+    pub stdout_truncated: bool,
+    pub stderr_truncated: bool,
 }
 
 /// Event emitted when a spawned process exits.
@@ -141,6 +146,30 @@ pub struct CommandStreamRequest<'a> {
     /// `None` uses the default queue capacity. Zero and oversized capacities
     /// are rejected.
     pub stream_queue_capacity: Option<usize>,
+}
+
+/// Request parameters for copying a guest file to a host path through command
+/// operation streaming.
+#[derive(Debug, Clone, Copy)]
+pub struct CopyFileOptions {
+    pub max_bytes: u64,
+    pub timeout_ms: u32,
+    pub missing_ok: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CopyFileResult {
+    pub bytes_copied: u64,
+}
+
+enum CopyFileCommandStatus {
+    Present,
+    Missing,
+}
+
+enum CopyFileOutcome {
+    Copied { bytes_copied: u64 },
+    Missing,
 }
 
 struct CommandOperation {
@@ -1387,6 +1416,316 @@ async fn write_command_frame(
     Ok(())
 }
 
+fn shell_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\\''"))
+}
+
+fn command_capture_output_to_bytes(
+    name: &str,
+    output: CommandOwnedCapturedOutput,
+) -> io::Result<(Vec<u8>, bool)> {
+    match output {
+        CommandOwnedCapturedOutput::Captured { bytes, truncated } => Ok((bytes, truncated)),
+        CommandOwnedCapturedOutput::Discarded => Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("command result discarded {name} for capture request"),
+        )),
+    }
+}
+
+fn append_diagnostic(stderr: &mut Vec<u8>, diagnostic: &str) {
+    if diagnostic.is_empty() {
+        return;
+    }
+    if !stderr.is_empty() && !stderr.ends_with(b"\n") {
+        stderr.push(b'\n');
+    }
+    stderr.extend_from_slice(diagnostic.as_bytes());
+}
+
+fn command_result_to_exec_result(result: CommandOperationResult) -> io::Result<ExecResult> {
+    if result.stream_overflowed {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "capture command unexpectedly overflowed a stream queue",
+        ));
+    }
+
+    let (stdout, stdout_truncated) = command_capture_output_to_bytes("stdout", result.stdout)?;
+    let (mut stderr, stderr_truncated) = command_capture_output_to_bytes("stderr", result.stderr)?;
+
+    let exit_code = match result.termination {
+        CommandTermination::Exited { exit_code } => exit_code,
+        CommandTermination::TimedOut => {
+            if stderr.is_empty() {
+                stderr.extend_from_slice(b"Timeout");
+            }
+            EXEC_TIMEOUT_EXIT_CODE
+        }
+        CommandTermination::Cancelled => {
+            if stderr.is_empty() {
+                stderr.extend_from_slice(b"Cancelled");
+            }
+            append_diagnostic(&mut stderr, &result.diagnostic);
+            1
+        }
+        CommandTermination::StartFailed | CommandTermination::WaitFailed => {
+            append_diagnostic(&mut stderr, &result.diagnostic);
+            1
+        }
+    };
+
+    Ok(ExecResult {
+        exit_code,
+        stdout,
+        stderr,
+        stdout_truncated,
+        stderr_truncated,
+    })
+}
+
+fn copy_temp_path(host_path: &Path, seq: u32) -> PathBuf {
+    let file_name = host_path
+        .file_name()
+        .map(|name| name.to_string_lossy())
+        .unwrap_or_else(|| "copy".into());
+    host_path.with_file_name(format!(".{file_name}.vm0tmp-{seq}"))
+}
+
+async fn remove_temp_file(path: &Path) {
+    match tokio::fs::remove_file(path).await {
+        Ok(()) => {}
+        Err(err) if err.kind() == io::ErrorKind::NotFound => {}
+        Err(_) => {}
+    }
+}
+
+async fn write_copy_stream_event(
+    temp_file: &mut tokio::fs::File,
+    bytes_copied: &mut u64,
+    max_bytes: u64,
+    event: CommandOutputEvent,
+) -> io::Result<()> {
+    if event.stream != CommandOutputStream::Stdout {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "copy_file received stderr stream event",
+        ));
+    }
+    if event.truncated {
+        return Err(io::Error::other("copy_file stdout stream was truncated"));
+    }
+    *bytes_copied = bytes_copied
+        .checked_add(event.chunk.len() as u64)
+        .ok_or_else(|| io::Error::other("copy_file byte count overflow"))?;
+    if *bytes_copied > max_bytes {
+        return Err(io::Error::other(format!(
+            "copy_file exceeded {max_bytes} bytes"
+        )));
+    }
+    temp_file.write_all(&event.chunk).await
+}
+
+fn copy_command_stderr(result: &CommandOperationResult) -> io::Result<(Vec<u8>, bool)> {
+    match &result.stderr {
+        CommandOwnedCapturedOutput::Captured { bytes, truncated } => {
+            Ok((bytes.clone(), *truncated))
+        }
+        CommandOwnedCapturedOutput::Discarded => Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "copy_file command discarded stderr capture",
+        )),
+    }
+}
+
+fn validate_copy_command_result(
+    path: &str,
+    result: CommandOperationResult,
+    missing_ok: bool,
+) -> io::Result<CopyFileCommandStatus> {
+    if result.stream_overflowed {
+        return Err(io::Error::other(
+            "copy_file stream queue overflowed before all chunks were written",
+        ));
+    }
+    if !matches!(&result.stdout, CommandOwnedCapturedOutput::Discarded) {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "copy_file command unexpectedly captured stdout",
+        ));
+    }
+    let (mut stderr, stderr_truncated) = copy_command_stderr(&result)?;
+    if stderr_truncated {
+        append_diagnostic(&mut stderr, "stderr truncated");
+    }
+    match result.termination {
+        CommandTermination::Exited { exit_code: 0 } if !stderr_truncated => {
+            Ok(CopyFileCommandStatus::Present)
+        }
+        CommandTermination::Exited { exit_code: 0 } => Err(io::Error::other(format!(
+            "copy_file stderr exceeded diagnostic limit for {path}: {}",
+            String::from_utf8_lossy(&stderr)
+        ))),
+        CommandTermination::Exited { exit_code: 66 } if missing_ok => {
+            Ok(CopyFileCommandStatus::Missing)
+        }
+        CommandTermination::Exited { exit_code: 66 } => Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            format!("guest file not found: {path}"),
+        )),
+        CommandTermination::Exited { exit_code } => Err(io::Error::other(format!(
+            "copy_file failed for {path} with exit code {exit_code}: {}",
+            String::from_utf8_lossy(&stderr)
+        ))),
+        CommandTermination::TimedOut => Err(io::Error::new(
+            io::ErrorKind::TimedOut,
+            format!("copy_file timed out for {path}"),
+        )),
+        CommandTermination::Cancelled => Err(io::Error::other(format!(
+            "copy_file was cancelled for {path}: {}",
+            result.diagnostic
+        ))),
+        CommandTermination::StartFailed | CommandTermination::WaitFailed => Err(io::Error::other(
+            format!("copy_file command failed for {path}: {}", result.diagnostic),
+        )),
+    }
+}
+
+async fn start_command_operation_on_shared(
+    shared: &Arc<Shared>,
+    request: CommandOperationRequest<'_>,
+) -> io::Result<CommandOperationHandle> {
+    if request.timeout_ms == 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "command operation requires a positive timeout; use spawn_watch for unbounded commands",
+        ));
+    }
+    if matches!(request.stream_queue_capacity, Some(0)) {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "command stream queue capacity must be positive",
+        ));
+    }
+    if let Some(capacity) = request.stream_queue_capacity
+        && capacity > MAX_COMMAND_STREAM_CAPACITY
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("command stream queue capacity must be at most {MAX_COMMAND_STREAM_CAPACITY}"),
+        ));
+    }
+    let streams_output = command_output_policy_streams(request.stdout)
+        || command_output_policy_streams(request.stderr);
+    if !streams_output && request.stream_queue_capacity.is_some() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "command stream queue capacity requires a streaming output policy",
+        ));
+    }
+    let stream_queue_capacity = if streams_output {
+        Some(
+            request
+                .stream_queue_capacity
+                .unwrap_or(DEFAULT_COMMAND_STREAM_CAPACITY),
+        )
+    } else {
+        None
+    };
+
+    let payload = vsock_proto::encode_command_start(
+        request.timeout_ms,
+        request.command,
+        request.env,
+        request.sudo,
+        request.label,
+        request.stdout,
+        request.stderr,
+    )
+    .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e.to_string()))?;
+
+    let (stream_tx, stream_rx) = match stream_queue_capacity {
+        Some(capacity) => {
+            let (tx, rx) = mpsc::channel(capacity);
+            (Some(tx), Some(rx))
+        }
+        None => (None, None),
+    };
+    let (result_tx, result_rx) = oneshot::channel();
+    let seq = shared.next_seq();
+    let diagnostic = CommandOperationDiagnostic::new(seq, request.label);
+    let operation = CommandOperation {
+        diagnostic: diagnostic.clone(),
+        result_tx,
+        stream_tx,
+        stdout_capture: command_capture_state(request.stdout),
+        stderr_capture: command_capture_state(request.stderr),
+        stdout_stream: command_stream_state(request.stdout),
+        stderr_stream: command_stream_state(request.stderr),
+        expected_output_seq: 0,
+        stream_overflowed: false,
+    };
+
+    {
+        let mut guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
+        match &mut *guard {
+            ConnectionState::Closed { .. } => {
+                return Err(io::Error::new(
+                    io::ErrorKind::ConnectionReset,
+                    "connection closed",
+                ));
+            }
+            ConnectionState::Connected { operations, .. } => {
+                operations.insert(seq, Operation::Command(operation));
+            }
+        }
+    }
+
+    let mut registration_guard = CommandOperationRegistrationGuard::new(Arc::clone(shared), seq);
+    write_command_frame(
+        shared,
+        MSG_COMMAND_START,
+        seq,
+        &payload,
+        Some(diagnostic.frame("start")),
+    )
+    .await?;
+    registration_guard.disarm();
+
+    Ok(CommandOperationHandle {
+        shared: Arc::clone(shared),
+        seq: Some(seq),
+        diagnostic,
+        result_rx: Some(result_rx),
+        stream_rx,
+    })
+}
+
+async fn command_capture_on_shared(
+    shared: &Arc<Shared>,
+    request: CommandCaptureRequest<'_>,
+) -> io::Result<CommandOperationResult> {
+    let handle = start_command_operation_on_shared(
+        shared,
+        CommandOperationRequest {
+            timeout_ms: request.timeout_ms,
+            command: request.command,
+            env: request.env,
+            sudo: request.sudo,
+            label: request.label,
+            stdout: CommandOutputPolicy::Capture {
+                limit_bytes: request.stdout_limit_bytes,
+            },
+            stderr: CommandOutputPolicy::Capture {
+                limit_bytes: request.stderr_limit_bytes,
+            },
+            stream_queue_capacity: None,
+        },
+    )
+    .await?;
+    handle.wait(request.wait_timeout).await
+}
+
 async fn exec_on_shared(
     shared: &Arc<Shared>,
     command: &str,
@@ -1395,8 +1734,20 @@ async fn exec_on_shared(
     sudo: bool,
 ) -> io::Result<ExecResult> {
     let request_timeout = Duration::from_millis(timeout_ms as u64 + 5000);
-    exec_on_shared_with_request_timeout(shared, command, timeout_ms, env, sudo, request_timeout)
-        .await
+    exec_capture_on_shared(
+        shared,
+        CommandCaptureRequest {
+            timeout_ms,
+            command,
+            env,
+            sudo,
+            label: "exec",
+            stdout_limit_bytes: DEFAULT_COMMAND_CAPTURE_LIMIT_BYTES,
+            stderr_limit_bytes: DEFAULT_COMMAND_CAPTURE_LIMIT_BYTES,
+            wait_timeout: request_timeout,
+        },
+    )
+    .await
 }
 
 async fn exec_cleanup_on_shared(
@@ -1406,59 +1757,34 @@ async fn exec_cleanup_on_shared(
     env: &[(&str, &str)],
     sudo: bool,
 ) -> io::Result<ExecResult> {
-    exec_on_shared_with_request_timeout(
+    exec_capture_on_shared(
         shared,
-        command,
-        timeout_ms,
-        env,
-        sudo,
-        Duration::from_millis(timeout_ms as u64),
+        CommandCaptureRequest {
+            timeout_ms,
+            command,
+            env,
+            sudo,
+            label: "exec-cleanup",
+            stdout_limit_bytes: SMALL_COMMAND_CAPTURE_LIMIT_BYTES,
+            stderr_limit_bytes: SMALL_COMMAND_CAPTURE_LIMIT_BYTES,
+            wait_timeout: Duration::from_millis(timeout_ms as u64),
+        },
     )
     .await
 }
 
-async fn exec_on_shared_with_request_timeout(
+async fn exec_capture_on_shared(
     shared: &Arc<Shared>,
-    command: &str,
-    timeout_ms: u32,
-    env: &[(&str, &str)],
-    sudo: bool,
-    request_timeout: Duration,
+    request: CommandCaptureRequest<'_>,
 ) -> io::Result<ExecResult> {
-    if timeout_ms == 0 {
+    if request.timeout_ms == 0 {
         return Err(io::Error::new(
             io::ErrorKind::InvalidInput,
             "exec requires a positive timeout; use spawn_watch for unbounded commands",
         ));
     }
-    let payload = vsock_proto::encode_exec(timeout_ms, command, env, sudo);
-    let resp = request_on_shared(shared, MSG_EXEC, &payload, request_timeout).await?;
-
-    if resp.msg_type == MSG_ERROR {
-        let msg = vsock_proto::decode_error(&resp.payload)
-            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
-        return Ok(ExecResult {
-            exit_code: 1,
-            stdout: Vec::new(),
-            stderr: msg.as_bytes().to_vec(),
-        });
-    }
-
-    if resp.msg_type != MSG_EXEC_RESULT {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidData,
-            format!("unexpected response type: 0x{:02X}", resp.msg_type),
-        ));
-    }
-
-    let (exit_code, stdout, stderr) = vsock_proto::decode_exec_result(&resp.payload)
-        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
-
-    Ok(ExecResult {
-        exit_code,
-        stdout: stdout.to_vec(),
-        stderr: stderr.to_vec(),
-    })
+    let result = command_capture_on_shared(shared, request).await?;
+    command_result_to_exec_result(result)
 }
 
 impl VsockHost {
@@ -1628,113 +1954,7 @@ impl VsockHost {
         &self,
         request: CommandOperationRequest<'_>,
     ) -> io::Result<CommandOperationHandle> {
-        if request.timeout_ms == 0 {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidInput,
-                "command operation requires a positive timeout; use spawn_watch for unbounded commands",
-            ));
-        }
-        if matches!(request.stream_queue_capacity, Some(0)) {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidInput,
-                "command stream queue capacity must be positive",
-            ));
-        }
-        if let Some(capacity) = request.stream_queue_capacity
-            && capacity > MAX_COMMAND_STREAM_CAPACITY
-        {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidInput,
-                format!(
-                    "command stream queue capacity must be at most {MAX_COMMAND_STREAM_CAPACITY}"
-                ),
-            ));
-        }
-        let streams_output = command_output_policy_streams(request.stdout)
-            || command_output_policy_streams(request.stderr);
-        if !streams_output && request.stream_queue_capacity.is_some() {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidInput,
-                "command stream queue capacity requires a streaming output policy",
-            ));
-        }
-        let stream_queue_capacity = if streams_output {
-            Some(
-                request
-                    .stream_queue_capacity
-                    .unwrap_or(DEFAULT_COMMAND_STREAM_CAPACITY),
-            )
-        } else {
-            None
-        };
-
-        let payload = vsock_proto::encode_command_start(
-            request.timeout_ms,
-            request.command,
-            request.env,
-            request.sudo,
-            request.label,
-            request.stdout,
-            request.stderr,
-        )
-        .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e.to_string()))?;
-
-        let (stream_tx, stream_rx) = match stream_queue_capacity {
-            Some(capacity) => {
-                let (tx, rx) = mpsc::channel(capacity);
-                (Some(tx), Some(rx))
-            }
-            None => (None, None),
-        };
-        let (result_tx, result_rx) = oneshot::channel();
-        let seq = self.shared.next_seq();
-        let diagnostic = CommandOperationDiagnostic::new(seq, request.label);
-        let operation = CommandOperation {
-            diagnostic: diagnostic.clone(),
-            result_tx,
-            stream_tx,
-            stdout_capture: command_capture_state(request.stdout),
-            stderr_capture: command_capture_state(request.stderr),
-            stdout_stream: command_stream_state(request.stdout),
-            stderr_stream: command_stream_state(request.stderr),
-            expected_output_seq: 0,
-            stream_overflowed: false,
-        };
-
-        {
-            let mut guard = self.shared.state.lock().unwrap_or_else(|e| e.into_inner());
-            match &mut *guard {
-                ConnectionState::Closed { .. } => {
-                    return Err(io::Error::new(
-                        io::ErrorKind::ConnectionReset,
-                        "connection closed",
-                    ));
-                }
-                ConnectionState::Connected { operations, .. } => {
-                    operations.insert(seq, Operation::Command(operation));
-                }
-            }
-        }
-
-        let mut registration_guard =
-            CommandOperationRegistrationGuard::new(Arc::clone(&self.shared), seq);
-        write_command_frame(
-            &self.shared,
-            MSG_COMMAND_START,
-            seq,
-            &payload,
-            Some(diagnostic.frame("start")),
-        )
-        .await?;
-        registration_guard.disarm();
-
-        Ok(CommandOperationHandle {
-            shared: Arc::clone(&self.shared),
-            seq: Some(seq),
-            diagnostic,
-            result_rx: Some(result_rx),
-            stream_rx,
-        })
+        start_command_operation_on_shared(&self.shared, request).await
     }
 
     /// Run a capture-only command operation with default capture limits.
@@ -1765,23 +1985,7 @@ impl VsockHost {
         &self,
         request: CommandCaptureRequest<'_>,
     ) -> io::Result<CommandOperationResult> {
-        let handle = self
-            .start_command_operation(CommandOperationRequest {
-                timeout_ms: request.timeout_ms,
-                command: request.command,
-                env: request.env,
-                sudo: request.sudo,
-                label: request.label,
-                stdout: CommandOutputPolicy::Capture {
-                    limit_bytes: request.stdout_limit_bytes,
-                },
-                stderr: CommandOutputPolicy::Capture {
-                    limit_bytes: request.stderr_limit_bytes,
-                },
-                stream_queue_capacity: None,
-            })
-            .await?;
-        handle.wait(request.wait_timeout).await
+        command_capture_on_shared(&self.shared, request).await
     }
 
     /// Start a streaming command operation with a bounded output event receiver.
@@ -1827,6 +2031,215 @@ impl VsockHost {
         exec_on_shared(&self.shared, command, timeout_ms, env, sudo).await
     }
 
+    /// Execute a capture-style command with explicit output limits.
+    pub async fn exec_capture(&self, request: CommandCaptureRequest<'_>) -> io::Result<ExecResult> {
+        exec_capture_on_shared(&self.shared, request).await
+    }
+
+    /// Read a small file from the guest through command capture.
+    ///
+    /// Missing files return `Ok(None)`. Files larger than `max_bytes` return
+    /// an error instead of silently returning truncated bytes.
+    pub async fn read_file(
+        &self,
+        path: &str,
+        max_bytes: u64,
+        timeout_ms: u32,
+    ) -> io::Result<Option<Vec<u8>>> {
+        let stdout_limit_bytes = u32::try_from(max_bytes).map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "read_file max_bytes exceeds command capture limit",
+            )
+        })?;
+        if stdout_limit_bytes == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "read_file max_bytes must be positive",
+            ));
+        }
+
+        const MISSING_FILE_EXIT_CODE: i32 = 66;
+        let command = format!(
+            "if test -f {path}; then cat -- {path}; else exit {MISSING_FILE_EXIT_CODE}; fi",
+            path = shell_quote(path)
+        );
+        let result = self
+            .exec_capture(CommandCaptureRequest {
+                timeout_ms,
+                command: &command,
+                env: &[],
+                sudo: false,
+                label: "read-file",
+                stdout_limit_bytes,
+                stderr_limit_bytes: SMALL_COMMAND_CAPTURE_LIMIT_BYTES,
+                wait_timeout: Duration::from_millis(timeout_ms as u64 + 5000),
+            })
+            .await?;
+        if result.exit_code == MISSING_FILE_EXIT_CODE {
+            return Ok(None);
+        }
+        if result.exit_code != 0 {
+            return Err(io::Error::other(format!(
+                "failed to read file {path}: {}",
+                String::from_utf8_lossy(&result.stderr)
+            )));
+        }
+        if result.stdout_truncated {
+            return Err(io::Error::other(format!(
+                "file {path} exceeded {max_bytes} bytes"
+            )));
+        }
+        if result.stderr_truncated {
+            return Err(io::Error::other(format!(
+                "stderr while reading file {path} exceeded diagnostic limit"
+            )));
+        }
+        Ok(Some(result.stdout))
+    }
+
+    /// Stream a guest file to a host path and atomically rename it into place
+    /// after the command exits successfully.
+    pub async fn copy_file(
+        &self,
+        path: &str,
+        host_path: &Path,
+        options: CopyFileOptions,
+    ) -> io::Result<CopyFileResult> {
+        if options.max_bytes == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "copy_file max_bytes must be positive",
+            ));
+        }
+        let stream_limit_bytes = u32::try_from(options.max_bytes).map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "copy_file max_bytes exceeds command stream limit",
+            )
+        })?;
+        if options.timeout_ms == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "copy_file timeout must be positive",
+            ));
+        }
+
+        if let Some(parent) = host_path.parent()
+            && !parent.as_os_str().is_empty()
+        {
+            tokio::fs::create_dir_all(parent).await?;
+        }
+
+        let temp_path = copy_temp_path(host_path, self.shared.next_seq());
+        let copy_result = self
+            .copy_file_to_temp(
+                path,
+                &temp_path,
+                stream_limit_bytes,
+                options.timeout_ms,
+                options.missing_ok,
+            )
+            .await;
+        match copy_result {
+            Ok(CopyFileOutcome::Copied { bytes_copied }) => {
+                match tokio::fs::rename(&temp_path, host_path).await {
+                    Ok(()) => Ok(CopyFileResult { bytes_copied }),
+                    Err(err) => {
+                        remove_temp_file(&temp_path).await;
+                        Err(err)
+                    }
+                }
+            }
+            Ok(CopyFileOutcome::Missing) => {
+                remove_temp_file(&temp_path).await;
+                Ok(CopyFileResult { bytes_copied: 0 })
+            }
+            Err(err) => {
+                remove_temp_file(&temp_path).await;
+                Err(err)
+            }
+        }
+    }
+
+    async fn copy_file_to_temp(
+        &self,
+        path: &str,
+        temp_path: &Path,
+        stream_limit_bytes: u32,
+        timeout_ms: u32,
+        missing_ok: bool,
+    ) -> io::Result<CopyFileOutcome> {
+        const MISSING_FILE_EXIT_CODE: i32 = 66;
+        let command = format!(
+            "if test -f {path}; then cat -- {path}; else exit {MISSING_FILE_EXIT_CODE}; fi",
+            path = shell_quote(path)
+        );
+        let mut handle = self
+            .command_stream(CommandStreamRequest {
+                timeout_ms,
+                command: &command,
+                env: &[],
+                sudo: false,
+                label: "copy-file",
+                stdout: CommandOutputPolicy::Stream {
+                    limit_bytes: stream_limit_bytes,
+                    chunk_limit_bytes: 64 * 1024,
+                },
+                stderr: CommandOutputPolicy::Capture {
+                    limit_bytes: SMALL_COMMAND_CAPTURE_LIMIT_BYTES,
+                },
+                stream_queue_capacity: None,
+            })
+            .await?;
+        let mut stream_rx = handle.take_stream_receiver().ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "copy_file command did not create a stream receiver",
+            )
+        })?;
+        let wait_timeout = Duration::from_millis(timeout_ms as u64 + 5000);
+        let mut temp_file = tokio::fs::File::create(temp_path).await?;
+        let mut bytes_copied = 0u64;
+
+        let drain_result = tokio::time::timeout(wait_timeout, async {
+            while let Some(event) = stream_rx.recv().await {
+                write_copy_stream_event(
+                    &mut temp_file,
+                    &mut bytes_copied,
+                    stream_limit_bytes as u64,
+                    event,
+                )
+                .await?;
+            }
+            io::Result::Ok(())
+        })
+        .await;
+        match drain_result {
+            Ok(Ok(())) => {}
+            Ok(Err(err)) => {
+                let _ = handle.cancel_and_wait(Duration::from_secs(1)).await;
+                return Err(err);
+            }
+            Err(_) => {
+                let _ = handle.cancel_and_wait(Duration::from_secs(1)).await;
+                return Err(io::Error::new(
+                    io::ErrorKind::TimedOut,
+                    format!("copy_file stream drain timed out for {path}"),
+                ));
+            }
+        };
+
+        let result = handle.wait(Duration::from_secs(5)).await?;
+        match validate_copy_command_result(path, result, missing_ok)? {
+            CopyFileCommandStatus::Present => {}
+            CopyFileCommandStatus::Missing => return Ok(CopyFileOutcome::Missing),
+        }
+        temp_file.flush().await?;
+
+        Ok(CopyFileOutcome::Copied { bytes_copied })
+    }
+
     /// Maximum content per write_file message.  Leaves headroom below
     /// [`vsock_proto::MAX_MESSAGE_SIZE`] for the path and frame overhead.
     const WRITE_FILE_CHUNK_LIMIT: usize = 15 * 1024 * 1024;
@@ -1856,8 +2269,8 @@ impl VsockHost {
         // suffix prevents concurrent large writes to the same destination
         // from appending to or cleaning up each other's staging file.
         let tmp = format!("{path}.vm0tmp-{}", self.shared.next_seq());
-        let escaped_tmp = tmp.replace('\'', "'\\''");
-        let rm_tmp = format!("rm -f -- '{escaped_tmp}'");
+        let quoted_tmp = shell_quote(&tmp);
+        let rm_tmp = format!("rm -f -- {quoted_tmp}");
         let mut cleanup_guard =
             ChunkedWriteCleanupGuard::new(Arc::clone(&self.shared), rm_tmp, sudo);
 
@@ -1876,10 +2289,18 @@ impl VsockHost {
         }
 
         // Atomic rename temp → target.
-        let escaped_path = path.replace('\'', "'\\''");
-        let mv_cmd = format!("mv -f -- '{escaped_tmp}' '{escaped_path}'");
+        let mv_cmd = format!("mv -f -- {quoted_tmp} {}", shell_quote(path));
         match self
-            .exec(&mv_cmd, Self::HELPER_EXEC_TIMEOUT_MS, &[], sudo)
+            .exec_capture(CommandCaptureRequest {
+                command: &mv_cmd,
+                timeout_ms: Self::HELPER_EXEC_TIMEOUT_MS,
+                env: &[],
+                sudo,
+                label: "write-file-rename",
+                stdout_limit_bytes: SMALL_COMMAND_CAPTURE_LIMIT_BYTES,
+                stderr_limit_bytes: SMALL_COMMAND_CAPTURE_LIMIT_BYTES,
+                wait_timeout: Duration::from_millis(Self::HELPER_EXEC_TIMEOUT_MS as u64 + 5000),
+            })
             .await
         {
             Ok(r) if r.exit_code == 0 => {
@@ -2391,6 +2812,27 @@ mod tests {
         stream.write_all(&frame).await.unwrap();
     }
 
+    async fn send_stream_command_result(
+        stream: &mut UnixStream,
+        seq: u32,
+        termination: CommandTermination,
+        stderr: &[u8],
+    ) {
+        let payload = vsock_proto::encode_command_result(
+            termination,
+            12,
+            CommandCapturedOutput::Discarded,
+            CommandCapturedOutput::Captured {
+                bytes: stderr,
+                truncated: false,
+            },
+            "",
+        )
+        .unwrap();
+        let frame = vsock_proto::encode(MSG_COMMAND_RESULT, seq, &payload).unwrap();
+        stream.write_all(&frame).await.unwrap();
+    }
+
     async fn send_raw_command_result(stream: &mut UnixStream, seq: u32, payload: Vec<u8>) {
         let frame = vsock_proto::encode(MSG_COMMAND_RESULT, seq, &payload).unwrap();
         stream.write_all(&frame).await.unwrap();
@@ -2437,7 +2879,7 @@ mod tests {
         .unwrap();
     }
 
-    async fn assert_connection_accepts_legacy_exec(
+    async fn assert_connection_accepts_command_exec(
         host: &Arc<VsockHost>,
         guest: &mut UnixStream,
         decoder: &mut Decoder,
@@ -2447,10 +2889,18 @@ mod tests {
             tokio::spawn(async move { host.exec("echo ok", 5000, &[], false).await })
         };
         let msg = read_guest_message(guest, decoder).await;
-        assert_eq!(msg.msg_type, MSG_EXEC);
-        let payload = vsock_proto::encode_exec_result(0, b"ok", b"");
-        let response = vsock_proto::encode(MSG_EXEC_RESULT, msg.seq, &payload).unwrap();
-        guest.write_all(&response).await.unwrap();
+        assert_eq!(msg.msg_type, MSG_COMMAND_START);
+        let decoded = vsock_proto::decode_command_start(&msg.payload).unwrap();
+        assert_eq!(decoded.command, "echo ok");
+        assert_eq!(decoded.label, "exec");
+        send_command_result(
+            guest,
+            msg.seq,
+            CommandTermination::Exited { exit_code: 0 },
+            b"ok",
+            b"",
+        )
+        .await;
         let exec_result = exec_task.await.unwrap().unwrap();
         assert_eq!(exec_result.stdout, b"ok");
     }
@@ -2602,7 +3052,7 @@ mod tests {
             assert!(is_connected(&host));
         }
 
-        assert_connection_accepts_legacy_exec(&host, &mut guest, &mut decoder).await;
+        assert_connection_accepts_command_exec(&host, &mut guest, &mut decoder).await;
     }
 
     #[tokio::test]
@@ -2895,7 +3345,7 @@ mod tests {
         assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
         assert_eq!(operation_count(&host), 0);
 
-        assert_connection_accepts_legacy_exec(&host, &mut guest, &mut decoder).await;
+        assert_connection_accepts_command_exec(&host, &mut guest, &mut decoder).await;
     }
 
     #[tokio::test]
@@ -2925,7 +3375,7 @@ mod tests {
         assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
         assert_eq!(operation_count(&host), 0);
 
-        assert_connection_accepts_legacy_exec(&host, &mut guest, &mut decoder).await;
+        assert_connection_accepts_command_exec(&host, &mut guest, &mut decoder).await;
     }
 
     #[tokio::test]
@@ -3002,7 +3452,7 @@ mod tests {
         assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
         assert_eq!(operation_count(&host), 0);
 
-        assert_connection_accepts_legacy_exec(&host, &mut guest, &mut decoder).await;
+        assert_connection_accepts_command_exec(&host, &mut guest, &mut decoder).await;
     }
 
     #[tokio::test]
@@ -3029,7 +3479,7 @@ mod tests {
         assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
         assert_eq!(operation_count(&host), 0);
 
-        assert_connection_accepts_legacy_exec(&host, &mut guest, &mut decoder).await;
+        assert_connection_accepts_command_exec(&host, &mut guest, &mut decoder).await;
     }
 
     #[tokio::test]
@@ -3059,7 +3509,7 @@ mod tests {
         assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
         assert_eq!(operation_count(&host), 0);
 
-        assert_connection_accepts_legacy_exec(&host, &mut guest, &mut decoder).await;
+        assert_connection_accepts_command_exec(&host, &mut guest, &mut decoder).await;
     }
 
     #[tokio::test]
@@ -3086,7 +3536,7 @@ mod tests {
         assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
         assert_eq!(operation_count(&host), 0);
 
-        assert_connection_accepts_legacy_exec(&host, &mut guest, &mut decoder).await;
+        assert_connection_accepts_command_exec(&host, &mut guest, &mut decoder).await;
     }
 
     #[tokio::test]
@@ -3690,7 +4140,7 @@ mod tests {
         assert_eq!(err.to_string(), "command operation already active");
         assert_eq!(operation_count(&host), 0);
 
-        assert_connection_accepts_legacy_exec(&host, &mut guest, &mut decoder).await;
+        assert_connection_accepts_command_exec(&host, &mut guest, &mut decoder).await;
     }
 
     #[tokio::test]
@@ -3863,10 +4313,17 @@ mod tests {
 
         let exec_task = tokio::spawn(async move { host.exec("echo ok", 5000, &[], false).await });
         let exec_msg = read_guest_message(&mut guest, &mut decoder).await;
-        assert_eq!(exec_msg.msg_type, MSG_EXEC);
-        let payload = vsock_proto::encode_exec_result(0, b"ok", b"");
-        let response = vsock_proto::encode(MSG_EXEC_RESULT, exec_msg.seq, &payload).unwrap();
-        guest.write_all(&response).await.unwrap();
+        assert_eq!(exec_msg.msg_type, MSG_COMMAND_START);
+        let decoded = vsock_proto::decode_command_start(&exec_msg.payload).unwrap();
+        assert_eq!(decoded.command, "echo ok");
+        send_command_result(
+            &mut guest,
+            exec_msg.seq,
+            CommandTermination::Exited { exit_code: 0 },
+            b"ok",
+            b"",
+        )
+        .await;
         let exec_result = exec_task.await.unwrap().unwrap();
         assert_eq!(exec_result.stdout, b"ok");
     }
@@ -3895,7 +4352,7 @@ mod tests {
         let frame = vsock_proto::encode(MSG_COMMAND_OUTPUT, msg.seq, &[0]).unwrap();
         guest.write_all(&frame).await.unwrap();
 
-        assert_connection_accepts_legacy_exec(&host, &mut guest, &mut decoder).await;
+        assert_connection_accepts_command_exec(&host, &mut guest, &mut decoder).await;
     }
 
     #[tokio::test]
@@ -3915,7 +4372,7 @@ mod tests {
         let result_frame = vsock_proto::encode(MSG_COMMAND_RESULT, msg.seq, &[0]).unwrap();
         guest.write_all(&result_frame).await.unwrap();
 
-        assert_connection_accepts_legacy_exec(&host, &mut guest, &mut decoder).await;
+        assert_connection_accepts_command_exec(&host, &mut guest, &mut decoder).await;
     }
 
     #[tokio::test]
@@ -3953,7 +4410,7 @@ mod tests {
         )
         .await;
 
-        assert_connection_accepts_legacy_exec(&host, &mut guest, &mut decoder).await;
+        assert_connection_accepts_command_exec(&host, &mut guest, &mut decoder).await;
     }
 
     #[tokio::test]
@@ -3985,7 +4442,7 @@ mod tests {
         let frame = vsock_proto::encode(MSG_COMMAND_RESULT, msg.seq, &[0]).unwrap();
         guest.write_all(&frame).await.unwrap();
 
-        assert_connection_accepts_legacy_exec(&host, &mut guest, &mut decoder).await;
+        assert_connection_accepts_command_exec(&host, &mut guest, &mut decoder).await;
     }
 
     #[tokio::test]
@@ -4016,10 +4473,18 @@ mod tests {
             tokio::spawn(async move { host.exec("echo ok", 5000, &[], false).await })
         };
         let msg = read_guest_message(&mut guest, &mut decoder).await;
-        assert_eq!(msg.msg_type, MSG_EXEC, "start frame should not be written");
-        let payload = vsock_proto::encode_exec_result(0, b"ok", b"");
-        let response = vsock_proto::encode(MSG_EXEC_RESULT, msg.seq, &payload).unwrap();
-        guest.write_all(&response).await.unwrap();
+        assert_eq!(
+            msg.msg_type, MSG_COMMAND_START,
+            "start frame should not be written"
+        );
+        send_command_result(
+            &mut guest,
+            msg.seq,
+            CommandTermination::Exited { exit_code: 0 },
+            b"ok",
+            b"",
+        )
+        .await;
         let exec_result = exec_task.await.unwrap().unwrap();
         assert_eq!(exec_result.stdout, b"ok");
         assert!(is_connected(&host));
@@ -4040,10 +4505,18 @@ mod tests {
             tokio::spawn(async move { host.exec("echo ok", 5000, &[], false).await })
         };
         let msg = read_guest_message(&mut guest, &mut decoder).await;
-        assert_eq!(msg.msg_type, MSG_EXEC, "drop must not send command cancel");
-        let payload = vsock_proto::encode_exec_result(0, b"ok", b"");
-        let response = vsock_proto::encode(MSG_EXEC_RESULT, msg.seq, &payload).unwrap();
-        guest.write_all(&response).await.unwrap();
+        assert_eq!(
+            msg.msg_type, MSG_COMMAND_START,
+            "drop must not send command cancel"
+        );
+        send_command_result(
+            &mut guest,
+            msg.seq,
+            CommandTermination::Exited { exit_code: 0 },
+            b"ok",
+            b"",
+        )
+        .await;
         let exec_result = exec_task.await.unwrap().unwrap();
         assert_eq!(exec_result.stdout, b"ok");
         assert!(is_connected(&host));
@@ -4101,7 +4574,7 @@ mod tests {
             CommandTermination::Exited { exit_code: 0 }
         );
 
-        assert_connection_accepts_legacy_exec(&host, &mut guest, &mut decoder).await;
+        assert_connection_accepts_command_exec(&host, &mut guest, &mut decoder).await;
     }
 
     #[tokio::test]
@@ -4131,7 +4604,7 @@ mod tests {
         assert_eq!(operation_count(&host), 0);
         assert!(is_connected(&host));
 
-        assert_connection_accepts_legacy_exec(&host, &mut guest, &mut decoder).await;
+        assert_connection_accepts_command_exec(&host, &mut guest, &mut decoder).await;
     }
 
     #[tokio::test]
@@ -4174,17 +4647,23 @@ mod tests {
             let mut buf = [0u8; 4096];
             let n = guest.read(&mut buf).await.unwrap();
             let msgs = decoder.decode(&buf[..n]).unwrap();
-            assert_eq!(msgs[0].msg_type, MSG_EXEC);
+            assert_eq!(msgs[0].msg_type, MSG_COMMAND_START);
 
-            let d = vsock_proto::decode_exec(&msgs[0].payload).unwrap();
+            let d = vsock_proto::decode_command_start(&msgs[0].payload).unwrap();
             assert_eq!(d.command, "echo hello");
             assert_eq!(d.timeout_ms, 5000);
             assert!(d.env.is_empty());
             assert!(!d.sudo);
+            assert_eq!(d.label, "exec");
 
-            let payload = vsock_proto::encode_exec_result(0, b"hello\n", b"");
-            let resp = vsock_proto::encode(MSG_EXEC_RESULT, msgs[0].seq, &payload).unwrap();
-            guest.write_all(&resp).await.unwrap();
+            send_command_result(
+                &mut guest,
+                msgs[0].seq,
+                CommandTermination::Exited { exit_code: 0 },
+                b"hello\n",
+                b"",
+            )
+            .await;
         });
 
         let host = host_from_stream(host_stream).await.unwrap();
@@ -4229,9 +4708,243 @@ mod tests {
         });
 
         let host = host_from_stream(host_stream).await.unwrap();
-        let result = host.exec("badcmd", 5000, &[], false).await.unwrap();
-        assert_eq!(result.exit_code, 1);
-        assert_eq!(result.stderr, b"command not found");
+        let err = host.exec("badcmd", 5000, &[], false).await.unwrap_err();
+        assert!(err.to_string().contains("command not found"));
+    }
+
+    #[tokio::test]
+    async fn read_file_returns_content_and_missing() {
+        let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+        let host = Arc::new(host);
+
+        let read_task = {
+            let host = Arc::clone(&host);
+            tokio::spawn(async move { host.read_file("/tmp/session.txt", 1024, 5000).await })
+        };
+        let msg = read_guest_message(&mut guest, &mut decoder).await;
+        assert_eq!(msg.msg_type, MSG_COMMAND_START);
+        let decoded = vsock_proto::decode_command_start(&msg.payload).unwrap();
+        assert_eq!(decoded.label, "read-file");
+        assert!(decoded.command.contains("cat -- '/tmp/session.txt'"));
+        send_command_result(
+            &mut guest,
+            msg.seq,
+            CommandTermination::Exited { exit_code: 0 },
+            b"session-id\n",
+            b"",
+        )
+        .await;
+        let content = read_task.await.unwrap().unwrap();
+        assert_eq!(content.as_deref(), Some(&b"session-id\n"[..]));
+
+        let missing_task = {
+            let host = Arc::clone(&host);
+            tokio::spawn(async move { host.read_file("/tmp/missing.txt", 1024, 5000).await })
+        };
+        let msg = read_guest_message(&mut guest, &mut decoder).await;
+        assert_eq!(msg.msg_type, MSG_COMMAND_START);
+        send_command_result(
+            &mut guest,
+            msg.seq,
+            CommandTermination::Exited { exit_code: 66 },
+            b"",
+            b"",
+        )
+        .await;
+        let missing = missing_task.await.unwrap().unwrap();
+        assert_eq!(missing, None);
+    }
+
+    #[tokio::test]
+    async fn copy_file_streams_to_temp_then_renames() {
+        let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let dir =
+            std::env::temp_dir().join(format!("vsock-host-copy-{}-{unique}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let host_path = dir.join("system.log");
+        let copy_path = host_path.clone();
+
+        let copy_task = tokio::spawn(async move {
+            host.copy_file(
+                "/tmp/vm0-system-run.log",
+                &copy_path,
+                CopyFileOptions {
+                    max_bytes: 1024,
+                    timeout_ms: 5000,
+                    missing_ok: false,
+                },
+            )
+            .await
+        });
+
+        let msg = read_guest_message(&mut guest, &mut decoder).await;
+        assert_eq!(msg.msg_type, MSG_COMMAND_START);
+        let decoded = vsock_proto::decode_command_start(&msg.payload).unwrap();
+        assert_eq!(decoded.label, "copy-file");
+        assert_eq!(
+            decoded.command,
+            "if test -f '/tmp/vm0-system-run.log'; then cat -- '/tmp/vm0-system-run.log'; else exit 66; fi"
+        );
+        assert_eq!(
+            decoded.stdout,
+            CommandOutputPolicy::Stream {
+                limit_bytes: 1024,
+                chunk_limit_bytes: 64 * 1024,
+            }
+        );
+        send_command_output(
+            &mut guest,
+            msg.seq,
+            0,
+            CommandOutputStream::Stdout,
+            b"line 1\n",
+            false,
+        )
+        .await;
+        send_command_output(
+            &mut guest,
+            msg.seq,
+            1,
+            CommandOutputStream::Stdout,
+            b"line 2\n",
+            false,
+        )
+        .await;
+        send_stream_command_result(
+            &mut guest,
+            msg.seq,
+            CommandTermination::Exited { exit_code: 0 },
+            b"",
+        )
+        .await;
+
+        let result = copy_task.await.unwrap().unwrap();
+        assert_eq!(result.bytes_copied, 14);
+        assert_eq!(std::fs::read(&host_path).unwrap(), b"line 1\nline 2\n");
+        assert!(
+            std::fs::read_dir(&dir).unwrap().all(|entry| !entry
+                .unwrap()
+                .file_name()
+                .to_string_lossy()
+                .contains("vm0tmp")),
+            "copy temp file should not remain"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn copy_file_removes_temp_without_publishing_on_stream_truncation() {
+        let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!(
+            "vsock-host-copy-truncated-{}-{unique}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let host_path = dir.join("system.log");
+        std::fs::write(&host_path, b"old host log").unwrap();
+        let copy_path = host_path.clone();
+
+        let copy_task = tokio::spawn(async move {
+            host.copy_file(
+                "/tmp/vm0-system-run.log",
+                &copy_path,
+                CopyFileOptions {
+                    max_bytes: 1024,
+                    timeout_ms: 5000,
+                    missing_ok: false,
+                },
+            )
+            .await
+        });
+
+        let msg = read_guest_message(&mut guest, &mut decoder).await;
+        send_command_output(
+            &mut guest,
+            msg.seq,
+            0,
+            CommandOutputStream::Stdout,
+            b"partial",
+            true,
+        )
+        .await;
+
+        let cancel = read_guest_message(&mut guest, &mut decoder).await;
+        assert_eq!(cancel.msg_type, MSG_COMMAND_CANCEL);
+        assert_eq!(cancel.seq, msg.seq);
+        send_stream_command_result(&mut guest, msg.seq, CommandTermination::Cancelled, b"").await;
+
+        let err = copy_task.await.unwrap().unwrap_err();
+        assert!(err.to_string().contains("truncated"));
+        assert_eq!(std::fs::read(&host_path).unwrap(), b"old host log");
+        assert!(
+            std::fs::read_dir(&dir).unwrap().all(|entry| !entry
+                .unwrap()
+                .file_name()
+                .to_string_lossy()
+                .contains("vm0tmp")),
+            "failed copy temp file should be removed"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn copy_file_missing_ok_leaves_no_final_or_temp_file() {
+        let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!(
+            "vsock-host-copy-missing-{}-{unique}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let host_path = dir.join("system.log");
+        let copy_path = host_path.clone();
+
+        let copy_task = tokio::spawn(async move {
+            host.copy_file(
+                "/tmp/missing.log",
+                &copy_path,
+                CopyFileOptions {
+                    max_bytes: 1024,
+                    timeout_ms: 5000,
+                    missing_ok: true,
+                },
+            )
+            .await
+        });
+
+        let msg = read_guest_message(&mut guest, &mut decoder).await;
+        assert_eq!(msg.msg_type, MSG_COMMAND_START);
+        send_stream_command_result(
+            &mut guest,
+            msg.seq,
+            CommandTermination::Exited { exit_code: 66 },
+            b"",
+        )
+        .await;
+
+        let result = copy_task.await.unwrap().unwrap();
+        assert_eq!(result.bytes_copied, 0);
+        assert!(!host_path.exists());
+        assert!(
+            std::fs::read_dir(&dir).unwrap().all(|entry| !entry
+                .unwrap()
+                .file_name()
+                .to_string_lossy()
+                .contains("vm0tmp")),
+            "missing copy temp file should be removed"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[tokio::test]
@@ -4306,17 +5019,23 @@ mod tests {
                         let resp =
                             vsock_proto::encode(MSG_WRITE_FILE_RESULT, msg.seq, &payload).unwrap();
                         guest.write_all(&resp).await.unwrap();
-                    } else if msg.msg_type == MSG_EXEC {
+                    } else if msg.msg_type == MSG_COMMAND_START {
                         // Atomic rename: mv temp → target
-                        let decoded = vsock_proto::decode_exec(&msg.payload).unwrap();
+                        let decoded = vsock_proto::decode_command_start(&msg.payload).unwrap();
                         let temp_path = temp_path.as_ref().expect("temp path");
                         assert!(decoded.command.contains("mv -f --"));
                         assert!(decoded.command.contains(temp_path));
                         assert!(decoded.command.contains("/tmp/big.bin"));
+                        assert_eq!(decoded.label, "write-file-rename");
 
-                        let payload = vsock_proto::encode_exec_result(0, &[], &[]);
-                        let resp = vsock_proto::encode(MSG_EXEC_RESULT, msg.seq, &payload).unwrap();
-                        guest.write_all(&resp).await.unwrap();
+                        send_command_result(
+                            &mut guest,
+                            msg.seq,
+                            CommandTermination::Exited { exit_code: 0 },
+                            &[],
+                            &[],
+                        )
+                        .await;
                         // Done — verify chunks and return
                         assert_eq!(chunks_received.len(), 2);
                         assert!(!chunks_received[0].0); // first: create
@@ -4418,15 +5137,21 @@ mod tests {
                         let resp =
                             vsock_proto::encode(MSG_WRITE_FILE_RESULT, msg.seq, &payload).unwrap();
                         guest.write_all(&resp).await.unwrap();
-                    } else if msg.msg_type == MSG_EXEC {
+                    } else if msg.msg_type == MSG_COMMAND_START {
                         // Cleanup: rm -f temp file
-                        let decoded = vsock_proto::decode_exec(&msg.payload).unwrap();
+                        let decoded = vsock_proto::decode_command_start(&msg.payload).unwrap();
                         let temp_path = temp_path.as_ref().expect("temp path");
                         assert!(decoded.command.contains("rm -f --"));
                         assert!(decoded.command.contains(temp_path));
-                        let payload = vsock_proto::encode_exec_result(0, &[], &[]);
-                        let resp = vsock_proto::encode(MSG_EXEC_RESULT, msg.seq, &payload).unwrap();
-                        guest.write_all(&resp).await.unwrap();
+                        assert_eq!(decoded.label, "exec-cleanup");
+                        send_command_result(
+                            &mut guest,
+                            msg.seq,
+                            CommandTermination::Exited { exit_code: 0 },
+                            &[],
+                            &[],
+                        )
+                        .await;
                         return;
                     }
                 }
@@ -4475,26 +5200,35 @@ mod tests {
                         let resp =
                             vsock_proto::encode(MSG_WRITE_FILE_RESULT, msg.seq, &payload).unwrap();
                         guest.write_all(&resp).await.unwrap();
-                    } else if msg.msg_type == MSG_EXEC {
+                    } else if msg.msg_type == MSG_COMMAND_START {
                         exec_count += 1;
-                        let decoded = vsock_proto::decode_exec(&msg.payload).unwrap();
+                        let decoded = vsock_proto::decode_command_start(&msg.payload).unwrap();
                         let temp_path = temp_path.as_ref().expect("temp path");
                         if decoded.command.contains("mv -f --") {
                             // mv fails
                             assert!(decoded.command.contains(temp_path));
-                            let payload =
-                                vsock_proto::encode_exec_result(1, &[], b"permission denied");
-                            let resp =
-                                vsock_proto::encode(MSG_EXEC_RESULT, msg.seq, &payload).unwrap();
-                            guest.write_all(&resp).await.unwrap();
+                            assert_eq!(decoded.label, "write-file-rename");
+                            send_command_result(
+                                &mut guest,
+                                msg.seq,
+                                CommandTermination::Exited { exit_code: 1 },
+                                &[],
+                                b"permission denied",
+                            )
+                            .await;
                         } else {
                             // cleanup rm
                             assert!(decoded.command.contains("rm -f --"));
                             assert!(decoded.command.contains(temp_path));
-                            let payload = vsock_proto::encode_exec_result(0, &[], &[]);
-                            let resp =
-                                vsock_proto::encode(MSG_EXEC_RESULT, msg.seq, &payload).unwrap();
-                            guest.write_all(&resp).await.unwrap();
+                            assert_eq!(decoded.label, "exec-cleanup");
+                            send_command_result(
+                                &mut guest,
+                                msg.seq,
+                                CommandTermination::Exited { exit_code: 0 },
+                                &[],
+                                &[],
+                            )
+                            .await;
                             assert_eq!(exec_count, 2); // mv then rm
                             return;
                         }
@@ -4553,17 +5287,23 @@ mod tests {
                         if let Some(tx) = first_chunk_tx.take() {
                             let _ = tx.send(());
                         }
-                    } else if msg.msg_type == MSG_EXEC {
-                        let decoded = vsock_proto::decode_exec(&msg.payload).unwrap();
+                    } else if msg.msg_type == MSG_COMMAND_START {
+                        let decoded = vsock_proto::decode_command_start(&msg.payload).unwrap();
                         let temp_path = temp_path.as_ref().expect("temp path");
                         assert!(decoded.command.contains("rm -f --"));
                         assert!(decoded.command.contains(temp_path));
+                        assert_eq!(decoded.label, "exec-cleanup");
                         if let Some(tx) = cleanup_tx.take() {
                             let _ = tx.send(decoded.command.to_string());
                         }
-                        let payload = vsock_proto::encode_exec_result(0, &[], &[]);
-                        let resp = vsock_proto::encode(MSG_EXEC_RESULT, msg.seq, &payload).unwrap();
-                        guest.write_all(&resp).await.unwrap();
+                        send_command_result(
+                            &mut guest,
+                            msg.seq,
+                            CommandTermination::Exited { exit_code: 0 },
+                            &[],
+                            &[],
+                        )
+                        .await;
                         return;
                     }
                 }
@@ -4993,15 +5733,20 @@ mod tests {
                 all_msgs.extend(msgs);
             }
             assert_eq!(all_msgs.len(), 2);
-            assert!(all_msgs.iter().all(|m| m.msg_type == MSG_EXEC));
+            assert!(all_msgs.iter().all(|m| m.msg_type == MSG_COMMAND_START));
 
             // Reply in reverse order to exercise seq-based dispatching.
             for msg in all_msgs.iter().rev() {
-                let d = vsock_proto::decode_exec(&msg.payload).unwrap();
+                let d = vsock_proto::decode_command_start(&msg.payload).unwrap();
                 let out = format!("reply:{}", d.command);
-                let payload = vsock_proto::encode_exec_result(0, out.as_bytes(), b"");
-                let resp = vsock_proto::encode(MSG_EXEC_RESULT, msg.seq, &payload).unwrap();
-                guest.write_all(&resp).await.unwrap();
+                send_command_result(
+                    &mut guest,
+                    msg.seq,
+                    CommandTermination::Exited { exit_code: 0 },
+                    out.as_bytes(),
+                    b"",
+                )
+                .await;
             }
 
             let mut discard = [0u8; 1];
@@ -5042,13 +5787,18 @@ mod tests {
             let mut buf = [0u8; 4096];
             let n = guest.read(&mut buf).await.unwrap();
             let msgs = decoder.decode(&buf[..n]).unwrap();
-            assert_eq!(msgs[0].msg_type, MSG_EXEC);
+            assert_eq!(msgs[0].msg_type, MSG_COMMAND_START);
             // Handshake used seq=1, so first request must be seq=2.
             assert_eq!(msgs[0].seq, 2, "first post-handshake seq should be 2");
 
-            let payload = vsock_proto::encode_exec_result(0, b"ok", b"");
-            let resp = vsock_proto::encode(MSG_EXEC_RESULT, msgs[0].seq, &payload).unwrap();
-            guest.write_all(&resp).await.unwrap();
+            send_command_result(
+                &mut guest,
+                msgs[0].seq,
+                CommandTermination::Exited { exit_code: 0 },
+                b"ok",
+                b"",
+            )
+            .await;
         });
 
         let host = host_from_stream(host_stream).await.unwrap();
@@ -5268,14 +6018,19 @@ mod tests {
             let mut buf = [0u8; 4096];
             let n = guest.read(&mut buf).await.unwrap();
             let msgs = decoder.decode(&buf[..n]).unwrap();
-            assert_eq!(msgs[0].msg_type, MSG_EXEC);
+            assert_eq!(msgs[0].msg_type, MSG_COMMAND_START);
 
             // Write the response and close the socket. The response must
             // race with EOF such that reader_loop processes both before the
             // host's `request_raw` returns from its select!.
-            let payload = vsock_proto::encode_exec_result(0, b"race-survived", b"");
-            let resp = vsock_proto::encode(MSG_EXEC_RESULT, msgs[0].seq, &payload).unwrap();
-            guest.write_all(&resp).await.unwrap();
+            send_command_result(
+                &mut guest,
+                msgs[0].seq,
+                CommandTermination::Exited { exit_code: 0 },
+                b"race-survived",
+                b"",
+            )
+            .await;
             drop(guest);
         });
 
@@ -5315,13 +6070,18 @@ mod tests {
             // Now read the exec request (sent concurrently with wait_for_exit)
             let n = guest.read(&mut buf).await.unwrap();
             let msgs = decoder.decode(&buf[..n]).unwrap();
-            assert_eq!(msgs[0].msg_type, MSG_EXEC);
+            assert_eq!(msgs[0].msg_type, MSG_COMMAND_START);
             let exec_seq = msgs[0].seq;
 
             // Reply to exec first
-            let exec_payload = vsock_proto::encode_exec_result(0, b"concurrent", b"");
-            let exec_resp = vsock_proto::encode(MSG_EXEC_RESULT, exec_seq, &exec_payload).unwrap();
-            guest.write_all(&exec_resp).await.unwrap();
+            send_command_result(
+                &mut guest,
+                exec_seq,
+                CommandTermination::Exited { exit_code: 0 },
+                b"concurrent",
+                b"",
+            )
+            .await;
 
             let _ = exit_after_exec.await;
             let exit_payload = vsock_proto::encode_process_exit(50, 42, b"exited", b"");

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -5039,6 +5039,52 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn read_file_rejects_invalid_max_bytes_without_sending_frame() {
+        let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+        let host = Arc::new(host);
+
+        let err = host.read_file("/tmp/empty.txt", 0, 5000).await.unwrap_err();
+
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+        assert_eq!(operation_count(&host), 0);
+
+        let err = host
+            .read_file("/tmp/huge.txt", u64::from(u32::MAX) + 1, 5000)
+            .await
+            .unwrap_err();
+
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+        assert_eq!(operation_count(&host), 0);
+        assert_connection_accepts_command_exec(&host, &mut guest, &mut decoder).await;
+    }
+
+    #[tokio::test]
+    async fn read_file_quotes_guest_path_with_single_quote() {
+        let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+        let read_task =
+            tokio::spawn(async move { host.read_file("/tmp/session'one.txt", 1024, 5000).await });
+
+        let msg = read_guest_message(&mut guest, &mut decoder).await;
+        assert_eq!(msg.msg_type, MSG_COMMAND_START);
+        let decoded = vsock_proto::decode_command_start(&msg.payload).unwrap();
+        assert_eq!(
+            decoded.command,
+            "if test -f '/tmp/session'\\''one.txt'; then cat -- '/tmp/session'\\''one.txt'; else exit 66; fi"
+        );
+        send_command_result(
+            &mut guest,
+            msg.seq,
+            CommandTermination::Exited { exit_code: 0 },
+            b"ok",
+            b"",
+        )
+        .await;
+
+        let content = read_task.await.unwrap().unwrap();
+        assert_eq!(content.as_deref(), Some(&b"ok"[..]));
+    }
+
+    #[tokio::test]
     async fn copy_file_streams_to_temp_then_renames() {
         let (host, mut guest, mut decoder) = setup_host_and_guest().await;
         let unique = std::time::SystemTime::now()
@@ -5116,6 +5162,111 @@ mod tests {
                 .contains("vm0tmp")),
             "copy temp file should not remain"
         );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn copy_file_rejects_invalid_options_without_sending_frame_or_creating_parent() {
+        let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+        let host = Arc::new(host);
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!(
+            "vsock-host-copy-invalid-{}-{unique}",
+            std::process::id()
+        ));
+        let host_path = dir.join("nested/system.log");
+
+        let err = host
+            .copy_file(
+                "/tmp/system.log",
+                &host_path,
+                CopyFileOptions {
+                    max_bytes: 0,
+                    timeout_ms: 5000,
+                    missing_ok: false,
+                },
+            )
+            .await
+            .unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+        assert!(!dir.exists());
+
+        let err = host
+            .copy_file(
+                "/tmp/system.log",
+                &host_path,
+                CopyFileOptions {
+                    max_bytes: 1024,
+                    timeout_ms: 0,
+                    missing_ok: false,
+                },
+            )
+            .await
+            .unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+        assert!(!dir.exists());
+        assert_eq!(operation_count(&host), 0);
+
+        assert_connection_accepts_command_exec(&host, &mut guest, &mut decoder).await;
+    }
+
+    #[tokio::test]
+    async fn copy_file_creates_parent_and_quotes_guest_path_with_single_quote() {
+        let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!(
+            "vsock-host-copy-parent-quote-{}-{unique}",
+            std::process::id()
+        ));
+        let host_path = dir.join("nested/system.log");
+        let copy_path = host_path.clone();
+
+        let copy_task = tokio::spawn(async move {
+            host.copy_file(
+                "/tmp/vm0-system-run's.log",
+                &copy_path,
+                CopyFileOptions {
+                    max_bytes: 1024,
+                    timeout_ms: 5000,
+                    missing_ok: false,
+                },
+            )
+            .await
+        });
+
+        let msg = read_guest_message(&mut guest, &mut decoder).await;
+        assert_eq!(msg.msg_type, MSG_COMMAND_START);
+        let decoded = vsock_proto::decode_command_start(&msg.payload).unwrap();
+        assert_eq!(
+            decoded.command,
+            "if test -f '/tmp/vm0-system-run'\\''s.log'; then cat -- '/tmp/vm0-system-run'\\''s.log'; else exit 66; fi"
+        );
+        send_command_output(
+            &mut guest,
+            msg.seq,
+            0,
+            CommandOutputStream::Stdout,
+            b"quoted path\n",
+            false,
+        )
+        .await;
+        send_stream_command_result(
+            &mut guest,
+            msg.seq,
+            CommandTermination::Exited { exit_code: 0 },
+            b"",
+        )
+        .await;
+
+        let result = copy_task.await.unwrap().unwrap();
+        assert_eq!(result.bytes_copied, 12);
+        assert_eq!(std::fs::read(&host_path).unwrap(), b"quoted path\n");
         let _ = std::fs::remove_dir_all(&dir);
     }
 


### PR DESCRIPTION
## Summary
- route sandbox exec capture through the unified command operation path
- add explicit exec output limits and truncation reporting
- add sandbox read_file/copy_file helpers for small reads and streamed guest file copy
- split exec and spawn_watch request types so output handling is explicit

Fixes #12693

## Tests
- cargo check --manifest-path crates/Cargo.toml -p vsock-host -p sandbox -p sandbox-fc -p sandbox-mock -p runner
- cargo clippy --manifest-path crates/Cargo.toml -p vsock-host --all-targets --all-features -- -D warnings
- cargo test --manifest-path crates/Cargo.toml -p sandbox --lib
- cargo test --manifest-path crates/Cargo.toml -p sandbox-mock --lib sandbox_exec_applies_mock_capture_budget
- cargo test --manifest-path crates/Cargo.toml -p sandbox-mock --lib sandbox_copy_file
- cargo test --manifest-path crates/Cargo.toml -p vsock-host --lib copy_file
- cargo test --manifest-path crates/Cargo.toml -p runner --bin runner copy_guest_logs
- cargo test --manifest-path crates/Cargo.toml -p runner --bin runner read_guest_error_file
- cargo test --manifest-path crates/Cargo.toml -p sandbox-fc --lib exec_response_success_serialization