### PR TITLE
refactor(api): migrate slack webhooks

### DIFF
--- a/turbo/apps/api/src/__tests__/mocks.ts
+++ b/turbo/apps/api/src/__tests__/mocks.ts
@@ -71,6 +71,8 @@ export interface ApiTestMocks {
     readonly conversations: {
       readonly list: AsyncMock;
       readonly open: AsyncMock;
+      readonly history: AsyncMock;
+      readonly replies: AsyncMock;
     };
     readonly files: {
       readonly info: AsyncMock;
@@ -84,6 +86,10 @@ export interface ApiTestMocks {
     };
     readonly views: {
       readonly publish: AsyncMock;
+      readonly open: AsyncMock;
+    };
+    readonly users: {
+      readonly info: AsyncMock;
     };
     readonly fetchFile: AsyncMock;
   };
@@ -200,6 +206,8 @@ const apiTestMocks: ApiTestMocks = vi.hoisted((): ApiTestMocks => {
     conversations: {
       list: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
       open: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
+      history: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
+      replies: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
     },
     files: {
       info: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
@@ -213,6 +221,10 @@ const apiTestMocks: ApiTestMocks = vi.hoisted((): ApiTestMocks => {
     },
     views: {
       publish: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
+      open: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
+    },
+    users: {
+      info: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
     },
     fetchFile: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
   };
@@ -500,6 +512,8 @@ vi.mock("@slack/web-api", () => {
         conversations: {
           list: apiTestMocks.slack.conversations.list,
           open: apiTestMocks.slack.conversations.open,
+          history: apiTestMocks.slack.conversations.history,
+          replies: apiTestMocks.slack.conversations.replies,
         },
         files: {
           info: apiTestMocks.slack.files.info,
@@ -514,6 +528,10 @@ vi.mock("@slack/web-api", () => {
         },
         views: {
           publish: apiTestMocks.slack.views.publish,
+          open: apiTestMocks.slack.views.open,
+        },
+        users: {
+          info: apiTestMocks.slack.users.info,
         },
       };
     }),
@@ -645,11 +663,15 @@ export function resetApiTestMocks(): void {
   apiTestMocks.slack.chat.postEphemeral.mockReset();
   apiTestMocks.slack.conversations.list.mockReset();
   apiTestMocks.slack.conversations.open.mockReset();
+  apiTestMocks.slack.conversations.history.mockReset();
+  apiTestMocks.slack.conversations.replies.mockReset();
   apiTestMocks.slack.files.info.mockReset();
   apiTestMocks.slack.files.getUploadURLExternal.mockReset();
   apiTestMocks.slack.files.completeUploadExternal.mockReset();
   apiTestMocks.slack.oauth.v2.access.mockReset();
   apiTestMocks.slack.views.publish.mockReset();
+  apiTestMocks.slack.views.open.mockReset();
+  apiTestMocks.slack.users.info.mockReset();
   apiTestMocks.slack.fetchFile.mockReset();
   apiTestMocks.stripe.invoices.list.mockReset();
   apiTestMocks.stripe.invoices.create.mockReset();

--- a/turbo/apps/api/src/lib/slack-request-verification.ts
+++ b/turbo/apps/api/src/lib/slack-request-verification.ts
@@ -1,0 +1,48 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+import { now } from "./time";
+
+interface SlackSignatureHeaders {
+  readonly signature: string;
+  readonly timestamp: string;
+}
+
+const SLACK_REPLAY_WINDOW_SECONDS = 60 * 5;
+
+export function getSlackSignatureHeaders(
+  headers: Headers,
+): SlackSignatureHeaders | null {
+  const signature = headers.get("x-slack-signature");
+  const timestamp = headers.get("x-slack-request-timestamp");
+
+  if (!signature || !timestamp) {
+    return null;
+  }
+
+  return { signature, timestamp };
+}
+
+export function verifySlackSignature(args: {
+  readonly signingSecret: string;
+  readonly signature: string;
+  readonly timestamp: string;
+  readonly body: string;
+}): boolean {
+  const currentTime = Math.floor(now() / 1000);
+  const requestTime = Number.parseInt(args.timestamp, 10);
+  if (
+    !Number.isFinite(requestTime) ||
+    Math.abs(currentTime - requestTime) > SLACK_REPLAY_WINDOW_SECONDS
+  ) {
+    return false;
+  }
+
+  const baseString = `v0:${args.timestamp}:${args.body}`;
+  const expectedSignature = `v0=${createHmac("sha256", args.signingSecret)
+    .update(baseString)
+    .digest("hex")}`;
+
+  const actual = Buffer.from(args.signature);
+  const expected = Buffer.from(expectedSignature);
+  return actual.length === expected.length && timingSafeEqual(actual, expected);
+}

--- a/turbo/apps/api/src/lib/slack-webhook-blocks.ts
+++ b/turbo/apps/api/src/lib/slack-webhook-blocks.ts
@@ -1,0 +1,556 @@
+import type { Block, KnownBlock, MarkdownBlock, View } from "@slack/web-api";
+
+import { env } from "./env";
+
+type SlackBlocks = (Block | KnownBlock)[];
+
+export const AGENT_PICKER_CALLBACK_ID = "switch_agent_modal";
+export const AGENT_PICKER_BLOCK_ID = "agent_select_block";
+export const AGENT_PICKER_ACTION_ID = "agent_select";
+export const AGENT_PICKER_ORG_DEFAULT_VALUE = "__org_default__";
+
+export const MODEL_PICKER_CALLBACK_ID = "model_preference_modal";
+export const MODEL_PICKER_BLOCK_ID = "model_select_block";
+export const MODEL_PICKER_ACTION_ID = "model_select";
+
+interface AgentPickerOption {
+  readonly composeId: string;
+  readonly name: string;
+  readonly displayName?: string | null;
+}
+
+interface ModelPickerOption {
+  readonly model: string;
+  readonly label: string;
+  readonly isDefault?: boolean;
+}
+
+interface AppHomeOptions {
+  readonly isLinked: boolean;
+  readonly isInstalled?: boolean;
+  readonly vm0UserId?: string;
+  readonly userEmail?: string;
+  readonly agentName?: string;
+  readonly isOverrideActive?: boolean;
+  readonly canSwitch?: boolean;
+  readonly loginUrl?: string;
+}
+
+function appUrl(): string {
+  return env("VM0_WEB_URL");
+}
+
+function buildAppHomeHeaderBlocks(): SlackBlocks {
+  return [
+    {
+      type: "header",
+      text: { type: "plain_text", text: "Welcome to Zero! :wave:" },
+    },
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: "Connect your AI agents to Slack and interact with them through messages.",
+      },
+    },
+    { type: "divider" },
+  ];
+}
+
+function buildAppHomeNotInstalledBlocks(): SlackBlocks {
+  return [
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: ":warning: *Zero is not installed for this workspace*\nAsk a workspace admin to install Zero from the platform.",
+      },
+    },
+    {
+      type: "actions",
+      elements: [
+        {
+          type: "button",
+          text: { type: "plain_text", text: "Open Zero Settings" },
+          url: `${appUrl()}/works`,
+          action_id: "home_open_settings",
+          style: "primary",
+        },
+      ],
+    },
+  ];
+}
+
+function buildAppHomeDisconnectedBlocks(loginUrl?: string): SlackBlocks {
+  const blocks: SlackBlocks = [
+    {
+      type: "section",
+      text: { type: "mrkdwn", text: ":x: *Account not connected*" },
+    },
+  ];
+  if (!loginUrl) {
+    return blocks;
+  }
+  blocks.push({
+    type: "actions",
+    elements: [
+      {
+        type: "button",
+        text: { type: "plain_text", text: "Connect" },
+        url: loginUrl,
+        action_id: "home_login_prompt",
+        style: "primary",
+      },
+    ],
+  });
+  return blocks;
+}
+
+function buildAppHomeAccountBlock(options: AppHomeOptions): SlackBlocks {
+  return [
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: `:white_check_mark: *Connected to Zero*\nAccount: ${
+          options.userEmail || options.vm0UserId
+        }`,
+      },
+    },
+  ];
+}
+
+function buildAppHomeAgentBlocks(options: AppHomeOptions): SlackBlocks {
+  const blocks: SlackBlocks = [
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: options.isOverrideActive
+          ? ":robot_face: *Your Agent*"
+          : ":robot_face: *Workspace Agent*",
+      },
+    },
+  ];
+
+  if (options.agentName) {
+    const settingsButton = {
+      type: "button" as const,
+      text: { type: "plain_text" as const, text: "Settings" },
+      url: `${appUrl()}/works`,
+      action_id: "home_environment_setup",
+    };
+    blocks.push({
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: `AgentName: *${options.agentName}*`,
+      },
+      ...(options.canSwitch ? {} : { accessory: settingsButton }),
+    });
+    if (options.canSwitch) {
+      blocks.push({
+        type: "actions",
+        elements: [
+          {
+            type: "button",
+            text: { type: "plain_text", text: "Switch" },
+            action_id: "home_switch_agent",
+            style: "primary",
+          },
+          settingsButton,
+        ],
+      });
+    }
+    return blocks;
+  }
+
+  blocks.push({
+    type: "section",
+    text: { type: "mrkdwn", text: "_No agent configured yet._" },
+  });
+  return blocks;
+}
+
+function buildAppHomeUsageBlocks(): SlackBlocks {
+  return [
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: ":bulb: *Here are some things you can do:*",
+      },
+    },
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: "*Commands*\n\u2022 `/zero connect` - Connect to Zero\n\u2022 `/zero disconnect` - Disconnect from Zero",
+      },
+    },
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: "*Usage*\nSend a DM or `@Zero` in any channel to chat with your agents",
+      },
+    },
+    { type: "divider" },
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: "*Disconnect Zero Account*\nThis will remove your Zero account connection",
+      },
+      accessory: {
+        type: "button",
+        text: { type: "plain_text", text: "Disconnect" },
+        action_id: "home_disconnect",
+        style: "danger",
+        confirm: {
+          title: { type: "plain_text", text: "Disconnect Zero Account" },
+          text: {
+            type: "plain_text",
+            text: "This will remove your Zero account connection",
+          },
+          confirm: { type: "plain_text", text: "Disconnect" },
+          deny: { type: "plain_text", text: "Cancel" },
+        },
+      },
+    },
+  ];
+}
+
+export function buildAppHomeView(options: AppHomeOptions): View {
+  const blocks = buildAppHomeHeaderBlocks();
+
+  if (options.isInstalled === false) {
+    return {
+      type: "home",
+      blocks: [...blocks, ...buildAppHomeNotInstalledBlocks()],
+    };
+  }
+
+  if (!options.isLinked) {
+    return {
+      type: "home",
+      blocks: [...blocks, ...buildAppHomeDisconnectedBlocks(options.loginUrl)],
+    };
+  }
+
+  return {
+    type: "home",
+    blocks: [
+      ...blocks,
+      ...buildAppHomeAccountBlock(options),
+      { type: "divider" },
+      ...buildAppHomeAgentBlocks(options),
+      { type: "divider" },
+      ...buildAppHomeUsageBlocks(),
+    ],
+  };
+}
+
+export function buildErrorMessage(error: string): SlackBlocks {
+  return [
+    {
+      type: "section",
+      text: { type: "mrkdwn", text: `:x: *Error*\n${error}` },
+    },
+  ];
+}
+
+export function buildLoginPromptMessage(loginUrl: string): SlackBlocks {
+  return [
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: "To use Zero in Slack, please connect your account first.",
+      },
+    },
+    {
+      type: "actions",
+      elements: [
+        {
+          type: "button",
+          text: { type: "plain_text", text: "Connect" },
+          url: loginUrl,
+          action_id: "login_prompt",
+          style: "primary",
+        },
+      ],
+    },
+  ];
+}
+
+export function buildHelpMessage(opts?: {
+  readonly canSwitch?: boolean;
+  readonly canModel?: boolean;
+}): SlackBlocks {
+  const switchLine = opts?.canSwitch
+    ? "\n\u2022 `/zero switch` - Choose which agent responds to your messages"
+    : "";
+  const modelLine = opts?.canModel
+    ? "\n\u2022 `/zero model` - Choose your model"
+    : "";
+  return [
+    {
+      type: "section",
+      text: { type: "mrkdwn", text: "*Zero Slack Bot Help*" },
+    },
+    { type: "divider" },
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: `*Commands*\n\u2022 \`/zero connect\` - Connect to Zero${switchLine}${modelLine}\n\u2022 \`/zero disconnect\` - Disconnect from Zero`,
+      },
+    },
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: "*Usage*\n\u2022 `@Zero <message>` - Send a message to your agent",
+      },
+    },
+  ];
+}
+
+export function buildSuccessMessage(message: string): SlackBlocks {
+  return [
+    {
+      type: "section",
+      text: { type: "mrkdwn", text: `:white_check_mark: ${message}` },
+    },
+  ];
+}
+
+export function buildWelcomeMessage(agentName?: string): SlackBlocks {
+  const blocks: SlackBlocks = [
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: ":wave: *Hi! I'm Zero.*\n\nI can connect you to AI agents to help with your tasks.",
+      },
+    },
+    { type: "divider" },
+  ];
+
+  if (agentName) {
+    blocks.push(
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: `*Workspace Agent*\n\u2022 \`${agentName}\``,
+        },
+      },
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: "*How to Use*\n\u2022 Just describe what you need help with",
+        },
+      },
+    );
+  } else {
+    blocks.push({
+      type: "section",
+      text: { type: "mrkdwn", text: "_No workspace agent configured yet._" },
+    });
+  }
+
+  return blocks;
+}
+
+const MARKDOWN_BLOCK_MAX_LENGTH = 12_000;
+
+function buildMarkdownMessage(content: string): SlackBlocks {
+  const truncationSuffix = "\n\n_(Message too long to view in Slack.)_";
+  const text =
+    content.length > MARKDOWN_BLOCK_MAX_LENGTH
+      ? content.slice(0, MARKDOWN_BLOCK_MAX_LENGTH - truncationSuffix.length) +
+        truncationSuffix
+      : content;
+  const block: MarkdownBlock = { type: "markdown", text };
+  return [block];
+}
+
+export function buildAgentResponseMessage(
+  content: string,
+  logsUrl?: string,
+  footerText?: string,
+): SlackBlocks {
+  const blocks: SlackBlocks = [...buildMarkdownMessage(content)];
+  if (logsUrl) {
+    blocks.push({
+      type: "context",
+      elements: [{ type: "mrkdwn", text: `:clipboard: <${logsUrl}|Audit>` }],
+    });
+  }
+  if (footerText) {
+    blocks.push({
+      type: "context",
+      elements: [{ type: "mrkdwn", text: footerText }],
+    });
+  }
+  return blocks;
+}
+
+export function buildAgentPickerModal(args: {
+  readonly options: readonly AgentPickerOption[];
+  readonly currentSelectedId: string | null;
+  readonly orgDefaultName: string | null;
+  readonly privateMetadata?: string;
+}): View {
+  const orgDefaultLabel = args.orgDefaultName
+    ? `Use org default (${args.orgDefaultName})`
+    : "Use org default";
+  const selectOptions = [
+    {
+      text: { type: "plain_text" as const, text: orgDefaultLabel },
+      value: AGENT_PICKER_ORG_DEFAULT_VALUE,
+    },
+    ...args.options.map((option) => {
+      return {
+        text: {
+          type: "plain_text" as const,
+          text: (option.displayName ?? option.name).slice(0, 75),
+        },
+        value: option.composeId,
+      };
+    }),
+  ];
+  const initialOption = args.currentSelectedId
+    ? (selectOptions.find((option) => {
+        return option.value === args.currentSelectedId;
+      }) ?? selectOptions[0])
+    : selectOptions[0];
+
+  return {
+    type: "modal",
+    callback_id: AGENT_PICKER_CALLBACK_ID,
+    title: { type: "plain_text", text: "Switch Agent" },
+    submit: { type: "plain_text", text: "Switch" },
+    close: { type: "plain_text", text: "Cancel" },
+    blocks: [
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: "Choose which agent should respond to your mentions and DMs. Only affects your own messages.",
+        },
+      },
+      {
+        type: "input",
+        block_id: AGENT_PICKER_BLOCK_ID,
+        label: { type: "plain_text", text: "Agent" },
+        element: {
+          type: "static_select",
+          action_id: AGENT_PICKER_ACTION_ID,
+          placeholder: { type: "plain_text", text: "Select an agent" },
+          options: selectOptions,
+          ...(initialOption && { initial_option: initialOption }),
+        },
+      },
+    ],
+    ...(args.privateMetadata && { private_metadata: args.privateMetadata }),
+  };
+}
+
+function formatModelPickerOptionLabel(option: ModelPickerOption): string {
+  if (!option.isDefault) {
+    return option.label.slice(0, 75);
+  }
+  const suffix = " (workspace default)";
+  if (option.label.length + suffix.length <= 75) {
+    return `${option.label}${suffix}`;
+  }
+  return `${option.label.slice(0, 75 - suffix.length)}${suffix}`;
+}
+
+export function buildModelPickerModal(args: {
+  readonly options: readonly ModelPickerOption[];
+  readonly currentSelectedModel: string | null;
+  readonly privateMetadata?: string;
+}): View {
+  const selectOptions = args.options.map((option) => {
+    return {
+      text: {
+        type: "plain_text" as const,
+        text: formatModelPickerOptionLabel(option),
+      },
+      value: option.model,
+    };
+  });
+  const defaultModel = args.options.find((option) => {
+    return option.isDefault;
+  })?.model;
+  const currentOption = args.currentSelectedModel
+    ? selectOptions.find((option) => {
+        return option.value === args.currentSelectedModel;
+      })
+    : undefined;
+  const defaultOption = defaultModel
+    ? selectOptions.find((option) => {
+        return option.value === defaultModel;
+      })
+    : undefined;
+  const initialOption = currentOption ?? defaultOption ?? selectOptions[0];
+
+  return {
+    type: "modal",
+    callback_id: MODEL_PICKER_CALLBACK_ID,
+    title: { type: "plain_text", text: "Switch Model" },
+    submit: { type: "plain_text", text: "Switch" },
+    close: { type: "plain_text", text: "Cancel" },
+    blocks: [
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: "Choose your model. This only affects your own runs.",
+        },
+      },
+      {
+        type: "input",
+        block_id: MODEL_PICKER_BLOCK_ID,
+        label: { type: "plain_text", text: "Model" },
+        element: {
+          type: "static_select",
+          action_id: MODEL_PICKER_ACTION_ID,
+          placeholder: { type: "plain_text", text: "Select a model" },
+          options: selectOptions,
+          ...(initialOption && { initial_option: initialOption }),
+        },
+      },
+    ],
+    ...(args.privateMetadata && { private_metadata: args.privateMetadata }),
+  };
+}
+
+export function buildLoginMessage(loginUrl: string): SlackBlocks {
+  return [
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: "Please connect your account to use Zero in this workspace.",
+      },
+    },
+    {
+      type: "actions",
+      elements: [
+        {
+          type: "button",
+          text: { type: "plain_text", text: "Connect" },
+          url: loginUrl,
+          action_id: "login",
+          style: "primary",
+        },
+      ],
+    },
+  ];
+}

--- a/turbo/apps/api/src/lib/slack-webhook-context.ts
+++ b/turbo/apps/api/src/lib/slack-webhook-context.ts
@@ -1,0 +1,484 @@
+import type { WebClient } from "@slack/web-api";
+
+import {
+  fetchSlackUserInfoMap,
+  formatSenderBlock,
+  type SlackUserInfo,
+} from "../signals/external/slack-message-client";
+
+export interface SlackFile {
+  readonly id?: string;
+  readonly name?: string;
+  readonly title?: string;
+  readonly mimetype?: string;
+  readonly filetype?: string;
+  readonly pretty_type?: string;
+  readonly size?: number;
+  readonly original_w?: string;
+  readonly original_h?: string;
+  readonly thumb_360?: string;
+  readonly thumb_480?: string;
+  readonly permalink?: string;
+  readonly permalink_public?: string;
+  readonly url_private_download?: string;
+}
+
+interface SlackAttachment {
+  readonly image_url?: string;
+  readonly image_width?: number;
+  readonly image_height?: number;
+  readonly thumb_url?: string;
+  readonly title?: string;
+  readonly fallback?: string;
+}
+
+interface RichTextStyle {
+  readonly bold?: boolean;
+  readonly italic?: boolean;
+  readonly strike?: boolean;
+  readonly code?: boolean;
+}
+
+interface RichTextElement {
+  readonly type: string;
+  readonly text?: string;
+  readonly url?: string;
+  readonly name?: string;
+  readonly unicode?: string;
+  readonly user_id?: string;
+  readonly usergroup_id?: string;
+  readonly channel_id?: string;
+  readonly range?: string;
+  readonly style?: RichTextStyle | string;
+  readonly indent?: number;
+  readonly offset?: number;
+  readonly language?: string;
+  readonly elements?: readonly RichTextElement[];
+}
+
+interface SlackBlock {
+  readonly type: string;
+  readonly elements?: readonly RichTextElement[];
+}
+
+interface SlackMessage {
+  readonly user?: string;
+  readonly text?: string;
+  readonly ts?: string;
+  readonly bot_id?: string;
+  readonly files?: readonly SlackFile[];
+  readonly attachments?: readonly SlackAttachment[];
+  readonly blocks?: readonly SlackBlock[];
+}
+
+async function fetchThreadContext(
+  client: WebClient,
+  channel: string,
+  threadTs: string,
+  limit = 100,
+): Promise<readonly SlackMessage[]> {
+  const result = await client.conversations.replies({
+    channel,
+    ts: threadTs,
+    limit,
+  });
+  return (result.messages ?? []) as SlackMessage[];
+}
+
+async function fetchChannelContext(
+  client: WebClient,
+  channel: string,
+  limit = 10,
+  latest?: string,
+): Promise<readonly SlackMessage[]> {
+  const result = await client.conversations.history({
+    channel,
+    limit,
+    ...(latest && { latest }),
+  });
+  return [...((result.messages ?? []) as SlackMessage[])].reverse();
+}
+
+function applyTextStyle(
+  text: string,
+  style: RichTextStyle | string | undefined,
+): string {
+  if (typeof style === "string" || !style) {
+    return text;
+  }
+  if (style.code) {
+    return `\`${text}\``;
+  }
+  let result = text;
+  if (style.bold) {
+    result = `**${result}**`;
+  }
+  if (style.italic) {
+    result = `_${result}_`;
+  }
+  if (style.strike) {
+    result = `~${result}~`;
+  }
+  return result;
+}
+
+function formatInlineElement(element: RichTextElement): string {
+  switch (element.type) {
+    case "text": {
+      return applyTextStyle(element.text ?? "", element.style);
+    }
+    case "link": {
+      return element.url
+        ? `[${element.text ?? element.url}](${element.url})`
+        : (element.text ?? "");
+    }
+    case "emoji": {
+      return element.unicode
+        ? String.fromCodePoint(
+            ...element.unicode.split("-").map((hex) => {
+              return Number.parseInt(hex, 16);
+            }),
+          )
+        : `:${element.name ?? "emoji"}:`;
+    }
+    case "user": {
+      return `<@${element.user_id ?? "unknown"}>`;
+    }
+    case "usergroup": {
+      return `<!subteam^${element.usergroup_id ?? "unknown"}>`;
+    }
+    case "channel": {
+      return `<#${element.channel_id ?? "unknown"}>`;
+    }
+    case "broadcast": {
+      return `@${element.range ?? "here"}`;
+    }
+    default: {
+      return element.text ?? "";
+    }
+  }
+}
+
+function inlineElementsToText(elements: readonly RichTextElement[]): string {
+  return elements.map(formatInlineElement).join("");
+}
+
+function formatRichTextList(section: RichTextElement): string[] {
+  const indent = "  ".repeat(section.indent ?? 0);
+  const listStyle =
+    typeof section.style === "string" ? section.style : undefined;
+  const parts: string[] = [];
+  const elements = section.elements ?? [];
+  for (const [index, item] of elements.entries()) {
+    const bullet =
+      listStyle === "ordered" ? `${(section.offset ?? 0) + index + 1}.` : "-";
+    parts.push(
+      `${indent}${bullet} ${inlineElementsToText(item.elements ?? [])}`,
+    );
+  }
+  return parts;
+}
+
+function formatRichTextSection(section: RichTextElement): string[] {
+  switch (section.type) {
+    case "rich_text_section": {
+      return [inlineElementsToText(section.elements ?? [])];
+    }
+    case "rich_text_list": {
+      return formatRichTextList(section);
+    }
+    case "rich_text_preformatted": {
+      const code = inlineElementsToText(section.elements ?? []);
+      const language = section.language ?? "";
+      return [`\`\`\`${language}\n${code}\n\`\`\``];
+    }
+    case "rich_text_quote": {
+      return [
+        inlineElementsToText(section.elements ?? [])
+          .split("\n")
+          .map((line) => {
+            return `> ${line}`;
+          })
+          .join("\n"),
+      ];
+    }
+    default: {
+      return [];
+    }
+  }
+}
+
+function extractTextFromBlocks(
+  blocks: readonly SlackBlock[] | undefined,
+): string | undefined {
+  if (!blocks || blocks.length === 0) {
+    return undefined;
+  }
+
+  const parts: string[] = [];
+  for (const block of blocks) {
+    if (block.type !== "rich_text") {
+      continue;
+    }
+    for (const section of block.elements ?? []) {
+      parts.push(...formatRichTextSection(section));
+    }
+  }
+
+  const result = parts.join("\n");
+  return result.length > 0 ? result : undefined;
+}
+
+function formatFileInfo(file: SlackFile): string {
+  const parts: string[] = [];
+  const name = file.name || file.title || "Untitled";
+  const type = file.pretty_type || file.mimetype || "file";
+  parts.push(`[Slack file] ${name} (${type})`);
+
+  if (file.original_w && file.original_h) {
+    parts.push(`   [Dimensions] ${file.original_w}x${file.original_h}`);
+  }
+  if (file.id) {
+    parts.push(`   [ID] ${file.id}`);
+  } else {
+    const url =
+      file.permalink_public ||
+      file.thumb_480 ||
+      file.thumb_360 ||
+      file.permalink;
+    if (url) {
+      parts.push(`   [URL] ${url}`);
+    }
+  }
+
+  return parts.join("\n");
+}
+
+function formatAttachmentImage(attachment: SlackAttachment): string | null {
+  if (!attachment.image_url && !attachment.thumb_url) {
+    return null;
+  }
+  const parts: string[] = [];
+  const title = attachment.title || attachment.fallback || "Image";
+  parts.push(`[image]: ${title}`);
+  if (attachment.image_width && attachment.image_height) {
+    parts.push(
+      `   [Dimensions] ${attachment.image_width}x${attachment.image_height}`,
+    );
+  }
+  const url = attachment.image_url || attachment.thumb_url;
+  if (url) {
+    parts.push(
+      `   View: curl -sS -o /tmp/attachment_image.jpg "${url}" && read /tmp/attachment_image.jpg`,
+    );
+  }
+  return parts.join("\n");
+}
+
+function resolveUserMentions(
+  text: string,
+  userInfoMap?: Map<string, SlackUserInfo>,
+): string {
+  if (!userInfoMap || userInfoMap.size === 0) {
+    return text;
+  }
+  return text.replace(/<@(\w+)>/g, (_match, userId: string) => {
+    const info = userInfoMap.get(userId);
+    return info?.name ? `@${info.name} (${userId})` : `<@${userId}>`;
+  });
+}
+
+function extractMentionedUserIds(messages: readonly SlackMessage[]): string[] {
+  const ids = new Set<string>();
+  for (const message of messages) {
+    addMentionedUserIdsFromBlocks(message.blocks, ids);
+    if (message.text) {
+      for (const match of message.text.matchAll(/<@(\w+)>/g)) {
+        const userId = match[1];
+        if (userId) {
+          ids.add(userId);
+        }
+      }
+    }
+  }
+  return [...ids];
+}
+
+function addMentionedUserIdsFromBlocks(
+  blocks: readonly SlackBlock[] | undefined,
+  ids: Set<string>,
+): void {
+  for (const block of blocks ?? []) {
+    for (const section of block.elements ?? []) {
+      addMentionedUserIdsFromElements(section.elements, ids);
+    }
+  }
+}
+
+function addMentionedUserIdsFromElements(
+  elements: readonly RichTextElement[] | undefined,
+  ids: Set<string>,
+): void {
+  for (const element of elements ?? []) {
+    if (element.type === "user" && element.user_id) {
+      ids.add(element.user_id);
+    }
+  }
+}
+
+function formatMessageWithMetadata(
+  message: SlackMessage,
+  relativeIndex: number,
+  fileParts: readonly string[],
+  userInfoMap?: Map<string, SlackUserInfo>,
+): string {
+  const senderId = message.bot_id ? "BOT" : (message.user ?? "unknown");
+  const userInfo = userInfoMap?.get(senderId);
+  const rawText = extractTextFromBlocks(message.blocks) ?? message.text ?? "";
+  const text = resolveUserMentions(rawText, userInfoMap);
+
+  const parts = [
+    "---",
+    "",
+    `- RELATIVE_INDEX: ${relativeIndex}`,
+    formatSenderBlock(userInfo ?? { id: senderId }),
+    "",
+    text,
+  ];
+  if (fileParts.length > 0) {
+    parts.push(...fileParts);
+  }
+  return parts.join("\n");
+}
+
+const CONTEXT_PREAMBLE = [
+  "The messages below are from a Slack conversation. When responding:",
+  "- Messages closer to RELATIVE_INDEX 0 are more recent \u2014 prioritize them.",
+  "- Match the tone of the conversation \u2014 casual messages deserve casual replies.",
+  "- Only provide technical analysis when explicitly asked a technical question.",
+  "- Keep responses proportional to the message length and complexity.",
+].join("\n");
+
+function formatContextForAgent(
+  messages: readonly SlackMessage[],
+  contextType: "thread" | "channel" = "thread",
+  userInfoMap?: Map<string, SlackUserInfo>,
+): string {
+  if (messages.length === 0) {
+    return "";
+  }
+
+  const totalMessages = messages.length;
+  const formattedMessages = messages.map((message, index) => {
+    const fileParts: string[] = [];
+    for (const file of message.files ?? []) {
+      fileParts.push(formatFileInfo(file));
+    }
+    for (const attachment of message.attachments ?? []) {
+      const attachmentInfo = formatAttachmentImage(attachment);
+      if (attachmentInfo) {
+        fileParts.push(attachmentInfo);
+      }
+    }
+    return formatMessageWithMetadata(
+      message,
+      index - totalMessages,
+      fileParts,
+      userInfoMap,
+    );
+  });
+
+  const header =
+    contextType === "thread"
+      ? "# Slack Thread Context"
+      : "# Recent Channel Messages";
+  return `${header}\n\n${CONTEXT_PREAMBLE}\n\n${formattedMessages.join(
+    "\n\n",
+  )}\n\n---`;
+}
+
+function formatCurrentMessageFiles(files: readonly SlackFile[]): string {
+  return files.map(formatFileInfo).join("\n");
+}
+
+export async function fetchConversationContexts(
+  client: WebClient,
+  channelId: string,
+  threadTs: string | undefined,
+  currentMessageTs?: string,
+): Promise<{ readonly executionContext: string }> {
+  const isDm = channelId.startsWith("D");
+  const contextType = threadTs ? "thread" : "channel";
+  const allMessages = threadTs
+    ? await fetchThreadContext(client, channelId, threadTs)
+    : isDm
+      ? []
+      : await fetchChannelContext(client, channelId, 10);
+  const channelMessages =
+    threadTs && !isDm
+      ? await fetchChannelContext(client, channelId, 10, threadTs)
+      : [];
+  const contextMessages = currentMessageTs
+    ? allMessages.filter((message) => {
+        return message.ts !== currentMessageTs;
+      })
+    : allMessages;
+  const allContextMessages = [...channelMessages, ...allMessages];
+  const senderIds = allContextMessages.flatMap((message) => {
+    return message.user && !message.bot_id ? [message.user] : [];
+  });
+  const mentionedIds = extractMentionedUserIds(allContextMessages);
+  const userInfoMap = await fetchSlackUserInfoMap(client, [
+    ...senderIds,
+    ...mentionedIds,
+  ]);
+  const channelContextPrefix =
+    channelMessages.length > 0
+      ? formatContextForAgent(channelMessages, "channel", userInfoMap)
+      : "";
+  const threadExecContext =
+    contextMessages.length > 0
+      ? formatContextForAgent(contextMessages, contextType, userInfoMap)
+      : "";
+  return {
+    executionContext: channelContextPrefix
+      ? `${channelContextPrefix}\n\n${threadExecContext}`
+      : threadExecContext,
+  };
+}
+
+export async function enrichMessageContent(opts: {
+  readonly messageContent: string;
+  readonly files: readonly SlackFile[] | undefined;
+  readonly client: WebClient;
+  readonly userId: string;
+}): Promise<{
+  readonly prompt: string;
+  readonly userInfoExtras: {
+    readonly slackDisplayName?: string;
+    readonly slackUserId?: string;
+  };
+}> {
+  let prompt = opts.messageContent;
+  if (opts.files && opts.files.length > 0) {
+    prompt = `${prompt}\n\n${formatCurrentMessageFiles(opts.files)}`;
+  }
+
+  const mentionedIds = extractMentionedUserIds([{ text: opts.messageContent }]);
+  const userInfoMap = await fetchSlackUserInfoMap(opts.client, [
+    opts.userId,
+    ...mentionedIds,
+  ]);
+  prompt = resolveUserMentions(prompt, userInfoMap);
+
+  const currentUser = userInfoMap.get(opts.userId);
+  return {
+    prompt,
+    userInfoExtras: currentUser
+      ? {
+          slackDisplayName: currentUser.name,
+          slackUserId: currentUser.id,
+        }
+      : {},
+  };
+}

--- a/turbo/apps/api/src/signals/external/slack-message-client.ts
+++ b/turbo/apps/api/src/signals/external/slack-message-client.ts
@@ -1,4 +1,9 @@
-import { WebClient, type Block, type KnownBlock } from "@slack/web-api";
+import {
+  WebClient,
+  type Block,
+  type KnownBlock,
+  type View,
+} from "@slack/web-api";
 
 import { safeAsync } from "../utils";
 
@@ -95,6 +100,23 @@ export async function setThreadStatus(
   });
 }
 
+export async function publishAppHome(
+  client: WebClient,
+  userId: string,
+  view: View,
+): Promise<void> {
+  await client.views.publish({ user_id: userId, view });
+}
+
+export async function openView(
+  client: WebClient,
+  triggerId: string,
+  view: View,
+): Promise<{ readonly viewId: string | undefined }> {
+  const result = await client.views.open({ trigger_id: triggerId, view });
+  return { viewId: result.view?.id };
+}
+
 export async function postEphemeral(
   client: WebClient,
   options: {
@@ -121,6 +143,77 @@ export async function postEphemeral(
     throw result.error;
   }
   return { kind: "ok", ts: result.ok.message_ts };
+}
+
+export interface SlackUserInfo {
+  readonly id: string;
+  readonly name?: string;
+  readonly email?: string;
+  readonly timezone?: string;
+}
+
+export function formatSenderBlock(info: SlackUserInfo): string {
+  const parts = [`id: ${info.id}`];
+  if (info.name) {
+    parts.push(`name: ${info.name}`);
+  }
+  if (info.email) {
+    parts.push(`email: ${info.email}`);
+  }
+  if (info.timezone) {
+    parts.push(`timezone: ${info.timezone}`);
+  }
+  return `- SENDER: {${parts.join(", ")}}`;
+}
+
+async function fetchSlackUserInfo(
+  client: WebClient,
+  userId: string,
+): Promise<SlackUserInfo | undefined> {
+  const result = await client.users.info({ user: userId });
+  if (!result.ok || !result.user) {
+    return undefined;
+  }
+
+  const user = result.user;
+  const name =
+    user.profile?.display_name ||
+    user.profile?.real_name ||
+    user.real_name ||
+    user.name;
+  const email = user.profile?.email;
+  const timezone = user.tz_label || user.tz;
+
+  return {
+    id: userId,
+    name: name || undefined,
+    email: email || undefined,
+    timezone: timezone || undefined,
+  };
+}
+
+export async function fetchSlackUserInfoMap(
+  client: WebClient,
+  userIds: readonly string[],
+): Promise<Map<string, SlackUserInfo>> {
+  const map = new Map<string, SlackUserInfo>();
+  const uniqueIds = [...new Set(userIds)];
+  const results = await Promise.allSettled(
+    uniqueIds.map(async (id) => {
+      const info = await fetchSlackUserInfo(client, id);
+      if (info) {
+        map.set(id, info);
+      }
+    }),
+  );
+
+  for (const result of results) {
+    if (result.status === "rejected") {
+      continue;
+    }
+  }
+
+  return map;
 }
 
 type GetUploadUrlResult =

--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -109,7 +109,10 @@ import { zeroIntegrationsTelegramUploadCompleteRoutes } from "./routes/zero-inte
 import { zeroIntegrationsTelegramUploadInitRoutes } from "./routes/zero-integrations-telegram-upload-init";
 import { zeroSlackChannelsRoutes } from "./routes/zero-slack-channels";
 import { zeroSlackBrowserConnectRoutes } from "./routes/zero-slack-browser-connect";
+import { zeroSlackCommandsRoutes } from "./routes/zero-slack-commands";
 import { zeroSlackConnectRoutes } from "./routes/zero-slack-connect";
+import { zeroSlackEventsRoutes } from "./routes/zero-slack-events";
+import { zeroSlackInteractiveRoutes } from "./routes/zero-slack-interactive";
 import { zeroSlackOauthRoutes } from "./routes/zero-slack-oauth";
 import { zeroTeamRoutes } from "./routes/zero-team";
 import { zeroUploadsCompleteRoutes } from "./routes/zero-uploads-complete";
@@ -251,6 +254,9 @@ export const ROUTES: readonly RouteEntry[] = [
   ...zeroSlackBrowserConnectRoutes,
   ...zeroSlackConnectRoutes,
   ...zeroSlackOauthRoutes,
+  ...zeroSlackCommandsRoutes,
+  ...zeroSlackEventsRoutes,
+  ...zeroSlackInteractiveRoutes,
   ...zeroIntegrationsAgentPhoneRoutes,
   ...zeroIntegrationsChatMessageRoutes,
   ...zeroIntegrationsSlackRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-slack-webhooks.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-slack-webhooks.ts
@@ -8,11 +8,13 @@ import {
 import { agentRunQueue } from "@vm0/db/schema/agent-run-queue";
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { agentSessions } from "@vm0/db/schema/agent-session";
+import { conversations } from "@vm0/db/schema/conversation";
 import { orgMembersMetadata } from "@vm0/db/schema/org-members-metadata";
 import { orgMetadata } from "@vm0/db/schema/org-metadata";
 import { runnerJobQueue } from "@vm0/db/schema/runner-job-queue";
 import { slackOrgConnections } from "@vm0/db/schema/slack-org-connection";
 import { slackOrgInstallations } from "@vm0/db/schema/slack-org-installation";
+import { slackOrgThreadSessions } from "@vm0/db/schema/slack-org-thread-session";
 import { slackUserAgentPreferences } from "@vm0/db/schema/slack-user-agent-preference";
 import { userCache } from "@vm0/db/schema/user-cache";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
@@ -20,6 +22,7 @@ import { zeroRuns } from "@vm0/db/schema/zero-run";
 import { and, eq, inArray } from "drizzle-orm";
 
 import { writeDb$, type Db } from "../../../external/db";
+import { nowDate } from "../../../external/time";
 import { encryptSecretForTests } from "./encrypt-secret";
 
 export interface SlackWebhookFixture {
@@ -239,6 +242,133 @@ export const findUserSelectedModel$ = command(
       .limit(1);
     signal.throwIfAborted();
     return row?.selectedModel;
+  },
+);
+
+export const setSlackWebhookUserSelectedModel$ = command(
+  async (
+    { set },
+    args: {
+      readonly orgId: string;
+      readonly userId: string;
+      readonly selectedModel: string | null;
+    },
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const db = set(writeDb$);
+    await db
+      .update(orgMembersMetadata)
+      .set({ selectedModel: args.selectedModel })
+      .where(
+        and(
+          eq(orgMembersMetadata.orgId, args.orgId),
+          eq(orgMembersMetadata.userId, args.userId),
+        ),
+      );
+    signal.throwIfAborted();
+  },
+);
+
+export const seedSlackThreadSession$ = command(
+  async (
+    { set },
+    args: {
+      readonly fixture: SlackWebhookFixture;
+      readonly channelId: string;
+      readonly threadTs: string;
+      readonly selectedModel: string;
+    },
+    signal: AbortSignal,
+  ): Promise<string> => {
+    const db = set(writeDb$);
+    if (!args.fixture.defaultAgentId) {
+      throw new Error("fixture default agent is required");
+    }
+
+    const [connection] = await db
+      .select({ id: slackOrgConnections.id })
+      .from(slackOrgConnections)
+      .where(
+        and(
+          eq(
+            slackOrgConnections.slackWorkspaceId,
+            args.fixture.slackWorkspaceId,
+          ),
+          eq(slackOrgConnections.slackUserId, args.fixture.slackUserId),
+        ),
+      )
+      .limit(1);
+    signal.throwIfAborted();
+    if (!connection) {
+      throw new Error("fixture Slack connection is required");
+    }
+
+    const [session] = await db
+      .insert(agentSessions)
+      .values({
+        userId: args.fixture.userId,
+        orgId: args.fixture.orgId,
+        agentComposeId: args.fixture.defaultAgentId,
+      })
+      .returning({ id: agentSessions.id });
+    signal.throwIfAborted();
+    if (!session) {
+      throw new Error("Slack session insert returned no row");
+    }
+
+    const [run] = await db
+      .insert(agentRuns)
+      .values({
+        userId: args.fixture.userId,
+        orgId: args.fixture.orgId,
+        sessionId: session.id,
+        status: "completed",
+        prompt: "previous Slack session",
+        completedAt: nowDate(),
+      })
+      .returning({ id: agentRuns.id });
+    signal.throwIfAborted();
+    if (!run) {
+      throw new Error("Slack run insert returned no row");
+    }
+
+    await db.insert(zeroRuns).values({
+      id: run.id,
+      triggerSource: "slack",
+      modelProvider: "vm0",
+      selectedModel: args.selectedModel,
+    });
+    signal.throwIfAborted();
+
+    const [conversation] = await db
+      .insert(conversations)
+      .values({
+        runId: run.id,
+        cliAgentType: "claude-code",
+        cliAgentSessionId: `slack-test-${randomUUID()}`,
+        cliAgentSessionHistory: "[]",
+      })
+      .returning({ id: conversations.id });
+    signal.throwIfAborted();
+    if (!conversation) {
+      throw new Error("Slack conversation insert returned no row");
+    }
+
+    await db
+      .update(agentSessions)
+      .set({ conversationId: conversation.id })
+      .where(eq(agentSessions.id, session.id));
+    signal.throwIfAborted();
+
+    await db.insert(slackOrgThreadSessions).values({
+      connectionId: connection.id,
+      slackChannelId: args.channelId,
+      slackThreadTs: args.threadTs,
+      agentSessionId: session.id,
+    });
+    signal.throwIfAborted();
+
+    return session.id;
   },
 );
 

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-slack-webhooks.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-slack-webhooks.ts
@@ -1,0 +1,338 @@
+import { randomUUID } from "node:crypto";
+
+import { command } from "ccstate";
+import {
+  agentComposes,
+  agentComposeVersions,
+} from "@vm0/db/schema/agent-compose";
+import { agentRunQueue } from "@vm0/db/schema/agent-run-queue";
+import { agentRuns } from "@vm0/db/schema/agent-run";
+import { agentSessions } from "@vm0/db/schema/agent-session";
+import { orgMembersMetadata } from "@vm0/db/schema/org-members-metadata";
+import { orgMetadata } from "@vm0/db/schema/org-metadata";
+import { runnerJobQueue } from "@vm0/db/schema/runner-job-queue";
+import { slackOrgConnections } from "@vm0/db/schema/slack-org-connection";
+import { slackOrgInstallations } from "@vm0/db/schema/slack-org-installation";
+import { slackUserAgentPreferences } from "@vm0/db/schema/slack-user-agent-preference";
+import { userCache } from "@vm0/db/schema/user-cache";
+import { zeroAgents } from "@vm0/db/schema/zero-agent";
+import { zeroRuns } from "@vm0/db/schema/zero-run";
+import { and, eq, inArray } from "drizzle-orm";
+
+import { writeDb$, type Db } from "../../../external/db";
+import { encryptSecretForTests } from "./encrypt-secret";
+
+export interface SlackWebhookFixture {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly slackWorkspaceId: string;
+  readonly slackUserId: string;
+  readonly defaultAgentId: string | null;
+  readonly switchAgentId: string | null;
+}
+
+interface SeedSlackWebhookFixtureArgs {
+  readonly withConnection?: boolean;
+  readonly withDefaultAgent?: boolean;
+  readonly withSwitchAgent?: boolean;
+  readonly orgId?: string;
+  readonly userId?: string;
+  readonly slackWorkspaceId?: string;
+  readonly slackUserId?: string;
+  readonly installationOrgId?: string | null;
+}
+
+async function seedRunnableAgent(args: {
+  readonly db: Db;
+  readonly orgId: string;
+  readonly userId: string;
+  readonly namePrefix: string;
+}): Promise<string> {
+  const name = `${args.namePrefix}-${randomUUID().slice(0, 8)}`;
+  const [compose] = await args.db
+    .insert(agentComposes)
+    .values({
+      userId: args.userId,
+      orgId: args.orgId,
+      name,
+    })
+    .returning({ id: agentComposes.id });
+  if (!compose) {
+    throw new Error("seedRunnableAgent insert returned no compose");
+  }
+
+  const versionId = randomUUID();
+  await args.db.insert(agentComposeVersions).values({
+    id: versionId,
+    composeId: compose.id,
+    createdBy: args.userId,
+    content: {
+      version: "1.0",
+      agents: {
+        [name]: {
+          framework: "claude-code",
+          environment: { ANTHROPIC_API_KEY: "test-key" },
+        },
+      },
+    },
+  });
+  await args.db
+    .update(agentComposes)
+    .set({ headVersionId: versionId })
+    .where(eq(agentComposes.id, compose.id));
+
+  await args.db.insert(zeroAgents).values({
+    id: compose.id,
+    orgId: args.orgId,
+    owner: args.userId,
+    name,
+    displayName: name,
+    visibility: "public",
+    customSkills: [],
+  });
+
+  return compose.id;
+}
+
+export const seedSlackWebhookFixture$ = command(
+  async (
+    { set },
+    args: SeedSlackWebhookFixtureArgs,
+    signal: AbortSignal,
+  ): Promise<SlackWebhookFixture> => {
+    const db = set(writeDb$);
+    const orgId = args.orgId ?? `org_${randomUUID()}`;
+    const userId = args.userId ?? `user_${randomUUID()}`;
+    const slackWorkspaceId =
+      args.slackWorkspaceId ??
+      `T_${randomUUID().replace(/-/g, "").slice(0, 10)}`;
+    const slackUserId =
+      args.slackUserId ?? `U_USER_${randomUUID().slice(0, 8)}`;
+    const installationOrgId =
+      args.installationOrgId === undefined ? orgId : args.installationOrgId;
+
+    await db.insert(userCache).values({
+      userId,
+      email: `${userId}@example.com`,
+      name: "Slack Test User",
+    });
+    signal.throwIfAborted();
+
+    const defaultAgentId = args.withDefaultAgent
+      ? await seedRunnableAgent({
+          db,
+          orgId,
+          userId,
+          namePrefix: "default-agent",
+        })
+      : null;
+    signal.throwIfAborted();
+
+    const switchAgentId = args.withSwitchAgent
+      ? await seedRunnableAgent({
+          db,
+          orgId,
+          userId,
+          namePrefix: "switch-agent",
+        })
+      : null;
+    signal.throwIfAborted();
+
+    await db.insert(orgMetadata).values({
+      orgId,
+      defaultAgentId,
+      credits: 100_000,
+    });
+    signal.throwIfAborted();
+    await db.insert(orgMembersMetadata).values({
+      orgId,
+      userId,
+      timezone: "UTC",
+    });
+    signal.throwIfAborted();
+
+    await db.insert(slackOrgInstallations).values({
+      slackWorkspaceId,
+      slackWorkspaceName: "Test Workspace",
+      orgId: installationOrgId,
+      encryptedBotToken: encryptSecretForTests("xoxb-test-bot-token"),
+      botUserId: "U_BOT_TEST",
+    });
+    signal.throwIfAborted();
+
+    if (args.withConnection) {
+      await db.insert(slackOrgConnections).values({
+        slackUserId,
+        slackWorkspaceId,
+        vm0UserId: userId,
+      });
+      signal.throwIfAborted();
+    }
+
+    return {
+      orgId,
+      userId,
+      slackWorkspaceId,
+      slackUserId,
+      defaultAgentId,
+      switchAgentId,
+    };
+  },
+);
+
+export const countSlackWebhookConnections$ = command(
+  async (
+    { set },
+    slackWorkspaceId: string,
+    signal: AbortSignal,
+  ): Promise<number> => {
+    const db = set(writeDb$);
+    const rows = await db
+      .select({ id: slackOrgConnections.id })
+      .from(slackOrgConnections)
+      .where(eq(slackOrgConnections.slackWorkspaceId, slackWorkspaceId));
+    signal.throwIfAborted();
+    return rows.length;
+  },
+);
+
+export const findSlackAgentPreference$ = command(
+  async (
+    { set },
+    args: { readonly orgId: string; readonly userId: string },
+    signal: AbortSignal,
+  ): Promise<string | null | undefined> => {
+    const db = set(writeDb$);
+    const [row] = await db
+      .select({
+        selectedComposeId: slackUserAgentPreferences.selectedComposeId,
+      })
+      .from(slackUserAgentPreferences)
+      .where(
+        and(
+          eq(slackUserAgentPreferences.orgId, args.orgId),
+          eq(slackUserAgentPreferences.vm0UserId, args.userId),
+        ),
+      )
+      .limit(1);
+    signal.throwIfAborted();
+    return row?.selectedComposeId;
+  },
+);
+
+export const findUserSelectedModel$ = command(
+  async (
+    { set },
+    args: { readonly orgId: string; readonly userId: string },
+    signal: AbortSignal,
+  ): Promise<string | null | undefined> => {
+    const db = set(writeDb$);
+    const [row] = await db
+      .select({ selectedModel: orgMembersMetadata.selectedModel })
+      .from(orgMembersMetadata)
+      .where(
+        and(
+          eq(orgMembersMetadata.orgId, args.orgId),
+          eq(orgMembersMetadata.userId, args.userId),
+        ),
+      )
+      .limit(1);
+    signal.throwIfAborted();
+    return row?.selectedModel;
+  },
+);
+
+export const deleteSlackWebhookFixture$ = command(
+  async (
+    { set },
+    fixture: SlackWebhookFixture,
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const db = set(writeDb$);
+    const runRows = await db
+      .select({ id: agentRuns.id })
+      .from(agentRuns)
+      .where(
+        and(
+          eq(agentRuns.orgId, fixture.orgId),
+          eq(agentRuns.userId, fixture.userId),
+        ),
+      );
+    signal.throwIfAborted();
+
+    const runIds = runRows.map((row) => {
+      return row.id;
+    });
+    if (runIds.length > 0) {
+      await db
+        .delete(runnerJobQueue)
+        .where(inArray(runnerJobQueue.runId, runIds));
+      signal.throwIfAborted();
+      await db
+        .delete(agentRunQueue)
+        .where(inArray(agentRunQueue.runId, runIds));
+      signal.throwIfAborted();
+      await db.delete(zeroRuns).where(inArray(zeroRuns.id, runIds));
+      signal.throwIfAborted();
+      await db.delete(agentRuns).where(inArray(agentRuns.id, runIds));
+      signal.throwIfAborted();
+    }
+
+    await db
+      .delete(slackUserAgentPreferences)
+      .where(eq(slackUserAgentPreferences.orgId, fixture.orgId));
+    signal.throwIfAborted();
+    await db
+      .delete(slackOrgConnections)
+      .where(
+        eq(slackOrgConnections.slackWorkspaceId, fixture.slackWorkspaceId),
+      );
+    signal.throwIfAborted();
+    await db
+      .delete(slackOrgInstallations)
+      .where(
+        eq(slackOrgInstallations.slackWorkspaceId, fixture.slackWorkspaceId),
+      );
+    signal.throwIfAborted();
+
+    await db
+      .delete(agentSessions)
+      .where(
+        and(
+          eq(agentSessions.orgId, fixture.orgId),
+          eq(agentSessions.userId, fixture.userId),
+        ),
+      );
+    signal.throwIfAborted();
+    await db.delete(orgMetadata).where(eq(orgMetadata.orgId, fixture.orgId));
+    signal.throwIfAborted();
+    await db
+      .delete(orgMembersMetadata)
+      .where(eq(orgMembersMetadata.orgId, fixture.orgId));
+    signal.throwIfAborted();
+
+    const composeRows = await db
+      .select({ id: agentComposes.id })
+      .from(agentComposes)
+      .where(eq(agentComposes.orgId, fixture.orgId));
+    signal.throwIfAborted();
+    const composeIds = composeRows.map((row) => {
+      return row.id;
+    });
+    if (composeIds.length > 0) {
+      await db
+        .delete(agentComposeVersions)
+        .where(inArray(agentComposeVersions.composeId, composeIds));
+      signal.throwIfAborted();
+      await db.delete(zeroAgents).where(inArray(zeroAgents.id, composeIds));
+      signal.throwIfAborted();
+      await db
+        .delete(agentComposes)
+        .where(inArray(agentComposes.id, composeIds));
+      signal.throwIfAborted();
+    }
+
+    await db.delete(userCache).where(eq(userCache.userId, fixture.userId));
+    signal.throwIfAborted();
+  },
+);

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-slack-commands.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-slack-commands.test.ts
@@ -1,0 +1,273 @@
+import { createHmac } from "node:crypto";
+
+import { createStore } from "ccstate";
+
+import { createApp } from "../../../app-factory";
+import { testContext } from "../../../__tests__/test-helpers";
+import { mockEnv, mockOptionalEnv } from "../../../lib/env";
+import { now } from "../../external/time";
+import { clearAllDetached } from "../../utils";
+import { createFixtureTracker } from "./helpers/zero-route-test";
+import {
+  countSlackWebhookConnections$,
+  deleteSlackWebhookFixture$,
+  seedSlackWebhookFixture$,
+  type SlackWebhookFixture,
+} from "./helpers/zero-slack-webhooks";
+
+const context = testContext();
+const store = createStore();
+const SIGNING_SECRET = "test-slack-signing-secret";
+const COMMAND_PATH = "/api/zero/slack/commands";
+
+function configureSlackWebhookTest(): void {
+  mockOptionalEnv("SLACK_SIGNING_SECRET", SIGNING_SECRET);
+  mockOptionalEnv("RUNNER_DEFAULT_GROUP", "vm0/test");
+  mockEnv("VM0_WEB_URL", "https://app.vm0.test");
+  mockEnv("VM0_API_URL", "https://api.vm0.test");
+  context.mocks.slack.chat.postMessage.mockResolvedValue({
+    ok: true,
+    ts: "1710000000.000000",
+    channel: "C-test",
+  });
+  context.mocks.slack.chat.postEphemeral.mockResolvedValue({
+    ok: true,
+    message_ts: "1710000000.000001",
+  });
+  context.mocks.slack.views.publish.mockResolvedValue({ ok: true });
+  context.mocks.slack.views.open.mockResolvedValue({
+    ok: true,
+    view: { id: "V-test" },
+  });
+}
+
+function buildCommandBody(
+  overrides: Partial<{
+    readonly teamId: string;
+    readonly userId: string;
+    readonly channelId: string;
+    readonly text: string;
+    readonly triggerId: string;
+  }> = {},
+): string {
+  return new URLSearchParams({
+    token: "test-token",
+    team_id: overrides.teamId ?? "T-test",
+    team_domain: "test-workspace",
+    channel_id: overrides.channelId ?? "C-test",
+    channel_name: "general",
+    user_id: overrides.userId ?? "U-test",
+    user_name: "testuser",
+    command: "/zero",
+    text: overrides.text ?? "",
+    response_url: "https://hooks.slack.com/commands/T-test/response",
+    trigger_id: overrides.triggerId ?? "trigger-123",
+    api_app_id: "A-test",
+  }).toString();
+}
+
+function signedHeaders(body: string): Record<string, string> {
+  const timestamp = Math.floor(now() / 1000).toString();
+  const signature = `v0=${createHmac("sha256", SIGNING_SECRET)
+    .update(`v0:${timestamp}:${body}`)
+    .digest("hex")}`;
+  return {
+    "content-type": "application/x-www-form-urlencoded",
+    "x-slack-request-timestamp": timestamp,
+    "x-slack-signature": signature,
+  };
+}
+
+async function postCommand(
+  body: string,
+  headers: Record<string, string> = signedHeaders(body),
+): Promise<{ readonly status: number; readonly body: unknown }> {
+  const response = await createApp({ signal: context.signal }).request(
+    COMMAND_PATH,
+    {
+      method: "POST",
+      headers,
+      body,
+    },
+  );
+  const contentType = response.headers.get("content-type") ?? "";
+  return {
+    status: response.status,
+    body: contentType.includes("application/json")
+      ? await response.json()
+      : await response.text(),
+  };
+}
+
+describe("POST /api/zero/slack/commands", () => {
+  const track = createFixtureTracker<SlackWebhookFixture>((fixture) => {
+    return store.set(deleteSlackWebhookFixture$, fixture, context.signal);
+  });
+
+  beforeEach(() => {
+    configureSlackWebhookTest();
+  });
+
+  it("returns 503 when Slack signing is not configured", async () => {
+    mockOptionalEnv("SLACK_SIGNING_SECRET", undefined);
+
+    const response = await postCommand(buildCommandBody({ text: "help" }), {
+      "content-type": "application/x-www-form-urlencoded",
+    });
+
+    expect(response.status).toBe(503);
+    expect(response.body).toStrictEqual({
+      error: "Slack integration is not configured",
+    });
+  });
+
+  it("rejects missing and invalid Slack signatures", async () => {
+    const body = buildCommandBody({ text: "help" });
+
+    const missing = await postCommand(body, {
+      "content-type": "application/x-www-form-urlencoded",
+    });
+    expect(missing.status).toBe(401);
+    expect(missing.body).toStrictEqual({
+      error: "Missing Slack signature headers",
+    });
+
+    const invalid = await postCommand(body, {
+      "content-type": "application/x-www-form-urlencoded",
+      "x-slack-request-timestamp": Math.floor(now() / 1000).toString(),
+      "x-slack-signature": "v0=invalid",
+    });
+    expect(invalid.status).toBe(401);
+    expect(invalid.body).toStrictEqual({ error: "Invalid signature" });
+  });
+
+  it("returns help for empty, help, and unknown commands", async () => {
+    const fixture = await track(
+      store.set(
+        seedSlackWebhookFixture$,
+        { withConnection: true, withDefaultAgent: true },
+        context.signal,
+      ),
+    );
+
+    for (const text of ["", "help", "unknown"]) {
+      const response = await postCommand(
+        buildCommandBody({
+          teamId: fixture.slackWorkspaceId,
+          userId: fixture.slackUserId,
+          text,
+        }),
+      );
+
+      expect(response.status).toBe(200);
+      expect(response.body).toMatchObject({ response_type: "ephemeral" });
+      expect(JSON.stringify(response.body)).toContain("Zero Slack Bot Help");
+    }
+  });
+
+  it("handles connect states", async () => {
+    const notInstalled = await postCommand(
+      buildCommandBody({ teamId: "T-not-installed", text: "connect" }),
+    );
+    expect(notInstalled.status).toBe(200);
+    expect(JSON.stringify(notInstalled.body)).toContain("hasn't been set up");
+
+    const fixture = await track(
+      store.set(
+        seedSlackWebhookFixture$,
+        { withConnection: false },
+        context.signal,
+      ),
+    );
+    const login = await postCommand(
+      buildCommandBody({
+        teamId: fixture.slackWorkspaceId,
+        userId: fixture.slackUserId,
+        text: "connect",
+      }),
+    );
+    expect(login.status).toBe(200);
+    expect(JSON.stringify(login.body)).toContain("Connect");
+
+    const connected = await track(
+      store.set(
+        seedSlackWebhookFixture$,
+        { withConnection: true },
+        context.signal,
+      ),
+    );
+    const alreadyConnected = await postCommand(
+      buildCommandBody({
+        teamId: connected.slackWorkspaceId,
+        userId: connected.slackUserId,
+        text: "connect",
+      }),
+    );
+    expect(alreadyConnected.status).toBe(200);
+    expect(JSON.stringify(alreadyConnected.body)).toContain(
+      "already connected",
+    );
+  });
+
+  it("disconnects the Slack user and refreshes App Home", async () => {
+    const fixture = await track(
+      store.set(
+        seedSlackWebhookFixture$,
+        { withConnection: true, withDefaultAgent: true },
+        context.signal,
+      ),
+    );
+
+    const response = await postCommand(
+      buildCommandBody({
+        teamId: fixture.slackWorkspaceId,
+        userId: fixture.slackUserId,
+        text: "disconnect",
+      }),
+    );
+    await clearAllDetached();
+
+    expect(response.status).toBe(200);
+    await expect(
+      store.set(
+        countSlackWebhookConnections$,
+        fixture.slackWorkspaceId,
+        context.signal,
+      ),
+    ).resolves.toBe(0);
+    expect(context.mocks.slack.views.publish).toHaveBeenCalledOnce();
+  });
+
+  it("opens switch and model modals for connected users", async () => {
+    const fixture = await track(
+      store.set(
+        seedSlackWebhookFixture$,
+        {
+          withConnection: true,
+          withDefaultAgent: true,
+          withSwitchAgent: true,
+        },
+        context.signal,
+      ),
+    );
+
+    const switchResponse = await postCommand(
+      buildCommandBody({
+        teamId: fixture.slackWorkspaceId,
+        userId: fixture.slackUserId,
+        text: "switch",
+      }),
+    );
+    const modelResponse = await postCommand(
+      buildCommandBody({
+        teamId: fixture.slackWorkspaceId,
+        userId: fixture.slackUserId,
+        text: "model",
+      }),
+    );
+
+    expect(switchResponse.status).toBe(200);
+    expect(modelResponse.status).toBe(200);
+    expect(context.mocks.slack.views.open).toHaveBeenCalledTimes(2);
+  });
+});

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-slack-commands.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-slack-commands.test.ts
@@ -1,4 +1,4 @@
-import { createHmac } from "node:crypto";
+import { createHmac, randomBytes } from "node:crypto";
 
 import { createStore } from "ccstate";
 
@@ -17,7 +17,7 @@ import {
 
 const context = testContext();
 const store = createStore();
-const SIGNING_SECRET = "test-slack-signing-secret";
+const SIGNING_SECRET = randomBytes(32).toString("hex");
 const COMMAND_PATH = "/api/zero/slack/commands";
 
 function configureSlackWebhookTest(): void {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-slack-events.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-slack-events.test.ts
@@ -1,0 +1,348 @@
+import { createHmac } from "node:crypto";
+
+import { createStore } from "ccstate";
+import { agentRuns } from "@vm0/db/schema/agent-run";
+import { zeroRuns } from "@vm0/db/schema/zero-run";
+import { eq } from "drizzle-orm";
+
+import { createApp } from "../../../app-factory";
+import { testContext } from "../../../__tests__/test-helpers";
+import { mockEnv, mockOptionalEnv } from "../../../lib/env";
+import { writeDb$ } from "../../external/db";
+import { now } from "../../external/time";
+import { clearAllDetached } from "../../utils";
+import { createFixtureTracker } from "./helpers/zero-route-test";
+import {
+  countSlackWebhookConnections$,
+  deleteSlackWebhookFixture$,
+  seedSlackWebhookFixture$,
+  type SlackWebhookFixture,
+} from "./helpers/zero-slack-webhooks";
+
+const context = testContext();
+const store = createStore();
+const SIGNING_SECRET = "test-slack-signing-secret";
+const EVENTS_PATH = "/api/zero/slack/events";
+
+function configureSlackWebhookTest(): void {
+  mockOptionalEnv("SLACK_SIGNING_SECRET", SIGNING_SECRET);
+  mockOptionalEnv("RUNNER_DEFAULT_GROUP", "vm0/test");
+  mockEnv("VM0_WEB_URL", "https://app.vm0.test");
+  mockEnv("VM0_API_URL", "https://api.vm0.test");
+  context.mocks.s3.send.mockResolvedValue({});
+  context.mocks.slack.assistant.threads.setStatus.mockResolvedValue({
+    ok: true,
+  });
+  context.mocks.slack.chat.postMessage.mockResolvedValue({
+    ok: true,
+    ts: "1710000000.000000",
+    channel: "C-test",
+  });
+  context.mocks.slack.chat.postEphemeral.mockResolvedValue({
+    ok: true,
+    message_ts: "1710000000.000001",
+  });
+  context.mocks.slack.conversations.history.mockResolvedValue({
+    ok: true,
+    messages: [],
+  });
+  context.mocks.slack.conversations.replies.mockResolvedValue({
+    ok: true,
+    messages: [],
+  });
+  context.mocks.slack.users.info.mockResolvedValue({
+    ok: true,
+    user: {
+      profile: {
+        display_name: "Slack User",
+        email: "slack@example.com",
+      },
+      tz: "UTC",
+    },
+  });
+  context.mocks.slack.views.publish.mockResolvedValue({ ok: true });
+}
+
+function signedHeaders(body: string): Record<string, string> {
+  const timestamp = Math.floor(now() / 1000).toString();
+  const signature = `v0=${createHmac("sha256", SIGNING_SECRET)
+    .update(`v0:${timestamp}:${body}`)
+    .digest("hex")}`;
+  return {
+    "content-type": "application/json",
+    "x-slack-request-timestamp": timestamp,
+    "x-slack-signature": signature,
+  };
+}
+
+async function postEvent(
+  payload: Record<string, unknown>,
+  extraHeaders: Record<string, string> = {},
+): Promise<{ readonly status: number; readonly body: unknown }> {
+  const body = JSON.stringify(payload);
+  const response = await createApp({ signal: context.signal }).request(
+    EVENTS_PATH,
+    {
+      method: "POST",
+      headers: { ...signedHeaders(body), ...extraHeaders },
+      body,
+    },
+  );
+  const contentType = response.headers.get("content-type") ?? "";
+  return {
+    status: response.status,
+    body: contentType.includes("application/json")
+      ? await response.json()
+      : await response.text(),
+  };
+}
+
+async function postRawEvent(
+  body: string,
+  headers: Record<string, string>,
+): Promise<{ readonly status: number; readonly body: unknown }> {
+  const response = await createApp({ signal: context.signal }).request(
+    EVENTS_PATH,
+    {
+      method: "POST",
+      headers,
+      body,
+    },
+  );
+  return {
+    status: response.status,
+    body: await response.json(),
+  };
+}
+
+describe("POST /api/zero/slack/events", () => {
+  const track = createFixtureTracker<SlackWebhookFixture>((fixture) => {
+    return store.set(deleteSlackWebhookFixture$, fixture, context.signal);
+  });
+
+  beforeEach(() => {
+    configureSlackWebhookTest();
+  });
+
+  it("returns the Slack url_verification challenge", async () => {
+    const response = await postEvent({
+      type: "url_verification",
+      challenge: "challenge-123",
+      token: "test-token",
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toStrictEqual({ challenge: "challenge-123" });
+  });
+
+  it("rejects missing and invalid Slack signatures", async () => {
+    const body = JSON.stringify({ type: "event_callback" });
+    const missing = await postRawEvent(body, {
+      "content-type": "application/json",
+    });
+    expect(missing.status).toBe(401);
+    expect(missing.body).toStrictEqual({
+      error: "Missing Slack signature headers",
+    });
+
+    const invalid = await postRawEvent(body, {
+      "content-type": "application/json",
+      "x-slack-request-timestamp": Math.floor(now() / 1000).toString(),
+      "x-slack-signature": "v0=invalid",
+    });
+    expect(invalid.status).toBe(401);
+    expect(invalid.body).toStrictEqual({ error: "Invalid signature" });
+  });
+
+  it("suppresses Slack retries before scheduling side effects", async () => {
+    const fixture = await track(
+      store.set(
+        seedSlackWebhookFixture$,
+        { withConnection: true, withDefaultAgent: true },
+        context.signal,
+      ),
+    );
+
+    const response = await postEvent(
+      {
+        type: "event_callback",
+        team_id: fixture.slackWorkspaceId,
+        event: {
+          type: "app_mention",
+          user: fixture.slackUserId,
+          text: "hello",
+          ts: "1710000000.000000",
+          channel: "C-test",
+        },
+      },
+      { "x-slack-retry-num": "1" },
+    );
+    await clearAllDetached();
+
+    expect(response.status).toBe(200);
+    expect(response.body).toBe("OK");
+    expect(context.mocks.slack.chat.postMessage).not.toHaveBeenCalled();
+    expect(
+      context.mocks.slack.assistant.threads.setStatus,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("prompts disconnected users to connect for mentions and DMs", async () => {
+    const mentionFixture = await track(
+      store.set(
+        seedSlackWebhookFixture$,
+        { withConnection: false, withDefaultAgent: true },
+        context.signal,
+      ),
+    );
+    const mention = await postEvent({
+      type: "event_callback",
+      team_id: mentionFixture.slackWorkspaceId,
+      event: {
+        type: "app_mention",
+        user: mentionFixture.slackUserId,
+        text: "hello agent",
+        ts: "1710000000.000000",
+        channel: "C-test",
+      },
+    });
+    await clearAllDetached();
+
+    expect(mention.status).toBe(200);
+    expect(context.mocks.slack.chat.postEphemeral).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "C-test",
+        user: mentionFixture.slackUserId,
+      }),
+    );
+
+    const dmFixture = await track(
+      store.set(
+        seedSlackWebhookFixture$,
+        { withConnection: false, withDefaultAgent: true },
+        context.signal,
+      ),
+    );
+    const dm = await postEvent({
+      type: "event_callback",
+      team_id: dmFixture.slackWorkspaceId,
+      event: {
+        type: "message",
+        channel_type: "im",
+        user: dmFixture.slackUserId,
+        text: "hello in dm",
+        ts: "1710000001.000000",
+        channel: "D-test",
+      },
+    });
+    await clearAllDetached();
+
+    expect(dm.status).toBe(200);
+    expect(context.mocks.slack.chat.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "D-test",
+        text: "Please connect your account first",
+      }),
+    );
+  });
+
+  it("refreshes App Home, sends Messages tab welcome once, and cleans up uninstall events", async () => {
+    const fixture = await track(
+      store.set(
+        seedSlackWebhookFixture$,
+        { withConnection: true, withDefaultAgent: true },
+        context.signal,
+      ),
+    );
+
+    await postEvent({
+      type: "event_callback",
+      team_id: fixture.slackWorkspaceId,
+      event: {
+        type: "app_home_opened",
+        user: fixture.slackUserId,
+        tab: "home",
+        channel: "D-home",
+      },
+    });
+    await clearAllDetached();
+    expect(context.mocks.slack.views.publish).toHaveBeenCalledOnce();
+
+    await postEvent({
+      type: "event_callback",
+      team_id: fixture.slackWorkspaceId,
+      event: {
+        type: "app_home_opened",
+        user: fixture.slackUserId,
+        tab: "messages",
+        channel: "D-home",
+      },
+    });
+    await clearAllDetached();
+    expect(context.mocks.slack.chat.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ channel: "D-home" }),
+    );
+
+    await postEvent({
+      type: "event_callback",
+      team_id: fixture.slackWorkspaceId,
+      event: { type: "app_uninstalled" },
+    });
+    await clearAllDetached();
+    await expect(
+      store.set(
+        countSlackWebhookConnections$,
+        fixture.slackWorkspaceId,
+        context.signal,
+      ),
+    ).resolves.toBe(0);
+  });
+
+  it("creates a Slack-triggered zero run for connected app mentions", async () => {
+    const fixture = await track(
+      store.set(
+        seedSlackWebhookFixture$,
+        { withConnection: true, withDefaultAgent: true },
+        context.signal,
+      ),
+    );
+    expect(fixture.defaultAgentId).toBeTruthy();
+
+    const response = await postEvent({
+      type: "event_callback",
+      team_id: fixture.slackWorkspaceId,
+      event: {
+        type: "app_mention",
+        user: fixture.slackUserId,
+        text: "summarize this thread",
+        ts: "1710000000.000000",
+        channel: "C-test",
+      },
+    });
+    await clearAllDetached();
+
+    expect(response.status).toBe(200);
+    const db = store.set(writeDb$);
+    const [run] = await db
+      .select({
+        id: agentRuns.id,
+        prompt: agentRuns.prompt,
+        appendSystemPrompt: agentRuns.appendSystemPrompt,
+      })
+      .from(agentRuns)
+      .where(eq(agentRuns.userId, fixture.userId))
+      .limit(1);
+    expect(run?.prompt).toBe("summarize this thread");
+    expect(run?.appendSystemPrompt).toContain(
+      "You are currently running inside: Slack",
+    );
+    expect(run?.appendSystemPrompt).toContain("Slack display name: Slack User");
+
+    const [zeroRun] = await db
+      .select({ triggerSource: zeroRuns.triggerSource })
+      .from(zeroRuns)
+      .where(eq(zeroRuns.id, run?.id ?? "00000000-0000-0000-0000-000000000000"))
+      .limit(1);
+    expect(zeroRun?.triggerSource).toBe("slack");
+  });
+});

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-slack-events.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-slack-events.test.ts
@@ -1,4 +1,4 @@
-import { createHmac } from "node:crypto";
+import { createHmac, randomBytes } from "node:crypto";
 
 import { createStore } from "ccstate";
 import { agentRuns } from "@vm0/db/schema/agent-run";
@@ -16,12 +16,14 @@ import {
   countSlackWebhookConnections$,
   deleteSlackWebhookFixture$,
   seedSlackWebhookFixture$,
+  seedSlackThreadSession$,
+  setSlackWebhookUserSelectedModel$,
   type SlackWebhookFixture,
 } from "./helpers/zero-slack-webhooks";
 
 const context = testContext();
 const store = createStore();
-const SIGNING_SECRET = "test-slack-signing-secret";
+const SIGNING_SECRET = randomBytes(32).toString("hex");
 const EVENTS_PATH = "/api/zero/slack/events";
 
 function configureSlackWebhookTest(): void {
@@ -63,8 +65,10 @@ function configureSlackWebhookTest(): void {
   context.mocks.slack.views.publish.mockResolvedValue({ ok: true });
 }
 
-function signedHeaders(body: string): Record<string, string> {
-  const timestamp = Math.floor(now() / 1000).toString();
+function signedHeaders(
+  body: string,
+  timestamp = Math.floor(now() / 1000).toString(),
+): Record<string, string> {
   const signature = `v0=${createHmac("sha256", SIGNING_SECRET)
     .update(`v0:${timestamp}:${body}`)
     .digest("hex")}`;
@@ -152,6 +156,11 @@ describe("POST /api/zero/slack/events", () => {
     });
     expect(invalid.status).toBe(401);
     expect(invalid.body).toStrictEqual({ error: "Invalid signature" });
+
+    const staleTimestamp = (Math.floor(now() / 1000) - 301).toString();
+    const stale = await postRawEvent(body, signedHeaders(body, staleTimestamp));
+    expect(stale.status).toBe(401);
+    expect(stale.body).toStrictEqual({ error: "Invalid signature" });
   });
 
   it("suppresses Slack retries before scheduling side effects", async () => {
@@ -344,5 +353,68 @@ describe("POST /api/zero/slack/events", () => {
       .where(eq(zeroRuns.id, run?.id ?? "00000000-0000-0000-0000-000000000000"))
       .limit(1);
     expect(zeroRun?.triggerSource).toBe("slack");
+  });
+
+  it("starts a new Slack session when the selected model changed", async () => {
+    const fixture = await track(
+      store.set(
+        seedSlackWebhookFixture$,
+        { withConnection: true, withDefaultAgent: true },
+        context.signal,
+      ),
+    );
+    expect(fixture.defaultAgentId).toBeTruthy();
+
+    const channelId = "D-model";
+    const threadTs = "2400.001";
+    const previousSessionId = await store.set(
+      seedSlackThreadSession$,
+      {
+        fixture,
+        channelId,
+        threadTs,
+        selectedModel: "claude-sonnet-4-6",
+      },
+      context.signal,
+    );
+    await store.set(
+      setSlackWebhookUserSelectedModel$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        selectedModel: "claude-opus-4-7",
+      },
+      context.signal,
+    );
+
+    const prompt = "model changed in Slack thread";
+    const response = await postEvent({
+      type: "event_callback",
+      team_id: fixture.slackWorkspaceId,
+      event: {
+        type: "message",
+        channel_type: "im",
+        user: fixture.slackUserId,
+        text: prompt,
+        ts: "2400.002",
+        thread_ts: threadTs,
+        channel: channelId,
+      },
+    });
+    await clearAllDetached();
+
+    expect(response.status).toBe(200);
+    const db = store.set(writeDb$);
+    const [run] = await db
+      .select({
+        id: agentRuns.id,
+        sessionId: agentRuns.sessionId,
+        continuedFromSessionId: agentRuns.continuedFromSessionId,
+      })
+      .from(agentRuns)
+      .where(eq(agentRuns.prompt, prompt))
+      .limit(1);
+    expect(run?.continuedFromSessionId).toBeNull();
+    expect(run?.sessionId).not.toBe(previousSessionId);
   });
 });

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-slack-interactive.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-slack-interactive.test.ts
@@ -1,0 +1,324 @@
+import { createHmac } from "node:crypto";
+
+import { createStore } from "ccstate";
+
+import { createApp } from "../../../app-factory";
+import { testContext } from "../../../__tests__/test-helpers";
+import { mockEnv, mockOptionalEnv } from "../../../lib/env";
+import { now } from "../../external/time";
+import { createFixtureTracker } from "./helpers/zero-route-test";
+import {
+  countSlackWebhookConnections$,
+  deleteSlackWebhookFixture$,
+  findSlackAgentPreference$,
+  findUserSelectedModel$,
+  seedSlackWebhookFixture$,
+  type SlackWebhookFixture,
+} from "./helpers/zero-slack-webhooks";
+
+const context = testContext();
+const store = createStore();
+const SIGNING_SECRET = "test-slack-signing-secret";
+const INTERACTIVE_PATH = "/api/zero/slack/interactive";
+
+function configureSlackWebhookTest(): void {
+  mockOptionalEnv("SLACK_SIGNING_SECRET", SIGNING_SECRET);
+  mockOptionalEnv("RUNNER_DEFAULT_GROUP", "vm0/test");
+  mockEnv("VM0_WEB_URL", "https://app.vm0.test");
+  mockEnv("VM0_API_URL", "https://api.vm0.test");
+  context.mocks.slack.chat.postEphemeral.mockResolvedValue({
+    ok: true,
+    message_ts: "1710000000.000001",
+  });
+  context.mocks.slack.views.publish.mockResolvedValue({ ok: true });
+  context.mocks.slack.views.open.mockResolvedValue({
+    ok: true,
+    view: { id: "V-test" },
+  });
+}
+
+function signedHeaders(body: string): Record<string, string> {
+  const timestamp = Math.floor(now() / 1000).toString();
+  const signature = `v0=${createHmac("sha256", SIGNING_SECRET)
+    .update(`v0:${timestamp}:${body}`)
+    .digest("hex")}`;
+  return {
+    "content-type": "application/x-www-form-urlencoded",
+    "x-slack-request-timestamp": timestamp,
+    "x-slack-signature": signature,
+  };
+}
+
+async function postInteractiveBody(
+  body: string,
+  headers: Record<string, string> = signedHeaders(body),
+): Promise<{ readonly status: number; readonly body: unknown }> {
+  const response = await createApp({ signal: context.signal }).request(
+    INTERACTIVE_PATH,
+    {
+      method: "POST",
+      headers,
+      body,
+    },
+  );
+  const contentType = response.headers.get("content-type") ?? "";
+  return {
+    status: response.status,
+    body: contentType.includes("application/json")
+      ? await response.json()
+      : await response.text(),
+  };
+}
+
+function postInteractive(
+  payload: Record<string, unknown>,
+): Promise<{ readonly status: number; readonly body: unknown }> {
+  return postInteractiveBody(
+    new URLSearchParams({ payload: JSON.stringify(payload) }).toString(),
+  );
+}
+
+function agentPickerSubmission(args: {
+  readonly workspaceId: string;
+  readonly slackUserId: string;
+  readonly selectedValue: string;
+  readonly channelId?: string;
+}): Record<string, unknown> {
+  return {
+    type: "view_submission",
+    user: {
+      id: args.slackUserId,
+      username: "testuser",
+      team_id: args.workspaceId,
+    },
+    team: { id: args.workspaceId, domain: "test" },
+    view: {
+      callback_id: "switch_agent_modal",
+      ...(args.channelId && {
+        private_metadata: JSON.stringify({ channelId: args.channelId }),
+      }),
+      state: {
+        values: {
+          agent_select_block: {
+            agent_select: {
+              selected_option: { value: args.selectedValue },
+            },
+          },
+        },
+      },
+    },
+  };
+}
+
+function modelPickerSubmission(args: {
+  readonly workspaceId: string;
+  readonly slackUserId: string;
+  readonly selectedValue: string;
+  readonly channelId?: string;
+}): Record<string, unknown> {
+  return {
+    type: "view_submission",
+    user: {
+      id: args.slackUserId,
+      username: "testuser",
+      team_id: args.workspaceId,
+    },
+    team: { id: args.workspaceId, domain: "test" },
+    view: {
+      callback_id: "model_preference_modal",
+      ...(args.channelId && {
+        private_metadata: JSON.stringify({ channelId: args.channelId }),
+      }),
+      state: {
+        values: {
+          model_select_block: {
+            model_select: {
+              selected_option: { value: args.selectedValue },
+            },
+          },
+        },
+      },
+    },
+  };
+}
+
+describe("POST /api/zero/slack/interactive", () => {
+  const track = createFixtureTracker<SlackWebhookFixture>((fixture) => {
+    return store.set(deleteSlackWebhookFixture$, fixture, context.signal);
+  });
+
+  beforeEach(() => {
+    configureSlackWebhookTest();
+  });
+
+  it("rejects missing Slack signatures and missing payloads", async () => {
+    const body = new URLSearchParams({
+      payload: JSON.stringify({ type: "block_actions" }),
+    }).toString();
+    const missingSignature = await postInteractiveBody(body, {
+      "content-type": "application/x-www-form-urlencoded",
+    });
+    expect(missingSignature.status).toBe(401);
+    expect(missingSignature.body).toStrictEqual({
+      error: "Missing Slack signature headers",
+    });
+
+    const missingPayload = await postInteractiveBody("foo=bar");
+    expect(missingPayload.status).toBe(400);
+    expect(missingPayload.body).toStrictEqual({ error: "Missing payload" });
+  });
+
+  it("returns an empty 200 response for empty block actions", async () => {
+    const response = await postInteractive({
+      type: "block_actions",
+      user: { id: "U-test", username: "testuser", team_id: "T-test" },
+      team: { id: "T-test", domain: "test" },
+      actions: [],
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toBe("");
+  });
+
+  it("disconnects from App Home and refreshes the view", async () => {
+    const fixture = await track(
+      store.set(
+        seedSlackWebhookFixture$,
+        { withConnection: true, withDefaultAgent: true },
+        context.signal,
+      ),
+    );
+
+    const response = await postInteractive({
+      type: "block_actions",
+      user: {
+        id: fixture.slackUserId,
+        username: "testuser",
+        team_id: fixture.slackWorkspaceId,
+      },
+      team: { id: fixture.slackWorkspaceId, domain: "test" },
+      actions: [{ action_id: "home_disconnect", block_id: "home" }],
+    });
+
+    expect(response.status).toBe(200);
+    await expect(
+      store.set(
+        countSlackWebhookConnections$,
+        fixture.slackWorkspaceId,
+        context.signal,
+      ),
+    ).resolves.toBe(0);
+    expect(context.mocks.slack.views.publish).toHaveBeenCalledOnce();
+  });
+
+  it("persists the selected agent and rejects agents from other orgs", async () => {
+    const fixture = await track(
+      store.set(
+        seedSlackWebhookFixture$,
+        {
+          withConnection: true,
+          withDefaultAgent: true,
+          withSwitchAgent: true,
+        },
+        context.signal,
+      ),
+    );
+    expect(fixture.switchAgentId).toBeTruthy();
+
+    const response = await postInteractive(
+      agentPickerSubmission({
+        workspaceId: fixture.slackWorkspaceId,
+        slackUserId: fixture.slackUserId,
+        selectedValue: fixture.switchAgentId ?? "",
+        channelId: "C-test",
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(
+      store.set(
+        findSlackAgentPreference$,
+        { orgId: fixture.orgId, userId: fixture.userId },
+        context.signal,
+      ),
+    ).resolves.toBe(fixture.switchAgentId);
+    expect(context.mocks.slack.chat.postEphemeral).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "C-test",
+        user: fixture.slackUserId,
+      }),
+    );
+
+    const other = await track(
+      store.set(
+        seedSlackWebhookFixture$,
+        { withConnection: true, withDefaultAgent: true },
+        context.signal,
+      ),
+    );
+    expect(other.defaultAgentId).toBeTruthy();
+
+    const rejected = await postInteractive(
+      agentPickerSubmission({
+        workspaceId: fixture.slackWorkspaceId,
+        slackUserId: fixture.slackUserId,
+        selectedValue: other.defaultAgentId ?? "",
+      }),
+    );
+
+    expect(rejected.status).toBe(200);
+    expect(rejected.body).toMatchObject({
+      response_action: "errors",
+      errors: {
+        agent_select_block: "You don't have access to that agent.",
+      },
+    });
+  });
+
+  it("persists the selected model and opens the home switch modal", async () => {
+    const fixture = await track(
+      store.set(
+        seedSlackWebhookFixture$,
+        {
+          withConnection: true,
+          withDefaultAgent: true,
+          withSwitchAgent: true,
+        },
+        context.signal,
+      ),
+    );
+
+    const modelResponse = await postInteractive(
+      modelPickerSubmission({
+        workspaceId: fixture.slackWorkspaceId,
+        slackUserId: fixture.slackUserId,
+        selectedValue: "claude-sonnet-4-6",
+        channelId: "C-test",
+      }),
+    );
+
+    expect(modelResponse.status).toBe(200);
+    await expect(
+      store.set(
+        findUserSelectedModel$,
+        { orgId: fixture.orgId, userId: fixture.userId },
+        context.signal,
+      ),
+    ).resolves.toBe("claude-sonnet-4-6");
+
+    const switchResponse = await postInteractive({
+      type: "block_actions",
+      user: {
+        id: fixture.slackUserId,
+        username: "testuser",
+        team_id: fixture.slackWorkspaceId,
+      },
+      team: { id: fixture.slackWorkspaceId, domain: "test" },
+      trigger_id: "trigger-123",
+      actions: [{ action_id: "home_switch_agent", block_id: "home" }],
+    });
+
+    expect(switchResponse.status).toBe(200);
+    expect(context.mocks.slack.views.open).toHaveBeenCalledOnce();
+  });
+});

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-slack-interactive.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-slack-interactive.test.ts
@@ -1,4 +1,4 @@
-import { createHmac } from "node:crypto";
+import { createHmac, randomBytes } from "node:crypto";
 
 import { createStore } from "ccstate";
 
@@ -18,7 +18,7 @@ import {
 
 const context = testContext();
 const store = createStore();
-const SIGNING_SECRET = "test-slack-signing-secret";
+const SIGNING_SECRET = randomBytes(32).toString("hex");
 const INTERACTIVE_PATH = "/api/zero/slack/interactive";
 
 function configureSlackWebhookTest(): void {

--- a/turbo/apps/api/src/signals/routes/zero-slack-commands.ts
+++ b/turbo/apps/api/src/signals/routes/zero-slack-commands.ts
@@ -1,0 +1,11 @@
+import { zeroSlackCommandsContract } from "@vm0/api-contracts/contracts/zero-slack-commands";
+
+import type { RouteEntry } from "../route";
+import { handleZeroSlackCommands$ } from "../services/zero-slack-webhooks.service";
+
+export const zeroSlackCommandsRoutes: readonly RouteEntry[] = [
+  {
+    route: zeroSlackCommandsContract.post,
+    handler: handleZeroSlackCommands$,
+  },
+];

--- a/turbo/apps/api/src/signals/routes/zero-slack-events.ts
+++ b/turbo/apps/api/src/signals/routes/zero-slack-events.ts
@@ -1,0 +1,11 @@
+import { zeroSlackEventsContract } from "@vm0/api-contracts/contracts/zero-slack-events";
+
+import type { RouteEntry } from "../route";
+import { handleZeroSlackEvents$ } from "../services/zero-slack-webhooks.service";
+
+export const zeroSlackEventsRoutes: readonly RouteEntry[] = [
+  {
+    route: zeroSlackEventsContract.post,
+    handler: handleZeroSlackEvents$,
+  },
+];

--- a/turbo/apps/api/src/signals/routes/zero-slack-interactive.ts
+++ b/turbo/apps/api/src/signals/routes/zero-slack-interactive.ts
@@ -1,0 +1,11 @@
+import { zeroSlackInteractiveContract } from "@vm0/api-contracts/contracts/zero-slack-interactive";
+
+import type { RouteEntry } from "../route";
+import { handleZeroSlackInteractive$ } from "../services/zero-slack-webhooks.service";
+
+export const zeroSlackInteractiveRoutes: readonly RouteEntry[] = [
+  {
+    route: zeroSlackInteractiveContract.post,
+    handler: handleZeroSlackInteractive$,
+  },
+];

--- a/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
@@ -84,6 +84,8 @@ interface UserInfo {
   readonly name: string | null;
   readonly email: string | null;
   readonly timezone: string | null;
+  readonly slackDisplayName?: string;
+  readonly slackUserId?: string;
 }
 
 interface ZeroAgentConfig {
@@ -242,6 +244,12 @@ function buildCurrentUserPrompt(userInfo: UserInfo): string {
     lines.push(`Email: ${userInfo.email}`);
   }
   lines.push(`Timezone: ${userInfo.timezone ?? "UTC"}`);
+  if (userInfo.slackDisplayName) {
+    lines.push(`Slack display name: ${userInfo.slackDisplayName}`);
+  }
+  if (userInfo.slackUserId) {
+    lines.push(`Slack user ID: ${userInfo.slackUserId}`);
+  }
   return lines.join("\n");
 }
 
@@ -455,9 +463,11 @@ function createRunBody(args: {
     triggerSource:
       args.triggerSource ??
       (args.triggerAgentId ? ("agent" as const) : ("web" as const)),
-    appendSystemPrompt: args.appendSystemPrompt
-      ? `${baseAppendSystemPrompt}\n\n${args.appendSystemPrompt}`
-      : baseAppendSystemPrompt,
+    appendSystemPrompt: [baseAppendSystemPrompt, args.appendSystemPrompt]
+      .filter((part): part is string => {
+        return Boolean(part);
+      })
+      .join("\n\n"),
     disallowedTools: [...DISALLOWED_TOOLS],
     vars: { ZERO_AGENT_ID: args.agent.id },
   };
@@ -484,7 +494,12 @@ export const createZeroRun$ = command(
       readonly apiStartTime: number;
       readonly triggerSource?: TriggerSource;
       readonly appendSystemPrompt?: string;
+      readonly userInfoExtras?: Pick<
+        UserInfo,
+        "slackDisplayName" | "slackUserId"
+      >;
       readonly callbacks?: readonly RunCallback[];
+      readonly selectedModelOverride?: string;
       readonly zeroRunMetadata?: ZeroRunMetadata;
     },
     signal: AbortSignal,
@@ -566,7 +581,7 @@ export const createZeroRun$ = command(
         body: createRunBody({
           body: args.body,
           agent,
-          userInfo,
+          userInfo: { ...userInfo, ...args.userInfoExtras },
           permissionPolicies: agentPermissionPolicies,
           triggerAgentId,
           triggerSource: args.triggerSource,
@@ -575,7 +590,8 @@ export const createZeroRun$ = command(
         apiStartTime: args.apiStartTime,
         modelProviderId: agent.modelProviderId ?? undefined,
         modelProviderType: args.body.modelProvider,
-        selectedModelOverride: agent.selectedModel ?? undefined,
+        selectedModelOverride:
+          args.selectedModelOverride ?? agent.selectedModel ?? undefined,
         extraEnvironment: { ZERO_AGENT_ID: agent.id },
         callbacks: args.callbacks ?? callbacksForTriggerAgent(triggerAgentId),
         includeZeroTokenSecret: true,

--- a/turbo/apps/api/src/signals/services/zero-slack-webhooks.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-slack-webhooks.service.ts
@@ -3,10 +3,7 @@ import { randomBytes } from "node:crypto";
 import { command, type Getter, type Setter } from "ccstate";
 import type { Block, KnownBlock } from "@slack/web-api";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
-import {
-  getAllFeatureStates,
-  isFeatureEnabled,
-} from "@vm0/core/feature-switch";
+import { isFeatureEnabled } from "@vm0/core/feature-switch";
 import {
   getVm0VisibleModels,
   isSupportedRunModel,
@@ -15,6 +12,7 @@ import {
 import { RUN_ERROR_GUIDANCE } from "@vm0/api-contracts/contracts/errors";
 import { slackOrgCallbackPayloadSchema } from "@vm0/api-contracts/contracts/internal-callbacks-slack-org";
 import { agentSessions } from "@vm0/db/schema/agent-session";
+import { conversations } from "@vm0/db/schema/conversation";
 import { orgMetadata } from "@vm0/db/schema/org-metadata";
 import { slackOrgConnections } from "@vm0/db/schema/slack-org-connection";
 import { slackOrgInstallations } from "@vm0/db/schema/slack-org-installation";
@@ -22,6 +20,7 @@ import { slackOrgThreadSessions } from "@vm0/db/schema/slack-org-thread-session"
 import { slackUserAgentPreferences } from "@vm0/db/schema/slack-user-agent-preference";
 import { userCache } from "@vm0/db/schema/user-cache";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
+import { zeroRuns } from "@vm0/db/schema/zero-run";
 import { and, eq } from "drizzle-orm";
 import type { z } from "zod";
 
@@ -571,9 +570,7 @@ async function slackModelPickerState(
   }[];
   readonly currentSelectedModel: string | null;
 }> {
-  const overrides = await get(userFeatureSwitchOverrides(orgId, userId));
-  const featureStates = getAllFeatureStates({ orgId, userId, overrides });
-  const visibleModels = new Set(getVm0VisibleModels(featureStates));
+  const visibleModels = new Set(getVm0VisibleModels());
   const [policies, preference] = await Promise.all([
     set(listOrgModelPolicies$, { orgId, userId }, signal),
     get(userModelPreference({ orgId, userId })),
@@ -1023,9 +1020,12 @@ async function resolveCompatibleThreadSession(args: {
   readonly connectionId: string;
   readonly userId: string;
   readonly agentComposeId: string;
+  readonly selectedModelOverride?: string;
 }): Promise<string | undefined> {
   const [session] = await args.db
-    .select({ agentSessionId: slackOrgThreadSessions.agentSessionId })
+    .select({
+      agentSessionId: slackOrgThreadSessions.agentSessionId,
+    })
     .from(slackOrgThreadSessions)
     .where(
       and(
@@ -1039,7 +1039,10 @@ async function resolveCompatibleThreadSession(args: {
     return undefined;
   }
   const [agentSession] = await args.db
-    .select({ agentComposeId: agentSessions.agentComposeId })
+    .select({
+      agentComposeId: agentSessions.agentComposeId,
+      conversationId: agentSessions.conversationId,
+    })
     .from(agentSessions)
     .where(
       and(
@@ -1048,9 +1051,26 @@ async function resolveCompatibleThreadSession(args: {
       ),
     )
     .limit(1);
-  return agentSession?.agentComposeId === args.agentComposeId
-    ? session.agentSessionId
-    : undefined;
+  if (agentSession?.agentComposeId !== args.agentComposeId) {
+    return undefined;
+  }
+
+  if (args.selectedModelOverride && agentSession.conversationId) {
+    const [previousRun] = await args.db
+      .select({ selectedModel: zeroRuns.selectedModel })
+      .from(conversations)
+      .innerJoin(zeroRuns, eq(zeroRuns.id, conversations.runId))
+      .where(eq(conversations.id, agentSession.conversationId))
+      .limit(1);
+    if (
+      previousRun?.selectedModel &&
+      previousRun.selectedModel !== args.selectedModelOverride
+    ) {
+      return undefined;
+    }
+  }
+
+  return session.agentSessionId;
 }
 
 async function postPreDispatchErrorReply(args: {
@@ -1214,20 +1234,6 @@ async function buildRunAgentParams(
     client: resolved.client,
     userId: args.slackUserId,
   });
-  const existingSessionId = await resolveCompatibleThreadSession({
-    db: args.db,
-    channelId: args.channelId,
-    threadTs: resolved.threadTs,
-    connectionId: resolved.connection.id,
-    userId: resolved.connection.vm0UserId,
-    agentComposeId: resolved.composeId,
-  });
-  const { executionContext } = await fetchConversationContexts(
-    resolved.client,
-    args.channelId,
-    args.threadTs,
-    args.messageTs,
-  );
   const selectedModelOverride = (
     await args.get(
       userModelPreference({
@@ -1236,6 +1242,21 @@ async function buildRunAgentParams(
       }),
     )
   ).selectedModel;
+  const existingSessionId = await resolveCompatibleThreadSession({
+    db: args.db,
+    channelId: args.channelId,
+    threadTs: resolved.threadTs,
+    connectionId: resolved.connection.id,
+    userId: resolved.connection.vm0UserId,
+    agentComposeId: resolved.composeId,
+    selectedModelOverride: selectedModelOverride ?? undefined,
+  });
+  const { executionContext } = await fetchConversationContexts(
+    resolved.client,
+    args.channelId,
+    args.threadTs,
+    args.messageTs,
+  );
   const callbackContext: SlackCallbackPayload = {
     workspaceId: args.workspaceId,
     channelId: args.channelId,

--- a/turbo/apps/api/src/signals/services/zero-slack-webhooks.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-slack-webhooks.service.ts
@@ -1,0 +1,1848 @@
+import { randomBytes } from "node:crypto";
+
+import { command, type Getter, type Setter } from "ccstate";
+import type { Block, KnownBlock } from "@slack/web-api";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import {
+  getAllFeatureStates,
+  isFeatureEnabled,
+} from "@vm0/core/feature-switch";
+import {
+  getVm0VisibleModels,
+  isSupportedRunModel,
+  type SupportedRunModel,
+} from "@vm0/api-contracts/contracts/model-providers";
+import { RUN_ERROR_GUIDANCE } from "@vm0/api-contracts/contracts/errors";
+import { slackOrgCallbackPayloadSchema } from "@vm0/api-contracts/contracts/internal-callbacks-slack-org";
+import { agentSessions } from "@vm0/db/schema/agent-session";
+import { orgMetadata } from "@vm0/db/schema/org-metadata";
+import { slackOrgConnections } from "@vm0/db/schema/slack-org-connection";
+import { slackOrgInstallations } from "@vm0/db/schema/slack-org-installation";
+import { slackOrgThreadSessions } from "@vm0/db/schema/slack-org-thread-session";
+import { slackUserAgentPreferences } from "@vm0/db/schema/slack-user-agent-preference";
+import { userCache } from "@vm0/db/schema/user-cache";
+import { zeroAgents } from "@vm0/db/schema/zero-agent";
+import { and, eq } from "drizzle-orm";
+import type { z } from "zod";
+
+import { env, optionalEnv } from "../../lib/env";
+import { logger } from "../../lib/log";
+import {
+  getSlackSignatureHeaders,
+  verifySlackSignature,
+} from "../../lib/slack-request-verification";
+import {
+  AGENT_PICKER_ACTION_ID,
+  AGENT_PICKER_BLOCK_ID,
+  AGENT_PICKER_CALLBACK_ID,
+  AGENT_PICKER_ORG_DEFAULT_VALUE,
+  MODEL_PICKER_ACTION_ID,
+  MODEL_PICKER_BLOCK_ID,
+  MODEL_PICKER_CALLBACK_ID,
+  buildAgentPickerModal,
+  buildAgentResponseMessage,
+  buildAppHomeView,
+  buildErrorMessage,
+  buildHelpMessage,
+  buildLoginMessage,
+  buildLoginPromptMessage,
+  buildModelPickerModal,
+  buildSuccessMessage,
+  buildWelcomeMessage,
+} from "../../lib/slack-webhook-blocks";
+import {
+  enrichMessageContent,
+  fetchConversationContexts,
+  type SlackFile,
+} from "../../lib/slack-webhook-context";
+import { request$ } from "../context/hono";
+import { waitUntil } from "../context/wait-until";
+import {
+  createSlackClient,
+  openView,
+  postMessage,
+  publishAppHome,
+  setThreadStatus,
+} from "../external/slack-message-client";
+import { now, nowDate } from "../external/time";
+import { writeDb$, type Db } from "../external/db";
+import { userFeatureSwitchOverrides } from "./feature-switches.service";
+import { decryptSecretValue } from "./crypto.utils";
+import { zeroComposeList } from "./zero-compose-data.service";
+import { listOrgModelPolicies$ } from "./zero-model-policy.service";
+import {
+  updateUserModelPreference$,
+  userModelPreference,
+} from "./zero-user-data.service";
+import { publishSlackAdminSignal$ } from "./zero-slack-connect.service";
+import { createZeroRun$ } from "./zero-runs-create.service";
+import { safeAsync, safeJsonParse } from "../utils";
+
+const L = logger("ZeroSlackWebhooks");
+const AGENT_PICKER_MAX_OPTIONS = 100;
+const MODEL_PICKER_MAX_OPTIONS = 100;
+
+type ComputedGetter = Getter;
+type ComputedSetter = Setter;
+type SlackInstallation = typeof slackOrgInstallations.$inferSelect;
+type SlackConnection = typeof slackOrgConnections.$inferSelect;
+type SlackCallbackPayload = z.infer<typeof slackOrgCallbackPayloadSchema>;
+
+interface SlackCommandPayload {
+  readonly team_id: string;
+  readonly channel_id: string;
+  readonly user_id: string;
+  readonly text: string;
+  readonly trigger_id: string;
+}
+
+interface SlackEventCallback {
+  readonly type: "event_callback";
+  readonly team_id: string;
+  readonly event:
+    | SlackAppMentionEvent
+    | SlackDirectMessageEvent
+    | SlackAppHomeOpenedEvent
+    | SlackAppUninstalledEvent
+    | SlackTokensRevokedEvent;
+}
+
+interface SlackUrlVerificationEvent {
+  readonly type: "url_verification";
+  readonly challenge: string;
+}
+
+interface SlackAppMentionEvent {
+  readonly type: "app_mention";
+  readonly user: string;
+  readonly text: string;
+  readonly ts: string;
+  readonly channel: string;
+  readonly channel_type?: string;
+  readonly thread_ts?: string;
+  readonly files?: readonly SlackFile[];
+}
+
+interface SlackDirectMessageEvent {
+  readonly type: "message";
+  readonly channel_type: "im";
+  readonly user: string;
+  readonly text: string;
+  readonly ts: string;
+  readonly channel: string;
+  readonly thread_ts?: string;
+  readonly subtype?: string;
+  readonly bot_id?: string;
+  readonly files?: readonly SlackFile[];
+}
+
+interface SlackAppHomeOpenedEvent {
+  readonly type: "app_home_opened";
+  readonly user: string;
+  readonly tab: "home" | "messages";
+  readonly channel: string;
+}
+
+interface SlackAppUninstalledEvent {
+  readonly type: "app_uninstalled";
+}
+
+interface SlackTokensRevokedEvent {
+  readonly type: "tokens_revoked";
+  readonly tokens: {
+    readonly bot?: readonly string[];
+  };
+}
+
+type SlackEvent = SlackUrlVerificationEvent | SlackEventCallback;
+
+interface SlackInteractivePayload {
+  readonly type: "view_submission" | "block_actions" | "shortcut";
+  readonly user: {
+    readonly id: string;
+    readonly username: string;
+    readonly team_id: string;
+  };
+  readonly team: {
+    readonly id: string;
+    readonly domain: string;
+  };
+  readonly trigger_id?: string;
+  readonly actions?: readonly {
+    readonly action_id: string;
+    readonly block_id: string;
+  }[];
+  readonly view?: {
+    readonly callback_id: string;
+    readonly private_metadata?: string;
+    readonly state: {
+      readonly values: Record<
+        string,
+        Record<
+          string,
+          { readonly selected_option?: { readonly value: string } | null }
+        >
+      >;
+    };
+  };
+}
+
+interface ConnectionContext {
+  readonly connection: SlackConnection;
+  readonly installation: SlackInstallation;
+  readonly orgId: string;
+}
+
+interface RunAgentParams {
+  readonly agentId: string;
+  readonly agentName: string;
+  readonly orgId: string;
+  readonly sessionId: string | undefined;
+  readonly prompt: string;
+  readonly threadContext: string;
+  readonly userInfoExtras: {
+    readonly slackDisplayName?: string;
+    readonly slackUserId?: string;
+  };
+  readonly userId: string;
+  readonly botUserId: string;
+  readonly channelId: string;
+  readonly channelType: "channel" | "dm" | "group_dm";
+  readonly threadTs: string;
+  readonly callbackContext: SlackCallbackPayload;
+  readonly apiStartTime: number;
+  readonly selectedModelOverride?: string;
+}
+
+type SlackChannelType = "channel" | "dm" | "group_dm";
+
+interface SlackAgentMessageArgs {
+  readonly get: ComputedGetter;
+  readonly set: ComputedSetter;
+  readonly db: Db;
+  readonly workspaceId: string;
+  readonly channelId: string;
+  readonly channelType: SlackChannelType;
+  readonly slackUserId: string;
+  readonly messageText: string;
+  readonly messageTs: string;
+  readonly threadTs?: string;
+  readonly files?: readonly SlackFile[];
+  readonly apiStartTime: number;
+  readonly signal: AbortSignal;
+}
+
+interface ResolvedSlackAgentMessage {
+  readonly installation: SlackInstallation & { readonly orgId: string };
+  readonly connection: SlackConnection;
+  readonly client: ReturnType<typeof createSlackClient>;
+  readonly threadTs: string;
+  readonly composeId: string;
+  readonly agent: {
+    readonly id: string;
+    readonly name: string;
+    readonly displayName: string | null;
+  };
+}
+
+interface CommandModelResponseArgs {
+  readonly get: ComputedGetter;
+  readonly set: ComputedSetter;
+  readonly payload: SlackCommandPayload;
+  readonly installation: SlackInstallation;
+  readonly connection: SlackConnection;
+  readonly signal: AbortSignal;
+}
+
+interface RunAgentResult {
+  readonly status: "accepted" | "queued" | "failed";
+  readonly response?: string;
+  readonly runId?: string;
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function emptyResponse(): Response {
+  return new Response("", { status: 200 });
+}
+
+function textResponse(text: string): Response {
+  return new Response(text, { status: 200 });
+}
+
+function ephemeral(blocks: unknown[]): Response {
+  return jsonResponse({ response_type: "ephemeral", blocks });
+}
+
+function parseCommandPayload(body: string): SlackCommandPayload {
+  const params = new URLSearchParams(body);
+  return {
+    team_id: params.get("team_id") ?? "",
+    channel_id: params.get("channel_id") ?? "",
+    user_id: params.get("user_id") ?? "",
+    text: params.get("text") ?? "",
+    trigger_id: params.get("trigger_id") ?? "",
+  };
+}
+
+async function verifiedSlackBody(
+  request: Request,
+): Promise<
+  | { readonly ok: true; readonly body: string }
+  | { readonly ok: false; readonly response: Response }
+> {
+  const signingSecret = optionalEnv("SLACK_SIGNING_SECRET");
+  if (!signingSecret) {
+    return {
+      ok: false,
+      response: jsonResponse(
+        { error: "Slack integration is not configured" },
+        503,
+      ),
+    };
+  }
+
+  const body = await request.text();
+  const headers = getSlackSignatureHeaders(request.headers);
+  if (!headers) {
+    return {
+      ok: false,
+      response: jsonResponse({ error: "Missing Slack signature headers" }, 401),
+    };
+  }
+
+  const valid = verifySlackSignature({
+    signingSecret,
+    signature: headers.signature,
+    timestamp: headers.timestamp,
+    body,
+  });
+  if (!valid) {
+    return {
+      ok: false,
+      response: jsonResponse({ error: "Invalid signature" }, 401),
+    };
+  }
+
+  return { ok: true, body };
+}
+
+function buildOrgConnectUrl(
+  workspaceId: string,
+  slackUserId: string,
+  channelId: string,
+  threadTs?: string,
+): string {
+  const params = new URLSearchParams({ w: workspaceId, u: slackUserId });
+  if (channelId) {
+    params.set("c", channelId);
+  }
+  if (threadTs) {
+    params.set("t", threadTs);
+  }
+  return `${env("VM0_WEB_URL")}/settings/slack?${params.toString()}`;
+}
+
+function buildNotInstalledMessage(detail?: string): unknown[] {
+  return [
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text:
+          detail ??
+          "The Zero Slack app hasn't been set up for this workspace yet.",
+      },
+    },
+    {
+      type: "actions",
+      elements: [
+        {
+          type: "button",
+          text: { type: "plain_text", text: "Set up on Platform" },
+          url: `${env("VM0_WEB_URL")}/works`,
+          action_id: "open_platform_setup",
+        },
+      ],
+    },
+  ];
+}
+
+async function installationForWorkspace(
+  db: Db,
+  workspaceId: string,
+): Promise<SlackInstallation | undefined> {
+  const [installation] = await db
+    .select()
+    .from(slackOrgInstallations)
+    .where(eq(slackOrgInstallations.slackWorkspaceId, workspaceId))
+    .limit(1);
+  return installation;
+}
+
+async function connectionForSlackUser(
+  db: Db,
+  workspaceId: string,
+  slackUserId: string,
+): Promise<SlackConnection | undefined> {
+  const [connection] = await db
+    .select()
+    .from(slackOrgConnections)
+    .where(
+      and(
+        eq(slackOrgConnections.slackUserId, slackUserId),
+        eq(slackOrgConnections.slackWorkspaceId, workspaceId),
+      ),
+    )
+    .limit(1);
+  return connection;
+}
+
+async function resolveConnectionContext(
+  db: Db,
+  slackUserId: string,
+  workspaceId: string,
+): Promise<ConnectionContext | null> {
+  const installation = await installationForWorkspace(db, workspaceId);
+  if (!installation?.orgId) {
+    return null;
+  }
+  const connection = await connectionForSlackUser(db, workspaceId, slackUserId);
+  if (!connection) {
+    return null;
+  }
+  return { connection, installation, orgId: installation.orgId };
+}
+
+async function resolveDefaultComposeId(
+  db: Db,
+  orgId: string,
+): Promise<string | null> {
+  const [row] = await db
+    .select({ defaultAgentId: orgMetadata.defaultAgentId })
+    .from(orgMetadata)
+    .where(eq(orgMetadata.orgId, orgId))
+    .limit(1);
+  return row?.defaultAgentId ?? null;
+}
+
+async function getUserAgentPreference(
+  db: Db,
+  vm0UserId: string,
+  orgId: string,
+): Promise<string | null> {
+  const [row] = await db
+    .select({ selectedComposeId: slackUserAgentPreferences.selectedComposeId })
+    .from(slackUserAgentPreferences)
+    .where(
+      and(
+        eq(slackUserAgentPreferences.vm0UserId, vm0UserId),
+        eq(slackUserAgentPreferences.orgId, orgId),
+      ),
+    )
+    .limit(1);
+  return row?.selectedComposeId ?? null;
+}
+
+async function setUserAgentPreference(args: {
+  readonly db: Db;
+  readonly vm0UserId: string;
+  readonly orgId: string;
+  readonly composeId: string | null;
+}): Promise<void> {
+  await args.db
+    .insert(slackUserAgentPreferences)
+    .values({
+      vm0UserId: args.vm0UserId,
+      orgId: args.orgId,
+      selectedComposeId: args.composeId,
+    })
+    .onConflictDoUpdate({
+      target: [
+        slackUserAgentPreferences.vm0UserId,
+        slackUserAgentPreferences.orgId,
+      ],
+      set: {
+        selectedComposeId: args.composeId,
+        updatedAt: nowDate(),
+      },
+    });
+}
+
+async function getWorkspaceAgent(
+  db: Db,
+  composeId: string,
+  orgId?: string,
+): Promise<
+  | {
+      readonly id: string;
+      readonly name: string;
+      readonly displayName: string | null;
+    }
+  | undefined
+> {
+  const [agent] = await db
+    .select({
+      id: zeroAgents.id,
+      name: zeroAgents.name,
+      displayName: zeroAgents.displayName,
+    })
+    .from(zeroAgents)
+    .where(
+      orgId
+        ? and(eq(zeroAgents.id, composeId), eq(zeroAgents.orgId, orgId))
+        : eq(zeroAgents.id, composeId),
+    )
+    .limit(1);
+  return agent;
+}
+
+async function resolveEffectiveComposeId(
+  db: Db,
+  vm0UserId: string,
+  orgId: string,
+): Promise<string | null> {
+  const override = await getUserAgentPreference(db, vm0UserId, orgId);
+  if (override) {
+    const [row] = await db
+      .select({ id: zeroAgents.id })
+      .from(zeroAgents)
+      .where(and(eq(zeroAgents.id, override), eq(zeroAgents.orgId, orgId)))
+      .limit(1);
+    if (row?.id) {
+      return override;
+    }
+  }
+  return resolveDefaultComposeId(db, orgId);
+}
+
+async function disconnect(db: Db, connectionId: string): Promise<void> {
+  await db
+    .delete(slackOrgConnections)
+    .where(eq(slackOrgConnections.id, connectionId));
+}
+
+async function cleanupWorkspaceInstallation(
+  set: ComputedSetter,
+  db: Db,
+  workspaceId: string,
+  signal: AbortSignal,
+): Promise<boolean> {
+  const installation = await installationForWorkspace(db, workspaceId);
+  signal.throwIfAborted();
+  if (!installation) {
+    return false;
+  }
+  await db
+    .delete(slackOrgConnections)
+    .where(eq(slackOrgConnections.slackWorkspaceId, workspaceId));
+  signal.throwIfAborted();
+  await db
+    .delete(slackOrgInstallations)
+    .where(eq(slackOrgInstallations.slackWorkspaceId, workspaceId));
+  signal.throwIfAborted();
+  if (installation.orgId) {
+    await set(
+      publishSlackAdminSignal$,
+      { orgId: installation.orgId, topic: "slack:changed" },
+      signal,
+    );
+  }
+  return true;
+}
+
+async function slackModelPickerState(
+  get: ComputedGetter,
+  set: ComputedSetter,
+  orgId: string,
+  userId: string,
+  signal: AbortSignal,
+): Promise<{
+  readonly enabled: boolean;
+  readonly options: readonly {
+    readonly model: SupportedRunModel;
+    readonly label: string;
+    readonly isDefault: boolean;
+  }[];
+  readonly currentSelectedModel: string | null;
+}> {
+  const overrides = await get(userFeatureSwitchOverrides(orgId, userId));
+  const featureStates = getAllFeatureStates({ orgId, userId, overrides });
+  const visibleModels = new Set(getVm0VisibleModels(featureStates));
+  const [policies, preference] = await Promise.all([
+    set(listOrgModelPolicies$, { orgId, userId }, signal),
+    get(userModelPreference({ orgId, userId })),
+  ]);
+  return {
+    enabled: true,
+    options: policies.policies.flatMap((policy) => {
+      if (
+        !isSupportedRunModel(policy.model) ||
+        !visibleModels.has(policy.model) ||
+        policy.routeStatus !== "valid"
+      ) {
+        return [];
+      }
+      return {
+        model: policy.model,
+        label: policy.modelLabel,
+        isDefault: policy.isDefault,
+      };
+    }),
+    currentSelectedModel: preference.selectedModel,
+  };
+}
+
+async function isModelCommandAvailable(
+  get: ComputedGetter,
+  set: ComputedSetter,
+  installation: SlackInstallation | undefined,
+  connection: SlackConnection | undefined,
+  signal: AbortSignal,
+): Promise<boolean> {
+  if (!installation?.orgId || !connection) {
+    return false;
+  }
+  const picker = await slackModelPickerState(
+    get,
+    set,
+    installation.orgId,
+    connection.vm0UserId,
+    signal,
+  );
+  return picker.enabled && picker.options.length > 0;
+}
+
+async function refreshOrgAppHome(
+  db: Db,
+  installation: SlackInstallation,
+  slackUserId: string,
+): Promise<void> {
+  const workspaceId = installation.slackWorkspaceId;
+  const botToken = decryptSecretValue(installation.encryptedBotToken);
+  const client = createSlackClient(botToken);
+  const connection = await connectionForSlackUser(db, workspaceId, slackUserId);
+  if (!connection) {
+    await publishAppHome(
+      client,
+      slackUserId,
+      buildAppHomeView({
+        isLinked: false,
+        loginUrl: buildOrgConnectUrl(workspaceId, slackUserId, ""),
+      }),
+    );
+    return;
+  }
+
+  let agentName: string | undefined;
+  let isOverrideActive = false;
+  let canSwitch = false;
+  if (installation.orgId) {
+    const orgId = installation.orgId;
+    const [effectiveComposeId, overrideComposeId, defaultComposeId] =
+      await Promise.all([
+        resolveEffectiveComposeId(db, connection.vm0UserId, orgId),
+        getUserAgentPreference(db, connection.vm0UserId, orgId),
+        resolveDefaultComposeId(db, orgId),
+      ]);
+    if (effectiveComposeId) {
+      const agent = await getWorkspaceAgent(db, effectiveComposeId);
+      agentName = agent?.displayName ?? agent?.name;
+    }
+    isOverrideActive = Boolean(
+      overrideComposeId && overrideComposeId !== defaultComposeId,
+    );
+    canSwitch = Boolean(defaultComposeId);
+  }
+
+  const [metadata] = await db
+    .select({ email: userCache.email })
+    .from(userCache)
+    .where(eq(userCache.userId, connection.vm0UserId))
+    .limit(1);
+
+  await publishAppHome(
+    client,
+    slackUserId,
+    buildAppHomeView({
+      isLinked: true,
+      vm0UserId: connection.vm0UserId,
+      userEmail: metadata?.email ?? undefined,
+      agentName,
+      isOverrideActive,
+      canSwitch,
+    }),
+  );
+}
+
+async function commandSwitchResponse(
+  get: ComputedGetter,
+  db: Db,
+  payload: SlackCommandPayload,
+  installation: SlackInstallation,
+  connection: SlackConnection,
+): Promise<Response> {
+  if (!installation.orgId) {
+    return ephemeral(
+      buildErrorMessage(
+        "This workspace is not bound to an org. Please contact your admin.",
+      ),
+    );
+  }
+  if (!payload.trigger_id) {
+    return ephemeral(
+      buildErrorMessage(
+        "Couldn't open the agent picker \u2014 please try again.",
+      ),
+    );
+  }
+  const { composes } = await get(zeroComposeList(installation.orgId));
+  const defaultComposeId = await resolveDefaultComposeId(
+    db,
+    installation.orgId,
+  );
+  const options = composes
+    .filter((compose) => {
+      return compose.id !== defaultComposeId;
+    })
+    .slice(0, AGENT_PICKER_MAX_OPTIONS)
+    .map((compose) => {
+      return {
+        composeId: compose.id,
+        name: compose.name,
+        displayName: compose.displayName,
+      };
+    });
+  const orgDefaultName = defaultComposeId
+    ? ((await getWorkspaceAgent(db, defaultComposeId))?.displayName ??
+      (await getWorkspaceAgent(db, defaultComposeId))?.name ??
+      null)
+    : null;
+  const currentOverride = await getUserAgentPreference(
+    db,
+    connection.vm0UserId,
+    installation.orgId,
+  );
+  const client = createSlackClient(
+    decryptSecretValue(installation.encryptedBotToken),
+  );
+  const result = await safeAsync(() => {
+    return openView(
+      client,
+      payload.trigger_id,
+      buildAgentPickerModal({
+        options,
+        currentSelectedId: currentOverride,
+        orgDefaultName,
+        privateMetadata: JSON.stringify({ channelId: payload.channel_id }),
+      }),
+    );
+  });
+  if ("error" in result) {
+    L.warn("Failed to open agent picker modal", { error: result.error });
+    return ephemeral(
+      buildErrorMessage(
+        "Couldn't open the agent picker \u2014 please try again.",
+      ),
+    );
+  }
+  return emptyResponse();
+}
+
+async function commandModelResponse(
+  args: CommandModelResponseArgs,
+): Promise<Response> {
+  if (!args.installation.orgId) {
+    return ephemeral(
+      buildErrorMessage(
+        "This workspace is not bound to an org. Please contact your admin.",
+      ),
+    );
+  }
+  if (!args.payload.trigger_id) {
+    return ephemeral(
+      buildErrorMessage(
+        "Couldn't open the model picker \u2014 please try again.",
+      ),
+    );
+  }
+  const picker = await slackModelPickerState(
+    args.get,
+    args.set,
+    args.installation.orgId,
+    args.connection.vm0UserId,
+    args.signal,
+  );
+  if (!picker.enabled) {
+    return ephemeral(
+      buildErrorMessage("Model switching is not available for this workspace."),
+    );
+  }
+  if (picker.options.length === 0) {
+    return ephemeral(
+      buildErrorMessage("No models are configured for this workspace."),
+    );
+  }
+  const client = createSlackClient(
+    decryptSecretValue(args.installation.encryptedBotToken),
+  );
+  const result = await safeAsync(() => {
+    return openView(
+      client,
+      args.payload.trigger_id,
+      buildModelPickerModal({
+        options: picker.options.slice(0, MODEL_PICKER_MAX_OPTIONS),
+        currentSelectedModel: picker.currentSelectedModel,
+        privateMetadata: JSON.stringify({ channelId: args.payload.channel_id }),
+      }),
+    );
+  });
+  if ("error" in result) {
+    L.warn("Failed to open model picker modal", { error: result.error });
+    return ephemeral(
+      buildErrorMessage(
+        "Couldn't open the model picker \u2014 please try again.",
+      ),
+    );
+  }
+  return emptyResponse();
+}
+
+export const handleZeroSlackCommands$ = command(
+  async ({ get, set }, signal: AbortSignal): Promise<Response> => {
+    const request = get(request$);
+    const verified = await verifiedSlackBody(request.raw);
+    signal.throwIfAborted();
+    if (!verified.ok) {
+      return verified.response;
+    }
+
+    const payload = parseCommandPayload(verified.body);
+    const db = set(writeDb$);
+    const args = payload.text.trim().split(/\s+/);
+    const subCommand = args[0]?.toLowerCase() ?? "";
+    const installation = await installationForWorkspace(db, payload.team_id);
+    signal.throwIfAborted();
+    const connection = installation
+      ? await connectionForSlackUser(db, payload.team_id, payload.user_id)
+      : undefined;
+    signal.throwIfAborted();
+    const canSwitchAgents = Boolean(installation?.orgId);
+    const canModel = () => {
+      return isModelCommandAvailable(
+        get,
+        set,
+        installation,
+        connection,
+        signal,
+      );
+    };
+
+    if (subCommand === "help" || subCommand === "") {
+      return ephemeral(
+        buildHelpMessage({
+          canSwitch: canSwitchAgents,
+          canModel: await canModel(),
+        }),
+      );
+    }
+
+    if (subCommand === "connect") {
+      if (!installation) {
+        return ephemeral(
+          buildNotInstalledMessage(
+            "The Zero Slack app hasn't been set up for this workspace yet. An org admin can complete the setup from the platform.",
+          ),
+        );
+      }
+      if (connection) {
+        return ephemeral(
+          buildSuccessMessage(
+            "You are already connected.\nMention `@Zero` in any channel or send a DM to start chatting with your agent.",
+          ),
+        );
+      }
+      return ephemeral(
+        buildLoginMessage(
+          buildOrgConnectUrl(
+            payload.team_id,
+            payload.user_id,
+            payload.channel_id,
+          ),
+        ),
+      );
+    }
+
+    if (!installation) {
+      return ephemeral(buildNotInstalledMessage());
+    }
+
+    if (subCommand === "disconnect") {
+      if (!connection) {
+        return ephemeral(buildErrorMessage("You are not connected."));
+      }
+      await disconnect(db, connection.id);
+      signal.throwIfAborted();
+      waitUntil(
+        refreshOrgAppHome(db, installation, payload.user_id).catch((error) => {
+          L.warn("Failed to refresh App Home after disconnect", { error });
+        }),
+      );
+      return ephemeral(
+        buildSuccessMessage(
+          "You have been disconnected and your agent access has been revoked.",
+        ),
+      );
+    }
+
+    if (!connection) {
+      return ephemeral(
+        buildLoginMessage(
+          buildOrgConnectUrl(
+            payload.team_id,
+            payload.user_id,
+            payload.channel_id,
+          ),
+        ),
+      );
+    }
+
+    if (subCommand === "switch") {
+      return commandSwitchResponse(get, db, payload, installation, connection);
+    }
+
+    if (subCommand === "model") {
+      return commandModelResponse({
+        get,
+        set,
+        payload,
+        installation,
+        connection,
+        signal,
+      });
+    }
+
+    return ephemeral(
+      buildHelpMessage({
+        canSwitch: canSwitchAgents,
+        canModel: await canModel(),
+      }),
+    );
+  },
+);
+
+function buildSlackPrompt(args: {
+  readonly botUserId: string;
+  readonly channelId: string;
+  readonly channelType: "channel" | "dm" | "group_dm";
+  readonly threadTs: string;
+  readonly threadContext: string;
+}): string {
+  const typeLabel =
+    args.channelType === "dm"
+      ? "Direct message"
+      : args.channelType === "group_dm"
+        ? "Group direct message"
+        : "Channel";
+  return [
+    "# Current Integration",
+    "You are currently running inside: Slack",
+    `Your bot user ID: ${args.botUserId}`,
+    `Channel ID: ${args.channelId}`,
+    `Channel type: ${typeLabel}`,
+    `Thread ID: ${args.threadTs}`,
+    args.threadContext,
+  ]
+    .filter(Boolean)
+    .join("\n");
+}
+
+function generateCallbackSecret(): string {
+  return randomBytes(32).toString("hex");
+}
+
+async function runAgentForSlackOrg(
+  set: ComputedSetter,
+  params: RunAgentParams,
+  signal: AbortSignal,
+): Promise<RunAgentResult> {
+  const result = await set(
+    createZeroRun$,
+    {
+      auth: {
+        tokenType: "session",
+        userId: params.userId,
+        orgId: params.orgId,
+        orgRole: "member",
+      },
+      body: {
+        prompt: params.prompt,
+        agentId: params.agentId,
+        sessionId: params.sessionId,
+      },
+      apiStartTime: params.apiStartTime,
+      triggerSource: "slack",
+      appendSystemPrompt: buildSlackPrompt(params),
+      userInfoExtras: params.userInfoExtras,
+      selectedModelOverride: params.selectedModelOverride,
+      callbacks: [
+        {
+          url: `${env("VM0_API_URL")}/api/internal/callbacks/slack/org`,
+          secret: generateCallbackSecret(),
+          payload: params.callbackContext,
+        },
+      ],
+    },
+    signal,
+  );
+  if (result.status === 201) {
+    return {
+      status: result.body.status === "queued" ? "queued" : "accepted",
+      runId: result.body.runId,
+    };
+  }
+
+  const guidance = RUN_ERROR_GUIDANCE[result.body.error.code];
+  return {
+    status: "failed",
+    response: guidance
+      ? `${guidance.title}: ${guidance.guidance}`
+      : result.body.error.message,
+  };
+}
+
+async function resolveCompatibleThreadSession(args: {
+  readonly db: Db;
+  readonly channelId: string;
+  readonly threadTs: string;
+  readonly connectionId: string;
+  readonly userId: string;
+  readonly agentComposeId: string;
+}): Promise<string | undefined> {
+  const [session] = await args.db
+    .select({ agentSessionId: slackOrgThreadSessions.agentSessionId })
+    .from(slackOrgThreadSessions)
+    .where(
+      and(
+        eq(slackOrgThreadSessions.connectionId, args.connectionId),
+        eq(slackOrgThreadSessions.slackChannelId, args.channelId),
+        eq(slackOrgThreadSessions.slackThreadTs, args.threadTs),
+      ),
+    )
+    .limit(1);
+  if (!session?.agentSessionId) {
+    return undefined;
+  }
+  const [agentSession] = await args.db
+    .select({ agentComposeId: agentSessions.agentComposeId })
+    .from(agentSessions)
+    .where(
+      and(
+        eq(agentSessions.id, session.agentSessionId),
+        eq(agentSessions.userId, args.userId),
+      ),
+    )
+    .limit(1);
+  return agentSession?.agentComposeId === args.agentComposeId
+    ? session.agentSessionId
+    : undefined;
+}
+
+async function postPreDispatchErrorReply(args: {
+  readonly get: ComputedGetter;
+  readonly db: Db;
+  readonly client: ReturnType<typeof createSlackClient>;
+  readonly channelId: string;
+  readonly threadTs: string;
+  readonly errorText: string;
+  readonly orgId: string;
+  readonly vm0UserId: string;
+  readonly composeId: string;
+  readonly agentLabel: string;
+}): Promise<void> {
+  const overrides = await args.get(
+    userFeatureSwitchOverrides(args.orgId, args.vm0UserId),
+  );
+  const logsUrl = isFeatureEnabled(FeatureSwitchKey.AuditLink, {
+    userId: args.vm0UserId,
+    orgId: args.orgId,
+    overrides,
+  })
+    ? `${env("VM0_WEB_URL")}/activities`
+    : undefined;
+  const orgDefaultComposeId = await resolveDefaultComposeId(
+    args.db,
+    args.orgId,
+  );
+  const triggeredBy =
+    args.composeId !== orgDefaultComposeId
+      ? `Sent via ${args.agentLabel}`
+      : undefined;
+  await args.client.chat.postMessage({
+    channel: args.channelId,
+    thread_ts: args.threadTs,
+    text: args.errorText,
+    blocks: buildAgentResponseMessage(args.errorText, logsUrl, triggeredBy),
+  });
+}
+
+async function postSlackUserNotice(args: {
+  readonly client: ReturnType<typeof createSlackClient>;
+  readonly channelId: string;
+  readonly channelType: SlackChannelType;
+  readonly slackUserId: string;
+  readonly threadTs: string;
+  readonly ephemeralThreadTs?: string;
+  readonly text: string;
+  readonly blocks?: (Block | KnownBlock)[];
+}): Promise<void> {
+  if (args.channelType === "dm") {
+    await postMessage(args.client, args.channelId, args.text, {
+      threadTs: args.threadTs,
+      blocks: args.blocks,
+    });
+    return;
+  }
+
+  await args.client.chat.postEphemeral({
+    channel: args.channelId,
+    user: args.slackUserId,
+    ...(args.ephemeralThreadTs && { thread_ts: args.ephemeralThreadTs }),
+    text: args.text,
+    ...(args.blocks && { blocks: args.blocks }),
+  });
+}
+
+async function resolveSlackAgentMessage(
+  args: SlackAgentMessageArgs,
+): Promise<ResolvedSlackAgentMessage | null> {
+  const installation = await installationForWorkspace(
+    args.db,
+    args.workspaceId,
+  );
+  const orgId = installation?.orgId;
+  if (!installation || !orgId) {
+    return null;
+  }
+  const boundInstallation = { ...installation, orgId };
+  const botToken = decryptSecretValue(installation.encryptedBotToken);
+  const client = createSlackClient(botToken);
+  const threadTs = args.threadTs ?? args.messageTs;
+  const connection = await connectionForSlackUser(
+    args.db,
+    args.workspaceId,
+    args.slackUserId,
+  );
+
+  if (!connection) {
+    const connectUrl = buildOrgConnectUrl(
+      args.workspaceId,
+      args.slackUserId,
+      args.channelId,
+      args.channelType === "dm" ? threadTs : undefined,
+    );
+    await postSlackUserNotice({
+      client,
+      channelId: args.channelId,
+      channelType: args.channelType,
+      slackUserId: args.slackUserId,
+      threadTs,
+      text: "Please connect your account first",
+      blocks: buildLoginPromptMessage(connectUrl),
+    });
+    return null;
+  }
+
+  const composeId = await resolveEffectiveComposeId(
+    args.db,
+    connection.vm0UserId,
+    boundInstallation.orgId,
+  );
+  if (!composeId) {
+    await postSlackUserNotice({
+      client,
+      channelId: args.channelId,
+      channelType: args.channelType,
+      slackUserId: args.slackUserId,
+      threadTs,
+      ephemeralThreadTs: args.threadTs ? threadTs : undefined,
+      text: "No agent is configured for this org. Please ask your org admin to set a default agent.",
+    });
+    return null;
+  }
+
+  const agent = await getWorkspaceAgent(
+    args.db,
+    composeId,
+    boundInstallation.orgId,
+  );
+  if (!agent) {
+    await postSlackUserNotice({
+      client,
+      channelId: args.channelId,
+      channelType: args.channelType,
+      slackUserId: args.slackUserId,
+      threadTs,
+      ephemeralThreadTs: args.threadTs ? threadTs : undefined,
+      text: "The configured agent could not be found. Please contact your org admin.",
+    });
+    return null;
+  }
+
+  return {
+    installation: boundInstallation,
+    connection,
+    client,
+    threadTs,
+    composeId,
+    agent,
+  };
+}
+
+async function buildRunAgentParams(
+  args: SlackAgentMessageArgs,
+  resolved: ResolvedSlackAgentMessage,
+): Promise<RunAgentParams> {
+  const { prompt, userInfoExtras } = await enrichMessageContent({
+    messageContent: args.messageText,
+    files: args.files,
+    client: resolved.client,
+    userId: args.slackUserId,
+  });
+  const existingSessionId = await resolveCompatibleThreadSession({
+    db: args.db,
+    channelId: args.channelId,
+    threadTs: resolved.threadTs,
+    connectionId: resolved.connection.id,
+    userId: resolved.connection.vm0UserId,
+    agentComposeId: resolved.composeId,
+  });
+  const { executionContext } = await fetchConversationContexts(
+    resolved.client,
+    args.channelId,
+    args.threadTs,
+    args.messageTs,
+  );
+  const selectedModelOverride = (
+    await args.get(
+      userModelPreference({
+        orgId: resolved.installation.orgId,
+        userId: resolved.connection.vm0UserId,
+      }),
+    )
+  ).selectedModel;
+  const callbackContext: SlackCallbackPayload = {
+    workspaceId: args.workspaceId,
+    channelId: args.channelId,
+    threadTs: resolved.threadTs,
+    messageTs: args.messageTs,
+    connectionId: resolved.connection.id,
+    agentId: resolved.composeId,
+    existingSessionId,
+  };
+
+  return {
+    agentId: resolved.composeId,
+    agentName: resolved.agent.name,
+    orgId: resolved.installation.orgId,
+    sessionId: existingSessionId,
+    prompt,
+    threadContext: executionContext,
+    userInfoExtras,
+    userId: resolved.connection.vm0UserId,
+    botUserId: resolved.installation.botUserId,
+    channelId: args.channelId,
+    channelType: args.channelType,
+    threadTs: resolved.threadTs,
+    callbackContext,
+    apiStartTime: args.apiStartTime,
+    selectedModelOverride: selectedModelOverride ?? undefined,
+  };
+}
+
+async function handleSlackRunResult(args: {
+  readonly message: SlackAgentMessageArgs;
+  readonly resolved: ResolvedSlackAgentMessage;
+  readonly result: RunAgentResult;
+}): Promise<void> {
+  const { message, resolved, result } = args;
+  if (result.status === "queued") {
+    const queueUrl = `${env("VM0_WEB_URL")}/?queue=1`;
+    await resolved.client.chat.postEphemeral({
+      channel: message.channelId,
+      user: message.slackUserId,
+      ...(message.channelType === "dm" || message.threadTs
+        ? { thread_ts: resolved.threadTs }
+        : {}),
+      text: `\u26a0 Run queued -- concurrency limit reached. Will start automatically when a slot is available. <${queueUrl}|View queue>`,
+      blocks: [
+        {
+          type: "section",
+          text: {
+            type: "mrkdwn",
+            text: ":warning: *Run queued*\n\nConcurrency limit reached. Will start automatically when a slot is available.",
+          },
+        },
+        {
+          type: "context",
+          elements: [{ type: "mrkdwn", text: `<${queueUrl}|View queue>` }],
+        },
+      ],
+    });
+  } else if (result.status === "failed") {
+    if (!result.runId) {
+      await postPreDispatchErrorReply({
+        get: message.get,
+        db: message.db,
+        client: resolved.client,
+        channelId: message.channelId,
+        threadTs: resolved.threadTs,
+        errorText:
+          result.response ?? "Sorry, an error occurred. Please try again.",
+        orgId: resolved.installation.orgId,
+        vm0UserId: resolved.connection.vm0UserId,
+        composeId: resolved.composeId,
+        agentLabel: resolved.agent.displayName ?? resolved.agent.name,
+      });
+    }
+    await setThreadStatus(
+      resolved.client,
+      message.channelId,
+      resolved.threadTs,
+      "",
+    ).catch((error) => {
+      L.warn("Failed to clear thread status", { error });
+    });
+  }
+}
+
+async function handleSlackAgentMessage(
+  args: SlackAgentMessageArgs,
+): Promise<void> {
+  const resolved = await resolveSlackAgentMessage(args);
+  if (!resolved) {
+    return;
+  }
+
+  await setThreadStatus(
+    resolved.client,
+    args.channelId,
+    resolved.threadTs,
+    "is thinking...",
+  );
+  const runParams = await buildRunAgentParams(args, resolved);
+  const result = await runAgentForSlackOrg(args.set, runParams, args.signal);
+  await handleSlackRunResult({ message: args, resolved, result });
+}
+
+async function handleAppHomeOpened(
+  db: Db,
+  workspaceId: string,
+  slackUserId: string,
+): Promise<void> {
+  const installation = await installationForWorkspace(db, workspaceId);
+  if (!installation) {
+    return;
+  }
+  await refreshOrgAppHome(db, installation, slackUserId);
+}
+
+async function handleMessagesTabOpened(
+  db: Db,
+  workspaceId: string,
+  slackUserId: string,
+  channelId: string,
+): Promise<void> {
+  const installation = await installationForWorkspace(db, workspaceId);
+  if (!installation) {
+    return;
+  }
+  const [connection] = await db
+    .select({ id: slackOrgConnections.id })
+    .from(slackOrgConnections)
+    .where(
+      and(
+        eq(slackOrgConnections.slackUserId, slackUserId),
+        eq(slackOrgConnections.slackWorkspaceId, workspaceId),
+      ),
+    )
+    .limit(1);
+  if (!connection) {
+    return;
+  }
+  const updated = await db
+    .update(slackOrgConnections)
+    .set({ dmWelcomeSent: true })
+    .where(
+      and(
+        eq(slackOrgConnections.id, connection.id),
+        eq(slackOrgConnections.dmWelcomeSent, false),
+      ),
+    );
+  if (updated.rowCount === 0) {
+    return;
+  }
+  const agentName = installation.orgId
+    ? await resolveDefaultComposeId(db, installation.orgId).then(
+        async (composeId) => {
+          const agent = composeId
+            ? await getWorkspaceAgent(db, composeId)
+            : undefined;
+          return agent?.displayName ?? agent?.name;
+        },
+      )
+    : undefined;
+  await postMessage(
+    createSlackClient(decryptSecretValue(installation.encryptedBotToken)),
+    channelId,
+    "Hi! I'm Zero. I can connect you to AI agents to help with your tasks.",
+    { blocks: buildWelcomeMessage(agentName) },
+  );
+}
+
+function handleEventCallback(args: {
+  readonly get: ComputedGetter;
+  readonly set: ComputedSetter;
+  readonly db: Db;
+  readonly payload: SlackEventCallback;
+  readonly apiStartTime: number;
+  readonly signal: AbortSignal;
+}): void {
+  const event = args.payload.event;
+  if (event.type === "app_mention") {
+    waitUntil(
+      handleSlackAgentMessage({
+        ...args,
+        workspaceId: args.payload.team_id,
+        channelId: event.channel,
+        channelType:
+          event.channel_type === "im"
+            ? "dm"
+            : event.channel_type === "mpim"
+              ? "group_dm"
+              : "channel",
+        slackUserId: event.user,
+        messageText: event.text,
+        messageTs: event.ts,
+        threadTs: event.thread_ts,
+        files: event.files,
+      }).catch((error) => {
+        L.error("Error handling org app_mention", { error });
+      }),
+    );
+  }
+
+  if (
+    event.type === "message" &&
+    event.channel_type === "im" &&
+    (!event.subtype || event.subtype === "file_share") &&
+    !event.bot_id
+  ) {
+    waitUntil(
+      handleSlackAgentMessage({
+        ...args,
+        workspaceId: args.payload.team_id,
+        channelId: event.channel,
+        channelType: "dm",
+        slackUserId: event.user,
+        messageText: event.text,
+        messageTs: event.ts,
+        threadTs: event.thread_ts,
+        files: event.files,
+      }).catch((error) => {
+        L.error("Error handling org direct_message", { error });
+      }),
+    );
+  }
+
+  if (event.type === "app_home_opened" && event.tab === "home") {
+    waitUntil(
+      handleAppHomeOpened(args.db, args.payload.team_id, event.user).catch(
+        (error) => {
+          L.error("Error handling org app_home_opened", { error });
+        },
+      ),
+    );
+  }
+
+  if (event.type === "app_home_opened" && event.tab === "messages") {
+    waitUntil(
+      handleMessagesTabOpened(
+        args.db,
+        args.payload.team_id,
+        event.user,
+        event.channel,
+      ).catch((error) => {
+        L.error("Error handling org messages_tab_opened", { error });
+      }),
+    );
+  }
+
+  if (event.type === "app_uninstalled") {
+    waitUntil(
+      cleanupWorkspaceInstallation(
+        args.set,
+        args.db,
+        args.payload.team_id,
+        args.signal,
+      ).catch((error) => {
+        L.error("Error handling app_uninstalled", { error });
+      }),
+    );
+  }
+
+  if (event.type === "tokens_revoked" && event.tokens.bot?.length) {
+    waitUntil(
+      cleanupWorkspaceInstallation(
+        args.set,
+        args.db,
+        args.payload.team_id,
+        args.signal,
+      ).catch((error) => {
+        L.error("Error handling tokens_revoked", { error });
+      }),
+    );
+  }
+}
+
+export const handleZeroSlackEvents$ = command(
+  async ({ get, set }, signal: AbortSignal): Promise<Response> => {
+    const request = get(request$);
+    const apiStartTime = now();
+    const verified = await verifiedSlackBody(request.raw);
+    signal.throwIfAborted();
+    if (!verified.ok) {
+      return verified.response;
+    }
+
+    const parsedPayload = safeJsonParse(verified.body);
+    if (parsedPayload === undefined) {
+      return jsonResponse({ error: "Invalid JSON payload" }, 400);
+    }
+    const payload = parsedPayload as SlackEvent;
+
+    if (payload.type === "url_verification") {
+      return jsonResponse({ challenge: payload.challenge });
+    }
+
+    if (payload.type === "event_callback") {
+      if (request.header("x-slack-retry-num")) {
+        return textResponse("OK");
+      }
+      handleEventCallback({
+        get,
+        set,
+        db: set(writeDb$),
+        payload,
+        apiStartTime,
+        signal,
+      });
+      return textResponse("OK");
+    }
+
+    return textResponse("OK");
+  },
+);
+
+function parseViewChannelId(
+  privateMetadata: string | undefined,
+): string | undefined {
+  if (!privateMetadata) {
+    return undefined;
+  }
+  const metadata = safeJsonParse(privateMetadata);
+  const channelId =
+    typeof metadata === "object" && metadata !== null && "channelId" in metadata
+      ? metadata.channelId
+      : undefined;
+  return typeof channelId === "string" && channelId.length > 0
+    ? channelId
+    : undefined;
+}
+
+async function postEphemeralMessage(args: {
+  readonly botToken: string;
+  readonly channel: string;
+  readonly slackUserId: string;
+  readonly text: string;
+}): Promise<void> {
+  await createSlackClient(args.botToken).chat.postEphemeral({
+    channel: args.channel,
+    user: args.slackUserId,
+    text: args.text,
+  });
+}
+
+async function resolveOrgDefaultName(db: Db, orgId: string): Promise<string> {
+  const defaultComposeId = await resolveDefaultComposeId(db, orgId);
+  if (!defaultComposeId) {
+    return "the org default agent";
+  }
+  const agent = await getWorkspaceAgent(db, defaultComposeId);
+  return agent?.displayName ?? agent?.name ?? "the org default agent";
+}
+
+async function handleAgentPickerSubmit(
+  db: Db,
+  payload: SlackInteractivePayload,
+): Promise<Response> {
+  const selected =
+    payload.view?.state.values[AGENT_PICKER_BLOCK_ID]?.[AGENT_PICKER_ACTION_ID]
+      ?.selected_option?.value;
+  if (!selected) {
+    return jsonResponse({
+      response_action: "errors",
+      errors: { [AGENT_PICKER_BLOCK_ID]: "Please choose an agent." },
+    });
+  }
+  const ctx = await resolveConnectionContext(
+    db,
+    payload.user.id,
+    payload.team.id,
+  );
+  if (!ctx) {
+    return emptyResponse();
+  }
+  const botToken = decryptSecretValue(ctx.installation.encryptedBotToken);
+  const channelId = parseViewChannelId(payload.view?.private_metadata);
+  if (selected === AGENT_PICKER_ORG_DEFAULT_VALUE) {
+    const defaultName = await resolveOrgDefaultName(db, ctx.orgId);
+    await setUserAgentPreference({
+      db,
+      vm0UserId: ctx.connection.vm0UserId,
+      orgId: ctx.orgId,
+      composeId: null,
+    });
+    if (channelId) {
+      await postEphemeralMessage({
+        botToken,
+        channel: channelId,
+        slackUserId: payload.user.id,
+        text: `Switched to *${defaultName}*.`,
+      });
+    }
+    waitUntil(refreshOrgAppHome(db, ctx.installation, payload.user.id));
+    return emptyResponse();
+  }
+
+  const agent = await getWorkspaceAgent(db, selected, ctx.orgId);
+  if (!agent || agent.id !== selected) {
+    return jsonResponse({
+      response_action: "errors",
+      errors: {
+        [AGENT_PICKER_BLOCK_ID]: "You don't have access to that agent.",
+      },
+    });
+  }
+  await setUserAgentPreference({
+    db,
+    vm0UserId: ctx.connection.vm0UserId,
+    orgId: ctx.orgId,
+    composeId: agent.id,
+  });
+  if (channelId) {
+    await postEphemeralMessage({
+      botToken,
+      channel: channelId,
+      slackUserId: payload.user.id,
+      text: `Switched to *${agent.displayName ?? agent.name}*.`,
+    });
+  }
+  waitUntil(refreshOrgAppHome(db, ctx.installation, payload.user.id));
+  return emptyResponse();
+}
+
+async function handleModelPickerSubmit(
+  get: ComputedGetter,
+  set: ComputedSetter,
+  db: Db,
+  payload: SlackInteractivePayload,
+  signal: AbortSignal,
+): Promise<Response> {
+  const selected =
+    payload.view?.state.values[MODEL_PICKER_BLOCK_ID]?.[MODEL_PICKER_ACTION_ID]
+      ?.selected_option?.value;
+  if (!selected) {
+    return jsonResponse({
+      response_action: "errors",
+      errors: { [MODEL_PICKER_BLOCK_ID]: "Please choose a model." },
+    });
+  }
+  const ctx = await resolveConnectionContext(
+    db,
+    payload.user.id,
+    payload.team.id,
+  );
+  if (!ctx) {
+    return emptyResponse();
+  }
+  const picker = await slackModelPickerState(
+    get,
+    set,
+    ctx.orgId,
+    ctx.connection.vm0UserId,
+    signal,
+  );
+  const option = picker.options.find((candidate) => {
+    return candidate.model === selected;
+  });
+  if (!option) {
+    return jsonResponse({
+      response_action: "errors",
+      errors: {
+        [MODEL_PICKER_BLOCK_ID]: "You don't have access to that model.",
+      },
+    });
+  }
+  await set(
+    updateUserModelPreference$,
+    {
+      orgId: ctx.orgId,
+      userId: ctx.connection.vm0UserId,
+      preference: { selectedModel: option.model },
+    },
+    signal,
+  );
+  const channelId = parseViewChannelId(payload.view?.private_metadata);
+  if (channelId) {
+    await postEphemeralMessage({
+      botToken: decryptSecretValue(ctx.installation.encryptedBotToken),
+      channel: channelId,
+      slackUserId: payload.user.id,
+      text: `Switched to *${option.label}*.`,
+    });
+  }
+  return emptyResponse();
+}
+
+async function handleHomeSwitchAgent(
+  get: ComputedGetter,
+  db: Db,
+  payload: SlackInteractivePayload,
+): Promise<void> {
+  if (!payload.trigger_id) {
+    return;
+  }
+  const triggerId = payload.trigger_id;
+  const ctx = await resolveConnectionContext(
+    db,
+    payload.user.id,
+    payload.team.id,
+  );
+  if (!ctx) {
+    return;
+  }
+  const { composes } = await get(zeroComposeList(ctx.orgId));
+  const defaultComposeId = await resolveDefaultComposeId(db, ctx.orgId);
+  const options = composes
+    .filter((compose) => {
+      return compose.id !== defaultComposeId;
+    })
+    .slice(0, AGENT_PICKER_MAX_OPTIONS)
+    .map((compose) => {
+      return {
+        composeId: compose.id,
+        name: compose.name,
+        displayName: compose.displayName,
+      };
+    });
+  const orgDefaultName = defaultComposeId
+    ? ((await getWorkspaceAgent(db, defaultComposeId))?.displayName ??
+      (await getWorkspaceAgent(db, defaultComposeId))?.name ??
+      null)
+    : null;
+  const currentOverride = await getUserAgentPreference(
+    db,
+    ctx.connection.vm0UserId,
+    ctx.orgId,
+  );
+  const result = await safeAsync(() => {
+    return openView(
+      createSlackClient(decryptSecretValue(ctx.installation.encryptedBotToken)),
+      triggerId,
+      buildAgentPickerModal({
+        options,
+        currentSelectedId: currentOverride,
+        orgDefaultName,
+      }),
+    );
+  });
+  if ("error" in result) {
+    L.warn("Failed to open switch modal from App Home", {
+      error: result.error,
+    });
+  }
+}
+
+async function handleHomeDisconnect(
+  db: Db,
+  payload: SlackInteractivePayload,
+): Promise<void> {
+  const connection = await connectionForSlackUser(
+    db,
+    payload.team.id,
+    payload.user.id,
+  );
+  if (!connection) {
+    return;
+  }
+  await disconnect(db, connection.id);
+  const installation = await installationForWorkspace(db, payload.team.id);
+  if (!installation) {
+    return;
+  }
+  await refreshOrgAppHome(db, installation, payload.user.id);
+}
+
+export const handleZeroSlackInteractive$ = command(
+  async ({ get, set }, signal: AbortSignal): Promise<Response> => {
+    const request = get(request$);
+    const verified = await verifiedSlackBody(request.raw);
+    signal.throwIfAborted();
+    if (!verified.ok) {
+      return verified.response;
+    }
+
+    const payloadString = new URLSearchParams(verified.body).get("payload");
+    if (!payloadString) {
+      return jsonResponse({ error: "Missing payload" }, 400);
+    }
+
+    const parsedPayload = safeJsonParse(payloadString);
+    if (parsedPayload === undefined) {
+      return jsonResponse({ error: "Invalid payload" }, 400);
+    }
+    const payload = parsedPayload as SlackInteractivePayload;
+
+    const db = set(writeDb$);
+    if (
+      payload.type === "view_submission" &&
+      payload.view?.callback_id === AGENT_PICKER_CALLBACK_ID
+    ) {
+      return handleAgentPickerSubmit(db, payload);
+    }
+    if (
+      payload.type === "view_submission" &&
+      payload.view?.callback_id === MODEL_PICKER_CALLBACK_ID
+    ) {
+      return handleModelPickerSubmit(get, set, db, payload, signal);
+    }
+    if (payload.type === "block_actions") {
+      const action = payload.actions?.[0];
+      if (!action) {
+        return emptyResponse();
+      }
+      if (action.action_id === "home_disconnect") {
+        await handleHomeDisconnect(db, payload);
+      } else if (action.action_id === "home_switch_agent") {
+        await handleHomeSwitchAgent(get, db, payload);
+      }
+    }
+    return emptyResponse();
+  },
+);

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -1124,6 +1124,18 @@ export {
   type ZeroSlackConnectContract,
 } from "./zero-slack-connect";
 export {
+  zeroSlackCommandsContract,
+  type ZeroSlackCommandsContract,
+} from "./zero-slack-commands";
+export {
+  zeroSlackEventsContract,
+  type ZeroSlackEventsContract,
+} from "./zero-slack-events";
+export {
+  zeroSlackInteractiveContract,
+  type ZeroSlackInteractiveContract,
+} from "./zero-slack-interactive";
+export {
   zeroSlackBrowserConnectContract,
   zeroSlackBrowserConnectQuerySchema,
   type ZeroSlackBrowserConnectContract,

--- a/turbo/packages/api-contracts/src/contracts/zero-slack-commands.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-slack-commands.ts
@@ -1,0 +1,21 @@
+import { z } from "zod";
+
+import { initContract } from "./base";
+
+const c = initContract();
+
+export const zeroSlackCommandsContract = c.router({
+  post: {
+    method: "POST",
+    path: "/api/zero/slack/commands",
+    body: c.type<string>(),
+    responses: {
+      200: z.unknown(),
+      401: z.object({ error: z.string() }),
+      503: z.object({ error: z.string() }),
+    },
+    summary: "Handle Zero Slack slash commands",
+  },
+});
+
+export type ZeroSlackCommandsContract = typeof zeroSlackCommandsContract;

--- a/turbo/packages/api-contracts/src/contracts/zero-slack-events.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-slack-events.ts
@@ -1,0 +1,22 @@
+import { z } from "zod";
+
+import { initContract } from "./base";
+
+const c = initContract();
+
+export const zeroSlackEventsContract = c.router({
+  post: {
+    method: "POST",
+    path: "/api/zero/slack/events",
+    body: c.type<string>(),
+    responses: {
+      200: z.unknown(),
+      400: z.object({ error: z.string() }),
+      401: z.object({ error: z.string() }),
+      503: z.object({ error: z.string() }),
+    },
+    summary: "Handle Zero Slack Events API callbacks",
+  },
+});
+
+export type ZeroSlackEventsContract = typeof zeroSlackEventsContract;

--- a/turbo/packages/api-contracts/src/contracts/zero-slack-interactive.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-slack-interactive.ts
@@ -1,0 +1,22 @@
+import { z } from "zod";
+
+import { initContract } from "./base";
+
+const c = initContract();
+
+export const zeroSlackInteractiveContract = c.router({
+  post: {
+    method: "POST",
+    path: "/api/zero/slack/interactive",
+    body: c.type<string>(),
+    responses: {
+      200: z.unknown(),
+      400: z.object({ error: z.string() }),
+      401: z.object({ error: z.string() }),
+      503: z.object({ error: z.string() }),
+    },
+    summary: "Handle Zero Slack interactive component callbacks",
+  },
+});
+
+export type ZeroSlackInteractiveContract = typeof zeroSlackInteractiveContract;


### PR DESCRIPTION
## Summary
- add apps/api Slack webhook contracts and routes for slash commands, events, and interactive payloads
- move Slack webhook command/event/interactive handling into API-owned services without importing apps/web
- add route integration coverage for verification, commands, App Home, Slack events, and interactive submissions

Closes #12890

## Validation
- pnpm -F api exec vitest run src/signals/routes/__tests__/zero-slack-commands.test.ts src/signals/routes/__tests__/zero-slack-events.test.ts src/signals/routes/__tests__/zero-slack-interactive.test.ts
- pnpm -F api lint
- pnpm -F api exec tsc --noEmit --pretty false
- pnpm knip --workspace api
- pnpm check-types
- git diff --check