### PR TITLE
feat(model-providers): add codex framework gateways for openrouter and vercel

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/components/settings/provider-icons.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/provider-icons.tsx
@@ -23,6 +23,8 @@ const PROVIDER_ICONS: Readonly<Record<ModelProviderType, string>> =
     "zai-api-key": chatglmIcon,
     "moonshot-api-key": kimiIcon,
     "vercel-ai-gateway": vercelIcon,
+    "openrouter-codex": openrouterIcon,
+    "vercel-ai-gateway-codex": vercelIcon,
     "openai-api-key": openaiIcon,
     "codex-oauth-token": openaiIcon,
     "azure-foundry": azureIcon,

--- a/turbo/apps/platform/src/views/zero-page/components/settings/provider-ui-config.ts
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/provider-ui-config.ts
@@ -42,124 +42,113 @@ interface ProviderUIOverrides {
   authMethodLabelOverrides?: Record<string, string>;
 }
 
+const PROVIDER_UI_OVERRIDES = Object.freeze<
+  Partial<Record<ModelProviderType, ProviderUIOverrides>>
+>({
+  "claude-code-oauth-token": {
+    label: "Claude Code (OAuth token)",
+    description:
+      "Leverage Claude Code's exceptional intelligence to build and run agents.",
+  },
+  "codex-oauth-token": {
+    description:
+      "Sign in with your ChatGPT subscription (Plus / Pro / Business / Edu / Enterprise). Workspace selection happens on auth.openai.com.",
+  },
+  "anthropic-api-key": {
+    description:
+      "Power your agents with Claude models for advanced reasoning and analysis.",
+  },
+  "openrouter-api-key": {
+    description:
+      "Route to 200+ models from multiple providers through unified interface.",
+    defaultModel: "anthropic/claude-sonnet-4.5",
+  },
+  "moonshot-api-key": {
+    description:
+      "Process extensive context with up to 200k tokens for complex workflows.",
+  },
+  "minimax-api-key": {
+    description:
+      "Generate multimodal content including text, images, and voice.",
+  },
+  "zai-api-key": {
+    description:
+      "Access Zhipu AI's ChatGLM models with excellent performance at competitive pricing.",
+  },
+  "deepseek-api-key": {
+    label: "Deepseek",
+    description:
+      "Execute deep reasoning and analytical tasks with cost-effective performance.",
+  },
+  "vercel-ai-gateway": {
+    description:
+      "Access Claude models through Vercel AI Gateway with a unified API.",
+  },
+  "openrouter-codex": {
+    description: "Route GPT models through OpenRouter for codex-style agents.",
+    defaultModel: "openai/gpt-5.5",
+  },
+  "vercel-ai-gateway-codex": {
+    description:
+      "Route GPT models through Vercel AI Gateway for codex-style agents.",
+  },
+  "azure-foundry": {
+    label: "Azure foundry portal",
+    description:
+      "Deploy enterprise-grade AI with Azure security and compliance.",
+    authMethodLabelOverrides: { "api-key": "API key" },
+    secretFieldOverrides: {
+      ANTHROPIC_FOUNDRY_API_KEY: {
+        label: "Anthropic foundry API key",
+        placeholder: "API key from Azure Foundry portal",
+      },
+      ANTHROPIC_FOUNDRY_RESOURCE: {
+        label: "Anthropic foundry resource",
+        placeholder: "Enter Anthropic foundry resource",
+      },
+    },
+  },
+  vm0: {
+    label: "Built-in model",
+    description:
+      "Powered by Claude — uses your VM0 credits. No API key needed.",
+  },
+  "aws-bedrock": {
+    description:
+      "Scale foundation models with AWS enterprise security and infrastructure.",
+    authMethodLabelOverrides: {
+      "api-key": "Bedrock API key",
+      "access-keys": "IAM access keys",
+    },
+    secretFieldOverrides: {
+      AWS_BEARER_TOKEN_BEDROCK: {
+        label: "Bedrock API key",
+        placeholder: "Bedrock API key from AWS console",
+      },
+      AWS_REGION: {
+        label: "AWS region",
+        placeholder: "e.g., us-east-1, us-west-2",
+      },
+      AWS_ACCESS_KEY_ID: {
+        label: "AWS access key ID",
+        placeholder: "IAM access key ID",
+      },
+      AWS_SECRET_ACCESS_KEY: {
+        label: "AWS secret access key",
+        placeholder: "IAM secret access key",
+      },
+      AWS_SESSION_TOKEN: {
+        label: "AWS session token",
+        placeholder: "Optional, for temporary secrets",
+      },
+    },
+  },
+});
+
 function getOverrides(
   type: ModelProviderType,
 ): ProviderUIOverrides | undefined {
-  if (type === "claude-code-oauth-token") {
-    return {
-      label: "Claude Code (OAuth token)",
-      description:
-        "Leverage Claude Code's exceptional intelligence to build and run agents.",
-    };
-  }
-  if (type === "codex-oauth-token") {
-    return {
-      description:
-        "Sign in with your ChatGPT subscription (Plus / Pro / Business / Edu / Enterprise). Workspace selection happens on auth.openai.com.",
-    };
-  }
-  if (type === "anthropic-api-key") {
-    return {
-      description:
-        "Power your agents with Claude models for advanced reasoning and analysis.",
-    };
-  }
-  if (type === "openrouter-api-key") {
-    return {
-      description:
-        "Route to 200+ models from multiple providers through unified interface.",
-      defaultModel: "anthropic/claude-sonnet-4.5",
-    };
-  }
-  if (type === "moonshot-api-key") {
-    return {
-      description:
-        "Process extensive context with up to 200k tokens for complex workflows.",
-    };
-  }
-  if (type === "minimax-api-key") {
-    return {
-      description:
-        "Generate multimodal content including text, images, and voice.",
-    };
-  }
-  if (type === "zai-api-key") {
-    return {
-      description:
-        "Access Zhipu AI's ChatGLM models with excellent performance at competitive pricing.",
-    };
-  }
-  if (type === "deepseek-api-key") {
-    return {
-      label: "Deepseek",
-      description:
-        "Execute deep reasoning and analytical tasks with cost-effective performance.",
-    };
-  }
-  if (type === "vercel-ai-gateway") {
-    return {
-      description:
-        "Access Claude models through Vercel AI Gateway with a unified API.",
-    };
-  }
-  if (type === "azure-foundry") {
-    return {
-      label: "Azure foundry portal",
-      description:
-        "Deploy enterprise-grade AI with Azure security and compliance.",
-      authMethodLabelOverrides: { "api-key": "API key" },
-      secretFieldOverrides: {
-        ANTHROPIC_FOUNDRY_API_KEY: {
-          label: "Anthropic foundry API key",
-          placeholder: "API key from Azure Foundry portal",
-        },
-        ANTHROPIC_FOUNDRY_RESOURCE: {
-          label: "Anthropic foundry resource",
-          placeholder: "Enter Anthropic foundry resource",
-        },
-      },
-    };
-  }
-  if (type === "vm0") {
-    return {
-      label: "Built-in model",
-      description:
-        "Powered by Claude — uses your VM0 credits. No API key needed.",
-    };
-  }
-  if (type === "aws-bedrock") {
-    return {
-      description:
-        "Scale foundation models with AWS enterprise security and infrastructure.",
-      authMethodLabelOverrides: {
-        "api-key": "Bedrock API key",
-        "access-keys": "IAM access keys",
-      },
-      secretFieldOverrides: {
-        AWS_BEARER_TOKEN_BEDROCK: {
-          label: "Bedrock API key",
-          placeholder: "Bedrock API key from AWS console",
-        },
-        AWS_REGION: {
-          label: "AWS region",
-          placeholder: "e.g., us-east-1, us-west-2",
-        },
-        AWS_ACCESS_KEY_ID: {
-          label: "AWS access key ID",
-          placeholder: "IAM access key ID",
-        },
-        AWS_SECRET_ACCESS_KEY: {
-          label: "AWS secret access key",
-          placeholder: "IAM secret access key",
-        },
-        AWS_SESSION_TOKEN: {
-          label: "AWS session token",
-          placeholder: "Optional, for temporary secrets",
-        },
-      },
-    };
-  }
-  return undefined;
+  return PROVIDER_UI_OVERRIDES[type];
 }
 
 /**

--- a/turbo/packages/api-contracts/src/contracts/__tests__/model-providers.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/model-providers.test.ts
@@ -89,11 +89,14 @@ describe("model-first canonical catalog", () => {
       "claude-code-oauth-token",
       "anthropic-api-key",
       "openrouter-api-key",
+      "vercel-ai-gateway",
     ]);
     expect(getProvidersForModel("gpt-5.5")).toEqual([
       "vm0",
       "openai-api-key",
       "codex-oauth-token",
+      "openrouter-codex",
+      "vercel-ai-gateway-codex",
     ]);
     expect(getProvidersForModel("deepseek/deepseek-v4-pro")).toContain(
       "openrouter-api-key",
@@ -177,6 +180,8 @@ describe("getProviderBaseUrl", () => {
     ["deepseek-api-key", "https://api.deepseek.com/anthropic"],
     ["zai-api-key", "https://api.z.ai/api/anthropic"],
     ["vercel-ai-gateway", "https://ai-gateway.vercel.sh"],
+    ["openrouter-codex", "https://openrouter.ai/api/v1"],
+    ["vercel-ai-gateway-codex", "https://ai-gateway.vercel.sh/v1"],
   ] as [ModelProviderType, string][])(
     "returns correct URL for %s",
     (type, expectedUrl) => {
@@ -620,7 +625,106 @@ describe("getFirewallBaseUrl regression — existing providers unchanged", () =>
     ["vercel-ai-gateway", "https://ai-gateway.vercel.sh/v1/messages"],
     ["openai-api-key", "https://api.openai.com/v1/responses"],
     ["codex-oauth-token", "https://chatgpt.com/backend-api/codex"],
+    // Codex gateway providers scope the firewall to OPENAI_BASE_URL so codex
+    // can use either /chat/completions or /responses paths the gateway
+    // proxies — distinct from the narrow /v1/responses scope on the OpenAI
+    // direct provider.
+    ["openrouter-codex", "https://openrouter.ai/api/v1"],
+    ["vercel-ai-gateway-codex", "https://ai-gateway.vercel.sh/v1"],
   ] as const)("%s firewall base URL is %s", (type, expected) => {
     expect(MODEL_PROVIDER_FIREWALL_CONFIGS[type]!.apis[0]!.base).toBe(expected);
   });
+});
+
+describe("codex-framework gateway providers (openrouter-codex, vercel-ai-gateway-codex)", () => {
+  it.each(["openrouter-codex", "vercel-ai-gateway-codex"] as const)(
+    "%s declares codex framework",
+    (type) => {
+      expect(getFrameworkForType(type)).toBe("codex");
+    },
+  );
+
+  it.each(["openrouter-codex", "vercel-ai-gateway-codex"] as const)(
+    "%s maps OPENAI_API_KEY, OPENAI_BASE_URL, OPENAI_MODEL",
+    (type) => {
+      const mapping = getEnvironmentMapping(type);
+      expect(mapping).toBeDefined();
+      expect(mapping!["OPENAI_API_KEY"]).toBe("$secret");
+      expect(mapping!["OPENAI_BASE_URL"]).toMatch(/^https:\/\//);
+      expect(mapping!["OPENAI_MODEL"]).toBe("$model");
+    },
+  );
+
+  it.each(["openrouter-codex", "vercel-ai-gateway-codex"] as const)(
+    "%s offers GPT models with gpt-5.5 default",
+    (type) => {
+      expect(getModels(type)).toEqual([
+        "openai/gpt-5.5",
+        "openai/gpt-5.4",
+        "openai/gpt-5.4-mini",
+      ]);
+      expect(getDefaultModel(type)).toBe("openai/gpt-5.5");
+    },
+  );
+
+  it("appear in selectable provider types", () => {
+    const selectable = getSelectableProviderTypes();
+    expect(selectable).toContain("openrouter-codex");
+    expect(selectable).toContain("vercel-ai-gateway-codex");
+  });
+
+  it("translate canonical GPT models to vendor-prefixed runtime IDs", () => {
+    expect(getProviderRuntimeModel("openrouter-codex", "gpt-5.5")).toBe(
+      "openai/gpt-5.5",
+    );
+    expect(getProviderRuntimeModel("vercel-ai-gateway-codex", "gpt-5.4")).toBe(
+      "openai/gpt-5.4",
+    );
+    expect(
+      getProviderRuntimeModel("vercel-ai-gateway-codex", "gpt-5.4-mini"),
+    ).toBe("openai/gpt-5.4-mini");
+  });
+
+  it("share the secretName with their claude-code twin gateway", () => {
+    // Same API key powers both protocols on the same upstream gateway.
+    // The codex twin must not invent a separate secret env var.
+    const openrouterCodex = MODEL_PROVIDER_TYPES["openrouter-codex"];
+    const openrouterClaudeCode = MODEL_PROVIDER_TYPES["openrouter-api-key"];
+    expect(openrouterCodex.secretName).toBe(openrouterClaudeCode.secretName);
+
+    const vercelCodex = MODEL_PROVIDER_TYPES["vercel-ai-gateway-codex"];
+    const vercelClaudeCode = MODEL_PROVIDER_TYPES["vercel-ai-gateway"];
+    expect(vercelCodex.secretName).toBe(vercelClaudeCode.secretName);
+  });
+
+  it("are NOT compatible with their claude-code twin (different protocol)", () => {
+    expect(
+      areProvidersCompatible("openrouter-codex", "openrouter-api-key"),
+    ).toBe(false);
+    expect(
+      areProvidersCompatible("vercel-ai-gateway-codex", "vercel-ai-gateway"),
+    ).toBe(false);
+  });
+
+  it("modelProviderTypeSchema accepts both new types", () => {
+    expect(modelProviderTypeSchema.safeParse("openrouter-codex").success).toBe(
+      true,
+    );
+    expect(
+      modelProviderTypeSchema.safeParse("vercel-ai-gateway-codex").success,
+    ).toBe(true);
+  });
+
+  it.each(["openrouter-codex", "vercel-ai-gateway-codex"] as const)(
+    "%s firewall injects Authorization: Bearer header on the resolved base",
+    (type) => {
+      const config = MODEL_PROVIDER_FIREWALL_CONFIGS[type];
+      expect(config.apis).toHaveLength(1);
+      expect(config.apis[0]!.auth.headers).toMatchObject({
+        Authorization: expect.stringMatching(
+          /^Bearer \$\{\{ secrets\.[A-Z_]+ \}\}$/,
+        ),
+      });
+    },
+  );
 });

--- a/turbo/packages/api-contracts/src/contracts/model-providers.ts
+++ b/turbo/packages/api-contracts/src/contracts/model-providers.ts
@@ -484,6 +484,7 @@ export const MODEL_PROVIDER_TYPES = {
       CLAUDE_CODE_SUBAGENT_MODEL: "$model",
     } as Record<string, string>,
     models: [
+      "anthropic/claude-opus-4.7",
       "anthropic/claude-opus-4.6",
       "anthropic/claude-opus-4.5",
       "anthropic/claude-sonnet-4.6",
@@ -495,6 +496,53 @@ export const MODEL_PROVIDER_TYPES = {
       "zai/glm-5-turbo",
     ] as string[],
     defaultModel: "anthropic/claude-sonnet-4.6",
+  },
+  // Codex-framework twin of openrouter-api-key. Same upstream gateway (OpenRouter)
+  // and same API key (shared secretName), but routes through OpenRouter's
+  // OpenAI-compatible endpoint surface for GPT models that codex CLI requires.
+  // Pairing rule: the claude-code entry serves Anthropic Messages API
+  // (/v1/messages); this codex entry serves OpenAI Chat Completions / Responses
+  // (/v1/chat/completions, /v1/responses) under the same /api/v1 prefix.
+  "openrouter-codex": {
+    framework: "codex" as const,
+    secretName: "OPENROUTER_API_KEY",
+    label: "OpenRouter (Codex)",
+    secretLabel: "API key",
+    helpText: "Get your API key at: https://openrouter.ai/settings/keys",
+    environmentMapping: {
+      OPENAI_API_KEY: "$secret",
+      OPENAI_BASE_URL: "https://openrouter.ai/api/v1",
+      OPENAI_MODEL: "$model",
+    } as Record<string, string>,
+    models: [
+      "openai/gpt-5.5",
+      "openai/gpt-5.4",
+      "openai/gpt-5.4-mini",
+    ] as string[],
+    defaultModel: "openai/gpt-5.5",
+  },
+  // Codex-framework twin of vercel-ai-gateway. Vercel exposes both
+  // Anthropic Messages and OpenAI Chat Completions / Responses on the same
+  // base URL, distinguished by path. The claude-code entry uses /v1/messages;
+  // this codex entry uses /v1/chat/completions or /v1/responses (codex CLI
+  // picks the path it needs).
+  "vercel-ai-gateway-codex": {
+    framework: "codex" as const,
+    secretName: "VERCEL_AI_GATEWAY_API_KEY",
+    label: "Vercel AI Gateway (Codex)",
+    secretLabel: "API key",
+    helpText: "Get your API key from the Vercel AI Gateway dashboard",
+    environmentMapping: {
+      OPENAI_API_KEY: "$secret",
+      OPENAI_BASE_URL: "https://ai-gateway.vercel.sh/v1",
+      OPENAI_MODEL: "$model",
+    } as Record<string, string>,
+    models: [
+      "openai/gpt-5.5",
+      "openai/gpt-5.4",
+      "openai/gpt-5.4-mini",
+    ] as string[],
+    defaultModel: "openai/gpt-5.5",
   },
   "openai-api-key": {
     framework: "codex" as const,
@@ -726,6 +774,7 @@ const MODEL_FIRST_PROVIDER_COMPATIBILITY = {
     "claude-code-oauth-token",
     "anthropic-api-key",
     "openrouter-api-key",
+    "vercel-ai-gateway",
   ],
   "claude-opus-4-6": [
     "vm0",
@@ -742,9 +791,27 @@ const MODEL_FIRST_PROVIDER_COMPATIBILITY = {
     "vercel-ai-gateway",
   ],
   "claude-haiku-4-5": ["vm0", "openrouter-api-key"],
-  "gpt-5.5": ["vm0", "openai-api-key", "codex-oauth-token"],
-  "gpt-5.4": ["vm0", "openai-api-key", "codex-oauth-token"],
-  "gpt-5.4-mini": ["vm0", "openai-api-key", "codex-oauth-token"],
+  "gpt-5.5": [
+    "vm0",
+    "openai-api-key",
+    "codex-oauth-token",
+    "openrouter-codex",
+    "vercel-ai-gateway-codex",
+  ],
+  "gpt-5.4": [
+    "vm0",
+    "openai-api-key",
+    "codex-oauth-token",
+    "openrouter-codex",
+    "vercel-ai-gateway-codex",
+  ],
+  "gpt-5.4-mini": [
+    "vm0",
+    "openai-api-key",
+    "codex-oauth-token",
+    "openrouter-codex",
+    "vercel-ai-gateway-codex",
+  ],
   "deepseek-v4-pro": ["vm0", "deepseek-api-key", "openrouter-api-key"],
   "deepseek-v4-flash": ["vm0", "deepseek-api-key", "openrouter-api-key"],
   "kimi-k2.6": [
@@ -779,10 +846,21 @@ const PROVIDER_RUNTIME_MODEL_ALIASES: Partial<
     "glm-5.1": "z-ai/glm-5.1",
   },
   "vercel-ai-gateway": {
+    "claude-opus-4-7": "anthropic/claude-opus-4.7",
     "claude-opus-4-6": "anthropic/claude-opus-4.6",
     "claude-sonnet-4-6": "anthropic/claude-sonnet-4.6",
     "kimi-k2.6": "moonshotai/kimi-k2.6",
     "kimi-k2.5": "moonshotai/kimi-k2.5",
+  },
+  "openrouter-codex": {
+    "gpt-5.5": "openai/gpt-5.5",
+    "gpt-5.4": "openai/gpt-5.4",
+    "gpt-5.4-mini": "openai/gpt-5.4-mini",
+  },
+  "vercel-ai-gateway-codex": {
+    "gpt-5.5": "openai/gpt-5.5",
+    "gpt-5.4": "openai/gpt-5.4",
+    "gpt-5.4-mini": "openai/gpt-5.4-mini",
   },
 };
 
@@ -886,10 +964,20 @@ function getFirewallBaseUrl(type: ModelProviderType): string {
   if (type === "codex-oauth-token") {
     return "https://chatgpt.com/backend-api/codex";
   }
-  // Other codex providers use OpenAI's Responses API — the only inference
-  // endpoint codex hits today. Scoping to /v1/responses keeps token
-  // replacement narrow (admin endpoints like /v1/files don't see the swap).
+  // Codex framework providers split into two shapes:
+  //   1. OpenAI direct (no OPENAI_BASE_URL override) — codex hits /v1/responses
+  //      exclusively, so we scope the firewall tightly to that path. Admin
+  //      endpoints like /v1/files stay outside the token-replacement surface.
+  //   2. OpenAI-compatible gateways (openrouter-codex, vercel-ai-gateway-codex)
+  //      set OPENAI_BASE_URL — these can serve /v1/chat/completions and
+  //      /v1/responses interchangeably under the same /v1 prefix. We scope
+  //      to that base directly so codex can use either path the gateway
+  //      supports without re-listing endpoints here.
   if (getFrameworkForType(type) === "codex") {
+    const overrideBase = getEnvironmentMapping(type)?.OPENAI_BASE_URL;
+    if (overrideBase) {
+      return overrideBase.replace(/\/+$/, "");
+    }
     return "https://api.openai.com/v1/responses";
   }
   const base = (
@@ -1010,6 +1098,25 @@ export const MODEL_PROVIDER_FIREWALL_CONFIGS: Record<
     { name: "Authorization", valuePrefix: "Bearer" },
     "sk-CoffeeSafeLocalCoffeeSafeLocalCo",
   ),
+  // Codex-framework twin of openrouter-api-key. Same key shape as the
+  // claude-code entry; the difference is the firewall base URL — codex
+  // SDK hits OpenAI-compatible paths (/chat/completions, /responses)
+  // under https://openrouter.ai/api/v1, derived from the OPENAI_BASE_URL
+  // mapping by getFirewallBaseUrl.
+  "openrouter-codex": mpFirewall(
+    "openrouter-codex",
+    { name: "Authorization", valuePrefix: "Bearer" },
+    "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",
+  ),
+  // Codex-framework twin of vercel-ai-gateway. Same placeholder format
+  // (Vercel gateway proxies upstream); base URL scoped to /v1 prefix by
+  // getFirewallBaseUrl so codex can use either /chat/completions or
+  // /responses paths the gateway exposes.
+  "vercel-ai-gateway-codex": mpFirewall(
+    "vercel-ai-gateway-codex",
+    { name: "Authorization", valuePrefix: "Bearer" },
+    "sk-CoffeeSafeLocalCoffeeSafeLocalCo",
+  ),
   // Placeholder: sk-proj-{156 chars}T3BlbkFJ{156 chars} (typical project key shape)
   // Source: matches turbo/packages/connectors/src/firewalls/openai.generated.ts
   "openai-api-key": mpFirewall(
@@ -1106,6 +1213,8 @@ export const modelProviderTypeSchema = z.enum([
   "deepseek-api-key",
   "zai-api-key",
   "vercel-ai-gateway",
+  "openrouter-codex",
+  "vercel-ai-gateway-codex",
   "openai-api-key",
   "codex-oauth-token",
   "azure-foundry",
@@ -1253,14 +1362,25 @@ export function getEnvironmentMapping(
 }
 
 /**
- * Get the ANTHROPIC_BASE_URL for a model provider type.
- * Returns null for Anthropic-native providers (no base URL override).
+ * Get the upstream base URL for a model provider type.
+ *
+ * Returns the framework-appropriate base URL override from
+ * environmentMapping — ANTHROPIC_BASE_URL for claude-code, OPENAI_BASE_URL
+ * for codex. Returns null when the provider relies on the SDK's default
+ * (Anthropic-native providers, OpenAI direct).
+ *
+ * Used by areProvidersCompatible to detect session-continuation safety
+ * across provider swaps. Providers hitting the same upstream URL are
+ * compatible; different URLs imply different upstreams and so a
+ * potentially different request/response contract.
  */
 export function getProviderBaseUrl(type: ModelProviderType): string | null {
   const config = MODEL_PROVIDER_TYPES[type];
   if (!("environmentMapping" in config)) return null;
-  const url = config.environmentMapping["ANTHROPIC_BASE_URL"];
-  return url ?? null;
+  const anthropicUrl = config.environmentMapping["ANTHROPIC_BASE_URL"];
+  if (anthropicUrl) return anthropicUrl;
+  const openaiUrl = config.environmentMapping["OPENAI_BASE_URL"];
+  return openaiUrl ?? null;
 }
 
 /**


### PR DESCRIPTION
## Summary

Pair every gateway-style API key with both `claude-code` and `codex` frameworks so users can route GPT models through OpenRouter or Vercel AI Gateway with the same API key they already use for Claude, instead of needing a separate direct OpenAI key.

Concretely:

- **Two new providers** — `openrouter-codex` and `vercel-ai-gateway-codex` (framework `codex`, `OPENAI_BASE_URL` pointed at the gateway). Each shares its `secretName` with its claude-code twin so a single user-entered key powers both protocols on the same gateway.
- **Firewall routing** — `getFirewallBaseUrl` now honors `OPENAI_BASE_URL` for codex providers, scoping gateway egress to the `/v1` prefix (covers both `/chat/completions` and `/responses`) while the OpenAI direct provider keeps its narrow `/v1/responses` scope.
- **Session-continuation safety** — `getProviderBaseUrl` falls back to `OPENAI_BASE_URL`, so `areProvidersCompatible` correctly rejects cross-protocol swaps (e.g. `openrouter-api-key` ↔ `openrouter-codex`).
- **Catalog fixes** — `vercel-ai-gateway` (claude-code) gains `claude-opus-4.7`; `MODEL_FIRST_PROVIDER_COMPATIBILITY` exposes the new codex routes for `gpt-5.5` / `5.4` / `5.4-mini` and adds `vercel-ai-gateway` to `claude-opus-4-7`.
- **UI** — `provider-ui-config.ts` refactored to a `Record` lookup (the per-function-line lint cap was hit) and adds copy/icons for the new entries.

How the per-protocol routing works on the gateways:

- `vercel-ai-gateway` (claude-code) → `https://ai-gateway.vercel.sh` + Anthropic Messages SDK ➜ `/v1/messages`
- `vercel-ai-gateway-codex` (codex) → `https://ai-gateway.vercel.sh/v1` + codex SDK ➜ `/v1/chat/completions` (or `/v1/responses`)
- `openrouter-api-key` (claude-code) → `https://openrouter.ai/api` ➜ `/v1/messages`
- `openrouter-codex` (codex) → `https://openrouter.ai/api/v1` ➜ `/v1/chat/completions` (or `/v1/responses`)

## Test plan

- [x] `pnpm -F @vm0/api-contracts exec vitest run` (187 tests, all pass; covers new codex provider declarations, firewall base URL regression, runtime-model alias, and protocol-aware compatibility)
- [x] `pnpm -F @vm0/api-contracts lint && pnpm -F @vm0/app lint && pnpm -F web lint && pnpm -F api lint && pnpm -F @vm0/cli lint` — all 0 errors
- [x] `pnpm -F @vm0/api-contracts check-types`, `pnpm -F @vm0/app check-types`, `pnpm -F web check-types`, `pnpm -F api check-types`, `pnpm -F @vm0/cli check-types` — all clean
- [x] `pnpm format` — no churn beyond the new code
- [x] `pnpm knip` — exit 0 (only pre-existing config hints)
- [ ] DB-backed integration tests (web/api/platform vitest suites) — sandbox lacks PostgreSQL; rely on CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)