### PR TITLE
refactor(api): migrate agent completion webhook

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -48,6 +48,7 @@ import { usageRoutes } from "./routes/usage";
 import { userExportRoutes } from "./routes/user-export";
 import { vercelSandboxSmokeRoutes } from "./routes/vercel-sandbox-smoke";
 import { webhooksAgentCheckpointsRoutes } from "./routes/webhooks-agent-checkpoints";
+import { webhooksAgentCompleteRoutes } from "./routes/webhooks-agent-complete";
 import { webhooksAgentEventsRoutes } from "./routes/webhooks-agent-events";
 import { webhooksAgentHealthUsageTelemetryRoutes } from "./routes/webhooks-agent-health-usage-telemetry";
 import { webhooksAgentStorageRoutes } from "./routes/webhooks-agent-storage";
@@ -193,6 +194,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...webhooksStripeRoutes,
   ...webhooksAgentHealthUsageTelemetryRoutes,
   ...webhooksAgentCheckpointsRoutes,
+  ...webhooksAgentCompleteRoutes,
   ...webhooksAgentEventsRoutes,
   ...webhooksAgentStorageRoutes,
   ...agentCheckpointsRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-complete.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-complete.test.ts
@@ -1,0 +1,542 @@
+import { randomUUID } from "node:crypto";
+
+import { createStore } from "ccstate";
+import { and, eq } from "drizzle-orm";
+import { HttpResponse, http } from "msw";
+import { describe, expect, it } from "vitest";
+import type { StoredExecutionContext } from "@vm0/api-contracts/contracts/runners";
+import { webhookCompleteContract } from "@vm0/api-contracts/contracts/webhooks";
+import { agentRunCallbacks } from "@vm0/db/schema/agent-run-callback";
+import { agentRunQueue } from "@vm0/db/schema/agent-run-queue";
+import { agentRuns } from "@vm0/db/schema/agent-run";
+import { agentSessions } from "@vm0/db/schema/agent-session";
+import { checkpoints } from "@vm0/db/schema/checkpoint";
+import { conversations } from "@vm0/db/schema/conversation";
+import { orgMetadata } from "@vm0/db/schema/org-metadata";
+import { runnerJobQueue } from "@vm0/db/schema/runner-job-queue";
+import { usageEvent } from "@vm0/db/schema/usage-event";
+import { usagePricing } from "@vm0/db/schema/usage-pricing";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { verifyHmacSignature } from "../../../lib/event-consumer/hmac";
+import { now } from "../../../lib/time";
+import { server } from "../../../mocks/server";
+import { signSandboxJwtForTests } from "../../auth/tokens";
+import { writeDb$ } from "../../external/db";
+import {
+  encryptQueuedRunnerJobPayload,
+  queuedRunnerJobPayload,
+} from "../../services/agent-run-queue-payload.service";
+import { clearAllDetached } from "../../utils";
+import { seedAgentRunCallback$ } from "./helpers/agent-run-callback";
+import {
+  deleteUsageInsightFixture$,
+  seedCompose$,
+  seedRun$,
+  seedUsageInsightFixture$,
+  type UsageInsightFixture,
+} from "./helpers/zero-usage-insight";
+import { createFixtureTracker } from "./helpers/zero-route-test";
+
+const context = testContext();
+const store = createStore();
+const TEST_CALLBACK_SECRET = "test-callback-secret";
+
+interface CompleteWebhookFixture extends UsageInsightFixture {
+  readonly composeId: string;
+  readonly runId: string;
+}
+
+interface CheckpointFixture {
+  readonly checkpointId: string;
+  readonly conversationId: string;
+  readonly sessionId: string;
+  readonly artifactVersion: string;
+  readonly volumeVersion: string;
+}
+
+function currentSecond(): number {
+  return Math.floor(now() / 1000);
+}
+
+function sandboxToken(fixture: {
+  readonly runId: string;
+  readonly userId: string;
+  readonly orgId: string;
+}): string {
+  const nowSeconds = currentSecond();
+  return signSandboxJwtForTests({
+    scope: "sandbox",
+    runId: fixture.runId,
+    userId: fixture.userId,
+    orgId: fixture.orgId,
+    iat: nowSeconds,
+    exp: nowSeconds + 60,
+  });
+}
+
+function authHeaders(fixture: {
+  readonly runId: string;
+  readonly userId: string;
+  readonly orgId: string;
+}): { readonly authorization: string } {
+  return { authorization: `Bearer ${sandboxToken(fixture)}` };
+}
+
+function completeClient() {
+  return setupApp({ context })(webhookCompleteContract);
+}
+
+async function seedFixture(
+  status = "running",
+): Promise<CompleteWebhookFixture> {
+  const base = await store.set(
+    seedUsageInsightFixture$,
+    undefined,
+    context.signal,
+  );
+  const { composeId } = await store.set(
+    seedCompose$,
+    { orgId: base.orgId, userId: base.userId },
+    context.signal,
+  );
+  const { runId } = await store.set(
+    seedRun$,
+    { orgId: base.orgId, userId: base.userId, composeId, status },
+    context.signal,
+  );
+  return { ...base, composeId, runId };
+}
+
+async function seedCheckpoint(
+  fixture: CompleteWebhookFixture,
+): Promise<CheckpointFixture> {
+  const db = store.set(writeDb$);
+  const [run] = await db
+    .select({ sessionId: agentRuns.sessionId })
+    .from(agentRuns)
+    .where(eq(agentRuns.id, fixture.runId))
+    .limit(1);
+  if (!run) {
+    throw new Error("seedCheckpoint: run not found");
+  }
+
+  const historyHash = "a".repeat(64);
+  const [conversation] = await db
+    .insert(conversations)
+    .values({
+      runId: fixture.runId,
+      cliAgentType: "codex",
+      cliAgentSessionId: `cli-${fixture.runId}`,
+      cliAgentSessionHistoryHash: historyHash,
+    })
+    .returning({ id: conversations.id });
+  if (!conversation) {
+    throw new Error("seedCheckpoint: conversation insert returned no row");
+  }
+
+  await db
+    .update(agentSessions)
+    .set({ conversationId: conversation.id })
+    .where(eq(agentSessions.id, run.sessionId));
+
+  const artifactVersion = `artifact-${randomUUID()}`;
+  const volumeVersion = `volume-${randomUUID()}`;
+  const [checkpoint] = await db
+    .insert(checkpoints)
+    .values({
+      runId: fixture.runId,
+      conversationId: conversation.id,
+      agentComposeSnapshot: {
+        agentComposeVersionId: fixture.composeId,
+      },
+      artifactSnapshots: [
+        {
+          name: "workspace",
+          version: artifactVersion,
+          mountPath: "/workspace",
+        },
+      ],
+      volumeVersionsSnapshot: {
+        versions: {
+          cache: volumeVersion,
+        },
+      },
+    })
+    .returning({ id: checkpoints.id });
+  if (!checkpoint) {
+    throw new Error("seedCheckpoint: checkpoint insert returned no row");
+  }
+
+  return {
+    checkpointId: checkpoint.id,
+    conversationId: conversation.id,
+    sessionId: run.sessionId,
+    artifactVersion,
+    volumeVersion,
+  };
+}
+
+async function runById(runId: string) {
+  const db = store.set(writeDb$);
+  const [run] = await db
+    .select()
+    .from(agentRuns)
+    .where(eq(agentRuns.id, runId))
+    .limit(1);
+  return run;
+}
+
+const track = createFixtureTracker<CompleteWebhookFixture>(async (fixture) => {
+  const db = store.set(writeDb$);
+  await db.delete(orgMetadata).where(eq(orgMetadata.orgId, fixture.orgId));
+  await store.set(deleteUsageInsightFixture$, fixture, context.signal);
+});
+
+describe("POST /api/webhooks/agent/complete", () => {
+  it("rejects missing sandbox auth", async () => {
+    const fixture = await track(seedFixture());
+
+    const response = await accept(
+      completeClient().complete({
+        body: { runId: fixture.runId, exitCode: 0 },
+        headers: {},
+      }),
+      [401],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Not authenticated or runId mismatch",
+        code: "UNAUTHORIZED",
+      },
+    });
+  });
+
+  it("rejects a body runId that does not match the sandbox token", async () => {
+    const fixture = await track(seedFixture());
+
+    const response = await accept(
+      completeClient().complete({
+        body: { runId: randomUUID(), exitCode: 0 },
+        headers: authHeaders(fixture),
+      }),
+      [401],
+    );
+
+    expect(response.body.error.message).toBe(
+      "Not authenticated or runId mismatch",
+    );
+  });
+
+  it("completes a successful run from its checkpoint", async () => {
+    const fixture = await track(seedFixture());
+    const checkpoint = await seedCheckpoint(fixture);
+
+    const response = await accept(
+      completeClient().complete({
+        body: {
+          runId: fixture.runId,
+          exitCode: 0,
+          lastEventSequence: 7,
+          sandboxId: "sandbox-success",
+          sandboxReuseResult: "reused",
+        },
+        headers: authHeaders(fixture),
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      success: true,
+      status: "completed",
+    });
+
+    const run = await runById(fixture.runId);
+    expect(run).toMatchObject({
+      status: "completed",
+      lastEventSequence: 7,
+      sandboxId: "sandbox-success",
+      sandboxReuseResult: "reused",
+      error: null,
+    });
+    expect(run?.completedAt).toBeInstanceOf(Date);
+    expect(run?.result).toStrictEqual({
+      checkpointId: checkpoint.checkpointId,
+      agentSessionId: checkpoint.sessionId,
+      conversationId: checkpoint.conversationId,
+      artifact: {
+        workspace: checkpoint.artifactVersion,
+      },
+      volumes: {
+        cache: checkpoint.volumeVersion,
+      },
+    });
+    expect(context.mocks.ably.publish).toHaveBeenCalledWith(
+      `run:changed:${fixture.runId}`,
+      { status: "completed" },
+    );
+  });
+
+  it("fails a successful completion when the checkpoint is missing", async () => {
+    const fixture = await track(seedFixture());
+
+    const response = await accept(
+      completeClient().complete({
+        body: { runId: fixture.runId, exitCode: 0 },
+        headers: authHeaders(fixture),
+      }),
+      [404],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Checkpoint for run not found",
+        code: "NOT_FOUND",
+      },
+    });
+
+    const run = await runById(fixture.runId);
+    expect(run).toMatchObject({
+      status: "failed",
+      error: "Checkpoint for run not found",
+    });
+  });
+
+  it("records runner failure output and upgrades a stale timeout", async () => {
+    const fixture = await track(seedFixture("timeout"));
+
+    const response = await accept(
+      completeClient().complete({
+        body: {
+          runId: fixture.runId,
+          exitCode: 1,
+          error: "codex exited with status 1",
+          sandboxId: "sandbox-failure",
+          sandboxReuseResult: "poolMiss",
+        },
+        headers: authHeaders(fixture),
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      success: true,
+      status: "failed",
+    });
+
+    const run = await runById(fixture.runId);
+    expect(run).toMatchObject({
+      status: "failed",
+      error: "codex exited with status 1",
+      sandboxId: "sandbox-failure",
+      sandboxReuseResult: "poolMiss",
+    });
+    expect(context.mocks.ably.publish).toHaveBeenCalledWith(
+      `run:changed:${fixture.runId}`,
+      { status: "failed" },
+    );
+  });
+
+  it("returns idempotent success for duplicate terminal completions", async () => {
+    const fixture = await track(seedFixture("completed"));
+
+    const response = await accept(
+      completeClient().complete({
+        body: { runId: fixture.runId, exitCode: 1, lastEventSequence: 12 },
+        headers: authHeaders(fixture),
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      success: true,
+      status: "completed",
+    });
+
+    const run = await runById(fixture.runId);
+    expect(run?.status).toBe("completed");
+    expect(run?.lastEventSequence).toBe(12);
+    expect(context.mocks.ably.publish).not.toHaveBeenCalled();
+  });
+
+  it("dispatches callbacks, drains the queue, and settles usage after completion", async () => {
+    const fixture = await track(seedFixture());
+    await seedCheckpoint(fixture);
+    const callbackUrl = "https://callback.example/complete";
+    const { callbackId } = await store.set(
+      seedAgentRunCallback$,
+      { runId: fixture.runId, url: callbackUrl, payload: { channel: "C1" } },
+      context.signal,
+    );
+
+    let callbackBody: unknown;
+    server.use(
+      http.post(callbackUrl, async ({ request }) => {
+        const rawBody = await request.text();
+        const timestamp = Number(request.headers.get("x-vm0-timestamp"));
+        const signature = request.headers.get("x-vm0-signature");
+        expect(signature).not.toBeNull();
+        expect(
+          verifyHmacSignature(
+            rawBody,
+            TEST_CALLBACK_SECRET,
+            timestamp,
+            signature ?? "",
+          ),
+        ).toBeTruthy();
+        callbackBody = JSON.parse(rawBody) as unknown;
+        return HttpResponse.json({ ok: true });
+      }),
+    );
+
+    const { runId: queuedRunId } = await store.set(
+      seedRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        composeId: fixture.composeId,
+        status: "queued",
+      },
+      context.signal,
+    );
+    const db = store.set(writeDb$);
+    const runnerGroup = `runner-group-${randomUUID()}`;
+    const profile = "vm0/default";
+    const queuedSessionId = `session-${randomUUID()}`;
+    const queuedExecutionContext = {
+      workingDir: "/workspace",
+      storageManifest: null,
+      environment: null,
+      resumeSession: null,
+      encryptedSecrets: null,
+      cliAgentType: "codex",
+    } satisfies StoredExecutionContext;
+    await db.insert(agentRunQueue).values({
+      runId: queuedRunId,
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      encryptedParams: encryptQueuedRunnerJobPayload(
+        queuedRunnerJobPayload({
+          runnerGroup,
+          profile,
+          sessionId: queuedSessionId,
+          executionContext: queuedExecutionContext,
+        }),
+      ),
+      expiresAt: new Date(now() + 60_000),
+    });
+
+    const provider = `test-provider-${randomUUID()}`;
+    await db.insert(orgMetadata).values({
+      orgId: fixture.orgId,
+      credits: 1000,
+      tier: "free",
+    });
+    await db.insert(usagePricing).values({
+      kind: "model",
+      provider,
+      category: "tokens.input",
+      unitPrice: 1,
+      unitSize: 1000,
+    });
+    await db.insert(usageEvent).values({
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      runId: fixture.runId,
+      kind: "model",
+      provider,
+      category: "tokens.input",
+      quantity: 5000,
+      status: "pending",
+      idempotencyKey: randomUUID(),
+    });
+
+    await accept(
+      completeClient().complete({
+        body: { runId: fixture.runId, exitCode: 0 },
+        headers: authHeaders(fixture),
+      }),
+      [200],
+    );
+
+    await clearAllDetached();
+
+    expect(callbackBody).toStrictEqual({
+      callbackId,
+      runId: fixture.runId,
+      status: "completed",
+      payload: { channel: "C1" },
+    });
+    const [callback] = await db
+      .select({
+        status: agentRunCallbacks.status,
+        attempts: agentRunCallbacks.attempts,
+        deliveredAt: agentRunCallbacks.deliveredAt,
+      })
+      .from(agentRunCallbacks)
+      .where(eq(agentRunCallbacks.id, callbackId))
+      .limit(1);
+    expect(callback?.status).toBe("delivered");
+    expect(callback?.attempts).toBe(1);
+    expect(callback?.deliveredAt).toBeInstanceOf(Date);
+
+    const queuedRun = await runById(queuedRunId);
+    expect(queuedRun?.status).toBe("pending");
+    expect(queuedRun?.runnerGroup).toBe(runnerGroup);
+    const [runnerJob] = await db
+      .select({
+        runId: runnerJobQueue.runId,
+        runnerGroup: runnerJobQueue.runnerGroup,
+        profile: runnerJobQueue.profile,
+        sessionId: runnerJobQueue.sessionId,
+        executionContext: runnerJobQueue.executionContext,
+      })
+      .from(runnerJobQueue)
+      .where(eq(runnerJobQueue.runId, queuedRunId))
+      .limit(1);
+    expect(runnerJob).toStrictEqual({
+      runId: queuedRunId,
+      runnerGroup,
+      profile,
+      sessionId: queuedSessionId,
+      executionContext: queuedExecutionContext,
+    });
+    expect(context.mocks.ably.publish).toHaveBeenCalledWith(
+      "queue:changed",
+      null,
+    );
+    expect(context.mocks.ably.publish).toHaveBeenCalledWith("job", {
+      runId: queuedRunId,
+      profile,
+    });
+
+    const [eventRow] = await db
+      .select({
+        status: usageEvent.status,
+        creditsCharged: usageEvent.creditsCharged,
+      })
+      .from(usageEvent)
+      .where(eq(usageEvent.runId, fixture.runId));
+    expect(eventRow).toStrictEqual({
+      status: "processed",
+      creditsCharged: 5,
+    });
+
+    const [orgRow] = await db
+      .select({ credits: orgMetadata.credits })
+      .from(orgMetadata)
+      .where(eq(orgMetadata.orgId, fixture.orgId));
+    expect(orgRow?.credits).toBe(995);
+
+    await db
+      .delete(usagePricing)
+      .where(
+        and(
+          eq(usagePricing.kind, "model"),
+          eq(usagePricing.provider, provider),
+          eq(usagePricing.category, "tokens.input"),
+        ),
+      );
+  });
+});

--- a/turbo/apps/api/src/signals/routes/webhooks-agent-complete.ts
+++ b/turbo/apps/api/src/signals/routes/webhooks-agent-complete.ts
@@ -1,0 +1,64 @@
+import { command } from "ccstate";
+import { webhookCompleteContract } from "@vm0/api-contracts/contracts/webhooks";
+
+import { logger } from "../../lib/log";
+import { authorization$ } from "../context/hono";
+import { bodyResultOf } from "../context/request";
+import { waitUntil } from "../context/wait-until";
+import type { RouteEntry } from "../route";
+import {
+  completeAgentRun$,
+  dispatchCompleteSideEffects$,
+} from "../services/agent-webhook-complete.service";
+import {
+  getSandboxAuthForRun,
+  unauthorizedRunMismatch,
+} from "./agent-webhook-auth";
+
+const L = logger("webhook:complete");
+
+const completeBody$ = bodyResultOf(webhookCompleteContract.complete);
+
+const completeAgentRunRoute$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const bodyResult = await get(completeBody$);
+    signal.throwIfAborted();
+    if (!bodyResult.ok) {
+      return bodyResult.response;
+    }
+
+    const body = bodyResult.data;
+    const auth = getSandboxAuthForRun(body.runId, get(authorization$));
+    if (!auth) {
+      return unauthorizedRunMismatch;
+    }
+
+    const result = await set(completeAgentRun$, { auth, body }, signal);
+    signal.throwIfAborted();
+
+    if (result.sideEffects) {
+      waitUntil(
+        set(dispatchCompleteSideEffects$, result.sideEffects, signal).catch(
+          (error: unknown) => {
+            L.error("dispatchCompleteSideEffects failed", {
+              runId: result.sideEffects?.runId,
+              error,
+            });
+          },
+        ),
+      );
+    }
+
+    return {
+      status: result.status,
+      body: result.body,
+    };
+  },
+);
+
+export const webhooksAgentCompleteRoutes: readonly RouteEntry[] = [
+  {
+    route: webhookCompleteContract.complete,
+    handler: completeAgentRunRoute$,
+  },
+];

--- a/turbo/apps/api/src/signals/services/agent-webhook-complete.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-complete.service.ts
@@ -1,0 +1,469 @@
+import { command } from "ccstate";
+import type { z } from "zod";
+import { and, eq, inArray, sql } from "drizzle-orm";
+import type { RunResult, RunStatus } from "@vm0/api-contracts/contracts/runs";
+import { webhookCompleteContract } from "@vm0/api-contracts/contracts/webhooks";
+import { agentRuns } from "@vm0/db/schema/agent-run";
+import { agentSessions } from "@vm0/db/schema/agent-session";
+import { checkpoints } from "@vm0/db/schema/checkpoint";
+
+import { notFound } from "../../lib/error";
+import { logger } from "../../lib/log";
+import { nowDate } from "../../lib/time";
+import type { SandboxAuth } from "../../types/auth";
+import { writeDb$, type Db } from "../external/db";
+import { publishRunChangedForUserSafely } from "../external/realtime";
+import { dispatchRunCallbacks } from "./agent-run-callback.service";
+import { processOrgUsageEvents$ } from "./zero-credit-usage.service";
+import { drainOrgQueue$ } from "./zero-run-queue.service";
+
+type WebhookCompleteBody = z.infer<
+  typeof webhookCompleteContract.complete.body
+>;
+type TerminalStatus = "completed" | "failed";
+
+interface CompleteAgentRunInput {
+  readonly auth: SandboxAuth;
+  readonly body: WebhookCompleteBody;
+}
+
+interface TerminalSideEffectsInput {
+  readonly runId: string;
+  readonly orgId: string;
+  readonly status: TerminalStatus;
+  readonly error?: string;
+}
+
+interface CompletionResponse {
+  readonly status: 200 | 404;
+  readonly body:
+    | {
+        readonly success: true;
+        readonly status: TerminalStatus;
+      }
+    | {
+        readonly error: {
+          readonly message: string;
+          readonly code: "NOT_FOUND";
+        };
+      };
+  readonly sideEffects?: TerminalSideEffectsInput;
+}
+
+interface VolumeVersionsSnapshot {
+  readonly versions: Record<string, string>;
+}
+
+interface RunRecord {
+  readonly orgId: string;
+  readonly status: string;
+  readonly userId: string;
+}
+
+interface ArtifactSnapshot {
+  readonly name: string;
+  readonly version: string;
+  readonly mountPath: string;
+}
+
+const L = logger("webhook:complete");
+
+function isVolumeVersionsSnapshot(
+  value: unknown,
+): value is VolumeVersionsSnapshot {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "versions" in value &&
+    typeof value.versions === "object" &&
+    value.versions !== null &&
+    !Array.isArray(value.versions) &&
+    Object.values(value.versions).every((entry) => {
+      return typeof entry === "string";
+    })
+  );
+}
+
+function isArtifactSnapshot(value: unknown): value is ArtifactSnapshot {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "name" in value &&
+    "version" in value &&
+    "mountPath" in value &&
+    typeof value.name === "string" &&
+    typeof value.version === "string" &&
+    typeof value.mountPath === "string"
+  );
+}
+
+function decodeArtifactSnapshotsToRecord(
+  raw: unknown,
+): Record<string, string> | undefined {
+  if (raw === null || raw === undefined) {
+    return undefined;
+  }
+
+  if (!Array.isArray(raw) || raw.length === 0) {
+    return undefined;
+  }
+
+  const result: Record<string, string> = {};
+  for (const [index, entry] of raw.entries()) {
+    if (!isArtifactSnapshot(entry)) {
+      throw new Error(`Invalid checkpoint artifact snapshot at index ${index}`);
+    }
+    result[entry.name] = entry.version;
+  }
+  return result;
+}
+
+function buildRunResult(
+  checkpoint: typeof checkpoints.$inferSelect,
+  sessionId: string | undefined,
+): RunResult {
+  const artifact = decodeArtifactSnapshotsToRecord(
+    checkpoint.artifactSnapshots,
+  );
+  const volumeVersions = isVolumeVersionsSnapshot(
+    checkpoint.volumeVersionsSnapshot,
+  )
+    ? checkpoint.volumeVersionsSnapshot.versions
+    : undefined;
+
+  return {
+    checkpointId: checkpoint.id,
+    agentSessionId: sessionId ?? checkpoint.conversationId,
+    conversationId: checkpoint.conversationId,
+    ...(artifact ? { artifact } : {}),
+    ...(volumeVersions ? { volumes: volumeVersions } : {}),
+  };
+}
+
+async function persistLastEventSequence(
+  db: Db,
+  runId: string,
+  userId: string,
+  lastEventSequence: number,
+): Promise<void> {
+  await db
+    .update(agentRuns)
+    .set({
+      lastEventSequence: sql<number>`greatest(coalesce(${agentRuns.lastEventSequence}, -1), ${lastEventSequence})`,
+    })
+    .where(and(eq(agentRuns.id, runId), eq(agentRuns.userId, userId)));
+}
+
+async function readCompletionResponseStatus(
+  db: Db,
+  runId: string,
+  userId: string,
+): Promise<TerminalStatus> {
+  const [currentRun] = await db
+    .select({ status: agentRuns.status })
+    .from(agentRuns)
+    .where(and(eq(agentRuns.id, runId), eq(agentRuns.userId, userId)))
+    .limit(1);
+
+  return currentRun?.status === "completed" ? "completed" : "failed";
+}
+
+async function transitionRunStatus(
+  db: Db,
+  runId: string,
+  update: {
+    readonly status: RunStatus;
+    readonly completedAt: Date;
+    readonly error?: string;
+    readonly result?: RunResult;
+    readonly sandboxId?: string;
+    readonly sandboxReuseResult?: WebhookCompleteBody["sandboxReuseResult"];
+  },
+  allowedFromStatuses: readonly RunStatus[],
+): Promise<boolean> {
+  const [updated] = await db
+    .update(agentRuns)
+    .set(update)
+    .where(
+      and(
+        eq(agentRuns.id, runId),
+        inArray(agentRuns.status, [...allowedFromStatuses]),
+      ),
+    )
+    .returning({ id: agentRuns.id });
+  return !!updated;
+}
+
+function successResponse(
+  runId: string,
+  orgId: string,
+  status: TerminalStatus,
+  error?: string,
+): CompletionResponse {
+  return {
+    status: 200,
+    body: {
+      success: true,
+      status,
+    },
+    sideEffects: {
+      runId,
+      orgId,
+      status,
+      ...(error ? { error } : {}),
+    },
+  };
+}
+
+async function currentStatusResponse(
+  db: Db,
+  input: CompleteAgentRunInput,
+): Promise<CompletionResponse> {
+  return {
+    status: 200,
+    body: {
+      success: true,
+      status: await readCompletionResponseStatus(
+        db,
+        input.body.runId,
+        input.auth.userId,
+      ),
+    },
+  };
+}
+
+async function handleMissingCheckpoint(
+  db: Db,
+  input: CompleteAgentRunInput,
+  run: RunRecord,
+  signal: AbortSignal,
+): Promise<CompletionResponse> {
+  const error = "Checkpoint for run not found";
+  const transitioned = await transitionRunStatus(
+    db,
+    input.body.runId,
+    {
+      status: "failed",
+      completedAt: nowDate(),
+      error,
+      sandboxId: input.body.sandboxId,
+      sandboxReuseResult: input.body.sandboxReuseResult,
+    },
+    ["pending", "running", "timeout"],
+  );
+  signal.throwIfAborted();
+
+  if (!transitioned) {
+    return await currentStatusResponse(db, input);
+  }
+
+  await publishRunChangedForUserSafely(run.userId, input.body.runId, {
+    status: "failed",
+  });
+  signal.throwIfAborted();
+
+  return {
+    status: 404,
+    body: {
+      error: {
+        message: error,
+        code: "NOT_FOUND",
+      },
+    },
+    sideEffects: {
+      runId: input.body.runId,
+      orgId: run.orgId,
+      status: "failed",
+      error,
+    },
+  };
+}
+
+async function handleSuccessfulCompletion(
+  db: Db,
+  input: CompleteAgentRunInput,
+  run: RunRecord,
+  signal: AbortSignal,
+): Promise<CompletionResponse> {
+  const [checkpoint] = await db
+    .select()
+    .from(checkpoints)
+    .where(eq(checkpoints.runId, input.body.runId))
+    .limit(1);
+  signal.throwIfAborted();
+
+  if (!checkpoint) {
+    return await handleMissingCheckpoint(db, input, run, signal);
+  }
+
+  const [session] = await db
+    .select({ id: agentSessions.id })
+    .from(agentSessions)
+    .where(eq(agentSessions.conversationId, checkpoint.conversationId))
+    .limit(1);
+  signal.throwIfAborted();
+
+  const result = buildRunResult(checkpoint, session?.id);
+  const transitioned = await transitionRunStatus(
+    db,
+    input.body.runId,
+    {
+      status: "completed",
+      completedAt: nowDate(),
+      result,
+      sandboxId: input.body.sandboxId,
+      sandboxReuseResult: input.body.sandboxReuseResult,
+    },
+    ["pending", "running", "timeout"],
+  );
+  signal.throwIfAborted();
+
+  if (!transitioned) {
+    return await currentStatusResponse(db, input);
+  }
+
+  await publishRunChangedForUserSafely(run.userId, input.body.runId, {
+    status: "completed",
+  });
+  signal.throwIfAborted();
+
+  L.debug("Run completed successfully", { runId: input.body.runId });
+  return successResponse(input.body.runId, run.orgId, "completed");
+}
+
+async function handleFailedCompletion(
+  db: Db,
+  input: CompleteAgentRunInput,
+  run: RunRecord,
+  signal: AbortSignal,
+): Promise<CompletionResponse> {
+  const error = input.body.error?.trim() || "Run failed without error message";
+  const transitioned = await transitionRunStatus(
+    db,
+    input.body.runId,
+    {
+      status: "failed",
+      completedAt: nowDate(),
+      error,
+      sandboxId: input.body.sandboxId,
+      sandboxReuseResult: input.body.sandboxReuseResult,
+    },
+    ["pending", "running", "timeout"],
+  );
+  signal.throwIfAborted();
+
+  if (!transitioned) {
+    return await currentStatusResponse(db, input);
+  }
+
+  await publishRunChangedForUserSafely(run.userId, input.body.runId, {
+    status: "failed",
+  });
+  signal.throwIfAborted();
+
+  L.warn("Run failed", {
+    runId: input.body.runId,
+    exitCode: input.body.exitCode,
+    error,
+  });
+  return successResponse(input.body.runId, run.orgId, "failed", error);
+}
+
+export const dispatchCompleteSideEffects$ = command(
+  async (
+    { set },
+    input: TerminalSideEffectsInput,
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const db = set(writeDb$);
+    const callbackStatus =
+      input.status === "completed" ? "completed" : "failed";
+    await dispatchRunCallbacks(
+      db,
+      input.runId,
+      callbackStatus,
+      undefined,
+      input.error,
+    ).catch((error: unknown) => {
+      L.error("Failed to dispatch terminal callbacks", {
+        runId: input.runId,
+        error,
+      });
+    });
+    signal.throwIfAborted();
+
+    await set(drainOrgQueue$, { orgId: input.orgId }, signal).catch(
+      (error: unknown) => {
+        L.error("Failed to drain org queue", {
+          runId: input.runId,
+          orgId: input.orgId,
+          error,
+        });
+      },
+    );
+    signal.throwIfAborted();
+
+    await set(processOrgUsageEvents$, input.orgId, signal);
+    signal.throwIfAborted();
+  },
+);
+
+export const completeAgentRun$ = command(
+  async (
+    { set },
+    input: CompleteAgentRunInput,
+    signal: AbortSignal,
+  ): Promise<CompletionResponse> => {
+    const db = set(writeDb$);
+    const [run] = await db
+      .select({
+        id: agentRuns.id,
+        orgId: agentRuns.orgId,
+        status: agentRuns.status,
+        userId: agentRuns.userId,
+      })
+      .from(agentRuns)
+      .where(
+        and(
+          eq(agentRuns.id, input.body.runId),
+          eq(agentRuns.userId, input.auth.userId),
+        ),
+      )
+      .limit(1);
+    signal.throwIfAborted();
+
+    if (!run) {
+      return notFound("Agent run not found");
+    }
+
+    if (input.body.lastEventSequence !== undefined) {
+      await persistLastEventSequence(
+        db,
+        input.body.runId,
+        input.auth.userId,
+        input.body.lastEventSequence,
+      );
+      signal.throwIfAborted();
+    }
+
+    if (run.status === "completed" || run.status === "failed") {
+      L.debug("Skipping duplicate completion for terminal run", {
+        runId: input.body.runId,
+        status: run.status,
+      });
+      return {
+        status: 200,
+        body: {
+          success: true,
+          status: run.status,
+        },
+      };
+    }
+
+    if (input.body.exitCode === 0) {
+      return await handleSuccessfulCompletion(db, input, run, signal);
+    }
+
+    return await handleFailedCompletion(db, input, run, signal);
+  },
+);


### PR DESCRIPTION
## Summary

- Add an API-owned `POST /api/webhooks/agent/complete` route for sandbox completion callbacks.
- Move terminal completion behavior into ccstate commands: status transition, checkpoint result projection, duplicate completion handling, timeout upgrade semantics, realtime publish, callback dispatch, queue drain, and usage settlement.
- Add integration coverage for auth, success, missing checkpoint, runner failure, duplicate completion, callbacks, queue drain, and usage settlement.

Closes #13214

## Validation

- `pnpm -F api exec vitest run src/signals/routes/__tests__/webhooks-agent-complete.test.ts src/signals/routes/__tests__/webhooks-agent-checkpoints.test.ts src/signals/routes/__tests__/webhooks-agent-health-usage-telemetry.test.ts src/signals/routes/__tests__/webhooks-agent-events.test.ts`
- `pnpm -F api check-types`
- `pnpm -F api lint`
- `git diff --check`
- pre-commit: `prettier`, `knip`, `turbo run check-types --concurrency=1`