### PR TITLE
refactor(api): migrate telegram cleanup cron route

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -23,6 +23,7 @@ import { cronAggregateInsightsRoutes } from "./routes/cron-aggregate-insights";
 import { cronAggregateUsageRoutes } from "./routes/cron-aggregate-usage";
 import { cronProcessUsageEventsRoutes } from "./routes/cron-process-usage-events";
 import { cronReconcileBillingEntitlementsRoutes } from "./routes/cron-reconcile-billing-entitlements";
+import { cronTelegramCleanupRoutes } from "./routes/cron-telegram-cleanup";
 import { deviceTokenRoutes } from "./routes/device-token";
 import { emailUnsubscribeRoutes } from "./routes/email-unsubscribe";
 import { generateImageRoutes } from "./routes/generate-image";
@@ -211,6 +212,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...cronAggregateUsageRoutes,
   ...cronProcessUsageEventsRoutes,
   ...cronReconcileBillingEntitlementsRoutes,
+  ...cronTelegramCleanupRoutes,
   ...deviceTokenRoutes,
   ...emailUnsubscribeRoutes,
   ...generateImageRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-telegram-cleanup.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-telegram-cleanup.test.ts
@@ -1,0 +1,179 @@
+import { randomUUID } from "node:crypto";
+
+import { cronTelegramCleanupContract } from "@vm0/api-contracts/contracts/cron";
+import { telegramMessages } from "@vm0/db/schema/telegram-message";
+import { createStore } from "ccstate";
+import { count, eq } from "drizzle-orm";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { mockEnv } from "../../../lib/env";
+import { clearMockNow, mockNow, nowDate } from "../../../lib/time";
+import { writeDb$ } from "../../external/db";
+import {
+  deleteTelegramFixture$,
+  freezeTelegramFixture,
+  makeTelegramFixtureBuilder,
+  seedTelegramInstallation$,
+  type TelegramFixture,
+} from "./helpers/zero-telegram";
+import { createFixtureTracker } from "./helpers/zero-route-test";
+
+const context = testContext();
+const store = createStore();
+const FIXED_NOW_MS = Date.UTC(2026, 4, 14, 12, 0, 0);
+
+function apiClient() {
+  return setupApp({ context })(cronTelegramCleanupContract);
+}
+
+function cronHeaders(secret = "test-cron-secret") {
+  return { authorization: `Bearer ${secret}` };
+}
+
+function newId(prefix: string): string {
+  return `${prefix}-${randomUUID()}`;
+}
+
+async function cleanupFixture(fixture: TelegramFixture): Promise<void> {
+  await store.set(deleteTelegramFixture$, fixture, context.signal);
+}
+
+async function seedInstallation(): Promise<TelegramFixture> {
+  const orgId = newId("org");
+  const userId = newId("user");
+  const telegramBotId = newId("telegram-bot");
+  const builder = makeTelegramFixtureBuilder(orgId);
+  const installation = await store.set(
+    seedTelegramInstallation$,
+    {
+      orgId,
+      ownerUserId: userId,
+      telegramBotId,
+    },
+    context.signal,
+  );
+
+  builder.composeIds.push(installation.composeId);
+  builder.telegramBotIds.push(installation.telegramBotId);
+  builder.userIds.push(userId);
+
+  return freezeTelegramFixture(builder);
+}
+
+async function insertMessages(args: {
+  readonly installationId: string;
+  readonly messages: number;
+  readonly createdAt: Date;
+}): Promise<void> {
+  const db = store.set(writeDb$);
+  await db.insert(telegramMessages).values(
+    Array.from({ length: args.messages }, () => {
+      return {
+        installationId: args.installationId,
+        chatId: newId("chat"),
+        messageId: newId("message"),
+        fromUserId: newId("from-user"),
+        text: "test message",
+        createdAt: args.createdAt,
+      };
+    }),
+  );
+}
+
+async function countMessages(installationId: string): Promise<number> {
+  const db = store.set(writeDb$);
+  const [row] = await db
+    .select({ value: count() })
+    .from(telegramMessages)
+    .where(eq(telegramMessages.installationId, installationId));
+  return row?.value ?? 0;
+}
+
+describe("GET /api/cron/telegram-cleanup", () => {
+  const track = createFixtureTracker<TelegramFixture>(cleanupFixture);
+
+  beforeEach(() => {
+    mockEnv("CRON_SECRET", "test-cron-secret");
+    mockNow(FIXED_NOW_MS);
+  });
+
+  afterEach(() => {
+    clearMockNow();
+  });
+
+  it("rejects requests with an invalid cron secret", async () => {
+    const response = await accept(
+      apiClient().cleanup({ headers: cronHeaders("wrong-secret") }),
+      [401],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Invalid cron secret", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("preserves recent messages and returns a deleted count", async () => {
+    const fixture = await track(seedInstallation());
+    const installationId = fixture.telegramBotIds[0] ?? "";
+    await insertMessages({
+      installationId,
+      messages: 2,
+      createdAt: nowDate(),
+    });
+
+    const response = await accept(
+      apiClient().cleanup({ headers: cronHeaders() }),
+      [200],
+    );
+
+    expect(typeof response.body.deleted).toBe("number");
+    await expect(countMessages(installationId)).resolves.toBe(2);
+  });
+
+  it("deletes messages older than 30 days", async () => {
+    const fixture = await track(seedInstallation());
+    const installationId = fixture.telegramBotIds[0] ?? "";
+    const oldDate = nowDate();
+    oldDate.setDate(oldDate.getDate() - 31);
+    const recentDate = nowDate();
+
+    await insertMessages({ installationId, messages: 3, createdAt: oldDate });
+    await insertMessages({
+      installationId,
+      messages: 2,
+      createdAt: recentDate,
+    });
+
+    await expect(countMessages(installationId)).resolves.toBe(5);
+
+    const response = await accept(
+      apiClient().cleanup({ headers: cronHeaders() }),
+      [200],
+    );
+
+    expect(response.body.deleted).toBeGreaterThanOrEqual(3);
+    await expect(countMessages(installationId)).resolves.toBe(2);
+  });
+
+  it("does not delete messages within the retention window", async () => {
+    const fixture = await track(seedInstallation());
+    const installationId = fixture.telegramBotIds[0] ?? "";
+    const recentDate = nowDate();
+    recentDate.setDate(recentDate.getDate() - 29);
+
+    await insertMessages({
+      installationId,
+      messages: 5,
+      createdAt: recentDate,
+    });
+
+    const response = await accept(
+      apiClient().cleanup({ headers: cronHeaders() }),
+      [200],
+    );
+
+    expect(typeof response.body.deleted).toBe("number");
+    await expect(countMessages(installationId)).resolves.toBe(5);
+  });
+});

--- a/turbo/apps/api/src/signals/routes/cron-telegram-cleanup.ts
+++ b/turbo/apps/api/src/signals/routes/cron-telegram-cleanup.ts
@@ -1,0 +1,28 @@
+import { cronTelegramCleanupContract } from "@vm0/api-contracts/contracts/cron";
+import { command } from "ccstate";
+
+import type { RouteEntry } from "../route";
+import { cleanupTelegramMessages$ } from "../services/cron-telegram-cleanup.service";
+import { cronUnauthorized, hasValidCronSecret } from "./cron-auth";
+
+const telegramCleanupRoute$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    if (!hasValidCronSecret(get)) {
+      return cronUnauthorized();
+    }
+
+    const deleted = await set(cleanupTelegramMessages$, signal);
+    signal.throwIfAborted();
+    return {
+      status: 200 as const,
+      body: { deleted },
+    };
+  },
+);
+
+export const cronTelegramCleanupRoutes: readonly RouteEntry[] = [
+  {
+    route: cronTelegramCleanupContract.cleanup,
+    handler: telegramCleanupRoute$,
+  },
+];

--- a/turbo/apps/api/src/signals/services/cron-telegram-cleanup.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-telegram-cleanup.service.ts
@@ -1,0 +1,36 @@
+import { command } from "ccstate";
+import { sql } from "drizzle-orm";
+
+import { nowDate } from "../../lib/time";
+import { writeDb$ } from "../external/db";
+
+const TELEGRAM_MESSAGE_RETENTION_DAYS = 30;
+const TELEGRAM_MESSAGE_DELETE_BATCH_SIZE = 10_000;
+
+export const cleanupTelegramMessages$ = command(
+  async ({ set }, signal: AbortSignal): Promise<number> => {
+    const db = set(writeDb$);
+    const cutoffDate = nowDate();
+    cutoffDate.setDate(cutoffDate.getDate() - TELEGRAM_MESSAGE_RETENTION_DAYS);
+
+    let totalDeleted = 0;
+    let batchDeleted: number;
+
+    do {
+      const result = await db.execute(sql`
+        DELETE FROM telegram_messages
+        WHERE ctid IN (
+          SELECT ctid FROM telegram_messages
+          WHERE created_at < ${cutoffDate}
+          LIMIT ${TELEGRAM_MESSAGE_DELETE_BATCH_SIZE}
+        )
+      `);
+      signal.throwIfAborted();
+
+      batchDeleted = Number(result.rowCount ?? 0);
+      totalDeleted += batchDeleted;
+    } while (batchDeleted === TELEGRAM_MESSAGE_DELETE_BATCH_SIZE);
+
+    return totalDeleted;
+  },
+);

--- a/turbo/packages/api-contracts/src/contracts/cron.ts
+++ b/turbo/packages/api-contracts/src/contracts/cron.ts
@@ -62,6 +62,10 @@ const cronReconcileBillingEntitlementsResponseSchema = z.object({
   downgraded: z.number(),
 });
 
+const cronTelegramCleanupResponseSchema = z.object({
+  deleted: z.number(),
+});
+
 const cronAggregateInsightsSkippedResponseSchema = z.object({
   users: z.number(),
   skipped: z.literal(true),
@@ -117,6 +121,19 @@ export const cronReconcileBillingEntitlementsContract = c.router({
   },
 });
 
+export const cronTelegramCleanupContract = c.router({
+  cleanup: {
+    method: "GET",
+    path: "/api/cron/telegram-cleanup",
+    headers: authHeadersSchema,
+    responses: {
+      200: cronTelegramCleanupResponseSchema,
+      401: apiErrorSchema,
+    },
+    summary: "Delete expired Telegram messages",
+  },
+});
+
 export const cronAggregateInsightsContract = c.router({
   aggregate: {
     method: "GET",
@@ -137,6 +154,7 @@ export type CronReconcileBillingEntitlementsContract =
   typeof cronReconcileBillingEntitlementsContract;
 export type CronAggregateInsightsContract =
   typeof cronAggregateInsightsContract;
+export type CronTelegramCleanupContract = typeof cronTelegramCleanupContract;
 
 // Export schemas for reuse
 export {
@@ -145,5 +163,6 @@ export {
   cronAggregateUsageResponseSchema,
   cronProcessUsageEventsResponseSchema,
   cronReconcileBillingEntitlementsResponseSchema,
+  cronTelegramCleanupResponseSchema,
   cronAggregateInsightsResponseSchema,
 };

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -372,6 +372,8 @@ export {
   cronProcessUsageEventsResponseSchema,
   cronReconcileBillingEntitlementsContract,
   cronReconcileBillingEntitlementsResponseSchema,
+  cronTelegramCleanupContract,
+  cronTelegramCleanupResponseSchema,
   cleanupResultSchema,
   cleanupResponseSchema,
   type CronAggregateInsightsContract,
@@ -379,6 +381,7 @@ export {
   type CronCleanupSandboxesContract,
   type CronProcessUsageEventsContract,
   type CronReconcileBillingEntitlementsContract,
+  type CronTelegramCleanupContract,
 } from "./cron";
 export {
   orgDefaultAgentContract,


### PR DESCRIPTION
## Summary

- add the ts-rest contract for `GET /api/cron/telegram-cleanup`
- register the API cron route and port the 30-day Telegram message retention cleanup
- add API route integration coverage for cron auth, recent-message preservation, old-message deletion, and retention-window behavior

## Validation

- `pnpm -F api exec vitest src/signals/routes/__tests__/cron-telegram-cleanup.test.ts`
- `pnpm -F api lint`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F api check-types`
- `pnpm -F @vm0/api-contracts check-types`
- pre-commit: prettier, knip, full `turbo run check-types --concurrency=1`, commitlint

Closes #13247
Part of #12820