### PR TITLE
fix: dispatch API run failure callbacks

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-chat-messages.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-chat-messages.test.ts
@@ -25,6 +25,7 @@ import { and, eq, inArray, isNull } from "drizzle-orm";
 import { http, HttpResponse } from "msw";
 import { describe, expect, it } from "vitest";
 
+import { createApp } from "../../../app-factory";
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
 import { mockEnv, mockOptionalEnv } from "../../../lib/env";
 import { server } from "../../../mocks/server";
@@ -62,6 +63,23 @@ function client() {
 
 function authHeaders() {
   return { authorization: "Bearer clerk-session" };
+}
+
+function proxyChatCallbackToApp(): void {
+  server.use(
+    http.post(
+      "http://localhost:3000/api/internal/callbacks/chat",
+      async ({ request }) => {
+        const rawBody = await request.text();
+        const app = createApp({ signal: context.signal });
+        return await app.request("/api/internal/callbacks/chat", {
+          method: "POST",
+          headers: request.headers,
+          body: rawBody,
+        });
+      },
+    ),
+  );
 }
 
 function encryptedSecretsFromExecutionContext(value: unknown): string | null {
@@ -513,6 +531,72 @@ describe("POST /api/zero/chat/messages", () => {
     );
     expect(context.mocks.ably.publish).toHaveBeenCalledWith(
       `chatThreadRunCreated:${response.body.threadId}`,
+      null,
+    );
+  });
+
+  it("dispatches a terminal chat callback when run dispatch fails after insert", async () => {
+    const fixture = await track(seedFixture());
+    proxyChatCallbackToApp();
+    mockOptionalEnv("RUNNER_DEFAULT_GROUP", undefined);
+
+    const response = await send({
+      agentId: fixture.agentId,
+      prompt: "fail before worker start",
+    });
+    await clearAllDetached();
+
+    expect(response.body.status).toBe("failed");
+    expect(response.body.runId).toStrictEqual(expect.any(String));
+
+    const writeDb = store.set(writeDb$);
+    const [run] = await writeDb
+      .select({
+        status: agentRuns.status,
+        error: agentRuns.error,
+      })
+      .from(agentRuns)
+      .where(eq(agentRuns.id, response.body.runId!))
+      .limit(1);
+    expect(run).toStrictEqual({
+      status: "failed",
+      error: expect.stringContaining("RUNNER_DEFAULT_GROUP"),
+    });
+
+    const [callback] = await writeDb
+      .select({
+        status: agentRunCallbacks.status,
+        attempts: agentRunCallbacks.attempts,
+        deliveredAt: agentRunCallbacks.deliveredAt,
+      })
+      .from(agentRunCallbacks)
+      .where(eq(agentRunCallbacks.runId, response.body.runId!))
+      .limit(1);
+    expect(callback).toStrictEqual({
+      status: "delivered",
+      attempts: 1,
+      deliveredAt: expect.any(Date),
+    });
+
+    const messages = await writeDb
+      .select({
+        role: chatMessages.role,
+        runId: chatMessages.runId,
+        error: chatMessages.error,
+      })
+      .from(chatMessages)
+      .where(eq(chatMessages.chatThreadId, response.body.threadId));
+    expect(messages).toContainEqual({
+      role: "assistant",
+      runId: response.body.runId,
+      error: expect.any(String),
+    });
+    expect(context.mocks.ably.publish).toHaveBeenCalledWith(
+      `run:changed:${response.body.runId}`,
+      { status: "failed" },
+    );
+    expect(context.mocks.ably.publish).toHaveBeenCalledWith(
+      `chatThreadRunUpdated:${response.body.threadId}`,
       null,
     );
   });

--- a/turbo/apps/api/src/signals/services/agent-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-callback.service.ts
@@ -1,0 +1,174 @@
+import { agentRunCallbacks } from "@vm0/db/schema/agent-run-callback";
+import { and, eq, or } from "drizzle-orm";
+
+import { env, optionalEnv } from "../../lib/env";
+import { computeHmacSignature } from "../../lib/event-consumer/hmac";
+import { logger } from "../../lib/log";
+import type { Db } from "../external/db";
+import { now, nowDate } from "../external/time";
+import { safeAsync } from "../utils";
+import { decryptSecretValue } from "./crypto.utils";
+
+const L = logger("AgentRunCallback");
+
+interface CallbackRecord {
+  readonly id: string;
+  readonly url: string;
+  readonly encryptedSecret: string;
+  readonly payload: unknown;
+}
+
+interface DispatchResult {
+  readonly callbackId: string;
+  readonly success: boolean;
+  readonly error?: string;
+}
+
+type TerminalCallbackStatus = "completed" | "failed";
+
+interface DispatchSingleCallbackInput {
+  readonly db: Db;
+  readonly callback: CallbackRecord;
+  readonly runId: string;
+  readonly status: TerminalCallbackStatus;
+  readonly result?: Record<string, unknown>;
+  readonly error?: string;
+}
+
+function resolveCallbackUrl(url: string): string {
+  return env("ENV") === "development" && url.startsWith("https://tunnel-")
+    ? url.replace(/^https:\/\/tunnel-[^/]+/, "http://localhost:3000")
+    : url;
+}
+
+export async function dispatchRunCallbacks(
+  db: Db,
+  runId: string,
+  status: TerminalCallbackStatus,
+  result?: Record<string, unknown>,
+  error?: string,
+): Promise<DispatchResult[]> {
+  const callbacks = await db
+    .select({
+      id: agentRunCallbacks.id,
+      url: agentRunCallbacks.url,
+      encryptedSecret: agentRunCallbacks.encryptedSecret,
+      payload: agentRunCallbacks.payload,
+    })
+    .from(agentRunCallbacks)
+    .where(
+      and(
+        eq(agentRunCallbacks.runId, runId),
+        or(
+          eq(agentRunCallbacks.status, "pending"),
+          eq(agentRunCallbacks.status, "failed"),
+        ),
+      ),
+    );
+
+  const results: DispatchResult[] = [];
+  for (const callback of callbacks) {
+    const dispatchResult = await dispatchSingleCallback({
+      db,
+      callback,
+      runId,
+      status,
+      result,
+      error,
+    });
+    results.push(dispatchResult);
+  }
+  return results;
+}
+
+async function dispatchSingleCallback(
+  input: DispatchSingleCallbackInput,
+): Promise<DispatchResult> {
+  const { db, callback, runId, status, result, error } = input;
+  const secret = decryptSecretValue(callback.encryptedSecret);
+  const body = JSON.stringify({
+    callbackId: callback.id,
+    runId,
+    status,
+    result,
+    error,
+    payload: callback.payload,
+  });
+  const timestamp = Math.floor(now() / 1000);
+  const signature = computeHmacSignature(body, secret, timestamp);
+
+  await db
+    .update(agentRunCallbacks)
+    .set({
+      attempts: 1,
+      lastAttemptAt: nowDate(),
+    })
+    .where(eq(agentRunCallbacks.id, callback.id));
+
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    "X-VM0-Signature": signature,
+    "X-VM0-Timestamp": timestamp.toString(),
+  };
+  const bypass = optionalEnv("VERCEL_AUTOMATION_BYPASS_SECRET");
+  if (bypass) {
+    headers["x-vercel-protection-bypass"] = bypass;
+  }
+
+  const responseResult = await safeAsync(() => {
+    return fetch(resolveCallbackUrl(callback.url), {
+      method: "POST",
+      headers,
+      body,
+    });
+  });
+
+  if (!("ok" in responseResult)) {
+    const errorMessage =
+      responseResult.error instanceof Error
+        ? responseResult.error.message
+        : "Unknown error";
+    await markCallbackFailed(db, callback.id, errorMessage);
+    L.error("Callback dispatch threw", {
+      callbackId: callback.id,
+      runId,
+      error: responseResult.error,
+    });
+    return { callbackId: callback.id, success: false, error: errorMessage };
+  }
+
+  const response = responseResult.ok;
+  if (response.ok) {
+    await db
+      .update(agentRunCallbacks)
+      .set({
+        status: "delivered",
+        deliveredAt: nowDate(),
+      })
+      .where(eq(agentRunCallbacks.id, callback.id));
+    return { callbackId: callback.id, success: true };
+  }
+
+  const errorMessage = `HTTP ${response.status}: ${response.statusText}`;
+  await markCallbackFailed(db, callback.id, errorMessage);
+  L.warn("Callback dispatch failed", {
+    callbackId: callback.id,
+    runId,
+    error: errorMessage,
+  });
+  return { callbackId: callback.id, success: false, error: errorMessage };
+}
+
+async function markCallbackFailed(
+  db: Db,
+  callbackId: string,
+  error: string,
+): Promise<void> {
+  await db
+    .update(agentRunCallbacks)
+    .set({
+      status: "failed",
+      lastError: error,
+    })
+    .where(eq(agentRunCallbacks.id, callbackId));
+}

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -89,6 +89,7 @@ import {
 import { writeDb$, type Db } from "../external/db";
 import {
   publishOrgSignal,
+  publishRunChangedForUserSafely,
   publishRunnerJobNotification,
 } from "../external/realtime";
 import { now, nowDate } from "../external/time";
@@ -105,6 +106,9 @@ import {
   queuedRunnerJobPayload,
 } from "./agent-run-queue-payload.service";
 import { userFeatureSwitchOverrides } from "./feature-switches.service";
+import { dispatchRunCallbacks } from "./agent-run-callback.service";
+import { drainOrgQueue$ } from "./zero-run-queue.service";
+import { logger } from "../../lib/log";
 
 const PENDING_RUN_TTL_MS = 15 * 60 * 1000;
 const QUEUED_RUN_TTL_MS = 2 * 60 * 60 * 1000;
@@ -125,6 +129,7 @@ const PLATFORM_ENV_SECRET_NAMES = [
   "GOOGLE_ADS_DEVELOPER_TOKEN",
   "GOOGLE_ADS_LOGIN_CUSTOMER_ID",
 ] as const;
+const L = logger("AgentRunCreate");
 
 type CreateRunBody = z.infer<typeof unifiedRunRequestSchema>;
 type ComputedGetter = Getter;
@@ -2242,9 +2247,9 @@ async function markRunFailed(
   db: Db,
   runId: string,
   error: unknown,
-): Promise<void> {
+): Promise<boolean> {
   const message = error instanceof Error ? error.message : "Run failed";
-  await db
+  const [updated] = await db
     .update(agentRuns)
     .set({
       status: "failed",
@@ -2260,7 +2265,24 @@ async function markRunFailed(
           eq(agentRuns.status, "running"),
         ),
       ),
-    );
+    )
+    .returning({
+      userId: agentRuns.userId,
+    });
+
+  if (!updated) {
+    return false;
+  }
+
+  await publishRunChangedForUserSafely(updated.userId, runId, {
+    status: "failed",
+  });
+  await dispatchRunCallbacks(db, runId, "failed", undefined, message).catch(
+    (error: unknown) => {
+      L.error("Failed to dispatch failed-run callbacks", { runId, error });
+    },
+  );
+  return true;
 }
 
 async function buildRunnerJobPayload(
@@ -2720,6 +2742,7 @@ async function completePendingRun(input: {
   readonly args: CreateAgentRunArgs;
   readonly context: PreparedRunContext;
   readonly run: RunRecord;
+  readonly drainOrgQueue: () => Promise<void>;
   readonly signal: AbortSignal;
 }): Promise<Extract<CreateRunRouteResult, { readonly status: 201 }>> {
   const dispatchResult = await safeAsync(() => {
@@ -2746,8 +2769,21 @@ async function completePendingRun(input: {
     return createdRunResponse(input.run, dispatchResult.ok);
   }
 
-  await markRunFailed(input.db, input.run.id, dispatchResult.error);
+  const transitioned = await markRunFailed(
+    input.db,
+    input.run.id,
+    dispatchResult.error,
+  );
   input.signal.throwIfAborted();
+  if (transitioned) {
+    await input.drainOrgQueue().catch((error: unknown) => {
+      L.error("Failed to drain org queue after run dispatch failure", {
+        runId: input.run.id,
+        error,
+      });
+    });
+    input.signal.throwIfAborted();
+  }
   return failedRunResponse(input.run, dispatchResult.error);
 }
 
@@ -2798,6 +2834,9 @@ export const createAgentRun$ = command(
       args,
       context,
       run: transactionResult,
+      drainOrgQueue: async () => {
+        await set(drainOrgQueue$, { orgId: args.orgId }, signal);
+      },
       signal,
     });
   },


### PR DESCRIPTION
## Summary
- Add an API-side run callback dispatcher for terminal run callbacks.
- Dispatch failed-run callbacks and publish `run:changed` when API run creation fails after the run row is inserted.
- Drain the org queue after a pending API run fails during dispatch/materialization.
- Cover the API web-chat failure path so a failed dispatch delivers the chat callback and emits `chatThreadRunUpdated`.

Fixes #13202

## Verification
- `pnpm -F api lint`
- `pnpm -F api exec vitest src/signals/routes/__tests__/zero-chat-messages.test.ts src/signals/routes/__tests__/agent-runs-create.test.ts --run`

## Notes
- `pnpm check-types` is currently blocked on existing web-side type errors, first seen in `apps/web/app/api/runners/poll/route.ts`, `apps/web/app/api/webhooks/agent/usage-event/route.ts`, and other unrelated files.
