### PR TITLE
chore(platform): polish model policy copy and fix brand icons

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/__tests__/org-providers-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/__tests__/org-providers-tab.test.tsx
@@ -259,7 +259,7 @@ describe("org-providers-tab — stale banner reconnect", () => {
 
     click(await screen.findByText("Add model"));
     const dialog = getModelPolicyDialog();
-    clickRouteChoice(dialog, "BYOK: workspace API key");
+    clickRouteChoice(dialog, "API Key");
     click(within(dialog).getByText("Edit API key"));
 
     const providerDialog = getOrgProviderDialog();
@@ -286,7 +286,7 @@ describe("org-providers-tab — stale banner reconnect", () => {
 
     click(await screen.findByText("Add model"));
     const dialog = getModelPolicyDialog();
-    clickRouteChoice(dialog, "BYOK: workspace API key");
+    clickRouteChoice(dialog, "API Key");
     clickDialogButton(dialog, "Add Anthropic API key");
 
     const providerDialog = getOrgProviderDialog();
@@ -313,7 +313,7 @@ describe("org-providers-tab — stale banner reconnect", () => {
 
     click(await screen.findByText("Add model"));
     const dialog = getModelPolicyDialog();
-    clickRouteChoice(dialog, "BYOK: workspace API key");
+    clickRouteChoice(dialog, "API Key");
     clickDialogButton(dialog, "Add Anthropic API key");
 
     const providerDialog = getOrgProviderDialog();
@@ -360,7 +360,7 @@ describe("org-providers-tab — stale banner reconnect", () => {
       "org-model-policy-row-claude-opus-4-7",
     );
     const dialog = await openModelPolicyDialog(row);
-    clickRouteChoice(dialog, "BYOK: Claude Subscription");
+    clickRouteChoice(dialog, "Claude Subscription");
     expect(
       within(dialog).queryByText("OAuth provider"),
     ).not.toBeInTheDocument();
@@ -394,7 +394,7 @@ describe("org-providers-tab — stale banner reconnect", () => {
 
     const row = await screen.findByTestId("org-model-policy-row-gpt-5.5");
     const dialog = await openModelPolicyDialog(row);
-    clickRouteChoice(dialog, "BYOK: Codex Subscription");
+    clickRouteChoice(dialog, "Codex Subscription");
     expect(
       within(dialog).queryByText("OAuth provider"),
     ).not.toBeInTheDocument();

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-model-policies-section.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-model-policies-section.tsx
@@ -81,17 +81,27 @@ function isByokProviderType(type: ModelProviderType): boolean {
   return type !== "vm0" && !isOAuthMemberType(type);
 }
 
-function getModelIconType(model: SupportedRunModel): ModelProviderType | null {
-  const compatibleTypes = getProvidersForModel(model);
-  return (
-    compatibleTypes.find((type) => {
-      return type !== "vm0" && !isOAuthMemberType(type);
-    }) ??
-    compatibleTypes.find((type) => {
-      return type !== "vm0";
-    }) ??
-    null
-  );
+const MODEL_BRAND_ICON: Readonly<Record<SupportedRunModel, ModelProviderType>> =
+  {
+    "claude-opus-4-7": "anthropic-api-key",
+    "claude-opus-4-6": "anthropic-api-key",
+    "claude-sonnet-4-6": "anthropic-api-key",
+    "claude-haiku-4-5": "anthropic-api-key",
+    "deepseek-v4-pro": "deepseek-api-key",
+    "deepseek-v4-flash": "deepseek-api-key",
+    "kimi-k2.6": "moonshot-api-key",
+    "kimi-k2.5": "moonshot-api-key",
+    "MiniMax-M2.7": "minimax-api-key",
+    "glm-5.1": "zai-api-key",
+    "gpt-5.5": "openai-api-key",
+    "gpt-5.4": "openai-api-key",
+    "gpt-5.4-mini": "openai-api-key",
+    "gpt-5.3-codex": "openai-api-key",
+    "gpt-5.2": "openai-api-key",
+  };
+
+function getModelIconType(model: SupportedRunModel): ModelProviderType {
+  return MODEL_BRAND_ICON[model];
 }
 
 function getApiProviderTypes(model: SupportedRunModel): ModelProviderType[] {
@@ -112,13 +122,13 @@ function getOAuthRouteCopy(oauthTypes: ModelProviderType[]): {
 } {
   if (oauthTypes.includes("codex-oauth-token")) {
     return {
-      title: "BYOK: Codex Subscription",
+      title: "Codex Subscription",
       description:
         "Lets members use their own Codex Pro/Team subscription. Each member opens their Preferences, switches to Personal Models, and connects ChatGPT (Codex). The token only launches the Codex CLI inside a secure sandbox and is sent directly to OpenAI.",
     };
   }
   return {
-    title: "BYOK: Claude Subscription",
+    title: "Claude Subscription",
     description:
       "Lets members use their own Claude Pro/Max/Team subscription. Each member opens their Preferences, switches to Personal Models, and sets a Claude Code OAuth Token. The token only launches the Claude Code CLI inside a secure sandbox and is sent directly to Anthropic.",
   };
@@ -902,7 +912,7 @@ function ModelPolicyRouteDialog({
               active={dialog.routeKind === "built-in"}
               icon={<ProviderIcon type="vm0" size={18} />}
               title="Built-in"
-              description="Uses VM0 managed keys and workspace credits. No setup is required for members."
+              description="Use workspace credits to access the model."
               onClick={() => {
                 chooseRoute("built-in");
               }}
@@ -911,8 +921,8 @@ function ModelPolicyRouteDialog({
               active={dialog.routeKind === "api-key"}
               disabled={apiTypes.length === 0}
               icon={<IconKey size={18} stroke={1.6} />}
-              title="BYOK: workspace API key"
-              description="An admin adds one provider API key for the workspace. Every member can use this route without adding personal credentials."
+              title="API Key"
+              description="Use an API key to access the model. API key routes are shared workspace credentials. They are best when the team should run through one billing account."
               onClick={() => {
                 chooseRoute("api-key");
               }}
@@ -933,7 +943,7 @@ function ModelPolicyRouteDialog({
           {dialog.routeKind === "api-key" && (
             <div className="flex flex-col gap-2">
               <label className="text-sm font-medium text-foreground">
-                Workspace API provider
+                API Provider
               </label>
               <ProviderTypeSelect
                 value={selectedProviderType}
@@ -946,11 +956,6 @@ function ModelPolicyRouteDialog({
                   setRoute({ routeKind: "api-key", providerType });
                 }}
               />
-              <p className="text-xs leading-5 text-muted-foreground">
-                API key routes are shared workspace credentials. They are best
-                when the team should run through one billing account or one
-                centrally managed key.
-              </p>
             </div>
           )}
 

--- a/turbo/apps/platform/src/views/zero-page/components/preferences/__tests__/personal-providers-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/preferences/__tests__/personal-providers-tab.test.tsx
@@ -93,11 +93,16 @@ describe("personal-providers-tab — OAuth-only configuration", () => {
     await waitFor(() => {
       expect(
         screen.getByText(
-          /Personal Claude Code and ChatGPT credentials, used only in your own runs/,
+          /Personal Claude Code and ChatGPT subscription, used only in your own runs/,
         ),
       ).toBeInTheDocument();
     });
     expect(screen.getByText("ChatGPT (Codex)")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /Organization admins can add more models from the Models page in organization management/,
+      ),
+    ).toBeInTheDocument();
   });
 
   it("renders fixed OAuth actions without default or add-provider UI", async () => {
@@ -111,7 +116,7 @@ describe("personal-providers-tab — OAuth-only configuration", () => {
     await waitFor(() => {
       expect(
         screen.getByText(
-          /Personal Claude Code and ChatGPT credentials, used only in your own runs/,
+          /Personal Claude Code and ChatGPT subscription, used only in your own runs/,
         ),
       ).toBeInTheDocument();
     });

--- a/turbo/apps/platform/src/views/zero-page/components/preferences/personal-providers-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/preferences/personal-providers-tab.tsx
@@ -60,10 +60,16 @@ function OAuthCredentialsSection() {
 
   return (
     <section className="flex flex-col gap-3">
-      <p className="text-sm text-muted-foreground">
-        Personal Claude Code and ChatGPT credentials, used only in your own
-        runs.
-      </p>
+      <div className="space-y-1 text-sm text-muted-foreground">
+        <p>
+          Personal Claude Code and ChatGPT subscription, used only in your own
+          runs.
+        </p>
+        <p>
+          Organization admins can add more models from the Models page in
+          organization management.
+        </p>
+      </div>
       <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
         {isLoading ? (
           <>


### PR DESCRIPTION
## Summary

- Drop the `BYOK:` prefix and the `workspace` qualifier from the org model policy dialog and personal providers tab so route titles read as `API Key` / `Claude Subscription` / `Codex Subscription` and the description for the workspace-credit route just says it spends credits to access the model.
- Rewrite the model icon resolver. The old resolver returned the first non-`vm0` provider from the model's routing list, so Haiku (only routable via OpenRouter today) rendered with the OpenRouter icon, and GLM-5.1 would have done the same had the lookup used the vm0 concrete type. The new resolver consults an explicit `Record<SupportedRunModel, ModelProviderType>` brand table — adding a model now forces an icon choice at type-check time.
- Bring along the in-flight copy update for the personal providers tab (Personal Claude Code and ChatGPT subscription, plus a hint pointing org admins at the Models page) and its test coverage.

## Test plan

- [x] `pnpm -F @vm0/app exec vitest run` for the two affected test files
- [x] `pnpm -F @vm0/app exec tsc --noEmit`
- [x] `pnpm turbo run lint --filter=@vm0/app`
- [x] `pnpm format`
- [ ] Visually verify in the org model policies dialog that Haiku and GLM render with their brand icons (Anthropic / ChatGLM) instead of OpenRouter

🤖 Generated with [Claude Code](https://claude.com/claude-code)