### PR TITLE
refactor(api): migrate v1 chat message send to api

### DIFF
--- a/turbo/apps/api/src/__tests__/app-factory.test.ts
+++ b/turbo/apps/api/src/__tests__/app-factory.test.ts
@@ -222,16 +222,17 @@ describe("createApp", () => {
     it("forwards POST bodies to the upstream", async () => {
       mockEnv("VM0_WEB_URL", "https://www.vm0.ai");
       let observedBody: Promise<string> | undefined;
+      const proxyPath = "/__legacy/proxy/post-body";
       useUndiciMock()
         .get("https://www.vm0.ai")
-        .intercept({ path: "/api/v1/chat-threads/messages", method: "POST" })
+        .intercept({ path: proxyPath, method: "POST" })
         .reply((opts) => {
           observedBody = readBodyAsString(opts.body);
           return { statusCode: 202, data: "" };
         });
 
       const app = createApp({ signal: context.signal });
-      const response = await app.request("/api/v1/chat-threads/messages", {
+      const response = await app.request(proxyPath, {
         method: "POST",
         headers: { "content-type": "application/json" },
         body: '{"hello":"world"}',

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads-v1.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads-v1.test.ts
@@ -1,19 +1,30 @@
 import { randomUUID } from "node:crypto";
 
 import { createApp } from "../../../app-factory";
-import { agentComposes } from "@vm0/db/schema/agent-compose";
+import {
+  agentComposes,
+  agentComposeVersions,
+} from "@vm0/db/schema/agent-compose";
+import { agentRunCallbacks } from "@vm0/db/schema/agent-run-callback";
+import { agentRuns } from "@vm0/db/schema/agent-run";
+import { agentSessions } from "@vm0/db/schema/agent-session";
 import { chatMessages } from "@vm0/db/schema/chat-message";
 import { chatThreads } from "@vm0/db/schema/chat-thread";
 import { cliTokens } from "@vm0/db/schema/cli-tokens";
 import { orgMembersCache } from "@vm0/db/schema/org-members-cache";
+import { orgMetadata } from "@vm0/db/schema/org-metadata";
+import { runnerJobQueue } from "@vm0/db/schema/runner-job-queue";
+import { zeroRuns } from "@vm0/db/schema/zero-run";
 import {
   chatThreadV1GetContract,
   chatThreadV1MessagesContract,
+  chatThreadV1SendContract,
 } from "@vm0/api-contracts/contracts/chat-threads-v1";
 import { createStore } from "ccstate";
 import { and, eq } from "drizzle-orm";
 
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { decryptSecretValue } from "../../services/crypto.utils";
 import { writeDb$ } from "../../external/db";
 import { now } from "../../external/time";
 import { signPatJwtForTests, signSandboxJwtForTests } from "../../auth/tokens";
@@ -28,6 +39,11 @@ interface PatFixture {
 interface ThreadFixture {
   readonly threadId: string;
   readonly composeId: string;
+}
+
+interface RunnableAgentFixture {
+  readonly composeId: string;
+  readonly versionId: string;
 }
 
 const store = createStore();
@@ -105,6 +121,7 @@ async function seedExpiredPatFixture(): Promise<PatFixture> {
 
 async function deletePatFixture(fixture: PatFixture): Promise<void> {
   const writeDb = store.set(writeDb$);
+  await writeDb.delete(orgMetadata).where(eq(orgMetadata.orgId, fixture.orgId));
   await writeDb
     .delete(orgMembersCache)
     .where(
@@ -147,6 +164,102 @@ async function deleteThreadFixture(fixture: ThreadFixture): Promise<void> {
   await writeDb
     .delete(agentComposes)
     .where(eq(agentComposes.id, fixture.composeId));
+}
+
+async function seedRunnableAgentFixture(
+  pat: PatFixture,
+): Promise<RunnableAgentFixture> {
+  const composeId = randomUUID();
+  const versionId = randomUUID();
+  const writeDb = store.set(writeDb$);
+  const content = {
+    version: "1.0",
+    agents: {
+      main: {
+        framework: "claude-code",
+        environment: { ANTHROPIC_API_KEY: "test-key" },
+        experimental_runner: { group: "vm0/test" },
+      },
+    },
+  };
+
+  await writeDb.insert(agentComposes).values({
+    id: composeId,
+    userId: pat.userId,
+    orgId: pat.orgId,
+    name: `compose-${composeId.slice(0, 8)}`,
+    headVersionId: versionId,
+  });
+  await writeDb.insert(agentComposeVersions).values({
+    id: versionId,
+    composeId,
+    content,
+    createdBy: pat.userId,
+  });
+
+  return { composeId, versionId };
+}
+
+async function setDefaultAgent(
+  pat: PatFixture,
+  agent: RunnableAgentFixture,
+): Promise<void> {
+  const writeDb = store.set(writeDb$);
+  await writeDb
+    .insert(orgMetadata)
+    .values({ orgId: pat.orgId, defaultAgentId: agent.composeId })
+    .onConflictDoUpdate({
+      target: orgMetadata.orgId,
+      set: { defaultAgentId: agent.composeId },
+    });
+}
+
+async function seedRunnableThreadFixture(
+  pat: PatFixture,
+): Promise<ThreadFixture & RunnableAgentFixture> {
+  const agent = await seedRunnableAgentFixture(pat);
+  const threadId = randomUUID();
+  const writeDb = store.set(writeDb$);
+  await writeDb.insert(chatThreads).values({
+    id: threadId,
+    userId: pat.userId,
+    agentComposeId: agent.composeId,
+    title: "test thread",
+  });
+  return { threadId, composeId: agent.composeId, versionId: agent.versionId };
+}
+
+async function seedPriorThreadRun(args: {
+  readonly pat: PatFixture;
+  readonly threadId: string;
+  readonly composeId: string;
+  readonly versionId: string;
+}): Promise<string> {
+  const writeDb = store.set(writeDb$);
+  const sessionId = randomUUID();
+  const runId = randomUUID();
+  await writeDb.insert(agentSessions).values({
+    id: sessionId,
+    userId: args.pat.userId,
+    orgId: args.pat.orgId,
+    agentComposeId: args.composeId,
+  });
+  await writeDb.insert(agentRuns).values({
+    id: runId,
+    userId: args.pat.userId,
+    orgId: args.pat.orgId,
+    agentComposeVersionId: args.versionId,
+    sessionId,
+    status: "completed",
+    prompt: "previous prompt",
+    result: { agentSessionId: sessionId },
+  });
+  await writeDb.insert(zeroRuns).values({
+    id: runId,
+    triggerSource: "web",
+    chatThreadId: args.threadId,
+  });
+  return sessionId;
 }
 
 interface SeedMessageOptions {
@@ -556,6 +669,244 @@ describe("GET /api/v1/chat-threads/:threadId/messages", () => {
         params: { threadId: thread.threadId },
         query: {},
         headers: { authorization: `Bearer ${intruder.token}` },
+      }),
+      [404],
+    );
+
+    expect(response.body.error.code).toBe("NOT_FOUND");
+  });
+});
+
+describe("POST /api/v1/chat-threads/messages", () => {
+  const pats: PatFixture[] = [];
+  const threads: ThreadFixture[] = [];
+  const agents: RunnableAgentFixture[] = [];
+
+  beforeEach(() => {
+    context.mocks.clerk.authenticateRequest.mockReset();
+    context.mocks.clerk.authenticateRequest.mockResolvedValue({
+      isAuthenticated: false,
+    });
+  });
+
+  afterEach(async () => {
+    while (threads.length > 0) {
+      const t = threads.pop();
+      if (t) {
+        await deleteThreadFixture(t);
+      }
+    }
+    while (agents.length > 0) {
+      const agent = agents.pop();
+      if (agent) {
+        await store
+          .set(writeDb$)
+          .delete(agentComposes)
+          .where(eq(agentComposes.id, agent.composeId));
+      }
+    }
+    while (pats.length > 0) {
+      const p = pats.pop();
+      if (p) {
+        await deletePatFixture(p);
+      }
+    }
+  });
+
+  it("creates a thread, run, chat callback, user message, and runner job", async () => {
+    const pat = await seedPatFixture();
+    pats.push(pat);
+    const agent = await seedRunnableAgentFixture(pat);
+    await setDefaultAgent(pat, agent);
+    agents.push(agent);
+
+    const client = setupApp({ context })(chatThreadV1SendContract);
+    const response = await accept(
+      client.send({
+        headers: { authorization: `Bearer ${pat.token}` },
+        body: { prompt: "hello from v1" },
+      }),
+      [201],
+    );
+
+    const writeDb = store.set(writeDb$);
+    const [thread] = await writeDb
+      .select({
+        id: chatThreads.id,
+        userId: chatThreads.userId,
+        agentComposeId: chatThreads.agentComposeId,
+      })
+      .from(chatThreads)
+      .where(eq(chatThreads.id, response.body.threadId))
+      .limit(1);
+    expect(thread).toStrictEqual({
+      id: response.body.threadId,
+      userId: pat.userId,
+      agentComposeId: agent.composeId,
+    });
+
+    const [message] = await writeDb
+      .select({
+        id: chatMessages.id,
+        content: chatMessages.content,
+        role: chatMessages.role,
+        runId: chatMessages.runId,
+      })
+      .from(chatMessages)
+      .where(eq(chatMessages.id, response.body.messageId))
+      .limit(1);
+    if (!message?.runId) {
+      throw new Error("Expected inserted chat message to reference a run");
+    }
+    expect(message).toMatchObject({
+      id: response.body.messageId,
+      content: "hello from v1",
+      role: "user",
+    });
+
+    const [run] = await writeDb
+      .select({
+        prompt: agentRuns.prompt,
+        appendSystemPrompt: agentRuns.appendSystemPrompt,
+        triggerSource: zeroRuns.triggerSource,
+        chatThreadId: zeroRuns.chatThreadId,
+      })
+      .from(agentRuns)
+      .innerJoin(zeroRuns, eq(zeroRuns.id, agentRuns.id))
+      .where(eq(agentRuns.id, message.runId))
+      .limit(1);
+    expect(run).toStrictEqual({
+      prompt: "hello from v1",
+      appendSystemPrompt:
+        "# Current Integration\nYou are currently running inside: Web\n\nYou are communicating with the user through the web chat UI.",
+      triggerSource: "web",
+      chatThreadId: response.body.threadId,
+    });
+
+    const [callback] = await writeDb
+      .select({
+        url: agentRunCallbacks.url,
+        encryptedSecret: agentRunCallbacks.encryptedSecret,
+        payload: agentRunCallbacks.payload,
+      })
+      .from(agentRunCallbacks)
+      .where(eq(agentRunCallbacks.runId, message.runId))
+      .limit(1);
+    if (!callback) {
+      throw new Error("Expected chat callback to be registered");
+    }
+    expect(callback.url).toBe(
+      "http://localhost:3000/api/internal/callbacks/chat",
+    );
+    expect(decryptSecretValue(callback.encryptedSecret)).toHaveLength(64);
+    expect(callback.payload).toStrictEqual({
+      threadId: response.body.threadId,
+      agentId: agent.composeId,
+    });
+
+    const [job] = await writeDb
+      .select({ runnerGroup: runnerJobQueue.runnerGroup })
+      .from(runnerJobQueue)
+      .where(eq(runnerJobQueue.runId, message.runId))
+      .limit(1);
+    expect(job).toStrictEqual({ runnerGroup: "vm0/test" });
+    expect(context.mocks.ably.publish).toHaveBeenCalledWith(
+      `chatThreadMessageCreated:${response.body.threadId}`,
+      null,
+    );
+    expect(context.mocks.ably.publish).toHaveBeenCalledWith(
+      `chatThreadRunCreated:${response.body.threadId}`,
+      null,
+    );
+    expect(context.mocks.ably.publish).toHaveBeenCalledWith(
+      "threadListChanged",
+      null,
+    );
+    expect(response.body.createdAt).toStrictEqual(expect.any(String));
+  });
+
+  it("continues an existing thread from the latest session", async () => {
+    const pat = await seedPatFixture();
+    pats.push(pat);
+    const thread = await seedRunnableThreadFixture(pat);
+    threads.push(thread);
+    const priorSessionId = await seedPriorThreadRun({
+      pat,
+      threadId: thread.threadId,
+      composeId: thread.composeId,
+      versionId: thread.versionId,
+    });
+
+    const client = setupApp({ context })(chatThreadV1SendContract);
+    const response = await accept(
+      client.send({
+        headers: { authorization: `Bearer ${pat.token}` },
+        body: { prompt: "continue", threadId: thread.threadId },
+      }),
+      [201],
+    );
+
+    expect(response.body.threadId).toBe(thread.threadId);
+
+    const writeDb = store.set(writeDb$);
+    const [message] = await writeDb
+      .select({ runId: chatMessages.runId })
+      .from(chatMessages)
+      .where(eq(chatMessages.id, response.body.messageId))
+      .limit(1);
+    if (!message?.runId) {
+      throw new Error("Expected continuation message to reference a run");
+    }
+
+    const [run] = await writeDb
+      .select({
+        sessionId: agentRuns.sessionId,
+        continuedFromSessionId: agentRuns.continuedFromSessionId,
+        chatThreadId: zeroRuns.chatThreadId,
+      })
+      .from(agentRuns)
+      .innerJoin(zeroRuns, eq(zeroRuns.id, agentRuns.id))
+      .where(eq(agentRuns.id, message.runId))
+      .limit(1);
+    expect(run).toStrictEqual({
+      sessionId: priorSessionId,
+      continuedFromSessionId: priorSessionId,
+      chatThreadId: thread.threadId,
+    });
+  });
+
+  it("returns 400 when no default agent is configured", async () => {
+    const pat = await seedPatFixture();
+    pats.push(pat);
+
+    const client = setupApp({ context })(chatThreadV1SendContract);
+    const response = await accept(
+      client.send({
+        headers: { authorization: `Bearer ${pat.token}` },
+        body: { prompt: "hello" },
+      }),
+      [400],
+    );
+
+    expect(response.body.error).toStrictEqual({
+      message: "No default agent configured for this organization",
+      code: "BAD_REQUEST",
+    });
+  });
+
+  it("returns 404 when appending to another user's thread", async () => {
+    const owner = await seedPatFixture();
+    pats.push(owner);
+    const intruder = await seedPatFixture();
+    pats.push(intruder);
+    const thread = await seedRunnableThreadFixture(owner);
+    threads.push(thread);
+
+    const client = setupApp({ context })(chatThreadV1SendContract);
+    const response = await accept(
+      client.send({
+        headers: { authorization: `Bearer ${intruder.token}` },
+        body: { prompt: "nope", threadId: thread.threadId },
       }),
       [404],
     );

--- a/turbo/apps/api/src/signals/routes/chat-threads-v1.ts
+++ b/turbo/apps/api/src/signals/routes/chat-threads-v1.ts
@@ -1,17 +1,20 @@
-import { computed } from "ccstate";
+import { command, computed } from "ccstate";
 import {
   chatThreadV1GetContract,
   chatThreadV1MessagesContract,
+  chatThreadV1SendContract,
 } from "@vm0/api-contracts/contracts/chat-threads-v1";
 
-import { authContext$ } from "../auth/auth-context";
+import { authContext$, organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
-import { pathParamsOf, queryOf } from "../context/request";
+import { bodyResultOf, pathParamsOf, queryOf } from "../context/request";
+import { now } from "../external/time";
 import { notFound } from "../../lib/error";
 import {
   chatThreadMessagesV1,
   ownedChatThreadV1,
 } from "../services/chat-thread.service";
+import { sendChatThreadMessageV1$ } from "../services/chat-thread-v1-send.service";
 import type { RouteEntry } from "../route";
 
 const getThreadHandler$ = computed(async (get) => {
@@ -47,13 +50,48 @@ const getThreadMessagesHandler$ = computed(async (get) => {
   return { status: 200 as const, body: { messages: [...messages] } };
 });
 
+const sendThreadMessageBody$ = bodyResultOf(chatThreadV1SendContract.send);
+
+const sendThreadMessageHandler$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const apiStartTime = now();
+    const auth = get(organizationAuthContext$);
+    const body = await get(sendThreadMessageBody$);
+    signal.throwIfAborted();
+    if (!body.ok) {
+      return body.response;
+    }
+
+    return await set(
+      sendChatThreadMessageV1$,
+      {
+        userId: auth.userId,
+        orgId: auth.orgId,
+        prompt: body.data.prompt,
+        threadId: body.data.threadId,
+        apiStartTime,
+      },
+      signal,
+    );
+  },
+);
+
 const getThread$ = authRoute({ accept: ["pat"] }, getThreadHandler$);
 const getThreadMessages$ = authRoute(
   { accept: ["pat"] },
   getThreadMessagesHandler$,
 );
+const sendThreadMessage$ = authRoute(
+  {
+    accept: ["pat"],
+    requireOrganization: true,
+    missingOrganizationStatus: 401,
+  },
+  sendThreadMessageHandler$,
+);
 
 export const chatThreadsV1Routes: readonly RouteEntry[] = [
   { route: chatThreadV1GetContract.get, handler: getThread$ },
   { route: chatThreadV1MessagesContract.list, handler: getThreadMessages$ },
+  { route: chatThreadV1SendContract.send, handler: sendThreadMessage$ },
 ];

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -26,6 +26,7 @@ import {
   agentComposes,
   agentComposeVersions,
 } from "@vm0/db/schema/agent-compose";
+import { agentRunCallbacks } from "@vm0/db/schema/agent-run-callback";
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { agentSessions } from "@vm0/db/schema/agent-session";
 import { conversations } from "@vm0/db/schema/conversation";
@@ -49,7 +50,11 @@ import { writeDb$, type Db } from "../external/db";
 import { publishRunnerJobNotification } from "../external/realtime";
 import { now, nowDate } from "../external/time";
 import { safeAsync } from "../utils";
-import { decryptSecretValue, encryptSecretsMap } from "./crypto.utils";
+import {
+  decryptSecretValue,
+  encryptSecretValue,
+  encryptSecretsMap,
+} from "./crypto.utils";
 import { prepareAgentRunStorageManifest } from "./agent-run-storage.service";
 
 const PENDING_RUN_TTL_MS = 15 * 60 * 1000;
@@ -121,6 +126,12 @@ interface RunRecord {
   readonly id: string;
   readonly createdAt: Date;
   readonly sessionId: string;
+}
+
+interface RunCallback {
+  readonly url: string;
+  readonly secret: string;
+  readonly payload: unknown;
 }
 
 interface ResolvedModelProviderEnvironment {
@@ -831,6 +842,8 @@ async function insertRunRecord(
     readonly artifacts: readonly ContextArtifact[];
     readonly additionalVolumes: readonly AdditionalVolume[] | undefined;
     readonly modelProvider: ResolvedModelProviderEnvironment | null;
+    readonly callbacks: readonly RunCallback[] | undefined;
+    readonly chatThreadId: string | undefined;
   },
 ): Promise<RunRecord> {
   const sessionId =
@@ -886,7 +899,21 @@ async function insertRunRecord(
     triggerSource: args.body.triggerSource ?? "cli",
     modelProvider: args.modelProvider?.type ?? null,
     selectedModel: args.modelProvider?.selectedModel ?? null,
+    chatThreadId: args.chatThreadId ?? null,
   });
+
+  if (args.callbacks && args.callbacks.length > 0) {
+    await tx.insert(agentRunCallbacks).values(
+      args.callbacks.map((callback) => {
+        return {
+          runId: run.id,
+          url: callback.url,
+          encryptedSecret: encryptSecretValue(callback.secret),
+          payload: callback.payload,
+        };
+      }),
+    );
+  }
 
   return run;
 }
@@ -1073,6 +1100,8 @@ export const createAgentRun$ = command(
       readonly orgId: string;
       readonly body: CreateRunBody;
       readonly apiStartTime: number;
+      readonly callbacks?: readonly RunCallback[];
+      readonly chatThreadId?: string;
     },
     signal: AbortSignal,
   ): Promise<CreateRunRouteResult> => {
@@ -1156,6 +1185,8 @@ export const createAgentRun$ = command(
         artifacts,
         additionalVolumes,
         modelProvider,
+        callbacks: args.callbacks,
+        chatThreadId: args.chatThreadId,
       });
     });
     signal.throwIfAborted();

--- a/turbo/apps/api/src/signals/services/chat-thread-v1-send.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-thread-v1-send.service.ts
@@ -1,0 +1,225 @@
+import { randomBytes } from "node:crypto";
+
+import { command } from "ccstate";
+import type { TriggerSource } from "@vm0/api-contracts/contracts/logs";
+import { agentRuns } from "@vm0/db/schema/agent-run";
+import { chatMessages } from "@vm0/db/schema/chat-message";
+import { chatThreads } from "@vm0/db/schema/chat-thread";
+import { orgMetadata } from "@vm0/db/schema/org-metadata";
+import { zeroRuns } from "@vm0/db/schema/zero-run";
+import { and, desc, eq } from "drizzle-orm";
+
+import { env } from "../../lib/env";
+import { badRequestMessage, notFound } from "../../lib/error";
+import { writeDb$, type Db } from "../external/db";
+import {
+  publishThreadListChanged,
+  publishUserSignal,
+} from "../external/realtime";
+import { createAgentRun$ } from "./agent-run-create.service";
+
+interface OwnedThreadForSend {
+  readonly id: string;
+  readonly agentComposeId: string;
+}
+
+function hasAgentSessionId(
+  value: unknown,
+): value is { readonly agentSessionId: string } {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "agentSessionId" in value &&
+    typeof (value as { readonly agentSessionId: unknown }).agentSessionId ===
+      "string"
+  );
+}
+
+function buildWebChatPrompt(): string {
+  return [
+    "# Current Integration\nYou are currently running inside: Web",
+    "You are communicating with the user through the web chat UI.",
+  ].join("\n\n");
+}
+
+function generateCallbackSecret(): string {
+  return randomBytes(32).toString("hex");
+}
+
+function chatCallbackUrl(): string {
+  return new URL("/api/internal/callbacks/chat", env("VM0_API_URL")).toString();
+}
+
+export const sendChatThreadMessageV1$ = command(
+  async (
+    { set },
+    args: {
+      readonly userId: string;
+      readonly orgId: string;
+      readonly prompt: string;
+      readonly threadId: string | undefined;
+      readonly apiStartTime: number;
+    },
+    signal: AbortSignal,
+  ) => {
+    const db = set(writeDb$);
+
+    let thread: OwnedThreadForSend;
+    let sessionId: string | undefined;
+
+    if (args.threadId) {
+      const [existingThread] = await db
+        .select({
+          id: chatThreads.id,
+          agentComposeId: chatThreads.agentComposeId,
+        })
+        .from(chatThreads)
+        .where(
+          and(
+            eq(chatThreads.id, args.threadId),
+            eq(chatThreads.userId, args.userId),
+          ),
+        )
+        .limit(1);
+      signal.throwIfAborted();
+
+      if (!existingThread) {
+        return notFound("Chat thread not found");
+      }
+
+      thread = existingThread;
+      sessionId = await latestSessionIdForThread(db, thread.id);
+      signal.throwIfAborted();
+    } else {
+      const agentId = await defaultAgentId(db, args.orgId);
+      signal.throwIfAborted();
+
+      if (!agentId) {
+        return badRequestMessage(
+          "No default agent configured for this organization",
+        );
+      }
+
+      const [createdThread] = await db
+        .insert(chatThreads)
+        .values({
+          userId: args.userId,
+          agentComposeId: agentId,
+          title: null,
+        })
+        .returning({
+          id: chatThreads.id,
+          agentComposeId: chatThreads.agentComposeId,
+        });
+      signal.throwIfAborted();
+
+      if (!createdThread) {
+        throw new Error("Failed to create chat thread");
+      }
+
+      thread = createdThread;
+    }
+
+    const triggerSource: TriggerSource = "web";
+    const runBody = {
+      prompt: args.prompt,
+      agentComposeId: thread.agentComposeId,
+      ...(sessionId ? { sessionId } : {}),
+      triggerSource,
+      appendSystemPrompt: buildWebChatPrompt(),
+    };
+
+    const runResult = await set(
+      createAgentRun$,
+      {
+        userId: args.userId,
+        orgId: args.orgId,
+        body: runBody,
+        apiStartTime: args.apiStartTime,
+        chatThreadId: thread.id,
+        callbacks: [
+          {
+            url: chatCallbackUrl(),
+            secret: generateCallbackSecret(),
+            payload: { threadId: thread.id, agentId: thread.agentComposeId },
+          },
+        ],
+      },
+      signal,
+    );
+    signal.throwIfAborted();
+
+    if (runResult.status !== 201) {
+      return runResult;
+    }
+
+    const [message] = await db
+      .insert(chatMessages)
+      .values({
+        chatThreadId: thread.id,
+        role: "user",
+        content: args.prompt,
+        runId: runResult.body.runId,
+      })
+      .returning({ id: chatMessages.id });
+    signal.throwIfAborted();
+
+    if (!message) {
+      throw new Error("Failed to insert chat message");
+    }
+
+    await publishUserSignal(
+      [args.userId],
+      `chatThreadMessageCreated:${thread.id}`,
+    );
+    signal.throwIfAborted();
+
+    await publishThreadListChanged(args.userId);
+    signal.throwIfAborted();
+
+    await publishUserSignal([args.userId], `chatThreadRunCreated:${thread.id}`);
+    signal.throwIfAborted();
+
+    await publishThreadListChanged(args.userId);
+    signal.throwIfAborted();
+
+    return {
+      status: 201 as const,
+      body: {
+        threadId: thread.id,
+        messageId: message.id,
+        createdAt: runResult.body.createdAt,
+      },
+    };
+  },
+);
+
+async function defaultAgentId(db: Db, orgId: string): Promise<string | null> {
+  const [orgRow] = await db
+    .select({ defaultAgentId: orgMetadata.defaultAgentId })
+    .from(orgMetadata)
+    .where(eq(orgMetadata.orgId, orgId))
+    .limit(1);
+
+  return orgRow?.defaultAgentId ?? null;
+}
+
+async function latestSessionIdForThread(
+  db: Db,
+  threadId: string,
+): Promise<string | undefined> {
+  const rows = await db
+    .select({ result: agentRuns.result })
+    .from(zeroRuns)
+    .innerJoin(agentRuns, eq(zeroRuns.id, agentRuns.id))
+    .where(eq(zeroRuns.chatThreadId, threadId))
+    .orderBy(desc(agentRuns.createdAt))
+    .limit(5);
+
+  for (const row of rows) {
+    if (hasAgentSessionId(row.result)) {
+      return row.result.agentSessionId;
+    }
+  }
+  return undefined;
+}

--- a/turbo/packages/api-contracts/src/contracts/chat-threads-v1.ts
+++ b/turbo/packages/api-contracts/src/contracts/chat-threads-v1.ts
@@ -85,6 +85,8 @@ export const chatThreadV1SendContract = c.router({
       401: apiErrorSchema,
       403: apiErrorSchema,
       404: apiErrorSchema,
+      429: apiErrorSchema,
+      503: apiErrorSchema,
     },
     summary:
       "Send a chat message — creates a new thread on the caller's default agent when threadId is omitted",


### PR DESCRIPTION
Closes #12865

## Summary
- register `chatThreadV1SendContract.send` in `apps/api` as the authoritative POST `/api/v1/chat-threads/messages` handler
- add API-native v1 send orchestration for default-thread creation, existing-thread continuation, chat callback registration, user-message insertion, realtime signals, and runner dispatch
- extend API run creation with internal callback/chat-thread metadata persisted before runner notification
- update legacy proxy coverage now that this path is API-owned

## Validation
- `scripts/prepare.sh`
- `pnpm format`
- `pnpm -F api lint`
- `pnpm -F api exec vitest src/signals/routes/__tests__/chat-threads-v1.test.ts src/__tests__/app-factory.test.ts`
- `pnpm -F api exec vitest`
- `pnpm check-types`
- `pnpm knip`