### PR TITLE
fix(cli): collapse duplicate codex failure results

### DIFF
--- a/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
@@ -1081,6 +1081,54 @@ describe("logs command", () => {
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(countOccurrences(logCalls, "Codex Failed")).toBe(1);
     });
+
+    it("should collapse paired Codex error and turn.failed when default tail order is descending", async () => {
+      server.use(
+        http.get(
+          "http://localhost:3000/api/agent/runs/:id/telemetry/agent",
+          () => {
+            return HttpResponse.json({
+              events: [
+                {
+                  sequenceNumber: 3,
+                  eventType: "turn.failed",
+                  createdAt: "2024-01-15T10:30:02Z",
+                  eventData: {
+                    type: "turn.failed",
+                    error: "Rate limit exceeded",
+                  },
+                },
+                {
+                  sequenceNumber: 2,
+                  eventType: "error",
+                  createdAt: "2024-01-15T10:30:01Z",
+                  eventData: {
+                    type: "error",
+                    message: "API connection failed",
+                  },
+                },
+                {
+                  sequenceNumber: 1,
+                  eventType: "thread.started",
+                  createdAt: "2024-01-15T10:30:00Z",
+                  eventData: {
+                    type: "thread.started",
+                    thread_id: "thread-x",
+                  },
+                },
+              ],
+              framework: "codex",
+              hasMore: false,
+            });
+          },
+        ),
+      );
+
+      await logsCommand.parseAsync(["node", "cli", "run-123"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(countOccurrences(logCalls, "Codex Failed")).toBe(1);
+    });
   });
 
   describe("system log", () => {

--- a/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
@@ -12,6 +12,10 @@ import { http, HttpResponse } from "msw";
 import { server } from "../../../mocks/server";
 import { logsCommand } from "../index";
 
+function countOccurrences(text: string, pattern: string): number {
+  return text.split(pattern).length - 1;
+}
+
 describe("logs command", () => {
   const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
     throw new Error("process.exit called");
@@ -1028,6 +1032,54 @@ describe("logs command", () => {
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("Codex Failed");
+    });
+
+    it("should collapse paired top-level error and turn.failed into one Codex failure", async () => {
+      server.use(
+        http.get(
+          "http://localhost:3000/api/agent/runs/:id/telemetry/agent",
+          () => {
+            return HttpResponse.json({
+              events: [
+                {
+                  sequenceNumber: 1,
+                  eventType: "thread.started",
+                  createdAt: "2024-01-15T10:30:00Z",
+                  eventData: {
+                    type: "thread.started",
+                    thread_id: "thread-x",
+                  },
+                },
+                {
+                  sequenceNumber: 2,
+                  eventType: "error",
+                  createdAt: "2024-01-15T10:30:01Z",
+                  eventData: {
+                    type: "error",
+                    message: "API connection failed",
+                  },
+                },
+                {
+                  sequenceNumber: 3,
+                  eventType: "turn.failed",
+                  createdAt: "2024-01-15T10:30:02Z",
+                  eventData: {
+                    type: "turn.failed",
+                    error: "Rate limit exceeded",
+                  },
+                },
+              ],
+              framework: "codex",
+              hasMore: false,
+            });
+          },
+        ),
+      );
+
+      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(countOccurrences(logCalls, "Codex Failed")).toBe(1);
     });
   });
 

--- a/turbo/apps/cli/src/commands/logs/index.ts
+++ b/turbo/apps/cli/src/commands/logs/index.ts
@@ -12,7 +12,7 @@ import {
 import { getApiUrl } from "../../lib/api/config";
 import { parseTime } from "../../lib/utils/time-parser";
 import { formatBytes } from "../../lib/utils/file-utils";
-import { parseEvent } from "../../lib/events/event-parser-factory";
+import { EventStreamNormalizer } from "../../lib/events/event-stream-normalizer";
 import { EventRenderer } from "../../lib/events/event-renderer";
 import { paginate } from "../../lib/utils/paginate";
 import { searchCommand } from "./search";
@@ -243,12 +243,15 @@ function createLogRenderer(verbose: boolean): EventRenderer {
 function renderAgentEvent(
   event: RunEvent,
   renderer: EventRenderer,
+  normalizer: EventStreamNormalizer,
   framework: string,
 ): void {
-  const eventData = event.eventData as Record<string, unknown>;
-  const parsed = parseEvent(eventData, framework);
-  if (parsed) {
-    parsed.timestamp = new Date(event.createdAt);
+  const parsedEvents = normalizer.process(
+    event.eventData,
+    framework,
+    new Date(event.createdAt),
+  );
+  for (const parsed of parsedEvents) {
     renderer.render(parsed);
   }
 }
@@ -464,10 +467,14 @@ async function showAgentEvents(
 
   // Create renderer for log viewing (with timestamps, always verbose)
   const renderer = createLogRenderer(true);
+  const normalizer = new EventStreamNormalizer();
   const framework = firstResponse.framework;
 
   for (const event of events) {
-    renderAgentEvent(event, renderer, framework);
+    renderAgentEvent(event, renderer, normalizer, framework);
+  }
+  for (const parsed of normalizer.flush()) {
+    renderer.render(parsed);
   }
 
   console.log(chalk.dim(`View on platform: ${platformUrl}`));

--- a/turbo/apps/cli/src/commands/run/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/run/__tests__/index.test.ts
@@ -20,6 +20,10 @@ vi.mock("child_process", async (importOriginal) => {
 import { spawn } from "child_process";
 const mockSpawn = vi.mocked(spawn);
 
+function countOccurrences(text: string, pattern: string): number {
+  return text.split(pattern).length - 1;
+}
+
 describe("run command", () => {
   const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
     throw new Error("process.exit called");
@@ -1951,6 +1955,124 @@ describe("run command", () => {
         expect.stringContaining("Run failed"),
       );
       expect(pollCount).toBe(1);
+    });
+
+    it("should collapse paired Codex error and turn.failed before failed run lifecycle output", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/agent/runs/:id/events", () => {
+          return HttpResponse.json({
+            events: [
+              {
+                sequenceNumber: 0,
+                eventType: "thread.started",
+                eventData: {
+                  type: "thread.started",
+                  thread_id: "thread-x",
+                },
+                createdAt: "2025-01-01T00:00:00Z",
+              },
+              {
+                sequenceNumber: 1,
+                eventType: "error",
+                eventData: {
+                  type: "error",
+                  message: "API connection failed",
+                },
+                createdAt: "2025-01-01T00:00:01Z",
+              },
+              {
+                sequenceNumber: 2,
+                eventType: "turn.failed",
+                eventData: {
+                  type: "turn.failed",
+                  error: "Rate limit exceeded",
+                },
+                createdAt: "2025-01-01T00:00:02Z",
+              },
+            ],
+            hasMore: false,
+            nextSequence: 2,
+            run: { status: "failed", error: "Agent crashed" },
+            framework: "codex",
+          });
+        }),
+      );
+
+      await expect(async () => {
+        await runCommand.parseAsync(["node", "cli", testUuid, "test prompt"]);
+      }).rejects.toThrow("process.exit called");
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(countOccurrences(logCalls, "Codex Failed")).toBe(1);
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Run failed"),
+      );
+    });
+
+    it("should collapse paired Codex error and turn.failed across event pages", async () => {
+      let pollCount = 0;
+      server.use(
+        http.get("http://localhost:3000/api/agent/runs/:id/events", () => {
+          pollCount++;
+          if (pollCount === 1) {
+            return HttpResponse.json({
+              events: [
+                {
+                  sequenceNumber: 0,
+                  eventType: "thread.started",
+                  eventData: {
+                    type: "thread.started",
+                    thread_id: "thread-x",
+                  },
+                  createdAt: "2025-01-01T00:00:00Z",
+                },
+                {
+                  sequenceNumber: 1,
+                  eventType: "error",
+                  eventData: {
+                    type: "error",
+                    message: "API connection failed",
+                  },
+                  createdAt: "2025-01-01T00:00:01Z",
+                },
+              ],
+              hasMore: true,
+              nextSequence: 1,
+              run: { status: "running" },
+              framework: "codex",
+            });
+          }
+
+          return HttpResponse.json({
+            events: [
+              {
+                sequenceNumber: 2,
+                eventType: "turn.failed",
+                eventData: {
+                  type: "turn.failed",
+                  error: "Rate limit exceeded",
+                },
+                createdAt: "2025-01-01T00:00:02Z",
+              },
+            ],
+            hasMore: false,
+            nextSequence: 2,
+            run: { status: "failed", error: "Agent crashed" },
+            framework: "codex",
+          });
+        }),
+      );
+
+      await expect(async () => {
+        await runCommand.parseAsync(["node", "cli", testUuid, "test prompt"]);
+      }).rejects.toThrow("process.exit called");
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(pollCount).toBe(2);
+      expect(countOccurrences(logCalls, "Codex Failed")).toBe(1);
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Run failed"),
+      );
     });
 
     it("should not drain additional pages after failed status without watermark", async () => {

--- a/turbo/apps/cli/src/commands/run/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/run/__tests__/index.test.ts
@@ -2075,6 +2075,49 @@ describe("run command", () => {
       );
     });
 
+    it("should flush standalone Codex error before failed run lifecycle output", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/agent/runs/:id/events", () => {
+          return HttpResponse.json({
+            events: [
+              {
+                sequenceNumber: 0,
+                eventType: "thread.started",
+                eventData: {
+                  type: "thread.started",
+                  thread_id: "thread-x",
+                },
+                createdAt: "2025-01-01T00:00:00Z",
+              },
+              {
+                sequenceNumber: 1,
+                eventType: "error",
+                eventData: {
+                  type: "error",
+                  message: "API connection failed",
+                },
+                createdAt: "2025-01-01T00:00:01Z",
+              },
+            ],
+            hasMore: false,
+            nextSequence: 1,
+            run: { status: "failed", error: "Agent crashed" },
+            framework: "codex",
+          });
+        }),
+      );
+
+      await expect(async () => {
+        await runCommand.parseAsync(["node", "cli", testUuid, "test prompt"]);
+      }).rejects.toThrow("process.exit called");
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(countOccurrences(logCalls, "Codex Failed")).toBe(1);
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Run failed"),
+      );
+    });
+
     it("should not drain additional pages after failed status without watermark", async () => {
       let pollCount = 0;
       server.use(

--- a/turbo/apps/cli/src/commands/run/shared.ts
+++ b/turbo/apps/cli/src/commands/run/shared.ts
@@ -3,7 +3,7 @@ import * as fs from "node:fs";
 import { config as dotenvConfig } from "dotenv";
 import { getEvents } from "../../lib/api";
 import type { GetEventsResponse } from "../../lib/api/core/types";
-import { parseEvent } from "../../lib/events/event-parser-factory";
+import { EventStreamNormalizer } from "../../lib/events/event-stream-normalizer";
 import { EventRenderer } from "../../lib/events/event-renderer";
 import { extractAndGroupVariables } from "@vm0/core/variable-expander";
 import {
@@ -484,6 +484,7 @@ export async function pollEvents(
   options?: EventRenderingOptions,
 ): Promise<PollResult> {
   const renderer = new EventRenderer({ verbose: options?.verbose });
+  const normalizer = new EventStreamNormalizer();
 
   let nextSequence = -1;
   const terminalDrain: TerminalDrainState = {
@@ -491,6 +492,11 @@ export async function pollEvents(
     lastProgressAt: 0,
   };
   let seenResultEvent = false;
+  const flushPendingEvents = (): void => {
+    for (const parsed of normalizer.flush()) {
+      renderer.render(parsed);
+    }
+  };
 
   for (;;) {
     const previousSequence = nextSequence;
@@ -504,10 +510,11 @@ export async function pollEvents(
     // Render agent events (use appropriate renderer based on framework from API)
     if (madeSequenceProgress) {
       for (const event of response.events) {
-        const eventData = event.eventData as Record<string, unknown>;
-
-        const parsed = parseEvent(eventData, response.framework);
-        if (parsed) {
+        const parsedEvents = normalizer.process(
+          event.eventData,
+          response.framework,
+        );
+        for (const parsed of parsedEvents) {
           renderer.render(parsed);
           if (parsed.type === "result") {
             pageHasResultEvent = true;
@@ -535,6 +542,7 @@ export async function pollEvents(
       terminalDrain.runState &&
       hasReachedTerminalWatermark(terminalDrain.runState, nextSequence)
     ) {
+      flushPendingEvents();
       return renderTerminalRunResult(runId, terminalDrain.runState);
     }
 
@@ -549,6 +557,7 @@ export async function pollEvents(
         seenResultEvent,
       )
     ) {
+      flushPendingEvents();
       return renderTerminalRunResult(runId, terminalRunState);
     }
 

--- a/turbo/apps/cli/src/commands/zero/logs/__tests__/view.test.ts
+++ b/turbo/apps/cli/src/commands/zero/logs/__tests__/view.test.ts
@@ -30,6 +30,10 @@ function makeEvent(
   };
 }
 
+function countOccurrences(text: string, pattern: string): number {
+  return text.split(pattern).length - 1;
+}
+
 const RUN_ID = "abc12345-1234-1234-1234-123456789abc";
 
 describe("zero logs view command", () => {
@@ -223,6 +227,54 @@ describe("zero logs view command", () => {
     expect(logCalls).toContain("Codex Started");
     expect(logCalls).toContain("Codex zero output");
     expect(logCalls).toContain("Codex Completed");
+  });
+
+  it("should collapse paired Codex error and turn.failed when default tail order is descending", async () => {
+    server.use(
+      http.get(
+        "http://localhost:3000/api/zero/runs/:id/telemetry/agent",
+        () => {
+          return HttpResponse.json({
+            events: [
+              {
+                sequenceNumber: 3,
+                eventType: "turn.failed",
+                createdAt: "2024-01-15T10:30:02Z",
+                eventData: {
+                  type: "turn.failed",
+                  error: "Rate limit exceeded",
+                },
+              },
+              {
+                sequenceNumber: 2,
+                eventType: "error",
+                createdAt: "2024-01-15T10:30:01Z",
+                eventData: {
+                  type: "error",
+                  message: "API connection failed",
+                },
+              },
+              {
+                sequenceNumber: 1,
+                eventType: "thread.started",
+                createdAt: "2024-01-15T10:30:00Z",
+                eventData: {
+                  type: "thread.started",
+                  thread_id: "thread-zero-1",
+                },
+              },
+            ],
+            framework: "codex",
+            hasMore: false,
+          });
+        },
+      ),
+    );
+
+    await zeroLogsCommand.parseAsync(["node", "cli", RUN_ID]);
+
+    const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+    expect(countOccurrences(logCalls, "Codex Failed")).toBe(1);
   });
 
   it("should handle authentication error", async () => {

--- a/turbo/apps/cli/src/commands/zero/logs/index.ts
+++ b/turbo/apps/cli/src/commands/zero/logs/index.ts
@@ -2,7 +2,7 @@ import { Command } from "commander";
 import chalk from "chalk";
 import { getZeroRunAgentEvents, type RunEvent } from "../../../lib/api";
 import { parseTime } from "../../../lib/utils/time-parser";
-import { parseEvent } from "../../../lib/events/event-parser-factory";
+import { EventStreamNormalizer } from "../../../lib/events/event-stream-normalizer";
 import { EventRenderer } from "../../../lib/events/event-renderer";
 import { paginate } from "../../../lib/utils/paginate";
 import { withErrorHandler } from "../../../lib/command";
@@ -15,12 +15,15 @@ const PAGE_LIMIT = 100;
 function renderAgentEvent(
   event: RunEvent,
   renderer: EventRenderer,
+  normalizer: EventStreamNormalizer,
   framework: string,
 ): void {
-  const eventData = event.eventData as Record<string, unknown>;
-  const parsed = parseEvent(eventData, framework);
-  if (parsed) {
-    parsed.timestamp = new Date(event.createdAt);
+  const parsedEvents = normalizer.process(
+    event.eventData,
+    framework,
+    new Date(event.createdAt),
+  );
+  for (const parsed of parsedEvents) {
     renderer.render(parsed);
   }
 }
@@ -97,10 +100,14 @@ async function showAgentEvents(
     showTimestamp: true,
     verbose: true,
   });
+  const normalizer = new EventStreamNormalizer();
   const framework = firstResponse.framework;
 
   for (const event of events) {
-    renderAgentEvent(event, renderer, framework);
+    renderAgentEvent(event, renderer, normalizer, framework);
+  }
+  for (const parsed of normalizer.flush()) {
+    renderer.render(parsed);
   }
 }
 

--- a/turbo/apps/cli/src/commands/zero/run/__tests__/run.test.ts
+++ b/turbo/apps/cli/src/commands/zero/run/__tests__/run.test.ts
@@ -7,7 +7,7 @@
  * - Real (internal): All CLI code, formatters, validators
  */
 
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { http, HttpResponse } from "msw";
 import { server } from "../../../../mocks/server";
 import { mainRunCommand } from "../run";
@@ -73,6 +73,12 @@ describe("zero run command", () => {
         },
       ),
     );
+  });
+
+  afterEach(() => {
+    mockExit.mockClear();
+    mockConsoleLog.mockClear();
+    mockConsoleError.mockClear();
   });
 
   describe("agent ID validation", () => {

--- a/turbo/apps/cli/src/commands/zero/run/__tests__/run.test.ts
+++ b/turbo/apps/cli/src/commands/zero/run/__tests__/run.test.ts
@@ -17,7 +17,7 @@ describe("zero run command", () => {
   const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
     throw new Error("process.exit called");
   }) as never);
-  vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
   const mockConsoleError = vi
     .spyOn(console, "error")
     .mockImplementation(() => {});
@@ -49,6 +49,10 @@ describe("zero run command", () => {
     hasMore: false,
     framework: "claude-code",
   };
+
+  function countOccurrences(text: string, pattern: string): number {
+    return text.split(pattern).length - 1;
+  }
 
   beforeEach(() => {
     chalk.level = 0;
@@ -297,6 +301,72 @@ describe("zero run command", () => {
       );
       expect(mockConsoleError).not.toHaveBeenCalledWith(
         expect.stringContaining("Run timed out"),
+      );
+    });
+
+    it("should collapse paired Codex error and turn.failed before failed run output", async () => {
+      server.use(
+        http.get(
+          "http://localhost:3000/api/zero/runs/:id/telemetry/agent",
+          () => {
+            return HttpResponse.json({
+              events: [
+                {
+                  sequenceNumber: 0,
+                  eventType: "thread.started",
+                  eventData: {
+                    type: "thread.started",
+                    thread_id: "thread-zero-1",
+                  },
+                  createdAt: "2025-01-01T00:00:00Z",
+                },
+                {
+                  sequenceNumber: 1,
+                  eventType: "error",
+                  eventData: {
+                    type: "error",
+                    message: "API connection failed",
+                  },
+                  createdAt: "2025-01-01T00:00:01Z",
+                },
+                {
+                  sequenceNumber: 2,
+                  eventType: "turn.failed",
+                  eventData: {
+                    type: "turn.failed",
+                    error: "Rate limit exceeded",
+                  },
+                  createdAt: "2025-01-01T00:00:02Z",
+                },
+              ],
+              hasMore: false,
+              framework: "codex",
+            });
+          },
+        ),
+        http.get("http://localhost:3000/api/zero/runs/:id", () => {
+          return HttpResponse.json({
+            ...defaultGetRunResponse,
+            status: "failed",
+            error: "Agent crashed",
+            result: undefined,
+          });
+        }),
+      );
+
+      await expect(async () => {
+        await mainRunCommand.parseAsync([
+          "node",
+          "cli",
+          testAgentId,
+          "test prompt",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(countOccurrences(logCalls, "Codex Failed")).toBe(1);
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Run failed"),
       );
     });
 

--- a/turbo/apps/cli/src/commands/zero/run/shared.ts
+++ b/turbo/apps/cli/src/commands/zero/run/shared.ts
@@ -1,7 +1,7 @@
 import chalk from "chalk";
 import { getZeroRunAgentEvents, getZeroRun } from "../../../lib/api";
 import type { RunResult } from "../../../lib/api";
-import { parseEvent } from "../../../lib/events/event-parser-factory";
+import { EventStreamNormalizer } from "../../../lib/events/event-stream-normalizer";
 import { EventRenderer } from "../../../lib/events/event-renderer";
 import type { PollResult, EventRenderingOptions } from "../../run/shared";
 
@@ -154,6 +154,7 @@ export async function pollZeroEvents(
   options?: EventRenderingOptions,
 ): Promise<PollResult> {
   const renderer = new EventRenderer({ verbose: options?.verbose });
+  const normalizer = new EventStreamNormalizer();
 
   let lastSequence = -1;
   let complete = false;
@@ -161,6 +162,11 @@ export async function pollZeroEvents(
   let terminalRunResponse: TerminalRunResponse | undefined;
   let terminalSeenAt = 0;
   let lastTerminalProgressAt = 0;
+  const flushPendingEvents = (): void => {
+    for (const parsed of normalizer.flush()) {
+      renderer.render(parsed);
+    }
+  };
 
   while (!complete) {
     // 1. Fetch events from telemetry endpoint
@@ -177,9 +183,11 @@ export async function pollZeroEvents(
 
     // 2. Parse and render each event
     for (const event of contiguousEvents) {
-      const eventData = event.eventData as Record<string, unknown>;
-      const parsed = parseEvent(eventData, eventsResponse.framework);
-      if (parsed) {
+      const parsedEvents = normalizer.process(
+        event.eventData,
+        eventsResponse.framework,
+      );
+      for (const parsed of parsedEvents) {
         renderer.render(parsed);
       }
     }
@@ -222,6 +230,7 @@ export async function pollZeroEvents(
           blockedByGap,
         )
       ) {
+        flushPendingEvents();
         result = renderTerminalRunResult(runId, terminalRunResponse);
         complete = true;
       }

--- a/turbo/apps/cli/src/lib/events/event-stream-normalizer.ts
+++ b/turbo/apps/cli/src/lib/events/event-stream-normalizer.ts
@@ -1,0 +1,72 @@
+import type { ParsedEvent } from "./claude-event-parser";
+import { parseEvent } from "./event-parser-factory";
+
+function asRecord(rawEvent: unknown): Record<string, unknown> | null {
+  if (!rawEvent || typeof rawEvent !== "object") {
+    return null;
+  }
+  return rawEvent as Record<string, unknown>;
+}
+
+function getEventType(
+  rawEvent: Record<string, unknown> | null,
+): string | undefined {
+  const eventType = rawEvent?.type;
+  return typeof eventType === "string" ? eventType : undefined;
+}
+
+/**
+ * Preserves single-event parser behavior while applying stream-aware
+ * presentation fixes that require one-event lookahead.
+ */
+export class EventStreamNormalizer {
+  private pendingCodexError: ParsedEvent | null = null;
+
+  process(
+    rawEvent: unknown,
+    framework?: string,
+    timestamp?: Date,
+  ): ParsedEvent[] {
+    const isCodex = framework === "codex";
+    const rawRecord = asRecord(rawEvent);
+    const eventType = getEventType(rawRecord);
+    const parsed = rawRecord ? parseEvent(rawRecord, framework) : null;
+    if (parsed && timestamp) {
+      parsed.timestamp = timestamp;
+    }
+
+    if (!isCodex) {
+      const output = this.flush();
+      if (parsed) {
+        output.push(parsed);
+      }
+      return output;
+    }
+
+    if (eventType === "error" && parsed?.type === "result") {
+      const output = this.flush();
+      this.pendingCodexError = parsed;
+      return output;
+    }
+
+    if (eventType === "turn.failed") {
+      this.pendingCodexError = null;
+      return parsed ? [parsed] : [];
+    }
+
+    const output = this.flush();
+    if (parsed) {
+      output.push(parsed);
+    }
+    return output;
+  }
+
+  flush(): ParsedEvent[] {
+    if (!this.pendingCodexError) {
+      return [];
+    }
+    const output = [this.pendingCodexError];
+    this.pendingCodexError = null;
+    return output;
+  }
+}


### PR DESCRIPTION
## Summary

- add a CLI event stream normalizer that holds Codex top-level error events for one-event lookahead
- use the normalizer in both live `vm0 run` polling and historical `vm0 logs` rendering
- cover same-page and cross-page `error` + `turn.failed` Codex failure streams

Fixes #13112

## Verification

- `pnpm -C turbo/apps/cli test src/commands/logs/__tests__/index.test.ts src/commands/run/__tests__/index.test.ts`
- `pnpm -C turbo/apps/cli check-types`
- `pnpm -C turbo/apps/cli lint`
- pre-commit: prettier, knip, workspace check-types

## Note

`dev-server:turbo-reset` completed dependency cleanup/reinstall, but `pnpm db:migrate` failed on existing local data with `credit_usage -> usage_event backfill found 46 existing usage_event rows with mismatched payloads`; unrelated to this CLI change.