### PR TITLE
test: add vercel sandbox smoke e2e

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -689,6 +689,7 @@ jobs:
       )
     outputs:
       preview-url: ${{ steps.alias.outputs.url || steps.deploy.outputs.url }}
+      api-preview-url: ${{ steps.api-alias.outputs.url || steps.api-deploy.outputs.url }}
     permissions:
       contents: read
       pull-requests: write
@@ -880,7 +881,7 @@ jobs:
 
       - name: Resolve API deploy environment
         id: api-deploy-env
-        if: needs.prepare.outputs.api-changed == 'true' || needs.prepare.outputs.ci-changed == 'true'
+        if: needs.prepare.outputs.api-changed == 'true' || needs.prepare.outputs.ci-changed == 'true' || needs.prepare.outputs.e2e-changed == 'true'
         uses: ./.github/actions/web-api-env
         with:
           app: api
@@ -896,7 +897,7 @@ jobs:
 
       - name: Deploy API to Vercel
         id: api-deploy
-        if: needs.prepare.outputs.api-changed == 'true' || needs.prepare.outputs.ci-changed == 'true'
+        if: needs.prepare.outputs.api-changed == 'true' || needs.prepare.outputs.ci-changed == 'true' || needs.prepare.outputs.e2e-changed == 'true'
         uses: ./.github/actions/vercel-deploy
         with:
           vercel-token: ${{ secrets.VERCEL_TOKEN }}
@@ -916,7 +917,7 @@ jobs:
           skip-finish: ${{ github.event_name == 'merge_group' || (github.event_name == 'pull_request' && vars.PREVIEW_DOMAIN != '') }}
 
       - name: Check API health
-        if: needs.prepare.outputs.api-changed == 'true' || needs.prepare.outputs.ci-changed == 'true'
+        if: needs.prepare.outputs.api-changed == 'true' || needs.prepare.outputs.ci-changed == 'true' || needs.prepare.outputs.e2e-changed == 'true'
         run: |
           set -euo pipefail
           vercel curl /health --deployment "$API_DEPLOYMENT_URL" --token "$VERCEL_TOKEN" -- \
@@ -933,7 +934,7 @@ jobs:
 
       - name: Create API Vercel Alias
         id: api-alias
-        if: vars.PREVIEW_DOMAIN != '' && (needs.prepare.outputs.api-changed == 'true' || needs.prepare.outputs.ci-changed == 'true')
+        if: vars.PREVIEW_DOMAIN != '' && (needs.prepare.outputs.api-changed == 'true' || needs.prepare.outputs.ci-changed == 'true' || needs.prepare.outputs.e2e-changed == 'true')
         uses: ./.github/actions/vercel-alias
         with:
           vercel-token: ${{ secrets.VERCEL_TOKEN }}
@@ -946,7 +947,7 @@ jobs:
           deployment-env: ${{ steps.api-deploy.outputs.deployment-env }}
 
       - name: Post API preview URL
-        if: github.event_name == 'pull_request' && (needs.prepare.outputs.api-changed == 'true' || needs.prepare.outputs.ci-changed == 'true')
+        if: github.event_name == 'pull_request' && (needs.prepare.outputs.api-changed == 'true' || needs.prepare.outputs.ci-changed == 'true' || needs.prepare.outputs.e2e-changed == 'true')
         uses: marocchino/sticky-pull-request-comment@v3
         with:
           header: api-preview
@@ -1344,6 +1345,8 @@ jobs:
           echo "✅ Serial tests passed"
         env:
           VM0_API_URL: ${{ needs.deploy-web.outputs.preview-url }}
+          VERCEL_SANDBOX_SMOKE_API_URL: ${{ needs.deploy-web.outputs.api-preview-url }}
+          CRON_SECRET: ${{ secrets.CRON_SECRET }}
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
           USE_MOCK_CLAUDE: "true"
           USE_MOCK_CODEX: "true"

--- a/e2e/tests/01-serial/ser-t08-vercel-sandbox-smoke.bats
+++ b/e2e/tests/01-serial/ser-t08-vercel-sandbox-smoke.bats
@@ -1,0 +1,81 @@
+#!/usr/bin/env bats
+
+# End-to-end Vercel Sandbox smoke test against a deployed API.
+#
+# Required env:
+#   VERCEL_SANDBOX_SMOKE_API_URL       - deployed API URL
+#   CRON_SECRET                        - shared with the deployment
+#
+# Optional env:
+#   VERCEL_AUTOMATION_BYPASS_SECRET    - preview protection bypass
+
+load '../../helpers/setup'
+
+export BATS_TEST_TIMEOUT=120
+
+vercel_sandbox_smoke_api_url() {
+    local url="$VERCEL_SANDBOX_SMOKE_API_URL"
+    case "$url" in
+        http*) printf '%s' "$url" ;;
+        *)     printf 'https://%s' "$url" ;;
+    esac
+}
+
+setup_file() {
+    if [[ -z "${VERCEL_SANDBOX_SMOKE_API_URL:-}" ]]; then
+        skip "VERCEL_SANDBOX_SMOKE_API_URL not set"
+    fi
+    if [[ -z "${CRON_SECRET:-}" ]]; then
+        skip "CRON_SECRET not set"
+    fi
+}
+
+@test "vercel sandbox: smoke endpoint creates, runs, and stops sandbox" {
+    local base body_file status_code target
+    base=$(vercel_sandbox_smoke_api_url)
+    body_file="$BATS_TEST_TMPDIR/vercel-sandbox-smoke-response.json"
+
+    local -a headers=(
+        -H "Authorization: Bearer $CRON_SECRET"
+        -H "Accept: application/json"
+    )
+    if [[ -n "${VERCEL_AUTOMATION_BYPASS_SECRET:-}" ]]; then
+        headers+=(-H "x-vercel-protection-bypass: $VERCEL_AUTOMATION_BYPASS_SECRET")
+    fi
+
+    target="${base%/}/api/internal/vercel-sandbox/smoke"
+    run curl -sS --max-time 90 -o "$body_file" -w "%{http_code}" \
+        -X POST \
+        "${headers[@]}" \
+        "$target"
+    if [[ "$status" -ne 0 ]]; then
+        echo "# smoke endpoint curl failed with exit $status" >&2
+        echo "# curl output: $output" >&2
+        if [[ -s "$body_file" ]]; then
+            echo "# response body: $(cat "$body_file")" >&2
+        fi
+        return 1
+    fi
+
+    status_code="$output"
+    if [[ "$status_code" != "200" ]]; then
+        echo "# smoke endpoint returned HTTP $status_code" >&2
+        echo "# response body: $(cat "$body_file")" >&2
+        return 1
+    fi
+
+    if ! jq -e '
+      .success == true and
+      .sandbox.runtime == "node24" and
+      (.sandbox.id | type == "string" and length > 0) and
+      .command.cmd == "node" and
+      .command.args == ["--version"] and
+      .command.exitCode == 0 and
+      (.command.stdout | test("^v[0-9]+\\.[0-9]+\\.[0-9]+")) and
+      .cleanup.status == "stopped"
+    ' "$body_file" >/dev/null; then
+        echo "# smoke endpoint returned unexpected success payload" >&2
+        echo "# response body: $(cat "$body_file")" >&2
+        return 1
+    fi
+}


### PR DESCRIPTION
## Summary
- add a gated BATS e2e for POST /api/internal/vercel-sandbox/smoke
- assert the deployed API creates a node24 sandbox, runs node --version, and stops cleanup
- pass CRON_SECRET into serial e2e so CI previews can exercise the real endpoint

## Testing
- ./e2e/test/libs/bats/bin/bats -T e2e/tests/01-serial/ser-t08-vercel-sandbox-smoke.bats
- local stub server success-path check for the same BATS assertions
- git diff --check