### PR TITLE
refactor: compact vsock message types

### DIFF
--- a/crates/vsock-guest/tests/connection.rs
+++ b/crates/vsock-guest/tests/connection.rs
@@ -19,7 +19,6 @@ use vsock_proto::{
 
 const EXIT_CODE_TIMEOUT: i32 = 124;
 const DRAIN_DEADLINE_SECS: u64 = 5;
-const RETIRED_EXEC_MESSAGE_TYPES: &[u8] = &[0x03, 0x04];
 const LARGE_ENV_COMMAND: &str =
     "printf '%s:%s:%s:%s:%s\\n' \"$SMALL\" \"${#BIG_A}\" \"${#BIG_B}\" \"${#BIG_C}\" \"${#BIG_D}\"";
 
@@ -125,15 +124,6 @@ fn orphan_sleep_command(marker: &str, pid_path: &str) -> String {
     format!("sleep 30 & echo $! > {pid_path}; echo {marker}")
 }
 
-fn encode_retired_exec_payload(command: &str) -> Vec<u8> {
-    let mut payload = Vec::with_capacity(9 + command.len());
-    payload.extend_from_slice(&5000_u32.to_be_bytes());
-    payload.push(0);
-    payload.extend_from_slice(&(command.len() as u32).to_be_bytes());
-    payload.extend_from_slice(command.as_bytes());
-    payload
-}
-
 #[test]
 fn run_exits_after_shutdown_even_when_ack_write_fails() {
     use std::net::Shutdown;
@@ -230,38 +220,6 @@ fn read_message(stream: &mut impl std::io::Read) -> vsock_proto::RawMessage {
 /// Read one framed message from the stream and discard it.
 fn read_and_discard_message(stream: &mut impl std::io::Read) {
     let _ = read_message(stream);
-}
-
-#[test]
-fn retired_exec_message_types_return_unknown_error_without_running_payload() {
-    let marker_path = unique_tmp_path("retired-exec", ".marker");
-    let (handle, mut host_stream) = start_guest_connection();
-
-    for (index, msg_type) in RETIRED_EXEC_MESSAGE_TYPES.iter().copied().enumerate() {
-        let payload = if msg_type == 0x03 {
-            encode_retired_exec_payload(&format!("touch {}", marker_path.as_str()))
-        } else {
-            Vec::new()
-        };
-        let seq = 77 + index as u32;
-        let msg = vsock_proto::encode(msg_type, seq, &payload).unwrap();
-        host_stream.write_all(&msg).unwrap();
-
-        let response = read_message(&mut host_stream);
-        assert_eq!(response.msg_type, MSG_ERROR);
-        assert_eq!(response.seq, seq);
-        let error = vsock_proto::decode_error(&response.payload).unwrap();
-        assert!(
-            error.contains(&format!("0x{msg_type:02X}")),
-            "unknown-message error should name retired type: {error}"
-        );
-    }
-    assert!(
-        !std::path::Path::new(marker_path.as_str()).exists(),
-        "retired exec payload must not be executed",
-    );
-
-    finish_guest_connection(handle, host_stream);
 }
 
 #[derive(Debug)]

--- a/crates/vsock-proto/src/lib.rs
+++ b/crates/vsock-proto/src/lib.rs
@@ -18,20 +18,18 @@
 //! | 0x00 | G→H       | ready             | (empty) |
 //! | 0x01 | H→G       | ping              | (empty) |
 //! | 0x02 | G→H       | pong              | (empty) |
-//! | 0x03 | —         | retired           | legacy exec, do not reuse |
-//! | 0x04 | —         | retired           | legacy exec_result, do not reuse |
-//! | 0x05 | H→G       | write_file        | `[2B path_len][path][1B flags][4B content_len][content]` (flags: `SUDO=0x01`, `APPEND=0x02`) |
-//! | 0x06 | G→H       | write_file_result | `[1B success][2B error_len][error]` |
-//! | 0x07 | H→G       | spawn_watch       | `[4B timeout_ms][1B flags][4B cmd_len][command]([4B env_count]([4B key_len][key][4B val_len][value])*)([2B log_path_len][log_path])` (flags: `SUDO=0x01`, `STREAM_STDOUT=0x02`) |
-//! | 0x08 | G→H       | spawn_watch_result| `[4B pid]` |
-//! | 0x09 | G→H       | process_exit      | `[4B pid][4B exit_code][4B stdout_len][stdout][4B stderr_len][stderr]` |
-//! | 0x0A | H→G       | shutdown          | (empty) |
-//! | 0x0B | G→H       | shutdown_ack      | (empty) |
-//! | 0x0C | G→H       | stdout_chunk      | `[4B pid][data]` |
-//! | 0x0D | H→G       | command_start     | `[4B timeout_ms][1B flags][4B cmd_len][command][4B env_count]... [2B label_len][label][stdout_policy][stderr_policy]` |
-//! | 0x0E | G→H       | command_output    | `[1B stream][4B output_seq][1B flags][4B chunk_len][chunk]` |
-//! | 0x0F | G→H       | command_result    | `[1B termination]...[4B duration_ms][stdout][stderr][2B diagnostic_len][diagnostic]` |
-//! | 0x10 | H→G       | command_cancel    | (empty) |
+//! | 0x03 | H→G       | write_file        | `[2B path_len][path][1B flags][4B content_len][content]` (flags: `SUDO=0x01`, `APPEND=0x02`) |
+//! | 0x04 | G→H       | write_file_result | `[1B success][2B error_len][error]` |
+//! | 0x05 | H→G       | spawn_watch       | `[4B timeout_ms][1B flags][4B cmd_len][command]([4B env_count]([4B key_len][key][4B val_len][value])*)([2B log_path_len][log_path])` (flags: `SUDO=0x01`, `STREAM_STDOUT=0x02`) |
+//! | 0x06 | G→H       | spawn_watch_result| `[4B pid]` |
+//! | 0x07 | G→H       | process_exit      | `[4B pid][4B exit_code][4B stdout_len][stdout][4B stderr_len][stderr]` |
+//! | 0x08 | H→G       | shutdown          | (empty) |
+//! | 0x09 | G→H       | shutdown_ack      | (empty) |
+//! | 0x0A | G→H       | stdout_chunk      | `[4B pid][data]` |
+//! | 0x0B | H→G       | command_start     | `[4B timeout_ms][1B flags][4B cmd_len][command][4B env_count]... [2B label_len][label][stdout_policy][stderr_policy]` |
+//! | 0x0C | G→H       | command_output    | `[1B stream][4B output_seq][1B flags][4B chunk_len][chunk]` |
+//! | 0x0D | G→H       | command_result    | `[1B termination]...[4B duration_ms][stdout][stderr][2B diagnostic_len][diagnostic]` |
+//! | 0x0E | H→G       | command_cancel    | (empty) |
 //! | 0xFF | G→H       | error             | `[2B error_len][error]` |
 //!
 //! Command operation messages are request-scoped; host/guest dispatch layers
@@ -52,18 +50,18 @@ pub const MIN_BODY_SIZE: usize = 5;
 pub const MSG_READY: u8 = 0x00;
 pub const MSG_PING: u8 = 0x01;
 pub const MSG_PONG: u8 = 0x02;
-pub const MSG_WRITE_FILE: u8 = 0x05;
-pub const MSG_WRITE_FILE_RESULT: u8 = 0x06;
-pub const MSG_SPAWN_WATCH: u8 = 0x07;
-pub const MSG_SPAWN_WATCH_RESULT: u8 = 0x08;
-pub const MSG_PROCESS_EXIT: u8 = 0x09;
-pub const MSG_SHUTDOWN: u8 = 0x0A;
-pub const MSG_SHUTDOWN_ACK: u8 = 0x0B;
-pub const MSG_STDOUT_CHUNK: u8 = 0x0C;
-pub const MSG_COMMAND_START: u8 = 0x0D;
-pub const MSG_COMMAND_OUTPUT: u8 = 0x0E;
-pub const MSG_COMMAND_RESULT: u8 = 0x0F;
-pub const MSG_COMMAND_CANCEL: u8 = 0x10;
+pub const MSG_WRITE_FILE: u8 = 0x03;
+pub const MSG_WRITE_FILE_RESULT: u8 = 0x04;
+pub const MSG_SPAWN_WATCH: u8 = 0x05;
+pub const MSG_SPAWN_WATCH_RESULT: u8 = 0x06;
+pub const MSG_PROCESS_EXIT: u8 = 0x07;
+pub const MSG_SHUTDOWN: u8 = 0x08;
+pub const MSG_SHUTDOWN_ACK: u8 = 0x09;
+pub const MSG_STDOUT_CHUNK: u8 = 0x0A;
+pub const MSG_COMMAND_START: u8 = 0x0B;
+pub const MSG_COMMAND_OUTPUT: u8 = 0x0C;
+pub const MSG_COMMAND_RESULT: u8 = 0x0D;
+pub const MSG_COMMAND_CANCEL: u8 = 0x0E;
 pub const MSG_ERROR: u8 = 0xFF;
 
 /// Default vsock port for host-guest communication.


### PR DESCRIPTION
## Summary
- remove the retired legacy exec gaps from the vsock message type table
- shift active vsock message type constants down to keep the protocol IDs contiguous
- remove the retired exec unknown-message regression test that no longer applies

## Tests
- cargo fmt --manifest-path crates/Cargo.toml --all
- cargo test --manifest-path crates/Cargo.toml -p vsock-proto -p vsock-guest -p vsock-host
- git diff --check
- pre-commit: cargo-fmt, cargo-clippy, cargo-doc