### PR TITLE
refactor: make codex providers feature-switch free

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-schedule.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-schedule.test.ts
@@ -3,7 +3,7 @@ import { randomUUID } from "node:crypto";
 import { createStore } from "ccstate";
 import { eq } from "drizzle-orm";
 import { HttpResponse, http } from "msw";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { zeroAgentSchedules } from "@vm0/db/schema/zero-agent-schedule";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
 
@@ -195,6 +195,7 @@ async function runSummary(runId: string): Promise<string | null> {
 }
 
 afterEach(() => {
+  vi.useRealTimers();
   clearMockNow();
   context.mocks.axiom.query.mockReset();
 });
@@ -319,7 +320,10 @@ describe("POST /api/internal/callbacks/schedule/*", () => {
   });
 
   it("advances cron callbacks and persists completed-run summaries", async () => {
-    mockNow(new Date("2026-05-13T04:00:00.000Z"));
+    const completedAt = new Date("2026-05-13T04:00:00.000Z");
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(completedAt);
+    mockNow(completedAt);
     const fixture = await track(seedFixture());
     const scheduleId = await seedSchedule(fixture, {
       kind: "cron",

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-me-model-providers-codex-oauth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-me-model-providers-codex-oauth.test.ts
@@ -1,18 +1,14 @@
 import { randomUUID } from "node:crypto";
 
 import { createStore } from "ccstate";
-import { and, eq } from "drizzle-orm";
 import { http, HttpResponse } from "msw";
 import { describe, expect, it } from "vitest";
 
 import { zeroPersonalModelProvidersMainContract } from "@vm0/api-contracts/contracts/zero-personal-model-providers";
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
-import { userFeatureSwitches } from "@vm0/db/schema/user-feature-switches";
 
 import { createApp } from "../../../app-factory";
 import { server } from "../../../mocks/server";
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
-import { writeDb$ } from "../../external/db";
 import {
   deleteUserModelProviders$,
   type UserModelProviderFixture,
@@ -49,44 +45,6 @@ function uniqueOrgUser(prefix: string): UserModelProviderFixture {
   };
 }
 
-async function setPersonalSwitches(
-  orgId: string,
-  userId: string,
-  switches: Partial<Record<FeatureSwitchKey, boolean>>,
-): Promise<void> {
-  const writeDb = store.set(writeDb$);
-  await writeDb
-    .insert(userFeatureSwitches)
-    .values({ orgId, userId, switches })
-    .onConflictDoUpdate({
-      target: [userFeatureSwitches.orgId, userFeatureSwitches.userId],
-      set: { switches },
-    });
-}
-
-async function enableAllPersonalSwitches(
-  orgId: string,
-  userId: string,
-): Promise<void> {
-  await setPersonalSwitches(orgId, userId, {
-    [FeatureSwitchKey.CodexOauthProvider]: true,
-  });
-}
-
-async function deletePersonalSwitches(
-  fixture: UserModelProviderFixture,
-): Promise<void> {
-  const writeDb = store.set(writeDb$);
-  await writeDb
-    .delete(userFeatureSwitches)
-    .where(
-      and(
-        eq(userFeatureSwitches.orgId, fixture.orgId),
-        eq(userFeatureSwitches.userId, fixture.userId),
-      ),
-    );
-}
-
 function base64Url(value: string): string {
   return Buffer.from(value)
     .toString("base64")
@@ -107,7 +65,6 @@ describe("GET /api/zero/me/model-providers/codex-oauth-token/oauth", () => {
   const track = createFixtureTracker<UserModelProviderFixture>(
     async (fixture) => {
       await store.set(deleteUserModelProviders$, fixture, context.signal);
-      await deletePersonalSwitches(fixture);
     },
   );
 
@@ -124,32 +81,10 @@ describe("GET /api/zero/me/model-providers/codex-oauth-token/oauth", () => {
     expect(url.searchParams.get("redirect_url")).toBe(authorizeUrl());
   });
 
-  it("returns 404 from authorize when Codex OAuth is disabled", async () => {
-    const fixture = await track(
-      Promise.resolve(uniqueOrgUser("codex-oauth-authz-off")),
-    );
-    await setPersonalSwitches(fixture.orgId, fixture.userId, {
-      [FeatureSwitchKey.CodexOauthProvider]: false,
-    });
-    mocks.clerk.session(fixture.userId, fixture.orgId);
-    const app = createApp({ signal: context.signal });
-
-    const response = await app.request(authorizeUrl(), {
-      method: "GET",
-      headers: sessionHeaders(),
-    });
-
-    expect(response.status).toBe(404);
-    await expect(response.json()).resolves.toStrictEqual({
-      error: "Not found",
-    });
-  });
-
   it("redirects authorize to OpenAI OAuth with state and PKCE cookies", async () => {
     const fixture = await track(
       Promise.resolve(uniqueOrgUser("codex-oauth-authz")),
     );
-    await enableAllPersonalSwitches(fixture.orgId, fixture.userId);
     mocks.clerk.session(fixture.userId, fixture.orgId);
     const app = createApp({ signal: context.signal });
 
@@ -227,7 +162,6 @@ describe("GET /api/zero/me/model-providers/codex-oauth-token/oauth", () => {
     const fixture = await track(
       Promise.resolve(uniqueOrgUser("codex-oauth-callback")),
     );
-    await enableAllPersonalSwitches(fixture.orgId, fixture.userId);
     mocks.clerk.session(fixture.userId, fixture.orgId);
     const accessToken = createJwt({ exp: 1_900_000_000 });
     const idToken = createJwt({
@@ -308,36 +242,6 @@ describe("GET /api/zero/me/model-providers/codex-oauth-token/oauth", () => {
           needsReconnect: false,
         }),
       ]),
-    );
-  });
-
-  it("redirects callback with an error when Codex OAuth is disabled", async () => {
-    const fixture = await track(
-      Promise.resolve(uniqueOrgUser("codex-oauth-callback-off")),
-    );
-    await setPersonalSwitches(fixture.orgId, fixture.userId, {
-      [FeatureSwitchKey.CodexOauthProvider]: false,
-    });
-    mocks.clerk.session(fixture.userId, fixture.orgId);
-    const app = createApp({ signal: context.signal });
-
-    const response = await app.request(
-      callbackUrl("code=code-1&state=state-1"),
-      {
-        method: "GET",
-        headers: sessionHeaders(
-          "__session=opaque; model_provider_oauth_state=state-1; model_provider_oauth_pkce=verifier-1",
-        ),
-      },
-    );
-
-    expect(response.status).toBe(307);
-    const location = response.headers.get("location");
-    expect(location).not.toBeNull();
-    const url = new URL(location!);
-    expect(url.pathname).toBe("/connector/error");
-    expect(url.searchParams.get("message")).toBe(
-      "OpenAI OAuth is not available",
     );
   });
 });

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-me-model-providers-upsert.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-me-model-providers-upsert.test.ts
@@ -4,9 +4,7 @@ import { createStore } from "ccstate";
 import { and, eq } from "drizzle-orm";
 
 import { zeroPersonalModelProvidersMainContract } from "@vm0/api-contracts/contracts/zero-personal-model-providers";
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { secrets } from "@vm0/db/schema/secret";
-import { userFeatureSwitches } from "@vm0/db/schema/user-feature-switches";
 
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
 import { now } from "../../../lib/time";
@@ -30,27 +28,6 @@ function uniqueOrgUser(prefix: string): UserModelProviderFixture {
     orgId: `org_${prefix}_${randomUUID().slice(0, 8)}`,
     userId: `user_${prefix}_${randomUUID().slice(0, 8)}`,
   };
-}
-
-async function setPersonalSwitches(
-  orgId: string,
-  userId: string,
-  switches: Partial<Record<FeatureSwitchKey, boolean>>,
-) {
-  const writeDb = store.set(writeDb$);
-  await writeDb
-    .insert(userFeatureSwitches)
-    .values({ orgId, userId, switches })
-    .onConflictDoUpdate({
-      target: [userFeatureSwitches.orgId, userFeatureSwitches.userId],
-      set: { switches },
-    });
-}
-
-async function enableAllPersonalSwitches(orgId: string, userId: string) {
-  await setPersonalSwitches(orgId, userId, {
-    [FeatureSwitchKey.CodexOauthProvider]: true,
-  });
 }
 
 // ===========================================================================
@@ -144,7 +121,6 @@ describe("POST /api/zero/me/model-providers (upsert)", () => {
   it("creates a single-secret personal provider", async () => {
     const fixture = uniqueOrgUser("zmmp-single-create");
     await track(Promise.resolve(fixture));
-    await enableAllPersonalSwitches(fixture.orgId, fixture.userId);
     mocks.clerk.session(fixture.userId, fixture.orgId);
 
     const client = setupApp({ context })(
@@ -184,7 +160,6 @@ describe("POST /api/zero/me/model-providers (upsert)", () => {
   it("updates an existing personal provider with 200", async () => {
     const fixture = uniqueOrgUser("zmmp-single-update");
     await track(Promise.resolve(fixture));
-    await enableAllPersonalSwitches(fixture.orgId, fixture.userId);
     mocks.clerk.session(fixture.userId, fixture.orgId);
 
     const client = setupApp({ context })(
@@ -210,7 +185,6 @@ describe("POST /api/zero/me/model-providers (upsert)", () => {
   it("returns 400 when single-secret provider is missing the secret", async () => {
     const fixture = uniqueOrgUser("zmmp-missing-secret");
     await track(Promise.resolve(fixture));
-    await enableAllPersonalSwitches(fixture.orgId, fixture.userId);
     mocks.clerk.session(fixture.userId, fixture.orgId);
 
     const client = setupApp({ context })(
@@ -229,7 +203,6 @@ describe("POST /api/zero/me/model-providers (upsert)", () => {
   it("returns 404 when posting vm0 with a secret", async () => {
     const fixture = uniqueOrgUser("zmmp-vm0-with-secret");
     await track(Promise.resolve(fixture));
-    await enableAllPersonalSwitches(fixture.orgId, fixture.userId);
     mocks.clerk.session(fixture.userId, fixture.orgId);
 
     const client = setupApp({ context })(
@@ -248,7 +221,6 @@ describe("POST /api/zero/me/model-providers (upsert)", () => {
   it("returns 404 when posting vm0 with no secret", async () => {
     const fixture = uniqueOrgUser("zmmp-vm0-no-secret");
     await track(Promise.resolve(fixture));
-    await enableAllPersonalSwitches(fixture.orgId, fixture.userId);
     mocks.clerk.session(fixture.userId, fixture.orgId);
 
     const client = setupApp({ context })(
@@ -267,7 +239,6 @@ describe("POST /api/zero/me/model-providers (upsert)", () => {
   it("returns 404 for openai-api-key", async () => {
     const fixture = uniqueOrgUser("zmmp-openai-rejected");
     await track(Promise.resolve(fixture));
-    await enableAllPersonalSwitches(fixture.orgId, fixture.userId);
     mocks.clerk.session(fixture.userId, fixture.orgId);
 
     const client = setupApp({ context })(
@@ -295,7 +266,6 @@ describe("POST /api/zero/me/model-providers (upsert)", () => {
   it("paste valid auth.json persists derived secrets + metadata", async () => {
     const fixture = uniqueOrgUser("zmmp-codex-happy");
     await track(Promise.resolve(fixture));
-    await enableAllPersonalSwitches(fixture.orgId, fixture.userId);
     mocks.clerk.session(fixture.userId, fixture.orgId);
 
     const client = setupApp({ context })(
@@ -349,7 +319,6 @@ describe("POST /api/zero/me/model-providers (upsert)", () => {
   it("returns 400 CODEX_AUTH_JSON_SHAPE_INVALID on malformed JSON", async () => {
     const fixture = uniqueOrgUser("zmmp-codex-malformed");
     await track(Promise.resolve(fixture));
-    await enableAllPersonalSwitches(fixture.orgId, fixture.userId);
     mocks.clerk.session(fixture.userId, fixture.orgId);
 
     const client = setupApp({ context })(
@@ -374,7 +343,6 @@ describe("POST /api/zero/me/model-providers (upsert)", () => {
   it("returns 400 CODEX_AUTH_JSON_SHAPE_INVALID when tokens.refresh_token missing", async () => {
     const fixture = uniqueOrgUser("zmmp-codex-missing-rt");
     await track(Promise.resolve(fixture));
-    await enableAllPersonalSwitches(fixture.orgId, fixture.userId);
     mocks.clerk.session(fixture.userId, fixture.orgId);
 
     const incomplete = JSON.stringify({
@@ -408,7 +376,6 @@ describe("POST /api/zero/me/model-providers (upsert)", () => {
   it("returns 400 CODEX_FREE_PLAN_REJECTED for free-plan accounts", async () => {
     const fixture = uniqueOrgUser("zmmp-codex-free");
     await track(Promise.resolve(fixture));
-    await enableAllPersonalSwitches(fixture.orgId, fixture.userId);
     mocks.clerk.session(fixture.userId, fixture.orgId);
 
     const client = setupApp({ context })(
@@ -433,7 +400,6 @@ describe("POST /api/zero/me/model-providers (upsert)", () => {
   it("returns 400 BAD_REQUEST when CODEX_AUTH_JSON is missing from secrets", async () => {
     const fixture = uniqueOrgUser("zmmp-codex-no-blob");
     await track(Promise.resolve(fixture));
-    await enableAllPersonalSwitches(fixture.orgId, fixture.userId);
     mocks.clerk.session(fixture.userId, fixture.orgId);
 
     const client = setupApp({ context })(
@@ -454,39 +420,4 @@ describe("POST /api/zero/me/model-providers (upsert)", () => {
       error: { code: "BAD_REQUEST" },
     });
   });
-
-  it("returns 404 when CodexOauthProvider feature switch is off", async () => {
-    const fixture = uniqueOrgUser("zmmp-codex-gate-off");
-    await track(Promise.resolve(fixture));
-    await setPersonalSwitches(fixture.orgId, fixture.userId, {
-      [FeatureSwitchKey.CodexOauthProvider]: false,
-    });
-    mocks.clerk.session(fixture.userId, fixture.orgId);
-
-    const client = setupApp({ context })(
-      zeroPersonalModelProvidersMainContract,
-    );
-    const response = await accept(
-      client.upsert({
-        body: {
-          type: "codex-oauth-token",
-          authMethod: "auth_json",
-          secrets: { CODEX_AUTH_JSON: makeAuthJson() },
-        },
-        headers: { authorization: "Bearer clerk-session" },
-      }),
-      [404],
-    );
-    expect(response.body).toMatchObject({
-      error: {
-        code: "NOT_FOUND",
-        message: 'Provider "codex-oauth-token" not found',
-      },
-    });
-  });
 });
-
-// Cleanup the userFeatureSwitches rows created by this suite — the sibling
-// `deleteUserModelProviders$` helper only cleans `model_providers` + `secrets`.
-// Without this the userFeatureSwitches table grows unboundedly across runs.
-// (Same pattern as the delete sibling test.)

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-model-providers.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-model-providers.test.ts
@@ -2,14 +2,12 @@ import { randomUUID } from "node:crypto";
 
 import { and, eq } from "drizzle-orm";
 import { createStore } from "ccstate";
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import {
   zeroModelProvidersByTypeContract,
   zeroModelProvidersMainContract,
 } from "@vm0/api-contracts/contracts/zero-model-providers";
 import { modelProviders } from "@vm0/db/schema/model-provider";
 import { secrets } from "@vm0/db/schema/secret";
-import { userFeatureSwitches } from "@vm0/db/schema/user-feature-switches";
 
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
 import { now } from "../../../lib/time";
@@ -39,21 +37,6 @@ function uniqueOrgUser(prefix: string): {
     orgId: `org_${prefix}_${randomUUID().slice(0, 8)}`,
     userId: `user_${prefix}_${randomUUID().slice(0, 8)}`,
   };
-}
-
-async function setSwitches(
-  orgId: string,
-  userId: string,
-  switches: Partial<Record<FeatureSwitchKey, boolean>>,
-): Promise<void> {
-  const writeDb = store.set(writeDb$);
-  await writeDb
-    .insert(userFeatureSwitches)
-    .values({ orgId, userId, switches })
-    .onConflictDoUpdate({
-      target: [userFeatureSwitches.orgId, userFeatureSwitches.userId],
-      set: { switches },
-    });
 }
 
 function base64UrlEncode(input: string): string {
@@ -538,18 +521,13 @@ describe("POST /api/zero/model-providers", () => {
     expect(response.body.error.code).toBe("BAD_REQUEST");
   });
 
-  it("gates openai-api-key with CodexBeta only", async () => {
-    const enabled = uniqueOrgUser("zmp-openai-enabled");
-    const disabled = uniqueOrgUser("zmp-openai-disabled");
-    await track(Promise.resolve({ orgId: enabled.orgId }));
-    await track(Promise.resolve({ orgId: disabled.orgId }));
+  it("creates an openai-api-key provider by default", async () => {
+    const fixture = uniqueOrgUser("zmp-openai");
+    await track(Promise.resolve({ orgId: fixture.orgId }));
     const client = setupApp({ context })(zeroModelProvidersMainContract);
 
-    await setSwitches(enabled.orgId, enabled.userId, {
-      [FeatureSwitchKey.CodexBeta]: true,
-    });
-    mocks.clerk.session(enabled.userId, enabled.orgId, "org:admin");
-    const ok = await accept(
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+    const response = await accept(
       client.upsert({
         headers: { authorization: "Bearer clerk-session" },
         body: {
@@ -559,25 +537,8 @@ describe("POST /api/zero/model-providers", () => {
       }),
       [201],
     );
-    expect(ok.body.provider.framework).toBe("codex");
-
-    await setSwitches(disabled.orgId, disabled.userId, {
-      [FeatureSwitchKey.CodexBeta]: false,
-    });
-    mocks.clerk.session(disabled.userId, disabled.orgId, "org:admin");
-    const notFound = await accept(
-      client.upsert({
-        headers: { authorization: "Bearer clerk-session" },
-        body: {
-          type: "openai-api-key",
-          secret: "sk-proj-test",
-        },
-      }),
-      [404],
-    );
-    expect(notFound.body.error.message).toBe(
-      'Provider "openai-api-key" not found',
-    );
+    expect(response.body.provider.framework).toBe("codex");
+    expect(response.body.provider.type).toBe("openai-api-key");
 
     const other = await accept(
       client.upsert({
@@ -592,9 +553,6 @@ describe("POST /api/zero/model-providers", () => {
   it("does not mark provider rows as defaults across frameworks", async () => {
     const fixture = uniqueOrgUser("zmp-cross-framework");
     await track(Promise.resolve({ orgId: fixture.orgId }));
-    await setSwitches(fixture.orgId, fixture.userId, {
-      [FeatureSwitchKey.CodexBeta]: true,
-    });
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
     const client = setupApp({ context })(zeroModelProvidersMainContract);
 
@@ -660,9 +618,6 @@ describe("POST /api/zero/model-providers", () => {
   it("handles codex auth_json paste and never stores the raw blob", async () => {
     const fixture = uniqueOrgUser("zmp-codex-paste");
     await track(Promise.resolve({ orgId: fixture.orgId }));
-    await setSwitches(fixture.orgId, fixture.userId, {
-      [FeatureSwitchKey.CodexOauthProvider]: true,
-    });
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
     const client = setupApp({ context })(zeroModelProvidersMainContract);
 
@@ -704,9 +659,6 @@ describe("POST /api/zero/model-providers", () => {
   it("returns typed codex auth_json validation errors", async () => {
     const fixture = uniqueOrgUser("zmp-codex-invalid");
     await track(Promise.resolve({ orgId: fixture.orgId }));
-    await setSwitches(fixture.orgId, fixture.userId, {
-      [FeatureSwitchKey.CodexOauthProvider]: true,
-    });
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
     const client = setupApp({ context })(zeroModelProvidersMainContract);
 
@@ -750,12 +702,9 @@ describe("POST /api/zero/model-providers", () => {
     expect(missing.body.error.code).toBe("BAD_REQUEST");
   });
 
-  it("re-paste clears codex reconnect state and respects the feature gate", async () => {
+  it("re-paste clears codex reconnect state", async () => {
     const fixture = uniqueOrgUser("zmp-codex-repaste");
     await track(Promise.resolve({ orgId: fixture.orgId }));
-    await setSwitches(fixture.orgId, fixture.userId, {
-      [FeatureSwitchKey.CodexOauthProvider]: true,
-    });
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
     const client = setupApp({ context })(zeroModelProvidersMainContract);
 
@@ -801,24 +750,6 @@ describe("POST /api/zero/model-providers", () => {
     await expect(
       findOrgModelProviderSecret(fixture.orgId, "CHATGPT_REFRESH_TOKEN"),
     ).resolves.toBe("rt_fresh_org");
-
-    await setSwitches(fixture.orgId, fixture.userId, {
-      [FeatureSwitchKey.CodexOauthProvider]: false,
-    });
-    const blocked = await accept(
-      client.upsert({
-        headers: { authorization: "Bearer clerk-session" },
-        body: {
-          type: "codex-oauth-token",
-          authMethod: "auth_json",
-          secrets: { CODEX_AUTH_JSON: makeAuthJson() },
-        },
-      }),
-      [404],
-    );
-    expect(blocked.body.error.message).toBe(
-      'Provider "codex-oauth-token" not found',
-    );
   });
 });
 

--- a/turbo/apps/api/src/signals/routes/zero-me-model-providers-codex-oauth.ts
+++ b/turbo/apps/api/src/signals/routes/zero-me-model-providers-codex-oauth.ts
@@ -1,7 +1,5 @@
 import { command } from "ccstate";
 import { zeroPersonalModelProvidersCodexOauthContract } from "@vm0/api-contracts/contracts/zero-personal-model-providers";
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
-import { isFeatureEnabled } from "@vm0/core/feature-switch";
 
 import { requiredAuthContext$ } from "../auth/auth-context";
 import { queryOf } from "../context/request";
@@ -12,7 +10,6 @@ import {
   exchangeChatgptCode,
   getChatgptOAuthClientId,
 } from "../services/codex-oauth-browser.service";
-import { userFeatureSwitchOverrides } from "../services/feature-switches.service";
 import { upsertUserMultiAuthModelProvider$ } from "../services/zero-model-provider.service";
 import { safeAsync } from "../utils";
 import type { RouteEntry } from "../route";
@@ -112,10 +109,6 @@ function redirectWithError(
   return response;
 }
 
-function featureDisabledResponse(): Response {
-  return jsonResponse({ error: "Not found" }, 404);
-}
-
 function missingOrganizationResponse(): Response {
   return jsonResponse(
     {
@@ -126,12 +119,6 @@ function missingOrganizationResponse(): Response {
     },
     400,
   );
-}
-
-function isModelProviderOAuthEnabled(
-  params: Parameters<typeof isFeatureEnabled>[1],
-): boolean {
-  return isFeatureEnabled(FeatureSwitchKey.CodexOauthProvider, params);
 }
 
 function errorMessage(error: unknown): string {
@@ -163,20 +150,6 @@ const authorizeInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   }
   if (!auth.orgId) {
     return missingOrganizationResponse();
-  }
-
-  const overrides = await get(
-    userFeatureSwitchOverrides(auth.orgId, auth.userId),
-  );
-  signal.throwIfAborted();
-  if (
-    !isModelProviderOAuthEnabled({
-      orgId: auth.orgId,
-      userId: auth.userId,
-      overrides,
-    })
-  ) {
-    return featureDisabledResponse();
   }
 
   const state = generateState();
@@ -250,20 +223,6 @@ const callbackInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   }
 
   const result = await safeAsync(async () => {
-    const overrides = await get(
-      userFeatureSwitchOverrides(auth.orgId, auth.userId),
-    );
-    signal.throwIfAborted();
-    if (
-      !isModelProviderOAuthEnabled({
-        orgId: auth.orgId,
-        userId: auth.userId,
-        overrides,
-      })
-    ) {
-      return redirectWithError(origin, "OpenAI OAuth is not available", true);
-    }
-
     const exchangeResult = await exchangeChatgptCode({
       clientId: getChatgptOAuthClientId(),
       code: authorizationCode,

--- a/turbo/apps/api/src/signals/routes/zero-me-model-providers-upsert.ts
+++ b/turbo/apps/api/src/signals/routes/zero-me-model-providers-upsert.ts
@@ -1,6 +1,4 @@
 import { command } from "ccstate";
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
-import { isFeatureEnabled } from "@vm0/core/feature-switch";
 import {
   hasAuthMethods,
   type ModelProviderResponse,
@@ -13,7 +11,6 @@ import { authRoute } from "../auth/auth-route";
 import { bodyResultOf } from "../context/request";
 import { badRequestMessage } from "../../lib/error";
 import { handleCodexAuthJsonPaste } from "../services/codex-auth-json-paste-handler";
-import { userFeatureSwitchOverrides } from "../services/feature-switches.service";
 import {
   upsertUserModelProvider$,
   upsertUserMultiAuthModelProvider$,
@@ -96,20 +93,6 @@ const upsertInner$ = command(async ({ get, set }, signal: AbortSignal) => {
 
   // Branch 1: codex-oauth-token + auth_json paste flow
   if (type === "codex-oauth-token" && authMethod === "auth_json") {
-    const overrides = await get(
-      userFeatureSwitchOverrides(auth.orgId, auth.userId),
-    );
-    signal.throwIfAborted();
-    // Gate 4: CodexOauthProvider
-    if (
-      !isFeatureEnabled(FeatureSwitchKey.CodexOauthProvider, {
-        orgId: auth.orgId,
-        userId: auth.userId,
-        overrides,
-      })
-    ) {
-      return providerNotFound(type);
-    }
     const raw = secrets?.CODEX_AUTH_JSON;
     if (!raw) {
       return badRequestMessage("Missing CODEX_AUTH_JSON secret");

--- a/turbo/apps/api/src/signals/routes/zero-model-providers.ts
+++ b/turbo/apps/api/src/signals/routes/zero-model-providers.ts
@@ -1,6 +1,4 @@
 import { command, computed } from "ccstate";
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
-import { isFeatureEnabled } from "@vm0/core/feature-switch";
 import {
   hasAuthMethods,
   type ModelProviderResponse,
@@ -15,7 +13,6 @@ import { authRoute } from "../auth/auth-route";
 import { bodyResultOf, pathParamsOf } from "../context/request";
 import { badRequestMessage, isNotFoundResponse } from "../../lib/error";
 import { handleCodexAuthJsonPaste } from "../services/codex-auth-json-paste-handler";
-import { userFeatureSwitchOverrides } from "../services/feature-switches.service";
 import {
   deleteOrgModelProvider$,
   upsertOrgModelProvider$,
@@ -41,18 +38,6 @@ const listModelProvidersInner$ = computed(async (get) => {
   const result = await get(zeroModelProviders(auth.orgId));
   return { status: 200 as const, body: result };
 });
-
-function providerNotFound(type: string) {
-  return {
-    status: 404 as const,
-    body: {
-      error: {
-        message: `Provider "${type}" not found`,
-        code: "NOT_FOUND" as const,
-      },
-    },
-  };
-}
 
 function toModelProviderResponse(
   provider: ModelProviderInfo,
@@ -99,29 +84,7 @@ const upsertModelProviderInner$ = command(
 
     const { type, secret, authMethod, secrets } = bodyResult.data;
 
-    const overrides = await get(
-      userFeatureSwitchOverrides(auth.orgId, auth.userId),
-    );
-    signal.throwIfAborted();
-    const featureContext = {
-      orgId: auth.orgId,
-      userId: auth.userId,
-      overrides,
-    };
-
-    if (
-      type === "openai-api-key" &&
-      !isFeatureEnabled(FeatureSwitchKey.CodexBeta, featureContext)
-    ) {
-      return providerNotFound(type);
-    }
-
     if (type === "codex-oauth-token" && authMethod === "auth_json") {
-      if (
-        !isFeatureEnabled(FeatureSwitchKey.CodexOauthProvider, featureContext)
-      ) {
-        return providerNotFound(type);
-      }
       const raw = secrets?.CODEX_AUTH_JSON;
       if (!raw) {
         return badRequestMessage("Missing CODEX_AUTH_JSON secret");

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-default-model-resolution.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-default-model-resolution.test.tsx
@@ -37,7 +37,6 @@ import type {
   ModelProviderResponse,
   OrgModelPolicy,
 } from "@vm0/api-contracts/contracts/model-providers";
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { detachedSetupPage, fill } from "../../../__tests__/page-helper.ts";
@@ -440,10 +439,7 @@ describe("chat composer — default model resolution", () => {
       .spyOn(window, "open")
       .mockReturnValue({ closed: true } as Window);
     let sendRequests = 0;
-    setMockFeatureSwitches({
-      [FeatureSwitchKey.CodexBeta]: true,
-      [FeatureSwitchKey.CodexOauthProvider]: true,
-    });
+    setMockFeatureSwitches({});
     setMockOrgModelPolicies([
       buildMemberOauthPolicy({
         model: "gpt-5.5",
@@ -518,10 +514,7 @@ describe("chat composer — default model resolution", () => {
       .spyOn(window, "open")
       .mockReturnValue({ closed: true } as Window);
     let sendRequests = 0;
-    setMockFeatureSwitches({
-      [FeatureSwitchKey.CodexBeta]: true,
-      [FeatureSwitchKey.CodexOauthProvider]: true,
-    });
+    setMockFeatureSwitches({});
     setMockOrgModelPolicies([
       buildMemberOauthPolicy({
         model: "gpt-5.5",

--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-add-provider-dialog-codex.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-add-provider-dialog-codex.test.tsx
@@ -2,15 +2,13 @@
  * Tests for the Connect Codex entry on the model-providers settings tab.
  *
  * Covers:
- * - Card hidden when CodexOauthProvider feature switch is off (DoD: gate-off)
- * - Card visible when feature switch is on (DoD: gate-on)
+ * - Card visible by default
  * - Click on the card opens the codex auth.json paste dialog
  *   (replaces the broken cross-origin OAuth redirect; #11980)
  */
 
 import { beforeEach, describe, expect, it } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { detachedSetupPage, click } from "../../../__tests__/page-helper.ts";
 import { setOrgAddProviderDialogOpen$ } from "../../../signals/zero-page/settings/org-model-providers.ts";
@@ -26,30 +24,13 @@ async function openProvidersPage() {
   });
 }
 
-describe("connect ChatGPT card — feature switch gating", () => {
+describe("connect ChatGPT card", () => {
   beforeEach(() => {
     setMockFeatureSwitches({});
     resetMockOrgModelProviders();
   });
 
-  it("hides the ChatGPT card when the feature switch is off", async () => {
-    await openProvidersPage();
-    context.store.set(setOrgAddProviderDialogOpen$, true);
-
-    await waitFor(() => {
-      expect(screen.getAllByRole("dialog").length).toBeGreaterThan(0);
-    });
-
-    expect(
-      screen.queryByTestId("org-provider-card-codex-oauth-token"),
-    ).not.toBeInTheDocument();
-  });
-
-  it("shows the ChatGPT card when the feature switch is on", async () => {
-    setMockFeatureSwitches({
-      [FeatureSwitchKey.CodexOauthProvider]: true,
-    });
-
+  it("shows the ChatGPT card by default", async () => {
     await openProvidersPage();
     context.store.set(setOrgAddProviderDialogOpen$, true);
 
@@ -63,9 +44,7 @@ describe("connect ChatGPT card — feature switch gating", () => {
 
 describe("connect Codex card — click handler", () => {
   beforeEach(() => {
-    setMockFeatureSwitches({
-      [FeatureSwitchKey.CodexOauthProvider]: true,
-    });
+    setMockFeatureSwitches({});
     resetMockOrgModelProviders();
   });
 

--- a/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
@@ -1,7 +1,6 @@
 import type { ReactNode } from "react";
 import { useLastResolved, useLoadable } from "ccstate-react";
 import { IconCpu } from "@tabler/icons-react";
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import {
   Select,
   SelectContent,
@@ -24,7 +23,6 @@ import {
   type ModelProviderType,
   type OrgModelPolicy,
 } from "@vm0/api-contracts/contracts/model-providers";
-import { featureSwitch$ } from "../../../signals/external/feature-switch";
 import { orgModelPolicies$ } from "../../../signals/external/org-model-policies";
 import { userModelPreference$ } from "../../../signals/external/user-model-preference";
 import { getVm0ModelMultiplier } from "./settings/provider-ui-config";
@@ -142,16 +140,6 @@ function stripInteractiveClasses(cls: string | undefined): string | undefined {
       );
     })
     .join(" ");
-}
-
-function isModelFirstPolicyVisible(
-  policy: OrgModelPolicy,
-  features: Partial<Record<FeatureSwitchKey, boolean>> | undefined,
-): boolean {
-  if (policy.model.startsWith("gpt-")) {
-    return features?.[FeatureSwitchKey.CodexBeta] ?? false;
-  }
-  return true;
 }
 
 function getModelFirstIconType(model: string): ModelProviderType | undefined {
@@ -372,13 +360,9 @@ function ModelFirstModelPicker({
   const policiesLoadable = useLoadable(orgModelPolicies$);
   const lastPolicies = useLastResolved(orgModelPolicies$);
   const userPreference = useLastResolved(userModelPreference$);
-  const features = useLastResolved(featureSwitch$);
   const policyResponse =
     policiesLoadable.state === "hasData" ? policiesLoadable.data : lastPolicies;
-  const policies =
-    policyResponse?.policies.filter((policy) => {
-      return isModelFirstPolicyVisible(policy, features);
-    }) ?? [];
+  const policies = policyResponse?.policies ?? [];
   const resolved = resolveModelFirstDefault(value, userPreference, policies);
   const selectedModel = resolved?.selectedModel ?? null;
   const explicitSelectedModel = value?.selectedModel ?? null;

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/__tests__/org-providers-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/__tests__/org-providers-tab.test.tsx
@@ -11,7 +11,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { screen, waitFor, within } from "@testing-library/react";
 import { toast } from "@vm0/ui/components/ui/sonner";
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { zeroModelProvidersMainContract } from "@vm0/api-contracts/contracts/zero-model-providers";
 import type { ModelProviderResponse } from "@vm0/api-contracts/contracts/model-providers";
 import { server } from "../../../../../mocks/server.ts";
@@ -197,23 +196,6 @@ describe("org-providers-tab — stale banner reconnect", () => {
     expect(screen.queryByText("Default provider")).not.toBeInTheDocument();
   });
 
-  it("hides the stale Codex reconnect banner when the Codex OAuth provider switch is off", async () => {
-    setMockFeatureSwitches({
-      [FeatureSwitchKey.CodexOauthProvider]: false,
-    });
-    setMockOrgModelProviders([makeStaleProvider()]);
-
-    await openProvidersPage();
-
-    await expect(
-      screen.findByText(/Manage workspace models/i),
-    ).resolves.toBeInTheDocument();
-    expect(
-      screen.queryByText(/ChatGPT session needs reconnection/i),
-    ).not.toBeInTheDocument();
-    expect(screen.queryByText("Re-paste auth.json")).not.toBeInTheDocument();
-  });
-
   it("changes the default model from the default selector", async () => {
     setMockFeatureSwitches({});
 
@@ -369,25 +351,6 @@ describe("org-providers-tab — stale banner reconnect", () => {
     });
   });
 
-  it("hides ChatGPT Codex route options when the Codex OAuth provider switch is off", async () => {
-    setMockFeatureSwitches({
-      [FeatureSwitchKey.CodexBeta]: true,
-      [FeatureSwitchKey.CodexOauthProvider]: false,
-    });
-
-    await openProvidersPage();
-
-    const row = await screen.findByTestId("org-model-policy-row-gpt-5.5");
-    const dialog = await openModelPolicyDialog(row);
-
-    expect(within(dialog).getByText("Built-in")).toBeInTheDocument();
-    expect(
-      within(dialog).queryByText("BYOK: member OAuth"),
-    ).not.toBeInTheDocument();
-    expect(within(dialog).queryByRole("combobox")).not.toBeInTheDocument();
-    expect(screen.queryByText(/ChatGPT \(Codex\)/i)).not.toBeInTheDocument();
-  });
-
   it("stores OAuth routes as member credentials without token input", async () => {
     setMockFeatureSwitches({});
 
@@ -420,10 +383,7 @@ describe("org-providers-tab — stale banner reconnect", () => {
   });
 
   it("stores ChatGPT OAuth routes without opening paste auth", async () => {
-    setMockFeatureSwitches({
-      [FeatureSwitchKey.CodexBeta]: true,
-      [FeatureSwitchKey.CodexOauthProvider]: true,
-    });
+    setMockFeatureSwitches({});
 
     await openProvidersPage();
 
@@ -446,9 +406,7 @@ describe("org-providers-tab — stale banner reconnect", () => {
   });
 
   it("opens the paste dialog in reconnect mode when Re-paste button is clicked", async () => {
-    setMockFeatureSwitches({
-      [FeatureSwitchKey.CodexOauthProvider]: true,
-    });
+    setMockFeatureSwitches({});
     setMockOrgModelProviders([makeStaleProvider()]);
     await openProvidersPage();
 
@@ -460,9 +418,7 @@ describe("org-providers-tab — stale banner reconnect", () => {
   });
 
   it("clears the stale banner after a successful re-paste", async () => {
-    setMockFeatureSwitches({
-      [FeatureSwitchKey.CodexOauthProvider]: true,
-    });
+    setMockFeatureSwitches({});
     setMockOrgModelProviders([makeStaleProvider()]);
     server.use(
       mockApi(zeroModelProvidersMainContract.upsert, ({ respond }) => {

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-model-policies-section.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-model-policies-section.tsx
@@ -65,20 +65,13 @@ import {
   type ModelPolicyDialogMode,
   type ModelPolicyRouteKind,
 } from "../../../../signals/zero-page/settings/org-model-policy-dialog.ts";
-import { featureSwitch$ } from "../../../../signals/external/feature-switch.ts";
 import { pageSignal$ } from "../../../../signals/page-signal.ts";
 import { detach, Reason } from "../../../../signals/utils.ts";
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import {
   getUILabel,
   getVm0ModelMultiplier,
 } from "../settings/provider-ui-config.ts";
 import { ProviderIcon } from "../settings/provider-icons.tsx";
-
-interface ModelPolicyFeatureGates {
-  codexBetaEnabled: boolean;
-  codexOauthEnabled: boolean;
-}
 
 function isOAuthMemberType(type: ModelProviderType): boolean {
   return type === "claude-code-oauth-token" || type === "codex-oauth-token";
@@ -86,36 +79,6 @@ function isOAuthMemberType(type: ModelProviderType): boolean {
 
 function isByokProviderType(type: ModelProviderType): boolean {
   return type !== "vm0" && !isOAuthMemberType(type);
-}
-
-function isRouteProviderVisible(
-  type: ModelProviderType,
-  gates: ModelPolicyFeatureGates,
-): boolean {
-  if (type === "openai-api-key") {
-    return gates.codexBetaEnabled;
-  }
-  if (type === "codex-oauth-token") {
-    return gates.codexOauthEnabled;
-  }
-  return true;
-}
-
-function isRunModelVisible(
-  model: SupportedRunModel,
-  gates: ModelPolicyFeatureGates,
-): boolean {
-  if (model.startsWith("gpt-")) {
-    return gates.codexBetaEnabled;
-  }
-  return true;
-}
-
-function isModelPolicyVisible(
-  policy: OrgModelPolicy,
-  gates: ModelPolicyFeatureGates,
-): boolean {
-  return isRunModelVisible(policy.model, gates);
 }
 
 function getModelIconType(model: SupportedRunModel): ModelProviderType | null {
@@ -131,21 +94,15 @@ function getModelIconType(model: SupportedRunModel): ModelProviderType | null {
   );
 }
 
-function getApiProviderTypes(
-  model: SupportedRunModel,
-  gates: ModelPolicyFeatureGates,
-): ModelProviderType[] {
+function getApiProviderTypes(model: SupportedRunModel): ModelProviderType[] {
   return getProvidersForModel(model).filter((type) => {
-    return isRouteProviderVisible(type, gates) && isByokProviderType(type);
+    return isByokProviderType(type);
   });
 }
 
-function getOAuthProviderTypes(
-  model: SupportedRunModel,
-  gates: ModelPolicyFeatureGates,
-): ModelProviderType[] {
+function getOAuthProviderTypes(model: SupportedRunModel): ModelProviderType[] {
   return getProvidersForModel(model).filter((type) => {
-    return isRouteProviderVisible(type, gates) && isOAuthMemberType(type);
+    return isOAuthMemberType(type);
   });
 }
 
@@ -775,14 +732,12 @@ function ModelPolicyRouteDialog({
   policies,
   addableModels,
   providers,
-  gates,
   saving,
   onSubmit,
 }: {
   policies: OrgModelPolicy[];
   addableModels: SupportedRunModel[];
   providers: ModelProviderResponse[];
-  gates: ModelPolicyFeatureGates;
   saving: boolean;
   onSubmit: (next: UpdateOrgModelPolicy[]) => void;
 }) {
@@ -793,12 +748,8 @@ function ModelPolicyRouteDialog({
   const openAddProvider = useSet(orgOpenAddDialogForModelPolicyRoute$);
   const openEditProvider = useSet(orgOpenEditDialog$);
   const selectedModel = dialog.model ?? addableModels[0] ?? null;
-  const apiTypes = selectedModel
-    ? getApiProviderTypes(selectedModel, gates)
-    : [];
-  const oauthTypes = selectedModel
-    ? getOAuthProviderTypes(selectedModel, gates)
-    : [];
+  const apiTypes = selectedModel ? getApiProviderTypes(selectedModel) : [];
+  const oauthTypes = selectedModel ? getOAuthProviderTypes(selectedModel) : [];
   const selectedProviderType = getSelectedProviderType({
     routeKind: dialog.routeKind,
     providerType: dialog.providerType,
@@ -1038,7 +989,6 @@ export function OrgModelPoliciesSection() {
   const lastPolicies = useLastResolved(orgModelPolicies$);
   const providersLoadable = useLoadable(orgConfiguredProviders$);
   const lastProviders = useLastResolved(orgConfiguredProviders$);
-  const features = useLastResolved(featureSwitch$);
   const pageSignal = useGet(pageSignal$);
   const openAddModelDialog = useSet(openAddModelPolicyDialog$);
   const openEditModelDialog = useSet(openEditModelPolicyDialog$);
@@ -1055,10 +1005,6 @@ export function OrgModelPoliciesSection() {
       : (lastProviders ?? []);
   const providersReady =
     providersLoadable.state === "hasData" || lastProviders !== undefined;
-  const gates = {
-    codexBetaEnabled: features?.[FeatureSwitchKey.CodexBeta] ?? false,
-    codexOauthEnabled: features?.[FeatureSwitchKey.CodexOauthProvider] ?? false,
-  };
 
   if (
     (!data && policiesLoadable.state === "loading") ||
@@ -1073,7 +1019,7 @@ export function OrgModelPoliciesSection() {
 
   const policies = data.policies;
   const visiblePolicies = policies.filter((policy) => {
-    return isModelPolicyVisible(policy, gates);
+    return SUPPORTED_RUN_MODELS.includes(policy.model);
   });
   const configuredModels = new Set(
     policies.map((policy) => {
@@ -1081,7 +1027,7 @@ export function OrgModelPoliciesSection() {
     }),
   );
   const addableModels = SUPPORTED_RUN_MODELS.filter((model) => {
-    return !configuredModels.has(model) && isRunModelVisible(model, gates);
+    return !configuredModels.has(model);
   });
 
   const submit = (next: UpdateOrgModelPolicy[]) => {
@@ -1154,7 +1100,6 @@ export function OrgModelPoliciesSection() {
         policies={policies}
         addableModels={addableModels}
         providers={providers}
-        gates={gates}
         saving={saving}
         onSubmit={submit}
       />

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-providers-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-providers-tab.tsx
@@ -2,7 +2,6 @@
 // oxlint-disable max-lines-per-function
 import { useGet, useSet, useLoadable } from "ccstate-react";
 import type { ModelProviderResponse } from "@vm0/api-contracts/contracts/model-providers";
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import {
   orgAddProviderDialogOpen$,
   setOrgAddProviderDialogOpen$,
@@ -18,7 +17,6 @@ import {
   PersonalCodexAuthPasteDialog,
 } from "../settings/codex-auth-paste-dialog.tsx";
 import { PersonalProviderDialog } from "../settings/personal-provider-dialog.tsx";
-import { featureSwitch$ } from "../../../../signals/external/feature-switch.ts";
 import { OrgModelPoliciesSection } from "./org-model-policies-section.tsx";
 
 export function OrgProvidersTab() {
@@ -59,14 +57,7 @@ export function OrgProvidersTab() {
  * pill so users see the failed row at a glance.
  */
 function StaleBannerSection() {
-  const features = useGet(featureSwitch$);
   const providersLoadable = useLoadable(orgConfiguredProviders$);
-  const codexOauthEnabled =
-    features?.[FeatureSwitchKey.CodexOauthProvider] ?? false;
-  if (!codexOauthEnabled) {
-    return null;
-  }
-
   const providers =
     providersLoadable.state === "hasData" ? providersLoadable.data : [];
   return <StaleProviderBanner providers={providers} />;

--- a/turbo/apps/platform/src/views/zero-page/components/preferences/__tests__/personal-providers-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/preferences/__tests__/personal-providers-tab.test.tsx
@@ -1,6 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
 import { screen, waitFor, within } from "@testing-library/react";
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import {
   zeroPersonalModelProvidersByTypeContract,
   zeroPersonalModelProvidersMainContract,
@@ -86,9 +85,7 @@ describe("personal-providers-tab — settings navigation", () => {
 
 describe("personal-providers-tab — OAuth-only configuration", () => {
   it("opens directly from the model-configuration tab search param", async () => {
-    setMockFeatureSwitches({
-      [FeatureSwitchKey.CodexOauthProvider]: true,
-    });
+    setMockFeatureSwitches({});
     mockPreferences();
     setMockPersonalModelProviders([]);
     detachedSetupPage({ context, path: "/settings?tab=model-configuration" });
@@ -104,9 +101,7 @@ describe("personal-providers-tab — OAuth-only configuration", () => {
   });
 
   it("renders fixed OAuth actions without default or add-provider UI", async () => {
-    setMockFeatureSwitches({
-      [FeatureSwitchKey.CodexOauthProvider]: true,
-    });
+    setMockFeatureSwitches({});
     mockPreferences();
     setMockPersonalModelProviders([]);
     detachedSetupPage({ context, path: "/settings" });
@@ -144,34 +139,8 @@ describe("personal-providers-tab — OAuth-only configuration", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("hides ChatGPT OAuth when the Codex OAuth provider switch is off", async () => {
-    setMockFeatureSwitches({
-      [FeatureSwitchKey.CodexOauthProvider]: false,
-    });
-    mockPreferences();
-    setMockPersonalModelProviders([makeProvider("codex-oauth-token")]);
-    detachedSetupPage({ context, path: "/settings" });
-
-    await openModelConfiguration();
-
-    await waitFor(() => {
-      expect(
-        screen.getByTestId("oauth-card-claude-code-oauth-token"),
-      ).toBeInTheDocument();
-    });
-    expect(
-      screen.queryByTestId("oauth-card-codex-oauth-token"),
-    ).not.toBeInTheDocument();
-    expect(screen.queryByText("ChatGPT (Codex)")).not.toBeInTheDocument();
-    expect(
-      screen.queryByText(/ChatGPT authorization/i),
-    ).not.toBeInTheDocument();
-  });
-
   it("opens the Claude Code OAuth write dialog without a model selector", async () => {
-    setMockFeatureSwitches({
-      [FeatureSwitchKey.CodexOauthProvider]: true,
-    });
+    setMockFeatureSwitches({});
     mockPreferences();
     setMockPersonalModelProviders([]);
     detachedSetupPage({ context, path: "/settings" });
@@ -189,9 +158,7 @@ describe("personal-providers-tab — OAuth-only configuration", () => {
   });
 
   it("shows saved OAuth state on the fixed cards", async () => {
-    setMockFeatureSwitches({
-      [FeatureSwitchKey.CodexOauthProvider]: true,
-    });
+    setMockFeatureSwitches({});
     mockPreferences();
     setMockPersonalModelProviders([
       makeProvider("claude-code-oauth-token"),
@@ -233,9 +200,7 @@ describe("personal-providers-tab — OAuth-only configuration", () => {
   });
 
   it("disconnects ChatGPT (Codex) auth.json from the fixed card", async () => {
-    setMockFeatureSwitches({
-      [FeatureSwitchKey.CodexOauthProvider]: true,
-    });
+    setMockFeatureSwitches({});
     mockPreferences();
     setMockPersonalModelProviders([
       makeProvider("codex-oauth-token", { workspaceName: "Personal Acme" }),
@@ -259,9 +224,7 @@ describe("personal-providers-tab — OAuth-only configuration", () => {
   });
 
   it("keeps OAuth cards visible while the provider list refreshes", async () => {
-    setMockFeatureSwitches({
-      [FeatureSwitchKey.CodexOauthProvider]: true,
-    });
+    setMockFeatureSwitches({});
     mockPreferences();
     const provider = makeProvider("codex-oauth-token", {
       workspaceName: "Personal Acme",
@@ -307,9 +270,7 @@ describe("personal-providers-tab — ChatGPT (Codex) auth.json flow", () => {
     const openSpy = vi
       .spyOn(window, "open")
       .mockReturnValue({ closed: true } as Window);
-    setMockFeatureSwitches({
-      [FeatureSwitchKey.CodexOauthProvider]: true,
-    });
+    setMockFeatureSwitches({});
     mockPreferences();
     setMockPersonalModelProviders([]);
     detachedSetupPage({ context, path: "/settings" });
@@ -325,9 +286,7 @@ describe("personal-providers-tab — ChatGPT (Codex) auth.json flow", () => {
   });
 
   it("opens the auth.json reconnect dialog for stale ChatGPT (Codex)", async () => {
-    setMockFeatureSwitches({
-      [FeatureSwitchKey.CodexOauthProvider]: true,
-    });
+    setMockFeatureSwitches({});
     mockPreferences();
     setMockPersonalModelProviders([
       makeProvider("codex-oauth-token", {

--- a/turbo/apps/platform/src/views/zero-page/components/preferences/personal-providers-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/preferences/personal-providers-tab.tsx
@@ -1,10 +1,4 @@
-import {
-  useGet,
-  useLastLoadable,
-  useLastResolved,
-  useLoadable,
-  useSet,
-} from "ccstate-react";
+import { useGet, useLastLoadable, useLoadable, useSet } from "ccstate-react";
 import { IconDotsVertical, IconPlus } from "@tabler/icons-react";
 import {
   Button,
@@ -17,7 +11,6 @@ import type {
   ModelProviderResponse,
   ModelProviderType,
 } from "@vm0/api-contracts/contracts/model-providers";
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import {
   disconnectPersonalOAuthCredential$,
   personalActionPromise$,
@@ -25,7 +18,6 @@ import {
   personalOpenOAuthCredentialDialog$,
   setCodexPasteDialogStatePersonal$,
 } from "../../../../signals/zero-page/settings/personal-model-providers.ts";
-import { featureSwitch$ } from "../../../../signals/external/feature-switch.ts";
 import { detach, Reason } from "../../../../signals/utils.ts";
 import { pageSignal$ } from "../../../../signals/page-signal.ts";
 import { ProviderIcon } from "../settings/provider-icons.tsx";
@@ -46,7 +38,6 @@ export function PersonalProvidersTab() {
 
 function OAuthCredentialsSection() {
   const providersLoadable = useLastLoadable(personalConfiguredProviders$);
-  const features = useLastResolved(featureSwitch$);
   const openCredentialDialog = useSet(personalOpenOAuthCredentialDialog$);
   const openCodexPasteDialog = useSet(setCodexPasteDialogStatePersonal$);
   const disconnectCredential = useSet(disconnectPersonalOAuthCredential$);
@@ -56,8 +47,6 @@ function OAuthCredentialsSection() {
   const isLoading = providersLoadable.state === "loading";
   const providers =
     providersLoadable.state === "hasData" ? providersLoadable.data : [];
-  const codexOauthEnabled =
-    features?.[FeatureSwitchKey.CodexOauthProvider] ?? false;
   const claudeCode = findProvider(providers, "claude-code-oauth-token");
   const openAI = findProvider(providers, "codex-oauth-token");
   const openAIStatus = getOpenAIStatus(openAI);
@@ -72,14 +61,14 @@ function OAuthCredentialsSection() {
   return (
     <section className="flex flex-col gap-3">
       <p className="text-sm text-muted-foreground">
-        Personal Claude Code{codexOauthEnabled ? " and ChatGPT" : ""}{" "}
-        credentials, used only in your own runs.
+        Personal Claude Code and ChatGPT credentials, used only in your own
+        runs.
       </p>
       <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
         {isLoading ? (
           <>
             <OAuthCardSkeleton />
-            {codexOauthEnabled && <OAuthCardSkeleton />}
+            <OAuthCardSkeleton />
           </>
         ) : (
           <>
@@ -118,39 +107,37 @@ function OAuthCredentialsSection() {
               }}
               testId="oauth-card-claude-code-oauth-token"
             />
-            {codexOauthEnabled && (
-              <OAuthCredentialCard
-                type="codex-oauth-token"
-                title="ChatGPT (Codex)"
-                description="Paste Codex auth.json for Codex-backed model routes."
-                status={openAIStatus}
-                menuItems={
-                  openAI
-                    ? [
-                        {
-                          label: "Replace",
-                          onSelect: connectOpenAI,
+            <OAuthCredentialCard
+              type="codex-oauth-token"
+              title="ChatGPT (Codex)"
+              description="Paste Codex auth.json for Codex-backed model routes."
+              status={openAIStatus}
+              menuItems={
+                openAI
+                  ? [
+                      {
+                        label: "Replace",
+                        onSelect: connectOpenAI,
+                      },
+                      {
+                        label: "Disconnect",
+                        disabled: disconnecting,
+                        onSelect: () => {
+                          detach(
+                            disconnectCredential(
+                              "codex-oauth-token",
+                              pageSignal,
+                            ),
+                            Reason.DomCallback,
+                          );
                         },
-                        {
-                          label: "Disconnect",
-                          disabled: disconnecting,
-                          onSelect: () => {
-                            detach(
-                              disconnectCredential(
-                                "codex-oauth-token",
-                                pageSignal,
-                              ),
-                              Reason.DomCallback,
-                            );
-                          },
-                        },
-                      ]
-                    : []
-                }
-                onAction={connectOpenAI}
-                testId="oauth-card-codex-oauth-token"
-              />
-            )}
+                      },
+                    ]
+                  : []
+              }
+              onAction={connectOpenAI}
+              testId="oauth-card-codex-oauth-token"
+            />
           </>
         )}
       </div>

--- a/turbo/apps/platform/src/views/zero-page/components/settings/org-add-provider-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/org-add-provider-dialog.tsx
@@ -11,13 +11,11 @@ import {
   getSelectableProviderTypes,
   type ModelProviderType,
 } from "@vm0/api-contracts/contracts/model-providers";
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import {
   orgConfiguredProviders$,
   orgOpenAddDialog$,
   setCodexPasteDialogState$,
 } from "../../../../signals/zero-page/settings/org-model-providers.ts";
-import { featureSwitch$ } from "../../../../signals/external/feature-switch.ts";
 import { getUILabel, getUIDescription } from "./provider-ui-config.ts";
 import { ProviderIcon } from "./provider-icons.tsx";
 
@@ -73,10 +71,6 @@ export function OrgAddProviderDialog({
   onOpenChange: (open: boolean) => void;
 }) {
   const configuredProviders = useLastResolved(orgConfiguredProviders$);
-  const features = useLastResolved(featureSwitch$);
-  const codexBetaEnabled = features?.[FeatureSwitchKey.CodexBeta] ?? false;
-  const codexOauthEnabled =
-    features?.[FeatureSwitchKey.CodexOauthProvider] ?? false;
   const openAdd = useSet(orgOpenAddDialog$);
   const openCodexPaste = useSet(setCodexPasteDialogState$);
   const configuredSet = new Set(
@@ -99,12 +93,6 @@ export function OrgAddProviderDialog({
 
   const availableTypes = getProviderTypes().filter((type) => {
     if (configuredSet.has(type)) {
-      return false;
-    }
-    if (type === "openai-api-key" && !codexBetaEnabled) {
-      return false;
-    }
-    if (type === "codex-oauth-token" && !codexOauthEnabled) {
       return false;
     }
     return true;

--- a/turbo/apps/platform/src/views/zero-page/components/settings/provider-dialog-fields.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/provider-dialog-fields.tsx
@@ -7,7 +7,6 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@vm0/ui/components/ui/select";
-import { useLastResolved } from "ccstate-react";
 import {
   MODEL_PROVIDER_TYPES,
   getAuthMethodsForType,
@@ -27,7 +26,6 @@ import {
   getUIAuthMethodLabel,
 } from "./provider-ui-config.ts";
 import { ClaudeCodeSetupPrompt } from "./setup-prompt.tsx";
-import { featureSwitch$ } from "../../../../signals/external/feature-switch.ts";
 
 export function OAuthFields({
   secret,
@@ -311,14 +309,13 @@ function ModelSelector({
   onUseDefaultModelChange: (value: boolean) => void;
 }) {
   const type = providerType as keyof typeof MODEL_PROVIDER_TYPES;
-  const features = useLastResolved(featureSwitch$);
 
   if (!hasModelSelection(type)) {
     return null;
   }
 
   const models = (
-    type === "vm0" ? getVm0VisibleModels(features) : (getModels(type) ?? [])
+    type === "vm0" ? getVm0VisibleModels() : (getModels(type) ?? [])
   ).filter((m) => {
     return m !== "";
   });

--- a/turbo/apps/web/app/[locale]/models/__tests__/data.test.ts
+++ b/turbo/apps/web/app/[locale]/models/__tests__/data.test.ts
@@ -4,18 +4,16 @@ import { VM0_MODEL_TO_PROVIDER } from "@vm0/api-contracts/contracts/model-provid
 import { MODELS } from "../data";
 
 describe("models page data", () => {
-  it("covers every public VM0 managed model", () => {
+  it("only documents VM0 managed models", () => {
     const modelIds = MODELS.map((model) => {
       return model.modelId;
     });
-    const publicVm0ModelIds = Object.entries(VM0_MODEL_TO_PROVIDER)
-      .filter(([, config]) => {
-        return !config.featureFlag;
-      })
-      .map(([modelId]) => {
-        return modelId;
-      });
+    const vm0ModelIds = new Set(Object.keys(VM0_MODEL_TO_PROVIDER));
     expect(new Set(modelIds).size).toBe(modelIds.length);
-    expect([...modelIds].sort()).toStrictEqual(publicVm0ModelIds.sort());
+    expect(
+      modelIds.every((modelId) => {
+        return vm0ModelIds.has(modelId);
+      }),
+    ).toBe(true);
   });
 });

--- a/turbo/apps/web/app/api/telegram/webhook/__tests__/commands.test.ts
+++ b/turbo/apps/web/app/api/telegram/webhook/__tests__/commands.test.ts
@@ -517,7 +517,7 @@ describe("Telegram bot commands", () => {
       expect(text).toContain("/model claude-sonnet-4-6");
       expect(text).toContain("/model deepseek-v4-pro");
       expect(text).toContain("DeepSeek V4 Pro");
-      expect(text).not.toContain("/model gpt-5.5");
+      expect(text).toContain("/model gpt-5.5");
     });
 
     it("should persist a matched model argument", async () => {

--- a/turbo/apps/web/app/api/zero/me/model-providers/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/me/model-providers/__tests__/route.test.ts
@@ -1,5 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import { describe, it, expect, beforeEach } from "vitest";
 import { GET, POST } from "../route";
 import { DELETE } from "../[type]/route";
 import {
@@ -14,18 +13,6 @@ import {
   type UserContext,
 } from "../../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
-
-vi.mock("@vm0/core/feature-switch", async (importOriginal) => {
-  const actual =
-    await importOriginal<typeof import("@vm0/core/feature-switch")>();
-  return {
-    ...actual,
-    isFeatureEnabled: vi.fn().mockReturnValue(true),
-  };
-});
-
-const { isFeatureEnabled } = await import("@vm0/core/feature-switch");
-const mockIsFeatureEnabled = isFeatureEnabled as ReturnType<typeof vi.fn>;
 
 const context = testContext();
 
@@ -90,9 +77,6 @@ describe("Model-first personal OAuth model provider routes", () => {
     context.setupMocks();
     user = await context.setupUser();
     void user;
-    mockIsFeatureEnabled.mockImplementation(() => {
-      return true;
-    });
   });
 
   describe("no active organization", () => {
@@ -386,14 +370,6 @@ describe("Model-first personal OAuth model provider routes", () => {
       const data = await response.json();
       expect(data.error.code).toBe("BAD_REQUEST");
     });
-
-    it("returns 404 when CodexOauthProvider feature switch is off", async () => {
-      mockIsFeatureEnabled.mockImplementation((key: FeatureSwitchKey) => {
-        return key !== FeatureSwitchKey.CodexOauthProvider;
-      });
-      const response = await pasteAuthJson(makeAuthJson());
-      expect(response.status).toBe(404);
-    });
   });
 });
 
@@ -407,9 +383,6 @@ describe("Model-first personal OAuth model provider routes", () => {
 describe("Model-first personal OAuth routes — cross-user privacy invariant", () => {
   beforeEach(() => {
     context.setupMocks();
-    mockIsFeatureEnabled.mockImplementation(() => {
-      return true;
-    });
   });
 
   async function setupTwoUserOrg(): Promise<{

--- a/turbo/apps/web/app/api/zero/me/model-providers/route.ts
+++ b/turbo/apps/web/app/api/zero/me/model-providers/route.ts
@@ -5,8 +5,6 @@ import {
   type ModelProviderType,
 } from "@vm0/api-contracts/contracts/model-providers";
 import { createErrorResponse } from "@vm0/api-contracts/contracts/errors";
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
-import { isFeatureEnabled } from "@vm0/core/feature-switch";
 import { initServices } from "../../../../../src/lib/init-services";
 import {
   requireAuth,
@@ -22,7 +20,6 @@ import {
   handleCodexAuthJsonPaste,
   serializeUpsertedProvider,
 } from "../../../../../src/lib/zero/model-provider/codex-auth-json-paste-handler";
-import { loadFeatureSwitchOverrides } from "../../../../../src/lib/zero/user/feature-switches-service";
 import { logger } from "../../../../../src/lib/shared/logger";
 import { isBadRequest } from "@vm0/api-services/errors";
 
@@ -91,18 +88,6 @@ const router = tsr.router(zeroPersonalModelProvidersMainContract, {
     }
 
     if (type === "codex-oauth-token" && authMethod === "auth_json") {
-      const overrides = await loadFeatureSwitchOverrides(
-        org.orgId,
-        authCtx.userId,
-      );
-      const eligible = isFeatureEnabled(FeatureSwitchKey.CodexOauthProvider, {
-        orgId: org.orgId,
-        userId: authCtx.userId,
-        overrides,
-      });
-      if (!eligible) {
-        return createErrorResponse("NOT_FOUND", `Provider "${type}" not found`);
-      }
       const raw = secrets?.CODEX_AUTH_JSON;
       if (!raw) {
         return createErrorResponse(

--- a/turbo/apps/web/app/api/zero/model-providers/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/model-providers/__tests__/route.test.ts
@@ -1,5 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import { describe, it, expect, beforeEach } from "vitest";
 import { GET, POST } from "../route";
 import { DELETE } from "../[type]/route";
 import {
@@ -17,18 +16,6 @@ import {
 } from "../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../src/__tests__/clerk-mock";
 import type { ModelProviderType } from "@vm0/api-contracts/contracts/model-providers";
-
-vi.mock("@vm0/core/feature-switch", async (importOriginal) => {
-  const actual =
-    await importOriginal<typeof import("@vm0/core/feature-switch")>();
-  return {
-    ...actual,
-    isFeatureEnabled: vi.fn().mockReturnValue(true),
-  };
-});
-
-const { isFeatureEnabled } = await import("@vm0/core/feature-switch");
-const mockIsFeatureEnabled = isFeatureEnabled as ReturnType<typeof vi.fn>;
 
 const context = testContext();
 
@@ -314,22 +301,8 @@ describe("Org-level model provider routes", () => {
     });
   });
 
-  // ---------------------------------------------------------------------------
-  // codex-beta gate on POST /api/zero/model-providers
-  // ---------------------------------------------------------------------------
-
-  describe("openai-api-key codex-beta gate", () => {
-    beforeEach(() => {
-      mockIsFeatureEnabled.mockImplementation(() => {
-        return true;
-      });
-    });
-
-    it("creates openai-api-key provider when codex-beta is enabled", async () => {
-      mockIsFeatureEnabled.mockImplementation((key) => {
-        return key === FeatureSwitchKey.CodexBeta;
-      });
-
+  describe("openai-api-key provider", () => {
+    it("creates openai-api-key provider by default", async () => {
       const response = await createProvider(
         "openai-api-key",
         "sk-proj-test",
@@ -340,28 +313,6 @@ describe("Org-level model provider routes", () => {
       expect(data.provider.type).toBe("openai-api-key");
       expect(data.provider.framework).toBe("codex");
     });
-
-    it("returns 404 when codex-beta is disabled", async () => {
-      mockIsFeatureEnabled.mockImplementation((key) => {
-        return key !== FeatureSwitchKey.CodexBeta;
-      });
-
-      const response = await createProvider(
-        "openai-api-key",
-        "sk-proj-test",
-        "gpt-5.5",
-      );
-      expect(response.status).toBe(404);
-    });
-
-    it("does not gate other provider types when codex-beta is disabled", async () => {
-      mockIsFeatureEnabled.mockImplementation((key) => {
-        return key !== FeatureSwitchKey.CodexBeta;
-      });
-
-      const response = await createProvider("anthropic-api-key", "sk-ant-test");
-      expect(response.status).toBe(201);
-    });
   });
 
   // ---------------------------------------------------------------------------
@@ -369,12 +320,6 @@ describe("Org-level model provider routes", () => {
   // ---------------------------------------------------------------------------
 
   describe("cross-framework providers", () => {
-    beforeEach(() => {
-      mockIsFeatureEnabled.mockImplementation(() => {
-        return true;
-      });
-    });
-
     it("does not mark any cross-framework provider as default", async () => {
       await createProvider("anthropic-api-key", "ant-key");
       await createProvider("openai-api-key", "sk-proj-test", "gpt-5.5");
@@ -416,8 +361,6 @@ describe("Org-level model provider routes", () => {
     let user: UserContext;
 
     beforeEach(async () => {
-      vi.clearAllMocks();
-      mockIsFeatureEnabled.mockReturnValue(true);
       context.setupMocks();
       user = await context.setupUser();
     });
@@ -711,20 +654,6 @@ describe("Org-level model provider routes", () => {
         "model-provider",
       );
       expect(refresh).toBe("rt_fresh");
-    });
-
-    it("returns 404 when codexOauthProvider feature switch is disabled", async () => {
-      // Default mock returns true; flip to false for this single call only.
-      mockIsFeatureEnabled.mockImplementationOnce(
-        (key: { name?: string } | string) => {
-          const keyName = typeof key === "string" ? key : key.name;
-          return keyName !== "codexOauthProvider";
-        },
-      );
-      const response = await pasteAuthJson(makeAuthJson());
-      expect(response.status).toBe(404);
-      const data = await response.json();
-      expect(data.error.code).toBe("NOT_FOUND");
     });
   });
 });

--- a/turbo/apps/web/app/api/zero/model-providers/route.ts
+++ b/turbo/apps/web/app/api/zero/model-providers/route.ts
@@ -2,8 +2,6 @@ import { createHandler, tsr } from "../../../../src/lib/ts-rest-handler";
 import { zeroModelProvidersMainContract } from "@vm0/api-contracts/contracts/zero-model-providers";
 import { hasAuthMethods } from "@vm0/api-contracts/contracts/model-providers";
 import { createErrorResponse } from "@vm0/api-contracts/contracts/errors";
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
-import { isFeatureEnabled } from "@vm0/core/feature-switch";
 import { initServices } from "../../../../src/lib/init-services";
 import {
   requireAuth,
@@ -20,7 +18,6 @@ import {
   handleCodexAuthJsonPaste,
   serializeUpsertedProvider,
 } from "../../../../src/lib/zero/model-provider/codex-auth-json-paste-handler";
-import { loadFeatureSwitchOverrides } from "../../../../src/lib/zero/user/feature-switches-service";
 import { logger } from "../../../../src/lib/shared/logger";
 import { isBadRequest } from "@vm0/api-services/errors";
 
@@ -84,34 +81,7 @@ const router = tsr.router(zeroModelProvidersMainContract, {
 
     const { type, secret, authMethod, secrets } = body;
 
-    if (type === "openai-api-key") {
-      const overrides = await loadFeatureSwitchOverrides(
-        org.orgId,
-        authCtx.userId,
-      );
-      const codexBetaEnabled = isFeatureEnabled(FeatureSwitchKey.CodexBeta, {
-        userId: authCtx.userId,
-        orgId: org.orgId,
-        overrides,
-      });
-      if (!codexBetaEnabled) {
-        return createErrorResponse("NOT_FOUND", `Provider "${type}" not found`);
-      }
-    }
-
     if (type === "codex-oauth-token" && authMethod === "auth_json") {
-      const overrides = await loadFeatureSwitchOverrides(
-        org.orgId,
-        authCtx.userId,
-      );
-      const eligible = isFeatureEnabled(FeatureSwitchKey.CodexOauthProvider, {
-        orgId: org.orgId,
-        userId: authCtx.userId,
-        overrides,
-      });
-      if (!eligible) {
-        return createErrorResponse("NOT_FOUND", `Provider "${type}" not found`);
-      }
       const raw = secrets?.CODEX_AUTH_JSON;
       if (!raw) {
         return createErrorResponse(

--- a/turbo/apps/web/app/api/zero/slack/commands/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/slack/commands/__tests__/route.test.ts
@@ -476,7 +476,7 @@ describe("POST /api/zero/slack/commands", () => {
       expect(values).not.toContain("__workspace_default__");
       expect(values).toContain("claude-sonnet-4-6");
       expect(values).toContain("deepseek-v4-pro");
-      expect(values).not.toContain("gpt-5.5");
+      expect(values).toContain("gpt-5.5");
       expect(labels).toContain("Claude Sonnet 4.6 (workspace default)");
       expect(inputBlock?.element?.initial_option?.value).toBe(
         "deepseek-v4-pro",

--- a/turbo/apps/web/src/lib/zero/__tests__/build-zero-context.test.ts
+++ b/turbo/apps/web/src/lib/zero/__tests__/build-zero-context.test.ts
@@ -25,7 +25,6 @@ import {
 } from "../../../__tests__/db-test-seeders/agents";
 import { setOrgCredits } from "../../../__tests__/db-test-seeders/org";
 import { setTestCheckpointArtifactSnapshots } from "../../../__tests__/db-test-seeders/runs";
-import { seedUserFeatureSwitches } from "../../../__tests__/db-test-seeders/feature-switches";
 // eslint-disable-next-line web/no-direct-db-in-tests -- Service-level exception: no API route
 import { createZeroRun } from "../zero-run-service";
 // eslint-disable-next-line web/no-direct-db-in-tests -- Service-level exception: no API route
@@ -580,9 +579,6 @@ describe("Org-Level Runtime Resolution (Zero Layer)", () => {
         skipDefaultApiKey: true,
       });
       const codexAgentId = await getTestZeroAgentId(user.orgId, agentName);
-      await seedUserFeatureSwitches(user.orgId, user.userId, {
-        codexBeta: true,
-      });
       const provider = await createTestOrgModelProvider(
         "openai-api-key",
         "org-openai-key",

--- a/turbo/apps/web/src/lib/zero/__tests__/zero-run-service.test.ts
+++ b/turbo/apps/web/src/lib/zero/__tests__/zero-run-service.test.ts
@@ -25,7 +25,6 @@ import {
   createTestZeroAgent,
   deleteTestCompose,
 } from "../../../__tests__/db-test-seeders/agents";
-import { seedUserFeatureSwitches } from "../../../__tests__/db-test-seeders/feature-switches";
 import { bindCustomSkillToAgent } from "../../../__tests__/db-test-seeders/skills";
 import { createTestUserConnector } from "../../../__tests__/db-test-seeders/connectors";
 import {
@@ -393,9 +392,6 @@ describe("createZeroRun() — service-only parameters", () => {
         agentName,
       );
       await bindCustomSkillToAgent(providerCodexAgentId, "my-skill");
-      await seedUserFeatureSwitches(user.orgId, user.userId, {
-        codexBeta: true,
-      });
       const provider = await createTestOrgModelProvider(
         "openai-api-key",
         "org-openai-key",

--- a/turbo/apps/web/src/lib/zero/model-policy/model-preference-picker.ts
+++ b/turbo/apps/web/src/lib/zero/model-policy/model-preference-picker.ts
@@ -1,11 +1,9 @@
-import { getAllFeatureStates } from "@vm0/core/feature-switch";
 import {
   getCanonicalModelDisplayName,
   getVm0VisibleModels,
   isSupportedRunModel,
   type SupportedRunModel,
 } from "@vm0/api-contracts/contracts/model-providers";
-import { loadFeatureSwitchOverrides } from "../user/feature-switches-service";
 import { ensureOrgModelPolicies } from "./org-model-policy-service";
 import { resolveModelFirstRouteDescriptor } from "./model-first-route-service";
 import { getUserModelPreferenceModel } from "./user-model-preference-service";
@@ -45,17 +43,7 @@ export async function getModelPreferencePickerState(params: {
   orgId: string;
   userId: string;
 }): Promise<ModelPreferencePickerState> {
-  const overrides = await loadFeatureSwitchOverrides(
-    params.orgId,
-    params.userId,
-  );
-  const featureStates = getAllFeatureStates({
-    orgId: params.orgId,
-    userId: params.userId,
-    overrides,
-  });
-
-  const visibleModels = new Set(getVm0VisibleModels(featureStates));
+  const visibleModels = new Set(getVm0VisibleModels());
   const policies = await ensureOrgModelPolicies(params.orgId, params.userId);
   const currentSelectedModel = await getUserModelPreferenceModel(
     params.orgId,

--- a/turbo/apps/web/src/lib/zero/slack/model-picker.ts
+++ b/turbo/apps/web/src/lib/zero/slack/model-picker.ts
@@ -4,8 +4,6 @@ import {
   isSupportedRunModel,
   type SupportedRunModel,
 } from "@vm0/api-contracts/contracts/model-providers";
-import { getAllFeatureStates } from "@vm0/core/feature-switch";
-import { loadFeatureSwitchOverrides } from "../user/feature-switches-service";
 import { ensureOrgModelPolicies } from "../model-policy/org-model-policy-service";
 import { resolveModelFirstRouteDescriptor } from "../model-policy/model-first-route-service";
 import { getUserModelPreferenceModel } from "../model-policy/user-model-preference-service";
@@ -43,17 +41,7 @@ export async function getSlackModelPickerState(params: {
   orgId: string;
   userId: string;
 }): Promise<SlackModelPickerState> {
-  const overrides = await loadFeatureSwitchOverrides(
-    params.orgId,
-    params.userId,
-  );
-  const featureStates = getAllFeatureStates({
-    orgId: params.orgId,
-    userId: params.userId,
-    overrides,
-  });
-
-  const visibleModels = new Set(getVm0VisibleModels(featureStates));
+  const visibleModels = new Set(getVm0VisibleModels());
   const policies = await ensureOrgModelPolicies(params.orgId, params.userId);
   const currentSelectedModel = await getUserModelPreferenceModel(
     params.orgId,

--- a/turbo/packages/api-contracts/src/contracts/__tests__/model-providers.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/model-providers.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect } from "vitest";
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import {
   getProviderBaseUrl,
   areProvidersCompatible,
@@ -27,7 +26,6 @@ import {
   DEFAULT_ORG_MODEL_POLICY_DEFAULT_MODEL,
   SUPPORTED_RUN_MODELS,
   DEFAULT_ORG_MODEL_POLICY_MODELS,
-  VM0_MODEL_TO_PROVIDER,
   MODEL_PROVIDER_FIREWALL_CONFIGS,
   MODEL_PROVIDER_TYPES,
   modelProviderTypeSchema,
@@ -288,37 +286,15 @@ describe("model selection for Anthropic-native providers", () => {
 });
 
 describe("getVm0VisibleModels", () => {
-  it("returns all models when no features are provided", () => {
+  it("returns all VM0 managed models", () => {
     const models = getVm0VisibleModels();
     expect(models).toContain("kimi-k2.5");
     expect(models).toContain("MiniMax-M2.7");
     expect(models).toContain("glm-5.1");
     expect(models).toContain("deepseek-v4-pro");
     expect(models).toContain("deepseek-v4-flash");
-    // All feature-flagged models must be hidden when no features are provided
-    const featureFlaggedModels = Object.entries(VM0_MODEL_TO_PROVIDER)
-      .filter(([, config]) => {
-        return config.featureFlag !== undefined;
-      })
-      .map(([model]) => {
-        return model;
-      });
-    for (const model of featureFlaggedModels) {
-      expect(models).not.toContain(model);
-    }
-  });
-
-  it("DeepSeek V4 models and compatibility aliases are not feature gated", () => {
-    const models = getVm0VisibleModels({});
-    expect(models).toContain("deepseek-v4-pro");
-    expect(models).toContain("deepseek-v4-flash");
-  });
-
-  it("shows GPT models only when Codex beta is enabled", () => {
-    expect(getVm0VisibleModels({})).not.toContain("gpt-5.5");
-    expect(
-      getVm0VisibleModels({ [FeatureSwitchKey.CodexBeta]: true }),
-    ).toContain("gpt-5.5");
+    expect(models).toContain("gpt-5.5");
+    expect(models).toContain("gpt-5.3-codex");
   });
 });
 

--- a/turbo/packages/api-contracts/src/contracts/model-providers.ts
+++ b/turbo/packages/api-contracts/src/contracts/model-providers.ts
@@ -1,6 +1,5 @@
 import { z } from "zod";
 
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import type { ExpandedFirewallConfig } from "@vm0/connectors/firewall-types";
 
 /**
@@ -153,7 +152,6 @@ interface Vm0ModelConfig {
   // different identifier than what we show to users (e.g. OpenRouter uses
   // "z-ai/glm-5.1" while our UI shows "glm-5.1").
   apiModel?: string;
-  featureFlag?: FeatureSwitchKey;
 }
 
 // Key order is load-bearing: `Object.keys()` preserves insertion order and
@@ -204,27 +202,22 @@ export const VM0_MODEL_TO_PROVIDER: Record<string, Vm0ModelConfig> = {
   "gpt-5.5": {
     concreteType: "openai-api-key",
     vendor: "openai",
-    featureFlag: FeatureSwitchKey.CodexBeta,
   },
   "gpt-5.4": {
     concreteType: "openai-api-key",
     vendor: "openai",
-    featureFlag: FeatureSwitchKey.CodexBeta,
   },
   "gpt-5.4-mini": {
     concreteType: "openai-api-key",
     vendor: "openai",
-    featureFlag: FeatureSwitchKey.CodexBeta,
   },
   "gpt-5.3-codex": {
     concreteType: "openai-api-key",
     vendor: "openai",
-    featureFlag: FeatureSwitchKey.CodexBeta,
   },
   "gpt-5.2": {
     concreteType: "openai-api-key",
     vendor: "openai",
-    featureFlag: FeatureSwitchKey.CodexBeta,
   },
 };
 
@@ -313,21 +306,10 @@ export function modelSupportsImageInput(
 }
 
 /**
- * Return the VM0 managed models visible to the caller, filtered by feature
- * switches. Models without a featureFlag are always visible; models with a
- * flag require the flag to be enabled in the supplied feature map.
+ * Return the VM0 managed models visible to callers.
  */
-export function getVm0VisibleModels(
-  features?: Partial<Record<FeatureSwitchKey, boolean>>,
-): string[] {
-  return Object.entries(VM0_MODEL_TO_PROVIDER)
-    .filter(([, { featureFlag }]) => {
-      if (!featureFlag) return true;
-      return features?.[featureFlag] === true;
-    })
-    .map(([model]) => {
-      return model;
-    });
+export function getVm0VisibleModels(): string[] {
+  return Object.keys(VM0_MODEL_TO_PROVIDER);
 }
 
 /**

--- a/turbo/packages/connectors/src/feature-switch-key.ts
+++ b/turbo/packages/connectors/src/feature-switch-key.ts
@@ -56,8 +56,6 @@ export enum FeatureSwitchKey {
 
   Trinity = "trinity",
   ZapierConnector = "zapierConnector",
-  CodexBeta = "codexBeta",
-  CodexOauthProvider = "codexOauthProvider",
   VoiceChatRealtimeBilling = "voiceChatRealtimeBilling",
   PrivateAgents = "privateAgents",
 }

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -323,27 +323,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
       "Enable the Zapier connector. When disabled, Zapier is hidden from the connectors list and cannot be connected.",
     enabled: false,
   },
-  [FeatureSwitchKey.CodexBeta]: {
-    maintainer: "lancy@vm0.ai",
-    description:
-      "Gate the codex framework via BYOK OpenAI provider in zero web. " +
-      "When off, the openai-api-key tile is hidden in the add-provider " +
-      "dialog and POST /api/zero/model-providers with type=openai-api-key " +
-      "returns 404. Staff-only during rollout; per-user toggle via Lab.",
-    enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
-  },
-  [FeatureSwitchKey.CodexOauthProvider]: {
-    maintainer: "lancy@vm0.ai",
-    description:
-      "Gate the ChatGPT-OAuth model provider in zero web (Epic #11872). " +
-      "When off, the 'Connect ChatGPT' tile is hidden in the add-provider " +
-      "dialog, server routes that initiate the OAuth dance return 404, and " +
-      "stale-provider UX is bypassed. Staff-only during rollout; per-user " +
-      "toggle via Lab.",
-    enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
-  },
   [FeatureSwitchKey.VoiceChatRealtimeBilling]: {
     maintainer: "lancy@vm0.ai",
     description:


### PR DESCRIPTION
Closes #13115

## Summary
- remove CodexBeta and CodexOauthProvider from the feature-switch registry and enum
- make GPT VM0 models, OpenAI API key providers, and ChatGPT/Codex OAuth provider flows visible by default
- remove matching feature-gate branches from web/api routes, platform provider UI, Slack/model preference pickers, and tests

## Verification
- pnpm format
- pnpm -F @vm0/api-contracts exec vitest run src/contracts/__tests__/model-providers.test.ts
- pnpm -F api exec vitest run src/signals/routes/__tests__/zero-model-providers.test.ts src/signals/routes/__tests__/zero-me-model-providers-upsert.test.ts src/signals/routes/__tests__/zero-me-model-providers-codex-oauth.test.ts
- pnpm -F web exec vitest run app/api/zero/model-providers/__tests__/route.test.ts app/api/zero/me/model-providers/__tests__/route.test.ts src/lib/zero/__tests__/zero-run-service.test.ts src/lib/zero/__tests__/build-zero-context.test.ts
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/org-add-provider-dialog-codex.test.tsx src/views/zero-page/__tests__/chat-default-model-resolution.test.tsx src/views/zero-page/components/preferences/__tests__/personal-providers-tab.test.tsx src/views/zero-page/components/org-manage/__tests__/org-providers-tab.test.tsx
- pnpm -F web exec vitest run app/[locale]/models/__tests__/data.test.ts
- pnpm -F @vm0/api-contracts check-types
- pnpm -F api check-types
- pnpm -F web check-types
- pnpm -F @vm0/app check-types
- pnpm -F @vm0/api-contracts lint
- pnpm -F api lint
- pnpm -F web lint
- pnpm -F @vm0/app lint
- git diff --check
- pre-commit: pnpm knip; pnpm check-types