### PR TITLE
fix: log Codex JSONL failure diagnostics

### DIFF
--- a/crates/guest-agent/src/cli.rs
+++ b/crates/guest-agent/src/cli.rs
@@ -125,6 +125,10 @@ impl CliFrameworkBehavior {
             }
         }
     }
+
+    fn logs_codex_failure_diagnostics(self) -> bool {
+        matches!(self.framework, env::Framework::Codex)
+    }
 }
 
 async fn tick_optional_interval(interval: &mut Option<tokio::time::Interval>) {
@@ -760,6 +764,17 @@ pub async fn execute_cli(
                             }
                             // Extract tool info BEFORE masking (masker may replace tool names).
                             behavior.track_claude_tool_events(&event, &mut stuck_tool_tracker);
+                            if behavior.logs_codex_failure_diagnostics()
+                                && let Some(diagnostic) =
+                                    events::masked_codex_failure_diagnostic(&event, masker)
+                            {
+                                log_warn!(
+                                    LOG_TAG,
+                                    "Codex JSONL failure event seq={seq} type={}: {}",
+                                    diagnostic.event_type,
+                                    diagnostic.message
+                                );
+                            }
                             // Prepare event (fast: mask secrets, add seq) and enqueue
                             // for background sending.  Never blocks the reading loop.
                             if let Some(payload) = events::prepare_event(&mut event, seq, masker)

--- a/crates/guest-agent/src/events.rs
+++ b/crates/guest-agent/src/events.rs
@@ -16,6 +16,7 @@ use serde_json::{Value, json};
 
 const LOG_TAG: &str = "sandbox:guest-agent";
 const CODEX_FAILURE_DIAGNOSTIC_MAX_BYTES: usize = 4096;
+const CODEX_FAILURE_DIAGNOSTIC_TRUNCATED_SUFFIX: &str = "...[truncated]";
 
 #[derive(Debug, PartialEq, Eq)]
 pub(crate) struct CodexFailureDiagnostic {
@@ -79,28 +80,18 @@ pub(crate) fn masked_codex_failure_diagnostic(
     event: &Value,
     masker: &SecretMasker,
 ) -> Option<CodexFailureDiagnostic> {
-    if !is_codex_failure_event_type(event) {
-        return None;
-    }
-
-    let mut masked_event = event.clone();
-    masker.mask_value(&mut masked_event);
-    extract_codex_failure_diagnostic(&masked_event)
-}
-
-fn is_codex_failure_event_type(event: &Value) -> bool {
-    match event.get("type").and_then(Value::as_str) {
-        Some("error" | "turn.failed") => true,
-        Some("turn.completed") => codex_turn_completed_failure_status(event).is_some(),
-        _ => false,
-    }
+    let diagnostic = extract_codex_failure_diagnostic(event)?;
+    Some(CodexFailureDiagnostic {
+        event_type: diagnostic.event_type,
+        message: mask_and_truncate_diagnostic(&diagnostic.message, masker),
+    })
 }
 
 fn extract_codex_failure_diagnostic(event: &Value) -> Option<CodexFailureDiagnostic> {
     match event.get("type").and_then(Value::as_str)? {
         "error" => Some(CodexFailureDiagnostic {
             event_type: "error",
-            message: message_from_field(event.get("message"))
+            message: raw_message_from_field(event.get("message"))
                 .or_else(|| codex_error_message(event.get("error")))
                 .unwrap_or_else(|| "error".into()),
         }),
@@ -137,7 +128,7 @@ fn codex_turn_completed_failure_status(event: &Value) -> Option<&'static str> {
 
 fn codex_error_message(error: Option<&Value>) -> Option<String> {
     let error = error?;
-    if let Some(message) = message_from_field(Some(error)) {
+    if let Some(message) = raw_message_from_field(Some(error)) {
         return Some(message);
     }
 
@@ -146,33 +137,33 @@ fn codex_error_message(error: Option<&Value>) -> Option<String> {
     combined_message_and_details(message, details)
 }
 
-fn message_from_field(value: Option<&Value>) -> Option<String> {
-    value
-        .and_then(Value::as_str)
-        .and_then(normalized_diagnostic_message)
+fn raw_message_from_field(value: Option<&Value>) -> Option<String> {
+    value.and_then(Value::as_str).and_then(trimmed_message)
 }
 
 fn combined_message_and_details(message: Option<&str>, details: Option<&str>) -> Option<String> {
     match (
-        message.and_then(normalized_diagnostic_message),
-        details.and_then(normalized_diagnostic_message),
+        message.and_then(trimmed_message),
+        details.and_then(trimmed_message),
     ) {
-        (Some(message), Some(details)) => Some(truncate_diagnostic_message(&format!(
-            "{message} ({details})"
-        ))),
+        (Some(message), Some(details)) => Some(format!("{message} ({details})")),
         (Some(message), None) => Some(message),
         (None, Some(details)) => Some(details),
         (None, None) => None,
     }
 }
 
-fn normalized_diagnostic_message(message: &str) -> Option<String> {
+fn trimmed_message(message: &str) -> Option<String> {
     let message = message.trim();
     if message.is_empty() {
         return None;
     }
 
-    Some(truncate_diagnostic_message(message))
+    Some(message.to_string())
+}
+
+fn mask_and_truncate_diagnostic(message: &str, masker: &SecretMasker) -> String {
+    truncate_diagnostic_message(&masker.mask_string(message))
 }
 
 fn truncate_diagnostic_message(message: &str) -> String {
@@ -180,11 +171,16 @@ fn truncate_diagnostic_message(message: &str) -> String {
         return message.to_string();
     }
 
-    let mut end = CODEX_FAILURE_DIAGNOSTIC_MAX_BYTES;
+    let mut end =
+        CODEX_FAILURE_DIAGNOSTIC_MAX_BYTES - CODEX_FAILURE_DIAGNOSTIC_TRUNCATED_SUFFIX.len();
     while !message.is_char_boundary(end) {
         end -= 1;
     }
-    format!("{}...[truncated]", &message[..end])
+    format!(
+        "{}{}",
+        &message[..end],
+        CODEX_FAILURE_DIAGNOSTIC_TRUNCATED_SUFFIX
+    )
 }
 
 /// POST a prepared event payload to the webhook endpoint.
@@ -609,6 +605,49 @@ mod tests {
                 event_type: "error",
                 message: "request failed with token ***".to_string(),
             })
+        );
+    }
+
+    #[test]
+    fn codex_failure_diagnostic_masks_before_truncating() {
+        let prefix = "x".repeat(
+            CODEX_FAILURE_DIAGNOSTIC_MAX_BYTES
+                - CODEX_FAILURE_DIAGNOSTIC_TRUNCATED_SUFFIX.len()
+                - "super".len(),
+        );
+        let event = serde_json::json!({
+            "type": "error",
+            "message": format!("{prefix}supersecret after-boundary")
+        });
+        let masker = SecretMasker::from_raw("c3VwZXJzZWNyZXQ=");
+        let diagnostic = masked_codex_failure_diagnostic(&event, &masker)
+            .expect("error event should produce a diagnostic");
+
+        assert!(
+            diagnostic.message.contains("***"),
+            "diagnostic should keep the masked token marker: {diagnostic:?}"
+        );
+        assert!(
+            !diagnostic.message.contains("super"),
+            "diagnostic should not leak a partial secret near the truncation boundary: {diagnostic:?}"
+        );
+    }
+
+    #[test]
+    fn codex_failure_diagnostic_truncates_to_max_bytes() {
+        let event = serde_json::json!({
+            "type": "error",
+            "message": "x".repeat(CODEX_FAILURE_DIAGNOSTIC_MAX_BYTES + 100)
+        });
+        let diagnostic = masked_codex_failure_diagnostic(&event, &SecretMasker::from_raw(""))
+            .expect("error event should produce a diagnostic");
+
+        assert_eq!(diagnostic.message.len(), CODEX_FAILURE_DIAGNOSTIC_MAX_BYTES);
+        assert!(
+            diagnostic
+                .message
+                .ends_with(CODEX_FAILURE_DIAGNOSTIC_TRUNCATED_SUFFIX),
+            "diagnostic should end with truncation marker: {diagnostic:?}"
         );
     }
 

--- a/crates/guest-agent/src/events.rs
+++ b/crates/guest-agent/src/events.rs
@@ -15,6 +15,13 @@ use guest_common::{log_error, log_info};
 use serde_json::{Value, json};
 
 const LOG_TAG: &str = "sandbox:guest-agent";
+const CODEX_FAILURE_DIAGNOSTIC_MAX_BYTES: usize = 4096;
+
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct CodexFailureDiagnostic {
+    pub event_type: &'static str,
+    pub message: String,
+}
 
 /// Send a single event to the webhook, masking secrets first.
 ///
@@ -60,6 +67,124 @@ pub fn prepare_event(event: &mut Value, seq: u32, masker: &SecretMasker) -> Opti
         "runId": env::run_id(),
         "events": [event],
     }))
+}
+
+/// Extract a secret-masked Codex failure diagnostic from stdout JSONL.
+///
+/// Codex reports terminal failures on stdout JSONL (`type=error` or
+/// `type=turn.failed`), while the guest-agent process failure summary is built
+/// from stderr. Logging these events into the system log preserves the real
+/// failure reason when stderr only contains side-channel background-task noise.
+pub(crate) fn masked_codex_failure_diagnostic(
+    event: &Value,
+    masker: &SecretMasker,
+) -> Option<CodexFailureDiagnostic> {
+    if !is_codex_failure_event_type(event) {
+        return None;
+    }
+
+    let mut masked_event = event.clone();
+    masker.mask_value(&mut masked_event);
+    extract_codex_failure_diagnostic(&masked_event)
+}
+
+fn is_codex_failure_event_type(event: &Value) -> bool {
+    match event.get("type").and_then(Value::as_str) {
+        Some("error" | "turn.failed") => true,
+        Some("turn.completed") => codex_turn_completed_failure_status(event).is_some(),
+        _ => false,
+    }
+}
+
+fn extract_codex_failure_diagnostic(event: &Value) -> Option<CodexFailureDiagnostic> {
+    match event.get("type").and_then(Value::as_str)? {
+        "error" => Some(CodexFailureDiagnostic {
+            event_type: "error",
+            message: message_from_field(event.get("message"))
+                .or_else(|| codex_error_message(event.get("error")))
+                .unwrap_or_else(|| "error".into()),
+        }),
+        "turn.failed" => Some(CodexFailureDiagnostic {
+            event_type: "turn.failed",
+            message: codex_error_message(event.get("error"))
+                .unwrap_or_else(|| "turn failed".into()),
+        }),
+        "turn.completed" => {
+            let status = codex_turn_completed_failure_status(event)?;
+            Some(CodexFailureDiagnostic {
+                event_type: "turn.completed",
+                message: codex_error_message(
+                    event.pointer("/turn/error").or_else(|| event.get("error")),
+                )
+                .unwrap_or_else(|| format!("turn {status}")),
+            })
+        }
+        _ => None,
+    }
+}
+
+fn codex_turn_completed_failure_status(event: &Value) -> Option<&'static str> {
+    let status = event
+        .pointer("/turn/status")
+        .or_else(|| event.get("status"))
+        .and_then(Value::as_str)?;
+    match status {
+        "failed" | "Failed" => Some("failed"),
+        "interrupted" | "Interrupted" => Some("interrupted"),
+        _ => None,
+    }
+}
+
+fn codex_error_message(error: Option<&Value>) -> Option<String> {
+    let error = error?;
+    if let Some(message) = message_from_field(Some(error)) {
+        return Some(message);
+    }
+
+    let message = error.get("message").and_then(Value::as_str);
+    let details = error.get("additional_details").and_then(Value::as_str);
+    combined_message_and_details(message, details)
+}
+
+fn message_from_field(value: Option<&Value>) -> Option<String> {
+    value
+        .and_then(Value::as_str)
+        .and_then(normalized_diagnostic_message)
+}
+
+fn combined_message_and_details(message: Option<&str>, details: Option<&str>) -> Option<String> {
+    match (
+        message.and_then(normalized_diagnostic_message),
+        details.and_then(normalized_diagnostic_message),
+    ) {
+        (Some(message), Some(details)) => Some(truncate_diagnostic_message(&format!(
+            "{message} ({details})"
+        ))),
+        (Some(message), None) => Some(message),
+        (None, Some(details)) => Some(details),
+        (None, None) => None,
+    }
+}
+
+fn normalized_diagnostic_message(message: &str) -> Option<String> {
+    let message = message.trim();
+    if message.is_empty() {
+        return None;
+    }
+
+    Some(truncate_diagnostic_message(message))
+}
+
+fn truncate_diagnostic_message(message: &str) -> String {
+    if message.len() <= CODEX_FAILURE_DIAGNOSTIC_MAX_BYTES {
+        return message.to_string();
+    }
+
+    let mut end = CODEX_FAILURE_DIAGNOSTIC_MAX_BYTES;
+    while !message.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!("{}...[truncated]", &message[..end])
 }
 
 /// POST a prepared event payload to the webhook endpoint.
@@ -347,6 +472,154 @@ mod tests {
             "message": {"content": []}
         });
         assert!(extract_claude_tool_info(&event).is_empty());
+    }
+
+    #[test]
+    fn codex_error_event_yields_failure_diagnostic() {
+        let event = serde_json::json!({
+            "type": "error",
+            "message": "server rejected request"
+        });
+
+        assert_eq!(
+            masked_codex_failure_diagnostic(&event, &SecretMasker::from_raw("")),
+            Some(CodexFailureDiagnostic {
+                event_type: "error",
+                message: "server rejected request".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn codex_turn_failed_event_yields_failure_diagnostic() {
+        let event = serde_json::json!({
+            "type": "turn.failed",
+            "error": {"message": "turn failed from server"}
+        });
+
+        assert_eq!(
+            masked_codex_failure_diagnostic(&event, &SecretMasker::from_raw("")),
+            Some(CodexFailureDiagnostic {
+                event_type: "turn.failed",
+                message: "turn failed from server".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn codex_turn_failed_appends_additional_details() {
+        let event = serde_json::json!({
+            "type": "turn.failed",
+            "error": {
+                "message": "turn failed from server",
+                "additional_details": "rate limit exceeded"
+            }
+        });
+
+        assert_eq!(
+            masked_codex_failure_diagnostic(&event, &SecretMasker::from_raw("")),
+            Some(CodexFailureDiagnostic {
+                event_type: "turn.failed",
+                message: "turn failed from server (rate limit exceeded)".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn codex_turn_failed_legacy_string_error_yields_failure_diagnostic() {
+        let event = serde_json::json!({
+            "type": "turn.failed",
+            "error": "legacy turn failure"
+        });
+
+        assert_eq!(
+            masked_codex_failure_diagnostic(&event, &SecretMasker::from_raw("")),
+            Some(CodexFailureDiagnostic {
+                event_type: "turn.failed",
+                message: "legacy turn failure".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn codex_turn_failed_unknown_object_uses_generic_message() {
+        let event = serde_json::json!({
+            "type": "turn.failed",
+            "error": {"code": "internal", "context": "not a public error message"}
+        });
+
+        assert_eq!(
+            masked_codex_failure_diagnostic(&event, &SecretMasker::from_raw("")),
+            Some(CodexFailureDiagnostic {
+                event_type: "turn.failed",
+                message: "turn failed".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn codex_error_event_accepts_nested_error_shape() {
+        let event = serde_json::json!({
+            "type": "error",
+            "error": {
+                "message": "server rejected request",
+                "additional_details": "policy denied"
+            }
+        });
+
+        assert_eq!(
+            masked_codex_failure_diagnostic(&event, &SecretMasker::from_raw("")),
+            Some(CodexFailureDiagnostic {
+                event_type: "error",
+                message: "server rejected request (policy denied)".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn codex_failed_turn_completed_event_yields_failure_diagnostic() {
+        let event = serde_json::json!({
+            "type": "turn.completed",
+            "turn": {
+                "status": "failed",
+                "error": {"message": "failed TurnCompleted reason"}
+            }
+        });
+
+        assert_eq!(
+            masked_codex_failure_diagnostic(&event, &SecretMasker::from_raw("")),
+            Some(CodexFailureDiagnostic {
+                event_type: "turn.completed",
+                message: "failed TurnCompleted reason".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn codex_failure_diagnostic_masks_secrets() {
+        let event = serde_json::json!({
+            "type": "error",
+            "message": "request failed with token supersecret"
+        });
+        let masker = SecretMasker::from_raw("c3VwZXJzZWNyZXQ=");
+
+        assert_eq!(
+            masked_codex_failure_diagnostic(&event, &masker),
+            Some(CodexFailureDiagnostic {
+                event_type: "error",
+                message: "request failed with token ***".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn non_failure_codex_event_has_no_failure_diagnostic() {
+        let event = serde_json::json!({"type": "turn.completed", "usage": {}});
+
+        assert_eq!(
+            masked_codex_failure_diagnostic(&event, &SecretMasker::from_raw("")),
+            None
+        );
     }
 
     // Note: end-to-end coverage of `extract_session_id` (including both

--- a/crates/guest-agent/src/events.rs
+++ b/crates/guest-agent/src/events.rs
@@ -163,7 +163,11 @@ fn trimmed_message(message: &str) -> Option<String> {
 }
 
 fn mask_and_truncate_diagnostic(message: &str, masker: &SecretMasker) -> String {
-    truncate_diagnostic_message(&masker.mask_string(message))
+    truncate_diagnostic_message(&escape_log_line_breaks(&masker.mask_string(message)))
+}
+
+fn escape_log_line_breaks(message: &str) -> String {
+    message.replace('\r', "\\r").replace('\n', "\\n")
 }
 
 fn truncate_diagnostic_message(message: &str) -> String {
@@ -604,6 +608,22 @@ mod tests {
             Some(CodexFailureDiagnostic {
                 event_type: "error",
                 message: "request failed with token ***".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn codex_failure_diagnostic_escapes_line_breaks() {
+        let event = serde_json::json!({
+            "type": "error",
+            "message": "first line\nsecond line\rthird line"
+        });
+
+        assert_eq!(
+            masked_codex_failure_diagnostic(&event, &SecretMasker::from_raw("")),
+            Some(CodexFailureDiagnostic {
+                event_type: "error",
+                message: "first line\\nsecond line\\rthird line".to_string(),
             })
         );
     }

--- a/crates/guest-agent/tests/codex_jsonl_failure_logging.rs
+++ b/crates/guest-agent/tests/codex_jsonl_failure_logging.rs
@@ -1,0 +1,136 @@
+//! Codex stdout JSONL failure events should be visible in the system log.
+//!
+//! This test lives in its own binary because `guest_agent::env` caches
+//! environment values in process-wide `LazyLock`s.
+
+mod common;
+
+use guest_agent::http::HttpClient;
+use guest_agent::masker::SecretMasker;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+struct SystemLogOverrideGuard;
+
+impl SystemLogOverrideGuard {
+    fn set(path: &Path) -> Self {
+        guest_common::log::set_system_log_file(path);
+        Self
+    }
+}
+
+impl Drop for SystemLogOverrideGuard {
+    fn drop(&mut self) {
+        guest_common::log::clear_system_log_file();
+    }
+}
+
+#[tokio::test]
+async fn codex_jsonl_error_event_is_written_to_system_log() -> Result<(), Box<dyn std::error::Error>>
+{
+    let mock = build_and_locate_mock_codex()?;
+    let tmp = tempfile::tempdir()?;
+    let system_log_path = tmp.path().join("system.log");
+
+    unsafe {
+        setup_codex_env(&mock, tmp.path(), "error-event")?;
+    }
+
+    let _system_log = SystemLogOverrideGuard::set(&system_log_path);
+    let masker = SecretMasker::from_raw("");
+    let cli_result = tokio::time::timeout(
+        Duration::from_secs(5),
+        guest_agent::cli::execute_cli(
+            &masker,
+            common::spawn_dummy_heartbeat(),
+            HttpClient::for_current_env()?,
+        ),
+    )
+    .await
+    .expect("execute_cli should return promptly")?;
+
+    assert_eq!(cli_result.exit_code, common::CLEAN_EXIT);
+    let system_log = std::fs::read_to_string(&system_log_path)?;
+    assert!(
+        system_log.contains(
+            "Codex JSONL failure event seq=1 type=error: Mock error event for fixture testing"
+        ),
+        "system log should include Codex JSONL failure reason: {system_log}"
+    );
+
+    Ok(())
+}
+
+fn build_and_locate_mock_codex() -> Result<PathBuf, String> {
+    let exe = std::env::current_exe().map_err(|e| format!("current_exe: {e}"))?;
+    let target_profile_dir = exe
+        .parent()
+        .and_then(|p| p.parent())
+        .ok_or_else(|| "target/<profile> dir".to_string())?;
+    let target_dir = target_profile_dir
+        .parent()
+        .ok_or_else(|| "target dir".to_string())?;
+    let profile_dir_name = target_profile_dir
+        .file_name()
+        .and_then(|n| n.to_str())
+        .ok_or_else(|| "profile dir name".to_string())?;
+
+    let mut cmd = std::process::Command::new("cargo");
+    cmd.args(["build", "-p", "guest-mock-codex", "--quiet"])
+        .arg("--target-dir")
+        .arg(target_dir);
+    match profile_dir_name {
+        "debug" => {}
+        "release" => {
+            cmd.arg("--release");
+        }
+        other => {
+            cmd.args(["--profile", other]);
+        }
+    }
+
+    let status = cmd
+        .status()
+        .map_err(|e| format!("invoke cargo build: {e}"))?;
+    if !status.success() {
+        return Err("cargo build -p guest-mock-codex failed".into());
+    }
+
+    let mock = target_profile_dir.join("guest-mock-codex");
+    if !mock.exists() {
+        return Err(format!("mock binary not found at {}", mock.display()));
+    }
+    Ok(mock)
+}
+
+unsafe fn setup_codex_env(
+    mock_path: &Path,
+    workdir: &Path,
+    fixture_name: &str,
+) -> Result<(), String> {
+    unsafe {
+        std::env::set_var("CLI_AGENT_TYPE", "codex");
+        std::env::set_var("VM0_MOCK_CODEX_PATH", mock_path);
+        std::env::set_var("USE_MOCK_CODEX", "true");
+        std::env::set_var("MOCK_CODEX_FIXTURE", fixture_name);
+        std::env::set_var("VM0_POST_RESULT_SIGTERM_GRACE_SECS", "3");
+        std::env::set_var("VM0_POST_RESULT_SIGKILL_GRACE_SECS", "1");
+        let run_id = std::env::current_exe()
+            .ok()
+            .as_deref()
+            .and_then(Path::file_name)
+            .map(|n| n.to_string_lossy().into_owned())
+            .unwrap_or_else(|| "codex-jsonl-failure-logging-test".to_string());
+        std::env::set_var("VM0_RUN_ID", run_id);
+        std::env::set_var("VM0_PROMPT", "drive the codex error fixture");
+        std::env::set_var("VM0_WORKING_DIR", workdir);
+        std::env::set_var("VM0_API_URL", "http://127.0.0.1:1");
+        std::env::set_var("VM0_API_TOKEN", "");
+        std::env::set_var("VM0_SANDBOX_ID", "00000000-0000-4000-8000-000000000abc");
+        std::env::set_var("VM0_SANDBOX_REUSE_RESULT", "reused");
+        std::env::set_var("HOME", workdir);
+    }
+    std::fs::create_dir_all(workdir).map_err(|e| format!("create workdir: {e}"))?;
+    std::env::set_current_dir(workdir).map_err(|e| format!("set_current_dir: {e}"))?;
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- log secret-masked Codex stdout JSONL failure events into the guest-agent system log
- cover `type=error`, `type=turn.failed`, legacy string errors, and failed/interrupted `turn.completed` shapes
- keep Codex memories enabled by default; this PR only improves failure diagnostics
- add an integration test proving mock Codex JSONL failure events reach the system log
- avoid cloning whole failure events for logging; mask selected diagnostic text before applying a hard 4 KiB log cap
- escape CR/LF in diagnostic messages so one Codex error cannot inject extra system-log lines

Refs #13108

## Tests

- `cargo fmt -p guest-agent`
- `git diff --check`
- `CARGO_BUILD_JOBS=1 cargo test -p guest-agent --lib events::tests:: -- --nocapture`
- `CARGO_BUILD_JOBS=1 cargo test -p guest-agent --lib`
- `CARGO_BUILD_JOBS=1 cargo clippy -p guest-agent --lib -- -D warnings`
- `CARGO_BUILD_JOBS=1 cargo test -p guest-agent --test codex_jsonl_failure_logging -- --nocapture`
- `CARGO_BUILD_JOBS=1 cargo clippy -p guest-agent --test codex_jsonl_failure_logging -- -D warnings`

Note: the pre-commit hook attempted workspace `cargo-clippy` and failed in unrelated crate resolution paths (`ably-subscriber` integration earlier; later `guest-agent` bin dependency resolution). The targeted `guest-agent` lib and new integration-test clippy checks above passed.
