### PR TITLE
feat: force a fresh CLI session when user switches models mid-thread

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -1545,6 +1545,19 @@ function createSendMessage(deps: SendMessageDeps) {
         { signal },
       );
 
+      // Model-first lets the user swap models mid-thread (the picker stays
+      // editable). When the new selection differs from the thread's pinned
+      // model, signal the server to start a fresh CLI session — resuming the
+      // existing sessionId across providers/models triggers
+      // PROVIDER_INCOMPATIBLE (or "Invalid signature in thinking block") on
+      // the runner side. The server then injects prior chat messages into
+      // the system prompt so the agent still has conversation context.
+      const threadPinSelectedModel = thread?.selectedModel ?? null;
+      const forceNewSession =
+        threadPinSelectedModel !== null &&
+        effectiveSelectedModel !== undefined &&
+        threadPinSelectedModel !== effectiveSelectedModel;
+
       const client = get(zeroClient$)(chatMessagesContract);
       const [, sendResult] = await Promise.all([
         set(flushDraftClear$, signal),
@@ -1559,6 +1572,7 @@ function createSendMessage(deps: SendMessageDeps) {
               modelSelection,
               attachFiles: result.attachFiles,
               ...(isGoal ? { goal: true } : {}),
+              ...(forceNewSession ? { forceNewSession: true } : {}),
             },
             fetchOptions: { signal },
           }),

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-thread-page-model-picker-readonly.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-thread-page-model-picker-readonly.test.tsx
@@ -159,9 +159,11 @@ describe("chat thread page — model picker read-only", () => {
     });
   });
 
-  // CHAT-LOCK-003: model-first selection is a user preference on new threads,
-  // but an already-started thread still keeps its own model locked.
-  it("renders model-first picker as plain text when thread has a user message (CHAT-LOCK-003)", async () => {
+  // CHAT-LOCK-003: in model-first mode the picker stays interactive even after
+  // a user turn — the user can switch models mid-thread; the composer sets
+  // `forceNewSession` on send so the server starts a fresh CLI session and
+  // injects the prior messages into the system prompt.
+  it("keeps model-first picker interactive when thread has a user message (CHAT-LOCK-003)", async () => {
     setMockFeatureSwitches({
       [FeatureSwitchKey.ModelFirstModelProvider]: true,
     });
@@ -175,11 +177,9 @@ describe("chat thread page — model picker read-only", () => {
 
     detachedSetupPage({ context, path: `/chats/${THREAD_ID}` });
 
-    const label = await waitFor(() => {
-      return screen.getByLabelText("GLM-5.1");
+    await waitFor(() => {
+      return screen.getByRole("combobox", { name: /GLM-5\.1/i });
     });
-    expect(label.tagName).toBe("SPAN");
-    expect(screen.queryByRole("combobox", { name: "GLM-5.1" })).toBeNull();
   });
 
   // CHAT-LOCK-004: empty thread keeps the picker interactive.

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -2063,8 +2063,11 @@ function useChatComposerModel(
     modelSelection,
     setModelSelection: handleModelSelectionChange,
     sessionProviderType: threadData?.latestSessionProviderType ?? null,
-    // Lock after the first user turn; assistant-only preambles remain editable.
-    disabled: hasUserMessages,
+    // Classic mode keeps the legacy "one model per thread" lock after the
+    // first user turn. Model-first stays editable so the user can swap models
+    // mid-thread; the composer signals the server to start a fresh CLI
+    // session on send (sessionId continuation would fail across providers).
+    disabled: hasUserMessages && !modelFirstEnabled,
     agentDefault: agentModelDefault,
   });
   const modelPickerLoading =

--- a/turbo/apps/web/app/api/zero/chat/messages/__tests__/route.force-new-session.test.ts
+++ b/turbo/apps/web/app/api/zero/chat/messages/__tests__/route.force-new-session.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { POST } from "../route";
+import {
+  createTestRequest,
+  createTestCompose,
+  enableModelFirstModelProviderForUser,
+  insertOrgDefaultModelProvider,
+  insertOrgModelPolicy,
+  insertUserModelPreference,
+  setOrgCredits,
+  setTestRunStatus,
+  getTestRun,
+  findTestZeroRun,
+  completeTestRun,
+} from "../../../../../../src/__tests__/api-test-helpers";
+import { getTestZeroAgentId } from "../../../../../../src/__tests__/db-test-assertions/agents";
+import { getTestChatThreadModelOverride } from "../../../../../../src/__tests__/db-test-assertions/org";
+import {
+  testContext,
+  uniqueId,
+  type UserContext,
+} from "../../../../../../src/__tests__/test-helpers";
+import { reloadEnv } from "../../../../../../src/env";
+
+const URL = "http://localhost:3000/api/zero/chat/messages";
+const MODEL_FIRST_SENTINEL = "00000000-0000-4000-8000-000000000000";
+
+const context = testContext();
+
+async function postChat(body: Record<string, unknown>) {
+  return POST(
+    createTestRequest(URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+  );
+}
+
+describe("POST /api/zero/chat/messages — forceNewSession (model-first)", () => {
+  let user: UserContext;
+  let agentId: string;
+
+  beforeEach(async () => {
+    context.setupMocks();
+    user = await context.setupUser();
+    const compose = await createTestCompose(uniqueId("chat-fns"));
+    agentId = await getTestZeroAgentId(user.orgId, compose.name);
+    vi.stubEnv("RUNNER_DEFAULT_GROUP", "vm0/production");
+    reloadEnv();
+    await insertOrgDefaultModelProvider(user.orgId, "anthropic-api-key");
+    await enableModelFirstModelProviderForUser(user.orgId, user.userId);
+    await setOrgCredits(user.orgId, 10_000);
+    await insertOrgModelPolicy({
+      orgId: user.orgId,
+      model: "claude-opus-4-7",
+      isDefault: true,
+    });
+    await insertOrgModelPolicy({
+      orgId: user.orgId,
+      model: "claude-sonnet-4-6",
+    });
+  });
+
+  it("rewrites the thread pin and starts a fresh session when forceNewSession is set", async () => {
+    await insertUserModelPreference({
+      orgId: user.orgId,
+      userId: user.userId,
+      model: "claude-opus-4-7",
+    });
+
+    const first = await postChat({ agentId, prompt: "first on opus" });
+    expect(first.status).toBe(201);
+    const { threadId, runId } = await first.json();
+    await context.mocks.flushAfter();
+    await completeTestRun(user.userId, runId);
+
+    const initialPin = await getTestChatThreadModelOverride(threadId);
+    expect(initialPin.selectedModel).toBe("claude-opus-4-7");
+
+    const second = await postChat({
+      agentId,
+      prompt: "switch to sonnet",
+      threadId,
+      modelSelection: {
+        modelProviderId: MODEL_FIRST_SENTINEL,
+        selectedModel: "claude-sonnet-4-6",
+      },
+      forceNewSession: true,
+    });
+    expect(second.status).toBe(201);
+    const { runId: secondRunId } = await second.json();
+    await context.mocks.flushAfter();
+
+    const secondPin = await getTestChatThreadModelOverride(threadId);
+    expect(secondPin.selectedModel).toBe("claude-sonnet-4-6");
+
+    const secondRun = await findTestZeroRun(secondRunId);
+    expect(secondRun?.selectedModel).toBe("claude-sonnet-4-6");
+  });
+
+  it("injects prior chat messages into appendSystemPrompt when forcing a new session", async () => {
+    await insertUserModelPreference({
+      orgId: user.orgId,
+      userId: user.userId,
+      model: "claude-opus-4-7",
+    });
+
+    const first = await postChat({ agentId, prompt: "hello on opus" });
+    expect(first.status).toBe(201);
+    const { threadId, runId } = await first.json();
+    await context.mocks.flushAfter();
+    await completeTestRun(user.userId, runId);
+
+    const second = await postChat({
+      agentId,
+      prompt: "now on sonnet",
+      threadId,
+      modelSelection: {
+        modelProviderId: MODEL_FIRST_SENTINEL,
+        selectedModel: "claude-sonnet-4-6",
+      },
+      forceNewSession: true,
+    });
+    expect(second.status).toBe(201);
+    const { runId: secondRunId } = await second.json();
+    await context.mocks.flushAfter();
+
+    const run = await getTestRun(secondRunId);
+    const prompt = run.appendSystemPrompt ?? "";
+    expect(prompt).toContain("# Prior Chat Thread Context");
+    expect(prompt).toContain("User: hello on opus");
+    expect(prompt).toContain("RELATIVE_INDEX: 0");
+  });
+
+  it("suppresses the incomplete-rounds context block when forcing a new session", async () => {
+    await insertUserModelPreference({
+      orgId: user.orgId,
+      userId: user.userId,
+      model: "claude-opus-4-7",
+    });
+
+    const first = await postChat({ agentId, prompt: "round A" });
+    expect(first.status).toBe(201);
+    const { threadId, runId } = await first.json();
+    await context.mocks.flushAfter();
+    await setTestRunStatus(runId, "cancelled");
+
+    const second = await postChat({
+      agentId,
+      prompt: "switch to sonnet after cancel",
+      threadId,
+      modelSelection: {
+        modelProviderId: MODEL_FIRST_SENTINEL,
+        selectedModel: "claude-sonnet-4-6",
+      },
+      forceNewSession: true,
+    });
+    expect(second.status).toBe(201);
+    const { runId: secondRunId } = await second.json();
+    await context.mocks.flushAfter();
+
+    const run = await getTestRun(secondRunId);
+    const prompt = run.appendSystemPrompt ?? "";
+    expect(prompt).not.toContain("# Incomplete Rounds Context");
+    // The cancelled round's user text still surfaces via the prior-messages
+    // block — replaying it as an incomplete round under a different model
+    // would be misleading, but the agent still needs to see what was said.
+    expect(prompt).toContain("# Prior Chat Thread Context");
+    expect(prompt).toContain("User: round A");
+  });
+
+  it("still rejects a model change on an existing thread without forceNewSession", async () => {
+    await insertUserModelPreference({
+      orgId: user.orgId,
+      userId: user.userId,
+      model: "claude-opus-4-7",
+    });
+
+    const first = await postChat({ agentId, prompt: "first on opus" });
+    expect(first.status).toBe(201);
+    const { threadId, runId } = await first.json();
+    await context.mocks.flushAfter();
+    await completeTestRun(user.userId, runId);
+
+    const second = await postChat({
+      agentId,
+      prompt: "switch to sonnet without flag",
+      threadId,
+      modelSelection: {
+        modelProviderId: MODEL_FIRST_SENTINEL,
+        selectedModel: "claude-sonnet-4-6",
+      },
+    });
+    expect(second.status).toBe(400);
+    const data = await second.json();
+    expect(data.error.code).toBe("BAD_REQUEST");
+  });
+});

--- a/turbo/apps/web/app/api/zero/chat/messages/route.ts
+++ b/turbo/apps/web/app/api/zero/chat/messages/route.ts
@@ -27,8 +27,10 @@ import {
   buildWebAttachFilesPrompt,
   buildWebChatGoalPrompt,
   buildWebChatIncompleteContext,
+  buildWebChatPriorMessagesContext,
   type WebChatGoalContext,
   type WebChatIncompleteRound,
+  type WebChatPriorMessage,
 } from "../../../../../src/lib/zero/integration-prompt";
 import { isFeatureEnabled } from "@vm0/core/feature-switch";
 import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
@@ -127,17 +129,72 @@ const GOAL_DEFAULT_BUDGET = 10;
 
 function buildAppendSystemPrompt(
   incompleteContext: string,
+  priorContext: string,
   goalContext: WebChatGoalContext | null,
 ): string {
   return [
     buildWebChatPrompt(),
     goalContext ? buildWebChatGoalPrompt(goalContext) : "",
+    priorContext,
     incompleteContext,
   ]
     .filter((part) => {
       return typeof part === "string" && part.length > 0;
     })
     .join("\n\n");
+}
+
+/**
+ * Number of prior chat messages to embed in the system prompt when
+ * `forceNewSession` is set. Matches `PREVIOUS_CONTEXT_MESSAGES` (used by
+ * the title generator) — large enough to anchor the agent on the most
+ * recent exchange, small enough to stay well under any model context cap.
+ */
+const PRIOR_HISTORY_MESSAGE_LIMIT = 10;
+
+async function loadPriorMessagesForNewSession(
+  threadId: string,
+): Promise<WebChatPriorMessage[]> {
+  const rows = await getLatestMessagesByThreadId(
+    threadId,
+    PRIOR_HISTORY_MESSAGE_LIMIT,
+  );
+  return rows.map((row) => {
+    return {
+      role: row.role,
+      content: row.content,
+      attachFiles: row.attachFiles,
+    };
+  });
+}
+
+/**
+ * When the user switches models mid-thread (`forceNewSession`), the existing
+ * CLI session cannot be resumed under a different provider/model. Drop the
+ * thread's model pin so `resolveRunModelOverride` writes the new selection
+ * freshly, and build a prior-messages block to keep the agent's conversation
+ * context across the model switch. Returns "" for new threads / non-forced
+ * sends so the caller can `filter(Boolean).join()`.
+ */
+async function prepareForceNewSessionContext(
+  threadId: string,
+  forceNewSession: boolean,
+  isNewThread: boolean,
+): Promise<string> {
+  if (!forceNewSession || isNewThread) return "";
+  await globalThis.services.db
+    .update(chatThreads)
+    .set({
+      modelProviderId: null,
+      modelProviderType: null,
+      modelProviderCredentialScope: null,
+      selectedModel: null,
+      updatedAt: new Date(),
+    })
+    .where(eq(chatThreads.id, threadId));
+  return buildWebChatPriorMessagesContext(
+    await loadPriorMessagesForNewSession(threadId),
+  );
 }
 
 interface GoalOriginRow {
@@ -690,10 +747,17 @@ async function resolveRunModelOverride(
     | { modelProviderId: string; selectedModel: string }
     | null
     | undefined,
+  forceNewSession: boolean,
 ): Promise<ResolvedThreadModelPin> {
   if (modelSelection !== undefined && modelSelection !== null) {
     if (modelFirstEnabled) {
-      const storedPin = await getExistingModelFirstThreadPin(threadId);
+      // When the user explicitly switched models mid-thread, ignore the
+      // stored-pin / first-run-pin fallbacks — both would re-route the new
+      // run to the previous model. Resolve fresh from the incoming
+      // `modelSelection` exactly as we do for a brand-new thread.
+      const storedPin = forceNewSession
+        ? null
+        : await getExistingModelFirstThreadPin(threadId);
       if (storedPin) {
         const pin = await persistModelFirstThreadPinIfUnset(
           threadId,
@@ -732,7 +796,12 @@ async function resolveRunModelOverride(
     });
   } else {
     if (modelFirstEnabled) {
-      const storedPin = await getExistingModelFirstThreadPin(threadId);
+      // forceNewSession with no explicit modelSelection still means "drop the
+      // prior session" — pick up the user's current default route instead of
+      // re-applying the thread's stale pin (or its first-run model).
+      const storedPin = forceNewSession
+        ? null
+        : await getExistingModelFirstThreadPin(threadId);
       if (storedPin) {
         const resolvedStoredPin = await resolveStoredModelFirstPin({
           orgId,
@@ -799,7 +868,14 @@ async function rejectIfThreadModelLocked(
   threadId: string,
   incoming: { modelProviderId: string; selectedModel: string } | null,
   modelFirstEnabled: boolean,
+  forceNewSession: boolean,
 ): Promise<boolean> {
+  // The composer surfaces a different selectedModel only when the user
+  // explicitly switched the picker mid-thread (model-first mode). Honor
+  // that intent — the lock is for accidental client divergence, not for
+  // user-driven model swaps.
+  if (forceNewSession) return false;
+
   if (modelFirstEnabled) {
     const existingPin = await getExistingModelFirstThreadPin(threadId);
     if (!existingPin?.selectedModel) {
@@ -905,6 +981,7 @@ async function validateThreadModelSelectionLock(params: {
   threadId: string | undefined;
   modelSelection: IncomingModelSelection;
   modelFirstEnabled: boolean;
+  forceNewSession: boolean;
   emit: (op: string, ms: number) => void;
 }) {
   const { threadId, modelSelection } = params;
@@ -917,6 +994,7 @@ async function validateThreadModelSelectionLock(params: {
       threadId,
       modelSelection,
       params.modelFirstEnabled,
+      params.forceNewSession,
     );
   });
   params.emit(CHAT_REQUEST_OPS.model_selection_lock_check, lockT.ms);
@@ -929,6 +1007,7 @@ async function validateSendModelSelection(params: {
   threadId: string | undefined;
   modelSelection: IncomingModelSelection;
   modelFirstEnabled: boolean;
+  forceNewSession: boolean;
   emit: (op: string, ms: number) => void;
 }) {
   const ownershipError = await validateLegacyModelSelectionOwnership({
@@ -943,6 +1022,7 @@ async function validateSendModelSelection(params: {
     threadId: params.threadId,
     modelSelection: params.modelSelection,
     modelFirstEnabled: params.modelFirstEnabled,
+    forceNewSession: params.forceNewSession,
     emit: params.emit,
   });
 }
@@ -962,6 +1042,7 @@ async function persistExplicitModelFirstSelection(params: {
   threadId: string;
   modelFirstEnabled: boolean;
   modelSelection: IncomingModelSelection;
+  forceNewSession: boolean;
 }): Promise<boolean> {
   if (
     !hasExplicitModelFirstSelection(
@@ -971,7 +1052,12 @@ async function persistExplicitModelFirstSelection(params: {
   ) {
     return false;
   }
-  const existingPin = await getExistingModelFirstThreadPin(params.threadId);
+  // When the user explicitly switched models mid-thread, treat their pick as
+  // the new preference — the stored / first-run pin is the old model and
+  // would otherwise short-circuit this update.
+  const existingPin = params.forceNewSession
+    ? null
+    : await getExistingModelFirstThreadPin(params.threadId);
   if (existingPin) {
     return false;
   }
@@ -1009,6 +1095,7 @@ async function resolveThread(
   existingThreadId: string | undefined,
   clientThreadId: string | undefined,
   agentPin: ThreadModelPin,
+  forceNewSession: boolean,
   dims?: ChatSpanDimensions,
 ): Promise<ResolvedThread> {
   const emit = (op: string, ms: number): void => {
@@ -1037,11 +1124,16 @@ async function resolveThread(
   // them in parallel caps wall time at the slowest arm. The prior 4th arm
   // (`getLatestMessagesByThreadId`) was a ~275ms P50 read used only by the
   // fire-and-forget title generator — now lifted off this critical path.
+  //
+  // When `forceNewSession` is set, the prior session is intentionally
+  // discarded so the latest-session-id lookup is skipped — the parallel
+  // shape is preserved with a no-op arm to keep span emission stable.
   const [threadT, sessionIdT, incompleteT] = await Promise.all([
     timed(async () => {
       return getChatThread(existingThreadId, userId);
     }),
     timed(async () => {
+      if (forceNewSession) return undefined;
       return getLatestSessionIdForThread(existingThreadId);
     }),
     timed(async () => {
@@ -1060,9 +1152,15 @@ async function resolveThread(
     dims.thread_is_new = false;
   }
 
-  const incompleteContext = buildWebChatIncompleteContext(
-    groupIncompleteRoundsByRunId(incompleteT.result),
-  );
+  // When forcing a new session, the user is mid-thread and the incomplete
+  // context belongs to the previous model's session — replaying it under a
+  // different model is meaningless and can confuse the agent. The prior
+  // messages context built downstream covers the conversation gap instead.
+  const incompleteContext = forceNewSession
+    ? ""
+    : buildWebChatIncompleteContext(
+        groupIncompleteRoundsByRunId(incompleteT.result),
+      );
 
   return {
     threadId: thread.id,
@@ -1309,11 +1407,19 @@ const router = tsr.router(chatMessagesContract, {
       authCtx.userId,
     );
 
+    // forceNewSession is set by the web composer when the user picked a
+    // different model than the thread's persisted pin. The thread-pin lock,
+    // session-id reuse, and incomplete-rounds context are all bypassed for
+    // this run, and prior chat messages are injected into the system prompt
+    // so the agent still has conversation context across the model switch.
+    const forceNewSession = body.forceNewSession === true;
+
     const modelSelectionError = await validateSendModelSelection({
       orgId: callerOrg.orgId,
       threadId: body.threadId,
       modelSelection: body.modelSelection,
       modelFirstEnabled,
+      forceNewSession,
       emit,
     });
     if (modelSelectionError) return modelSelectionError;
@@ -1345,8 +1451,15 @@ const router = tsr.router(chatMessagesContract, {
           body.threadId,
           body.clientThreadId,
           eagerPin,
+          forceNewSession,
           dims,
         );
+
+      const priorContext = await prepareForceNewSessionContext(
+        threadId,
+        forceNewSession,
+        isNewThread,
+      );
 
       const persistedExplicitModelFirstSelection =
         await persistExplicitModelFirstSelection({
@@ -1355,6 +1468,7 @@ const router = tsr.router(chatMessagesContract, {
           threadId,
           modelFirstEnabled,
           modelSelection: body.modelSelection,
+          forceNewSession,
         });
 
       if (await activeRunExistsForThread(threadId)) {
@@ -1392,6 +1506,7 @@ const router = tsr.router(chatMessagesContract, {
           },
           modelFirstEnabled,
           body.modelSelection,
+          forceNewSession,
         );
       });
       emit(CHAT_REQUEST_OPS.resolve_model_override, overrideT.ms);
@@ -1486,6 +1601,7 @@ const router = tsr.router(chatMessagesContract, {
         debugNoMockCodex: body.debugNoMockCodex,
         appendSystemPrompt: buildAppendSystemPrompt(
           incompleteContext,
+          priorContext,
           goalContext,
         ),
         callbacks: [chatCallback],

--- a/turbo/apps/web/src/lib/zero/integration-prompt.ts
+++ b/turbo/apps/web/src/lib/zero/integration-prompt.ts
@@ -267,6 +267,78 @@ export function buildWebAttachFilesPrompt(
   return blocks.join("\n");
 }
 
+export interface WebChatPriorMessage {
+  role: "user" | "assistant";
+  content: string;
+  attachFiles: string[] | null;
+}
+
+const WEB_CHAT_PRIOR_MESSAGE_CHAR_CAP = 4000;
+const WEB_CHAT_PRIOR_PREAMBLE = [
+  "The messages below are completed rounds earlier in this chat thread. The",
+  "CLI session history has been reset for this run (the user switched models",
+  "mid-thread, so the previous session is not safe to resume), so the prior",
+  "conversation is shown here verbatim. RELATIVE_INDEX 0 is the most recent.",
+  "Treat them as part of the conversation you are continuing.",
+].join("\n");
+
+function truncateForPriorContext(value: string): string {
+  if (value.length <= WEB_CHAT_PRIOR_MESSAGE_CHAR_CAP) return value;
+  return `${value.slice(0, WEB_CHAT_PRIOR_MESSAGE_CHAR_CAP)}…[truncated]`;
+}
+
+function formatPriorAttachFiles(ids: string[] | null | undefined): string {
+  if (!ids || ids.length === 0) return "";
+  return ids
+    .map((id) => {
+      return `[Web file]\n   [ID] ${id}`;
+    })
+    .join("\n");
+}
+
+/**
+ * Build a transcript block describing successfully completed rounds earlier
+ * in the thread. Used when the web chat send forces a new CLI session (the
+ * user switched models mid-thread), so the agent still sees the prior
+ * conversation that would otherwise have lived only in the discarded CLI
+ * session history.
+ *
+ * Empty input returns `""` so the caller can `filter(Boolean).join()`.
+ */
+export function buildWebChatPriorMessagesContext(
+  msgs: WebChatPriorMessage[],
+): string {
+  if (msgs.length === 0) return "";
+
+  const total = msgs.length;
+  const blocks = msgs.map((m, idx) => {
+    const relativeIndex = idx - total + 1;
+    const attach = formatPriorAttachFiles(m.attachFiles);
+    const body = truncateForPriorContext(m.content);
+    const roleLabel = m.role === "user" ? "User" : "Assistant";
+    const lines = [
+      "---",
+      "",
+      `- RELATIVE_INDEX: ${relativeIndex}`,
+      `- ROLE: ${m.role}`,
+      "",
+      `${roleLabel}: ${body || "[empty message]"}`,
+    ];
+    if (attach) lines.push(attach);
+    return lines.join("\n");
+  });
+
+  return [
+    "# Prior Chat Thread Context",
+    "",
+    WEB_CHAT_PRIOR_PREAMBLE,
+    "",
+    blocks.join("\n\n"),
+    "",
+    "---",
+  ].join("\n");
+}
+
 export interface WebChatIncompleteRoundMessage {
   role: "user" | "assistant";
   content: string | null;

--- a/turbo/packages/api-contracts/src/contracts/chat-threads.ts
+++ b/turbo/packages/api-contracts/src/contracts/chat-threads.ts
@@ -460,6 +460,17 @@ export const chatMessagesContract = c.router({
          * pick it. Gated by the Goal feature switch.
          */
         goal: z.boolean().optional(),
+        /**
+         * Force a new CLI session for this run instead of resuming the
+         * thread's latest session. Set by the web composer when the user
+         * picks a different `selectedModel` than the one pinned on the
+         * thread — the persisted CLI session history was produced by the
+         * previous model and is not safe to replay through a different one.
+         * Server skips `getLatestSessionIdForThread`, allows the thread pin
+         * to be rewritten, and injects prior chat messages into the system
+         * prompt so the agent still has the conversation context.
+         */
+        forceNewSession: z.boolean().optional(),
         // Test-only escape hatch: when the host runner has USE_MOCK_CODEX
         // set (CI default), allow the request to bypass the mock and execute
         // the real codex CLI. Mirrors `debugNoMockClaude` / `debugNoMockCodex`
@@ -485,6 +496,7 @@ export const chatMessagesContract = c.router({
         debugNoMockCodex: z.undefined().optional(),
         interruptsRunId: z.undefined().optional(),
         goal: z.undefined().optional(),
+        forceNewSession: z.undefined().optional(),
       }),
       z.object({
         agentId: z.string().min(1),
@@ -501,6 +513,7 @@ export const chatMessagesContract = c.router({
         debugNoMockCodex: z.undefined().optional(),
         revokesMessageId: z.undefined().optional(),
         goal: z.undefined().optional(),
+        forceNewSession: z.undefined().optional(),
       }),
     ]),
     responses: {


### PR DESCRIPTION
## Summary
- Replaces the hard model-pin lock with a fail-safe handshake: when the composer's `selectedModel` differs from the thread's pinned model, the request carries `forceNewSession: true`, the server skips the latest-session lookup, clears the thread pin, resolves the new model freshly, and injects prior chat messages into `appendSystemPrompt` (Slack-style block) so the agent still has conversation context.
- Picker is now editable mid-thread **only in model-first mode**; classic mode keeps the legacy one-model-per-thread lock.
- Eliminates the `PROVIDER_INCOMPATIBLE` / \"Invalid signature in thinking block\" red error that currently surfaces when an existing chat thread tries to resume a CLI session under a different provider family or model.

## Touched files
- `packages/api-contracts/.../chat-threads.ts` — new optional `forceNewSession: boolean` on `chatMessagesContract.send`.
- `apps/platform/.../zero-chat-thread-page.tsx` — picker is read-only only when classic mode + thread has user messages; model-first stays editable.
- `apps/platform/.../create-chat-thread.ts` — composer compares the resolved `selectedModel` against `threadData.selectedModel` and sets `forceNewSession` on send.
- `apps/web/.../integration-prompt.ts` — new `buildWebChatPriorMessagesContext` (4000-char truncation cap, `[Web file]` blocks).
- `apps/web/.../chat/messages/route.ts`:
  - `validateThreadModelSelectionLock` / `rejectIfThreadModelLocked` short-circuit when `forceNewSession === true`.
  - `resolveThread` skips `getLatestSessionIdForThread` and suppresses incomplete-rounds context when forcing.
  - New `prepareForceNewSessionContext` helper: clears the thread's model pin and builds the prior-messages context (capped at 10 most recent).
  - `resolveRunModelOverride` + `persistExplicitModelFirstSelection` bypass stored-pin / first-run-pin fallbacks when forcing, so the new selection actually takes effect and the user preference updates.

## Test plan
- [x] `pnpm -F web exec tsc --noEmit` — clean
- [x] `pnpm -F @vm0/app exec tsc --noEmit` — clean
- [x] `pnpm -F api exec tsc --noEmit` — clean (with raised heap)
- [x] `pnpm -F @vm0/api-contracts exec tsc --noEmit` — clean
- [x] `pnpm -F web exec eslint app/api/zero/chat/messages/ src/lib/zero/integration-prompt.ts` — clean
- [x] `pnpm -F web exec vitest run app/api/zero/chat/messages/__tests__/` — 4 files, 67 tests pass (new file \`route.force-new-session.test.ts\` adds 4 cases: pin rewrite, prior-history injection, incomplete-context suppression, regression for no-flag case)
- [x] \`pnpm -F web exec vitest run src/lib/zero/__tests__/integration-prompt.test.ts\` — 16/16
- [x] \`pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-thread-page-model-picker-readonly.test.tsx\` — 4/4 (updated CHAT-LOCK-003 to reflect new model-first behavior)
- [x] \`pnpm -F @vm0/app exec vitest run src/signals/chat-page/__tests__/\` — 5 files, 14/14
- [x] \`pnpm format\` — no diff
- [x] \`pnpm knip\` — no new findings related to these changes

## Out of scope
- The drift root cause (an unchanged \`selectedModel\` resolving to a different provider via model-first policy / OAuth re-route) is not addressed here — the user-driven flag covers the visible UX path, and we can decide separately whether to tighten \`resolveModelFirstRouteDescriptor\` to make pinned threads sticky to their original provider.

🤖 Generated with [Claude Code](https://claude.com/claude-code)