### PR TITLE
perf: preserve Axiom batch capacity

### DIFF
--- a/crates/runner/src/axiom_layer.rs
+++ b/crates/runner/src/axiom_layer.rs
@@ -243,7 +243,7 @@ async fn flush(client: &Client, ingest_url: &str, token: &str, batch: &mut Vec<V
     if batch.is_empty() {
         return;
     }
-    let drained: Vec<Value> = std::mem::take(batch);
+    let drained = std::mem::replace(batch, Vec::with_capacity(BATCH_SIZE));
     match client
         .post(ingest_url)
         .bearer_auth(token)


### PR DESCRIPTION
## Summary

- preserve the Axiom dispatcher's next batch capacity after each flush
- keep existing batching, shutdown, HTTP send, and retry/drop behavior unchanged

Closes #13086

## Verification

```bash
cargo test --manifest-path crates/Cargo.toml -p runner --test axiom_layer
cargo fmt --manifest-path crates/Cargo.toml --all -- --check
cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features -- -D warnings
```

Pre-commit also passed cargo fmt, cargo doc, and cargo clippy.
