### PR TITLE
feat(platform): condense onboarding into a "try it" flow for use-case deep links

### DIFF
--- a/turbo/apps/platform/src/signals/onboarding-page/onboarding-page-setup.ts
+++ b/turbo/apps/platform/src/signals/onboarding-page/onboarding-page-setup.ts
@@ -10,6 +10,7 @@ import { updatePage$ } from "../react-router.ts";
 import { detachedNavigateTo$, searchParams$ } from "../route.ts";
 import {
   markConnectorsFromUrl$,
+  markUseCaseMode$,
   resetOnboardingStep$,
   toggleZeroConnector$,
   zeroNeedsOnboarding$,
@@ -26,13 +27,22 @@ export const setupOnboardingPage$ = command(
     set(resetOnboardingStep$);
     signal.throwIfAborted();
 
-    // If onboarding is not needed, redirect to home
+    // Detect use-case deep link early — `?prompt=...&connector=...` lets even
+    // already-onboarded users land here intentionally (to try a suggested
+    // task), so we must NOT auto-redirect them home in that case.
+    const earlyParams = get(searchParams$);
+    const hasUseCaseLink =
+      (earlyParams.get("prompt")?.length ?? 0) > 0 &&
+      earlyParams.get("connector") !== null;
+
+    // If onboarding is not needed and there's no use-case deep link, send the
+    // user home — the page has nothing to show.
     const needsOnboarding = await get(zeroNeedsOnboarding$);
     signal.throwIfAborted();
     const needsMemberOnboarding = await get(zeroNeedsMemberOnboarding$);
     signal.throwIfAborted();
 
-    if (!needsOnboarding && !needsMemberOnboarding) {
+    if (!needsOnboarding && !needsMemberOnboarding && !hasUseCaseLink) {
       set(detachedNavigateTo$, "/", { replace: true });
       return;
     }
@@ -74,6 +84,20 @@ export const setupOnboardingPage$ = command(
       if (unique.length > 0) {
         set(markConnectorsFromUrl$);
       }
+    }
+
+    // "Use case" deep link: ?prompt=... + ?connector=... together signal that
+    // the user came in from a specific suggested task. We seed an editable
+    // prompt draft and switch onboarding into condensed mode where step 4
+    // ("Where would you like to work?") is skipped and step 3 grows a
+    // composer + "Try It" CTA that goes straight to the web chat.
+    const promptParam = params.get("prompt");
+    if (
+      promptParam !== null &&
+      promptParam.length > 0 &&
+      connectorParam !== null
+    ) {
+      set(markUseCaseMode$, promptParam);
     }
   },
 );

--- a/turbo/apps/platform/src/signals/zero-page/__tests__/onboarding-use-case-mode.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/onboarding-use-case-mode.test.ts
@@ -1,0 +1,353 @@
+import { describe, it, expect } from "vitest";
+import { server } from "../../../mocks/server.ts";
+import { testContext } from "../../__tests__/test-helpers.ts";
+import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
+import { setupOnboardingPage$ } from "../../onboarding-page/onboarding-page-setup.ts";
+import {
+  onboardingIsUseCase$,
+  onboardingPromptDraft$,
+  setOnboardingPromptDraft$,
+  setZeroStep$,
+  setZeroWorkspaceName$,
+  zeroSelectedConnectors$,
+} from "../zero-onboarding.ts";
+import {
+  onboardingBackendWillAuthorizeConnectors$,
+  onboardingEffectiveStep$,
+  onboardingNextLabel$,
+  onboardingResolvedPrompt$,
+  onboardingShowDialog$,
+  onboardingStepNext$,
+  onboardingVisibleSteps$,
+} from "../zero-onboarding-actions.ts";
+import { pathname, search } from "../../location.ts";
+import { createMockApi } from "../../../mocks/msw-contract.ts";
+import {
+  onboardingStatusContract,
+  onboardingSetupContract,
+} from "@vm0/api-contracts/contracts/onboarding";
+
+const context = testContext();
+const mockApi = createMockApi(context);
+
+function mockAdminOnboarding() {
+  server.use(
+    mockApi(onboardingStatusContract.getStatus, ({ respond }) => {
+      return respond(200, {
+        needsOnboarding: true,
+        isAdmin: true,
+        hasOrg: true,
+        hasDefaultAgent: false,
+        defaultAgentId: null,
+        defaultAgentMetadata: null,
+      });
+    }),
+  );
+}
+
+function mockMemberOnboarding(defaultAgentId: string) {
+  server.use(
+    mockApi(onboardingStatusContract.getStatus, ({ respond }) => {
+      return respond(200, {
+        needsOnboarding: true,
+        isAdmin: false,
+        hasOrg: true,
+        hasDefaultAgent: true,
+        defaultAgentId,
+        defaultAgentMetadata: null,
+      });
+    }),
+  );
+}
+
+describe("onboarding use-case mode (?prompt=...&connector=...)", () => {
+  it("flags use-case mode and seeds the prompt draft from the URL", async () => {
+    mockAdminOnboarding();
+
+    detachedSetupPage({
+      context,
+      path: "/onboarding?prompt=clone+vm0%2C+scan+tech+debt&connector=github",
+      withoutRender: true,
+    });
+
+    await context.store.set(setupOnboardingPage$, context.signal);
+
+    expect(context.store.get(onboardingIsUseCase$)).toBeTruthy();
+    expect(context.store.get(onboardingPromptDraft$)).toBe(
+      "clone vm0, scan tech debt",
+    );
+    expect(context.store.get(zeroSelectedConnectors$)).toContain("github");
+  });
+
+  it("does not enter use-case mode when only ?prompt= is present", async () => {
+    mockAdminOnboarding();
+
+    detachedSetupPage({
+      context,
+      path: "/onboarding?prompt=hello",
+      withoutRender: true,
+    });
+
+    await context.store.set(setupOnboardingPage$, context.signal);
+
+    expect(context.store.get(onboardingIsUseCase$)).toBeFalsy();
+    expect(context.store.get(onboardingPromptDraft$)).toBe("");
+  });
+
+  it("does not enter use-case mode when only ?connector= is present", async () => {
+    mockAdminOnboarding();
+
+    detachedSetupPage({
+      context,
+      path: "/onboarding?connector=github",
+      withoutRender: true,
+    });
+
+    await context.store.set(setupOnboardingPage$, context.signal);
+
+    expect(context.store.get(onboardingIsUseCase$)).toBeFalsy();
+  });
+
+  it("admin visible steps drop step 4 in use-case mode", async () => {
+    mockAdminOnboarding();
+
+    detachedSetupPage({
+      context,
+      path: "/onboarding?prompt=hi&connector=github",
+      withoutRender: true,
+    });
+
+    await context.store.set(setupOnboardingPage$, context.signal);
+
+    const visible = await context.store.get(onboardingVisibleSteps$);
+    expect(visible).toStrictEqual(["1", "3"]);
+  });
+
+  it("member visible steps reduce to just step 3 in use-case mode", async () => {
+    mockMemberOnboarding("a0000000-0000-4000-a000-000000000001");
+
+    detachedSetupPage({
+      context,
+      path: "/onboarding?prompt=hi&connector=github",
+      withoutRender: true,
+    });
+
+    await context.store.set(setupOnboardingPage$, context.signal);
+
+    const visible = await context.store.get(onboardingVisibleSteps$);
+    expect(visible).toStrictEqual(["3"]);
+  });
+
+  it("admin visible steps keep step 4 outside use-case mode", async () => {
+    mockAdminOnboarding();
+
+    detachedSetupPage({
+      context,
+      path: "/onboarding?connector=github",
+      withoutRender: true,
+    });
+
+    await context.store.set(setupOnboardingPage$, context.signal);
+
+    const visible = await context.store.get(onboardingVisibleSteps$);
+    // No use-case → classic deep-link flow keeps step 4
+    expect(visible).toStrictEqual(["1", "3", "4"]);
+  });
+
+  it("button label switches to 'Try It' on step 3 in use-case mode", async () => {
+    mockMemberOnboarding("a0000000-0000-4000-a000-000000000001");
+
+    detachedSetupPage({
+      context,
+      path: "/onboarding?prompt=hi&connector=github",
+      withoutRender: true,
+    });
+
+    await context.store.set(setupOnboardingPage$, context.signal);
+
+    await expect(context.store.get(onboardingNextLabel$)).resolves.toBe(
+      "Try It",
+    );
+  });
+
+  it("try it on step 3 in use-case mode triggers the setup API with the selected connectors", async () => {
+    let capturedBody: { selectedConnectors?: string[] } | null = null;
+    const agentId = "d0000000-0000-4000-a000-000000000001";
+
+    server.use(
+      mockApi(onboardingStatusContract.getStatus, ({ respond }) => {
+        return respond(200, {
+          needsOnboarding: true,
+          isAdmin: true,
+          hasOrg: true,
+          hasDefaultAgent: false,
+          defaultAgentId: null,
+          defaultAgentMetadata: null,
+        });
+      }),
+      mockApi(onboardingSetupContract.setup, ({ body, respond }) => {
+        capturedBody = body as { selectedConnectors?: string[] };
+        return respond(200, { agentId });
+      }),
+    );
+
+    detachedSetupPage({
+      context,
+      path: "/onboarding?prompt=original&connector=github",
+      withoutRender: true,
+    });
+
+    await context.store.set(setupOnboardingPage$, context.signal);
+
+    // Advance from step 1 (workspace name) to step 3, simulating the user
+    // filling in a workspace name and clicking Next.
+    context.store.set(setZeroWorkspaceName$, "Acme");
+    context.store.set(setZeroStep$, "3");
+    await expect(context.store.get(onboardingEffectiveStep$)).resolves.toBe(
+      "3",
+    );
+
+    // User edits the prompt in the composer and clicks Try It.
+    context.store.set(setOnboardingPromptDraft$, "edited prompt");
+    await context.store.set(onboardingStepNext$, context.signal);
+
+    expect(capturedBody).toBeTruthy();
+    expect(capturedBody!.selectedConnectors).toStrictEqual(["github"]);
+    // The onboarding deep-link params must be cleared before the optimistic
+    // router forwards search params to /chats/:threadId — otherwise the new
+    // chat URL still carries ?prompt= + ?connector=.
+    const remaining = new URLSearchParams(search());
+    expect(remaining.get("prompt")).toBeNull();
+    expect(remaining.get("connector")).toBeNull();
+  });
+
+  it("resolved prompt prefers the edited draft over the URL prompt", async () => {
+    mockAdminOnboarding();
+
+    detachedSetupPage({
+      context,
+      path: "/onboarding?prompt=from-url&connector=github",
+      withoutRender: true,
+    });
+
+    await context.store.set(setupOnboardingPage$, context.signal);
+
+    // Initially draft is seeded from URL → both agree.
+    expect(context.store.get(onboardingResolvedPrompt$)).toBe("from-url");
+
+    context.store.set(setOnboardingPromptDraft$, "edited prompt");
+    expect(context.store.get(onboardingResolvedPrompt$)).toBe("edited prompt");
+  });
+
+  describe("already-onboarded user revisiting via use-case deep link", () => {
+    function mockOnboarded(defaultAgentId: string) {
+      server.use(
+        mockApi(onboardingStatusContract.getStatus, ({ respond }) => {
+          return respond(200, {
+            needsOnboarding: false,
+            isAdmin: false,
+            hasOrg: true,
+            hasDefaultAgent: true,
+            defaultAgentId,
+            defaultAgentMetadata: null,
+          });
+        }),
+      );
+    }
+
+    it("does not redirect to home when the URL carries ?prompt= + ?connector=", async () => {
+      mockOnboarded("a0000000-0000-4000-a000-000000000099");
+
+      detachedSetupPage({
+        context,
+        path: "/onboarding?prompt=hi&connector=github",
+        withoutRender: true,
+      });
+
+      await context.store.set(setupOnboardingPage$, context.signal);
+
+      // No redirect happened — we're still on /onboarding.
+      expect(pathname()).toBe("/onboarding");
+    });
+
+    it("redirects to home for an onboarded user when no use-case link is present", async () => {
+      mockOnboarded("a0000000-0000-4000-a000-000000000099");
+
+      detachedSetupPage({
+        context,
+        path: "/onboarding",
+        withoutRender: true,
+      });
+
+      await context.store.set(setupOnboardingPage$, context.signal);
+
+      // The historical behavior is preserved when there's nothing to try.
+      expect(pathname()).toBe("/");
+    });
+
+    it("shows the dialog with a single-step flow (step 3 only)", async () => {
+      mockOnboarded("a0000000-0000-4000-a000-000000000099");
+
+      detachedSetupPage({
+        context,
+        path: "/onboarding?prompt=hi&connector=github",
+        withoutRender: true,
+      });
+
+      await context.store.set(setupOnboardingPage$, context.signal);
+
+      await expect(
+        context.store.get(onboardingShowDialog$),
+      ).resolves.toBeTruthy();
+      await expect(context.store.get(onboardingEffectiveStep$)).resolves.toBe(
+        "3",
+      );
+      await expect(
+        context.store.get(onboardingVisibleSteps$),
+      ).resolves.toStrictEqual(["3"]);
+      await expect(context.store.get(onboardingNextLabel$)).resolves.toBe(
+        "Try It",
+      );
+    });
+
+    it("does not suppress the post-connect permission dialog", async () => {
+      mockOnboarded("a0000000-0000-4000-a000-000000000099");
+
+      detachedSetupPage({
+        context,
+        path: "/onboarding?prompt=hi&connector=github",
+        withoutRender: true,
+      });
+
+      await context.store.set(setupOnboardingPage$, context.signal);
+
+      // The signal-level flag the view reads to decide whether to silence the
+      // per-connector "authorize to agent" dialog. For an already-onboarded
+      // user the backend won't bulk-authorize, so the dialog must run.
+      await expect(
+        context.store.get(onboardingBackendWillAuthorizeConnectors$),
+      ).resolves.toBeFalsy();
+    });
+  });
+
+  it("resolved prompt falls back to the URL when the draft is empty (classic deep link)", async () => {
+    mockMemberOnboarding("a0000000-0000-4000-a000-000000000001");
+
+    // Classic deep-link without ?prompt= → draft never seeded.
+    detachedSetupPage({
+      context,
+      path: "/onboarding?connector=github",
+      withoutRender: true,
+    });
+
+    await context.store.set(setupOnboardingPage$, context.signal);
+
+    // No prompt to forward at all.
+    expect(context.store.get(onboardingResolvedPrompt$)).toBeNull();
+
+    // And if a URL prompt is present but the draft was cleared by the user,
+    // the draft (empty after trimming) yields to the URL value.
+    context.store.set(setOnboardingPromptDraft$, "   ");
+    expect(context.store.get(onboardingResolvedPrompt$)).toBeNull();
+  });
+});

--- a/turbo/apps/platform/src/signals/zero-page/home-page-setup.ts
+++ b/turbo/apps/platform/src/signals/zero-page/home-page-setup.ts
@@ -12,25 +12,25 @@ export const setupHomePage$ = command(
 
     await set(checkSettingsParam$, signal);
 
-    // Redirect bare / to /agents/:id/chat, forwarding ?prompt= and ?queue= if present
+    // Redirect bare / to /agents/:id/chat. Use-case "Try It" deep links go
+    // through /onboarding directly (see buildPromptHref in use-cases/data.ts),
+    // so we no longer intercept ?prompt= here. ?queue= is forwarded so the
+    // queue drawer opens on arrival.
     const homeAgentId = await get(homeAgentId$);
     signal.throwIfAborted();
-    if (homeAgentId) {
-      const params = get(searchParams$);
-      const forwardParams = new URLSearchParams();
-      const prompt = params.get("prompt");
-      const queue = params.get("queue");
-      if (prompt) {
-        forwardParams.set("prompt", prompt);
-      }
-      if (queue) {
-        forwardParams.set("queue", queue);
-      }
-      set(detachedNavigateTo$, "/agents/:agentId/chat", {
-        pathParams: { agentId: homeAgentId },
-        searchParams: forwardParams.size > 0 ? forwardParams : undefined,
-        replace: true,
-      });
+    if (!homeAgentId) {
+      return;
     }
+    const params = get(searchParams$);
+    const queue = params.get("queue");
+    const forwardParams = new URLSearchParams();
+    if (queue) {
+      forwardParams.set("queue", queue);
+    }
+    set(detachedNavigateTo$, "/agents/:agentId/chat", {
+      pathParams: { agentId: homeAgentId },
+      searchParams: forwardParams.size > 0 ? forwardParams : undefined,
+      replace: true,
+    });
   },
 );

--- a/turbo/apps/platform/src/signals/zero-page/zero-onboarding-actions.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-onboarding-actions.ts
@@ -25,10 +25,18 @@ import { ROUTES } from "../route-paths.ts";
 import { slackOrgData$ } from "./zero-slack.ts";
 
 import { reloadBillingStatus$ } from "./billing.ts";
-import { reloadAgentById$, reloadAgents$ } from "../agent.ts";
+import { agentById, reloadAgentById$, reloadAgents$ } from "../agent.ts";
 import { reloadPinnedAgents$ } from "./zero-pinned-agents.ts";
 import { showAppSkeleton$, startSkeletonCycling$ } from "../app-skeleton.ts";
 import { sendNewThreadOptimistically$ } from "../chat-page/optimistic-chat-thread-page.ts";
+import { composerModelProviders$ } from "./composer-model-providers.ts";
+import { modelFirstModelProviderEnabled$ } from "../external/feature-switch.ts";
+import { orgModelPolicies$ } from "../external/org-model-policies.ts";
+import { userModelPreference$ } from "../external/user-model-preference.ts";
+import {
+  resolveEffectiveAgentDefaultSelection,
+  resolveModelFirstUserDefaultSelection,
+} from "./model-provider-default.ts";
 import { logger } from "../log.ts";
 
 const L = logger("OnboardingAddToSlack");
@@ -387,6 +395,35 @@ export const onboardingAddToSlack$ = command(
   },
 );
 
+/**
+ * Resolve a concrete model selection for a brand-new chat thread started
+ * from onboarding. Mirrors the resolution `chatPageAgentModelDefault$` does
+ * on the regular agent chat landing page, so use-case threads start with the
+ * same model the user would otherwise see in the composer picker.
+ */
+const resolveOnboardingModelSelection$ = command(
+  async ({ get }, agentId: string, signal: AbortSignal) => {
+    if (get(modelFirstModelProviderEnabled$)) {
+      const policies = await get(orgModelPolicies$);
+      signal.throwIfAborted();
+      const userPreference = await get(userModelPreference$);
+      signal.throwIfAborted();
+      return resolveModelFirstUserDefaultSelection({
+        userPreference,
+        policies,
+      });
+    }
+    const agent = await get(agentById(agentId));
+    signal.throwIfAborted();
+    const composerProviders = await get(composerModelProviders$);
+    signal.throwIfAborted();
+    return resolveEffectiveAgentDefaultSelection({
+      agent,
+      providers: composerProviders.providers,
+    });
+  },
+);
+
 export const onboardingContinueWeb$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     set(showAppSkeleton$);
@@ -426,6 +463,18 @@ export const onboardingContinueWeb$ = command(
           cleaned.delete("connector");
           set(updateSearchParams$, cleaned);
 
+          // Resolve a concrete modelSelection so the new thread starts with a
+          // real model. Model-first orgs read the (userId, orgId) preference
+          // (`userModelPreference$`); legacy orgs read the agent's default.
+          // Passing `null` would defer resolution to the backend, but the
+          // chat page reads the persisted thread's modelSelection back and
+          // would render an empty picker until the next user action.
+          const modelSelection = await set(
+            resolveOnboardingModelSelection$,
+            agentId,
+            signal,
+          );
+
           // Use the root signal (not the caller's page signal) so the POST
           // /chat/messages request survives the imminent /onboarding →
           // /chats/:threadId navigation. Aborting the fetch mid-flight would
@@ -437,7 +486,7 @@ export const onboardingContinueWeb$ = command(
             {
               agentId: agentId,
               prompt,
-              modelSelection: null,
+              modelSelection,
               goal: false,
             },
             rootSignal,

--- a/turbo/apps/platform/src/signals/zero-page/zero-onboarding-actions.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-onboarding-actions.ts
@@ -3,6 +3,7 @@ import {
   zeroNeedsOnboarding$,
   zeroNeedsMemberOnboarding$,
   zeroOnboardingStep$,
+  zeroOnboardingStatus$,
   zeroAgentName$,
   zeroWorkspaceName$,
   zeroSelectedConnectors$,
@@ -10,9 +11,16 @@ import {
   completeZeroOnboarding$,
   completeMemberOnboarding$,
   connectorsFromUrl$,
+  onboardingIsUseCase$,
+  onboardingPromptDraft$,
 } from "./zero-onboarding.ts";
 import { currentChatAgentDisplayName$ } from "../agent-chat.ts";
-import { detachedNavigateTo$, searchParams$ } from "../route.ts";
+import {
+  detachedNavigateTo$,
+  searchParams$,
+  updateSearchParams$,
+} from "../route.ts";
+import { rootSignal$ } from "../root-signal.ts";
 import { ROUTES } from "../route-paths.ts";
 import { slackOrgData$ } from "./zero-slack.ts";
 
@@ -20,6 +28,7 @@ import { reloadBillingStatus$ } from "./billing.ts";
 import { reloadAgentById$, reloadAgents$ } from "../agent.ts";
 import { reloadPinnedAgents$ } from "./zero-pinned-agents.ts";
 import { showAppSkeleton$, startSkeletonCycling$ } from "../app-skeleton.ts";
+import { sendNewThreadOptimistically$ } from "../chat-page/optimistic-chat-thread-page.ts";
 import { logger } from "../log.ts";
 
 const L = logger("OnboardingAddToSlack");
@@ -51,6 +60,13 @@ export const onboardingEffectiveConnectors$ = computed((get) => {
  */
 export const onboardingEffectiveStep$ = computed(async (get) => {
   const step = await get(zeroOnboardingStep$);
+  const isUseCase = get(onboardingIsUseCase$);
+  // Already-onboarded user arriving via a use-case deep link: there is no
+  // onboarding to do, but we still want to show step 3 so they can review
+  // connectors + tweak the prompt before hitting Try It.
+  if ((!step || step === "done") && isUseCase) {
+    return "3";
+  }
   if (!step || step === "done") {
     return undefined;
   }
@@ -62,9 +78,13 @@ export const onboardingEffectiveStep$ = computed(async (get) => {
   if (fromUrl && step === "2") {
     return "3";
   }
-  const selected = get(zeroSelectedConnectors$);
-  if (step === "3" && selected.length === 0) {
-    return "4";
+  // Use-case mode has no step 4 — stay on step 3 even with an empty
+  // selection so the composer + Try It CTA remain visible.
+  if (!isUseCase) {
+    const selected = get(zeroSelectedConnectors$);
+    if (step === "3" && selected.length === 0) {
+      return "4";
+    }
   }
   return step;
 });
@@ -72,20 +92,36 @@ export const onboardingEffectiveStep$ = computed(async (get) => {
 /**
  * Steps shown in the progress bar. Admin owns step 1; step 3 only appears
  * when at least one connector is selected. Step 2 (the picker) is omitted
- * when connectors arrived via `?connector=` deep link.
+ * when connectors arrived via `?connector=` deep link. Step 4 ("Where would
+ * you like to work?") is omitted in "use case" mode — the Try It CTA on
+ * step 3 goes straight to web chat.
  */
 export const onboardingVisibleSteps$ = computed(async (get) => {
   const isAdmin = await get(zeroNeedsOnboarding$);
+  const needsMember = await get(zeroNeedsMemberOnboarding$);
   const selected = get(zeroSelectedConnectors$);
   const hasSelected = selected.length > 0;
   const fromUrl = get(connectorsFromUrl$);
+  const isUseCase = get(onboardingIsUseCase$);
+  // Already-onboarded user arriving via use-case deep link: collapse the
+  // flow to a single step 3 (composer + connectors). No workspace step
+  // because the workspace already exists.
+  if (isUseCase && !isAdmin && !needsMember) {
+    return (hasSelected ? ["3"] : []) as readonly string[];
+  }
   if (isAdmin) {
+    if (isUseCase) {
+      return (hasSelected ? ["1", "3"] : ["1"]) as readonly string[];
+    }
     if (fromUrl) {
       return (hasSelected ? ["1", "3", "4"] : ["1", "4"]) as readonly string[];
     }
     return (
       hasSelected ? ["1", "2", "3", "4"] : ["1", "2", "4"]
     ) as readonly string[];
+  }
+  if (isUseCase) {
+    return (hasSelected ? ["3"] : []) as readonly string[];
   }
   if (fromUrl) {
     return (hasSelected ? ["3", "4"] : ["4"]) as readonly string[];
@@ -127,6 +163,21 @@ export const onboardingStepKey$ = computed(async (get) => {
 // Navigation
 // ---------------------------------------------------------------------------
 
+/**
+ * True when the running flow will run the onboarding "complete/setup" backend
+ * call at finish, which bulk-authorizes selected connectors to the default
+ * agent. The post-connect permission dialog can be suppressed in that case;
+ * already-onboarded users (use-case revisit) must run the dialog so each new
+ * connector is authorized individually.
+ */
+export const onboardingBackendWillAuthorizeConnectors$ = computed(
+  async (get) => {
+    const needsOnboarding = await get(zeroNeedsOnboarding$);
+    const needsMember = await get(zeroNeedsMemberOnboarding$);
+    return needsOnboarding || needsMember;
+  },
+);
+
 /** Show the back button on every step except the first visible one. */
 export const onboardingShowBack$ = computed(async (get) => {
   const step = await get(onboardingEffectiveStep$);
@@ -148,6 +199,20 @@ export const onboardingNextDisabled$ = computed(async (get) => {
     return !get(zeroWorkspaceName$).trim();
   }
   return false;
+});
+
+/**
+ * Label shown on the primary forward button in the footer. "Try It" on the
+ * terminal step of a use-case flow signals that clicking finishes onboarding
+ * and jumps into the chat; everywhere else it's a plain "Next".
+ */
+export const onboardingNextLabel$ = computed(async (get) => {
+  const step = await get(onboardingEffectiveStep$);
+  const isUseCase = get(onboardingIsUseCase$);
+  if (isUseCase && step === "3") {
+    return "Try It";
+  }
+  return "Next";
 });
 
 export const onboardingStepBack$ = command(
@@ -177,12 +242,18 @@ export const onboardingStepBack$ = command(
 );
 
 export const onboardingStepNext$ = command(
-  async ({ get, set }, _signal: AbortSignal) => {
+  async ({ get, set }, signal: AbortSignal) => {
     const step = await get(onboardingEffectiveStep$);
+    signal.throwIfAborted();
     const hasSelected = get(zeroSelectedConnectors$).length > 0;
     const fromUrl = get(connectorsFromUrl$);
+    const isUseCase = get(onboardingIsUseCase$);
     switch (step) {
       case "1": {
+        if (isUseCase) {
+          set(setZeroStep$, "3");
+          break;
+        }
         set(setZeroStep$, fromUrl ? (hasSelected ? "3" : "4") : "2");
         break;
       }
@@ -191,6 +262,12 @@ export const onboardingStepNext$ = command(
         break;
       }
       case "3": {
+        if (isUseCase) {
+          // Try It: create org + default agent, authorize selected connectors,
+          // navigate to the new agent's web chat with the edited prompt.
+          await set(onboardingContinueWeb$, signal);
+          break;
+        }
         set(setZeroStep$, "4");
         break;
       }
@@ -205,7 +282,10 @@ export const onboardingStepNext$ = command(
 export const onboardingShowDialog$ = computed(async (get) => {
   const needsOnboarding = await get(zeroNeedsOnboarding$);
   const needsMember = await get(zeroNeedsMemberOnboarding$);
-  return needsOnboarding || needsMember;
+  // Already-onboarded users still see the dialog when they arrive via a
+  // use-case deep link, so they can review connectors + edit the prompt.
+  const isUseCase = get(onboardingIsUseCase$);
+  return needsOnboarding || needsMember || isUseCase;
 });
 
 // ---------------------------------------------------------------------------
@@ -245,6 +325,20 @@ export const completeOnboarding$ = command(
   },
 );
 
+/**
+ * Resolve the prompt to carry forward when finishing onboarding. The editable
+ * composer (use-case mode) wins over the raw `?prompt=` URL param; falling
+ * back to the URL keeps the historical behavior intact when the composer
+ * isn't shown.
+ */
+export const onboardingResolvedPrompt$ = computed((get) => {
+  const draft = get(onboardingPromptDraft$).trim();
+  if (draft.length > 0) {
+    return draft;
+  }
+  return get(searchParams$).get("prompt");
+});
+
 export const onboardingAddToSlack$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     set(showAppSkeleton$);
@@ -265,7 +359,7 @@ export const onboardingAddToSlack$ = command(
         // workspace app is already installed). Either one continues the
         // onboarding flow in Slack — open whichever the backend offered.
         const targetUrl = slackData.installUrl ?? slackData.connectUrl;
-        const prompt = get(searchParams$).get("prompt");
+        const prompt = get(onboardingResolvedPrompt$);
 
         if (targetUrl) {
           const url = new URL(targetUrl, window.location.origin);
@@ -283,7 +377,7 @@ export const onboardingAddToSlack$ = command(
           });
         }
 
-        // Forward ?prompt= to /works so the page can keep the same context
+        // Forward the prompt to /works so the page can keep the same context
         // (e.g. re-opening the DM) once the OAuth tab returns.
         set(detachedNavigateTo$, "/works", {
           searchParams: prompt ? new URLSearchParams({ prompt }) : undefined,
@@ -300,16 +394,59 @@ export const onboardingContinueWeb$ = command(
     await Promise.all([
       set(startSkeletonCycling$, signal),
       (async () => {
-        const agentId = await set(completeOnboarding$, signal);
+        // Already-onboarded users (typical "use-case deep link revisit")
+        // skip the setup/complete API — calling /onboarding/complete would
+        // overwrite their existing connector authorizations on the default
+        // agent. Read defaultAgentId from status and continue.
+        const status = await get(zeroOnboardingStatus$);
+        signal.throwIfAborted();
+        const alreadyOnboarded =
+          !status.needsOnboarding && status.defaultAgentId !== null;
+        const agentId = alreadyOnboarded
+          ? status.defaultAgentId
+          : await set(completeOnboarding$, signal);
 
         if (!agentId) {
           return;
         }
 
-        // Forward ?prompt= to the chat page so the composer gets pre-filled
-        // with the prompt the user arrived with.
-        const prompt = get(searchParams$).get("prompt");
+        const prompt = get(onboardingResolvedPrompt$);
+        const isUseCase = get(onboardingIsUseCase$);
 
+        // Use-case mode: send the prompt as the first message in a brand-new
+        // thread so the user lands inside the running thread instead of an
+        // empty composer. sendNewThreadOptimistically$ handles the navigate
+        // to `/chats/:threadId`.
+        if (isUseCase && prompt && prompt.length > 0) {
+          // Drop the onboarding deep-link params from the URL before the
+          // optimistic router forwards search params to /chats/:threadId —
+          // otherwise the new chat URL still carries ?prompt= + ?connector=.
+          const cleaned = new URLSearchParams(get(searchParams$));
+          cleaned.delete("prompt");
+          cleaned.delete("connector");
+          set(updateSearchParams$, cleaned);
+
+          // Use the root signal (not the caller's page signal) so the POST
+          // /chat/messages request survives the imminent /onboarding →
+          // /chats/:threadId navigation. Aborting the fetch mid-flight would
+          // surface as "Chat not found" once the persisted thread fails to
+          // resolve.
+          const rootSignal = get(rootSignal$);
+          await set(
+            sendNewThreadOptimistically$,
+            {
+              agentId: agentId,
+              prompt,
+              modelSelection: null,
+              goal: false,
+            },
+            rootSignal,
+          );
+          return;
+        }
+
+        // Classic deep-link flow: navigate to the agent's empty composer page
+        // and forward the prompt so it gets pre-filled.
         set(detachedNavigateTo$, "/agents/:agentId/chat", {
           pathParams: { agentId: agentId },
           searchParams: prompt ? new URLSearchParams({ prompt }) : undefined,

--- a/turbo/apps/platform/src/signals/zero-page/zero-onboarding.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-onboarding.ts
@@ -84,6 +84,33 @@ export const markConnectorsFromUrl$ = command(({ set }) => {
   set(internalConnectorsFromUrl$, true);
 });
 
+/**
+ * True when the user arrived via a "use case" deep link carrying both
+ * `?connector=` and `?prompt=`. In this mode the onboarding is condensed —
+ * step 4 ("Where would you like to work?") is skipped and step 3 grows an
+ * editable composer so the user can tweak the prompt before continuing
+ * straight into the web chat with their default agent.
+ */
+const internalUseCaseMode$ = state(false);
+const internalPromptDraft$ = state("");
+
+export const onboardingIsUseCase$ = computed((get) => {
+  return get(internalUseCaseMode$);
+});
+
+export const onboardingPromptDraft$ = computed((get) => {
+  return get(internalPromptDraft$);
+});
+
+export const markUseCaseMode$ = command(({ set }, prompt: string) => {
+  set(internalUseCaseMode$, true);
+  set(internalPromptDraft$, prompt);
+});
+
+export const setOnboardingPromptDraft$ = command(({ set }, value: string) => {
+  set(internalPromptDraft$, value);
+});
+
 export const zeroOnboardingStep$ = computed(async (get) => {
   const userStep = get(userStep$);
   if (userStep !== null) {
@@ -153,6 +180,8 @@ export const toggleZeroConnector$ = command(
 export const resetOnboardingStep$ = command(({ set }) => {
   set(userStep$, null);
   set(internalConnectorsFromUrl$, false);
+  set(internalUseCaseMode$, false);
+  set(internalPromptDraft$, "");
 });
 
 /**

--- a/turbo/apps/platform/src/views/zero-page/__tests__/prompt-param-injection.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/prompt-param-injection.test.tsx
@@ -14,18 +14,6 @@ function mockChatAPI() {
 }
 
 describe("prompt query parameter injection", () => {
-  it("should inject ?prompt= into chat input when navigating to /", async () => {
-    mockChatAPI();
-    detachedSetupPage({ context, path: "/?prompt=Hello%20world" });
-
-    // Should redirect to /talk/:id and show the prompt in the input
-    const textarea = await waitFor(() => {
-      return screen.getByPlaceholderText(PLACEHOLDER) as HTMLTextAreaElement;
-    });
-
-    expect(textarea).toHaveValue("Hello world");
-  });
-
   it("should inject ?prompt= into chat input when navigating to /talk/:id", async () => {
     mockChatAPI();
     detachedSetupPage({

--- a/turbo/apps/platform/src/views/zero-page/zero-onboarding.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-onboarding.tsx
@@ -27,10 +27,14 @@ import {
   toggleZeroConnector$,
   connectorSearch$,
   setConnectorSearch$,
+  onboardingIsUseCase$,
+  onboardingPromptDraft$,
+  setOnboardingPromptDraft$,
 } from "../../signals/zero-page/zero-onboarding.ts";
 import {
   onboardingDisplayName$,
   onboardingAddToSlack$,
+  onboardingBackendWillAuthorizeConnectors$,
   onboardingContinueWeb$,
   onboardingContinueTelegram$,
   onboardingEffectiveStep$,
@@ -41,6 +45,7 @@ import {
   onboardingShowBack$,
   onboardingShowNext$,
   onboardingNextDisabled$,
+  onboardingNextLabel$,
   onboardingStepBack$,
   onboardingStepNext$,
   onboardingIsAdmin$,
@@ -354,7 +359,43 @@ function ConnectStepContent() {
           })}
         </div>
       )}
+      <UseCasePromptComposer />
     </>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Use case "Try It" composer — only renders when onboarding arrived via the
+// `?prompt=...&connector=...` deep link. A plain editable textarea so the
+// user can tweak the suggested prompt before clicking the footer "Try It".
+// No internal send button — the footer button is the single CTA.
+// ---------------------------------------------------------------------------
+
+function UseCasePromptComposer() {
+  const isUseCase = useGet(onboardingIsUseCase$);
+  const draft = useGet(onboardingPromptDraft$);
+  const setDraft = useSet(setOnboardingPromptDraft$);
+
+  if (!isUseCase) {
+    return null;
+  }
+
+  return (
+    <div data-testid="onboarding-prompt-composer" className="w-full mt-6">
+      <p className="text-xs font-medium text-muted-foreground mb-2">
+        Your first prompt
+      </p>
+      <textarea
+        data-testid="onboarding-prompt-input"
+        value={draft}
+        onChange={(e) => {
+          setDraft(e.target.value);
+        }}
+        autoFocus
+        rows={4}
+        className="w-full resize-none rounded-xl zero-border bg-background px-4 py-3 text-sm leading-relaxed text-foreground placeholder:text-muted-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      />
+    </div>
   );
 }
 
@@ -737,6 +778,11 @@ function OrbitIllustration() {
 function OnboardingProgressBar() {
   const currentStep = useLastResolved(onboardingCurrentStepIndex$) ?? 0;
   const visibleSteps = useLastResolved(onboardingVisibleSteps$) ?? [];
+  // A single-step flow has nothing to track — hide the bar to avoid the
+  // visual "always 100%" stripe (use-case revisit by an onboarded user).
+  if (visibleSteps.length <= 1) {
+    return null;
+  }
   return (
     <ProgressBar totalSteps={visibleSteps.length} currentStep={currentStep} />
   );
@@ -746,6 +792,7 @@ function OnboardingFooterNav() {
   const showBack = useLastResolved(onboardingShowBack$) ?? false;
   const showNext = useLastResolved(onboardingShowNext$) ?? false;
   const nextDisabled = useLastResolved(onboardingNextDisabled$) ?? false;
+  const nextLabel = useLastResolved(onboardingNextLabel$) ?? "Next";
   const stepBack = useSet(onboardingStepBack$);
   const stepNext = useSet(onboardingStepNext$);
   const pageSignal = useGet(pageSignal$);
@@ -773,7 +820,7 @@ function OnboardingFooterNav() {
             className="rounded-lg min-w-[100px]"
             disabled={nextDisabled}
           >
-            Next
+            {nextLabel}
           </Button>
         )}
       </div>
@@ -1026,6 +1073,12 @@ export function ZeroOnboarding() {
   const selectedConnectorType = useGet(selectedConnectorType$);
   const setSelected = useSet(setSelectedConnectorType$);
   const clearPermissionDialog = useSet(setPermissionDialogType$);
+  // We suppress the post-connect permission dialog only when the backend will
+  // bulk-authorize selected connectors at the end of onboarding. Already-
+  // onboarded users entering via a use-case deep link need the dialog so each
+  // new connector is authorized to their existing default agent.
+  const suppressPermissionDialog =
+    useLastResolved(onboardingBackendWillAuthorizeConnectors$) ?? true;
 
   if (!effectiveStep) {
     return null;
@@ -1043,9 +1096,9 @@ export function ZeroOnboarding() {
             return setSelected(null);
           }}
           onSuccess={() => {
-            // During onboarding the backend authorizes connectors for the
-            // default agent at step 4, so suppress the permission dialog.
-            clearPermissionDialog(null);
+            if (suppressPermissionDialog) {
+              clearPermissionDialog(null);
+            }
           }}
         />
       )}

--- a/turbo/apps/web/app/[locale]/use-cases/data.ts
+++ b/turbo/apps/web/app/[locale]/use-cases/data.ts
@@ -1666,5 +1666,9 @@ export function buildPromptHref(
   if (cleaned) qs.set("prompt", cleaned);
   if (connector) qs.set("connector", connector);
   const query = qs.toString();
-  return query ? `${platformUrl}/?${query}` : platformUrl;
+  // Route Try It through /onboarding so the user always sees the connector
+  // setup + editable prompt composer first — regardless of whether the user
+  // is fresh or already onboarded. The /onboarding page itself decides
+  // whether to show the workspace step or jump straight to step 3.
+  return query ? `${platformUrl}/onboarding?${query}` : platformUrl;
 }

--- a/turbo/apps/web/src/__tests__/use-cases-data.test.ts
+++ b/turbo/apps/web/src/__tests__/use-cases-data.test.ts
@@ -122,6 +122,16 @@ describe("use cases translation coverage", () => {
 describe("buildPromptHref", () => {
   const connectors = USE_CASES[0]!.connectors;
 
+  it("points at /onboarding so Try It always goes through the connector step", () => {
+    const href = buildPromptHref(
+      "show me recent errors",
+      connectors,
+      "https://app.example.com",
+    );
+    const url = new URL(href);
+    expect(url.pathname).toBe("/onboarding");
+  });
+
   it("strips @Zero prefix from the prompt", () => {
     const href = buildPromptHref(
       "@Zero top 3 Sentry errors in the last 24h",
@@ -153,7 +163,7 @@ describe("buildPromptHref", () => {
     expect(href).toContain("prompt=hello+world+%26+friends");
   });
 
-  it("omits empty params", () => {
+  it("returns the bare platform URL when both params are empty", () => {
     expect(buildPromptHref("", [], "https://app.example.com")).toBe(
       "https://app.example.com",
     );


### PR DESCRIPTION
## Summary

Route the marketing-site "Try It" CTA through `/onboarding` directly and condense the onboarding dialog when the URL carries both `?prompt=` and `?connector=`. The user lands on step 3 with their selected connectors + an editable composer seeded from the URL prompt, hits **Try It**, and gets dropped straight inside a brand-new chat thread with the prompt already sent — no second click to send.

### Marketing site (`apps/web`)
- `buildPromptHref` now points at `${platformUrl}/onboarding?prompt=...&connector=...` (previously `/?prompt=...&connector=...`). Use-case "Try It" links bypass the home-page bounce, so already-onboarded users no longer slip past the connector-highlight step.

### Onboarding (`apps/platform`)
- New "use-case mode" detected when `?prompt=` and `?connector=` are both present.
  - Fresh admin: progress collapses from `[1, 2, 3, 4]` → `[1, 3]` (workspace name → connectors).
  - Fresh member: `[3]` only.
  - Already-onboarded user: also `[3]`, with no progress bar (single-step flow).
- Step 3 grows a plain editable `<textarea>` seeded from `onboardingPromptDraft$` (initialized from `?prompt=`). No toolbar / send button inside the composer — the footer button is the single CTA.
- Footer button label becomes **"Try It"** on the terminal use-case step.
- Try It triggers `onboardingContinueWeb$`, which:
  - For fresh users: runs the existing `completeOnboarding$` (creates org + default agent + bulk-authorizes selected connectors).
  - For already-onboarded users: **skips** `completeOnboarding$` (otherwise `/onboarding/complete` would destructively replace existing `user_connectors` rows on the default agent). Uses `status.defaultAgentId` directly.
  - Calls `sendNewThreadOptimistically$` to mint an optimistic thread + send the prompt as the first message + navigate to `/chats/:threadId`.
- URL `?prompt=` / `?connector=` are stripped before the optimistic router forwards search params, so the new chat URL doesn't carry stale onboarding params.
- The send uses `rootSignal$` (not the page signal) so the in-flight `POST /chat/messages` survives the `/onboarding` → `/chats/:threadId` navigation — otherwise the fetch is cancelled and the destination page shows "Chat not found".
- The post-connect permission dialog is no longer unconditionally suppressed: when the user is already onboarded (`onboardingBackendWillAuthorizeConnectors$ === false`), the dialog runs so each new connector gets authorized to their existing default agent.

### Home page (`setupHomePage$`)
- No longer intercepts `?prompt=` — that flow is now owned by `/onboarding`. Forwards `?queue=` only.

## Test plan
- [x] `pnpm -F web exec vitest run src/__tests__/use-cases-data.test.ts` — 8/8 (includes new "points at /onboarding" assertion)
- [x] `pnpm -F @vm0/app exec vitest run src/signals/zero-page/__tests__/onboarding-use-case-mode.test.ts` — 14/14 (new file)
- [x] `pnpm -F @vm0/app exec vitest run src/signals/` — 449/449 passes
- [x] `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/` — 1159/1159 passes
- [x] `pnpm check-types` — clean
- [x] `pnpm lint` — clean
- [ ] Manual: hit `https://app.vm0.ai/onboarding?prompt=...&connector=github` as both a fresh user and an already-onboarded user; verify the textarea seeds, "Try It" creates a thread + lands on `/chats/<id>` with the prompt already sent, and the URL no longer carries `?prompt`/`?connector`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)