### PR TITLE
feat(api): implement agent run create and cancel routes

### DIFF
--- a/turbo/apps/api/src/signals/external/realtime.ts
+++ b/turbo/apps/api/src/signals/external/realtime.ts
@@ -4,6 +4,7 @@ import type { RemoteAgentRealtimeSubscription } from "@vm0/api-contracts/contrac
 import { env } from "../../lib/env";
 import { logger } from "../../lib/log";
 import { singleton } from "../../lib/singleton";
+import { safeAsync } from "../utils";
 
 const L = logger("Realtime");
 
@@ -136,6 +137,27 @@ export async function publishCancelToRunnerGroup(
   const channel = client.channels.get(`runner-group:${group}`);
   await channel.publish("cancel", { runId });
   L.debug(`Published cancel ${runId} to runner-group:${group}`);
+}
+
+export async function publishRunnerJobNotification(
+  group: string,
+  runId: string,
+  profile: string,
+): Promise<boolean> {
+  const result = await safeAsync(async () => {
+    const channel = ablyClient().channels.get(`runner-group:${group}`);
+    await channel.publish("job", { runId, profile });
+    L.debug(`Published job ${runId} to runner-group:${group}`);
+  });
+  if ("ok" in result) {
+    return true;
+  }
+  L.warn("Failed to publish runner job notification", {
+    group,
+    runId,
+    error: result.error,
+  });
+  return false;
 }
 
 export async function createRemoteAgentDeviceRealtimeSubscription(

--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -6,6 +6,8 @@ import { agentComposesByIdRoutes } from "./routes/agent-composes-id";
 import { agentComposesMetadataRoutes } from "./routes/agent-composes-metadata";
 import { agentComposesReadRoutes } from "./routes/agent-composes-read";
 import { agentComposesRoutes } from "./routes/agent-composes";
+import { agentRunsCancelRoutes } from "./routes/agent-runs-cancel";
+import { agentRunsCreateRoutes } from "./routes/agent-runs-create";
 import { agentRunsReadRoutes } from "./routes/agent-runs-read";
 import { agentRunTelemetryRoutes } from "./routes/agent-run-telemetry";
 import { agentSessionsRoutes } from "./routes/agent-sessions-id";
@@ -155,6 +157,8 @@ export const ROUTES: readonly RouteEntry[] = [
   ...agentComposesByIdRoutes,
   ...agentComposesMetadataRoutes,
   ...agentComposesRoutes,
+  ...agentRunsCreateRoutes,
+  ...agentRunsCancelRoutes,
   ...agentRunsReadRoutes,
   ...agentRunTelemetryRoutes,
   ...agentSessionsRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/agent-runs-cancel.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/agent-runs-cancel.test.ts
@@ -1,0 +1,303 @@
+import { randomUUID } from "node:crypto";
+
+import { runsCancelContract } from "@vm0/api-contracts/contracts/runs";
+import { agentRunQueue } from "@vm0/db/schema/agent-run-queue";
+import { agentRuns } from "@vm0/db/schema/agent-run";
+import { createStore } from "ccstate";
+import { eq } from "drizzle-orm";
+import { describe, expect, it } from "vitest";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { signSandboxJwtForTests } from "../../auth/tokens";
+import { writeDb$ } from "../../external/db";
+import { now, nowDate } from "../../external/time";
+import { clearAllDetached } from "../../utils";
+import {
+  createFixtureTracker,
+  createZeroRouteMocks,
+} from "./helpers/zero-route-test";
+import {
+  deleteUsageInsightFixture$,
+  seedCompose$,
+  seedRun$,
+  seedUsageInsightFixture$,
+  type UsageInsightFixture,
+} from "./helpers/zero-usage-insight";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+
+const track = createFixtureTracker<UsageInsightFixture>((fixture) => {
+  return store.set(deleteUsageInsightFixture$, fixture, context.signal);
+});
+
+function cancelClient() {
+  return setupApp({ context })(runsCancelContract);
+}
+
+function currentSecond(): number {
+  return Math.floor(now() / 1000);
+}
+
+function sandboxToken(args: {
+  readonly userId: string;
+  readonly orgId: string;
+  readonly runId: string;
+}): string {
+  const seconds = currentSecond();
+  return signSandboxJwtForTests({
+    scope: "sandbox",
+    userId: args.userId,
+    orgId: args.orgId,
+    runId: args.runId,
+    iat: seconds,
+    exp: seconds + 60,
+  });
+}
+
+async function fixture(): Promise<{
+  readonly fixture: UsageInsightFixture;
+  readonly composeId: string;
+}> {
+  const fx = await track(
+    store.set(seedUsageInsightFixture$, undefined, context.signal),
+  );
+  const compose = await store.set(
+    seedCompose$,
+    { orgId: fx.orgId, userId: fx.userId },
+    context.signal,
+  );
+  mocks.clerk.session(fx.userId, fx.orgId);
+  return { fixture: fx, composeId: compose.composeId };
+}
+
+async function createRun(args: {
+  readonly fixture: UsageInsightFixture;
+  readonly composeId: string;
+  readonly status: string;
+}): Promise<string> {
+  const { runId } = await store.set(
+    seedRun$,
+    {
+      orgId: args.fixture.orgId,
+      userId: args.fixture.userId,
+      composeId: args.composeId,
+      status: args.status,
+    },
+    context.signal,
+  );
+  return runId;
+}
+
+describe("POST /api/agent/runs/:id/cancel", () => {
+  it("returns 401 when unauthenticated", async () => {
+    const response = await accept(
+      cancelClient().cancel({
+        params: { id: randomUUID() },
+        headers: {},
+      }),
+      [401],
+    );
+
+    expect(response.body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("returns 404 when the run does not exist", async () => {
+    await fixture();
+
+    const response = await accept(
+      cancelClient().cancel({
+        params: { id: randomUUID() },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [404],
+    );
+
+    expect(response.body.error.code).toBe("NOT_FOUND");
+  });
+
+  it("cancels a running run and publishes side effects", async () => {
+    const fx = await fixture();
+    const runId = await createRun({
+      fixture: fx.fixture,
+      composeId: fx.composeId,
+      status: "running",
+    });
+
+    const response = await accept(
+      cancelClient().cancel({
+        params: { id: runId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      id: runId,
+      status: "cancelled",
+      message: "Run cancelled successfully",
+    });
+
+    const db = store.set(writeDb$);
+    const [run] = await db
+      .select({ status: agentRuns.status })
+      .from(agentRuns)
+      .where(eq(agentRuns.id, runId));
+    expect(run?.status).toBe("cancelled");
+
+    await clearAllDetached();
+    expect(context.mocks.ably.publish).toHaveBeenCalledWith(
+      "queue:changed",
+      null,
+    );
+    expect(context.mocks.ably.publish).toHaveBeenCalledWith(
+      `runChanged:${runId}`,
+      { status: "cancelled" },
+    );
+  });
+
+  it("cancels a queued run and removes its queue entry", async () => {
+    const fx = await fixture();
+    const runId = await createRun({
+      fixture: fx.fixture,
+      composeId: fx.composeId,
+      status: "queued",
+    });
+    const db = store.set(writeDb$);
+    await db.insert(agentRunQueue).values({
+      runId,
+      orgId: fx.fixture.orgId,
+      userId: fx.fixture.userId,
+      createdAt: nowDate(),
+      expiresAt: new Date(now() + 60_000),
+    });
+
+    await accept(
+      cancelClient().cancel({
+        params: { id: runId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    const queueRows = await db
+      .select()
+      .from(agentRunQueue)
+      .where(eq(agentRunQueue.runId, runId));
+    expect(queueRows).toHaveLength(0);
+  });
+
+  it("returns 200 for an already-cancelled run without side effects", async () => {
+    const fx = await fixture();
+    const runId = await createRun({
+      fixture: fx.fixture,
+      composeId: fx.composeId,
+      status: "cancelled",
+    });
+
+    const response = await accept(
+      cancelClient().cancel({
+        params: { id: runId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body.status).toBe("cancelled");
+    await clearAllDetached();
+    expect(context.mocks.ably.publish).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 RUN_NOT_CANCELLABLE for completed runs", async () => {
+    const fx = await fixture();
+    const runId = await createRun({
+      fixture: fx.fixture,
+      composeId: fx.composeId,
+      status: "completed",
+    });
+
+    const response = await accept(
+      cancelClient().cancel({
+        params: { id: runId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [400],
+    );
+
+    expect(response.body.error.code).toBe("RUN_NOT_CANCELLABLE");
+  });
+
+  it("returns 404 for a run in another org", async () => {
+    const owner = await fixture();
+    const runId = await createRun({
+      fixture: owner.fixture,
+      composeId: owner.composeId,
+      status: "running",
+    });
+    const other = await track(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    mocks.clerk.session(other.userId, other.orgId);
+
+    const response = await accept(
+      cancelClient().cancel({
+        params: { id: runId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [404],
+    );
+
+    expect(response.body.error.code).toBe("NOT_FOUND");
+  });
+
+  it("accepts a sandbox token with any capability", async () => {
+    const fx = await fixture();
+    const runId = await createRun({
+      fixture: fx.fixture,
+      composeId: fx.composeId,
+      status: "running",
+    });
+
+    const response = await accept(
+      cancelClient().cancel({
+        params: { id: runId },
+        headers: {
+          authorization: `Bearer ${sandboxToken({
+            userId: fx.fixture.userId,
+            orgId: fx.fixture.orgId,
+            runId,
+          })}`,
+        },
+      }),
+      [200],
+    );
+
+    expect(response.body.status).toBe("cancelled");
+  });
+
+  it("returns 404 when the sandbox token source run is missing", async () => {
+    const fx = await fixture();
+    const runId = await createRun({
+      fixture: fx.fixture,
+      composeId: fx.composeId,
+      status: "running",
+    });
+
+    const response = await accept(
+      cancelClient().cancel({
+        params: { id: runId },
+        headers: {
+          authorization: `Bearer ${sandboxToken({
+            userId: fx.fixture.userId,
+            orgId: fx.fixture.orgId,
+            runId: randomUUID(),
+          })}`,
+        },
+      }),
+      [404],
+    );
+
+    expect(response.body.error.code).toBe("NOT_FOUND");
+  });
+});

--- a/turbo/apps/api/src/signals/routes/__tests__/agent-runs-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/agent-runs-create.test.ts
@@ -1,0 +1,926 @@
+import { randomUUID } from "node:crypto";
+
+import { runsMainContract } from "@vm0/api-contracts/contracts/runs";
+import {
+  agentComposes,
+  agentComposeVersions,
+} from "@vm0/db/schema/agent-compose";
+import { VOLUME_ORG_USER_ID } from "@vm0/core";
+import { agentRuns } from "@vm0/db/schema/agent-run";
+import { agentSessions } from "@vm0/db/schema/agent-session";
+import { conversations } from "@vm0/db/schema/conversation";
+import { checkpoints } from "@vm0/db/schema/checkpoint";
+import { orgMetadata } from "@vm0/db/schema/org-metadata";
+import { runnerJobQueue } from "@vm0/db/schema/runner-job-queue";
+import { storages, storageVersions } from "@vm0/db/schema/storage";
+import { userCache } from "@vm0/db/schema/user-cache";
+import { zeroAgents } from "@vm0/db/schema/zero-agent";
+import { createStore, command } from "ccstate";
+import { eq } from "drizzle-orm";
+import { describe, expect, it } from "vitest";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { signSandboxJwtForTests } from "../../auth/tokens";
+import { writeDb$ } from "../../external/db";
+import { mockEnv, mockOptionalEnv } from "../../../lib/env";
+import { decryptSecretsMap } from "../../services/crypto.utils";
+import { now, nowDate } from "../../external/time";
+import {
+  createFixtureTracker,
+  createZeroRouteMocks,
+} from "./helpers/zero-route-test";
+import {
+  deleteUsageInsightFixture$,
+  seedUsageInsightFixture$,
+  type UsageInsightFixture,
+} from "./helpers/zero-usage-insight";
+import {
+  deleteOrgModelProviders$,
+  seedOrgModelProvider$,
+} from "./helpers/zero-model-providers";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+
+interface AgentConfig {
+  readonly framework?: "claude-code" | "codex";
+  readonly environment?: Record<string, string>;
+  readonly volumes?: readonly string[];
+  readonly experimental_runner?: { readonly group?: string };
+  readonly experimental_profile?: string;
+}
+
+interface ComposeSeed {
+  readonly fixture: UsageInsightFixture;
+  readonly name?: string;
+  readonly overrides?: AgentConfig;
+  readonly artifacts?: readonly {
+    readonly name: string;
+    readonly version?: string;
+    readonly mount_path?: string;
+  }[];
+  readonly volumes?: Record<
+    string,
+    {
+      readonly name: string;
+      readonly version: string;
+      readonly optional?: boolean;
+    }
+  >;
+}
+
+type StorageType = "artifact" | "volume";
+
+const seedRunnableCompose$ = command(
+  async (
+    { set },
+    args: ComposeSeed,
+    signal: AbortSignal,
+  ): Promise<{ readonly composeId: string; readonly versionId: string }> => {
+    const db = set(writeDb$);
+    const name = args.name ?? `agent-${randomUUID().slice(0, 8)}`;
+    const versionId = randomUUID();
+    const content = {
+      version: "1.0",
+      agents: {
+        [name]: {
+          framework: "claude-code",
+          environment: { ANTHROPIC_API_KEY: "test-key" },
+          ...args.overrides,
+        },
+      },
+      ...(args.volumes ? { volumes: args.volumes } : {}),
+      ...(args.artifacts ? { artifacts: args.artifacts } : {}),
+    };
+
+    const [compose] = await db
+      .insert(agentComposes)
+      .values({
+        userId: args.fixture.userId,
+        orgId: args.fixture.orgId,
+        name,
+      })
+      .returning({ id: agentComposes.id });
+    signal.throwIfAborted();
+    if (!compose) {
+      throw new Error("compose insert returned no row");
+    }
+
+    await db.insert(agentComposeVersions).values({
+      id: versionId,
+      composeId: compose.id,
+      content,
+      createdBy: args.fixture.userId,
+    });
+    signal.throwIfAborted();
+    await db
+      .update(agentComposes)
+      .set({ headVersionId: versionId })
+      .where(eq(agentComposes.id, compose.id));
+    signal.throwIfAborted();
+    await db.insert(zeroAgents).values({
+      id: compose.id,
+      orgId: args.fixture.orgId,
+      owner: args.fixture.userId,
+      name,
+      visibility: "public",
+    });
+    signal.throwIfAborted();
+
+    return { composeId: compose.id, versionId };
+  },
+);
+
+const seedConversationForSession$ = command(
+  async (
+    { set },
+    args: { readonly runId: string; readonly sessionId: string },
+    signal: AbortSignal,
+  ): Promise<string> => {
+    const db = set(writeDb$);
+    const [conversation] = await db
+      .insert(conversations)
+      .values({
+        runId: args.runId,
+        cliAgentType: "claude-code",
+        cliAgentSessionId: `session-${args.runId}`,
+        cliAgentSessionHistory: "{}",
+      })
+      .returning({ id: conversations.id });
+    signal.throwIfAborted();
+    if (!conversation) {
+      throw new Error("conversation insert returned no row");
+    }
+    await db
+      .update(agentSessions)
+      .set({ conversationId: conversation.id })
+      .where(eq(agentSessions.id, args.sessionId));
+    signal.throwIfAborted();
+    return conversation.id;
+  },
+);
+
+const track = createFixtureTracker<UsageInsightFixture>((fixture) => {
+  return store.set(deleteUsageInsightFixture$, fixture, context.signal);
+});
+const trackModelProviders = createFixtureTracker<{ readonly orgId: string }>(
+  (modelProviderFixture) => {
+    return store.set(
+      deleteOrgModelProviders$,
+      modelProviderFixture,
+      context.signal,
+    );
+  },
+);
+
+function runsClient() {
+  return setupApp({ context })(runsMainContract);
+}
+
+function vm0Template(expression: string): string {
+  return `$${expression}`;
+}
+
+async function fixture(): Promise<UsageInsightFixture> {
+  const created = await track(
+    store.set(seedUsageInsightFixture$, undefined, context.signal),
+  );
+  mocks.clerk.session(created.userId, created.orgId);
+  context.mocks.s3.send.mockResolvedValue({});
+  mockOptionalEnv("RUNNER_DEFAULT_GROUP", "vm0/test");
+  return created;
+}
+
+async function createCompose(
+  args: ComposeSeed,
+): Promise<{ readonly composeId: string; readonly versionId: string }> {
+  return await store.set(seedRunnableCompose$, args, context.signal);
+}
+
+async function seedStorage(args: {
+  readonly fixture: UsageInsightFixture;
+  readonly type: StorageType;
+  readonly name: string;
+  readonly versionId?: string;
+}): Promise<string> {
+  const db = store.set(writeDb$);
+  const storageId = randomUUID();
+  const versionId = args.versionId ?? randomUUID().replaceAll("-", "");
+  const userId =
+    args.type === "volume" ? VOLUME_ORG_USER_ID : args.fixture.userId;
+  await db.insert(storages).values({
+    id: storageId,
+    orgId: args.fixture.orgId,
+    userId,
+    name: args.name,
+    type: args.type,
+    s3Prefix: `${args.fixture.orgId}/${args.type}/${args.name}`,
+    size: 100,
+    fileCount: 1,
+  });
+  await db.insert(storageVersions).values({
+    id: versionId,
+    storageId,
+    s3Key: `${args.fixture.orgId}/${args.type}/${args.name}/${versionId}`,
+    size: 100,
+    fileCount: 1,
+    createdBy: args.fixture.userId,
+  });
+  await db
+    .update(storages)
+    .set({ headVersionId: versionId })
+    .where(eq(storages.id, storageId));
+  return versionId;
+}
+
+function sandboxToken(args: {
+  readonly userId: string;
+  readonly orgId: string;
+  readonly runId?: string;
+}): string {
+  const seconds = Math.floor(now() / 1000);
+  return signSandboxJwtForTests({
+    scope: "sandbox",
+    userId: args.userId,
+    orgId: args.orgId,
+    runId: args.runId ?? `run_${randomUUID()}`,
+    iat: seconds,
+    exp: seconds + 60,
+  });
+}
+
+describe("POST /api/agent/runs", () => {
+  it("returns 401 when unauthenticated", async () => {
+    const response = await accept(
+      runsClient().create({
+        headers: {},
+        body: { prompt: "test", agentComposeId: randomUUID() },
+      }),
+      [401],
+    );
+
+    expect(response.body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("validates the request body", async () => {
+    await fixture();
+    const response = await accept(
+      runsClient().create({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { agentComposeId: randomUUID() } as never,
+      }),
+      [400],
+    );
+
+    expect(response.body.error.code).toBe("BAD_REQUEST");
+    expect(response.body.error.message).toContain("prompt");
+  });
+
+  it("creates a pending run, session, and runner job", async () => {
+    const fx = await fixture();
+    const compose = await createCompose({ fixture: fx });
+
+    const response = await accept(
+      runsClient().create({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          agentComposeId: compose.composeId,
+          prompt: "Create a run",
+          appendSystemPrompt: "Be concise.",
+        },
+      }),
+      [201],
+    );
+
+    expect(response.body).toMatchObject({ status: "pending" });
+    expect(response.body.sessionId).toBeDefined();
+    expect(response.body.createdAt).toBeDefined();
+
+    const db = store.set(writeDb$);
+    const [run] = await db
+      .select()
+      .from(agentRuns)
+      .where(eq(agentRuns.id, response.body.runId));
+    expect(run?.status).toBe("pending");
+    expect(run?.sessionId).toBe(response.body.sessionId);
+    expect(run?.appendSystemPrompt).toBe("Be concise.");
+    expect(run?.lastHeartbeatAt).not.toBeNull();
+
+    const [job] = await db
+      .select()
+      .from(runnerJobQueue)
+      .where(eq(runnerJobQueue.runId, response.body.runId));
+    expect(job?.runnerGroup).toBe("vm0/test");
+    expect(job?.profile).toBe("vm0/default");
+    expect(job).toBeDefined();
+    const executionContext = job!.executionContext as {
+      readonly storageManifest: {
+        readonly artifacts: readonly { readonly vasStorageName: string }[];
+      };
+    };
+    expect(
+      executionContext.storageManifest.artifacts.map((artifact) => {
+        return artifact.vasStorageName;
+      }),
+    ).toStrictEqual(["memory"]);
+  });
+
+  it("stores vars, secret names, additional volumes, and encrypted runner secrets", async () => {
+    const fx = await fixture();
+    const docsVersion = await seedStorage({
+      fixture: fx,
+      type: "volume",
+      name: "docs",
+    });
+    const compose = await createCompose({
+      fixture: fx,
+      overrides: {
+        environment: {
+          ANTHROPIC_API_KEY: "test-key",
+          MY_VAR: vm0Template("{{ vars.MY_VAR }}"),
+          API_KEY: vm0Template("{{ secrets.API_KEY }}"),
+        },
+      },
+    });
+
+    const response = await accept(
+      runsClient().create({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          agentComposeId: compose.composeId,
+          prompt: "Use env",
+          vars: { MY_VAR: "value" },
+          secrets: { API_KEY: "secret-value" },
+          additionalVolumes: [
+            { name: "docs", version: docsVersion, mountPath: "/mnt/docs" },
+          ],
+        },
+      }),
+      [201],
+    );
+
+    expect(response.body).toMatchObject({ status: "pending" });
+
+    const db = store.set(writeDb$);
+    const [run] = await db
+      .select()
+      .from(agentRuns)
+      .where(eq(agentRuns.id, response.body.runId));
+    expect(run?.vars).toStrictEqual({ MY_VAR: "value" });
+    expect(run?.secretNames).toStrictEqual(["API_KEY"]);
+    expect(run?.additionalVolumes).toStrictEqual([
+      { name: "docs", version: docsVersion, mountPath: "/mnt/docs" },
+    ]);
+
+    const [job] = await db
+      .select({ executionContext: runnerJobQueue.executionContext })
+      .from(runnerJobQueue)
+      .where(eq(runnerJobQueue.runId, response.body.runId));
+    const executionContext = job?.executionContext as {
+      readonly environment: Record<string, string>;
+      readonly encryptedSecrets: string | null;
+      readonly storageManifest: {
+        readonly storages: readonly {
+          readonly name: string;
+          readonly mountPath: string;
+          readonly vasVersionId: string;
+        }[];
+      };
+    };
+    expect(executionContext.environment).toMatchObject({
+      MY_VAR: "value",
+      API_KEY: "secret-value",
+    });
+    expect(decryptSecretsMap(executionContext.encryptedSecrets)).toStrictEqual({
+      API_KEY: "secret-value",
+    });
+    expect(executionContext.storageManifest.storages).toMatchObject([
+      { name: "docs", mountPath: "/mnt/docs", vasVersionId: docsVersion },
+    ]);
+  });
+
+  it("injects an org model provider when the compose omits a framework API key", async () => {
+    const fx = await fixture();
+    await store.set(
+      seedOrgModelProvider$,
+      {
+        orgId: fx.orgId,
+        type: "anthropic-api-key",
+        isDefault: true,
+        selectedModel: "claude-sonnet-4-6",
+        secretName: "ANTHROPIC_API_KEY",
+      },
+      context.signal,
+    );
+    await trackModelProviders(Promise.resolve({ orgId: fx.orgId }));
+    const compose = await createCompose({
+      fixture: fx,
+      overrides: { environment: {} },
+    });
+
+    const response = await accept(
+      runsClient().create({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          agentComposeId: compose.composeId,
+          prompt: "Use provider",
+        },
+      }),
+      [201],
+    );
+
+    const db = store.set(writeDb$);
+    const [job] = await db
+      .select({ executionContext: runnerJobQueue.executionContext })
+      .from(runnerJobQueue)
+      .where(eq(runnerJobQueue.runId, response.body.runId));
+    const executionContext = job?.executionContext as {
+      readonly environment: Record<string, string>;
+      readonly encryptedSecrets: string | null;
+      readonly modelUsageProvider: string;
+    };
+    expect(executionContext.environment).toMatchObject({
+      ANTHROPIC_API_KEY: "test-secret-value",
+      ANTHROPIC_MODEL: "claude-sonnet-4-6",
+    });
+    expect(decryptSecretsMap(executionContext.encryptedSecrets)).toMatchObject({
+      ANTHROPIC_API_KEY: "test-secret-value",
+    });
+    expect(executionContext.modelUsageProvider).toBe("claude-sonnet-4-6");
+  });
+
+  it("persists requested artifacts plus memory on the new session", async () => {
+    const fx = await fixture();
+    const compose = await createCompose({ fixture: fx });
+
+    const response = await accept(
+      runsClient().create({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          agentComposeId: compose.composeId,
+          prompt: "Seed artifacts",
+          artifacts: [{ name: "artifact", mountPath: "/mnt/work" }],
+        },
+      }),
+      [201],
+    );
+
+    const db = store.set(writeDb$);
+    const [session] = await db
+      .select({ artifacts: agentSessions.artifacts })
+      .from(agentSessions)
+      .where(eq(agentSessions.id, response.body.sessionId));
+    expect(
+      session?.artifacts
+        .map((artifact) => {
+          return artifact.name;
+        })
+        .sort(),
+    ).toStrictEqual(["artifact", "memory"]);
+
+    const [job] = await db
+      .select({ executionContext: runnerJobQueue.executionContext })
+      .from(runnerJobQueue)
+      .where(eq(runnerJobQueue.runId, response.body.runId));
+    expect(job).toBeDefined();
+    const executionContext = job!.executionContext as {
+      readonly storageManifest: {
+        readonly artifacts: readonly {
+          readonly mountPath: string;
+          readonly vasStorageName: string;
+          readonly archiveUrl: string;
+          readonly manifestUrl?: string;
+        }[];
+      };
+    };
+    expect(
+      executionContext.storageManifest.artifacts
+        .map(
+          (artifact): { readonly mountPath: string; readonly name: string } => {
+            return {
+              name: artifact.vasStorageName,
+              mountPath: artifact.mountPath,
+            };
+          },
+        )
+        .sort((left, right) => {
+          return left.name.localeCompare(right.name);
+        }),
+    ).toStrictEqual([
+      { name: "artifact", mountPath: "/mnt/work" },
+      {
+        name: "memory",
+        mountPath: "/home/user/.claude/projects/-home-user-workspace/memory",
+      },
+    ]);
+    expect(
+      executionContext.storageManifest.artifacts.every((artifact) => {
+        return artifact.archiveUrl && artifact.manifestUrl;
+      }),
+    ).toBeTruthy();
+  });
+
+  it("includes compose artifacts and volumes in the runner storage manifest", async () => {
+    const fx = await fixture();
+    const volumeVersion = await seedStorage({
+      fixture: fx,
+      type: "volume",
+      name: "knowledge-base",
+    });
+    const artifactVersion = await seedStorage({
+      fixture: fx,
+      type: "artifact",
+      name: "compose-artifact",
+    });
+    const compose = await createCompose({
+      fixture: fx,
+      overrides: { volumes: ["kb:/mnt/kb"] },
+      volumes: { kb: { name: "knowledge-base", version: "latest" } },
+      artifacts: [{ name: "compose-artifact", mount_path: "/mnt/artifact" }],
+    });
+
+    const response = await accept(
+      runsClient().create({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          agentComposeId: compose.composeId,
+          prompt: "Use storage",
+        },
+      }),
+      [201],
+    );
+
+    const db = store.set(writeDb$);
+    const [job] = await db
+      .select({ executionContext: runnerJobQueue.executionContext })
+      .from(runnerJobQueue)
+      .where(eq(runnerJobQueue.runId, response.body.runId));
+    expect(job).toBeDefined();
+    const executionContext = job!.executionContext as {
+      readonly storageManifest: {
+        readonly storages: readonly {
+          readonly name: string;
+          readonly mountPath: string;
+          readonly vasVersionId: string;
+        }[];
+        readonly artifacts: readonly {
+          readonly mountPath: string;
+          readonly vasStorageName: string;
+          readonly vasVersionId: string;
+        }[];
+      };
+    };
+
+    expect(executionContext.storageManifest.storages).toMatchObject([
+      { name: "kb", mountPath: "/mnt/kb", vasVersionId: volumeVersion },
+    ]);
+    expect(
+      executionContext.storageManifest.artifacts
+        .map((artifact) => {
+          return {
+            mountPath: artifact.mountPath,
+            name: artifact.vasStorageName,
+            version: artifact.vasVersionId,
+          };
+        })
+        .sort((left, right) => {
+          return left.name.localeCompare(right.name);
+        }),
+    ).toStrictEqual([
+      {
+        mountPath: "/mnt/artifact",
+        name: "compose-artifact",
+        version: artifactVersion,
+      },
+      {
+        mountPath: "/home/user/.claude/projects/-home-user-workspace/memory",
+        name: "memory",
+        version: expect.any(String),
+      },
+    ]);
+  });
+
+  it("returns 404 for cross-org compose access", async () => {
+    const owner = await fixture();
+    const compose = await createCompose({ fixture: owner });
+    const other = await track(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    mocks.clerk.session(other.userId, other.orgId);
+
+    const response = await accept(
+      runsClient().create({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          agentComposeId: compose.composeId,
+          prompt: "Try cross org",
+        },
+      }),
+      [404],
+    );
+
+    expect(response.body.error.code).toBe("NOT_FOUND");
+  });
+
+  it("rejects a simultaneous checkpoint and session continue request", async () => {
+    const fx = await fixture();
+    const compose = await createCompose({ fixture: fx });
+
+    const response = await accept(
+      runsClient().create({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          agentComposeId: compose.composeId,
+          prompt: "bad resume",
+          checkpointId: randomUUID(),
+          sessionId: randomUUID(),
+        },
+      }),
+      [400],
+    );
+
+    expect(response.body.error.message).toContain(
+      "both checkpointId and sessionId",
+    );
+  });
+
+  it("returns 429 when the org concurrency limit is reached", async () => {
+    const fx = await fixture();
+    const compose = await createCompose({ fixture: fx });
+
+    await accept(
+      runsClient().create({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { agentComposeId: compose.composeId, prompt: "first" },
+      }),
+      [201],
+    );
+
+    const response = await accept(
+      runsClient().create({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { agentComposeId: compose.composeId, prompt: "second" },
+      }),
+      [429],
+    );
+
+    expect(response.body.error.code).toBe("CONCURRENT_RUN_LIMIT");
+  });
+
+  it("does not count stale pending runs toward the concurrency limit", async () => {
+    const fx = await fixture();
+    const compose = await createCompose({ fixture: fx });
+    const db = store.set(writeDb$);
+    const [session] = await db
+      .insert(agentSessions)
+      .values({
+        userId: fx.userId,
+        orgId: fx.orgId,
+        agentComposeId: compose.composeId,
+      })
+      .returning({ id: agentSessions.id });
+    if (!session) {
+      throw new Error("session insert returned no row");
+    }
+    await db.insert(agentRuns).values({
+      userId: fx.userId,
+      orgId: fx.orgId,
+      agentComposeVersionId: compose.versionId,
+      sessionId: session.id,
+      prompt: "stale",
+      status: "pending",
+      createdAt: new Date(now() - 16 * 60 * 1000),
+    });
+
+    const response = await accept(
+      runsClient().create({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { agentComposeId: compose.composeId, prompt: "fresh" },
+      }),
+      [201],
+    );
+
+    expect(response.body.status).toBe("pending");
+  });
+
+  it("allows two concurrent pro-tier runs", async () => {
+    const fx = await fixture();
+    const compose = await createCompose({ fixture: fx });
+    const db = store.set(writeDb$);
+    await db
+      .insert(orgMetadata)
+      .values({ orgId: fx.orgId, tier: "pro" })
+      .onConflictDoUpdate({
+        target: orgMetadata.orgId,
+        set: { tier: "pro" },
+      });
+
+    await accept(
+      runsClient().create({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { agentComposeId: compose.composeId, prompt: "first" },
+      }),
+      [201],
+    );
+    const response = await accept(
+      runsClient().create({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { agentComposeId: compose.composeId, prompt: "second" },
+      }),
+      [201],
+    );
+
+    expect(response.body.status).toBe("pending");
+  });
+
+  it("accepts sandbox tokens with any capability for create", async () => {
+    const fx = await fixture();
+    const compose = await createCompose({ fixture: fx });
+
+    const response = await accept(
+      runsClient().create({
+        headers: {
+          authorization: `Bearer ${sandboxToken({
+            userId: fx.userId,
+            orgId: fx.orgId,
+          })}`,
+        },
+        body: { agentComposeId: compose.composeId, prompt: "sandbox create" },
+      }),
+      [201],
+    );
+
+    expect(response.body.status).toBe("pending");
+  });
+
+  it("enforces the production captureNetworkBodies gate", async () => {
+    const fx = await fixture();
+    const compose = await createCompose({ fixture: fx });
+    mockEnv("ENV", "production");
+
+    const rejected = await accept(
+      runsClient().create({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          agentComposeId: compose.composeId,
+          prompt: "capture",
+          captureNetworkBodies: true,
+        },
+      }),
+      [403],
+    );
+    expect(rejected.body.error.message).toContain("internal accounts");
+
+    const db = store.set(writeDb$);
+    await db.insert(userCache).values({
+      userId: fx.userId,
+      email: "engineer@vm0.ai",
+      name: "Engineer",
+      cachedAt: nowDate(),
+    });
+
+    const accepted = await accept(
+      runsClient().create({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          agentComposeId: compose.composeId,
+          prompt: "capture internal",
+          captureNetworkBodies: true,
+        },
+      }),
+      [201],
+    );
+    expect(accepted.body.status).toBe("pending");
+  });
+
+  it("returns 201 failed and persists the run when dispatch fails after insert", async () => {
+    const fx = await fixture();
+    const compose = await createCompose({ fixture: fx });
+    mockOptionalEnv("RUNNER_DEFAULT_GROUP", undefined);
+
+    const response = await accept(
+      runsClient().create({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { agentComposeId: compose.composeId, prompt: "no runner" },
+      }),
+      [201],
+    );
+
+    expect(response.body.status).toBe("failed");
+    expect(response.body.error).toContain("RUNNER_DEFAULT_GROUP");
+
+    const db = store.set(writeDb$);
+    const [run] = await db
+      .select({ status: agentRuns.status, error: agentRuns.error })
+      .from(agentRuns)
+      .where(eq(agentRuns.id, response.body.runId));
+    expect(run).toMatchObject({
+      status: "failed",
+      error: expect.stringContaining("RUNNER_DEFAULT_GROUP"),
+    });
+  });
+
+  it("continues an existing session and reuses its session id", async () => {
+    const fx = await fixture();
+    const compose = await createCompose({ fixture: fx });
+    const first = await accept(
+      runsClient().create({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { agentComposeId: compose.composeId, prompt: "first" },
+      }),
+      [201],
+    );
+    const conversationId = await store.set(
+      seedConversationForSession$,
+      { runId: first.body.runId, sessionId: first.body.sessionId },
+      context.signal,
+    );
+    const db = store.set(writeDb$);
+    await db
+      .update(agentRuns)
+      .set({ status: "completed", completedAt: nowDate() })
+      .where(eq(agentRuns.id, first.body.runId));
+
+    const continued = await accept(
+      runsClient().create({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { sessionId: first.body.sessionId, prompt: "continue" },
+      }),
+      [201],
+    );
+
+    expect(continued.body.sessionId).toBe(first.body.sessionId);
+    const [run] = await db
+      .select({
+        continuedFromSessionId: agentRuns.continuedFromSessionId,
+      })
+      .from(agentRuns)
+      .where(eq(agentRuns.id, continued.body.runId));
+    expect(run?.continuedFromSessionId).toBe(first.body.sessionId);
+
+    const [job] = await db
+      .select({ executionContext: runnerJobQueue.executionContext })
+      .from(runnerJobQueue)
+      .where(eq(runnerJobQueue.runId, continued.body.runId));
+    expect(job).toBeDefined();
+    const executionContext = job!.executionContext as {
+      readonly resumeSession: { readonly sessionId: string };
+    };
+    expect(executionContext.resumeSession.sessionId).toBe(
+      `session-${first.body.runId}`,
+    );
+    expect(conversationId).toBeDefined();
+  });
+
+  it("resumes from a checkpoint and stores resumedFromCheckpointId", async () => {
+    const fx = await fixture();
+    const compose = await createCompose({ fixture: fx });
+    const first = await accept(
+      runsClient().create({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { agentComposeId: compose.composeId, prompt: "first" },
+      }),
+      [201],
+    );
+    const conversationId = await store.set(
+      seedConversationForSession$,
+      { runId: first.body.runId, sessionId: first.body.sessionId },
+      context.signal,
+    );
+    const db = store.set(writeDb$);
+    await db
+      .update(agentRuns)
+      .set({ status: "completed", completedAt: nowDate() })
+      .where(eq(agentRuns.id, first.body.runId));
+    const [checkpoint] = await db
+      .insert(checkpoints)
+      .values({
+        runId: first.body.runId,
+        conversationId,
+        agentComposeSnapshot: { agentComposeVersionId: compose.versionId },
+        artifactSnapshots: [{ name: "artifact", mountPath: "/mnt/work" }],
+        volumeVersionsSnapshot: { versions: { docs: "v1" } },
+      })
+      .returning({ id: checkpoints.id });
+    if (!checkpoint) {
+      throw new Error("checkpoint insert returned no row");
+    }
+
+    const response = await accept(
+      runsClient().create({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { checkpointId: checkpoint.id, prompt: "resume" },
+      }),
+      [201],
+    );
+
+    const [run] = await db
+      .select({
+        resumedFromCheckpointId: agentRuns.resumedFromCheckpointId,
+      })
+      .from(agentRuns)
+      .where(eq(agentRuns.id, response.body.runId));
+    expect(run?.resumedFromCheckpointId).toBe(checkpoint.id);
+  });
+});

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-usage-insight.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-usage-insight.ts
@@ -8,6 +8,7 @@ import {
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { agentSessions } from "@vm0/db/schema/agent-session";
 import { chatThreads } from "@vm0/db/schema/chat-thread";
+import { storages, storageVersions } from "@vm0/db/schema/storage";
 import { usageEvent } from "@vm0/db/schema/usage-event";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
 import { zeroAgentSchedules } from "@vm0/db/schema/zero-agent-schedule";
@@ -196,6 +197,28 @@ export const deleteUsageInsightFixture$ = command(
         and(eq(agentComposes.orgId, orgId), eq(agentComposes.userId, userId)),
       );
     signal.throwIfAborted();
+
+    const storageRows = await db
+      .select({ id: storages.id })
+      .from(storages)
+      .where(eq(storages.orgId, orgId));
+    signal.throwIfAborted();
+    const storageIds = storageRows.map((row) => {
+      return row.id;
+    });
+    if (storageIds.length > 0) {
+      await db
+        .update(storages)
+        .set({ headVersionId: null })
+        .where(inArray(storages.id, storageIds));
+      signal.throwIfAborted();
+      await db
+        .delete(storageVersions)
+        .where(inArray(storageVersions.storageId, storageIds));
+      signal.throwIfAborted();
+      await db.delete(storages).where(eq(storages.orgId, orgId));
+      signal.throwIfAborted();
+    }
   },
 );
 

--- a/turbo/apps/api/src/signals/routes/agent-runs-cancel.ts
+++ b/turbo/apps/api/src/signals/routes/agent-runs-cancel.ts
@@ -1,0 +1,120 @@
+import { command } from "ccstate";
+import { runsCancelContract } from "@vm0/api-contracts/contracts/runs";
+import { agentRuns } from "@vm0/db/schema/agent-run";
+import { and, eq } from "drizzle-orm";
+
+import { authContext$, type AuthErrorResponse } from "../auth/auth-context";
+import { authRoute } from "../auth/auth-route";
+import { pathParamsOf } from "../context/request";
+import { waitUntil } from "../context/wait-until";
+import { writeDb$ } from "../external/db";
+import { badRequestMessage, isNotFoundResponse } from "../../lib/error";
+import { logger } from "../../lib/log";
+import {
+  cancelRun$,
+  dispatchCancelSideEffects$,
+} from "../services/zero-run-cancel.service";
+import type { RouteEntry } from "../route";
+
+const L = logger("AgentRunsCancel");
+
+function missingOrg(): AuthErrorResponse {
+  return {
+    status: 401,
+    body: {
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    },
+  };
+}
+
+function sandboxRunNotFound() {
+  return {
+    status: 404 as const,
+    body: {
+      error: { message: "Agent run not found", code: "NOT_FOUND" },
+    },
+  };
+}
+
+const cancelRunInner$ = command(async ({ get, set }, signal: AbortSignal) => {
+  const auth = get(authContext$);
+  const params = get(pathParamsOf(runsCancelContract.cancel));
+  const db = set(writeDb$);
+
+  let orgId: string | undefined;
+  if (auth.tokenType === "sandbox") {
+    const [sandboxRun] = await db
+      .select({ orgId: agentRuns.orgId })
+      .from(agentRuns)
+      .where(
+        and(eq(agentRuns.id, auth.runId), eq(agentRuns.userId, auth.userId)),
+      )
+      .limit(1);
+    signal.throwIfAborted();
+    if (!sandboxRun) {
+      return sandboxRunNotFound();
+    }
+    orgId = sandboxRun.orgId;
+  } else {
+    orgId = auth.orgId;
+  }
+
+  if (!orgId) {
+    return missingOrg();
+  }
+
+  const result = await set(
+    cancelRun$,
+    { runId: params.id, userId: auth.userId, orgId },
+    signal,
+  );
+  signal.throwIfAborted();
+
+  if ("status" in result) {
+    if (isNotFoundResponse(result)) {
+      return {
+        status: 404 as const,
+        body: {
+          error: { message: result.body.error.message, code: "NOT_FOUND" },
+        },
+      };
+    }
+    return result.status === 400
+      ? result
+      : badRequestMessage("Unable to cancel run");
+  }
+
+  if (!result.alreadyCancelled) {
+    waitUntil(
+      set(dispatchCancelSideEffects$, result, signal).catch(
+        (error: unknown) => {
+          L.error("dispatchCancelSideEffects failed", {
+            runId: result.runId,
+            error,
+          });
+        },
+      ),
+    );
+  }
+
+  return {
+    status: 200 as const,
+    body: {
+      id: params.id,
+      status: "cancelled" as const,
+      message: "Run cancelled successfully",
+    },
+  };
+});
+
+export const agentRunsCancelRoutes: readonly RouteEntry[] = [
+  {
+    route: runsCancelContract.cancel,
+    handler: authRoute(
+      {
+        acceptAnySandboxCapability: true,
+      },
+      cancelRunInner$,
+    ),
+  },
+];

--- a/turbo/apps/api/src/signals/routes/agent-runs-create.ts
+++ b/turbo/apps/api/src/signals/routes/agent-runs-create.ts
@@ -1,0 +1,46 @@
+import { command } from "ccstate";
+import { runsMainContract } from "@vm0/api-contracts/contracts/runs";
+
+import { organizationAuthContext$ } from "../auth/auth-context";
+import { authRoute } from "../auth/auth-route";
+import { bodyResultOf } from "../context/request";
+import { now } from "../external/time";
+import { createAgentRun$ } from "../services/agent-run-create.service";
+import type { RouteEntry } from "../route";
+
+const createRunBody$ = bodyResultOf(runsMainContract.create);
+
+const createRunInner$ = command(async ({ get, set }, signal: AbortSignal) => {
+  const apiStartTime = now();
+  const body = await get(createRunBody$);
+  signal.throwIfAborted();
+  if (!body.ok) {
+    return body.response;
+  }
+
+  const auth = get(organizationAuthContext$);
+  return await set(
+    createAgentRun$,
+    {
+      userId: auth.userId,
+      orgId: auth.orgId,
+      body: body.data,
+      apiStartTime,
+    },
+    signal,
+  );
+});
+
+export const agentRunsCreateRoutes: readonly RouteEntry[] = [
+  {
+    route: runsMainContract.create,
+    handler: authRoute(
+      {
+        acceptAnySandboxCapability: true,
+        requireOrganization: true,
+        missingOrganizationStatus: 401,
+      },
+      createRunInner$,
+    ),
+  },
+];

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -1,0 +1,1191 @@
+import { command, type Getter } from "ccstate";
+import {
+  DEFAULT_PROFILE,
+  type StorageManifest,
+  type StoredExecutionContext,
+} from "@vm0/api-contracts/contracts/runners";
+import {
+  MODEL_PROVIDER_TYPES,
+  type ModelProviderType,
+} from "@vm0/api-contracts/contracts/model-providers";
+import {
+  type CreateRunResponse,
+  type RunStatus,
+  unifiedRunRequestSchema,
+} from "@vm0/api-contracts/contracts/runs";
+import {
+  isSupportedFramework,
+  MOUNT_PATH_TEMPLATE,
+  type SupportedFramework,
+} from "@vm0/core";
+import {
+  expandVariables,
+  extractAndGroupVariables,
+} from "@vm0/core/variable-expander";
+import {
+  agentComposes,
+  agentComposeVersions,
+} from "@vm0/db/schema/agent-compose";
+import { agentRuns } from "@vm0/db/schema/agent-run";
+import { agentSessions } from "@vm0/db/schema/agent-session";
+import { conversations } from "@vm0/db/schema/conversation";
+import { checkpoints } from "@vm0/db/schema/checkpoint";
+import { modelProviders } from "@vm0/db/schema/model-provider";
+import { orgMetadata } from "@vm0/db/schema/org-metadata";
+import { runnerJobQueue } from "@vm0/db/schema/runner-job-queue";
+import { secrets as secretsTable } from "@vm0/db/schema/secret";
+import { userCache } from "@vm0/db/schema/user-cache";
+import { zeroRuns } from "@vm0/db/schema/zero-run";
+import { and, count, eq, gt, or, sql } from "drizzle-orm";
+import type { z } from "zod";
+
+import { env, optionalEnv } from "../../lib/env";
+import {
+  badRequestMessage,
+  notFound,
+  providerUnavailable,
+} from "../../lib/error";
+import { writeDb$, type Db } from "../external/db";
+import { publishRunnerJobNotification } from "../external/realtime";
+import { now, nowDate } from "../external/time";
+import { safeAsync } from "../utils";
+import { decryptSecretValue, encryptSecretsMap } from "./crypto.utils";
+import { prepareAgentRunStorageManifest } from "./agent-run-storage.service";
+
+const PENDING_RUN_TTL_MS = 15 * 60 * 1000;
+const AUTO_MEMORY_ARTIFACT_NAME = "memory";
+const AUTO_MEMORY_MOUNT_PATH =
+  "/home/user/.claude/projects/-home-user-workspace/memory";
+const CODEX_AUTO_MEMORY_MOUNT_PATH = "/home/user/.codex/memories";
+
+const TIER_LIMITS = Object.freeze({
+  free: 1,
+  pro: 2,
+  team: 10,
+});
+
+const ORG_SENTINEL_USER_ID = "__org__";
+
+type CreateRunBody = z.infer<typeof unifiedRunRequestSchema>;
+type ComputedGetter = Getter;
+
+interface ContextArtifact {
+  readonly name: string;
+  readonly version?: string;
+  readonly mountPath: string;
+}
+
+interface ComposeArtifact {
+  readonly name: string;
+  readonly version?: string;
+  readonly mount_path?: string;
+}
+
+interface AdditionalVolume {
+  readonly name: string;
+  readonly version?: string;
+  readonly mountPath: string;
+  readonly system?: boolean;
+}
+
+interface AgentConfig {
+  readonly framework?: string;
+  readonly environment?: Record<string, string>;
+  readonly experimental_runner?: { readonly group?: string };
+  readonly experimental_profile?: string;
+}
+
+interface AgentComposeContent {
+  readonly agent?: AgentConfig;
+  readonly agents?: Record<string, AgentConfig | undefined>;
+  readonly artifacts?: readonly ComposeArtifact[];
+}
+
+interface ResolvedCompose {
+  readonly agentComposeVersionId: string;
+  readonly composeId: string;
+  readonly composeUserId: string;
+  readonly orgId: string;
+  readonly agentName?: string;
+  readonly content: AgentComposeContent;
+  readonly artifacts: readonly ContextArtifact[];
+  readonly volumeVersions?: Record<string, string>;
+  readonly additionalVolumes?: readonly AdditionalVolume[];
+  readonly sessionId?: string;
+  readonly resumedFromCheckpointId?: string;
+  readonly continuedFromSessionId?: string;
+  readonly resumeSession?: StoredExecutionContext["resumeSession"];
+}
+
+interface RunRecord {
+  readonly id: string;
+  readonly createdAt: Date;
+  readonly sessionId: string;
+}
+
+interface ResolvedModelProviderEnvironment {
+  readonly type: ModelProviderType;
+  readonly environment: Record<string, string>;
+  readonly secrets: Record<string, string>;
+  readonly selectedModel: string | null;
+}
+
+type ApiErrorResponse<Status extends number, Code extends string> = {
+  readonly status: Status;
+  readonly body: {
+    readonly error: {
+      readonly message: string;
+      readonly code: Code;
+    };
+  };
+};
+
+type CreateRunRouteResult =
+  | { readonly status: 201; readonly body: CreateRunResponse }
+  | ApiErrorResponse<400, "BAD_REQUEST">
+  | ApiErrorResponse<403, "FORBIDDEN">
+  | ApiErrorResponse<404, "NOT_FOUND">
+  | ApiErrorResponse<429, "CONCURRENT_RUN_LIMIT">
+  | ApiErrorResponse<503, "PROVIDER_UNAVAILABLE">;
+
+type CreateRunErrorResult = Exclude<
+  CreateRunRouteResult,
+  { readonly status: 201 }
+>;
+
+function forbidden(message: string): ApiErrorResponse<403, "FORBIDDEN"> {
+  return {
+    status: 403,
+    body: { error: { message, code: "FORBIDDEN" } },
+  };
+}
+
+function concurrentRunLimit(): ApiErrorResponse<429, "CONCURRENT_RUN_LIMIT"> {
+  return {
+    status: 429,
+    body: {
+      error: {
+        message: "Concurrent run limit reached",
+        code: "CONCURRENT_RUN_LIMIT",
+      },
+    },
+  };
+}
+
+function isRouteError(value: unknown): value is CreateRunErrorResult {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "status" in value &&
+    typeof (value as { readonly status: unknown }).status === "number" &&
+    (value as { readonly status: number }).status !== 201
+  );
+}
+
+function firstAgent(content: AgentComposeContent): AgentConfig | undefined {
+  if (content.agent) {
+    return content.agent;
+  }
+  if (!content.agents) {
+    return undefined;
+  }
+  const firstKey = Object.keys(content.agents)[0];
+  return firstKey ? content.agents[firstKey] : undefined;
+}
+
+function resolveFramework(
+  content: AgentComposeContent,
+): SupportedFramework | null {
+  const framework = firstAgent(content)?.framework;
+  if (!isSupportedFramework(framework)) {
+    return null;
+  }
+  return framework;
+}
+
+function frameworkWorkingDir(_framework: SupportedFramework): string {
+  return "/home/user/workspace";
+}
+
+function frameworkApiKeyEnv(framework: SupportedFramework): string {
+  return framework === "codex" ? "OPENAI_API_KEY" : "ANTHROPIC_API_KEY";
+}
+
+function autoMemoryArtifact(framework: SupportedFramework): ContextArtifact {
+  return {
+    name: AUTO_MEMORY_ARTIFACT_NAME,
+    mountPath:
+      framework === "codex"
+        ? CODEX_AUTO_MEMORY_MOUNT_PATH
+        : AUTO_MEMORY_MOUNT_PATH,
+  };
+}
+
+function withAutoMemoryArtifact(
+  artifacts: readonly ContextArtifact[],
+  framework: SupportedFramework,
+): readonly ContextArtifact[] {
+  if (
+    artifacts.some((artifact) => {
+      return artifact.name === AUTO_MEMORY_ARTIFACT_NAME;
+    })
+  ) {
+    return artifacts;
+  }
+  return [...artifacts, autoMemoryArtifact(framework)];
+}
+
+function resolveComposeArtifactMountPath(
+  artifact: ComposeArtifact,
+  framework: SupportedFramework,
+): string {
+  if (!artifact.mount_path || artifact.mount_path === MOUNT_PATH_TEMPLATE) {
+    return frameworkWorkingDir(framework);
+  }
+  return artifact.mount_path;
+}
+
+function composeArtifacts(
+  content: AgentComposeContent,
+  framework: SupportedFramework,
+): readonly ContextArtifact[] {
+  return (content.artifacts ?? []).map((artifact) => {
+    return {
+      name: artifact.name,
+      version: artifact.version,
+      mountPath: resolveComposeArtifactMountPath(artifact, framework),
+    };
+  });
+}
+
+function artifactsForRun(args: {
+  readonly resolved: ResolvedCompose;
+  readonly framework: SupportedFramework;
+  readonly bodyArtifacts: readonly ContextArtifact[] | undefined;
+}): readonly ContextArtifact[] {
+  const baseArtifacts =
+    args.resolved.sessionId || args.resolved.resumedFromCheckpointId
+      ? args.resolved.artifacts
+      : [
+          ...composeArtifacts(args.resolved.content, args.framework),
+          ...args.resolved.artifacts,
+        ];
+  return withAutoMemoryArtifact(
+    [...baseArtifacts, ...(args.bodyArtifacts ?? [])],
+    args.framework,
+  );
+}
+
+function runnerGroup(content: AgentComposeContent): string | null {
+  return firstAgent(content)?.experimental_runner?.group ?? null;
+}
+
+function runnerProfile(content: AgentComposeContent): string {
+  return firstAgent(content)?.experimental_profile ?? DEFAULT_PROFILE;
+}
+
+function isOfficialRunnerGroup(group: string): boolean {
+  return group.split("/")[0] === "vm0";
+}
+
+function expandEnvironment(
+  content: AgentComposeContent,
+  vars: Record<string, string> | undefined,
+  secrets: Record<string, string> | undefined,
+  additionalEnvironment: Record<string, string> | undefined,
+): Record<string, string> | null {
+  const environment = firstAgent(content)?.environment;
+  const mergedEnvironment = {
+    ...additionalEnvironment,
+    ...environment,
+  };
+  if (Object.keys(mergedEnvironment).length === 0) {
+    return null;
+  }
+
+  const { result } = expandVariables(mergedEnvironment, { vars, secrets });
+  return result;
+}
+
+function missingEnvironmentReferences(
+  content: AgentComposeContent,
+  vars: Record<string, string> | undefined,
+  secrets: Record<string, string> | undefined,
+): string[] {
+  const environment = firstAgent(content)?.environment;
+  if (!environment) {
+    return [];
+  }
+  const grouped = extractAndGroupVariables(environment);
+  const missingVars = grouped.vars
+    .filter((ref) => {
+      return vars?.[ref.name] === undefined;
+    })
+    .map((ref) => {
+      return `vars.${ref.name}`;
+    });
+  const missingSecrets = grouped.secrets
+    .filter((ref) => {
+      return secrets?.[ref.name] === undefined;
+    })
+    .map((ref) => {
+      return `secrets.${ref.name}`;
+    });
+  return [...missingVars, ...missingSecrets];
+}
+
+function hasExplicitFrameworkApiKey(
+  content: AgentComposeContent,
+  framework: SupportedFramework,
+): boolean {
+  return (
+    firstAgent(content)?.environment?.[frameworkApiKeyEnv(framework)] !==
+    undefined
+  );
+}
+
+function isModelProviderType(type: string): type is ModelProviderType {
+  return Object.hasOwn(MODEL_PROVIDER_TYPES, type);
+}
+
+interface SingleSecretModelProviderConfig {
+  readonly framework: SupportedFramework;
+  readonly secretName: string;
+  readonly environmentMapping: Record<string, string>;
+  readonly defaultModel?: string;
+}
+
+function isSingleSecretModelProviderConfig(
+  value: unknown,
+): value is SingleSecretModelProviderConfig {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "framework" in value &&
+    "secretName" in value &&
+    "environmentMapping" in value &&
+    typeof (value as { readonly secretName: unknown }).secretName === "string"
+  );
+}
+
+function modelProviderEnvironment(
+  type: ModelProviderType,
+  config: SingleSecretModelProviderConfig,
+  secretValue: string,
+  selectedModel: string | null,
+): ResolvedModelProviderEnvironment {
+  const model = selectedModel ?? config.defaultModel ?? "";
+  const environment: Record<string, string> = {};
+  for (const [key, value] of Object.entries(config.environmentMapping)) {
+    environment[key] = value
+      .replaceAll("$secret", secretValue)
+      .replaceAll("$model", model);
+  }
+
+  return {
+    type,
+    environment,
+    secrets: { [config.secretName]: secretValue },
+    selectedModel: model || null,
+  };
+}
+
+async function resolveModelProviderEnvironment(
+  db: Db,
+  args: {
+    readonly orgId: string;
+    readonly userId: string;
+    readonly framework: SupportedFramework;
+  },
+): Promise<ResolvedModelProviderEnvironment | null> {
+  const rows = await db
+    .select({
+      type: modelProviders.type,
+      userId: modelProviders.userId,
+      isDefault: modelProviders.isDefault,
+      selectedModel: modelProviders.selectedModel,
+      encryptedValue: secretsTable.encryptedValue,
+    })
+    .from(modelProviders)
+    .leftJoin(secretsTable, eq(modelProviders.secretId, secretsTable.id))
+    .where(
+      and(
+        eq(modelProviders.orgId, args.orgId),
+        or(
+          eq(modelProviders.userId, args.userId),
+          eq(modelProviders.userId, ORG_SENTINEL_USER_ID),
+        ),
+      ),
+    );
+
+  const sortedRows = rows.sort((left, right) => {
+    const leftUser = left.userId === args.userId ? 1 : 0;
+    const rightUser = right.userId === args.userId ? 1 : 0;
+    if (leftUser !== rightUser) {
+      return rightUser - leftUser;
+    }
+    const leftDefault = left.isDefault ? 1 : 0;
+    const rightDefault = right.isDefault ? 1 : 0;
+    return rightDefault - leftDefault;
+  });
+
+  for (const row of sortedRows) {
+    if (!isModelProviderType(row.type)) {
+      continue;
+    }
+    const config = MODEL_PROVIDER_TYPES[row.type];
+    if (
+      !isSingleSecretModelProviderConfig(config) ||
+      config.framework !== args.framework ||
+      !row.encryptedValue
+    ) {
+      continue;
+    }
+    return modelProviderEnvironment(
+      row.type,
+      config,
+      decryptSecretValue(row.encryptedValue),
+      row.selectedModel,
+    );
+  }
+
+  return null;
+}
+
+function parseVolumeVersionsSnapshot(
+  value: unknown,
+): Record<string, string> | undefined {
+  if (!value || typeof value !== "object") {
+    return undefined;
+  }
+  if (
+    "versions" in value &&
+    typeof value.versions === "object" &&
+    value.versions !== null
+  ) {
+    return value.versions as Record<string, string>;
+  }
+  return value as Record<string, string>;
+}
+
+function parseAdditionalVolumeSnapshot(
+  value: unknown,
+): AdditionalVolume | null {
+  if (typeof value !== "object" || value === null) {
+    return null;
+  }
+  const candidate = value as {
+    readonly name?: unknown;
+    readonly versionId?: unknown;
+    readonly mountPath?: unknown;
+  };
+  if (
+    typeof candidate.name !== "string" ||
+    typeof candidate.versionId !== "string" ||
+    typeof candidate.mountPath !== "string"
+  ) {
+    return null;
+  }
+  return {
+    name: candidate.name,
+    version: candidate.versionId,
+    mountPath: candidate.mountPath,
+  };
+}
+
+function parseAdditionalVolumesSnapshot(
+  value: unknown,
+): readonly AdditionalVolume[] | undefined {
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    !("additionalVolumes" in value)
+  ) {
+    return undefined;
+  }
+  const additionalVolumes = (value as { readonly additionalVolumes?: unknown })
+    .additionalVolumes;
+  if (!Array.isArray(additionalVolumes)) {
+    return undefined;
+  }
+  const parsed = additionalVolumes.flatMap((item) => {
+    const volume = parseAdditionalVolumeSnapshot(item);
+    return volume ? [volume] : [];
+  });
+  return parsed.length > 0 ? parsed : undefined;
+}
+
+async function orgTier(
+  db: Db,
+  orgId: string,
+): Promise<keyof typeof TIER_LIMITS> {
+  const [row] = await db
+    .select({ tier: orgMetadata.tier })
+    .from(orgMetadata)
+    .where(eq(orgMetadata.orgId, orgId))
+    .limit(1);
+
+  return row?.tier === "pro" || row?.tier === "team" ? row.tier : "free";
+}
+
+async function checkRunConcurrencyLimit(
+  tx: Db,
+  orgId: string,
+): Promise<CreateRunErrorResult | null> {
+  const limit = TIER_LIMITS[await orgTier(tx, orgId)];
+
+  const staleThreshold = new Date(now() - PENDING_RUN_TTL_MS);
+  const [activeResult] = await tx
+    .select({ count: count() })
+    .from(agentRuns)
+    .where(
+      and(
+        eq(agentRuns.orgId, orgId),
+        or(
+          eq(agentRuns.status, "running"),
+          and(
+            eq(agentRuns.status, "pending"),
+            gt(agentRuns.createdAt, staleThreshold),
+          ),
+        ),
+      ),
+    );
+  const activeCount = Number(activeResult?.count ?? 0);
+  return activeCount >= limit ? concurrentRunLimit() : null;
+}
+
+async function lookupComposeByVersion(
+  db: Db,
+  versionId: string,
+): Promise<ResolvedCompose | CreateRunErrorResult> {
+  const [row] = await db
+    .select({
+      versionContent: agentComposeVersions.content,
+      composeName: agentComposes.name,
+      composeOrgId: agentComposes.orgId,
+      composeId: agentComposes.id,
+      composeUserId: agentComposes.userId,
+    })
+    .from(agentComposeVersions)
+    .leftJoin(
+      agentComposes,
+      eq(agentComposeVersions.composeId, agentComposes.id),
+    )
+    .where(eq(agentComposeVersions.id, versionId))
+    .limit(1);
+
+  if (!row?.composeId || !row.composeOrgId || !row.composeUserId) {
+    return notFound("Agent compose version not found");
+  }
+
+  return {
+    agentComposeVersionId: versionId,
+    composeId: row.composeId,
+    composeUserId: row.composeUserId,
+    agentName: row.composeName ?? undefined,
+    orgId: row.composeOrgId,
+    content: row.versionContent as AgentComposeContent,
+    artifacts: [],
+  };
+}
+
+async function resolveByComposeId(
+  db: Db,
+  composeId: string,
+): Promise<ResolvedCompose | CreateRunErrorResult> {
+  const [row] = await db
+    .select({
+      composeId: agentComposes.id,
+      composeName: agentComposes.name,
+      composeOrgId: agentComposes.orgId,
+      composeUserId: agentComposes.userId,
+      headVersionId: agentComposes.headVersionId,
+      versionId: agentComposeVersions.id,
+      versionContent: agentComposeVersions.content,
+    })
+    .from(agentComposes)
+    .leftJoin(
+      agentComposeVersions,
+      eq(agentComposeVersions.id, agentComposes.headVersionId),
+    )
+    .where(eq(agentComposes.id, composeId))
+    .limit(1);
+
+  if (!row) {
+    return notFound("Agent compose not found");
+  }
+  if (!row.headVersionId || !row.versionId) {
+    return badRequestMessage(
+      "Agent compose has no versions. Run 'vm0 build' first.",
+    );
+  }
+
+  return {
+    agentComposeVersionId: row.versionId,
+    composeId: row.composeId,
+    composeUserId: row.composeUserId,
+    agentName: row.composeName || undefined,
+    orgId: row.composeOrgId,
+    content: row.versionContent as AgentComposeContent,
+    artifacts: [],
+  };
+}
+
+async function resolveBySessionId(
+  db: Db,
+  sessionId: string,
+  userId: string,
+  orgId: string,
+): Promise<ResolvedCompose | CreateRunErrorResult> {
+  const [session] = await db
+    .select({
+      id: agentSessions.id,
+      agentComposeId: agentSessions.agentComposeId,
+      conversationId: agentSessions.conversationId,
+      artifacts: agentSessions.artifacts,
+    })
+    .from(agentSessions)
+    .where(
+      and(
+        eq(agentSessions.id, sessionId),
+        eq(agentSessions.userId, userId),
+        eq(agentSessions.orgId, orgId),
+      ),
+    )
+    .limit(1);
+
+  if (!session) {
+    return notFound("Agent session not found");
+  }
+
+  const resolved = await resolveByComposeId(db, session.agentComposeId);
+  if (isRouteError(resolved)) {
+    return resolved;
+  }
+
+  const resumeSession =
+    session.conversationId === null
+      ? undefined
+      : await loadResumeSession(db, session.conversationId);
+
+  return {
+    ...resolved,
+    artifacts: session.artifacts ?? [],
+    sessionId: session.id,
+    continuedFromSessionId: session.id,
+    resumeSession,
+  };
+}
+
+async function resolveByCheckpointId(
+  db: Db,
+  checkpointId: string,
+  userId: string,
+  orgId: string,
+): Promise<ResolvedCompose | CreateRunErrorResult> {
+  const [row] = await db
+    .select({
+      snapshot: checkpoints.agentComposeSnapshot,
+      artifacts: checkpoints.artifactSnapshots,
+      volumeVersionsSnapshot: checkpoints.volumeVersionsSnapshot,
+      conversationId: checkpoints.conversationId,
+      runUserId: agentRuns.userId,
+      runOrgId: agentRuns.orgId,
+    })
+    .from(checkpoints)
+    .leftJoin(agentRuns, eq(checkpoints.runId, agentRuns.id))
+    .where(eq(checkpoints.id, checkpointId))
+    .limit(1);
+
+  if (!row || row.runUserId !== userId || row.runOrgId !== orgId) {
+    return notFound("Checkpoint not found");
+  }
+
+  const snapshot = row.snapshot as { readonly agentComposeVersionId?: string };
+  if (!snapshot.agentComposeVersionId) {
+    return badRequestMessage(
+      "Invalid checkpoint: missing agentComposeVersionId",
+    );
+  }
+
+  const resolved = await lookupComposeByVersion(
+    db,
+    snapshot.agentComposeVersionId,
+  );
+  if (isRouteError(resolved)) {
+    return resolved;
+  }
+
+  return {
+    ...resolved,
+    artifacts: row.artifacts ?? [],
+    volumeVersions: parseVolumeVersionsSnapshot(row.volumeVersionsSnapshot),
+    additionalVolumes: parseAdditionalVolumesSnapshot(
+      row.volumeVersionsSnapshot,
+    ),
+    resumedFromCheckpointId: checkpointId,
+    resumeSession: await loadResumeSession(db, row.conversationId),
+  };
+}
+
+async function loadResumeSession(
+  db: Db,
+  conversationId: string,
+): Promise<StoredExecutionContext["resumeSession"] | undefined> {
+  const [conversation] = await db
+    .select({
+      cliAgentSessionId: conversations.cliAgentSessionId,
+      cliAgentSessionHistory: conversations.cliAgentSessionHistory,
+    })
+    .from(conversations)
+    .where(eq(conversations.id, conversationId))
+    .limit(1);
+
+  if (!conversation?.cliAgentSessionHistory) {
+    return undefined;
+  }
+
+  return {
+    sessionId: conversation.cliAgentSessionId,
+    sessionHistory: conversation.cliAgentSessionHistory,
+  };
+}
+
+async function resolveCompose(
+  db: Db,
+  body: CreateRunBody,
+  userId: string,
+  orgId: string,
+): Promise<ResolvedCompose | CreateRunErrorResult> {
+  if (body.checkpointId && body.sessionId) {
+    return badRequestMessage(
+      "Cannot specify both checkpointId and sessionId. Use checkpointId to resume from a checkpoint, or sessionId to continue a session.",
+    );
+  }
+
+  if (body.checkpointId) {
+    return await resolveByCheckpointId(db, body.checkpointId, userId, orgId);
+  }
+  if (body.sessionId) {
+    return await resolveBySessionId(db, body.sessionId, userId, orgId);
+  }
+  if (body.agentComposeVersionId) {
+    return await lookupComposeByVersion(db, body.agentComposeVersionId);
+  }
+  if (!body.agentComposeId) {
+    return badRequestMessage(
+      "Missing agentComposeId or agentComposeVersionId. Provide composeId, agentComposeVersionId, checkpointId, or sessionId.",
+    );
+  }
+  return await resolveByComposeId(db, body.agentComposeId);
+}
+
+async function enforceCaptureNetworkBodiesGate(
+  db: Db,
+  userId: string,
+  captureNetworkBodies: boolean | undefined,
+): Promise<CreateRunErrorResult | null> {
+  if (!captureNetworkBodies || env("ENV") !== "production") {
+    return null;
+  }
+
+  const [cachedUser] = await db
+    .select({ email: userCache.email })
+    .from(userCache)
+    .where(eq(userCache.userId, userId))
+    .limit(1);
+
+  if (!cachedUser?.email.endsWith("@vm0.ai")) {
+    return forbidden("captureNetworkBodies is restricted to internal accounts");
+  }
+  return null;
+}
+
+function validateCompose(
+  content: AgentComposeContent,
+  vars: Record<string, string> | undefined,
+  secrets: Record<string, string> | undefined,
+): { readonly framework: SupportedFramework } | CreateRunErrorResult {
+  const framework = resolveFramework(content);
+  if (!framework) {
+    return badRequestMessage(
+      "Agent must have a supported framework configured",
+    );
+  }
+
+  const missing = missingEnvironmentReferences(content, vars, secrets);
+  if (missing.length > 0) {
+    return badRequestMessage(`Missing required values: ${missing.join(", ")}`);
+  }
+
+  return { framework };
+}
+
+async function insertRunRecord(
+  tx: Db,
+  args: {
+    readonly userId: string;
+    readonly orgId: string;
+    readonly resolved: ResolvedCompose;
+    readonly body: CreateRunBody;
+    readonly artifacts: readonly ContextArtifact[];
+    readonly additionalVolumes: readonly AdditionalVolume[] | undefined;
+    readonly modelProvider: ResolvedModelProviderEnvironment | null;
+  },
+): Promise<RunRecord> {
+  const sessionId =
+    args.resolved.sessionId ??
+    (
+      await tx
+        .insert(agentSessions)
+        .values({
+          userId: args.userId,
+          orgId: args.orgId,
+          agentComposeId: args.resolved.composeId,
+          artifacts: [...args.artifacts],
+          conversationId: null,
+        })
+        .returning({ id: agentSessions.id })
+    )[0]?.id;
+
+  if (!sessionId) {
+    throw new Error("Failed to create agent session");
+  }
+
+  const [run] = await tx
+    .insert(agentRuns)
+    .values({
+      userId: args.userId,
+      orgId: args.orgId,
+      agentComposeVersionId: args.resolved.agentComposeVersionId,
+      status: "pending",
+      prompt: args.body.prompt,
+      appendSystemPrompt: args.body.appendSystemPrompt ?? null,
+      vars: args.body.vars ?? null,
+      secretNames: args.body.secrets ? Object.keys(args.body.secrets) : null,
+      additionalVolumes: args.additionalVolumes
+        ? [...args.additionalVolumes]
+        : null,
+      resumedFromCheckpointId: args.resolved.resumedFromCheckpointId ?? null,
+      continuedFromSessionId: args.resolved.continuedFromSessionId ?? null,
+      sessionId,
+      lastHeartbeatAt: nowDate(),
+    })
+    .returning({
+      id: agentRuns.id,
+      createdAt: agentRuns.createdAt,
+      sessionId: agentRuns.sessionId,
+    });
+
+  if (!run) {
+    throw new Error("Failed to create run record");
+  }
+
+  await tx.insert(zeroRuns).values({
+    id: run.id,
+    triggerSource: args.body.triggerSource ?? "cli",
+    modelProvider: args.modelProvider?.type ?? null,
+    selectedModel: args.modelProvider?.selectedModel ?? null,
+  });
+
+  return run;
+}
+
+function buildStoredExecutionContext(args: {
+  readonly runId: string;
+  readonly userId: string;
+  readonly orgId: string;
+  readonly resolved: ResolvedCompose;
+  readonly body: CreateRunBody;
+  readonly framework: SupportedFramework;
+  readonly modelProvider: ResolvedModelProviderEnvironment | null;
+  readonly apiStartTime: number;
+  readonly storageManifest: StorageManifest;
+  readonly additionalVolumes: readonly AdditionalVolume[] | undefined;
+}): StoredExecutionContext {
+  const secrets = {
+    ...args.modelProvider?.secrets,
+    ...args.body.secrets,
+  };
+  return {
+    workingDir: frameworkWorkingDir(args.framework),
+    storageManifest: args.storageManifest,
+    environment: expandEnvironment(
+      args.resolved.content,
+      args.body.vars,
+      Object.keys(secrets).length > 0 ? secrets : undefined,
+      args.modelProvider?.environment,
+    ),
+    resumeSession: args.resolved.resumeSession ?? null,
+    encryptedSecrets: encryptSecretsMap(
+      Object.keys(secrets).length > 0 ? secrets : null,
+    ),
+    secretConnectorMap: null,
+    secretConnectorMetadataMap: null,
+    cliAgentType: args.framework,
+    debugNoMockClaude: args.body.debugNoMockClaude || undefined,
+    debugNoMockCodex: args.body.debugNoMockCodex || undefined,
+    captureNetworkBodies: args.body.captureNetworkBodies || undefined,
+    apiStartTime: args.apiStartTime,
+    firewalls: undefined,
+    networkPolicies: undefined,
+    disallowedTools: args.body.disallowedTools,
+    tools: args.body.tools,
+    settings: args.body.settings,
+    experimentalProfile: runnerProfile(args.resolved.content),
+    featureFlags: {},
+    billableFirewalls: [],
+    modelUsageProvider: args.modelProvider?.selectedModel ?? undefined,
+  };
+}
+
+async function markRunFailed(
+  db: Db,
+  runId: string,
+  error: unknown,
+): Promise<void> {
+  const message = error instanceof Error ? error.message : "Run failed";
+  await db
+    .update(agentRuns)
+    .set({
+      status: "failed",
+      error: message,
+      completedAt: nowDate(),
+    })
+    .where(
+      and(
+        eq(agentRuns.id, runId),
+        or(
+          eq(agentRuns.status, "queued"),
+          eq(agentRuns.status, "pending"),
+          eq(agentRuns.status, "running"),
+        ),
+      ),
+    );
+}
+
+async function dispatchRun(
+  get: ComputedGetter,
+  db: Db,
+  args: {
+    readonly run: RunRecord;
+    readonly userId: string;
+    readonly orgId: string;
+    readonly resolved: ResolvedCompose;
+    readonly body: CreateRunBody;
+    readonly artifacts: readonly ContextArtifact[];
+    readonly framework: SupportedFramework;
+    readonly modelProvider: ResolvedModelProviderEnvironment | null;
+    readonly apiStartTime: number;
+    readonly additionalVolumes: readonly AdditionalVolume[] | undefined;
+  },
+): Promise<{ readonly status: RunStatus; readonly sandboxId?: string }> {
+  await db
+    .update(agentRuns)
+    .set({ lastHeartbeatAt: nowDate() })
+    .where(and(eq(agentRuns.id, args.run.id), eq(agentRuns.status, "pending")));
+
+  const group =
+    runnerGroup(args.resolved.content) ?? optionalEnv("RUNNER_DEFAULT_GROUP");
+  if (!group) {
+    throw new Error("No executor configured: set RUNNER_DEFAULT_GROUP");
+  }
+  if (!isOfficialRunnerGroup(group)) {
+    throw new Error("Only vm0/* runner groups are supported");
+  }
+
+  const profile = runnerProfile(args.resolved.content);
+  const storageManifest = await prepareAgentRunStorageManifest({
+    get,
+    db,
+    content: args.resolved.content,
+    vars: args.body.vars,
+    agentOrgId: args.resolved.orgId,
+    runtimeOrgId: args.orgId,
+    userId: args.userId,
+    artifacts: args.artifacts,
+    volumeVersionOverrides: args.resolved.volumeVersions,
+    additionalVolumes: args.additionalVolumes,
+    framework: args.framework,
+  });
+  const storedContext = buildStoredExecutionContext({
+    ...args,
+    runId: args.run.id,
+    storageManifest,
+  });
+
+  await db.insert(runnerJobQueue).values({
+    runId: args.run.id,
+    runnerGroup: group,
+    profile,
+    sessionId: storedContext.resumeSession?.sessionId ?? null,
+    executionContext: storedContext,
+    expiresAt: new Date(now() + 2 * 60 * 60 * 1000),
+  });
+
+  await db
+    .update(agentRuns)
+    .set({ runnerGroup: group })
+    .where(eq(agentRuns.id, args.run.id));
+
+  await publishRunnerJobNotification(group, args.run.id, profile);
+
+  return { status: "pending" };
+}
+
+function createdRunResponse(
+  run: RunRecord,
+  dispatchResult: { readonly status: RunStatus; readonly sandboxId?: string },
+): Extract<CreateRunRouteResult, { readonly status: 201 }> {
+  return {
+    status: 201,
+    body: {
+      runId: run.id,
+      status: dispatchResult.status,
+      sandboxId: dispatchResult.sandboxId,
+      sessionId: run.sessionId,
+      createdAt: run.createdAt.toISOString(),
+    },
+  };
+}
+
+function failedRunResponse(
+  run: RunRecord,
+  error: unknown,
+): Extract<CreateRunRouteResult, { readonly status: 201 }> {
+  return {
+    status: 201,
+    body: {
+      runId: run.id,
+      status: "failed",
+      sessionId: run.sessionId,
+      error: error instanceof Error ? error.message : "Run failed",
+      createdAt: run.createdAt.toISOString(),
+    },
+  };
+}
+
+export const createAgentRun$ = command(
+  async (
+    { get, set },
+    args: {
+      readonly userId: string;
+      readonly orgId: string;
+      readonly body: CreateRunBody;
+      readonly apiStartTime: number;
+    },
+    signal: AbortSignal,
+  ): Promise<CreateRunRouteResult> => {
+    const db = set(writeDb$);
+
+    const captureGate = await enforceCaptureNetworkBodiesGate(
+      db,
+      args.userId,
+      args.body.captureNetworkBodies,
+    );
+    signal.throwIfAborted();
+    if (captureGate) {
+      return captureGate;
+    }
+
+    const resolved = await resolveCompose(
+      db,
+      args.body,
+      args.userId,
+      args.orgId,
+    );
+    signal.throwIfAborted();
+    if (isRouteError(resolved)) {
+      return resolved;
+    }
+
+    if (resolved.orgId !== args.orgId) {
+      return notFound("Resource not found");
+    }
+
+    const validation = validateCompose(
+      resolved.content,
+      args.body.vars,
+      args.body.secrets,
+    );
+    if (isRouteError(validation)) {
+      return validation;
+    }
+
+    const modelProvider = hasExplicitFrameworkApiKey(
+      resolved.content,
+      validation.framework,
+    )
+      ? null
+      : await resolveModelProviderEnvironment(db, {
+          orgId: args.orgId,
+          userId: args.userId,
+          framework: validation.framework,
+        });
+    signal.throwIfAborted();
+    if (
+      !hasExplicitFrameworkApiKey(resolved.content, validation.framework) &&
+      !modelProvider
+    ) {
+      return providerUnavailable(
+        `No model provider configured and ${frameworkApiKeyEnv(validation.framework)} is not declared in compose environment`,
+      );
+    }
+
+    const artifacts = artifactsForRun({
+      resolved,
+      framework: validation.framework,
+      bodyArtifacts: args.body.artifacts,
+    });
+    const additionalVolumes =
+      args.body.additionalVolumes ?? resolved.additionalVolumes;
+
+    const transactionResult = await db.transaction(async (tx) => {
+      await tx.execute(
+        sql`SELECT pg_advisory_xact_lock(hashtext(${args.orgId}))`,
+      );
+      const concurrency = await checkRunConcurrencyLimit(tx, args.orgId);
+      if (concurrency) {
+        return concurrency;
+      }
+      return await insertRunRecord(tx, {
+        userId: args.userId,
+        orgId: args.orgId,
+        resolved,
+        body: args.body,
+        artifacts,
+        additionalVolumes,
+        modelProvider,
+      });
+    });
+    signal.throwIfAborted();
+
+    if (isRouteError(transactionResult)) {
+      return transactionResult;
+    }
+
+    const dispatchResult = await safeAsync(() => {
+      return dispatchRun(get, db, {
+        run: transactionResult,
+        userId: args.userId,
+        orgId: args.orgId,
+        resolved,
+        body: args.body,
+        artifacts,
+        framework: validation.framework,
+        modelProvider,
+        apiStartTime: args.apiStartTime,
+        additionalVolumes,
+      });
+    });
+    signal.throwIfAborted();
+
+    if ("ok" in dispatchResult) {
+      return createdRunResponse(transactionResult, dispatchResult.ok);
+    }
+
+    await markRunFailed(db, transactionResult.id, dispatchResult.error);
+    signal.throwIfAborted();
+    return failedRunResponse(transactionResult, dispatchResult.error);
+  },
+);

--- a/turbo/apps/api/src/signals/services/agent-run-storage.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-storage.service.ts
@@ -1,0 +1,755 @@
+import { gzipSync } from "node:zlib";
+
+import type { StorageManifest } from "@vm0/api-contracts/contracts/runners";
+import {
+  expandVariablesInString,
+  getInstructionsFilename,
+  getInstructionsStorageName,
+  MIN_VERSION_PREFIX_LENGTH,
+  SYSTEM_ORG_ID,
+  type SupportedFramework,
+  VOLUME_ORG_USER_ID,
+} from "@vm0/core";
+import { storages, storageVersions } from "@vm0/db/schema/storage";
+import type { Getter } from "ccstate";
+import { and, eq, like } from "drizzle-orm";
+
+import { env } from "../../lib/env";
+import { generatePresignedGetUrl, putS3Object } from "../external/s3";
+import type { Db } from "../external/db";
+import { nowDate } from "../external/time";
+import { safeAsync } from "../utils";
+import { computeContentHashFromHashes } from "./storage-content-hash.service";
+
+type ComputedGetter = Getter;
+type StorageType = "artifact" | "volume";
+type ManifestStorage = StorageManifest["storages"][number];
+type ManifestArtifact = StorageManifest["artifacts"][number];
+
+interface ContextArtifact {
+  readonly name: string;
+  readonly version?: string;
+  readonly mountPath: string;
+}
+
+interface AdditionalVolume {
+  readonly name: string;
+  readonly version?: string;
+  readonly mountPath: string;
+  readonly system?: boolean;
+}
+
+interface VolumeConfig {
+  readonly name: string;
+  readonly version: string;
+  readonly optional?: boolean;
+  readonly system?: boolean;
+}
+
+interface AgentConfig {
+  readonly framework?: string;
+  readonly volumes?: readonly string[];
+  readonly instructions?: unknown;
+}
+
+interface AgentComposeContent {
+  readonly agent?: AgentConfig;
+  readonly agents?: Record<string, AgentConfig | undefined>;
+  readonly volumes?: Record<string, VolumeConfig | undefined>;
+}
+
+interface ResolvedVolume {
+  readonly name: string;
+  readonly mountPath: string;
+  readonly vasStorageName: string;
+  readonly vasVersion: string;
+  readonly instructionsTargetFilename?: string;
+  readonly optional?: boolean;
+  readonly system?: boolean;
+}
+
+interface StorageResolution {
+  readonly storageId: string;
+  readonly versionId: string;
+  readonly s3Key: string;
+}
+
+interface StorageLookup {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly name: string;
+  readonly type: StorageType;
+}
+
+const EMPTY_TAR_GZ = gzipSync(Buffer.alloc(1024, 0));
+const DOWNLOAD_URL_TTL_SECONDS = 60 * 60;
+
+function instructionsMountPath(framework: SupportedFramework): string {
+  return framework === "codex" ? "/home/user/.codex" : "/home/user/.claude";
+}
+
+function firstAgentEntry(
+  content: AgentComposeContent,
+): { readonly name: string | undefined; readonly agent: AgentConfig } | null {
+  if (content.agent) {
+    return { name: undefined, agent: content.agent };
+  }
+
+  const firstEntry = Object.entries(content.agents ?? {})[0];
+  if (!firstEntry?.[1]) {
+    return null;
+  }
+  return { name: firstEntry[0], agent: firstEntry[1] };
+}
+
+function parseVolumeDeclaration(declaration: string): {
+  readonly name: string;
+  readonly mountPath: string;
+} {
+  const [name, mountPath, extra] = declaration.split(":");
+  if (extra !== undefined || !name?.trim() || !mountPath?.trim()) {
+    throw new Error(
+      `Invalid volume declaration: ${declaration}. Expected format: volume-name:/mount/path`,
+    );
+  }
+  return { name: name.trim(), mountPath: mountPath.trim() };
+}
+
+function expandTemplate(
+  value: string,
+  vars: Record<string, string> | undefined,
+  context: string,
+): string {
+  const { result, missingVars } = expandVariablesInString(value, {
+    vars: vars ?? {},
+  });
+  if (missingVars.length > 0) {
+    throw new Error(
+      `${context} is missing required variables: ${missingVars
+        .map((ref) => {
+          return ref.name;
+        })
+        .join(", ")}`,
+    );
+  }
+  return result;
+}
+
+function resolveComposeVolumes(args: {
+  readonly content: AgentComposeContent;
+  readonly vars: Record<string, string> | undefined;
+  readonly volumeVersionOverrides: Record<string, string> | undefined;
+  readonly framework: SupportedFramework;
+}): readonly ResolvedVolume[] {
+  const entry = firstAgentEntry(args.content);
+  if (!entry) {
+    return [];
+  }
+
+  const resolved: ResolvedVolume[] = [];
+  for (const declaration of entry.agent.volumes ?? []) {
+    const parsed = parseVolumeDeclaration(declaration);
+    const config = args.content.volumes?.[parsed.name];
+    if (!config) {
+      throw new Error(
+        `Volume "${parsed.name}" is not defined in the volumes section`,
+      );
+    }
+
+    const versionOverride = args.volumeVersionOverrides?.[parsed.name];
+    resolved.push({
+      name: parsed.name,
+      mountPath: parsed.mountPath,
+      vasStorageName: expandTemplate(
+        config.name,
+        args.vars,
+        `Volume "${parsed.name}" name`,
+      ),
+      vasVersion: expandTemplate(
+        versionOverride ?? config.version,
+        args.vars,
+        `Volume "${parsed.name}" version`,
+      ),
+      optional: config.optional,
+      system: config.system,
+    });
+  }
+
+  if (entry.agent.instructions && entry.name) {
+    const storageName = getInstructionsStorageName(entry.name);
+    resolved.push({
+      name: storageName,
+      mountPath: instructionsMountPath(args.framework),
+      vasStorageName: storageName,
+      vasVersion: "latest",
+      instructionsTargetFilename: getInstructionsFilename(args.framework),
+    });
+  }
+
+  return resolved;
+}
+
+function dedupArtifacts(
+  artifacts: readonly ContextArtifact[],
+): readonly ContextArtifact[] {
+  const byName = new Map<string, ContextArtifact>();
+  for (const artifact of artifacts) {
+    byName.set(artifact.name, artifact);
+  }
+  return [...byName.values()];
+}
+
+function createEmptyStorageManifest(): string {
+  return JSON.stringify({
+    version: "1",
+    createdAt: nowDate().toISOString(),
+    totalSize: 0,
+    fileCount: 0,
+    files: [],
+  });
+}
+
+async function findStorage(
+  db: Db,
+  lookup: StorageLookup,
+): Promise<
+  | {
+      readonly id: string;
+      readonly headVersionId: string | null;
+      readonly s3Prefix: string;
+    }
+  | undefined
+> {
+  const [storage] = await db
+    .select({
+      id: storages.id,
+      headVersionId: storages.headVersionId,
+      s3Prefix: storages.s3Prefix,
+    })
+    .from(storages)
+    .where(
+      and(
+        eq(storages.orgId, lookup.orgId),
+        eq(storages.userId, lookup.userId),
+        eq(storages.name, lookup.name),
+        eq(storages.type, lookup.type),
+      ),
+    )
+    .limit(1);
+  return storage;
+}
+
+async function ensureArtifactStorage(args: {
+  readonly get: ComputedGetter;
+  readonly db: Db;
+  readonly orgId: string;
+  readonly userId: string;
+  readonly name: string;
+  readonly bucket: string;
+}): Promise<void> {
+  const lookup = {
+    orgId: args.orgId,
+    userId: args.userId,
+    name: args.name,
+    type: "artifact" as const,
+  };
+  let storage = await findStorage(args.db, lookup);
+
+  if (!storage) {
+    const [created] = await args.db
+      .insert(storages)
+      .values({
+        orgId: args.orgId,
+        userId: args.userId,
+        name: args.name,
+        type: "artifact",
+        s3Prefix: `${args.orgId}/artifact/${args.name}`,
+      })
+      .onConflictDoNothing()
+      .returning({
+        id: storages.id,
+        headVersionId: storages.headVersionId,
+        s3Prefix: storages.s3Prefix,
+      });
+    storage = created ?? (await findStorage(args.db, lookup));
+  }
+
+  if (!storage) {
+    throw new Error(`Failed to create artifact storage "${args.name}"`);
+  }
+  if (storage.headVersionId) {
+    return;
+  }
+
+  const versionId = computeContentHashFromHashes(storage.id, []);
+  const s3Key = `${storage.s3Prefix}/${versionId}`;
+  await Promise.all([
+    args.get(
+      putS3Object(
+        args.bucket,
+        `${s3Key}/manifest.json`,
+        createEmptyStorageManifest(),
+        "application/json",
+      ),
+    ),
+    args.get(
+      putS3Object(
+        args.bucket,
+        `${s3Key}/archive.tar.gz`,
+        EMPTY_TAR_GZ,
+        "application/gzip",
+      ),
+    ),
+  ]);
+
+  await args.db.transaction(async (tx) => {
+    await tx
+      .insert(storageVersions)
+      .values({
+        id: versionId,
+        storageId: storage.id,
+        s3Key,
+        size: 0,
+        fileCount: 0,
+        message: "Initial empty artifact",
+        createdBy: args.userId,
+      })
+      .onConflictDoNothing();
+    await tx
+      .update(storages)
+      .set({
+        headVersionId: versionId,
+        size: 0,
+        fileCount: 0,
+        updatedAt: nowDate(),
+      })
+      .where(eq(storages.id, storage.id));
+  });
+}
+
+async function resolveLatestVersion(
+  db: Db,
+  lookup: StorageLookup,
+): Promise<StorageResolution> {
+  const [row] = await db
+    .select({
+      storageId: storages.id,
+      headVersionId: storages.headVersionId,
+      versionId: storageVersions.id,
+      s3Key: storageVersions.s3Key,
+    })
+    .from(storages)
+    .leftJoin(storageVersions, eq(storages.headVersionId, storageVersions.id))
+    .where(
+      and(
+        eq(storages.orgId, lookup.orgId),
+        eq(storages.userId, lookup.userId),
+        eq(storages.name, lookup.name),
+        eq(storages.type, lookup.type),
+      ),
+    )
+    .limit(1);
+
+  if (!row) {
+    throw new Error(`Storage "${lookup.name}" not found in database`);
+  }
+  if (!row.headVersionId) {
+    throw new Error(`Storage "${lookup.name}" has no HEAD version`);
+  }
+  if (!row.versionId || !row.s3Key) {
+    throw new Error(`Storage "${lookup.name}" HEAD version not found`);
+  }
+
+  return {
+    storageId: row.storageId,
+    versionId: row.versionId,
+    s3Key: row.s3Key,
+  };
+}
+
+async function resolvePinnedVersion(
+  db: Db,
+  lookup: StorageLookup,
+  version: string,
+): Promise<StorageResolution> {
+  const storage = await findStorage(db, lookup);
+  if (!storage) {
+    throw new Error(`Storage "${lookup.name}" not found in database`);
+  }
+
+  const [exactMatch] = await db
+    .select({ id: storageVersions.id, s3Key: storageVersions.s3Key })
+    .from(storageVersions)
+    .where(
+      and(
+        eq(storageVersions.storageId, storage.id),
+        eq(storageVersions.id, version),
+      ),
+    )
+    .limit(1);
+  if (exactMatch) {
+    return {
+      storageId: storage.id,
+      versionId: exactMatch.id,
+      s3Key: exactMatch.s3Key,
+    };
+  }
+
+  if (
+    version.length < MIN_VERSION_PREFIX_LENGTH ||
+    !/^[a-f0-9]+$/i.test(version)
+  ) {
+    throw new Error(
+      `Version prefix too short. Minimum ${MIN_VERSION_PREFIX_LENGTH} characters required.`,
+    );
+  }
+
+  const matches = await db
+    .select({ id: storageVersions.id, s3Key: storageVersions.s3Key })
+    .from(storageVersions)
+    .where(
+      and(
+        eq(storageVersions.storageId, storage.id),
+        like(storageVersions.id, `${version}%`),
+      ),
+    )
+    .limit(2);
+  if (matches.length === 0) {
+    throw new Error(`Storage "${lookup.name}" version "${version}" not found`);
+  }
+  if (matches.length > 1) {
+    throw new Error(
+      `Ambiguous version prefix "${version}" for storage "${lookup.name}". Please use more characters.`,
+    );
+  }
+
+  const match = matches[0];
+  if (!match) {
+    throw new Error(`Storage "${lookup.name}" version "${version}" not found`);
+  }
+  return { storageId: storage.id, versionId: match.id, s3Key: match.s3Key };
+}
+
+function resolveStorageVersion(
+  db: Db,
+  lookup: StorageLookup,
+  version: string | undefined,
+): Promise<StorageResolution> {
+  return version === undefined || version === "latest"
+    ? resolveLatestVersion(db, lookup)
+    : resolvePinnedVersion(db, lookup, version);
+}
+
+function isMissingStorageError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    (error.message.includes("not found in database") ||
+      error.message.includes("has no HEAD version"))
+  );
+}
+
+function volumeStorageName(volume: ResolvedVolume | AdditionalVolume): string {
+  return "vasStorageName" in volume ? volume.vasStorageName : volume.name;
+}
+
+function volumeVersion(
+  volume: ResolvedVolume | AdditionalVolume,
+): string | undefined {
+  return "vasVersion" in volume ? volume.vasVersion : volume.version;
+}
+
+async function resolveVolumeStorage(args: {
+  readonly db: Db;
+  readonly volume: ResolvedVolume | AdditionalVolume;
+  readonly primaryOrgId: string;
+  readonly allowSystemFallback: boolean;
+}): Promise<StorageResolution | null> {
+  if (args.allowSystemFallback && args.volume.system) {
+    const systemResult = await safeAsync(() => {
+      return resolveStorageVersion(
+        args.db,
+        {
+          orgId: SYSTEM_ORG_ID,
+          userId: VOLUME_ORG_USER_ID,
+          name: volumeStorageName(args.volume),
+          type: "volume",
+        },
+        volumeVersion(args.volume),
+      );
+    });
+    if ("ok" in systemResult) {
+      return systemResult.ok;
+    }
+    if (!isMissingStorageError(systemResult.error)) {
+      throw systemResult.error;
+    }
+  }
+
+  return await resolveStorageVersion(
+    args.db,
+    {
+      orgId: args.primaryOrgId,
+      userId: VOLUME_ORG_USER_ID,
+      name: volumeStorageName(args.volume),
+      type: "volume",
+    },
+    volumeVersion(args.volume),
+  );
+}
+
+async function buildStorageEntry(args: {
+  readonly get: ComputedGetter;
+  readonly bucket: string;
+  readonly name: string;
+  readonly mountPath: string;
+  readonly vasStorageName: string;
+  readonly instructionsTargetFilename?: string;
+  readonly resolved: StorageResolution;
+}): Promise<ManifestStorage> {
+  const archiveUrl = await args.get(
+    generatePresignedGetUrl(
+      args.bucket,
+      `${args.resolved.s3Key}/archive.tar.gz`,
+      DOWNLOAD_URL_TTL_SECONDS,
+      undefined,
+      true,
+    ),
+  );
+  return {
+    name: args.name,
+    mountPath: args.mountPath,
+    vasStorageName: args.vasStorageName,
+    vasVersionId: args.resolved.versionId,
+    ...(args.instructionsTargetFilename
+      ? { instructionsTargetFilename: args.instructionsTargetFilename }
+      : {}),
+    archiveUrl,
+  };
+}
+
+async function buildComposeStorageEntry(args: {
+  readonly get: ComputedGetter;
+  readonly db: Db;
+  readonly bucket: string;
+  readonly agentOrgId: string;
+  readonly volume: ResolvedVolume;
+}): Promise<ManifestStorage | null> {
+  const resolvedResult = await safeAsync(() => {
+    return resolveVolumeStorage({
+      db: args.db,
+      volume: args.volume,
+      primaryOrgId: args.agentOrgId,
+      allowSystemFallback: true,
+    });
+  });
+  if ("error" in resolvedResult) {
+    if (args.volume.optional && isMissingStorageError(resolvedResult.error)) {
+      return null;
+    }
+    throw resolvedResult.error;
+  }
+  if (!resolvedResult.ok) {
+    return null;
+  }
+  return await buildStorageEntry({
+    get: args.get,
+    bucket: args.bucket,
+    name: args.volume.name,
+    mountPath: args.volume.mountPath,
+    vasStorageName: args.volume.vasStorageName,
+    instructionsTargetFilename: args.volume.instructionsTargetFilename,
+    resolved: resolvedResult.ok,
+  });
+}
+
+async function buildAdditionalStorageEntry(args: {
+  readonly get: ComputedGetter;
+  readonly db: Db;
+  readonly bucket: string;
+  readonly runtimeOrgId: string;
+  readonly volume: AdditionalVolume;
+}): Promise<ManifestStorage | null> {
+  const resolvedResult = await safeAsync(() => {
+    return resolveVolumeStorage({
+      db: args.db,
+      volume: args.volume,
+      primaryOrgId: args.runtimeOrgId,
+      allowSystemFallback: true,
+    });
+  });
+  if ("error" in resolvedResult) {
+    if (isMissingStorageError(resolvedResult.error)) {
+      return null;
+    }
+    throw resolvedResult.error;
+  }
+  if (!resolvedResult.ok) {
+    return null;
+  }
+  return await buildStorageEntry({
+    get: args.get,
+    bucket: args.bucket,
+    name: args.volume.name,
+    mountPath: args.volume.mountPath,
+    vasStorageName: args.volume.name,
+    resolved: resolvedResult.ok,
+  });
+}
+
+async function buildArtifactEntry(args: {
+  readonly get: ComputedGetter;
+  readonly db: Db;
+  readonly bucket: string;
+  readonly runtimeOrgId: string;
+  readonly userId: string;
+  readonly artifact: ContextArtifact;
+}): Promise<ManifestArtifact> {
+  const resolved = await resolveStorageVersion(
+    args.db,
+    {
+      orgId: args.runtimeOrgId,
+      userId: args.userId,
+      name: args.artifact.name,
+      type: "artifact",
+    },
+    args.artifact.version,
+  );
+  const [archiveUrl, manifestUrl] = await Promise.all([
+    args.get(
+      generatePresignedGetUrl(
+        args.bucket,
+        `${resolved.s3Key}/archive.tar.gz`,
+        DOWNLOAD_URL_TTL_SECONDS,
+        undefined,
+        true,
+      ),
+    ),
+    args.get(
+      generatePresignedGetUrl(
+        args.bucket,
+        `${resolved.s3Key}/manifest.json`,
+        DOWNLOAD_URL_TTL_SECONDS,
+        undefined,
+        true,
+      ),
+    ),
+  ]);
+
+  return {
+    mountPath: args.artifact.mountPath,
+    vasStorageName: args.artifact.name,
+    vasStorageId: resolved.storageId,
+    vasVersionId: resolved.versionId,
+    archiveUrl,
+    manifestUrl,
+  };
+}
+
+function mergeStorageEntries(args: {
+  readonly composeEntries: readonly ManifestStorage[];
+  readonly additionalEntries: readonly ManifestStorage[];
+}): readonly ManifestStorage[] {
+  const additionalMountPaths = new Set(
+    args.additionalEntries.map((entry) => {
+      return entry.mountPath;
+    }),
+  );
+  return [
+    ...args.composeEntries.filter((entry) => {
+      return !additionalMountPaths.has(entry.mountPath);
+    }),
+    ...args.additionalEntries,
+  ];
+}
+
+export async function prepareAgentRunStorageManifest(args: {
+  readonly get: ComputedGetter;
+  readonly db: Db;
+  readonly content: AgentComposeContent;
+  readonly vars: Record<string, string> | undefined;
+  readonly agentOrgId: string;
+  readonly runtimeOrgId: string;
+  readonly userId: string;
+  readonly artifacts: readonly ContextArtifact[];
+  readonly volumeVersionOverrides: Record<string, string> | undefined;
+  readonly additionalVolumes: readonly AdditionalVolume[] | undefined;
+  readonly framework: SupportedFramework;
+}): Promise<StorageManifest> {
+  const bucket = env("R2_USER_STORAGES_BUCKET_NAME");
+  const artifacts = dedupArtifacts(args.artifacts);
+  const composeVolumes = resolveComposeVolumes({
+    content: args.content,
+    vars: args.vars,
+    volumeVersionOverrides: args.volumeVersionOverrides,
+    framework: args.framework,
+  });
+
+  await Promise.all(
+    artifacts.map((artifact) => {
+      return ensureArtifactStorage({
+        get: args.get,
+        db: args.db,
+        orgId: args.runtimeOrgId,
+        userId: args.userId,
+        name: artifact.name,
+        bucket,
+      });
+    }),
+  );
+
+  const [composeEntries, additionalEntries, artifactEntries] =
+    await Promise.all([
+      Promise.all(
+        composeVolumes.map((volume) => {
+          return buildComposeStorageEntry({
+            get: args.get,
+            db: args.db,
+            bucket,
+            agentOrgId: args.agentOrgId,
+            volume,
+          });
+        }),
+      ),
+      Promise.all(
+        (args.additionalVolumes ?? []).map((volume) => {
+          return buildAdditionalStorageEntry({
+            get: args.get,
+            db: args.db,
+            bucket,
+            runtimeOrgId: args.runtimeOrgId,
+            volume,
+          });
+        }),
+      ),
+      Promise.all(
+        artifacts.map((artifact) => {
+          return buildArtifactEntry({
+            get: args.get,
+            db: args.db,
+            bucket,
+            runtimeOrgId: args.runtimeOrgId,
+            userId: args.userId,
+            artifact,
+          });
+        }),
+      ),
+    ]);
+
+  return {
+    storages: [
+      ...mergeStorageEntries({
+        composeEntries: composeEntries.filter(
+          (entry): entry is ManifestStorage => {
+            return entry !== null;
+          },
+        ),
+        additionalEntries: additionalEntries.filter(
+          (entry): entry is ManifestStorage => {
+            return entry !== null;
+          },
+        ),
+      }),
+    ],
+    artifacts: artifactEntries,
+  };
+}

--- a/turbo/apps/api/src/signals/services/crypto.utils.ts
+++ b/turbo/apps/api/src/signals/services/crypto.utils.ts
@@ -64,3 +64,13 @@ export function decryptSecretsMap(
     JSON.parse(decryptSecretValue(encryptedData)) as unknown,
   );
 }
+
+export function encryptSecretsMap(
+  secrets: Record<string, string> | null | undefined,
+): string | null {
+  if (!secrets) {
+    return null;
+  }
+
+  return encryptSecretValue(JSON.stringify(secrets));
+}

--- a/turbo/packages/api-contracts/src/contracts/runs.ts
+++ b/turbo/packages/api-contracts/src/contracts/runs.ts
@@ -262,6 +262,7 @@ export const runsMainContract = c.router({
       402: apiErrorSchema,
       403: apiErrorSchema,
       404: apiErrorSchema,
+      429: apiErrorSchema,
       422: apiErrorSchema,
       503: apiErrorSchema,
     },


### PR DESCRIPTION
## Summary
- Reimplement `/api/agent/runs` create and cancel routes in `apps/api` without importing or delegating to `apps/web`
- Add API-native run creation, runner queue dispatch, model-provider env injection, storage manifest preparation, artifact/memory handling, additional volumes, checkpoint/session resume, and concurrency limits
- Add route-level integration coverage for create and cancel behavior, including storage manifests and sandbox-token cancellation

Closes #12847

## Validation
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F api exec vitest src/signals/routes/__tests__/agent-runs-create.test.ts src/signals/routes/__tests__/agent-runs-cancel.test.ts`
- `pnpm -F api exec vitest src/signals/routes/__tests__/agent-runs-read.test.ts src/signals/routes/__tests__/zero-runs-cancel.test.ts`
- pre-commit: `pnpm check-types`