### PR TITLE
fix(runner): gate local jobs by live runner profiles

### DIFF
--- a/crates/runner/src/cmd/local/submit.rs
+++ b/crates/runner/src/cmd/local/submit.rs
@@ -367,14 +367,14 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let runners_dir = dir.path().join(".runners");
         std::fs::create_dir_all(&runners_dir).unwrap();
-        let record = crate::local_runner_registry::LocalRunnerRecord {
-            runner_id: "runner-1".into(),
-            name: "local".into(),
-            profiles: vec!["vm0/default".into()],
-            updated_at_ms: 1,
-            pid: Some(std::process::id()),
-        };
-        let json = serde_json::to_vec(&record).unwrap();
+        let json = serde_json::to_vec(&serde_json::json!({
+            "runner_id": "runner-1",
+            "name": "local",
+            "profiles": ["vm0/default"],
+            "updated_at_ms": 1,
+            "pid": std::process::id(),
+        }))
+        .unwrap();
         std::fs::write(runners_dir.join("runner-1.json"), json).unwrap();
 
         let err = ensure_live_runner_supports_profile(dir.path(), "test/group", "vm0/default")

--- a/crates/runner/src/cmd/local/submit.rs
+++ b/crates/runner/src/cmd/local/submit.rs
@@ -161,10 +161,14 @@ pub async fn run_submit(args: SubmitArgs) -> RunnerResult<ExitCode> {
     // Write atomically: tmp file then rename.
     let tmp_path = group_dir.join(format!("{job_id}.job.tmp"));
     let job_path = group_dir.join(format!("{job_id}.job"));
-    std::fs::write(&tmp_path, &json)
-        .map_err(|e| RunnerError::Internal(format!("write job file: {e}")))?;
-    std::fs::rename(&tmp_path, &job_path)
-        .map_err(|e| RunnerError::Internal(format!("rename job file: {e}")))?;
+    std::fs::write(&tmp_path, &json).map_err(|e| {
+        let _ = std::fs::remove_file(&tmp_path);
+        RunnerError::Internal(format!("write job file: {e}"))
+    })?;
+    std::fs::rename(&tmp_path, &job_path).map_err(|e| {
+        let _ = std::fs::remove_file(&tmp_path);
+        RunnerError::Internal(format!("rename job file: {e}"))
+    })?;
 
     // Poll for result, listening for Ctrl+C to cancel.
     let result_path = group_dir.join(format!("{job_id}.result"));

--- a/crates/runner/src/cmd/local/submit.rs
+++ b/crates/runner/src/cmd/local/submit.rs
@@ -10,6 +10,7 @@ use clap::Args;
 
 use crate::error::{RunnerError, RunnerResult};
 use crate::ids::RunId;
+use crate::local_runner_registry::LocalRunnerRegistry;
 use crate::paths::HomePaths;
 use crate::provider::{JobRequest, JobResponse};
 
@@ -83,6 +84,26 @@ fn cleanup_files(
     let _ = std::fs::remove_file(group_dir.join(format!("{job_id}.claim")));
 }
 
+fn ensure_live_runner_supports_profile(
+    group_dir: &std::path::Path,
+    group: &str,
+    profile: &str,
+) -> RunnerResult<()> {
+    let live_profiles = LocalRunnerRegistry::new(group_dir.to_path_buf()).live_profiles()?;
+    if live_profiles.contains(profile) {
+        return Ok(());
+    }
+
+    let available = if live_profiles.is_empty() {
+        "none".to_string()
+    } else {
+        live_profiles.into_iter().collect::<Vec<_>>().join(", ")
+    };
+    Err(RunnerError::Config(format!(
+        "no live local runner in group {group} supports profile {profile}; live profiles: {available}; start a local runner with this profile or choose a supported profile"
+    )))
+}
+
 pub async fn run_submit(args: SubmitArgs) -> RunnerResult<ExitCode> {
     crate::group::validate_or_err(&args.group)?;
 
@@ -110,10 +131,15 @@ pub async fn run_submit(args: SubmitArgs) -> RunnerResult<ExitCode> {
 
     let home = HomePaths::new()?;
     let group_dir = home.groups_dir().join(&args.group);
+    let requested_profile = args
+        .profile
+        .clone()
+        .unwrap_or_else(|| crate::profile::DEFAULT_PROFILE.to_owned());
 
     std::fs::create_dir_all(&group_dir).map_err(|e| {
         RunnerError::Config(format!("create group dir {}: {e}", group_dir.display()))
     })?;
+    ensure_live_runner_supports_profile(&group_dir, &args.group, &requested_profile)?;
 
     let job_id = RunId::new_v4();
     let request = JobRequest {
@@ -287,6 +313,77 @@ mod tests {
 
         // Second cleanup (idempotent — no panic on missing files)
         cleanup_files(&job_path, &result_path, &cancel_path, group_dir, job_id);
+    }
+
+    #[test]
+    fn preflight_rejects_profile_without_live_runner() {
+        let dir = tempfile::tempdir().unwrap();
+
+        let err = ensure_live_runner_supports_profile(dir.path(), "test/group", "vm0/default")
+            .unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("no live local runner in group test/group supports profile vm0/default"),
+            "got: {err}"
+        );
+        assert!(
+            !dir.path().read_dir().unwrap().any(|entry| entry
+                .unwrap()
+                .path()
+                .extension()
+                .and_then(|ext| ext.to_str())
+                == Some("job")),
+            "preflight must not create job files"
+        );
+    }
+
+    #[test]
+    fn preflight_accepts_profile_from_live_runner() {
+        let dir = tempfile::tempdir().unwrap();
+        LocalRunnerRegistry::new(dir.path().to_path_buf())
+            .write_record("runner-1", "local", vec!["vm0/default".into()])
+            .unwrap();
+
+        ensure_live_runner_supports_profile(dir.path(), "test/group", "vm0/default").unwrap();
+    }
+
+    #[test]
+    fn preflight_accepts_profile_from_any_live_runner() {
+        let dir = tempfile::tempdir().unwrap();
+        let registry = LocalRunnerRegistry::new(dir.path().to_path_buf());
+        registry
+            .write_record("runner-1", "local-a", vec!["vm0/default".into()])
+            .unwrap();
+        registry
+            .write_record("runner-2", "local-b", vec!["vm0/large".into()])
+            .unwrap();
+
+        ensure_live_runner_supports_profile(dir.path(), "test/group", "vm0/large").unwrap();
+    }
+
+    #[test]
+    fn preflight_ignores_stale_runner_records() {
+        let dir = tempfile::tempdir().unwrap();
+        let runners_dir = dir.path().join(".runners");
+        std::fs::create_dir_all(&runners_dir).unwrap();
+        let record = crate::local_runner_registry::LocalRunnerRecord {
+            runner_id: "runner-1".into(),
+            name: "local".into(),
+            profiles: vec!["vm0/default".into()],
+            updated_at_ms: 1,
+            pid: Some(std::process::id()),
+        };
+        let json = serde_json::to_vec(&record).unwrap();
+        std::fs::write(runners_dir.join("runner-1.json"), json).unwrap();
+
+        let err = ensure_live_runner_supports_profile(dir.path(), "test/group", "vm0/default")
+            .unwrap_err();
+
+        assert!(
+            err.to_string().contains("live profiles: none"),
+            "got: {err}"
+        );
     }
 
     #[tokio::test]

--- a/crates/runner/src/cmd/service.rs
+++ b/crates/runner/src/cmd/service.rs
@@ -1,9 +1,13 @@
+use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 use crate::error::{ActiveJobsError, RunnerError, RunnerResult};
 use crate::ids::RunId;
+use crate::local_runner_registry::LocalRunnerRegistry;
 use crate::paths::HomePaths;
 use clap::{Args, Subcommand};
+use tokio::time::Instant;
 use tracing::{info, warn};
 
 #[derive(Args)]
@@ -125,6 +129,8 @@ pub async fn run_service(args: ServiceArgs) -> RunnerResult<()> {
 // ---------------------------------------------------------------------------
 
 const UNIT_PREFIX: &str = "vm0-runner-";
+const LOCAL_SERVICE_READY_TIMEOUT: Duration = Duration::from_secs(30);
+const LOCAL_SERVICE_READY_POLL: Duration = Duration::from_millis(100);
 
 /// Build the full systemd unit name from the user-supplied suffix.
 ///
@@ -254,6 +260,73 @@ fn validate_env_vars(vars: &[String]) -> RunnerResult<()> {
         }
     }
     Ok(())
+}
+
+fn missing_local_profiles(
+    live_profiles: &BTreeSet<String>,
+    required_profiles: &BTreeSet<String>,
+) -> Vec<String> {
+    required_profiles
+        .difference(live_profiles)
+        .cloned()
+        .collect()
+}
+
+fn format_profile_set(profiles: &BTreeSet<String>) -> String {
+    if profiles.is_empty() {
+        "none".to_string()
+    } else {
+        profiles.iter().cloned().collect::<Vec<_>>().join(", ")
+    }
+}
+
+async fn wait_for_local_service_ready(
+    unit: &str,
+    config: &crate::config::RunnerConfig,
+    home: &HomePaths,
+) -> RunnerResult<()> {
+    let required_profiles: BTreeSet<String> = config.profiles.keys().cloned().collect();
+    let registry = LocalRunnerRegistry::new(home.groups_dir().join(&config.group));
+    let deadline = Instant::now() + LOCAL_SERVICE_READY_TIMEOUT;
+
+    loop {
+        let live_profiles = registry.live_profiles_for_runner(&config.name)?;
+        let missing = missing_local_profiles(&live_profiles, &required_profiles);
+        if missing.is_empty() {
+            info!(
+                unit,
+                group = %config.group,
+                runner_name = %config.name,
+                profiles = %format_profile_set(&required_profiles),
+                "local service ready"
+            );
+            return Ok(());
+        }
+
+        if Instant::now() >= deadline {
+            return Err(RunnerError::Internal(format!(
+                "local service {unit} did not become ready within {LOCAL_SERVICE_READY_TIMEOUT:?}; \
+                 group {}; runner {}; required profiles: {}; live profiles: {}; missing profiles: {}",
+                config.group,
+                config.name,
+                format_profile_set(&required_profiles),
+                format_profile_set(&live_profiles),
+                missing.join(", ")
+            )));
+        }
+
+        tokio::time::sleep(LOCAL_SERVICE_READY_POLL).await;
+    }
+}
+
+async fn stop_transient_after_start_failure(unit: &str) {
+    let svc = format!("{unit}.service");
+    if let Err(e) = run_systemctl(&["stop", &svc]).await {
+        warn!(unit, error = %e, "failed to stop service after local readiness failure");
+    }
+    if let Err(e) = run_systemctl(&["reset-failed", &svc]).await {
+        warn!(unit, error = %e, "failed to reset service failure state after local readiness failure");
+    }
 }
 
 /// Run `systemctl <args>` and check exit status.
@@ -639,6 +712,11 @@ async fn start(args: ServiceRunArgs) -> RunnerResult<()> {
     }
 
     let config_path = resolve_config_path(&args.config)?;
+    let local_ready_config = if args.local {
+        Some(crate::config::load(&config_path).await?)
+    } else {
+        None
+    };
     let exe_path =
         std::env::current_exe().map_err(|e| RunnerError::Internal(format!("current_exe: {e}")))?;
 
@@ -678,6 +756,15 @@ async fn start(args: ServiceRunArgs) -> RunnerResult<()> {
             "systemd-run failed: {status}"
         )));
     }
+
+    if let Some(config) = &local_ready_config {
+        let home = HomePaths::new()?;
+        if let Err(e) = wait_for_local_service_ready(&unit, config, &home).await {
+            stop_transient_after_start_failure(&unit).await;
+            return Err(e);
+        }
+    }
+
     info!(unit = %unit, "transient service started");
     Ok(())
 }
@@ -718,6 +805,11 @@ async fn install(args: ServiceRunArgs) -> RunnerResult<()> {
     let unit = unit_name(&args.name)?;
     validate_env_vars(&args.env)?;
     let config_path = resolve_config_path(&args.config)?;
+    let local_ready_config = if args.local {
+        Some(crate::config::load(&config_path).await?)
+    } else {
+        None
+    };
     let exe_path =
         std::env::current_exe().map_err(|e| RunnerError::Internal(format!("current_exe: {e}")))?;
 
@@ -729,6 +821,20 @@ async fn install(args: ServiceRunArgs) -> RunnerResult<()> {
     run_systemctl(&["daemon-reload"]).await?;
     let svc = format!("{unit}.service");
     run_systemctl(&["enable", "--now", &svc]).await?;
+
+    if let Some(config) = &local_ready_config {
+        let home = HomePaths::new()?;
+        if let Err(e) = wait_for_local_service_ready(&unit, config, &home).await {
+            if let Err(cleanup_err) = uninstall_service(&args.name).await {
+                warn!(
+                    unit = %unit,
+                    error = %cleanup_err,
+                    "failed to uninstall service after local readiness failure"
+                );
+            }
+            return Err(e);
+        }
+    }
 
     info!(unit = %unit, "service installed and started");
     Ok(())

--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -85,7 +85,7 @@ pub(super) async fn handle_discovered_job(job: DiscoveredJob, mut ctx: Discovere
     }
     // claim() runs in the branch handler: non-interruptible, so a successful
     // claim is always paired with complete().
-    let Some(context) = ctx.spawn_ctx.provider.claim(run_id).await else {
+    let Some(context) = ctx.spawn_ctx.provider.claim(run_id, &profile_name).await else {
         // None means the job won't run here: either lost the race to another
         // runner, or the provider rejected the job. Release the reservation and
         // cancel token so the runner can continue.

--- a/crates/runner/src/cmd/start/job_lifecycle.rs
+++ b/crates/runner/src/cmd/start/job_lifecycle.rs
@@ -243,7 +243,7 @@ mod tests {
             None
         }
 
-        async fn claim(&self, _run_id: RunId) -> Option<ExecutionContext> {
+        async fn claim(&self, _run_id: RunId, _expected_profile: &str) -> Option<ExecutionContext> {
             None
         }
 

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -49,6 +49,7 @@ use crate::host;
 use crate::http::HttpClient;
 use crate::idle_pool::{IdlePool, IdlePoolConfig, ParkingGate};
 use crate::kmsg_log;
+use crate::local_runner_registry::{LocalRunnerRegistration, LocalRunnerRegistry};
 use crate::lock;
 use crate::network_log_drain::NetworkLogDrainCoordinator;
 use crate::network_log_manager::NetworkLogManager;
@@ -402,12 +403,25 @@ pub async fn run_start(
     let cancel_tokens: Arc<tokio::sync::Mutex<HashMap<RunId, CancellationToken>>> =
         Arc::new(tokio::sync::Mutex::new(HashMap::new()));
 
+    let mut local_registration = None;
     let (provider, group_name): (Arc<dyn JobProvider>, String) = if args.local {
         let group_dir = home.groups_dir().join(&group);
         std::fs::create_dir_all(&group_dir).map_err(|e| {
             RunnerError::Config(format!("create group dir {}: {e}", group_dir.display()))
         })?;
-        let provider = LocalProvider::new(group_dir, cancel.clone(), Arc::clone(&cancel_tokens));
+        let local_profiles: Vec<String> = runner_config.profiles.keys().cloned().collect();
+        local_registration = Some(LocalRunnerRegistration::new(
+            LocalRunnerRegistry::new(group_dir.clone()),
+            runner_id.clone(),
+            name.clone(),
+            local_profiles.clone(),
+        ));
+        let provider = LocalProvider::new(
+            group_dir,
+            local_profiles,
+            cancel.clone(),
+            Arc::clone(&cancel_tokens),
+        );
         (provider, group)
     } else {
         let group_name = group.clone();
@@ -449,6 +463,7 @@ pub async fn run_start(
         mitm,
         mitm_crash_rx,
         provider,
+        local_registration,
         cancel_tokens,
         cancel,
         exec_config,
@@ -483,6 +498,7 @@ struct RunConfig {
     mitm: proxy::MitmProxy,
     mitm_crash_rx: tokio::sync::mpsc::Receiver<()>,
     provider: Arc<dyn JobProvider>,
+    local_registration: Option<LocalRunnerRegistration>,
     /// Per-job cancel tokens shared with the provider for cancel events
     /// (Ably for ApiProvider, `.cancel` files for LocalProvider).
     cancel_tokens: Arc<tokio::sync::Mutex<HashMap<RunId, CancellationToken>>>,
@@ -772,6 +788,24 @@ fn maybe_panic_outer_job(
     }
 }
 
+fn set_local_registration_active(
+    registration: Option<&LocalRunnerRegistration>,
+    active: bool,
+    mode: RunnerMode,
+) {
+    let Some(registration) = registration else {
+        return;
+    };
+    let result = if active {
+        registration.refresh()
+    } else {
+        registration.remove()
+    };
+    if let Err(e) = result {
+        warn!(error = %e, ?mode, active, "local: runner registry update failed");
+    }
+}
+
 async fn run(config: RunConfig) -> RunnerResult<()> {
     let RunConfig {
         id: runner_id,
@@ -787,6 +821,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
         mut mitm,
         mut mitm_crash_rx,
         provider,
+        local_registration,
         cancel_tokens,
         cancel,
         exec_config,
@@ -902,6 +937,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
     let mut discover_fut = Box::pin(provider.discover());
 
     let mut current_mode = RunnerMode::Running;
+    set_local_registration_active(local_registration.as_ref(), true, current_mode);
     let spawn_ctx = SpawnContext {
         provider: Arc::clone(&provider),
         exec_config: Arc::clone(&exec_config),
@@ -922,6 +958,11 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
         if mode != current_mode {
             current_mode = mode;
             status.set_mode(mode).await;
+            set_local_registration_active(
+                local_registration.as_ref(),
+                matches!(mode, RunnerMode::Running),
+                mode,
+            );
         }
         match mode {
             // Stopped should not normally reach here — teardown sets it and
@@ -1081,6 +1122,11 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
             // Heartbeat: report runner state to the server
             _ = heartbeat_tick.tick() => {
                 send_heartbeat(&hb_ctx, current_mode).await;
+                set_local_registration_active(
+                    local_registration.as_ref(),
+                    matches!(current_mode, RunnerMode::Running),
+                    current_mode,
+                );
             }
             // Immediate heartbeat after a VM is parked — eliminates the
             // up-to-10s blind spot for session affinity routing.
@@ -1102,6 +1148,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
     // the historical shutdown-deadlock regression covered by mock providers.
     drop(discover_fut);
     teardown.event("drop_discover_fut");
+    set_local_registration_active(local_registration.as_ref(), false, RunnerMode::Stopping);
 
     // Drain idle pool first — these VMs hold budget reservations. This
     // also clears `idle_vms` in status.json so the final snapshot is

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -806,6 +806,10 @@ fn set_local_registration_active(
     }
 }
 
+fn local_registration_active_for_mode(mode: RunnerMode) -> bool {
+    matches!(mode, RunnerMode::Running | RunnerMode::Draining)
+}
+
 async fn run(config: RunConfig) -> RunnerResult<()> {
     let RunConfig {
         id: runner_id,
@@ -960,7 +964,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
             status.set_mode(mode).await;
             set_local_registration_active(
                 local_registration.as_ref(),
-                matches!(mode, RunnerMode::Running),
+                local_registration_active_for_mode(mode),
                 mode,
             );
         }
@@ -1124,7 +1128,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                 send_heartbeat(&hb_ctx, current_mode).await;
                 set_local_registration_active(
                     local_registration.as_ref(),
-                    matches!(current_mode, RunnerMode::Running),
+                    local_registration_active_for_mode(current_mode),
                     current_mode,
                 );
             }

--- a/crates/runner/src/cmd/start/tests/main_loop.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop.rs
@@ -13,6 +13,14 @@ use crate::idle_pool::ParkingState;
 // Test 1: Normal discover → claim → execute → complete
 // -----------------------------------------------------------------------
 
+#[test]
+fn local_registration_stays_visible_while_draining() {
+    assert!(local_registration_active_for_mode(RunnerMode::Running));
+    assert!(local_registration_active_for_mode(RunnerMode::Draining));
+    assert!(!local_registration_active_for_mode(RunnerMode::Stopping));
+    assert!(!local_registration_active_for_mode(RunnerMode::Stopped));
+}
+
 #[tokio::test(start_paused = true)]
 async fn main_loop_discover_claim_execute_complete() {
     let (config, env) = mock_run_config(test_profiles(), 8, 32768, 4);

--- a/crates/runner/src/cmd/start/tests/support/env.rs
+++ b/crates/runner/src/cmd/start/tests/support/env.rs
@@ -196,6 +196,7 @@ fn build_mock_run_config_with_runtime(
         mitm,
         mitm_crash_rx,
         provider,
+        local_registration: None,
         cancel_tokens: Arc::clone(&cancel_tokens),
         cancel: cancel.clone(),
         exec_config: Arc::new(executor::ExecutorConfig {

--- a/crates/runner/src/local_runner_registry.rs
+++ b/crates/runner/src/local_runner_registry.rs
@@ -1,0 +1,345 @@
+use std::collections::BTreeSet;
+use std::path::PathBuf;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use serde::{Deserialize, Serialize};
+use tracing::warn;
+
+use crate::error::{RunnerError, RunnerResult};
+
+pub(crate) const RUNNER_REGISTRY_TTL: Duration = Duration::from_secs(30);
+
+const RUNNERS_DIR: &str = ".runners";
+
+#[derive(Clone, Debug)]
+pub(crate) struct LocalRunnerRegistration {
+    registry: LocalRunnerRegistry,
+    runner_id: String,
+    name: String,
+    profiles: Vec<String>,
+}
+
+impl LocalRunnerRegistration {
+    pub(crate) fn new(
+        registry: LocalRunnerRegistry,
+        runner_id: String,
+        name: String,
+        profiles: impl IntoIterator<Item = String>,
+    ) -> Self {
+        Self {
+            registry,
+            runner_id,
+            name,
+            profiles: normalize_profiles(profiles),
+        }
+    }
+
+    pub(crate) fn refresh(&self) -> RunnerResult<()> {
+        self.registry
+            .write_record(&self.runner_id, &self.name, self.profiles.clone())
+    }
+
+    pub(crate) fn remove(&self) -> RunnerResult<()> {
+        self.registry.remove_record(&self.runner_id)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct LocalRunnerRegistry {
+    group_dir: PathBuf,
+}
+
+impl LocalRunnerRegistry {
+    pub(crate) fn new(group_dir: PathBuf) -> Self {
+        Self { group_dir }
+    }
+
+    pub(crate) fn live_profiles(&self) -> RunnerResult<BTreeSet<String>> {
+        Ok(self
+            .live_records_at(now_ms(), RUNNER_REGISTRY_TTL)?
+            .into_iter()
+            .flat_map(|record| record.profiles)
+            .collect())
+    }
+
+    pub(crate) fn write_record(
+        &self,
+        runner_id: &str,
+        name: &str,
+        profiles: Vec<String>,
+    ) -> RunnerResult<()> {
+        self.write_record_at(runner_id, name, profiles, now_ms())
+    }
+
+    pub(crate) fn remove_record(&self, runner_id: &str) -> RunnerResult<()> {
+        let path = self.record_path(runner_id);
+        match std::fs::remove_file(&path) {
+            Ok(()) => Ok(()),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(e) => Err(RunnerError::Internal(format!(
+                "remove local runner registry record {}: {e}",
+                path.display()
+            ))),
+        }
+    }
+
+    fn write_record_at(
+        &self,
+        runner_id: &str,
+        name: &str,
+        profiles: Vec<String>,
+        updated_at_ms: u64,
+    ) -> RunnerResult<()> {
+        let runners_dir = self.runners_dir();
+        std::fs::create_dir_all(&runners_dir).map_err(|e| {
+            RunnerError::Internal(format!(
+                "create local runner registry dir {}: {e}",
+                runners_dir.display()
+            ))
+        })?;
+
+        let record = LocalRunnerRecord {
+            runner_id: runner_id.to_owned(),
+            name: name.to_owned(),
+            profiles: normalize_profiles(profiles),
+            updated_at_ms,
+            pid: Some(std::process::id()),
+        };
+        let json = serde_json::to_vec(&record)
+            .map_err(|e| RunnerError::Internal(format!("serialize local runner registry: {e}")))?;
+        let tmp_path = runners_dir.join(format!("{runner_id}.{}.tmp", std::process::id()));
+        let record_path = self.record_path(runner_id);
+        std::fs::write(&tmp_path, json).map_err(|e| {
+            RunnerError::Internal(format!(
+                "write local runner registry temp file {}: {e}",
+                tmp_path.display()
+            ))
+        })?;
+        std::fs::rename(&tmp_path, &record_path).map_err(|e| {
+            let _ = std::fs::remove_file(&tmp_path);
+            RunnerError::Internal(format!(
+                "publish local runner registry record {}: {e}",
+                record_path.display()
+            ))
+        })?;
+        Ok(())
+    }
+
+    fn live_records_at(&self, now_ms: u64, ttl: Duration) -> RunnerResult<Vec<LocalRunnerRecord>> {
+        let runners_dir = self.runners_dir();
+        let entries = match std::fs::read_dir(&runners_dir) {
+            Ok(entries) => entries,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+            Err(e) => {
+                return Err(RunnerError::Internal(format!(
+                    "read local runner registry dir {}: {e}",
+                    runners_dir.display()
+                )));
+            }
+        };
+        let ttl_ms = duration_millis_u64(ttl);
+        let mut records = Vec::new();
+        for entry in entries.filter_map(Result::ok) {
+            let path = entry.path();
+            if path.extension().and_then(|ext| ext.to_str()) != Some("json") {
+                continue;
+            }
+            let bytes = match std::fs::read(&path) {
+                Ok(bytes) => bytes,
+                Err(e) => {
+                    warn!(path = %path.display(), error = %e, "local: failed to read runner registry record");
+                    continue;
+                }
+            };
+            let record: LocalRunnerRecord = match serde_json::from_slice(&bytes) {
+                Ok(record) => record,
+                Err(e) => {
+                    warn!(path = %path.display(), error = %e, "local: invalid runner registry record");
+                    continue;
+                }
+            };
+            if now_ms.saturating_sub(record.updated_at_ms) > ttl_ms {
+                let _ = std::fs::remove_file(&path);
+                continue;
+            }
+            records.push(record);
+        }
+        Ok(records)
+    }
+
+    fn runners_dir(&self) -> PathBuf {
+        self.group_dir.join(RUNNERS_DIR)
+    }
+
+    fn record_path(&self, runner_id: &str) -> PathBuf {
+        self.runners_dir().join(format!("{runner_id}.json"))
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub(crate) struct LocalRunnerRecord {
+    pub(crate) runner_id: String,
+    pub(crate) name: String,
+    pub(crate) profiles: Vec<String>,
+    pub(crate) updated_at_ms: u64,
+    #[serde(default)]
+    pub(crate) pid: Option<u32>,
+}
+
+fn normalize_profiles(profiles: impl IntoIterator<Item = String>) -> Vec<String> {
+    profiles
+        .into_iter()
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect()
+}
+
+fn now_ms() -> u64 {
+    let duration = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default();
+    duration_millis_u64(duration)
+}
+
+fn duration_millis_u64(duration: Duration) -> u64 {
+    duration.as_millis().try_into().unwrap_or(u64::MAX)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    fn registry(dir: &Path) -> LocalRunnerRegistry {
+        LocalRunnerRegistry::new(dir.to_path_buf())
+    }
+
+    #[test]
+    fn writes_and_reads_live_runner_record() {
+        let dir = tempfile::tempdir().unwrap();
+        let registry = registry(dir.path());
+
+        registry
+            .write_record_at(
+                "runner-1",
+                "local-a",
+                vec!["vm0/default".into(), "vm0/large".into()],
+                1_000,
+            )
+            .unwrap();
+
+        let records = registry
+            .live_records_at(1_000, Duration::from_secs(30))
+            .unwrap();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].runner_id, "runner-1");
+        assert_eq!(records[0].name, "local-a");
+        assert_eq!(records[0].profiles, vec!["vm0/default", "vm0/large"]);
+        assert_eq!(records[0].updated_at_ms, 1_000);
+        assert_eq!(records[0].pid, Some(std::process::id()));
+    }
+
+    #[test]
+    fn aggregates_profiles_from_live_runner_records() {
+        let dir = tempfile::tempdir().unwrap();
+        let registry = registry(dir.path());
+
+        registry
+            .write_record("runner-a", "a", vec!["vm0/default".into()])
+            .unwrap();
+        registry
+            .write_record("runner-b", "b", vec!["vm0/large".into()])
+            .unwrap();
+
+        let profiles = registry.live_profiles().unwrap();
+        assert!(profiles.contains("vm0/default"));
+        assert!(profiles.contains("vm0/large"));
+    }
+
+    #[test]
+    fn ignores_and_removes_stale_runner_records() {
+        let dir = tempfile::tempdir().unwrap();
+        let registry = registry(dir.path());
+
+        registry
+            .write_record_at("runner-1", "local-a", vec!["vm0/default".into()], 1_000)
+            .unwrap();
+
+        let records = registry
+            .live_records_at(32_000, Duration::from_secs(30))
+            .unwrap();
+        assert!(records.is_empty());
+        assert!(!registry.record_path("runner-1").exists());
+    }
+
+    #[test]
+    fn ignores_corrupt_runner_records() {
+        let dir = tempfile::tempdir().unwrap();
+        let registry = registry(dir.path());
+        let runners_dir = registry.runners_dir();
+        std::fs::create_dir_all(&runners_dir).unwrap();
+        std::fs::write(runners_dir.join("bad.json"), b"not json").unwrap();
+
+        let records = registry
+            .live_records_at(1_000, Duration::from_secs(30))
+            .unwrap();
+        assert!(records.is_empty());
+    }
+
+    #[test]
+    fn normalizes_profiles_in_registry_record() {
+        let dir = tempfile::tempdir().unwrap();
+        let registry = registry(dir.path());
+
+        registry
+            .write_record_at(
+                "runner-1",
+                "local-a",
+                vec![
+                    "vm0/large".into(),
+                    "vm0/default".into(),
+                    "vm0/default".into(),
+                ],
+                1_000,
+            )
+            .unwrap();
+
+        let records = registry
+            .live_records_at(1_000, Duration::from_secs(30))
+            .unwrap();
+        assert_eq!(records[0].profiles, vec!["vm0/default", "vm0/large"]);
+    }
+
+    #[test]
+    fn remove_record_is_idempotent() {
+        let dir = tempfile::tempdir().unwrap();
+        let registry = registry(dir.path());
+
+        registry
+            .write_record_at("runner-1", "local-a", vec!["vm0/default".into()], 1_000)
+            .unwrap();
+        registry.remove_record("runner-1").unwrap();
+        registry.remove_record("runner-1").unwrap();
+
+        assert!(!registry.record_path("runner-1").exists());
+    }
+
+    #[test]
+    fn registration_refresh_and_remove_manage_current_runner_record() {
+        let dir = tempfile::tempdir().unwrap();
+        let registry = registry(dir.path());
+        let registration = LocalRunnerRegistration::new(
+            registry.clone(),
+            "runner-1".into(),
+            "local-a".into(),
+            ["vm0/default".to_string()],
+        );
+
+        registration.refresh().unwrap();
+        let records = registry.live_profiles().unwrap();
+        assert!(records.contains("vm0/default"));
+
+        registration.remove().unwrap();
+        assert!(registry.live_profiles().unwrap().is_empty());
+    }
+}

--- a/crates/runner/src/local_runner_registry.rs
+++ b/crates/runner/src/local_runner_registry.rs
@@ -72,7 +72,7 @@ impl LocalRunnerRegistry {
     }
 
     pub(crate) fn remove_record(&self, runner_id: &str) -> RunnerResult<()> {
-        let path = self.record_path(runner_id);
+        let path = self.record_path(runner_id, std::process::id());
         match std::fs::remove_file(&path) {
             Ok(()) => Ok(()),
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
@@ -107,8 +107,9 @@ impl LocalRunnerRegistry {
         };
         let json = serde_json::to_vec(&record)
             .map_err(|e| RunnerError::Internal(format!("serialize local runner registry: {e}")))?;
-        let tmp_path = runners_dir.join(format!("{runner_id}.{}.tmp", std::process::id()));
-        let record_path = self.record_path(runner_id);
+        let pid = std::process::id();
+        let tmp_path = runners_dir.join(format!("{runner_id}.{pid}.tmp"));
+        let record_path = self.record_path(runner_id, pid);
         std::fs::write(&tmp_path, json).map_err(|e| {
             RunnerError::Internal(format!(
                 "write local runner registry temp file {}: {e}",
@@ -171,8 +172,8 @@ impl LocalRunnerRegistry {
         self.group_dir.join(RUNNERS_DIR)
     }
 
-    fn record_path(&self, runner_id: &str) -> PathBuf {
-        self.runners_dir().join(format!("{runner_id}.json"))
+    fn record_path(&self, runner_id: &str, pid: u32) -> PathBuf {
+        self.runners_dir().join(format!("{runner_id}-{pid}.json"))
     }
 }
 
@@ -269,7 +270,11 @@ mod tests {
             .live_records_at(32_000, Duration::from_secs(30))
             .unwrap();
         assert!(records.is_empty());
-        assert!(!registry.record_path("runner-1").exists());
+        assert!(
+            !registry
+                .record_path("runner-1", std::process::id())
+                .exists()
+        );
     }
 
     #[test]
@@ -321,7 +326,11 @@ mod tests {
         registry.remove_record("runner-1").unwrap();
         registry.remove_record("runner-1").unwrap();
 
-        assert!(!registry.record_path("runner-1").exists());
+        assert!(
+            !registry
+                .record_path("runner-1", std::process::id())
+                .exists()
+        );
     }
 
     #[test]
@@ -341,5 +350,38 @@ mod tests {
 
         registration.remove().unwrap();
         assert!(registry.live_profiles().unwrap().is_empty());
+    }
+
+    #[test]
+    fn remove_record_preserves_other_process_record_for_same_runner_id() {
+        let dir = tempfile::tempdir().unwrap();
+        let registry = registry(dir.path());
+
+        registry
+            .write_record_at("runner-1", "local-a", vec!["vm0/default".into()], 1_000)
+            .unwrap();
+        let other_pid = std::process::id().wrapping_add(1);
+        let other_path = registry.record_path("runner-1", other_pid);
+        std::fs::write(
+            &other_path,
+            serde_json::to_vec(&serde_json::json!({
+                "runner_id": "runner-1",
+                "name": "local-b",
+                "profiles": ["vm0/large"],
+                "updated_at_ms": 1_000,
+                "pid": other_pid,
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        registry.remove_record("runner-1").unwrap();
+
+        assert!(
+            !registry
+                .record_path("runner-1", std::process::id())
+                .exists()
+        );
+        assert!(other_path.exists());
     }
 }

--- a/crates/runner/src/local_runner_registry.rs
+++ b/crates/runner/src/local_runner_registry.rs
@@ -62,6 +62,15 @@ impl LocalRunnerRegistry {
             .collect())
     }
 
+    pub(crate) fn live_profiles_for_runner(&self, name: &str) -> RunnerResult<BTreeSet<String>> {
+        Ok(self
+            .live_records_at(now_ms(), RUNNER_REGISTRY_TTL)?
+            .into_iter()
+            .filter(|record| record.name == name)
+            .flat_map(|record| record.profiles)
+            .collect())
+    }
+
     pub(crate) fn write_record(
         &self,
         runner_id: &str,
@@ -164,6 +173,12 @@ impl LocalRunnerRegistry {
                 let _ = std::fs::remove_file(&path);
                 continue;
             }
+            if let Some(pid) = record.pid
+                && !process_is_running(pid)
+            {
+                let _ = std::fs::remove_file(&path);
+                continue;
+            }
             records.push(record);
         }
         Ok(records)
@@ -205,6 +220,35 @@ fn now_ms() -> u64 {
 
 fn duration_millis_u64(duration: Duration) -> u64 {
     duration.as_millis().try_into().unwrap_or(u64::MAX)
+}
+
+#[cfg(target_os = "linux")]
+fn process_is_running(pid: u32) -> bool {
+    let Ok(stat) = std::fs::read_to_string(format!("/proc/{pid}/stat")) else {
+        return false;
+    };
+    let Some((_, after_comm)) = stat.rsplit_once(") ") else {
+        return false;
+    };
+    !after_comm.starts_with('Z')
+}
+
+#[cfg(all(unix, not(target_os = "linux")))]
+fn process_is_running(pid: u32) -> bool {
+    let Ok(raw_pid) = i32::try_from(pid) else {
+        return false;
+    };
+    let pid = nix::unistd::Pid::from_raw(raw_pid);
+    match nix::sys::signal::kill(pid, None) {
+        Ok(()) => true,
+        Err(nix::errno::Errno::ESRCH) => false,
+        Err(_) => true,
+    }
+}
+
+#[cfg(not(unix))]
+fn process_is_running(_pid: u32) -> bool {
+    false
 }
 
 #[cfg(test)]
@@ -259,6 +303,23 @@ mod tests {
     }
 
     #[test]
+    fn filters_profiles_by_runner_name() {
+        let dir = tempfile::tempdir().unwrap();
+        let registry = registry(dir.path());
+
+        registry
+            .write_record("runner-a", "local-a", vec!["vm0/default".into()])
+            .unwrap();
+        registry
+            .write_record("runner-b", "local-b", vec!["vm0/large".into()])
+            .unwrap();
+
+        let profiles = registry.live_profiles_for_runner("local-a").unwrap();
+        assert!(profiles.contains("vm0/default"));
+        assert!(!profiles.contains("vm0/large"));
+    }
+
+    #[test]
     fn ignores_and_removes_stale_runner_records() {
         let dir = tempfile::tempdir().unwrap();
         let registry = registry(dir.path());
@@ -290,6 +351,35 @@ mod tests {
             .live_records_at(1_000, Duration::from_secs(30))
             .unwrap();
         assert!(records.is_empty());
+    }
+
+    #[test]
+    fn ignores_and_removes_dead_runner_records() {
+        let dir = tempfile::tempdir().unwrap();
+        let registry = registry(dir.path());
+        let runners_dir = registry.runners_dir();
+        std::fs::create_dir_all(&runners_dir).unwrap();
+        let dead_pid = u32::MAX;
+        let path = registry.record_path("runner-1", dead_pid);
+
+        std::fs::write(
+            &path,
+            serde_json::to_vec(&serde_json::json!({
+                "runner_id": "runner-1",
+                "name": "local-a",
+                "profiles": ["vm0/default"],
+                "updated_at_ms": 1_000,
+                "pid": dead_pid,
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        let records = registry
+            .live_records_at(1_000, Duration::from_secs(30))
+            .unwrap();
+        assert!(records.is_empty());
+        assert!(!path.exists());
     }
 
     #[test]

--- a/crates/runner/src/local_runner_registry.rs
+++ b/crates/runner/src/local_runner_registry.rs
@@ -177,13 +177,13 @@ impl LocalRunnerRegistry {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub(crate) struct LocalRunnerRecord {
-    pub(crate) runner_id: String,
-    pub(crate) name: String,
-    pub(crate) profiles: Vec<String>,
-    pub(crate) updated_at_ms: u64,
+struct LocalRunnerRecord {
+    runner_id: String,
+    name: String,
+    profiles: Vec<String>,
+    updated_at_ms: u64,
     #[serde(default)]
-    pub(crate) pid: Option<u32>,
+    pid: Option<u32>,
 }
 
 fn normalize_profiles(profiles: impl IntoIterator<Item = String>) -> Vec<String> {

--- a/crates/runner/src/local_runner_registry.rs
+++ b/crates/runner/src/local_runner_registry.rs
@@ -111,6 +111,7 @@ impl LocalRunnerRegistry {
         let tmp_path = runners_dir.join(format!("{runner_id}.{pid}.tmp"));
         let record_path = self.record_path(runner_id, pid);
         std::fs::write(&tmp_path, json).map_err(|e| {
+            let _ = std::fs::remove_file(&tmp_path);
             RunnerError::Internal(format!(
                 "write local runner registry temp file {}: {e}",
                 tmp_path.display()

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -13,6 +13,7 @@ mod idle_pool;
 mod ids;
 mod image_hash;
 mod kmsg_log;
+mod local_runner_registry;
 mod lock;
 mod network_log_drain;
 mod network_log_manager;

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -156,7 +156,7 @@ impl JobProvider for ApiProvider {
         }
     }
 
-    async fn claim(&self, run_id: RunId) -> Option<ExecutionContext> {
+    async fn claim(&self, run_id: RunId, _expected_profile: &str) -> Option<ExecutionContext> {
         match self.api.claim(run_id).await {
             Ok(ctx) => {
                 info!(run_id = %run_id, "job claimed");

--- a/crates/runner/src/provider/local.rs
+++ b/crates/runner/src/provider/local.rs
@@ -340,14 +340,19 @@ impl JobProvider for LocalProvider {
             }
         };
 
-        // Atomic write: tmp then rename, so submit never reads a partial file.
-        let tmp_file = self.group_dir.join(format!("{run_id}.result.tmp"));
+        // Atomic write: unique tmp then rename, so submit never reads a
+        // partial file and concurrent poison-job retries do not share a tmp.
+        let tmp_file = self
+            .group_dir
+            .join(format!("{run_id}.{}.result.tmp", RunId::new_v4()));
         let result_file = self.group_dir.join(format!("{run_id}.result"));
         if let Err(e) = std::fs::write(&tmp_file, &json) {
+            let _ = std::fs::remove_file(&tmp_file);
             warn!(run_id = %run_id, error = %e, "local: failed to write result file");
             return;
         }
         if let Err(e) = std::fs::rename(&tmp_file, &result_file) {
+            let _ = std::fs::remove_file(&tmp_file);
             warn!(run_id = %run_id, error = %e, "local: failed to rename result file");
         }
         // Best-effort cleanup of cancel file (may have been written after the
@@ -700,6 +705,21 @@ mod tests {
             !cancel_path.exists(),
             "complete() should clean up cancel file"
         );
+    }
+
+    #[tokio::test]
+    async fn complete_does_not_depend_on_fixed_result_tmp_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let cancel = CancellationToken::new();
+        let provider = make_provider(dir.path(), cancel, empty_cancel_tokens());
+
+        let run_id = RunId::new_v4();
+        std::fs::create_dir(dir.path().join(format!("{run_id}.result.tmp"))).unwrap();
+
+        provider.complete(run_id, 0, None, None, None).await;
+
+        let resp = read_result(dir.path(), run_id);
+        assert_eq!(resp.exit_code, 0);
     }
 
     /// Cancel file written before token is inserted (race between submit

--- a/crates/runner/src/provider/local.rs
+++ b/crates/runner/src/provider/local.rs
@@ -257,6 +257,19 @@ impl JobProvider for LocalProvider {
                 return None;
             }
         };
+        let requested_profile = req
+            .profile
+            .as_deref()
+            .unwrap_or(crate::profile::DEFAULT_PROFILE);
+        if !self.supported_profiles.contains(requested_profile) {
+            warn!(
+                run_id = %run_id,
+                profile = requested_profile,
+                "local: claimed job no longer matches supported profiles"
+            );
+            let _ = std::fs::remove_file(&claim_file);
+            return None;
+        }
 
         info!(run_id = %run_id, "local: job claimed");
         Some(ExecutionContext {
@@ -816,5 +829,26 @@ mod tests {
             "error must mention invalid JSON, got: {:?}",
             resp.error
         );
+    }
+
+    #[tokio::test]
+    async fn claim_rejects_unsupported_profile_after_discovery_race() {
+        let dir = tempfile::tempdir().unwrap();
+        let cancel = CancellationToken::new();
+        let provider = make_provider(dir.path(), cancel, empty_cancel_tokens());
+
+        let run_id = RunId::new_v4();
+        write_job_with_profile(dir.path(), run_id, "default job", Some("vm0/default"));
+
+        let (discovered, profile) = provider.find_unclaimed_job().unwrap();
+        assert_eq!(discovered, run_id);
+        assert_eq!(profile, "vm0/default");
+
+        write_job_with_profile(dir.path(), run_id, "large job", Some("vm0/large"));
+
+        assert!(provider.claim(run_id).await.is_none());
+        assert!(dir.path().join(format!("{run_id}.job")).exists());
+        assert!(!dir.path().join(format!("{run_id}.claim")).exists());
+        assert!(!dir.path().join(format!("{run_id}.result")).exists());
     }
 }

--- a/crates/runner/src/provider/local.rs
+++ b/crates/runner/src/provider/local.rs
@@ -202,7 +202,7 @@ impl JobProvider for LocalProvider {
         }
     }
 
-    async fn claim(&self, run_id: RunId) -> Option<ExecutionContext> {
+    async fn claim(&self, run_id: RunId, expected_profile: &str) -> Option<ExecutionContext> {
         // Atomic claim via O_EXCL — only the first runner to create the file wins.
         let claim_file = self.group_dir.join(format!("{run_id}.claim"));
         if std::fs::OpenOptions::new()
@@ -261,6 +261,16 @@ impl JobProvider for LocalProvider {
             .profile
             .as_deref()
             .unwrap_or(crate::profile::DEFAULT_PROFILE);
+        if requested_profile != expected_profile {
+            warn!(
+                run_id = %run_id,
+                expected_profile,
+                actual_profile = requested_profile,
+                "local: claimed job profile changed after discovery"
+            );
+            let _ = std::fs::remove_file(&claim_file);
+            return None;
+        }
         if !self.supported_profiles.contains(requested_profile) {
             warn!(
                 run_id = %run_id,
@@ -429,7 +439,7 @@ mod tests {
         assert_eq!(run_id, job_id);
         assert_eq!(profile, crate::profile::DEFAULT_PROFILE);
 
-        let ctx = provider.claim(run_id).await.unwrap();
+        let ctx = provider.claim(run_id, &profile).await.unwrap();
         assert_eq!(ctx.run_id, run_id);
         assert_eq!(ctx.prompt, "hello world");
 
@@ -477,14 +487,14 @@ mod tests {
         let job2 = RunId::new_v4();
         write_job(dir.path(), job1, "job1");
 
-        let (run_id1, _) = provider.discover().await.unwrap();
-        let ctx1 = provider.claim(run_id1).await.unwrap();
+        let (run_id1, profile1) = provider.discover().await.unwrap();
+        let ctx1 = provider.claim(run_id1, &profile1).await.unwrap();
         assert_eq!(ctx1.prompt, "job1");
 
         write_job(dir.path(), job2, "job2");
 
-        let (run_id2, _) = provider.discover().await.unwrap();
-        let ctx2 = provider.claim(run_id2).await.unwrap();
+        let (run_id2, profile2) = provider.discover().await.unwrap();
+        let ctx2 = provider.claim(run_id2, &profile2).await.unwrap();
         assert_eq!(ctx2.prompt, "job2");
         assert_ne!(run_id1, run_id2);
 
@@ -514,13 +524,13 @@ mod tests {
         let job_id = RunId::new_v4();
         write_job(dir.path(), job_id, "shared");
 
-        let (id_a, _) = provider_a.discover().await.unwrap();
-        let (id_b, _) = provider_b.discover().await.unwrap();
+        let (id_a, profile_a) = provider_a.discover().await.unwrap();
+        let (id_b, profile_b) = provider_b.discover().await.unwrap();
         assert_eq!(id_a, job_id);
         assert_eq!(id_b, job_id);
 
-        let claim_a = provider_a.claim(id_a).await;
-        let claim_b = provider_b.claim(id_b).await;
+        let claim_a = provider_a.claim(id_a, &profile_a).await;
+        let claim_b = provider_b.claim(id_b, &profile_b).await;
 
         assert!(
             claim_a.is_some() ^ claim_b.is_some(),
@@ -541,7 +551,7 @@ mod tests {
         assert_eq!(run_id, job_id);
         assert_eq!(profile, "vm0/default");
 
-        let ctx = provider.claim(run_id).await.unwrap();
+        let ctx = provider.claim(run_id, &profile).await.unwrap();
         assert_eq!(ctx.experimental_profile.as_deref(), Some("vm0/default"));
     }
 
@@ -723,7 +733,10 @@ mod tests {
 
         // Claim the job so it's no longer discoverable, then write another
         // job to let discover() return.
-        provider.claim(run_id).await.unwrap();
+        provider
+            .claim(run_id, crate::profile::DEFAULT_PROFILE)
+            .await
+            .unwrap();
         let other_job = RunId::new_v4();
         write_job(dir.path(), other_job, "next job");
 
@@ -752,7 +765,12 @@ mod tests {
         let claim_path = dir.path().join(format!("{run_id}.claim"));
 
         // No .job file — claim() should fail at the read step.
-        assert!(provider.claim(run_id).await.is_none());
+        assert!(
+            provider
+                .claim(run_id, crate::profile::DEFAULT_PROFILE)
+                .await
+                .is_none()
+        );
         assert!(
             !claim_path.exists(),
             "claim file must be removed when job read fails"
@@ -775,7 +793,12 @@ mod tests {
         let result_path = dir.path().join(format!("{run_id}.result"));
         std::fs::write(&job_path, b"not json").unwrap();
 
-        assert!(provider.claim(run_id).await.is_none());
+        assert!(
+            provider
+                .claim(run_id, crate::profile::DEFAULT_PROFILE)
+                .await
+                .is_none()
+        );
 
         assert!(!claim_path.exists(), "claim file must be removed");
         assert!(!job_path.exists(), "poison job file must be removed");
@@ -819,7 +842,7 @@ mod tests {
         assert_eq!(discovered, run_id);
         assert_eq!(profile, "vm0/large");
 
-        assert!(provider.claim(run_id).await.is_none());
+        assert!(provider.claim(run_id, &profile).await.is_none());
         let resp = read_result(dir.path(), run_id);
         assert_ne!(resp.exit_code, 0);
         assert!(
@@ -846,7 +869,33 @@ mod tests {
 
         write_job_with_profile(dir.path(), run_id, "large job", Some("vm0/large"));
 
-        assert!(provider.claim(run_id).await.is_none());
+        assert!(provider.claim(run_id, "vm0/default").await.is_none());
+        assert!(dir.path().join(format!("{run_id}.job")).exists());
+        assert!(!dir.path().join(format!("{run_id}.claim")).exists());
+        assert!(!dir.path().join(format!("{run_id}.result")).exists());
+    }
+
+    #[tokio::test]
+    async fn claim_rejects_supported_profile_change_after_discovery_race() {
+        let dir = tempfile::tempdir().unwrap();
+        let cancel = CancellationToken::new();
+        let provider = provider_with_profiles(
+            dir.path(),
+            ["vm0/default".to_owned(), "vm0/large".to_owned()],
+            cancel,
+            empty_cancel_tokens(),
+        );
+
+        let run_id = RunId::new_v4();
+        write_job_with_profile(dir.path(), run_id, "default job", Some("vm0/default"));
+
+        let (discovered, profile) = provider.find_unclaimed_job().unwrap();
+        assert_eq!(discovered, run_id);
+        assert_eq!(profile, "vm0/default");
+
+        write_job_with_profile(dir.path(), run_id, "large job", Some("vm0/large"));
+
+        assert!(provider.claim(run_id, &profile).await.is_none());
         assert!(dir.path().join(format!("{run_id}.job")).exists());
         assert!(!dir.path().join(format!("{run_id}.claim")).exists());
         assert!(!dir.path().join(format!("{run_id}.result")).exists());

--- a/crates/runner/src/provider/local.rs
+++ b/crates/runner/src/provider/local.rs
@@ -5,7 +5,7 @@
 //! winning runner executes the job and writes a `{job_id}.result` file that
 //! `submit` polls for.
 
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
@@ -61,6 +61,7 @@ pub(crate) struct JobResponse {
 /// corresponding cancellation token from the shared `cancel_tokens` map.
 pub struct LocalProvider {
     group_dir: PathBuf,
+    supported_profiles: BTreeSet<String>,
     cancel: CancellationToken,
     cancel_tokens: Arc<tokio::sync::Mutex<HashMap<RunId, CancellationToken>>>,
 }
@@ -69,12 +70,14 @@ impl LocalProvider {
     /// Create a new file-queue provider for the given group directory.
     pub fn new(
         group_dir: PathBuf,
+        supported_profiles: impl IntoIterator<Item = String>,
         cancel: CancellationToken,
         cancel_tokens: Arc<tokio::sync::Mutex<HashMap<RunId, CancellationToken>>>,
     ) -> Arc<Self> {
         info!(path = %group_dir.display(), "local provider watching");
         Arc::new(Self {
             group_dir,
+            supported_profiles: supported_profiles.into_iter().collect(),
             cancel,
             cancel_tokens,
         })
@@ -156,14 +159,22 @@ impl LocalProvider {
             };
             let claim_path = self.group_dir.join(format!("{job_id}.claim"));
             if !claim_path.exists() {
-                // Silent fallback to default profile — claim() is the single
-                // source of truth for logging and poison handling, so errors
-                // here are intentionally swallowed to avoid duplicate warns.
-                let profile = std::fs::read(&path)
+                // claim() is the single source of truth for logging and poison
+                // handling. If discovery cannot parse the job, still return it
+                // using any supported profile so claim() can mark the poisoned
+                // job failed instead of leaving it behind forever.
+                let profile = match std::fs::read(&path)
                     .ok()
                     .and_then(|buf| serde_json::from_slice::<JobRequest>(&buf).ok())
-                    .and_then(|req| req.profile)
-                    .unwrap_or_else(|| crate::profile::DEFAULT_PROFILE.to_owned());
+                {
+                    Some(req) => req
+                        .profile
+                        .unwrap_or_else(|| crate::profile::DEFAULT_PROFILE.to_owned()),
+                    None => self.supported_profiles.iter().next()?.clone(),
+                };
+                if !self.supported_profiles.contains(&profile) {
+                    continue;
+                }
                 return Some((job_id, profile));
             }
         }
@@ -335,6 +346,28 @@ mod tests {
         Arc::new(tokio::sync::Mutex::new(HashMap::new()))
     }
 
+    fn make_provider(
+        dir: &std::path::Path,
+        cancel: CancellationToken,
+        cancel_tokens: Arc<tokio::sync::Mutex<HashMap<RunId, CancellationToken>>>,
+    ) -> Arc<LocalProvider> {
+        provider_with_profiles(
+            dir,
+            [crate::profile::DEFAULT_PROFILE.to_owned()],
+            cancel,
+            cancel_tokens,
+        )
+    }
+
+    fn provider_with_profiles(
+        dir: &std::path::Path,
+        profiles: impl IntoIterator<Item = String>,
+        cancel: CancellationToken,
+        cancel_tokens: Arc<tokio::sync::Mutex<HashMap<RunId, CancellationToken>>>,
+    ) -> Arc<LocalProvider> {
+        LocalProvider::new(dir.to_path_buf(), profiles, cancel, cancel_tokens)
+    }
+
     /// Write a job file into the group directory.
     fn write_job(dir: &std::path::Path, job_id: RunId, prompt: &str) {
         write_job_with_profile(dir, job_id, prompt, None);
@@ -374,7 +407,7 @@ mod tests {
     async fn discover_claim_complete() {
         let dir = tempfile::tempdir().unwrap();
         let cancel = CancellationToken::new();
-        let provider = LocalProvider::new(dir.path().to_path_buf(), cancel, empty_cancel_tokens());
+        let provider = make_provider(dir.path(), cancel, empty_cancel_tokens());
 
         let job_id = RunId::new_v4();
         write_job(dir.path(), job_id, "hello world");
@@ -398,11 +431,7 @@ mod tests {
     async fn shutdown_returns_none() {
         let dir = tempfile::tempdir().unwrap();
         let cancel = CancellationToken::new();
-        let provider = LocalProvider::new(
-            dir.path().to_path_buf(),
-            cancel.clone(),
-            empty_cancel_tokens(),
-        );
+        let provider = make_provider(dir.path(), cancel.clone(), empty_cancel_tokens());
 
         cancel.cancel();
         assert!(provider.discover().await.is_none());
@@ -412,7 +441,7 @@ mod tests {
     async fn skips_already_claimed_jobs() {
         let dir = tempfile::tempdir().unwrap();
         let cancel = CancellationToken::new();
-        let provider = LocalProvider::new(dir.path().to_path_buf(), cancel, empty_cancel_tokens());
+        let provider = make_provider(dir.path(), cancel, empty_cancel_tokens());
 
         // Write two jobs, pre-claim the first
         let job1 = RunId::new_v4();
@@ -429,7 +458,7 @@ mod tests {
     async fn concurrent_jobs() {
         let dir = tempfile::tempdir().unwrap();
         let cancel = CancellationToken::new();
-        let provider = LocalProvider::new(dir.path().to_path_buf(), cancel, empty_cancel_tokens());
+        let provider = make_provider(dir.path(), cancel, empty_cancel_tokens());
 
         let job1 = RunId::new_v4();
         let job2 = RunId::new_v4();
@@ -466,12 +495,8 @@ mod tests {
         let cancel = CancellationToken::new();
 
         let tokens = empty_cancel_tokens();
-        let provider_a = LocalProvider::new(
-            dir.path().to_path_buf(),
-            cancel.clone(),
-            Arc::clone(&tokens),
-        );
-        let provider_b = LocalProvider::new(dir.path().to_path_buf(), cancel, tokens);
+        let provider_a = make_provider(dir.path(), cancel.clone(), Arc::clone(&tokens));
+        let provider_b = make_provider(dir.path(), cancel, tokens);
 
         let job_id = RunId::new_v4();
         write_job(dir.path(), job_id, "shared");
@@ -494,7 +519,7 @@ mod tests {
     async fn discover_returns_profile_from_job() {
         let dir = tempfile::tempdir().unwrap();
         let cancel = CancellationToken::new();
-        let provider = LocalProvider::new(dir.path().to_path_buf(), cancel, empty_cancel_tokens());
+        let provider = make_provider(dir.path(), cancel, empty_cancel_tokens());
 
         let job_id = RunId::new_v4();
         write_job_with_profile(dir.path(), job_id, "profiled job", Some("vm0/default"));
@@ -511,7 +536,7 @@ mod tests {
     async fn discover_defaults_profile_when_missing() {
         let dir = tempfile::tempdir().unwrap();
         let cancel = CancellationToken::new();
-        let provider = LocalProvider::new(dir.path().to_path_buf(), cancel, empty_cancel_tokens());
+        let provider = make_provider(dir.path(), cancel, empty_cancel_tokens());
 
         let job_id = RunId::new_v4();
         write_job(dir.path(), job_id, "default job");
@@ -519,6 +544,47 @@ mod tests {
         let (run_id, profile) = provider.discover().await.unwrap();
         assert_eq!(run_id, job_id);
         assert_eq!(profile, crate::profile::DEFAULT_PROFILE);
+    }
+
+    #[test]
+    fn discover_skips_unsupported_profile_and_continues_scanning() {
+        let dir = tempfile::tempdir().unwrap();
+        let cancel = CancellationToken::new();
+        let provider = make_provider(dir.path(), cancel, empty_cancel_tokens());
+
+        let unsupported = RunId::nil();
+        let supported = RunId::new_v4();
+        write_job_with_profile(dir.path(), unsupported, "large job", Some("vm0/large"));
+
+        assert!(provider.find_unclaimed_job().is_none());
+        assert!(!dir.path().join(format!("{unsupported}.claim")).exists());
+        assert!(!dir.path().join(format!("{unsupported}.result")).exists());
+        assert!(dir.path().join(format!("{unsupported}.job")).exists());
+
+        write_job_with_profile(dir.path(), supported, "default job", Some("vm0/default"));
+
+        let (run_id, profile) = provider.find_unclaimed_job().unwrap();
+        assert_eq!(run_id, supported);
+        assert_eq!(profile, "vm0/default");
+    }
+
+    #[tokio::test]
+    async fn discover_returns_supported_non_default_profile() {
+        let dir = tempfile::tempdir().unwrap();
+        let cancel = CancellationToken::new();
+        let provider = provider_with_profiles(
+            dir.path(),
+            ["vm0/large".to_owned()],
+            cancel,
+            empty_cancel_tokens(),
+        );
+
+        let job_id = RunId::new_v4();
+        write_job_with_profile(dir.path(), job_id, "large job", Some("vm0/large"));
+
+        let (run_id, profile) = provider.discover().await.unwrap();
+        assert_eq!(run_id, job_id);
+        assert_eq!(profile, "vm0/large");
     }
 
     #[tokio::test]
@@ -531,7 +597,7 @@ mod tests {
         let job_token = CancellationToken::new();
         tokens.lock().await.insert(run_id, job_token.clone());
 
-        let provider = LocalProvider::new(dir.path().to_path_buf(), cancel, tokens);
+        let provider = make_provider(dir.path(), cancel, tokens);
 
         // Write a .cancel file and a dummy .job so discover returns.
         std::fs::write(dir.path().join(format!("{run_id}.cancel")), b"").unwrap();
@@ -555,7 +621,7 @@ mod tests {
         let job_token = CancellationToken::new();
         tokens.lock().await.insert(run_id, job_token);
 
-        let provider = LocalProvider::new(dir.path().to_path_buf(), cancel, tokens);
+        let provider = make_provider(dir.path(), cancel, tokens);
 
         let cancel_path = dir.path().join(format!("{run_id}.cancel"));
         std::fs::write(&cancel_path, b"").unwrap();
@@ -576,7 +642,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let cancel = CancellationToken::new();
         let tokens = empty_cancel_tokens();
-        let provider = LocalProvider::new(dir.path().to_path_buf(), cancel, tokens);
+        let provider = make_provider(dir.path(), cancel, tokens);
 
         // Write cancel file for a run_id that has no token.
         let unknown_id = RunId::new_v4();
@@ -599,7 +665,7 @@ mod tests {
     async fn complete_cleans_up_cancel_file() {
         let dir = tempfile::tempdir().unwrap();
         let cancel = CancellationToken::new();
-        let provider = LocalProvider::new(dir.path().to_path_buf(), cancel, empty_cancel_tokens());
+        let provider = make_provider(dir.path(), cancel, empty_cancel_tokens());
 
         let run_id = RunId::new_v4();
         let cancel_path = dir.path().join(format!("{run_id}.cancel"));
@@ -621,7 +687,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let cancel = CancellationToken::new();
         let tokens = empty_cancel_tokens();
-        let provider = LocalProvider::new(dir.path().to_path_buf(), cancel, Arc::clone(&tokens));
+        let provider = make_provider(dir.path(), cancel, Arc::clone(&tokens));
 
         let run_id = RunId::new_v4();
         let cancel_path = dir.path().join(format!("{run_id}.cancel"));
@@ -667,7 +733,7 @@ mod tests {
     async fn claim_cleans_up_on_missing_job_file() {
         let dir = tempfile::tempdir().unwrap();
         let cancel = CancellationToken::new();
-        let provider = LocalProvider::new(dir.path().to_path_buf(), cancel, empty_cancel_tokens());
+        let provider = make_provider(dir.path(), cancel, empty_cancel_tokens());
 
         let run_id = RunId::new_v4();
         let claim_path = dir.path().join(format!("{run_id}.claim"));
@@ -688,7 +754,7 @@ mod tests {
     async fn claim_handles_poison_job_json() {
         let dir = tempfile::tempdir().unwrap();
         let cancel = CancellationToken::new();
-        let provider = LocalProvider::new(dir.path().to_path_buf(), cancel, empty_cancel_tokens());
+        let provider = make_provider(dir.path(), cancel, empty_cancel_tokens());
 
         let run_id = RunId::new_v4();
         let claim_path = dir.path().join(format!("{run_id}.claim"));
@@ -719,5 +785,36 @@ mod tests {
 
         // Next discover() scan must not re-surface the job.
         assert!(provider.find_unclaimed_job().is_none());
+    }
+
+    #[tokio::test]
+    async fn poison_job_json_is_discovered_even_without_default_profile_support() {
+        let dir = tempfile::tempdir().unwrap();
+        let cancel = CancellationToken::new();
+        let provider = provider_with_profiles(
+            dir.path(),
+            ["vm0/large".to_owned()],
+            cancel,
+            empty_cancel_tokens(),
+        );
+
+        let run_id = RunId::new_v4();
+        let job_path = dir.path().join(format!("{run_id}.job"));
+        std::fs::write(&job_path, b"not json").unwrap();
+
+        let (discovered, profile) = provider.find_unclaimed_job().unwrap();
+        assert_eq!(discovered, run_id);
+        assert_eq!(profile, "vm0/large");
+
+        assert!(provider.claim(run_id).await.is_none());
+        let resp = read_result(dir.path(), run_id);
+        assert_ne!(resp.exit_code, 0);
+        assert!(
+            resp.error
+                .as_deref()
+                .is_some_and(|e| e.contains("invalid job JSON")),
+            "error must mention invalid JSON, got: {:?}",
+            resp.error
+        );
     }
 }

--- a/crates/runner/src/provider/mock.rs
+++ b/crates/runner/src/provider/mock.rs
@@ -260,7 +260,7 @@ impl JobProvider for MockJobProvider {
         }
     }
 
-    async fn claim(&self, run_id: RunId) -> Option<ExecutionContext> {
+    async fn claim(&self, run_id: RunId, _expected_profile: &str) -> Option<ExecutionContext> {
         self.claim_results
             .lock()
             .unwrap_or_else(|e| e.into_inner())

--- a/crates/runner/src/provider/mod.rs
+++ b/crates/runner/src/provider/mod.rs
@@ -43,13 +43,14 @@ pub trait JobProvider: Send + Sync {
     /// dropped (cancelled) at any `.await` point.
     async fn discover(&self) -> Option<(RunId, String)>;
 
-    /// Claim a discovered job. Returns `None` if the job was already claimed
-    /// by another runner or an error occurred.
+    /// Claim a discovered job for the profile returned by `discover()`.
+    /// Returns `None` if the job was already claimed by another runner, the
+    /// profile no longer matches, or an error occurred.
     ///
     /// Callers **must** invoke this from a non-cancellable context (e.g.
     /// inside a `select!` branch handler) to guarantee that a successful
     /// claim is always paired with a later [`complete()`](JobProvider::complete).
-    async fn claim(&self, run_id: RunId) -> Option<ExecutionContext>;
+    async fn claim(&self, run_id: RunId, expected_profile: &str) -> Option<ExecutionContext>;
 
     /// Report job completion. Called concurrently from spawned executor tasks.
     ///


### PR DESCRIPTION
## Summary
- add a local runner registry under each local group so running local runners advertise supported profiles
- make local submit fail fast when no live runner supports the requested profile
- make local providers ignore jobs for unsupported profiles while still cleaning up poisoned job JSON

## Tests
- cargo fmt --manifest-path crates/Cargo.toml --all --check
- cargo test --manifest-path crates/Cargo.toml -p runner local_runner_registry
- cargo test --manifest-path crates/Cargo.toml -p runner provider::local
- cargo test --manifest-path crates/Cargo.toml -p runner cmd::local
- cargo test --manifest-path crates/Cargo.toml -p runner
- pre-commit: cargo-fmt, cargo-clippy, cargo-doc

Closes #13087