### PR TITLE
feat(api): port Slack connect side effects

### DIFF
--- a/turbo/apps/api/src/lib/slack-connect-blocks.ts
+++ b/turbo/apps/api/src/lib/slack-connect-blocks.ts
@@ -1,4 +1,218 @@
-import type { Block, KnownBlock } from "@slack/web-api";
+import type { Block, KnownBlock, View } from "@slack/web-api";
+
+interface AppHomeViewOptions {
+  readonly appUrl: string;
+  readonly isLinked: boolean;
+  readonly vm0UserId?: string;
+  readonly userEmail?: string;
+  readonly agentName?: string;
+  readonly isOverrideActive?: boolean;
+  readonly canSwitch?: boolean;
+  readonly loginUrl?: string;
+}
+
+function appHomeIntroBlocks(): (Block | KnownBlock)[] {
+  return [
+    {
+      type: "header",
+      text: {
+        type: "plain_text",
+        text: "Welcome to Zero! :wave:",
+      },
+    },
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: "Connect your AI agents to Slack and interact with them through messages.",
+      },
+    },
+    { type: "divider" },
+  ];
+}
+
+function disconnectedAppHomeBlocks(
+  loginUrl: string | undefined,
+): (Block | KnownBlock)[] {
+  const blocks: (Block | KnownBlock)[] = [
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: ":x: *Account not connected*",
+      },
+    },
+  ];
+  if (loginUrl) {
+    blocks.push({
+      type: "actions",
+      elements: [
+        {
+          type: "button",
+          text: {
+            type: "plain_text",
+            text: "Connect",
+          },
+          url: loginUrl,
+          action_id: "home_login_prompt",
+          style: "primary",
+        },
+      ],
+    });
+  }
+  return blocks;
+}
+
+function connectedStatusBlock(options: AppHomeViewOptions): KnownBlock {
+  return {
+    type: "section",
+    text: {
+      type: "mrkdwn",
+      text: `:white_check_mark: *Connected to Zero*\nAccount: ${options.userEmail ?? options.vm0UserId}`,
+    },
+  };
+}
+
+function appHomeAgentBlocks(
+  options: AppHomeViewOptions,
+): (Block | KnownBlock)[] {
+  const agentHeading = options.isOverrideActive
+    ? ":robot_face: *Your Agent*"
+    : ":robot_face: *Workspace Agent*";
+  const blocks: (Block | KnownBlock)[] = [
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: agentHeading,
+      },
+    },
+  ];
+
+  if (!options.agentName) {
+    return [
+      ...blocks,
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: "_No agent configured yet._",
+        },
+      },
+    ];
+  }
+
+  const settingsButton = {
+    type: "button" as const,
+    text: { type: "plain_text" as const, text: "Settings" },
+    url: `${options.appUrl}/works`,
+    action_id: "home_environment_setup",
+  };
+  const agentBlock: KnownBlock = {
+    type: "section",
+    text: {
+      type: "mrkdwn",
+      text: `AgentName: *${options.agentName}*`,
+    },
+    ...(options.canSwitch ? {} : { accessory: settingsButton }),
+  };
+  blocks.push(agentBlock);
+  if (options.canSwitch) {
+    blocks.push({
+      type: "actions",
+      elements: [
+        {
+          type: "button",
+          text: { type: "plain_text", text: "Switch" },
+          action_id: "home_switch_agent",
+          style: "primary",
+        },
+        settingsButton,
+      ],
+    });
+  }
+  return blocks;
+}
+
+function appHomeHelpBlocks(): (Block | KnownBlock)[] {
+  return [
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: ":bulb: *Here are some things you can do:*",
+      },
+    },
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: "*Commands*\n\u2022 `/zero connect` - Connect to Zero\n\u2022 `/zero disconnect` - Disconnect from Zero",
+      },
+    },
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: "*Usage*\nSend a DM or `@Zero` in any channel to chat with your agents",
+      },
+    },
+  ];
+}
+
+function disconnectAccountBlock(): KnownBlock {
+  return {
+    type: "section",
+    text: {
+      type: "mrkdwn",
+      text: "*Disconnect Zero Account*\nThis will remove your Zero account connection",
+    },
+    accessory: {
+      type: "button",
+      text: {
+        type: "plain_text",
+        text: "Disconnect",
+      },
+      action_id: "home_disconnect",
+      style: "danger",
+      confirm: {
+        title: { type: "plain_text", text: "Disconnect Zero Account" },
+        text: {
+          type: "plain_text",
+          text: "This will remove your Zero account connection",
+        },
+        confirm: { type: "plain_text", text: "Disconnect" },
+        deny: { type: "plain_text", text: "Cancel" },
+      },
+    },
+  };
+}
+
+export function buildAppHomeView(options: AppHomeViewOptions): View {
+  const blocks = appHomeIntroBlocks();
+
+  if (!options.isLinked) {
+    return {
+      type: "home",
+      blocks: [...blocks, ...disconnectedAppHomeBlocks(options.loginUrl)],
+    };
+  }
+
+  blocks.push(
+    connectedStatusBlock(options),
+    { type: "divider" },
+    ...appHomeAgentBlocks(options),
+    { type: "divider" },
+    ...appHomeHelpBlocks(),
+    { type: "divider" },
+    disconnectAccountBlock(),
+  );
+
+  return {
+    type: "home",
+    blocks,
+  };
+}
 
 export function buildWelcomeMessage(
   agentName?: string,

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-slack-connect.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-slack-connect.ts
@@ -3,7 +3,8 @@ import { randomUUID } from "node:crypto";
 import { command } from "ccstate";
 import { slackOrgConnections } from "@vm0/db/schema/slack-org-connection";
 import { slackOrgInstallations } from "@vm0/db/schema/slack-org-installation";
-import { and, eq } from "drizzle-orm";
+import { storageVersions, storages } from "@vm0/db/schema/storage";
+import { and, eq, inArray } from "drizzle-orm";
 
 import { writeDb$ } from "../../../external/db";
 import { encryptSecretForTests } from "./encrypt-secret";
@@ -108,6 +109,49 @@ export const findSlackOrgInstallation$ = command(
   },
 );
 
+export const findArtifactStorage$ = command(
+  async (
+    { set },
+    values: {
+      readonly orgId: string;
+      readonly userId: string;
+    },
+    signal: AbortSignal,
+  ): Promise<
+    | {
+        readonly id: string;
+        readonly headVersionId: string | null;
+        readonly s3Prefix: string;
+        readonly versionId: string | null;
+        readonly versionS3Key: string | null;
+      }
+    | undefined
+  > => {
+    const writeDb = set(writeDb$);
+    const [storage] = await writeDb
+      .select({
+        id: storages.id,
+        headVersionId: storages.headVersionId,
+        s3Prefix: storages.s3Prefix,
+        versionId: storageVersions.id,
+        versionS3Key: storageVersions.s3Key,
+      })
+      .from(storages)
+      .leftJoin(storageVersions, eq(storages.headVersionId, storageVersions.id))
+      .where(
+        and(
+          eq(storages.orgId, values.orgId),
+          eq(storages.userId, values.userId),
+          eq(storages.name, "artifact"),
+          eq(storages.type, "artifact"),
+        ),
+      )
+      .limit(1);
+    signal.throwIfAborted();
+    return storage;
+  },
+);
+
 export const deleteSlackConnectOrg$ = command(
   async (
     { set },
@@ -115,6 +159,33 @@ export const deleteSlackConnectOrg$ = command(
     signal: AbortSignal,
   ): Promise<void> => {
     const writeDb = set(writeDb$);
+    const storageRows = await writeDb
+      .select({ id: storages.id })
+      .from(storages)
+      .where(
+        and(
+          eq(storages.orgId, fixture.orgId),
+          eq(storages.userId, fixture.userId),
+        ),
+      );
+    signal.throwIfAborted();
+    const storageIds = storageRows.map((storage) => {
+      return storage.id;
+    });
+    if (storageIds.length > 0) {
+      await writeDb
+        .update(storages)
+        .set({ headVersionId: null })
+        .where(inArray(storages.id, storageIds));
+      signal.throwIfAborted();
+      await writeDb
+        .delete(storageVersions)
+        .where(inArray(storageVersions.storageId, storageIds));
+      signal.throwIfAborted();
+      await writeDb.delete(storages).where(inArray(storages.id, storageIds));
+      signal.throwIfAborted();
+    }
+
     await writeDb
       .delete(slackOrgConnections)
       .where(

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-slack-connect.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-slack-connect.test.ts
@@ -12,6 +12,7 @@ import {
 } from "./helpers/zero-route-test";
 import {
   deleteSlackConnectOrg$,
+  findArtifactStorage$,
   findSlackOrgConnection$,
   findSlackOrgInstallation$,
   seedSlackConnectOrg$,
@@ -22,6 +23,38 @@ const context = testContext();
 const store = createStore();
 const mocks = createZeroRouteMocks(context);
 const SLACK_CONNECT_PATH = "/api/zero/integrations/slack/connect";
+
+function userIdsFromClerkListArgs(args: unknown): readonly string[] {
+  if (typeof args !== "object" || args === null || !("userId" in args)) {
+    return [];
+  }
+  const userId = args.userId;
+  if (
+    !Array.isArray(userId) ||
+    !userId.every((candidate) => {
+      return typeof candidate === "string";
+    })
+  ) {
+    return [];
+  }
+  return userId;
+}
+
+function mockClerkUsersById(): void {
+  context.mocks.clerk.users.getUserList.mockImplementation((args: unknown) => {
+    return Promise.resolve({
+      data: userIdsFromClerkListArgs(args).map((userId) => {
+        return {
+          id: userId,
+          emailAddresses: [
+            { id: `email_${userId}`, emailAddress: `${userId}@example.com` },
+          ],
+          primaryEmailAddressId: `email_${userId}`,
+        };
+      }),
+    });
+  });
+}
 
 async function postRawSlackConnect(body: string): Promise<{
   readonly status: number;
@@ -191,6 +224,8 @@ describe("POST /api/zero/integrations/slack/connect", () => {
       ok: true,
       message_ts: "mock.ephemeral.ts",
     });
+    context.mocks.slack.views.publish.mockResolvedValue({ ok: true });
+    mockClerkUsersById();
   });
 
   it("returns 401 when not authenticated", async () => {
@@ -325,6 +360,59 @@ describe("POST /api/zero/integrations/slack/connect", () => {
     expect(response.body.role).toBe("admin");
   });
 
+  it("creates artifact storage with an initial empty version after connect", async () => {
+    const fixture = await track(
+      store.set(seedSlackConnectOrg$, {}, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+
+    const client = setupApp({ context })(zeroSlackConnectContract);
+    await accept(
+      client.connect({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          workspaceId: fixture.slackWorkspaceId,
+          slackUserId: fixture.slackUserId,
+        },
+      }),
+      [200],
+    );
+    await clearAllDetached();
+
+    const artifactStorage = await store.set(
+      findArtifactStorage$,
+      { orgId: fixture.orgId, userId: fixture.userId },
+      context.signal,
+    );
+
+    expect(artifactStorage).toMatchObject({
+      s3Prefix: `${fixture.orgId}/artifact/artifact`,
+      headVersionId: expect.any(String),
+      versionId: expect.any(String),
+    });
+    expect(artifactStorage?.versionS3Key).toBe(
+      `${fixture.orgId}/artifact/artifact/${artifactStorage?.versionId}`,
+    );
+    expect(context.mocks.s3.send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        input: expect.objectContaining({
+          Bucket: "test-user-storages",
+          Key: `${artifactStorage?.versionS3Key}/manifest.json`,
+          ContentType: "application/json",
+        }),
+      }),
+    );
+    expect(context.mocks.s3.send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        input: expect.objectContaining({
+          Bucket: "test-user-storages",
+          Key: `${artifactStorage?.versionS3Key}/archive.tar.gz`,
+          ContentType: "application/gzip",
+        }),
+      }),
+    );
+  });
+
   it("sends an ephemeral Slack confirmation when channel context is provided", async () => {
     const fixture = await track(
       store.set(seedSlackConnectOrg$, {}, context.signal),
@@ -356,6 +444,22 @@ describe("POST /api/zero/integrations/slack/connect", () => {
       }),
     );
     expect(context.mocks.slack.chat.postMessage).not.toHaveBeenCalled();
+    expect(context.mocks.slack.views.publish).toHaveBeenCalledWith(
+      expect.objectContaining({
+        user_id: fixture.slackUserId,
+        view: expect.objectContaining({
+          type: "home",
+          blocks: expect.arrayContaining([
+            expect.objectContaining({
+              type: "section",
+              text: expect.objectContaining({
+                text: expect.stringContaining("*Connected to Zero*"),
+              }),
+            }),
+          ]),
+        }),
+      }),
+    );
 
     const connection = await store.set(
       findSlackOrgConnection$,

--- a/turbo/apps/api/src/signals/routes/zero-slack-browser-connect.ts
+++ b/turbo/apps/api/src/signals/routes/zero-slack-browser-connect.ts
@@ -139,6 +139,7 @@ const browserConnect$ = command(async ({ get, set }, signal: AbortSignal) => {
       {
         installation: result.installation,
         slackUserId: result.slackUserId,
+        orgId,
         channelId: result.channelId,
         threadTs: result.threadTs,
       },

--- a/turbo/apps/api/src/signals/routes/zero-slack-connect.ts
+++ b/turbo/apps/api/src/signals/routes/zero-slack-connect.ts
@@ -86,6 +86,7 @@ const connectInner$ = command(async ({ get, set }, signal: AbortSignal) => {
       {
         installation: result.installation,
         slackUserId: result.slackUserId,
+        orgId: auth.orgId,
         channelId: result.channelId,
         threadTs: result.threadTs,
       },

--- a/turbo/apps/api/src/signals/routes/zero-slack-oauth.ts
+++ b/turbo/apps/api/src/signals/routes/zero-slack-oauth.ts
@@ -226,26 +226,30 @@ const connectOauth$ = command(async ({ get }, signal: AbortSignal) => {
   return noStoreRedirect(authUrl.toString());
 });
 
-function notifyAfterConnect(
-  set: <T, TArgs extends unknown[]>(
-    command: import("ccstate").Command<T, TArgs>,
-    ...args: TArgs
-  ) => T,
-  installation: SlackInstallation,
-  slackUserId: string,
-  pendingPrompt: string | null,
-  signal: AbortSignal,
-): void {
+type CommandSetter = <T, TArgs extends unknown[]>(
+  command: import("ccstate").Command<T, TArgs>,
+  ...args: TArgs
+) => T;
+
+function notifyAfterConnect(args: {
+  readonly set: CommandSetter;
+  readonly installation: SlackInstallation;
+  readonly slackUserId: string;
+  readonly orgId: string;
+  readonly pendingPrompt: string | null;
+  readonly signal: AbortSignal;
+}): void {
   waitUntil(
     Promise.resolve(
-      set(
+      args.set(
         notifySlackConnect$,
         {
-          installation,
-          slackUserId,
-          ...(pendingPrompt ? { pendingPrompt } : {}),
+          installation: args.installation,
+          slackUserId: args.slackUserId,
+          orgId: args.orgId,
+          ...(args.pendingPrompt ? { pendingPrompt: args.pendingPrompt } : {}),
         },
-        signal,
+        args.signal,
       ),
     ).catch((error: unknown) => {
       L.warn("Failed to notify connect success", { error });
@@ -302,13 +306,14 @@ async function handlePlatformInstall(args: {
     .onConflictDoNothing();
   args.signal.throwIfAborted();
 
-  await notifyAfterConnect(
-    args.set,
-    args.installation,
-    args.authedUserId,
-    args.state.prompt,
-    args.signal,
-  );
+  notifyAfterConnect({
+    set: args.set,
+    installation: args.installation,
+    slackUserId: args.authedUserId,
+    orgId: args.state.orgId,
+    pendingPrompt: args.state.prompt,
+    signal: args.signal,
+  });
 
   if (args.isReinstall && args.state.reinstall) {
     return redirectResponse(appUrl("/?tab=works&updated=1"));
@@ -529,13 +534,14 @@ async function handleConnectCallback(args: {
   );
   args.signal.throwIfAborted();
 
-  await notifyAfterConnect(
-    args.set,
+  notifyAfterConnect({
+    set: args.set,
     installation,
-    exchange.ok.authedUserId,
-    args.state.prompt,
-    args.signal,
-  );
+    slackUserId: exchange.ok.authedUserId,
+    orgId: args.state.orgId,
+    pendingPrompt: args.state.prompt,
+    signal: args.signal,
+  });
 
   return redirectResponse(
     appUrl(

--- a/turbo/apps/api/src/signals/services/agent-run-storage.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-storage.service.ts
@@ -327,6 +327,17 @@ async function ensureArtifactStorage(args: {
   });
 }
 
+export async function ensureUserArtifactStorage(args: {
+  readonly get: Getter;
+  readonly db: Db;
+  readonly orgId: string;
+  readonly userId: string;
+  readonly name: string;
+  readonly bucket: string;
+}): Promise<void> {
+  await ensureArtifactStorage(args);
+}
+
 async function resolveLatestVersion(
   db: Db,
   lookup: StorageLookup,

--- a/turbo/apps/api/src/signals/services/zero-slack-connect.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-slack-connect.service.ts
@@ -4,13 +4,17 @@ import { orgMembersCache } from "@vm0/db/schema/org-members-cache";
 import { orgMetadata } from "@vm0/db/schema/org-metadata";
 import { slackOrgConnections } from "@vm0/db/schema/slack-org-connection";
 import { slackOrgInstallations } from "@vm0/db/schema/slack-org-installation";
+import { slackUserAgentPreferences } from "@vm0/db/schema/slack-user-agent-preference";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
 import { and, eq, isNull } from "drizzle-orm";
 
 import {
+  buildAppHomeView,
   buildSuccessMessage,
   buildWelcomeMessage,
 } from "../../lib/slack-connect-blocks";
+import { env } from "../../lib/env";
+import { clerk$ } from "../external/clerk";
 import { publishUserSignal } from "../external/realtime";
 import {
   createSlackClient,
@@ -19,9 +23,11 @@ import {
 } from "../external/slack-message-client";
 import { nowDate } from "../external/time";
 import { db$, writeDb$, type Db } from "../external/db";
+import { ensureUserArtifactStorage } from "./agent-run-storage.service";
 import { decryptSecretValue } from "./crypto.utils";
 
 type SlackInstallation = typeof slackOrgInstallations.$inferSelect;
+type SlackClient = ReturnType<typeof createSlackClient>;
 
 type ConnectResult =
   | { readonly kind: "not_found"; readonly message: string }
@@ -82,6 +88,171 @@ async function upsertSlackConnection(
   }
 
   return existing.id;
+}
+
+async function resolveDefaultComposeId(
+  db: Db,
+  orgId: string,
+): Promise<string | null> {
+  const [metadata] = await db
+    .select({ defaultAgentId: orgMetadata.defaultAgentId })
+    .from(orgMetadata)
+    .where(eq(orgMetadata.orgId, orgId))
+    .limit(1);
+  return metadata?.defaultAgentId ?? null;
+}
+
+async function getUserAgentPreference(
+  db: Db,
+  vm0UserId: string,
+  orgId: string,
+): Promise<string | null> {
+  const [preference] = await db
+    .select({ selectedComposeId: slackUserAgentPreferences.selectedComposeId })
+    .from(slackUserAgentPreferences)
+    .where(
+      and(
+        eq(slackUserAgentPreferences.vm0UserId, vm0UserId),
+        eq(slackUserAgentPreferences.orgId, orgId),
+      ),
+    )
+    .limit(1);
+  return preference?.selectedComposeId ?? null;
+}
+
+async function resolveEffectiveComposeId(
+  db: Db,
+  vm0UserId: string,
+  orgId: string,
+): Promise<string | null> {
+  const override = await getUserAgentPreference(db, vm0UserId, orgId);
+  if (override) {
+    const [agent] = await db
+      .select({ id: zeroAgents.id })
+      .from(zeroAgents)
+      .where(and(eq(zeroAgents.id, override), eq(zeroAgents.orgId, orgId)))
+      .limit(1);
+    if (agent?.id) {
+      return override;
+    }
+  }
+  return resolveDefaultComposeId(db, orgId);
+}
+
+async function getWorkspaceAgentName(
+  db: Db,
+  composeId: string,
+): Promise<string | undefined> {
+  const [agent] = await db
+    .select({ name: zeroAgents.name, displayName: zeroAgents.displayName })
+    .from(zeroAgents)
+    .where(eq(zeroAgents.id, composeId))
+    .limit(1);
+  return agent?.displayName ?? agent?.name;
+}
+
+async function getPrimaryUserEmail(
+  clerkClient: ReturnType<typeof clerk$.read>,
+  userId: string,
+): Promise<string | undefined> {
+  const users = await clerkClient.users.getUserList({ userId: [userId] });
+  const user = users.data.find((candidate) => {
+    return candidate.id === userId;
+  });
+  const primaryEmailAddressId = user?.primaryEmailAddressId;
+  const email = user?.emailAddresses.find((candidate) => {
+    return candidate.id === primaryEmailAddressId;
+  });
+  return email?.emailAddress;
+}
+
+function buildSlackConnectUrl(
+  workspaceId: string,
+  slackUserId: string,
+): string {
+  const params = new URLSearchParams({ w: workspaceId, u: slackUserId });
+  return `${env("VM0_WEB_URL")}/settings/slack?${params.toString()}`;
+}
+
+async function refreshSlackAppHome(args: {
+  readonly db: Db;
+  readonly clerkClient: ReturnType<typeof clerk$.read>;
+  readonly client: SlackClient;
+  readonly installation: SlackInstallation;
+  readonly slackUserId: string;
+}): Promise<void> {
+  const [connection] = await args.db
+    .select()
+    .from(slackOrgConnections)
+    .where(
+      and(
+        eq(slackOrgConnections.slackUserId, args.slackUserId),
+        eq(
+          slackOrgConnections.slackWorkspaceId,
+          args.installation.slackWorkspaceId,
+        ),
+      ),
+    )
+    .limit(1);
+
+  if (!connection) {
+    await args.client.views.publish({
+      user_id: args.slackUserId,
+      view: buildAppHomeView({
+        appUrl: env("VM0_WEB_URL"),
+        isLinked: false,
+        loginUrl: buildSlackConnectUrl(
+          args.installation.slackWorkspaceId,
+          args.slackUserId,
+        ),
+      }),
+    });
+    return;
+  }
+
+  let agentName: string | undefined;
+  let isOverrideActive = false;
+  let canSwitch = false;
+  if (args.installation.orgId) {
+    const [effectiveComposeId, overrideComposeId, defaultComposeId] =
+      await Promise.all([
+        resolveEffectiveComposeId(
+          args.db,
+          connection.vm0UserId,
+          args.installation.orgId,
+        ),
+        getUserAgentPreference(
+          args.db,
+          connection.vm0UserId,
+          args.installation.orgId,
+        ),
+        resolveDefaultComposeId(args.db, args.installation.orgId),
+      ]);
+
+    if (effectiveComposeId) {
+      agentName = await getWorkspaceAgentName(args.db, effectiveComposeId);
+    }
+    isOverrideActive = Boolean(
+      overrideComposeId && overrideComposeId !== defaultComposeId,
+    );
+    canSwitch = Boolean(defaultComposeId);
+  }
+
+  await args.client.views.publish({
+    user_id: args.slackUserId,
+    view: buildAppHomeView({
+      appUrl: env("VM0_WEB_URL"),
+      isLinked: true,
+      vm0UserId: connection.vm0UserId,
+      userEmail: await getPrimaryUserEmail(
+        args.clerkClient,
+        connection.vm0UserId,
+      ),
+      agentName,
+      isOverrideActive,
+      canSwitch,
+    }),
+  });
 }
 
 export function zeroSlackConnectStatus(args: {
@@ -150,7 +321,7 @@ export function zeroSlackConnectStatus(args: {
 
 export const connectSlackWorkspace$ = command(
   async (
-    { set },
+    { get, set },
     args: {
       readonly userId: string;
       readonly orgId: string;
@@ -220,6 +391,16 @@ export const connectSlackWorkspace$ = command(
       });
       signal.throwIfAborted();
 
+      await ensureUserArtifactStorage({
+        get,
+        db: writeDb,
+        orgId: args.orgId,
+        userId: args.userId,
+        name: "artifact",
+        bucket: env("R2_USER_STORAGES_BUCKET_NAME"),
+      });
+      signal.throwIfAborted();
+
       return {
         kind: "ok",
         connectionId,
@@ -239,6 +420,16 @@ export const connectSlackWorkspace$ = command(
       slackUserId: args.slackUserId,
       slackWorkspaceId: args.workspaceId,
       vm0UserId: args.userId,
+    });
+    signal.throwIfAborted();
+
+    await ensureUserArtifactStorage({
+      get,
+      db: writeDb,
+      orgId: args.orgId,
+      userId: args.userId,
+      name: "artifact",
+      bucket: env("R2_USER_STORAGES_BUCKET_NAME"),
     });
     signal.throwIfAborted();
 
@@ -289,10 +480,11 @@ export const publishSlackAdminSignal$ = command(
 
 export const notifySlackConnect$ = command(
   async (
-    { set },
+    { get, set },
     args: {
       readonly installation: SlackInstallation;
       readonly slackUserId: string;
+      readonly orgId: string;
       readonly channelId?: string;
       readonly threadTs?: string;
       readonly pendingPrompt?: string;
@@ -303,6 +495,13 @@ export const notifySlackConnect$ = command(
     const client = createSlackClient(
       decryptSecretValue(args.installation.encryptedBotToken),
     );
+    const defaultComposeId = await resolveDefaultComposeId(writeDb, args.orgId);
+    signal.throwIfAborted();
+    const agentName = defaultComposeId
+      ? await getWorkspaceAgentName(writeDb, defaultComposeId)
+      : undefined;
+    signal.throwIfAborted();
+
     const blocks = buildSuccessMessage(
       "You're connected! :tada:\nMention `@Zero` in any channel or send a DM to start chatting with your agent.",
     );
@@ -322,50 +521,55 @@ export const notifySlackConnect$ = command(
       sentEphemeral = result.kind === "ok";
     }
 
-    if (sentEphemeral) {
-      return;
-    }
-
-    const connectMessage = await postMessage(
-      client,
-      args.slackUserId,
-      "You're connected!",
-      { blocks },
-    );
-    signal.throwIfAborted();
-    if (connectMessage.kind !== "ok") {
-      return;
-    }
-
-    await postMessage(client, args.slackUserId, "Hi! I'm Zero.", {
-      threadTs: connectMessage.ts,
-      blocks: buildWelcomeMessage(),
-    });
-    signal.throwIfAborted();
-
-    if (args.pendingPrompt) {
-      const safePrompt = `\`\`\`${args.pendingPrompt.replaceAll("`", "'")}\`\`\``;
-      await postMessage(
+    if (!sentEphemeral) {
+      const connectMessage = await postMessage(
         client,
         args.slackUserId,
-        `By the way, would you like me to run this for you?\n\n${safePrompt}\n\nJust paste it in a message and I'll get started!`,
-        { threadTs: connectMessage.ts },
+        "You're connected!",
+        { blocks },
       );
       signal.throwIfAborted();
+      if (connectMessage.kind === "ok") {
+        await postMessage(client, args.slackUserId, "Hi! I'm Zero.", {
+          threadTs: connectMessage.ts,
+          blocks: buildWelcomeMessage(agentName),
+        });
+        signal.throwIfAborted();
+
+        if (args.pendingPrompt) {
+          const safePrompt = `\`\`\`${args.pendingPrompt.replaceAll("`", "'")}\`\`\``;
+          await postMessage(
+            client,
+            args.slackUserId,
+            `By the way, would you like me to run this for you?\n\n${safePrompt}\n\nJust paste it in a message and I'll get started!`,
+            { threadTs: connectMessage.ts },
+          );
+          signal.throwIfAborted();
+        }
+
+        await writeDb
+          .update(slackOrgConnections)
+          .set({ dmWelcomeSent: true })
+          .where(
+            and(
+              eq(slackOrgConnections.slackUserId, args.slackUserId),
+              eq(
+                slackOrgConnections.slackWorkspaceId,
+                args.installation.slackWorkspaceId,
+              ),
+            ),
+          );
+        signal.throwIfAborted();
+      }
     }
 
-    await writeDb
-      .update(slackOrgConnections)
-      .set({ dmWelcomeSent: true })
-      .where(
-        and(
-          eq(slackOrgConnections.slackUserId, args.slackUserId),
-          eq(
-            slackOrgConnections.slackWorkspaceId,
-            args.installation.slackWorkspaceId,
-          ),
-        ),
-      );
+    await refreshSlackAppHome({
+      db: writeDb,
+      clerkClient: get(clerk$),
+      client,
+      installation: args.installation,
+      slackUserId: args.slackUserId,
+    });
     signal.throwIfAborted();
   },
 );


### PR DESCRIPTION
## Summary
- create the user artifact storage and initial empty version from the API Slack connect command
- refresh Slack App Home after API Slack connect notifications, including connected agent state
- cover artifact-storage and App Home side effects in route tests

Fixes #12794

## Tests
- pnpm --dir turbo --filter api lint
- pnpm --dir turbo --filter api check-types
- pnpm --dir turbo --filter api test
- pnpm --dir turbo --filter web run db:reset (local DB schema sync before full api test)
- git diff --check