### PR TITLE
feat(api): migrate third-party webhooks

### DIFF
--- a/turbo/apps/api/src/__tests__/mocks.ts
+++ b/turbo/apps/api/src/__tests__/mocks.ts
@@ -7,6 +7,7 @@ import { mockStripeClient } from "../signals/external/stripe-client";
 type AsyncMock = Mock<(...args: unknown[]) => Promise<unknown>>;
 type BooleanMock = Mock<(...args: unknown[]) => boolean>;
 type SyncMock = Mock<(...args: unknown[]) => void>;
+type UnknownMock = Mock<(...args: unknown[]) => unknown>;
 
 export interface ApiTestMocks {
   readonly axiom: {
@@ -27,6 +28,7 @@ export interface ApiTestMocks {
   };
   readonly clerk: {
     readonly authenticateRequest: AsyncMock;
+    readonly verifyWebhook: AsyncMock;
     readonly organizations: {
       readonly createOrganizationDomain: AsyncMock;
       readonly deleteOrganizationDomain: AsyncMock;
@@ -110,6 +112,10 @@ export interface ApiTestMocks {
     readonly subscriptions: {
       readonly retrieve: AsyncMock;
       readonly update: AsyncMock;
+      readonly cancel: AsyncMock;
+    };
+    readonly webhooks: {
+      readonly constructEvent: UnknownMock;
     };
     readonly checkout: {
       readonly sessions: {
@@ -159,6 +165,7 @@ const apiTestMocks: ApiTestMocks = vi.hoisted((): ApiTestMocks => {
 
   const clerk = {
     authenticateRequest: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
+    verifyWebhook: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
     organizations: {
       createOrganizationDomain:
         vi.fn<(...args: unknown[]) => Promise<unknown>>(),
@@ -246,6 +253,10 @@ const apiTestMocks: ApiTestMocks = vi.hoisted((): ApiTestMocks => {
     subscriptions: {
       retrieve: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
       update: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
+      cancel: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
+    },
+    webhooks: {
+      constructEvent: vi.fn<(...args: unknown[]) => unknown>(),
     },
     checkout: {
       sessions: {
@@ -400,6 +411,14 @@ vi.mock("@clerk/backend", () => {
   };
 });
 
+vi.mock("@clerk/backend/webhooks", () => {
+  return {
+    verifyWebhook: (...args: unknown[]): Promise<unknown> => {
+      return apiTestMocks.clerk.verifyWebhook(...args);
+    },
+  };
+});
+
 vi.mock("@google/genai", () => {
   class GoogleGenAI {
     readonly models = {
@@ -470,6 +489,10 @@ vi.mock("stripe", async (importOriginal) => {
         subscriptions: {
           retrieve: apiTestMocks.stripe.subscriptions.retrieve,
           update: apiTestMocks.stripe.subscriptions.update,
+          cancel: apiTestMocks.stripe.subscriptions.cancel,
+        },
+        webhooks: {
+          constructEvent: apiTestMocks.stripe.webhooks.constructEvent,
         },
         checkout: {
           sessions: {
@@ -635,6 +658,7 @@ export function resetApiTestMocks(): void {
   apiTestMocks.axiomLogging.error.mockReset();
   apiTestMocks.axiomLogging.flush.mockReset();
   apiTestMocks.clerk.authenticateRequest.mockReset();
+  apiTestMocks.clerk.verifyWebhook.mockReset();
   apiTestMocks.clerk.organizations.createOrganizationDomain.mockReset();
   apiTestMocks.clerk.organizations.deleteOrganizationDomain.mockReset();
   apiTestMocks.clerk.organizations.createOrganizationInvitation.mockReset();
@@ -682,6 +706,8 @@ export function resetApiTestMocks(): void {
   apiTestMocks.stripe.customers.create.mockReset();
   apiTestMocks.stripe.subscriptions.retrieve.mockReset();
   apiTestMocks.stripe.subscriptions.update.mockReset();
+  apiTestMocks.stripe.subscriptions.cancel.mockReset();
+  apiTestMocks.stripe.webhooks.constructEvent.mockReset();
   apiTestMocks.stripe.checkout.sessions.create.mockReset();
   apiTestMocks.stripe.checkout.sessions.retrieve.mockReset();
   apiTestMocks.stripe.checkout.sessions.expire.mockReset();

--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -45,6 +45,9 @@ import { modelStatsRoutes } from "./routes/model-stats";
 import { runnersRoutes } from "./routes/runners";
 import { usageRoutes } from "./routes/usage";
 import { userExportRoutes } from "./routes/user-export";
+import { webhooksClerkRoutes } from "./routes/webhooks-clerk";
+import { webhooksGithubRoutes } from "./routes/webhooks-github";
+import { webhooksStripeRoutes } from "./routes/webhooks-stripe";
 import { zeroAgentInstructionsRoutes } from "./routes/zero-agent-instructions";
 import { zeroAgentsRoutes } from "./routes/zero-agents";
 import { zeroApiKeysRoutes } from "./routes/zero-api-keys";
@@ -173,6 +176,9 @@ export const ROUTES: readonly RouteEntry[] = [
   ...logsSearchRoutes,
   ...usageRoutes,
   ...userExportRoutes,
+  ...webhooksClerkRoutes,
+  ...webhooksGithubRoutes,
+  ...webhooksStripeRoutes,
   ...agentCheckpointsRoutes,
   ...agentComposesReadRoutes,
   ...agentComposesByIdRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-third-party.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-third-party.test.ts
@@ -16,6 +16,7 @@ import { userCache } from "@vm0/db/schema/user-cache";
 import { users } from "@vm0/db/schema/user";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
+import { storages } from "@vm0/db/schema/storage";
 import { command, createStore } from "ccstate";
 import { and, eq, inArray } from "drizzle-orm";
 import { describe, expect, it } from "vitest";
@@ -274,6 +275,7 @@ const deleteClerkFixture$ = command(
     _signal: AbortSignal,
   ): Promise<void> => {
     const db = set(writeDb$);
+    await db.delete(storages).where(eq(storages.userId, fixture.userId));
     await db.delete(userCache).where(eq(userCache.userId, fixture.userId));
     await db.delete(users).where(eq(users.id, fixture.userId));
   },
@@ -560,5 +562,49 @@ describe("POST /api/webhooks/clerk", () => {
       .where(eq(users.id, fixture.userId));
     expect(cacheRows).toHaveLength(0);
     expect(userRows).toHaveLength(0);
+  });
+
+  it("continues user deletion cleanup when user S3 cleanup fails", async () => {
+    const fixture = await trackClerk(
+      store.set(seedClerkFixture$, undefined, context.signal),
+    );
+    const db = store.set(writeDb$);
+    await db.insert(storages).values({
+      userId: fixture.userId,
+      orgId: `org_${randomUUID()}`,
+      name: "memory",
+      type: "memory",
+      s3Prefix: `users/${fixture.userId}/memory`,
+    });
+    context.mocks.clerk.verifyWebhook.mockResolvedValue({
+      type: "user.deleted",
+      data: { id: fixture.userId },
+    });
+    context.mocks.s3.send.mockRejectedValueOnce(new Error("R2 unavailable"));
+
+    const response = await postRaw({
+      path: "/api/webhooks/clerk",
+      body: "{}",
+    });
+    await clearAllDetached();
+
+    expect(response.status).toBe(200);
+    expect(response.body).toBe("OK");
+
+    const cacheRows = await db
+      .select({ userId: userCache.userId })
+      .from(userCache)
+      .where(eq(userCache.userId, fixture.userId));
+    const userRows = await db
+      .select({ id: users.id })
+      .from(users)
+      .where(eq(users.id, fixture.userId));
+    const storageRows = await db
+      .select({ id: storages.id })
+      .from(storages)
+      .where(eq(storages.userId, fixture.userId));
+    expect(cacheRows).toHaveLength(0);
+    expect(userRows).toHaveLength(0);
+    expect(storageRows).toHaveLength(0);
   });
 });

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-third-party.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-third-party.test.ts
@@ -1,0 +1,564 @@
+import { createHmac, randomUUID } from "node:crypto";
+
+import {
+  agentComposes,
+  agentComposeVersions,
+} from "@vm0/db/schema/agent-compose";
+import { agentRunCallbacks } from "@vm0/db/schema/agent-run-callback";
+import { agentRuns } from "@vm0/db/schema/agent-run";
+import { creditExpiresRecord } from "@vm0/db/schema/credit-expires-record";
+import { githubInstallations } from "@vm0/db/schema/github-installation";
+import { githubUserLinks } from "@vm0/db/schema/github-user-link";
+import { orgMembersMetadata } from "@vm0/db/schema/org-members-metadata";
+import { orgMetadata } from "@vm0/db/schema/org-metadata";
+import { runnerJobQueue } from "@vm0/db/schema/runner-job-queue";
+import { userCache } from "@vm0/db/schema/user-cache";
+import { users } from "@vm0/db/schema/user";
+import { zeroAgents } from "@vm0/db/schema/zero-agent";
+import { zeroRuns } from "@vm0/db/schema/zero-run";
+import { command, createStore } from "ccstate";
+import { and, eq, inArray } from "drizzle-orm";
+import { describe, expect, it } from "vitest";
+
+import { createApp } from "../../../app-factory";
+import { testContext } from "../../../__tests__/test-helpers";
+import { mockEnv, mockOptionalEnv } from "../../../lib/env";
+import { writeDb$ } from "../../external/db";
+import { clearAllDetached } from "../../utils";
+import {
+  createFixtureTracker,
+  createZeroRouteMocks,
+} from "./helpers/zero-route-test";
+import {
+  deleteUsageInsightFixture$,
+  seedUsageInsightFixture$,
+  type UsageInsightFixture,
+} from "./helpers/zero-usage-insight";
+
+const context = testContext();
+const store = createStore();
+createZeroRouteMocks(context);
+
+interface AppResponse {
+  readonly status: number;
+  readonly body: unknown;
+  readonly headers: Headers;
+}
+
+interface GitHubWebhookFixture extends UsageInsightFixture {
+  readonly composeId: string;
+  readonly installationDbId: string;
+}
+
+interface StripeFixture {
+  readonly orgId: string;
+  readonly userId: string;
+}
+
+interface ClerkFixture {
+  readonly userId: string;
+}
+
+function signGithub(secret: string, body: string): string {
+  return `sha256=${createHmac("sha256", secret).update(body).digest("hex")}`;
+}
+
+async function postRaw(args: {
+  readonly path: string;
+  readonly body: string;
+  readonly headers?: HeadersInit;
+}): Promise<AppResponse> {
+  const app = createApp({ signal: context.signal });
+  const response = await app.request(args.path, {
+    method: "POST",
+    headers: args.headers,
+    body: args.body,
+  });
+  const contentType = response.headers.get("content-type") ?? "";
+  const body = contentType.includes("application/json")
+    ? await response.json()
+    : await response.text();
+  return { status: response.status, body, headers: response.headers };
+}
+
+const deleteGitHubFixture$ = command(
+  async (
+    { set },
+    fixture: GitHubWebhookFixture,
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const db = set(writeDb$);
+    const runRows = await db
+      .select({ id: agentRuns.id })
+      .from(agentRuns)
+      .where(
+        and(
+          eq(agentRuns.orgId, fixture.orgId),
+          eq(agentRuns.userId, fixture.userId),
+        ),
+      );
+    signal.throwIfAborted();
+    const runIds = runRows.map((row) => {
+      return row.id;
+    });
+    if (runIds.length > 0) {
+      await db
+        .delete(agentRunCallbacks)
+        .where(inArray(agentRunCallbacks.runId, runIds));
+      signal.throwIfAborted();
+      await db
+        .delete(runnerJobQueue)
+        .where(inArray(runnerJobQueue.runId, runIds));
+      signal.throwIfAborted();
+      await db.delete(zeroRuns).where(inArray(zeroRuns.id, runIds));
+      signal.throwIfAborted();
+      await db.delete(agentRuns).where(inArray(agentRuns.id, runIds));
+      signal.throwIfAborted();
+    }
+    await db
+      .delete(githubUserLinks)
+      .where(eq(githubUserLinks.installationId, fixture.installationDbId));
+    signal.throwIfAborted();
+    await db
+      .delete(githubInstallations)
+      .where(eq(githubInstallations.id, fixture.installationDbId));
+    signal.throwIfAborted();
+    await set(deleteUsageInsightFixture$, fixture, signal);
+    signal.throwIfAborted();
+  },
+);
+
+const seedGitHubWebhookFixture$ = command(
+  async (
+    { set },
+    _input: void,
+    signal: AbortSignal,
+  ): Promise<GitHubWebhookFixture> => {
+    const db = set(writeDb$);
+    const fixture = await set(seedUsageInsightFixture$, undefined, signal);
+    signal.throwIfAborted();
+    const name = `github-webhook-${randomUUID().slice(0, 8)}`;
+    const versionId = randomUUID();
+
+    const [compose] = await db
+      .insert(agentComposes)
+      .values({ userId: fixture.userId, orgId: fixture.orgId, name })
+      .returning({ id: agentComposes.id });
+    signal.throwIfAborted();
+    if (!compose) {
+      throw new Error("compose insert returned no row");
+    }
+
+    await db.insert(agentComposeVersions).values({
+      id: versionId,
+      composeId: compose.id,
+      createdBy: fixture.userId,
+      content: {
+        version: "1.0",
+        agents: {
+          [name]: {
+            framework: "claude-code",
+            environment: { ANTHROPIC_API_KEY: "test-key" },
+          },
+        },
+      },
+    });
+    signal.throwIfAborted();
+    await db
+      .update(agentComposes)
+      .set({ headVersionId: versionId })
+      .where(eq(agentComposes.id, compose.id));
+    signal.throwIfAborted();
+    await db.insert(zeroAgents).values({
+      id: compose.id,
+      orgId: fixture.orgId,
+      owner: fixture.userId,
+      name,
+      visibility: "public",
+      displayName: "GitHub Agent",
+      customSkills: [],
+    });
+    signal.throwIfAborted();
+    await db.insert(orgMetadata).values({
+      orgId: fixture.orgId,
+      credits: 100_000,
+      tier: "pro",
+    });
+    signal.throwIfAborted();
+    await db.insert(userCache).values({
+      userId: fixture.userId,
+      email: "github-webhook@example.com",
+      name: "GitHub User",
+    });
+    signal.throwIfAborted();
+    await db.insert(orgMembersMetadata).values({
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      timezone: "UTC",
+      creditEnabled: true,
+    });
+    signal.throwIfAborted();
+
+    const [installation] = await db
+      .insert(githubInstallations)
+      .values({
+        installationId: "123456",
+        status: "active",
+        defaultComposeId: compose.id,
+      })
+      .returning({ id: githubInstallations.id });
+    signal.throwIfAborted();
+    if (!installation) {
+      throw new Error("installation insert returned no row");
+    }
+
+    await db.insert(githubUserLinks).values({
+      githubUserId: "98765",
+      installationId: installation.id,
+      vm0UserId: fixture.userId,
+    });
+    signal.throwIfAborted();
+
+    return {
+      ...fixture,
+      composeId: compose.id,
+      installationDbId: installation.id,
+    };
+  },
+);
+
+const deleteStripeFixture$ = command(
+  async (
+    { set },
+    fixture: StripeFixture,
+    _signal: AbortSignal,
+  ): Promise<void> => {
+    const db = set(writeDb$);
+    await db
+      .delete(creditExpiresRecord)
+      .where(eq(creditExpiresRecord.orgId, fixture.orgId));
+    await db
+      .delete(orgMembersMetadata)
+      .where(eq(orgMembersMetadata.orgId, fixture.orgId));
+    await db.delete(orgMetadata).where(eq(orgMetadata.orgId, fixture.orgId));
+  },
+);
+
+const seedStripeFixture$ = command(
+  async (
+    { set },
+    _input: void,
+    _signal: AbortSignal,
+  ): Promise<StripeFixture> => {
+    const db = set(writeDb$);
+    const orgId = `org_${randomUUID()}`;
+    const userId = `user_${randomUUID()}`;
+    await db.insert(orgMetadata).values({
+      orgId,
+      credits: 0,
+      stripeCustomerId: "cus_test",
+    });
+    await db.insert(orgMembersMetadata).values({
+      orgId,
+      userId,
+      creditEnabled: false,
+    });
+    return { orgId, userId };
+  },
+);
+
+const deleteClerkFixture$ = command(
+  async (
+    { set },
+    fixture: ClerkFixture,
+    _signal: AbortSignal,
+  ): Promise<void> => {
+    const db = set(writeDb$);
+    await db.delete(userCache).where(eq(userCache.userId, fixture.userId));
+    await db.delete(users).where(eq(users.id, fixture.userId));
+  },
+);
+
+const seedClerkFixture$ = command(
+  async (
+    { set },
+    _input: void,
+    _signal: AbortSignal,
+  ): Promise<ClerkFixture> => {
+    const db = set(writeDb$);
+    const userId = `user_${randomUUID()}`;
+    await db.insert(users).values({ id: userId });
+    await db.insert(userCache).values({
+      userId,
+      email: "deleted-user@example.com",
+      name: "Deleted User",
+    });
+    return { userId };
+  },
+);
+
+const trackGitHub = createFixtureTracker<GitHubWebhookFixture>((fixture) => {
+  return store.set(deleteGitHubFixture$, fixture, context.signal);
+});
+const trackStripe = createFixtureTracker<StripeFixture>((fixture) => {
+  return store.set(deleteStripeFixture$, fixture, context.signal);
+});
+const trackClerk = createFixtureTracker<ClerkFixture>((fixture) => {
+  return store.set(deleteClerkFixture$, fixture, context.signal);
+});
+
+describe("POST /api/webhooks/github", () => {
+  it("returns 503 when GitHub webhook secret is not configured", async () => {
+    const response = await postRaw({
+      path: "/api/webhooks/github",
+      body: "{}",
+    });
+
+    expect(response.status).toBe(503);
+    expect(response.body).toStrictEqual({
+      error: "GitHub App integration is not configured",
+    });
+  });
+
+  it("rejects invalid GitHub signatures", async () => {
+    mockOptionalEnv("GITHUB_APP_WEBHOOK_SECRET", "github-secret");
+    const response = await postRaw({
+      path: "/api/webhooks/github",
+      body: "{}",
+      headers: {
+        "x-hub-signature-256": "sha256=bad",
+        "x-github-event": "ping",
+        "x-github-delivery": "delivery-1",
+      },
+    });
+
+    expect(response.status).toBe(401);
+    expect(response.body).toStrictEqual({ error: "Invalid signature" });
+  });
+
+  it("responds to GitHub ping", async () => {
+    mockOptionalEnv("GITHUB_APP_WEBHOOK_SECRET", "github-secret");
+    const body = JSON.stringify({ zen: "testing" });
+
+    const response = await postRaw({
+      path: "/api/webhooks/github",
+      body,
+      headers: {
+        "x-hub-signature-256": signGithub("github-secret", body),
+        "x-github-event": "ping",
+        "x-github-delivery": "delivery-1",
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toStrictEqual({ message: "pong" });
+  });
+
+  it("dispatches GitHub issue comments through API-native run creation", async () => {
+    const fixture = await trackGitHub(
+      store.set(seedGitHubWebhookFixture$, undefined, context.signal),
+    );
+    mockOptionalEnv("GITHUB_APP_WEBHOOK_SECRET", "github-secret");
+    mockOptionalEnv("GITHUB_APP_SLUG", "vm0-agent");
+    mockOptionalEnv("RUNNER_DEFAULT_GROUP", "vm0/test");
+    context.mocks.s3.send.mockResolvedValue({});
+
+    const body = JSON.stringify({
+      action: "created",
+      issue: {
+        number: 7,
+        title: "Investigate API route",
+        body: "Move the route to apps/api",
+        labels: [],
+        user: { id: 123, login: "reporter", type: "User" },
+      },
+      comment: {
+        id: 77,
+        body: "@vm0-agent[bot] please handle this",
+        user: { id: 98_765, login: "linked-user", type: "User" },
+      },
+      repository: { full_name: "vm0-ai/vm0" },
+      installation: { id: 123_456 },
+      sender: { id: 98_765, login: "linked-user", type: "User" },
+    });
+
+    const response = await postRaw({
+      path: "/api/webhooks/github",
+      body,
+      headers: {
+        "x-hub-signature-256": signGithub("github-secret", body),
+        "x-github-event": "issue_comment",
+        "x-github-delivery": "delivery-2",
+      },
+    });
+    await clearAllDetached();
+
+    expect(response.status).toBe(200);
+    expect(response.body).toBe("OK");
+
+    const db = store.set(writeDb$);
+    const runs = await db
+      .select({
+        id: agentRuns.id,
+        prompt: agentRuns.prompt,
+        triggerSource: zeroRuns.triggerSource,
+      })
+      .from(agentRuns)
+      .innerJoin(zeroRuns, eq(zeroRuns.id, agentRuns.id))
+      .where(
+        and(
+          eq(agentRuns.orgId, fixture.orgId),
+          eq(agentRuns.userId, fixture.userId),
+        ),
+      );
+
+    expect(runs).toHaveLength(1);
+    expect(runs[0]?.prompt).toBe("@vm0-agent[bot] please handle this");
+    expect(runs[0]?.triggerSource).toBe("github");
+
+    const callbacks = await db
+      .select({ id: agentRunCallbacks.id })
+      .from(agentRunCallbacks)
+      .where(eq(agentRunCallbacks.runId, runs[0]?.id ?? ""));
+    expect(callbacks).toHaveLength(1);
+  });
+});
+
+describe("POST /api/webhooks/stripe", () => {
+  it("returns 503 when Stripe webhook secret is not configured", async () => {
+    const response = await postRaw({
+      path: "/api/webhooks/stripe",
+      body: "{}",
+    });
+
+    expect(response.status).toBe(503);
+    expect(response.body).toStrictEqual({
+      error: "Stripe billing is not configured",
+    });
+  });
+
+  it("rejects invalid Stripe signatures", async () => {
+    mockOptionalEnv("STRIPE_WEBHOOK_SECRET", "stripe-secret");
+    context.mocks.stripe.webhooks.constructEvent.mockImplementation(() => {
+      throw new Error("bad signature");
+    });
+
+    const response = await postRaw({
+      path: "/api/webhooks/stripe",
+      body: "{}",
+      headers: { "stripe-signature": "bad" },
+    });
+
+    expect(response.status).toBe(401);
+    expect(response.body).toStrictEqual({
+      error: "Invalid webhook signature",
+    });
+  });
+
+  it("updates subscription metadata from checkout completion", async () => {
+    const fixture = await trackStripe(
+      store.set(seedStripeFixture$, undefined, context.signal),
+    );
+    mockOptionalEnv("STRIPE_WEBHOOK_SECRET", "stripe-secret");
+    mockEnv(
+      "ZERO_PRICE",
+      JSON.stringify({ pro: ["price_pro"], team: ["price_team"] }),
+    );
+    context.mocks.stripe.webhooks.constructEvent.mockReturnValue({
+      id: "evt_checkout",
+      type: "checkout.session.completed",
+      data: {
+        object: {
+          id: "cs_test",
+          subscription: "sub_test",
+          customer: "cus_test",
+          metadata: null,
+        },
+      },
+    });
+    context.mocks.stripe.subscriptions.retrieve.mockResolvedValue({
+      id: "sub_test",
+      status: "active",
+      items: {
+        data: [
+          {
+            price: { id: "price_pro" },
+            current_period_end: 1_800_000_000,
+          },
+        ],
+      },
+    });
+
+    const response = await postRaw({
+      path: "/api/webhooks/stripe",
+      body: "{}",
+      headers: { "stripe-signature": "valid" },
+    });
+
+    expect(response.status).toBe(200);
+    const db = store.set(writeDb$);
+    const [row] = await db
+      .select({
+        tier: orgMetadata.tier,
+        stripeSubscriptionId: orgMetadata.stripeSubscriptionId,
+        subscriptionStatus: orgMetadata.subscriptionStatus,
+      })
+      .from(orgMetadata)
+      .where(eq(orgMetadata.orgId, fixture.orgId));
+    expect(row).toStrictEqual({
+      tier: "pro",
+      stripeSubscriptionId: "sub_test",
+      subscriptionStatus: "active",
+    });
+  });
+});
+
+describe("POST /api/webhooks/clerk", () => {
+  it("rejects invalid Clerk signatures", async () => {
+    context.mocks.clerk.verifyWebhook.mockRejectedValue(
+      new Error("invalid signature"),
+    );
+
+    const response = await postRaw({
+      path: "/api/webhooks/clerk",
+      body: "{}",
+    });
+
+    expect(response.status).toBe(401);
+    expect(response.body).toStrictEqual({
+      error: "Invalid webhook signature",
+    });
+  });
+
+  it("runs user deletion cleanup after a Clerk user.deleted event", async () => {
+    const fixture = await trackClerk(
+      store.set(seedClerkFixture$, undefined, context.signal),
+    );
+    context.mocks.clerk.verifyWebhook.mockResolvedValue({
+      type: "user.deleted",
+      data: { id: fixture.userId },
+    });
+    context.mocks.s3.send.mockResolvedValue({});
+
+    const response = await postRaw({
+      path: "/api/webhooks/clerk",
+      body: "{}",
+    });
+    await clearAllDetached();
+
+    expect(response.status).toBe(200);
+    expect(response.body).toBe("OK");
+
+    const db = store.set(writeDb$);
+    const cacheRows = await db
+      .select({ userId: userCache.userId })
+      .from(userCache)
+      .where(eq(userCache.userId, fixture.userId));
+    const userRows = await db
+      .select({ id: users.id })
+      .from(users)
+      .where(eq(users.id, fixture.userId));
+    expect(cacheRows).toHaveLength(0);
+    expect(userRows).toHaveLength(0);
+  });
+});

--- a/turbo/apps/api/src/signals/routes/webhooks-clerk.ts
+++ b/turbo/apps/api/src/signals/routes/webhooks-clerk.ts
@@ -1,0 +1,99 @@
+import { verifyWebhook } from "@clerk/backend/webhooks";
+import { webhookClerkContract } from "@vm0/api-contracts/contracts/webhooks";
+import { command } from "ccstate";
+
+import { optionalEnv } from "../../lib/env";
+import { logger } from "../../lib/log";
+import { request$ } from "../context/hono";
+import { waitUntil } from "../context/wait-until";
+import type { RouteEntry } from "../route";
+import { safeAsync } from "../utils";
+import {
+  cleanupClerkDeletedOrg$,
+  cleanupClerkDeletedUser$,
+} from "../services/webhooks-clerk-cleanup.service";
+
+const L = logger("WebhookClerkRoute");
+
+function jsonError(message: string, status: 401): Response {
+  return Response.json({ error: message }, { status });
+}
+
+function eventDataId(data: unknown): string | undefined {
+  if (
+    typeof data === "object" &&
+    data !== null &&
+    "id" in data &&
+    typeof data.id === "string"
+  ) {
+    return data.id;
+  }
+  return undefined;
+}
+
+const postClerkWebhook$ = command(
+  async ({ get, set }, signal: AbortSignal): Promise<Response> => {
+    const request = get(request$).raw;
+    const signingSecret = optionalEnv("CLERK_WEBHOOK_SIGNING_SECRET");
+
+    const eventResult = await safeAsync(() => {
+      return verifyWebhook(request.clone(), { signingSecret });
+    });
+    signal.throwIfAborted();
+    if ("error" in eventResult) {
+      return jsonError("Invalid webhook signature", 401);
+    }
+
+    const event = eventResult.ok;
+    L.debug("clerk webhook received", { type: event.type });
+
+    if (event.type === "organization.deleted") {
+      const orgId = eventDataId(event.data);
+      if (!orgId) {
+        L.error("organization.deleted event missing org ID", {
+          data: event.data,
+        });
+        return new Response("OK", { status: 200 });
+      }
+
+      waitUntil(
+        set(cleanupClerkDeletedOrg$, orgId, signal).catch((error: unknown) => {
+          L.error("organization.deleted cleanup failed", { orgId, error });
+        }),
+      );
+      return new Response("OK", { status: 200 });
+    }
+
+    if (event.type === "user.deleted") {
+      const userId = eventDataId(event.data);
+      if (!userId) {
+        L.error("user.deleted event missing user ID", { data: event.data });
+        return new Response("OK", { status: 200 });
+      }
+
+      waitUntil(
+        set(cleanupClerkDeletedUser$, userId, signal).catch(
+          (error: unknown) => {
+            L.error("user.deleted cleanup failed", { userId, error });
+          },
+        ),
+      );
+      return new Response("OK", { status: 200 });
+    }
+
+    if (event.type === "organizationMembership.deleted") {
+      L.debug("organizationMembership.deleted received");
+      return new Response("OK", { status: 200 });
+    }
+
+    L.debug("ignoring unhandled Clerk event", { type: event.type });
+    return new Response("OK", { status: 200 });
+  },
+);
+
+export const webhooksClerkRoutes: readonly RouteEntry[] = [
+  {
+    route: webhookClerkContract.post,
+    handler: postClerkWebhook$,
+  },
+];

--- a/turbo/apps/api/src/signals/routes/webhooks-github.ts
+++ b/turbo/apps/api/src/signals/routes/webhooks-github.ts
@@ -1,0 +1,170 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+import { command } from "ccstate";
+import { webhookGithubContract } from "@vm0/api-contracts/contracts/webhooks";
+
+import { optionalEnv } from "../../lib/env";
+import { logger } from "../../lib/log";
+import type { RouteEntry } from "../route";
+import { request$ } from "../context/hono";
+import { waitUntil } from "../context/wait-until";
+import { now } from "../external/time";
+import { safeAsync, safeJsonParse } from "../utils";
+import {
+  gitHubInstallationEventSchema,
+  gitHubIssueCommentEventSchema,
+  gitHubIssuesEventSchema,
+  handleGithubInstallationEvent$,
+  handleGithubIssueCommentEvent$,
+  handleGithubIssuesEvent$,
+} from "../services/webhooks-github.service";
+
+const L = logger("WebhookGithubRoute");
+
+interface GithubWebhookHeaders {
+  readonly signature: string;
+  readonly event: string;
+  readonly deliveryId: string;
+}
+
+function jsonError(message: string, status: 400 | 401 | 503): Response {
+  return Response.json({ error: message }, { status });
+}
+
+function githubWebhookHeaders(headers: Headers): GithubWebhookHeaders | null {
+  const signature = headers.get("x-hub-signature-256");
+  const event = headers.get("x-github-event");
+  const deliveryId = headers.get("x-github-delivery");
+  return signature && event && deliveryId
+    ? { signature, event, deliveryId }
+    : null;
+}
+
+async function verifyGitHubWebhookSignature(args: {
+  readonly secret: string;
+  readonly signature: string;
+  readonly body: string;
+}): Promise<boolean> {
+  const expected = `sha256=${createHmac("sha256", args.secret)
+    .update(args.body)
+    .digest("hex")}`;
+
+  const result = await safeAsync(() => {
+    return Promise.resolve(
+      timingSafeEqual(Buffer.from(args.signature), Buffer.from(expected)),
+    );
+  });
+  return "ok" in result ? result.ok : false;
+}
+
+const postGithubWebhook$ = command(
+  async ({ get, set }, signal: AbortSignal): Promise<Response> => {
+    const apiStartTime = now();
+    const webhookSecret = optionalEnv("GITHUB_APP_WEBHOOK_SECRET");
+    const appSlug = optionalEnv("GITHUB_APP_SLUG");
+
+    if (!webhookSecret) {
+      return jsonError("GitHub App integration is not configured", 503);
+    }
+
+    const request = get(request$);
+    const headers = githubWebhookHeaders(request.raw.headers);
+    if (!headers) {
+      return jsonError("Missing GitHub webhook headers", 401);
+    }
+
+    const body = await request.text();
+    signal.throwIfAborted();
+
+    const signatureVerified = await verifyGitHubWebhookSignature({
+      secret: webhookSecret,
+      signature: headers.signature,
+      body,
+    });
+    signal.throwIfAborted();
+
+    if (!signatureVerified) {
+      return jsonError("Invalid signature", 401);
+    }
+
+    const payload = safeJsonParse(body);
+    if (
+      typeof payload !== "object" ||
+      payload === null ||
+      Array.isArray(payload)
+    ) {
+      return jsonError("Invalid JSON payload", 400);
+    }
+
+    if (headers.event === "ping") {
+      return Response.json({ message: "pong" });
+    }
+
+    if (headers.event === "issues") {
+      const parsed = gitHubIssuesEventSchema.safeParse(payload);
+      if (!parsed.success) {
+        L.error("Invalid issues event payload", { error: parsed.error });
+        return jsonError("Invalid payload structure", 400);
+      }
+
+      waitUntil(
+        set(
+          handleGithubIssuesEvent$,
+          { payload: parsed.data, appSlug, apiStartTime },
+          signal,
+        ).catch((error: unknown) => {
+          L.error("Error handling issues event", { error });
+        }),
+      );
+      return new Response("OK", { status: 200 });
+    }
+
+    if (headers.event === "issue_comment") {
+      const parsed = gitHubIssueCommentEventSchema.safeParse(payload);
+      if (!parsed.success) {
+        L.error("Invalid issue_comment event payload", {
+          error: parsed.error,
+        });
+        return jsonError("Invalid payload structure", 400);
+      }
+
+      waitUntil(
+        set(
+          handleGithubIssueCommentEvent$,
+          { payload: parsed.data, appSlug, apiStartTime },
+          signal,
+        ).catch((error: unknown) => {
+          L.error("Error handling issue_comment event", { error });
+        }),
+      );
+      return new Response("OK", { status: 200 });
+    }
+
+    if (headers.event === "installation") {
+      const parsed = gitHubInstallationEventSchema.safeParse(payload);
+      if (!parsed.success) {
+        L.error("Invalid installation event payload", { error: parsed.error });
+        return jsonError("Invalid payload structure", 400);
+      }
+
+      waitUntil(
+        set(handleGithubInstallationEvent$, parsed.data, signal).catch(
+          (error: unknown) => {
+            L.error("Error handling installation event", { error });
+          },
+        ),
+      );
+      return new Response("OK", { status: 200 });
+    }
+
+    L.debug("Ignoring unhandled GitHub event", { event: headers.event });
+    return new Response("OK", { status: 200 });
+  },
+);
+
+export const webhooksGithubRoutes: readonly RouteEntry[] = [
+  {
+    route: webhookGithubContract.post,
+    handler: postGithubWebhook$,
+  },
+];

--- a/turbo/apps/api/src/signals/routes/webhooks-stripe.ts
+++ b/turbo/apps/api/src/signals/routes/webhooks-stripe.ts
@@ -1,0 +1,59 @@
+import type { Stripe } from "stripe";
+import { command } from "ccstate";
+import { webhookStripeContract } from "@vm0/api-contracts/contracts/webhooks";
+
+import { optionalEnv } from "../../lib/env";
+import type { RouteEntry } from "../route";
+import { request$ } from "../context/hono";
+import { getStripeClient } from "../external/stripe-client";
+import { safeAsync } from "../utils";
+import { handleStripeWebhookEvent$ } from "../services/webhooks-stripe.service";
+
+function jsonError(message: string, status: 401 | 503): Response {
+  return Response.json({ error: message }, { status });
+}
+
+const postStripeWebhook$ = command(
+  async ({ get, set }, signal: AbortSignal): Promise<Response> => {
+    const webhookSecret = optionalEnv("STRIPE_WEBHOOK_SECRET");
+    if (!webhookSecret) {
+      return jsonError("Stripe billing is not configured", 503);
+    }
+
+    const request = get(request$);
+    const signature = request.raw.headers.get("stripe-signature");
+    if (!signature) {
+      return jsonError("Missing stripe-signature header", 401);
+    }
+
+    const body = await request.text();
+    signal.throwIfAborted();
+
+    const eventResult = await safeAsync((): Promise<Stripe.Event> => {
+      return Promise.resolve(
+        getStripeClient().webhooks.constructEvent(
+          body,
+          signature,
+          webhookSecret,
+        ),
+      );
+    });
+    signal.throwIfAborted();
+    if ("error" in eventResult) {
+      return jsonError("Invalid webhook signature", 401);
+    }
+
+    const event = eventResult.ok;
+    await set(handleStripeWebhookEvent$, event, signal);
+    signal.throwIfAborted();
+
+    return new Response("OK", { status: 200 });
+  },
+);
+
+export const webhooksStripeRoutes: readonly RouteEntry[] = [
+  {
+    route: webhookStripeContract.post,
+    handler: postStripeWebhook$,
+  },
+];

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -205,7 +205,7 @@ interface RunRecord {
   readonly status: "pending" | "queued";
 }
 
-interface RunCallback {
+export interface RunCallback {
   readonly url: string;
   readonly secret: string;
   readonly payload: unknown;

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -205,7 +205,7 @@ interface RunRecord {
   readonly status: "pending" | "queued";
 }
 
-export interface RunCallback {
+interface RunCallback {
   readonly url: string;
   readonly secret: string;
   readonly payload: unknown;

--- a/turbo/apps/api/src/signals/services/github-issues-api.service.ts
+++ b/turbo/apps/api/src/signals/services/github-issues-api.service.ts
@@ -16,6 +16,42 @@ function authHeaders(token: string): Record<string, string> {
   };
 }
 
+export interface GithubIssueComment {
+  readonly id: number;
+  readonly user: {
+    readonly login: string;
+    readonly type: string;
+  };
+  readonly body: string;
+  readonly created_at: string;
+}
+
+export async function fetchGithubIssueComments(args: {
+  readonly token: string;
+  readonly repo: string;
+  readonly issueNumber: number;
+  readonly signal: AbortSignal;
+}): Promise<readonly GithubIssueComment[]> {
+  const response = await fetch(
+    `${GITHUB_API_BASE}/repos/${args.repo}/issues/${args.issueNumber}/comments?per_page=100&direction=asc`,
+    {
+      headers: authHeaders(args.token),
+      signal: args.signal,
+    },
+  );
+
+  if (!response.ok) {
+    L.warn("Failed to fetch issue comments", {
+      status: response.status,
+      repo: args.repo,
+      issueNumber: args.issueNumber,
+    });
+    return [];
+  }
+
+  return (await response.json()) as readonly GithubIssueComment[];
+}
+
 export async function postGithubIssueComment(args: {
   readonly token: string;
   readonly repo: string;
@@ -42,6 +78,69 @@ export async function postGithubIssueComment(args: {
 
   const data = (await response.json()) as { readonly id: number };
   return String(data.id);
+}
+
+export async function postGithubIssueCommentBestEffort(args: {
+  readonly token: string;
+  readonly repo: string;
+  readonly issueNumber: number;
+  readonly body: string;
+  readonly signal: AbortSignal;
+}): Promise<void> {
+  const result = await safeAsync(async (): Promise<void> => {
+    await postGithubIssueComment(args);
+  });
+
+  if ("error" in result) {
+    L.warn("Best-effort comment failed", {
+      repo: args.repo,
+      issueNumber: args.issueNumber,
+      error: result.error,
+    });
+  }
+}
+
+export async function addGithubCommentReaction(args: {
+  readonly token: string;
+  readonly repo: string;
+  readonly commentId: string;
+  readonly content: string;
+  readonly signal: AbortSignal;
+}): Promise<string | undefined> {
+  const result = await safeAsync(async (): Promise<string | undefined> => {
+    const response = await fetch(
+      `${GITHUB_API_BASE}/repos/${args.repo}/issues/comments/${args.commentId}/reactions`,
+      {
+        method: "POST",
+        headers: authHeaders(args.token),
+        body: JSON.stringify({ content: args.content }),
+        signal: args.signal,
+      },
+    );
+
+    if (!response.ok) {
+      L.warn("Failed to add comment reaction", {
+        commentId: args.commentId,
+        content: args.content,
+        status: response.status,
+      });
+      return undefined;
+    }
+
+    const data = (await response.json()) as { readonly id: number };
+    return String(data.id);
+  });
+
+  if ("error" in result) {
+    L.warn("Failed to add comment reaction", {
+      commentId: args.commentId,
+      content: args.content,
+      error: result.error,
+    });
+    return undefined;
+  }
+
+  return result.ok;
 }
 
 export async function removeGithubCommentReaction(args: {

--- a/turbo/apps/api/src/signals/services/webhooks-clerk-cleanup.service.ts
+++ b/turbo/apps/api/src/signals/services/webhooks-clerk-cleanup.service.ts
@@ -40,6 +40,7 @@ import { nowDate } from "../external/time";
 import { publishCancelToRunnerGroup } from "../external/realtime";
 import { deleteWebhook } from "../external/telegram-client";
 import { getStripeClient } from "../external/stripe-client";
+import { safeAsync } from "../utils";
 import { decryptSecretValue } from "./crypto.utils";
 import { deleteZeroConnectorLocalState$ } from "./zero-connector-data.service";
 
@@ -331,6 +332,49 @@ async function deleteObjectsForPrefixes(args: {
   }
 }
 
+async function deleteUserObjectsForPrefixesBestEffort(args: {
+  readonly get: Getter;
+  readonly bucket: string;
+  readonly prefixes: readonly string[];
+  readonly userId: string;
+}): Promise<void> {
+  for (const prefix of args.prefixes) {
+    const objectsResult = await safeAsync(() => {
+      return args.get(listS3Objects(args.bucket, prefix));
+    });
+    if ("error" in objectsResult) {
+      L.warn("failed to list user storage objects", {
+        userId: args.userId,
+        prefix,
+        error: objectsResult.error,
+      });
+      continue;
+    }
+
+    if (objectsResult.ok.length === 0) {
+      continue;
+    }
+
+    const deleteResult = await safeAsync(() => {
+      return args.get(
+        deleteS3Objects(
+          args.bucket,
+          objectsResult.ok.map((object) => {
+            return object.key;
+          }),
+        ),
+      );
+    });
+    if ("error" in deleteResult) {
+      L.warn("failed to delete user storage objects", {
+        userId: args.userId,
+        prefix,
+        error: deleteResult.error,
+      });
+    }
+  }
+}
+
 async function deleteOrgS3Data(args: {
   readonly get: Getter;
   readonly db: Db;
@@ -369,9 +413,10 @@ async function deleteUserS3Data(args: {
     .select({ s3Prefix: storages.s3Prefix })
     .from(storages)
     .where(eq(storages.userId, args.userId));
-  await deleteObjectsForPrefixes({
+  await deleteUserObjectsForPrefixesBestEffort({
     get: args.get,
     bucket,
+    userId: args.userId,
     prefixes: storageRows.map((row) => {
       return row.s3Prefix;
     }),
@@ -386,7 +431,16 @@ async function deleteUserS3Data(args: {
   const exportKeys = exportRows.flatMap((row) => {
     return row.s3Key ? [row.s3Key] : [];
   });
-  await args.get(deleteS3Objects(bucket, exportKeys));
+  const deleteExportsResult = await safeAsync(() => {
+    return args.get(deleteS3Objects(bucket, exportKeys));
+  });
+  if ("error" in deleteExportsResult) {
+    L.warn("failed to delete user export objects", {
+      userId: args.userId,
+      count: exportKeys.length,
+      error: deleteExportsResult.error,
+    });
+  }
 }
 
 async function deleteOrgData(db: Db, orgId: string): Promise<void> {

--- a/turbo/apps/api/src/signals/services/webhooks-clerk-cleanup.service.ts
+++ b/turbo/apps/api/src/signals/services/webhooks-clerk-cleanup.service.ts
@@ -1,0 +1,497 @@
+import { connectorTypeSchema } from "@vm0/connectors/connectors";
+import {
+  agentComposes,
+  agentComposeVersions,
+} from "@vm0/db/schema/agent-compose";
+import { agentRunQueue } from "@vm0/db/schema/agent-run-queue";
+import { agentRuns } from "@vm0/db/schema/agent-run";
+import { cliTokens } from "@vm0/db/schema/cli-tokens";
+import { composeJobs } from "@vm0/db/schema/compose-job";
+import { connectorSessions } from "@vm0/db/schema/connector-session";
+import { connectors } from "@vm0/db/schema/connector";
+import { deviceCodes } from "@vm0/db/schema/device-codes";
+import { exportJobs } from "@vm0/db/schema/export-job";
+import { githubUserLinks } from "@vm0/db/schema/github-user-link";
+import { modelProviders } from "@vm0/db/schema/model-provider";
+import { orgCache } from "@vm0/db/schema/org-cache";
+import { orgMembersCache } from "@vm0/db/schema/org-members-cache";
+import { orgMembersMetadata } from "@vm0/db/schema/org-members-metadata";
+import { orgMetadata } from "@vm0/db/schema/org-metadata";
+import { secrets } from "@vm0/db/schema/secret";
+import { slackOrgConnections } from "@vm0/db/schema/slack-org-connection";
+import { slackOrgInstallations } from "@vm0/db/schema/slack-org-installation";
+import { storages } from "@vm0/db/schema/storage";
+import { telegramInstallations } from "@vm0/db/schema/telegram-installation";
+import { telegramUserLinks } from "@vm0/db/schema/telegram-user-link";
+import { usageDaily } from "@vm0/db/schema/usage-daily";
+import { userCache } from "@vm0/db/schema/user-cache";
+import { users } from "@vm0/db/schema/user";
+import { variables } from "@vm0/db/schema/variable";
+import { zeroAgentSchedules } from "@vm0/db/schema/zero-agent-schedule";
+import { zeroAgents } from "@vm0/db/schema/zero-agent";
+import { command, type Getter, type Setter } from "ccstate";
+import { and, eq, inArray, isNotNull } from "drizzle-orm";
+
+import { env } from "../../lib/env";
+import { logger } from "../../lib/log";
+import { writeDb$, type Db } from "../external/db";
+import { deleteS3Objects, listS3Objects } from "../external/s3";
+import { nowDate } from "../external/time";
+import { publishCancelToRunnerGroup } from "../external/realtime";
+import { deleteWebhook } from "../external/telegram-client";
+import { getStripeClient } from "../external/stripe-client";
+import { decryptSecretValue } from "./crypto.utils";
+import { deleteZeroConnectorLocalState$ } from "./zero-connector-data.service";
+
+const L = logger("WebhookClerkCleanup");
+
+async function publishCancelBestEffort(
+  runnerGroup: string | null,
+  runId: string,
+): Promise<void> {
+  if (!runnerGroup) {
+    return;
+  }
+  await publishCancelToRunnerGroup(runnerGroup, runId).catch(
+    (error: unknown) => {
+      L.warn("failed to publish run cancellation", {
+        runId,
+        runnerGroup,
+        error,
+      });
+    },
+  );
+}
+
+async function cancelOrgRuns(db: Db, orgId: string): Promise<void> {
+  const cancelled = await db
+    .update(agentRuns)
+    .set({ status: "cancelled", completedAt: nowDate() })
+    .where(
+      and(
+        eq(agentRuns.orgId, orgId),
+        inArray(agentRuns.status, ["queued", "pending", "running"]),
+      ),
+    )
+    .returning({ id: agentRuns.id, runnerGroup: agentRuns.runnerGroup });
+
+  await db.delete(agentRunQueue).where(eq(agentRunQueue.orgId, orgId));
+  await Promise.all(
+    cancelled.map((run) => {
+      return publishCancelBestEffort(run.runnerGroup, run.id);
+    }),
+  );
+}
+
+async function cancelUserRuns(db: Db, userId: string): Promise<void> {
+  const cancelled = await db
+    .update(agentRuns)
+    .set({ status: "cancelled", completedAt: nowDate() })
+    .where(
+      and(
+        eq(agentRuns.userId, userId),
+        inArray(agentRuns.status, ["queued", "pending", "running"]),
+      ),
+    )
+    .returning({ id: agentRuns.id, runnerGroup: agentRuns.runnerGroup });
+
+  await db.delete(agentRunQueue).where(eq(agentRunQueue.userId, userId));
+  await Promise.all(
+    cancelled.map((run) => {
+      return publishCancelBestEffort(run.runnerGroup, run.id);
+    }),
+  );
+}
+
+async function cleanupWorkspaceInstallation(
+  db: Db,
+  workspaceId: string,
+): Promise<void> {
+  await db
+    .delete(slackOrgConnections)
+    .where(eq(slackOrgConnections.slackWorkspaceId, workspaceId));
+  await db
+    .delete(slackOrgInstallations)
+    .where(eq(slackOrgInstallations.slackWorkspaceId, workspaceId));
+}
+
+async function cancelStripeSubscription(db: Db, orgId: string): Promise<void> {
+  const [meta] = await db
+    .select({
+      stripeSubscriptionId: orgMetadata.stripeSubscriptionId,
+      subscriptionStatus: orgMetadata.subscriptionStatus,
+    })
+    .from(orgMetadata)
+    .where(eq(orgMetadata.orgId, orgId))
+    .limit(1);
+
+  if (!meta?.stripeSubscriptionId || meta.subscriptionStatus === "canceled") {
+    return;
+  }
+
+  await getStripeClient().subscriptions.cancel(meta.stripeSubscriptionId);
+}
+
+async function deregisterOrgTelegramWebhooks(
+  db: Db,
+  orgId: string,
+): Promise<void> {
+  const installations = await db
+    .select({
+      telegramBotId: telegramInstallations.telegramBotId,
+      encryptedBotToken: telegramInstallations.encryptedBotToken,
+    })
+    .from(telegramInstallations)
+    .where(eq(telegramInstallations.orgId, orgId));
+
+  for (const installation of installations) {
+    await deleteWebhook(
+      decryptSecretValue(installation.encryptedBotToken),
+    ).catch((error: unknown) => {
+      L.warn("failed to deregister telegram webhook", {
+        telegramBotId: installation.telegramBotId,
+        error,
+      });
+    });
+  }
+}
+
+async function deregisterOwnedTelegramWebhooks(
+  db: Db,
+  userId: string,
+): Promise<void> {
+  const installations = await db
+    .select({
+      telegramBotId: telegramInstallations.telegramBotId,
+      encryptedBotToken: telegramInstallations.encryptedBotToken,
+    })
+    .from(telegramInstallations)
+    .where(eq(telegramInstallations.ownerUserId, userId));
+
+  for (const installation of installations) {
+    await deleteWebhook(
+      decryptSecretValue(installation.encryptedBotToken),
+    ).catch((error: unknown) => {
+      L.warn("failed to deregister telegram webhook", {
+        telegramBotId: installation.telegramBotId,
+        error,
+      });
+    });
+  }
+}
+
+async function revokeOrgConnectorTokens(args: {
+  readonly set: Setter;
+  readonly db: Db;
+  readonly orgId: string;
+  readonly signal: AbortSignal;
+}): Promise<void> {
+  const rows = await args.db
+    .select({ userId: connectors.userId, type: connectors.type })
+    .from(connectors)
+    .where(eq(connectors.orgId, args.orgId));
+  args.signal.throwIfAborted();
+
+  for (const row of rows) {
+    const parsed = connectorTypeSchema.safeParse(row.type);
+    if (!parsed.success) {
+      L.warn("unknown connector type, skipping revocation", {
+        orgId: args.orgId,
+        type: row.type,
+      });
+      continue;
+    }
+
+    await args.set(
+      deleteZeroConnectorLocalState$,
+      { orgId: args.orgId, userId: row.userId, type: parsed.data },
+      args.signal,
+    );
+  }
+}
+
+async function revokeUserConnectorTokens(args: {
+  readonly set: Setter;
+  readonly db: Db;
+  readonly userId: string;
+  readonly signal: AbortSignal;
+}): Promise<void> {
+  const rows = await args.db
+    .select({ orgId: connectors.orgId, type: connectors.type })
+    .from(connectors)
+    .where(eq(connectors.userId, args.userId));
+  args.signal.throwIfAborted();
+
+  for (const row of rows) {
+    const parsed = connectorTypeSchema.safeParse(row.type);
+    if (!parsed.success) {
+      L.warn("unknown connector type, skipping revocation", {
+        userId: args.userId,
+        type: row.type,
+      });
+      continue;
+    }
+
+    await args.set(
+      deleteZeroConnectorLocalState$,
+      { orgId: row.orgId, userId: args.userId, type: parsed.data },
+      args.signal,
+    );
+  }
+}
+
+async function cleanupOrgExternalServices(args: {
+  readonly set: Setter;
+  readonly db: Db;
+  readonly orgId: string;
+  readonly signal: AbortSignal;
+}): Promise<void> {
+  const steps: readonly {
+    readonly name: string;
+    readonly run: () => Promise<void>;
+  }[] = [
+    {
+      name: "stripe subscription",
+      run: () => {
+        return cancelStripeSubscription(args.db, args.orgId);
+      },
+    },
+    {
+      name: "telegram webhooks",
+      run: () => {
+        return deregisterOrgTelegramWebhooks(args.db, args.orgId);
+      },
+    },
+    {
+      name: "connector tokens",
+      run: () => {
+        return revokeOrgConnectorTokens(args);
+      },
+    },
+  ];
+
+  for (const step of steps) {
+    await step.run().catch((error: unknown) => {
+      L.warn(`failed to cleanup ${step.name}`, { orgId: args.orgId, error });
+    });
+    args.signal.throwIfAborted();
+  }
+}
+
+async function cleanupUserExternalServices(args: {
+  readonly set: Setter;
+  readonly db: Db;
+  readonly userId: string;
+  readonly signal: AbortSignal;
+}): Promise<void> {
+  const steps: readonly {
+    readonly name: string;
+    readonly run: () => Promise<void>;
+  }[] = [
+    {
+      name: "connector tokens",
+      run: () => {
+        return revokeUserConnectorTokens(args);
+      },
+    },
+    {
+      name: "telegram owned bots",
+      run: () => {
+        return deregisterOwnedTelegramWebhooks(args.db, args.userId);
+      },
+    },
+  ];
+
+  for (const step of steps) {
+    await step.run().catch((error: unknown) => {
+      L.warn(`failed to cleanup ${step.name}`, { userId: args.userId, error });
+    });
+    args.signal.throwIfAborted();
+  }
+}
+
+async function deleteObjectsForPrefixes(args: {
+  readonly get: Getter;
+  readonly bucket: string;
+  readonly prefixes: readonly string[];
+}): Promise<void> {
+  for (const prefix of args.prefixes) {
+    const objects = await args.get(listS3Objects(args.bucket, prefix));
+    if (objects.length === 0) {
+      continue;
+    }
+    await args.get(
+      deleteS3Objects(
+        args.bucket,
+        objects.map((object) => {
+          return object.key;
+        }),
+      ),
+    );
+  }
+}
+
+async function deleteOrgS3Data(args: {
+  readonly get: Getter;
+  readonly db: Db;
+  readonly orgId: string;
+}): Promise<void> {
+  const bucket = env("R2_USER_STORAGES_BUCKET_NAME");
+  const storageRows = await args.db
+    .select({ s3Prefix: storages.s3Prefix })
+    .from(storages)
+    .where(eq(storages.orgId, args.orgId));
+  await deleteObjectsForPrefixes({
+    get: args.get,
+    bucket,
+    prefixes: storageRows.map((row) => {
+      return row.s3Prefix;
+    }),
+  });
+
+  const exportRows = await args.db
+    .select({ s3Key: exportJobs.s3Key })
+    .from(exportJobs)
+    .where(and(eq(exportJobs.orgId, args.orgId), isNotNull(exportJobs.s3Key)));
+  const exportKeys = exportRows.flatMap((row) => {
+    return row.s3Key ? [row.s3Key] : [];
+  });
+  await args.get(deleteS3Objects(bucket, exportKeys));
+}
+
+async function deleteUserS3Data(args: {
+  readonly get: Getter;
+  readonly db: Db;
+  readonly userId: string;
+}): Promise<void> {
+  const bucket = env("R2_USER_STORAGES_BUCKET_NAME");
+  const storageRows = await args.db
+    .select({ s3Prefix: storages.s3Prefix })
+    .from(storages)
+    .where(eq(storages.userId, args.userId));
+  await deleteObjectsForPrefixes({
+    get: args.get,
+    bucket,
+    prefixes: storageRows.map((row) => {
+      return row.s3Prefix;
+    }),
+  });
+
+  const exportRows = await args.db
+    .select({ s3Key: exportJobs.s3Key })
+    .from(exportJobs)
+    .where(
+      and(eq(exportJobs.userId, args.userId), isNotNull(exportJobs.s3Key)),
+    );
+  const exportKeys = exportRows.flatMap((row) => {
+    return row.s3Key ? [row.s3Key] : [];
+  });
+  await args.get(deleteS3Objects(bucket, exportKeys));
+}
+
+async function deleteOrgData(db: Db, orgId: string): Promise<void> {
+  await cancelOrgRuns(db, orgId);
+
+  const installations = await db
+    .select({ slackWorkspaceId: slackOrgInstallations.slackWorkspaceId })
+    .from(slackOrgInstallations)
+    .where(eq(slackOrgInstallations.orgId, orgId));
+  for (const installation of installations) {
+    await cleanupWorkspaceInstallation(db, installation.slackWorkspaceId);
+  }
+
+  await db
+    .delete(zeroAgentSchedules)
+    .where(eq(zeroAgentSchedules.orgId, orgId));
+  await db.delete(agentRuns).where(eq(agentRuns.orgId, orgId));
+  await db.delete(agentComposes).where(eq(agentComposes.orgId, orgId));
+  await db.delete(storages).where(eq(storages.orgId, orgId));
+  await db.delete(modelProviders).where(eq(modelProviders.orgId, orgId));
+  await db.delete(secrets).where(eq(secrets.orgId, orgId));
+  await db.delete(connectors).where(eq(connectors.orgId, orgId));
+  await db.delete(variables).where(eq(variables.orgId, orgId));
+  await db.delete(usageDaily).where(eq(usageDaily.orgId, orgId));
+  await db.delete(exportJobs).where(eq(exportJobs.orgId, orgId));
+  await db.delete(zeroAgents).where(eq(zeroAgents.orgId, orgId));
+  await db.delete(orgMembersCache).where(eq(orgMembersCache.orgId, orgId));
+  await db
+    .delete(orgMembersMetadata)
+    .where(eq(orgMembersMetadata.orgId, orgId));
+  await db.delete(orgCache).where(eq(orgCache.orgId, orgId));
+  await db.delete(orgMetadata).where(eq(orgMetadata.orgId, orgId));
+}
+
+async function deleteUserData(db: Db, userId: string): Promise<void> {
+  await cancelUserRuns(db, userId);
+
+  await db
+    .delete(slackOrgConnections)
+    .where(eq(slackOrgConnections.vm0UserId, userId));
+  await db.delete(githubUserLinks).where(eq(githubUserLinks.vm0UserId, userId));
+  await db
+    .delete(telegramUserLinks)
+    .where(eq(telegramUserLinks.vm0UserId, userId));
+  await db
+    .delete(telegramInstallations)
+    .where(eq(telegramInstallations.ownerUserId, userId));
+  await db.delete(agentRuns).where(eq(agentRuns.userId, userId));
+
+  const composeRows = await db
+    .select({ id: agentComposes.id })
+    .from(agentComposes)
+    .where(eq(agentComposes.userId, userId));
+  const composeIds = composeRows.map((row) => {
+    return row.id;
+  });
+  if (composeIds.length > 0) {
+    await db
+      .delete(agentComposeVersions)
+      .where(inArray(agentComposeVersions.composeId, composeIds));
+  }
+
+  await db.delete(agentComposes).where(eq(agentComposes.userId, userId));
+  await db.delete(storages).where(eq(storages.userId, userId));
+  await db.delete(modelProviders).where(eq(modelProviders.userId, userId));
+  await db.delete(secrets).where(eq(secrets.userId, userId));
+  await db.delete(connectors).where(eq(connectors.userId, userId));
+  await db.delete(variables).where(eq(variables.userId, userId));
+  await db.delete(usageDaily).where(eq(usageDaily.userId, userId));
+  await db.delete(exportJobs).where(eq(exportJobs.userId, userId));
+  await db
+    .delete(zeroAgentSchedules)
+    .where(eq(zeroAgentSchedules.userId, userId));
+  await db.delete(cliTokens).where(eq(cliTokens.userId, userId));
+  await db.delete(composeJobs).where(eq(composeJobs.userId, userId));
+  await db
+    .delete(connectorSessions)
+    .where(eq(connectorSessions.userId, userId));
+  await db.delete(deviceCodes).where(eq(deviceCodes.userId, userId));
+  await db.delete(orgMembersCache).where(eq(orgMembersCache.userId, userId));
+  await db
+    .delete(orgMembersMetadata)
+    .where(eq(orgMembersMetadata.userId, userId));
+  await db.delete(userCache).where(eq(userCache.userId, userId));
+  await db.delete(users).where(eq(users.id, userId));
+}
+
+export const cleanupClerkDeletedOrg$ = command(
+  async ({ get, set }, orgId: string, signal: AbortSignal): Promise<void> => {
+    const db = set(writeDb$);
+    await cleanupOrgExternalServices({ set, db, orgId, signal });
+    signal.throwIfAborted();
+    await deleteOrgS3Data({ get, db, orgId });
+    signal.throwIfAborted();
+    await deleteOrgData(db, orgId);
+  },
+);
+
+export const cleanupClerkDeletedUser$ = command(
+  async ({ get, set }, userId: string, signal: AbortSignal): Promise<void> => {
+    const db = set(writeDb$);
+    await cleanupUserExternalServices({ set, db, userId, signal });
+    signal.throwIfAborted();
+    await deleteUserS3Data({ get, db, userId });
+    signal.throwIfAborted();
+    await deleteUserData(db, userId);
+  },
+);

--- a/turbo/apps/api/src/signals/services/webhooks-github.service.ts
+++ b/turbo/apps/api/src/signals/services/webhooks-github.service.ts
@@ -1,0 +1,935 @@
+import { randomBytes } from "node:crypto";
+
+import {
+  githubIssuesCallbackPayloadSchema,
+  type GitHubIssuesCallbackPayload,
+} from "@vm0/api-contracts/contracts/internal-callbacks-github-issues";
+import { agentComposes } from "@vm0/db/schema/agent-compose";
+import { agentSessions } from "@vm0/db/schema/agent-session";
+import { githubInstallations } from "@vm0/db/schema/github-installation";
+import { githubIssueSessions } from "@vm0/db/schema/github-issue-session";
+import { githubUserLinks } from "@vm0/db/schema/github-user-link";
+import { zeroAgents } from "@vm0/db/schema/zero-agent";
+import { command } from "ccstate";
+import { and, eq } from "drizzle-orm";
+import { z } from "zod";
+
+import { env, optionalEnv } from "../../lib/env";
+import { logger } from "../../lib/log";
+import { writeDb$, type Db } from "../external/db";
+import { nowDate } from "../external/time";
+import { safeAsync } from "../utils";
+import {
+  addGithubCommentReaction,
+  fetchGithubIssueComments,
+  postGithubIssueCommentBestEffort,
+  removeGithubCommentReaction,
+  type GithubIssueComment,
+} from "./github-issues-api.service";
+import { getGithubInstallationAccessToken } from "./github-app.service";
+import { encryptSecretValue } from "./crypto.utils";
+import { createZeroIntegrationRun$ } from "./zero-runs-create.service";
+
+const L = logger("WebhookGithub");
+
+const gitHubUserSchema = z.object({
+  id: z.number(),
+  login: z.string(),
+  type: z.string(),
+});
+
+const gitHubLabelSchema = z.object({
+  id: z.number(),
+  name: z.string(),
+});
+
+const gitHubIssueSchema = z.object({
+  number: z.number(),
+  title: z.string(),
+  body: z.string().nullable(),
+  labels: z.array(gitHubLabelSchema),
+  user: gitHubUserSchema,
+});
+
+const gitHubCommentSchema = z.object({
+  id: z.number(),
+  body: z.string(),
+  user: gitHubUserSchema,
+});
+
+const gitHubRepositorySchema = z.object({
+  full_name: z.string(),
+});
+
+const gitHubInstallationRefSchema = z.object({
+  id: z.number(),
+});
+
+export const gitHubIssuesEventSchema = z.object({
+  action: z.string(),
+  issue: gitHubIssueSchema,
+  label: gitHubLabelSchema.optional(),
+  repository: gitHubRepositorySchema,
+  installation: gitHubInstallationRefSchema,
+  sender: gitHubUserSchema,
+});
+
+export const gitHubIssueCommentEventSchema = z.object({
+  action: z.string(),
+  issue: gitHubIssueSchema,
+  comment: gitHubCommentSchema,
+  repository: gitHubRepositorySchema,
+  installation: gitHubInstallationRefSchema,
+  sender: gitHubUserSchema,
+});
+
+const gitHubInstallationAccountSchema = z.object({
+  id: z.number(),
+  login: z.string(),
+  type: z.string(),
+});
+
+export const gitHubInstallationEventSchema = z.object({
+  action: z.string(),
+  installation: z.object({
+    id: z.number(),
+    account: gitHubInstallationAccountSchema,
+  }),
+  sender: z
+    .object({
+      id: z.number(),
+      login: z.string(),
+    })
+    .optional(),
+});
+
+type GitHubIssue = z.infer<typeof gitHubIssueSchema>;
+type GitHubComment = z.infer<typeof gitHubCommentSchema>;
+type GitHubIssuesEvent = z.infer<typeof gitHubIssuesEventSchema>;
+type GitHubIssueCommentEvent = z.infer<typeof gitHubIssueCommentEventSchema>;
+type GitHubInstallationEvent = z.infer<typeof gitHubInstallationEventSchema>;
+type GitHubInstallationRecord = typeof githubInstallations.$inferSelect;
+
+interface DispatchParams {
+  readonly ghInstallationId: string;
+  readonly repo: string;
+  readonly issue: GitHubIssue;
+  readonly senderGithubUserId: string;
+  readonly prompt: string;
+  readonly commentId?: string;
+  readonly comment?: GitHubComment;
+  readonly forceNewSession?: boolean;
+  readonly appSlug?: string;
+  readonly apiStartTime: number;
+}
+
+type ExistingSessionResult =
+  | { readonly kind: "duplicate" }
+  | {
+      readonly kind: "resolved";
+      readonly sessionId: string | undefined;
+      readonly lastCommentId: string | null | undefined;
+    };
+
+interface GitHubRunTarget {
+  readonly composeId: string;
+  readonly orgId: string;
+  readonly zeroAgentId: string;
+}
+
+function generateCallbackSecret(): string {
+  return randomBytes(32).toString("hex");
+}
+
+function buildIntegrationPrompt(platform: "GitHub"): string {
+  return `# Current Integration\nYou are currently running inside: ${platform}`;
+}
+
+function buildGitHubPrompt(issueContext: string): string {
+  return [buildIntegrationPrompt("GitHub"), issueContext]
+    .filter((part): part is string => {
+      return Boolean(part);
+    })
+    .join("\n\n");
+}
+
+function buildIssuePrompt(issue: GitHubIssue): string {
+  return issue.body ?? issue.title;
+}
+
+function buildCommentPrompt(comment: GitHubComment): string {
+  return comment.body;
+}
+
+function buildPromptParts(
+  prompt: string,
+  issueContext: string,
+  isCommentTrigger: boolean,
+): {
+  readonly prompt: string;
+  readonly appendSystemPrompt: string | undefined;
+} {
+  const appendSystemPrompt = buildGitHubPrompt(issueContext) || undefined;
+  const userPrompt = isCommentTrigger
+    ? prompt
+    : issueContext
+      ? "Based on the GitHub issue above and its discussion, analyze the request and decide on the appropriate action."
+      : prompt;
+
+  return { prompt: userPrompt, appendSystemPrompt };
+}
+
+function formatIssueContext(args: {
+  readonly issue: GitHubIssue;
+  readonly comments: readonly GithubIssueComment[];
+  readonly lastCommentId: string | undefined;
+  readonly currentCommentId: string | undefined;
+}): string {
+  let relevantComments = args.lastCommentId
+    ? args.comments.filter((comment) => {
+        return comment.id > Number(args.lastCommentId);
+      })
+    : args.comments;
+
+  if (args.currentCommentId) {
+    relevantComments = relevantComments.filter((comment) => {
+      return String(comment.id) !== args.currentCommentId;
+    });
+  }
+
+  if (relevantComments.length === 0 && args.lastCommentId) {
+    return "";
+  }
+
+  const parts: string[] = ["# GitHub Issue Context"];
+
+  if (!args.lastCommentId) {
+    parts.push(
+      "",
+      `**${args.issue.title}** (#${args.issue.number})`,
+      "",
+      args.issue.body ?? "_No description provided._",
+    );
+  }
+
+  if (relevantComments.length > 0) {
+    parts.push("", "## Comments", "");
+    for (const comment of relevantComments) {
+      const role = comment.user.type === "Bot" ? "bot" : "user";
+      parts.push(`**@${comment.user.login}** (${role}):`, comment.body, "");
+    }
+  }
+
+  parts.push("---");
+  return parts.join("\n");
+}
+
+async function getGitHubToken(args: {
+  readonly ghInstallationId: string;
+  readonly signal: AbortSignal;
+}): Promise<string | undefined> {
+  const appId = optionalEnv("GITHUB_APP_ID");
+  const privateKey = optionalEnv("GITHUB_APP_PRIVATE_KEY");
+  if (!appId || !privateKey) {
+    return undefined;
+  }
+
+  const { token } = await getGithubInstallationAccessToken({
+    appId,
+    privateKey,
+    installationId: args.ghInstallationId,
+    signal: args.signal,
+  });
+  return token;
+}
+
+async function getGitHubTokenForInstallation(args: {
+  readonly installation: GitHubInstallationRecord;
+  readonly signal: AbortSignal;
+}): Promise<string | undefined> {
+  if (!args.installation.installationId) {
+    return undefined;
+  }
+
+  const token = await getGitHubToken({
+    ghInstallationId: args.installation.installationId,
+    signal: args.signal,
+  });
+  args.signal.throwIfAborted();
+  return token;
+}
+
+async function validateSessionAgent(args: {
+  readonly db: Db;
+  readonly sessionId: string;
+  readonly vm0UserId: string;
+  readonly expectedComposeId: string;
+  readonly signal: AbortSignal;
+}): Promise<string | undefined> {
+  const [session] = await args.db
+    .select({ agentComposeId: agentSessions.agentComposeId })
+    .from(agentSessions)
+    .where(
+      and(
+        eq(agentSessions.id, args.sessionId),
+        eq(agentSessions.userId, args.vm0UserId),
+      ),
+    )
+    .limit(1);
+  args.signal.throwIfAborted();
+
+  if (session?.agentComposeId === args.expectedComposeId) {
+    return args.sessionId;
+  }
+  return undefined;
+}
+
+async function resolveExistingSession(args: {
+  readonly db: Db;
+  readonly installationDbId: string;
+  readonly repo: string;
+  readonly issueNumber: number;
+  readonly composeId: string;
+  readonly vm0UserId: string;
+  readonly commentId: string | undefined;
+  readonly signal: AbortSignal;
+}): Promise<ExistingSessionResult> {
+  const [found] = await args.db
+    .select({
+      agentSessionId: githubIssueSessions.agentSessionId,
+      lastCommentId: githubIssueSessions.lastCommentId,
+    })
+    .from(githubIssueSessions)
+    .where(
+      and(
+        eq(githubIssueSessions.installationId, args.installationDbId),
+        eq(githubIssueSessions.repo, args.repo),
+        eq(githubIssueSessions.issueNumber, args.issueNumber),
+      ),
+    )
+    .limit(1);
+  args.signal.throwIfAborted();
+
+  if (!found) {
+    return { kind: "resolved", sessionId: undefined, lastCommentId: undefined };
+  }
+
+  if (args.commentId && found.lastCommentId === args.commentId) {
+    return { kind: "duplicate" };
+  }
+
+  const sessionId = await validateSessionAgent({
+    db: args.db,
+    sessionId: found.agentSessionId,
+    vm0UserId: args.vm0UserId,
+    expectedComposeId: args.composeId,
+    signal: args.signal,
+  });
+
+  return {
+    kind: "resolved",
+    sessionId,
+    lastCommentId: sessionId ? found.lastCommentId : undefined,
+  };
+}
+
+function createRunErrorMessage(result: {
+  readonly status: number;
+  readonly body: unknown;
+}): string {
+  if (
+    typeof result.body === "object" &&
+    result.body !== null &&
+    "error" in result.body
+  ) {
+    const error = result.body.error;
+    if (
+      typeof error === "object" &&
+      error !== null &&
+      "message" in error &&
+      typeof error.message === "string"
+    ) {
+      return error.message;
+    }
+  }
+  return `GitHub-triggered agent run failed with status ${result.status}`;
+}
+
+async function handleDispatchError(args: {
+  readonly error: unknown;
+  readonly token: string | undefined;
+  readonly repo: string;
+  readonly issueNumber: number;
+  readonly commentId: string | undefined;
+  readonly reactionId: string | undefined;
+  readonly commentBody: string | undefined;
+  readonly signal: AbortSignal;
+}): Promise<void> {
+  if (args.token && args.commentId && args.reactionId) {
+    await removeGithubCommentReaction({
+      token: args.token,
+      repo: args.repo,
+      commentId: args.commentId,
+      reactionId: args.reactionId,
+      signal: args.signal,
+    });
+  }
+
+  const quotePrefix = args.commentBody
+    ? `${args.commentBody
+        .split("\n")
+        .map((line) => {
+          return `> ${line}`;
+        })
+        .join("\n")}\n\n`
+    : "";
+
+  if (args.token) {
+    const message =
+      args.error instanceof Error
+        ? args.error.message
+        : "An unexpected error occurred.";
+    await postGithubIssueCommentBestEffort({
+      token: args.token,
+      repo: args.repo,
+      issueNumber: args.issueNumber,
+      body: `${quotePrefix}Failed to start the agent: ${message}`,
+      signal: args.signal,
+    });
+  }
+}
+
+async function loadActiveInstallation(args: {
+  readonly db: Db;
+  readonly ghInstallationId: string;
+  readonly signal: AbortSignal;
+}): Promise<GitHubInstallationRecord> {
+  const [installation] = await args.db
+    .select()
+    .from(githubInstallations)
+    .where(
+      and(
+        eq(githubInstallations.installationId, args.ghInstallationId),
+        eq(githubInstallations.status, "active"),
+      ),
+    )
+    .limit(1);
+  args.signal.throwIfAborted();
+
+  if (!installation) {
+    throw new Error(
+      `GitHub installation not found: installationId=${args.ghInstallationId}`,
+    );
+  }
+
+  return installation;
+}
+
+async function maybeAddCommentReaction(args: {
+  readonly token: string | undefined;
+  readonly repo: string;
+  readonly commentId: string | undefined;
+  readonly signal: AbortSignal;
+}): Promise<string | undefined> {
+  if (!args.token || !args.commentId) {
+    return undefined;
+  }
+
+  return await addGithubCommentReaction({
+    token: args.token,
+    repo: args.repo,
+    commentId: args.commentId,
+    content: "eyes",
+    signal: args.signal,
+  });
+}
+
+async function loadLinkedVm0UserId(args: {
+  readonly db: Db;
+  readonly githubUserId: string;
+  readonly installationDbId: string;
+  readonly signal: AbortSignal;
+}): Promise<string | undefined> {
+  const [userLink] = await args.db
+    .select({ vm0UserId: githubUserLinks.vm0UserId })
+    .from(githubUserLinks)
+    .where(
+      and(
+        eq(githubUserLinks.githubUserId, args.githubUserId),
+        eq(githubUserLinks.installationId, args.installationDbId),
+      ),
+    )
+    .limit(1);
+  args.signal.throwIfAborted();
+
+  return userLink?.vm0UserId;
+}
+
+async function loadGitHubRunTarget(args: {
+  readonly db: Db;
+  readonly installation: GitHubInstallationRecord;
+  readonly signal: AbortSignal;
+}): Promise<GitHubRunTarget> {
+  const [compose] = await args.db
+    .select({
+      id: agentComposes.id,
+      name: agentComposes.name,
+      orgId: agentComposes.orgId,
+    })
+    .from(agentComposes)
+    .where(eq(agentComposes.id, args.installation.defaultComposeId))
+    .limit(1);
+  args.signal.throwIfAborted();
+
+  if (!compose) {
+    throw new Error(
+      `Agent compose not found: composeId=${args.installation.defaultComposeId}`,
+    );
+  }
+
+  const [agent] = await args.db
+    .select({ id: zeroAgents.id })
+    .from(zeroAgents)
+    .where(
+      and(
+        eq(zeroAgents.orgId, compose.orgId),
+        eq(zeroAgents.name, compose.name),
+      ),
+    )
+    .limit(1);
+  args.signal.throwIfAborted();
+
+  if (!agent) {
+    throw new Error(
+      `Zero agent not found for compose: composeId=${compose.id}`,
+    );
+  }
+
+  return {
+    composeId: compose.id,
+    orgId: compose.orgId,
+    zeroAgentId: agent.id,
+  };
+}
+
+async function resolveDispatchSession(args: {
+  readonly db: Db;
+  readonly params: DispatchParams;
+  readonly installationDbId: string;
+  readonly issueNumber: number;
+  readonly composeId: string;
+  readonly vm0UserId: string;
+  readonly signal: AbortSignal;
+}): Promise<ExistingSessionResult> {
+  if (args.params.forceNewSession) {
+    return { kind: "resolved", sessionId: undefined, lastCommentId: undefined };
+  }
+
+  return await resolveExistingSession({
+    db: args.db,
+    installationDbId: args.installationDbId,
+    repo: args.params.repo,
+    issueNumber: args.issueNumber,
+    composeId: args.composeId,
+    vm0UserId: args.vm0UserId,
+    commentId: args.params.commentId,
+    signal: args.signal,
+  });
+}
+
+async function buildIssueContextForRun(args: {
+  readonly token: string | undefined;
+  readonly params: DispatchParams;
+  readonly issueNumber: number;
+  readonly existingSessionId: string | undefined;
+  readonly lastCommentId: string | null | undefined;
+  readonly signal: AbortSignal;
+}): Promise<string> {
+  if (!args.token) {
+    return "";
+  }
+
+  const comments = await fetchGithubIssueComments({
+    token: args.token,
+    repo: args.params.repo,
+    issueNumber: args.issueNumber,
+    signal: args.signal,
+  });
+  args.signal.throwIfAborted();
+
+  return formatIssueContext({
+    issue: args.params.issue,
+    comments,
+    lastCommentId: args.existingSessionId
+      ? (args.lastCommentId ?? undefined)
+      : undefined,
+    currentCommentId: args.params.commentId,
+  });
+}
+
+function buildCallbackPayload(args: {
+  readonly installationDbId: string;
+  readonly params: DispatchParams;
+  readonly issueNumber: number;
+  readonly composeId: string;
+  readonly existingSessionId: string | undefined;
+  readonly reactionId: string | undefined;
+}): GitHubIssuesCallbackPayload {
+  return githubIssuesCallbackPayloadSchema.parse({
+    installationId: args.installationDbId,
+    repo: args.params.repo,
+    issueNumber: args.issueNumber,
+    agentId: args.composeId,
+    existingSessionId: args.existingSessionId,
+    triggerCommentId: args.params.commentId,
+    triggerCommentBody: args.params.commentId
+      ? args.params.comment?.body
+      : undefined,
+    triggerReactionId: args.reactionId,
+  });
+}
+
+async function updateExistingSessionComment(args: {
+  readonly db: Db;
+  readonly installationDbId: string;
+  readonly repo: string;
+  readonly issueNumber: number;
+  readonly existingSessionId: string | undefined;
+  readonly commentId: string | undefined;
+}): Promise<void> {
+  if (!args.existingSessionId || !args.commentId) {
+    return;
+  }
+
+  await args.db
+    .update(githubIssueSessions)
+    .set({ lastCommentId: args.commentId, updatedAt: nowDate() })
+    .where(
+      and(
+        eq(githubIssueSessions.installationId, args.installationDbId),
+        eq(githubIssueSessions.repo, args.repo),
+        eq(githubIssueSessions.issueNumber, args.issueNumber),
+      ),
+    );
+}
+
+export const handleGithubIssuesEvent$ = command(
+  async (
+    { set },
+    args: {
+      readonly payload: GitHubIssuesEvent;
+      readonly appSlug: string | undefined;
+      readonly apiStartTime: number;
+    },
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const { action, issue, label, repository, installation, sender } =
+      args.payload;
+
+    if (action !== "opened" && action !== "labeled") {
+      L.debug("Ignoring issues event", { action });
+      return;
+    }
+
+    if (!args.appSlug) {
+      L.debug("Ignoring issues event: app slug not configured");
+      return;
+    }
+
+    if (action === "labeled" && label?.name !== args.appSlug) {
+      L.debug("Ignoring label that is not app slug", {
+        label: label?.name,
+        expected: args.appSlug,
+      });
+      return;
+    }
+
+    if (
+      action === "opened" &&
+      !issue.labels.some((candidate) => {
+        return candidate.name === args.appSlug;
+      })
+    ) {
+      L.debug("Ignoring opened issue without app slug label", {
+        expected: args.appSlug,
+      });
+      return;
+    }
+
+    await set(
+      dispatchGithubAgentRun$,
+      {
+        ghInstallationId: String(installation.id),
+        repo: repository.full_name,
+        issue,
+        senderGithubUserId: String(sender.id),
+        prompt: buildIssuePrompt(issue),
+        forceNewSession: true,
+        appSlug: args.appSlug,
+        apiStartTime: args.apiStartTime,
+      },
+      signal,
+    );
+  },
+);
+
+export const handleGithubIssueCommentEvent$ = command(
+  async (
+    { set },
+    args: {
+      readonly payload: GitHubIssueCommentEvent;
+      readonly appSlug: string | undefined;
+      readonly apiStartTime: number;
+    },
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const { action, issue, comment, repository, installation, sender } =
+      args.payload;
+
+    if (action !== "created") {
+      L.debug("Ignoring issue_comment event", { action });
+      return;
+    }
+
+    if (sender.type === "Bot") {
+      L.debug("Ignoring comment from bot", { sender: sender.login });
+      return;
+    }
+
+    if (!args.appSlug) {
+      L.debug("Ignoring comment: app slug not configured");
+      return;
+    }
+
+    const botMention = `@${args.appSlug}[bot]`;
+    if (!comment.body.includes(botMention)) {
+      L.debug("Ignoring comment: no bot mention", { expected: botMention });
+      return;
+    }
+
+    await set(
+      dispatchGithubAgentRun$,
+      {
+        ghInstallationId: String(installation.id),
+        repo: repository.full_name,
+        issue,
+        senderGithubUserId: String(sender.id),
+        prompt: buildCommentPrompt(comment),
+        commentId: String(comment.id),
+        comment,
+        appSlug: args.appSlug,
+        apiStartTime: args.apiStartTime,
+      },
+      signal,
+    );
+  },
+);
+
+const dispatchGithubAgentRun$ = command(
+  async (
+    { set },
+    params: DispatchParams,
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const db = set(writeDb$);
+    const issueNumber = params.issue.number;
+
+    const installation = await loadActiveInstallation({
+      db,
+      ghInstallationId: params.ghInstallationId,
+      signal,
+    });
+    const token = await getGitHubTokenForInstallation({ installation, signal });
+    signal.throwIfAborted();
+
+    const reactionId = await maybeAddCommentReaction({
+      token,
+      repo: params.repo,
+      commentId: params.commentId,
+      signal,
+    });
+    signal.throwIfAborted();
+
+    const vm0UserId = await loadLinkedVm0UserId({
+      db,
+      githubUserId: params.senderGithubUserId,
+      installationDbId: installation.id,
+      signal,
+    });
+    if (!vm0UserId) {
+      L.warn("No VM0 user linked for GitHub user", {
+        githubUserId: params.senderGithubUserId,
+        installationId: installation.id,
+      });
+      return;
+    }
+
+    const target = await loadGitHubRunTarget({ db, installation, signal });
+    const sessionResult = await resolveDispatchSession({
+      db,
+      params,
+      installationDbId: installation.id,
+      issueNumber,
+      composeId: target.composeId,
+      vm0UserId,
+      signal,
+    });
+    if (sessionResult.kind === "duplicate") {
+      return;
+    }
+
+    const existingSessionId = sessionResult.sessionId;
+    const issueContext = await buildIssueContextForRun({
+      token,
+      params,
+      issueNumber,
+      existingSessionId,
+      lastCommentId: sessionResult.lastCommentId,
+      signal,
+    });
+    const promptParts = buildPromptParts(
+      params.prompt,
+      issueContext,
+      Boolean(params.commentId),
+    );
+
+    const callbackPayload = buildCallbackPayload({
+      installationDbId: installation.id,
+      params,
+      issueNumber,
+      composeId: target.composeId,
+      existingSessionId,
+      reactionId,
+    });
+
+    const dispatchResult = await safeAsync(async () => {
+      const result = await set(
+        createZeroIntegrationRun$,
+        {
+          userId: vm0UserId,
+          orgId: target.orgId,
+          agentId: target.zeroAgentId,
+          sessionId: existingSessionId,
+          prompt: promptParts.prompt,
+          appendSystemPrompt: promptParts.appendSystemPrompt,
+          triggerSource: "github",
+          callbacks: [
+            {
+              url: `${env("VM0_API_URL")}/api/internal/callbacks/github/issues`,
+              secret: generateCallbackSecret(),
+              payload: callbackPayload,
+            },
+          ],
+          apiStartTime: params.apiStartTime,
+        },
+        signal,
+      );
+      signal.throwIfAborted();
+
+      if (result.status !== 201) {
+        throw new Error(createRunErrorMessage(result));
+      }
+
+      L.debug("Agent run dispatched for GitHub issue", {
+        runId: result.body.runId,
+        repo: params.repo,
+        issueNumber,
+      });
+
+      await updateExistingSessionComment({
+        db,
+        installationDbId: installation.id,
+        repo: params.repo,
+        issueNumber,
+        existingSessionId,
+        commentId: params.commentId,
+      });
+      signal.throwIfAborted();
+    });
+    signal.throwIfAborted();
+
+    if ("error" in dispatchResult) {
+      await handleDispatchError({
+        error: dispatchResult.error,
+        token,
+        repo: params.repo,
+        issueNumber,
+        commentId: params.commentId,
+        reactionId,
+        commentBody: params.comment?.body,
+        signal,
+      });
+      signal.throwIfAborted();
+      throw dispatchResult.error;
+    }
+  },
+);
+
+export const handleGithubInstallationEvent$ = command(
+  async (
+    { set },
+    payload: GitHubInstallationEvent,
+    signal: AbortSignal,
+  ): Promise<void> => {
+    if (payload.action !== "created") {
+      L.debug("Ignoring installation event", { action: payload.action });
+      return;
+    }
+
+    const db = set(writeDb$);
+    const targetId = String(payload.installation.account.id);
+    const ghInstallationId = String(payload.installation.id);
+
+    const [pending] = await db
+      .select()
+      .from(githubInstallations)
+      .where(
+        and(
+          eq(githubInstallations.targetId, targetId),
+          eq(githubInstallations.status, "pending"),
+        ),
+      )
+      .limit(1);
+    signal.throwIfAborted();
+
+    if (!pending) {
+      L.debug("No pending installation found for target", { targetId });
+      return;
+    }
+
+    const appId = optionalEnv("GITHUB_APP_ID");
+    const privateKey = optionalEnv("GITHUB_APP_PRIVATE_KEY");
+    if (!appId || !privateKey) {
+      throw new Error(
+        "GitHub App not configured (GITHUB_APP_ID / GITHUB_APP_PRIVATE_KEY missing), cannot activate pending installation",
+      );
+    }
+
+    const { token } = await getGithubInstallationAccessToken({
+      appId,
+      privateKey,
+      installationId: ghInstallationId,
+      signal,
+    });
+    signal.throwIfAborted();
+
+    await db
+      .update(githubInstallations)
+      .set({
+        status: "active",
+        installationId: ghInstallationId,
+        encryptedAccessToken: encryptSecretValue(token),
+        targetName: payload.installation.account.login,
+        adminGithubUserId: payload.sender ? String(payload.sender.id) : null,
+        updatedAt: nowDate(),
+      })
+      .where(eq(githubInstallations.id, pending.id));
+    signal.throwIfAborted();
+
+    L.debug("Activated pending GitHub installation", {
+      installationId: ghInstallationId,
+      targetId,
+      recordId: pending.id,
+    });
+  },
+);

--- a/turbo/apps/api/src/signals/services/webhooks-stripe.service.ts
+++ b/turbo/apps/api/src/signals/services/webhooks-stripe.service.ts
@@ -1,0 +1,580 @@
+import type { Stripe } from "stripe";
+import type { OrgTier } from "@vm0/api-contracts/contracts/orgs";
+import { creditExpiresRecord } from "@vm0/db/schema/credit-expires-record";
+import { orgMembersMetadata } from "@vm0/db/schema/org-members-metadata";
+import { orgMetadata } from "@vm0/db/schema/org-metadata";
+import { command } from "ccstate";
+import { and, eq, gt, lte, sql } from "drizzle-orm";
+
+import { env } from "../../lib/env";
+import { logger } from "../../lib/log";
+import { now, nowDate } from "../../lib/time";
+import { writeDb$, type Db } from "../external/db";
+import { getStripeClient } from "../external/stripe-client";
+import { getCampaign } from "./one-time-products";
+
+const L = logger("WebhookStripe");
+
+type WriteTx = Parameters<Parameters<Db["transaction"]>[0]>[0];
+
+interface CheckoutSessionInput {
+  readonly id: string;
+  readonly subscription: string | { readonly id: string } | null;
+  readonly customer: string | { readonly id: string } | null;
+  readonly metadata: Record<string, string> | null;
+  readonly payment_status?: string | null;
+}
+
+interface InvoiceInput {
+  readonly id: string;
+  readonly customer: string | { readonly id: string } | null;
+  readonly metadata: Record<string, string> | null;
+  readonly lines: {
+    readonly data: readonly {
+      readonly period: { readonly end: number };
+      readonly parent: {
+        readonly type: "subscription_item_details" | "invoice_item_details";
+      } | null;
+    }[];
+  };
+  readonly parent: {
+    readonly subscription_details: {
+      readonly subscription: string | { readonly id: string };
+    } | null;
+  } | null;
+}
+
+interface SubscriptionInput {
+  readonly id: string;
+  readonly status: string;
+  readonly cancel_at_period_end: boolean;
+  readonly items: {
+    readonly data: readonly {
+      readonly price: { readonly id: string };
+      readonly current_period_end?: number | null;
+    }[];
+  };
+}
+
+interface SubscriptionDeletedInput {
+  readonly id: string;
+}
+
+function subscriptionPeriodEnd(subscription: SubscriptionInput): Date | null {
+  const periodEndUnix = subscription.items.data[0]?.current_period_end;
+  return typeof periodEndUnix === "number"
+    ? new Date(periodEndUnix * 1000)
+    : null;
+}
+
+function subscriptionCanRefreshPaidThrough(
+  subscription: SubscriptionInput,
+): boolean {
+  return subscription.status === "active" || subscription.status === "trialing";
+}
+
+function monthlyCreditsForTier(tier: OrgTier): number {
+  switch (tier) {
+    case "free": {
+      return 0;
+    }
+    case "pro": {
+      return 20_000;
+    }
+    case "team": {
+      return 120_000;
+    }
+  }
+}
+
+function autoRechargeNeverExpiresAt(): Date {
+  return new Date("2999-12-31T00:00:00Z");
+}
+
+function tierFromPriceId(priceId: string): OrgTier {
+  const priceMap = env("ZERO_PRICE");
+  if (priceMap) {
+    for (const [tier, ids] of Object.entries(priceMap)) {
+      if (ids.includes(priceId)) {
+        return tier as OrgTier;
+      }
+    }
+  }
+  throw new Error(`Unknown Stripe price ID: ${priceId}`);
+}
+
+async function grantOrgCredits(
+  tx: WriteTx,
+  orgId: string,
+  amount: number,
+): Promise<void> {
+  await tx.execute(
+    sql`INSERT INTO org_metadata (org_id, credits, created_at, updated_at)
+        VALUES (${orgId}, ${amount}, now(), now())
+        ON CONFLICT (org_id)
+        DO UPDATE SET credits = org_metadata.credits + ${amount}, updated_at = now()`,
+  );
+}
+
+async function createExpiresRecord(
+  tx: WriteTx,
+  orgId: string,
+  params: {
+    readonly source: string;
+    readonly stripeInvoiceId: string;
+    readonly amount: number;
+    readonly expiresAt: Date;
+  },
+): Promise<boolean> {
+  const rows = await tx
+    .insert(creditExpiresRecord)
+    .values({
+      orgId,
+      source: params.source,
+      stripeInvoiceId: params.stripeInvoiceId,
+      amount: params.amount,
+      remaining: params.amount,
+      expiresAt: params.expiresAt,
+    })
+    .onConflictDoNothing()
+    .returning({ id: creditExpiresRecord.id });
+
+  return rows.length > 0;
+}
+
+async function expireCredits(tx: WriteTx, orgId: string): Promise<number> {
+  const expired = await tx
+    .select({
+      id: creditExpiresRecord.id,
+      remaining: creditExpiresRecord.remaining,
+    })
+    .from(creditExpiresRecord)
+    .where(
+      and(
+        eq(creditExpiresRecord.orgId, orgId),
+        lte(creditExpiresRecord.expiresAt, nowDate()),
+        gt(creditExpiresRecord.remaining, 0),
+      ),
+    )
+    .for("update");
+
+  if (expired.length === 0) {
+    return 0;
+  }
+
+  const totalExpired = expired.reduce((sum, record) => {
+    return sum + record.remaining;
+  }, 0);
+
+  for (const record of expired) {
+    await tx
+      .update(creditExpiresRecord)
+      .set({ remaining: 0 })
+      .where(eq(creditExpiresRecord.id, record.id));
+  }
+
+  if (totalExpired > 0) {
+    await tx
+      .update(orgMetadata)
+      .set({
+        credits: sql`GREATEST(${orgMetadata.credits} - ${totalExpired}, 0)`,
+        updatedAt: nowDate(),
+      })
+      .where(eq(orgMetadata.orgId, orgId));
+  }
+
+  L.debug("expired credits settled", { orgId, totalExpired });
+  return totalExpired;
+}
+
+async function resetMemberCreditFlags(db: Db, orgId: string): Promise<void> {
+  await db
+    .update(orgMembersMetadata)
+    .set({ creditEnabled: true, updatedAt: nowDate() })
+    .where(
+      and(
+        eq(orgMembersMetadata.orgId, orgId),
+        eq(orgMembersMetadata.creditEnabled, false),
+      ),
+    );
+}
+
+async function handleAutoRechargeInvoicePaid(
+  db: Db,
+  invoice: Pick<InvoiceInput, "id" | "metadata">,
+): Promise<boolean> {
+  const metadata = invoice.metadata;
+  if (!metadata || metadata.type !== "auto_recharge") {
+    return false;
+  }
+
+  const orgId = metadata.orgId;
+  const creditsAmount = Number(metadata.creditsAmount);
+  if (!orgId || !creditsAmount || Number.isNaN(creditsAmount)) {
+    L.warn("Auto-recharge invoice has invalid metadata", {
+      invoiceId: invoice.id,
+      metadata,
+    });
+    return false;
+  }
+
+  const granted = await db.transaction(async (tx) => {
+    const inserted = await createExpiresRecord(tx, orgId, {
+      source: "auto_recharge",
+      stripeInvoiceId: invoice.id,
+      amount: creditsAmount,
+      expiresAt: autoRechargeNeverExpiresAt(),
+    });
+
+    if (!inserted) {
+      L.debug("Auto-recharge invoice already processed", {
+        orgId,
+        invoiceId: invoice.id,
+      });
+      return false;
+    }
+
+    await grantOrgCredits(tx, orgId, creditsAmount);
+    await tx
+      .update(orgMetadata)
+      .set({ autoRechargePendingAt: null, updatedAt: nowDate() })
+      .where(eq(orgMetadata.orgId, orgId));
+    return true;
+  });
+
+  if (granted) {
+    L.debug("Auto-recharge credits granted", {
+      orgId,
+      creditsAmount,
+      invoiceId: invoice.id,
+    });
+  }
+
+  return true;
+}
+
+async function handleOneTimePurchaseCompleted(
+  db: Db,
+  session: CheckoutSessionInput,
+): Promise<void> {
+  const metadata = session.metadata ?? {};
+  const orgId = metadata.orgId;
+  const campaignKey = metadata.campaignKey;
+
+  if (!orgId || !campaignKey) {
+    L.warn("one_time_purchase missing metadata", {
+      sessionId: session.id,
+      hasOrgId: Boolean(orgId),
+      hasCampaignKey: Boolean(campaignKey),
+    });
+    return;
+  }
+
+  const campaign = getCampaign(campaignKey);
+  if (!campaign) {
+    L.warn("one_time_purchase unknown campaign; skipping", {
+      sessionId: session.id,
+      campaignKey,
+    });
+    return;
+  }
+
+  const expiresAt = new Date(
+    now() + campaign.expiresDays * 24 * 60 * 60 * 1000,
+  );
+
+  await db.transaction(async (tx) => {
+    const inserted = await createExpiresRecord(tx, orgId, {
+      source: campaign.source,
+      stripeInvoiceId: session.id,
+      amount: campaign.credits,
+      expiresAt,
+    });
+
+    if (!inserted) {
+      L.debug("one_time_purchase already processed", {
+        sessionId: session.id,
+        orgId,
+      });
+      return;
+    }
+
+    await grantOrgCredits(tx, orgId, campaign.credits);
+  });
+}
+
+async function handleCheckoutCompleted(
+  db: Db,
+  session: CheckoutSessionInput,
+): Promise<void> {
+  if (session.metadata?.purpose === "one_time_purchase") {
+    if (session.payment_status !== "paid") {
+      L.debug("one_time_purchase checkout completed before payment settled", {
+        sessionId: session.id,
+        paymentStatus: session.payment_status ?? null,
+      });
+      return;
+    }
+    await handleOneTimePurchaseCompleted(db, session);
+    return;
+  }
+
+  const subscriptionId =
+    typeof session.subscription === "string"
+      ? session.subscription
+      : session.subscription?.id;
+  if (!subscriptionId) {
+    L.warn("checkout.session.completed without subscription ID", {
+      sessionId: session.id,
+    });
+    return;
+  }
+
+  const customerId =
+    typeof session.customer === "string"
+      ? session.customer
+      : session.customer?.id;
+  if (!customerId) {
+    L.warn("checkout.session.completed without customer ID", {
+      sessionId: session.id,
+    });
+    return;
+  }
+
+  const stripe = getStripeClient();
+  const subscription = await stripe.subscriptions.retrieve(subscriptionId);
+  const priceId = subscription.items.data[0]?.price?.id;
+  if (!priceId) {
+    L.warn("subscription has no price ID", { subscriptionId });
+    return;
+  }
+
+  const tier = tierFromPriceId(priceId);
+  const [existing] = await db
+    .select({ stripeSubscriptionId: orgMetadata.stripeSubscriptionId })
+    .from(orgMetadata)
+    .where(eq(orgMetadata.stripeCustomerId, customerId))
+    .limit(1);
+
+  if (existing?.stripeSubscriptionId === subscriptionId) {
+    L.debug("checkout.session.completed already processed", { subscriptionId });
+    return;
+  }
+
+  const itemPeriodEnd = subscription.items.data[0]?.current_period_end;
+  const periodEnd = itemPeriodEnd ? new Date(itemPeriodEnd * 1000) : undefined;
+
+  await db
+    .update(orgMetadata)
+    .set({
+      tier,
+      stripeSubscriptionId: subscriptionId,
+      subscriptionStatus: subscription.status,
+      cancelAtPeriodEnd: false,
+      ...(periodEnd ? { currentPeriodEnd: periodEnd } : {}),
+      updatedAt: nowDate(),
+    })
+    .where(eq(orgMetadata.stripeCustomerId, customerId));
+}
+
+async function handleInvoicePaid(db: Db, invoice: InvoiceInput): Promise<void> {
+  const handled = await handleAutoRechargeInvoicePaid(db, invoice);
+  if (handled) {
+    return;
+  }
+
+  const subscription = invoice.parent?.subscription_details?.subscription;
+  const subscriptionId =
+    typeof subscription === "string" ? subscription : subscription?.id;
+  if (!subscriptionId) {
+    L.warn("invoice.paid without subscription; skipping", {
+      invoiceId: invoice.id,
+    });
+    return;
+  }
+
+  const customerId =
+    typeof invoice.customer === "string"
+      ? invoice.customer
+      : invoice.customer?.id;
+  if (!customerId) {
+    L.warn("invoice.paid without customer ID", { invoiceId: invoice.id });
+    return;
+  }
+
+  const [org] = await db
+    .select({
+      orgId: orgMetadata.orgId,
+      lastProcessedInvoiceId: orgMetadata.lastProcessedInvoiceId,
+    })
+    .from(orgMetadata)
+    .where(eq(orgMetadata.stripeCustomerId, customerId))
+    .limit(1);
+
+  if (!org) {
+    L.warn("invoice.paid for unknown customer", {
+      customerId,
+      invoiceId: invoice.id,
+    });
+    return;
+  }
+
+  if (org.lastProcessedInvoiceId === invoice.id) {
+    L.debug("invoice.paid already processed", {
+      invoiceId: invoice.id,
+      orgId: org.orgId,
+    });
+    return;
+  }
+
+  const stripe = getStripeClient();
+  const subscriptionRecord =
+    await stripe.subscriptions.retrieve(subscriptionId);
+  const priceId = subscriptionRecord.items.data[0]?.price?.id;
+  if (!priceId) {
+    L.warn("subscription has no price ID for credit grant", {
+      subscriptionId,
+    });
+    return;
+  }
+
+  const tier = tierFromPriceId(priceId);
+  const credits = monthlyCreditsForTier(tier);
+  if (credits <= 0) {
+    L.warn("no credits to grant for tier", {
+      tier,
+      invoiceId: invoice.id,
+      orgId: org.orgId,
+    });
+    return;
+  }
+
+  const subscriptionLine = invoice.lines.data.find((line) => {
+    return line.parent?.type === "subscription_item_details";
+  });
+  const periodEndUnix = subscriptionLine?.period.end;
+  if (!periodEndUnix) {
+    throw new Error(
+      `invoice.paid has no subscription line item with period.end (invoiceId=${invoice.id}, orgId=${org.orgId})`,
+    );
+  }
+  const periodEndDate = new Date(periodEndUnix * 1000);
+  const expiresAt = new Date(periodEndDate);
+  expiresAt.setMonth(expiresAt.getMonth() + 1);
+
+  const granted = await db.transaction(async (tx) => {
+    await expireCredits(tx, org.orgId);
+
+    const inserted = await createExpiresRecord(tx, org.orgId, {
+      source: "subscription_renewal",
+      stripeInvoiceId: invoice.id,
+      amount: credits,
+      expiresAt,
+    });
+    if (!inserted) {
+      L.debug("invoice.paid already processed by concurrent delivery", {
+        invoiceId: invoice.id,
+        orgId: org.orgId,
+      });
+      return false;
+    }
+
+    await grantOrgCredits(tx, org.orgId, credits);
+    await tx
+      .update(orgMetadata)
+      .set({
+        lastProcessedInvoiceId: invoice.id,
+        currentPeriodEnd: periodEndDate,
+        updatedAt: nowDate(),
+      })
+      .where(eq(orgMetadata.orgId, org.orgId));
+    return true;
+  });
+
+  if (!granted) {
+    return;
+  }
+
+  await resetMemberCreditFlags(db, org.orgId);
+}
+
+async function handleSubscriptionUpdated(
+  db: Db,
+  subscription: SubscriptionInput,
+): Promise<void> {
+  const priceId = subscription.items.data[0]?.price?.id;
+  const canSyncPaidEntitlement =
+    subscriptionCanRefreshPaidThrough(subscription);
+  const tier: OrgTier | undefined =
+    canSyncPaidEntitlement && priceId ? tierFromPriceId(priceId) : undefined;
+  const periodEnd = canSyncPaidEntitlement
+    ? subscriptionPeriodEnd(subscription)
+    : null;
+
+  await db
+    .update(orgMetadata)
+    .set({
+      subscriptionStatus: subscription.status,
+      cancelAtPeriodEnd: subscription.cancel_at_period_end,
+      updatedAt: nowDate(),
+      ...(tier ? { tier } : {}),
+      ...(periodEnd ? { currentPeriodEnd: periodEnd } : {}),
+    })
+    .where(eq(orgMetadata.stripeSubscriptionId, subscription.id));
+}
+
+async function handleSubscriptionDeleted(
+  db: Db,
+  subscription: SubscriptionDeletedInput,
+): Promise<void> {
+  await db
+    .update(orgMetadata)
+    .set({
+      tier: "free",
+      subscriptionStatus: "canceled",
+      stripeSubscriptionId: null,
+      cancelAtPeriodEnd: false,
+      updatedAt: nowDate(),
+    })
+    .where(eq(orgMetadata.stripeSubscriptionId, subscription.id));
+}
+
+export const handleStripeWebhookEvent$ = command(
+  async ({ set }, event: Stripe.Event, signal: AbortSignal): Promise<void> => {
+    const db = set(writeDb$);
+    L.debug("stripe webhook received", { type: event.type, id: event.id });
+
+    switch (event.type) {
+      case "checkout.session.completed": {
+        await handleCheckoutCompleted(db, event.data.object);
+        signal.throwIfAborted();
+        break;
+      }
+      case "checkout.session.async_payment_succeeded": {
+        await handleCheckoutCompleted(db, event.data.object);
+        signal.throwIfAborted();
+        break;
+      }
+      case "invoice.paid": {
+        await handleInvoicePaid(db, event.data.object);
+        signal.throwIfAborted();
+        break;
+      }
+      case "customer.subscription.updated": {
+        await handleSubscriptionUpdated(db, event.data.object);
+        signal.throwIfAborted();
+        break;
+      }
+      case "customer.subscription.deleted": {
+        await handleSubscriptionDeleted(db, event.data.object);
+        signal.throwIfAborted();
+        break;
+      }
+      default: {
+        L.debug("ignoring unhandled Stripe event", { type: event.type });
+      }
+    }
+
+    signal.throwIfAborted();
+  },
+);

--- a/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
@@ -38,7 +38,7 @@ import { env } from "../../lib/env";
 import { badRequestMessage, notFound } from "../../lib/error";
 import type { AuthContext } from "../../types/auth";
 import { writeDb$, type Db } from "../external/db";
-import { createAgentRun$ } from "./agent-run-create.service";
+import { createAgentRun$, type RunCallback } from "./agent-run-create.service";
 
 type ZeroRunCreateBody = z.infer<(typeof zeroRunsMainContract.create)["body"]>;
 
@@ -269,6 +269,17 @@ function buildAppendSystemPrompt(args: {
     .join("\n\n");
 }
 
+function mergeAppendSystemPrompt(
+  base: string,
+  appendSystemPrompt: string | undefined,
+): string {
+  return [base, appendSystemPrompt]
+    .filter((part): part is string => {
+      return Boolean(part);
+    })
+    .join("\n\n");
+}
+
 async function inferAgentIdFromSession(
   db: Db,
   args: {
@@ -473,6 +484,35 @@ function createRunBody(args: {
   };
 }
 
+function createIntegrationRunBody(args: {
+  readonly prompt: string;
+  readonly sessionId: string | undefined;
+  readonly agent: ZeroAgentRunRecord;
+  readonly userInfo: UserInfo;
+  readonly permissionPolicies:
+    | ReturnType<typeof resolveFirewallPolicies>
+    | undefined;
+  readonly triggerSource: TriggerSource;
+  readonly appendSystemPrompt: string | undefined;
+}) {
+  return {
+    prompt: args.prompt,
+    agentComposeId: args.agent.id,
+    sessionId: args.sessionId,
+    permissionPolicies: args.permissionPolicies ?? undefined,
+    triggerSource: args.triggerSource,
+    appendSystemPrompt: mergeAppendSystemPrompt(
+      buildAppendSystemPrompt({
+        agent: args.agent,
+        userInfo: args.userInfo,
+      }),
+      args.appendSystemPrompt,
+    ),
+    disallowedTools: [...DISALLOWED_TOOLS],
+    vars: { ZERO_AGENT_ID: args.agent.id },
+  };
+}
+
 function callbacksForTriggerAgent(triggerAgentId: string | undefined) {
   return triggerAgentId
     ? [
@@ -484,6 +524,104 @@ function callbacksForTriggerAgent(triggerAgentId: string | undefined) {
       ]
     : undefined;
 }
+
+export const createZeroIntegrationRun$ = command(
+  async (
+    { set },
+    args: {
+      readonly userId: string;
+      readonly orgId: string;
+      readonly agentId: string;
+      readonly sessionId?: string;
+      readonly prompt: string;
+      readonly appendSystemPrompt?: string;
+      readonly triggerSource: TriggerSource;
+      readonly callbacks?: readonly RunCallback[];
+      readonly apiStartTime: number;
+    },
+    signal: AbortSignal,
+  ) => {
+    const db = set(writeDb$);
+    const agent = await loadZeroAgent(db, args.agentId);
+    signal.throwIfAborted();
+    if (!agent || agent.orgId !== args.orgId) {
+      return notFound("Agent not found");
+    }
+
+    if (agent.visibility === "private" && agent.owner !== args.userId) {
+      return forbidden("Only the private agent owner can run this agent");
+    }
+
+    const userInfo = await loadUserInfo(db, {
+      userId: args.userId,
+      orgId: args.orgId,
+    });
+    signal.throwIfAborted();
+
+    const allowedConnectorTypes = await loadAllowedConnectorTypes(db, {
+      userId: args.userId,
+      orgId: args.orgId,
+      agentId: agent.id,
+    });
+    signal.throwIfAborted();
+    const allowedCustomConnectorIds = await loadAllowedCustomConnectorIds(db, {
+      userId: args.userId,
+      orgId: args.orgId,
+      agentId: agent.id,
+    });
+    signal.throwIfAborted();
+
+    const agentPermissionPolicies = resolveFirewallPolicies(
+      toFirewallPolicies(
+        agent.permissionPolicies,
+        agent.unknownPermissionPolicies,
+      ),
+      [...allowedConnectorTypes],
+    );
+
+    const framework = resolveAgentFramework(agent.content);
+    if (!framework) {
+      return badRequestMessage(
+        "Agent must have a supported framework configured",
+      );
+    }
+
+    const prependAdditionalVolumes = [
+      ...buildSystemSkillVolumes(allowedConnectorTypes, framework),
+      ...buildCustomSkillVolumes(agent.customSkills, framework),
+    ];
+
+    return await set(
+      createAgentRun$,
+      {
+        userId: args.userId,
+        orgId: args.orgId,
+        body: createIntegrationRunBody({
+          prompt: args.prompt,
+          sessionId: args.sessionId,
+          agent,
+          userInfo,
+          permissionPolicies: agentPermissionPolicies,
+          triggerSource: args.triggerSource,
+          appendSystemPrompt: args.appendSystemPrompt,
+        }),
+        apiStartTime: args.apiStartTime,
+        modelProviderId: agent.modelProviderId ?? undefined,
+        selectedModelOverride: agent.selectedModel ?? undefined,
+        extraEnvironment: { ZERO_AGENT_ID: agent.id },
+        callbacks: args.callbacks,
+        includeZeroTokenSecret: true,
+        enforceVm0Credits: true,
+        queueOnConcurrencyLimit: true,
+        prependAdditionalVolumes,
+        allowedConnectorTypes,
+        allowedCustomConnectorIds,
+        validateEnvironmentReferences: false,
+      },
+      signal,
+    );
+  },
+);
 
 export const createZeroRun$ = command(
   async (

--- a/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
@@ -38,7 +38,7 @@ import { env } from "../../lib/env";
 import { badRequestMessage, notFound } from "../../lib/error";
 import type { AuthContext } from "../../types/auth";
 import { writeDb$, type Db } from "../external/db";
-import { createAgentRun$, type RunCallback } from "./agent-run-create.service";
+import { createAgentRun$ } from "./agent-run-create.service";
 
 type ZeroRunCreateBody = z.infer<(typeof zeroRunsMainContract.create)["body"]>;
 

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -197,7 +197,10 @@ export {
 } from "./internal-callbacks-voice-chat";
 export {
   sandboxReuseResultSchema,
+  webhookClerkContract,
   webhookEventsContract,
+  webhookGithubContract,
+  webhookStripeContract,
   webhookCompleteContract,
   webhookCheckpointsContract,
   webhookCheckpointsPrepareHistoryContract,
@@ -220,7 +223,10 @@ export {
   type WebhookStoragesPrepareContract,
   type WebhookStoragesCommitContract,
   webhookUsageEventContract,
+  type WebhookClerkContract,
   type WebhookUsageEventContract,
+  type WebhookGithubContract,
+  type WebhookStripeContract,
 } from "./webhooks";
 export {
   cliAuthDeviceContract,

--- a/turbo/packages/api-contracts/src/contracts/webhooks.ts
+++ b/turbo/packages/api-contracts/src/contracts/webhooks.ts
@@ -11,6 +11,63 @@ import {
 
 const c = initContract();
 
+const thirdPartyWebhookErrorSchema = z.object({ error: z.string() });
+const thirdPartyWebhookOkSchema = z.union([
+  z.string(),
+  z.object({ message: z.literal("pong") }),
+]);
+
+/**
+ * Clerk third-party webhook contract for /api/webhooks/clerk.
+ */
+export const webhookClerkContract = c.router({
+  post: {
+    method: "POST",
+    path: "/api/webhooks/clerk",
+    body: c.type<string>(),
+    responses: {
+      200: thirdPartyWebhookOkSchema,
+      401: thirdPartyWebhookErrorSchema,
+    },
+    summary: "Handle Clerk organization and user webhooks",
+  },
+});
+
+/**
+ * GitHub App third-party webhook contract for /api/webhooks/github.
+ */
+export const webhookGithubContract = c.router({
+  post: {
+    method: "POST",
+    path: "/api/webhooks/github",
+    body: c.type<string>(),
+    responses: {
+      200: thirdPartyWebhookOkSchema,
+      400: thirdPartyWebhookErrorSchema,
+      401: thirdPartyWebhookErrorSchema,
+      503: thirdPartyWebhookErrorSchema,
+    },
+    summary: "Handle GitHub App webhooks",
+  },
+});
+
+/**
+ * Stripe third-party webhook contract for /api/webhooks/stripe.
+ */
+export const webhookStripeContract = c.router({
+  post: {
+    method: "POST",
+    path: "/api/webhooks/stripe",
+    body: c.type<string>(),
+    responses: {
+      200: thirdPartyWebhookOkSchema,
+      401: thirdPartyWebhookErrorSchema,
+      503: thirdPartyWebhookErrorSchema,
+    },
+    summary: "Handle Stripe billing webhooks",
+  },
+});
+
 /**
  * Sandbox reuse outcome. One enum value per code branch in the runner's
  * reuse-decision block. `reused` means the sandbox was unparked from the idle
@@ -472,6 +529,9 @@ export const webhookStoragesCommitContract = c.router({
 });
 
 export type WebhookEventsContract = typeof webhookEventsContract;
+export type WebhookClerkContract = typeof webhookClerkContract;
+export type WebhookGithubContract = typeof webhookGithubContract;
+export type WebhookStripeContract = typeof webhookStripeContract;
 export type WebhookCompleteContract = typeof webhookCompleteContract;
 export type WebhookCheckpointsContract = typeof webhookCheckpointsContract;
 export type WebhookCheckpointsPrepareHistoryContract =


### PR DESCRIPTION
## Summary
- register API-native Clerk, GitHub, and Stripe third-party webhook routes and contracts
- port webhook side effects into API signal services, including GitHub-triggered Zero runs, billing updates, and Clerk deletion cleanup
- add integration coverage for webhook auth, dispatch, billing, and cleanup paths

Closes #12867

## Validation
- pnpm format
- pnpm -F api lint
- pnpm check-types
- pnpm -F api exec vitest run src/signals/routes/__tests__/webhooks-third-party.test.ts src/signals/routes/__tests__/zero-runs-create.test.ts
- pnpm knip

## Local full-suite note
- pnpm vitest --run was also attempted and failed on unrelated existing full-suite/environment issues, including missing agentphone_user_links, unhandled MSW auth-shadow/callback requests, and org_model_policies/model_providers delete constraints.