### PR TITLE
fix: anchor cron schedule next run time

### DIFF
--- a/turbo/apps/api/src/signals/services/__tests__/zero-schedules.service.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/zero-schedules.service.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+
+import { calculateNextRun } from "../zero-schedules.service";
+
+describe("calculateNextRun", () => {
+  it("uses the supplied start date when finding the next cron run", () => {
+    const nextRunAt = calculateNextRun(
+      "0 9 * * *",
+      "UTC",
+      new Date("2099-01-01T04:00:00.000Z"),
+    );
+
+    expect(nextRunAt?.toISOString()).toBe("2099-01-01T09:00:00.000Z");
+  });
+});

--- a/turbo/apps/api/src/signals/services/zero-schedules.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-schedules.service.ts
@@ -85,9 +85,9 @@ function scheduleResponse(
 export function calculateNextRun(
   cronExpression: string,
   timezone: string,
-  startFrom: Date = nowDate(),
+  fromDate: Date,
 ): Date | null {
-  return new Cron(cronExpression, { timezone }).nextRun(startFrom);
+  return new Cron(cronExpression, { timezone }).nextRun(fromDate);
 }
 
 type OwnershipResult =
@@ -254,7 +254,11 @@ export const enableSchedule$ = command(
     if (schedule.triggerType === "loop") {
       nextRunAt = now;
     } else if (schedule.cronExpression) {
-      nextRunAt = calculateNextRun(schedule.cronExpression, schedule.timezone);
+      nextRunAt = calculateNextRun(
+        schedule.cronExpression,
+        schedule.timezone,
+        now,
+      );
     } else if (schedule.atTime) {
       if (schedule.atTime > now) {
         nextRunAt = schedule.atTime;


### PR DESCRIPTION
## Summary
- Require an explicit base date when calculating cron next-run times
- Use callback completion time and schedule enable time as the cron calculation anchor
- Add coverage for next-run calculation using a supplied start date

## Tests
- DATABASE_URL=postgresql://postgres:postgres@localhost:5432/vm0_test pnpm exec vitest run src/signals/routes/__tests__/internal-callbacks-schedule.test.ts src/signals/services/__tests__/zero-schedules.service.test.ts
- pnpm exec prettier --check src/signals/routes/internal-callbacks-schedule.ts src/signals/services/zero-schedules.service.ts src/signals/services/__tests__/zero-schedules.service.test.ts
- pnpm exec tsc --noEmit
- git diff --check
- pre-commit: prettier, knip, turbo check-types