### PR TITLE
feat(api): add serverless vercel sandbox abstraction

### DIFF
--- a/turbo/apps/api/src/__tests__/test-helpers.ts
+++ b/turbo/apps/api/src/__tests__/test-helpers.ts
@@ -13,9 +13,9 @@ import { closeDbPool } from "../lib/db";
 import { clearMockedEnv } from "../lib/env";
 import { clearMockListStripeInvoices } from "../signals/external/stripe-client";
 import {
-  clearMockVercelSandboxClient,
-  clearMockVercelSandboxSmokeCleanupTimeoutMs,
-} from "../signals/external/vercel-sandbox";
+  clearMockSandboxClient,
+  clearMockSandboxCleanupTimeoutMs,
+} from "../signals/external/sandbox";
 import { ROUTES, type RouteEntry } from "../signals/route";
 import { clearAllDetached } from "../signals/utils";
 import { getApiTestMocks, type ApiTestMocks } from "./mocks";
@@ -139,8 +139,8 @@ export function testContext(): TestContext {
     await clearAllDetached();
     clearMockedEnv();
     clearMockListStripeInvoices();
-    clearMockVercelSandboxClient();
-    clearMockVercelSandboxSmokeCleanupTimeoutMs();
+    clearMockSandboxClient();
+    clearMockSandboxCleanupTimeoutMs();
   });
 
   afterAll(async () => {

--- a/turbo/apps/api/src/signals/external/__tests__/sandbox.test.ts
+++ b/turbo/apps/api/src/signals/external/__tests__/sandbox.test.ts
@@ -96,6 +96,31 @@ describe("sandbox utilities", () => {
     expect(truncated.data.toString()).toBe("abc");
   });
 
+  it("aborts bounded file reads without destroying streams with an error", async () => {
+    const controller = new AbortController();
+    const stream = new (class AbortableReadable extends Readable {
+      destroyedWith: Error | null | undefined;
+
+      override _read(): void {}
+
+      override _destroy(
+        error: Error | null,
+        callback: (error?: Error | null) => void,
+      ): void {
+        this.destroyedWith = error;
+        callback();
+      }
+    })();
+    const error = new Error("request aborted");
+    error.name = "AbortError";
+
+    const read = readStreamToBoundedBuffer(stream, 10, controller.signal);
+    controller.abort(error);
+
+    await expect(read).rejects.toThrow("request aborted");
+    expect(stream.destroyedWith).toBeNull();
+  });
+
   it("redacts command, env, and network policy secrets", () => {
     expect(
       redactSandboxMessage(
@@ -130,10 +155,36 @@ describe("sandbox utilities", () => {
       error: {
         phase: "stop",
         name: "AbortError",
-        message: "Vercel Sandbox cleanup timed out",
+        message: "Sandbox cleanup timed out",
       },
     });
     expect(cleanupSignal?.aborted).toBeTruthy();
+  });
+
+  it("does not start cleanup when the caller signal is already aborted", async () => {
+    const controller = new AbortController();
+    const error = new Error("request aborted");
+    error.name = "AbortError";
+    controller.abort(error);
+    let cleanupStarted = false;
+
+    const result = await sandboxCleanupOperation({
+      signal: controller.signal,
+      operation() {
+        cleanupStarted = true;
+        return Promise.resolve();
+      },
+    });
+
+    expect(result).toStrictEqual({
+      status: "failed",
+      error: {
+        phase: "stop",
+        name: "AbortError",
+        message: "request aborted",
+      },
+    });
+    expect(cleanupStarted).toBeFalsy();
   });
 });
 

--- a/turbo/apps/api/src/signals/external/__tests__/sandbox.test.ts
+++ b/turbo/apps/api/src/signals/external/__tests__/sandbox.test.ts
@@ -1,0 +1,259 @@
+import { Readable } from "node:stream";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { getVercelSandboxClient } from "../vercel-sandbox";
+import {
+  clearMockSandboxCleanupTimeoutMs,
+  clearMockSandboxClient,
+  createBoundedTextCollector,
+  emptyBoundedTextOutput,
+  mockSandboxCleanupTimeoutMs,
+  mockSandboxClient,
+  readStreamToBoundedBuffer,
+  redactSandboxMessage,
+  sandboxCleanupOperation,
+  sandboxError,
+  type SandboxCommandResult,
+  type SandboxHandle,
+} from "../sandbox";
+
+function sandboxHandle(): SandboxHandle {
+  return { sandboxId: "sb_test" };
+}
+
+function commandResult(
+  args: {
+    readonly sandboxId?: string;
+    readonly commandId?: string;
+    readonly exitCode?: number | null;
+    readonly stdout?: string;
+    readonly stderr?: string;
+  } = {},
+): SandboxCommandResult {
+  return {
+    sandboxId: args.sandboxId ?? sandboxHandle().sandboxId,
+    commandId: args.commandId ?? "cmd_test",
+    detached: false,
+    exitCode: args.exitCode ?? 0,
+    stdout:
+      args.stdout === undefined
+        ? emptyBoundedTextOutput(1024)
+        : {
+            text: args.stdout,
+            bytes: Buffer.byteLength(args.stdout),
+            limitBytes: 1024,
+            truncated: false,
+          },
+    stderr:
+      args.stderr === undefined
+        ? emptyBoundedTextOutput(1024)
+        : {
+            text: args.stderr,
+            bytes: Buffer.byteLength(args.stderr),
+            limitBytes: 1024,
+            truncated: false,
+          },
+  };
+}
+
+afterEach(() => {
+  clearMockSandboxClient();
+  clearMockSandboxCleanupTimeoutMs();
+});
+
+describe("sandbox utilities", () => {
+  it("captures bounded command output with truncation metadata", () => {
+    const collector = createBoundedTextCollector(5);
+
+    collector.writable.write("abc");
+    collector.writable.write("def");
+
+    expect(collector.output()).toStrictEqual({
+      text: "abcde",
+      bytes: 6,
+      limitBytes: 5,
+      truncated: true,
+    });
+  });
+
+  it("reads bounded file streams and preserves empty files", async () => {
+    const empty = await readStreamToBoundedBuffer(Readable.from([""]), 10);
+    expect(empty.status).toBe("ok");
+    expect(empty.bytes).toBe(0);
+    expect(empty.data.toString()).toBe("");
+
+    const truncated = await readStreamToBoundedBuffer(
+      Readable.from(["abcdef"]),
+      3,
+    );
+    expect(truncated).toMatchObject({
+      status: "too_large",
+      bytes: 6,
+      limitBytes: 3,
+      truncated: true,
+    });
+    expect(truncated.data.toString()).toBe("abc");
+  });
+
+  it("redacts command, env, and network policy secrets", () => {
+    expect(
+      redactSandboxMessage(
+        'failed Bearer token-value STRIPE_SECRET=sk_test {"authorization":"Bearer abc","x-api-key":"key-value"} password=plain',
+      ),
+    ).toBe(
+      'failed Bearer [redacted] STRIPE_SECRET=[redacted] {"authorization":"[redacted]","x-api-key":"[redacted]"} password=[redacted]',
+    );
+  });
+
+  it("returns structured cleanup failures and aborts timed out cleanup", async () => {
+    let cleanupSignal: AbortSignal | undefined;
+
+    const result = await sandboxCleanupOperation({
+      timeoutMs: 0,
+      operation(signal) {
+        cleanupSignal = signal;
+        return new Promise((_resolve, reject) => {
+          signal.addEventListener(
+            "abort",
+            () => {
+              reject(signal.reason);
+            },
+            { once: true },
+          );
+        });
+      },
+    });
+
+    expect(result).toStrictEqual({
+      status: "failed",
+      error: {
+        phase: "stop",
+        name: "AbortError",
+        message: "Vercel Sandbox cleanup timed out",
+      },
+    });
+    expect(cleanupSignal?.aborted).toBeTruthy();
+  });
+});
+
+describe("Vercel sandbox client test override", () => {
+  it("allows tests to override cleanup timeout", () => {
+    expect(() => {
+      mockSandboxCleanupTimeoutMs(1);
+    }).not.toThrow();
+  });
+
+  it("can fake every operation without Vercel credentials", async () => {
+    const handle = sandboxHandle();
+    const calls = {
+      create: [] as unknown[],
+      get: [] as string[],
+      run: [] as unknown[],
+      read: [] as unknown[],
+      network: [] as unknown[],
+      extend: [] as unknown[],
+      stop: [] as SandboxHandle[],
+    };
+
+    mockSandboxClient({
+      create(options) {
+        calls.create.push(options);
+        return Promise.resolve(handle);
+      },
+      get(sandboxId) {
+        calls.get.push(sandboxId);
+        return Promise.resolve({ sandboxId });
+      },
+      runCommand(sandboxHandle, options) {
+        calls.run.push({ sandboxHandle, options });
+        return Promise.resolve(commandResult());
+      },
+      readFile(sandboxHandle, options) {
+        calls.read.push({ sandboxHandle, options });
+        return Promise.resolve({ status: "missing" });
+      },
+      updateNetworkPolicy(sandboxHandle, options) {
+        calls.network.push({ sandboxHandle, options });
+        return Promise.resolve();
+      },
+      extendTimeout(sandboxHandle, options) {
+        calls.extend.push({ sandboxHandle, options });
+        return Promise.resolve();
+      },
+      stop(sandboxHandle) {
+        calls.stop.push(sandboxHandle);
+        return Promise.resolve({ status: "stopped" });
+      },
+    });
+
+    const client = getVercelSandboxClient();
+    await expect(client.create({ runtime: "node24" })).resolves.toStrictEqual(
+      handle,
+    );
+    await expect(client.get(handle.sandboxId)).resolves.toStrictEqual(handle);
+    await expect(
+      client.runCommand(handle, { cmd: "node", args: ["--version"] }),
+    ).resolves.toMatchObject({ commandId: "cmd_test", exitCode: 0 });
+    await expect(
+      client.readFile(handle, { path: "/tmp/missing" }),
+    ).resolves.toStrictEqual({ status: "missing" });
+    await expect(
+      client.updateNetworkPolicy(handle, { networkPolicy: "deny-all" }),
+    ).resolves.toBeUndefined();
+    await expect(
+      client.extendTimeout(handle, { durationMs: 1000 }),
+    ).resolves.toBeUndefined();
+    await expect(client.stop(handle)).resolves.toStrictEqual({
+      status: "stopped",
+    });
+
+    expect(calls).toMatchObject({
+      create: [{ runtime: "node24" }],
+      get: ["sb_test"],
+      stop: [handle],
+    });
+  });
+
+  it("can return sanitized fake cleanup failures", async () => {
+    const handle = sandboxHandle();
+    mockSandboxClient({
+      create() {
+        return Promise.resolve(handle);
+      },
+      get(sandboxId) {
+        return Promise.resolve({ sandboxId });
+      },
+      runCommand() {
+        return Promise.resolve(commandResult());
+      },
+      readFile() {
+        return Promise.resolve({ status: "missing" });
+      },
+      updateNetworkPolicy() {
+        return Promise.resolve();
+      },
+      extendTimeout() {
+        return Promise.resolve();
+      },
+      stop() {
+        return Promise.resolve({
+          status: "failed",
+          error: sandboxError(
+            "stop",
+            new Error("stop failed authorization=Bearer secret"),
+          ),
+        });
+      },
+    });
+
+    await expect(getVercelSandboxClient().stop(handle)).resolves.toStrictEqual({
+      status: "failed",
+      error: {
+        phase: "stop",
+        name: "Error",
+        message: "stop failed authorization=[redacted]",
+      },
+    });
+  });
+});

--- a/turbo/apps/api/src/signals/external/sandbox.ts
+++ b/turbo/apps/api/src/signals/external/sandbox.ts
@@ -1,0 +1,577 @@
+import { Writable } from "node:stream";
+
+import { timeout } from "signal-timers";
+
+import { testOverride } from "../../lib/singleton";
+
+export const DEFAULT_SANDBOX_OUTPUT_LIMIT_BYTES = 64 * 1024;
+export const DEFAULT_SANDBOX_FILE_LIMIT_BYTES = 64 * 1024;
+const DEFAULT_SANDBOX_CLEANUP_TIMEOUT_MS = 15 * 1000;
+
+export interface SandboxHandle {
+  readonly sandboxId: string;
+}
+
+export interface SandboxCommandHandle {
+  readonly sandboxId: string;
+  readonly commandId: string;
+}
+
+export interface SandboxResources {
+  readonly vcpus: number;
+}
+
+interface SandboxNetworkTransformer {
+  readonly headers?: Readonly<Record<string, string>>;
+}
+
+interface SandboxNetworkPolicyRule {
+  readonly transform?: readonly SandboxNetworkTransformer[];
+}
+
+export type SandboxNetworkPolicy =
+  | "allow-all"
+  | "deny-all"
+  | {
+      readonly allow?:
+        | readonly string[]
+        | Readonly<Record<string, readonly SandboxNetworkPolicyRule[]>>;
+      readonly subnets?: {
+        readonly allow?: readonly string[];
+        readonly deny?: readonly string[];
+      };
+    };
+
+export interface CreateSandboxOptions {
+  readonly runtime?: string;
+  readonly timeoutMs?: number;
+  readonly resources?: SandboxResources;
+  readonly ports?: readonly number[];
+  readonly env?: Readonly<Record<string, string>>;
+  readonly networkPolicy?: SandboxNetworkPolicy;
+  readonly signal?: AbortSignal;
+}
+
+export interface SandboxOperationOptions {
+  readonly signal?: AbortSignal;
+}
+
+export interface RunSandboxCommandOptions {
+  readonly cmd: string;
+  readonly args?: readonly string[];
+  readonly cwd?: string;
+  readonly env?: Readonly<Record<string, string>>;
+  readonly detached?: boolean;
+  readonly outputLimitBytes?: number;
+  readonly signal?: AbortSignal;
+}
+
+export interface ReadSandboxFileOptions {
+  readonly path: string;
+  readonly cwd?: string;
+  readonly limitBytes?: number;
+  readonly signal?: AbortSignal;
+}
+
+export interface UpdateSandboxNetworkPolicyOptions {
+  readonly networkPolicy: SandboxNetworkPolicy;
+  readonly signal?: AbortSignal;
+}
+
+export interface ExtendSandboxTimeoutOptions {
+  readonly durationMs: number;
+  readonly signal?: AbortSignal;
+}
+
+export interface StopSandboxOptions {
+  readonly blocking?: boolean;
+  readonly timeoutMs?: number;
+  readonly signal?: AbortSignal;
+}
+
+export interface BoundedTextOutput {
+  readonly text: string;
+  readonly bytes: number;
+  readonly limitBytes: number;
+  readonly truncated: boolean;
+}
+
+export interface SandboxCommandResult {
+  readonly sandboxId: string;
+  readonly commandId: string;
+  readonly detached: boolean;
+  readonly exitCode: number | null;
+  readonly stdout: BoundedTextOutput;
+  readonly stderr: BoundedTextOutput;
+}
+
+export type SandboxFileReadResult =
+  | {
+      readonly status: "missing";
+    }
+  | {
+      readonly status: "ok";
+      readonly data: Buffer;
+      readonly bytes: number;
+      readonly limitBytes: number;
+      readonly truncated: false;
+    }
+  | {
+      readonly status: "too_large";
+      readonly data: Buffer;
+      readonly bytes: number;
+      readonly limitBytes: number;
+      readonly truncated: true;
+    };
+
+export type SandboxErrorPhase =
+  | "create"
+  | "get"
+  | "run"
+  | "read"
+  | "network"
+  | "extend-timeout"
+  | "stop";
+
+export interface SandboxError {
+  readonly phase: SandboxErrorPhase;
+  readonly name: string;
+  readonly message: string;
+}
+
+type SandboxOperationResult<T> =
+  | { readonly ok: true; readonly value: T }
+  | { readonly ok: false; readonly error: SandboxError };
+
+export type SandboxCleanupResult =
+  | {
+      readonly status: "stopped";
+    }
+  | {
+      readonly status: "failed";
+      readonly error: SandboxError;
+    };
+
+export interface SandboxClient {
+  readonly create: (options?: CreateSandboxOptions) => Promise<SandboxHandle>;
+  readonly get: (
+    sandboxId: string,
+    options?: SandboxOperationOptions,
+  ) => Promise<SandboxHandle>;
+  readonly runCommand: (
+    handle: SandboxHandle,
+    options: RunSandboxCommandOptions,
+  ) => Promise<SandboxCommandResult>;
+  readonly getCommand?: (
+    handle: SandboxHandle,
+    commandId: string,
+    options?: SandboxOperationOptions,
+  ) => Promise<SandboxCommandHandle>;
+  readonly waitCommand?: (
+    command: SandboxCommandHandle,
+    options?: SandboxOperationOptions,
+  ) => Promise<SandboxCommandResult>;
+  readonly readFile: (
+    handle: SandboxHandle,
+    options: ReadSandboxFileOptions,
+  ) => Promise<SandboxFileReadResult>;
+  readonly updateNetworkPolicy: (
+    handle: SandboxHandle,
+    options: UpdateSandboxNetworkPolicyOptions,
+  ) => Promise<void>;
+  readonly extendTimeout: (
+    handle: SandboxHandle,
+    options: ExtendSandboxTimeoutOptions,
+  ) => Promise<void>;
+  readonly stop: (
+    handle: SandboxHandle,
+    options?: StopSandboxOptions,
+  ) => Promise<SandboxCleanupResult>;
+}
+
+const {
+  get: getMockedSandboxClient,
+  set: setMockedSandboxClient,
+  clear: clearMockedSandboxClient,
+} = testOverride<SandboxClient | undefined>(() => {
+  return undefined;
+});
+
+const {
+  get: getMockedSandboxCleanupTimeoutMs,
+  set: setMockedSandboxCleanupTimeoutMs,
+  clear: clearMockedSandboxCleanupTimeoutMs,
+} = testOverride<number | undefined>(() => {
+  return undefined;
+});
+
+export function getMockSandboxClient(): SandboxClient | undefined {
+  return getMockedSandboxClient();
+}
+
+export function mockSandboxClient(client: SandboxClient): void {
+  setMockedSandboxClient(client);
+}
+
+export function clearMockSandboxClient(): void {
+  clearMockedSandboxClient();
+}
+
+export function getSandboxCleanupTimeoutMs(): number | undefined {
+  return getMockedSandboxCleanupTimeoutMs();
+}
+
+export function mockSandboxCleanupTimeoutMs(timeoutMs: number): void {
+  setMockedSandboxCleanupTimeoutMs(timeoutMs);
+}
+
+export function clearMockSandboxCleanupTimeoutMs(): void {
+  clearMockedSandboxCleanupTimeoutMs();
+}
+
+export function normalizeSandboxLimitBytes(
+  limitBytes: number | undefined,
+  defaultLimitBytes: number,
+): number {
+  if (limitBytes === undefined) {
+    return defaultLimitBytes;
+  }
+  if (!Number.isSafeInteger(limitBytes) || limitBytes < 0) {
+    throw new RangeError("Sandbox byte limit must be a non-negative integer");
+  }
+  return limitBytes;
+}
+
+export function emptyBoundedTextOutput(limitBytes: number): BoundedTextOutput {
+  return {
+    text: "",
+    bytes: 0,
+    limitBytes,
+    truncated: false,
+  };
+}
+
+class BoundedTextWritable extends Writable {
+  readonly #chunks: Buffer[] = [];
+  readonly #limitBytes: number;
+  #bytes = 0;
+  #storedBytes = 0;
+  #truncated = false;
+
+  constructor(limitBytes: number) {
+    super();
+    this.#limitBytes = limitBytes;
+  }
+
+  override _write(
+    chunk: unknown,
+    encoding: BufferEncoding,
+    callback: (error?: Error | null) => void,
+  ): void {
+    const buffer = Buffer.isBuffer(chunk)
+      ? chunk
+      : Buffer.from(String(chunk), encoding);
+    this.#bytes += buffer.length;
+
+    const remainingBytes = this.#limitBytes - this.#storedBytes;
+    if (remainingBytes > 0) {
+      const stored = buffer.subarray(0, remainingBytes);
+      this.#chunks.push(stored);
+      this.#storedBytes += stored.length;
+    }
+    if (buffer.length > remainingBytes) {
+      this.#truncated = true;
+    }
+
+    callback();
+  }
+
+  output(): BoundedTextOutput {
+    return {
+      text: Buffer.concat(this.#chunks, this.#storedBytes).toString("utf8"),
+      bytes: this.#bytes,
+      limitBytes: this.#limitBytes,
+      truncated: this.#truncated,
+    };
+  }
+}
+
+interface BoundedTextCollector {
+  readonly writable: Writable;
+  readonly output: () => BoundedTextOutput;
+}
+
+export function createBoundedTextCollector(
+  limitBytes: number,
+): BoundedTextCollector {
+  const writable = new BoundedTextWritable(limitBytes);
+  return {
+    writable,
+    output() {
+      return writable.output();
+    },
+  };
+}
+
+function bufferFromStreamChunk(chunk: unknown): Buffer {
+  if (Buffer.isBuffer(chunk)) {
+    return chunk;
+  }
+  if (chunk instanceof Uint8Array) {
+    return Buffer.from(chunk);
+  }
+  return Buffer.from(String(chunk));
+}
+
+function stopReadableStream(
+  stream: NodeJS.ReadableStream,
+  reason?: unknown,
+): void {
+  const destroy = (
+    stream as NodeJS.ReadableStream & {
+      destroy?: (error?: Error) => void;
+    }
+  ).destroy;
+  if (destroy) {
+    destroy.call(stream, reason instanceof Error ? reason : undefined);
+    return;
+  }
+  stream.pause();
+}
+
+export function readStreamToBoundedBuffer(
+  stream: NodeJS.ReadableStream,
+  limitBytes: number,
+  signal?: AbortSignal,
+): Promise<Exclude<SandboxFileReadResult, { readonly status: "missing" }>> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    let bytes = 0;
+    let storedBytes = 0;
+    let settled = false;
+    let truncated = false;
+
+    function cleanup() {
+      stream.removeListener("data", onData);
+      stream.removeListener("end", onEnd);
+      stream.removeListener("error", onError);
+      signal?.removeEventListener("abort", onAbort);
+    }
+
+    function result():
+      | Extract<SandboxFileReadResult, { readonly status: "ok" }>
+      | Extract<SandboxFileReadResult, { readonly status: "too_large" }> {
+      const data = Buffer.concat(chunks, storedBytes);
+      if (truncated) {
+        return {
+          status: "too_large",
+          data,
+          bytes,
+          limitBytes,
+          truncated: true,
+        };
+      }
+      return {
+        status: "ok",
+        data,
+        bytes,
+        limitBytes,
+        truncated: false,
+      };
+    }
+
+    function finish(
+      value:
+        | Exclude<SandboxFileReadResult, { readonly status: "missing" }>
+        | undefined,
+      error?: unknown,
+    ) {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      cleanup();
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve(value ?? result());
+    }
+
+    function onData(chunk: unknown) {
+      const buffer = bufferFromStreamChunk(chunk);
+      bytes += buffer.length;
+
+      const remainingBytes = limitBytes - storedBytes;
+      if (remainingBytes > 0) {
+        const stored = buffer.subarray(0, remainingBytes);
+        chunks.push(stored);
+        storedBytes += stored.length;
+      }
+      if (buffer.length > remainingBytes) {
+        truncated = true;
+        stopReadableStream(stream);
+        finish(result());
+      }
+    }
+
+    function onEnd() {
+      finish(result());
+    }
+
+    function onError(error: unknown) {
+      finish(undefined, error);
+    }
+
+    function onAbort() {
+      const reason = signal?.reason ?? new Error("Sandbox file read aborted");
+      stopReadableStream(stream, reason);
+      finish(undefined, reason);
+    }
+
+    if (signal?.aborted) {
+      onAbort();
+      return;
+    }
+
+    stream.on("data", onData);
+    stream.once("end", onEnd);
+    stream.once("error", onError);
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+export function redactSandboxMessage(message: string): string {
+  return message
+    .replace(
+      /(["']?\b[\w.-]*(?:token|secret|password|authorization|api[_-]?key|key)[\w.-]*\b["']?\s*[:=]\s*)(["'])(?:(?!\2).)*\2/gi,
+      "$1$2[redacted]$2",
+    )
+    .replace(
+      /(["']?\b[\w.-]*(?:token|secret|password|authorization|api[_-]?key|key)[\w.-]*\b["']?\s*[:=]\s*)Bearer\s+[A-Za-z0-9._~+/=-]+/gi,
+      "$1[redacted]",
+    )
+    .replace(
+      /(["']?\b[\w.-]*(?:token|secret|password|authorization|api[_-]?key|key)[\w.-]*\b["']?\s*[:=]\s*)[^"',}&\s]+/gi,
+      "$1[redacted]",
+    )
+    .replace(/Bearer\s+[A-Za-z0-9._~+/=-]+/gi, "Bearer [redacted]")
+    .slice(0, 1000);
+}
+
+export function sandboxError(
+  phase: SandboxErrorPhase,
+  error: unknown,
+): SandboxError {
+  if (error instanceof Error) {
+    return {
+      phase,
+      name: error.name,
+      message: redactSandboxMessage(error.message),
+    };
+  }
+  return {
+    phase,
+    name: "Error",
+    message: redactSandboxMessage(String(error)),
+  };
+}
+
+export function sandboxOperation<T>(
+  phase: SandboxErrorPhase,
+  fn: () => Promise<T>,
+): Promise<SandboxOperationResult<T>> {
+  return Promise.resolve()
+    .then(fn)
+    .then(
+      (value) => {
+        return { ok: true, value } as const;
+      },
+      (error: unknown) => {
+        return { ok: false, error: sandboxError(phase, error) } as const;
+      },
+    );
+}
+
+function cleanupTimeoutError(): Error {
+  const error = new Error("Vercel Sandbox cleanup timed out");
+  error.name = "AbortError";
+  return error;
+}
+
+export async function sandboxCleanupOperation(args: {
+  readonly timeoutMs?: number;
+  readonly signal?: AbortSignal;
+  readonly operation: (signal: AbortSignal) => Promise<void>;
+}): Promise<SandboxCleanupResult> {
+  const timeoutMs = args.timeoutMs ?? DEFAULT_SANDBOX_CLEANUP_TIMEOUT_MS;
+  const cleanupController = new AbortController();
+  const timeoutController = new AbortController();
+
+  const operationResultPromise = sandboxOperation("stop", () => {
+    return args.operation(cleanupController.signal);
+  });
+
+  const timeoutResultPromise = new Promise<SandboxOperationResult<void>>(
+    (resolve) => {
+      let settled = false;
+      function finish(error: unknown, abortOperation: boolean) {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        args.signal?.removeEventListener("abort", onAbort);
+        timeoutController.signal.removeEventListener(
+          "abort",
+          onTimeoutCanceled,
+        );
+        if (abortOperation) {
+          cleanupController.abort(error);
+        }
+        resolve({ ok: false, error: sandboxError("stop", error) });
+      }
+      function onAbort() {
+        finish(
+          args.signal?.reason ?? new Error("Vercel Sandbox cleanup aborted"),
+          true,
+        );
+      }
+      function onTimeoutCanceled() {
+        finish(new Error("Vercel Sandbox cleanup timeout canceled"), false);
+      }
+
+      if (args.signal?.aborted) {
+        onAbort();
+        return;
+      }
+
+      args.signal?.addEventListener("abort", onAbort, { once: true });
+      timeoutController.signal.addEventListener("abort", onTimeoutCanceled, {
+        once: true,
+      });
+      timeout(
+        () => {
+          finish(cleanupTimeoutError(), true);
+        },
+        timeoutMs,
+        { signal: timeoutController.signal },
+      );
+    },
+  );
+
+  const result = await Promise.race([
+    operationResultPromise,
+    timeoutResultPromise,
+  ]).finally(() => {
+    timeoutController.abort();
+  });
+
+  if (result.ok) {
+    return { status: "stopped" };
+  }
+
+  return {
+    status: "failed",
+    error: result.error,
+  };
+}

--- a/turbo/apps/api/src/signals/external/sandbox.ts
+++ b/turbo/apps/api/src/signals/external/sandbox.ts
@@ -323,17 +323,14 @@ function bufferFromStreamChunk(chunk: unknown): Buffer {
   return Buffer.from(String(chunk));
 }
 
-function stopReadableStream(
-  stream: NodeJS.ReadableStream,
-  reason?: unknown,
-): void {
+function stopReadableStream(stream: NodeJS.ReadableStream): void {
   const destroy = (
     stream as NodeJS.ReadableStream & {
       destroy?: (error?: Error) => void;
     }
   ).destroy;
   if (destroy) {
-    destroy.call(stream, reason instanceof Error ? reason : undefined);
+    destroy.call(stream);
     return;
   }
   stream.pause();
@@ -425,7 +422,7 @@ export function readStreamToBoundedBuffer(
 
     function onAbort() {
       const reason = signal?.reason ?? new Error("Sandbox file read aborted");
-      stopReadableStream(stream, reason);
+      stopReadableStream(stream);
       finish(undefined, reason);
     }
 
@@ -477,6 +474,12 @@ export function sandboxError(
   };
 }
 
+export function sandboxErrorToException(error: SandboxError): Error {
+  const exception = new Error(error.message);
+  exception.name = error.name;
+  return exception;
+}
+
 export function sandboxOperation<T>(
   phase: SandboxErrorPhase,
   fn: () => Promise<T>,
@@ -494,7 +497,7 @@ export function sandboxOperation<T>(
 }
 
 function cleanupTimeoutError(): Error {
-  const error = new Error("Vercel Sandbox cleanup timed out");
+  const error = new Error("Sandbox cleanup timed out");
   error.name = "AbortError";
   return error;
 }
@@ -508,9 +511,15 @@ export async function sandboxCleanupOperation(args: {
   const cleanupController = new AbortController();
   const timeoutController = new AbortController();
 
-  const operationResultPromise = sandboxOperation("stop", () => {
-    return args.operation(cleanupController.signal);
-  });
+  if (args.signal?.aborted) {
+    return {
+      status: "failed",
+      error: sandboxError(
+        "stop",
+        args.signal.reason ?? new Error("Sandbox cleanup aborted"),
+      ),
+    };
+  }
 
   const timeoutResultPromise = new Promise<SandboxOperationResult<void>>(
     (resolve) => {
@@ -532,12 +541,12 @@ export async function sandboxCleanupOperation(args: {
       }
       function onAbort() {
         finish(
-          args.signal?.reason ?? new Error("Vercel Sandbox cleanup aborted"),
+          args.signal?.reason ?? new Error("Sandbox cleanup aborted"),
           true,
         );
       }
       function onTimeoutCanceled() {
-        finish(new Error("Vercel Sandbox cleanup timeout canceled"), false);
+        finish(new Error("Sandbox cleanup timeout canceled"), false);
       }
 
       if (args.signal?.aborted) {
@@ -558,6 +567,10 @@ export async function sandboxCleanupOperation(args: {
       );
     },
   );
+
+  const operationResultPromise = sandboxOperation("stop", () => {
+    return args.operation(cleanupController.signal);
+  });
 
   const result = await Promise.race([
     operationResultPromise,

--- a/turbo/apps/api/src/signals/external/vercel-sandbox.ts
+++ b/turbo/apps/api/src/signals/external/vercel-sandbox.ts
@@ -9,8 +9,11 @@ import {
   normalizeSandboxLimitBytes,
   readStreamToBoundedBuffer,
   sandboxCleanupOperation,
+  sandboxErrorToException,
+  sandboxOperation,
   type SandboxClient,
   type SandboxCommandResult,
+  type SandboxErrorPhase,
   type SandboxFileReadResult,
   type SandboxHandle,
 } from "./sandbox";
@@ -37,106 +40,132 @@ async function getSandbox(
   return Sandbox.get({ sandboxId: handle.sandboxId, signal });
 }
 
+async function vercelSandboxOperation<T>(
+  phase: SandboxErrorPhase,
+  operation: () => Promise<T>,
+): Promise<T> {
+  const result = await sandboxOperation(phase, operation);
+  if (result.ok) {
+    return result.value;
+  }
+
+  throw sandboxErrorToException(result.error);
+}
+
 function createRealVercelSandboxClient(): SandboxClient {
   return {
-    async create(options = {}): Promise<SandboxHandle> {
-      const Sandbox = await getVercelSandboxClass();
-      const sandbox = await Sandbox.create({
-        runtime: options.runtime,
-        timeout: options.timeoutMs,
-        resources: options.resources,
-        ports: options.ports ? [...options.ports] : undefined,
-        env: options.env ? { ...options.env } : undefined,
-        networkPolicy: options.networkPolicy as VercelNetworkPolicy | undefined,
-        signal: options.signal,
+    create(options = {}): Promise<SandboxHandle> {
+      return vercelSandboxOperation("create", async () => {
+        const Sandbox = await getVercelSandboxClass();
+        const sandbox = await Sandbox.create({
+          runtime: options.runtime,
+          timeout: options.timeoutMs,
+          resources: options.resources,
+          ports: options.ports ? [...options.ports] : undefined,
+          env: options.env ? { ...options.env } : undefined,
+          networkPolicy: options.networkPolicy as
+            | VercelNetworkPolicy
+            | undefined,
+          signal: options.signal,
+        });
+
+        return { sandboxId: sandbox.sandboxId };
       });
-
-      return { sandboxId: sandbox.sandboxId };
     },
 
-    async get(sandboxId, options = {}): Promise<SandboxHandle> {
-      const sandbox = await getSandbox({ sandboxId }, options.signal);
-      return { sandboxId: sandbox.sandboxId };
+    get(sandboxId, options = {}): Promise<SandboxHandle> {
+      return vercelSandboxOperation("get", async () => {
+        const sandbox = await getSandbox({ sandboxId }, options.signal);
+        return { sandboxId: sandbox.sandboxId };
+      });
     },
 
-    async runCommand(handle, options): Promise<SandboxCommandResult> {
-      const outputLimitBytes = normalizeSandboxLimitBytes(
-        options.outputLimitBytes,
-        DEFAULT_SANDBOX_OUTPUT_LIMIT_BYTES,
-      );
-      const sandbox = await getSandbox(handle, options.signal);
+    runCommand(handle, options): Promise<SandboxCommandResult> {
+      return vercelSandboxOperation("run", async () => {
+        const outputLimitBytes = normalizeSandboxLimitBytes(
+          options.outputLimitBytes,
+          DEFAULT_SANDBOX_OUTPUT_LIMIT_BYTES,
+        );
+        const sandbox = await getSandbox(handle, options.signal);
 
-      if (options.detached) {
+        if (options.detached) {
+          const command = await sandbox.runCommand({
+            cmd: options.cmd,
+            args: options.args ? [...options.args] : undefined,
+            cwd: options.cwd,
+            env: options.env ? { ...options.env } : undefined,
+            detached: true,
+            signal: options.signal,
+          });
+
+          return {
+            sandboxId: handle.sandboxId,
+            commandId: command.cmdId,
+            detached: true,
+            exitCode: command.exitCode,
+            stdout: emptyBoundedTextOutput(outputLimitBytes),
+            stderr: emptyBoundedTextOutput(outputLimitBytes),
+          };
+        }
+
+        const stdout = createBoundedTextCollector(outputLimitBytes);
+        const stderr = createBoundedTextCollector(outputLimitBytes);
         const command = await sandbox.runCommand({
           cmd: options.cmd,
           args: options.args ? [...options.args] : undefined,
           cwd: options.cwd,
           env: options.env ? { ...options.env } : undefined,
-          detached: true,
+          stdout: stdout.writable,
+          stderr: stderr.writable,
           signal: options.signal,
         });
 
         return {
           sandboxId: handle.sandboxId,
           commandId: command.cmdId,
-          detached: true,
+          detached: false,
           exitCode: command.exitCode,
-          stdout: emptyBoundedTextOutput(outputLimitBytes),
-          stderr: emptyBoundedTextOutput(outputLimitBytes),
+          stdout: stdout.output(),
+          stderr: stderr.output(),
         };
-      }
-
-      const stdout = createBoundedTextCollector(outputLimitBytes);
-      const stderr = createBoundedTextCollector(outputLimitBytes);
-      const command = await sandbox.runCommand({
-        cmd: options.cmd,
-        args: options.args ? [...options.args] : undefined,
-        cwd: options.cwd,
-        env: options.env ? { ...options.env } : undefined,
-        stdout: stdout.writable,
-        stderr: stderr.writable,
-        signal: options.signal,
       });
-
-      return {
-        sandboxId: handle.sandboxId,
-        commandId: command.cmdId,
-        detached: false,
-        exitCode: command.exitCode,
-        stdout: stdout.output(),
-        stderr: stderr.output(),
-      };
     },
 
-    async readFile(handle, options): Promise<SandboxFileReadResult> {
-      const limitBytes = normalizeSandboxLimitBytes(
-        options.limitBytes,
-        DEFAULT_SANDBOX_FILE_LIMIT_BYTES,
-      );
-      const sandbox = await getSandbox(handle, options.signal);
-      const stream = await sandbox.readFile(
-        { path: options.path, cwd: options.cwd },
-        { signal: options.signal },
-      );
-      if (!stream) {
-        return { status: "missing" };
-      }
+    readFile(handle, options): Promise<SandboxFileReadResult> {
+      return vercelSandboxOperation("read", async () => {
+        const limitBytes = normalizeSandboxLimitBytes(
+          options.limitBytes,
+          DEFAULT_SANDBOX_FILE_LIMIT_BYTES,
+        );
+        const sandbox = await getSandbox(handle, options.signal);
+        const stream = await sandbox.readFile(
+          { path: options.path, cwd: options.cwd },
+          { signal: options.signal },
+        );
+        if (!stream) {
+          return { status: "missing" };
+        }
 
-      return readStreamToBoundedBuffer(stream, limitBytes, options.signal);
+        return readStreamToBoundedBuffer(stream, limitBytes, options.signal);
+      });
     },
 
-    async updateNetworkPolicy(handle, options): Promise<void> {
-      const sandbox = await getSandbox(handle, options.signal);
-      await sandbox.updateNetworkPolicy(
-        options.networkPolicy as VercelNetworkPolicy,
-        { signal: options.signal },
-      );
+    updateNetworkPolicy(handle, options): Promise<void> {
+      return vercelSandboxOperation("network", async () => {
+        const sandbox = await getSandbox(handle, options.signal);
+        await sandbox.updateNetworkPolicy(
+          options.networkPolicy as VercelNetworkPolicy,
+          { signal: options.signal },
+        );
+      });
     },
 
-    async extendTimeout(handle, options): Promise<void> {
-      const sandbox = await getSandbox(handle, options.signal);
-      await sandbox.extendTimeout(options.durationMs, {
-        signal: options.signal,
+    extendTimeout(handle, options): Promise<void> {
+      return vercelSandboxOperation("extend-timeout", async () => {
+        const sandbox = await getSandbox(handle, options.signal);
+        await sandbox.extendTimeout(options.durationMs, {
+          signal: options.signal,
+        });
       });
     },
 

--- a/turbo/apps/api/src/signals/external/vercel-sandbox.ts
+++ b/turbo/apps/api/src/signals/external/vercel-sandbox.ts
@@ -1,131 +1,161 @@
-import { singleton, testOverride } from "../../lib/singleton";
+import { singleton } from "../../lib/singleton";
+import {
+  createBoundedTextCollector,
+  DEFAULT_SANDBOX_FILE_LIMIT_BYTES,
+  DEFAULT_SANDBOX_OUTPUT_LIMIT_BYTES,
+  emptyBoundedTextOutput,
+  getMockSandboxClient,
+  getSandboxCleanupTimeoutMs,
+  normalizeSandboxLimitBytes,
+  readStreamToBoundedBuffer,
+  sandboxCleanupOperation,
+  type SandboxClient,
+  type SandboxCommandResult,
+  type SandboxFileReadResult,
+  type SandboxHandle,
+} from "./sandbox";
 
 type VercelSandboxSdk = typeof import("@vercel/sandbox");
+type VercelNetworkPolicy = import("@vercel/sandbox").NetworkPolicy;
 
 export const VERCEL_SANDBOX_SMOKE_RUNTIME = "node24";
 export const VERCEL_SANDBOX_SMOKE_TIMEOUT_MS = 60 * 1000;
-const VERCEL_SANDBOX_SMOKE_CLEANUP_TIMEOUT_MS = 15 * 1000;
-
-export interface VercelSandboxCommandOptions {
-  readonly cmd: string;
-  readonly args?: readonly string[];
-  readonly signal?: AbortSignal;
-}
-
-export interface VercelSandboxCommandResult {
-  readonly exitCode: number;
-  readonly stdout: string;
-  readonly stderr: string;
-}
-
-export interface VercelSandboxInstance {
-  readonly id: string;
-  readonly runCommand: (
-    options: VercelSandboxCommandOptions,
-  ) => Promise<VercelSandboxCommandResult>;
-  readonly stop: (options?: { readonly signal?: AbortSignal }) => Promise<void>;
-}
-
-export interface CreateVercelSandboxOptions {
-  readonly runtime?: string;
-  readonly timeoutMs?: number;
-  readonly signal?: AbortSignal;
-}
-
-interface VercelSandboxClient {
-  readonly create: (
-    options?: CreateVercelSandboxOptions,
-  ) => Promise<VercelSandboxInstance>;
-}
 
 const getVercelSandboxClass = singleton(
   async (): Promise<VercelSandboxSdk["Sandbox"]> => {
-    // This SDK is only needed by the smoke route; keep normal API route init light.
+    // The SDK is only needed by sandbox-backed flows; keep normal API route init light.
     const sdk = await import("@vercel/sandbox");
     return sdk.Sandbox;
   },
 );
 
-function createRealVercelSandboxClient(): VercelSandboxClient {
+async function getSandbox(
+  handle: SandboxHandle,
+  signal?: AbortSignal,
+): Promise<Awaited<ReturnType<VercelSandboxSdk["Sandbox"]["get"]>>> {
+  const Sandbox = await getVercelSandboxClass();
+  return Sandbox.get({ sandboxId: handle.sandboxId, signal });
+}
+
+function createRealVercelSandboxClient(): SandboxClient {
   return {
-    async create(options = {}): Promise<VercelSandboxInstance> {
+    async create(options = {}): Promise<SandboxHandle> {
       const Sandbox = await getVercelSandboxClass();
       const sandbox = await Sandbox.create({
-        runtime: options.runtime ?? VERCEL_SANDBOX_SMOKE_RUNTIME,
-        timeout: options.timeoutMs ?? VERCEL_SANDBOX_SMOKE_TIMEOUT_MS,
+        runtime: options.runtime,
+        timeout: options.timeoutMs,
+        resources: options.resources,
+        ports: options.ports ? [...options.ports] : undefined,
+        env: options.env ? { ...options.env } : undefined,
+        networkPolicy: options.networkPolicy as VercelNetworkPolicy | undefined,
+        signal: options.signal,
+      });
+
+      return { sandboxId: sandbox.sandboxId };
+    },
+
+    async get(sandboxId, options = {}): Promise<SandboxHandle> {
+      const sandbox = await getSandbox({ sandboxId }, options.signal);
+      return { sandboxId: sandbox.sandboxId };
+    },
+
+    async runCommand(handle, options): Promise<SandboxCommandResult> {
+      const outputLimitBytes = normalizeSandboxLimitBytes(
+        options.outputLimitBytes,
+        DEFAULT_SANDBOX_OUTPUT_LIMIT_BYTES,
+      );
+      const sandbox = await getSandbox(handle, options.signal);
+
+      if (options.detached) {
+        const command = await sandbox.runCommand({
+          cmd: options.cmd,
+          args: options.args ? [...options.args] : undefined,
+          cwd: options.cwd,
+          env: options.env ? { ...options.env } : undefined,
+          detached: true,
+          signal: options.signal,
+        });
+
+        return {
+          sandboxId: handle.sandboxId,
+          commandId: command.cmdId,
+          detached: true,
+          exitCode: command.exitCode,
+          stdout: emptyBoundedTextOutput(outputLimitBytes),
+          stderr: emptyBoundedTextOutput(outputLimitBytes),
+        };
+      }
+
+      const stdout = createBoundedTextCollector(outputLimitBytes);
+      const stderr = createBoundedTextCollector(outputLimitBytes);
+      const command = await sandbox.runCommand({
+        cmd: options.cmd,
+        args: options.args ? [...options.args] : undefined,
+        cwd: options.cwd,
+        env: options.env ? { ...options.env } : undefined,
+        stdout: stdout.writable,
+        stderr: stderr.writable,
         signal: options.signal,
       });
 
       return {
-        id: sandbox.sandboxId,
-        async runCommand(
-          commandOptions: VercelSandboxCommandOptions,
-        ): Promise<VercelSandboxCommandResult> {
-          const command = await sandbox.runCommand(
-            commandOptions.cmd,
-            [...(commandOptions.args ?? [])],
-            { signal: commandOptions.signal },
-          );
-          const [stdout, stderr] = await Promise.all([
-            command.stdout({ signal: commandOptions.signal }),
-            command.stderr({ signal: commandOptions.signal }),
-          ]);
-
-          return {
-            exitCode: command.exitCode,
-            stdout,
-            stderr,
-          };
-        },
-        async stop(options = {}): Promise<void> {
-          await sandbox.stop({ blocking: true, signal: options.signal });
-        },
+        sandboxId: handle.sandboxId,
+        commandId: command.cmdId,
+        detached: false,
+        exitCode: command.exitCode,
+        stdout: stdout.output(),
+        stderr: stderr.output(),
       };
+    },
+
+    async readFile(handle, options): Promise<SandboxFileReadResult> {
+      const limitBytes = normalizeSandboxLimitBytes(
+        options.limitBytes,
+        DEFAULT_SANDBOX_FILE_LIMIT_BYTES,
+      );
+      const sandbox = await getSandbox(handle, options.signal);
+      const stream = await sandbox.readFile(
+        { path: options.path, cwd: options.cwd },
+        { signal: options.signal },
+      );
+      if (!stream) {
+        return { status: "missing" };
+      }
+
+      return readStreamToBoundedBuffer(stream, limitBytes, options.signal);
+    },
+
+    async updateNetworkPolicy(handle, options): Promise<void> {
+      const sandbox = await getSandbox(handle, options.signal);
+      await sandbox.updateNetworkPolicy(
+        options.networkPolicy as VercelNetworkPolicy,
+        { signal: options.signal },
+      );
+    },
+
+    async extendTimeout(handle, options): Promise<void> {
+      const sandbox = await getSandbox(handle, options.signal);
+      await sandbox.extendTimeout(options.durationMs, {
+        signal: options.signal,
+      });
+    },
+
+    stop(handle, options = {}) {
+      return sandboxCleanupOperation({
+        timeoutMs: options.timeoutMs ?? getSandboxCleanupTimeoutMs(),
+        signal: options.signal,
+        operation: async (signal) => {
+          const sandbox = await getSandbox(handle, signal);
+          await sandbox.stop({
+            blocking: options.blocking ?? true,
+            signal,
+          });
+        },
+      });
     },
   };
 }
 
-const {
-  get: getMockedVercelSandboxClient,
-  set: setMockedVercelSandboxClient,
-  clear: clearMockedVercelSandboxClient,
-} = testOverride<VercelSandboxClient | undefined>(() => {
-  return undefined;
-});
-
-const {
-  get: getMockedVercelSandboxCleanupTimeoutMs,
-  set: setMockedVercelSandboxCleanupTimeoutMs,
-  clear: clearMockedVercelSandboxCleanupTimeoutMs,
-} = testOverride<number | undefined>(() => {
-  return undefined;
-});
-
-export function getVercelSandboxClient(): VercelSandboxClient {
-  return getMockedVercelSandboxClient() ?? createRealVercelSandboxClient();
-}
-
-export function getVercelSandboxSmokeCleanupTimeoutMs(): number {
-  return (
-    getMockedVercelSandboxCleanupTimeoutMs() ??
-    VERCEL_SANDBOX_SMOKE_CLEANUP_TIMEOUT_MS
-  );
-}
-
-export function mockVercelSandboxClient(client: VercelSandboxClient): void {
-  setMockedVercelSandboxClient(client);
-}
-
-export function clearMockVercelSandboxClient(): void {
-  clearMockedVercelSandboxClient();
-}
-
-export function mockVercelSandboxSmokeCleanupTimeoutMs(
-  timeoutMs: number,
-): void {
-  setMockedVercelSandboxCleanupTimeoutMs(timeoutMs);
-}
-
-export function clearMockVercelSandboxSmokeCleanupTimeoutMs(): void {
-  clearMockedVercelSandboxCleanupTimeoutMs();
+export function getVercelSandboxClient(): SandboxClient {
+  return getMockSandboxClient() ?? createRealVercelSandboxClient();
 }

--- a/turbo/apps/api/src/signals/routes/__tests__/vercel-sandbox-smoke.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/vercel-sandbox-smoke.test.ts
@@ -1,12 +1,16 @@
 import { mockEnv } from "../../../lib/env";
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
 import {
-  mockVercelSandboxClient,
-  mockVercelSandboxSmokeCleanupTimeoutMs,
-  type CreateVercelSandboxOptions,
-  type VercelSandboxCommandOptions,
-  type VercelSandboxCommandResult,
-} from "../../external/vercel-sandbox";
+  emptyBoundedTextOutput,
+  mockSandboxClient,
+  sandboxError,
+  type CreateSandboxOptions,
+  type RunSandboxCommandOptions,
+  type SandboxCleanupResult,
+  type SandboxCommandResult,
+  type SandboxHandle,
+  type StopSandboxOptions,
+} from "../../external/sandbox";
 import { vercelSandboxSmokeContract } from "../vercel-sandbox-smoke";
 
 const context = testContext();
@@ -20,55 +24,104 @@ function mockSandbox(
     readonly createError?: unknown;
     readonly runError?: unknown;
     readonly stopError?: unknown;
-    readonly stop?: (options?: {
-      readonly signal?: AbortSignal;
-    }) => Promise<void>;
-    readonly runResult?: VercelSandboxCommandResult;
+    readonly runResult?: SandboxCommandResult;
+    readonly stop?: (
+      handle: SandboxHandle,
+      options?: StopSandboxOptions,
+    ) => Promise<SandboxCleanupResult>;
   } = {},
 ) {
+  const handle = { sandboxId: "sandbox_smoke_test" };
   const calls = {
-    create: [] as CreateVercelSandboxOptions[],
-    run: [] as VercelSandboxCommandOptions[],
-    stop: [] as ({ readonly signal?: AbortSignal } | undefined)[],
+    create: [] as CreateSandboxOptions[],
+    run: [] as {
+      readonly handle: SandboxHandle;
+      readonly options: RunSandboxCommandOptions;
+    }[],
+    stop: [] as {
+      readonly handle: SandboxHandle;
+      readonly options: StopSandboxOptions | undefined;
+    }[],
   };
 
-  mockVercelSandboxClient({
+  mockSandboxClient({
     create(options = {}) {
       calls.create.push(options);
       if (args.createError !== undefined) {
         throw args.createError;
       }
 
+      return Promise.resolve(handle);
+    },
+    get(sandboxId) {
+      return Promise.resolve({ sandboxId });
+    },
+    runCommand(commandHandle, options) {
+      calls.run.push({ handle: commandHandle, options });
+      if (args.runError !== undefined) {
+        throw args.runError;
+      }
+      return Promise.resolve(
+        args.runResult ?? commandResult({ exitCode: 0, stdout: "v24.0.0\n" }),
+      );
+    },
+    readFile() {
+      throw new Error("readFile is not used by the smoke route");
+    },
+    updateNetworkPolicy() {
+      throw new Error("updateNetworkPolicy is not used by the smoke route");
+    },
+    extendTimeout() {
+      throw new Error("extendTimeout is not used by the smoke route");
+    },
+    stop(commandHandle, options) {
+      calls.stop.push({ handle: commandHandle, options });
+      if (args.stop) {
+        return args.stop(commandHandle, options);
+      }
+      if (args.stopError !== undefined) {
+        return Promise.resolve({
+          status: "failed",
+          error: sandboxError("stop", args.stopError),
+        });
+      }
       return Promise.resolve({
-        id: "sandbox_smoke_test",
-        runCommand(options) {
-          calls.run.push(options);
-          if (args.runError !== undefined) {
-            throw args.runError;
-          }
-          return Promise.resolve(
-            args.runResult ?? {
-              exitCode: 0,
-              stdout: "v24.0.0\n",
-              stderr: "",
-            },
-          );
-        },
-        stop(options) {
-          calls.stop.push(options);
-          if (args.stopError !== undefined) {
-            throw args.stopError;
-          }
-          if (args.stop) {
-            return args.stop(options);
-          }
-          return Promise.resolve();
-        },
+        status: "stopped",
       });
     },
   });
 
   return calls;
+}
+
+function textOutput(text: string) {
+  return {
+    text,
+    bytes: Buffer.byteLength(text),
+    limitBytes: 1024,
+    truncated: false,
+  };
+}
+
+function commandResult(args: {
+  readonly exitCode: number | null;
+  readonly stdout?: string;
+  readonly stderr?: string;
+}): SandboxCommandResult {
+  return {
+    sandboxId: "sandbox_smoke_test",
+    commandId: "cmd_smoke_test",
+    detached: false,
+    exitCode: args.exitCode,
+    stdout:
+      args.stdout === undefined
+        ? emptyBoundedTextOutput(1024)
+        : textOutput(args.stdout),
+    stderr:
+      args.stderr === undefined
+        ? emptyBoundedTextOutput(1024)
+        : textOutput(args.stderr),
+  };
 }
 
 function abortError(message: string): Error {
@@ -142,12 +195,15 @@ describe("POST /api/internal/vercel-sandbox/smoke", () => {
       timeoutMs: 60_000,
     });
     expect(calls.run).toHaveLength(1);
-    expect(calls.run[0]).toMatchObject({
+    expect(calls.run[0]?.options).toMatchObject({
       cmd: "node",
       args: ["--version"],
+      outputLimitBytes: 1024,
     });
     expect(calls.stop).toHaveLength(1);
-    expect(calls.stop[0]?.signal).toBeInstanceOf(AbortSignal);
+    expect(calls.stop[0]?.handle).toStrictEqual({
+      sandboxId: "sandbox_smoke_test",
+    });
   });
 
   it("returns a failure when sandbox creation fails", async () => {
@@ -300,27 +356,15 @@ describe("POST /api/internal/vercel-sandbox/smoke", () => {
     expect(calls.stop).toHaveLength(1);
   });
 
-  it("fails cleanup when sandbox stop waits for the cleanup timeout", async () => {
-    mockVercelSandboxSmokeCleanupTimeoutMs(0);
+  it("fails cleanup when sandbox stop reports a cleanup timeout", async () => {
     const calls = mockSandbox({
-      stop(options) {
-        return new Promise((_resolve, reject) => {
-          const signal = options?.signal;
-          if (!signal) {
-            reject(new Error("stop called without a cleanup signal"));
-            return;
-          }
-          if (signal.aborted) {
-            reject(signal.reason);
-            return;
-          }
-          signal.addEventListener(
-            "abort",
-            () => {
-              reject(signal.reason);
-            },
-            { once: true },
-          );
+      stop() {
+        return Promise.resolve({
+          status: "failed",
+          error: sandboxError(
+            "stop",
+            abortError("Vercel Sandbox cleanup timed out"),
+          ),
         });
       },
     });
@@ -362,7 +406,6 @@ describe("POST /api/internal/vercel-sandbox/smoke", () => {
       },
     });
     expect(calls.stop).toHaveLength(1);
-    expect(calls.stop[0]?.signal?.aborted).toBeTruthy();
   });
 
   it("returns command diagnostics when cleanup fails", async () => {
@@ -411,11 +454,11 @@ describe("POST /api/internal/vercel-sandbox/smoke", () => {
 
   it("treats a non-zero command exit as a smoke failure", async () => {
     const calls = mockSandbox({
-      runResult: {
+      runResult: commandResult({
         exitCode: 1,
         stdout: "",
         stderr: "unexpected\n",
-      },
+      }),
     });
 
     const response = await accept(

--- a/turbo/apps/api/src/signals/routes/__tests__/vercel-sandbox-smoke.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/vercel-sandbox-smoke.test.ts
@@ -361,10 +361,7 @@ describe("POST /api/internal/vercel-sandbox/smoke", () => {
       stop() {
         return Promise.resolve({
           status: "failed",
-          error: sandboxError(
-            "stop",
-            abortError("Vercel Sandbox cleanup timed out"),
-          ),
+          error: sandboxError("stop", abortError("Sandbox cleanup timed out")),
         });
       },
     });
@@ -383,7 +380,7 @@ describe("POST /api/internal/vercel-sandbox/smoke", () => {
         phase: "cleanup",
         cause: {
           name: "AbortError",
-          message: "Vercel Sandbox cleanup timed out",
+          message: "Sandbox cleanup timed out",
         },
       },
       sandbox: {
@@ -401,7 +398,7 @@ describe("POST /api/internal/vercel-sandbox/smoke", () => {
         status: "failed",
         error: {
           name: "AbortError",
-          message: "Vercel Sandbox cleanup timed out",
+          message: "Sandbox cleanup timed out",
         },
       },
     });
@@ -476,6 +473,36 @@ describe("POST /api/internal/vercel-sandbox/smoke", () => {
       stdout: "",
       stderr: "unexpected\n",
     });
+    expect(response.body.cleanup).toStrictEqual({ status: "stopped" });
+    expect(calls.stop).toHaveLength(1);
+  });
+
+  it("treats a missing command exit code as a smoke failure", async () => {
+    const calls = mockSandbox({
+      runResult: commandResult({
+        exitCode: null,
+        stdout: "started\n",
+        stderr: "",
+      }),
+    });
+
+    const response = await accept(
+      client().smoke({
+        headers: { authorization: "Bearer test-cron-secret" },
+      }),
+      [503],
+    );
+
+    expect(response.body.error).toStrictEqual({
+      message: "Vercel Sandbox smoke check failed during command execution",
+      code: "VERCEL_SANDBOX_SMOKE_FAILED",
+      phase: "run",
+      cause: {
+        name: "Error",
+        message: "Smoke command did not produce an exit code",
+      },
+    });
+    expect(response.body.command).toBeUndefined();
     expect(response.body.cleanup).toStrictEqual({ status: "stopped" });
     expect(calls.stop).toHaveLength(1);
   });

--- a/turbo/apps/api/src/signals/services/vercel-sandbox-smoke.service.ts
+++ b/turbo/apps/api/src/signals/services/vercel-sandbox-smoke.service.ts
@@ -1,22 +1,21 @@
-import { timeout } from "signal-timers";
-
 import {
   getVercelSandboxClient,
-  getVercelSandboxSmokeCleanupTimeoutMs,
   VERCEL_SANDBOX_SMOKE_RUNTIME,
   VERCEL_SANDBOX_SMOKE_TIMEOUT_MS,
-  type VercelSandboxCommandResult,
-  type VercelSandboxInstance,
 } from "../external/vercel-sandbox";
+import {
+  sandboxOperation,
+  type SandboxCleanupResult,
+  type SandboxCommandResult,
+  type SandboxError,
+  type SandboxHandle,
+} from "../external/sandbox";
 
 const SMOKE_COMMAND = Object.freeze({
   cmd: "node",
   args: ["--version"] as const,
 });
-
-type SandboxOperationResult<T> =
-  | { readonly ok: true; readonly value: T }
-  | { readonly ok: false; readonly error: unknown };
+const SMOKE_OUTPUT_LIMIT_BYTES = 1024;
 
 export type VercelSandboxSmokePhase = "create" | "run" | "cleanup";
 
@@ -63,147 +62,42 @@ export type VercelSandboxSmokeResult =
       readonly cleanup?: VercelSandboxSmokeCleanup;
     };
 
-function redactErrorMessage(message: string): string {
-  return message
-    .replace(/Bearer\s+[A-Za-z0-9._~+/=-]+/gi, "Bearer [redacted]")
-    .replace(
-      /(["']?\b[\w.-]*(?:token|secret|password)[\w.-]*\b["']?\s*[:=]\s*)(["']?)[^"',}&\s]+(["']?)/gi,
-      "$1$2[redacted]$3",
-    )
-    .slice(0, 1000);
-}
-
-function smokeError(error: unknown): VercelSandboxSmokeError {
-  if (error instanceof Error) {
-    return {
-      name: error.name,
-      message: redactErrorMessage(error.message),
-    };
-  }
-
+function smokeError(error: SandboxError): VercelSandboxSmokeError {
   return {
-    name: "Error",
-    message: redactErrorMessage(String(error)),
+    name: error.name,
+    message: error.message,
   };
 }
 
-function sandboxInfo(
-  sandbox: VercelSandboxInstance,
-): VercelSandboxSmokeSandbox {
+function sandboxInfo(sandbox: SandboxHandle): VercelSandboxSmokeSandbox {
   return {
-    id: sandbox.id,
+    id: sandbox.sandboxId,
     runtime: VERCEL_SANDBOX_SMOKE_RUNTIME,
   };
 }
 
 function commandInfo(
-  result: VercelSandboxCommandResult,
+  result: SandboxCommandResult & { readonly exitCode: number },
 ): VercelSandboxSmokeCommand {
   return {
     cmd: SMOKE_COMMAND.cmd,
     args: SMOKE_COMMAND.args,
     exitCode: result.exitCode,
-    stdout: result.stdout,
-    stderr: result.stderr,
+    stdout: result.stdout.text,
+    stderr: result.stderr.text,
   };
 }
 
-function sandboxOperation<T>(
-  fn: () => Promise<T>,
-): Promise<SandboxOperationResult<T>> {
-  return Promise.resolve()
-    .then(fn)
-    .then(
-      (value) => {
-        return { ok: true, value } as const;
-      },
-      (error: unknown) => {
-        return { ok: false, error } as const;
-      },
-    );
-}
-
-function cleanupTimeoutError(): Error {
-  const error = new Error("Vercel Sandbox cleanup timed out");
-  error.name = "AbortError";
-  return error;
-}
-
-function canceledCleanupTimeoutResult(
-  signal: AbortSignal,
-): SandboxOperationResult<void> {
-  return {
-    ok: false,
-    error:
-      signal.reason ?? new Error("Vercel Sandbox cleanup timeout canceled"),
-  };
-}
-
-function cleanupTimeoutResult(
-  cleanupController: AbortController,
-): SandboxOperationResult<void> {
-  const error = cleanupTimeoutError();
-  cleanupController.abort(error);
-
-  return { ok: false, error };
-}
-
-function cleanupTimeoutOperation(
-  cleanupController: AbortController,
-  cleanupTimeoutSignal: AbortSignal,
-): Promise<SandboxOperationResult<void>> {
-  return new Promise((resolve) => {
-    let settled = false;
-    function finish(result: SandboxOperationResult<void>) {
-      if (settled) {
-        return;
-      }
-      settled = true;
-      cleanupTimeoutSignal.removeEventListener("abort", onAbort);
-      resolve(result);
-    }
-    function onAbort() {
-      finish(canceledCleanupTimeoutResult(cleanupTimeoutSignal));
-    }
-
-    cleanupTimeoutSignal.addEventListener("abort", onAbort, { once: true });
-    timeout(
-      () => {
-        finish(cleanupTimeoutResult(cleanupController));
-      },
-      getVercelSandboxSmokeCleanupTimeoutMs(),
-      { signal: cleanupTimeoutSignal },
-    );
-  });
-}
-
-async function stopSandbox(
-  sandbox: VercelSandboxInstance,
-): Promise<VercelSandboxSmokeCleanup> {
-  const cleanupController = new AbortController();
-  const cleanupTimeoutController = new AbortController();
-  const stopResultPromise = sandboxOperation(() => {
-    return sandbox.stop({ signal: cleanupController.signal });
-  });
-  const cleanupTimeoutResultPromise = cleanupTimeoutOperation(
-    cleanupController,
-    cleanupTimeoutController.signal,
-  );
-
-  const stopResult = await Promise.race([
-    stopResultPromise,
-    cleanupTimeoutResultPromise,
-  ]).finally(() => {
-    cleanupTimeoutController.abort();
-  });
-
-  if (stopResult.ok) {
+function smokeCleanup(
+  cleanup: SandboxCleanupResult,
+): VercelSandboxSmokeCleanup {
+  if (cleanup.status === "stopped") {
     return { status: "stopped" };
   }
 
   return {
     status: "failed",
-    error: smokeError(stopResult.error),
+    error: smokeError(cleanup.error),
   };
 }
 
@@ -211,7 +105,7 @@ export async function runVercelSandboxSmoke(
   signal: AbortSignal,
 ): Promise<VercelSandboxSmokeResult> {
   const client = getVercelSandboxClient();
-  const createResult = await sandboxOperation(() => {
+  const createResult = await sandboxOperation("create", () => {
     return client.create({
       runtime: VERCEL_SANDBOX_SMOKE_RUNTIME,
       timeoutMs: VERCEL_SANDBOX_SMOKE_TIMEOUT_MS,
@@ -231,21 +125,32 @@ export async function runVercelSandboxSmoke(
   let command: VercelSandboxSmokeCommand | undefined;
   let runError: VercelSandboxSmokeError | undefined;
 
-  const runResult = await sandboxOperation(() => {
-    return sandbox.runCommand({
+  const runResult = await sandboxOperation("run", () => {
+    return client.runCommand(sandbox, {
       cmd: SMOKE_COMMAND.cmd,
       args: SMOKE_COMMAND.args,
+      outputLimitBytes: SMOKE_OUTPUT_LIMIT_BYTES,
       signal,
     });
   });
 
   if (runResult.ok) {
-    command = commandInfo(runResult.value);
+    if (runResult.value.exitCode === null) {
+      runError = {
+        name: "Error",
+        message: "Smoke command did not produce an exit code",
+      };
+    } else {
+      command = commandInfo({
+        ...runResult.value,
+        exitCode: runResult.value.exitCode,
+      });
+    }
   } else {
     runError = smokeError(runResult.error);
   }
 
-  const cleanup = await stopSandbox(sandbox);
+  const cleanup = smokeCleanup(await client.stop(sandbox));
   const sandboxPayload = sandboxInfo(sandbox);
 
   if (runError) {


### PR DESCRIPTION
Closes #13208

## Summary
- Add a provider-neutral sandbox abstraction for serverless use, including handles, command execution, bounded output/file reads, network policy updates, timeout extension, cleanup, and redacted structured errors.
- Implement the abstraction on top of Vercel Sandbox using `Sandbox.get` rehydration for serverless requests.
- Migrate the Vercel Sandbox smoke endpoint and tests to use the generic sandbox client mock.

## Tests
- `pnpm -C turbo/apps/api exec vitest run src/signals/external/__tests__/sandbox.test.ts src/signals/routes/__tests__/vercel-sandbox-smoke.test.ts`
- `pnpm -C turbo --filter api lint`
- `pnpm -C turbo --filter api check-types`
- `pnpm -C turbo --filter api build`
- pre-commit: `knip` and full `turbo run check-types --concurrency=1`