### PR TITLE
refactor(api): migrate chat callback

### DIFF
--- a/turbo/apps/api/package.json
+++ b/turbo/apps/api/package.json
@@ -48,6 +48,7 @@
     "stripe": "^20.4.1",
     "tar": "^7.5.11",
     "undici": "^6.24.1",
+    "web-push": "^3.6.7",
     "zod": "^4.3.6"
   },
   "devDependencies": {
@@ -57,6 +58,7 @@
     "@types/archiver": "^7.0.0",
     "@types/node": "^24.3.0",
     "@types/pg": "^8.20.0",
+    "@types/web-push": "^3.6.4",
     "@typescript-eslint/rule-tester": "^8.59.2",
     "@typescript-eslint/utils": "^8.59.2",
     "@vm0/eslint-config": "workspace:*",

--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -30,6 +30,7 @@ import { apiHealth$ } from "./routes/health";
 import { healthAuthProbeRoutes } from "./routes/health-auth-probe";
 import { githubOauthRoutes } from "./routes/github-oauth";
 import { internalCallbacksAgentRoutes } from "./routes/internal-callbacks-agent";
+import { internalCallbacksChatRoutes } from "./routes/internal-callbacks-chat";
 import { internalCallbacksGithubIssuesRoutes } from "./routes/internal-callbacks-github-issues";
 import { internalCallbacksScheduleRoutes } from "./routes/internal-callbacks-schedule";
 import { internalCallbacksSlackOrgRoutes } from "./routes/internal-callbacks-slack-org";
@@ -154,6 +155,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...healthAuthProbeRoutes,
   ...githubOauthRoutes,
   ...internalCallbacksAgentRoutes,
+  ...internalCallbacksChatRoutes,
   ...internalCallbacksGithubIssuesRoutes,
   ...internalCallbacksScheduleRoutes,
   ...internalCallbacksSlackOrgRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-chat.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-chat.test.ts
@@ -1,0 +1,425 @@
+import { randomUUID } from "node:crypto";
+
+import { createStore } from "ccstate";
+import {
+  agentComposes,
+  agentComposeVersions,
+} from "@vm0/db/schema/agent-compose";
+import { agentRunCallbacks } from "@vm0/db/schema/agent-run-callback";
+import { agentRuns } from "@vm0/db/schema/agent-run";
+import { agentSessions } from "@vm0/db/schema/agent-session";
+import { chatMessages } from "@vm0/db/schema/chat-message";
+import { chatThreads } from "@vm0/db/schema/chat-thread";
+import { runnerJobQueue } from "@vm0/db/schema/runner-job-queue";
+import { zeroAgents } from "@vm0/db/schema/zero-agent";
+import { zeroRuns } from "@vm0/db/schema/zero-run";
+import { and, eq, inArray, isNotNull, isNull } from "drizzle-orm";
+import { describe, expect, it } from "vitest";
+
+import { createApp } from "../../../app-factory";
+import { testContext } from "../../../__tests__/test-helpers";
+import { computeHmacSignature } from "../../../lib/event-consumer/hmac";
+import { mockEnv, mockOptionalEnv } from "../../../lib/env";
+import { now } from "../../../lib/time";
+import { writeDb$ } from "../../external/db";
+import { clearAllDetached } from "../../utils";
+import { seedAgentRunCallback$ } from "./helpers/agent-run-callback";
+import { createFixtureTracker } from "./helpers/zero-route-test";
+
+const context = testContext();
+const store = createStore();
+
+const PATH = "/api/internal/callbacks/chat";
+const TEST_CALLBACK_SECRET = "test-callback-secret";
+
+interface ChatCallbackFixture {
+  readonly userId: string;
+  readonly orgId: string;
+  readonly agentId: string;
+  readonly versionId: string;
+  readonly sessionId: string;
+  readonly threadId: string;
+  readonly runId: string;
+  readonly callbackId: string;
+}
+
+const track = createFixtureTracker<ChatCallbackFixture>(deleteFixture);
+
+function vm0Template(expression: string): string {
+  return `$${expression}`;
+}
+
+async function seedChatCallbackFixture(): Promise<ChatCallbackFixture> {
+  const userId = `user_${randomUUID()}`;
+  const orgId = `org_${randomUUID()}`;
+  const agentId = randomUUID();
+  const versionId = randomUUID();
+  const sessionId = randomUUID();
+  const threadId = randomUUID();
+  const name = `agent-${agentId.slice(0, 8)}`;
+  const db = store.set(writeDb$);
+
+  await db.insert(agentComposes).values({
+    id: agentId,
+    userId,
+    orgId,
+    name,
+    headVersionId: versionId,
+  });
+  await db.insert(agentComposeVersions).values({
+    id: versionId,
+    composeId: agentId,
+    createdBy: userId,
+    content: {
+      version: "1.0",
+      agents: {
+        [name]: {
+          framework: "claude-code",
+          environment: {
+            ANTHROPIC_API_KEY: "test-key",
+            ZERO_AGENT_ID: vm0Template("{{ vars.ZERO_AGENT_ID }}"),
+            ZERO_TOKEN: vm0Template("{{ secrets.ZERO_TOKEN }}"),
+          },
+        },
+      },
+    },
+  });
+  await db.insert(zeroAgents).values({
+    id: agentId,
+    orgId,
+    owner: userId,
+    name,
+    visibility: "public",
+  });
+  await db.insert(chatThreads).values({
+    id: threadId,
+    userId,
+    agentComposeId: agentId,
+    title: "Test thread",
+  });
+  await db.insert(agentSessions).values({
+    id: sessionId,
+    userId,
+    orgId,
+    agentComposeId: agentId,
+  });
+  const [run] = await db
+    .insert(agentRuns)
+    .values({
+      userId,
+      orgId,
+      agentComposeVersionId: versionId,
+      sessionId,
+      status: "completed",
+      prompt: "test prompt",
+      completedAt: new Date("2026-01-01T00:00:10.000Z"),
+      lastEventSequence: 1,
+      vars: { ZERO_AGENT_ID: agentId },
+    })
+    .returning({ id: agentRuns.id });
+  if (!run) {
+    throw new Error("run insert returned no row");
+  }
+  await db.insert(zeroRuns).values({
+    id: run.id,
+    triggerSource: "web",
+    chatThreadId: threadId,
+  });
+  await db.insert(chatMessages).values({
+    chatThreadId: threadId,
+    role: "user",
+    content: "test prompt",
+    runId: run.id,
+  });
+
+  const { callbackId } = await store.set(
+    seedAgentRunCallback$,
+    {
+      runId: run.id,
+      url: `http://localhost${PATH}`,
+      payload: { threadId, agentId },
+    },
+    context.signal,
+  );
+
+  context.mocks.s3.send.mockResolvedValue({});
+  mockEnv("VM0_API_URL", "http://localhost:3000");
+  mockOptionalEnv("RUNNER_DEFAULT_GROUP", "vm0/test");
+  mockOptionalEnv("OPENROUTER_API_KEY", undefined);
+  mockOptionalEnv("VAPID_PUBLIC_KEY", undefined);
+  mockOptionalEnv("VAPID_PRIVATE_KEY", undefined);
+
+  return {
+    userId,
+    orgId,
+    agentId,
+    versionId,
+    sessionId,
+    threadId,
+    runId: run.id,
+    callbackId,
+  };
+}
+
+async function deleteFixture(fixture: ChatCallbackFixture): Promise<void> {
+  const db = store.set(writeDb$);
+  const runRows = await db
+    .select({ id: agentRuns.id })
+    .from(agentRuns)
+    .where(
+      and(
+        eq(agentRuns.orgId, fixture.orgId),
+        eq(agentRuns.userId, fixture.userId),
+      ),
+    );
+  const runIds = runRows.map((row) => {
+    return row.id;
+  });
+
+  if (runIds.length > 0) {
+    await db
+      .delete(runnerJobQueue)
+      .where(inArray(runnerJobQueue.runId, runIds));
+    await db
+      .delete(agentRunCallbacks)
+      .where(inArray(agentRunCallbacks.runId, runIds));
+  }
+  await db
+    .delete(chatMessages)
+    .where(eq(chatMessages.chatThreadId, fixture.threadId));
+  if (runIds.length > 0) {
+    await db.delete(zeroRuns).where(inArray(zeroRuns.id, runIds));
+    await db.delete(agentRuns).where(inArray(agentRuns.id, runIds));
+  }
+  await db
+    .delete(agentSessions)
+    .where(eq(agentSessions.userId, fixture.userId));
+  await db.delete(chatThreads).where(eq(chatThreads.id, fixture.threadId));
+  await db.delete(zeroAgents).where(eq(zeroAgents.id, fixture.agentId));
+  await db
+    .delete(agentComposeVersions)
+    .where(eq(agentComposeVersions.composeId, fixture.agentId));
+  await db.delete(agentComposes).where(eq(agentComposes.id, fixture.agentId));
+}
+
+function signedHeaders(rawBody: string, secret = TEST_CALLBACK_SECRET) {
+  const timestamp = Math.floor(now() / 1000);
+  return {
+    "Content-Type": "application/json",
+    "X-VM0-Signature": computeHmacSignature(rawBody, secret, timestamp),
+    "X-VM0-Timestamp": String(timestamp),
+  };
+}
+
+async function postSignedCallback(
+  body: Record<string, unknown>,
+  secret?: string,
+): Promise<Response> {
+  const rawBody = JSON.stringify(body);
+  const app = createApp({ signal: context.signal });
+  return await app.request(PATH, {
+    method: "POST",
+    headers: signedHeaders(rawBody, secret),
+    body: rawBody,
+  });
+}
+
+function completedAssistantOutput(text: string): void {
+  context.mocks.axiom.query
+    .mockResolvedValueOnce([{ sequenceNumber: 0 }, { sequenceNumber: 1 }])
+    .mockResolvedValueOnce([
+      {
+        eventType: "assistant",
+        sequenceNumber: 1,
+        eventData: {
+          message: { content: [{ type: "text", text }] },
+        },
+      },
+    ]);
+}
+
+async function listMessages(threadId: string) {
+  return await store
+    .set(writeDb$)
+    .select()
+    .from(chatMessages)
+    .where(eq(chatMessages.chatThreadId, threadId))
+    .orderBy(chatMessages.createdAt);
+}
+
+describe("POST /api/internal/callbacks/chat", () => {
+  it("returns 200 for progress status without querying Axiom", async () => {
+    const fixture = await track(seedChatCallbackFixture());
+
+    const response = await postSignedCallback({
+      callbackId: fixture.callbackId,
+      runId: fixture.runId,
+      status: "progress",
+      payload: { threadId: fixture.threadId, agentId: fixture.agentId },
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toStrictEqual({ success: true });
+    expect(context.mocks.axiom.query).not.toHaveBeenCalled();
+  });
+
+  it("inserts assistant output on completed callbacks", async () => {
+    const fixture = await track(seedChatCallbackFixture());
+    completedAssistantOutput("final answer");
+
+    const response = await postSignedCallback({
+      callbackId: fixture.callbackId,
+      runId: fixture.runId,
+      status: "completed",
+      payload: { threadId: fixture.threadId, agentId: fixture.agentId },
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toStrictEqual({ success: true });
+
+    const messages = await listMessages(fixture.threadId);
+    expect(
+      messages.some((message) => {
+        return (
+          message.role === "assistant" &&
+          message.runId === fixture.runId &&
+          message.sequenceNumber === 1 &&
+          message.content === "final answer"
+        );
+      }),
+    ).toBeTruthy();
+    expect(context.mocks.ably.publish).toHaveBeenCalledWith(
+      `chatThreadRunUpdated:${fixture.threadId}`,
+      null,
+    );
+    await clearAllDetached();
+  });
+
+  it("inserts assistant error messages on failed callbacks", async () => {
+    const fixture = await track(seedChatCallbackFixture());
+
+    const response = await postSignedCallback({
+      callbackId: fixture.callbackId,
+      runId: fixture.runId,
+      status: "failed",
+      error: "Cannot continue session from checkpoint",
+      payload: { threadId: fixture.threadId, agentId: fixture.agentId },
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toStrictEqual({ success: true });
+
+    const messages = await listMessages(fixture.threadId);
+    expect(
+      messages.some((message) => {
+        return (
+          message.role === "assistant" &&
+          message.runId === fixture.runId &&
+          message.error === "Cannot continue session from checkpoint"
+        );
+      }),
+    ).toBeTruthy();
+    expect(context.mocks.axiom.query).not.toHaveBeenCalled();
+  });
+
+  it("auto-sends the oldest queued user message after a terminal callback", async () => {
+    const fixture = await track(seedChatCallbackFixture());
+    const db = store.set(writeDb$);
+    const [queued] = await db
+      .insert(chatMessages)
+      .values({
+        chatThreadId: fixture.threadId,
+        role: "user",
+        content: "queued next turn",
+        runId: null,
+      })
+      .returning({ id: chatMessages.id });
+    if (!queued) {
+      throw new Error("queued message insert returned no row");
+    }
+    completedAssistantOutput("previous answer");
+
+    const response = await postSignedCallback({
+      callbackId: fixture.callbackId,
+      runId: fixture.runId,
+      status: "completed",
+      payload: { threadId: fixture.threadId, agentId: fixture.agentId },
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toStrictEqual({ success: true });
+
+    const [claimed] = await db
+      .select({
+        id: chatMessages.id,
+        runId: chatMessages.runId,
+        revokesMessageId: chatMessages.revokesMessageId,
+        content: chatMessages.content,
+      })
+      .from(chatMessages)
+      .where(
+        and(
+          eq(chatMessages.chatThreadId, fixture.threadId),
+          eq(chatMessages.revokesMessageId, queued.id),
+          isNotNull(chatMessages.runId),
+        ),
+      )
+      .limit(1);
+    expect(claimed).toMatchObject({
+      content: "queued next turn",
+      revokesMessageId: queued.id,
+    });
+    expect(claimed?.runId).toBeTruthy();
+    expect(claimed?.runId).not.toBe(fixture.runId);
+
+    const [callback] = await db
+      .select({
+        url: agentRunCallbacks.url,
+        payload: agentRunCallbacks.payload,
+      })
+      .from(agentRunCallbacks)
+      .where(eq(agentRunCallbacks.runId, claimed!.runId!))
+      .limit(1);
+    expect(callback?.url).toContain(PATH);
+    expect(callback?.payload).toStrictEqual({
+      threadId: fixture.threadId,
+      agentId: fixture.agentId,
+    });
+
+    const [zeroRun] = await db
+      .select({ chatThreadId: zeroRuns.chatThreadId })
+      .from(zeroRuns)
+      .where(eq(zeroRuns.id, claimed!.runId!))
+      .limit(1);
+    expect(zeroRun?.chatThreadId).toBe(fixture.threadId);
+    await clearAllDetached();
+  });
+
+  it("rejects invalid callback signatures", async () => {
+    const fixture = await track(seedChatCallbackFixture());
+
+    const response = await postSignedCallback(
+      {
+        callbackId: fixture.callbackId,
+        runId: fixture.runId,
+        status: "completed",
+        payload: { threadId: fixture.threadId, agentId: fixture.agentId },
+      },
+      "wrong-secret",
+    );
+
+    expect(response.status).toBe(401);
+    const messages = await store
+      .set(writeDb$)
+      .select({ id: chatMessages.id })
+      .from(chatMessages)
+      .where(
+        and(
+          eq(chatMessages.chatThreadId, fixture.threadId),
+          eq(chatMessages.role, "assistant"),
+          isNull(chatMessages.error),
+        ),
+      );
+    expect(messages).toStrictEqual([]);
+  });
+});

--- a/turbo/apps/api/src/signals/routes/internal-callbacks-chat.ts
+++ b/turbo/apps/api/src/signals/routes/internal-callbacks-chat.ts
@@ -1,0 +1,1294 @@
+import { randomBytes } from "node:crypto";
+
+import { command } from "ccstate";
+import {
+  chatCallbackPayloadSchema,
+  internalCallbacksChatContract,
+} from "@vm0/api-contracts/contracts/internal-callbacks-chat";
+import { agentRuns } from "@vm0/db/schema/agent-run";
+import { chatMessages } from "@vm0/db/schema/chat-message";
+import { chatThreads } from "@vm0/db/schema/chat-thread";
+import { zeroAgents } from "@vm0/db/schema/zero-agent";
+import { zeroRuns } from "@vm0/db/schema/zero-run";
+import {
+  and,
+  asc,
+  desc,
+  eq,
+  inArray,
+  isNotNull,
+  isNull,
+  sql,
+} from "drizzle-orm";
+
+import {
+  callbackPayload$,
+  callbackRoute,
+} from "../../lib/callback-route/callback-route";
+import { waitForRunEventWatermarkVisible } from "../../lib/agent-event-visibility";
+import { escapeAplString } from "../../lib/axiom-apl";
+import { env } from "../../lib/env";
+import { logger } from "../../lib/log";
+import { now } from "../../lib/time";
+import type { RouteEntry } from "../route";
+import { waitUntil } from "../context/wait-until";
+import { getDatasetName, queryAxiomDirect } from "../external/axiom";
+import { writeDb$, type Db } from "../external/db";
+import {
+  publishThreadListChanged,
+  publishUserSignal,
+} from "../external/realtime";
+import { recordSandboxOperation } from "../external/sandbox-op-log";
+import { createAgentRun$ } from "../services/agent-run-create.service";
+import { saveRunSummary$ } from "../services/run-summary.service";
+import {
+  formatChatRunErrorMessage,
+  insertAssistantEventMessages$,
+  resolveAttachFileUrls,
+  visibleChatMessageCondition,
+} from "../services/zero-chat-thread.service";
+import { sendUserPushNotifications } from "../services/zero-push-notifications.service";
+import {
+  generateAndPersistChatThreadTitleFromCallback,
+  generateChatNotificationSummary,
+} from "../services/zero-chat-title.service";
+import { safeAsync } from "../utils";
+
+const log = logger("callback:chat");
+const GOAL_DONE_SENTINEL = "[GOAL_DONE]";
+const AGENT_RUN_EVENTS_DATASET = "agent-run-events";
+const INCOMPLETE_MESSAGE_CHAR_CAP = 4000;
+
+interface ContentBlock {
+  readonly type?: string;
+  readonly text?: string;
+}
+
+interface CodexItem {
+  readonly type?: string;
+  readonly text?: string;
+}
+
+interface AxiomChatOutputEvent {
+  readonly eventType?: string;
+  readonly sequenceNumber?: number;
+  readonly eventData?: {
+    readonly message?: { readonly content?: readonly ContentBlock[] };
+    readonly item?: CodexItem;
+    readonly result?: string;
+    readonly sequenceNumber?: number;
+  };
+}
+
+interface AssistantEventItem {
+  readonly sequenceNumber: number;
+  readonly content: string;
+}
+
+interface ResultEventItem {
+  readonly sequenceNumber: number;
+  readonly content: string;
+}
+
+interface IncompleteRoundRow {
+  readonly runId: string;
+  readonly runStatus: "cancelled" | "failed" | "timeout";
+  readonly role: "user" | "assistant";
+  readonly content: string | null;
+  readonly error: string | null;
+  readonly attachFiles: readonly string[] | null;
+}
+
+interface IncompleteRound {
+  readonly runId: string;
+  readonly status: "cancelled" | "failed" | "timeout";
+  readonly messages: IncompleteRoundMessage[];
+}
+
+interface IncompleteRoundMessage {
+  readonly role: "user" | "assistant";
+  readonly content: string | null;
+  readonly error: string | null;
+  readonly attachFiles: readonly string[] | null;
+}
+
+interface QueuedUserMessage {
+  readonly id: string;
+  readonly content: string | null;
+  readonly attachFiles: readonly string[] | null;
+  readonly modelProviderId: string | null;
+  readonly modelProviderType: string | null;
+  readonly modelProviderCredentialScope: string | null;
+  readonly selectedModel: string | null;
+  readonly goalRemainingTurns: number | null;
+  readonly goalOriginMessageId: string | null;
+}
+
+interface AgentForAutoSend {
+  readonly id: string;
+  readonly orgId: string;
+}
+
+interface ChatThreadForRunRow {
+  readonly chatThreadId: string;
+  readonly userId: string;
+}
+
+interface ChatRunInfo {
+  readonly prompt: string;
+  readonly error: string | null;
+  readonly lastEventSequence: number | null;
+}
+
+interface GoalContext {
+  readonly remainingTurns: number;
+}
+
+interface CreateQueuedChatRunInput {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly agentId: string;
+  readonly prompt: string;
+  readonly sessionId: string | null;
+  readonly appendSystemPrompt: string;
+  readonly threadId: string;
+  readonly queuedMessage: QueuedUserMessage;
+}
+
+function generateCallbackSecret(): string {
+  return randomBytes(32).toString("hex");
+}
+
+function chatCallbackUrl(): string {
+  return new URL("/api/internal/callbacks/chat", env("VM0_API_URL")).toString();
+}
+
+function buildQueuedCreateAgentRunArgs(
+  input: CreateQueuedChatRunInput,
+  apiStartTime: number,
+) {
+  return {
+    userId: input.userId,
+    orgId: input.orgId,
+    apiStartTime,
+    chatThreadId: input.threadId,
+    includeZeroTokenSecret: true,
+    callbacks: [
+      {
+        url: chatCallbackUrl(),
+        secret: generateCallbackSecret(),
+        payload: {
+          threadId: input.threadId,
+          agentId: input.agentId,
+        },
+      },
+    ],
+    body: {
+      prompt: input.prompt,
+      agentComposeId: input.agentId,
+      ...(input.sessionId ? { sessionId: input.sessionId } : {}),
+      triggerSource: "web" as const,
+      appendSystemPrompt: input.appendSystemPrompt,
+      vars: { ZERO_AGENT_ID: input.agentId },
+    },
+  };
+}
+
+function extractAnthropicContent(
+  blocks: readonly ContentBlock[],
+): string | null {
+  const parts = blocks.flatMap((block) => {
+    return block.type === "text" && typeof block.text === "string"
+      ? [block.text]
+      : [];
+  });
+  if (parts.length === 0) {
+    return null;
+  }
+  return parts.length === 1 ? parts[0]! : parts.join("\n\n");
+}
+
+function extractCodexAgentMessageContent(item: CodexItem): string | null {
+  if (
+    item.type !== "agent_message" ||
+    typeof item.text !== "string" ||
+    item.text.length === 0
+  ) {
+    return null;
+  }
+  return item.text;
+}
+
+function extractAssistantContent(event: AxiomChatOutputEvent): string | null {
+  const content = event.eventData?.message?.content;
+  if (content) {
+    return extractAnthropicContent(content);
+  }
+  const item = event.eventData?.item;
+  if (item) {
+    return extractCodexAgentMessageContent(item);
+  }
+  return null;
+}
+
+function extractResultFallback(
+  sequenceNumber: number,
+  event: AxiomChatOutputEvent,
+): ResultEventItem | null {
+  const result = event.eventData?.result;
+  if (typeof result !== "string") {
+    return null;
+  }
+  if (!result.trim()) {
+    return null;
+  }
+  return { sequenceNumber, content: result };
+}
+
+async function queryChatOutputEvents(args: {
+  readonly runId: string;
+  readonly lastEventSequence: number | null;
+  readonly signal: AbortSignal;
+}): Promise<{
+  readonly assistantItems: readonly AssistantEventItem[];
+  readonly resultFallback: ResultEventItem | null;
+}> {
+  await waitForRunEventWatermarkVisible(args.runId, args.lastEventSequence);
+  args.signal.throwIfAborted();
+
+  const dataset = getDatasetName(AGENT_RUN_EVENTS_DATASET);
+  const apl = `['${dataset}']
+| where runId == "${escapeAplString(args.runId)}"
+| where eventType == "assistant" or eventType == "result" or eventType == "item.completed"
+| order by sequenceNumber asc
+| limit 200`;
+
+  const events = await queryAxiomDirect<AxiomChatOutputEvent>(apl, {
+    noCache: true,
+  });
+  args.signal.throwIfAborted();
+
+  const assistantItems: AssistantEventItem[] = [];
+  let resultFallback: ResultEventItem | null = null;
+  for (const event of events) {
+    const sequenceNumber =
+      event.sequenceNumber ?? event.eventData?.sequenceNumber;
+    if (typeof sequenceNumber !== "number") {
+      continue;
+    }
+
+    const assistant = extractAssistantContent(event);
+    if (assistant !== null) {
+      assistantItems.push({ sequenceNumber, content: assistant });
+      continue;
+    }
+
+    const fallback = extractResultFallback(sequenceNumber, event);
+    if (fallback !== null) {
+      resultFallback = fallback;
+    }
+  }
+
+  return { assistantItems, resultFallback };
+}
+
+async function latestEventBackedAssistantMessage(
+  db: Db,
+  runId: string,
+): Promise<{ readonly content: string } | null> {
+  const [message] = await db
+    .select({ content: chatMessages.content })
+    .from(chatMessages)
+    .where(
+      and(
+        eq(chatMessages.runId, runId),
+        eq(chatMessages.role, "assistant"),
+        isNotNull(chatMessages.sequenceNumber),
+      ),
+    )
+    .orderBy(desc(chatMessages.sequenceNumber))
+    .limit(1);
+
+  if (!message || message.content === null) {
+    return null;
+  }
+  return { content: message.content };
+}
+
+async function recordLastEventToComplete(db: Db, runId: string): Promise<void> {
+  const [run] = await db
+    .select({ completedAt: agentRuns.completedAt })
+    .from(agentRuns)
+    .where(eq(agentRuns.id, runId))
+    .limit(1);
+  if (!run?.completedAt) {
+    return;
+  }
+
+  const [message] = await db
+    .select({
+      lastEventAt: sql<Date | null>`MAX(${chatMessages.createdAt})`,
+    })
+    .from(chatMessages)
+    .where(
+      and(
+        eq(chatMessages.runId, runId),
+        eq(chatMessages.role, "assistant"),
+        isNotNull(chatMessages.sequenceNumber),
+      ),
+    );
+  if (!message?.lastEventAt) {
+    return;
+  }
+
+  const lastEventMs =
+    message.lastEventAt instanceof Date
+      ? message.lastEventAt.getTime()
+      : new Date(message.lastEventAt).getTime();
+  recordSandboxOperation({
+    sandboxType: "runner",
+    actionType: "last_event_to_complete",
+    durationMs: Math.max(0, run.completedAt.getTime() - lastEventMs),
+    success: true,
+    runId,
+  });
+}
+
+async function insertAssistantErrorMessage(args: {
+  readonly db: Db;
+  readonly runId: string;
+  readonly prompt: string;
+  readonly threadId: string;
+  readonly userId: string;
+  readonly getFormattedError: () => Promise<string>;
+}): Promise<void> {
+  const displayErrorMessage = await args.getFormattedError();
+  await args.db.insert(chatMessages).values({
+    chatThreadId: args.threadId,
+    role: "assistant",
+    content: displayErrorMessage,
+    runId: args.runId,
+    error: displayErrorMessage,
+  });
+
+  await publishUserSignal(
+    [args.userId],
+    `chatThreadMessageCreated:${args.threadId}`,
+  );
+  await publishThreadListChanged(args.userId);
+  await sendUserPushNotifications({
+    db: args.db,
+    userId: args.userId,
+    notification: {
+      title: args.prompt.slice(0, 60),
+      body: `Task failed: ${displayErrorMessage.slice(0, 80)}`,
+      url: `/chats/${args.threadId}`,
+    },
+  });
+}
+
+async function handleCompletedChatCallback(args: {
+  readonly db: Db;
+  readonly runId: string;
+  readonly run: ChatRunInfo;
+  readonly chatThread: ChatThreadForRunRow;
+  readonly signal: AbortSignal;
+  readonly insertAssistantItems: (
+    items: readonly AssistantEventItem[],
+  ) => Promise<void>;
+  readonly saveRunSummary: (resultText: string) => Promise<void>;
+}): Promise<void> {
+  const { assistantItems, resultFallback } = await queryChatOutputEvents({
+    runId: args.runId,
+    lastEventSequence: args.run.lastEventSequence,
+    signal: args.signal,
+  });
+  args.signal.throwIfAborted();
+
+  if (assistantItems.length > 0) {
+    await args.insertAssistantItems(assistantItems);
+    args.signal.throwIfAborted();
+  }
+
+  let lastResultText =
+    assistantItems.length > 0
+      ? assistantItems[assistantItems.length - 1]!.content
+      : null;
+  if (lastResultText === null) {
+    const existingAssistant = await latestEventBackedAssistantMessage(
+      args.db,
+      args.runId,
+    );
+    args.signal.throwIfAborted();
+
+    if (existingAssistant) {
+      lastResultText = existingAssistant.content;
+    } else if (resultFallback) {
+      await args.insertAssistantItems([resultFallback]);
+      args.signal.throwIfAborted();
+      lastResultText = resultFallback.content;
+    }
+  }
+
+  waitUntil(
+    safeAsync(() => {
+      return recordLastEventToComplete(args.db, args.runId);
+    }).then((result) => {
+      if ("error" in result) {
+        log.warn("Failed to record last_event_to_complete", {
+          runId: args.runId,
+          error: result.error,
+        });
+      }
+    }),
+  );
+
+  await args.saveRunSummary(lastResultText ?? "");
+  args.signal.throwIfAborted();
+
+  await generateAndPersistChatThreadTitleFromCallback({
+    db: args.db,
+    threadId: args.chatThread.chatThreadId,
+    userId: args.chatThread.userId,
+    runId: args.runId,
+    prompt: args.run.prompt,
+    currentAssistantReply: lastResultText ?? undefined,
+  });
+  args.signal.throwIfAborted();
+
+  let summary: string | null = null;
+  if (lastResultText) {
+    const generated = await safeAsync(() => {
+      return generateChatNotificationSummary(args.run.prompt, lastResultText);
+    });
+    args.signal.throwIfAborted();
+    if ("ok" in generated) {
+      summary = generated.ok;
+    } else {
+      log.warn("Failed to generate notification summary", {
+        runId: args.runId,
+        error: generated.error,
+      });
+    }
+  }
+
+  await sendUserPushNotifications({
+    db: args.db,
+    userId: args.chatThread.userId,
+    notification: {
+      title: args.run.prompt.slice(0, 60),
+      body: summary ?? "Your task is complete",
+      url: `/chats/${args.chatThread.chatThreadId}`,
+    },
+  });
+}
+
+async function handleFailedChatCallback(args: {
+  readonly db: Db;
+  readonly runId: string;
+  readonly run: ChatRunInfo;
+  readonly chatThread: ChatThreadForRunRow;
+  readonly errorMessage: string;
+  readonly getFormattedError: () => Promise<string>;
+}): Promise<void> {
+  await insertAssistantErrorMessage({
+    db: args.db,
+    runId: args.runId,
+    prompt: args.run.prompt,
+    threadId: args.chatThread.chatThreadId,
+    userId: args.chatThread.userId,
+    getFormattedError: args.getFormattedError,
+  });
+}
+
+async function publishChatThreadRunUpdated(args: {
+  readonly userId: string;
+  readonly threadId: string;
+}): Promise<void> {
+  await publishUserSignal(
+    [args.userId],
+    `chatThreadRunUpdated:${args.threadId}`,
+  );
+  await publishThreadListChanged(args.userId);
+}
+
+function buildWebChatPrompt(): string {
+  return [
+    "# Current Integration\nYou are currently running inside: Web",
+    "You are communicating with the user through the web chat UI.",
+  ].join("\n\n");
+}
+
+function buildWebAttachFilesPrompt(
+  files: readonly {
+    readonly id: string;
+    readonly filename: string;
+    readonly contentType: string;
+  }[],
+): string {
+  return files
+    .map((file) => {
+      return `[Web file] ${file.filename} (${file.contentType})\n   [ID] ${file.id}`;
+    })
+    .join("\n");
+}
+
+function buildWebChatGoalPrompt(context: GoalContext): string {
+  const turnLabel = context.remainingTurns === 1 ? "turn" : "turns";
+  return [
+    "# Goal Mode",
+    "",
+    "You are operating in goal mode. The user message that triggered this run",
+    "may be a continuation of an earlier `/go` objective -- the same message body",
+    "will repeat verbatim each turn until the goal is satisfied. Treat each",
+    "repetition as the signal to continue working on the objective, not as a",
+    "fresh request to start over.",
+    "",
+    `You have ${String(context.remainingTurns)} ${turnLabel} remaining (this one included).`,
+    "",
+    "When you believe the goal is satisfied, include the literal text `[GOAL_DONE]`",
+    "somewhere in your final assistant message. The runtime detects this",
+    "sentinel and stops the goal chain. Only emit it after verifying concrete",
+    "deliverables -- do not declare completion prematurely.",
+  ].join("\n");
+}
+
+function buildAppendSystemPrompt(
+  incompleteContext: string,
+  goalContext: GoalContext | null,
+): string {
+  return [
+    buildWebChatPrompt(),
+    goalContext ? buildWebChatGoalPrompt(goalContext) : "",
+    incompleteContext,
+  ]
+    .filter((part) => {
+      return part.length > 0;
+    })
+    .join("\n\n");
+}
+
+function formatAttachFileIds(
+  ids: readonly string[] | null | undefined,
+): string {
+  if (!ids || ids.length === 0) {
+    return "";
+  }
+  return ids
+    .map((id) => {
+      return `[Web file]\n   [ID] ${id}`;
+    })
+    .join("\n");
+}
+
+function truncateIncomplete(value: string): string {
+  if (value.length <= INCOMPLETE_MESSAGE_CHAR_CAP) {
+    return value;
+  }
+  return `${value.slice(0, INCOMPLETE_MESSAGE_CHAR_CAP)}...[truncated]`;
+}
+
+function formatIncompleteMessage(message: IncompleteRoundMessage): string {
+  const attach = formatAttachFileIds(message.attachFiles);
+  if (message.role === "user") {
+    const body =
+      message.content !== null && message.content !== ""
+        ? truncateIncomplete(message.content)
+        : "[empty message]";
+    return attach ? `User: ${body}\n${attach}` : `User: ${body}`;
+  }
+  if (message.content !== null && message.content !== "") {
+    return `Assistant (partial): ${truncateIncomplete(message.content)}`;
+  }
+  return "Assistant: [no response before run ended]";
+}
+
+function buildWebChatIncompleteContext(
+  rounds: readonly IncompleteRound[],
+): string {
+  if (rounds.length === 0) {
+    return "";
+  }
+  const total = rounds.length;
+  const blocks = rounds.map((round, index) => {
+    const relativeIndex = index - total + 1;
+    const rendered = round.messages.map(formatIncompleteMessage);
+    const hasAssistant = round.messages.some((message) => {
+      return message.role === "assistant";
+    });
+    if (!hasAssistant) {
+      rendered.push("Assistant: [no response before run ended]");
+    }
+    return [
+      "---",
+      "",
+      `- RELATIVE_INDEX: ${relativeIndex}`,
+      `- RUN_STATUS: ${round.status}`,
+      "",
+      ...rendered,
+    ].join("\n");
+  });
+  return [
+    "# Incomplete Rounds Context",
+    "",
+    "The rounds below were sent in this thread but their runs did not complete",
+    "(cancelled, failed, or timed out), so the CLI session history does not",
+    "contain them. Treat them as part of the conversation you are having with",
+    "the user. RELATIVE_INDEX 0 is the most recent incomplete round.",
+    "",
+    blocks.join("\n\n"),
+    "",
+    "---",
+  ].join("\n");
+}
+
+function isIncompleteRunStatus(
+  value: string | null,
+): value is "cancelled" | "failed" | "timeout" {
+  return value === "cancelled" || value === "failed" || value === "timeout";
+}
+
+function groupIncompleteRoundsByRunId(
+  rows: readonly IncompleteRoundRow[],
+): readonly IncompleteRound[] {
+  const byRunId = new Map<string, IncompleteRound>();
+  const order: string[] = [];
+  for (const row of rows) {
+    let round = byRunId.get(row.runId);
+    if (!round) {
+      round = {
+        runId: row.runId,
+        status: row.runStatus,
+        messages: [],
+      };
+      byRunId.set(row.runId, round);
+      order.push(row.runId);
+    }
+    round.messages.push({
+      role: row.role,
+      content: row.content,
+      error: row.error,
+      attachFiles: row.attachFiles,
+    });
+  }
+  return order.map((runId) => {
+    const round = byRunId.get(runId);
+    if (!round) {
+      throw new Error("Incomplete round grouping lost run id");
+    }
+    return round;
+  });
+}
+
+async function getIncompleteRoundsSinceLastSuccess(
+  db: Db,
+  threadId: string,
+  maxRounds = 20,
+): Promise<readonly IncompleteRoundRow[]> {
+  const rows = await db
+    .select({
+      runId: chatMessages.runId,
+      role: chatMessages.role,
+      content: chatMessages.content,
+      error: chatMessages.error,
+      attachFiles: chatMessages.attachFiles,
+      createdAt: chatMessages.createdAt,
+      sequenceNumber: chatMessages.sequenceNumber,
+      runStatus: agentRuns.status,
+    })
+    .from(chatMessages)
+    .innerJoin(agentRuns, eq(agentRuns.id, chatMessages.runId))
+    .where(
+      and(
+        eq(chatMessages.chatThreadId, threadId),
+        visibleChatMessageCondition(),
+        inArray(agentRuns.status, ["cancelled", "failed", "timeout"]),
+        inArray(chatMessages.role, ["user", "assistant"]),
+        sql`${chatMessages.createdAt} > COALESCE(
+          (
+            SELECT MAX(cm2.created_at)
+            FROM chat_messages cm2
+            INNER JOIN agent_runs ar2 ON ar2.id = cm2.run_id
+            WHERE cm2.chat_thread_id = ${threadId}
+              AND NOT EXISTS (
+                SELECT 1
+                FROM chat_messages revoker2
+                WHERE revoker2.revokes_message_id = cm2.id
+              )
+              AND ar2.result ? 'agentSessionId'
+              AND jsonb_typeof(ar2.result->'agentSessionId') = 'string'
+          ),
+          '-infinity'::timestamptz
+        )`,
+      ),
+    )
+    .orderBy(asc(chatMessages.createdAt), asc(chatMessages.sequenceNumber));
+
+  const candidates: IncompleteRoundRow[] = [];
+  for (const row of rows) {
+    if (row.runId === null || !isIncompleteRunStatus(row.runStatus)) {
+      continue;
+    }
+    if (row.role !== "user" && row.role !== "assistant") {
+      continue;
+    }
+    candidates.push({
+      runId: row.runId,
+      runStatus: row.runStatus,
+      role: row.role,
+      content: row.content,
+      error: row.error,
+      attachFiles: row.attachFiles,
+    });
+  }
+
+  const orderedRunIds: string[] = [];
+  const seen = new Set<string>();
+  for (const row of candidates) {
+    if (!seen.has(row.runId)) {
+      seen.add(row.runId);
+      orderedRunIds.push(row.runId);
+    }
+  }
+  if (orderedRunIds.length <= maxRounds) {
+    return candidates;
+  }
+
+  const keep = new Set(orderedRunIds.slice(orderedRunIds.length - maxRounds));
+  return candidates.filter((row) => {
+    return keep.has(row.runId);
+  });
+}
+
+async function nextQueuedUserMessage(
+  db: Db,
+  threadId: string,
+): Promise<QueuedUserMessage | null> {
+  const [message] = await db
+    .select({
+      id: chatMessages.id,
+      content: chatMessages.content,
+      attachFiles: chatMessages.attachFiles,
+      modelProviderId: chatThreads.modelProviderId,
+      modelProviderType: chatThreads.modelProviderType,
+      modelProviderCredentialScope: chatThreads.modelProviderCredentialScope,
+      selectedModel: chatThreads.selectedModel,
+      goalRemainingTurns: chatMessages.goalRemainingTurns,
+      goalOriginMessageId: chatMessages.goalOriginMessageId,
+    })
+    .from(chatMessages)
+    .innerJoin(chatThreads, eq(chatThreads.id, chatMessages.chatThreadId))
+    .where(
+      and(
+        eq(chatMessages.chatThreadId, threadId),
+        eq(chatMessages.role, "user"),
+        isNull(chatMessages.archivedAt),
+        isNull(chatMessages.runId),
+        isNull(chatMessages.revokesMessageId),
+        isNull(chatMessages.interruptsRunId),
+        sql`NOT EXISTS (
+          SELECT 1
+          FROM ${chatMessages} AS revoker
+          WHERE revoker.revokes_message_id = ${chatMessages.id}
+        )`,
+      ),
+    )
+    .orderBy(asc(chatMessages.createdAt), asc(chatMessages.id))
+    .limit(1);
+
+  return message ?? null;
+}
+
+async function chatThreadForRunFromDb(
+  db: Db,
+  runId: string,
+): Promise<ChatThreadForRunRow | null> {
+  const [row] = await db
+    .select({
+      chatThreadId: zeroRuns.chatThreadId,
+      userId: chatThreads.userId,
+    })
+    .from(zeroRuns)
+    .innerJoin(chatThreads, eq(zeroRuns.chatThreadId, chatThreads.id))
+    .where(eq(zeroRuns.id, runId))
+    .limit(1);
+
+  if (!row?.chatThreadId) {
+    return null;
+  }
+  return { chatThreadId: row.chatThreadId, userId: row.userId };
+}
+
+function hasAgentSessionId(
+  value: unknown,
+): value is { readonly agentSessionId: string } {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "agentSessionId" in value &&
+    typeof (value as { readonly agentSessionId: unknown }).agentSessionId ===
+      "string"
+  );
+}
+
+async function latestSessionIdForThreadFromDb(
+  db: Db,
+  threadId: string,
+): Promise<string | null> {
+  const rows = await db
+    .select({ result: agentRuns.result })
+    .from(zeroRuns)
+    .innerJoin(agentRuns, eq(zeroRuns.id, agentRuns.id))
+    .where(eq(zeroRuns.chatThreadId, threadId))
+    .orderBy(desc(agentRuns.createdAt))
+    .limit(5);
+
+  for (const row of rows) {
+    if (hasAgentSessionId(row.result)) {
+      return row.result.agentSessionId;
+    }
+  }
+  return null;
+}
+
+function containsGoalDoneSentinel(content: string | null): boolean {
+  return content !== null && content.includes(GOAL_DONE_SENTINEL);
+}
+
+async function maybeInsertGoalContinuation(args: {
+  readonly db: Db;
+  readonly runId: string;
+  readonly terminalStatus: "completed" | "failed";
+}): Promise<void> {
+  if (args.terminalStatus !== "completed") {
+    return;
+  }
+
+  const [trigger] = await args.db
+    .select({
+      threadId: chatMessages.chatThreadId,
+      content: chatMessages.content,
+      attachFiles: chatMessages.attachFiles,
+      goalRemainingTurns: chatMessages.goalRemainingTurns,
+      goalOriginMessageId: chatMessages.goalOriginMessageId,
+    })
+    .from(chatMessages)
+    .where(
+      and(eq(chatMessages.runId, args.runId), eq(chatMessages.role, "user")),
+    )
+    .limit(1);
+
+  if (
+    !trigger ||
+    trigger.goalRemainingTurns === null ||
+    trigger.goalOriginMessageId === null ||
+    trigger.goalRemainingTurns <= 1
+  ) {
+    return;
+  }
+
+  const [interrupt] = await args.db
+    .select({ id: chatMessages.id })
+    .from(chatMessages)
+    .where(eq(chatMessages.interruptsRunId, args.runId))
+    .limit(1);
+  if (interrupt) {
+    return;
+  }
+
+  const [lastAssistant] = await args.db
+    .select({ content: chatMessages.content })
+    .from(chatMessages)
+    .where(
+      and(
+        eq(chatMessages.runId, args.runId),
+        eq(chatMessages.role, "assistant"),
+        isNotNull(chatMessages.content),
+      ),
+    )
+    .orderBy(desc(chatMessages.sequenceNumber), desc(chatMessages.createdAt))
+    .limit(1);
+  if (lastAssistant && containsGoalDoneSentinel(lastAssistant.content)) {
+    log.debug("Goal chain stopped by sentinel", {
+      runId: args.runId,
+      goalOriginMessageId: trigger.goalOriginMessageId,
+    });
+    return;
+  }
+
+  await args.db
+    .insert(chatMessages)
+    .values({
+      chatThreadId: trigger.threadId,
+      role: "user",
+      content: trigger.content,
+      runId: null,
+      attachFiles: trigger.attachFiles,
+      goalRemainingTurns: trigger.goalRemainingTurns - 1,
+      goalOriginMessageId: trigger.goalOriginMessageId,
+      goalContinuationOfRunId: args.runId,
+    })
+    .onConflictDoNothing({ target: chatMessages.goalContinuationOfRunId });
+}
+
+async function loadAgentForAutoSend(
+  db: Db,
+  agentId: string,
+): Promise<AgentForAutoSend | null> {
+  const [agent] = await db
+    .select({ id: zeroAgents.id, orgId: zeroAgents.orgId })
+    .from(zeroAgents)
+    .where(eq(zeroAgents.id, agentId))
+    .limit(1);
+  return agent ?? null;
+}
+
+function fallbackAttachFiles(ids: readonly string[] | null): readonly {
+  readonly id: string;
+  readonly filename: string;
+  readonly contentType: string;
+  readonly size: number;
+  readonly url: string;
+}[] {
+  return (ids ?? []).map((id) => {
+    return {
+      id,
+      filename: id,
+      contentType: "application/octet-stream",
+      size: 0,
+      url: "",
+    };
+  });
+}
+
+async function autoSendQueuedMessageOnRunComplete(args: {
+  readonly getResolvedAttachFiles: (
+    userId: string,
+    fileIds: readonly string[],
+  ) => Promise<
+    readonly {
+      readonly id: string;
+      readonly filename: string;
+      readonly contentType: string;
+      readonly size: number;
+      readonly url: string;
+    }[]
+  >;
+  readonly createRun: (
+    input: CreateQueuedChatRunInput,
+  ) => Promise<{ readonly runId: string } | null>;
+  readonly db: Db;
+  readonly runId: string;
+  readonly agentId: string;
+  readonly terminalStatus: "completed" | "failed";
+}): Promise<void> {
+  const chatThread = await chatThreadForRunFromDb(args.db, args.runId);
+  if (!chatThread) {
+    return;
+  }
+  const { chatThreadId: threadId, userId } = chatThread;
+
+  await maybeInsertGoalContinuation({
+    db: args.db,
+    runId: args.runId,
+    terminalStatus: args.terminalStatus,
+  });
+
+  const queuedMessage = await nextQueuedUserMessage(args.db, threadId);
+  if (!queuedMessage) {
+    return;
+  }
+
+  const agent = await loadAgentForAutoSend(args.db, args.agentId);
+  if (!agent) {
+    log.warn("Auto-send aborted: agent not found", {
+      threadId,
+      agentId: args.agentId,
+    });
+    return;
+  }
+
+  const [sessionId, incompleteRows] = await Promise.all([
+    latestSessionIdForThreadFromDb(args.db, threadId),
+    getIncompleteRoundsSinceLastSuccess(args.db, threadId),
+  ]);
+  const incompleteContext = buildWebChatIncompleteContext(
+    groupIncompleteRoundsByRunId(incompleteRows),
+  );
+
+  const resolvedAttachFiles =
+    queuedMessage.attachFiles && queuedMessage.attachFiles.length > 0
+      ? await args.getResolvedAttachFiles(userId, queuedMessage.attachFiles)
+      : [];
+  const attachFiles =
+    resolvedAttachFiles.length > 0
+      ? resolvedAttachFiles
+      : fallbackAttachFiles(queuedMessage.attachFiles);
+  const content = queuedMessage.content ?? "";
+  const fullPrompt =
+    attachFiles.length === 0
+      ? content
+      : `${content}\n\n${buildWebAttachFilesPrompt(attachFiles)}`;
+
+  const goalContext =
+    queuedMessage.goalRemainingTurns !== null
+      ? { remainingTurns: queuedMessage.goalRemainingTurns }
+      : null;
+
+  const run = await args.createRun({
+    orgId: agent.orgId,
+    userId,
+    agentId: agent.id,
+    prompt: fullPrompt,
+    sessionId,
+    appendSystemPrompt: buildAppendSystemPrompt(incompleteContext, goalContext),
+    threadId,
+    queuedMessage,
+  });
+  if (!run) {
+    return;
+  }
+
+  const claimed = await args.db
+    .insert(chatMessages)
+    .values({
+      chatThreadId: threadId,
+      role: "user",
+      content: queuedMessage.content,
+      runId: run.runId,
+      attachFiles: queuedMessage.attachFiles
+        ? [...queuedMessage.attachFiles]
+        : null,
+      revokesMessageId: queuedMessage.id,
+      goalRemainingTurns: queuedMessage.goalRemainingTurns,
+      goalOriginMessageId: queuedMessage.goalOriginMessageId,
+    })
+    .onConflictDoNothing({ target: chatMessages.revokesMessageId })
+    .returning({ id: chatMessages.id });
+
+  if (claimed.length === 0) {
+    await args.db
+      .update(agentRuns)
+      .set({ status: "cancelled", error: "Queued message already claimed" })
+      .where(eq(agentRuns.id, run.runId));
+    log.warn("Auto-send created a run for an already-claimed message", {
+      threadId,
+      runId: run.runId,
+      userMessageId: queuedMessage.id,
+    });
+    return;
+  }
+
+  await publishUserSignal([userId], `chatThreadMessageCreated:${threadId}`);
+  await publishUserSignal([userId], `chatThreadRunCreated:${threadId}`);
+  await publishThreadListChanged(userId);
+}
+
+async function createQueuedChatRun(args: {
+  readonly db: Db;
+  readonly input: CreateQueuedChatRunInput;
+  readonly signal: AbortSignal;
+  readonly createRun: (
+    input: CreateQueuedChatRunInput,
+  ) => Promise<{ readonly runId: string } | null>;
+}): Promise<{ readonly runId: string } | null> {
+  const created = await args.createRun(args.input);
+  args.signal.throwIfAborted();
+  if (!created) {
+    return null;
+  }
+
+  await args.db
+    .update(zeroRuns)
+    .set({
+      modelProvider: args.input.queuedMessage.modelProviderType,
+      modelProviderId: args.input.queuedMessage.modelProviderId,
+      modelProviderCredentialScope:
+        args.input.queuedMessage.modelProviderCredentialScope,
+      selectedModel: args.input.queuedMessage.selectedModel,
+    })
+    .where(eq(zeroRuns.id, created.runId));
+  args.signal.throwIfAborted();
+
+  return created;
+}
+
+async function loadTerminalChatCallback(args: {
+  readonly db: Db;
+  readonly runId: string;
+  readonly callbackStatus: "completed" | "failed";
+  readonly payloadThreadId: string;
+  readonly signal: AbortSignal;
+}): Promise<{
+  readonly run: ChatRunInfo;
+  readonly chatThread: ChatThreadForRunRow;
+} | null> {
+  const [run] = await args.db
+    .select({
+      prompt: agentRuns.prompt,
+      error: agentRuns.error,
+      lastEventSequence: agentRuns.lastEventSequence,
+    })
+    .from(agentRuns)
+    .where(eq(agentRuns.id, args.runId))
+    .limit(1);
+  args.signal.throwIfAborted();
+
+  if (!run) {
+    return null;
+  }
+
+  const chatThread = await chatThreadForRunFromDb(args.db, args.runId);
+  args.signal.throwIfAborted();
+  if (!chatThread) {
+    log.debug("Skipping terminal chat callback for missing chat thread", {
+      runId: args.runId,
+      status: args.callbackStatus,
+      payloadThreadId: args.payloadThreadId,
+    });
+    return null;
+  }
+
+  if (chatThread.chatThreadId !== args.payloadThreadId) {
+    log.warn("Chat callback payload thread does not match run mapping", {
+      runId: args.runId,
+      payloadThreadId: args.payloadThreadId,
+      chatThreadId: chatThread.chatThreadId,
+    });
+  }
+
+  return { run, chatThread };
+}
+
+const handleChatCallback$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const apiStartTime = now();
+    const callback = get(callbackPayload$);
+    const payload = chatCallbackPayloadSchema.safeParse(callback.payload);
+    if (!payload.success) {
+      return {
+        status: 400 as const,
+        body: { error: "Invalid or missing payload" },
+      };
+    }
+
+    if (callback.status === "progress") {
+      return { status: 200 as const, body: { success: true as const } };
+    }
+
+    const db = set(writeDb$);
+    const loaded = await loadTerminalChatCallback({
+      db,
+      runId: callback.runId,
+      callbackStatus: callback.status,
+      payloadThreadId: payload.data.threadId,
+      signal,
+    });
+    if (!loaded) {
+      return { status: 200 as const, body: { success: true as const } };
+    }
+    const { run, chatThread } = loaded;
+
+    if (callback.status === "completed") {
+      await handleCompletedChatCallback({
+        db,
+        runId: callback.runId,
+        run,
+        chatThread,
+        signal,
+        insertAssistantItems: async (items) => {
+          await set(
+            insertAssistantEventMessages$,
+            {
+              runId: callback.runId,
+              threadId: chatThread.chatThreadId,
+              userId: chatThread.userId,
+              items,
+            },
+            signal,
+          );
+        },
+        saveRunSummary: (resultText) => {
+          return set(
+            saveRunSummary$,
+            {
+              runId: callback.runId,
+              triggerSource: "chat",
+              prompt: run.prompt,
+              resultText,
+            },
+            signal,
+          );
+        },
+      });
+      signal.throwIfAborted();
+    } else if (callback.status === "failed") {
+      const errorMessage = callback.error ?? run.error ?? "Run failed";
+      await handleFailedChatCallback({
+        db,
+        runId: callback.runId,
+        run,
+        chatThread,
+        errorMessage,
+        getFormattedError: () => {
+          return get(
+            formatChatRunErrorMessage({
+              chatThreadId: chatThread.chatThreadId,
+              runId: callback.runId,
+              errorMessage,
+            }),
+          );
+        },
+      });
+      signal.throwIfAborted();
+    }
+
+    await publishChatThreadRunUpdated({
+      userId: chatThread.userId,
+      threadId: chatThread.chatThreadId,
+    });
+    signal.throwIfAborted();
+
+    await autoSendQueuedMessageOnRunComplete({
+      db,
+      runId: callback.runId,
+      agentId: payload.data.agentId,
+      terminalStatus: callback.status === "completed" ? "completed" : "failed",
+      getResolvedAttachFiles: (userId, fileIds) => {
+        return get(resolveAttachFileUrls(userId, fileIds));
+      },
+      createRun: (input) => {
+        return createQueuedChatRun({
+          db,
+          input,
+          signal,
+          createRun: async (runInput) => {
+            const runResult = await set(
+              createAgentRun$,
+              buildQueuedCreateAgentRunArgs(runInput, apiStartTime),
+              signal,
+            );
+            if (runResult.status !== 201) {
+              log.warn("Auto-send failed to create run", {
+                threadId: runInput.threadId,
+                status: runResult.status,
+              });
+              return null;
+            }
+            return { runId: runResult.body.runId };
+          },
+        });
+      },
+    });
+    signal.throwIfAborted();
+
+    return { status: 200 as const, body: { success: true as const } };
+  },
+);
+
+export const internalCallbacksChatRoutes: readonly RouteEntry[] = [
+  {
+    route: internalCallbacksChatContract.post,
+    handler: callbackRoute(handleChatCallback$),
+  },
+];

--- a/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
@@ -361,7 +361,7 @@ function effectiveModelFirstThreadPin(params: {
   });
 }
 
-function resolveAttachFileUrls(
+export function resolveAttachFileUrls(
   userId: string,
   fileIds: readonly string[],
 ): Computed<Promise<readonly ResolvedAttachFile[]>> {
@@ -431,7 +431,7 @@ function genericErrorStreakForRun(params: {
   });
 }
 
-function formatChatRunErrorMessage(params: {
+export function formatChatRunErrorMessage(params: {
   readonly chatThreadId: string;
   readonly runId: string;
   readonly errorMessage: string;

--- a/turbo/apps/api/src/signals/services/zero-chat-title.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-title.service.ts
@@ -1,7 +1,7 @@
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { chatMessages } from "@vm0/db/schema/chat-message";
 import { chatThreads } from "@vm0/db/schema/chat-thread";
-import { and, desc, eq, inArray, isNotNull } from "drizzle-orm";
+import { and, desc, eq, inArray, isNotNull, sql } from "drizzle-orm";
 
 import { optionalEnv } from "../../lib/env";
 import { logger } from "../../lib/log";
@@ -24,6 +24,7 @@ interface TitleContextMessage {
 
 interface ChatTitleInput {
   readonly currentUserMessage: string;
+  readonly currentAssistantReply?: string;
   readonly priorRounds?: readonly TitleContextMessage[];
 }
 
@@ -112,6 +113,11 @@ function generateChatTitle(input: ChatTitleInput): Promise<string | null> {
   sections.push(
     `Most recent user message:\n${input.currentUserMessage.slice(0, TITLE_CONTEXT_CHAR_CAP)}`,
   );
+  if (input.currentAssistantReply) {
+    sections.push(
+      `Most recent assistant reply:\n${input.currentAssistantReply.slice(0, TITLE_CONTEXT_CHAR_CAP)}`,
+    );
+  }
 
   return generateText([
     {
@@ -129,7 +135,22 @@ function generateChatTitle(input: ChatTitleInput): Promise<string | null> {
 async function getLatestTitleContextMessages(
   db: Db,
   threadId: string,
+  options?: { readonly excludeRunId?: string },
 ): Promise<TitleContextMessage[]> {
+  const filters = [
+    eq(chatMessages.chatThreadId, threadId),
+    isNotNull(chatMessages.content),
+    inArray(chatMessages.role, ["user", "assistant"]),
+    visibleChatMessageCondition(),
+  ];
+  if (options?.excludeRunId !== undefined) {
+    filters.push(
+      // Keep prior context free of the current exchange. User rows have the run
+      // id too, so this excludes both sides of the just-completed round.
+      sql`(${chatMessages.runId} IS NULL OR ${chatMessages.runId} != ${options.excludeRunId})`,
+    );
+  }
+
   const rows = await db
     .select({
       role: chatMessages.role,
@@ -139,14 +160,7 @@ async function getLatestTitleContextMessages(
     })
     .from(chatMessages)
     .leftJoin(agentRuns, eq(agentRuns.id, chatMessages.runId))
-    .where(
-      and(
-        eq(chatMessages.chatThreadId, threadId),
-        isNotNull(chatMessages.content),
-        inArray(chatMessages.role, ["user", "assistant"]),
-        visibleChatMessageCondition(),
-      ),
-    )
+    .where(and(...filters))
     .orderBy(desc(chatMessages.createdAt), desc(chatMessages.sequenceNumber))
     .limit(TITLE_PRIOR_MESSAGE_CAP);
 
@@ -209,4 +223,55 @@ export async function generateAndPersistChatThreadTitle(args: {
       err: result.error,
     });
   }
+}
+
+export async function generateAndPersistChatThreadTitleFromCallback(args: {
+  readonly db: Db;
+  readonly threadId: string;
+  readonly userId: string;
+  readonly runId: string;
+  readonly prompt: string;
+  readonly currentAssistantReply: string | undefined;
+}): Promise<void> {
+  const result = await safeAsync(async () => {
+    const priorRounds = await getLatestTitleContextMessages(
+      args.db,
+      args.threadId,
+      { excludeRunId: args.runId },
+    );
+    const title = await generateChatTitle({
+      currentUserMessage: args.prompt,
+      currentAssistantReply: args.currentAssistantReply,
+      priorRounds: priorRounds.length > 0 ? priorRounds : undefined,
+    });
+    if (title) {
+      await updateChatThreadTitle(args.db, args.threadId, args.userId, title);
+    }
+  });
+  if ("error" in result) {
+    log.warn("Chat title generation failed", {
+      threadId: args.threadId,
+      err: result.error,
+    });
+  }
+}
+
+export function generateChatNotificationSummary(
+  prompt: string,
+  resultText: string,
+): Promise<string | null> {
+  return generateText(
+    [
+      {
+        role: "system",
+        content:
+          "Summarize this completed task in one short notification sentence, max 90 chars. Plain text only.",
+      },
+      {
+        role: "user",
+        content: `User request:\n${prompt.slice(0, TITLE_CONTEXT_CHAR_CAP)}\n\nAssistant reply:\n${resultText.slice(0, TITLE_CONTEXT_CHAR_CAP)}`,
+      },
+    ],
+    35,
+  );
 }

--- a/turbo/apps/api/src/signals/services/zero-push-notifications.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-push-notifications.service.ts
@@ -1,0 +1,83 @@
+import webpush, { WebPushError } from "web-push";
+import { eq } from "drizzle-orm";
+import { pushSubscriptions } from "@vm0/db/schema/push-subscription";
+
+import { logger } from "../../lib/log";
+import { optionalEnv } from "../../lib/env";
+import type { Db } from "../external/db";
+import { safeAsync } from "../utils";
+
+const log = logger("api:push");
+
+interface PushNotification {
+  readonly title: string;
+  readonly body: string;
+  readonly url: string;
+}
+
+/**
+ * Send push notifications to all registered devices for a user.
+ *
+ * Missing VAPID keys are an intentional no-op, matching the legacy web route.
+ */
+export async function sendUserPushNotifications(args: {
+  readonly db: Db;
+  readonly userId: string;
+  readonly notification: PushNotification;
+}): Promise<void> {
+  const publicKey = optionalEnv("VAPID_PUBLIC_KEY");
+  const privateKey = optionalEnv("VAPID_PRIVATE_KEY");
+  if (!publicKey || !privateKey) {
+    return;
+  }
+
+  webpush.setVapidDetails("mailto:contact@vm0.ai", publicKey, privateKey);
+
+  const subscriptions = await args.db
+    .select()
+    .from(pushSubscriptions)
+    .where(eq(pushSubscriptions.userId, args.userId));
+  if (subscriptions.length === 0) {
+    return;
+  }
+
+  const payload = JSON.stringify(args.notification);
+  await Promise.all(
+    subscriptions.map(async (subscription) => {
+      const result = await safeAsync(() => {
+        return webpush.sendNotification(
+          {
+            endpoint: subscription.endpoint,
+            keys: {
+              p256dh: subscription.p256dh,
+              auth: subscription.auth,
+            },
+          },
+          payload,
+        );
+      });
+      if ("ok" in result) {
+        return;
+      }
+
+      const statusCode =
+        result.error instanceof WebPushError
+          ? result.error.statusCode
+          : undefined;
+      if (statusCode === 410 || statusCode === 404) {
+        await args.db
+          .delete(pushSubscriptions)
+          .where(eq(pushSubscriptions.id, subscription.id));
+        log.debug("Removed stale push subscription", {
+          endpoint: subscription.endpoint,
+        });
+        return;
+      }
+
+      log.warn("Failed to send push notification", {
+        endpoint: subscription.endpoint,
+        error: result.error,
+      });
+    }),
+  );
+}

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -172,6 +172,12 @@ export {
   type StoragesListContract,
 } from "./storages";
 export {
+  internalCallbacksChatContract,
+  chatCallbackPayloadSchema,
+  type InternalCallbacksChatContract,
+  type ChatCallbackPayload,
+} from "./internal-callbacks-chat";
+export {
   internalCallbacksTelegramContract,
   telegramCallbackPayloadSchema,
   type InternalCallbacksTelegramContract,

--- a/turbo/packages/api-contracts/src/contracts/internal-callbacks-chat.ts
+++ b/turbo/packages/api-contracts/src/contracts/internal-callbacks-chat.ts
@@ -1,0 +1,41 @@
+import { z } from "zod";
+
+import { initContract } from "./base";
+import {
+  internalCallbackBodySchema,
+  internalCallbackErrorSchema,
+  internalCallbackHeadersSchema,
+  internalCallbackSuccessSchema,
+} from "./internal-callbacks-shared";
+
+const c = initContract();
+
+export const chatCallbackPayloadSchema = z
+  .object({
+    threadId: z.string(),
+    agentId: z.string(),
+  })
+  .passthrough();
+
+export const internalCallbacksChatContract = c.router({
+  post: {
+    method: "POST",
+    path: "/api/internal/callbacks/chat",
+    headers: internalCallbackHeadersSchema,
+    body: internalCallbackBodySchema.extend({
+      payload: chatCallbackPayloadSchema,
+    }),
+    responses: {
+      200: internalCallbackSuccessSchema,
+      400: internalCallbackErrorSchema,
+      401: internalCallbackErrorSchema,
+      404: internalCallbackErrorSchema,
+      500: internalCallbackErrorSchema,
+    },
+    summary: "Handle callbacks for web chat task runs",
+  },
+});
+
+export type ChatCallbackPayload = z.infer<typeof chatCallbackPayloadSchema>;
+export type InternalCallbacksChatContract =
+  typeof internalCallbacksChatContract;

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -98,7 +98,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   apps/api:
     dependencies:
@@ -207,6 +207,9 @@ importers:
       undici:
         specifier: ^6.24.1
         version: 6.24.1
+      web-push:
+        specifier: ^3.6.7
+        version: 3.6.7
       zod:
         specifier: 4.3.6
         version: 4.3.6
@@ -229,6 +232,9 @@ importers:
       '@types/pg':
         specifier: ^8.20.0
         version: 8.20.0
+      '@types/web-push':
+        specifier: ^3.6.4
+        version: 3.6.4
       '@typescript-eslint/rule-tester':
         specifier: ^8.59.2
         version: 8.59.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
@@ -267,7 +273,7 @@ importers:
         version: 8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   apps/cli:
     dependencies:
@@ -349,7 +355,7 @@ importers:
         version: 6.24.1
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       yaml:
         specifier: '>=2.8.3'
         version: 2.8.3
@@ -530,7 +536,7 @@ importers:
         version: 8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   apps/web:
     dependencies:
@@ -777,7 +783,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/api-contracts:
     dependencies:
@@ -817,7 +823,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/api-services:
     devDependencies:
@@ -841,7 +847,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/connectors:
     dependencies:
@@ -875,7 +881,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/core:
     dependencies:
@@ -909,7 +915,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/db:
     dependencies:
@@ -946,7 +952,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/eslint-config:
     devDependencies:
@@ -1000,7 +1006,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       yaml:
         specifier: '>=2.8.3'
         version: 2.8.3
@@ -1110,7 +1116,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
 packages:
 
@@ -2109,89 +2115,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -2314,24 +2336,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.2.6':
     resolution: {integrity: sha512-URUTu1+dMkxJsPFgm+OeEvq9wf5sujw0EvgYy80TDGHTSLTnIHeqb0Eu8A3sC95IRgjejQL+kC4mw+4yPxiAXA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.2.6':
     resolution: {integrity: sha512-DOj182mPV8G3UkrayLoREM5YEYI+Dk5wv7Ox9xl1fFibAELEsFD0lDPfHIeILlutMMfdyhlzYPELG3peuKaurw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.2.6':
     resolution: {integrity: sha512-HKQ5SP/V/ub73UvF7n/zeJlxk2kLmtL7Wzrg4WfmkjmNos5onJ2tKu7yZOPdL18A6Svfn3max29ym+ry7NkK4g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.2.6':
     resolution: {integrity: sha512-LZXpTlPyS5v7HhSmnvsLGP3iIYgYOBnc8r8ArlT55sGHV89bR2HlDdBjWQ+PY6SJMmk8TuVGFuxalnP3k/0Dwg==}
@@ -2385,24 +2411,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@ngrok/ngrok-linux-arm64-musl@1.7.0':
     resolution: {integrity: sha512-e66vUdVrBlQ0lT9ZdamB4U604zt5Gualt8/WVcUGzbu8s5LajWd6g/mzZCUjK4UepjvMpfgmCp1/+rX7Rk8d5A==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@ngrok/ngrok-linux-x64-gnu@1.7.0':
     resolution: {integrity: sha512-M6gF0DyOEFqXLfWxObfL3bxYZ4+PnKBHuyLVaqNfFN9Y5utY2mdPOn5422Ppbk4XoIK5/YkuhRqPJl/9FivKEw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@ngrok/ngrok-linux-x64-musl@1.7.0':
     resolution: {integrity: sha512-4Ijm0dKeoyzZTMaYxR2EiNjtlK81ebflg/WYIO1XtleFrVy4UJEGnxtxEidYoT4BfCqi4uvXiK2Mx216xXKvog==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@ngrok/ngrok-win32-arm64-msvc@1.7.0':
     resolution: {integrity: sha512-u7qyWIJI2/YG1HTBnHwUR1+Z2tyGfAsUAItJK/+N1G0FeWJhIWQvSIFJHlaPy4oW1Dc8mSDBX9qvVsiQgLaRFg==}
@@ -2913,41 +2943,49 @@ packages:
     resolution: {integrity: sha512-heV2+jmXyYnUrpUXSPugqWDRpnsQcDm2AX4wzTuvgdlZfoNYO0O3W2AVpJYaDn9AG4JdM6Kxom8+foE7/BcSig==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-arm64-musl@11.19.1':
     resolution: {integrity: sha512-jvo2Pjs1c9KPxMuMPIeQsgu0mOJF9rEb3y3TdpsrqwxRM+AN6/nDDwv45n5ZrUnQMsdBy5gIabioMKnQfWo9ew==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-linux-ppc64-gnu@11.19.1':
     resolution: {integrity: sha512-vLmdNxWCdN7Uo5suays6A/+ywBby2PWBBPXctWPg5V0+eVuzsJxgAn6MMB4mPlshskYbppjpN2Zg83ArHze9gQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-gnu@11.19.1':
     resolution: {integrity: sha512-/b+WgR+VTSBxzgOhDO7TlMXC1ufPIMR6Vj1zN+/x+MnyXGW7prTLzU9eW85Aj7Th7CCEG9ArCbTeqxCzFWdg2w==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-musl@11.19.1':
     resolution: {integrity: sha512-YlRdeWb9j42p29ROh+h4eg/OQ3dTJlpHSa+84pUM9+p6i3djtPz1q55yLJhgW9XfDch7FN1pQ/Vd6YP+xfRIuw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-linux-s390x-gnu@11.19.1':
     resolution: {integrity: sha512-EDpafVOQWF8/MJynsjOGFThcqhRHy417sRyLfQmeiamJ8qVhSKAn2Dn2VVKUGCjVB9C46VGjhNo7nOPUi1x6uA==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-gnu@11.19.1':
     resolution: {integrity: sha512-NxjZe+rqWhr+RT8/Ik+5ptA3oz7tUw361Wa5RWQXKnfqwSSHdHyrw6IdcTfYuml9dM856AlKWZIUXDmA9kkiBQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-musl@11.19.1':
     resolution: {integrity: sha512-cM/hQwsO3ReJg5kR+SpI69DMfvNCp+A/eVR4b4YClE5bVZwz8rh2Nh05InhwI5HR/9cArbEkzMjcKgTHS6UaNw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-openharmony-arm64@11.19.1':
     resolution: {integrity: sha512-QF080IowFB0+9Rh6RcD19bdgh49BpQHUW5TajG1qvWHvmrQznTZZjYlgE2ltLXyKY+qs4F/v5xuX1XS7Is+3qA==}
@@ -3051,48 +3089,56 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-arm64-musl@1.57.0':
     resolution: {integrity: sha512-i66WyEPVEvq9bxRUCJ/MP5EBfnTDN3nhwEdFZFTO5MmLLvzngfWEG3NSdXQzTT3vk5B9i6C2XSIYBh+aG6uqyg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxlint/binding-linux-ppc64-gnu@1.57.0':
     resolution: {integrity: sha512-oMZDCwz4NobclZU3pH+V1/upVlJZiZvne4jQP+zhJwt+lmio4XXr4qG47CehvrW1Lx2YZiIHuxM2D4YpkG3KVA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-riscv64-gnu@1.57.0':
     resolution: {integrity: sha512-uoBnjJ3MMEBbfnWC1jSFr7/nSCkcQYa72NYoNtLl1imshDnWSolYCjzb8LVCwYCCfLJXD+0gBLD7fyC14c0+0g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-riscv64-musl@1.57.0':
     resolution: {integrity: sha512-BdrwD7haPZ8a9KrZhKJRSj6jwCor+Z8tHFZ3PT89Y3Jq5v3LfMfEePeAmD0LOTWpiTmzSzdmyw9ijneapiVHKQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxlint/binding-linux-s390x-gnu@1.57.0':
     resolution: {integrity: sha512-BNs+7ZNsRstVg2tpNxAXfMX/Iv5oZh204dVyb8Z37+/gCh+yZqNTlg6YwCLIMPSk5wLWIGOaQjT0GUOahKYImw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-x64-gnu@1.57.0':
     resolution: {integrity: sha512-AghS18w+XcENcAX0+BQGLiqjpqpaxKJa4cWWP0OWNLacs27vHBxu7TYkv9LUSGe5w8lOJHeMxcYfZNOAPqw2bg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-x64-musl@1.57.0':
     resolution: {integrity: sha512-E/FV3GB8phu/Rpkhz5T96hAiJlGzn91qX5yj5gU754P5cmVGXY1Jw/VSjDSlZBCY3VHjsVLdzgdkJaomEmcNOg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxlint/binding-openharmony-arm64@1.57.0':
     resolution: {integrity: sha512-xvZ2yZt0nUVfU14iuGv3V25jpr9pov5N0Wr28RXnHFxHCRxNDMtYPHV61gGLhN9IlXM96gI4pyYpLSJC5ClLCQ==}
@@ -3147,36 +3193,42 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm-musl@2.5.6':
     resolution: {integrity: sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-arm64-glibc@2.5.6':
     resolution: {integrity: sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-musl@2.5.6':
     resolution: {integrity: sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-x64-glibc@2.5.6':
     resolution: {integrity: sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-x64-musl@2.5.6':
     resolution: {integrity: sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-win32-arm64@2.5.6':
     resolution: {integrity: sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==}
@@ -3879,72 +3931,84 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.12':
     resolution: {integrity: sha512-V6/wZztnBqlx5hJQqNWwFdxIKN0m38p8Jas+VoSfgH54HSj9tKTt1dZvG6JRHcjh6D7TvrJPWFGaY9UBVOaWPw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
     resolution: {integrity: sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.12':
     resolution: {integrity: sha512-AP3E9BpcUYliZCxa3w5Kwj9OtEVDYK6sVoUzy4vTOJsjPOgdaJZKFmN4oOlX0Wp0RPV2ETfmIra9x1xuayFB7g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.12':
     resolution: {integrity: sha512-nWwpvUSPkoFmZo0kQazZYOrT7J5DGOJ/+QHHzjvNlooDZED8oH82Yg67HvehPPLAg5fUff7TfWFHQS8IV1n3og==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.12':
     resolution: {integrity: sha512-RNrafz5bcwRy+O9e6P8Z/OCAJW/A+qtBczIqVYwTs14pf4iV1/+eKEjdOUta93q2TsT/FI0XYDP3TCky38LMAg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.12':
     resolution: {integrity: sha512-Jpw/0iwoKWx3LJ2rc1yjFrj+T7iHZn2JDg1Yny1ma0luviFS4mhAIcd1LFNxK3EYu3DHWCps0ydXQ5i/rrJ2ig==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
     resolution: {integrity: sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.12':
     resolution: {integrity: sha512-vRugONE4yMfVn0+7lUKdKvN4D5YusEiPilaoO2sgUWpCvrncvWgPMzK00ZFFJuiPgLwgFNP5eSiUlv2tfc+lpA==}
@@ -4053,66 +4117,79 @@ packages:
     resolution: {integrity: sha512-RzeBwv0B3qtVBWtcuABtSuCzToo2IEAIQrcyB/b2zMvBWVbjo8bZDjACUpnaafaxhTw2W+imQbP2BD1usasK4g==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.0':
     resolution: {integrity: sha512-Sf7zusNI2CIU1HLzuu9Tc5YGAHEZs5Lu7N1ssJG4Tkw6e0MEsN7NdjUDDfGNHy2IU+ENyWT+L2obgWiguWibWQ==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.0':
     resolution: {integrity: sha512-DX2x7CMcrJzsE91q7/O02IJQ5/aLkVtYFryqCjduJhUfGKG6yJV8hxaw8pZa93lLEpPTP/ohdN4wFz7yp/ry9A==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.0':
     resolution: {integrity: sha512-09EL+yFVbJZlhcQfShpswwRZ0Rg+z/CsSELFCnPt3iK+iqwGsI4zht3secj5vLEs957QvFFXnzAT0FFPIxSrkQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.0':
     resolution: {integrity: sha512-i9IcCMPr3EXm8EQg5jnja0Zyc1iFxJjZWlb4wr7U2Wx/GrddOuEafxRdMPRYVaXjgbhvqalp6np07hN1w9kAKw==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.0':
     resolution: {integrity: sha512-DGzdJK9kyJ+B78MCkWeGnpXJ91tK/iKA6HwHxF4TAlPIY7GXEvMe8hBFRgdrR9Ly4qebR/7gfUs9y2IoaVEyog==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.0':
     resolution: {integrity: sha512-RwpnLsqC8qbS8z1H1AxBA1H6qknR4YpPR9w2XX0vo2Sz10miu57PkNcnHVaZkbqyw/kUWfKMI73jhmfi9BRMUQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.0':
     resolution: {integrity: sha512-Z8pPf54Ly3aqtdWC3G4rFigZgNvd+qJlOE52fmko3KST9SoGfAdSRCwyoyG05q1HrrAblLbk1/PSIV+80/pxLg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.0':
     resolution: {integrity: sha512-3a3qQustp3COCGvnP4SvrMHnPQ9d1vzCakQVRTliaz8cIp/wULGjiGpbcqrkv0WrHTEp8bQD/B3HBjzujVWLOA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.0':
     resolution: {integrity: sha512-pjZDsVH/1VsghMJ2/kAaxt6dL0psT6ZexQVrijczOf+PeP2BUqTHYejk3l6TlPRydggINOeNRhvpLa0AYpCWSQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.0':
     resolution: {integrity: sha512-3ObQs0BhvPgiUVZrN7gqCSvmFuMWvWvsjG5ayJ3Lraqv+2KhOsp+pUbigqbeWqueGIsnn+09HBw27rJ+gYK4VQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.0':
     resolution: {integrity: sha512-EtylprDtQPdS5rXvAayrNDYoJhIz1/vzN2fEubo3yLE7tfAw+948dO0g4M0vkTVFhKojnF+n6C8bDNe+gDRdTg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.0':
     resolution: {integrity: sha512-k09oiRCi/bHU9UVFqD17r3eJR9bn03TyKraCrlz5ULFJGdJGi7VOmm9jl44vOJvRJ6P7WuBi/s2A97LxxHGIdw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.0':
     resolution: {integrity: sha512-1o/0/pIhozoSaDJoDcec+IVLbnRtQmHwPV730+AOD29lHEEo4F5BEUB24H0OBdhbBBDwIOSuf7vgg0Ywxdfiiw==}
@@ -4724,36 +4801,42 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-arm64-musl@1.15.21':
     resolution: {integrity: sha512-8/yGCMO333ultDaMQivE5CjO6oXDPeeg1IV4sphojPkb0Pv0i6zvcRIkgp60xDB+UxLr6VgHgt+BBgqS959E9g==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-linux-ppc64-gnu@1.15.21':
     resolution: {integrity: sha512-ucW0HzPx0s1dgRvcvuLSPSA/2Kk/VYTv9st8qe1Kc22Gu0Q0rH9+6TcBTmMuNIp0Xs4BPr1uBttmbO1wEGI49Q==}
     engines: {node: '>=10'}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-s390x-gnu@1.15.21':
     resolution: {integrity: sha512-ulTnOGc5I7YRObE/9NreAhQg94QkiR5qNhhcUZ1iFAYjzg/JGAi1ch+s/Ixe61pMIr8bfVrF0NOaB0f8wjaAfA==}
     engines: {node: '>=10'}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-x64-gnu@1.15.21':
     resolution: {integrity: sha512-D0RokxtM+cPvSqJIKR6uja4hbD+scI9ezo95mBhfSyLUs9wnPPl26sLp1ZPR/EXRdYm3F3S6RUtVi+8QXhT24Q==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-x64-musl@1.15.21':
     resolution: {integrity: sha512-nER8u7VeRfmU6fMDzl1NQAbbB/G7O2avmvCOwIul1uGkZ2/acbPH+DCL9h5+0yd/coNcxMBTL6NGepIew+7C2w==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-win32-arm64-msvc@1.15.21':
     resolution: {integrity: sha512-+/AgNBnjYugUA8C0Do4YzymgvnGbztv7j8HKSQLvR/DQgZPoXQ2B3PqB2mTtGh/X5DhlJWiqnunN35JUgWcAeQ==}
@@ -4878,24 +4961,28 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.2.2':
     resolution: {integrity: sha512-oCfG/mS+/+XRlwNjnsNLVwnMWYH7tn/kYPsNPh+JSOMlnt93mYNCKHYzylRhI51X+TbR+ufNhhKKzm6QkqX8ag==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.2.2':
     resolution: {integrity: sha512-rTAGAkDgqbXHNp/xW0iugLVmX62wOp2PoE39BTCGKjv3Iocf6AFbRP/wZT/kuCxC9QBh9Pu8XPkv/zCZB2mcMg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.2.2':
     resolution: {integrity: sha512-XW3t3qwbIwiSyRCggeO2zxe3KWaEbM0/kW9e8+0XpBgyKU4ATYzcVSMKteZJ1iukJ3HgHBjbg9P5YPRCVUxlnQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.2.2':
     resolution: {integrity: sha512-eKSztKsmEsn1O5lJ4ZAfyn41NfG7vzCg496YiGtMDV86jz1q/irhms5O0VrY6ZwTUkFy/EKG3RfWgxSI3VbZ8Q==}
@@ -7320,24 +7407,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -9145,6 +9236,7 @@ packages:
       '@vitest/ui': 4.1.5
       happy-dom: '*'
       jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true
@@ -14022,7 +14114,7 @@ snapshots:
       '@vitest/mocker': 4.1.5(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       playwright: 1.59.1
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -14036,7 +14128,7 @@ snapshots:
       '@vitest/mocker': 4.1.5(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       playwright: 1.59.1
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -14052,7 +14144,7 @@ snapshots:
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       ws: 8.20.0
     transitivePeerDependencies:
       - bufferutil
@@ -14070,7 +14162,7 @@ snapshots:
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       ws: 8.20.0
     transitivePeerDependencies:
       - bufferutil
@@ -14090,7 +14182,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
     optionalDependencies:
       '@vitest/browser': 4.1.5(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.5)
 
@@ -14148,7 +14240,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   '@vitest/utils@4.1.5':
     dependencies:
@@ -18377,7 +18469,7 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
-  vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3):
+  vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.5
       '@vitest/mocker': 4.1.5(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
@@ -18407,18 +18499,39 @@ snapshots:
       '@vitest/ui': 4.1.5(vitest@4.1.5)
       happy-dom: 20.9.0
     transitivePeerDependencies:
-      - '@vitejs/devtools'
-      - esbuild
-      - jiti
-      - less
       - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - terser
-      - tsx
-      - yaml
+
+  vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)):
+    dependencies:
+      '@vitest/expect': 4.1.5
+      '@vitest/mocker': 4.1.5(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/pretty-format': 4.1.5
+      '@vitest/runner': 4.1.5
+      '@vitest/snapshot': 4.1.5
+      '@vitest/spy': 4.1.5
+      '@vitest/utils': 4.1.5
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.1
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@types/node': 24.3.0
+      '@vitest/browser-playwright': 4.1.5(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(playwright@1.59.1)(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.5)
+      '@vitest/coverage-v8': 4.1.5(@vitest/browser@4.1.5)(vitest@4.1.5)
+      '@vitest/ui': 4.1.5(vitest@4.1.5)
+      happy-dom: 20.9.0
+    transitivePeerDependencies:
+      - msw
 
   vscode-languageserver-textdocument@1.0.12: {}
 


### PR DESCRIPTION
## Summary
- add the API contract and apps/api route for POST /api/internal/callbacks/chat
- port terminal chat callback side effects: final Axiom sweep, assistant/error messages, realtime updates, summaries, titles, push notifications, and queued-message continuation
- add API integration coverage for progress, completion, failure, queued auto-send, and signature rejection

Fixes #13071

## Testing
- pnpm --dir turbo -F api lint
- pnpm --dir turbo -F api check-types
- pnpm --dir turbo -F api exec vitest --run src/signals/routes/__tests__/internal-callbacks-chat.test.ts
- pnpm --dir turbo -F web exec vitest --run app/api/zero/chat/messages/__tests__/route.force-new-session.test.ts
- pnpm --dir turbo -F web db:migrate
- pnpm --dir turbo test (passed: 1040 files, 11176 tests)
- pnpm --dir turbo -F web exec vitest --run src/lib/zero/agentphone/__tests__/shared.test.ts

Note: a later repeated local full-suite run failed only because the AgentPhone shared test uses fixed agentphone_message_id seeds already left in this persistent local DB by the previous full run. I deleted those local seed rows and reran the AgentPhone file successfully.