### PR TITLE
test: speed up guest-agent integration retries

### DIFF
--- a/crates/guest-agent/src/heartbeat.rs
+++ b/crates/guest-agent/src/heartbeat.rs
@@ -27,14 +27,19 @@ pub async fn heartbeat_loop(
     http: HttpClient,
     shutdown: CancellationToken,
 ) -> Result<(), AgentError> {
-    heartbeat_loop_with_interval(http, shutdown, constants::HEARTBEAT_INTERVAL_SECS).await
+    heartbeat_loop_with_interval(
+        http,
+        shutdown,
+        Duration::from_secs(constants::HEARTBEAT_INTERVAL_SECS),
+    )
+    .await
 }
 
-/// Like [`heartbeat_loop`] but with a configurable interval (for testing).
+/// Like [`heartbeat_loop`] but with a configurable interval.
 pub async fn heartbeat_loop_with_interval(
     http: HttpClient,
     shutdown: CancellationToken,
-    interval_secs: u64,
+    interval: Duration,
 ) -> Result<(), AgentError> {
     // No API token → local/test mode; heartbeat has no server to reach.
     if !env::has_api() {
@@ -42,7 +47,7 @@ pub async fn heartbeat_loop_with_interval(
         return Ok(());
     }
 
-    let mut interval = tokio::time::interval(Duration::from_secs(interval_secs));
+    let mut interval = tokio::time::interval(interval);
     let mut is_first = true;
     let mut consecutive_failures: u32 = 0;
 

--- a/crates/guest-agent/src/http.rs
+++ b/crates/guest-agent/src/http.rs
@@ -116,7 +116,7 @@ where
             }
         }
 
-        if attempt < max_retries {
+        if attempt < max_retries && !retry_delay.is_zero() {
             tokio::time::sleep(retry_delay).await;
         }
     }

--- a/crates/guest-agent/src/http.rs
+++ b/crates/guest-agent/src/http.rs
@@ -44,6 +44,7 @@ impl HttpClient {
     ///
     /// Production callers should use [`HttpClient::new`]. Integration tests use
     /// this to cover real retry behavior without paying production backoff time.
+    #[doc(hidden)]
     pub fn with_retry_delay(retry_delay: Duration) -> Result<Self, AgentError> {
         let inner = Client::builder()
             .connect_timeout(Duration::from_secs(constants::HTTP_CONNECT_TIMEOUT_SECS))

--- a/crates/guest-agent/src/http.rs
+++ b/crates/guest-agent/src/http.rs
@@ -20,6 +20,7 @@ use tokio::io::{AsyncRead, AsyncSeekExt, ReadBuf};
 
 const LOG_TAG: &str = "sandbox:guest-agent";
 const HTTP_TOO_MANY_REQUESTS: u16 = 429;
+const DEFAULT_RETRY_DELAY: Duration = Duration::from_secs(1);
 
 /// Shared guest-agent HTTP client.
 ///
@@ -31,10 +32,19 @@ const HTTP_TOO_MANY_REQUESTS: u16 = 429;
 #[derive(Clone)]
 pub struct HttpClient {
     inner: Option<Client>,
+    retry_delay: Duration,
 }
 
 impl HttpClient {
     pub fn new() -> Result<Self, AgentError> {
+        Self::with_retry_delay(DEFAULT_RETRY_DELAY)
+    }
+
+    /// Build a client with a custom retry delay.
+    ///
+    /// Production callers should use [`HttpClient::new`]. Integration tests use
+    /// this to cover real retry behavior without paying production backoff time.
+    pub fn with_retry_delay(retry_delay: Duration) -> Result<Self, AgentError> {
         let inner = Client::builder()
             .connect_timeout(Duration::from_secs(constants::HTTP_CONNECT_TIMEOUT_SECS))
             .timeout(Duration::from_secs(constants::HTTP_TIMEOUT_SECS))
@@ -43,14 +53,20 @@ impl HttpClient {
                 AgentError::Http(format!("failed to build guest-agent HTTP client: {e}"))
             })?;
 
-        Ok(Self { inner: Some(inner) })
+        Ok(Self {
+            inner: Some(inner),
+            retry_delay,
+        })
     }
 
     pub fn for_current_env() -> Result<Self, AgentError> {
         if env::has_api() {
             Self::new()
         } else {
-            Ok(Self { inner: None })
+            Ok(Self {
+                inner: None,
+                retry_delay: DEFAULT_RETRY_DELAY,
+            })
         }
     }
 
@@ -66,6 +82,7 @@ impl HttpClient {
 async fn send_with_retry<BuildRequest, BuildRequestFuture, BuildClientError, ClientErrorFuture>(
     label: &str,
     max_retries: u32,
+    retry_delay: Duration,
     final_error: String,
     mut build_request: BuildRequest,
     mut build_client_error: BuildClientError,
@@ -99,7 +116,7 @@ where
         }
 
         if attempt < max_retries {
-            tokio::time::sleep(Duration::from_secs(1)).await;
+            tokio::time::sleep(retry_delay).await;
         }
     }
 
@@ -122,6 +139,7 @@ impl HttpClient {
         let resp = send_with_retry(
             "POST",
             max_retries,
+            self.retry_delay,
             format!("POST failed after {max_retries} attempts to {url}"),
             || {
                 let mut req = client
@@ -194,6 +212,7 @@ impl HttpClient {
         send_with_retry(
             "PUT presigned",
             max_retries,
+            self.retry_delay,
             format!("PUT presigned failed after {max_retries} attempts"),
             move || {
                 let data = data.clone();
@@ -338,6 +357,7 @@ impl HttpClient {
         send_with_retry(
             "PUT presigned",
             max_retries,
+            self.retry_delay,
             format!("PUT presigned failed after {max_retries} attempts"),
             move || {
                 let source_file = Arc::clone(&source_file);
@@ -396,7 +416,10 @@ mod tests {
 
     #[tokio::test]
     async fn disabled_client_fails_before_request_build() {
-        let client = HttpClient { inner: None };
+        let client = HttpClient {
+            inner: None,
+            retry_delay: DEFAULT_RETRY_DELAY,
+        };
         let result = client
             .post_json("http://127.0.0.1:1/test", &serde_json::json!({}), 1)
             .await;
@@ -409,7 +432,10 @@ mod tests {
 
     #[tokio::test]
     async fn disabled_client_raw_upload_fails_before_request_build() {
-        let client = HttpClient { inner: None };
+        let client = HttpClient {
+            inner: None,
+            retry_delay: DEFAULT_RETRY_DELAY,
+        };
         let result = client
             .put_presigned(
                 "http://127.0.0.1:1/upload",
@@ -426,7 +452,10 @@ mod tests {
 
     #[tokio::test]
     async fn disabled_client_stream_upload_fails_before_file_open() {
-        let client = HttpClient { inner: None };
+        let client = HttpClient {
+            inner: None,
+            retry_delay: DEFAULT_RETRY_DELAY,
+        };
         let result = client
             .put_presigned_file(
                 "http://127.0.0.1:1/upload",

--- a/crates/guest-agent/tests/integration.rs
+++ b/crates/guest-agent/tests/integration.rs
@@ -599,7 +599,7 @@ async fn put_presigned_file_retry_fails_if_source_shrinks() {
     assert!(mutation_done.load(Ordering::SeqCst));
     assert!(result.is_err());
     let calls = mock.calls_async().await;
-    assert!(calls >= 1);
+    assert_eq!(calls, 1);
     mock.delete_async().await;
 }
 

--- a/crates/guest-agent/tests/integration.rs
+++ b/crates/guest-agent/tests/integration.rs
@@ -1,14 +1,17 @@
 // Each #[tokio::test] spins up an isolated single-thread runtime, so
 // tokio::sync::Mutex cannot wake waiters across runtimes.  A std Mutex
 // serialises correctly (each runtime owns its own OS thread).
-#![allow(clippy::await_holding_lock, clippy::expect_used)]
+#![allow(clippy::await_holding_lock)]
 
 use base64::Engine;
 use bytes::Bytes;
 use guest_agent::masker::SecretMasker;
 use httpmock::prelude::*;
-use serde_json::json;
-use std::sync::{LazyLock, Mutex};
+use serde_json::{Value, json};
+use std::sync::{
+    Arc, LazyLock, Mutex,
+    atomic::{AtomicBool, AtomicUsize, Ordering},
+};
 use std::time::Duration;
 use tokio_util::sync::CancellationToken;
 
@@ -40,13 +43,67 @@ macro_rules! http_client {
 }
 
 const TEST_HTTP_RETRY_DELAY: Duration = Duration::from_millis(10);
-const TEST_HTTP_RETRY_SWITCH_DELAY: Duration = Duration::from_millis(100);
 const TEST_HEARTBEAT_INTERVAL: Duration = Duration::from_millis(100);
 const MOCK_CALL_POLL_INTERVAL: Duration = Duration::from_millis(10);
 const MOCK_CALL_TIMEOUT: Duration = Duration::from_secs(10);
 
+#[allow(clippy::expect_used)]
 fn test_http_client(retry_delay: Duration) -> guest_agent::http::HttpClient {
     guest_agent::http::HttpClient::with_retry_delay(retry_delay).expect("build test http client")
+}
+
+fn http_status(status: u16) -> HttpMockResponse {
+    HttpMockResponse::builder().status(status).build()
+}
+
+fn json_http_response(status: u16, body: Value) -> HttpMockResponse {
+    HttpMockResponse::builder()
+        .status(status)
+        .header("Content-Type", "application/json")
+        .body(body.to_string())
+        .build()
+}
+
+fn retry_then_response(
+    failures: usize,
+    success_response: HttpMockResponse,
+) -> impl Fn(&HttpMockRequest) -> HttpMockResponse {
+    let attempts = AtomicUsize::new(0);
+
+    move |_req| {
+        if attempts.fetch_add(1, Ordering::SeqCst) < failures {
+            return http_status(500);
+        }
+
+        success_response.clone()
+    }
+}
+
+fn request_header_eq(req: &HttpMockRequest, name: &str, expected: &str) -> bool {
+    req.headers_vec()
+        .iter()
+        .any(|(key, value)| key.eq_ignore_ascii_case(name) && value == expected)
+}
+
+fn upload_request_matches(
+    req: &HttpMockRequest,
+    expected_body: &[u8],
+    expected_content_length: &str,
+) -> bool {
+    request_header_eq(req, "content-length", expected_content_length)
+        && req.body_ref() == expected_body
+}
+
+fn upload_validation_response(
+    req: &HttpMockRequest,
+    expected_body: &[u8],
+    expected_content_length: &str,
+) -> HttpMockResponse {
+    if upload_request_matches(req, expected_body, expected_content_length) {
+        http_status(200)
+    } else {
+        http_status(400)
+    }
 }
 
 async fn wait_mock_calls(
@@ -187,42 +244,21 @@ async fn post_json_retry_then_succeed() {
     let _guard = TEST_MUTEX.lock().unwrap();
     let server = &*MOCK_SERVER;
 
-    // Register failure mock first (lower ID = matched first by BTreeMap iteration).
-    let fail_mock = server.mock(|when, then| {
+    let mock = server.mock(|when, then| {
         when.method(POST).path("/test/retry-succeed");
-        then.status(500);
-    });
-    // Success mock registered second — becomes active after fail_mock is deleted.
-    let success_mock = server.mock(|when, then| {
-        when.method(POST).path("/test/retry-succeed");
-        then.status(200)
-            .header("Content-Type", "application/json")
-            .json_body(json!({"recovered": true}));
+        then.respond_with(retry_then_response(
+            2,
+            json_http_response(200, json!({"recovered": true})),
+        ));
     });
 
     let url = format!("{}/test/retry-succeed", server.base_url());
-    let handle = tokio::spawn(async move {
-        test_http_client(TEST_HTTP_RETRY_SWITCH_DELAY)
-            .post_json(&url, &json!({}), 3)
-            .await
-    });
+    let result = http_client!().post_json(&url, &json!({}), 3).await;
 
-    // Wait until the failure mock has been hit twice, then remove it so
-    // the third attempt falls through to the success mock.
-    wait_mock_calls(
-        &fail_mock,
-        2,
-        MOCK_CALL_TIMEOUT,
-        "post_json_retry_then_succeed failure attempts",
-    )
-    .await;
-    fail_mock.delete_async().await;
-
-    let result = handle.await.unwrap();
     let val = result.unwrap().unwrap();
     assert_eq!(val["recovered"], true);
-    success_mock.assert_calls_async(1).await;
-    success_mock.delete_async().await;
+    mock.assert_calls_async(3).await;
+    mock.delete_async().await;
 }
 
 #[tokio::test]
@@ -361,37 +397,20 @@ async fn put_presigned_retry_then_succeed() {
     let _guard = TEST_MUTEX.lock().unwrap();
     let server = &*MOCK_SERVER;
 
-    // Failure mock first (lower ID = matched first by BTreeMap).
-    let fail_mock = server.mock(|when, then| {
+    let mock = server.mock(|when, then| {
         when.method(PUT).path("/test/put-retry");
-        then.status(500);
-    });
-    let success_mock = server.mock(|when, then| {
-        when.method(PUT).path("/test/put-retry");
-        then.status(200);
+        then.respond_with(retry_then_response(1, http_status(200)));
     });
 
     let url = format!("{}/test/put-retry", server.base_url());
     let data = Bytes::from_static(b"retry data");
-    let handle = tokio::spawn(async move {
-        test_http_client(TEST_HTTP_RETRY_SWITCH_DELAY)
-            .put_presigned(&url, data, "application/octet-stream")
-            .await
-    });
+    let result = http_client!()
+        .put_presigned(&url, data, "application/octet-stream")
+        .await;
 
-    wait_mock_calls(
-        &fail_mock,
-        1,
-        MOCK_CALL_TIMEOUT,
-        "put_presigned_retry_then_succeed first failure",
-    )
-    .await;
-    fail_mock.delete_async().await;
-
-    let result = handle.await.unwrap();
     assert!(result.is_ok());
-    success_mock.assert_calls_async(1).await;
-    success_mock.delete_async().await;
+    mock.assert_calls_async(2).await;
+    mock.delete_async().await;
 }
 
 // =========================================================================
@@ -509,36 +528,27 @@ async fn put_presigned_file_retry_then_succeed() {
     let file_path = dir.path().join("retry.bin");
     std::fs::write(&file_path, b"retry file data").unwrap();
 
-    let fail_mock = server.mock(|when, then| {
+    let mock = server.mock(|when, then| {
         when.method(PUT).path("/test/put-file-retry");
-        then.status(500);
-    });
-    let success_mock = server.mock(|when, then| {
-        when.method(PUT).path("/test/put-file-retry");
-        then.status(200);
+        let attempts = AtomicUsize::new(0);
+        then.respond_with(move |req| {
+            if attempts.fetch_add(1, Ordering::SeqCst) == 0 {
+                return http_status(500);
+            }
+
+            upload_validation_response(req, b"retry file data", "15")
+        });
     });
 
     let url = format!("{}/test/put-file-retry", server.base_url());
     let path = file_path.clone();
-    let handle = tokio::spawn(async move {
-        test_http_client(TEST_HTTP_RETRY_SWITCH_DELAY)
-            .put_presigned_file(&url, &path, "application/gzip")
-            .await
-    });
+    let result = http_client!()
+        .put_presigned_file(&url, &path, "application/gzip")
+        .await;
 
-    wait_mock_calls(
-        &fail_mock,
-        1,
-        MOCK_CALL_TIMEOUT,
-        "put_presigned_file_retry_then_succeed first failure",
-    )
-    .await;
-    fail_mock.delete_async().await;
-
-    let result = handle.await.unwrap();
     assert!(result.is_ok());
-    success_mock.assert_calls_async(1).await;
-    success_mock.delete_async().await;
+    mock.assert_calls_async(2).await;
+    mock.delete_async().await;
 }
 
 #[tokio::test]
@@ -550,39 +560,36 @@ async fn put_presigned_file_retry_fails_if_source_shrinks() {
     let file_path = dir.path().join("retry-shrunk.bin");
     std::fs::write(&file_path, b"retry file data").unwrap();
 
-    let fail_mock = server.mock(|when, then| {
+    let mutation_done = Arc::new(AtomicBool::new(false));
+    let mutation_done_for_mock = Arc::clone(&mutation_done);
+    let file_path_for_mock = file_path.clone();
+    let mock = server.mock(|when, then| {
         when.method(PUT).path("/test/put-file-retry-shrunk");
-        then.status(500);
-    });
-    let success_mock = server.mock(|when, then| {
-        when.method(PUT)
-            .path("/test/put-file-retry-shrunk")
-            .body("short");
-        then.status(200);
+        let attempts = AtomicUsize::new(0);
+        then.respond_with(move |req| {
+            if attempts.fetch_add(1, Ordering::SeqCst) == 0 {
+                mutation_done_for_mock.store(
+                    std::fs::write(&file_path_for_mock, b"short").is_ok(),
+                    Ordering::SeqCst,
+                );
+                return http_status(500);
+            }
+
+            upload_validation_response(req, b"retry file data", "15")
+        });
     });
 
     let url = format!("{}/test/put-file-retry-shrunk", server.base_url());
     let path = file_path.clone();
-    let handle = tokio::spawn(async move {
-        test_http_client(TEST_HTTP_RETRY_SWITCH_DELAY)
-            .put_presigned_file(&url, &path, "application/gzip")
-            .await
-    });
+    let result = http_client!()
+        .put_presigned_file(&url, &path, "application/gzip")
+        .await;
 
-    wait_mock_calls(
-        &fail_mock,
-        1,
-        MOCK_CALL_TIMEOUT,
-        "put_presigned_file_retry_fails_if_source_shrinks first failure",
-    )
-    .await;
-    std::fs::write(&file_path, b"short").unwrap();
-    fail_mock.delete_async().await;
-
-    let result = handle.await.unwrap();
+    assert!(mutation_done.load(Ordering::SeqCst));
     assert!(result.is_err());
-    success_mock.assert_calls_async(0).await;
-    success_mock.delete_async().await;
+    let calls = mock.calls_async().await;
+    assert!(calls >= 1);
+    mock.delete_async().await;
 }
 
 #[tokio::test]
@@ -594,40 +601,35 @@ async fn put_presigned_file_retry_uses_original_length_if_source_grows() {
     let file_path = dir.path().join("retry-grown.bin");
     std::fs::write(&file_path, b"retry file data").unwrap();
 
-    let fail_mock = server.mock(|when, then| {
+    let mutation_done = Arc::new(AtomicBool::new(false));
+    let mutation_done_for_mock = Arc::clone(&mutation_done);
+    let file_path_for_mock = file_path.clone();
+    let mock = server.mock(|when, then| {
         when.method(PUT).path("/test/put-file-retry-grown");
-        then.status(500);
-    });
-    let success_mock = server.mock(|when, then| {
-        when.method(PUT)
-            .path("/test/put-file-retry-grown")
-            .header("Content-Length", "15")
-            .body("retry file data");
-        then.status(200);
+        let attempts = AtomicUsize::new(0);
+        then.respond_with(move |req| {
+            if attempts.fetch_add(1, Ordering::SeqCst) == 0 {
+                mutation_done_for_mock.store(
+                    std::fs::write(&file_path_for_mock, b"retry file data plus extra").is_ok(),
+                    Ordering::SeqCst,
+                );
+                return http_status(500);
+            }
+
+            upload_validation_response(req, b"retry file data", "15")
+        });
     });
 
     let url = format!("{}/test/put-file-retry-grown", server.base_url());
     let path = file_path.clone();
-    let handle = tokio::spawn(async move {
-        test_http_client(TEST_HTTP_RETRY_SWITCH_DELAY)
-            .put_presigned_file(&url, &path, "application/gzip")
-            .await
-    });
+    let result = http_client!()
+        .put_presigned_file(&url, &path, "application/gzip")
+        .await;
 
-    wait_mock_calls(
-        &fail_mock,
-        1,
-        MOCK_CALL_TIMEOUT,
-        "put_presigned_file_retry_uses_original_length_if_source_grows first failure",
-    )
-    .await;
-    std::fs::write(&file_path, b"retry file data plus extra").unwrap();
-    fail_mock.delete_async().await;
-
-    let result = handle.await.unwrap();
+    assert!(mutation_done.load(Ordering::SeqCst));
     assert!(result.is_ok());
-    success_mock.assert_calls_async(1).await;
-    success_mock.delete_async().await;
+    mock.assert_calls_async(2).await;
+    mock.delete_async().await;
 }
 
 #[tokio::test]
@@ -641,40 +643,36 @@ async fn put_presigned_file_retry_uses_original_handle_if_path_is_replaced() {
     std::fs::write(&file_path, b"retry file data").unwrap();
     std::fs::write(&replacement_path, b"changed content").unwrap();
 
-    let fail_mock = server.mock(|when, then| {
+    let mutation_done = Arc::new(AtomicBool::new(false));
+    let mutation_done_for_mock = Arc::clone(&mutation_done);
+    let file_path_for_mock = file_path.clone();
+    let replacement_path_for_mock = replacement_path.clone();
+    let mock = server.mock(|when, then| {
         when.method(PUT).path("/test/put-file-retry-replaced");
-        then.status(500);
-    });
-    let success_mock = server.mock(|when, then| {
-        when.method(PUT)
-            .path("/test/put-file-retry-replaced")
-            .header("Content-Length", "15")
-            .body("retry file data");
-        then.status(200);
+        let attempts = AtomicUsize::new(0);
+        then.respond_with(move |req| {
+            if attempts.fetch_add(1, Ordering::SeqCst) == 0 {
+                mutation_done_for_mock.store(
+                    std::fs::rename(&replacement_path_for_mock, &file_path_for_mock).is_ok(),
+                    Ordering::SeqCst,
+                );
+                return http_status(500);
+            }
+
+            upload_validation_response(req, b"retry file data", "15")
+        });
     });
 
     let url = format!("{}/test/put-file-retry-replaced", server.base_url());
     let path = file_path.clone();
-    let handle = tokio::spawn(async move {
-        test_http_client(TEST_HTTP_RETRY_SWITCH_DELAY)
-            .put_presigned_file(&url, &path, "application/gzip")
-            .await
-    });
+    let result = http_client!()
+        .put_presigned_file(&url, &path, "application/gzip")
+        .await;
 
-    wait_mock_calls(
-        &fail_mock,
-        1,
-        MOCK_CALL_TIMEOUT,
-        "put_presigned_file_retry_uses_original_handle_if_path_is_replaced first failure",
-    )
-    .await;
-    std::fs::rename(&replacement_path, &file_path).unwrap();
-    fail_mock.delete_async().await;
-
-    let result = handle.await.unwrap();
+    assert!(mutation_done.load(Ordering::SeqCst));
     assert!(result.is_ok());
-    success_mock.assert_calls_async(1).await;
-    success_mock.delete_async().await;
+    mock.assert_calls_async(2).await;
+    mock.delete_async().await;
 }
 
 #[tokio::test]

--- a/crates/guest-agent/tests/integration.rs
+++ b/crates/guest-agent/tests/integration.rs
@@ -43,7 +43,7 @@ macro_rules! http_client {
     };
 }
 
-const TEST_HTTP_RETRY_DELAY: Duration = Duration::from_millis(10);
+const TEST_HTTP_RETRY_DELAY: Duration = Duration::ZERO;
 const TEST_HEARTBEAT_INTERVAL: Duration = Duration::from_millis(20);
 const MOCK_CALL_TIMEOUT: Duration = Duration::from_secs(10);
 

--- a/crates/guest-agent/tests/integration.rs
+++ b/crates/guest-agent/tests/integration.rs
@@ -1,7 +1,7 @@
 // Each #[tokio::test] spins up an isolated single-thread runtime, so
 // tokio::sync::Mutex cannot wake waiters across runtimes.  A std Mutex
 // serialises correctly (each runtime owns its own OS thread).
-#![allow(clippy::await_holding_lock)]
+#![allow(clippy::await_holding_lock, clippy::expect_used)]
 
 use base64::Engine;
 use bytes::Bytes;
@@ -35,12 +35,19 @@ static TEST_MUTEX: Mutex<()> = Mutex::new(());
 
 macro_rules! http_client {
     () => {
-        guest_agent::http::HttpClient::new().unwrap()
+        test_http_client(TEST_HTTP_RETRY_DELAY)
     };
 }
 
+const TEST_HTTP_RETRY_DELAY: Duration = Duration::from_millis(10);
+const TEST_HTTP_RETRY_SWITCH_DELAY: Duration = Duration::from_millis(100);
+const TEST_HEARTBEAT_INTERVAL: Duration = Duration::from_millis(100);
 const MOCK_CALL_POLL_INTERVAL: Duration = Duration::from_millis(10);
 const MOCK_CALL_TIMEOUT: Duration = Duration::from_secs(10);
+
+fn test_http_client(retry_delay: Duration) -> guest_agent::http::HttpClient {
+    guest_agent::http::HttpClient::with_retry_delay(retry_delay).expect("build test http client")
+}
 
 async fn wait_mock_calls(
     mock_: &httpmock::Mock<'_>,
@@ -194,7 +201,11 @@ async fn post_json_retry_then_succeed() {
     });
 
     let url = format!("{}/test/retry-succeed", server.base_url());
-    let handle = tokio::spawn(async move { http_client!().post_json(&url, &json!({}), 3).await });
+    let handle = tokio::spawn(async move {
+        test_http_client(TEST_HTTP_RETRY_SWITCH_DELAY)
+            .post_json(&url, &json!({}), 3)
+            .await
+    });
 
     // Wait until the failure mock has been hit twice, then remove it so
     // the third attempt falls through to the success mock.
@@ -363,7 +374,7 @@ async fn put_presigned_retry_then_succeed() {
     let url = format!("{}/test/put-retry", server.base_url());
     let data = Bytes::from_static(b"retry data");
     let handle = tokio::spawn(async move {
-        http_client!()
+        test_http_client(TEST_HTTP_RETRY_SWITCH_DELAY)
             .put_presigned(&url, data, "application/octet-stream")
             .await
     });
@@ -510,7 +521,7 @@ async fn put_presigned_file_retry_then_succeed() {
     let url = format!("{}/test/put-file-retry", server.base_url());
     let path = file_path.clone();
     let handle = tokio::spawn(async move {
-        http_client!()
+        test_http_client(TEST_HTTP_RETRY_SWITCH_DELAY)
             .put_presigned_file(&url, &path, "application/gzip")
             .await
     });
@@ -553,7 +564,7 @@ async fn put_presigned_file_retry_fails_if_source_shrinks() {
     let url = format!("{}/test/put-file-retry-shrunk", server.base_url());
     let path = file_path.clone();
     let handle = tokio::spawn(async move {
-        http_client!()
+        test_http_client(TEST_HTTP_RETRY_SWITCH_DELAY)
             .put_presigned_file(&url, &path, "application/gzip")
             .await
     });
@@ -598,7 +609,7 @@ async fn put_presigned_file_retry_uses_original_length_if_source_grows() {
     let url = format!("{}/test/put-file-retry-grown", server.base_url());
     let path = file_path.clone();
     let handle = tokio::spawn(async move {
-        http_client!()
+        test_http_client(TEST_HTTP_RETRY_SWITCH_DELAY)
             .put_presigned_file(&url, &path, "application/gzip")
             .await
     });
@@ -645,7 +656,7 @@ async fn put_presigned_file_retry_uses_original_handle_if_path_is_replaced() {
     let url = format!("{}/test/put-file-retry-replaced", server.base_url());
     let path = file_path.clone();
     let handle = tokio::spawn(async move {
-        http_client!()
+        test_http_client(TEST_HTTP_RETRY_SWITCH_DELAY)
             .put_presigned_file(&url, &path, "application/gzip")
             .await
     });
@@ -776,9 +787,6 @@ async fn heartbeat_consecutive_failures_fatal() {
     let _guard = TEST_MUTEX.lock().unwrap();
     let server = &*MOCK_SERVER;
 
-    // Use a 1s heartbeat interval so the test completes in ~3s (3 failures).
-    const TEST_INTERVAL: u64 = 1;
-
     // First heartbeat succeeds.
     let success_mock = server.mock(|when, then| {
         when.method(POST).path("/api/webhooks/agent/heartbeat");
@@ -791,7 +799,7 @@ async fn heartbeat_consecutive_failures_fatal() {
         guest_agent::heartbeat::heartbeat_loop_with_interval(
             http_client!(),
             shutdown_clone,
-            TEST_INTERVAL,
+            TEST_HEARTBEAT_INTERVAL,
         )
         .await
     });
@@ -841,9 +849,6 @@ async fn heartbeat_recovery_resets_counter() {
     let _guard = TEST_MUTEX.lock().unwrap();
     let server = &*MOCK_SERVER;
 
-    // Use a 1s heartbeat interval so the test completes quickly.
-    const TEST_INTERVAL: u64 = 1;
-
     // Sequence: success → 2 failures → success (reset)
     // The loop should NOT exit because failures never reach 3 consecutive.
 
@@ -858,7 +863,7 @@ async fn heartbeat_recovery_resets_counter() {
         guest_agent::heartbeat::heartbeat_loop_with_interval(
             http_client!(),
             shutdown_clone,
-            TEST_INTERVAL,
+            TEST_HEARTBEAT_INTERVAL,
         )
         .await
     });

--- a/crates/guest-agent/tests/integration.rs
+++ b/crates/guest-agent/tests/integration.rs
@@ -785,10 +785,16 @@ async fn heartbeat_consecutive_failures_fatal() {
     let _guard = TEST_MUTEX.lock().unwrap();
     let server = &*MOCK_SERVER;
 
-    // First heartbeat succeeds.
-    let success_mock = server.mock(|when, then| {
+    let mock = server.mock(|when, then| {
         when.method(POST).path("/api/webhooks/agent/heartbeat");
-        then.status(200);
+        let attempts = AtomicUsize::new(0);
+        then.respond_with(move |_req| {
+            if attempts.fetch_add(1, Ordering::SeqCst) == 0 {
+                return http_status(200);
+            }
+
+            json_http_response(401, json!({"error": {"message": "Run expired"}}))
+        });
     });
 
     let shutdown = CancellationToken::new();
@@ -800,23 +806,6 @@ async fn heartbeat_consecutive_failures_fatal() {
             TEST_HEARTBEAT_INTERVAL,
         )
         .await
-    });
-
-    // Wait for first successful heartbeat.
-    wait_mock_calls(
-        &success_mock,
-        1,
-        MOCK_CALL_TIMEOUT,
-        "heartbeat_consecutive_failures_fatal initial heartbeat",
-    )
-    .await;
-
-    // Switch to 401 responses — simulates server invalidating the runId.
-    success_mock.delete_async().await;
-    let fail_mock = server.mock(|when, then| {
-        when.method(POST).path("/api/webhooks/agent/heartbeat");
-        then.status(401)
-            .json_body(json!({"error": {"message": "Run expired"}}));
     });
 
     // heartbeat_loop should exit after MAX_CONSECUTIVE_HEARTBEAT_FAILURES.
@@ -826,8 +815,8 @@ async fn heartbeat_consecutive_failures_fatal() {
         .expect("task should not panic");
 
     // Clean up mocks before assertions to avoid leaks on panic.
-    let fail_calls = fail_mock.calls_async().await;
-    fail_mock.delete_async().await;
+    let heartbeat_calls = mock.calls_async().await;
+    mock.delete_async().await;
     shutdown.cancel();
 
     assert!(result.is_err());
@@ -837,9 +826,9 @@ async fn heartbeat_consecutive_failures_fatal() {
         "error should mention consecutive failures: {err}"
     );
 
-    // 401 is a 4xx error → post_json returns immediately (no internal retries),
-    // so fail_mock should be called exactly MAX_CONSECUTIVE_HEARTBEAT_FAILURES times.
-    assert_eq!(fail_calls, 3);
+    // 401 is a 4xx error -> post_json returns immediately (no internal retries),
+    // so the sequence is one success followed by the fatal failure window.
+    assert_eq!(heartbeat_calls, 4);
 }
 
 #[tokio::test]
@@ -847,12 +836,13 @@ async fn heartbeat_recovery_resets_counter() {
     let _guard = TEST_MUTEX.lock().unwrap();
     let server = &*MOCK_SERVER;
 
-    // Sequence: success → 2 failures → success (reset)
-    // The loop should NOT exit because failures never reach 3 consecutive.
-
     let mock = server.mock(|when, then| {
         when.method(POST).path("/api/webhooks/agent/heartbeat");
-        then.status(200);
+        let attempts = AtomicUsize::new(0);
+        then.respond_with(move |_req| match attempts.fetch_add(1, Ordering::SeqCst) {
+            1 | 2 | 4 | 5 => json_http_response(401, json!({"error": {"message": "Run expired"}})),
+            _ => http_status(200),
+        });
     });
 
     let shutdown = CancellationToken::new();
@@ -866,53 +856,20 @@ async fn heartbeat_recovery_resets_counter() {
         .await
     });
 
-    // Wait for first successful heartbeat.
+    // Sequence: success -> 2 failures -> success -> 2 failures -> success.
+    // Without recovery resetting the failure counter, the second failure pair
+    // would reach the fatal threshold before call 7.
     wait_mock_calls(
         &mock,
-        1,
+        7,
         MOCK_CALL_TIMEOUT,
-        "heartbeat_recovery_resets_counter initial heartbeat",
-    )
-    .await;
-
-    // Switch to failures (2 consecutive — below threshold).
-    mock.delete_async().await;
-    let fail_mock = server.mock(|when, then| {
-        when.method(POST).path("/api/webhooks/agent/heartbeat");
-        then.status(401)
-            .json_body(json!({"error": {"message": "Run expired"}}));
-    });
-
-    // Wait for 2 failed heartbeats.
-    wait_mock_calls(
-        &fail_mock,
-        2,
-        MOCK_CALL_TIMEOUT,
-        "heartbeat_recovery_resets_counter failed heartbeats",
-    )
-    .await;
-
-    // Capture fail count before deleting (can't query after delete).
-    let fail_total = fail_mock.calls_async().await;
-
-    // Recover — switch back to success.  This should reset the counter.
-    fail_mock.delete_async().await;
-    let recovery_mock = server.mock(|when, then| {
-        when.method(POST).path("/api/webhooks/agent/heartbeat");
-        then.status(200);
-    });
-
-    // Wait for a successful heartbeat after recovery.
-    wait_mock_calls(
-        &recovery_mock,
-        1,
-        MOCK_CALL_TIMEOUT,
-        "heartbeat_recovery_resets_counter recovery heartbeat",
+        "heartbeat_recovery_resets_counter full sequence",
     )
     .await;
 
     // Clean up mocks before assertions.
-    recovery_mock.delete_async().await;
+    let heartbeat_calls = mock.calls_async().await;
+    mock.delete_async().await;
 
     // The loop should still be running — shut it down gracefully.
     shutdown.cancel();
@@ -925,8 +882,7 @@ async fn heartbeat_recovery_resets_counter() {
         result.is_ok(),
         "heartbeat_loop should exit Ok after shutdown, not Err"
     );
-    // Exactly 2 failures before recovery (401 = no internal retry).
-    assert_eq!(fail_total, 2);
+    assert!(heartbeat_calls >= 7);
 }
 
 // =========================================================================

--- a/crates/guest-agent/tests/integration.rs
+++ b/crates/guest-agent/tests/integration.rs
@@ -13,6 +13,7 @@ use std::sync::{
     atomic::{AtomicBool, AtomicUsize, Ordering},
 };
 use std::time::Duration;
+use tokio::sync::Notify;
 use tokio_util::sync::CancellationToken;
 
 /// Shared mock server — env vars are set once before any `LazyLock` in the
@@ -43,8 +44,7 @@ macro_rules! http_client {
 }
 
 const TEST_HTTP_RETRY_DELAY: Duration = Duration::from_millis(10);
-const TEST_HEARTBEAT_INTERVAL: Duration = Duration::from_millis(100);
-const MOCK_CALL_POLL_INTERVAL: Duration = Duration::from_millis(10);
+const TEST_HEARTBEAT_INTERVAL: Duration = Duration::from_millis(20);
 const MOCK_CALL_TIMEOUT: Duration = Duration::from_secs(10);
 
 #[allow(clippy::expect_used)]
@@ -106,30 +106,41 @@ fn upload_validation_response(
     }
 }
 
-async fn wait_mock_calls(
-    mock_: &httpmock::Mock<'_>,
-    expected: usize,
-    timeout: Duration,
-    context: &str,
-) {
-    let mut observed = 0;
+#[derive(Clone, Default)]
+struct MockCallObserver {
+    calls: Arc<AtomicUsize>,
+    notify: Arc<Notify>,
+}
 
-    let result = tokio::time::timeout(timeout, async {
-        loop {
-            observed = mock_.calls_async().await;
-            if observed >= expected {
-                return;
+impl MockCallObserver {
+    fn record(&self) -> usize {
+        let calls = self.calls.fetch_add(1, Ordering::SeqCst) + 1;
+        self.notify.notify_one();
+        calls
+    }
+
+    fn calls(&self) -> usize {
+        self.calls.load(Ordering::SeqCst)
+    }
+
+    async fn wait_for(&self, expected: usize, timeout: Duration, context: &str) {
+        let result = tokio::time::timeout(timeout, async {
+            loop {
+                if self.calls() >= expected {
+                    return;
+                }
+
+                self.notify.notified().await;
             }
+        })
+        .await;
 
-            tokio::time::sleep(MOCK_CALL_POLL_INTERVAL).await;
-        }
-    })
-    .await;
-
-    assert!(
-        result.is_ok(),
-        "timed out waiting for {context}: expected at least {expected} mock calls, observed {observed} after {timeout:?}",
-    );
+        assert!(
+            result.is_ok(),
+            "timed out waiting for {context}: expected at least {expected} mock calls, observed {} after {timeout:?}",
+            self.calls(),
+        );
+    }
 }
 
 struct SystemLogOverrideGuard;
@@ -735,10 +746,15 @@ async fn put_presigned_file_4xx_no_retry() {
 async fn heartbeat_first_success() {
     let _guard = TEST_MUTEX.lock().unwrap();
     let server = &*MOCK_SERVER;
+    let observer = MockCallObserver::default();
+    let observer_for_mock = observer.clone();
 
     let mock = server.mock(|when, then| {
         when.method(POST).path("/api/webhooks/agent/heartbeat");
-        then.status(200);
+        then.respond_with(move |_req| {
+            observer_for_mock.record();
+            http_status(200)
+        });
     });
 
     let shutdown = CancellationToken::new();
@@ -748,13 +764,13 @@ async fn heartbeat_first_success() {
     });
 
     // Wait for the first heartbeat to land, then shut down.
-    wait_mock_calls(
-        &mock,
-        1,
-        MOCK_CALL_TIMEOUT,
-        "heartbeat_first_success initial heartbeat",
-    )
-    .await;
+    observer
+        .wait_for(
+            1,
+            MOCK_CALL_TIMEOUT,
+            "heartbeat_first_success initial heartbeat",
+        )
+        .await;
     shutdown.cancel();
 
     let result = handle.await.unwrap();
@@ -784,12 +800,13 @@ async fn heartbeat_first_failure_fatal() {
 async fn heartbeat_consecutive_failures_fatal() {
     let _guard = TEST_MUTEX.lock().unwrap();
     let server = &*MOCK_SERVER;
+    let observer = MockCallObserver::default();
+    let observer_for_mock = observer.clone();
 
     let mock = server.mock(|when, then| {
         when.method(POST).path("/api/webhooks/agent/heartbeat");
-        let attempts = AtomicUsize::new(0);
         then.respond_with(move |_req| {
-            if attempts.fetch_add(1, Ordering::SeqCst) == 0 {
+            if observer_for_mock.record() == 1 {
                 return http_status(200);
             }
 
@@ -815,7 +832,7 @@ async fn heartbeat_consecutive_failures_fatal() {
         .expect("task should not panic");
 
     // Clean up mocks before assertions to avoid leaks on panic.
-    let heartbeat_calls = mock.calls_async().await;
+    let heartbeat_calls = observer.calls();
     mock.delete_async().await;
     shutdown.cancel();
 
@@ -835,12 +852,13 @@ async fn heartbeat_consecutive_failures_fatal() {
 async fn heartbeat_recovery_resets_counter() {
     let _guard = TEST_MUTEX.lock().unwrap();
     let server = &*MOCK_SERVER;
+    let observer = MockCallObserver::default();
+    let observer_for_mock = observer.clone();
 
     let mock = server.mock(|when, then| {
         when.method(POST).path("/api/webhooks/agent/heartbeat");
-        let attempts = AtomicUsize::new(0);
-        then.respond_with(move |_req| match attempts.fetch_add(1, Ordering::SeqCst) {
-            1 | 2 | 4 | 5 => json_http_response(401, json!({"error": {"message": "Run expired"}})),
+        then.respond_with(move |_req| match observer_for_mock.record() {
+            2 | 3 | 5 | 6 => json_http_response(401, json!({"error": {"message": "Run expired"}})),
             _ => http_status(200),
         });
     });
@@ -859,15 +877,15 @@ async fn heartbeat_recovery_resets_counter() {
     // Sequence: success -> 2 failures -> success -> 2 failures -> success.
     // Without recovery resetting the failure counter, the second failure pair
     // would reach the fatal threshold before call 7.
-    wait_mock_calls(
-        &mock,
-        7,
-        MOCK_CALL_TIMEOUT,
-        "heartbeat_recovery_resets_counter full sequence",
-    )
-    .await;
+    observer
+        .wait_for(
+            7,
+            MOCK_CALL_TIMEOUT,
+            "heartbeat_recovery_resets_counter full sequence",
+        )
+        .await;
 
-    let heartbeat_calls = mock.calls_async().await;
+    let heartbeat_calls = observer.calls();
 
     // The loop should still be running. Stop it before deleting the mock so no
     // background heartbeat can race with mock teardown.

--- a/crates/guest-agent/tests/integration.rs
+++ b/crates/guest-agent/tests/integration.rs
@@ -867,16 +867,16 @@ async fn heartbeat_recovery_resets_counter() {
     )
     .await;
 
-    // Clean up mocks before assertions.
     let heartbeat_calls = mock.calls_async().await;
-    mock.delete_async().await;
 
-    // The loop should still be running — shut it down gracefully.
+    // The loop should still be running. Stop it before deleting the mock so no
+    // background heartbeat can race with mock teardown.
     shutdown.cancel();
     let result = tokio::time::timeout(Duration::from_secs(30), handle)
         .await
         .expect("heartbeat_loop should exit within timeout")
         .expect("task should not panic");
+    mock.delete_async().await;
 
     assert!(
         result.is_ok(),


### PR DESCRIPTION
## Summary
- add configurable HTTP retry delays while preserving the production 1s default
- let guest-agent heartbeat tests use sub-second intervals
- reduce guest-agent integration retry/heartbeat test runtime from ~28s to ~3s without fake timers

## Tests
- cargo test --manifest-path crates/Cargo.toml -p guest-agent --test integration
- cargo test --manifest-path crates/Cargo.toml -p guest-agent --lib
- pre-commit cargo fmt/clippy/doc via git commit