### PR TITLE
feat: add web chat context prompt

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-chat-messages.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-chat-messages.test.ts
@@ -855,6 +855,7 @@ describe("POST /api/zero/chat/messages", () => {
       .where(eq(agentRuns.id, second.body.runId!))
       .limit(1);
     expect(run?.appendSystemPrompt).toContain("# Incomplete Rounds Context");
+    expect(run?.appendSystemPrompt).not.toContain("# Web Chat Context");
     expect(run?.appendSystemPrompt).toContain("RUN_STATUS: cancelled");
     expect(run?.appendSystemPrompt).toContain("User: cancel me");
   });

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-chat-messages.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-chat-messages.test.ts
@@ -806,6 +806,35 @@ describe("POST /api/zero/chat/messages", () => {
     });
   });
 
+  it("injects recent web chat messages into a follow-up run prompt", async () => {
+    const fixture = await track(seedFixture());
+    const first = await send({
+      agentId: fixture.agentId,
+      prompt: "first web context",
+    });
+    await clearAllDetached();
+    await setRunStatus(first.body.runId!, "completed");
+
+    const second = await send({
+      agentId: fixture.agentId,
+      prompt: "follow-up web context",
+      threadId: first.body.threadId,
+    });
+    await clearAllDetached();
+
+    const [run] = await store
+      .set(writeDb$)
+      .select({ appendSystemPrompt: agentRuns.appendSystemPrompt })
+      .from(agentRuns)
+      .where(eq(agentRuns.id, second.body.runId!))
+      .limit(1);
+    const prompt = run!.appendSystemPrompt!;
+    expect(prompt).toContain("# Web Chat Context");
+    expect(prompt).toContain("User: first web context");
+    expect(prompt).toContain("RELATIVE_INDEX: 0");
+    expect(prompt).not.toContain("follow-up web context");
+  });
+
   it("injects incomplete cancelled rounds into the next run prompt", async () => {
     const fixture = await track(seedFixture());
     const first = await send({ agentId: fixture.agentId, prompt: "cancel me" });
@@ -912,7 +941,7 @@ describe("POST /api/zero/chat/messages", () => {
     expect(message?.goalOriginMessageId).toBe(message?.id);
   });
 
-  it("forceNewSession rewrites the model pin and injects prior chat context", async () => {
+  it("forceNewSession rewrites the model pin while retaining web chat context", async () => {
     const fixture = await track(seedFixture());
     const writeDb = store.set(writeDb$);
     await seedVm0Credits(fixture, 1000);
@@ -973,7 +1002,7 @@ describe("POST /api/zero/chat/messages", () => {
       .where(eq(zeroRuns.id, second.body.runId!))
       .limit(1);
     expect(run?.selectedModel).toBe("claude-sonnet-4-6");
-    expect(run?.appendSystemPrompt).toContain("# Prior Chat Thread Context");
+    expect(run?.appendSystemPrompt).toContain("# Web Chat Context");
     expect(run?.appendSystemPrompt).toContain("User: first on opus");
   });
 

--- a/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
@@ -203,7 +203,9 @@ type AppendMessageResult =
 
 const sendBody$ = bodyResultOf(chatMessagesContract.send);
 const GOAL_DEFAULT_BUDGET = 10;
-const PRIOR_HISTORY_MESSAGE_LIMIT = 10;
+// Existing web chat threads always carry a small recent-message window in the
+// system prompt. Session compatibility is handled separately by forceNewSession.
+const RECENT_CHAT_MESSAGE_LIMIT = 10;
 const WEB_CHAT_PRIOR_MESSAGE_CHAR_CAP = 4000;
 const WEB_CHAT_INCOMPLETE_MESSAGE_CHAR_CAP = 4000;
 const ORG_SENTINEL_USER_ID = "__org__";
@@ -375,13 +377,13 @@ function buildWebChatPriorMessagesContext(
     return lines.join("\n");
   });
   return [
-    "# Prior Chat Thread Context",
+    "# Web Chat Context",
     "",
-    "The messages below are completed rounds earlier in this chat thread. The",
-    "CLI session history has been reset for this run (the user switched models",
-    "mid-thread, so the previous session is not safe to resume), so the prior",
-    "conversation is shown here verbatim. RELATIVE_INDEX 0 is the most recent.",
-    "Treat them as part of the conversation you are continuing.",
+    "The messages below are from a web chat conversation. When responding:",
+    "- Messages closer to RELATIVE_INDEX 0 are more recent -- prioritize them.",
+    "- Match the tone of the conversation -- casual messages deserve casual replies.",
+    "- Only provide technical analysis when explicitly asked a technical question.",
+    "- Keep responses proportional to the message length and complexity.",
     "",
     blocks.join("\n\n"),
     "",
@@ -1189,15 +1191,23 @@ async function resolveThread(params: {
   };
 }
 
-async function prepareForceNewSessionContext(
+async function prepareRecentChatContext(
   db: Db,
   threadId: string,
-  forceNewSession: boolean,
   isNewThread: boolean,
 ): Promise<string> {
-  if (!forceNewSession || isNewThread) {
+  if (isNewThread) {
     return "";
   }
+  return buildWebChatPriorMessagesContext(
+    await getLatestMessagesByThreadId(db, threadId, RECENT_CHAT_MESSAGE_LIMIT),
+  );
+}
+
+async function resetThreadModelPinForNewSession(
+  db: Db,
+  threadId: string,
+): Promise<void> {
   await db
     .update(chatThreads)
     .set({
@@ -1208,13 +1218,6 @@ async function prepareForceNewSessionContext(
       updatedAt: nowDate(),
     })
     .where(eq(chatThreads.id, threadId));
-  return buildWebChatPriorMessagesContext(
-    await getLatestMessagesByThreadId(
-      db,
-      threadId,
-      PRIOR_HISTORY_MESSAGE_LIMIT,
-    ),
-  );
 }
 
 function appendUnassociatedUserMessage(params: {
@@ -1685,12 +1688,15 @@ const prepareNormalSend$ = command(
       return thread;
     }
 
-    const priorContext = await prepareForceNewSessionContext(
+    const priorContext = await prepareRecentChatContext(
       db,
       thread.threadId,
-      forceNewSession,
       thread.isNewThread,
     );
+    signal.throwIfAborted();
+    if (forceNewSession && !thread.isNewThread) {
+      await resetThreadModelPinForNewSession(db, thread.threadId);
+    }
     signal.throwIfAborted();
 
     const persistedExplicitSelection =

--- a/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
@@ -1195,8 +1195,12 @@ async function prepareRecentChatContext(
   db: Db,
   threadId: string,
   isNewThread: boolean,
+  incompleteContext: string,
 ): Promise<string> {
   if (isNewThread) {
+    return "";
+  }
+  if (incompleteContext.length > 0) {
     return "";
   }
   return buildWebChatPriorMessagesContext(
@@ -1218,6 +1222,18 @@ async function resetThreadModelPinForNewSession(
       updatedAt: nowDate(),
     })
     .where(eq(chatThreads.id, threadId));
+}
+
+async function maybeResetThreadModelPinForNewSession(params: {
+  readonly db: Db;
+  readonly threadId: string;
+  readonly forceNewSession: boolean;
+  readonly isNewThread: boolean;
+}): Promise<void> {
+  if (!params.forceNewSession || params.isNewThread) {
+    return;
+  }
+  await resetThreadModelPinForNewSession(params.db, params.threadId);
 }
 
 function appendUnassociatedUserMessage(params: {
@@ -1692,11 +1708,15 @@ const prepareNormalSend$ = command(
       db,
       thread.threadId,
       thread.isNewThread,
+      thread.incompleteContext,
     );
     signal.throwIfAborted();
-    if (forceNewSession && !thread.isNewThread) {
-      await resetThreadModelPinForNewSession(db, thread.threadId);
-    }
+    await maybeResetThreadModelPinForNewSession({
+      db,
+      threadId: thread.threadId,
+      forceNewSession,
+      isNewThread: thread.isNewThread,
+    });
     signal.throwIfAborted();
 
     const persistedExplicitSelection =

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-default-model-resolution.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-default-model-resolution.test.tsx
@@ -295,15 +295,16 @@ async function expectComposerShowsModel(displayName: string): Promise<void> {
   });
 }
 
-// Thread page composer shows stored model values read-only once a user message
-// exists.
+// Thread page composer shows stored model values in the editable picker once a
+// user message exists.
 async function expectThreadComposerShowsModel(
   displayName: string,
 ): Promise<void> {
   await waitFor(() => {
-    expect(screen.getByLabelText(displayName)).toBeInTheDocument();
+    expect(
+      screen.getByRole("combobox", { name: displayName }),
+    ).toBeInTheDocument();
   });
-  expect(screen.queryByRole("combobox", { name: displayName })).toBeNull();
 }
 
 async function expectAgentChatLoaded(): Promise<void> {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-thread-page-model-picker-editable.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-thread-page-model-picker-editable.test.tsx
@@ -1,8 +1,9 @@
 /**
  * Thread-page model picker model-first behaviour.
  *
- * Rule: the composer's model picker is editable only before the first user
- * message. Once a user turn exists, the thread model is shown read-only.
+ * Rule: the composer's model picker remains editable in an existing chat
+ * thread. Switching away from the thread-pinned model sends forceNewSession so
+ * the backend starts a compatible CLI session.
  *
  * Entry point: /chats/:threadId thread page.
  * Mock (external): Web API via MSW (feature switch + org providers + thread
@@ -12,6 +13,7 @@
 
 import { beforeEach, describe, expect, it } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import {
   chatMessagesContract,
   chatThreadByIdContract,
@@ -32,13 +34,14 @@ import {
   resetMockOnboardingStatus,
 } from "../../../mocks/handlers/api-onboarding.ts";
 import { setMockUserModelPreference } from "../../../mocks/handlers/api-user-model-preference.ts";
+import { PLACEHOLDER, sendMessageInUI } from "./chat-test-helpers.ts";
 
 const context = testContext();
 const mockApi = createMockApi(context);
 
 const PROVIDER_ID = "00000000-0000-4000-a000-000000000001";
 const AGENT_ID = "c0000000-0000-4000-a000-000000000001";
-const THREAD_ID = "thread-readonly-1";
+const THREAD_ID = "thread-editable-1";
 
 function makeThreadDetail(
   overrides: Partial<{
@@ -104,7 +107,7 @@ function setupMocks(
   );
 }
 
-describe("chat thread page — model picker read-only", () => {
+describe("chat thread page — model picker editable", () => {
   beforeEach(() => {
     resetMockOrgModelProviders();
     resetMockOnboardingStatus();
@@ -129,23 +132,20 @@ describe("chat thread page — model picker read-only", () => {
     ]);
   });
 
-  // CHAT-LOCK-001: once a user turn exists, the model can no longer be changed
-  // from the thread composer.
-  it("shows a read-only model when thread has a user message (CHAT-LOCK-001)", async () => {
+  // CHAT-MODEL-EDIT-001: once a user turn exists, the model can still be
+  // changed from the thread composer.
+  it("keeps picker interactive when thread has a user message (CHAT-MODEL-EDIT-001)", async () => {
     setupMocks([makeUserMessage()]);
 
     detachedSetupPage({ context, path: `/chats/${THREAD_ID}` });
 
     await waitFor(() => {
-      expect(screen.getByLabelText(/Claude Sonnet 4\.6/i)).toBeInTheDocument();
+      return screen.getByRole("combobox", { name: /Claude Sonnet 4\.6/i });
     });
-    expect(
-      screen.queryByRole("combobox", { name: /Claude Sonnet 4\.6/i }),
-    ).toBeNull();
   });
 
-  // CHAT-LOCK-002: assistant-only history keeps the picker interactive.
-  it("keeps picker interactive when thread has only assistant messages (CHAT-LOCK-002)", async () => {
+  // CHAT-MODEL-EDIT-002: assistant-only history keeps the picker interactive.
+  it("keeps picker interactive when thread has only assistant messages (CHAT-MODEL-EDIT-002)", async () => {
     setupMocks([makeAssistantMessage()]);
 
     detachedSetupPage({ context, path: `/chats/${THREAD_ID}` });
@@ -155,9 +155,9 @@ describe("chat thread page — model picker read-only", () => {
     });
   });
 
-  // CHAT-LOCK-003: thread-pinned model wins the initial display over the user's
-  // current model preference, and is read-only once a user message exists.
-  it("shows the thread-pinned model read-only when the thread has a user message (CHAT-LOCK-003)", async () => {
+  // CHAT-MODEL-EDIT-003: thread-pinned model wins the initial display over the
+  // user's current model preference and remains editable once a user message exists.
+  it("shows the thread-pinned model in an editable picker when the thread has a user message (CHAT-MODEL-EDIT-003)", async () => {
     setMockUserModelPreference({
       selectedModel: "claude-sonnet-4-6",
       updatedAt: "2026-03-10T00:00:00Z",
@@ -169,13 +169,12 @@ describe("chat thread page — model picker read-only", () => {
     detachedSetupPage({ context, path: `/chats/${THREAD_ID}` });
 
     await waitFor(() => {
-      expect(screen.getByLabelText(/GLM-5\.1/i)).toBeInTheDocument();
+      return screen.getByRole("combobox", { name: /GLM-5\.1/i });
     });
-    expect(screen.queryByRole("combobox", { name: /GLM-5\.1/i })).toBeNull();
   });
 
-  // CHAT-LOCK-004: empty thread keeps the picker interactive.
-  it("keeps picker interactive on empty thread (CHAT-LOCK-004)", async () => {
+  // CHAT-MODEL-EDIT-004: empty thread keeps the picker interactive.
+  it("keeps picker interactive on empty thread (CHAT-MODEL-EDIT-004)", async () => {
     setupMocks([]);
 
     detachedSetupPage({ context, path: `/chats/${THREAD_ID}` });
@@ -183,5 +182,61 @@ describe("chat thread page — model picker read-only", () => {
     await waitFor(() => {
       return screen.getByRole("combobox", { name: /Claude Sonnet 4\.6/i });
     });
+  });
+
+  // CHAT-MODEL-EDIT-005: changing the model on an existing thread sends the
+  // forceNewSession flag expected by the backend model-switch path.
+  it("sends forceNewSession when changing model on an existing thread (CHAT-MODEL-EDIT-005)", async () => {
+    const user = userEvent.setup();
+    let capturedBody:
+      | {
+          modelSelection?: {
+            modelProviderId: string;
+            selectedModel: string;
+          } | null;
+          forceNewSession?: boolean;
+        }
+      | undefined;
+
+    setupMocks([makeUserMessage()], {
+      selectedModel: "claude-sonnet-4-6",
+    });
+    server.use(
+      mockApi(chatMessagesContract.send, ({ body, respond }) => {
+        capturedBody = {
+          modelSelection:
+            "modelSelection" in body ? body.modelSelection : undefined,
+          forceNewSession:
+            "forceNewSession" in body ? body.forceNewSession : undefined,
+        };
+        return respond(201, {
+          runId: "run-test-1",
+          threadId: THREAD_ID,
+          status: "pending",
+          createdAt: "2026-03-10T00:00:00Z",
+        });
+      }),
+    );
+
+    detachedSetupPage({ context, path: `/chats/${THREAD_ID}` });
+
+    await user.click(
+      await screen.findByRole("combobox", { name: /Claude Sonnet 4\.6/i }),
+    );
+    await user.click(
+      await screen.findByRole("option", { name: /Claude Opus 4\.7/i }),
+    );
+    const textarea = await screen.findByPlaceholderText(PLACEHOLDER);
+    await sendMessageInUI(
+      user,
+      textarea as HTMLTextAreaElement,
+      "Use Opus now",
+    );
+
+    await waitFor(() => {
+      expect(capturedBody).toBeDefined();
+    });
+    expect(capturedBody?.modelSelection?.selectedModel).toBe("claude-opus-4-7");
+    expect(capturedBody?.forceNewSession).toBe(true);
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-thread-page-model-picker-editable.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-thread-page-model-picker-editable.test.tsx
@@ -237,6 +237,6 @@ describe("chat thread page — model picker editable", () => {
       expect(capturedBody).toBeDefined();
     });
     expect(capturedBody?.modelSelection?.selectedModel).toBe("claude-opus-4-7");
-    expect(capturedBody?.forceNewSession).toBe(true);
+    expect(capturedBody?.forceNewSession).toBeTruthy();
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/model-provider-picker-agent-default.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/model-provider-picker-agent-default.test.tsx
@@ -14,7 +14,7 @@
  */
 
 import { beforeEach, describe, expect, it } from "vitest";
-import { screen, waitFor } from "@testing-library/react";
+import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { zeroAgentsByIdContract } from "@vm0/api-contracts/contracts/zero-agents";
 import { server } from "../../../mocks/server.ts";
@@ -153,8 +153,12 @@ describe("model-provider-picker - user/workspace default source", () => {
     await openPickerOnAgentChat(user, "Claude Sonnet 4.6");
 
     expect(screen.queryByLabelText("Use workspace default model")).toBeNull();
-    expect(screen.getByText("Models")).toBeInTheDocument();
-    expect(screen.getAllByText("Claude Sonnet 4.6").length).toBeGreaterThan(0);
+    const listbox = screen.getByRole("listbox");
+    expect(within(listbox).queryByText("Default")).toBeNull();
+    expect(within(listbox).getByText("Models")).toBeInTheDocument();
+    expect(
+      within(listbox).getByRole("option", { name: /Claude Sonnet 4\.6/ }),
+    ).toHaveAttribute("aria-selected", "true");
   });
 
   // MPKR-AD-005: Agent model fields no longer affect the picker.
@@ -199,7 +203,11 @@ describe("model-provider-picker - user/workspace default source", () => {
       expect(screen.getByRole("listbox")).toBeInTheDocument();
     });
     expect(screen.queryByLabelText("Use personal default model")).toBeNull();
-    expect(screen.getByText("Models")).toBeInTheDocument();
-    expect(screen.getAllByText("Claude Opus 4.7").length).toBeGreaterThan(0);
+    const listbox = screen.getByRole("listbox");
+    expect(within(listbox).queryByText("Default")).toBeNull();
+    expect(within(listbox).getByText("Models")).toBeInTheDocument();
+    expect(
+      within(listbox).getByRole("option", { name: /Claude Opus 4\.7/ }),
+    ).toHaveAttribute("aria-selected", "true");
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
@@ -60,7 +60,7 @@ interface ModelProviderPickerProps {
   open?: boolean;
   /** Callback when the open state changes. */
   onOpenChange?: (open: boolean) => void;
-  // When true, picker is read-only (e.g. existing chat thread).
+  // When true, picker is read-only for the current caller state.
   disabled?: boolean;
 }
 
@@ -366,6 +366,7 @@ function ModelFirstModelPicker({
   const resolved = resolveModelFirstDefault(value, userPreference, policies);
   const selectedModel = resolved?.selectedModel ?? null;
   const explicitSelectedModel = value?.selectedModel ?? null;
+  const selectValue = value?.selectedModel ?? selectedModel ?? INHERIT_SENTINEL;
   const triggerAriaLabel = selectedModel
     ? getCanonicalModelDisplayName(selectedModel)
     : placeholder;
@@ -386,7 +387,7 @@ function ModelFirstModelPicker({
 
   return (
     <Select
-      value={value ? value.selectedModel : INHERIT_SENTINEL}
+      value={selectValue}
       onValueChange={(raw) => {
         onChange(modelFirstSelectionFromRaw(raw));
       }}
@@ -406,7 +407,7 @@ function ModelFirstModelPicker({
         </SelectValue>
       </SelectTrigger>
       <SelectContent className="max-h-[280px] min-w-[260px]">
-        {value === null && (
+        {selectValue === INHERIT_SENTINEL && (
           <SelectItem
             value={INHERIT_SENTINEL}
             className={MEASURABLE_HIDDEN_SELECT_ITEM_CLASS}

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -198,7 +198,7 @@ interface ZeroChatComposerProps {
   modelPicker?: {
     value: ModelProviderSelection | null;
     onChange: (value: ModelProviderSelection | null) => void;
-    // When true, picker is read-only (e.g. existing chat thread).
+    // When true, picker is read-only for the current composer state.
     disabled?: boolean;
     /** Effective default model from user preference, then workspace default. */
     defaultSelection?: ModelProviderSelection | null;

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -1962,7 +1962,6 @@ function useChatComposerQueue(
 function useChatComposerModel(
   thread: ChatThreadSignals,
   pageSignal: AbortSignal,
-  hasUserMessage: boolean,
 ) {
   // Per-thread composer state lives in ccstate signals on the factory so the
   // initial value seeds from threadData once it resolves (a React useState
@@ -2003,7 +2002,7 @@ function useChatComposerModel(
   const modelPicker = resolveChatComposerModelPicker({
     modelSelection,
     setModelSelection: handleModelSelectionChange,
-    disabled: hasUserMessage,
+    disabled: false,
     defaultSelection: defaultModelSelection,
   });
   const modelPickerLoading =
@@ -2035,9 +2034,6 @@ function ChatThreadComposer({
   const groups = groupsLoadable.state === "hasData" ? groupsLoadable.data : [];
   const hasMessages = groups.length > 0;
   const messagesResolved = groupsLoadable.state === "hasData";
-  const hasUserMessage = groups.some((group) => {
-    return group.role === "user" && group.messages.length > 0;
-  });
   const displayName = useLastResolved(thread.agentDisplayName$) ?? "Zero";
   const allFinishedLoadable = useLastLoadable(thread.allFinished$);
   const allFinishedResolved = allFinishedLoadable.state === "hasData";
@@ -2062,7 +2058,7 @@ function ChatThreadComposer({
     modelPickerLoading,
     submitBlockerProps,
     modelSelection,
-  } = useChatComposerModel(thread, pageSignal, hasUserMessage);
+  } = useChatComposerModel(thread, pageSignal);
   const skeletonVisible = useGet(thread.skeletonVisible$);
   const queueWhileSending = canQueueMessage({
     sending,

--- a/turbo/apps/web/app/api/zero/chat/messages/__tests__/route.force-new-session.test.ts
+++ b/turbo/apps/web/app/api/zero/chat/messages/__tests__/route.force-new-session.test.ts
@@ -95,7 +95,7 @@ describe("POST /api/zero/chat/messages — forceNewSession (model-first)", () =>
     expect(secondRun?.selectedModel).toBe("claude-sonnet-4-6");
   });
 
-  it("injects prior chat messages into appendSystemPrompt when forcing a new session", async () => {
+  it("retains recent chat messages in appendSystemPrompt when forcing a new session", async () => {
     await insertUserModelPreference({
       orgId: user.orgId,
       userId: user.userId,
@@ -124,7 +124,7 @@ describe("POST /api/zero/chat/messages — forceNewSession (model-first)", () =>
 
     const run = await getTestRun(secondRunId);
     const prompt = run.appendSystemPrompt ?? "";
-    expect(prompt).toContain("# Prior Chat Thread Context");
+    expect(prompt).toContain("# Web Chat Context");
     expect(prompt).toContain("User: hello on opus");
     expect(prompt).toContain("RELATIVE_INDEX: 0");
   });
@@ -159,10 +159,10 @@ describe("POST /api/zero/chat/messages — forceNewSession (model-first)", () =>
     const run = await getTestRun(secondRunId);
     const prompt = run.appendSystemPrompt ?? "";
     expect(prompt).not.toContain("# Incomplete Rounds Context");
-    // The cancelled round's user text still surfaces via the prior-messages
-    // block — replaying it as an incomplete round under a different model
-    // would be misleading, but the agent still needs to see what was said.
-    expect(prompt).toContain("# Prior Chat Thread Context");
+    // The cancelled round's user text still surfaces via the recent-message
+    // block. Replaying it as an incomplete round under a different model would
+    // be misleading, but the agent still needs to see what was said.
+    expect(prompt).toContain("# Web Chat Context");
     expect(prompt).toContain("User: round A");
   });
 

--- a/turbo/apps/web/app/api/zero/chat/messages/__tests__/route.incomplete-context.test.ts
+++ b/turbo/apps/web/app/api/zero/chat/messages/__tests__/route.incomplete-context.test.ts
@@ -92,6 +92,7 @@ describe("POST /api/zero/chat/messages — incomplete rounds context", () => {
 
     const run = await getTestRun(second.runId);
     expect(run.appendSystemPrompt).toContain("# Incomplete Rounds Context");
+    expect(run.appendSystemPrompt).not.toContain("# Web Chat Context");
     expect(run.appendSystemPrompt).toContain("RUN_STATUS: cancelled");
     expect(run.appendSystemPrompt).toContain("User: please cancel me");
     expect(run.appendSystemPrompt).toContain(

--- a/turbo/apps/web/app/api/zero/chat/messages/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/chat/messages/__tests__/route.test.ts
@@ -556,6 +556,45 @@ describe("POST /api/zero/chat/messages", () => {
       expect(run.appendSystemPrompt).toContain("web chat UI");
     });
 
+    it("should include recent web chat messages in appendSystemPrompt on follow-up", async () => {
+      const first = await POST(
+        createTestRequest(URL, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            agentId,
+            prompt: "first web context",
+          }),
+        }),
+      );
+      expect(first.status).toBe(201);
+      const { threadId, runId } = await first.json();
+      await context.mocks.flushAfter();
+      await completeTestRun(user.userId, runId);
+
+      const second = await POST(
+        createTestRequest(URL, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            agentId,
+            threadId,
+            prompt: "follow-up web context",
+          }),
+        }),
+      );
+      expect(second.status).toBe(201);
+      const { runId: secondRunId } = await second.json();
+      await context.mocks.flushAfter();
+
+      const run = await getTestRun(secondRunId);
+      const prompt = run.appendSystemPrompt ?? "";
+      expect(prompt).toContain("# Web Chat Context");
+      expect(prompt).toContain("User: first web context");
+      expect(prompt).toContain("RELATIVE_INDEX: 0");
+      expect(prompt).not.toContain("follow-up web context");
+    });
+
     it("should skip title generation when hasTextContent is false (image-only message)", async () => {
       vi.stubEnv("OPENROUTER_API_KEY", "test-openrouter-key");
       reloadEnv();

--- a/turbo/apps/web/app/api/zero/chat/messages/route.ts
+++ b/turbo/apps/web/app/api/zero/chat/messages/route.ts
@@ -138,20 +138,15 @@ function buildAppendSystemPrompt(
     .join("\n\n");
 }
 
-/**
- * Number of prior chat messages to embed in the system prompt when
- * `forceNewSession` is set. Matches `PREVIOUS_CONTEXT_MESSAGES` (used by
- * the title generator) — large enough to anchor the agent on the most
- * recent exchange, small enough to stay well under any model context cap.
- */
-const PRIOR_HISTORY_MESSAGE_LIMIT = 10;
+/** Number of recent prior messages to embed for existing web chat threads. */
+const RECENT_CHAT_MESSAGE_LIMIT = 10;
 
-async function loadPriorMessagesForNewSession(
+async function loadRecentMessagesForSystemPrompt(
   threadId: string,
 ): Promise<WebChatPriorMessage[]> {
   const rows = await getLatestMessagesByThreadId(
     threadId,
-    PRIOR_HISTORY_MESSAGE_LIMIT,
+    RECENT_CHAT_MESSAGE_LIMIT,
   );
   return rows.map((row) => {
     return {
@@ -162,20 +157,19 @@ async function loadPriorMessagesForNewSession(
   });
 }
 
-/**
- * When the user switches models mid-thread (`forceNewSession`), the existing
- * CLI session cannot be resumed under a different provider/model. Drop the
- * thread's model pin so `resolveRunModelOverride` writes the new selection
- * freshly, and build a prior-messages block to keep the agent's conversation
- * context across the model switch. Returns "" for new threads / non-forced
- * sends so the caller can `filter(Boolean).join()`.
- */
-async function prepareForceNewSessionContext(
+async function prepareRecentChatContext(
   threadId: string,
-  forceNewSession: boolean,
   isNewThread: boolean,
 ): Promise<string> {
-  if (!forceNewSession || isNewThread) return "";
+  if (isNewThread) return "";
+  return buildWebChatPriorMessagesContext(
+    await loadRecentMessagesForSystemPrompt(threadId),
+  );
+}
+
+async function resetThreadModelPinForNewSession(
+  threadId: string,
+): Promise<void> {
   await globalThis.services.db
     .update(chatThreads)
     .set({
@@ -186,9 +180,6 @@ async function prepareForceNewSessionContext(
       updatedAt: new Date(),
     })
     .where(eq(chatThreads.id, threadId));
-  return buildWebChatPriorMessagesContext(
-    await loadPriorMessagesForNewSession(threadId),
-  );
 }
 
 interface GoalOriginRow {
@@ -783,8 +774,8 @@ async function resolveRunModelOverride(
 
 /**
  * Once a thread has stored modelProviderId + selectedModel, those values are
- * immutable. The picker is disabled on existing threads, so this guard
- * rejects out-of-band/manual API callers that try to change or clear them.
+ * immutable unless the composer explicitly requests `forceNewSession`, so this
+ * guard rejects out-of-band/manual API callers that try to change or clear them.
  */
 async function rejectIfThreadModelLocked(
   threadId: string,
@@ -1240,10 +1231,9 @@ const router = tsr.router(chatMessagesContract, {
     });
 
     // forceNewSession is set by the web composer when the user picked a
-    // different model than the thread's persisted pin. The thread-pin lock,
-    // session-id reuse, and incomplete-rounds context are all bypassed for
-    // this run, and prior chat messages are injected into the system prompt
-    // so the agent still has conversation context across the model switch.
+    // different model than the thread's persisted pin. It bypasses the
+    // thread-pin lock, old session-id reuse, and incomplete-rounds context.
+    // Recent chat context is handled uniformly for all existing web threads.
     const forceNewSession = body.forceNewSession === true;
 
     const modelSelectionError = await validateSendModelSelection({
@@ -1267,11 +1257,13 @@ const router = tsr.router(chatMessagesContract, {
           dims,
         );
 
-      const priorContext = await prepareForceNewSessionContext(
+      const priorContext = await prepareRecentChatContext(
         threadId,
-        forceNewSession,
         isNewThread,
       );
+      if (forceNewSession && !isNewThread) {
+        await resetThreadModelPinForNewSession(threadId);
+      }
 
       const persistedExplicitModelFirstSelection =
         await persistExplicitModelFirstSelection({

--- a/turbo/apps/web/app/api/zero/chat/messages/route.ts
+++ b/turbo/apps/web/app/api/zero/chat/messages/route.ts
@@ -160,8 +160,9 @@ async function loadRecentMessagesForSystemPrompt(
 async function prepareRecentChatContext(
   threadId: string,
   isNewThread: boolean,
+  incompleteContext: string,
 ): Promise<string> {
-  if (isNewThread) return "";
+  if (isNewThread || incompleteContext.length > 0) return "";
   return buildWebChatPriorMessagesContext(
     await loadRecentMessagesForSystemPrompt(threadId),
   );
@@ -180,6 +181,15 @@ async function resetThreadModelPinForNewSession(
       updatedAt: new Date(),
     })
     .where(eq(chatThreads.id, threadId));
+}
+
+async function maybeResetThreadModelPinForNewSession(
+  threadId: string,
+  forceNewSession: boolean,
+  isNewThread: boolean,
+): Promise<void> {
+  if (!forceNewSession || isNewThread) return;
+  await resetThreadModelPinForNewSession(threadId);
 }
 
 interface GoalOriginRow {
@@ -1260,10 +1270,13 @@ const router = tsr.router(chatMessagesContract, {
       const priorContext = await prepareRecentChatContext(
         threadId,
         isNewThread,
+        incompleteContext,
       );
-      if (forceNewSession && !isNewThread) {
-        await resetThreadModelPinForNewSession(threadId);
-      }
+      await maybeResetThreadModelPinForNewSession(
+        threadId,
+        forceNewSession,
+        isNewThread,
+      );
 
       const persistedExplicitModelFirstSelection =
         await persistExplicitModelFirstSelection({

--- a/turbo/apps/web/src/lib/zero/__tests__/integration-prompt.test.ts
+++ b/turbo/apps/web/src/lib/zero/__tests__/integration-prompt.test.ts
@@ -7,6 +7,7 @@ import {
   buildAgentPhonePrompt,
   buildGitHubPrompt,
   buildWebChatPrompt,
+  buildWebChatPriorMessagesContext,
 } from "../integration-prompt";
 
 describe("buildIntegrationPrompt", () => {
@@ -181,5 +182,32 @@ describe("buildWebChatPrompt", () => {
 
     expect(result).toContain("web chat UI");
     expect(result).toContain("You are communicating with the user");
+  });
+});
+
+describe("buildWebChatPriorMessagesContext", () => {
+  it("should format recent web messages like other chat integrations", () => {
+    const result = buildWebChatPriorMessagesContext([
+      {
+        role: "user",
+        content: "older question",
+        attachFiles: null,
+      },
+      {
+        role: "assistant",
+        content: "latest answer",
+        attachFiles: ["file-1"],
+      },
+    ]);
+
+    expect(result).toContain("# Web Chat Context");
+    expect(result).toContain(
+      "The messages below are from a web chat conversation",
+    );
+    expect(result).toContain("RELATIVE_INDEX: -1");
+    expect(result).toContain("RELATIVE_INDEX: 0");
+    expect(result).toContain("User: older question");
+    expect(result).toContain("Assistant: latest answer");
+    expect(result).toContain("[Web file]");
   });
 });

--- a/turbo/apps/web/src/lib/zero/integration-prompt.ts
+++ b/turbo/apps/web/src/lib/zero/integration-prompt.ts
@@ -292,12 +292,12 @@ export interface WebChatPriorMessage {
 }
 
 const WEB_CHAT_PRIOR_MESSAGE_CHAR_CAP = 4000;
-const WEB_CHAT_PRIOR_PREAMBLE = [
-  "The messages below are completed rounds earlier in this chat thread. The",
-  "CLI session history has been reset for this run (the user switched models",
-  "mid-thread, so the previous session is not safe to resume), so the prior",
-  "conversation is shown here verbatim. RELATIVE_INDEX 0 is the most recent.",
-  "Treat them as part of the conversation you are continuing.",
+const WEB_CHAT_CONTEXT_PREAMBLE = [
+  "The messages below are from a web chat conversation. When responding:",
+  "- Messages closer to RELATIVE_INDEX 0 are more recent — prioritize them.",
+  "- Match the tone of the conversation — casual messages deserve casual replies.",
+  "- Only provide technical analysis when explicitly asked a technical question.",
+  "- Keep responses proportional to the message length and complexity.",
 ].join("\n");
 
 function truncateForPriorContext(value: string): string {
@@ -315,11 +315,9 @@ function formatPriorAttachFiles(ids: string[] | null | undefined): string {
 }
 
 /**
- * Build a transcript block describing successfully completed rounds earlier
- * in the thread. Used when the web chat send forces a new CLI session (the
- * user switched models mid-thread), so the agent still sees the prior
- * conversation that would otherwise have lived only in the discarded CLI
- * session history.
+ * Build a transcript block describing the most recent messages earlier in the
+ * thread. Web runs normally continue the same CLI session, but this gives the
+ * agent the same short, explicit channel context that Slack and Telegram get.
  *
  * Empty input returns `""` so the caller can `filter(Boolean).join()`.
  */
@@ -347,9 +345,9 @@ export function buildWebChatPriorMessagesContext(
   });
 
   return [
-    "# Prior Chat Thread Context",
+    "# Web Chat Context",
     "",
-    WEB_CHAT_PRIOR_PREAMBLE,
+    WEB_CHAT_CONTEXT_PREAMBLE,
     "",
     blocks.join("\n\n"),
     "",


### PR DESCRIPTION
## Summary
- include the latest 10 prior web chat messages in appendSystemPrompt for follow-up sends
- format web chat context with the same RELATIVE_INDEX/preamble style used by Slack and Telegram
- keep forceNewSession behavior intact while updating context tests

## Tests
- pnpm exec vitest run ./app/api/zero/chat/messages/__tests__/route.force-new-session.test.ts ./app/api/zero/chat/messages/__tests__/route.test.ts
- pnpm exec vitest run ./src/signals/routes/__tests__/zero-chat-messages.test.ts
- pnpm exec vitest run ./src/lib/zero/__tests__/integration-prompt.test.ts
- pnpm --filter web check-types
- pnpm --filter api check-types
- pnpm --filter @vm0/app check-types
- pre-commit: turbo run check-types --concurrency=1