### PR TITLE
refactor: remove legacy vsock exec protocol

### DIFF
--- a/crates/vsock-guest/src/connection.rs
+++ b/crates/vsock-guest/src/connection.rs
@@ -161,10 +161,10 @@ fn handle_connection_with_outcome(stream: UnixStream) -> io::Result<ConnectionEn
                 // stdout chunks could arrive at the host before the result.
                 handle_spawn_watch(
                     SpawnWatchRequest {
-                        timeout_ms: d.fields.timeout_ms,
-                        command: d.fields.command,
-                        env: &d.fields.env,
-                        sudo: d.fields.sudo,
+                        timeout_ms: d.timeout_ms,
+                        command: d.command,
+                        env: &d.env,
+                        sudo: d.sudo,
                         stream_stdout: d.stream_stdout,
                         stdout_log_path: d.stdout_log_path,
                     },

--- a/crates/vsock-guest/src/connection.rs
+++ b/crates/vsock-guest/src/connection.rs
@@ -5,20 +5,16 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::thread;
 use std::time::Duration;
 
-use vsock_proto::{
-    self, MSG_COMMAND_CANCEL, MSG_COMMAND_START, MSG_EXEC, MSG_EXEC_RESULT, MSG_READY,
-    MSG_SPAWN_WATCH,
-};
+use vsock_proto::{self, MSG_COMMAND_CANCEL, MSG_COMMAND_START, MSG_READY, MSG_SPAWN_WATCH};
 
 use crate::command::{
     CommandRegistry, CommandWorkerRequest, cancel_command_operation, send_command_error,
     start_command_operation,
 };
 use crate::error::to_io_error;
-use crate::handlers::{MessageOutcome, handle_exec, handle_message};
+use crate::handlers::{MessageOutcome, handle_message};
 use crate::log::log;
 use crate::monitor::{SpawnWatchRequest, handle_spawn_watch};
-use crate::threading::{SystemThreadSpawner, ThreadSpawner};
 use crate::writer::GuestWriter;
 
 // Vsock constants (only used on Linux)
@@ -27,19 +23,9 @@ const VSOCK_CID_HOST: u32 = 2;
 
 /// Read buffer size for the connection event loop (local tuning constant).
 const READ_BUFFER_SIZE: usize = 64 * 1024; // 64KB
-const THREAD_EXEC_WORKER: &str = "vsock-exec-worker";
-
 enum ConnectionEnd {
     Closed,
     Shutdown,
-}
-
-struct ExecWorkerRequest {
-    timeout_ms: u32,
-    command: String,
-    env: Vec<(String, String)>,
-    sudo: bool,
-    seq: u32,
 }
 
 /// Signals all command work spawned for this host connection when the
@@ -175,40 +161,14 @@ fn handle_connection_with_outcome(stream: UnixStream) -> io::Result<ConnectionEn
                 // stdout chunks could arrive at the host before the result.
                 handle_spawn_watch(
                     SpawnWatchRequest {
-                        timeout_ms: d.exec.timeout_ms,
-                        command: d.exec.command,
-                        env: &d.exec.env,
-                        sudo: d.exec.sudo,
+                        timeout_ms: d.fields.timeout_ms,
+                        command: d.fields.command,
+                        env: &d.fields.env,
+                        sudo: d.fields.sudo,
                         stream_stdout: d.stream_stdout,
                         stdout_log_path: d.stdout_log_path,
                     },
                     msg.seq,
-                    writer.clone(),
-                    connection_cancel.clone(),
-                )?;
-            } else if msg.msg_type == MSG_EXEC {
-                log(
-                    "INFO",
-                    &format!("Received: type=0x{:02X} seq={}", msg.msg_type, msg.seq),
-                );
-                let d = vsock_proto::decode_exec(&msg.payload).map_err(to_io_error)?;
-                let timeout_ms = d.timeout_ms;
-                let command = d.command.to_owned();
-                let env: Vec<(String, String)> = d
-                    .env
-                    .iter()
-                    .map(|(k, v)| ((*k).to_owned(), (*v).to_owned()))
-                    .collect();
-                let sudo = d.sudo;
-                let seq = msg.seq;
-                spawn_exec_worker(
-                    ExecWorkerRequest {
-                        timeout_ms,
-                        command,
-                        env,
-                        sudo,
-                        seq,
-                    },
                     writer.clone(),
                     connection_cancel.clone(),
                 )?;
@@ -231,71 +191,6 @@ fn handle_connection_with_outcome(stream: UnixStream) -> io::Result<ConnectionEn
 
     log("INFO", "Host disconnected");
     Ok(ConnectionEnd::Closed)
-}
-
-fn spawn_exec_worker(
-    request: ExecWorkerRequest,
-    writer: GuestWriter,
-    connection_cancel: Arc<AtomicBool>,
-) -> io::Result<()> {
-    spawn_exec_worker_with_spawner(request, writer, connection_cancel, SystemThreadSpawner)
-}
-
-fn spawn_exec_worker_with_spawner<S>(
-    request: ExecWorkerRequest,
-    writer: GuestWriter,
-    connection_cancel: Arc<AtomicBool>,
-    spawner: S,
-) -> io::Result<()>
-where
-    S: ThreadSpawner,
-{
-    let worker_writer = writer.clone();
-    let seq = request.seq;
-    let result = spawner.spawn_unit(
-        THREAD_EXEC_WORKER,
-        Box::new(move || {
-            let env_refs: Vec<(&str, &str)> = request
-                .env
-                .iter()
-                .map(|(k, v)| (k.as_str(), v.as_str()))
-                .collect();
-            let (exit_code, stdout, stderr) = handle_exec(
-                request.timeout_ms,
-                &request.command,
-                &env_refs,
-                request.sudo,
-                &connection_cancel,
-            );
-            if let Err(e) = send_exec_result(seq, exit_code, &stdout, &stderr, &worker_writer) {
-                log("ERROR", &format!("Failed to send exec_result: {e}"));
-            }
-        }),
-    );
-
-    match result {
-        Ok(_) => Ok(()),
-        Err(e) => {
-            let stderr = format!("Failed to spawn exec worker thread: {e}");
-            send_exec_result(seq, 1, &[], stderr.as_bytes(), &writer)
-        }
-    }
-}
-
-fn send_exec_result(
-    seq: u32,
-    exit_code: i32,
-    stdout: &[u8],
-    stderr: &[u8],
-    writer: &GuestWriter,
-) -> io::Result<()> {
-    let payload = vsock_proto::encode_exec_result(exit_code, stdout, stderr);
-    let encoded = vsock_proto::encode(MSG_EXEC_RESULT, seq, &payload).map_err(to_io_error)?;
-    if let Err(e) = writer.write_frame(&encoded) {
-        log("ERROR", &format!("Failed to send exec_result: {}", e));
-        return Err(e);
-    }
-    Ok(())
 }
 
 /// Maximum reconnection attempts before giving up
@@ -380,63 +275,5 @@ pub fn run(unix_socket: Option<&str>) -> io::Result<()> {
                 thread::sleep(Duration::from_millis(RECONNECT_DELAY_MS));
             }
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::threading::test_support::FailingThreadSpawner;
-    use std::io::Read;
-    use std::os::unix::net::UnixStream;
-    use std::time::Duration;
-
-    fn read_message(stream: &mut UnixStream) -> vsock_proto::RawMessage {
-        let mut hdr = [0u8; 4];
-        stream.read_exact(&mut hdr).unwrap();
-        let body_len = u32::from_be_bytes(hdr) as usize;
-        let mut body = vec![0u8; body_len];
-        stream.read_exact(&mut body).unwrap();
-
-        let mut full = Vec::with_capacity(4 + body_len);
-        full.extend_from_slice(&hdr);
-        full.extend_from_slice(&body);
-        let mut decoder = vsock_proto::Decoder::new();
-        let mut messages = decoder.decode(&full).unwrap();
-        assert_eq!(messages.len(), 1);
-        messages.remove(0)
-    }
-
-    #[test]
-    fn exec_worker_spawn_failure_returns_exec_result() {
-        let (guest, mut host) = UnixStream::pair().unwrap();
-        host.set_read_timeout(Some(Duration::from_secs(3))).unwrap();
-        let writer = GuestWriter::new(guest);
-
-        spawn_exec_worker_with_spawner(
-            ExecWorkerRequest {
-                timeout_ms: 0,
-                command: "echo should-not-run".to_string(),
-                env: Vec::new(),
-                sudo: false,
-                seq: 42,
-            },
-            writer,
-            Arc::new(AtomicBool::new(false)),
-            FailingThreadSpawner::fail_once(THREAD_EXEC_WORKER),
-        )
-        .unwrap();
-
-        let msg = read_message(&mut host);
-        assert_eq!(msg.msg_type, MSG_EXEC_RESULT);
-        assert_eq!(msg.seq, 42);
-        let (code, stdout, stderr) = vsock_proto::decode_exec_result(&msg.payload).unwrap();
-        assert_eq!(code, 1);
-        assert!(stdout.is_empty());
-        assert!(
-            String::from_utf8_lossy(stderr).contains("exec worker thread"),
-            "unexpected stderr: {:?}",
-            String::from_utf8_lossy(stderr),
-        );
     }
 }

--- a/crates/vsock-guest/src/handlers.rs
+++ b/crates/vsock-guest/src/handlers.rs
@@ -13,18 +13,13 @@ use vsock_proto::{
 
 use crate::drain::drain_into_vec_cancellable;
 use crate::error::to_io_error;
-use crate::exec::{
-    format_env_diagnostics, spawn_in_own_process_group, spawn_with_pipes, truncate_preview,
-};
+use crate::exec::spawn_in_own_process_group;
 use crate::log::log;
 use crate::process::{extract_exit_code, kill_and_reap_child, kill_process_tree};
 use crate::shutdown::handle_shutdown;
 use crate::threading::{SystemThreadSpawner, ThreadSpawner, spawn_scoped_named};
 use crate::user::apply_write_file_identity;
-use crate::wait::{
-    WaitOutcome, await_drain_deadline, finalize_buffered_result,
-    wait_with_drain_and_timeout_or_cancelled, wait_with_kill_timeout,
-};
+use crate::wait::{WaitOutcome, await_drain_deadline, wait_with_kill_timeout};
 
 const THREAD_WRITE_STDERR: &str = "vsock-write-stderr";
 const THREAD_WRITE_STDIN: &str = "vsock-write-stdin";
@@ -36,60 +31,6 @@ static DEBUG_GUEST_WRITE_FILE_PATH: Mutex<Option<PathBuf>> = Mutex::new(None);
 pub(crate) enum MessageOutcome {
     Response(Vec<u8>),
     Shutdown(Vec<u8>),
-}
-
-/// Handle exec message
-pub(crate) fn handle_exec(
-    timeout_ms: u32,
-    command: &str,
-    env: &[(&str, &str)],
-    sudo: bool,
-    connection_cancel: &AtomicBool,
-) -> (i32, Vec<u8>, Vec<u8>) {
-    log(
-        "INFO",
-        &format!(
-            "exec: {} (timeout={}ms, sudo={}, {})",
-            truncate_preview(command),
-            timeout_ms,
-            sudo,
-            format_env_diagnostics(command, env),
-        ),
-    );
-
-    let spawned = match spawn_with_pipes(command, env, sudo) {
-        Ok(c) => c,
-        Err(e) => {
-            return (
-                1,
-                Vec::new(),
-                format!(
-                    "Failed to execute: {e} ({})",
-                    format_env_diagnostics(command, env)
-                )
-                .into_bytes(),
-            );
-        }
-    };
-    let crate::exec::SpawnedCommand {
-        child,
-        env_script: _env_script,
-    } = spawned;
-
-    let (outcome, stdout, stderr_buf) =
-        wait_with_drain_and_timeout_or_cancelled(child, timeout_ms, connection_cancel);
-    let result = finalize_buffered_result(outcome, stdout, stderr_buf);
-
-    log(
-        "INFO",
-        &format!(
-            "exec result: exit_code={}, stdout_len={}, stderr_len={}",
-            result.0,
-            result.1.len(),
-            result.2.len()
-        ),
-    );
-    result
 }
 
 /// Handle write_file message
@@ -276,7 +217,7 @@ pub(crate) fn set_debug_guest_write_file_path(path: PathBuf) -> Result<(), PathB
 
 /// Handle incoming message and return the connection-loop outcome.
 ///
-/// `MSG_EXEC` and `MSG_SPAWN_WATCH` are handled separately in
+/// Command operation and `MSG_SPAWN_WATCH` are handled separately in
 /// `handle_connection` because they run in background threads.
 pub(crate) fn handle_message(msg: &RawMessage) -> io::Result<MessageOutcome> {
     log(

--- a/crates/vsock-guest/src/wait.rs
+++ b/crates/vsock-guest/src/wait.rs
@@ -6,7 +6,7 @@ use std::time::{Duration, Instant};
 
 use crate::drain::drain_into_vec_cancellable;
 use crate::process::{extract_exit_code, kill_and_reap_child, kill_process_tree};
-use crate::threading::{SystemThreadSpawner, ThreadSpawner, spawn_scoped_named};
+use crate::threading::{ThreadSpawner, spawn_scoped_named};
 
 /// Exit code returned when command times out (same as bash/Python)
 pub(crate) const EXIT_CODE_TIMEOUT: i32 = 124;
@@ -241,19 +241,6 @@ fn kill_child(child_id: u32, reason: KillReason) -> WatchdogKill {
 /// which drops the read end of the pipe. The orphan's next write then sees
 /// EPIPE / SIGPIPE, so neither kernel pipe buffers nor our heap accumulate
 /// further bytes.
-pub(crate) fn wait_with_drain_and_timeout_or_cancelled(
-    child: Child,
-    timeout_ms: u32,
-    external_cancel: &AtomicBool,
-) -> (WaitOutcome, Vec<u8>, Vec<u8>) {
-    wait_with_drain_and_timeout_or_cancelled_with_spawner(
-        child,
-        timeout_ms,
-        external_cancel,
-        SystemThreadSpawner,
-    )
-}
-
 pub(crate) fn wait_with_drain_and_timeout_or_cancelled_with_spawner<S>(
     mut child: Child,
     timeout_ms: u32,

--- a/crates/vsock-guest/tests/connection.rs
+++ b/crates/vsock-guest/tests/connection.rs
@@ -5,7 +5,7 @@
     clippy::indexing_slicing
 )]
 
-use std::io::{Read, Write};
+use std::io::Write;
 use std::thread;
 use std::time::Duration;
 
@@ -13,12 +13,13 @@ use vsock_guest::{handle_connection, run};
 use vsock_proto::{
     self, CommandCapturedOutput, CommandOutputPolicy, CommandOutputStream, CommandTermination,
     MSG_COMMAND_CANCEL, MSG_COMMAND_OUTPUT, MSG_COMMAND_RESULT, MSG_COMMAND_START, MSG_ERROR,
-    MSG_EXEC, MSG_EXEC_RESULT, MSG_PROCESS_EXIT, MSG_SHUTDOWN, MSG_SHUTDOWN_ACK, MSG_SPAWN_WATCH,
-    MSG_SPAWN_WATCH_RESULT, MSG_STDOUT_CHUNK,
+    MSG_PROCESS_EXIT, MSG_SHUTDOWN, MSG_SHUTDOWN_ACK, MSG_SPAWN_WATCH, MSG_SPAWN_WATCH_RESULT,
+    MSG_STDOUT_CHUNK,
 };
 
 const EXIT_CODE_TIMEOUT: i32 = 124;
 const DRAIN_DEADLINE_SECS: u64 = 5;
+const RETIRED_EXEC_MESSAGE_TYPE: u8 = 0x03;
 const LARGE_ENV_COMMAND: &str =
     "printf '%s:%s:%s:%s:%s\\n' \"$SMALL\" \"${#BIG_A}\" \"${#BIG_B}\" \"${#BIG_C}\" \"${#BIG_D}\"";
 
@@ -124,312 +125,13 @@ fn orphan_sleep_command(marker: &str, pid_path: &str) -> String {
     format!("sleep 30 & echo $! > {pid_path}; echo {marker}")
 }
 
-/// Helper: send a MSG_EXEC via the writer half, read MSG_EXEC_RESULT from the
-/// reader half, and return `(exit_code, stdout, stderr)`.
-fn send_exec_and_read_result(
-    writer: &mut impl std::io::Write,
-    reader: &mut impl std::io::Read,
-    seq: u32,
-    command: &str,
-    timeout_ms: u32,
-) -> (i32, Vec<u8>, Vec<u8>) {
-    send_exec_and_read_result_with_env(writer, reader, seq, command, timeout_ms, &[])
-}
-
-fn send_exec_and_read_result_with_env(
-    writer: &mut impl std::io::Write,
-    reader: &mut impl std::io::Read,
-    seq: u32,
-    command: &str,
-    timeout_ms: u32,
-    env: &[(&str, &str)],
-) -> (i32, Vec<u8>, Vec<u8>) {
-    let payload = vsock_proto::encode_exec(timeout_ms, command, env, false);
-    let msg = vsock_proto::encode(MSG_EXEC, seq, &payload).unwrap();
-    writer.write_all(&msg).unwrap();
-
-    // Read response — first 4 bytes are length header
-    let mut hdr = [0u8; 4];
-    reader.read_exact(&mut hdr).unwrap();
-    let body_len = u32::from_be_bytes(hdr) as usize;
-    let mut body = vec![0u8; body_len];
-    reader.read_exact(&mut body).unwrap();
-
-    // Decode
-    let mut full = Vec::with_capacity(4 + body_len);
-    full.extend_from_slice(&hdr);
-    full.extend_from_slice(&body);
-    let mut decoder = vsock_proto::Decoder::new();
-    let msgs = decoder.decode(&full).unwrap();
-    assert_eq!(msgs.len(), 1);
-    assert_eq!(msgs[0].msg_type, MSG_EXEC_RESULT);
-    assert_eq!(msgs[0].seq, seq);
-    vsock_proto::decode_exec_result(&msgs[0].payload)
-        .map(|(code, out, err)| (code, out.to_vec(), err.to_vec()))
-        .unwrap()
-}
-
-/// Verify that a slow exec does not block a fast exec that arrives later.
-/// This is the core regression test for the non-blocking exec fix.
-#[test]
-fn slow_exec_does_not_block_fast_exec() {
-    use std::os::unix::net::UnixStream as StdUnixStream;
-
-    let slow_pid_path = unique_pid_path("slow-exec");
-    let (guest_stream, mut host_stream) = StdUnixStream::pair().unwrap();
-
-    // Run handle_connection in a background thread (it blocks on read)
-    let handle = thread::spawn(move || {
-        let _ = handle_connection(guest_stream);
-    });
-
-    // Read and discard the MSG_READY sent by handle_connection
-    let mut hdr = [0u8; 4];
-    host_stream.read_exact(&mut hdr).unwrap();
-    let body_len = u32::from_be_bytes(hdr) as usize;
-    let mut body = vec![0u8; body_len];
-    host_stream.read_exact(&mut body).unwrap();
-
-    // Send a slow exec and wait until its child shell has actually started.
-    // This keeps the ordering deterministic without a fixed timing delay.
-    let slow_command = format!("echo $$ > '{}'; sleep 5", slow_pid_path.as_str());
-    let slow_payload = vsock_proto::encode_exec(5000, &slow_command, &[], false);
-    let slow_msg = vsock_proto::encode(MSG_EXEC, 1, &slow_payload).unwrap();
-    host_stream.write_all(&slow_msg).unwrap();
-
-    let slow_pid = read_pid_file(slow_pid_path.as_str());
-    assert!(
-        pid_alive(slow_pid),
-        "slow exec should still be running before fast exec"
-    );
-
-    // Send a fast exec — this should return quickly despite the slow one
-    let fast_payload = vsock_proto::encode_exec(5000, "echo ok", &[], false);
-    let fast_msg = vsock_proto::encode(MSG_EXEC, 2, &fast_payload).unwrap();
-    host_stream.write_all(&fast_msg).unwrap();
-
-    // Read responses — we need to find seq=2 (the fast one) within 3 seconds.
-    // Before the fix, this would block on the slow exec.
-    host_stream
-        .set_read_timeout(Some(Duration::from_secs(3)))
-        .unwrap();
-
-    let mut decoder = vsock_proto::Decoder::new();
-    let mut found_fast = false;
-    let deadline = std::time::Instant::now() + Duration::from_secs(3);
-
-    while std::time::Instant::now() < deadline {
-        let mut buf = [0u8; 4096];
-        match host_stream.read(&mut buf) {
-            Ok(0) => break,
-            Ok(n) => {
-                for msg in decoder.decode(buf.get(..n).unwrap_or_default()).unwrap() {
-                    if msg.seq == 2 && msg.msg_type == MSG_EXEC_RESULT {
-                        let (code, stdout, _) =
-                            vsock_proto::decode_exec_result(&msg.payload).unwrap();
-                        assert_eq!(code, 0);
-                        assert_eq!(String::from_utf8_lossy(stdout).trim(), "ok");
-                        found_fast = true;
-                    }
-                }
-                if found_fast {
-                    break;
-                }
-            }
-            Err(e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
-            Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => break,
-            Err(e) => panic!("read error: {e}"),
-        }
-    }
-
-    assert!(
-        found_fast,
-        "fast exec (seq=2) should complete while slow exec is still running"
-    );
-
-    // Shut down: drop the stream so handle_connection sees EOF
-    drop(host_stream);
-    let _ = handle.join();
-}
-
-/// Verify that a normal exec still returns correct results.
-#[test]
-fn exec_returns_correct_result() {
-    use std::os::unix::net::UnixStream as StdUnixStream;
-
-    let (guest_stream, host_stream) = StdUnixStream::pair().unwrap();
-    let mut host_writer = host_stream.try_clone().unwrap();
-    let mut host_reader = host_stream;
-
-    let handle = thread::spawn(move || {
-        let _ = handle_connection(guest_stream);
-    });
-
-    // Discard MSG_READY
-    let mut hdr = [0u8; 4];
-    host_reader.read_exact(&mut hdr).unwrap();
-    let body_len = u32::from_be_bytes(hdr) as usize;
-    let mut body = vec![0u8; body_len];
-    host_reader.read_exact(&mut body).unwrap();
-
-    host_reader
-        .set_read_timeout(Some(Duration::from_secs(5)))
-        .unwrap();
-
-    let (code, stdout, _stderr) =
-        send_exec_and_read_result(&mut host_writer, &mut host_reader, 1, "echo hello", 5000);
-    assert_eq!(code, 0);
-    assert_eq!(String::from_utf8_lossy(&stdout).trim(), "hello");
-
-    drop(host_writer);
-    drop(host_reader);
-    let _ = handle.join();
-}
-
-#[test]
-fn exec_large_env_payload_succeeds() {
-    use std::os::unix::net::UnixStream as StdUnixStream;
-
-    let values = large_env_values();
-    let env = large_env_entries(&values);
-
-    let (guest_stream, host_stream) = StdUnixStream::pair().unwrap();
-    let mut host_writer = host_stream.try_clone().unwrap();
-    let mut host_reader = host_stream;
-
-    let handle = thread::spawn(move || {
-        let _ = handle_connection(guest_stream);
-    });
-    read_and_discard_message(&mut host_reader); // MSG_READY
-    host_reader
-        .set_read_timeout(Some(Duration::from_secs(5)))
-        .unwrap();
-
-    let (code, stdout, stderr) = send_exec_and_read_result_with_env(
-        &mut host_writer,
-        &mut host_reader,
-        1,
-        LARGE_ENV_COMMAND,
-        5000,
-        &env,
-    );
-
-    assert_eq!(code, 0, "stderr: {}", String::from_utf8_lossy(&stderr));
-    assert_large_env_stdout(&stdout);
-
-    drop(host_writer);
-    drop(host_reader);
-    let _ = handle.join();
-}
-
-#[test]
-fn exec_invalid_env_payload_returns_error_without_leaking_value() {
-    use std::os::unix::net::UnixStream as StdUnixStream;
-
-    let (guest_stream, host_stream) = StdUnixStream::pair().unwrap();
-    let mut host_writer = host_stream.try_clone().unwrap();
-    let mut host_reader = host_stream;
-
-    let handle = thread::spawn(move || {
-        let _ = handle_connection(guest_stream);
-    });
-    read_and_discard_message(&mut host_reader); // MSG_READY
-    host_reader
-        .set_read_timeout(Some(Duration::from_secs(5)))
-        .unwrap();
-
-    let secret = "do-not-print-this-secret";
-    let (code, stdout, stderr) = send_exec_and_read_result_with_env(
-        &mut host_writer,
-        &mut host_reader,
-        1,
-        "echo should-not-run",
-        5000,
-        &[("BAD;KEY", secret)],
-    );
-    let stderr = String::from_utf8_lossy(&stderr);
-
-    assert_eq!(code, 1);
-    assert!(stdout.is_empty());
-    assert!(stderr.contains("invalid environment variable name"));
-    assert!(!stderr.contains(secret));
-
-    drop(host_writer);
-    drop(host_reader);
-    let _ = handle.join();
-}
-
-/// Buffered exec killed by timeout returns exit code 124.
-#[test]
-fn exec_timeout_returns_124() {
-    use std::os::unix::net::UnixStream as StdUnixStream;
-
-    let (guest_stream, host_stream) = StdUnixStream::pair().unwrap();
-    let mut host_writer = host_stream.try_clone().unwrap();
-    let mut host_reader = host_stream;
-
-    let handle = thread::spawn(move || {
-        let _ = handle_connection(guest_stream);
-    });
-
-    // Discard MSG_READY
-    let mut hdr = [0u8; 4];
-    host_reader.read_exact(&mut hdr).unwrap();
-    let body_len = u32::from_be_bytes(hdr) as usize;
-    let mut body = vec![0u8; body_len];
-    host_reader.read_exact(&mut body).unwrap();
-
-    host_reader
-        .set_read_timeout(Some(Duration::from_secs(5)))
-        .unwrap();
-
-    // sleep 60 with a 500ms timeout → killed by timeout
-    let (code, _stdout, stderr) =
-        send_exec_and_read_result(&mut host_writer, &mut host_reader, 1, "sleep 60", 500);
-    assert_eq!(code, EXIT_CODE_TIMEOUT);
-    assert_eq!(String::from_utf8_lossy(&stderr), "Timeout");
-
-    drop(host_writer);
-    drop(host_reader);
-    let _ = handle.join();
-}
-
-/// Regression for #9701: `timeout_ms == 0` must mean "no timeout", not
-/// "kill immediately". Before the fix, `wait_with_timeout` built a
-/// `Duration::ZERO` and the killer thread fired on the first tick,
-/// returning exit 124 ("Timeout") for any command.
-#[test]
-fn exec_timeout_zero_means_no_timeout() {
-    use std::os::unix::net::UnixStream as StdUnixStream;
-
-    let (guest_stream, host_stream) = StdUnixStream::pair().unwrap();
-    let mut host_writer = host_stream.try_clone().unwrap();
-    let mut host_reader = host_stream;
-
-    let handle = thread::spawn(move || {
-        let _ = handle_connection(guest_stream);
-    });
-
-    // Discard MSG_READY
-    let mut hdr = [0u8; 4];
-    host_reader.read_exact(&mut hdr).unwrap();
-    let body_len = u32::from_be_bytes(hdr) as usize;
-    let mut body = vec![0u8; body_len];
-    host_reader.read_exact(&mut body).unwrap();
-
-    host_reader
-        .set_read_timeout(Some(Duration::from_secs(5)))
-        .unwrap();
-
-    let (code, stdout, stderr) =
-        send_exec_and_read_result(&mut host_writer, &mut host_reader, 1, "echo hello", 0);
-    assert_eq!(code, 0);
-    assert_eq!(String::from_utf8_lossy(&stdout), "hello\n");
-    assert_eq!(stderr, b"");
-
-    drop(host_writer);
-    drop(host_reader);
-    let _ = handle.join();
+fn encode_retired_exec_payload(command: &str) -> Vec<u8> {
+    let mut payload = Vec::with_capacity(9 + command.len());
+    payload.extend_from_slice(&5000_u32.to_be_bytes());
+    payload.push(0);
+    payload.extend_from_slice(&(command.len() as u32).to_be_bytes());
+    payload.extend_from_slice(command.as_bytes());
+    payload
 }
 
 #[test]
@@ -528,6 +230,31 @@ fn read_message(stream: &mut impl std::io::Read) -> vsock_proto::RawMessage {
 /// Read one framed message from the stream and discard it.
 fn read_and_discard_message(stream: &mut impl std::io::Read) {
     let _ = read_message(stream);
+}
+
+#[test]
+fn retired_exec_message_returns_unknown_error_without_running_payload() {
+    let marker_path = unique_tmp_path("retired-exec", ".marker");
+    let (handle, mut host_stream) = start_guest_connection();
+
+    let payload = encode_retired_exec_payload(&format!("touch {}", marker_path.as_str()));
+    let msg = vsock_proto::encode(RETIRED_EXEC_MESSAGE_TYPE, 77, &payload).unwrap();
+    host_stream.write_all(&msg).unwrap();
+
+    let response = read_message(&mut host_stream);
+    assert_eq!(response.msg_type, MSG_ERROR);
+    assert_eq!(response.seq, 77);
+    let error = vsock_proto::decode_error(&response.payload).unwrap();
+    assert!(
+        error.contains("0x03"),
+        "unknown-message error should name retired type: {error}"
+    );
+    assert!(
+        !std::path::Path::new(marker_path.as_str()).exists(),
+        "retired exec payload must not be executed",
+    );
+
+    finish_guest_connection(handle, host_stream);
 }
 
 #[derive(Debug)]
@@ -734,6 +461,35 @@ fn command_capture_only_stdout_stderr_success() {
     assert!(!result.stdout_truncated);
     assert!(!result.stderr_truncated);
     assert!(result.diagnostic.is_empty());
+
+    finish_guest_connection(handle, host_stream);
+}
+
+#[test]
+fn command_large_env_payload_succeeds() {
+    let values = large_env_values();
+    let env = large_env_entries(&values);
+    let (handle, mut host_stream) = start_guest_connection();
+
+    send_command_start_with_env(
+        &mut host_stream,
+        124,
+        LARGE_ENV_COMMAND,
+        5000,
+        &env,
+        CommandOutputPolicy::Capture { limit_bytes: 128 },
+        CommandOutputPolicy::Capture { limit_bytes: 1024 },
+    );
+    let (_chunks, result) = read_command_result(&mut host_stream, 124);
+
+    assert_eq!(
+        result.termination,
+        CommandTermination::Exited { exit_code: 0 },
+        "diagnostic: {} stderr: {:?}",
+        result.diagnostic,
+        result.stderr,
+    );
+    assert_large_env_stdout(&result.stdout.unwrap_or_default());
 
     finish_guest_connection(handle, host_stream);
 }
@@ -1933,91 +1689,84 @@ fn wait_for_pid_exit(pid: u32, context: &str) {
     }
 }
 
-/// Regression for #11077 (`MSG_EXEC` side): with `timeout_ms = 0`, a
-/// backgrounded grandchild that inherits the stdout fd must NOT keep
-/// `MSG_EXEC_RESULT` from arriving after the foreground shell exits.
-/// Pre-fix, `wait_with_output` blocked on stdout EOF and waited the full
-/// ~30 s for the orphaned `sleep` to release the fd. Post-fix, the
-/// drain thread cancels at the deadline (well below 30 s) and we return.
+/// Regression for #11077: with `timeout_ms = 0`, a backgrounded grandchild
+/// that inherits the stdout fd must not keep the command result from arriving
+/// after the foreground shell exits. Pre-fix, buffered output collection
+/// waited the full ~30 s for the orphaned `sleep` to release the fd. Post-fix,
+/// the drain thread cancels at the deadline (well below 30 s) and we return.
 #[test]
-fn exec_returns_when_orphaned_grandchild_holds_stdout() {
-    use std::os::unix::net::UnixStream as StdUnixStream;
+fn command_returns_when_orphaned_grandchild_holds_stdout() {
     use std::time::Instant;
 
-    let (guest_stream, host_stream) = StdUnixStream::pair().unwrap();
-    let mut host_writer = host_stream.try_clone().unwrap();
-    let mut host_reader = host_stream;
-
-    let handle = thread::spawn(move || {
-        let _ = handle_connection(guest_stream);
-    });
-
-    read_and_discard_message(&mut host_reader); // MSG_READY
-
-    host_reader
+    let (handle, mut host_stream) = start_guest_connection();
+    host_stream
         .set_read_timeout(Some(Duration::from_secs(15)))
         .unwrap();
-
-    let orphan = OrphanProcessGuard::new("orphan-exec-sleep");
-    let command = orphan_sleep_command("orphan-exec", orphan.pid_path());
+    let orphan = OrphanProcessGuard::new("orphan-command-sleep");
+    let command = orphan_sleep_command("orphan-command", orphan.pid_path());
     let start = Instant::now();
-    let (code, stdout, _stderr) =
-        send_exec_and_read_result(&mut host_writer, &mut host_reader, 1, &command, 0);
+    send_command_start(
+        &mut host_stream,
+        122,
+        &command,
+        0,
+        CommandOutputPolicy::Capture { limit_bytes: 1024 },
+        CommandOutputPolicy::Capture { limit_bytes: 1024 },
+    );
+    let (_chunks, result) = read_command_result(&mut host_stream, 122);
     let elapsed = start.elapsed();
 
-    assert_eq!(code, 0);
+    assert_eq!(
+        result.termination,
+        CommandTermination::Exited { exit_code: 0 }
+    );
+    let stdout = result.stdout.unwrap_or_default();
     assert!(
-        String::from_utf8_lossy(&stdout).contains("orphan-exec"),
-        "expected stdout to contain 'orphan-exec', got: {:?}",
+        String::from_utf8_lossy(&stdout).contains("orphan-command"),
+        "expected stdout to contain 'orphan-command', got: {:?}",
         String::from_utf8_lossy(&stdout),
     );
     assert!(
         elapsed < Duration::from_secs(DRAIN_DEADLINE_SECS + 5),
-        "MSG_EXEC_RESULT should arrive within drain deadline, took {elapsed:?}",
+        "command result should arrive within drain deadline, took {elapsed:?}",
     );
 
-    drop(host_writer);
-    drop(host_reader);
-    let _ = handle.join();
+    finish_guest_connection(handle, host_stream);
 }
 
 /// Output written by an inherited-fd grandchild within the drain deadline must
 /// still be included after the foreground shell exits.
 #[test]
-fn exec_captures_grandchild_output_before_drain_deadline() {
-    use std::os::unix::net::UnixStream as StdUnixStream;
+fn command_captures_grandchild_output_before_drain_deadline() {
     use std::time::Instant;
 
-    let (guest_stream, host_stream) = StdUnixStream::pair().unwrap();
-    let mut host_writer = host_stream.try_clone().unwrap();
-    let mut host_reader = host_stream;
-
-    let handle = thread::spawn(move || {
-        let _ = handle_connection(guest_stream);
-    });
-
-    read_and_discard_message(&mut host_reader); // MSG_READY
-    host_reader
+    let (handle, mut host_stream) = start_guest_connection();
+    host_stream
         .set_read_timeout(Some(Duration::from_secs(8)))
         .unwrap();
 
     let start = Instant::now();
-    let (code, stdout, stderr) = send_exec_and_read_result(
-        &mut host_writer,
-        &mut host_reader,
-        1,
+    send_command_start(
+        &mut host_stream,
+        123,
         "echo stdout-early; echo stderr-early >&2; { sleep 1; echo stdout-late; echo stderr-late >&2; } &",
         0,
+        CommandOutputPolicy::Capture { limit_bytes: 1024 },
+        CommandOutputPolicy::Capture { limit_bytes: 1024 },
     );
+    let (_chunks, result) = read_command_result(&mut host_stream, 123);
     let elapsed = start.elapsed();
 
-    assert_eq!(code, 0);
     assert_eq!(
-        String::from_utf8_lossy(&stdout),
+        result.termination,
+        CommandTermination::Exited { exit_code: 0 }
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&result.stdout.unwrap_or_default()),
         "stdout-early\nstdout-late\n"
     );
     assert_eq!(
-        String::from_utf8_lossy(&stderr),
+        String::from_utf8_lossy(&result.stderr.unwrap_or_default()),
         "stderr-early\nstderr-late\n"
     );
     assert!(
@@ -2025,9 +1774,7 @@ fn exec_captures_grandchild_output_before_drain_deadline() {
         "late output should be captured before drain deadline, took {elapsed:?}",
     );
 
-    drop(host_writer);
-    drop(host_reader);
-    let _ = handle.join();
+    finish_guest_connection(handle, host_stream);
 }
 
 /// Returns true iff `pid` is still a live (or zombie-but-unreaped) process
@@ -2038,38 +1785,6 @@ fn exec_captures_grandchild_output_before_drain_deadline() {
 fn pid_alive(pid: u32) -> bool {
     // SAFETY: `kill` with sig=0 is a no-op existence check.
     unsafe { libc::kill(pid as i32, 0) == 0 }
-}
-
-#[test]
-fn exec_timeout_zero_silent_child_is_cancelled_on_host_disconnect() {
-    use std::os::unix::net::UnixStream as StdUnixStream;
-
-    let pid_path = unique_pid_path("exec-cancel");
-
-    let (guest_stream, mut host_stream) = StdUnixStream::pair().unwrap();
-    let handle = thread::spawn(move || {
-        let _ = handle_connection(guest_stream);
-    });
-    read_and_discard_message(&mut host_stream); // MSG_READY
-
-    let payload = vsock_proto::encode_exec(
-        0,
-        &format!("echo $$ > '{}'; sleep 60", pid_path.as_str()),
-        &[],
-        false,
-    );
-    let msg = vsock_proto::encode(MSG_EXEC, 1, &payload).unwrap();
-    host_stream.write_all(&msg).unwrap();
-
-    let pid = read_pid_file(pid_path.as_str());
-    assert!(
-        pid_alive(pid),
-        "child should still be running before disconnect",
-    );
-
-    drop(host_stream);
-    let _ = handle.join();
-    wait_for_pid_exit(pid, "exec host disconnect");
 }
 
 #[test]
@@ -2241,9 +1956,8 @@ fn streaming_terminates_child_on_vsock_disconnect() {
 /// the second pipe would fill, the child would block on its next write,
 /// and the test would hit the read timeout.
 ///
-/// Pins down the concurrent-drain invariant shared by `MSG_EXEC` and buffered
-/// `MSG_SPAWN_WATCH`. The streaming path in `spawn_streaming_monitor` follows
-/// the same
+/// Pins down the concurrent-drain invariant for buffered `MSG_SPAWN_WATCH`.
+/// The streaming path in `spawn_streaming_monitor` follows the same
 /// stderr-thread-before-stdout-thread structure for the same reason.
 #[test]
 fn buffered_spawn_watch_concurrent_large_stdout_stderr() {

--- a/crates/vsock-guest/tests/connection.rs
+++ b/crates/vsock-guest/tests/connection.rs
@@ -19,7 +19,7 @@ use vsock_proto::{
 
 const EXIT_CODE_TIMEOUT: i32 = 124;
 const DRAIN_DEADLINE_SECS: u64 = 5;
-const RETIRED_EXEC_MESSAGE_TYPE: u8 = 0x03;
+const RETIRED_EXEC_MESSAGE_TYPES: &[u8] = &[0x03, 0x04];
 const LARGE_ENV_COMMAND: &str =
     "printf '%s:%s:%s:%s:%s\\n' \"$SMALL\" \"${#BIG_A}\" \"${#BIG_B}\" \"${#BIG_C}\" \"${#BIG_D}\"";
 
@@ -233,22 +233,29 @@ fn read_and_discard_message(stream: &mut impl std::io::Read) {
 }
 
 #[test]
-fn retired_exec_message_returns_unknown_error_without_running_payload() {
+fn retired_exec_message_types_return_unknown_error_without_running_payload() {
     let marker_path = unique_tmp_path("retired-exec", ".marker");
     let (handle, mut host_stream) = start_guest_connection();
 
-    let payload = encode_retired_exec_payload(&format!("touch {}", marker_path.as_str()));
-    let msg = vsock_proto::encode(RETIRED_EXEC_MESSAGE_TYPE, 77, &payload).unwrap();
-    host_stream.write_all(&msg).unwrap();
+    for (index, msg_type) in RETIRED_EXEC_MESSAGE_TYPES.iter().copied().enumerate() {
+        let payload = if msg_type == 0x03 {
+            encode_retired_exec_payload(&format!("touch {}", marker_path.as_str()))
+        } else {
+            Vec::new()
+        };
+        let seq = 77 + index as u32;
+        let msg = vsock_proto::encode(msg_type, seq, &payload).unwrap();
+        host_stream.write_all(&msg).unwrap();
 
-    let response = read_message(&mut host_stream);
-    assert_eq!(response.msg_type, MSG_ERROR);
-    assert_eq!(response.seq, 77);
-    let error = vsock_proto::decode_error(&response.payload).unwrap();
-    assert!(
-        error.contains("0x03"),
-        "unknown-message error should name retired type: {error}"
-    );
+        let response = read_message(&mut host_stream);
+        assert_eq!(response.msg_type, MSG_ERROR);
+        assert_eq!(response.seq, seq);
+        let error = vsock_proto::decode_error(&response.payload).unwrap();
+        assert!(
+            error.contains(&format!("0x{msg_type:02X}")),
+            "unknown-message error should name retired type: {error}"
+        );
+    }
     assert!(
         !std::path::Path::new(marker_path.as_str()).exists(),
         "retired exec payload must not be executed",

--- a/crates/vsock-proto/src/lib.rs
+++ b/crates/vsock-proto/src/lib.rs
@@ -18,8 +18,8 @@
 //! | 0x00 | G→H       | ready             | (empty) |
 //! | 0x01 | H→G       | ping              | (empty) |
 //! | 0x02 | G→H       | pong              | (empty) |
-//! | 0x03 | H→G       | exec              | `[4B timeout_ms][1B flags][4B cmd_len][command]([4B env_count]([4B key_len][key][4B val_len][value])*)` |
-//! | 0x04 | G→H       | exec_result       | `[4B exit_code][4B stdout_len][stdout][4B stderr_len][stderr]` |
+//! | 0x03 | —         | retired           | legacy exec, do not reuse |
+//! | 0x04 | —         | retired           | legacy exec_result, do not reuse |
 //! | 0x05 | H→G       | write_file        | `[2B path_len][path][1B flags][4B content_len][content]` (flags: `SUDO=0x01`, `APPEND=0x02`) |
 //! | 0x06 | G→H       | write_file_result | `[1B success][2B error_len][error]` |
 //! | 0x07 | H→G       | spawn_watch       | `[4B timeout_ms][1B flags][4B cmd_len][command]([4B env_count]([4B key_len][key][4B val_len][value])*)([2B log_path_len][log_path])` (flags: `SUDO=0x01`, `STREAM_STDOUT=0x02`) |
@@ -52,8 +52,6 @@ pub const MIN_BODY_SIZE: usize = 5;
 pub const MSG_READY: u8 = 0x00;
 pub const MSG_PING: u8 = 0x01;
 pub const MSG_PONG: u8 = 0x02;
-pub const MSG_EXEC: u8 = 0x03;
-pub const MSG_EXEC_RESULT: u8 = 0x04;
 pub const MSG_WRITE_FILE: u8 = 0x05;
 pub const MSG_WRITE_FILE_RESULT: u8 = 0x06;
 pub const MSG_SPAWN_WATCH: u8 = 0x07;
@@ -70,9 +68,6 @@ pub const MSG_ERROR: u8 = 0xFF;
 
 /// Default vsock port for host-guest communication.
 pub const VSOCK_PORT: u32 = 1000;
-
-// Exec payload flags.
-pub const EXEC_FLAG_SUDO: u8 = 0x01;
 
 // Spawn-watch payload flags.
 pub const SPAWN_WATCH_FLAG_SUDO: u8 = 0x01;
@@ -358,47 +353,14 @@ pub fn encode(msg_type: u8, seq: u32, payload: &[u8]) -> Result<Vec<u8>, Protoco
     Ok(buf)
 }
 
-/// Encode exec payload: `[4B timeout_ms][1B flags][4B cmd_len][command]([4B env_count]([4B key_len][key][4B val_len][value])*)`.
-///
-/// The env section is only appended when `env` is non-empty, keeping the
-/// payload backward-compatible with old decoders that don't expect it.
-pub fn encode_exec(timeout_ms: u32, command: &str, env: &[(&str, &str)], sudo: bool) -> Vec<u8> {
-    let cmd = command.as_bytes();
-    let env_size: usize = if env.is_empty() {
-        0
-    } else {
-        4 + env
-            .iter()
-            .map(|(k, v)| 8 + k.len() + v.len())
-            .sum::<usize>()
-    };
-    let mut p = Vec::with_capacity(9 + cmd.len() + env_size);
-    p.extend_from_slice(&timeout_ms.to_be_bytes());
-    p.push(if sudo { EXEC_FLAG_SUDO } else { 0 });
-    p.extend_from_slice(&(cmd.len() as u32).to_be_bytes());
-    p.extend_from_slice(cmd);
-    if !env.is_empty() {
-        p.extend_from_slice(&(env.len() as u32).to_be_bytes());
-        for (key, val) in env {
-            let kb = key.as_bytes();
-            let vb = val.as_bytes();
-            p.extend_from_slice(&(kb.len() as u32).to_be_bytes());
-            p.extend_from_slice(kb);
-            p.extend_from_slice(&(vb.len() as u32).to_be_bytes());
-            p.extend_from_slice(vb);
-        }
-    }
-    p
-}
-
-/// Encode spawn_watch payload: exec fields + optional `[2B log_path_len][log_path]`.
+/// Encode spawn_watch payload: command fields + optional `[2B log_path_len][log_path]`.
 ///
 /// `stream_stdout` controls whether stdout is streamed to the host via
 /// `MSG_STDOUT_CHUNK`. `stdout_log_path`, when present, additionally asks
 /// the guest to tee streamed stdout to that file.
 ///
-/// Unlike `encode_exec`, this always writes the env section (even when empty)
-/// so `decode_spawn_watch` can unambiguously find the log_path boundary.
+/// This always writes the env section (even when empty) so
+/// `decode_spawn_watch` can unambiguously find the log_path boundary.
 pub fn encode_spawn_watch(
     timeout_ms: u32,
     command: &str,
@@ -452,14 +414,6 @@ pub fn encode_spawn_watch(
         p.extend_from_slice(path_bytes);
     }
     Ok(p)
-}
-
-/// Encode exec_result payload: `[4B exit_code][4B stdout_len][stdout][4B stderr_len][stderr]`.
-pub fn encode_exec_result(exit_code: i32, stdout: &[u8], stderr: &[u8]) -> Vec<u8> {
-    let mut p = Vec::with_capacity(12 + stdout.len() + stderr.len());
-    p.extend_from_slice(&exit_code.to_be_bytes());
-    append_output_pair(&mut p, stdout, stderr);
-    p
 }
 
 fn append_output_pair(p: &mut Vec<u8>, stdout: &[u8], stderr: &[u8]) {
@@ -792,35 +746,40 @@ pub fn encode_error(message: &str) -> Vec<u8> {
 // Decode
 // ---------------------------------------------------------------------------
 
-struct DecodedExecInner<'a> {
-    exec: DecodedExec<'a>,
+struct DecodedCommandFieldsInner<'a> {
+    fields: DecodedCommandFields<'a>,
     offset: usize,
     raw_flags: u8,
 }
 
-/// Decode exec/spawn_watch shared fields.
+/// Decode the command-shaped prefix used by spawn_watch payloads.
 ///
-/// The env section is optional: if the payload ends right after the command,
-/// an empty vec is returned (backward-compatible with old encoders).
-fn decode_exec_inner(payload: &[u8], sudo_flag: u8) -> Result<DecodedExecInner<'_>, ProtocolError> {
-    let timeout_ms =
-        read_u32_at(payload, 0).ok_or(ProtocolError::InvalidPayload("exec payload too short"))?;
-    let flags =
-        read_u8_at(payload, 4).ok_or(ProtocolError::InvalidPayload("exec payload too short"))?;
+/// The env section is optional: if the payload ends right after the command, an
+/// empty vec is returned. `encode_spawn_watch` always writes the env section so
+/// the optional log path remains unambiguous for new payloads.
+fn decode_command_fields(
+    payload: &[u8],
+    sudo_flag: u8,
+) -> Result<DecodedCommandFieldsInner<'_>, ProtocolError> {
+    let timeout_ms = read_u32_at(payload, 0).ok_or(ProtocolError::InvalidPayload(
+        "command fields payload too short",
+    ))?;
+    let flags = read_u8_at(payload, 4).ok_or(ProtocolError::InvalidPayload(
+        "command fields payload too short",
+    ))?;
     let sudo = (flags & sudo_flag) != 0;
-    let cmd_len = read_u32_at(payload, 5)
-        .ok_or(ProtocolError::InvalidPayload("exec payload too short"))? as usize;
-    let command = std::str::from_utf8(
-        payload
-            .get(9..9 + cmd_len)
-            .ok_or(ProtocolError::InvalidPayload("exec command truncated"))?,
-    )
+    let cmd_len = read_u32_at(payload, 5).ok_or(ProtocolError::InvalidPayload(
+        "command fields payload too short",
+    ))? as usize;
+    let command = std::str::from_utf8(payload.get(9..9 + cmd_len).ok_or(
+        ProtocolError::InvalidPayload("command fields command truncated"),
+    )?)
     .map_err(|_| ProtocolError::InvalidPayload("invalid UTF-8 in command"))?;
 
     let env_start = 9 + cmd_len;
     if env_start >= payload.len() {
-        return Ok(DecodedExecInner {
-            exec: DecodedExec {
+        return Ok(DecodedCommandFieldsInner {
+            fields: DecodedCommandFields {
                 timeout_ms,
                 command,
                 env: Vec::new(),
@@ -831,44 +790,40 @@ fn decode_exec_inner(payload: &[u8], sudo_flag: u8) -> Result<DecodedExecInner<'
         });
     }
 
-    let env_count = read_u32_at(payload, env_start)
-        .ok_or(ProtocolError::InvalidPayload("exec env count truncated"))?
-        as usize;
+    let env_count = read_u32_at(payload, env_start).ok_or(ProtocolError::InvalidPayload(
+        "command fields env count truncated",
+    ))? as usize;
     // Do not pre-allocate based on env_count: it is untrusted wire data and a
     // malformed message can claim u32::MAX pairs. The per-iteration bounds
     // checks below return an error as soon as the payload runs out.
     let mut env = Vec::new();
     let mut offset = env_start + 4;
     for _ in 0..env_count {
-        let key_len = read_u32_at(payload, offset)
-            .ok_or(ProtocolError::InvalidPayload("exec env key_len truncated"))?
-            as usize;
+        let key_len = read_u32_at(payload, offset).ok_or(ProtocolError::InvalidPayload(
+            "command fields env key_len truncated",
+        ))? as usize;
         offset += 4;
-        let key = std::str::from_utf8(
-            payload
-                .get(offset..offset + key_len)
-                .ok_or(ProtocolError::InvalidPayload("exec env key truncated"))?,
-        )
+        let key = std::str::from_utf8(payload.get(offset..offset + key_len).ok_or(
+            ProtocolError::InvalidPayload("command fields env key truncated"),
+        )?)
         .map_err(|_| ProtocolError::InvalidPayload("invalid UTF-8 in env key"))?;
         offset += key_len;
 
-        let val_len = read_u32_at(payload, offset)
-            .ok_or(ProtocolError::InvalidPayload("exec env val_len truncated"))?
-            as usize;
+        let val_len = read_u32_at(payload, offset).ok_or(ProtocolError::InvalidPayload(
+            "command fields env val_len truncated",
+        ))? as usize;
         offset += 4;
-        let val = std::str::from_utf8(
-            payload
-                .get(offset..offset + val_len)
-                .ok_or(ProtocolError::InvalidPayload("exec env value truncated"))?,
-        )
+        let val = std::str::from_utf8(payload.get(offset..offset + val_len).ok_or(
+            ProtocolError::InvalidPayload("command fields env value truncated"),
+        )?)
         .map_err(|_| ProtocolError::InvalidPayload("invalid UTF-8 in env value"))?;
         offset += val_len;
 
         env.push((key, val));
     }
 
-    Ok(DecodedExecInner {
-        exec: DecodedExec {
+    Ok(DecodedCommandFieldsInner {
+        fields: DecodedCommandFields {
             timeout_ms,
             command,
             env,
@@ -879,22 +834,17 @@ fn decode_exec_inner(payload: &[u8], sudo_flag: u8) -> Result<DecodedExecInner<'
     })
 }
 
-/// Decode exec payload into a [`DecodedExec`] struct.
-pub fn decode_exec(payload: &[u8]) -> Result<DecodedExec<'_>, ProtocolError> {
-    decode_exec_inner(payload, EXEC_FLAG_SUDO).map(|d| d.exec)
-}
-
-/// Decode spawn_watch payload. Extends exec fields with streaming metadata.
+/// Decode spawn_watch payload. Extends command fields with streaming metadata.
 ///
-/// Wire format: `[exec fields...]([2B log_path_len][log_path])`.
-/// The log_path section is optional — if the payload ends after the exec
+/// Wire format: `[command fields...]([2B log_path_len][log_path])`.
+/// The log_path section is optional — if the payload ends after the command
 /// fields, `stdout_log_path` is `None`.
 pub fn decode_spawn_watch(payload: &[u8]) -> Result<DecodedSpawnWatch<'_>, ProtocolError> {
-    let DecodedExecInner {
-        exec,
+    let DecodedCommandFieldsInner {
+        fields,
         offset,
         raw_flags,
-    } = decode_exec_inner(payload, SPAWN_WATCH_FLAG_SUDO)?;
+    } = decode_command_fields(payload, SPAWN_WATCH_FLAG_SUDO)?;
     let stream_flag = (raw_flags & SPAWN_WATCH_FLAG_STREAM_STDOUT) != 0;
     let stdout_log_path = if offset == payload.len() {
         None
@@ -927,76 +877,49 @@ pub fn decode_spawn_watch(payload: &[u8]) -> Result<DecodedSpawnWatch<'_>, Proto
         ));
     }
     Ok(DecodedSpawnWatch {
-        exec,
+        fields,
         stream_stdout: stream_flag,
         stdout_log_path,
     })
 }
 
-/// Decode exec_result payload. Returns `(exit_code, stdout, stderr)`.
-pub fn decode_exec_result(payload: &[u8]) -> Result<(i32, &[u8], &[u8]), ProtocolError> {
-    let exit_code =
-        read_i32_at(payload, 0).ok_or(ProtocolError::InvalidPayload("exec_result too short"))?;
-    let (stdout, stderr) = decode_output_pair_at(payload, 4, OutputPairContext::ExecResult)?;
-    Ok((exit_code, stdout, stderr))
-}
-
-#[derive(Clone, Copy)]
-enum OutputPairContext {
-    ExecResult,
-    ProcessExit,
-}
-
-impl OutputPairContext {
-    fn too_short(self) -> &'static str {
-        match self {
-            Self::ExecResult => "exec_result too short",
-            Self::ProcessExit => "process_exit too short",
-        }
-    }
-
-    fn stdout_truncated(self) -> &'static str {
-        match self {
-            Self::ExecResult => "exec_result stdout truncated",
-            Self::ProcessExit => "process_exit stdout truncated",
-        }
-    }
-
-    fn stderr_truncated(self) -> &'static str {
-        match self {
-            Self::ExecResult => "exec_result stderr truncated",
-            Self::ProcessExit => "process_exit stderr truncated",
-        }
-    }
-}
-
-fn decode_output_pair_at(
-    payload: &[u8],
-    offset: usize,
-    ctx: OutputPairContext,
-) -> Result<(&[u8], &[u8]), ProtocolError> {
+fn decode_output_pair_at(payload: &[u8], offset: usize) -> Result<(&[u8], &[u8]), ProtocolError> {
     let stdout_len = read_u32_at(payload, offset)
-        .ok_or(ProtocolError::InvalidPayload(ctx.too_short()))? as usize;
-    let stdout_start = offset
-        .checked_add(4)
-        .ok_or(ProtocolError::InvalidPayload(ctx.stdout_truncated()))?;
-    let stderr_len_offset = stdout_start
-        .checked_add(stdout_len)
-        .ok_or(ProtocolError::InvalidPayload(ctx.stdout_truncated()))?;
-    let stdout = payload
-        .get(stdout_start..stderr_len_offset)
-        .ok_or(ProtocolError::InvalidPayload(ctx.stdout_truncated()))?;
+        .ok_or(ProtocolError::InvalidPayload("process_exit too short"))?
+        as usize;
+    let stdout_start = offset.checked_add(4).ok_or(ProtocolError::InvalidPayload(
+        "process_exit stdout truncated",
+    ))?;
+    let stderr_len_offset =
+        stdout_start
+            .checked_add(stdout_len)
+            .ok_or(ProtocolError::InvalidPayload(
+                "process_exit stdout truncated",
+            ))?;
+    let stdout =
+        payload
+            .get(stdout_start..stderr_len_offset)
+            .ok_or(ProtocolError::InvalidPayload(
+                "process_exit stdout truncated",
+            ))?;
     let stderr_len = read_u32_at(payload, stderr_len_offset)
-        .ok_or(ProtocolError::InvalidPayload(ctx.too_short()))? as usize;
+        .ok_or(ProtocolError::InvalidPayload("process_exit too short"))?
+        as usize;
     let stderr_start = stderr_len_offset
         .checked_add(4)
-        .ok_or(ProtocolError::InvalidPayload(ctx.stderr_truncated()))?;
+        .ok_or(ProtocolError::InvalidPayload(
+            "process_exit stderr truncated",
+        ))?;
     let stderr_end = stderr_start
         .checked_add(stderr_len)
-        .ok_or(ProtocolError::InvalidPayload(ctx.stderr_truncated()))?;
+        .ok_or(ProtocolError::InvalidPayload(
+            "process_exit stderr truncated",
+        ))?;
     let stderr = payload
         .get(stderr_start..stderr_end)
-        .ok_or(ProtocolError::InvalidPayload(ctx.stderr_truncated()))?;
+        .ok_or(ProtocolError::InvalidPayload(
+            "process_exit stderr truncated",
+        ))?;
     Ok((stdout, stderr))
 }
 
@@ -1050,17 +973,17 @@ pub fn decode_spawn_watch_result(payload: &[u8]) -> Result<u32, ProtocolError> {
     ))
 }
 
-/// Decoded exec/spawn_watch fields.
-pub struct DecodedExec<'a> {
+/// Decoded command fields shared by spawn_watch payloads.
+pub struct DecodedCommandFields<'a> {
     pub timeout_ms: u32,
     pub command: &'a str,
     pub env: Vec<(&'a str, &'a str)>,
     pub sudo: bool,
 }
 
-/// Decoded spawn_watch fields: exec fields + stdout streaming options.
+/// Decoded spawn_watch fields: command fields + stdout streaming options.
 pub struct DecodedSpawnWatch<'a> {
-    pub exec: DecodedExec<'a>,
+    pub fields: DecodedCommandFields<'a>,
     /// Whether vsock-guest should stream stdout chunks to the host.
     pub stream_stdout: bool,
     /// Optional guest-side file path where vsock-guest also tees stdout.
@@ -1076,7 +999,7 @@ pub fn decode_process_exit(payload: &[u8]) -> Result<ProcessExit<'_>, ProtocolEr
         read_u32_at(payload, 0).ok_or(ProtocolError::InvalidPayload("process_exit too short"))?;
     let exit_code =
         read_i32_at(payload, 4).ok_or(ProtocolError::InvalidPayload("process_exit too short"))?;
-    let (stdout, stderr) = decode_output_pair_at(payload, 8, OutputPairContext::ProcessExit)?;
+    let (stdout, stderr) = decode_output_pair_at(payload, 8)?;
     Ok((pid, exit_code, stdout, stderr))
 }
 
@@ -1459,11 +1382,11 @@ mod tests {
 
     #[test]
     fn encode_decode_roundtrip_with_payload() {
-        let data = encode(MSG_EXEC, 42, b"hello world").unwrap();
+        let data = encode(MSG_PING, 42, b"hello world").unwrap();
         let mut dec = Decoder::new();
         let msgs = dec.decode(&data).unwrap();
         assert_eq!(msgs.len(), 1);
-        assert_eq!(msgs[0].msg_type, MSG_EXEC);
+        assert_eq!(msgs[0].msg_type, MSG_PING);
         assert_eq!(msgs[0].seq, 42);
         assert_eq!(msgs[0].payload, b"hello world");
     }
@@ -1514,55 +1437,6 @@ mod tests {
         let mut dec = Decoder::new();
         let err = dec.decode(&bad).unwrap_err();
         assert!(matches!(err, ProtocolError::MessageTooSmall(2)));
-    }
-
-    #[test]
-    fn exec_payload_roundtrip() {
-        let payload = encode_exec(5000, "echo hello", &[], false);
-        let d = decode_exec(&payload).unwrap();
-        assert_eq!(d.timeout_ms, 5000);
-        assert_eq!(d.command, "echo hello");
-        assert!(d.env.is_empty());
-        assert!(!d.sudo);
-    }
-
-    #[test]
-    fn exec_payload_roundtrip_with_sudo() {
-        let payload = encode_exec(5000, "date -s @123", &[], true);
-        let d = decode_exec(&payload).unwrap();
-        assert_eq!(d.timeout_ms, 5000);
-        assert_eq!(d.command, "date -s @123");
-        assert!(d.env.is_empty());
-        assert!(d.sudo);
-    }
-
-    #[test]
-    fn exec_payload_roundtrip_with_env() {
-        let env_vars = [("PATH", "/usr/bin"), ("HOME", "/home/user")];
-        let payload = encode_exec(3000, "ls", &env_vars, false);
-        let d = decode_exec(&payload).unwrap();
-        assert_eq!(d.timeout_ms, 3000);
-        assert_eq!(d.command, "ls");
-        assert_eq!(d.env, vec![("PATH", "/usr/bin"), ("HOME", "/home/user")]);
-        assert!(!d.sudo);
-    }
-
-    #[test]
-    fn exec_result_payload_roundtrip() {
-        let payload = encode_exec_result(0, b"out", b"err");
-        let (code, stdout, stderr) = decode_exec_result(&payload).unwrap();
-        assert_eq!(code, 0);
-        assert_eq!(stdout, b"out");
-        assert_eq!(stderr, b"err");
-    }
-
-    #[test]
-    fn exec_result_empty_output() {
-        let payload = encode_exec_result(1, &[], &[]);
-        let (code, stdout, stderr) = decode_exec_result(&payload).unwrap();
-        assert_eq!(code, 1);
-        assert!(stdout.is_empty());
-        assert!(stderr.is_empty());
     }
 
     #[test]
@@ -1650,10 +1524,10 @@ mod tests {
         )
         .unwrap();
         let d = decode_spawn_watch(&payload).unwrap();
-        assert_eq!(d.exec.timeout_ms, 5000);
-        assert_eq!(d.exec.command, "echo hello");
-        assert_eq!(d.exec.env, vec![("FOO", "bar")]);
-        assert!(!d.exec.sudo);
+        assert_eq!(d.fields.timeout_ms, 5000);
+        assert_eq!(d.fields.command, "echo hello");
+        assert_eq!(d.fields.env, vec![("FOO", "bar")]);
+        assert!(!d.fields.sudo);
         assert!(d.stream_stdout);
         assert_eq!(d.stdout_log_path.unwrap(), "/tmp/vm0-system-123.log");
     }
@@ -1662,10 +1536,10 @@ mod tests {
     fn spawn_watch_payload_roundtrip_stream_only() {
         let payload = encode_spawn_watch(3000, "ls", &[], true, true, None).unwrap();
         let d = decode_spawn_watch(&payload).unwrap();
-        assert_eq!(d.exec.timeout_ms, 3000);
-        assert_eq!(d.exec.command, "ls");
-        assert!(d.exec.env.is_empty());
-        assert!(d.exec.sudo);
+        assert_eq!(d.fields.timeout_ms, 3000);
+        assert_eq!(d.fields.command, "ls");
+        assert!(d.fields.env.is_empty());
+        assert!(d.fields.sudo);
         assert!(d.stream_stdout);
         assert!(d.stdout_log_path.is_none());
     }
@@ -1674,7 +1548,7 @@ mod tests {
     fn spawn_watch_payload_roundtrip_buffered() {
         let payload = encode_spawn_watch(1000, "cmd", &[], false, false, None).unwrap();
         let d = decode_spawn_watch(&payload).unwrap();
-        assert_eq!(d.exec.command, "cmd");
+        assert_eq!(d.fields.command, "cmd");
         assert!(!d.stream_stdout);
         assert!(d.stdout_log_path.is_none());
     }
@@ -2737,56 +2611,6 @@ mod tests {
     }
 
     #[test]
-    fn decode_exec_too_short() {
-        assert!(decode_exec(&[0; 4]).is_err());
-    }
-
-    #[test]
-    fn decode_exec_rejects_oversized_env_count() {
-        // Valid exec header (empty cmd, no env) plus an env_count field claiming
-        // u32::MAX pairs but no actual pair bytes. Must return Err without
-        // attempting to allocate a vector sized by env_count.
-        let mut p = encode_exec(1000, "", &[], false);
-        p.extend_from_slice(&u32::MAX.to_be_bytes());
-        assert!(matches!(
-            decode_exec(&p),
-            Err(ProtocolError::InvalidPayload(_))
-        ));
-    }
-
-    #[test]
-    fn decode_exec_result_too_short() {
-        assert!(decode_exec_result(&[0; 8]).is_err());
-    }
-
-    #[test]
-    fn decode_exec_result_rejects_truncated_stdout() {
-        let mut payload = 0_i32.to_be_bytes().to_vec();
-        payload.extend_from_slice(&3_u32.to_be_bytes());
-        payload.extend_from_slice(b"ab");
-
-        let err = decode_exec_result(&payload).unwrap_err();
-        assert!(matches!(
-            err,
-            ProtocolError::InvalidPayload("exec_result stdout truncated")
-        ));
-    }
-
-    #[test]
-    fn decode_exec_result_rejects_truncated_stderr() {
-        let mut payload = 0_i32.to_be_bytes().to_vec();
-        payload.extend_from_slice(&0_u32.to_be_bytes());
-        payload.extend_from_slice(&3_u32.to_be_bytes());
-        payload.extend_from_slice(b"xy");
-
-        let err = decode_exec_result(&payload).unwrap_err();
-        assert!(matches!(
-            err,
-            ProtocolError::InvalidPayload("exec_result stderr truncated")
-        ));
-    }
-
-    #[test]
     fn decode_process_exit_rejects_truncated_stdout() {
         let mut payload = 123_u32.to_be_bytes().to_vec();
         payload.extend_from_slice(&1_i32.to_be_bytes());
@@ -2816,14 +2640,7 @@ mod tests {
     }
 
     #[test]
-    fn decode_output_pair_messages_allow_trailing_bytes() {
-        let mut exec_result = encode_exec_result(0, b"out", b"err");
-        exec_result.extend_from_slice(b"trailing");
-        let (code, stdout, stderr) = decode_exec_result(&exec_result).unwrap();
-        assert_eq!(code, 0);
-        assert_eq!(stdout, b"out");
-        assert_eq!(stderr, b"err");
-
+    fn decode_process_exit_allows_trailing_bytes() {
         let mut process_exit = encode_process_exit(123, 1, b"out", b"err");
         process_exit.extend_from_slice(b"trailing");
         let (pid, code, stdout, stderr) = decode_process_exit(&process_exit).unwrap();
@@ -2836,24 +2653,6 @@ mod tests {
     #[test]
     fn decode_write_file_too_short() {
         assert!(decode_write_file(&[0; 3]).is_err());
-    }
-
-    #[test]
-    fn full_message_exec_roundtrip() {
-        let payload = encode_exec(10000, "ls -la", &[], false);
-        let msg = encode(MSG_EXEC, 5, &payload).unwrap();
-
-        let mut dec = Decoder::new();
-        let msgs = dec.decode(&msg).unwrap();
-        assert_eq!(msgs.len(), 1);
-        assert_eq!(msgs[0].msg_type, MSG_EXEC);
-        assert_eq!(msgs[0].seq, 5);
-
-        let d = decode_exec(&msgs[0].payload).unwrap();
-        assert_eq!(d.timeout_ms, 10000);
-        assert_eq!(d.command, "ls -la");
-        assert!(d.env.is_empty());
-        assert!(!d.sudo);
     }
 
     #[test]

--- a/crates/vsock-proto/src/lib.rs
+++ b/crates/vsock-proto/src/lib.rs
@@ -747,7 +747,10 @@ pub fn encode_error(message: &str) -> Vec<u8> {
 // ---------------------------------------------------------------------------
 
 struct DecodedCommandFieldsInner<'a> {
-    fields: DecodedCommandFields<'a>,
+    timeout_ms: u32,
+    command: &'a str,
+    env: Vec<(&'a str, &'a str)>,
+    sudo: bool,
     offset: usize,
     raw_flags: u8,
 }
@@ -757,17 +760,14 @@ struct DecodedCommandFieldsInner<'a> {
 /// The env section is optional: if the payload ends right after the command, an
 /// empty vec is returned. `encode_spawn_watch` always writes the env section so
 /// the optional log path remains unambiguous for new payloads.
-fn decode_command_fields(
-    payload: &[u8],
-    sudo_flag: u8,
-) -> Result<DecodedCommandFieldsInner<'_>, ProtocolError> {
+fn decode_command_fields(payload: &[u8]) -> Result<DecodedCommandFieldsInner<'_>, ProtocolError> {
     let timeout_ms = read_u32_at(payload, 0).ok_or(ProtocolError::InvalidPayload(
         "command fields payload too short",
     ))?;
     let flags = read_u8_at(payload, 4).ok_or(ProtocolError::InvalidPayload(
         "command fields payload too short",
     ))?;
-    let sudo = (flags & sudo_flag) != 0;
+    let sudo = (flags & SPAWN_WATCH_FLAG_SUDO) != 0;
     let cmd_len = read_u32_at(payload, 5).ok_or(ProtocolError::InvalidPayload(
         "command fields payload too short",
     ))? as usize;
@@ -779,12 +779,10 @@ fn decode_command_fields(
     let env_start = 9 + cmd_len;
     if env_start >= payload.len() {
         return Ok(DecodedCommandFieldsInner {
-            fields: DecodedCommandFields {
-                timeout_ms,
-                command,
-                env: Vec::new(),
-                sudo,
-            },
+            timeout_ms,
+            command,
+            env: Vec::new(),
+            sudo,
             offset: env_start,
             raw_flags: flags,
         });
@@ -823,12 +821,10 @@ fn decode_command_fields(
     }
 
     Ok(DecodedCommandFieldsInner {
-        fields: DecodedCommandFields {
-            timeout_ms,
-            command,
-            env,
-            sudo,
-        },
+        timeout_ms,
+        command,
+        env,
+        sudo,
         offset,
         raw_flags: flags,
     })
@@ -841,10 +837,13 @@ fn decode_command_fields(
 /// fields, `stdout_log_path` is `None`.
 pub fn decode_spawn_watch(payload: &[u8]) -> Result<DecodedSpawnWatch<'_>, ProtocolError> {
     let DecodedCommandFieldsInner {
-        fields,
+        timeout_ms,
+        command,
+        env,
+        sudo,
         offset,
         raw_flags,
-    } = decode_command_fields(payload, SPAWN_WATCH_FLAG_SUDO)?;
+    } = decode_command_fields(payload)?;
     let stream_flag = (raw_flags & SPAWN_WATCH_FLAG_STREAM_STDOUT) != 0;
     let stdout_log_path = if offset == payload.len() {
         None
@@ -877,7 +876,10 @@ pub fn decode_spawn_watch(payload: &[u8]) -> Result<DecodedSpawnWatch<'_>, Proto
         ));
     }
     Ok(DecodedSpawnWatch {
-        fields,
+        timeout_ms,
+        command,
+        env,
+        sudo,
         stream_stdout: stream_flag,
         stdout_log_path,
     })
@@ -973,17 +975,12 @@ pub fn decode_spawn_watch_result(payload: &[u8]) -> Result<u32, ProtocolError> {
     ))
 }
 
-/// Decoded command fields shared by spawn_watch payloads.
-pub struct DecodedCommandFields<'a> {
+/// Decoded spawn_watch fields.
+pub struct DecodedSpawnWatch<'a> {
     pub timeout_ms: u32,
     pub command: &'a str,
     pub env: Vec<(&'a str, &'a str)>,
     pub sudo: bool,
-}
-
-/// Decoded spawn_watch fields: command fields + stdout streaming options.
-pub struct DecodedSpawnWatch<'a> {
-    pub fields: DecodedCommandFields<'a>,
     /// Whether vsock-guest should stream stdout chunks to the host.
     pub stream_stdout: bool,
     /// Optional guest-side file path where vsock-guest also tees stdout.
@@ -1524,10 +1521,10 @@ mod tests {
         )
         .unwrap();
         let d = decode_spawn_watch(&payload).unwrap();
-        assert_eq!(d.fields.timeout_ms, 5000);
-        assert_eq!(d.fields.command, "echo hello");
-        assert_eq!(d.fields.env, vec![("FOO", "bar")]);
-        assert!(!d.fields.sudo);
+        assert_eq!(d.timeout_ms, 5000);
+        assert_eq!(d.command, "echo hello");
+        assert_eq!(d.env, vec![("FOO", "bar")]);
+        assert!(!d.sudo);
         assert!(d.stream_stdout);
         assert_eq!(d.stdout_log_path.unwrap(), "/tmp/vm0-system-123.log");
     }
@@ -1536,10 +1533,10 @@ mod tests {
     fn spawn_watch_payload_roundtrip_stream_only() {
         let payload = encode_spawn_watch(3000, "ls", &[], true, true, None).unwrap();
         let d = decode_spawn_watch(&payload).unwrap();
-        assert_eq!(d.fields.timeout_ms, 3000);
-        assert_eq!(d.fields.command, "ls");
-        assert!(d.fields.env.is_empty());
-        assert!(d.fields.sudo);
+        assert_eq!(d.timeout_ms, 3000);
+        assert_eq!(d.command, "ls");
+        assert!(d.env.is_empty());
+        assert!(d.sudo);
         assert!(d.stream_stdout);
         assert!(d.stdout_log_path.is_none());
     }
@@ -1548,7 +1545,7 @@ mod tests {
     fn spawn_watch_payload_roundtrip_buffered() {
         let payload = encode_spawn_watch(1000, "cmd", &[], false, false, None).unwrap();
         let d = decode_spawn_watch(&payload).unwrap();
-        assert_eq!(d.fields.command, "cmd");
+        assert_eq!(d.command, "cmd");
         assert!(!d.stream_stdout);
         assert!(d.stdout_log_path.is_none());
     }

--- a/crates/vsock-test/tests/integration.rs
+++ b/crates/vsock-test/tests/integration.rs
@@ -849,8 +849,8 @@ async fn test_spawn_watch_interleaved_output() {
 
 /// Core regression test: a slow exec must not block a subsequent fast exec.
 ///
-/// Before the fix, MSG_EXEC blocked the guest event loop synchronously, so a
-/// `sleep 5` would prevent any other exec from being processed until it finished.
+/// Before the command operation path moved work off the guest event loop, a
+/// `sleep 5` could prevent any other exec from being processed until it finished.
 #[tokio::test]
 async fn test_concurrent_exec_not_blocked() {
     let h = Harness::new().await;


### PR DESCRIPTION
## Summary
- retire legacy vsock message types 0x03/0x04 and remove public MSG_EXEC/MSG_EXEC_RESULT helpers
- remove guest-side legacy exec worker path and keep command operation / spawn_watch handling
- migrate remaining regression coverage to command operation and add a retired-message safety test

Closes #13056
Refs #12657

## Tests
- cargo fmt --manifest-path crates/Cargo.toml --all
- cargo clippy --manifest-path crates/Cargo.toml -p vsock-proto -p vsock-guest -p vsock-host -p vsock-test --all-targets -- -D warnings
- cargo test --manifest-path crates/Cargo.toml -p vsock-proto -p vsock-guest -p vsock-host -p vsock-test
- rg -n "MSG_EXEC|MSG_EXEC_RESULT|encode_exec\\(|decode_exec\\(|decode_exec_result\\(|handle_exec\\(" --glob "!**/CHANGELOG.md" --glob "!target/**" --glob "!node_modules/**"
- git diff --check