### PR TITLE
fix(api): align chat message env validation

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-chat-messages.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-chat-messages.test.ts
@@ -468,6 +468,48 @@ describe("POST /api/zero/chat/messages", () => {
     );
   });
 
+  it("does not require unconfigured connector environment refs before creating a chat run", async () => {
+    const fixture = await track(seedFixture());
+    await store
+      .set(writeDb$)
+      .update(agentComposeVersions)
+      .set({
+        content: {
+          version: "1.0",
+          agents: {
+            default: {
+              framework: "claude-code",
+              environment: {
+                ANTHROPIC_API_KEY: "test-key",
+                ZERO_AGENT_ID: vm0Template("{{ vars.ZERO_AGENT_ID }}"),
+                ZERO_TOKEN: vm0Template("{{ secrets.ZERO_TOKEN }}"),
+                JIRA_EMAIL: vm0Template("{{ vars.JIRA_EMAIL }}"),
+                GITLAB_HOST: vm0Template("{{ vars.GITLAB_HOST }}"),
+                GH_TOKEN: vm0Template("{{ secrets.GH_TOKEN }}"),
+                SLACK_TOKEN: vm0Template("{{ secrets.SLACK_TOKEN }}"),
+              },
+            },
+          },
+        },
+      })
+      .where(eq(agentComposeVersions.id, fixture.versionId));
+
+    const response = await send({
+      agentId: fixture.agentId,
+      prompt: "use the default zero agent",
+    });
+    await clearAllDetached();
+
+    expect(response.body.status).toBe("pending");
+    const [run] = await store
+      .set(writeDb$)
+      .select({ id: agentRuns.id })
+      .from(agentRuns)
+      .where(eq(agentRuns.id, response.body.runId!))
+      .limit(1);
+    expect(run?.id).toBe(response.body.runId);
+  });
+
   it("preserves clientThreadId for new thread creation", async () => {
     const fixture = await track(seedFixture());
     const clientThreadId = randomUUID();

--- a/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
@@ -1898,6 +1898,7 @@ const createNormalChatRun$ = command(
         apiStartTime: args.apiStartTime,
         chatThreadId: prepared.thread.threadId,
         includeZeroTokenSecret: true,
+        validateEnvironmentReferences: false,
         callbacks: [
           {
             url: chatCallbackUrl(),


### PR DESCRIPTION
## Summary
- Skip full compose environment reference validation for API-native Zero chat sends to match the existing web chat route behavior.
- Add API route coverage for a chat compose with unconfigured connector vars/secrets so it still creates a run instead of returning 400.

## Validation
- `pnpm -C turbo install`
- `pnpm -C turbo -F api exec vitest run src/signals/routes/__tests__/zero-chat-messages.test.ts`
- `pnpm -C turbo -F api lint`
- `pnpm -C turbo -F api check-types`
- `pnpm -C turbo exec prettier --check apps/api/src/signals/routes/zero-chat-messages.ts apps/api/src/signals/routes/__tests__/zero-chat-messages.test.ts`
- pre-commit hook: `prettier`, `knip --cache`, `pnpm -C turbo check-types`
