### PR TITLE
refactor(api): migrate skills sync cron route

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -24,6 +24,7 @@ import { cronAggregateUsageRoutes } from "./routes/cron-aggregate-usage";
 import { cronDrainEmailOutboxRoutes } from "./routes/cron-drain-email-outbox";
 import { cronProcessUsageEventsRoutes } from "./routes/cron-process-usage-events";
 import { cronReconcileBillingEntitlementsRoutes } from "./routes/cron-reconcile-billing-entitlements";
+import { cronSyncSkillsRoutes } from "./routes/cron-sync-skills";
 import { cronTelegramCleanupRoutes } from "./routes/cron-telegram-cleanup";
 import { cronVoiceChatCleanupRoutes } from "./routes/cron-voice-chat-cleanup";
 import { deviceTokenRoutes } from "./routes/device-token";
@@ -219,6 +220,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...cronDrainEmailOutboxRoutes,
   ...cronProcessUsageEventsRoutes,
   ...cronReconcileBillingEntitlementsRoutes,
+  ...cronSyncSkillsRoutes,
   ...cronTelegramCleanupRoutes,
   ...cronVoiceChatCleanupRoutes,
   ...deviceTokenRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-sync-skills.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-sync-skills.test.ts
@@ -1,0 +1,552 @@
+import { randomUUID } from "node:crypto";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { getEligibleConnectorTypes } from "@vm0/connectors/connector-utils";
+import {
+  DEFAULT_SKILLS_BRANCH,
+  DEFAULT_SKILLS_REPO,
+} from "@vm0/core/github-url";
+import { getSkillStorageName } from "@vm0/core/storage-names";
+import { SEED_SKILLS } from "@vm0/core/zero-seed-skills";
+import { cronSyncSkillsContract } from "@vm0/api-contracts/contracts/cron";
+import { skills } from "@vm0/db/schema/skill";
+import { storages } from "@vm0/db/schema/storage";
+import { createStore, command } from "ccstate";
+import { eq, inArray, like } from "drizzle-orm";
+import { http, HttpResponse } from "msw";
+import { create as createTar } from "tar";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { mockEnv } from "../../../lib/env";
+import { server } from "../../../mocks/server";
+import { writeDb$ } from "../../external/db";
+
+const context = testContext();
+const store = createStore();
+const CRON_SECRET = "test-cron-secret";
+const BUCKET = "test-user-storages";
+const TEST_SKILL_PREFIX = "api-test-skill";
+const ALL_SEED_SKILL_NAMES: readonly string[] = [
+  ...new Set([...SEED_SKILLS, ...getEligibleConnectorTypes()]),
+];
+
+interface MockSkillEntry {
+  readonly name: string;
+  readonly files: readonly {
+    readonly path: string;
+    readonly content: string;
+  }[];
+}
+
+const EXTRA_SKILLS = {
+  alphaSkill: {
+    name: `${TEST_SKILL_PREFIX}-alpha`,
+    files: [
+      {
+        path: "SKILL.md",
+        content: [
+          "---",
+          `name: ${TEST_SKILL_PREFIX}-alpha`,
+          "description: Alpha integration skill",
+          "---",
+          "",
+          "# Alpha Skill",
+          "Send messages to Alpha.",
+        ].join("\n"),
+      },
+      { path: "index.ts", content: 'console.log("alpha");' },
+    ],
+  },
+  betaSkill: {
+    name: `${TEST_SKILL_PREFIX}-beta`,
+    files: [
+      {
+        path: "SKILL.md",
+        content: [
+          "---",
+          `name: ${TEST_SKILL_PREFIX}-beta`,
+          "description: Beta integration",
+          "---",
+          "",
+          "# Beta Skill",
+        ].join("\n"),
+      },
+    ],
+  },
+} satisfies Record<string, MockSkillEntry>;
+
+const cleanupOfficialTestSkills$ = command(
+  async ({ set }, _input: void, signal: AbortSignal): Promise<void> => {
+    const db = set(writeDb$);
+    const urlPrefix = `https://github.com/vm0-ai/${DEFAULT_SKILLS_REPO}/tree/${DEFAULT_SKILLS_BRANCH}/${TEST_SKILL_PREFIX}-`;
+    const skillRows = await db
+      .select({ id: skills.id, storageId: skills.storageId })
+      .from(skills)
+      .where(like(skills.url, `${urlPrefix}%`));
+    signal.throwIfAborted();
+
+    if (skillRows.length === 0) {
+      return;
+    }
+
+    const skillIds = skillRows.map((row) => {
+      return row.id;
+    });
+    const storageIds = skillRows
+      .map((row) => {
+        return row.storageId;
+      })
+      .filter((id): id is string => {
+        return id !== null;
+      });
+
+    await db.delete(skills).where(inArray(skills.id, skillIds));
+    signal.throwIfAborted();
+    if (storageIds.length > 0) {
+      await db.delete(storages).where(inArray(storages.id, storageIds));
+      signal.throwIfAborted();
+    }
+  },
+);
+
+const setAllSkillsCommitSha$ = command(
+  async ({ set }, commitSha: string, signal: AbortSignal): Promise<void> => {
+    const db = set(writeDb$);
+    await db.update(skills).set({ commitSha });
+    signal.throwIfAborted();
+  },
+);
+
+function apiClient() {
+  return setupApp({ context })(cronSyncSkillsContract);
+}
+
+function cronHeaders(secret = CRON_SECRET) {
+  return { authorization: `Bearer ${secret}` };
+}
+
+function newCommitSha(): string {
+  return randomUUID().replaceAll("-", "").padEnd(40, "a").slice(0, 40);
+}
+
+function createGitRefsResponse(commitSha: string): string {
+  const header = "001e# service=git-upload-pack\n0000";
+  const refLine = `003f${commitSha} refs/heads/main\n`;
+  return header + refLine;
+}
+
+function createMockTarball(mockSkills: readonly MockSkillEntry[]): Buffer {
+  const tmpDir = mkdtempSync(join(tmpdir(), "vm0-api-test-tarball-"));
+  const prefix = `${DEFAULT_SKILLS_REPO}-${DEFAULT_SKILLS_BRANCH}`;
+
+  mkdirSync(join(tmpDir, prefix), { recursive: true });
+  const filePaths: string[] = [];
+
+  for (const skill of mockSkills) {
+    const skillDir = join(tmpDir, prefix, skill.name);
+    mkdirSync(skillDir, { recursive: true });
+
+    for (const file of skill.files) {
+      const filePath = join(skillDir, file.path);
+      mkdirSync(join(filePath, ".."), { recursive: true });
+      writeFileSync(filePath, file.content);
+      filePaths.push(join(prefix, skill.name, file.path));
+    }
+  }
+
+  const tarPath = join(tmpDir, "test.tar.gz");
+  createTar({ gzip: true, file: tarPath, cwd: tmpDir, sync: true }, filePaths);
+  const tarball = readFileSync(tarPath);
+  rmSync(tmpDir, { recursive: true, force: true });
+  return tarball;
+}
+
+function seedSkillEntries(): MockSkillEntry[] {
+  return ALL_SEED_SKILL_NAMES.map((name) => {
+    return {
+      name,
+      files: [
+        {
+          path: "SKILL.md",
+          content: `---\nname: ${name}\ndescription: ${name} skill\n---\n\n# ${name}\n`,
+        },
+      ],
+    };
+  });
+}
+
+function createFullTarball(extras: readonly MockSkillEntry[]): Buffer {
+  return createMockTarball([...seedSkillEntries(), ...extras]);
+}
+
+function setupGitRefsHandler(commitSha: string): void {
+  server.use(
+    http.get("https://github.com/vm0-ai/vm0-skills.git/info/refs", () => {
+      return new HttpResponse(createGitRefsResponse(commitSha));
+    }),
+  );
+}
+
+function setupMswHandlers(commitSha: string, tarball: Buffer): void {
+  setupGitRefsHandler(commitSha);
+  server.use(
+    http.get(
+      "https://codeload.github.com/vm0-ai/vm0-skills/tar.gz/refs/heads/main",
+      () => {
+        return new HttpResponse(tarball);
+      },
+    ),
+  );
+}
+
+function commandName(command: unknown): string {
+  return command instanceof Object && "constructor" in command
+    ? command.constructor.name
+    : "";
+}
+
+function commandInput(command: unknown): Record<string, unknown> {
+  if (
+    typeof command !== "object" ||
+    command === null ||
+    !("input" in command) ||
+    typeof command.input !== "object" ||
+    command.input === null
+  ) {
+    return {};
+  }
+  return command.input as Record<string, unknown>;
+}
+
+function s3CallsByName(name: string): unknown[] {
+  return context.mocks.s3.send.mock.calls
+    .map((call) => {
+      return call[0];
+    })
+    .filter((command) => {
+      return commandName(command) === name;
+    });
+}
+
+function setupS3ListObjects(keys: readonly string[]): void {
+  context.mocks.s3.send.mockImplementation((command: unknown) => {
+    if (commandName(command) === "ListObjectsV2Command") {
+      return Promise.resolve({
+        Contents: keys.map((key) => {
+          return {
+            Key: key,
+            Size: 1,
+            LastModified: new Date("2026-05-14T00:00:00.000Z"),
+          };
+        }),
+      });
+    }
+    return Promise.resolve({});
+  });
+}
+
+function testSkillUrl(name: string): string {
+  return `https://github.com/vm0-ai/${DEFAULT_SKILLS_REPO}/tree/${DEFAULT_SKILLS_BRANCH}/${name}`;
+}
+
+async function findSkillByUrl(url: string): Promise<{
+  readonly fullPath: string;
+  readonly commitSha: string | null;
+  readonly versionHash: string | null;
+  readonly fileCount: number;
+  readonly frontmatter: unknown;
+} | null> {
+  const db = store.set(writeDb$);
+  const [row] = await db
+    .select({
+      fullPath: skills.fullPath,
+      commitSha: skills.commitSha,
+      versionHash: skills.versionHash,
+      fileCount: skills.fileCount,
+      frontmatter: skills.frontmatter,
+    })
+    .from(skills)
+    .where(eq(skills.url, url))
+    .limit(1);
+  return row ?? null;
+}
+
+async function findSystemStorageByName(name: string): Promise<{
+  readonly type: string;
+  readonly headVersionId: string | null;
+} | null> {
+  const db = store.set(writeDb$);
+  const [row] = await db
+    .select({
+      type: storages.type,
+      headVersionId: storages.headVersionId,
+    })
+    .from(storages)
+    .where(eq(storages.name, name))
+    .limit(1);
+  return row ?? null;
+}
+
+describe("GET /api/cron/sync-skills", () => {
+  beforeEach(() => {
+    mockEnv("CRON_SECRET", CRON_SECRET);
+    mockEnv("R2_USER_STORAGES_BUCKET_NAME", BUCKET);
+    context.mocks.s3.send.mockReset();
+    context.mocks.s3.send.mockResolvedValue({});
+  });
+
+  afterEach(async () => {
+    await store.set(cleanupOfficialTestSkills$, undefined, context.signal);
+  });
+
+  it("rejects requests with an invalid cron secret", async () => {
+    const response = await accept(
+      apiClient().sync({ headers: cronHeaders("wrong-secret") }),
+      [401],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Invalid cron secret", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("rejects requests with no authorization header", async () => {
+    const response = await accept(apiClient().sync({ headers: {} }), [401]);
+
+    expect(response.body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("skips sync when the stored commit SHA is unchanged", async () => {
+    const commitSha = newCommitSha();
+    await store.set(setAllSkillsCommitSha$, commitSha, context.signal);
+    setupGitRefsHandler(commitSha);
+
+    const response = await accept(
+      apiClient().sync({ headers: cronHeaders() }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      success: true,
+      commitSha,
+      synced: 0,
+      skipped: 0,
+      failed: 0,
+      removed: 0,
+      total: 0,
+    });
+  });
+
+  it("syncs new skills from the repository tarball", async () => {
+    const commitSha = newCommitSha();
+    setupMswHandlers(
+      commitSha,
+      createFullTarball([EXTRA_SKILLS.alphaSkill, EXTRA_SKILLS.betaSkill]),
+    );
+
+    const response = await accept(
+      apiClient().sync({ headers: cronHeaders() }),
+      [200],
+    );
+
+    expect(response.body.success).toBeTruthy();
+    expect(response.body.commitSha).toBe(commitSha);
+    expect(response.body.synced + response.body.skipped).toBeGreaterThan(0);
+
+    const alphaSkill = await findSkillByUrl(
+      testSkillUrl(EXTRA_SKILLS.alphaSkill.name),
+    );
+    expect(alphaSkill).toMatchObject({
+      fullPath: `vm0-ai/vm0-skills/tree/main/${EXTRA_SKILLS.alphaSkill.name}`,
+      commitSha,
+      fileCount: 2,
+      frontmatter: {
+        name: EXTRA_SKILLS.alphaSkill.name,
+        description: "Alpha integration skill",
+      },
+    });
+    expect(alphaSkill?.versionHash).toBeTruthy();
+
+    const alphaStorage = await findSystemStorageByName(
+      getSkillStorageName(
+        `vm0-ai/vm0-skills/tree/main/${EXTRA_SKILLS.alphaSkill.name}`,
+      ),
+    );
+    expect(alphaStorage).toMatchObject({
+      type: "volume",
+      headVersionId: expect.any(String),
+    });
+  });
+
+  it("skips malformed skill frontmatter and syncs other skills", async () => {
+    const commitSha = newCommitSha();
+    const badSkill = {
+      name: `${TEST_SKILL_PREFIX}-bad-yaml`,
+      files: [
+        {
+          path: "SKILL.md",
+          content: [
+            "---",
+            `name: ${TEST_SKILL_PREFIX}-bad-yaml`,
+            "description:",
+            "  - not_a_string",
+            "- BAD_LINE",
+            "---",
+            "",
+            "# Bad YAML Skill",
+          ].join("\n"),
+        },
+      ],
+    };
+    setupMswHandlers(
+      commitSha,
+      createFullTarball([EXTRA_SKILLS.alphaSkill, badSkill]),
+    );
+
+    const response = await accept(
+      apiClient().sync({ headers: cronHeaders() }),
+      [200],
+    );
+
+    expect(response.body.failed).toBe(1);
+    await expect(
+      findSkillByUrl(testSkillUrl(EXTRA_SKILLS.alphaSkill.name)),
+    ).resolves.not.toBeNull();
+    await expect(
+      findSkillByUrl(testSkillUrl(badSkill.name)),
+    ).resolves.toBeNull();
+  });
+
+  it("only uploads changed skills during incremental sync", async () => {
+    const firstCommitSha = newCommitSha();
+    setupMswHandlers(
+      firstCommitSha,
+      createFullTarball([EXTRA_SKILLS.alphaSkill, EXTRA_SKILLS.betaSkill]),
+    );
+    await accept(apiClient().sync({ headers: cronHeaders() }), [200]);
+
+    context.mocks.s3.send.mockClear();
+    const nextCommitSha = newCommitSha();
+    const modifiedAlpha = {
+      name: EXTRA_SKILLS.alphaSkill.name,
+      files: [
+        {
+          path: "SKILL.md",
+          content: [
+            "---",
+            `name: ${EXTRA_SKILLS.alphaSkill.name}`,
+            "description: Updated alpha skill",
+            "---",
+            "",
+            "# Alpha Skill v2",
+          ].join("\n"),
+        },
+        { path: "index.ts", content: 'console.log("alpha v2");' },
+      ],
+    };
+    setupMswHandlers(
+      nextCommitSha,
+      createFullTarball([modifiedAlpha, EXTRA_SKILLS.betaSkill]),
+    );
+
+    const response = await accept(
+      apiClient().sync({ headers: cronHeaders() }),
+      [200],
+    );
+
+    expect(response.body.commitSha).toBe(nextCommitSha);
+    expect(response.body.synced).toBe(1);
+    expect(response.body.skipped).toBeGreaterThanOrEqual(1);
+    expect(s3CallsByName("PutObjectCommand")).toHaveLength(2);
+
+    await expect(
+      findSkillByUrl(testSkillUrl(EXTRA_SKILLS.alphaSkill.name)),
+    ).resolves.toMatchObject({
+      commitSha: nextCommitSha,
+      frontmatter: {
+        name: EXTRA_SKILLS.alphaSkill.name,
+        description: "Updated alpha skill",
+      },
+    });
+  });
+
+  it("removes skills deleted from the source repository and cleans S3 objects", async () => {
+    const firstCommitSha = newCommitSha();
+    setupMswHandlers(
+      firstCommitSha,
+      createFullTarball([EXTRA_SKILLS.alphaSkill, EXTRA_SKILLS.betaSkill]),
+    );
+    await accept(apiClient().sync({ headers: cronHeaders() }), [200]);
+
+    setupS3ListObjects(["mock/archive.tar.gz", "mock/manifest.json"]);
+    const nextCommitSha = newCommitSha();
+    setupMswHandlers(
+      nextCommitSha,
+      createFullTarball([EXTRA_SKILLS.alphaSkill]),
+    );
+
+    const response = await accept(
+      apiClient().sync({ headers: cronHeaders() }),
+      [200],
+    );
+
+    expect(response.body.removed).toBe(1);
+    await expect(
+      findSkillByUrl(testSkillUrl(EXTRA_SKILLS.betaSkill.name)),
+    ).resolves.toBeNull();
+    await expect(
+      findSkillByUrl(testSkillUrl(EXTRA_SKILLS.alphaSkill.name)),
+    ).resolves.not.toBeNull();
+
+    const deleteCommand = s3CallsByName("DeleteObjectsCommand")[0];
+    expect(commandInput(deleteCommand)).toMatchObject({
+      Bucket: BUCKET,
+      Delete: {
+        Objects: [
+          { Key: "mock/archive.tar.gz" },
+          { Key: "mock/manifest.json" },
+        ],
+      },
+    });
+  });
+
+  it("keeps DB orphan removal when S3 cleanup fails", async () => {
+    const firstCommitSha = newCommitSha();
+    setupMswHandlers(
+      firstCommitSha,
+      createFullTarball([EXTRA_SKILLS.alphaSkill, EXTRA_SKILLS.betaSkill]),
+    );
+    await accept(apiClient().sync({ headers: cronHeaders() }), [200]);
+
+    context.mocks.s3.send.mockImplementation((command: unknown) => {
+      if (commandName(command) === "ListObjectsV2Command") {
+        return Promise.reject(new Error("S3 connection failed"));
+      }
+      return Promise.resolve({});
+    });
+    const nextCommitSha = newCommitSha();
+    setupMswHandlers(
+      nextCommitSha,
+      createFullTarball([EXTRA_SKILLS.alphaSkill]),
+    );
+
+    const response = await accept(
+      apiClient().sync({ headers: cronHeaders() }),
+      [200],
+    );
+
+    expect(response.body.removed).toBe(1);
+    await expect(
+      findSkillByUrl(testSkillUrl(EXTRA_SKILLS.betaSkill.name)),
+    ).resolves.toBeNull();
+  });
+});

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-sync-skills.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-sync-skills.test.ts
@@ -12,6 +12,7 @@ import { join } from "node:path";
 import { getEligibleConnectorTypes } from "@vm0/connectors/connector-utils";
 import {
   DEFAULT_SKILLS_BRANCH,
+  DEFAULT_SKILLS_OWNER,
   DEFAULT_SKILLS_REPO,
 } from "@vm0/core/github-url";
 import { getSkillStorageName } from "@vm0/core/storage-names";
@@ -121,6 +122,22 @@ const cleanupOfficialTestSkills$ = command(
 const setAllSkillsCommitSha$ = command(
   async ({ set }, commitSha: string, signal: AbortSignal): Promise<void> => {
     const db = set(writeDb$);
+    const skillName = `${TEST_SKILL_PREFIX}-existing`;
+    await db
+      .insert(skills)
+      .values({
+        url: testSkillUrl(skillName),
+        name: skillName,
+        fullPath: `${DEFAULT_SKILLS_OWNER}/${DEFAULT_SKILLS_REPO}/tree/${DEFAULT_SKILLS_BRANCH}/${skillName}`,
+        commitSha,
+        frontmatter: {
+          name: skillName,
+          description: `${skillName} skill`,
+        },
+      })
+      .onConflictDoNothing();
+    signal.throwIfAborted();
+
     await db.update(skills).set({ commitSha });
     signal.throwIfAborted();
   },

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-sync-skills.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-sync-skills.test.ts
@@ -387,6 +387,32 @@ describe("GET /api/cron/sync-skills", () => {
     });
   });
 
+  it("excludes repository directories without a SKILL.md file", async () => {
+    const commitSha = newCommitSha();
+    const nonSkillDirectory = {
+      name: `${TEST_SKILL_PREFIX}-no-skill-md`,
+      files: [{ path: "README.md", content: "Not a skill." }],
+    };
+    setupMswHandlers(
+      commitSha,
+      createFullTarball([
+        EXTRA_SKILLS.alphaSkill,
+        EXTRA_SKILLS.betaSkill,
+        nonSkillDirectory,
+      ]),
+    );
+
+    const response = await accept(
+      apiClient().sync({ headers: cronHeaders() }),
+      [200],
+    );
+
+    expect(response.body.total).toBe(ALL_SEED_SKILL_NAMES.length + 2);
+    await expect(
+      findSkillByUrl(testSkillUrl(nonSkillDirectory.name)),
+    ).resolves.toBeNull();
+  });
+
   it("skips malformed skill frontmatter and syncs other skills", async () => {
     const commitSha = newCommitSha();
     const badSkill = {
@@ -548,5 +574,48 @@ describe("GET /api/cron/sync-skills", () => {
     await expect(
       findSkillByUrl(testSkillUrl(EXTRA_SKILLS.betaSkill.name)),
     ).resolves.toBeNull();
+  });
+
+  it("logs when seed skills are missing from the source repository", async () => {
+    mockEnv("AXIOM_TOKEN_TELEMETRY", "test-token");
+    mockEnv("AXIOM_DATASET_SUFFIX", "dev");
+    const omittedSkills = SEED_SKILLS.slice(0, 2);
+    const omittedSkillSet = new Set(omittedSkills);
+    const keptSkills = ALL_SEED_SKILL_NAMES.filter((name) => {
+      return !omittedSkillSet.has(name);
+    });
+    const commitSha = newCommitSha();
+    setupMswHandlers(
+      commitSha,
+      createMockTarball(
+        keptSkills.map((name) => {
+          return {
+            name,
+            files: [
+              {
+                path: "SKILL.md",
+                content: `---\nname: ${name}\ndescription: ${name} skill\n---\n\n# ${name}\n`,
+              },
+            ],
+          };
+        }),
+      ),
+    );
+
+    await accept(apiClient().sync({ headers: cronHeaders() }), [200]);
+
+    expect(context.mocks.axiomLogging.error).toHaveBeenCalledWith(
+      expect.stringContaining("SEED_SKILLS references skills not found"),
+      expect.objectContaining({
+        context: "skills:sync",
+        missingSkills: expect.arrayContaining([
+          expect.stringContaining("vm0-ai/vm0-skills"),
+        ]),
+      }),
+    );
+
+    const restoreCommitSha = newCommitSha();
+    setupMswHandlers(restoreCommitSha, createFullTarball([]));
+    await accept(apiClient().sync({ headers: cronHeaders() }), [200]);
   });
 });

--- a/turbo/apps/api/src/signals/routes/cron-sync-skills.ts
+++ b/turbo/apps/api/src/signals/routes/cron-sync-skills.ts
@@ -1,0 +1,26 @@
+import { cronSyncSkillsContract } from "@vm0/api-contracts/contracts/cron";
+import { command } from "ccstate";
+
+import type { RouteEntry } from "../route";
+import { syncSkills$ } from "../services/cron-sync-skills.service";
+import { cronUnauthorized, hasValidCronSecret } from "./cron-auth";
+
+const syncSkillsRoute$ = command(async ({ get, set }, signal: AbortSignal) => {
+  if (!hasValidCronSecret(get)) {
+    return cronUnauthorized();
+  }
+
+  const result = await set(syncSkills$, signal);
+  signal.throwIfAborted();
+  return {
+    status: 200 as const,
+    body: { success: true as const, ...result },
+  };
+});
+
+export const cronSyncSkillsRoutes: readonly RouteEntry[] = [
+  {
+    route: cronSyncSkillsContract.sync,
+    handler: syncSkillsRoute$,
+  },
+];

--- a/turbo/apps/api/src/signals/services/cron-sync-skills.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-sync-skills.service.ts
@@ -1,0 +1,758 @@
+import { createHash } from "node:crypto";
+import { mkdirSync, rmSync } from "node:fs";
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { gunzipSync } from "node:zlib";
+
+import {
+  DEFAULT_SKILLS_BRANCH,
+  DEFAULT_SKILLS_OWNER,
+  DEFAULT_SKILLS_REPO,
+  resolveSkillRef,
+} from "@vm0/core/github-url";
+import {
+  parseSkillFrontmatter,
+  type SkillFrontmatter,
+} from "@vm0/core/skill-frontmatter";
+import {
+  getSkillStorageName,
+  SYSTEM_ORG_ID,
+  VOLUME_ORG_USER_ID,
+} from "@vm0/core/storage-names";
+import { SEED_SKILLS } from "@vm0/core/zero-seed-skills";
+import { skills } from "@vm0/db/schema/skill";
+import { storages, storageVersions } from "@vm0/db/schema/storage";
+import { command, type Computed } from "ccstate";
+import { eq, inArray, like } from "drizzle-orm";
+import { create as createTar, Parser } from "tar";
+
+import { env } from "../../lib/env";
+import { logger } from "../../lib/log";
+import { nowDate } from "../../lib/time";
+import { writeDb$, type Db } from "../external/db";
+import { deleteS3Objects, listS3Objects, putS3Object } from "../external/s3";
+import { safeAsync } from "../utils";
+import type { FileEntryWithHash } from "./storage-content-hash.service";
+
+interface SyncSkillsResult {
+  readonly commitSha: string;
+  readonly synced: number;
+  readonly skipped: number;
+  readonly failed: number;
+  readonly removed: number;
+  readonly total: number;
+}
+
+interface ExtractedFile {
+  readonly path: string;
+  readonly content: Buffer;
+  readonly hash: string;
+  readonly size: number;
+}
+
+interface ExtractedSkill {
+  readonly skillName: string;
+  readonly files: readonly ExtractedFile[];
+}
+
+interface SkillSyncContext {
+  readonly skillName: string;
+  readonly files: readonly ExtractedFile[];
+  readonly url: string;
+  readonly fullPath: string;
+  readonly storageName: string;
+  readonly frontmatter: SkillFrontmatter;
+  readonly versionHash: string;
+  readonly totalSize: number;
+}
+
+interface SkillArchiveUpload {
+  readonly archiveBuffer: Buffer;
+  readonly manifestBuffer: Buffer;
+  readonly s3Prefix: string;
+  readonly s3Key: string;
+}
+
+type Getter = <T>(source: Computed<T>) => T;
+
+const log = logger("skills:sync");
+const REPO_REFS_URL = `https://github.com/${DEFAULT_SKILLS_OWNER}/${DEFAULT_SKILLS_REPO}.git/info/refs?service=git-upload-pack`;
+const TARBALL_URL = `https://codeload.github.com/${DEFAULT_SKILLS_OWNER}/${DEFAULT_SKILLS_REPO}/tar.gz/refs/heads/${DEFAULT_SKILLS_BRANCH}`;
+const SYNC_BATCH_SIZE = 5;
+
+function parseHeadRef(pktLineText: string, branch: string): string {
+  const refSuffix = `refs/heads/${branch}`;
+  const shaLength = 40;
+
+  for (const line of pktLineText.split("\n")) {
+    const refIndex = line.indexOf(refSuffix);
+    if (refIndex === -1) {
+      continue;
+    }
+
+    const shaEnd = refIndex - 1;
+    const shaStart = shaEnd - shaLength;
+    if (shaStart < 0) {
+      continue;
+    }
+
+    const sha = line.substring(shaStart, shaEnd);
+    if (/^[0-9a-f]{40}$/.test(sha)) {
+      return sha;
+    }
+  }
+
+  throw new Error(`refs/heads/${branch} not found in git refs`);
+}
+
+async function fetchHeadCommitSha(signal: AbortSignal): Promise<string> {
+  const response = await fetch(REPO_REFS_URL, { signal });
+  if (!response.ok) {
+    throw new Error(`Failed to fetch git refs: ${response.status}`);
+  }
+
+  return parseHeadRef(await response.text(), DEFAULT_SKILLS_BRANCH);
+}
+
+function extractSkillsFromTarball(gzipped: Buffer): Promise<ExtractedSkill[]> {
+  const decompressed = gunzipSync(gzipped);
+  const filesBySkill = new Map<string, ExtractedFile[]>();
+
+  return new Promise((resolve, reject) => {
+    const parser = new Parser({
+      onReadEntry: (entry) => {
+        if (entry.type !== "File") {
+          entry.resume();
+          return;
+        }
+
+        const parts = entry.path.split("/");
+        if (parts.length < 3) {
+          entry.resume();
+          return;
+        }
+
+        const skillName = parts[1]!;
+        const relativePath = parts.slice(2).join("/");
+        const chunks: Buffer[] = [];
+        entry.on("data", (chunk: Buffer) => {
+          chunks.push(chunk);
+        });
+        entry.on("end", () => {
+          const content = Buffer.concat(chunks);
+          const hash = createHash("sha256").update(content).digest("hex");
+          const files = filesBySkill.get(skillName) ?? [];
+          files.push({
+            path: relativePath,
+            content,
+            hash,
+            size: content.length,
+          });
+          filesBySkill.set(skillName, files);
+        });
+      },
+    });
+
+    parser.on("end", () => {
+      const extracted: ExtractedSkill[] = [];
+      for (const [skillName, files] of filesBySkill) {
+        if (
+          files.some((file) => {
+            return file.path === "SKILL.md";
+          })
+        ) {
+          extracted.push({ skillName, files });
+        }
+      }
+      resolve(extracted);
+    });
+    parser.on("error", reject);
+    parser.write(decompressed);
+    parser.end();
+  });
+}
+
+async function downloadAndExtractSkills(
+  signal: AbortSignal,
+): Promise<ExtractedSkill[]> {
+  const response = await fetch(TARBALL_URL, { signal });
+  if (!response.ok) {
+    throw new Error(`Failed to download tarball: ${response.status}`);
+  }
+
+  return await extractSkillsFromTarball(
+    Buffer.from(await response.arrayBuffer()),
+  );
+}
+
+function computeSystemSkillHash(
+  skillUrl: string,
+  files: readonly FileEntryWithHash[],
+): string {
+  if (files.length === 0) {
+    return createHash("sha256")
+      .update(`system-skill:${skillUrl}\n`)
+      .digest("hex");
+  }
+
+  const entries = files
+    .map((file) => {
+      return `${file.path}:${file.hash}`;
+    })
+    .sort();
+  return createHash("sha256")
+    .update(`system-skill:${skillUrl}\n${entries.join("\n")}`)
+    .digest("hex");
+}
+
+function skillUrl(skillName: string): string {
+  return `https://github.com/${DEFAULT_SKILLS_OWNER}/${DEFAULT_SKILLS_REPO}/tree/${DEFAULT_SKILLS_BRANCH}/${skillName}`;
+}
+
+function buildSkillSyncContext(extracted: ExtractedSkill): SkillSyncContext {
+  const skillName = extracted.skillName;
+  const files = extracted.files;
+  const url = skillUrl(skillName);
+  const fullPath = `${DEFAULT_SKILLS_OWNER}/${DEFAULT_SKILLS_REPO}/tree/${DEFAULT_SKILLS_BRANCH}/${skillName}`;
+  const skillMd = files.find((file) => {
+    return file.path === "SKILL.md";
+  });
+  const frontmatter: SkillFrontmatter = skillMd
+    ? parseSkillFrontmatter(skillMd.content.toString("utf8"))
+    : {};
+  const fileEntries: FileEntryWithHash[] = files.map((file) => {
+    return {
+      path: file.path,
+      hash: file.hash,
+      size: file.size,
+    };
+  });
+  const totalSize = files.reduce((sum, file) => {
+    return sum + file.size;
+  }, 0);
+
+  return {
+    skillName,
+    files,
+    url,
+    fullPath,
+    storageName: getSkillStorageName(fullPath),
+    frontmatter,
+    versionHash: computeSystemSkillHash(url, fileEntries),
+    totalSize,
+  };
+}
+
+async function createSkillArchive(
+  files: readonly ExtractedFile[],
+): Promise<{ archiveBuffer: Buffer; manifestBuffer: Buffer }> {
+  const tmpDir = await mkdtemp(join(tmpdir(), "vm0-api-skill-"));
+  await Promise.all(
+    files.map((file) => {
+      const filePath = join(tmpDir, file.path);
+      mkdirSync(join(filePath, ".."), { recursive: true });
+      return writeFile(filePath, file.content);
+    }),
+  );
+
+  const tarPath = join(tmpDir, "__archive.tar.gz");
+  await createTar(
+    {
+      gzip: true,
+      file: tarPath,
+      cwd: tmpDir,
+    },
+    files.map((file) => {
+      return file.path;
+    }),
+  );
+
+  const archiveBuffer = await readFile(tarPath);
+  const manifestBuffer = Buffer.from(
+    JSON.stringify(
+      {
+        version: 1,
+        files: files.map((file) => {
+          return {
+            path: file.path,
+            hash: file.hash,
+            size: file.size,
+          };
+        }),
+        createdAt: nowDate().toISOString(),
+      },
+      null,
+      2,
+    ),
+  );
+  rmSync(tmpDir, { recursive: true, force: true });
+
+  return { archiveBuffer, manifestBuffer };
+}
+
+async function hasCurrentSkillVersion(args: {
+  readonly db: Db;
+  readonly url: string;
+  readonly versionHash: string;
+  readonly commitSha: string;
+  readonly signal: AbortSignal;
+}): Promise<boolean> {
+  const [existingSkill] = await args.db
+    .select({ versionHash: skills.versionHash })
+    .from(skills)
+    .where(eq(skills.url, args.url))
+    .limit(1);
+  args.signal.throwIfAborted();
+
+  if (existingSkill?.versionHash !== args.versionHash) {
+    return false;
+  }
+
+  await args.db
+    .update(skills)
+    .set({ commitSha: args.commitSha, updatedAt: nowDate() })
+    .where(eq(skills.url, args.url));
+  args.signal.throwIfAborted();
+  return true;
+}
+
+async function uploadSkillArchive(args: {
+  readonly get: Getter;
+  readonly context: SkillSyncContext;
+  readonly signal: AbortSignal;
+}): Promise<SkillArchiveUpload> {
+  const { archiveBuffer, manifestBuffer } = await createSkillArchive(
+    args.context.files,
+  );
+  args.signal.throwIfAborted();
+
+  const bucketName = env("R2_USER_STORAGES_BUCKET_NAME");
+  const s3Prefix = `${SYSTEM_ORG_ID}/volume/${args.context.storageName}`;
+  const s3Key = `${s3Prefix}/${args.context.versionHash}`;
+
+  await Promise.all([
+    args.get(
+      putS3Object(
+        bucketName,
+        `${s3Key}/archive.tar.gz`,
+        archiveBuffer,
+        "application/gzip",
+      ),
+    ),
+    args.get(
+      putS3Object(
+        bucketName,
+        `${s3Key}/manifest.json`,
+        manifestBuffer,
+        "application/json",
+      ),
+    ),
+  ]);
+  args.signal.throwIfAborted();
+
+  return { archiveBuffer, manifestBuffer, s3Prefix, s3Key };
+}
+
+async function upsertSkillStorage(args: {
+  readonly db: Db;
+  readonly context: SkillSyncContext;
+  readonly upload: SkillArchiveUpload;
+  readonly timestamp: Date;
+  readonly signal: AbortSignal;
+}): Promise<string> {
+  const [storage] = await args.db
+    .insert(storages)
+    .values({
+      orgId: SYSTEM_ORG_ID,
+      userId: VOLUME_ORG_USER_ID,
+      name: args.context.storageName,
+      type: "volume",
+      s3Prefix: args.upload.s3Prefix,
+      size: args.upload.archiveBuffer.length,
+      fileCount: args.context.files.length,
+    })
+    .onConflictDoUpdate({
+      target: [storages.orgId, storages.userId, storages.name, storages.type],
+      set: {
+        size: args.upload.archiveBuffer.length,
+        fileCount: args.context.files.length,
+        updatedAt: args.timestamp,
+      },
+    })
+    .returning({ id: storages.id });
+  args.signal.throwIfAborted();
+
+  if (!storage) {
+    throw new Error(
+      `Failed to create storage for skill ${args.context.skillName}`,
+    );
+  }
+
+  return storage.id;
+}
+
+async function insertSkillStorageVersion(args: {
+  readonly db: Db;
+  readonly storageId: string;
+  readonly context: SkillSyncContext;
+  readonly upload: SkillArchiveUpload;
+  readonly commitSha: string;
+  readonly signal: AbortSignal;
+}): Promise<void> {
+  await args.db
+    .insert(storageVersions)
+    .values({
+      id: args.context.versionHash,
+      storageId: args.storageId,
+      s3Key: args.upload.s3Key,
+      size: args.upload.archiveBuffer.length,
+      fileCount: args.context.files.length,
+      message: `Synced from ${DEFAULT_SKILLS_OWNER}/${DEFAULT_SKILLS_REPO}@${args.commitSha.slice(0, 7)}`,
+      createdBy: "system",
+    })
+    .onConflictDoNothing();
+  args.signal.throwIfAborted();
+}
+
+async function updateSkillStorageHead(args: {
+  readonly db: Db;
+  readonly storageId: string;
+  readonly context: SkillSyncContext;
+  readonly upload: SkillArchiveUpload;
+  readonly timestamp: Date;
+  readonly signal: AbortSignal;
+}): Promise<void> {
+  await args.db
+    .update(storages)
+    .set({
+      headVersionId: args.context.versionHash,
+      size: args.upload.archiveBuffer.length,
+      fileCount: args.context.files.length,
+      updatedAt: args.timestamp,
+    })
+    .where(eq(storages.id, args.storageId));
+  args.signal.throwIfAborted();
+}
+
+async function upsertSkillRecord(args: {
+  readonly db: Db;
+  readonly storageId: string;
+  readonly context: SkillSyncContext;
+  readonly upload: SkillArchiveUpload;
+  readonly commitSha: string;
+  readonly timestamp: Date;
+  readonly signal: AbortSignal;
+}): Promise<void> {
+  const displayName = args.context.frontmatter.name ?? args.context.skillName;
+
+  await args.db
+    .insert(skills)
+    .values({
+      url: args.context.url,
+      name: displayName,
+      fullPath: args.context.fullPath,
+      storageId: args.storageId,
+      versionHash: args.context.versionHash,
+      commitSha: args.commitSha,
+      frontmatter: args.context.frontmatter,
+      s3Key: args.upload.s3Key,
+      size: args.context.totalSize,
+      fileCount: args.context.files.length,
+      syncedAt: args.timestamp,
+    })
+    .onConflictDoUpdate({
+      target: skills.url,
+      set: {
+        name: displayName,
+        fullPath: args.context.fullPath,
+        storageId: args.storageId,
+        versionHash: args.context.versionHash,
+        commitSha: args.commitSha,
+        frontmatter: args.context.frontmatter,
+        s3Key: args.upload.s3Key,
+        size: args.context.totalSize,
+        fileCount: args.context.files.length,
+        syncedAt: args.timestamp,
+        updatedAt: args.timestamp,
+      },
+    });
+  args.signal.throwIfAborted();
+}
+
+async function syncSingleSkill(args: {
+  readonly get: Getter;
+  readonly db: Db;
+  readonly extracted: ExtractedSkill;
+  readonly commitSha: string;
+  readonly signal: AbortSignal;
+}): Promise<boolean> {
+  const context = buildSkillSyncContext(args.extracted);
+
+  if (
+    await hasCurrentSkillVersion({
+      db: args.db,
+      url: context.url,
+      versionHash: context.versionHash,
+      commitSha: args.commitSha,
+      signal: args.signal,
+    })
+  ) {
+    return false;
+  }
+
+  const timestamp = nowDate();
+  const upload = await uploadSkillArchive({
+    get: args.get,
+    context,
+    signal: args.signal,
+  });
+  const storageId = await upsertSkillStorage({
+    db: args.db,
+    context,
+    upload,
+    timestamp,
+    signal: args.signal,
+  });
+  await insertSkillStorageVersion({
+    db: args.db,
+    storageId,
+    context,
+    upload,
+    commitSha: args.commitSha,
+    signal: args.signal,
+  });
+  await updateSkillStorageHead({
+    db: args.db,
+    storageId,
+    context,
+    upload,
+    timestamp,
+    signal: args.signal,
+  });
+  await upsertSkillRecord({
+    db: args.db,
+    storageId,
+    context,
+    upload,
+    commitSha: args.commitSha,
+    timestamp,
+    signal: args.signal,
+  });
+
+  log.debug("Synced skill", {
+    skillName: context.skillName,
+    versionHash: context.versionHash.slice(0, 8),
+  });
+  return true;
+}
+
+async function removeOrphanedSkills(args: {
+  readonly get: Getter;
+  readonly db: Db;
+  readonly extractedSkills: readonly ExtractedSkill[];
+  readonly signal: AbortSignal;
+}): Promise<number> {
+  const tarballUrls = new Set(
+    args.extractedSkills.map((skill) => {
+      return skillUrl(skill.skillName);
+    }),
+  );
+  const urlPrefix = `https://github.com/${DEFAULT_SKILLS_OWNER}/${DEFAULT_SKILLS_REPO}/tree/${DEFAULT_SKILLS_BRANCH}/`;
+  const existingSkills = await args.db
+    .select({ id: skills.id, url: skills.url, storageId: skills.storageId })
+    .from(skills)
+    .where(like(skills.url, `${urlPrefix}%`));
+  args.signal.throwIfAborted();
+
+  const orphans = existingSkills.filter((skill) => {
+    return !tarballUrls.has(skill.url);
+  });
+  if (orphans.length === 0) {
+    return 0;
+  }
+
+  const orphanIds = orphans.map((skill) => {
+    return skill.id;
+  });
+  const orphanStorageIds = orphans
+    .map((skill) => {
+      return skill.storageId;
+    })
+    .filter((id): id is string => {
+      return id !== null;
+    });
+
+  const orphanStorages =
+    orphanStorageIds.length > 0
+      ? await args.db
+          .select({ id: storages.id, s3Prefix: storages.s3Prefix })
+          .from(storages)
+          .where(inArray(storages.id, orphanStorageIds))
+      : [];
+  args.signal.throwIfAborted();
+
+  await args.db.delete(skills).where(inArray(skills.id, orphanIds));
+  args.signal.throwIfAborted();
+
+  if (orphanStorageIds.length > 0) {
+    await args.db
+      .delete(storages)
+      .where(inArray(storages.id, orphanStorageIds));
+    args.signal.throwIfAborted();
+  }
+
+  const bucket = env("R2_USER_STORAGES_BUCKET_NAME");
+  for (const storage of orphanStorages) {
+    const cleanupResult = await safeAsync(async () => {
+      const objects = await args.get(listS3Objects(bucket, storage.s3Prefix));
+      args.signal.throwIfAborted();
+      if (objects.length > 0) {
+        await args.get(
+          deleteS3Objects(
+            bucket,
+            objects.map((object) => {
+              return object.key;
+            }),
+          ),
+        );
+        args.signal.throwIfAborted();
+      }
+    });
+    if ("error" in cleanupResult) {
+      log.warn("Failed to clean up S3 objects for removed skill", {
+        s3Prefix: storage.s3Prefix,
+        error:
+          cleanupResult.error instanceof Error
+            ? cleanupResult.error.message
+            : String(cleanupResult.error),
+      });
+    }
+  }
+
+  log.debug("Removed orphaned skills", {
+    removed: orphans.length,
+    skillUrls: orphans.map((skill) => {
+      return skill.url;
+    }),
+  });
+  return orphans.length;
+}
+
+function validateSeedSkills(extractedSkills: readonly ExtractedSkill[]): void {
+  const tarballNames = new Set(
+    extractedSkills.map((skill) => {
+      return skill.skillName;
+    }),
+  );
+  const missingSkills = SEED_SKILLS.filter((name) => {
+    return !tarballNames.has(name);
+  });
+
+  if (missingSkills.length > 0) {
+    log.error("SEED_SKILLS references skills not found in repository", {
+      missingSkills: missingSkills.map((name) => {
+        return resolveSkillRef(name);
+      }),
+    });
+  }
+}
+
+export const syncSkills$ = command(
+  async ({ get, set }, signal: AbortSignal): Promise<SyncSkillsResult> => {
+    const db = set(writeDb$);
+    const headSha = await fetchHeadCommitSha(signal);
+    signal.throwIfAborted();
+
+    const [existing] = await db
+      .select({ commitSha: skills.commitSha })
+      .from(skills)
+      .limit(1);
+    signal.throwIfAborted();
+
+    if (existing?.commitSha === headSha) {
+      return {
+        commitSha: headSha,
+        synced: 0,
+        skipped: 0,
+        failed: 0,
+        removed: 0,
+        total: 0,
+      };
+    }
+
+    const extractedSkills = await downloadAndExtractSkills(signal);
+    signal.throwIfAborted();
+
+    let synced = 0;
+    let skipped = 0;
+    let failed = 0;
+
+    for (
+      let index = 0;
+      index < extractedSkills.length;
+      index += SYNC_BATCH_SIZE
+    ) {
+      const batch = extractedSkills.slice(index, index + SYNC_BATCH_SIZE);
+      const results = await Promise.allSettled(
+        batch.map((extracted) => {
+          return syncSingleSkill({
+            get,
+            db,
+            extracted,
+            commitSha: headSha,
+            signal,
+          });
+        }),
+      );
+      signal.throwIfAborted();
+
+      for (let resultIndex = 0; resultIndex < results.length; resultIndex++) {
+        const result = results[resultIndex]!;
+        if (result.status === "fulfilled") {
+          if (result.value) {
+            synced++;
+          } else {
+            skipped++;
+          }
+        } else {
+          failed++;
+          log.warn("Skipping skill due to sync error", {
+            skillName: batch[resultIndex]!.skillName,
+            error:
+              result.reason instanceof Error
+                ? result.reason.message
+                : String(result.reason),
+          });
+        }
+      }
+    }
+
+    const removed = await removeOrphanedSkills({
+      get,
+      db,
+      extractedSkills,
+      signal,
+    });
+    signal.throwIfAborted();
+    validateSeedSkills(extractedSkills);
+
+    log.debug("Skills sync completed", {
+      commitSha: headSha,
+      synced,
+      skipped,
+      failed,
+      removed,
+      total: extractedSkills.length,
+    });
+
+    return {
+      commitSha: headSha,
+      synced,
+      skipped,
+      failed,
+      removed,
+      total: extractedSkills.length,
+    };
+  },
+);

--- a/turbo/packages/api-contracts/src/contracts/cron.ts
+++ b/turbo/packages/api-contracts/src/contracts/cron.ts
@@ -77,6 +77,16 @@ const cronDrainEmailOutboxResponseSchema = z.object({
   cleaned: z.number(),
 });
 
+const cronSyncSkillsResponseSchema = z.object({
+  success: z.literal(true),
+  commitSha: z.string(),
+  synced: z.number(),
+  skipped: z.number(),
+  failed: z.number(),
+  removed: z.number(),
+  total: z.number(),
+});
+
 const cronAggregateInsightsSkippedResponseSchema = z.object({
   users: z.number(),
   skipped: z.literal(true),
@@ -171,6 +181,19 @@ export const cronDrainEmailOutboxContract = c.router({
   },
 });
 
+export const cronSyncSkillsContract = c.router({
+  sync: {
+    method: "GET",
+    path: "/api/cron/sync-skills",
+    headers: authHeadersSchema,
+    responses: {
+      200: cronSyncSkillsResponseSchema,
+      401: apiErrorSchema,
+    },
+    summary: "Sync official skills from the skills repository",
+  },
+});
+
 export const cronAggregateInsightsContract = c.router({
   aggregate: {
     method: "GET",
@@ -194,6 +217,7 @@ export type CronAggregateInsightsContract =
 export type CronTelegramCleanupContract = typeof cronTelegramCleanupContract;
 export type CronVoiceChatCleanupContract = typeof cronVoiceChatCleanupContract;
 export type CronDrainEmailOutboxContract = typeof cronDrainEmailOutboxContract;
+export type CronSyncSkillsContract = typeof cronSyncSkillsContract;
 
 // Export schemas for reuse
 export {
@@ -205,5 +229,6 @@ export {
   cronTelegramCleanupResponseSchema,
   cronVoiceChatCleanupResponseSchema,
   cronDrainEmailOutboxResponseSchema,
+  cronSyncSkillsResponseSchema,
   cronAggregateInsightsResponseSchema,
 };

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -376,6 +376,8 @@ export {
   cronProcessUsageEventsResponseSchema,
   cronReconcileBillingEntitlementsContract,
   cronReconcileBillingEntitlementsResponseSchema,
+  cronSyncSkillsContract,
+  cronSyncSkillsResponseSchema,
   cronTelegramCleanupContract,
   cronTelegramCleanupResponseSchema,
   cronVoiceChatCleanupContract,
@@ -388,6 +390,7 @@ export {
   type CronDrainEmailOutboxContract,
   type CronProcessUsageEventsContract,
   type CronReconcileBillingEntitlementsContract,
+  type CronSyncSkillsContract,
   type CronTelegramCleanupContract,
   type CronVoiceChatCleanupContract,
 } from "./cron";


### PR DESCRIPTION
## Summary
- Add the API contract and signal route for `GET /api/cron/sync-skills`
- Port the official skills sync flow into `apps/api`, including git ref freshness checks, tarball extraction, S3 archive uploads, DB upserts, orphan cleanup, and seed-skill validation
- Add API route integration coverage for auth, unchanged commits, new syncs, malformed frontmatter, incremental updates, orphan removal, and S3 cleanup failure handling

## Testing
- `pnpm -F api exec vitest src/signals/routes/__tests__/cron-sync-skills.test.ts`
- `pnpm -F api lint`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F api check-types`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm format`
- pre-commit: prettier, knip, full `turbo run check-types --concurrency=1`, commitlint

Closes #13250
Part of #12820