### PR TITLE
refactor(api): migrate zero agents patch route

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-agents-update.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-agents-update.test.ts
@@ -5,6 +5,7 @@ import {
   zeroAgentsByIdContract,
 } from "@vm0/api-contracts/contracts/zero-agents";
 import { agentComposes } from "@vm0/db/schema/agent-compose";
+import { zeroAgents } from "@vm0/db/schema/zero-agent";
 import { createStore } from "ccstate";
 import { eq } from "drizzle-orm";
 
@@ -365,6 +366,436 @@ describe("PUT /api/zero/agents/:id", () => {
 
     expect(response.body).toStrictEqual({
       error: { message: `Agent not found: ${agentId}`, code: "NOT_FOUND" },
+    });
+  });
+});
+
+describe("PATCH /api/zero/agents/:id", () => {
+  const track = createFixtureTracker<SkillsFixture>((fixture) => {
+    return store.set(deleteSkillsForFixture$, fixture, context.signal);
+  });
+  const trackModelProviders = createFixtureTracker<OrgModelProviderFixture>(
+    (fixture) => {
+      return store.set(deleteOrgModelProviders$, fixture, context.signal);
+    },
+  );
+
+  it("returns 401 when the request is unauthenticated", async () => {
+    const response = await accept(
+      agentsClient().updateMetadata({
+        params: { id: randomUUID() },
+        headers: {},
+        body: {},
+      }),
+      [401],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("returns 403 for a sandbox token without agent:write capability", async () => {
+    const seconds = currentSecond();
+    const token = signSandboxJwtForTests({
+      scope: "zero",
+      userId: `user_${randomUUID()}`,
+      orgId: `org_${randomUUID()}`,
+      runId: `run_${randomUUID()}`,
+      capabilities: ["agent:read"],
+      iat: seconds,
+      exp: seconds + 60,
+    });
+
+    const response = await accept(
+      agentsClient().updateMetadata({
+        params: { id: randomUUID() },
+        headers: { authorization: `Bearer ${token}` },
+        body: {},
+      }),
+      [403],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Missing required capability: agent:write",
+        code: "FORBIDDEN",
+      },
+    });
+  });
+
+  it("updates metadata fields and preserves omitted fields without recomposing", async () => {
+    const fixture = await track(
+      store.set(seedSkillsFixture$, undefined, context.signal),
+    );
+    const agent = await store.set(
+      seedAgentForInstructions$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        displayName: "Original Agent",
+        description: "Original description",
+        sound: "calm",
+        avatarUrl: "preset:4",
+        customSkills: ["existing-skill"],
+      },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      agentsClient().updateMetadata({
+        params: { id: agent.agentId },
+        headers: authHeaders(),
+        body: {
+          displayName: "Updated Agent",
+          description: "Updated description",
+          avatarUrl: null,
+          preferPersonalProvider: true,
+        },
+      }),
+      [200],
+    );
+
+    expect(response.body).toMatchObject({
+      agentId: agent.agentId,
+      ownerId: fixture.userId,
+      displayName: "Updated Agent",
+      description: "Updated description",
+      sound: "calm",
+      avatarUrl: null,
+      customSkills: ["existing-skill"],
+      preferPersonalProvider: true,
+    });
+
+    const [compose] = await store
+      .set(writeDb$)
+      .select({ headVersionId: agentComposes.headVersionId })
+      .from(agentComposes)
+      .where(eq(agentComposes.id, agent.agentId));
+    expect(compose?.headVersionId).toBeNull();
+  });
+
+  it("returns 400 for invalid path params", async () => {
+    const response = await accept(
+      agentsClient().updateMetadata({
+        params: { id: "not-a-uuid" },
+        headers: authHeaders(),
+        body: { displayName: "Invalid" },
+      }),
+      [400],
+    );
+
+    expect(response.body.error.code).toBe("BAD_REQUEST");
+  });
+
+  it("returns 404 for an unknown agent", async () => {
+    const fixture = await track(
+      store.set(seedSkillsFixture$, undefined, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    const agentId = randomUUID();
+
+    const response = await accept(
+      agentsClient().updateMetadata({
+        params: { id: agentId },
+        headers: authHeaders(),
+        body: {},
+      }),
+      [404],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: `Agent not found: ${agentId}`, code: "NOT_FOUND" },
+    });
+  });
+
+  it("returns 403 when a non-owner member updates another user's agent", async () => {
+    const fixture = await track(
+      store.set(seedSkillsFixture$, undefined, context.signal),
+    );
+    const agent = await store.set(
+      seedAgentForInstructions$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+      },
+      context.signal,
+    );
+    mocks.clerk.session(`user_${randomUUID()}`, fixture.orgId, "org:member");
+
+    const response = await accept(
+      agentsClient().updateMetadata({
+        params: { id: agent.agentId },
+        headers: authHeaders(),
+        body: { displayName: "Nope" },
+      }),
+      [403],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Only the agent owner or org admin can update agent profile",
+        code: "FORBIDDEN",
+      },
+    });
+  });
+
+  it("allows an org admin to update another user's public agent", async () => {
+    const fixture = await track(
+      store.set(seedSkillsFixture$, undefined, context.signal),
+    );
+    const adminUserId = `user_${randomUUID()}`;
+    const agent = await store.set(
+      seedAgentForInstructions$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        displayName: "Owner Agent",
+      },
+      context.signal,
+    );
+    mocks.clerk.session(adminUserId, fixture.orgId, "org:admin");
+
+    const response = await accept(
+      agentsClient().updateMetadata({
+        params: { id: agent.agentId },
+        headers: authHeaders(),
+        body: { displayName: "Admin Updated" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toMatchObject({
+      agentId: agent.agentId,
+      ownerId: fixture.userId,
+      displayName: "Admin Updated",
+    });
+  });
+
+  it("returns 403 when an org admin updates another user's private agent", async () => {
+    const fixture = await track(
+      store.set(seedSkillsFixture$, undefined, context.signal),
+    );
+    const adminUserId = `user_${randomUUID()}`;
+    const agent = await store.set(
+      seedAgentForInstructions$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        visibility: "private",
+      },
+      context.signal,
+    );
+    mocks.clerk.session(adminUserId, fixture.orgId, "org:admin");
+
+    const response = await accept(
+      agentsClient().updateMetadata({
+        params: { id: agent.agentId },
+        headers: authHeaders(),
+        body: { displayName: "Admin Updated" },
+      }),
+      [403],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Only the private agent owner can update agent profile",
+        code: "FORBIDDEN",
+      },
+    });
+  });
+
+  it("allows an owner to update private agent metadata without changing visibility", async () => {
+    const fixture = await track(
+      store.set(seedSkillsFixture$, undefined, context.signal),
+    );
+    const agent = await store.set(
+      seedAgentForInstructions$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        displayName: "Private Agent",
+        visibility: "private",
+      },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      agentsClient().updateMetadata({
+        params: { id: agent.agentId },
+        headers: authHeaders(),
+        body: { displayName: "Owner Updated Private Agent" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toMatchObject({
+      agentId: agent.agentId,
+      displayName: "Owner Updated Private Agent",
+      visibility: "private",
+    });
+  });
+
+  it("returns 403 when private visibility is requested while the feature is disabled", async () => {
+    const fixture = await track(
+      store.set(seedSkillsFixture$, undefined, context.signal),
+    );
+    const agent = await store.set(
+      seedAgentForInstructions$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+      },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      agentsClient().updateMetadata({
+        params: { id: agent.agentId },
+        headers: authHeaders(),
+        body: { visibility: "private" },
+      }),
+      [403],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Private agents are not available for this account",
+        code: "FORBIDDEN",
+      },
+    });
+  });
+
+  it("returns 400 when modelProviderId is outside the organization", async () => {
+    const fixture = await track(
+      store.set(seedSkillsFixture$, undefined, context.signal),
+    );
+    const agent = await store.set(
+      seedAgentForInstructions$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+      },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    const modelProviderId = randomUUID();
+
+    const response = await accept(
+      agentsClient().updateMetadata({
+        params: { id: agent.agentId },
+        headers: authHeaders(),
+        body: { modelProviderId, selectedModel: "claude-sonnet-4-6" },
+      }),
+      [400],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: `Model provider "${modelProviderId}" not found in this org`,
+        code: "BAD_REQUEST",
+      },
+    });
+  });
+
+  it("returns 400 when the selected model is not available for the provider", async () => {
+    const fixture = await track(
+      store.set(seedSkillsFixture$, undefined, context.signal),
+    );
+    await trackModelProviders(Promise.resolve({ orgId: fixture.orgId }));
+    const provider = await store.set(
+      seedOrgModelProvider$,
+      {
+        orgId: fixture.orgId,
+        type: "anthropic-api-key",
+      },
+      context.signal,
+    );
+    const agent = await store.set(
+      seedAgentForInstructions$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+      },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      agentsClient().updateMetadata({
+        params: { id: agent.agentId },
+        headers: authHeaders(),
+        body: {
+          modelProviderId: provider.id,
+          selectedModel: "gpt-4-not-a-claude-model",
+        },
+      }),
+      [400],
+    );
+
+    expect(response.body.error.code).toBe("BAD_REQUEST");
+    expect(response.body.error.message).toContain("gpt-4-not-a-claude-model");
+    expect(response.body.error.message).toContain("not available");
+  });
+
+  it("updates model selection and preferPersonalProvider", async () => {
+    const fixture = await track(
+      store.set(seedSkillsFixture$, undefined, context.signal),
+    );
+    await trackModelProviders(Promise.resolve({ orgId: fixture.orgId }));
+    const provider = await store.set(
+      seedOrgModelProvider$,
+      {
+        orgId: fixture.orgId,
+        type: "anthropic-api-key",
+      },
+      context.signal,
+    );
+    const agent = await store.set(
+      seedAgentForInstructions$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+      },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      agentsClient().updateMetadata({
+        params: { id: agent.agentId },
+        headers: authHeaders(),
+        body: {
+          modelProviderId: provider.id,
+          selectedModel: "claude-sonnet-4-6",
+          preferPersonalProvider: true,
+        },
+      }),
+      [200],
+    );
+
+    expect(response.body).toMatchObject({
+      modelProviderId: provider.id,
+      selectedModel: "claude-sonnet-4-6",
+      preferPersonalProvider: true,
+    });
+
+    const [row] = await store
+      .set(writeDb$)
+      .select({
+        modelProviderId: zeroAgents.modelProviderId,
+        selectedModel: zeroAgents.selectedModel,
+        preferPersonalProvider: zeroAgents.preferPersonalProvider,
+      })
+      .from(zeroAgents)
+      .where(eq(zeroAgents.id, agent.agentId));
+    expect(row).toStrictEqual({
+      modelProviderId: provider.id,
+      selectedModel: "claude-sonnet-4-6",
+      preferPersonalProvider: true,
     });
   });
 });

--- a/turbo/apps/api/src/signals/routes/zero-agents.ts
+++ b/turbo/apps/api/src/signals/routes/zero-agents.ts
@@ -57,7 +57,7 @@ interface AgentUpdateBody {
   readonly displayName?: string;
   readonly description?: string;
   readonly sound?: string;
-  readonly avatarUrl?: string;
+  readonly avatarUrl?: string | null;
   readonly customSkills?: readonly string[];
   readonly modelProviderId?: string | null;
   readonly selectedModel?: string | null;
@@ -65,12 +65,15 @@ interface AgentUpdateBody {
   readonly visibility?: ZeroAgentVisibility;
 }
 
-interface ExistingAgentForUpdate {
+interface ExistingAgentVisibility {
+  readonly owner: string | null;
+  readonly visibility: ZeroAgentVisibility | null;
+}
+
+interface ExistingAgentForUpdate extends ExistingAgentVisibility {
   readonly id: string;
   readonly name: string;
   readonly customSkills: readonly string[] | null;
-  readonly owner: string | null;
-  readonly visibility: ZeroAgentVisibility | null;
 }
 
 interface AgentMember {
@@ -242,6 +245,26 @@ function findAgentForUpdate(
     });
 }
 
+function findAgentMetadataForUpdate(
+  writeDb: Db,
+  orgId: string,
+  agentId: string,
+) {
+  return writeDb
+    .select({
+      id: zeroAgents.id,
+      name: zeroAgents.name,
+      owner: zeroAgents.owner,
+      visibility: zeroAgents.visibility,
+    })
+    .from(zeroAgents)
+    .where(and(eq(zeroAgents.orgId, orgId), eq(zeroAgents.id, agentId)))
+    .limit(1)
+    .then((rows) => {
+      return rows[0] ?? null;
+    });
+}
+
 function requireAgentConfigurationPermission(
   existing: ExistingAgentForUpdate,
   member: AgentMember,
@@ -257,7 +280,7 @@ function requireAgentConfigurationPermission(
 }
 
 function visibilityOwnerError(
-  existing: ExistingAgentForUpdate,
+  existing: ExistingAgentVisibility,
   member: AgentMember,
   requestedVisibility: ZeroAgentVisibility | undefined,
 ) {
@@ -330,7 +353,7 @@ async function validateAgentVisibilityUpdate(args: {
   readonly writeDb: Db;
   readonly orgId: string;
   readonly member: AgentMember;
-  readonly existing: ExistingAgentForUpdate;
+  readonly existing: ExistingAgentVisibility;
   readonly requestedVisibility: ZeroAgentVisibility | undefined;
   readonly nextVisibility: ZeroAgentVisibility;
   readonly signal: AbortSignal;
@@ -613,6 +636,87 @@ const updateAgentInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   };
 });
 
+const updateAgentMetadataBody$ = bodyResultOf(
+  zeroAgentsByIdContract.updateMetadata,
+);
+
+const updateAgentMetadataInner$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const auth = get(organizationAuthContext$);
+    const member = { userId: auth.userId, role: auth.orgRole ?? "member" };
+    const params = get(pathParamsOf(zeroAgentsByIdContract.updateMetadata));
+    const body = await get(updateAgentMetadataBody$);
+    signal.throwIfAborted();
+    if (!body.ok) {
+      return body.response;
+    }
+
+    const writeDb = set(writeDb$);
+    const existing = await findAgentMetadataForUpdate(
+      writeDb,
+      auth.orgId,
+      params.id,
+    );
+    signal.throwIfAborted();
+    if (!existing) {
+      return agentNotFound(params.id);
+    }
+
+    const permissionError = requireAgentPermission(
+      existing.owner,
+      member,
+      "update agent profile",
+      { visibility: existing.visibility },
+    );
+    if (permissionError) {
+      return permissionError;
+    }
+
+    if (body.data.visibility !== undefined) {
+      const visibilityError = await validateAgentVisibilityUpdate({
+        get,
+        writeDb,
+        orgId: auth.orgId,
+        member,
+        existing,
+        requestedVisibility: body.data.visibility,
+        nextVisibility: body.data.visibility,
+        signal,
+      });
+      if (visibilityError) {
+        return visibilityError;
+      }
+    }
+
+    const modelError = await validateModelSelection(
+      writeDb,
+      auth.orgId,
+      body.data.modelProviderId,
+      body.data.selectedModel,
+    );
+    signal.throwIfAborted();
+    if (modelError) {
+      return modelError;
+    }
+
+    await writeDb
+      .update(zeroAgents)
+      .set(buildAgentUpsertConflictSet(body.data, nowDate()))
+      .where(eq(zeroAgents.id, params.id));
+    signal.throwIfAborted();
+
+    const agent = await readAgentForResponse(writeDb, auth.orgId, params.id);
+    signal.throwIfAborted();
+
+    return {
+      status: 200 as const,
+      body: agent
+        ? agentResponse(agent)
+        : defaultAgentResponse({ agentId: params.id, ownerId: auth.userId }),
+    };
+  },
+);
+
 const deleteAgentInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   const auth = get(organizationAuthContext$);
   const member = { userId: auth.userId, role: auth.orgRole ?? "member" };
@@ -876,6 +980,10 @@ export const zeroAgentsRoutes: readonly RouteEntry[] = [
   {
     route: zeroAgentsByIdContract.update,
     handler: authRoute(agentWriteAuth, updateAgentInner$),
+  },
+  {
+    route: zeroAgentsByIdContract.updateMetadata,
+    handler: authRoute(agentWriteAuth, updateAgentMetadataInner$),
   },
   {
     route: zeroAgentsByIdContract.delete,


### PR DESCRIPTION
## Summary
- register `PATCH /api/zero/agents/:id` on the API backend via `zeroAgentsByIdContract.updateMetadata`
- add a metadata-only ccstate command that updates existing `zero_agents` rows without recomposing
- add route-level API coverage for auth, permissions, validation, partial updates, model selection, and persistence

Closes #12842

## Validation
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-agents-update.test.ts`
- `pnpm format`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm check-types`
- `pnpm knip --cache`
- `git diff --check`