### PR TITLE
fix: warn sms and mms agentphone users

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/agentphone-connect-params.ts
+++ b/turbo/apps/platform/src/signals/zero-page/agentphone-connect-params.ts
@@ -5,6 +5,9 @@ interface AgentPhoneConnectParams {
   signature: string;
 }
 
+export const AGENTPHONE_SMS_MMS_CONNECT_RISK_MESSAGE =
+  "SMS and MMS replies may not be delivered reliably. For the most reliable experience, use iMessage with this AgentPhone number.";
+
 interface AgentPhoneConnectParamError {
   title: string;
   message: string;
@@ -14,7 +17,12 @@ type SearchParamValue = string | string[] | undefined;
 type SearchParams = URLSearchParams | Record<string, SearchParamValue>;
 
 type ParsedAgentPhoneConnectParams =
-  | { ok: true; params: AgentPhoneConnectParams; returnPath: string }
+  | {
+      ok: true;
+      params: AgentPhoneConnectParams;
+      channel: string | null;
+      returnPath: string;
+    }
   | { ok: false; error: AgentPhoneConnectParamError; returnPath: string };
 
 function firstParam(
@@ -28,13 +36,26 @@ function firstParam(
   return Array.isArray(value) ? value[0] : value;
 }
 
-function encodeReturnPath(params: AgentPhoneConnectParams): string {
+export function isUnreliableAgentPhoneConnectChannel(
+  channel: string | null | undefined,
+): boolean {
+  const normalized = channel?.trim().toLowerCase();
+  return normalized === "sms" || normalized === "mms";
+}
+
+function encodeReturnPath(
+  params: AgentPhoneConnectParams,
+  channel: string | null,
+): string {
   const search = new URLSearchParams({
     handle: params.phoneHandle,
     agent: params.agentphoneAgentId,
     ts: String(params.timestamp),
     sig: params.signature,
   });
+  if (channel) {
+    search.set("channel", channel);
+  }
   return `/agentphone/connect?${search.toString()}`;
 }
 
@@ -56,6 +77,7 @@ export function parseAgentPhoneConnectParams(
   const agentphoneAgentId = firstParam(searchParams, "agent")?.trim();
   const tsRaw = firstParam(searchParams, "ts")?.trim();
   const signature = firstParam(searchParams, "sig")?.trim();
+  const channel = firstParam(searchParams, "channel")?.trim().toLowerCase();
 
   if (!phoneHandle || !agentphoneAgentId || !tsRaw || !signature) {
     return {
@@ -91,6 +113,7 @@ export function parseAgentPhoneConnectParams(
   return {
     ok: true,
     params,
-    returnPath: encodeReturnPath(params),
+    channel: channel || null,
+    returnPath: encodeReturnPath(params, channel || null),
   };
 }

--- a/turbo/apps/platform/src/views/conn/__tests__/zero-agentphone-connect-page.test.tsx
+++ b/turbo/apps/platform/src/views/conn/__tests__/zero-agentphone-connect-page.test.tsx
@@ -14,6 +14,8 @@ const mockApi = createMockApi(context);
 const VALID_PATH =
   "/agentphone/connect?handle=%2B17022452623&agent=agt-phone&ts=1777200000&sig=" +
   "a".repeat(64);
+const VALID_SMS_PATH = `${VALID_PATH}&channel=sms`;
+const VALID_IMESSAGE_PATH = `${VALID_PATH}&channel=imessage`;
 
 function buttonWithText(text: string): HTMLButtonElement {
   const button = screen.getAllByRole("button").find((element) => {
@@ -123,6 +125,51 @@ describe("zero agentphone connect page", () => {
       screen.findByText("Phone number connected"),
     ).resolves.toBeInTheDocument();
     expect(screen.getByText("+17022452623")).toBeInTheDocument();
+  });
+
+  it("warns SMS users that replies may be unreliable", async () => {
+    server.use(
+      mockApi(
+        zeroIntegrationsAgentPhoneContract.connectAgentPhone,
+        ({ respond }) => {
+          return respond(200, { phoneHandle: "+17022452623" });
+        },
+      ),
+    );
+
+    detachedSetupPage({
+      context,
+      path: VALID_SMS_PATH,
+      session: { token: "clerk-token" },
+    });
+
+    await expect(
+      screen.findByText(/SMS and MMS replies may not be delivered reliably/u),
+    ).resolves.toBeInTheDocument();
+
+    click(buttonWithText("Connect"));
+
+    await expect(
+      screen.findByText("Phone number connected"),
+    ).resolves.toBeInTheDocument();
+    expect(
+      screen.getByText(/use iMessage with this AgentPhone number/u),
+    ).toBeInTheDocument();
+  });
+
+  it("does not warn iMessage users about SMS and MMS reliability", async () => {
+    detachedSetupPage({
+      context,
+      path: VALID_IMESSAGE_PATH,
+      session: { token: "clerk-token" },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Connect phone number")).toBeInTheDocument();
+    });
+    expect(
+      screen.queryByText(/SMS and MMS replies may not be delivered reliably/u),
+    ).not.toBeInTheDocument();
   });
 
   it("surfaces invalid or expired signature errors from the backend", async () => {

--- a/turbo/apps/platform/src/views/zero-page/zero-agentphone-connect-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-agentphone-connect-page.tsx
@@ -12,7 +12,11 @@ import { Button } from "@vm0/ui";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { searchParams$ } from "../../signals/route.ts";
 import { connectAgentPhoneAccount$ } from "../../signals/zero-page/agentphone-connect-signals.ts";
-import { parseAgentPhoneConnectParams } from "../../signals/zero-page/agentphone-connect-params.ts";
+import {
+  AGENTPHONE_SMS_MMS_CONNECT_RISK_MESSAGE,
+  isUnreliableAgentPhoneConnectChannel,
+  parseAgentPhoneConnectParams,
+} from "../../signals/zero-page/agentphone-connect-params.ts";
 import { detach, Reason } from "../../signals/utils.ts";
 import { Link } from "../router/link.tsx";
 
@@ -85,6 +89,18 @@ function InvalidState({ title, message }: { title: string; message: string }) {
   );
 }
 
+function SmsMmsRiskNotice({ channel }: { channel: string | null }) {
+  if (!isUnreliableAgentPhoneConnectChannel(channel)) {
+    return null;
+  }
+
+  return (
+    <div className="w-full rounded-lg border border-amber-500/30 bg-amber-500/10 p-3 text-sm text-amber-800 dark:text-amber-200">
+      {AGENTPHONE_SMS_MMS_CONNECT_RISK_MESSAGE}
+    </div>
+  );
+}
+
 function getAgentPhoneConnectErrorMessage(error: unknown): string {
   return error instanceof Error
     ? error.message
@@ -125,6 +141,7 @@ export function ZeroAgentPhoneConnectPage(): JSX.Element {
             </>
           }
         />
+        <SmsMmsRiskNotice channel={parsed.channel} />
         <BackLink />
       </PageShell>
     );
@@ -137,6 +154,7 @@ export function ZeroAgentPhoneConnectPage(): JSX.Element {
         title="Connect phone number"
         body="Link this phone number to your VM0 account so you can interact with Zero from text messages."
       />
+      <SmsMmsRiskNotice channel={parsed.channel} />
       {error ? (
         <div
           className="w-full rounded-lg border border-destructive/30 bg-destructive/10 p-3 text-sm text-destructive"

--- a/turbo/apps/web/app/api/agentphone/webhook/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agentphone/webhook/__tests__/route.test.ts
@@ -209,6 +209,10 @@ describe("POST /api/agentphone/webhook", () => {
       }),
     );
     expect(sendMessage.calls[0]?.body).toContain("/agentphone/connect");
+    expect(sendMessage.calls[0]?.body).toContain("channel=sms");
+    expect(sendMessage.calls[0]?.body).not.toContain(
+      "SMS and MMS replies may not be delivered reliably",
+    );
     expect(await countTestAgentPhoneMessages(phone)).toBe(1);
   });
 
@@ -233,6 +237,10 @@ describe("POST /api/agentphone/webhook", () => {
 
     expect(sendMessage.calls).toHaveLength(1);
     expect(sendMessage.calls[0]?.body).toContain("/agentphone/connect");
+    expect(sendMessage.calls[0]?.body).toContain("channel=mms");
+    expect(sendMessage.calls[0]?.body).not.toContain(
+      "SMS and MMS replies may not be delivered reliably",
+    );
     expect(await countTestAgentPhoneMessages(phone)).toBe(1);
   });
 
@@ -395,6 +403,9 @@ describe("POST /api/agentphone/webhook", () => {
     await context.mocks.flushAfter();
 
     expect(sendMessage.calls[0]?.body).toContain("/connect");
+    expect(sendMessage.calls[0]?.body).toContain(
+      "SMS and MMS replies may not be delivered reliably",
+    );
     const runs = await findTestRunsByUserAndPromptContaining(
       user.userId,
       "/help",

--- a/turbo/apps/web/app/api/internal/callbacks/agentphone/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/agentphone/__tests__/route.test.ts
@@ -230,6 +230,32 @@ describe("POST /api/internal/callbacks/agentphone", () => {
     );
   });
 
+  it("does not warn SMS callback recipients on normal replies", async () => {
+    const { runId, payload, secret } = await setupAgentPhoneCallback();
+    context.mocks.axiom.queryAxiom.mockResolvedValueOnce([
+      { eventData: { result: "Done from SMS AgentPhone." } },
+    ]);
+    const sendMessage = agentPhoneSendMessage();
+    server.use(sendMessage.handler);
+
+    const request = createSignedCallbackRequest(
+      "http://localhost/api/internal/callbacks/agentphone",
+      {
+        runId,
+        status: "completed",
+        payload: { ...payload, channel: "sms" },
+      },
+      secret,
+    );
+    const response = await POST(request);
+
+    expect(response.status).toBe(200);
+    expect(sendMessage.calls[0]?.body).toContain("Done from SMS AgentPhone.");
+    expect(sendMessage.calls[0]?.body).not.toContain(
+      "SMS and MMS replies may not be delivered reliably",
+    );
+  });
+
   it("skips completed callbacks after the phone link is disconnected", async () => {
     const { runId, payload, secret, userLinkId } =
       await setupAgentPhoneCallback();

--- a/turbo/apps/web/src/lib/zero/agentphone/handlers/inbound.ts
+++ b/turbo/apps/web/src/lib/zero/agentphone/handlers/inbound.ts
@@ -9,6 +9,7 @@ import {
 import { AGENTPHONE_ROOT_MESSAGE_ID } from "../constants";
 import {
   buildAgentPhoneConnectUrl,
+  appendAgentPhoneSlashCommandRiskWarning,
   enrichAgentPhonePrompt,
   fetchAgentPhoneContext,
   lookupAgentPhoneThreadSession,
@@ -57,6 +58,19 @@ async function sendAgentPhoneText(params: {
   });
 }
 
+async function sendAgentPhoneSlashCommandText(params: {
+  event: AgentPhoneMessageEvent;
+  body: string;
+}): Promise<void> {
+  await sendAgentPhoneText({
+    event: params.event,
+    body: appendAgentPhoneSlashCommandRiskWarning(
+      params.body,
+      params.event.channel,
+    ),
+  });
+}
+
 async function refreshTypingIfSupported(
   event: AgentPhoneMessageEvent,
 ): Promise<void> {
@@ -80,6 +94,7 @@ function formatConnectPrompt(event: AgentPhoneMessageEvent): string {
     phoneHandle: event.fromNumber,
     agentphoneAgentId: event.agentphoneAgentId,
     secret: SECRETS_ENCRYPTION_KEY,
+    channel: event.channel,
   });
 
   return [
@@ -102,10 +117,16 @@ function formatHelpMessage(): string {
   ].join("\n");
 }
 
-async function sendConnectPrompt(event: AgentPhoneMessageEvent): Promise<void> {
+async function sendConnectPrompt(
+  event: AgentPhoneMessageEvent,
+  options?: { readonly slashCommand: boolean },
+): Promise<void> {
+  const body = formatConnectPrompt(event);
   await sendAgentPhoneText({
     event,
-    body: formatConnectPrompt(event),
+    body: options?.slashCommand
+      ? appendAgentPhoneSlashCommandRiskWarning(body, event.channel)
+      : body,
   });
 }
 
@@ -135,14 +156,14 @@ async function handleConnectCommand(params: {
   userLink: AgentPhoneUserLink | null;
 }): Promise<void> {
   if (params.userLink) {
-    await sendAgentPhoneText({
+    await sendAgentPhoneSlashCommandText({
       event: params.event,
       body: "You are already connected. Send a message here to start chatting with Zero.",
     });
     return;
   }
 
-  await sendConnectPrompt(params.event);
+  await sendConnectPrompt(params.event, { slashCommand: true });
 }
 
 async function handleDisconnectCommand(params: {
@@ -150,7 +171,7 @@ async function handleDisconnectCommand(params: {
   userLink: AgentPhoneUserLink | null;
 }): Promise<void> {
   if (!params.userLink) {
-    await sendAgentPhoneText({
+    await sendAgentPhoneSlashCommandText({
       event: params.event,
       body: "Error: This phone number is not connected.",
     });
@@ -161,7 +182,7 @@ async function handleDisconnectCommand(params: {
     .delete(agentphoneUserLinks)
     .where(eq(agentphoneUserLinks.id, params.userLink.id));
 
-  await sendAgentPhoneText({
+  await sendAgentPhoneSlashCommandText({
     event: params.event,
     body: "This phone number has been disconnected from VM0.",
   });
@@ -172,7 +193,7 @@ async function handleNewSessionCommand(params: {
   userLink: AgentPhoneUserLink | null;
 }): Promise<void> {
   if (!params.userLink) {
-    await sendConnectPrompt(params.event);
+    await sendConnectPrompt(params.event, { slashCommand: true });
     return;
   }
 
@@ -185,7 +206,7 @@ async function handleNewSessionCommand(params: {
       ),
     );
 
-  await sendAgentPhoneText({
+  await sendAgentPhoneSlashCommandText({
     event: params.event,
     body: "New session started.",
   });
@@ -213,20 +234,21 @@ async function dispatchAgentPhoneCommand(params: {
       await handleNewSessionCommand(params);
       return true;
     case "help":
-      await sendAgentPhoneText({
+      await sendAgentPhoneSlashCommandText({
         event: params.event,
         body: formatHelpMessage(),
       });
       return true;
     case "model":
       if (!params.userLink) {
-        await sendConnectPrompt(params.event);
+        await sendConnectPrompt(params.event, { slashCommand: true });
         return true;
       }
       await handleAgentPhoneModelCommand({
         text: params.event.body,
         agentphoneAgentId: params.event.agentphoneAgentId,
         phoneHandle: params.event.fromNumber,
+        channel: params.event.channel,
         orgId: params.userLink.orgId,
         userId: params.userLink.vm0UserId,
       });

--- a/turbo/apps/web/src/lib/zero/agentphone/handlers/model.ts
+++ b/turbo/apps/web/src/lib/zero/agentphone/handlers/model.ts
@@ -9,6 +9,7 @@ import {
 } from "../../model-policy/model-preference-picker";
 import { updateUserModelPreference } from "../../model-policy/user-model-preference-service";
 import { sendAgentPhoneMessage } from "../client";
+import { appendAgentPhoneSlashCommandRiskWarning } from "../shared";
 
 function commandArgument(text: string): string {
   const trimmed = text.trim();
@@ -122,6 +123,7 @@ export async function handleAgentPhoneModelCommand(params: {
   text: string;
   agentphoneAgentId: string;
   phoneHandle: string;
+  channel?: string | null;
   orgId: string;
   userId: string;
 }): Promise<void> {
@@ -134,7 +136,10 @@ export async function handleAgentPhoneModelCommand(params: {
     await sendAgentPhoneMessage({
       agentphoneAgentId: params.agentphoneAgentId,
       toNumber: params.phoneHandle,
-      body: "Error: Model switching is not available for this workspace.",
+      body: appendAgentPhoneSlashCommandRiskWarning(
+        "Error: Model switching is not available for this workspace.",
+        params.channel,
+      ),
     });
     return;
   }
@@ -143,7 +148,10 @@ export async function handleAgentPhoneModelCommand(params: {
     await sendAgentPhoneMessage({
       agentphoneAgentId: params.agentphoneAgentId,
       toNumber: params.phoneHandle,
-      body: "Error: No models are configured for this workspace.",
+      body: appendAgentPhoneSlashCommandRiskWarning(
+        "Error: No models are configured for this workspace.",
+        params.channel,
+      ),
     });
     return;
   }
@@ -153,7 +161,10 @@ export async function handleAgentPhoneModelCommand(params: {
     await sendAgentPhoneMessage({
       agentphoneAgentId: params.agentphoneAgentId,
       toNumber: params.phoneHandle,
-      body: formatAgentPhoneModelOptionsMessage(picker),
+      body: appendAgentPhoneSlashCommandRiskWarning(
+        formatAgentPhoneModelOptionsMessage(picker),
+        params.channel,
+      ),
     });
     return;
   }
@@ -163,7 +174,10 @@ export async function handleAgentPhoneModelCommand(params: {
     await sendAgentPhoneMessage({
       agentphoneAgentId: params.agentphoneAgentId,
       toNumber: params.phoneHandle,
-      body: formatUnknownModelMessage(input, picker),
+      body: appendAgentPhoneSlashCommandRiskWarning(
+        formatUnknownModelMessage(input, picker),
+        params.channel,
+      ),
     });
     return;
   }
@@ -172,6 +186,9 @@ export async function handleAgentPhoneModelCommand(params: {
   await sendAgentPhoneMessage({
     agentphoneAgentId: params.agentphoneAgentId,
     toNumber: params.phoneHandle,
-    body: `Switched to ${option.label}.`,
+    body: appendAgentPhoneSlashCommandRiskWarning(
+      `Switched to ${option.label}.`,
+      params.channel,
+    ),
   });
 }

--- a/turbo/apps/web/src/lib/zero/agentphone/shared.ts
+++ b/turbo/apps/web/src/lib/zero/agentphone/shared.ts
@@ -40,6 +40,31 @@ export interface AgentPhoneMessageEvent {
   receivedAt: Date | null;
 }
 
+const AGENTPHONE_SMS_MMS_SLASH_COMMAND_RISK_MESSAGE =
+  "Note: SMS and MMS replies may not be delivered reliably. For the most reliable experience, use iMessage with this AgentPhone number.";
+
+function isUnreliableAgentPhoneReplyChannel(
+  channel: string | null | undefined,
+): boolean {
+  const normalized = channel?.trim().toLowerCase();
+  return normalized === "sms" || normalized === "mms";
+}
+
+export function appendAgentPhoneSlashCommandRiskWarning(
+  body: string,
+  channel: string | null | undefined,
+): string {
+  if (!isUnreliableAgentPhoneReplyChannel(channel)) {
+    return body;
+  }
+
+  if (body.includes(AGENTPHONE_SMS_MMS_SLASH_COMMAND_RISK_MESSAGE)) {
+    return body;
+  }
+
+  return [body, AGENTPHONE_SMS_MMS_SLASH_COMMAND_RISK_MESSAGE].join("\n\n");
+}
+
 export function normalizePhoneHandle(handle: string): string {
   return handle.trim().replace(/[^\d+]/gu, "");
 }
@@ -205,6 +230,7 @@ export function buildAgentPhoneConnectUrl(params: {
   phoneHandle: string;
   agentphoneAgentId: string;
   secret: string;
+  channel?: string | null;
 }): string {
   const ts = Math.floor(Date.now() / 1000);
   const phoneHandle = normalizePhoneHandle(params.phoneHandle);
@@ -220,6 +246,9 @@ export function buildAgentPhoneConnectUrl(params: {
     ts: String(ts),
     sig,
   });
+  if (params.channel) {
+    query.set("channel", params.channel);
+  }
   return `${getAppUrl()}/agentphone/connect?${query.toString()}`;
 }
 


### PR DESCRIPTION
## Summary
- show SMS/MMS delivery risk copy only on AgentPhone slash command responses
- propagate the inbound channel into connect links and show the connect-page warning only for channel=sms or channel=mms
- keep iMessage links and normal AgentPhone/callback replies free of the warning

Related to #13022

## Tests
- pnpm prettier --check apps/web/src/lib/zero/agentphone/shared.ts apps/web/src/lib/zero/agentphone/handlers/inbound.ts apps/web/src/lib/zero/agentphone/handlers/model.ts apps/web/app/api/internal/callbacks/agentphone/__tests__/route.test.ts apps/web/app/api/agentphone/webhook/__tests__/route.test.ts apps/platform/src/signals/zero-page/agentphone-connect-params.ts apps/platform/src/views/zero-page/zero-agentphone-connect-page.tsx apps/platform/src/views/conn/__tests__/zero-agentphone-connect-page.test.tsx
- pnpm -F web exec oxlint src/lib/zero/agentphone/shared.ts src/lib/zero/agentphone/handlers/inbound.ts src/lib/zero/agentphone/handlers/model.ts app/api/internal/callbacks/agentphone/__tests__/route.test.ts app/api/agentphone/webhook/__tests__/route.test.ts
- pnpm -F @vm0/app exec oxlint src/signals/zero-page/agentphone-connect-params.ts src/views/zero-page/zero-agentphone-connect-page.tsx src/views/conn/__tests__/zero-agentphone-connect-page.test.tsx
- pnpm -F web exec eslint src/lib/zero/agentphone/shared.ts src/lib/zero/agentphone/handlers/inbound.ts src/lib/zero/agentphone/handlers/model.ts app/api/internal/callbacks/agentphone/__tests__/route.test.ts app/api/agentphone/webhook/__tests__/route.test.ts
- pnpm -F @vm0/app exec eslint src/signals/zero-page/agentphone-connect-params.ts src/views/zero-page/zero-agentphone-connect-page.tsx src/views/conn/__tests__/zero-agentphone-connect-page.test.tsx
- pnpm -F web check-types
- pnpm -F @vm0/app check-types
- pnpm -F @vm0/app exec vitest run src/views/conn/__tests__/zero-agentphone-connect-page.test.tsx
- pre-commit: prettier, knip, check-types