### PR TITLE
refactor(vsock-guest): consolidate sandbox user lookup

### DIFF
--- a/crates/vsock-guest/src/exec.rs
+++ b/crates/vsock-guest/src/exec.rs
@@ -37,9 +37,9 @@ fn shell_escape_value(val: &str) -> String {
 /// When `sudo` is true the command runs as root, bypassing `su - user` and
 /// the PAM overhead that comes with it.
 ///
-/// In release builds the guest-init process is already root, so `sh -c`
-/// suffices. In debug builds the process is a normal user, so `sudo sh -c`
-/// is needed to elevate.
+/// In production-style builds, non-sudo commands run through `su - user`.
+/// In debug/test-support builds, local tests run as the current user unless
+/// `sudo` explicitly requests elevation through `sudo sh -c`.
 pub(crate) fn build_exec_command(command: &str, sudo: bool) -> Command {
     match get_exec_user() {
         Some(user) => {

--- a/crates/vsock-guest/src/exec.rs
+++ b/crates/vsock-guest/src/exec.rs
@@ -1,9 +1,7 @@
-use std::ffi::{CStr, CString};
 use std::fs::{self, DirBuilder, File, OpenOptions};
 use std::io::{self, Read, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
-use std::sync::OnceLock;
 use std::time::{Duration, SystemTime};
 
 use std::os::fd::{AsRawFd, RawFd};
@@ -11,13 +9,10 @@ use std::os::unix::fs::{DirBuilderExt, MetadataExt, OpenOptionsExt, PermissionsE
 
 /// Maximum length for command preview in logs
 const COMMAND_PREVIEW_MAX_LEN: usize = 100;
-const SANDBOX_USER: &str = "user";
 const ENV_SCRIPT_PREFIX: &str = "vm0-env-";
 const ENV_SCRIPT_SUFFIX: &str = ".sh";
 const ENV_SCRIPT_STALE_AFTER: Duration = Duration::from_secs(60 * 60);
 const CHOWN_UNCHANGED_UID: libc::uid_t = !0;
-const PASSWD_BUFFER_MAX_LEN: usize = 1024 * 1024;
-static SANDBOX_USER_GID: OnceLock<libc::gid_t> = OnceLock::new();
 
 fn get_exec_user() -> Option<&'static str> {
     #[cfg(any(debug_assertions, feature = "test-support"))]
@@ -28,7 +23,7 @@ fn get_exec_user() -> Option<&'static str> {
     #[cfg(not(any(debug_assertions, feature = "test-support")))]
     {
         // Default user for command execution (UID 1000, matching E2B sandbox)
-        Some(SANDBOX_USER)
+        Some(crate::user::sandbox_user_name())
     }
 }
 
@@ -329,70 +324,6 @@ fn ensure_env_script_dir(dir: &Path) -> io::Result<()> {
     Ok(())
 }
 
-fn initial_passwd_buffer_len() -> usize {
-    // SAFETY: sysconf is read-only for this process setting.
-    let len = unsafe { libc::sysconf(libc::_SC_GETPW_R_SIZE_MAX) };
-    if len > 0 {
-        (len as usize).min(PASSWD_BUFFER_MAX_LEN)
-    } else {
-        16 * 1024
-    }
-}
-
-fn lookup_user_gid_cstr(user: &CStr) -> io::Result<libc::gid_t> {
-    let mut buffer = vec![0_u8; initial_passwd_buffer_len()];
-    loop {
-        // SAFETY: zero is a valid initial state for passwd before getpwnam_r
-        // fills it with pointers into `buffer`.
-        let mut passwd: libc::passwd = unsafe { std::mem::zeroed() };
-        let mut result: *mut libc::passwd = std::ptr::null_mut();
-        // SAFETY: all pointers are valid for the duration of the call, and
-        // `buffer` is writable with the length supplied to getpwnam_r.
-        let ret = unsafe {
-            libc::getpwnam_r(
-                user.as_ptr(),
-                &mut passwd,
-                buffer.as_mut_ptr().cast(),
-                buffer.len(),
-                &mut result,
-            )
-        };
-        if ret == 0 {
-            if result.is_null() {
-                return Err(io::Error::new(
-                    io::ErrorKind::NotFound,
-                    format!("sandbox user not found: {}", user.to_string_lossy()),
-                ));
-            }
-            return Ok(passwd.pw_gid);
-        }
-        if ret == libc::ERANGE && buffer.len() < PASSWD_BUFFER_MAX_LEN {
-            buffer.resize((buffer.len() * 2).min(PASSWD_BUFFER_MAX_LEN), 0);
-            continue;
-        }
-        return Err(io::Error::from_raw_os_error(ret));
-    }
-}
-
-fn lookup_user_gid(user: &str) -> io::Result<libc::gid_t> {
-    let user = CString::new(user).map_err(|_| {
-        io::Error::new(
-            io::ErrorKind::InvalidInput,
-            "sandbox user name must not contain NUL bytes",
-        )
-    })?;
-    lookup_user_gid_cstr(&user)
-}
-
-fn sandbox_user_gid() -> io::Result<libc::gid_t> {
-    if let Some(gid) = SANDBOX_USER_GID.get() {
-        return Ok(*gid);
-    }
-    let gid = lookup_user_gid(SANDBOX_USER)?;
-    let _ = SANDBOX_USER_GID.set(gid);
-    Ok(*SANDBOX_USER_GID.get().unwrap_or(&gid))
-}
-
 fn fchown_group(fd: RawFd, gid: libc::gid_t) -> io::Result<()> {
     // SAFETY: `fd` comes from an open file/directory descriptor and `-1`
     // as uid asks fchown to leave the owner unchanged.
@@ -509,7 +440,7 @@ fn create_env_script_in_dir(
                 // owned either path, an existing same-UID process could
                 // chmod/replace run.sh after the path appears in argv but
                 // before bash opens it.
-                let sandbox_gid = sandbox_user_gid()?;
+                let sandbox_gid = crate::user::sandbox_user_gid()?;
                 let script_dir_file = File::open(&script_dir)?;
                 fchown_group(file.as_raw_fd(), sandbox_gid)?;
                 file.set_permissions(fs::Permissions::from_mode(0o440))?;
@@ -662,23 +593,6 @@ mod tests {
         std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o700)).unwrap();
         let guard = TempDirGuard(dir.clone());
         (dir, guard)
-    }
-
-    #[test]
-    fn lookup_user_gid_reads_system_group() {
-        let root = std::ffi::CString::new("root").unwrap();
-
-        assert_eq!(lookup_user_gid_cstr(&root).unwrap(), 0);
-    }
-
-    #[test]
-    fn lookup_user_gid_reports_missing_user() {
-        let user =
-            std::ffi::CString::new(format!("vm0-missing-user-{}", std::process::id())).unwrap();
-
-        let err = lookup_user_gid_cstr(&user).unwrap_err();
-
-        assert_eq!(err.kind(), io::ErrorKind::NotFound);
     }
 
     #[test]

--- a/crates/vsock-guest/src/user.rs
+++ b/crates/vsock-guest/src/user.rs
@@ -270,6 +270,15 @@ mod tests {
         assert_eq!(credentials.groups, vec![2000]);
     }
 
+    #[cfg(any(debug_assertions, feature = "test-support"))]
+    #[test]
+    fn sandbox_user_gid_is_unavailable_in_local_builds() {
+        let err = sandbox_user_gid().unwrap_err();
+
+        assert_eq!(err.kind(), io::ErrorKind::Other);
+        assert!(err.to_string().contains("sandbox user gid is unavailable"));
+    }
+
     #[test]
     fn parse_user_credentials_fails_when_user_missing() {
         let err =

--- a/crates/vsock-guest/src/user.rs
+++ b/crates/vsock-guest/src/user.rs
@@ -304,4 +304,13 @@ mod tests {
 
         assert_eq!(err.kind(), io::ErrorKind::InvalidData);
     }
+
+    #[test]
+    fn parse_user_credentials_fails_on_invalid_gid() {
+        let err =
+            parse_user_credentials("user:x:1000:not-a-gid::/home/user:/bin/bash\n", "", "user")
+                .unwrap_err();
+
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    }
 }

--- a/crates/vsock-guest/src/user.rs
+++ b/crates/vsock-guest/src/user.rs
@@ -3,12 +3,14 @@ use std::io;
 use std::path::PathBuf;
 use std::process::Command;
 #[cfg(not(any(debug_assertions, feature = "test-support")))]
-use std::sync::OnceLock;
+use std::sync::{Mutex, OnceLock};
 
 #[cfg(not(any(debug_assertions, feature = "test-support")))]
 const SANDBOX_USER: &str = "user";
 #[cfg(not(any(debug_assertions, feature = "test-support")))]
 static SANDBOX_USER_CREDENTIALS: OnceLock<UserCredentials> = OnceLock::new();
+#[cfg(not(any(debug_assertions, feature = "test-support")))]
+static SANDBOX_USER_CREDENTIALS_INIT: Mutex<()> = Mutex::new(());
 
 #[cfg(any(test, not(any(debug_assertions, feature = "test-support"))))]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -134,6 +136,13 @@ fn system_user_credentials(username: &str) -> io::Result<UserCredentials> {
 
 #[cfg(not(any(debug_assertions, feature = "test-support")))]
 fn cached_system_user_credentials() -> io::Result<&'static UserCredentials> {
+    if let Some(credentials) = SANDBOX_USER_CREDENTIALS.get() {
+        return Ok(credentials);
+    }
+
+    let _guard = SANDBOX_USER_CREDENTIALS_INIT
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
     if let Some(credentials) = SANDBOX_USER_CREDENTIALS.get() {
         return Ok(credentials);
     }

--- a/crates/vsock-guest/src/user.rs
+++ b/crates/vsock-guest/src/user.rs
@@ -26,6 +26,25 @@ enum TargetIdentity {
     User(UserCredentials),
 }
 
+#[cfg(not(any(debug_assertions, feature = "test-support")))]
+pub(crate) fn sandbox_user_name() -> &'static str {
+    SANDBOX_USER
+}
+
+pub(crate) fn sandbox_user_gid() -> io::Result<libc::gid_t> {
+    #[cfg(any(debug_assertions, feature = "test-support"))]
+    {
+        Err(io::Error::other(
+            "sandbox user gid is unavailable in debug/test-support builds",
+        ))
+    }
+
+    #[cfg(not(any(debug_assertions, feature = "test-support")))]
+    {
+        cached_system_user_credentials().map(|credentials| credentials.gid as libc::gid_t)
+    }
+}
+
 pub(crate) fn apply_write_file_identity(command: &mut Command, sudo: bool) -> io::Result<()> {
     #[cfg(any(debug_assertions, feature = "test-support"))]
     let _ = command;
@@ -239,6 +258,16 @@ mod tests {
         assert_eq!(credentials.gid, 1000);
         assert_eq!(credentials.home, PathBuf::from("/home/user"));
         assert_eq!(credentials.groups, vec![27, 113, 1000]);
+    }
+
+    #[test]
+    fn parse_user_credentials_uses_passwd_primary_gid_without_group_entry() {
+        let passwd = "user:x:1000:2000::/home/user:/bin/bash\n";
+
+        let credentials = parse_user_credentials(passwd, "", "user").unwrap();
+
+        assert_eq!(credentials.gid, 2000);
+        assert_eq!(credentials.groups, vec![2000]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Make `vsock-guest/src/user.rs` the single source for production sandbox user identity helpers.
- Replace `exec.rs`'s duplicate sandbox username/gid cache and `getpwnam_r` path with calls into `user.rs`.
- Keep command execution policy and env-script chmod/chown security behavior in `exec.rs`.
- Add parser coverage for primary gid extraction when no group entry exists.

Closes #13019

## Tests

- `cargo test --manifest-path crates/Cargo.toml -p vsock-guest user::tests`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-guest exec::tests`
- `cargo fmt --manifest-path crates/Cargo.toml --all`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-guest`
- `cargo clippy --manifest-path crates/Cargo.toml -p vsock-guest --all-targets -- -D warnings`
- `cargo check --manifest-path crates/Cargo.toml -p vsock-guest --release`
- pre-commit `cargo-fmt`, `cargo-doc`, `cargo-clippy`
