### PR TITLE
test(vsock-guest): remove fixed timeout sleep

### DIFF
--- a/crates/vsock-guest/src/exec.rs
+++ b/crates/vsock-guest/src/exec.rs
@@ -659,9 +659,17 @@ mod tests {
     }
 
     #[cfg(target_os = "linux")]
-    fn kill_background_pid_and_wait(pid: libc::pid_t, pidfd: &std::os::fd::OwnedFd) {
+    fn kill_pidfd_and_wait(pidfd: &std::os::fd::OwnedFd) {
         // SAFETY: best-effort cleanup of a test-owned background process.
-        let _ = unsafe { libc::kill(pid, libc::SIGKILL) };
+        let _ = unsafe {
+            libc::syscall(
+                libc::SYS_pidfd_send_signal,
+                std::os::fd::AsRawFd::as_raw_fd(pidfd),
+                libc::SIGKILL,
+                std::ptr::null::<libc::siginfo_t>(),
+                0,
+            )
+        };
         let _ = wait_for_pidfd_exit(pidfd, Duration::from_secs(1));
     }
 
@@ -1086,12 +1094,12 @@ mod tests {
 
         let outcome = wait_with_kill_timeout(child.take().unwrap(), 100);
         if !matches!(outcome, WaitOutcome::TimedOut) {
-            kill_background_pid_and_wait(background_pid, &background_pidfd);
+            kill_pidfd_and_wait(&background_pidfd);
             panic!("expected timeout kill to return WaitOutcome::TimedOut");
         }
 
         if !wait_for_pidfd_exit(&background_pidfd, Duration::from_secs(2)).unwrap() {
-            kill_background_pid_and_wait(background_pid, &background_pidfd);
+            kill_pidfd_and_wait(&background_pidfd);
             panic!(
                 "timeout kill should terminate background pid {background_pid} in the process group"
             );

--- a/crates/vsock-guest/src/exec.rs
+++ b/crates/vsock-guest/src/exec.rs
@@ -616,7 +616,7 @@ mod tests {
             let result = unsafe { libc::poll(&mut pollfd, 1, timeout_ms) };
             if result > 0 {
                 let revents = pollfd.revents;
-                if revents & libc::POLLNVAL != 0 {
+                if revents & (libc::POLLERR | libc::POLLNVAL) != 0 {
                     return Err(std::io::Error::other("pidfd became invalid while polling"));
                 }
                 if revents & (libc::POLLIN | libc::POLLHUP) != 0 {

--- a/crates/vsock-guest/src/exec.rs
+++ b/crates/vsock-guest/src/exec.rs
@@ -615,7 +615,16 @@ mod tests {
             // SAFETY: `pollfd` points to one initialized descriptor entry.
             let result = unsafe { libc::poll(&mut pollfd, 1, timeout_ms) };
             if result > 0 {
-                return Ok(true);
+                let revents = pollfd.revents;
+                if revents & libc::POLLNVAL != 0 {
+                    return Err(std::io::Error::other("pidfd became invalid while polling"));
+                }
+                if revents & (libc::POLLIN | libc::POLLHUP) != 0 {
+                    return Ok(true);
+                }
+                return Err(std::io::Error::other(format!(
+                    "unexpected pidfd poll revents: {revents:#x}"
+                )));
             }
             if result == 0 {
                 return Ok(false);
@@ -640,6 +649,20 @@ mod tests {
         std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o700)).unwrap();
         let guard = TempDirGuard(dir.clone());
         (dir, guard)
+    }
+
+    #[cfg(target_os = "linux")]
+    fn kill_spawned_child(child: &mut Option<Child>) {
+        if let Some(child) = child.take() {
+            crate::process::kill_and_reap_child(child);
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    fn kill_background_pid_and_wait(pid: libc::pid_t, pidfd: &std::os::fd::OwnedFd) {
+        // SAFETY: best-effort cleanup of a test-owned background process.
+        let _ = unsafe { libc::kill(pid, libc::SIGKILL) };
+        let _ = wait_for_pidfd_exit(pidfd, Duration::from_secs(1));
     }
 
     #[test]
@@ -1034,25 +1057,41 @@ mod tests {
 
         let mut command = build_exec_command(&script, false);
         command.stdout(Stdio::null()).stderr(Stdio::null());
-        let child = spawn_in_own_process_group(&mut command).unwrap();
-        assert!(
-            wait_for_path(&ready, Duration::from_secs(2)),
-            "background child should be started before timeout kill is tested"
-        );
-        let background_pid: libc::pid_t = std::fs::read_to_string(&background_pid)
-            .unwrap()
-            .trim()
-            .parse()
-            .unwrap();
-        let background_pidfd = open_pidfd(background_pid)
-            .unwrap_or_else(|e| panic!("failed to open pidfd for pid {background_pid}: {e}"));
+        let mut child = Some(spawn_in_own_process_group(&mut command).unwrap());
+        if !wait_for_path(&ready, Duration::from_secs(2)) {
+            kill_spawned_child(&mut child);
+            panic!("background child should be started before timeout kill is tested");
+        }
+        let background_pid_text = match std::fs::read_to_string(&background_pid) {
+            Ok(pid) => pid,
+            Err(e) => {
+                kill_spawned_child(&mut child);
+                panic!("failed to read background pid: {e}");
+            }
+        };
+        let background_pid: libc::pid_t = match background_pid_text.trim().parse() {
+            Ok(pid) => pid,
+            Err(e) => {
+                kill_spawned_child(&mut child);
+                panic!("failed to parse background pid {background_pid_text:?}: {e}");
+            }
+        };
+        let background_pidfd = match open_pidfd(background_pid) {
+            Ok(pidfd) => pidfd,
+            Err(e) => {
+                kill_spawned_child(&mut child);
+                panic!("failed to open pidfd for pid {background_pid}: {e}");
+            }
+        };
 
-        let outcome = wait_with_kill_timeout(child, 100);
-        assert!(matches!(outcome, WaitOutcome::TimedOut));
+        let outcome = wait_with_kill_timeout(child.take().unwrap(), 100);
+        if !matches!(outcome, WaitOutcome::TimedOut) {
+            kill_background_pid_and_wait(background_pid, &background_pidfd);
+            panic!("expected timeout kill to return WaitOutcome::TimedOut");
+        }
 
         if !wait_for_pidfd_exit(&background_pidfd, Duration::from_secs(2)).unwrap() {
-            // SAFETY: best-effort cleanup of the test-owned background pid.
-            let _ = unsafe { libc::kill(background_pid, libc::SIGKILL) };
+            kill_background_pid_and_wait(background_pid, &background_pidfd);
             panic!(
                 "timeout kill should terminate background pid {background_pid} in the process group"
             );

--- a/crates/vsock-guest/src/exec.rs
+++ b/crates/vsock-guest/src/exec.rs
@@ -681,9 +681,16 @@ mod tests {
     }
 
     #[cfg(target_os = "linux")]
-    fn kill_pidfd_and_wait(pidfd: &std::os::fd::OwnedFd) -> std::io::Result<bool> {
+    fn kill_pidfd_and_wait(pidfd: &std::os::fd::OwnedFd) -> std::io::Result<()> {
         signal_pidfd(pidfd, libc::SIGKILL)?;
-        wait_for_pidfd_exit(pidfd, Duration::from_secs(1))
+        if wait_for_pidfd_exit(pidfd, Duration::from_secs(1))? {
+            return Ok(());
+        }
+
+        Err(std::io::Error::new(
+            std::io::ErrorKind::TimedOut,
+            "timed out waiting for pidfd process to exit after SIGKILL",
+        ))
     }
 
     #[test]

--- a/crates/vsock-guest/src/exec.rs
+++ b/crates/vsock-guest/src/exec.rs
@@ -580,6 +580,53 @@ mod tests {
         path.exists()
     }
 
+    #[cfg(target_os = "linux")]
+    fn open_pidfd(pid: libc::pid_t) -> std::io::Result<std::os::fd::OwnedFd> {
+        use std::os::fd::FromRawFd;
+
+        // SAFETY: `pidfd_open` does not dereference user pointers. On success
+        // it returns a new file descriptor owned by this process.
+        let fd = unsafe { libc::syscall(libc::SYS_pidfd_open, pid, 0) };
+        if fd < 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+
+        // SAFETY: `fd` is a fresh descriptor returned by `pidfd_open` above.
+        Ok(unsafe { std::os::fd::OwnedFd::from_raw_fd(fd as std::os::fd::RawFd) })
+    }
+
+    #[cfg(target_os = "linux")]
+    fn wait_for_pidfd_exit(
+        pidfd: &std::os::fd::OwnedFd,
+        timeout: Duration,
+    ) -> std::io::Result<bool> {
+        let deadline = Instant::now() + timeout;
+        loop {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                return Ok(false);
+            }
+            let timeout_ms = remaining.as_millis().clamp(1, i32::MAX as u128) as i32;
+            let mut pollfd = libc::pollfd {
+                fd: std::os::fd::AsRawFd::as_raw_fd(pidfd),
+                events: libc::POLLIN,
+                revents: 0,
+            };
+            // SAFETY: `pollfd` points to one initialized descriptor entry.
+            let result = unsafe { libc::poll(&mut pollfd, 1, timeout_ms) };
+            if result > 0 {
+                return Ok(true);
+            }
+            if result == 0 {
+                return Ok(false);
+            }
+            let err = std::io::Error::last_os_error();
+            if err.kind() != std::io::ErrorKind::Interrupted {
+                return Err(err);
+            }
+        }
+    }
+
     fn temp_dir(label: &str) -> (PathBuf, TempDirGuard) {
         let dir = std::env::temp_dir().join(format!(
             "vsock-guest-{label}-{}-{}",
@@ -973,25 +1020,17 @@ mod tests {
         );
     }
 
-    #[cfg(unix)]
+    #[cfg(target_os = "linux")]
     #[test]
     fn spawn_in_own_process_group_timeout_kills_background_child() {
-        let dir = std::env::temp_dir().join(format!(
-            "vsock-guest-pg-{}-{}",
-            std::process::id(),
-            SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .unwrap()
-                .as_nanos()
-        ));
-        std::fs::create_dir_all(&dir).unwrap();
-        let _guard = TempDirGuard(dir.clone());
+        let (dir, _guard) = temp_dir("pg");
         let ready = dir.join("ready");
-        let survived = dir.join("survived");
+        let background_pid = dir.join("background-pid");
         let ready_arg = shell_escape_value(ready.to_str().unwrap());
-        let survived_arg = shell_escape_value(survived.to_str().unwrap());
-        let script =
-            format!("trap '' HUP; (sleep 1; touch {survived_arg}) & touch {ready_arg}; wait");
+        let background_pid_arg = shell_escape_value(background_pid.to_str().unwrap());
+        let script = format!(
+            "trap '' HUP; sleep 60 & echo $! > {background_pid_arg}; touch {ready_arg}; wait"
+        );
 
         let mut command = build_exec_command(&script, false);
         command.stdout(Stdio::null()).stderr(Stdio::null());
@@ -1000,14 +1039,23 @@ mod tests {
             wait_for_path(&ready, Duration::from_secs(2)),
             "background child should be started before timeout kill is tested"
         );
+        let background_pid: libc::pid_t = std::fs::read_to_string(&background_pid)
+            .unwrap()
+            .trim()
+            .parse()
+            .unwrap();
+        let background_pidfd = open_pidfd(background_pid)
+            .unwrap_or_else(|e| panic!("failed to open pidfd for pid {background_pid}: {e}"));
 
         let outcome = wait_with_kill_timeout(child, 100);
         assert!(matches!(outcome, WaitOutcome::TimedOut));
 
-        std::thread::sleep(Duration::from_millis(1500));
-        assert!(
-            !survived.exists(),
-            "timeout kill should terminate background children in the process group"
-        );
+        if !wait_for_pidfd_exit(&background_pidfd, Duration::from_secs(2)).unwrap() {
+            // SAFETY: best-effort cleanup of the test-owned background pid.
+            let _ = unsafe { libc::kill(background_pid, libc::SIGKILL) };
+            panic!(
+                "timeout kill should terminate background pid {background_pid} in the process group"
+            );
+        }
     }
 }

--- a/crates/vsock-guest/src/exec.rs
+++ b/crates/vsock-guest/src/exec.rs
@@ -1070,14 +1070,11 @@ mod tests {
         let (dir, _guard) = temp_dir("pg");
         let ready = dir.join("ready");
         let background_pid = dir.join("background-pid");
-        let background_fifo = dir.join("background-fifo");
         let ready_arg = shell_escape_value(ready.to_str().unwrap());
         let background_pid_arg = shell_escape_value(background_pid.to_str().unwrap());
-        let background_fifo_arg = shell_escape_value(background_fifo.to_str().unwrap());
         let script = format!(
-            "trap '' HUP; mkfifo {background_fifo_arg}; \
-             (read _ < {background_fifo_arg}) & echo $! > {background_pid_arg}; \
-             exec 3> {background_fifo_arg}; touch {ready_arg}; wait"
+            "trap '' HUP; tail -f /dev/null & echo $! > {background_pid_arg}; \
+             touch {ready_arg}; wait"
         );
 
         let mut command = build_exec_command(&script, false);

--- a/crates/vsock-guest/src/exec.rs
+++ b/crates/vsock-guest/src/exec.rs
@@ -1070,10 +1070,14 @@ mod tests {
         let (dir, _guard) = temp_dir("pg");
         let ready = dir.join("ready");
         let background_pid = dir.join("background-pid");
+        let background_fifo = dir.join("background-fifo");
         let ready_arg = shell_escape_value(ready.to_str().unwrap());
         let background_pid_arg = shell_escape_value(background_pid.to_str().unwrap());
+        let background_fifo_arg = shell_escape_value(background_fifo.to_str().unwrap());
         let script = format!(
-            "trap '' HUP; sleep 60 & echo $! > {background_pid_arg}; touch {ready_arg}; wait"
+            "trap '' HUP; mkfifo {background_fifo_arg}; \
+             (read _ < {background_fifo_arg}) & echo $! > {background_pid_arg}; \
+             exec 3> {background_fifo_arg}; touch {ready_arg}; wait"
         );
 
         let mut command = build_exec_command(&script, false);

--- a/crates/vsock-guest/src/exec.rs
+++ b/crates/vsock-guest/src/exec.rs
@@ -659,18 +659,31 @@ mod tests {
     }
 
     #[cfg(target_os = "linux")]
-    fn kill_pidfd_and_wait(pidfd: &std::os::fd::OwnedFd) {
+    fn signal_pidfd(pidfd: &std::os::fd::OwnedFd, signal: libc::c_int) -> std::io::Result<()> {
         // SAFETY: best-effort cleanup of a test-owned background process.
-        let _ = unsafe {
+        let result = unsafe {
             libc::syscall(
                 libc::SYS_pidfd_send_signal,
                 std::os::fd::AsRawFd::as_raw_fd(pidfd),
-                libc::SIGKILL,
+                signal,
                 std::ptr::null::<libc::siginfo_t>(),
                 0,
             )
         };
-        let _ = wait_for_pidfd_exit(pidfd, Duration::from_secs(1));
+        if result == 0 {
+            return Ok(());
+        }
+        let err = std::io::Error::last_os_error();
+        if err.raw_os_error() == Some(libc::ESRCH) {
+            return Ok(());
+        }
+        Err(err)
+    }
+
+    #[cfg(target_os = "linux")]
+    fn kill_pidfd_and_wait(pidfd: &std::os::fd::OwnedFd) -> std::io::Result<bool> {
+        signal_pidfd(pidfd, libc::SIGKILL)?;
+        wait_for_pidfd_exit(pidfd, Duration::from_secs(1))
     }
 
     #[test]
@@ -1094,15 +1107,26 @@ mod tests {
 
         let outcome = wait_with_kill_timeout(child.take().unwrap(), 100);
         if !matches!(outcome, WaitOutcome::TimedOut) {
-            kill_pidfd_and_wait(&background_pidfd);
+            kill_pidfd_and_wait(&background_pidfd)
+                .unwrap_or_else(|e| panic!("failed to clean up background pidfd: {e}"));
             panic!("expected timeout kill to return WaitOutcome::TimedOut");
         }
 
-        if !wait_for_pidfd_exit(&background_pidfd, Duration::from_secs(2)).unwrap() {
-            kill_pidfd_and_wait(&background_pidfd);
-            panic!(
-                "timeout kill should terminate background pid {background_pid} in the process group"
-            );
+        match wait_for_pidfd_exit(&background_pidfd, Duration::from_secs(2)) {
+            Ok(true) => {}
+            Ok(false) => {
+                kill_pidfd_and_wait(&background_pidfd)
+                    .unwrap_or_else(|e| panic!("failed to clean up background pidfd: {e}"));
+                panic!(
+                    "timeout kill should terminate background pid {background_pid} in the process group"
+                );
+            }
+            Err(e) => {
+                let cleanup = kill_pidfd_and_wait(&background_pidfd);
+                panic!(
+                    "failed to wait for background pid {background_pid} exit: {e}; cleanup={cleanup:?}"
+                );
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- replace the fixed 1500ms post-timeout sleep in the process-group timeout test with direct pidfd observation
- have the test capture the background child PID before timeout kill and poll the pidfd until that exact process exits
- keep production timeout and process-tree kill logic unchanged

## Tests
- cargo test --manifest-path crates/Cargo.toml -p vsock-guest exec::tests
- cargo test --manifest-path crates/Cargo.toml -p vsock-guest
- cargo fmt --manifest-path crates/Cargo.toml --all --check
- cargo clippy --manifest-path crates/Cargo.toml -p vsock-guest --all-targets -- -D warnings
- cargo clippy --all-targets --all-features (from crates/)

Closes #13147