### PR TITLE
refactor(api): migrate agent composes create route

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -5,6 +5,7 @@ import { agentCheckpointsRoutes } from "./routes/agent-checkpoints-id";
 import { agentComposesByIdRoutes } from "./routes/agent-composes-id";
 import { agentComposesMetadataRoutes } from "./routes/agent-composes-metadata";
 import { agentComposesReadRoutes } from "./routes/agent-composes-read";
+import { agentComposesRoutes } from "./routes/agent-composes";
 import { agentRunsReadRoutes } from "./routes/agent-runs-read";
 import { agentRunTelemetryRoutes } from "./routes/agent-run-telemetry";
 import { agentSessionsRoutes } from "./routes/agent-sessions-id";
@@ -144,6 +145,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...agentComposesReadRoutes,
   ...agentComposesByIdRoutes,
   ...agentComposesMetadataRoutes,
+  ...agentComposesRoutes,
   ...agentRunsReadRoutes,
   ...agentRunTelemetryRoutes,
   ...agentSessionsRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/agent-composes-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/agent-composes-create.test.ts
@@ -1,0 +1,471 @@
+import { randomUUID } from "node:crypto";
+
+import { command, createStore } from "ccstate";
+import {
+  agentComposeApiContentSchema,
+  composesMainContract,
+} from "@vm0/api-contracts/contracts/composes";
+import {
+  agentComposes,
+  agentComposeVersions,
+} from "@vm0/db/schema/agent-compose";
+import { eq } from "drizzle-orm";
+import type { z } from "zod";
+import { describe, expect, it } from "vitest";
+
+import { createApp } from "../../../app-factory";
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { now } from "../../../lib/time";
+import { signSandboxJwtForTests } from "../../auth/tokens";
+import { writeDb$ } from "../../external/db";
+import {
+  createFixtureTracker,
+  createZeroRouteMocks,
+} from "./helpers/zero-route-test";
+
+type AgentComposeApiContent = z.infer<typeof agentComposeApiContentSchema>;
+type AgentDefinition = AgentComposeApiContent["agents"][string];
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+
+const deleteCreatedComposesForOrg$ = command(
+  async ({ set }, orgId: string, signal: AbortSignal): Promise<void> => {
+    const db = set(writeDb$);
+    await db.delete(agentComposes).where(eq(agentComposes.orgId, orgId));
+    signal.throwIfAborted();
+  },
+);
+
+const trackOrgFixture = createFixtureTracker<string>((orgId) => {
+  return store.set(deleteCreatedComposesForOrg$, orgId, context.signal);
+});
+
+async function trackOrg(orgId: string): Promise<void> {
+  await trackOrgFixture(Promise.resolve(orgId));
+}
+
+function client() {
+  return setupApp({ context })(composesMainContract);
+}
+
+function agentName(prefix: string): string {
+  return `${prefix}-${randomUUID().slice(0, 8)}`;
+}
+
+function composeContent(
+  name: string,
+  agent: AgentDefinition = { framework: "claude-code" },
+): AgentComposeApiContent {
+  return {
+    version: "1.0",
+    agents: {
+      [name]: agent,
+    },
+  };
+}
+
+function currentSecond(): number {
+  return Math.floor(now() / 1000);
+}
+
+function sandboxToken(args: {
+  readonly userId: string;
+  readonly orgId: string;
+}): string {
+  const seconds = currentSecond();
+  return signSandboxJwtForTests({
+    scope: "sandbox",
+    userId: args.userId,
+    orgId: args.orgId,
+    runId: `run_${randomUUID()}`,
+    iat: seconds,
+    exp: seconds + 60,
+  });
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+async function storedContent(versionId: string): Promise<unknown> {
+  const db = store.set(writeDb$);
+  const [row] = await db
+    .select({ content: agentComposeVersions.content })
+    .from(agentComposeVersions)
+    .where(eq(agentComposeVersions.id, versionId))
+    .limit(1);
+
+  if (!row) {
+    throw new Error(`Expected stored compose version ${versionId}`);
+  }
+  return row.content;
+}
+
+function storedAgent(content: unknown, name: string): Record<string, unknown> {
+  if (!isRecord(content) || !isRecord(content.agents)) {
+    throw new Error("Expected compose content with agents object");
+  }
+
+  const agent = content.agents[name];
+  if (!isRecord(agent)) {
+    throw new Error(`Expected stored agent ${name}`);
+  }
+  return agent;
+}
+
+describe("POST /api/agent/composes", () => {
+  it("returns 401 when unauthenticated", async () => {
+    const response = await accept(
+      client().create({
+        body: { content: composeContent("unauth-agent") },
+        headers: {},
+      }),
+      [401],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("creates a new compose", async () => {
+    const orgId = `org_${randomUUID()}`;
+    const userId = `user_${randomUUID()}`;
+    await trackOrg(orgId);
+    mocks.clerk.session(userId, orgId);
+    const name = agentName("create-agent");
+
+    const response = await accept(
+      client().create({
+        body: { content: composeContent(name) },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [201],
+    );
+
+    expect(response.body).toMatchObject({
+      name,
+      action: "created",
+    });
+    expect(response.body.composeId).toStrictEqual(expect.any(String));
+    expect(response.body.versionId).toMatch(/^[a-f0-9]{64}$/);
+    expect(response.body.updatedAt).toStrictEqual(expect.any(String));
+  });
+
+  it("normalizes mixed-case agent names before persisting", async () => {
+    const orgId = `org_${randomUUID()}`;
+    await trackOrg(orgId);
+    mocks.clerk.session(`user_${randomUUID()}`, orgId);
+
+    const response = await accept(
+      client().create({
+        body: {
+          content: composeContent("My-Researcher", {
+            framework: "claude-code",
+            instructions: "AGENTS.md",
+          }),
+        },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [201],
+    );
+
+    expect(response.body.name).toBe("my-researcher");
+    const content = await storedContent(response.body.versionId);
+    if (!isRecord(content) || !isRecord(content.agents)) {
+      throw new Error("Expected stored compose content with agents object");
+    }
+    expect(content.agents["my-researcher"]).toBeDefined();
+    expect(content.agents["My-Researcher"]).toBeUndefined();
+  });
+
+  it("strips deprecated and unknown agent fields from persisted content", async () => {
+    const orgId = `org_${randomUUID()}`;
+    await trackOrg(orgId);
+    mocks.clerk.session(`user_${randomUUID()}`, orgId);
+    const name = agentName("strip-fields");
+    const agentWithExtraFields = {
+      framework: "claude-code",
+      skills: [
+        "https://github.com/example/agent/tree/main/.claude/skills/slack",
+      ],
+      image: "custom/image:v1",
+      working_dir: "/custom/path",
+      apps: ["github"],
+    } satisfies AgentDefinition & {
+      readonly image: string;
+      readonly working_dir: string;
+      readonly apps: readonly string[];
+    };
+
+    const response = await accept(
+      client().create({
+        body: {
+          content: composeContent(name, agentWithExtraFields),
+        },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [201],
+    );
+
+    const agent = storedAgent(
+      await storedContent(response.body.versionId),
+      name,
+    );
+    expect(agent.framework).toBe("claude-code");
+    expect(agent.skills).toBeUndefined();
+    expect(agent.image).toBeUndefined();
+    expect(agent.working_dir).toBeUndefined();
+    expect(agent.apps).toBeUndefined();
+  });
+
+  it("updates an existing compose by normalized name", async () => {
+    const orgId = `org_${randomUUID()}`;
+    await trackOrg(orgId);
+    mocks.clerk.session(`user_${randomUUID()}`, orgId);
+    const name = agentName("update-agent");
+
+    const first = await accept(
+      client().create({
+        body: {
+          content: composeContent(name, {
+            framework: "claude-code",
+            description: "Initial description",
+          }),
+        },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [201],
+    );
+
+    const second = await accept(
+      client().create({
+        body: {
+          content: composeContent(name, {
+            framework: "claude-code",
+            description: "Updated description",
+          }),
+        },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(second.body.composeId).toBe(first.body.composeId);
+    expect(second.body.versionId).not.toBe(first.body.versionId);
+    expect(second.body.action).toBe("created");
+    const agent = storedAgent(await storedContent(second.body.versionId), name);
+    expect(agent.description).toBe("Updated description");
+  });
+
+  it("reuses an existing version for identical normalized content", async () => {
+    const orgId = `org_${randomUUID()}`;
+    await trackOrg(orgId);
+    mocks.clerk.session(`user_${randomUUID()}`, orgId);
+    const name = agentName("existing-version");
+
+    const first = await accept(
+      client().create({
+        body: { content: composeContent(name) },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [201],
+    );
+    const second = await accept(
+      client().create({
+        body: { content: composeContent(name) },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(second.body.composeId).toBe(first.body.composeId);
+    expect(second.body.versionId).toBe(first.body.versionId);
+    expect(second.body.action).toBe("existing");
+  });
+
+  it("allows the same compose name in different orgs", async () => {
+    const firstOrgId = `org_${randomUUID()}`;
+    const secondOrgId = `org_${randomUUID()}`;
+    await trackOrg(firstOrgId);
+    await trackOrg(secondOrgId);
+    const name = agentName("shared-name");
+
+    mocks.clerk.session(`user_${randomUUID()}`, firstOrgId);
+    const first = await accept(
+      client().create({
+        body: { content: composeContent(name) },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [201],
+    );
+
+    mocks.clerk.session(`user_${randomUUID()}`, secondOrgId);
+    const second = await accept(
+      client().create({
+        body: { content: composeContent(name) },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [201],
+    );
+
+    expect(second.body.composeId).not.toBe(first.body.composeId);
+    expect(second.body.versionId).toBe(first.body.versionId);
+  });
+
+  it("rejects empty, multiple, and invalid agent names", async () => {
+    const orgId = `org_${randomUUID()}`;
+    await trackOrg(orgId);
+    mocks.clerk.session(`user_${randomUUID()}`, orgId);
+
+    const empty = await accept(
+      client().create({
+        body: { content: { version: "1.0", agents: {} } },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [400],
+    );
+    expect(empty.body.error.message).toBe(
+      "agents must have at least one agent defined",
+    );
+
+    const multiple = await accept(
+      client().create({
+        body: {
+          content: {
+            version: "1.0",
+            agents: {
+              "agent-one": { framework: "claude-code" },
+              "agent-two": { framework: "claude-code" },
+            },
+          },
+        },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [400],
+    );
+    expect(multiple.body.error.message).toBe(
+      "Multiple agents not supported yet. Only one agent allowed.",
+    );
+
+    const invalid = await accept(
+      client().create({
+        body: { content: composeContent("ab") },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [400],
+    );
+    expect(invalid.body.error.message).toContain("Invalid agent name format");
+  });
+
+  it("rejects array agents during request validation", async () => {
+    const orgId = `org_${randomUUID()}`;
+    await trackOrg(orgId);
+    mocks.clerk.session(`user_${randomUUID()}`, orgId);
+    const app = createApp({ signal: context.signal });
+
+    const response = await app.request("/api/agent/composes", {
+      method: "POST",
+      headers: {
+        authorization: "Bearer clerk-session",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        content: {
+          version: "1.0",
+          agents: [{ framework: "claude-code" }],
+        },
+      }),
+    });
+
+    expect(response.status).toBe(400);
+    const body = (await response.json()) as {
+      readonly error: { readonly message: string; readonly code: string };
+    };
+    expect(body.error.code).toBe("BAD_REQUEST");
+    expect(body.error.message).toContain("content.agents");
+    expect(body.error.message).toContain("expected record");
+  });
+
+  it("accepts claude-code and codex frameworks", async () => {
+    const orgId = `org_${randomUUID()}`;
+    await trackOrg(orgId);
+    mocks.clerk.session(`user_${randomUUID()}`, orgId);
+
+    const claudeCode = await accept(
+      client().create({
+        body: { content: composeContent(agentName("claude-code-agent")) },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [201],
+    );
+    const codex = await accept(
+      client().create({
+        body: {
+          content: composeContent(agentName("codex-agent"), {
+            framework: "codex",
+          }),
+        },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [201],
+    );
+
+    expect(claudeCode.body.action).toBe("created");
+    expect(codex.body.action).toBe("created");
+  });
+
+  it("rejects unsupported frameworks through request validation", async () => {
+    const orgId = `org_${randomUUID()}`;
+    await trackOrg(orgId);
+    mocks.clerk.session(`user_${randomUUID()}`, orgId);
+    const app = createApp({ signal: context.signal });
+
+    const response = await app.request("/api/agent/composes", {
+      method: "POST",
+      headers: {
+        authorization: "Bearer clerk-session",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        content: {
+          version: "1.0",
+          agents: {
+            [agentName("bad-framework")]: {
+              framework: "unsupported-framework",
+            },
+          },
+        },
+      }),
+    });
+
+    expect(response.status).toBe(400);
+    const body = (await response.json()) as {
+      readonly error: { readonly message: string; readonly code: string };
+    };
+    expect(body.error.code).toBe("BAD_REQUEST");
+    expect(body.error.message).toContain("Invalid option");
+  });
+
+  it("accepts sandbox tokens", async () => {
+    const orgId = `org_${randomUUID()}`;
+    const userId = `user_${randomUUID()}`;
+    await trackOrg(orgId);
+    const name = agentName("sandbox-agent");
+
+    const response = await accept(
+      client().create({
+        body: { content: composeContent(name) },
+        headers: {
+          authorization: `Bearer ${sandboxToken({ userId, orgId })}`,
+        },
+      }),
+      [201],
+    );
+
+    expect(response.body.name).toBe(name);
+    expect(response.body.action).toBe("created");
+  });
+});

--- a/turbo/apps/api/src/signals/routes/agent-composes.ts
+++ b/turbo/apps/api/src/signals/routes/agent-composes.ts
@@ -1,0 +1,48 @@
+import { command } from "ccstate";
+import { composesMainContract } from "@vm0/api-contracts/contracts/composes";
+
+import { authContext$ } from "../auth/auth-context";
+import { authRoute } from "../auth/auth-route";
+import { bodyResultOf } from "../context/request";
+import { badRequestMessage } from "../../lib/error";
+import type { RouteEntry } from "../route";
+import { createAgentCompose$ } from "../services/agent-composes-create.service";
+
+const createComposeBody$ = bodyResultOf(composesMainContract.create);
+
+const createComposeInner$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const auth = get(authContext$);
+    const bodyResult = await get(createComposeBody$);
+    signal.throwIfAborted();
+    if (!bodyResult.ok) {
+      return bodyResult.response;
+    }
+
+    if (!auth.orgId) {
+      return badRequestMessage(
+        "Explicit org context required — ensure active org in session",
+      );
+    }
+
+    return await set(
+      createAgentCompose$,
+      {
+        userId: auth.userId,
+        orgId: auth.orgId,
+        content: bodyResult.data.content,
+      },
+      signal,
+    );
+  },
+);
+
+export const agentComposesRoutes: readonly RouteEntry[] = [
+  {
+    route: composesMainContract.create,
+    handler: authRoute(
+      { acceptAnySandboxCapability: true },
+      createComposeInner$,
+    ),
+  },
+];

--- a/turbo/apps/api/src/signals/services/agent-composes-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-composes-create.service.ts
@@ -1,0 +1,191 @@
+import { createHash } from "node:crypto";
+
+import { command } from "ccstate";
+import {
+  AGENT_NAME_REGEX,
+  agentComposeApiContentSchema,
+} from "@vm0/api-contracts/contracts/composes";
+import {
+  agentComposes,
+  agentComposeVersions,
+} from "@vm0/db/schema/agent-compose";
+import { and, eq } from "drizzle-orm";
+import type { z } from "zod";
+
+import { badRequestMessage } from "../../lib/error";
+import { writeDb$ } from "../external/db";
+import { nowDate } from "../external/time";
+
+type AgentComposeApiContent = z.infer<typeof agentComposeApiContentSchema>;
+
+interface CreateAgentComposeArgs {
+  readonly userId: string;
+  readonly orgId: string;
+  readonly content: AgentComposeApiContent;
+}
+
+interface CreateAgentComposeBody {
+  readonly composeId: string;
+  readonly name: string;
+  readonly versionId: string;
+  readonly action: "created" | "existing";
+  readonly updatedAt: string;
+}
+
+type CreateAgentComposeResult =
+  | ReturnType<typeof badRequestMessage>
+  | {
+      readonly status: 200 | 201;
+      readonly body: CreateAgentComposeBody;
+    };
+
+function sortObjectKeys(value: unknown): unknown {
+  if (value === null || typeof value !== "object") {
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map(sortObjectKeys);
+  }
+
+  const sorted: Record<string, unknown> = {};
+  const record = value as Record<string, unknown>;
+  const keys = Object.keys(record).sort();
+  for (const key of keys) {
+    sorted[key] = sortObjectKeys(record[key]);
+  }
+  return sorted;
+}
+
+function computeComposeVersionId(content: unknown): string {
+  const canonical = JSON.stringify(sortObjectKeys(content));
+  return createHash("sha256").update(canonical).digest("hex");
+}
+
+export const createAgentCompose$ = command(
+  async (
+    { set },
+    args: CreateAgentComposeArgs,
+    signal: AbortSignal,
+  ): Promise<CreateAgentComposeResult> => {
+    if (Array.isArray(args.content.agents)) {
+      return badRequestMessage(
+        "agents must be an object, not an array. Use format: agents: { agent-name: { ... } }",
+      );
+    }
+
+    const agentKeys = Object.keys(args.content.agents);
+    if (agentKeys.length === 0) {
+      return badRequestMessage("agents must have at least one agent defined");
+    }
+
+    if (agentKeys.length > 1) {
+      return badRequestMessage(
+        "Multiple agents not supported yet. Only one agent allowed.",
+      );
+    }
+
+    const agentName = agentKeys[0];
+    if (!agentName) {
+      return badRequestMessage("agents must have at least one agent defined");
+    }
+
+    if (!AGENT_NAME_REGEX.test(agentName)) {
+      return badRequestMessage(
+        "Invalid agent name format. Must be 3-64 characters, letters, numbers, and hyphens only. Must start and end with letter or number.",
+      );
+    }
+
+    const agent = args.content.agents[agentName];
+    if (!agent) {
+      return badRequestMessage("agents must have at least one agent defined");
+    }
+
+    const normalizedAgentName = agentName.toLowerCase();
+    const { skills: _deprecatedSkills, ...agentWithoutSkills } = agent;
+    const resolvedContent = {
+      ...args.content,
+      agents: {
+        [normalizedAgentName]: agentWithoutSkills,
+      },
+    };
+    const versionId = computeComposeVersionId(resolvedContent);
+    const db = set(writeDb$);
+
+    const [existingComposes, existingVersions] = await Promise.all([
+      db
+        .select()
+        .from(agentComposes)
+        .where(
+          and(
+            eq(agentComposes.orgId, args.orgId),
+            eq(agentComposes.name, normalizedAgentName),
+          ),
+        )
+        .limit(1),
+      db
+        .select()
+        .from(agentComposeVersions)
+        .where(eq(agentComposeVersions.id, versionId))
+        .limit(1),
+    ]);
+    signal.throwIfAborted();
+
+    const existing = existingComposes[0];
+    let composeId = existing?.id;
+    const isNewCompose = !composeId;
+
+    if (!composeId) {
+      const [created] = await db
+        .insert(agentComposes)
+        .values({
+          userId: args.userId,
+          name: normalizedAgentName,
+          orgId: args.orgId,
+        })
+        .returning({ id: agentComposes.id });
+      signal.throwIfAborted();
+
+      if (!created) {
+        throw new Error("Failed to create agent compose");
+      }
+
+      composeId = created.id;
+    }
+
+    let action: "created" | "existing";
+    if (existingVersions.length > 0) {
+      action = "existing";
+    } else {
+      await db.insert(agentComposeVersions).values({
+        id: versionId,
+        composeId,
+        content: resolvedContent,
+        createdBy: args.userId,
+      });
+      signal.throwIfAborted();
+      action = "created";
+    }
+
+    const updatedAt = nowDate();
+    await db
+      .update(agentComposes)
+      .set({
+        headVersionId: versionId,
+        updatedAt,
+      })
+      .where(eq(agentComposes.id, composeId));
+    signal.throwIfAborted();
+
+    return {
+      status: isNewCompose ? 201 : 200,
+      body: {
+        composeId,
+        name: normalizedAgentName,
+        versionId,
+        action,
+        updatedAt: updatedAt.toISOString(),
+      },
+    };
+  },
+);


### PR DESCRIPTION
Closes #12846.

## Summary
- Add the API backend implementation for `POST /api/agent/composes`.
- Register the route in the API signal router.
- Add integration coverage for auth, sandbox tokens, creation, updates, validation, normalization, version reuse, and field stripping.

## Validation
- `pnpm format`
- `pnpm lint`
- `pnpm check-types`
- `pnpm -F api check-types`
- `pnpm knip --no-progress`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/agent-composes-create.test.ts`
- `pnpm vitest` failed in unrelated `apps/web` UI/environment tests after the new API route test passed in the full run: 13 failed files / 1007 total, 30 failed tests / 10854 total. Representative failures include `zero-instructions-tab.test.tsx`, `avatar-customizer.test.tsx`, and `theme-toggle.test.tsx` with happy-dom/jsdom globals or worker-exit errors.