### PR TITLE
feat: add vercel sandbox smoke path

### DIFF
--- a/turbo/apps/api/package.json
+++ b/turbo/apps/api/package.json
@@ -31,6 +31,7 @@
     "@vercel/functions": "^3.4.4",
     "@vercel/oidc": "^3.2.1",
     "@vercel/otel": "^2.1.2",
+    "@vercel/sandbox": "^1.10.2",
     "@vm0/api-contracts": "workspace:*",
     "@vm0/connectors": "workspace:*",
     "@vm0/core": "workspace:*",

--- a/turbo/apps/api/src/__tests__/test-helpers.ts
+++ b/turbo/apps/api/src/__tests__/test-helpers.ts
@@ -12,6 +12,10 @@ import { createApp } from "../app-factory";
 import { closeDbPool } from "../lib/db";
 import { clearMockedEnv } from "../lib/env";
 import { clearMockListStripeInvoices } from "../signals/external/stripe-client";
+import {
+  clearMockVercelSandboxClient,
+  clearMockVercelSandboxSmokeCleanupTimeoutMs,
+} from "../signals/external/vercel-sandbox";
 import { ROUTES, type RouteEntry } from "../signals/route";
 import { clearAllDetached } from "../signals/utils";
 import { getApiTestMocks, type ApiTestMocks } from "./mocks";
@@ -135,6 +139,8 @@ export function testContext(): TestContext {
     await clearAllDetached();
     clearMockedEnv();
     clearMockListStripeInvoices();
+    clearMockVercelSandboxClient();
+    clearMockVercelSandboxSmokeCleanupTimeoutMs();
   });
 
   afterAll(async () => {

--- a/turbo/apps/api/src/signals/external/vercel-sandbox.ts
+++ b/turbo/apps/api/src/signals/external/vercel-sandbox.ts
@@ -1,0 +1,131 @@
+import { singleton, testOverride } from "../../lib/singleton";
+
+type VercelSandboxSdk = typeof import("@vercel/sandbox");
+
+export const VERCEL_SANDBOX_SMOKE_RUNTIME = "node24";
+export const VERCEL_SANDBOX_SMOKE_TIMEOUT_MS = 60 * 1000;
+const VERCEL_SANDBOX_SMOKE_CLEANUP_TIMEOUT_MS = 15 * 1000;
+
+export interface VercelSandboxCommandOptions {
+  readonly cmd: string;
+  readonly args?: readonly string[];
+  readonly signal?: AbortSignal;
+}
+
+export interface VercelSandboxCommandResult {
+  readonly exitCode: number;
+  readonly stdout: string;
+  readonly stderr: string;
+}
+
+export interface VercelSandboxInstance {
+  readonly id: string;
+  readonly runCommand: (
+    options: VercelSandboxCommandOptions,
+  ) => Promise<VercelSandboxCommandResult>;
+  readonly stop: (options?: { readonly signal?: AbortSignal }) => Promise<void>;
+}
+
+export interface CreateVercelSandboxOptions {
+  readonly runtime?: string;
+  readonly timeoutMs?: number;
+  readonly signal?: AbortSignal;
+}
+
+interface VercelSandboxClient {
+  readonly create: (
+    options?: CreateVercelSandboxOptions,
+  ) => Promise<VercelSandboxInstance>;
+}
+
+const getVercelSandboxClass = singleton(
+  async (): Promise<VercelSandboxSdk["Sandbox"]> => {
+    // This SDK is only needed by the smoke route; keep normal API route init light.
+    const sdk = await import("@vercel/sandbox");
+    return sdk.Sandbox;
+  },
+);
+
+function createRealVercelSandboxClient(): VercelSandboxClient {
+  return {
+    async create(options = {}): Promise<VercelSandboxInstance> {
+      const Sandbox = await getVercelSandboxClass();
+      const sandbox = await Sandbox.create({
+        runtime: options.runtime ?? VERCEL_SANDBOX_SMOKE_RUNTIME,
+        timeout: options.timeoutMs ?? VERCEL_SANDBOX_SMOKE_TIMEOUT_MS,
+        signal: options.signal,
+      });
+
+      return {
+        id: sandbox.sandboxId,
+        async runCommand(
+          commandOptions: VercelSandboxCommandOptions,
+        ): Promise<VercelSandboxCommandResult> {
+          const command = await sandbox.runCommand(
+            commandOptions.cmd,
+            [...(commandOptions.args ?? [])],
+            { signal: commandOptions.signal },
+          );
+          const [stdout, stderr] = await Promise.all([
+            command.stdout({ signal: commandOptions.signal }),
+            command.stderr({ signal: commandOptions.signal }),
+          ]);
+
+          return {
+            exitCode: command.exitCode,
+            stdout,
+            stderr,
+          };
+        },
+        async stop(options = {}): Promise<void> {
+          await sandbox.stop({ blocking: true, signal: options.signal });
+        },
+      };
+    },
+  };
+}
+
+const {
+  get: getMockedVercelSandboxClient,
+  set: setMockedVercelSandboxClient,
+  clear: clearMockedVercelSandboxClient,
+} = testOverride<VercelSandboxClient | undefined>(() => {
+  return undefined;
+});
+
+const {
+  get: getMockedVercelSandboxCleanupTimeoutMs,
+  set: setMockedVercelSandboxCleanupTimeoutMs,
+  clear: clearMockedVercelSandboxCleanupTimeoutMs,
+} = testOverride<number | undefined>(() => {
+  return undefined;
+});
+
+export function getVercelSandboxClient(): VercelSandboxClient {
+  return getMockedVercelSandboxClient() ?? createRealVercelSandboxClient();
+}
+
+export function getVercelSandboxSmokeCleanupTimeoutMs(): number {
+  return (
+    getMockedVercelSandboxCleanupTimeoutMs() ??
+    VERCEL_SANDBOX_SMOKE_CLEANUP_TIMEOUT_MS
+  );
+}
+
+export function mockVercelSandboxClient(client: VercelSandboxClient): void {
+  setMockedVercelSandboxClient(client);
+}
+
+export function clearMockVercelSandboxClient(): void {
+  clearMockedVercelSandboxClient();
+}
+
+export function mockVercelSandboxSmokeCleanupTimeoutMs(
+  timeoutMs: number,
+): void {
+  setMockedVercelSandboxCleanupTimeoutMs(timeoutMs);
+}
+
+export function clearMockVercelSandboxSmokeCleanupTimeoutMs(): void {
+  clearMockedVercelSandboxCleanupTimeoutMs();
+}

--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -45,6 +45,7 @@ import { modelStatsRoutes } from "./routes/model-stats";
 import { runnersRoutes } from "./routes/runners";
 import { usageRoutes } from "./routes/usage";
 import { userExportRoutes } from "./routes/user-export";
+import { vercelSandboxSmokeRoutes } from "./routes/vercel-sandbox-smoke";
 import { webhooksClerkRoutes } from "./routes/webhooks-clerk";
 import { webhooksGithubRoutes } from "./routes/webhooks-github";
 import { webhooksStripeRoutes } from "./routes/webhooks-stripe";
@@ -178,6 +179,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...logsSearchRoutes,
   ...usageRoutes,
   ...userExportRoutes,
+  ...vercelSandboxSmokeRoutes,
   ...webhooksClerkRoutes,
   ...webhooksGithubRoutes,
   ...webhooksStripeRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/vercel-sandbox-smoke.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/vercel-sandbox-smoke.test.ts
@@ -1,0 +1,439 @@
+import { mockEnv } from "../../../lib/env";
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import {
+  mockVercelSandboxClient,
+  mockVercelSandboxSmokeCleanupTimeoutMs,
+  type CreateVercelSandboxOptions,
+  type VercelSandboxCommandOptions,
+  type VercelSandboxCommandResult,
+} from "../../external/vercel-sandbox";
+import { vercelSandboxSmokeContract } from "../vercel-sandbox-smoke";
+
+const context = testContext();
+
+function client() {
+  return setupApp({ context })(vercelSandboxSmokeContract);
+}
+
+function mockSandbox(
+  args: {
+    readonly createError?: unknown;
+    readonly runError?: unknown;
+    readonly stopError?: unknown;
+    readonly stop?: (options?: {
+      readonly signal?: AbortSignal;
+    }) => Promise<void>;
+    readonly runResult?: VercelSandboxCommandResult;
+  } = {},
+) {
+  const calls = {
+    create: [] as CreateVercelSandboxOptions[],
+    run: [] as VercelSandboxCommandOptions[],
+    stop: [] as ({ readonly signal?: AbortSignal } | undefined)[],
+  };
+
+  mockVercelSandboxClient({
+    create(options = {}) {
+      calls.create.push(options);
+      if (args.createError !== undefined) {
+        throw args.createError;
+      }
+
+      return Promise.resolve({
+        id: "sandbox_smoke_test",
+        runCommand(options) {
+          calls.run.push(options);
+          if (args.runError !== undefined) {
+            throw args.runError;
+          }
+          return Promise.resolve(
+            args.runResult ?? {
+              exitCode: 0,
+              stdout: "v24.0.0\n",
+              stderr: "",
+            },
+          );
+        },
+        stop(options) {
+          calls.stop.push(options);
+          if (args.stopError !== undefined) {
+            throw args.stopError;
+          }
+          if (args.stop) {
+            return args.stop(options);
+          }
+          return Promise.resolve();
+        },
+      });
+    },
+  });
+
+  return calls;
+}
+
+function abortError(message: string): Error {
+  const error = new Error(message);
+  error.name = "AbortError";
+  return error;
+}
+
+describe("POST /api/internal/vercel-sandbox/smoke", () => {
+  beforeEach(() => {
+    mockEnv("CRON_SECRET", "test-cron-secret");
+  });
+
+  it("requires the cron secret", async () => {
+    const calls = mockSandbox();
+
+    const response = await accept(
+      client().smoke({
+        headers: { authorization: "Bearer wrong" },
+      }),
+      [401],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Invalid cron secret", code: "UNAUTHORIZED" },
+    });
+    expect(calls.create).toHaveLength(0);
+    expect(calls.stop).toHaveLength(0);
+  });
+
+  it("does not create a sandbox when the authorization header is missing", async () => {
+    const calls = mockSandbox();
+
+    const response = await accept(client().smoke({ headers: {} }), [401]);
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Invalid cron secret", code: "UNAUTHORIZED" },
+    });
+    expect(calls.create).toHaveLength(0);
+    expect(calls.stop).toHaveLength(0);
+  });
+
+  it("runs the fixed smoke command and stops the sandbox", async () => {
+    const calls = mockSandbox();
+
+    const response = await accept(
+      client().smoke({
+        headers: { authorization: "Bearer test-cron-secret" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      success: true,
+      sandbox: {
+        id: "sandbox_smoke_test",
+        runtime: "node24",
+      },
+      command: {
+        cmd: "node",
+        args: ["--version"],
+        exitCode: 0,
+        stdout: "v24.0.0\n",
+        stderr: "",
+      },
+      cleanup: { status: "stopped" },
+    });
+    expect(calls.create).toHaveLength(1);
+    expect(calls.create[0]).toMatchObject({
+      runtime: "node24",
+      timeoutMs: 60_000,
+    });
+    expect(calls.run).toHaveLength(1);
+    expect(calls.run[0]).toMatchObject({
+      cmd: "node",
+      args: ["--version"],
+    });
+    expect(calls.stop).toHaveLength(1);
+    expect(calls.stop[0]?.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("returns a failure when sandbox creation fails", async () => {
+    const calls = mockSandbox({
+      createError: new Error("create failed token=secret"),
+    });
+
+    const response = await accept(
+      client().smoke({
+        headers: { authorization: "Bearer test-cron-secret" },
+      }),
+      [503],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Vercel Sandbox smoke check failed during sandbox creation",
+        code: "VERCEL_SANDBOX_SMOKE_FAILED",
+        phase: "create",
+        cause: {
+          name: "Error",
+          message: "create failed token=[redacted]",
+        },
+      },
+    });
+    expect(calls.stop).toHaveLength(0);
+  });
+
+  it("redacts non-error sandbox creation failures", async () => {
+    const calls = mockSandbox({
+      createError:
+        'create failed Bearer sandbox-token password=plain-text VERCEL_OIDC_TOKEN=oidc-secret {"access_token":"json-secret"}',
+    });
+
+    const response = await accept(
+      client().smoke({
+        headers: { authorization: "Bearer test-cron-secret" },
+      }),
+      [503],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Vercel Sandbox smoke check failed during sandbox creation",
+        code: "VERCEL_SANDBOX_SMOKE_FAILED",
+        phase: "create",
+        cause: {
+          name: "Error",
+          message:
+            'create failed Bearer [redacted] password=[redacted] VERCEL_OIDC_TOKEN=[redacted] {"access_token":"[redacted]"}',
+        },
+      },
+    });
+    expect(calls.stop).toHaveLength(0);
+  });
+
+  it("stops the sandbox when command execution fails", async () => {
+    const calls = mockSandbox({
+      runError: new Error("run failed"),
+    });
+
+    const response = await accept(
+      client().smoke({
+        headers: { authorization: "Bearer test-cron-secret" },
+      }),
+      [503],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Vercel Sandbox smoke check failed during command execution",
+        code: "VERCEL_SANDBOX_SMOKE_FAILED",
+        phase: "run",
+        cause: {
+          name: "Error",
+          message: "run failed",
+        },
+      },
+      sandbox: {
+        id: "sandbox_smoke_test",
+        runtime: "node24",
+      },
+      cleanup: { status: "stopped" },
+    });
+    expect(calls.run).toHaveLength(1);
+    expect(calls.stop).toHaveLength(1);
+  });
+
+  it("preserves the command failure when cleanup also fails", async () => {
+    const calls = mockSandbox({
+      runError: new Error("run failed"),
+      stopError: new Error("stop failed"),
+    });
+
+    const response = await accept(
+      client().smoke({
+        headers: { authorization: "Bearer test-cron-secret" },
+      }),
+      [503],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Vercel Sandbox smoke check failed during command execution",
+        code: "VERCEL_SANDBOX_SMOKE_FAILED",
+        phase: "run",
+        cause: {
+          name: "Error",
+          message: "run failed",
+        },
+      },
+      sandbox: {
+        id: "sandbox_smoke_test",
+        runtime: "node24",
+      },
+      cleanup: {
+        status: "failed",
+        error: {
+          name: "Error",
+          message: "stop failed",
+        },
+      },
+    });
+    expect(calls.run).toHaveLength(1);
+    expect(calls.stop).toHaveLength(1);
+  });
+
+  it("stops the sandbox when command execution is aborted", async () => {
+    const calls = mockSandbox({
+      runError: abortError("request aborted"),
+    });
+
+    const response = await accept(
+      client().smoke({
+        headers: { authorization: "Bearer test-cron-secret" },
+      }),
+      [503],
+    );
+
+    expect(response.body.error).toStrictEqual({
+      message: "Vercel Sandbox smoke check failed during command execution",
+      code: "VERCEL_SANDBOX_SMOKE_FAILED",
+      phase: "run",
+      cause: {
+        name: "AbortError",
+        message: "request aborted",
+      },
+    });
+    expect(response.body.cleanup).toStrictEqual({ status: "stopped" });
+    expect(calls.stop).toHaveLength(1);
+  });
+
+  it("fails cleanup when sandbox stop waits for the cleanup timeout", async () => {
+    mockVercelSandboxSmokeCleanupTimeoutMs(0);
+    const calls = mockSandbox({
+      stop(options) {
+        return new Promise((_resolve, reject) => {
+          const signal = options?.signal;
+          if (!signal) {
+            reject(new Error("stop called without a cleanup signal"));
+            return;
+          }
+          if (signal.aborted) {
+            reject(signal.reason);
+            return;
+          }
+          signal.addEventListener(
+            "abort",
+            () => {
+              reject(signal.reason);
+            },
+            { once: true },
+          );
+        });
+      },
+    });
+
+    const response = await accept(
+      client().smoke({
+        headers: { authorization: "Bearer test-cron-secret" },
+      }),
+      [503],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Vercel Sandbox smoke check failed during sandbox cleanup",
+        code: "VERCEL_SANDBOX_SMOKE_FAILED",
+        phase: "cleanup",
+        cause: {
+          name: "AbortError",
+          message: "Vercel Sandbox cleanup timed out",
+        },
+      },
+      sandbox: {
+        id: "sandbox_smoke_test",
+        runtime: "node24",
+      },
+      command: {
+        cmd: "node",
+        args: ["--version"],
+        exitCode: 0,
+        stdout: "v24.0.0\n",
+        stderr: "",
+      },
+      cleanup: {
+        status: "failed",
+        error: {
+          name: "AbortError",
+          message: "Vercel Sandbox cleanup timed out",
+        },
+      },
+    });
+    expect(calls.stop).toHaveLength(1);
+    expect(calls.stop[0]?.signal?.aborted).toBeTruthy();
+  });
+
+  it("returns command diagnostics when cleanup fails", async () => {
+    const calls = mockSandbox({
+      stopError: new Error("stop failed"),
+    });
+
+    const response = await accept(
+      client().smoke({
+        headers: { authorization: "Bearer test-cron-secret" },
+      }),
+      [503],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Vercel Sandbox smoke check failed during sandbox cleanup",
+        code: "VERCEL_SANDBOX_SMOKE_FAILED",
+        phase: "cleanup",
+        cause: {
+          name: "Error",
+          message: "stop failed",
+        },
+      },
+      sandbox: {
+        id: "sandbox_smoke_test",
+        runtime: "node24",
+      },
+      command: {
+        cmd: "node",
+        args: ["--version"],
+        exitCode: 0,
+        stdout: "v24.0.0\n",
+        stderr: "",
+      },
+      cleanup: {
+        status: "failed",
+        error: {
+          name: "Error",
+          message: "stop failed",
+        },
+      },
+    });
+    expect(calls.stop).toHaveLength(1);
+  });
+
+  it("treats a non-zero command exit as a smoke failure", async () => {
+    const calls = mockSandbox({
+      runResult: {
+        exitCode: 1,
+        stdout: "",
+        stderr: "unexpected\n",
+      },
+    });
+
+    const response = await accept(
+      client().smoke({
+        headers: { authorization: "Bearer test-cron-secret" },
+      }),
+      [503],
+    );
+
+    expect(response.body.error.phase).toBe("run");
+    expect(response.body.command).toStrictEqual({
+      cmd: "node",
+      args: ["--version"],
+      exitCode: 1,
+      stdout: "",
+      stderr: "unexpected\n",
+    });
+    expect(response.body.cleanup).toStrictEqual({ status: "stopped" });
+    expect(calls.stop).toHaveLength(1);
+  });
+});

--- a/turbo/apps/api/src/signals/routes/vercel-sandbox-smoke.ts
+++ b/turbo/apps/api/src/signals/routes/vercel-sandbox-smoke.ts
@@ -1,0 +1,138 @@
+import { initContract } from "@ts-rest/core";
+import { command } from "ccstate";
+import { z } from "zod";
+
+import type { RouteEntry } from "../route";
+import {
+  runVercelSandboxSmoke,
+  type VercelSandboxSmokeResult,
+} from "../services/vercel-sandbox-smoke.service";
+import { cronUnauthorized, hasValidCronSecret } from "./cron-auth";
+
+const c = initContract();
+
+const smokeErrorSchema = z.object({
+  name: z.string(),
+  message: z.string(),
+});
+
+const smokeSandboxSchema = z.object({
+  id: z.string(),
+  runtime: z.literal("node24"),
+});
+
+const smokeCommandSchema = z.object({
+  cmd: z.literal("node"),
+  args: z.tuple([z.literal("--version")]),
+  exitCode: z.number().int(),
+  stdout: z.string(),
+  stderr: z.string(),
+});
+
+const smokeCleanupSchema = z.discriminatedUnion("status", [
+  z.object({ status: z.literal("stopped") }),
+  z.object({
+    status: z.literal("failed"),
+    error: smokeErrorSchema,
+  }),
+]);
+
+const smokeFailureSchema = z.object({
+  error: z.object({
+    message: z.string(),
+    code: z.literal("VERCEL_SANDBOX_SMOKE_FAILED"),
+    phase: z.enum(["create", "run", "cleanup"]),
+    cause: smokeErrorSchema,
+  }),
+  sandbox: smokeSandboxSchema.optional(),
+  command: smokeCommandSchema.optional(),
+  cleanup: smokeCleanupSchema.optional(),
+});
+
+const unauthorizedSchema = z.object({
+  error: z.object({
+    message: z.string(),
+    code: z.literal("UNAUTHORIZED"),
+  }),
+});
+
+export const vercelSandboxSmokeContract = c.router({
+  smoke: {
+    method: "POST",
+    path: "/api/internal/vercel-sandbox/smoke",
+    body: c.noBody(),
+    headers: z.object({
+      authorization: z.string().optional(),
+    }),
+    responses: {
+      200: z.object({
+        success: z.literal(true),
+        sandbox: smokeSandboxSchema,
+        command: smokeCommandSchema,
+        cleanup: z.object({ status: z.literal("stopped") }),
+      }),
+      401: unauthorizedSchema,
+      503: smokeFailureSchema,
+    },
+    summary: "Run a fixed Vercel Sandbox smoke check",
+  },
+});
+
+function failureMessage(
+  result: Extract<VercelSandboxSmokeResult, { ok: false }>,
+) {
+  switch (result.phase) {
+    case "create": {
+      return "Vercel Sandbox smoke check failed during sandbox creation";
+    }
+    case "run": {
+      return "Vercel Sandbox smoke check failed during command execution";
+    }
+    case "cleanup": {
+      return "Vercel Sandbox smoke check failed during sandbox cleanup";
+    }
+  }
+}
+
+const vercelSandboxSmokeRoute$ = command(
+  async ({ get }, signal: AbortSignal) => {
+    if (!hasValidCronSecret(get)) {
+      return cronUnauthorized();
+    }
+
+    const result = await runVercelSandboxSmoke(signal);
+    if (result.ok) {
+      return {
+        status: 200 as const,
+        body: {
+          success: true as const,
+          sandbox: result.sandbox,
+          command: result.command,
+          cleanup: result.cleanup,
+        },
+      };
+    }
+
+    return {
+      status: 503 as const,
+      body: {
+        error: {
+          message: failureMessage(result),
+          code: "VERCEL_SANDBOX_SMOKE_FAILED" as const,
+          phase: result.phase,
+          cause: result.error,
+        },
+        ...(result.sandbox ? { sandbox: result.sandbox } : {}),
+        ...(result.command ? { command: result.command } : {}),
+        ...(result.cleanup ? { cleanup: result.cleanup } : {}),
+      },
+    };
+  },
+);
+
+export const vercelSandboxSmokeRoutes: readonly RouteEntry[] = [
+  {
+    route: vercelSandboxSmokeContract.smoke,
+    handler: vercelSandboxSmokeRoute$,
+  },
+];

--- a/turbo/apps/api/src/signals/services/vercel-sandbox-smoke.service.ts
+++ b/turbo/apps/api/src/signals/services/vercel-sandbox-smoke.service.ts
@@ -1,0 +1,305 @@
+import { timeout } from "signal-timers";
+
+import {
+  getVercelSandboxClient,
+  getVercelSandboxSmokeCleanupTimeoutMs,
+  VERCEL_SANDBOX_SMOKE_RUNTIME,
+  VERCEL_SANDBOX_SMOKE_TIMEOUT_MS,
+  type VercelSandboxCommandResult,
+  type VercelSandboxInstance,
+} from "../external/vercel-sandbox";
+
+const SMOKE_COMMAND = Object.freeze({
+  cmd: "node",
+  args: ["--version"] as const,
+});
+
+type SandboxOperationResult<T> =
+  | { readonly ok: true; readonly value: T }
+  | { readonly ok: false; readonly error: unknown };
+
+export type VercelSandboxSmokePhase = "create" | "run" | "cleanup";
+
+export interface VercelSandboxSmokeError {
+  readonly message: string;
+  readonly name: string;
+}
+
+export type VercelSandboxSmokeCleanup =
+  | {
+      readonly status: "stopped";
+    }
+  | {
+      readonly status: "failed";
+      readonly error: VercelSandboxSmokeError;
+    };
+
+export interface VercelSandboxSmokeCommand {
+  readonly cmd: typeof SMOKE_COMMAND.cmd;
+  readonly args: typeof SMOKE_COMMAND.args;
+  readonly exitCode: number;
+  readonly stdout: string;
+  readonly stderr: string;
+}
+
+export interface VercelSandboxSmokeSandbox {
+  readonly id: string;
+  readonly runtime: typeof VERCEL_SANDBOX_SMOKE_RUNTIME;
+}
+
+export type VercelSandboxSmokeResult =
+  | {
+      readonly ok: true;
+      readonly sandbox: VercelSandboxSmokeSandbox;
+      readonly command: VercelSandboxSmokeCommand;
+      readonly cleanup: { readonly status: "stopped" };
+    }
+  | {
+      readonly ok: false;
+      readonly phase: VercelSandboxSmokePhase;
+      readonly error: VercelSandboxSmokeError;
+      readonly sandbox?: VercelSandboxSmokeSandbox;
+      readonly command?: VercelSandboxSmokeCommand;
+      readonly cleanup?: VercelSandboxSmokeCleanup;
+    };
+
+function redactErrorMessage(message: string): string {
+  return message
+    .replace(/Bearer\s+[A-Za-z0-9._~+/=-]+/gi, "Bearer [redacted]")
+    .replace(
+      /(["']?\b[\w.-]*(?:token|secret|password)[\w.-]*\b["']?\s*[:=]\s*)(["']?)[^"',}&\s]+(["']?)/gi,
+      "$1$2[redacted]$3",
+    )
+    .slice(0, 1000);
+}
+
+function smokeError(error: unknown): VercelSandboxSmokeError {
+  if (error instanceof Error) {
+    return {
+      name: error.name,
+      message: redactErrorMessage(error.message),
+    };
+  }
+
+  return {
+    name: "Error",
+    message: redactErrorMessage(String(error)),
+  };
+}
+
+function sandboxInfo(
+  sandbox: VercelSandboxInstance,
+): VercelSandboxSmokeSandbox {
+  return {
+    id: sandbox.id,
+    runtime: VERCEL_SANDBOX_SMOKE_RUNTIME,
+  };
+}
+
+function commandInfo(
+  result: VercelSandboxCommandResult,
+): VercelSandboxSmokeCommand {
+  return {
+    cmd: SMOKE_COMMAND.cmd,
+    args: SMOKE_COMMAND.args,
+    exitCode: result.exitCode,
+    stdout: result.stdout,
+    stderr: result.stderr,
+  };
+}
+
+function sandboxOperation<T>(
+  fn: () => Promise<T>,
+): Promise<SandboxOperationResult<T>> {
+  return Promise.resolve()
+    .then(fn)
+    .then(
+      (value) => {
+        return { ok: true, value } as const;
+      },
+      (error: unknown) => {
+        return { ok: false, error } as const;
+      },
+    );
+}
+
+function cleanupTimeoutError(): Error {
+  const error = new Error("Vercel Sandbox cleanup timed out");
+  error.name = "AbortError";
+  return error;
+}
+
+function canceledCleanupTimeoutResult(
+  signal: AbortSignal,
+): SandboxOperationResult<void> {
+  return {
+    ok: false,
+    error:
+      signal.reason ?? new Error("Vercel Sandbox cleanup timeout canceled"),
+  };
+}
+
+function cleanupTimeoutResult(
+  cleanupController: AbortController,
+): SandboxOperationResult<void> {
+  const error = cleanupTimeoutError();
+  cleanupController.abort(error);
+
+  return { ok: false, error };
+}
+
+function cleanupTimeoutOperation(
+  cleanupController: AbortController,
+  cleanupTimeoutSignal: AbortSignal,
+): Promise<SandboxOperationResult<void>> {
+  return new Promise((resolve) => {
+    let settled = false;
+    function finish(result: SandboxOperationResult<void>) {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      cleanupTimeoutSignal.removeEventListener("abort", onAbort);
+      resolve(result);
+    }
+    function onAbort() {
+      finish(canceledCleanupTimeoutResult(cleanupTimeoutSignal));
+    }
+
+    cleanupTimeoutSignal.addEventListener("abort", onAbort, { once: true });
+    timeout(
+      () => {
+        finish(cleanupTimeoutResult(cleanupController));
+      },
+      getVercelSandboxSmokeCleanupTimeoutMs(),
+      { signal: cleanupTimeoutSignal },
+    );
+  });
+}
+
+async function stopSandbox(
+  sandbox: VercelSandboxInstance,
+): Promise<VercelSandboxSmokeCleanup> {
+  const cleanupController = new AbortController();
+  const cleanupTimeoutController = new AbortController();
+  const stopResultPromise = sandboxOperation(() => {
+    return sandbox.stop({ signal: cleanupController.signal });
+  });
+  const cleanupTimeoutResultPromise = cleanupTimeoutOperation(
+    cleanupController,
+    cleanupTimeoutController.signal,
+  );
+
+  const stopResult = await Promise.race([
+    stopResultPromise,
+    cleanupTimeoutResultPromise,
+  ]).finally(() => {
+    cleanupTimeoutController.abort();
+  });
+
+  if (stopResult.ok) {
+    return { status: "stopped" };
+  }
+
+  return {
+    status: "failed",
+    error: smokeError(stopResult.error),
+  };
+}
+
+export async function runVercelSandboxSmoke(
+  signal: AbortSignal,
+): Promise<VercelSandboxSmokeResult> {
+  const client = getVercelSandboxClient();
+  const createResult = await sandboxOperation(() => {
+    return client.create({
+      runtime: VERCEL_SANDBOX_SMOKE_RUNTIME,
+      timeoutMs: VERCEL_SANDBOX_SMOKE_TIMEOUT_MS,
+      signal,
+    });
+  });
+
+  if (!createResult.ok) {
+    return {
+      ok: false,
+      phase: "create",
+      error: smokeError(createResult.error),
+    };
+  }
+
+  const sandbox = createResult.value;
+  let command: VercelSandboxSmokeCommand | undefined;
+  let runError: VercelSandboxSmokeError | undefined;
+
+  const runResult = await sandboxOperation(() => {
+    return sandbox.runCommand({
+      cmd: SMOKE_COMMAND.cmd,
+      args: SMOKE_COMMAND.args,
+      signal,
+    });
+  });
+
+  if (runResult.ok) {
+    command = commandInfo(runResult.value);
+  } else {
+    runError = smokeError(runResult.error);
+  }
+
+  const cleanup = await stopSandbox(sandbox);
+  const sandboxPayload = sandboxInfo(sandbox);
+
+  if (runError) {
+    return {
+      ok: false,
+      phase: "run",
+      error: runError,
+      sandbox: sandboxPayload,
+      cleanup,
+    };
+  }
+
+  if (!command) {
+    return {
+      ok: false,
+      phase: "run",
+      error: {
+        name: "Error",
+        message: "Smoke command did not produce a result",
+      },
+      sandbox: sandboxPayload,
+      cleanup,
+    };
+  }
+
+  if (command.exitCode !== 0) {
+    return {
+      ok: false,
+      phase: "run",
+      error: {
+        name: "Error",
+        message: `Smoke command exited with code ${command.exitCode}`,
+      },
+      sandbox: sandboxPayload,
+      command,
+      cleanup,
+    };
+  }
+
+  if (cleanup.status === "failed") {
+    return {
+      ok: false,
+      phase: "cleanup",
+      error: cleanup.error,
+      sandbox: sandboxPayload,
+      command,
+      cleanup,
+    };
+  }
+
+  return {
+    ok: true,
+    sandbox: sandboxPayload,
+    command,
+    cleanup,
+  };
+}

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -156,6 +156,9 @@ importers:
       '@vercel/otel':
         specifier: ^2.1.2
         version: 2.1.2(@opentelemetry/api-logs@0.215.0)(@opentelemetry/api@1.9.1)(@opentelemetry/instrumentation@0.215.0(@opentelemetry/api@1.9.1))(@opentelemetry/resources@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.215.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))
+      '@vercel/sandbox':
+        specifier: ^1.10.2
+        version: 1.10.2
       '@vm0/api-contracts':
         specifier: workspace:*
         version: link:../../packages/api-contracts
@@ -5509,6 +5512,10 @@ packages:
       '@aws-sdk/credential-provider-web-identity':
         optional: true
 
+  '@vercel/oidc@3.2.0':
+    resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
+    engines: {node: '>= 20'}
+
   '@vercel/oidc@3.2.1':
     resolution: {integrity: sha512-UUqZ2y+VXHgVH1Luoo+477/NcrO4X+ln38U70ldRgGiWJAuHhtjTm7cCAnyLkl2feg7ZmTBK3F1kvJKFEQc01w==}
     engines: {node: '>= 20'}
@@ -5524,6 +5531,9 @@ packages:
       '@opentelemetry/sdk-logs': '>=0.200.0 <0.300.0'
       '@opentelemetry/sdk-metrics': '>=2.0.0 <3.0.0'
       '@opentelemetry/sdk-trace-base': '>=2.0.0 <3.0.0'
+
+  '@vercel/sandbox@1.10.2':
+    resolution: {integrity: sha512-rWhYfIyW0Va0gFxtz434LhVirV+eQs+AK0QQWtsOPw2oTvOSA4iogQqemRqvRPPbqI8nfZOz6kbCsytVa20gdw==}
 
   '@vitejs/plugin-react@6.0.1':
     resolution: {integrity: sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ==}
@@ -5616,6 +5626,9 @@ packages:
   '@wallet-standard/wallet@1.1.0':
     resolution: {integrity: sha512-Gt8TnSlDZpAl+RWOOAB/kuvC7RpcdWAlFbHNoi4gsXsfaWa1QCT6LBcfIYTPdOZC9OVZUDwqGuGAcqZejDmHjg==}
     engines: {node: '>=16'}
+
+  '@workflow/serde@4.1.0-beta.2':
+    resolution: {integrity: sha512-8kkeoQKLDaKXefjV5dbhBj2aErfKp1Mc4pb6tj8144cF+Em5SPbyMbyLCHp+BVrFfFVCBluCtMx+jjvaFVZGww==}
 
   '@zxcvbn-ts/core@3.0.4':
     resolution: {integrity: sha512-aQeiT0F09FuJaAqNrxynlAwZ2mW/1MdXakKWNmGM1Qp/VaY6CnB/GfnMS2T8gB2231Esp1/maCWd8vTG4OuShw==}
@@ -5777,6 +5790,9 @@ packages:
   async-function@1.0.0:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
     engines: {node: '>= 0.4'}
+
+  async-retry@1.3.3:
+    resolution: {integrity: sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==}
 
   async@3.2.6:
     resolution: {integrity: sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==}
@@ -7348,6 +7364,9 @@ packages:
   jsonc-parser@3.3.1:
     resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
 
+  jsonlines@0.1.1:
+    resolution: {integrity: sha512-ekDrAGso79Cvf+dtm+mL8OBI2bmAOt3gssYs833De/C9NmIpWDWyUO4zPgB5x2/OhY366dkhgfPMYfwZF7yOZA==}
+
   jsx-ast-utils@3.3.5:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
@@ -7928,6 +7947,10 @@ packages:
 
   orderedmap@2.1.1:
     resolution: {integrity: sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==}
+
+  os-paths@4.4.0:
+    resolution: {integrity: sha512-wrAwOeXp1RRMFfQY8Sy7VaGVmPocaLwSFOYCGKSyo8qmJ+/yaafCl5BCA1IQZWqFSRBrKDYFeR9d/VyQzfH/jg==}
+    engines: {node: '>= 6.0'}
 
   outvariant@1.4.3:
     resolution: {integrity: sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==}
@@ -8856,6 +8879,9 @@ packages:
     resolution: {integrity: sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==}
     engines: {node: '>=6'}
 
+  tar-stream@3.1.7:
+    resolution: {integrity: sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==}
+
   tar-stream@3.1.8:
     resolution: {integrity: sha512-U6QpVRyCGHva435KoNWy9PRoi2IFYCgtEhq9nmrPPpbRacPs9IH4aJ3gbrFC8dPcXvdSZ4XXfXT5Fshbp2MtlQ==}
 
@@ -9039,6 +9065,10 @@ packages:
   undici@6.24.1:
     resolution: {integrity: sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==}
     engines: {node: '>=18.17'}
+
+  undici@7.25.0:
+    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
+    engines: {node: '>=20.18.1'}
 
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
@@ -9385,6 +9415,14 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
+
+  xdg-app-paths@5.1.0:
+    resolution: {integrity: sha512-RAQ3WkPf4KTU1A8RtFx3gWywzVKe00tfOPFfl2NDGqbIFENQO4kqAJp7mhQjNj/33W5x5hiWWUdyfPq/5SU3QA==}
+    engines: {node: '>=6'}
+
+  xdg-portable@7.3.0:
+    resolution: {integrity: sha512-sqMMuL1rc0FmMBOzCpd0yuy9trqF2yTTVe+E9ogwCSWQCdDEtQUwrZPT6AxqtsFGRNxycgncbP/xmOOSPw5ZUw==}
+    engines: {node: '>= 6.0'}
 
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
@@ -14098,6 +14136,8 @@ snapshots:
     optionalDependencies:
       '@aws-sdk/credential-provider-web-identity': 3.972.38
 
+  '@vercel/oidc@3.2.0': {}
+
   '@vercel/oidc@3.2.1': {}
 
   '@vercel/otel@2.1.2(@opentelemetry/api-logs@0.215.0)(@opentelemetry/api@1.9.1)(@opentelemetry/instrumentation@0.215.0(@opentelemetry/api@1.9.1))(@opentelemetry/resources@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.215.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))':
@@ -14109,6 +14149,22 @@ snapshots:
       '@opentelemetry/sdk-logs': 0.215.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-metrics': 2.7.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 2.7.0(@opentelemetry/api@1.9.1)
+
+  '@vercel/sandbox@1.10.2':
+    dependencies:
+      '@vercel/oidc': 3.2.0
+      '@workflow/serde': 4.1.0-beta.2
+      async-retry: 1.3.3
+      jsonlines: 0.1.1
+      ms: 2.1.3
+      picocolors: 1.1.1
+      tar-stream: 3.1.7
+      undici: 7.25.0
+      xdg-app-paths: 5.1.0
+      zod: 4.3.6
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
 
   '@vitejs/plugin-react@6.0.1(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
@@ -14286,6 +14342,8 @@ snapshots:
   '@wallet-standard/wallet@1.1.0':
     dependencies:
       '@wallet-standard/base': 1.1.0
+
+  '@workflow/serde@4.1.0-beta.2': {}
 
   '@zxcvbn-ts/core@3.0.4':
     dependencies:
@@ -14490,6 +14548,10 @@ snapshots:
       js-tokens: 10.0.0
 
   async-function@1.0.0: {}
+
+  async-retry@1.3.3:
+    dependencies:
+      retry: 0.13.1
 
   async@3.2.6: {}
 
@@ -16139,6 +16201,8 @@ snapshots:
 
   jsonc-parser@3.3.1: {}
 
+  jsonlines@0.1.1: {}
+
   jsx-ast-utils@3.3.5:
     dependencies:
       array-includes: 3.1.9
@@ -16916,6 +16980,8 @@ snapshots:
       word-wrap: 1.2.5
 
   orderedmap@2.1.1: {}
+
+  os-paths@4.4.0: {}
 
   outvariant@1.4.3: {}
 
@@ -18101,6 +18167,15 @@ snapshots:
 
   tapable@2.3.2: {}
 
+  tar-stream@3.1.7:
+    dependencies:
+      b4a: 1.8.0
+      fast-fifo: 1.3.2
+      streamx: 2.25.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
   tar-stream@3.1.8:
     dependencies:
       b4a: 1.8.0
@@ -18311,6 +18386,8 @@ snapshots:
   undici-types@7.10.0: {}
 
   undici@6.24.1: {}
+
+  undici@7.25.0: {}
 
   unified@11.0.5:
     dependencies:
@@ -18653,6 +18730,14 @@ snapshots:
   ws@8.18.3: {}
 
   ws@8.20.0: {}
+
+  xdg-app-paths@5.1.0:
+    dependencies:
+      xdg-portable: 7.3.0
+
+  xdg-portable@7.3.0:
+    dependencies:
+      os-paths: 4.4.0
 
   xtend@4.0.2: {}
 


### PR DESCRIPTION
## Summary
- add an internal cron-secret protected Vercel Sandbox smoke endpoint at POST /api/internal/vercel-sandbox/smoke
- run a fixed `node --version` command in a node24 sandbox with a 60s sandbox lifetime
- always stop the sandbox after creation succeeds, including command failure/abort paths
- bound cleanup with an independent 15s stop timeout so transient stop hangs cannot hold the request indefinitely
- lazy-load the Vercel Sandbox SDK so normal API route initialization does not execute the smoke-only SDK path
- add route-level test coverage for auth no-ops, create/run/cleanup failures, command abort, cleanup stop signal, cleanup timeout, broader secret redaction, combined run+cleanup failure, and non-zero command exit

## Operational notes
- No new app env var is required; Vercel Sandbox auth uses Vercel OIDC in the Vercel-deployed API runtime.
- Caller auth is the existing `Authorization: Bearer ${CRON_SECRET}` pattern.
- API build was verified so the new SDK dependency bundles into the Vercel function output.

## Tests
- pnpm --filter api build
- pnpm --filter api lint
- pnpm --filter api check-types
- pnpm --filter api exec vitest run src/signals/routes/__tests__/vercel-sandbox-smoke.test.ts
- pnpm knip --cache
- pnpm install --frozen-lockfile --ignore-scripts --child-concurrency=1 --network-concurrency=1
- pre-commit: prettier, knip --cache, turbo run check-types --concurrency=1

Closes #13130
