### PR TITLE
fix: clean up benchmark init failures

### DIFF
--- a/crates/runner/src/cmd/benchmark.rs
+++ b/crates/runner/src/cmd/benchmark.rs
@@ -341,7 +341,7 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     use async_trait::async_trait;
-    use sandbox::{SandboxError, SandboxInitializationPhase};
+    use sandbox::{Sandbox, SandboxError, SandboxInitializationPhase};
 
     #[test]
     fn parse_env_args_accepts_key_value_pairs() {
@@ -399,6 +399,39 @@ mod tests {
         assert_eq!(shutdowns.load(Ordering::SeqCst), 1);
     }
 
+    #[tokio::test]
+    async fn create_factory_or_shutdown_runtime_returns_factory_without_shutdown() {
+        let shutdowns = Arc::new(AtomicUsize::new(0));
+        let mut runtime = SuccessfulFactoryRuntime {
+            shutdowns: Arc::clone(&shutdowns),
+        };
+
+        let factory = create_factory_or_shutdown_runtime(&mut runtime, test_factory_config())
+            .await
+            .unwrap();
+
+        assert_eq!(factory.name(), "test");
+        assert_eq!(shutdowns.load(Ordering::SeqCst), 0);
+    }
+
+    struct SuccessfulFactoryRuntime {
+        shutdowns: Arc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl SandboxRuntime for SuccessfulFactoryRuntime {
+        async fn create_factory(
+            &self,
+            _config: sandbox::FactoryConfig,
+        ) -> sandbox::Result<Box<dyn SandboxFactory>> {
+            Ok(Box::new(TestFactory))
+        }
+
+        async fn shutdown(&mut self) {
+            self.shutdowns.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
     struct FailingFactoryRuntime {
         shutdowns: Arc<AtomicUsize>,
     }
@@ -418,6 +451,30 @@ mod tests {
         async fn shutdown(&mut self) {
             self.shutdowns.fetch_add(1, Ordering::SeqCst);
         }
+    }
+
+    struct TestFactory;
+
+    #[async_trait]
+    impl SandboxFactory for TestFactory {
+        fn name(&self) -> &str {
+            "test"
+        }
+
+        fn config_hash(&self) -> String {
+            "test".into()
+        }
+
+        async fn create(
+            &self,
+            _config: sandbox::SandboxConfig,
+        ) -> sandbox::Result<Box<dyn Sandbox>> {
+            panic!("benchmark lifecycle tests do not create sandboxes")
+        }
+
+        async fn destroy(&self, _sandbox: Box<dyn Sandbox>) {}
+
+        async fn shutdown(&mut self) {}
     }
 
     fn test_factory_config() -> sandbox::FactoryConfig {

--- a/crates/runner/src/cmd/benchmark.rs
+++ b/crates/runner/src/cmd/benchmark.rs
@@ -5,7 +5,7 @@ use std::time::{Duration, Instant};
 use clap::Args;
 use sandbox::{
     EXEC_OUTPUT_LIMIT_7_MIB, ExecRequest, ExecResult, RuntimeProvider, SandboxConfig,
-    SandboxFactory, SandboxId,
+    SandboxFactory, SandboxId, SandboxRuntime,
 };
 use tracing::{info, warn};
 
@@ -119,13 +119,27 @@ pub async fn run_benchmark(
     let factory_config = runner_config.factory_config(profile_name, profile_config, &home);
 
     let t = Instant::now();
-    let mut runtime = runtime_provider
+    let mut runtime = match runtime_provider
         .create_runtime(sandbox::RuntimeConfig {
             proxy_port: Some(mitm.port()),
             dns_port: None, // benchmark does not use custom DNS proxy
         })
-        .await?;
-    let mut factory = runtime.create_factory(factory_config).await?;
+        .await
+    {
+        Ok(runtime) => runtime,
+        Err(e) => {
+            stop_benchmark_proxy(&mut mitm, "runtime_create").await;
+            return Err(e.into());
+        }
+    };
+    let mut factory =
+        match create_factory_or_shutdown_runtime(runtime.as_mut(), factory_config).await {
+            Ok(factory) => factory,
+            Err(e) => {
+                stop_benchmark_proxy(&mut mitm, "factory_create").await;
+                return Err(e.into());
+            }
+        };
     let factory_ms = t.elapsed().as_millis();
     info!(factory_ms, "factory ready");
 
@@ -194,6 +208,25 @@ pub async fn run_benchmark(
         }
     };
     Ok(ExitCode::from(code))
+}
+
+async fn stop_benchmark_proxy(mitm: &mut proxy::MitmProxy, phase: &'static str) {
+    if let Err(e) = mitm.stop().await {
+        warn!(error = %e, phase, "proxy stop failed during benchmark cleanup");
+    }
+}
+
+async fn create_factory_or_shutdown_runtime(
+    runtime: &mut dyn SandboxRuntime,
+    factory_config: sandbox::FactoryConfig,
+) -> sandbox::Result<Box<dyn SandboxFactory>> {
+    match runtime.create_factory(factory_config).await {
+        Ok(factory) => Ok(factory),
+        Err(e) => {
+            runtime.shutdown().await;
+            Err(e)
+        }
+    }
 }
 
 /// Create, register, start, exec, stop, unregister, destroy.
@@ -301,6 +334,12 @@ async fn run_in_sandbox(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::path::PathBuf;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use async_trait::async_trait;
+    use sandbox::{SandboxError, SandboxInitializationPhase};
 
     #[test]
     fn parse_env_args_accepts_key_value_pairs() {
@@ -337,5 +376,56 @@ mod tests {
         let input = vec!["GOOD=ok".to_string(), "BAD".to_string()];
         let err = parse_env_args(&input).unwrap_err();
         assert!(err.to_string().contains("'BAD'"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn create_factory_or_shutdown_runtime_shuts_down_runtime_after_factory_error() {
+        let shutdowns = Arc::new(AtomicUsize::new(0));
+        let mut runtime = FailingFactoryRuntime {
+            shutdowns: Arc::clone(&shutdowns),
+        };
+
+        let result = create_factory_or_shutdown_runtime(&mut runtime, test_factory_config()).await;
+
+        assert!(matches!(
+            result,
+            Err(SandboxError::Initialization {
+                phase: SandboxInitializationPhase::Factory,
+                message,
+            }) if message == "factory failed"
+        ));
+        assert_eq!(shutdowns.load(Ordering::SeqCst), 1);
+    }
+
+    struct FailingFactoryRuntime {
+        shutdowns: Arc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl SandboxRuntime for FailingFactoryRuntime {
+        async fn create_factory(
+            &self,
+            _config: sandbox::FactoryConfig,
+        ) -> sandbox::Result<Box<dyn SandboxFactory>> {
+            Err(SandboxError::Initialization {
+                phase: SandboxInitializationPhase::Factory,
+                message: "factory failed".into(),
+            })
+        }
+
+        async fn shutdown(&mut self) {
+            self.shutdowns.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    fn test_factory_config() -> sandbox::FactoryConfig {
+        sandbox::FactoryConfig {
+            profile: "vm0/test".into(),
+            binary_path: PathBuf::from("/firecracker"),
+            kernel_path: PathBuf::from("/vmlinux"),
+            rootfs_path: PathBuf::from("/rootfs.ext4"),
+            base_dir: PathBuf::from("/tmp/vm0-test"),
+            snapshot: None,
+        }
     }
 }

--- a/crates/runner/src/cmd/benchmark.rs
+++ b/crates/runner/src/cmd/benchmark.rs
@@ -88,7 +88,7 @@ pub async fn run_benchmark(
     let snapshot_lock =
         lock::acquire_shared(home.snapshot_lock(&profile_config.snapshot_hash)).await?;
     config::validate_profile_image_artifacts(profile_name, profile_config, &home).await?;
-    let _resource_locks = (rootfs_lock, snapshot_lock);
+    let resource_locks = (rootfs_lock, snapshot_lock);
 
     // Block until memory.bin is in page cache so benchmark numbers are stable.
     {
@@ -128,6 +128,7 @@ pub async fn run_benchmark(
     {
         Ok(runtime) => runtime,
         Err(e) => {
+            drop(resource_locks);
             stop_benchmark_proxy(&mut mitm, "runtime_create").await;
             return Err(e.into());
         }
@@ -136,6 +137,7 @@ pub async fn run_benchmark(
         match create_factory_or_shutdown_runtime(runtime.as_mut(), factory_config).await {
             Ok(factory) => factory,
             Err(e) => {
+                drop(resource_locks);
                 stop_benchmark_proxy(&mut mitm, "factory_create").await;
                 return Err(e.into());
             }


### PR DESCRIPTION
## Summary

- explicitly stop benchmark mitmproxy when runtime creation fails after proxy start
- shut down benchmark runtime before stopping proxy when factory creation fails
- add a focused regression test for factory creation failure preserving runtime shutdown

Closes #13314

## Tests

- cargo test --manifest-path crates/Cargo.toml -p runner benchmark
- cargo fmt --manifest-path crates/Cargo.toml --all --check
- cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features -- -D warnings
- pre-commit hook: cargo-fmt, cargo-clippy, cargo-doc