### PR TITLE
fix: suppress expected command exits

### DIFF
--- a/crates/sandbox-fc/src/control.rs
+++ b/crates/sandbox-fc/src/control.rs
@@ -427,6 +427,7 @@ async fn execute(
             label: "runner-exec",
             stdout_limit_bytes: RUNNER_EXEC_CAPTURE_LIMIT_BYTES,
             stderr_limit_bytes: RUNNER_EXEC_CAPTURE_LIMIT_BYTES,
+            expected_exit_codes: &[],
             wait_timeout: Duration::from_millis(timeout_ms as u64 + 5000),
         })
         .await

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -1352,6 +1352,7 @@ impl Sandbox for FirecrackerSandbox {
                     label: "sandbox-exec",
                     stdout_limit_bytes: limits.stdout_limit_bytes,
                     stderr_limit_bytes: limits.stderr_limit_bytes,
+                    expected_exit_codes: &[],
                     wait_timeout: Duration::from_millis(request.timeout_ms() as u64 + 5000),
                 }
             ) => {

--- a/crates/sandbox-fc/src/snapshot.rs
+++ b/crates/sandbox-fc/src/snapshot.rs
@@ -2007,6 +2007,7 @@ async fn run_with_firecracker(
             label: "snapshot-prewarm",
             stdout_limit_bytes: PREWARM_EXEC_CAPTURE_LIMIT_BYTES,
             stderr_limit_bytes: PREWARM_EXEC_CAPTURE_LIMIT_BYTES,
+            expected_exit_codes: &[],
             wait_timeout: Duration::from_millis(35_000),
         })
         .await

--- a/crates/vsock-guest/src/command.rs
+++ b/crates/vsock-guest/src/command.rs
@@ -131,6 +131,7 @@ pub(crate) struct CommandWorkerRequest {
     label: String,
     stdout: CommandOutputPolicy,
     stderr: CommandOutputPolicy,
+    expected_exit_codes: Vec<i32>,
 }
 
 impl CommandWorkerRequest {
@@ -148,6 +149,7 @@ impl CommandWorkerRequest {
             label: decoded.label.to_owned(),
             stdout: decoded.stdout,
             stderr: decoded.stderr,
+            expected_exit_codes: decoded.expected_exit_codes,
         }
     }
 }
@@ -814,8 +816,15 @@ fn duration_ms(started: Instant) -> u32 {
     u32::try_from(started.elapsed().as_millis()).unwrap_or(u32::MAX)
 }
 
-fn command_termination_is_notable(termination: CommandTermination) -> bool {
-    !matches!(termination, CommandTermination::Exited { exit_code: 0 })
+fn command_termination_is_notable(
+    termination: CommandTermination,
+    expected_exit_codes: &[i32],
+) -> bool {
+    !matches!(
+        termination,
+        CommandTermination::Exited { exit_code }
+            if exit_code == 0 || expected_exit_codes.contains(&exit_code)
+    )
 }
 
 fn log_command_terminal_if_notable(
@@ -828,7 +837,7 @@ fn log_command_terminal_if_notable(
 ) {
     let elapsed = started.elapsed();
     let slow = elapsed >= COMMAND_STAGE_SLOW_THRESHOLD;
-    let notable = command_termination_is_notable(termination)
+    let notable = command_termination_is_notable(termination, &request.expected_exit_codes)
         || stdout_result.capture_truncated
         || stderr_result.capture_truncated
         || !diagnostic.is_empty();
@@ -894,6 +903,7 @@ mod tests {
             label: "test".to_string(),
             stdout: CommandOutputPolicy::Capture { limit_bytes: 1024 },
             stderr: CommandOutputPolicy::Capture { limit_bytes: 1024 },
+            expected_exit_codes: Vec::new(),
         }
     }
 
@@ -911,12 +921,21 @@ mod tests {
     #[test]
     fn command_termination_notable_tracks_nonzero_exit() {
         assert!(!command_termination_is_notable(
-            CommandTermination::Exited { exit_code: 0 }
+            CommandTermination::Exited { exit_code: 0 },
+            &[]
         ));
-        assert!(command_termination_is_notable(CommandTermination::Exited {
-            exit_code: 1
-        }));
-        assert!(command_termination_is_notable(CommandTermination::TimedOut));
+        assert!(command_termination_is_notable(
+            CommandTermination::Exited { exit_code: 1 },
+            &[]
+        ));
+        assert!(!command_termination_is_notable(
+            CommandTermination::Exited { exit_code: 66 },
+            &[66]
+        ));
+        assert!(command_termination_is_notable(
+            CommandTermination::TimedOut,
+            &[124]
+        ));
     }
 
     #[test]

--- a/crates/vsock-guest/tests/connection.rs
+++ b/crates/vsock-guest/tests/connection.rs
@@ -431,6 +431,38 @@ fn command_capture_only_stdout_stderr_success() {
 }
 
 #[test]
+fn command_expected_nonzero_exit_still_returns_result() {
+    let (handle, mut host_stream) = start_guest_connection();
+
+    let payload = vsock_proto::encode_command_start_with_expected_exit_codes(
+        vsock_proto::CommandStartEncodeRequest {
+            timeout_ms: 5000,
+            command: "exit 66",
+            env: &[],
+            sudo: false,
+            label: "test",
+            stdout: CommandOutputPolicy::Capture { limit_bytes: 1024 },
+            stderr: CommandOutputPolicy::Capture { limit_bytes: 1024 },
+            expected_exit_codes: &[66],
+        },
+    );
+    let msg = vsock_proto::encode(MSG_COMMAND_START, 102, &payload.unwrap()).unwrap();
+    host_stream.write_all(&msg).unwrap();
+    let (chunks, result) = read_command_result(&mut host_stream, 102);
+
+    assert!(chunks.is_empty());
+    assert_eq!(
+        result.termination,
+        CommandTermination::Exited { exit_code: 66 }
+    );
+    assert_eq!(result.stdout, Some(Vec::new()));
+    assert_eq!(result.stderr, Some(Vec::new()));
+    assert!(result.diagnostic.is_empty());
+
+    finish_guest_connection(handle, host_stream);
+}
+
+#[test]
 fn command_large_env_payload_succeeds() {
     let values = large_env_values();
     let env = large_env_entries(&values);

--- a/crates/vsock-host/src/command.rs
+++ b/crates/vsock-host/src/command.rs
@@ -68,6 +68,7 @@ pub struct CommandOperationRequest<'a> {
     pub label: &'a str,
     pub stdout: CommandOutputPolicy,
     pub stderr: CommandOutputPolicy,
+    pub expected_exit_codes: &'a [i32],
     /// Optional bounded host-side output event queue override.
     ///
     /// `None` uses the default queue capacity when either output policy
@@ -86,6 +87,7 @@ pub struct CommandCaptureRequest<'a> {
     pub label: &'a str,
     pub stdout_limit_bytes: u32,
     pub stderr_limit_bytes: u32,
+    pub expected_exit_codes: &'a [i32],
     pub wait_timeout: Duration,
 }
 
@@ -98,6 +100,7 @@ pub struct CommandStreamRequest<'a> {
     pub label: &'a str,
     pub stdout: CommandOutputPolicy,
     pub stderr: CommandOutputPolicy,
+    pub expected_exit_codes: &'a [i32],
     /// Optional host-side output event queue capacity override.
     ///
     /// `None` uses the default queue capacity. Zero and oversized capacities
@@ -178,6 +181,7 @@ struct CommandOperation {
 struct CommandOperationDiagnostic {
     seq: u32,
     label_log: String,
+    expected_exit_codes: Vec<i32>,
     registered_at: Instant,
     first_output_at: Option<Instant>,
 }
@@ -259,10 +263,11 @@ impl Drop for CommandFrameWriteGuard {
 }
 
 impl CommandOperationDiagnostic {
-    fn new(seq: u32, label: &str) -> Self {
+    fn new(seq: u32, label: &str, expected_exit_codes: &[i32]) -> Self {
         Self {
             seq,
             label_log: command_label_log(label),
+            expected_exit_codes: expected_exit_codes.to_vec(),
             registered_at: Instant::now(),
             first_output_at: None,
         }
@@ -313,7 +318,7 @@ impl CommandOperationDiagnostic {
     ) {
         let elapsed_ms = self.elapsed_ms();
         let slow = elapsed_ms >= COMMAND_STAGE_SLOW_THRESHOLD.as_millis();
-        let notable = command_termination_is_notable(result.termination)
+        let notable = command_termination_is_notable(result.termination, &self.expected_exit_codes)
             || command_result_has_truncation(result)
             || stream_overflowed
             || !result.diagnostic.is_empty();
@@ -575,8 +580,15 @@ fn command_protocol_error(error: impl ToString) -> io::Error {
     io::Error::new(io::ErrorKind::InvalidData, error.to_string())
 }
 
-fn command_termination_is_notable(termination: CommandTermination) -> bool {
-    !matches!(termination, CommandTermination::Exited { exit_code: 0 })
+fn command_termination_is_notable(
+    termination: CommandTermination,
+    expected_exit_codes: &[i32],
+) -> bool {
+    !matches!(
+        termination,
+        CommandTermination::Exited { exit_code }
+            if exit_code == 0 || expected_exit_codes.contains(&exit_code)
+    )
 }
 
 fn command_label_log(label: &str) -> String {
@@ -1070,14 +1082,17 @@ pub(crate) async fn start_command_operation_on_shared(
         None
     };
 
-    let payload = vsock_proto::encode_command_start(
-        request.timeout_ms,
-        request.command,
-        request.env,
-        request.sudo,
-        request.label,
-        request.stdout,
-        request.stderr,
+    let payload = vsock_proto::encode_command_start_with_expected_exit_codes(
+        vsock_proto::CommandStartEncodeRequest {
+            timeout_ms: request.timeout_ms,
+            command: request.command,
+            env: request.env,
+            sudo: request.sudo,
+            label: request.label,
+            stdout: request.stdout,
+            stderr: request.stderr,
+            expected_exit_codes: request.expected_exit_codes,
+        },
     )
     .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e.to_string()))?;
 
@@ -1090,7 +1105,8 @@ pub(crate) async fn start_command_operation_on_shared(
     };
     let (result_tx, result_rx) = oneshot::channel();
     let seq = shared.next_seq();
-    let diagnostic = CommandOperationDiagnostic::new(seq, request.label);
+    let diagnostic =
+        CommandOperationDiagnostic::new(seq, request.label, request.expected_exit_codes);
     let operation = CommandOperation {
         diagnostic: diagnostic.clone(),
         result_tx,
@@ -1156,6 +1172,7 @@ pub(crate) async fn command_capture_on_shared(
             stderr: CommandOutputPolicy::Capture {
                 limit_bytes: request.stderr_limit_bytes,
             },
+            expected_exit_codes: request.expected_exit_codes,
             stream_queue_capacity: None,
         },
     )
@@ -1184,6 +1201,7 @@ pub(crate) async fn command_stream_on_shared(
             label: request.label,
             stdout: request.stdout,
             stderr: request.stderr,
+            expected_exit_codes: request.expected_exit_codes,
             stream_queue_capacity: request.stream_queue_capacity,
         },
     )
@@ -1208,6 +1226,7 @@ pub(crate) async fn exec_on_shared(
             label: "exec",
             stdout_limit_bytes: DEFAULT_COMMAND_CAPTURE_LIMIT_BYTES,
             stderr_limit_bytes: DEFAULT_COMMAND_CAPTURE_LIMIT_BYTES,
+            expected_exit_codes: &[],
             wait_timeout: request_timeout,
         },
     )
@@ -1231,6 +1250,7 @@ pub(crate) async fn exec_cleanup_on_shared(
             label: "exec-cleanup",
             stdout_limit_bytes: SMALL_COMMAND_CAPTURE_LIMIT_BYTES,
             stderr_limit_bytes: SMALL_COMMAND_CAPTURE_LIMIT_BYTES,
+            expected_exit_codes: &[],
             wait_timeout: Duration::from_millis(timeout_ms as u64),
         },
     )
@@ -1270,7 +1290,7 @@ mod tests {
     fn command_operation_for_snapshot(seq: u32, label: &str) -> CommandOperation {
         let (result_tx, _result_rx) = oneshot::channel();
         CommandOperation {
-            diagnostic: CommandOperationDiagnostic::new(seq, label),
+            diagnostic: CommandOperationDiagnostic::new(seq, label, &[]),
             result_tx,
             stream_tx: None,
             stdout_capture: CommandCaptureState::Discard,
@@ -1285,12 +1305,21 @@ mod tests {
     #[test]
     fn command_termination_notable_tracks_nonzero_exit() {
         assert!(!command_termination_is_notable(
-            CommandTermination::Exited { exit_code: 0 }
+            CommandTermination::Exited { exit_code: 0 },
+            &[]
         ));
-        assert!(command_termination_is_notable(CommandTermination::Exited {
-            exit_code: 1
-        }));
-        assert!(command_termination_is_notable(CommandTermination::TimedOut));
+        assert!(command_termination_is_notable(
+            CommandTermination::Exited { exit_code: 1 },
+            &[]
+        ));
+        assert!(!command_termination_is_notable(
+            CommandTermination::Exited { exit_code: 66 },
+            &[66]
+        ));
+        assert!(command_termination_is_notable(
+            CommandTermination::TimedOut,
+            &[124]
+        ));
     }
 
     #[test]
@@ -1332,7 +1361,7 @@ mod tests {
             "{}secret-tail",
             "a".repeat(COMMAND_LABEL_LOG_PREFIX_MAX_BYTES)
         );
-        let mut diagnostic = CommandOperationDiagnostic::new(7, &label);
+        let mut diagnostic = CommandOperationDiagnostic::new(7, &label, &[]);
         diagnostic.registered_at =
             Instant::now() - COMMAND_STAGE_SLOW_THRESHOLD - Duration::from_millis(1);
 
@@ -1354,6 +1383,7 @@ mod tests {
         let mut diagnostic = CommandOperationDiagnostic {
             seq: 9,
             label_log: "slow-first-output".to_string(),
+            expected_exit_codes: Vec::new(),
             registered_at: Instant::now() - COMMAND_STAGE_SLOW_THRESHOLD - Duration::from_millis(1),
             first_output_at: None,
         };

--- a/crates/vsock-host/src/file.rs
+++ b/crates/vsock-host/src/file.rs
@@ -325,6 +325,7 @@ impl VsockHost {
                 label: "read-file",
                 stdout_limit_bytes,
                 stderr_limit_bytes: command::SMALL_COMMAND_CAPTURE_LIMIT_BYTES,
+                expected_exit_codes: &[MISSING_FILE_EXIT_CODE],
                 wait_timeout: Duration::from_millis(timeout_ms as u64 + 5000),
             })
             .await?;
@@ -438,6 +439,11 @@ impl VsockHost {
             "if test -f {path}; then cat -- {path}; else exit {MISSING_FILE_EXIT_CODE}; fi",
             path = shell_quote(path)
         );
+        let expected_exit_codes: &[i32] = if missing_ok {
+            &[MISSING_FILE_EXIT_CODE]
+        } else {
+            &[]
+        };
         let mut handle = self
             .command_stream(CommandStreamRequest {
                 timeout_ms,
@@ -452,6 +458,7 @@ impl VsockHost {
                 stderr: CommandOutputPolicy::Capture {
                     limit_bytes: command::SMALL_COMMAND_CAPTURE_LIMIT_BYTES,
                 },
+                expected_exit_codes,
                 stream_queue_capacity: Some(COPY_FILE_STREAM_QUEUE_CAPACITY),
             })
             .await?;
@@ -560,6 +567,7 @@ impl VsockHost {
                 label: "write-file-rename",
                 stdout_limit_bytes: command::SMALL_COMMAND_CAPTURE_LIMIT_BYTES,
                 stderr_limit_bytes: command::SMALL_COMMAND_CAPTURE_LIMIT_BYTES,
+                expected_exit_codes: &[],
                 wait_timeout: Duration::from_millis(HELPER_EXEC_TIMEOUT_MS as u64 + 5000),
             })
             .await

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -589,6 +589,7 @@ impl VsockHost {
             label,
             stdout_limit_bytes: command::DEFAULT_COMMAND_CAPTURE_LIMIT_BYTES,
             stderr_limit_bytes: command::DEFAULT_COMMAND_CAPTURE_LIMIT_BYTES,
+            expected_exit_codes: &[],
             wait_timeout,
         })
         .await

--- a/crates/vsock-host/src/tests/command.rs
+++ b/crates/vsock-host/src/tests/command.rs
@@ -28,6 +28,7 @@ async fn start_capture_operation(host: &crate::VsockHost, command: &str) -> Comm
         label: "test-command",
         stdout: CommandOutputPolicy::Capture { limit_bytes: 1024 },
         stderr: CommandOutputPolicy::Capture { limit_bytes: 1024 },
+        expected_exit_codes: &[],
         stream_queue_capacity: None,
     })
     .await
@@ -49,6 +50,7 @@ async fn command_capture_sends_start_and_receives_result() {
                 label: "capture-test",
                 stdout_limit_bytes: 7,
                 stderr_limit_bytes: 9,
+                expected_exit_codes: &[],
                 wait_timeout: Duration::from_secs(5),
             })
             .await
@@ -71,6 +73,7 @@ async fn command_capture_sends_start_and_receives_result() {
         decoded.stderr,
         CommandOutputPolicy::Capture { limit_bytes: 9 }
     );
+    assert!(decoded.expected_exit_codes.is_empty());
 
     send_command_result(
         &mut guest,
@@ -104,6 +107,44 @@ async fn command_capture_sends_start_and_receives_result() {
 }
 
 #[tokio::test]
+async fn command_start_sends_expected_exit_codes() {
+    let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+
+    let handle = host
+        .start_command_operation(CommandOperationRequest {
+            timeout_ms: 5000,
+            command: "optional",
+            env: &[],
+            sudo: false,
+            label: "expected-exit",
+            stdout: CommandOutputPolicy::Capture { limit_bytes: 16 },
+            stderr: CommandOutputPolicy::Capture { limit_bytes: 16 },
+            expected_exit_codes: &[66],
+            stream_queue_capacity: None,
+        })
+        .await
+        .unwrap();
+
+    let msg = read_guest_message(&mut guest, &mut decoder).await;
+    let decoded = vsock_proto::decode_command_start(&msg.payload).unwrap();
+    assert_eq!(decoded.expected_exit_codes, vec![66]);
+
+    send_command_result(
+        &mut guest,
+        msg.seq,
+        CommandTermination::Exited { exit_code: 66 },
+        b"",
+        b"",
+    )
+    .await;
+    let result = handle.wait(Duration::from_secs(5)).await.unwrap();
+    assert_eq!(
+        result.termination,
+        CommandTermination::Exited { exit_code: 66 }
+    );
+}
+
+#[tokio::test]
 async fn command_capture_repeated_short_operations_soak() {
     let (host, mut guest, mut decoder) = setup_host_and_guest().await;
     let host = Arc::new(host);
@@ -119,6 +160,7 @@ async fn command_capture_repeated_short_operations_soak() {
                 label: &label,
                 stdout: CommandOutputPolicy::Capture { limit_bytes: 16 },
                 stderr: CommandOutputPolicy::Capture { limit_bytes: 16 },
+                expected_exit_codes: &[],
                 stream_queue_capacity: None,
             })
             .await
@@ -169,6 +211,7 @@ async fn command_capture_large_stdout_stderr_within_limits_soak() {
             stderr: CommandOutputPolicy::Capture {
                 limit_bytes: stderr.len() as u32,
             },
+            expected_exit_codes: &[],
             stream_queue_capacity: None,
         })
         .await
@@ -216,6 +259,7 @@ async fn command_result_preserves_non_default_metadata() {
             label: "metadata",
             stdout: CommandOutputPolicy::Discard,
             stderr: CommandOutputPolicy::Capture { limit_bytes: 1024 },
+            expected_exit_codes: &[],
             stream_queue_capacity: None,
         })
         .await
@@ -263,6 +307,7 @@ async fn command_result_capture_for_discard_policy_poisons_connection() {
             label: "discard-result",
             stdout: CommandOutputPolicy::Discard,
             stderr: CommandOutputPolicy::Discard,
+            expected_exit_codes: &[],
             stream_queue_capacity: None,
         })
         .await
@@ -301,6 +346,7 @@ async fn command_result_over_capture_limit_poisons_connection() {
             label: "capture-limit",
             stdout: CommandOutputPolicy::Capture { limit_bytes: 4 },
             stderr: CommandOutputPolicy::Discard,
+            expected_exit_codes: &[],
             stream_queue_capacity: None,
         })
         .await
@@ -339,6 +385,7 @@ async fn command_result_discard_for_capture_policy_poisons_connection() {
             label: "missing-capture",
             stdout: CommandOutputPolicy::Capture { limit_bytes: 4 },
             stderr: CommandOutputPolicy::Discard,
+            expected_exit_codes: &[],
             stream_queue_capacity: None,
         })
         .await
@@ -374,6 +421,7 @@ async fn command_result_zero_capture_limit_accepts_empty_capture() {
             label: "zero-capture",
             stdout: CommandOutputPolicy::Capture { limit_bytes: 0 },
             stderr: CommandOutputPolicy::Capture { limit_bytes: 0 },
+            expected_exit_codes: &[],
             stream_queue_capacity: None,
         })
         .await
@@ -431,6 +479,7 @@ async fn command_stream_rejects_zero_capacity_without_sending_frame() {
                 chunk_limit_bytes: 16,
             },
             stderr: CommandOutputPolicy::Discard,
+            expected_exit_codes: &[],
             stream_queue_capacity: Some(0),
         })
         .await
@@ -461,6 +510,7 @@ async fn command_stream_rejects_oversized_capacity_without_sending_frame() {
                 chunk_limit_bytes: 16,
             },
             stderr: CommandOutputPolicy::Discard,
+            expected_exit_codes: &[],
             stream_queue_capacity: Some(command_impl::test_support::MAX_STREAM_CAPACITY + 1),
         })
         .await
@@ -492,6 +542,7 @@ async fn command_start_stream_policy_uses_default_receiver() {
                 stream_limit_bytes: 1024,
                 chunk_limit_bytes: 16,
             },
+            expected_exit_codes: &[],
             stream_queue_capacity: None,
         })
         .await
@@ -538,6 +589,7 @@ async fn command_start_rejects_receiver_without_stream_policy() {
             label: "unexpected-receiver",
             stdout: CommandOutputPolicy::Capture { limit_bytes: 1024 },
             stderr: CommandOutputPolicy::Discard,
+            expected_exit_codes: &[],
             stream_queue_capacity: Some(1),
         })
         .await
@@ -565,6 +617,7 @@ async fn command_stream_rejects_non_streaming_policy() {
             label: "non-streaming-helper",
             stdout: CommandOutputPolicy::Capture { limit_bytes: 1024 },
             stderr: CommandOutputPolicy::Discard,
+            expected_exit_codes: &[],
             stream_queue_capacity: None,
         })
         .await
@@ -595,6 +648,7 @@ async fn command_start_encode_error_does_not_register_or_send_frame() {
                 chunk_limit_bytes: 0,
             },
             stderr: CommandOutputPolicy::Discard,
+            expected_exit_codes: &[],
             stream_queue_capacity: Some(1),
         })
         .await
@@ -622,6 +676,7 @@ async fn command_start_rejects_zero_timeout_without_sending_frame() {
             label: "zero-timeout",
             stdout: CommandOutputPolicy::Capture { limit_bytes: 1024 },
             stderr: CommandOutputPolicy::Capture { limit_bytes: 1024 },
+            expected_exit_codes: &[],
             stream_queue_capacity: None,
         })
         .await
@@ -708,6 +763,7 @@ async fn command_stream_dispatches_stdout_stderr_and_closes_on_result() {
                 limit_bytes: 1024,
                 chunk_limit_bytes: 16,
             },
+            expected_exit_codes: &[],
             stream_queue_capacity: None,
         })
         .await
@@ -773,6 +829,7 @@ async fn command_stream_full_channel_closes_stream_and_marks_result() {
                 chunk_limit_bytes: 16,
             },
             stderr: CommandOutputPolicy::Discard,
+            expected_exit_codes: &[],
             stream_queue_capacity: Some(1),
         })
         .await
@@ -829,6 +886,7 @@ async fn command_stream_many_chunks_soak_does_not_block_terminal_result() {
                 chunk_limit_bytes: 16,
             },
             stderr: CommandOutputPolicy::Discard,
+            expected_exit_codes: &[],
             stream_queue_capacity: Some(2),
         })
         .await
@@ -886,6 +944,7 @@ async fn command_output_for_non_streamed_side_poisons_connection() {
                 limit_bytes: 1024,
                 chunk_limit_bytes: 16,
             },
+            expected_exit_codes: &[],
             stream_queue_capacity: Some(1),
         })
         .await
@@ -924,6 +983,7 @@ async fn command_output_seq_gap_poisons_connection() {
                 chunk_limit_bytes: 16,
             },
             stderr: CommandOutputPolicy::Discard,
+            expected_exit_codes: &[],
             stream_queue_capacity: Some(1),
         })
         .await
@@ -962,6 +1022,7 @@ async fn command_output_zero_stream_limit_accepts_empty_truncation_marker() {
                 chunk_limit_bytes: 16,
             },
             stderr: CommandOutputPolicy::Discard,
+            expected_exit_codes: &[],
             stream_queue_capacity: Some(1),
         })
         .await
@@ -1008,6 +1069,7 @@ async fn command_output_empty_non_truncated_poisons_connection() {
                 chunk_limit_bytes: 16,
             },
             stderr: CommandOutputPolicy::Discard,
+            expected_exit_codes: &[],
             stream_queue_capacity: Some(1),
         })
         .await
@@ -1046,6 +1108,7 @@ async fn command_output_over_requested_chunk_limit_poisons_connection() {
                 chunk_limit_bytes: 3,
             },
             stderr: CommandOutputPolicy::Discard,
+            expected_exit_codes: &[],
             stream_queue_capacity: Some(4),
         })
         .await
@@ -1084,6 +1147,7 @@ async fn command_output_over_requested_stream_limit_poisons_connection() {
                 chunk_limit_bytes: 3,
             },
             stderr: CommandOutputPolicy::Discard,
+            expected_exit_codes: &[],
             stream_queue_capacity: Some(4),
         })
         .await
@@ -1131,6 +1195,7 @@ async fn command_output_after_truncation_poisons_connection() {
                 chunk_limit_bytes: 4,
             },
             stderr: CommandOutputPolicy::Discard,
+            expected_exit_codes: &[],
             stream_queue_capacity: Some(4),
         })
         .await
@@ -1178,6 +1243,7 @@ async fn command_stream_dropped_receiver_does_not_block_result() {
                 chunk_limit_bytes: 16,
             },
             stderr: CommandOutputPolicy::Discard,
+            expected_exit_codes: &[],
             stream_queue_capacity: Some(1),
         })
         .await
@@ -1271,6 +1337,7 @@ async fn command_connection_close_wakes_result_and_stream() {
                 chunk_limit_bytes: 16,
             },
             stderr: CommandOutputPolicy::Discard,
+            expected_exit_codes: &[],
             stream_queue_capacity: Some(1),
         })
         .await
@@ -1302,6 +1369,7 @@ async fn command_start_after_connection_close_returns_connection_reset() {
             label: "closed",
             stdout: CommandOutputPolicy::Capture { limit_bytes: 1024 },
             stderr: CommandOutputPolicy::Capture { limit_bytes: 1024 },
+            expected_exit_codes: &[],
             stream_queue_capacity: None,
         })
         .await
@@ -1328,6 +1396,7 @@ async fn host_drop_closes_active_command_result_and_stream() {
                 chunk_limit_bytes: 16,
             },
             stderr: CommandOutputPolicy::Discard,
+            expected_exit_codes: &[],
             stream_queue_capacity: Some(1),
         })
         .await

--- a/crates/vsock-host/src/tests/file.rs
+++ b/crates/vsock-host/src/tests/file.rs
@@ -52,6 +52,7 @@ async fn read_file_returns_content_and_missing() {
     let decoded = vsock_proto::decode_command_start(&msg.payload).unwrap();
     assert_eq!(decoded.label, "read-file");
     assert!(decoded.command.contains("cat -- '/tmp/session.txt'"));
+    assert_eq!(decoded.expected_exit_codes, vec![66]);
     send_command_result(
         &mut guest,
         msg.seq,
@@ -69,6 +70,8 @@ async fn read_file_returns_content_and_missing() {
     };
     let msg = read_guest_message(&mut guest, &mut decoder).await;
     assert_eq!(msg.msg_type, MSG_COMMAND_START);
+    let decoded = vsock_proto::decode_command_start(&msg.payload).unwrap();
+    assert_eq!(decoded.expected_exit_codes, vec![66]);
     send_command_result(
         &mut guest,
         msg.seq,
@@ -489,6 +492,8 @@ async fn copy_file_missing_ok_leaves_no_final_or_temp_file() {
 
     let msg = read_guest_message(&mut guest, &mut decoder).await;
     assert_eq!(msg.msg_type, MSG_COMMAND_START);
+    let decoded = vsock_proto::decode_command_start(&msg.payload).unwrap();
+    assert_eq!(decoded.expected_exit_codes, vec![66]);
     send_stream_command_result(
         &mut guest,
         msg.seq,
@@ -542,6 +547,8 @@ async fn copy_file_missing_without_missing_ok_preserves_existing_file_and_remove
 
     let msg = read_guest_message(&mut guest, &mut decoder).await;
     assert_eq!(msg.msg_type, MSG_COMMAND_START);
+    let decoded = vsock_proto::decode_command_start(&msg.payload).unwrap();
+    assert!(decoded.expected_exit_codes.is_empty());
     send_stream_command_result(
         &mut guest,
         msg.seq,

--- a/crates/vsock-proto/src/lib.rs
+++ b/crates/vsock-proto/src/lib.rs
@@ -46,10 +46,11 @@ mod wire;
 pub use error::ProtocolError;
 pub use frame::{Decoder, RawMessage, encode};
 pub use payloads::command::{
-    CommandCapturedOutput, CommandOutputPolicy, CommandOutputStream, CommandTermination,
-    DecodedCommandOutput, DecodedCommandResult, DecodedCommandStart, decode_command_cancel,
-    decode_command_output, decode_command_result, decode_command_start, encode_command_cancel,
-    encode_command_output, encode_command_result, encode_command_start,
+    CommandCapturedOutput, CommandOutputPolicy, CommandOutputStream, CommandStartEncodeRequest,
+    CommandTermination, DecodedCommandOutput, DecodedCommandResult, DecodedCommandStart,
+    decode_command_cancel, decode_command_output, decode_command_result, decode_command_start,
+    encode_command_cancel, encode_command_output, encode_command_result, encode_command_start,
+    encode_command_start_with_expected_exit_codes,
 };
 pub use payloads::error::{decode_error, encode_error};
 pub use payloads::process::{

--- a/crates/vsock-proto/src/payloads/command.rs
+++ b/crates/vsock-proto/src/payloads/command.rs
@@ -25,6 +25,7 @@ const COMMAND_CAPTURED_OUTPUT_DISCARDED: u8 = 0x00;
 const COMMAND_CAPTURED_OUTPUT_CAPTURED: u8 = 0x01;
 
 const MAX_COMMAND_ENV_VARS: usize = 4096;
+const MAX_COMMAND_EXPECTED_EXIT_CODES: usize = 64;
 
 /// Command output stream selector.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -78,6 +79,18 @@ pub enum CommandCapturedOutput<'a> {
     Captured { bytes: &'a [u8], truncated: bool },
 }
 
+/// Parameters for encoding a command start payload with extended metadata.
+pub struct CommandStartEncodeRequest<'a> {
+    pub timeout_ms: u32,
+    pub command: &'a str,
+    pub env: &'a [(&'a str, &'a str)],
+    pub sudo: bool,
+    pub label: &'a str,
+    pub stdout: CommandOutputPolicy,
+    pub stderr: CommandOutputPolicy,
+    pub expected_exit_codes: &'a [i32],
+}
+
 /// Decoded command start payload.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DecodedCommandStart<'a> {
@@ -88,6 +101,7 @@ pub struct DecodedCommandStart<'a> {
     pub label: &'a str,
     pub stdout: CommandOutputPolicy,
     pub stderr: CommandOutputPolicy,
+    pub expected_exit_codes: Vec<i32>,
 }
 
 /// Decoded command output payload.
@@ -167,10 +181,7 @@ fn append_command_output_policy(p: &mut Vec<u8>, policy: CommandOutputPolicy) {
     }
 }
 
-/// Encode command_start payload.
-///
-/// Wire format:
-/// `[4B timeout_ms][1B flags][4B cmd_len][command][4B env_count]... [2B label_len][label][stdout_policy][stderr_policy]`.
+/// Encode command_start payload with no expected non-zero exits.
 pub fn encode_command_start(
     timeout_ms: u32,
     command: &str,
@@ -180,22 +191,52 @@ pub fn encode_command_start(
     stdout: CommandOutputPolicy,
     stderr: CommandOutputPolicy,
 ) -> Result<Vec<u8>, ProtocolError> {
-    let cmd = command.as_bytes();
-    let label_bytes = label.as_bytes();
+    encode_command_start_with_expected_exit_codes(CommandStartEncodeRequest {
+        timeout_ms,
+        command,
+        env,
+        sudo,
+        label,
+        stdout,
+        stderr,
+        expected_exit_codes: &[],
+    })
+}
+
+/// Encode command_start payload.
+///
+/// Wire format:
+/// `[4B timeout_ms][1B flags][4B cmd_len][command][4B env_count]... [2B label_len][label][stdout_policy][stderr_policy][2B expected_exit_count][4B exit_code]...`.
+pub fn encode_command_start_with_expected_exit_codes(
+    request: CommandStartEncodeRequest<'_>,
+) -> Result<Vec<u8>, ProtocolError> {
+    let cmd = request.command.as_bytes();
+    let label_bytes = request.label.as_bytes();
     let cmd_len = ensure_u32_len("command", cmd.len())?;
-    let env_count = ensure_u32_len("env_count", env.len())?;
-    if env.len() > MAX_COMMAND_ENV_VARS {
-        return Err(ProtocolError::PayloadTooLarge("env_count", env.len()));
+    let env_count = ensure_u32_len("env_count", request.env.len())?;
+    if request.env.len() > MAX_COMMAND_ENV_VARS {
+        return Err(ProtocolError::PayloadTooLarge(
+            "env_count",
+            request.env.len(),
+        ));
     }
     let label_len = ensure_u16_len("label", label_bytes.len())?;
+    let expected_exit_count =
+        ensure_u16_len("expected_exit_count", request.expected_exit_codes.len())?;
+    if request.expected_exit_codes.len() > MAX_COMMAND_EXPECTED_EXIT_CODES {
+        return Err(ProtocolError::PayloadTooLarge(
+            "expected_exit_count",
+            request.expected_exit_codes.len(),
+        ));
+    }
 
-    let stdout_policy_len = command_output_policy_encoded_len(stdout)?;
-    let stderr_policy_len = command_output_policy_encoded_len(stderr)?;
+    let stdout_policy_len = command_output_policy_encoded_len(request.stdout)?;
+    let stderr_policy_len = command_output_policy_encoded_len(request.stderr)?;
 
     let mut payload_len = 4 + 1 + 4;
     payload_len = checked_payload_len_add(payload_len, cmd.len())?;
     payload_len = checked_payload_len_add(payload_len, 4)?;
-    for (key, val) in env {
+    for (key, val) in request.env {
         let key_bytes = key.as_bytes();
         let val_bytes = val.as_bytes();
         ensure_u32_len("env key", key_bytes.len())?;
@@ -208,15 +249,17 @@ pub fn encode_command_start(
     payload_len = checked_payload_len_add(payload_len, label_bytes.len())?;
     payload_len = checked_payload_len_add(payload_len, stdout_policy_len)?;
     payload_len = checked_payload_len_add(payload_len, stderr_policy_len)?;
+    payload_len = checked_payload_len_add(payload_len, 2)?;
+    payload_len = checked_payload_len_add(payload_len, request.expected_exit_codes.len() * 4)?;
     ensure_payload_fits_message(payload_len)?;
 
     let mut p = Vec::with_capacity(payload_len);
-    p.extend_from_slice(&timeout_ms.to_be_bytes());
-    p.push(if sudo { COMMAND_FLAG_SUDO } else { 0 });
+    p.extend_from_slice(&request.timeout_ms.to_be_bytes());
+    p.push(if request.sudo { COMMAND_FLAG_SUDO } else { 0 });
     p.extend_from_slice(&cmd_len.to_be_bytes());
     p.extend_from_slice(cmd);
     p.extend_from_slice(&env_count.to_be_bytes());
-    for (key, val) in env {
+    for (key, val) in request.env {
         let key_bytes = key.as_bytes();
         let val_bytes = val.as_bytes();
         p.extend_from_slice(&(key_bytes.len() as u32).to_be_bytes());
@@ -226,8 +269,12 @@ pub fn encode_command_start(
     }
     p.extend_from_slice(&label_len.to_be_bytes());
     p.extend_from_slice(label_bytes);
-    append_command_output_policy(&mut p, stdout);
-    append_command_output_policy(&mut p, stderr);
+    append_command_output_policy(&mut p, request.stdout);
+    append_command_output_policy(&mut p, request.stderr);
+    p.extend_from_slice(&expected_exit_count.to_be_bytes());
+    for exit_code in request.expected_exit_codes {
+        p.extend_from_slice(&exit_code.to_be_bytes());
+    }
     debug_assert_eq!(p.len(), payload_len);
     Ok(p)
 }
@@ -473,6 +520,35 @@ pub fn decode_command_start(payload: &[u8]) -> Result<DecodedCommandStart<'_>, P
     )?;
     let stdout = decode_command_output_policy(payload, &mut offset)?;
     let stderr = decode_command_output_policy(payload, &mut offset)?;
+    let expected_exit_count = read_u16(
+        payload,
+        &mut offset,
+        "command start expected_exit_count truncated",
+    )?;
+    if expected_exit_count as usize > MAX_COMMAND_EXPECTED_EXIT_CODES {
+        return Err(ProtocolError::InvalidPayload(
+            "command start expected_exit_count too large",
+        ));
+    }
+    let expected_exit_bytes =
+        (expected_exit_count as usize)
+            .checked_mul(4)
+            .ok_or(ProtocolError::InvalidPayload(
+                "command start expected exits truncated",
+            ))?;
+    if payload.len().saturating_sub(offset) < expected_exit_bytes {
+        return Err(ProtocolError::InvalidPayload(
+            "command start expected exits truncated",
+        ));
+    }
+    let mut expected_exit_codes = Vec::with_capacity(expected_exit_count as usize);
+    for _ in 0..expected_exit_count {
+        expected_exit_codes.push(read_i32(
+            payload,
+            &mut offset,
+            "command start expected exit truncated",
+        )?);
+    }
     expect_consumed(payload, offset, "command start trailing bytes")?;
     Ok(DecodedCommandStart {
         timeout_ms,
@@ -482,6 +558,7 @@ pub fn decode_command_start(payload: &[u8]) -> Result<DecodedCommandStart<'_>, P
         label,
         stdout,
         stderr,
+        expected_exit_codes,
     })
 }
 

--- a/crates/vsock-proto/src/payloads/command/tests.rs
+++ b/crates/vsock-proto/src/payloads/command/tests.rs
@@ -25,6 +25,7 @@ fn command_start_roundtrip_discard_policies() {
             label: "",
             stdout: CommandOutputPolicy::Discard,
             stderr: CommandOutputPolicy::Discard,
+            expected_exit_codes: Vec::new(),
         }
     );
 }
@@ -57,6 +58,8 @@ fn command_start_wire_layout_places_label_before_output_policies() {
             0,
             0,
             7,
+            0,
+            0,
         ]
     );
 }
@@ -118,6 +121,26 @@ fn command_start_roundtrip_stream_policy_allows_zero_stream_limit() {
         }
     );
     assert_eq!(decoded.stderr, CommandOutputPolicy::Discard);
+    assert!(decoded.expected_exit_codes.is_empty());
+}
+
+#[test]
+fn command_start_roundtrip_expected_exit_codes() {
+    let payload = encode_command_start_with_expected_exit_codes(CommandStartEncodeRequest {
+        timeout_ms: 1000,
+        command: "optional-file",
+        env: &[],
+        sudo: false,
+        label: "read-file",
+        stdout: CommandOutputPolicy::Capture { limit_bytes: 4096 },
+        stderr: CommandOutputPolicy::Discard,
+        expected_exit_codes: &[66, -9],
+    })
+    .unwrap();
+
+    let decoded = decode_command_start(&payload).unwrap();
+    assert_eq!(decoded.label, "read-file");
+    assert_eq!(decoded.expected_exit_codes, vec![66, -9]);
 }
 
 #[test]
@@ -612,6 +635,67 @@ fn command_start_rejects_zero_stream_chunk_limit() {
     assert!(matches!(
         err,
         ProtocolError::InvalidPayload("command output chunk limit must be non-zero")
+    ));
+}
+
+#[test]
+fn command_start_rejects_expected_exit_count_above_limit() {
+    let expected_exit_codes = vec![0; MAX_COMMAND_EXPECTED_EXIT_CODES + 1];
+    let err = encode_command_start_with_expected_exit_codes(CommandStartEncodeRequest {
+        timeout_ms: 1,
+        command: "cmd",
+        env: &[],
+        sudo: false,
+        label: "",
+        stdout: CommandOutputPolicy::Discard,
+        stderr: CommandOutputPolicy::Discard,
+        expected_exit_codes: &expected_exit_codes,
+    })
+    .unwrap_err();
+    assert!(matches!(
+        err,
+        ProtocolError::PayloadTooLarge("expected_exit_count", _)
+    ));
+
+    let mut payload = encode_command_start(
+        1,
+        "cmd",
+        &[],
+        false,
+        "",
+        CommandOutputPolicy::Discard,
+        CommandOutputPolicy::Discard,
+    )
+    .unwrap();
+    let count_offset = payload.len() - 2;
+    payload[count_offset..]
+        .copy_from_slice(&((MAX_COMMAND_EXPECTED_EXIT_CODES as u16) + 1).to_be_bytes());
+    let err = decode_command_start(&payload).unwrap_err();
+    assert!(matches!(
+        err,
+        ProtocolError::InvalidPayload("command start expected_exit_count too large")
+    ));
+}
+
+#[test]
+fn command_start_rejects_truncated_expected_exit_codes() {
+    let mut payload = encode_command_start_with_expected_exit_codes(CommandStartEncodeRequest {
+        timeout_ms: 1,
+        command: "cmd",
+        env: &[],
+        sudo: false,
+        label: "",
+        stdout: CommandOutputPolicy::Discard,
+        stderr: CommandOutputPolicy::Discard,
+        expected_exit_codes: &[66],
+    })
+    .unwrap();
+    payload.pop();
+
+    let err = decode_command_start(&payload).unwrap_err();
+    assert!(matches!(
+        err,
+        ProtocolError::InvalidPayload("command start expected exits truncated")
     ));
 }
 


### PR DESCRIPTION
## Summary
- add expected exit codes to the command_start protocol metadata
- suppress host and guest command warnings for expected non-zero exits
- mark missing-file sentinel exit 66 as expected for read_file and missing-ok copy_file

## Tests
- cargo test --manifest-path crates/Cargo.toml -p vsock-proto
- cargo test --manifest-path crates/Cargo.toml -p vsock-host
- cargo test --manifest-path crates/Cargo.toml -p vsock-guest
- cargo test --manifest-path crates/Cargo.toml -p sandbox-fc --lib
- cargo clippy --manifest-path crates/Cargo.toml -p vsock-proto -p vsock-host -p vsock-guest -p sandbox-fc --all-targets --all-features -- -D warnings
- cargo fmt --manifest-path crates/Cargo.toml --all --check

Closes #13253