### PR TITLE
fix: keep resumed telegram context window

### DIFF
--- a/turbo/apps/web/src/lib/zero/agentphone/__tests__/shared.test.ts
+++ b/turbo/apps/web/src/lib/zero/agentphone/__tests__/shared.test.ts
@@ -53,6 +53,89 @@ describe("AgentPhone file context", () => {
     );
   });
 
+  it("includes resumed conversation context regardless of lastProcessedMessageId", async () => {
+    const phoneHandle = uniquePhone();
+    const userLink = await insertTestAgentPhoneUserLink({
+      phoneHandle,
+      vm0UserId: uniqueId("user"),
+      orgId: uniqueId("org"),
+    });
+
+    await insertTestAgentPhoneMessage({
+      agentphoneMessageId: "apmsg-old",
+      agentphoneUserLinkId: userLink.id,
+      phoneHandle,
+      fromNumber: phoneHandle,
+      toNumber: "+19039853128",
+      direction: "inbound",
+      body: "Old AgentPhone message",
+      createdAt: new Date(Date.now() - 60_000),
+    });
+    await insertTestAgentPhoneMessage({
+      agentphoneMessageId: "apmsg-new",
+      agentphoneUserLinkId: userLink.id,
+      phoneHandle,
+      fromNumber: phoneHandle,
+      toNumber: "+19039853128",
+      direction: "inbound",
+      body: "New AgentPhone message",
+      createdAt: new Date(Date.now() - 30_000),
+    });
+
+    const contextResult = await fetchAgentPhoneContext({
+      userLinkId: userLink.id,
+      phoneHandle,
+      lastProcessedMessageId: "apmsg-old",
+    });
+
+    expect(contextResult.executionContext).toContain("Old AgentPhone message");
+    expect(contextResult.executionContext).toContain("New AgentPhone message");
+  });
+
+  it("excludes current message while keeping resumed conversation history", async () => {
+    const phoneHandle = uniquePhone();
+    const userLink = await insertTestAgentPhoneUserLink({
+      phoneHandle,
+      vm0UserId: uniqueId("user"),
+      orgId: uniqueId("org"),
+    });
+
+    await insertTestAgentPhoneMessage({
+      agentphoneMessageId: "apmsg-history",
+      agentphoneUserLinkId: userLink.id,
+      phoneHandle,
+      fromNumber: phoneHandle,
+      toNumber: "+19039853128",
+      direction: "inbound",
+      body: "Earlier AgentPhone context",
+      createdAt: new Date(Date.now() - 60_000),
+    });
+    await insertTestAgentPhoneMessage({
+      agentphoneMessageId: "apmsg-current",
+      agentphoneUserLinkId: userLink.id,
+      phoneHandle,
+      fromNumber: phoneHandle,
+      toNumber: "+19039853128",
+      direction: "inbound",
+      body: "Current AgentPhone prompt",
+      createdAt: new Date(Date.now() - 30_000),
+    });
+
+    const contextResult = await fetchAgentPhoneContext({
+      userLinkId: userLink.id,
+      phoneHandle,
+      lastProcessedMessageId: "apmsg-history",
+      currentMessageId: "apmsg-current",
+    });
+
+    expect(contextResult.executionContext).toContain(
+      "Earlier AgentPhone context",
+    );
+    expect(contextResult.executionContext).not.toContain(
+      "Current AgentPhone prompt",
+    );
+  });
+
   it("enriches the current prompt with a file reference", () => {
     const result = enrichAgentPhonePrompt(
       "please inspect this",

--- a/turbo/apps/web/src/lib/zero/agentphone/shared.ts
+++ b/turbo/apps/web/src/lib/zero/agentphone/shared.ts
@@ -442,22 +442,12 @@ export async function fetchAgentPhoneContext(params: {
     );
   });
 
-  const lastProcessedIndex = params.lastProcessedMessageId
-    ? chronological.findIndex((message) => {
-        return message.messageId === params.lastProcessedMessageId;
-      })
-    : -1;
-  const executionMessages =
-    lastProcessedIndex >= 0
-      ? chronological.slice(lastProcessedIndex + 1)
-      : chronological;
-
-  if (executionMessages.length === 0) {
+  if (chronological.length === 0) {
     return { executionContext: "" };
   }
 
-  const total = executionMessages.length;
-  const formatted = executionMessages.map((message, index) => {
+  const total = chronological.length;
+  const formatted = chronological.map((message, index) => {
     const sender = message.isBot ? "BOT" : phoneHandle;
     const parts = [
       "---",

--- a/turbo/apps/web/src/lib/zero/telegram/__tests__/context.test.ts
+++ b/turbo/apps/web/src/lib/zero/telegram/__tests__/context.test.ts
@@ -57,7 +57,7 @@ describe("fetchTelegramContext", () => {
     expect(firstIdx).toBeLessThan(secondIdx);
   });
 
-  it("should filter execution context by lastProcessedMessageId", async () => {
+  it("should include resumed chat context regardless of lastProcessedMessageId", async () => {
     const chatId = uniqueId("chat");
 
     await insertTelegramMessage({
@@ -81,8 +81,7 @@ describe("fetchTelegramContext", () => {
 
     const result = await fetchTelegramContext(installationId, chatId, "10");
 
-    // Execution context only includes messages after ID 10
-    expect(result.executionContext).not.toContain("Old message");
+    expect(result.executionContext).toContain("Old message");
     expect(result.executionContext).toContain("New message");
   });
 
@@ -105,7 +104,7 @@ describe("fetchTelegramContext", () => {
     );
   });
 
-  it("should return empty execution context when no new messages after lastProcessedMessageId", async () => {
+  it("should keep prior messages when resuming after the latest message", async () => {
     const chatId = uniqueId("chat");
 
     await insertTelegramMessage({
@@ -120,7 +119,41 @@ describe("fetchTelegramContext", () => {
 
     const result = await fetchTelegramContext(installationId, chatId, "5");
 
-    expect(result.executionContext).toBe("");
+    expect(result.executionContext).toContain("Only message");
+  });
+
+  it("should exclude current message while keeping resumed chat history", async () => {
+    const chatId = uniqueId("chat");
+
+    await insertTelegramMessage({
+      installationId,
+      chatId,
+      messageId: "10",
+      fromUserId: "111",
+      fromUsername: "alice",
+      text: "Earlier resumed context",
+      createdAt: new Date(Date.now() - 60_000),
+    });
+    await insertTelegramMessage({
+      installationId,
+      chatId,
+      messageId: "20",
+      fromUserId: "222",
+      fromUsername: "bob",
+      text: "Current prompt message",
+      createdAt: new Date(Date.now() - 30_000),
+    });
+
+    const result = await fetchTelegramContext(
+      installationId,
+      chatId,
+      "10",
+      undefined,
+      "20",
+    );
+
+    expect(result.executionContext).toContain("Earlier resumed context");
+    expect(result.executionContext).not.toContain("Current prompt message");
   });
 
   it("should only return messages for the specified chat", async () => {

--- a/turbo/apps/web/src/lib/zero/telegram/context.ts
+++ b/turbo/apps/web/src/lib/zero/telegram/context.ts
@@ -75,17 +75,17 @@ function normalizeTelegramContextScope(scope: TelegramMessageScope):
 /**
  * Fetch recent Telegram messages for a chat and build execution context.
  *
- * @param installationId - Telegram installation ID
+ * @param scope - Telegram installation ID or official bot scope
  * @param chatId - Telegram chat ID
- * @param lastProcessedMessageId - Only include messages after this ID for execution context
+ * @param _lastProcessedMessageId - Preserved for call-site compatibility; context uses the full recent window
  * @param client - Telegram client (needed to download images for execution context)
  * @param currentMessageId - The message being processed; excluded from context to avoid duplication with prompt
- * @returns executionContext (only new messages, with file references)
+ * @returns executionContext (recent messages, with file references)
  */
 export async function fetchTelegramContext(
   scope: TelegramMessageScope,
   chatId: string,
-  lastProcessedMessageId?: string,
+  _lastProcessedMessageId?: string,
   _client?: TelegramClient,
   currentMessageId?: string,
 ): Promise<{ executionContext: string }> {
@@ -131,17 +131,10 @@ export async function fetchTelegramContext(
     count: chronological.length,
   });
 
-  // For execution context, only include messages after lastProcessedMessageId
-  const executionMessages = lastProcessedMessageId
-    ? chronological.filter((m) => {
-        return Number(m.messageId) > Number(lastProcessedMessageId);
-      })
-    : chronological;
-
   // Execution context: include image references for on-demand CLI download.
   const executionContext =
-    executionMessages.length > 0
-      ? formatContextForAgent(executionMessages, normalizedScope.botId)
+    chronological.length > 0
+      ? formatContextForAgent(chronological, normalizedScope.botId)
       : "";
 
   return { executionContext };


### PR DESCRIPTION
## Summary
- Stop filtering Telegram execution context by lastProcessedMessageId so resumed runs receive the full recent chat window.
- Stop filtering AgentPhone execution context by lastProcessedMessageId so resumed runs receive the full recent text-message window.
- Keep current inbound message de-duplication intact for both integrations.
- Update Telegram and AgentPhone context regression tests for resumed-session behavior.

## Verification
- PASS: pnpm prettier --write apps/web/src/lib/zero/agentphone/shared.ts apps/web/src/lib/zero/agentphone/__tests__/shared.test.ts apps/web/src/lib/zero/telegram/context.ts apps/web/src/lib/zero/telegram/__tests__/context.test.ts
- PASS: git diff --check
- PASS: pnpm -F web lint
- FAIL: pnpm vitest --run apps/web/src/lib/zero/telegram/__tests__/context.test.ts apps/web/src/lib/zero/agentphone/__tests__/shared.test.ts (local test DB schema is behind: agentphone_user_links table missing, telegram_installations.owner_user_id missing)
- FAIL: pre-commit hook check-types (unrelated existing @vm0/app platform type errors)

Fixes #13021