### PR TITLE
chore(guest-agent): try claude without print mode

### DIFF
--- a/crates/guest-agent/src/cli.rs
+++ b/crates/guest-agent/src/cli.rs
@@ -162,7 +162,6 @@ fn build_claude_args(
     prompt: &str,
 ) -> Vec<String> {
     let mut args = vec![
-        "--print".to_string(),
         "--verbose".to_string(),
         "--output-format".to_string(),
         "stream-json".to_string(),
@@ -687,7 +686,7 @@ pub async fn execute_cli(
     tokio::pin!(drain_deadline);
 
     // Forced termination: some conditions require reaping the CLI process
-    // group before returning. For Claude Code --print mode, post-result
+    // group before returning. For Claude Code stream-json output, post-result
     // reap arms a delayed SIGTERM after `type=result`; fatal watchdog /
     // heartbeat paths send SIGTERM immediately. Both paths share the same
     // SIGKILL escalation deadline so no forced termination can fall through
@@ -1145,7 +1144,7 @@ mod tests {
     #[test]
     fn build_claude_args_basic() {
         let args = build_claude_args_for_test("", "", "", "", "", "hello world");
-        assert!(args.contains(&"--print".to_string()));
+        assert!(!args.contains(&"--print".to_string()));
         assert!(args.contains(&"--dangerously-skip-permissions".to_string()));
         assert_prompt_with_separator(&args, "hello world");
         assert!(!args.contains(&"--append-system-prompt".to_string()));


### PR DESCRIPTION
## Summary
- remove `--print` from the Claude Code guest-agent launch args
- keep the existing `--verbose --output-format stream-json` shape and positional prompt handling
- update the command-construction test expectation for this experiment

## Validation
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent cli::tests::build_claude_args_basic`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent cli::tests::build_claude_args`
- `BATS_TEST_TIMEOUT=120 ./e2e/test/libs/bats/bin/bats -T e2e/tests/03-runner/t27-real-claude-smoke.bats` (local run skipped all 5 cases because `ANTHROPIC_API_KEY` is not set; CI provides `secrets.CI_ANTHROPIC_API_KEY`)
- pre-commit lefthook: `cargo-fmt`, `cargo-clippy`, `cargo-doc`

## Notes
This intentionally does not add `--input-format stream-json` or change stdin wiring. The PR is meant to let CI verify whether real Claude still runs without `--print`.