### PR TITLE
feat(api): migrate zero agents create route

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-agents-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-agents-create.test.ts
@@ -1,0 +1,317 @@
+import { randomUUID } from "node:crypto";
+
+import { zeroAgentsMainContract } from "@vm0/api-contracts/contracts/zero-agents";
+import { getInstructionsStorageName } from "@vm0/core/storage-names";
+import {
+  agentComposes,
+  agentComposeVersions,
+} from "@vm0/db/schema/agent-compose";
+import { storages } from "@vm0/db/schema/storage";
+import { zeroAgents } from "@vm0/db/schema/zero-agent";
+import { createStore } from "ccstate";
+import { and, eq } from "drizzle-orm";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { now } from "../../../lib/time";
+import { signSandboxJwtForTests } from "../../auth/tokens";
+import { writeDb$ } from "../../external/db";
+import {
+  createFixtureTracker,
+  createZeroRouteMocks,
+} from "./helpers/zero-route-test";
+import {
+  deleteSkillsForFixture$,
+  seedAgentForInstructions$,
+  seedSkill$,
+  seedSkillsFixture$,
+  type SkillsFixture,
+} from "./helpers/zero-skills";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+const ZERO_AGENT_ID_TEMPLATE = ["$", "{{ vars.ZERO_AGENT_ID }}"].join("");
+const ZERO_TOKEN_TEMPLATE = ["$", "{{ secrets.ZERO_TOKEN }}"].join("");
+
+function authHeaders() {
+  return { authorization: "Bearer clerk-session" };
+}
+
+function agentsClient() {
+  return setupApp({ context })(zeroAgentsMainContract);
+}
+
+function currentSecond(): number {
+  return Math.floor(now() / 1000);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function expectRecord(value: unknown, label: string): Record<string, unknown> {
+  if (!isRecord(value)) {
+    throw new Error(`Expected ${label} to be an object`);
+  }
+  return value;
+}
+
+describe("POST /api/zero/agents", () => {
+  const track = createFixtureTracker<SkillsFixture>((fixture) => {
+    return store.set(deleteSkillsForFixture$, fixture, context.signal);
+  });
+
+  it("returns 401 when the request is unauthenticated", async () => {
+    const response = await accept(
+      agentsClient().create({ headers: {}, body: {} }),
+      [401],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("returns 403 for a zero token without agent:write capability", async () => {
+    const seconds = currentSecond();
+    const token = signSandboxJwtForTests({
+      scope: "zero",
+      userId: `user_${randomUUID()}`,
+      orgId: `org_${randomUUID()}`,
+      runId: `run_${randomUUID()}`,
+      capabilities: ["agent:read"],
+      iat: seconds,
+      exp: seconds + 60,
+    });
+
+    const response = await accept(
+      agentsClient().create({
+        headers: { authorization: `Bearer ${token}` },
+        body: {},
+      }),
+      [403],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Missing required capability: agent:write",
+        code: "FORBIDDEN",
+      },
+    });
+  });
+
+  it("creates agent metadata, compose content, and instructions storage", async () => {
+    const fixture = await track(
+      store.set(seedSkillsFixture$, undefined, context.signal),
+    );
+    await store.set(
+      seedSkill$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        name: "research-notes",
+      },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    context.mocks.s3.send.mockClear();
+    context.mocks.s3.send.mockResolvedValue({});
+
+    const response = await accept(
+      agentsClient().create({
+        headers: authHeaders(),
+        body: {
+          displayName: "Research Agent",
+          description: "Tracks research context",
+          sound: "calm",
+          avatarUrl: "preset:2",
+          customSkills: ["research-notes"],
+        },
+      }),
+      [201],
+    );
+
+    expect(response.body).toMatchObject({
+      ownerId: fixture.userId,
+      displayName: "Research Agent",
+      description: "Tracks research context",
+      sound: "calm",
+      avatarUrl: "preset:2",
+      permissionPolicies: null,
+      customSkills: ["research-notes"],
+      modelProviderId: null,
+      selectedModel: null,
+      preferPersonalProvider: false,
+      visibility: "public",
+    });
+    expect(response.body.agentId).toStrictEqual(expect.any(String));
+
+    const db = store.set(writeDb$);
+    const [agent] = await db
+      .select({
+        id: zeroAgents.id,
+        name: zeroAgents.name,
+        owner: zeroAgents.owner,
+        customSkills: zeroAgents.customSkills,
+        visibility: zeroAgents.visibility,
+      })
+      .from(zeroAgents)
+      .where(eq(zeroAgents.id, response.body.agentId));
+    expect(agent).toStrictEqual({
+      id: response.body.agentId,
+      name: expect.any(String),
+      owner: fixture.userId,
+      customSkills: ["research-notes"],
+      visibility: "public",
+    });
+
+    const [compose] = await db
+      .select({
+        id: agentComposes.id,
+        name: agentComposes.name,
+        headVersionId: agentComposes.headVersionId,
+      })
+      .from(agentComposes)
+      .where(eq(agentComposes.id, response.body.agentId));
+    expect(compose?.id).toBe(response.body.agentId);
+    expect(compose?.name).toBe(agent?.name);
+    expect(compose?.headVersionId).toMatch(/^[a-f0-9]{64}$/);
+
+    const headVersionId = compose?.headVersionId;
+    if (!headVersionId || !compose?.name) {
+      throw new Error("Expected created compose with head version");
+    }
+
+    const [version] = await db
+      .select({ content: agentComposeVersions.content })
+      .from(agentComposeVersions)
+      .where(eq(agentComposeVersions.id, headVersionId));
+    const content = expectRecord(version?.content, "compose content");
+    const agents = expectRecord(content.agents, "compose agents");
+    const storedAgent = expectRecord(agents[compose.name], "stored agent");
+    const environment = expectRecord(
+      storedAgent.environment,
+      "stored agent environment",
+    );
+    expect(storedAgent.framework).toBe("claude-code");
+    expect(storedAgent.instructions).toBe("CLAUDE.md");
+    expect(environment.ZERO_AGENT_ID).toBe(ZERO_AGENT_ID_TEMPLATE);
+    expect(environment.ZERO_TOKEN).toBe(ZERO_TOKEN_TEMPLATE);
+
+    const [instructionsStorage] = await db
+      .select({ headVersionId: storages.headVersionId })
+      .from(storages)
+      .where(
+        and(
+          eq(storages.orgId, fixture.orgId),
+          eq(storages.name, getInstructionsStorageName(compose.name)),
+        ),
+      );
+    expect(instructionsStorage?.headVersionId).toMatch(/^[a-f0-9]{64}$/);
+    expect(context.mocks.s3.send).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns 400 when a requested custom skill does not exist", async () => {
+    const fixture = await track(
+      store.set(seedSkillsFixture$, undefined, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      agentsClient().create({
+        headers: authHeaders(),
+        body: { customSkills: ["missing-skill"] },
+      }),
+      [400],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message:
+          "Custom skill 'missing-skill' not found in this organization. Create it with 'zero skill create' first.",
+        code: "VALIDATION_ERROR",
+      },
+    });
+  });
+
+  it("returns 400 when a built-in connector is requested as a custom skill", async () => {
+    const fixture = await track(
+      store.set(seedSkillsFixture$, undefined, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      agentsClient().create({
+        headers: authHeaders(),
+        body: { customSkills: ["github"] },
+      }),
+      [400],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message:
+          "'github' is a built-in connector, not a custom skill. Enable it via connectors instead.",
+        code: "VALIDATION_ERROR",
+      },
+    });
+  });
+
+  it("returns 403 when private visibility is requested while the feature is disabled", async () => {
+    const fixture = await track(
+      store.set(seedSkillsFixture$, undefined, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      agentsClient().create({
+        headers: authHeaders(),
+        body: { visibility: "private" },
+      }),
+      [403],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Private agents are not available for this account",
+        code: "FORBIDDEN",
+      },
+    });
+  });
+
+  it("returns 409 when the public agent limit has been reached", async () => {
+    const fixture = await track(
+      store.set(seedSkillsFixture$, undefined, context.signal),
+    );
+    for (let i = 0; i < 7; i += 1) {
+      await store.set(
+        seedAgentForInstructions$,
+        {
+          orgId: fixture.orgId,
+          userId: fixture.userId,
+          visibility: "public",
+        },
+        context.signal,
+      );
+    }
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    context.mocks.s3.send.mockClear();
+    context.mocks.s3.send.mockResolvedValue({});
+
+    const response = await accept(
+      agentsClient().create({
+        headers: authHeaders(),
+        body: {},
+      }),
+      [409],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message:
+          "This organization has reached the maximum number of agents (7). Delete an existing agent before creating a new one.",
+        code: "CONFLICT",
+      },
+    });
+  });
+});

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-runs-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-runs-create.test.ts
@@ -191,6 +191,10 @@ const trackModelProviders = createFixtureTracker<{ readonly orgId: string }>(
     );
   },
 );
+const trackVm0ApiKey = createFixtureTracker<string>(async (label) => {
+  const db = store.set(writeDb$);
+  await db.delete(vm0ApiKeys).where(eq(vm0ApiKeys.label, label));
+});
 
 async function fixture(): Promise<UsageInsightFixture> {
   const created = await track(
@@ -262,11 +266,12 @@ async function seedVm0ApiKey(args: {
   readonly apiKey: string;
 }): Promise<void> {
   const db = store.set(writeDb$);
+  const label = await trackVm0ApiKey(Promise.resolve(`test-${randomUUID()}`));
   await db.insert(vm0ApiKeys).values({
     vendor: args.vendor,
     model: args.model,
     apiKey: args.apiKey,
-    label: `test-${randomUUID()}`,
+    label,
   });
 }
 
@@ -1263,6 +1268,11 @@ describe("POST /api/zero/runs", () => {
     await setOrgCredits(fx.orgId, 100);
     await setMemberCredits({ orgId: fx.orgId, userId: fx.userId });
     await seedExpiredCredits({ orgId: fx.orgId, remaining: 100 });
+    await seedVm0ApiKey({
+      vendor: "anthropic",
+      model: "claude-opus-4-6",
+      apiKey: "sk-vm0-managed",
+    });
     await seedDefaultModelProvider({ orgId: fx.orgId, type: "vm0" });
 
     const response = await accept(

--- a/turbo/apps/api/src/signals/routes/zero-agents.ts
+++ b/turbo/apps/api/src/signals/routes/zero-agents.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from "node:crypto";
+
 import { command, computed, type Computed } from "ccstate";
 import { and, count, eq, inArray } from "drizzle-orm";
 import { zeroAgentCustomConnectorsContract } from "@vm0/api-contracts/contracts/zero-agent-custom-connectors";
@@ -28,6 +30,7 @@ import {
   requireAgentPermission,
 } from "../../lib/require-agent-permission";
 import {
+  createServerSideZeroAgentCompose$,
   recomposeAgentIfStale$,
   serverSideZeroAgentCompose$,
 } from "../services/agent-compose.service";
@@ -98,6 +101,12 @@ function validationError(message: string) {
 function publicAgentLimitError() {
   return conflict(
     "This organization has reached the maximum number of agents (7). Delete an existing agent before making this agent public.",
+  );
+}
+
+function publicAgentCreateLimitError() {
+  return conflict(
+    "This organization has reached the maximum number of agents (7). Delete an existing agent before creating a new one.",
   );
 }
 
@@ -401,6 +410,130 @@ function readAgentForResponse(writeDb: Db, orgId: string, agentId: string) {
       return rows[0] ?? null;
     });
 }
+
+const createAgentBody$ = bodyResultOf(zeroAgentsMainContract.create);
+
+const createAgentInner$ = command(async ({ get, set }, signal: AbortSignal) => {
+  const auth = get(organizationAuthContext$);
+  const body = await get(createAgentBody$);
+  signal.throwIfAborted();
+  if (!body.ok) {
+    return body.response;
+  }
+
+  const writeDb = set(writeDb$);
+  const customSkills = body.data.customSkills ?? [];
+  const visibility = body.data.visibility ?? "public";
+  const visibilityError = await privateVisibilityError({
+    get,
+    orgId: auth.orgId,
+    userId: auth.userId,
+    nextVisibility: visibility,
+    signal,
+  });
+  if (visibilityError) {
+    return visibilityError;
+  }
+
+  const customSkillsError = await validateCustomSkills(
+    writeDb,
+    auth.orgId,
+    customSkills,
+  );
+  signal.throwIfAborted();
+  if (customSkillsError) {
+    return customSkillsError;
+  }
+
+  const agentName = randomUUID();
+  const compose = await set(
+    createServerSideZeroAgentCompose$,
+    {
+      userId: auth.userId,
+      orgId: auth.orgId,
+      agentName,
+      instructions: "",
+    },
+    signal,
+  );
+  signal.throwIfAborted();
+
+  const metadata = {
+    displayName: body.data.displayName ?? null,
+    description: body.data.description ?? null,
+    sound: body.data.sound ?? null,
+    avatarUrl: body.data.avatarUrl ?? null,
+    customSkills: [...customSkills],
+    modelProviderId: null,
+    selectedModel: null,
+    preferPersonalProvider: false,
+    visibility,
+  };
+
+  const result = await writeDb.transaction(async (tx) => {
+    await tx
+      .select({ id: zeroAgents.id })
+      .from(zeroAgents)
+      .where(eq(zeroAgents.orgId, auth.orgId))
+      .for("update");
+    signal.throwIfAborted();
+
+    if (visibility === "public") {
+      const [publicAgentCount] = await tx
+        .select({ value: count() })
+        .from(zeroAgents)
+        .where(
+          and(
+            eq(zeroAgents.orgId, auth.orgId),
+            eq(zeroAgents.visibility, "public"),
+          ),
+        );
+      signal.throwIfAborted();
+
+      if ((publicAgentCount?.value ?? 0) >= PUBLIC_AGENT_LIMIT) {
+        return { blocked: true as const };
+      }
+    }
+
+    await tx
+      .insert(zeroAgents)
+      .values({
+        id: compose.composeId,
+        orgId: auth.orgId,
+        name: compose.composeName,
+        owner: auth.userId,
+        ...metadata,
+      })
+      .onConflictDoUpdate({
+        target: [zeroAgents.orgId, zeroAgents.name],
+        set: {
+          ...metadata,
+          updatedAt: nowDate(),
+        },
+      });
+    signal.throwIfAborted();
+
+    return { blocked: false as const };
+  });
+  signal.throwIfAborted();
+
+  if (result.blocked) {
+    return publicAgentCreateLimitError();
+  }
+
+  const agent = await readAgentForResponse(
+    writeDb,
+    auth.orgId,
+    compose.composeId,
+  );
+  signal.throwIfAborted();
+
+  if (!agent) {
+    throw new Error(`Created zero agent not found: ${compose.composeId}`);
+  }
+
+  return { status: 201 as const, body: agentResponse(agent) };
+});
 
 const listAgentsInner$ = computed(async (get) => {
   const auth = get(organizationAuthContext$);
@@ -884,6 +1017,10 @@ const agentDeleteAuth = {
 } as const;
 
 export const zeroAgentsRoutes: readonly RouteEntry[] = [
+  {
+    route: zeroAgentsMainContract.create,
+    handler: authRoute(agentWriteAuth, createAgentInner$),
+  },
   {
     route: zeroAgentsMainContract.list,
     handler: authRoute(agentReadAuth, listAgentsInner$),

--- a/turbo/apps/api/src/signals/services/agent-compose.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-compose.service.ts
@@ -174,6 +174,77 @@ export const recomposeAgentIfStale$ = command(
   },
 );
 
+export const createServerSideZeroAgentCompose$ = command(
+  async (
+    { set },
+    args: {
+      readonly userId: string;
+      readonly orgId: string;
+      readonly agentName: string;
+      readonly instructions?: string;
+    },
+    signal: AbortSignal,
+  ): Promise<{
+    readonly composeId: string;
+    readonly composeName: string;
+    readonly versionId: string;
+  }> => {
+    const content = buildZeroAgentComposeContent(args.agentName);
+
+    if (args.instructions !== undefined) {
+      await set(
+        uploadVolumeServerSide$,
+        {
+          orgId: args.orgId,
+          storageName: getInstructionsStorageName(args.agentName.toLowerCase()),
+          files: instructionFilesForFramework({
+            content: args.instructions,
+            framework: "claude-code",
+          }),
+        },
+        signal,
+      );
+      signal.throwIfAborted();
+    }
+
+    const versionId = computeComposeVersionId(content);
+    const writeDb = set(writeDb$);
+    const [compose] = await writeDb
+      .insert(agentComposes)
+      .values({
+        userId: args.userId,
+        orgId: args.orgId,
+        name: args.agentName,
+      })
+      .returning({ id: agentComposes.id });
+    signal.throwIfAborted();
+
+    if (!compose) {
+      throw new Error("Failed to create zero agent compose");
+    }
+
+    await writeDb.insert(agentComposeVersions).values({
+      id: versionId,
+      composeId: compose.id,
+      content,
+      createdBy: args.userId,
+    });
+    signal.throwIfAborted();
+
+    await writeDb
+      .update(agentComposes)
+      .set({ headVersionId: versionId, updatedAt: nowDate() })
+      .where(eq(agentComposes.id, compose.id));
+    signal.throwIfAborted();
+
+    return {
+      composeId: compose.id,
+      composeName: args.agentName,
+      versionId,
+    };
+  },
+);
+
 export const serverSideZeroAgentCompose$ = command(
   async (
     { set },


### PR DESCRIPTION
## Summary
- Register `POST /api/zero/agents` in the API app instead of relying on the web fallback.
- Add server-side zero-agent compose creation with instructions storage parity.
- Cover auth, custom skills, visibility, public limit, compose content, and instructions storage in API integration tests.
- Isolate VM0 API key fixtures in zero-runs tests so VM0 managed key rows do not leak into downstream tests.

Fixes #12868

## Tests
- `pnpm format`
- `pnpm turbo run lint`
- `pnpm check-types`
- `pnpm knip`
- `pnpm -F api lint`
- `pnpm -F api exec vitest src/signals/routes/__tests__/zero-agents-create.test.ts src/signals/routes/__tests__/zero-runs-create.test.ts src/signals/routes/__tests__/internal-callbacks-schedule.test.ts`
- `pnpm -F @vm0/app exec vitest src/views/conn/__tests__/add-connection-dialog.test.tsx src/views/network-insights/__tests__/network-insights-page-interaction.test.tsx src/views/org/__tests__/org-misc-components.test.tsx src/views/zero-page/__tests__/chat-sidebar.test.tsx src/views/zero-page/__tests__/context-network-content.test.tsx src/views/zero-page/__tests__/org-billing-tab.test.tsx src/views/zero-page/__tests__/org-provider-dialog.test.tsx src/views/zero-page/__tests__/schedule-dialog.test.tsx src/views/zero-page/__tests__/zero-chat-page.test.tsx src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx src/views/zero-page/__tests__/zero-ideation-page.test.tsx src/views/zero-page/__tests__/zero-schedule-detail-page-interaction.test.tsx src/views/zero-page/__tests__/zero-schedule-page.test.tsx`
- `pnpm -F web exec vitest app/api/cron/aggregate-insights/__tests__/route.test.ts`

Note: before the rebase, `pnpm vitest` completed locally with 30 unrelated 5s timeouts across existing platform/web tests. The timed-out files were rerun in scoped workspace commands above and passed.