### PR TITLE
fix: start AgentPhone typing earlier

### DIFF
--- a/turbo/apps/web/app/api/agentphone/webhook/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agentphone/webhook/__tests__/route.test.ts
@@ -412,6 +412,41 @@ describe("POST /api/agentphone/webhook", () => {
     expect(runs).toHaveLength(0);
   });
 
+  it("does not send iMessage typing for slash commands", async () => {
+    const phone = uniquePhone();
+    const user = await context.setupUser();
+    await insertTestAgentPhoneUserLink({
+      phoneHandle: phone,
+      vm0UserId: user.userId,
+      orgId: user.orgId,
+    });
+    const sendMessage = agentPhoneSendMessage();
+    const typing = agentPhoneTypingIndicator();
+    server.use(sendMessage.handler, typing.handler);
+
+    const response = await POST(
+      createWebhookRequest(
+        createWebhookPayload({
+          channel: "imessage",
+          from: phone,
+          message: "/help",
+          messageId: uniqueId("msg-help-imessage"),
+        }),
+      ),
+    );
+
+    expect(response.status).toBe(200);
+    await context.mocks.flushAfter();
+
+    expect(sendMessage.calls[0]?.body).toContain("/connect");
+    expect(typing.mocked).not.toHaveBeenCalled();
+    const runs = await findTestRunsByUserAndPromptContaining(
+      user.userId,
+      "/help",
+    );
+    expect(runs).toHaveLength(0);
+  });
+
   it("handles /model by updating the user's model preference", async () => {
     const phone = uniquePhone();
     const user = await context.setupUser();

--- a/turbo/apps/web/src/lib/zero/agentphone/handlers/inbound.ts
+++ b/turbo/apps/web/src/lib/zero/agentphone/handlers/inbound.ts
@@ -279,6 +279,8 @@ export async function handleAgentPhoneMessage(
     return;
   }
 
+  await refreshTypingIfSupported(event);
+
   const session = await lookupAgentPhoneThreadSession(userLink.id);
   let existingSessionId = session.existingSessionId;
   let lastProcessedMessageId = session.lastProcessedMessageId;
@@ -323,8 +325,6 @@ export async function handleAgentPhoneMessage(
     event.messageId,
     event.mediaUrl,
   );
-
-  await refreshTypingIfSupported(event);
 
   const { status, response, runId } = await runAgentForAgentPhone({
     agentId: agent.agentId,


### PR DESCRIPTION
## Summary
- Move the initial AgentPhone iMessage typing indicator to fire as soon as the selected agent is resolved
- Keep slash command handling from showing iMessage typing indicators

## Tests
- DATABASE_URL=postgresql://user@localhost:5432/vm0_test PATH=/tmp/vm0-bin:/home/user/.codex/tmp/arg0/codex-arg0VpXsjR:/usr/lib/node_modules/@openai/codex/node_modules/@openai/codex-linux-arm64/vendor/aarch64-unknown-linux-musl/path:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/home/user/go/bin:/home/user/.cargo/bin:/home/user/go/bin:/home/user/.cargo/bin pnpm exec vitest run app/api/agentphone/webhook/__tests__/route.test.ts
- PATH=/tmp/vm0-bin:/home/user/.codex/tmp/arg0/codex-arg0VpXsjR:/usr/lib/node_modules/@openai/codex/node_modules/@openai/codex-linux-arm64/vendor/aarch64-unknown-linux-musl/path:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/home/user/go/bin:/home/user/.cargo/bin:/home/user/go/bin:/home/user/.cargo/bin pnpm --filter web exec prettier --check app/api/agentphone/webhook/__tests__/route.test.ts src/lib/zero/agentphone/handlers/inbound.ts
- PATH=/tmp/vm0-bin:/home/user/.codex/tmp/arg0/codex-arg0VpXsjR:/usr/lib/node_modules/@openai/codex/node_modules/@openai/codex-linux-arm64/vendor/aarch64-unknown-linux-musl/path:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/home/user/go/bin:/home/user/.cargo/bin:/home/user/go/bin:/home/user/.cargo/bin pnpm --filter web exec oxlint app/api/agentphone/webhook/__tests__/route.test.ts src/lib/zero/agentphone/handlers/inbound.ts