### PR TITLE
chore(rust): update dependencies

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -1068,9 +1068,9 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "filetime"
-version = "0.2.28"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d5b2eef6fafbf69f877e55509ce5b11a760690ac9700a2921be067aa6afaef6"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
 dependencies = [
  "cfg-if",
  "libc",
@@ -4315,9 +4315,9 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]


### PR DESCRIPTION
## Summary

- Updated Rust dependency lockfile entries in the `crates` workspace.
- `filetime`: `0.2.28` -> `0.2.29`
- `zerofrom`: `0.1.7` -> `0.1.8`

## Dependencies not updated

- `crc`: remains `3.3.0`; `3.4.0` is blocked by transitive dependency `crc-fast = "~3.3"` via `aws-smithy-checksums` / `aws-sdk-s3`.
- `crc-fast`: remains `1.9.0`; `1.10.0` is blocked by transitive dependency `crc-fast = "~1.9.0"` via `aws-smithy-checksums` / `aws-sdk-s3`.
- `generic-array`: remains `0.14.7`; `0.14.9` is blocked by transitive dependency `generic-array = "=0.14.7"` via `crypto-common` / `digest`.

## Manual version bumps

- None. The remaining blocked dependencies are transitive constraints, not direct `Cargo.toml` constraints in this repository.

## Test status

- Passed: `env -u CLI_AGENT_TYPE cargo test --workspace` from `crates/`.
- Note: a plain `cargo test --workspace` in this scheduled agent environment inherited `CLI_AGENT_TYPE=codex` and failed `guest-agent/tests/cli_stderr_exact_limit_no_newline.rs` before rerunning with that ambient variable removed. The passing run matches the workspace default Claude-path test setup.