### PR TITLE
refactor(api): migrate agent event webhook

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -36,6 +36,7 @@ import { internalCallbacksScheduleRoutes } from "./routes/internal-callbacks-sch
 import { internalCallbacksSlackOrgRoutes } from "./routes/internal-callbacks-slack-org";
 import { internalCallbacksTelegramRoutes } from "./routes/internal-callbacks-telegram";
 import { internalCallbacksVoiceChatRoutes } from "./routes/internal-callbacks-voice-chat";
+import { internalEventConsumerAgentPhoneTypingRoutes } from "./routes/internal-event-consumers-agentphone-typing";
 import { internalEventConsumerAxiomRoutes } from "./routes/internal-event-consumers-axiom";
 import { internalEventConsumerChatAssistantRoutes } from "./routes/internal-event-consumers-chat-assistant";
 import { internalEventConsumerTelegramTypingRoutes } from "./routes/internal-event-consumers-telegram-typing";
@@ -47,6 +48,7 @@ import { usageRoutes } from "./routes/usage";
 import { userExportRoutes } from "./routes/user-export";
 import { vercelSandboxSmokeRoutes } from "./routes/vercel-sandbox-smoke";
 import { webhooksAgentCheckpointsRoutes } from "./routes/webhooks-agent-checkpoints";
+import { webhooksAgentEventsRoutes } from "./routes/webhooks-agent-events";
 import { webhooksAgentHealthUsageTelemetryRoutes } from "./routes/webhooks-agent-health-usage-telemetry";
 import { webhooksAgentStorageRoutes } from "./routes/webhooks-agent-storage";
 import { webhooksClerkRoutes } from "./routes/webhooks-clerk";
@@ -177,6 +179,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...internalCallbacksSlackOrgRoutes,
   ...internalCallbacksTelegramRoutes,
   ...internalCallbacksVoiceChatRoutes,
+  ...internalEventConsumerAgentPhoneTypingRoutes,
   ...internalEventConsumerAxiomRoutes,
   ...internalEventConsumerChatAssistantRoutes,
   ...internalEventConsumerTelegramTypingRoutes,
@@ -190,6 +193,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...webhooksStripeRoutes,
   ...webhooksAgentHealthUsageTelemetryRoutes,
   ...webhooksAgentCheckpointsRoutes,
+  ...webhooksAgentEventsRoutes,
   ...webhooksAgentStorageRoutes,
   ...agentCheckpointsRoutes,
   ...agentComposesReadRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-events.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-events.test.ts
@@ -1,0 +1,386 @@
+import { randomUUID } from "node:crypto";
+
+import { createStore } from "ccstate";
+import { and, eq } from "drizzle-orm";
+import { HttpResponse, http } from "msw";
+import { beforeEach, describe, expect, it } from "vitest";
+import { webhookEventsContract } from "@vm0/api-contracts/contracts/webhooks";
+import { chatMessages } from "@vm0/db/schema/chat-message";
+
+import { createApp } from "../../../app-factory";
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { mockEnv, mockOptionalEnv } from "../../../lib/env";
+import { now } from "../../../lib/time";
+import { server } from "../../../mocks/server";
+import { signSandboxJwtForTests } from "../../auth/tokens";
+import { writeDb$ } from "../../external/db";
+import { clearAllDetached } from "../../utils";
+import { seedAgentRunCallback$ } from "./helpers/agent-run-callback";
+import {
+  addRunToThread$,
+  deleteZeroChatThread$,
+  seedZeroChatThread$,
+  type ZeroChatThreadFixture,
+} from "./helpers/zero-chat-threads";
+import { seedRun$ } from "./helpers/zero-usage-insight";
+import { createFixtureTracker } from "./helpers/zero-route-test";
+
+const context = testContext();
+const store = createStore();
+
+interface AgentEventsFixture extends ZeroChatThreadFixture {
+  readonly runId: string;
+}
+
+const trackChatFixture = createFixtureTracker<ZeroChatThreadFixture>(
+  (fixture) => {
+    return store.set(deleteZeroChatThread$, fixture, context.signal);
+  },
+);
+
+function currentSecond(): number {
+  return Math.floor(now() / 1000);
+}
+
+function sandboxToken(fixture: {
+  readonly runId: string;
+  readonly userId: string;
+  readonly orgId: string;
+}): string {
+  const nowSeconds = currentSecond();
+  return signSandboxJwtForTests({
+    scope: "sandbox",
+    runId: fixture.runId,
+    userId: fixture.userId,
+    orgId: fixture.orgId,
+    iat: nowSeconds,
+    exp: nowSeconds + 60,
+  });
+}
+
+function authHeaders(fixture: {
+  readonly runId: string;
+  readonly userId: string;
+  readonly orgId: string;
+}): { readonly authorization: string } {
+  return { authorization: `Bearer ${sandboxToken(fixture)}` };
+}
+
+function webhookClient() {
+  return setupApp({ context })(webhookEventsContract);
+}
+
+async function forwardToApi(request: Request): Promise<Response> {
+  const url = new URL(request.url);
+  const body = await request.text();
+  const app = createApp({ signal: context.signal });
+  const response = await app.request(url.pathname, {
+    method: request.method,
+    headers: request.headers,
+    body,
+  });
+
+  return new HttpResponse(response.body, {
+    status: response.status,
+    headers: response.headers,
+  });
+}
+
+function routeInternalConsumers(): void {
+  server.use(
+    http.post(
+      "http://api.test/api/internal/event-consumers/:consumer",
+      ({ request }) => {
+        return forwardToApi(request);
+      },
+    ),
+  );
+}
+
+async function seedFixture(): Promise<AgentEventsFixture> {
+  const fixture = await trackChatFixture(
+    store.set(seedZeroChatThread$, {}, context.signal),
+  );
+  const { runId } = await store.set(
+    seedRun$,
+    {
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      composeId: fixture.composeId,
+      status: "running",
+    },
+    context.signal,
+  );
+  await store.set(
+    addRunToThread$,
+    { threadId: fixture.threadId, runId },
+    context.signal,
+  );
+  return { ...fixture, runId };
+}
+
+function readAssistantMessages(runId: string): Promise<
+  readonly {
+    readonly content: string | null;
+    readonly sequenceNumber: number | null;
+    readonly runEventId: string | null;
+  }[]
+> {
+  const writeDb = store.set(writeDb$);
+  return writeDb
+    .select({
+      content: chatMessages.content,
+      sequenceNumber: chatMessages.sequenceNumber,
+      runEventId: chatMessages.runEventId,
+    })
+    .from(chatMessages)
+    .where(
+      and(eq(chatMessages.runId, runId), eq(chatMessages.role, "assistant")),
+    );
+}
+
+beforeEach(() => {
+  mockEnv("VM0_API_URL", "http://api.test");
+  mockOptionalEnv("AGENTPHONE_API_BASE_URL", "https://api.agentphone.to");
+  mockOptionalEnv("AGENTPHONE_API_KEY", "agentphone-test-key");
+  routeInternalConsumers();
+});
+
+describe("POST /api/webhooks/agent/events", () => {
+  it("rejects missing sandbox auth", async () => {
+    const response = await accept(
+      webhookClient().send({
+        body: {
+          runId: randomUUID(),
+          events: [{ type: "assistant", sequenceNumber: 1 }],
+        },
+        headers: {},
+      }),
+      [401],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Not authenticated or runId mismatch",
+        code: "UNAUTHORIZED",
+      },
+    });
+  });
+
+  it("rejects invalid event payloads before dispatch", async () => {
+    const fixture = await seedFixture();
+    const response = await accept(
+      webhookClient().send({
+        body: { runId: fixture.runId, events: [] },
+        headers: authHeaders(fixture),
+      }),
+      [400],
+    );
+
+    expect(response.body.error.message).toContain("events");
+    expect(context.mocks.axiom.ingest).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when the authenticated run does not exist", async () => {
+    const missing = {
+      runId: randomUUID(),
+      userId: `user_${randomUUID()}`,
+      orgId: `org_${randomUUID()}`,
+    };
+
+    const response = await accept(
+      webhookClient().send({
+        body: {
+          runId: missing.runId,
+          events: [{ type: "assistant", sequenceNumber: 1 }],
+        },
+        headers: authHeaders(missing),
+      }),
+      [404],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Agent run not found", code: "NOT_FOUND" },
+    });
+  });
+
+  it("dispatches valid events to required and optional consumers", async () => {
+    const fixture = await seedFixture();
+
+    const response = await accept(
+      webhookClient().send({
+        body: {
+          runId: fixture.runId,
+          events: [
+            {
+              type: "assistant",
+              sequenceNumber: 7,
+              message: {
+                id: "msg_7",
+                content: [{ type: "text", text: "Hello from API events" }],
+              },
+            },
+            {
+              type: "tool_result",
+              sequenceNumber: 8,
+              result: "ok",
+            },
+          ],
+        },
+        headers: authHeaders(fixture),
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      received: 2,
+      firstSequence: 7,
+      lastSequence: 8,
+    });
+    expect(context.mocks.axiom.ingest).toHaveBeenCalledWith(
+      "agent-run-events",
+      expect.arrayContaining([
+        expect.objectContaining({
+          runId: fixture.runId,
+          userId: fixture.userId,
+          sequenceNumber: 7,
+          eventType: "assistant",
+        }),
+        expect.objectContaining({
+          runId: fixture.runId,
+          userId: fixture.userId,
+          sequenceNumber: 8,
+          eventType: "tool_result",
+        }),
+      ]),
+    );
+    await expect(readAssistantMessages(fixture.runId)).resolves.toStrictEqual([
+      {
+        content: "Hello from API events",
+        sequenceNumber: 7,
+        runEventId: "msg_7",
+      },
+    ]);
+    expect(context.mocks.ably.publish).toHaveBeenCalledWith(
+      `run:changed:${fixture.runId}`,
+      { firstSequence: 7, lastSequence: 8 },
+    );
+  });
+
+  it("does not dispatch optional consumers when required Axiom dispatch fails", async () => {
+    const fixture = await seedFixture();
+    context.mocks.axiom.ingest.mockReturnValue(false);
+    let chatAssistantCalls = 0;
+    server.use(
+      http.post(
+        "http://api.test/api/internal/event-consumers/chat-assistant",
+        () => {
+          chatAssistantCalls++;
+          return HttpResponse.json({ processed: 1 });
+        },
+      ),
+    );
+
+    const response = await accept(
+      webhookClient().send({
+        body: {
+          runId: fixture.runId,
+          events: [{ type: "assistant", sequenceNumber: 1 }],
+        },
+        headers: authHeaders(fixture),
+      }),
+      [500],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Required event consumer dispatch failed: axiom",
+        code: "INTERNAL_SERVER_ERROR",
+      },
+    });
+    expect(chatAssistantCalls).toBe(0);
+  });
+
+  it("accepts events when an optional consumer fails", async () => {
+    const fixture = await seedFixture();
+    server.use(
+      http.post(
+        "http://api.test/api/internal/event-consumers/chat-assistant",
+        () => {
+          return HttpResponse.json(
+            { error: "chat assistant unavailable" },
+            { status: 503 },
+          );
+        },
+      ),
+    );
+
+    const response = await accept(
+      webhookClient().send({
+        body: {
+          runId: fixture.runId,
+          events: [{ type: "assistant", sequenceNumber: 1 }],
+        },
+        headers: authHeaders(fixture),
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      received: 1,
+      firstSequence: 1,
+      lastSequence: 1,
+    });
+    expect(context.mocks.axiom.ingest).toHaveBeenCalledWith(
+      "agent-run-events",
+      [
+        expect.objectContaining({
+          runId: fixture.runId,
+          sequenceNumber: 1,
+          eventType: "assistant",
+        }),
+      ],
+    );
+  });
+
+  it("dispatches AgentPhone typing refresh through the API consumer", async () => {
+    const fixture = await seedFixture();
+    await store.set(
+      seedAgentRunCallback$,
+      {
+        runId: fixture.runId,
+        url: "http://localhost/api/internal/callbacks/agentphone",
+        payload: {
+          conversationId: "conv-agentphone-api-events",
+          channel: "imessage",
+        },
+      },
+      context.signal,
+    );
+
+    const typingCalls: string[] = [];
+    server.use(
+      http.post(
+        "https://api.agentphone.to/v1/conversations/:conversationId/typing",
+        ({ params }) => {
+          typingCalls.push(String(params.conversationId));
+          return HttpResponse.json({ scheduled: true });
+        },
+      ),
+    );
+
+    await accept(
+      webhookClient().send({
+        body: {
+          runId: fixture.runId,
+          events: [{ type: "tool_result", sequenceNumber: 1 }],
+        },
+        headers: authHeaders(fixture),
+      }),
+      [200],
+    );
+    await clearAllDetached();
+
+    expect(typingCalls).toStrictEqual(["conv-agentphone-api-events"]);
+  });
+});

--- a/turbo/apps/api/src/signals/routes/internal-event-consumers-agentphone-typing.ts
+++ b/turbo/apps/api/src/signals/routes/internal-event-consumers-agentphone-typing.ts
@@ -1,0 +1,140 @@
+import { command } from "ccstate";
+import { and, eq } from "drizzle-orm";
+import { agentRunCallbacks } from "@vm0/db/schema/agent-run-callback";
+import { internalEventConsumerAgentPhoneTypingContract } from "@vm0/api-contracts/contracts/internal-event-consumers";
+
+import {
+  eventConsumerPayload$,
+  eventConsumerRoute,
+} from "../../lib/event-consumer/route";
+import { logger } from "../../lib/log";
+import { optionalEnv } from "../../lib/env";
+import { waitUntil } from "../context/wait-until";
+import { db$ } from "../external/db";
+import type { RouteEntry } from "../route";
+
+const L = logger("event-consumer:agentphone-typing");
+
+interface AgentPhoneTypingTarget {
+  readonly conversationId: string;
+}
+
+function parseAgentPhoneTypingTarget(
+  payload: unknown,
+): AgentPhoneTypingTarget | undefined {
+  if (!payload || typeof payload !== "object") {
+    return undefined;
+  }
+
+  const data = payload as Record<string, unknown>;
+  if (
+    data.channel !== "imessage" ||
+    typeof data.conversationId !== "string" ||
+    data.conversationId.length === 0
+  ) {
+    return undefined;
+  }
+
+  return { conversationId: data.conversationId };
+}
+
+async function sendAgentPhoneTypingIndicator(
+  conversationId: string,
+  signal: AbortSignal,
+): Promise<void> {
+  const apiBaseUrl = optionalEnv("AGENTPHONE_API_BASE_URL");
+  const apiKey = optionalEnv("AGENTPHONE_API_KEY");
+  if (!apiBaseUrl || !apiKey) {
+    throw new Error("AgentPhone typing API is not configured");
+  }
+
+  const response = await fetch(
+    `${apiBaseUrl}/v1/conversations/${encodeURIComponent(conversationId)}/typing`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({}),
+      signal,
+    },
+  );
+  signal.throwIfAborted();
+
+  if (!response.ok) {
+    const body = await response.text();
+    signal.throwIfAborted();
+    throw new Error(`AgentPhone typing API error: ${response.status} ${body}`);
+  }
+}
+
+const refreshAgentPhoneTypingForRun$ = command(
+  async ({ get }, runId: string, signal: AbortSignal): Promise<void> => {
+    const db = get(db$);
+    const callbacks = await db
+      .select({
+        url: agentRunCallbacks.url,
+        payload: agentRunCallbacks.payload,
+      })
+      .from(agentRunCallbacks)
+      .where(
+        and(
+          eq(agentRunCallbacks.runId, runId),
+          eq(agentRunCallbacks.status, "pending"),
+        ),
+      );
+    signal.throwIfAborted();
+
+    const targets = new Map<string, AgentPhoneTypingTarget>();
+    for (const callback of callbacks) {
+      if (!callback.url.endsWith("/api/internal/callbacks/agentphone")) {
+        continue;
+      }
+
+      const target = parseAgentPhoneTypingTarget(callback.payload);
+      if (target) {
+        targets.set(target.conversationId, target);
+      }
+    }
+
+    for (const target of targets.values()) {
+      await sendAgentPhoneTypingIndicator(target.conversationId, signal);
+      signal.throwIfAborted();
+    }
+  },
+);
+
+const refreshInner$ = command(
+  ({ get, set }, signal: AbortSignal): RefreshResponse => {
+    const payload = get(eventConsumerPayload$);
+    signal.throwIfAborted();
+
+    waitUntil(
+      set(refreshAgentPhoneTypingForRun$, payload.runId, signal).catch(
+        (error: unknown) => {
+          L.debug("Failed to refresh AgentPhone typing from events", {
+            runId: payload.runId,
+            batch: payload.events.length,
+            error,
+          });
+        },
+      ),
+    );
+
+    return { status: 200, body: { scheduled: true } };
+  },
+);
+
+interface RefreshResponse {
+  readonly status: 200;
+  readonly body: { readonly scheduled: true };
+}
+
+export const internalEventConsumerAgentPhoneTypingRoutes: readonly RouteEntry[] =
+  [
+    {
+      route: internalEventConsumerAgentPhoneTypingContract.refresh,
+      handler: eventConsumerRoute(refreshInner$),
+    },
+  ];

--- a/turbo/apps/api/src/signals/routes/webhooks-agent-events.ts
+++ b/turbo/apps/api/src/signals/routes/webhooks-agent-events.ts
@@ -1,0 +1,36 @@
+import { command } from "ccstate";
+import { webhookEventsContract } from "@vm0/api-contracts/contracts/webhooks";
+
+import { authorization$ } from "../context/hono";
+import { bodyResultOf } from "../context/request";
+import type { RouteEntry } from "../route";
+import { receiveAgentEvents$ } from "../services/agent-webhook-events.service";
+import {
+  getSandboxAuthForRun,
+  unauthorizedRunMismatch,
+} from "./agent-webhook-auth";
+
+const eventsBody$ = bodyResultOf(webhookEventsContract.send);
+
+const receiveEvents$ = command(async ({ get, set }, signal: AbortSignal) => {
+  const bodyResult = await get(eventsBody$);
+  signal.throwIfAborted();
+  if (!bodyResult.ok) {
+    return bodyResult.response;
+  }
+
+  const body = bodyResult.data;
+  const auth = getSandboxAuthForRun(body.runId, get(authorization$));
+  if (!auth) {
+    return unauthorizedRunMismatch;
+  }
+
+  return await set(receiveAgentEvents$, { auth, body }, signal);
+});
+
+export const webhooksAgentEventsRoutes: readonly RouteEntry[] = [
+  {
+    route: webhookEventsContract.send,
+    handler: receiveEvents$,
+  },
+];

--- a/turbo/apps/api/src/signals/services/agent-webhook-events.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-events.service.ts
@@ -1,0 +1,335 @@
+import { command } from "ccstate";
+import { and, eq } from "drizzle-orm";
+import { agentRuns } from "@vm0/db/schema/agent-run";
+
+import type {
+  AgentEvent,
+  RunEventContext,
+} from "../../lib/event-consumer/verify";
+import { computeHmacSignature } from "../../lib/event-consumer/hmac";
+import { env } from "../../lib/env";
+import { notFound } from "../../lib/error";
+import { logger } from "../../lib/log";
+import { now } from "../../lib/time";
+import type { SandboxAuth } from "../../types/auth";
+import { db$ } from "../external/db";
+import { publishRunChangedForUserSafely } from "../external/realtime";
+import { safeAsync } from "../utils";
+
+const L = logger("webhook:events");
+
+interface AgentEventsBody {
+  readonly runId: string;
+  readonly events: readonly AgentEvent[];
+}
+
+interface ReceiveAgentEventsParams {
+  readonly auth: SandboxAuth;
+  readonly body: AgentEventsBody;
+}
+
+interface DispatchableConsumer {
+  readonly name: string;
+  readonly path: string;
+  readonly required?: boolean;
+  readonly eventTypes?: readonly string[];
+}
+
+interface PreparedConsumer {
+  readonly name: string;
+  readonly path: string;
+  readonly required?: boolean;
+  readonly events: readonly AgentEvent[];
+}
+
+interface DispatchAgentEventConsumersParams {
+  readonly runId: string;
+  readonly events: readonly AgentEvent[];
+  readonly context: RunEventContext;
+}
+
+interface DispatchRuntime {
+  readonly runId: string;
+  readonly context: RunEventContext;
+  readonly baseUrl: string;
+  readonly secretsEncryptionKey: string;
+  readonly signal: AbortSignal;
+}
+
+const EVENT_CONSUMERS: readonly DispatchableConsumer[] = [
+  {
+    name: "axiom",
+    path: "/api/internal/event-consumers/axiom",
+    required: true,
+  },
+  {
+    name: "chat-assistant",
+    path: "/api/internal/event-consumers/chat-assistant",
+    eventTypes: ["assistant", "item.completed"],
+  },
+  {
+    name: "telegram-typing",
+    path: "/api/internal/event-consumers/telegram-typing",
+  },
+  {
+    name: "agentphone-typing",
+    path: "/api/internal/event-consumers/agentphone-typing",
+  },
+  {
+    name: "voice-chat",
+    path: "/api/internal/event-consumers/voice-chat",
+    eventTypes: ["assistant"],
+  },
+];
+
+class RequiredEventConsumerDispatchError extends Error {
+  readonly failures: readonly string[];
+
+  constructor(failures: readonly string[]) {
+    super(`Required event consumer dispatch failed: ${failures.join(", ")}`);
+    this.name = "RequiredEventConsumerDispatchError";
+    this.failures = failures;
+  }
+}
+
+function isRequiredEventConsumerDispatchError(
+  error: unknown,
+): error is RequiredEventConsumerDispatchError {
+  return error instanceof RequiredEventConsumerDispatchError;
+}
+
+function internalServerError(message: string) {
+  return {
+    status: 500 as const,
+    body: {
+      error: {
+        message,
+        code: "INTERNAL_SERVER_ERROR",
+      },
+    },
+  };
+}
+
+function resolveBaseUrl(baseUrl: string): string {
+  return env("ENV") === "development" && baseUrl.startsWith("https://tunnel-")
+    ? baseUrl.replace(/^https:\/\/tunnel-[^/]+/u, "http://localhost:3000")
+    : baseUrl;
+}
+
+async function readFailureBody(response: Response): Promise<string> {
+  return await response.text().catch(() => {
+    return "";
+  });
+}
+
+async function drainResponse(response: Response): Promise<void> {
+  await response.arrayBuffer().catch(() => {
+    return undefined;
+  });
+}
+
+async function dispatchToConsumer(
+  consumer: PreparedConsumer,
+  runtime: DispatchRuntime,
+): Promise<void> {
+  const body = JSON.stringify({
+    runId: runtime.runId,
+    events: consumer.events,
+    context: runtime.context,
+  });
+  const timestamp = Math.floor(now() / 1000);
+  const signature = computeHmacSignature(
+    body,
+    runtime.secretsEncryptionKey,
+    timestamp,
+  );
+
+  const response = await fetch(`${runtime.baseUrl}${consumer.path}`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-VM0-Signature": signature,
+      "X-VM0-Timestamp": timestamp.toString(),
+    },
+    body,
+    signal: runtime.signal,
+  });
+  runtime.signal.throwIfAborted();
+
+  if (!response.ok) {
+    const responseBody = await readFailureBody(response);
+    runtime.signal.throwIfAborted();
+    throw new Error(
+      `HTTP ${response.status}${responseBody ? `: ${responseBody}` : ""}`,
+    );
+  }
+
+  await drainResponse(response);
+  runtime.signal.throwIfAborted();
+}
+
+async function dispatchConsumerGroup(
+  consumers: readonly PreparedConsumer[],
+  runtime: DispatchRuntime,
+): Promise<readonly string[]> {
+  const results = await Promise.allSettled(
+    consumers.map((consumer) => {
+      return dispatchToConsumer(consumer, runtime);
+    }),
+  );
+  runtime.signal.throwIfAborted();
+
+  const failures: string[] = [];
+  for (const [index, result] of results.entries()) {
+    if (result.status === "rejected") {
+      const consumer = consumers[index];
+      L.error(`Event consumer "${consumer?.name}" failed`, {
+        runId: runtime.runId,
+        error: result.reason,
+      });
+      if (consumer?.required) {
+        failures.push(consumer.name);
+      }
+    }
+  }
+
+  return failures;
+}
+
+const dispatchAgentEventConsumers$ = command(
+  async (
+    _store,
+    params: DispatchAgentEventConsumersParams,
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const runtime: DispatchRuntime = {
+      runId: params.runId,
+      context: params.context,
+      baseUrl: resolveBaseUrl(env("VM0_API_URL")),
+      secretsEncryptionKey: env("SECRETS_ENCRYPTION_KEY"),
+      signal,
+    };
+
+    const consumers = EVENT_CONSUMERS.map(
+      (consumer): PreparedConsumer | null => {
+        const matchingEvents = consumer.eventTypes
+          ? params.events.filter((event) => {
+              return consumer.eventTypes?.includes(event.type) ?? false;
+            })
+          : params.events;
+
+        if (matchingEvents.length === 0) {
+          return null;
+        }
+
+        return {
+          name: consumer.name,
+          path: consumer.path,
+          required: consumer.required,
+          events: matchingEvents,
+        };
+      },
+    ).filter((consumer): consumer is PreparedConsumer => {
+      return consumer !== null;
+    });
+
+    const requiredConsumers = consumers.filter((consumer) => {
+      return consumer.required;
+    });
+    const optionalConsumers = consumers.filter((consumer) => {
+      return !consumer.required;
+    });
+
+    const requiredFailures = await dispatchConsumerGroup(
+      requiredConsumers,
+      runtime,
+    );
+    signal.throwIfAborted();
+
+    if (requiredFailures.length > 0) {
+      throw new RequiredEventConsumerDispatchError(requiredFailures);
+    }
+
+    await dispatchConsumerGroup(optionalConsumers, runtime);
+    signal.throwIfAborted();
+  },
+);
+
+export const receiveAgentEvents$ = command(
+  async (
+    { get, set },
+    params: ReceiveAgentEventsParams,
+    signal: AbortSignal,
+  ) => {
+    const db = get(db$);
+    const [run] = await db
+      .select({ orgId: agentRuns.orgId })
+      .from(agentRuns)
+      .where(
+        and(
+          eq(agentRuns.id, params.body.runId),
+          eq(agentRuns.userId, params.auth.userId),
+        ),
+      )
+      .limit(1);
+    signal.throwIfAborted();
+
+    if (!run) {
+      return notFound("Agent run not found");
+    }
+
+    const firstSequence = params.body.events[0]!.sequenceNumber;
+    const lastSequence =
+      params.body.events[params.body.events.length - 1]!.sequenceNumber;
+
+    L.debug(
+      `Dispatching events ${firstSequence}-${lastSequence} to consumers for run ${params.body.runId}`,
+    );
+    const startedAt = now();
+    const dispatchResult = await safeAsync(() => {
+      return set(
+        dispatchAgentEventConsumers$,
+        {
+          runId: params.body.runId,
+          events: params.body.events,
+          context: {
+            userId: params.auth.userId,
+            orgId: run.orgId,
+          },
+        },
+        signal,
+      );
+    });
+    signal.throwIfAborted();
+
+    if ("error" in dispatchResult) {
+      if (isRequiredEventConsumerDispatchError(dispatchResult.error)) {
+        return internalServerError(dispatchResult.error.message);
+      }
+      throw dispatchResult.error;
+    }
+
+    await publishRunChangedForUserSafely(
+      params.auth.userId,
+      params.body.runId,
+      {
+        firstSequence,
+        lastSequence,
+      },
+    );
+    signal.throwIfAborted();
+
+    L.debug(
+      `Events ${firstSequence}-${lastSequence} dispatched for run ${params.body.runId} (${now() - startedAt}ms)`,
+    );
+
+    return {
+      status: 200 as const,
+      body: {
+        received: params.body.events.length,
+        firstSequence,
+        lastSequence,
+      },
+    };
+  },
+);

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -352,9 +352,11 @@ export {
 } from "./test-telegram-state";
 export {
   internalEventConsumerAxiomContract,
+  internalEventConsumerAgentPhoneTypingContract,
   internalEventConsumerChatAssistantContract,
   internalEventConsumerTelegramTypingContract,
   internalEventConsumerVoiceChatContract,
+  type InternalEventConsumerAgentPhoneTypingContract,
   type InternalEventConsumerAxiomContract,
   type InternalEventConsumerChatAssistantContract,
   type InternalEventConsumerTelegramTypingContract,

--- a/turbo/packages/api-contracts/src/contracts/internal-event-consumers.ts
+++ b/turbo/packages/api-contracts/src/contracts/internal-event-consumers.ts
@@ -61,6 +61,21 @@ export const internalEventConsumerTelegramTypingContract = c.router({
   },
 });
 
+export const internalEventConsumerAgentPhoneTypingContract = c.router({
+  refresh: {
+    method: "POST",
+    path: "/api/internal/event-consumers/agentphone-typing",
+    headers: eventConsumerHeadersSchema,
+    body: z.object({ runId: z.string() }).passthrough(),
+    responses: {
+      200: z.object({ scheduled: z.literal(true) }),
+      401: eventConsumerUnauthorizedSchema,
+    },
+    summary:
+      "Refresh AgentPhone typing indicators for all pending iMessage callbacks of a run",
+  },
+});
+
 export const internalEventConsumerAxiomContract = c.router({
   ingest: {
     method: "POST",
@@ -112,6 +127,9 @@ export type InternalEventConsumerChatAssistantContract =
 
 export type InternalEventConsumerTelegramTypingContract =
   typeof internalEventConsumerTelegramTypingContract;
+
+export type InternalEventConsumerAgentPhoneTypingContract =
+  typeof internalEventConsumerAgentPhoneTypingContract;
 
 export type InternalEventConsumerVoiceChatContract =
   typeof internalEventConsumerVoiceChatContract;


### PR DESCRIPTION
## Summary
- add an API-owned `POST /api/webhooks/agent/events` route and ccstate service for runner event ingestion
- dispatch required and optional event consumers through API-owned HMAC-signed internal routes, including AgentPhone typing parity
- cover auth, validation, missing run, required Axiom failure, optional consumer failure, chat persistence, realtime publish, and AgentPhone typing side effects

## Tests
- `pnpm -F api exec vitest run src/signals/routes/__tests__/webhooks-agent-events.test.ts src/signals/routes/__tests__/internal-event-consumers.test.ts src/signals/routes/__tests__/internal-event-consumers-telegram-typing.test.ts`
- `pnpm -F api check-types`
- `pnpm -F api lint`
- pre-commit: `prettier`, `knip --cache`, `turbo run check-types --concurrency=1`

Closes #13213