### PR TITLE
fix: resolve API model-first runtime framework

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-chat-messages.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-chat-messages.test.ts
@@ -307,13 +307,17 @@ async function seedModelProvider(
 async function seedVm0ApiKey(
   fixture: ChatMessageFixture,
   model: string,
+  options: {
+    readonly vendor?: string;
+    readonly apiModel?: string;
+  } = {},
 ): Promise<void> {
   await store
     .set(writeDb$)
     .insert(vm0ApiKeys)
     .values({
-      vendor: "anthropic",
-      model,
+      vendor: options.vendor ?? "anthropic",
+      model: options.apiModel ?? model,
       apiKey: `vm0-key-${model}`,
       label: fixture.agentId,
     });
@@ -1169,6 +1173,57 @@ describe("POST /api/zero/chat/messages", () => {
     );
     expect(decryptSecretsMap(executionContext.encryptedSecrets)).toMatchObject({
       DEEPSEEK_API_KEY: "org-deepseek-key",
+    });
+  });
+
+  it("runs VM0 GPT model-first routes with the Codex runtime framework", async () => {
+    const fixture = await track(seedFixture());
+    const writeDb = store.set(writeDb$);
+    await removeComposeFrameworkApiKey(fixture);
+    await seedVm0Credits(fixture, 1000);
+    await seedModelProvider(fixture, "gpt-5.5", {
+      type: "vm0",
+      userId: ORG_SENTINEL_USER_ID,
+    });
+    await seedVm0ApiKey(fixture, "gpt-5.5", { vendor: "openai" });
+    await writeDb.insert(orgModelPolicies).values({
+      orgId: fixture.orgId,
+      model: "gpt-5.5",
+      isDefault: true,
+      defaultProviderType: "vm0",
+      credentialScope: "org",
+      createdByUserId: fixture.userId,
+      updatedByUserId: fixture.userId,
+    });
+
+    const response = await send({
+      agentId: fixture.agentId,
+      prompt: "run with built-in gpt",
+      modelSelection: {
+        modelProviderId: "00000000-0000-4000-8000-000000000000",
+        selectedModel: "gpt-5.5",
+      },
+    });
+    await clearAllDetached();
+
+    const [job] = await writeDb
+      .select({ executionContext: runnerJobQueue.executionContext })
+      .from(runnerJobQueue)
+      .where(eq(runnerJobQueue.runId, response.body.runId!))
+      .limit(1);
+    const executionContext = job?.executionContext as {
+      readonly cliAgentType: string;
+      readonly environment: Record<string, string>;
+      readonly encryptedSecrets: string | null;
+    };
+    expect(executionContext.cliAgentType).toBe("codex");
+    expect(executionContext.environment).toMatchObject({
+      OPENAI_API_KEY: "vm0-key-gpt-5.5",
+      OPENAI_MODEL: "gpt-5.5",
+    });
+    expect(executionContext.environment.ANTHROPIC_API_KEY).toBeUndefined();
+    expect(decryptSecretsMap(executionContext.encryptedSecrets)).toMatchObject({
+      OPENAI_API_KEY: "vm0-key-gpt-5.5",
     });
   });
 

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -371,6 +371,73 @@ function resolveFramework(
   return framework;
 }
 
+function modelProviderFramework(
+  modelProvider: ResolvedModelProviderEnvironment,
+): SupportedFramework {
+  return getFrameworkForType(modelProvider.concreteType ?? modelProvider.type);
+}
+
+function frameworkForProviderSelection(
+  providerType: ModelProviderType,
+  selectedModel: string | null | undefined,
+): SupportedFramework | null {
+  if (providerType !== "vm0") {
+    return getFrameworkForType(providerType);
+  }
+  if (!selectedModel) {
+    return null;
+  }
+  return getFrameworkForType(getVm0ConcreteProviderType(selectedModel));
+}
+
+async function resolveRequestedRunFramework(
+  db: Db,
+  args: CreateAgentRunArgs,
+  composeFramework: SupportedFramework,
+): Promise<SupportedFramework> {
+  if (args.modelProviderType && isModelProviderType(args.modelProviderType)) {
+    return (
+      frameworkForProviderSelection(
+        args.modelProviderType,
+        args.selectedModelOverride,
+      ) ?? composeFramework
+    );
+  }
+
+  if (!args.modelProviderId) {
+    return composeFramework;
+  }
+
+  const [provider] = await db
+    .select({
+      type: modelProviders.type,
+      selectedModel: modelProviders.selectedModel,
+    })
+    .from(modelProviders)
+    .where(
+      and(
+        eq(modelProviders.id, args.modelProviderId),
+        eq(modelProviders.orgId, args.orgId),
+        or(
+          eq(modelProviders.userId, args.userId),
+          eq(modelProviders.userId, ORG_SENTINEL_USER_ID),
+        ),
+      ),
+    )
+    .limit(1);
+
+  if (!provider || !isModelProviderType(provider.type)) {
+    return composeFramework;
+  }
+
+  return (
+    frameworkForProviderSelection(
+      provider.type,
+      args.selectedModelOverride ?? provider.selectedModel,
+    ) ?? composeFramework
+  );
+}
+
 function frameworkWorkingDir(_framework: SupportedFramework): string {
   return "/home/user/workspace";
 }
@@ -2568,16 +2635,26 @@ async function prepareRunContext(
     return validation;
   }
 
+  const requestedFramework = await resolveRequestedRunFramework(
+    db,
+    args,
+    validation.framework,
+  );
+  signal.throwIfAborted();
+
   const modelProvider = await resolveRunModelProvider(
     db,
     args,
     resolved.content,
-    validation.framework,
+    requestedFramework,
     signal,
   );
   if (isRouteError(modelProvider)) {
     return modelProvider;
   }
+  const framework = modelProvider
+    ? modelProviderFramework(modelProvider)
+    : requestedFramework;
 
   const [
     oauthConnectorContext,
@@ -2617,7 +2694,7 @@ async function prepareRunContext(
 
   const artifacts = artifactsForRun({
     resolved,
-    framework: validation.framework,
+    framework,
     bodyArtifacts: body.artifacts,
   });
   const additionalVolumes = mergeAdditionalVolumes({
@@ -2628,7 +2705,7 @@ async function prepareRunContext(
   return {
     body,
     resolved,
-    framework: validation.framework,
+    framework,
     modelProvider,
     connectorContext,
     customConnectorContext,


### PR DESCRIPTION
## Summary
- align API run creation with web's provider-first runtime framework resolution
- resolve VM0 GPT model-first selections to the Codex/OpenAI framework before provider lookup
- add API chat route integration coverage for built-in GPT-5.5 model-first runs

## Web/API comparison
- web resolves runtime framework from provider/admission before falling back to compose framework
- API previously used compose framework when resolving model providers, which filtered out VM0 GPT's OpenAI concrete provider under Claude compose content
- API now derives requested framework from provider type/provider id/selected model and writes the final provider framework into the runner context

## Tests
- pnpm -F api exec vitest run src/signals/routes/__tests__/zero-chat-messages.test.ts
- pnpm -F api exec vitest run src/signals/routes/__tests__/zero-runs-create.test.ts
- pnpm -F api check-types
- pnpm -F api lint
- pnpm exec prettier --check apps/api/src/signals/services/agent-run-create.service.ts apps/api/src/signals/routes/__tests__/zero-chat-messages.test.ts
- pre-commit: prettier, knip, turbo run check-types --concurrency=1