### PR TITLE
feat(api): migrate telegram link route

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-telegram.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-telegram.test.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from "node:crypto";
+import { createHash, createHmac, randomUUID } from "node:crypto";
 
 import { integrationsTelegramBotListContract } from "@vm0/api-contracts/contracts/integrations";
 import {
@@ -15,6 +15,7 @@ import { server } from "../../../mocks/server";
 import { signSandboxJwtForTests } from "../../auth/tokens";
 import { mockEnv } from "../../../lib/env";
 import { now } from "../../external/time";
+import { clearAllDetached } from "../../utils";
 import { buildTelegramBotAvatarUrl } from "../../external/telegram-avatar";
 import {
   deleteOrgMembership$,
@@ -85,6 +86,70 @@ function telegramOauthHead(contentLength: string, expectedOrigin?: string) {
       headers: { "content-length": contentLength },
     });
   });
+}
+
+interface TelegramAuthTestData {
+  readonly id: number;
+  readonly first_name: string;
+  readonly username?: string;
+  readonly auth_date: number;
+  readonly hash: string;
+}
+
+function makeTelegramAuth(
+  telegramUserId: number,
+  username?: string,
+  botToken = "test-bot-token",
+): TelegramAuthTestData {
+  const authDate = Math.floor(now() / 1000);
+  const fields: Omit<TelegramAuthTestData, "hash"> = username
+    ? {
+        auth_date: authDate,
+        id: telegramUserId,
+        first_name: "Test",
+        username,
+      }
+    : {
+        auth_date: authDate,
+        id: telegramUserId,
+        first_name: "Test",
+      };
+
+  const checkString = Object.entries(fields)
+    .sort(([a], [b]) => {
+      return a.localeCompare(b);
+    })
+    .map(([key, value]) => {
+      return `${key}=${value}`;
+    })
+    .join("\n");
+
+  const secretKey = createHash("sha256").update(botToken).digest();
+  const hash = createHmac("sha256", secretKey)
+    .update(checkString)
+    .digest("hex");
+
+  return { ...fields, hash };
+}
+
+function signConnectParams(args: {
+  readonly installationId: string;
+  readonly telegramUserId: string;
+  readonly timestamp: number;
+  readonly botToken?: string;
+  readonly telegramUsername?: string;
+  readonly telegramDisplayName?: string;
+}): string {
+  let data = `${args.installationId}:${args.telegramUserId}:${args.timestamp}`;
+  if (args.telegramUsername || args.telegramDisplayName) {
+    data += `:${args.telegramUsername ?? ""}`;
+  }
+  if (args.telegramDisplayName) {
+    data += `:${args.telegramDisplayName}`;
+  }
+  return createHmac("sha256", args.botToken ?? "test-bot-token")
+    .update(data)
+    .digest("hex");
 }
 
 describe("GET /api/zero/integrations/telegram/bots", () => {
@@ -680,6 +745,412 @@ describe("GET /api/integrations/telegram/link", () => {
     );
 
     expect(response.body.error.code).toBe("FORBIDDEN");
+  });
+});
+
+describe("POST /api/integrations/telegram/link", () => {
+  const fixtures: TelegramFixture[] = [];
+  const memberships: OrgMembershipFixture[] = [];
+
+  beforeEach(() => {
+    configureOfficialBotEnv();
+    context.mocks.s3.send.mockResolvedValue({});
+  });
+
+  afterEach(async () => {
+    while (fixtures.length > 0) {
+      const fixture = fixtures.pop();
+      if (fixture) {
+        await store.set(deleteTelegramFixture$, fixture, context.signal);
+      }
+    }
+    while (memberships.length > 0) {
+      const membership = memberships.pop();
+      if (membership) {
+        await store.set(deleteOrgMembership$, membership, context.signal);
+      }
+    }
+  });
+
+  async function seedLinkContext(): Promise<{
+    readonly token: string;
+    readonly orgId: string;
+    readonly userId: string;
+  }> {
+    const orgId = `org_${randomUUID()}`;
+    const userId = `user_${randomUUID()}`;
+    const membership = await store.set(
+      seedOrgMembership$,
+      { orgId, userId, seedOrgCache: false },
+      context.signal,
+    );
+    memberships.push(membership);
+    fixtures.push(freezeTelegramFixture(makeTelegramFixtureBuilder(orgId)));
+    mocks.clerk.session(userId, orgId);
+    return {
+      token: "clerk-session",
+      orgId,
+      userId,
+    };
+  }
+
+  it("returns 401 when not authenticated", async () => {
+    const client = setupApp({ context })(zeroIntegrationsTelegramContract);
+
+    const response = await accept(
+      client.link({
+        headers: {},
+        body: { telegramBotId: "some-id" },
+      }),
+      [401],
+    );
+
+    expectUnauthorized(response.body);
+  });
+
+  it("returns 400 when telegramBotId is missing", async () => {
+    const { token } = await seedLinkContext();
+    const client = setupApp({ context })(zeroIntegrationsTelegramContract);
+
+    const response = await accept(
+      client.link({
+        headers: { authorization: `Bearer ${token}` },
+        body: {} as never,
+      }),
+      [400],
+    );
+
+    expect(response.body.error.code).toBe("BAD_REQUEST");
+  });
+
+  it("returns 404 when the custom bot installation does not exist", async () => {
+    const { token } = await seedLinkContext();
+    const client = setupApp({ context })(zeroIntegrationsTelegramContract);
+
+    const response = await accept(
+      client.link({
+        headers: { authorization: `Bearer ${token}` },
+        body: {
+          telegramBotId: newTelegramBotId(),
+          telegramAuth: makeTelegramAuth(99_001, "missing_bot"),
+        },
+      }),
+      [404],
+    );
+
+    expect(response.body.error.code).toBe("NOT_FOUND");
+  });
+
+  it("returns 400 without telegramAuth or connectSignature", async () => {
+    const { token, orgId, userId } = await seedLinkContext();
+    const telegramBotId = newTelegramBotId();
+    const builder = makeTelegramFixtureBuilder(orgId);
+    const installation = await store.set(
+      seedTelegramInstallation$,
+      { orgId, ownerUserId: userId, telegramBotId },
+      context.signal,
+    );
+    builder.composeIds.push(installation.composeId);
+    builder.telegramBotIds.push(installation.telegramBotId);
+    fixtures.push(freezeTelegramFixture(builder));
+    const client = setupApp({ context })(zeroIntegrationsTelegramContract);
+
+    const response = await accept(
+      client.link({
+        headers: { authorization: `Bearer ${token}` },
+        body: { telegramBotId },
+      }),
+      [400],
+    );
+
+    expect(response.body.error.code).toBe("BAD_REQUEST");
+    expect(response.body.error.message).toBe(
+      "Either telegramAuth or connectSignature is required",
+    );
+  });
+
+  it("links a custom bot account via Telegram Login Widget auth", async () => {
+    const { token, orgId, userId } = await seedLinkContext();
+    const telegramBotId = newTelegramBotId();
+    const builder = makeTelegramFixtureBuilder(orgId);
+    const installation = await store.set(
+      seedTelegramInstallation$,
+      { orgId, ownerUserId: userId, telegramBotId },
+      context.signal,
+    );
+    builder.composeIds.push(installation.composeId);
+    builder.telegramBotIds.push(installation.telegramBotId);
+    fixtures.push(freezeTelegramFixture(builder));
+    const client = setupApp({ context })(zeroIntegrationsTelegramContract);
+
+    const response = await accept(
+      client.link({
+        headers: { authorization: `Bearer ${token}` },
+        body: {
+          telegramBotId,
+          telegramAuth: makeTelegramAuth(99_002, "custom_tg"),
+        },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      botUsername: `bot_${telegramBotId}`,
+      telegramUserId: "99002",
+    });
+
+    const status = await accept(
+      client.getLinkStatus({
+        query: { botId: telegramBotId },
+        headers: { authorization: `Bearer ${token}` },
+      }),
+      [200],
+    );
+    expect(status.body).toMatchObject({
+      linked: true,
+      telegramUserId: "99002",
+      botUsername: `bot_${telegramBotId}`,
+    });
+  });
+
+  it("links the official bot account via Telegram Login Widget auth", async () => {
+    const { token } = await seedLinkContext();
+    const telegramUserId = Number(newTelegramBotId());
+    const client = setupApp({ context })(zeroIntegrationsTelegramContract);
+
+    const response = await accept(
+      client.link({
+        headers: { authorization: `Bearer ${token}` },
+        body: {
+          telegramBotId: OFFICIAL_TELEGRAM_BOT_ID,
+          telegramAuth: makeTelegramAuth(
+            telegramUserId,
+            "official_tg",
+            OFFICIAL_BOT_TOKEN,
+          ),
+        },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      botUsername: OFFICIAL_BOT_USERNAME,
+      telegramUserId: String(telegramUserId),
+    });
+  });
+
+  it("returns 409 when a Telegram user is already linked to another user for the same bot", async () => {
+    const { token, orgId, userId } = await seedLinkContext();
+    const telegramBotId = newTelegramBotId();
+    const builder = makeTelegramFixtureBuilder(orgId);
+    const installation = await store.set(
+      seedTelegramInstallation$,
+      { orgId, ownerUserId: userId, telegramBotId },
+      context.signal,
+    );
+    builder.composeIds.push(installation.composeId);
+    builder.telegramBotIds.push(installation.telegramBotId);
+    fixtures.push(freezeTelegramFixture(builder));
+    await store.set(
+      seedTelegramUserLink$,
+      {
+        installationId: telegramBotId,
+        telegramUserId: "99004",
+        vm0UserId: `user_${randomUUID()}`,
+      },
+      context.signal,
+    );
+    const client = setupApp({ context })(zeroIntegrationsTelegramContract);
+
+    const response = await accept(
+      client.link({
+        headers: { authorization: `Bearer ${token}` },
+        body: {
+          telegramBotId,
+          telegramAuth: makeTelegramAuth(99_004, "taken_tg"),
+        },
+      }),
+      [409],
+    );
+
+    expect(response.body.error.code).toBe("CONFLICT");
+    expect(response.body.error.message).toContain(
+      "already connected to another VM0 account",
+    );
+  });
+
+  it("links a custom bot account via a valid connectSignature and sends confirmation", async () => {
+    const { token, orgId, userId } = await seedLinkContext();
+    const telegramBotId = newTelegramBotId();
+    const builder = makeTelegramFixtureBuilder(orgId);
+    const installation = await store.set(
+      seedTelegramInstallation$,
+      { orgId, ownerUserId: userId, telegramBotId },
+      context.signal,
+    );
+    builder.composeIds.push(installation.composeId);
+    builder.telegramBotIds.push(installation.telegramBotId);
+    fixtures.push(freezeTelegramFixture(builder));
+    const sentMessages: {
+      readonly chat_id: string;
+      readonly text: string;
+    }[] = [];
+    server.use(
+      http.post(
+        "https://api.telegram.org/bottest-bot-token/sendMessage",
+        async ({ request }) => {
+          sentMessages.push(
+            (await request.json()) as { chat_id: string; text: string },
+          );
+          return HttpResponse.json({
+            ok: true,
+            result: { message_id: 1, chat: { id: 99_005 } },
+          });
+        },
+      ),
+    );
+    const timestamp = Math.floor(now() / 1000);
+    const telegramUserId = "99005";
+    const client = setupApp({ context })(zeroIntegrationsTelegramContract);
+
+    const response = await accept(
+      client.link({
+        headers: { authorization: `Bearer ${token}` },
+        body: {
+          telegramBotId,
+          connectSignature: {
+            telegramUserId,
+            telegramUsername: "connect_tg",
+            telegramDisplayName: "Connect User",
+            timestamp,
+            signature: signConnectParams({
+              installationId: telegramBotId,
+              telegramUserId,
+              timestamp,
+              telegramUsername: "connect_tg",
+              telegramDisplayName: "Connect User",
+            }),
+          },
+        },
+      }),
+      [200],
+    );
+
+    expect(response.body.telegramUserId).toBe(telegramUserId);
+    await clearAllDetached();
+    expect(sentMessages).toStrictEqual([
+      {
+        chat_id: telegramUserId,
+        parse_mode: "HTML",
+        text: "✅ Account linked.\nSend me a message to start chatting with your agent.",
+      },
+    ]);
+  });
+
+  it("returns 403 when connecting a custom bot from another org", async () => {
+    const { token } = await seedLinkContext();
+    const otherOrgId = `org_${randomUUID()}`;
+    const otherBotId = newTelegramBotId();
+    const builder = makeTelegramFixtureBuilder(otherOrgId);
+    const installation = await store.set(
+      seedTelegramInstallation$,
+      {
+        orgId: otherOrgId,
+        ownerUserId: `user_${randomUUID()}`,
+        telegramBotId: otherBotId,
+      },
+      context.signal,
+    );
+    builder.composeIds.push(installation.composeId);
+    builder.telegramBotIds.push(installation.telegramBotId);
+    fixtures.push(freezeTelegramFixture(builder));
+    const client = setupApp({ context })(zeroIntegrationsTelegramContract);
+
+    const response = await accept(
+      client.link({
+        headers: { authorization: `Bearer ${token}` },
+        body: {
+          telegramBotId: otherBotId,
+          telegramAuth: makeTelegramAuth(99_006),
+        },
+      }),
+      [403],
+    );
+
+    expect(response.body.error.code).toBe("FORBIDDEN");
+  });
+
+  it("returns 400 for invalid telegramAuth hash", async () => {
+    const { token, orgId, userId } = await seedLinkContext();
+    const telegramBotId = newTelegramBotId();
+    const builder = makeTelegramFixtureBuilder(orgId);
+    const installation = await store.set(
+      seedTelegramInstallation$,
+      { orgId, ownerUserId: userId, telegramBotId },
+      context.signal,
+    );
+    builder.composeIds.push(installation.composeId);
+    builder.telegramBotIds.push(installation.telegramBotId);
+    fixtures.push(freezeTelegramFixture(builder));
+    const client = setupApp({ context })(zeroIntegrationsTelegramContract);
+
+    const response = await accept(
+      client.link({
+        headers: { authorization: `Bearer ${token}` },
+        body: {
+          telegramBotId,
+          telegramAuth: {
+            id: 99_007,
+            first_name: "Test",
+            auth_date: Math.floor(now() / 1000),
+            hash: "invalid_hash",
+          },
+        },
+      }),
+      [400],
+    );
+
+    expect(response.body.error.message).toBe("Invalid Telegram authorization");
+  });
+
+  it("returns 400 for expired connectSignature", async () => {
+    const { token, orgId, userId } = await seedLinkContext();
+    const telegramBotId = newTelegramBotId();
+    const builder = makeTelegramFixtureBuilder(orgId);
+    const installation = await store.set(
+      seedTelegramInstallation$,
+      { orgId, ownerUserId: userId, telegramBotId },
+      context.signal,
+    );
+    builder.composeIds.push(installation.composeId);
+    builder.telegramBotIds.push(installation.telegramBotId);
+    fixtures.push(freezeTelegramFixture(builder));
+    const timestamp = Math.floor(now() / 1000) - 601;
+    const telegramUserId = "99008";
+    const client = setupApp({ context })(zeroIntegrationsTelegramContract);
+
+    const response = await accept(
+      client.link({
+        headers: { authorization: `Bearer ${token}` },
+        body: {
+          telegramBotId,
+          connectSignature: {
+            telegramUserId,
+            timestamp,
+            signature: signConnectParams({
+              installationId: telegramBotId,
+              telegramUserId,
+              timestamp,
+            }),
+          },
+        },
+      }),
+      [400],
+    );
+
+    expect(response.body.error.message).toContain(
+      "Invalid or expired connect link",
+    );
   });
 });
 

--- a/turbo/apps/api/src/signals/routes/integrations-telegram-link.ts
+++ b/turbo/apps/api/src/signals/routes/integrations-telegram-link.ts
@@ -1,4 +1,4 @@
-import { command } from "ccstate";
+import { command, type Setter } from "ccstate";
 import { and, eq, inArray } from "drizzle-orm";
 import {
   OFFICIAL_TELEGRAM_BOT_ID,
@@ -7,17 +7,151 @@ import {
 import { telegramInstallations } from "@vm0/db/schema/telegram-installation";
 import { telegramOfficialUserLinks } from "@vm0/db/schema/telegram-official-user-link";
 import { telegramUserLinks } from "@vm0/db/schema/telegram-user-link";
+import type { z } from "zod";
 
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
-import { queryOf } from "../context/request";
+import { waitUntil } from "../context/wait-until";
+import { bodyResultOf, queryOf } from "../context/request";
 import { writeDb$ } from "../external/db";
+import {
+  getOfficialTelegramBotConfig,
+  isOfficialTelegramBotId,
+} from "../external/telegram-official";
+import { sendMessage } from "../external/telegram-client";
 import { publishUserSignal } from "../external/realtime";
 import { logger } from "../../lib/log";
 import { safeAsync } from "../utils";
+import {
+  ensureTelegramArtifactStorage$,
+  formatTelegramUserDisplayName,
+  linkOfficialTelegramUserToVm0User$,
+  linkTelegramUserToVm0User$,
+  telegramInstallationForLink,
+  type TelegramInstallationForLink,
+  verifyConnectSignature,
+  verifyTelegramLogin,
+  type LinkOfficialTelegramUserResult,
+  type LinkTelegramUserResult,
+} from "../services/zero-telegram-link.service";
+import type { AuthContext } from "../../types/auth";
 import type { RouteEntry } from "../route";
 
 const log = logger("api:telegram:link");
+
+type TelegramLinkBody = z.infer<
+  typeof zeroIntegrationsTelegramContract.link.body
+>;
+type OrganizationAuth = AuthContext & { readonly orgId: string };
+type ErrorStatus = 400 | 403 | 404 | 409;
+type LinkTelegramUserConflictReason = Extract<
+  LinkTelegramUserResult,
+  { readonly ok: false }
+>["reason"];
+type LinkOfficialTelegramUserConflictReason = Extract<
+  LinkOfficialTelegramUserResult,
+  { readonly ok: false }
+>["reason"];
+
+function errorResult(status: ErrorStatus, message: string, code: string) {
+  return {
+    status,
+    body: {
+      error: { message, code },
+    },
+  };
+}
+
+function orgMismatchResponse() {
+  return errorResult(
+    403,
+    "This Telegram bot belongs to a different organization. Switch to the bot's organization to connect.",
+    "FORBIDDEN",
+  );
+}
+
+function missingAuthMethodResponse() {
+  return errorResult(
+    400,
+    "Either telegramAuth or connectSignature is required",
+    "BAD_REQUEST",
+  );
+}
+
+function invalidTelegramAuthResponse() {
+  return errorResult(400, "Invalid Telegram authorization", "BAD_REQUEST");
+}
+
+function invalidConnectSignatureResponse() {
+  return errorResult(
+    400,
+    "Invalid or expired connect link. Please use /connect again in Telegram.",
+    "BAD_REQUEST",
+  );
+}
+
+function linkConflictResponse(reason: LinkTelegramUserConflictReason) {
+  const message =
+    reason === "telegram-user-linked"
+      ? "This Telegram account is already connected to another VM0 account for this bot. Disconnect it before connecting a different account."
+      : reason === "vm0-user-linked"
+        ? "Your VM0 account is already connected to another Telegram account for this bot. Disconnect it before connecting a different Telegram account."
+        : "This Telegram account link already exists. Disconnect it first and try again.";
+
+  return errorResult(409, message, "CONFLICT");
+}
+
+function officialLinkConflictResponse(
+  reason: LinkOfficialTelegramUserConflictReason,
+) {
+  const message =
+    reason === "telegram-user-linked"
+      ? "This Telegram account is already connected to another VM0 organization through the official Zero bot. Disconnect it before connecting a different account."
+      : reason === "vm0-org-linked"
+        ? "Your VM0 account is already connected to another Telegram account for the official Zero bot in this organization. Disconnect it before connecting a different Telegram account."
+        : "This official Telegram account link already exists. Disconnect it first and try again.";
+
+  return errorResult(409, message, "CONFLICT");
+}
+
+function linkSuccessResponse(botUsername: string, telegramUserId: string) {
+  return {
+    status: 200 as const,
+    body: {
+      botUsername,
+      telegramUserId,
+    },
+  };
+}
+
+function sendConnectSuccessMessage(args: {
+  readonly botToken: string;
+  readonly telegramUserId: string;
+  readonly official: boolean;
+}): void {
+  const text = args.official
+    ? "✅ Account linked.\nSend me a message to start chatting with Zero."
+    : "✅ Account linked.\nSend me a message to start chatting with your agent.";
+
+  waitUntil(
+    sendMessage(args.botToken, args.telegramUserId, text)
+      .then((result) => {
+        if (result.kind === "telegram-error") {
+          log.warn("Failed to send Telegram connect success message", {
+            telegramUserId: args.telegramUserId,
+            status: result.status,
+            description: result.description,
+          });
+        }
+      })
+      .catch((error: unknown) => {
+        log.warn("Failed to send Telegram connect success message", {
+          telegramUserId: args.telegramUserId,
+          error,
+        });
+      }),
+  );
+}
 
 function noLinkedTelegramAccountResponse() {
   return {
@@ -94,7 +228,279 @@ const unlinkInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   return { status: 204 as const, body: undefined };
 });
 
+const ensureLinkArtifactStorage$ = command(
+  async (
+    { set },
+    auth: OrganizationAuth,
+    signal: AbortSignal,
+  ): Promise<void> => {
+    await set(
+      ensureTelegramArtifactStorage$,
+      { orgId: auth.orgId, userId: auth.userId },
+      signal,
+    );
+    signal.throwIfAborted();
+  },
+);
+
+const linkOfficialInner$ = command(
+  async (
+    { set },
+    args: { readonly auth: OrganizationAuth; readonly body: TelegramLinkBody },
+    signal: AbortSignal,
+  ) => {
+    const config = getOfficialTelegramBotConfig();
+    if (!config.botToken) {
+      return errorResult(
+        404,
+        "Official Telegram bot is not configured",
+        "NOT_FOUND",
+      );
+    }
+
+    const telegramAuth = args.body.telegramAuth;
+    if (telegramAuth) {
+      if (!verifyTelegramLogin(telegramAuth, config.botToken)) {
+        return invalidTelegramAuthResponse();
+      }
+
+      const telegramUserId = String(telegramAuth.id);
+      const result = await set(
+        linkOfficialTelegramUserToVm0User$,
+        {
+          telegramUserId,
+          telegramUsername: telegramAuth.username,
+          telegramDisplayName: formatTelegramUserDisplayName(telegramAuth),
+          vm0UserId: args.auth.userId,
+          orgId: args.auth.orgId,
+        },
+        signal,
+      );
+      signal.throwIfAborted();
+
+      if (!result.ok) {
+        return officialLinkConflictResponse(result.reason);
+      }
+
+      await set(ensureLinkArtifactStorage$, args.auth, signal);
+
+      return linkSuccessResponse(config.botUsername ?? "Zero", telegramUserId);
+    }
+
+    const connectSignature = args.body.connectSignature;
+    if (connectSignature) {
+      if (
+        !verifyConnectSignature({
+          installationId: OFFICIAL_TELEGRAM_BOT_ID,
+          telegramUserId: connectSignature.telegramUserId,
+          timestamp: connectSignature.timestamp,
+          signature: connectSignature.signature,
+          botToken: config.botToken,
+          telegramUsername: connectSignature.telegramUsername,
+          telegramDisplayName: connectSignature.telegramDisplayName,
+        })
+      ) {
+        return invalidConnectSignatureResponse();
+      }
+
+      const result = await set(
+        linkOfficialTelegramUserToVm0User$,
+        {
+          telegramUserId: connectSignature.telegramUserId,
+          telegramUsername: connectSignature.telegramUsername,
+          telegramDisplayName: connectSignature.telegramDisplayName,
+          vm0UserId: args.auth.userId,
+          orgId: args.auth.orgId,
+        },
+        signal,
+      );
+      signal.throwIfAborted();
+
+      if (!result.ok) {
+        return officialLinkConflictResponse(result.reason);
+      }
+
+      await set(ensureLinkArtifactStorage$, args.auth, signal);
+
+      sendConnectSuccessMessage({
+        botToken: config.botToken,
+        telegramUserId: connectSignature.telegramUserId,
+        official: true,
+      });
+
+      return linkSuccessResponse(
+        config.botUsername ?? "Zero",
+        connectSignature.telegramUserId,
+      );
+    }
+
+    return missingAuthMethodResponse();
+  },
+);
+
+async function linkCustomWithTelegramAuth(args: {
+  readonly set: Setter;
+  readonly auth: OrganizationAuth;
+  readonly body: TelegramLinkBody;
+  readonly installation: TelegramInstallationForLink;
+  readonly signal: AbortSignal;
+}) {
+  const telegramAuth = args.body.telegramAuth;
+  if (!telegramAuth) {
+    return missingAuthMethodResponse();
+  }
+
+  if (!verifyTelegramLogin(telegramAuth, args.installation.botToken)) {
+    return invalidTelegramAuthResponse();
+  }
+
+  const telegramUserId = String(telegramAuth.id);
+  const result = await args.set(
+    linkTelegramUserToVm0User$,
+    {
+      installationId: args.installation.telegramBotId,
+      telegramUserId,
+      telegramUsername: telegramAuth.username,
+      telegramDisplayName: formatTelegramUserDisplayName(telegramAuth),
+      vm0UserId: args.auth.userId,
+    },
+    args.signal,
+  );
+  args.signal.throwIfAborted();
+
+  if (!result.ok) {
+    return linkConflictResponse(result.reason);
+  }
+
+  await args.set(ensureLinkArtifactStorage$, args.auth, args.signal);
+  return linkSuccessResponse(
+    args.installation.botUsername ?? "Telegram bot",
+    telegramUserId,
+  );
+}
+
+async function linkCustomWithConnectSignature(args: {
+  readonly set: Setter;
+  readonly auth: OrganizationAuth;
+  readonly body: TelegramLinkBody;
+  readonly installation: TelegramInstallationForLink;
+  readonly signal: AbortSignal;
+}) {
+  const connectSignature = args.body.connectSignature;
+  if (!connectSignature) {
+    return missingAuthMethodResponse();
+  }
+
+  if (
+    !verifyConnectSignature({
+      installationId: args.installation.telegramBotId,
+      telegramUserId: connectSignature.telegramUserId,
+      timestamp: connectSignature.timestamp,
+      signature: connectSignature.signature,
+      botToken: args.installation.botToken,
+      telegramUsername: connectSignature.telegramUsername,
+      telegramDisplayName: connectSignature.telegramDisplayName,
+    })
+  ) {
+    return invalidConnectSignatureResponse();
+  }
+
+  const result = await args.set(
+    linkTelegramUserToVm0User$,
+    {
+      installationId: args.installation.telegramBotId,
+      telegramUserId: connectSignature.telegramUserId,
+      telegramUsername: connectSignature.telegramUsername,
+      telegramDisplayName: connectSignature.telegramDisplayName,
+      vm0UserId: args.auth.userId,
+    },
+    args.signal,
+  );
+  args.signal.throwIfAborted();
+
+  if (!result.ok) {
+    return linkConflictResponse(result.reason);
+  }
+
+  await args.set(ensureLinkArtifactStorage$, args.auth, args.signal);
+
+  sendConnectSuccessMessage({
+    botToken: args.installation.botToken,
+    telegramUserId: connectSignature.telegramUserId,
+    official: false,
+  });
+
+  return linkSuccessResponse(
+    args.installation.botUsername ?? "Telegram bot",
+    connectSignature.telegramUserId,
+  );
+}
+
+const linkCustomInner$ = command(
+  async (
+    { get, set },
+    args: { readonly auth: OrganizationAuth; readonly body: TelegramLinkBody },
+    signal: AbortSignal,
+  ) => {
+    const installation = await get(
+      telegramInstallationForLink({ botId: args.body.telegramBotId }),
+    );
+    signal.throwIfAborted();
+
+    if (!installation) {
+      return errorResult(404, "Installation not found", "NOT_FOUND");
+    }
+    if (installation.orgId !== args.auth.orgId) {
+      return orgMismatchResponse();
+    }
+
+    if (args.body.telegramAuth) {
+      return linkCustomWithTelegramAuth({
+        set,
+        auth: args.auth,
+        body: args.body,
+        installation,
+        signal,
+      });
+    }
+
+    if (args.body.connectSignature) {
+      return linkCustomWithConnectSignature({
+        set,
+        auth: args.auth,
+        body: args.body,
+        installation,
+        signal,
+      });
+    }
+
+    return missingAuthMethodResponse();
+  },
+);
+
+const linkInner$ = command(async ({ get, set }, signal: AbortSignal) => {
+  const auth = get(organizationAuthContext$);
+  const body = await get(bodyResultOf(zeroIntegrationsTelegramContract.link));
+  signal.throwIfAborted();
+
+  if (!body.ok) {
+    return body.response;
+  }
+
+  const linkCommand = isOfficialTelegramBotId(body.data.telegramBotId)
+    ? linkOfficialInner$
+    : linkCustomInner$;
+  return set(linkCommand, { auth, body: body.data }, signal);
+});
+
 export const integrationsTelegramLinkRoutes: readonly RouteEntry[] = [
+  {
+    route: zeroIntegrationsTelegramContract.link,
+    handler: authRoute(
+      { requireOrganization: true, missingOrganizationStatus: 401 },
+      linkInner$,
+    ),
+  },
   {
     route: zeroIntegrationsTelegramContract.unlink,
     handler: authRoute(

--- a/turbo/apps/api/src/signals/services/zero-telegram-link.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-telegram-link.service.ts
@@ -1,0 +1,585 @@
+import { createHash, createHmac, timingSafeEqual } from "node:crypto";
+import { gzipSync } from "node:zlib";
+
+import { command, computed, type Computed } from "ccstate";
+import { and, eq } from "drizzle-orm";
+import { storages, storageVersions } from "@vm0/db/schema/storage";
+import { telegramInstallations } from "@vm0/db/schema/telegram-installation";
+import { telegramOfficialUserLinks } from "@vm0/db/schema/telegram-official-user-link";
+import { telegramUserLinks } from "@vm0/db/schema/telegram-user-link";
+
+import { env } from "../../lib/env";
+import { logger } from "../../lib/log";
+import { now, nowDate } from "../external/time";
+import { db$, writeDb$ } from "../external/db";
+import { publishUserSignal } from "../external/realtime";
+import { putS3Object } from "../external/s3";
+import { safeAsync } from "../utils";
+import { computeContentHashFromHashes } from "./storage-content-hash.service";
+import { decryptSecretValue } from "./crypto.utils";
+
+const L = logger("api:telegram:link");
+const PENDING_TELEGRAM_USER_ID = "pending";
+const MAX_AUTH_AGE_SECONDS = 300;
+const MAX_CONNECT_AGE_SECONDS = 600;
+
+type TelegramUserLink = typeof telegramUserLinks.$inferSelect;
+type OfficialTelegramUserLink = typeof telegramOfficialUserLinks.$inferSelect;
+
+interface TelegramAuthData {
+  readonly id: number;
+  readonly first_name?: string;
+  readonly last_name?: string;
+  readonly username?: string;
+  readonly photo_url?: string;
+  readonly auth_date: number;
+  readonly hash: string;
+}
+
+export type LinkTelegramUserResult =
+  | { readonly ok: true; readonly userLink: TelegramUserLink }
+  | {
+      readonly ok: false;
+      readonly reason: "telegram-user-linked" | "vm0-user-linked" | "conflict";
+      readonly userLink?: TelegramUserLink;
+    };
+
+export type LinkOfficialTelegramUserResult =
+  | { readonly ok: true; readonly userLink: OfficialTelegramUserLink }
+  | {
+      readonly ok: false;
+      readonly reason: "telegram-user-linked" | "vm0-org-linked" | "conflict";
+      readonly userLink?: OfficialTelegramUserLink;
+    };
+
+export interface TelegramInstallationForLink {
+  readonly telegramBotId: string;
+  readonly botUsername: string | null;
+  readonly botToken: string;
+  readonly orgId: string;
+}
+
+function telegramUserProfileUpdate(
+  params: {
+    readonly telegramUsername?: string | null;
+    readonly telegramDisplayName?: string | null;
+  },
+  existing: {
+    readonly telegramUsername: string | null;
+    readonly telegramDisplayName: string | null;
+  },
+) {
+  return {
+    telegramUsername:
+      params.telegramUsername === undefined
+        ? existing.telegramUsername
+        : normalizeTelegramUsername(params.telegramUsername),
+    telegramDisplayName:
+      params.telegramDisplayName === undefined
+        ? existing.telegramDisplayName
+        : normalizeTelegramDisplayName(params.telegramDisplayName),
+    updatedAt: nowDate(),
+  };
+}
+
+function normalizeTelegramUsername(
+  telegramUsername: string | null | undefined,
+): string | null {
+  const value = telegramUsername?.trim().replace(/^@+/, "");
+  return value || null;
+}
+
+function normalizeTelegramDisplayName(
+  telegramDisplayName: string | null | undefined,
+): string | null {
+  const value = telegramDisplayName?.trim().replace(/\s+/g, " ");
+  return value ? value.slice(0, 255) : null;
+}
+
+export function formatTelegramUserDisplayName(user: {
+  readonly first_name?: string;
+  readonly last_name?: string;
+}): string | null {
+  return normalizeTelegramDisplayName(
+    [user.first_name, user.last_name]
+      .map((part) => {
+        return part?.trim();
+      })
+      .filter(Boolean)
+      .join(" "),
+  );
+}
+
+function timingSafeHexEqual(left: string, right: string): boolean {
+  const leftBuffer = Buffer.from(left, "hex");
+  const rightBuffer = Buffer.from(right, "hex");
+  if (leftBuffer.length !== rightBuffer.length) {
+    return false;
+  }
+  return timingSafeEqual(leftBuffer, rightBuffer);
+}
+
+export function verifyTelegramLogin(
+  auth: TelegramAuthData,
+  botToken: string,
+): boolean {
+  const nowSeconds = Math.floor(now() / 1000);
+  if (nowSeconds - auth.auth_date > MAX_AUTH_AGE_SECONDS) {
+    return false;
+  }
+
+  const checkString = Object.entries(auth)
+    .filter(([key]) => {
+      return key !== "hash";
+    })
+    .filter(([, value]) => {
+      return value !== undefined;
+    })
+    .sort(([a], [b]) => {
+      return a.localeCompare(b);
+    })
+    .map(([key, value]) => {
+      return `${key}=${value}`;
+    })
+    .join("\n");
+
+  const secretKey = createHash("sha256").update(botToken).digest();
+  const hmac = createHmac("sha256", secretKey)
+    .update(checkString)
+    .digest("hex");
+
+  return timingSafeHexEqual(hmac, auth.hash);
+}
+
+function signConnectParams(args: {
+  readonly installationId: string;
+  readonly telegramUserId: string;
+  readonly timestamp: number;
+  readonly botToken: string;
+  readonly telegramUsername?: string | null;
+  readonly telegramDisplayName?: string | null;
+}): string {
+  const normalizedTelegramUsername = normalizeTelegramUsername(
+    args.telegramUsername,
+  );
+  const normalizedTelegramDisplayName = normalizeTelegramDisplayName(
+    args.telegramDisplayName,
+  );
+  let data = `${args.installationId}:${args.telegramUserId}:${args.timestamp}`;
+  if (normalizedTelegramUsername || normalizedTelegramDisplayName) {
+    data += `:${normalizedTelegramUsername ?? ""}`;
+  }
+  if (normalizedTelegramDisplayName) {
+    data += `:${normalizedTelegramDisplayName}`;
+  }
+  return createHmac("sha256", args.botToken).update(data).digest("hex");
+}
+
+export function verifyConnectSignature(args: {
+  readonly installationId: string;
+  readonly telegramUserId: string;
+  readonly timestamp: number;
+  readonly signature: string;
+  readonly botToken: string;
+  readonly telegramUsername?: string | null;
+  readonly telegramDisplayName?: string | null;
+}): boolean {
+  const nowSeconds = Math.floor(now() / 1000);
+  if (nowSeconds - args.timestamp > MAX_CONNECT_AGE_SECONDS) {
+    return false;
+  }
+
+  const expected = signConnectParams(args);
+  return timingSafeHexEqual(expected, args.signature);
+}
+
+async function publishTelegramUserChanged(userId: string): Promise<void> {
+  const publishResult = await safeAsync(() => {
+    return publishUserSignal([userId], "telegram:changed");
+  });
+  if ("error" in publishResult) {
+    L.warn("Failed to publish Telegram user change", {
+      error: publishResult.error,
+    });
+  }
+}
+
+export function telegramInstallationForLink(args: {
+  readonly botId: string;
+}): Computed<Promise<TelegramInstallationForLink | null>> {
+  return computed(async (get): Promise<TelegramInstallationForLink | null> => {
+    const db = get(db$);
+    const [row] = await db
+      .select({
+        telegramBotId: telegramInstallations.telegramBotId,
+        botUsername: telegramInstallations.botUsername,
+        encryptedBotToken: telegramInstallations.encryptedBotToken,
+        orgId: telegramInstallations.orgId,
+      })
+      .from(telegramInstallations)
+      .where(eq(telegramInstallations.telegramBotId, args.botId))
+      .limit(1);
+
+    if (!row) {
+      return null;
+    }
+
+    return {
+      telegramBotId: row.telegramBotId,
+      botUsername: row.botUsername ?? null,
+      botToken: decryptSecretValue(row.encryptedBotToken),
+      orgId: row.orgId,
+    };
+  });
+}
+
+function createEmptyTarGz(): Buffer {
+  return gzipSync(Buffer.alloc(1024, 0));
+}
+
+export const ensureTelegramArtifactStorage$ = command(
+  async (
+    { get, set },
+    args: { readonly orgId: string; readonly userId: string },
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const writeDb = set(writeDb$);
+    const [storage] = await writeDb
+      .insert(storages)
+      .values({
+        name: "artifact",
+        type: "artifact",
+        userId: args.userId,
+        s3Prefix: `${args.orgId}/artifact/artifact`,
+        size: 0,
+        fileCount: 0,
+        orgId: args.orgId,
+      })
+      .onConflictDoNothing()
+      .returning();
+    signal.throwIfAborted();
+
+    const [currentStorage] = storage
+      ? [storage]
+      : await writeDb
+          .select()
+          .from(storages)
+          .where(
+            and(
+              eq(storages.orgId, args.orgId),
+              eq(storages.userId, args.userId),
+              eq(storages.name, "artifact"),
+              eq(storages.type, "artifact"),
+            ),
+          )
+          .limit(1);
+    signal.throwIfAborted();
+
+    if (!currentStorage || currentStorage.headVersionId) {
+      return;
+    }
+
+    const versionId = computeContentHashFromHashes(currentStorage.id, []);
+    const s3Key = `${currentStorage.s3Prefix}/${versionId}`;
+    const bucketName = env("R2_USER_STORAGES_BUCKET_NAME");
+
+    await Promise.all([
+      get(
+        putS3Object(
+          bucketName,
+          `${s3Key}/manifest.json`,
+          JSON.stringify({ files: [] }),
+          "application/json",
+        ),
+      ),
+      get(
+        putS3Object(
+          bucketName,
+          `${s3Key}/archive.tar.gz`,
+          createEmptyTarGz(),
+          "application/gzip",
+        ),
+      ),
+    ]);
+    signal.throwIfAborted();
+
+    await writeDb.transaction(async (tx) => {
+      await tx
+        .insert(storageVersions)
+        .values({
+          id: versionId,
+          storageId: currentStorage.id,
+          s3Key,
+          size: 0,
+          fileCount: 0,
+          message: "Initial empty artifact (auto-created)",
+          createdBy: "user",
+        })
+        .onConflictDoNothing();
+
+      await tx
+        .update(storages)
+        .set({
+          headVersionId: versionId,
+          size: 0,
+          fileCount: 0,
+          updatedAt: nowDate(),
+        })
+        .where(eq(storages.id, currentStorage.id));
+    });
+    signal.throwIfAborted();
+  },
+);
+
+export const linkTelegramUserToVm0User$ = command(
+  async (
+    { set },
+    params: {
+      readonly installationId: string;
+      readonly telegramUserId: string;
+      readonly telegramUsername?: string | null;
+      readonly telegramDisplayName?: string | null;
+      readonly vm0UserId: string;
+    },
+    signal: AbortSignal,
+  ): Promise<LinkTelegramUserResult> => {
+    const writeDb = set(writeDb$);
+    const [existingTelegramLink] = await writeDb
+      .select()
+      .from(telegramUserLinks)
+      .where(
+        and(
+          eq(telegramUserLinks.installationId, params.installationId),
+          eq(telegramUserLinks.telegramUserId, params.telegramUserId),
+        ),
+      )
+      .limit(1);
+    signal.throwIfAborted();
+
+    if (existingTelegramLink) {
+      if (existingTelegramLink.vm0UserId !== params.vm0UserId) {
+        return {
+          ok: false,
+          reason: "telegram-user-linked",
+          userLink: existingTelegramLink,
+        };
+      }
+
+      const [updated] = await writeDb
+        .update(telegramUserLinks)
+        .set(telegramUserProfileUpdate(params, existingTelegramLink))
+        .where(eq(telegramUserLinks.id, existingTelegramLink.id))
+        .returning();
+      signal.throwIfAborted();
+
+      await publishTelegramUserChanged(params.vm0UserId);
+      signal.throwIfAborted();
+      return { ok: true, userLink: updated ?? existingTelegramLink };
+    }
+
+    const [existingVm0Link] = await writeDb
+      .select()
+      .from(telegramUserLinks)
+      .where(
+        and(
+          eq(telegramUserLinks.installationId, params.installationId),
+          eq(telegramUserLinks.vm0UserId, params.vm0UserId),
+        ),
+      )
+      .limit(1);
+    signal.throwIfAborted();
+
+    if (existingVm0Link) {
+      if (existingVm0Link.telegramUserId === params.telegramUserId) {
+        const [updated] = await writeDb
+          .update(telegramUserLinks)
+          .set(telegramUserProfileUpdate(params, existingVm0Link))
+          .where(eq(telegramUserLinks.id, existingVm0Link.id))
+          .returning();
+        signal.throwIfAborted();
+
+        await publishTelegramUserChanged(params.vm0UserId);
+        signal.throwIfAborted();
+        return { ok: true, userLink: updated ?? existingVm0Link };
+      }
+
+      if (
+        existingVm0Link.telegramUserId === PENDING_TELEGRAM_USER_ID &&
+        params.telegramUserId !== PENDING_TELEGRAM_USER_ID
+      ) {
+        const [updated] = await writeDb
+          .update(telegramUserLinks)
+          .set({
+            telegramUserId: params.telegramUserId,
+            telegramUsername: normalizeTelegramUsername(
+              params.telegramUsername,
+            ),
+            telegramDisplayName: normalizeTelegramDisplayName(
+              params.telegramDisplayName,
+            ),
+            updatedAt: nowDate(),
+          })
+          .where(eq(telegramUserLinks.id, existingVm0Link.id))
+          .returning();
+        signal.throwIfAborted();
+
+        await publishTelegramUserChanged(params.vm0UserId);
+        signal.throwIfAborted();
+        return { ok: true, userLink: updated ?? existingVm0Link };
+      }
+
+      return {
+        ok: false,
+        reason: "vm0-user-linked",
+        userLink: existingVm0Link,
+      };
+    }
+
+    const [inserted] = await writeDb
+      .insert(telegramUserLinks)
+      .values({
+        telegramUserId: params.telegramUserId,
+        telegramUsername: normalizeTelegramUsername(params.telegramUsername),
+        telegramDisplayName: normalizeTelegramDisplayName(
+          params.telegramDisplayName,
+        ),
+        installationId: params.installationId,
+        vm0UserId: params.vm0UserId,
+      })
+      .onConflictDoNothing()
+      .returning();
+    signal.throwIfAborted();
+
+    if (inserted) {
+      await publishTelegramUserChanged(params.vm0UserId);
+      signal.throwIfAborted();
+      return { ok: true, userLink: inserted };
+    }
+
+    return { ok: false, reason: "conflict" };
+  },
+);
+
+export const linkOfficialTelegramUserToVm0User$ = command(
+  async (
+    { set },
+    params: {
+      readonly telegramUserId: string;
+      readonly telegramUsername?: string | null;
+      readonly telegramDisplayName?: string | null;
+      readonly vm0UserId: string;
+      readonly orgId: string;
+    },
+    signal: AbortSignal,
+  ): Promise<LinkOfficialTelegramUserResult> => {
+    const writeDb = set(writeDb$);
+    const [existingTelegramLink] = await writeDb
+      .select()
+      .from(telegramOfficialUserLinks)
+      .where(
+        eq(telegramOfficialUserLinks.telegramUserId, params.telegramUserId),
+      )
+      .limit(1);
+    signal.throwIfAborted();
+
+    if (existingTelegramLink) {
+      if (
+        existingTelegramLink.vm0UserId !== params.vm0UserId ||
+        existingTelegramLink.orgId !== params.orgId
+      ) {
+        return {
+          ok: false,
+          reason: "telegram-user-linked",
+          userLink: existingTelegramLink,
+        };
+      }
+
+      const [updated] = await writeDb
+        .update(telegramOfficialUserLinks)
+        .set({
+          telegramUsername:
+            params.telegramUsername === undefined
+              ? existingTelegramLink.telegramUsername
+              : normalizeTelegramUsername(params.telegramUsername),
+          telegramDisplayName:
+            params.telegramDisplayName === undefined
+              ? existingTelegramLink.telegramDisplayName
+              : normalizeTelegramDisplayName(params.telegramDisplayName),
+          updatedAt: nowDate(),
+        })
+        .where(eq(telegramOfficialUserLinks.id, existingTelegramLink.id))
+        .returning();
+      signal.throwIfAborted();
+
+      await publishTelegramUserChanged(params.vm0UserId);
+      signal.throwIfAborted();
+      return { ok: true, userLink: updated ?? existingTelegramLink };
+    }
+
+    const [existingVm0OrgLink] = await writeDb
+      .select()
+      .from(telegramOfficialUserLinks)
+      .where(
+        and(
+          eq(telegramOfficialUserLinks.vm0UserId, params.vm0UserId),
+          eq(telegramOfficialUserLinks.orgId, params.orgId),
+        ),
+      )
+      .limit(1);
+    signal.throwIfAborted();
+
+    if (existingVm0OrgLink) {
+      if (existingVm0OrgLink.telegramUserId === params.telegramUserId) {
+        const [updated] = await writeDb
+          .update(telegramOfficialUserLinks)
+          .set({
+            telegramUsername:
+              params.telegramUsername === undefined
+                ? existingVm0OrgLink.telegramUsername
+                : normalizeTelegramUsername(params.telegramUsername),
+            telegramDisplayName:
+              params.telegramDisplayName === undefined
+                ? existingVm0OrgLink.telegramDisplayName
+                : normalizeTelegramDisplayName(params.telegramDisplayName),
+            updatedAt: nowDate(),
+          })
+          .where(eq(telegramOfficialUserLinks.id, existingVm0OrgLink.id))
+          .returning();
+        signal.throwIfAborted();
+
+        await publishTelegramUserChanged(params.vm0UserId);
+        signal.throwIfAborted();
+        return { ok: true, userLink: updated ?? existingVm0OrgLink };
+      }
+
+      return {
+        ok: false,
+        reason: "vm0-org-linked",
+        userLink: existingVm0OrgLink,
+      };
+    }
+
+    const [inserted] = await writeDb
+      .insert(telegramOfficialUserLinks)
+      .values({
+        telegramUserId: params.telegramUserId,
+        telegramUsername: normalizeTelegramUsername(params.telegramUsername),
+        telegramDisplayName: normalizeTelegramDisplayName(
+          params.telegramDisplayName,
+        ),
+        vm0UserId: params.vm0UserId,
+        orgId: params.orgId,
+      })
+      .onConflictDoNothing()
+      .returning();
+    signal.throwIfAborted();
+
+    if (inserted) {
+      await publishTelegramUserChanged(params.vm0UserId);
+      signal.throwIfAborted();
+      return { ok: true, userLink: inserted };
+    }
+
+    return { ok: false, reason: "conflict" };
+  },
+);


### PR DESCRIPTION
## Summary
- Add the API implementation for `POST /api/integrations/telegram/link` for official and custom Telegram bot linking.
- Share Telegram login/connect signature verification and link persistence helpers in an API service.
- Add integration coverage for Login Widget auth, `/connect` signatures, conflict handling, org isolation, invalid/expired auth, storage bootstrapping, and confirmation messages.

Fixes #12851

## Validation
- `pnpm format`
- `pnpm -F api lint`
- `pnpm check-types`
- `pnpm knip`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-integrations-telegram.test.ts src/signals/routes/__tests__/zero-integrations-telegram-message.test.ts`
- `git diff --check -- turbo/apps/api/src/signals/routes/integrations-telegram-link.ts turbo/apps/api/src/signals/routes/__tests__/zero-integrations-telegram.test.ts turbo/apps/api/src/signals/services/zero-telegram-link.service.ts`

Note: I also started full `pnpm vitest`; it produced broad existing failures across unrelated app/web/api tests and was interrupted after 48+ minutes. The focused API coverage above passed after that run.