### PR TITLE
refactor(api): migrate voice chat cleanup cron route

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -24,6 +24,7 @@ import { cronAggregateUsageRoutes } from "./routes/cron-aggregate-usage";
 import { cronProcessUsageEventsRoutes } from "./routes/cron-process-usage-events";
 import { cronReconcileBillingEntitlementsRoutes } from "./routes/cron-reconcile-billing-entitlements";
 import { cronTelegramCleanupRoutes } from "./routes/cron-telegram-cleanup";
+import { cronVoiceChatCleanupRoutes } from "./routes/cron-voice-chat-cleanup";
 import { deviceTokenRoutes } from "./routes/device-token";
 import { emailUnsubscribeRoutes } from "./routes/email-unsubscribe";
 import { generateImageRoutes } from "./routes/generate-image";
@@ -213,6 +214,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...cronProcessUsageEventsRoutes,
   ...cronReconcileBillingEntitlementsRoutes,
   ...cronTelegramCleanupRoutes,
+  ...cronVoiceChatCleanupRoutes,
   ...deviceTokenRoutes,
   ...emailUnsubscribeRoutes,
   ...generateImageRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-voice-chat-cleanup.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-voice-chat-cleanup.test.ts
@@ -1,0 +1,214 @@
+import { cronVoiceChatCleanupContract } from "@vm0/api-contracts/contracts/cron";
+import { voiceChatSessions } from "@vm0/db/schema/voice-chat";
+import { createStore } from "ccstate";
+import { and, count, eq } from "drizzle-orm";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { mockEnv } from "../../../lib/env";
+import { clearMockNow, mockNow, nowDate } from "../../../lib/time";
+import { writeDb$ } from "../../external/db";
+import { clearAllDetached } from "../../utils";
+import {
+  deleteVoiceChatFixture$,
+  seedVoiceChatFixture$,
+  type VoiceChatFixture,
+} from "./helpers/zero-voice-chat";
+import { createFixtureTracker } from "./helpers/zero-route-test";
+
+const context = testContext();
+const store = createStore();
+const FIXED_NOW_MS = Date.UTC(2026, 4, 14, 12, 0, 0);
+
+type ReasoningStatus = "idle" | "running";
+
+function apiClient() {
+  return setupApp({ context })(cronVoiceChatCleanupContract);
+}
+
+function cronHeaders(secret = "test-cron-secret") {
+  return { authorization: `Bearer ${secret}` };
+}
+
+async function cleanupFixture(fixture: VoiceChatFixture): Promise<void> {
+  await store.set(deleteVoiceChatFixture$, fixture, context.signal);
+}
+
+function minutesAgo(minutes: number, extraMs = 0): Date {
+  const date = nowDate();
+  date.setTime(date.getTime() - minutes * 60 * 1000 - extraMs);
+  return date;
+}
+
+async function insertSession(args: {
+  readonly fixture: VoiceChatFixture;
+  readonly userId?: string;
+  readonly reasoningStatus: ReasoningStatus;
+  readonly lastSummaryAt: Date;
+}): Promise<string> {
+  const db = store.set(writeDb$);
+  const [row] = await db
+    .insert(voiceChatSessions)
+    .values({
+      orgId: args.fixture.orgId,
+      userId: args.userId ?? args.fixture.userId,
+      reasoningStatus: args.reasoningStatus,
+      lastSummaryAt: args.lastSummaryAt,
+    })
+    .returning({ id: voiceChatSessions.id });
+
+  if (!row) {
+    throw new Error("insertSession: insert returned no row");
+  }
+
+  return row.id;
+}
+
+async function findSession(sessionId: string): Promise<{
+  readonly reasoningStatus: string;
+  readonly lastSummaryAt: Date | null;
+  readonly lastReasoningDurationMs: number | null;
+} | null> {
+  const db = store.set(writeDb$);
+  const [row] = await db
+    .select({
+      reasoningStatus: voiceChatSessions.reasoningStatus,
+      lastSummaryAt: voiceChatSessions.lastSummaryAt,
+      lastReasoningDurationMs: voiceChatSessions.lastReasoningDurationMs,
+    })
+    .from(voiceChatSessions)
+    .where(eq(voiceChatSessions.id, sessionId))
+    .limit(1);
+  return row ?? null;
+}
+
+async function countSessionsByStatus(
+  fixture: VoiceChatFixture,
+  reasoningStatus: ReasoningStatus,
+): Promise<number> {
+  const db = store.set(writeDb$);
+  const [row] = await db
+    .select({ value: count() })
+    .from(voiceChatSessions)
+    .where(
+      and(
+        eq(voiceChatSessions.orgId, fixture.orgId),
+        eq(voiceChatSessions.reasoningStatus, reasoningStatus),
+      ),
+    );
+  return row?.value ?? 0;
+}
+
+describe("GET /api/cron/voice-chat-cleanup", () => {
+  const track = createFixtureTracker<VoiceChatFixture>(cleanupFixture);
+
+  beforeEach(() => {
+    mockEnv("CRON_SECRET", "test-cron-secret");
+    mockNow(FIXED_NOW_MS);
+  });
+
+  afterEach(() => {
+    clearMockNow();
+  });
+
+  it("rejects requests with an invalid cron secret", async () => {
+    const response = await accept(
+      apiClient().cleanup({ headers: cronHeaders("wrong-secret") }),
+      [401],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Invalid cron secret", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("rejects requests with no authorization header", async () => {
+    const response = await accept(apiClient().cleanup({ headers: {} }), [401]);
+
+    expect(response.body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("resets a stuck reasoner and queues a reasoning re-tick", async () => {
+    const fixture = await track(
+      store.set(seedVoiceChatFixture$, {}, context.signal),
+    );
+    const sessionId = await insertSession({
+      fixture,
+      reasoningStatus: "running",
+      lastSummaryAt: minutesAgo(5, 1),
+    });
+
+    const response = await accept(
+      apiClient().cleanup({ headers: cronHeaders() }),
+      [200],
+    );
+
+    expect(response.body.success).toBeTruthy();
+    expect(response.body.reasonerReset).toBeGreaterThanOrEqual(1);
+    await clearAllDetached();
+    await expect(findSession(sessionId)).resolves.toMatchObject({
+      reasoningStatus: "idle",
+      lastReasoningDurationMs: expect.any(Number),
+    });
+  });
+
+  it("does not touch a non-stuck reasoner", async () => {
+    const fixture = await track(
+      store.set(seedVoiceChatFixture$, {}, context.signal),
+    );
+    const freshReasoningAt = minutesAgo(2);
+    const sessionId = await insertSession({
+      fixture,
+      reasoningStatus: "running",
+      lastSummaryAt: freshReasoningAt,
+    });
+
+    const response = await accept(
+      apiClient().cleanup({ headers: cronHeaders() }),
+      [200],
+    );
+
+    expect(response.body.reasonerReset).toBe(0);
+    await expect(findSession(sessionId)).resolves.toStrictEqual({
+      reasoningStatus: "running",
+      lastSummaryAt: freshReasoningAt,
+      lastReasoningDurationMs: null,
+    });
+  });
+
+  it("caps stuck reasoner recovery at 50 sessions per tick", async () => {
+    const fixture = await track(
+      store.set(seedVoiceChatFixture$, {}, context.signal),
+    );
+    const staleReasoningAt = minutesAgo(5, 1);
+
+    for (let index = 0; index < 60; index++) {
+      await insertSession({
+        fixture,
+        userId: `user_${index.toString()}`,
+        reasoningStatus: "running",
+        lastSummaryAt: staleReasoningAt,
+      });
+    }
+
+    const first = await accept(
+      apiClient().cleanup({ headers: cronHeaders() }),
+      [200],
+    );
+
+    expect(first.body.reasonerReset).toBe(50);
+    await clearAllDetached();
+    await expect(countSessionsByStatus(fixture, "running")).resolves.toBe(10);
+    await expect(countSessionsByStatus(fixture, "idle")).resolves.toBe(50);
+
+    const second = await accept(
+      apiClient().cleanup({ headers: cronHeaders() }),
+      [200],
+    );
+
+    expect(second.body.reasonerReset).toBeGreaterThanOrEqual(10);
+    await clearAllDetached();
+    await expect(countSessionsByStatus(fixture, "running")).resolves.toBe(0);
+    await expect(countSessionsByStatus(fixture, "idle")).resolves.toBe(60);
+  });
+});

--- a/turbo/apps/api/src/signals/routes/cron-voice-chat-cleanup.ts
+++ b/turbo/apps/api/src/signals/routes/cron-voice-chat-cleanup.ts
@@ -1,0 +1,41 @@
+import { cronVoiceChatCleanupContract } from "@vm0/api-contracts/contracts/cron";
+import { command } from "ccstate";
+
+import { waitUntil } from "../context/wait-until";
+import type { RouteEntry } from "../route";
+import { resetStuckVoiceChatReasoners$ } from "../services/cron-voice-chat-cleanup.service";
+import { triggerVoiceChatReasoning$ } from "../services/zero-voice-chat.service";
+import { cronUnauthorized, hasValidCronSecret } from "./cron-auth";
+
+const voiceChatCleanupRoute$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    if (!hasValidCronSecret(get)) {
+      return cronUnauthorized();
+    }
+
+    const recoveredReasonerIds = await set(
+      resetStuckVoiceChatReasoners$,
+      signal,
+    );
+    signal.throwIfAborted();
+
+    for (const sessionId of recoveredReasonerIds) {
+      waitUntil(set(triggerVoiceChatReasoning$, sessionId, signal));
+    }
+
+    return {
+      status: 200 as const,
+      body: {
+        success: true as const,
+        reasonerReset: recoveredReasonerIds.length,
+      },
+    };
+  },
+);
+
+export const cronVoiceChatCleanupRoutes: readonly RouteEntry[] = [
+  {
+    route: cronVoiceChatCleanupContract.cleanup,
+    handler: voiceChatCleanupRoute$,
+  },
+];

--- a/turbo/apps/api/src/signals/services/cron-voice-chat-cleanup.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-voice-chat-cleanup.service.ts
@@ -1,0 +1,51 @@
+import { voiceChatSessions } from "@vm0/db/schema/voice-chat";
+import { command } from "ccstate";
+import { and, desc, eq, inArray, lt } from "drizzle-orm";
+
+import { nowDate } from "../../lib/time";
+import { writeDb$ } from "../external/db";
+
+const REASONER_STUCK_MS = 5 * 60 * 1000;
+const BATCH_LIMIT = 50;
+
+export const resetStuckVoiceChatReasoners$ = command(
+  async ({ set }, signal: AbortSignal): Promise<readonly string[]> => {
+    const db = set(writeDb$);
+    const reasonerStuckThreshold = nowDate();
+    reasonerStuckThreshold.setTime(
+      reasonerStuckThreshold.getTime() - REASONER_STUCK_MS,
+    );
+
+    const stuckReasonerIds = db
+      .select({ id: voiceChatSessions.id })
+      .from(voiceChatSessions)
+      .where(
+        and(
+          eq(voiceChatSessions.reasoningStatus, "running"),
+          lt(voiceChatSessions.lastSummaryAt, reasonerStuckThreshold),
+        ),
+      )
+      .orderBy(
+        desc(voiceChatSessions.lastSummaryAt),
+        desc(voiceChatSessions.createdAt),
+      )
+      .limit(BATCH_LIMIT);
+
+    const recoveredReasoners = await db
+      .update(voiceChatSessions)
+      .set({ reasoningStatus: "idle" })
+      .where(
+        and(
+          eq(voiceChatSessions.reasoningStatus, "running"),
+          lt(voiceChatSessions.lastSummaryAt, reasonerStuckThreshold),
+          inArray(voiceChatSessions.id, stuckReasonerIds),
+        ),
+      )
+      .returning({ id: voiceChatSessions.id });
+    signal.throwIfAborted();
+
+    return recoveredReasoners.map((row) => {
+      return row.id;
+    });
+  },
+);

--- a/turbo/packages/api-contracts/src/contracts/cron.ts
+++ b/turbo/packages/api-contracts/src/contracts/cron.ts
@@ -66,6 +66,11 @@ const cronTelegramCleanupResponseSchema = z.object({
   deleted: z.number(),
 });
 
+const cronVoiceChatCleanupResponseSchema = z.object({
+  success: z.literal(true),
+  reasonerReset: z.number(),
+});
+
 const cronAggregateInsightsSkippedResponseSchema = z.object({
   users: z.number(),
   skipped: z.literal(true),
@@ -134,6 +139,19 @@ export const cronTelegramCleanupContract = c.router({
   },
 });
 
+export const cronVoiceChatCleanupContract = c.router({
+  cleanup: {
+    method: "GET",
+    path: "/api/cron/voice-chat-cleanup",
+    headers: authHeadersSchema,
+    responses: {
+      200: cronVoiceChatCleanupResponseSchema,
+      401: apiErrorSchema,
+    },
+    summary: "Reset stuck voice-chat reasoners",
+  },
+});
+
 export const cronAggregateInsightsContract = c.router({
   aggregate: {
     method: "GET",
@@ -155,6 +173,7 @@ export type CronReconcileBillingEntitlementsContract =
 export type CronAggregateInsightsContract =
   typeof cronAggregateInsightsContract;
 export type CronTelegramCleanupContract = typeof cronTelegramCleanupContract;
+export type CronVoiceChatCleanupContract = typeof cronVoiceChatCleanupContract;
 
 // Export schemas for reuse
 export {
@@ -164,5 +183,6 @@ export {
   cronProcessUsageEventsResponseSchema,
   cronReconcileBillingEntitlementsResponseSchema,
   cronTelegramCleanupResponseSchema,
+  cronVoiceChatCleanupResponseSchema,
   cronAggregateInsightsResponseSchema,
 };

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -374,6 +374,8 @@ export {
   cronReconcileBillingEntitlementsResponseSchema,
   cronTelegramCleanupContract,
   cronTelegramCleanupResponseSchema,
+  cronVoiceChatCleanupContract,
+  cronVoiceChatCleanupResponseSchema,
   cleanupResultSchema,
   cleanupResponseSchema,
   type CronAggregateInsightsContract,
@@ -382,6 +384,7 @@ export {
   type CronProcessUsageEventsContract,
   type CronReconcileBillingEntitlementsContract,
   type CronTelegramCleanupContract,
+  type CronVoiceChatCleanupContract,
 } from "./cron";
 export {
   orgDefaultAgentContract,


### PR DESCRIPTION
## Summary

- add the ts-rest contract for `GET /api/cron/voice-chat-cleanup`
- register the API cron route and port stuck voice-chat reasoner reset behavior
- use API `waitUntil` plus `triggerVoiceChatReasoning$` to replace the web route's deferred `after()` re-tick
- add API route integration coverage for cron auth, stuck reset/re-tick, non-stuck preservation, and the 50-session batch cap

## Validation

- `pnpm -F api exec vitest src/signals/routes/__tests__/cron-voice-chat-cleanup.test.ts`
- `pnpm -F api lint`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F api check-types`
- `pnpm -F @vm0/api-contracts check-types`
- pre-commit: prettier, knip, full `turbo run check-types --concurrency=1`, commitlint

Closes #13248
Part of #12820
