### PR TITLE
fix: align Ably timing deadlines

### DIFF
--- a/crates/ably-subscriber/src/connection.rs
+++ b/crates/ably-subscriber/src/connection.rs
@@ -1811,6 +1811,29 @@ mod tests {
     }
 
     #[test]
+    fn conn_state_uses_default_idle_interval_without_connection_details() {
+        let timing = TimingConfig::default();
+        let token = TokenDetails {
+            token: "tok".to_string(),
+            expires: unix_now_ms() + 3_600_000,
+            issued: 0,
+            capability: None,
+            client_id: None,
+        };
+        let msg = ProtocolMessage {
+            action: action::CONNECTED,
+            connection_details: None,
+            ..Default::default()
+        };
+
+        let state = ConnState::from_connected(&msg, token, &timing);
+        assert_eq!(
+            state.max_idle_interval,
+            Some(timing.default_max_idle_interval)
+        );
+    }
+
+    #[test]
     fn conn_state_handles_huge_external_timing_values_without_panicking() {
         let msg = ProtocolMessage {
             action: action::CONNECTED,
@@ -1847,6 +1870,21 @@ mod tests {
 
         let renewal_at = ConnState::compute_renewal_at(&token, Duration::from_secs(300))
             .expect("expired tokens should still schedule renewal");
+        assert!(renewal_at <= Instant::now());
+    }
+
+    #[test]
+    fn token_inside_renewal_margin_is_scheduled_immediately() {
+        let token = TokenDetails {
+            token: "tok".to_string(),
+            expires: unix_now_ms() + 60_000,
+            issued: 0,
+            capability: None,
+            client_id: None,
+        };
+
+        let renewal_at = ConnState::compute_renewal_at(&token, Duration::from_secs(300))
+            .expect("tokens inside the renewal margin should schedule renewal");
         assert!(renewal_at <= Instant::now());
     }
 

--- a/crates/ably-subscriber/src/connection.rs
+++ b/crates/ably-subscriber/src/connection.rs
@@ -1784,6 +1784,34 @@ mod tests {
     }
 
     #[test]
+    fn conn_state_keeps_default_connection_state_ttl_when_details_omit_ttl() {
+        let timing = TimingConfig::default();
+        let token = TokenDetails {
+            token: "tok".to_string(),
+            expires: unix_now_ms() + 3_600_000,
+            issued: 0,
+            capability: None,
+            client_id: None,
+        };
+        let msg = ProtocolMessage {
+            action: action::CONNECTED,
+            connection_details: Some(ConnectionDetails {
+                connection_state_ttl: None,
+                max_idle_interval: Some(10000),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        let state = ConnState::from_connected(&msg, token, &timing);
+        assert_eq!(
+            state.connection_state_ttl,
+            timing.default_connection_state_ttl
+        );
+        assert_eq!(state.max_idle_interval, Some(Duration::from_millis(10000)));
+    }
+
+    #[test]
     fn conn_state_disables_idle_timeout_for_missing_or_non_positive_idle_interval() {
         let timing = TimingConfig::default();
         let token = TokenDetails {
@@ -1808,6 +1836,11 @@ mod tests {
             let state = ConnState::from_connected(&msg, token.clone(), &timing);
             assert_eq!(state.max_idle_interval, None);
         }
+    }
+
+    #[test]
+    fn idle_deadline_is_disabled_without_max_idle_interval() {
+        assert_eq!(idle_deadline(None, Duration::from_secs(10)), None);
     }
 
     #[test]

--- a/crates/ably-subscriber/src/connection.rs
+++ b/crates/ably-subscriber/src/connection.rs
@@ -296,10 +296,10 @@ pub(crate) struct ConnState {
     pub connection_key: Option<String>,
     pub channel_serial: Option<String>,
     pub connection_state_ttl: Duration,
-    pub max_idle_interval: Duration,
+    pub max_idle_interval: Option<Duration>,
     pub disconnected_at: Option<Instant>,
     pub token: TokenDetails,
-    pub token_renewal_at: Instant,
+    pub token_renewal_at: Option<Instant>,
 }
 
 impl ConnState {
@@ -309,7 +309,7 @@ impl ConnState {
             connection_key: None,
             channel_serial: None,
             connection_state_ttl: timing.default_connection_state_ttl,
-            max_idle_interval: timing.default_max_idle_interval,
+            max_idle_interval: Some(timing.default_max_idle_interval),
             disconnected_at: None,
             token_renewal_at: Self::compute_renewal_at(&token, timing.token_renewal_margin),
             token,
@@ -328,24 +328,25 @@ impl ConnState {
             if let Some(ref key) = details.connection_key {
                 self.connection_key = Some(key.clone());
             }
-            if let Some(ttl) = details.connection_state_ttl {
-                self.connection_state_ttl = Duration::from_millis(ttl.max(0) as u64);
+            if let Some(ttl) = details.connection_state_ttl
+                && let Some(ttl) = positive_external_millis(ttl)
+            {
+                self.connection_state_ttl = ttl;
             }
-            if let Some(idle) = details.max_idle_interval {
-                self.max_idle_interval = Duration::from_millis(idle.max(0) as u64);
-            }
+            self.max_idle_interval = details.max_idle_interval.and_then(positive_external_millis);
         }
     }
 
-    fn compute_renewal_at(token: &TokenDetails, margin: Duration) -> Instant {
-        let now_ms = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_millis() as i64;
-        let remaining_ms = (token.expires - now_ms).max(0) as u64;
-        let margin_ms = margin.as_millis() as u64;
-        let renew_in = Duration::from_millis(remaining_ms.saturating_sub(margin_ms));
-        Instant::now() + renew_in
+    fn compute_renewal_at(token: &TokenDetails, margin: Duration) -> Option<Instant> {
+        let now_ms = unix_now_ms();
+        let remaining_ms = token.expires.saturating_sub(now_ms);
+        if remaining_ms <= 0 {
+            return Some(Instant::now());
+        }
+
+        let renew_in_ms = (remaining_ms as u128).saturating_sub(margin.as_millis());
+        let renew_in = Duration::from_millis(u64::try_from(renew_in_ms).ok()?);
+        checked_deadline_after(renew_in)
     }
 
     /// Resume is allowed while the Ably connection state is still retained and
@@ -359,6 +360,38 @@ impl ConnState {
             false
         }
     }
+}
+
+fn unix_now_ms() -> i64 {
+    let now_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis();
+    i64::try_from(now_ms).unwrap_or(i64::MAX)
+}
+
+fn positive_external_millis(value: i64) -> Option<Duration> {
+    if value <= 0 {
+        return None;
+    }
+    Some(Duration::from_millis(value as u64))
+}
+
+fn checked_deadline_after(duration: Duration) -> Option<Instant> {
+    Instant::now().checked_add(duration)
+}
+
+fn checked_deadline_from(start: Instant, duration: Duration) -> Option<Instant> {
+    start.checked_add(duration)
+}
+
+fn idle_deadline(
+    max_idle_interval: Option<Duration>,
+    heartbeat_margin: Duration,
+) -> Option<(Instant, Duration)> {
+    let idle_timeout = max_idle_interval?.checked_add(heartbeat_margin)?;
+    let deadline = checked_deadline_after(idle_timeout)?;
+    Some((deadline, idle_timeout))
 }
 
 // ---------------------------------------------------------------------------
@@ -703,9 +736,9 @@ fn suspend_deadline(p: &EventLoopState) -> Option<Instant> {
     {
         return None;
     }
-    p.conn_state
-        .disconnected_at
-        .map(|disconnected_at| disconnected_at + p.conn_state.connection_state_ttl)
+    p.conn_state.disconnected_at.and_then(|disconnected_at| {
+        checked_deadline_from(disconnected_at, p.conn_state.connection_state_ttl)
+    })
 }
 
 fn should_enter_suspended_retry(p: &EventLoopState) -> bool {
@@ -871,8 +904,8 @@ pub(crate) async fn run_event_loop(mut p: EventLoopState, mut close_rx: oneshot:
                 tracing::warn!("WebSocket transport missing before receive loop");
                 break;
             };
-            let idle_timeout = p.conn_state.max_idle_interval + p.timing.heartbeat_margin;
-            let idle_deadline = Instant::now() + idle_timeout;
+            let idle_deadline =
+                idle_deadline(p.conn_state.max_idle_interval, p.timing.heartbeat_margin);
 
             tokio::select! {
                 biased;
@@ -883,7 +916,7 @@ pub(crate) async fn run_event_loop(mut p: EventLoopState, mut close_rx: oneshot:
                     return;
                 }
 
-                _ = tokio::time::sleep_until(p.conn_state.token_renewal_at) => {
+                _ = sleep_until_optional(p.conn_state.token_renewal_at), if p.conn_state.token_renewal_at.is_some() => {
                     let connect_timeout = p.timing.connect_timeout;
                     let result = tokio::select! {
                         biased;
@@ -961,7 +994,10 @@ pub(crate) async fn run_event_loop(mut p: EventLoopState, mut close_rx: oneshot:
                     }
                 }
 
-                _ = tokio::time::sleep_until(idle_deadline) => {
+                _ = sleep_until_optional(idle_deadline.map(|(deadline, _)| deadline)), if idle_deadline.is_some() => {
+                    let Some((_, idle_timeout)) = idle_deadline else {
+                        continue;
+                    };
                     disconnect_reason = Some(format!("heartbeat timeout after {idle_timeout:?}"));
                     immediate_retry = true;
                     close_before_reconnect = true;
@@ -1436,7 +1472,7 @@ async fn handle_renewal_result(
         return true;
     }
 
-    p.conn_state.token_renewal_at = Instant::now() + p.timing.token_renewal_retry_delay;
+    p.conn_state.token_renewal_at = checked_deadline_after(p.timing.token_renewal_retry_delay);
     false
 }
 
@@ -1713,7 +1749,105 @@ mod tests {
         assert_eq!(state.connection_id.as_deref(), Some("conn-1"));
         assert_eq!(state.connection_key.as_deref(), Some("conn-1!key"));
         assert_eq!(state.connection_state_ttl, Duration::from_millis(60000));
-        assert_eq!(state.max_idle_interval, Duration::from_millis(10000));
+        assert_eq!(state.max_idle_interval, Some(Duration::from_millis(10000)));
+        assert!(state.token_renewal_at.is_some());
+    }
+
+    #[test]
+    fn conn_state_ignores_non_positive_connection_state_ttl() {
+        let timing = TimingConfig::default();
+        let token = TokenDetails {
+            token: "tok".to_string(),
+            expires: unix_now_ms() + 3_600_000,
+            issued: 0,
+            capability: None,
+            client_id: None,
+        };
+
+        for ttl in [0, -1] {
+            let msg = ProtocolMessage {
+                action: action::CONNECTED,
+                connection_details: Some(ConnectionDetails {
+                    connection_state_ttl: Some(ttl),
+                    max_idle_interval: Some(10000),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            };
+
+            let state = ConnState::from_connected(&msg, token.clone(), &timing);
+            assert_eq!(
+                state.connection_state_ttl,
+                timing.default_connection_state_ttl
+            );
+        }
+    }
+
+    #[test]
+    fn conn_state_disables_idle_timeout_for_missing_or_non_positive_idle_interval() {
+        let timing = TimingConfig::default();
+        let token = TokenDetails {
+            token: "tok".to_string(),
+            expires: unix_now_ms() + 3_600_000,
+            issued: 0,
+            capability: None,
+            client_id: None,
+        };
+
+        for idle in [None, Some(0), Some(-1)] {
+            let msg = ProtocolMessage {
+                action: action::CONNECTED,
+                connection_details: Some(ConnectionDetails {
+                    connection_state_ttl: Some(60000),
+                    max_idle_interval: idle,
+                    ..Default::default()
+                }),
+                ..Default::default()
+            };
+
+            let state = ConnState::from_connected(&msg, token.clone(), &timing);
+            assert_eq!(state.max_idle_interval, None);
+        }
+    }
+
+    #[test]
+    fn conn_state_handles_huge_external_timing_values_without_panicking() {
+        let msg = ProtocolMessage {
+            action: action::CONNECTED,
+            connection_details: Some(ConnectionDetails {
+                connection_state_ttl: Some(i64::MAX),
+                max_idle_interval: Some(i64::MAX),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let token = TokenDetails {
+            token: "tok".to_string(),
+            expires: i64::MAX,
+            issued: 0,
+            capability: None,
+            client_id: None,
+        };
+
+        let state = ConnState::from_connected(&msg, token, &TimingConfig::default());
+        let _ = idle_deadline(state.max_idle_interval, Duration::from_secs(10));
+        let _ = checked_deadline_from(Instant::now(), state.connection_state_ttl);
+        let _ = state.token_renewal_at;
+    }
+
+    #[test]
+    fn expired_token_renewal_is_scheduled_immediately() {
+        let token = TokenDetails {
+            token: "tok".to_string(),
+            expires: 0,
+            issued: 0,
+            capability: None,
+            client_id: None,
+        };
+
+        let renewal_at = ConnState::compute_renewal_at(&token, Duration::from_secs(300))
+            .expect("expired tokens should still schedule renewal");
+        assert!(renewal_at <= Instant::now());
     }
 
     #[test]
@@ -1723,7 +1857,7 @@ mod tests {
             connection_key: Some("c1!key".to_string()),
             channel_serial: None,
             connection_state_ttl: Duration::from_secs(120),
-            max_idle_interval: Duration::from_secs(15),
+            max_idle_interval: Some(Duration::from_secs(15)),
             disconnected_at: None,
             token: TokenDetails {
                 token: "t".to_string(),
@@ -1732,7 +1866,7 @@ mod tests {
                 capability: None,
                 client_id: None,
             },
-            token_renewal_at: Instant::now() + Duration::from_secs(3600),
+            token_renewal_at: checked_deadline_after(Duration::from_secs(3600)),
         };
 
         // No disconnected_at → cannot resume

--- a/crates/ably-subscriber/src/lib.rs
+++ b/crates/ably-subscriber/src/lib.rs
@@ -8,7 +8,8 @@
 //! - MessagePack binary protocol (Ably default)
 //! - Automatic connection resume after disconnection
 //! - Proactive token renewal before expiry
-//! - Heartbeat-based connection liveness detection
+//! - Heartbeat-based connection liveness detection when Ably advertises a
+//!   positive idle interval
 //!
 //! # Example
 //! ```no_run

--- a/crates/ably-subscriber/src/types.rs
+++ b/crates/ably-subscriber/src/types.rs
@@ -120,7 +120,9 @@ pub struct TimingConfig {
     pub close_timeout: Duration,
     /// Timeout wrapping each individual reconnect attempt.
     pub reconnect_timeout: Duration,
-    /// Default `max_idle_interval` when the server doesn't specify one.
+    /// Fallback `max_idle_interval` when the server omits connection details.
+    /// If connection details are present but `maxIdleInterval` is zero or
+    /// absent, no idle timeout is enforced, matching Ably realtime semantics.
     pub default_max_idle_interval: Duration,
     /// Default `connection_state_ttl` when the server doesn't specify one.
     pub default_connection_state_ttl: Duration,

--- a/crates/ably-subscriber/tests/integration.rs
+++ b/crates/ably-subscriber/tests/integration.rs
@@ -2174,6 +2174,55 @@ async fn heartbeat_timeout_triggers_reconnect() {
     server_task.await.unwrap();
 }
 
+#[tokio::test]
+async fn zero_max_idle_interval_disables_heartbeat_timeout() {
+    let http = MockServer::start();
+    let ws = MockAblyServer::start().await.unwrap();
+    mock_token_endpoint(&http, "testKey.testId");
+
+    let ws_port = ws.port;
+    let server_task = tokio::spawn(async move {
+        let mut conn = ws
+            .accept_and_handshake_with_opts(
+                "ch",
+                "conn-1",
+                HandshakeOptions {
+                    max_idle_interval_ms: 0,
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+
+        // Old behavior treated maxIdleInterval=0 as heartbeat_margin and
+        // disconnected before this message. Ably semantics disable the idle
+        // timeout when no maximum idle interval is promised.
+        tokio::time::sleep(Duration::from_millis(75)).await;
+        send_message(&mut conn, "ch", "after-zero-idle", serde_json::json!("ok"))
+            .await
+            .unwrap();
+    });
+
+    let mut timing = TimingConfig::default();
+    timing.heartbeat_margin = Duration::from_millis(20);
+    let mut sub = subscribe(test_config_with_timing(ws_port, http.port(), "ch", timing))
+        .await
+        .unwrap();
+
+    assert!(matches!(sub.next().await.unwrap(), Event::Connected));
+
+    let event = tokio::time::timeout(Duration::from_secs(5), sub.next())
+        .await
+        .expect("timed out waiting for message after zero idle interval")
+        .unwrap();
+    match event {
+        Event::Message(msg) => assert_eq!(msg.name.as_deref(), Some("after-zero-idle")),
+        other => panic!("expected Message, got {other:?}"),
+    }
+
+    server_task.await.unwrap();
+}
+
 // ---------------------------------------------------------------------------
 // Test 20: retry continues indefinitely and enters suspended after TTL expiry
 // ---------------------------------------------------------------------------

--- a/crates/ably-subscriber/tests/integration.rs
+++ b/crates/ably-subscriber/tests/integration.rs
@@ -2180,6 +2180,7 @@ async fn zero_max_idle_interval_disables_heartbeat_timeout() {
     let ws = MockAblyServer::start().await.unwrap();
     mock_token_endpoint(&http, "testKey.testId");
 
+    let (advance_tx, advance_rx) = tokio::sync::oneshot::channel();
     let ws_port = ws.port;
     let server_task = tokio::spawn(async move {
         let mut conn = ws
@@ -2197,19 +2198,22 @@ async fn zero_max_idle_interval_disables_heartbeat_timeout() {
         // Old behavior treated maxIdleInterval=0 as heartbeat_margin and
         // disconnected before this message. Ably semantics disable the idle
         // timeout when no maximum idle interval is promised.
-        tokio::time::sleep(Duration::from_millis(75)).await;
+        advance_rx.await.unwrap();
+        tokio::time::advance(Duration::from_secs(2)).await;
         send_message(&mut conn, "ch", "after-zero-idle", serde_json::json!("ok"))
             .await
             .unwrap();
     });
 
     let mut timing = TimingConfig::default();
-    timing.heartbeat_margin = Duration::from_millis(20);
+    timing.heartbeat_margin = Duration::from_secs(1);
     let mut sub = subscribe(test_config_with_timing(ws_port, http.port(), "ch", timing))
         .await
         .unwrap();
 
     assert!(matches!(sub.next().await.unwrap(), Event::Connected));
+    tokio::time::pause();
+    let _ = advance_tx.send(());
 
     let event = tokio::time::timeout(Duration::from_secs(5), sub.next())
         .await

--- a/crates/ably-subscriber/tests/integration.rs
+++ b/crates/ably-subscriber/tests/integration.rs
@@ -3451,23 +3451,33 @@ async fn channel_error_backpressure_closes_socket_before_subscription_close() {
 }
 
 // ---------------------------------------------------------------------------
-// Test 26: expired connection_state_ttl skips resume (fresh connect)
+// Test 26: non-positive connection_state_ttl keeps the default resume window
 // ---------------------------------------------------------------------------
 
 #[tokio::test]
-async fn expired_ttl_skips_resume() {
+async fn non_positive_ttl_keeps_default_resume_window() {
     let http = MockServer::start();
     let ws = MockAblyServer::start().await.unwrap();
-    mock_token_endpoint(&http, "testKey.testId");
+    let token_path = "/keys/testKey.testId/requestToken";
+    let now = now_ms();
+    let token_mock = http.mock(|when, then| {
+        when.method(POST).path(token_path);
+        then.status(201)
+            .header("content-type", "application/json")
+            .json_body(serde_json::json!({
+                "token": "mock-token-abc",
+                "expires": now + 3_600_000,
+                "issued": now,
+                "capability": "{\"*\":[\"*\"]}",
+            }));
+    });
 
     let ws_port = ws.port;
-    let (resume_tx, resume_rx) = tokio::sync::oneshot::channel::<bool>();
     let (message_seen_tx, message_seen_rx) = tokio::sync::oneshot::channel::<()>();
 
     let server_task = tokio::spawn(async move {
-        // First connection with an already-expired connection_state_ttl.
-        // The server-provided TTL overrides the TimingConfig default, so we
-        // set it here to ensure can_resume() is false on reconnect.
+        // Non-positive connectionStateTtl should be treated as absent, not as
+        // an already-expired resume window.
         let conn = ws
             .accept_and_handshake_with_opts(
                 "ch",
@@ -3481,24 +3491,17 @@ async fn expired_ttl_skips_resume() {
             .unwrap();
         drop(conn);
 
-        // Second connection — send CONNECTED with the *same* conn_id.
-        // If client tried resume and got the same ID, it would skip ATTACH.
-        // But since TTL expired, can_resume()=false → fresh connect → ATTACH.
-        let mut conn2 = ws.accept_and_handshake("ch", "conn-2").await.unwrap();
-
-        // The fact that accept_and_handshake succeeded (it reads ATTACH and
-        // sends ATTACHED) proves the client sent ATTACH, i.e. did NOT resume.
-        let _ = resume_tx.send(true);
+        let mut conn2 = ws.accept_and_handshake("ch", "conn-1").await.unwrap();
 
         send_message(
             &mut conn2,
             "ch",
-            "after-fresh-connect",
+            "after-default-ttl-resume",
             serde_json::json!("ok"),
         )
         .await
         .unwrap();
-        wait_for_test_observation(message_seen_rx, "after-fresh-connect message").await;
+        wait_for_test_observation(message_seen_rx, "after-default-ttl-resume message").await;
     });
 
     let mut timing = TimingConfig::default();
@@ -3529,22 +3532,20 @@ async fn expired_ttl_skips_resume() {
         }
     }
 
-    // Message after fresh connect
+    // Message after reconnect proves the subscription is still alive.
     let event = tokio::time::timeout(Duration::from_secs(5), sub.next())
         .await
         .expect("timed out waiting for message")
         .unwrap();
     match event {
         Event::Message(msg) => {
-            assert_eq!(msg.name.as_deref(), Some("after-fresh-connect"));
+            assert_eq!(msg.name.as_deref(), Some("after-default-ttl-resume"));
             message_seen_tx.send(()).unwrap();
         }
         other => panic!("expected Message, got {other:?}"),
     }
 
-    // Verify server saw ATTACH (meaning client did NOT resume)
-    let did_attach = resume_rx.await.expect("server task panicked");
-    assert!(did_attach, "client should have sent ATTACH (no resume)");
+    token_mock.assert_calls(1);
     server_task.await.unwrap();
 }
 


### PR DESCRIPTION
## Summary

- Align `ably-subscriber` timing semantics with ably-js for Ably connection details.
- Treat explicit missing/zero/non-positive `maxIdleInterval` as no idle timeout instead of a near-immediate heartbeat timeout.
- Use checked deadline arithmetic for Ably-derived idle, suspend, and proactive token renewal deadlines.
- Keep proactive token renewal for normal tokens, while allowing unrepresentable far-future deadlines to disable proactive renewal instead of panicking.

Fixes #13285

## Tests

- `cargo clippy --manifest-path crates/Cargo.toml -p ably-subscriber --all-targets --all-features`
- `cargo test --manifest-path crates/Cargo.toml -p ably-subscriber`
- pre-commit hook: `cargo-fmt`, workspace `cargo-clippy`, workspace `cargo-doc`
