### PR TITLE
fix(api): preserve chat model provider selection

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-chat-messages.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-chat-messages.test.ts
@@ -17,6 +17,7 @@ import { orgModelPolicies } from "@vm0/db/schema/org-model-policy";
 import { runnerJobQueue } from "@vm0/db/schema/runner-job-queue";
 import { secrets } from "@vm0/db/schema/secret";
 import { userFeatureSwitches } from "@vm0/db/schema/user-feature-switches";
+import { vm0ApiKeys } from "@vm0/db/schema/vm0-api-key";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
 import { createStore } from "ccstate";
@@ -44,6 +45,7 @@ import { encryptSecretForTests } from "./helpers/encrypt-secret";
 const context = testContext();
 const store = createStore();
 const mocks = createZeroRouteMocks(context);
+const ORG_SENTINEL_USER_ID = "__org__";
 
 interface ChatMessageFixture {
   readonly userId: string;
@@ -192,6 +194,7 @@ async function deleteFixture(fixture: ChatMessageFixture): Promise<void> {
     .delete(modelProviders)
     .where(eq(modelProviders.orgId, fixture.orgId));
   await writeDb.delete(secrets).where(eq(secrets.orgId, fixture.orgId));
+  await writeDb.delete(vm0ApiKeys).where(eq(vm0ApiKeys.label, fixture.agentId));
   await writeDb.delete(zeroAgents).where(eq(zeroAgents.id, fixture.agentId));
   await writeDb
     .delete(agentComposeVersions)
@@ -261,19 +264,27 @@ async function seedModelProvider(
   options: {
     readonly type?: string;
     readonly userId?: string;
+    readonly isDefault?: boolean;
+    readonly secretValue?: string;
   } = {},
 ): Promise<string> {
   const writeDb = store.set(writeDb$);
   const providerType = options.type ?? "anthropic-api-key";
   const providerUserId = options.userId ?? fixture.userId;
+  const secretName =
+    providerType === "deepseek-api-key"
+      ? "DEEPSEEK_API_KEY"
+      : "ANTHROPIC_API_KEY";
   const [secret] =
     providerType === "vm0"
       ? [undefined]
       : await writeDb
           .insert(secrets)
           .values({
-            name: "ANTHROPIC_API_KEY",
-            encryptedValue: encryptSecretForTests("test-provider-key"),
+            name: secretName,
+            encryptedValue: encryptSecretForTests(
+              options.secretValue ?? "test-provider-key",
+            ),
             type: "model-provider",
             userId: providerUserId,
             orgId: fixture.orgId,
@@ -284,13 +295,51 @@ async function seedModelProvider(
     .values({
       type: providerType,
       secretId: secret?.id ?? null,
-      isDefault: true,
+      isDefault: options.isDefault ?? true,
       selectedModel,
       userId: providerUserId,
       orgId: fixture.orgId,
     })
     .returning({ id: modelProviders.id });
   return provider!.id;
+}
+
+async function seedVm0ApiKey(
+  fixture: ChatMessageFixture,
+  model: string,
+): Promise<void> {
+  await store
+    .set(writeDb$)
+    .insert(vm0ApiKeys)
+    .values({
+      vendor: "anthropic",
+      model,
+      apiKey: `vm0-key-${model}`,
+      label: fixture.agentId,
+    });
+}
+
+async function removeComposeFrameworkApiKey(
+  fixture: ChatMessageFixture,
+): Promise<void> {
+  await store
+    .set(writeDb$)
+    .update(agentComposeVersions)
+    .set({
+      content: {
+        version: "1.0",
+        agents: {
+          zero: {
+            framework: "claude-code",
+            environment: {
+              ZERO_AGENT_ID: vm0Template("{{ vars.ZERO_AGENT_ID }}"),
+              ZERO_TOKEN: vm0Template("{{ secrets.ZERO_TOKEN }}"),
+            },
+          },
+        },
+      },
+    })
+    .where(eq(agentComposeVersions.id, fixture.versionId));
 }
 
 async function seedVm0Credits(
@@ -916,6 +965,12 @@ describe("POST /api/zero/chat/messages", () => {
     const fixture = await track(seedFixture());
     const writeDb = store.set(writeDb$);
     await seedVm0Credits(fixture, 1000);
+    await seedModelProvider(fixture, "claude-opus-4-7", {
+      type: "vm0",
+      userId: ORG_SENTINEL_USER_ID,
+    });
+    await seedVm0ApiKey(fixture, "claude-opus-4-7");
+    await seedVm0ApiKey(fixture, "claude-sonnet-4-6");
     await writeDb.insert(orgModelPolicies).values([
       {
         orgId: fixture.orgId,
@@ -975,6 +1030,116 @@ describe("POST /api/zero/chat/messages", () => {
     expect(run?.selectedModel).toBe("claude-sonnet-4-6");
     expect(run?.appendSystemPrompt).toContain("# Prior Chat Thread Context");
     expect(run?.appendSystemPrompt).toContain("User: first on opus");
+  });
+
+  it("passes explicit provider selection into the runner job context", async () => {
+    const fixture = await track(seedFixture());
+    const writeDb = store.set(writeDb$);
+    await removeComposeFrameworkApiKey(fixture);
+    await seedModelProvider(fixture, "claude-sonnet-4-6", {
+      type: "anthropic-api-key",
+      isDefault: true,
+      secretValue: "default-anthropic-key",
+    });
+    const deepseekProviderId = await seedModelProvider(
+      fixture,
+      "deepseek-v4-flash",
+      {
+        type: "deepseek-api-key",
+        isDefault: false,
+        secretValue: "selected-deepseek-key",
+      },
+    );
+
+    const response = await send({
+      agentId: fixture.agentId,
+      prompt: "run with selected deepseek provider",
+      modelSelection: {
+        modelProviderId: deepseekProviderId,
+        selectedModel: "deepseek-v4-pro",
+      },
+    });
+    await clearAllDetached();
+
+    const [job] = await writeDb
+      .select({ executionContext: runnerJobQueue.executionContext })
+      .from(runnerJobQueue)
+      .where(eq(runnerJobQueue.runId, response.body.runId!))
+      .limit(1);
+    const executionContext = job?.executionContext as {
+      readonly environment: Record<string, string>;
+      readonly encryptedSecrets: string | null;
+    };
+    expect(executionContext.environment).toMatchObject({
+      ANTHROPIC_AUTH_TOKEN: "selected-deepseek-key",
+      ANTHROPIC_BASE_URL: "https://api.deepseek.com/anthropic",
+      ANTHROPIC_MODEL: "deepseek-v4-pro",
+    });
+    expect(executionContext.environment.ANTHROPIC_API_KEY).toBeUndefined();
+    expect(decryptSecretsMap(executionContext.encryptedSecrets)).toMatchObject({
+      DEEPSEEK_API_KEY: "selected-deepseek-key",
+    });
+  });
+
+  it("honors org-scoped model-first route credentials during run creation", async () => {
+    const fixture = await track(seedFixture());
+    const writeDb = store.set(writeDb$);
+    await removeComposeFrameworkApiKey(fixture);
+    await seedModelProvider(fixture, "deepseek-v4-flash", {
+      type: "deepseek-api-key",
+      userId: fixture.userId,
+      isDefault: true,
+      secretValue: "member-deepseek-key",
+    });
+    const orgProviderId = await seedModelProvider(
+      fixture,
+      "deepseek-v4-flash",
+      {
+        type: "deepseek-api-key",
+        userId: ORG_SENTINEL_USER_ID,
+        isDefault: true,
+        secretValue: "org-deepseek-key",
+      },
+    );
+    await writeDb.insert(orgModelPolicies).values({
+      orgId: fixture.orgId,
+      model: "deepseek-v4-pro",
+      isDefault: true,
+      defaultProviderType: "deepseek-api-key",
+      credentialScope: "org",
+      modelProviderId: orgProviderId,
+      createdByUserId: fixture.userId,
+      updatedByUserId: fixture.userId,
+    });
+
+    const response = await send({
+      agentId: fixture.agentId,
+      prompt: "run with org policy deepseek provider",
+      modelSelection: {
+        modelProviderId: "00000000-0000-4000-8000-000000000000",
+        selectedModel: "deepseek-v4-pro",
+      },
+    });
+    await clearAllDetached();
+
+    const [job] = await writeDb
+      .select({ executionContext: runnerJobQueue.executionContext })
+      .from(runnerJobQueue)
+      .where(eq(runnerJobQueue.runId, response.body.runId!))
+      .limit(1);
+    const executionContext = job?.executionContext as {
+      readonly environment: Record<string, string>;
+      readonly encryptedSecrets: string | null;
+    };
+    expect(executionContext.environment.ANTHROPIC_AUTH_TOKEN).toBe(
+      "org-deepseek-key",
+    );
+    expect(executionContext.environment.ANTHROPIC_MODEL).toBe(
+      "deepseek-v4-pro",
+    );
+    expect(decryptSecretsMap(executionContext.encryptedSecrets)).toMatchObject({
+      DEEPSEEK_API_KEY: "org-deepseek-key",
+    });
   });
 
   it("returns 402 when VM0 model-first admission has no spendable credits", async () => {

--- a/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
@@ -5,6 +5,7 @@ import {
   chatMessagesContract,
   type AttachFile,
 } from "@vm0/api-contracts/contracts/chat-threads";
+import type { ModelProviderCredentialScope } from "@vm0/api-contracts/contracts/model-providers";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { isFeatureEnabled } from "@vm0/core/feature-switch";
 import { agentRuns } from "@vm0/db/schema/agent-run";
@@ -100,8 +101,31 @@ interface AgentForChatSend {
 interface ThreadModelPin {
   readonly modelProviderId: string | null;
   readonly modelProviderType: string | null;
+  readonly modelProviderCredentialScope: ModelProviderCredentialScope | null;
+  readonly selectedModel: string | null;
+}
+
+function parseModelProviderCredentialScope(
+  value: string | null,
+): ModelProviderCredentialScope | null {
+  if (value === null || value === "org" || value === "member") {
+    return value;
+  }
+  throw new Error(`Unknown model provider credential scope "${value}"`);
+}
+
+function threadModelPinFromRow(row: {
+  readonly modelProviderId: string | null;
+  readonly modelProviderType: string | null;
   readonly modelProviderCredentialScope: string | null;
   readonly selectedModel: string | null;
+}): ThreadModelPin {
+  return {
+    ...row,
+    modelProviderCredentialScope: parseModelProviderCredentialScope(
+      row.modelProviderCredentialScope,
+    ),
+  };
 }
 
 interface ResolvedThread {
@@ -751,7 +775,9 @@ async function defaultModelFirstPin(
   return {
     modelProviderId: policy.modelProviderId ?? null,
     modelProviderType: policy.defaultProviderType,
-    modelProviderCredentialScope: policy.credentialScope,
+    modelProviderCredentialScope: parseModelProviderCredentialScope(
+      policy.credentialScope,
+    ),
     selectedModel: policy.model,
   };
 }
@@ -773,7 +799,7 @@ async function getStoredThreadModelPin(
   if (!thread?.selectedModel) {
     return null;
   }
-  return thread;
+  return threadModelPinFromRow(thread);
 }
 
 async function modelProviderPinAvailable(params: {
@@ -825,7 +851,7 @@ async function getFirstRunModelPin(
   if (!run?.selectedModel) {
     return null;
   }
-  return run;
+  return threadModelPinFromRow(run);
 }
 
 async function existingModelFirstThreadPin(
@@ -898,7 +924,9 @@ async function resolveModelSelectionPin(params: {
   return {
     modelProviderId: policy.modelProviderId ?? null,
     modelProviderType: policy.defaultProviderType,
-    modelProviderCredentialScope: policy.credentialScope,
+    modelProviderCredentialScope: parseModelProviderCredentialScope(
+      policy.credentialScope,
+    ),
     selectedModel: policy.model,
   };
 }
@@ -960,7 +988,9 @@ async function persistThreadPinIfUnset(
       modelProviderCredentialScope: chatThreads.modelProviderCredentialScope,
       selectedModel: chatThreads.selectedModel,
     });
-  return updated ?? (await getStoredThreadModelPin(db, threadId)) ?? pin;
+  return updated
+    ? threadModelPinFromRow(updated)
+    : ((await getStoredThreadModelPin(db, threadId)) ?? pin);
 }
 
 async function resolveRunModelPin(params: {
@@ -1904,6 +1934,12 @@ const createNormalChatRun$ = command(
         apiStartTime: args.apiStartTime,
         chatThreadId: prepared.thread.threadId,
         includeZeroTokenSecret: true,
+        modelProviderId: modelPin.modelProviderId ?? undefined,
+        modelProviderCredentialScope:
+          modelPin.modelProviderCredentialScope ?? undefined,
+        modelProviderType:
+          providerAdmission.effectiveModelProvider ?? undefined,
+        selectedModelOverride: modelPin.selectedModel ?? undefined,
         validateEnvironmentReferences: false,
         callbacks: [
           {

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -2471,8 +2471,7 @@ async function resolveRunModelProvider(
   const hasFrameworkKey = hasExplicitFrameworkApiKey(content, framework);
   const hasProviderOverride =
     args.modelProviderId !== undefined ||
-    args.modelProviderCredentialScope !== undefined ||
-    args.modelProviderType !== undefined;
+    args.modelProviderCredentialScope !== undefined;
   const shouldResolveModelProvider =
     hasProviderOverride || !hasFrameworkKey || args.modelProviderType === "vm0";
   const modelProvider = shouldResolveModelProvider

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -17,6 +17,7 @@ import {
   getVm0Vendor,
   hasAuthMethods,
   MODEL_PROVIDER_TYPES,
+  type ModelProviderCredentialScope,
   type ModelProviderType,
 } from "@vm0/api-contracts/contracts/model-providers";
 import {
@@ -265,6 +266,7 @@ interface CreateAgentRunArgs {
   readonly body: CreateRunBody;
   readonly apiStartTime: number;
   readonly modelProviderId?: string;
+  readonly modelProviderCredentialScope?: ModelProviderCredentialScope;
   readonly modelProviderType?: string;
   readonly selectedModelOverride?: string;
   readonly callbacks?: readonly RunCallback[];
@@ -808,6 +810,7 @@ interface ResolveModelProviderEnvironmentArgs {
   readonly userId: string;
   readonly framework: SupportedFramework;
   readonly modelProviderId?: string;
+  readonly modelProviderCredentialScope?: ModelProviderCredentialScope;
   readonly modelProviderType?: string;
   readonly selectedModelOverride?: string;
 }
@@ -831,6 +834,18 @@ function isCandidateModelProviderRow(
   args: ResolveModelProviderEnvironmentArgs,
 ): row is ResolvableModelProviderEnvironmentRow {
   if (args.modelProviderId && row.id !== args.modelProviderId) {
+    return false;
+  }
+  if (
+    args.modelProviderCredentialScope === "org" &&
+    row.userId !== ORG_SENTINEL_USER_ID
+  ) {
+    return false;
+  }
+  if (
+    args.modelProviderCredentialScope === "member" &&
+    row.userId !== args.userId
+  ) {
     return false;
   }
   if (args.modelProviderType && row.type !== args.modelProviderType) {
@@ -2454,14 +2469,19 @@ async function resolveRunModelProvider(
   signal: AbortSignal,
 ): Promise<ResolvedModelProviderEnvironment | null | CreateRunErrorResult> {
   const hasFrameworkKey = hasExplicitFrameworkApiKey(content, framework);
+  const hasProviderOverride =
+    args.modelProviderId !== undefined ||
+    args.modelProviderCredentialScope !== undefined ||
+    args.modelProviderType !== undefined;
   const shouldResolveModelProvider =
-    !hasFrameworkKey || args.modelProviderType === "vm0";
+    hasProviderOverride || !hasFrameworkKey || args.modelProviderType === "vm0";
   const modelProvider = shouldResolveModelProvider
     ? await resolveModelProviderEnvironment(db, {
         orgId: args.orgId,
         userId: args.userId,
         framework,
         modelProviderId: args.modelProviderId,
+        modelProviderCredentialScope: args.modelProviderCredentialScope,
         modelProviderType: args.modelProviderType,
         selectedModelOverride: args.selectedModelOverride,
       })


### PR DESCRIPTION
## Summary
- pass Zero chat model-provider pins from the API backend route into run creation
- honor org/member credential scope when resolving model providers
- add route integration coverage for explicit provider selection and org-scoped model-first credentials

Fixes #13148

## Tests
- pnpm format
- pnpm -F api exec vitest src/signals/routes/__tests__/zero-chat-messages.test.ts
- pnpm -F api lint
- pnpm -F api check-types
- pre-commit: knip --cache
- pre-commit: pnpm check-types