### PR TITLE
refactor: type factory lifecycle resources

### DIFF
--- a/crates/runner/src/cmd/benchmark.rs
+++ b/crates/runner/src/cmd/benchmark.rs
@@ -139,7 +139,7 @@ pub async fn run_benchmark(
     };
     let (result, timing) = run_sandbox(&args, &env_pairs, &*factory, &mitm, sandbox_config).await;
     let total_ms = total.elapsed().as_millis();
-    // Shutdown factory first (releases COW pool, base loop handle), then runtime.
+    // Shutdown factory first (releases the COW pool), then runtime-owned pools.
     factory.shutdown().await;
     runtime.shutdown().await;
     if let Err(e) = mitm.stop().await {

--- a/crates/runner/src/cmd/start/factory_lifecycle.rs
+++ b/crates/runner/src/cmd/start/factory_lifecycle.rs
@@ -159,10 +159,6 @@ mod tests {
             "recording".into()
         }
 
-        async fn startup(&mut self) -> sandbox::Result<()> {
-            Ok(())
-        }
-
         async fn create(
             &self,
             _config: sandbox::SandboxConfig,

--- a/crates/runner/src/cmd/start/factory_lifecycle.rs
+++ b/crates/runner/src/cmd/start/factory_lifecycle.rs
@@ -204,4 +204,44 @@ mod tests {
         assert_eq!(runtime.factory_shutdowns.load(Ordering::SeqCst), 1);
         assert_eq!(runtime.runtime_shutdowns.load(Ordering::SeqCst), 1);
     }
+
+    #[tokio::test]
+    async fn start_factories_shuts_down_runtime_after_first_factory_create_error() {
+        let temp = tempfile::tempdir().unwrap();
+        let home = HomePaths::with_root(temp.path().join("home"));
+        let base_dir = temp.path().join("base");
+        let firecracker = config::FirecrackerConfig {
+            binary: temp.path().join("firecracker"),
+            kernel: temp.path().join("vmlinux"),
+        };
+        let mut profiles = BTreeMap::new();
+        profiles.insert("vm0/first".into(), profile("rootfs-1", "snapshot-1"));
+        profiles.insert("vm0/second".into(), profile("rootfs-2", "snapshot-2"));
+        let mut runtime = RecordingRuntime::new(1);
+
+        let result = start_factories(&profiles, &firecracker, &base_dir, &home, &mut runtime).await;
+
+        assert!(result.is_err());
+        assert_eq!(runtime.create_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(runtime.factory_shutdowns.load(Ordering::SeqCst), 0);
+        assert_eq!(runtime.runtime_shutdowns.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn shutdown_factories_skips_factories_that_are_still_referenced() {
+        let mut runtime = RecordingRuntime::new(usize::MAX);
+        let factory_shutdowns = Arc::clone(&runtime.factory_shutdowns);
+        let retained_factory: SharedFactory = Arc::new(Box::new(RecordingFactory {
+            shutdowns: Arc::clone(&factory_shutdowns),
+        }));
+        let mut factories = BTreeMap::new();
+        factories.insert("vm0/first".into(), (Arc::clone(&retained_factory), false));
+
+        shutdown_factories(&mut factories, &mut runtime, None).await;
+
+        assert!(factories.is_empty());
+        assert_eq!(factory_shutdowns.load(Ordering::SeqCst), 0);
+        assert_eq!(runtime.runtime_shutdowns.load(Ordering::SeqCst), 1);
+        drop(retained_factory);
+    }
 }

--- a/crates/runner/src/cmd/start/factory_lifecycle.rs
+++ b/crates/runner/src/cmd/start/factory_lifecycle.rs
@@ -88,7 +88,7 @@ pub(super) async fn shutdown_factories(
             Err(_) => warn!(profile = %name, "factory still referenced at shutdown"),
         }
     }
-    // Clean up shared resources (netns pool, base loop cache).
+    // Clean up runtime-owned shared resources (netns and NBD device pools).
     let phase = teardown.map(|timer| timer.phase_start("runtime_shutdown"));
     runtime.shutdown().await;
     if let (Some(timer), Some(phase)) = (teardown, phase) {

--- a/crates/runner/src/cmd/start/factory_lifecycle.rs
+++ b/crates/runner/src/cmd/start/factory_lifecycle.rs
@@ -1,4 +1,4 @@
-//! Sandbox factory startup and shutdown for `runner start`.
+//! Sandbox factory creation and shutdown for `runner start`.
 
 use std::collections::BTreeMap;
 use std::path::Path;

--- a/crates/runner/src/cmd/start/idle_lifecycle.rs
+++ b/crates/runner/src/cmd/start/idle_lifecycle.rs
@@ -195,10 +195,6 @@ mod tests {
             "panic-destroy".into()
         }
 
-        async fn startup(&mut self) -> sandbox::Result<()> {
-            Ok(())
-        }
-
         async fn create(
             &self,
             config: sandbox::SandboxConfig,
@@ -225,10 +221,6 @@ mod tests {
 
         fn config_hash(&self) -> String {
             "recording-destroy".into()
-        }
-
-        async fn startup(&mut self) -> sandbox::Result<()> {
-            Ok(())
         }
 
         async fn create(

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -7,7 +7,7 @@
 //!
 //! The sibling modules keep focused responsibilities out of this orchestration
 //! file:
-//! - `factory_lifecycle`: sandbox factory startup and shutdown.
+//! - `factory_lifecycle`: sandbox factory creation and shutdown.
 //! - `idle_lifecycle`: idle-pool lifecycle, status updates, and destroy helpers.
 //! - `identity`: persistent runner id storage.
 //! - `job_discovery`: discovery branch handling and idle-reuse admission.

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -377,7 +377,7 @@ pub async fn run_start(
         }
     };
 
-    // Build sandbox runtime with shared resources (netns pool, base loop cache).
+    // Build sandbox runtime with shared resources (netns and NBD device pools).
     let runtime = runtime_provider
         .create_runtime(sandbox::RuntimeConfig {
             proxy_port: Some(mitm.port()),

--- a/crates/runner/src/cmd/start/tests/support/idle_pool.rs
+++ b/crates/runner/src/cmd/start/tests/support/idle_pool.rs
@@ -52,7 +52,7 @@ pub(in super::super) async fn seed_idle_pool_with_overrides(
     memory_mb: u32,
 ) -> SandboxId {
     let runtime = sandbox_mock::MockSandboxRuntime::with_overrides(Arc::clone(overrides));
-    let mut factory = runtime
+    let factory = runtime
         .create_factory(sandbox::FactoryConfig {
             profile: profile_name.into(),
             binary_path: PathBuf::new(),
@@ -63,7 +63,6 @@ pub(in super::super) async fn seed_idle_pool_with_overrides(
         })
         .await
         .expect("create factory");
-    factory.startup().await.expect("startup");
     let factory_arc: Arc<Box<dyn sandbox::SandboxFactory>> = Arc::new(factory);
     let sandbox_id = SandboxId::new_v4();
     let sandbox = factory_arc

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -1558,10 +1558,6 @@ mod tests {
             "destroy-panic".into()
         }
 
-        async fn startup(&mut self) -> sandbox::Result<()> {
-            self.inner.startup().await
-        }
-
         async fn create(&self, config: SandboxConfig) -> sandbox::Result<Box<dyn Sandbox>> {
             self.inner.create(config).await
         }
@@ -2992,8 +2988,7 @@ mod tests {
     async fn execute_inner_happy_path() {
         let dir = tempfile::tempdir().unwrap();
         let config = test_executor_config(dir.path()).await;
-        let mut factory = MockSandboxFactory::new();
-        factory.startup().await.unwrap();
+        let factory = MockSandboxFactory::new();
 
         let (exit_code, error_msg) =
             run_execute_inner(&factory, &minimal_context(), &config, &default_params())
@@ -3008,8 +3003,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let config = test_executor_config(dir.path()).await;
         let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
-        let mut factory = sandbox_mock::MockSandboxFactory::with_overrides(overrides.clone());
-        factory.startup().await.unwrap();
+        let factory = sandbox_mock::MockSandboxFactory::with_overrides(overrides.clone());
 
         let (exit_code, error_msg) =
             run_execute_inner(&factory, &minimal_context(), &config, &default_params())
@@ -3028,8 +3022,7 @@ mod tests {
     async fn execute_inner_with_snapshot_runs_clock_fix_and_reseed() {
         let dir = tempfile::tempdir().unwrap();
         let config = test_executor_config(dir.path()).await;
-        let mut factory = MockSandboxFactory::new();
-        factory.startup().await.unwrap();
+        let factory = MockSandboxFactory::new();
 
         let params = JobParams {
             restore_guest_state: true,
@@ -3045,8 +3038,7 @@ mod tests {
     async fn execute_inner_with_storage_manifest() {
         let dir = tempfile::tempdir().unwrap();
         let config = test_executor_config(dir.path()).await;
-        let mut factory = MockSandboxFactory::new();
-        factory.startup().await.unwrap();
+        let factory = MockSandboxFactory::new();
 
         let mut ctx = minimal_context();
         ctx.storage_manifest = Some(StorageManifest {
@@ -3068,8 +3060,7 @@ mod tests {
     async fn execute_inner_with_resume_session() {
         let dir = tempfile::tempdir().unwrap();
         let config = test_executor_config(dir.path()).await;
-        let mut factory = MockSandboxFactory::new();
-        factory.startup().await.unwrap();
+        let factory = MockSandboxFactory::new();
 
         let mut ctx = minimal_context();
         ctx.resume_session = Some(ResumeSession {
@@ -3086,8 +3077,7 @@ mod tests {
     async fn execute_inner_create_failure_returns_error() {
         let dir = tempfile::tempdir().unwrap();
         let config = test_executor_config(dir.path()).await;
-        let mut factory = MockSandboxFactory::new();
-        factory.startup().await.unwrap();
+        let factory = MockSandboxFactory::new();
         factory.push_create_result(Err(sandbox_create_error("no free devices")));
 
         let err = run_execute_inner(&factory, &minimal_context(), &config, &default_params())
@@ -3107,8 +3097,7 @@ mod tests {
         let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::with_wait_exit_error(
             "wait timeout",
         ));
-        let mut factory = sandbox_mock::MockSandboxFactory::with_overrides(overrides);
-        factory.startup().await.unwrap();
+        let factory = sandbox_mock::MockSandboxFactory::with_overrides(overrides);
 
         let (exit_code, error) =
             run_execute_inner(&factory, &minimal_context(), &config, &default_params())
@@ -3127,10 +3116,9 @@ mod tests {
         overrides.push_start_result(Err(SandboxError::Start {
             message: "boot failed".into(),
         }));
-        let mut factory = DestroyPanicFactory {
+        let factory = DestroyPanicFactory {
             inner: MockSandboxFactory::with_overrides(overrides),
         };
-        factory.startup().await.unwrap();
 
         let ctx = minimal_context();
         let mut telemetry = test_telemetry(&config, &ctx);
@@ -3158,8 +3146,7 @@ mod tests {
     async fn execute_job_wraps_execute_inner() {
         let dir = tempfile::tempdir().unwrap();
         let config = test_executor_config(dir.path()).await;
-        let mut factory = MockSandboxFactory::new();
-        factory.startup().await.unwrap();
+        let factory = MockSandboxFactory::new();
 
         let cancel = tokio_util::sync::CancellationToken::new();
         let (outcome, _telemetry) = execute_job(
@@ -3183,8 +3170,7 @@ mod tests {
     async fn execute_job_create_failure_returns_exit_1() {
         let dir = tempfile::tempdir().unwrap();
         let config = test_executor_config(dir.path()).await;
-        let mut factory = MockSandboxFactory::new();
-        factory.startup().await.unwrap();
+        let factory = MockSandboxFactory::new();
         factory.push_create_result(Err(sandbox_create_error("boom")));
 
         let cancel = tokio_util::sync::CancellationToken::new();
@@ -3213,8 +3199,7 @@ mod tests {
     async fn execute_job_reuse_succeeds() {
         let dir = tempfile::tempdir().unwrap();
         let config = test_executor_config(dir.path()).await;
-        let mut factory = MockSandboxFactory::new();
-        factory.startup().await.unwrap();
+        let factory = MockSandboxFactory::new();
 
         // First: create a sandbox via normal execute_job
         let cancel = tokio_util::sync::CancellationToken::new();
@@ -3248,8 +3233,7 @@ mod tests {
     async fn execute_job_reuse_with_session_context() {
         let dir = tempfile::tempdir().unwrap();
         let config = test_executor_config(dir.path()).await;
-        let mut factory = MockSandboxFactory::new();
-        factory.startup().await.unwrap();
+        let factory = MockSandboxFactory::new();
 
         // First turn: execute with resume_session
         let mut ctx = minimal_context();
@@ -3302,8 +3286,7 @@ mod tests {
 
         let dir = tempfile::tempdir().unwrap();
         let config = test_executor_config(dir.path()).await;
-        let mut factory = MockSandboxFactory::new();
-        factory.startup().await.unwrap();
+        let factory = MockSandboxFactory::new();
 
         // Execute first job
         let cancel = tokio_util::sync::CancellationToken::new();
@@ -3482,8 +3465,7 @@ mod tests {
     async fn execute_job_nonzero_exit_still_returns_sandbox() {
         let dir = tempfile::tempdir().unwrap();
         let config = test_executor_config(dir.path()).await;
-        let mut factory = MockSandboxFactory::new();
-        factory.startup().await.unwrap();
+        let factory = MockSandboxFactory::new();
 
         let cancel = tokio_util::sync::CancellationToken::new();
         let (outcome, _telemetry) = execute_job(
@@ -3904,8 +3886,7 @@ mod tests {
     async fn execute_job_records_sandbox_reuse_miss_in_telemetry() {
         let dir = tempfile::tempdir().unwrap();
         let config = test_executor_config(dir.path()).await;
-        let mut factory = MockSandboxFactory::new();
-        factory.startup().await.unwrap();
+        let factory = MockSandboxFactory::new();
 
         let cancel = tokio_util::sync::CancellationToken::new();
         let (_outcome, telemetry) = execute_job(
@@ -3934,8 +3915,7 @@ mod tests {
     async fn execute_job_reuse_records_sandbox_reuse_hit_in_telemetry() {
         let dir = tempfile::tempdir().unwrap();
         let config = test_executor_config(dir.path()).await;
-        let mut factory = MockSandboxFactory::new();
-        factory.startup().await.unwrap();
+        let factory = MockSandboxFactory::new();
 
         let cancel = tokio_util::sync::CancellationToken::new();
         let (outcome, _telemetry) = execute_job(

--- a/crates/sandbox-fc/src/factory/mod.rs
+++ b/crates/sandbox-fc/src/factory/mod.rs
@@ -188,6 +188,25 @@ impl FirecrackerFactory {
                 message: "factory shut down".into(),
             })
     }
+
+    fn netns_pool_for_destroy(&self, sandbox_id: &str) -> Option<NetnsPoolHandle> {
+        match self.resources.as_ref() {
+            Some(resources) => Some(resources.netns_pool.clone()),
+            None => match self.shutdown_netns_pool.clone() {
+                Some(netns_pool) => {
+                    warn!(
+                        id = %sandbox_id,
+                        "destroy called after factory shutdown; running best-effort cleanup"
+                    );
+                    Some(netns_pool)
+                }
+                None => {
+                    warn!(id = %sandbox_id, "destroy called after factory shutdown");
+                    None
+                }
+            },
+        }
+    }
 }
 
 #[async_trait]
@@ -322,21 +341,8 @@ impl SandboxFactory for FirecrackerFactory {
                 return;
             }
         };
-        let netns_pool = match self.resources.as_ref() {
-            Some(resources) => resources.netns_pool.clone(),
-            None => match self.shutdown_netns_pool.clone() {
-                Some(netns_pool) => {
-                    warn!(
-                        id = %sandbox.id,
-                        "destroy called after factory shutdown; running best-effort cleanup"
-                    );
-                    netns_pool
-                }
-                None => {
-                    warn!(id = %sandbox.id, "destroy called after factory shutdown");
-                    return;
-                }
-            },
+        let Some(netns_pool) = self.netns_pool_for_destroy(&sandbox.id) else {
+            return;
         };
         let sandbox_id = sandbox.id.clone();
 
@@ -603,6 +609,47 @@ mod tests {
         };
 
         assert_factory_invalid_state(err, "shutdown");
+    }
+
+    #[tokio::test]
+    async fn create_rejects_factory_after_shutdown_even_with_retained_destroy_pool() {
+        let mut factory = test_factory_with_resources(
+            NetnsPoolHandle::new_for_test(NetnsPool::inactive_for_test()),
+            NetnsPoolOwnership::Shared,
+            test_leak_cleaner(),
+        );
+        factory.shutdown().await;
+
+        let config = sandbox::SandboxConfig {
+            id: sandbox::SandboxId::new_v4(),
+            resources: sandbox::ResourceLimits {
+                cpu_count: 1,
+                memory_mb: 512,
+            },
+        };
+        let err = match factory.create(config).await {
+            Ok(_) => panic!("create should fail after shutdown"),
+            Err(err) => err,
+        };
+
+        assert_factory_invalid_state(err, "shutdown");
+    }
+
+    #[tokio::test]
+    async fn destroy_uses_retained_netns_pool_after_shutdown() {
+        let pool = NetnsPoolHandle::new_for_test(NetnsPool::inactive_for_test());
+        let mut factory = test_factory_with_resources(
+            pool.clone(),
+            NetnsPoolOwnership::Shared,
+            test_leak_cleaner(),
+        );
+        factory.shutdown().await;
+
+        let selected = factory
+            .netns_pool_for_destroy("sandbox")
+            .expect("shutdown factory should retain destroy netns pool");
+
+        assert_eq!(selected.strong_count_for_test(), 3);
     }
 
     #[tokio::test]

--- a/crates/sandbox-fc/src/factory/mod.rs
+++ b/crates/sandbox-fc/src/factory/mod.rs
@@ -470,13 +470,13 @@ mod tests {
     use super::*;
     use crate::factory::leak_cleaner::LeakCleaner;
     use crate::leaked_resources::LeakedResources;
-    use crate::network::NetnsPool;
+    use crate::network::{NetnsLease, NetnsPool};
     use std::path::PathBuf;
     use std::sync::{Arc, Mutex};
 
     #[tokio::test]
     async fn shutdown_cleans_owned_netns_pool_with_extra_arc_refs() {
-        let pool = NetnsPoolHandle::new_for_test(NetnsPool::inactive_for_test());
+        let (pool, mut lease) = test_pool_with_lease("owned-test-ns");
         let _destroy_task_clone = pool.clone();
         let mut factory = test_factory_with_resources(
             pool.clone(),
@@ -487,13 +487,17 @@ mod tests {
         factory.shutdown().await;
 
         assert!(factory.resources.is_none());
-        assert!(factory.shutdown_netns_pool.is_some());
-        assert_eq!(pool.strong_count_for_test(), 3);
+        let retained = factory
+            .shutdown_netns_pool
+            .as_ref()
+            .expect("shutdown factory should retain netns release authority");
+        let _ = retained.release(&mut lease).await;
+        assert!(lease.is_none());
     }
 
     #[tokio::test]
     async fn shutdown_keeps_shared_netns_pool_for_runtime_shutdown() {
-        let pool = NetnsPoolHandle::new_for_test(NetnsPool::inactive_for_test());
+        let (pool, mut lease) = test_pool_with_lease("shared-test-ns");
         let mut factory = test_factory_with_resources(
             pool.clone(),
             NetnsPoolOwnership::Shared,
@@ -504,7 +508,8 @@ mod tests {
 
         assert!(factory.resources.is_none());
         assert!(factory.shutdown_netns_pool.is_some());
-        assert_eq!(pool.strong_count_for_test(), 2);
+        let _ = pool.release(&mut lease).await;
+        assert!(lease.is_none());
     }
 
     fn test_config(base_dir: PathBuf) -> FirecrackerConfig {
@@ -532,6 +537,13 @@ mod tests {
             resources: None,
             shutdown_netns_pool: None,
         }
+    }
+
+    fn test_pool_with_lease(name: &str) -> (NetnsPoolHandle, Option<NetnsLease>) {
+        let mut raw_pool = NetnsPool::inactive_for_test();
+        let lease = Some(raw_pool.lease_for_test(name));
+        raw_pool.track_lease_for_test(lease.as_ref().unwrap());
+        (NetnsPoolHandle::new_for_test(raw_pool), lease)
     }
 
     fn test_factory_with_resources(
@@ -659,10 +671,7 @@ mod tests {
 
     #[tokio::test]
     async fn destroy_uses_retained_netns_pool_after_shutdown() {
-        let mut raw_pool = NetnsPool::inactive_for_test();
-        let mut lease = Some(raw_pool.lease_for_test("test-ns"));
-        raw_pool.track_lease_for_test(lease.as_ref().unwrap());
-        let pool = NetnsPoolHandle::new_for_test(raw_pool);
+        let (pool, mut lease) = test_pool_with_lease("test-ns");
         let mut factory = test_factory_with_resources(
             pool.clone(),
             NetnsPoolOwnership::Shared,

--- a/crates/sandbox-fc/src/factory/mod.rs
+++ b/crates/sandbox-fc/src/factory/mod.rs
@@ -604,7 +604,7 @@ mod tests {
         };
 
         let err = match factory.create(config).await {
-            Ok(_) => panic!("create should fail before startup"),
+            Ok(_) => panic!("create should fail without factory resources"),
             Err(err) => err,
         };
 

--- a/crates/sandbox-fc/src/factory/mod.rs
+++ b/crates/sandbox-fc/src/factory/mod.rs
@@ -312,17 +312,17 @@ impl SandboxFactory for FirecrackerFactory {
     }
 
     async fn destroy(&self, sandbox: Box<dyn Sandbox>) {
-        let resources = match self.resources() {
-            Ok(resources) => resources,
-            Err(err) => {
-                warn!(error = %err, "destroy called after factory shutdown");
-                return;
-            }
-        };
         let sandbox = match (sandbox as Box<dyn std::any::Any>).downcast::<FirecrackerSandbox>() {
             Ok(s) => *s,
             Err(_) => {
                 warn!("destroy called with non-firecracker sandbox, ignoring");
+                return;
+            }
+        };
+        let resources = match self.resources() {
+            Ok(resources) => resources,
+            Err(err) => {
+                warn!(id = %sandbox.id, error = %err, "destroy called after factory shutdown");
                 return;
             }
         };

--- a/crates/sandbox-fc/src/factory/mod.rs
+++ b/crates/sandbox-fc/src/factory/mod.rs
@@ -4,6 +4,8 @@ mod create_transaction;
 mod invariant;
 mod leak_cleaner;
 
+use std::path::PathBuf;
+
 use async_trait::async_trait;
 use sandbox::{
     Sandbox, SandboxConfig, SandboxError, SandboxFactory, SandboxInitializationPhase,
@@ -32,28 +34,39 @@ pub(crate) struct FirecrackerFactory {
     config: FirecrackerConfig,
     factory_paths: FactoryPaths,
     runtime_paths: RuntimePaths,
-    netns_pool: Option<NetnsPoolHandle>,
-    owns_netns_pool: bool,
     /// Shared NBD device pool for pre-validated device indices.
     device_pool: nbd_cow::pool::DevicePoolHandle,
-    /// Base image path and size (bytes), populated during startup.
-    base_image_path: Option<std::path::PathBuf>,
-    base_image_size: u64,
-    /// Bounded producer for one-shot COW slots.
-    cow_pool: Option<crate::cow_pool::CowPoolHandle>,
-    started: bool,
     cleanup_group: FactoryCleanupGroup,
+    resources: Option<StartedFactoryResources>,
+}
+
+struct StartedFactoryResources {
+    netns_pool: NetnsPoolHandle,
+    netns_ownership: NetnsPoolOwnership,
+    base_image: BaseImageInfo,
+    /// Bounded producer for one-shot COW slots.
+    cow_pool: crate::cow_pool::CowPoolHandle,
     /// Owns the channel/task that drains leaked sandbox resources from Drop.
-    leak_cleaner: Option<LeakCleaner>,
+    leak_cleaner: LeakCleaner,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum NetnsPoolOwnership {
+    Owned,
+    Shared,
+}
+
+struct BaseImageInfo {
+    path: PathBuf,
+    size: u64,
 }
 
 impl FirecrackerFactory {
-    /// Create a new factory without allocating system resources.
-    /// Call `startup()` to initialize pools before use.
+    /// Create a fully initialized factory.
     ///
     /// When `netns_pool` is provided, the factory shares it instead of
-    /// creating a new one in `startup()` (used for multi-profile runners).
-    pub(crate) async fn new(
+    /// creating a new one (used for multi-profile runners).
+    pub(crate) async fn start(
         config: FirecrackerConfig,
         netns_pool: Option<NetnsPoolHandle>,
         device_pool: nbd_cow::pool::DevicePoolHandle,
@@ -77,36 +90,100 @@ impl FirecrackerFactory {
 
         let factory_paths = FactoryPaths::new(config.base_dir.clone());
         let runtime_paths = RuntimePaths::new();
-        let owns_netns_pool = netns_pool.is_none();
+        let (netns_pool, netns_ownership) = match netns_pool {
+            Some(netns_pool) => (netns_pool, NetnsPoolOwnership::Shared),
+            None => {
+                let t = std::time::Instant::now();
+                let netns_config = NetnsPoolConfig {
+                    proxy_port: config.proxy_port,
+                    dns_port: config.dns_port,
+                }
+                .into_checked()?;
+                let netns_pool = NetnsPoolHandle::create_checked(netns_config)
+                    .await
+                    .map_err(|e| SandboxError::Initialization {
+                        phase: SandboxInitializationPhase::Factory,
+                        message: format!("netns pool: {e}"),
+                    })?;
+                info!(
+                    elapsed_ms = t.elapsed().as_millis() as u64,
+                    "netns pool created"
+                );
+                (netns_pool, NetnsPoolOwnership::Owned)
+            }
+        };
+
+        let rootfs = config.rootfs_path.clone();
+        let base_size = match tokio::fs::metadata(&rootfs).await {
+            Ok(metadata) => metadata.len(),
+            Err(error) => {
+                if netns_ownership == NetnsPoolOwnership::Owned
+                    && let Err(cleanup_error) = netns_pool.cleanup().await
+                {
+                    warn!(
+                        error = %cleanup_error,
+                        "failed to cleanup owned netns pool after factory startup failure"
+                    );
+                }
+                return Err(SandboxError::Initialization {
+                    phase: SandboxInitializationPhase::Factory,
+                    message: format!("base image metadata: {error}"),
+                });
+            }
+        };
+
+        info!(
+            rootfs = %rootfs.display(),
+            base_size,
+            "base image size determined"
+        );
+
+        let cow_pool_config = crate::cow_pool::CowPoolConfig {
+            workspaces_dir: factory_paths.workspaces(),
+            base_size,
+            golden_cow: config.snapshot.as_ref().map(|s| s.cow_path.clone()),
+        };
+        let cow_pool = crate::cow_pool::CowPoolHandle::new(cow_pool_config);
+        cow_pool.warmup().await;
+
+        let leak_cleaner = LeakCleaner::spawn(netns_pool.clone());
+        let cleanup_group = FactoryCleanupGroup::new();
+        cleanup_group.start_accepting();
+
+        let mode = if config.snapshot.is_some() {
+            "snapshot"
+        } else {
+            "fresh"
+        };
+        info!(mode, "factory started");
 
         Ok(Self {
             config,
             factory_paths,
             runtime_paths,
-            netns_pool,
-            owns_netns_pool,
             device_pool,
-            base_image_path: None,
-            base_image_size: 0,
-            cow_pool: None,
-            started: false,
-            cleanup_group: FactoryCleanupGroup::new(),
-            leak_cleaner: None,
+            cleanup_group,
+            resources: Some(StartedFactoryResources {
+                netns_pool,
+                netns_ownership,
+                base_image: BaseImageInfo {
+                    path: rootfs,
+                    size: base_size,
+                },
+                cow_pool,
+                leak_cleaner,
+            }),
         })
     }
 
-    /// # Panics
-    /// Panics if called before `startup()` — this is a programming error.
-    #[allow(clippy::expect_used)]
-    fn netns_pool(&self) -> &NetnsPoolHandle {
-        self.netns_pool.as_ref().expect("factory not started")
-    }
-
-    /// # Panics
-    /// Panics if called before `startup()` — this is a programming error.
-    #[allow(clippy::expect_used)]
-    fn cow_pool(&self) -> &crate::cow_pool::CowPoolHandle {
-        self.cow_pool.as_ref().expect("factory not started")
+    fn resources(&self) -> sandbox::Result<&StartedFactoryResources> {
+        self.resources
+            .as_ref()
+            .ok_or_else(|| SandboxError::InvalidState {
+                context: SandboxInvalidStateContext::Factory,
+                state: "shutdown".into(),
+                message: "factory shut down".into(),
+            })
     }
 }
 
@@ -120,114 +197,26 @@ impl SandboxFactory for FirecrackerFactory {
         config_hash()
     }
 
-    async fn startup(&mut self) -> sandbox::Result<()> {
-        if self.started {
-            return Err(SandboxError::InvalidState {
-                context: SandboxInvalidStateContext::Factory,
-                state: "started".into(),
-                message: "factory already started".into(),
-            });
-        }
-        self.cleanup_group.start_accepting();
-
-        // Create netns pool only if not provided externally (shared pool case).
-        if self.netns_pool.is_none() {
-            self.owns_netns_pool = true;
-            let t = std::time::Instant::now();
-            let netns_config = NetnsPoolConfig {
-                proxy_port: self.config.proxy_port,
-                dns_port: self.config.dns_port,
-            }
-            .into_checked()?;
-            let netns_pool = NetnsPoolHandle::create_checked(netns_config)
-                .await
-                .map_err(|e| SandboxError::Initialization {
-                    phase: SandboxInitializationPhase::Factory,
-                    message: format!("netns pool: {e}"),
-                })?;
-            info!(
-                elapsed_ms = t.elapsed().as_millis() as u64,
-                "netns pool created"
-            );
-            self.netns_pool = Some(netns_pool);
-        }
-
-        // Determine base image size from file metadata.
-        let rootfs = &self.config.rootfs_path;
-        let base_size = tokio::fs::metadata(rootfs)
-            .await
-            .map_err(|e| SandboxError::Initialization {
-                phase: SandboxInitializationPhase::Factory,
-                message: format!("base image metadata: {e}"),
-            })?
-            .len();
-
-        info!(
-            rootfs = %rootfs.display(),
-            base_size,
-            "base image size determined"
-        );
-
-        self.base_image_path = Some(rootfs.clone());
-        self.base_image_size = base_size;
-
-        // Initialize COW pool with base image info.
-        let cow_pool_config = crate::cow_pool::CowPoolConfig {
-            workspaces_dir: self.factory_paths.workspaces(),
-            base_size,
-            golden_cow: self.config.snapshot.as_ref().map(|s| s.cow_path.clone()),
-        };
-        let cow_pool = crate::cow_pool::CowPoolHandle::new(cow_pool_config);
-        cow_pool.warmup().await;
-        self.cow_pool = Some(cow_pool);
-
-        // Spawn background task to clean up resources leaked by sandbox Drop
-        // impls that fire without going through factory.destroy().
-        self.leak_cleaner = Some(LeakCleaner::spawn(self.netns_pool().clone()));
-
-        self.started = true;
-
-        let mode = if self.config.snapshot.is_some() {
-            "snapshot"
-        } else {
-            "fresh"
-        };
-        info!(mode, "factory started");
-
-        Ok(())
-    }
-
     async fn create(&self, config: SandboxConfig) -> sandbox::Result<Box<dyn Sandbox>> {
-        if !self.started {
-            return Err(SandboxError::InvalidState {
-                context: SandboxInvalidStateContext::Factory,
-                state: "not started".into(),
-                message: "factory not started".into(),
-            });
-        }
-
+        let resources = self.resources()?;
+        let leak_tx = resources.leak_cleaner.sender();
         let id = config.id.to_string();
         let rollback_cleanup = FactoryCreateRollbackCleanup {
             id: id.clone(),
-            netns_pool: self.netns_pool().clone(),
+            netns_pool: resources.netns_pool.clone(),
         };
-        let mut tx = SandboxCreateTransaction::new_with_leak_tx(
-            id.clone(),
-            self.leak_cleaner.as_ref().and_then(LeakCleaner::sender),
-        );
+        let mut tx = SandboxCreateTransaction::new_with_leak_tx(id.clone(), leak_tx.clone());
 
         let create_result: sandbox::Result<SandboxCreateResources> =
             async {
                 // Acquire a pre-warmed COW slot from the pool.
                 // The slot provides: workspace dir (already created) and cow file.
-                let slot =
-                    self.cow_pool()
-                        .acquire()
-                        .await
-                        .map_err(|e| SandboxError::Initialization {
-                            phase: SandboxInitializationPhase::SandboxAllocation,
-                            message: format!("acquire COW slot: {e}"),
-                        })?;
+                let slot = resources.cow_pool.acquire().await.map_err(|e| {
+                    SandboxError::Initialization {
+                        phase: SandboxInitializationPhase::SandboxAllocation,
+                        message: format!("acquire COW slot: {e}"),
+                    }
+                })?;
                 tx.track_slot(slot);
 
                 // The slot workspace is {workspaces_dir}/{slot_uuid}/.
@@ -266,7 +255,7 @@ impl SandboxFactory for FirecrackerFactory {
                 }
 
                 // Acquire a network namespace from the pool.
-                let network = self.netns_pool().acquire().await.map_err(|e| {
+                let network = resources.netns_pool.acquire().await.map_err(|e| {
                     SandboxError::Initialization {
                         phase: SandboxInitializationPhase::SandboxAllocation,
                         message: format!("acquire netns: {e}"),
@@ -275,17 +264,13 @@ impl SandboxFactory for FirecrackerFactory {
                 tx.track_network(network);
 
                 // Create NBD COW device (~15ms via netlink, no subprocess).
-                let base_image =
-                    self.base_image_path
-                        .as_ref()
-                        .ok_or_else(|| SandboxError::InvalidState {
-                            context: SandboxInvalidStateContext::Factory,
-                            state: "started without base image".into(),
-                            message: "factory base image path missing".into(),
-                        })?;
                 let cow_device = self
                     .device_pool
-                    .create_cow_device(base_image, &cow_file, self.base_image_size)
+                    .create_cow_device(
+                        &resources.base_image.path,
+                        &cow_file,
+                        resources.base_image.size,
+                    )
                     .await
                     .map_err(|e| SandboxError::Initialization {
                         phase: SandboxInitializationPhase::SandboxAllocation,
@@ -320,13 +305,20 @@ impl SandboxFactory for FirecrackerFactory {
             sock_paths,
             network,
             cow_device,
-            self.leak_cleaner.as_ref().and_then(LeakCleaner::sender),
+            leak_tx,
         );
 
         Ok(Box::new(sandbox))
     }
 
     async fn destroy(&self, sandbox: Box<dyn Sandbox>) {
+        let resources = match self.resources() {
+            Ok(resources) => resources,
+            Err(err) => {
+                warn!(error = %err, "destroy called after factory shutdown");
+                return;
+            }
+        };
         let sandbox = match (sandbox as Box<dyn std::any::Any>).downcast::<FirecrackerSandbox>() {
             Ok(s) => *s,
             Err(_) => {
@@ -334,7 +326,7 @@ impl SandboxFactory for FirecrackerFactory {
                 return;
             }
         };
-        let netns_pool = self.netns_pool().clone();
+        let netns_pool = resources.netns_pool.clone();
         let sandbox_id = sandbox.id.clone();
 
         // Move all cleanup-owned resources into a task before the first await.
@@ -352,30 +344,34 @@ impl SandboxFactory for FirecrackerFactory {
     async fn shutdown(&mut self) {
         self.cleanup_group.shutdown().await;
 
+        let Some(resources) = self.resources.take() else {
+            info!("factory shutdown complete");
+            return;
+        };
+        let StartedFactoryResources {
+            netns_pool,
+            netns_ownership,
+            cow_pool,
+            leak_cleaner,
+            ..
+        } = resources;
+
         // Close the leak channel and let the drain task finish queued cleanup
         // before we unwrap the shared pool Arcs below.
-        if let Some(cleaner) = self.leak_cleaner.take() {
-            cleaner.shutdown().await;
-        }
+        leak_cleaner.shutdown().await;
 
         // Clean up COW pool (delete pre-warmed COW files).
-        if let Some(pool) = self.cow_pool.take() {
-            pool.cleanup().await;
-        }
-
-        self.base_image_path = None;
+        cow_pool.cleanup().await;
 
         // Direct factories own their netns pool and must clean it up even when
         // detached destroy tasks still hold Arc clones. Shared runtime pools are
         // cleaned up by FirecrackerRuntime::shutdown().
-        if self.owns_netns_pool
-            && let Some(netns_pool) = self.netns_pool.take()
+        if netns_ownership == NetnsPoolOwnership::Owned
             && let Err(e) = netns_pool.cleanup().await
         {
             warn!(error = %e, "failed to cleanup owned netns pool");
         }
 
-        self.started = false;
         info!("factory shutdown complete");
     }
 }
@@ -447,7 +443,7 @@ async fn destroy_firecracker_sandbox(mut sandbox: FirecrackerSandbox, netns_pool
 impl Drop for FirecrackerFactory {
     fn drop(&mut self) {
         // Safety net for abnormal paths (e.g. panic before shutdown()).
-        self.leak_cleaner.take();
+        self.resources.take();
     }
 }
 
@@ -464,29 +460,31 @@ mod tests {
     async fn shutdown_cleans_owned_netns_pool_with_extra_arc_refs() {
         let pool = NetnsPoolHandle::new_for_test(NetnsPool::inactive_for_test());
         let _destroy_task_clone = pool.clone();
-        let mut factory = test_factory(true);
-        factory.netns_pool = Some(pool);
-        factory.owns_netns_pool = true;
+        let mut factory = test_factory_with_resources(
+            pool.clone(),
+            NetnsPoolOwnership::Owned,
+            test_leak_cleaner(),
+        );
 
         factory.shutdown().await;
 
-        assert!(factory.netns_pool.is_none());
+        assert!(factory.resources.is_none());
+        assert_eq!(pool.strong_count_for_test(), 2);
     }
 
     #[tokio::test]
     async fn shutdown_keeps_shared_netns_pool_for_runtime_shutdown() {
         let pool = NetnsPoolHandle::new_for_test(NetnsPool::inactive_for_test());
-        let mut factory = test_factory(true);
-        factory.netns_pool = Some(pool.clone());
-        factory.owns_netns_pool = false;
+        let mut factory = test_factory_with_resources(
+            pool.clone(),
+            NetnsPoolOwnership::Shared,
+            test_leak_cleaner(),
+        );
 
         factory.shutdown().await;
 
-        assert!(factory.netns_pool.is_some());
-        assert_eq!(
-            factory.netns_pool.as_ref().unwrap().strong_count_for_test(),
-            2
-        );
+        assert!(factory.resources.is_none());
+        assert_eq!(pool.strong_count_for_test(), 1);
     }
 
     fn test_config(base_dir: PathBuf) -> FirecrackerConfig {
@@ -502,56 +500,79 @@ mod tests {
         }
     }
 
-    fn test_factory(started: bool) -> FirecrackerFactory {
+    fn test_factory_without_resources() -> FirecrackerFactory {
         FirecrackerFactory {
             config: test_config(PathBuf::from("/tmp/factory-test-base")),
             factory_paths: FactoryPaths::new(PathBuf::from("/tmp/factory-test")),
             runtime_paths: RuntimePaths::new(),
-            netns_pool: None,
-            owns_netns_pool: true,
             device_pool: nbd_cow::pool::DevicePoolHandle::new(
                 nbd_cow::pool::DevicePoolConfig::default(),
             ),
-            base_image_path: None,
-            base_image_size: 0,
-            cow_pool: None,
-            started,
             cleanup_group: FactoryCleanupGroup::new(),
-            leak_cleaner: None,
+            resources: None,
         }
     }
 
-    fn assert_factory_invalid_state(
-        err: SandboxError,
-        expected_state: &str,
-        expected_message: &str,
-    ) {
+    fn test_factory_with_resources(
+        netns_pool: NetnsPoolHandle,
+        netns_ownership: NetnsPoolOwnership,
+        leak_cleaner: LeakCleaner,
+    ) -> FirecrackerFactory {
+        let factory_paths = FactoryPaths::new(PathBuf::from("/tmp/factory-test"));
+        let cow_pool = crate::cow_pool::CowPoolHandle::new(crate::cow_pool::CowPoolConfig {
+            workspaces_dir: factory_paths.workspaces(),
+            base_size: 0,
+            golden_cow: None,
+        });
+        let cleanup_group = FactoryCleanupGroup::new();
+        cleanup_group.start_accepting();
+        FirecrackerFactory {
+            config: test_config(PathBuf::from("/tmp/factory-test-base")),
+            factory_paths,
+            runtime_paths: RuntimePaths::new(),
+            device_pool: nbd_cow::pool::DevicePoolHandle::new(
+                nbd_cow::pool::DevicePoolConfig::default(),
+            ),
+            cleanup_group,
+            resources: Some(StartedFactoryResources {
+                netns_pool,
+                netns_ownership,
+                base_image: BaseImageInfo {
+                    path: PathBuf::from("/tmp/rootfs.ext4"),
+                    size: 0,
+                },
+                cow_pool,
+                leak_cleaner,
+            }),
+        }
+    }
+
+    fn test_leak_cleaner() -> LeakCleaner {
+        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel::<LeakedResources>();
+        let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
+        let handle = tokio::spawn(async move {
+            let _ = shutdown_rx.await;
+        });
+        LeakCleaner::from_parts_for_test(tx, shutdown_tx, handle)
+    }
+
+    fn assert_factory_invalid_state(err: SandboxError, expected_state: &str) {
         match err {
             SandboxError::InvalidState {
                 context,
                 state,
-                message,
+                message: _,
             } => {
                 assert_eq!(context, SandboxInvalidStateContext::Factory);
                 assert_eq!(state, expected_state);
-                assert_eq!(message, expected_message);
             }
             other => panic!("expected factory invalid-state error, got {other:?}"),
         }
     }
 
     #[tokio::test]
-    async fn startup_rejects_already_started_factory() {
-        let mut factory = test_factory(true);
-
-        let err = factory.startup().await.unwrap_err();
-
-        assert_factory_invalid_state(err, "started", "factory already started");
-    }
-
-    #[tokio::test]
-    async fn create_rejects_not_started_factory() {
-        let factory = test_factory(false);
+    async fn create_rejects_shutdown_factory() {
+        let factory = test_factory_without_resources();
         let config = sandbox::SandboxConfig {
             id: sandbox::SandboxId::new_v4(),
             resources: sandbox::ResourceLimits {
@@ -565,7 +586,7 @@ mod tests {
             Err(err) => err,
         };
 
-        assert_factory_invalid_state(err, "not started", "factory not started");
+        assert_factory_invalid_state(err, "shutdown");
     }
 
     #[tokio::test]
@@ -573,15 +594,17 @@ mod tests {
         let events = Arc::new(Mutex::new(Vec::new()));
         let cleanup_events = Arc::clone(&events);
         let leak_events = Arc::clone(&events);
-        let mut factory = test_factory(true);
-
         let (tx, _rx) = tokio::sync::mpsc::unbounded_channel::<LeakedResources>();
         let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
         let handle = tokio::spawn(async move {
             let _ = shutdown_rx.await;
             leak_events.lock().unwrap().push("leak_cleaner");
         });
-        factory.leak_cleaner = Some(LeakCleaner::from_parts_for_test(tx, shutdown_tx, handle));
+        let mut factory = test_factory_with_resources(
+            NetnsPoolHandle::new_for_test(NetnsPool::inactive_for_test()),
+            NetnsPoolOwnership::Owned,
+            LeakCleaner::from_parts_for_test(tx, shutdown_tx, handle),
+        );
 
         let waiter =
             factory

--- a/crates/sandbox-fc/src/factory/mod.rs
+++ b/crates/sandbox-fc/src/factory/mod.rs
@@ -38,6 +38,8 @@ pub(crate) struct FirecrackerFactory {
     device_pool: nbd_cow::pool::DevicePoolHandle,
     cleanup_group: FactoryCleanupGroup,
     resources: Option<StartedFactoryResources>,
+    /// Best-effort release authority for sandboxes destroyed after shutdown.
+    shutdown_netns_pool: Option<NetnsPoolHandle>,
 }
 
 struct StartedFactoryResources {
@@ -173,6 +175,7 @@ impl FirecrackerFactory {
                 cow_pool,
                 leak_cleaner,
             }),
+            shutdown_netns_pool: None,
         })
     }
 
@@ -319,14 +322,22 @@ impl SandboxFactory for FirecrackerFactory {
                 return;
             }
         };
-        let resources = match self.resources() {
-            Ok(resources) => resources,
-            Err(err) => {
-                warn!(id = %sandbox.id, error = %err, "destroy called after factory shutdown");
-                return;
-            }
+        let netns_pool = match self.resources.as_ref() {
+            Some(resources) => resources.netns_pool.clone(),
+            None => match self.shutdown_netns_pool.clone() {
+                Some(netns_pool) => {
+                    warn!(
+                        id = %sandbox.id,
+                        "destroy called after factory shutdown; running best-effort cleanup"
+                    );
+                    netns_pool
+                }
+                None => {
+                    warn!(id = %sandbox.id, "destroy called after factory shutdown");
+                    return;
+                }
+            },
         };
-        let netns_pool = resources.netns_pool.clone();
         let sandbox_id = sandbox.id.clone();
 
         // Move all cleanup-owned resources into a task before the first await.
@@ -355,6 +366,7 @@ impl SandboxFactory for FirecrackerFactory {
             leak_cleaner,
             ..
         } = resources;
+        self.shutdown_netns_pool = Some(netns_pool.clone());
 
         // Close the leak channel and let the drain task finish queued cleanup
         // before we unwrap the shared pool Arcs below.
@@ -469,7 +481,8 @@ mod tests {
         factory.shutdown().await;
 
         assert!(factory.resources.is_none());
-        assert_eq!(pool.strong_count_for_test(), 2);
+        assert!(factory.shutdown_netns_pool.is_some());
+        assert_eq!(pool.strong_count_for_test(), 3);
     }
 
     #[tokio::test]
@@ -484,7 +497,8 @@ mod tests {
         factory.shutdown().await;
 
         assert!(factory.resources.is_none());
-        assert_eq!(pool.strong_count_for_test(), 1);
+        assert!(factory.shutdown_netns_pool.is_some());
+        assert_eq!(pool.strong_count_for_test(), 2);
     }
 
     fn test_config(base_dir: PathBuf) -> FirecrackerConfig {
@@ -510,6 +524,7 @@ mod tests {
             ),
             cleanup_group: FactoryCleanupGroup::new(),
             resources: None,
+            shutdown_netns_pool: None,
         }
     }
 
@@ -544,6 +559,7 @@ mod tests {
                 cow_pool,
                 leak_cleaner,
             }),
+            shutdown_netns_pool: None,
         }
     }
 

--- a/crates/sandbox-fc/src/factory/mod.rs
+++ b/crates/sandbox-fc/src/factory/mod.rs
@@ -612,6 +612,13 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn destroy_without_resources_or_retained_pool_has_no_release_authority() {
+        let factory = test_factory_without_resources();
+
+        assert!(factory.netns_pool_for_destroy("sandbox").is_none());
+    }
+
+    #[tokio::test]
     async fn create_rejects_factory_after_shutdown_even_with_retained_destroy_pool() {
         let mut factory = test_factory_with_resources(
             NetnsPoolHandle::new_for_test(NetnsPool::inactive_for_test()),
@@ -633,6 +640,21 @@ mod tests {
         };
 
         assert_factory_invalid_state(err, "shutdown");
+    }
+
+    #[tokio::test]
+    async fn shutdown_is_idempotent_after_resources_are_taken() {
+        let mut factory = test_factory_with_resources(
+            NetnsPoolHandle::new_for_test(NetnsPool::inactive_for_test()),
+            NetnsPoolOwnership::Shared,
+            test_leak_cleaner(),
+        );
+
+        factory.shutdown().await;
+        factory.shutdown().await;
+
+        assert!(factory.resources.is_none());
+        assert!(factory.shutdown_netns_pool.is_some());
     }
 
     #[tokio::test]

--- a/crates/sandbox-fc/src/factory/mod.rs
+++ b/crates/sandbox-fc/src/factory/mod.rs
@@ -124,7 +124,7 @@ impl FirecrackerFactory {
                 {
                     warn!(
                         error = %cleanup_error,
-                        "failed to cleanup owned netns pool after factory startup failure"
+                        "failed to cleanup owned netns pool after factory initialization failure"
                     );
                 }
                 return Err(SandboxError::Initialization {
@@ -637,7 +637,10 @@ mod tests {
 
     #[tokio::test]
     async fn destroy_uses_retained_netns_pool_after_shutdown() {
-        let pool = NetnsPoolHandle::new_for_test(NetnsPool::inactive_for_test());
+        let mut raw_pool = NetnsPool::inactive_for_test();
+        let mut lease = Some(raw_pool.lease_for_test("test-ns"));
+        raw_pool.track_lease_for_test(lease.as_ref().unwrap());
+        let pool = NetnsPoolHandle::new_for_test(raw_pool);
         let mut factory = test_factory_with_resources(
             pool.clone(),
             NetnsPoolOwnership::Shared,
@@ -649,7 +652,9 @@ mod tests {
             .netns_pool_for_destroy("sandbox")
             .expect("shutdown factory should retain destroy netns pool");
 
-        assert_eq!(selected.strong_count_for_test(), 3);
+        let _ = selected.release(&mut lease).await;
+
+        assert!(lease.is_none());
     }
 
     #[tokio::test]

--- a/crates/sandbox-fc/src/network/pool.rs
+++ b/crates/sandbox-fc/src/network/pool.rs
@@ -1822,11 +1822,6 @@ impl NetnsPoolHandle {
         Self::new(pool)
     }
 
-    #[cfg(test)]
-    pub(crate) fn strong_count_for_test(&self) -> usize {
-        Arc::strong_count(&self.inner)
-    }
-
     pub(crate) async fn acquire(&self) -> Result<NetnsLease> {
         loop {
             let plan = {

--- a/crates/sandbox-fc/src/runtime.rs
+++ b/crates/sandbox-fc/src/runtime.rs
@@ -27,7 +27,7 @@ pub struct FirecrackerRuntime {
 impl FirecrackerRuntime {
     /// Create a new runtime with shared resources.
     ///
-    /// This allocates a network namespace pool and an empty base loop cache.
+    /// This allocates network namespace and NBD device pools.
     /// All factories created via [`SandboxRuntime::create_factory`] share these
     /// resources.
     pub async fn new(config: sandbox::RuntimeConfig) -> Result<Self, SandboxError> {

--- a/crates/sandbox-fc/src/runtime.rs
+++ b/crates/sandbox-fc/src/runtime.rs
@@ -99,13 +99,12 @@ impl SandboxRuntime for FirecrackerRuntime {
         config: FactoryConfig,
     ) -> sandbox::Result<Box<dyn SandboxFactory>> {
         let fc_config = self.to_firecracker_config(config);
-        let mut factory = FirecrackerFactory::new(
+        let factory = FirecrackerFactory::start(
             fc_config,
             Some(self.netns_pool.clone()),
             self.device_pool.clone(),
         )
         .await?;
-        factory.startup().await?;
         Ok(Box::new(factory))
     }
 

--- a/crates/sandbox-mock/src/lib.rs
+++ b/crates/sandbox-mock/src/lib.rs
@@ -983,10 +983,6 @@ impl SandboxFactory for MockSandboxFactory {
         "mock-config-hash".into()
     }
 
-    async fn startup(&mut self) -> Result<()> {
-        Ok(())
-    }
-
     async fn create(&self, config: SandboxConfig) -> Result<Box<dyn Sandbox>> {
         if let Some(result) = self.create_results.lock_ignoring_poison().pop_front() {
             result?;
@@ -1577,8 +1573,7 @@ mod tests {
     #[tokio::test]
     async fn overrides_count_park_and_unpark_calls_across_factory_sandboxes() {
         let overrides = Arc::new(MockSandboxOverrides::new());
-        let mut factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));
-        factory.startup().await.unwrap();
+        let factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));
 
         let mut first = factory.create(test_sandbox_config()).await.unwrap();
         let mut second = factory.create(test_sandbox_config()).await.unwrap();
@@ -1597,8 +1592,7 @@ mod tests {
     #[tokio::test]
     async fn overrides_count_destroy_calls_across_factory_sandboxes() {
         let overrides = Arc::new(MockSandboxOverrides::new());
-        let mut factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));
-        factory.startup().await.unwrap();
+        let factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));
 
         let first = factory.create(test_sandbox_config()).await.unwrap();
         let second = factory.create(test_sandbox_config()).await.unwrap();
@@ -2167,8 +2161,7 @@ mod tests {
     #[tokio::test]
     async fn overrides_record_spawn_watch_output_modes_in_order() {
         let overrides = Arc::new(MockSandboxOverrides::new());
-        let mut factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));
-        factory.startup().await.unwrap();
+        let factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));
         let sandbox = factory.create(test_sandbox_config()).await.unwrap();
         let buffered = sandbox
             .spawn_watch(&SpawnWatchRequest {
@@ -2232,8 +2225,7 @@ mod tests {
     #[tokio::test]
     async fn wait_exit_rejects_consumed_spawn_handle() {
         let runtime = MockSandboxRuntime::new();
-        let mut factory = runtime.create_factory(test_factory_config()).await.unwrap();
-        factory.startup().await.unwrap();
+        let factory = runtime.create_factory(test_factory_config()).await.unwrap();
         let sandbox = factory.create(test_sandbox_config()).await.unwrap();
         let mut handle = sandbox
             .spawn_watch(&SpawnWatchRequest {
@@ -2292,7 +2284,6 @@ mod tests {
     #[tokio::test]
     async fn factory_creates_sandbox() {
         let mut factory = MockSandboxFactory::new();
-        factory.startup().await.unwrap();
         let sandbox = factory.create(test_sandbox_config()).await.unwrap();
         assert!(!sandbox.id().is_empty());
         factory.destroy(sandbox).await;
@@ -2367,8 +2358,7 @@ mod tests {
 
     #[tokio::test]
     async fn factory_create_queued_error() {
-        let mut factory = MockSandboxFactory::new();
-        factory.startup().await.unwrap();
+        let factory = MockSandboxFactory::new();
         factory.push_create_result(Err(SandboxError::Initialization {
             phase: SandboxInitializationPhase::SandboxAllocation,
             message: "out of resources".into(),

--- a/crates/sandbox/src/factory.rs
+++ b/crates/sandbox/src/factory.rs
@@ -14,9 +14,6 @@ pub trait SandboxFactory: Send + Sync {
     /// snapshots.  The hash covers boot args, guest network parameters, and
     /// any other factory-specific settings baked into the snapshot.
     fn config_hash(&self) -> String;
-    /// Initialize factory resources (pools, connections, etc.).
-    /// Must be called before `create()` or `destroy()`.
-    async fn startup(&mut self) -> Result<()>;
     /// Create a new sandbox instance with the given configuration.
     async fn create(&self, config: SandboxConfig) -> Result<Box<dyn Sandbox>>;
     /// Tear down a sandbox, releasing all resources back to the factory pools.

--- a/crates/sandbox/src/runtime.rs
+++ b/crates/sandbox/src/runtime.rs
@@ -45,8 +45,8 @@ pub trait RuntimeProvider: Send + Sync {
     /// backend-specific shared resources while creating the runtime.
     ///
     /// On success, the returned runtime is ready for
-    /// [`SandboxRuntime::create_factory`] calls. This does not create, start, or
-    /// initialize any factory; factory startup remains part of
+    /// [`SandboxRuntime::create_factory`] calls. This does not create or
+    /// initialize any factory; factory initialization remains part of
     /// [`SandboxRuntime::create_factory`].
     ///
     /// The caller owns the returned runtime and is responsible for eventually

--- a/crates/sandbox/src/runtime.rs
+++ b/crates/sandbox/src/runtime.rs
@@ -22,8 +22,7 @@ use crate::factory::SandboxFactory;
 pub trait SandboxRuntime: Send + Sync {
     /// Create a new sandbox factory for the given profile configuration.
     ///
-    /// The returned factory is fully initialized (`startup()` has been called)
-    /// and ready to create sandboxes.
+    /// The returned factory is fully initialized and ready to create sandboxes.
     async fn create_factory(&self, config: FactoryConfig) -> Result<Box<dyn SandboxFactory>>;
 
     /// Release shared resources (network pools, device caches).


### PR DESCRIPTION
## Summary

- remove `SandboxFactory::startup()` so runtime-created factories are ready by construction
- replace FirecrackerFactory's split `started`/resource `Option` fields with a single typed started resource state
- preserve owned/shared netns shutdown behavior and update mocks/tests for the simplified lifecycle

Closes #13280

## Tests

- `cargo test --manifest-path crates/Cargo.toml -p sandbox-fc --lib factory`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox-mock`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox`
- `cargo test --manifest-path crates/Cargo.toml -p runner factory_lifecycle`
- `cargo test --manifest-path crates/Cargo.toml -p runner idle_lifecycle`
- `cargo test --manifest-path crates/Cargo.toml -p runner execute_inner_happy_path`
- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p sandbox -p sandbox-fc -p sandbox-mock -p runner --all-targets --all-features -- -D warnings`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox-fc --lib`
- `cargo test --manifest-path crates/Cargo.toml -p runner execute_job_wraps_execute_inner`
- pre-commit: `cargo-fmt`, `cargo-clippy`, `cargo-doc`