### PR TITLE
fix(platform): unblock e2e onboarding by fixing eager-init step race

### DIFF
--- a/e2e/playwright/tests/smoke.spec.ts
+++ b/e2e/playwright/tests/smoke.spec.ts
@@ -44,24 +44,42 @@ test("sign in and complete onboarding to chat page", async ({ page }) => {
 });
 
 async function completeOnboarding(page: import("@playwright/test").Page) {
+  // NOTE: Playwright's locator.isVisible() returns the *current* visibility
+  // synchronously — the `timeout` option only controls element resolution,
+  // not visibility polling. waitFor({ state: "visible" }) does the real wait
+  // and is what we need here, because step 1 → step 2 transition now runs
+  // an async eager-init API call before the next step renders.
+  const tryAwaitVisible = async (
+    locator: ReturnType<typeof page.locator>,
+    timeout: number,
+  ): Promise<boolean> => {
+    return await locator
+      .waitFor({ state: "visible", timeout })
+      .then(() => true)
+      .catch(() => false);
+  };
+
   const workspaceInput = page.getByPlaceholder("e.g. Acme Corp");
-  if (await workspaceInput.isVisible({ timeout: 3_000 }).catch(() => false)) {
+  if (await tryAwaitVisible(workspaceInput, 5_000)) {
     await workspaceInput.fill("E2E Test Workspace");
     await page.getByRole("button", { name: "Next" }).click();
   }
 
+  // step 1 → step 2 transition runs the eager-init API; allow plenty of time.
   const chooseTools = page.getByTestId("onboarding-step-select-connectors");
-  if (await chooseTools.isVisible({ timeout: 3_000 }).catch(() => false)) {
+  if (await tryAwaitVisible(chooseTools, 15_000)) {
     await page.getByRole("button", { name: "Next" }).click();
   }
 
+  // step 3 (connect-your-apps) is skipped when no connectors are selected,
+  // so it usually never appears — short timeout to avoid wasting test budget.
   const connectApps = page.getByTestId("onboarding-step-connect");
-  if (await connectApps.isVisible({ timeout: 3_000 }).catch(() => false)) {
+  if (await tryAwaitVisible(connectApps, 1_500)) {
     await page.getByRole("button", { name: "Next" }).click();
   }
 
   const whereToWork = page.getByTestId("onboarding-step-where-to-work");
-  if (await whereToWork.isVisible({ timeout: 3_000 }).catch(() => false)) {
+  if (await tryAwaitVisible(whereToWork, 10_000)) {
     await page.getByRole("button", { name: "Continue in web" }).click();
   }
 }

--- a/turbo/apps/platform/src/signals/zero-page/zero-onboarding-actions.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-onboarding-actions.ts
@@ -504,7 +504,12 @@ export const onboardingContinueWeb$ = command(
           : await set(completeOnboarding$, signal);
 
         if (!agentId) {
-          return;
+          // Surfacing via throw lets `useLoadableSet` consumers (WhereToWorkContent)
+          // render the error UI instead of silently leaving the user stuck on the
+          // onboarding skeleton.
+          throw new Error(
+            "Onboarding could not resolve a default agent. Please retry.",
+          );
         }
 
         const prompt = get(onboardingResolvedPrompt$);

--- a/turbo/apps/platform/src/views/zero-page/zero-onboarding.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-onboarding.tsx
@@ -841,35 +841,57 @@ function OnboardingFooterNav() {
   const nextDisabled = useLastResolved(onboardingNextDisabled$) ?? false;
   const nextLabel = useLastResolved(onboardingNextLabel$) ?? "Next";
   const stepBack = useSet(onboardingStepBack$);
-  const stepNext = useSet(onboardingStepNext$);
+  // Step 1's Next triggers eager-init (a backend setup call); the loadable
+  // state lets us disable the button + show a spinner so users can't double
+  // submit and so e2e drivers can see the in-flight state.
+  const [nextLoadable, stepNext] = useLoadableSet(onboardingStepNext$);
   const pageSignal = useGet(pageSignal$);
+  const nextLoading = nextLoadable.state === "loading";
+  const nextError =
+    nextLoadable.state === "hasError" ? String(nextLoadable.error) : null;
   return (
-    <div className="shrink-0 border-t border-border/40 flex items-center justify-between px-5 sm:px-10 py-5">
-      <div>
-        {showBack && (
-          <Button
-            variant="ghost"
-            className="rounded-lg text-muted-foreground"
-            onClick={() => {
-              detach(stepBack(pageSignal), Reason.DomCallback);
-            }}
-          >
-            Back
-          </Button>
-        )}
-      </div>
-      <div>
-        {showNext && (
-          <Button
-            onClick={() => {
-              detach(stepNext(pageSignal), Reason.DomCallback);
-            }}
-            className="rounded-lg min-w-[100px]"
-            disabled={nextDisabled}
-          >
-            {nextLabel}
-          </Button>
-        )}
+    <div className="shrink-0 border-t border-border/40 flex flex-col gap-2 px-5 sm:px-10 py-5">
+      {nextError && (
+        <div
+          role="alert"
+          className="w-full rounded-lg border border-destructive/30 bg-destructive/5 px-4 py-2 text-sm text-destructive"
+        >
+          {nextError}
+        </div>
+      )}
+      <div className="flex items-center justify-between">
+        <div>
+          {showBack && (
+            <Button
+              variant="ghost"
+              className="rounded-lg text-muted-foreground"
+              onClick={() => {
+                detach(stepBack(pageSignal), Reason.DomCallback);
+              }}
+            >
+              Back
+            </Button>
+          )}
+        </div>
+        <div>
+          {showNext && (
+            <Button
+              onClick={() => {
+                detach(stepNext(pageSignal), Reason.DomCallback);
+              }}
+              className="rounded-lg min-w-[100px]"
+              disabled={nextDisabled || nextLoading}
+              aria-busy={nextLoading}
+              data-testid="onboarding-next-button"
+            >
+              {nextLoading ? (
+                <IconLoader size={16} className="animate-spin" />
+              ) : (
+                nextLabel
+              )}
+            </Button>
+          )}
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

PR #13194 (eager-init workspace at step 1) made step 1 → step 2 transition async (workspace setup API call), which exposed three latent issues that together caused `smoke.spec.ts` to hang at "Choose your tools" with the app skeleton overlay and time out at `waitForURL("**/agents/*/chat")`. This blocks merge for any PR rebased onto current main (already observed on #13193, #13195).

Root cause and the three fixes:

- **e2e helper used `locator.isVisible({timeout: 3_000})`** thinking it waits, but Playwright's `isVisible` is synchronous — the `timeout` option only controls element resolution, not visibility polling. After clicking Next on step 1, the helper checked subsequent steps within ~50ms (per playwright trace) and all returned false, so it skipped Next on step 2/3 and Continue-in-web on step 4. Switch to `waitFor({state: "visible"})` and size budgets per-step (15s for the eager-init step, 1.5s for the conditionally-rendered connect step).
- **`onboardingContinueWeb$` silently returned** when agentId resolution returned null, leaving the skeleton overlay up and producing the exact "stuck on onboarding" symptom users would otherwise hit on any transient backend failure. Throw instead so `useLoadableSet` consumers (WhereToWorkContent) surface the error.
- **`OnboardingFooterNav` used `useSet(onboardingStepNext$)`**, so the Next button stayed enabled and visually idle while the eager-init API was in flight (users could double-submit). Switch to `useLoadableSet`, disable + spinner while loading, render any error inline, expose `data-testid="onboarding-next-button"` + `aria-busy` for future e2e drivers.

## Test plan

- [x] Local `pnpm -F @vm0/app exec vitest run` for the three onboarding test files (58/58 pass)
- [x] Local `pnpm turbo run lint --filter=@vm0/app` (0 warnings)
- [x] Local `pnpm turbo run check-types` (clean across all 11 packages)
- [x] Local `VM0_API_URL=https://www.vm7.ai:8443 JOB_REF=local npx playwright test --project=setup` (was 60s timeout; now passes in ~18s)
- [ ] CI: cli-e2e-02-playwright should now pass on this PR + on any rebased PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)