### PR TITLE
refactor(api): migrate zero image io generate route

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -57,6 +57,7 @@ import { zeroDefaultAgentRoutes } from "./routes/zero-default-agent";
 import { zeroDeveloperSupportRoutes } from "./routes/zero-developer-support";
 import { zeroFeatureSwitchesRoutes } from "./routes/zero-feature-switches";
 import { zeroInsightsRoutes } from "./routes/zero-insights";
+import { zeroImageIoGenerateRoutes } from "./routes/zero-image-io-generate";
 import { zeroLogsRoutes } from "./routes/zero-logs";
 import { zeroMemberCreditCapRoutes } from "./routes/zero-member-credit-cap";
 import { zeroModelPoliciesRoutes } from "./routes/zero-model-policies";
@@ -190,6 +191,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...zeroDeveloperSupportRoutes,
   ...zeroFeatureSwitchesRoutes,
   ...zeroInsightsRoutes,
+  ...zeroImageIoGenerateRoutes,
   ...zeroLogsRoutes,
   ...zeroMemberCreditCapRoutes,
   ...zeroModelPoliciesRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-image-io-generate.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-image-io-generate.test.ts
@@ -1,0 +1,655 @@
+import { Buffer } from "node:buffer";
+import { randomUUID } from "node:crypto";
+
+import { createStore } from "ccstate";
+import { and, eq, inArray } from "drizzle-orm";
+import { HttpResponse, http } from "msw";
+
+import { createApp } from "../../../app-factory";
+import { orgMetadata } from "@vm0/db/schema/org-metadata";
+import { orgMembersMetadata } from "@vm0/db/schema/org-members-metadata";
+import { runUploadedFiles } from "@vm0/db/schema/run-uploaded-file";
+import { usageEvent } from "@vm0/db/schema/usage-event";
+import { usagePricing } from "@vm0/db/schema/usage-pricing";
+import { testContext } from "../../../__tests__/test-helpers";
+import { server } from "../../../mocks/server";
+import { signSandboxJwtForTests } from "../../auth/tokens";
+import { writeDb$ } from "../../external/db";
+import { now } from "../../external/time";
+import {
+  IMAGE_IO_MODEL,
+  OPENAI_IMAGE_GENERATION_URL,
+  type ImagePricing,
+  type ImageUsage,
+} from "../../services/zero-image-io-generate.service";
+import {
+  deleteOrgMembership$,
+  seedOrgMembership$,
+} from "./helpers/zero-org-membership";
+import {
+  deleteUsageInsightFixture$,
+  seedCompose$,
+  seedRun$,
+} from "./helpers/zero-usage-insight";
+import {
+  createFixtureTracker,
+  createZeroRouteMocks,
+} from "./helpers/zero-route-test";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+const TEST_BUCKET = "test-user-storages";
+const IMAGE_BYTES = Buffer.from("fake image bytes");
+const IMAGE_PRICING_CATEGORIES = [
+  "tokens.input.text",
+  "tokens.input.image",
+  "tokens.output.image",
+] as const;
+
+type ImagePricingCategory = (typeof IMAGE_PRICING_CATEGORIES)[number];
+
+interface ImageFixture {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly insertedPricingCategories: readonly ImagePricingCategory[];
+}
+
+interface PricingSnapshot {
+  readonly category: ImagePricingCategory;
+  readonly unitPrice: number;
+  readonly unitSize: number;
+}
+
+function authHeaders() {
+  return { authorization: "Bearer clerk-session" };
+}
+
+function currentSecond(): number {
+  return Math.floor(now() / 1000);
+}
+
+function commandInput(command: unknown): Record<string, unknown> {
+  if (
+    typeof command === "object" &&
+    command !== null &&
+    "input" in command &&
+    typeof command.input === "object" &&
+    command.input !== null
+  ) {
+    return command.input as Record<string, unknown>;
+  }
+  return {};
+}
+
+function zeroToken(args: {
+  readonly userId: string;
+  readonly orgId: string;
+  readonly runId: string;
+  readonly capabilities?: readonly ["file:write"];
+}): string {
+  const seconds = currentSecond();
+  return signSandboxJwtForTests({
+    scope: "zero",
+    userId: args.userId,
+    orgId: args.orgId,
+    runId: args.runId,
+    capabilities: args.capabilities ?? ["file:write"],
+    iat: seconds,
+    exp: seconds + 60,
+  });
+}
+
+function expectedCredits(usage: ImageUsage, pricing: ImagePricing): number {
+  const rows: readonly (readonly [ImagePricingCategory, number])[] = [
+    ["tokens.input.text", usage.textInputTokens],
+    ["tokens.input.image", usage.imageInputTokens],
+    ["tokens.output.image", usage.imageOutputTokens],
+  ];
+
+  return rows.reduce((total, [category, quantity]) => {
+    if (quantity <= 0) {
+      return total;
+    }
+    const row = pricing.get(category);
+    if (!row) {
+      return total;
+    }
+    return total + Math.ceil((quantity * row.unitPrice) / row.unitSize);
+  }, 0);
+}
+
+async function ensureImagePricing(): Promise<{
+  readonly pricing: ImagePricing;
+  readonly insertedCategories: readonly ImagePricingCategory[];
+}> {
+  const writeDb = store.set(writeDb$);
+  const rows = await writeDb
+    .select({
+      category: usagePricing.category,
+      unitPrice: usagePricing.unitPrice,
+      unitSize: usagePricing.unitSize,
+    })
+    .from(usagePricing)
+    .where(
+      and(
+        eq(usagePricing.kind, "image"),
+        eq(usagePricing.provider, IMAGE_IO_MODEL),
+        inArray(usagePricing.category, [...IMAGE_PRICING_CATEGORIES]),
+      ),
+    );
+
+  const pricing = new Map<ImagePricingCategory, PricingSnapshot>();
+  for (const row of rows) {
+    if (isImagePricingCategory(row.category)) {
+      pricing.set(row.category, {
+        category: row.category,
+        unitPrice: row.unitPrice,
+        unitSize: row.unitSize,
+      });
+    }
+  }
+
+  const insertedCategories: ImagePricingCategory[] = [];
+  const defaults: Readonly<Record<ImagePricingCategory, PricingSnapshot>> = {
+    "tokens.input.text": {
+      category: "tokens.input.text",
+      unitPrice: 6000,
+      unitSize: 1_000_000,
+    },
+    "tokens.input.image": {
+      category: "tokens.input.image",
+      unitPrice: 9600,
+      unitSize: 1_000_000,
+    },
+    "tokens.output.image": {
+      category: "tokens.output.image",
+      unitPrice: 36_000,
+      unitSize: 1_000_000,
+    },
+  };
+
+  for (const category of IMAGE_PRICING_CATEGORIES) {
+    if (!pricing.has(category)) {
+      const row = defaults[category];
+      await writeDb.insert(usagePricing).values({
+        kind: "image",
+        provider: IMAGE_IO_MODEL,
+        category,
+        unitPrice: row.unitPrice,
+        unitSize: row.unitSize,
+      });
+      pricing.set(category, row);
+      insertedCategories.push(category);
+    }
+  }
+
+  return { pricing, insertedCategories };
+}
+
+function isImagePricingCategory(value: string): value is ImagePricingCategory {
+  return IMAGE_PRICING_CATEGORIES.some((category) => {
+    return category === value;
+  });
+}
+
+async function deleteImagePricingRows(): Promise<readonly PricingSnapshot[]> {
+  const writeDb = store.set(writeDb$);
+  const rows = await writeDb
+    .select({
+      category: usagePricing.category,
+      unitPrice: usagePricing.unitPrice,
+      unitSize: usagePricing.unitSize,
+    })
+    .from(usagePricing)
+    .where(
+      and(
+        eq(usagePricing.kind, "image"),
+        eq(usagePricing.provider, IMAGE_IO_MODEL),
+        inArray(usagePricing.category, [...IMAGE_PRICING_CATEGORIES]),
+      ),
+    );
+
+  await writeDb
+    .delete(usagePricing)
+    .where(
+      and(
+        eq(usagePricing.kind, "image"),
+        eq(usagePricing.provider, IMAGE_IO_MODEL),
+        inArray(usagePricing.category, [...IMAGE_PRICING_CATEGORIES]),
+      ),
+    );
+
+  return rows.filter((row): row is PricingSnapshot => {
+    return isImagePricingCategory(row.category);
+  });
+}
+
+async function restoreImagePricingRows(
+  rows: readonly PricingSnapshot[],
+): Promise<void> {
+  if (rows.length === 0) {
+    return;
+  }
+  await store
+    .set(writeDb$)
+    .insert(usagePricing)
+    .values(
+      rows.map((row) => {
+        return {
+          kind: "image",
+          provider: IMAGE_IO_MODEL,
+          category: row.category,
+          unitPrice: row.unitPrice,
+          unitSize: row.unitSize,
+        };
+      }),
+    );
+}
+
+async function seedImageFixture(options: {
+  readonly credits?: number;
+  readonly withPricing?: boolean;
+}): Promise<ImageFixture> {
+  const orgId = `org_${randomUUID()}`;
+  const userId = `user_${randomUUID()}`;
+  const writeDb = store.set(writeDb$);
+
+  await store.set(
+    seedOrgMembership$,
+    { orgId, userId, role: "admin" },
+    context.signal,
+  );
+  await writeDb.insert(orgMetadata).values({
+    orgId,
+    tier: "free",
+    credits: options.credits ?? 10_000,
+  });
+  await writeDb.insert(orgMembersMetadata).values({
+    orgId,
+    userId,
+    creditEnabled: true,
+  });
+
+  const pricing = options.withPricing
+    ? await ensureImagePricing()
+    : { insertedCategories: [] };
+
+  return {
+    orgId,
+    userId,
+    insertedPricingCategories: pricing.insertedCategories,
+  };
+}
+
+async function deleteImageFixture(fixture: ImageFixture): Promise<void> {
+  const writeDb = store.set(writeDb$);
+  await writeDb
+    .delete(runUploadedFiles)
+    .where(
+      and(
+        eq(runUploadedFiles.orgId, fixture.orgId),
+        eq(runUploadedFiles.userId, fixture.userId),
+      ),
+    );
+  await writeDb
+    .delete(orgMembersMetadata)
+    .where(
+      and(
+        eq(orgMembersMetadata.orgId, fixture.orgId),
+        eq(orgMembersMetadata.userId, fixture.userId),
+      ),
+    );
+  await store.set(deleteUsageInsightFixture$, fixture, context.signal);
+  await writeDb.delete(orgMetadata).where(eq(orgMetadata.orgId, fixture.orgId));
+  await store.set(deleteOrgMembership$, fixture, context.signal);
+  if (fixture.insertedPricingCategories.length > 0) {
+    await writeDb
+      .delete(usagePricing)
+      .where(
+        and(
+          eq(usagePricing.kind, "image"),
+          eq(usagePricing.provider, IMAGE_IO_MODEL),
+          inArray(usagePricing.category, [
+            ...fixture.insertedPricingCategories,
+          ]),
+        ),
+      );
+  }
+}
+
+describe("POST /api/zero/image-io/generate", () => {
+  const track = createFixtureTracker<ImageFixture>(deleteImageFixture);
+  const trackPricing = createFixtureTracker<readonly PricingSnapshot[]>(
+    restoreImagePricingRows,
+  );
+
+  beforeEach(() => {
+    context.mocks.clerk.authenticateRequest.mockReset();
+    context.mocks.clerk.authenticateRequest.mockResolvedValue({
+      isAuthenticated: false,
+    });
+    context.mocks.s3.send.mockReset();
+    context.mocks.s3.send.mockResolvedValue({});
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    const app = createApp({ signal: context.signal });
+    const response = await app.request("/api/zero/image-io/generate", {
+      method: "POST",
+      body: JSON.stringify({ prompt: "a cat" }),
+    });
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("rejects empty prompts before OpenAI", async () => {
+    const fixture = await track(seedImageFixture({ withPricing: true }));
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    let calledOpenAi = false;
+    server.use(
+      http.post(OPENAI_IMAGE_GENERATION_URL, () => {
+        calledOpenAi = true;
+        return HttpResponse.json({});
+      }),
+    );
+
+    const app = createApp({ signal: context.signal });
+    const response = await app.request("/api/zero/image-io/generate", {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({ prompt: "   " }),
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toStrictEqual({
+      error: { message: "prompt is required", code: "BAD_REQUEST" },
+    });
+    expect(calledOpenAi).toBeFalsy();
+  });
+
+  it("returns 402 when the org has no spendable credits", async () => {
+    const fixture = await track(seedImageFixture({ credits: 0 }));
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const app = createApp({ signal: context.signal });
+    const response = await app.request("/api/zero/image-io/generate", {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({ prompt: "a cat" }),
+    });
+
+    expect(response.status).toBe(402);
+    await expect(response.json()).resolves.toStrictEqual({
+      error: {
+        message: "Insufficient credits. Please add credits to continue.",
+        code: "INSUFFICIENT_CREDITS",
+      },
+    });
+  });
+
+  it("returns 503 when image pricing is not configured", async () => {
+    const fixture = await track(seedImageFixture({ credits: 1000 }));
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    await trackPricing(deleteImagePricingRows());
+    let calledOpenAi = false;
+    server.use(
+      http.post(OPENAI_IMAGE_GENERATION_URL, () => {
+        calledOpenAi = true;
+        return HttpResponse.json({});
+      }),
+    );
+
+    const app = createApp({ signal: context.signal });
+    const response = await app.request("/api/zero/image-io/generate", {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({ prompt: "a cat" }),
+    });
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toStrictEqual({
+      error: {
+        message: "Image generation pricing is not configured",
+        code: "NOT_CONFIGURED",
+      },
+    });
+    expect(calledOpenAi).toBeFalsy();
+  });
+
+  it("generates image files for run-scoped zero tokens", async () => {
+    const fixture = await track(seedImageFixture({ withPricing: true }));
+    const { pricing } = await ensureImagePricing();
+    const { composeId } = await store.set(
+      seedCompose$,
+      { orgId: fixture.orgId, userId: fixture.userId },
+      context.signal,
+    );
+    const { runId } = await store.set(
+      seedRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        composeId,
+        triggerSource: "web",
+      },
+      context.signal,
+    );
+    const usage: ImageUsage = {
+      textInputTokens: 1000,
+      imageInputTokens: 500,
+      imageOutputTokens: 2000,
+      totalTokens: 3500,
+    };
+    const creditsCharged = expectedCredits(usage, pricing);
+    let observedAuthorization: string | null = null;
+    let observedBody: unknown = null;
+    server.use(
+      http.post(OPENAI_IMAGE_GENERATION_URL, async ({ request }) => {
+        observedAuthorization = request.headers.get("authorization");
+        observedBody = await request.json();
+        return HttpResponse.json({
+          data: [
+            {
+              b64_json: IMAGE_BYTES.toString("base64"),
+              revised_prompt: "A small robot paints a sunflower.",
+            },
+          ],
+          output_format: "png",
+          size: "1024x1024",
+          quality: "medium",
+          background: "opaque",
+          usage: {
+            total_tokens: usage.totalTokens,
+            input_tokens: usage.textInputTokens + usage.imageInputTokens,
+            output_tokens: usage.imageOutputTokens,
+            input_tokens_details: {
+              text_tokens: usage.textInputTokens,
+              image_tokens: usage.imageInputTokens,
+            },
+          },
+        });
+      }),
+    );
+
+    const token = zeroToken({
+      userId: fixture.userId,
+      orgId: fixture.orgId,
+      runId,
+    });
+    const app = createApp({ signal: context.signal });
+    const response = await app.request("/api/zero/image-io/generate", {
+      method: "POST",
+      headers: { authorization: `Bearer ${token}` },
+      body: JSON.stringify({
+        prompt: "a small robot painting a sunflower",
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    const body: unknown = await response.json();
+    expect(body).toMatchObject({
+      contentType: "image/png",
+      size: IMAGE_BYTES.byteLength,
+      creditsCharged,
+      model: IMAGE_IO_MODEL,
+      imageSize: "1024x1024",
+      quality: "medium",
+      background: "opaque",
+      outputFormat: "png",
+      revisedPrompt: "A small robot paints a sunflower.",
+      usage,
+    });
+    expect(observedAuthorization).toBe("Bearer test-openai-key");
+    expect(observedBody).toMatchObject({
+      model: IMAGE_IO_MODEL,
+      prompt: "a small robot painting a sunflower",
+      n: 1,
+      size: "1024x1024",
+      quality: "medium",
+      background: "auto",
+      output_format: "png",
+    });
+
+    if (
+      !(
+        typeof body === "object" &&
+        body !== null &&
+        "id" in body &&
+        "filename" in body &&
+        "url" in body
+      )
+    ) {
+      throw new Error("Expected image response id, filename, and url");
+    }
+    const fileId = String(body.id);
+    const filename = String(body.filename);
+    const url = String(body.url);
+    expect(filename).toBe(`image-${fileId.slice(0, 8)}.png`);
+    expect(url).toBe(
+      `http://localhost:3000/f/${encodeURIComponent(
+        fixture.userId.replace(/^user_/, ""),
+      )}/${fileId}/${filename}`,
+    );
+
+    const putInput = commandInput(context.mocks.s3.send.mock.calls[0]?.[0]);
+    expect(putInput.Bucket).toBe(TEST_BUCKET);
+    expect(putInput.Key).toBe(
+      `uploads/${fixture.userId}/${fileId}/${filename}`,
+    );
+    expect(putInput.ContentType).toBe("image/png");
+    const putBody = putInput.Body;
+    expect(Buffer.isBuffer(putBody)).toBeTruthy();
+    if (!Buffer.isBuffer(putBody)) {
+      throw new Error("Expected S3 put body to be a Buffer");
+    }
+    expect(putBody).toStrictEqual(IMAGE_BYTES);
+
+    const uploadRows = await store
+      .set(writeDb$)
+      .select()
+      .from(runUploadedFiles)
+      .where(eq(runUploadedFiles.externalId, fileId));
+    expect(uploadRows).toHaveLength(1);
+    expect(uploadRows[0]).toMatchObject({
+      runId,
+      source: "web",
+      externalId: fileId,
+      userId: fixture.userId,
+      orgId: fixture.orgId,
+      filename,
+      contentType: "image/png",
+      sizeBytes: IMAGE_BYTES.byteLength,
+      url,
+    });
+    expect(uploadRows[0]?.metadata).toMatchObject({
+      generatedBy: "zero-official-image",
+      model: IMAGE_IO_MODEL,
+      imageSize: "1024x1024",
+      quality: "medium",
+      background: "opaque",
+      outputFormat: "png",
+      s3Key: `uploads/${fixture.userId}/${fileId}/${filename}`,
+    });
+
+    const usageRows = await store
+      .set(writeDb$)
+      .select()
+      .from(usageEvent)
+      .where(
+        and(
+          eq(usageEvent.orgId, fixture.orgId),
+          eq(usageEvent.userId, fixture.userId),
+          eq(usageEvent.kind, "image"),
+          eq(usageEvent.provider, IMAGE_IO_MODEL),
+        ),
+      );
+    expect(usageRows).toHaveLength(3);
+    expect(usageRows).toStrictEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          category: "tokens.input.text",
+          quantity: usage.textInputTokens,
+          status: "processed",
+          billingError: null,
+        }),
+        expect.objectContaining({
+          category: "tokens.input.image",
+          quantity: usage.imageInputTokens,
+          status: "processed",
+          billingError: null,
+        }),
+        expect.objectContaining({
+          category: "tokens.output.image",
+          quantity: usage.imageOutputTokens,
+          status: "processed",
+          billingError: null,
+        }),
+      ]),
+    );
+    const totalCredits = usageRows.reduce((total, row) => {
+      return total + (row.creditsCharged ?? 0);
+    }, 0);
+    expect(totalCredits).toBe(creditsCharged);
+  });
+
+  it("returns 500 when OpenAI image generation fails", async () => {
+    const fixture = await track(
+      seedImageFixture({ credits: 1000, withPricing: true }),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    server.use(
+      http.post(OPENAI_IMAGE_GENERATION_URL, () => {
+        return HttpResponse.json(
+          { error: { message: "rate limit exceeded" } },
+          { status: 429 },
+        );
+      }),
+    );
+
+    const app = createApp({ signal: context.signal });
+    const response = await app.request("/api/zero/image-io/generate", {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({ prompt: "a cat" }),
+    });
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toStrictEqual({
+      error: {
+        message: "Image generation failed",
+        code: "INTERNAL_SERVER_ERROR",
+      },
+    });
+    expect(context.mocks.s3.send).not.toHaveBeenCalled();
+    const usageRows = await store
+      .set(writeDb$)
+      .select()
+      .from(usageEvent)
+      .where(eq(usageEvent.orgId, fixture.orgId));
+    expect(usageRows).toHaveLength(0);
+  });
+});

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-image-io-generate.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-image-io-generate.test.ts
@@ -86,7 +86,7 @@ function zeroToken(args: {
   readonly userId: string;
   readonly orgId: string;
   readonly runId: string;
-  readonly capabilities?: readonly ["file:write"];
+  readonly capabilities?: readonly "file:write"[];
 }): string {
   const seconds = currentSecond();
   return signSandboxJwtForTests({
@@ -346,6 +346,30 @@ describe("POST /api/zero/image-io/generate", () => {
     });
   });
 
+  it("returns 403 when a zero token lacks file write capability", async () => {
+    const token = zeroToken({
+      userId: `user_${randomUUID()}`,
+      orgId: `org_${randomUUID()}`,
+      runId: randomUUID(),
+      capabilities: [],
+    });
+
+    const app = createApp({ signal: context.signal });
+    const response = await app.request("/api/zero/image-io/generate", {
+      method: "POST",
+      headers: { authorization: `Bearer ${token}` },
+      body: JSON.stringify({ prompt: "a cat" }),
+    });
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toStrictEqual({
+      error: {
+        message: "Missing required capability: file:write",
+        code: "FORBIDDEN",
+      },
+    });
+  });
+
   it("rejects empty prompts before OpenAI", async () => {
     const fixture = await track(seedImageFixture({ withPricing: true }));
     mocks.clerk.session(fixture.userId, fixture.orgId);
@@ -367,6 +391,38 @@ describe("POST /api/zero/image-io/generate", () => {
     expect(response.status).toBe(400);
     await expect(response.json()).resolves.toStrictEqual({
       error: { message: "prompt is required", code: "BAD_REQUEST" },
+    });
+    expect(calledOpenAi).toBeFalsy();
+  });
+
+  it("rejects transparent JPEG requests before OpenAI", async () => {
+    const fixture = await track(seedImageFixture({}));
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    let calledOpenAi = false;
+    server.use(
+      http.post(OPENAI_IMAGE_GENERATION_URL, () => {
+        calledOpenAi = true;
+        return HttpResponse.json({});
+      }),
+    );
+
+    const app = createApp({ signal: context.signal });
+    const response = await app.request("/api/zero/image-io/generate", {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({
+        prompt: "a transparent badge",
+        background: "transparent",
+        outputFormat: "jpeg",
+      }),
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toStrictEqual({
+      error: {
+        message: "transparent background requires png or webp output",
+        code: "BAD_REQUEST",
+      },
     });
     expect(calledOpenAi).toBeFalsy();
   });

--- a/turbo/apps/api/src/signals/routes/zero-image-io-generate.ts
+++ b/turbo/apps/api/src/signals/routes/zero-image-io-generate.ts
@@ -1,0 +1,126 @@
+import { command } from "ccstate";
+import { zeroImageIoGenerateContract } from "@vm0/api-contracts/contracts/zero-image-io-generate";
+
+import { organizationAuthContext$ } from "../auth/auth-context";
+import { authRoute } from "../auth/auth-route";
+import { bodyResultOf } from "../context/request";
+import { logger } from "../../lib/log";
+import type { RouteEntry } from "../route";
+import { env } from "../../lib/env";
+import {
+  checkImageCredits$,
+  imagePricing$,
+  IMAGE_IO_MODEL,
+  insufficientCredits,
+  internalError,
+  OPENAI_IMAGE_GENERATION_URL,
+  parseImageGenerationResult,
+  parseImageOptions,
+  recordGeneratedImage$,
+  serviceUnavailable,
+} from "../services/zero-image-io-generate.service";
+
+const L = logger("ZeroImageIoGenerate");
+const imageBody$ = bodyResultOf(zeroImageIoGenerateContract.post);
+
+const postImageInner$ = command(async ({ get, set }, signal: AbortSignal) => {
+  const auth = get(organizationAuthContext$);
+  const bodyResult = await get(imageBody$);
+  signal.throwIfAborted();
+  if (!bodyResult.ok) {
+    return bodyResult.response;
+  }
+
+  const options = parseImageOptions(bodyResult.data);
+  if ("status" in options) {
+    return options;
+  }
+
+  const hasCredits = await set(
+    checkImageCredits$,
+    { orgId: auth.orgId, userId: auth.userId },
+    signal,
+  );
+  if (!hasCredits) {
+    return insufficientCredits();
+  }
+
+  const pricing = await get(imagePricing$);
+  signal.throwIfAborted();
+  if (!pricing) {
+    return serviceUnavailable(
+      "Image generation pricing is not configured",
+      "NOT_CONFIGURED",
+    );
+  }
+
+  const openaiResponse = await fetch(OPENAI_IMAGE_GENERATION_URL, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${env("OPENAI_API_KEY")}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      model: IMAGE_IO_MODEL,
+      prompt: options.prompt,
+      n: 1,
+      size: options.size,
+      quality: options.quality,
+      background: options.background,
+      output_format: options.outputFormat,
+    }),
+    signal,
+  });
+  signal.throwIfAborted();
+
+  if (!openaiResponse.ok) {
+    const errorBody = await openaiResponse.text();
+    signal.throwIfAborted();
+    L.error("OpenAI image request failed", {
+      status: openaiResponse.status,
+      body: errorBody,
+    });
+    return internalError("Image generation failed");
+  }
+
+  const responseBody: unknown = await openaiResponse.json();
+  signal.throwIfAborted();
+  const generation = parseImageGenerationResult(responseBody, options);
+  if ("status" in generation) {
+    if (generation.body.error.code === "USAGE_UNKNOWN") {
+      L.error("OpenAI image response missing usage", { responseBody });
+    }
+    return generation;
+  }
+
+  const runId =
+    auth.tokenType === "zero" || auth.tokenType === "sandbox"
+      ? auth.runId
+      : undefined;
+  const result = await set(
+    recordGeneratedImage$,
+    {
+      orgId: auth.orgId,
+      userId: auth.userId,
+      runId,
+      pricing,
+      generation,
+    },
+    signal,
+  );
+
+  return { status: 200 as const, body: result };
+});
+
+export const zeroImageIoGenerateRoutes: readonly RouteEntry[] = [
+  {
+    route: zeroImageIoGenerateContract.post,
+    handler: authRoute(
+      {
+        requireOrganization: true,
+        requiredCapability: "file:write",
+      },
+      postImageInner$,
+    ),
+  },
+];

--- a/turbo/apps/api/src/signals/services/zero-image-io-generate.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-image-io-generate.service.ts
@@ -1,0 +1,602 @@
+import { Buffer } from "node:buffer";
+import { randomUUID } from "node:crypto";
+
+import { command, computed, type Computed } from "ccstate";
+import { usageEvent } from "@vm0/db/schema/usage-event";
+import { usagePricing } from "@vm0/db/schema/usage-pricing";
+import { and, eq, inArray, sql } from "drizzle-orm";
+
+import { buildFileUrl } from "../../lib/file-url";
+import { env } from "../../lib/env";
+import { db$, writeDb$ } from "../external/db";
+import { putS3Object } from "../external/s3";
+import { recordWebUploadedFile$ } from "./run-uploaded-files.service";
+import { processOrgUsageEvents$ } from "./zero-credit-usage.service";
+
+export const OPENAI_IMAGE_GENERATION_URL =
+  "https://api.openai.com/v1/images/generations";
+export const IMAGE_IO_MODEL = "gpt-image-2";
+const IMAGE_IO_MAX_PROMPT_LENGTH = 32_000;
+
+const USAGE_KIND = "image";
+const USAGE_PROVIDER = IMAGE_IO_MODEL;
+const TEXT_INPUT_CATEGORY = "tokens.input.text";
+const IMAGE_INPUT_CATEGORY = "tokens.input.image";
+const IMAGE_OUTPUT_CATEGORY = "tokens.output.image";
+const REQUIRED_PRICING_CATEGORIES = [
+  TEXT_INPUT_CATEGORY,
+  IMAGE_INPUT_CATEGORY,
+  IMAGE_OUTPUT_CATEGORY,
+] as const;
+
+const IMAGE_SIZES = ["1024x1024", "1024x1536", "1536x1024"] as const;
+const IMAGE_QUALITIES = ["low", "medium", "high", "auto"] as const;
+const IMAGE_BACKGROUNDS = ["auto", "opaque", "transparent"] as const;
+const IMAGE_OUTPUT_FORMATS = ["png", "webp", "jpeg"] as const;
+
+type ImageSize = (typeof IMAGE_SIZES)[number];
+type ImageQuality = (typeof IMAGE_QUALITIES)[number];
+type ImageBackground = (typeof IMAGE_BACKGROUNDS)[number];
+type ImageOutputFormat = (typeof IMAGE_OUTPUT_FORMATS)[number];
+type PricingCategory = (typeof REQUIRED_PRICING_CATEGORIES)[number];
+
+type ErrorStatus = 400 | 402 | 500 | 502 | 503;
+
+interface ErrorBody {
+  readonly error: {
+    readonly message: string;
+    readonly code: string;
+  };
+}
+
+type ErrorResponse = {
+  readonly status: ErrorStatus;
+  readonly body: ErrorBody;
+};
+
+interface ImagePricingRow {
+  readonly unitPrice: number;
+  readonly unitSize: number;
+}
+
+export type ImagePricing = ReadonlyMap<PricingCategory, ImagePricingRow>;
+
+interface ImageOptions {
+  readonly prompt: string;
+  readonly size: ImageSize;
+  readonly quality: ImageQuality;
+  readonly background: ImageBackground;
+  readonly outputFormat: ImageOutputFormat;
+}
+
+export interface ImageUsage {
+  readonly textInputTokens: number;
+  readonly imageInputTokens: number;
+  readonly imageOutputTokens: number;
+  readonly totalTokens: number;
+}
+
+interface ParsedImageGeneration {
+  readonly imageBytes: Buffer;
+  readonly revisedPrompt: string | undefined;
+  readonly imageSize: string;
+  readonly quality: string;
+  readonly background: string;
+  readonly outputFormat: ImageOutputFormat;
+  readonly usage: ImageUsage;
+}
+
+interface RecordedImage {
+  readonly id: string;
+  readonly filename: string;
+  readonly contentType: string;
+  readonly size: number;
+  readonly url: string;
+  readonly creditsCharged: number;
+  readonly model: string;
+  readonly imageSize: string;
+  readonly quality: string;
+  readonly background: string;
+  readonly outputFormat: ImageOutputFormat;
+  readonly revisedPrompt: string | undefined;
+  readonly usage: ImageUsage;
+}
+
+interface CreditCheckRow extends Record<string, unknown> {
+  readonly credit_enabled: boolean | null;
+  readonly credits: string | null;
+  readonly unsettled_expired: string | null;
+}
+
+interface OpenAiImageGenerationResponse {
+  readonly data?: readonly OpenAiImageData[];
+  readonly output_format?: string;
+  readonly size?: string;
+  readonly quality?: string;
+  readonly background?: string;
+  readonly usage?: OpenAiImageUsage;
+}
+
+interface OpenAiImageData {
+  readonly b64_json?: string;
+  readonly revised_prompt?: string;
+}
+
+interface OpenAiImageUsage {
+  readonly total_tokens?: number;
+  readonly input_tokens?: number;
+  readonly output_tokens?: number;
+  readonly input_tokens_details?: {
+    readonly text_tokens?: number;
+    readonly image_tokens?: number;
+  };
+}
+
+function errorBody(message: string, code: string): ErrorBody {
+  return { error: { message, code } };
+}
+
+function badRequest(message: string, code = "BAD_REQUEST") {
+  return { status: 400 as const, body: errorBody(message, code) };
+}
+
+export function internalError(message: string) {
+  return {
+    status: 500 as const,
+    body: errorBody(message, "INTERNAL_SERVER_ERROR"),
+  };
+}
+
+function badGateway(message: string, code: string) {
+  return { status: 502 as const, body: errorBody(message, code) };
+}
+
+export function serviceUnavailable(message: string, code: string) {
+  return { status: 503 as const, body: errorBody(message, code) };
+}
+
+export function insufficientCredits() {
+  return {
+    status: 402 as const,
+    body: errorBody(
+      "Insufficient credits. Please add credits to continue.",
+      "INSUFFICIENT_CREDITS",
+    ),
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function readString(
+  body: Record<string, unknown>,
+  key: string,
+  fallback: string,
+): string {
+  const value = body[key];
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim()
+    : fallback;
+}
+
+function includesString<T extends string>(
+  values: readonly T[],
+  value: string,
+): value is T {
+  return values.some((candidate) => {
+    return candidate === value;
+  });
+}
+
+export function parseImageOptions(body: unknown): ImageOptions | ErrorResponse {
+  if (!isRecord(body)) {
+    return badRequest("Invalid JSON body");
+  }
+
+  const prompt = typeof body.prompt === "string" ? body.prompt.trim() : "";
+  if (prompt.length === 0) {
+    return badRequest("prompt is required");
+  }
+  if (prompt.length > IMAGE_IO_MAX_PROMPT_LENGTH) {
+    return badRequest(
+      `prompt exceeds ${IMAGE_IO_MAX_PROMPT_LENGTH} characters`,
+    );
+  }
+
+  const size = readString(body, "size", "1024x1024");
+  if (!includesString(IMAGE_SIZES, size)) {
+    return badRequest(`Unsupported image size: ${size}`);
+  }
+
+  const quality = readString(body, "quality", "medium");
+  if (!includesString(IMAGE_QUALITIES, quality)) {
+    return badRequest(`Unsupported image quality: ${quality}`);
+  }
+
+  const background = readString(body, "background", "auto");
+  if (!includesString(IMAGE_BACKGROUNDS, background)) {
+    return badRequest(`Unsupported image background: ${background}`);
+  }
+
+  const outputFormat = readString(body, "outputFormat", "png");
+  if (!includesString(IMAGE_OUTPUT_FORMATS, outputFormat)) {
+    return badRequest(`Unsupported image output format: ${outputFormat}`);
+  }
+  if (background === "transparent" && outputFormat === "jpeg") {
+    return badRequest("transparent background requires png or webp output");
+  }
+
+  return { prompt, size, quality, background, outputFormat };
+}
+
+function mapPricingRows(
+  rows: readonly (ImagePricingRow & { readonly category: string })[],
+): ImagePricing {
+  const pricing = new Map<PricingCategory, ImagePricingRow>();
+  for (const row of rows) {
+    if (includesString(REQUIRED_PRICING_CATEGORIES, row.category)) {
+      pricing.set(row.category, {
+        unitPrice: row.unitPrice,
+        unitSize: row.unitSize,
+      });
+    }
+  }
+  return pricing;
+}
+
+function getMissingPricing(pricing: ImagePricing): readonly PricingCategory[] {
+  return REQUIRED_PRICING_CATEGORIES.filter((category) => {
+    return !pricing.has(category);
+  });
+}
+
+export const imagePricing$: Computed<Promise<ImagePricing | null>> = computed(
+  async (get): Promise<ImagePricing | null> => {
+    const db = get(db$);
+    const rows = await db
+      .select({
+        category: usagePricing.category,
+        unitPrice: usagePricing.unitPrice,
+        unitSize: usagePricing.unitSize,
+      })
+      .from(usagePricing)
+      .where(
+        and(
+          eq(usagePricing.kind, USAGE_KIND),
+          eq(usagePricing.provider, USAGE_PROVIDER),
+          inArray(usagePricing.category, [...REQUIRED_PRICING_CATEGORIES]),
+        ),
+      );
+
+    const pricing = mapPricingRows(rows);
+    return getMissingPricing(pricing).length === 0 ? pricing : null;
+  },
+);
+
+export const checkImageCredits$ = command(
+  async (
+    { set },
+    args: { readonly orgId: string; readonly userId: string },
+    signal: AbortSignal,
+  ): Promise<boolean> => {
+    const writeDb = set(writeDb$);
+    const { rows } = await writeDb.execute<CreditCheckRow>(sql`
+      WITH member AS (
+        SELECT credit_enabled FROM org_members_metadata
+        WHERE org_id = ${args.orgId} AND user_id = ${args.userId}
+        LIMIT 1
+      ),
+      org AS (
+        SELECT credits FROM org_metadata
+        WHERE org_id = ${args.orgId}
+        LIMIT 1
+      ),
+      expired AS (
+        SELECT COALESCE(SUM(remaining), 0)::bigint AS total
+        FROM credit_expires_record
+        WHERE org_id = ${args.orgId}
+          AND expires_at <= now()
+          AND remaining > 0
+      )
+      SELECT
+        (SELECT credit_enabled FROM member) AS credit_enabled,
+        (SELECT credits FROM org) AS credits,
+        (SELECT total FROM expired) AS unsettled_expired
+    `);
+    signal.throwIfAborted();
+
+    const row = rows[0];
+    if (!row || row.credit_enabled === false || row.credits === null) {
+      return false;
+    }
+
+    const credits = Number(row.credits);
+    const unsettledExpired = Number(row.unsettled_expired ?? 0);
+    return credits - unsettledExpired > 0;
+  },
+);
+
+function readNumber(value: unknown): number | undefined {
+  return typeof value === "number" ? value : undefined;
+}
+
+function readOpenAiUsage(value: unknown): OpenAiImageUsage | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  const details = isRecord(value.input_tokens_details)
+    ? {
+        text_tokens: readNumber(value.input_tokens_details.text_tokens),
+        image_tokens: readNumber(value.input_tokens_details.image_tokens),
+      }
+    : undefined;
+
+  return {
+    total_tokens: readNumber(value.total_tokens),
+    input_tokens: readNumber(value.input_tokens),
+    output_tokens: readNumber(value.output_tokens),
+    input_tokens_details: details,
+  };
+}
+
+function parseUsage(usage: OpenAiImageUsage | undefined): ImageUsage | null {
+  if (!usage) {
+    return null;
+  }
+
+  const textInputTokens =
+    usage.input_tokens_details?.text_tokens ?? usage.input_tokens ?? 0;
+  const imageInputTokens = usage.input_tokens_details?.image_tokens ?? 0;
+  const imageOutputTokens = usage.output_tokens ?? 0;
+  const totalTokens =
+    usage.total_tokens ??
+    textInputTokens + imageInputTokens + imageOutputTokens;
+
+  const values = [
+    textInputTokens,
+    imageInputTokens,
+    imageOutputTokens,
+    totalTokens,
+  ];
+  if (
+    values.some((value) => {
+      return !Number.isFinite(value) || value < 0;
+    })
+  ) {
+    return null;
+  }
+  if (textInputTokens + imageInputTokens + imageOutputTokens <= 0) {
+    return null;
+  }
+
+  return {
+    textInputTokens,
+    imageInputTokens,
+    imageOutputTokens,
+    totalTokens,
+  };
+}
+
+function parseOpenAiResponse(value: unknown): OpenAiImageGenerationResponse {
+  if (!isRecord(value)) {
+    return {};
+  }
+
+  const data = Array.isArray(value.data)
+    ? value.data.flatMap((item): OpenAiImageData[] => {
+        if (!isRecord(item)) {
+          return [];
+        }
+        return [
+          {
+            b64_json:
+              typeof item.b64_json === "string" ? item.b64_json : undefined,
+            revised_prompt:
+              typeof item.revised_prompt === "string"
+                ? item.revised_prompt
+                : undefined,
+          },
+        ];
+      })
+    : undefined;
+
+  return {
+    data,
+    output_format:
+      typeof value.output_format === "string" ? value.output_format : undefined,
+    size: typeof value.size === "string" ? value.size : undefined,
+    quality: typeof value.quality === "string" ? value.quality : undefined,
+    background:
+      typeof value.background === "string" ? value.background : undefined,
+    usage: readOpenAiUsage(value.usage),
+  };
+}
+
+export function parseImageGenerationResult(
+  value: unknown,
+  options: ImageOptions,
+): ParsedImageGeneration | ErrorResponse {
+  const response = parseOpenAiResponse(value);
+  const image = response.data?.[0];
+  if (!image?.b64_json) {
+    return badGateway("Model returned no image data", "NO_IMAGE_RETURNED");
+  }
+
+  const usage = parseUsage(response.usage);
+  if (!usage) {
+    return badGateway(
+      "Image generation usage was not returned",
+      "USAGE_UNKNOWN",
+    );
+  }
+
+  const imageBytes = Buffer.from(image.b64_json, "base64");
+  if (imageBytes.byteLength === 0) {
+    return badGateway("Model returned empty image", "NO_IMAGE_RETURNED");
+  }
+
+  const outputFormat =
+    response.output_format &&
+    includesString(IMAGE_OUTPUT_FORMATS, response.output_format)
+      ? response.output_format
+      : options.outputFormat;
+
+  return {
+    imageBytes,
+    revisedPrompt: image.revised_prompt,
+    imageSize: response.size ?? options.size,
+    quality: response.quality ?? options.quality,
+    background: response.background ?? options.background,
+    outputFormat,
+    usage,
+  };
+}
+
+function contentTypeForFormat(format: ImageOutputFormat): string {
+  if (format === "webp") {
+    return "image/webp";
+  }
+  if (format === "jpeg") {
+    return "image/jpeg";
+  }
+  return "image/png";
+}
+
+function extensionForFormat(format: ImageOutputFormat): string {
+  return format === "jpeg" ? "jpg" : format;
+}
+
+function estimateImageCredits(
+  usage: ImageUsage,
+  pricing: ImagePricing,
+): number {
+  const rows: readonly (readonly [PricingCategory, number])[] = [
+    [TEXT_INPUT_CATEGORY, usage.textInputTokens],
+    [IMAGE_INPUT_CATEGORY, usage.imageInputTokens],
+    [IMAGE_OUTPUT_CATEGORY, usage.imageOutputTokens],
+  ];
+
+  return rows.reduce((total, [category, quantity]) => {
+    if (quantity <= 0) {
+      return total;
+    }
+    const row = pricing.get(category);
+    if (!row) {
+      return total;
+    }
+    return total + Math.ceil((quantity * row.unitPrice) / row.unitSize);
+  }, 0);
+}
+
+export const recordGeneratedImage$ = command(
+  async (
+    { get, set },
+    params: {
+      readonly orgId: string;
+      readonly userId: string;
+      readonly runId: string | undefined;
+      readonly pricing: ImagePricing;
+      readonly generation: ParsedImageGeneration;
+    },
+    signal: AbortSignal,
+  ): Promise<RecordedImage> => {
+    const writeDb = set(writeDb$);
+    const fileId = randomUUID();
+    const filename = `image-${fileId.slice(0, 8)}.${extensionForFormat(
+      params.generation.outputFormat,
+    )}`;
+    const s3Key = `uploads/${params.userId}/${fileId}/${filename}`;
+    const contentType = contentTypeForFormat(params.generation.outputFormat);
+    await get(
+      putS3Object(
+        env("R2_USER_STORAGES_BUCKET_NAME"),
+        s3Key,
+        params.generation.imageBytes,
+        contentType,
+      ),
+    );
+    signal.throwIfAborted();
+
+    const url = buildFileUrl(params.userId, fileId, filename);
+    await set(
+      recordWebUploadedFile$,
+      {
+        runId: params.runId,
+        externalId: fileId,
+        userId: params.userId,
+        orgId: params.orgId,
+        filename,
+        contentType,
+        sizeBytes: params.generation.imageBytes.byteLength,
+        url,
+        s3Key,
+        metadata: {
+          generatedBy: "zero-official-image",
+          model: IMAGE_IO_MODEL,
+          imageSize: params.generation.imageSize,
+          quality: params.generation.quality,
+          background: params.generation.background,
+          outputFormat: params.generation.outputFormat,
+        },
+      },
+      signal,
+    );
+    signal.throwIfAborted();
+
+    const usageRows = [
+      {
+        category: TEXT_INPUT_CATEGORY,
+        quantity: params.generation.usage.textInputTokens,
+      },
+      {
+        category: IMAGE_INPUT_CATEGORY,
+        quantity: params.generation.usage.imageInputTokens,
+      },
+      {
+        category: IMAGE_OUTPUT_CATEGORY,
+        quantity: params.generation.usage.imageOutputTokens,
+      },
+    ].filter((row) => {
+      return row.quantity > 0;
+    });
+
+    await writeDb.insert(usageEvent).values(
+      usageRows.map((row) => {
+        return {
+          runId: null,
+          idempotencyKey: randomUUID(),
+          orgId: params.orgId,
+          userId: params.userId,
+          kind: USAGE_KIND,
+          provider: USAGE_PROVIDER,
+          category: row.category,
+          quantity: row.quantity,
+        };
+      }),
+    );
+    signal.throwIfAborted();
+
+    await set(processOrgUsageEvents$, params.orgId, signal);
+    signal.throwIfAborted();
+
+    return {
+      id: fileId,
+      filename,
+      contentType,
+      size: params.generation.imageBytes.byteLength,
+      url,
+      creditsCharged: estimateImageCredits(
+        params.generation.usage,
+        params.pricing,
+      ),
+      model: IMAGE_IO_MODEL,
+      imageSize: params.generation.imageSize,
+      quality: params.generation.quality,
+      background: params.generation.background,
+      outputFormat: params.generation.outputFormat,
+      revisedPrompt: params.generation.revisedPrompt,
+      usage: params.generation.usage,
+    };
+  },
+);

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -1206,6 +1206,15 @@ export {
   type PushSubscriptionsContract,
 } from "./push-subscriptions";
 export {
+  zeroImageIoGenerateContract,
+  zeroImageIoGenerateRequestSchema,
+  zeroImageIoGenerateResponseSchema,
+  zeroImageIoUsageSchema,
+  type ZeroImageIoGenerateContract,
+  type ZeroImageIoGenerateRequest,
+  type ZeroImageIoGenerateResponse,
+} from "./zero-image-io-generate";
+export {
   zeroVoiceIoQuotaContract,
   audioInputQuotaResponseSchema,
   type ZeroVoiceIoQuotaContract,

--- a/turbo/packages/api-contracts/src/contracts/zero-image-io-generate.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-image-io-generate.ts
@@ -1,0 +1,68 @@
+import { z } from "zod";
+
+import { authHeadersSchema, initContract } from "./base";
+import { apiErrorSchema } from "./errors";
+
+const c = initContract();
+
+export const zeroImageIoGenerateRequestSchema = z
+  .object({
+    prompt: z.unknown().optional(),
+    size: z.unknown().optional(),
+    quality: z.unknown().optional(),
+    background: z.unknown().optional(),
+    outputFormat: z.unknown().optional(),
+  })
+  .passthrough();
+
+export const zeroImageIoUsageSchema = z.object({
+  textInputTokens: z.number(),
+  imageInputTokens: z.number(),
+  imageOutputTokens: z.number(),
+  totalTokens: z.number(),
+});
+
+export const zeroImageIoGenerateResponseSchema = z.object({
+  id: z.string(),
+  filename: z.string(),
+  contentType: z.string(),
+  size: z.number(),
+  url: z.string(),
+  creditsCharged: z.number(),
+  model: z.string(),
+  imageSize: z.string(),
+  quality: z.string(),
+  background: z.string(),
+  outputFormat: z.string(),
+  revisedPrompt: z.string().optional(),
+  usage: zeroImageIoUsageSchema,
+});
+
+export type ZeroImageIoGenerateRequest = z.infer<
+  typeof zeroImageIoGenerateRequestSchema
+>;
+export type ZeroImageIoGenerateResponse = z.infer<
+  typeof zeroImageIoGenerateResponseSchema
+>;
+
+export const zeroImageIoGenerateContract = c.router({
+  post: {
+    method: "POST",
+    path: "/api/zero/image-io/generate",
+    headers: authHeadersSchema,
+    body: zeroImageIoGenerateRequestSchema,
+    responses: {
+      200: zeroImageIoGenerateResponseSchema,
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      402: apiErrorSchema,
+      403: apiErrorSchema,
+      500: apiErrorSchema,
+      502: apiErrorSchema,
+      503: apiErrorSchema,
+    },
+    summary: "Generate and persist an image file",
+  },
+});
+
+export type ZeroImageIoGenerateContract = typeof zeroImageIoGenerateContract;


### PR DESCRIPTION
Closes #12874

## Summary

- Add a ts-rest contract for `POST /api/zero/image-io/generate`.
- Register an API-authoritative command route for image generation with `file:write` auth, org credit checks, image pricing checks, OpenAI generation, R2 upload, run uploaded file recording, usage event insertion, and org usage settlement.
- Add API integration coverage for auth, validation, insufficient credits, missing pricing, successful run-scoped generation, S3/run-uploaded-files/usage side effects, and OpenAI failure.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm -F api exec vitest src/signals/routes/__tests__/zero-image-io-generate.test.ts`
- `pnpm -F api lint`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm knip`
- `git diff --check`

## Notes

- Full local `pnpm check-types` / pre-commit hook is currently blocked by unrelated existing type errors outside this change, e.g. implicit-any errors in `apps/web/app/api/runners/poll/route.ts`, `apps/web/app/api/webhooks/agent/usage-event/route.ts`, and other web routes.
- `pnpm -F api exec tsc --noEmit --pretty false` still reports the existing API baseline, but filtering the output for `zero-image`, `zeroImage`, and `image-io-generate` returns no matches.
