### PR TITLE
chore: update rootfs package versions

### DIFF
--- a/crates/runner/scripts/build-template.sh
+++ b/crates/runner/scripts/build-template.sh
@@ -111,7 +111,7 @@ CACHE_TMP_TAR=""
 
 # Pinned versions (changes here invalidate the template cache via script hash)
 GO_VERSION="1.26.3"
-CLAUDE_CODE_VERSION="2.1.140"
+CLAUDE_CODE_VERSION="2.1.141"
 CODEX_CLI_VERSION="0.130.0"
 GWS_CLI_VERSION="0.22.5"
 XURL_VERSION="1.0.3"


### PR DESCRIPTION
## Summary

Update pinned package versions in `crates/runner/scripts/build-template.sh`:

- **Claude Code CLI**: `2.1.140` → `2.1.141`

## Notes

All other pinned versions are already at latest:
- Go `1.26.3`
- Codex CLI `0.130.0`
- GWS CLI `0.22.5`
- XURL `1.0.3`
- Agent Browser `0.27.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)