### PR TITLE
chore(rust): update dependencies (2026-05-14)

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -195,9 +195,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.3"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -205,9 +205,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.40.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
 dependencies = [
  "cc",
  "cmake",


### PR DESCRIPTION
## Summary

Weekly Rust dependency update. `cargo update` resolved 2 package upgrades:

| Package | Old | New |
|---------|-----|-----|
| aws-lc-rs | 1.16.3 | 1.17.0 |
| aws-lc-sys | 0.40.0 | 0.41.0 |

## Dependencies that could not be updated

3 transitive dependencies are pinned by upstream crate version constraints and cannot be updated from this workspace:

| Package | Current | Latest | Pinned by |
|---------|---------|--------|-----------|
| crc | 3.3.0 | 3.4.0 | crc-fast 1.9.0 → aws-smithy-checksums 0.64.7 → aws-sdk-s3 |
| crc-fast | 1.9.0 | 1.10.0 | aws-smithy-checksums 0.64.7 → aws-sdk-s3 |
| generic-array | 0.14.7 | 0.14.9 | digest 0.10.7 / block-buffer 0.10.4 |

These will resolve once upstream crates (aws-smithy-checksums, digest) release new versions with loosened constraints.

## Manual version bumps

None required. All direct workspace dependencies are already at their latest compatible semver versions.

## Test status

All tests pass — 0 failures across all workspace crates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)