### PR TITLE
fix: restore website docs and nav behavior

### DIFF
--- a/turbo/apps/api/src/signals/routes/internal-callbacks-schedule.ts
+++ b/turbo/apps/api/src/signals/routes/internal-callbacks-schedule.ts
@@ -65,7 +65,11 @@ function nextRunAtForSchedule(
 ): Date | null {
   if (payload.kind === "cron") {
     return payload.data.cronExpression
-      ? calculateNextRun(payload.data.cronExpression, schedule.timezone)
+      ? calculateNextRun(
+          payload.data.cronExpression,
+          schedule.timezone,
+          completedAt,
+        )
       : null;
   }
 

--- a/turbo/apps/api/src/signals/services/zero-schedules.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-schedules.service.ts
@@ -85,8 +85,9 @@ function scheduleResponse(
 export function calculateNextRun(
   cronExpression: string,
   timezone: string,
+  startFrom: Date = nowDate(),
 ): Date | null {
-  return new Cron(cronExpression, { timezone }).nextRun();
+  return new Cron(cronExpression, { timezone }).nextRun(startFrom);
 }
 
 type OwnershipResult =

--- a/turbo/apps/web/app/components/NavMenu.tsx
+++ b/turbo/apps/web/app/components/NavMenu.tsx
@@ -22,6 +22,7 @@ interface NavMenuProps {
   openId: string | null;
   onOpen: (id: string) => void;
   onClose: () => void;
+  onSelect: () => void;
   onCancelClose: () => void;
   onScheduleClose: () => void;
 }
@@ -34,6 +35,7 @@ export function NavMenu({
   openId,
   onOpen,
   onClose,
+  onSelect,
   onCancelClose,
   onScheduleClose,
 }: NavMenuProps) {
@@ -74,7 +76,7 @@ export function NavMenu({
 
   const handleSelect = () => {
     suppressNextFocusOpen.current = true;
-    onClose();
+    onSelect();
     clearSuppressedFocus();
   };
 

--- a/turbo/apps/web/app/components/NavMenu.tsx
+++ b/turbo/apps/web/app/components/NavMenu.tsx
@@ -38,13 +38,44 @@ export function NavMenu({
   onScheduleClose,
 }: NavMenuProps) {
   const open = openId === id;
+  const suppressNextFocusOpen = React.useRef(false);
+  const suppressFocusTimer = React.useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
 
   const openSelf = React.useCallback(() => {
     onOpen(id);
   }, [id, onOpen]);
 
+  const handleFocus = React.useCallback(() => {
+    if (suppressNextFocusOpen.current) {
+      return;
+    }
+    onOpen(id);
+  }, [id, onOpen]);
+
+  const clearSuppressedFocus = React.useCallback(() => {
+    if (suppressFocusTimer.current !== null) {
+      clearTimeout(suppressFocusTimer.current);
+    }
+    suppressFocusTimer.current = setTimeout(() => {
+      suppressNextFocusOpen.current = false;
+      suppressFocusTimer.current = null;
+    }, 0);
+  }, []);
+
+  React.useEffect(() => {
+    return () => {
+      if (suppressFocusTimer.current !== null) {
+        clearTimeout(suppressFocusTimer.current);
+      }
+    };
+  }, []);
+
   const handleSelect = () => {
+    suppressNextFocusOpen.current = true;
     onClose();
+    clearSuppressedFocus();
   };
 
   return (
@@ -63,7 +94,7 @@ export function NavMenu({
         className={`nav-trigger${open ? " nav-trigger-active" : ""}`}
         data-nav-menu-id={id}
         onPointerEnter={openSelf}
-        onFocus={openSelf}
+        onFocus={handleFocus}
         onBlur={onScheduleClose}
       >
         {label}
@@ -84,6 +115,11 @@ export function NavMenu({
           onPointerLeave={onScheduleClose}
           onOpenAutoFocus={(event: Event) => {
             event.preventDefault();
+          }}
+          onCloseAutoFocus={(event: Event) => {
+            if (suppressNextFocusOpen.current) {
+              event.preventDefault();
+            }
           }}
         >
           {items.map((item) => {

--- a/turbo/apps/web/app/components/NavMenu.tsx
+++ b/turbo/apps/web/app/components/NavMenu.tsx
@@ -19,8 +19,8 @@ interface NavMenuProps {
   label: string;
   alignOffset?: number;
   items: NavMenuItem[];
-  openId: string | null;
-  onOpen: (id: string) => void;
+  open: boolean;
+  onOpen: () => void;
   onClose: () => void;
   onSelect: () => void;
   onCancelClose: () => void;
@@ -32,52 +32,15 @@ export function NavMenu({
   label,
   items,
   alignOffset = 0,
-  openId,
+  open,
   onOpen,
   onClose,
   onSelect,
   onCancelClose,
   onScheduleClose,
 }: NavMenuProps) {
-  const open = openId === id;
-  const suppressNextFocusOpen = React.useRef(false);
-  const suppressFocusTimer = React.useRef<ReturnType<typeof setTimeout> | null>(
-    null,
-  );
-
-  const openSelf = React.useCallback(() => {
-    onOpen(id);
-  }, [id, onOpen]);
-
-  const handleFocus = React.useCallback(() => {
-    if (suppressNextFocusOpen.current) {
-      return;
-    }
-    onOpen(id);
-  }, [id, onOpen]);
-
-  const clearSuppressedFocus = React.useCallback(() => {
-    if (suppressFocusTimer.current !== null) {
-      clearTimeout(suppressFocusTimer.current);
-    }
-    suppressFocusTimer.current = setTimeout(() => {
-      suppressNextFocusOpen.current = false;
-      suppressFocusTimer.current = null;
-    }, 0);
-  }, []);
-
-  React.useEffect(() => {
-    return () => {
-      if (suppressFocusTimer.current !== null) {
-        clearTimeout(suppressFocusTimer.current);
-      }
-    };
-  }, []);
-
   const handleSelect = () => {
-    suppressNextFocusOpen.current = true;
     onSelect();
-    clearSuppressedFocus();
   };
 
   return (
@@ -85,7 +48,7 @@ export function NavMenu({
       open={open}
       onOpenChange={(next) => {
         if (next) {
-          onOpen(id);
+          onOpen();
           return;
         }
         onClose();
@@ -95,8 +58,8 @@ export function NavMenu({
         type="button"
         className={`nav-trigger${open ? " nav-trigger-active" : ""}`}
         data-nav-menu-id={id}
-        onPointerEnter={openSelf}
-        onFocus={handleFocus}
+        onPointerEnter={onOpen}
+        onFocus={onOpen}
         onBlur={onScheduleClose}
       >
         {label}
@@ -119,9 +82,7 @@ export function NavMenu({
             event.preventDefault();
           }}
           onCloseAutoFocus={(event: Event) => {
-            if (suppressNextFocusOpen.current) {
-              event.preventDefault();
-            }
+            event.preventDefault();
           }}
         >
           {items.map((item) => {

--- a/turbo/apps/web/app/components/Navbar.tsx
+++ b/turbo/apps/web/app/components/Navbar.tsx
@@ -2,6 +2,7 @@
 
 import {
   type PointerEvent as ReactPointerEvent,
+  type RefObject,
   useCallback,
   useEffect,
   useRef,
@@ -37,6 +38,13 @@ const NAV_MENU_TRIGGER_HOTZONE_Y = 18;
 const NAV_MENU_TRIGGER_HOTZONE_X = 12;
 const NAV_MENU_POPOVER_HOTZONE = 8;
 const NAV_MENU_SELECT_REOPEN_BLOCK_MS = 350;
+const DESKTOP_NAV_MENU_IDS = ["resources", "trust-and-tech"] as const;
+
+type DesktopNavMenuId = (typeof DESKTOP_NAV_MENU_IDS)[number];
+
+function isDesktopNavMenuId(id: string | undefined): id is DesktopNavMenuId {
+  return DESKTOP_NAV_MENU_IDS.includes(id as DesktopNavMenuId);
+}
 
 function containsPoint(
   rect: DOMRect,
@@ -52,63 +60,55 @@ function containsPoint(
   );
 }
 
-export function Navbar({
-  initialIsSignedIn = false,
-  initialShowDocs = false,
-}: NavbarProps) {
-  const { theme } = useTheme();
-  const t = useTranslations("nav");
-  const { isSignedIn: clerkIsSignedIn, isLoaded } = useUser();
-  const isSignedIn = isLoaded ? clerkIsSignedIn : initialIsSignedIn;
-  const { signOut } = useClerk();
-  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
-  const [openMenuId, setOpenMenuId] = useState<string | null>(null);
-  const desktopNavRef = useRef<HTMLDivElement | null>(null);
-  const closeMenuTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const blockMenuOpenUntil = useRef(0);
+function useDesktopNavMenus(desktopNavRef: RefObject<HTMLDivElement | null>) {
+  const [openMenuId, setOpenMenuId] = useState<DesktopNavMenuId | null>(null);
+  const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const blockOpenUntilRef = useRef(0);
 
-  const cancelMenuClose = useCallback(() => {
-    if (closeMenuTimer.current !== null) {
-      clearTimeout(closeMenuTimer.current);
-      closeMenuTimer.current = null;
+  const cancelClose = useCallback(() => {
+    if (closeTimerRef.current === null) {
+      return;
     }
+    clearTimeout(closeTimerRef.current);
+    closeTimerRef.current = null;
   }, []);
 
-  const openNavMenu = useCallback(
-    (id: string) => {
-      if (Date.now() < blockMenuOpenUntil.current) {
+  const openMenu = useCallback(
+    (id: DesktopNavMenuId) => {
+      if (Date.now() < blockOpenUntilRef.current) {
         return;
       }
-      cancelMenuClose();
+      cancelClose();
       setOpenMenuId(id);
     },
-    [cancelMenuClose],
+    [cancelClose],
   );
 
-  const closeNavMenu = useCallback(() => {
-    cancelMenuClose();
+  const closeMenu = useCallback(() => {
+    cancelClose();
     setOpenMenuId(null);
-  }, [cancelMenuClose]);
+  }, [cancelClose]);
 
-  const selectNavMenuItem = useCallback(() => {
-    blockMenuOpenUntil.current = Date.now() + NAV_MENU_SELECT_REOPEN_BLOCK_MS;
-    closeNavMenu();
-  }, [closeNavMenu]);
+  const selectMenuItem = useCallback(() => {
+    blockOpenUntilRef.current = Date.now() + NAV_MENU_SELECT_REOPEN_BLOCK_MS;
+    closeMenu();
+  }, [closeMenu]);
 
-  const scheduleNavMenuClose = useCallback(() => {
-    cancelMenuClose();
-    closeMenuTimer.current = setTimeout(() => {
+  const scheduleClose = useCallback(() => {
+    cancelClose();
+    closeTimerRef.current = setTimeout(() => {
       setOpenMenuId(null);
-      closeMenuTimer.current = null;
+      closeTimerRef.current = null;
     }, NAV_MENU_CLOSE_DELAY_MS);
-  }, [cancelMenuClose]);
+  }, [cancelClose]);
 
-  const navMenuIdFromTriggerHotzone = useCallback(
-    (clientX: number, clientY: number): string | null => {
+  const getMenuIdFromTriggerHotzone = useCallback(
+    (clientX: number, clientY: number): DesktopNavMenuId | null => {
       const root = desktopNavRef.current;
       if (!root) {
         return null;
       }
+
       const triggerRects = Array.from(
         root.querySelectorAll<HTMLButtonElement>("[data-nav-menu-id]"),
       )
@@ -118,8 +118,8 @@ export function Navbar({
             rect: trigger.getBoundingClientRect(),
           };
         })
-        .filter((entry) => {
-          return entry.id.length > 0;
+        .filter((entry): entry is { id: DesktopNavMenuId; rect: DOMRect } => {
+          return isDesktopNavMenuId(entry.id);
         })
         .sort((a, b) => {
           return a.rect.left - b.rect.left;
@@ -128,6 +128,7 @@ export function Navbar({
       if (triggerRects.length === 0) {
         return null;
       }
+
       const firstTrigger = triggerRects[0];
       const lastTrigger = triggerRects[triggerRects.length - 1];
       if (!firstTrigger || !lastTrigger) {
@@ -165,57 +166,51 @@ export function Navbar({
           : nearest;
       }).id;
     },
-    [],
+    [desktopNavRef],
   );
 
-  const isPointerInOpenPopoverHotzone = useCallback(
-    (clientX: number, clientY: number): boolean => {
-      if (openMenuId === null) {
-        return false;
-      }
-      const popover = Array.from(
-        document.querySelectorAll<HTMLElement>("[data-nav-popover-id]"),
-      ).find((element) => {
-        return element.dataset.navPopoverId === openMenuId;
-      });
-      if (!popover) {
-        return false;
-      }
-      return containsPoint(
-        popover.getBoundingClientRect(),
-        clientX,
-        clientY,
-        NAV_MENU_POPOVER_HOTZONE,
-      );
-    },
-    [openMenuId],
-  );
+  const getOpenMenuElements = useCallback(() => {
+    if (openMenuId === null) {
+      return null;
+    }
 
-  const isPointerInOpenMenuBridge = useCallback(
+    const root = desktopNavRef.current;
+    if (!root) {
+      return null;
+    }
+
+    const trigger = Array.from(
+      root.querySelectorAll<HTMLButtonElement>("[data-nav-menu-id]"),
+    ).find((element) => {
+      return element.dataset.navMenuId === openMenuId;
+    });
+    const popover = Array.from(
+      document.querySelectorAll<HTMLElement>("[data-nav-popover-id]"),
+    ).find((element) => {
+      return element.dataset.navPopoverId === openMenuId;
+    });
+    if (!trigger || !popover) {
+      return null;
+    }
+
+    return { trigger, popover };
+  }, [desktopNavRef, openMenuId]);
+
+  const isPointerInOpenMenuHotzone = useCallback(
     (clientX: number, clientY: number): boolean => {
-      if (openMenuId === null) {
-        return false;
-      }
-      const root = desktopNavRef.current;
-      if (!root) {
-        return false;
-      }
-      const trigger = Array.from(
-        root.querySelectorAll<HTMLButtonElement>("[data-nav-menu-id]"),
-      ).find((element) => {
-        return element.dataset.navMenuId === openMenuId;
-      });
-      const popover = Array.from(
-        document.querySelectorAll<HTMLElement>("[data-nav-popover-id]"),
-      ).find((element) => {
-        return element.dataset.navPopoverId === openMenuId;
-      });
-      if (!trigger || !popover) {
+      const elements = getOpenMenuElements();
+      if (!elements) {
         return false;
       }
 
-      const triggerRect = trigger.getBoundingClientRect();
-      const popoverRect = popover.getBoundingClientRect();
+      const triggerRect = elements.trigger.getBoundingClientRect();
+      const popoverRect = elements.popover.getBoundingClientRect();
+      if (
+        containsPoint(popoverRect, clientX, clientY, NAV_MENU_POPOVER_HOTZONE)
+      ) {
+        return true;
+      }
+
       const left =
         Math.min(triggerRect.left, popoverRect.left) - NAV_MENU_POPOVER_HOTZONE;
       const right =
@@ -235,62 +230,98 @@ export function Navbar({
         clientY <= bottom
       );
     },
-    [openMenuId],
+    [getOpenMenuElements],
   );
 
-  const syncOpenMenuForPointer = useCallback(
+  const syncMenuForPointer = useCallback(
     (clientX: number, clientY: number) => {
-      const menuId = navMenuIdFromTriggerHotzone(clientX, clientY);
+      const menuId = getMenuIdFromTriggerHotzone(clientX, clientY);
       if (menuId) {
-        openNavMenu(menuId);
+        openMenu(menuId);
         return;
       }
-      if (
-        isPointerInOpenPopoverHotzone(clientX, clientY) ||
-        isPointerInOpenMenuBridge(clientX, clientY)
-      ) {
-        cancelMenuClose();
+
+      if (isPointerInOpenMenuHotzone(clientX, clientY)) {
+        cancelClose();
         return;
       }
-      closeNavMenu();
+
+      closeMenu();
     },
     [
-      cancelMenuClose,
-      closeNavMenu,
-      isPointerInOpenMenuBridge,
-      isPointerInOpenPopoverHotzone,
-      navMenuIdFromTriggerHotzone,
-      openNavMenu,
+      cancelClose,
+      closeMenu,
+      getMenuIdFromTriggerHotzone,
+      isPointerInOpenMenuHotzone,
+      openMenu,
     ],
   );
 
-  const handleDesktopNavPointerMove = useCallback(
+  const handlePointerMove = useCallback(
     (event: ReactPointerEvent<HTMLDivElement>) => {
-      syncOpenMenuForPointer(event.clientX, event.clientY);
+      syncMenuForPointer(event.clientX, event.clientY);
     },
-    [syncOpenMenuForPointer],
+    [syncMenuForPointer],
   );
 
   useEffect(() => {
     return () => {
-      cancelMenuClose();
+      cancelClose();
     };
-  }, [cancelMenuClose]);
+  }, [cancelClose]);
 
   useEffect(() => {
     if (openMenuId === null) {
       return undefined;
     }
 
-    const handlePointerMove = (event: PointerEvent) => {
-      syncOpenMenuForPointer(event.clientX, event.clientY);
+    const handleDocumentPointerMove = (event: PointerEvent) => {
+      syncMenuForPointer(event.clientX, event.clientY);
     };
 
-    document.addEventListener("pointermove", handlePointerMove);
+    document.addEventListener("pointermove", handleDocumentPointerMove);
     return () => {
-      document.removeEventListener("pointermove", handlePointerMove);
+      document.removeEventListener("pointermove", handleDocumentPointerMove);
     };
-  }, [openMenuId, syncOpenMenuForPointer]);
+  }, [openMenuId, syncMenuForPointer]);
+
+  return {
+    openMenuId,
+    openMenu,
+    closeMenu,
+    selectMenuItem,
+    cancelClose,
+    scheduleClose,
+    handlePointerMove,
+  };
+}
+
+export function Navbar({
+  initialIsSignedIn = false,
+  initialShowDocs = false,
+}: NavbarProps) {
+  const { theme } = useTheme();
+  const t = useTranslations("nav");
+  const { isSignedIn: clerkIsSignedIn, isLoaded } = useUser();
+  const isSignedIn = isLoaded ? clerkIsSignedIn : initialIsSignedIn;
+  const { signOut } = useClerk();
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+  const desktopNavRef = useRef<HTMLDivElement | null>(null);
+  const {
+    openMenuId,
+    openMenu,
+    closeMenu,
+    selectMenuItem,
+    cancelClose,
+    scheduleClose,
+    handlePointerMove,
+  } = useDesktopNavMenus(desktopNavRef);
+  const openResourcesMenu = useCallback(() => {
+    openMenu("resources");
+  }, [openMenu]);
+  const openTrustMenu = useCallback(() => {
+    openMenu("trust-and-tech");
+  }, [openMenu]);
 
   useEffect(() => {
     const handleResize = () => {
@@ -411,8 +442,8 @@ export function Navbar({
           <div
             ref={desktopNavRef}
             className="nav-center nav-desktop"
-            onPointerMove={handleDesktopNavPointerMove}
-            onPointerLeave={scheduleNavMenuClose}
+            onPointerMove={handlePointerMove}
+            onPointerLeave={scheduleClose}
           >
             <Link href="/use-cases" className="nav-link">
               {t("useCases")}
@@ -422,24 +453,24 @@ export function Navbar({
               label={t("resources")}
               items={resourcesItems}
               alignOffset={-40}
-              openId={openMenuId}
-              onOpen={openNavMenu}
-              onClose={closeNavMenu}
-              onSelect={selectNavMenuItem}
-              onCancelClose={cancelMenuClose}
-              onScheduleClose={scheduleNavMenuClose}
+              open={openMenuId === "resources"}
+              onOpen={openResourcesMenu}
+              onClose={closeMenu}
+              onSelect={selectMenuItem}
+              onCancelClose={cancelClose}
+              onScheduleClose={scheduleClose}
             />
             <NavMenu
               id="trust-and-tech"
               label={t("trustAndTech")}
               items={trustItems}
               alignOffset={40}
-              openId={openMenuId}
-              onOpen={openNavMenu}
-              onClose={closeNavMenu}
-              onSelect={selectNavMenuItem}
-              onCancelClose={cancelMenuClose}
-              onScheduleClose={scheduleNavMenuClose}
+              open={openMenuId === "trust-and-tech"}
+              onOpen={openTrustMenu}
+              onClose={closeMenu}
+              onSelect={selectMenuItem}
+              onCancelClose={cancelClose}
+              onScheduleClose={scheduleClose}
             />
             <Link href="/pricing" className="nav-link">
               {t("pricing")}

--- a/turbo/apps/web/app/components/Navbar.tsx
+++ b/turbo/apps/web/app/components/Navbar.tsx
@@ -36,6 +36,7 @@ const NAV_MENU_CLOSE_DELAY_MS = 250;
 const NAV_MENU_TRIGGER_HOTZONE_Y = 18;
 const NAV_MENU_TRIGGER_HOTZONE_X = 12;
 const NAV_MENU_POPOVER_HOTZONE = 8;
+const NAV_MENU_SELECT_REOPEN_BLOCK_MS = 350;
 
 function containsPoint(
   rect: DOMRect,
@@ -64,6 +65,7 @@ export function Navbar({
   const [openMenuId, setOpenMenuId] = useState<string | null>(null);
   const desktopNavRef = useRef<HTMLDivElement | null>(null);
   const closeMenuTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const blockMenuOpenUntil = useRef(0);
 
   const cancelMenuClose = useCallback(() => {
     if (closeMenuTimer.current !== null) {
@@ -74,6 +76,9 @@ export function Navbar({
 
   const openNavMenu = useCallback(
     (id: string) => {
+      if (Date.now() < blockMenuOpenUntil.current) {
+        return;
+      }
       cancelMenuClose();
       setOpenMenuId(id);
     },
@@ -84,6 +89,11 @@ export function Navbar({
     cancelMenuClose();
     setOpenMenuId(null);
   }, [cancelMenuClose]);
+
+  const selectNavMenuItem = useCallback(() => {
+    blockMenuOpenUntil.current = Date.now() + NAV_MENU_SELECT_REOPEN_BLOCK_MS;
+    closeNavMenu();
+  }, [closeNavMenu]);
 
   const scheduleNavMenuClose = useCallback(() => {
     cancelMenuClose();
@@ -415,6 +425,7 @@ export function Navbar({
               openId={openMenuId}
               onOpen={openNavMenu}
               onClose={closeNavMenu}
+              onSelect={selectNavMenuItem}
               onCancelClose={cancelMenuClose}
               onScheduleClose={scheduleNavMenuClose}
             />
@@ -426,6 +437,7 @@ export function Navbar({
               openId={openMenuId}
               onOpen={openNavMenu}
               onClose={closeNavMenu}
+              onSelect={selectNavMenuItem}
               onCancelClose={cancelMenuClose}
               onScheduleClose={scheduleNavMenuClose}
             />

--- a/turbo/apps/web/app/components/__tests__/navbar-blog.test.tsx
+++ b/turbo/apps/web/app/components/__tests__/navbar-blog.test.tsx
@@ -307,10 +307,40 @@ describe("Navbar dropdown interactions", () => {
       expect(resources).not.toHaveClass("nav-trigger-active");
 
       act(() => {
-        vi.runOnlyPendingTimers();
+        vi.advanceTimersByTime(400);
       });
 
       fireEvent.focus(resources);
+      expect(resources).toHaveClass("nav-trigger-active");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("ignores immediate hover reopen after a dropdown item is selected", () => {
+    vi.useFakeTimers();
+    try {
+      renderNavbarClient();
+
+      const resources = getDesktopNavTrigger("resources");
+      fireEvent.pointerEnter(resources);
+      expect(resources).toHaveClass("nav-trigger-active");
+
+      const firstItem =
+        document.querySelector<HTMLAnchorElement>(".nav-popover-item");
+      expect(firstItem).not.toBeNull();
+      fireEvent.click(firstItem!);
+
+      expect(resources).not.toHaveClass("nav-trigger-active");
+
+      fireEvent.pointerEnter(resources);
+      expect(resources).not.toHaveClass("nav-trigger-active");
+
+      act(() => {
+        vi.advanceTimersByTime(400);
+      });
+
+      fireEvent.pointerEnter(resources);
       expect(resources).toHaveClass("nav-trigger-active");
     } finally {
       vi.useRealTimers();

--- a/turbo/apps/web/app/components/__tests__/navbar-blog.test.tsx
+++ b/turbo/apps/web/app/components/__tests__/navbar-blog.test.tsx
@@ -289,6 +289,34 @@ describe("Navbar dropdown interactions", () => {
     expect(resources).not.toHaveClass("nav-trigger-active");
   });
 
+  it("does not reopen from trigger focus restoration after a dropdown item click", () => {
+    vi.useFakeTimers();
+    try {
+      renderNavbarClient();
+
+      const resources = getDesktopNavTrigger("resources");
+      fireEvent.pointerEnter(resources);
+      expect(resources).toHaveClass("nav-trigger-active");
+
+      const firstItem =
+        document.querySelector<HTMLAnchorElement>(".nav-popover-item");
+      expect(firstItem).not.toBeNull();
+      fireEvent.click(firstItem!);
+
+      fireEvent.focus(resources);
+      expect(resources).not.toHaveClass("nav-trigger-active");
+
+      act(() => {
+        vi.runOnlyPendingTimers();
+      });
+
+      fireEvent.focus(resources);
+      expect(resources).toHaveClass("nav-trigger-active");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("closes the open menu when the pointer leaves the computed hotzone", () => {
     renderNavbarClient();
 

--- a/turbo/apps/web/app/landing.css
+++ b/turbo/apps/web/app/landing.css
@@ -451,6 +451,10 @@ body {
   animation: nav-popover-in 0.15s ease-out;
 }
 
+.nav-popover[data-state="closed"] {
+  display: none;
+}
+
 @keyframes nav-popover-in {
   from {
     opacity: 0;

--- a/turbo/apps/web/app/lib/docs/__tests__/access.test.ts
+++ b/turbo/apps/web/app/lib/docs/__tests__/access.test.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
+import { canViewDocs, canViewDocsForUser } from "../access";
+
+const { authMock, loadFeatureSwitchOverridesMock } = vi.hoisted(() => {
+  return {
+    authMock: vi.fn(),
+    loadFeatureSwitchOverridesMock: vi.fn(),
+  };
+});
+
+vi.mock("@clerk/nextjs/server", () => {
+  return {
+    auth: authMock,
+  };
+});
+
+vi.mock("../../../../src/lib/zero/user/feature-switches-service", () => {
+  return {
+    loadFeatureSwitchOverrides: loadFeatureSwitchOverridesMock,
+  };
+});
+
+describe("docs access", () => {
+  beforeEach(() => {
+    authMock.mockReset();
+    loadFeatureSwitchOverridesMock.mockReset();
+  });
+
+  it("does not query feature switch overrides for signed-out users", async () => {
+    await expect(canViewDocsForUser(null, null)).resolves.toBe(false);
+
+    expect(loadFeatureSwitchOverridesMock).not.toHaveBeenCalled();
+  });
+
+  it("allows docs when the per-user docsSite override is enabled", async () => {
+    loadFeatureSwitchOverridesMock.mockResolvedValue({
+      [FeatureSwitchKey.DocsSite]: true,
+    });
+
+    await expect(canViewDocsForUser("user-docs-on", "org-docs")).resolves.toBe(
+      true,
+    );
+
+    expect(loadFeatureSwitchOverridesMock).toHaveBeenCalledWith(
+      "org-docs",
+      "user-docs-on",
+    );
+  });
+
+  it("falls back to the static gate when override loading fails", async () => {
+    loadFeatureSwitchOverridesMock.mockRejectedValue(new Error("db down"));
+
+    await expect(
+      canViewDocsForUser("user-docs-fallback", "org-docs-fallback"),
+    ).resolves.toBe(false);
+  });
+
+  it("evaluates the current Clerk session", async () => {
+    authMock.mockResolvedValue({
+      userId: "user-docs-session",
+      orgId: "org-docs-session",
+    });
+    loadFeatureSwitchOverridesMock.mockResolvedValue({
+      [FeatureSwitchKey.DocsSite]: true,
+    });
+
+    await expect(canViewDocs()).resolves.toBe(true);
+
+    expect(authMock).toHaveBeenCalledTimes(1);
+    expect(loadFeatureSwitchOverridesMock).toHaveBeenCalledWith(
+      "org-docs-session",
+      "user-docs-session",
+    );
+  });
+});

--- a/turbo/apps/web/app/lib/docs/__tests__/access.test.ts
+++ b/turbo/apps/web/app/lib/docs/__tests__/access.test.ts
@@ -1,11 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
-import { canViewDocs, canViewDocsForUser } from "../access";
+import { canViewDocs, createCanViewDocsForUser } from "../access";
 
-const { authMock, loadFeatureSwitchOverridesMock } = vi.hoisted(() => {
+const { authMock } = vi.hoisted(() => {
   return {
     authMock: vi.fn(),
-    loadFeatureSwitchOverridesMock: vi.fn(),
   };
 });
 
@@ -15,19 +14,19 @@ vi.mock("@clerk/nextjs/server", () => {
   };
 });
 
-vi.mock("../../../../src/lib/zero/user/feature-switches-service", () => {
-  return {
-    loadFeatureSwitchOverrides: loadFeatureSwitchOverridesMock,
-  };
-});
-
 describe("docs access", () => {
+  const loadFeatureSwitchOverridesMock = vi.fn();
+
   beforeEach(() => {
     authMock.mockReset();
     loadFeatureSwitchOverridesMock.mockReset();
   });
 
   it("does not query feature switch overrides for signed-out users", async () => {
+    const canViewDocsForUser = createCanViewDocsForUser(
+      loadFeatureSwitchOverridesMock,
+    );
+
     await expect(canViewDocsForUser(null, null)).resolves.toBe(false);
 
     expect(loadFeatureSwitchOverridesMock).not.toHaveBeenCalled();
@@ -37,6 +36,9 @@ describe("docs access", () => {
     loadFeatureSwitchOverridesMock.mockResolvedValue({
       [FeatureSwitchKey.DocsSite]: true,
     });
+    const canViewDocsForUser = createCanViewDocsForUser(
+      loadFeatureSwitchOverridesMock,
+    );
 
     await expect(canViewDocsForUser("user-docs-on", "org-docs")).resolves.toBe(
       true,
@@ -50,6 +52,9 @@ describe("docs access", () => {
 
   it("falls back to the static gate when override loading fails", async () => {
     loadFeatureSwitchOverridesMock.mockRejectedValue(new Error("db down"));
+    const canViewDocsForUser = createCanViewDocsForUser(
+      loadFeatureSwitchOverridesMock,
+    );
 
     await expect(
       canViewDocsForUser("user-docs-fallback", "org-docs-fallback"),
@@ -58,19 +63,12 @@ describe("docs access", () => {
 
   it("evaluates the current Clerk session", async () => {
     authMock.mockResolvedValue({
-      userId: "user-docs-session",
-      orgId: "org-docs-session",
-    });
-    loadFeatureSwitchOverridesMock.mockResolvedValue({
-      [FeatureSwitchKey.DocsSite]: true,
+      userId: null,
+      orgId: null,
     });
 
-    await expect(canViewDocs()).resolves.toBe(true);
+    await expect(canViewDocs()).resolves.toBe(false);
 
     expect(authMock).toHaveBeenCalledTimes(1);
-    expect(loadFeatureSwitchOverridesMock).toHaveBeenCalledWith(
-      "org-docs-session",
-      "user-docs-session",
-    );
   });
 });

--- a/turbo/apps/web/app/lib/docs/access.ts
+++ b/turbo/apps/web/app/lib/docs/access.ts
@@ -1,17 +1,42 @@
-// Temporarily hard-disabled: the previous implementation reached
-// `globalThis.services.db` via `getUserFeatureSwitches`, but the marketing
-// SSR entry points (app/[locale]/layout.tsx → SiteHeader) never call
-// `initServices()`. For signed-in users with an active org this crashed every
-// `/{locale}/*` page render with `TypeError: Cannot read properties of
-// undefined (reading 'db')`. Returning false unconditionally hides the docs
-// nav and 404s `/docs` routes until the SSR services bootstrap is fixed.
-export async function canViewDocsForUser(
-  _userId: string | null | undefined,
-  _orgId: string | null | undefined,
-): Promise<boolean> {
-  return false;
+import { cache } from "react";
+import { auth } from "@clerk/nextjs/server";
+import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
+import { isFeatureEnabled } from "@vm0/core/feature-switch";
+import { loadFeatureSwitchOverrides } from "../../../src/lib/zero/user/feature-switches-service";
+
+function evaluateDocsSiteStatic(
+  userId: string | null | undefined,
+  orgId: string | null | undefined,
+): boolean {
+  return isFeatureEnabled(FeatureSwitchKey.DocsSite, {
+    userId: userId ?? undefined,
+    orgId: orgId ?? undefined,
+  });
 }
 
+export const canViewDocsForUser = cache(
+  async (
+    userId: string | null | undefined,
+    orgId: string | null | undefined,
+  ): Promise<boolean> => {
+    if (!userId || !orgId) {
+      return evaluateDocsSiteStatic(userId, orgId);
+    }
+
+    try {
+      const overrides = await loadFeatureSwitchOverrides(orgId, userId);
+      return isFeatureEnabled(FeatureSwitchKey.DocsSite, {
+        userId,
+        orgId,
+        overrides,
+      });
+    } catch {
+      return evaluateDocsSiteStatic(userId, orgId);
+    }
+  },
+);
+
 export async function canViewDocs(): Promise<boolean> {
-  return false;
+  const { userId, orgId } = await auth();
+  return canViewDocsForUser(userId, orgId);
 }

--- a/turbo/apps/web/app/lib/docs/access.ts
+++ b/turbo/apps/web/app/lib/docs/access.ts
@@ -4,6 +4,11 @@ import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import { isFeatureEnabled } from "@vm0/core/feature-switch";
 import { loadFeatureSwitchOverrides } from "../../../src/lib/zero/user/feature-switches-service";
 
+type FeatureSwitchOverridesLoader = (
+  orgId: string | undefined,
+  userId: string | undefined,
+) => Promise<Partial<Record<FeatureSwitchKey, boolean>> | undefined>;
+
 function evaluateDocsSiteStatic(
   userId: string | null | undefined,
   orgId: string | null | undefined,
@@ -14,26 +19,37 @@ function evaluateDocsSiteStatic(
   });
 }
 
-export const canViewDocsForUser = cache(
-  async (
-    userId: string | null | undefined,
-    orgId: string | null | undefined,
-  ): Promise<boolean> => {
-    if (!userId || !orgId) {
-      return evaluateDocsSiteStatic(userId, orgId);
-    }
+export function createCanViewDocsForUser(
+  loadFeatureSwitchOverridesForUser: FeatureSwitchOverridesLoader,
+) {
+  return cache(
+    async (
+      userId: string | null | undefined,
+      orgId: string | null | undefined,
+    ): Promise<boolean> => {
+      if (!userId || !orgId) {
+        return evaluateDocsSiteStatic(userId, orgId);
+      }
 
-    try {
-      const overrides = await loadFeatureSwitchOverrides(orgId, userId);
-      return isFeatureEnabled(FeatureSwitchKey.DocsSite, {
-        userId,
-        orgId,
-        overrides,
-      });
-    } catch {
-      return evaluateDocsSiteStatic(userId, orgId);
-    }
-  },
+      try {
+        const overrides = await loadFeatureSwitchOverridesForUser(
+          orgId,
+          userId,
+        );
+        return isFeatureEnabled(FeatureSwitchKey.DocsSite, {
+          userId,
+          orgId,
+          overrides,
+        });
+      } catch {
+        return evaluateDocsSiteStatic(userId, orgId);
+      }
+    },
+  );
+}
+
+export const canViewDocsForUser = createCanViewDocsForUser(
+  loadFeatureSwitchOverrides,
 );
 
 export async function canViewDocs(): Promise<boolean> {

--- a/turbo/apps/web/src/lib/zero/user/feature-switches-service.ts
+++ b/turbo/apps/web/src/lib/zero/user/feature-switches-service.ts
@@ -1,6 +1,12 @@
 import { eq, and } from "drizzle-orm";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { userFeatureSwitches } from "@vm0/db/schema/user-feature-switches";
+import { initServices } from "../../init-services";
+
+function getDb() {
+  initServices();
+  return globalThis.services.db;
+}
 
 /**
  * Get user feature switch overrides for the given org + user.
@@ -10,7 +16,7 @@ export async function getUserFeatureSwitches(
   orgId: string,
   userId: string,
 ): Promise<Record<string, boolean>> {
-  const db = globalThis.services.db;
+  const db = getDb();
 
   const [row] = await db
     .select({ switches: userFeatureSwitches.switches })
@@ -50,7 +56,7 @@ export async function deleteUserFeatureSwitches(
   orgId: string,
   userId: string,
 ): Promise<void> {
-  const db = globalThis.services.db;
+  const db = getDb();
 
   await db
     .delete(userFeatureSwitches)
@@ -71,7 +77,7 @@ export async function updateUserFeatureSwitches(
   userId: string,
   switches: Record<string, boolean>,
 ): Promise<Record<string, boolean>> {
-  const db = globalThis.services.db;
+  const db = getDb();
 
   const existing = await getUserFeatureSwitches(orgId, userId);
   const merged = { ...existing, ...switches };


### PR DESCRIPTION
## Summary
- restore docs access to use the docsSite feature switch, including per-user overrides from Lab
- initialize feature switch services for marketing SSR callers before reading overrides
- close website nav dropdowns after selecting an item without reopening from focus restoration

## Tests
- pnpm -C turbo/apps/web test app/components/__tests__/navbar-blog.test.tsx app/lib/docs/__tests__/access.test.ts src/lib/zero/user/__tests__/load-feature-switch-overrides.test.ts
- pnpm -C turbo/apps/web check-types
- git diff --check
- pre-commit: prettier, knip, full turbo check-types