### PR TITLE
refactor(sandbox-fc): keep netns pool internals private

### DIFF
--- a/crates/sandbox-fc/src/factory/mod.rs
+++ b/crates/sandbox-fc/src/factory/mod.rs
@@ -28,7 +28,7 @@ pub(crate) use cow_cleanup::cow_destroy_retry_policy;
 pub(crate) use invariant::InvariantConfig;
 pub use invariant::{PREWARM_SCRIPT, config_hash};
 
-pub struct FirecrackerFactory {
+pub(crate) struct FirecrackerFactory {
     config: FirecrackerConfig,
     factory_paths: FactoryPaths,
     runtime_paths: RuntimePaths,
@@ -93,11 +93,6 @@ impl FirecrackerFactory {
             cleanup_group: FactoryCleanupGroup::new(),
             leak_cleaner: None,
         })
-    }
-
-    /// Whether this factory uses snapshot restore (vs fresh boot).
-    pub fn has_snapshot(&self) -> bool {
-        self.config.snapshot.is_some()
     }
 
     /// # Panics

--- a/crates/sandbox-fc/src/factory/mod.rs
+++ b/crates/sandbox-fc/src/factory/mod.rs
@@ -53,7 +53,7 @@ impl FirecrackerFactory {
     ///
     /// When `netns_pool` is provided, the factory shares it instead of
     /// creating a new one in `startup()` (used for multi-profile runners).
-    pub async fn new(
+    pub(crate) async fn new(
         config: FirecrackerConfig,
         netns_pool: Option<NetnsPoolHandle>,
         device_pool: nbd_cow::pool::DevicePoolHandle,

--- a/crates/sandbox-fc/src/lib.rs
+++ b/crates/sandbox-fc/src/lib.rs
@@ -9,9 +9,7 @@
 //! The main entry points are:
 //!
 //! - [`FirecrackerRuntime`], which manages shared host resources and creates
-//!   [`FirecrackerFactory`] instances.
-//! - [`FirecrackerFactory`], which creates and destroys [`FirecrackerSandbox`]
-//!   instances for a configured rootfs, kernel, and profile.
+//!   sandbox factories for configured rootfs, kernel, and profile settings.
 //! - [`FirecrackerSandbox`], the running microVM implementation of the
 //!   `sandbox::Sandbox` trait.
 //! - [`FirecrackerControl`], which exposes control-plane operations for a

--- a/crates/sandbox-fc/src/lib.rs
+++ b/crates/sandbox-fc/src/lib.rs
@@ -42,7 +42,7 @@ mod snapshot;
 pub use api::{ApiClient, ApiError, BalloonStatistics};
 pub use config::{FirecrackerConfig, SnapshotConfig};
 pub use control::FirecrackerControl;
-pub use factory::{FirecrackerFactory, PREWARM_SCRIPT, config_hash};
+pub use factory::{PREWARM_SCRIPT, config_hash};
 pub use network::{NetnsInfo, NetnsLease, NetnsPool, NetnsPoolConfig};
 pub use paths::{
     FactoryPaths, LockPaths, RuntimePaths, SandboxPaths, SnapshotOutputPaths, SockPaths,

--- a/crates/sandbox-fc/src/network/mod.rs
+++ b/crates/sandbox-fc/src/network/mod.rs
@@ -4,4 +4,5 @@ mod pool;
 
 pub(crate) use guest::generate_boot_args;
 pub(crate) use guest::{GUEST_NETWORK, GuestNetwork};
-pub use pool::{NetnsInfo, NetnsLease, NetnsPool, NetnsPoolConfig, NetnsPoolHandle};
+pub(crate) use pool::NetnsPoolHandle;
+pub use pool::{NetnsInfo, NetnsLease, NetnsPool, NetnsPoolConfig};

--- a/crates/sandbox-fc/src/network/pool.rs
+++ b/crates/sandbox-fc/src/network/pool.rs
@@ -124,14 +124,17 @@ impl NetnsInfo {
         }
     }
 
+    /// Returns the host network namespace name.
     pub fn name(&self) -> &str {
         &self.name
     }
 
+    /// Returns the host-side veth device name for this namespace.
     pub fn host_device(&self) -> &str {
         &self.host_device
     }
 
+    /// Returns the namespace-side veth IP used to identify the VM behind NAT.
     pub fn peer_ip(&self) -> &str {
         &self.peer_ip
     }
@@ -166,14 +169,17 @@ impl NetnsLease {
         )
     }
 
+    /// Returns cloneable metadata for the checked-out namespace.
     pub fn info(&self) -> &NetnsInfo {
         &self.info
     }
 
+    /// Returns the checked-out namespace name.
     pub fn name(&self) -> &str {
         self.info.name()
     }
 
+    /// Returns the checked-out namespace peer IP.
     pub fn peer_ip(&self) -> &str {
         self.info.peer_ip()
     }
@@ -365,7 +371,7 @@ impl CreationNotifier {
 }
 
 #[derive(Clone)]
-pub struct NetnsPoolHandle {
+pub(crate) struct NetnsPoolHandle {
     inner: Arc<tokio::sync::Mutex<NetnsPool>>,
 }
 

--- a/crates/sandbox-fc/src/network/pool.rs
+++ b/crates/sandbox-fc/src/network/pool.rs
@@ -1188,9 +1188,9 @@ impl NetnsPool {
 
     /// Acquire a namespace from the pool, or create one on-demand if empty.
     ///
-    /// The direct API is kept for one-shot local users. Shared users should use
-    /// `NetnsPoolHandle::acquire` so the mutex is not held while waiting for
-    /// namespace creation.
+    /// The direct API is kept for one-shot local users. Runtime-managed shared
+    /// pools use an internal handle that releases the pool lock before waiting
+    /// for namespace creation.
     pub async fn acquire(&mut self) -> Result<NetnsLease> {
         loop {
             match self.prepare_acquire()? {

--- a/crates/sandbox-fc/src/runtime.rs
+++ b/crates/sandbox-fc/src/runtime.rs
@@ -15,8 +15,8 @@ use crate::paths::{RuntimePaths, SandboxPaths, SnapshotOutputPaths, SockPaths};
 
 /// Firecracker-backed sandbox runtime.
 ///
-/// Manages shared resources (`NetnsPoolHandle`, [`DevicePoolHandle`]) and creates
-/// [`FirecrackerFactory`] instances that share them.
+/// Manages shared network namespace and device pools, then creates
+/// [`FirecrackerFactory`] instances that share those resources.
 pub struct FirecrackerRuntime {
     netns_pool: NetnsPoolHandle,
     device_pool: DevicePoolHandle,

--- a/crates/sandbox-fc/src/runtime.rs
+++ b/crates/sandbox-fc/src/runtime.rs
@@ -16,7 +16,7 @@ use crate::paths::{RuntimePaths, SandboxPaths, SnapshotOutputPaths, SockPaths};
 /// Firecracker-backed sandbox runtime.
 ///
 /// Manages shared network namespace and device pools, then creates
-/// [`FirecrackerFactory`] instances that share those resources.
+/// sandbox factories that share those resources.
 pub struct FirecrackerRuntime {
     netns_pool: NetnsPoolHandle,
     device_pool: DevicePoolHandle,


### PR DESCRIPTION
## Summary

- Add rustdoc for exported `NetnsInfo` and `NetnsLease` accessors
- Keep `NetnsPoolHandle` crate-internal instead of documenting it as supported external API
- Keep the Firecracker factory concrete type internal; external construction should go through `FirecrackerRuntime` / `FirecrackerRuntimeProvider`
- Remove the now-unused `FirecrackerFactory::has_snapshot` helper and update public rustdoc so internal handles/types do not appear in generated docs

Closes #13092

## Testing

- `cargo fmt --manifest-path crates/Cargo.toml --all`
- `RUSTDOCFLAGS='-D warnings' cargo doc --manifest-path crates/Cargo.toml -p sandbox-fc --no-deps`
- `cargo clippy --manifest-path crates/Cargo.toml -p sandbox-fc --all-targets -- -D warnings`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox-fc`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox-fc network::pool`
- `rg 'NetnsPoolHandle|FirecrackerFactory|FirecrackerFactory::new' crates/target/doc/sandbox_fc -n` (no matches)
- `git diff --check`

Note: the full pre-commit hook also runs workspace `cargo-clippy`, which currently fails independently in `guest-agent` tests with `E0463: can't find crate for guest_agent`. The focused `sandbox-fc` checks above pass.