### PR TITLE
fix(vsock): route spawn_watch lifecycle by sequence

### DIFF
--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -1485,6 +1485,7 @@ impl Sandbox for FirecrackerSandbox {
         })?;
 
         tokio::select! {
+            biased;
             result = &mut exit => {
                 result.map_err(|e| Self::operation_error(operation, e, self.has_backend_crashed()))
             }

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -1443,11 +1443,23 @@ impl Sandbox for FirecrackerSandbox {
                 request.output.streams_stdout(),
                 request.output.guest_log_path(),
             ) => {
-                let (pid, stdout_rx) = result.map_err(|e| Self::operation_error(operation, e, self.has_backend_crashed()))?;
-                Ok(SpawnHandle {
-                    pid,
-                    stdout_rx: request.output.streams_stdout().then_some(stdout_rx),
-                })
+                let mut handle = result.map_err(|e| Self::operation_error(operation, e, self.has_backend_crashed()))?;
+                let pid = handle.pid();
+                let stdout_rx = request
+                    .output
+                    .streams_stdout()
+                    .then(|| handle.take_stdout_receiver())
+                    .flatten();
+                let exit = Box::pin(async move {
+                    let event = handle.wait().await?;
+                    Ok(ProcessExit {
+                        pid: event.pid,
+                        exit_code: event.exit_code,
+                        stdout: event.stdout,
+                        stderr: event.stderr,
+                    })
+                });
+                Ok(SpawnHandle::new(pid, stdout_rx, exit))
             }
             () = wait_for_backend_crash(self.state_tx.subscribe()) => {
                 Err(Self::backend_crashed_error(operation))
@@ -1457,21 +1469,31 @@ impl Sandbox for FirecrackerSandbox {
 
     async fn wait_exit(
         &self,
-        handle: SpawnHandle,
+        mut handle: SpawnHandle,
         timeout: Duration,
     ) -> sandbox::Result<ProcessExit> {
         let operation = SandboxOperation::WaitExit;
-        let guest = self.operation_guest(operation).await?;
+        let mut exit = handle.take_exit_future().ok_or_else(|| {
+            Self::operation_error(
+                operation,
+                std::io::Error::new(
+                    std::io::ErrorKind::ConnectionReset,
+                    "spawn_watch handle already consumed",
+                ),
+                self.has_backend_crashed(),
+            )
+        })?;
 
         tokio::select! {
-            result = guest.wait_for_exit(handle.pid, timeout) => {
-                let event = result.map_err(|e| Self::operation_error(operation, e, self.has_backend_crashed()))?;
-                Ok(ProcessExit {
-                    pid: event.pid,
-                    exit_code: event.exit_code,
-                    stdout: event.stdout,
-                    stderr: event.stderr,
-                })
+            result = &mut exit => {
+                result.map_err(|e| Self::operation_error(operation, e, self.has_backend_crashed()))
+            }
+            _ = tokio::time::sleep(timeout) => {
+                Err(Self::operation_error(
+                    operation,
+                    std::io::Error::new(std::io::ErrorKind::TimedOut, "wait_exit timeout"),
+                    self.has_backend_crashed(),
+                ))
             }
             () = wait_for_backend_crash(self.state_tx.subscribe()) => {
                 Err(Self::backend_crashed_error(operation))

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -1483,6 +1483,9 @@ impl Sandbox for FirecrackerSandbox {
                 self.has_backend_crashed(),
             )
         })?;
+        // `wait_exit` consumes the handle; an unclaimed stream receiver can no
+        // longer be observed by the caller and would otherwise buffer forever.
+        drop(handle.stdout_rx.take());
 
         tokio::select! {
             biased;

--- a/crates/sandbox-mock/src/lib.rs
+++ b/crates/sandbox-mock/src/lib.rs
@@ -893,6 +893,9 @@ impl Sandbox for MockSandbox {
                 message: "spawn_watch handle already consumed".to_string(),
             });
         };
+        // `wait_exit` consumes the handle; an unclaimed stream receiver can no
+        // longer be observed by the caller and would otherwise buffer forever.
+        drop(handle.stdout_rx.take());
 
         if let Some(overrides) = &self.overrides {
             // Block until the test signals (gives a window for cancellation).
@@ -2258,6 +2261,32 @@ mod tests {
             }
             Err(other) => panic!("expected wait_exit operation error, got {other:?}"),
         }
+    }
+
+    #[tokio::test]
+    async fn wait_exit_drops_unclaimed_stdout_receiver_before_waiting() {
+        let gate = Arc::new(tokio::sync::Notify::new());
+        let overrides = Arc::new(MockSandboxOverrides::with_wait_exit_gate(Arc::clone(&gate)));
+        let sandbox = MockSandbox::with_overrides("test", overrides);
+        let (stdout_tx, stdout_rx) = tokio::sync::mpsc::unbounded_channel();
+        let handle = SpawnHandle::new(
+            1,
+            Some(stdout_rx),
+            Box::pin(std::future::pending::<std::io::Result<ProcessExit>>()),
+        );
+
+        let wait =
+            tokio::spawn(async move { sandbox.wait_exit(handle, Duration::from_secs(5)).await });
+        tokio::time::timeout(test_timeout(), async {
+            while !stdout_tx.is_closed() {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("wait_exit should drop an unclaimed stdout receiver before blocking");
+
+        gate.notify_waiters();
+        wait.await.unwrap().unwrap();
     }
 
     #[tokio::test]

--- a/crates/sandbox-mock/src/lib.rs
+++ b/crates/sandbox-mock/src/lib.rs
@@ -885,7 +885,15 @@ impl Sandbox for MockSandbox {
         ))
     }
 
-    async fn wait_exit(&self, handle: SpawnHandle, _timeout: Duration) -> Result<ProcessExit> {
+    async fn wait_exit(&self, mut handle: SpawnHandle, _timeout: Duration) -> Result<ProcessExit> {
+        let Some(_exit) = handle.take_exit_future() else {
+            return Err(SandboxError::Operation {
+                operation: SandboxOperation::WaitExit,
+                reason: SandboxOperationReason::Other,
+                message: "spawn_watch handle already consumed".to_string(),
+            });
+        };
+
         if let Some(overrides) = &self.overrides {
             // Block until the test signals (gives a window for cancellation).
             if let Some(gate) = &overrides.wait_exit_gate {
@@ -2216,6 +2224,40 @@ mod tests {
                 },
             ]
         );
+    }
+
+    #[tokio::test]
+    async fn wait_exit_rejects_consumed_spawn_handle() {
+        let runtime = MockSandboxRuntime::new();
+        let mut factory = runtime.create_factory(test_factory_config()).await.unwrap();
+        factory.startup().await.unwrap();
+        let sandbox = factory.create(test_sandbox_config()).await.unwrap();
+        let mut handle = sandbox
+            .spawn_watch(&SpawnWatchRequest {
+                cmd: "agent",
+                timeout: Duration::from_secs(5),
+                env: &[],
+                sudo: false,
+                output: SpawnOutputMode::Buffered,
+            })
+            .await
+            .unwrap();
+
+        let consumed = handle.take_exit_future();
+        assert!(consumed.is_some());
+        match sandbox.wait_exit(handle, Duration::from_secs(5)).await {
+            Ok(_) => panic!("wait_exit should reject an already consumed handle"),
+            Err(SandboxError::Operation {
+                operation,
+                reason,
+                message,
+            }) => {
+                assert_eq!(operation, SandboxOperation::WaitExit);
+                assert_eq!(reason, SandboxOperationReason::Other);
+                assert!(message.contains("already consumed"));
+            }
+            Err(other) => panic!("expected wait_exit operation error, got {other:?}"),
+        }
     }
 
     #[tokio::test]

--- a/crates/sandbox-mock/src/lib.rs
+++ b/crates/sandbox-mock/src/lib.rs
@@ -878,10 +878,11 @@ impl Sandbox for MockSandbox {
         {
             *self.stdout_tx.lock_ignoring_poison() = Some(tx);
         }
-        Ok(SpawnHandle {
-            pid: 1,
-            stdout_rx: request.output.streams_stdout().then_some(rx),
-        })
+        Ok(SpawnHandle::new(
+            1,
+            request.output.streams_stdout().then_some(rx),
+            Box::pin(std::future::pending::<std::io::Result<ProcessExit>>()),
+        ))
     }
 
     async fn wait_exit(&self, handle: SpawnHandle, _timeout: Duration) -> Result<ProcessExit> {

--- a/crates/sandbox/src/sandbox.rs
+++ b/crates/sandbox/src/sandbox.rs
@@ -177,11 +177,15 @@ pub trait Sandbox: Send + Sync + Any {
 
     // -- operations --
     //
-    // Operations require the sandbox to be running (post-`start`,
-    // pre-`stop`/`kill`) and, if it was previously parked, unparked.
-    // They race the guest IPC call against a crash notifier so a dying
-    // backend process surfaces as a specific error rather than an
-    // opaque IPC timeout.
+    // Operations that start new guest work require the sandbox to be running
+    // (post-`start`, pre-`stop`/`kill`) and, if it was previously parked,
+    // unparked. They race the guest IPC call against a crash notifier so a
+    // dying backend process surfaces as a specific error rather than an opaque
+    // IPC timeout.
+    //
+    // `wait_exit` is the exception: it consumes a `SpawnHandle` returned by
+    // `spawn_watch` and observes that handle's already-started backend exit
+    // operation instead of starting new guest work.
 
     /// Run `request.cmd` in the guest, block until it exits or the
     /// request timeout expires, and return the captured output.
@@ -224,7 +228,8 @@ pub trait Sandbox: Send + Sync + Any {
     ///
     /// Consumes the handle. If `stdout_rx` was not taken before waiting, the
     /// stream is discarded instead of being buffered without a reader. Returns
-    /// an error if the sandbox is not running, if the backing process crashes,
-    /// or if the timeout elapses before the guest process exits.
+    /// an error if the backend exit operation is no longer available, if the
+    /// backing process crashes before an exit result is delivered, or if the
+    /// timeout elapses before the guest process exits.
     async fn wait_exit(&self, handle: SpawnHandle, timeout: Duration) -> Result<ProcessExit>;
 }

--- a/crates/sandbox/src/sandbox.rs
+++ b/crates/sandbox/src/sandbox.rs
@@ -217,11 +217,14 @@ pub trait Sandbox: Send + Sync + Any {
     /// [`ProcessExit`] or streamed in real time through
     /// [`SpawnHandle::stdout_rx`], optionally
     /// teeing streamed chunks into a guest-side file.
+    /// Callers that take `stdout_rx` are responsible for draining it while the
+    /// process runs.
     async fn spawn_watch(&self, request: &SpawnWatchRequest<'_>) -> Result<SpawnHandle>;
     /// Wait for the process behind `handle` to exit, up to `timeout`.
     ///
-    /// Consumes the handle. Returns an error if the sandbox is not
-    /// running, if the backing process crashes, or if the timeout
-    /// elapses before the guest process exits.
+    /// Consumes the handle. If `stdout_rx` was not taken before waiting, the
+    /// stream is discarded instead of being buffered without a reader. Returns
+    /// an error if the sandbox is not running, if the backing process crashes,
+    /// or if the timeout elapses before the guest process exits.
     async fn wait_exit(&self, handle: SpawnHandle, timeout: Duration) -> Result<ProcessExit>;
 }

--- a/crates/sandbox/src/types.rs
+++ b/crates/sandbox/src/types.rs
@@ -127,9 +127,19 @@ pub struct CopyFileResult {
     pub bytes_copied: u64,
 }
 
+/// Backend-owned future that resolves when a watched process exits.
+///
+/// Sandbox implementations store this in [`SpawnHandle`] so
+/// [`Sandbox::wait_exit`](crate::Sandbox::wait_exit) can consume the exact
+/// backend operation created by [`Sandbox::spawn_watch`](crate::Sandbox::spawn_watch).
 pub type SpawnExitFuture =
     Pin<Box<dyn Future<Output = std::io::Result<ProcessExit>> + Send + 'static>>;
 
+/// Handle returned by [`Sandbox::spawn_watch`](crate::Sandbox::spawn_watch).
+///
+/// The handle owns backend-specific exit state and must be consumed by
+/// [`Sandbox::wait_exit`](crate::Sandbox::wait_exit). When stdout streaming is
+/// enabled, callers may take [`stdout_rx`](Self::stdout_rx) before waiting.
 pub struct SpawnHandle {
     pub pid: u32,
     /// Receives stdout chunks in real-time when the guest streams them.
@@ -139,6 +149,7 @@ pub struct SpawnHandle {
 }
 
 impl SpawnHandle {
+    /// Construct a spawn handle from backend-owned process state.
     pub fn new(
         pid: u32,
         stdout_rx: Option<tokio::sync::mpsc::UnboundedReceiver<Vec<u8>>>,
@@ -151,6 +162,11 @@ impl SpawnHandle {
         }
     }
 
+    /// Consume the backend exit future.
+    ///
+    /// This is intended for sandbox backend implementations of
+    /// [`Sandbox::wait_exit`](crate::Sandbox::wait_exit); ordinary callers should
+    /// pass the handle to that trait method instead.
     pub fn take_exit_future(&mut self) -> Option<SpawnExitFuture> {
         self.exit.take()
     }

--- a/crates/sandbox/src/types.rs
+++ b/crates/sandbox/src/types.rs
@@ -1,3 +1,5 @@
+use std::future::Future;
+use std::pin::Pin;
 use std::time::Duration;
 
 /// Capture budgets for stdout/stderr returned by [`ExecRequest`].
@@ -125,11 +127,33 @@ pub struct CopyFileResult {
     pub bytes_copied: u64,
 }
 
+pub type SpawnExitFuture =
+    Pin<Box<dyn Future<Output = std::io::Result<ProcessExit>> + Send + 'static>>;
+
 pub struct SpawnHandle {
     pub pid: u32,
     /// Receives stdout chunks in real-time when the guest streams them.
     /// `None` when the backend does not support streaming.
     pub stdout_rx: Option<tokio::sync::mpsc::UnboundedReceiver<Vec<u8>>>,
+    exit: Option<SpawnExitFuture>,
+}
+
+impl SpawnHandle {
+    pub fn new(
+        pid: u32,
+        stdout_rx: Option<tokio::sync::mpsc::UnboundedReceiver<Vec<u8>>>,
+        exit: SpawnExitFuture,
+    ) -> Self {
+        Self {
+            pid,
+            stdout_rx,
+            exit: Some(exit),
+        }
+    }
+
+    pub fn take_exit_future(&mut self) -> Option<SpawnExitFuture> {
+        self.exit.take()
+    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]

--- a/crates/sandbox/src/types.rs
+++ b/crates/sandbox/src/types.rs
@@ -139,7 +139,8 @@ pub type SpawnExitFuture =
 ///
 /// The handle owns backend-specific exit state and must be consumed by
 /// [`Sandbox::wait_exit`](crate::Sandbox::wait_exit). When stdout streaming is
-/// enabled, callers may take [`stdout_rx`](Self::stdout_rx) before waiting.
+/// enabled, callers may take [`stdout_rx`](Self::stdout_rx) before waiting; if
+/// they do, they must drain it while the process runs.
 pub struct SpawnHandle {
     pub pid: u32,
     /// Receives stdout chunks in real-time when the guest streams them.

--- a/crates/vsock-guest/src/monitor.rs
+++ b/crates/vsock-guest/src/monitor.rs
@@ -24,6 +24,7 @@ const THREAD_STREAM_STDERR: &str = "vsock-stream-stderr";
 const THREAD_STREAM_STDOUT: &str = "vsock-stream-stdout";
 
 struct StreamingMonitorRequest {
+    seq: u32,
     pid: u32,
     child: Child,
     timeout_ms: u32,
@@ -35,6 +36,7 @@ struct StreamingMonitorRequest {
 }
 
 struct BufferedMonitorRequest {
+    seq: u32,
     pid: u32,
     child: Child,
     timeout_ms: u32,
@@ -44,6 +46,7 @@ struct BufferedMonitorRequest {
 }
 
 struct StreamingSetupFailure {
+    seq: u32,
     pid: u32,
     child: Child,
     cancel: Arc<AtomicBool>,
@@ -72,12 +75,8 @@ pub(crate) struct SpawnWatchRequest<'a> {
 /// `MSG_STDOUT_CHUNK` messages. `stdout_log_path`, when present, additionally
 /// tees those chunks to a file path inside the VM.
 ///
-/// The result-before-monitor ordering is critical: the streaming monitor
-/// thread also writes to the same socket (via the shared `writer` mutex),
-/// and `MSG_STDOUT_CHUNK` messages must not arrive at the host before the
-/// `MSG_SPAWN_WATCH_RESULT` for this pid — the host only registers the
-/// stdout channel when it processes the result, so earlier chunks would
-/// be dropped.
+/// The result-before-monitor ordering is kept for readability, but lifecycle
+/// frames are routed by the original request sequence number.
 pub(crate) fn handle_spawn_watch(
     request: SpawnWatchRequest<'_>,
     seq: u32,
@@ -157,6 +156,7 @@ where
         let stdout_pipe = child.stdout.take();
         if let Err(e) = spawn_streaming_monitor(
             StreamingMonitorRequest {
+                seq,
                 pid,
                 child,
                 timeout_ms: request.timeout_ms,
@@ -178,6 +178,7 @@ where
         // in a single MSG_PROCESS_EXIT after wait.
         if let Err(e) = spawn_buffered_monitor(
             BufferedMonitorRequest {
+                seq,
                 pid,
                 child,
                 timeout_ms: request.timeout_ms,
@@ -218,6 +219,7 @@ where
     S: ThreadSpawner,
 {
     let StreamingMonitorRequest {
+        seq,
         pid,
         child,
         timeout_ms,
@@ -242,6 +244,7 @@ where
             };
             run_streaming_monitor(
                 StreamingMonitorRequest {
+                    seq,
                     pid,
                     child,
                     timeout_ms,
@@ -257,6 +260,7 @@ where
     );
     if let Err(e) = &result {
         send_process_exit(
+            seq,
             pid,
             1,
             &[],
@@ -272,6 +276,7 @@ where
     S: ThreadSpawner,
 {
     let StreamingMonitorRequest {
+        seq,
         pid,
         mut child,
         timeout_ms,
@@ -306,6 +311,7 @@ where
             Ok(handle) => Some(handle),
             Err(e) => {
                 finish_streaming_setup_failure(StreamingSetupFailure {
+                    seq,
                     pid,
                     child,
                     cancel,
@@ -370,7 +376,7 @@ where
                     // is itself unreachable, so retaining bytes we cannot
                     // deliver buys nothing.
                     let payload = vsock_proto::encode_stdout_chunk(pid, chunk);
-                    if let Ok(msg) = vsock_proto::encode(MSG_STDOUT_CHUNK, 0, &payload)
+                    if let Ok(msg) = vsock_proto::encode(MSG_STDOUT_CHUNK, seq, &payload)
                         && let Err(e) = stdout_writer.write_frame(&msg)
                     {
                         log(
@@ -386,6 +392,7 @@ where
             Ok(handle) => Some(handle),
             Err(e) => {
                 finish_streaming_setup_failure(StreamingSetupFailure {
+                    seq,
                     pid,
                     child,
                     cancel,
@@ -448,11 +455,12 @@ where
         ),
     );
 
-    send_process_exit(pid, exit_code, &[], &stderr, &writer);
+    send_process_exit(seq, pid, exit_code, &[], &stderr, &writer);
 }
 
 fn finish_streaming_setup_failure(failure: StreamingSetupFailure) {
     let StreamingSetupFailure {
+        seq,
         pid,
         child,
         cancel,
@@ -473,7 +481,7 @@ fn finish_streaming_setup_failure(failure: StreamingSetupFailure) {
     if let Some(handle) = stdout_handle {
         let _ = handle.join();
     }
-    send_process_exit(pid, 1, &[], error.as_bytes(), &writer);
+    send_process_exit(seq, pid, 1, &[], error.as_bytes(), &writer);
 }
 
 /// Buffered monitor: waits for process exit while concurrently draining
@@ -483,6 +491,7 @@ where
     S: ThreadSpawner,
 {
     let BufferedMonitorRequest {
+        seq,
         pid,
         child,
         timeout_ms,
@@ -523,12 +532,13 @@ where
                 ),
             );
 
-            send_process_exit(pid, exit_code, &stdout, &stderr, &writer);
+            send_process_exit(seq, pid, exit_code, &stdout, &stderr, &writer);
             drop(env_script);
         }),
     );
     if let Err(e) = &result {
         send_process_exit(
+            seq,
             pid,
             1,
             &[],
@@ -540,9 +550,16 @@ where
 }
 
 /// Send a process_exit notification over vsock (best-effort).
-fn send_process_exit(pid: u32, exit_code: i32, stdout: &[u8], stderr: &[u8], writer: &GuestWriter) {
+fn send_process_exit(
+    seq: u32,
+    pid: u32,
+    exit_code: i32,
+    stdout: &[u8],
+    stderr: &[u8],
+    writer: &GuestWriter,
+) {
     let payload = vsock_proto::encode_process_exit(pid, exit_code, stdout, stderr);
-    let exit_msg = match vsock_proto::encode(MSG_PROCESS_EXIT, 0, &payload) {
+    let exit_msg = match vsock_proto::encode(MSG_PROCESS_EXIT, seq, &payload) {
         Ok(msg) => msg,
         Err(e) => {
             log("ERROR", &format!("Failed to encode process_exit: {}", e));
@@ -614,6 +631,7 @@ mod tests {
 
         let exit = read_message(&mut host);
         assert_eq!(exit.msg_type, MSG_PROCESS_EXIT);
+        assert_eq!(exit.seq, 7);
         let (exit_pid, code, stdout, stderr) =
             vsock_proto::decode_process_exit(&exit.payload).unwrap();
         assert_eq!(exit_pid, pid);
@@ -657,6 +675,7 @@ mod tests {
 
         let exit = read_message(&mut host);
         assert_eq!(exit.msg_type, MSG_PROCESS_EXIT);
+        assert_eq!(exit.seq, 8);
         let (exit_pid, code, stdout, stderr) =
             vsock_proto::decode_process_exit(&exit.payload).unwrap();
         assert_eq!(exit_pid, pid);
@@ -700,6 +719,7 @@ mod tests {
 
         let exit = read_message(&mut host);
         assert_eq!(exit.msg_type, MSG_PROCESS_EXIT);
+        assert_eq!(exit.seq, 10);
         let (exit_pid, code, stdout, stderr) =
             vsock_proto::decode_process_exit(&exit.payload).unwrap();
         assert_eq!(exit_pid, pid);
@@ -743,6 +763,7 @@ mod tests {
 
         let exit = read_message(&mut host);
         assert_eq!(exit.msg_type, MSG_PROCESS_EXIT);
+        assert_eq!(exit.seq, 9);
         let (exit_pid, code, stdout, stderr) =
             vsock_proto::decode_process_exit(&exit.payload).unwrap();
         assert_eq!(exit_pid, pid);
@@ -786,6 +807,7 @@ mod tests {
 
         let exit = read_message(&mut host);
         assert_eq!(exit.msg_type, MSG_PROCESS_EXIT);
+        assert_eq!(exit.seq, 11);
         let (exit_pid, code, stdout, stderr) =
             vsock_proto::decode_process_exit(&exit.payload).unwrap();
         assert_eq!(exit_pid, pid);

--- a/crates/vsock-guest/src/monitor.rs
+++ b/crates/vsock-guest/src/monitor.rs
@@ -75,8 +75,9 @@ pub(crate) struct SpawnWatchRequest<'a> {
 /// `MSG_STDOUT_CHUNK` messages. `stdout_log_path`, when present, additionally
 /// tees those chunks to a file path inside the VM.
 ///
-/// The result-before-monitor ordering is kept for readability, but lifecycle
-/// frames are routed by the original request sequence number.
+/// The result-before-monitor ordering is a protocol invariant: lifecycle frames
+/// are routed by the original request sequence number, but the host still
+/// validates their pid against the preceding `MSG_SPAWN_WATCH_RESULT`.
 pub(crate) fn handle_spawn_watch(
     request: SpawnWatchRequest<'_>,
     seq: u32,

--- a/crates/vsock-guest/tests/connection.rs
+++ b/crates/vsock-guest/tests/connection.rs
@@ -1292,8 +1292,8 @@ fn streaming_monitor_clean_exit_returns_before_long_timeout() {
 }
 
 /// `MSG_SPAWN_WATCH_RESULT` must arrive before stdout chunks for that request.
-/// The host only registers the stdout stream after processing the spawn
-/// result, so a chunk sent first would be dropped by older host code.
+/// The host records the pid from the result and rejects lifecycle frames for
+/// that request until the pid is known.
 #[test]
 fn streaming_spawn_watch_result_precedes_stdout_chunks() {
     use std::os::unix::net::UnixStream as StdUnixStream;

--- a/crates/vsock-guest/tests/connection.rs
+++ b/crates/vsock-guest/tests/connection.rs
@@ -1291,7 +1291,7 @@ fn streaming_monitor_clean_exit_returns_before_long_timeout() {
     let _ = handle.join();
 }
 
-/// `MSG_SPAWN_WATCH_RESULT` must arrive before stdout chunks for that pid.
+/// `MSG_SPAWN_WATCH_RESULT` must arrive before stdout chunks for that request.
 /// The host only registers the stdout stream after processing the spawn
 /// result, so a chunk sent first would be dropped by older host code.
 #[test]

--- a/crates/vsock-guest/tests/connection.rs
+++ b/crates/vsock-guest/tests/connection.rs
@@ -1140,11 +1140,13 @@ fn read_streaming_result(
 
             // Collect stdout chunks and return on process_exit
             if msg.msg_type == MSG_STDOUT_CHUNK
+                && msg.seq == seq
                 && let Ok((chunk_pid, data)) = vsock_proto::decode_stdout_chunk(&msg.payload)
                 && chunk_pid == p
             {
                 stdout_data.extend_from_slice(data);
             } else if msg.msg_type == MSG_PROCESS_EXIT
+                && msg.seq == seq
                 && let Ok((exit_pid, code, _stdout, stderr)) =
                     vsock_proto::decode_process_exit(&msg.payload)
                 && exit_pid == p
@@ -1336,7 +1338,7 @@ fn streaming_spawn_watch_result_precedes_stdout_chunks() {
                 continue;
             }
 
-            if msg.msg_type == MSG_STDOUT_CHUNK {
+            if msg.msg_type == MSG_STDOUT_CHUNK && msg.seq == 1 {
                 let Some(p) = pid else {
                     panic!("stdout chunk arrived before spawn_watch_result");
                 };
@@ -1344,7 +1346,7 @@ fn streaming_spawn_watch_result_precedes_stdout_chunks() {
                 if chunk_pid == p {
                     stdout_data.extend_from_slice(data);
                 }
-            } else if msg.msg_type == MSG_PROCESS_EXIT {
+            } else if msg.msg_type == MSG_PROCESS_EXIT && msg.seq == 1 {
                 let Some(p) = pid else {
                     panic!("process_exit arrived before spawn_watch_result");
                 };
@@ -1547,6 +1549,7 @@ fn read_buffered_spawn_watch_result(
             }
             let Some(p) = pid else { continue };
             if msg.msg_type == MSG_PROCESS_EXIT
+                && msg.seq == seq
                 && let Ok((exit_pid, code, stdout, stderr)) =
                     vsock_proto::decode_process_exit(&msg.payload)
                 && exit_pid == p
@@ -1881,7 +1884,7 @@ fn streaming_terminates_child_on_vsock_disconnect() {
         for msg in decoder.decode(buf.get(..n).unwrap_or_default()).unwrap() {
             if msg.msg_type == MSG_SPAWN_WATCH_RESULT && msg.seq == 1 {
                 pid = vsock_proto::decode_spawn_watch_result(&msg.payload).ok();
-            } else if msg.msg_type == MSG_STDOUT_CHUNK {
+            } else if msg.msg_type == MSG_STDOUT_CHUNK && msg.seq == 1 {
                 got_chunk = true;
             }
         }

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -39,8 +39,7 @@ use tokio::time::{self, Instant};
 
 use vsock_proto::{
     Decoder, MSG_COMMAND_OUTPUT, MSG_COMMAND_RESULT, MSG_ERROR, MSG_PING, MSG_PONG,
-    MSG_PROCESS_EXIT, MSG_READY, MSG_SHUTDOWN, MSG_SHUTDOWN_ACK, MSG_SPAWN_WATCH_RESULT,
-    MSG_STDOUT_CHUNK, RawMessage,
+    MSG_PROCESS_EXIT, MSG_READY, MSG_SHUTDOWN, MSG_SHUTDOWN_ACK, MSG_STDOUT_CHUNK, RawMessage,
 };
 
 pub use command::{
@@ -318,19 +317,10 @@ async fn reader_loop(
                     return;
                 }
             } else {
-                // For spawn_watch_result: record pid metadata on the
-                // seq-owned operation before dispatching the response.
                 let response_sender = {
                     let mut guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
                     match &mut *guard {
-                        ConnectionState::Connected {
-                            pending, process, ..
-                        } => {
-                            if msg.msg_type == MSG_SPAWN_WATCH_RESULT {
-                                process::record_spawn_watch_result(process, msg.seq, &msg.payload);
-                            }
-                            pending.remove(&msg.seq)
-                        }
+                        ConnectionState::Connected { pending, .. } => pending.remove(&msg.seq),
                         ConnectionState::Closed { .. } => None,
                     }
                 };

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -630,8 +630,9 @@ impl VsockHost {
     /// When `stream_stdout` is true, stdout chunks are streamed to the host via
     /// `MSG_STDOUT_CHUNK`. `stdout_log_path`, when present, additionally asks
     /// the guest to tee those chunks into the given guest-side file.
-    /// The handle's `stdout_rx` channel receives streamed chunks when enabled
-    /// and is closed when the process exits or the connection drops.
+    /// Use [`SpawnWatchHandle::take_stdout_receiver`] to receive streamed chunks
+    /// when enabled. The receiver is closed when the process exits or the
+    /// connection drops.
     pub async fn spawn_watch(
         &self,
         command: &str,

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -39,7 +39,8 @@ use tokio::time::{self, Instant};
 
 use vsock_proto::{
     Decoder, MSG_COMMAND_OUTPUT, MSG_COMMAND_RESULT, MSG_ERROR, MSG_PING, MSG_PONG,
-    MSG_PROCESS_EXIT, MSG_READY, MSG_SHUTDOWN, MSG_SHUTDOWN_ACK, MSG_STDOUT_CHUNK, RawMessage,
+    MSG_PROCESS_EXIT, MSG_READY, MSG_SHUTDOWN, MSG_SHUTDOWN_ACK, MSG_SPAWN_WATCH_RESULT,
+    MSG_STDOUT_CHUNK, RawMessage,
 };
 
 pub use command::{
@@ -317,6 +318,12 @@ async fn reader_loop(
                     return;
                 }
             } else {
+                if msg.msg_type == MSG_SPAWN_WATCH_RESULT
+                    && process::record_spawn_watch_result(&shared, &msg).is_err()
+                {
+                    shared.poison_connection();
+                    return;
+                }
                 let response_sender = {
                     let mut guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
                     match &mut *guard {

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -48,7 +48,7 @@ pub use command::{
     CommandOutputEvent, CommandOwnedCapturedOutput, CommandStreamRequest,
 };
 pub use file::{CopyFileOptions, CopyFileResult};
-pub use process::ProcessExitEvent;
+pub use process::{ProcessExitEvent, SpawnWatchHandle};
 
 const READ_BUF_SIZE: usize = 64 * 1024;
 
@@ -66,9 +66,7 @@ pub struct ExecResult {
 ///
 /// Pending requests, active command operations, and connected process state
 /// live inside the `Connected` variant so registrations are structurally
-/// unreachable once the reader task has exited. Process cached exits live in
-/// BOTH variants because they are an observation log — a cached exit event
-/// remains a valid answer to `wait_for_exit` after the connection closes.
+/// unreachable once the reader task has exited.
 ///
 /// The invariant "connection is closed ⇔ registrations are impossible" is
 /// enforced by the type: every code path that cares about liveness must
@@ -80,12 +78,12 @@ enum ConnectionState {
         pending: HashMap<u32, oneshot::Sender<RawMessage>>,
         /// Active command-operation state owned by the command module.
         operations: command::Operations,
-        /// Legacy process lifecycle state owned by the process module.
+        /// Active spawn_watch operation state owned by the process module.
         process: process::ConnectedProcessState,
     },
     Closed {
-        /// Preserves cached process exits after connection close.
-        process: process::ClosedProcessState,
+        /// Empty process state marker after connection close.
+        _process: process::ClosedProcessState,
     },
 }
 
@@ -102,9 +100,9 @@ struct Shared {
     /// Single source of truth for connection liveness plus all per-connection
     /// registration tables. See [`ConnectionState`].
     state: std::sync::Mutex<ConnectionState>,
-    /// Notified when a new process exit event is cached or when the connection
-    /// closes. Pure signalling — all state is in `state`.
-    exit_notify: Notify,
+    /// Notified when the connection closes. Pure signalling — all state is in
+    /// `state`.
+    close_notify: Notify,
 }
 
 struct ListenerSocketGuard {
@@ -154,18 +152,15 @@ impl Shared {
         }
     }
 
-    /// Transition `Connected → Closed`, preserving the process exit cache and
-    /// dropping registration maps outside the state lock so sender drops (which
-    /// wake their receivers) run without the lock held. Idempotent: a second
-    /// call preserves whatever exits the first call cached and performs no
-    /// further work.
+    /// Transition `Connected → Closed`, dropping registration maps outside the
+    /// state lock so sender drops (which wake their receivers) run without the
+    /// lock held. Idempotent: a second call leaves the existing closed state
+    /// untouched.
     ///
     /// `mem::replace` writes a placeholder `Closed` state so the old variant
-    /// can be moved out for destructuring. The `Connected` arm rebuilds
-    /// `Closed` with the cached exits; the already-`Closed` arm uses an `@`
-    /// binding to write the whole variant back unchanged, so "cached exits
-    /// survive a double-close" is enforced by the match binding rather than by
-    /// convention.
+    /// can be moved out for destructuring. The already-`Closed` arm uses an `@`
+    /// binding to write the whole variant back unchanged, so double-close is a
+    /// structural no-op rather than a convention.
     fn close(&self) {
         self.close_with_reason("connection closed");
     }
@@ -176,7 +171,7 @@ impl Shared {
             match std::mem::replace(
                 &mut *guard,
                 ConnectionState::Closed {
-                    process: process::ClosedProcessState::empty(),
+                    _process: process::ClosedProcessState::empty(),
                 },
             ) {
                 ConnectionState::Connected {
@@ -187,23 +182,22 @@ impl Shared {
                     let command_snapshot = operations.close_snapshot();
                     let (closed_process, process_maps) = process.close();
                     *guard = ConnectionState::Closed {
-                        process: closed_process,
+                        _process: closed_process,
                     };
                     Some((pending, process_maps, operations, command_snapshot))
                 }
                 closed @ ConnectionState::Closed { .. } => {
-                    // Reassign the whole variant; cached exits preserved
-                    // by binding, not manually reconstructed.
+                    // Reassign the whole variant by binding rather than by
+                    // convention.
                     *guard = closed;
                     None
                 }
             }
         };
         if let Some((pending, process_maps, operations, command_snapshot)) = maps_to_drop {
-            let process_maps = process_maps.into_inner();
             let maps = (pending, process_maps, operations);
             drop(maps);
-            self.exit_notify.notify_waiters();
+            self.close_notify.notify_waiters();
             command::log_operations_closed(reason, &command_snapshot);
         }
     }
@@ -268,8 +262,8 @@ impl Drop for VsockHost {
 
 /// Background reader task: owns the read half and decoder exclusively.
 ///
-/// Dispatches responses to pending requests by seq number, and caches
-/// unsolicited process_exit events for `wait_for_exit`.
+/// Dispatches responses, command operations, and spawn_watch lifecycle frames
+/// by seq number.
 async fn reader_loop(
     mut reader: tokio::net::unix::OwnedReadHalf,
     mut decoder: Decoder,
@@ -313,15 +307,19 @@ async fn reader_loop(
                     shared.poison_connection();
                     return;
                 }
-            } else if msg.msg_type == MSG_STDOUT_CHUNK && msg.seq == 0 {
-                process::dispatch_stdout_chunk(&shared, &msg.payload);
-            } else if msg.msg_type == MSG_PROCESS_EXIT && msg.seq == 0 {
-                process::dispatch_process_exit(&shared, &msg.payload);
+            } else if msg.msg_type == MSG_STDOUT_CHUNK {
+                if process::dispatch_stdout_chunk(&shared, &msg).is_err() {
+                    shared.poison_connection();
+                    return;
+                }
+            } else if msg.msg_type == MSG_PROCESS_EXIT {
+                if process::dispatch_process_exit(&shared, &msg).is_err() {
+                    shared.poison_connection();
+                    return;
+                }
             } else {
-                // For spawn_watch_result: move the pre-registered stdout sender
-                // from pending_stdout to stdout_senders BEFORE dispatching the
-                // response — under one lock so the channel is keyed by pid in
-                // stdout_senders before any subsequent MSG_STDOUT_CHUNK arrives.
+                // For spawn_watch_result: record pid metadata on the
+                // seq-owned operation before dispatching the response.
                 let response_sender = {
                     let mut guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
                     match &mut *guard {
@@ -329,11 +327,7 @@ async fn reader_loop(
                             pending, process, ..
                         } => {
                             if msg.msg_type == MSG_SPAWN_WATCH_RESULT {
-                                process::move_stdout_registration_to_pid_before_response_dispatch(
-                                    process,
-                                    msg.seq,
-                                    &msg.payload,
-                                );
+                                process::record_spawn_watch_result(process, msg.seq, &msg.payload);
                             }
                             pending.remove(&msg.seq)
                         }
@@ -348,7 +342,7 @@ async fn reader_loop(
     }
     // Connection lost — transition state to Closed. `close()` drops all
     // registration maps outside the lock (waking every pending receiver
-    // with `RecvError`) and fires `exit_notify` so `wait_for_exit` wakes.
+    // with `RecvError`) and fires `close_notify` so test helpers wake.
     shared.close();
 }
 
@@ -480,7 +474,7 @@ impl VsockHost {
                 operations: command::Operations::new(),
                 process: process::ConnectedProcessState::new(),
             }),
-            exit_notify: Notify::new(),
+            close_notify: Notify::new(),
         });
 
         let reader_shared = Arc::clone(&shared);
@@ -633,13 +627,13 @@ impl VsockHost {
 
     /// Spawn a process on the guest and monitor for exit.
     ///
-    /// Returns immediately with `(pid, stdout_rx)`. Use [`wait_for_exit`](Self::wait_for_exit)
-    /// to wait for completion.
+    /// Returns immediately with a handle. Use [`SpawnWatchHandle::wait`] to
+    /// wait for completion.
     ///
     /// When `stream_stdout` is true, stdout chunks are streamed to the host via
     /// `MSG_STDOUT_CHUNK`. `stdout_log_path`, when present, additionally asks
     /// the guest to tee those chunks into the given guest-side file.
-    /// The returned `stdout_rx` channel receives streamed chunks when enabled
+    /// The handle's `stdout_rx` channel receives streamed chunks when enabled
     /// and is closed when the process exits or the connection drops.
     pub async fn spawn_watch(
         &self,
@@ -649,7 +643,7 @@ impl VsockHost {
         sudo: bool,
         stream_stdout: bool,
         stdout_log_path: Option<&str>,
-    ) -> io::Result<(u32, tokio::sync::mpsc::UnboundedReceiver<Vec<u8>>)> {
+    ) -> io::Result<SpawnWatchHandle> {
         process::spawn_watch_on_shared(
             &self.shared,
             command,
@@ -660,13 +654,6 @@ impl VsockHost {
             stdout_log_path,
         )
         .await
-    }
-
-    /// Wait for a spawned process to exit.
-    ///
-    /// Returns immediately if the exit event was already cached.
-    pub async fn wait_for_exit(&self, pid: u32, timeout: Duration) -> io::Result<ProcessExitEvent> {
-        process::wait_for_exit_on_shared(&self.shared, pid, timeout).await
     }
 
     /// Request graceful shutdown from guest.
@@ -682,17 +669,13 @@ impl VsockHost {
 impl VsockHost {
     /// Test-only: deterministically await the `Connected → Closed` transition
     /// without relying on a wall-clock sleep. Subscribes to the same
-    /// `exit_notify` signal that [`Shared::close`] fires on exit, and re-checks
+    /// `close_notify` signal that [`Shared::close`] fires on exit, and re-checks
     /// state under the same lock that `close` holds, so no transition is
     /// missed.
-    ///
-    /// Note that `exit_notify` also fires on `MSG_PROCESS_EXIT`; those wake
-    /// this helper early but it re-checks state and re-parks if still
-    /// `Connected`.
     async fn wait_until_closed(&self, timeout: Duration) -> io::Result<()> {
         let deadline = Instant::now() + timeout;
         loop {
-            let notified = self.shared.exit_notify.notified();
+            let notified = self.shared.close_notify.notified();
             tokio::pin!(notified);
             notified.as_mut().enable();
 

--- a/crates/vsock-host/src/process.rs
+++ b/crates/vsock-host/src/process.rs
@@ -137,6 +137,11 @@ impl Drop for SpawnOperationRegistrationGuard {
 /// Dropping the handle removes the host-side operation registration. It does
 /// not send a guest-side cancellation request; this matches the previous
 /// host-side wait timeout/drop behavior.
+///
+/// If stdout streaming is enabled, call [`take_stdout_receiver`](Self::take_stdout_receiver)
+/// before [`wait`](Self::wait). Waiting consumes the handle and drops any
+/// unclaimed stdout receiver so streamed output is not buffered without a
+/// reader.
 pub struct SpawnWatchHandle {
     shared: Arc<Shared>,
     seq: Option<u32>,
@@ -172,6 +177,11 @@ impl SpawnWatchHandle {
                 "spawn_watch operation closed",
             )
         })?;
+
+        // `wait` consumes the handle, so an unclaimed stdout receiver can no
+        // longer be observed by the caller. Drop it before waiting to avoid
+        // buffering streamed stdout in an unbounded channel with no reader.
+        drop(self.stdout_rx.take());
 
         let result = rx
             .await

--- a/crates/vsock-host/src/process.rs
+++ b/crates/vsock-host/src/process.rs
@@ -19,7 +19,6 @@ pub struct ProcessExitEvent {
 }
 
 struct SpawnOperation {
-    pid: Option<u32>,
     stdout_tx: Option<mpsc::UnboundedSender<Vec<u8>>>,
     exit_tx: oneshot::Sender<io::Result<ProcessExitEvent>>,
 }
@@ -184,18 +183,6 @@ fn remove_spawn_operation(shared: &Arc<Shared>, seq: u32) {
     }
 }
 
-pub(crate) fn record_spawn_watch_result(
-    process: &mut ConnectedProcessState,
-    seq: u32,
-    payload: &[u8],
-) {
-    if let Ok(pid) = vsock_proto::decode_spawn_watch_result(payload)
-        && let Some(operation) = process.operation_mut(seq)
-    {
-        operation.pid = Some(pid);
-    }
-}
-
 pub(crate) fn dispatch_stdout_chunk(shared: &Arc<Shared>, msg: &RawMessage) -> io::Result<()> {
     let active = {
         let guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
@@ -308,14 +295,7 @@ pub(crate) async fn spawn_watch_on_shared(
                 ));
             }
             ConnectionState::Connected { process, .. } => {
-                process.insert_operation(
-                    seq,
-                    SpawnOperation {
-                        pid: None,
-                        stdout_tx,
-                        exit_tx,
-                    },
-                );
+                process.insert_operation(seq, SpawnOperation { stdout_tx, exit_tx });
             }
         }
     }

--- a/crates/vsock-host/src/process.rs
+++ b/crates/vsock-host/src/process.rs
@@ -22,7 +22,7 @@ struct SpawnOperation {
     pid: Option<u32>,
     streams_stdout: bool,
     stdout_tx: Option<mpsc::UnboundedSender<Vec<u8>>>,
-    exit_tx: oneshot::Sender<io::Result<ProcessExitEvent>>,
+    exit_tx: oneshot::Sender<ProcessExitEvent>,
 }
 
 /// Process lifecycle state while the vsock connection is open.
@@ -163,7 +163,7 @@ pub struct SpawnWatchHandle {
     seq: Option<u32>,
     pid: u32,
     stdout_rx: Option<mpsc::UnboundedReceiver<Vec<u8>>>,
-    exit_rx: Option<oneshot::Receiver<io::Result<ProcessExitEvent>>>,
+    exit_rx: Option<oneshot::Receiver<ProcessExitEvent>>,
 }
 
 impl fmt::Debug for SpawnWatchHandle {
@@ -199,11 +199,11 @@ impl SpawnWatchHandle {
         // buffering streamed stdout in an unbounded channel with no reader.
         drop(self.stdout_rx.take());
 
-        let result = rx
+        let event = rx
             .await
             .map_err(|_| io::Error::new(io::ErrorKind::ConnectionReset, "connection closed"))?;
         self.seq = None;
-        result
+        Ok(event)
     }
 }
 
@@ -309,7 +309,7 @@ pub(crate) fn dispatch_process_exit(shared: &Arc<Shared>, msg: &RawMessage) -> i
         stderr: stderr.to_vec(),
     };
 
-    let _ = operation.exit_tx.send(Ok(event));
+    let _ = operation.exit_tx.send(event);
 
     Ok(())
 }

--- a/crates/vsock-host/src/process.rs
+++ b/crates/vsock-host/src/process.rs
@@ -89,6 +89,21 @@ fn validate_lifecycle_pid(
     Ok(())
 }
 
+fn require_recorded_lifecycle_pid(
+    frame: &'static str,
+    expected: Option<u32>,
+    actual: u32,
+) -> io::Result<u32> {
+    let expected = expected.ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("{frame} arrived before spawn_watch_result for pid {actual}"),
+        )
+    })?;
+    validate_lifecycle_pid(frame, Some(expected), actual)?;
+    Ok(expected)
+}
+
 /// Process lifecycle state after the vsock connection has closed.
 pub(crate) struct ClosedProcessState;
 
@@ -232,7 +247,7 @@ pub(crate) fn dispatch_stdout_chunk(shared: &Arc<Shared>, msg: &RawMessage) -> i
         };
         let (pid, data) = vsock_proto::decode_stdout_chunk(&msg.payload)
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
-        validate_lifecycle_pid("stdout_chunk", operation.pid, pid)?;
+        require_recorded_lifecycle_pid("stdout_chunk", operation.pid, pid)?;
         (operation.stdout_tx.clone(), data)
     };
 
@@ -262,11 +277,10 @@ pub(crate) fn dispatch_process_exit(shared: &Arc<Shared>, msg: &RawMessage) -> i
         let expected_pid = operation.pid;
         let (pid, exit_code, stdout, stderr) = vsock_proto::decode_process_exit(&msg.payload)
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
-        validate_lifecycle_pid("process_exit", expected_pid, pid)?;
+        let pid = require_recorded_lifecycle_pid("process_exit", expected_pid, pid)?;
         let Some(operation) = process.take_operation(msg.seq) else {
             return Ok(());
         };
-        let pid = operation.pid.unwrap_or(pid);
         (operation, pid, exit_code, stdout, stderr)
     };
 

--- a/crates/vsock-host/src/process.rs
+++ b/crates/vsock-host/src/process.rs
@@ -57,10 +57,6 @@ impl ConnectedProcessState {
         self.operations.get_mut(&seq)
     }
 
-    fn contains_operation(&self, seq: u32) -> bool {
-        self.operations.contains_key(&seq)
-    }
-
     fn take_operation(&mut self, seq: u32) -> Option<SpawnOperation> {
         self.operations.remove(&seq)
     }
@@ -184,28 +180,17 @@ fn remove_spawn_operation(shared: &Arc<Shared>, seq: u32) {
 }
 
 pub(crate) fn dispatch_stdout_chunk(shared: &Arc<Shared>, msg: &RawMessage) -> io::Result<()> {
-    let active = {
-        let guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
-        matches!(
-            &*guard,
-            ConnectionState::Connected { process, .. } if process.contains_operation(msg.seq)
-        )
-    };
-    if !active {
-        return Ok(());
-    }
-
-    let (_pid, data) = vsock_proto::decode_stdout_chunk(&msg.payload)
-        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
-
-    let sender = {
+    let (sender, data) = {
         let mut guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
-        match &mut *guard {
-            ConnectionState::Connected { process, .. } => process
-                .operation_mut(msg.seq)
-                .and_then(|operation| operation.stdout_tx.clone()),
-            ConnectionState::Closed { .. } => None,
-        }
+        let ConnectionState::Connected { process, .. } = &mut *guard else {
+            return Ok(());
+        };
+        let Some(operation) = process.operation_mut(msg.seq) else {
+            return Ok(());
+        };
+        let (_pid, data) = vsock_proto::decode_stdout_chunk(&msg.payload)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
+        (operation.stdout_tx.clone(), data)
     };
 
     if let Some(tx) = sender
@@ -223,19 +208,22 @@ pub(crate) fn dispatch_stdout_chunk(shared: &Arc<Shared>, msg: &RawMessage) -> i
 }
 
 pub(crate) fn dispatch_process_exit(shared: &Arc<Shared>, msg: &RawMessage) -> io::Result<()> {
-    let active = {
-        let guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
-        matches!(
-            &*guard,
-            ConnectionState::Connected { process, .. } if process.contains_operation(msg.seq)
-        )
+    let (operation, pid, exit_code, stdout, stderr) = {
+        let mut guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
+        let ConnectionState::Connected { process, .. } = &mut *guard else {
+            return Ok(());
+        };
+        if process.operation_mut(msg.seq).is_none() {
+            return Ok(());
+        }
+        let (pid, exit_code, stdout, stderr) = vsock_proto::decode_process_exit(&msg.payload)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
+        let Some(operation) = process.take_operation(msg.seq) else {
+            return Ok(());
+        };
+        (operation, pid, exit_code, stdout, stderr)
     };
-    if !active {
-        return Ok(());
-    }
 
-    let (pid, exit_code, stdout, stderr) = vsock_proto::decode_process_exit(&msg.payload)
-        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
     let event = ProcessExitEvent {
         pid,
         exit_code,
@@ -243,17 +231,7 @@ pub(crate) fn dispatch_process_exit(shared: &Arc<Shared>, msg: &RawMessage) -> i
         stderr: stderr.to_vec(),
     };
 
-    let operation = {
-        let mut guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
-        match &mut *guard {
-            ConnectionState::Connected { process, .. } => process.take_operation(msg.seq),
-            ConnectionState::Closed { .. } => None,
-        }
-    };
-
-    if let Some(operation) = operation {
-        let _ = operation.exit_tx.send(Ok(event));
-    }
+    let _ = operation.exit_tx.send(Ok(event));
 
     Ok(())
 }

--- a/crates/vsock-host/src/process.rs
+++ b/crates/vsock-host/src/process.rs
@@ -226,16 +226,22 @@ pub(crate) fn record_spawn_watch_result(shared: &Arc<Shared>, msg: &RawMessage) 
     if let ConnectionState::Connected { process, .. } = &mut *guard
         && let Some(operation) = process.operation_mut(msg.seq)
     {
+        if let Some(expected) = operation.pid {
+            let pid = vsock_proto::decode_spawn_watch_result(&msg.payload)
+                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
+            validate_lifecycle_pid("spawn_watch_result", Some(expected), pid)?;
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("duplicate spawn_watch_result for pid {pid}"),
+            ));
+        }
+
         let pid = match vsock_proto::decode_spawn_watch_result(&msg.payload) {
             Ok(pid) => pid,
-            Err(e) if operation.pid.is_some() => {
-                return Err(io::Error::new(io::ErrorKind::InvalidData, e.to_string()));
-            }
             // Initial malformed responses are still delivered to the pending
             // request path, which returns InvalidData and drops the operation.
             Err(_) => return Ok(()),
         };
-        validate_lifecycle_pid("spawn_watch_result", operation.pid, pid)?;
         operation.pid = Some(pid);
     }
     Ok(())

--- a/crates/vsock-host/src/process.rs
+++ b/crates/vsock-host/src/process.rs
@@ -1,15 +1,13 @@
 use std::collections::HashMap;
+use std::fmt;
 use std::io;
 use std::sync::Arc;
 use std::time::Duration;
 
-use tokio::sync::mpsc;
-use tokio::time::Instant;
-use vsock_proto::{MSG_ERROR, MSG_SPAWN_WATCH, MSG_SPAWN_WATCH_RESULT};
+use tokio::sync::{mpsc, oneshot};
+use vsock_proto::{MSG_ERROR, MSG_SPAWN_WATCH, MSG_SPAWN_WATCH_RESULT, RawMessage};
 
 use crate::{ConnectionState, Shared, request_raw_on_shared};
-
-type StdoutSenderMap = HashMap<u32, mpsc::UnboundedSender<Vec<u8>>>;
 
 /// Event emitted when a spawned process exits.
 #[derive(Debug, Clone)]
@@ -20,171 +18,237 @@ pub struct ProcessExitEvent {
     pub stderr: Vec<u8>,
 }
 
+struct SpawnOperation {
+    pid: Option<u32>,
+    stdout_tx: Option<mpsc::UnboundedSender<Vec<u8>>>,
+    exit_tx: oneshot::Sender<io::Result<ProcessExitEvent>>,
+}
+
 /// Process lifecycle state while the vsock connection is open.
 pub(crate) struct ConnectedProcessState {
-    /// Pre-registered stdout senders: request seq -> channel sender.
-    ///
-    /// `spawn_watch` inserts here before sending the request so the reader loop
-    /// can move the sender to `stdout_senders` when it processes the
-    /// `spawn_watch_result`, before any stdout chunk for that pid is handled.
-    pending_stdout: StdoutSenderMap,
-    /// Stdout chunk senders: pid -> channel sender.
-    stdout_senders: StdoutSenderMap,
-    /// Cached process exit events (unsolicited, seq=0).
-    exits: HashMap<u32, ProcessExitEvent>,
+    /// Active spawn_watch operations keyed by request sequence number.
+    operations: HashMap<u32, SpawnOperation>,
 }
 
 impl ConnectedProcessState {
     pub(crate) fn new() -> Self {
         Self {
-            pending_stdout: HashMap::new(),
-            stdout_senders: HashMap::new(),
-            exits: HashMap::new(),
+            operations: HashMap::new(),
         }
     }
 
-    pub(crate) fn close(self) -> (ClosedProcessState, ProcessSenderMaps) {
-        let Self {
-            pending_stdout,
-            stdout_senders,
-            exits,
-        } = self;
+    pub(crate) fn close(self) -> (ClosedProcessState, ProcessOperationMap) {
         (
-            ClosedProcessState { exits },
-            ProcessSenderMaps {
-                pending_stdout,
-                stdout_senders,
+            ClosedProcessState,
+            ProcessOperationMap {
+                _operations: self.operations,
             },
         )
     }
 
-    fn insert_pending_stdout(&mut self, seq: u32, tx: mpsc::UnboundedSender<Vec<u8>>) {
-        self.pending_stdout.insert(seq, tx);
+    fn insert_operation(&mut self, seq: u32, operation: SpawnOperation) {
+        self.operations.insert(seq, operation);
     }
 
-    fn remove_pending_stdout(&mut self, seq: u32) {
-        self.pending_stdout.remove(&seq);
+    fn remove_operation(&mut self, seq: u32) {
+        self.operations.remove(&seq);
     }
 
-    fn stdout_sender(&self, pid: u32) -> Option<mpsc::UnboundedSender<Vec<u8>>> {
-        self.stdout_senders.get(&pid).cloned()
+    fn operation_mut(&mut self, seq: u32) -> Option<&mut SpawnOperation> {
+        self.operations.get_mut(&seq)
     }
 
-    fn remove_stdout_sender(&mut self, pid: u32) {
-        self.stdout_senders.remove(&pid);
+    fn contains_operation(&self, seq: u32) -> bool {
+        self.operations.contains_key(&seq)
     }
 
-    fn insert_exit(&mut self, event: ProcessExitEvent) {
-        self.stdout_senders.remove(&event.pid);
-        self.exits.insert(event.pid, event);
-    }
-
-    fn take_exit(&mut self, pid: u32) -> Option<ProcessExitEvent> {
-        self.exits.remove(&pid)
+    fn take_operation(&mut self, seq: u32) -> Option<SpawnOperation> {
+        self.operations.remove(&seq)
     }
 
     #[cfg(test)]
     pub(crate) fn registration_counts(&self) -> (usize, usize) {
-        (self.pending_stdout.len(), self.stdout_senders.len())
+        let stdout_senders = self
+            .operations
+            .values()
+            .filter(|operation| operation.stdout_tx.is_some())
+            .count();
+        (self.operations.len(), stdout_senders)
     }
 }
 
 /// Process lifecycle state after the vsock connection has closed.
-pub(crate) struct ClosedProcessState {
-    /// Preserved across the close transition: callers of `wait_for_exit` can
-    /// still retrieve an exit event that was cached before close.
-    exits: HashMap<u32, ProcessExitEvent>,
-}
+pub(crate) struct ClosedProcessState;
 
 impl ClosedProcessState {
     pub(crate) fn empty() -> Self {
+        Self
+    }
+}
+
+/// Spawn operation map moved out during close so drops happen outside
+/// `Shared.state`.
+pub(crate) struct ProcessOperationMap {
+    _operations: HashMap<u32, SpawnOperation>,
+}
+
+struct SpawnOperationRegistrationGuard {
+    shared: Arc<Shared>,
+    seq: u32,
+    disarmed: bool,
+}
+
+impl SpawnOperationRegistrationGuard {
+    fn new(shared: Arc<Shared>, seq: u32) -> Self {
         Self {
-            exits: HashMap::new(),
+            shared,
+            seq,
+            disarmed: false,
         }
     }
 
-    fn take_exit(&mut self, pid: u32) -> Option<ProcessExitEvent> {
-        self.exits.remove(&pid)
+    fn disarm(&mut self) {
+        self.disarmed = true;
     }
 }
 
-/// Sender maps moved out during close so drops happen outside `Shared.state`.
-pub(crate) struct ProcessSenderMaps {
-    pending_stdout: StdoutSenderMap,
-    stdout_senders: StdoutSenderMap,
-}
-
-impl ProcessSenderMaps {
-    pub(crate) fn into_inner(self) -> (StdoutSenderMap, StdoutSenderMap) {
-        (self.pending_stdout, self.stdout_senders)
-    }
-}
-
-struct PendingStdoutGuard {
-    shared: Arc<Shared>,
-    seq: u32,
-}
-
-impl PendingStdoutGuard {
-    fn new(shared: Arc<Shared>, seq: u32) -> Self {
-        Self { shared, seq }
-    }
-}
-
-impl Drop for PendingStdoutGuard {
+impl Drop for SpawnOperationRegistrationGuard {
     fn drop(&mut self) {
-        remove_pending_stdout(&self.shared, self.seq);
+        if !self.disarmed {
+            remove_spawn_operation(&self.shared, self.seq);
+        }
     }
 }
 
-pub(crate) fn remove_pending_stdout(shared: &Arc<Shared>, seq: u32) {
+/// Handle for a spawn_watch operation.
+///
+/// Dropping the handle removes the host-side operation registration. It does
+/// not send a guest-side cancellation request; this matches the previous
+/// host-side wait timeout/drop behavior.
+pub struct SpawnWatchHandle {
+    shared: Arc<Shared>,
+    seq: Option<u32>,
+    pid: u32,
+    stdout_rx: Option<mpsc::UnboundedReceiver<Vec<u8>>>,
+    exit_rx: Option<oneshot::Receiver<io::Result<ProcessExitEvent>>>,
+}
+
+impl fmt::Debug for SpawnWatchHandle {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SpawnWatchHandle")
+            .field("seq", &self.seq)
+            .field("pid", &self.pid)
+            .field("has_stdout_receiver", &self.stdout_rx.is_some())
+            .field("has_exit_receiver", &self.exit_rx.is_some())
+            .finish_non_exhaustive()
+    }
+}
+
+impl SpawnWatchHandle {
+    pub fn pid(&self) -> u32 {
+        self.pid
+    }
+
+    pub fn take_stdout_receiver(&mut self) -> Option<mpsc::UnboundedReceiver<Vec<u8>>> {
+        self.stdout_rx.take()
+    }
+
+    pub async fn wait(mut self) -> io::Result<ProcessExitEvent> {
+        let rx = self.exit_rx.take().ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::ConnectionReset,
+                "spawn_watch operation closed",
+            )
+        })?;
+
+        let result = rx
+            .await
+            .map_err(|_| io::Error::new(io::ErrorKind::ConnectionReset, "connection closed"))?;
+        self.seq = None;
+        result
+    }
+}
+
+impl Drop for SpawnWatchHandle {
+    fn drop(&mut self) {
+        if let Some(seq) = self.seq.take() {
+            remove_spawn_operation(&self.shared, seq);
+        }
+    }
+}
+
+fn remove_spawn_operation(shared: &Arc<Shared>, seq: u32) {
     let mut guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
     if let ConnectionState::Connected { process, .. } = &mut *guard {
-        process.remove_pending_stdout(seq);
+        process.remove_operation(seq);
     }
 }
 
-pub(crate) fn move_stdout_registration_to_pid_before_response_dispatch(
+pub(crate) fn record_spawn_watch_result(
     process: &mut ConnectedProcessState,
     seq: u32,
     payload: &[u8],
 ) {
     if let Ok(pid) = vsock_proto::decode_spawn_watch_result(payload)
-        && let Some(tx) = process.pending_stdout.remove(&seq)
+        && let Some(operation) = process.operation_mut(seq)
     {
-        process.stdout_senders.insert(pid, tx);
+        operation.pid = Some(pid);
     }
 }
 
-pub(crate) fn dispatch_stdout_chunk(shared: &Arc<Shared>, payload: &[u8]) {
-    let Ok((pid, data)) = vsock_proto::decode_stdout_chunk(payload) else {
-        return;
+pub(crate) fn dispatch_stdout_chunk(shared: &Arc<Shared>, msg: &RawMessage) -> io::Result<()> {
+    let active = {
+        let guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
+        matches!(
+            &*guard,
+            ConnectionState::Connected { process, .. } if process.contains_operation(msg.seq)
+        )
     };
+    if !active {
+        return Ok(());
+    }
+
+    let (_pid, data) = vsock_proto::decode_stdout_chunk(&msg.payload)
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
 
     let sender = {
-        let guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
-        match &*guard {
-            ConnectionState::Connected { process, .. } => process.stdout_sender(pid),
+        let mut guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
+        match &mut *guard {
+            ConnectionState::Connected { process, .. } => process
+                .operation_mut(msg.seq)
+                .and_then(|operation| operation.stdout_tx.clone()),
             ConnectionState::Closed { .. } => None,
         }
     };
 
-    if let Some(tx) = sender {
-        // Best-effort: if receiver is dropped, remove sender.
-        if tx.send(data.to_vec()).is_err() {
-            let mut guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
-            if let ConnectionState::Connected { process, .. } = &mut *guard {
-                process.remove_stdout_sender(pid);
-            }
+    if let Some(tx) = sender
+        && tx.send(data.to_vec()).is_err()
+    {
+        let mut guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
+        if let ConnectionState::Connected { process, .. } = &mut *guard
+            && let Some(operation) = process.operation_mut(msg.seq)
+        {
+            operation.stdout_tx = None;
         }
     }
+
+    Ok(())
 }
 
-pub(crate) fn dispatch_process_exit(shared: &Arc<Shared>, payload: &[u8]) {
-    let Ok((pid, exit_code, stdout, stderr)) = vsock_proto::decode_process_exit(payload) else {
-        return;
+pub(crate) fn dispatch_process_exit(shared: &Arc<Shared>, msg: &RawMessage) -> io::Result<()> {
+    let active = {
+        let guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
+        matches!(
+            &*guard,
+            ConnectionState::Connected { process, .. } if process.contains_operation(msg.seq)
+        )
     };
+    if !active {
+        return Ok(());
+    }
 
+    let (pid, exit_code, stdout, stderr) = vsock_proto::decode_process_exit(&msg.payload)
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
     let event = ProcessExitEvent {
         pid,
         exit_code,
@@ -192,13 +256,19 @@ pub(crate) fn dispatch_process_exit(shared: &Arc<Shared>, payload: &[u8]) {
         stderr: stderr.to_vec(),
     };
 
-    {
+    let operation = {
         let mut guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
-        if let ConnectionState::Connected { process, .. } = &mut *guard {
-            process.insert_exit(event);
+        match &mut *guard {
+            ConnectionState::Connected { process, .. } => process.take_operation(msg.seq),
+            ConnectionState::Closed { .. } => None,
         }
+    };
+
+    if let Some(operation) = operation {
+        let _ = operation.exit_tx.send(Ok(event));
     }
-    shared.exit_notify.notify_waiters();
+
+    Ok(())
 }
 
 pub(crate) async fn spawn_watch_on_shared(
@@ -209,7 +279,7 @@ pub(crate) async fn spawn_watch_on_shared(
     sudo: bool,
     stream_stdout: bool,
     stdout_log_path: Option<&str>,
-) -> io::Result<(u32, mpsc::UnboundedReceiver<Vec<u8>>)> {
+) -> io::Result<SpawnWatchHandle> {
     let payload = vsock_proto::encode_spawn_watch(
         timeout_ms,
         command,
@@ -220,11 +290,13 @@ pub(crate) async fn spawn_watch_on_shared(
     )
     .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e.to_string()))?;
 
-    // Pre-create the stdout channel. In streaming mode, register it by seq
-    // number before sending the request. The reader loop will atomically move
-    // it from pending_stdout[seq] to stdout_senders[pid] when it processes the
-    // spawn_watch_result, before any stdout_chunk for that pid.
-    let (stdout_tx, stdout_rx) = mpsc::unbounded_channel();
+    let (stdout_tx, stdout_rx) = if stream_stdout {
+        let (tx, rx) = mpsc::unbounded_channel();
+        (Some(tx), Some(rx))
+    } else {
+        (None, None)
+    };
+    let (exit_tx, exit_rx) = oneshot::channel();
     let seq = shared.next_seq();
     {
         let mut guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
@@ -235,14 +307,19 @@ pub(crate) async fn spawn_watch_on_shared(
                     "connection closed",
                 ));
             }
-            ConnectionState::Connected { process, .. } if stream_stdout => {
-                process.insert_pending_stdout(seq, stdout_tx);
+            ConnectionState::Connected { process, .. } => {
+                process.insert_operation(
+                    seq,
+                    SpawnOperation {
+                        pid: None,
+                        stdout_tx,
+                        exit_tx,
+                    },
+                );
             }
-            ConnectionState::Connected { .. } => {}
         }
     }
-    let _pending_stdout_guard =
-        stream_stdout.then(|| PendingStdoutGuard::new(Arc::clone(shared), seq));
+    let mut registration_guard = SpawnOperationRegistrationGuard::new(Arc::clone(shared), seq);
 
     let resp = request_raw_on_shared(
         shared,
@@ -254,7 +331,6 @@ pub(crate) async fn spawn_watch_on_shared(
     .await?;
 
     if resp.msg_type == MSG_ERROR {
-        // No pid assigned — clean up pending stdout sender.
         let msg = vsock_proto::decode_error(&resp.payload)
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
         return Err(io::Error::other(msg));
@@ -267,58 +343,16 @@ pub(crate) async fn spawn_watch_on_shared(
         ));
     }
 
-    // If decode fails here, the reader's identical decode also failed and did
-    // not move `pending_stdout[seq]` to `stdout_senders[pid]`; the guard still
-    // owns cleanup of the pending registration.
     let pid = vsock_proto::decode_spawn_watch_result(&resp.payload)
         .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
 
-    // Channel already moved from pending_stdout to stdout_senders by reader_loop.
-    Ok((pid, stdout_rx))
-}
+    registration_guard.disarm();
 
-pub(crate) async fn wait_for_exit_on_shared(
-    shared: &Arc<Shared>,
-    pid: u32,
-    timeout: Duration,
-) -> io::Result<ProcessExitEvent> {
-    let deadline = Instant::now() + timeout;
-    loop {
-        // Register interest BEFORE checking the cache so a `notify_waiters`
-        // firing between the cache check and `select!` still wakes us.
-        let exit_notified = shared.exit_notify.notified();
-        tokio::pin!(exit_notified);
-        exit_notified.as_mut().enable();
-
-        {
-            let mut guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
-            match &mut *guard {
-                ConnectionState::Connected { process, .. } => {
-                    if let Some(event) = process.take_exit(pid) {
-                        return Ok(event);
-                    }
-                }
-                ConnectionState::Closed { process } => {
-                    if let Some(event) = process.take_exit(pid) {
-                        return Ok(event);
-                    }
-                    return Err(io::Error::new(
-                        io::ErrorKind::ConnectionReset,
-                        "connection closed",
-                    ));
-                }
-            }
-        }
-
-        tokio::select! {
-            biased;
-            _ = exit_notified => {
-                // Either a new exit event, or `close()` fired its
-                // `exit_notify.notify_waiters()` — re-check on next iter.
-            }
-            _ = tokio::time::sleep_until(deadline) => {
-                return Err(io::Error::new(io::ErrorKind::TimedOut, "wait timeout"));
-            }
-        }
-    }
+    Ok(SpawnWatchHandle {
+        shared: Arc::clone(shared),
+        seq: Some(seq),
+        pid,
+        stdout_rx,
+        exit_rx: Some(exit_rx),
+    })
 }

--- a/crates/vsock-host/src/process.rs
+++ b/crates/vsock-host/src/process.rs
@@ -222,14 +222,19 @@ fn remove_spawn_operation(shared: &Arc<Shared>, seq: u32) {
 }
 
 pub(crate) fn record_spawn_watch_result(shared: &Arc<Shared>, msg: &RawMessage) -> io::Result<()> {
-    let Ok(pid) = vsock_proto::decode_spawn_watch_result(&msg.payload) else {
-        return Ok(());
-    };
-
     let mut guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
     if let ConnectionState::Connected { process, .. } = &mut *guard
         && let Some(operation) = process.operation_mut(msg.seq)
     {
+        let pid = match vsock_proto::decode_spawn_watch_result(&msg.payload) {
+            Ok(pid) => pid,
+            Err(e) if operation.pid.is_some() => {
+                return Err(io::Error::new(io::ErrorKind::InvalidData, e.to_string()));
+            }
+            // Initial malformed responses are still delivered to the pending
+            // request path, which returns InvalidData and drops the operation.
+            Err(_) => return Ok(()),
+        };
         validate_lifecycle_pid("spawn_watch_result", operation.pid, pid)?;
         operation.pid = Some(pid);
     }

--- a/crates/vsock-host/src/process.rs
+++ b/crates/vsock-host/src/process.rs
@@ -19,6 +19,7 @@ pub struct ProcessExitEvent {
 }
 
 struct SpawnOperation {
+    pid: Option<u32>,
     stdout_tx: Option<mpsc::UnboundedSender<Vec<u8>>>,
     exit_tx: oneshot::Sender<io::Result<ProcessExitEvent>>,
 }
@@ -70,6 +71,22 @@ impl ConnectedProcessState {
             .count();
         (self.operations.len(), stdout_senders)
     }
+}
+
+fn validate_lifecycle_pid(
+    frame: &'static str,
+    expected: Option<u32>,
+    actual: u32,
+) -> io::Result<()> {
+    if let Some(expected) = expected
+        && expected != actual
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("{frame} pid mismatch: expected {expected}, got {actual}"),
+        ));
+    }
+    Ok(())
 }
 
 /// Process lifecycle state after the vsock connection has closed.
@@ -179,6 +196,21 @@ fn remove_spawn_operation(shared: &Arc<Shared>, seq: u32) {
     }
 }
 
+pub(crate) fn record_spawn_watch_result(shared: &Arc<Shared>, msg: &RawMessage) -> io::Result<()> {
+    let Ok(pid) = vsock_proto::decode_spawn_watch_result(&msg.payload) else {
+        return Ok(());
+    };
+
+    let mut guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
+    if let ConnectionState::Connected { process, .. } = &mut *guard
+        && let Some(operation) = process.operation_mut(msg.seq)
+    {
+        validate_lifecycle_pid("spawn_watch_result", operation.pid, pid)?;
+        operation.pid = Some(pid);
+    }
+    Ok(())
+}
+
 pub(crate) fn dispatch_stdout_chunk(shared: &Arc<Shared>, msg: &RawMessage) -> io::Result<()> {
     let (sender, data) = {
         let mut guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
@@ -188,8 +220,9 @@ pub(crate) fn dispatch_stdout_chunk(shared: &Arc<Shared>, msg: &RawMessage) -> i
         let Some(operation) = process.operation_mut(msg.seq) else {
             return Ok(());
         };
-        let (_pid, data) = vsock_proto::decode_stdout_chunk(&msg.payload)
+        let (pid, data) = vsock_proto::decode_stdout_chunk(&msg.payload)
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
+        validate_lifecycle_pid("stdout_chunk", operation.pid, pid)?;
         (operation.stdout_tx.clone(), data)
     };
 
@@ -213,14 +246,17 @@ pub(crate) fn dispatch_process_exit(shared: &Arc<Shared>, msg: &RawMessage) -> i
         let ConnectionState::Connected { process, .. } = &mut *guard else {
             return Ok(());
         };
-        if process.operation_mut(msg.seq).is_none() {
+        let Some(operation) = process.operation_mut(msg.seq) else {
             return Ok(());
-        }
+        };
+        let expected_pid = operation.pid;
         let (pid, exit_code, stdout, stderr) = vsock_proto::decode_process_exit(&msg.payload)
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
+        validate_lifecycle_pid("process_exit", expected_pid, pid)?;
         let Some(operation) = process.take_operation(msg.seq) else {
             return Ok(());
         };
+        let pid = operation.pid.unwrap_or(pid);
         (operation, pid, exit_code, stdout, stderr)
     };
 
@@ -273,7 +309,14 @@ pub(crate) async fn spawn_watch_on_shared(
                 ));
             }
             ConnectionState::Connected { process, .. } => {
-                process.insert_operation(seq, SpawnOperation { stdout_tx, exit_tx });
+                process.insert_operation(
+                    seq,
+                    SpawnOperation {
+                        pid: None,
+                        stdout_tx,
+                        exit_tx,
+                    },
+                );
             }
         }
     }

--- a/crates/vsock-host/src/process.rs
+++ b/crates/vsock-host/src/process.rs
@@ -20,6 +20,7 @@ pub struct ProcessExitEvent {
 
 struct SpawnOperation {
     pid: Option<u32>,
+    streams_stdout: bool,
     stdout_tx: Option<mpsc::UnboundedSender<Vec<u8>>>,
     exit_tx: oneshot::Sender<io::Result<ProcessExitEvent>>,
 }
@@ -259,6 +260,12 @@ pub(crate) fn dispatch_stdout_chunk(shared: &Arc<Shared>, msg: &RawMessage) -> i
         let (pid, data) = vsock_proto::decode_stdout_chunk(&msg.payload)
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
         require_recorded_lifecycle_pid("stdout_chunk", operation.pid, pid)?;
+        if !operation.streams_stdout {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("stdout_chunk for non-streaming spawn_watch pid {pid}"),
+            ));
+        }
         (operation.stdout_tx.clone(), data)
     };
 
@@ -348,6 +355,7 @@ pub(crate) async fn spawn_watch_on_shared(
                     seq,
                     SpawnOperation {
                         pid: None,
+                        streams_stdout: stream_stdout,
                         stdout_tx,
                         exit_tx,
                     },

--- a/crates/vsock-host/src/tests/connection.rs
+++ b/crates/vsock-host/src/tests/connection.rs
@@ -3,7 +3,6 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
-use tokio::time::Instant;
 use vsock_proto::{CommandTermination, Decoder, MSG_COMMAND_START, MSG_SHUTDOWN, MSG_SHUTDOWN_ACK};
 
 use super::support::{host_from_stream, make_pair, mock_handshake, send_command_result};
@@ -103,10 +102,15 @@ async fn test_request_after_close_returns_immediately() {
         .await
         .unwrap();
 
-    // This should fail quickly (via write error or Closed short-circuit),
-    // NOT wait for the 5s exec timeout.
-    let start = Instant::now();
-    let err = host.exec("echo hi", 5000, &[], false).await.unwrap_err();
+    // This should return from the closed-state path, not hang until the exec
+    // timeout.
+    let err = tokio::time::timeout(
+        Duration::from_secs(5),
+        host.exec("echo hi", 5000, &[], false),
+    )
+    .await
+    .expect("exec should return when the connection is already closed")
+    .unwrap_err();
     assert!(
         matches!(
             err.kind(),
@@ -114,11 +118,6 @@ async fn test_request_after_close_returns_immediately() {
         ),
         "expected ConnectionReset or BrokenPipe, got {:?}",
         err.kind()
-    );
-    assert!(
-        start.elapsed() < Duration::from_secs(1),
-        "request should fail immediately, took {:?}",
-        start.elapsed()
     );
 }
 

--- a/crates/vsock-host/src/tests/connection.rs
+++ b/crates/vsock-host/src/tests/connection.rs
@@ -98,7 +98,7 @@ async fn test_request_after_close_returns_immediately() {
     let host = host_from_stream(host_stream).await.unwrap();
 
     // Deterministically wait for reader to detect EOF and transition state
-    // to Closed — no wall-clock sleep, driven by `exit_notify`.
+    // to Closed — no wall-clock sleep, driven by `close_notify`.
     host.wait_until_closed(Duration::from_secs(5))
         .await
         .unwrap();

--- a/crates/vsock-host/src/tests/process.rs
+++ b/crates/vsock-host/src/tests/process.rs
@@ -839,6 +839,66 @@ async fn test_mismatched_active_process_exit_pid_closes_and_cleans_up() {
     );
 }
 
+async fn assert_bad_active_stdout_chunk_closes_and_cleans_up(payload: Vec<u8>) {
+    let (host_stream, mut guest) = make_pair();
+
+    tokio::spawn(async move {
+        let mut decoder = Decoder::new();
+        mock_handshake(&mut guest, &mut decoder).await;
+
+        let mut buf = [0u8; 4096];
+        let n = guest.read(&mut buf).await.unwrap();
+        let msgs = decoder.decode(&buf[..n]).unwrap();
+        assert_eq!(msgs[0].msg_type, MSG_SPAWN_WATCH);
+        let spawn_seq = msgs[0].seq;
+
+        let result_payload = vsock_proto::encode_spawn_watch_result(123);
+        let result =
+            vsock_proto::encode(MSG_SPAWN_WATCH_RESULT, spawn_seq, &result_payload).unwrap();
+        let chunk = vsock_proto::encode(MSG_STDOUT_CHUNK, spawn_seq, &payload).unwrap();
+        let mut combined = result;
+        combined.extend_from_slice(&chunk);
+        guest.write_all(&combined).await.unwrap();
+
+        let mut discard = [0u8; 1];
+        let _ = guest.read(&mut discard).await;
+    });
+
+    let host = host_from_stream(host_stream).await.unwrap();
+    let mut handle = host
+        .spawn_watch("bad-stdout", 0, &[], false, true, None)
+        .await
+        .unwrap();
+    assert_eq!(handle.pid(), 123);
+    let mut stdout_rx = handle.take_stdout_receiver().unwrap();
+
+    let err = wait_spawn(handle).await.unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::ConnectionReset);
+    let received = tokio::time::timeout(Duration::from_secs(5), stdout_rx.recv())
+        .await
+        .expect("stdout receiver should close");
+    assert!(received.is_none(), "bad stdout chunk must not be delivered");
+    assert_eq!(
+        registration_counts(&host),
+        (0, 0, 0),
+        "bad active stdout_chunk must close and clean registrations",
+    );
+}
+
+#[tokio::test]
+async fn test_malformed_active_stdout_chunk_closes_and_cleans_up() {
+    assert_bad_active_stdout_chunk_closes_and_cleans_up(b"\x00".to_vec()).await;
+}
+
+#[tokio::test]
+async fn test_mismatched_active_stdout_chunk_pid_closes_and_cleans_up() {
+    assert_bad_active_stdout_chunk_closes_and_cleans_up(vsock_proto::encode_stdout_chunk(
+        321,
+        b"wrong-pid",
+    ))
+    .await;
+}
+
 #[tokio::test]
 async fn test_duplicate_spawn_watch_result_cannot_overwrite_pid() {
     let (host_stream, mut guest) = make_pair();

--- a/crates/vsock-host/src/tests/process.rs
+++ b/crates/vsock-host/src/tests/process.rs
@@ -293,6 +293,66 @@ async fn test_malformed_unsolicited_process_frames_are_ignored() {
     assert_eq!(event.stdout, b"after-malformed");
 }
 
+async fn assert_lifecycle_before_result_closes(
+    msg_type: u8,
+    payload: Vec<u8>,
+    stream_stdout: bool,
+) {
+    let (host_stream, mut guest) = make_pair();
+
+    tokio::spawn(async move {
+        let mut decoder = Decoder::new();
+        mock_handshake(&mut guest, &mut decoder).await;
+
+        let mut buf = [0u8; 4096];
+        let n = guest.read(&mut buf).await.unwrap();
+        let msgs = decoder.decode(&buf[..n]).unwrap();
+        assert_eq!(msgs[0].msg_type, MSG_SPAWN_WATCH);
+        let spawn_seq = msgs[0].seq;
+
+        let frame = vsock_proto::encode(msg_type, spawn_seq, &payload).unwrap();
+        guest.write_all(&frame).await.unwrap();
+
+        let mut discard = [0u8; 1];
+        let _ = guest.read(&mut discard).await;
+    });
+
+    let host = host_from_stream(host_stream).await.unwrap();
+    let result = tokio::time::timeout(
+        Duration::from_secs(5),
+        host.spawn_watch("early-lifecycle", 0, &[], false, stream_stdout, None),
+    )
+    .await
+    .expect("pre-result lifecycle frame should close connection promptly");
+    let err = result.unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::ConnectionReset);
+    assert_eq!(
+        registration_counts(&host),
+        (0, 0, 0),
+        "pre-result lifecycle frame must clean all registrations",
+    );
+}
+
+#[tokio::test]
+async fn test_stdout_chunk_before_spawn_watch_result_closes_and_cleans_up() {
+    assert_lifecycle_before_result_closes(
+        MSG_STDOUT_CHUNK,
+        vsock_proto::encode_stdout_chunk(777, b"early stdout"),
+        true,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_process_exit_before_spawn_watch_result_closes_and_cleans_up() {
+    assert_lifecycle_before_result_closes(
+        MSG_PROCESS_EXIT,
+        vsock_proto::encode_process_exit(777, 0, b"early stdout", b""),
+        false,
+    )
+    .await;
+}
+
 #[tokio::test]
 async fn test_dropped_stdout_receiver_removes_stream_sender() {
     let (host_stream, mut guest) = make_pair();

--- a/crates/vsock-host/src/tests/process.rs
+++ b/crates/vsock-host/src/tests/process.rs
@@ -888,6 +888,49 @@ async fn test_duplicate_spawn_watch_result_cannot_overwrite_pid() {
 }
 
 #[tokio::test]
+async fn test_malformed_duplicate_spawn_watch_result_closes_and_cleans_up() {
+    let (host_stream, mut guest) = make_pair();
+
+    tokio::spawn(async move {
+        let mut decoder = Decoder::new();
+        mock_handshake(&mut guest, &mut decoder).await;
+
+        let mut buf = [0u8; 4096];
+        let n = guest.read(&mut buf).await.unwrap();
+        let msgs = decoder.decode(&buf[..n]).unwrap();
+        assert_eq!(msgs[0].msg_type, MSG_SPAWN_WATCH);
+        let spawn_seq = msgs[0].seq;
+
+        let result_payload = vsock_proto::encode_spawn_watch_result(123);
+        let result =
+            vsock_proto::encode(MSG_SPAWN_WATCH_RESULT, spawn_seq, &result_payload).unwrap();
+        guest.write_all(&result).await.unwrap();
+
+        let duplicate =
+            vsock_proto::encode(MSG_SPAWN_WATCH_RESULT, spawn_seq, b"\x00\x01").unwrap();
+        guest.write_all(&duplicate).await.unwrap();
+
+        let mut discard = [0u8; 1];
+        let _ = guest.read(&mut discard).await;
+    });
+
+    let host = host_from_stream(host_stream).await.unwrap();
+    let handle = host
+        .spawn_watch("malformed-duplicate-result", 0, &[], false, false, None)
+        .await
+        .unwrap();
+    assert_eq!(handle.pid(), 123);
+
+    let err = wait_spawn(handle).await.unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::ConnectionReset);
+    assert_eq!(
+        registration_counts(&host),
+        (0, 0, 0),
+        "malformed duplicate spawn_watch_result must close and clean registrations",
+    );
+}
+
+#[tokio::test]
 async fn test_spawn_watch_wait_future_drop_cleans_registration() {
     let (host_stream, mut guest) = make_pair();
 

--- a/crates/vsock-host/src/tests/process.rs
+++ b/crates/vsock-host/src/tests/process.rs
@@ -209,6 +209,47 @@ async fn test_spawn_watch_malformed_result_cleans_up() {
 }
 
 #[tokio::test]
+async fn test_spawn_watch_connection_closed_before_result_cleans_up() {
+    let (host_stream, mut guest) = make_pair();
+    let request_seen = Arc::new(Notify::new());
+
+    {
+        let request_seen = Arc::clone(&request_seen);
+        tokio::spawn(async move {
+            let mut decoder = Decoder::new();
+            mock_handshake(&mut guest, &mut decoder).await;
+
+            let mut buf = [0u8; 4096];
+            let n = guest.read(&mut buf).await.unwrap();
+            let msgs = decoder.decode(&buf[..n]).unwrap();
+            assert_eq!(msgs[0].msg_type, MSG_SPAWN_WATCH);
+            request_seen.notify_one();
+            drop(guest);
+        });
+    }
+
+    let host = Arc::new(host_from_stream(host_stream).await.unwrap());
+    let task_host = Arc::clone(&host);
+    let task = tokio::spawn(async move {
+        task_host
+            .spawn_watch("pending-result", 0, &[], false, true, None)
+            .await
+    });
+
+    tokio::time::timeout(Duration::from_secs(5), request_seen.notified())
+        .await
+        .expect("guest should receive spawn_watch request");
+
+    let err = task.await.unwrap().unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::ConnectionReset);
+    assert_eq!(
+        registration_counts(&host),
+        (0, 0, 0),
+        "connection close while spawn_watch is pending must clean registrations",
+    );
+}
+
+#[tokio::test]
 async fn test_malformed_unsolicited_process_frames_are_ignored() {
     let (host_stream, mut guest) = make_pair();
 
@@ -581,6 +622,48 @@ async fn test_spawn_watch_exit_result_survives_close_before_wait() {
     assert_eq!(event.exit_code, 3);
     assert_eq!(event.stdout, b"early-output");
     assert_eq!(event.stderr, b"err");
+}
+
+#[tokio::test]
+async fn test_malformed_active_process_exit_closes_and_cleans_up() {
+    let (host_stream, mut guest) = make_pair();
+
+    tokio::spawn(async move {
+        let mut decoder = Decoder::new();
+        mock_handshake(&mut guest, &mut decoder).await;
+
+        let mut buf = [0u8; 4096];
+        let n = guest.read(&mut buf).await.unwrap();
+        let msgs = decoder.decode(&buf[..n]).unwrap();
+        assert_eq!(msgs[0].msg_type, MSG_SPAWN_WATCH);
+        let spawn_seq = msgs[0].seq;
+
+        let result_payload = vsock_proto::encode_spawn_watch_result(123);
+        let result =
+            vsock_proto::encode(MSG_SPAWN_WATCH_RESULT, spawn_seq, &result_payload).unwrap();
+        let bad_exit = vsock_proto::encode(MSG_PROCESS_EXIT, spawn_seq, b"\x00").unwrap();
+        let mut combined = result;
+        combined.extend_from_slice(&bad_exit);
+        guest.write_all(&combined).await.unwrap();
+
+        let mut discard = [0u8; 1];
+        let _ = guest.read(&mut discard).await;
+    });
+
+    let host = host_from_stream(host_stream).await.unwrap();
+    let handle = host
+        .spawn_watch("malformed-exit", 0, &[], false, false, None)
+        .await
+        .unwrap();
+    assert_eq!(handle.pid(), 123);
+
+    let err = wait_spawn(handle).await.unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::ConnectionReset);
+    assert_eq!(
+        registration_counts(&host),
+        (0, 0, 0),
+        "malformed active process_exit must close and clean registrations",
+    );
 }
 
 #[tokio::test]

--- a/crates/vsock-host/src/tests/process.rs
+++ b/crates/vsock-host/src/tests/process.rs
@@ -900,6 +900,49 @@ async fn test_mismatched_active_stdout_chunk_pid_closes_and_cleans_up() {
 }
 
 #[tokio::test]
+async fn test_buffered_active_stdout_chunk_closes_and_cleans_up() {
+    let (host_stream, mut guest) = make_pair();
+
+    tokio::spawn(async move {
+        let mut decoder = Decoder::new();
+        mock_handshake(&mut guest, &mut decoder).await;
+
+        let mut buf = [0u8; 4096];
+        let n = guest.read(&mut buf).await.unwrap();
+        let msgs = decoder.decode(&buf[..n]).unwrap();
+        assert_eq!(msgs[0].msg_type, MSG_SPAWN_WATCH);
+        let spawn_seq = msgs[0].seq;
+
+        let result_payload = vsock_proto::encode_spawn_watch_result(123);
+        let result =
+            vsock_proto::encode(MSG_SPAWN_WATCH_RESULT, spawn_seq, &result_payload).unwrap();
+        let chunk_payload = vsock_proto::encode_stdout_chunk(123, b"unexpected stream");
+        let chunk = vsock_proto::encode(MSG_STDOUT_CHUNK, spawn_seq, &chunk_payload).unwrap();
+        let mut combined = result;
+        combined.extend_from_slice(&chunk);
+        guest.write_all(&combined).await.unwrap();
+
+        let mut discard = [0u8; 1];
+        let _ = guest.read(&mut discard).await;
+    });
+
+    let host = host_from_stream(host_stream).await.unwrap();
+    let handle = host
+        .spawn_watch("buffered-bad-stdout", 0, &[], false, false, None)
+        .await
+        .unwrap();
+    assert_eq!(handle.pid(), 123);
+
+    let err = wait_spawn(handle).await.unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::ConnectionReset);
+    assert_eq!(
+        registration_counts(&host),
+        (0, 0, 0),
+        "stdout_chunk for buffered spawn_watch must close and clean registrations",
+    );
+}
+
+#[tokio::test]
 async fn test_duplicate_spawn_watch_result_cannot_overwrite_pid() {
     let (host_stream, mut guest) = make_pair();
 

--- a/crates/vsock-host/src/tests/process.rs
+++ b/crates/vsock-host/src/tests/process.rs
@@ -359,6 +359,80 @@ async fn test_dropped_stdout_receiver_removes_stream_sender() {
 }
 
 #[tokio::test]
+async fn test_wait_drops_unclaimed_stdout_receiver() {
+    let (host_stream, mut guest) = make_pair();
+    let send_chunk = Arc::new(Notify::new());
+    let send_exit = Arc::new(Notify::new());
+
+    {
+        let send_chunk = Arc::clone(&send_chunk);
+        let send_exit = Arc::clone(&send_exit);
+        tokio::spawn(async move {
+            let mut decoder = Decoder::new();
+            mock_handshake(&mut guest, &mut decoder).await;
+
+            let mut buf = [0u8; 4096];
+            let n = guest.read(&mut buf).await.unwrap();
+            let msgs = decoder.decode(&buf[..n]).unwrap();
+            assert_eq!(msgs[0].msg_type, MSG_SPAWN_WATCH);
+            let spawn_seq = msgs[0].seq;
+
+            let payload = vsock_proto::encode_spawn_watch_result(556);
+            let resp = vsock_proto::encode(MSG_SPAWN_WATCH_RESULT, spawn_seq, &payload).unwrap();
+            guest.write_all(&resp).await.unwrap();
+
+            send_chunk.notified().await;
+            let chunk_payload = vsock_proto::encode_stdout_chunk(556, b"unclaimed chunk");
+            let chunk = vsock_proto::encode(MSG_STDOUT_CHUNK, spawn_seq, &chunk_payload).unwrap();
+            guest.write_all(&chunk).await.unwrap();
+
+            send_exit.notified().await;
+            let exit_payload = vsock_proto::encode_process_exit(556, 0, b"", b"");
+            let exit_msg = vsock_proto::encode(MSG_PROCESS_EXIT, spawn_seq, &exit_payload).unwrap();
+            guest.write_all(&exit_msg).await.unwrap();
+
+            let mut discard = [0u8; 1];
+            let _ = guest.read(&mut discard).await;
+        });
+    }
+
+    let host = host_from_stream(host_stream).await.unwrap();
+    let handle = host
+        .spawn_watch("streaming", 0, &[], false, true, None)
+        .await
+        .unwrap();
+    assert_eq!(handle.pid(), 556);
+    assert_eq!(registration_counts(&host), (0, 1, 1));
+
+    let wait = handle.wait();
+    tokio::pin!(wait);
+    tokio::select! {
+        biased;
+        result = &mut wait => panic!("spawn wait completed before exit: {result:?}"),
+        _ = tokio::task::yield_now() => {}
+    }
+
+    send_chunk.notify_one();
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            if registration_counts(&host) == (0, 1, 0) {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("wait should drop unclaimed stdout receiver before buffering chunks");
+
+    send_exit.notify_one();
+    let event = tokio::time::timeout(Duration::from_secs(5), &mut wait)
+        .await
+        .expect("spawn wait should complete")
+        .unwrap();
+    assert_eq!(event.exit_code, 0);
+}
+
+#[tokio::test]
 async fn test_spawn_watch_cancel_cleans_up_registrations() {
     let (host_stream, mut guest) = make_pair();
     let request_seen = Arc::new(Notify::new());

--- a/crates/vsock-host/src/tests/process.rs
+++ b/crates/vsock-host/src/tests/process.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use super::support::{host_from_stream, make_pair, mock_handshake, send_command_result};
-use crate::{ConnectionState, VsockHost};
+use crate::{ConnectionState, SpawnWatchHandle, VsockHost};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::sync::{Notify, oneshot};
 use tokio::time::Instant;
@@ -18,11 +18,17 @@ fn registration_counts(host: &VsockHost) -> (usize, usize, usize) {
         ConnectionState::Connected {
             pending, process, ..
         } => {
-            let (pending_stdout, stdout_senders) = process.registration_counts();
-            (pending.len(), pending_stdout, stdout_senders)
+            let (operations, stdout_senders) = process.registration_counts();
+            (pending.len(), operations, stdout_senders)
         }
         ConnectionState::Closed { .. } => (0, 0, 0),
     }
+}
+
+async fn wait_spawn(handle: SpawnWatchHandle) -> io::Result<crate::ProcessExitEvent> {
+    tokio::time::timeout(Duration::from_secs(5), handle.wait())
+        .await
+        .expect("spawn_watch exit should arrive before timeout")
 }
 
 #[tokio::test]
@@ -37,13 +43,14 @@ async fn test_spawn_watch_and_wait() {
         let n = guest.read(&mut buf).await.unwrap();
         let msgs = decoder.decode(&buf[..n]).unwrap();
         assert_eq!(msgs[0].msg_type, MSG_SPAWN_WATCH);
+        let spawn_seq = msgs[0].seq;
 
         let payload = vsock_proto::encode_spawn_watch_result(42);
-        let resp = vsock_proto::encode(MSG_SPAWN_WATCH_RESULT, msgs[0].seq, &payload).unwrap();
+        let resp = vsock_proto::encode(MSG_SPAWN_WATCH_RESULT, spawn_seq, &payload).unwrap();
         guest.write_all(&resp).await.unwrap();
 
         let exit_payload = vsock_proto::encode_process_exit(42, 0, b"done", b"");
-        let exit_msg = vsock_proto::encode(MSG_PROCESS_EXIT, 0, &exit_payload).unwrap();
+        let exit_msg = vsock_proto::encode(MSG_PROCESS_EXIT, spawn_seq, &exit_payload).unwrap();
         guest.write_all(&exit_msg).await.unwrap();
 
         let mut discard = [0u8; 1];
@@ -51,27 +58,24 @@ async fn test_spawn_watch_and_wait() {
     });
 
     let host = host_from_stream(host_stream).await.unwrap();
-    let (pid, mut stdout_rx) = host
+    let mut handle = host
         .spawn_watch("sleep 1", 0, &[], false, false, None)
         .await
         .unwrap();
-    assert_eq!(pid, 42);
+    assert_eq!(handle.pid(), 42);
     assert!(
-        stdout_rx.recv().await.is_none(),
+        handle.take_stdout_receiver().is_none(),
         "buffered spawn_watch must not keep a stdout stream registered",
     );
 
-    let event = host
-        .wait_for_exit(42, Duration::from_secs(5))
-        .await
-        .unwrap();
+    let event = wait_spawn(handle).await.unwrap();
     assert_eq!(event.pid, 42);
     assert_eq!(event.exit_code, 0);
     assert_eq!(event.stdout, b"done");
 }
 
 #[tokio::test]
-async fn test_cached_exit_event() {
+async fn test_exit_event_before_wait() {
     let (host_stream, mut guest) = make_pair();
 
     tokio::spawn(async move {
@@ -82,11 +86,12 @@ async fn test_cached_exit_event() {
         let n = guest.read(&mut buf).await.unwrap();
         let msgs = decoder.decode(&buf[..n]).unwrap();
         assert_eq!(msgs[0].msg_type, MSG_SPAWN_WATCH);
+        let spawn_seq = msgs[0].seq;
 
         let payload = vsock_proto::encode_spawn_watch_result(99);
-        let resp = vsock_proto::encode(MSG_SPAWN_WATCH_RESULT, msgs[0].seq, &payload).unwrap();
+        let resp = vsock_proto::encode(MSG_SPAWN_WATCH_RESULT, spawn_seq, &payload).unwrap();
         let exit_payload = vsock_proto::encode_process_exit(99, 1, b"", b"error");
-        let exit_msg = vsock_proto::encode(MSG_PROCESS_EXIT, 0, &exit_payload).unwrap();
+        let exit_msg = vsock_proto::encode(MSG_PROCESS_EXIT, spawn_seq, &exit_payload).unwrap();
 
         let mut combined = resp;
         combined.extend_from_slice(&exit_msg);
@@ -97,16 +102,13 @@ async fn test_cached_exit_event() {
     });
 
     let host = host_from_stream(host_stream).await.unwrap();
-    let (pid, _stdout_rx) = host
+    let handle = host
         .spawn_watch("false", 0, &[], false, false, None)
         .await
         .unwrap();
-    assert_eq!(pid, 99);
+    assert_eq!(handle.pid(), 99);
 
-    let event = host
-        .wait_for_exit(99, Duration::from_secs(5))
-        .await
-        .unwrap();
+    let event = wait_spawn(handle).await.unwrap();
     assert_eq!(event.exit_code, 1);
     assert_eq!(event.stderr, b"error");
 }
@@ -149,14 +151,14 @@ async fn test_spawn_watch_error_response_cleans_up() {
     assert_eq!(
         registration_counts(&host),
         (0, 0, 0),
-        "streaming spawn_watch error must clean pending stdout registration",
+        "streaming spawn_watch error must clean operation registration",
     );
 
-    let (pid, _stdout_rx) = host
+    let handle = host
         .spawn_watch("good-cmd", 0, &[], false, false, None)
         .await
         .unwrap();
-    assert_eq!(pid, 222);
+    assert_eq!(handle.pid(), 222);
 }
 
 #[tokio::test]
@@ -196,14 +198,14 @@ async fn test_spawn_watch_malformed_result_cleans_up() {
     assert_eq!(
         registration_counts(&host),
         (0, 0, 0),
-        "malformed streaming spawn_watch result must clean pending stdout registration",
+        "malformed streaming spawn_watch result must clean operation registration",
     );
 
-    let (pid, _stdout_rx) = host
+    let handle = host
         .spawn_watch("good-cmd", 0, &[], false, false, None)
         .await
         .unwrap();
-    assert_eq!(pid, 333);
+    assert_eq!(handle.pid(), 333);
 }
 
 #[tokio::test]
@@ -224,13 +226,14 @@ async fn test_malformed_unsolicited_process_frames_are_ignored() {
         let n = guest.read(&mut buf).await.unwrap();
         let msgs = decoder.decode(&buf[..n]).unwrap();
         assert_eq!(msgs[0].msg_type, MSG_SPAWN_WATCH);
+        let spawn_seq = msgs[0].seq;
 
         let payload = vsock_proto::encode_spawn_watch_result(444);
-        let resp = vsock_proto::encode(MSG_SPAWN_WATCH_RESULT, msgs[0].seq, &payload).unwrap();
+        let resp = vsock_proto::encode(MSG_SPAWN_WATCH_RESULT, spawn_seq, &payload).unwrap();
         guest.write_all(&resp).await.unwrap();
 
         let exit_payload = vsock_proto::encode_process_exit(444, 0, b"after-malformed", b"");
-        let exit_msg = vsock_proto::encode(MSG_PROCESS_EXIT, 0, &exit_payload).unwrap();
+        let exit_msg = vsock_proto::encode(MSG_PROCESS_EXIT, spawn_seq, &exit_payload).unwrap();
         guest.write_all(&exit_msg).await.unwrap();
 
         let mut discard = [0u8; 1];
@@ -238,22 +241,19 @@ async fn test_malformed_unsolicited_process_frames_are_ignored() {
     });
 
     let host = host_from_stream(host_stream).await.unwrap();
-    let (pid, _stdout_rx) = host
+    let handle = host
         .spawn_watch("after-malformed", 0, &[], false, false, None)
         .await
         .unwrap();
-    assert_eq!(pid, 444);
+    assert_eq!(handle.pid(), 444);
 
-    let event = host
-        .wait_for_exit(pid, Duration::from_secs(5))
-        .await
-        .unwrap();
+    let event = wait_spawn(handle).await.unwrap();
     assert_eq!(event.exit_code, 0);
     assert_eq!(event.stdout, b"after-malformed");
 }
 
 #[tokio::test]
-async fn test_dropped_stdout_receiver_removes_stream_registration() {
+async fn test_dropped_stdout_receiver_removes_stream_sender() {
     let (host_stream, mut guest) = make_pair();
     let send_chunk = Arc::new(Notify::new());
     let send_exit = Arc::new(Notify::new());
@@ -269,19 +269,20 @@ async fn test_dropped_stdout_receiver_removes_stream_registration() {
             let n = guest.read(&mut buf).await.unwrap();
             let msgs = decoder.decode(&buf[..n]).unwrap();
             assert_eq!(msgs[0].msg_type, MSG_SPAWN_WATCH);
+            let spawn_seq = msgs[0].seq;
 
             let payload = vsock_proto::encode_spawn_watch_result(555);
-            let resp = vsock_proto::encode(MSG_SPAWN_WATCH_RESULT, msgs[0].seq, &payload).unwrap();
+            let resp = vsock_proto::encode(MSG_SPAWN_WATCH_RESULT, spawn_seq, &payload).unwrap();
             guest.write_all(&resp).await.unwrap();
 
             send_chunk.notified().await;
             let chunk_payload = vsock_proto::encode_stdout_chunk(555, b"orphaned chunk");
-            let chunk = vsock_proto::encode(MSG_STDOUT_CHUNK, 0, &chunk_payload).unwrap();
+            let chunk = vsock_proto::encode(MSG_STDOUT_CHUNK, spawn_seq, &chunk_payload).unwrap();
             guest.write_all(&chunk).await.unwrap();
 
             send_exit.notified().await;
             let exit_payload = vsock_proto::encode_process_exit(555, 0, b"", b"");
-            let exit_msg = vsock_proto::encode(MSG_PROCESS_EXIT, 0, &exit_payload).unwrap();
+            let exit_msg = vsock_proto::encode(MSG_PROCESS_EXIT, spawn_seq, &exit_payload).unwrap();
             guest.write_all(&exit_msg).await.unwrap();
 
             let mut discard = [0u8; 1];
@@ -290,32 +291,29 @@ async fn test_dropped_stdout_receiver_removes_stream_registration() {
     }
 
     let host = host_from_stream(host_stream).await.unwrap();
-    let (pid, stdout_rx) = host
+    let mut handle = host
         .spawn_watch("streaming", 0, &[], false, true, None)
         .await
         .unwrap();
-    assert_eq!(pid, 555);
-    assert_eq!(registration_counts(&host), (0, 0, 1));
+    assert_eq!(handle.pid(), 555);
+    assert_eq!(registration_counts(&host), (0, 1, 1));
 
-    drop(stdout_rx);
+    drop(handle.take_stdout_receiver());
     send_chunk.notify_one();
 
     tokio::time::timeout(Duration::from_secs(5), async {
         loop {
-            if registration_counts(&host) == (0, 0, 0) {
+            if registration_counts(&host) == (0, 1, 0) {
                 break;
             }
             tokio::task::yield_now().await;
         }
     })
     .await
-    .expect("dropped stdout receiver should remove stream registration");
+    .expect("dropped stdout receiver should remove stream sender");
 
     send_exit.notify_one();
-    let event = host
-        .wait_for_exit(pid, Duration::from_secs(5))
-        .await
-        .unwrap();
+    let event = wait_spawn(handle).await.unwrap();
     assert_eq!(event.exit_code, 0);
 }
 
@@ -353,7 +351,7 @@ async fn test_spawn_watch_cancel_cleans_up_registrations() {
     tokio::time::timeout(Duration::from_secs(5), request_seen.notified())
         .await
         .expect("guest should receive spawn_watch request");
-    assert_eq!(registration_counts(&host), (1, 1, 0));
+    assert_eq!(registration_counts(&host), (1, 1, 1));
 
     task.abort();
     let _ = task.await;
@@ -403,7 +401,7 @@ async fn test_spawn_watch_after_close_returns_immediately() {
 }
 
 #[tokio::test]
-async fn test_wait_for_exit_no_lost_notification() {
+async fn test_spawn_watch_exit_before_wait() {
     let (host_stream, mut guest) = make_pair();
 
     tokio::spawn(async move {
@@ -414,13 +412,14 @@ async fn test_wait_for_exit_no_lost_notification() {
         let n = guest.read(&mut buf).await.unwrap();
         let msgs = decoder.decode(&buf[..n]).unwrap();
         assert_eq!(msgs[0].msg_type, MSG_SPAWN_WATCH);
+        let spawn_seq = msgs[0].seq;
 
         let payload = vsock_proto::encode_spawn_watch_result(88);
-        let resp = vsock_proto::encode(MSG_SPAWN_WATCH_RESULT, msgs[0].seq, &payload).unwrap();
+        let resp = vsock_proto::encode(MSG_SPAWN_WATCH_RESULT, spawn_seq, &payload).unwrap();
         guest.write_all(&resp).await.unwrap();
 
         let exit_payload = vsock_proto::encode_process_exit(88, 7, b"quick", b"");
-        let exit_msg = vsock_proto::encode(MSG_PROCESS_EXIT, 0, &exit_payload).unwrap();
+        let exit_msg = vsock_proto::encode(MSG_PROCESS_EXIT, spawn_seq, &exit_payload).unwrap();
         guest.write_all(&exit_msg).await.unwrap();
 
         let mut discard = [0u8; 1];
@@ -428,23 +427,20 @@ async fn test_wait_for_exit_no_lost_notification() {
     });
 
     let host = host_from_stream(host_stream).await.unwrap();
-    let (pid, _stdout_rx) = host
+    let handle = host
         .spawn_watch("quick-exit", 0, &[], false, false, None)
         .await
         .unwrap();
-    assert_eq!(pid, 88);
+    assert_eq!(handle.pid(), 88);
 
-    let event = host
-        .wait_for_exit(88, Duration::from_secs(5))
-        .await
-        .unwrap();
+    let event = wait_spawn(handle).await.unwrap();
     assert_eq!(event.pid, 88);
     assert_eq!(event.exit_code, 7);
     assert_eq!(event.stdout, b"quick");
 }
 
 #[tokio::test]
-async fn test_wait_for_exit_connection_closed() {
+async fn test_spawn_watch_connection_closed_while_waiting() {
     let (host_stream, mut guest) = make_pair();
     let (close_tx, close_rx) = oneshot::channel();
 
@@ -465,19 +461,14 @@ async fn test_wait_for_exit_connection_closed() {
         drop(guest);
     });
 
-    let host = Arc::new(host_from_stream(host_stream).await.unwrap());
-    let (pid, _stdout_rx) = host
+    let host = host_from_stream(host_stream).await.unwrap();
+    let handle = host
         .spawn_watch("long-running", 0, &[], false, false, None)
         .await
         .unwrap();
-    assert_eq!(pid, 77);
+    assert_eq!(handle.pid(), 77);
 
-    let host_for_wait = Arc::clone(&host);
-    let wait_task = tokio::spawn(async move {
-        host_for_wait
-            .wait_for_exit(77, Duration::from_secs(5))
-            .await
-    });
+    let wait_task = tokio::spawn(async move { handle.wait().await });
     close_tx.send(()).unwrap();
 
     let err = wait_task.await.unwrap().unwrap_err();
@@ -485,7 +476,7 @@ async fn test_wait_for_exit_connection_closed() {
 }
 
 #[tokio::test]
-async fn test_wait_for_exit_returns_cached_event_after_close() {
+async fn test_spawn_watch_exit_result_survives_close_before_wait() {
     let (host_stream, mut guest) = make_pair();
 
     tokio::spawn(async move {
@@ -496,12 +487,13 @@ async fn test_wait_for_exit_returns_cached_event_after_close() {
         let n = guest.read(&mut buf).await.unwrap();
         let msgs = decoder.decode(&buf[..n]).unwrap();
         assert_eq!(msgs[0].msg_type, MSG_SPAWN_WATCH);
+        let spawn_seq = msgs[0].seq;
 
         let result_payload = vsock_proto::encode_spawn_watch_result(111);
         let result =
-            vsock_proto::encode(MSG_SPAWN_WATCH_RESULT, msgs[0].seq, &result_payload).unwrap();
-        let exit_payload = vsock_proto::encode_process_exit(111, 3, b"cached-output", b"err");
-        let exit_msg = vsock_proto::encode(MSG_PROCESS_EXIT, 0, &exit_payload).unwrap();
+            vsock_proto::encode(MSG_SPAWN_WATCH_RESULT, spawn_seq, &result_payload).unwrap();
+        let exit_payload = vsock_proto::encode_process_exit(111, 3, b"early-output", b"err");
+        let exit_msg = vsock_proto::encode(MSG_PROCESS_EXIT, spawn_seq, &exit_payload).unwrap();
 
         let mut combined = result;
         combined.extend_from_slice(&exit_msg);
@@ -510,28 +502,27 @@ async fn test_wait_for_exit_returns_cached_event_after_close() {
     });
 
     let host = host_from_stream(host_stream).await.unwrap();
-    let (pid, _stdout_rx) = host
+    let handle = host
         .spawn_watch("quick-exit", 0, &[], false, false, None)
         .await
         .unwrap();
-    assert_eq!(pid, 111);
+    assert_eq!(handle.pid(), 111);
 
     host.wait_until_closed(Duration::from_secs(5))
         .await
         .unwrap();
 
-    let event = host
-        .wait_for_exit(pid, Duration::from_secs(5))
+    let event = wait_spawn(handle)
         .await
-        .expect("cached exit event must survive the Connected -> Closed transition");
+        .expect("exit result held by handle must survive connection close");
     assert_eq!(event.pid, 111);
     assert_eq!(event.exit_code, 3);
-    assert_eq!(event.stdout, b"cached-output");
+    assert_eq!(event.stdout, b"early-output");
     assert_eq!(event.stderr, b"err");
 }
 
 #[tokio::test]
-async fn test_wait_for_exit_timeout() {
+async fn test_spawn_watch_wait_timeout_drops_registration() {
     let (host_stream, mut guest) = make_pair();
 
     tokio::spawn(async move {
@@ -550,17 +541,89 @@ async fn test_wait_for_exit_timeout() {
     });
 
     let host = host_from_stream(host_stream).await.unwrap();
-    let (pid, _stdout_rx) = host
+    let handle = host
         .spawn_watch("long-running", 0, &[], false, false, None)
         .await
         .unwrap();
-    assert_eq!(pid, 55);
+    assert_eq!(handle.pid(), 55);
 
-    let err = host
-        .wait_for_exit(pid, Duration::from_millis(100))
+    tokio::time::timeout(Duration::from_millis(100), handle.wait())
         .await
         .unwrap_err();
-    assert_eq!(err.kind(), io::ErrorKind::TimedOut);
+    assert_eq!(registration_counts(&host), (0, 0, 0));
+}
+
+#[tokio::test]
+async fn test_concurrent_spawn_watch_routes_by_seq_not_pid() {
+    let (host_stream, mut guest) = make_pair();
+
+    tokio::spawn(async move {
+        let mut decoder = Decoder::new();
+        mock_handshake(&mut guest, &mut decoder).await;
+
+        let mut buf = [0u8; 4096];
+
+        let n = guest.read(&mut buf).await.unwrap();
+        let msgs = decoder.decode(&buf[..n]).unwrap();
+        assert_eq!(msgs[0].msg_type, MSG_SPAWN_WATCH);
+        let first_seq = msgs[0].seq;
+        let payload = vsock_proto::encode_spawn_watch_result(999);
+        let resp = vsock_proto::encode(MSG_SPAWN_WATCH_RESULT, first_seq, &payload).unwrap();
+        guest.write_all(&resp).await.unwrap();
+
+        let n = guest.read(&mut buf).await.unwrap();
+        let msgs = decoder.decode(&buf[..n]).unwrap();
+        assert_eq!(msgs[0].msg_type, MSG_SPAWN_WATCH);
+        let second_seq = msgs[0].seq;
+        let payload = vsock_proto::encode_spawn_watch_result(999);
+        let resp = vsock_proto::encode(MSG_SPAWN_WATCH_RESULT, second_seq, &payload).unwrap();
+        guest.write_all(&resp).await.unwrap();
+
+        let second_chunk_payload = vsock_proto::encode_stdout_chunk(999, b"second");
+        let first_chunk_payload = vsock_proto::encode_stdout_chunk(999, b"first");
+        let second_exit_payload = vsock_proto::encode_process_exit(999, 22, b"", b"second err");
+        let first_exit_payload = vsock_proto::encode_process_exit(999, 11, b"", b"first err");
+
+        let mut frames =
+            vsock_proto::encode(MSG_STDOUT_CHUNK, second_seq, &second_chunk_payload).unwrap();
+        frames.extend_from_slice(
+            &vsock_proto::encode(MSG_STDOUT_CHUNK, first_seq, &first_chunk_payload).unwrap(),
+        );
+        frames.extend_from_slice(
+            &vsock_proto::encode(MSG_PROCESS_EXIT, second_seq, &second_exit_payload).unwrap(),
+        );
+        frames.extend_from_slice(
+            &vsock_proto::encode(MSG_PROCESS_EXIT, first_seq, &first_exit_payload).unwrap(),
+        );
+        guest.write_all(&frames).await.unwrap();
+
+        let mut discard = [0u8; 1];
+        let _ = guest.read(&mut discard).await;
+    });
+
+    let host = host_from_stream(host_stream).await.unwrap();
+    let mut first = host
+        .spawn_watch("first", 0, &[], false, true, None)
+        .await
+        .unwrap();
+    let mut second = host
+        .spawn_watch("second", 0, &[], false, true, None)
+        .await
+        .unwrap();
+    assert_eq!(first.pid(), 999);
+    assert_eq!(second.pid(), 999);
+
+    let mut first_stdout = first.take_stdout_receiver().unwrap();
+    let mut second_stdout = second.take_stdout_receiver().unwrap();
+    assert_eq!(second_stdout.recv().await.unwrap(), b"second");
+    assert_eq!(first_stdout.recv().await.unwrap(), b"first");
+
+    let second_exit = wait_spawn(second).await.unwrap();
+    let first_exit = wait_spawn(first).await.unwrap();
+    assert_eq!(second_exit.exit_code, 22);
+    assert_eq!(second_exit.stderr, b"second err");
+    assert_eq!(first_exit.exit_code, 11);
+    assert_eq!(first_exit.stderr, b"first err");
 }
 
 #[tokio::test]
@@ -598,7 +661,7 @@ async fn test_concurrent_exec_and_wait_exit() {
 
         let _ = exit_after_exec.await;
         let exit_payload = vsock_proto::encode_process_exit(50, 42, b"exited", b"");
-        let exit_msg = vsock_proto::encode(MSG_PROCESS_EXIT, 0, &exit_payload).unwrap();
+        let exit_msg = vsock_proto::encode(MSG_PROCESS_EXIT, spawn_seq, &exit_payload).unwrap();
         guest.write_all(&exit_msg).await.unwrap();
 
         let mut discard = [0u8; 1];
@@ -606,15 +669,13 @@ async fn test_concurrent_exec_and_wait_exit() {
     });
 
     let host = Arc::new(host_from_stream(host_stream).await.unwrap());
-    let (pid, _stdout_rx) = host
+    let handle = host
         .spawn_watch("long-running", 0, &[], false, false, None)
         .await
         .unwrap();
-    assert_eq!(pid, 50);
+    assert_eq!(handle.pid(), 50);
 
-    let host2 = Arc::clone(&host);
-    let wait_task =
-        tokio::spawn(async move { host2.wait_for_exit(50, Duration::from_secs(5)).await });
+    let wait_task = tokio::spawn(async move { handle.wait().await });
 
     let exec_result = host
         .exec("echo concurrent", 5000, &[], false)

--- a/crates/vsock-host/src/tests/process.rs
+++ b/crates/vsock-host/src/tests/process.rs
@@ -584,7 +584,7 @@ async fn test_spawn_watch_exit_result_survives_close_before_wait() {
 }
 
 #[tokio::test]
-async fn test_spawn_watch_wait_timeout_drops_registration() {
+async fn test_spawn_watch_wait_future_drop_cleans_registration() {
     let (host_stream, mut guest) = make_pair();
 
     tokio::spawn(async move {
@@ -609,9 +609,8 @@ async fn test_spawn_watch_wait_timeout_drops_registration() {
         .unwrap();
     assert_eq!(handle.pid(), 55);
 
-    tokio::time::timeout(Duration::from_millis(100), handle.wait())
-        .await
-        .unwrap_err();
+    let wait = handle.wait();
+    drop(wait);
     assert_eq!(registration_counts(&host), (0, 0, 0));
 }
 

--- a/crates/vsock-host/src/tests/process.rs
+++ b/crates/vsock-host/src/tests/process.rs
@@ -6,7 +6,6 @@ use super::support::{host_from_stream, make_pair, mock_handshake, send_command_r
 use crate::{ConnectionState, SpawnWatchHandle, VsockHost};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::sync::{Notify, oneshot};
-use tokio::time::Instant;
 use vsock_proto::{
     CommandTermination, Decoder, MSG_COMMAND_START, MSG_ERROR, MSG_PROCESS_EXIT, MSG_SPAWN_WATCH,
     MSG_SPAWN_WATCH_RESULT, MSG_STDOUT_CHUNK,
@@ -617,11 +616,13 @@ async fn test_spawn_watch_after_close_returns_immediately() {
         .await
         .unwrap();
 
-    let start = Instant::now();
-    let err = host
-        .spawn_watch("long-running", 0, &[], false, false, None)
-        .await
-        .unwrap_err();
+    let err = tokio::time::timeout(
+        Duration::from_secs(5),
+        host.spawn_watch("long-running", 0, &[], false, false, None),
+    )
+    .await
+    .expect("spawn_watch should return when the connection is already closed")
+    .unwrap_err();
     assert!(
         matches!(
             err.kind(),
@@ -629,11 +630,6 @@ async fn test_spawn_watch_after_close_returns_immediately() {
         ),
         "expected ConnectionReset or BrokenPipe, got {:?}",
         err.kind()
-    );
-    assert!(
-        start.elapsed() < Duration::from_secs(1),
-        "spawn_watch should fail immediately, took {:?}",
-        start.elapsed()
     );
 }
 

--- a/crates/vsock-host/src/tests/process.rs
+++ b/crates/vsock-host/src/tests/process.rs
@@ -365,6 +365,68 @@ async fn test_spawn_watch_cancel_cleans_up_registrations() {
 }
 
 #[tokio::test]
+async fn test_late_malformed_lifecycle_after_handle_drop_is_ignored() {
+    let (host_stream, mut guest) = make_pair();
+    let release_late_frames = Arc::new(Notify::new());
+
+    {
+        let release_late_frames = Arc::clone(&release_late_frames);
+        tokio::spawn(async move {
+            let mut decoder = Decoder::new();
+            mock_handshake(&mut guest, &mut decoder).await;
+
+            let mut buf = [0u8; 4096];
+            let n = guest.read(&mut buf).await.unwrap();
+            let msgs = decoder.decode(&buf[..n]).unwrap();
+            assert_eq!(msgs[0].msg_type, MSG_SPAWN_WATCH);
+            let dropped_seq = msgs[0].seq;
+            let payload = vsock_proto::encode_spawn_watch_result(66);
+            let resp = vsock_proto::encode(MSG_SPAWN_WATCH_RESULT, dropped_seq, &payload).unwrap();
+            guest.write_all(&resp).await.unwrap();
+
+            release_late_frames.notified().await;
+            let bad_stdout = vsock_proto::encode(MSG_STDOUT_CHUNK, dropped_seq, b"\x00").unwrap();
+            let bad_exit = vsock_proto::encode(MSG_PROCESS_EXIT, dropped_seq, b"\x00").unwrap();
+            guest.write_all(&bad_stdout).await.unwrap();
+            guest.write_all(&bad_exit).await.unwrap();
+
+            let n = guest.read(&mut buf).await.unwrap();
+            let msgs = decoder.decode(&buf[..n]).unwrap();
+            assert_eq!(msgs[0].msg_type, MSG_SPAWN_WATCH);
+            let next_seq = msgs[0].seq;
+            let payload = vsock_proto::encode_spawn_watch_result(67);
+            let resp = vsock_proto::encode(MSG_SPAWN_WATCH_RESULT, next_seq, &payload).unwrap();
+            guest.write_all(&resp).await.unwrap();
+            let exit_payload = vsock_proto::encode_process_exit(67, 0, b"still-alive", b"");
+            let exit_msg = vsock_proto::encode(MSG_PROCESS_EXIT, next_seq, &exit_payload).unwrap();
+            guest.write_all(&exit_msg).await.unwrap();
+
+            let mut discard = [0u8; 1];
+            let _ = guest.read(&mut discard).await;
+        });
+    }
+
+    let host = host_from_stream(host_stream).await.unwrap();
+    let handle = host
+        .spawn_watch("drop-before-late-frame", 0, &[], false, true, None)
+        .await
+        .unwrap();
+    assert_eq!(handle.pid(), 66);
+    drop(handle);
+    assert_eq!(registration_counts(&host), (0, 0, 0));
+
+    release_late_frames.notify_one();
+
+    let next = host
+        .spawn_watch("next-spawn", 0, &[], false, false, None)
+        .await
+        .unwrap();
+    let event = wait_spawn(next).await.unwrap();
+    assert_eq!(event.pid, 67);
+    assert_eq!(event.stdout, b"still-alive");
+}
+
+#[tokio::test]
 async fn test_spawn_watch_after_close_returns_immediately() {
     let (host_stream, mut guest) = make_pair();
 

--- a/crates/vsock-host/src/tests/process.rs
+++ b/crates/vsock-host/src/tests/process.rs
@@ -888,6 +888,49 @@ async fn test_duplicate_spawn_watch_result_cannot_overwrite_pid() {
 }
 
 #[tokio::test]
+async fn test_duplicate_spawn_watch_result_same_pid_closes_and_cleans_up() {
+    let (host_stream, mut guest) = make_pair();
+
+    tokio::spawn(async move {
+        let mut decoder = Decoder::new();
+        mock_handshake(&mut guest, &mut decoder).await;
+
+        let mut buf = [0u8; 4096];
+        let n = guest.read(&mut buf).await.unwrap();
+        let msgs = decoder.decode(&buf[..n]).unwrap();
+        assert_eq!(msgs[0].msg_type, MSG_SPAWN_WATCH);
+        let spawn_seq = msgs[0].seq;
+
+        let result_payload = vsock_proto::encode_spawn_watch_result(123);
+        let result =
+            vsock_proto::encode(MSG_SPAWN_WATCH_RESULT, spawn_seq, &result_payload).unwrap();
+        guest.write_all(&result).await.unwrap();
+
+        let duplicate =
+            vsock_proto::encode(MSG_SPAWN_WATCH_RESULT, spawn_seq, &result_payload).unwrap();
+        guest.write_all(&duplicate).await.unwrap();
+
+        let mut discard = [0u8; 1];
+        let _ = guest.read(&mut discard).await;
+    });
+
+    let host = host_from_stream(host_stream).await.unwrap();
+    let handle = host
+        .spawn_watch("duplicate-same-pid-result", 0, &[], false, false, None)
+        .await
+        .unwrap();
+    assert_eq!(handle.pid(), 123);
+
+    let err = wait_spawn(handle).await.unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::ConnectionReset);
+    assert_eq!(
+        registration_counts(&host),
+        (0, 0, 0),
+        "duplicate same-pid spawn_watch_result must close and clean registrations",
+    );
+}
+
+#[tokio::test]
 async fn test_malformed_duplicate_spawn_watch_result_closes_and_cleans_up() {
     let (host_stream, mut guest) = make_pair();
 

--- a/crates/vsock-host/src/tests/process.rs
+++ b/crates/vsock-host/src/tests/process.rs
@@ -667,6 +667,93 @@ async fn test_malformed_active_process_exit_closes_and_cleans_up() {
 }
 
 #[tokio::test]
+async fn test_mismatched_active_process_exit_pid_closes_and_cleans_up() {
+    let (host_stream, mut guest) = make_pair();
+
+    tokio::spawn(async move {
+        let mut decoder = Decoder::new();
+        mock_handshake(&mut guest, &mut decoder).await;
+
+        let mut buf = [0u8; 4096];
+        let n = guest.read(&mut buf).await.unwrap();
+        let msgs = decoder.decode(&buf[..n]).unwrap();
+        assert_eq!(msgs[0].msg_type, MSG_SPAWN_WATCH);
+        let spawn_seq = msgs[0].seq;
+
+        let result_payload = vsock_proto::encode_spawn_watch_result(123);
+        let result =
+            vsock_proto::encode(MSG_SPAWN_WATCH_RESULT, spawn_seq, &result_payload).unwrap();
+        let wrong_pid_exit = vsock_proto::encode_process_exit(321, 0, b"wrong-pid", b"");
+        let exit = vsock_proto::encode(MSG_PROCESS_EXIT, spawn_seq, &wrong_pid_exit).unwrap();
+        let mut combined = result;
+        combined.extend_from_slice(&exit);
+        guest.write_all(&combined).await.unwrap();
+
+        let mut discard = [0u8; 1];
+        let _ = guest.read(&mut discard).await;
+    });
+
+    let host = host_from_stream(host_stream).await.unwrap();
+    let handle = host
+        .spawn_watch("mismatched-exit-pid", 0, &[], false, false, None)
+        .await
+        .unwrap();
+    assert_eq!(handle.pid(), 123);
+
+    let err = wait_spawn(handle).await.unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::ConnectionReset);
+    assert_eq!(
+        registration_counts(&host),
+        (0, 0, 0),
+        "mismatched active process_exit pid must close and clean registrations",
+    );
+}
+
+#[tokio::test]
+async fn test_duplicate_spawn_watch_result_cannot_overwrite_pid() {
+    let (host_stream, mut guest) = make_pair();
+
+    tokio::spawn(async move {
+        let mut decoder = Decoder::new();
+        mock_handshake(&mut guest, &mut decoder).await;
+
+        let mut buf = [0u8; 4096];
+        let n = guest.read(&mut buf).await.unwrap();
+        let msgs = decoder.decode(&buf[..n]).unwrap();
+        assert_eq!(msgs[0].msg_type, MSG_SPAWN_WATCH);
+        let spawn_seq = msgs[0].seq;
+
+        let result_payload = vsock_proto::encode_spawn_watch_result(123);
+        let result =
+            vsock_proto::encode(MSG_SPAWN_WATCH_RESULT, spawn_seq, &result_payload).unwrap();
+        guest.write_all(&result).await.unwrap();
+
+        let duplicate_payload = vsock_proto::encode_spawn_watch_result(321);
+        let duplicate =
+            vsock_proto::encode(MSG_SPAWN_WATCH_RESULT, spawn_seq, &duplicate_payload).unwrap();
+        guest.write_all(&duplicate).await.unwrap();
+
+        let mut discard = [0u8; 1];
+        let _ = guest.read(&mut discard).await;
+    });
+
+    let host = host_from_stream(host_stream).await.unwrap();
+    let handle = host
+        .spawn_watch("duplicate-result", 0, &[], false, false, None)
+        .await
+        .unwrap();
+    assert_eq!(handle.pid(), 123);
+
+    let err = wait_spawn(handle).await.unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::ConnectionReset);
+    assert_eq!(
+        registration_counts(&host),
+        (0, 0, 0),
+        "duplicate spawn_watch_result must not overwrite recorded pid",
+    );
+}
+
+#[tokio::test]
 async fn test_spawn_watch_wait_future_drop_cleans_registration() {
     let (host_stream, mut guest) = make_pair();
 

--- a/crates/vsock-proto/src/lib.rs
+++ b/crates/vsock-proto/src/lib.rs
@@ -22,10 +22,10 @@
 //! | 0x04 | G→H       | write_file_result | `[1B success][2B error_len][error]` |
 //! | 0x05 | H→G       | spawn_watch       | `[4B timeout_ms][1B flags][4B cmd_len][command]([4B env_count]([4B key_len][key][4B val_len][value])*)([2B log_path_len][log_path])` (flags: `SUDO=0x01`, `STREAM_STDOUT=0x02`) |
 //! | 0x06 | G→H       | spawn_watch_result| `[4B pid]` |
-//! | 0x07 | G→H       | process_exit      | `[4B pid][4B exit_code][4B stdout_len][stdout][4B stderr_len][stderr]` |
+//! | 0x07 | G→H       | process_exit      | `[4B pid][4B exit_code][4B stdout_len][stdout][4B stderr_len][stderr]` (`spawn_watch` uses the original request seq; pid is metadata, not the routing key) |
 //! | 0x08 | H→G       | shutdown          | (empty) |
 //! | 0x09 | G→H       | shutdown_ack      | (empty) |
-//! | 0x0A | G→H       | stdout_chunk      | `[4B pid][data]` |
+//! | 0x0A | G→H       | stdout_chunk      | `[4B pid][data]` (`spawn_watch` uses the original request seq; pid is metadata, not the routing key) |
 //! | 0x0B | H→G       | command_start     | `[4B timeout_ms][1B flags][4B cmd_len][command][4B env_count]... [2B label_len][label][stdout_policy][stderr_policy]` |
 //! | 0x0C | G→H       | command_output    | `[1B stream][4B output_seq][1B flags][4B chunk_len][chunk]` |
 //! | 0x0D | G→H       | command_result    | `[1B termination]...[4B duration_ms][stdout][stderr][2B diagnostic_len][diagnostic]` |

--- a/crates/vsock-proto/src/lib.rs
+++ b/crates/vsock-proto/src/lib.rs
@@ -8,7 +8,9 @@
 //!
 //! - **length**: big-endian u32, size of (type + seq + payload)
 //! - **type**: u8 message type
-//! - **seq**: big-endian u32, sequence number (0 for unsolicited messages)
+//! - **seq**: big-endian u32, sequence number. Request-scoped replies and
+//!   lifecycle frames use the original request sequence; 0 is reserved for
+//!   unsolicited frames.
 //! - **payload**: type-specific binary data
 //!
 //! ## Message Types

--- a/crates/vsock-test/tests/integration.rs
+++ b/crates/vsock-test/tests/integration.rs
@@ -883,20 +883,25 @@ async fn test_concurrent_exec_not_blocked() {
     // Launch a slow exec and wait until its guest-side shell has started
     // before submitting the fast exec.
     let slow = h.exec(&slow_command, 10000, &[], false);
+    let (fast_done_tx, fast_done_rx) = tokio::sync::oneshot::channel();
     let fast = async {
         wait_for_path(&ready_marker, Duration::from_secs(3)).await;
-        tokio::time::timeout(Duration::from_secs(3), h.exec("echo ok", 5000, &[], false))
-            .await
-            .expect("fast exec timed out — slow exec is blocking the event loop")
-            .expect("fast exec failed")
+        let result =
+            tokio::time::timeout(Duration::from_secs(3), h.exec("echo ok", 5000, &[], false))
+                .await
+                .expect("fast exec timed out — slow exec is blocking the event loop")
+                .expect("fast exec failed");
+        let _ = fast_done_tx.send(());
+        result
     };
 
     let (_, fast_result) = tokio::join!(
-        // We don't care about slow's result — just cancel it after fast completes
+        // We don't care about slow's result — cancel the future once the fast
+        // exec proves the guest event loop is not blocked.
         async {
             tokio::select! {
                 r = slow => Some(r),
-                _ = tokio::time::sleep(Duration::from_secs(5)) => None,
+                _ = fast_done_rx => None,
             }
         },
         fast

--- a/crates/vsock-test/tests/integration.rs
+++ b/crates/vsock-test/tests/integration.rs
@@ -125,6 +125,16 @@ impl Harness {
             let _ = g.join();
         }
     }
+
+    async fn wait_spawn(
+        &self,
+        handle: vsock_host::SpawnWatchHandle,
+        timeout: Duration,
+    ) -> io::Result<vsock_host::ProcessExitEvent> {
+        tokio::time::timeout(timeout, handle.wait())
+            .await
+            .map_err(|_| io::Error::new(io::ErrorKind::TimedOut, "wait timeout"))?
+    }
 }
 
 impl Deref for Harness {
@@ -373,16 +383,17 @@ async fn test_write_file_unwritable_path_fails() {
 async fn test_spawn_watch() {
     let h = Harness::new().await;
 
-    let (pid, _stdout_rx) = h
+    let handle = h
         .spawn_watch("echo done", 5000, &[], false, false, None)
         .await
         .expect("spawn_watch failed");
+    let pid = handle.pid();
     assert!(pid > 0);
 
     let event = h
-        .wait_for_exit(pid, Duration::from_secs(5))
+        .wait_spawn(handle, Duration::from_secs(5))
         .await
-        .expect("wait_for_exit failed");
+        .expect("spawn wait failed");
 
     assert_eq!(event.exit_code, 0);
     assert_eq!(event.stdout, b"done\n");
@@ -394,15 +405,15 @@ async fn test_spawn_watch() {
 async fn test_spawn_watch_exit_code() {
     let h = Harness::new().await;
 
-    let (pid, _stdout_rx) = h
+    let handle = h
         .spawn_watch("exit 42", 5000, &[], false, false, None)
         .await
         .expect("spawn_watch failed");
 
     let event = h
-        .wait_for_exit(pid, Duration::from_secs(5))
+        .wait_spawn(handle, Duration::from_secs(5))
         .await
-        .expect("wait_for_exit failed");
+        .expect("spawn wait failed");
 
     assert_eq!(event.exit_code, 42);
     h.finish();
@@ -412,15 +423,15 @@ async fn test_spawn_watch_exit_code() {
 async fn test_spawn_watch_stderr() {
     let h = Harness::new().await;
 
-    let (pid, _stdout_rx) = h
+    let handle = h
         .spawn_watch("echo error >&2 && exit 1", 5000, &[], false, false, None)
         .await
         .expect("spawn_watch failed");
 
     let event = h
-        .wait_for_exit(pid, Duration::from_secs(5))
+        .wait_spawn(handle, Duration::from_secs(5))
         .await
-        .expect("wait_for_exit failed");
+        .expect("spawn wait failed");
 
     assert_eq!(event.exit_code, 1);
     assert_eq!(event.stderr, b"error\n");
@@ -431,7 +442,7 @@ async fn test_spawn_watch_stderr() {
 async fn test_spawn_watch_both_stdout_stderr() {
     let h = Harness::new().await;
 
-    let (pid, _stdout_rx) = h
+    let handle = h
         .spawn_watch(
             "echo out && echo err >&2 && exit 2",
             5000,
@@ -444,9 +455,9 @@ async fn test_spawn_watch_both_stdout_stderr() {
         .expect("spawn_watch failed");
 
     let event = h
-        .wait_for_exit(pid, Duration::from_secs(5))
+        .wait_spawn(handle, Duration::from_secs(5))
         .await
-        .expect("wait_for_exit failed");
+        .expect("spawn wait failed");
 
     assert_eq!(event.exit_code, 2);
     assert_eq!(event.stdout, b"out\n");
@@ -458,15 +469,15 @@ async fn test_spawn_watch_both_stdout_stderr() {
 async fn test_spawn_watch_no_output() {
     let h = Harness::new().await;
 
-    let (pid, _stdout_rx) = h
+    let handle = h
         .spawn_watch("true", 5000, &[], false, false, None)
         .await
         .expect("spawn_watch failed");
 
     let event = h
-        .wait_for_exit(pid, Duration::from_secs(5))
+        .wait_spawn(handle, Duration::from_secs(5))
         .await
-        .expect("wait_for_exit failed");
+        .expect("spawn wait failed");
 
     assert_eq!(event.exit_code, 0);
     assert!(event.stdout.is_empty());
@@ -479,26 +490,28 @@ async fn test_spawn_watch_concurrent() {
     let h = Harness::new().await;
 
     // Spawn two processes — second finishes first
-    let (pid1, _rx1) = h
+    let handle1 = h
         .spawn_watch("sleep 0.1 && echo first", 5000, &[], false, false, None)
         .await
         .expect("spawn_watch 1 failed");
-    let (pid2, _rx2) = h
+    let pid1 = handle1.pid();
+    let handle2 = h
         .spawn_watch("echo second", 5000, &[], false, false, None)
         .await
         .expect("spawn_watch 2 failed");
+    let pid2 = handle2.pid();
 
     assert_ne!(pid1, pid2);
 
-    // Wait in reverse order to exercise cached exit events
+    // Wait in reverse order to exercise out-of-order handle completion.
     let event2 = h
-        .wait_for_exit(pid2, Duration::from_secs(5))
+        .wait_spawn(handle2, Duration::from_secs(5))
         .await
-        .expect("wait_for_exit 2 failed");
+        .expect("spawn wait 2 failed");
     let event1 = h
-        .wait_for_exit(pid1, Duration::from_secs(5))
+        .wait_spawn(handle1, Duration::from_secs(5))
         .await
-        .expect("wait_for_exit 1 failed");
+        .expect("spawn wait 1 failed");
 
     assert_eq!(event1.exit_code, 0);
     assert_eq!(event1.stdout, b"first\n");
@@ -507,10 +520,10 @@ async fn test_spawn_watch_concurrent() {
     h.finish();
 }
 
-/// Core concurrency test: exec works while wait_for_exit is pending.
+/// Core concurrency test: exec works while spawn wait is pending.
 ///
 /// This is the exact production scenario that motivated the VsockHost refactor —
-/// runner calls wait_for_exit (blocks for hours) and a separate task needs to
+/// runner waits for spawn exit (blocks for hours) and a separate task needs to
 /// exec into the same VM.
 #[tokio::test]
 async fn test_exec_while_waiting_for_exit() {
@@ -518,27 +531,28 @@ async fn test_exec_while_waiting_for_exit() {
 
     // Spawn a long-running process. Use `exec` to replace the shell so the
     // PID we get is the actual sleep process (same pattern as sigterm/sigkill tests).
-    let (pid, _stdout_rx) = h
+    let handle = h
         .spawn_watch("exec sleep 60", 0, &[], false, false, None)
         .await
         .expect("spawn_watch failed");
+    let pid = handle.pid();
 
-    // Run wait_for_exit and exec concurrently on the same task via join!.
+    // Run spawn wait and exec concurrently on the same task via join!.
     // The exec branch runs a command and then kills the long-running process,
-    // which unblocks wait_for_exit.
-    let (wait_result, _) = tokio::join!(h.wait_for_exit(pid, Duration::from_secs(10)), async {
-        // This exec must NOT block on the pending wait_for_exit.
+    // which unblocks spawn wait.
+    let (wait_result, _) = tokio::join!(h.wait_spawn(handle, Duration::from_secs(10)), async {
+        // This exec must NOT block on the pending spawn wait.
         let result = tokio::time::timeout(
             Duration::from_secs(5),
             h.exec("echo alive", 5000, &[], false),
         )
         .await
-        .expect("exec timed out — wait_for_exit is blocking")
+        .expect("exec timed out — spawn wait is blocking")
         .expect("exec failed");
         assert_eq!(result.exit_code, 0);
         assert_eq!(result.stdout, b"alive\n");
 
-        // Kill the process group so wait_for_exit resolves.
+        // Kill the process group so spawn wait resolves.
         h.exec(
             &format!("kill -15 -{pid} 2>/dev/null || kill -15 {pid}"),
             5000,
@@ -549,7 +563,7 @@ async fn test_exec_while_waiting_for_exit() {
         .expect("kill failed");
     });
 
-    let event = wait_result.expect("wait_for_exit failed");
+    let event = wait_result.expect("spawn wait failed");
     assert_eq!(event.pid, pid);
     assert_ne!(event.exit_code, 0); // killed
 
@@ -560,15 +574,15 @@ async fn test_exec_while_waiting_for_exit() {
 async fn test_spawn_watch_timeout() {
     let h = Harness::new().await;
 
-    let (pid, _stdout_rx) = h
+    let handle = h
         .spawn_watch("sleep 10", 100, &[], false, false, None)
         .await
         .expect("spawn_watch failed");
 
     let event = h
-        .wait_for_exit(pid, Duration::from_secs(5))
+        .wait_spawn(handle, Duration::from_secs(5))
         .await
-        .expect("wait_for_exit failed");
+        .expect("spawn wait failed");
 
     assert_eq!(event.exit_code, 124);
     assert!(event.stderr.starts_with(b"Timeout"));
@@ -576,28 +590,29 @@ async fn test_spawn_watch_timeout() {
 }
 
 #[tokio::test]
-async fn test_spawn_watch_cached_exit() {
+async fn test_spawn_watch_exit_before_wait() {
     let h = Harness::new().await;
 
-    let (pid, _stdout_rx) = h
-        .spawn_watch("echo cached", 5000, &[], false, false, None)
+    let handle = h
+        .spawn_watch("echo completed", 5000, &[], false, false, None)
         .await
         .expect("spawn_watch failed");
 
     // Use an exec round-trip as a synchronization barrier: by the time exec
-    // returns, the exit event from "echo cached" has arrived and been cached
-    // by read_and_dispatch. This tests the cache-hit path without any sleep.
+    // returns, the exit event from "echo completed" has already been delivered
+    // into the handle-owned receiver. This covers waiting after completion
+    // without any sleep.
     h.exec("true", 5000, &[], false)
         .await
         .expect("barrier exec failed");
 
     let event = h
-        .wait_for_exit(pid, Duration::from_secs(5))
+        .wait_spawn(handle, Duration::from_secs(5))
         .await
-        .expect("wait_for_exit failed");
+        .expect("spawn wait failed");
 
     assert_eq!(event.exit_code, 0);
-    assert_eq!(event.stdout, b"cached\n");
+    assert_eq!(event.stdout, b"completed\n");
     h.finish();
 }
 
@@ -605,7 +620,7 @@ async fn test_spawn_watch_cached_exit() {
 async fn test_spawn_watch_multiline() {
     let h = Harness::new().await;
 
-    let (pid, _stdout_rx) = h
+    let handle = h
         .spawn_watch(
             "printf 'line1\\nline2\\nline3\\n'",
             5000,
@@ -618,9 +633,9 @@ async fn test_spawn_watch_multiline() {
         .expect("spawn_watch failed");
 
     let event = h
-        .wait_for_exit(pid, Duration::from_secs(5))
+        .wait_spawn(handle, Duration::from_secs(5))
         .await
-        .expect("wait_for_exit failed");
+        .expect("spawn wait failed");
 
     assert_eq!(event.exit_code, 0);
     assert_eq!(event.stdout, b"line1\nline2\nline3\n");
@@ -631,7 +646,7 @@ async fn test_spawn_watch_multiline() {
 async fn test_spawn_watch_large_output() {
     let h = Harness::new().await;
 
-    let (pid, _stdout_rx) = h
+    let handle = h
         .spawn_watch(
             "dd if=/dev/zero bs=1024 count=10 2>/dev/null | base64",
             5000,
@@ -644,9 +659,9 @@ async fn test_spawn_watch_large_output() {
         .expect("spawn_watch failed");
 
     let event = h
-        .wait_for_exit(pid, Duration::from_secs(10))
+        .wait_spawn(handle, Duration::from_secs(10))
         .await
-        .expect("wait_for_exit failed");
+        .expect("spawn wait failed");
 
     assert_eq!(event.exit_code, 0);
     assert!(event.stdout.len() > 10000);
@@ -657,15 +672,15 @@ async fn test_spawn_watch_large_output() {
 async fn test_spawn_watch_delayed_output() {
     let h = Harness::new().await;
 
-    let (pid, _stdout_rx) = h
+    let handle = h
         .spawn_watch("sleep 0.2 && echo delayed", 5000, &[], false, false, None)
         .await
         .expect("spawn_watch failed");
 
     let event = h
-        .wait_for_exit(pid, Duration::from_secs(5))
+        .wait_spawn(handle, Duration::from_secs(5))
         .await
-        .expect("wait_for_exit failed");
+        .expect("spawn wait failed");
 
     assert_eq!(event.exit_code, 0);
     assert_eq!(event.stdout, b"delayed\n");
@@ -677,10 +692,11 @@ async fn test_spawn_watch_sigterm() {
     let h = Harness::new().await;
 
     // Use `exec` to replace shell so the PID we get is the actual sleep process
-    let (pid, _stdout_rx) = h
+    let handle = h
         .spawn_watch("exec sleep 60", 0, &[], false, false, None)
         .await
         .expect("spawn_watch failed");
+    let pid = handle.pid();
 
     // Kill process group with SIGTERM
     h.exec(
@@ -693,9 +709,9 @@ async fn test_spawn_watch_sigterm() {
     .expect("kill failed");
 
     let event = h
-        .wait_for_exit(pid, Duration::from_secs(5))
+        .wait_spawn(handle, Duration::from_secs(5))
         .await
-        .expect("wait_for_exit failed");
+        .expect("spawn wait failed");
 
     assert_eq!(event.exit_code, 143); // 128 + SIGTERM(15)
     h.finish();
@@ -705,10 +721,11 @@ async fn test_spawn_watch_sigterm() {
 async fn test_spawn_watch_sigkill() {
     let h = Harness::new().await;
 
-    let (pid, _stdout_rx) = h
+    let handle = h
         .spawn_watch("exec sleep 60", 0, &[], false, false, None)
         .await
         .expect("spawn_watch failed");
+    let pid = handle.pid();
 
     h.exec(
         &format!("kill -9 -{pid} 2>/dev/null || kill -9 {pid}"),
@@ -720,9 +737,9 @@ async fn test_spawn_watch_sigkill() {
     .expect("kill failed");
 
     let event = h
-        .wait_for_exit(pid, Duration::from_secs(5))
+        .wait_spawn(handle, Duration::from_secs(5))
         .await
-        .expect("wait_for_exit failed");
+        .expect("spawn wait failed");
 
     assert_eq!(event.exit_code, 137); // 128 + SIGKILL(9)
     h.finish();
@@ -732,25 +749,28 @@ async fn test_spawn_watch_sigkill() {
 async fn test_spawn_watch_rapid_multiple() {
     let h = Harness::new().await;
 
-    let mut pids = Vec::new();
+    let mut handles = Vec::new();
     for i in 0..5 {
-        let (pid, _rx) = h
+        let handle = h
             .spawn_watch(&format!("echo p{i}"), 5000, &[], false, false, None)
             .await
             .expect("spawn_watch failed");
-        pids.push(pid);
+        handles.push(handle);
     }
 
     // All PIDs should be unique
-    let unique: std::collections::HashSet<_> = pids.iter().collect();
+    let unique: std::collections::HashSet<_> = handles
+        .iter()
+        .map(vsock_host::SpawnWatchHandle::pid)
+        .collect();
     assert_eq!(unique.len(), 5);
 
     // All should complete successfully with correct output
-    for (i, &pid) in pids.iter().enumerate() {
+    for (i, handle) in handles.into_iter().enumerate() {
         let event = h
-            .wait_for_exit(pid, Duration::from_secs(5))
+            .wait_spawn(handle, Duration::from_secs(5))
             .await
-            .expect("wait_for_exit failed");
+            .expect("spawn wait failed");
         assert_eq!(event.exit_code, 0);
         assert_eq!(event.stdout, format!("p{i}\n").as_bytes());
     }
@@ -761,7 +781,7 @@ async fn test_spawn_watch_rapid_multiple() {
 async fn test_spawn_watch_nonexistent_command() {
     let h = Harness::new().await;
 
-    let (pid, _stdout_rx) = h
+    let handle = h
         .spawn_watch(
             "nonexistent_command_12345 2>&1",
             5000,
@@ -774,9 +794,9 @@ async fn test_spawn_watch_nonexistent_command() {
         .expect("spawn_watch failed");
 
     let event = h
-        .wait_for_exit(pid, Duration::from_secs(5))
+        .wait_spawn(handle, Duration::from_secs(5))
         .await
-        .expect("wait_for_exit failed");
+        .expect("spawn wait failed");
 
     assert_ne!(event.exit_code, 0);
     let output = if event.stderr.is_empty() {
@@ -793,7 +813,7 @@ async fn test_spawn_watch_nonexistent_command() {
 async fn test_spawn_watch_unicode() {
     let h = Harness::new().await;
 
-    let (pid, _stdout_rx) = h
+    let handle = h
         .spawn_watch(
             "printf '你好世界\\nこんにちは\\n🎉emoji🚀'",
             5000,
@@ -806,9 +826,9 @@ async fn test_spawn_watch_unicode() {
         .expect("spawn_watch failed");
 
     let event = h
-        .wait_for_exit(pid, Duration::from_secs(5))
+        .wait_spawn(handle, Duration::from_secs(5))
         .await
-        .expect("wait_for_exit failed");
+        .expect("spawn wait failed");
 
     assert_eq!(event.exit_code, 0);
     let stdout = String::from_utf8_lossy(&event.stdout);
@@ -822,7 +842,7 @@ async fn test_spawn_watch_unicode() {
 async fn test_spawn_watch_interleaved_output() {
     let h = Harness::new().await;
 
-    let (pid, _stdout_rx) = h
+    let handle = h
         .spawn_watch(
             "echo out1 && echo err1 >&2 && echo out2 && echo err2 >&2",
             5000,
@@ -835,9 +855,9 @@ async fn test_spawn_watch_interleaved_output() {
         .expect("spawn_watch failed");
 
     let event = h
-        .wait_for_exit(pid, Duration::from_secs(5))
+        .wait_spawn(handle, Duration::from_secs(5))
         .await
-        .expect("wait_for_exit failed");
+        .expect("spawn wait failed");
 
     assert_eq!(event.exit_code, 0);
     assert!(event.stdout.windows(4).any(|w| w == b"out1"));
@@ -1039,7 +1059,7 @@ async fn test_exec_with_env_special_chars() {
 async fn test_spawn_watch_with_env() {
     let h = Harness::new().await;
 
-    let (pid, _stdout_rx) = h
+    let handle = h
         .spawn_watch(
             "echo $GREETING",
             5000,
@@ -1052,9 +1072,9 @@ async fn test_spawn_watch_with_env() {
         .expect("spawn_watch failed");
 
     let event = h
-        .wait_for_exit(pid, Duration::from_secs(5))
+        .wait_spawn(handle, Duration::from_secs(5))
         .await
-        .expect("wait_for_exit failed");
+        .expect("spawn wait failed");
 
     assert_eq!(event.exit_code, 0);
     assert_eq!(event.stdout, b"hi_from_env\n");
@@ -1072,31 +1092,20 @@ async fn test_spawn_watch_stdout_streaming() {
     let log_file = h.dir.join("stream.log");
     let log_path = log_file.to_string_lossy().to_string();
 
-    let (pid, mut stdout_rx) = h
+    let mut handle = h
         .spawn_watch("echo hello_stream", 5000, &[], false, true, Some(&log_path))
         .await
         .expect("spawn_watch failed");
+    let mut stdout_rx = handle.take_stdout_receiver().unwrap();
 
-    // Collect streamed chunks
+    let event = h
+        .wait_spawn(handle, Duration::from_secs(5))
+        .await
+        .expect("wait failed");
     let mut streamed = Vec::new();
-    let event = loop {
-        tokio::select! {
-            biased;
-            chunk = stdout_rx.recv() => {
-                match chunk {
-                    Some(data) => streamed.extend_from_slice(&data),
-                    None => break h.wait_for_exit(pid, Duration::from_secs(5)).await.expect("wait failed"),
-                }
-            }
-            event = h.wait_for_exit(pid, Duration::from_secs(5)) => {
-                // Drain any remaining chunks
-                while let Ok(data) = stdout_rx.try_recv() {
-                    streamed.extend_from_slice(&data);
-                }
-                break event.expect("wait failed");
-            }
-        }
-    };
+    while let Ok(data) = stdout_rx.try_recv() {
+        streamed.extend_from_slice(&data);
+    }
 
     assert_eq!(event.exit_code, 0);
     // In streaming mode, stdout is delivered via chunks, not process_exit.
@@ -1120,29 +1129,20 @@ async fn test_spawn_watch_stdout_stream_only() {
     let existing_guest_log = h.dir.join("stream_only_guest.log");
     std::fs::write(&existing_guest_log, "preexisting\n").unwrap();
 
-    let (pid, mut stdout_rx) = h
+    let mut handle = h
         .spawn_watch("echo stream_only", 5000, &[], false, true, None)
         .await
         .expect("spawn_watch failed");
+    let mut stdout_rx = handle.take_stdout_receiver().unwrap();
 
+    let event = h
+        .wait_spawn(handle, Duration::from_secs(5))
+        .await
+        .expect("wait failed");
     let mut streamed = Vec::new();
-    let event = loop {
-        tokio::select! {
-            biased;
-            chunk = stdout_rx.recv() => {
-                match chunk {
-                    Some(data) => streamed.extend_from_slice(&data),
-                    None => break h.wait_for_exit(pid, Duration::from_secs(5)).await.expect("wait failed"),
-                }
-            }
-            event = h.wait_for_exit(pid, Duration::from_secs(5)) => {
-                while let Ok(data) = stdout_rx.try_recv() {
-                    streamed.extend_from_slice(&data);
-                }
-                break event.expect("wait failed");
-            }
-        }
-    };
+    while let Ok(data) = stdout_rx.try_recv() {
+        streamed.extend_from_slice(&data);
+    }
 
     assert_eq!(event.exit_code, 0);
     assert!(event.stdout.is_empty());
@@ -1162,7 +1162,7 @@ async fn test_spawn_watch_stdout_streaming_large() {
     let log_path = log_file.to_string_lossy().to_string();
 
     // Generate ~20KB of output (well over the 8KB chunk size)
-    let (pid, mut stdout_rx) = h
+    let mut handle = h
         .spawn_watch(
             "dd if=/dev/zero bs=1024 count=20 2>/dev/null | base64",
             5000,
@@ -1173,25 +1173,16 @@ async fn test_spawn_watch_stdout_streaming_large() {
         )
         .await
         .expect("spawn_watch failed");
+    let mut stdout_rx = handle.take_stdout_receiver().unwrap();
 
+    let event = h
+        .wait_spawn(handle, Duration::from_secs(10))
+        .await
+        .expect("wait failed");
     let mut streamed = Vec::new();
-    let event = loop {
-        tokio::select! {
-            biased;
-            chunk = stdout_rx.recv() => {
-                match chunk {
-                    Some(data) => streamed.extend_from_slice(&data),
-                    None => break h.wait_for_exit(pid, Duration::from_secs(10)).await.expect("wait failed"),
-                }
-            }
-            event = h.wait_for_exit(pid, Duration::from_secs(10)) => {
-                while let Ok(data) = stdout_rx.try_recv() {
-                    streamed.extend_from_slice(&data);
-                }
-                break event.expect("wait failed");
-            }
-        }
-    };
+    while let Ok(data) = stdout_rx.try_recv() {
+        streamed.extend_from_slice(&data);
+    }
 
     assert_eq!(event.exit_code, 0);
     assert!(event.stdout.is_empty());
@@ -1219,13 +1210,13 @@ async fn test_spawn_watch_stdout_log_path_not_in_env() {
 
     // The child prints its own env — stdout_log_path is a protocol parameter,
     // not an env var, so it should never appear in the child's environment.
-    let (pid, _stdout_rx) = h
+    let handle = h
         .spawn_watch("env", 5000, &[], false, true, Some(&log_path))
         .await
         .expect("spawn_watch failed");
 
     let event = h
-        .wait_for_exit(pid, Duration::from_secs(5))
+        .wait_spawn(handle, Duration::from_secs(5))
         .await
         .expect("wait failed");
 
@@ -1250,7 +1241,7 @@ async fn test_spawn_watch_stdout_streaming_timeout() {
     let log_path = log_file.to_string_lossy().to_string();
 
     // Process that produces output forever — must be killed by the 100ms timeout.
-    let (pid, mut stdout_rx) = h
+    let mut handle = h
         .spawn_watch(
             "while true; do echo tick; sleep 0.01; done",
             100,
@@ -1261,26 +1252,16 @@ async fn test_spawn_watch_stdout_streaming_timeout() {
         )
         .await
         .expect("spawn_watch failed");
+    let mut stdout_rx = handle.take_stdout_receiver().unwrap();
 
-    // Drain streamed chunks until process exits
+    let event = h
+        .wait_spawn(handle, Duration::from_secs(5))
+        .await
+        .expect("wait failed");
     let mut streamed = Vec::new();
-    let event = loop {
-        tokio::select! {
-            biased;
-            chunk = stdout_rx.recv() => {
-                match chunk {
-                    Some(data) => streamed.extend_from_slice(&data),
-                    None => break h.wait_for_exit(pid, Duration::from_secs(5)).await.expect("wait failed"),
-                }
-            }
-            event = h.wait_for_exit(pid, Duration::from_secs(5)) => {
-                while let Ok(data) = stdout_rx.try_recv() {
-                    streamed.extend_from_slice(&data);
-                }
-                break event.expect("wait failed");
-            }
-        }
-    };
+    while let Ok(data) = stdout_rx.try_recv() {
+        streamed.extend_from_slice(&data);
+    }
 
     assert_eq!(event.exit_code, 124); // timeout exit code
     // Should have received some streamed output before the kill

--- a/crates/vsock-test/tests/integration.rs
+++ b/crates/vsock-test/tests/integration.rs
@@ -1126,10 +1126,10 @@ async fn test_spawn_watch_stdout_streaming() {
 async fn test_spawn_watch_stdout_streaming_delivers_before_exit() {
     let h = Harness::new().await;
 
-    let release_file = h.dir.join("release-streaming-process");
+    let release_fifo = h.dir.join("release-streaming-process");
     let command = format!(
-        "printf 'before_exit\\n'; while [ ! -e {release} ]; do sleep 0.01; done",
-        release = shell_quote_path(&release_file)
+        "rm -f {release}; mkfifo {release}; printf 'before_exit\\n'; IFS= read -r _ < {release}",
+        release = shell_quote_path(&release_fifo)
     );
 
     let mut handle = h
@@ -1144,7 +1144,7 @@ async fn test_spawn_watch_stdout_streaming_delivers_before_exit() {
         .expect("stdout stream closed before first chunk");
     assert_eq!(String::from_utf8_lossy(&chunk).trim(), "before_exit");
 
-    std::fs::write(&release_file, "").expect("release streaming process");
+    std::fs::write(&release_fifo, b"\n").expect("release streaming process");
     let event = h
         .wait_spawn(handle, Duration::from_secs(5))
         .await

--- a/crates/vsock-test/tests/integration.rs
+++ b/crates/vsock-test/tests/integration.rs
@@ -1121,6 +1121,41 @@ async fn test_spawn_watch_stdout_streaming() {
     h.finish();
 }
 
+/// Streaming stdout must be observable before the process reaches exit.
+#[tokio::test]
+async fn test_spawn_watch_stdout_streaming_delivers_before_exit() {
+    let h = Harness::new().await;
+
+    let release_file = h.dir.join("release-streaming-process");
+    let command = format!(
+        "printf 'before_exit\\n'; while [ ! -e {release} ]; do sleep 0.01; done",
+        release = shell_quote_path(&release_file)
+    );
+
+    let mut handle = h
+        .spawn_watch(&command, 5000, &[], false, true, None)
+        .await
+        .expect("spawn_watch failed");
+    let mut stdout_rx = handle.take_stdout_receiver().unwrap();
+
+    let chunk = tokio::time::timeout(Duration::from_secs(2), stdout_rx.recv())
+        .await
+        .expect("streaming stdout was not delivered before process exit")
+        .expect("stdout stream closed before first chunk");
+    assert_eq!(String::from_utf8_lossy(&chunk).trim(), "before_exit");
+
+    std::fs::write(&release_file, "").expect("release streaming process");
+    let event = h
+        .wait_spawn(handle, Duration::from_secs(5))
+        .await
+        .expect("wait failed");
+
+    assert_eq!(event.exit_code, 0);
+    assert!(event.stdout.is_empty());
+
+    h.finish();
+}
+
 /// Streaming can be enabled without a guest-side tee file.
 #[tokio::test]
 async fn test_spawn_watch_stdout_stream_only() {


### PR DESCRIPTION
## Summary
- Route spawn_watch stdout and process-exit lifecycle frames by the original request sequence instead of pid
- Replace bare pid wait in vsock-host with an owned SpawnWatchHandle consumed by wait
- Carry the handle-owned exit future through sandbox-fc while preserving streamed stdout and final ProcessExit fields
- Update guest monitor/protocol docs and tests for seq-owned lifecycle frames

Closes #13149

## Tests
- cargo test --manifest-path crates/Cargo.toml -p vsock-host process
- cargo test --manifest-path crates/Cargo.toml -p vsock-guest
- cargo test --manifest-path crates/Cargo.toml -p vsock-test
- cargo check --manifest-path crates/Cargo.toml -p sandbox-fc -p sandbox-mock -p runner
- cargo test --manifest-path crates/Cargo.toml -p sandbox -p sandbox-mock
- cargo test --manifest-path crates/Cargo.toml -p sandbox-fc --lib
- cargo clippy --manifest-path crates/Cargo.toml -p vsock-host -p vsock-guest -p sandbox -p sandbox-mock -p sandbox-fc -p vsock-test --all-targets --all-features -- -D warnings
- pre-commit hook: cargo-fmt, cargo-clippy, cargo-doc