### PR TITLE
chore(security): enable pnpm minimumReleaseAge to defend against npm supply-chain attacks

### DIFF
--- a/turbo/.npmrc
+++ b/turbo/.npmrc
@@ -8,4 +8,4 @@ resolve-peers-from-workspace-root=true
 # our own releases install immediately. For emergency upgrades, override
 # per-command with `pnpm install --config.minimumReleaseAge=0`.
 minimumReleaseAge=10080
-minimumReleaseAgeExclude=@vm0/*,@cc0/*
+minimumReleaseAgeExclude=@vm0/*

--- a/turbo/.npmrc
+++ b/turbo/.npmrc
@@ -2,3 +2,10 @@
 # unnecessary optional peers from @clerk/clerk-js (react-native, @solana, viem, etc.)
 auto-install-peers=false
 resolve-peers-from-workspace-root=true
+
+# Defend against npm supply-chain attacks: require packages to be at least
+# 7 days old before installing. Internal @vm0 / @cc0 scopes are excluded so
+# our own releases install immediately. For emergency upgrades, override
+# per-command with `pnpm install --config.minimumReleaseAge=0`.
+minimumReleaseAge=10080
+minimumReleaseAgeExclude=@vm0/*,@cc0/*

--- a/turbo/package.json
+++ b/turbo/package.json
@@ -103,7 +103,7 @@
       "@tiptap/suggestion": "3.21.0"
     }
   },
-  "packageManager": "pnpm@10.15.0",
+  "packageManager": "pnpm@10.33.4",
   "engines": {
     "node": ">=20"
   }


### PR DESCRIPTION
## Summary

Adds a defense against npm supply-chain attacks (typosquats, hijacked maintainer accounts, malicious post-install scripts) by requiring every external package to be at least 7 days old before pnpm will install it. Internal `@vm0/*` and `@cc0/*` scopes are excluded so our own releases install immediately.

Background — recent context that motivated this:
- TanStack maintainer account compromise (Apr 2026) shipped malicious versions live within hours, and the standard mitigation that emerged on X is pnpm's [`minimumReleaseAge`](https://pnpm.io/settings#minimumreleaseage) (introduced in pnpm 10.16). See [Viking's writeup](https://x.com/vikingmute/status/2054178929548972513).
- We already had a near-miss in vm0-skills PR #71, which was a supply-chain attack attempt.

## Changes

**`turbo/.npmrc`**
- `minimumReleaseAge=10080` — 10 080 minutes = 7 days
- `minimumReleaseAgeExclude=@vm0/*,@cc0/*` — our own scopes are exempt

**`turbo/package.json`**
- Bump `packageManager` from `pnpm@10.15.0` → `pnpm@10.33.4` (latest 10.x patch). `minimumReleaseAge` is a no-op on 10.15.

## Operational notes

- **Renovate / Dependabot**: PRs that auto-bump to a brand-new release will fail `pnpm install` until 7 days have passed. Bots should either delay or rebase later.
- **Emergency upgrades** (e.g. Anthropic SDK same-day release for a new Claude model ID): bypass per-command with `pnpm install --config.minimumReleaseAge=0`. If we want this in CI as a workflow input, that's a follow-up.
- **Vercel deploys**: the first deploy after merge will fetch new package versions; subsequent deploys hit cache normally.
- **Out of scope**: `crates/` (cargo has its own supply-chain story) — separate effort.

## Test plan

- [ ] CI green (turbo install + lint + check-types + tests)
- [ ] Confirm Vercel preview deploy completes
- [ ] Spot-check that a pinned-to-latest dep (anything <7 days old) is either already cached or installs fine, and that installing a brand-new package without the override is rejected as expected