### PR TITLE
refactor(api): migrate cron usage billing routes

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -14,6 +14,10 @@ import type { SignalRouteHandler } from "./context/route";
 import { chatThreadsV1Routes } from "./routes/chat-threads-v1";
 import { connectorsTypeAuthorizeRoutes } from "./routes/connectors-type-authorize";
 import { connectorsTypeCallbackRoutes } from "./routes/connectors-type-callback";
+import { cronAggregateInsightsRoutes } from "./routes/cron-aggregate-insights";
+import { cronAggregateUsageRoutes } from "./routes/cron-aggregate-usage";
+import { cronProcessUsageEventsRoutes } from "./routes/cron-process-usage-events";
+import { cronReconcileBillingEntitlementsRoutes } from "./routes/cron-reconcile-billing-entitlements";
 import { deviceTokenRoutes } from "./routes/device-token";
 import { emailUnsubscribeRoutes } from "./routes/email-unsubscribe";
 import { apiHealth$ } from "./routes/health";
@@ -149,6 +153,10 @@ export const ROUTES: readonly RouteEntry[] = [
   ...agentSessionsRoutes,
   ...connectorsTypeAuthorizeRoutes,
   ...connectorsTypeCallbackRoutes,
+  ...cronAggregateInsightsRoutes,
+  ...cronAggregateUsageRoutes,
+  ...cronProcessUsageEventsRoutes,
+  ...cronReconcileBillingEntitlementsRoutes,
   ...deviceTokenRoutes,
   ...emailUnsubscribeRoutes,
   ...zeroAgentInstructionsRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-aggregate-insights.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-aggregate-insights.test.ts
@@ -1,0 +1,230 @@
+import { cronAggregateInsightsContract } from "@vm0/api-contracts/contracts/cron";
+import { insightsDaily } from "@vm0/db/schema/insights-daily";
+import { orgMetadata } from "@vm0/db/schema/org-metadata";
+import { userCache } from "@vm0/db/schema/user-cache";
+import { createStore } from "ccstate";
+import { and, eq } from "drizzle-orm";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { mockEnv } from "../../../lib/env";
+import { clearMockNow, mockNow } from "../../../lib/time";
+import { writeDb$ } from "../../external/db";
+import {
+  deleteUsageFixture$,
+  insertUsageEvent$,
+  seedRun$,
+  seedUsageFixture$,
+  type UsageFixture,
+} from "./helpers/zero-usage";
+import { createFixtureTracker } from "./helpers/zero-route-test";
+
+const context = testContext();
+const store = createStore();
+const FIXED_NOW_ISO = "2999-01-02T12:00:00.000Z";
+const TODAY = "2999-01-02";
+
+interface InsightData {
+  readonly agents: {
+    readonly agentName: string;
+    readonly runs: number;
+    readonly credits: number;
+  }[];
+  readonly creditsUsed: number;
+  readonly creditBalance: number;
+  readonly teamUsage: {
+    readonly name: string;
+    readonly credits: number;
+    readonly userId: string;
+  }[];
+  readonly services: {
+    readonly domain: string;
+    readonly calls: number;
+    readonly agentNames: string[];
+  }[];
+  readonly axiomDegraded?: boolean;
+}
+
+function apiClient() {
+  return setupApp({ context })(cronAggregateInsightsContract);
+}
+
+function cronHeaders(secret = "test-cron-secret") {
+  return { authorization: `Bearer ${secret}` };
+}
+
+async function cleanupFixture(fixture: UsageFixture): Promise<void> {
+  const db = store.set(writeDb$);
+  await db
+    .delete(insightsDaily)
+    .where(
+      and(
+        eq(insightsDaily.orgId, fixture.orgId),
+        eq(insightsDaily.userId, fixture.userId),
+      ),
+    );
+  await store.set(deleteUsageFixture$, fixture, context.signal);
+}
+
+async function setCreditBalance(fixture: UsageFixture): Promise<void> {
+  const db = store.set(writeDb$);
+  await db
+    .update(orgMetadata)
+    .set({ credits: 100_000 })
+    .where(eq(orgMetadata.orgId, fixture.orgId));
+}
+
+async function seedUserName(fixture: UsageFixture): Promise<void> {
+  const db = store.set(writeDb$);
+  await db.insert(userCache).values({
+    userId: fixture.userId,
+    email: "test@example.com",
+    name: "Test User",
+    cachedAt: new Date(FIXED_NOW_ISO),
+  });
+}
+
+async function findInsights(
+  fixture: UsageFixture,
+): Promise<InsightData | null> {
+  const db = store.set(writeDb$);
+  const [row] = await db
+    .select({ data: insightsDaily.data })
+    .from(insightsDaily)
+    .where(
+      and(
+        eq(insightsDaily.orgId, fixture.orgId),
+        eq(insightsDaily.userId, fixture.userId),
+        eq(insightsDaily.date, TODAY),
+      ),
+    )
+    .limit(1);
+  return (row?.data as InsightData | undefined) ?? null;
+}
+
+describe("GET /api/cron/aggregate-insights", () => {
+  const track = createFixtureTracker<UsageFixture>(cleanupFixture);
+
+  beforeEach(() => {
+    mockEnv("CRON_SECRET", "test-cron-secret");
+    mockNow(new Date(FIXED_NOW_ISO));
+    context.mocks.axiom.query.mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    clearMockNow();
+  });
+
+  it("rejects requests with an invalid cron secret", async () => {
+    const response = await accept(
+      apiClient().aggregate({ headers: cronHeaders("wrong-secret") }),
+      [401],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Invalid cron secret", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("returns skipped when there is no current activity", async () => {
+    const response = await accept(
+      apiClient().aggregate({ headers: cronHeaders() }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({ users: 0, skipped: true });
+  });
+
+  it("aggregates completed runs, processed credits, and network services", async () => {
+    const fixture = await track(
+      store.set(seedUsageFixture$, {}, context.signal),
+    );
+    await setCreditBalance(fixture);
+    await seedUserName(fixture);
+    const completedAt = new Date("2999-01-02T11:55:00.000Z");
+    const { runId } = await store.set(
+      seedRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        createdAt: completedAt,
+        startedAt: completedAt,
+        completedAt,
+      },
+      context.signal,
+    );
+    await store.set(
+      insertUsageEvent$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        runId,
+        creditsCharged: 500,
+        status: "processed",
+        processedAt: completedAt,
+      },
+      context.signal,
+    );
+    context.mocks.axiom.query.mockResolvedValue([
+      {
+        _time: completedAt.toISOString(),
+        runId,
+        host: "api.slack.com",
+        firewall_name: "slack",
+        firewall_permission: "send_message",
+        action: "ALLOW",
+      },
+    ]);
+
+    const response = await accept(
+      apiClient().aggregate({ headers: cronHeaders() }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      users: 1,
+      windows: 1,
+      networkRows: 1,
+    });
+    const data = await findInsights(fixture);
+    expect(data).toMatchObject({
+      creditsUsed: 500,
+      creditBalance: 100_000,
+    });
+    expect(data?.agents).toHaveLength(1);
+    expect(data?.agents[0]).toMatchObject({ runs: 1, credits: 500 });
+    expect(data?.teamUsage).toMatchObject([
+      { name: "Test User", credits: 500, userId: fixture.userId },
+    ]);
+    expect(data?.services).toMatchObject([{ domain: "slack", calls: 1 }]);
+  });
+
+  it("marks insights degraded when Axiom query fails", async () => {
+    const fixture = await track(
+      store.set(seedUsageFixture$, {}, context.signal),
+    );
+    await seedUserName(fixture);
+    const completedAt = new Date("2999-01-02T11:55:00.000Z");
+    await store.set(
+      seedRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        createdAt: completedAt,
+        startedAt: completedAt,
+        completedAt,
+      },
+      context.signal,
+    );
+    context.mocks.axiom.query.mockRejectedValue(new Error("axiom down"));
+
+    const response = await accept(
+      apiClient().aggregate({ headers: cronHeaders() }),
+      [200],
+    );
+
+    expect(response.body).toMatchObject({ users: 1, networkRows: 0 });
+    const data = await findInsights(fixture);
+    expect(data?.axiomDegraded).toBeTruthy();
+  });
+});

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-aggregate-usage.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-aggregate-usage.test.ts
@@ -1,0 +1,148 @@
+import { cronAggregateUsageContract } from "@vm0/api-contracts/contracts/cron";
+import { usageDaily } from "@vm0/db/schema/usage-daily";
+import { createStore } from "ccstate";
+import { and, eq } from "drizzle-orm";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { clearMockNow, mockNow } from "../../../lib/time";
+import { mockEnv } from "../../../lib/env";
+import { writeDb$ } from "../../external/db";
+import {
+  deleteUsageFixture$,
+  seedRun$,
+  seedUsageFixture$,
+  type UsageFixture,
+} from "./helpers/zero-usage";
+import { createFixtureTracker } from "./helpers/zero-route-test";
+
+const context = testContext();
+const store = createStore();
+const FIXED_NOW_ISO = "2026-05-12T12:00:00.000Z";
+
+function apiClient() {
+  return setupApp({ context })(cronAggregateUsageContract);
+}
+
+function cronHeaders(secret = "test-cron-secret") {
+  return { authorization: `Bearer ${secret}` };
+}
+
+async function cleanupFixture(fixture: UsageFixture): Promise<void> {
+  const db = store.set(writeDb$);
+  await db
+    .delete(usageDaily)
+    .where(
+      and(
+        eq(usageDaily.orgId, fixture.orgId),
+        eq(usageDaily.userId, fixture.userId),
+      ),
+    );
+  await store.set(deleteUsageFixture$, fixture, context.signal);
+}
+
+async function findUsageDaily(
+  fixture: UsageFixture,
+  date: string,
+): Promise<{ readonly runCount: number; readonly runTimeMs: number } | null> {
+  const db = store.set(writeDb$);
+  const [row] = await db
+    .select({
+      runCount: usageDaily.runCount,
+      runTimeMs: usageDaily.runTimeMs,
+    })
+    .from(usageDaily)
+    .where(
+      and(
+        eq(usageDaily.orgId, fixture.orgId),
+        eq(usageDaily.userId, fixture.userId),
+        eq(usageDaily.date, date),
+      ),
+    )
+    .limit(1);
+  return row ?? null;
+}
+
+describe("GET /api/cron/aggregate-usage", () => {
+  const track = createFixtureTracker<UsageFixture>(cleanupFixture);
+
+  beforeEach(() => {
+    mockEnv("CRON_SECRET", "test-cron-secret");
+    mockNow(new Date(FIXED_NOW_ISO));
+  });
+
+  afterEach(() => {
+    clearMockNow();
+  });
+
+  it("rejects requests with an invalid cron secret", async () => {
+    const response = await accept(
+      apiClient().aggregate({ headers: cronHeaders("wrong-secret") }),
+      [401],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Invalid cron secret", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("aggregates previous-day completed runs and is idempotent", async () => {
+    const fixture = await track(
+      store.set(seedUsageFixture$, {}, context.signal),
+    );
+    const date = "2026-05-11";
+    const run1Start = new Date("2026-05-11T10:00:00.000Z");
+    const run2Start = new Date("2026-05-11T10:01:00.000Z");
+
+    await store.set(
+      seedRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        createdAt: run1Start,
+        startedAt: run1Start,
+        completedAt: new Date(run1Start.getTime() + 5000),
+      },
+      context.signal,
+    );
+    await store.set(
+      seedRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        createdAt: run2Start,
+        startedAt: run2Start,
+        completedAt: new Date(run2Start.getTime() + 8000),
+      },
+      context.signal,
+    );
+
+    const first = await accept(
+      apiClient().aggregate({ headers: cronHeaders() }),
+      [200],
+    );
+    const second = await accept(
+      apiClient().aggregate({ headers: cronHeaders() }),
+      [200],
+    );
+
+    expect(first.body.date).toBe(date);
+    expect(second.body.date).toBe(date);
+    const usage = await findUsageDaily(fixture, date);
+    expect(usage).toStrictEqual({ runCount: 2, runTimeMs: 13_000 });
+  });
+
+  it("returns a successful empty aggregation when no runs match", async () => {
+    await track(store.set(seedUsageFixture$, {}, context.signal));
+
+    const response = await accept(
+      apiClient().aggregate({ headers: cronHeaders() }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      date: "2026-05-11",
+      aggregated: expect.any(Number),
+    });
+  });
+});

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-process-usage-events.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-process-usage-events.test.ts
@@ -1,0 +1,193 @@
+import { randomUUID } from "node:crypto";
+
+import { cronProcessUsageEventsContract } from "@vm0/api-contracts/contracts/cron";
+import { orgMetadata } from "@vm0/db/schema/org-metadata";
+import { usageEvent } from "@vm0/db/schema/usage-event";
+import { usagePricing } from "@vm0/db/schema/usage-pricing";
+import { createStore } from "ccstate";
+import { eq } from "drizzle-orm";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { mockEnv } from "../../../lib/env";
+import { writeDb$ } from "../../external/db";
+import {
+  deleteUsageFixture$,
+  insertUsageEvent$,
+  seedUsageFixture$,
+  type UsageFixture,
+} from "./helpers/zero-usage";
+import { createFixtureTracker } from "./helpers/zero-route-test";
+
+const context = testContext();
+const store = createStore();
+
+function apiClient() {
+  return setupApp({ context })(cronProcessUsageEventsContract);
+}
+
+function cronHeaders(secret = "test-cron-secret") {
+  return { authorization: `Bearer ${secret}` };
+}
+
+async function cleanupFixture(fixture: UsageFixture): Promise<void> {
+  await store.set(deleteUsageFixture$, fixture, context.signal);
+}
+
+async function seedCredits(fixture: UsageFixture): Promise<void> {
+  const db = store.set(writeDb$);
+  await db
+    .update(orgMetadata)
+    .set({ credits: 100_000 })
+    .where(eq(orgMetadata.orgId, fixture.orgId));
+}
+
+async function insertPricing(args: {
+  readonly kind?: string;
+  readonly provider: string;
+  readonly category: string;
+  readonly unitPrice: number;
+  readonly unitSize?: number;
+}): Promise<void> {
+  const db = store.set(writeDb$);
+  await db.insert(usagePricing).values({
+    kind: args.kind ?? "connector",
+    provider: args.provider,
+    category: args.category,
+    unitPrice: args.unitPrice,
+    unitSize: args.unitSize ?? 1,
+  });
+}
+
+async function findUsageEvent(id: string) {
+  const db = store.set(writeDb$);
+  const [row] = await db
+    .select({
+      status: usageEvent.status,
+      creditsCharged: usageEvent.creditsCharged,
+      billingError: usageEvent.billingError,
+    })
+    .from(usageEvent)
+    .where(eq(usageEvent.id, id))
+    .limit(1);
+  return row;
+}
+
+async function getOrgCredits(orgId: string): Promise<number> {
+  const db = store.set(writeDb$);
+  const [row] = await db
+    .select({ credits: orgMetadata.credits })
+    .from(orgMetadata)
+    .where(eq(orgMetadata.orgId, orgId))
+    .limit(1);
+  return Number(row?.credits ?? 0);
+}
+
+describe("GET /api/cron/process-usage-events", () => {
+  const track = createFixtureTracker<UsageFixture>(cleanupFixture);
+
+  beforeEach(() => {
+    mockEnv("CRON_SECRET", "test-cron-secret");
+  });
+
+  it("rejects requests with an invalid cron secret", async () => {
+    const response = await accept(
+      apiClient().process({ headers: cronHeaders("wrong-secret") }),
+      [401],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Invalid cron secret", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("processes pending usage events and deducts credits", async () => {
+    const fixture = await track(
+      store.set(seedUsageFixture$, {}, context.signal),
+    );
+    await seedCredits(fixture);
+    const provider = `provider-${randomUUID()}`;
+    await insertPricing({ provider, category: "tweet.read", unitPrice: 10 });
+    const eventId = await store.set(
+      insertUsageEvent$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        provider,
+        category: "tweet.read",
+        quantity: 3,
+        status: "pending",
+      },
+      context.signal,
+    );
+
+    const response = await accept(
+      apiClient().process({ headers: cronHeaders() }),
+      [200],
+    );
+
+    expect(response.body.success).toBeTruthy();
+    expect(response.body.processed).toBeGreaterThanOrEqual(1);
+    await expect(findUsageEvent(eventId)).resolves.toStrictEqual({
+      status: "processed",
+      creditsCharged: 30,
+      billingError: null,
+    });
+    await expect(getOrgCredits(fixture.orgId)).resolves.toBe(99_970);
+  });
+
+  it("uses fallback pricing and records missing pricing", async () => {
+    const fixture = await track(
+      store.set(seedUsageFixture$, {}, context.signal),
+    );
+    await seedCredits(fixture);
+    const fallbackProvider = `fallback-${randomUUID()}`;
+    const missingProvider = `missing-${randomUUID()}`;
+    await insertPricing({
+      provider: fallbackProvider,
+      category: "__fallback__",
+      unitPrice: 5,
+    });
+    const fallbackId = await store.set(
+      insertUsageEvent$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        provider: fallbackProvider,
+        category: "includes.unknown_key",
+        quantity: 4,
+        status: "pending",
+      },
+      context.signal,
+    );
+    const missingId = await store.set(
+      insertUsageEvent$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        provider: missingProvider,
+        category: "unknown.category",
+        quantity: 8,
+        status: "pending",
+      },
+      context.signal,
+    );
+
+    const response = await accept(
+      apiClient().process({ headers: cronHeaders() }),
+      [200],
+    );
+
+    expect(response.body.success).toBeTruthy();
+    await expect(findUsageEvent(fallbackId)).resolves.toStrictEqual({
+      status: "processed",
+      creditsCharged: 20,
+      billingError: "fallback_pricing",
+    });
+    await expect(findUsageEvent(missingId)).resolves.toStrictEqual({
+      status: "processed",
+      creditsCharged: 0,
+      billingError: "missing_pricing",
+    });
+  });
+});

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-reconcile-billing-entitlements.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-reconcile-billing-entitlements.test.ts
@@ -1,0 +1,204 @@
+import { randomUUID } from "node:crypto";
+
+import { cronReconcileBillingEntitlementsContract } from "@vm0/api-contracts/contracts/cron";
+import { orgMetadata } from "@vm0/db/schema/org-metadata";
+import { createStore } from "ccstate";
+import { eq } from "drizzle-orm";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { mockEnv } from "../../../lib/env";
+import { nowDate } from "../../../lib/time";
+import { writeDb$ } from "../../external/db";
+import { createFixtureTracker } from "./helpers/zero-route-test";
+
+const context = testContext();
+const store = createStore();
+const TEST_PRICE_PRO = "price_test_pro";
+const TEST_PRICE_TEAM = "price_test_team";
+
+interface BillingFixture {
+  readonly orgId: string;
+  readonly subscriptionId: string;
+}
+
+function apiClient() {
+  return setupApp({ context })(cronReconcileBillingEntitlementsContract);
+}
+
+function cronHeaders(secret = "test-cron-secret") {
+  return { authorization: `Bearer ${secret}` };
+}
+
+function hoursAgo(hours: number): Date {
+  return new Date(nowDate().getTime() - hours * 60 * 60 * 1000);
+}
+
+function stripeSubscription(
+  subscriptionId: string,
+  options: {
+    readonly status: string;
+    readonly periodEnd?: Date | null;
+    readonly priceId?: string;
+    readonly cancelAtPeriodEnd?: boolean;
+  },
+) {
+  return {
+    id: subscriptionId,
+    status: options.status,
+    cancel_at_period_end: options.cancelAtPeriodEnd ?? false,
+    items: {
+      data: [
+        {
+          price: { id: options.priceId ?? TEST_PRICE_PRO },
+          ...(options.periodEnd
+            ? {
+                current_period_end: Math.floor(
+                  options.periodEnd.getTime() / 1000,
+                ),
+              }
+            : {}),
+        },
+      ],
+    },
+  };
+}
+
+async function seedBillingOrg(args: {
+  readonly status: string;
+  readonly tier?: string;
+  readonly currentPeriodEnd?: Date | null;
+  readonly updatedAt?: Date;
+}): Promise<BillingFixture> {
+  const db = store.set(writeDb$);
+  const orgId = `org_${randomUUID()}`;
+  const subscriptionId = `sub_${randomUUID()}`;
+  await db.insert(orgMetadata).values({
+    orgId,
+    stripeCustomerId: `cus_${randomUUID()}`,
+    stripeSubscriptionId: subscriptionId,
+    subscriptionStatus: args.status,
+    currentPeriodEnd: args.currentPeriodEnd ?? null,
+    tier: args.tier ?? "pro",
+    updatedAt: args.updatedAt ?? hoursAgo(48),
+  });
+  return { orgId, subscriptionId };
+}
+
+async function cleanupFixture(fixture: BillingFixture): Promise<void> {
+  const db = store.set(writeDb$);
+  await db.delete(orgMetadata).where(eq(orgMetadata.orgId, fixture.orgId));
+}
+
+async function billingFields(orgId: string) {
+  const db = store.set(writeDb$);
+  const [row] = await db
+    .select({
+      tier: orgMetadata.tier,
+      subscriptionStatus: orgMetadata.subscriptionStatus,
+      stripeSubscriptionId: orgMetadata.stripeSubscriptionId,
+      currentPeriodEnd: orgMetadata.currentPeriodEnd,
+    })
+    .from(orgMetadata)
+    .where(eq(orgMetadata.orgId, orgId))
+    .limit(1);
+  return row;
+}
+
+describe("GET /api/cron/reconcile-billing-entitlements", () => {
+  const track = createFixtureTracker<BillingFixture>(cleanupFixture);
+
+  beforeEach(() => {
+    mockEnv("CRON_SECRET", "test-cron-secret");
+    mockEnv(
+      "ZERO_PRICE",
+      JSON.stringify({ pro: [TEST_PRICE_PRO], team: [TEST_PRICE_TEAM] }),
+    );
+  });
+
+  it("rejects requests with an invalid cron secret", async () => {
+    const response = await accept(
+      apiClient().reconcile({ headers: cronHeaders("wrong-secret") }),
+      [401],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Invalid cron secret", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("downgrades stale payment-failed subscriptions without paid-through", async () => {
+    const fixture = await track(
+      seedBillingOrg({ status: "past_due", currentPeriodEnd: null }),
+    );
+    context.mocks.stripe.subscriptions.retrieve.mockResolvedValue(
+      stripeSubscription(fixture.subscriptionId, {
+        status: "past_due",
+        periodEnd: null,
+      }),
+    );
+
+    const response = await accept(
+      apiClient().reconcile({ headers: cronHeaders() }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({ success: true, downgraded: 1 });
+    await expect(billingFields(fixture.orgId)).resolves.toMatchObject({
+      tier: "free",
+      subscriptionStatus: "past_due",
+      stripeSubscriptionId: fixture.subscriptionId,
+    });
+  });
+
+  it("repairs recovered Stripe subscriptions instead of downgrading", async () => {
+    const fixture = await track(
+      seedBillingOrg({ status: "past_due", currentPeriodEnd: null }),
+    );
+    const paidThrough = new Date(
+      Math.floor((nowDate().getTime() + 30 * 24 * 60 * 60 * 1000) / 1000) *
+        1000,
+    );
+    context.mocks.stripe.subscriptions.retrieve.mockResolvedValue(
+      stripeSubscription(fixture.subscriptionId, {
+        status: "active",
+        periodEnd: paidThrough,
+        priceId: TEST_PRICE_TEAM,
+      }),
+    );
+
+    const response = await accept(
+      apiClient().reconcile({ headers: cronHeaders() }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({ success: true, downgraded: 0 });
+    await expect(billingFields(fixture.orgId)).resolves.toMatchObject({
+      tier: "team",
+      subscriptionStatus: "active",
+      currentPeriodEnd: paidThrough,
+    });
+  });
+
+  it("keeps fresh payment-failed subscriptions in the grace window", async () => {
+    const fixture = await track(
+      seedBillingOrg({
+        status: "past_due",
+        currentPeriodEnd: null,
+        updatedAt: hoursAgo(1),
+      }),
+    );
+
+    const response = await accept(
+      apiClient().reconcile({ headers: cronHeaders() }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({ success: true, downgraded: 0 });
+    expect(context.mocks.stripe.subscriptions.retrieve).not.toHaveBeenCalled();
+    await expect(billingFields(fixture.orgId)).resolves.toMatchObject({
+      tier: "pro",
+      subscriptionStatus: "past_due",
+    });
+  });
+});

--- a/turbo/apps/api/src/signals/routes/cron-aggregate-insights.ts
+++ b/turbo/apps/api/src/signals/routes/cron-aggregate-insights.ts
@@ -1,0 +1,25 @@
+import { cronAggregateInsightsContract } from "@vm0/api-contracts/contracts/cron";
+import { command } from "ccstate";
+
+import type { RouteEntry } from "../route";
+import { aggregateInsights$ } from "../services/cron-aggregate-insights.service";
+import { cronUnauthorized, hasValidCronSecret } from "./cron-auth";
+
+const aggregateInsightsRoute$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    if (!hasValidCronSecret(get)) {
+      return cronUnauthorized();
+    }
+
+    const body = await set(aggregateInsights$, signal);
+    signal.throwIfAborted();
+    return { status: 200 as const, body };
+  },
+);
+
+export const cronAggregateInsightsRoutes: readonly RouteEntry[] = [
+  {
+    route: cronAggregateInsightsContract.aggregate,
+    handler: aggregateInsightsRoute$,
+  },
+];

--- a/turbo/apps/api/src/signals/routes/cron-aggregate-usage.ts
+++ b/turbo/apps/api/src/signals/routes/cron-aggregate-usage.ts
@@ -1,0 +1,25 @@
+import { cronAggregateUsageContract } from "@vm0/api-contracts/contracts/cron";
+import { command } from "ccstate";
+
+import type { RouteEntry } from "../route";
+import { aggregateUsageDaily$ } from "../services/cron-aggregate-usage.service";
+import { cronUnauthorized, hasValidCronSecret } from "./cron-auth";
+
+const aggregateUsageRoute$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    if (!hasValidCronSecret(get)) {
+      return cronUnauthorized();
+    }
+
+    const body = await set(aggregateUsageDaily$, signal);
+    signal.throwIfAborted();
+    return { status: 200 as const, body };
+  },
+);
+
+export const cronAggregateUsageRoutes: readonly RouteEntry[] = [
+  {
+    route: cronAggregateUsageContract.aggregate,
+    handler: aggregateUsageRoute$,
+  },
+];

--- a/turbo/apps/api/src/signals/routes/cron-auth.ts
+++ b/turbo/apps/api/src/signals/routes/cron-auth.ts
@@ -1,0 +1,32 @@
+import type { Computed } from "ccstate";
+
+import { env } from "../../lib/env";
+import { authorization$ } from "../context/hono";
+
+type CronGetter = <T>(source: Computed<T>) => T;
+
+interface CronUnauthorizedResponse {
+  readonly status: 401;
+  readonly body: {
+    readonly error: {
+      readonly message: "Invalid cron secret";
+      readonly code: "UNAUTHORIZED";
+    };
+  };
+}
+
+export function cronUnauthorized(): CronUnauthorizedResponse {
+  return {
+    status: 401,
+    body: {
+      error: {
+        message: "Invalid cron secret",
+        code: "UNAUTHORIZED",
+      },
+    },
+  };
+}
+
+export function hasValidCronSecret(get: CronGetter): boolean {
+  return get(authorization$) === `Bearer ${env("CRON_SECRET")}`;
+}

--- a/turbo/apps/api/src/signals/routes/cron-process-usage-events.ts
+++ b/turbo/apps/api/src/signals/routes/cron-process-usage-events.ts
@@ -1,0 +1,28 @@
+import { cronProcessUsageEventsContract } from "@vm0/api-contracts/contracts/cron";
+import { command } from "ccstate";
+
+import type { RouteEntry } from "../route";
+import { processStaleUsageEvents$ } from "../services/cron-process-usage-events.service";
+import { cronUnauthorized, hasValidCronSecret } from "./cron-auth";
+
+const processUsageEventsRoute$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    if (!hasValidCronSecret(get)) {
+      return cronUnauthorized();
+    }
+
+    const processed = await set(processStaleUsageEvents$, signal);
+    signal.throwIfAborted();
+    return {
+      status: 200 as const,
+      body: { success: true as const, processed },
+    };
+  },
+);
+
+export const cronProcessUsageEventsRoutes: readonly RouteEntry[] = [
+  {
+    route: cronProcessUsageEventsContract.process,
+    handler: processUsageEventsRoute$,
+  },
+];

--- a/turbo/apps/api/src/signals/routes/cron-reconcile-billing-entitlements.ts
+++ b/turbo/apps/api/src/signals/routes/cron-reconcile-billing-entitlements.ts
@@ -1,0 +1,28 @@
+import { cronReconcileBillingEntitlementsContract } from "@vm0/api-contracts/contracts/cron";
+import { command } from "ccstate";
+
+import type { RouteEntry } from "../route";
+import { reconcileBillingEntitlements$ } from "../services/cron-billing-entitlements.service";
+import { cronUnauthorized, hasValidCronSecret } from "./cron-auth";
+
+const reconcileBillingEntitlementsRoute$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    if (!hasValidCronSecret(get)) {
+      return cronUnauthorized();
+    }
+
+    const result = await set(reconcileBillingEntitlements$, signal);
+    signal.throwIfAborted();
+    return {
+      status: 200 as const,
+      body: { success: true as const, ...result },
+    };
+  },
+);
+
+export const cronReconcileBillingEntitlementsRoutes: readonly RouteEntry[] = [
+  {
+    route: cronReconcileBillingEntitlementsContract.reconcile,
+    handler: reconcileBillingEntitlementsRoute$,
+  },
+];

--- a/turbo/apps/api/src/signals/services/cron-aggregate-insights.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-aggregate-insights.service.ts
@@ -1,0 +1,1173 @@
+import {
+  getConnectorFirewall,
+  isFirewallConnectorType,
+} from "@vm0/connectors/firewalls";
+import { agentComposeVersions } from "@vm0/db/schema/agent-compose";
+import { agentRuns } from "@vm0/db/schema/agent-run";
+import { insightsDaily } from "@vm0/db/schema/insights-daily";
+import { orgMembersMetadata } from "@vm0/db/schema/org-members-metadata";
+import { orgMetadata } from "@vm0/db/schema/org-metadata";
+import { usageEvent } from "@vm0/db/schema/usage-event";
+import { userCache } from "@vm0/db/schema/user-cache";
+import { zeroAgents } from "@vm0/db/schema/zero-agent";
+import { command, type Computed } from "ccstate";
+import { and, eq, gte, inArray, isNotNull, lt, sql } from "drizzle-orm";
+
+import { logger } from "../../lib/log";
+import { getDatasetName, queryAxiom } from "../external/axiom";
+import { clerk$ } from "../external/clerk";
+import { writeDb$, type Db } from "../external/db";
+import { nowDate } from "../external/time";
+import { safeAsync } from "../utils";
+
+const L = logger("CronAggregateInsights");
+const OTHER_USAGE_AGENT_NAME = "Other usage";
+const NETWORK_RUN_ATTRIBUTION_BATCH_SIZE = 10_000;
+const AGGREGATION_REPROCESS_OVERLAP_MS = 5 * 60_000;
+
+interface AgentInfo {
+  readonly agentId: string | null;
+  agentName: string;
+  runs: number;
+  credits: number;
+}
+
+interface AxiomNetworkRow {
+  readonly _time: string;
+  readonly runId: string;
+  readonly host: string;
+  readonly firewall_name: string;
+  readonly firewall_permission: string;
+  readonly action: string;
+}
+
+interface UserNetworkData {
+  readonly serviceMap: Map<string, { calls: number; agentNames: Set<string> }>;
+  readonly permMap: Map<
+    string,
+    {
+      readonly label: string;
+      readonly connectorType: string;
+      allowed: number;
+      denied: number;
+      readonly agentNames: Set<string>;
+    }
+  >;
+}
+
+interface InsightData {
+  readonly agents: {
+    readonly agentName: string;
+    readonly agentId: string | null;
+    readonly runs: number;
+    readonly credits: number;
+  }[];
+  readonly creditsUsed: number;
+  readonly creditBalance: number;
+  readonly teamUsage: {
+    readonly userId: string;
+    readonly name: string;
+    readonly credits: number;
+    readonly agentNames: string[];
+    readonly agentCredits: Record<string, number>;
+  }[];
+  readonly topTask: { readonly name: string; readonly count: number } | null;
+  readonly services: {
+    readonly domain: string;
+    readonly calls: number;
+    readonly agentNames: string[];
+  }[];
+  readonly permissions: {
+    readonly label: string;
+    readonly connectorType: string;
+    readonly allowed: number;
+    readonly denied: number;
+    readonly agentNames: string[];
+  }[];
+  readonly axiomDegraded?: boolean;
+}
+
+interface TeamUsageEntry {
+  readonly userId: string;
+  readonly name: string;
+  readonly credits: number;
+  readonly agentNames: string[];
+  readonly agentCredits: Record<string, number>;
+}
+
+interface OrgCreditsInfo {
+  readonly creditsUsed: number;
+  readonly teamUsage: TeamUsageEntry[];
+}
+
+interface LedgerCreditRow {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly agentId: string | null;
+  readonly agentName: string;
+  readonly credits: number;
+}
+
+interface RunCountRow {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly agentId: string;
+  readonly agentName: string;
+  readonly runs: number;
+}
+
+interface ActiveUserRow {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly lastActivity: Date;
+}
+
+interface OrgUserPair {
+  readonly orgId: string;
+  readonly userId: string;
+}
+
+interface NetworkRunAgentRow {
+  readonly runId: string;
+  readonly orgId: string;
+  readonly userId: string;
+  readonly agentName: string;
+}
+
+interface WindowGroup {
+  readonly dayStart: Date;
+  readonly dayEnd: Date;
+  readonly targetDate: string;
+  readonly users: OrgUserPair[];
+}
+
+interface WindowScope {
+  readonly dayStart: Date;
+  readonly dayEnd: Date;
+  readonly users: OrgUserPair[];
+  readonly orgIds: string[];
+  readonly userIds: string[];
+}
+
+interface ClerkUserListUser {
+  readonly id: string;
+  readonly emailAddresses: readonly {
+    readonly id: string;
+    readonly emailAddress: string;
+  }[];
+  readonly primaryEmailAddressId: string | null;
+  readonly firstName: string | null;
+  readonly username: string | null;
+}
+
+interface ClerkLike {
+  readonly users: {
+    readonly getUserList: (args: {
+      readonly userId: string[];
+      readonly limit: number;
+    }) => Promise<{ readonly data: readonly ClerkUserListUser[] }>;
+  };
+}
+
+interface AggregateInsightsResult {
+  readonly users: number;
+  readonly skipped?: true;
+  readonly windows?: number;
+  readonly networkRows?: number;
+}
+
+interface AgentContribution {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly agentName: string;
+  readonly agentId: string | null;
+  readonly runs: number;
+  readonly credits: number;
+}
+
+interface BuildUserInsightArgs {
+  readonly networkData: UserNetworkData | undefined;
+  readonly agents: AgentInfo[];
+  readonly orgCreditsUsed: number;
+  readonly orgCreditBalance: number;
+  readonly orgTeamUsage: TeamUsageEntry[];
+  readonly axiomDegraded: boolean;
+}
+
+interface WindowUsageData {
+  readonly userAgentMap: Map<string, AgentInfo[]>;
+  readonly orgCreditsMap: Map<string, OrgCreditsInfo>;
+  readonly orgBalanceMap: Map<string, number>;
+}
+
+interface NetworkQueryResult {
+  readonly userNetworkMap: Map<string, UserNetworkData>;
+  readonly networkRows: number;
+  readonly axiomDegraded: boolean;
+}
+
+type SignalGetter = {
+  <T>(source: Computed<T>): T;
+  <T>(source: Computed<Promise<T>>): Promise<T>;
+};
+
+function normalizeDbDate(value: Date | string): Date {
+  return value instanceof Date ? value : new Date(value);
+}
+
+async function resolveUserTimezones(
+  db: Db,
+  orgUserPairs: OrgUserPair[],
+  signal: AbortSignal,
+): Promise<Map<string, string>> {
+  if (orgUserPairs.length === 0) {
+    return new Map();
+  }
+
+  const userIds = [
+    ...new Set(
+      orgUserPairs.map((pair) => {
+        return pair.userId;
+      }),
+    ),
+  ];
+
+  const rows = await db
+    .select({
+      orgId: orgMembersMetadata.orgId,
+      userId: orgMembersMetadata.userId,
+      timezone: orgMembersMetadata.timezone,
+    })
+    .from(orgMembersMetadata)
+    .where(
+      and(
+        inArray(orgMembersMetadata.userId, userIds),
+        isNotNull(orgMembersMetadata.timezone),
+      ),
+    );
+  signal.throwIfAborted();
+
+  const tzMap = new Map<string, string>();
+  for (const row of rows) {
+    if (row.timezone) {
+      tzMap.set(`${row.orgId}:${row.userId}`, row.timezone);
+    }
+  }
+  return tzMap;
+}
+
+function getLocalDayStartUtc(timezone: string, now: Date): Date {
+  const parts = new Intl.DateTimeFormat("en-CA", {
+    timeZone: timezone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).format(now);
+  const localMidnight = new Date(`${parts}T00:00:00`);
+  const utcStr = localMidnight.toLocaleString("en-US", { timeZone: "UTC" });
+  const tzStr = localMidnight.toLocaleString("en-US", { timeZone: timezone });
+  const utcDate = new Date(utcStr);
+  const tzDate = new Date(tzStr);
+  const offsetMs = utcDate.getTime() - tzDate.getTime();
+  return new Date(localMidnight.getTime() + offsetMs);
+}
+
+function getLocalToday(
+  timezone: string,
+  now: Date,
+): {
+  readonly targetDate: string;
+  readonly dayStart: Date;
+  readonly dayEnd: Date;
+} {
+  const dayStart = getLocalDayStartUtc(timezone, now);
+  const targetDate = new Intl.DateTimeFormat("en-CA", {
+    timeZone: timezone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).format(now);
+  return { targetDate, dayStart, dayEnd: now };
+}
+
+function getPermissionLabel(
+  firewallName: string,
+  permissionName: string,
+): string {
+  const key = `${firewallName}:${permissionName}`;
+
+  if (isFirewallConnectorType(firewallName)) {
+    const config = getConnectorFirewall(firewallName);
+    for (const api of config.apis) {
+      if (!api.permissions) {
+        continue;
+      }
+      for (const perm of api.permissions) {
+        if (perm.name === permissionName) {
+          return perm.description ?? key;
+        }
+      }
+    }
+  }
+
+  return key;
+}
+
+async function resolveUserNames(
+  db: Db,
+  clerk: ClerkLike,
+  userIds: string[],
+  signal: AbortSignal,
+): Promise<Map<string, string>> {
+  if (userIds.length === 0) {
+    return new Map();
+  }
+
+  const cachedUsers = await db
+    .select({
+      userId: userCache.userId,
+      email: userCache.email,
+      name: userCache.name,
+    })
+    .from(userCache)
+    .where(inArray(userCache.userId, userIds));
+  signal.throwIfAborted();
+
+  const nameMap = new Map(
+    cachedUsers.map((user) => {
+      return [user.userId, user.name ?? user.email.split("@")[0] ?? user.email];
+    }),
+  );
+
+  const missingIds = userIds.filter((id) => {
+    return !nameMap.has(id);
+  });
+  if (missingIds.length === 0) {
+    return nameMap;
+  }
+
+  const clerkUsers = await clerk.users.getUserList({
+    userId: missingIds,
+    limit: missingIds.length,
+  });
+  signal.throwIfAborted();
+
+  const now = nowDate();
+  for (const user of clerkUsers.data) {
+    const primaryEmail = user.emailAddresses.find((email) => {
+      return email.id === user.primaryEmailAddressId;
+    });
+    const email = primaryEmail?.emailAddress ?? "unknown";
+    const name =
+      user.firstName ?? user.username ?? email.split("@")[0] ?? "unknown";
+    nameMap.set(user.id, name);
+
+    await db
+      .insert(userCache)
+      .values({ userId: user.id, email, name, cachedAt: now })
+      .onConflictDoUpdate({
+        target: userCache.userId,
+        set: { email, name, cachedAt: now },
+      });
+    signal.throwIfAborted();
+  }
+
+  return nameMap;
+}
+
+function aggregateNetworkDataPerUser(
+  networkRows: AxiomNetworkRow[],
+  runIdToInfo: Map<
+    string,
+    {
+      readonly orgId: string;
+      readonly userId: string;
+      readonly agentName: string;
+    }
+  >,
+): Map<string, UserNetworkData> {
+  const userNetworkMap = new Map<string, UserNetworkData>();
+
+  for (const row of networkRows) {
+    if (!isFirewallConnectorType(row.firewall_name)) {
+      continue;
+    }
+
+    const info = runIdToInfo.get(row.runId);
+    if (!info) {
+      continue;
+    }
+
+    const key = `${info.orgId}:${info.userId}`;
+    const userData = userNetworkMap.get(key) ?? {
+      serviceMap: new Map<string, { calls: number; agentNames: Set<string> }>(),
+      permMap: new Map<
+        string,
+        {
+          label: string;
+          connectorType: string;
+          allowed: number;
+          denied: number;
+          agentNames: Set<string>;
+        }
+      >(),
+    };
+    userNetworkMap.set(key, userData);
+
+    const service = userData.serviceMap.get(row.firewall_name) ?? {
+      calls: 0,
+      agentNames: new Set<string>(),
+    };
+    service.calls++;
+    service.agentNames.add(info.agentName);
+    userData.serviceMap.set(row.firewall_name, service);
+
+    if (row.firewall_permission || row.action === "DENY") {
+      const hasPermission = row.firewall_permission.length > 0;
+      const permKey = hasPermission
+        ? `${row.firewall_name}:${row.firewall_permission}`
+        : row.firewall_name;
+      const label = hasPermission
+        ? getPermissionLabel(row.firewall_name, row.firewall_permission)
+        : row.firewall_name;
+      const permission = userData.permMap.get(permKey) ?? {
+        label,
+        connectorType: row.firewall_name,
+        allowed: 0,
+        denied: 0,
+        agentNames: new Set<string>(),
+      };
+      if (row.action === "ALLOW") {
+        permission.allowed++;
+      } else if (row.action === "DENY") {
+        permission.denied++;
+      }
+      permission.agentNames.add(info.agentName);
+      userData.permMap.set(permKey, permission);
+    }
+  }
+
+  return userNetworkMap;
+}
+
+function buildUserInsight(args: BuildUserInsightArgs): InsightData {
+  const {
+    networkData,
+    agents,
+    orgCreditsUsed,
+    orgCreditBalance,
+    orgTeamUsage,
+    axiomDegraded,
+  } = args;
+  const services = networkData
+    ? [...networkData.serviceMap.entries()]
+        .map(([domain, service]) => {
+          return {
+            domain,
+            calls: service.calls,
+            agentNames: [...service.agentNames],
+          };
+        })
+        .sort((a, b) => {
+          return b.calls - a.calls;
+        })
+    : [];
+
+  const permissions = networkData
+    ? [...networkData.permMap.values()]
+        .map((permission) => {
+          return {
+            label: permission.label,
+            connectorType: permission.connectorType,
+            allowed: permission.allowed,
+            denied: permission.denied,
+            agentNames: [...permission.agentNames],
+          };
+        })
+        .sort((a, b) => {
+          return b.allowed + b.denied - (a.allowed + a.denied);
+        })
+    : [];
+
+  const topPermission = permissions[0];
+  return {
+    agents: agents.map((agent) => {
+      return {
+        agentName: agent.agentName,
+        agentId: agent.agentId,
+        runs: agent.runs,
+        credits: agent.credits,
+      };
+    }),
+    creditsUsed: orgCreditsUsed,
+    creditBalance: orgCreditBalance,
+    teamUsage: orgTeamUsage,
+    topTask: topPermission
+      ? {
+          name: topPermission.label,
+          count: topPermission.allowed + topPermission.denied,
+        }
+      : null,
+    services,
+    permissions,
+    ...(axiomDegraded ? { axiomDegraded: true } : {}),
+  };
+}
+
+function aggregateOrgCredits(
+  memberRows: {
+    readonly orgId: string;
+    readonly userId: string;
+    readonly agentName: string;
+    readonly credits: number;
+  }[],
+  userNameMap: Map<string, string>,
+): Map<string, OrgCreditsInfo> {
+  const memberAgg = new Map<
+    string,
+    Map<
+      string,
+      {
+        credits: number;
+        agentNames: Set<string>;
+        agentCredits: Map<string, number>;
+      }
+    >
+  >();
+
+  for (const row of memberRows) {
+    const orgMembers = memberAgg.get(row.orgId) ?? new Map();
+    memberAgg.set(row.orgId, orgMembers);
+    const existing = orgMembers.get(row.userId) ?? {
+      credits: 0,
+      agentNames: new Set<string>(),
+      agentCredits: new Map<string, number>(),
+    };
+    const amount = Number(row.credits);
+    existing.credits += amount;
+    existing.agentNames.add(row.agentName);
+    existing.agentCredits.set(
+      row.agentName,
+      (existing.agentCredits.get(row.agentName) ?? 0) + amount,
+    );
+    orgMembers.set(row.userId, existing);
+  }
+
+  const orgCreditsMap = new Map<string, OrgCreditsInfo>();
+  for (const [orgId, members] of memberAgg) {
+    let creditsUsed = 0;
+    const teamUsage: TeamUsageEntry[] = [];
+    for (const [userId, data] of members) {
+      creditsUsed += data.credits;
+      teamUsage.push({
+        userId,
+        name: userNameMap.get(userId) ?? userId,
+        credits: data.credits,
+        agentNames: [...data.agentNames],
+        agentCredits: Object.fromEntries(data.agentCredits),
+      });
+    }
+    teamUsage.sort((a, b) => {
+      return b.credits - a.credits;
+    });
+    orgCreditsMap.set(orgId, { creditsUsed, teamUsage });
+  }
+
+  return orgCreditsMap;
+}
+
+function mergeActiveUserRows(rows: ActiveUserRow[]): ActiveUserRow[] {
+  const byUser = new Map<string, ActiveUserRow>();
+  for (const row of rows) {
+    const normalizedRow = {
+      ...row,
+      lastActivity: normalizeDbDate(row.lastActivity),
+    };
+    const key = `${row.orgId}:${row.userId}`;
+    const existing = byUser.get(key);
+    if (!existing || normalizedRow.lastActivity > existing.lastActivity) {
+      byUser.set(key, normalizedRow);
+    }
+  }
+  return [...byUser.values()];
+}
+
+async function queryActiveUsers(
+  db: Db,
+  lookbackStart: Date,
+  signal: AbortSignal,
+): Promise<ActiveUserRow[]> {
+  const [completedRuns, eventUsage] = await Promise.all([
+    db
+      .select({
+        orgId: agentRuns.orgId,
+        userId: agentRuns.userId,
+        lastActivity: sql<Date>`MAX(${agentRuns.completedAt})`.as(
+          "last_activity",
+        ),
+      })
+      .from(agentRuns)
+      .where(
+        and(
+          gte(agentRuns.completedAt, lookbackStart),
+          isNotNull(agentRuns.completedAt),
+        ),
+      )
+      .groupBy(agentRuns.orgId, agentRuns.userId),
+    db
+      .select({
+        orgId: usageEvent.orgId,
+        userId: usageEvent.userId,
+        lastActivity: sql<Date>`MAX(${usageEvent.processedAt})`.as(
+          "last_activity",
+        ),
+      })
+      .from(usageEvent)
+      .where(
+        and(
+          eq(usageEvent.status, "processed"),
+          gte(usageEvent.processedAt, lookbackStart),
+          isNotNull(usageEvent.processedAt),
+        ),
+      )
+      .groupBy(usageEvent.orgId, usageEvent.userId),
+  ]);
+  signal.throwIfAborted();
+
+  return mergeActiveUserRows([...completedRuns, ...eventUsage]);
+}
+
+function mergeAgentRows(
+  runRows: RunCountRow[],
+  creditRows: LedgerCreditRow[],
+  users: OrgUserPair[],
+): Map<string, AgentInfo[]> {
+  const wantedUsers = new Set(
+    users.map((user) => {
+      return `${user.orgId}:${user.userId}`;
+    }),
+  );
+  const byUser = new Map<string, Map<string, AgentInfo>>();
+
+  const add = (contribution: AgentContribution) => {
+    const { orgId, userId, agentName, agentId, runs, credits } = contribution;
+    const userKey = `${orgId}:${userId}`;
+    if (!wantedUsers.has(userKey)) {
+      return;
+    }
+
+    const userAgents = byUser.get(userKey) ?? new Map<string, AgentInfo>();
+    const agentKey = agentId ?? `unattributed:${agentName}`;
+    const existing = userAgents.get(agentKey) ?? {
+      agentId,
+      agentName,
+      runs: 0,
+      credits: 0,
+    };
+    existing.agentName = agentName;
+    existing.runs += runs;
+    existing.credits += credits;
+    userAgents.set(agentKey, existing);
+    byUser.set(userKey, userAgents);
+  };
+
+  for (const row of runRows) {
+    add({ ...row, credits: 0 });
+  }
+  for (const row of creditRows) {
+    add({ ...row, runs: 0, credits: Number(row.credits) });
+  }
+
+  const result = new Map<string, AgentInfo[]>();
+  for (const [userKey, agents] of byUser) {
+    const list = [...agents.values()];
+    list.sort((a, b) => {
+      return (
+        b.credits - a.credits ||
+        b.runs - a.runs ||
+        a.agentName.localeCompare(b.agentName)
+      );
+    });
+    result.set(userKey, list);
+  }
+  return result;
+}
+
+async function queryCompletedRunCounts(
+  db: Db,
+  scope: WindowScope,
+  signal: AbortSignal,
+): Promise<RunCountRow[]> {
+  const { orgIds, userIds, dayStart, dayEnd } = scope;
+  const rows = await db
+    .select({
+      orgId: agentRuns.orgId,
+      userId: agentRuns.userId,
+      agentId: zeroAgents.id,
+      agentName:
+        sql<string>`COALESCE(${zeroAgents.displayName}, ${zeroAgents.name})`.as(
+          "agent_name",
+        ),
+      runs: sql<number>`COUNT(DISTINCT ${agentRuns.id})::int`.as("runs"),
+    })
+    .from(agentRuns)
+    .innerJoin(
+      agentComposeVersions,
+      eq(agentRuns.agentComposeVersionId, agentComposeVersions.id),
+    )
+    .innerJoin(zeroAgents, eq(agentComposeVersions.composeId, zeroAgents.id))
+    .where(
+      and(
+        inArray(agentRuns.orgId, orgIds),
+        inArray(agentRuns.userId, userIds),
+        gte(agentRuns.completedAt, dayStart),
+        lt(agentRuns.completedAt, dayEnd),
+        isNotNull(agentRuns.completedAt),
+      ),
+    )
+    .groupBy(
+      agentRuns.orgId,
+      agentRuns.userId,
+      zeroAgents.id,
+      zeroAgents.displayName,
+      zeroAgents.name,
+    );
+  signal.throwIfAborted();
+
+  return rows.map((row) => {
+    return {
+      orgId: row.orgId,
+      userId: row.userId,
+      agentId: row.agentId,
+      agentName: row.agentName,
+      runs: Number(row.runs),
+    };
+  });
+}
+
+async function queryUsageEventCreditRows(
+  db: Db,
+  orgIds: string[],
+  dayStart: Date,
+  dayEnd: Date,
+  signal: AbortSignal,
+): Promise<LedgerCreditRow[]> {
+  const isRunless = sql`${usageEvent.runId} IS NULL`;
+  const rows = await db
+    .select({
+      orgId: usageEvent.orgId,
+      userId: usageEvent.userId,
+      agentId: sql<
+        string | null
+      >`CASE WHEN ${isRunless} THEN NULL ELSE ${zeroAgents.id}::text END`.as(
+        "agent_id",
+      ),
+      agentName:
+        sql<string>`CASE WHEN ${isRunless} THEN ${OTHER_USAGE_AGENT_NAME} ELSE COALESCE(${zeroAgents.displayName}, ${zeroAgents.name}, 'Unknown agent') END`.as(
+          "agent_name",
+        ),
+      credits:
+        sql<number>`COALESCE(SUM(${usageEvent.creditsCharged}), 0)::bigint`.as(
+          "credits",
+        ),
+    })
+    .from(usageEvent)
+    .leftJoin(agentRuns, eq(usageEvent.runId, agentRuns.id))
+    .leftJoin(
+      agentComposeVersions,
+      eq(agentRuns.agentComposeVersionId, agentComposeVersions.id),
+    )
+    .leftJoin(zeroAgents, eq(agentComposeVersions.composeId, zeroAgents.id))
+    .where(
+      and(
+        inArray(usageEvent.orgId, orgIds),
+        eq(usageEvent.status, "processed"),
+        gte(usageEvent.processedAt, dayStart),
+        lt(usageEvent.processedAt, dayEnd),
+        isNotNull(usageEvent.processedAt),
+      ),
+    )
+    .groupBy(
+      usageEvent.orgId,
+      usageEvent.userId,
+      isRunless,
+      zeroAgents.id,
+      zeroAgents.displayName,
+      zeroAgents.name,
+    );
+  signal.throwIfAborted();
+
+  return rows.map((row) => {
+    return { ...row, credits: Number(row.credits) };
+  });
+}
+
+async function queryNetworkRunAgentRows(
+  db: Db,
+  orgIds: string[],
+  userIds: string[],
+  runIds: string[],
+  signal: AbortSignal,
+): Promise<NetworkRunAgentRow[]> {
+  const rows: NetworkRunAgentRow[] = [];
+  for (let i = 0; i < runIds.length; i += NETWORK_RUN_ATTRIBUTION_BATCH_SIZE) {
+    const batch = runIds.slice(i, i + NETWORK_RUN_ATTRIBUTION_BATCH_SIZE);
+    rows.push(
+      ...(await db
+        .select({
+          runId: agentRuns.id,
+          orgId: agentRuns.orgId,
+          userId: agentRuns.userId,
+          agentName:
+            sql<string>`COALESCE(${zeroAgents.displayName}, ${zeroAgents.name})`.as(
+              "agent_name",
+            ),
+        })
+        .from(agentRuns)
+        .innerJoin(
+          agentComposeVersions,
+          eq(agentRuns.agentComposeVersionId, agentComposeVersions.id),
+        )
+        .innerJoin(
+          zeroAgents,
+          eq(agentComposeVersions.composeId, zeroAgents.id),
+        )
+        .where(
+          and(
+            inArray(agentRuns.orgId, orgIds),
+            inArray(agentRuns.userId, userIds),
+            inArray(agentRuns.id, batch),
+          ),
+        )),
+    );
+    signal.throwIfAborted();
+  }
+  return rows;
+}
+
+function windowScope(group: WindowGroup): WindowScope {
+  const { dayStart, dayEnd, users } = group;
+  return {
+    dayStart,
+    dayEnd,
+    users,
+    orgIds: [
+      ...new Set(
+        users.map((user) => {
+          return user.orgId;
+        }),
+      ),
+    ],
+    userIds: [
+      ...new Set(
+        users.map((user) => {
+          return user.userId;
+        }),
+      ),
+    ],
+  };
+}
+
+async function loadWindowUsageData(
+  db: Db,
+  clerk: ClerkLike,
+  scope: WindowScope,
+  signal: AbortSignal,
+): Promise<WindowUsageData> {
+  const [runRows, ledgerCreditRows] = await Promise.all([
+    queryCompletedRunCounts(db, scope, signal),
+    queryUsageEventCreditRows(
+      db,
+      scope.orgIds,
+      scope.dayStart,
+      scope.dayEnd,
+      signal,
+    ),
+  ]);
+  signal.throwIfAborted();
+
+  const userAgentMap = mergeAgentRows(runRows, ledgerCreditRows, scope.users);
+  const allCreditUserIds = [
+    ...new Set(
+      ledgerCreditRows.map((row) => {
+        return row.userId;
+      }),
+    ),
+  ];
+  const userNameMap = await resolveUserNames(
+    db,
+    clerk,
+    allCreditUserIds,
+    signal,
+  );
+  const orgCreditsMap = aggregateOrgCredits(ledgerCreditRows, userNameMap);
+
+  const balanceRows =
+    scope.orgIds.length > 0
+      ? await db
+          .select({ orgId: orgMetadata.orgId, credits: orgMetadata.credits })
+          .from(orgMetadata)
+          .where(inArray(orgMetadata.orgId, scope.orgIds))
+      : [];
+  signal.throwIfAborted();
+
+  return {
+    userAgentMap,
+    orgCreditsMap,
+    orgBalanceMap: new Map(
+      balanceRows.map((row) => {
+        return [row.orgId, Number(row.credits)];
+      }),
+    ),
+  };
+}
+
+async function queryWindowNetworkData(
+  get: SignalGetter,
+  db: Db,
+  scope: WindowScope,
+  signal: AbortSignal,
+): Promise<NetworkQueryResult> {
+  const dataset = getDatasetName("sandbox-telemetry-network");
+  const startIso = scope.dayStart.toISOString();
+  const endIso = scope.dayEnd.toISOString();
+  const apl = `['${dataset}']
+| where _time >= datetime("${startIso}") and _time < datetime("${endIso}")
+| where isnotnull(firewall_name) and firewall_name != ""
+| project runId, host, firewall_name, firewall_permission, action
+| limit 100000`;
+
+  const axiomResult = await safeAsync(async () => {
+    return [
+      ...((await get(
+        queryAxiom(apl),
+      )) as unknown as readonly AxiomNetworkRow[]),
+    ];
+  });
+  const networkRows = "ok" in axiomResult ? axiomResult.ok : [];
+  const axiomDegraded = "error" in axiomResult;
+  if ("error" in axiomResult) {
+    L.error("Failed to query Axiom for network logs", {
+      error:
+        axiomResult.error instanceof Error
+          ? axiomResult.error.message
+          : String(axiomResult.error),
+    });
+  }
+  signal.throwIfAborted();
+
+  const networkRunIds = [
+    ...new Set(
+      networkRows
+        .map((row) => {
+          return row.runId;
+        })
+        .filter(Boolean),
+    ),
+  ];
+  const runAgentRows =
+    networkRunIds.length > 0
+      ? await queryNetworkRunAgentRows(
+          db,
+          scope.orgIds,
+          scope.userIds,
+          networkRunIds,
+          signal,
+        )
+      : [];
+
+  const runIdToInfo = new Map<
+    string,
+    {
+      readonly orgId: string;
+      readonly userId: string;
+      readonly agentName: string;
+    }
+  >();
+  for (const row of runAgentRows) {
+    runIdToInfo.set(row.runId, {
+      orgId: row.orgId,
+      userId: row.userId,
+      agentName: row.agentName,
+    });
+  }
+
+  return {
+    userNetworkMap: aggregateNetworkDataPerUser(networkRows, runIdToInfo),
+    networkRows: networkRows.length,
+    axiomDegraded,
+  };
+}
+
+async function upsertWindowInsights(
+  db: Db,
+  group: WindowGroup,
+  usageData: WindowUsageData,
+  networkData: NetworkQueryResult,
+  signal: AbortSignal,
+): Promise<number> {
+  let upserted = 0;
+  for (const { orgId, userId } of group.users) {
+    const key = `${orgId}:${userId}`;
+    const data = buildUserInsight({
+      networkData: networkData.userNetworkMap.get(key),
+      agents: usageData.userAgentMap.get(key) ?? [],
+      orgCreditsUsed: usageData.orgCreditsMap.get(orgId)?.creditsUsed ?? 0,
+      orgCreditBalance: usageData.orgBalanceMap.get(orgId) ?? 0,
+      orgTeamUsage: usageData.orgCreditsMap.get(orgId)?.teamUsage ?? [],
+      axiomDegraded: networkData.axiomDegraded,
+    });
+
+    await db
+      .insert(insightsDaily)
+      .values({
+        orgId,
+        userId,
+        date: group.targetDate,
+        data,
+        updatedAt: group.dayEnd,
+      })
+      .onConflictDoUpdate({
+        target: [insightsDaily.orgId, insightsDaily.userId, insightsDaily.date],
+        set: { data, updatedAt: group.dayEnd },
+      });
+    signal.throwIfAborted();
+    upserted++;
+  }
+  return upserted;
+}
+
+async function processWindowGroup(
+  get: SignalGetter,
+  db: Db,
+  clerk: ClerkLike,
+  group: WindowGroup,
+  signal: AbortSignal,
+): Promise<{ readonly upserted: number; readonly networkRows: number }> {
+  const scope = windowScope(group);
+  const usageData = await loadWindowUsageData(db, clerk, scope, signal);
+  const networkData = await queryWindowNetworkData(get, db, scope, signal);
+  const upserted = await upsertWindowInsights(
+    db,
+    group,
+    usageData,
+    networkData,
+    signal,
+  );
+  return { upserted, networkRows: networkData.networkRows };
+}
+
+export const aggregateInsights$ = command(
+  async (
+    { get, set },
+    signal: AbortSignal,
+  ): Promise<AggregateInsightsResult> => {
+    const db = set(writeDb$);
+    const clerk = get(clerk$);
+    const now = nowDate();
+    const lookbackStart = new Date(now.getTime() - 25 * 3_600_000);
+    const activeUsers = await queryActiveUsers(db, lookbackStart, signal);
+
+    if (activeUsers.length === 0) {
+      L.debug("No users with new runs or ledger usage, skipping aggregation");
+      return { users: 0, skipped: true };
+    }
+
+    const activeOrgIds = [
+      ...new Set(
+        activeUsers.map((user) => {
+          return user.orgId;
+        }),
+      ),
+    ];
+    const activeUserIds = [
+      ...new Set(
+        activeUsers.map((user) => {
+          return user.userId;
+        }),
+      ),
+    ];
+
+    const lastAggRows = await db
+      .select({
+        orgId: insightsDaily.orgId,
+        userId: insightsDaily.userId,
+        lastUpdated: sql<Date>`MAX(${insightsDaily.updatedAt})`.as(
+          "last_updated",
+        ),
+      })
+      .from(insightsDaily)
+      .where(
+        and(
+          inArray(insightsDaily.orgId, activeOrgIds),
+          inArray(insightsDaily.userId, activeUserIds),
+        ),
+      )
+      .groupBy(insightsDaily.orgId, insightsDaily.userId);
+    signal.throwIfAborted();
+
+    const lastAggMap = new Map(
+      lastAggRows.map((row) => {
+        return [`${row.orgId}:${row.userId}`, normalizeDbDate(row.lastUpdated)];
+      }),
+    );
+
+    const usersToAggregate = activeUsers.filter((user) => {
+      const lastAgg = lastAggMap.get(`${user.orgId}:${user.userId}`);
+      if (!lastAgg) {
+        return true;
+      }
+      const lastCovered = new Date(
+        lastAgg.getTime() - AGGREGATION_REPROCESS_OVERLAP_MS,
+      );
+      return user.lastActivity >= lastCovered;
+    });
+
+    if (usersToAggregate.length === 0) {
+      L.debug("All active users are up to date");
+      return { users: 0, skipped: true };
+    }
+
+    const userTimezoneMap = await resolveUserTimezones(
+      db,
+      usersToAggregate,
+      signal,
+    );
+    const windowGroups = new Map<string, WindowGroup>();
+
+    for (const { orgId, userId } of usersToAggregate) {
+      const timezone = userTimezoneMap.get(`${orgId}:${userId}`) ?? "UTC";
+      const { targetDate, dayStart, dayEnd } = getLocalToday(timezone, now);
+      const windowKey = `${dayStart.toISOString()}|${dayEnd.toISOString()}`;
+      const group = windowGroups.get(windowKey) ?? {
+        dayStart,
+        dayEnd,
+        targetDate,
+        users: [],
+      };
+      group.users.push({ orgId, userId });
+      windowGroups.set(windowKey, group);
+    }
+
+    let upserted = 0;
+    let totalNetworkRows = 0;
+    for (const group of windowGroups.values()) {
+      const result = await processWindowGroup(get, db, clerk, group, signal);
+      upserted += result.upserted;
+      totalNetworkRows += result.networkRows;
+      signal.throwIfAborted();
+    }
+
+    L.debug("Aggregated insights", {
+      users: upserted,
+      windows: windowGroups.size,
+      networkRows: totalNetworkRows,
+    });
+
+    return {
+      users: upserted,
+      windows: windowGroups.size,
+      networkRows: totalNetworkRows,
+    };
+  },
+);

--- a/turbo/apps/api/src/signals/services/cron-aggregate-usage.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-aggregate-usage.service.ts
@@ -1,0 +1,51 @@
+import { agentRuns } from "@vm0/db/schema/agent-run";
+import { usageDaily } from "@vm0/db/schema/usage-daily";
+import { command } from "ccstate";
+import { sql } from "drizzle-orm";
+
+import { nowDate } from "../external/time";
+import { writeDb$ } from "../external/db";
+
+interface AggregateUsageResult {
+  readonly date: string;
+  readonly aggregated: number;
+}
+
+export const aggregateUsageDaily$ = command(
+  async ({ set }, signal: AbortSignal): Promise<AggregateUsageResult> => {
+    const db = set(writeDb$);
+    const now = nowDate();
+    const yesterday = new Date(
+      Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() - 1),
+    );
+    const today = new Date(
+      Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()),
+    );
+    const targetDate = yesterday.toISOString().split("T")[0]!;
+
+    const result = await db.execute(sql`
+      INSERT INTO ${usageDaily} (user_id, org_id, date, run_count, run_time_ms)
+      SELECT
+        ${agentRuns.userId},
+        ${agentRuns.orgId},
+        ${targetDate}::date,
+        COUNT(*)::int,
+        COALESCE(SUM(EXTRACT(EPOCH FROM (${agentRuns.completedAt} - ${agentRuns.startedAt})) * 1000), 0)::bigint
+      FROM ${agentRuns}
+      WHERE ${agentRuns.createdAt} >= ${yesterday}
+        AND ${agentRuns.createdAt} < ${today}
+        AND ${agentRuns.completedAt} IS NOT NULL
+      GROUP BY ${agentRuns.userId}, ${agentRuns.orgId}
+      ON CONFLICT (user_id, org_id, date) DO UPDATE SET
+        run_count = EXCLUDED.run_count,
+        run_time_ms = EXCLUDED.run_time_ms,
+        updated_at = NOW()
+    `);
+    signal.throwIfAborted();
+
+    return {
+      date: targetDate,
+      aggregated: result.rowCount ?? 0,
+    };
+  },
+);

--- a/turbo/apps/api/src/signals/services/cron-billing-entitlements.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-billing-entitlements.service.ts
@@ -1,0 +1,253 @@
+import type { OrgTier } from "@vm0/api-contracts/contracts/orgs";
+import { orgMetadata } from "@vm0/db/schema/org-metadata";
+import { command } from "ccstate";
+import { and, eq, inArray, isNotNull, isNull, lte, or } from "drizzle-orm";
+
+import { env } from "../../lib/env";
+import { logger } from "../../lib/log";
+import { nowDate } from "../external/time";
+import { writeDb$, type Db } from "../external/db";
+import { getStripeClient } from "../external/stripe-client";
+
+const L = logger("CronBillingEntitlements");
+
+const ENTITLEMENT_PERIOD_REFRESH_STATUSES = ["active", "trialing"] as const;
+const PAYMENT_FAILED_SUBSCRIPTION_STATUSES = ["past_due", "unpaid"] as const;
+const PAYMENT_FAILURE_DOWNGRADE_GRACE_MS = 24 * 60 * 60 * 1000;
+
+interface SubscriptionInput {
+  readonly id: string;
+  readonly status: string;
+  readonly cancel_at_period_end: boolean;
+  readonly items: {
+    readonly data: readonly {
+      readonly price: { readonly id: string };
+      readonly current_period_end?: number | null;
+    }[];
+  };
+}
+
+interface BillingCandidate {
+  readonly orgId: string;
+  readonly stripeSubscriptionId: string | null;
+}
+
+interface DowngradedSubscription {
+  readonly orgId: string;
+  readonly subscriptionId: string | null;
+  readonly status: string | null;
+}
+
+interface ReconcileBillingContext {
+  readonly db: Db;
+  readonly stripe: ReturnType<typeof getStripeClient>;
+  readonly now: Date;
+  readonly staleBefore: Date;
+  readonly signal: AbortSignal;
+}
+
+function subscriptionPeriodEnd(subscription: SubscriptionInput): Date | null {
+  const periodEndUnix = subscription.items.data[0]?.current_period_end;
+  return typeof periodEndUnix === "number"
+    ? new Date(periodEndUnix * 1000)
+    : null;
+}
+
+function subscriptionCanRefreshPaidThrough(
+  subscription: SubscriptionInput,
+): boolean {
+  return ENTITLEMENT_PERIOD_REFRESH_STATUSES.includes(
+    subscription.status as (typeof ENTITLEMENT_PERIOD_REFRESH_STATUSES)[number],
+  );
+}
+
+function subscriptionIsPaymentFailed(subscription: SubscriptionInput): boolean {
+  return PAYMENT_FAILED_SUBSCRIPTION_STATUSES.includes(
+    subscription.status as (typeof PAYMENT_FAILED_SUBSCRIPTION_STATUSES)[number],
+  );
+}
+
+function tierFromPriceId(priceId: string): OrgTier {
+  const priceMap = env("ZERO_PRICE");
+  if (priceMap) {
+    for (const [tier, ids] of Object.entries(priceMap)) {
+      if (ids.includes(priceId)) {
+        return tier as OrgTier;
+      }
+    }
+  }
+  throw new Error(`Unknown Stripe price ID: ${priceId}`);
+}
+
+async function reconcileBillingCandidate(
+  context: ReconcileBillingContext,
+  candidate: BillingCandidate,
+): Promise<DowngradedSubscription[]> {
+  const { db, stripe, now, staleBefore, signal } = context;
+  if (!candidate.stripeSubscriptionId) {
+    return [];
+  }
+
+  const subscription = (await stripe.subscriptions.retrieve(
+    candidate.stripeSubscriptionId,
+  )) as SubscriptionInput;
+  signal.throwIfAborted();
+
+  const stripePeriodEnd = subscriptionPeriodEnd(subscription);
+  const canRefreshPaidThrough = subscriptionCanRefreshPaidThrough(subscription);
+  const isPaymentFailed = subscriptionIsPaymentFailed(subscription);
+  const syncedFields = {
+    subscriptionStatus: subscription.status,
+    cancelAtPeriodEnd: subscription.cancel_at_period_end,
+    updatedAt: now,
+    ...(stripePeriodEnd ? { currentPeriodEnd: stripePeriodEnd } : {}),
+  };
+
+  const currentCandidate = and(
+    eq(orgMetadata.orgId, candidate.orgId),
+    eq(orgMetadata.stripeSubscriptionId, candidate.stripeSubscriptionId),
+    inArray(orgMetadata.tier, ["pro", "team"]),
+    inArray(orgMetadata.subscriptionStatus, [
+      ...PAYMENT_FAILED_SUBSCRIPTION_STATUSES,
+    ]),
+  );
+
+  if (subscription.status === "canceled") {
+    const rows = await db
+      .update(orgMetadata)
+      .set({
+        tier: "free",
+        subscriptionStatus: "canceled",
+        stripeSubscriptionId: null,
+        cancelAtPeriodEnd: false,
+        updatedAt: now,
+      })
+      .where(currentCandidate)
+      .returning({
+        orgId: orgMetadata.orgId,
+        status: orgMetadata.subscriptionStatus,
+      });
+    signal.throwIfAborted();
+
+    return rows.map((row) => {
+      return { ...row, subscriptionId: candidate.stripeSubscriptionId };
+    });
+  }
+
+  if (!isPaymentFailed) {
+    if (!canRefreshPaidThrough) {
+      L.warn(
+        "payment-failed local subscription has unexpected Stripe status; skipping downgrade",
+        {
+          orgId: candidate.orgId,
+          subscriptionId: candidate.stripeSubscriptionId,
+          status: subscription.status,
+        },
+      );
+      return [];
+    }
+
+    const priceId = subscription.items.data[0]?.price.id;
+    const tier = priceId ? tierFromPriceId(priceId) : undefined;
+
+    await db
+      .update(orgMetadata)
+      .set({
+        ...syncedFields,
+        ...(tier ? { tier } : {}),
+      })
+      .where(currentCandidate);
+    signal.throwIfAborted();
+    return [];
+  }
+
+  if (!stripePeriodEnd) {
+    L.warn(
+      "payment-failed subscription missing paid-through in Stripe; downgrading",
+      {
+        orgId: candidate.orgId,
+        subscriptionId: candidate.stripeSubscriptionId,
+        status: subscription.status,
+      },
+    );
+  } else if (stripePeriodEnd > staleBefore) {
+    await db.update(orgMetadata).set(syncedFields).where(currentCandidate);
+    signal.throwIfAborted();
+    return [];
+  }
+
+  const rows = await db
+    .update(orgMetadata)
+    .set({
+      tier: "free",
+      ...syncedFields,
+    })
+    .where(currentCandidate)
+    .returning({
+      orgId: orgMetadata.orgId,
+      subscriptionId: orgMetadata.stripeSubscriptionId,
+      status: orgMetadata.subscriptionStatus,
+    });
+  signal.throwIfAborted();
+  return rows;
+}
+
+export const reconcileBillingEntitlements$ = command(
+  async (
+    { set },
+    signal: AbortSignal,
+  ): Promise<{ readonly downgraded: number }> => {
+    const db = set(writeDb$);
+    const stripe = getStripeClient();
+    const now = nowDate();
+    const staleBefore = new Date(
+      now.getTime() - PAYMENT_FAILURE_DOWNGRADE_GRACE_MS,
+    );
+
+    const candidates = await db
+      .select({
+        orgId: orgMetadata.orgId,
+        stripeSubscriptionId: orgMetadata.stripeSubscriptionId,
+      })
+      .from(orgMetadata)
+      .where(
+        and(
+          inArray(orgMetadata.tier, ["pro", "team"]),
+          isNotNull(orgMetadata.stripeSubscriptionId),
+          inArray(orgMetadata.subscriptionStatus, [
+            ...PAYMENT_FAILED_SUBSCRIPTION_STATUSES,
+          ]),
+          or(
+            and(
+              isNull(orgMetadata.currentPeriodEnd),
+              lte(orgMetadata.updatedAt, staleBefore),
+            ),
+            lte(orgMetadata.currentPeriodEnd, staleBefore),
+          ),
+        ),
+      );
+    signal.throwIfAborted();
+
+    const downgraded: DowngradedSubscription[] = [];
+
+    for (const candidate of candidates) {
+      downgraded.push(
+        ...(await reconcileBillingCandidate(
+          { db, stripe, now, staleBefore, signal },
+          candidate,
+        )),
+      );
+    }
+
+    if (downgraded.length > 0) {
+      L.warn("stale payment-failed subscriptions downgraded", {
+        count: downgraded.length,
+        subscriptionIds: downgraded.slice(0, 10).map((row) => {
+          return row.subscriptionId;
+        }),
+      });
+    }
+
+    return { downgraded: downgraded.length };
+  },
+);

--- a/turbo/apps/api/src/signals/services/cron-process-usage-events.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-process-usage-events.service.ts
@@ -1,0 +1,24 @@
+import { usageEvent } from "@vm0/db/schema/usage-event";
+import { command } from "ccstate";
+import { eq } from "drizzle-orm";
+
+import { writeDb$ } from "../external/db";
+import { processOrgUsageEvents$ } from "./zero-credit-usage.service";
+
+export const processStaleUsageEvents$ = command(
+  async ({ set }, signal: AbortSignal): Promise<number> => {
+    const db = set(writeDb$);
+    const orgs = await db
+      .selectDistinct({ orgId: usageEvent.orgId })
+      .from(usageEvent)
+      .where(eq(usageEvent.status, "pending"));
+    signal.throwIfAborted();
+
+    for (const { orgId } of orgs) {
+      await set(processOrgUsageEvents$, orgId, signal);
+      signal.throwIfAborted();
+    }
+
+    return orgs.length;
+  },
+);

--- a/turbo/packages/api-contracts/src/contracts/cron.ts
+++ b/turbo/packages/api-contracts/src/contracts/cron.ts
@@ -47,5 +47,103 @@ export const cronCleanupSandboxesContract = c.router({
 
 export type CronCleanupSandboxesContract = typeof cronCleanupSandboxesContract;
 
+const cronAggregateUsageResponseSchema = z.object({
+  date: z.string(),
+  aggregated: z.number(),
+});
+
+const cronProcessUsageEventsResponseSchema = z.object({
+  success: z.literal(true),
+  processed: z.number(),
+});
+
+const cronReconcileBillingEntitlementsResponseSchema = z.object({
+  success: z.literal(true),
+  downgraded: z.number(),
+});
+
+const cronAggregateInsightsSkippedResponseSchema = z.object({
+  users: z.number(),
+  skipped: z.literal(true),
+});
+
+const cronAggregateInsightsAggregatedResponseSchema = z.object({
+  users: z.number(),
+  windows: z.number(),
+  networkRows: z.number(),
+});
+
+const cronAggregateInsightsResponseSchema = z.union([
+  cronAggregateInsightsSkippedResponseSchema,
+  cronAggregateInsightsAggregatedResponseSchema,
+]);
+
+export const cronAggregateUsageContract = c.router({
+  aggregate: {
+    method: "GET",
+    path: "/api/cron/aggregate-usage",
+    headers: authHeadersSchema,
+    responses: {
+      200: cronAggregateUsageResponseSchema,
+      401: apiErrorSchema,
+    },
+    summary: "Aggregate daily usage cache",
+  },
+});
+
+export const cronProcessUsageEventsContract = c.router({
+  process: {
+    method: "GET",
+    path: "/api/cron/process-usage-events",
+    headers: authHeadersSchema,
+    responses: {
+      200: cronProcessUsageEventsResponseSchema,
+      401: apiErrorSchema,
+    },
+    summary: "Process pending usage events",
+  },
+});
+
+export const cronReconcileBillingEntitlementsContract = c.router({
+  reconcile: {
+    method: "GET",
+    path: "/api/cron/reconcile-billing-entitlements",
+    headers: authHeadersSchema,
+    responses: {
+      200: cronReconcileBillingEntitlementsResponseSchema,
+      401: apiErrorSchema,
+    },
+    summary: "Reconcile billing entitlements",
+  },
+});
+
+export const cronAggregateInsightsContract = c.router({
+  aggregate: {
+    method: "GET",
+    path: "/api/cron/aggregate-insights",
+    headers: authHeadersSchema,
+    responses: {
+      200: cronAggregateInsightsResponseSchema,
+      401: apiErrorSchema,
+    },
+    summary: "Aggregate daily usage insights",
+  },
+});
+
+export type CronAggregateUsageContract = typeof cronAggregateUsageContract;
+export type CronProcessUsageEventsContract =
+  typeof cronProcessUsageEventsContract;
+export type CronReconcileBillingEntitlementsContract =
+  typeof cronReconcileBillingEntitlementsContract;
+export type CronAggregateInsightsContract =
+  typeof cronAggregateInsightsContract;
+
 // Export schemas for reuse
-export { cleanupResultSchema, cleanupResponseSchema };
+export {
+  cleanupResultSchema,
+  cleanupResponseSchema,
+  cronAggregateUsageResponseSchema,
+  cronProcessUsageEventsResponseSchema,
+  cronReconcileBillingEntitlementsResponseSchema,
+  cronAggregateInsightsResponseSchema,
+};

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -306,10 +306,22 @@ export {
   type InternalEventConsumerVoiceChatContract,
 } from "./internal-event-consumers";
 export {
+  cronAggregateInsightsContract,
+  cronAggregateInsightsResponseSchema,
+  cronAggregateUsageContract,
+  cronAggregateUsageResponseSchema,
   cronCleanupSandboxesContract,
+  cronProcessUsageEventsContract,
+  cronProcessUsageEventsResponseSchema,
+  cronReconcileBillingEntitlementsContract,
+  cronReconcileBillingEntitlementsResponseSchema,
   cleanupResultSchema,
   cleanupResponseSchema,
+  type CronAggregateInsightsContract,
+  type CronAggregateUsageContract,
   type CronCleanupSandboxesContract,
+  type CronProcessUsageEventsContract,
+  type CronReconcileBillingEntitlementsContract,
 } from "./cron";
 export {
   orgDefaultAgentContract,


### PR DESCRIPTION
## Summary
- add API contracts and Hono route handlers for usage/billing cron endpoints
- port aggregate usage, usage-event processing, billing entitlement reconciliation, and aggregate insights logic into `apps/api`
- add API integration coverage for cron auth, billing side effects, usage aggregation, and insight degradation behavior

Closes #12821

## Tests
- `pnpm format`
- `pnpm -F api exec vitest src/signals/routes/__tests__/cron-aggregate-usage.test.ts src/signals/routes/__tests__/cron-process-usage-events.test.ts src/signals/routes/__tests__/cron-reconcile-billing-entitlements.test.ts src/signals/routes/__tests__/cron-aggregate-insights.test.ts`
- `pnpm -F @vm0/api-contracts exec vitest`
- `pnpm turbo run lint`
- `pnpm check-types`
- `pnpm knip`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `git diff --check`

Note: full `pnpm vitest` was attempted locally and stopped after broad unrelated failures/hangs across existing web/API suites; the cron API tests above passed after that run.