### PR TITLE
fix: stabilize navbar dropdown hover

### DIFF
--- a/turbo/apps/web/app/components/NavMenu.tsx
+++ b/turbo/apps/web/app/components/NavMenu.tsx
@@ -20,10 +20,11 @@ interface NavMenuProps {
   alignOffset?: number;
   items: NavMenuItem[];
   openId: string | null;
-  onOpenChange: (id: string | null) => void;
+  onOpen: (id: string) => void;
+  onClose: () => void;
+  onCancelClose: () => void;
+  onScheduleClose: () => void;
 }
-
-const CLOSE_DELAY_MS = 250;
 
 export function NavMenu({
   id,
@@ -31,55 +32,39 @@ export function NavMenu({
   items,
   alignOffset = 0,
   openId,
-  onOpenChange,
+  onOpen,
+  onClose,
+  onCancelClose,
+  onScheduleClose,
 }: NavMenuProps) {
   const open = openId === id;
-  const closeTimer = React.useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  const cancelClose = React.useCallback(() => {
-    if (closeTimer.current !== null) {
-      clearTimeout(closeTimer.current);
-      closeTimer.current = null;
-    }
-  }, []);
-
-  const scheduleClose = React.useCallback(() => {
-    cancelClose();
-    closeTimer.current = setTimeout(() => {
-      onOpenChange(null);
-    }, CLOSE_DELAY_MS);
-  }, [cancelClose, onOpenChange]);
 
   const openSelf = React.useCallback(() => {
-    cancelClose();
-    onOpenChange(id);
-  }, [cancelClose, id, onOpenChange]);
-
-  React.useEffect(() => {
-    return () => {
-      cancelClose();
-    };
-  }, [cancelClose]);
+    onOpen(id);
+  }, [id, onOpen]);
 
   const handleSelect = () => {
-    cancelClose();
-    onOpenChange(null);
+    onClose();
   };
 
   return (
     <PopoverPrimitive.Root
       open={open}
       onOpenChange={(next) => {
-        onOpenChange(next ? id : null);
+        if (next) {
+          onOpen(id);
+          return;
+        }
+        onClose();
       }}
     >
       <PopoverPrimitive.Trigger
         type="button"
         className={`nav-trigger${open ? " nav-trigger-active" : ""}`}
+        data-nav-menu-id={id}
         onPointerEnter={openSelf}
-        onPointerLeave={scheduleClose}
         onFocus={openSelf}
-        onBlur={scheduleClose}
+        onBlur={onScheduleClose}
       >
         {label}
         <IconChevronDown
@@ -94,8 +79,9 @@ export function NavMenu({
           alignOffset={alignOffset}
           sideOffset={8}
           className="nav-popover"
-          onPointerEnter={cancelClose}
-          onPointerLeave={scheduleClose}
+          data-nav-popover-id={id}
+          onPointerEnter={onCancelClose}
+          onPointerLeave={onScheduleClose}
           onOpenAutoFocus={(event: Event) => {
             event.preventDefault();
           }}
@@ -149,6 +135,7 @@ function NavMenuRow({ item, onSelect }: NavMenuRowProps) {
         target="_blank"
         rel="noopener noreferrer"
         className="nav-popover-item"
+        onPointerDown={onSelect}
         onClick={onSelect}
       >
         {body}
@@ -157,7 +144,12 @@ function NavMenuRow({ item, onSelect }: NavMenuRowProps) {
   }
 
   return (
-    <Link href={item.href} className="nav-popover-item" onClick={onSelect}>
+    <Link
+      href={item.href}
+      className="nav-popover-item"
+      onPointerDown={onSelect}
+      onClick={onSelect}
+    >
       {body}
     </Link>
   );

--- a/turbo/apps/web/app/components/NavMenu.tsx
+++ b/turbo/apps/web/app/components/NavMenu.tsx
@@ -143,11 +143,7 @@ function NavMenuRow({ item, onSelect }: NavMenuRowProps) {
   }
 
   return (
-    <Link
-      href={item.href}
-      className="nav-popover-item"
-      onClick={onSelect}
-    >
+    <Link href={item.href} className="nav-popover-item" onClick={onSelect}>
       {body}
     </Link>
   );

--- a/turbo/apps/web/app/components/NavMenu.tsx
+++ b/turbo/apps/web/app/components/NavMenu.tsx
@@ -135,7 +135,6 @@ function NavMenuRow({ item, onSelect }: NavMenuRowProps) {
         target="_blank"
         rel="noopener noreferrer"
         className="nav-popover-item"
-        onPointerDown={onSelect}
         onClick={onSelect}
       >
         {body}
@@ -147,7 +146,6 @@ function NavMenuRow({ item, onSelect }: NavMenuRowProps) {
     <Link
       href={item.href}
       className="nav-popover-item"
-      onPointerDown={onSelect}
       onClick={onSelect}
     >
       {body}

--- a/turbo/apps/web/app/components/Navbar.tsx
+++ b/turbo/apps/web/app/components/Navbar.tsx
@@ -1,6 +1,12 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import {
+  type PointerEvent as ReactPointerEvent,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 import Image from "next/image";
 import NextLink from "next/link";
 import { Link } from "../../navigation";
@@ -26,6 +32,24 @@ interface NavbarProps {
 const GITHUB_URL = "https://github.com/vm0-ai/vm0";
 const STATUS_URL = "https://status.vm0.ai";
 const DEMO_URL = "https://calendar.app.google/csdygPrHHyNgxpTPA";
+const NAV_MENU_CLOSE_DELAY_MS = 250;
+const NAV_MENU_TRIGGER_HOTZONE_Y = 18;
+const NAV_MENU_TRIGGER_HOTZONE_X = 12;
+const NAV_MENU_POPOVER_HOTZONE = 8;
+
+function containsPoint(
+  rect: DOMRect,
+  clientX: number,
+  clientY: number,
+  margin = 0,
+): boolean {
+  return (
+    clientX >= rect.left - margin &&
+    clientX <= rect.right + margin &&
+    clientY >= rect.top - margin &&
+    clientY <= rect.bottom + margin
+  );
+}
 
 export function Navbar({
   initialIsSignedIn = false,
@@ -38,6 +62,219 @@ export function Navbar({
   const { signOut } = useClerk();
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const [openMenuId, setOpenMenuId] = useState<string | null>(null);
+  const desktopNavRef = useRef<HTMLDivElement | null>(null);
+  const closeMenuTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const cancelMenuClose = useCallback(() => {
+    if (closeMenuTimer.current !== null) {
+      clearTimeout(closeMenuTimer.current);
+      closeMenuTimer.current = null;
+    }
+  }, []);
+
+  const openNavMenu = useCallback(
+    (id: string) => {
+      cancelMenuClose();
+      setOpenMenuId(id);
+    },
+    [cancelMenuClose],
+  );
+
+  const closeNavMenu = useCallback(() => {
+    cancelMenuClose();
+    setOpenMenuId(null);
+  }, [cancelMenuClose]);
+
+  const scheduleNavMenuClose = useCallback(() => {
+    cancelMenuClose();
+    closeMenuTimer.current = setTimeout(() => {
+      setOpenMenuId(null);
+      closeMenuTimer.current = null;
+    }, NAV_MENU_CLOSE_DELAY_MS);
+  }, [cancelMenuClose]);
+
+  const navMenuIdFromTriggerHotzone = useCallback(
+    (clientX: number, clientY: number): string | null => {
+      const root = desktopNavRef.current;
+      if (!root) {
+        return null;
+      }
+      const triggerRects = Array.from(
+        root.querySelectorAll<HTMLButtonElement>("[data-nav-menu-id]"),
+      )
+        .map((trigger) => {
+          return {
+            id: trigger.dataset.navMenuId ?? "",
+            rect: trigger.getBoundingClientRect(),
+          };
+        })
+        .filter((entry) => {
+          return entry.id.length > 0;
+        })
+        .sort((a, b) => {
+          return a.rect.left - b.rect.left;
+        });
+
+      if (triggerRects.length === 0) {
+        return null;
+      }
+      const firstTrigger = triggerRects[0];
+      const lastTrigger = triggerRects[triggerRects.length - 1];
+      if (!firstTrigger || !lastTrigger) {
+        return null;
+      }
+
+      const top =
+        Math.min(...triggerRects.map((entry) => entry.rect.top)) -
+        NAV_MENU_TRIGGER_HOTZONE_Y;
+      const bottom =
+        Math.max(...triggerRects.map((entry) => entry.rect.bottom)) +
+        NAV_MENU_TRIGGER_HOTZONE_Y;
+      if (clientY < top || clientY > bottom) {
+        return null;
+      }
+
+      const left = firstTrigger.rect.left - NAV_MENU_TRIGGER_HOTZONE_X;
+      const right = lastTrigger.rect.right + NAV_MENU_TRIGGER_HOTZONE_X;
+      if (clientX < left || clientX > right) {
+        return null;
+      }
+
+      return triggerRects.reduce((nearest, current) => {
+        const currentCenter = current.rect.left + current.rect.width / 2;
+        const nearestCenter = nearest.rect.left + nearest.rect.width / 2;
+        return Math.abs(currentCenter - clientX) <
+          Math.abs(nearestCenter - clientX)
+          ? current
+          : nearest;
+      }).id;
+    },
+    [],
+  );
+
+  const isPointerInOpenPopoverHotzone = useCallback(
+    (clientX: number, clientY: number): boolean => {
+      if (openMenuId === null) {
+        return false;
+      }
+      const popover = Array.from(
+        document.querySelectorAll<HTMLElement>("[data-nav-popover-id]"),
+      ).find((element) => {
+        return element.dataset.navPopoverId === openMenuId;
+      });
+      if (!popover) {
+        return false;
+      }
+      return containsPoint(
+        popover.getBoundingClientRect(),
+        clientX,
+        clientY,
+        NAV_MENU_POPOVER_HOTZONE,
+      );
+    },
+    [openMenuId],
+  );
+
+  const isPointerInOpenMenuBridge = useCallback(
+    (clientX: number, clientY: number): boolean => {
+      if (openMenuId === null) {
+        return false;
+      }
+      const root = desktopNavRef.current;
+      if (!root) {
+        return false;
+      }
+      const trigger = Array.from(
+        root.querySelectorAll<HTMLButtonElement>("[data-nav-menu-id]"),
+      ).find((element) => {
+        return element.dataset.navMenuId === openMenuId;
+      });
+      const popover = Array.from(
+        document.querySelectorAll<HTMLElement>("[data-nav-popover-id]"),
+      ).find((element) => {
+        return element.dataset.navPopoverId === openMenuId;
+      });
+      if (!trigger || !popover) {
+        return false;
+      }
+
+      const triggerRect = trigger.getBoundingClientRect();
+      const popoverRect = popover.getBoundingClientRect();
+      const left =
+        Math.min(triggerRect.left, popoverRect.left) - NAV_MENU_POPOVER_HOTZONE;
+      const right =
+        Math.max(triggerRect.right, popoverRect.right) +
+        NAV_MENU_POPOVER_HOTZONE;
+      const top =
+        Math.min(triggerRect.bottom, popoverRect.top) -
+        NAV_MENU_POPOVER_HOTZONE;
+      const bottom =
+        Math.max(triggerRect.bottom, popoverRect.top) +
+        NAV_MENU_POPOVER_HOTZONE;
+
+      return (
+        clientX >= left &&
+        clientX <= right &&
+        clientY >= top &&
+        clientY <= bottom
+      );
+    },
+    [openMenuId],
+  );
+
+  const syncOpenMenuForPointer = useCallback(
+    (clientX: number, clientY: number) => {
+      const menuId = navMenuIdFromTriggerHotzone(clientX, clientY);
+      if (menuId) {
+        openNavMenu(menuId);
+        return;
+      }
+      if (
+        isPointerInOpenPopoverHotzone(clientX, clientY) ||
+        isPointerInOpenMenuBridge(clientX, clientY)
+      ) {
+        cancelMenuClose();
+        return;
+      }
+      closeNavMenu();
+    },
+    [
+      cancelMenuClose,
+      closeNavMenu,
+      isPointerInOpenMenuBridge,
+      isPointerInOpenPopoverHotzone,
+      navMenuIdFromTriggerHotzone,
+      openNavMenu,
+    ],
+  );
+
+  const handleDesktopNavPointerMove = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      syncOpenMenuForPointer(event.clientX, event.clientY);
+    },
+    [syncOpenMenuForPointer],
+  );
+
+  useEffect(() => {
+    return () => {
+      cancelMenuClose();
+    };
+  }, [cancelMenuClose]);
+
+  useEffect(() => {
+    if (openMenuId === null) {
+      return undefined;
+    }
+
+    const handlePointerMove = (event: PointerEvent) => {
+      syncOpenMenuForPointer(event.clientX, event.clientY);
+    };
+
+    document.addEventListener("pointermove", handlePointerMove);
+    return () => {
+      document.removeEventListener("pointermove", handlePointerMove);
+    };
+  }, [openMenuId, syncOpenMenuForPointer]);
 
   useEffect(() => {
     const handleResize = () => {
@@ -155,7 +392,12 @@ export function Navbar({
             </Link>
           </div>
 
-          <div className="nav-center nav-desktop">
+          <div
+            ref={desktopNavRef}
+            className="nav-center nav-desktop"
+            onPointerMove={handleDesktopNavPointerMove}
+            onPointerLeave={scheduleNavMenuClose}
+          >
             <Link href="/use-cases" className="nav-link">
               {t("useCases")}
             </Link>
@@ -165,7 +407,10 @@ export function Navbar({
               items={resourcesItems}
               alignOffset={-40}
               openId={openMenuId}
-              onOpenChange={setOpenMenuId}
+              onOpen={openNavMenu}
+              onClose={closeNavMenu}
+              onCancelClose={cancelMenuClose}
+              onScheduleClose={scheduleNavMenuClose}
             />
             <NavMenu
               id="trust-and-tech"
@@ -173,7 +418,10 @@ export function Navbar({
               items={trustItems}
               alignOffset={40}
               openId={openMenuId}
-              onOpenChange={setOpenMenuId}
+              onOpen={openNavMenu}
+              onClose={closeNavMenu}
+              onCancelClose={cancelMenuClose}
+              onScheduleClose={scheduleNavMenuClose}
             />
             <Link href="/pricing" className="nav-link">
               {t("pricing")}

--- a/turbo/apps/web/app/components/Navbar.tsx
+++ b/turbo/apps/web/app/components/Navbar.tsx
@@ -125,11 +125,17 @@ export function Navbar({
       }
 
       const top =
-        Math.min(...triggerRects.map((entry) => entry.rect.top)) -
-        NAV_MENU_TRIGGER_HOTZONE_Y;
+        Math.min(
+          ...triggerRects.map((entry) => {
+            return entry.rect.top;
+          }),
+        ) - NAV_MENU_TRIGGER_HOTZONE_Y;
       const bottom =
-        Math.max(...triggerRects.map((entry) => entry.rect.bottom)) +
-        NAV_MENU_TRIGGER_HOTZONE_Y;
+        Math.max(
+          ...triggerRects.map((entry) => {
+            return entry.rect.bottom;
+          }),
+        ) + NAV_MENU_TRIGGER_HOTZONE_Y;
       if (clientY < top || clientY > bottom) {
         return null;
       }

--- a/turbo/apps/web/app/components/__tests__/navbar-blog.test.tsx
+++ b/turbo/apps/web/app/components/__tests__/navbar-blog.test.tsx
@@ -274,7 +274,7 @@ describe("Navbar dropdown interactions", () => {
     }
   });
 
-  it("closes the open menu when a dropdown item is selected", () => {
+  it("closes the open menu when a dropdown item is clicked", () => {
     renderNavbarClient();
 
     const resources = getDesktopNavTrigger("resources");
@@ -284,7 +284,7 @@ describe("Navbar dropdown interactions", () => {
     const firstItem =
       document.querySelector<HTMLAnchorElement>(".nav-popover-item");
     expect(firstItem).not.toBeNull();
-    fireEvent.pointerDown(firstItem!);
+    fireEvent.click(firstItem!);
 
     expect(resources).not.toHaveClass("nav-trigger-active");
   });

--- a/turbo/apps/web/app/components/__tests__/navbar-blog.test.tsx
+++ b/turbo/apps/web/app/components/__tests__/navbar-blog.test.tsx
@@ -1,6 +1,14 @@
+// @vitest-environment happy-dom
 import { describe, it, expect, vi } from "vitest";
-import type { ComponentProps } from "react";
+import type {
+  AnchorHTMLAttributes,
+  ButtonHTMLAttributes,
+  ComponentProps,
+  HTMLAttributes,
+  ReactNode,
+} from "react";
 import { renderToStaticMarkup } from "react-dom/server";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import { ThemeProvider } from "../ThemeProvider";
 import { Navbar } from "../Navbar";
 
@@ -13,13 +21,14 @@ vi.mock("next-intl/navigation", () => {
           href,
           children,
           className,
+          ...props
         }: {
           href: string;
-          children: React.ReactNode;
+          children: ReactNode;
           className?: string;
-        }) => {
+        } & AnchorHTMLAttributes<HTMLAnchorElement>) => {
           return (
-            <a href={href} className={className}>
+            <a href={href} className={className} {...props}>
               {children}
             </a>
           );
@@ -69,13 +78,14 @@ vi.mock("next/link", () => {
       href,
       children,
       className,
+      ...props
     }: {
       href: string;
-      children: React.ReactNode;
+      children: ReactNode;
       className?: string;
-    }) => {
+    } & AnchorHTMLAttributes<HTMLAnchorElement>) => {
       return (
-        <a href={href} className={className}>
+        <a href={href} className={className} {...props}>
           {children}
         </a>
       );
@@ -107,7 +117,7 @@ vi.mock("@tabler/icons-react", () => {
 
 // External: @radix-ui/react-popover (used by NavMenu)
 vi.mock("@radix-ui/react-popover", () => {
-  const passthrough = ({ children }: { children?: React.ReactNode }) => {
+  const passthrough = ({ children }: { children?: ReactNode }) => {
     return <>{children}</>;
   };
   return {
@@ -115,14 +125,26 @@ vi.mock("@radix-ui/react-popover", () => {
     Trigger: ({
       children,
       className,
+      ...props
     }: {
-      children?: React.ReactNode;
+      children?: ReactNode;
       className?: string;
-    }) => {
-      return <button className={className}>{children}</button>;
+    } & ButtonHTMLAttributes<HTMLButtonElement>) => {
+      return (
+        <button className={className} {...props}>
+          {children}
+        </button>
+      );
     },
     Portal: passthrough,
-    Content: passthrough,
+    Content: ({
+      children,
+      ...props
+    }: {
+      children?: ReactNode;
+    } & HTMLAttributes<HTMLDivElement>) => {
+      return <div {...props}>{children}</div>;
+    },
   };
 });
 
@@ -132,6 +154,56 @@ function renderNavbar(props: ComponentProps<typeof Navbar> = {}) {
       <Navbar {...props} />
     </ThemeProvider>,
   );
+}
+
+function renderNavbarClient(props: ComponentProps<typeof Navbar> = {}) {
+  return render(
+    <ThemeProvider>
+      <Navbar {...props} />
+    </ThemeProvider>,
+  );
+}
+
+function getDesktopNavTrigger(label: string): HTMLButtonElement {
+  const trigger = screen.getAllByRole("button").find((button) => {
+    return (
+      button.classList.contains("nav-trigger") &&
+      button.textContent?.includes(label)
+    );
+  });
+  if (!trigger) {
+    throw new Error(`Missing nav trigger: ${label}`);
+  }
+  return trigger as HTMLButtonElement;
+}
+
+function getNavPopover(id: string): HTMLElement {
+  const popover = document.querySelector<HTMLElement>(
+    `[data-nav-popover-id="${id}"]`,
+  );
+  if (!popover) {
+    throw new Error(`Missing nav popover: ${id}`);
+  }
+  return popover;
+}
+
+function setElementRect(
+  element: Element,
+  rect: Pick<DOMRect, "bottom" | "height" | "left" | "right" | "top" | "width">,
+): void {
+  Object.defineProperty(element, "getBoundingClientRect", {
+    configurable: true,
+    value: () => {
+      return {
+        x: rect.left,
+        y: rect.top,
+        ...rect,
+        toJSON: () => {
+          return rect;
+        },
+      };
+    },
+  });
 }
 
 describe("Navbar blog link visibility", () => {
@@ -154,5 +226,96 @@ describe("Navbar blog link visibility", () => {
   it("renders docs link only when the server-side feature gate allows it", () => {
     expect(renderNavbar()).not.toContain('href="/docs"');
     expect(renderNavbar({ initialShowDocs: true })).toContain('href="/docs"');
+  });
+});
+
+describe("Navbar dropdown interactions", () => {
+  it("keeps the newly hovered menu open when a previous close timer expires", () => {
+    vi.useFakeTimers();
+    try {
+      renderNavbarClient();
+
+      const resources = getDesktopNavTrigger("resources");
+      const trust = getDesktopNavTrigger("trustAndTech");
+
+      const navCenter = document.querySelector<HTMLDivElement>(".nav-center");
+      expect(navCenter).not.toBeNull();
+      setElementRect(resources, {
+        left: 100,
+        right: 180,
+        top: 10,
+        bottom: 30,
+        width: 80,
+        height: 20,
+      });
+      setElementRect(trust, {
+        left: 220,
+        right: 340,
+        top: 10,
+        bottom: 30,
+        width: 120,
+        height: 20,
+      });
+
+      fireEvent.pointerEnter(resources);
+      expect(resources).toHaveClass("nav-trigger-active");
+
+      fireEvent.pointerMove(navCenter!, { clientX: 215, clientY: 20 });
+      expect(resources).not.toHaveClass("nav-trigger-active");
+      expect(trust).toHaveClass("nav-trigger-active");
+
+      act(() => {
+        vi.advanceTimersByTime(300);
+      });
+
+      expect(trust).toHaveClass("nav-trigger-active");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("closes the open menu when a dropdown item is selected", () => {
+    renderNavbarClient();
+
+    const resources = getDesktopNavTrigger("resources");
+    fireEvent.pointerEnter(resources);
+    expect(resources).toHaveClass("nav-trigger-active");
+
+    const firstItem =
+      document.querySelector<HTMLAnchorElement>(".nav-popover-item");
+    expect(firstItem).not.toBeNull();
+    fireEvent.pointerDown(firstItem!);
+
+    expect(resources).not.toHaveClass("nav-trigger-active");
+  });
+
+  it("closes the open menu when the pointer leaves the computed hotzone", () => {
+    renderNavbarClient();
+
+    const resources = getDesktopNavTrigger("resources");
+    const popover = getNavPopover("resources");
+    setElementRect(resources, {
+      left: 100,
+      right: 180,
+      top: 10,
+      bottom: 30,
+      width: 80,
+      height: 20,
+    });
+    setElementRect(popover, {
+      left: 80,
+      right: 400,
+      top: 42,
+      bottom: 220,
+      width: 320,
+      height: 178,
+    });
+
+    fireEvent.pointerEnter(resources);
+    expect(resources).toHaveClass("nav-trigger-active");
+
+    fireEvent.pointerMove(document, { clientX: 500, clientY: 260 });
+
+    expect(resources).not.toHaveClass("nav-trigger-active");
   });
 });

--- a/turbo/apps/web/app/landing.css
+++ b/turbo/apps/web/app/landing.css
@@ -422,6 +422,7 @@ body {
 
 /* ===== NAV POPOVER (mega-menu panel) ===== */
 .nav-popover {
+  position: relative;
   width: 320px;
   background: hsl(var(--gray-0));
   border: 0.7px solid hsl(var(--gray-200));
@@ -443,6 +444,7 @@ body {
   right: 0;
   top: -10px;
   height: 10px;
+  pointer-events: none;
 }
 
 .nav-popover[data-state="open"] {


### PR DESCRIPTION
## Summary
- Rework the desktop navbar dropdown hover handling around a shared hotzone controller
- Keep dropdowns stable when moving between Resources and Trust and close when leaving trigger/popover hotzones
- Close menu items immediately on pointer/click selection

Fixes #13044

## Verification
- pnpm --filter web exec vitest run app/components/__tests__/navbar-blog.test.tsx
- pnpm --filter web exec oxlint app/components/NavMenu.tsx app/components/Navbar.tsx app/components/__tests__/navbar-blog.test.tsx
- pnpm --filter web check-types
- git diff --check
- pre-commit: pnpm check-types via lefthook
