### PR TITLE
fix: hide model policy oauth provider label

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/__tests__/org-providers-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/__tests__/org-providers-tab.test.tsx
@@ -398,7 +398,12 @@ describe("org-providers-tab — stale banner reconnect", () => {
     );
     const dialog = await openModelPolicyDialog(row);
     clickRouteChoice(dialog, "BYOK: member OAuth");
-    expect(within(dialog).getByText("Claude Code (OAuth token)")).toBeDefined();
+    expect(
+      within(dialog).queryByText("OAuth provider"),
+    ).not.toBeInTheDocument();
+    expect(
+      within(dialog).queryByText("Claude Code (OAuth token)"),
+    ).not.toBeInTheDocument();
     expect(within(dialog).queryByRole("combobox")).not.toBeInTheDocument();
     expect(
       within(dialog).queryByText(/OAuth routes are personal/i),
@@ -430,7 +435,12 @@ describe("org-providers-tab — stale banner reconnect", () => {
     const row = await screen.findByTestId("org-model-policy-row-gpt-5.5");
     const dialog = await openModelPolicyDialog(row);
     clickRouteChoice(dialog, "BYOK: member OAuth");
-    expect(within(dialog).getByText("ChatGPT (Codex)")).toBeDefined();
+    expect(
+      within(dialog).queryByText("OAuth provider"),
+    ).not.toBeInTheDocument();
+    expect(
+      within(dialog).queryByText("ChatGPT (Codex)"),
+    ).not.toBeInTheDocument();
     expect(within(dialog).queryByRole("combobox")).not.toBeInTheDocument();
     clickDialogButton(dialog, "Save changes");
 

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-model-policies-section.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-model-policies-section.tsx
@@ -649,19 +649,6 @@ function ProviderTypeSelect({
   );
 }
 
-function ProviderTypeStatic({ type }: { type: ModelProviderType | null }) {
-  if (!type) {
-    return null;
-  }
-
-  return (
-    <div className="flex h-10 items-center gap-2 text-sm text-foreground">
-      <ProviderIcon type={type} size={16} />
-      <span>{getUILabel(type)}</span>
-    </div>
-  );
-}
-
 function buildPolicyUpdate(params: {
   policies: OrgModelPolicy[];
   model: SupportedRunModel;
@@ -995,15 +982,6 @@ function ModelPolicyRouteDialog({
                 when the team should run through one billing account or one
                 centrally managed key.
               </p>
-            </div>
-          )}
-
-          {dialog.routeKind === "oauth" && (
-            <div className="flex flex-col gap-2">
-              <label className="text-sm font-medium text-foreground">
-                OAuth provider
-              </label>
-              <ProviderTypeStatic type={selectedProviderType} />
             </div>
           )}
 


### PR DESCRIPTION
## Summary
- hide the redundant OAuth provider section after choosing BYOK member OAuth
- keep OAuth route selection behavior unchanged for Claude Code and ChatGPT Codex
- update org providers tests for the hidden dialog label

## Tests
- pnpm -C turbo/apps/platform test src/views/zero-page/components/org-manage/__tests__/org-providers-tab.test.tsx
- pnpm -C turbo/apps/platform check-types
- pre-commit: turbo check-types