### PR TITLE
fix: use CSS custom properties for safe-area insets in PWA (iOS 26 compat)

### DIFF
--- a/turbo/apps/platform/src/views/css/index.css
+++ b/turbo/apps/platform/src/views/css/index.css
@@ -34,6 +34,14 @@
   --color-credit-plan-team: #6b8de3;
 }
 
+/* Safe area insets as CSS custom properties — more reliable than direct env() in inline
+   styles across WebKit versions, including iOS 26+ standalone PWA mode.
+   Use var(--sat) / var(--sab) in components instead of env() directly. */
+:root {
+  --sat: env(safe-area-inset-top, 0px);
+  --sab: env(safe-area-inset-bottom, 0px);
+}
+
 /* Landing tagline carousel: smooth vertical fade-in */
 @keyframes zero-tagline-in {
   from {

--- a/turbo/apps/platform/src/views/zero-page/sidebar-layout.tsx
+++ b/turbo/apps/platform/src/views/zero-page/sidebar-layout.tsx
@@ -210,7 +210,7 @@ function MobileTopBar() {
   return (
     <div
       className="md:hidden shrink-0 flex items-center min-h-12 px-3 gap-2 bg-background border-b border-border/50 z-10"
-      style={{ paddingTop: "env(safe-area-inset-top)" }}
+      style={{ paddingTop: "var(--sat)" }}
     >
       <button
         type="button"

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -2160,7 +2160,7 @@ function ChatThreadComposer({
     <footer
       data-chat-composer
       className="relative shrink-0 bg-[hsl(var(--background))]"
-      style={{ paddingBottom: "max(0.5rem, env(safe-area-inset-bottom))" }}
+      style={{ paddingBottom: "max(0.5rem, var(--sab))" }}
     >
       <div className="pointer-events-none absolute inset-x-0 -top-5 h-[21px] bg-gradient-to-t from-[hsl(var(--background))] to-transparent" />
       <div className="overflow-y-auto [scrollbar-gutter:stable] px-4 sm:px-6 pt-3 pb-2">

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -425,7 +425,7 @@ function SidebarNavContent() {
         {/* Organization switcher */}
         <div
           className="shrink-0 px-2 pb-0"
-          style={{ paddingTop: "calc(0.375rem + env(safe-area-inset-top))" }}
+          style={{ paddingTop: "calc(0.375rem + var(--sat))" }}
         >
           <div className="flex items-center justify-between gap-2 rounded-lg py-0.5">
             <div className="min-w-0 flex-1">


### PR DESCRIPTION
## Problem

Customer report (#13101): on iPhone 15 Pro Max + iOS 26.3.1, the hamburger menu button overlaps the iOS status bar and can't be tapped.

The previous fix (PR #11709) applied `env(safe-area-inset-top)` as a React inline `style` prop. iOS 26's updated WebKit engine does not reliably resolve `env()` in inline styles for standalone PWA mode — the value falls back to `0`, so the top bar renders underneath the system status bar.

## Fix

Define `--sat` / `--sab` CSS custom properties in the global stylesheet (`index.css`), where WebKit correctly resolves `env()`. All three components that reference safe-area insets are updated to use `var(--sat)` / `var(--sab)` instead.

```css
/* index.css */
:root {
  --sat: env(safe-area-inset-top, 0px);
  --sab: env(safe-area-inset-bottom, 0px);
}
```

### Files changed
- `index.css` — adds `:root { --sat; --sab }`
- `sidebar-layout.tsx` — `MobileTopBar` padding-top
- `zero-sidebar.tsx` — sidebar top padding  
- `zero-chat-thread-page.tsx` — chat composer bottom padding

## Test plan
- [ ] PWA on iOS 26 device/sim: hamburger menu is below status bar and tappable
- [ ] PWA on iOS 17/18 (older): top bar still respects safe area
- [ ] Android PWA: no visual regression
- [ ] Desktop web: no regression (safe area insets resolve to 0)

Closes #13101