### PR TITLE
feat(api): migrate zero chat messages route

### DIFF
--- a/turbo/apps/api/src/lib/error.ts
+++ b/turbo/apps/api/src/lib/error.ts
@@ -38,6 +38,14 @@ export function providerDeleted() {
   );
 }
 
+export function insufficientCredits() {
+  return httpError(
+    402,
+    "INSUFFICIENT_CREDITS",
+    "Insufficient credits. Add credits or configure your own API key to continue.",
+  );
+}
+
 export function badRequestMessage(message: string) {
   return httpError(400, "BAD_REQUEST", message);
 }

--- a/turbo/apps/api/src/lib/error.ts
+++ b/turbo/apps/api/src/lib/error.ts
@@ -30,6 +30,14 @@ export function providerUnavailable(message: string) {
   return httpError(503, "PROVIDER_UNAVAILABLE", message);
 }
 
+export function providerDeleted() {
+  return httpError(
+    422,
+    "PROVIDER_DELETED",
+    "The selected model provider is no longer available",
+  );
+}
+
 export function badRequestMessage(message: string) {
   return httpError(400, "BAD_REQUEST", message);
 }

--- a/turbo/apps/api/src/signals/auth/tokens.ts
+++ b/turbo/apps/api/src/signals/auth/tokens.ts
@@ -4,6 +4,8 @@ import {
   ZERO_CAPABILITIES,
   ZeroCapability,
 } from "@vm0/api-contracts/contracts/composes";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import { isFeatureEnabled } from "@vm0/core/feature-switch";
 import { z } from "zod";
 
 import { env } from "../../lib/env";
@@ -19,6 +21,16 @@ import { singleton } from "../../lib/singleton";
 
 const SANDBOX_TOKEN_PREFIX = "vm0_sandbox_";
 const PAT_TOKEN_PREFIX = "vm0_pat_";
+
+const CONDITIONAL_CAPABILITIES = [
+  ["computer-use:write", FeatureSwitchKey.ComputerUse],
+] as const satisfies readonly (readonly [ZeroCapability, FeatureSwitchKey])[];
+
+const AGENT_EXCLUDED_CAPABILITIES = [
+  "schedule:delete",
+  "agent-run:write",
+  "agent:delete",
+] as const satisfies readonly ZeroCapability[];
 
 const jwtBaseSchema = z.object({
   userId: z.string().min(1),
@@ -225,6 +237,47 @@ export function generateSandboxToken(
     userId,
     runId,
     orgId,
+    iat: nowSeconds,
+    exp: nowSeconds + 2 * 60 * 60,
+  };
+
+  return SANDBOX_TOKEN_PREFIX + signJwt(payload);
+}
+
+export function generateZeroToken(
+  userId: string,
+  runId: string,
+  orgId: string,
+  overrides?: Partial<Record<FeatureSwitchKey, boolean>>,
+): string {
+  const nowSeconds = Math.floor(now() / 1000);
+  const capabilities: ZeroCapability[] = [];
+  for (const capability of ZERO_CAPABILITIES) {
+    if (
+      AGENT_EXCLUDED_CAPABILITIES.some((excludedCapability) => {
+        return excludedCapability === capability;
+      })
+    ) {
+      continue;
+    }
+    const conditionalCapability = CONDITIONAL_CAPABILITIES.find((entry) => {
+      return entry[0] === capability;
+    });
+    const flag = conditionalCapability?.[1];
+    if (
+      flag === undefined ||
+      isFeatureEnabled(flag, { userId, orgId, overrides })
+    ) {
+      capabilities.push(capability);
+    }
+  }
+
+  const payload: z.infer<typeof zeroTokenPayloadSchema> = {
+    scope: "zero",
+    userId,
+    runId,
+    orgId,
+    capabilities,
     iat: nowSeconds,
     exp: nowSeconds + 2 * 60 * 60,
   };

--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -49,6 +49,7 @@ import { zeroBillingPortalRoutes } from "./routes/zero-billing-portal";
 import { zeroBillingRedeemRoutes } from "./routes/zero-billing-redeem";
 import { zeroBillingStatusRoutes } from "./routes/zero-billing-status";
 import { zeroChatThreadRoutes } from "./routes/zero-chat-threads";
+import { zeroChatMessagesRoutes } from "./routes/zero-chat-messages";
 import { zeroComposesRoutes } from "./routes/zero-composes";
 import { zeroComputerUseRoutes } from "./routes/zero-computer-use";
 import { zeroConnectorsRoutes } from "./routes/zero-connectors";
@@ -182,6 +183,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...zeroBillingRedeemRoutes,
   ...zeroBillingStatusRoutes,
   ...zeroChatThreadRoutes,
+  ...zeroChatMessagesRoutes,
   ...zeroComposesRoutes,
   ...zeroComputerUseRoutes,
   ...zeroConnectorsRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-chat-messages.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-chat-messages.test.ts
@@ -12,6 +12,7 @@ import { chatMessages } from "@vm0/db/schema/chat-message";
 import { chatThreads } from "@vm0/db/schema/chat-thread";
 import { modelProviders } from "@vm0/db/schema/model-provider";
 import { orgMembersMetadata } from "@vm0/db/schema/org-members-metadata";
+import { orgMetadata } from "@vm0/db/schema/org-metadata";
 import { orgModelPolicies } from "@vm0/db/schema/org-model-policy";
 import { runnerJobQueue } from "@vm0/db/schema/runner-job-queue";
 import { secrets } from "@vm0/db/schema/secret";
@@ -183,6 +184,7 @@ async function deleteFixture(fixture: ChatMessageFixture): Promise<void> {
         eq(orgMembersMetadata.userId, fixture.userId),
       ),
     );
+  await writeDb.delete(orgMetadata).where(eq(orgMetadata.orgId, fixture.orgId));
   await writeDb
     .delete(orgModelPolicies)
     .where(eq(orgModelPolicies.orgId, fixture.orgId));
@@ -280,6 +282,36 @@ async function seedModelProvider(
     })
     .returning({ id: modelProviders.id });
   return provider!.id;
+}
+
+async function seedVm0Credits(
+  fixture: ChatMessageFixture,
+  credits: number,
+  creditEnabled = true,
+): Promise<void> {
+  const writeDb = store.set(writeDb$);
+  await writeDb
+    .insert(orgMetadata)
+    .values({
+      orgId: fixture.orgId,
+      credits,
+      tier: "free",
+    })
+    .onConflictDoUpdate({
+      target: orgMetadata.orgId,
+      set: { credits, tier: "free", updatedAt: nowDate() },
+    });
+  await writeDb
+    .insert(orgMembersMetadata)
+    .values({
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      creditEnabled,
+    })
+    .onConflictDoUpdate({
+      target: [orgMembersMetadata.orgId, orgMembersMetadata.userId],
+      set: { creditEnabled, updatedAt: nowDate() },
+    });
 }
 
 describe("POST /api/zero/chat/messages", () => {
@@ -832,6 +864,7 @@ describe("POST /api/zero/chat/messages", () => {
   it("forceNewSession rewrites the model pin and injects prior chat context", async () => {
     const fixture = await track(seedFixture());
     const writeDb = store.set(writeDb$);
+    await seedVm0Credits(fixture, 1000);
     await writeDb.insert(userFeatureSwitches).values({
       orgId: fixture.orgId,
       userId: fixture.userId,
@@ -897,6 +930,46 @@ describe("POST /api/zero/chat/messages", () => {
     expect(run?.selectedModel).toBe("claude-sonnet-4-6");
     expect(run?.appendSystemPrompt).toContain("# Prior Chat Thread Context");
     expect(run?.appendSystemPrompt).toContain("User: first on opus");
+  });
+
+  it("returns 402 when VM0 model-first admission has no spendable credits", async () => {
+    const fixture = await track(seedFixture());
+    const writeDb = store.set(writeDb$);
+    await seedVm0Credits(fixture, 0);
+    await writeDb.insert(userFeatureSwitches).values({
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      switches: { modelFirstModelProvider: true },
+      updatedAt: nowDate(),
+    });
+    await writeDb.insert(orgModelPolicies).values({
+      orgId: fixture.orgId,
+      model: "claude-sonnet-4-6",
+      isDefault: true,
+      defaultProviderType: "vm0",
+      credentialScope: "org",
+      createdByUserId: fixture.userId,
+      updatedByUserId: fixture.userId,
+    });
+
+    const response = await accept(
+      client().send({
+        headers: authHeaders(),
+        body: {
+          agentId: fixture.agentId,
+          prompt: "blocked by credits",
+        },
+      }),
+      [402],
+    );
+
+    expect(response.body.error.code).toBe("INSUFFICIENT_CREDITS");
+    const [run] = await writeDb
+      .select({ id: agentRuns.id })
+      .from(agentRuns)
+      .where(eq(agentRuns.userId, fixture.userId))
+      .limit(1);
+    expect(run).toBeUndefined();
   });
 
   it("locks an existing provider-first thread to its first model selection", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-chat-messages.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-chat-messages.test.ts
@@ -1,0 +1,566 @@
+import { randomUUID } from "node:crypto";
+
+import { chatMessagesContract } from "@vm0/api-contracts/contracts/chat-threads";
+import {
+  agentComposes,
+  agentComposeVersions,
+} from "@vm0/db/schema/agent-compose";
+import { agentRunCallbacks } from "@vm0/db/schema/agent-run-callback";
+import { agentRuns } from "@vm0/db/schema/agent-run";
+import { agentSessions } from "@vm0/db/schema/agent-session";
+import { chatMessages } from "@vm0/db/schema/chat-message";
+import { chatThreads } from "@vm0/db/schema/chat-thread";
+import { orgMembersMetadata } from "@vm0/db/schema/org-members-metadata";
+import { orgModelPolicies } from "@vm0/db/schema/org-model-policy";
+import { runnerJobQueue } from "@vm0/db/schema/runner-job-queue";
+import { userFeatureSwitches } from "@vm0/db/schema/user-feature-switches";
+import { zeroAgents } from "@vm0/db/schema/zero-agent";
+import { zeroRuns } from "@vm0/db/schema/zero-run";
+import { createStore } from "ccstate";
+import { and, eq, inArray, isNull } from "drizzle-orm";
+import { describe, expect, it } from "vitest";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { mockEnv, mockOptionalEnv } from "../../../lib/env";
+import {
+  decryptSecretValue,
+  decryptSecretsMap,
+} from "../../services/crypto.utils";
+import { writeDb$ } from "../../external/db";
+import { nowDate } from "../../external/time";
+import { clearAllDetached } from "../../utils";
+import {
+  createFixtureTracker,
+  createZeroRouteMocks,
+} from "./helpers/zero-route-test";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+
+interface ChatMessageFixture {
+  readonly userId: string;
+  readonly orgId: string;
+  readonly agentId: string;
+  readonly versionId: string;
+}
+
+const track = createFixtureTracker<ChatMessageFixture>(deleteFixture);
+
+function client() {
+  return setupApp({ context })(chatMessagesContract);
+}
+
+function authHeaders() {
+  return { authorization: "Bearer clerk-session" };
+}
+
+function encryptedSecretsFromExecutionContext(value: unknown): string | null {
+  if (
+    typeof value === "object" &&
+    value !== null &&
+    "encryptedSecrets" in value
+  ) {
+    const encryptedSecrets = (value as { encryptedSecrets: unknown })
+      .encryptedSecrets;
+    return typeof encryptedSecrets === "string" ? encryptedSecrets : null;
+  }
+  return null;
+}
+
+function vm0Template(expression: string): string {
+  return `$${expression}`;
+}
+
+async function seedFixture(): Promise<ChatMessageFixture> {
+  const userId = `user_${randomUUID()}`;
+  const orgId = `org_${randomUUID()}`;
+  const agentId = randomUUID();
+  const versionId = randomUUID();
+  const name = `agent-${agentId.slice(0, 8)}`;
+  const writeDb = store.set(writeDb$);
+
+  await writeDb.insert(agentComposes).values({
+    id: agentId,
+    userId,
+    orgId,
+    name,
+    headVersionId: versionId,
+  });
+  await writeDb.insert(agentComposeVersions).values({
+    id: versionId,
+    composeId: agentId,
+    createdBy: userId,
+    content: {
+      version: "1.0",
+      agents: {
+        [name]: {
+          framework: "claude-code",
+          environment: {
+            ANTHROPIC_API_KEY: "test-key",
+            ZERO_AGENT_ID: vm0Template("{{ vars.ZERO_AGENT_ID }}"),
+            ZERO_TOKEN: vm0Template("{{ secrets.ZERO_TOKEN }}"),
+          },
+        },
+      },
+    },
+  });
+  await writeDb.insert(zeroAgents).values({
+    id: agentId,
+    orgId,
+    owner: userId,
+    name,
+    visibility: "public",
+  });
+
+  mocks.clerk.session(userId, orgId);
+  context.mocks.s3.send.mockResolvedValue({});
+  mockEnv("VM0_API_URL", "http://localhost:3000");
+  mockOptionalEnv("RUNNER_DEFAULT_GROUP", "vm0/test");
+
+  return { userId, orgId, agentId, versionId };
+}
+
+async function deleteFixture(fixture: ChatMessageFixture): Promise<void> {
+  const writeDb = store.set(writeDb$);
+  const threadRows = await writeDb
+    .select({ id: chatThreads.id })
+    .from(chatThreads)
+    .where(eq(chatThreads.userId, fixture.userId));
+  const threadIds = threadRows.map((row) => {
+    return row.id;
+  });
+  const runRows = await writeDb
+    .select({ id: agentRuns.id })
+    .from(agentRuns)
+    .where(eq(agentRuns.userId, fixture.userId));
+  const runIds = runRows.map((row) => {
+    return row.id;
+  });
+
+  if (runIds.length > 0) {
+    await writeDb
+      .delete(runnerJobQueue)
+      .where(inArray(runnerJobQueue.runId, runIds));
+    await writeDb
+      .delete(agentRunCallbacks)
+      .where(inArray(agentRunCallbacks.runId, runIds));
+  }
+  if (threadIds.length > 0) {
+    await writeDb
+      .delete(chatMessages)
+      .where(inArray(chatMessages.chatThreadId, threadIds));
+  }
+  if (runIds.length > 0) {
+    await writeDb.delete(zeroRuns).where(inArray(zeroRuns.id, runIds));
+    await writeDb.delete(agentRuns).where(inArray(agentRuns.id, runIds));
+  }
+  await writeDb
+    .delete(agentSessions)
+    .where(eq(agentSessions.userId, fixture.userId));
+  if (threadIds.length > 0) {
+    await writeDb.delete(chatThreads).where(inArray(chatThreads.id, threadIds));
+  }
+  await writeDb
+    .delete(userFeatureSwitches)
+    .where(
+      and(
+        eq(userFeatureSwitches.orgId, fixture.orgId),
+        eq(userFeatureSwitches.userId, fixture.userId),
+      ),
+    );
+  await writeDb
+    .delete(orgMembersMetadata)
+    .where(
+      and(
+        eq(orgMembersMetadata.orgId, fixture.orgId),
+        eq(orgMembersMetadata.userId, fixture.userId),
+      ),
+    );
+  await writeDb
+    .delete(orgModelPolicies)
+    .where(eq(orgModelPolicies.orgId, fixture.orgId));
+  await writeDb.delete(zeroAgents).where(eq(zeroAgents.id, fixture.agentId));
+  await writeDb
+    .delete(agentComposeVersions)
+    .where(eq(agentComposeVersions.composeId, fixture.agentId));
+  await writeDb
+    .delete(agentComposes)
+    .where(eq(agentComposes.id, fixture.agentId));
+}
+
+function send(body: Record<string, unknown>) {
+  return accept(
+    client().send({
+      headers: authHeaders(),
+      body: body as never,
+    }),
+    [201],
+  );
+}
+
+async function firstUserMessage(threadId: string) {
+  const [message] = await store
+    .set(writeDb$)
+    .select({
+      id: chatMessages.id,
+      content: chatMessages.content,
+      runId: chatMessages.runId,
+      revokesMessageId: chatMessages.revokesMessageId,
+      interruptsRunId: chatMessages.interruptsRunId,
+      goalRemainingTurns: chatMessages.goalRemainingTurns,
+      goalOriginMessageId: chatMessages.goalOriginMessageId,
+    })
+    .from(chatMessages)
+    .where(eq(chatMessages.chatThreadId, threadId))
+    .orderBy(chatMessages.createdAt)
+    .limit(1);
+  return message;
+}
+
+async function setRunStatus(runId: string, status: string): Promise<void> {
+  await store
+    .set(writeDb$)
+    .update(agentRuns)
+    .set({ status, completedAt: nowDate() })
+    .where(eq(agentRuns.id, runId));
+}
+
+describe("POST /api/zero/chat/messages", () => {
+  it("returns 401 without auth", async () => {
+    context.mocks.clerk.authenticateRequest.mockResolvedValue({
+      isAuthenticated: false,
+    });
+
+    const response = await accept(
+      client().send({
+        headers: {},
+        body: { agentId: randomUUID(), prompt: "hello" },
+      }),
+      [401],
+    );
+
+    expect(response.body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("creates a thread, run, callback, ZERO_TOKEN secret, and user message", async () => {
+    const fixture = await track(seedFixture());
+
+    const response = await send({
+      agentId: fixture.agentId,
+      prompt: "hello from api chat",
+    });
+    await clearAllDetached();
+
+    expect(response.body.runId).toStrictEqual(expect.any(String));
+    expect(response.body.threadId).toStrictEqual(expect.any(String));
+
+    const writeDb = store.set(writeDb$);
+    const [run] = await writeDb
+      .select({
+        prompt: agentRuns.prompt,
+        appendSystemPrompt: agentRuns.appendSystemPrompt,
+        triggerSource: zeroRuns.triggerSource,
+        chatThreadId: zeroRuns.chatThreadId,
+      })
+      .from(agentRuns)
+      .innerJoin(zeroRuns, eq(zeroRuns.id, agentRuns.id))
+      .where(eq(agentRuns.id, response.body.runId!))
+      .limit(1);
+    expect(run).toStrictEqual({
+      prompt: "hello from api chat",
+      appendSystemPrompt: expect.stringContaining(
+        "You are currently running inside: Web",
+      ),
+      triggerSource: "web",
+      chatThreadId: response.body.threadId,
+    });
+
+    const message = await firstUserMessage(response.body.threadId);
+    expect(message).toMatchObject({
+      content: "hello from api chat",
+      runId: response.body.runId,
+      revokesMessageId: null,
+      interruptsRunId: null,
+    });
+
+    const [callback] = await writeDb
+      .select({
+        url: agentRunCallbacks.url,
+        encryptedSecret: agentRunCallbacks.encryptedSecret,
+        payload: agentRunCallbacks.payload,
+      })
+      .from(agentRunCallbacks)
+      .where(eq(agentRunCallbacks.runId, response.body.runId!))
+      .limit(1);
+    expect(callback?.url).toBe(
+      "http://localhost:3000/api/internal/callbacks/chat",
+    );
+    expect(decryptSecretValue(callback!.encryptedSecret)).toHaveLength(64);
+    expect(callback?.payload).toStrictEqual({
+      threadId: response.body.threadId,
+      agentId: fixture.agentId,
+    });
+
+    const [job] = await writeDb
+      .select({ executionContext: runnerJobQueue.executionContext })
+      .from(runnerJobQueue)
+      .where(eq(runnerJobQueue.runId, response.body.runId!))
+      .limit(1);
+    const secrets = decryptSecretsMap(
+      encryptedSecretsFromExecutionContext(job?.executionContext),
+    );
+    expect(secrets?.ZERO_TOKEN).toMatch(/^vm0_sandbox_/);
+    expect(context.mocks.ably.publish).toHaveBeenCalledWith(
+      `chatThreadMessageCreated:${response.body.threadId}`,
+      null,
+    );
+    expect(context.mocks.ably.publish).toHaveBeenCalledWith(
+      `chatThreadRunCreated:${response.body.threadId}`,
+      null,
+    );
+  });
+
+  it("queues an unassociated user message when the thread has an active run", async () => {
+    const fixture = await track(seedFixture());
+    const first = await send({ agentId: fixture.agentId, prompt: "first" });
+    await clearAllDetached();
+
+    const second = await send({
+      agentId: fixture.agentId,
+      prompt: "queued",
+      threadId: first.body.threadId,
+    });
+
+    expect(second.body.runId).toBeNull();
+    const [queued] = await store
+      .set(writeDb$)
+      .select({
+        content: chatMessages.content,
+        runId: chatMessages.runId,
+        revokesMessageId: chatMessages.revokesMessageId,
+      })
+      .from(chatMessages)
+      .where(
+        and(
+          eq(chatMessages.chatThreadId, first.body.threadId),
+          eq(chatMessages.content, "queued"),
+        ),
+      )
+      .limit(1);
+    expect(queued).toStrictEqual({
+      content: "queued",
+      runId: null,
+      revokesMessageId: null,
+    });
+  });
+
+  it("recalls only queued user messages", async () => {
+    const fixture = await track(seedFixture());
+    const first = await send({ agentId: fixture.agentId, prompt: "first" });
+    await clearAllDetached();
+    await send({
+      agentId: fixture.agentId,
+      prompt: "queued for recall",
+      threadId: first.body.threadId,
+    });
+
+    const [queued] = await store
+      .set(writeDb$)
+      .select({ id: chatMessages.id })
+      .from(chatMessages)
+      .where(
+        and(
+          eq(chatMessages.chatThreadId, first.body.threadId),
+          eq(chatMessages.content, "queued for recall"),
+          isNull(chatMessages.runId),
+        ),
+      )
+      .limit(1);
+
+    const recallId = randomUUID();
+    const recall = await send({
+      agentId: fixture.agentId,
+      threadId: first.body.threadId,
+      revokesMessageId: queued!.id,
+      clientMessageId: recallId,
+    });
+    expect(recall.body.runId).toBeNull();
+
+    const [recallMessage] = await store
+      .set(writeDb$)
+      .select({
+        id: chatMessages.id,
+        runId: chatMessages.runId,
+        content: chatMessages.content,
+        revokesMessageId: chatMessages.revokesMessageId,
+      })
+      .from(chatMessages)
+      .where(eq(chatMessages.id, recallId))
+      .limit(1);
+    expect(recallMessage).toStrictEqual({
+      id: recallId,
+      runId: null,
+      content: null,
+      revokesMessageId: queued!.id,
+    });
+  });
+
+  it("interrupts and cancels an active chat run", async () => {
+    const fixture = await track(seedFixture());
+    const first = await send({ agentId: fixture.agentId, prompt: "first" });
+    await clearAllDetached();
+
+    const interruptId = randomUUID();
+    const interrupt = await send({
+      agentId: fixture.agentId,
+      threadId: first.body.threadId,
+      interruptsRunId: first.body.runId,
+      clientMessageId: interruptId,
+    });
+    expect(interrupt.body.runId).toBeNull();
+
+    const writeDb = store.set(writeDb$);
+    const [run] = await writeDb
+      .select({ status: agentRuns.status })
+      .from(agentRuns)
+      .where(eq(agentRuns.id, first.body.runId!))
+      .limit(1);
+    expect(run?.status).toBe("cancelled");
+
+    const [message] = await writeDb
+      .select({
+        id: chatMessages.id,
+        content: chatMessages.content,
+        runId: chatMessages.runId,
+        interruptsRunId: chatMessages.interruptsRunId,
+      })
+      .from(chatMessages)
+      .where(eq(chatMessages.id, interruptId))
+      .limit(1);
+    expect(message).toStrictEqual({
+      id: interruptId,
+      content: null,
+      runId: null,
+      interruptsRunId: first.body.runId,
+    });
+  });
+
+  it("injects incomplete cancelled rounds into the next run prompt", async () => {
+    const fixture = await track(seedFixture());
+    const first = await send({ agentId: fixture.agentId, prompt: "cancel me" });
+    await clearAllDetached();
+    await setRunStatus(first.body.runId!, "cancelled");
+
+    const second = await send({
+      agentId: fixture.agentId,
+      prompt: "retry",
+      threadId: first.body.threadId,
+    });
+    await clearAllDetached();
+
+    const [run] = await store
+      .set(writeDb$)
+      .select({ appendSystemPrompt: agentRuns.appendSystemPrompt })
+      .from(agentRuns)
+      .where(eq(agentRuns.id, second.body.runId!))
+      .limit(1);
+    expect(run?.appendSystemPrompt).toContain("# Incomplete Rounds Context");
+    expect(run?.appendSystemPrompt).toContain("RUN_STATUS: cancelled");
+    expect(run?.appendSystemPrompt).toContain("User: cancel me");
+  });
+
+  it("persists goal columns for goal sends when the feature is enabled", async () => {
+    const fixture = await track(seedFixture());
+    await store
+      .set(writeDb$)
+      .insert(userFeatureSwitches)
+      .values({
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        switches: { goal: true },
+        updatedAt: nowDate(),
+      });
+
+    const response = await send({
+      agentId: fixture.agentId,
+      prompt: "finish the migration",
+      goal: true,
+    });
+    await clearAllDetached();
+
+    const message = await firstUserMessage(response.body.threadId);
+    expect(message?.goalRemainingTurns).toBe(10);
+    expect(message?.goalOriginMessageId).toBe(message?.id);
+  });
+
+  it("forceNewSession rewrites the model pin and injects prior chat context", async () => {
+    const fixture = await track(seedFixture());
+    const writeDb = store.set(writeDb$);
+    await writeDb.insert(userFeatureSwitches).values({
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      switches: { modelFirstModelProvider: true },
+      updatedAt: nowDate(),
+    });
+    await writeDb.insert(orgModelPolicies).values([
+      {
+        orgId: fixture.orgId,
+        model: "claude-opus-4-7",
+        isDefault: true,
+        defaultProviderType: "vm0",
+        credentialScope: "org",
+        createdByUserId: fixture.userId,
+        updatedByUserId: fixture.userId,
+      },
+      {
+        orgId: fixture.orgId,
+        model: "claude-sonnet-4-6",
+        isDefault: false,
+        defaultProviderType: "vm0",
+        credentialScope: "org",
+        createdByUserId: fixture.userId,
+        updatedByUserId: fixture.userId,
+      },
+    ]);
+
+    const first = await send({
+      agentId: fixture.agentId,
+      prompt: "first on opus",
+    });
+    await clearAllDetached();
+    await setRunStatus(first.body.runId!, "completed");
+
+    const second = await send({
+      agentId: fixture.agentId,
+      prompt: "now on sonnet",
+      threadId: first.body.threadId,
+      modelSelection: {
+        modelProviderId: "00000000-0000-4000-8000-000000000000",
+        selectedModel: "claude-sonnet-4-6",
+      },
+      forceNewSession: true,
+    });
+    await clearAllDetached();
+
+    const [thread] = await writeDb
+      .select({ selectedModel: chatThreads.selectedModel })
+      .from(chatThreads)
+      .where(eq(chatThreads.id, first.body.threadId))
+      .limit(1);
+    expect(thread?.selectedModel).toBe("claude-sonnet-4-6");
+
+    const [run] = await writeDb
+      .select({
+        selectedModel: zeroRuns.selectedModel,
+        appendSystemPrompt: agentRuns.appendSystemPrompt,
+      })
+      .from(zeroRuns)
+      .innerJoin(agentRuns, eq(agentRuns.id, zeroRuns.id))
+      .where(eq(zeroRuns.id, second.body.runId!))
+      .limit(1);
+    expect(run?.selectedModel).toBe("claude-sonnet-4-6");
+    expect(run?.appendSystemPrompt).toContain("# Prior Chat Thread Context");
+    expect(run?.appendSystemPrompt).toContain("User: first on opus");
+  });
+});

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-chat-messages.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-chat-messages.test.ts
@@ -10,18 +10,23 @@ import { agentRuns } from "@vm0/db/schema/agent-run";
 import { agentSessions } from "@vm0/db/schema/agent-session";
 import { chatMessages } from "@vm0/db/schema/chat-message";
 import { chatThreads } from "@vm0/db/schema/chat-thread";
+import { modelProviders } from "@vm0/db/schema/model-provider";
 import { orgMembersMetadata } from "@vm0/db/schema/org-members-metadata";
 import { orgModelPolicies } from "@vm0/db/schema/org-model-policy";
 import { runnerJobQueue } from "@vm0/db/schema/runner-job-queue";
+import { secrets } from "@vm0/db/schema/secret";
 import { userFeatureSwitches } from "@vm0/db/schema/user-feature-switches";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
 import { createStore } from "ccstate";
 import { and, eq, inArray, isNull } from "drizzle-orm";
+import { http, HttpResponse } from "msw";
 import { describe, expect, it } from "vitest";
 
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
 import { mockEnv, mockOptionalEnv } from "../../../lib/env";
+import { server } from "../../../mocks/server";
+import { generateZeroToken, verifyZeroToken } from "../../auth/tokens";
 import {
   decryptSecretValue,
   decryptSecretsMap,
@@ -33,6 +38,7 @@ import {
   createFixtureTracker,
   createZeroRouteMocks,
 } from "./helpers/zero-route-test";
+import { encryptSecretForTests } from "./helpers/encrypt-secret";
 
 const context = testContext();
 const store = createStore();
@@ -180,6 +186,10 @@ async function deleteFixture(fixture: ChatMessageFixture): Promise<void> {
   await writeDb
     .delete(orgModelPolicies)
     .where(eq(orgModelPolicies.orgId, fixture.orgId));
+  await writeDb
+    .delete(modelProviders)
+    .where(eq(modelProviders.orgId, fixture.orgId));
+  await writeDb.delete(secrets).where(eq(secrets.orgId, fixture.orgId));
   await writeDb.delete(zeroAgents).where(eq(zeroAgents.id, fixture.agentId));
   await writeDb
     .delete(agentComposeVersions)
@@ -210,6 +220,7 @@ async function firstUserMessage(threadId: string) {
       interruptsRunId: chatMessages.interruptsRunId,
       goalRemainingTurns: chatMessages.goalRemainingTurns,
       goalOriginMessageId: chatMessages.goalOriginMessageId,
+      attachFiles: chatMessages.attachFiles,
     })
     .from(chatMessages)
     .where(eq(chatMessages.chatThreadId, threadId))
@@ -218,12 +229,57 @@ async function firstUserMessage(threadId: string) {
   return message;
 }
 
-async function setRunStatus(runId: string, status: string): Promise<void> {
+async function setRunStatus(
+  runId: string,
+  status: string,
+  result?: unknown,
+): Promise<void> {
   await store
     .set(writeDb$)
     .update(agentRuns)
-    .set({ status, completedAt: nowDate() })
+    .set({ status, completedAt: nowDate(), ...(result ? { result } : {}) })
     .where(eq(agentRuns.id, runId));
+}
+
+async function runExecutionSecrets(runId: string) {
+  const [job] = await store
+    .set(writeDb$)
+    .select({ executionContext: runnerJobQueue.executionContext })
+    .from(runnerJobQueue)
+    .where(eq(runnerJobQueue.runId, runId))
+    .limit(1);
+  return decryptSecretsMap(
+    encryptedSecretsFromExecutionContext(job?.executionContext),
+  );
+}
+
+async function seedModelProvider(
+  fixture: ChatMessageFixture,
+  selectedModel: string,
+): Promise<string> {
+  const writeDb = store.set(writeDb$);
+  const [secret] = await writeDb
+    .insert(secrets)
+    .values({
+      name: "ANTHROPIC_API_KEY",
+      encryptedValue: encryptSecretForTests("test-provider-key"),
+      type: "model-provider",
+      userId: fixture.userId,
+      orgId: fixture.orgId,
+    })
+    .returning({ id: secrets.id });
+  const [provider] = await writeDb
+    .insert(modelProviders)
+    .values({
+      type: "anthropic-api-key",
+      secretId: secret!.id,
+      isDefault: true,
+      selectedModel,
+      userId: fixture.userId,
+      orgId: fixture.orgId,
+    })
+    .returning({ id: modelProviders.id });
+  return provider!.id;
 }
 
 describe("POST /api/zero/chat/messages", () => {
@@ -241,6 +297,60 @@ describe("POST /api/zero/chat/messages", () => {
     );
 
     expect(response.body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("returns 403 for a zero token without agent-run:write", async () => {
+    const token = generateZeroToken(
+      `user_${randomUUID()}`,
+      randomUUID(),
+      `org_${randomUUID()}`,
+    );
+
+    const response = await accept(
+      client().send({
+        headers: { authorization: `Bearer ${token}` },
+        body: { agentId: randomUUID(), prompt: "hello" },
+      }),
+      [403],
+    );
+
+    expect(response.body.error.code).toBe("FORBIDDEN");
+    expect(response.body.error.message).toContain("agent-run:write");
+  });
+
+  it("returns 404 when the agent is missing", async () => {
+    const fixture = await track(seedFixture());
+
+    const response = await accept(
+      client().send({
+        headers: authHeaders(),
+        body: { agentId: randomUUID(), prompt: "hello" },
+      }),
+      [404],
+    );
+
+    expect(response.body.error.code).toBe("NOT_FOUND");
+    expect(fixture.agentId).toStrictEqual(expect.any(String));
+  });
+
+  it("returns 403 when a non-owner runs a private agent", async () => {
+    const fixture = await track(seedFixture());
+    await store
+      .set(writeDb$)
+      .update(zeroAgents)
+      .set({ visibility: "private" })
+      .where(eq(zeroAgents.id, fixture.agentId));
+    mocks.clerk.session(`user_${randomUUID()}`, fixture.orgId);
+
+    const response = await accept(
+      client().send({
+        headers: authHeaders(),
+        body: { agentId: fixture.agentId, prompt: "hello" },
+      }),
+      [403],
+    );
+
+    expect(response.body.error.code).toBe("FORBIDDEN");
   });
 
   it("creates a thread, run, callback, ZERO_TOKEN secret, and user message", async () => {
@@ -302,15 +412,11 @@ describe("POST /api/zero/chat/messages", () => {
       agentId: fixture.agentId,
     });
 
-    const [job] = await writeDb
-      .select({ executionContext: runnerJobQueue.executionContext })
-      .from(runnerJobQueue)
-      .where(eq(runnerJobQueue.runId, response.body.runId!))
-      .limit(1);
-    const secrets = decryptSecretsMap(
-      encryptedSecretsFromExecutionContext(job?.executionContext),
-    );
+    const secrets = await runExecutionSecrets(response.body.runId!);
     expect(secrets?.ZERO_TOKEN).toMatch(/^vm0_sandbox_/);
+    expect(verifyZeroToken(secrets!.ZERO_TOKEN!)?.capabilities).not.toContain(
+      "agent-run:write",
+    );
     expect(context.mocks.ably.publish).toHaveBeenCalledWith(
       `chatThreadMessageCreated:${response.body.threadId}`,
       null,
@@ -319,6 +425,122 @@ describe("POST /api/zero/chat/messages", () => {
       `chatThreadRunCreated:${response.body.threadId}`,
       null,
     );
+  });
+
+  it("preserves clientThreadId for new thread creation", async () => {
+    const fixture = await track(seedFixture());
+    const clientThreadId = randomUUID();
+
+    const response = await send({
+      agentId: fixture.agentId,
+      prompt: "client thread",
+      clientThreadId,
+    });
+    await clearAllDetached();
+
+    expect(response.body.threadId).toBe(clientThreadId);
+    const [thread] = await store
+      .set(writeDb$)
+      .select({
+        id: chatThreads.id,
+        agentComposeId: chatThreads.agentComposeId,
+        userId: chatThreads.userId,
+      })
+      .from(chatThreads)
+      .where(eq(chatThreads.id, clientThreadId))
+      .limit(1);
+    expect(thread).toStrictEqual({
+      id: clientThreadId,
+      agentComposeId: fixture.agentId,
+      userId: fixture.userId,
+    });
+  });
+
+  it("passes user feature switch overrides into generated ZERO_TOKEN capabilities", async () => {
+    const fixture = await track(seedFixture());
+    await store
+      .set(writeDb$)
+      .insert(userFeatureSwitches)
+      .values({
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        switches: { computerUse: true },
+        updatedAt: nowDate(),
+      });
+
+    const response = await send({
+      agentId: fixture.agentId,
+      prompt: "open remote browser",
+    });
+    await clearAllDetached();
+
+    const secrets = await runExecutionSecrets(response.body.runId!);
+    const zeroAuth = verifyZeroToken(secrets!.ZERO_TOKEN!);
+    expect(zeroAuth?.capabilities).toContain("computer-use:write");
+  });
+
+  it("persists attachments on the user message and injects them into the run prompt", async () => {
+    const fixture = await track(seedFixture());
+    const fileId = randomUUID();
+
+    const response = await send({
+      agentId: fixture.agentId,
+      prompt: "read this file",
+      attachFiles: [
+        {
+          id: fileId,
+          filename: "notes.txt",
+          contentType: "text/plain",
+          size: 42,
+        },
+      ],
+    });
+    await clearAllDetached();
+
+    const [run] = await store
+      .set(writeDb$)
+      .select({ prompt: agentRuns.prompt })
+      .from(agentRuns)
+      .where(eq(agentRuns.id, response.body.runId!))
+      .limit(1);
+    expect(run?.prompt).toContain("[Web file] notes.txt (text/plain)");
+    expect(run?.prompt).toContain(`[ID] ${fileId}`);
+
+    const message = await firstUserMessage(response.body.threadId);
+    expect(message?.content).toBe("read this file");
+    expect(message?.attachFiles).toStrictEqual([fileId]);
+  });
+
+  it("generates a chat thread title when the lightweight model is configured", async () => {
+    const fixture = await track(seedFixture());
+    mockOptionalEnv("OPENROUTER_API_KEY", "title-api-key");
+    let upstreamAuthorization: string | null = null;
+    server.use(
+      http.post(
+        "https://openrouter.ai/api/v1/chat/completions",
+        ({ request }) => {
+          upstreamAuthorization = request.headers.get("authorization");
+          return HttpResponse.json({
+            choices: [{ message: { content: "**Migration Plan**" } }],
+          });
+        },
+      ),
+    );
+
+    const response = await send({
+      agentId: fixture.agentId,
+      prompt: "plan the API migration",
+    });
+    await clearAllDetached();
+
+    expect(upstreamAuthorization).toBe("Bearer title-api-key");
+    const [thread] = await store
+      .set(writeDb$)
+      .select({ title: chatThreads.title })
+      .from(chatThreads)
+      .where(eq(chatThreads.id, response.body.threadId))
+      .limit(1);
+    expect(thread?.title).toBe("Migration Plan");
   });
 
   it("queues an unassociated user message when the thread has an active run", async () => {
@@ -352,6 +574,45 @@ describe("POST /api/zero/chat/messages", () => {
       content: "queued",
       runId: null,
       revokesMessageId: null,
+    });
+  });
+
+  it("creates a follow-up run on an existing thread and continues the last session", async () => {
+    const fixture = await track(seedFixture());
+    const first = await send({ agentId: fixture.agentId, prompt: "first" });
+    await clearAllDetached();
+
+    const [firstRun] = await store
+      .set(writeDb$)
+      .select({ sessionId: agentRuns.sessionId })
+      .from(agentRuns)
+      .where(eq(agentRuns.id, first.body.runId!))
+      .limit(1);
+    await setRunStatus(first.body.runId!, "completed", {
+      agentSessionId: firstRun!.sessionId,
+    });
+
+    const second = await send({
+      agentId: fixture.agentId,
+      prompt: "follow up",
+      threadId: first.body.threadId,
+    });
+    await clearAllDetached();
+
+    expect(second.body.runId).toStrictEqual(expect.any(String));
+    expect(second.body.runId).not.toBe(first.body.runId);
+    const [secondRun] = await store
+      .set(writeDb$)
+      .select({
+        sessionId: agentRuns.sessionId,
+        continuedFromSessionId: agentRuns.continuedFromSessionId,
+      })
+      .from(agentRuns)
+      .where(eq(agentRuns.id, second.body.runId!))
+      .limit(1);
+    expect(secondRun).toStrictEqual({
+      sessionId: firstRun!.sessionId,
+      continuedFromSessionId: firstRun!.sessionId,
     });
   });
 
@@ -404,6 +665,22 @@ describe("POST /api/zero/chat/messages", () => {
       content: null,
       revokesMessageId: queued!.id,
     });
+
+    const associated = await firstUserMessage(first.body.threadId);
+    const rejected = await accept(
+      client().send({
+        headers: authHeaders(),
+        body: {
+          agentId: fixture.agentId,
+          threadId: first.body.threadId,
+          revokesMessageId: associated!.id,
+          clientMessageId: randomUUID(),
+        },
+      }),
+      [400],
+    );
+    expect(rejected.body.error.code).toBe("BAD_REQUEST");
+    expect(rejected.body.error.message).toContain("queued user messages");
   });
 
   it("interrupts and cancels an active chat run", async () => {
@@ -468,6 +745,64 @@ describe("POST /api/zero/chat/messages", () => {
     expect(run?.appendSystemPrompt).toContain("# Incomplete Rounds Context");
     expect(run?.appendSystemPrompt).toContain("RUN_STATUS: cancelled");
     expect(run?.appendSystemPrompt).toContain("User: cancel me");
+  });
+
+  it("truncates old incomplete round content in chronological order", async () => {
+    const fixture = await track(seedFixture());
+    const first = await send({
+      agentId: fixture.agentId,
+      prompt: "first incomplete",
+    });
+    await clearAllDetached();
+    await setRunStatus(first.body.runId!, "failed");
+
+    const secondPrompt = `second ${"x".repeat(4100)}`;
+    const second = await send({
+      agentId: fixture.agentId,
+      prompt: secondPrompt,
+      threadId: first.body.threadId,
+    });
+    await clearAllDetached();
+    await setRunStatus(second.body.runId!, "timeout");
+
+    const third = await send({
+      agentId: fixture.agentId,
+      prompt: "retry after two failures",
+      threadId: first.body.threadId,
+    });
+    await clearAllDetached();
+
+    const [run] = await store
+      .set(writeDb$)
+      .select({ appendSystemPrompt: agentRuns.appendSystemPrompt })
+      .from(agentRuns)
+      .where(eq(agentRuns.id, third.body.runId!))
+      .limit(1);
+    const prompt = run!.appendSystemPrompt!;
+    expect(prompt.indexOf("RUN_STATUS: failed")).toBeLessThan(
+      prompt.indexOf("RUN_STATUS: timeout"),
+    );
+    expect(prompt).toContain("User: first incomplete");
+    expect(prompt).toContain("...[truncated]");
+    expect(prompt).not.toContain("retry after two failures");
+  });
+
+  it("returns 403 for goal sends when the feature is disabled", async () => {
+    const fixture = await track(seedFixture());
+
+    const response = await accept(
+      client().send({
+        headers: authHeaders(),
+        body: {
+          agentId: fixture.agentId,
+          prompt: "finish the migration",
+          goal: true,
+        },
+      }),
+      [403],
+    );
+
+    expect(response.body.error.code).toBe("FORBIDDEN");
   });
 
   it("persists goal columns for goal sends when the feature is enabled", async () => {
@@ -562,5 +897,113 @@ describe("POST /api/zero/chat/messages", () => {
     expect(run?.selectedModel).toBe("claude-sonnet-4-6");
     expect(run?.appendSystemPrompt).toContain("# Prior Chat Thread Context");
     expect(run?.appendSystemPrompt).toContain("User: first on opus");
+  });
+
+  it("locks an existing provider-first thread to its first model selection", async () => {
+    const fixture = await track(seedFixture());
+    const providerId = await seedModelProvider(fixture, "claude-sonnet-4-6");
+
+    const first = await send({
+      agentId: fixture.agentId,
+      prompt: "first model",
+      modelSelection: {
+        modelProviderId: providerId,
+        selectedModel: "claude-sonnet-4-6",
+      },
+    });
+    await clearAllDetached();
+    await setRunStatus(first.body.runId!, "completed");
+
+    const response = await accept(
+      client().send({
+        headers: authHeaders(),
+        body: {
+          agentId: fixture.agentId,
+          prompt: "switch model",
+          threadId: first.body.threadId,
+          modelSelection: {
+            modelProviderId: providerId,
+            selectedModel: "claude-opus-4-7",
+          },
+        },
+      }),
+      [400],
+    );
+
+    expect(response.body.error.code).toBe("BAD_REQUEST");
+    expect(response.body.error.message).toContain(
+      "Cannot change model on an existing thread",
+    );
+  });
+
+  it("returns 422 when a provider-first thread pin points at a deleted provider", async () => {
+    const fixture = await track(seedFixture());
+    const providerId = await seedModelProvider(fixture, "claude-sonnet-4-6");
+
+    const first = await send({
+      agentId: fixture.agentId,
+      prompt: "first model",
+      modelSelection: {
+        modelProviderId: providerId,
+        selectedModel: "claude-sonnet-4-6",
+      },
+    });
+    await clearAllDetached();
+    await setRunStatus(first.body.runId!, "completed");
+    await store
+      .set(writeDb$)
+      .delete(modelProviders)
+      .where(eq(modelProviders.id, providerId));
+
+    const response = await accept(
+      client().send({
+        headers: authHeaders(),
+        body: {
+          agentId: fixture.agentId,
+          prompt: "follow up",
+          threadId: first.body.threadId,
+        },
+      }),
+      [422],
+    );
+
+    expect(response.body.error.code).toBe("PROVIDER_DELETED");
+  });
+
+  it("derives the runner framework from the compose content", async () => {
+    const fixture = await track(seedFixture());
+    await store
+      .set(writeDb$)
+      .update(agentComposeVersions)
+      .set({
+        content: {
+          version: "1.0",
+          agents: {
+            codex: {
+              framework: "codex",
+              environment: {
+                OPENAI_API_KEY: "test-key",
+                ZERO_AGENT_ID: vm0Template("{{ vars.ZERO_AGENT_ID }}"),
+                ZERO_TOKEN: vm0Template("{{ secrets.ZERO_TOKEN }}"),
+              },
+            },
+          },
+        },
+      })
+      .where(eq(agentComposeVersions.id, fixture.versionId));
+
+    const response = await send({
+      agentId: fixture.agentId,
+      prompt: "run codex",
+    });
+    await clearAllDetached();
+
+    const [job] = await store
+      .set(writeDb$)
+      .select({ executionContext: runnerJobQueue.executionContext })
+      .from(runnerJobQueue)
+      .where(eq(runnerJobQueue.runId, response.body.runId!))
+      .limit(1);
+    expect(job?.executionContext).toMatchObject({ cliAgentType: "codex" });
   });
 });

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-chat-messages.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-chat-messages.test.ts
@@ -258,26 +258,35 @@ async function runExecutionSecrets(runId: string) {
 async function seedModelProvider(
   fixture: ChatMessageFixture,
   selectedModel: string,
+  options: {
+    readonly type?: string;
+    readonly userId?: string;
+  } = {},
 ): Promise<string> {
   const writeDb = store.set(writeDb$);
-  const [secret] = await writeDb
-    .insert(secrets)
-    .values({
-      name: "ANTHROPIC_API_KEY",
-      encryptedValue: encryptSecretForTests("test-provider-key"),
-      type: "model-provider",
-      userId: fixture.userId,
-      orgId: fixture.orgId,
-    })
-    .returning({ id: secrets.id });
+  const providerType = options.type ?? "anthropic-api-key";
+  const providerUserId = options.userId ?? fixture.userId;
+  const [secret] =
+    providerType === "vm0"
+      ? [undefined]
+      : await writeDb
+          .insert(secrets)
+          .values({
+            name: "ANTHROPIC_API_KEY",
+            encryptedValue: encryptSecretForTests("test-provider-key"),
+            type: "model-provider",
+            userId: providerUserId,
+            orgId: fixture.orgId,
+          })
+          .returning({ id: secrets.id });
   const [provider] = await writeDb
     .insert(modelProviders)
     .values({
-      type: "anthropic-api-key",
-      secretId: secret!.id,
+      type: providerType,
+      secretId: secret?.id ?? null,
       isDefault: true,
       selectedModel,
-      userId: fixture.userId,
+      userId: providerUserId,
       orgId: fixture.orgId,
     })
     .returning({ id: modelProviders.id });
@@ -970,6 +979,62 @@ describe("POST /api/zero/chat/messages", () => {
       .where(eq(agentRuns.userId, fixture.userId))
       .limit(1);
     expect(run).toBeUndefined();
+  });
+
+  it("returns 402 when provider-first VM0 modelSelection has no spendable credits", async () => {
+    const fixture = await track(seedFixture());
+    await seedVm0Credits(fixture, 0);
+    const providerId = await seedModelProvider(fixture, "claude-sonnet-4-6", {
+      type: "vm0",
+    });
+
+    const response = await accept(
+      client().send({
+        headers: authHeaders(),
+        body: {
+          agentId: fixture.agentId,
+          prompt: "blocked by provider selection credits",
+          modelSelection: {
+            modelProviderId: providerId,
+            selectedModel: "claude-sonnet-4-6",
+          },
+        },
+      }),
+      [402],
+    );
+
+    expect(response.body.error.code).toBe("INSUFFICIENT_CREDITS");
+    const [run] = await store
+      .set(writeDb$)
+      .select({ id: agentRuns.id })
+      .from(agentRuns)
+      .where(eq(agentRuns.userId, fixture.userId))
+      .limit(1);
+    expect(run).toBeUndefined();
+  });
+
+  it("rejects modelSelection that belongs to another user in the same org", async () => {
+    const fixture = await track(seedFixture());
+    const providerId = await seedModelProvider(fixture, "claude-sonnet-4-6", {
+      userId: `user_${randomUUID()}`,
+    });
+
+    const response = await accept(
+      client().send({
+        headers: authHeaders(),
+        body: {
+          agentId: fixture.agentId,
+          prompt: "do not use another user provider",
+          modelSelection: {
+            modelProviderId: providerId,
+            selectedModel: "claude-sonnet-4-6",
+          },
+        },
+      }),
+      [400],
+    );
+
+    expect(response.body.error.code).toBe("BAD_REQUEST");
   });
 
   it("locks an existing provider-first thread to its first model selection", async () => {

--- a/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
@@ -23,6 +23,7 @@ import {
   inArray,
   isNotNull,
   isNull,
+  or,
   sql,
 } from "drizzle-orm";
 import type { z } from "zod";
@@ -37,7 +38,7 @@ import {
   publishUserSignal,
 } from "../external/realtime";
 import { now, nowDate } from "../external/time";
-import { badRequestMessage, notFound } from "../../lib/error";
+import { badRequestMessage, notFound, providerDeleted } from "../../lib/error";
 import { env } from "../../lib/env";
 import { createAgentRun$ } from "../services/agent-run-create.service";
 import {
@@ -46,6 +47,10 @@ import {
   type CancelRunResult,
 } from "../services/zero-run-cancel.service";
 import { userFeatureSwitchOverrides } from "../services/feature-switches.service";
+import {
+  generateAndPersistChatThreadTitle,
+  isChatTitleGenerationConfigured,
+} from "../services/zero-chat-title.service";
 import { visibleChatMessageCondition } from "../services/zero-chat-thread.service";
 import type { RouteEntry } from "../route";
 
@@ -174,6 +179,7 @@ interface PreparedNormalSend {
 
 type NormalSendFailure =
   | ReturnType<typeof notFound>
+  | ReturnType<typeof providerDeleted>
   | ReturnType<typeof forbidden>
   | ReturnType<typeof badRequestMessage>;
 
@@ -784,6 +790,29 @@ async function getStoredThreadModelPin(
   return thread;
 }
 
+async function modelProviderPinAvailable(params: {
+  readonly db: Db;
+  readonly orgId: string;
+  readonly userId: string;
+  readonly modelProviderId: string;
+}): Promise<boolean> {
+  const [provider] = await params.db
+    .select({ id: modelProviders.id })
+    .from(modelProviders)
+    .where(
+      and(
+        eq(modelProviders.id, params.modelProviderId),
+        eq(modelProviders.orgId, params.orgId),
+        or(
+          eq(modelProviders.userId, params.userId),
+          eq(modelProviders.userId, "__org__"),
+        ),
+      ),
+    )
+    .limit(1);
+  return provider !== undefined;
+}
+
 async function getFirstRunModelPin(
   db: Db,
   threadId: string,
@@ -889,7 +918,7 @@ async function resolveRunModelPin(params: {
   readonly modelFirst: boolean;
   readonly modelSelection: IncomingModelSelection;
   readonly forceNewSession: boolean;
-}): Promise<ThreadModelPin> {
+}): Promise<ThreadModelPin | ReturnType<typeof providerDeleted>> {
   if (params.modelFirst) {
     const existing = params.forceNewSession
       ? null
@@ -923,6 +952,17 @@ async function resolveRunModelPin(params: {
 
   const stored = await getStoredThreadModelPin(params.db, params.threadId);
   if (stored) {
+    if (
+      stored.modelProviderId &&
+      !(await modelProviderPinAvailable({
+        db: params.db,
+        orgId: params.orgId,
+        userId: params.userId,
+        modelProviderId: stored.modelProviderId,
+      }))
+    ) {
+      return providerDeleted();
+    }
     return stored;
   }
   return {
@@ -1688,6 +1728,65 @@ async function queueUnassociatedNormalMessage(params: {
   };
 }
 
+function scheduleChatTitleGeneration(params: {
+  readonly db: Db;
+  readonly body: NormalSendBody;
+  readonly thread: ResolvedThread;
+  readonly userId: string;
+}): void {
+  if (
+    params.body.hasTextContent === false ||
+    !isChatTitleGenerationConfigured()
+  ) {
+    return;
+  }
+
+  waitUntil(
+    generateAndPersistChatThreadTitle({
+      db: params.db,
+      threadId: params.thread.threadId,
+      userId: params.userId,
+      prompt: params.body.prompt,
+      includePriorRounds: !params.thread.isNewThread,
+    }),
+  );
+}
+
+function scheduleAssociatedUserMessage(params: {
+  readonly db: Db;
+  readonly body: NormalSendBody;
+  readonly threadId: string;
+  readonly userId: string;
+  readonly runId: string;
+  readonly goalOrigin: GoalOriginRow | null;
+}): void {
+  waitUntil(
+    (async () => {
+      await appendAssociatedUserMessage({
+        db: params.db,
+        threadId: params.threadId,
+        userId: params.userId,
+        prompt: params.body.prompt,
+        runId: params.runId,
+        attachFiles: params.body.attachFiles,
+        clientMessageId: params.goalOrigin
+          ? undefined
+          : params.body.clientMessageId,
+        goalOrigin: params.goalOrigin,
+      });
+      await publishUserSignal(
+        [params.userId],
+        `chatThreadMessageCreated:${params.threadId}`,
+      );
+      await publishUserSignal(
+        [params.userId],
+        `chatThreadRunCreated:${params.threadId}`,
+      );
+      await publishThreadListChanged(params.userId);
+    })(),
+  );
+}
+
 const createNormalChatRun$ = command(
   async (
     { set },
@@ -1709,6 +1808,9 @@ const createNormalChatRun$ = command(
       forceNewSession: prepared.forceNewSession,
     });
     signal.throwIfAborted();
+    if ("status" in modelPin) {
+      return modelPin;
+    }
 
     const fullPrompt = buildFullPrompt(args.body.prompt, args.body.attachFiles);
     const requestedModelProvider =
@@ -1768,31 +1870,20 @@ const createNormalChatRun$ = command(
       .where(eq(zeroRuns.id, runResult.body.runId));
     signal.throwIfAborted();
 
-    waitUntil(
-      (async () => {
-        await appendAssociatedUserMessage({
-          db: prepared.db,
-          threadId: prepared.thread.threadId,
-          userId: args.userId,
-          prompt: args.body.prompt,
-          runId: runResult.body.runId,
-          attachFiles: args.body.attachFiles,
-          clientMessageId: prepared.goalSetup.goalOriginRow
-            ? undefined
-            : args.body.clientMessageId,
-          goalOrigin: prepared.goalSetup.goalOriginRow,
-        });
-        await publishUserSignal(
-          [args.userId],
-          `chatThreadMessageCreated:${prepared.thread.threadId}`,
-        );
-        await publishUserSignal(
-          [args.userId],
-          `chatThreadRunCreated:${prepared.thread.threadId}`,
-        );
-        await publishThreadListChanged(args.userId);
-      })(),
-    );
+    scheduleChatTitleGeneration({
+      db: prepared.db,
+      body: args.body,
+      thread: prepared.thread,
+      userId: args.userId,
+    });
+    scheduleAssociatedUserMessage({
+      db: prepared.db,
+      body: args.body,
+      threadId: prepared.thread.threadId,
+      userId: args.userId,
+      runId: runResult.body.runId,
+      goalOrigin: prepared.goalSetup.goalOriginRow,
+    });
 
     if (prepared.persistedExplicitSelection && modelPin.selectedModel) {
       await updateUserModelPreference(

--- a/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
@@ -51,6 +51,7 @@ import {
   generateAndPersistChatThreadTitle,
   isChatTitleGenerationConfigured,
 } from "../services/zero-chat-title.service";
+import { checkOrgCreditsForRunAdmission } from "../services/zero-run-admission.service";
 import { visibleChatMessageCondition } from "../services/zero-chat-thread.service";
 import type { RouteEntry } from "../route";
 
@@ -1817,6 +1818,19 @@ const createNormalChatRun$ = command(
       args.body.modelProvider && args.body.modelProvider !== "default"
         ? args.body.modelProvider
         : undefined;
+    const effectiveModelProvider =
+      modelPin.modelProviderType ?? requestedModelProvider;
+    const creditAdmission = await checkOrgCreditsForRunAdmission({
+      db: prepared.db,
+      orgId: args.orgId,
+      userId: args.userId,
+      modelProviderType: effectiveModelProvider,
+    });
+    signal.throwIfAborted();
+    if (creditAdmission) {
+      return creditAdmission;
+    }
+
     const runResult = await set(
       createAgentRun$,
       {
@@ -1862,7 +1876,7 @@ const createNormalChatRun$ = command(
     await prepared.db
       .update(zeroRuns)
       .set({
-        modelProvider: modelPin.modelProviderType ?? requestedModelProvider,
+        modelProvider: effectiveModelProvider,
         modelProviderId: modelPin.modelProviderId,
         modelProviderCredentialScope: modelPin.modelProviderCredentialScope,
         selectedModel: modelPin.selectedModel,

--- a/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
@@ -209,6 +209,7 @@ const GOAL_DEFAULT_BUDGET = 10;
 const PRIOR_HISTORY_MESSAGE_LIMIT = 10;
 const WEB_CHAT_PRIOR_MESSAGE_CHAR_CAP = 4000;
 const WEB_CHAT_INCOMPLETE_MESSAGE_CHAR_CAP = 4000;
+const ORG_SENTINEL_USER_ID = "__org__";
 
 function forbidden(message: string) {
   return {
@@ -806,7 +807,7 @@ async function modelProviderPinAvailable(params: {
         eq(modelProviders.orgId, params.orgId),
         or(
           eq(modelProviders.userId, params.userId),
-          eq(modelProviders.userId, "__org__"),
+          eq(modelProviders.userId, ORG_SENTINEL_USER_ID),
         ),
       ),
     )
@@ -977,6 +978,7 @@ async function resolveRunModelPin(params: {
 async function validateModelSelection(params: {
   readonly db: Db;
   readonly orgId: string;
+  readonly userId: string;
   readonly threadId: string | undefined;
   readonly modelSelection: IncomingModelSelection;
   readonly modelFirst: boolean;
@@ -990,6 +992,10 @@ async function validateModelSelection(params: {
         and(
           eq(modelProviders.id, params.modelSelection.modelProviderId),
           eq(modelProviders.orgId, params.orgId),
+          or(
+            eq(modelProviders.userId, params.userId),
+            eq(modelProviders.userId, ORG_SENTINEL_USER_ID),
+          ),
         ),
       )
       .limit(1);
@@ -1617,6 +1623,7 @@ const prepareNormalSend$ = command(
     const modelError = await validateModelSelection({
       db,
       orgId: args.orgId,
+      userId: args.userId,
       threadId: args.body.threadId,
       modelSelection: args.body.modelSelection,
       modelFirst: useModelFirst,
@@ -1788,6 +1795,59 @@ function scheduleAssociatedUserMessage(params: {
   );
 }
 
+async function resolveEffectiveModelProviderType(params: {
+  readonly db: Db;
+  readonly orgId: string;
+  readonly userId: string;
+  readonly modelPin: ThreadModelPin;
+  readonly requestedModelProvider: string | undefined;
+}): Promise<string | null | undefined> {
+  if (params.modelPin.modelProviderType) {
+    return params.modelPin.modelProviderType;
+  }
+  if (!params.modelPin.modelProviderId) {
+    return params.requestedModelProvider;
+  }
+
+  const [provider] = await params.db
+    .select({ type: modelProviders.type })
+    .from(modelProviders)
+    .where(
+      and(
+        eq(modelProviders.id, params.modelPin.modelProviderId),
+        eq(modelProviders.orgId, params.orgId),
+        or(
+          eq(modelProviders.userId, params.userId),
+          eq(modelProviders.userId, ORG_SENTINEL_USER_ID),
+        ),
+      ),
+    )
+    .limit(1);
+
+  return provider?.type ?? params.requestedModelProvider;
+}
+
+async function resolveProviderAdmission(params: {
+  readonly db: Db;
+  readonly orgId: string;
+  readonly userId: string;
+  readonly modelPin: ThreadModelPin;
+  readonly requestedModelProvider: string | undefined;
+}): Promise<{
+  readonly effectiveModelProvider: string | null | undefined;
+  readonly error: Awaited<ReturnType<typeof checkOrgCreditsForRunAdmission>>;
+}> {
+  const effectiveModelProvider =
+    await resolveEffectiveModelProviderType(params);
+  const error = await checkOrgCreditsForRunAdmission({
+    db: params.db,
+    orgId: params.orgId,
+    userId: params.userId,
+    modelProviderType: effectiveModelProvider,
+  });
+  return { effectiveModelProvider, error };
+}
+
 const createNormalChatRun$ = command(
   async (
     { set },
@@ -1818,17 +1878,16 @@ const createNormalChatRun$ = command(
       args.body.modelProvider && args.body.modelProvider !== "default"
         ? args.body.modelProvider
         : undefined;
-    const effectiveModelProvider =
-      modelPin.modelProviderType ?? requestedModelProvider;
-    const creditAdmission = await checkOrgCreditsForRunAdmission({
+    const providerAdmission = await resolveProviderAdmission({
       db: prepared.db,
       orgId: args.orgId,
       userId: args.userId,
-      modelProviderType: effectiveModelProvider,
+      modelPin,
+      requestedModelProvider,
     });
     signal.throwIfAborted();
-    if (creditAdmission) {
-      return creditAdmission;
+    if (providerAdmission.error) {
+      return providerAdmission.error;
     }
 
     const runResult = await set(
@@ -1876,7 +1935,7 @@ const createNormalChatRun$ = command(
     await prepared.db
       .update(zeroRuns)
       .set({
-        modelProvider: effectiveModelProvider,
+        modelProvider: providerAdmission.effectiveModelProvider,
         modelProviderId: modelPin.modelProviderId,
         modelProviderCredentialScope: modelPin.modelProviderCredentialScope,
         selectedModel: modelPin.selectedModel,

--- a/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
@@ -1,0 +1,1894 @@
+import { randomBytes, randomUUID } from "node:crypto";
+
+import { command } from "ccstate";
+import {
+  chatMessagesContract,
+  type AttachFile,
+} from "@vm0/api-contracts/contracts/chat-threads";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import { isFeatureEnabled } from "@vm0/core/feature-switch";
+import { agentRuns } from "@vm0/db/schema/agent-run";
+import { chatMessages } from "@vm0/db/schema/chat-message";
+import { chatThreads } from "@vm0/db/schema/chat-thread";
+import { modelProviders } from "@vm0/db/schema/model-provider";
+import { orgMembersMetadata } from "@vm0/db/schema/org-members-metadata";
+import { orgModelPolicies } from "@vm0/db/schema/org-model-policy";
+import { zeroAgents } from "@vm0/db/schema/zero-agent";
+import { zeroRuns } from "@vm0/db/schema/zero-run";
+import {
+  and,
+  asc,
+  desc,
+  eq,
+  inArray,
+  isNotNull,
+  isNull,
+  sql,
+} from "drizzle-orm";
+import type { z } from "zod";
+
+import { organizationAuthContext$ } from "../auth/auth-context";
+import { authRoute } from "../auth/auth-route";
+import { bodyResultOf } from "../context/request";
+import { waitUntil } from "../context/wait-until";
+import { writeDb$, type Db } from "../external/db";
+import {
+  publishThreadListChanged,
+  publishUserSignal,
+} from "../external/realtime";
+import { now, nowDate } from "../external/time";
+import { badRequestMessage, notFound } from "../../lib/error";
+import { env } from "../../lib/env";
+import { createAgentRun$ } from "../services/agent-run-create.service";
+import {
+  cancelRun$,
+  dispatchCancelSideEffects$,
+  type CancelRunResult,
+} from "../services/zero-run-cancel.service";
+import { userFeatureSwitchOverrides } from "../services/feature-switches.service";
+import { visibleChatMessageCondition } from "../services/zero-chat-thread.service";
+import type { RouteEntry } from "../route";
+
+type SendBody = z.infer<typeof chatMessagesContract.send.body>;
+
+interface NormalSendBody {
+  readonly agentId: string;
+  readonly prompt: string;
+  readonly threadId?: string;
+  readonly clientThreadId?: string;
+  readonly modelProvider?: string;
+  readonly modelSelection?: {
+    readonly modelProviderId: string;
+    readonly selectedModel: string;
+  } | null;
+  readonly hasTextContent?: boolean;
+  readonly attachFiles?: AttachFile[];
+  readonly clientMessageId?: string;
+  readonly goal?: boolean;
+  readonly forceNewSession?: boolean;
+  readonly debugNoMockClaude?: boolean;
+  readonly debugNoMockCodex?: boolean;
+}
+
+interface RecallSendBody {
+  readonly agentId: string;
+  readonly threadId: string;
+  readonly revokesMessageId: string;
+  readonly clientMessageId?: string;
+}
+
+interface InterruptSendBody {
+  readonly agentId: string;
+  readonly threadId: string;
+  readonly interruptsRunId: string;
+  readonly clientMessageId?: string;
+}
+
+interface AgentForChatSend {
+  readonly id: string;
+  readonly orgId: string;
+  readonly owner: string;
+  readonly visibility: "public" | "private";
+  readonly modelProviderId: string | null;
+  readonly selectedModel: string | null;
+}
+
+interface ThreadModelPin {
+  readonly modelProviderId: string | null;
+  readonly modelProviderType: string | null;
+  readonly modelProviderCredentialScope: string | null;
+  readonly selectedModel: string | null;
+}
+
+interface ResolvedThread {
+  readonly threadId: string;
+  readonly sessionId: string | undefined;
+  readonly incompleteContext: string;
+  readonly isNewThread: boolean;
+}
+
+interface GoalOriginRow {
+  readonly messageId: string;
+  readonly remainingTurns: number;
+}
+
+interface GoalSetup {
+  readonly goalContext: WebChatGoalContext | null;
+  readonly goalOriginRow: GoalOriginRow | null;
+}
+
+interface WebChatGoalContext {
+  readonly remainingTurns: number;
+}
+
+interface WebChatPriorMessage {
+  readonly role: "user" | "assistant";
+  readonly content: string;
+  readonly attachFiles: readonly string[] | null;
+}
+
+interface WebChatIncompleteRoundMessage {
+  readonly role: "user" | "assistant";
+  readonly content: string | null;
+  readonly error: string | null;
+  readonly attachFiles: readonly string[] | null;
+}
+
+interface WebChatIncompleteRound {
+  readonly runId: string;
+  readonly status: "cancelled" | "failed" | "timeout";
+  readonly messages: WebChatIncompleteRoundMessage[];
+}
+
+interface IncompleteRoundRow extends WebChatIncompleteRoundMessage {
+  readonly runId: string;
+  readonly runStatus: "cancelled" | "failed" | "timeout";
+  readonly createdAt: Date;
+  readonly sequenceNumber: number | null;
+}
+
+type IncomingModelSelection = NormalSendBody["modelSelection"];
+
+type SignalGetter = {
+  <T>(signal: import("ccstate").Computed<T>): T;
+  <T>(signal: import("ccstate").Computed<Promise<T>>): Promise<T>;
+};
+
+interface NormalSendArgs {
+  readonly body: NormalSendBody;
+  readonly userId: string;
+  readonly orgId: string;
+  readonly apiStartTime: number;
+}
+
+interface PreparedNormalSend {
+  readonly db: Db;
+  readonly agent: AgentForChatSend;
+  readonly modelFirst: boolean;
+  readonly forceNewSession: boolean;
+  readonly goalSetup: GoalSetup;
+  readonly thread: ResolvedThread;
+  readonly priorContext: string;
+  readonly persistedExplicitSelection: boolean;
+}
+
+type NormalSendFailure =
+  | ReturnType<typeof notFound>
+  | ReturnType<typeof forbidden>
+  | ReturnType<typeof badRequestMessage>;
+
+interface CreatedChatMessageResponse {
+  readonly status: 201;
+  readonly body: {
+    readonly runId: string | null;
+    readonly threadId: string;
+    readonly status?: string;
+    readonly createdAt: string;
+  };
+}
+
+type AppendMessageResult =
+  | {
+      readonly ok: true;
+      readonly createdAt: Date;
+    }
+  | {
+      readonly ok: false;
+      readonly message: string;
+    };
+
+const sendBody$ = bodyResultOf(chatMessagesContract.send);
+const GOAL_DEFAULT_BUDGET = 10;
+const PRIOR_HISTORY_MESSAGE_LIMIT = 10;
+const WEB_CHAT_PRIOR_MESSAGE_CHAR_CAP = 4000;
+const WEB_CHAT_INCOMPLETE_MESSAGE_CHAR_CAP = 4000;
+
+function forbidden(message: string) {
+  return {
+    status: 403 as const,
+    body: { error: { message, code: "FORBIDDEN" as const } },
+  };
+}
+
+function isCancelResult(value: unknown): value is CancelRunResult {
+  return (
+    typeof value === "object" && value !== null && "alreadyCancelled" in value
+  );
+}
+
+function isRecallSendBody(body: SendBody): body is RecallSendBody {
+  return "revokesMessageId" in body && body.revokesMessageId !== undefined;
+}
+
+function isInterruptSendBody(body: SendBody): body is InterruptSendBody {
+  return "interruptsRunId" in body && body.interruptsRunId !== undefined;
+}
+
+function isNormalSendBody(body: SendBody): body is NormalSendBody {
+  return "prompt" in body && body.prompt !== undefined;
+}
+
+function hasAgentSessionId(
+  value: unknown,
+): value is { readonly agentSessionId: string } {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "agentSessionId" in value &&
+    typeof (value as { readonly agentSessionId: unknown }).agentSessionId ===
+      "string"
+  );
+}
+
+function generateCallbackSecret(): string {
+  return randomBytes(32).toString("hex");
+}
+
+function chatCallbackUrl(): string {
+  return new URL("/api/internal/callbacks/chat", env("VM0_API_URL")).toString();
+}
+
+function buildWebChatPrompt(): string {
+  return [
+    "# Current Integration\nYou are currently running inside: Web",
+    "You are communicating with the user through the web chat UI.",
+  ].join("\n\n");
+}
+
+function buildWebAttachFilesPrompt(
+  files: readonly {
+    readonly id: string;
+    readonly filename: string;
+    readonly contentType: string;
+  }[],
+): string {
+  return files
+    .map((file) => {
+      return `[Web file] ${file.filename} (${file.contentType})\n   [ID] ${file.id}`;
+    })
+    .join("\n");
+}
+
+function buildWebChatGoalPrompt(ctx: WebChatGoalContext): string {
+  const turnLabel = ctx.remainingTurns === 1 ? "turn" : "turns";
+  return [
+    "# Goal Mode",
+    "",
+    "You are operating in goal mode. The user message that triggered this run",
+    "may be a continuation of an earlier `/go` objective -- the same message body",
+    "will repeat verbatim each turn until the goal is satisfied. Treat each",
+    "repetition as the signal to continue working on the objective, not as a",
+    "fresh request to start over.",
+    "",
+    `You have ${String(ctx.remainingTurns)} ${turnLabel} remaining (this one included).`,
+    "",
+    "When you believe the goal is satisfied, include the literal text `[GOAL_DONE]`",
+    "somewhere in your final assistant message. The runtime detects this",
+    "sentinel and stops the goal chain. Only emit it after verifying concrete",
+    "deliverables -- do not declare completion prematurely.",
+  ].join("\n");
+}
+
+function buildAppendSystemPrompt(
+  incompleteContext: string,
+  priorContext: string,
+  goalContext: WebChatGoalContext | null,
+): string {
+  return [
+    buildWebChatPrompt(),
+    goalContext ? buildWebChatGoalPrompt(goalContext) : "",
+    priorContext,
+    incompleteContext,
+  ]
+    .filter((part) => {
+      return part.length > 0;
+    })
+    .join("\n\n");
+}
+
+function buildFullPrompt(
+  prompt: string,
+  attachFiles: readonly AttachFile[] | undefined,
+): string {
+  if (!attachFiles || attachFiles.length === 0) {
+    return prompt;
+  }
+  return `${prompt}\n\n${buildWebAttachFilesPrompt(attachFiles)}`;
+}
+
+function truncatePrior(value: string): string {
+  if (value.length <= WEB_CHAT_PRIOR_MESSAGE_CHAR_CAP) {
+    return value;
+  }
+  return `${value.slice(0, WEB_CHAT_PRIOR_MESSAGE_CHAR_CAP)}...[truncated]`;
+}
+
+function truncateIncomplete(value: string): string {
+  if (value.length <= WEB_CHAT_INCOMPLETE_MESSAGE_CHAR_CAP) {
+    return value;
+  }
+  return `${value.slice(0, WEB_CHAT_INCOMPLETE_MESSAGE_CHAR_CAP)}...[truncated]`;
+}
+
+function formatAttachFileIds(
+  ids: readonly string[] | null | undefined,
+): string {
+  if (!ids || ids.length === 0) {
+    return "";
+  }
+  return ids
+    .map((id) => {
+      return `[Web file]\n   [ID] ${id}`;
+    })
+    .join("\n");
+}
+
+function buildWebChatPriorMessagesContext(
+  messages: readonly WebChatPriorMessage[],
+): string {
+  if (messages.length === 0) {
+    return "";
+  }
+  const total = messages.length;
+  const blocks = messages.map((message, index) => {
+    const relativeIndex = index - total + 1;
+    const roleLabel = message.role === "user" ? "User" : "Assistant";
+    const attach = formatAttachFileIds(message.attachFiles);
+    const lines = [
+      "---",
+      "",
+      `- RELATIVE_INDEX: ${relativeIndex}`,
+      `- ROLE: ${message.role}`,
+      "",
+      `${roleLabel}: ${truncatePrior(message.content) || "[empty message]"}`,
+    ];
+    if (attach) {
+      lines.push(attach);
+    }
+    return lines.join("\n");
+  });
+  return [
+    "# Prior Chat Thread Context",
+    "",
+    "The messages below are completed rounds earlier in this chat thread. The",
+    "CLI session history has been reset for this run (the user switched models",
+    "mid-thread, so the previous session is not safe to resume), so the prior",
+    "conversation is shown here verbatim. RELATIVE_INDEX 0 is the most recent.",
+    "Treat them as part of the conversation you are continuing.",
+    "",
+    blocks.join("\n\n"),
+    "",
+    "---",
+  ].join("\n");
+}
+
+function formatIncompleteMessage(
+  message: WebChatIncompleteRoundMessage,
+): string {
+  const attach = formatAttachFileIds(message.attachFiles);
+  if (message.role === "user") {
+    const body =
+      message.content !== null && message.content !== ""
+        ? truncateIncomplete(message.content)
+        : "[empty message]";
+    return attach ? `User: ${body}\n${attach}` : `User: ${body}`;
+  }
+  if (message.content !== null && message.content !== "") {
+    return `Assistant (partial): ${truncateIncomplete(message.content)}`;
+  }
+  return "Assistant: [no response before run ended]";
+}
+
+function buildWebChatIncompleteContext(
+  rounds: readonly WebChatIncompleteRound[],
+): string {
+  if (rounds.length === 0) {
+    return "";
+  }
+  const total = rounds.length;
+  const blocks = rounds.map((round, index) => {
+    const relativeIndex = index - total + 1;
+    const rendered = round.messages.map(formatIncompleteMessage);
+    const hasAssistant = round.messages.some((message) => {
+      return message.role === "assistant";
+    });
+    if (!hasAssistant) {
+      rendered.push("Assistant: [no response before run ended]");
+    }
+    return [
+      "---",
+      "",
+      `- RELATIVE_INDEX: ${relativeIndex}`,
+      `- RUN_STATUS: ${round.status}`,
+      "",
+      ...rendered,
+    ].join("\n");
+  });
+  return [
+    "# Incomplete Rounds Context",
+    "",
+    "The rounds below were sent in this thread but their runs did not complete",
+    "(cancelled, failed, or timed out), so the CLI session history does not",
+    "contain them. Treat them as part of the conversation you are having with",
+    "the user. RELATIVE_INDEX 0 is the most recent incomplete round.",
+    "",
+    blocks.join("\n\n"),
+    "",
+    "---",
+  ].join("\n");
+}
+
+function isIncompleteRunStatus(
+  value: string | null,
+): value is "cancelled" | "failed" | "timeout" {
+  return value === "cancelled" || value === "failed" || value === "timeout";
+}
+
+function groupIncompleteRoundsByRunId(
+  rows: readonly IncompleteRoundRow[],
+): WebChatIncompleteRound[] {
+  const byRunId = new Map<string, WebChatIncompleteRound>();
+  const order: string[] = [];
+  for (const row of rows) {
+    let round = byRunId.get(row.runId);
+    if (!round) {
+      round = { runId: row.runId, status: row.runStatus, messages: [] };
+      byRunId.set(row.runId, round);
+      order.push(row.runId);
+    }
+    round.messages.push({
+      role: row.role,
+      content: row.content,
+      error: row.error,
+      attachFiles: row.attachFiles,
+    });
+  }
+  return order.map((runId) => {
+    const round = byRunId.get(runId);
+    if (!round) {
+      throw new Error("Incomplete round grouping lost run id");
+    }
+    return round;
+  });
+}
+
+async function loadAgentForChatSend(
+  db: Db,
+  agentId: string,
+): Promise<AgentForChatSend | undefined> {
+  const [agent] = await db
+    .select({
+      id: zeroAgents.id,
+      orgId: zeroAgents.orgId,
+      owner: zeroAgents.owner,
+      visibility: zeroAgents.visibility,
+      modelProviderId: zeroAgents.modelProviderId,
+      selectedModel: zeroAgents.selectedModel,
+    })
+    .from(zeroAgents)
+    .where(eq(zeroAgents.id, agentId))
+    .limit(1);
+  return agent;
+}
+
+async function latestSessionIdForThread(
+  db: Db,
+  threadId: string,
+): Promise<string | undefined> {
+  const rows = await db
+    .select({ result: agentRuns.result })
+    .from(zeroRuns)
+    .innerJoin(agentRuns, eq(zeroRuns.id, agentRuns.id))
+    .where(eq(zeroRuns.chatThreadId, threadId))
+    .orderBy(desc(agentRuns.createdAt))
+    .limit(5);
+
+  for (const row of rows) {
+    if (hasAgentSessionId(row.result)) {
+      return row.result.agentSessionId;
+    }
+  }
+  return undefined;
+}
+
+async function getLatestMessagesByThreadId(
+  db: Db,
+  threadId: string,
+  limit: number,
+): Promise<WebChatPriorMessage[]> {
+  const rows = await db
+    .select({
+      role: chatMessages.role,
+      content: chatMessages.content,
+      attachFiles: chatMessages.attachFiles,
+      createdAt: chatMessages.createdAt,
+      sequenceNumber: chatMessages.sequenceNumber,
+    })
+    .from(chatMessages)
+    .leftJoin(agentRuns, eq(agentRuns.id, chatMessages.runId))
+    .where(
+      and(
+        eq(chatMessages.chatThreadId, threadId),
+        isNotNull(chatMessages.content),
+        inArray(chatMessages.role, ["user", "assistant"]),
+        visibleChatMessageCondition(),
+      ),
+    )
+    .orderBy(desc(chatMessages.createdAt), desc(chatMessages.sequenceNumber))
+    .limit(limit);
+
+  return rows.reverse().flatMap((row) => {
+    if (
+      row.content === null ||
+      (row.role !== "user" && row.role !== "assistant")
+    ) {
+      return [];
+    }
+    return [
+      {
+        role: row.role,
+        content: row.content,
+        attachFiles: row.attachFiles,
+      },
+    ];
+  });
+}
+
+async function getIncompleteRoundsSinceLastSuccess(
+  db: Db,
+  threadId: string,
+  maxRounds = 20,
+): Promise<IncompleteRoundRow[]> {
+  const rows = await db
+    .select({
+      runId: chatMessages.runId,
+      role: chatMessages.role,
+      content: chatMessages.content,
+      error: chatMessages.error,
+      attachFiles: chatMessages.attachFiles,
+      createdAt: chatMessages.createdAt,
+      sequenceNumber: chatMessages.sequenceNumber,
+      runStatus: agentRuns.status,
+    })
+    .from(chatMessages)
+    .innerJoin(agentRuns, eq(agentRuns.id, chatMessages.runId))
+    .where(
+      and(
+        eq(chatMessages.chatThreadId, threadId),
+        visibleChatMessageCondition(),
+        inArray(agentRuns.status, ["cancelled", "failed", "timeout"]),
+        inArray(chatMessages.role, ["user", "assistant"]),
+        sql`${chatMessages.createdAt} > COALESCE(
+          (
+            SELECT MAX(cm2.created_at)
+            FROM chat_messages cm2
+            INNER JOIN agent_runs ar2 ON ar2.id = cm2.run_id
+            WHERE cm2.chat_thread_id = ${threadId}
+              AND NOT EXISTS (
+                SELECT 1
+                FROM chat_messages revoker2
+                WHERE revoker2.revokes_message_id = cm2.id
+              )
+              AND ar2.result ? 'agentSessionId'
+              AND jsonb_typeof(ar2.result->'agentSessionId') = 'string'
+          ),
+          '-infinity'::timestamptz
+        )`,
+      ),
+    )
+    .orderBy(asc(chatMessages.createdAt), asc(chatMessages.sequenceNumber));
+
+  const candidates: IncompleteRoundRow[] = [];
+  for (const row of rows) {
+    if (row.runId === null) {
+      continue;
+    }
+    if (!isIncompleteRunStatus(row.runStatus)) {
+      continue;
+    }
+    if (row.role !== "user" && row.role !== "assistant") {
+      continue;
+    }
+    candidates.push({
+      runId: row.runId,
+      runStatus: row.runStatus,
+      role: row.role,
+      content: row.content,
+      error: row.error,
+      attachFiles: row.attachFiles,
+      createdAt: row.createdAt,
+      sequenceNumber: row.sequenceNumber,
+    });
+  }
+
+  const orderedRunIds: string[] = [];
+  const seen = new Set<string>();
+  for (const row of candidates) {
+    if (!seen.has(row.runId)) {
+      seen.add(row.runId);
+      orderedRunIds.push(row.runId);
+    }
+  }
+  if (orderedRunIds.length <= maxRounds) {
+    return candidates;
+  }
+
+  const keep = new Set(orderedRunIds.slice(orderedRunIds.length - maxRounds));
+  return candidates.filter((row) => {
+    return keep.has(row.runId);
+  });
+}
+
+async function activeRunExistsForThread(
+  db: Db,
+  threadId: string,
+): Promise<boolean> {
+  const [run] = await db
+    .select({ id: zeroRuns.id })
+    .from(zeroRuns)
+    .innerJoin(agentRuns, eq(agentRuns.id, zeroRuns.id))
+    .where(
+      and(
+        eq(zeroRuns.chatThreadId, threadId),
+        inArray(agentRuns.status, ["queued", "pending", "running"]),
+      ),
+    )
+    .limit(1);
+  return run !== undefined;
+}
+
+async function modelFirstEnabled(
+  get: SignalGetter,
+  orgId: string,
+  userId: string,
+): Promise<boolean> {
+  const overrides = await get(userFeatureSwitchOverrides(orgId, userId));
+  return isFeatureEnabled(FeatureSwitchKey.ModelFirstModelProvider, {
+    orgId,
+    userId,
+    overrides,
+  });
+}
+
+async function goalEnabled(
+  get: SignalGetter,
+  orgId: string,
+  userId: string,
+): Promise<boolean> {
+  const overrides = await get(userFeatureSwitchOverrides(orgId, userId));
+  return isFeatureEnabled(FeatureSwitchKey.Goal, {
+    orgId,
+    userId,
+    overrides,
+  });
+}
+
+async function resolveGoalSetup(
+  get: SignalGetter,
+  body: NormalSendBody,
+  orgId: string,
+  userId: string,
+): Promise<GoalSetup | ReturnType<typeof forbidden>> {
+  if (body.goal !== true) {
+    return { goalContext: null, goalOriginRow: null };
+  }
+  if (!(await goalEnabled(get, orgId, userId))) {
+    return forbidden("Goal mode is not available for this account");
+  }
+  const messageId = body.clientMessageId ?? randomUUID();
+  return {
+    goalContext: { remainingTurns: GOAL_DEFAULT_BUDGET },
+    goalOriginRow: {
+      messageId,
+      remainingTurns: GOAL_DEFAULT_BUDGET,
+    },
+  };
+}
+
+async function defaultModelFirstPin(
+  db: Db,
+  orgId: string,
+  userId: string,
+): Promise<ThreadModelPin> {
+  const [preference] = await db
+    .select({ selectedModel: orgMembersMetadata.selectedModel })
+    .from(orgMembersMetadata)
+    .where(
+      and(
+        eq(orgMembersMetadata.orgId, orgId),
+        eq(orgMembersMetadata.userId, userId),
+      ),
+    )
+    .limit(1);
+
+  const preferredModel = preference?.selectedModel ?? null;
+  const [policy] = await db
+    .select({
+      model: orgModelPolicies.model,
+      defaultProviderType: orgModelPolicies.defaultProviderType,
+      credentialScope: orgModelPolicies.credentialScope,
+      modelProviderId: orgModelPolicies.modelProviderId,
+    })
+    .from(orgModelPolicies)
+    .where(
+      preferredModel
+        ? and(
+            eq(orgModelPolicies.orgId, orgId),
+            eq(orgModelPolicies.model, preferredModel),
+          )
+        : and(
+            eq(orgModelPolicies.orgId, orgId),
+            eq(orgModelPolicies.isDefault, true),
+          ),
+    )
+    .limit(1);
+
+  if (!policy && preferredModel) {
+    return defaultModelFirstPin(db, orgId, "__no_preference__");
+  }
+
+  if (!policy) {
+    return {
+      modelProviderId: null,
+      modelProviderType: null,
+      modelProviderCredentialScope: null,
+      selectedModel: null,
+    };
+  }
+
+  return {
+    modelProviderId: policy.modelProviderId ?? null,
+    modelProviderType: policy.defaultProviderType,
+    modelProviderCredentialScope: policy.credentialScope,
+    selectedModel: policy.model,
+  };
+}
+
+async function getStoredThreadModelPin(
+  db: Db,
+  threadId: string,
+): Promise<ThreadModelPin | null> {
+  const [thread] = await db
+    .select({
+      modelProviderId: chatThreads.modelProviderId,
+      modelProviderType: chatThreads.modelProviderType,
+      modelProviderCredentialScope: chatThreads.modelProviderCredentialScope,
+      selectedModel: chatThreads.selectedModel,
+    })
+    .from(chatThreads)
+    .where(eq(chatThreads.id, threadId))
+    .limit(1);
+  if (!thread?.selectedModel) {
+    return null;
+  }
+  return thread;
+}
+
+async function getFirstRunModelPin(
+  db: Db,
+  threadId: string,
+): Promise<ThreadModelPin | null> {
+  const [run] = await db
+    .select({
+      modelProviderId: zeroRuns.modelProviderId,
+      modelProviderType: zeroRuns.modelProvider,
+      modelProviderCredentialScope: zeroRuns.modelProviderCredentialScope,
+      selectedModel: zeroRuns.selectedModel,
+    })
+    .from(chatMessages)
+    .innerJoin(zeroRuns, eq(zeroRuns.id, chatMessages.runId))
+    .where(
+      and(
+        eq(chatMessages.chatThreadId, threadId),
+        eq(chatMessages.role, "user"),
+        isNotNull(chatMessages.runId),
+        isNotNull(zeroRuns.selectedModel),
+      ),
+    )
+    .orderBy(asc(chatMessages.createdAt), asc(chatMessages.id))
+    .limit(1);
+  if (!run?.selectedModel) {
+    return null;
+  }
+  return run;
+}
+
+async function existingModelFirstThreadPin(
+  db: Db,
+  threadId: string,
+): Promise<ThreadModelPin | null> {
+  return (
+    (await getStoredThreadModelPin(db, threadId)) ??
+    (await getFirstRunModelPin(db, threadId))
+  );
+}
+
+async function resolveModelSelectionPin(
+  db: Db,
+  orgId: string,
+  selectedModel: string,
+): Promise<ThreadModelPin> {
+  const [policy] = await db
+    .select({
+      model: orgModelPolicies.model,
+      defaultProviderType: orgModelPolicies.defaultProviderType,
+      credentialScope: orgModelPolicies.credentialScope,
+      modelProviderId: orgModelPolicies.modelProviderId,
+    })
+    .from(orgModelPolicies)
+    .where(
+      and(
+        eq(orgModelPolicies.orgId, orgId),
+        eq(orgModelPolicies.model, selectedModel),
+      ),
+    )
+    .limit(1);
+  if (!policy) {
+    return {
+      modelProviderId: null,
+      modelProviderType: null,
+      modelProviderCredentialScope: null,
+      selectedModel,
+    };
+  }
+  return {
+    modelProviderId: policy.modelProviderId ?? null,
+    modelProviderType: policy.defaultProviderType,
+    modelProviderCredentialScope: policy.credentialScope,
+    selectedModel: policy.model,
+  };
+}
+
+async function persistThreadPinIfUnset(
+  db: Db,
+  threadId: string,
+  pin: ThreadModelPin,
+): Promise<ThreadModelPin> {
+  if (!pin.selectedModel) {
+    return pin;
+  }
+  const [updated] = await db
+    .update(chatThreads)
+    .set({ ...pin, updatedAt: nowDate() })
+    .where(and(eq(chatThreads.id, threadId), isNull(chatThreads.selectedModel)))
+    .returning({
+      modelProviderId: chatThreads.modelProviderId,
+      modelProviderType: chatThreads.modelProviderType,
+      modelProviderCredentialScope: chatThreads.modelProviderCredentialScope,
+      selectedModel: chatThreads.selectedModel,
+    });
+  return updated ?? (await getStoredThreadModelPin(db, threadId)) ?? pin;
+}
+
+async function resolveRunModelPin(params: {
+  readonly db: Db;
+  readonly orgId: string;
+  readonly userId: string;
+  readonly threadId: string;
+  readonly agent: AgentForChatSend;
+  readonly modelFirst: boolean;
+  readonly modelSelection: IncomingModelSelection;
+  readonly forceNewSession: boolean;
+}): Promise<ThreadModelPin> {
+  if (params.modelFirst) {
+    const existing = params.forceNewSession
+      ? null
+      : await existingModelFirstThreadPin(params.db, params.threadId);
+    if (existing) {
+      return persistThreadPinIfUnset(params.db, params.threadId, existing);
+    }
+    const pin = params.modelSelection
+      ? await resolveModelSelectionPin(
+          params.db,
+          params.orgId,
+          params.modelSelection.selectedModel,
+        )
+      : await defaultModelFirstPin(params.db, params.orgId, params.userId);
+    return persistThreadPinIfUnset(params.db, params.threadId, pin);
+  }
+
+  if (params.modelSelection !== undefined && params.modelSelection !== null) {
+    const pin = {
+      modelProviderId: params.modelSelection.modelProviderId,
+      modelProviderType: null,
+      modelProviderCredentialScope: null,
+      selectedModel: params.modelSelection.selectedModel,
+    };
+    await params.db
+      .update(chatThreads)
+      .set({ ...pin, updatedAt: nowDate() })
+      .where(eq(chatThreads.id, params.threadId));
+    return pin;
+  }
+
+  const stored = await getStoredThreadModelPin(params.db, params.threadId);
+  if (stored) {
+    return stored;
+  }
+  return {
+    modelProviderId: params.agent.modelProviderId,
+    modelProviderType: null,
+    modelProviderCredentialScope: null,
+    selectedModel: params.agent.selectedModel,
+  };
+}
+
+async function validateModelSelection(params: {
+  readonly db: Db;
+  readonly orgId: string;
+  readonly threadId: string | undefined;
+  readonly modelSelection: IncomingModelSelection;
+  readonly modelFirst: boolean;
+  readonly forceNewSession: boolean;
+}): Promise<ReturnType<typeof badRequestMessage> | undefined> {
+  if (params.modelSelection && !params.modelFirst) {
+    const [provider] = await params.db
+      .select({ id: modelProviders.id })
+      .from(modelProviders)
+      .where(
+        and(
+          eq(modelProviders.id, params.modelSelection.modelProviderId),
+          eq(modelProviders.orgId, params.orgId),
+        ),
+      )
+      .limit(1);
+    if (!provider) {
+      return badRequestMessage("Unknown model provider for this workspace");
+    }
+  }
+
+  if (
+    params.forceNewSession ||
+    params.threadId === undefined ||
+    params.modelSelection === undefined
+  ) {
+    return undefined;
+  }
+
+  const existing = params.modelFirst
+    ? await existingModelFirstThreadPin(params.db, params.threadId)
+    : await getStoredThreadModelPin(params.db, params.threadId);
+  if (!existing?.selectedModel) {
+    return undefined;
+  }
+  if (
+    params.modelSelection === null ||
+    existing.selectedModel !== params.modelSelection.selectedModel
+  ) {
+    return badRequestMessage("Cannot change model on an existing thread");
+  }
+  return undefined;
+}
+
+async function updateUserModelPreference(
+  db: Db,
+  orgId: string,
+  userId: string,
+  selectedModel: string,
+): Promise<void> {
+  const nowValue = nowDate();
+  await db
+    .insert(orgMembersMetadata)
+    .values({
+      orgId,
+      userId,
+      selectedModel,
+      createdAt: nowValue,
+      updatedAt: nowValue,
+    })
+    .onConflictDoUpdate({
+      target: [orgMembersMetadata.orgId, orgMembersMetadata.userId],
+      set: { selectedModel, updatedAt: nowValue },
+    });
+}
+
+async function maybePersistExplicitModelFirstSelection(params: {
+  readonly db: Db;
+  readonly orgId: string;
+  readonly userId: string;
+  readonly threadId: string;
+  readonly modelFirst: boolean;
+  readonly modelSelection: IncomingModelSelection;
+  readonly forceNewSession: boolean;
+}): Promise<boolean> {
+  if (!params.modelFirst || !params.modelSelection) {
+    return false;
+  }
+  const existing = params.forceNewSession
+    ? null
+    : await existingModelFirstThreadPin(params.db, params.threadId);
+  if (existing) {
+    return false;
+  }
+  await updateUserModelPreference(
+    params.db,
+    params.orgId,
+    params.userId,
+    params.modelSelection.selectedModel,
+  );
+  return true;
+}
+
+async function createChatThread(
+  db: Db,
+  args: {
+    readonly userId: string;
+    readonly agentId: string;
+    readonly clientThreadId: string | undefined;
+    readonly pin: ThreadModelPin;
+  },
+): Promise<{ readonly id: string }> {
+  const [thread] = await db
+    .insert(chatThreads)
+    .values({
+      ...(args.clientThreadId ? { id: args.clientThreadId } : {}),
+      userId: args.userId,
+      agentComposeId: args.agentId,
+      title: null,
+      modelProviderId: args.pin.modelProviderId,
+      modelProviderType: args.pin.modelProviderType,
+      modelProviderCredentialScope: args.pin.modelProviderCredentialScope,
+      selectedModel: args.pin.selectedModel,
+    })
+    .returning({ id: chatThreads.id });
+  if (!thread) {
+    throw new Error("Failed to create chat thread");
+  }
+  return thread;
+}
+
+async function resolveThread(params: {
+  readonly db: Db;
+  readonly userId: string;
+  readonly agentId: string;
+  readonly existingThreadId: string | undefined;
+  readonly clientThreadId: string | undefined;
+  readonly agentPin: ThreadModelPin;
+  readonly forceNewSession: boolean;
+}): Promise<ResolvedThread | ReturnType<typeof notFound>> {
+  if (!params.existingThreadId) {
+    const thread = await createChatThread(params.db, {
+      userId: params.userId,
+      agentId: params.agentId,
+      clientThreadId: params.clientThreadId,
+      pin: params.agentPin,
+    });
+    return {
+      threadId: thread.id,
+      sessionId: undefined,
+      incompleteContext: "",
+      isNewThread: true,
+    };
+  }
+
+  const [thread] = await params.db
+    .select({ id: chatThreads.id })
+    .from(chatThreads)
+    .where(
+      and(
+        eq(chatThreads.id, params.existingThreadId),
+        eq(chatThreads.userId, params.userId),
+      ),
+    )
+    .limit(1);
+  if (!thread) {
+    return notFound("Chat thread not found");
+  }
+
+  const [sessionId, incompleteRows] = await Promise.all([
+    params.forceNewSession
+      ? Promise.resolve(undefined)
+      : latestSessionIdForThread(params.db, thread.id),
+    getIncompleteRoundsSinceLastSuccess(params.db, thread.id),
+  ]);
+  return {
+    threadId: thread.id,
+    sessionId,
+    incompleteContext: params.forceNewSession
+      ? ""
+      : buildWebChatIncompleteContext(
+          groupIncompleteRoundsByRunId(incompleteRows),
+        ),
+    isNewThread: false,
+  };
+}
+
+async function prepareForceNewSessionContext(
+  db: Db,
+  threadId: string,
+  forceNewSession: boolean,
+  isNewThread: boolean,
+): Promise<string> {
+  if (!forceNewSession || isNewThread) {
+    return "";
+  }
+  await db
+    .update(chatThreads)
+    .set({
+      modelProviderId: null,
+      modelProviderType: null,
+      modelProviderCredentialScope: null,
+      selectedModel: null,
+      updatedAt: nowDate(),
+    })
+    .where(eq(chatThreads.id, threadId));
+  return buildWebChatPriorMessagesContext(
+    await getLatestMessagesByThreadId(
+      db,
+      threadId,
+      PRIOR_HISTORY_MESSAGE_LIMIT,
+    ),
+  );
+}
+
+function appendUnassociatedUserMessage(params: {
+  readonly db: Db;
+  readonly threadId: string;
+  readonly userId: string;
+  readonly prompt: string;
+  readonly attachFiles: readonly AttachFile[] | undefined;
+  readonly clientMessageId: string | undefined;
+  readonly goalOrigin: GoalOriginRow | null;
+}): Promise<{ readonly createdAt: Date }> {
+  return params.db.transaction(async (tx) => {
+    await tx
+      .update(chatThreads)
+      .set({ draftContent: null, draftAttachments: null })
+      .where(
+        and(
+          eq(chatThreads.id, params.threadId),
+          eq(chatThreads.userId, params.userId),
+        ),
+      );
+
+    const explicitId =
+      params.goalOrigin?.messageId ?? params.clientMessageId ?? undefined;
+    const attachFileIds = params.attachFiles?.map((file) => {
+      return file.id;
+    });
+    const [inserted] = await tx
+      .insert(chatMessages)
+      .values({
+        ...(explicitId ? { id: explicitId } : {}),
+        chatThreadId: params.threadId,
+        role: "user",
+        content: params.prompt,
+        runId: null,
+        attachFiles:
+          attachFileIds && attachFileIds.length > 0 ? attachFileIds : null,
+        goalRemainingTurns: params.goalOrigin?.remainingTurns ?? null,
+        goalOriginMessageId: params.goalOrigin?.messageId ?? null,
+      })
+      .onConflictDoNothing({ target: chatMessages.id })
+      .returning({ createdAt: chatMessages.createdAt });
+    if (inserted) {
+      return inserted;
+    }
+    if (!explicitId) {
+      throw new Error("Failed to insert unassociated user message");
+    }
+    const [existing] = await tx
+      .select({ createdAt: chatMessages.createdAt })
+      .from(chatMessages)
+      .innerJoin(chatThreads, eq(chatThreads.id, chatMessages.chatThreadId))
+      .where(
+        and(
+          eq(chatMessages.id, explicitId),
+          eq(chatMessages.chatThreadId, params.threadId),
+          eq(chatThreads.userId, params.userId),
+          eq(chatMessages.role, "user"),
+          isNull(chatMessages.runId),
+        ),
+      )
+      .limit(1);
+    if (!existing) {
+      throw new Error("Failed to resolve unassociated user message");
+    }
+    return existing;
+  });
+}
+
+async function appendAssociatedUserMessage(params: {
+  readonly db: Db;
+  readonly threadId: string;
+  readonly userId: string;
+  readonly prompt: string;
+  readonly runId: string;
+  readonly attachFiles: readonly AttachFile[] | undefined;
+  readonly clientMessageId: string | undefined;
+  readonly goalOrigin: GoalOriginRow | null;
+}): Promise<void> {
+  await params.db.transaction(async (tx) => {
+    await tx
+      .update(chatThreads)
+      .set({ draftContent: null, draftAttachments: null })
+      .where(
+        and(
+          eq(chatThreads.id, params.threadId),
+          eq(chatThreads.userId, params.userId),
+        ),
+      );
+    const explicitId =
+      params.goalOrigin?.messageId ?? params.clientMessageId ?? undefined;
+    const attachFileIds = params.attachFiles?.map((file) => {
+      return file.id;
+    });
+    await tx
+      .insert(chatMessages)
+      .values({
+        ...(explicitId ? { id: explicitId } : {}),
+        chatThreadId: params.threadId,
+        role: "user",
+        content: params.prompt,
+        runId: params.runId,
+        attachFiles:
+          attachFileIds && attachFileIds.length > 0 ? attachFileIds : null,
+        goalRemainingTurns: params.goalOrigin?.remainingTurns ?? null,
+        goalOriginMessageId: params.goalOrigin?.messageId ?? null,
+      })
+      .onConflictDoNothing({ target: chatMessages.id });
+  });
+}
+
+function appendRecallUserMessage(params: {
+  readonly db: Db;
+  readonly threadId: string;
+  readonly revokesMessageId: string;
+  readonly clientMessageId: string | undefined;
+}): Promise<AppendMessageResult> {
+  return params.db.transaction(async (tx) => {
+    const [existingRevoker] = await tx
+      .select({
+        role: chatMessages.role,
+        runId: chatMessages.runId,
+        createdAt: chatMessages.createdAt,
+      })
+      .from(chatMessages)
+      .where(
+        and(
+          eq(chatMessages.chatThreadId, params.threadId),
+          eq(chatMessages.revokesMessageId, params.revokesMessageId),
+        ),
+      )
+      .limit(1);
+    if (existingRevoker) {
+      if (existingRevoker.role === "user" && existingRevoker.runId === null) {
+        return { ok: true, createdAt: existingRevoker.createdAt };
+      }
+      return {
+        ok: false,
+        message: "Only queued user messages can be recalled",
+      };
+    }
+
+    const [target] = await tx
+      .select({ id: chatMessages.id })
+      .from(chatMessages)
+      .where(
+        and(
+          eq(chatMessages.id, params.revokesMessageId),
+          eq(chatMessages.chatThreadId, params.threadId),
+          eq(chatMessages.role, "user"),
+          isNull(chatMessages.runId),
+          isNull(chatMessages.revokesMessageId),
+        ),
+      )
+      .limit(1);
+    if (!target) {
+      return {
+        ok: false,
+        message: "Only queued user messages can be recalled",
+      };
+    }
+
+    const [inserted] = await tx
+      .insert(chatMessages)
+      .values({
+        ...(params.clientMessageId ? { id: params.clientMessageId } : {}),
+        chatThreadId: params.threadId,
+        role: "user",
+        content: null,
+        runId: null,
+        revokesMessageId: params.revokesMessageId,
+        attachFiles: null,
+      })
+      .onConflictDoNothing()
+      .returning({ createdAt: chatMessages.createdAt });
+    if (inserted) {
+      return { ok: true, createdAt: inserted.createdAt };
+    }
+    const [resolved] = await tx
+      .select({ createdAt: chatMessages.createdAt })
+      .from(chatMessages)
+      .where(
+        and(
+          eq(chatMessages.chatThreadId, params.threadId),
+          eq(chatMessages.revokesMessageId, params.revokesMessageId),
+          eq(chatMessages.role, "user"),
+          isNull(chatMessages.runId),
+        ),
+      )
+      .limit(1);
+    if (!resolved) {
+      return { ok: false, message: "Failed to insert recall user message" };
+    }
+    return { ok: true, createdAt: resolved.createdAt };
+  });
+}
+
+function appendInterruptUserMessage(params: {
+  readonly db: Db;
+  readonly threadId: string;
+  readonly interruptsRunId: string;
+  readonly clientMessageId: string | undefined;
+}): Promise<AppendMessageResult> {
+  return params.db.transaction(async (tx) => {
+    const [existingInterrupter] = await tx
+      .select({
+        role: chatMessages.role,
+        runId: chatMessages.runId,
+        createdAt: chatMessages.createdAt,
+      })
+      .from(chatMessages)
+      .where(
+        and(
+          eq(chatMessages.chatThreadId, params.threadId),
+          eq(chatMessages.interruptsRunId, params.interruptsRunId),
+        ),
+      )
+      .limit(1);
+    if (existingInterrupter) {
+      if (
+        existingInterrupter.role === "user" &&
+        existingInterrupter.runId === null
+      ) {
+        return { ok: true, createdAt: existingInterrupter.createdAt };
+      }
+      return {
+        ok: false,
+        message: "Only active chat runs can be interrupted",
+      };
+    }
+
+    const [targetRun] = await tx
+      .select({ id: agentRuns.id })
+      .from(agentRuns)
+      .innerJoin(zeroRuns, eq(zeroRuns.id, agentRuns.id))
+      .where(
+        and(
+          eq(agentRuns.id, params.interruptsRunId),
+          eq(zeroRuns.chatThreadId, params.threadId),
+          inArray(agentRuns.status, ["queued", "pending", "running"]),
+        ),
+      )
+      .limit(1);
+    if (!targetRun) {
+      return {
+        ok: false,
+        message: "Only active chat runs can be interrupted",
+      };
+    }
+
+    const [inserted] = await tx
+      .insert(chatMessages)
+      .values({
+        ...(params.clientMessageId ? { id: params.clientMessageId } : {}),
+        chatThreadId: params.threadId,
+        role: "user",
+        content: null,
+        runId: null,
+        interruptsRunId: params.interruptsRunId,
+        attachFiles: null,
+      })
+      .onConflictDoNothing()
+      .returning({ createdAt: chatMessages.createdAt });
+    if (inserted) {
+      return { ok: true, createdAt: inserted.createdAt };
+    }
+    const [resolved] = await tx
+      .select({ createdAt: chatMessages.createdAt })
+      .from(chatMessages)
+      .where(
+        and(
+          eq(chatMessages.chatThreadId, params.threadId),
+          eq(chatMessages.interruptsRunId, params.interruptsRunId),
+          eq(chatMessages.role, "user"),
+          isNull(chatMessages.runId),
+        ),
+      )
+      .limit(1);
+    if (!resolved) {
+      return { ok: false, message: "Failed to insert interrupt user message" };
+    }
+    return { ok: true, createdAt: resolved.createdAt };
+  });
+}
+
+async function publishChatMessageCreated(
+  userId: string,
+  threadId: string,
+): Promise<void> {
+  await publishUserSignal([userId], `chatThreadMessageCreated:${threadId}`);
+  await publishThreadListChanged(userId);
+}
+
+async function assertOwnedThread(
+  db: Db,
+  threadId: string,
+  userId: string,
+): Promise<ReturnType<typeof notFound> | undefined> {
+  const [thread] = await db
+    .select({ id: chatThreads.id })
+    .from(chatThreads)
+    .where(and(eq(chatThreads.id, threadId), eq(chatThreads.userId, userId)))
+    .limit(1);
+  return thread ? undefined : notFound("Chat thread not found");
+}
+
+const handleRecallSend$ = command(
+  async (
+    { set },
+    args: {
+      readonly body: RecallSendBody;
+      readonly userId: string;
+    },
+    signal: AbortSignal,
+  ) => {
+    const db = set(writeDb$);
+    const ownership = await assertOwnedThread(
+      db,
+      args.body.threadId,
+      args.userId,
+    );
+    signal.throwIfAborted();
+    if (ownership) {
+      return ownership;
+    }
+
+    const message = await appendRecallUserMessage({
+      db,
+      threadId: args.body.threadId,
+      revokesMessageId: args.body.revokesMessageId,
+      clientMessageId: args.body.clientMessageId,
+    });
+    signal.throwIfAborted();
+    if (!message.ok) {
+      return badRequestMessage(message.message);
+    }
+
+    await publishChatMessageCreated(args.userId, args.body.threadId);
+    signal.throwIfAborted();
+    return {
+      status: 201 as const,
+      body: {
+        runId: null,
+        threadId: args.body.threadId,
+        createdAt: message.createdAt.toISOString(),
+      },
+    };
+  },
+);
+
+const handleInterruptSend$ = command(
+  async (
+    { set },
+    args: {
+      readonly body: InterruptSendBody;
+      readonly userId: string;
+      readonly orgId: string;
+    },
+    signal: AbortSignal,
+  ) => {
+    const db = set(writeDb$);
+    const ownership = await assertOwnedThread(
+      db,
+      args.body.threadId,
+      args.userId,
+    );
+    signal.throwIfAborted();
+    if (ownership) {
+      return ownership;
+    }
+
+    const message = await appendInterruptUserMessage({
+      db,
+      threadId: args.body.threadId,
+      interruptsRunId: args.body.interruptsRunId,
+      clientMessageId: args.body.clientMessageId,
+    });
+    signal.throwIfAborted();
+    if (!message.ok) {
+      return badRequestMessage(message.message);
+    }
+
+    await publishChatMessageCreated(args.userId, args.body.threadId);
+    signal.throwIfAborted();
+
+    const cancelResult = await set(
+      cancelRun$,
+      {
+        runId: args.body.interruptsRunId,
+        userId: args.userId,
+        orgId: args.orgId,
+      },
+      signal,
+    );
+    signal.throwIfAborted();
+    if (!isCancelResult(cancelResult)) {
+      return cancelResult;
+    }
+    if (!cancelResult.alreadyCancelled) {
+      waitUntil(
+        set(dispatchCancelSideEffects$, cancelResult, signal).catch(() => {}),
+      );
+    }
+
+    return {
+      status: 201 as const,
+      body: {
+        runId: null,
+        threadId: args.body.threadId,
+        createdAt: message.createdAt.toISOString(),
+      },
+    };
+  },
+);
+
+const prepareNormalSend$ = command(
+  async (
+    { get, set },
+    args: NormalSendArgs,
+    signal: AbortSignal,
+  ): Promise<PreparedNormalSend | NormalSendFailure> => {
+    const db = set(writeDb$);
+    const agent = await loadAgentForChatSend(db, args.body.agentId);
+    signal.throwIfAborted();
+    if (!agent || agent.orgId !== args.orgId) {
+      return notFound("Agent not found");
+    }
+    if (agent.visibility === "private" && agent.owner !== args.userId) {
+      return forbidden("Only the private agent owner can run this agent");
+    }
+
+    const useModelFirst = await modelFirstEnabled(get, args.orgId, args.userId);
+    signal.throwIfAborted();
+    const forceNewSession = args.body.forceNewSession === true;
+    const modelError = await validateModelSelection({
+      db,
+      orgId: args.orgId,
+      threadId: args.body.threadId,
+      modelSelection: args.body.modelSelection,
+      modelFirst: useModelFirst,
+      forceNewSession,
+    });
+    signal.throwIfAborted();
+    if (modelError) {
+      return modelError;
+    }
+
+    const goalSetup = await resolveGoalSetup(
+      get,
+      args.body,
+      args.orgId,
+      args.userId,
+    );
+    signal.throwIfAborted();
+    if ("status" in goalSetup) {
+      return goalSetup;
+    }
+
+    const eagerPin = args.body.threadId
+      ? {
+          modelProviderId: agent.modelProviderId,
+          modelProviderType: null,
+          modelProviderCredentialScope: null,
+          selectedModel: agent.selectedModel,
+        }
+      : useModelFirst
+        ? await defaultModelFirstPin(db, args.orgId, args.userId)
+        : {
+            modelProviderId: agent.modelProviderId,
+            modelProviderType: null,
+            modelProviderCredentialScope: null,
+            selectedModel: agent.selectedModel,
+          };
+
+    const thread = await resolveThread({
+      db,
+      userId: args.userId,
+      agentId: args.body.agentId,
+      existingThreadId: args.body.threadId,
+      clientThreadId: args.body.clientThreadId,
+      agentPin: eagerPin,
+      forceNewSession,
+    });
+    signal.throwIfAborted();
+    if ("status" in thread) {
+      return thread;
+    }
+
+    const priorContext = await prepareForceNewSessionContext(
+      db,
+      thread.threadId,
+      forceNewSession,
+      thread.isNewThread,
+    );
+    signal.throwIfAborted();
+
+    const persistedExplicitSelection =
+      await maybePersistExplicitModelFirstSelection({
+        db,
+        orgId: args.orgId,
+        userId: args.userId,
+        threadId: thread.threadId,
+        modelFirst: useModelFirst,
+        modelSelection: args.body.modelSelection,
+        forceNewSession,
+      });
+    signal.throwIfAborted();
+
+    return {
+      db,
+      agent,
+      modelFirst: useModelFirst,
+      forceNewSession,
+      goalSetup,
+      thread,
+      priorContext,
+      persistedExplicitSelection,
+    };
+  },
+);
+
+async function queueUnassociatedNormalMessage(params: {
+  readonly prepared: PreparedNormalSend;
+  readonly body: NormalSendBody;
+  readonly userId: string;
+}): Promise<CreatedChatMessageResponse> {
+  const message = await appendUnassociatedUserMessage({
+    db: params.prepared.db,
+    threadId: params.prepared.thread.threadId,
+    userId: params.userId,
+    prompt: params.body.prompt,
+    attachFiles: params.body.attachFiles,
+    clientMessageId: params.body.clientMessageId,
+    goalOrigin: params.prepared.goalSetup.goalOriginRow,
+  });
+  await publishChatMessageCreated(
+    params.userId,
+    params.prepared.thread.threadId,
+  );
+  return {
+    status: 201,
+    body: {
+      runId: null,
+      threadId: params.prepared.thread.threadId,
+      createdAt: message.createdAt.toISOString(),
+    },
+  };
+}
+
+const createNormalChatRun$ = command(
+  async (
+    { set },
+    params: {
+      readonly args: NormalSendArgs;
+      readonly prepared: PreparedNormalSend;
+    },
+    signal: AbortSignal,
+  ) => {
+    const { args, prepared } = params;
+    const modelPin = await resolveRunModelPin({
+      db: prepared.db,
+      orgId: args.orgId,
+      userId: args.userId,
+      threadId: prepared.thread.threadId,
+      agent: prepared.agent,
+      modelFirst: prepared.modelFirst,
+      modelSelection: args.body.modelSelection,
+      forceNewSession: prepared.forceNewSession,
+    });
+    signal.throwIfAborted();
+
+    const fullPrompt = buildFullPrompt(args.body.prompt, args.body.attachFiles);
+    const requestedModelProvider =
+      args.body.modelProvider && args.body.modelProvider !== "default"
+        ? args.body.modelProvider
+        : undefined;
+    const runResult = await set(
+      createAgentRun$,
+      {
+        userId: args.userId,
+        orgId: args.orgId,
+        apiStartTime: args.apiStartTime,
+        chatThreadId: prepared.thread.threadId,
+        includeZeroTokenSecret: true,
+        callbacks: [
+          {
+            url: chatCallbackUrl(),
+            secret: generateCallbackSecret(),
+            payload: {
+              threadId: prepared.thread.threadId,
+              agentId: args.body.agentId,
+            },
+          },
+        ],
+        body: {
+          prompt: fullPrompt,
+          agentComposeId: args.body.agentId,
+          ...(prepared.thread.sessionId
+            ? { sessionId: prepared.thread.sessionId }
+            : {}),
+          triggerSource: "web" as const,
+          appendSystemPrompt: buildAppendSystemPrompt(
+            prepared.thread.incompleteContext,
+            prepared.priorContext,
+            prepared.goalSetup.goalContext,
+          ),
+          vars: { ZERO_AGENT_ID: args.body.agentId },
+          debugNoMockClaude: args.body.debugNoMockClaude,
+          debugNoMockCodex: args.body.debugNoMockCodex,
+        },
+      },
+      signal,
+    );
+    signal.throwIfAborted();
+    if (runResult.status !== 201) {
+      return runResult;
+    }
+
+    await prepared.db
+      .update(zeroRuns)
+      .set({
+        modelProvider: modelPin.modelProviderType ?? requestedModelProvider,
+        modelProviderId: modelPin.modelProviderId,
+        modelProviderCredentialScope: modelPin.modelProviderCredentialScope,
+        selectedModel: modelPin.selectedModel,
+      })
+      .where(eq(zeroRuns.id, runResult.body.runId));
+    signal.throwIfAborted();
+
+    waitUntil(
+      (async () => {
+        await appendAssociatedUserMessage({
+          db: prepared.db,
+          threadId: prepared.thread.threadId,
+          userId: args.userId,
+          prompt: args.body.prompt,
+          runId: runResult.body.runId,
+          attachFiles: args.body.attachFiles,
+          clientMessageId: prepared.goalSetup.goalOriginRow
+            ? undefined
+            : args.body.clientMessageId,
+          goalOrigin: prepared.goalSetup.goalOriginRow,
+        });
+        await publishUserSignal(
+          [args.userId],
+          `chatThreadMessageCreated:${prepared.thread.threadId}`,
+        );
+        await publishUserSignal(
+          [args.userId],
+          `chatThreadRunCreated:${prepared.thread.threadId}`,
+        );
+        await publishThreadListChanged(args.userId);
+      })(),
+    );
+
+    if (prepared.persistedExplicitSelection && modelPin.selectedModel) {
+      await updateUserModelPreference(
+        prepared.db,
+        args.orgId,
+        args.userId,
+        modelPin.selectedModel,
+      );
+      signal.throwIfAborted();
+    }
+
+    return {
+      status: 201 as const,
+      body: {
+        runId: runResult.body.runId,
+        threadId: prepared.thread.threadId,
+        status: runResult.body.status,
+        createdAt: runResult.body.createdAt,
+      },
+    };
+  },
+);
+
+const sendNormalMessage$ = command(
+  async ({ set }, args: NormalSendArgs, signal: AbortSignal) => {
+    const prepared = await set(prepareNormalSend$, args, signal);
+    signal.throwIfAborted();
+    if ("status" in prepared) {
+      return prepared;
+    }
+
+    if (await activeRunExistsForThread(prepared.db, prepared.thread.threadId)) {
+      const response = await queueUnassociatedNormalMessage({
+        prepared,
+        body: args.body,
+        userId: args.userId,
+      });
+      signal.throwIfAborted();
+      return response;
+    }
+    signal.throwIfAborted();
+
+    return await set(createNormalChatRun$, { args, prepared }, signal);
+  },
+);
+
+const sendChatMessageInner$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const auth = get(organizationAuthContext$);
+    const body = await get(sendBody$);
+    signal.throwIfAborted();
+    if (!body.ok) {
+      return body.response;
+    }
+
+    if (isRecallSendBody(body.data)) {
+      return await set(
+        handleRecallSend$,
+        { body: body.data, userId: auth.userId },
+        signal,
+      );
+    }
+    if (isInterruptSendBody(body.data)) {
+      return await set(
+        handleInterruptSend$,
+        { body: body.data, userId: auth.userId, orgId: auth.orgId },
+        signal,
+      );
+    }
+    if (!isNormalSendBody(body.data)) {
+      return badRequestMessage("Prompt is required");
+    }
+
+    return await set(
+      sendNormalMessage$,
+      {
+        body: body.data,
+        userId: auth.userId,
+        orgId: auth.orgId,
+        apiStartTime: now(),
+      },
+      signal,
+    );
+  },
+);
+
+export const zeroChatMessagesRoutes: readonly RouteEntry[] = [
+  {
+    route: chatMessagesContract.send,
+    handler: authRoute(
+      {
+        requireOrganization: true,
+        missingOrganizationStatus: 401,
+        requiredCapability: "agent-run:write",
+      },
+      sendChatMessageInner$,
+    ),
+  },
+];

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -49,6 +49,7 @@ import {
 import { writeDb$, type Db } from "../external/db";
 import { publishRunnerJobNotification } from "../external/realtime";
 import { now, nowDate } from "../external/time";
+import { generateZeroToken } from "../auth/tokens";
 import { safeAsync } from "../utils";
 import {
   decryptSecretValue,
@@ -73,6 +74,23 @@ const ORG_SENTINEL_USER_ID = "__org__";
 
 type CreateRunBody = z.infer<typeof unifiedRunRequestSchema>;
 type ComputedGetter = Getter;
+
+function withZeroTokenSecret(
+  body: CreateRunBody,
+  zeroToken: string,
+): CreateRunBody {
+  return {
+    ...body,
+    secrets: {
+      ...body.secrets,
+      ZERO_TOKEN: zeroToken,
+    },
+  };
+}
+
+function withPendingZeroTokenSecret(body: CreateRunBody): CreateRunBody {
+  return withZeroTokenSecret(body, "__pending_zero_token__");
+}
 
 interface ContextArtifact {
   readonly name: string;
@@ -1005,6 +1023,7 @@ async function dispatchRun(
     readonly modelProvider: ResolvedModelProviderEnvironment | null;
     readonly apiStartTime: number;
     readonly additionalVolumes: readonly AdditionalVolume[] | undefined;
+    readonly includeZeroTokenSecret: boolean | undefined;
   },
 ): Promise<{ readonly status: RunStatus; readonly sandboxId?: string }> {
   await db
@@ -1022,11 +1041,17 @@ async function dispatchRun(
   }
 
   const profile = runnerProfile(args.resolved.content);
+  const body = args.includeZeroTokenSecret
+    ? withZeroTokenSecret(
+        args.body,
+        generateZeroToken(args.userId, args.run.id, args.orgId),
+      )
+    : args.body;
   const storageManifest = await prepareAgentRunStorageManifest({
     get,
     db,
     content: args.resolved.content,
-    vars: args.body.vars,
+    vars: body.vars,
     agentOrgId: args.resolved.orgId,
     runtimeOrgId: args.orgId,
     userId: args.userId,
@@ -1037,6 +1062,7 @@ async function dispatchRun(
   });
   const storedContext = buildStoredExecutionContext({
     ...args,
+    body,
     runId: args.run.id,
     storageManifest,
   });
@@ -1102,27 +1128,26 @@ export const createAgentRun$ = command(
       readonly apiStartTime: number;
       readonly callbacks?: readonly RunCallback[];
       readonly chatThreadId?: string;
+      readonly includeZeroTokenSecret?: boolean;
     },
     signal: AbortSignal,
   ): Promise<CreateRunRouteResult> => {
     const db = set(writeDb$);
+    const body = args.includeZeroTokenSecret
+      ? withPendingZeroTokenSecret(args.body)
+      : args.body;
 
     const captureGate = await enforceCaptureNetworkBodiesGate(
       db,
       args.userId,
-      args.body.captureNetworkBodies,
+      body.captureNetworkBodies,
     );
     signal.throwIfAborted();
     if (captureGate) {
       return captureGate;
     }
 
-    const resolved = await resolveCompose(
-      db,
-      args.body,
-      args.userId,
-      args.orgId,
-    );
+    const resolved = await resolveCompose(db, body, args.userId, args.orgId);
     signal.throwIfAborted();
     if (isRouteError(resolved)) {
       return resolved;
@@ -1134,8 +1159,8 @@ export const createAgentRun$ = command(
 
     const validation = validateCompose(
       resolved.content,
-      args.body.vars,
-      args.body.secrets,
+      body.vars,
+      body.secrets,
     );
     if (isRouteError(validation)) {
       return validation;
@@ -1164,10 +1189,10 @@ export const createAgentRun$ = command(
     const artifacts = artifactsForRun({
       resolved,
       framework: validation.framework,
-      bodyArtifacts: args.body.artifacts,
+      bodyArtifacts: body.artifacts,
     });
     const additionalVolumes =
-      args.body.additionalVolumes ?? resolved.additionalVolumes;
+      body.additionalVolumes ?? resolved.additionalVolumes;
 
     const transactionResult = await db.transaction(async (tx) => {
       await tx.execute(
@@ -1181,7 +1206,7 @@ export const createAgentRun$ = command(
         userId: args.userId,
         orgId: args.orgId,
         resolved,
-        body: args.body,
+        body,
         artifacts,
         additionalVolumes,
         modelProvider,
@@ -1201,12 +1226,13 @@ export const createAgentRun$ = command(
         userId: args.userId,
         orgId: args.orgId,
         resolved,
-        body: args.body,
+        body,
         artifacts,
         framework: validation.framework,
         modelProvider,
         apiStartTime: args.apiStartTime,
         additionalVolumes,
+        includeZeroTokenSecret: args.includeZeroTokenSecret,
       });
     });
     signal.throwIfAborted();

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -57,6 +57,7 @@ import {
   encryptSecretsMap,
 } from "./crypto.utils";
 import { prepareAgentRunStorageManifest } from "./agent-run-storage.service";
+import { userFeatureSwitchOverrides } from "./feature-switches.service";
 
 const PENDING_RUN_TTL_MS = 15 * 60 * 1000;
 const AUTO_MEMORY_ARTIFACT_NAME = "memory";
@@ -1041,10 +1042,18 @@ async function dispatchRun(
   }
 
   const profile = runnerProfile(args.resolved.content);
+  const featureSwitchOverrides = args.includeZeroTokenSecret
+    ? await get(userFeatureSwitchOverrides(args.orgId, args.userId))
+    : undefined;
   const body = args.includeZeroTokenSecret
     ? withZeroTokenSecret(
         args.body,
-        generateZeroToken(args.userId, args.run.id, args.orgId),
+        generateZeroToken(
+          args.userId,
+          args.run.id,
+          args.orgId,
+          featureSwitchOverrides,
+        ),
       )
     : args.body;
   const storageManifest = await prepareAgentRunStorageManifest({

--- a/turbo/apps/api/src/signals/services/zero-chat-title.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-title.service.ts
@@ -1,0 +1,212 @@
+import { agentRuns } from "@vm0/db/schema/agent-run";
+import { chatMessages } from "@vm0/db/schema/chat-message";
+import { chatThreads } from "@vm0/db/schema/chat-thread";
+import { and, desc, eq, inArray, isNotNull } from "drizzle-orm";
+
+import { optionalEnv } from "../../lib/env";
+import { logger } from "../../lib/log";
+import { publishThreadListChanged } from "../external/realtime";
+import type { Db } from "../external/db";
+import { safeAsync } from "../utils";
+import { visibleChatMessageCondition } from "./zero-chat-thread.service";
+
+const log = logger("api:zero:chat-title");
+const OPENROUTER_CHAT_COMPLETIONS_URL =
+  "https://openrouter.ai/api/v1/chat/completions";
+const TITLE_MODEL = "google/gemini-3.1-flash-lite-preview";
+const TITLE_CONTEXT_CHAR_CAP = 150;
+const TITLE_PRIOR_MESSAGE_CAP = 10;
+
+interface TitleContextMessage {
+  readonly role: "user" | "assistant";
+  readonly content: string;
+}
+
+interface ChatTitleInput {
+  readonly currentUserMessage: string;
+  readonly priorRounds?: readonly TitleContextMessage[];
+}
+
+interface OpenRouterResponse {
+  readonly choices: readonly {
+    readonly message: {
+      readonly content: string;
+    };
+  }[];
+}
+
+interface ChatMessageForGeneration {
+  readonly role: "system" | "user" | "assistant";
+  readonly content: string;
+}
+
+export function isChatTitleGenerationConfigured(): boolean {
+  return Boolean(optionalEnv("OPENROUTER_API_KEY"));
+}
+
+function stripMarkdown(text: string): string {
+  return text
+    .replace(/(\*{1,3}|_{1,3})(.+?)\1/g, "$2")
+    .replace(/^#{1,6}\s+/gm, "")
+    .replace(/^[-*_]{3,}\s*$/gm, "")
+    .replace(/`([^`]+)`/g, "$1")
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
+    .replace(/^["'](.+)["']$/, "$1")
+    .trim();
+}
+
+async function generateText(
+  messages: readonly ChatMessageForGeneration[],
+  maxTokens = 30,
+): Promise<string | null> {
+  const apiKey = optionalEnv("OPENROUTER_API_KEY");
+  if (!apiKey) {
+    return null;
+  }
+
+  const response = await fetch(OPENROUTER_CHAT_COMPLETIONS_URL, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      model: TITLE_MODEL,
+      messages,
+      max_tokens: maxTokens,
+      temperature: 0.3,
+    }),
+  });
+
+  if (!response.ok) {
+    const text = await response.text().catch(() => {
+      return "unknown error";
+    });
+    throw new Error(`OpenRouter request failed: ${response.status} ${text}`);
+  }
+
+  const data = (await response.json()) as OpenRouterResponse;
+  const content = data.choices[0]?.message.content.trim();
+  if (!content) {
+    throw new Error("OpenRouter returned empty content");
+  }
+
+  return stripMarkdown(content);
+}
+
+function generateChatTitle(input: ChatTitleInput): Promise<string | null> {
+  const sections: string[] = [];
+
+  if (input.priorRounds && input.priorRounds.length > 0) {
+    const recent = input.priorRounds.slice(-TITLE_PRIOR_MESSAGE_CAP);
+    const history = recent
+      .map((message) => {
+        return `${message.role}: ${message.content.slice(0, TITLE_CONTEXT_CHAR_CAP)}`;
+      })
+      .join("\n");
+    sections.push(
+      `Previous conversation (last ${recent.length} messages, for continuity):\n${history}`,
+    );
+  }
+
+  sections.push(
+    `Most recent user message:\n${input.currentUserMessage.slice(0, TITLE_CONTEXT_CHAR_CAP)}`,
+  );
+
+  return generateText([
+    {
+      role: "system",
+      content:
+        "Generate a short, descriptive title (max 60 chars) for a chat conversation. Weight the most recent exchange highest, but use the earlier rounds to keep the title consistent as the thread evolves. Return only the title as plain text. Do not use any markdown syntax such as #, *, **, _, ---, ``` or quotes. Just plain text.",
+    },
+    {
+      role: "user",
+      content: sections.join("\n\n"),
+    },
+  ]);
+}
+
+async function getLatestTitleContextMessages(
+  db: Db,
+  threadId: string,
+): Promise<TitleContextMessage[]> {
+  const rows = await db
+    .select({
+      role: chatMessages.role,
+      content: chatMessages.content,
+      createdAt: chatMessages.createdAt,
+      sequenceNumber: chatMessages.sequenceNumber,
+    })
+    .from(chatMessages)
+    .leftJoin(agentRuns, eq(agentRuns.id, chatMessages.runId))
+    .where(
+      and(
+        eq(chatMessages.chatThreadId, threadId),
+        isNotNull(chatMessages.content),
+        inArray(chatMessages.role, ["user", "assistant"]),
+        visibleChatMessageCondition(),
+      ),
+    )
+    .orderBy(desc(chatMessages.createdAt), desc(chatMessages.sequenceNumber))
+    .limit(TITLE_PRIOR_MESSAGE_CAP);
+
+  return rows.reverse().flatMap((row) => {
+    if (
+      row.content === null ||
+      (row.role !== "user" && row.role !== "assistant")
+    ) {
+      return [];
+    }
+    return [{ role: row.role, content: row.content }];
+  });
+}
+
+async function updateChatThreadTitle(
+  db: Db,
+  threadId: string,
+  userId: string,
+  title: string,
+): Promise<void> {
+  const [thread] = await db
+    .select({ renamedAt: chatThreads.renamedAt })
+    .from(chatThreads)
+    .where(eq(chatThreads.id, threadId))
+    .limit(1);
+
+  if (thread?.renamedAt) {
+    return;
+  }
+
+  await db
+    .update(chatThreads)
+    .set({ title })
+    .where(eq(chatThreads.id, threadId));
+  await publishThreadListChanged(userId);
+}
+
+export async function generateAndPersistChatThreadTitle(args: {
+  readonly db: Db;
+  readonly threadId: string;
+  readonly userId: string;
+  readonly prompt: string;
+  readonly includePriorRounds: boolean;
+}): Promise<void> {
+  const result = await safeAsync(async () => {
+    const priorRounds = args.includePriorRounds
+      ? await getLatestTitleContextMessages(args.db, args.threadId)
+      : [];
+    const title = await generateChatTitle({
+      currentUserMessage: args.prompt,
+      priorRounds: priorRounds.length > 0 ? priorRounds : undefined,
+    });
+    if (title) {
+      await updateChatThreadTitle(args.db, args.threadId, args.userId, title);
+    }
+  });
+  if ("error" in result) {
+    log.warn("Chat title generation failed", {
+      threadId: args.threadId,
+      err: result.error,
+    });
+  }
+}

--- a/turbo/apps/api/src/signals/services/zero-run-admission.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-run-admission.service.ts
@@ -1,0 +1,54 @@
+import { sql } from "drizzle-orm";
+
+import { insufficientCredits } from "../../lib/error";
+import type { Db } from "../external/db";
+
+interface CreditCheckRow extends Record<string, unknown> {
+  readonly credit_enabled: boolean | null;
+  readonly credits: string | null;
+  readonly unsettled_expired: string | null;
+}
+
+export async function checkOrgCreditsForRunAdmission(params: {
+  readonly db: Db;
+  readonly orgId: string;
+  readonly userId: string;
+  readonly modelProviderType: string | null | undefined;
+}): Promise<ReturnType<typeof insufficientCredits> | undefined> {
+  if (params.modelProviderType !== "vm0") {
+    return undefined;
+  }
+
+  const { rows } = await params.db.execute<CreditCheckRow>(sql`
+    WITH member AS (
+      SELECT credit_enabled FROM org_members_metadata
+      WHERE org_id = ${params.orgId} AND user_id = ${params.userId}
+      LIMIT 1
+    ),
+    org AS (
+      SELECT credits FROM org_metadata
+      WHERE org_id = ${params.orgId}
+      LIMIT 1
+    ),
+    expired AS (
+      SELECT COALESCE(SUM(remaining), 0)::bigint AS total
+      FROM credit_expires_record
+      WHERE org_id = ${params.orgId}
+        AND expires_at <= now()
+        AND remaining > 0
+    )
+    SELECT
+      (SELECT credit_enabled FROM member) AS credit_enabled,
+      (SELECT credits FROM org) AS credits,
+      (SELECT total FROM expired) AS unsettled_expired
+  `);
+
+  const row = rows[0];
+  if (!row || row.credit_enabled === false || row.credits === null) {
+    return insufficientCredits();
+  }
+
+  const credits = Number(row.credits);
+  const unsettledExpired = Number(row.unsettled_expired ?? 0);
+  return credits - unsettledExpired > 0 ? undefined : insufficientCredits();
+}

--- a/turbo/packages/api-contracts/src/contracts/chat-threads.ts
+++ b/turbo/packages/api-contracts/src/contracts/chat-threads.ts
@@ -525,6 +525,7 @@ export const chatMessagesContract = c.router({
       }),
       400: apiErrorSchema,
       401: apiErrorSchema,
+      402: apiErrorSchema,
       403: apiErrorSchema,
       404: apiErrorSchema,
       422: apiErrorSchema,


### PR DESCRIPTION
## Summary
- Add an API-native `POST /api/zero/chat/messages` route in `apps/api` and register it in the API route table.
- Reimplement the web chat send/queue/recall/interrupt flows without importing or sharing code from `apps/web`.
- Extend API run creation to inject a run-scoped `ZERO_TOKEN` secret for chat runs and add route-integrated coverage for the migrated endpoint.

Closes #12870.

## Validation
- `pnpm -C turbo -F api lint`
- `pnpm -C turbo -F api check-types`
- `pnpm -C turbo -F api exec vitest run src/signals/routes/__tests__/zero-chat-messages.test.ts`
- `pnpm -C turbo -F api exec vitest run src/signals/routes/__tests__/agent-runs-create.test.ts src/signals/routes/__tests__/chat-threads-v1.test.ts src/signals/routes/__tests__/zero-runs-cancel.test.ts`
- pre-commit hook: `pnpm -C turbo check-types`