### PR TITLE
fix(runner): copy guest sandbox ops logs

### DIFF
--- a/crates/runner/src/cmd/gc.rs
+++ b/crates/runner/src/cmd/gc.rs
@@ -788,8 +788,9 @@ async fn gc_orphaned_locks(home: &HomePaths, dry_run: bool) -> RunnerResult<u64>
 
 /// Delete stale log files (older than [`JOB_LOG_MAX_AGE`]).
 ///
-/// Covers per-job logs (`network-*.jsonl`, `system-*.log`, `metrics-*.jsonl`)
-/// and runner instance logs (`runner-*.log`). Returns `(files_removed, bytes_freed)`.
+/// Covers per-job logs (`network-*.jsonl`, `system-*.log`, `metrics-*.jsonl`,
+/// `sandbox-ops-*.jsonl`) and runner instance logs (`runner-*.log`).
+/// Returns `(files_removed, bytes_freed)`.
 async fn gc_job_logs(home: &HomePaths, dry_run: bool) -> RunnerResult<(u64, u64)> {
     let logs_dir = home.logs_dir();
     let Some(mut entries) = read_dir_or_missing(&logs_dir).await? else {
@@ -3116,7 +3117,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn gc_job_logs_deletes_stale_system_and_metrics() {
+    async fn gc_job_logs_deletes_stale_system_metrics_and_sandbox_ops() {
         use std::fs::FileTimes;
         use std::time::Duration;
 
@@ -3141,10 +3142,19 @@ mod tests {
             .set_times(FileTimes::new().set_modified(old_time))
             .unwrap();
 
+        let sandbox_ops_log =
+            logs_dir.join("sandbox-ops-550e8400-e29b-41d4-a716-446655440000.jsonl");
+        std::fs::write(&sandbox_ops_log, "{}").unwrap();
+        std::fs::File::open(&sandbox_ops_log)
+            .unwrap()
+            .set_times(FileTimes::new().set_modified(old_time))
+            .unwrap();
+
         let (removed, _) = gc_job_logs(&home, false).await.unwrap();
-        assert_eq!(removed, 2);
+        assert_eq!(removed, 3);
         assert!(!system_log.exists());
         assert!(!metrics_log.exists());
+        assert!(!sandbox_ops_log.exists());
     }
 
     #[tokio::test]

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -844,27 +844,24 @@ async fn copy_guest_logs(sandbox: &dyn Sandbox, context: &ExecutionContext, log_
         (
             format!("{GUEST_SYSTEM_LOG_PREFIX}{run_id}{GUEST_SYSTEM_LOG_SUFFIX}"),
             log_paths.system_log(run_id),
-            GUEST_LOG_COPY_MAX_BYTES,
         ),
         (
             format!("{GUEST_METRICS_LOG_PREFIX}{run_id}{GUEST_METRICS_LOG_SUFFIX}"),
             log_paths.metrics_log(run_id),
-            GUEST_LOG_COPY_MAX_BYTES,
         ),
         (
             format!("{GUEST_SANDBOX_OPS_LOG_PREFIX}{run_id}{GUEST_SANDBOX_OPS_LOG_SUFFIX}"),
             log_paths.sandbox_ops_log(run_id),
-            GUEST_LOG_COPY_MAX_BYTES,
         ),
     ];
 
-    for (guest_path, host_path, max_bytes) in &files {
+    for (guest_path, host_path) in &files {
         if let Err(e) = sandbox
             .copy_file(
                 guest_path,
                 host_path,
                 CopyFileOptions {
-                    max_bytes: *max_bytes,
+                    max_bytes: GUEST_LOG_COPY_MAX_BYTES,
                     timeout: DEFAULT_EXEC_TIMEOUT,
                     missing_ok: true,
                 },

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -2786,6 +2786,11 @@ mod tests {
 
         let calls = sandbox.copy_file_calls();
         assert_eq!(calls.len(), 3);
+        assert_eq!(
+            calls[2].path,
+            format!("/tmp/vm0-sandbox-ops-{}.jsonl", ctx.run_id)
+        );
+        assert_eq!(calls[2].host_path, log_paths.sandbox_ops_log(ctx.run_id));
         assert_eq!(calls[0].max_bytes, GUEST_LOG_COPY_MAX_BYTES);
         assert_eq!(calls[1].max_bytes, GUEST_LOG_COPY_MAX_BYTES);
         assert_eq!(calls[2].max_bytes, GUEST_LOG_COPY_MAX_BYTES);

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -2797,6 +2797,37 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn copy_guest_logs_keeps_existing_logs_when_sandbox_ops_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let log_paths = LogPaths::new(dir.path().to_path_buf());
+        let sandbox = MockSandbox::new("test");
+        let ctx = minimal_context();
+
+        sandbox.push_copy_file_result(Ok(b"system log\n".to_vec()));
+        sandbox.push_copy_file_result(Ok(b"{\"cpu\":0.5}\n".to_vec()));
+
+        copy_guest_logs(&sandbox, &ctx, &log_paths).await;
+
+        let system_log = tokio::fs::read_to_string(log_paths.system_log(ctx.run_id))
+            .await
+            .unwrap();
+        assert_eq!(system_log, "system log\n");
+
+        let metrics_log = tokio::fs::read_to_string(log_paths.metrics_log(ctx.run_id))
+            .await
+            .unwrap();
+        assert_eq!(metrics_log, "{\"cpu\":0.5}\n");
+        assert!(!log_paths.sandbox_ops_log(ctx.run_id).exists());
+
+        let calls = sandbox.copy_file_calls();
+        assert_eq!(calls.len(), 3);
+        assert!(
+            calls[2].missing_ok,
+            "missing sandbox ops log should be a best-effort no-op"
+        );
+    }
+
+    #[tokio::test]
     async fn copy_guest_logs_skips_on_nonzero_exit() {
         let dir = tempfile::tempdir().unwrap();
         let log_paths = LogPaths::new(dir.path().to_path_buf());

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -828,6 +828,8 @@ const GUEST_SYSTEM_LOG_PREFIX: &str = "/tmp/vm0-system-";
 const GUEST_SYSTEM_LOG_SUFFIX: &str = ".log";
 const GUEST_METRICS_LOG_PREFIX: &str = "/tmp/vm0-metrics-";
 const GUEST_METRICS_LOG_SUFFIX: &str = ".jsonl";
+const GUEST_SANDBOX_OPS_LOG_PREFIX: &str = "/tmp/vm0-sandbox-ops-";
+const GUEST_SANDBOX_OPS_LOG_SUFFIX: &str = ".jsonl";
 
 /// Copy guest log files to host (best-effort, post-job).
 ///
@@ -842,20 +844,27 @@ async fn copy_guest_logs(sandbox: &dyn Sandbox, context: &ExecutionContext, log_
         (
             format!("{GUEST_SYSTEM_LOG_PREFIX}{run_id}{GUEST_SYSTEM_LOG_SUFFIX}"),
             log_paths.system_log(run_id),
+            GUEST_LOG_COPY_MAX_BYTES,
         ),
         (
             format!("{GUEST_METRICS_LOG_PREFIX}{run_id}{GUEST_METRICS_LOG_SUFFIX}"),
             log_paths.metrics_log(run_id),
+            GUEST_LOG_COPY_MAX_BYTES,
+        ),
+        (
+            format!("{GUEST_SANDBOX_OPS_LOG_PREFIX}{run_id}{GUEST_SANDBOX_OPS_LOG_SUFFIX}"),
+            log_paths.sandbox_ops_log(run_id),
+            GUEST_LOG_COPY_MAX_BYTES,
         ),
     ];
 
-    for (guest_path, host_path) in &files {
+    for (guest_path, host_path, max_bytes) in &files {
         if let Err(e) = sandbox
             .copy_file(
                 guest_path,
                 host_path,
                 CopyFileOptions {
-                    max_bytes: GUEST_LOG_COPY_MAX_BYTES,
+                    max_bytes: *max_bytes,
                     timeout: DEFAULT_EXEC_TIMEOUT,
                     missing_ok: true,
                 },
@@ -2752,9 +2761,13 @@ mod tests {
         .await
         .unwrap();
 
-        // Queue two guest-copy results: system log + metrics log.
+        // Queue guest-copy results: system log + metrics log + sandbox ops log.
         sandbox.push_copy_file_result(Ok(b"system log line 1\nsystem log line 2\n".to_vec()));
         sandbox.push_copy_file_result(Ok(b"{\"cpu\":0.5}\n".to_vec()));
+        sandbox.push_copy_file_result(Ok(
+            b"{\"action_type\":\"final_telemetry_upload\",\"duration_ms\":10,\"success\":true}\n"
+                .to_vec(),
+        ));
 
         copy_guest_logs(&sandbox, &ctx, &log_paths).await;
 
@@ -2768,6 +2781,17 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(metrics_log, "{\"cpu\":0.5}\n");
+
+        let sandbox_ops_log = tokio::fs::read_to_string(log_paths.sandbox_ops_log(ctx.run_id))
+            .await
+            .unwrap();
+        assert!(sandbox_ops_log.contains("final_telemetry_upload"));
+
+        let calls = sandbox.copy_file_calls();
+        assert_eq!(calls.len(), 3);
+        assert_eq!(calls[0].max_bytes, GUEST_LOG_COPY_MAX_BYTES);
+        assert_eq!(calls[1].max_bytes, GUEST_LOG_COPY_MAX_BYTES);
+        assert_eq!(calls[2].max_bytes, GUEST_LOG_COPY_MAX_BYTES);
     }
 
     #[tokio::test]
@@ -2780,12 +2804,14 @@ mod tests {
         // Copy fails (file doesn't exist in guest).
         sandbox.push_copy_file_result(Err(sandbox_exec_error("No such file")));
         sandbox.push_copy_file_result(Err(sandbox_exec_error("No such file")));
+        sandbox.push_copy_file_result(Err(sandbox_exec_error("No such file")));
 
         copy_guest_logs(&sandbox, &ctx, &log_paths).await;
 
         // Host files should not be created
         assert!(!log_paths.system_log(ctx.run_id).exists());
         assert!(!log_paths.metrics_log(ctx.run_id).exists());
+        assert!(!log_paths.sandbox_ops_log(ctx.run_id).exists());
     }
 
     #[tokio::test]
@@ -2797,11 +2823,13 @@ mod tests {
 
         sandbox.push_copy_file_result(Err(sandbox_exec_error("vsock down")));
         sandbox.push_copy_file_result(Err(sandbox_exec_error("vsock down")));
+        sandbox.push_copy_file_result(Err(sandbox_exec_error("vsock down")));
 
         copy_guest_logs(&sandbox, &ctx, &log_paths).await;
 
         assert!(!log_paths.system_log(ctx.run_id).exists());
         assert!(!log_paths.metrics_log(ctx.run_id).exists());
+        assert!(!log_paths.sandbox_ops_log(ctx.run_id).exists());
     }
 
     // -----------------------------------------------------------------------

--- a/crates/runner/src/paths.rs
+++ b/crates/runner/src/paths.rs
@@ -366,11 +366,15 @@ impl LogPaths {
         self.dir.join(format!("metrics-{run_id}.jsonl"))
     }
 
+    pub fn sandbox_ops_log(&self, run_id: RunId) -> PathBuf {
+        self.dir.join(format!("sandbox-ops-{run_id}.jsonl"))
+    }
+
     /// Whether `name` matches any GC-eligible log file pattern.
     ///
-    /// Includes per-job logs (`network-*`, `system-*`, `metrics-*`, `proxy-*`)
-    /// runner instance logs (`runner-*.log`), and stale `.vm0tmp-*` copies of
-    /// those files left behind by a killed runner.
+    /// Includes per-job logs (`network-*`, `system-*`, `metrics-*`,
+    /// `sandbox-ops-*`, `proxy-*`) runner instance logs (`runner-*.log`), and
+    /// stale `.vm0tmp-*` copies of those files left behind by a killed runner.
     pub fn is_gc_eligible_log(name: &str) -> bool {
         Self::is_final_gc_eligible_log(name) || Self::is_gc_eligible_log_temp(name)
     }
@@ -379,6 +383,7 @@ impl LogPaths {
         (name.starts_with("network-") && name.ends_with(".jsonl"))
             || (name.starts_with("system-") && name.ends_with(".log"))
             || (name.starts_with("metrics-") && name.ends_with(".jsonl"))
+            || (name.starts_with("sandbox-ops-") && name.ends_with(".jsonl"))
             || (name.starts_with("proxy-") && name.ends_with(".jsonl"))
             || (name.starts_with("runner-") && name.ends_with(".log"))
     }
@@ -562,6 +567,11 @@ mod tests {
         assert!(lp.network_log(id).to_string_lossy().contains("network-"));
         assert!(lp.system_log(id).to_string_lossy().contains("system-"));
         assert!(lp.metrics_log(id).to_string_lossy().contains("metrics-"));
+        assert!(
+            lp.sandbox_ops_log(id)
+                .to_string_lossy()
+                .contains("sandbox-ops-")
+        );
         assert!(lp.proxy_log(id).to_string_lossy().contains("proxy-"));
     }
 
@@ -577,6 +587,9 @@ mod tests {
             "metrics-550e8400-e29b-41d4-a716-446655440000.jsonl"
         ));
         assert!(LogPaths::is_gc_eligible_log(
+            "sandbox-ops-550e8400-e29b-41d4-a716-446655440000.jsonl"
+        ));
+        assert!(LogPaths::is_gc_eligible_log(
             "proxy-550e8400-e29b-41d4-a716-446655440000.jsonl"
         ));
         assert!(LogPaths::is_gc_eligible_log("runner-2026-04-01.log"));
@@ -585,6 +598,9 @@ mod tests {
         ));
         assert!(LogPaths::is_gc_eligible_log(
             ".metrics-550e8400-e29b-41d4-a716-446655440000.jsonl.vm0tmp-101-7-2"
+        ));
+        assert!(LogPaths::is_gc_eligible_log(
+            ".sandbox-ops-550e8400-e29b-41d4-a716-446655440000.jsonl.vm0tmp-101-7-3"
         ));
     }
 


### PR DESCRIPTION
## Summary
- copy guest sandbox ops JSONL into the runner log directory during post-job cleanup
- add a `sandbox-ops-{run_id}.jsonl` log path and include it in log GC matching
- cover copy success, missing/exec-error cases, and GC matching in runner tests

## Notes
- Refs #13303
- This preserves the guest-local sandbox ops file for runner-side diagnosis; it does not change the telemetry upload/Axiom ingestion semantics.

## Tests
- cargo fmt --manifest-path crates/Cargo.toml --all --check
- cargo test --manifest-path crates/Cargo.toml -p runner copy_guest_logs -- --nocapture
- cargo test --manifest-path crates/Cargo.toml -p runner is_gc_eligible_log -- --nocapture
- cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets
- git diff --check
- pre-commit lefthook: cargo-fmt, cargo-clippy, cargo-doc, commitlint