### PR TITLE
refactor(platform): simplify bb0 device page

### DIFF
--- a/turbo/apps/platform/src/signals/device-bb0-page/bb0-device-onboarding.ts
+++ b/turbo/apps/platform/src/signals/device-bb0-page/bb0-device-onboarding.ts
@@ -5,8 +5,7 @@ import { accept } from "../../lib/accept.ts";
 import { zeroClient$ } from "../api-client.ts";
 import { jsonParseOr } from "../utils.ts";
 
-export const BB0_PROVISIONING_SERVICE_UUID =
-  "bb000001-8f16-4b2a-9bb0-000000000001";
+const BB0_PROVISIONING_SERVICE_UUID = "bb000001-8f16-4b2a-9bb0-000000000001";
 
 const BB0_DEVICE_NAME_PREFIX = "Zero-Buddy-";
 const BB0_INFO_CHARACTERISTIC_UUID = "bb000002-8f16-4b2a-9bb0-000000000001";
@@ -22,7 +21,6 @@ type Bb0ConnectionStatus =
 
 type Bb0OperationStatus =
   | "idle"
-  | "reading"
   | "sending_wifi"
   | "confirming_code"
   | "confirmed";
@@ -292,21 +290,6 @@ export const connectBb0Device$ = command(
         operationStatus: "idle",
         infoNotificationsEnabled,
       };
-    });
-  },
-);
-
-export const refreshBb0DeviceStatus$ = command(
-  async ({ get, set }, signal: AbortSignal) => {
-    set(internalProvisioningState$, (current): Bb0ProvisioningState => {
-      return { ...current, operationStatus: "reading" };
-    });
-
-    const session = requireSession(get(internalBleSession$));
-    set(internalDeviceInfo$, await readBb0Status(session));
-    signal.throwIfAborted();
-    set(internalProvisioningState$, (current): Bb0ProvisioningState => {
-      return { ...current, operationStatus: "idle" };
     });
   },
 );

--- a/turbo/apps/platform/src/views/device-bb0/bb0-device-page.tsx
+++ b/turbo/apps/platform/src/views/device-bb0/bb0-device-page.tsx
@@ -1,19 +1,13 @@
 import type { ReactNode } from "react";
 import { useGet, useSet } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
-import {
-  IconCheck,
-  IconChevronDown,
-  IconLoader,
-  IconRefresh,
-} from "@tabler/icons-react";
+import { IconCheck, IconLoader } from "@tabler/icons-react";
 import { Button } from "@vm0/ui/components/ui/button";
 import { Input } from "@vm0/ui/components/ui/input";
 import { cn } from "@vm0/ui";
 import { detach, Reason } from "../../signals/utils.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import {
-  BB0_PROVISIONING_SERVICE_UUID,
   bb0BrowserSupport$,
   bb0CanConfirmCode$,
   bb0CanSendWifi$,
@@ -25,7 +19,6 @@ import {
   confirmBb0DeviceCode$,
   connectBb0Device$,
   disconnectBb0Device$,
-  refreshBb0DeviceStatus$,
   resetBb0Onboarding$,
   sendBb0WifiCredentials$,
   setBb0DeviceCodeInput$,
@@ -194,25 +187,6 @@ function BleConnectStep() {
           )}
         </div>
 
-        <details className="group">
-          <summary className="inline-flex cursor-pointer select-none items-center gap-1 text-xs text-muted-foreground hover:text-foreground">
-            Technical details
-            <IconChevronDown
-              size={11}
-              stroke={1.8}
-              className="transition-transform group-open:rotate-180"
-            />
-          </summary>
-          <div className="zero-border mt-2 rounded-lg bg-muted/30 px-3 py-2 text-xs leading-6 text-muted-foreground">
-            Filter: <code className="text-foreground">Zero-Buddy-*</code>
-            <br />
-            Service UUID:{" "}
-            <code className="break-all text-foreground">
-              {BB0_PROVISIONING_SERVICE_UUID}
-            </code>
-          </div>
-        </details>
-
         <StepError message={error} />
       </div>
     </div>
@@ -231,13 +205,10 @@ function WifiStep() {
   const pageSignal = useGet(pageSignal$);
   const setSsid = useSet(setBb0WifiSsid$);
   const setPassword = useSet(setBb0WifiPassword$);
-  const [refreshLoadable, refresh] = useLoadableSet(refreshBb0DeviceStatus$);
   const [wifiLoadable, sendWifi] = useLoadableSet(sendBb0WifiCredentials$);
   const connected = state.connectionStatus === "connected";
-  const refreshing = refreshLoadable.state === "loading";
   const sendingWifi = wifiLoadable.state === "loading";
-  const error =
-    loadableErrorMessage(wifiLoadable) ?? loadableErrorMessage(refreshLoadable);
+  const error = loadableErrorMessage(wifiLoadable);
 
   return (
     <div className="px-6 py-5">
@@ -284,40 +255,20 @@ function WifiStep() {
           </label>
         </div>
 
-        <div className="flex flex-wrap gap-2">
-          <MorandiButton
-            disabled={!canSendWifi || sendingWifi || state.wifiSent}
-            onClick={() => {
-              detach(
-                sendWifi(pageSignal),
-                Reason.DomCallback,
-                "sendBb0WifiCredentials",
-              );
-            }}
-          >
-            {sendingWifi && <IconLoader size={14} className="animate-spin" />}
-            {state.wifiSent ? "Wi-Fi sent" : "Send Wi-Fi"}
-          </MorandiButton>
-          <Button
-            size="sm"
-            variant="outline"
-            disabled={!connected || refreshing || state.wifiSent}
-            onClick={() => {
-              detach(
-                refresh(pageSignal),
-                Reason.DomCallback,
-                "refreshBb0DeviceStatus",
-              );
-            }}
-          >
-            {refreshing ? (
-              <IconLoader size={14} className="animate-spin" />
-            ) : (
-              <IconRefresh size={14} />
-            )}
-            Refresh status
-          </Button>
-        </div>
+        <MorandiButton
+          className="self-start"
+          disabled={!canSendWifi || sendingWifi || state.wifiSent}
+          onClick={() => {
+            detach(
+              sendWifi(pageSignal),
+              Reason.DomCallback,
+              "sendBb0WifiCredentials",
+            );
+          }}
+        >
+          {sendingWifi && <IconLoader size={14} className="animate-spin" />}
+          {state.wifiSent ? "Wi-Fi sent" : "Send Wi-Fi"}
+        </MorandiButton>
 
         {state.wifiSent && (
           <p className="text-xs leading-5 text-muted-foreground">
@@ -471,10 +422,12 @@ export function Bb0DevicePage() {
 
           {/* Troubleshoot footer */}
           <p className="px-1 text-xs text-muted-foreground">
-            Having trouble? Hold <code className="text-foreground">BtnA</code>,
-            press <code className="text-foreground">BtnB</code>, then release{" "}
-            <code className="text-foreground">BtnA</code> to restart setup mode,
-            and{" "}
+            Need to reset BB0? Press and hold the small button on the left side
+            of the device — just to the right of the{" "}
+            <code className="text-foreground">Stick S3</code> sticker — for
+            about two seconds. When the screen shows{" "}
+            <code className="text-foreground">reset</code>, release the button
+            and BB0 will reboot itself. You can also{" "}
             <button
               type="button"
               className="underline underline-offset-2 hover:text-foreground"


### PR DESCRIPTION
## Summary
- Drop the "Technical details" disclosure (BLE filter + service UUID) from the BB0 device page connect step.
- Drop the Wi-Fi step's "Refresh status" button along with the now-unused `refreshBb0DeviceStatus$` command and `"reading"` operation status.
- Replace the BtnA/BtnB troubleshoot footer with hardware reset instructions: hold the small button on the left side of BB0 (right of the "Stick S3" sticker) for ~2s, release when the screen shows `reset`, and the device reboots itself. "Reset this page" link is retained.

## Test plan
- [x] `pnpm -F @vm0/app exec tsc --noEmit`
- [x] `pnpm -F @vm0/app exec eslint src/views/device-bb0/bb0-device-page.tsx src/signals/device-bb0-page/bb0-device-onboarding.ts`
- [x] `pnpm -F @vm0/app exec vitest run src/views/device-bb0` (2 passed)
- [x] Pre-commit lefthook (prettier, knip, full check-types, commitlint) — green
- [ ] Manual: load `/device/bb0` in a Web Bluetooth–capable browser and verify the three sections render cleanly without the removed elements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)