### PR TITLE
refactor(api): migrate github issues callback

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -30,6 +30,7 @@ import { apiHealth$ } from "./routes/health";
 import { healthAuthProbeRoutes } from "./routes/health-auth-probe";
 import { githubOauthRoutes } from "./routes/github-oauth";
 import { internalCallbacksAgentRoutes } from "./routes/internal-callbacks-agent";
+import { internalCallbacksGithubIssuesRoutes } from "./routes/internal-callbacks-github-issues";
 import { internalCallbacksScheduleRoutes } from "./routes/internal-callbacks-schedule";
 import { internalEventConsumerAxiomRoutes } from "./routes/internal-event-consumers-axiom";
 import { internalEventConsumerChatAssistantRoutes } from "./routes/internal-event-consumers-chat-assistant";
@@ -150,6 +151,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...healthAuthProbeRoutes,
   ...githubOauthRoutes,
   ...internalCallbacksAgentRoutes,
+  ...internalCallbacksGithubIssuesRoutes,
   ...internalCallbacksScheduleRoutes,
   ...internalEventConsumerAxiomRoutes,
   ...internalEventConsumerChatAssistantRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-github-issues.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-github-issues.test.ts
@@ -1,0 +1,749 @@
+import { Buffer } from "node:buffer";
+import { generateKeyPairSync, randomUUID } from "node:crypto";
+
+import { createStore } from "ccstate";
+import { and, eq } from "drizzle-orm";
+import { HttpResponse, http } from "msw";
+import { afterEach, describe, expect, it } from "vitest";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import { agentSessions } from "@vm0/db/schema/agent-session";
+import { githubInstallations } from "@vm0/db/schema/github-installation";
+import { githubIssueSessions } from "@vm0/db/schema/github-issue-session";
+import { userFeatureSwitches } from "@vm0/db/schema/user-feature-switches";
+
+import { createApp } from "../../../app-factory";
+import { testContext } from "../../../__tests__/test-helpers";
+import { computeHmacSignature } from "../../../lib/event-consumer/hmac";
+import { mockOptionalEnv } from "../../../lib/env";
+import { now, nowDate } from "../../../lib/time";
+import { server } from "../../../mocks/server";
+import { writeDb$ } from "../../external/db";
+import { seedAgentRunCallback$ } from "./helpers/agent-run-callback";
+import { createFixtureTracker } from "./helpers/zero-route-test";
+import {
+  deleteUsageInsightFixture$,
+  seedCompose$,
+  seedRun$,
+  seedUsageInsightFixture$,
+  type UsageInsightFixture,
+} from "./helpers/zero-usage-insight";
+
+const context = testContext();
+const store = createStore();
+
+const PATH = "/api/internal/callbacks/github/issues";
+const TEST_CALLBACK_SECRET = "test-callback-secret";
+const GITHUB_APP_ID = "123456";
+const GITHUB_COMMENT_ID = "42";
+
+interface GitHubIssuesFixture extends UsageInsightFixture {
+  readonly composeId: string;
+}
+
+interface GitHubIssuesPayload {
+  readonly installationId: string;
+  readonly repo: string;
+  readonly issueNumber: number;
+  readonly agentId: string;
+  readonly existingSessionId?: string;
+  readonly triggerCommentId?: string;
+  readonly triggerReactionId?: string;
+  readonly triggerCommentBody?: string;
+}
+
+interface CapturedComment {
+  readonly owner: string;
+  readonly repo: string;
+  readonly issueNumber: string;
+  readonly body: string;
+}
+
+interface CapturedReactionDelete {
+  readonly commentId: string;
+  readonly reactionId: string;
+}
+
+function newPrivateKeyBase64(): string {
+  const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+  const pem = privateKey.export({ type: "pkcs8", format: "pem" });
+  return Buffer.from(pem).toString("base64");
+}
+
+function remoteInstallationId(): string {
+  return String(Math.floor(Math.random() * 9_000_000_000) + 1_000_000_000);
+}
+
+function mockGithubAppEnv(): void {
+  mockOptionalEnv("GITHUB_APP_ID", GITHUB_APP_ID);
+  mockOptionalEnv("GITHUB_APP_PRIVATE_KEY", newPrivateKeyBase64());
+}
+
+function setupGithubApiMocks(installationId: string): {
+  readonly capturedComments: CapturedComment[];
+  readonly capturedReactionDeletes: CapturedReactionDelete[];
+} {
+  const capturedComments: CapturedComment[] = [];
+  const capturedReactionDeletes: CapturedReactionDelete[] = [];
+
+  server.use(
+    http.post(
+      `https://api.github.com/app/installations/${installationId}/access_tokens`,
+      () => {
+        return HttpResponse.json({
+          token: "ghs_test_token",
+          expires_at: "2099-01-01T00:00:00Z",
+        });
+      },
+    ),
+    http.post(
+      "https://api.github.com/repos/:owner/:repo/issues/:issueNumber/comments",
+      async ({ params, request }) => {
+        const body = (await request.json()) as { readonly body: string };
+        capturedComments.push({
+          owner: String(params["owner"]),
+          repo: String(params["repo"]),
+          issueNumber: String(params["issueNumber"]),
+          body: body.body,
+        });
+        return HttpResponse.json({ id: Number(GITHUB_COMMENT_ID) });
+      },
+    ),
+    http.delete(
+      "https://api.github.com/repos/:owner/:repo/issues/comments/:commentId/reactions/:reactionId",
+      ({ params }) => {
+        capturedReactionDeletes.push({
+          commentId: String(params["commentId"]),
+          reactionId: String(params["reactionId"]),
+        });
+        return HttpResponse.json({});
+      },
+    ),
+  );
+
+  return { capturedComments, capturedReactionDeletes };
+}
+
+async function deleteFixture(fixture: GitHubIssuesFixture): Promise<void> {
+  const writeDb = store.set(writeDb$);
+  await writeDb
+    .delete(userFeatureSwitches)
+    .where(
+      and(
+        eq(userFeatureSwitches.orgId, fixture.orgId),
+        eq(userFeatureSwitches.userId, fixture.userId),
+      ),
+    );
+  await store.set(deleteUsageInsightFixture$, fixture, context.signal);
+}
+
+async function seedFixture(): Promise<GitHubIssuesFixture> {
+  const base = await store.set(
+    seedUsageInsightFixture$,
+    undefined,
+    context.signal,
+  );
+  const { composeId } = await store.set(
+    seedCompose$,
+    {
+      orgId: base.orgId,
+      userId: base.userId,
+      name: `github-issues-callback-${randomUUID().slice(0, 8)}`,
+      displayName: "GitHub Agent",
+    },
+    context.signal,
+  );
+  return { ...base, composeId };
+}
+
+async function seedGithubInstallation(args: {
+  readonly composeId: string;
+  readonly installationId?: string | null;
+  readonly status?: "active" | "pending";
+}): Promise<{
+  readonly id: string;
+  readonly installationId: string | null;
+}> {
+  const writeDb = store.set(writeDb$);
+  const [row] = await writeDb
+    .insert(githubInstallations)
+    .values({
+      defaultComposeId: args.composeId,
+      installationId:
+        args.installationId === undefined
+          ? remoteInstallationId()
+          : args.installationId,
+      status: args.status ?? "active",
+    })
+    .returning({
+      id: githubInstallations.id,
+      installationId: githubInstallations.installationId,
+    });
+
+  if (!row) {
+    throw new Error("seedGithubInstallation: insert returned no row");
+  }
+  return row;
+}
+
+async function seedRunAndCallback(args: {
+  readonly fixture: GitHubIssuesFixture;
+  readonly payload: GitHubIssuesPayload;
+}): Promise<{ readonly runId: string; readonly callbackId: string }> {
+  const createdAt = new Date(now() - 60_000);
+  const { runId } = await store.set(
+    seedRun$,
+    {
+      orgId: args.fixture.orgId,
+      userId: args.fixture.userId,
+      composeId: args.fixture.composeId,
+      triggerSource: "github",
+      prompt: "Handle GitHub issue",
+      createdAt,
+      lastEventSequence: 0,
+    },
+    context.signal,
+  );
+  const { callbackId } = await store.set(
+    seedAgentRunCallback$,
+    {
+      runId,
+      url: `http://localhost${PATH}`,
+      payload: args.payload as unknown as Record<string, unknown>,
+    },
+    context.signal,
+  );
+  return { runId, callbackId };
+}
+
+async function seedAgentSession(
+  fixture: GitHubIssuesFixture,
+): Promise<{ readonly id: string }> {
+  const writeDb = store.set(writeDb$);
+  const [row] = await writeDb
+    .insert(agentSessions)
+    .values({
+      userId: fixture.userId,
+      orgId: fixture.orgId,
+      agentComposeId: fixture.composeId,
+      updatedAt: nowDate(),
+    })
+    .returning({ id: agentSessions.id });
+  if (!row) {
+    throw new Error("seedAgentSession: insert returned no row");
+  }
+  return row;
+}
+
+async function seedIssueSession(args: {
+  readonly userId: string;
+  readonly installationId: string;
+  readonly repo: string;
+  readonly issueNumber: number;
+  readonly agentSessionId: string;
+  readonly lastCommentId: string;
+}): Promise<void> {
+  const writeDb = store.set(writeDb$);
+  await writeDb.insert(githubIssueSessions).values(args);
+}
+
+async function findIssueSession(args: {
+  readonly installationId: string;
+  readonly repo: string;
+  readonly issueNumber: number;
+}) {
+  const writeDb = store.set(writeDb$);
+  const [row] = await writeDb
+    .select()
+    .from(githubIssueSessions)
+    .where(
+      and(
+        eq(githubIssueSessions.installationId, args.installationId),
+        eq(githubIssueSessions.repo, args.repo),
+        eq(githubIssueSessions.issueNumber, args.issueNumber),
+      ),
+    )
+    .limit(1);
+  return row ?? null;
+}
+
+async function enableAuditLink(fixture: GitHubIssuesFixture): Promise<void> {
+  const writeDb = store.set(writeDb$);
+  await writeDb.insert(userFeatureSwitches).values({
+    orgId: fixture.orgId,
+    userId: fixture.userId,
+    switches: { [FeatureSwitchKey.AuditLink]: true },
+  });
+}
+
+function signedHeaders(rawBody: string, secret = TEST_CALLBACK_SECRET) {
+  const timestamp = Math.floor(now() / 1000);
+  return {
+    "Content-Type": "application/json",
+    "X-VM0-Signature": computeHmacSignature(rawBody, secret, timestamp),
+    "X-VM0-Timestamp": String(timestamp),
+  };
+}
+
+async function postSignedCallback(
+  body: Record<string, unknown>,
+  secret?: string,
+): Promise<Response> {
+  const rawBody = JSON.stringify(body);
+  const app = createApp({ signal: context.signal });
+  return await app.request(PATH, {
+    method: "POST",
+    headers: signedHeaders(rawBody, secret),
+    body: rawBody,
+  });
+}
+
+function completedOutput(): void {
+  context.mocks.axiom.query.mockResolvedValueOnce([
+    {
+      eventType: "result",
+      eventData: { result: "Implemented the requested issue fix." },
+    },
+  ]);
+}
+
+afterEach(() => {
+  context.mocks.axiom.query.mockReset();
+});
+
+describe("POST /api/internal/callbacks/github/issues", () => {
+  const track = createFixtureTracker<GitHubIssuesFixture>((fixture) => {
+    return deleteFixture(fixture);
+  });
+
+  it("rejects requests with invalid signatures", async () => {
+    const fixture = await track(seedFixture());
+    const installation = await seedGithubInstallation({
+      composeId: fixture.composeId,
+    });
+    const payload: GitHubIssuesPayload = {
+      installationId: installation.id,
+      repo: "test-org/test-repo",
+      issueNumber: 42,
+      agentId: fixture.composeId,
+    };
+    const { runId, callbackId } = await seedRunAndCallback({
+      fixture,
+      payload,
+    });
+
+    const response = await postSignedCallback(
+      { callbackId, runId, status: "completed", payload },
+      "wrong-secret",
+    );
+
+    expect(response.status).toBe(401);
+  });
+
+  it("returns 404 when no callback record exists", async () => {
+    const response = await postSignedCallback({
+      runId: "00000000-0000-0000-0000-000000000000",
+      status: "completed",
+      payload: {
+        installationId: "00000000-0000-0000-0000-000000000001",
+        repo: "test-org/test-repo",
+        issueNumber: 42,
+        agentId: "00000000-0000-0000-0000-000000000002",
+      },
+    });
+
+    expect(response.status).toBe(404);
+  });
+
+  it("rejects invalid payloads after callback verification", async () => {
+    const fixture = await track(seedFixture());
+    const payload: GitHubIssuesPayload = {
+      installationId: "00000000-0000-0000-0000-000000000001",
+      repo: "test-org/test-repo",
+      issueNumber: 42,
+      agentId: fixture.composeId,
+    };
+    const { runId, callbackId } = await seedRunAndCallback({
+      fixture,
+      payload,
+    });
+
+    const response = await postSignedCallback({
+      callbackId,
+      runId,
+      status: "completed",
+      payload: { installationId: payload.installationId },
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toStrictEqual({
+      error: "Invalid or missing payload",
+    });
+  });
+
+  it("returns success without side effects for progress callbacks", async () => {
+    const fixture = await track(seedFixture());
+    const payload: GitHubIssuesPayload = {
+      installationId: "00000000-0000-0000-0000-000000000001",
+      repo: "test-org/test-repo",
+      issueNumber: 42,
+      agentId: fixture.composeId,
+    };
+    const { runId, callbackId } = await seedRunAndCallback({
+      fixture,
+      payload,
+    });
+
+    const response = await postSignedCallback({
+      callbackId,
+      runId,
+      status: "progress",
+      payload,
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toStrictEqual({ success: true });
+    expect(context.mocks.axiom.query).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when the GitHub installation is missing", async () => {
+    const fixture = await track(seedFixture());
+    const payload: GitHubIssuesPayload = {
+      installationId: "00000000-0000-0000-0000-000000000099",
+      repo: "test-org/test-repo",
+      issueNumber: 42,
+      agentId: fixture.composeId,
+    };
+    const { runId, callbackId } = await seedRunAndCallback({
+      fixture,
+      payload,
+    });
+
+    const response = await postSignedCallback({
+      callbackId,
+      runId,
+      status: "completed",
+      payload,
+    });
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toStrictEqual({
+      error: "GitHub installation not found",
+    });
+  });
+
+  it("returns 400 when the GitHub installation is pending", async () => {
+    const fixture = await track(seedFixture());
+    const installation = await seedGithubInstallation({
+      composeId: fixture.composeId,
+      installationId: null,
+      status: "pending",
+    });
+    const payload: GitHubIssuesPayload = {
+      installationId: installation.id,
+      repo: "test-org/test-repo",
+      issueNumber: 42,
+      agentId: fixture.composeId,
+    };
+    const { runId, callbackId } = await seedRunAndCallback({
+      fixture,
+      payload,
+    });
+
+    const response = await postSignedCallback({
+      callbackId,
+      runId,
+      status: "completed",
+      payload,
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toStrictEqual({
+      error: "GitHub installation is pending approval",
+    });
+  });
+
+  it("returns 500 when GitHub App credentials are not configured", async () => {
+    const fixture = await track(seedFixture());
+    const installation = await seedGithubInstallation({
+      composeId: fixture.composeId,
+    });
+    const payload: GitHubIssuesPayload = {
+      installationId: installation.id,
+      repo: "test-org/test-repo",
+      issueNumber: 42,
+      agentId: fixture.composeId,
+    };
+    const { runId, callbackId } = await seedRunAndCallback({
+      fixture,
+      payload,
+    });
+
+    const response = await postSignedCallback({
+      callbackId,
+      runId,
+      status: "completed",
+      payload,
+    });
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toStrictEqual({
+      error: "GitHub App not configured",
+    });
+  });
+
+  it("posts a completed run comment without an audit link when the switch is off", async () => {
+    const fixture = await track(seedFixture());
+    const installation = await seedGithubInstallation({
+      composeId: fixture.composeId,
+    });
+    if (!installation.installationId) {
+      throw new Error("Expected active installation to have remote ID");
+    }
+    mockGithubAppEnv();
+    const { capturedComments } = setupGithubApiMocks(
+      installation.installationId,
+    );
+    const payload: GitHubIssuesPayload = {
+      installationId: installation.id,
+      repo: "test-org/test-repo",
+      issueNumber: 42,
+      agentId: fixture.composeId,
+    };
+    const { runId, callbackId } = await seedRunAndCallback({
+      fixture,
+      payload,
+    });
+    completedOutput();
+
+    const response = await postSignedCallback({
+      callbackId,
+      runId,
+      status: "completed",
+      payload,
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toStrictEqual({ success: true });
+    expect(capturedComments).toHaveLength(1);
+    expect(capturedComments[0]).toMatchObject({
+      owner: "test-org",
+      repo: "test-repo",
+      issueNumber: "42",
+    });
+    expect(capturedComments[0]!.body).toContain("GitHub Agent");
+    expect(capturedComments[0]!.body).toContain(
+      "Implemented the requested issue fix.",
+    );
+    expect(capturedComments[0]!.body).not.toContain("Audit");
+    expect(context.mocks.axiom.query).toHaveBeenCalledTimes(1);
+  });
+
+  it("includes an audit link when the AuditLink switch is on", async () => {
+    const fixture = await track(seedFixture());
+    const installation = await seedGithubInstallation({
+      composeId: fixture.composeId,
+    });
+    if (!installation.installationId) {
+      throw new Error("Expected active installation to have remote ID");
+    }
+    mockGithubAppEnv();
+    const { capturedComments } = setupGithubApiMocks(
+      installation.installationId,
+    );
+    await enableAuditLink(fixture);
+    const payload: GitHubIssuesPayload = {
+      installationId: installation.id,
+      repo: "test-org/test-repo",
+      issueNumber: 42,
+      agentId: fixture.composeId,
+    };
+    const { runId, callbackId } = await seedRunAndCallback({
+      fixture,
+      payload,
+    });
+    completedOutput();
+
+    const response = await postSignedCallback({
+      callbackId,
+      runId,
+      status: "completed",
+      payload,
+    });
+
+    expect(response.status).toBe(200);
+    expect(capturedComments).toHaveLength(1);
+    expect(capturedComments[0]!.body).toContain("Audit");
+    expect(capturedComments[0]!.body).toContain(`/activities/${runId}`);
+  });
+
+  it("posts a failed run comment with the run error", async () => {
+    const fixture = await track(seedFixture());
+    const installation = await seedGithubInstallation({
+      composeId: fixture.composeId,
+    });
+    if (!installation.installationId) {
+      throw new Error("Expected active installation to have remote ID");
+    }
+    mockGithubAppEnv();
+    const { capturedComments } = setupGithubApiMocks(
+      installation.installationId,
+    );
+    const payload: GitHubIssuesPayload = {
+      installationId: installation.id,
+      repo: "test-org/test-repo",
+      issueNumber: 42,
+      agentId: fixture.composeId,
+    };
+    const { runId, callbackId } = await seedRunAndCallback({
+      fixture,
+      payload,
+    });
+
+    const response = await postSignedCallback({
+      callbackId,
+      runId,
+      status: "failed",
+      error: "Agent crashed unexpectedly",
+      payload,
+    });
+
+    expect(response.status).toBe(200);
+    expect(capturedComments).toHaveLength(1);
+    expect(capturedComments[0]!.body).toContain("**Error:**");
+    expect(capturedComments[0]!.body).toContain("Agent crashed unexpectedly");
+    expect(context.mocks.axiom.query).not.toHaveBeenCalled();
+  });
+
+  it("quotes the trigger comment and removes the trigger reaction", async () => {
+    const fixture = await track(seedFixture());
+    const installation = await seedGithubInstallation({
+      composeId: fixture.composeId,
+    });
+    if (!installation.installationId) {
+      throw new Error("Expected active installation to have remote ID");
+    }
+    mockGithubAppEnv();
+    const { capturedComments, capturedReactionDeletes } = setupGithubApiMocks(
+      installation.installationId,
+    );
+    const payload: GitHubIssuesPayload = {
+      installationId: installation.id,
+      repo: "test-org/test-repo",
+      issueNumber: 42,
+      agentId: fixture.composeId,
+      triggerCommentId: "100",
+      triggerReactionId: "200",
+      triggerCommentBody: "@vm0 please fix this\nwith context",
+    };
+    const { runId, callbackId } = await seedRunAndCallback({
+      fixture,
+      payload,
+    });
+    completedOutput();
+
+    const response = await postSignedCallback({
+      callbackId,
+      runId,
+      status: "completed",
+      payload,
+    });
+
+    expect(response.status).toBe(200);
+    expect(capturedComments[0]!.body).toContain("> @vm0 please fix this");
+    expect(capturedComments[0]!.body).toContain("> with context");
+    expect(capturedReactionDeletes).toStrictEqual([
+      { commentId: "100", reactionId: "200" },
+    ]);
+  });
+
+  it("creates a GitHub issue session for a new issue", async () => {
+    const fixture = await track(seedFixture());
+    const installation = await seedGithubInstallation({
+      composeId: fixture.composeId,
+    });
+    if (!installation.installationId) {
+      throw new Error("Expected active installation to have remote ID");
+    }
+    mockGithubAppEnv();
+    setupGithubApiMocks(installation.installationId);
+    const payload: GitHubIssuesPayload = {
+      installationId: installation.id,
+      repo: "test-org/test-repo",
+      issueNumber: 42,
+      agentId: fixture.composeId,
+    };
+    const { runId, callbackId } = await seedRunAndCallback({
+      fixture,
+      payload,
+    });
+    const session = await seedAgentSession(fixture);
+    completedOutput();
+
+    const response = await postSignedCallback({
+      callbackId,
+      runId,
+      status: "completed",
+      payload,
+    });
+
+    expect(response.status).toBe(200);
+    const issueSession = await findIssueSession({
+      installationId: installation.id,
+      repo: payload.repo,
+      issueNumber: payload.issueNumber,
+    });
+    expect(issueSession).not.toBeNull();
+    expect(issueSession!.agentSessionId).toBe(session.id);
+    expect(issueSession!.userId).toBe(fixture.userId);
+    expect(issueSession!.lastCommentId).toBe(GITHUB_COMMENT_ID);
+  });
+
+  it("updates lastCommentId for an existing issue session on completed runs", async () => {
+    const fixture = await track(seedFixture());
+    const installation = await seedGithubInstallation({
+      composeId: fixture.composeId,
+    });
+    if (!installation.installationId) {
+      throw new Error("Expected active installation to have remote ID");
+    }
+    mockGithubAppEnv();
+    setupGithubApiMocks(installation.installationId);
+    const session = await seedAgentSession(fixture);
+    const payload: GitHubIssuesPayload = {
+      installationId: installation.id,
+      repo: "test-org/test-repo",
+      issueNumber: 42,
+      agentId: fixture.composeId,
+      existingSessionId: "existing-session-id",
+    };
+    await seedIssueSession({
+      userId: fixture.userId,
+      installationId: installation.id,
+      repo: payload.repo,
+      issueNumber: payload.issueNumber,
+      agentSessionId: session.id,
+      lastCommentId: "old-comment-id",
+    });
+    const { runId, callbackId } = await seedRunAndCallback({
+      fixture,
+      payload,
+    });
+    completedOutput();
+
+    const response = await postSignedCallback({
+      callbackId,
+      runId,
+      status: "completed",
+      payload,
+    });
+
+    expect(response.status).toBe(200);
+    const issueSession = await findIssueSession({
+      installationId: installation.id,
+      repo: payload.repo,
+      issueNumber: payload.issueNumber,
+    });
+    expect(issueSession).not.toBeNull();
+    expect(issueSession!.lastCommentId).toBe(GITHUB_COMMENT_ID);
+  });
+});

--- a/turbo/apps/api/src/signals/routes/internal-callbacks-github-issues.ts
+++ b/turbo/apps/api/src/signals/routes/internal-callbacks-github-issues.ts
@@ -1,0 +1,363 @@
+import { command } from "ccstate";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import { isFeatureEnabled } from "@vm0/core/feature-switch";
+import {
+  githubIssuesCallbackPayloadSchema,
+  internalCallbacksGithubIssuesContract,
+  type GitHubIssuesCallbackPayload,
+} from "@vm0/api-contracts/contracts/internal-callbacks-github-issues";
+import { agentRuns } from "@vm0/db/schema/agent-run";
+import { agentSessions } from "@vm0/db/schema/agent-session";
+import { githubInstallations } from "@vm0/db/schema/github-installation";
+import { githubIssueSessions } from "@vm0/db/schema/github-issue-session";
+import { zeroAgents } from "@vm0/db/schema/zero-agent";
+import { and, desc, eq, gte } from "drizzle-orm";
+
+import {
+  callbackPayload$,
+  callbackRoute,
+} from "../../lib/callback-route/callback-route";
+import type { RouteEntry } from "../route";
+import { optionalEnv, env } from "../../lib/env";
+import { logger } from "../../lib/log";
+import { writeDb$, type Db } from "../external/db";
+import { nowDate } from "../external/time";
+import { getGithubInstallationAccessToken } from "../services/github-app.service";
+import {
+  postGithubIssueComment,
+  removeGithubCommentReaction,
+} from "../services/github-issues-api.service";
+import { getRunOutputText } from "../services/run-output.service";
+import { userFeatureSwitchOverrides } from "../services/feature-switches.service";
+
+const L = logger("InternalCallbacksGithubIssues");
+
+function successResponse(): {
+  readonly status: 200;
+  readonly body: { readonly success: true };
+} {
+  return { status: 200, body: { success: true } };
+}
+
+function errorResponse(
+  status: 400 | 404 | 500,
+  message: string,
+): {
+  readonly status: 400 | 404 | 500;
+  readonly body: { readonly error: string };
+} {
+  return { status, body: { error: message } };
+}
+
+function parsePayload(payload: unknown): GitHubIssuesCallbackPayload | null {
+  const result = githubIssuesCallbackPayloadSchema.safeParse(payload);
+  return result.success ? result.data : null;
+}
+
+async function findNewSessionId(args: {
+  readonly db: Db;
+  readonly userId: string;
+  readonly agentId: string;
+  readonly runCreatedAt: Date;
+  readonly signal: AbortSignal;
+}): Promise<string | undefined> {
+  const [newSession] = await args.db
+    .select({ id: agentSessions.id })
+    .from(agentSessions)
+    .where(
+      and(
+        eq(agentSessions.userId, args.userId),
+        eq(agentSessions.agentComposeId, args.agentId),
+        gte(agentSessions.updatedAt, args.runCreatedAt),
+      ),
+    )
+    .orderBy(desc(agentSessions.updatedAt))
+    .limit(1);
+  args.signal.throwIfAborted();
+  return newSession?.id;
+}
+
+async function resolveAgentInfo(args: {
+  readonly db: Db;
+  readonly agentId: string;
+  readonly signal: AbortSignal;
+}): Promise<{ readonly label: string; readonly name: string }> {
+  const [agentRow] = await args.db
+    .select({ displayName: zeroAgents.displayName, name: zeroAgents.name })
+    .from(zeroAgents)
+    .where(eq(zeroAgents.id, args.agentId))
+    .limit(1);
+  args.signal.throwIfAborted();
+
+  return {
+    label: agentRow?.displayName ?? agentRow?.name ?? "your agent",
+    name: agentRow?.name ?? "your agent",
+  };
+}
+
+async function saveIssueSession(args: {
+  readonly db: Db;
+  readonly runId: string;
+  readonly agentId: string;
+  readonly installationId: string;
+  readonly repo: string;
+  readonly issueNumber: number;
+  readonly existingSessionId: string | undefined;
+  readonly commentId: string;
+  readonly status: "completed" | "failed";
+  readonly signal: AbortSignal;
+}): Promise<void> {
+  const [run] = await args.db
+    .select({ userId: agentRuns.userId, createdAt: agentRuns.createdAt })
+    .from(agentRuns)
+    .where(eq(agentRuns.id, args.runId))
+    .limit(1);
+  args.signal.throwIfAborted();
+
+  if (!run) {
+    return;
+  }
+
+  const newSessionId = !args.existingSessionId
+    ? await findNewSessionId({
+        db: args.db,
+        userId: run.userId,
+        agentId: args.agentId,
+        runCreatedAt: run.createdAt,
+        signal: args.signal,
+      })
+    : undefined;
+
+  if (!args.existingSessionId && newSessionId) {
+    await args.db
+      .insert(githubIssueSessions)
+      .values({
+        userId: run.userId,
+        installationId: args.installationId,
+        repo: args.repo,
+        issueNumber: args.issueNumber,
+        agentSessionId: newSessionId,
+        lastCommentId: args.commentId,
+      })
+      .onConflictDoNothing();
+    args.signal.throwIfAborted();
+  } else if (
+    args.existingSessionId &&
+    args.status === "completed" &&
+    args.commentId
+  ) {
+    await args.db
+      .update(githubIssueSessions)
+      .set({
+        lastCommentId: args.commentId,
+        updatedAt: nowDate(),
+      })
+      .where(
+        and(
+          eq(githubIssueSessions.installationId, args.installationId),
+          eq(githubIssueSessions.repo, args.repo),
+          eq(githubIssueSessions.issueNumber, args.issueNumber),
+        ),
+      );
+    args.signal.throwIfAborted();
+  }
+}
+
+function formatGitHubComment(args: {
+  readonly status: "completed" | "failed";
+  readonly agentName: string;
+  readonly logsUrl?: string;
+  readonly output?: string;
+  readonly error?: string;
+  readonly triggerCommentBody?: string;
+}): string {
+  const content =
+    args.status === "completed"
+      ? (args.output ?? "Task completed successfully.")
+      : `**Error:** ${args.error ?? "Agent execution failed."}`;
+
+  const parts: string[] = [];
+  if (args.triggerCommentBody) {
+    const quoted = args.triggerCommentBody
+      .split("\n")
+      .map((line) => {
+        return `> ${line}`;
+      })
+      .join("\n");
+    parts.push(quoted, "");
+  }
+
+  parts.push(`<sub>🤖 **${args.agentName}**</sub>`, "", content);
+  if (args.logsUrl) {
+    parts.push("", `<sub>📋 [Audit](${args.logsUrl})</sub>`);
+  }
+
+  return parts.join("\n");
+}
+
+async function resolveGitHubAuditLogsUrl(args: {
+  readonly db: Db;
+  readonly runId: string;
+  readonly getFeatureOverrides: (
+    orgId: string,
+    userId: string,
+  ) => Promise<Record<string, boolean>>;
+  readonly signal: AbortSignal;
+}): Promise<string | undefined> {
+  const [run] = await args.db
+    .select({ userId: agentRuns.userId, orgId: agentRuns.orgId })
+    .from(agentRuns)
+    .where(eq(agentRuns.id, args.runId))
+    .limit(1);
+  args.signal.throwIfAborted();
+  if (!run) {
+    return undefined;
+  }
+
+  const overrides = await args.getFeatureOverrides(run.orgId, run.userId);
+  args.signal.throwIfAborted();
+  const typedOverrides =
+    Object.keys(overrides).length > 0
+      ? (overrides as Partial<Record<FeatureSwitchKey, boolean>>)
+      : undefined;
+  const enabled = isFeatureEnabled(FeatureSwitchKey.AuditLink, {
+    userId: run.userId,
+    orgId: run.orgId,
+    overrides: typedOverrides,
+  });
+  if (!enabled) {
+    return undefined;
+  }
+
+  return `${env("VM0_WEB_URL")}/activities/${encodeURIComponent(args.runId)}`;
+}
+
+const handleGithubIssuesCallback$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const callback = get(callbackPayload$);
+    const payload = parsePayload(callback.payload);
+    if (!payload) {
+      return errorResponse(400, "Invalid or missing payload");
+    }
+
+    const { runId, status, error } = callback;
+    const { installationId, repo, issueNumber, agentId, existingSessionId } =
+      payload;
+
+    L.debug("Processing GitHub issues callback", {
+      runId,
+      status,
+      repo,
+      issueNumber,
+    });
+
+    if (status === "progress") {
+      return successResponse();
+    }
+
+    const db = set(writeDb$);
+    const [installation] = await db
+      .select()
+      .from(githubInstallations)
+      .where(eq(githubInstallations.id, installationId))
+      .limit(1);
+    signal.throwIfAborted();
+
+    if (!installation) {
+      L.error("GitHub installation not found", { installationId });
+      return errorResponse(404, "GitHub installation not found");
+    }
+
+    if (!installation.installationId) {
+      L.error("GitHub installation is pending, cannot post comment", {
+        installationId,
+      });
+      return errorResponse(400, "GitHub installation is pending approval");
+    }
+
+    const appId = optionalEnv("GITHUB_APP_ID");
+    const privateKey = optionalEnv("GITHUB_APP_PRIVATE_KEY");
+    if (!appId || !privateKey) {
+      L.error("GitHub App credentials not configured");
+      return errorResponse(500, "GitHub App not configured");
+    }
+
+    const { token } = await getGithubInstallationAccessToken({
+      appId,
+      privateKey,
+      installationId: installation.installationId,
+      signal,
+    });
+    signal.throwIfAborted();
+
+    const agent = await resolveAgentInfo({ db, agentId, signal });
+    const output =
+      status === "completed"
+        ? await getRunOutputText(runId, { signal })
+        : undefined;
+    signal.throwIfAborted();
+
+    const logsUrl = await resolveGitHubAuditLogsUrl({
+      db,
+      runId,
+      getFeatureOverrides: (orgId, userId) => {
+        return get(userFeatureSwitchOverrides(orgId, userId));
+      },
+      signal,
+    });
+    const commentBody = formatGitHubComment({
+      status,
+      agentName: agent.label,
+      logsUrl,
+      output,
+      error,
+      triggerCommentBody: payload.triggerCommentBody,
+    });
+    const commentId = await postGithubIssueComment({
+      token,
+      repo,
+      issueNumber,
+      body: commentBody,
+      signal,
+    });
+    signal.throwIfAborted();
+
+    if (payload.triggerCommentId && payload.triggerReactionId) {
+      await removeGithubCommentReaction({
+        token,
+        repo,
+        commentId: payload.triggerCommentId,
+        reactionId: payload.triggerReactionId,
+        signal,
+      });
+      signal.throwIfAborted();
+    }
+
+    await saveIssueSession({
+      db,
+      runId,
+      agentId,
+      installationId,
+      repo,
+      issueNumber,
+      existingSessionId,
+      commentId,
+      status,
+      signal,
+    });
+
+    L.debug("GitHub issues callback processed successfully", {
+      runId,
+      commentId,
+    });
+
+    return successResponse();
+  },
+);
+
+export const internalCallbacksGithubIssuesRoutes: readonly RouteEntry[] = [
+  {
+    route: internalCallbacksGithubIssuesContract.post,
+    handler: callbackRoute(handleGithubIssuesCallback$),
+  },
+];

--- a/turbo/apps/api/src/signals/services/github-app.service.ts
+++ b/turbo/apps/api/src/signals/services/github-app.service.ts
@@ -1,0 +1,102 @@
+import { Buffer } from "node:buffer";
+import { createSign } from "node:crypto";
+
+import { now } from "../../lib/time";
+
+const INSTALLATION_ID_RE = /^\d+$/;
+
+function validateInstallationId(installationId: string): string {
+  if (!INSTALLATION_ID_RE.test(installationId)) {
+    throw new Error(
+      `Invalid GitHub installation ID: expected numeric string, got "${installationId}"`,
+    );
+  }
+  return installationId;
+}
+
+function base64url(value: string): string {
+  return Buffer.from(value)
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+function parsePemKey(input: string): string {
+  if (!input.startsWith("-----BEGIN")) {
+    return Buffer.from(input, "base64").toString("utf8");
+  }
+
+  const match = input.match(
+    /^(-----BEGIN [^-]+-----)[\s]+([\s\S]+?)[\s]+(-----END [^-]+-----)$/,
+  );
+  if (!match) {
+    return input;
+  }
+
+  const header = match[1];
+  const bodyMatch = match[2];
+  const footer = match[3];
+  if (!header || !bodyMatch || !footer) {
+    return input;
+  }
+
+  const body = bodyMatch.replace(/\s+/g, "\n");
+  return `${header}\n${body}\n${footer}\n`;
+}
+
+function createAppJwt(appId: string, privateKeyPemOrBase64: string): string {
+  const nowSeconds = Math.floor(now() / 1000);
+  const encodedHeader = base64url(JSON.stringify({ alg: "RS256", typ: "JWT" }));
+  const encodedPayload = base64url(
+    JSON.stringify({
+      iat: nowSeconds - 60,
+      exp: nowSeconds + 600,
+      iss: appId,
+    }),
+  );
+  const signingInput = `${encodedHeader}.${encodedPayload}`;
+  const signer = createSign("RSA-SHA256");
+  signer.update(signingInput);
+  const signature = signer.sign(
+    parsePemKey(privateKeyPemOrBase64),
+    "base64url",
+  );
+
+  return `${signingInput}.${signature}`;
+}
+
+export async function getGithubInstallationAccessToken(args: {
+  readonly appId: string;
+  readonly privateKey: string;
+  readonly installationId: string;
+  readonly signal: AbortSignal;
+}): Promise<{ readonly token: string; readonly expiresAt: string }> {
+  const installationId = validateInstallationId(args.installationId);
+  const jwt = createAppJwt(args.appId, args.privateKey);
+  const response = await fetch(
+    `https://api.github.com/app/installations/${installationId}/access_tokens`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${jwt}`,
+        Accept: "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+      signal: args.signal,
+    },
+  );
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(
+      `Failed to get installation access token: ${response.status} ${body}`,
+    );
+  }
+
+  const data = (await response.json()) as {
+    readonly token: string;
+    readonly expires_at: string;
+  };
+  return { token: data.token, expiresAt: data.expires_at };
+}

--- a/turbo/apps/api/src/signals/services/github-issues-api.service.ts
+++ b/turbo/apps/api/src/signals/services/github-issues-api.service.ts
@@ -1,0 +1,80 @@
+import { logger } from "../../lib/log";
+import { safeAsync } from "../utils";
+
+const GITHUB_API_BASE = "https://api.github.com";
+const L = logger("GithubIssuesApi");
+
+const GITHUB_HEADERS = {
+  Accept: "application/vnd.github+json",
+  "X-GitHub-Api-Version": "2022-11-28",
+} as const;
+
+function authHeaders(token: string): Record<string, string> {
+  return {
+    Authorization: `Bearer ${token}`,
+    ...GITHUB_HEADERS,
+  };
+}
+
+export async function postGithubIssueComment(args: {
+  readonly token: string;
+  readonly repo: string;
+  readonly issueNumber: number;
+  readonly body: string;
+  readonly signal: AbortSignal;
+}): Promise<string> {
+  const response = await fetch(
+    `${GITHUB_API_BASE}/repos/${args.repo}/issues/${args.issueNumber}/comments`,
+    {
+      method: "POST",
+      headers: authHeaders(args.token),
+      body: JSON.stringify({ body: args.body }),
+      signal: args.signal,
+    },
+  );
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(
+      `Failed to post GitHub comment: ${response.status} ${body}`,
+    );
+  }
+
+  const data = (await response.json()) as { readonly id: number };
+  return String(data.id);
+}
+
+export async function removeGithubCommentReaction(args: {
+  readonly token: string;
+  readonly repo: string;
+  readonly commentId: string;
+  readonly reactionId: string;
+  readonly signal: AbortSignal;
+}): Promise<void> {
+  const result = await safeAsync(async (): Promise<void> => {
+    const response = await fetch(
+      `${GITHUB_API_BASE}/repos/${args.repo}/issues/comments/${args.commentId}/reactions/${args.reactionId}`,
+      {
+        method: "DELETE",
+        headers: authHeaders(args.token),
+        signal: args.signal,
+      },
+    );
+
+    if (!response.ok) {
+      L.warn("Failed to remove comment reaction", {
+        commentId: args.commentId,
+        reactionId: args.reactionId,
+        status: response.status,
+      });
+    }
+  });
+
+  if ("error" in result) {
+    L.warn("Failed to remove comment reaction", {
+      commentId: args.commentId,
+      reactionId: args.reactionId,
+      error: result.error,
+    });
+  }
+}

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -1229,6 +1229,12 @@ export {
   type InternalCallbacksAgentContract,
 } from "./internal-callbacks-agent";
 export {
+  githubIssuesCallbackPayloadSchema,
+  internalCallbacksGithubIssuesContract,
+  type GitHubIssuesCallbackPayload,
+  type InternalCallbacksGithubIssuesContract,
+} from "./internal-callbacks-github-issues";
+export {
   internalCallbacksScheduleContract,
   scheduleCronCallbackPayloadSchema,
   scheduleLoopCallbackPayloadSchema,

--- a/turbo/packages/api-contracts/src/contracts/internal-callbacks-github-issues.ts
+++ b/turbo/packages/api-contracts/src/contracts/internal-callbacks-github-issues.ts
@@ -1,0 +1,49 @@
+import { z } from "zod";
+
+import { initContract } from "./base";
+import {
+  internalCallbackBodySchema,
+  internalCallbackErrorSchema,
+  internalCallbackHeadersSchema,
+  internalCallbackSuccessSchema,
+} from "./internal-callbacks-shared";
+
+const c = initContract();
+
+export const githubIssuesCallbackPayloadSchema = z
+  .object({
+    installationId: z.string(),
+    repo: z.string(),
+    issueNumber: z.number(),
+    agentId: z.string(),
+    existingSessionId: z.string().optional(),
+    triggerCommentId: z.string().optional(),
+    triggerReactionId: z.string().optional(),
+    triggerCommentBody: z.string().optional(),
+  })
+  .passthrough();
+
+export const internalCallbacksGithubIssuesContract = c.router({
+  post: {
+    method: "POST",
+    path: "/api/internal/callbacks/github/issues",
+    headers: internalCallbackHeadersSchema,
+    body: internalCallbackBodySchema.extend({
+      payload: githubIssuesCallbackPayloadSchema,
+    }),
+    responses: {
+      200: internalCallbackSuccessSchema,
+      400: internalCallbackErrorSchema,
+      401: internalCallbackErrorSchema,
+      404: internalCallbackErrorSchema,
+      500: internalCallbackErrorSchema,
+    },
+    summary: "Handle callbacks for GitHub issue-triggered runs",
+  },
+});
+
+export type GitHubIssuesCallbackPayload = z.infer<
+  typeof githubIssuesCallbackPayloadSchema
+>;
+export type InternalCallbacksGithubIssuesContract =
+  typeof internalCallbacksGithubIssuesContract;


### PR DESCRIPTION
## Summary
- add the API contract and registered Hono route for POST /api/internal/callbacks/github/issues
- port GitHub App token, issue comment, reaction cleanup, audit-link, and issue-session persistence behavior to API-side services
- add API integration coverage for callback verification, validation, GitHub side effects, audit links, and session persistence

## Validation
- pnpm -F api exec vitest --run src/signals/routes/__tests__/internal-callbacks-github-issues.test.ts
- pnpm -F api lint
- pnpm check-types
- pnpm knip

Closes #13067