### PR TITLE
perf(guest-common): avoid system log newline allocation

### DIFF
--- a/crates/guest-common/src/log.rs
+++ b/crates/guest-common/src/log.rs
@@ -64,13 +64,17 @@ impl SystemLogState {
     }
 }
 
-fn write_line_with_newline(file: &mut File, line: &str) -> io::Result<()> {
+fn write_line_with_newline(writer: &mut impl Write, line: &str) -> io::Result<()> {
     let mut line = line.as_bytes();
     let mut newline = b"\n".as_slice();
 
     while !line.is_empty() || !newline.is_empty() {
         let bufs = [IoSlice::new(line), IoSlice::new(newline)];
-        let written = file.write_vectored(&bufs)?;
+        let written = match writer.write_vectored(&bufs) {
+            Ok(written) => written,
+            Err(error) if error.kind() == io::ErrorKind::Interrupted => continue,
+            Err(error) => return Err(error),
+        };
         if written == 0 {
             return Err(io::Error::new(
                 io::ErrorKind::WriteZero,
@@ -436,6 +440,55 @@ mod tests {
         state.append_line("recovers").unwrap();
         let content = std::fs::read_to_string(path).unwrap();
         assert_eq!(content, "recovers\n");
+    }
+
+    struct InterruptedPartialWriter {
+        output: Vec<u8>,
+        interrupt_next_write: bool,
+        max_write_size: usize,
+    }
+
+    impl Write for InterruptedPartialWriter {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.write_vectored(&[IoSlice::new(buf)])
+        }
+
+        fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
+            if self.interrupt_next_write {
+                self.interrupt_next_write = false;
+                return Err(io::ErrorKind::Interrupted.into());
+            }
+
+            let mut written = 0usize;
+            for buf in bufs {
+                if written == self.max_write_size {
+                    break;
+                }
+                let remaining = self.max_write_size - written;
+                let take = remaining.min(buf.len());
+                let chunk = buf.get(..take).ok_or_else(invalid_write_count)?;
+                self.output.extend_from_slice(chunk);
+                written += take;
+            }
+            Ok(written)
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn write_line_with_newline_retries_interrupted_partial_writes() {
+        let mut writer = InterruptedPartialWriter {
+            output: Vec::new(),
+            interrupt_next_write: true,
+            max_write_size: 3,
+        };
+
+        write_line_with_newline(&mut writer, "abcdef").unwrap();
+
+        assert_eq!(writer.output, b"abcdef\n");
     }
 
     #[test]

--- a/crates/guest-common/src/log.rs
+++ b/crates/guest-common/src/log.rs
@@ -65,12 +65,11 @@ impl SystemLogState {
 }
 
 fn write_line_with_newline(writer: &mut impl Write, line: &str) -> io::Result<()> {
-    let mut line = line.as_bytes();
-    let mut newline = b"\n".as_slice();
+    let mut bufs = [IoSlice::new(line.as_bytes()), IoSlice::new(b"\n")];
+    let mut bufs = &mut bufs[..];
 
-    while !line.is_empty() || !newline.is_empty() {
-        let bufs = [IoSlice::new(line), IoSlice::new(newline)];
-        let written = match writer.write_vectored(&bufs) {
+    while !bufs.is_empty() {
+        let written = match writer.write_vectored(bufs) {
             Ok(written) => written,
             Err(error) if error.kind() == io::ErrorKind::Interrupted => continue,
             Err(error) => return Err(error),
@@ -82,25 +81,10 @@ fn write_line_with_newline(writer: &mut impl Write, line: &str) -> io::Result<()
             ));
         }
 
-        if written < line.len() {
-            line = line.get(written..).ok_or_else(invalid_write_count)?;
-        } else {
-            let newline_written = written - line.len();
-            line = &[];
-            newline = newline
-                .get(newline_written..)
-                .ok_or_else(invalid_write_count)?;
-        }
+        IoSlice::advance_slices(&mut bufs, written);
     }
 
     Ok(())
-}
-
-fn invalid_write_count() -> io::Error {
-    io::Error::new(
-        io::ErrorKind::InvalidData,
-        "vectored write advanced past system log line",
-    )
 }
 
 fn open_system_log_file(path: &Path) -> std::io::Result<File> {
@@ -466,8 +450,7 @@ mod tests {
                 }
                 let remaining = self.max_write_size - written;
                 let take = remaining.min(buf.len());
-                let chunk = buf.get(..take).ok_or_else(invalid_write_count)?;
-                self.output.extend_from_slice(chunk);
+                self.output.extend(buf.iter().take(take).copied());
                 written += take;
             }
             Ok(written)

--- a/crates/guest-common/src/log.rs
+++ b/crates/guest-common/src/log.rs
@@ -1,7 +1,7 @@
 //! Logging utilities for VM scripts.
 
 use std::fs::{File, OpenOptions};
-use std::io::Write;
+use std::io::{self, IoSlice, Write};
 use std::path::{Path, PathBuf};
 use std::sync::{LazyLock, Mutex};
 
@@ -54,9 +54,7 @@ impl SystemLogState {
             }
         };
 
-        let mut line = line.as_bytes().to_vec();
-        line.push(b'\n');
-        let result = file.write_all(&line).and_then(|()| file.flush());
+        let result = write_line_with_newline(file, line).and_then(|()| file.flush());
 
         if result.is_err() {
             self.file = None;
@@ -64,6 +62,41 @@ impl SystemLogState {
 
         result
     }
+}
+
+fn write_line_with_newline(file: &mut File, line: &str) -> io::Result<()> {
+    let mut line = line.as_bytes();
+    let mut newline = b"\n".as_slice();
+
+    while !line.is_empty() || !newline.is_empty() {
+        let bufs = [IoSlice::new(line), IoSlice::new(newline)];
+        let written = file.write_vectored(&bufs)?;
+        if written == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::WriteZero,
+                "failed to write system log line",
+            ));
+        }
+
+        if written < line.len() {
+            line = line.get(written..).ok_or_else(invalid_write_count)?;
+        } else {
+            let newline_written = written - line.len();
+            line = &[];
+            newline = newline
+                .get(newline_written..)
+                .ok_or_else(invalid_write_count)?;
+        }
+    }
+
+    Ok(())
+}
+
+fn invalid_write_count() -> io::Error {
+    io::Error::new(
+        io::ErrorKind::InvalidData,
+        "vectored write advanced past system log line",
+    )
 }
 
 fn open_system_log_file(path: &Path) -> std::io::Result<File> {

--- a/crates/guest-common/src/log.rs
+++ b/crates/guest-common/src/log.rs
@@ -492,6 +492,20 @@ mod tests {
     }
 
     #[test]
+    fn write_line_with_newline_errors_on_write_zero() {
+        let mut writer = InterruptedPartialWriter {
+            output: Vec::new(),
+            interrupt_next_write: false,
+            max_write_size: 0,
+        };
+
+        let error = write_line_with_newline(&mut writer, "line").unwrap_err();
+
+        assert_eq!(error.kind(), io::ErrorKind::WriteZero);
+        assert!(writer.output.is_empty());
+    }
+
+    #[test]
     fn emit_appends_complete_lines_concurrently() {
         let _guard = LOG_TEST_MUTEX.lock().unwrap();
         let dir = tempfile::tempdir().unwrap();

--- a/crates/guest-common/src/log.rs
+++ b/crates/guest-common/src/log.rs
@@ -489,6 +489,19 @@ mod tests {
     }
 
     #[test]
+    fn write_line_with_newline_preserves_empty_line() {
+        let mut writer = InterruptedPartialWriter {
+            output: Vec::new(),
+            interrupt_next_write: false,
+            max_write_size: 8,
+        };
+
+        write_line_with_newline(&mut writer, "").unwrap();
+
+        assert_eq!(writer.output, b"\n");
+    }
+
+    #[test]
     fn emit_appends_complete_lines_concurrently() {
         let _guard = LOG_TEST_MUTEX.lock().unwrap();
         let dir = tempfile::tempdir().unwrap();


### PR DESCRIPTION
## Summary

- avoid allocating a temporary `Vec<u8>` for every guest system log line just to append `\n`
- use stable vectored writes plus a retry loop so the line body and newline stay one logical append path without relying on unstable `write_all_vectored`
- preserve synchronous `flush()` and cached-handle reopen-on-error behavior

Closes #13283

## Tests

- `cargo test --manifest-path crates/Cargo.toml -p guest-common --lib log::tests`
- `cargo test --manifest-path crates/Cargo.toml -p guest-common --lib`
- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-common --all-targets --all-features -- -D warnings`
- `git diff --check`
- pre-commit hook: cargo fmt, cargo clippy, cargo doc
