### PR TITLE
feat: gate agentphone works controls

### DIFF
--- a/turbo/apps/platform/src/signals/bootstrap.ts
+++ b/turbo/apps/platform/src/signals/bootstrap.ts
@@ -18,6 +18,7 @@ import { setupGlobalMethod$ } from "./bootstrap/global-method.ts";
 import { setupLoggers$ } from "./bootstrap/loggers.ts";
 import { setupSlackConnectPage$ } from "./zero-page/slack-connect-page.ts";
 import { setupAgentPhoneConnectPage$ } from "./zero-page/agentphone-connect-page.ts";
+import { setupAgentPhoneSettingsPage$ } from "./zero-page/agentphone-settings-page.ts";
 import { setupTelegramConnectPage$ } from "./zero-page/telegram-connect-page.ts";
 import { setupTelegramSettingsPage$ } from "./zero-page/telegram-settings-page.ts";
 import { setupActivityPage$ } from "./activity-page/activity-page-setup.ts";
@@ -158,6 +159,10 @@ const ROUTE_CONFIG = [
   {
     path: ROUTES.settingsTelegram,
     setup: setupAuthPageWrapper(setupTelegramSettingsPage$),
+  },
+  {
+    path: ROUTES.settingsAgentPhone,
+    setup: setupAuthPageWrapper(setupAgentPhoneSettingsPage$),
   },
   {
     path: ROUTES.telegramConnect,

--- a/turbo/apps/platform/src/signals/route-paths.ts
+++ b/turbo/apps/platform/src/signals/route-paths.ts
@@ -21,6 +21,7 @@ export const ROUTES = {
   settings: "/settings",
   settingsSlack: "/settings/slack",
   settingsTelegram: "/settings/telegram",
+  settingsAgentPhone: "/settings/agentphone",
   telegramConnect: "/telegram/connect",
   agentphoneConnect: "/agentphone/connect",
   settingsApiKeys: "/settings/api-keys",

--- a/turbo/apps/platform/src/signals/zero-page/agentphone-settings-page.ts
+++ b/turbo/apps/platform/src/signals/zero-page/agentphone-settings-page.ts
@@ -1,0 +1,25 @@
+import { command } from "ccstate";
+import { createElement } from "react";
+import { ZeroAgentPhoneSettingsPage } from "../../views/zero-page/zero-agentphone-settings-page.tsx";
+import { hideAppSkeleton$ } from "../app-skeleton.ts";
+import { updateDocumentTitle$ } from "../document-title.ts";
+import { updatePage$ } from "../react-router.ts";
+import { onboardGuard$ } from "./onboard-guard.ts";
+import {
+  resetAgentPhoneConnectUi$,
+  setAgentPhoneConnectDialogOpen$,
+} from "./zero-agentphone.ts";
+
+export const setupAgentPhoneSettingsPage$ = command(
+  async ({ set }, signal: AbortSignal) => {
+    set(resetAgentPhoneConnectUi$);
+    set(setAgentPhoneConnectDialogOpen$, false);
+    set(updatePage$, createElement(ZeroAgentPhoneSettingsPage), "sidebar");
+    set(updateDocumentTitle$, "AgentPhone");
+
+    await Promise.all([
+      set(hideAppSkeleton$, signal),
+      set(onboardGuard$, signal),
+    ]);
+  },
+);

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-agentphone-settings-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-agentphone-settings-page.test.tsx
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
+import { setMockAgentPhoneIntegration } from "../../../mocks/handlers/api-integrations-agentphone.ts";
+
+const context = testContext();
+
+describe("agentphone settings page", () => {
+  it("shows AgentPhone controls when the app UI switch is enabled", async () => {
+    setMockAgentPhoneIntegration({
+      linked: false,
+      agentPhoneNumber: "+19039853128",
+      configured: true,
+    });
+    detachedSetupPage({
+      context,
+      path: "/settings/agentphone",
+      featureSwitches: {
+        [FeatureSwitchKey.AgentPhoneAppUi]: true,
+        [FeatureSwitchKey.AgentPhoneWorksControls]: false,
+      },
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "AgentPhone" }),
+      ).toBeInTheDocument();
+      expect(screen.getByLabelText("Connect AgentPhone")).toBeInTheDocument();
+    });
+  });
+
+  it("hides AgentPhone controls when the app UI switch is disabled", async () => {
+    detachedSetupPage({
+      context,
+      path: "/settings/agentphone",
+      featureSwitches: { [FeatureSwitchKey.AgentPhoneAppUi]: false },
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("AgentPhone is not enabled for this workspace."),
+      ).toBeInTheDocument();
+      expect(screen.queryByLabelText("Connect AgentPhone")).toBeNull();
+    });
+  });
+});

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-works-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-works-page.test.tsx
@@ -60,6 +60,19 @@ function renderWorksPage() {
   detachedSetupPage({ context, path: "/works" });
 }
 
+function agentPhoneAppSwitches() {
+  return {
+    [FeatureSwitchKey.AgentPhoneAppUi]: true,
+  };
+}
+
+function agentPhoneInlineSwitches() {
+  return {
+    [FeatureSwitchKey.AgentPhoneAppUi]: true,
+    [FeatureSwitchKey.AgentPhoneWorksControls]: true,
+  };
+}
+
 describe("works page - slack integration status display", () => {
   it("renders the Slack integration card on the works page (CONN-D-058)", async () => {
     mockSlackAPI({ isConnected: true, isInstalled: true, isAdmin: true });
@@ -162,7 +175,7 @@ describe("works page - AgentPhone integration card", () => {
     detachedSetupPage({
       context,
       path: "/works",
-      featureSwitches: { [FeatureSwitchKey.AgentPhoneAppUi]: true },
+      featureSwitches: agentPhoneInlineSwitches(),
     });
 
     await waitFor(() => {
@@ -179,6 +192,37 @@ describe("works page - AgentPhone integration card", () => {
     });
   });
 
+  it("links to AgentPhone settings when works controls are disabled", async () => {
+    mockSlackAPI({ isConnected: true, isInstalled: true, isAdmin: true });
+    setMockAgentPhoneIntegration({
+      linked: false,
+      agentPhoneNumber: "+19039853128",
+      configured: true,
+    });
+    detachedSetupPage({
+      context,
+      path: "/works",
+      featureSwitches: {
+        ...agentPhoneAppSwitches(),
+        [FeatureSwitchKey.AgentPhoneWorksControls]: false,
+      },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("AgentPhone")).toBeInTheDocument();
+      expect(
+        screen.getByLabelText("Open AgentPhone settings"),
+      ).toBeInTheDocument();
+      expect(screen.queryByLabelText("Connect AgentPhone")).toBeNull();
+    });
+
+    click(screen.getByLabelText("Open AgentPhone settings"));
+
+    await waitFor(() => {
+      expect(context.store.get(pathname$)).toBe("/settings/agentphone");
+    });
+  });
+
   it("starts verification from the list page and refreshes when AgentPhone connects", async () => {
     mockSlackAPI({ isConnected: true, isInstalled: true, isAdmin: true });
     setMockAgentPhoneIntegration({
@@ -189,7 +233,7 @@ describe("works page - AgentPhone integration card", () => {
     detachedSetupPage({
       context,
       path: "/works",
-      featureSwitches: { [FeatureSwitchKey.AgentPhoneAppUi]: true },
+      featureSwitches: agentPhoneInlineSwitches(),
     });
 
     await waitFor(() => {
@@ -247,7 +291,7 @@ describe("works page - AgentPhone integration card", () => {
     detachedSetupPage({
       context,
       path: "/works",
-      featureSwitches: { [FeatureSwitchKey.AgentPhoneAppUi]: true },
+      featureSwitches: agentPhoneInlineSwitches(),
     });
 
     await waitFor(() => {
@@ -295,7 +339,7 @@ describe("works page - AgentPhone integration card", () => {
     detachedSetupPage({
       context,
       path: "/works",
-      featureSwitches: { [FeatureSwitchKey.AgentPhoneAppUi]: true },
+      featureSwitches: agentPhoneInlineSwitches(),
     });
 
     await waitFor(() => {

--- a/turbo/apps/platform/src/views/zero-page/agentphone-card.tsx
+++ b/turbo/apps/platform/src/views/zero-page/agentphone-card.tsx
@@ -10,6 +10,7 @@ import {
   IconCircleCheck,
   IconDotsVertical,
   IconLoader2,
+  IconSettings,
 } from "@tabler/icons-react";
 import { Button } from "@vm0/ui";
 import {
@@ -45,7 +46,9 @@ import {
   waitForAgentPhoneConnection$,
 } from "../../signals/zero-page/zero-agentphone.ts";
 import { AGENTPHONE_SMS_MMS_CONNECT_RISK_MESSAGE } from "../../signals/zero-page/agentphone-connect-params.ts";
+import { ROUTES } from "../../signals/route-paths.ts";
 import { detach, Reason } from "../../signals/utils.ts";
+import { Link } from "../router/link.tsx";
 import imessageIconImg from "./components/settings/icons/imessage.svg";
 
 function AgentPhoneVerificationStatus({
@@ -244,7 +247,68 @@ function AgentPhoneConnectDialog() {
   );
 }
 
-export function AgentPhoneCard() {
+function AgentPhoneConnectedIndicator({
+  connectedPhone,
+}: {
+  readonly connectedPhone: string | null;
+}) {
+  return (
+    <span
+      data-testid="agentphone-connected-indicator"
+      className="inline-flex min-w-0 max-w-52 shrink-0 items-center gap-1.5 rounded-lg border border-border bg-background px-1.5 py-1 text-xs font-medium text-secondary-foreground"
+    >
+      <IconCircleCheck className="h-3 w-3 text-green-600" />
+      <span className="min-w-0 truncate" title={connectedPhone ?? ""}>
+        {connectedPhone ? `Connected (${connectedPhone})` : "Connected"}
+      </span>
+    </span>
+  );
+}
+
+function AgentPhoneManageLinkCard({
+  summary,
+  connectedPhone,
+}: {
+  readonly summary: string;
+  readonly connectedPhone: string | null;
+}) {
+  return (
+    <Link
+      pathname={ROUTES.settingsAgentPhone}
+      className="zero-card flex flex-col text-inherit no-underline transition-colors hover:bg-muted/30"
+      aria-label="Open AgentPhone settings"
+    >
+      <div className="flex items-center gap-4 p-4">
+        <div className="shrink-0 inline-flex h-7 w-7 items-center justify-center overflow-hidden">
+          <img src={imessageIconImg} alt="" className="h-7 w-7" />
+        </div>
+        <div className="flex min-w-0 flex-1 flex-col gap-1">
+          <div className="flex min-w-0 items-center gap-2">
+            <div className="truncate text-sm font-medium text-foreground">
+              AgentPhone
+            </div>
+          </div>
+          <div className="truncate text-sm text-muted-foreground">
+            {summary}
+          </div>
+        </div>
+        {connectedPhone ? (
+          <AgentPhoneConnectedIndicator connectedPhone={connectedPhone} />
+        ) : null}
+        <span className="shrink-0 inline-flex h-8 items-center gap-1.5 rounded-lg border border-border bg-background px-2.5 text-xs font-medium text-secondary-foreground">
+          <IconSettings size={14} stroke={1.5} />
+          Manage
+        </span>
+      </div>
+    </Link>
+  );
+}
+
+export function AgentPhoneCard({
+  controls = "inline",
+}: {
+  readonly controls?: "inline" | "manage-link";
+}) {
   const statusLoadable = useLastLoadable(agentPhoneLinkStatus$);
   const status =
     statusLoadable.state === "hasData" ? statusLoadable.data : null;
@@ -259,6 +323,15 @@ export function AgentPhoneCard() {
   const summary = status?.agentPhoneNumber
     ? `Text Zero at ${status.agentPhoneNumber}`
     : "Text-message access to Zero";
+
+  if (controls === "manage-link") {
+    return (
+      <AgentPhoneManageLinkCard
+        summary={summary}
+        connectedPhone={connectedPhone}
+      />
+    );
+  }
 
   return (
     <>
@@ -278,15 +351,7 @@ export function AgentPhoneCard() {
             </div>
           </div>
           {isConnected ? (
-            <span
-              data-testid="agentphone-connected-indicator"
-              className="inline-flex min-w-0 max-w-52 shrink-0 items-center gap-1.5 rounded-lg border border-border bg-background px-1.5 py-1 text-xs font-medium text-secondary-foreground"
-            >
-              <IconCircleCheck className="h-3 w-3 text-green-600" />
-              <span className="min-w-0 truncate" title={connectedPhone ?? ""}>
-                {connectedPhone ? `Connected (${connectedPhone})` : "Connected"}
-              </span>
-            </span>
+            <AgentPhoneConnectedIndicator connectedPhone={connectedPhone} />
           ) : null}
           {status !== null && !isConnected ? (
             <Button

--- a/turbo/apps/platform/src/views/zero-page/zero-agentphone-settings-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-agentphone-settings-page.tsx
@@ -1,0 +1,49 @@
+import { useLastResolved } from "ccstate-react";
+import { IconArrowLeft } from "@tabler/icons-react";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
+import { ROUTES } from "../../signals/route-paths.ts";
+import { Link } from "../router/link.tsx";
+import { AgentPhoneCard } from "./agentphone-card.tsx";
+
+export function ZeroAgentPhoneSettingsPage() {
+  const features = useLastResolved(featureSwitch$);
+  const enabled = features?.[FeatureSwitchKey.AgentPhoneAppUi];
+
+  return (
+    <div className="flex flex-1 flex-col min-h-0">
+      <header className="shrink-0 bg-transparent px-4 sm:px-6 pt-10 pb-3">
+        <div className="mx-auto max-w-[900px]">
+          <Link
+            pathname={ROUTES.works}
+            className="mb-3 inline-flex items-center gap-1.5 text-sm text-muted-foreground transition-colors hover:text-foreground"
+          >
+            <IconArrowLeft size={14} stroke={1.5} />
+            Channels
+          </Link>
+          <h1 className="text-lg font-semibold tracking-tight text-foreground">
+            AgentPhone
+          </h1>
+          <p className="mt-0.5 text-sm text-muted-foreground">
+            Manage text-message access to Zero.
+          </p>
+        </div>
+      </header>
+      <main className="flex-1 overflow-auto px-4 sm:px-6 pt-3 pb-8">
+        <div className="mx-auto max-w-[900px]">
+          {enabled === true ? (
+            <AgentPhoneCard />
+          ) : enabled === false ? (
+            <div className="zero-card p-5 text-sm text-muted-foreground">
+              AgentPhone is not enabled for this workspace.
+            </div>
+          ) : (
+            <div className="zero-card p-5 text-sm text-muted-foreground">
+              Loading AgentPhone...
+            </div>
+          )}
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/turbo/apps/platform/src/views/zero-page/zero-works-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-works-page.tsx
@@ -328,6 +328,8 @@ export function ZeroWorksPage() {
   const displayNameLoadable = useLoadable(currentChatAgentDisplayName$);
   const features = useLastResolved(featureSwitch$);
   const showAgentPhone = features?.[FeatureSwitchKey.AgentPhoneAppUi] ?? false;
+  const showAgentPhoneWorksControls =
+    features?.[FeatureSwitchKey.AgentPhoneWorksControls] ?? false;
   const displayName =
     displayNameLoadable.state === "hasData"
       ? (displayNameLoadable.data ?? "Zero")
@@ -350,7 +352,11 @@ export function ZeroWorksPage() {
         <div className="mx-auto max-w-[900px] flex flex-col gap-4">
           <SlackCard displayName={displayName} />
           <TelegramCard />
-          {showAgentPhone ? <AgentPhoneCard /> : null}
+          {showAgentPhone ? (
+            <AgentPhoneCard
+              controls={showAgentPhoneWorksControls ? "inline" : "manage-link"}
+            />
+          ) : null}
         </div>
       </main>
     </div>

--- a/turbo/packages/connectors/src/feature-switch-key.ts
+++ b/turbo/packages/connectors/src/feature-switch-key.ts
@@ -42,6 +42,7 @@ export enum FeatureSwitchKey {
   TestOauthConnector = "testOauthConnector",
   ChatHeaderNewButton = "chatHeaderNewButton",
   AgentPhoneAppUi = "agentPhoneAppUi",
+  AgentPhoneWorksControls = "agentPhoneWorksControls",
 
   ChatMessageStartButton = "chatMessageStartButton",
   Goal = "goal",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -238,6 +238,13 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
+  [FeatureSwitchKey.AgentPhoneWorksControls]: {
+    maintainer: "linghan@vm0.ai",
+    description:
+      "Show AgentPhone connect and disconnect controls directly on the Works page. When off, the Works card links to the AgentPhone settings page.",
+    enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+  },
   [FeatureSwitchKey.ChatMessageStartButton]: {
     maintainer: "linghan@vm0.ai",
     description:


### PR DESCRIPTION
## Summary
- add `AgentPhoneWorksControls` as a staff-only feature switch
- keep `AgentPhoneAppUi` as the broad AgentPhone surface gate, and use the new switch only for Works-page inline controls
- restore `/settings/agentphone` as the fallback path when inline controls are off

## Verification
- `pnpm --dir turbo --filter @vm0/app exec vitest run src/views/zero-page/__tests__/zero-works-page.test.tsx src/views/zero-page/__tests__/zero-agentphone-settings-page.test.tsx src/views/conn/__tests__/zero-agentphone-connect-page.test.tsx`
- `pnpm --dir turbo --filter @vm0/app exec vitest run src/views/zero-page/__tests__/onboarding-continue-web.test.tsx`
- `pnpm --dir turbo --filter @vm0/app check-types`
- `pnpm --dir turbo --filter @vm0/core check-types`
- `pnpm --dir turbo --filter @vm0/connectors check-types`
- `pnpm --dir turbo --filter @vm0/app lint`
- pre-commit: prettier, knip, full `turbo run check-types --concurrency=1`