### PR TITLE
refactor(api): migrate zero agents metadata patch

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-agents-update.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-agents-update.test.ts
@@ -652,6 +652,39 @@ describe("PATCH /api/zero/agents/:id", () => {
     });
   });
 
+  it("allows the owner to update private agent metadata without changing visibility", async () => {
+    const fixture = await track(
+      store.set(seedSkillsFixture$, undefined, context.signal),
+    );
+    const agent = await store.set(
+      seedAgentForInstructions$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        displayName: "Private Agent",
+        visibility: "private",
+      },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      agentsClient().updateMetadata({
+        params: { id: agent.agentId },
+        headers: authHeaders(),
+        body: { displayName: "Private Agent Updated" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toMatchObject({
+      agentId: agent.agentId,
+      ownerId: fixture.userId,
+      displayName: "Private Agent Updated",
+      visibility: "private",
+    });
+  });
+
   it("returns 400 when modelProviderId is outside the organization", async () => {
     const fixture = await track(
       store.set(seedSkillsFixture$, undefined, context.signal),

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-agents-update.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-agents-update.test.ts
@@ -369,6 +369,449 @@ describe("PUT /api/zero/agents/:id", () => {
   });
 });
 
+describe("PATCH /api/zero/agents/:id", () => {
+  const track = createFixtureTracker<SkillsFixture>((fixture) => {
+    return store.set(deleteSkillsForFixture$, fixture, context.signal);
+  });
+  const trackModelProviders = createFixtureTracker<OrgModelProviderFixture>(
+    (fixture) => {
+      return store.set(deleteOrgModelProviders$, fixture, context.signal);
+    },
+  );
+
+  it("returns 401 when the request is unauthenticated", async () => {
+    const response = await accept(
+      agentsClient().updateMetadata({
+        params: { id: randomUUID() },
+        headers: {},
+        body: {},
+      }),
+      [401],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("returns 403 for a sandbox token without agent:write capability", async () => {
+    const seconds = currentSecond();
+    const token = signSandboxJwtForTests({
+      scope: "zero",
+      userId: `user_${randomUUID()}`,
+      orgId: `org_${randomUUID()}`,
+      runId: `run_${randomUUID()}`,
+      capabilities: ["agent:read"],
+      iat: seconds,
+      exp: seconds + 60,
+    });
+
+    const response = await accept(
+      agentsClient().updateMetadata({
+        params: { id: randomUUID() },
+        headers: { authorization: `Bearer ${token}` },
+        body: {},
+      }),
+      [403],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Missing required capability: agent:write",
+        code: "FORBIDDEN",
+      },
+    });
+  });
+
+  it("updates only provided metadata fields and does not recompose the agent", async () => {
+    const fixture = await track(
+      store.set(seedSkillsFixture$, undefined, context.signal),
+    );
+    const agent = await store.set(
+      seedAgentForInstructions$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        displayName: "Old Agent",
+        description: "Old description",
+        sound: "calm",
+        avatarUrl: "preset:1",
+        customSkills: ["existing-skill"],
+      },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      agentsClient().updateMetadata({
+        params: { id: agent.agentId },
+        headers: authHeaders(),
+        body: {
+          displayName: "Updated Agent",
+          description: "Updated description",
+          preferPersonalProvider: true,
+        },
+      }),
+      [200],
+    );
+
+    expect(response.body).toMatchObject({
+      agentId: agent.agentId,
+      ownerId: fixture.userId,
+      displayName: "Updated Agent",
+      description: "Updated description",
+      sound: "calm",
+      avatarUrl: "preset:1",
+      customSkills: ["existing-skill"],
+      modelProviderId: null,
+      selectedModel: null,
+      preferPersonalProvider: true,
+      visibility: "public",
+    });
+
+    const [compose] = await store
+      .set(writeDb$)
+      .select({ headVersionId: agentComposes.headVersionId })
+      .from(agentComposes)
+      .where(eq(agentComposes.id, agent.agentId));
+    expect(compose?.headVersionId).toBeNull();
+  });
+
+  it("clears avatarUrl when null is provided", async () => {
+    const fixture = await track(
+      store.set(seedSkillsFixture$, undefined, context.signal),
+    );
+    const agent = await store.set(
+      seedAgentForInstructions$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        avatarUrl: "https://example.com/avatar.png",
+      },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      agentsClient().updateMetadata({
+        params: { id: agent.agentId },
+        headers: authHeaders(),
+        body: { avatarUrl: null },
+      }),
+      [200],
+    );
+
+    expect(response.body.avatarUrl).toBeNull();
+  });
+
+  it("returns 404 for an unknown agent", async () => {
+    const fixture = await track(
+      store.set(seedSkillsFixture$, undefined, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    const agentId = randomUUID();
+
+    const response = await accept(
+      agentsClient().updateMetadata({
+        params: { id: agentId },
+        headers: authHeaders(),
+        body: {},
+      }),
+      [404],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: `Agent not found: ${agentId}`, code: "NOT_FOUND" },
+    });
+  });
+
+  it("returns 403 when a non-owner member updates another user's agent", async () => {
+    const fixture = await track(
+      store.set(seedSkillsFixture$, undefined, context.signal),
+    );
+    const agent = await store.set(
+      seedAgentForInstructions$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+      },
+      context.signal,
+    );
+    mocks.clerk.session(`user_${randomUUID()}`, fixture.orgId, "org:member");
+
+    const response = await accept(
+      agentsClient().updateMetadata({
+        params: { id: agent.agentId },
+        headers: authHeaders(),
+        body: { displayName: "Nope" },
+      }),
+      [403],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Only the agent owner or org admin can update agent profile",
+        code: "FORBIDDEN",
+      },
+    });
+  });
+
+  it("allows an admin to update another user's public agent metadata", async () => {
+    const fixture = await track(
+      store.set(seedSkillsFixture$, undefined, context.signal),
+    );
+    const adminUserId = `user_${randomUUID()}`;
+    const agent = await store.set(
+      seedAgentForInstructions$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+      },
+      context.signal,
+    );
+    mocks.clerk.session(adminUserId, fixture.orgId, "org:admin");
+
+    const response = await accept(
+      agentsClient().updateMetadata({
+        params: { id: agent.agentId },
+        headers: authHeaders(),
+        body: { displayName: "Admin Updated" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toMatchObject({
+      agentId: agent.agentId,
+      ownerId: fixture.userId,
+      displayName: "Admin Updated",
+    });
+  });
+
+  it("returns 403 when an admin changes visibility for another user's public agent", async () => {
+    const fixture = await track(
+      store.set(seedSkillsFixture$, undefined, context.signal),
+    );
+    const adminUserId = `user_${randomUUID()}`;
+    const agent = await store.set(
+      seedAgentForInstructions$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+      },
+      context.signal,
+    );
+    mocks.clerk.session(adminUserId, fixture.orgId, "org:admin");
+
+    const response = await accept(
+      agentsClient().updateMetadata({
+        params: { id: agent.agentId },
+        headers: authHeaders(),
+        body: { visibility: "private" },
+      }),
+      [403],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Only the agent owner can update agent visibility",
+        code: "FORBIDDEN",
+      },
+    });
+  });
+
+  it("returns 403 when an admin updates another user's private agent", async () => {
+    const fixture = await track(
+      store.set(seedSkillsFixture$, undefined, context.signal),
+    );
+    const adminUserId = `user_${randomUUID()}`;
+    const agent = await store.set(
+      seedAgentForInstructions$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        visibility: "private",
+      },
+      context.signal,
+    );
+    mocks.clerk.session(adminUserId, fixture.orgId, "org:admin");
+
+    const response = await accept(
+      agentsClient().updateMetadata({
+        params: { id: agent.agentId },
+        headers: authHeaders(),
+        body: { displayName: "Nope" },
+      }),
+      [403],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Only the private agent owner can update agent profile",
+        code: "FORBIDDEN",
+      },
+    });
+  });
+
+  it("returns 400 when modelProviderId is outside the organization", async () => {
+    const fixture = await track(
+      store.set(seedSkillsFixture$, undefined, context.signal),
+    );
+    const agent = await store.set(
+      seedAgentForInstructions$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+      },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    const modelProviderId = randomUUID();
+
+    const response = await accept(
+      agentsClient().updateMetadata({
+        params: { id: agent.agentId },
+        headers: authHeaders(),
+        body: { modelProviderId, selectedModel: "claude-sonnet-4-6" },
+      }),
+      [400],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: `Model provider "${modelProviderId}" not found in this org`,
+        code: "BAD_REQUEST",
+      },
+    });
+  });
+
+  it("returns 400 when selectedModel is unavailable for the model provider", async () => {
+    const fixture = await track(
+      store.set(seedSkillsFixture$, undefined, context.signal),
+    );
+    await trackModelProviders(Promise.resolve({ orgId: fixture.orgId }));
+    const provider = await store.set(
+      seedOrgModelProvider$,
+      {
+        orgId: fixture.orgId,
+        type: "anthropic-api-key",
+      },
+      context.signal,
+    );
+    const agent = await store.set(
+      seedAgentForInstructions$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+      },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      agentsClient().updateMetadata({
+        params: { id: agent.agentId },
+        headers: authHeaders(),
+        body: { modelProviderId: provider.id, selectedModel: "not-a-model" },
+      }),
+      [400],
+    );
+
+    expect(response.body.error.code).toBe("BAD_REQUEST");
+    expect(response.body.error.message).toContain(
+      'Model "not-a-model" is not available for provider type "anthropic-api-key"',
+    );
+  });
+
+  it("persists valid model selection and preferPersonalProvider", async () => {
+    const fixture = await track(
+      store.set(seedSkillsFixture$, undefined, context.signal),
+    );
+    await trackModelProviders(Promise.resolve({ orgId: fixture.orgId }));
+    const provider = await store.set(
+      seedOrgModelProvider$,
+      {
+        orgId: fixture.orgId,
+        type: "anthropic-api-key",
+      },
+      context.signal,
+    );
+    const agent = await store.set(
+      seedAgentForInstructions$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+      },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      agentsClient().updateMetadata({
+        params: { id: agent.agentId },
+        headers: authHeaders(),
+        body: {
+          modelProviderId: provider.id,
+          selectedModel: "claude-sonnet-4-6",
+          preferPersonalProvider: true,
+        },
+      }),
+      [200],
+    );
+
+    expect(response.body).toMatchObject({
+      modelProviderId: provider.id,
+      selectedModel: "claude-sonnet-4-6",
+      preferPersonalProvider: true,
+    });
+  });
+
+  it("returns 409 when switching a private agent to public would exceed the public limit", async () => {
+    const fixture = await track(
+      store.set(seedSkillsFixture$, undefined, context.signal),
+    );
+    const privateAgent = await store.set(
+      seedAgentForInstructions$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        visibility: "private",
+      },
+      context.signal,
+    );
+    await Promise.all(
+      Array.from({ length: 7 }, () => {
+        return store.set(
+          seedAgentForInstructions$,
+          {
+            orgId: fixture.orgId,
+            userId: fixture.userId,
+            visibility: "public",
+          },
+          context.signal,
+        );
+      }),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      agentsClient().updateMetadata({
+        params: { id: privateAgent.agentId },
+        headers: authHeaders(),
+        body: { visibility: "public" },
+      }),
+      [409],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message:
+          "This organization has reached the maximum number of agents (7). Delete an existing agent before making this agent public.",
+        code: "CONFLICT",
+      },
+    });
+  });
+});
+
 describe("PUT /api/zero/agents/:id/instructions", () => {
   const track = createFixtureTracker<SkillsFixture>((fixture) => {
     return store.set(deleteSkillsForFixture$, fixture, context.signal);

--- a/turbo/apps/api/src/signals/routes/zero-agents.ts
+++ b/turbo/apps/api/src/signals/routes/zero-agents.ts
@@ -57,7 +57,7 @@ interface AgentUpdateBody {
   readonly displayName?: string;
   readonly description?: string;
   readonly sound?: string;
-  readonly avatarUrl?: string;
+  readonly avatarUrl?: string | null;
   readonly customSkills?: readonly string[];
   readonly modelProviderId?: string | null;
   readonly selectedModel?: string | null;
@@ -77,6 +77,11 @@ interface AgentMember {
   readonly userId: string;
   readonly role: string;
 }
+
+type ExistingAgentForMetadataUpdate = ExistingAgentForUpdate & {
+  readonly owner: string;
+  readonly visibility: ZeroAgentVisibility;
+};
 
 type SignalGetter = {
   <T>(source: Computed<T>): T;
@@ -236,6 +241,27 @@ function findAgentForUpdate(
     .from(agentComposes)
     .leftJoin(zeroAgents, eq(agentComposes.id, zeroAgents.id))
     .where(and(eq(agentComposes.orgId, orgId), eq(agentComposes.id, agentId)))
+    .limit(1)
+    .then((rows) => {
+      return rows[0] ?? null;
+    });
+}
+
+function findAgentMetadataForUpdate(
+  writeDb: Db,
+  orgId: string,
+  agentId: string,
+): Promise<ExistingAgentForMetadataUpdate | null> {
+  return writeDb
+    .select({
+      id: zeroAgents.id,
+      name: zeroAgents.name,
+      customSkills: zeroAgents.customSkills,
+      owner: zeroAgents.owner,
+      visibility: zeroAgents.visibility,
+    })
+    .from(zeroAgents)
+    .where(and(eq(zeroAgents.orgId, orgId), eq(zeroAgents.id, agentId)))
     .limit(1)
     .then((rows) => {
       return rows[0] ?? null;
@@ -517,6 +543,9 @@ const updateAgentCustomConnectorsBody$ = bodyResultOf(
 );
 
 const updateAgentBody$ = bodyResultOf(zeroAgentsByIdContract.update);
+const updateAgentMetadataBody$ = bodyResultOf(
+  zeroAgentsByIdContract.updateMetadata,
+);
 
 const updateAgentInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   const auth = get(organizationAuthContext$);
@@ -612,6 +641,84 @@ const updateAgentInner$ = command(async ({ get, set }, signal: AbortSignal) => {
       : defaultAgentResponse({ agentId: params.id, ownerId: auth.userId }),
   };
 });
+
+const updateAgentMetadataInner$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const auth = get(organizationAuthContext$);
+    const member = { userId: auth.userId, role: auth.orgRole ?? "member" };
+    const params = get(pathParamsOf(zeroAgentsByIdContract.updateMetadata));
+    const body = await get(updateAgentMetadataBody$);
+    signal.throwIfAborted();
+    if (!body.ok) {
+      return body.response;
+    }
+
+    const writeDb = set(writeDb$);
+    const existing = await findAgentMetadataForUpdate(
+      writeDb,
+      auth.orgId,
+      params.id,
+    );
+    signal.throwIfAborted();
+    if (!existing) {
+      return agentNotFound(params.id);
+    }
+
+    const permissionError = requireAgentPermission(
+      existing.owner,
+      member,
+      "update agent profile",
+      { visibility: existing.visibility },
+    );
+    if (permissionError) {
+      return permissionError;
+    }
+
+    const nextVisibility = body.data.visibility ?? existing.visibility;
+    const visibilityError = await validateAgentVisibilityUpdate({
+      get,
+      writeDb,
+      orgId: auth.orgId,
+      member,
+      existing,
+      requestedVisibility: body.data.visibility,
+      nextVisibility,
+      signal,
+    });
+    if (visibilityError) {
+      return visibilityError;
+    }
+
+    const modelError = await validateModelSelection(
+      writeDb,
+      auth.orgId,
+      body.data.modelProviderId,
+      body.data.selectedModel,
+    );
+    signal.throwIfAborted();
+    if (modelError) {
+      return modelError;
+    }
+
+    await writeDb
+      .update(zeroAgents)
+      .set(buildAgentUpsertConflictSet(body.data, nowDate()))
+      .where(
+        and(eq(zeroAgents.orgId, auth.orgId), eq(zeroAgents.id, params.id)),
+      );
+    signal.throwIfAborted();
+
+    const agent = await readAgentForResponse(writeDb, auth.orgId, params.id);
+    signal.throwIfAborted();
+
+    return {
+      status: 200 as const,
+      body: agent
+        ? agentResponse(agent)
+        : defaultAgentResponse({ agentId: params.id, ownerId: auth.userId }),
+    };
+  },
+);
 
 const deleteAgentInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   const auth = get(organizationAuthContext$);
@@ -876,6 +983,10 @@ export const zeroAgentsRoutes: readonly RouteEntry[] = [
   {
     route: zeroAgentsByIdContract.update,
     handler: authRoute(agentWriteAuth, updateAgentInner$),
+  },
+  {
+    route: zeroAgentsByIdContract.updateMetadata,
+    handler: authRoute(agentWriteAuth, updateAgentMetadataInner$),
   },
   {
     route: zeroAgentsByIdContract.delete,

--- a/turbo/apps/api/src/signals/routes/zero-agents.ts
+++ b/turbo/apps/api/src/signals/routes/zero-agents.ts
@@ -674,19 +674,20 @@ const updateAgentMetadataInner$ = command(
       return permissionError;
     }
 
-    const nextVisibility = body.data.visibility ?? existing.visibility;
-    const visibilityError = await validateAgentVisibilityUpdate({
-      get,
-      writeDb,
-      orgId: auth.orgId,
-      member,
-      existing,
-      requestedVisibility: body.data.visibility,
-      nextVisibility,
-      signal,
-    });
-    if (visibilityError) {
-      return visibilityError;
+    if (body.data.visibility !== undefined) {
+      const visibilityError = await validateAgentVisibilityUpdate({
+        get,
+        writeDb,
+        orgId: auth.orgId,
+        member,
+        existing,
+        requestedVisibility: body.data.visibility,
+        nextVisibility: body.data.visibility,
+        signal,
+      });
+      if (visibilityError) {
+        return visibilityError;
+      }
     }
 
     const modelError = await validateModelSelection(


### PR DESCRIPTION
## Summary

- Register `zeroAgentsByIdContract.updateMetadata` in the API backend.
- Add a metadata-only PATCH command for `PATCH /api/zero/agents/:id` that updates explicit `zero_agents` fields without recomposing.
- Add API integration coverage for auth, permissions, model validation, partial updates, avatar clearing, visibility limits, and no-compose behavior.

## Validation

- `pnpm format`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-agents-update.test.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm turbo run check-types --filter=api --concurrency=1`
- `pnpm check-types` (passes via pre-commit after warming the API turbo cache; first uncached root run exceeded the local lefthook 120s timeout at `api#check-types`)
- `pnpm knip --cache`
- `git diff --check`

Closes #12842