### PR TITLE
refactor(api): migrate slack dispatch probe route

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -144,6 +144,7 @@ import { testOAuthProviderAuthorizeRoutes } from "./routes/test-oauth-provider-a
 import { testOAuthProviderEchoRoutes } from "./routes/test-oauth-provider-echo";
 import { testOAuthProviderTokenRoutes } from "./routes/test-oauth-provider-token";
 import { testOAuthProviderUserinfoRoutes } from "./routes/test-oauth-provider-userinfo";
+import { testSlackDispatchProbeRoutes } from "./routes/test-slack-dispatch-probe";
 import { testSlackMockRoutes } from "./routes/test-slack-mock";
 import { testSlackStateRoutes } from "./routes/test-slack-state";
 import { testTelegramMockRoutes } from "./routes/test-telegram-mock";
@@ -302,6 +303,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...testOAuthProviderEchoRoutes,
   ...testOAuthProviderTokenRoutes,
   ...testOAuthProviderUserinfoRoutes,
+  ...testSlackDispatchProbeRoutes,
   ...testSlackMockRoutes,
   ...testSlackStateRoutes,
   ...testTelegramMockRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/test-slack-dispatch-probe.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/test-slack-dispatch-probe.test.ts
@@ -1,0 +1,243 @@
+import { createStore } from "ccstate";
+import type { TestSlackDispatchProbeResponse } from "@vm0/api-contracts/contracts/test-slack-dispatch-probe";
+import { agentRuns } from "@vm0/db/schema/agent-run";
+import { zeroRuns } from "@vm0/db/schema/zero-run";
+import { eq } from "drizzle-orm";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { createApp } from "../../../app-factory";
+import { testContext } from "../../../__tests__/test-helpers";
+import { mockEnv, mockOptionalEnv } from "../../../lib/env";
+import { writeDb$ } from "../../external/db";
+import { createFixtureTracker } from "./helpers/zero-route-test";
+import {
+  deleteSlackWebhookFixture$,
+  seedSlackWebhookFixture$,
+  type SlackWebhookFixture,
+} from "./helpers/zero-slack-webhooks";
+
+const context = testContext();
+const store = createStore();
+const ROUTE = "/api/test/slack-dispatch-probe";
+
+function configureSlackProbeTest(): void {
+  mockEnv("ENV", "development");
+  mockOptionalEnv("RUNNER_DEFAULT_GROUP", "vm0/test");
+  mockEnv("VM0_WEB_URL", "https://app.vm0.test");
+  mockEnv("VM0_API_URL", "https://api.vm0.test");
+  context.mocks.s3.send.mockResolvedValue({});
+  context.mocks.slack.assistant.threads.setStatus.mockResolvedValue({
+    ok: true,
+  });
+  context.mocks.slack.chat.postMessage.mockResolvedValue({
+    ok: true,
+    ts: "1710000000.000000",
+    channel: "C-test",
+  });
+  context.mocks.slack.chat.postEphemeral.mockResolvedValue({
+    ok: true,
+    message_ts: "1710000000.000001",
+  });
+  context.mocks.slack.conversations.history.mockResolvedValue({
+    ok: true,
+    messages: [],
+  });
+  context.mocks.slack.conversations.replies.mockResolvedValue({
+    ok: true,
+    messages: [],
+  });
+  context.mocks.slack.users.info.mockResolvedValue({
+    ok: true,
+    user: {
+      profile: {
+        display_name: "Slack User",
+        email: "slack@example.com",
+      },
+      tz: "UTC",
+    },
+  });
+}
+
+function requestApp(path: string, init?: RequestInit): Promise<Response> {
+  const app = createApp({ signal: context.signal });
+  return Promise.resolve(app.request(path, init));
+}
+
+function postProbe(body: unknown): Promise<Response> {
+  return requestApp(ROUTE, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+async function readJson<T>(response: Response): Promise<T> {
+  return (await response.json()) as T;
+}
+
+async function readSingleRunForUser(userId: string): Promise<{
+  readonly id: string;
+  readonly prompt: string;
+  readonly appendSystemPrompt: string | null;
+}> {
+  const db = store.set(writeDb$);
+  const [run] = await db
+    .select({
+      id: agentRuns.id,
+      prompt: agentRuns.prompt,
+      appendSystemPrompt: agentRuns.appendSystemPrompt,
+    })
+    .from(agentRuns)
+    .where(eq(agentRuns.userId, userId))
+    .limit(1);
+  if (!run) {
+    throw new Error(`No run found for user ${userId}`);
+  }
+  return run;
+}
+
+async function readZeroRunTriggerSource(
+  runId: string,
+): Promise<string | null | undefined> {
+  const db = store.set(writeDb$);
+  const [zeroRun] = await db
+    .select({ triggerSource: zeroRuns.triggerSource })
+    .from(zeroRuns)
+    .where(eq(zeroRuns.id, runId))
+    .limit(1);
+  return zeroRun?.triggerSource;
+}
+
+describe("POST /api/test/slack-dispatch-probe", () => {
+  const track = createFixtureTracker<SlackWebhookFixture>((fixture) => {
+    return store.set(deleteSlackWebhookFixture$, fixture, context.signal);
+  });
+
+  beforeEach(() => {
+    configureSlackProbeTest();
+  });
+
+  it("hides the test endpoint outside allowed environments", async () => {
+    mockEnv("ENV", "production");
+
+    const response = await postProbe({});
+
+    expect(response.status).toBe(404);
+    await expect(response.text()).resolves.toBe("Not found");
+  });
+
+  it("returns the legacy missing-field error", async () => {
+    const response = await postProbe({
+      team_id: "T-test",
+      channel_id: "C-test",
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toStrictEqual({
+      error: "team_id, channel_id, user_id, message_text, message_ts required",
+    });
+  });
+
+  it("synchronously dispatches connected mention probes", async () => {
+    const fixture = await track(
+      store.set(
+        seedSlackWebhookFixture$,
+        { withConnection: true, withDefaultAgent: true },
+        context.signal,
+      ),
+    );
+
+    const response = await postProbe({
+      team_id: fixture.slackWorkspaceId,
+      channel_id: "C-test",
+      user_id: fixture.slackUserId,
+      message_text: "summarize this channel",
+      message_ts: "1710000000.000000",
+      channel_type: "channel",
+    });
+
+    expect(response.status).toBe(200);
+    await expect(
+      readJson<TestSlackDispatchProbeResponse>(response),
+    ).resolves.toStrictEqual({ ok: true });
+
+    const run = await readSingleRunForUser(fixture.userId);
+    expect(run.prompt).toBe("summarize this channel");
+    expect(run.appendSystemPrompt).toContain(
+      "You are currently running inside: Slack",
+    );
+    expect(run.appendSystemPrompt).toContain("Channel type: Channel");
+    await expect(readZeroRunTriggerSource(run.id)).resolves.toBe("slack");
+  });
+
+  it("synchronously dispatches connected direct-message probes", async () => {
+    const fixture = await track(
+      store.set(
+        seedSlackWebhookFixture$,
+        { withConnection: true, withDefaultAgent: true },
+        context.signal,
+      ),
+    );
+
+    const response = await postProbe({
+      team_id: fixture.slackWorkspaceId,
+      channel_id: "D-test",
+      user_id: fixture.slackUserId,
+      message_text: "hello in dm",
+      message_ts: "1710000001.000000",
+      channel_type: "im",
+    });
+
+    expect(response.status).toBe(200);
+    await expect(
+      readJson<TestSlackDispatchProbeResponse>(response),
+    ).resolves.toStrictEqual({ ok: true });
+
+    const run = await readSingleRunForUser(fixture.userId);
+    expect(run.prompt).toBe("hello in dm");
+    expect(run.appendSystemPrompt).toContain("Channel type: Direct message");
+    expect(
+      context.mocks.slack.assistant.threads.setStatus,
+    ).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel_id: "D-test",
+        thread_ts: "1710000001.000000",
+      }),
+    );
+  });
+
+  it("serializes synchronous dispatch errors as diagnostic 200 responses", async () => {
+    const fixture = await track(
+      store.set(
+        seedSlackWebhookFixture$,
+        { withConnection: true, withDefaultAgent: true },
+        context.signal,
+      ),
+    );
+    const statusError = Object.assign(new Error("status update failed"), {
+      code: "slack_status_failed",
+    });
+    context.mocks.slack.assistant.threads.setStatus.mockRejectedValueOnce(
+      statusError,
+    );
+
+    const response = await postProbe({
+      team_id: fixture.slackWorkspaceId,
+      channel_id: "C-test",
+      user_id: fixture.slackUserId,
+      message_text: "trigger an error",
+      message_ts: "1710000002.000000",
+    });
+
+    expect(response.status).toBe(200);
+    const body = await readJson<TestSlackDispatchProbeResponse>(response);
+    expect(body).toMatchObject({
+      ok: false,
+      error: {
+        name: "Error",
+        message: "status update failed",
+        code: "slack_status_failed",
+      },
+    });
+  });
+});

--- a/turbo/apps/api/src/signals/routes/test-slack-dispatch-probe.ts
+++ b/turbo/apps/api/src/signals/routes/test-slack-dispatch-probe.ts
@@ -1,0 +1,148 @@
+import { command } from "ccstate";
+import {
+  testSlackDispatchProbeContract,
+  type TestSlackDispatchProbeBody,
+} from "@vm0/api-contracts/contracts/test-slack-dispatch-probe";
+
+import { request$ } from "../context/hono";
+import { now } from "../external/time";
+import type { RouteEntry } from "../route";
+import { dispatchZeroSlackProbe$ } from "../services/zero-slack-webhooks.service";
+import { safeAsync } from "../utils";
+import {
+  isTestEndpointAllowed,
+  testEndpointNotFoundResponse,
+} from "./test-oauth-provider-helpers";
+
+const REQUIRED_FIELDS_ERROR =
+  "team_id, channel_id, user_id, message_text, message_ts required";
+
+interface SerializedProbeError {
+  readonly name: string;
+  readonly message: string;
+  readonly code?: string;
+  readonly stack?: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readString(
+  record: Readonly<Record<string, unknown>>,
+  key: string,
+): string | undefined {
+  const value = record[key];
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function parseProbeBody(value: unknown): TestSlackDispatchProbeBody | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const teamId = readString(value, "team_id");
+  const channelId = readString(value, "channel_id");
+  const userId = readString(value, "user_id");
+  const messageText = readString(value, "message_text");
+  const messageTs = readString(value, "message_ts");
+  if (!teamId || !channelId || !userId || !messageText || !messageTs) {
+    return null;
+  }
+
+  const channelType = readString(value, "channel_type");
+  return {
+    team_id: teamId,
+    channel_id: channelId,
+    user_id: userId,
+    message_text: messageText,
+    message_ts: messageTs,
+    ...(channelType === "im" || channelType === "channel"
+      ? { channel_type: channelType }
+      : {}),
+  };
+}
+
+function readOptionalErrorString(
+  error: Error,
+  key: string,
+): string | undefined {
+  const value = (error as unknown as Record<string, unknown>)[key];
+  return typeof value === "string" ? value : undefined;
+}
+
+function serializeProbeError(error: unknown): SerializedProbeError {
+  if (error instanceof Error) {
+    return {
+      name: error.name,
+      message: error.message,
+      code: readOptionalErrorString(error, "code"),
+      stack: error.stack?.split("\n").slice(0, 10).join("\n"),
+    };
+  }
+
+  return {
+    name: "Error",
+    message: String(error),
+  };
+}
+
+const postSlackDispatchProbe$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const request = get(request$);
+    if (!isTestEndpointAllowed(request)) {
+      return testEndpointNotFoundResponse();
+    }
+
+    const rawBody = await request.json().catch((): null => {
+      return null;
+    });
+    signal.throwIfAborted();
+
+    const body = parseProbeBody(rawBody);
+    if (!body) {
+      return {
+        status: 400 as const,
+        body: { error: REQUIRED_FIELDS_ERROR },
+      };
+    }
+
+    const dispatchResult = await safeAsync(() => {
+      return set(
+        dispatchZeroSlackProbe$,
+        {
+          workspaceId: body.team_id,
+          channelId: body.channel_id,
+          channelType: body.channel_type === "im" ? "dm" : "channel",
+          slackUserId: body.user_id,
+          messageText: body.message_text,
+          messageTs: body.message_ts,
+          apiStartTime: now(),
+        },
+        signal,
+      );
+    });
+    signal.throwIfAborted();
+    if ("error" in dispatchResult) {
+      return {
+        status: 200 as const,
+        body: {
+          ok: false as const,
+          error: serializeProbeError(dispatchResult.error),
+        },
+      };
+    }
+
+    return {
+      status: 200 as const,
+      body: { ok: true as const },
+    };
+  },
+);
+
+export const testSlackDispatchProbeRoutes: readonly RouteEntry[] = [
+  {
+    route: testSlackDispatchProbeContract.post,
+    handler: postSlackDispatchProbe$,
+  },
+];

--- a/turbo/apps/api/src/signals/services/zero-slack-webhooks.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-slack-webhooks.service.ts
@@ -231,6 +231,16 @@ interface SlackAgentMessageArgs {
   readonly signal: AbortSignal;
 }
 
+interface ZeroSlackDispatchProbeInput {
+  readonly workspaceId: string;
+  readonly channelId: string;
+  readonly channelType: SlackChannelType;
+  readonly slackUserId: string;
+  readonly messageText: string;
+  readonly messageTs: string;
+  readonly apiStartTime: number;
+}
+
 interface ResolvedSlackAgentMessage {
   readonly installation: SlackInstallation & { readonly orgId: string };
   readonly connection: SlackConnection;
@@ -1360,6 +1370,28 @@ async function handleSlackAgentMessage(
   const result = await runAgentForSlackOrg(args.set, runParams, args.signal);
   await handleSlackRunResult({ message: args, resolved, result });
 }
+
+export const dispatchZeroSlackProbe$ = command(
+  async (
+    { get, set },
+    input: ZeroSlackDispatchProbeInput,
+    signal: AbortSignal,
+  ): Promise<void> => {
+    await handleSlackAgentMessage({
+      get,
+      set,
+      db: set(writeDb$),
+      workspaceId: input.workspaceId,
+      channelId: input.channelId,
+      channelType: input.channelType,
+      slackUserId: input.slackUserId,
+      messageText: input.messageText,
+      messageTs: input.messageTs,
+      apiStartTime: input.apiStartTime,
+      signal,
+    });
+  },
+);
 
 async function handleAppHomeOpened(
   db: Db,

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -299,6 +299,18 @@ export {
   type TestOAuthProviderUserinfoResponse,
 } from "./test-oauth-provider-userinfo";
 export {
+  testSlackDispatchProbeBodySchema,
+  testSlackDispatchProbeContract,
+  testSlackDispatchProbeErrorSchema,
+  testSlackDispatchProbeFailureResponseSchema,
+  testSlackDispatchProbeResponseSchema,
+  testSlackDispatchProbeSuccessResponseSchema,
+  type TestSlackDispatchProbeBody,
+  type TestSlackDispatchProbeContract,
+  type TestSlackDispatchProbeError,
+  type TestSlackDispatchProbeResponse,
+} from "./test-slack-dispatch-probe";
+export {
   testSlackStateContract,
   testSlackStateErrorSchema,
   testSlackStateResponseSchema,

--- a/turbo/packages/api-contracts/src/contracts/test-slack-dispatch-probe.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-slack-dispatch-probe.ts
@@ -1,0 +1,63 @@
+import { z } from "zod";
+
+import { initContract } from "./base";
+
+const c = initContract();
+
+export const testSlackDispatchProbeBodySchema = z.object({
+  team_id: z.string(),
+  channel_id: z.string(),
+  user_id: z.string(),
+  message_text: z.string(),
+  message_ts: z.string(),
+  channel_type: z.enum(["channel", "im"]).optional(),
+});
+
+export const testSlackDispatchProbeErrorSchema = z.object({
+  error: z.string(),
+});
+
+export const testSlackDispatchProbeSuccessResponseSchema = z.object({
+  ok: z.literal(true),
+});
+
+export const testSlackDispatchProbeFailureResponseSchema = z.object({
+  ok: z.literal(false),
+  error: z.object({
+    name: z.string(),
+    message: z.string(),
+    code: z.string().optional(),
+    stack: z.string().optional(),
+  }),
+});
+
+export const testSlackDispatchProbeResponseSchema = z.union([
+  testSlackDispatchProbeSuccessResponseSchema,
+  testSlackDispatchProbeFailureResponseSchema,
+]);
+
+export const testSlackDispatchProbeContract = c.router({
+  post: {
+    method: "POST",
+    path: "/api/test/slack-dispatch-probe",
+    body: testSlackDispatchProbeBodySchema,
+    responses: {
+      200: testSlackDispatchProbeResponseSchema,
+      400: testSlackDispatchProbeErrorSchema,
+      404: z.string(),
+    },
+    summary: "Synchronously dispatch a Slack test message for diagnostics",
+  },
+});
+
+export type TestSlackDispatchProbeBody = z.infer<
+  typeof testSlackDispatchProbeBodySchema
+>;
+export type TestSlackDispatchProbeContract =
+  typeof testSlackDispatchProbeContract;
+export type TestSlackDispatchProbeError = z.infer<
+  typeof testSlackDispatchProbeErrorSchema
+>;
+export type TestSlackDispatchProbeResponse = z.infer<
+  typeof testSlackDispatchProbeResponseSchema
+>;


### PR DESCRIPTION
Closes #12858

## Summary
- add an API contract and API route for `POST /api/test/slack-dispatch-probe`
- reuse the API Slack dispatch path through `dispatchZeroSlackProbe$` so the probe creates Zero runs via the API backend
- cover the environment guard, legacy validation error, channel and DM dispatch, and diagnostic error response with integration tests

## Validation
- `pnpm format`
- `pnpm -F api lint`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/test-slack-dispatch-probe.test.ts src/signals/routes/__tests__/zero-slack-events.test.ts`
- `pnpm check-types`
- `pnpm knip`
- `git diff --check`