### PR TITLE
refactor(api): migrate voice-chat callback

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -34,6 +34,7 @@ import { internalCallbacksGithubIssuesRoutes } from "./routes/internal-callbacks
 import { internalCallbacksScheduleRoutes } from "./routes/internal-callbacks-schedule";
 import { internalCallbacksSlackOrgRoutes } from "./routes/internal-callbacks-slack-org";
 import { internalCallbacksTelegramRoutes } from "./routes/internal-callbacks-telegram";
+import { internalCallbacksVoiceChatRoutes } from "./routes/internal-callbacks-voice-chat";
 import { internalEventConsumerAxiomRoutes } from "./routes/internal-event-consumers-axiom";
 import { internalEventConsumerChatAssistantRoutes } from "./routes/internal-event-consumers-chat-assistant";
 import { internalEventConsumerTelegramTypingRoutes } from "./routes/internal-event-consumers-telegram-typing";
@@ -157,6 +158,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...internalCallbacksScheduleRoutes,
   ...internalCallbacksSlackOrgRoutes,
   ...internalCallbacksTelegramRoutes,
+  ...internalCallbacksVoiceChatRoutes,
   ...internalEventConsumerAxiomRoutes,
   ...internalEventConsumerChatAssistantRoutes,
   ...internalEventConsumerTelegramTypingRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-voice-chat.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-voice-chat.test.ts
@@ -1,0 +1,334 @@
+import { randomUUID } from "node:crypto";
+
+import { createStore } from "ccstate";
+import { eq } from "drizzle-orm";
+import { describe, expect, it } from "vitest";
+import { agentRuns } from "@vm0/db/schema/agent-run";
+import { voiceChatItems, voiceChatTasks } from "@vm0/db/schema/voice-chat";
+
+import { createApp } from "../../../app-factory";
+import { testContext } from "../../../__tests__/test-helpers";
+import { computeHmacSignature } from "../../../lib/event-consumer/hmac";
+import { now } from "../../../lib/time";
+import { clearAllDetached } from "../../utils";
+import { writeDb$ } from "../../external/db";
+import { seedAgentRunCallback$ } from "./helpers/agent-run-callback";
+import {
+  addVoiceChatSession$,
+  deleteVoiceChatFixture$,
+  seedVoiceChatAgent$,
+  seedVoiceChatFixture$,
+  seedVoiceChatTask$,
+  type VoiceChatFixture,
+} from "./helpers/zero-voice-chat";
+import { createFixtureTracker } from "./helpers/zero-route-test";
+import { seedRun$ } from "./helpers/zero-usage-insight";
+
+const context = testContext();
+const store = createStore();
+
+const PATH = "/api/internal/callbacks/voice-chat";
+const TEST_CALLBACK_SECRET = "test-callback-secret";
+
+interface VoiceChatCallbackFixture extends VoiceChatFixture {
+  readonly agentId: string;
+  readonly sessionId: string;
+  readonly runId: string;
+  readonly taskId: string;
+  readonly callbackId: string;
+}
+
+const track = createFixtureTracker<VoiceChatFixture>((fixture) => {
+  return store.set(deleteVoiceChatFixture$, fixture, context.signal);
+});
+
+async function seedVoiceChatCallbackFixture(args: {
+  readonly agentIdOnRun?: string;
+}): Promise<VoiceChatCallbackFixture> {
+  const fixture = await track(
+    store.set(seedVoiceChatFixture$, {}, context.signal),
+  );
+  const agentId = await store.set(
+    seedVoiceChatAgent$,
+    fixture,
+    {},
+    context.signal,
+  );
+  const sessionId = await store.set(
+    addVoiceChatSession$,
+    fixture,
+    { agentId },
+    context.signal,
+  );
+  const { runId } = await store.set(
+    seedRun$,
+    {
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      composeId: agentId,
+      triggerSource: "voice-chat",
+      status: "running",
+      lastEventSequence: 7,
+    },
+    context.signal,
+  );
+  const db = store.set(writeDb$);
+  await db
+    .update(agentRuns)
+    .set({ vars: { ZERO_AGENT_ID: args.agentIdOnRun ?? agentId } })
+    .where(eq(agentRuns.id, runId));
+  const taskId = await store.set(
+    seedVoiceChatTask$,
+    sessionId,
+    { status: "queued", runId },
+    context.signal,
+  );
+  const { callbackId } = await store.set(
+    seedAgentRunCallback$,
+    {
+      runId,
+      url: `http://localhost${PATH}`,
+      payload: { taskId },
+    },
+    context.signal,
+  );
+
+  return { ...fixture, agentId, sessionId, runId, taskId, callbackId };
+}
+
+function signedHeaders(rawBody: string, secret = TEST_CALLBACK_SECRET) {
+  const timestamp = Math.floor(now() / 1000);
+  return {
+    "Content-Type": "application/json",
+    "X-VM0-Signature": computeHmacSignature(rawBody, secret, timestamp),
+    "X-VM0-Timestamp": String(timestamp),
+  };
+}
+
+async function postSignedCallback(
+  body: Record<string, unknown>,
+  secret?: string,
+): Promise<Response> {
+  const rawBody = JSON.stringify(body);
+  const app = createApp({ signal: context.signal });
+  return await app.request(PATH, {
+    method: "POST",
+    headers: signedHeaders(rawBody, secret),
+    body: rawBody,
+  });
+}
+
+async function getTask(taskId: string) {
+  const db = store.set(writeDb$);
+  const [task] = await db
+    .select()
+    .from(voiceChatTasks)
+    .where(eq(voiceChatTasks.id, taskId))
+    .limit(1);
+  return task ?? null;
+}
+
+async function listItems(sessionId: string) {
+  const db = store.set(writeDb$);
+  return await db
+    .select()
+    .from(voiceChatItems)
+    .where(eq(voiceChatItems.sessionId, sessionId));
+}
+
+function completedOutput(text: string): void {
+  context.mocks.axiom.query
+    .mockResolvedValueOnce(
+      Array.from({ length: 8 }, (_, sequenceNumber) => {
+        return { sequenceNumber };
+      }),
+    )
+    .mockResolvedValueOnce([
+      {
+        eventType: "result",
+        eventData: { result: text },
+      },
+    ]);
+}
+
+describe("POST /api/internal/callbacks/voice-chat", () => {
+  it("returns 200 for progress status without touching the task", async () => {
+    const fixture = await seedVoiceChatCallbackFixture({});
+
+    const response = await postSignedCallback({
+      callbackId: fixture.callbackId,
+      runId: fixture.runId,
+      status: "progress",
+      payload: { taskId: fixture.taskId },
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toStrictEqual({ success: true });
+    await expect(getTask(fixture.taskId)).resolves.toMatchObject({
+      status: "queued",
+    });
+    expect(context.mocks.axiom.query).not.toHaveBeenCalled();
+  });
+
+  it("completes the task and writes a task_result item on completed", async () => {
+    const fixture = await seedVoiceChatCallbackFixture({});
+    completedOutput("final answer");
+
+    const response = await postSignedCallback({
+      callbackId: fixture.callbackId,
+      runId: fixture.runId,
+      status: "completed",
+      payload: { taskId: fixture.taskId },
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toStrictEqual({ success: true });
+
+    const task = await getTask(fixture.taskId);
+    expect(task).toMatchObject({
+      status: "done",
+      error: null,
+      result: "final answer",
+    });
+    expect(task?.assistantMessages).toStrictEqual([
+      { type: "assistant", content: "final answer", at: expect.any(String) },
+    ]);
+
+    const items = await listItems(fixture.sessionId);
+    expect(
+      items.some((item) => {
+        return (
+          item.role === "task_result" &&
+          item.taskId === fixture.taskId &&
+          item.content?.includes("final answer") === true
+        );
+      }),
+    ).toBeTruthy();
+
+    expect(context.mocks.ably.publish).toHaveBeenCalledWith(
+      `voice-chat:${fixture.sessionId}`,
+      null,
+    );
+    await clearAllDetached();
+  });
+
+  it("marks the task failed and records the callback error on failed", async () => {
+    const fixture = await seedVoiceChatCallbackFixture({});
+
+    const response = await postSignedCallback({
+      callbackId: fixture.callbackId,
+      runId: fixture.runId,
+      status: "failed",
+      error: "runner crashed",
+      payload: { taskId: fixture.taskId },
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toStrictEqual({ success: true });
+
+    const task = await getTask(fixture.taskId);
+    expect(task).toMatchObject({
+      status: "failed",
+      error: "runner crashed",
+      result: null,
+    });
+
+    const items = await listItems(fixture.sessionId);
+    expect(
+      items.some((item) => {
+        return (
+          item.role === "task_result" &&
+          item.taskId === fixture.taskId &&
+          item.content?.includes("runner crashed") === true
+        );
+      }),
+    ).toBeTruthy();
+    await clearAllDetached();
+  });
+
+  it("rejects requests with invalid signatures", async () => {
+    const fixture = await seedVoiceChatCallbackFixture({});
+
+    const response = await postSignedCallback(
+      {
+        callbackId: fixture.callbackId,
+        runId: fixture.runId,
+        status: "completed",
+        payload: { taskId: fixture.taskId },
+      },
+      "wrong-secret",
+    );
+
+    expect(response.status).toBe(401);
+    await expect(getTask(fixture.taskId)).resolves.toMatchObject({
+      status: "queued",
+    });
+  });
+
+  it("returns 400 when payload is missing taskId", async () => {
+    const fixture = await seedVoiceChatCallbackFixture({});
+
+    const response = await postSignedCallback({
+      callbackId: fixture.callbackId,
+      runId: fixture.runId,
+      status: "completed",
+      payload: {},
+    });
+
+    expect(response.status).toBe(400);
+    await expect(getTask(fixture.taskId)).resolves.toMatchObject({
+      status: "queued",
+    });
+  });
+
+  it("fails the task with a system note on agent mismatch", async () => {
+    const fixture = await seedVoiceChatCallbackFixture({
+      agentIdOnRun: randomUUID(),
+    });
+    completedOutput("ignored answer");
+
+    const response = await postSignedCallback({
+      callbackId: fixture.callbackId,
+      runId: fixture.runId,
+      status: "completed",
+      payload: { taskId: fixture.taskId },
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toStrictEqual({ success: true });
+
+    const task = await getTask(fixture.taskId);
+    expect(task).toMatchObject({
+      status: "failed",
+      error: "agent mismatch",
+    });
+    const items = await listItems(fixture.sessionId);
+    expect(
+      items.some((item) => {
+        return (
+          item.role === "system_note" &&
+          item.taskId === fixture.taskId &&
+          item.content?.toLowerCase().includes("agent mismatch") === true
+        );
+      }),
+    ).toBeTruthy();
+    await clearAllDetached();
+  });
+
+  it("returns 200 for an unknown taskId", async () => {
+    const fixture = await seedVoiceChatCallbackFixture({});
+
+    const response = await postSignedCallback({
+      callbackId: fixture.callbackId,
+      runId: fixture.runId,
+      status: "completed",
+      payload: { taskId: randomUUID() },
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toStrictEqual({ success: true });
+    await expect(getTask(fixture.taskId)).resolves.toMatchObject({
+      status: "queued",
+    });
+  });
+});

--- a/turbo/apps/api/src/signals/routes/internal-callbacks-voice-chat.ts
+++ b/turbo/apps/api/src/signals/routes/internal-callbacks-voice-chat.ts
@@ -1,0 +1,131 @@
+import { command } from "ccstate";
+import {
+  internalCallbacksVoiceChatContract,
+  voiceChatCallbackPayloadSchema,
+} from "@vm0/api-contracts/contracts/internal-callbacks-voice-chat";
+import { agentRuns } from "@vm0/db/schema/agent-run";
+import { eq } from "drizzle-orm";
+
+import {
+  callbackPayload$,
+  callbackRoute,
+} from "../../lib/callback-route/callback-route";
+import { logger } from "../../lib/log";
+import type { RouteEntry } from "../route";
+import { waitUntil } from "../context/wait-until";
+import { db$, type ReadonlyDb } from "../external/db";
+import { publishUserSignal } from "../external/realtime";
+import {
+  completeVoiceChatTask$,
+  triggerVoiceChatReasoning$,
+} from "../services/zero-voice-chat.service";
+import { getRunOutputText } from "../services/run-output.service";
+
+const log = logger("callback:voice-chat");
+
+async function readRunInfo(
+  db: ReadonlyDb,
+  runId: string,
+  signal: AbortSignal,
+): Promise<{
+  readonly agentId: string;
+  readonly lastEventSequence: number | null;
+}> {
+  const [run] = await db
+    .select({
+      vars: agentRuns.vars,
+      lastEventSequence: agentRuns.lastEventSequence,
+    })
+    .from(agentRuns)
+    .where(eq(agentRuns.id, runId))
+    .limit(1);
+  signal.throwIfAborted();
+
+  if (!run) {
+    log.warn("run not found while resolving ZERO_AGENT_ID", { runId });
+    return { agentId: "", lastEventSequence: null };
+  }
+
+  const vars = run.vars as { readonly ZERO_AGENT_ID?: unknown } | null;
+  const zeroAgentId = vars?.ZERO_AGENT_ID;
+  if (typeof zeroAgentId !== "string" || zeroAgentId.length === 0) {
+    log.warn("vars.ZERO_AGENT_ID absent on run", { runId });
+    return { agentId: "", lastEventSequence: run.lastEventSequence };
+  }
+
+  return { agentId: zeroAgentId, lastEventSequence: run.lastEventSequence };
+}
+
+const handleVoiceChatCallback$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const callback = get(callbackPayload$);
+    const payload = voiceChatCallbackPayloadSchema.safeParse(callback.payload);
+    if (!payload.success) {
+      return {
+        status: 400 as const,
+        body: { error: "Invalid or missing payload" },
+      };
+    }
+
+    if (callback.status === "progress") {
+      return { status: 200 as const, body: { success: true as const } };
+    }
+
+    const run = await readRunInfo(get(db$), callback.runId, signal);
+    signal.throwIfAborted();
+
+    const resultText =
+      callback.status === "completed"
+        ? await getRunOutputText(callback.runId, {
+            knownLastEventSequence: run.lastEventSequence,
+            signal,
+          }).catch((error: unknown) => {
+            log.warn("Failed to extract run output text", {
+              runId: callback.runId,
+              error,
+            });
+            return undefined;
+          })
+        : undefined;
+    signal.throwIfAborted();
+
+    const completed = await set(
+      completeVoiceChatTask$,
+      {
+        taskId: payload.data.taskId,
+        result: resultText ?? null,
+        error:
+          callback.status === "failed"
+            ? (callback.error ?? "Run failed")
+            : null,
+        agentId: run.agentId,
+      },
+      signal,
+    );
+    signal.throwIfAborted();
+
+    if (!completed) {
+      log.warn("voice-chat task not found - ignoring callback", {
+        taskId: payload.data.taskId,
+        runId: callback.runId,
+      });
+      return { status: 200 as const, body: { success: true as const } };
+    }
+
+    await publishUserSignal(
+      [completed.session.userId],
+      `voice-chat:${completed.session.id}`,
+    );
+    signal.throwIfAborted();
+    waitUntil(set(triggerVoiceChatReasoning$, completed.session.id, signal));
+
+    return { status: 200 as const, body: { success: true as const } };
+  },
+);
+
+export const internalCallbacksVoiceChatRoutes: readonly RouteEntry[] = [
+  {
+    route: internalCallbacksVoiceChatContract.post,
+    handler: callbackRoute(handleVoiceChatCallback$),
+  },
+];

--- a/turbo/apps/api/src/signals/services/zero-voice-chat.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-voice-chat.service.ts
@@ -35,11 +35,16 @@ import { and, asc, desc, eq, inArray, sql } from "drizzle-orm";
 import { env, optionalEnv } from "../../lib/env";
 import { logger } from "../../lib/log";
 import { now, nowDate } from "../../lib/time";
-import { notFound } from "../../lib/error";
-import { db$, writeDb$ } from "../external/db";
+import { isBadRequestResponse, notFound } from "../../lib/error";
+import { db$, writeDb$, type Db } from "../external/db";
 import { publishUserSignal } from "../external/realtime";
 import { safeAsync, safeJsonParse } from "../utils";
 import { createAgentRun$ } from "./agent-run-create.service";
+import {
+  cancelRun$,
+  dispatchCancelSideEffects$,
+  type CancelRunResult,
+} from "./zero-run-cancel.service";
 
 const ACTIVE_TASK_STATUSES = ["pending", "queued", "running"] as const;
 const FINISHED_TASK_STATUSES = ["done", "failed"] as const;
@@ -111,6 +116,31 @@ const logToken = logger("api:zero:voice-chat:token");
 type SessionRow = typeof voiceChatSessions.$inferSelect;
 type ItemRow = typeof voiceChatItems.$inferSelect;
 type TaskRow = typeof voiceChatTasks.$inferSelect;
+type WriteTx = Parameters<Parameters<Db["transaction"]>[0]>[0];
+
+interface CompleteVoiceChatTaskArgs {
+  readonly taskId: string;
+  readonly result: string | null;
+  readonly error: string | null;
+  readonly agentId: string;
+}
+
+interface CompleteVoiceChatTaskOutcome {
+  readonly item: ItemRow;
+  readonly task: TaskRow;
+  readonly mismatch: boolean;
+  readonly session: {
+    readonly id: string;
+    readonly orgId: string;
+    readonly userId: string;
+  };
+}
+
+interface CompleteVoiceChatTaskResult {
+  readonly item: ItemRow;
+  readonly task: TaskRow;
+  readonly session: { readonly id: string; readonly userId: string };
+}
 
 type ErrorResponse<Status extends number, Code extends string> = {
   readonly status: Status;
@@ -682,6 +712,257 @@ export const appendVoiceChatTaskAssistantResult$ = command(
       return null;
     }
     return { sessionId: row.sessionId, userId: session.userId };
+  },
+);
+
+function isCancelRunResult(value: unknown): value is CancelRunResult {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "alreadyCancelled" in value &&
+    "runId" in value
+  );
+}
+
+function isRunNotCancellableResult(value: unknown): boolean {
+  if (!isBadRequestResponse(value)) {
+    return false;
+  }
+  const body = value.body;
+  if (typeof body !== "object" || body === null || !("error" in body)) {
+    return false;
+  }
+  const error = body.error;
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    error.code === "RUN_NOT_CANCELLABLE"
+  );
+}
+
+function formatTaskResult(params: {
+  readonly result: string | null;
+  readonly error: string | null;
+}): string {
+  if (params.error) {
+    return `[task failed] ${params.error}`;
+  }
+  return params.result ?? "[task returned empty result]";
+}
+
+async function completeMismatchedVoiceChatTask(
+  tx: WriteTx,
+  taskRow: TaskRow,
+  sessionRow: SessionRow,
+  finishedAt: Date,
+): Promise<CompleteVoiceChatTaskOutcome> {
+  const [failedTask] = await tx
+    .update(voiceChatTasks)
+    .set({
+      status: "failed",
+      error: "agent mismatch",
+      finishedAt,
+    })
+    .where(eq(voiceChatTasks.id, taskRow.id))
+    .returning();
+
+  const [noteItem] = await tx
+    .insert(voiceChatItems)
+    .values({
+      sessionId: taskRow.sessionId,
+      role: "system_note",
+      content: "agent mismatch — task failed",
+      taskId: taskRow.id,
+      realtimeItemId: null,
+    })
+    .returning();
+
+  if (!noteItem) {
+    throw new Error("Failed to insert voice-chat mismatch note");
+  }
+
+  return {
+    task: failedTask ?? taskRow,
+    item: noteItem,
+    mismatch: true,
+    session: {
+      id: sessionRow.id,
+      orgId: sessionRow.orgId,
+      userId: sessionRow.userId,
+    },
+  };
+}
+
+async function completeMatchedVoiceChatTask(
+  tx: WriteTx,
+  taskRow: TaskRow,
+  sessionRow: SessionRow,
+  args: CompleteVoiceChatTaskArgs,
+  finishedAt: Date,
+): Promise<CompleteVoiceChatTaskOutcome> {
+  const finalEntries: VoiceChatTaskResultEntry[] = args.result
+    ? [
+        {
+          type: "assistant",
+          content: args.result,
+          at: finishedAt.toISOString(),
+        },
+      ]
+    : [];
+  const consolidatedResult = [
+    flattenTaskResult(taskRow.assistantMessages) ?? "",
+    args.result ?? "",
+  ]
+    .filter((content) => {
+      return content.length > 0;
+    })
+    .join("\n");
+  const [completedTask] = await tx
+    .update(voiceChatTasks)
+    .set({
+      status: args.error ? "failed" : "done",
+      assistantMessages: sql`${voiceChatTasks.assistantMessages} || ${JSON.stringify(finalEntries)}::jsonb`,
+      result: consolidatedResult.length > 0 ? consolidatedResult : null,
+      resultUpdatedAt: consolidatedResult.length > 0 ? finishedAt : null,
+      error: args.error,
+      finishedAt,
+    })
+    .where(eq(voiceChatTasks.id, taskRow.id))
+    .returning();
+
+  const [resultItem] = await tx
+    .insert(voiceChatItems)
+    .values({
+      sessionId: taskRow.sessionId,
+      role: "task_result",
+      content: formatTaskResult({
+        result: args.result,
+        error: args.error,
+      }),
+      taskId: taskRow.id,
+      realtimeItemId: null,
+    })
+    .returning();
+
+  if (!resultItem) {
+    throw new Error("Failed to insert voice-chat task result");
+  }
+
+  return {
+    task: completedTask ?? taskRow,
+    item: resultItem,
+    mismatch: false,
+    session: {
+      id: sessionRow.id,
+      orgId: sessionRow.orgId,
+      userId: sessionRow.userId,
+    },
+  };
+}
+
+async function completeVoiceChatTaskMutation(
+  writeDb: Db,
+  args: CompleteVoiceChatTaskArgs,
+): Promise<CompleteVoiceChatTaskOutcome | null> {
+  return await writeDb.transaction(async (tx) => {
+    const [taskRow] = await tx
+      .select()
+      .from(voiceChatTasks)
+      .where(eq(voiceChatTasks.id, args.taskId))
+      .for("update")
+      .limit(1);
+    if (!taskRow) {
+      return null;
+    }
+
+    const [sessionRow] = await tx
+      .select()
+      .from(voiceChatSessions)
+      .where(eq(voiceChatSessions.id, taskRow.sessionId))
+      .limit(1);
+    if (!sessionRow) {
+      return null;
+    }
+
+    const finishedAt = nowDate();
+    return sessionRow.agentId !== args.agentId
+      ? await completeMismatchedVoiceChatTask(
+          tx,
+          taskRow,
+          sessionRow,
+          finishedAt,
+        )
+      : await completeMatchedVoiceChatTask(
+          tx,
+          taskRow,
+          sessionRow,
+          args,
+          finishedAt,
+        );
+  });
+}
+
+export const completeVoiceChatTask$ = command(
+  async (
+    { set },
+    args: CompleteVoiceChatTaskArgs,
+    signal: AbortSignal,
+  ): Promise<CompleteVoiceChatTaskResult | null> => {
+    const writeDb = set(writeDb$);
+    const outcome = await completeVoiceChatTaskMutation(writeDb, args);
+    signal.throwIfAborted();
+
+    if (!outcome) {
+      return null;
+    }
+
+    if (outcome.mismatch) {
+      const pending = await writeDb
+        .select()
+        .from(voiceChatTasks)
+        .where(
+          and(
+            eq(voiceChatTasks.sessionId, outcome.session.id),
+            inArray(voiceChatTasks.status, ["pending", "queued"]),
+          ),
+        );
+      signal.throwIfAborted();
+
+      for (const task of pending) {
+        if (!task.runId) {
+          continue;
+        }
+        const cancelled = await set(
+          cancelRun$,
+          {
+            runId: task.runId,
+            userId: outcome.session.userId,
+            orgId: outcome.session.orgId,
+          },
+          signal,
+        );
+        signal.throwIfAborted();
+        if (isCancelRunResult(cancelled)) {
+          await set(dispatchCancelSideEffects$, cancelled, signal);
+          signal.throwIfAborted();
+          continue;
+        }
+        if (isRunNotCancellableResult(cancelled)) {
+          logTask.warn(
+            `cancelRun for task ${task.id} (runId=${task.runId}) skipped - run is no longer cancellable`,
+          );
+          continue;
+        }
+        throw new Error(`Failed to cancel voice-chat task run ${task.runId}`);
+      }
+    }
+
+    return {
+      task: outcome.task,
+      item: outcome.item,
+      session: { id: outcome.session.id, userId: outcome.session.userId },
+    };
   },
 );
 

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -184,6 +184,12 @@ export {
   type SlackOrgCallbackPayload,
 } from "./internal-callbacks-slack-org";
 export {
+  internalCallbacksVoiceChatContract,
+  voiceChatCallbackPayloadSchema,
+  type InternalCallbacksVoiceChatContract,
+  type VoiceChatCallbackPayload,
+} from "./internal-callbacks-voice-chat";
+export {
   sandboxReuseResultSchema,
   webhookEventsContract,
   webhookCompleteContract,

--- a/turbo/packages/api-contracts/src/contracts/internal-callbacks-voice-chat.ts
+++ b/turbo/packages/api-contracts/src/contracts/internal-callbacks-voice-chat.ts
@@ -1,0 +1,42 @@
+import { z } from "zod";
+
+import { initContract } from "./base";
+import {
+  internalCallbackBodySchema,
+  internalCallbackErrorSchema,
+  internalCallbackHeadersSchema,
+  internalCallbackSuccessSchema,
+} from "./internal-callbacks-shared";
+
+const c = initContract();
+
+export const voiceChatCallbackPayloadSchema = z
+  .object({
+    taskId: z.string(),
+  })
+  .passthrough();
+
+export const internalCallbacksVoiceChatContract = c.router({
+  post: {
+    method: "POST",
+    path: "/api/internal/callbacks/voice-chat",
+    headers: internalCallbackHeadersSchema,
+    body: internalCallbackBodySchema.extend({
+      payload: voiceChatCallbackPayloadSchema,
+    }),
+    responses: {
+      200: internalCallbackSuccessSchema,
+      400: internalCallbackErrorSchema,
+      401: internalCallbackErrorSchema,
+      404: internalCallbackErrorSchema,
+      500: internalCallbackErrorSchema,
+    },
+    summary: "Handle callbacks for voice-chat task runs",
+  },
+});
+
+export type VoiceChatCallbackPayload = z.infer<
+  typeof voiceChatCallbackPayloadSchema
+>;
+export type InternalCallbacksVoiceChatContract =
+  typeof internalCallbacksVoiceChatContract;


### PR DESCRIPTION
## Summary
- add the ts-rest contract and API route for POST /api/internal/callbacks/voice-chat
- port voice-chat task completion/failure handling into API services, including agent mismatch handling, realtime publish, and post-response reasoning trigger
- cover progress, terminal success/failure, invalid signature, invalid payload, mismatch, and unknown-task behavior with API integration tests

## Tests
- pnpm format
- pnpm check-types
- pnpm knip
- pnpm -F api lint
- pnpm -F api exec vitest --run src/signals/routes/__tests__/internal-callbacks-voice-chat.test.ts
- git diff --check

Fixes #13070