### PR TITLE
chore(platform): clarify byok oauth route copy

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/__tests__/org-providers-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/__tests__/org-providers-tab.test.tsx
@@ -360,7 +360,7 @@ describe("org-providers-tab — stale banner reconnect", () => {
       "org-model-policy-row-claude-opus-4-7",
     );
     const dialog = await openModelPolicyDialog(row);
-    clickRouteChoice(dialog, "BYOK: member OAuth");
+    clickRouteChoice(dialog, "BYOK: Claude Subscription");
     expect(
       within(dialog).queryByText("OAuth provider"),
     ).not.toBeInTheDocument();
@@ -394,7 +394,7 @@ describe("org-providers-tab — stale banner reconnect", () => {
 
     const row = await screen.findByTestId("org-model-policy-row-gpt-5.5");
     const dialog = await openModelPolicyDialog(row);
-    clickRouteChoice(dialog, "BYOK: member OAuth");
+    clickRouteChoice(dialog, "BYOK: Codex Subscription");
     expect(
       within(dialog).queryByText("OAuth provider"),
     ).not.toBeInTheDocument();

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-model-policies-section.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-model-policies-section.tsx
@@ -106,6 +106,24 @@ function getOAuthProviderTypes(model: SupportedRunModel): ModelProviderType[] {
   });
 }
 
+function getOAuthRouteCopy(oauthTypes: ModelProviderType[]): {
+  title: string;
+  description: string;
+} {
+  if (oauthTypes.includes("codex-oauth-token")) {
+    return {
+      title: "BYOK: Codex Subscription",
+      description:
+        "Lets members use their own Codex Pro/Team subscription. Each member opens their Preferences, switches to Personal Models, and connects ChatGPT (Codex). The token only launches the Codex CLI inside a secure sandbox and is sent directly to OpenAI.",
+    };
+  }
+  return {
+    title: "BYOK: Claude Subscription",
+    description:
+      "Lets members use their own Claude Pro/Max/Team subscription. Each member opens their Preferences, switches to Personal Models, and sets a Claude Code OAuth Token. The token only launches the Claude Code CLI inside a secure sandbox and is sent directly to Anthropic.",
+  };
+}
+
 function findProviderByType(
   providers: ModelProviderResponse[],
   type: ModelProviderType | null,
@@ -903,8 +921,8 @@ function ModelPolicyRouteDialog({
               <RouteChoiceButton
                 active={dialog.routeKind === "oauth"}
                 icon={<IconUsers size={18} stroke={1.6} />}
-                title="BYOK: member OAuth"
-                description="Admins enable the OAuth route for this model. Each member uses their own credentials configured outside this dialog."
+                title={getOAuthRouteCopy(oauthTypes).title}
+                description={getOAuthRouteCopy(oauthTypes).description}
                 onClick={() => {
                   chooseRoute("oauth");
                 }}


### PR DESCRIPTION
## Summary
- Replace the opaque `BYOK: member OAuth` route choice with model-aware labels (`BYOK: Claude Subscription` for Claude models, `BYOK: Codex Subscription` for GPT models) in the org model-policy dialog.
- Rewrite the OAuth route description to spell out the concrete flow members follow (Preferences → Personal Models → connect Claude Code OAuth Token / ChatGPT (Codex)) and that the token only launches the CLI inside a secure sandbox and is forwarded straight to Anthropic/OpenAI.
- Update the two affected `clickRouteChoice` calls in `org-providers-tab.test.tsx` to use the new labels.

## Test plan
- [ ] `pnpm -F @vm0/app exec vitest run src/views/zero-page/components/org-manage/__tests__/org-providers-tab.test.tsx`
- [ ] Visually inspect the Add / Edit model dialog in the platform org settings to confirm copy renders correctly for both a Claude row and a GPT row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)