### PR TITLE
refactor(api): migrate slack org callback

### DIFF
--- a/turbo/apps/api/src/__tests__/mocks.ts
+++ b/turbo/apps/api/src/__tests__/mocks.ts
@@ -59,6 +59,11 @@ export interface ApiTestMocks {
     readonly clientConfig: SyncMock;
   };
   readonly slack: {
+    readonly assistant: {
+      readonly threads: {
+        readonly setStatus: AsyncMock;
+      };
+    };
     readonly chat: {
       readonly postMessage: AsyncMock;
       readonly postEphemeral: AsyncMock;
@@ -183,6 +188,11 @@ const apiTestMocks: ApiTestMocks = vi.hoisted((): ApiTestMocks => {
   };
 
   const slack = {
+    assistant: {
+      threads: {
+        setStatus: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
+      },
+    },
     chat: {
       postMessage: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
       postEphemeral: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
@@ -478,6 +488,11 @@ vi.mock("@slack/web-api", () => {
   return {
     WebClient: vi.fn(function (): unknown {
       return {
+        assistant: {
+          threads: {
+            setStatus: apiTestMocks.slack.assistant.threads.setStatus,
+          },
+        },
         chat: {
           postMessage: apiTestMocks.slack.chat.postMessage,
           postEphemeral: apiTestMocks.slack.chat.postEphemeral,
@@ -625,6 +640,7 @@ export function resetApiTestMocks(): void {
     "https://r2.example.com/upload?sig=test",
   );
   apiTestMocks.s3.clientConfig.mockReset();
+  apiTestMocks.slack.assistant.threads.setStatus.mockReset();
   apiTestMocks.slack.chat.postMessage.mockReset();
   apiTestMocks.slack.chat.postEphemeral.mockReset();
   apiTestMocks.slack.conversations.list.mockReset();

--- a/turbo/apps/api/src/lib/slack-blocks.ts
+++ b/turbo/apps/api/src/lib/slack-blocks.ts
@@ -1,4 +1,58 @@
-import type { Block, KnownBlock } from "@slack/web-api";
+import type { Block, KnownBlock, MarkdownBlock } from "@slack/web-api";
+
+const MARKDOWN_BLOCK_MAX_LENGTH = 12_000;
+
+function buildMarkdownMessage(content: string): (Block | KnownBlock)[] {
+  const truncationSuffix = "\n\n_(Message too long to view in Slack.)_";
+  const truncated =
+    content.length > MARKDOWN_BLOCK_MAX_LENGTH
+      ? content.substring(
+          0,
+          MARKDOWN_BLOCK_MAX_LENGTH - truncationSuffix.length,
+        ) + truncationSuffix
+      : content;
+
+  const block: MarkdownBlock = {
+    type: "markdown",
+    text: truncated,
+  };
+
+  return [block];
+}
+
+export function buildAgentResponseMessage(
+  content: string,
+  logsUrl?: string,
+  footerText?: string,
+): (Block | KnownBlock)[] {
+  const blocks: (Block | KnownBlock)[] = [...buildMarkdownMessage(content)];
+
+  if (logsUrl) {
+    blocks.push({
+      type: "context",
+      elements: [
+        {
+          type: "mrkdwn",
+          text: `:clipboard: <${logsUrl}|Audit>`,
+        },
+      ],
+    });
+  }
+
+  if (footerText) {
+    blocks.push({
+      type: "context",
+      elements: [
+        {
+          type: "mrkdwn",
+          text: footerText,
+        },
+      ],
+    });
+  }
+
+  return blocks;
+}
 
 /**
  * Build a divider + context block pair for message footers.

--- a/turbo/apps/api/src/signals/external/slack-message-client.ts
+++ b/turbo/apps/api/src/signals/external/slack-message-client.ts
@@ -82,6 +82,19 @@ export async function postMessage(
   return { kind: "ok", ts: result.ok.ts, channel: result.ok.channel };
 }
 
+export async function setThreadStatus(
+  client: WebClient,
+  channel: string,
+  threadTs: string,
+  status: string,
+): Promise<void> {
+  await client.assistant.threads.setStatus({
+    channel_id: channel,
+    thread_ts: threadTs,
+    status,
+  });
+}
+
 export async function postEphemeral(
   client: WebClient,
   options: {

--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -32,6 +32,7 @@ import { githubOauthRoutes } from "./routes/github-oauth";
 import { internalCallbacksAgentRoutes } from "./routes/internal-callbacks-agent";
 import { internalCallbacksGithubIssuesRoutes } from "./routes/internal-callbacks-github-issues";
 import { internalCallbacksScheduleRoutes } from "./routes/internal-callbacks-schedule";
+import { internalCallbacksSlackOrgRoutes } from "./routes/internal-callbacks-slack-org";
 import { internalCallbacksTelegramRoutes } from "./routes/internal-callbacks-telegram";
 import { internalEventConsumerAxiomRoutes } from "./routes/internal-event-consumers-axiom";
 import { internalEventConsumerChatAssistantRoutes } from "./routes/internal-event-consumers-chat-assistant";
@@ -154,6 +155,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...internalCallbacksAgentRoutes,
   ...internalCallbacksGithubIssuesRoutes,
   ...internalCallbacksScheduleRoutes,
+  ...internalCallbacksSlackOrgRoutes,
   ...internalCallbacksTelegramRoutes,
   ...internalEventConsumerAxiomRoutes,
   ...internalEventConsumerChatAssistantRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-slack-org.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-slack-org.test.ts
@@ -1,0 +1,524 @@
+import { randomUUID } from "node:crypto";
+
+import { createStore } from "ccstate";
+import { and, eq } from "drizzle-orm";
+import { beforeEach, describe, expect, it } from "vitest";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import { agentRuns } from "@vm0/db/schema/agent-run";
+import { modelProviders } from "@vm0/db/schema/model-provider";
+import { orgMetadata } from "@vm0/db/schema/org-metadata";
+import { slackOrgConnections } from "@vm0/db/schema/slack-org-connection";
+import { slackOrgThreadSessions } from "@vm0/db/schema/slack-org-thread-session";
+import { userFeatureSwitches } from "@vm0/db/schema/user-feature-switches";
+import { zeroRuns } from "@vm0/db/schema/zero-run";
+
+import { createApp } from "../../../app-factory";
+import { testContext } from "../../../__tests__/test-helpers";
+import { computeHmacSignature } from "../../../lib/event-consumer/hmac";
+import { now } from "../../../lib/time";
+import { writeDb$ } from "../../external/db";
+import { seedAgentRunCallback$ } from "./helpers/agent-run-callback";
+import {
+  deleteOrgModelProviders$,
+  seedOrgModelProvider$,
+} from "./helpers/zero-model-providers";
+import { createFixtureTracker } from "./helpers/zero-route-test";
+import {
+  deleteSlackIntegrationFixture$,
+  seedSlackOrgInstallation$,
+  type SlackIntegrationFixture,
+} from "./helpers/zero-integrations-slack";
+import {
+  deleteUsageInsightFixture$,
+  seedCompose$,
+  seedRun$,
+  seedUsageInsightFixture$,
+  type UsageInsightFixture,
+} from "./helpers/zero-usage-insight";
+
+const context = testContext();
+const store = createStore();
+
+const PATH = "/api/internal/callbacks/slack/org";
+const TEST_CALLBACK_SECRET = "test-callback-secret";
+
+interface SlackOrgCallbackPayload {
+  readonly workspaceId: string;
+  readonly channelId: string;
+  readonly threadTs: string;
+  readonly messageTs: string;
+  readonly connectionId: string;
+  readonly agentId: string;
+  readonly existingSessionId?: string;
+}
+
+interface SlackOrgCallbackFixture extends UsageInsightFixture {
+  readonly composeId: string;
+  readonly slackWorkspaceId: string;
+  readonly slackUserId: string;
+  readonly connectionId: string;
+  readonly runId: string;
+  readonly callbackId: string;
+  readonly payload: SlackOrgCallbackPayload;
+}
+
+interface SlackPostMessageCall {
+  readonly channel: string;
+  readonly thread_ts?: string;
+  readonly text: string;
+  readonly blocks?: unknown[];
+}
+
+async function seedSlackConnection(args: {
+  readonly slackWorkspaceId: string;
+  readonly vm0UserId: string;
+  readonly slackUserId?: string;
+}): Promise<{ readonly connectionId: string; readonly slackUserId: string }> {
+  const db = store.set(writeDb$);
+  const slackUserId =
+    args.slackUserId ??
+    `U${randomUUID().replaceAll("-", "").slice(0, 9).toUpperCase()}`;
+  const [row] = await db
+    .insert(slackOrgConnections)
+    .values({
+      slackUserId,
+      slackWorkspaceId: args.slackWorkspaceId,
+      vm0UserId: args.vm0UserId,
+    })
+    .returning({ id: slackOrgConnections.id });
+  if (!row) {
+    throw new Error("seedSlackConnection: insert returned no row");
+  }
+  return { connectionId: row.id, slackUserId };
+}
+
+async function seedFixture(): Promise<SlackOrgCallbackFixture> {
+  const base = await store.set(
+    seedUsageInsightFixture$,
+    undefined,
+    context.signal,
+  );
+  const { composeId } = await store.set(
+    seedCompose$,
+    {
+      orgId: base.orgId,
+      userId: base.userId,
+      name: `slack-callback-${randomUUID().slice(0, 8)}`,
+      displayName: "Slack Agent",
+    },
+    context.signal,
+  );
+  const slackFixture = await store.set(
+    seedSlackOrgInstallation$,
+    { orgId: base.orgId },
+    context.signal,
+  );
+  const { connectionId, slackUserId } = await seedSlackConnection({
+    slackWorkspaceId: slackFixture.slackWorkspaceId,
+    vm0UserId: base.userId,
+  });
+  const { runId } = await store.set(
+    seedRun$,
+    {
+      orgId: base.orgId,
+      userId: base.userId,
+      composeId,
+      triggerSource: "slack",
+      prompt: "Handle Slack thread",
+      lastEventSequence: 0,
+    },
+    context.signal,
+  );
+  const payload: SlackOrgCallbackPayload = {
+    workspaceId: slackFixture.slackWorkspaceId,
+    channelId: `C${randomUUID().replaceAll("-", "").slice(0, 9)}`,
+    threadTs: "1715000000.000100",
+    messageTs: "1715000000.000100",
+    connectionId,
+    agentId: composeId,
+  };
+  const { callbackId } = await store.set(
+    seedAgentRunCallback$,
+    {
+      runId,
+      url: `http://localhost${PATH}`,
+      payload: payload as unknown as Record<string, unknown>,
+    },
+    context.signal,
+  );
+
+  return {
+    ...base,
+    composeId,
+    slackWorkspaceId: slackFixture.slackWorkspaceId,
+    slackUserId,
+    connectionId,
+    runId,
+    callbackId,
+    payload,
+  };
+}
+
+async function deleteFixture(fixture: SlackOrgCallbackFixture): Promise<void> {
+  const db = store.set(writeDb$);
+  await db
+    .delete(userFeatureSwitches)
+    .where(
+      and(
+        eq(userFeatureSwitches.orgId, fixture.orgId),
+        eq(userFeatureSwitches.userId, fixture.userId),
+      ),
+    );
+  await db.delete(orgMetadata).where(eq(orgMetadata.orgId, fixture.orgId));
+  await db
+    .delete(modelProviders)
+    .where(eq(modelProviders.orgId, fixture.orgId));
+  const slackFixture: SlackIntegrationFixture = {
+    orgId: fixture.orgId,
+    slackWorkspaceId: fixture.slackWorkspaceId,
+  };
+  await store.set(deleteSlackIntegrationFixture$, slackFixture, context.signal);
+  await store.set(deleteOrgModelProviders$, fixture, context.signal);
+  await store.set(deleteUsageInsightFixture$, fixture, context.signal);
+}
+
+function signedHeaders(rawBody: string, secret = TEST_CALLBACK_SECRET) {
+  const timestamp = Math.floor(now() / 1000);
+  return {
+    "Content-Type": "application/json",
+    "X-VM0-Signature": computeHmacSignature(rawBody, secret, timestamp),
+    "X-VM0-Timestamp": String(timestamp),
+  };
+}
+
+async function postSignedCallback(
+  body: Record<string, unknown>,
+  secret?: string,
+): Promise<Response> {
+  const rawBody = JSON.stringify(body);
+  const app = createApp({ signal: context.signal });
+  return await app.request(PATH, {
+    method: "POST",
+    headers: signedHeaders(rawBody, secret),
+    body: rawBody,
+  });
+}
+
+function completedOutput(text = "SLACK_CALLBACK_OUTPUT"): void {
+  context.mocks.axiom.query.mockResolvedValueOnce([
+    {
+      eventType: "result",
+      eventData: { result: text },
+    },
+  ]);
+}
+
+async function enableAuditLink(
+  fixture: SlackOrgCallbackFixture,
+): Promise<void> {
+  const db = store.set(writeDb$);
+  await db.insert(userFeatureSwitches).values({
+    orgId: fixture.orgId,
+    userId: fixture.userId,
+    switches: { [FeatureSwitchKey.AuditLink]: true },
+  });
+}
+
+async function setOrgDefaultAgent(
+  fixture: SlackOrgCallbackFixture,
+  defaultAgentId: string | null,
+): Promise<void> {
+  const db = store.set(writeDb$);
+  await db
+    .insert(orgMetadata)
+    .values({ orgId: fixture.orgId, defaultAgentId })
+    .onConflictDoUpdate({
+      target: orgMetadata.orgId,
+      set: { defaultAgentId },
+    });
+}
+
+async function setRunSelectedModel(
+  runId: string,
+  selectedModel: string,
+): Promise<void> {
+  const db = store.set(writeDb$);
+  await db
+    .update(zeroRuns)
+    .set({ selectedModel })
+    .where(eq(zeroRuns.id, runId));
+}
+
+async function seedAdditionalMentioner(
+  fixture: SlackOrgCallbackFixture,
+): Promise<string> {
+  const { connectionId, slackUserId } = await seedSlackConnection({
+    slackWorkspaceId: fixture.slackWorkspaceId,
+    vm0UserId: `user_${randomUUID()}`,
+  });
+  const db = store.set(writeDb$);
+  await db.insert(slackOrgThreadSessions).values({
+    connectionId,
+    slackChannelId: fixture.payload.channelId,
+    slackThreadTs: fixture.payload.threadTs,
+    agentSessionId: null,
+  });
+  return slackUserId;
+}
+
+async function findThreadSession(
+  fixture: SlackOrgCallbackFixture,
+): Promise<{ readonly agentSessionId: string | null } | null> {
+  const db = store.set(writeDb$);
+  const [row] = await db
+    .select({ agentSessionId: slackOrgThreadSessions.agentSessionId })
+    .from(slackOrgThreadSessions)
+    .where(
+      and(
+        eq(slackOrgThreadSessions.connectionId, fixture.connectionId),
+        eq(slackOrgThreadSessions.slackChannelId, fixture.payload.channelId),
+        eq(slackOrgThreadSessions.slackThreadTs, fixture.payload.threadTs),
+      ),
+    )
+    .limit(1);
+  return row ?? null;
+}
+
+function firstPostMessageCall(): SlackPostMessageCall {
+  return context.mocks.slack.chat.postMessage.mock
+    .calls[0]![0] as SlackPostMessageCall;
+}
+
+describe("POST /api/internal/callbacks/slack/org", () => {
+  const track = createFixtureTracker<SlackOrgCallbackFixture>((fixture) => {
+    return deleteFixture(fixture);
+  });
+
+  beforeEach(() => {
+    context.mocks.slack.chat.postMessage.mockResolvedValue({
+      ok: true,
+      ts: "1715000000.000200",
+      channel: "C-callback",
+    });
+    context.mocks.slack.assistant.threads.setStatus.mockResolvedValue({
+      ok: true,
+    });
+  });
+
+  it("rejects requests with invalid signatures", async () => {
+    const fixture = await track(seedFixture());
+
+    const response = await postSignedCallback(
+      {
+        callbackId: fixture.callbackId,
+        runId: fixture.runId,
+        status: "completed",
+        payload: fixture.payload,
+      },
+      "wrong-secret",
+    );
+
+    expect(response.status).toBe(401);
+  });
+
+  it("rejects invalid payloads after callback verification", async () => {
+    const fixture = await track(seedFixture());
+
+    const response = await postSignedCallback({
+      callbackId: fixture.callbackId,
+      runId: fixture.runId,
+      status: "completed",
+      payload: { workspaceId: fixture.slackWorkspaceId },
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toStrictEqual({
+      error: "Invalid or missing payload",
+    });
+  });
+
+  it("sets thinking status for progress callbacks", async () => {
+    const fixture = await track(seedFixture());
+
+    const response = await postSignedCallback({
+      callbackId: fixture.callbackId,
+      runId: fixture.runId,
+      status: "progress",
+      payload: fixture.payload,
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toStrictEqual({ success: true });
+    expect(
+      context.mocks.slack.assistant.threads.setStatus,
+    ).toHaveBeenCalledWith({
+      channel_id: fixture.payload.channelId,
+      thread_ts: fixture.payload.threadTs,
+      status: "is thinking...",
+    });
+    expect(context.mocks.slack.chat.postMessage).not.toHaveBeenCalled();
+  });
+
+  it("returns success for progress callbacks when installation is missing", async () => {
+    const fixture = await track(seedFixture());
+
+    const response = await postSignedCallback({
+      callbackId: fixture.callbackId,
+      runId: fixture.runId,
+      status: "progress",
+      payload: { ...fixture.payload, workspaceId: "T_missing" },
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toStrictEqual({ success: true });
+    expect(
+      context.mocks.slack.assistant.threads.setStatus,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("posts completion output, saves the thread session, and clears status", async () => {
+    const fixture = await track(seedFixture());
+    completedOutput();
+
+    const response = await postSignedCallback({
+      callbackId: fixture.callbackId,
+      runId: fixture.runId,
+      status: "completed",
+      payload: fixture.payload,
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toStrictEqual({ success: true });
+
+    const call = firstPostMessageCall();
+    expect(call).toMatchObject({
+      channel: fixture.payload.channelId,
+      thread_ts: fixture.payload.threadTs,
+      text: "SLACK_CALLBACK_OUTPUT",
+    });
+    expect(JSON.stringify(call.blocks)).toContain("SLACK_CALLBACK_OUTPUT");
+
+    const [run] = await store
+      .set(writeDb$)
+      .select({ sessionId: agentRuns.sessionId })
+      .from(agentRuns)
+      .where(eq(agentRuns.id, fixture.runId))
+      .limit(1);
+    const session = await findThreadSession(fixture);
+    expect(session?.agentSessionId).toBe(run?.sessionId);
+
+    expect(
+      context.mocks.slack.assistant.threads.setStatus,
+    ).toHaveBeenLastCalledWith({
+      channel_id: fixture.payload.channelId,
+      thread_ts: fixture.payload.threadTs,
+      status: "",
+    });
+  });
+
+  it("renders audit, responded-by, reply-to, and selected-model footer text", async () => {
+    const fixture = await track(seedFixture());
+    await enableAuditLink(fixture);
+    await setOrgDefaultAgent(fixture, null);
+    await setRunSelectedModel(fixture.runId, "claude-opus-4-7");
+    await seedAdditionalMentioner(fixture);
+    completedOutput("footer output");
+
+    const response = await postSignedCallback({
+      callbackId: fixture.callbackId,
+      runId: fixture.runId,
+      status: "completed",
+      payload: fixture.payload,
+    });
+
+    expect(response.status).toBe(200);
+    const blocks = JSON.stringify(firstPostMessageCall().blocks);
+    expect(blocks).toContain("Audit");
+    expect(blocks).toContain(`/activities/${fixture.runId}`);
+    expect(blocks).toContain("Responded by Slack Agent");
+    expect(blocks).toContain(`Reply to <@${fixture.slackUserId}>`);
+    expect(blocks).toContain("Claude Opus 4.7");
+  });
+
+  it("uses the org default claude-code provider model when the run has no selected model", async () => {
+    const fixture = await track(seedFixture());
+    await setOrgDefaultAgent(fixture, fixture.composeId);
+    await store.set(
+      seedOrgModelProvider$,
+      {
+        orgId: fixture.orgId,
+        type: "anthropic-api-key",
+        isDefault: true,
+        selectedModel: "claude-sonnet-4-6",
+      },
+      context.signal,
+    );
+    completedOutput("model fallback output");
+
+    const response = await postSignedCallback({
+      callbackId: fixture.callbackId,
+      runId: fixture.runId,
+      status: "completed",
+      payload: fixture.payload,
+    });
+
+    expect(response.status).toBe(200);
+    const blocks = JSON.stringify(firstPostMessageCall().blocks);
+    expect(blocks).toContain("Claude Sonnet 4.6");
+    expect(blocks).not.toContain("Responded by");
+  });
+
+  it("posts failed-run errors without saving a thread session", async () => {
+    const fixture = await track(seedFixture());
+
+    const response = await postSignedCallback({
+      callbackId: fixture.callbackId,
+      runId: fixture.runId,
+      status: "failed",
+      error: "Something broke",
+      payload: fixture.payload,
+    });
+
+    expect(response.status).toBe(200);
+    expect(firstPostMessageCall().text).toContain("Something broke");
+    await expect(findThreadSession(fixture)).resolves.toBeNull();
+  });
+
+  it("returns 404 when installation is not found for terminal callbacks", async () => {
+    const fixture = await track(seedFixture());
+
+    const response = await postSignedCallback({
+      callbackId: fixture.callbackId,
+      runId: fixture.runId,
+      status: "completed",
+      payload: { ...fixture.payload, workspaceId: "T_missing" },
+    });
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toStrictEqual({
+      error: "Slack installation not found",
+    });
+  });
+
+  it("maps Slack API platform errors to callback errors", async () => {
+    const fixture = await track(seedFixture());
+    completedOutput();
+    context.mocks.slack.chat.postMessage.mockRejectedValueOnce(
+      Object.assign(new Error("channel_not_found"), {
+        data: { ok: false, error: "channel_not_found" },
+      }),
+    );
+
+    const response = await postSignedCallback({
+      callbackId: fixture.callbackId,
+      runId: fixture.runId,
+      status: "completed",
+      payload: fixture.payload,
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toStrictEqual({
+      error: "Slack API error: channel_not_found",
+    });
+  });
+});

--- a/turbo/apps/api/src/signals/routes/internal-callbacks-slack-org.ts
+++ b/turbo/apps/api/src/signals/routes/internal-callbacks-slack-org.ts
@@ -1,0 +1,584 @@
+import { command } from "ccstate";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import { isFeatureEnabled } from "@vm0/core/feature-switch";
+import { getModelDisplayName } from "@vm0/core/model-display-name";
+import {
+  getFrameworkForType,
+  modelProviderTypeSchema,
+} from "@vm0/api-contracts/contracts/model-providers";
+import {
+  internalCallbacksSlackOrgContract,
+  slackOrgCallbackPayloadSchema,
+  type SlackOrgCallbackPayload,
+} from "@vm0/api-contracts/contracts/internal-callbacks-slack-org";
+import { agentRuns } from "@vm0/db/schema/agent-run";
+import { modelProviders } from "@vm0/db/schema/model-provider";
+import { orgMetadata } from "@vm0/db/schema/org-metadata";
+import { slackOrgConnections } from "@vm0/db/schema/slack-org-connection";
+import { slackOrgInstallations } from "@vm0/db/schema/slack-org-installation";
+import { slackOrgThreadSessions } from "@vm0/db/schema/slack-org-thread-session";
+import { zeroAgents } from "@vm0/db/schema/zero-agent";
+import { zeroRuns } from "@vm0/db/schema/zero-run";
+import { and, eq, sql } from "drizzle-orm";
+
+import {
+  callbackPayload$,
+  callbackRoute,
+} from "../../lib/callback-route/callback-route";
+import { buildAgentResponseMessage } from "../../lib/slack-blocks";
+import type { RouteEntry } from "../route";
+import { env } from "../../lib/env";
+import { logger } from "../../lib/log";
+import { nowDate } from "../external/time";
+import { writeDb$, type Db } from "../external/db";
+import {
+  createSlackClient,
+  postMessage,
+  setThreadStatus,
+} from "../external/slack-message-client";
+import { decryptSecretValue } from "../services/crypto.utils";
+import { userFeatureSwitchOverrides } from "../services/feature-switches.service";
+import { getRunOutputText } from "../services/run-output.service";
+import { saveRunSummary$ } from "../services/run-summary.service";
+
+const L = logger("InternalCallbacksSlackOrg");
+const ORG_SENTINEL_USER_ID = "__org__";
+
+type TerminalStatus = "completed" | "failed";
+
+interface RunContext {
+  readonly userId: string;
+  readonly orgId: string;
+  readonly prompt: string;
+  readonly sessionId: string | null;
+  readonly lastEventSequence: number | null;
+}
+
+interface SlackInstallation {
+  readonly encryptedBotToken: string;
+}
+
+type SlackOrgCallbackResult =
+  | { readonly status: 200; readonly body: { readonly success: true } }
+  | {
+      readonly status: 400 | 404 | 502;
+      readonly body: { readonly error: string };
+    };
+
+function successResponse(): {
+  readonly status: 200;
+  readonly body: { readonly success: true };
+} {
+  return { status: 200, body: { success: true } };
+}
+
+function errorResponse(
+  status: 400 | 404 | 502,
+  message: string,
+): {
+  readonly status: 400 | 404 | 502;
+  readonly body: { readonly error: string };
+} {
+  return { status, body: { error: message } };
+}
+
+function parsePayload(payload: unknown): SlackOrgCallbackPayload | null {
+  const result = slackOrgCallbackPayloadSchema.safeParse(payload);
+  return result.success ? result.data : null;
+}
+
+function buildLogsUrl(runId: string): string {
+  return `${env("VM0_WEB_URL")}/activities/${encodeURIComponent(runId)}`;
+}
+
+async function loadInstallation(args: {
+  readonly db: Db;
+  readonly workspaceId: string;
+  readonly signal: AbortSignal;
+}): Promise<SlackInstallation | undefined> {
+  const [installation] = await args.db
+    .select({ encryptedBotToken: slackOrgInstallations.encryptedBotToken })
+    .from(slackOrgInstallations)
+    .where(eq(slackOrgInstallations.slackWorkspaceId, args.workspaceId))
+    .limit(1);
+  args.signal.throwIfAborted();
+  return installation;
+}
+
+async function loadRunContext(args: {
+  readonly db: Db;
+  readonly runId: string;
+  readonly signal: AbortSignal;
+}): Promise<RunContext | undefined> {
+  const [run] = await args.db
+    .select({
+      userId: agentRuns.userId,
+      orgId: agentRuns.orgId,
+      prompt: agentRuns.prompt,
+      sessionId: agentRuns.sessionId,
+      lastEventSequence: agentRuns.lastEventSequence,
+    })
+    .from(agentRuns)
+    .where(eq(agentRuns.id, args.runId))
+    .limit(1);
+  args.signal.throwIfAborted();
+  return run;
+}
+
+async function resolveRunSelectedModel(
+  db: Db,
+  runId: string,
+): Promise<string | undefined> {
+  const [row] = await db
+    .select({ selectedModel: zeroRuns.selectedModel })
+    .from(zeroRuns)
+    .where(eq(zeroRuns.id, runId))
+    .limit(1);
+  return row?.selectedModel ?? undefined;
+}
+
+async function resolveReplyToMention(
+  db: Db,
+  connectionId: string,
+): Promise<string | undefined> {
+  const [row] = await db
+    .select({ slackUserId: slackOrgConnections.slackUserId })
+    .from(slackOrgConnections)
+    .where(eq(slackOrgConnections.id, connectionId))
+    .limit(1);
+  return row?.slackUserId ? `<@${row.slackUserId}>` : undefined;
+}
+
+async function countThreadMentioners(args: {
+  readonly db: Db;
+  readonly workspaceId: string;
+  readonly channelId: string;
+  readonly threadTs: string;
+}): Promise<number> {
+  const [row] = await args.db
+    .select({
+      count: sql<number>`count(distinct ${slackOrgThreadSessions.connectionId})::int`,
+    })
+    .from(slackOrgThreadSessions)
+    .innerJoin(
+      slackOrgConnections,
+      eq(slackOrgThreadSessions.connectionId, slackOrgConnections.id),
+    )
+    .where(
+      and(
+        eq(slackOrgConnections.slackWorkspaceId, args.workspaceId),
+        eq(slackOrgThreadSessions.slackChannelId, args.channelId),
+        eq(slackOrgThreadSessions.slackThreadTs, args.threadTs),
+      ),
+    );
+  return row?.count ?? 0;
+}
+
+async function resolveRespondedByLabel(args: {
+  readonly db: Db;
+  readonly orgId: string;
+  readonly composeId: string;
+}): Promise<string | undefined> {
+  const [orgRow] = await args.db
+    .select({ defaultAgentId: orgMetadata.defaultAgentId })
+    .from(orgMetadata)
+    .where(eq(orgMetadata.orgId, args.orgId))
+    .limit(1);
+
+  if (args.composeId === orgRow?.defaultAgentId) {
+    return undefined;
+  }
+
+  const [agent] = await args.db
+    .select({ displayName: zeroAgents.displayName, name: zeroAgents.name })
+    .from(zeroAgents)
+    .where(eq(zeroAgents.id, args.composeId))
+    .limit(1);
+  const label = agent?.displayName ?? agent?.name;
+  return label ? `Responded by ${label}` : undefined;
+}
+
+async function resolveOrgDefaultModelProviderSelectedModel(
+  db: Db,
+  orgId: string,
+): Promise<string | undefined> {
+  const rows = await db
+    .select({
+      type: modelProviders.type,
+      selectedModel: modelProviders.selectedModel,
+    })
+    .from(modelProviders)
+    .where(
+      and(
+        eq(modelProviders.orgId, orgId),
+        eq(modelProviders.userId, ORG_SENTINEL_USER_ID),
+        eq(modelProviders.isDefault, true),
+      ),
+    );
+  const row = rows.find((candidate) => {
+    const parsed = modelProviderTypeSchema.safeParse(candidate.type);
+    return parsed.success && getFrameworkForType(parsed.data) === "claude-code";
+  });
+  return row?.selectedModel ?? undefined;
+}
+
+async function resolveModelLabel(args: {
+  readonly db: Db;
+  readonly orgId: string;
+  readonly runId: string;
+}): Promise<string | undefined> {
+  const selectedModel = await resolveRunSelectedModel(args.db, args.runId);
+  const model =
+    selectedModel ??
+    (await resolveOrgDefaultModelProviderSelectedModel(args.db, args.orgId));
+  return model ? getModelDisplayName(model) : undefined;
+}
+
+async function resolveFooterText(args: {
+  readonly db: Db;
+  readonly orgId: string;
+  readonly runId: string;
+  readonly payload: SlackOrgCallbackPayload;
+}): Promise<string | undefined> {
+  const [respondedBy, mentionerCount, modelLabel] = await Promise.all([
+    resolveRespondedByLabel({
+      db: args.db,
+      orgId: args.orgId,
+      composeId: args.payload.agentId,
+    }),
+    countThreadMentioners({
+      db: args.db,
+      workspaceId: args.payload.workspaceId,
+      channelId: args.payload.channelId,
+      threadTs: args.payload.threadTs,
+    }),
+    resolveModelLabel({
+      db: args.db,
+      orgId: args.orgId,
+      runId: args.runId,
+    }),
+  ]);
+
+  const parts: string[] = [];
+  if (respondedBy) {
+    parts.push(respondedBy);
+  }
+  if (mentionerCount > 1) {
+    const replyTo = await resolveReplyToMention(
+      args.db,
+      args.payload.connectionId,
+    );
+    if (replyTo) {
+      parts.push(`Reply to ${replyTo}`);
+    }
+  }
+  if (modelLabel) {
+    parts.push(modelLabel);
+  }
+
+  return parts.length > 0 ? parts.join(" · ") : undefined;
+}
+
+async function resolveAuditLogsUrl(args: {
+  readonly runId: string;
+  readonly run: RunContext | undefined;
+  readonly getFeatureOverrides: (
+    orgId: string,
+    userId: string,
+  ) => Promise<Record<string, boolean>>;
+  readonly signal: AbortSignal;
+}): Promise<string | undefined> {
+  if (!args.run) {
+    return undefined;
+  }
+
+  const overrides = await args.getFeatureOverrides(
+    args.run.orgId,
+    args.run.userId,
+  );
+  args.signal.throwIfAborted();
+  const typedOverrides =
+    Object.keys(overrides).length > 0
+      ? (overrides as Partial<Record<FeatureSwitchKey, boolean>>)
+      : undefined;
+  const enabled = isFeatureEnabled(FeatureSwitchKey.AuditLink, {
+    userId: args.run.userId,
+    orgId: args.run.orgId,
+    overrides: typedOverrides,
+  });
+  return enabled ? buildLogsUrl(args.runId) : undefined;
+}
+
+async function saveOrgThreadSession(args: {
+  readonly db: Db;
+  readonly payload: SlackOrgCallbackPayload;
+  readonly run: RunContext | undefined;
+  readonly status: TerminalStatus;
+  readonly signal: AbortSignal;
+}): Promise<void> {
+  if (args.status === "failed" || !args.run) {
+    return;
+  }
+
+  const agentSessionId = args.payload.existingSessionId ?? args.run.sessionId;
+  if (args.payload.existingSessionId || !agentSessionId) {
+    return;
+  }
+
+  await args.db
+    .insert(slackOrgThreadSessions)
+    .values({
+      connectionId: args.payload.connectionId,
+      slackChannelId: args.payload.channelId,
+      slackThreadTs: args.payload.threadTs,
+      agentSessionId,
+    })
+    .onConflictDoUpdate({
+      target: [
+        slackOrgThreadSessions.connectionId,
+        slackOrgThreadSessions.slackChannelId,
+        slackOrgThreadSessions.slackThreadTs,
+      ],
+      set: {
+        agentSessionId,
+        updatedAt: nowDate(),
+      },
+    });
+  args.signal.throwIfAborted();
+}
+
+function buildResponseText(args: {
+  readonly status: TerminalStatus;
+  readonly error: string | undefined;
+  readonly output: string | undefined;
+}): string {
+  if (args.status === "failed") {
+    return `Error: ${args.error ?? "Agent execution failed."}`;
+  }
+  return args.output ?? "Task completed successfully.";
+}
+
+function refreshThreadStatus(args: {
+  readonly token: string;
+  readonly channelId: string;
+  readonly threadTs: string;
+  readonly status: string;
+  readonly runId: string;
+  readonly failureMessage: string;
+}): void {
+  const client = createSlackClient(args.token);
+  void setThreadStatus(
+    client,
+    args.channelId,
+    args.threadTs,
+    args.status,
+  ).catch((error: unknown) => {
+    L.warn(args.failureMessage, { runId: args.runId, error });
+  });
+}
+
+async function resolveCompletionText(args: {
+  readonly runId: string;
+  readonly status: TerminalStatus;
+  readonly run: RunContext | undefined;
+  readonly signal: AbortSignal;
+}): Promise<string | undefined> {
+  if (args.status === "failed") {
+    return undefined;
+  }
+
+  const output = await getRunOutputText(args.runId, {
+    waitForOutput: false,
+    knownLastEventSequence: args.run?.lastEventSequence,
+    signal: args.signal,
+  });
+  args.signal.throwIfAborted();
+  return output;
+}
+
+async function handleProgress(args: {
+  readonly db: Db;
+  readonly runId: string;
+  readonly payload: SlackOrgCallbackPayload;
+  readonly signal: AbortSignal;
+}): Promise<SlackOrgCallbackResult> {
+  const installation = await loadInstallation({
+    db: args.db,
+    workspaceId: args.payload.workspaceId,
+    signal: args.signal,
+  });
+
+  if (installation) {
+    refreshThreadStatus({
+      token: decryptSecretValue(installation.encryptedBotToken),
+      channelId: args.payload.channelId,
+      threadTs: args.payload.threadTs,
+      status: "is thinking...",
+      runId: args.runId,
+      failureMessage: "Failed to set thinking thread status",
+    });
+  }
+
+  return successResponse();
+}
+
+async function handleCompletion(args: {
+  readonly db: Db;
+  readonly runId: string;
+  readonly status: TerminalStatus;
+  readonly error: string | undefined;
+  readonly payload: SlackOrgCallbackPayload;
+  readonly getFeatureOverrides: (
+    orgId: string,
+    userId: string,
+  ) => Promise<Record<string, boolean>>;
+  readonly saveRunSummary: (
+    runId: string,
+    prompt: string,
+    resultText: string,
+  ) => Promise<void>;
+  readonly signal: AbortSignal;
+}): Promise<SlackOrgCallbackResult> {
+  const installation = await loadInstallation({
+    db: args.db,
+    workspaceId: args.payload.workspaceId,
+    signal: args.signal,
+  });
+  if (!installation) {
+    L.error("Slack org installation not found", {
+      workspaceId: args.payload.workspaceId,
+    });
+    return errorResponse(404, "Slack installation not found");
+  }
+
+  const botToken = decryptSecretValue(installation.encryptedBotToken);
+  const run = await loadRunContext({
+    db: args.db,
+    runId: args.runId,
+    signal: args.signal,
+  });
+  const output = await resolveCompletionText({
+    runId: args.runId,
+    status: args.status,
+    run,
+    signal: args.signal,
+  });
+  const logsUrl = await resolveAuditLogsUrl({
+    runId: args.runId,
+    run,
+    getFeatureOverrides: args.getFeatureOverrides,
+    signal: args.signal,
+  });
+
+  await saveOrgThreadSession({
+    db: args.db,
+    payload: args.payload,
+    run,
+    status: args.status,
+    signal: args.signal,
+  });
+
+  const footerText = run
+    ? await resolveFooterText({
+        db: args.db,
+        orgId: run.orgId,
+        runId: args.runId,
+        payload: args.payload,
+      })
+    : undefined;
+  args.signal.throwIfAborted();
+
+  const responseText = buildResponseText({
+    status: args.status,
+    error: args.error,
+    output,
+  });
+  const client = createSlackClient(botToken);
+  const postResult = await postMessage(
+    client,
+    args.payload.channelId,
+    responseText,
+    {
+      threadTs: args.payload.threadTs,
+      blocks: buildAgentResponseMessage(responseText, logsUrl, footerText),
+    },
+  );
+  args.signal.throwIfAborted();
+  if (postResult.kind === "slack_error") {
+    return errorResponse(400, `Slack API error: ${postResult.error}`);
+  }
+
+  if (run?.prompt) {
+    await args.saveRunSummary(args.runId, run.prompt, output ?? "");
+    args.signal.throwIfAborted();
+  }
+
+  refreshThreadStatus({
+    token: botToken,
+    channelId: args.payload.channelId,
+    threadTs: args.payload.threadTs,
+    status: "",
+    runId: args.runId,
+    failureMessage: "Failed to clear thread status",
+  });
+
+  L.debug("Slack org callback processed successfully", { runId: args.runId });
+  return successResponse();
+}
+
+const handleSlackOrgCallback$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const callback = get(callbackPayload$);
+    const payload = parsePayload(callback.payload);
+    if (!payload) {
+      return errorResponse(400, "Invalid or missing payload");
+    }
+
+    L.debug("Processing org Slack callback", {
+      runId: callback.runId,
+      status: callback.status,
+      channelId: payload.channelId,
+    });
+
+    const db = set(writeDb$);
+    if (callback.status === "progress") {
+      return await handleProgress({
+        db,
+        runId: callback.runId,
+        payload,
+        signal,
+      });
+    }
+
+    return await handleCompletion({
+      db,
+      runId: callback.runId,
+      status: callback.status,
+      error: callback.error,
+      payload,
+      getFeatureOverrides: (orgId, userId) => {
+        return get(userFeatureSwitchOverrides(orgId, userId));
+      },
+      saveRunSummary: (runId, prompt, resultText) => {
+        return set(
+          saveRunSummary$,
+          {
+            runId,
+            triggerSource: "slack",
+            prompt,
+            resultText,
+          },
+          signal,
+        );
+      },
+      signal,
+    });
+  },
+);
+
+export const internalCallbacksSlackOrgRoutes: readonly RouteEntry[] = [
+  {
+    route: internalCallbacksSlackOrgContract.post,
+    handler: callbackRoute(handleSlackOrgCallback$),
+  },
+];

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -178,6 +178,12 @@ export {
   type TelegramCallbackPayload,
 } from "./internal-callbacks-telegram";
 export {
+  internalCallbacksSlackOrgContract,
+  slackOrgCallbackPayloadSchema,
+  type InternalCallbacksSlackOrgContract,
+  type SlackOrgCallbackPayload,
+} from "./internal-callbacks-slack-org";
+export {
   sandboxReuseResultSchema,
   webhookEventsContract,
   webhookCompleteContract,

--- a/turbo/packages/api-contracts/src/contracts/internal-callbacks-slack-org.ts
+++ b/turbo/packages/api-contracts/src/contracts/internal-callbacks-slack-org.ts
@@ -1,0 +1,49 @@
+import { z } from "zod";
+
+import { initContract } from "./base";
+import {
+  internalCallbackBodySchema,
+  internalCallbackErrorSchema,
+  internalCallbackHeadersSchema,
+  internalCallbackSuccessSchema,
+} from "./internal-callbacks-shared";
+
+const c = initContract();
+
+export const slackOrgCallbackPayloadSchema = z
+  .object({
+    workspaceId: z.string(),
+    channelId: z.string(),
+    threadTs: z.string(),
+    messageTs: z.string(),
+    connectionId: z.string(),
+    agentId: z.string(),
+    existingSessionId: z.string().optional(),
+  })
+  .passthrough();
+
+export const internalCallbacksSlackOrgContract = c.router({
+  post: {
+    method: "POST",
+    path: "/api/internal/callbacks/slack/org",
+    headers: internalCallbackHeadersSchema,
+    body: internalCallbackBodySchema.extend({
+      payload: slackOrgCallbackPayloadSchema,
+    }),
+    responses: {
+      200: internalCallbackSuccessSchema,
+      400: internalCallbackErrorSchema,
+      401: internalCallbackErrorSchema,
+      404: internalCallbackErrorSchema,
+      500: internalCallbackErrorSchema,
+      502: internalCallbackErrorSchema,
+    },
+    summary: "Handle callbacks for org Slack-triggered runs",
+  },
+});
+
+export type SlackOrgCallbackPayload = z.infer<
+  typeof slackOrgCallbackPayloadSchema
+>;
+export type InternalCallbacksSlackOrgContract =
+  typeof internalCallbacksSlackOrgContract;


### PR DESCRIPTION
## Summary
- add a ts-rest contract and API route for `POST /api/internal/callbacks/slack/org`
- preserve org Slack callback behavior for progress status, terminal Slack replies, audit/footer rendering, thread session persistence, and run summaries
- extend API Slack helpers and API integration tests for Slack callback behavior

Fixes #13069

## Validation
- `pnpm -F api exec vitest --run src/signals/routes/__tests__/internal-callbacks-slack-org.test.ts`
- `pnpm -F api lint`
- `pnpm check-types`
- `pnpm knip`
- `git diff --check`
