### PR TITLE
refactor(api): migrate internal agent callback

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -29,6 +29,7 @@ import { generateImageRoutes } from "./routes/generate-image";
 import { apiHealth$ } from "./routes/health";
 import { healthAuthProbeRoutes } from "./routes/health-auth-probe";
 import { githubOauthRoutes } from "./routes/github-oauth";
+import { internalCallbacksAgentRoutes } from "./routes/internal-callbacks-agent";
 import { internalEventConsumerAxiomRoutes } from "./routes/internal-event-consumers-axiom";
 import { internalEventConsumerChatAssistantRoutes } from "./routes/internal-event-consumers-chat-assistant";
 import { internalEventConsumerTelegramTypingRoutes } from "./routes/internal-event-consumers-telegram-typing";
@@ -146,6 +147,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...cliAuthTestRoutes,
   ...healthAuthProbeRoutes,
   ...githubOauthRoutes,
+  ...internalCallbacksAgentRoutes,
   ...internalEventConsumerAxiomRoutes,
   ...internalEventConsumerChatAssistantRoutes,
   ...internalEventConsumerTelegramTypingRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-agent.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-agent.test.ts
@@ -1,0 +1,231 @@
+import { randomUUID } from "node:crypto";
+
+import { HttpResponse, http } from "msw";
+import { createStore } from "ccstate";
+import { describe, expect, it } from "vitest";
+import { zeroRuns } from "@vm0/db/schema/zero-run";
+import { eq } from "drizzle-orm";
+
+import { createApp } from "../../../app-factory";
+import { testContext } from "../../../__tests__/test-helpers";
+import { server } from "../../../mocks/server";
+import { computeHmacSignature } from "../../../lib/event-consumer/hmac";
+import { now } from "../../../lib/time";
+import { mockOptionalEnv } from "../../../lib/env";
+import { writeDb$ } from "../../external/db";
+import { seedAgentRunCallback$ } from "./helpers/agent-run-callback";
+import {
+  deleteUsageInsightFixture$,
+  seedCompose$,
+  seedRun$,
+  seedUsageInsightFixture$,
+  type UsageInsightFixture,
+} from "./helpers/zero-usage-insight";
+import { createFixtureTracker } from "./helpers/zero-route-test";
+
+const context = testContext();
+const store = createStore();
+
+const PATH = "/api/internal/callbacks/agent";
+const TEST_CALLBACK_SECRET = "test-callback-secret";
+const OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions";
+
+interface AgentCallbackFixture extends UsageInsightFixture {
+  readonly composeId: string;
+}
+
+async function deleteFixture(fixture: AgentCallbackFixture): Promise<void> {
+  await store.set(deleteUsageInsightFixture$, fixture, context.signal);
+}
+
+async function seedFixture(): Promise<AgentCallbackFixture> {
+  const base = await store.set(
+    seedUsageInsightFixture$,
+    undefined,
+    context.signal,
+  );
+  const { composeId } = await store.set(
+    seedCompose$,
+    {
+      orgId: base.orgId,
+      userId: base.userId,
+      name: `agent-callback-${randomUUID().slice(0, 8)}`,
+    },
+    context.signal,
+  );
+  return { ...base, composeId };
+}
+
+async function seedAgentRun(fixture: AgentCallbackFixture): Promise<{
+  readonly runId: string;
+  readonly callbackId: string;
+}> {
+  const { runId } = await store.set(
+    seedRun$,
+    {
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      composeId: fixture.composeId,
+      prompt: "Delegate this task to the other agent",
+      triggerSource: "agent",
+    },
+    context.signal,
+  );
+  const { callbackId } = await store.set(
+    seedAgentRunCallback$,
+    {
+      runId,
+      url: `http://localhost${PATH}`,
+      payload: {},
+    },
+    context.signal,
+  );
+  return { runId, callbackId };
+}
+
+function signedHeaders(
+  rawBody: string,
+  secret = TEST_CALLBACK_SECRET,
+): Record<string, string> {
+  const timestamp = Math.floor(now() / 1000);
+  return {
+    "Content-Type": "application/json",
+    "X-VM0-Signature": computeHmacSignature(rawBody, secret, timestamp),
+    "X-VM0-Timestamp": String(timestamp),
+  };
+}
+
+function postCallback(body: Record<string, unknown>, secret?: string) {
+  const rawBody = JSON.stringify(body);
+  const app = createApp({ signal: context.signal });
+  return app.request(PATH, {
+    method: "POST",
+    headers: signedHeaders(rawBody, secret),
+    body: rawBody,
+  });
+}
+
+async function runSummary(runId: string): Promise<string | null> {
+  const db = store.set(writeDb$);
+  const [row] = await db
+    .select({ summary: zeroRuns.summary })
+    .from(zeroRuns)
+    .where(eq(zeroRuns.id, runId))
+    .limit(1);
+  return row?.summary ?? null;
+}
+
+describe("POST /api/internal/callbacks/agent", () => {
+  const track = createFixtureTracker<AgentCallbackFixture>((fixture) => {
+    return deleteFixture(fixture);
+  });
+
+  it("rejects requests with invalid signatures", async () => {
+    const fixture = await track(seedFixture());
+    const { runId, callbackId } = await seedAgentRun(fixture);
+
+    const response = await postCallback(
+      { callbackId, runId, status: "completed", payload: {} },
+      "wrong-secret",
+    );
+
+    expect(response.status).toBe(401);
+  });
+
+  it("returns 404 when no callback record exists", async () => {
+    const response = await postCallback({
+      runId: "00000000-0000-0000-0000-000000000000",
+      status: "completed",
+      payload: {},
+    });
+
+    expect(response.status).toBe(404);
+  });
+
+  it("returns success without mutating the run for progress callbacks", async () => {
+    const fixture = await track(seedFixture());
+    const { runId, callbackId } = await seedAgentRun(fixture);
+
+    const response = await postCallback({
+      callbackId,
+      runId,
+      status: "progress",
+      payload: {},
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toStrictEqual({ success: true });
+    await expect(runSummary(runId)).resolves.toBeNull();
+    expect(context.mocks.axiom.query).not.toHaveBeenCalled();
+  });
+
+  it("generates and persists a summary for completed callbacks", async () => {
+    const fixture = await track(seedFixture());
+    const { runId, callbackId } = await seedAgentRun(fixture);
+    context.mocks.axiom.query.mockResolvedValueOnce([
+      {
+        eventType: "result",
+        eventData: { result: "Task completed successfully." },
+      },
+    ]);
+    mockOptionalEnv("OPENROUTER_API_KEY", "test-openrouter-key");
+    server.use(
+      http.post(OPENROUTER_URL, () => {
+        return HttpResponse.json({
+          choices: [{ message: { content: "Agent delegated the task." } }],
+        });
+      }),
+    );
+
+    const response = await postCallback({
+      callbackId,
+      runId,
+      status: "completed",
+      payload: {},
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toStrictEqual({ success: true });
+    await expect(runSummary(runId)).resolves.toBe("Agent delegated the task.");
+  });
+
+  it("returns success without a summary when the lightweight model is unavailable", async () => {
+    const fixture = await track(seedFixture());
+    const { runId, callbackId } = await seedAgentRun(fixture);
+    context.mocks.axiom.query.mockResolvedValueOnce([
+      {
+        eventType: "result",
+        eventData: { result: "Task completed successfully." },
+      },
+    ]);
+
+    const response = await postCallback({
+      callbackId,
+      runId,
+      status: "completed",
+      payload: {},
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toStrictEqual({ success: true });
+    await expect(runSummary(runId)).resolves.toBeNull();
+  });
+
+  it("returns success without generating summaries for failed callbacks", async () => {
+    const fixture = await track(seedFixture());
+    const { runId, callbackId } = await seedAgentRun(fixture);
+
+    const response = await postCallback({
+      callbackId,
+      runId,
+      status: "failed",
+      error: "Agent run failed",
+      payload: {},
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toStrictEqual({ success: true });
+    await expect(runSummary(runId)).resolves.toBeNull();
+    expect(context.mocks.axiom.query).not.toHaveBeenCalled();
+  });
+});

--- a/turbo/apps/api/src/signals/routes/internal-callbacks-agent.ts
+++ b/turbo/apps/api/src/signals/routes/internal-callbacks-agent.ts
@@ -1,0 +1,63 @@
+import { command } from "ccstate";
+import { internalCallbacksAgentContract } from "@vm0/api-contracts/contracts/internal-callbacks-agent";
+import { agentRuns } from "@vm0/db/schema/agent-run";
+import { eq } from "drizzle-orm";
+
+import {
+  callbackPayload$,
+  callbackRoute,
+} from "../../lib/callback-route/callback-route";
+import type { RouteEntry } from "../route";
+import { db$ } from "../external/db";
+import { getRunOutputText } from "../services/run-output.service";
+import { saveRunSummary$ } from "../services/run-summary.service";
+
+const handleAgentCallback$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const callback = get(callbackPayload$);
+
+    if (callback.status !== "completed") {
+      return { status: 200 as const, body: { success: true as const } };
+    }
+
+    const db = get(db$);
+    const [run] = await db
+      .select({
+        prompt: agentRuns.prompt,
+        lastEventSequence: agentRuns.lastEventSequence,
+      })
+      .from(agentRuns)
+      .where(eq(agentRuns.id, callback.runId))
+      .limit(1);
+    signal.throwIfAborted();
+
+    if (run) {
+      const resultText = await getRunOutputText(callback.runId, {
+        knownLastEventSequence: run.lastEventSequence,
+        signal,
+      });
+      signal.throwIfAborted();
+
+      await set(
+        saveRunSummary$,
+        {
+          runId: callback.runId,
+          triggerSource: "agent",
+          prompt: run.prompt,
+          resultText: resultText ?? "",
+        },
+        signal,
+      );
+      signal.throwIfAborted();
+    }
+
+    return { status: 200 as const, body: { success: true as const } };
+  },
+);
+
+export const internalCallbacksAgentRoutes: readonly RouteEntry[] = [
+  {
+    route: internalCallbacksAgentContract.post,
+    handler: callbackRoute(handleAgentCallback$),
+  },
+];

--- a/turbo/apps/api/src/signals/services/run-output.service.ts
+++ b/turbo/apps/api/src/signals/services/run-output.service.ts
@@ -1,0 +1,182 @@
+import { delay } from "signal-timers";
+
+import { waitForRunEventWatermarkVisible } from "../../lib/agent-event-visibility";
+import { escapeAplString } from "../../lib/axiom-apl";
+import { getDatasetName, queryAxiomDirect } from "../external/axiom";
+
+interface RunOutput {
+  readonly result: string | null;
+  readonly error: string | null;
+}
+
+interface RunOutputQueryOptions {
+  readonly waitForOutput?: boolean;
+  readonly knownLastEventSequence?: number | null;
+  readonly outputRetryDelayMs?: number;
+  readonly signal?: AbortSignal;
+}
+
+type RunOutputOptionsInput = RunOutputQueryOptions | number | null | undefined;
+
+interface CodexItem {
+  readonly type?: string;
+  readonly text?: string;
+}
+
+interface RunOutputEvent {
+  readonly eventType?: string;
+  readonly eventData?: {
+    readonly result?: string;
+    readonly item?: CodexItem;
+  };
+}
+
+const AGENT_RUN_EVENTS_DATASET = "agent-run-events";
+const OUTPUT_EVENT_FILTER = `eventType == "result" or (eventType == "item.completed" and ['eventData.item.type'] == "agent_message")`;
+const OUTPUT_QUERY_ATTEMPTS = 4;
+const OUTPUT_QUERY_RETRY_MS = 500;
+const FRESH_AXIOM_QUERY_OPTIONS = { noCache: true } as const;
+const NEVER_ABORTED_SIGNAL = new AbortController().signal;
+
+function normalizeOptions(
+  input?: RunOutputOptionsInput,
+): RunOutputQueryOptions {
+  if (typeof input === "number" || input === null) {
+    return { knownLastEventSequence: input };
+  }
+  return input ?? {};
+}
+
+function waitForOutputRetry(
+  delayMs: number,
+  signal: AbortSignal | undefined,
+): Promise<void> {
+  return delay(delayMs, { signal: signal ?? NEVER_ABORTED_SIGNAL });
+}
+
+async function queryOutputEventsDesc(runId: string): Promise<RunOutputEvent[]> {
+  const dataset = getDatasetName(AGENT_RUN_EVENTS_DATASET);
+  const apl = `['${dataset}']
+| where runId == "${escapeAplString(runId)}"
+| where ${OUTPUT_EVENT_FILTER}
+| order by sequenceNumber desc
+| limit 1`;
+
+  return [
+    ...(await queryAxiomDirect<RunOutputEvent>(apl, FRESH_AXIOM_QUERY_OPTIONS)),
+  ];
+}
+
+async function queryLatestOutputEvent(
+  runId: string,
+  options: RunOutputQueryOptions = {},
+): Promise<RunOutputEvent | undefined> {
+  const attempts =
+    options.waitForOutput === false ||
+    typeof options.knownLastEventSequence === "number"
+      ? 1
+      : OUTPUT_QUERY_ATTEMPTS;
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    options.signal?.throwIfAborted();
+    const event = (await queryOutputEventsDesc(runId)).find(isOutputEvent);
+    if (event || attempt === attempts) {
+      return event;
+    }
+    await waitForOutputRetry(
+      options.outputRetryDelayMs ?? OUTPUT_QUERY_RETRY_MS,
+      options.signal,
+    );
+  }
+  return undefined;
+}
+
+function waitForVisibleOutput(
+  runId: string,
+  options: RunOutputQueryOptions,
+): Promise<number | undefined> {
+  if (options.waitForOutput === false) {
+    return Promise.resolve(undefined);
+  }
+  return waitForRunEventWatermarkVisible(
+    runId,
+    options.knownLastEventSequence ?? null,
+  );
+}
+
+async function extractRunOutput(
+  runId: string,
+  error?: string | null,
+  optionsInput?: RunOutputOptionsInput,
+): Promise<RunOutput> {
+  const options = normalizeOptions(optionsInput);
+  const resolvedLastEventSequence = await waitForVisibleOutput(runId, options);
+  const queryOptions =
+    options.knownLastEventSequence === undefined &&
+    typeof resolvedLastEventSequence === "number"
+      ? { ...options, knownLastEventSequence: resolvedLastEventSequence }
+      : options;
+
+  const event = await queryLatestOutputEvent(runId, queryOptions);
+
+  if (!event) {
+    return {
+      result: null,
+      error: error ?? null,
+    };
+  }
+
+  return buildRunOutput(event, error);
+}
+
+function extractCodexAgentMessageText(
+  item: CodexItem | undefined,
+): string | null {
+  if (
+    item?.type !== "agent_message" ||
+    typeof item.text !== "string" ||
+    item.text.length === 0
+  ) {
+    return null;
+  }
+  return item.text;
+}
+
+function isOutputEvent(event: RunOutputEvent): boolean {
+  if (event.eventType === "item.completed") {
+    return extractCodexAgentMessageText(event.eventData?.item) !== null;
+  }
+
+  return event.eventType === "result" || event.eventType === undefined;
+}
+
+function extractOutputText(event: RunOutputEvent): string | null {
+  const result = event.eventData?.result;
+  if (typeof result === "string") {
+    return result;
+  }
+
+  const codexText = extractCodexAgentMessageText(event.eventData?.item);
+  if (codexText !== null) {
+    return codexText;
+  }
+
+  return null;
+}
+
+function buildRunOutput(
+  event: RunOutputEvent,
+  error?: string | null,
+): RunOutput {
+  return {
+    result: extractOutputText(event),
+    error: error ?? null,
+  };
+}
+
+export async function getRunOutputText(
+  runId: string,
+  optionsInput?: RunOutputOptionsInput,
+): Promise<string | undefined> {
+  const output = await extractRunOutput(runId, undefined, optionsInput);
+  return output.result ?? undefined;
+}

--- a/turbo/apps/api/src/signals/services/run-summary.service.ts
+++ b/turbo/apps/api/src/signals/services/run-summary.service.ts
@@ -1,0 +1,159 @@
+import { command } from "ccstate";
+import { eq } from "drizzle-orm";
+import { zeroRuns } from "@vm0/db/schema/zero-run";
+
+import { logger } from "../../lib/log";
+import { optionalEnv } from "../../lib/env";
+import { writeDb$ } from "../external/db";
+import { safeAsync } from "../utils";
+
+const log = logger("run-summary");
+const OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions";
+const OPENROUTER_MODEL = "google/gemini-3.1-flash-lite-preview";
+
+interface ChatMessage {
+  readonly role: "system" | "user" | "assistant";
+  readonly content: string;
+}
+
+interface OpenRouterResponse {
+  readonly choices: readonly {
+    readonly message: {
+      readonly content: string;
+    };
+  }[];
+}
+
+async function generateText(
+  messages: readonly ChatMessage[],
+  maxTokens: number,
+): Promise<string | null> {
+  const apiKey = optionalEnv("OPENROUTER_API_KEY");
+  if (!apiKey) {
+    log.warn("OPENROUTER_API_KEY not configured, skipping text generation");
+    return null;
+  }
+
+  const response = await fetch(OPENROUTER_URL, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      model: OPENROUTER_MODEL,
+      messages,
+      max_tokens: maxTokens,
+      temperature: 0.3,
+    }),
+  });
+
+  if (!response.ok) {
+    const text = await response.text().catch(() => {
+      return "unknown error";
+    });
+    throw new Error(`OpenRouter request failed: ${response.status} ${text}`);
+  }
+
+  const data = (await response.json()) as OpenRouterResponse;
+  const content = data.choices[0]?.message.content.trim();
+  if (!content) {
+    throw new Error("OpenRouter returned empty content");
+  }
+  return stripMarkdown(content);
+}
+
+function stripMarkdown(text: string): string {
+  return text
+    .replace(/(\*{1,3}|_{1,3})(.+?)\1/g, "$2")
+    .replace(/^#{1,6}\s+/gm, "")
+    .replace(/^[-*_]{3,}\s*$/gm, "")
+    .replace(/`([^`]+)`/g, "$1")
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
+    .replace(/^["'](.+)["']$/, "$1")
+    .trim();
+}
+
+function truncateSnippet(
+  text: string,
+  maxLines = 3,
+  maxCharsPerLine = 80,
+): string {
+  return text
+    .split("\n")
+    .slice(0, maxLines)
+    .map((line) => {
+      return line.length > maxCharsPerLine
+        ? `${line.slice(0, maxCharsPerLine)}...`
+        : line;
+    })
+    .join("\n");
+}
+
+function generateRunSummary(
+  triggerSource: string,
+  prompt: string,
+  resultText: string,
+): Promise<string | null> {
+  const promptSnippet = truncateSnippet(prompt);
+  const resultSnippet = truncateSnippet(resultText);
+
+  return generateText(
+    [
+      {
+        role: "system",
+        content: `Summarize the result of this ${triggerSource} agent run in at most 50 words as plain text. No markdown, no quotes. Focus on what was accomplished or produced - the user's original request is provided only for context.`,
+      },
+      {
+        role: "user",
+        content: `Context (user request):\n${promptSnippet}\n\nResult:\n${resultSnippet}`,
+      },
+    ],
+    80,
+  );
+}
+
+export const saveRunSummary$ = command(
+  async (
+    { set },
+    args: {
+      readonly runId: string;
+      readonly triggerSource: string;
+      readonly prompt: string;
+      readonly resultText: string;
+    },
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const result = await safeAsync(async () => {
+      const summary = await generateRunSummary(
+        args.triggerSource,
+        args.prompt,
+        args.resultText,
+      );
+      signal.throwIfAborted();
+
+      if (!summary) {
+        log.warn("Run summary generation returned null (API key missing?)", {
+          runId: args.runId,
+          triggerSource: args.triggerSource,
+        });
+        return;
+      }
+
+      const writeDb = set(writeDb$);
+      await writeDb
+        .update(zeroRuns)
+        .set({ summary })
+        .where(eq(zeroRuns.id, args.runId));
+      signal.throwIfAborted();
+    });
+    signal.throwIfAborted();
+
+    if ("error" in result) {
+      log.warn("Failed to generate run summary", {
+        runId: args.runId,
+        error: result.error,
+      });
+    }
+  },
+);

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -1225,6 +1225,17 @@ export {
   type ZeroImageIoGenerateResponse,
 } from "./zero-image-io-generate";
 export {
+  internalCallbacksAgentContract,
+  type InternalCallbacksAgentContract,
+} from "./internal-callbacks-agent";
+export {
+  internalCallbackBodySchema,
+  internalCallbackErrorSchema,
+  internalCallbackHeadersSchema,
+  internalCallbackSuccessSchema,
+  type InternalCallbackBody,
+} from "./internal-callbacks-shared";
+export {
   zeroVoiceIoQuotaContract,
   audioInputQuotaResponseSchema,
   type ZeroVoiceIoQuotaContract,

--- a/turbo/packages/api-contracts/src/contracts/internal-callbacks-agent.ts
+++ b/turbo/packages/api-contracts/src/contracts/internal-callbacks-agent.ts
@@ -1,0 +1,28 @@
+import { initContract } from "./base";
+import {
+  internalCallbackBodySchema,
+  internalCallbackErrorSchema,
+  internalCallbackHeadersSchema,
+  internalCallbackSuccessSchema,
+} from "./internal-callbacks-shared";
+
+const c = initContract();
+
+export const internalCallbacksAgentContract = c.router({
+  post: {
+    method: "POST",
+    path: "/api/internal/callbacks/agent",
+    headers: internalCallbackHeadersSchema,
+    body: internalCallbackBodySchema,
+    responses: {
+      200: internalCallbackSuccessSchema,
+      400: internalCallbackErrorSchema,
+      401: internalCallbackErrorSchema,
+      404: internalCallbackErrorSchema,
+    },
+    summary: "Handle terminal callbacks for agent-triggered runs",
+  },
+});
+
+export type InternalCallbacksAgentContract =
+  typeof internalCallbacksAgentContract;

--- a/turbo/packages/api-contracts/src/contracts/internal-callbacks-shared.ts
+++ b/turbo/packages/api-contracts/src/contracts/internal-callbacks-shared.ts
@@ -1,0 +1,27 @@
+import { z } from "zod";
+
+export const internalCallbackHeadersSchema = z.object({
+  "x-vm0-signature": z.string().optional(),
+  "x-vm0-timestamp": z.string().optional(),
+});
+
+export const internalCallbackBodySchema = z
+  .object({
+    callbackId: z.string().optional(),
+    runId: z.string().optional(),
+    status: z.enum(["completed", "failed", "progress"]),
+    result: z.record(z.string(), z.unknown()).optional(),
+    error: z.string().optional(),
+    payload: z.unknown().optional(),
+  })
+  .passthrough();
+
+export const internalCallbackSuccessSchema = z.object({
+  success: z.literal(true),
+});
+
+export const internalCallbackErrorSchema = z.object({
+  error: z.string(),
+});
+
+export type InternalCallbackBody = z.infer<typeof internalCallbackBodySchema>;


### PR DESCRIPTION
## Summary
- add the API contract and route registration for `POST /api/internal/callbacks/agent`
- port the agent callback behavior to `apps/api`, including run-output lookup and non-blocking run-summary persistence
- cover invalid signatures, missing callbacks, progress/failed no-ops, successful summary persistence, and missing OpenRouter key behavior with API integration tests

## Testing
- `pnpm -F api exec vitest --run src/signals/routes/__tests__/internal-callbacks-agent.test.ts`
- `pnpm -F api lint`
- `pnpm check-types`
- `pnpm knip`

Closes #13065
Parent: #12852
