### PR TITLE
feat(feature-switch): enable QueueMessage globally

### DIFF
--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -256,8 +256,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     maintainer: "linghan@vm0.ai",
     description:
       "Allow keyboard sends during an active chat thread run to append the draft to that thread's pending message queue.",
-    enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+    enabled: true,
   },
   [FeatureSwitchKey.ChatThreadPin]: {
     maintainer: "ethan@vm0.ai",


### PR DESCRIPTION
## Summary
- Graduate `QueueMessage` from staff-org rollout to full rollout (set `enabled: true`, drop `enabledOrgIdHashes`).
- Feature has been baking under `STAFF_ORG_ID_HASHES` since its introduction and is ready for GA.

## Test plan
- [ ] CI green
- [ ] Verify all-org users can queue messages during an active chat thread run

🤖 Generated with [Claude Code](https://claude.com/claude-code)