### PR TITLE
refactor(api): migrate agent checkpoint webhooks

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -46,6 +46,7 @@ import { runnersRoutes } from "./routes/runners";
 import { usageRoutes } from "./routes/usage";
 import { userExportRoutes } from "./routes/user-export";
 import { vercelSandboxSmokeRoutes } from "./routes/vercel-sandbox-smoke";
+import { webhooksAgentCheckpointsRoutes } from "./routes/webhooks-agent-checkpoints";
 import { webhooksAgentHealthUsageTelemetryRoutes } from "./routes/webhooks-agent-health-usage-telemetry";
 import { webhooksAgentStorageRoutes } from "./routes/webhooks-agent-storage";
 import { webhooksClerkRoutes } from "./routes/webhooks-clerk";
@@ -186,6 +187,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...webhooksGithubRoutes,
   ...webhooksStripeRoutes,
   ...webhooksAgentHealthUsageTelemetryRoutes,
+  ...webhooksAgentCheckpointsRoutes,
   ...webhooksAgentStorageRoutes,
   ...agentCheckpointsRoutes,
   ...agentComposesReadRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-checkpoints.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-checkpoints.test.ts
@@ -365,6 +365,32 @@ describe("POST /api/webhooks/agent/checkpoints", () => {
     expect(blob?.refCount).toBe(1);
   });
 
+  it("normalizes empty artifact snapshots to a missing response field", async () => {
+    const fixture = await track(seedFixture());
+    const body = { ...checkpointBody(fixture), artifactSnapshots: [] };
+    const db = store.set(writeDb$);
+    await db
+      .insert(blobs)
+      .values({ hash: fixture.historyHash, size: 789, refCount: 0 });
+
+    const response = await accept(
+      checkpointClient().create({
+        body,
+        headers: authHeaders(fixture),
+      }),
+      [200],
+    );
+
+    expect(response.body.artifacts).toBeUndefined();
+
+    const [checkpoint] = await db
+      .select({ artifactSnapshots: checkpoints.artifactSnapshots })
+      .from(checkpoints)
+      .where(eq(checkpoints.id, response.body.checkpointId))
+      .limit(1);
+    expect(checkpoint?.artifactSnapshots).toBeNull();
+  });
+
   it("returns 404 when the sandbox run does not exist", async () => {
     const fixture = await track(seedFixture());
     const missingRunId = randomUUID();

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-checkpoints.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-checkpoints.test.ts
@@ -1,0 +1,385 @@
+import { randomBytes, randomUUID } from "node:crypto";
+
+import {
+  webhookCheckpointsContract,
+  webhookCheckpointsPrepareHistoryContract,
+} from "@vm0/api-contracts/contracts/webhooks";
+import { agentRuns } from "@vm0/db/schema/agent-run";
+import { agentSessions } from "@vm0/db/schema/agent-session";
+import { blobs } from "@vm0/db/schema/blob";
+import { checkpoints } from "@vm0/db/schema/checkpoint";
+import { conversations } from "@vm0/db/schema/conversation";
+import { createStore } from "ccstate";
+import { eq } from "drizzle-orm";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { mockEnv } from "../../../lib/env";
+import { now } from "../../../lib/time";
+import { signSandboxJwtForTests } from "../../auth/tokens";
+import { writeDb$ } from "../../external/db";
+import { createFixtureTracker } from "./helpers/zero-route-test";
+import {
+  deleteUsageInsightFixture$,
+  seedCompose$,
+  seedRun$,
+  seedUsageInsightFixture$,
+  type UsageInsightFixture,
+} from "./helpers/zero-usage-insight";
+
+const BUCKET = "test-user-storages";
+
+const context = testContext();
+const store = createStore();
+
+interface AgentCheckpointFixture extends UsageInsightFixture {
+  readonly composeId: string;
+  readonly runId: string;
+  readonly historyHash: string;
+}
+
+function sha256Hash(): string {
+  return randomBytes(32).toString("hex");
+}
+
+function currentSecond(): number {
+  return Math.floor(now() / 1000);
+}
+
+function sandboxToken(fixture: {
+  readonly runId: string;
+  readonly userId: string;
+  readonly orgId: string;
+}): string {
+  const nowSeconds = currentSecond();
+  return signSandboxJwtForTests({
+    scope: "sandbox",
+    runId: fixture.runId,
+    userId: fixture.userId,
+    orgId: fixture.orgId,
+    iat: nowSeconds,
+    exp: nowSeconds + 60,
+  });
+}
+
+function authHeaders(fixture: {
+  readonly runId: string;
+  readonly userId: string;
+  readonly orgId: string;
+}): {
+  readonly authorization: string;
+} {
+  return { authorization: `Bearer ${sandboxToken(fixture)}` };
+}
+
+function checkpointClient() {
+  return setupApp({ context })(webhookCheckpointsContract);
+}
+
+function prepareHistoryClient() {
+  return setupApp({ context })(webhookCheckpointsPrepareHistoryContract);
+}
+
+function checkpointBody(fixture: AgentCheckpointFixture) {
+  return {
+    runId: fixture.runId,
+    cliAgentType: "codex",
+    cliAgentSessionId: `session-${fixture.runId}`,
+    cliAgentSessionHistoryHash: fixture.historyHash,
+    artifactSnapshots: [
+      {
+        name: "workspace",
+        version: sha256Hash(),
+        mountPath: "/workspace",
+      },
+    ],
+    volumeVersionsSnapshot: {
+      versions: {
+        cache: sha256Hash(),
+      },
+    },
+  };
+}
+
+async function seedFixture(): Promise<AgentCheckpointFixture> {
+  const base = await store.set(
+    seedUsageInsightFixture$,
+    undefined,
+    context.signal,
+  );
+  const { composeId } = await store.set(
+    seedCompose$,
+    { orgId: base.orgId, userId: base.userId },
+    context.signal,
+  );
+  const { runId } = await store.set(
+    seedRun$,
+    {
+      orgId: base.orgId,
+      userId: base.userId,
+      composeId,
+      status: "running",
+    },
+    context.signal,
+  );
+
+  const db = store.set(writeDb$);
+  await db
+    .update(agentRuns)
+    .set({
+      vars: { MODE: "test" },
+      secretNames: ["API_TOKEN"],
+      additionalVolumes: [
+        {
+          name: "cache",
+          version: sha256Hash(),
+          mountPath: "/cache",
+        },
+        {
+          name: "workspace",
+          mountPath: "/workspace",
+        },
+      ],
+    })
+    .where(eq(agentRuns.id, runId));
+
+  return { ...base, composeId, runId, historyHash: sha256Hash() };
+}
+
+const track = createFixtureTracker<AgentCheckpointFixture>(async (fixture) => {
+  const db = store.set(writeDb$);
+  await db.delete(blobs).where(eq(blobs.hash, fixture.historyHash));
+  await store.set(deleteUsageInsightFixture$, fixture, context.signal);
+});
+
+beforeEach(() => {
+  mockEnv("R2_USER_STORAGES_BUCKET_NAME", BUCKET);
+});
+
+describe("POST /api/webhooks/agent/checkpoints/prepare-history", () => {
+  it("rejects missing sandbox auth", async () => {
+    const fixture = await track(seedFixture());
+
+    const response = await accept(
+      prepareHistoryClient().prepare({
+        body: {
+          runId: fixture.runId,
+          hash: fixture.historyHash,
+          size: 123,
+        },
+        headers: {},
+      }),
+      [401],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Not authenticated or runId mismatch",
+        code: "UNAUTHORIZED",
+      },
+    });
+  });
+
+  it("returns existing when the blob is registered and present in S3", async () => {
+    const fixture = await track(seedFixture());
+    const db = store.set(writeDb$);
+    await db
+      .insert(blobs)
+      .values({ hash: fixture.historyHash, size: 123, refCount: 0 });
+    context.mocks.s3.send.mockResolvedValue({});
+
+    const response = await accept(
+      prepareHistoryClient().prepare({
+        body: {
+          runId: fixture.runId,
+          hash: fixture.historyHash,
+          size: 123,
+        },
+        headers: authHeaders(fixture),
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({ existing: true });
+    expect(context.mocks.s3.getSignedUrl).not.toHaveBeenCalled();
+  });
+
+  it("pre-registers a missing blob and returns a presigned upload URL", async () => {
+    const fixture = await track(seedFixture());
+
+    const response = await accept(
+      prepareHistoryClient().prepare({
+        body: {
+          runId: fixture.runId,
+          hash: fixture.historyHash,
+          size: 456,
+        },
+        headers: authHeaders(fixture),
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      existing: false,
+      presignedUrl: "https://r2.example.com/upload?sig=test",
+    });
+
+    const db = store.set(writeDb$);
+    const [blob] = await db
+      .select()
+      .from(blobs)
+      .where(eq(blobs.hash, fixture.historyHash))
+      .limit(1);
+    expect(blob).toMatchObject({
+      hash: fixture.historyHash,
+      size: 456,
+      refCount: 0,
+    });
+  });
+
+  it("returns 404 when the sandbox run does not exist", async () => {
+    const fixture = await track(seedFixture());
+    const missingRunId = randomUUID();
+
+    const response = await accept(
+      prepareHistoryClient().prepare({
+        body: {
+          runId: missingRunId,
+          hash: fixture.historyHash,
+          size: 123,
+        },
+        headers: authHeaders({ ...fixture, runId: missingRunId }),
+      }),
+      [404],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Agent run not found", code: "NOT_FOUND" },
+    });
+  });
+});
+
+describe("POST /api/webhooks/agent/checkpoints", () => {
+  it("rejects a body runId that does not match the sandbox token", async () => {
+    const fixture = await track(seedFixture());
+
+    const response = await accept(
+      checkpointClient().create({
+        body: { ...checkpointBody(fixture), runId: randomUUID() },
+        headers: authHeaders(fixture),
+      }),
+      [401],
+    );
+
+    expect(response.body.error.message).toBe(
+      "Not authenticated or runId mismatch",
+    );
+  });
+
+  it("creates a checkpoint and persists conversation, artifact, volume, and session state", async () => {
+    const fixture = await track(seedFixture());
+    const body = checkpointBody(fixture);
+    const db = store.set(writeDb$);
+    await db
+      .insert(blobs)
+      .values({ hash: fixture.historyHash, size: 789, refCount: 0 });
+
+    const response = await accept(
+      checkpointClient().create({
+        body,
+        headers: authHeaders(fixture),
+      }),
+      [200],
+    );
+
+    expect(response.body).toMatchObject({
+      artifacts: body.artifactSnapshots,
+      volumes: body.volumeVersionsSnapshot.versions,
+    });
+
+    const [conversation] = await db
+      .select()
+      .from(conversations)
+      .where(eq(conversations.id, response.body.conversationId))
+      .limit(1);
+    expect(conversation).toMatchObject({
+      runId: fixture.runId,
+      cliAgentType: body.cliAgentType,
+      cliAgentSessionId: body.cliAgentSessionId,
+      cliAgentSessionHistoryHash: fixture.historyHash,
+    });
+
+    const [run] = await db
+      .select({
+        agentComposeVersionId: agentRuns.agentComposeVersionId,
+        sessionId: agentRuns.sessionId,
+      })
+      .from(agentRuns)
+      .where(eq(agentRuns.id, fixture.runId))
+      .limit(1);
+    expect(run?.agentComposeVersionId).toBeTruthy();
+
+    const [checkpoint] = await db
+      .select()
+      .from(checkpoints)
+      .where(eq(checkpoints.id, response.body.checkpointId))
+      .limit(1);
+    expect(checkpoint).toMatchObject({
+      runId: fixture.runId,
+      conversationId: response.body.conversationId,
+      artifactSnapshots: body.artifactSnapshots,
+      volumeVersionsSnapshot: {
+        versions: body.volumeVersionsSnapshot.versions,
+        additionalVolumes: [
+          {
+            name: "cache",
+            versionId: body.volumeVersionsSnapshot.versions.cache,
+            mountPath: "/cache",
+          },
+          {
+            name: "workspace",
+            versionId: "latest",
+            mountPath: "/workspace",
+          },
+        ],
+      },
+    });
+    expect(checkpoint?.agentComposeSnapshot).toStrictEqual({
+      agentComposeVersionId: run?.agentComposeVersionId,
+      vars: { MODE: "test" },
+      secretNames: ["API_TOKEN"],
+    });
+
+    const [session] = await db
+      .select()
+      .from(agentSessions)
+      .where(eq(agentSessions.id, run?.sessionId ?? ""))
+      .limit(1);
+    expect(session?.conversationId).toBe(response.body.conversationId);
+
+    const [blob] = await db
+      .select()
+      .from(blobs)
+      .where(eq(blobs.hash, fixture.historyHash))
+      .limit(1);
+    expect(blob?.refCount).toBe(1);
+  });
+
+  it("returns 404 when the sandbox run does not exist", async () => {
+    const fixture = await track(seedFixture());
+    const missingRunId = randomUUID();
+    const body = { ...checkpointBody(fixture), runId: missingRunId };
+
+    const response = await accept(
+      checkpointClient().create({
+        body,
+        headers: authHeaders({ ...fixture, runId: missingRunId }),
+      }),
+      [404],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Agent run not found", code: "NOT_FOUND" },
+    });
+  });
+});

--- a/turbo/apps/api/src/signals/routes/webhooks-agent-checkpoints.ts
+++ b/turbo/apps/api/src/signals/routes/webhooks-agent-checkpoints.ts
@@ -1,0 +1,93 @@
+import { command } from "ccstate";
+import {
+  webhookCheckpointsContract,
+  webhookCheckpointsPrepareHistoryContract,
+} from "@vm0/api-contracts/contracts/webhooks";
+
+import { notFound } from "../../lib/error";
+import { authorization$ } from "../context/hono";
+import { bodyResultOf } from "../context/request";
+import type { RouteEntry } from "../route";
+import {
+  createAgentCheckpoint$,
+  prepareCheckpointHistoryUpload$,
+} from "../services/agent-webhook-checkpoints.service";
+import { safeAsync } from "../utils";
+import {
+  getSandboxAuthForRun,
+  unauthorizedRunMismatch,
+} from "./agent-webhook-auth";
+
+const PG_FOREIGN_KEY_VIOLATION = "23503";
+
+function isForeignKeyViolation(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  const { cause } = error;
+  if (typeof cause !== "object" || cause === null || !("code" in cause)) {
+    return false;
+  }
+
+  return cause.code === PG_FOREIGN_KEY_VIOLATION;
+}
+
+const createBody$ = bodyResultOf(webhookCheckpointsContract.create);
+const createCheckpoint$ = command(async ({ get, set }, signal: AbortSignal) => {
+  const bodyResult = await get(createBody$);
+  signal.throwIfAborted();
+  if (!bodyResult.ok) {
+    return bodyResult.response;
+  }
+
+  const body = bodyResult.data;
+  const auth = getSandboxAuthForRun(body.runId, get(authorization$));
+  if (!auth) {
+    return unauthorizedRunMismatch;
+  }
+
+  const result = await safeAsync(() => {
+    return set(createAgentCheckpoint$, { auth, body }, signal);
+  });
+  signal.throwIfAborted();
+
+  if ("error" in result) {
+    if (isForeignKeyViolation(result.error)) {
+      return notFound("Agent run not found");
+    }
+    throw result.error;
+  }
+
+  return result.ok;
+});
+
+const prepareHistoryBody$ = bodyResultOf(
+  webhookCheckpointsPrepareHistoryContract.prepare,
+);
+const prepareHistory$ = command(async ({ get, set }, signal: AbortSignal) => {
+  const bodyResult = await get(prepareHistoryBody$);
+  signal.throwIfAborted();
+  if (!bodyResult.ok) {
+    return bodyResult.response;
+  }
+
+  const body = bodyResult.data;
+  const auth = getSandboxAuthForRun(body.runId, get(authorization$));
+  if (!auth) {
+    return unauthorizedRunMismatch;
+  }
+
+  return await set(prepareCheckpointHistoryUpload$, { auth, body }, signal);
+});
+
+export const webhooksAgentCheckpointsRoutes: readonly RouteEntry[] = [
+  {
+    route: webhookCheckpointsContract.create,
+    handler: createCheckpoint$,
+  },
+  {
+    route: webhookCheckpointsPrepareHistoryContract.prepare,
+    handler: prepareHistory$,
+  },
+];

--- a/turbo/apps/api/src/signals/services/agent-webhook-checkpoints.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-checkpoints.service.ts
@@ -1,0 +1,335 @@
+import type { z } from "zod";
+import {
+  webhookCheckpointsContract,
+  webhookCheckpointsPrepareHistoryContract,
+} from "@vm0/api-contracts/contracts/webhooks";
+import { agentRuns } from "@vm0/db/schema/agent-run";
+import { agentSessions } from "@vm0/db/schema/agent-session";
+import { blobs } from "@vm0/db/schema/blob";
+import { checkpoints } from "@vm0/db/schema/checkpoint";
+import { conversations } from "@vm0/db/schema/conversation";
+import type { ContextArtifact } from "@vm0/db/types";
+import { command } from "ccstate";
+import { and, eq, sql } from "drizzle-orm";
+
+import { env } from "../../lib/env";
+import { notFound } from "../../lib/error";
+import { logger } from "../../lib/log";
+import { nowDate } from "../../lib/time";
+import type { SandboxAuth } from "../../types/auth";
+import { writeDb$ } from "../external/db";
+import { generatePresignedPutUrl, s3ObjectExists } from "../external/s3";
+
+type CheckpointCreateBody = z.infer<
+  typeof webhookCheckpointsContract.create.body
+>;
+type PrepareHistoryBody = z.infer<
+  typeof webhookCheckpointsPrepareHistoryContract.prepare.body
+>;
+
+interface CheckpointAuthInput<TBody> {
+  readonly auth: SandboxAuth;
+  readonly body: TBody;
+}
+
+interface AgentComposeSnapshot {
+  readonly agentComposeVersionId: string;
+  readonly vars?: Record<string, string>;
+  readonly secretNames?: readonly string[];
+}
+
+interface AdditionalVolumeSnapshot {
+  readonly name: string;
+  readonly versionId: string;
+  readonly mountPath: string;
+}
+
+interface EnrichedVolumeVersionsSnapshot {
+  readonly versions: Record<string, string>;
+  readonly additionalVolumes?: readonly AdditionalVolumeSnapshot[];
+}
+
+const L = logger("webhooks:agent:checkpoints");
+
+function recordOfStringsOrUndefined(
+  value: unknown,
+): Record<string, string> | undefined {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return undefined;
+  }
+
+  const entries = Object.entries(value);
+  const result: Record<string, string> = {};
+  for (const [key, entryValue] of entries) {
+    if (typeof entryValue !== "string") {
+      return undefined;
+    }
+    result[key] = entryValue;
+  }
+
+  return result;
+}
+
+function artifactSnapshotsForDb(
+  snapshots: CheckpointCreateBody["artifactSnapshots"],
+): ContextArtifact[] | null {
+  if (!snapshots || snapshots.length === 0) {
+    return null;
+  }
+
+  return snapshots.map((snapshot) => {
+    return {
+      name: snapshot.name,
+      version: snapshot.version,
+      mountPath: snapshot.mountPath,
+    };
+  });
+}
+
+function enrichVolumeSnapshot(args: {
+  readonly request: CheckpointCreateBody["volumeVersionsSnapshot"];
+  readonly additionalVolumes:
+    | readonly {
+        readonly name: string;
+        readonly version?: string;
+        readonly mountPath: string;
+      }[]
+    | null;
+}): EnrichedVolumeVersionsSnapshot | null {
+  const request = args.request;
+  if (!request) {
+    return null;
+  }
+
+  const additionalVolumes =
+    args.additionalVolumes && args.additionalVolumes.length > 0
+      ? args.additionalVolumes.map((volume): AdditionalVolumeSnapshot => {
+          const versionId =
+            request.versions[volume.name] ?? volume.version ?? "latest";
+          return {
+            name: volume.name,
+            versionId,
+            mountPath: volume.mountPath,
+          };
+        })
+      : undefined;
+
+  return {
+    versions: request.versions,
+    ...(additionalVolumes ? { additionalVolumes } : {}),
+  };
+}
+
+export const prepareCheckpointHistoryUpload$ = command(
+  async (
+    { get, set },
+    input: CheckpointAuthInput<PrepareHistoryBody>,
+    signal: AbortSignal,
+  ) => {
+    const db = set(writeDb$);
+    const [run] = await db
+      .select({ id: agentRuns.id })
+      .from(agentRuns)
+      .where(
+        and(
+          eq(agentRuns.id, input.body.runId),
+          eq(agentRuns.userId, input.auth.userId),
+        ),
+      )
+      .limit(1);
+    signal.throwIfAborted();
+
+    if (!run) {
+      return notFound("Agent run not found");
+    }
+
+    const bucketName = env("R2_USER_STORAGES_BUCKET_NAME");
+    const s3Key = `blobs/${input.body.hash}.blob`;
+    const [existingBlob] = await db
+      .select({ hash: blobs.hash })
+      .from(blobs)
+      .where(eq(blobs.hash, input.body.hash))
+      .limit(1);
+    signal.throwIfAborted();
+
+    if (existingBlob) {
+      const exists = await get(s3ObjectExists(bucketName, s3Key));
+      signal.throwIfAborted();
+      if (exists) {
+        return {
+          status: 200 as const,
+          body: { existing: true },
+        };
+      }
+    }
+
+    const presignedUrl = await get(
+      generatePresignedPutUrl(
+        bucketName,
+        s3Key,
+        "application/octet-stream",
+        3600,
+        true,
+      ),
+    );
+    signal.throwIfAborted();
+
+    await db
+      .insert(blobs)
+      .values({ hash: input.body.hash, size: input.body.size, refCount: 0 })
+      .onConflictDoUpdate({
+        target: blobs.hash,
+        set: { size: input.body.size },
+      });
+    signal.throwIfAborted();
+
+    return {
+      status: 200 as const,
+      body: {
+        presignedUrl,
+        existing: false,
+      },
+    };
+  },
+);
+
+export const createAgentCheckpoint$ = command(
+  async (
+    { set },
+    input: CheckpointAuthInput<CheckpointCreateBody>,
+    signal: AbortSignal,
+  ) => {
+    const db = set(writeDb$);
+    const [run] = await db
+      .select({
+        agentComposeVersionId: agentRuns.agentComposeVersionId,
+        additionalVolumes: agentRuns.additionalVolumes,
+        secretNames: agentRuns.secretNames,
+        sessionId: agentRuns.sessionId,
+        vars: agentRuns.vars,
+      })
+      .from(agentRuns)
+      .where(
+        and(
+          eq(agentRuns.id, input.body.runId),
+          eq(agentRuns.userId, input.auth.userId),
+        ),
+      )
+      .limit(1);
+    signal.throwIfAborted();
+
+    if (!run) {
+      return notFound("Agent run not found");
+    }
+
+    if (!run.agentComposeVersionId) {
+      return notFound(
+        "Agent compose version not found (agent may have been deleted)",
+      );
+    }
+
+    await db
+      .insert(blobs)
+      .values({
+        hash: input.body.cliAgentSessionHistoryHash,
+        size: 0,
+        refCount: 1,
+      })
+      .onConflictDoUpdate({
+        target: blobs.hash,
+        set: { refCount: sql`${blobs.refCount} + 1` },
+      });
+    signal.throwIfAborted();
+
+    const [conversation] = await db
+      .insert(conversations)
+      .values({
+        runId: input.body.runId,
+        cliAgentType: input.body.cliAgentType,
+        cliAgentSessionId: input.body.cliAgentSessionId,
+        cliAgentSessionHistoryHash: input.body.cliAgentSessionHistoryHash,
+      })
+      .onConflictDoUpdate({
+        target: conversations.runId,
+        set: {
+          cliAgentType: input.body.cliAgentType,
+          cliAgentSessionId: input.body.cliAgentSessionId,
+          cliAgentSessionHistoryHash: input.body.cliAgentSessionHistoryHash,
+        },
+      })
+      .returning({ id: conversations.id });
+    signal.throwIfAborted();
+
+    if (!conversation) {
+      throw new Error("Failed to upsert conversation record");
+    }
+
+    const vars = recordOfStringsOrUndefined(run.vars);
+    const agentComposeSnapshot: AgentComposeSnapshot = {
+      agentComposeVersionId: run.agentComposeVersionId,
+      ...(vars ? { vars } : {}),
+      ...(run.secretNames ? { secretNames: run.secretNames } : {}),
+    };
+    const artifactSnapshots = artifactSnapshotsForDb(
+      input.body.artifactSnapshots,
+    );
+    const volumeVersionsSnapshot = enrichVolumeSnapshot({
+      request: input.body.volumeVersionsSnapshot,
+      additionalVolumes: run.additionalVolumes,
+    });
+
+    const checkpointFields = {
+      conversationId: conversation.id,
+      agentComposeSnapshot,
+      artifactSnapshots,
+      volumeVersionsSnapshot,
+    };
+    const [checkpoint] = await db
+      .insert(checkpoints)
+      .values({
+        runId: input.body.runId,
+        ...checkpointFields,
+      })
+      .onConflictDoUpdate({
+        target: checkpoints.runId,
+        set: checkpointFields,
+      })
+      .returning({ id: checkpoints.id });
+    signal.throwIfAborted();
+
+    if (!checkpoint) {
+      throw new Error("Failed to upsert checkpoint record");
+    }
+
+    const [agentSession] = await db
+      .update(agentSessions)
+      .set({
+        conversationId: conversation.id,
+        updatedAt: nowDate(),
+      })
+      .where(eq(agentSessions.id, run.sessionId))
+      .returning({ id: agentSessions.id });
+    signal.throwIfAborted();
+
+    if (!agentSession) {
+      return notFound("AgentSession not found");
+    }
+
+    L.debug("Checkpoint created", {
+      runId: input.body.runId,
+      checkpointId: checkpoint.id,
+      conversationId: conversation.id,
+    });
+
+    return {
+      status: 200 as const,
+      body: {
+        checkpointId: checkpoint.id,
+        agentSessionId: agentSession.id,
+        conversationId: conversation.id,
+        artifacts: input.body.artifactSnapshots,
+        volumes: input.body.volumeVersionsSnapshot?.versions,
+      },
+    };
+  },
+);

--- a/turbo/apps/api/src/signals/services/agent-webhook-checkpoints.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-checkpoints.service.ts
@@ -86,6 +86,12 @@ function artifactSnapshotsForDb(
   });
 }
 
+function responseArtifacts(
+  snapshots: CheckpointCreateBody["artifactSnapshots"],
+): CheckpointCreateBody["artifactSnapshots"] | undefined {
+  return snapshots && snapshots.length > 0 ? snapshots : undefined;
+}
+
 function enrichVolumeSnapshot(args: {
   readonly request: CheckpointCreateBody["volumeVersionsSnapshot"];
   readonly additionalVolumes:
@@ -327,7 +333,7 @@ export const createAgentCheckpoint$ = command(
         checkpointId: checkpoint.id,
         agentSessionId: agentSession.id,
         conversationId: conversation.id,
-        artifacts: input.body.artifactSnapshots,
+        artifacts: responseArtifacts(input.body.artifactSnapshots),
         volumes: input.body.volumeVersionsSnapshot?.versions,
       },
     };


### PR DESCRIPTION
## Summary
- migrate agent checkpoint create and prepare-history webhook routes into apps/api
- preserve sandbox run authentication, checkpoint/conversation/session persistence, blob registration, and presigned history upload behavior
- add route-level integration coverage for auth, missing runs, blob prepare paths, and checkpoint DB side effects

Closes #13212

## Validation
- pnpm -F api exec vitest run src/signals/routes/__tests__/webhooks-agent-checkpoints.test.ts
- pnpm -F api exec vitest run src/signals/routes/__tests__/webhooks-agent-checkpoints.test.ts src/signals/routes/__tests__/agent-checkpoints-id.test.ts src/signals/routes/__tests__/webhooks-agent-storage.test.ts
- pnpm -F api check-types
- pnpm -F api lint
- pnpm format
- pre-commit: pnpm knip; turbo run check-types --concurrency=1