### PR TITLE
fix: log AgentPhone verification send failures

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-agentphone-link.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-agentphone-link.test.ts
@@ -281,6 +281,82 @@ describe("/api/integrations/agentphone/link", () => {
     expect(sendMessage.calls).toHaveLength(1);
   });
 
+  it("logs provider details when verification text sending is rejected", async () => {
+    const user = await setupEnabledUser();
+    const phone = uniquePhone();
+    await trackAgentPhoneVerificationCooldowns({
+      ...user,
+      phoneHandles: [phone],
+    });
+    server.use(
+      http.post("https://api.agentphone.to/v1/messages", () => {
+        return HttpResponse.text("provider quota exceeded", { status: 429 });
+      }),
+    );
+    const client = setupApp({ context })(zeroIntegrationsAgentPhoneContract);
+
+    const response = await accept(
+      client.startLink({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { phoneHandle: phone },
+      }),
+      [503],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "AgentPhone verification text could not be sent",
+        code: "PROVIDER_UNAVAILABLE",
+      },
+    });
+    expect(context.mocks.axiomLogging.warn).toHaveBeenCalledWith(
+      "AgentPhone verification text provider rejected send",
+      expect.objectContaining({
+        agentphoneAgentId: "agt-test-agentphone",
+        phoneHandle: `***${phone.slice(-4)}`,
+        status: 429,
+        statusText: "Too Many Requests",
+        body: "provider quota exceeded",
+        context: "api:agentphone:link",
+      }),
+    );
+  });
+
+  it("logs fetch failures when verification text sending fails before response", async () => {
+    const user = await setupEnabledUser();
+    const phone = uniquePhone();
+    await trackAgentPhoneVerificationCooldowns({
+      ...user,
+      phoneHandles: [phone],
+    });
+    server.use(
+      http.post("https://api.agentphone.to/v1/messages", () => {
+        return HttpResponse.error();
+      }),
+    );
+    const client = setupApp({ context })(zeroIntegrationsAgentPhoneContract);
+
+    await accept(
+      client.startLink({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { phoneHandle: phone },
+      }),
+      [503],
+    );
+
+    expect(context.mocks.axiomLogging.error).toHaveBeenCalledWith(
+      "AgentPhone verification text send failed",
+      expect.objectContaining({
+        agentphoneAgentId: "agt-test-agentphone",
+        phoneHandle: `***${phone.slice(-4)}`,
+        context: "api:agentphone:link",
+        error: expect.objectContaining({
+          message: expect.any(String),
+        }),
+      }),
+    );
+  });
+
   it("rejects empty normalized phone input", async () => {
     await setupEnabledUser();
     const client = setupApp({ context })(zeroIntegrationsAgentPhoneContract);

--- a/turbo/apps/api/src/signals/routes/zero-integrations-agentphone.ts
+++ b/turbo/apps/api/src/signals/routes/zero-integrations-agentphone.ts
@@ -10,6 +10,7 @@ import { and, eq } from "drizzle-orm";
 
 import { env, optionalEnv } from "../../lib/env";
 import { badRequestMessage, conflict, notFound } from "../../lib/error";
+import { logger } from "../../lib/log";
 import { now } from "../../lib/time";
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
@@ -38,6 +39,7 @@ const agentPhoneAuthOptions = {
 } as const;
 
 const VERIFICATION_SEND_COOLDOWN_MS = 60_000;
+const log = logger("api:agentphone:link");
 
 const startLinkBody$ = bodyResultOf(
   zeroIntegrationsAgentPhoneContract.startLink,
@@ -147,6 +149,24 @@ function isValidPhoneHandle(value: string): boolean {
   return /^\+[1-9]\d{7,14}$/u.test(value);
 }
 
+function maskPhoneHandle(value: string): string {
+  const normalized = normalizePhoneHandle(value);
+  if (normalized.length <= 4) {
+    return "[redacted]";
+  }
+  return `***${normalized.slice(-4)}`;
+}
+
+async function safeResponseText(response: Response): Promise<string> {
+  return response.text().catch(() => {
+    return "[unavailable]";
+  });
+}
+
+function truncateForLog(value: string): string {
+  return value.length > 500 ? `${value.slice(0, 500)}...` : value;
+}
+
 function signAgentPhoneConnectParams(params: {
   readonly phoneHandle: string;
   readonly agentphoneAgentId: string;
@@ -203,7 +223,18 @@ async function sendAgentPhoneMessage(params: {
     signal: params.signal,
   });
 
-  return response.ok;
+  if (!response.ok) {
+    log.warn("AgentPhone verification text provider rejected send", {
+      agentphoneAgentId: params.config.agentphoneAgentId,
+      phoneHandle: maskPhoneHandle(params.toNumber),
+      status: response.status,
+      statusText: response.statusText,
+      body: truncateForLog(await safeResponseText(response)),
+    });
+    return false;
+  }
+
+  return true;
 }
 
 const requireAgentPhoneUi$ = computed(async (get) => {
@@ -316,7 +347,12 @@ const sendAgentPhoneVerificationText$ = command(
         toNumber: params.phoneHandle,
         body: `Confirm this phone number for VM0: ${params.connectUrl}`,
         signal,
-      }).catch(() => {
+      }).catch((error: unknown) => {
+        log.error("AgentPhone verification text send failed", {
+          agentphoneAgentId: params.config.agentphoneAgentId,
+          phoneHandle: maskPhoneHandle(params.phoneHandle),
+          error,
+        });
         return false;
       });
       signal.throwIfAborted();

--- a/turbo/apps/api/src/signals/routes/zero-integrations-agentphone.ts
+++ b/turbo/apps/api/src/signals/routes/zero-integrations-agentphone.ts
@@ -157,7 +157,7 @@ function maskPhoneHandle(value: string): string {
   return `***${normalized.slice(-4)}`;
 }
 
-async function safeResponseText(response: Response): Promise<string> {
+function safeResponseText(response: Response): Promise<string> {
   return response.text().catch(() => {
     return "[unavailable]";
   });


### PR DESCRIPTION
## Summary
- add Axiom-visible logs for AgentPhone verification text provider rejections, including status/statusText/body
- add catch logging for fetch-level verification send failures
- mask phone handles to the last four digits in logs
- add tests covering provider rejection and fetch failure logging

## Verification
- npx pnpm@10.33.4 exec prettier --check apps/api/src/signals/routes/zero-integrations-agentphone.ts apps/api/src/signals/routes/__tests__/zero-integrations-agentphone-link.test.ts
- NODE_OPTIONS=--max-old-space-size=4096 npx pnpm@10.33.4 --filter api check-types
- npx pnpm@10.33.4 --filter api exec eslint src/signals/routes/zero-integrations-agentphone.ts src/signals/routes/__tests__/zero-integrations-agentphone-link.test.ts --max-warnings 0

## Notes
- Targeted Vitest command was attempted, but local Postgres is not running in this environment, so the file fails with ECONNREFUSED on localhost:5432 before reaching the new assertions.