### PR TITLE
refactor(api): migrate agent storage webhooks

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -47,6 +47,7 @@ import { usageRoutes } from "./routes/usage";
 import { userExportRoutes } from "./routes/user-export";
 import { vercelSandboxSmokeRoutes } from "./routes/vercel-sandbox-smoke";
 import { webhooksAgentHealthUsageTelemetryRoutes } from "./routes/webhooks-agent-health-usage-telemetry";
+import { webhooksAgentStorageRoutes } from "./routes/webhooks-agent-storage";
 import { webhooksClerkRoutes } from "./routes/webhooks-clerk";
 import { webhooksGithubRoutes } from "./routes/webhooks-github";
 import { webhooksStripeRoutes } from "./routes/webhooks-stripe";
@@ -185,6 +186,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...webhooksGithubRoutes,
   ...webhooksStripeRoutes,
   ...webhooksAgentHealthUsageTelemetryRoutes,
+  ...webhooksAgentStorageRoutes,
   ...agentCheckpointsRoutes,
   ...agentComposesReadRoutes,
   ...agentComposesByIdRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-storage.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-storage.test.ts
@@ -1,0 +1,354 @@
+import { randomUUID } from "node:crypto";
+
+import {
+  webhookStoragesCommitContract,
+  webhookStoragesPrepareContract,
+} from "@vm0/api-contracts/contracts/webhooks";
+import { storages, storageVersions } from "@vm0/db/schema/storage";
+import { storageVersionLineage } from "@vm0/db/schema/storage-version-lineage";
+import { createStore } from "ccstate";
+import { and, eq } from "drizzle-orm";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { mockEnv } from "../../../lib/env";
+import { now } from "../../../lib/time";
+import { signSandboxJwtForTests } from "../../auth/tokens";
+import { writeDb$ } from "../../external/db";
+import { createFixtureTracker } from "./helpers/zero-route-test";
+import {
+  deleteUsageInsightFixture$,
+  seedCompose$,
+  seedRun$,
+  seedUsageInsightFixture$,
+  type UsageInsightFixture,
+} from "./helpers/zero-usage-insight";
+
+const BUCKET = "test-user-storages";
+const TEST_HASH = "a".repeat(64);
+const SECOND_TEST_HASH = "b".repeat(64);
+
+const context = testContext();
+const store = createStore();
+
+type StorageType = "volume" | "artifact";
+
+interface StorageFile {
+  readonly path: string;
+  readonly hash: string;
+  readonly size: number;
+}
+
+interface AgentStorageFixture extends UsageInsightFixture {
+  readonly composeId: string;
+  readonly runId: string;
+}
+
+interface PrepareBody {
+  readonly runId: string;
+  readonly storageName: string;
+  readonly storageType: StorageType;
+  readonly files: StorageFile[];
+}
+
+interface CommitBody {
+  readonly runId: string;
+  readonly storageName: string;
+  readonly storageType: StorageType;
+  readonly versionId: string;
+  readonly parentVersionId?: string;
+  readonly files: StorageFile[];
+  readonly message?: string;
+}
+
+function currentSecond(): number {
+  return Math.floor(now() / 1000);
+}
+
+function sandboxToken(fixture: {
+  readonly runId: string;
+  readonly userId: string;
+  readonly orgId: string;
+}): string {
+  const nowSeconds = currentSecond();
+  return signSandboxJwtForTests({
+    scope: "sandbox",
+    runId: fixture.runId,
+    userId: fixture.userId,
+    orgId: fixture.orgId,
+    iat: nowSeconds,
+    exp: nowSeconds + 60,
+  });
+}
+
+function authHeaders(fixture: AgentStorageFixture): {
+  readonly authorization: string;
+} {
+  return { authorization: `Bearer ${sandboxToken(fixture)}` };
+}
+
+function storageName(prefix: string): string {
+  return `${prefix}-${randomUUID().slice(0, 8)}`;
+}
+
+function validFile(overrides: Partial<StorageFile> = {}): StorageFile {
+  return {
+    path: "test.txt",
+    hash: TEST_HASH,
+    size: 100,
+    ...overrides,
+  };
+}
+
+function prepareBody(
+  fixture: AgentStorageFixture,
+  overrides: Partial<PrepareBody> = {},
+): PrepareBody {
+  return {
+    runId: fixture.runId,
+    storageName: storageName("agent-storage"),
+    storageType: "artifact",
+    files: [validFile()],
+    ...overrides,
+  };
+}
+
+function commitBody(
+  fixture: AgentStorageFixture,
+  overrides: Partial<CommitBody>,
+): CommitBody {
+  return {
+    runId: fixture.runId,
+    storageName: storageName("agent-storage"),
+    storageType: "artifact",
+    versionId: "0".repeat(64),
+    files: [validFile()],
+    ...overrides,
+  };
+}
+
+function prepareClient() {
+  return setupApp({ context })(webhookStoragesPrepareContract);
+}
+
+function commitClient() {
+  return setupApp({ context })(webhookStoragesCommitContract);
+}
+
+async function seedFixture(): Promise<AgentStorageFixture> {
+  const base = await store.set(
+    seedUsageInsightFixture$,
+    undefined,
+    context.signal,
+  );
+  const { composeId } = await store.set(
+    seedCompose$,
+    { orgId: base.orgId, userId: base.userId },
+    context.signal,
+  );
+  const { runId } = await store.set(
+    seedRun$,
+    {
+      orgId: base.orgId,
+      userId: base.userId,
+      composeId,
+      status: "running",
+    },
+    context.signal,
+  );
+  return { ...base, composeId, runId };
+}
+
+async function prepareOk(fixture: AgentStorageFixture, body: PrepareBody) {
+  const response = await accept(
+    prepareClient().prepare({
+      body,
+      headers: authHeaders(fixture),
+    }),
+    [200],
+  );
+  return response.body;
+}
+
+const track = createFixtureTracker<AgentStorageFixture>((fixture) => {
+  return store.set(deleteUsageInsightFixture$, fixture, context.signal);
+});
+
+beforeEach(() => {
+  mockEnv("R2_USER_STORAGES_BUCKET_NAME", BUCKET);
+});
+
+describe("POST /api/webhooks/agent/storages/prepare", () => {
+  it("rejects missing sandbox auth", async () => {
+    const fixture = await track(seedFixture());
+
+    const response = await accept(
+      prepareClient().prepare({
+        body: prepareBody(fixture),
+        headers: {},
+      }),
+      [401],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Not authenticated or runId mismatch",
+        code: "UNAUTHORIZED",
+      },
+    });
+  });
+
+  it("rejects a body runId that does not match the sandbox token", async () => {
+    const fixture = await track(seedFixture());
+
+    const response = await accept(
+      prepareClient().prepare({
+        body: prepareBody(fixture, { runId: randomUUID() }),
+        headers: authHeaders(fixture),
+      }),
+      [401],
+    );
+
+    expect(response.body.error.message).toBe(
+      "Not authenticated or runId mismatch",
+    );
+  });
+
+  it("creates storage metadata scoped to the sandbox run organization", async () => {
+    const fixture = await track(seedFixture());
+    const name = storageName("webhook-prepare");
+    const body = prepareBody(fixture, { storageName: name });
+
+    const response = await prepareOk(fixture, body);
+
+    expect(response.existing).toBeFalsy();
+    expect(response.uploads?.archive.key).toBe(
+      `${fixture.orgId}/artifact/${name}/${response.versionId}/archive.tar.gz`,
+    );
+    expect(response.uploads?.manifest.key).toBe(
+      `${fixture.orgId}/artifact/${name}/${response.versionId}/manifest.json`,
+    );
+
+    const db = store.set(writeDb$);
+    const [storage] = await db
+      .select()
+      .from(storages)
+      .where(and(eq(storages.orgId, fixture.orgId), eq(storages.name, name)))
+      .limit(1);
+    expect(storage).toMatchObject({
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      name,
+      type: "artifact",
+      size: 0,
+      fileCount: 0,
+    });
+  });
+});
+
+describe("POST /api/webhooks/agent/storages/commit", () => {
+  it("commits uploaded storage and records artifact lineage", async () => {
+    const fixture = await track(seedFixture());
+    const name = storageName("webhook-commit");
+    const parentVersionId = SECOND_TEST_HASH;
+    const prepare = prepareBody(fixture, { storageName: name });
+    const prepared = await prepareOk(fixture, prepare);
+
+    context.mocks.s3.send.mockResolvedValue({});
+    const response = await accept(
+      commitClient().commit({
+        body: commitBody(fixture, {
+          storageName: name,
+          storageType: "artifact",
+          versionId: prepared.versionId,
+          parentVersionId,
+          files: prepare.files,
+          message: "agent commit",
+        }),
+        headers: authHeaders(fixture),
+      }),
+      [200],
+    );
+
+    expect(response.body).toMatchObject({
+      success: true,
+      versionId: prepared.versionId,
+      storageName: name,
+      size: 100,
+      fileCount: 1,
+    });
+
+    const db = store.set(writeDb$);
+    const [storage] = await db
+      .select()
+      .from(storages)
+      .where(and(eq(storages.orgId, fixture.orgId), eq(storages.name, name)))
+      .limit(1);
+    expect(storage?.headVersionId).toBe(prepared.versionId);
+
+    const [version] = await db
+      .select()
+      .from(storageVersions)
+      .where(
+        and(
+          eq(storageVersions.storageId, storage?.id ?? ""),
+          eq(storageVersions.id, prepared.versionId),
+        ),
+      )
+      .limit(1);
+    expect(version).toMatchObject({
+      id: prepared.versionId,
+      size: 100,
+      fileCount: 1,
+      message: "agent commit",
+      createdBy: "agent",
+    });
+
+    const [lineage] = await db
+      .select()
+      .from(storageVersionLineage)
+      .where(eq(storageVersionLineage.versionId, prepared.versionId))
+      .limit(1);
+    expect(lineage).toMatchObject({
+      storageId: storage?.id,
+      versionId: prepared.versionId,
+      parentVersionId,
+      runId: fixture.runId,
+      storageType: "artifact",
+    });
+  });
+
+  it("does not record lineage for volume commits", async () => {
+    const fixture = await track(seedFixture());
+    const name = storageName("webhook-volume");
+    const file = validFile({ path: "volume.txt" });
+    const prepare = prepareBody(fixture, {
+      storageName: name,
+      storageType: "volume",
+      files: [file],
+    });
+    const prepared = await prepareOk(fixture, prepare);
+
+    context.mocks.s3.send.mockResolvedValue({});
+    await accept(
+      commitClient().commit({
+        body: commitBody(fixture, {
+          storageName: name,
+          storageType: "volume",
+          versionId: prepared.versionId,
+          parentVersionId: SECOND_TEST_HASH,
+          files: [file],
+        }),
+        headers: authHeaders(fixture),
+      }),
+      [200],
+    );
+
+    const db = store.set(writeDb$);
+    const lineage = await db
+      .select()
+      .from(storageVersionLineage)
+      .where(eq(storageVersionLineage.versionId, prepared.versionId));
+    expect(lineage).toStrictEqual([]);
+  });
+});

--- a/turbo/apps/api/src/signals/routes/agent-webhook-auth.ts
+++ b/turbo/apps/api/src/signals/routes/agent-webhook-auth.ts
@@ -1,0 +1,33 @@
+import type { SandboxAuth } from "../../types/auth";
+import { isSandboxToken, verifySandboxToken } from "../auth/tokens";
+
+export const unauthorizedRunMismatch = Object.freeze({
+  status: 401 as const,
+  body: Object.freeze({
+    error: Object.freeze({
+      message: "Not authenticated or runId mismatch",
+      code: "UNAUTHORIZED",
+    }),
+  }),
+});
+
+export function getSandboxAuthForRun(
+  expectedRunId: string,
+  authHeader: string | undefined,
+): SandboxAuth | null {
+  if (!authHeader?.startsWith("Bearer ")) {
+    return null;
+  }
+
+  const token = authHeader.substring("Bearer ".length);
+  if (!isSandboxToken(token)) {
+    return null;
+  }
+
+  const auth = verifySandboxToken(token);
+  if (!auth || auth.runId !== expectedRunId) {
+    return null;
+  }
+
+  return auth;
+}

--- a/turbo/apps/api/src/signals/routes/webhooks-agent-health-usage-telemetry.ts
+++ b/turbo/apps/api/src/signals/routes/webhooks-agent-health-usage-telemetry.ts
@@ -11,8 +11,6 @@ import { and, eq } from "drizzle-orm";
 import { notFound } from "../../lib/error";
 import { logger } from "../../lib/log";
 import { nowDate } from "../../lib/time";
-import type { SandboxAuth } from "../../types/auth";
-import { isSandboxToken, verifySandboxToken } from "../auth/tokens";
 import { authorization$ } from "../context/hono";
 import { bodyResultOf } from "../context/request";
 import { waitUntil } from "../context/wait-until";
@@ -22,6 +20,10 @@ import { recordSandboxOperation } from "../external/sandbox-op-log";
 import type { RouteEntry } from "../route";
 import { dispatchProgressCallbacks$ } from "../services/agent-run-callbacks.service";
 import { safeAsync } from "../utils";
+import {
+  getSandboxAuthForRun,
+  unauthorizedRunMismatch,
+} from "./agent-webhook-auth";
 
 const SANDBOX_TELEMETRY_SYSTEM_DATASET = "sandbox-telemetry-system";
 const SANDBOX_TELEMETRY_METRICS_DATASET = "sandbox-telemetry-metrics";
@@ -29,37 +31,6 @@ const SANDBOX_TELEMETRY_NETWORK_DATASET = "sandbox-telemetry-network";
 const PG_FOREIGN_KEY_VIOLATION = "23503";
 
 const L = logger("webhooks:agent");
-
-const unauthorizedRunMismatch = Object.freeze({
-  status: 401 as const,
-  body: Object.freeze({
-    error: Object.freeze({
-      message: "Not authenticated or runId mismatch",
-      code: "UNAUTHORIZED",
-    }),
-  }),
-});
-
-function getSandboxAuthForRun(
-  expectedRunId: string,
-  authHeader: string | undefined,
-): SandboxAuth | null {
-  if (!authHeader?.startsWith("Bearer ")) {
-    return null;
-  }
-
-  const token = authHeader.substring("Bearer ".length);
-  if (!isSandboxToken(token)) {
-    return null;
-  }
-
-  const auth = verifySandboxToken(token);
-  if (!auth || auth.runId !== expectedRunId) {
-    return null;
-  }
-
-  return auth;
-}
 
 function isForeignKeyViolation(error: unknown): boolean {
   if (!(error instanceof Error)) {

--- a/turbo/apps/api/src/signals/routes/webhooks-agent-storage.ts
+++ b/turbo/apps/api/src/signals/routes/webhooks-agent-storage.ts
@@ -1,0 +1,87 @@
+import { command } from "ccstate";
+import {
+  webhookStoragesCommitContract,
+  webhookStoragesPrepareContract,
+} from "@vm0/api-contracts/contracts/webhooks";
+
+import { authorization$ } from "../context/hono";
+import { bodyResultOf } from "../context/request";
+import type { RouteEntry } from "../route";
+import {
+  commitStorageUploadForAuth$,
+  prepareStorageUploadForAuth$,
+} from "../services/storage-write.service";
+import {
+  getSandboxAuthForRun,
+  unauthorizedRunMismatch,
+} from "./agent-webhook-auth";
+
+const prepareBody$ = bodyResultOf(webhookStoragesPrepareContract.prepare);
+const commitBody$ = bodyResultOf(webhookStoragesCommitContract.commit);
+
+const prepareStorage$ = command(async ({ get, set }, signal: AbortSignal) => {
+  const bodyResult = await get(prepareBody$);
+  signal.throwIfAborted();
+  if (!bodyResult.ok) {
+    return bodyResult.response;
+  }
+
+  const body = bodyResult.data;
+  const auth = getSandboxAuthForRun(body.runId, get(authorization$));
+  if (!auth) {
+    return unauthorizedRunMismatch;
+  }
+
+  return await set(
+    prepareStorageUploadForAuth$,
+    {
+      auth: {
+        tokenType: "sandbox",
+        userId: auth.userId,
+        orgId: auth.orgId,
+        runId: auth.runId,
+      },
+      ...body,
+    },
+    signal,
+  );
+});
+
+const commitStorage$ = command(async ({ get, set }, signal: AbortSignal) => {
+  const bodyResult = await get(commitBody$);
+  signal.throwIfAborted();
+  if (!bodyResult.ok) {
+    return bodyResult.response;
+  }
+
+  const body = bodyResult.data;
+  const auth = getSandboxAuthForRun(body.runId, get(authorization$));
+  if (!auth) {
+    return unauthorizedRunMismatch;
+  }
+
+  return await set(
+    commitStorageUploadForAuth$,
+    {
+      auth: {
+        tokenType: "sandbox",
+        userId: auth.userId,
+        orgId: auth.orgId,
+        runId: auth.runId,
+      },
+      ...body,
+    },
+    signal,
+  );
+});
+
+export const webhooksAgentStorageRoutes: readonly RouteEntry[] = [
+  {
+    route: webhookStoragesPrepareContract.prepare,
+    handler: prepareStorage$,
+  },
+  {
+    route: webhookStoragesCommitContract.commit,
+    handler: commitStorage$,
+  },
+];

--- a/turbo/apps/api/src/signals/services/storage-write.service.ts
+++ b/turbo/apps/api/src/signals/services/storage-write.service.ts
@@ -2,11 +2,13 @@ import { MAX_FILE_SIZE_BYTES } from "@vm0/api-contracts/contracts/storages";
 import { VOLUME_ORG_USER_ID } from "@vm0/core/storage-names";
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { storages, storageVersions } from "@vm0/db/schema/storage";
+import { storageVersionLineage } from "@vm0/db/schema/storage-version-lineage";
 import { command, type Computed } from "ccstate";
 import { and, eq } from "drizzle-orm";
 
 import { badRequestMessage, notFound } from "../../lib/error";
 import { env } from "../../lib/env";
+import { logger } from "../../lib/log";
 import { nowDate } from "../../lib/time";
 import type { AuthContext } from "../../types/auth";
 import { writeDb$, type Db } from "../external/db";
@@ -21,6 +23,8 @@ import {
   computeContentHashFromHashes,
   type FileEntryWithHash,
 } from "./storage-content-hash.service";
+
+const L = logger("storage-write");
 
 type StorageType = "volume" | "artifact";
 
@@ -46,6 +50,7 @@ interface CommitStorageInput {
   readonly versionId: string;
   readonly files: readonly FileEntryWithHash[];
   readonly runId?: string;
+  readonly parentVersionId?: string;
   readonly message?: string;
 }
 
@@ -611,6 +616,41 @@ async function commitNewStorageVersion(args: {
   };
 }
 
+async function recordStorageLineage(args: {
+  readonly db: Db;
+  readonly storageId: string;
+  readonly versionId: string;
+  readonly parentVersionId: string | undefined;
+  readonly runId: string | undefined;
+  readonly storageType: StorageType;
+}): Promise<void> {
+  const parentVersionId = args.parentVersionId;
+  const runId = args.runId;
+  if (!parentVersionId || !runId || args.storageType === "volume") {
+    return;
+  }
+
+  const result = await safeAsync(() => {
+    return args.db.insert(storageVersionLineage).values({
+      storageId: args.storageId,
+      versionId: args.versionId,
+      parentVersionId,
+      runId,
+      storageType: args.storageType,
+    });
+  });
+
+  if ("error" in result) {
+    L.error(
+      `Failed to record lineage for ${args.versionId}: ${
+        result.error instanceof Error
+          ? result.error.message
+          : String(result.error)
+      }`,
+    );
+  }
+}
+
 export const prepareStorageUploadForAuth$ = command(
   async (
     { get, set },
@@ -748,7 +788,7 @@ export const commitStorageUploadForAuth$ = command(
       });
     }
 
-    return await commitNewStorageVersion({
+    const response = await commitNewStorageVersion({
       get,
       db: writeDb,
       bucket,
@@ -756,5 +796,20 @@ export const commitStorageUploadForAuth$ = command(
       input: args,
       signal,
     });
+    signal.throwIfAborted();
+
+    if (response.status === 200) {
+      await recordStorageLineage({
+        db: writeDb,
+        storageId: storage.id,
+        versionId: args.versionId,
+        parentVersionId: args.parentVersionId,
+        runId: args.runId,
+        storageType: args.storageType,
+      });
+      signal.throwIfAborted();
+    }
+
+    return response;
   },
 );


### PR DESCRIPTION
## Summary
- add API signal routes for the sandbox agent storage prepare and commit webhooks
- share sandbox webhook runId auth with the existing heartbeat/usage/telemetry routes
- preserve artifact lineage recording for agent commit webhooks
- add route-level integration coverage for auth, prepare/commit, and volume lineage behavior

Closes #13211

## Validation
- pnpm -F api exec vitest run src/signals/routes/__tests__/webhooks-agent-storage.test.ts src/signals/routes/__tests__/storages-write.test.ts
- pnpm -F api check-types
- pnpm -F api lint
- pre-commit: prettier, knip, turbo run check-types --concurrency=1