### PR TITLE
refactor(api): migrate telegram callback

### DIFF
--- a/turbo/apps/api/src/lib/telegram-format.ts
+++ b/turbo/apps/api/src/lib/telegram-format.ts
@@ -1,3 +1,6 @@
+/** Maximum message length allowed by Telegram */
+const MAX_MESSAGE_LENGTH = 4096;
+
 /**
  * Escape HTML special characters for Telegram HTML parse mode.
  */
@@ -112,4 +115,91 @@ export function buildTelegramResponse(
   }
 
   return `${content}\n\n${footers.join("\n")}`;
+}
+
+/**
+ * Build a structured error response for Telegram.
+ */
+export function buildTelegramErrorResponse(
+  errorDetail: string,
+  logsUrl?: string,
+  footerText?: string,
+): string {
+  const header = `❌ <b>Agent Execution Error</b>`;
+  const content = markdownToTelegramHtml(errorDetail);
+  const footers: string[] = [];
+
+  if (logsUrl) {
+    footers.push(
+      mutedTelegramFooter(`<a href="${escapeHtml(logsUrl)}">📋 Audit</a>`),
+    );
+  }
+  if (footerText) {
+    footers.push(mutedTelegramFooter(footerText));
+  }
+
+  if (footers.length === 0) {
+    return `${header}\n\n${content}`;
+  }
+
+  return `${header}\n\n${content}\n\n${footers.join("\n")}`;
+}
+
+/**
+ * Split a message into chunks that fit within Telegram's message length limit.
+ */
+export function splitMessage(
+  text: string,
+  maxLength: number = MAX_MESSAGE_LENGTH,
+): string[] {
+  if (text.length <= maxLength) {
+    return [text];
+  }
+
+  const chunks: string[] = [];
+  let remaining = text;
+
+  while (remaining.length > 0) {
+    if (remaining.length <= maxLength) {
+      chunks.push(remaining);
+      break;
+    }
+
+    const window = remaining.slice(0, maxLength);
+    const codeBlockOpens = (window.match(/```/g) ?? []).length;
+    if (codeBlockOpens % 2 !== 0) {
+      const lastOpenIndex = window.lastIndexOf("```");
+      if (lastOpenIndex > 0) {
+        chunks.push(remaining.slice(0, lastOpenIndex).trimEnd());
+        remaining = remaining.slice(lastOpenIndex);
+        continue;
+      }
+      const closingIndex = remaining.indexOf("```", 3);
+      if (closingIndex !== -1) {
+        const endIndex = closingIndex + 3;
+        chunks.push(remaining.slice(0, endIndex));
+        remaining = remaining.slice(endIndex).replace(/^\n/, "");
+        continue;
+      }
+    }
+
+    const lastParagraph = window.lastIndexOf("\n\n");
+    if (lastParagraph > maxLength / 4) {
+      chunks.push(remaining.slice(0, lastParagraph).trimEnd());
+      remaining = remaining.slice(lastParagraph + 2);
+      continue;
+    }
+
+    const lastNewline = window.lastIndexOf("\n");
+    if (lastNewline > maxLength / 4) {
+      chunks.push(remaining.slice(0, lastNewline).trimEnd());
+      remaining = remaining.slice(lastNewline + 1);
+      continue;
+    }
+
+    chunks.push(remaining.slice(0, maxLength));
+    remaining = remaining.slice(maxLength);
+  }
+
+  return chunks;
 }

--- a/turbo/apps/api/src/signals/external/telegram-client.ts
+++ b/turbo/apps/api/src/signals/external/telegram-client.ts
@@ -177,7 +177,35 @@ export async function sendChatAction(
   }
 }
 
-type SendTelegramMessageResult =
+/**
+ * Delete a Telegram message.
+ *
+ * Response failures throw; callers that want best-effort cleanup should use
+ * safeAsync around this function.
+ */
+export async function deleteMessage(
+  token: string,
+  chatId: string,
+  messageId: number,
+): Promise<void> {
+  const url = `https://api.telegram.org/bot${token}/deleteMessage`;
+  const response = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ chat_id: chatId, message_id: messageId }),
+  });
+  if (!response.ok) {
+    throw new Error(
+      `Telegram API error: ${response.status} ${response.statusText}`,
+    );
+  }
+  const data: unknown = await response.json();
+  if (isTelegramApiErrorPayload(data)) {
+    throw new Error(`Telegram API error: ${data.description}`);
+  }
+}
+
+export type SendTelegramMessageResult =
   | {
       readonly kind: "ok";
       readonly messageId: number;

--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -32,6 +32,7 @@ import { githubOauthRoutes } from "./routes/github-oauth";
 import { internalCallbacksAgentRoutes } from "./routes/internal-callbacks-agent";
 import { internalCallbacksGithubIssuesRoutes } from "./routes/internal-callbacks-github-issues";
 import { internalCallbacksScheduleRoutes } from "./routes/internal-callbacks-schedule";
+import { internalCallbacksTelegramRoutes } from "./routes/internal-callbacks-telegram";
 import { internalEventConsumerAxiomRoutes } from "./routes/internal-event-consumers-axiom";
 import { internalEventConsumerChatAssistantRoutes } from "./routes/internal-event-consumers-chat-assistant";
 import { internalEventConsumerTelegramTypingRoutes } from "./routes/internal-event-consumers-telegram-typing";
@@ -153,6 +154,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...internalCallbacksAgentRoutes,
   ...internalCallbacksGithubIssuesRoutes,
   ...internalCallbacksScheduleRoutes,
+  ...internalCallbacksTelegramRoutes,
   ...internalEventConsumerAxiomRoutes,
   ...internalEventConsumerChatAssistantRoutes,
   ...internalEventConsumerTelegramTypingRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-telegram.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-telegram.test.ts
@@ -1,0 +1,578 @@
+import { randomUUID } from "node:crypto";
+
+import { createStore } from "ccstate";
+import { and, eq } from "drizzle-orm";
+import { HttpResponse, http } from "msw";
+import { afterEach, describe, expect, it } from "vitest";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import { OFFICIAL_TELEGRAM_BOT_ID } from "@vm0/api-contracts/contracts/zero-integrations-telegram";
+import { agentRuns } from "@vm0/db/schema/agent-run";
+import { agentSessions } from "@vm0/db/schema/agent-session";
+import { modelProviders } from "@vm0/db/schema/model-provider";
+import { telegramInstallations } from "@vm0/db/schema/telegram-installation";
+import { telegramMessages } from "@vm0/db/schema/telegram-message";
+import { telegramOfficialUserLinks } from "@vm0/db/schema/telegram-official-user-link";
+import { telegramThreadSessions } from "@vm0/db/schema/telegram-thread-session";
+import { telegramUserLinks } from "@vm0/db/schema/telegram-user-link";
+import { userFeatureSwitches } from "@vm0/db/schema/user-feature-switches";
+import { zeroRuns } from "@vm0/db/schema/zero-run";
+
+import { createApp } from "../../../app-factory";
+import { testContext } from "../../../__tests__/test-helpers";
+import { computeHmacSignature } from "../../../lib/event-consumer/hmac";
+import { clearMockedEnv, mockEnv } from "../../../lib/env";
+import { now } from "../../../lib/time";
+import { server } from "../../../mocks/server";
+import { writeDb$ } from "../../external/db";
+import { seedAgentRunCallback$ } from "./helpers/agent-run-callback";
+import { encryptSecretForTests } from "./helpers/encrypt-secret";
+import { createFixtureTracker } from "./helpers/zero-route-test";
+import {
+  deleteUsageInsightFixture$,
+  seedCompose$,
+  seedRun$,
+  seedUsageInsightFixture$,
+  type UsageInsightFixture,
+} from "./helpers/zero-usage-insight";
+
+const context = testContext();
+const store = createStore();
+
+const PATH = "/api/internal/callbacks/telegram";
+const TEST_CALLBACK_SECRET = "test-callback-secret";
+const TEST_BOT_TOKEN = "test-bot-token";
+const OFFICIAL_BOT_TOKEN = "123456:official-test-token";
+
+interface TelegramCallbackPayload {
+  readonly installationId: string;
+  readonly chatId: string;
+  readonly messageId: string;
+  readonly rootMessageId?: string | null;
+  readonly userLinkId: string;
+  readonly agentId: string;
+  readonly existingSessionId?: string | null;
+  readonly isDM: boolean;
+  readonly thinkingMessageId?: string | null;
+}
+
+interface TelegramFixture extends UsageInsightFixture {
+  readonly composeId: string;
+  readonly installationId: string;
+  readonly userLinkId: string;
+  readonly runId: string;
+  readonly callbackId: string;
+  readonly payload: TelegramCallbackPayload;
+}
+
+interface TelegramSendMessageBody {
+  readonly chat_id: string;
+  readonly text: string;
+  readonly parse_mode?: string;
+  readonly reply_parameters?: { readonly message_id: number };
+}
+
+function telegramApiMocks(token = TEST_BOT_TOKEN): {
+  readonly chatActions: unknown[];
+  readonly deleteMessages: unknown[];
+  readonly sentMessages: TelegramSendMessageBody[];
+} {
+  const chatActions: unknown[] = [];
+  const deleteMessages: unknown[] = [];
+  const sentMessages: TelegramSendMessageBody[] = [];
+  let nextMessageId = 900;
+
+  server.use(
+    http.post(
+      `https://api.telegram.org/bot${token}/sendChatAction`,
+      async ({ request }) => {
+        chatActions.push(await request.json());
+        return HttpResponse.json({ ok: true, result: true });
+      },
+    ),
+    http.post(
+      `https://api.telegram.org/bot${token}/deleteMessage`,
+      async ({ request }) => {
+        deleteMessages.push(await request.json());
+        return HttpResponse.json({ ok: true, result: true });
+      },
+    ),
+    http.post(
+      `https://api.telegram.org/bot${token}/sendMessage`,
+      async ({ request }) => {
+        const body = (await request.json()) as TelegramSendMessageBody;
+        sentMessages.push(body);
+        return HttpResponse.json({
+          ok: true,
+          result: {
+            message_id: nextMessageId++,
+            chat: { id: Number(body.chat_id) || 123 },
+            text: body.text,
+          },
+        });
+      },
+    ),
+  );
+
+  return { chatActions, deleteMessages, sentMessages };
+}
+
+async function deleteFixture(fixture: TelegramFixture): Promise<void> {
+  const db = store.set(writeDb$);
+  await db
+    .delete(telegramThreadSessions)
+    .where(eq(telegramThreadSessions.telegramUserLinkId, fixture.userLinkId));
+  await db
+    .delete(telegramMessages)
+    .where(eq(telegramMessages.installationId, fixture.installationId));
+  await db
+    .delete(telegramMessages)
+    .where(eq(telegramMessages.officialOrgId, fixture.orgId));
+  await db
+    .delete(telegramUserLinks)
+    .where(eq(telegramUserLinks.id, fixture.userLinkId));
+  await db
+    .delete(telegramInstallations)
+    .where(eq(telegramInstallations.telegramBotId, fixture.installationId));
+  await db
+    .delete(telegramOfficialUserLinks)
+    .where(
+      and(
+        eq(telegramOfficialUserLinks.orgId, fixture.orgId),
+        eq(telegramOfficialUserLinks.vm0UserId, fixture.userId),
+      ),
+    );
+  await db
+    .delete(userFeatureSwitches)
+    .where(
+      and(
+        eq(userFeatureSwitches.orgId, fixture.orgId),
+        eq(userFeatureSwitches.userId, fixture.userId),
+      ),
+    );
+  await db
+    .delete(modelProviders)
+    .where(eq(modelProviders.orgId, fixture.orgId));
+  await store.set(deleteUsageInsightFixture$, fixture, context.signal);
+}
+
+async function seedTelegramInstallation(args: {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly composeId: string;
+}): Promise<{ readonly installationId: string; readonly userLinkId: string }> {
+  const db = store.set(writeDb$);
+  const installationId = `bot-${randomUUID()}`;
+  await db.insert(telegramInstallations).values({
+    telegramBotId: installationId,
+    botUsername: `bot_${installationId.slice(4, 12)}`,
+    encryptedBotToken: encryptSecretForTests(TEST_BOT_TOKEN),
+    webhookSecret: `whs_${randomUUID()}`,
+    defaultComposeId: args.composeId,
+    ownerUserId: args.userId,
+    orgId: args.orgId,
+  });
+  const [userLink] = await db
+    .insert(telegramUserLinks)
+    .values({
+      installationId,
+      telegramUserId: `tg-${randomUUID()}`,
+      telegramUsername: "alice",
+      telegramDisplayName: "Alice",
+      vm0UserId: args.userId,
+    })
+    .returning({ id: telegramUserLinks.id });
+  if (!userLink) {
+    throw new Error(
+      "seedTelegramInstallation: user link insert returned no row",
+    );
+  }
+  return { installationId, userLinkId: userLink.id };
+}
+
+async function seedFixture(): Promise<TelegramFixture> {
+  const base = await store.set(
+    seedUsageInsightFixture$,
+    undefined,
+    context.signal,
+  );
+  const { composeId } = await store.set(
+    seedCompose$,
+    {
+      orgId: base.orgId,
+      userId: base.userId,
+      name: `telegram-callback-${randomUUID().slice(0, 8)}`,
+      displayName: "Telegram Agent",
+    },
+    context.signal,
+  );
+  const { installationId, userLinkId } = await seedTelegramInstallation({
+    orgId: base.orgId,
+    userId: base.userId,
+    composeId,
+  });
+  const { runId } = await store.set(
+    seedRun$,
+    {
+      orgId: base.orgId,
+      userId: base.userId,
+      composeId,
+      triggerSource: "telegram",
+      prompt: "Handle Telegram message",
+      lastEventSequence: 0,
+    },
+    context.signal,
+  );
+  const payload: TelegramCallbackPayload = {
+    installationId,
+    chatId: "12345",
+    messageId: "42",
+    rootMessageId: "100",
+    userLinkId,
+    agentId: composeId,
+    existingSessionId: null,
+    isDM: false,
+  };
+  const { callbackId } = await store.set(
+    seedAgentRunCallback$,
+    {
+      runId,
+      url: `http://localhost${PATH}`,
+      payload: payload as unknown as Record<string, unknown>,
+    },
+    context.signal,
+  );
+
+  return {
+    ...base,
+    composeId,
+    installationId,
+    userLinkId,
+    runId,
+    callbackId,
+    payload,
+  };
+}
+
+function signedHeaders(rawBody: string, secret = TEST_CALLBACK_SECRET) {
+  const timestamp = Math.floor(now() / 1000);
+  return {
+    "Content-Type": "application/json",
+    "X-VM0-Signature": computeHmacSignature(rawBody, secret, timestamp),
+    "X-VM0-Timestamp": String(timestamp),
+  };
+}
+
+async function postSignedCallback(
+  body: Record<string, unknown>,
+  secret?: string,
+): Promise<Response> {
+  const rawBody = JSON.stringify(body);
+  const app = createApp({ signal: context.signal });
+  return await app.request(PATH, {
+    method: "POST",
+    headers: signedHeaders(rawBody, secret),
+    body: rawBody,
+  });
+}
+
+function completedOutput(text = "**Done** with `code`"): void {
+  context.mocks.axiom.query.mockResolvedValueOnce([
+    {
+      eventType: "result",
+      eventData: { result: text },
+    },
+  ]);
+}
+
+async function enableAuditLink(fixture: TelegramFixture): Promise<void> {
+  const db = store.set(writeDb$);
+  await db.insert(userFeatureSwitches).values({
+    orgId: fixture.orgId,
+    userId: fixture.userId,
+    switches: { [FeatureSwitchKey.AuditLink]: true },
+  });
+}
+
+async function findThreadSession(args: {
+  readonly userLinkId: string;
+  readonly chatId: string;
+  readonly rootMessageId: string;
+}): Promise<{ readonly agentSessionId: string } | null> {
+  const db = store.set(writeDb$);
+  const [row] = await db
+    .select({ agentSessionId: telegramThreadSessions.agentSessionId })
+    .from(telegramThreadSessions)
+    .where(
+      and(
+        eq(telegramThreadSessions.telegramUserLinkId, args.userLinkId),
+        eq(telegramThreadSessions.chatId, args.chatId),
+        eq(telegramThreadSessions.rootMessageId, args.rootMessageId),
+      ),
+    )
+    .limit(1);
+  return row ?? null;
+}
+
+afterEach(() => {
+  context.mocks.axiom.query.mockReset();
+  clearMockedEnv();
+});
+
+describe("POST /api/internal/callbacks/telegram", () => {
+  const track = createFixtureTracker<TelegramFixture>((fixture) => {
+    return deleteFixture(fixture);
+  });
+
+  it("rejects requests with invalid signatures", async () => {
+    const fixture = await track(seedFixture());
+
+    const response = await postSignedCallback(
+      {
+        callbackId: fixture.callbackId,
+        runId: fixture.runId,
+        status: "completed",
+        payload: fixture.payload,
+      },
+      "wrong-secret",
+    );
+
+    expect(response.status).toBe(401);
+  });
+
+  it("rejects invalid payloads after callback verification", async () => {
+    const fixture = await track(seedFixture());
+
+    const response = await postSignedCallback({
+      callbackId: fixture.callbackId,
+      runId: fixture.runId,
+      status: "completed",
+      payload: { installationId: fixture.installationId },
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toStrictEqual({
+      error: "Invalid or missing payload",
+    });
+  });
+
+  it("refreshes typing for progress callbacks without sending a message", async () => {
+    const fixture = await track(seedFixture());
+    const telegram = telegramApiMocks();
+
+    const response = await postSignedCallback({
+      callbackId: fixture.callbackId,
+      runId: fixture.runId,
+      status: "progress",
+      payload: { ...fixture.payload, thinkingMessageId: "100" },
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toStrictEqual({ success: true });
+    expect(telegram.chatActions).toHaveLength(1);
+    expect(telegram.deleteMessages).toHaveLength(0);
+    expect(telegram.sentMessages).toHaveLength(0);
+  });
+
+  it("renders completed output as Telegram HTML and stores the bot reply", async () => {
+    const fixture = await track(seedFixture());
+    const telegram = telegramApiMocks();
+    completedOutput();
+
+    const response = await postSignedCallback({
+      callbackId: fixture.callbackId,
+      runId: fixture.runId,
+      status: "completed",
+      payload: fixture.payload,
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toStrictEqual({ success: true });
+    expect(telegram.sentMessages).toHaveLength(1);
+    expect(telegram.sentMessages[0]).toMatchObject({
+      chat_id: fixture.payload.chatId,
+      parse_mode: "HTML",
+      reply_parameters: { message_id: Number(fixture.payload.messageId) },
+    });
+    expect(telegram.sentMessages[0]?.text).toContain(
+      "<b>Done</b> with <code>code</code>",
+    );
+
+    const db = store.set(writeDb$);
+    const [stored] = await db
+      .select({ text: telegramMessages.text, isBot: telegramMessages.isBot })
+      .from(telegramMessages)
+      .where(eq(telegramMessages.installationId, fixture.installationId))
+      .limit(1);
+    expect(stored).toStrictEqual({
+      text: "**Done** with `code`",
+      isBot: true,
+    });
+  });
+
+  it("includes audit links and agent reply footer text when configured", async () => {
+    const fixture = await track(seedFixture());
+    const db = store.set(writeDb$);
+    await enableAuditLink(fixture);
+    await db
+      .update(zeroRuns)
+      .set({ selectedModel: "claude-opus-4-7" })
+      .where(eq(zeroRuns.id, fixture.runId));
+    const telegram = telegramApiMocks();
+    completedOutput("Plain result");
+
+    const response = await postSignedCallback({
+      callbackId: fixture.callbackId,
+      runId: fixture.runId,
+      status: "completed",
+      payload: fixture.payload,
+    });
+
+    expect(response.status).toBe(200);
+    const text = telegram.sentMessages[0]?.text ?? "";
+    expect(text).toContain("📋 Audit");
+    expect(text).toContain(`/activities/${fixture.runId}`);
+    expect(text).toContain("Claude Opus 4.7");
+    expect(text).not.toContain("Responded by");
+  });
+
+  it("deletes legacy thinking placeholders and renders failed callbacks", async () => {
+    const fixture = await track(seedFixture());
+    const telegram = telegramApiMocks();
+
+    const response = await postSignedCallback({
+      callbackId: fixture.callbackId,
+      runId: fixture.runId,
+      status: "failed",
+      error: "请先 [连接 Notion](https://example.com/connect?agentId=123)",
+      payload: { ...fixture.payload, thinkingMessageId: "100" },
+    });
+
+    expect(response.status).toBe(200);
+    expect(telegram.deleteMessages).toHaveLength(1);
+    const text = telegram.sentMessages[0]?.text ?? "";
+    expect(text).toContain("<b>Agent Execution Error</b>");
+    expect(text).toContain(
+      '<a href="https://example.com/connect?agentId=123">连接 Notion</a>',
+    );
+  });
+
+  it("does not quote DM replies and replaces the DM thread mapping", async () => {
+    const fixture = await track(seedFixture());
+    const db = store.set(writeDb$);
+    const [run] = await db
+      .select({ sessionId: agentRuns.sessionId })
+      .from(agentRuns)
+      .where(eq(agentRuns.id, fixture.runId))
+      .limit(1);
+    if (!run) {
+      throw new Error("Expected seeded run");
+    }
+    const [oldSession] = await db
+      .insert(agentSessions)
+      .values({
+        userId: fixture.userId,
+        orgId: fixture.orgId,
+        agentComposeId: fixture.composeId,
+      })
+      .returning({ id: agentSessions.id });
+    if (!oldSession) {
+      throw new Error("Expected old session");
+    }
+    await db.insert(telegramThreadSessions).values({
+      telegramUserLinkId: fixture.userLinkId,
+      chatId: fixture.payload.chatId,
+      rootMessageId: "dm",
+      agentSessionId: oldSession.id,
+    });
+    const telegram = telegramApiMocks();
+    completedOutput("DM result");
+
+    const response = await postSignedCallback({
+      callbackId: fixture.callbackId,
+      runId: fixture.runId,
+      status: "completed",
+      payload: {
+        ...fixture.payload,
+        rootMessageId: "dm",
+        existingSessionId: null,
+        isDM: true,
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expect(telegram.sentMessages[0]?.reply_parameters).toBeUndefined();
+    const session = await findThreadSession({
+      userLinkId: fixture.userLinkId,
+      chatId: fixture.payload.chatId,
+      rootMessageId: "dm",
+    });
+    expect(session?.agentSessionId).toBe(run.sessionId);
+    expect(session?.agentSessionId).not.toBe(oldSession.id);
+  });
+
+  it("uses the official bot token and official message scope", async () => {
+    const fixture = await track(seedFixture());
+    const db = store.set(writeDb$);
+    const [officialLink] = await db
+      .insert(telegramOfficialUserLinks)
+      .values({
+        orgId: fixture.orgId,
+        vm0UserId: fixture.userId,
+        telegramUserId: `tg-${randomUUID()}`,
+      })
+      .returning({ id: telegramOfficialUserLinks.id });
+    if (!officialLink) {
+      throw new Error("Expected official user link");
+    }
+    mockEnv("TELEGRAM_OFFICIAL_BOT_TOKEN", OFFICIAL_BOT_TOKEN);
+    mockEnv("TELEGRAM_OFFICIAL_BOT_USERNAME", "zerobot");
+    mockEnv("TELEGRAM_OFFICIAL_WEBHOOK_SECRET", "official-secret");
+    const telegram = telegramApiMocks(OFFICIAL_BOT_TOKEN);
+    completedOutput("Official result");
+
+    const response = await postSignedCallback({
+      callbackId: fixture.callbackId,
+      runId: fixture.runId,
+      status: "completed",
+      payload: {
+        ...fixture.payload,
+        installationId: OFFICIAL_TELEGRAM_BOT_ID,
+        userLinkId: officialLink.id,
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expect(telegram.sentMessages).toHaveLength(1);
+    const [stored] = await db
+      .select({
+        officialOrgId: telegramMessages.officialOrgId,
+        officialUserLinkId: telegramMessages.officialUserLinkId,
+      })
+      .from(telegramMessages)
+      .where(eq(telegramMessages.officialOrgId, fixture.orgId))
+      .limit(1);
+    expect(stored).toStrictEqual({
+      officialOrgId: fixture.orgId,
+      officialUserLinkId: officialLink.id,
+    });
+  });
+
+  it("returns success without side effects when the installation is missing", async () => {
+    const fixture = await track(seedFixture());
+    const telegram = telegramApiMocks();
+
+    const response = await postSignedCallback({
+      callbackId: fixture.callbackId,
+      runId: fixture.runId,
+      status: "completed",
+      payload: {
+        ...fixture.payload,
+        installationId: "missing-installation",
+      },
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toStrictEqual({ success: true });
+    expect(telegram.sentMessages).toHaveLength(0);
+  });
+});

--- a/turbo/apps/api/src/signals/routes/internal-callbacks-telegram.ts
+++ b/turbo/apps/api/src/signals/routes/internal-callbacks-telegram.ts
@@ -1,0 +1,532 @@
+import { command } from "ccstate";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import { isFeatureEnabled } from "@vm0/core/feature-switch";
+import {
+  internalCallbacksTelegramContract,
+  telegramCallbackPayloadSchema,
+  type TelegramCallbackPayload,
+} from "@vm0/api-contracts/contracts/internal-callbacks-telegram";
+import { agentRuns } from "@vm0/db/schema/agent-run";
+import { zeroAgents } from "@vm0/db/schema/zero-agent";
+import { eq } from "drizzle-orm";
+
+import {
+  callbackPayload$,
+  callbackRoute,
+} from "../../lib/callback-route/callback-route";
+import {
+  buildTelegramErrorResponse,
+  buildTelegramResponse,
+  splitMessage,
+} from "../../lib/telegram-format";
+import type { RouteEntry } from "../route";
+import { env } from "../../lib/env";
+import { logger } from "../../lib/log";
+import { writeDb$, type Db } from "../external/db";
+import {
+  deleteMessage,
+  sendChatAction,
+  sendMessage,
+  type SendTelegramMessageResult,
+} from "../external/telegram-client";
+import {
+  getOfficialTelegramBotConfig,
+  isOfficialTelegramBotId,
+} from "../external/telegram-official";
+import { userFeatureSwitchOverrides } from "../services/feature-switches.service";
+import { getRunOutputText } from "../services/run-output.service";
+import {
+  saveTelegramThreadSession,
+  storeTelegramBotMessage,
+} from "../services/zero-telegram-callback-persistence.service";
+import { telegramBotToken } from "../services/zero-telegram-data.service";
+import { resolveTelegramAgentReplyFooterText } from "../services/zero-telegram-footer.service";
+import { safeAsync } from "../utils";
+
+const L = logger("InternalCallbacksTelegram");
+
+interface RunContext {
+  readonly userId: string;
+  readonly orgId: string;
+  readonly sessionId: string;
+  readonly lastEventSequence: number | null;
+}
+
+type TelegramCallbackResult =
+  | { readonly status: 200; readonly body: { readonly success: true } }
+  | { readonly status: 400 | 502; readonly body: { readonly error: string } };
+
+function successResponse(): {
+  readonly status: 200;
+  readonly body: { readonly success: true };
+} {
+  return { status: 200, body: { success: true } };
+}
+
+function errorResponse(
+  status: 400 | 500 | 502,
+  message: string,
+): {
+  readonly status: 400 | 500 | 502;
+  readonly body: { readonly error: string };
+} {
+  return { status, body: { error: message } };
+}
+
+function parsePayload(payload: unknown): TelegramCallbackPayload | null {
+  const result = telegramCallbackPayloadSchema.safeParse(payload);
+  return result.success ? result.data : null;
+}
+
+function agentDisplayLabel(row: {
+  readonly displayName: string | null;
+  readonly name: string | null;
+}): string {
+  return row.displayName?.trim() || row.name?.trim() || "zero";
+}
+
+async function resolveAgentInfo(args: {
+  readonly db: Db;
+  readonly agentId: string;
+  readonly signal: AbortSignal;
+}): Promise<{ readonly label: string; readonly name: string }> {
+  const [agentRow] = await args.db
+    .select({ displayName: zeroAgents.displayName, name: zeroAgents.name })
+    .from(zeroAgents)
+    .where(eq(zeroAgents.id, args.agentId))
+    .limit(1);
+  args.signal.throwIfAborted();
+
+  const label = agentRow ? agentDisplayLabel(agentRow) : "zero";
+  return {
+    label,
+    name: agentRow?.name ?? label,
+  };
+}
+
+async function resolveTelegramAuditLogsUrl(args: {
+  readonly runId: string;
+  readonly orgId: string;
+  readonly userId: string;
+  readonly getFeatureOverrides: (
+    orgId: string,
+    userId: string,
+  ) => Promise<Record<string, boolean>>;
+  readonly signal: AbortSignal;
+}): Promise<string | undefined> {
+  const overrides = await args.getFeatureOverrides(args.orgId, args.userId);
+  args.signal.throwIfAborted();
+  const typedOverrides =
+    Object.keys(overrides).length > 0
+      ? (overrides as Partial<Record<FeatureSwitchKey, boolean>>)
+      : undefined;
+  const enabled = isFeatureEnabled(FeatureSwitchKey.AuditLink, {
+    userId: args.userId,
+    orgId: args.orgId,
+    overrides: typedOverrides,
+  });
+  if (!enabled) {
+    return undefined;
+  }
+
+  return `${env("VM0_WEB_URL")}/activities/${encodeURIComponent(args.runId)}`;
+}
+
+async function deleteThinkingMessageIfPresent(args: {
+  readonly botToken: string;
+  readonly chatId: string;
+  readonly thinkingMessageId: string | null | undefined;
+}): Promise<void> {
+  if (!args.thinkingMessageId) {
+    return;
+  }
+
+  const result = await safeAsync(() => {
+    return deleteMessage(
+      args.botToken,
+      args.chatId,
+      Number(args.thinkingMessageId),
+    );
+  });
+  if ("error" in result) {
+    L.debug("Failed to delete legacy thinking placeholder", {
+      thinkingMessageId: args.thinkingMessageId,
+      error: result.error,
+    });
+  }
+}
+
+function buildCompletionOutput(args: {
+  readonly status: "completed" | "failed";
+  readonly output: string | undefined;
+  readonly error: string | undefined;
+  readonly logsUrl: string | undefined;
+  readonly footerText: string | undefined;
+}): { readonly htmlOutput: string; readonly responseText: string | undefined } {
+  if (args.status === "completed") {
+    const responseText = args.output ?? "Task completed successfully.";
+    return {
+      responseText,
+      htmlOutput: buildTelegramResponse(
+        responseText,
+        args.logsUrl,
+        args.footerText,
+      ),
+    };
+  }
+
+  const errorDetail =
+    args.error ?? "The agent encountered an error during execution.";
+  return {
+    responseText: undefined,
+    htmlOutput: buildTelegramErrorResponse(
+      errorDetail,
+      args.logsUrl,
+      args.footerText,
+    ),
+  };
+}
+
+function telegramErrorResponse(
+  result: Extract<SendTelegramMessageResult, { kind: "telegram-error" }>,
+): {
+  readonly status: 400 | 502;
+  readonly body: { readonly error: string };
+} {
+  return {
+    status: result.status >= 500 ? 502 : 400,
+    body: {
+      error: `Telegram API error: ${
+        result.description ?? `HTTP ${result.status}`
+      }`,
+    },
+  };
+}
+
+async function loadRunContext(args: {
+  readonly db: Db;
+  readonly runId: string;
+  readonly signal: AbortSignal;
+}): Promise<RunContext | undefined> {
+  const [run] = await args.db
+    .select({
+      userId: agentRuns.userId,
+      orgId: agentRuns.orgId,
+      sessionId: agentRuns.sessionId,
+      lastEventSequence: agentRuns.lastEventSequence,
+    })
+    .from(agentRuns)
+    .where(eq(agentRuns.id, args.runId))
+    .limit(1);
+  args.signal.throwIfAborted();
+  return run;
+}
+
+async function resolveCompletionText(args: {
+  readonly runId: string;
+  readonly status: "completed" | "failed";
+  readonly run: RunContext | undefined;
+  readonly signal: AbortSignal;
+}): Promise<string | undefined> {
+  if (args.status === "failed") {
+    return undefined;
+  }
+
+  const output = await getRunOutputText(args.runId, {
+    waitForOutput: false,
+    knownLastEventSequence: args.run?.lastEventSequence,
+    signal: args.signal,
+  });
+  args.signal.throwIfAborted();
+  return output;
+}
+
+async function resolveCompletionDecorations(args: {
+  readonly db: Db;
+  readonly runId: string;
+  readonly run: RunContext | undefined;
+  readonly installationId: string;
+  readonly agentId: string;
+  readonly getFeatureOverrides: (
+    orgId: string,
+    userId: string,
+  ) => Promise<Record<string, boolean>>;
+  readonly signal: AbortSignal;
+}): Promise<{
+  readonly logsUrl: string | undefined;
+  readonly footerText: string | undefined;
+}> {
+  if (!args.run) {
+    return { logsUrl: undefined, footerText: undefined };
+  }
+
+  const logsUrl = await resolveTelegramAuditLogsUrl({
+    runId: args.runId,
+    orgId: args.run.orgId,
+    userId: args.run.userId,
+    getFeatureOverrides: args.getFeatureOverrides,
+    signal: args.signal,
+  });
+  const footerText = await resolveTelegramAgentReplyFooterText({
+    db: args.db,
+    orgId: args.run.orgId,
+    runId: args.runId,
+    installationId: args.installationId,
+    agentId: args.agentId,
+  });
+  args.signal.throwIfAborted();
+
+  return { logsUrl, footerText };
+}
+
+async function sendCompletionMessages(args: {
+  readonly botToken: string;
+  readonly chatId: string;
+  readonly htmlOutput: string;
+  readonly replyToMessageId: number | undefined;
+  readonly signal: AbortSignal;
+}): Promise<
+  | { readonly kind: "ok"; readonly firstMessageId: number | undefined }
+  | Extract<SendTelegramMessageResult, { kind: "telegram-error" }>
+> {
+  let firstMessageId: number | undefined;
+  for (const chunk of splitMessage(args.htmlOutput)) {
+    const sent = await sendMessage(args.botToken, args.chatId, chunk, {
+      replyToMessageId: args.replyToMessageId,
+    });
+    args.signal.throwIfAborted();
+    if (sent.kind === "telegram-error") {
+      return sent;
+    }
+    if (firstMessageId === undefined) {
+      firstMessageId = sent.messageId;
+    }
+  }
+
+  return { kind: "ok", firstMessageId };
+}
+
+async function persistCompletionResult(args: {
+  readonly db: Db;
+  readonly run: RunContext | undefined;
+  readonly isOfficial: boolean;
+  readonly payload: TelegramCallbackPayload;
+  readonly botReplyMessageId: number | undefined;
+  readonly responseText: string | undefined;
+  readonly status: "completed" | "failed";
+  readonly signal: AbortSignal;
+}): Promise<void> {
+  if (args.botReplyMessageId === undefined) {
+    return;
+  }
+
+  await storeTelegramBotMessage({
+    db: args.db,
+    scope:
+      args.isOfficial && args.run
+        ? {
+            kind: "official",
+            orgId: args.run.orgId,
+            userLinkId: args.payload.userLinkId,
+          }
+        : { kind: "custom", installationId: args.payload.installationId },
+    chatId: args.payload.chatId,
+    messageId: args.botReplyMessageId,
+    text: args.responseText,
+  });
+  args.signal.throwIfAborted();
+
+  if (!args.run) {
+    return;
+  }
+
+  await saveTelegramThreadSession({
+    db: args.db,
+    userLinkId: args.payload.userLinkId,
+    userLinkKind: args.isOfficial ? "official" : "custom",
+    chatId: args.payload.chatId,
+    rootMessageId: args.payload.isDM ? "dm" : String(args.botReplyMessageId),
+    previousRootMessageId: args.payload.rootMessageId ?? undefined,
+    existingSessionId: args.payload.existingSessionId ?? undefined,
+    newSessionId: args.payload.existingSessionId
+      ? undefined
+      : args.run.sessionId,
+    messageId: args.payload.messageId,
+    runStatus: args.status,
+  });
+  args.signal.throwIfAborted();
+}
+
+async function handleCompletion(args: {
+  readonly db: Db;
+  readonly botToken: string;
+  readonly runId: string;
+  readonly status: "completed" | "failed";
+  readonly error: string | undefined;
+  readonly payload: TelegramCallbackPayload;
+  readonly getFeatureOverrides: (
+    orgId: string,
+    userId: string,
+  ) => Promise<Record<string, boolean>>;
+  readonly signal: AbortSignal;
+}): Promise<TelegramCallbackResult> {
+  const {
+    installationId,
+    chatId,
+    messageId,
+    agentId,
+    isDM,
+    thinkingMessageId,
+  } = args.payload;
+
+  const agent = await resolveAgentInfo({
+    db: args.db,
+    agentId,
+    signal: args.signal,
+  });
+  const isOfficial = isOfficialTelegramBotId(installationId);
+
+  await deleteThinkingMessageIfPresent({
+    botToken: args.botToken,
+    chatId,
+    thinkingMessageId,
+  });
+  args.signal.throwIfAborted();
+
+  await sendChatAction(args.botToken, chatId, "typing");
+  args.signal.throwIfAborted();
+
+  const run = await loadRunContext({
+    db: args.db,
+    runId: args.runId,
+    signal: args.signal,
+  });
+
+  if (args.status === "failed") {
+    L.error("Agent run failed", {
+      runId: args.runId,
+      agentName: agent.name,
+      chatId,
+      error: args.error,
+    });
+  }
+
+  const output = await resolveCompletionText({
+    runId: args.runId,
+    status: args.status,
+    run,
+    signal: args.signal,
+  });
+  const { logsUrl, footerText } = await resolveCompletionDecorations({
+    db: args.db,
+    runId: args.runId,
+    run,
+    installationId,
+    agentId,
+    getFeatureOverrides: args.getFeatureOverrides,
+    signal: args.signal,
+  });
+  const { htmlOutput, responseText } = buildCompletionOutput({
+    status: args.status,
+    output,
+    error: args.error,
+    logsUrl,
+    footerText,
+  });
+
+  const sendResult = await sendCompletionMessages({
+    botToken: args.botToken,
+    chatId,
+    htmlOutput,
+    replyToMessageId: isDM ? undefined : Number(messageId),
+    signal: args.signal,
+  });
+  if (sendResult.kind === "telegram-error") {
+    return telegramErrorResponse(sendResult);
+  }
+
+  await persistCompletionResult({
+    db: args.db,
+    run,
+    isOfficial,
+    payload: args.payload,
+    botReplyMessageId: sendResult.firstMessageId,
+    responseText,
+    status: args.status,
+    signal: args.signal,
+  });
+
+  return successResponse();
+}
+
+const handleTelegramCallback$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const callback = get(callbackPayload$);
+    const payload = parsePayload(callback.payload);
+    if (!payload) {
+      return errorResponse(400, "Invalid or missing payload");
+    }
+
+    L.debug("Processing Telegram callback", {
+      runId: callback.runId,
+      status: callback.status,
+      chatId: payload.chatId,
+    });
+
+    const botToken = isOfficialTelegramBotId(payload.installationId)
+      ? getOfficialTelegramBotConfig().botToken
+      : (await get(telegramBotToken({ botId: payload.installationId })))
+          ?.botToken;
+    signal.throwIfAborted();
+
+    if (!botToken) {
+      L.warn("Telegram bot token not configured", {
+        installationId: payload.installationId,
+      });
+      return successResponse();
+    }
+
+    if (callback.status === "progress") {
+      const typing = await safeAsync(() => {
+        return sendChatAction(botToken, payload.chatId, "typing");
+      });
+      signal.throwIfAborted();
+      if ("error" in typing) {
+        L.debug("Failed to refresh typing indicator", {
+          runId: callback.runId,
+          error: typing.error,
+        });
+      }
+      return successResponse();
+    }
+
+    const db = set(writeDb$);
+    const result = await handleCompletion({
+      db,
+      botToken,
+      runId: callback.runId,
+      status: callback.status,
+      error: callback.error,
+      payload,
+      getFeatureOverrides: (orgId, userId) => {
+        return get(userFeatureSwitchOverrides(orgId, userId));
+      },
+      signal,
+    });
+    signal.throwIfAborted();
+
+    if (result.status === 200) {
+      L.debug("Telegram callback processed successfully", {
+        runId: callback.runId,
+      });
+    }
+    return result;
+  },
+);
+
+export const internalCallbacksTelegramRoutes: readonly RouteEntry[] = [
+  {
+    route: internalCallbacksTelegramContract.post,
+    handler: callbackRoute(handleTelegramCallback$),
+  },
+];

--- a/turbo/apps/api/src/signals/services/zero-telegram-callback-persistence.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-telegram-callback-persistence.service.ts
@@ -1,0 +1,127 @@
+import { and, eq } from "drizzle-orm";
+import { telegramMessages } from "@vm0/db/schema/telegram-message";
+import { telegramThreadSessions } from "@vm0/db/schema/telegram-thread-session";
+
+import { nowDate } from "../external/time";
+import type { Db } from "../external/db";
+
+type TelegramMessageScope =
+  | { readonly kind: "custom"; readonly installationId: string }
+  | {
+      readonly kind: "official";
+      readonly orgId: string;
+      readonly userLinkId: string | null;
+    };
+
+export async function storeTelegramBotMessage(args: {
+  readonly db: Db;
+  readonly scope: TelegramMessageScope;
+  readonly chatId: string;
+  readonly messageId: number;
+  readonly text: string | undefined;
+}): Promise<void> {
+  await args.db
+    .insert(telegramMessages)
+    .values({
+      installationId:
+        args.scope.kind === "custom" ? args.scope.installationId : null,
+      officialOrgId: args.scope.kind === "official" ? args.scope.orgId : null,
+      officialUserLinkId:
+        args.scope.kind === "official" ? args.scope.userLinkId : null,
+      chatId: args.chatId,
+      messageId: String(args.messageId),
+      fromUserId: "0",
+      fromUsername: null,
+      fromDisplayName: null,
+      text: args.text ?? null,
+      fileId: null,
+      fileType: null,
+      fileName: null,
+      fileMimeType: null,
+      fileSize: null,
+      fileWidth: null,
+      fileHeight: null,
+      fileDuration: null,
+      entities: null,
+      isBot: true,
+    })
+    .onConflictDoNothing();
+}
+
+export async function saveTelegramThreadSession(args: {
+  readonly db: Db;
+  readonly userLinkId: string;
+  readonly userLinkKind: "custom" | "official";
+  readonly chatId: string;
+  readonly rootMessageId: string;
+  readonly previousRootMessageId: string | undefined;
+  readonly existingSessionId: string | undefined;
+  readonly newSessionId: string | undefined;
+  readonly messageId: string;
+  readonly runStatus: "completed" | "failed";
+}): Promise<void> {
+  if (!args.existingSessionId && args.newSessionId) {
+    const updated = await args.db
+      .update(telegramThreadSessions)
+      .set({
+        agentSessionId: args.newSessionId,
+        lastProcessedMessageId: args.messageId,
+        updatedAt: nowDate(),
+      })
+      .where(
+        and(
+          args.userLinkKind === "custom"
+            ? eq(telegramThreadSessions.telegramUserLinkId, args.userLinkId)
+            : eq(
+                telegramThreadSessions.telegramOfficialUserLinkId,
+                args.userLinkId,
+              ),
+          eq(telegramThreadSessions.chatId, args.chatId),
+          eq(telegramThreadSessions.rootMessageId, args.rootMessageId),
+        ),
+      )
+      .returning({ id: telegramThreadSessions.id });
+
+    if (updated.length > 0) {
+      return;
+    }
+
+    await args.db
+      .insert(telegramThreadSessions)
+      .values({
+        telegramUserLinkId:
+          args.userLinkKind === "custom" ? args.userLinkId : null,
+        telegramOfficialUserLinkId:
+          args.userLinkKind === "official" ? args.userLinkId : null,
+        chatId: args.chatId,
+        rootMessageId: args.rootMessageId,
+        agentSessionId: args.newSessionId,
+        lastProcessedMessageId: args.messageId,
+      })
+      .onConflictDoNothing();
+    return;
+  }
+
+  if (args.existingSessionId && args.runStatus === "completed") {
+    const matchRootMessageId = args.previousRootMessageId ?? args.rootMessageId;
+    await args.db
+      .update(telegramThreadSessions)
+      .set({
+        rootMessageId: args.rootMessageId,
+        lastProcessedMessageId: args.messageId,
+        updatedAt: nowDate(),
+      })
+      .where(
+        and(
+          args.userLinkKind === "custom"
+            ? eq(telegramThreadSessions.telegramUserLinkId, args.userLinkId)
+            : eq(
+                telegramThreadSessions.telegramOfficialUserLinkId,
+                args.userLinkId,
+              ),
+          eq(telegramThreadSessions.chatId, args.chatId),
+          eq(telegramThreadSessions.rootMessageId, matchRootMessageId),
+        ),
+      );
+  }
+}

--- a/turbo/apps/api/src/signals/services/zero-telegram-footer.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-telegram-footer.service.ts
@@ -1,18 +1,27 @@
 import { computed, type Computed } from "ccstate";
 import { getModelDisplayName } from "@vm0/core/model-display-name";
 import {
+  getFrameworkForType,
+  modelProviderTypeSchema,
+} from "@vm0/api-contracts/contracts/model-providers";
+import {
   agentComposes,
   agentComposeVersions,
 } from "@vm0/db/schema/agent-compose";
 import { agentRuns } from "@vm0/db/schema/agent-run";
+import { modelProviders } from "@vm0/db/schema/model-provider";
+import { telegramInstallations } from "@vm0/db/schema/telegram-installation";
 import { telegramUserLinks } from "@vm0/db/schema/telegram-user-link";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
 import { zeroAgentSchedules } from "@vm0/db/schema/zero-agent-schedule";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
 import { and, eq } from "drizzle-orm";
 
+import { isOfficialTelegramBotId } from "../external/telegram-official";
 import { db$, type ReadonlyDb } from "../external/db";
 import { escapeHtml } from "../../lib/telegram-format";
+
+const ORG_SENTINEL_USER_ID = "__org__";
 
 function telegramUserMention(telegramUserId: string, label: string): string {
   const href = `tg://user?id=${encodeURIComponent(telegramUserId)}`;
@@ -46,6 +55,114 @@ function displayLabel(row: {
     return agentName;
   }
   return row.composeName.trim() || "zero";
+}
+
+async function resolveComposeLabel(
+  db: ReadonlyDb,
+  composeId: string,
+): Promise<string | undefined> {
+  const [row] = await db
+    .select({
+      agentDisplayName: zeroAgents.displayName,
+      agentName: zeroAgents.name,
+      composeName: agentComposes.name,
+    })
+    .from(agentComposes)
+    .leftJoin(zeroAgents, eq(zeroAgents.id, agentComposes.id))
+    .where(eq(agentComposes.id, composeId))
+    .limit(1);
+  return row ? displayLabel(row) : undefined;
+}
+
+async function resolveTelegramRespondedByLabel(args: {
+  readonly db: ReadonlyDb;
+  readonly installationId: string;
+  readonly composeId: string;
+}): Promise<string | undefined> {
+  if (isOfficialTelegramBotId(args.installationId)) {
+    return undefined;
+  }
+
+  const [installation] = await args.db
+    .select({ defaultComposeId: telegramInstallations.defaultComposeId })
+    .from(telegramInstallations)
+    .where(eq(telegramInstallations.telegramBotId, args.installationId))
+    .limit(1);
+
+  if (installation?.defaultComposeId === args.composeId) {
+    return undefined;
+  }
+
+  const label = await resolveComposeLabel(args.db, args.composeId);
+  return label ? `Responded by ${escapeHtml(label)}` : undefined;
+}
+
+async function resolveOrgDefaultModelProviderSelectedModel(
+  db: ReadonlyDb,
+  orgId: string,
+): Promise<string | undefined> {
+  const rows = await db
+    .select({
+      type: modelProviders.type,
+      selectedModel: modelProviders.selectedModel,
+    })
+    .from(modelProviders)
+    .where(
+      and(
+        eq(modelProviders.orgId, orgId),
+        eq(modelProviders.userId, ORG_SENTINEL_USER_ID),
+        eq(modelProviders.isDefault, true),
+      ),
+    );
+  const row = rows.find((candidate) => {
+    const parsed = modelProviderTypeSchema.safeParse(candidate.type);
+    return parsed.success && getFrameworkForType(parsed.data) === "claude-code";
+  });
+  return row?.selectedModel ?? undefined;
+}
+
+async function resolveAgentReplyModelLabel(args: {
+  readonly db: ReadonlyDb;
+  readonly orgId: string;
+  readonly runId: string;
+}): Promise<string | undefined> {
+  const selectedModel = await resolveRunSelectedModel(args.db, args.runId);
+  const model =
+    selectedModel ??
+    (await resolveOrgDefaultModelProviderSelectedModel(args.db, args.orgId));
+
+  return model ? escapeHtml(getModelDisplayName(model)) : undefined;
+}
+
+export async function resolveTelegramAgentReplyFooterText(args: {
+  readonly db: ReadonlyDb;
+  readonly orgId: string;
+  readonly runId: string;
+  readonly installationId: string;
+  readonly agentId: string;
+}): Promise<string | undefined> {
+  const [respondedBy, modelLabel] = await Promise.all([
+    resolveTelegramRespondedByLabel({
+      db: args.db,
+      installationId: args.installationId,
+      composeId: args.agentId,
+    }),
+    resolveAgentReplyModelLabel({
+      db: args.db,
+      orgId: args.orgId,
+      runId: args.runId,
+    }),
+  ]);
+
+  const parts: string[] = [];
+  if (respondedBy) {
+    parts.push(respondedBy);
+  }
+  if (modelLabel) {
+    parts.push(modelLabel);
+  }
+
+  return parts.length > 0 ? parts.join(" · ") : undefined;
 }
 
 async function resolveRunAgentLabel(

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -172,6 +172,12 @@ export {
   type StoragesListContract,
 } from "./storages";
 export {
+  internalCallbacksTelegramContract,
+  telegramCallbackPayloadSchema,
+  type InternalCallbacksTelegramContract,
+  type TelegramCallbackPayload,
+} from "./internal-callbacks-telegram";
+export {
   sandboxReuseResultSchema,
   webhookEventsContract,
   webhookCompleteContract,

--- a/turbo/packages/api-contracts/src/contracts/internal-callbacks-telegram.ts
+++ b/turbo/packages/api-contracts/src/contracts/internal-callbacks-telegram.ts
@@ -1,0 +1,51 @@
+import { z } from "zod";
+
+import { initContract } from "./base";
+import {
+  internalCallbackBodySchema,
+  internalCallbackErrorSchema,
+  internalCallbackHeadersSchema,
+  internalCallbackSuccessSchema,
+} from "./internal-callbacks-shared";
+
+const c = initContract();
+
+export const telegramCallbackPayloadSchema = z
+  .object({
+    installationId: z.string(),
+    chatId: z.string(),
+    messageId: z.string(),
+    rootMessageId: z.string().nullable().optional(),
+    userLinkId: z.string(),
+    agentId: z.string(),
+    existingSessionId: z.string().nullable().optional(),
+    isDM: z.boolean(),
+    thinkingMessageId: z.string().nullable().optional(),
+  })
+  .passthrough();
+
+export const internalCallbacksTelegramContract = c.router({
+  post: {
+    method: "POST",
+    path: "/api/internal/callbacks/telegram",
+    headers: internalCallbackHeadersSchema,
+    body: internalCallbackBodySchema.extend({
+      payload: telegramCallbackPayloadSchema,
+    }),
+    responses: {
+      200: internalCallbackSuccessSchema,
+      400: internalCallbackErrorSchema,
+      401: internalCallbackErrorSchema,
+      404: internalCallbackErrorSchema,
+      500: internalCallbackErrorSchema,
+      502: internalCallbackErrorSchema,
+    },
+    summary: "Handle callbacks for Telegram-triggered runs",
+  },
+});
+
+export type TelegramCallbackPayload = z.infer<
+  typeof telegramCallbackPayloadSchema
+>;
+export type InternalCallbacksTelegramContract =
+  typeof internalCallbacksTelegramContract;


### PR DESCRIPTION
## Summary
- Add an API contract and registered API backend route for `POST /api/internal/callbacks/telegram`.
- Preserve Telegram callback behavior for custom and official bot tokens, progress typing refresh, completed/failed response rendering, audit/footer text, thinking-message cleanup, message storage, and thread-session persistence.
- Add API integration coverage for signature/payload validation, progress, completed output, audit footer, failures, DM threading, official bot scope, and missing installations.

Fixes #13068

## Validation
- `pnpm -F api exec vitest --run src/signals/routes/__tests__/internal-callbacks-telegram.test.ts`
- `pnpm -F api lint`
- `pnpm check-types`
- `pnpm knip`