### PR TITLE
refactor(api): migrate cleanup sandboxes cron route

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -21,6 +21,7 @@ import { connectorsTypeAuthorizeRoutes } from "./routes/connectors-type-authoriz
 import { connectorsTypeCallbackRoutes } from "./routes/connectors-type-callback";
 import { cronAggregateInsightsRoutes } from "./routes/cron-aggregate-insights";
 import { cronAggregateUsageRoutes } from "./routes/cron-aggregate-usage";
+import { cronCleanupSandboxesRoutes } from "./routes/cron-cleanup-sandboxes";
 import { cronDrainEmailOutboxRoutes } from "./routes/cron-drain-email-outbox";
 import { cronProcessUsageEventsRoutes } from "./routes/cron-process-usage-events";
 import { cronReconcileBillingEntitlementsRoutes } from "./routes/cron-reconcile-billing-entitlements";
@@ -217,6 +218,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...connectorsTypeCallbackRoutes,
   ...cronAggregateInsightsRoutes,
   ...cronAggregateUsageRoutes,
+  ...cronCleanupSandboxesRoutes,
   ...cronDrainEmailOutboxRoutes,
   ...cronProcessUsageEventsRoutes,
   ...cronReconcileBillingEntitlementsRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-cleanup-sandboxes.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-cleanup-sandboxes.test.ts
@@ -1,0 +1,433 @@
+import { createHash, randomUUID } from "node:crypto";
+
+import { cronCleanupSandboxesContract } from "@vm0/api-contracts/contracts/cron";
+import {
+  agentComposeVersions,
+  agentComposes,
+} from "@vm0/db/schema/agent-compose";
+import { agentRunQueue } from "@vm0/db/schema/agent-run-queue";
+import { agentRuns } from "@vm0/db/schema/agent-run";
+import { agentSessions } from "@vm0/db/schema/agent-session";
+import { exportJobs } from "@vm0/db/schema/export-job";
+import { createStore } from "ccstate";
+import { eq } from "drizzle-orm";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { mockEnv } from "../../../lib/env";
+import { clearMockNow, mockNow } from "../../../lib/time";
+import { writeDb$ } from "../../external/db";
+import { createFixtureTracker } from "./helpers/zero-route-test";
+
+const context = testContext();
+const store = createStore();
+const CRON_SECRET = "test-cron-secret";
+const BUCKET = "test-user-storage-bucket";
+const FIXED_NOW_MS = Date.parse("2000-01-01T00:10:00.000Z");
+
+interface RunFixture {
+  readonly runId: string;
+  readonly sessionId: string;
+  readonly composeId: string;
+  readonly versionId: string;
+}
+
+interface ExportJobFixture {
+  readonly id: string;
+}
+
+function apiClient() {
+  return setupApp({ context })(cronCleanupSandboxesContract);
+}
+
+function cronHeaders(secret = CRON_SECRET) {
+  return { authorization: `Bearer ${secret}` };
+}
+
+function versionId(): string {
+  return createHash("sha256").update(randomUUID()).digest("hex");
+}
+
+function minutesAgo(minutes: number): Date {
+  return new Date(FIXED_NOW_MS - minutes * 60 * 1000);
+}
+
+async function cleanupRunFixture(fixture: RunFixture): Promise<void> {
+  const db = store.set(writeDb$);
+  await db.delete(agentRunQueue).where(eq(agentRunQueue.runId, fixture.runId));
+  await db.delete(agentRuns).where(eq(agentRuns.id, fixture.runId));
+  await db.delete(agentSessions).where(eq(agentSessions.id, fixture.sessionId));
+  await db
+    .delete(agentComposeVersions)
+    .where(eq(agentComposeVersions.id, fixture.versionId));
+  await db.delete(agentComposes).where(eq(agentComposes.id, fixture.composeId));
+}
+
+async function cleanupExportJobFixture(
+  fixture: ExportJobFixture,
+): Promise<void> {
+  const db = store.set(writeDb$);
+  await db.delete(exportJobs).where(eq(exportJobs.id, fixture.id));
+}
+
+async function insertRunFixture(args?: {
+  readonly status?: string;
+  readonly composeName?: string;
+  readonly createdAt?: Date;
+  readonly lastHeartbeatAt?: Date | null;
+}): Promise<RunFixture> {
+  const db = store.set(writeDb$);
+  const userId = `user-${randomUUID()}`;
+  const orgId = `org-${randomUUID()}`;
+  const composeName = args?.composeName ?? `cleanup-${randomUUID()}`;
+  const [compose] = await db
+    .insert(agentComposes)
+    .values({ userId, orgId, name: composeName })
+    .returning({ id: agentComposes.id });
+  if (!compose) {
+    throw new Error("insertRunFixture: compose insert returned no row");
+  }
+
+  const id = versionId();
+  await db.insert(agentComposeVersions).values({
+    id,
+    composeId: compose.id,
+    createdBy: userId,
+    content: { agents: {} },
+  });
+  await db
+    .update(agentComposes)
+    .set({ headVersionId: id })
+    .where(eq(agentComposes.id, compose.id));
+
+  const [session] = await db
+    .insert(agentSessions)
+    .values({
+      userId,
+      orgId,
+      agentComposeId: compose.id,
+      artifacts: [],
+    })
+    .returning({ id: agentSessions.id });
+  if (!session) {
+    throw new Error("insertRunFixture: session insert returned no row");
+  }
+
+  const [run] = await db
+    .insert(agentRuns)
+    .values({
+      userId,
+      orgId,
+      agentComposeVersionId: id,
+      sessionId: session.id,
+      status: args?.status ?? "pending",
+      prompt: "cleanup sandboxes test",
+      sandboxId: `sandbox-${randomUUID()}`,
+      createdAt: args?.createdAt,
+      lastHeartbeatAt: args?.lastHeartbeatAt,
+    })
+    .returning({ id: agentRuns.id });
+  if (!run) {
+    throw new Error("insertRunFixture: run insert returned no row");
+  }
+
+  return {
+    runId: run.id,
+    sessionId: session.id,
+    composeId: compose.id,
+    versionId: id,
+  };
+}
+
+async function insertQueueEntry(
+  fixture: RunFixture,
+  expiresAt: Date,
+): Promise<void> {
+  const db = store.set(writeDb$);
+  const [run] = await db
+    .select({
+      userId: agentRuns.userId,
+      orgId: agentRuns.orgId,
+      createdAt: agentRuns.createdAt,
+    })
+    .from(agentRuns)
+    .where(eq(agentRuns.id, fixture.runId))
+    .limit(1);
+  if (!run) {
+    throw new Error("insertQueueEntry: run not found");
+  }
+
+  await db.insert(agentRunQueue).values({
+    runId: fixture.runId,
+    userId: run.userId,
+    orgId: run.orgId,
+    createdAt: run.createdAt,
+    expiresAt,
+  });
+}
+
+async function insertExportJob(args: {
+  readonly status: string;
+  readonly createdAt?: Date;
+  readonly expiresAt?: Date | null;
+  readonly s3Key?: string | null;
+}): Promise<ExportJobFixture> {
+  const db = store.set(writeDb$);
+  const [job] = await db
+    .insert(exportJobs)
+    .values({
+      userId: `user-${randomUUID()}`,
+      orgId: `org-${randomUUID()}`,
+      status: args.status,
+      createdAt: args.createdAt,
+      expiresAt: args.expiresAt,
+      s3Key: args.s3Key,
+    })
+    .returning({ id: exportJobs.id });
+  if (!job) {
+    throw new Error("insertExportJob: insert returned no row");
+  }
+  return job;
+}
+
+async function findRun(runId: string): Promise<{
+  readonly status: string;
+  readonly error: string | null;
+} | null> {
+  const db = store.set(writeDb$);
+  const [row] = await db
+    .select({ status: agentRuns.status, error: agentRuns.error })
+    .from(agentRuns)
+    .where(eq(agentRuns.id, runId))
+    .limit(1);
+  return row ?? null;
+}
+
+async function findExportJob(jobId: string): Promise<{
+  readonly status: string;
+  readonly error: string | null;
+} | null> {
+  const db = store.set(writeDb$);
+  const [row] = await db
+    .select({ status: exportJobs.status, error: exportJobs.error })
+    .from(exportJobs)
+    .where(eq(exportJobs.id, jobId))
+    .limit(1);
+  return row ?? null;
+}
+
+describe("GET /api/cron/cleanup-sandboxes", () => {
+  const trackRun = createFixtureTracker<RunFixture>(cleanupRunFixture);
+  const trackExportJob = createFixtureTracker<ExportJobFixture>(
+    cleanupExportJobFixture,
+  );
+
+  beforeEach(() => {
+    mockEnv("CRON_SECRET", CRON_SECRET);
+    mockEnv("R2_USER_STORAGES_BUCKET_NAME", BUCKET);
+    mockNow(FIXED_NOW_MS);
+    context.mocks.s3.send.mockReset();
+    context.mocks.s3.send.mockResolvedValue({});
+  });
+
+  afterEach(() => {
+    clearMockNow();
+  });
+
+  it("rejects requests with an invalid cron secret", async () => {
+    const response = await accept(
+      apiClient().cleanup({ headers: cronHeaders("wrong-secret") }),
+      [401],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Invalid cron secret", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("returns the cleanup result shape for an authorized request", async () => {
+    const response = await accept(
+      apiClient().cleanup({ headers: cronHeaders() }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      cleaned: 0,
+      errors: 0,
+      results: [],
+      exportJobsCleaned: 0,
+      exportJobsStuck: 0,
+    });
+  });
+
+  it("does not cleanup a run with a recent heartbeat", async () => {
+    const fixture = await trackRun(
+      insertRunFixture({
+        status: "running",
+        createdAt: minutesAgo(1),
+        lastHeartbeatAt: minutesAgo(1),
+      }),
+    );
+
+    const response = await accept(
+      apiClient().cleanup({ headers: cronHeaders() }),
+      [200],
+    );
+
+    expect(response.body.results).toHaveLength(0);
+    await expect(findRun(fixture.runId)).resolves.toMatchObject({
+      status: "running",
+      error: null,
+    });
+  });
+
+  it("cleans up pending runs after the pending timeout", async () => {
+    const fixture = await trackRun(
+      insertRunFixture({ status: "pending", createdAt: minutesAgo(6) }),
+    );
+
+    const response = await accept(
+      apiClient().cleanup({ headers: cronHeaders() }),
+      [200],
+    );
+
+    expect(response.body.cleaned).toBe(1);
+    expect(response.body.results).toContainEqual(
+      expect.objectContaining({
+        runId: fixture.runId,
+        status: "cleaned",
+        reason: "Run timed out while pending (never started)",
+      }),
+    );
+    await expect(findRun(fixture.runId)).resolves.toMatchObject({
+      status: "timeout",
+      error: "Run timed out while pending (never started)",
+    });
+  });
+
+  it("cleans up running runs after the heartbeat timeout", async () => {
+    const fixture = await trackRun(
+      insertRunFixture({
+        status: "running",
+        createdAt: minutesAgo(1),
+        lastHeartbeatAt: minutesAgo(3),
+      }),
+    );
+
+    const response = await accept(
+      apiClient().cleanup({ headers: cronHeaders() }),
+      [200],
+    );
+
+    expect(response.body.cleaned).toBe(1);
+    expect(response.body.results).toContainEqual(
+      expect.objectContaining({
+        runId: fixture.runId,
+        status: "cleaned",
+        reason: "Run timed out (no heartbeat)",
+      }),
+    );
+    await expect(findRun(fixture.runId)).resolves.toMatchObject({
+      status: "timeout",
+      error: "Run timed out (no heartbeat)",
+    });
+  });
+
+  it("keeps debug compose runs until the debug heartbeat timeout", async () => {
+    const fixture = await trackRun(
+      insertRunFixture({
+        status: "running",
+        composeName: `debug-${randomUUID()}`,
+        createdAt: minutesAgo(1),
+        lastHeartbeatAt: minutesAgo(30),
+      }),
+    );
+
+    const response = await accept(
+      apiClient().cleanup({ headers: cronHeaders() }),
+      [200],
+    );
+
+    expect(response.body.results).toHaveLength(0);
+    await expect(findRun(fixture.runId)).resolves.toMatchObject({
+      status: "running",
+      error: null,
+    });
+  });
+
+  it("times out expired queued runs", async () => {
+    const fixture = await trackRun(
+      insertRunFixture({ status: "queued", createdAt: minutesAgo(130) }),
+    );
+    await insertQueueEntry(fixture, minutesAgo(1));
+
+    const response = await accept(
+      apiClient().cleanup({ headers: cronHeaders() }),
+      [200],
+    );
+
+    expect(response.body.cleaned).toBe(0);
+    await expect(findRun(fixture.runId)).resolves.toMatchObject({
+      status: "timeout",
+      error: "Queued run expired (exceeded queue TTL)",
+    });
+  });
+
+  it("drains queued runs when an org has no active runs", async () => {
+    const fixture = await trackRun(
+      insertRunFixture({ status: "queued", createdAt: minutesAgo(1) }),
+    );
+    await insertQueueEntry(fixture, minutesAgo(-60));
+
+    const response = await accept(
+      apiClient().cleanup({ headers: cronHeaders() }),
+      [200],
+    );
+
+    expect(response.body.cleaned).toBe(0);
+    await expect(findRun(fixture.runId)).resolves.toMatchObject({
+      status: "pending",
+      error: null,
+    });
+  });
+
+  it("cleans expired export jobs and fails stuck export jobs", async () => {
+    const expiredJob = await trackExportJob(
+      insertExportJob({
+        status: "completed",
+        createdAt: minutesAgo(30),
+        expiresAt: minutesAgo(1),
+        s3Key: "exports/expired.zip",
+      }),
+    );
+    const stuckJob = await trackExportJob(
+      insertExportJob({
+        status: "running",
+        createdAt: minutesAgo(11),
+      }),
+    );
+
+    const response = await accept(
+      apiClient().cleanup({ headers: cronHeaders() }),
+      [200],
+    );
+
+    expect(response.body.exportJobsCleaned).toBe(1);
+    expect(response.body.exportJobsStuck).toBe(1);
+    await expect(findExportJob(expiredJob.id)).resolves.toBeNull();
+    await expect(findExportJob(stuckJob.id)).resolves.toStrictEqual({
+      status: "failed",
+      error: "Export job timed out",
+    });
+    expect(context.mocks.s3.send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        input: expect.objectContaining({
+          Bucket: BUCKET,
+          Delete: {
+            Objects: [{ Key: "exports/expired.zip" }],
+          },
+        }),
+      }),
+    );
+  });
+});

--- a/turbo/apps/api/src/signals/routes/cron-cleanup-sandboxes.ts
+++ b/turbo/apps/api/src/signals/routes/cron-cleanup-sandboxes.ts
@@ -1,0 +1,25 @@
+import { cronCleanupSandboxesContract } from "@vm0/api-contracts/contracts/cron";
+import { command } from "ccstate";
+
+import type { RouteEntry } from "../route";
+import { cleanupSandboxes$ } from "../services/cron-cleanup-sandboxes.service";
+import { cronUnauthorized, hasValidCronSecret } from "./cron-auth";
+
+const cleanupSandboxesRoute$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    if (!hasValidCronSecret(get)) {
+      return cronUnauthorized();
+    }
+
+    const body = await set(cleanupSandboxes$, signal);
+    signal.throwIfAborted();
+    return { status: 200 as const, body };
+  },
+);
+
+export const cronCleanupSandboxesRoutes: readonly RouteEntry[] = [
+  {
+    route: cronCleanupSandboxesContract.cleanup,
+    handler: cleanupSandboxesRoute$,
+  },
+];

--- a/turbo/apps/api/src/signals/services/cron-cleanup-sandboxes.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-cleanup-sandboxes.service.ts
@@ -1,0 +1,341 @@
+import { command, type Command, type Computed } from "ccstate";
+import {
+  agentComposeVersions,
+  agentComposes,
+} from "@vm0/db/schema/agent-compose";
+import { agentRuns } from "@vm0/db/schema/agent-run";
+import { exportJobs } from "@vm0/db/schema/export-job";
+import { and, eq, inArray, isNotNull, lt } from "drizzle-orm";
+
+import { env } from "../../lib/env";
+import { logger } from "../../lib/log";
+import { now, nowDate } from "../external/time";
+import { writeDb$, type Db } from "../external/db";
+import { deleteS3Objects } from "../external/s3";
+import { safeAsync } from "../utils";
+import { dispatchCompleteSideEffects$ } from "./agent-webhook-complete.service";
+import {
+  cleanupExpiredQueueEntries$,
+  drainStaleQueues$,
+} from "./zero-run-queue.service";
+
+const L = logger("CronCleanupSandboxes");
+
+const HEARTBEAT_TIMEOUT_MS = 2 * 60 * 1000;
+const DEBUG_HEARTBEAT_TIMEOUT_MS = 60 * 60 * 1000;
+const PENDING_TIMEOUT_MS = 5 * 60 * 1000;
+const DEBUG_COMPOSE_PREFIX = "debug-";
+const EXPORT_JOB_TIMEOUT_MS = 10 * 60 * 1000;
+
+interface CleanupResult {
+  readonly runId: string;
+  readonly sandboxId: string | null;
+  readonly status: "cleaned" | "error";
+  readonly error?: string;
+  readonly reason?: string;
+}
+
+interface CleanupSandboxesResult {
+  readonly cleaned: number;
+  readonly errors: number;
+  readonly results: readonly CleanupResult[];
+  readonly exportJobsCleaned: number;
+  readonly exportJobsStuck: number;
+}
+
+interface StaleRun {
+  readonly id: string;
+  readonly orgId: string;
+  readonly status: string;
+  readonly sandboxId: string | null;
+  readonly lastHeartbeatAt: Date | null;
+  readonly createdAt: Date;
+  readonly composeName: string | null;
+}
+
+type ComputedGetter = <T>(source: Computed<T>) => T;
+type CommandSetter = <T, TArgs extends unknown[]>(
+  command: Command<T, TArgs>,
+  ...args: TArgs
+) => T;
+
+function isExpiredRun(
+  run: StaleRun,
+  cutoffs: {
+    readonly running: Date;
+    readonly debug: Date;
+    readonly pending: Date;
+  },
+): boolean {
+  const referenceTime = run.lastHeartbeatAt ?? run.createdAt;
+  if (run.status === "pending") {
+    return referenceTime < cutoffs.pending;
+  }
+
+  const isDebug = run.composeName?.startsWith(DEBUG_COMPOSE_PREFIX) ?? false;
+  return referenceTime < (isDebug ? cutoffs.debug : cutoffs.running);
+}
+
+async function cleanupExportJobs(
+  get: ComputedGetter,
+  db: Db,
+  signal: AbortSignal,
+): Promise<{
+  readonly exportJobsCleaned: number;
+  readonly exportJobsStuck: number;
+}> {
+  let exportJobsCleaned = 0;
+  let exportJobsStuck = 0;
+  const currentTime = nowDate();
+
+  const expiredExports = await db
+    .select({ id: exportJobs.id, s3Key: exportJobs.s3Key })
+    .from(exportJobs)
+    .where(
+      and(
+        eq(exportJobs.status, "completed"),
+        isNotNull(exportJobs.expiresAt),
+        lt(exportJobs.expiresAt, currentTime),
+      ),
+    );
+  signal.throwIfAborted();
+
+  if (expiredExports.length > 0) {
+    const s3Keys = expiredExports
+      .map((entry) => {
+        return entry.s3Key;
+      })
+      .filter((key): key is string => {
+        return key !== null;
+      });
+    if (s3Keys.length > 0) {
+      await get(deleteS3Objects(env("R2_USER_STORAGES_BUCKET_NAME"), s3Keys));
+      signal.throwIfAborted();
+    }
+
+    await db.delete(exportJobs).where(
+      inArray(
+        exportJobs.id,
+        expiredExports.map((entry) => {
+          return entry.id;
+        }),
+      ),
+    );
+    signal.throwIfAborted();
+
+    exportJobsCleaned = expiredExports.length;
+    L.debug("Cleaned up expired export jobs", { count: exportJobsCleaned });
+  }
+
+  const stuckCutoffTime = new Date(now() - EXPORT_JOB_TIMEOUT_MS);
+  const stuckExportJobs = await db
+    .select({ id: exportJobs.id })
+    .from(exportJobs)
+    .where(
+      and(
+        inArray(exportJobs.status, ["pending", "running"]),
+        lt(exportJobs.createdAt, stuckCutoffTime),
+      ),
+    );
+  signal.throwIfAborted();
+
+  for (const job of stuckExportJobs) {
+    await db
+      .update(exportJobs)
+      .set({
+        status: "failed",
+        completedAt: currentTime,
+        error: "Export job timed out",
+      })
+      .where(
+        and(
+          eq(exportJobs.id, job.id),
+          inArray(exportJobs.status, ["pending", "running"]),
+        ),
+      );
+    signal.throwIfAborted();
+    exportJobsStuck++;
+  }
+
+  if (exportJobsStuck > 0) {
+    L.debug("Failed stuck export jobs", { count: exportJobsStuck });
+  }
+
+  return { exportJobsCleaned, exportJobsStuck };
+}
+
+async function cleanupSingleRun(
+  set: CommandSetter,
+  db: Db,
+  run: StaleRun,
+  signal: AbortSignal,
+): Promise<CleanupResult | undefined> {
+  const timeoutReason =
+    run.status === "pending"
+      ? "Run timed out while pending (never started)"
+      : "Run timed out (no heartbeat)";
+
+  const [updated] = await db
+    .update(agentRuns)
+    .set({
+      status: "timeout",
+      completedAt: nowDate(),
+      error: timeoutReason,
+    })
+    .where(
+      and(
+        eq(agentRuns.id, run.id),
+        inArray(agentRuns.status, ["pending", "running"]),
+      ),
+    )
+    .returning({ id: agentRuns.id });
+  signal.throwIfAborted();
+
+  if (!updated) {
+    L.debug("Run already transitioned, skipping timeout", { runId: run.id });
+    return undefined;
+  }
+
+  await set(
+    dispatchCompleteSideEffects$,
+    {
+      runId: run.id,
+      orgId: run.orgId,
+      status: "failed",
+      error: timeoutReason,
+    },
+    signal,
+  );
+  signal.throwIfAborted();
+
+  const isDebug = run.composeName?.startsWith(DEBUG_COMPOSE_PREFIX) ?? false;
+  const referenceTime = run.lastHeartbeatAt ?? run.createdAt;
+  L.debug("Cleaned up expired run", {
+    runId: run.id,
+    status: run.status,
+    sandboxId: run.sandboxId,
+    composeName: run.composeName,
+    isDebug,
+    referenceTime: referenceTime.toISOString(),
+  });
+
+  return {
+    runId: run.id,
+    sandboxId: run.sandboxId,
+    status: "cleaned",
+    reason: timeoutReason,
+  };
+}
+
+export const cleanupSandboxes$ = command(
+  async (
+    { get, set },
+    signal: AbortSignal,
+  ): Promise<CleanupSandboxesResult> => {
+    const db = set(writeDb$);
+    const currentTime = now();
+    const cutoffs = {
+      running: new Date(currentTime - HEARTBEAT_TIMEOUT_MS),
+      debug: new Date(currentTime - DEBUG_HEARTBEAT_TIMEOUT_MS),
+      pending: new Date(currentTime - PENDING_TIMEOUT_MS),
+    };
+
+    L.debug("Checking for expired runs", {
+      runningBefore: cutoffs.running.toISOString(),
+      pendingBefore: cutoffs.pending.toISOString(),
+      debugBefore: cutoffs.debug.toISOString(),
+    });
+
+    const staleRuns = await db
+      .select({
+        id: agentRuns.id,
+        orgId: agentRuns.orgId,
+        status: agentRuns.status,
+        sandboxId: agentRuns.sandboxId,
+        lastHeartbeatAt: agentRuns.lastHeartbeatAt,
+        createdAt: agentRuns.createdAt,
+        composeName: agentComposes.name,
+      })
+      .from(agentRuns)
+      .leftJoin(
+        agentComposeVersions,
+        eq(agentRuns.agentComposeVersionId, agentComposeVersions.id),
+      )
+      .leftJoin(
+        agentComposes,
+        eq(agentComposeVersions.composeId, agentComposes.id),
+      )
+      .where(inArray(agentRuns.status, ["pending", "running"]));
+    signal.throwIfAborted();
+
+    const expiredRuns = staleRuns.filter((run) => {
+      return isExpiredRun(run, cutoffs);
+    });
+
+    const expiredQueueCount = await set(cleanupExpiredQueueEntries$, signal);
+    signal.throwIfAborted();
+    const drainedCount = await set(drainStaleQueues$, signal);
+    signal.throwIfAborted();
+    if (expiredQueueCount > 0 || drainedCount > 0) {
+      L.debug("Queue maintenance completed", {
+        expired: expiredQueueCount,
+        drained: drainedCount,
+      });
+    }
+
+    const results: CleanupResult[] = [];
+    if (expiredRuns.length === 0) {
+      L.debug("No expired sandboxes found");
+    } else {
+      L.debug("Found expired sandboxes to cleanup", {
+        count: expiredRuns.length,
+      });
+    }
+
+    for (const run of expiredRuns) {
+      const cleanupResult = await safeAsync(() => {
+        return cleanupSingleRun(set, db, run, signal);
+      });
+      signal.throwIfAborted();
+
+      if ("ok" in cleanupResult) {
+        if (cleanupResult.ok) {
+          results.push(cleanupResult.ok);
+        }
+      } else {
+        const errorMessage =
+          cleanupResult.error instanceof Error
+            ? cleanupResult.error.message
+            : "Unknown error";
+        L.error("Failed to cleanup run", {
+          runId: run.id,
+          error: errorMessage,
+        });
+        results.push({
+          runId: run.id,
+          sandboxId: run.sandboxId,
+          status: "error",
+          error: errorMessage,
+        });
+      }
+    }
+
+    const { exportJobsCleaned, exportJobsStuck } = await cleanupExportJobs(
+      get,
+      db,
+      signal,
+    );
+
+    return {
+      cleaned: results.filter((result) => {
+        return result.status === "cleaned";
+      }).length,
+      errors: results.filter((result) => {
+        return result.status === "error";
+      }).length,
+      results,
+      exportJobsCleaned,
+      exportJobsStuck,
+    };
+  },
+);

--- a/turbo/apps/api/src/signals/services/zero-run-queue.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-run-queue.service.ts
@@ -4,7 +4,7 @@ import { agentRunQueue } from "@vm0/db/schema/agent-run-queue";
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { orgMetadata } from "@vm0/db/schema/org-metadata";
 import { runnerJobQueue } from "@vm0/db/schema/runner-job-queue";
-import { and, count, eq, gt, or, sql } from "drizzle-orm";
+import { and, count, eq, gt, inArray, lt, or, sql } from "drizzle-orm";
 
 import { writeDb$ } from "../external/db";
 import { now, nowDate } from "../external/time";
@@ -171,5 +171,87 @@ export const drainOrgQueue$ = command(
     }
 
     return transitioned.promoted;
+  },
+);
+
+export const cleanupExpiredQueueEntries$ = command(
+  async ({ set }, signal: AbortSignal): Promise<number> => {
+    const writeDb = set(writeDb$);
+    const currentTime = nowDate();
+
+    const deleted = await writeDb
+      .delete(agentRunQueue)
+      .where(lt(agentRunQueue.expiresAt, currentTime))
+      .returning({ runId: agentRunQueue.runId });
+    signal.throwIfAborted();
+
+    if (deleted.length === 0) {
+      return 0;
+    }
+
+    await writeDb
+      .update(agentRuns)
+      .set({
+        status: "timeout",
+        completedAt: currentTime,
+        error: "Queued run expired (exceeded queue TTL)",
+      })
+      .where(
+        and(
+          inArray(
+            agentRuns.id,
+            deleted.map((entry) => {
+              return entry.runId;
+            }),
+          ),
+          eq(agentRuns.status, "queued"),
+        ),
+      );
+    signal.throwIfAborted();
+
+    L.debug("Cleaned up expired queue entries", { count: deleted.length });
+    return deleted.length;
+  },
+);
+
+export const drainStaleQueues$ = command(
+  async ({ set }, signal: AbortSignal): Promise<number> => {
+    const writeDb = set(writeDb$);
+    const staleThreshold = new Date(now() - PENDING_RUN_TTL_MS);
+
+    const orgsWithQueued = await writeDb
+      .selectDistinct({ orgId: agentRunQueue.orgId })
+      .from(agentRunQueue);
+    signal.throwIfAborted();
+
+    let drained = 0;
+    for (const { orgId } of orgsWithQueued) {
+      const [activeRow] = await writeDb
+        .select({ count: count() })
+        .from(agentRuns)
+        .where(
+          and(
+            eq(agentRuns.orgId, orgId),
+            or(
+              eq(agentRuns.status, "running"),
+              and(
+                eq(agentRuns.status, "pending"),
+                gt(agentRuns.createdAt, staleThreshold),
+              ),
+            ),
+          ),
+        );
+      signal.throwIfAborted();
+
+      const activeCount = Number(activeRow?.count ?? 0);
+      if (activeCount === 0) {
+        L.debug("Draining stale queue", { orgId });
+        await set(drainOrgQueue$, { orgId }, signal);
+        signal.throwIfAborted();
+        drained++;
+      }
+    }
+
+    return drained;
   },
 );

--- a/turbo/packages/api-contracts/src/contracts/cron.ts
+++ b/turbo/packages/api-contracts/src/contracts/cron.ts
@@ -22,6 +22,8 @@ const cleanupResponseSchema = z.object({
   cleaned: z.number(),
   errors: z.number(),
   results: z.array(cleanupResultSchema),
+  exportJobsCleaned: z.number(),
+  exportJobsStuck: z.number(),
 });
 
 /**


### PR DESCRIPTION
## Summary
- migrate GET /api/cron/cleanup-sandboxes into the API signal backend
- add queue maintenance commands for expired and stale queued runs
- cover run timeout, debug timeout, queue maintenance, and export job cleanup in API route integration tests

## Validation
- pnpm -F api exec vitest src/signals/routes/__tests__/cron-cleanup-sandboxes.test.ts
- pnpm -F api lint
- pnpm -F @vm0/api-contracts lint
- pnpm -F api check-types
- pnpm -F @vm0/api-contracts check-types
- pnpm format
- git diff --check
- pre-commit hook: prettier, knip, full turbo check-types, commitlint

Closes #13251