### PR TITLE
docs(runner): document network log drain producers

### DIFF
--- a/crates/runner/src/dns.rs
+++ b/crates/runner/src/dns.rs
@@ -54,7 +54,11 @@ impl DnsProxy {
         self.port
     }
 
-    pub fn drain_producer(&self) -> NetworkLogDrainProducer {
+    /// Return a clone of the DNS network-log drain producer.
+    ///
+    /// `NetworkLogDrainCoordinator` uses this to ask the dnsmasq stderr reader
+    /// task to drain complete log rows already visible to that task.
+    pub(crate) fn drain_producer(&self) -> NetworkLogDrainProducer {
         self.drain.clone()
     }
 

--- a/crates/runner/src/kmsg_log.rs
+++ b/crates/runner/src/kmsg_log.rs
@@ -69,7 +69,11 @@ impl KmsgHandle {
         }
     }
 
-    pub fn drain_producer(&self) -> NetworkLogDrainProducer {
+    /// Return a clone of the kmsg network-log drain producer.
+    ///
+    /// `NetworkLogDrainCoordinator` uses this to ask the `dmesg -w` reader
+    /// task to drain complete log rows already visible to that task.
+    pub(crate) fn drain_producer(&self) -> NetworkLogDrainProducer {
         self.drain.clone()
     }
 }


### PR DESCRIPTION
## Summary
- tighten DNS and kmsg drain producer helpers to crate visibility
- document both producers as NetworkLogDrainCoordinator inputs
- keep drain semantics scoped to rows already visible to the runner reader tasks

## Tests
- cargo fmt --manifest-path crates/Cargo.toml --all --check
- cargo test --manifest-path crates/Cargo.toml -p runner

Closes #13024