### PR TITLE
refactor(guest-download): type instruction filenames

### DIFF
--- a/crates/guest-download/src/instructions.rs
+++ b/crates/guest-download/src/instructions.rs
@@ -18,31 +18,55 @@ impl InstructionNormalization {
     }
 }
 
-pub(crate) fn normalize_instruction_files(entries: &[InstructionNormalization]) {
-    const CANDIDATES: [&str; 2] = ["CLAUDE.md", "AGENTS.md"];
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum InstructionFilename {
+    Claude,
+    Agents,
+}
 
+impl InstructionFilename {
+    const ALL: [Self; 2] = [Self::Claude, Self::Agents];
+
+    fn parse(filename: &str) -> Option<Self> {
+        match filename {
+            "CLAUDE.md" => Some(Self::Claude),
+            "AGENTS.md" => Some(Self::Agents),
+            _ => None,
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Claude => "CLAUDE.md",
+            Self::Agents => "AGENTS.md",
+        }
+    }
+}
+
+pub(crate) fn normalize_instruction_files(entries: &[InstructionNormalization]) {
     for entry in entries {
-        let target_filename = entry.target_filename.as_str();
-        if !valid_instruction_filename(target_filename) {
+        let raw_target_filename = entry.target_filename.as_str();
+        let Some(target_filename) = InstructionFilename::parse(raw_target_filename) else {
             log_warn!(
                 LOG_TAG,
                 "Skipping invalid instructions target filename: {}",
-                target_filename
+                raw_target_filename
             );
             continue;
-        }
+        };
 
         let mount_path = Path::new(&entry.mount_path);
-        let target_path = mount_path.join(target_filename);
+        let target_path = mount_path.join(target_filename.as_str());
         if target_path.exists() {
             remove_alternate_instruction_files(mount_path, target_filename);
             continue;
         }
 
-        let source = CANDIDATES
+        let source = InstructionFilename::ALL
             .iter()
-            .filter(|candidate| **candidate != target_filename)
-            .map(|candidate| mount_path.join(candidate))
+            .copied()
+            .filter(|candidate| *candidate != target_filename)
+            .map(|candidate| mount_path.join(candidate.as_str()))
             .find(|path| path.is_file());
 
         let Some(source_path) = source else {
@@ -76,17 +100,13 @@ pub(crate) fn normalize_instruction_files(entries: &[InstructionNormalization]) 
     }
 }
 
-fn valid_instruction_filename(filename: &str) -> bool {
-    matches!(filename, "CLAUDE.md" | "AGENTS.md")
-}
-
-fn remove_alternate_instruction_files(mount_path: &Path, target_filename: &str) {
-    for candidate in ["CLAUDE.md", "AGENTS.md"] {
+fn remove_alternate_instruction_files(mount_path: &Path, target_filename: InstructionFilename) {
+    for candidate in InstructionFilename::ALL {
         if candidate == target_filename {
             continue;
         }
 
-        let path = mount_path.join(candidate);
+        let path = mount_path.join(candidate.as_str());
         if !path.exists() {
             continue;
         }
@@ -136,6 +156,26 @@ mod tests {
     }
 
     #[test]
+    fn normalize_instruction_files_copies_agents_to_claude_for_claude_target() {
+        disable_system_log();
+        let dir = tempfile::tempdir().unwrap();
+        let mount = dir.path().join(".claude");
+        fs::create_dir_all(&mount).unwrap();
+        fs::write(mount.join("AGENTS.md"), "runtime instructions").unwrap();
+
+        normalize_instruction_files(&[InstructionNormalization::new(
+            mount.to_string_lossy().into(),
+            "CLAUDE.md".into(),
+        )]);
+
+        assert_eq!(
+            fs::read_to_string(mount.join("CLAUDE.md")).unwrap(),
+            "runtime instructions"
+        );
+        assert!(!mount.join("AGENTS.md").exists());
+    }
+
+    #[test]
     fn normalize_instruction_files_leaves_existing_target_unchanged() {
         disable_system_log();
         let dir = tempfile::tempdir().unwrap();
@@ -154,5 +194,30 @@ mod tests {
             "canonical"
         );
         assert!(!mount.join("CLAUDE.md").exists());
+    }
+
+    #[test]
+    fn normalize_instruction_files_skips_invalid_target_without_deleting_files() {
+        disable_system_log();
+        let dir = tempfile::tempdir().unwrap();
+        let mount = dir.path().join(".codex");
+        fs::create_dir_all(&mount).unwrap();
+        fs::write(mount.join("CLAUDE.md"), "claude").unwrap();
+        fs::write(mount.join("AGENTS.md"), "agents").unwrap();
+
+        normalize_instruction_files(&[InstructionNormalization::new(
+            mount.to_string_lossy().into(),
+            "../outside.md".into(),
+        )]);
+
+        assert_eq!(
+            fs::read_to_string(mount.join("CLAUDE.md")).unwrap(),
+            "claude"
+        );
+        assert_eq!(
+            fs::read_to_string(mount.join("AGENTS.md")).unwrap(),
+            "agents"
+        );
+        assert!(!dir.path().join("outside.md").exists());
     }
 }


### PR DESCRIPTION
## Summary

- Replace duplicated guest-download instruction filename string rules with a private typed allowlist.
- Parse manifest-provided instruction targets before path construction and cleanup decisions.
- Add coverage for reverse normalization and invalid target safety.

Closes #13063

## Tests

- `cargo test --manifest-path crates/Cargo.toml -p guest-download instructions`
- `cargo test --manifest-path crates/Cargo.toml -p guest-download`

Pre-commit also ran:

- `cargo-fmt`
- `cargo-clippy`
- `cargo-doc`
