### PR TITLE
refactor(api): migrate zero org members patch

### DIFF
--- a/turbo/apps/api/src/__tests__/mocks.ts
+++ b/turbo/apps/api/src/__tests__/mocks.ts
@@ -41,6 +41,7 @@ export interface ApiTestMocks {
       readonly deleteOrganization: AsyncMock;
       readonly updateOrganization: AsyncMock;
       readonly updateOrganizationDomain: AsyncMock;
+      readonly updateOrganizationMembership: AsyncMock;
       readonly updateOrganizationLogo: AsyncMock;
     };
     readonly users: {
@@ -162,6 +163,8 @@ const apiTestMocks: ApiTestMocks = vi.hoisted((): ApiTestMocks => {
       deleteOrganization: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
       updateOrganization: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
       updateOrganizationDomain:
+        vi.fn<(...args: unknown[]) => Promise<unknown>>(),
+      updateOrganizationMembership:
         vi.fn<(...args: unknown[]) => Promise<unknown>>(),
       updateOrganizationLogo: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
     },
@@ -576,6 +579,7 @@ export function resetApiTestMocks(): void {
   apiTestMocks.clerk.organizations.deleteOrganization.mockReset();
   apiTestMocks.clerk.organizations.updateOrganization.mockReset();
   apiTestMocks.clerk.organizations.updateOrganizationDomain.mockReset();
+  apiTestMocks.clerk.organizations.updateOrganizationMembership.mockReset();
   apiTestMocks.clerk.organizations.updateOrganizationLogo.mockReset();
   apiTestMocks.clerk.users.getUserList.mockReset();
   apiTestMocks.clerk.users.getOrganizationMembershipList.mockReset();

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-org-members.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-org-members.test.ts
@@ -93,6 +93,19 @@ function mockClerkUsers(users: readonly ClerkUserFixture[]): void {
   });
 }
 
+function clerkUser(args: {
+  readonly id: string;
+  readonly email: string;
+}): ClerkUserFixture {
+  return {
+    id: args.id,
+    email: args.email,
+    firstName: null,
+    lastName: null,
+    imageUrl: "",
+  };
+}
+
 interface CleanupFixture {
   readonly orgId?: string;
   readonly workspaceId?: string;
@@ -490,6 +503,210 @@ describe("GET /api/zero/org/members", () => {
 
     expect(response.body.membershipRequests).toStrictEqual([]);
     expect(response.body.members).toHaveLength(1);
+  });
+});
+
+describe("PATCH /api/zero/org/members", () => {
+  it("returns 401 when unauthenticated", async () => {
+    const client = setupApp({ context })(zeroOrgMembersContract);
+
+    const response = await accept(
+      client.updateRole({
+        headers: {},
+        body: { email: "member@example.com", role: "admin" },
+      }),
+      [401],
+    );
+
+    expect(response.body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("returns 401 when the authenticated session has no organization", async () => {
+    mocks.clerk.session(uniqueId("user"), null);
+    const client = setupApp({ context })(zeroOrgMembersContract);
+
+    const response = await accept(
+      client.updateRole({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { email: "member@example.com", role: "admin" },
+      }),
+      [401],
+    );
+
+    expect(response.body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("returns 400 for an invalid body without updating Clerk", async () => {
+    const orgId = uniqueId("org");
+    const userId = uniqueId("user");
+    mocks.clerk.session(userId, orgId, "org:admin");
+    const app = createApp({ signal: context.signal });
+
+    const response = await app.request("/api/zero/org/members", {
+      method: "PATCH",
+      headers: {
+        authorization: "Bearer clerk-session",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ email: "not-an-email", role: "admin" }),
+    });
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body).toMatchObject({ error: { code: "BAD_REQUEST" } });
+    expect(
+      context.mocks.clerk.organizations.updateOrganizationMembership,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("updates another member role for an admin caller", async () => {
+    const orgId = uniqueId("org");
+    const adminUserId = uniqueId("user-admin");
+    const targetUserId = uniqueId("user-target");
+    const targetEmail = "member@example.com";
+    mocks.clerk.session(adminUserId, orgId, "org:admin");
+    mockClerkUsers([clerkUser({ id: targetUserId, email: targetEmail })]);
+    const client = setupApp({ context })(zeroOrgMembersContract);
+
+    const response = await accept(
+      client.updateRole({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { email: targetEmail, role: "admin" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      message: `Updated role for ${targetEmail}`,
+    });
+    expect(
+      context.mocks.clerk.organizations.updateOrganizationMembership,
+    ).toHaveBeenCalledWith({
+      organizationId: orgId,
+      userId: targetUserId,
+      role: "org:admin",
+    });
+    expect(
+      context.mocks.clerk.organizations.getOrganizationMembershipList,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 for non-admin callers without updating Clerk", async () => {
+    const orgId = uniqueId("org");
+    const userId = uniqueId("user");
+    mocks.clerk.session(userId, orgId, "org:member");
+    const client = setupApp({ context })(zeroOrgMembersContract);
+
+    const response = await accept(
+      client.updateRole({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { email: "member@example.com", role: "admin" },
+      }),
+      [403],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Access denied", code: "FORBIDDEN" },
+    });
+    expect(context.mocks.clerk.users.getUserList).not.toHaveBeenCalled();
+    expect(
+      context.mocks.clerk.organizations.updateOrganizationMembership,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when the target email does not resolve to a user", async () => {
+    const orgId = uniqueId("org");
+    const adminUserId = uniqueId("user-admin");
+    mocks.clerk.session(adminUserId, orgId, "org:admin");
+    mockClerkUsers([]);
+    const client = setupApp({ context })(zeroOrgMembersContract);
+
+    const response = await accept(
+      client.updateRole({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { email: "missing@example.com", role: "member" },
+      }),
+      [404],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Resource not found", code: "NOT_FOUND" },
+    });
+    expect(
+      context.mocks.clerk.organizations.updateOrganizationMembership,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when the only admin tries to demote themselves", async () => {
+    const orgId = uniqueId("org");
+    const adminUserId = uniqueId("user-admin");
+    const adminEmail = "admin@example.com";
+    mocks.clerk.session(adminUserId, orgId, "org:admin");
+    mockClerkUsers([clerkUser({ id: adminUserId, email: adminEmail })]);
+    mockClerkMemberships([
+      {
+        userId: adminUserId,
+        role: "org:admin",
+        createdAtMs: 1_700_000_000_000,
+      },
+    ]);
+    const client = setupApp({ context })(zeroOrgMembersContract);
+
+    const response = await accept(
+      client.updateRole({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { email: adminEmail, role: "member" },
+      }),
+      [400],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Invalid request", code: "BAD_REQUEST" },
+    });
+    expect(
+      context.mocks.clerk.organizations.updateOrganizationMembership,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("allows an admin to demote themselves when another admin exists", async () => {
+    const orgId = uniqueId("org");
+    const adminUserId = uniqueId("user-admin");
+    const otherAdminUserId = uniqueId("user-other-admin");
+    const adminEmail = "admin@example.com";
+    mocks.clerk.session(adminUserId, orgId, "org:admin");
+    mockClerkUsers([clerkUser({ id: adminUserId, email: adminEmail })]);
+    mockClerkMemberships([
+      {
+        userId: adminUserId,
+        role: "org:admin",
+        createdAtMs: 1_700_000_000_000,
+      },
+      {
+        userId: otherAdminUserId,
+        role: "org:admin",
+        createdAtMs: 1_700_000_100_000,
+      },
+    ]);
+    const client = setupApp({ context })(zeroOrgMembersContract);
+
+    const response = await accept(
+      client.updateRole({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { email: adminEmail, role: "member" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      message: `Updated role for ${adminEmail}`,
+    });
+    expect(
+      context.mocks.clerk.organizations.updateOrganizationMembership,
+    ).toHaveBeenCalledWith({
+      organizationId: orgId,
+      userId: adminUserId,
+      role: "org:member",
+    });
   });
 });
 

--- a/turbo/apps/api/src/signals/routes/zero-org-members.ts
+++ b/turbo/apps/api/src/signals/routes/zero-org-members.ts
@@ -4,10 +4,42 @@ import { zeroOrgMembersContract } from "@vm0/api-contracts/contracts/zero-org-me
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
 import { bodyResultOf } from "../context/request";
-import { removeZeroOrgMember$ } from "../services/zero-org-data.service";
+import {
+  removeZeroOrgMember$,
+  updateZeroOrgMemberRole$,
+} from "../services/zero-org-data.service";
 import type { RouteEntry } from "../route";
 
+const updateRoleBody$ = bodyResultOf(zeroOrgMembersContract.updateRole);
 const removeMemberBody$ = bodyResultOf(zeroOrgMembersContract.removeMember);
+
+const updateRoleInner$ = command(async ({ get, set }, signal: AbortSignal) => {
+  const auth = get(organizationAuthContext$);
+  const body = await get(updateRoleBody$);
+  signal.throwIfAborted();
+  if (!body.ok) {
+    return body.response;
+  }
+
+  const result = await set(
+    updateZeroOrgMemberRole$,
+    {
+      callerUserId: auth.userId,
+      orgId: auth.orgId,
+      callerRole: auth.orgRole,
+      targetEmail: body.data.email,
+      newRole: body.data.role,
+    },
+    signal,
+  );
+  signal.throwIfAborted();
+
+  if ("status" in result) {
+    return result;
+  }
+
+  return { status: 200 as const, body: result };
+});
 
 const removeMemberInner$ = command(
   async ({ get, set }, signal: AbortSignal) => {
@@ -39,6 +71,13 @@ const removeMemberInner$ = command(
 );
 
 export const zeroOrgMembersRoutes: readonly RouteEntry[] = [
+  {
+    route: zeroOrgMembersContract.updateRole,
+    handler: authRoute(
+      { requireOrganization: true, missingOrganizationStatus: 401 },
+      updateRoleInner$,
+    ),
+  },
   {
     route: zeroOrgMembersContract.removeMember,
     handler: authRoute(

--- a/turbo/apps/api/src/signals/services/zero-org-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-org-data.service.ts
@@ -99,6 +99,11 @@ type RemoveZeroOrgMemberErrorResponse =
   | ReturnType<typeof notFound>
   | typeof forbiddenAccess;
 
+type UpdateZeroOrgMemberRoleErrorResponse =
+  | ReturnType<typeof badRequestMessage>
+  | ReturnType<typeof notFound>
+  | typeof forbiddenAccess;
+
 interface UpdateZeroOrgArgs {
   readonly orgId: string;
   readonly userId: string;
@@ -124,6 +129,14 @@ interface RemoveZeroOrgMemberArgs {
   readonly callerUserId: string;
   readonly callerRole: OrgRole;
   readonly email: string;
+}
+
+interface UpdateZeroOrgMemberRoleArgs {
+  readonly callerUserId: string;
+  readonly orgId: string;
+  readonly callerRole: OrgRole | undefined;
+  readonly targetEmail: string;
+  readonly newRole: OrgRole;
 }
 
 interface ClerkUpdate {
@@ -465,6 +478,57 @@ export const removeZeroOrgMember$ = command(
     signal.throwIfAborted();
 
     return { message: `Removed ${args.email} from org` };
+  },
+);
+
+export const updateZeroOrgMemberRole$ = command(
+  async (
+    { get },
+    args: UpdateZeroOrgMemberRoleArgs,
+    signal: AbortSignal,
+  ): Promise<OrgMessageResponse | UpdateZeroOrgMemberRoleErrorResponse> => {
+    if (args.callerRole !== "admin") {
+      return forbiddenAccess;
+    }
+
+    const client = get(clerk$);
+    const users = await client.users.getUserList({
+      emailAddress: [args.targetEmail],
+    });
+    signal.throwIfAborted();
+
+    const targetUser = users.data[0];
+    if (!targetUser) {
+      return notFound("Resource not found");
+    }
+
+    if (targetUser.id === args.callerUserId) {
+      if (args.newRole !== "member") {
+        return badRequestMessage("Invalid request");
+      }
+
+      const memberships =
+        await client.organizations.getOrganizationMembershipList({
+          organizationId: args.orgId,
+        });
+      signal.throwIfAborted();
+
+      const adminCount = memberships.data.filter((membership) => {
+        return membership.role === "org:admin";
+      }).length;
+      if (adminCount < 2) {
+        return badRequestMessage("Invalid request");
+      }
+    }
+
+    await client.organizations.updateOrganizationMembership({
+      organizationId: args.orgId,
+      userId: targetUser.id,
+      role: args.newRole === "admin" ? "org:admin" : "org:member",
+    });
+    signal.throwIfAborted();
+
+    return { message: `Updated role for ${args.targetEmail}` };
   },
 );
 

--- a/turbo/packages/api-contracts/src/contracts/zero-org-members.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-org-members.ts
@@ -41,6 +41,7 @@ export const zeroOrgMembersContract = c.router({
       400: apiErrorSchema,
       401: apiErrorSchema,
       403: apiErrorSchema,
+      404: apiErrorSchema,
       500: apiErrorSchema,
     },
     summary: "Update a member's role (zero proxy)",


### PR DESCRIPTION
## Summary
- Add an API-native `PATCH /api/zero/org/members` route.
- Move member role updates into the API org data service with admin, missing-user, and self-demotion handling.
- Add route coverage for auth, validation, admin updates, missing users, and self-demotion cases.

Closes #12845.

## Tests
- `pnpm -F api exec vitest src/signals/routes/__tests__/zero-org-members.test.ts`
- `pnpm -F api lint`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm check-types` via pre-commit hook
- `git diff --check`