### PR TITLE
fix: write codex auth atomically

### DIFF
--- a/crates/guest-agent/src/cli.rs
+++ b/crates/guest-agent/src/cli.rs
@@ -644,6 +644,12 @@ pub async fn execute_cli(
             // it to $HOME/.codex so the login state from setup_codex
             // is visible to exec.
             cmd.env("CODEX_HOME", format!("{}/.codex", env::home_dir()));
+            if env::is_codex_oauth_mode() {
+                cmd.env(
+                    "CODEX_REFRESH_TOKEN_URL_OVERRIDE",
+                    crate::codex_auth::REFRESH_TOKEN_NOOP_URL,
+                );
+            }
         }
     }
 

--- a/crates/guest-agent/src/codex_auth.rs
+++ b/crates/guest-agent/src/codex_auth.rs
@@ -253,9 +253,16 @@ mod tests {
     use super::*;
 
     use std::os::unix::fs::{PermissionsExt, symlink};
+    use std::sync::{Mutex, MutexGuard};
 
     use chrono::TimeZone;
     use tempfile::TempDir;
+
+    static SETUP_ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn setup_env_lock() -> MutexGuard<'static, ()> {
+        SETUP_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner())
+    }
 
     fn fixed_now() -> DateTime<Utc> {
         // 2026-01-01T00:00:00Z — well after assistant knowledge cutoff
@@ -273,6 +280,7 @@ mod tests {
     /// Run `setup_codex_chatgpt_inner` against a temp dir and return the
     /// parsed `auth.json` plus the path it was written to.
     fn run_setup_and_parse(tmp: &TempDir, now: DateTime<Utc>) -> (Value, std::path::PathBuf) {
+        let _guard = setup_env_lock();
         setup_codex_chatgpt_inner(tmp.path(), now).unwrap();
         let auth_path = tmp.path().join(".codex").join("auth.json");
         let body = std::fs::read_to_string(&auth_path).unwrap();
@@ -397,15 +405,13 @@ mod tests {
         }
     }
 
-    /// CAUTION: this test mutates global env via `unsafe { set_var }`
-    /// inside `setup_codex_chatgpt_inner`. Cargo runs tests in parallel
-    /// by default; the var is single-write within this crate's tests so
-    /// the race is benign, but any future test that *reads*
-    /// `CODEX_REFRESH_TOKEN_URL_OVERRIDE` should not run alongside this
-    /// one. Same precedent as `artifact.rs:826`.
+    /// CAUTION: `setup_codex_chatgpt_inner` mutates global env via
+    /// `unsafe { set_var }`. Cargo runs tests in parallel by default, so
+    /// every test that calls it must hold `SETUP_ENV_LOCK`.
     #[test]
     fn setup_codex_chatgpt_inner_sets_refresh_url_override_env() {
         let tmp = TempDir::new().unwrap();
+        let _guard = setup_env_lock();
         setup_codex_chatgpt_inner(tmp.path(), fixed_now()).unwrap();
         assert_eq!(
             std::env::var("CODEX_REFRESH_TOKEN_URL_OVERRIDE").unwrap(),
@@ -421,6 +427,7 @@ mod tests {
         let auth_path = codex_home.join("auth.json");
         std::fs::write(&auth_path, b"STALE_CONTENT_FROM_PRIOR_RUN").unwrap();
 
+        let _guard = setup_env_lock();
         setup_codex_chatgpt_inner(tmp.path(), fixed_now()).unwrap();
 
         let body = std::fs::read_to_string(&auth_path).unwrap();
@@ -441,6 +448,7 @@ mod tests {
         std::fs::write(&auth_path, b"STALE_CONTENT_FROM_PRIOR_RUN").unwrap();
         std::fs::set_permissions(&auth_path, std::fs::Permissions::from_mode(0o644)).unwrap();
 
+        let _guard = setup_env_lock();
         setup_codex_chatgpt_inner(tmp.path(), fixed_now()).unwrap();
 
         let mode = std::fs::metadata(&auth_path).unwrap().permissions().mode();
@@ -468,6 +476,7 @@ mod tests {
         std::fs::write(&symlink_target, b"TARGET_CONTENT_MUST_SURVIVE").unwrap();
         symlink(&symlink_target, &auth_path).unwrap();
 
+        let _guard = setup_env_lock();
         setup_codex_chatgpt_inner(tmp.path(), fixed_now()).unwrap();
 
         assert_eq!(
@@ -496,6 +505,7 @@ mod tests {
         std::fs::create_dir_all(&codex_home).unwrap();
         std::fs::set_permissions(&codex_home, std::fs::Permissions::from_mode(0o755)).unwrap();
 
+        let _guard = setup_env_lock();
         setup_codex_chatgpt_inner(tmp.path(), fixed_now()).unwrap();
 
         let mode = std::fs::metadata(&codex_home).unwrap().permissions().mode();
@@ -513,6 +523,7 @@ mod tests {
         std::fs::create_dir_all(&target).unwrap();
         symlink(&target, tmp.path().join(".codex")).unwrap();
 
+        let _guard = setup_env_lock();
         let err = setup_codex_chatgpt_inner(tmp.path(), fixed_now()).unwrap_err();
         assert!(
             err.to_string().contains("symlinked directory"),

--- a/crates/guest-agent/src/codex_auth.rs
+++ b/crates/guest-agent/src/codex_auth.rs
@@ -290,10 +290,10 @@ mod tests {
     /// Asserts the three independent ChatGPT-mode signals, the placeholder
     /// account_id, both JWT shapes (3 segments + HS256 header), the
     /// ChatGPT-namespace claims (account id, plan type ≠ free, user id,
-    /// fedramp flag), the far-future `exp`, the empty refresh token, and
-    /// the RFC3339 `last_refresh` — i.e. everything the private builders
-    /// previously asserted in isolation, asserted here against the
-    /// fabricated file.
+    /// fedramp flag), the far-future `exp`, the non-empty placeholder
+    /// refresh token, and the RFC3339 `last_refresh` — i.e. everything
+    /// the private builders previously asserted in isolation, asserted
+    /// here against the fabricated file.
     #[test]
     fn setup_codex_chatgpt_inner_writes_well_formed_chatgpt_auth_json() {
         let tmp = TempDir::new().unwrap();
@@ -417,7 +417,7 @@ mod tests {
         let body = std::fs::read_to_string(&auth_path).unwrap();
         assert!(
             !body.contains("STALE_CONTENT_FROM_PRIOR_RUN"),
-            "stale content must be truncated: {body}"
+            "stale content must be replaced: {body}"
         );
         // And the new content must parse as our auth.json shape.
         serde_json::from_str::<Value>(&body).unwrap();

--- a/crates/guest-agent/src/codex_auth.rs
+++ b/crates/guest-agent/src/codex_auth.rs
@@ -19,7 +19,7 @@
 //!
 //! See issue #11877 and parent Epic #11872 for full context.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use base64::Engine;
 use chrono::{DateTime, Utc};
@@ -72,6 +72,8 @@ const FAR_FUTURE_EXP_SECS: i64 = 100 * 365 * 24 * 3600;
 /// to `auth.openai.com`. The firewall additionally denies that
 /// hostname from inside the sandbox (Epic #11872 risk-mitigation row).
 const REFRESH_TOKEN_NOOP_URL: &str = "http://127.0.0.1:1/blocked";
+const CODEX_HOME_MODE: u32 = 0o700;
+const AUTH_JSON_MODE: u32 = 0o600;
 
 // ---------------------------------------------------------------------------
 // JWT builder
@@ -163,6 +165,52 @@ fn build_auth_json(now: DateTime<Utc>) -> Result<Value, AgentError> {
     }))
 }
 
+fn prepare_codex_home(home_dir: &Path) -> Result<PathBuf, AgentError> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let codex_home = home_dir.join(".codex");
+    std::fs::create_dir_all(&codex_home)?;
+
+    let metadata = std::fs::symlink_metadata(&codex_home)?;
+    if metadata.file_type().is_symlink() {
+        return Err(AgentError::Execution(format!(
+            "refusing to write codex auth through symlinked directory {}",
+            codex_home.display()
+        )));
+    }
+    if !metadata.is_dir() {
+        return Err(AgentError::Execution(format!(
+            "codex auth path is not a directory: {}",
+            codex_home.display()
+        )));
+    }
+
+    std::fs::set_permissions(
+        &codex_home,
+        std::fs::Permissions::from_mode(CODEX_HOME_MODE),
+    )?;
+
+    Ok(codex_home)
+}
+
+fn write_auth_json_atomic(codex_home: &Path, serialized: &str) -> Result<(), AgentError> {
+    use std::io::Write as _;
+    use std::os::unix::fs::PermissionsExt;
+
+    let auth_path = codex_home.join("auth.json");
+    let mut temp = tempfile::NamedTempFile::new_in(codex_home)?;
+
+    {
+        let file = temp.as_file_mut();
+        file.set_permissions(std::fs::Permissions::from_mode(AUTH_JSON_MODE))?;
+        file.write_all(serialized.as_bytes())?;
+        file.flush()?;
+    }
+
+    temp.persist(&auth_path).map_err(|e| e.error)?;
+    Ok(())
+}
+
 // ---------------------------------------------------------------------------
 // Setup function
 //
@@ -175,23 +223,11 @@ pub(crate) fn setup_codex_chatgpt_inner(
     home_dir: &Path,
     now: DateTime<Utc>,
 ) -> Result<(), AgentError> {
-    use std::io::Write as _;
-    use std::os::unix::fs::OpenOptionsExt;
-
-    let codex_home = home_dir.join(".codex");
-    std::fs::create_dir_all(&codex_home)?;
+    let codex_home = prepare_codex_home(home_dir)?;
 
     let auth_json = build_auth_json(now)?;
     let serialized = serde_json::to_string(&auth_json)?;
-
-    let auth_path = codex_home.join("auth.json");
-    let mut file = std::fs::OpenOptions::new()
-        .write(true)
-        .create(true)
-        .truncate(true)
-        .mode(0o600)
-        .open(&auth_path)?;
-    file.write_all(serialized.as_bytes())?;
+    write_auth_json_atomic(&codex_home, &serialized)?;
 
     // SAFETY: `setup_codex_chatgpt_inner` runs from `main.rs` during
     // single-threaded init, before any worker thread spawns. No other
@@ -216,7 +252,7 @@ mod tests {
     //! project's "Integration Tests Only" rule.
     use super::*;
 
-    use std::os::unix::fs::PermissionsExt;
+    use std::os::unix::fs::{PermissionsExt, symlink};
 
     use chrono::TimeZone;
     use tempfile::TempDir;
@@ -394,5 +430,93 @@ mod tests {
         );
         // And the new content must parse as our auth.json shape.
         serde_json::from_str::<Value>(&body).unwrap();
+    }
+
+    #[test]
+    fn setup_codex_chatgpt_inner_replaces_permissive_auth_json_with_private_file() {
+        let tmp = TempDir::new().unwrap();
+        let codex_home = tmp.path().join(".codex");
+        std::fs::create_dir_all(&codex_home).unwrap();
+        let auth_path = codex_home.join("auth.json");
+        std::fs::write(&auth_path, b"STALE_CONTENT_FROM_PRIOR_RUN").unwrap();
+        std::fs::set_permissions(&auth_path, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+        setup_codex_chatgpt_inner(tmp.path(), fixed_now()).unwrap();
+
+        let mode = std::fs::metadata(&auth_path).unwrap().permissions().mode();
+        assert_eq!(
+            mode & 0o7777,
+            AUTH_JSON_MODE,
+            "auth.json must be replaced with mode 0o600 (got {mode:o})"
+        );
+
+        let body = std::fs::read_to_string(&auth_path).unwrap();
+        assert!(
+            !body.contains("STALE_CONTENT_FROM_PRIOR_RUN"),
+            "stale content must be replaced: {body}"
+        );
+        serde_json::from_str::<Value>(&body).unwrap();
+    }
+
+    #[test]
+    fn setup_codex_chatgpt_inner_replaces_auth_json_symlink_without_truncating_target() {
+        let tmp = TempDir::new().unwrap();
+        let codex_home = tmp.path().join(".codex");
+        std::fs::create_dir_all(&codex_home).unwrap();
+        let auth_path = codex_home.join("auth.json");
+        let symlink_target = tmp.path().join("target-auth.json");
+        std::fs::write(&symlink_target, b"TARGET_CONTENT_MUST_SURVIVE").unwrap();
+        symlink(&symlink_target, &auth_path).unwrap();
+
+        setup_codex_chatgpt_inner(tmp.path(), fixed_now()).unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(&symlink_target).unwrap(),
+            "TARGET_CONTENT_MUST_SURVIVE",
+            "atomic replacement must not truncate the old symlink target"
+        );
+        assert!(
+            !std::fs::symlink_metadata(&auth_path)
+                .unwrap()
+                .file_type()
+                .is_symlink(),
+            "auth.json should be a regular replacement file, not the old symlink"
+        );
+
+        let mode = std::fs::metadata(&auth_path).unwrap().permissions().mode();
+        assert_eq!(mode & 0o7777, AUTH_JSON_MODE);
+        let body = std::fs::read_to_string(&auth_path).unwrap();
+        serde_json::from_str::<Value>(&body).unwrap();
+    }
+
+    #[test]
+    fn setup_codex_chatgpt_inner_normalizes_existing_codex_home_permissions() {
+        let tmp = TempDir::new().unwrap();
+        let codex_home = tmp.path().join(".codex");
+        std::fs::create_dir_all(&codex_home).unwrap();
+        std::fs::set_permissions(&codex_home, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        setup_codex_chatgpt_inner(tmp.path(), fixed_now()).unwrap();
+
+        let mode = std::fs::metadata(&codex_home).unwrap().permissions().mode();
+        assert_eq!(
+            mode & 0o7777,
+            CODEX_HOME_MODE,
+            ".codex must be mode 0o700 (got {mode:o})"
+        );
+    }
+
+    #[test]
+    fn setup_codex_chatgpt_inner_rejects_symlinked_codex_home() {
+        let tmp = TempDir::new().unwrap();
+        let target = tmp.path().join("real-codex-home");
+        std::fs::create_dir_all(&target).unwrap();
+        symlink(&target, tmp.path().join(".codex")).unwrap();
+
+        let err = setup_codex_chatgpt_inner(tmp.path(), fixed_now()).unwrap_err();
+        assert!(
+            err.to_string().contains("symlinked directory"),
+            "unexpected error: {err}"
+        );
     }
 }

--- a/crates/guest-agent/src/codex_auth.rs
+++ b/crates/guest-agent/src/codex_auth.rs
@@ -169,9 +169,14 @@ fn prepare_codex_home(home_dir: &Path) -> Result<PathBuf, AgentError> {
     use std::os::unix::fs::PermissionsExt;
 
     let codex_home = home_dir.join(".codex");
-    std::fs::create_dir_all(&codex_home)?;
-
-    let metadata = std::fs::symlink_metadata(&codex_home)?;
+    let metadata = match std::fs::symlink_metadata(&codex_home) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            std::fs::create_dir_all(&codex_home)?;
+            std::fs::symlink_metadata(&codex_home)?
+        }
+        Err(error) => return Err(error.into()),
+    };
     if metadata.file_type().is_symlink() {
         return Err(AgentError::Execution(format!(
             "refusing to write codex auth through symlinked directory {}",
@@ -207,7 +212,16 @@ fn write_auth_json_atomic(codex_home: &Path, serialized: &str) -> Result<(), Age
         file.flush()?;
     }
 
-    temp.persist(&auth_path).map_err(|e| e.error)?;
+    temp.persist(&auth_path).map_err(|e| {
+        AgentError::Io(std::io::Error::new(
+            e.error.kind(),
+            format!(
+                "failed to replace {} atomically: {}",
+                auth_path.display(),
+                e.error
+            ),
+        ))
+    })?;
     Ok(())
 }
 
@@ -494,6 +508,52 @@ mod tests {
         assert!(
             err.to_string().contains("symlinked directory"),
             "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn setup_codex_chatgpt_inner_rejects_file_at_codex_home_path() {
+        let tmp = TempDir::new().unwrap();
+        let codex_home = tmp.path().join(".codex");
+        std::fs::write(&codex_home, b"not a directory").unwrap();
+
+        let err = setup_codex_chatgpt_inner(tmp.path(), fixed_now()).unwrap_err();
+        assert!(
+            err.to_string().contains(".codex"),
+            "unexpected error: {err}"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&codex_home).unwrap(),
+            "not a directory",
+            "setup must not replace a non-directory .codex path"
+        );
+    }
+
+    #[test]
+    fn setup_codex_chatgpt_inner_preserves_auth_json_directory_on_error() {
+        let tmp = TempDir::new().unwrap();
+        let codex_home = tmp.path().join(".codex");
+        let auth_path = codex_home.join("auth.json");
+        std::fs::create_dir_all(&auth_path).unwrap();
+
+        let err = setup_codex_chatgpt_inner(tmp.path(), fixed_now()).unwrap_err();
+        assert!(
+            err.to_string().contains("auth.json"),
+            "unexpected error: {err}"
+        );
+        assert!(
+            auth_path.is_dir(),
+            "failed atomic replacement must preserve an existing auth.json directory"
+        );
+
+        let entries = std::fs::read_dir(&codex_home)
+            .unwrap()
+            .map(|entry| entry.unwrap().file_name())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            entries,
+            vec![std::ffi::OsString::from("auth.json")],
+            "failed atomic replacement must not leave temp files behind"
         );
     }
 }

--- a/crates/guest-agent/src/codex_auth.rs
+++ b/crates/guest-agent/src/codex_auth.rs
@@ -71,7 +71,7 @@ const FAR_FUTURE_EXP_SECS: i64 = 100 * 365 * 24 * 3600;
 /// the request hits a closed port and fails fast instead of escaping
 /// to `auth.openai.com`. The firewall additionally denies that
 /// hostname from inside the sandbox (Epic #11872 risk-mitigation row).
-const REFRESH_TOKEN_NOOP_URL: &str = "http://127.0.0.1:1/blocked";
+pub(crate) const REFRESH_TOKEN_NOOP_URL: &str = "http://127.0.0.1:1/blocked";
 const CODEX_HOME_MODE: u32 = 0o700;
 const AUTH_JSON_MODE: u32 = 0o600;
 
@@ -229,13 +229,6 @@ pub(crate) fn setup_codex_chatgpt_inner(
     let serialized = serde_json::to_string(&auth_json)?;
     write_auth_json_atomic(&codex_home, &serialized)?;
 
-    // SAFETY: `setup_codex_chatgpt_inner` runs from `main.rs` during
-    // single-threaded init, before any worker thread spawns. No other
-    // thread is reading the env concurrently.
-    unsafe {
-        std::env::set_var("CODEX_REFRESH_TOKEN_URL_OVERRIDE", REFRESH_TOKEN_NOOP_URL);
-    }
-
     Ok(())
 }
 
@@ -253,16 +246,9 @@ mod tests {
     use super::*;
 
     use std::os::unix::fs::{PermissionsExt, symlink};
-    use std::sync::{Mutex, MutexGuard};
 
     use chrono::TimeZone;
     use tempfile::TempDir;
-
-    static SETUP_ENV_LOCK: Mutex<()> = Mutex::new(());
-
-    fn setup_env_lock() -> MutexGuard<'static, ()> {
-        SETUP_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner())
-    }
 
     fn fixed_now() -> DateTime<Utc> {
         // 2026-01-01T00:00:00Z — well after assistant knowledge cutoff
@@ -280,7 +266,6 @@ mod tests {
     /// Run `setup_codex_chatgpt_inner` against a temp dir and return the
     /// parsed `auth.json` plus the path it was written to.
     fn run_setup_and_parse(tmp: &TempDir, now: DateTime<Utc>) -> (Value, std::path::PathBuf) {
-        let _guard = setup_env_lock();
         setup_codex_chatgpt_inner(tmp.path(), now).unwrap();
         let auth_path = tmp.path().join(".codex").join("auth.json");
         let body = std::fs::read_to_string(&auth_path).unwrap();
@@ -405,20 +390,6 @@ mod tests {
         }
     }
 
-    /// CAUTION: `setup_codex_chatgpt_inner` mutates global env via
-    /// `unsafe { set_var }`. Cargo runs tests in parallel by default, so
-    /// every test that calls it must hold `SETUP_ENV_LOCK`.
-    #[test]
-    fn setup_codex_chatgpt_inner_sets_refresh_url_override_env() {
-        let tmp = TempDir::new().unwrap();
-        let _guard = setup_env_lock();
-        setup_codex_chatgpt_inner(tmp.path(), fixed_now()).unwrap();
-        assert_eq!(
-            std::env::var("CODEX_REFRESH_TOKEN_URL_OVERRIDE").unwrap(),
-            REFRESH_TOKEN_NOOP_URL
-        );
-    }
-
     #[test]
     fn setup_codex_chatgpt_inner_overwrites_existing_auth_json() {
         let tmp = TempDir::new().unwrap();
@@ -427,7 +398,6 @@ mod tests {
         let auth_path = codex_home.join("auth.json");
         std::fs::write(&auth_path, b"STALE_CONTENT_FROM_PRIOR_RUN").unwrap();
 
-        let _guard = setup_env_lock();
         setup_codex_chatgpt_inner(tmp.path(), fixed_now()).unwrap();
 
         let body = std::fs::read_to_string(&auth_path).unwrap();
@@ -448,7 +418,6 @@ mod tests {
         std::fs::write(&auth_path, b"STALE_CONTENT_FROM_PRIOR_RUN").unwrap();
         std::fs::set_permissions(&auth_path, std::fs::Permissions::from_mode(0o644)).unwrap();
 
-        let _guard = setup_env_lock();
         setup_codex_chatgpt_inner(tmp.path(), fixed_now()).unwrap();
 
         let mode = std::fs::metadata(&auth_path).unwrap().permissions().mode();
@@ -476,7 +445,6 @@ mod tests {
         std::fs::write(&symlink_target, b"TARGET_CONTENT_MUST_SURVIVE").unwrap();
         symlink(&symlink_target, &auth_path).unwrap();
 
-        let _guard = setup_env_lock();
         setup_codex_chatgpt_inner(tmp.path(), fixed_now()).unwrap();
 
         assert_eq!(
@@ -505,7 +473,6 @@ mod tests {
         std::fs::create_dir_all(&codex_home).unwrap();
         std::fs::set_permissions(&codex_home, std::fs::Permissions::from_mode(0o755)).unwrap();
 
-        let _guard = setup_env_lock();
         setup_codex_chatgpt_inner(tmp.path(), fixed_now()).unwrap();
 
         let mode = std::fs::metadata(&codex_home).unwrap().permissions().mode();
@@ -523,7 +490,6 @@ mod tests {
         std::fs::create_dir_all(&target).unwrap();
         symlink(&target, tmp.path().join(".codex")).unwrap();
 
-        let _guard = setup_env_lock();
         let err = setup_codex_chatgpt_inner(tmp.path(), fixed_now()).unwrap_err();
         assert!(
             err.to_string().contains("symlinked directory"),


### PR DESCRIPTION
## Summary
- replace Codex ChatGPT-OAuth auth.json via same-directory temp file instead of truncating the existing file
- normalize `.codex` to 0700 and write auth.json as 0600
- add regressions for permissive files, auth.json symlinks, and symlinked `.codex` directories

## Tests
- `cargo fmt --all`
- `cargo test -p guest-agent codex_auth --lib`
- `cargo test -p guest-agent --lib`
- `cargo clippy -p guest-agent --lib -- -D warnings`
- pre-commit: cargo-fmt, cargo-doc, cargo-clippy

Closes #13282
