### PR TITLE
feat: add cli auth feature flags

### DIFF
--- a/turbo/packages/connectors/src/feature-switch-key.ts
+++ b/turbo/packages/connectors/src/feature-switch-key.ts
@@ -24,6 +24,8 @@ export enum FeatureSwitchKey {
   GoogleAdsConnector = "googleAdsConnector",
   MetaAdsConnector = "metaAdsConnector",
   StripeConnector = "stripeConnector",
+  CliAuth = "cliAuth",
+  StripeCliAuth = "stripeCliAuth",
   PosthogConnector = "posthogConnector",
   PwaOfflineCache = "pwaOfflineCache",
   MailchimpConnector = "mailchimpConnector",

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -94,6 +94,33 @@ describe("isFeatureEnabled", () => {
       }),
     ).toBe(true);
   });
+
+  it("should enable CLI auth switches for staff orgs only by default", () => {
+    expect(isFeatureEnabled(FeatureSwitchKey.CliAuth, {})).toBe(false);
+    expect(isFeatureEnabled(FeatureSwitchKey.StripeCliAuth, {})).toBe(false);
+
+    expect(
+      isFeatureEnabled(FeatureSwitchKey.CliAuth, {
+        orgId: "org_3ANttyrbWYJk6JKRSTRLEsbsDLe",
+      }),
+    ).toBe(true);
+    expect(
+      isFeatureEnabled(FeatureSwitchKey.StripeCliAuth, {
+        orgId: "org_3ANttyrbWYJk6JKRSTRLEsbsDLe",
+      }),
+    ).toBe(true);
+
+    expect(
+      isFeatureEnabled(FeatureSwitchKey.CliAuth, {
+        orgId: "org_nonexistent",
+      }),
+    ).toBe(false);
+    expect(
+      isFeatureEnabled(FeatureSwitchKey.StripeCliAuth, {
+        orgId: "org_nonexistent",
+      }),
+    ).toBe(false);
+  });
 });
 
 describe("getAllFeatureStates", () => {
@@ -190,6 +217,30 @@ describe("overrides", () => {
     expect(
       isFeatureEnabled(FeatureSwitchKey.DropboxConnector, {
         overrides: { [FeatureSwitchKey.AhrefsConnector]: true },
+      }),
+    ).toBe(false);
+  });
+
+  it("should allow CLI auth switches to be overridden independently", () => {
+    expect(
+      isFeatureEnabled(FeatureSwitchKey.CliAuth, {
+        overrides: { [FeatureSwitchKey.CliAuth]: true },
+      }),
+    ).toBe(true);
+    expect(
+      isFeatureEnabled(FeatureSwitchKey.StripeCliAuth, {
+        overrides: { [FeatureSwitchKey.StripeCliAuth]: true },
+      }),
+    ).toBe(true);
+
+    expect(
+      isFeatureEnabled(FeatureSwitchKey.StripeCliAuth, {
+        overrides: { [FeatureSwitchKey.CliAuth]: true },
+      }),
+    ).toBe(false);
+    expect(
+      isFeatureEnabled(FeatureSwitchKey.CliAuth, {
+        overrides: { [FeatureSwitchKey.StripeCliAuth]: true },
       }),
     ).toBe(false);
   });

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -134,6 +134,20 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     description: "Enable the Stripe payment connector integration",
     enabled: false,
   },
+  [FeatureSwitchKey.CliAuth]: {
+    maintainer: "liangyou@vm0.ai",
+    description:
+      "Gate CLI-based connector auth UI and API surfaces. Rollout control only; credential routes still require normal auth and ownership checks.",
+    enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+  },
+  [FeatureSwitchKey.StripeCliAuth]: {
+    maintainer: "liangyou@vm0.ai",
+    description:
+      "Gate Stripe-specific CLI auth UI and API surfaces. Stripe CLI auth consumers should also require CliAuth.",
+    enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+  },
   [FeatureSwitchKey.PosthogConnector]: {
     maintainer: "ethan@vm0.ai",
     description: "Enable the PostHog analytics connector",


### PR DESCRIPTION
## Summary

- Add umbrella `CliAuth` and provider-specific `StripeCliAuth` feature switches.
- Register both switches as staff-org staged rollout gates with `liangyou@vm0.ai` as maintainer.
- Add feature-switch tests for default, staff-org, and independent override behavior.

Closes #13127

## Tests

- `pnpm --filter @vm0/core test -- feature-switch`
- `pnpm --filter @vm0/core check-types`
- `pnpm --filter @vm0/connectors check-types`
- pre-commit: `knip` and `turbo run check-types --concurrency=1`