### PR TITLE
chore: update rootfs package versions

### DIFF
--- a/crates/runner/scripts/build-template.sh
+++ b/crates/runner/scripts/build-template.sh
@@ -111,7 +111,7 @@ CACHE_TMP_TAR=""
 
 # Pinned versions (changes here invalidate the template cache via script hash)
 GO_VERSION="1.26.3"
-CLAUDE_CODE_VERSION="2.1.139"
+CLAUDE_CODE_VERSION="2.1.140"
 CODEX_CLI_VERSION="0.130.0"
 GWS_CLI_VERSION="0.22.5"
 XURL_VERSION="1.0.3"


### PR DESCRIPTION
## Updates

- Claude Code CLI: `2.1.139` -> `2.1.140`

## Verification

- Checked pinned versions in `crates/runner/scripts/build-template.sh`:
  - Go: `1.26.3` is current
  - Codex CLI: `0.130.0` is current
  - Google Workspace CLI: `0.22.5` is current
  - xurl: `1.0.3` is current
  - agent-browser: `0.27.0` is current
- Ran `bash -n crates/runner/scripts/build-template.sh`
