### PR TITLE
feat(feature-switch): enable ChatThreadPin globally

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-chat-delete.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-chat-delete.test.tsx
@@ -131,7 +131,13 @@ async function deleteThread(nthButton: number) {
   click(menuTriggers[nthButton - 1]);
 
   const deleteItem = await waitFor(() => {
-    return screen.getByRole("menuitem", { name: /Delete chat/i });
+    const item = screen.getAllByRole("menuitem").find((el) => {
+      return /Delete chat/i.test(el.textContent ?? "");
+    });
+    if (!item) {
+      throw new Error("Delete chat menu item not visible yet");
+    }
+    return item;
   });
   click(deleteItem);
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-chat-delete.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-chat-delete.test.tsx
@@ -120,13 +120,20 @@ function mockAPIs() {
 }
 
 async function deleteThread(nthButton: number) {
-  const deleteButtons = await waitFor(() => {
-    const btns = screen.getAllByLabelText("Delete chat");
+  // With ChatThreadPin enabled the per-thread delete is reached through the
+  // kebab menu trigger; open it first then click the "Delete chat" item.
+  const menuTriggers = await waitFor(() => {
+    const btns = screen.getAllByLabelText("Open chat menu");
     expect(btns.length).toBeGreaterThanOrEqual(nthButton);
     return btns;
   });
 
-  click(deleteButtons[nthButton - 1]);
+  click(menuTriggers[nthButton - 1]);
+
+  const deleteItem = await waitFor(() => {
+    return screen.getByRole("menuitem", { name: /Delete chat/i });
+  });
+  click(deleteItem);
 
   const dialog = await waitFor(() => {
     return screen.getByRole("dialog");

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-interaction.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-interaction.test.tsx
@@ -369,8 +369,13 @@ describe("zero sidebar - delete thread button shows confirmation (SIDEBAR-D-018)
       expect(screen.getByText("First chat")).toBeInTheDocument();
     });
 
-    const deleteButtons = screen.getAllByLabelText("Delete chat");
-    click(deleteButtons[0]);
+    // ChatThreadPin enabled by default — open the kebab menu, then click Delete.
+    const menuTriggers = screen.getAllByLabelText("Open chat menu");
+    click(menuTriggers[0]);
+    const deleteItem = await waitFor(() => {
+      return screen.getByRole("menuitem", { name: /Delete chat/i });
+    });
+    click(deleteItem);
 
     await waitFor(() => {
       const dialog = screen.getByRole("dialog");
@@ -422,8 +427,13 @@ describe("zero sidebar - confirm delete removes thread (SIDEBAR-D-019)", () => {
       expect(screen.getByText("First chat")).toBeInTheDocument();
     });
 
-    const deleteButtons = screen.getAllByLabelText("Delete chat");
-    click(deleteButtons[0]);
+    // ChatThreadPin enabled by default — open the kebab menu, then click Delete.
+    const menuTriggers = screen.getAllByLabelText("Open chat menu");
+    click(menuTriggers[0]);
+    const deleteItem = await waitFor(() => {
+      return screen.getByRole("menuitem", { name: /Delete chat/i });
+    });
+    click(deleteItem);
 
     const dialog = await waitFor(() => {
       return screen.getByRole("dialog");

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-interaction.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-interaction.test.tsx
@@ -373,7 +373,13 @@ describe("zero sidebar - delete thread button shows confirmation (SIDEBAR-D-018)
     const menuTriggers = screen.getAllByLabelText("Open chat menu");
     click(menuTriggers[0]);
     const deleteItem = await waitFor(() => {
-      return screen.getByRole("menuitem", { name: /Delete chat/i });
+      const item = screen.getAllByRole("menuitem").find((el) => {
+        return /Delete chat/i.test(el.textContent ?? "");
+      });
+      if (!item) {
+        throw new Error("Delete chat menu item not visible yet");
+      }
+      return item;
     });
     click(deleteItem);
 
@@ -431,7 +437,13 @@ describe("zero sidebar - confirm delete removes thread (SIDEBAR-D-019)", () => {
     const menuTriggers = screen.getAllByLabelText("Open chat menu");
     click(menuTriggers[0]);
     const deleteItem = await waitFor(() => {
-      return screen.getByRole("menuitem", { name: /Delete chat/i });
+      const item = screen.getAllByRole("menuitem").find((el) => {
+        return /Delete chat/i.test(el.textContent ?? "");
+      });
+      if (!item) {
+        throw new Error("Delete chat menu item not visible yet");
+      }
+      return item;
     });
     click(deleteItem);
 

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -262,8 +262,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     maintainer: "ethan@vm0.ai",
     description:
       "Replace the sidebar's per-thread trash button with a kebab/pin menu that exposes Pin/Unpin and Delete. Pinned threads sort to the top of the agent's chat list. Mobile shows the menu trigger always; desktop shows it on hover.",
-    enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+    enabled: true,
   },
   [FeatureSwitchKey.ChatThreadRename]: {
     maintainer: "ethan@vm0.ai",


### PR DESCRIPTION
## Summary
- Flip `ChatThreadPin` from staff-org gated to fully enabled — sidebar kebab/pin menu (Pin/Unpin + Delete) goes to all users.

## Test plan
- [ ] CI green