### PR TITLE
fix: improve model provider icons in dark mode

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-thread-page-model-picker-editable.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-thread-page-model-picker-editable.test.tsx
@@ -168,9 +168,12 @@ describe("chat thread page — model picker editable", () => {
 
     detachedSetupPage({ context, path: `/chats/${THREAD_ID}` });
 
-    await waitFor(() => {
+    const trigger = await waitFor(() => {
       return screen.getByRole("combobox", { name: /GLM-5\.1/i });
     });
+    const icon = trigger.querySelector("img");
+    expect(icon?.getAttribute("src")).toContain("chatglm.svg");
+    expect(icon).toHaveClass("zero-icon-mono");
   });
 
   // CHAT-MODEL-EDIT-004: empty thread keeps the picker interactive.

--- a/turbo/apps/platform/src/views/zero-page/__tests__/provider-icons.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/provider-icons.test.tsx
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { render } from "@testing-library/react";
+
+import { ProviderIcon } from "../components/settings/provider-icons.tsx";
+
+describe("provider icons", () => {
+  it("applies dark-mode inversion to monochrome OpenAI and Kimi provider marks", () => {
+    for (const type of [
+      "openai-api-key",
+      "codex-oauth-token",
+      "moonshot-api-key",
+    ] as const) {
+      const { container, unmount } = render(<ProviderIcon type={type} />);
+      expect(container.querySelector("img")).toHaveClass("zero-icon-mono");
+      unmount();
+    }
+  });
+
+  it("does not invert colorful provider marks", () => {
+    const { container } = render(<ProviderIcon type="anthropic-api-key" />);
+    expect(container.querySelector("img")).not.toHaveClass("zero-icon-mono");
+  });
+});

--- a/turbo/apps/platform/src/views/zero-page/__tests__/provider-icons.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/provider-icons.test.tsx
@@ -4,11 +4,12 @@ import { render } from "@testing-library/react";
 import { ProviderIcon } from "../components/settings/provider-icons.tsx";
 
 describe("provider icons", () => {
-  it("applies dark-mode inversion to monochrome OpenAI and Kimi provider marks", () => {
+  it("applies dark-mode inversion to low-contrast provider marks", () => {
     for (const type of [
       "openai-api-key",
       "codex-oauth-token",
       "moonshot-api-key",
+      "zai-api-key",
     ] as const) {
       const { container, unmount } = render(<ProviderIcon type={type} />);
       expect(container.querySelector("img")).toHaveClass("zero-icon-mono");

--- a/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
@@ -19,13 +19,17 @@ import {
 import {
   getCanonicalModelDisplayName,
   getProvidersForModel,
+  isSupportedRunModel,
   VM0_MODEL_TO_PROVIDER,
   type ModelProviderType,
   type OrgModelPolicy,
 } from "@vm0/api-contracts/contracts/model-providers";
 import { orgModelPolicies$ } from "../../../signals/external/org-model-policies";
 import { userModelPreference$ } from "../../../signals/external/user-model-preference";
-import { getVm0ModelMultiplier } from "./settings/provider-ui-config";
+import {
+  getModelBrandIconType,
+  getVm0ModelMultiplier,
+} from "./settings/provider-ui-config";
 import { ProviderIcon } from "./settings/provider-icons";
 
 const MODEL_FIRST_SELECTION_PROVIDER_ID =
@@ -143,6 +147,9 @@ function stripInteractiveClasses(cls: string | undefined): string | undefined {
 }
 
 function getModelFirstIconType(model: string): ModelProviderType | undefined {
+  if (isSupportedRunModel(model)) {
+    return getModelBrandIconType(model);
+  }
   const vm0Entry = VM0_MODEL_TO_PROVIDER[model];
   if (vm0Entry) {
     return vm0Entry.concreteType as ModelProviderType;

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-model-policies-section.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-model-policies-section.tsx
@@ -68,6 +68,7 @@ import {
 import { pageSignal$ } from "../../../../signals/page-signal.ts";
 import { detach, Reason } from "../../../../signals/utils.ts";
 import {
+  getModelBrandIconType as getModelIconType,
   getUILabel,
   getVm0ModelMultiplier,
 } from "../settings/provider-ui-config.ts";
@@ -79,27 +80,6 @@ function isOAuthMemberType(type: ModelProviderType): boolean {
 
 function isByokProviderType(type: ModelProviderType): boolean {
   return type !== "vm0" && !isOAuthMemberType(type);
-}
-
-const MODEL_BRAND_ICON: Readonly<Record<SupportedRunModel, ModelProviderType>> =
-  {
-    "claude-opus-4-7": "anthropic-api-key",
-    "claude-opus-4-6": "anthropic-api-key",
-    "claude-sonnet-4-6": "anthropic-api-key",
-    "claude-haiku-4-5": "anthropic-api-key",
-    "deepseek-v4-pro": "deepseek-api-key",
-    "deepseek-v4-flash": "deepseek-api-key",
-    "kimi-k2.6": "moonshot-api-key",
-    "kimi-k2.5": "moonshot-api-key",
-    "MiniMax-M2.7": "minimax-api-key",
-    "glm-5.1": "zai-api-key",
-    "gpt-5.5": "openai-api-key",
-    "gpt-5.4": "openai-api-key",
-    "gpt-5.4-mini": "openai-api-key",
-  };
-
-function getModelIconType(model: SupportedRunModel): ModelProviderType {
-  return MODEL_BRAND_ICON[model];
 }
 
 function getApiProviderTypes(model: SupportedRunModel): ModelProviderType[] {

--- a/turbo/apps/platform/src/views/zero-page/components/settings/provider-icons.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/provider-icons.tsx
@@ -37,6 +37,7 @@ const DARK_INVERT_PROVIDER_ICONS: Readonly<
   "openai-api-key": true,
   "codex-oauth-token": true,
   "moonshot-api-key": true,
+  "zai-api-key": true,
 });
 
 function providerIconNeedsDarkInvert(type: ModelProviderType): boolean {

--- a/turbo/apps/platform/src/views/zero-page/components/settings/provider-icons.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/provider-icons.tsx
@@ -1,4 +1,5 @@
 import type { ModelProviderType } from "@vm0/api-contracts/contracts/model-providers";
+import { cn } from "@vm0/ui";
 
 import anthropicIcon from "./icons/anthropic.svg";
 import azureIcon from "./icons/azure.svg";
@@ -30,6 +31,18 @@ const PROVIDER_ICONS: Readonly<Record<ModelProviderType, string>> =
     vm0: vm0Icon,
   });
 
+const DARK_INVERT_PROVIDER_ICONS: Readonly<
+  Partial<Record<ModelProviderType, true>>
+> = Object.freeze({
+  "openai-api-key": true,
+  "codex-oauth-token": true,
+  "moonshot-api-key": true,
+});
+
+function providerIconNeedsDarkInvert(type: ModelProviderType): boolean {
+  return DARK_INVERT_PROVIDER_ICONS[type] === true;
+}
+
 export function ProviderIcon({
   type,
   size = 28,
@@ -42,7 +55,16 @@ export function ProviderIcon({
     return <DefaultIcon size={size} />;
   }
   return (
-    <img src={icon} width={size} height={size} alt="" className="shrink-0" />
+    <img
+      src={icon}
+      width={size}
+      height={size}
+      alt=""
+      className={cn(
+        "shrink-0",
+        providerIconNeedsDarkInvert(type) && "zero-icon-mono",
+      )}
+    />
   );
 }
 

--- a/turbo/apps/platform/src/views/zero-page/components/settings/provider-ui-config.ts
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/provider-ui-config.ts
@@ -4,6 +4,7 @@ import {
   hasAuthMethods,
   type ModelProviderType,
   type SecretFieldConfig,
+  type SupportedRunModel,
 } from "@vm0/api-contracts/contracts/model-providers";
 
 /**
@@ -209,6 +210,29 @@ export function getUIAuthMethodLabel(
   return (
     getOverrides(type)?.authMethodLabelOverrides?.[authMethodKey] ?? coreLabel
   );
+}
+
+const MODEL_BRAND_ICON: Readonly<Record<SupportedRunModel, ModelProviderType>> =
+  Object.freeze({
+    "claude-opus-4-7": "anthropic-api-key",
+    "claude-opus-4-6": "anthropic-api-key",
+    "claude-sonnet-4-6": "anthropic-api-key",
+    "claude-haiku-4-5": "anthropic-api-key",
+    "deepseek-v4-pro": "deepseek-api-key",
+    "deepseek-v4-flash": "deepseek-api-key",
+    "kimi-k2.6": "moonshot-api-key",
+    "kimi-k2.5": "moonshot-api-key",
+    "MiniMax-M2.7": "minimax-api-key",
+    "glm-5.1": "zai-api-key",
+    "gpt-5.5": "openai-api-key",
+    "gpt-5.4": "openai-api-key",
+    "gpt-5.4-mini": "openai-api-key",
+  });
+
+export function getModelBrandIconType(
+  model: SupportedRunModel,
+): ModelProviderType {
+  return MODEL_BRAND_ICON[model];
 }
 
 /**


### PR DESCRIPTION
## Summary
- Apply the existing dark-mode monochrome icon inversion class to OpenAI, Codex OAuth, and Kimi model provider icons.
- Add provider icon tests covering monochrome inversion and colorful icon behavior.

## Tests
- corepack pnpm -F @vm0/app test src/views/zero-page/__tests__/provider-icons.test.tsx
- corepack pnpm -F @vm0/app lint
- corepack pnpm -F @vm0/app check-types