### PR TITLE
refactor(api): migrate CLI auth routes

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -9,6 +9,8 @@ import { agentRunTelemetryRoutes } from "./routes/agent-run-telemetry";
 import { agentSessionsRoutes } from "./routes/agent-sessions-id";
 import { authMeRoutes } from "./routes/auth-me";
 import { audioTranscriptionsV1Routes } from "./routes/audio-transcriptions-v1";
+import { cliAuthRoutes } from "./routes/cli-auth";
+import { cliAuthTestRoutes } from "./routes/cli-auth-test";
 import type { SignalRouteHandler } from "./context/route";
 import { chatThreadsV1Routes } from "./routes/chat-threads-v1";
 import { connectorsTypeAuthorizeRoutes } from "./routes/connectors-type-authorize";
@@ -123,6 +125,8 @@ export const ROUTES: readonly RouteEntry[] = [
     handler: apiHealth$,
   },
   ...authMeRoutes,
+  ...cliAuthRoutes,
+  ...cliAuthTestRoutes,
   ...healthAuthProbeRoutes,
   ...githubOauthRoutes,
   ...internalEventConsumerTelegramTypingRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/cli-auth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cli-auth.test.ts
@@ -1,0 +1,787 @@
+import { randomUUID } from "node:crypto";
+
+import {
+  cliAuthDeviceContract,
+  cliAuthOrgContract,
+  cliAuthTokenContract,
+} from "@vm0/api-contracts/contracts/cli-auth";
+import {
+  cliAuthTestApproveContract,
+  cliAuthTestCodexOauthContract,
+  cliAuthTestConnectorContract,
+  cliAuthTestEnableConnectorContract,
+  cliAuthTestTokenContract,
+} from "@vm0/api-contracts/contracts/cli-auth-test";
+import { agentComposes } from "@vm0/db/schema/agent-compose";
+import { cliTokens } from "@vm0/db/schema/cli-tokens";
+import { connectors } from "@vm0/db/schema/connector";
+import { creditExpiresRecord } from "@vm0/db/schema/credit-expires-record";
+import { deviceCodes } from "@vm0/db/schema/device-codes";
+import { modelProviders } from "@vm0/db/schema/model-provider";
+import { orgCache } from "@vm0/db/schema/org-cache";
+import { orgMembersCache } from "@vm0/db/schema/org-members-cache";
+import { orgMetadata } from "@vm0/db/schema/org-metadata";
+import { secrets } from "@vm0/db/schema/secret";
+import { userConnectors } from "@vm0/db/schema/user-connector";
+import { zeroAgents } from "@vm0/db/schema/zero-agent";
+import { createStore } from "ccstate";
+import { and, eq, inArray } from "drizzle-orm";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { setupApp, testContext } from "../../../__tests__/test-helpers";
+import { mockEnv, mockOptionalEnv } from "../../../lib/env";
+import { signPatJwtForTests } from "../../auth/tokens";
+import { writeDb$ } from "../../external/db";
+import { now, nowDate } from "../../external/time";
+import { DEFAULT_TEST_EMAIL } from "../../services/cli-auth.service";
+
+const context = testContext();
+const store = createStore();
+const ORG_SENTINEL_USER_ID = "__org__";
+
+interface HttpResponse {
+  readonly status: number;
+  readonly body: unknown;
+}
+
+interface DeviceAuthResponseBody {
+  readonly device_code: string;
+  readonly user_code: string;
+  readonly verification_path: string;
+  readonly expires_in: number;
+  readonly interval: number;
+}
+
+interface OAuthErrorBody {
+  readonly error: string;
+  readonly error_description: string;
+}
+
+interface CliTokenResponseBody {
+  readonly access_token: string;
+  readonly token_type: "Bearer";
+  readonly expires_in: number;
+}
+
+interface TestTokenResponseBody extends CliTokenResponseBody {
+  readonly user_id: string;
+}
+
+interface TestApproveResponseBody {
+  readonly success: true;
+  readonly userId: string;
+}
+
+interface TestConnectorResponseBody {
+  readonly ok: true;
+  readonly connectorType: string;
+  readonly orgId: string;
+}
+
+interface TestEnableConnectorResponseBody {
+  readonly ok: true;
+  readonly composeId: string;
+  readonly connectorTypes: readonly string[];
+}
+
+interface TestCodexOauthResponseBody {
+  readonly ok?: true;
+  readonly orgId: string;
+  readonly tokenExpiresAt?: string;
+}
+
+async function acceptResponse<TBody>(
+  promise: Promise<HttpResponse>,
+  expectedStatus: number,
+): Promise<{ readonly status: number; readonly body: TBody }> {
+  const response = await promise;
+  expect(response.status).toBe(expectedStatus);
+  return { status: response.status, body: response.body as TBody };
+}
+
+describe("CLI auth routes", () => {
+  const FAR_FUTURE_CACHE_AT = new Date("2126-01-01T00:00:00.000Z");
+
+  const cleanupState = {
+    deviceCodes: [] as string[],
+    orgIds: [] as string[],
+    userIds: [] as string[],
+    composeIds: [] as string[],
+  };
+
+  function unique(values: readonly string[]): string[] {
+    return [...new Set(values)];
+  }
+
+  function trackOrg(orgId: string): string {
+    cleanupState.orgIds.push(orgId);
+    return orgId;
+  }
+
+  function trackUser(userId: string): string {
+    cleanupState.userIds.push(userId);
+    return userId;
+  }
+
+  function currentSecond(): number {
+    return Math.floor(now() / 1000);
+  }
+
+  function randomDeviceCode(): string {
+    const raw = randomUUID().replace(/-/g, "").toUpperCase();
+    return `${raw.slice(0, 4)}-${raw.slice(4, 8)}`;
+  }
+
+  function mockTestUser(args: {
+    readonly userId: string;
+    readonly orgId: string;
+    readonly slug?: string;
+    readonly email?: string;
+  }): void {
+    context.mocks.clerk.users.getUserList.mockResolvedValue({
+      data: [{ id: args.userId }],
+    });
+    context.mocks.clerk.users.getOrganizationMembershipList.mockResolvedValue({
+      data: [
+        {
+          createdAt: Date.parse("2026-01-01T00:00:00.000Z"),
+          organization: {
+            id: args.orgId,
+            slug: args.slug ?? "cli-auth-test-org",
+            name: args.slug ?? "cli-auth-test-org",
+          },
+          publicUserData: { userId: args.userId },
+          role: "org:admin",
+        },
+      ],
+    });
+  }
+
+  async function seedOrgMembership(args: {
+    readonly orgId: string;
+    readonly userId: string;
+    readonly slug: string;
+    readonly role?: "admin" | "member";
+  }): Promise<void> {
+    trackOrg(args.orgId);
+    trackUser(args.userId);
+    const writeDb = store.set(writeDb$);
+    await writeDb
+      .insert(orgCache)
+      .values({
+        orgId: args.orgId,
+        slug: args.slug,
+        name: args.slug,
+        cachedAt: FAR_FUTURE_CACHE_AT,
+      })
+      .onConflictDoUpdate({
+        target: orgCache.orgId,
+        set: {
+          slug: args.slug,
+          name: args.slug,
+          cachedAt: FAR_FUTURE_CACHE_AT,
+        },
+      });
+    await writeDb
+      .insert(orgMembersCache)
+      .values({
+        orgId: args.orgId,
+        userId: args.userId,
+        role: args.role ?? "admin",
+        cachedAt: FAR_FUTURE_CACHE_AT,
+      })
+      .onConflictDoUpdate({
+        target: [orgMembersCache.orgId, orgMembersCache.userId],
+        set: {
+          role: args.role ?? "admin",
+          cachedAt: FAR_FUTURE_CACHE_AT,
+        },
+      });
+  }
+
+  async function seedDeviceCode(args: {
+    readonly status: "pending" | "authenticated" | "denied";
+    readonly userId?: string;
+    readonly orgId?: string;
+    readonly expiresAt?: Date;
+  }): Promise<string> {
+    const code = randomDeviceCode();
+    cleanupState.deviceCodes.push(code);
+    const writeDb = store.set(writeDb$);
+    const timestamp = nowDate();
+    await writeDb.insert(deviceCodes).values({
+      code,
+      purpose: "cli",
+      status: args.status,
+      userId: args.userId,
+      orgId: args.orgId,
+      expiresAt:
+        args.expiresAt ?? new Date(timestamp.getTime() + 15 * 60 * 1000),
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    });
+    return code;
+  }
+
+  async function seedCliToken(args: {
+    readonly userId: string;
+    readonly orgId: string;
+  }): Promise<string> {
+    const tokenId = randomUUID();
+    const token = signPatJwtForTests({
+      scope: "cli",
+      userId: args.userId,
+      orgId: args.orgId,
+      tokenId,
+      iat: currentSecond(),
+      exp: currentSecond() + 60,
+    });
+    const writeDb = store.set(writeDb$);
+    await writeDb.insert(cliTokens).values({
+      id: tokenId,
+      token,
+      userId: args.userId,
+      name: "test token",
+      expiresAt: new Date(now() + 60_000),
+    });
+    return token;
+  }
+
+  async function seedCompose(args: {
+    readonly orgId: string;
+    readonly userId: string;
+  }): Promise<string> {
+    const composeId = randomUUID();
+    cleanupState.composeIds.push(composeId);
+    const writeDb = store.set(writeDb$);
+    await writeDb.insert(agentComposes).values({
+      id: composeId,
+      userId: args.userId,
+      orgId: args.orgId,
+      name: `cli-auth-${composeId.slice(0, 8)}`,
+    });
+    return composeId;
+  }
+
+  async function fetchDeviceCode(code: string) {
+    const writeDb = store.set(writeDb$);
+    const [row] = await writeDb
+      .select()
+      .from(deviceCodes)
+      .where(eq(deviceCodes.code, code))
+      .limit(1);
+    return row;
+  }
+
+  async function fetchCliToken(token: string) {
+    const writeDb = store.set(writeDb$);
+    const [row] = await writeDb
+      .select()
+      .from(cliTokens)
+      .where(eq(cliTokens.token, token))
+      .limit(1);
+    return row;
+  }
+
+  beforeEach(() => {
+    mockEnv("ENV", "development");
+  });
+
+  afterEach(async () => {
+    const writeDb = store.set(writeDb$);
+    const orgIds = unique(cleanupState.orgIds);
+    const userIds = unique(cleanupState.userIds);
+    const composeIds = unique(cleanupState.composeIds);
+    const codes = unique(cleanupState.deviceCodes);
+
+    if (orgIds.length > 0) {
+      await writeDb
+        .delete(userConnectors)
+        .where(inArray(userConnectors.orgId, orgIds));
+      await writeDb.delete(connectors).where(inArray(connectors.orgId, orgIds));
+      await writeDb
+        .delete(modelProviders)
+        .where(inArray(modelProviders.orgId, orgIds));
+      await writeDb.delete(secrets).where(inArray(secrets.orgId, orgIds));
+      await writeDb
+        .delete(creditExpiresRecord)
+        .where(inArray(creditExpiresRecord.orgId, orgIds));
+      await writeDb
+        .delete(orgMetadata)
+        .where(inArray(orgMetadata.orgId, orgIds));
+      await writeDb
+        .delete(orgMembersCache)
+        .where(inArray(orgMembersCache.orgId, orgIds));
+      await writeDb.delete(orgCache).where(inArray(orgCache.orgId, orgIds));
+    }
+
+    if (composeIds.length > 0) {
+      await writeDb
+        .delete(zeroAgents)
+        .where(inArray(zeroAgents.id, composeIds));
+      await writeDb
+        .delete(agentComposes)
+        .where(inArray(agentComposes.id, composeIds));
+    }
+
+    if (codes.length > 0) {
+      await writeDb.delete(deviceCodes).where(inArray(deviceCodes.code, codes));
+    }
+
+    if (userIds.length > 0) {
+      await writeDb.delete(cliTokens).where(inArray(cliTokens.userId, userIds));
+    }
+
+    cleanupState.deviceCodes.length = 0;
+    cleanupState.orgIds.length = 0;
+    cleanupState.userIds.length = 0;
+    cleanupState.composeIds.length = 0;
+  });
+
+  describe("POST /api/cli/auth/device", () => {
+    it("creates a pending CLI device code", async () => {
+      const client = setupApp({ context })(cliAuthDeviceContract);
+
+      const response = await acceptResponse<DeviceAuthResponseBody>(
+        client.create({ body: {} }),
+        200,
+      );
+      cleanupState.deviceCodes.push(response.body.device_code);
+
+      expect(response.body.device_code).toMatch(/^[A-Z2-9]{4}-[A-Z2-9]{4}$/);
+      expect(response.body.user_code).toBe(response.body.device_code);
+      expect(response.body.verification_path).toBe("/cli-auth");
+      expect(response.body.expires_in).toBe(900);
+      expect(response.body.interval).toBe(5);
+
+      const row = await fetchDeviceCode(response.body.device_code);
+      expect(row).toMatchObject({ purpose: "cli", status: "pending" });
+    });
+  });
+
+  describe("POST /api/cli/auth/token", () => {
+    it("returns authorization_pending for pending CLI device codes", async () => {
+      const code = await seedDeviceCode({ status: "pending" });
+      const client = setupApp({ context })(cliAuthTokenContract);
+
+      const response = await acceptResponse<OAuthErrorBody>(
+        client.exchange({ body: { device_code: code } }),
+        202,
+      );
+
+      expect(response.body).toStrictEqual({
+        error: "authorization_pending",
+        error_description:
+          "The user has not yet completed authorization in the browser",
+      });
+    });
+
+    it("issues a PAT and deletes the device code after authentication", async () => {
+      const userId = trackUser(`user_${randomUUID()}`);
+      const orgId = trackOrg(`org_${randomUUID()}`);
+      const code = await seedDeviceCode({
+        status: "authenticated",
+        userId,
+        orgId,
+      });
+      const client = setupApp({ context })(cliAuthTokenContract);
+
+      const response = await acceptResponse<CliTokenResponseBody>(
+        client.exchange({ body: { device_code: code } }),
+        200,
+      );
+
+      expect(response.body.access_token).toMatch(/^vm0_pat_/);
+      expect(response.body.token_type).toBe("Bearer");
+      expect(response.body.expires_in).toBe(90 * 24 * 60 * 60);
+      await expect(fetchDeviceCode(code)).resolves.toBeUndefined();
+      await expect(
+        fetchCliToken(response.body.access_token),
+      ).resolves.toMatchObject({
+        userId,
+        name: "CLI Device Flow Authentication",
+      });
+    });
+  });
+
+  describe("POST /api/cli/auth/org", () => {
+    it("switches a PAT to a target organization by slug", async () => {
+      const userId = trackUser(`user_${randomUUID()}`);
+      const sourceOrgId = trackOrg(`org_${randomUUID()}`);
+      const targetOrgId = trackOrg(`org_${randomUUID()}`);
+      await seedOrgMembership({
+        orgId: sourceOrgId,
+        userId,
+        slug: `source-${randomUUID()}`,
+      });
+      const targetSlug = `target-${randomUUID()}`;
+      await seedOrgMembership({
+        orgId: targetOrgId,
+        userId,
+        slug: targetSlug,
+        role: "member",
+      });
+      const token = await seedCliToken({ userId, orgId: sourceOrgId });
+      const client = setupApp({ context })(cliAuthOrgContract);
+
+      const response = await acceptResponse<CliTokenResponseBody>(
+        client.switchOrg({
+          headers: { authorization: `Bearer ${token}` },
+          body: { slug: targetSlug },
+        }),
+        200,
+      );
+
+      expect(response.body.access_token).toMatch(/^vm0_pat_/);
+      expect(response.body.token_type).toBe("Bearer");
+      expect(response.body.expires_in).toBe(90 * 24 * 60 * 60);
+      await expect(
+        fetchCliToken(response.body.access_token),
+      ).resolves.toMatchObject({
+        userId,
+        name: "CLI Org Switch",
+      });
+    });
+
+    it("refreshes org cache from Clerk when switching to an uncached slug", async () => {
+      const userId = trackUser(`user_${randomUUID()}`);
+      const sourceOrgId = trackOrg(`org_${randomUUID()}`);
+      const targetOrgId = trackOrg(`org_${randomUUID()}`);
+      const targetSlug = `target-${randomUUID()}`;
+      context.mocks.clerk.organizations.getOrganization.mockResolvedValue({
+        id: targetOrgId,
+        slug: targetSlug,
+        name: "Target Org",
+        createdBy: userId,
+      });
+      context.mocks.clerk.users.getOrganizationMembershipList.mockResolvedValue(
+        {
+          data: [
+            {
+              createdAt: Date.parse("2026-01-01T00:00:00.000Z"),
+              organization: {
+                id: sourceOrgId,
+                slug: `source-${randomUUID()}`,
+                name: "Source Org",
+              },
+              publicUserData: { userId },
+              role: "org:admin",
+            },
+            {
+              createdAt: Date.parse("2026-01-02T00:00:00.000Z"),
+              organization: {
+                id: targetOrgId,
+                slug: targetSlug,
+                name: "Target Org",
+              },
+              publicUserData: { userId },
+              role: "org:member",
+            },
+          ],
+        },
+      );
+      const token = await seedCliToken({ userId, orgId: sourceOrgId });
+      const client = setupApp({ context })(cliAuthOrgContract);
+
+      const response = await acceptResponse<CliTokenResponseBody>(
+        client.switchOrg({
+          headers: { authorization: `Bearer ${token}` },
+          body: { slug: targetSlug },
+        }),
+        200,
+      );
+
+      expect(response.body.access_token).toMatch(/^vm0_pat_/);
+      await expect(
+        fetchCliToken(response.body.access_token),
+      ).resolves.toMatchObject({
+        userId,
+        name: "CLI Org Switch",
+      });
+
+      const writeDb = store.set(writeDb$);
+      await expect(
+        writeDb
+          .select()
+          .from(orgCache)
+          .where(eq(orgCache.orgId, targetOrgId))
+          .limit(1),
+      ).resolves.toMatchObject([
+        expect.objectContaining({ slug: targetSlug, name: "Target Org" }),
+      ]);
+    });
+  });
+
+  describe("POST /api/cli/auth/test-token", () => {
+    it("returns 404 outside allowed test environments", async () => {
+      mockEnv("ENV", "production");
+      const client = setupApp({ context })(cliAuthTestTokenContract);
+
+      const response = await acceptResponse<string>(
+        client.create({ query: {}, body: {} }),
+        404,
+      );
+
+      expect(response.body).toBe("Not found");
+    });
+
+    it("creates a test PAT and seeds org lookup state in development", async () => {
+      const userId = trackUser(`user_${randomUUID()}`);
+      const orgId = trackOrg(`org_${randomUUID()}`);
+      mockTestUser({ userId, orgId, slug: "test-token-org" });
+      const client = setupApp({ context })(cliAuthTestTokenContract);
+
+      const response = await acceptResponse<TestTokenResponseBody>(
+        client.create({ query: {}, body: {} }),
+        200,
+      );
+
+      expect(response.body).toMatchObject({
+        token_type: "Bearer",
+        expires_in: 90 * 24 * 60 * 60,
+        user_id: userId,
+      });
+      expect(response.body.access_token).toMatch(/^vm0_pat_/);
+      await expect(
+        fetchCliToken(response.body.access_token),
+      ).resolves.toMatchObject({
+        userId,
+        name: "CI Test Token",
+      });
+
+      const writeDb = store.set(writeDb$);
+      await expect(
+        writeDb
+          .select()
+          .from(orgCache)
+          .where(eq(orgCache.orgId, orgId))
+          .limit(1),
+      ).resolves.toHaveLength(1);
+      await expect(
+        writeDb
+          .select()
+          .from(orgMembersCache)
+          .where(
+            and(
+              eq(orgMembersCache.orgId, orgId),
+              eq(orgMembersCache.userId, userId),
+            ),
+          )
+          .limit(1),
+      ).resolves.toHaveLength(1);
+      await expect(
+        writeDb
+          .select()
+          .from(orgMetadata)
+          .where(eq(orgMetadata.orgId, orgId))
+          .limit(1),
+      ).resolves.toHaveLength(1);
+    });
+  });
+
+  describe("POST /api/cli/auth/test-approve", () => {
+    it("approves a pending CLI device code when mock Claude is enabled", async () => {
+      mockOptionalEnv("USE_MOCK_CLAUDE", "true");
+      const userId = trackUser(`user_${randomUUID()}`);
+      const orgId = trackOrg(`org_${randomUUID()}`);
+      mockTestUser({ userId, orgId });
+      const deviceClient = setupApp({ context })(cliAuthDeviceContract);
+      const approveClient = setupApp({ context })(cliAuthTestApproveContract);
+      const deviceResponse = await acceptResponse<DeviceAuthResponseBody>(
+        deviceClient.create({ body: {} }),
+        200,
+      );
+      cleanupState.deviceCodes.push(deviceResponse.body.device_code);
+
+      const response = await acceptResponse<TestApproveResponseBody>(
+        approveClient.approve({
+          query: { email: DEFAULT_TEST_EMAIL },
+          body: { device_code: deviceResponse.body.device_code.toLowerCase() },
+        }),
+        200,
+      );
+
+      expect(response.body).toStrictEqual({ success: true, userId });
+      await expect(
+        fetchDeviceCode(deviceResponse.body.device_code),
+      ).resolves.toMatchObject({
+        status: "authenticated",
+        userId,
+      });
+    });
+  });
+
+  describe("POST /api/cli/auth/test-connector", () => {
+    it("seeds an OAuth connector for the test user org", async () => {
+      const userId = trackUser(`user_${randomUUID()}`);
+      const orgId = trackOrg(`org_${randomUUID()}`);
+      await seedOrgMembership({ orgId, userId, slug: "connector-org" });
+      mockTestUser({ userId, orgId });
+      const client = setupApp({ context })(cliAuthTestConnectorContract);
+
+      const response = await acceptResponse<TestConnectorResponseBody>(
+        client.create({
+          query: {},
+          body: {
+            connectorName: "github",
+            accessToken: "github-access-token",
+            refreshToken: "github-refresh-token",
+            expiresIn: 3600,
+          },
+        }),
+        200,
+      );
+
+      expect(response.body).toStrictEqual({
+        ok: true,
+        connectorType: "github",
+        orgId,
+      });
+
+      const writeDb = store.set(writeDb$);
+      await expect(
+        writeDb
+          .select()
+          .from(connectors)
+          .where(
+            and(
+              eq(connectors.orgId, orgId),
+              eq(connectors.userId, userId),
+              eq(connectors.type, "github"),
+            ),
+          )
+          .limit(1),
+      ).resolves.toHaveLength(1);
+
+      const computerResponse = await acceptResponse<TestConnectorResponseBody>(
+        client.create({
+          query: {},
+          body: {
+            connectorName: "computer",
+            accessToken: "computer-access-token",
+          },
+        }),
+        200,
+      );
+
+      expect(computerResponse.body).toStrictEqual({
+        ok: true,
+        connectorType: "computer",
+        orgId,
+      });
+      await expect(
+        writeDb
+          .select()
+          .from(connectors)
+          .where(
+            and(
+              eq(connectors.orgId, orgId),
+              eq(connectors.userId, userId),
+              eq(connectors.type, "computer"),
+            ),
+          )
+          .limit(1),
+      ).resolves.toHaveLength(1);
+    });
+  });
+
+  describe("POST /api/cli/auth/test-enable-connector", () => {
+    it("creates a zero agent row and enables requested connectors", async () => {
+      const userId = trackUser(`user_${randomUUID()}`);
+      const orgId = trackOrg(`org_${randomUUID()}`);
+      await seedOrgMembership({ orgId, userId, slug: "enable-connector-org" });
+      mockTestUser({ userId, orgId });
+      const composeId = await seedCompose({ orgId, userId });
+      const client = setupApp({ context })(cliAuthTestEnableConnectorContract);
+
+      const response = await acceptResponse<TestEnableConnectorResponseBody>(
+        client.create({
+          query: {},
+          body: { composeId, connectorTypes: ["github", "slack"] },
+        }),
+        200,
+      );
+
+      expect(response.body).toStrictEqual({
+        ok: true,
+        composeId,
+        connectorTypes: ["github", "slack"],
+      });
+
+      const writeDb = store.set(writeDb$);
+      const connectorRows = await writeDb
+        .select({ connectorType: userConnectors.connectorType })
+        .from(userConnectors)
+        .where(
+          and(
+            eq(userConnectors.orgId, orgId),
+            eq(userConnectors.userId, userId),
+            eq(userConnectors.agentId, composeId),
+          ),
+        );
+      expect(
+        connectorRows
+          .map((row) => {
+            return row.connectorType;
+          })
+          .sort(),
+      ).toStrictEqual(["github", "slack"]);
+      await expect(
+        writeDb
+          .select()
+          .from(zeroAgents)
+          .where(eq(zeroAgents.id, composeId))
+          .limit(1),
+      ).resolves.toHaveLength(1);
+    });
+  });
+
+  describe("POST /api/cli/auth/test-codex-oauth", () => {
+    it("seeds legacy Codex OAuth token state for the test user org", async () => {
+      const userId = trackUser(`user_${randomUUID()}`);
+      const orgId = trackOrg(`org_${randomUUID()}`);
+      await seedOrgMembership({ orgId, userId, slug: "codex-oauth-org" });
+      mockTestUser({ userId, orgId });
+      const client = setupApp({ context })(cliAuthTestCodexOauthContract);
+
+      const response = await acceptResponse<TestCodexOauthResponseBody>(
+        client.create({
+          query: {},
+          body: {
+            accessToken: "codex-access-token",
+            refreshToken: "codex-refresh-token",
+            accountId: "codex-account",
+            idToken: "codex-id-token",
+            expiresIn: 600,
+            needsReconnect: true,
+            lastRefreshErrorCode: "refresh_failed",
+          },
+        }),
+        200,
+      );
+
+      expect(response.body.ok).toBeTruthy();
+      expect(response.body.orgId).toBe(orgId);
+      expect(response.body.tokenExpiresAt).toBeDefined();
+
+      const writeDb = store.set(writeDb$);
+      const [provider] = await writeDb
+        .select()
+        .from(modelProviders)
+        .where(
+          and(
+            eq(modelProviders.orgId, orgId),
+            eq(modelProviders.userId, ORG_SENTINEL_USER_ID),
+            eq(modelProviders.type, "codex-oauth-token"),
+          ),
+        )
+        .limit(1);
+      expect(provider).toMatchObject({
+        authMethod: "auth_json",
+        needsReconnect: true,
+        lastRefreshErrorCode: "refresh_failed",
+      });
+      expect(provider?.tokenExpiresAt).toBeInstanceOf(Date);
+    });
+  });
+});

--- a/turbo/apps/api/src/signals/routes/cli-auth-test.ts
+++ b/turbo/apps/api/src/signals/routes/cli-auth-test.ts
@@ -1,0 +1,438 @@
+import { optionalEnv } from "../../lib/env";
+import {
+  cliAuthTestApproveContract,
+  cliAuthTestCodexOauthContract,
+  cliAuthTestConnectorContract,
+  cliAuthTestEnableConnectorContract,
+  cliAuthTestTokenContract,
+} from "@vm0/api-contracts/contracts/cli-auth-test";
+import { connectorTypeSchema } from "@vm0/connectors/connectors";
+import { PROVIDER_HANDLERS } from "@vm0/connectors/oauth-providers";
+import { agentComposes } from "@vm0/db/schema/agent-compose";
+import { deviceCodes } from "@vm0/db/schema/device-codes";
+import { modelProviders } from "@vm0/db/schema/model-provider";
+import { userConnectors } from "@vm0/db/schema/user-connector";
+import { zeroAgents } from "@vm0/db/schema/zero-agent";
+import { command } from "ccstate";
+import { and, eq } from "drizzle-orm";
+
+import { bodyResultOf, queryOf } from "../context/request";
+import { request$ } from "../context/hono";
+import { writeDb$ } from "../external/db";
+import { nowDate } from "../external/time";
+import type { RouteEntry } from "../route";
+import {
+  isTestEndpointAllowed,
+  testEndpointNotFoundResponse,
+} from "./test-oauth-provider-helpers";
+import {
+  DEFAULT_TEST_EMAIL,
+  issueCliToken$,
+  testUserId,
+  testUserOrgId,
+  ensureTestOrg$,
+} from "../services/cli-auth.service";
+import { upsertOAuthConnector$ } from "../services/zero-connector-data.service";
+import { upsertOrgMultiAuthModelProvider$ } from "../services/zero-model-provider.service";
+import {
+  isCodexAuthJsonFreePlanError,
+  isCodexAuthJsonShapeError,
+  parseCodexAuthJson,
+} from "../services/codex-auth-json-parser";
+import { safeAsync } from "../utils";
+
+const ORG_SENTINEL_USER_ID = "__org__";
+
+const testApproveBody$ = bodyResultOf(cliAuthTestApproveContract.approve);
+const testApproveQuery$ = queryOf(cliAuthTestApproveContract.approve);
+const testTokenQuery$ = queryOf(cliAuthTestTokenContract.create);
+const testConnectorBody$ = bodyResultOf(cliAuthTestConnectorContract.create);
+const testConnectorQuery$ = queryOf(cliAuthTestConnectorContract.create);
+const testEnableConnectorBody$ = bodyResultOf(
+  cliAuthTestEnableConnectorContract.create,
+);
+const testEnableConnectorQuery$ = queryOf(
+  cliAuthTestEnableConnectorContract.create,
+);
+const testCodexOauthBody$ = bodyResultOf(cliAuthTestCodexOauthContract.create);
+const testCodexOauthQuery$ = queryOf(cliAuthTestCodexOauthContract.create);
+
+function stringError(status: 400 | 404, error: string) {
+  return { status, body: { error } };
+}
+
+function testEndpointAllowed(request: {
+  header: (name: string) => string | undefined;
+}) {
+  return isTestEndpointAllowed(request);
+}
+
+const approveDeviceForTest$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    if (optionalEnv("USE_MOCK_CLAUDE") !== "true") {
+      return testEndpointNotFoundResponse();
+    }
+
+    const bodyResult = await get(testApproveBody$);
+    signal.throwIfAborted();
+    if (!bodyResult.ok) {
+      return stringError(400, "device_code required");
+    }
+
+    const deviceCode = bodyResult.data.device_code;
+    if (!deviceCode) {
+      return stringError(400, "device_code required");
+    }
+
+    const normalizedCode = deviceCode.toUpperCase();
+    const writeDb = set(writeDb$);
+    const [session] = await writeDb
+      .select()
+      .from(deviceCodes)
+      .where(
+        and(
+          eq(deviceCodes.code, normalizedCode),
+          eq(deviceCodes.purpose, "cli"),
+        ),
+      )
+      .limit(1);
+    signal.throwIfAborted();
+
+    if (!session) {
+      return new Response("Not found", { status: 404 });
+    }
+    if (session.status !== "pending") {
+      return stringError(400, "Device code is not in pending status");
+    }
+    if (nowDate() > session.expiresAt) {
+      return stringError(400, "Device code has expired");
+    }
+
+    const query = get(testApproveQuery$);
+    const userId = await get(testUserId(query.email ?? DEFAULT_TEST_EMAIL));
+    signal.throwIfAborted();
+
+    await writeDb
+      .update(deviceCodes)
+      .set({ status: "authenticated", userId, updatedAt: nowDate() })
+      .where(eq(deviceCodes.code, normalizedCode));
+    signal.throwIfAborted();
+
+    return { status: 200 as const, body: { success: true as const, userId } };
+  },
+);
+
+const createTestToken$ = command(async ({ get, set }, signal: AbortSignal) => {
+  if (!testEndpointAllowed(get(request$))) {
+    return testEndpointNotFoundResponse();
+  }
+
+  const query = get(testTokenQuery$);
+  const userId = await get(testUserId(query.email ?? DEFAULT_TEST_EMAIL));
+  signal.throwIfAborted();
+  const { orgId } = await set(ensureTestOrg$, userId, signal);
+  signal.throwIfAborted();
+  const issued = await set(
+    issueCliToken$,
+    { userId, orgId, name: "CI Test Token" },
+    signal,
+  );
+  signal.throwIfAborted();
+
+  return {
+    status: 200 as const,
+    body: {
+      access_token: issued.token,
+      token_type: "Bearer" as const,
+      expires_in: issued.expiresIn,
+      user_id: userId,
+    },
+  };
+});
+
+async function testOrgForUser(
+  get: <T>(value: import("ccstate").Computed<T>) => T,
+  userId: string,
+): Promise<string | null> {
+  return await get(testUserOrgId(userId));
+}
+
+const createTestConnector$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    if (!testEndpointAllowed(get(request$))) {
+      return testEndpointNotFoundResponse();
+    }
+
+    const bodyResult = await get(testConnectorBody$);
+    signal.throwIfAborted();
+    if (!bodyResult.ok) {
+      return stringError(400, "connectorName and accessToken are required");
+    }
+
+    const connectorParsed = connectorTypeSchema.safeParse(
+      bodyResult.data.connectorName,
+    );
+    if (!connectorParsed.success) {
+      return stringError(
+        400,
+        `Unknown connector type: "${bodyResult.data.connectorName}"`,
+      );
+    }
+    const connectorType = connectorParsed.data;
+
+    const query = get(testConnectorQuery$);
+    const userId = await get(testUserId(query.email ?? DEFAULT_TEST_EMAIL));
+    signal.throwIfAborted();
+    const orgId = await testOrgForUser(get, userId);
+    signal.throwIfAborted();
+    if (!orgId) {
+      return stringError(400, "Test user has no org — run test-token first");
+    }
+
+    const refreshSecretName =
+      connectorType === "computer"
+        ? undefined
+        : PROVIDER_HANDLERS[connectorType].getRefreshSecretName?.();
+    await set(
+      upsertOAuthConnector$,
+      {
+        orgId,
+        userId,
+        type: connectorType,
+        accessToken: bodyResult.data.accessToken,
+        userInfo: {
+          id: `e2e-test-${connectorType}`,
+          username: `e2e-${connectorType}`,
+          email: `e2e-${connectorType}@test.vm0.ai`,
+        },
+        oauthScopes: [],
+        refreshToken: bodyResult.data.refreshToken,
+        refreshSecretName,
+        expiresIn: bodyResult.data.expiresIn,
+      },
+      signal,
+    );
+    signal.throwIfAborted();
+
+    return {
+      status: 200 as const,
+      body: { ok: true as const, connectorType, orgId },
+    };
+  },
+);
+
+const enableTestConnectors$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    if (!testEndpointAllowed(get(request$))) {
+      return testEndpointNotFoundResponse();
+    }
+
+    const bodyResult = await get(testEnableConnectorBody$);
+    signal.throwIfAborted();
+    if (!bodyResult.ok) {
+      return stringError(400, "composeId and connectorTypes are required");
+    }
+
+    const invalidTypes = bodyResult.data.connectorTypes.filter((type) => {
+      return !connectorTypeSchema.safeParse(type).success;
+    });
+    if (invalidTypes.length > 0) {
+      return stringError(
+        400,
+        `Unknown connector types: ${invalidTypes.join(", ")}`,
+      );
+    }
+
+    const query = get(testEnableConnectorQuery$);
+    const userId = await get(testUserId(query.email ?? DEFAULT_TEST_EMAIL));
+    signal.throwIfAborted();
+    const orgId = await testOrgForUser(get, userId);
+    signal.throwIfAborted();
+    if (!orgId) {
+      return stringError(400, "Test user has no org — run test-token first");
+    }
+
+    const writeDb = set(writeDb$);
+    const [compose] = await writeDb
+      .select({
+        id: agentComposes.id,
+        orgId: agentComposes.orgId,
+        userId: agentComposes.userId,
+        name: agentComposes.name,
+      })
+      .from(agentComposes)
+      .where(eq(agentComposes.id, bodyResult.data.composeId))
+      .limit(1);
+    signal.throwIfAborted();
+
+    if (!compose) {
+      return stringError(
+        404,
+        `Compose not found: ${bodyResult.data.composeId}`,
+      );
+    }
+
+    await writeDb
+      .insert(zeroAgents)
+      .values({
+        id: compose.id,
+        orgId: compose.orgId,
+        owner: compose.userId,
+        name: compose.name,
+      })
+      .onConflictDoNothing();
+    signal.throwIfAborted();
+
+    await writeDb.insert(userConnectors).values(
+      bodyResult.data.connectorTypes.map((connectorType) => {
+        return {
+          orgId,
+          userId,
+          agentId: compose.id,
+          connectorType,
+        };
+      }),
+    );
+    signal.throwIfAborted();
+
+    return {
+      status: 200 as const,
+      body: {
+        ok: true as const,
+        composeId: bodyResult.data.composeId,
+        connectorTypes: bodyResult.data.connectorTypes,
+      },
+    };
+  },
+);
+
+const seedCodexOauth$ = command(async ({ get, set }, signal: AbortSignal) => {
+  if (!testEndpointAllowed(get(request$))) {
+    return testEndpointNotFoundResponse();
+  }
+
+  const bodyResult = await get(testCodexOauthBody$);
+  signal.throwIfAborted();
+  if (!bodyResult.ok) {
+    return stringError(400, "Invalid body shape");
+  }
+
+  const query = get(testCodexOauthQuery$);
+  const userId = await get(testUserId(query.email ?? DEFAULT_TEST_EMAIL));
+  signal.throwIfAborted();
+  const orgId = await testOrgForUser(get, userId);
+  signal.throwIfAborted();
+  if (!orgId) {
+    return stringError(400, "Test user has no org — run test-token first");
+  }
+
+  if ("authJson" in bodyResult.data) {
+    const { authJson } = bodyResult.data;
+    const parsedResult = await safeAsync(() => {
+      return Promise.resolve(parseCodexAuthJson(authJson));
+    });
+    signal.throwIfAborted();
+    if ("error" in parsedResult) {
+      if (isCodexAuthJsonFreePlanError(parsedResult.error)) {
+        return stringError(400, "Free plan rejected by parser");
+      }
+      if (isCodexAuthJsonShapeError(parsedResult.error)) {
+        return stringError(
+          400,
+          `auth.json shape invalid: ${parsedResult.error.message}`,
+        );
+      }
+      throw parsedResult.error;
+    }
+
+    const parsed = parsedResult.ok;
+    await set(
+      upsertOrgMultiAuthModelProvider$,
+      {
+        orgId,
+        type: "codex-oauth-token",
+        authMethod: "auth_json",
+        secretValues: {
+          CHATGPT_ACCESS_TOKEN: parsed.accessToken,
+          CHATGPT_REFRESH_TOKEN: parsed.refreshToken,
+          CHATGPT_ACCOUNT_ID: parsed.accountId,
+          CHATGPT_ID_TOKEN: parsed.idToken,
+        },
+        metadata: {
+          tokenExpiresAt: parsed.tokenExpiresAt,
+          workspaceName: parsed.workspaceName,
+          planType: parsed.planType,
+        },
+      },
+      signal,
+    );
+    signal.throwIfAborted();
+    return {
+      status: 200 as const,
+      body: {
+        ok: true as const,
+        orgId,
+        tokenExpiresAt: parsed.tokenExpiresAt.toISOString(),
+      },
+    };
+  }
+
+  const tokenExpiresAt = new Date(
+    nowDate().getTime() + (bodyResult.data.expiresIn ?? 600) * 1000,
+  );
+  await set(
+    upsertOrgMultiAuthModelProvider$,
+    {
+      orgId,
+      type: "codex-oauth-token",
+      authMethod: "auth_json",
+      secretValues: {
+        CHATGPT_ACCESS_TOKEN: bodyResult.data.accessToken,
+        CHATGPT_REFRESH_TOKEN: bodyResult.data.refreshToken,
+        CHATGPT_ACCOUNT_ID: bodyResult.data.accountId,
+        CHATGPT_ID_TOKEN: bodyResult.data.idToken,
+      },
+      metadata: { tokenExpiresAt },
+    },
+    signal,
+  );
+  signal.throwIfAborted();
+
+  const writeDb = set(writeDb$);
+  await writeDb
+    .update(modelProviders)
+    .set({
+      tokenExpiresAt,
+      needsReconnect: bodyResult.data.needsReconnect ?? false,
+      lastRefreshErrorCode: bodyResult.data.lastRefreshErrorCode ?? null,
+      updatedAt: nowDate(),
+    })
+    .where(
+      and(
+        eq(modelProviders.orgId, orgId),
+        eq(modelProviders.userId, ORG_SENTINEL_USER_ID),
+        eq(modelProviders.type, "codex-oauth-token"),
+      ),
+    );
+  signal.throwIfAborted();
+
+  return {
+    status: 200 as const,
+    body: {
+      ok: true as const,
+      orgId,
+      tokenExpiresAt: tokenExpiresAt.toISOString(),
+    },
+  };
+});
+
+export const cliAuthTestRoutes: readonly RouteEntry[] = [
+  { route: cliAuthTestApproveContract.approve, handler: approveDeviceForTest$ },
+  { route: cliAuthTestTokenContract.create, handler: createTestToken$ },
+  { route: cliAuthTestConnectorContract.create, handler: createTestConnector$ },
+  {
+    route: cliAuthTestEnableConnectorContract.create,
+    handler: enableTestConnectors$,
+  },
+  { route: cliAuthTestCodexOauthContract.create, handler: seedCodexOauth$ },
+];

--- a/turbo/apps/api/src/signals/routes/cli-auth.ts
+++ b/turbo/apps/api/src/signals/routes/cli-auth.ts
@@ -1,0 +1,233 @@
+import { randomInt } from "node:crypto";
+
+import {
+  cliAuthDeviceContract,
+  cliAuthOrgContract,
+  cliAuthTokenContract,
+} from "@vm0/api-contracts/contracts/cli-auth";
+import { deviceCodes } from "@vm0/db/schema/device-codes";
+import { command } from "ccstate";
+import { and, eq } from "drizzle-orm";
+
+import { authContext$ } from "../auth/auth-context";
+import { authRoute } from "../auth/auth-route";
+import { bodyResultOf } from "../context/request";
+import { writeDb$ } from "../external/db";
+import { nowDate } from "../external/time";
+import type { RouteEntry } from "../route";
+import { getMemberRoleAndUpdateCache$ } from "../services/auth.service";
+import {
+  CLI_TOKEN_EXPIRES_IN_SECONDS,
+  issueCliToken$,
+  orgIdBySlug$,
+} from "../services/cli-auth.service";
+
+const DEVICE_CODE_CHARS = "ABCDEFGHJKMNPQRSTUVWXYZ23456789";
+const DEVICE_CODE_EXPIRES_IN_SECONDS = 900;
+const DEVICE_CODE_POLL_INTERVAL_SECONDS = 5;
+
+function generateDeviceCode(): string {
+  const chars = Array.from({ length: 8 }, () => {
+    return DEVICE_CODE_CHARS[randomInt(DEVICE_CODE_CHARS.length)];
+  });
+  return `${chars.slice(0, 4).join("")}-${chars.slice(4).join("")}`;
+}
+
+function oauthError(
+  status: 400 | 202 | 500,
+  error: string,
+  errorDescription: string,
+) {
+  return {
+    status,
+    body: { error, error_description: errorDescription },
+  };
+}
+
+const tokenBody$ = bodyResultOf(cliAuthTokenContract.exchange);
+const orgBody$ = bodyResultOf(cliAuthOrgContract.switchOrg);
+
+const createDeviceInner$ = command(async ({ set }, signal: AbortSignal) => {
+  const writeDb = set(writeDb$);
+  const deviceCode = generateDeviceCode();
+  const now = nowDate();
+  const expiresAt = new Date(
+    now.getTime() + DEVICE_CODE_EXPIRES_IN_SECONDS * 1000,
+  );
+
+  await writeDb.insert(deviceCodes).values({
+    code: deviceCode,
+    purpose: "cli",
+    status: "pending",
+    expiresAt,
+    createdAt: now,
+    updatedAt: now,
+  });
+  signal.throwIfAborted();
+
+  return {
+    status: 200 as const,
+    body: {
+      device_code: deviceCode,
+      user_code: deviceCode,
+      verification_path: "/cli-auth",
+      expires_in: DEVICE_CODE_EXPIRES_IN_SECONDS,
+      interval: DEVICE_CODE_POLL_INTERVAL_SECONDS,
+    },
+  };
+});
+
+const exchangeTokenInner$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const bodyResult = await get(tokenBody$);
+    signal.throwIfAborted();
+    if (!bodyResult.ok) {
+      return oauthError(
+        400,
+        "invalid_request",
+        bodyResult.response.body.error.message,
+      );
+    }
+
+    const writeDb = set(writeDb$);
+    const deviceCode = bodyResult.data.device_code;
+    const [session] = await writeDb
+      .select()
+      .from(deviceCodes)
+      .where(
+        and(eq(deviceCodes.code, deviceCode), eq(deviceCodes.purpose, "cli")),
+      )
+      .limit(1);
+    signal.throwIfAborted();
+
+    if (!session) {
+      return oauthError(400, "invalid_request", "Invalid device code");
+    }
+
+    if (nowDate() > session.expiresAt) {
+      return oauthError(400, "expired_token", "The device code has expired");
+    }
+
+    switch (session.status) {
+      case "pending": {
+        return oauthError(
+          202,
+          "authorization_pending",
+          "The user has not yet completed authorization in the browser",
+        );
+      }
+      case "denied": {
+        await writeDb
+          .delete(deviceCodes)
+          .where(eq(deviceCodes.code, deviceCode));
+        signal.throwIfAborted();
+        return oauthError(
+          400,
+          "access_denied",
+          "The user denied the authorization request",
+        );
+      }
+      case "authenticated": {
+        const issued = await set(
+          issueCliToken$,
+          {
+            userId: session.userId ?? "",
+            orgId: session.orgId ?? "",
+            name: "CLI Device Flow Authentication",
+          },
+          signal,
+        );
+        signal.throwIfAborted();
+
+        await writeDb
+          .delete(deviceCodes)
+          .where(eq(deviceCodes.code, deviceCode));
+        signal.throwIfAborted();
+
+        return {
+          status: 200 as const,
+          body: {
+            access_token: issued.token,
+            token_type: "Bearer" as const,
+            expires_in: issued.expiresIn,
+          },
+        };
+      }
+      default: {
+        return oauthError(500, "server_error", "Unknown device code status");
+      }
+    }
+  },
+);
+
+const switchOrgInner$ = command(async ({ get, set }, signal: AbortSignal) => {
+  const bodyResult = await get(orgBody$);
+  signal.throwIfAborted();
+  if (!bodyResult.ok) {
+    return oauthError(
+      400,
+      "invalid_request",
+      bodyResult.response.body.error.message,
+    );
+  }
+
+  const auth = get(authContext$);
+  const orgId = await set(orgIdBySlug$, bodyResult.data.slug, signal);
+  signal.throwIfAborted();
+  if (!orgId) {
+    return {
+      status: 404 as const,
+      body: {
+        error: { message: "Organization not found", code: "not_found" },
+      },
+    };
+  }
+
+  const membership = await set(
+    getMemberRoleAndUpdateCache$,
+    orgId,
+    auth.userId,
+    signal,
+  );
+  signal.throwIfAborted();
+  if (!membership) {
+    return {
+      status: 403 as const,
+      body: {
+        error: {
+          message: "Not a member of this organization",
+          code: "forbidden",
+        },
+      },
+    };
+  }
+
+  const issued = await set(
+    issueCliToken$,
+    {
+      userId: auth.userId,
+      orgId,
+      name: "CLI Org Switch",
+    },
+    signal,
+  );
+  signal.throwIfAborted();
+
+  return {
+    status: 200 as const,
+    body: {
+      access_token: issued.token,
+      token_type: "Bearer" as const,
+      expires_in: CLI_TOKEN_EXPIRES_IN_SECONDS,
+    },
+  };
+});
+
+export const cliAuthRoutes: readonly RouteEntry[] = [
+  { route: cliAuthDeviceContract.create, handler: createDeviceInner$ },
+  { route: cliAuthTokenContract.exchange, handler: exchangeTokenInner$ },
+  {
+    route: cliAuthOrgContract.switchOrg,
+    handler: authRoute({ accept: ["pat"] }, switchOrgInner$),
+  },
+];

--- a/turbo/apps/api/src/signals/services/cli-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/cli-auth.service.ts
@@ -1,0 +1,268 @@
+import { randomUUID } from "node:crypto";
+
+import { cliTokens } from "@vm0/db/schema/cli-tokens";
+import { creditExpiresRecord } from "@vm0/db/schema/credit-expires-record";
+import { orgCache } from "@vm0/db/schema/org-cache";
+import { orgMembersCache } from "@vm0/db/schema/org-members-cache";
+import { orgMetadata } from "@vm0/db/schema/org-metadata";
+import { command, computed, type Computed } from "ccstate";
+import { desc, eq, sql } from "drizzle-orm";
+
+import { generateCliToken } from "../auth/tokens";
+import { clerk$ } from "../external/clerk";
+import { db$, writeDb$ } from "../external/db";
+import { nowDate } from "../external/time";
+import { safeAsync } from "../utils";
+
+export const DEFAULT_TEST_EMAIL = "dev+clerk_test+serial@vm0-e2e.ai";
+export const CLI_TOKEN_EXPIRES_IN_SECONDS = 90 * 24 * 60 * 60;
+
+const STARTER_GRANT_AMOUNT = 10_000;
+const STARTER_GRANT_SOURCE = "starter_grant";
+const FAR_FUTURE_CACHE_MS = 365 * 24 * 60 * 60 * 1000;
+const ORG_CACHE_TTL_MS = 60_000;
+
+interface IssuedCliToken {
+  readonly token: string;
+  readonly expiresIn: number;
+}
+
+function isClerkNotFound(error: unknown): boolean {
+  if (typeof error !== "object" || error === null) {
+    return false;
+  }
+  return (
+    Reflect.get(error, "statusCode") === 404 ||
+    Reflect.get(error, "code") === "NOT_FOUND" ||
+    Reflect.get(error, "name") === "NotFoundError"
+  );
+}
+
+export const orgIdBySlug$ = command(
+  async (
+    { get, set },
+    slug: string,
+    signal: AbortSignal,
+  ): Promise<string | null> => {
+    const [cached] = await get(db$)
+      .select({ orgId: orgCache.orgId, cachedAt: orgCache.cachedAt })
+      .from(orgCache)
+      .where(eq(orgCache.slug, slug))
+      .limit(1);
+    signal.throwIfAborted();
+
+    const currentTime = nowDate();
+    if (
+      cached &&
+      currentTime.getTime() - cached.cachedAt.getTime() < ORG_CACHE_TTL_MS
+    ) {
+      return cached.orgId;
+    }
+
+    const client = get(clerk$);
+    const result = await safeAsync(() => {
+      return client.organizations.getOrganization({ slug });
+    });
+    signal.throwIfAborted();
+
+    if ("error" in result) {
+      if (isClerkNotFound(result.error)) {
+        return null;
+      }
+      throw result.error;
+    }
+
+    const org = result.ok;
+    if (!org.slug) {
+      return null;
+    }
+
+    const writeDb = set(writeDb$);
+    await writeDb
+      .insert(orgCache)
+      .values({
+        orgId: org.id,
+        slug: org.slug,
+        name: org.name,
+        createdBy: org.createdBy ?? null,
+        cachedAt: currentTime,
+      })
+      .onConflictDoUpdate({
+        target: orgCache.orgId,
+        set: {
+          slug: org.slug,
+          name: org.name,
+          createdBy: org.createdBy ?? null,
+          cachedAt: currentTime,
+        },
+      });
+    signal.throwIfAborted();
+
+    return org.id;
+  },
+);
+
+export const issueCliToken$ = command(
+  async (
+    { set },
+    args: {
+      readonly userId: string;
+      readonly orgId: string;
+      readonly name: string;
+    },
+    _signal: AbortSignal,
+  ): Promise<IssuedCliToken> => {
+    const writeDb = set(writeDb$);
+    const tokenId = randomUUID();
+    const now = nowDate();
+    const expiresAt = new Date(
+      now.getTime() + CLI_TOKEN_EXPIRES_IN_SECONDS * 1000,
+    );
+    const token = generateCliToken(args.userId, args.orgId, tokenId);
+
+    await writeDb.insert(cliTokens).values({
+      id: tokenId,
+      token,
+      userId: args.userId,
+      name: args.name,
+      expiresAt,
+      createdAt: now,
+    });
+
+    return { token, expiresIn: CLI_TOKEN_EXPIRES_IN_SECONDS };
+  },
+);
+
+export function testUserId(email: string): Computed<Promise<string>> {
+  return computed(async (get): Promise<string> => {
+    const { data: users } = await get(clerk$).users.getUserList({
+      emailAddress: [email],
+    });
+    const userId = users[0]?.id;
+    if (!userId) {
+      throw new Error(`Test user not found for email: ${email}`);
+    }
+    return userId;
+  });
+}
+
+function clerkRoleToCacheRole(role: string): "admin" | "member" {
+  return role === "org:admin" ? "admin" : "member";
+}
+
+const ensureStarterCreditGrant$ = command(
+  async ({ set }, orgId: string, _signal: AbortSignal): Promise<void> => {
+    const writeDb = set(writeDb$);
+    await writeDb.transaction(async (tx) => {
+      const [existing] = await tx
+        .select({ orgId: orgMetadata.orgId })
+        .from(orgMetadata)
+        .where(eq(orgMetadata.orgId, orgId))
+        .limit(1);
+      if (existing) {
+        return;
+      }
+
+      const expiresAt = nowDate();
+      expiresAt.setMonth(expiresAt.getMonth() + 1);
+      const inserted = await tx
+        .insert(creditExpiresRecord)
+        .values({
+          orgId,
+          source: STARTER_GRANT_SOURCE,
+          stripeInvoiceId: null,
+          amount: STARTER_GRANT_AMOUNT,
+          remaining: STARTER_GRANT_AMOUNT,
+          expiresAt,
+        })
+        .onConflictDoNothing()
+        .returning({ id: creditExpiresRecord.id });
+      if (inserted.length === 0) {
+        return;
+      }
+
+      await tx.execute(
+        sql`INSERT INTO org_metadata (org_id, credits, created_at, updated_at)
+            VALUES (${orgId}, ${STARTER_GRANT_AMOUNT}, now(), now())
+            ON CONFLICT (org_id)
+            DO UPDATE SET credits = org_metadata.credits + ${STARTER_GRANT_AMOUNT}, updated_at = now()`,
+      );
+    });
+  },
+);
+
+export const ensureTestOrg$ = command(
+  async (
+    { get, set },
+    userId: string,
+    signal: AbortSignal,
+  ): Promise<{ readonly orgId: string }> => {
+    const memberships = await get(clerk$).users.getOrganizationMembershipList({
+      userId,
+    });
+    signal.throwIfAborted();
+
+    const ordered = [...memberships.data].sort((a, b) => {
+      return a.createdAt - b.createdAt;
+    });
+    const membership = ordered[0];
+    if (!membership) {
+      throw new Error(`Test user ${userId} has no organization membership`);
+    }
+
+    const org = membership.organization;
+    const writeDb = set(writeDb$);
+    const [cached] = await writeDb
+      .select({ orgId: orgCache.orgId })
+      .from(orgCache)
+      .where(eq(orgCache.orgId, org.id))
+      .limit(1);
+    signal.throwIfAborted();
+
+    if (!cached) {
+      await writeDb.insert(orgCache).values({
+        orgId: org.id,
+        slug: org.slug ?? org.id,
+        name: org.name ?? org.slug ?? org.id,
+        cachedAt: new Date(nowDate().getTime() + FAR_FUTURE_CACHE_MS),
+      });
+      signal.throwIfAborted();
+    }
+
+    await writeDb
+      .insert(orgMembersCache)
+      .values({
+        orgId: org.id,
+        userId,
+        role: clerkRoleToCacheRole(membership.role),
+        cachedAt: new Date(nowDate().getTime() + FAR_FUTURE_CACHE_MS),
+      })
+      .onConflictDoUpdate({
+        target: [orgMembersCache.orgId, orgMembersCache.userId],
+        set: {
+          role: clerkRoleToCacheRole(membership.role),
+          cachedAt: new Date(nowDate().getTime() + FAR_FUTURE_CACHE_MS),
+        },
+      });
+    signal.throwIfAborted();
+
+    await set(ensureStarterCreditGrant$, org.id, signal);
+    signal.throwIfAborted();
+
+    return { orgId: org.id };
+  },
+);
+
+export function testUserOrgId(
+  userId: string,
+): Computed<Promise<string | null>> {
+  return computed(async (get): Promise<string | null> => {
+    const [cached] = await get(db$)
+      .select({ orgId: orgMembersCache.orgId })
+      .from(orgMembersCache)
+      .where(eq(orgMembersCache.userId, userId))
+      .orderBy(desc(orgMembersCache.cachedAt))
+      .limit(1);
+    return cached?.orgId ?? null;
+  });
+}

--- a/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
@@ -55,6 +55,7 @@ type StoredConnectorRow = {
 
 const oauthScopesSchema = z.array(z.string());
 const DEFAULT_ACCESS_TOKEN_EXPIRES_IN_SECS = 3600;
+const COMPUTER_CONNECTOR_AUTH_TOKEN_SECRET = "COMPUTER_CONNECTOR_AUTHTOKEN";
 const COMPUTER_CONNECTOR_SECRET_NAMES = [
   "COMPUTER_CONNECTOR_BRIDGE_TOKEN",
   "COMPUTER_CONNECTOR_DOMAIN_ID",
@@ -69,6 +70,13 @@ interface ExternalUserInfo {
 
 function parseOauthScopes(value: string | null): string[] | null {
   return value ? oauthScopesSchema.parse(JSON.parse(value)) : null;
+}
+
+function getSecretNameForConnector(type: ConnectorType): string {
+  if (type === "computer") {
+    return COMPUTER_CONNECTOR_AUTH_TOKEN_SECRET;
+  }
+  return PROVIDER_HANDLERS[type].getSecretName();
 }
 
 function storedConnectorRowToResponse(
@@ -613,10 +621,12 @@ async function upsertConnectorSecret(
 }
 
 function connectorTokenExpiresAt(args: {
-  readonly type: Exclude<ConnectorType, "computer">;
+  readonly type: ConnectorType;
   readonly expiresIn: number | undefined;
 }): Date | null {
-  const isRefreshable = Boolean(PROVIDER_HANDLERS[args.type].refreshToken);
+  const isRefreshable =
+    args.type !== "computer" &&
+    Boolean(PROVIDER_HANDLERS[args.type].refreshToken);
   const fallbackSecs = isRefreshable
     ? DEFAULT_ACCESS_TOKEN_EXPIRES_IN_SECS
     : null;
@@ -632,7 +642,7 @@ export const upsertOAuthConnector$ = command(
     args: {
       readonly orgId: string;
       readonly userId: string;
-      readonly type: Exclude<ConnectorType, "computer">;
+      readonly type: ConnectorType;
       readonly accessToken: string;
       readonly userInfo: ExternalUserInfo;
       readonly oauthScopes: readonly string[];
@@ -646,7 +656,6 @@ export const upsertOAuthConnector$ = command(
     readonly created: boolean;
   }> => {
     const writeDb = set(writeDb$);
-    const handler = PROVIDER_HANDLERS[args.type];
     const tokenExpiresAt = connectorTokenExpiresAt({
       type: args.type,
       expiresIn: args.expiresIn,
@@ -655,7 +664,7 @@ export const upsertOAuthConnector$ = command(
     await upsertConnectorSecret(writeDb, {
       orgId: args.orgId,
       userId: args.userId,
-      name: handler.getSecretName(),
+      name: getSecretNameForConnector(args.type),
       value: args.accessToken,
       description: `OAuth token for ${args.type} connector`,
     });

--- a/turbo/packages/api-contracts/src/contracts/cli-auth-test.ts
+++ b/turbo/packages/api-contracts/src/contracts/cli-auth-test.ts
@@ -1,0 +1,137 @@
+import { z } from "zod";
+import { initContract } from "./base";
+
+const c = initContract();
+
+const testEmailQuerySchema = z.object({
+  email: z.string().optional(),
+});
+
+const stringErrorResponseSchema = z.object({
+  error: z.string(),
+});
+
+const notFoundTextSchema = z.string();
+
+export const cliAuthTestApproveContract = c.router({
+  approve: {
+    method: "POST",
+    path: "/api/cli/auth/test-approve",
+    query: testEmailQuerySchema,
+    body: z.object({
+      device_code: z.string().optional(),
+    }),
+    responses: {
+      200: z.object({ success: z.literal(true), userId: z.string() }),
+      400: stringErrorResponseSchema,
+      404: notFoundTextSchema,
+    },
+    summary: "Approve a CLI auth device code for tests",
+  },
+});
+
+export const cliAuthTestTokenContract = c.router({
+  create: {
+    method: "POST",
+    path: "/api/cli/auth/test-token",
+    query: testEmailQuerySchema,
+    body: z.object({}).optional(),
+    responses: {
+      200: z.object({
+        access_token: z.string(),
+        token_type: z.literal("Bearer"),
+        expires_in: z.number(),
+        user_id: z.string(),
+      }),
+      404: notFoundTextSchema,
+    },
+    summary: "Create a CLI auth token for tests",
+  },
+});
+
+export const cliAuthTestConnectorContract = c.router({
+  create: {
+    method: "POST",
+    path: "/api/cli/auth/test-connector",
+    query: testEmailQuerySchema,
+    body: z.object({
+      connectorName: z.string(),
+      accessToken: z.string(),
+      refreshToken: z.string().min(1).optional(),
+      expiresIn: z.number().int().optional(),
+    }),
+    responses: {
+      200: z.object({
+        ok: z.literal(true),
+        connectorType: z.string(),
+        orgId: z.string(),
+      }),
+      400: stringErrorResponseSchema,
+      404: notFoundTextSchema.or(stringErrorResponseSchema),
+    },
+    summary: "Seed an OAuth connector for tests",
+  },
+});
+
+export const cliAuthTestEnableConnectorContract = c.router({
+  create: {
+    method: "POST",
+    path: "/api/cli/auth/test-enable-connector",
+    query: testEmailQuerySchema,
+    body: z.object({
+      composeId: z.string().uuid(),
+      connectorTypes: z.array(z.string()).min(1),
+    }),
+    responses: {
+      200: z.object({
+        ok: z.literal(true),
+        composeId: z.string(),
+        connectorTypes: z.array(z.string()),
+      }),
+      400: stringErrorResponseSchema,
+      404: notFoundTextSchema.or(stringErrorResponseSchema),
+    },
+    summary: "Enable connector rows for a test compose",
+  },
+});
+
+const codexLegacyBodySchema = z.object({
+  accessToken: z.string().min(1),
+  refreshToken: z.string().min(1),
+  accountId: z.string().min(1),
+  idToken: z.string().min(1),
+  expiresIn: z.number().int().optional(),
+  needsReconnect: z.boolean().optional(),
+  lastRefreshErrorCode: z.string().nullable().optional(),
+});
+
+const codexAuthJsonBodySchema = z.object({
+  authJson: z.string().min(1),
+});
+
+export const cliAuthTestCodexOauthContract = c.router({
+  create: {
+    method: "POST",
+    path: "/api/cli/auth/test-codex-oauth",
+    query: testEmailQuerySchema,
+    body: z.union([codexAuthJsonBodySchema, codexLegacyBodySchema]),
+    responses: {
+      200: z.object({
+        ok: z.literal(true).optional(),
+        orgId: z.string(),
+        tokenExpiresAt: z.string().optional(),
+      }),
+      400: stringErrorResponseSchema,
+      404: notFoundTextSchema,
+    },
+    summary: "Seed Codex OAuth model provider state for tests",
+  },
+});
+
+export type CliAuthTestApproveContract = typeof cliAuthTestApproveContract;
+export type CliAuthTestTokenContract = typeof cliAuthTestTokenContract;
+export type CliAuthTestConnectorContract = typeof cliAuthTestConnectorContract;
+export type CliAuthTestEnableConnectorContract =
+  typeof cliAuthTestEnableConnectorContract;
+export type CliAuthTestCodexOauthContract =
+  typeof cliAuthTestCodexOauthContract;


### PR DESCRIPTION
## Summary
- move CLI auth device, token, org-switch, and CLI test helper routes into apps/api
- add shared API service logic for issuing CLI PATs and seeding the CLI test org
- add api-contracts coverage and API integration tests for device flow, org switching, connector setup, and Codex OAuth test setup

Closes #12848

## Issue plan
- Research: https://github.com/vm0-ai/vm0/issues/12848#issuecomment-4429451800
- Innovation: https://github.com/vm0-ai/vm0/issues/12848#issuecomment-4429452739
- Plan: https://github.com/vm0-ai/vm0/issues/12848#issuecomment-4429454168

## Validation
- pnpm -F api-contracts check-types
- pnpm -F api lint
- pnpm -F api exec vitest src/signals/routes/__tests__/cli-auth.test.ts
- pnpm knip
- git diff --check
- pnpm -F api exec tsc --noEmit --pretty false 2>&1 | rg "src/signals/routes/__tests__/cli-auth.test.ts|src/signals/routes/cli-auth|src/signals/services/cli-auth|src/signals/services/zero-connector-data|packages/api-contracts/src/contracts/cli-auth-test|src/signals/route.ts" (no matches)

## Local check note
- pnpm check-types currently fails in @vm0/app with existing platform ts-rest client typing errors outside this PR's touched files. The API-specific typecheck filter above has no #12848 file matches.