### PR TITLE
refactor(api): migrate agent health usage telemetry webhooks

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -46,6 +46,7 @@ import { runnersRoutes } from "./routes/runners";
 import { usageRoutes } from "./routes/usage";
 import { userExportRoutes } from "./routes/user-export";
 import { vercelSandboxSmokeRoutes } from "./routes/vercel-sandbox-smoke";
+import { webhooksAgentHealthUsageTelemetryRoutes } from "./routes/webhooks-agent-health-usage-telemetry";
 import { webhooksClerkRoutes } from "./routes/webhooks-clerk";
 import { webhooksGithubRoutes } from "./routes/webhooks-github";
 import { webhooksStripeRoutes } from "./routes/webhooks-stripe";
@@ -183,6 +184,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...webhooksClerkRoutes,
   ...webhooksGithubRoutes,
   ...webhooksStripeRoutes,
+  ...webhooksAgentHealthUsageTelemetryRoutes,
   ...agentCheckpointsRoutes,
   ...agentComposesReadRoutes,
   ...agentComposesByIdRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-health-usage-telemetry.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-health-usage-telemetry.test.ts
@@ -1,0 +1,378 @@
+import { randomUUID } from "node:crypto";
+
+import { createStore } from "ccstate";
+import { HttpResponse, http } from "msw";
+import { delay } from "signal-timers";
+import { describe, expect, it } from "vitest";
+import {
+  webhookHeartbeatContract,
+  webhookTelemetryContract,
+  webhookUsageEventContract,
+} from "@vm0/api-contracts/contracts/webhooks";
+import { agentRunCallbacks } from "@vm0/db/schema/agent-run-callback";
+import { agentRuns } from "@vm0/db/schema/agent-run";
+import { usageEvent } from "@vm0/db/schema/usage-event";
+import { eq } from "drizzle-orm";
+
+import { server } from "../../../mocks/server";
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { verifyHmacSignature } from "../../../lib/event-consumer/hmac";
+import { now } from "../../../lib/time";
+import { writeDb$ } from "../../external/db";
+import { signSandboxJwtForTests } from "../../auth/tokens";
+import { seedAgentRunCallback$ } from "./helpers/agent-run-callback";
+import {
+  deleteUsageInsightFixture$,
+  seedCompose$,
+  seedRun$,
+  seedUsageInsightFixture$,
+  type UsageInsightFixture,
+} from "./helpers/zero-usage-insight";
+import { createFixtureTracker } from "./helpers/zero-route-test";
+
+const context = testContext();
+const store = createStore();
+const TEST_CALLBACK_SECRET = "test-callback-secret";
+
+interface AgentWebhookFixture extends UsageInsightFixture {
+  readonly composeId: string;
+  readonly runId: string;
+}
+
+function currentSecond(): number {
+  return Math.floor(now() / 1000);
+}
+
+function sandboxToken(fixture: {
+  readonly runId: string;
+  readonly userId: string;
+  readonly orgId: string;
+}): string {
+  const nowSeconds = currentSecond();
+  return signSandboxJwtForTests({
+    scope: "sandbox",
+    runId: fixture.runId,
+    userId: fixture.userId,
+    orgId: fixture.orgId,
+    iat: nowSeconds,
+    exp: nowSeconds + 60,
+  });
+}
+
+async function seedFixture(status = "running"): Promise<AgentWebhookFixture> {
+  const base = await store.set(
+    seedUsageInsightFixture$,
+    undefined,
+    context.signal,
+  );
+  const { composeId } = await store.set(
+    seedCompose$,
+    { orgId: base.orgId, userId: base.userId },
+    context.signal,
+  );
+  const { runId } = await store.set(
+    seedRun$,
+    {
+      orgId: base.orgId,
+      userId: base.userId,
+      composeId,
+      status,
+    },
+    context.signal,
+  );
+  return { ...base, composeId, runId };
+}
+
+async function heartbeatAt(runId: string): Promise<Date | null> {
+  const db = store.set(writeDb$);
+  const [row] = await db
+    .select({ lastHeartbeatAt: agentRuns.lastHeartbeatAt })
+    .from(agentRuns)
+    .where(eq(agentRuns.id, runId))
+    .limit(1);
+  return row?.lastHeartbeatAt ?? null;
+}
+
+function waitFor<T>(promise: Promise<T>): Promise<T> {
+  return Promise.race([
+    promise,
+    delay(1000, { signal: context.signal }).then(() => {
+      throw new Error("Timed out waiting for webhook side effect");
+    }),
+  ]);
+}
+
+describe("POST /api/webhooks/agent/heartbeat", () => {
+  const track = createFixtureTracker<AgentWebhookFixture>((fixture) => {
+    return store.set(deleteUsageInsightFixture$, fixture, context.signal);
+  });
+
+  it("rejects missing sandbox auth", async () => {
+    const client = setupApp({ context })(webhookHeartbeatContract);
+
+    const response = await accept(
+      client.send({ body: { runId: randomUUID() }, headers: {} }),
+      [401],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Not authenticated or runId mismatch",
+        code: "UNAUTHORIZED",
+      },
+    });
+  });
+
+  it("updates the run heartbeat and dispatches pending progress callbacks", async () => {
+    const fixture = await track(seedFixture());
+    const callbackUrl = "https://callback.example/progress";
+    const { callbackId } = await store.set(
+      seedAgentRunCallback$,
+      { runId: fixture.runId, url: callbackUrl, payload: { channel: "C1" } },
+      context.signal,
+    );
+    let callbackBody: unknown;
+    const progressReceived = new Promise<void>((resolve) => {
+      server.use(
+        http.post(callbackUrl, async ({ request }) => {
+          const rawBody = await request.text();
+          const timestamp = Number(request.headers.get("x-vm0-timestamp"));
+          const signature = request.headers.get("x-vm0-signature");
+          expect(signature).not.toBeNull();
+          expect(
+            verifyHmacSignature(
+              rawBody,
+              TEST_CALLBACK_SECRET,
+              timestamp,
+              signature ?? "",
+            ),
+          ).toBeTruthy();
+          callbackBody = JSON.parse(rawBody) as unknown;
+          resolve();
+          return HttpResponse.json({ ok: true });
+        }),
+      );
+    });
+    const client = setupApp({ context })(webhookHeartbeatContract);
+
+    const response = await accept(
+      client.send({
+        body: { runId: fixture.runId },
+        headers: { authorization: `Bearer ${sandboxToken(fixture)}` },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({ ok: true });
+    await expect(heartbeatAt(fixture.runId)).resolves.toBeInstanceOf(Date);
+    await waitFor(progressReceived);
+    expect(callbackBody).toStrictEqual({
+      callbackId,
+      runId: fixture.runId,
+      status: "progress",
+      payload: { channel: "C1" },
+    });
+
+    const db = store.set(writeDb$);
+    const [callback] = await db
+      .select({
+        status: agentRunCallbacks.status,
+        attempts: agentRunCallbacks.attempts,
+        lastAttemptAt: agentRunCallbacks.lastAttemptAt,
+      })
+      .from(agentRunCallbacks)
+      .where(eq(agentRunCallbacks.id, callbackId))
+      .limit(1);
+    expect(callback).toStrictEqual({
+      status: "pending",
+      attempts: 0,
+      lastAttemptAt: null,
+    });
+  });
+});
+
+describe("POST /api/webhooks/agent/usage-event", () => {
+  const track = createFixtureTracker<AgentWebhookFixture>((fixture) => {
+    return store.set(deleteUsageInsightFixture$, fixture, context.signal);
+  });
+
+  it("persists usage events idempotently for the sandbox run", async () => {
+    const fixture = await track(seedFixture());
+    const idempotencyKey = randomUUID();
+    const client = setupApp({ context })(webhookUsageEventContract);
+    const request = {
+      body: {
+        runId: fixture.runId,
+        events: [
+          {
+            idempotencyKey,
+            kind: "model" as const,
+            provider: "claude-sonnet-4-6",
+            category: "tokens.input",
+            quantity: 42,
+          },
+        ],
+      },
+      headers: { authorization: `Bearer ${sandboxToken(fixture)}` },
+    };
+
+    await accept(client.send(request), [200]);
+    await accept(client.send(request), [200]);
+
+    const db = store.set(writeDb$);
+    const rows = await db
+      .select({
+        runId: usageEvent.runId,
+        orgId: usageEvent.orgId,
+        userId: usageEvent.userId,
+        kind: usageEvent.kind,
+        provider: usageEvent.provider,
+        category: usageEvent.category,
+        quantity: usageEvent.quantity,
+        idempotencyKey: usageEvent.idempotencyKey,
+      })
+      .from(usageEvent)
+      .where(eq(usageEvent.idempotencyKey, idempotencyKey));
+
+    expect(rows).toStrictEqual([
+      {
+        runId: fixture.runId,
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        kind: "model",
+        provider: "claude-sonnet-4-6",
+        category: "tokens.input",
+        quantity: 42,
+        idempotencyKey,
+      },
+    ]);
+  });
+
+  it("returns 404 when the authenticated run no longer exists", async () => {
+    const missingRun = {
+      runId: randomUUID(),
+      userId: `user_${randomUUID()}`,
+      orgId: `org_${randomUUID()}`,
+    };
+    const client = setupApp({ context })(webhookUsageEventContract);
+
+    const response = await accept(
+      client.send({
+        body: {
+          runId: missingRun.runId,
+          events: [
+            {
+              idempotencyKey: randomUUID(),
+              kind: "connector",
+              provider: "github",
+              category: "repo.read",
+              quantity: 1,
+            },
+          ],
+        },
+        headers: { authorization: `Bearer ${sandboxToken(missingRun)}` },
+      }),
+      [404],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Run not found", code: "NOT_FOUND" },
+    });
+  });
+});
+
+describe("POST /api/webhooks/agent/telemetry", () => {
+  const track = createFixtureTracker<AgentWebhookFixture>((fixture) => {
+    return store.set(deleteUsageInsightFixture$, fixture, context.signal);
+  });
+
+  it("ingests sandbox telemetry and flushes network logs", async () => {
+    const fixture = await track(seedFixture());
+    const client = setupApp({ context })(webhookTelemetryContract);
+
+    const response = await accept(
+      client.send({
+        body: {
+          runId: fixture.runId,
+          systemLog: "boot ok",
+          metrics: [
+            {
+              ts: "2026-05-14T01:00:00.000Z",
+              cpu: 10,
+              mem_used: 100,
+              mem_total: 200,
+              disk_used: 300,
+              disk_total: 400,
+            },
+          ],
+          networkLogs: [
+            {
+              timestamp: "2026-05-14T01:00:01.000Z",
+              action: "ALLOW",
+              host: "api.example.com",
+              port: 443,
+            },
+          ],
+          sandboxOperations: [
+            {
+              ts: "2026-05-14T01:00:02.000Z",
+              action_type: "codex_exec",
+              duration_ms: 123,
+              success: false,
+              error: "exit 1",
+            },
+          ],
+        },
+        headers: { authorization: `Bearer ${sandboxToken(fixture)}` },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      success: true,
+      id: fixture.runId,
+    });
+    expect(context.mocks.axiom.ingest).toHaveBeenCalledWith(
+      "sandbox-telemetry-system",
+      [
+        expect.objectContaining({
+          runId: fixture.runId,
+          userId: fixture.userId,
+          log: "boot ok",
+        }),
+      ],
+    );
+    expect(context.mocks.axiom.ingest).toHaveBeenCalledWith(
+      "sandbox-telemetry-metrics",
+      [
+        {
+          _time: "2026-05-14T01:00:00.000Z",
+          runId: fixture.runId,
+          userId: fixture.userId,
+          cpu: 10,
+          mem_used: 100,
+          mem_total: 200,
+          disk_used: 300,
+          disk_total: 400,
+        },
+      ],
+    );
+    expect(context.mocks.axiom.ingest).toHaveBeenCalledWith(
+      "sandbox-telemetry-network",
+      [
+        {
+          _time: "2026-05-14T01:00:01.000Z",
+          runId: fixture.runId,
+          userId: fixture.userId,
+          action: "ALLOW",
+          host: "api.example.com",
+          port: 443,
+        },
+      ],
+    );
+    expect(context.mocks.axiom.flush).toHaveBeenCalledWith({
+      client: "telemetry",
+      throwOnError: true,
+    });
+  });
+});

--- a/turbo/apps/api/src/signals/routes/webhooks-agent-health-usage-telemetry.ts
+++ b/turbo/apps/api/src/signals/routes/webhooks-agent-health-usage-telemetry.ts
@@ -1,0 +1,272 @@
+import { command } from "ccstate";
+import {
+  webhookHeartbeatContract,
+  webhookTelemetryContract,
+  webhookUsageEventContract,
+} from "@vm0/api-contracts/contracts/webhooks";
+import { agentRuns } from "@vm0/db/schema/agent-run";
+import { usageEvent } from "@vm0/db/schema/usage-event";
+import { and, eq } from "drizzle-orm";
+
+import { notFound } from "../../lib/error";
+import { logger } from "../../lib/log";
+import { nowDate } from "../../lib/time";
+import type { SandboxAuth } from "../../types/auth";
+import { isSandboxToken, verifySandboxToken } from "../auth/tokens";
+import { authorization$ } from "../context/hono";
+import { bodyResultOf } from "../context/request";
+import { waitUntil } from "../context/wait-until";
+import { db$, writeDb$ } from "../external/db";
+import { flushAxiom, getDatasetName, ingestToAxiom } from "../external/axiom";
+import { recordSandboxOperation } from "../external/sandbox-op-log";
+import type { RouteEntry } from "../route";
+import { dispatchProgressCallbacks$ } from "../services/agent-run-callbacks.service";
+import { safeAsync } from "../utils";
+
+const SANDBOX_TELEMETRY_SYSTEM_DATASET = "sandbox-telemetry-system";
+const SANDBOX_TELEMETRY_METRICS_DATASET = "sandbox-telemetry-metrics";
+const SANDBOX_TELEMETRY_NETWORK_DATASET = "sandbox-telemetry-network";
+const PG_FOREIGN_KEY_VIOLATION = "23503";
+
+const L = logger("webhooks:agent");
+
+const unauthorizedRunMismatch = Object.freeze({
+  status: 401 as const,
+  body: Object.freeze({
+    error: Object.freeze({
+      message: "Not authenticated or runId mismatch",
+      code: "UNAUTHORIZED",
+    }),
+  }),
+});
+
+function getSandboxAuthForRun(
+  expectedRunId: string,
+  authHeader: string | undefined,
+): SandboxAuth | null {
+  if (!authHeader?.startsWith("Bearer ")) {
+    return null;
+  }
+
+  const token = authHeader.substring("Bearer ".length);
+  if (!isSandboxToken(token)) {
+    return null;
+  }
+
+  const auth = verifySandboxToken(token);
+  if (!auth || auth.runId !== expectedRunId) {
+    return null;
+  }
+
+  return auth;
+}
+
+function isForeignKeyViolation(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  const { cause } = error;
+  if (typeof cause !== "object" || cause === null || !("code" in cause)) {
+    return false;
+  }
+
+  return cause.code === PG_FOREIGN_KEY_VIOLATION;
+}
+
+const heartbeatBody$ = bodyResultOf(webhookHeartbeatContract.send);
+const heartbeat$ = command(async ({ get, set }, signal: AbortSignal) => {
+  const bodyResult = await get(heartbeatBody$);
+  signal.throwIfAborted();
+  if (!bodyResult.ok) {
+    return bodyResult.response;
+  }
+
+  const body = bodyResult.data;
+  const auth = getSandboxAuthForRun(body.runId, get(authorization$));
+  if (!auth) {
+    return unauthorizedRunMismatch;
+  }
+
+  const db = set(writeDb$);
+  const result = await db
+    .update(agentRuns)
+    .set({ lastHeartbeatAt: nowDate() })
+    .where(and(eq(agentRuns.id, body.runId), eq(agentRuns.userId, auth.userId)))
+    .returning({ id: agentRuns.id });
+  signal.throwIfAborted();
+
+  if (result.length === 0) {
+    return notFound("Agent run not found");
+  }
+
+  waitUntil(set(dispatchProgressCallbacks$, body.runId, signal));
+
+  return {
+    status: 200 as const,
+    body: { ok: true },
+  };
+});
+
+const usageEventBody$ = bodyResultOf(webhookUsageEventContract.send);
+const usageEvent$ = command(async ({ get, set }, signal: AbortSignal) => {
+  const bodyResult = await get(usageEventBody$);
+  signal.throwIfAborted();
+  if (!bodyResult.ok) {
+    return bodyResult.response;
+  }
+
+  const body = bodyResult.data;
+  const auth = getSandboxAuthForRun(body.runId, get(authorization$));
+  if (!auth) {
+    return unauthorizedRunMismatch;
+  }
+
+  const db = set(writeDb$);
+  const insertResult = await safeAsync(() => {
+    return db
+      .insert(usageEvent)
+      .values(
+        body.events.map((event) => {
+          return {
+            runId: body.runId,
+            orgId: auth.orgId,
+            userId: auth.userId,
+            kind: event.kind,
+            provider: event.provider,
+            category: event.category,
+            quantity: event.quantity,
+            idempotencyKey: event.idempotencyKey,
+          };
+        }),
+      )
+      .onConflictDoNothing({ target: [usageEvent.idempotencyKey] });
+  });
+  signal.throwIfAborted();
+  if ("error" in insertResult) {
+    if (isForeignKeyViolation(insertResult.error)) {
+      L.debug("Run not found for usage event, dropping", {
+        runId: body.runId,
+        eventCount: body.events.length,
+      });
+      return notFound("Run not found");
+    }
+    throw insertResult.error;
+  }
+
+  return {
+    status: 200 as const,
+    body: { success: true },
+  };
+});
+
+const telemetryBody$ = bodyResultOf(webhookTelemetryContract.send);
+const telemetry$ = command(async ({ get }, signal: AbortSignal) => {
+  const bodyResult = await get(telemetryBody$);
+  signal.throwIfAborted();
+  if (!bodyResult.ok) {
+    return bodyResult.response;
+  }
+
+  const body = bodyResult.data;
+  const auth = getSandboxAuthForRun(body.runId, get(authorization$));
+  if (!auth) {
+    return unauthorizedRunMismatch;
+  }
+
+  const db = get(db$);
+  const [run] = await db
+    .select({ id: agentRuns.id })
+    .from(agentRuns)
+    .where(and(eq(agentRuns.id, body.runId), eq(agentRuns.userId, auth.userId)))
+    .limit(1);
+  signal.throwIfAborted();
+
+  if (!run) {
+    return notFound("Agent run not found");
+  }
+
+  if (body.systemLog) {
+    ingestToAxiom(getDatasetName(SANDBOX_TELEMETRY_SYSTEM_DATASET), [
+      {
+        _time: nowDate().toISOString(),
+        runId: body.runId,
+        userId: auth.userId,
+        log: body.systemLog,
+      },
+    ]);
+  }
+
+  if (body.metrics && body.metrics.length > 0) {
+    ingestToAxiom(
+      getDatasetName(SANDBOX_TELEMETRY_METRICS_DATASET),
+      body.metrics.map((metric) => {
+        return {
+          _time: metric.ts,
+          runId: body.runId,
+          userId: auth.userId,
+          cpu: metric.cpu,
+          mem_used: metric.mem_used,
+          mem_total: metric.mem_total,
+          disk_used: metric.disk_used,
+          disk_total: metric.disk_total,
+        };
+      }),
+    );
+  }
+
+  if (body.networkLogs && body.networkLogs.length > 0) {
+    ingestToAxiom(
+      getDatasetName(SANDBOX_TELEMETRY_NETWORK_DATASET),
+      body.networkLogs.map(({ timestamp, ...rest }) => {
+        return {
+          ...rest,
+          _time: timestamp,
+          runId: body.runId,
+          userId: auth.userId,
+        };
+      }),
+    );
+    await flushAxiom({ client: "telemetry", throwOnError: true });
+    signal.throwIfAborted();
+  }
+
+  if (body.sandboxOperations && body.sandboxOperations.length > 0) {
+    for (const op of body.sandboxOperations) {
+      recordSandboxOperation({
+        actionType: op.action_type,
+        sandboxType: "runner",
+        durationMs: op.duration_ms,
+        success: op.success,
+        runId: body.runId,
+        dimensions: {
+          source: "sandbox",
+          ...(op.error ? { error: op.error } : {}),
+        },
+      });
+    }
+  }
+
+  return {
+    status: 200 as const,
+    body: {
+      success: true,
+      id: body.runId,
+    },
+  };
+});
+
+export const webhooksAgentHealthUsageTelemetryRoutes: readonly RouteEntry[] = [
+  {
+    route: webhookHeartbeatContract.send,
+    handler: heartbeat$,
+  },
+  {
+    route: webhookUsageEventContract.send,
+    handler: usageEvent$,
+  },
+  {
+    route: webhookTelemetryContract.send,
+    handler: telemetry$,
+  },
+];

--- a/turbo/apps/api/src/signals/services/agent-run-callbacks.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-callbacks.service.ts
@@ -1,0 +1,80 @@
+import { command } from "ccstate";
+import { and, eq } from "drizzle-orm";
+import { agentRunCallbacks } from "@vm0/db/schema/agent-run-callback";
+import { agentRuns } from "@vm0/db/schema/agent-run";
+
+import { computeHmacSignature } from "../../lib/event-consumer/hmac";
+import { env } from "../../lib/env";
+import { now } from "../../lib/time";
+import { db$ } from "../external/db";
+import { decryptSecretValue } from "./crypto.utils";
+
+function resolveCallbackUrl(url: string): string {
+  return env("ENV") === "development" && url.startsWith("https://tunnel-")
+    ? url.replace(/^https:\/\/tunnel-[^/]+/, "http://localhost:3000")
+    : url;
+}
+
+export const dispatchProgressCallbacks$ = command(
+  async ({ get }, runId: string, signal: AbortSignal): Promise<void> => {
+    const db = get(db$);
+    const [run] = await db
+      .select({ status: agentRuns.status })
+      .from(agentRuns)
+      .where(eq(agentRuns.id, runId))
+      .limit(1);
+    signal.throwIfAborted();
+
+    if (!run || run.status === "completed" || run.status === "failed") {
+      return;
+    }
+
+    const callbacks = await db
+      .select({
+        id: agentRunCallbacks.id,
+        url: agentRunCallbacks.url,
+        encryptedSecret: agentRunCallbacks.encryptedSecret,
+        payload: agentRunCallbacks.payload,
+      })
+      .from(agentRunCallbacks)
+      .where(
+        and(
+          eq(agentRunCallbacks.runId, runId),
+          eq(agentRunCallbacks.status, "pending"),
+        ),
+      );
+    signal.throwIfAborted();
+
+    if (callbacks.length === 0) {
+      return;
+    }
+
+    await Promise.allSettled(
+      callbacks.map((callback) => {
+        const body = JSON.stringify({
+          callbackId: callback.id,
+          runId,
+          status: "progress",
+          payload: callback.payload,
+        });
+        const timestamp = Math.floor(now() / 1000);
+        const signature = computeHmacSignature(
+          body,
+          decryptSecretValue(callback.encryptedSecret),
+          timestamp,
+        );
+
+        return fetch(resolveCallbackUrl(callback.url), {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "X-VM0-Signature": signature,
+            "X-VM0-Timestamp": timestamp.toString(),
+          },
+          body,
+          signal,
+        });
+      }),
+    );
+  },
+);


### PR DESCRIPTION
## Summary
- add API routes for `/api/webhooks/agent/heartbeat`, `/api/webhooks/agent/usage-event`, and `/api/webhooks/agent/telemetry`
- preserve sandbox JWT run matching, heartbeat callback progress dispatch, usage-event idempotency, and telemetry Axiom ingestion/flush behavior
- add API integration coverage for auth, DB side effects, callback dispatch, and Axiom ingestion

Closes #13210

## Tests
- `pnpm -F api exec vitest run src/signals/routes/__tests__/webhooks-agent-health-usage-telemetry.test.ts`
- `pnpm -F api check-types`
- `pnpm -F api lint`
- pre-commit: `pnpm turbo run check-types --concurrency=1`