### PR TITLE
refactor: collapse apiBackendMutations into apiBackend

### DIFF
--- a/turbo/apps/platform/src/signals/__tests__/api-client.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/api-client.test.ts
@@ -247,33 +247,8 @@ describe("zeroClient$ 401 redirect", () => {
   });
 });
 
-describe("zeroClient$ apiBackendMutations routing", () => {
-  it("routes POST contract requests to api host when flag is on", async () => {
-    vi.stubGlobal("location", new URL("https://platform.vm0.ai/"));
-    detachedSetupPage({
-      context,
-      path: "/",
-      withoutRender: true,
-      featureSwitches: { apiBackendMutations: true },
-    });
-
-    const requestHosts: string[] = [];
-    server.use(
-      mockApi(zeroFeatureSwitchesContract.update, ({ request, respond }) => {
-        requestHosts.push(new URL(request.url).host);
-        return respond(200, { switches: {} });
-      }),
-    );
-
-    const createClient = context.store.get(zeroClient$);
-    const client = createClient(zeroFeatureSwitchesContract);
-    const result = await client.update({ body: { switches: {} } });
-
-    expect(result.status).toBe(200);
-    expect(requestHosts).toStrictEqual(["api.vm0.ai"]);
-  });
-
-  it("keeps POST contract requests on www when flag is off", async () => {
+describe("zeroClient$ apiBackend routing", () => {
+  it("keeps POST contract requests on www when apiBackend is off", async () => {
     vi.stubGlobal("location", new URL("https://platform.vm0.ai/"));
     detachedSetupPage({
       context,
@@ -297,13 +272,37 @@ describe("zeroClient$ apiBackendMutations routing", () => {
     expect(requestHosts).toStrictEqual(["www.vm0.ai"]);
   });
 
-  it("does not affect GET contract requests on zeroClient$", async () => {
+  it("routes POST contract requests to api host when apiBackend is on", async () => {
     vi.stubGlobal("location", new URL("https://platform.vm0.ai/"));
     detachedSetupPage({
       context,
       path: "/",
       withoutRender: true,
-      featureSwitches: { apiBackendMutations: true },
+      featureSwitches: { apiBackend: true },
+    });
+
+    const requestHosts: string[] = [];
+    server.use(
+      mockApi(zeroFeatureSwitchesContract.update, ({ request, respond }) => {
+        requestHosts.push(new URL(request.url).host);
+        return respond(200, { switches: {} });
+      }),
+    );
+
+    const createClient = context.store.get(zeroClient$);
+    const client = createClient(zeroFeatureSwitchesContract);
+    const result = await client.update({ body: { switches: {} } });
+
+    expect(result.status).toBe(200);
+    expect(requestHosts).toStrictEqual(["api.vm0.ai"]);
+  });
+
+  it("keeps GET contract requests on www when apiBackend is off", async () => {
+    vi.stubGlobal("location", new URL("https://platform.vm0.ai/"));
+    detachedSetupPage({
+      context,
+      path: "/",
+      withoutRender: true,
     });
 
     const requestHosts: string[] = [];
@@ -327,32 +326,37 @@ describe("zeroClient$ apiBackendMutations routing", () => {
     expect(requestHosts).toStrictEqual(["www.vm0.ai"]);
   });
 
-  it("apiBackend on forces mutations to api regardless of mutations flag", async () => {
+  it("routes GET contract requests to api host when apiBackend is on", async () => {
     vi.stubGlobal("location", new URL("https://platform.vm0.ai/"));
     detachedSetupPage({
       context,
       path: "/",
       withoutRender: true,
-      featureSwitches: { apiBackend: true, apiBackendMutations: false },
+      featureSwitches: { apiBackend: true },
     });
 
     const requestHosts: string[] = [];
     server.use(
-      mockApi(zeroFeatureSwitchesContract.update, ({ request, respond }) => {
+      mockApi(zeroOrgContract.get, ({ request, respond }) => {
         requestHosts.push(new URL(request.url).host);
-        return respond(200, { switches: {} });
+        return respond(200, {
+          id: "org_1",
+          name: "Org",
+          slug: "org-1",
+          role: "admin",
+        });
       }),
     );
 
     const createClient = context.store.get(zeroClient$);
-    const client = createClient(zeroFeatureSwitchesContract);
-    const result = await client.update({ body: { switches: {} } });
+    const client = createClient(zeroOrgContract);
+    const result = await client.get();
 
     expect(result.status).toBe(200);
     expect(requestHosts).toStrictEqual(["api.vm0.ai"]);
   });
 
-  it("apiBase: 'api' override still wins for GET regardless of flag state", async () => {
+  it("apiBase: 'api' override still wins for GET when apiBackend is off", async () => {
     vi.stubGlobal("location", new URL("https://platform.vm0.ai/"));
     detachedSetupPage({
       context,

--- a/turbo/apps/platform/src/signals/__tests__/fetch.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/fetch.test.ts
@@ -490,8 +490,10 @@ describe("401 refresh-and-retry", () => {
   });
 });
 
-describe("apiBackendMutations routing", () => {
-  function captureMutationHosts(method: "post" | "put" | "patch" | "delete") {
+describe("apiBackend routing", () => {
+  function captureItemHosts(
+    method: "get" | "post" | "put" | "patch" | "delete",
+  ) {
     const hosts: string[] = [];
     server.use(
       http[method]("*/api/zero/items", ({ request }) => {
@@ -502,23 +504,7 @@ describe("apiBackendMutations routing", () => {
     return hosts;
   }
 
-  it("routes POST to api host when apiBackendMutations is on", async () => {
-    vi.stubGlobal("location", new URL("https://platform.vm0.ai/"));
-    detachedSetupPage({
-      context,
-      path: "/",
-      withoutRender: true,
-      featureSwitches: { apiBackendMutations: true },
-    });
-
-    const hosts = captureMutationHosts("post");
-    const fch = context.store.get(fetch$);
-    await fch("/api/zero/items", { method: "POST" });
-
-    expect(hosts).toStrictEqual(["api.vm0.ai"]);
-  });
-
-  it("keeps POST on www when apiBackendMutations is off", async () => {
+  it("keeps GET and POST on www when apiBackend is off", async () => {
     vi.stubGlobal("location", new URL("https://platform.vm0.ai/"));
     detachedSetupPage({
       context,
@@ -526,63 +512,46 @@ describe("apiBackendMutations routing", () => {
       withoutRender: true,
     });
 
-    const hosts = captureMutationHosts("post");
-    const fch = context.store.get(fetch$);
-    await fch("/api/zero/items", { method: "POST" });
-
-    expect(hosts).toStrictEqual(["www.vm0.ai"]);
-  });
-
-  it("does not affect GET routing", async () => {
-    vi.stubGlobal("location", new URL("https://platform.vm0.ai/"));
-    detachedSetupPage({
-      context,
-      path: "/",
-      withoutRender: true,
-      featureSwitches: { apiBackendMutations: true },
-    });
-
-    const hosts: string[] = [];
-    server.use(
-      http.get("*/api/zero/items", ({ request }) => {
-        hosts.push(new URL(request.url).host);
-        return new Response(null, { status: 200 });
-      }),
-    );
-
+    const getHosts = captureItemHosts("get");
+    const postHosts = captureItemHosts("post");
     const fch = context.store.get(fetch$);
     await fch("/api/zero/items");
+    await fch("/api/zero/items", { method: "POST" });
 
-    expect(hosts).toStrictEqual(["www.vm0.ai"]);
+    expect(getHosts).toStrictEqual(["www.vm0.ai"]);
+    expect(postHosts).toStrictEqual(["www.vm0.ai"]);
   });
 
-  it("apiBackend on forces mutations to api regardless of mutations flag", async () => {
+  it("routes GET and POST to api host when apiBackend is on", async () => {
     vi.stubGlobal("location", new URL("https://platform.vm0.ai/"));
     detachedSetupPage({
       context,
       path: "/",
       withoutRender: true,
-      featureSwitches: { apiBackend: true, apiBackendMutations: false },
+      featureSwitches: { apiBackend: true },
     });
 
-    const hosts = captureMutationHosts("put");
+    const getHosts = captureItemHosts("get");
+    const postHosts = captureItemHosts("post");
     const fch = context.store.get(fetch$);
-    await fch("/api/zero/items", { method: "PUT" });
+    await fch("/api/zero/items");
+    await fch("/api/zero/items", { method: "POST" });
 
-    expect(hosts).toStrictEqual(["api.vm0.ai"]);
+    expect(getHosts).toStrictEqual(["api.vm0.ai"]);
+    expect(postHosts).toStrictEqual(["api.vm0.ai"]);
   });
 
-  it("routes PATCH and DELETE the same way as POST", async () => {
+  it("routes PATCH and DELETE the same way as POST when apiBackend is on", async () => {
     vi.stubGlobal("location", new URL("https://platform.vm0.ai/"));
     detachedSetupPage({
       context,
       path: "/",
       withoutRender: true,
-      featureSwitches: { apiBackendMutations: true },
+      featureSwitches: { apiBackend: true },
     });
 
-    const patchHosts = captureMutationHosts("patch");
-    const deleteHosts = captureMutationHosts("delete");
+    const patchHosts = captureItemHosts("patch");
+    const deleteHosts = captureItemHosts("delete");
     const fch = context.store.get(fetch$);
 
     await fch("/api/zero/items", { method: "PATCH" });
@@ -592,16 +561,16 @@ describe("apiBackendMutations routing", () => {
     expect(deleteHosts).toStrictEqual(["api.vm0.ai"]);
   });
 
-  it("classifies methods on a Request input", async () => {
+  it("routes Request input through apiBackend", async () => {
     vi.stubGlobal("location", new URL("https://platform.vm0.ai/"));
     detachedSetupPage({
       context,
       path: "/",
       withoutRender: true,
-      featureSwitches: { apiBackendMutations: true },
+      featureSwitches: { apiBackend: true },
     });
 
-    const hosts = captureMutationHosts("post");
+    const hosts = captureItemHosts("post");
     const fch = context.store.get(fetch$);
     await fch(new Request("/api/zero/items", { method: "POST" }));
 

--- a/turbo/apps/platform/src/signals/api-base.ts
+++ b/turbo/apps/platform/src/signals/api-base.ts
@@ -63,13 +63,3 @@ export function resolveApiBaseForNavigation(useApiBackend: boolean): string {
   }
   return browserOriginBase(target) ?? configuredApiBase(target);
 }
-
-export function isMutationMethod(method: string): boolean {
-  const upper = method.toUpperCase();
-  return (
-    upper === "POST" ||
-    upper === "PUT" ||
-    upper === "PATCH" ||
-    upper === "DELETE"
-  );
-}

--- a/turbo/apps/platform/src/signals/api-client.ts
+++ b/turbo/apps/platform/src/signals/api-client.ts
@@ -11,8 +11,8 @@ import type {
   InitClientReturn,
 } from "@ts-rest/core";
 import { clerk$ } from "./auth.ts";
-import { apiBase$, apiBaseForMutation$ } from "./fetch.ts";
-import { isMutationMethod, resolveApiBase } from "./api-base.ts";
+import { apiBase$ } from "./fetch.ts";
+import { resolveApiBase } from "./api-base.ts";
 import { createAuthedTsRestClient } from "./api-client-base.ts";
 
 /**
@@ -59,14 +59,11 @@ export const zeroClient$ = computed((get) => {
       getClerk: () => {
         return get(clerk$);
       },
-      resolvePath: async (path, { method }) => {
+      resolvePath: async (path) => {
         if (options?.apiBase === "api") {
           return rebaseApiPath(path, resolveApiBase(true));
         }
-        const apiBase = isMutationMethod(method)
-          ? await get(apiBaseForMutation$)
-          : await get(apiBase$);
-        return rebaseApiPath(path, apiBase);
+        return rebaseApiPath(path, await get(apiBase$));
       },
     });
   };

--- a/turbo/apps/platform/src/signals/external/feature-switch.ts
+++ b/turbo/apps/platform/src/signals/external/feature-switch.ts
@@ -56,10 +56,6 @@ export const apiBackendEnabled$ = computed((get) => {
   return get(featureSwitch$)[FeatureSwitchKey.ApiBackend] ?? false;
 });
 
-export const apiBackendMutationsEnabled$ = computed((get) => {
-  return get(featureSwitch$)[FeatureSwitchKey.ApiBackendMutations] ?? false;
-});
-
 export const reloadFeatureSwitch$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     const clerk = await get(clerk$);

--- a/turbo/apps/platform/src/signals/fetch.ts
+++ b/turbo/apps/platform/src/signals/fetch.ts
@@ -1,15 +1,8 @@
 import { computed } from "ccstate";
-import {
-  apiBackendEnabled$,
-  apiBackendMutationsEnabled$,
-} from "./external/feature-switch.ts";
+import { apiBackendEnabled$ } from "./external/feature-switch.ts";
 import { clerk$ } from "./auth.ts";
 import { fetchFreshToken, handleUnauthorizedRedirect } from "./auth-retry.ts";
-import {
-  isMutationMethod,
-  resolveApiBase,
-  resolveApiBaseForNavigation,
-} from "./api-base.ts";
+import { resolveApiBase, resolveApiBaseForNavigation } from "./api-base.ts";
 
 /**
  * API base URL for opening external navigation (e.g. connector OAuth popup).
@@ -29,23 +22,6 @@ export const apiBaseForNavigation$ = computed(async (get) => {
  */
 export const apiBase$ = computed(async (get) => {
   return resolveApiBase(await get(apiBackendEnabled$));
-});
-
-/**
- * API base URL for mutation requests (POST/PUT/PATCH/DELETE).
- *
- * Resolves to the api host when either the master ApiBackend flag is on,
- * or the per-mutation ApiBackendMutations flag is on. The mutation flag
- * exists so Stage 3 of the api-backend migration can flip mutations to
- * api.vm0.ai per-org without flipping ApiBackend (which would also move
- * GETs that may not be ready). Unported mutation routes still work because
- * apps/api falls back to web for unmatched routes.
- */
-export const apiBaseForMutation$ = computed(async (get) => {
-  if (await get(apiBackendEnabled$)) {
-    return resolveApiBase(true);
-  }
-  return resolveApiBase(await get(apiBackendMutationsEnabled$));
 });
 
 function mergeHeadersWithAutoIds(
@@ -120,24 +96,11 @@ function rewriteRequestUrl(
   );
 }
 
-function pickRequestMethod(
-  url: string | URL | Request,
-  options: RequestInit | undefined,
-): string {
-  if (url instanceof Request) {
-    return url.method;
-  }
-  return options?.method ?? "GET";
-}
-
 export const fetch$ = computed((get) => {
   return async (url: string | URL | Request, options?: RequestInit) => {
     const clerk = await get(clerk$);
     const initialToken = (await clerk.session?.getToken()) ?? null;
-    const method = pickRequestMethod(url, options);
-    const apiBase = isMutationMethod(method)
-      ? await get(apiBaseForMutation$)
-      : await get(apiBase$);
+    const apiBase = await get(apiBase$);
 
     const performFetch = async (token: string | null): Promise<Response> => {
       // Clone Request inputs so the body stream is available for retry.

--- a/turbo/packages/connectors/src/feature-switch-key.ts
+++ b/turbo/packages/connectors/src/feature-switch-key.ts
@@ -54,7 +54,6 @@ export enum FeatureSwitchKey {
   ZoomConnector = "zoomConnector",
   ApiKeys = "apiKeys",
   ApiBackend = "apiBackend",
-  ApiBackendMutations = "apiBackendMutations",
   ConnectorCategories = "connectorCategories",
 
   Trinity = "trinity",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -308,20 +308,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
-  [FeatureSwitchKey.ApiBackendMutations]: {
-    maintainer: "ethan@vm0.ai",
-    description:
-      "Route platform mutation traffic (POST/PUT/PATCH/DELETE) to the api " +
-      "backend host independent of ApiBackend. When ApiBackend is OFF and " +
-      "this is ON, GETs stay on www while mutations use api.vm0.ai; ported " +
-      "mutation routes are served there and unported routes fall through to " +
-      "web via the api app's notFound proxy. When ApiBackend is ON, mutations " +
-      "follow the host-level switch regardless of this flag. Used during " +
-      "Stage 3 of the api-backend migration to roll out mutation routes " +
-      "per-org without flipping the host-level ApiBackend flag.",
-    enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
-  },
   [FeatureSwitchKey.ConnectorCategories]: {
     maintainer: "ethan@vm0.ai",
     description:


### PR DESCRIPTION
## Summary
- remove the `apiBackendMutations` feature switch key and registry entry
- route platform `fetch$` and `zeroClient$` traffic through the single `apiBackend` switch
- update routing coverage for GET, POST, PATCH, DELETE, Request inputs, and explicit `apiBase: "api"` overrides

## Notes
Stale persisted `apiBackendMutations` overrides need no migration because unregistered feature switch keys are ignored by the existing switch resolution path.

Closes #13209

## Tests
- `pnpm -F @vm0/app exec vitest --run src/signals/__tests__/api-client.test.ts src/signals/__tests__/fetch.test.ts`
- `pnpm -F @vm0/core exec vitest --run src/__tests__/feature-switch.test.ts`
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`
- `pnpm -F @vm0/core lint`
- `pnpm -F @vm0/core check-types`
- `pnpm -F @vm0/connectors lint`
- `pnpm -F @vm0/connectors check-types`
- `pnpm format`
- `pnpm turbo run lint`
- `pnpm check-types`
- `pnpm knip`
- `pnpm test` (1054/1057 files passed; failed on unrelated full-suite DB/timing issues in `zero-usage-insight.test.ts`, `app/api/integrations/telegram/__tests__/route.test.ts`, and `src/lib/zero/agentphone/__tests__/shared.test.ts`)
- `pnpm --filter api exec vitest --run src/signals/routes/__tests__/zero-usage-insight.test.ts`
- `pnpm --filter web exec vitest --run app/api/integrations/telegram/__tests__/route.test.ts src/lib/zero/agentphone/__tests__/shared.test.ts`
