### PR TITLE
feat(platform): eager-init workspace at step 1 + sticky admin scope

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/__tests__/onboarding-use-case-mode.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/onboarding-use-case-mode.test.ts
@@ -4,6 +4,7 @@ import { testContext } from "../../__tests__/test-helpers.ts";
 import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
 import { setupOnboardingPage$ } from "../../onboarding-page/onboarding-page-setup.ts";
 import {
+  onboardingEagerInitialized$,
   onboardingIsUseCase$,
   onboardingPromptDraft$,
   setOnboardingPromptDraft$,
@@ -16,6 +17,7 @@ import {
   onboardingEffectiveStep$,
   onboardingNextLabel$,
   onboardingResolvedPrompt$,
+  onboardingShowBack$,
   onboardingShowDialog$,
   onboardingStepNext$,
   onboardingVisibleSteps$,
@@ -327,6 +329,207 @@ describe("onboarding use-case mode (?prompt=...&connector=...)", () => {
       await expect(
         context.store.get(onboardingBackendWillAuthorizeConnectors$),
       ).resolves.toBeFalsy();
+    });
+  });
+
+  describe("admin eager init on step 1 Next", () => {
+    function setupAdminMocks() {
+      const agentId = "d0000000-0000-4000-a000-000000000099";
+      const setupCalls: { selectedConnectors?: string[] }[] = [];
+      server.use(
+        mockApi(onboardingStatusContract.getStatus, ({ respond }) => {
+          return respond(200, {
+            needsOnboarding: true,
+            isAdmin: true,
+            hasOrg: true,
+            hasDefaultAgent: false,
+            defaultAgentId: null,
+            defaultAgentMetadata: null,
+          });
+        }),
+        mockApi(onboardingSetupContract.setup, ({ body, respond }) => {
+          setupCalls.push(body as { selectedConnectors?: string[] });
+          return respond(200, { agentId });
+        }),
+      );
+      return { setupCalls, agentId };
+    }
+
+    it("provisions the workspace and advances to the connect step (use-case)", async () => {
+      const { setupCalls } = setupAdminMocks();
+
+      detachedSetupPage({
+        context,
+        path: "/onboarding?prompt=hi&connector=github",
+        withoutRender: true,
+      });
+
+      await context.store.set(setupOnboardingPage$, context.signal);
+
+      context.store.set(setZeroWorkspaceName$, "Acme");
+      await context.store.set(onboardingStepNext$, context.signal);
+
+      // Setup API was called exactly once at step 1, with the URL connector
+      // bulk-authorized.
+      expect(setupCalls).toHaveLength(1);
+      expect(setupCalls[0]!.selectedConnectors).toStrictEqual(["github"]);
+      // We're now on step 3 (the connect-with-composer step).
+      await expect(context.store.get(onboardingEffectiveStep$)).resolves.toBe(
+        "3",
+      );
+      // Eager-init flag flipped.
+      expect(context.store.get(onboardingEagerInitialized$)).toBeTruthy();
+    });
+
+    it("provisions the workspace and advances to the picker (regular flow, no URL connectors)", async () => {
+      const { setupCalls } = setupAdminMocks();
+
+      detachedSetupPage({
+        context,
+        path: "/onboarding",
+        withoutRender: true,
+      });
+
+      await context.store.set(setupOnboardingPage$, context.signal);
+
+      context.store.set(setZeroWorkspaceName$, "Acme");
+      await context.store.set(onboardingStepNext$, context.signal);
+
+      expect(setupCalls).toHaveLength(1);
+      // No connectors picked yet → backend gets no selectedConnectors.
+      expect(setupCalls[0]!.selectedConnectors).toBeUndefined();
+      // Step 1 → step 2 (the picker).
+      await expect(context.store.get(onboardingEffectiveStep$)).resolves.toBe(
+        "2",
+      );
+    });
+
+    it("hides the Back button after eager init", async () => {
+      setupAdminMocks();
+
+      detachedSetupPage({
+        context,
+        path: "/onboarding?prompt=hi&connector=github",
+        withoutRender: true,
+      });
+
+      await context.store.set(setupOnboardingPage$, context.signal);
+      context.store.set(setZeroWorkspaceName$, "Acme");
+      await context.store.set(onboardingStepNext$, context.signal);
+
+      await expect(context.store.get(onboardingShowBack$)).resolves.toBeFalsy();
+    });
+
+    it("keeps the dialog visible after the server flips needsOnboarding false", async () => {
+      setupAdminMocks();
+
+      detachedSetupPage({
+        context,
+        path: "/onboarding?prompt=hi&connector=github",
+        withoutRender: true,
+      });
+
+      await context.store.set(setupOnboardingPage$, context.signal);
+      context.store.set(setZeroWorkspaceName$, "Acme");
+      await context.store.set(onboardingStepNext$, context.signal);
+
+      // Post-eager-init `zeroNeedsOnboarding$` will reload to false because
+      // the backend now reports the user as onboarded. The dialog must still
+      // be shown so the user can finish the remaining step.
+      await expect(
+        context.store.get(onboardingShowDialog$),
+      ).resolves.toBeTruthy();
+    });
+
+    it("permission dialog suppression stays on after eager init in use-case mode", async () => {
+      setupAdminMocks();
+
+      detachedSetupPage({
+        context,
+        path: "/onboarding?prompt=hi&connector=github",
+        withoutRender: true,
+      });
+
+      await context.store.set(setupOnboardingPage$, context.signal);
+      context.store.set(setZeroWorkspaceName$, "Acme");
+      await context.store.set(onboardingStepNext$, context.signal);
+
+      // Use-case mode: the URL connectors were bulk-authorized at eager init,
+      // and step 3 doesn't let the user pick anything new. Suppression stays
+      // on so the post-OAuth permission dialog doesn't pop up redundantly.
+      await expect(
+        context.store.get(onboardingBackendWillAuthorizeConnectors$),
+      ).resolves.toBeTruthy();
+    });
+
+    it("permission dialog suppression flips off after eager init in the regular flow", async () => {
+      setupAdminMocks();
+
+      detachedSetupPage({
+        context,
+        path: "/onboarding",
+        withoutRender: true,
+      });
+
+      await context.store.set(setupOnboardingPage$, context.signal);
+      context.store.set(setZeroWorkspaceName$, "Acme");
+      await context.store.set(onboardingStepNext$, context.signal);
+
+      // Regular flow: the user is about to pick brand-new connectors via the
+      // picker — those weren't covered by the eager-init bulk authorize, so
+      // each Connect must run the permission dialog.
+      await expect(
+        context.store.get(onboardingBackendWillAuthorizeConnectors$),
+      ).resolves.toBeFalsy();
+    });
+
+    it("try it on step 3 after eager init does not re-call setup", async () => {
+      const { setupCalls, agentId } = setupAdminMocks();
+      server.use(
+        mockApi(onboardingStatusContract.getStatus, ({ respond }) => {
+          return respond(200, {
+            needsOnboarding: true,
+            isAdmin: true,
+            hasOrg: true,
+            hasDefaultAgent: false,
+            defaultAgentId: null,
+            defaultAgentMetadata: null,
+          });
+        }),
+      );
+
+      detachedSetupPage({
+        context,
+        path: "/onboarding?prompt=hi&connector=github",
+        withoutRender: true,
+      });
+
+      await context.store.set(setupOnboardingPage$, context.signal);
+      context.store.set(setZeroWorkspaceName$, "Acme");
+      // Step 1 Next → setup runs (call #1).
+      await context.store.set(onboardingStepNext$, context.signal);
+      expect(setupCalls).toHaveLength(1);
+
+      // After eager-init the backend reports needsOnboarding=false. Override
+      // the mock so continueWeb$ reads the new state when polling status.
+      server.use(
+        mockApi(onboardingStatusContract.getStatus, ({ respond }) => {
+          return respond(200, {
+            needsOnboarding: false,
+            isAdmin: true,
+            hasOrg: true,
+            hasDefaultAgent: true,
+            defaultAgentId: agentId,
+            defaultAgentMetadata: null,
+          });
+        }),
+      );
+
+      // Step 3 (Try It) → must NOT re-call setup.
+      context.store.set(setOnboardingPromptDraft$, "hello");
+      await context.store.set(onboardingStepNext$, context.signal);
+
+      expect(setupCalls).toHaveLength(1);
     });
   });
 

--- a/turbo/apps/platform/src/signals/zero-page/onboard-guard.ts
+++ b/turbo/apps/platform/src/signals/zero-page/onboard-guard.ts
@@ -2,6 +2,7 @@ import { command } from "ccstate";
 import { clerk$, resolveWebOrigin } from "../auth.ts";
 import { detachedNavigateTo$, searchParams$ } from "../route.ts";
 import {
+  onboardingEagerInitialized$,
   zeroOnboardingStatus$,
   zeroNeedsOnboarding$,
   zeroNeedsMemberOnboarding$,
@@ -20,6 +21,14 @@ const FORWARDED_ONBOARDING_PARAMS = ["prompt", "connector"] as const;
  */
 export const onboardGuard$ = command(
   async ({ get, set }, signal: AbortSignal): Promise<boolean> => {
+    // Admin has already provisioned the workspace via eager init this
+    // session; the server may not have surfaced the new state in the cached
+    // status yet, but locally we know onboarding is done. Don't redirect
+    // back to /onboarding when they navigate elsewhere (e.g. continue-in-web).
+    if (get(onboardingEagerInitialized$)) {
+      return false;
+    }
+
     const needsOnboarding = await get(zeroNeedsOnboarding$);
     signal.throwIfAborted();
     const needsMemberOnboarding = await get(zeroNeedsMemberOnboarding$);

--- a/turbo/apps/platform/src/signals/zero-page/zero-onboarding-actions.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-onboarding-actions.ts
@@ -11,8 +11,11 @@ import {
   completeZeroOnboarding$,
   completeMemberOnboarding$,
   connectorsFromUrl$,
+  onboardingEagerInitialized$,
+  onboardingEagerInitializedAgentId$,
   onboardingIsUseCase$,
   onboardingPromptDraft$,
+  markEagerInitialized$,
 } from "./zero-onboarding.ts";
 import { currentChatAgentDisplayName$ } from "../agent-chat.ts";
 import {
@@ -45,7 +48,19 @@ const L = logger("OnboardingAddToSlack");
 // Admin flag
 // ---------------------------------------------------------------------------
 
-export const onboardingIsAdmin$ = zeroNeedsOnboarding$;
+/**
+ * Whether the current user should be treated as the org admin throughout the
+ * onboarding session. Sticky: once we've eagerly provisioned the workspace
+ * at step 1, `zeroNeedsOnboarding$` flips false on the server, but the user
+ * is still the admin completing the rest of the steps — keep the flag true
+ * so view-layer step decisions stay consistent.
+ */
+export const onboardingIsAdmin$ = computed(async (get) => {
+  if (get(onboardingEagerInitialized$)) {
+    return true;
+  }
+  return await get(zeroNeedsOnboarding$);
+});
 
 // ---------------------------------------------------------------------------
 // Step resolution (moved from TSX)
@@ -78,7 +93,7 @@ export const onboardingEffectiveStep$ = computed(async (get) => {
   if (!step || step === "done") {
     return undefined;
   }
-  const isAdmin = await get(zeroNeedsOnboarding$);
+  const isAdmin = await get(onboardingIsAdmin$);
   const fromUrl = get(connectorsFromUrl$);
   if (!isAdmin && step === "1") {
     return fromUrl ? "3" : "2";
@@ -105,7 +120,7 @@ export const onboardingEffectiveStep$ = computed(async (get) => {
  * step 3 goes straight to web chat.
  */
 export const onboardingVisibleSteps$ = computed(async (get) => {
-  const isAdmin = await get(zeroNeedsOnboarding$);
+  const isAdmin = await get(onboardingIsAdmin$);
   const needsMember = await get(zeroNeedsMemberOnboarding$);
   const selected = get(zeroSelectedConnectors$);
   const hasSelected = selected.length > 0;
@@ -172,22 +187,40 @@ export const onboardingStepKey$ = computed(async (get) => {
 // ---------------------------------------------------------------------------
 
 /**
- * True when the running flow will run the onboarding "complete/setup" backend
- * call at finish, which bulk-authorizes selected connectors to the default
- * agent. The post-connect permission dialog can be suppressed in that case;
- * already-onboarded users (use-case revisit) must run the dialog so each new
- * connector is authorized individually.
+ * True when the backend already has (or will run) bulk-authorize for the
+ * connectors the user is about to Connect — i.e. when the post-connect
+ * permission dialog is redundant and should be suppressed.
+ *
+ * - Eager-init admin in use-case mode: the URL connectors were bulk-authorized
+ *   at step 1, and step 2 doesn't let the user pick anything new — suppress.
+ * - Eager-init admin in the regular flow: step 2 picker can add connectors
+ *   the eager-init call didn't cover; let the dialog run per connector.
+ * - Pre-eager admins / fresh members: setup or complete will bulk-authorize
+ *   at finish — suppress until then.
+ * - Already-onboarded users (use-case revisit): no bulk-authorize is coming;
+ *   let the dialog run.
  */
 export const onboardingBackendWillAuthorizeConnectors$ = computed(
   async (get) => {
+    if (get(onboardingEagerInitialized$)) {
+      return get(onboardingIsUseCase$);
+    }
     const needsOnboarding = await get(zeroNeedsOnboarding$);
     const needsMember = await get(zeroNeedsMemberOnboarding$);
     return needsOnboarding || needsMember;
   },
 );
 
-/** Show the back button on every step except the first visible one. */
+/**
+ * Show the back button on every step except the first visible one. Hidden
+ * entirely once the workspace has been eagerly provisioned at step 1 — going
+ * back to rename it would be misleading since the org + default agent
+ * already exist server-side.
+ */
 export const onboardingShowBack$ = computed(async (get) => {
+  if (get(onboardingEagerInitialized$)) {
+    return false;
+  }
   const step = await get(onboardingEffectiveStep$);
   if (!step) {
     return false;
@@ -258,6 +291,19 @@ export const onboardingStepNext$ = command(
     const isUseCase = get(onboardingIsUseCase$);
     switch (step) {
       case "1": {
+        // Eagerly provision the workspace + default agent so the user can
+        // never roll back past it. selectedConnectors (URL deep link or
+        // explicit picker selection) are bulk-authorized to the new agent
+        // in the same call.
+        if (!get(onboardingEagerInitialized$)) {
+          const agentId = await set(completeZeroOnboarding$, signal);
+          signal.throwIfAborted();
+          set(markEagerInitialized$, agentId ?? null);
+          set(reloadBillingStatus$);
+          set(reloadAgents$);
+          set(reloadAgentById$);
+          set(reloadPinnedAgents$);
+        }
         if (isUseCase) {
           set(setZeroStep$, "3");
           break;
@@ -271,8 +317,10 @@ export const onboardingStepNext$ = command(
       }
       case "3": {
         if (isUseCase) {
-          // Try It: create org + default agent, authorize selected connectors,
-          // navigate to the new agent's web chat with the edited prompt.
+          // Try It: navigate to the new agent's web chat with the edited
+          // prompt. The workspace + agent + initial connector authorization
+          // were already created at step 1 (eager init) — no setup API
+          // call here.
           await set(onboardingContinueWeb$, signal);
           break;
         }
@@ -288,12 +336,14 @@ export const onboardingStepNext$ = command(
 // ---------------------------------------------------------------------------
 
 export const onboardingShowDialog$ = computed(async (get) => {
-  const needsOnboarding = await get(zeroNeedsOnboarding$);
+  const isAdmin = await get(onboardingIsAdmin$);
   const needsMember = await get(zeroNeedsMemberOnboarding$);
   // Already-onboarded users still see the dialog when they arrive via a
   // use-case deep link, so they can review connectors + edit the prompt.
+  // Admins whose setup just ran (eager-init) also keep the dialog open
+  // through the sticky onboardingIsAdmin$ flag.
   const isUseCase = get(onboardingIsUseCase$);
-  return needsOnboarding || needsMember || isUseCase;
+  return isAdmin || needsMember || isUseCase;
 });
 
 // ---------------------------------------------------------------------------
@@ -305,7 +355,7 @@ export const onboardingShowDialog$ = computed(async (get) => {
  * Admin sees the name they typed; member sees the default agent's display name.
  */
 export const onboardingDisplayName$ = computed(async (get) => {
-  const isAdmin = await get(zeroNeedsOnboarding$);
+  const isAdmin = await get(onboardingIsAdmin$);
   if (isAdmin) {
     return get(zeroAgentName$);
   }
@@ -320,6 +370,24 @@ export const completeOnboarding$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     set(reloadBillingStatus$);
 
+    // Admin already ran setup at step 1 (eager init). Don't re-call it —
+    // calling completeZeroOnboarding$ twice would error on the existing
+    // workspace. The agentId returned by the eager setup was captured at
+    // that moment; prefer that over a status round-trip (`zeroOnboardingStatus$`
+    // may still be cached from before eager init in some flows).
+    if (get(onboardingEagerInitialized$)) {
+      const captured = get(onboardingEagerInitializedAgentId$);
+      if (captured) {
+        return captured;
+      }
+      const status = await get(zeroOnboardingStatus$);
+      signal.throwIfAborted();
+      return status.defaultAgentId ?? undefined;
+    }
+
+    // Members joining an existing org still run the complete API at the end
+    // (authorizes selected connectors). Admins who did NOT go through eager
+    // init (legacy callers) fall through to the original setup call.
     const isAdmin = await get(zeroNeedsOnboarding$);
     signal.throwIfAborted();
     const agentId = isAdmin

--- a/turbo/apps/platform/src/signals/zero-page/zero-onboarding.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-onboarding.ts
@@ -111,6 +111,35 @@ export const setOnboardingPromptDraft$ = command(({ set }, value: string) => {
   set(internalPromptDraft$, value);
 });
 
+/**
+ * True once an admin has clicked Next on step 1 and the workspace + default
+ * agent have been provisioned. The dialog stays visible while the user
+ * finishes picking/connecting connectors, and the Back button is hidden —
+ * going back would be misleading now that the workspace exists.
+ *
+ * We also remember the agentId returned by the eager setup so the later
+ * "Continue in web" / "Try It" step can navigate without re-reading the
+ * onboarding status (which `zeroOnboardingStatus$` may still have cached
+ * from before eager init).
+ */
+const internalEagerInitialized$ = state(false);
+const internalEagerInitializedAgentId$ = state<string | null>(null);
+
+export const onboardingEagerInitialized$ = computed((get) => {
+  return get(internalEagerInitialized$);
+});
+
+export const onboardingEagerInitializedAgentId$ = computed((get) => {
+  return get(internalEagerInitializedAgentId$);
+});
+
+export const markEagerInitialized$ = command(
+  ({ set }, agentId: string | null) => {
+    set(internalEagerInitialized$, true);
+    set(internalEagerInitializedAgentId$, agentId);
+  },
+);
+
 export const zeroOnboardingStep$ = computed(async (get) => {
   const userStep = get(userStep$);
   if (userStep !== null) {
@@ -182,6 +211,8 @@ export const resetOnboardingStep$ = command(({ set }) => {
   set(internalConnectorsFromUrl$, false);
   set(internalUseCaseMode$, false);
   set(internalPromptDraft$, "");
+  set(internalEagerInitialized$, false);
+  set(internalEagerInitializedAgentId$, null);
 });
 
 /**

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-onboarding.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-onboarding.test.tsx
@@ -9,7 +9,10 @@ import {
   click,
 } from "../../../__tests__/page-helper.ts";
 import { createMockApi } from "../../../mocks/msw-contract.ts";
-import { onboardingStatusContract } from "@vm0/api-contracts/contracts/onboarding";
+import {
+  onboardingSetupContract,
+  onboardingStatusContract,
+} from "@vm0/api-contracts/contracts/onboarding";
 import { pathname$ } from "../../../signals/route.ts";
 
 const context = testContext();
@@ -25,6 +28,13 @@ function mockOnboardingNeeded() {
         hasDefaultAgent: false,
         defaultAgentId: null,
         defaultAgentMetadata: null,
+      });
+    }),
+    // Step 1 Next eagerly provisions the workspace — every test that walks
+    // past step 1 needs this mock available.
+    mockApi(onboardingSetupContract.setup, ({ respond }) => {
+      return respond(200, {
+        agentId: "d0000000-0000-4000-a000-000000000001",
       });
     }),
   );
@@ -487,8 +497,8 @@ describe("connector polling status shows (AGENT-D-059)", () => {
 // AGENT-D-068: Back button returns to previous step
 // ---------------------------------------------------------------------------
 
-describe("back button returns to previous step (AGENT-D-068)", () => {
-  it("back button returns to step 1 from step 2", async () => {
+describe("back button hidden after eager init (AGENT-D-068)", () => {
+  it("step 1 Next eagerly provisions the workspace; no Back button on step 2", async () => {
     mockOnboardingNeeded();
     await renderOnboardingPage();
 
@@ -503,14 +513,9 @@ describe("back button returns to previous step (AGENT-D-068)", () => {
       ).toBeInTheDocument();
     });
 
-    // Click Back
-    click(screen.getByText("Back"));
-
-    await waitFor(() => {
-      expect(
-        screen.getByTestId("onboarding-step-workspace-name"),
-      ).toBeInTheDocument();
-    });
+    // The workspace + default agent have already been created — going back
+    // to rename the workspace would be misleading, so Back is hidden.
+    expect(screen.queryByText("Back")).not.toBeInTheDocument();
   });
 });
 
@@ -580,7 +585,7 @@ describe("connectors via URL skip step 2", () => {
     });
   });
 
-  it("admin: back from step 3 returns to step 1 when connectors via URL", async () => {
+  it("admin: no Back button on step 3 when connectors via URL (eager init done)", async () => {
     mockOnboardingNeeded();
     detachedSetupPage({ context, path: "/onboarding?connector=slack" });
 
@@ -593,14 +598,8 @@ describe("connectors via URL skip step 2", () => {
       expect(screen.getByTestId("onboarding-step-connect")).toBeInTheDocument();
     });
 
-    click(screen.getByText("Back"));
-
-    // Should go back to step 1 (skipping step 2)
-    await waitFor(() => {
-      expect(
-        screen.getByTestId("onboarding-step-workspace-name"),
-      ).toBeInTheDocument();
-    });
+    // Workspace provisioned at step 1; Back is hidden.
+    expect(screen.queryByText("Back")).not.toBeInTheDocument();
   });
 
   it("falls back to normal flow when no valid URL connectors", async () => {


### PR DESCRIPTION
## Summary

Provision the workspace + default agent the moment the admin clicks Next on step 1 of onboarding, instead of deferring to the final step. The user can never roll back past it (Back is hidden), and the dialog stays mounted through the rest of the flow even though the server has already flipped `needsOnboarding` to false.

Follow-up to #13051: that PR introduced the use-case "Try It" dialog but kept setup-at-the-end semantics. The admin's typed workspace name was only persisted when they reached step 4, which made the flow feel laggy for use-case deep links and meant a refresh between step 1 and step 4 lost the typed name.

## Changes

- `markEagerInitialized$` flips a new `internalEagerInitialized$` signal and remembers the agentId returned by setup, so later continue-in-web / try-it paths skip the duplicate setup call.
- `onboardingIsAdmin$` is now sticky (`eagerInit || zeroNeedsOnboarding$`) so view-layer step decisions stay on the admin track after eager init, even though the server flips `needsOnboarding` false.
- `onboardingShowBack$` returns false post-eager-init.
- `onboardingShowDialog$` keeps the dialog mounted on the (sticky) admin track.
- `onboardingBackendWillAuthorizeConnectors$` post-eager-init returns true only in use-case mode (the URL connectors were bulk-authorized at step 1 and step 3 doesn't let the user pick more). In the regular flow it flips false so each Connect runs the per-connector permission dialog for fresh picks.
- `completeOnboarding$` in `continue-in-web` / `try-it` paths short-circuits when `eagerInit` is true and returns the captured agentId — avoids re-calling setup (which would 409 on the existing workspace) and avoids a stale-status round-trip.
- `onboardGuard$` short-circuits when `eagerInit` is true, preventing the cached pre-init status from bouncing the user back to `/onboarding` on their first navigation away.

Member-joining-existing-org path is unaffected: members never see step 1, so `eagerInit` stays false and they continue to call `completeMemberOnboarding$` at the final step.

## Test plan

- [x] `pnpm -F @vm0/app exec vitest run src/signals/zero-page/__tests__/onboarding-use-case-mode.test.ts` — 21/21 (7 new cases for eager-init: setup-on-step-1 advances to step 3 / step 2, Back hidden, dialog stays open, suppression on for use-case after eager init, suppression off for regular flow after eager init, Try It on step 3 does not re-call setup)
- [x] `pnpm -F @vm0/app exec vitest run src/signals/` — 456/456
- [x] `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/` — 1158/1158 (rewrote two Back-button regression tests to assert "no Back after eager init" instead of "Back returns to step 1")
- [x] `pnpm check-types` — clean
- [x] `pnpm lint` — clean
- [ ] Manual: `https://app.vm0.ai/onboarding?prompt=...&connector=github` as a fresh admin — verify clicking Next on step 1 (a) hits `/onboarding/setup`, (b) hides Back, (c) keeps the dialog open through step 3, (d) Try It does not re-call setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)