### PR TITLE
ci: mark cloudflare ssh tunnel failures

### DIFF
--- a/.github/actions/setup-ssh-tunnel/action.yml
+++ b/.github/actions/setup-ssh-tunnel/action.yml
@@ -55,19 +55,7 @@ runs:
           > "$HOME/.ssh/cf-access.env"
         chmod 600 "$HOME/.ssh/cf-access.env"
 
-        # Proxy script that converts host to tunnel hostname.
-        # Must match parse_host() naming in scripts/cloudflared-ssh.sh:
-        #   subdomain dots -> hyphens, append -ssh
-        #   e.g. dev-1.aws.vm3.ai -> dev-1-aws-ssh.vm3.ai
-        printf '%s\n' \
-          '#!/bin/bash' \
-          "source $HOME/.ssh/cf-access.env" \
-          'HOST="$1"; DOMAIN="vm3.ai"' \
-          'SUB="${HOST%.${DOMAIN}}"' \
-          'TUNNEL_HOST="${SUB//./-}-ssh.${DOMAIN}"' \
-          'exec cloudflared access ssh --hostname "$TUNNEL_HOST" --id "$CF_ACCESS_CLIENT_ID" --secret "$CF_ACCESS_CLIENT_SECRET"' \
-          > "$HOME/.ssh/cf-proxy.sh"
-        chmod 755 "$HOME/.ssh/cf-proxy.sh"
+        install -m 755 "$GITHUB_WORKSPACE/.github/scripts/cloudflare-ssh-proxy.sh" "$HOME/.ssh/cf-proxy.sh"
 
         SSH_CONFIG="$(printf '%s\n' \
           "Host *.vm3.ai" \

--- a/.github/scripts/cloudflare-ssh-proxy.sh
+++ b/.github/scripts/cloudflare-ssh-proxy.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HOST="${1:-}"
+if [ -z "$HOST" ]; then
+  echo "Usage: $0 <host>" >&2
+  exit 2
+fi
+
+CF_ACCESS_ENV_FILE="${CF_ACCESS_ENV_FILE:-$HOME/.ssh/cf-access.env}"
+if [ ! -f "$CF_ACCESS_ENV_FILE" ]; then
+  echo "::error title=Cloudflare Access SSH not configured::Missing credentials file at ${CF_ACCESS_ENV_FILE}" >&2
+  exit 2
+fi
+
+# shellcheck source=/dev/null
+source "$CF_ACCESS_ENV_FILE"
+
+if [ -z "${CF_ACCESS_CLIENT_ID:-}" ] || [ -z "${CF_ACCESS_CLIENT_SECRET:-}" ]; then
+  echo "::error title=Cloudflare Access SSH not configured::CF_ACCESS_CLIENT_ID and CF_ACCESS_CLIENT_SECRET must be set" >&2
+  exit 2
+fi
+
+DOMAIN="${CF_TUNNEL_DOMAIN:-vm3.ai}"
+SUB="${HOST%.${DOMAIN}}"
+TUNNEL_HOST="${SUB//./-}-ssh.${DOMAIN}"
+CLOUDFLARED_BIN="${CLOUDFLARED_BIN:-cloudflared}"
+LOG_DIR="${RUNNER_TEMP:-${TMPDIR:-/tmp}}"
+mkdir -p "$LOG_DIR"
+
+safe_host=$(printf '%s' "$HOST" | tr -c 'A-Za-z0-9_.-' '_')
+LOG_FILE=$(mktemp "${LOG_DIR%/}/cloudflared-ssh-${safe_host}.XXXXXX.log")
+
+github_escape() {
+  local value="$1"
+  value=${value//'%'/'%25'}
+  value=${value//$'\r'/'%0D'}
+  value=${value//$'\n'/'%0A'}
+  printf '%s' "$value"
+}
+
+redact_cloudflared_log() {
+  sed -E \
+    -e 's/(--secret(=|[[:space:]]+))[^[:space:]]+/\1[redacted]/g' \
+    -e 's/(--id(=|[[:space:]]+))[^[:space:]]+/\1[redacted]/g' \
+    -e 's/(CF_ACCESS_CLIENT_SECRET=)[^[:space:]]+/\1[redacted]/g' \
+    -e 's/(CF_ACCESS_CLIENT_ID=)[^[:space:]]+/\1[redacted]/g' \
+    -e 's/(Authorization:[[:space:]]*Bearer[[:space:]]+)[^[:space:]]+/\1[redacted]/Ig' \
+    "$LOG_FILE"
+}
+
+failure_title() {
+  if grep -Eiq "Unable to reach the origin service|connection (refused|reset|timed out)|i/o timeout|context canceled|no route to host|websocket: bad handshake|EOF" "$LOG_FILE"; then
+    echo "Metal Cloudflare tunnel unavailable"
+  elif grep -Eiq "access denied|unauthorized|forbidden|invalid.*token|service token|authentication" "$LOG_FILE"; then
+    echo "Cloudflare Access credentials rejected"
+  elif grep -Eiq "command not found|No such file or directory" "$LOG_FILE"; then
+    echo "cloudflared is not installed"
+  else
+    echo "Metal Cloudflare SSH tunnel failed"
+  fi
+}
+
+failure_message() {
+  local status="$1"
+  local title="$2"
+  case "$title" in
+    "Metal Cloudflare tunnel unavailable")
+      echo "Cloudflare Access SSH to ${HOST} (${TUNNEL_HOST}) failed with cloudflared exit ${status}. The metal host tunnel is disconnected or unreachable; check the cloudflared service on the metal host."
+      ;;
+    "Cloudflare Access credentials rejected")
+      echo "Cloudflare Access SSH to ${HOST} (${TUNNEL_HOST}) failed with cloudflared exit ${status}. Check CF_ACCESS_CLIENT_ID / CF_ACCESS_CLIENT_SECRET for this workflow."
+      ;;
+    "cloudflared is not installed")
+      echo "Cloudflare Access SSH to ${HOST} (${TUNNEL_HOST}) failed because cloudflared could not be executed."
+      ;;
+    *)
+      echo "Cloudflare Access SSH to ${HOST} (${TUNNEL_HOST}) failed with cloudflared exit ${status}. Check the cloudflared stderr below."
+      ;;
+  esac
+}
+
+emit_failure_marker() {
+  local status="$1"
+  local title message escaped_title escaped_message
+  title=$(failure_title)
+  message=$(failure_message "$status" "$title")
+  escaped_title=$(github_escape "$title")
+  escaped_message=$(github_escape "$message")
+
+  echo "::error title=${escaped_title}::${escaped_message}" >&2
+
+  if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+    {
+      echo "### ${title}"
+      echo ""
+      echo "- Host: \`${HOST}\`"
+      echo "- Tunnel: \`${TUNNEL_HOST}\`"
+      echo "- cloudflared exit: \`${status}\`"
+      echo "- Diagnosis: ${message}"
+      echo ""
+    } >> "$GITHUB_STEP_SUMMARY"
+  fi
+
+  if [ -s "$LOG_FILE" ]; then
+    echo "----- cloudflared stderr (last 20 lines, redacted) -----" >&2
+    redact_cloudflared_log | tail -n 20 >&2
+  fi
+}
+
+status=0
+"$CLOUDFLARED_BIN" access ssh \
+  --hostname "$TUNNEL_HOST" \
+  --id "$CF_ACCESS_CLIENT_ID" \
+  --secret "$CF_ACCESS_CLIENT_SECRET" \
+  2> "$LOG_FILE" || status=$?
+
+if [ "$status" -ne 0 ]; then
+  emit_failure_marker "$status"
+fi
+
+rm -f "$LOG_FILE"
+exit "$status"

--- a/.github/scripts/tests/cloudflare-ssh-proxy-test.sh
+++ b/.github/scripts/tests/cloudflare-ssh-proxy-test.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+PROXY="$REPO_ROOT/.github/scripts/cloudflare-ssh-proxy.sh"
+
+assert_contains() {
+  local file="$1"
+  local expected="$2"
+  if ! grep -Fq -- "$expected" "$file"; then
+    echo "expected ${file} to contain: ${expected}" >&2
+    echo "--- ${file} ---" >&2
+    cat "$file" >&2
+    exit 1
+  fi
+}
+
+assert_not_contains() {
+  local file="$1"
+  local unexpected="$2"
+  if grep -Fq -- "$unexpected" "$file"; then
+    echo "expected ${file} not to contain: ${unexpected}" >&2
+    echo "--- ${file} ---" >&2
+    cat "$file" >&2
+    exit 1
+  fi
+}
+
+make_home() {
+  local dir="$1"
+  mkdir -p "$dir/.ssh"
+  cat > "$dir/.ssh/cf-access.env" <<'EOF'
+export CF_ACCESS_CLIENT_ID="client-id"
+export CF_ACCESS_CLIENT_SECRET="super-secret"
+EOF
+}
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+home_success="$tmp/home-success"
+make_home "$home_success"
+args_file="$tmp/cloudflared.args"
+success_cloudflared="$tmp/cloudflared-success"
+cat > "$success_cloudflared" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" > "$FAKE_ARGS_FILE"
+exit 0
+EOF
+chmod +x "$success_cloudflared"
+
+HOME="$home_success" \
+CLOUDFLARED_BIN="$success_cloudflared" \
+FAKE_ARGS_FILE="$args_file" \
+"$PROXY" dev-1.aws.vm3.ai > "$tmp/success.out" 2> "$tmp/success.err"
+
+assert_contains "$args_file" "--hostname dev-1-aws-ssh.vm3.ai"
+assert_contains "$args_file" "--id client-id"
+assert_contains "$args_file" "--secret super-secret"
+assert_not_contains "$tmp/success.err" "::error"
+
+home_failure="$tmp/home-failure"
+make_home "$home_failure"
+summary="$tmp/summary.md"
+failure_cloudflared="$tmp/cloudflared-failure"
+cat > "$failure_cloudflared" <<'EOF'
+#!/usr/bin/env bash
+printf 'failed args: %s\n' "$*" >&2
+echo "Unable to reach the origin service: context canceled" >&2
+exit 255
+EOF
+chmod +x "$failure_cloudflared"
+
+status=0
+HOME="$home_failure" \
+CLOUDFLARED_BIN="$failure_cloudflared" \
+GITHUB_STEP_SUMMARY="$summary" \
+"$PROXY" dev-1.aws.vm3.ai > "$tmp/failure.out" 2> "$tmp/failure.err" || status=$?
+
+if [ "$status" -ne 255 ]; then
+  echo "expected failure status 255, got ${status}" >&2
+  exit 1
+fi
+
+assert_contains "$tmp/failure.err" "::error title=Metal Cloudflare tunnel unavailable::"
+assert_contains "$tmp/failure.err" "dev-1.aws.vm3.ai"
+assert_contains "$tmp/failure.err" "dev-1-aws-ssh.vm3.ai"
+assert_contains "$tmp/failure.err" "----- cloudflared stderr (last 20 lines, redacted) -----"
+assert_contains "$summary" "### Metal Cloudflare tunnel unavailable"
+assert_contains "$summary" "cloudflared exit: \`255\`"
+assert_not_contains "$tmp/failure.err" "super-secret"
+assert_not_contains "$summary" "super-secret"
+
+echo "cloudflare-ssh-proxy-test: ok"


### PR DESCRIPTION
## Summary
- install a shared Cloudflare SSH ProxyCommand script from setup-ssh-tunnel
- emit a GitHub error annotation and step summary when cloudflared cannot connect to a metal host
- include redacted cloudflared stderr tail and shell coverage for success/failure paths

## Tests
- bash -n .github/scripts/*.sh .github/scripts/tests/*.sh
- for test_script in .github/scripts/tests/*.sh; do bash "$test_script"; done