### PR TITLE
fix(web): hard-disable canViewDocs to stop SSR crash on /[locale]/*

### DIFF
--- a/turbo/apps/web/app/lib/docs/access.ts
+++ b/turbo/apps/web/app/lib/docs/access.ts
@@ -1,30 +1,17 @@
-import { auth } from "@clerk/nextjs/server";
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
-import { isFeatureEnabled } from "@vm0/core/feature-switch";
-import { env } from "../../../src/env";
-import { loadFeatureSwitchOverrides } from "../../../src/lib/zero/user/feature-switches-service";
-
+// Temporarily hard-disabled: the previous implementation reached
+// `globalThis.services.db` via `getUserFeatureSwitches`, but the marketing
+// SSR entry points (app/[locale]/layout.tsx → SiteHeader) never call
+// `initServices()`. For signed-in users with an active org this crashed every
+// `/{locale}/*` page render with `TypeError: Cannot read properties of
+// undefined (reading 'db')`. Returning false unconditionally hides the docs
+// nav and 404s `/docs` routes until the SSR services bootstrap is fixed.
 export async function canViewDocsForUser(
-  userId: string | null | undefined,
-  orgId: string | null | undefined,
+  _userId: string | null | undefined,
+  _orgId: string | null | undefined,
 ): Promise<boolean> {
-  if (!userId || !env().NEXT_PUBLIC_STRAPI_URL) {
-    return false;
-  }
-
-  const overrides = await loadFeatureSwitchOverrides(
-    orgId ?? undefined,
-    userId,
-  );
-
-  return isFeatureEnabled(FeatureSwitchKey.DocsSite, {
-    userId,
-    orgId: orgId ?? undefined,
-    overrides,
-  });
+  return false;
 }
 
 export async function canViewDocs(): Promise<boolean> {
-  const { userId, orgId } = await auth();
-  return canViewDocsForUser(userId, orgId);
+  return false;
 }


### PR DESCRIPTION
## Problem

Sentry [WEB-42](https://vm0.sentry.io/issues/7475999025/) — `TypeError: Cannot read properties of undefined (reading 'db')` on `GET /en` (and every other `/{locale}/*` marketing page). 23 events since 11:40 UTC today, all from release `1e962d2`. The Next.js error boundary surfaces this to users as a "Something went wrong / Our team has been notified" overlay.

## Root cause

PR #12330 added `canViewDocsForUser(userId, orgId)` to `app/components/SiteHeader.tsx`, which renders SSR from `app/[locale]/layout.tsx`. The call graph reaches the DB:

```
SiteHeader (SSR)
  └─ canViewDocsForUser(userId, orgId)
       └─ loadFeatureSwitchOverrides(orgId, userId)
            └─ getUserFeatureSwitches(orgId, userId)
                 └─ const db = globalThis.services.db   // ← undefined
```

But `globalThis.services` is only populated after `initServices()` is called, and **no SSR entry point in `apps/web` calls it** — `instrumentation.ts` only initializes in dev, and the prod pattern is per-handler `initServices()` inside API route handlers. The marketing layout / page Server Components don't have that call.

The crash is intermittent because `canViewDocsForUser` early-returns for unauthenticated users; only signed-in users with an active org context hit the DB call. Every `/{locale}/*` page (home, pricing, docs, blog, security, models, rankings, use-cases, and all non-English locales) is affected because they share `[locale]/layout.tsx`.

## Fix

Hard-disable `canViewDocsForUser` and `canViewDocs` — both unconditionally return `false`. Net effect:
- `SiteHeader` hides the docs nav for everyone (same as before #12330)
- `/[locale]/docs` and `/[locale]/docs/[...slug]` 404 via their existing `if (!(await canViewDocs())) notFound()` guards
- No DB access on the SSR path, so the marketing site stops crashing for signed-in users

This is intentionally minimal — it gates the docs site until the SSR services bootstrap is restored properly (e.g. calling `initServices()` from `app/[locale]/layout.tsx` or moving the feature-switch check out of SSR).

## Test plan

- [ ] CI green (lint, types, tests, knip)
- [ ] After merge & deploy: load https://www.vm0.ai/en while signed in with an active org — should render the homepage, no error overlay
- [ ] Sentry WEB-42 stops receiving new events tied to release > 1e962d2
- [ ] https://www.vm0.ai/en/docs returns 404 (expected — docs nav is intentionally disabled)