### PR TITLE
fix: avoid symlink traversal in codex session lookup

### DIFF
--- a/crates/guest-agent/src/events.rs
+++ b/crates/guest-agent/src/events.rs
@@ -317,9 +317,7 @@ fn extract_codex_thread_id(event: &Value) -> Option<(String, String)> {
         return None;
     }
     let thread_id = event.get("thread_id").and_then(|v| v.as_str())?;
-    if thread_id.is_empty() {
-        return None;
-    }
+    crate::session_history::normalize_codex_thread_id(thread_id)?;
 
     let home = env::home_dir();
     let marker = format!("CODEX_SEARCH:{home}/.codex/sessions:{thread_id}");

--- a/crates/guest-agent/src/session_history.rs
+++ b/crates/guest-agent/src/session_history.rs
@@ -72,44 +72,46 @@ fn decode_marker(content: &str) -> Option<(PathBuf, &str)> {
 /// "session file not found" rather than guessing at an alternative,
 /// because picking the wrong session would corrupt resume state.
 fn find_codex_session_file(sessions_dir: &Path, thread_id: &str) -> Option<PathBuf> {
-    let mut all_jsonl = Vec::new();
-    walk_recursive(sessions_dir, &mut all_jsonl, |p| {
-        let s = p.to_string_lossy();
-        s.ends_with(".jsonl") || s.ends_with(".jsonl.zst")
-    });
-
     let id_norm = thread_id.replace('-', "");
-    for path in all_jsonl {
-        if let Some(name) = path.file_name() {
-            let name_norm = name.to_string_lossy().replace('-', "");
-            if name_norm.contains(&id_norm) {
-                return Some(path);
+    find_codex_session_file_recursive(sessions_dir, &id_norm)
+}
+
+/// DFS walk of `dir`, returning the first matching real file. Symlinks
+/// are skipped because the Codex sessions tree is user-controlled
+/// filesystem state and checkpoint lookup must not follow it outside the
+/// expected history directory.
+fn find_codex_session_file_recursive(dir: &Path, id_norm: &str) -> Option<PathBuf> {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return None;
+    };
+    for entry in entries.flatten() {
+        let Ok(file_type) = entry.file_type() else {
+            continue;
+        };
+        let path = entry.path();
+        if file_type.is_dir() {
+            if let Some(found) = find_codex_session_file_recursive(&path, id_norm) {
+                return Some(found);
             }
+        } else if file_type.is_file() && codex_session_filename_matches(&path, id_norm) {
+            return Some(path);
         }
     }
 
     None
 }
 
-/// DFS walk of `dir`, pushing matching paths into `sink`. Silently skips
-/// directories that fail to open — codex's date-based layout means most
-/// `YYYY/MM/DD/` subtrees won't exist on a given run, and an io error here
-/// would mask the real lookup failure (no matching file) downstream.
-fn walk_recursive<F>(dir: &Path, sink: &mut Vec<PathBuf>, predicate: F)
-where
-    F: Fn(&Path) -> bool + Copy,
-{
-    let Ok(entries) = std::fs::read_dir(dir) else {
-        return;
+fn codex_session_filename_matches(path: &Path, id_norm: &str) -> bool {
+    let Some(name) = path.file_name() else {
+        return false;
     };
-    for entry in entries.flatten() {
-        let path = entry.path();
-        if path.is_dir() {
-            walk_recursive(&path, sink, predicate);
-        } else if predicate(&path) {
-            sink.push(path);
-        }
+    let name = name.to_string_lossy();
+    if !(name.ends_with(".jsonl") || name.ends_with(".jsonl.zst")) {
+        return false;
     }
+
+    let name_norm = name.replace('-', "");
+    name_norm.contains(id_norm)
 }
 
 /// Read the bytes at `path`, decompressing legacy zstd files if the extension is `.zst`.
@@ -139,10 +141,11 @@ fn read_history_bytes(path: &Path) -> Result<Vec<u8>, AgentError> {
 // (both Claude literal-path and codex marker → recursive scan + zstd
 // decode) lives in `crates/guest-agent/tests/codex_session_resume.rs`,
 // driven via the `send_event` → checkpoint flow. The internal helpers
-// (`find_codex_session_file`, `walk_recursive`, `read_history_bytes`,
-// `decode_marker`) are exercised transitively by those integration
-// tests, in line with the project's "integration tests only" policy
-// (`docs/testing.md`, `CLAUDE.md`).
+// (`find_codex_session_file`, `find_codex_session_file_recursive`,
+// `codex_session_filename_matches`, `read_history_bytes`, `decode_marker`)
+// are exercised transitively by those integration tests, in line with
+// the project's "integration tests only" policy (`docs/testing.md`,
+// `CLAUDE.md`).
 //
 // `decode_marker` is the one piece of non-trivial parsing logic; if it
 // regresses, the integration tests will catch it because the codex flow

--- a/crates/guest-agent/src/session_history.rs
+++ b/crates/guest-agent/src/session_history.rs
@@ -28,7 +28,7 @@ use std::ffi::OsStr;
 use std::io;
 use std::path::{Path, PathBuf};
 
-#[cfg(unix)]
+#[cfg(target_os = "linux")]
 use std::{fs::File, io::Read};
 
 const CODEX_MARKER_PREFIX: &str = "CODEX_SEARCH:";
@@ -75,10 +75,13 @@ fn read_codex_session_history(
     thread_id: &str,
 ) -> Result<Option<Vec<u8>>, AgentError> {
     let id_norm = thread_id.replace('-', "");
+    if id_norm.is_empty() {
+        return Ok(None);
+    }
     read_codex_session_history_impl(sessions_dir, &id_norm)
 }
 
-#[cfg(not(unix))]
+#[cfg(not(target_os = "linux"))]
 fn read_codex_session_history_impl(
     sessions_dir: &Path,
     id_norm: &str,
@@ -96,7 +99,7 @@ fn read_codex_session_history_impl(
     read_history_bytes(&path).map(Some)
 }
 
-#[cfg(not(unix))]
+#[cfg(not(target_os = "linux"))]
 /// DFS walk of `dir`, returning the first matching real file. Symlinks
 /// are skipped because the Codex sessions tree is user-controlled
 /// filesystem state and checkpoint lookup must not follow it outside the
@@ -126,7 +129,7 @@ fn find_codex_session_file_recursive(dir: &Path, id_norm: &str) -> Option<PathBu
     None
 }
 
-#[cfg(unix)]
+#[cfg(target_os = "linux")]
 fn read_codex_session_history_impl(
     sessions_dir: &Path,
     id_norm: &str,
@@ -137,7 +140,7 @@ fn read_codex_session_history_impl(
     find_and_read_codex_session_file_recursive(&root, sessions_dir, id_norm)
 }
 
-#[cfg(unix)]
+#[cfg(target_os = "linux")]
 fn find_and_read_codex_session_file_recursive(
     dir: &File,
     dir_path: &Path,
@@ -191,14 +194,14 @@ fn codex_session_filename_matches(name: &OsStr, id_norm: &str) -> bool {
     name_norm.contains(id_norm)
 }
 
-#[cfg(unix)]
+#[cfg(target_os = "linux")]
 fn read_dir_fd(dir: &File) -> io::Result<std::fs::ReadDir> {
     use std::os::fd::AsRawFd;
 
     std::fs::read_dir(PathBuf::from(format!("/proc/self/fd/{}", dir.as_raw_fd())))
 }
 
-#[cfg(unix)]
+#[cfg(target_os = "linux")]
 fn open_codex_session_dir(path: &Path) -> io::Result<File> {
     use std::fs::OpenOptions;
     use std::os::unix::fs::OpenOptionsExt;
@@ -209,7 +212,7 @@ fn open_codex_session_dir(path: &Path) -> io::Result<File> {
         .open(path)
 }
 
-#[cfg(unix)]
+#[cfg(target_os = "linux")]
 fn open_codex_child_dir(parent: &File, name: &OsStr) -> io::Result<File> {
     open_codex_child(
         parent,
@@ -218,7 +221,7 @@ fn open_codex_child_dir(parent: &File, name: &OsStr) -> io::Result<File> {
     )
 }
 
-#[cfg(unix)]
+#[cfg(target_os = "linux")]
 fn open_codex_child_file(parent: &File, name: &OsStr) -> io::Result<File> {
     open_codex_child(
         parent,
@@ -227,7 +230,7 @@ fn open_codex_child_file(parent: &File, name: &OsStr) -> io::Result<File> {
     )
 }
 
-#[cfg(unix)]
+#[cfg(target_os = "linux")]
 fn open_codex_child(parent: &File, name: &OsStr, flags: i32) -> io::Result<File> {
     use std::ffi::CString;
     use std::os::fd::{AsRawFd, FromRawFd};
@@ -242,7 +245,7 @@ fn open_codex_child(parent: &File, name: &OsStr, flags: i32) -> io::Result<File>
     Ok(unsafe { File::from_raw_fd(fd) })
 }
 
-#[cfg(unix)]
+#[cfg(target_os = "linux")]
 fn should_skip_raced_codex_entry(err: &io::Error) -> bool {
     matches!(
         err.kind(),
@@ -256,7 +259,7 @@ fn read_history_bytes(path: &Path) -> Result<Vec<u8>, AgentError> {
     decode_history_bytes(path, raw)
 }
 
-#[cfg(unix)]
+#[cfg(target_os = "linux")]
 fn read_history_bytes_from_file(path: &Path, mut file: File) -> Result<Vec<u8>, AgentError> {
     let mut raw = Vec::new();
     file.read_to_end(&mut raw)

--- a/crates/guest-agent/src/session_history.rs
+++ b/crates/guest-agent/src/session_history.rs
@@ -24,7 +24,12 @@
 //! `read_session_history` surfaces the failure instead.
 
 use crate::error::AgentError;
+use std::ffi::OsStr;
+use std::io;
 use std::path::{Path, PathBuf};
+
+#[cfg(unix)]
+use std::{fs::File, io::Read};
 
 const CODEX_MARKER_PREFIX: &str = "CODEX_SEARCH:";
 
@@ -39,17 +44,16 @@ pub fn read_session_history(path_file: &str) -> Result<Vec<u8>, AgentError> {
     })?;
     let trimmed = raw.trim();
 
-    let session_path = if let Some((sessions_dir, thread_id)) = decode_marker(trimmed) {
-        find_codex_session_file(&sessions_dir, thread_id).ok_or_else(|| {
+    if let Some((sessions_dir, thread_id)) = decode_marker(trimmed) {
+        return read_codex_session_history(&sessions_dir, thread_id)?.ok_or_else(|| {
             AgentError::Checkpoint(format!(
                 "Codex session file not found under {} for thread_id {thread_id}",
                 sessions_dir.display()
             ))
-        })?
-    } else {
-        PathBuf::from(trimmed)
-    };
+        });
+    }
 
+    let session_path = PathBuf::from(trimmed);
     read_history_bytes(&session_path)
 }
 
@@ -66,23 +70,33 @@ fn decode_marker(content: &str) -> Option<(PathBuf, &str)> {
     Some((PathBuf::from(dir), thread_id))
 }
 
-/// Resolve a codex session file under `sessions_dir` by matching the
-/// dash-stripped `thread_id` substring against filenames. Returns `None`
-/// if no file matches — callers should propagate this as
-/// "session file not found" rather than guessing at an alternative,
-/// because picking the wrong session would corrupt resume state.
-fn find_codex_session_file(sessions_dir: &Path, thread_id: &str) -> Option<PathBuf> {
+fn read_codex_session_history(
+    sessions_dir: &Path,
+    thread_id: &str,
+) -> Result<Option<Vec<u8>>, AgentError> {
+    let id_norm = thread_id.replace('-', "");
+    read_codex_session_history_impl(sessions_dir, &id_norm)
+}
+
+#[cfg(not(unix))]
+fn read_codex_session_history_impl(
+    sessions_dir: &Path,
+    id_norm: &str,
+) -> Result<Option<Vec<u8>>, AgentError> {
     if !std::fs::symlink_metadata(sessions_dir)
         .ok()
         .is_some_and(|metadata| metadata.file_type().is_dir())
     {
-        return None;
+        return Ok(None);
     }
 
-    let id_norm = thread_id.replace('-', "");
-    find_codex_session_file_recursive(sessions_dir, &id_norm)
+    let Some(path) = find_codex_session_file_recursive(sessions_dir, id_norm) else {
+        return Ok(None);
+    };
+    read_history_bytes(&path).map(Some)
 }
 
+#[cfg(not(unix))]
 /// DFS walk of `dir`, returning the first matching real file. Symlinks
 /// are skipped because the Codex sessions tree is user-controlled
 /// filesystem state and checkpoint lookup must not follow it outside the
@@ -100,7 +114,11 @@ fn find_codex_session_file_recursive(dir: &Path, id_norm: &str) -> Option<PathBu
             if let Some(found) = find_codex_session_file_recursive(&path, id_norm) {
                 return Some(found);
             }
-        } else if file_type.is_file() && codex_session_filename_matches(&path, id_norm) {
+        } else if file_type.is_file()
+            && path
+                .file_name()
+                .is_some_and(|name| codex_session_filename_matches(name, id_norm))
+        {
             return Some(path);
         }
     }
@@ -108,10 +126,62 @@ fn find_codex_session_file_recursive(dir: &Path, id_norm: &str) -> Option<PathBu
     None
 }
 
-fn codex_session_filename_matches(path: &Path, id_norm: &str) -> bool {
-    let Some(name) = path.file_name() else {
-        return false;
+#[cfg(unix)]
+fn read_codex_session_history_impl(
+    sessions_dir: &Path,
+    id_norm: &str,
+) -> Result<Option<Vec<u8>>, AgentError> {
+    let Ok(root) = open_codex_session_dir(sessions_dir) else {
+        return Ok(None);
     };
+    find_and_read_codex_session_file_recursive(&root, sessions_dir, id_norm)
+}
+
+#[cfg(unix)]
+fn find_and_read_codex_session_file_recursive(
+    dir: &File,
+    dir_path: &Path,
+    id_norm: &str,
+) -> Result<Option<Vec<u8>>, AgentError> {
+    let Ok(entries) = read_dir_fd(dir) else {
+        return Ok(None);
+    };
+
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let Ok(file_type) = entry.file_type() else {
+            continue;
+        };
+        let path = dir_path.join(&name);
+        if file_type.is_dir() {
+            let Ok(child) = open_codex_child_dir(dir, &name) else {
+                continue;
+            };
+            if let Some(found) = find_and_read_codex_session_file_recursive(&child, &path, id_norm)?
+            {
+                return Ok(Some(found));
+            }
+        } else if file_type.is_file() && codex_session_filename_matches(&name, id_norm) {
+            let file = match open_codex_child_file(dir, &name) {
+                Ok(file) => file,
+                Err(e) if should_skip_raced_codex_entry(&e) => continue,
+                Err(e) => return Err(read_history_error(&path, e)),
+            };
+            if !file
+                .metadata()
+                .ok()
+                .is_some_and(|metadata| metadata.file_type().is_file())
+            {
+                continue;
+            }
+            return read_history_bytes_from_file(&path, file).map(Some);
+        }
+    }
+
+    Ok(None)
+}
+
+fn codex_session_filename_matches(name: &OsStr, id_norm: &str) -> bool {
     let name = name.to_string_lossy();
     if !(name.ends_with(".jsonl") || name.ends_with(".jsonl.zst")) {
         return false;
@@ -121,14 +191,87 @@ fn codex_session_filename_matches(path: &Path, id_norm: &str) -> bool {
     name_norm.contains(id_norm)
 }
 
+#[cfg(unix)]
+fn read_dir_fd(dir: &File) -> io::Result<std::fs::ReadDir> {
+    use std::os::fd::AsRawFd;
+
+    std::fs::read_dir(PathBuf::from(format!("/proc/self/fd/{}", dir.as_raw_fd())))
+}
+
+#[cfg(unix)]
+fn open_codex_session_dir(path: &Path) -> io::Result<File> {
+    use std::fs::OpenOptions;
+    use std::os::unix::fs::OpenOptionsExt;
+
+    OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC)
+        .open(path)
+}
+
+#[cfg(unix)]
+fn open_codex_child_dir(parent: &File, name: &OsStr) -> io::Result<File> {
+    open_codex_child(
+        parent,
+        name,
+        libc::O_RDONLY | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+    )
+}
+
+#[cfg(unix)]
+fn open_codex_child_file(parent: &File, name: &OsStr) -> io::Result<File> {
+    open_codex_child(
+        parent,
+        name,
+        libc::O_RDONLY | libc::O_NOFOLLOW | libc::O_CLOEXEC | libc::O_NONBLOCK,
+    )
+}
+
+#[cfg(unix)]
+fn open_codex_child(parent: &File, name: &OsStr, flags: i32) -> io::Result<File> {
+    use std::ffi::CString;
+    use std::os::fd::{AsRawFd, FromRawFd};
+    use std::os::unix::ffi::OsStrExt;
+
+    let name = CString::new(name.as_bytes())
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
+    let fd = unsafe { libc::openat(parent.as_raw_fd(), name.as_ptr(), flags) };
+    if fd < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(unsafe { File::from_raw_fd(fd) })
+}
+
+#[cfg(unix)]
+fn should_skip_raced_codex_entry(err: &io::Error) -> bool {
+    matches!(
+        err.kind(),
+        io::ErrorKind::NotFound | io::ErrorKind::NotADirectory
+    ) || err.raw_os_error() == Some(libc::ELOOP)
+}
+
 /// Read the bytes at `path`, decompressing legacy zstd files if the extension is `.zst`.
 fn read_history_bytes(path: &Path) -> Result<Vec<u8>, AgentError> {
-    let raw = std::fs::read(path).map_err(|e| {
-        AgentError::Checkpoint(format!(
-            "Failed to read session history at {}: {e}",
-            path.display()
-        ))
-    })?;
+    let raw = std::fs::read(path).map_err(|e| read_history_error(path, e))?;
+    decode_history_bytes(path, raw)
+}
+
+#[cfg(unix)]
+fn read_history_bytes_from_file(path: &Path, mut file: File) -> Result<Vec<u8>, AgentError> {
+    let mut raw = Vec::new();
+    file.read_to_end(&mut raw)
+        .map_err(|e| read_history_error(path, e))?;
+    decode_history_bytes(path, raw)
+}
+
+fn read_history_error(path: &Path, source: io::Error) -> AgentError {
+    AgentError::Checkpoint(format!(
+        "Failed to read session history at {}: {source}",
+        path.display()
+    ))
+}
+
+fn decode_history_bytes(path: &Path, raw: Vec<u8>) -> Result<Vec<u8>, AgentError> {
     if path
         .extension()
         .is_some_and(|ext| ext.eq_ignore_ascii_case("zst"))
@@ -148,11 +291,10 @@ fn read_history_bytes(path: &Path) -> Result<Vec<u8>, AgentError> {
 // (both Claude literal-path and codex marker → recursive scan + zstd
 // decode) lives in `crates/guest-agent/tests/codex_session_resume.rs`,
 // driven via the `send_event` → checkpoint flow. The internal helpers
-// (`find_codex_session_file`, `find_codex_session_file_recursive`,
-// `codex_session_filename_matches`, `read_history_bytes`, `decode_marker`)
-// are exercised transitively by those integration tests, in line with
-// the project's "integration tests only" policy (`docs/testing.md`,
-// `CLAUDE.md`).
+// (`read_codex_session_history`, `codex_session_filename_matches`,
+// `read_history_bytes`, `decode_marker`) are exercised transitively by
+// those integration tests, in line with the project's "integration
+// tests only" policy (`docs/testing.md`, `CLAUDE.md`).
 //
 // `decode_marker` is the one piece of non-trivial parsing logic; if it
 // regresses, the integration tests will catch it because the codex flow

--- a/crates/guest-agent/src/session_history.rs
+++ b/crates/guest-agent/src/session_history.rs
@@ -72,6 +72,13 @@ fn decode_marker(content: &str) -> Option<(PathBuf, &str)> {
 /// "session file not found" rather than guessing at an alternative,
 /// because picking the wrong session would corrupt resume state.
 fn find_codex_session_file(sessions_dir: &Path, thread_id: &str) -> Option<PathBuf> {
+    if !std::fs::symlink_metadata(sessions_dir)
+        .ok()
+        .is_some_and(|metadata| metadata.file_type().is_dir())
+    {
+        return None;
+    }
+
     let id_norm = thread_id.replace('-', "");
     find_codex_session_file_recursive(sessions_dir, &id_norm)
 }

--- a/crates/guest-agent/src/session_history.rs
+++ b/crates/guest-agent/src/session_history.rs
@@ -74,11 +74,18 @@ fn read_codex_session_history(
     sessions_dir: &Path,
     thread_id: &str,
 ) -> Result<Option<Vec<u8>>, AgentError> {
-    let id_norm = thread_id.replace('-', "");
-    if id_norm.is_empty() {
+    let Some(id_norm) = normalize_codex_thread_id(thread_id) else {
         return Ok(None);
-    }
+    };
     read_codex_session_history_impl(sessions_dir, &id_norm)
+}
+
+pub(crate) fn normalize_codex_thread_id(thread_id: &str) -> Option<String> {
+    let id_norm = thread_id.replace('-', "");
+    if id_norm.len() != 32 || !id_norm.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        return None;
+    }
+    Some(id_norm.to_ascii_lowercase())
 }
 
 #[cfg(not(target_os = "linux"))]
@@ -190,7 +197,7 @@ fn codex_session_filename_matches(name: &OsStr, id_norm: &str) -> bool {
         return false;
     }
 
-    let name_norm = name.replace('-', "");
+    let name_norm = name.replace('-', "").to_ascii_lowercase();
     name_norm.contains(id_norm)
 }
 

--- a/crates/guest-agent/tests/codex_session_resume.rs
+++ b/crates/guest-agent/tests/codex_session_resume.rs
@@ -359,6 +359,44 @@ async fn read_session_history_codex_marker_skips_symlinks() {
     );
 }
 
+#[cfg(unix)]
+#[tokio::test]
+async fn read_session_history_codex_marker_rejects_symlinked_sessions_root() {
+    use std::os::unix::fs::symlink;
+
+    setup_env_once();
+    let _guard = TEST_MUTEX.lock().unwrap();
+    reset_session_files();
+
+    let tmp = tempfile::tempdir().unwrap();
+    let real_sessions_dir = tmp.path().join("real-sessions");
+    let sessions_link = tmp.path().join("sessions-link");
+    std::fs::create_dir_all(&real_sessions_dir).unwrap();
+
+    let thread_id = "0193abcd-ef01-7234-89ab-cdef01234567";
+    std::fs::write(
+        real_sessions_dir.join(format!("{thread_id}.jsonl")),
+        b"outside-root-history\n",
+    )
+    .unwrap();
+    symlink(&real_sessions_dir, &sessions_link).unwrap();
+
+    let path_file = tmp.path().join("path.txt");
+    let marker = format!(
+        "CODEX_SEARCH:{}:{thread_id}",
+        sessions_link.to_string_lossy()
+    );
+    std::fs::write(&path_file, marker.as_bytes()).unwrap();
+
+    let err = guest_agent::session_history::read_session_history(path_file.to_str().unwrap())
+        .expect_err("codex lookup must not follow a symlinked sessions root");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("Codex session file not found"),
+        "expected symlinked sessions root to be ignored, got: {msg}"
+    );
+}
+
 #[tokio::test]
 async fn read_session_history_resolves_claude_literal_path() {
     // Claude path goes through the same public entry but uses a literal

--- a/crates/guest-agent/tests/codex_session_resume.rs
+++ b/crates/guest-agent/tests/codex_session_resume.rs
@@ -312,6 +312,35 @@ async fn read_session_history_codex_marker_with_no_match_fails_fast() {
     );
 }
 
+#[tokio::test]
+async fn read_session_history_codex_marker_rejects_dash_only_thread_id() {
+    setup_env_once();
+    let _guard = TEST_MUTEX.lock().unwrap();
+    reset_session_files();
+
+    let tmp = tempfile::tempdir().unwrap();
+    let sessions_dir = tmp.path().join("sessions");
+    write_session_file(
+        &sessions_dir,
+        &["2026", "04", "27"],
+        "rollout-unrelated.jsonl",
+        b"unrelated\n",
+    )
+    .unwrap();
+
+    let path_file = tmp.path().join("path.txt");
+    let marker = format!("CODEX_SEARCH:{}:---", sessions_dir.to_string_lossy());
+    std::fs::write(&path_file, marker.as_bytes()).unwrap();
+
+    let err = guest_agent::session_history::read_session_history(path_file.to_str().unwrap())
+        .expect_err("dash-only codex thread id must not match every history file");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("Codex session file not found"),
+        "expected malformed thread id to fail fast, got: {msg}"
+    );
+}
+
 #[cfg(unix)]
 #[tokio::test]
 async fn read_session_history_codex_marker_skips_symlinks() {

--- a/crates/guest-agent/tests/codex_session_resume.rs
+++ b/crates/guest-agent/tests/codex_session_resume.rs
@@ -397,6 +397,38 @@ async fn read_session_history_codex_marker_rejects_symlinked_sessions_root() {
     );
 }
 
+#[cfg(unix)]
+#[tokio::test]
+async fn read_session_history_codex_marker_skips_special_files() {
+    use std::os::unix::net::UnixListener;
+
+    setup_env_once();
+    let _guard = TEST_MUTEX.lock().unwrap();
+    reset_session_files();
+
+    let tmp = tempfile::tempdir().unwrap();
+    let sessions_dir = tmp.path().join("sessions");
+    std::fs::create_dir_all(&sessions_dir).unwrap();
+
+    let thread_id = "0193abcd-ef01-7234-89ab-cdef01234567";
+    let _socket = UnixListener::bind(sessions_dir.join(format!("{thread_id}.jsonl"))).unwrap();
+
+    let path_file = tmp.path().join("path.txt");
+    let marker = format!(
+        "CODEX_SEARCH:{}:{thread_id}",
+        sessions_dir.to_string_lossy()
+    );
+    std::fs::write(&path_file, marker.as_bytes()).unwrap();
+
+    let err = guest_agent::session_history::read_session_history(path_file.to_str().unwrap())
+        .expect_err("codex lookup must ignore matching non-regular files");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("Codex session file not found"),
+        "expected matching special file to be ignored, got: {msg}"
+    );
+}
+
 #[tokio::test]
 async fn read_session_history_resolves_claude_literal_path() {
     // Claude path goes through the same public entry but uses a literal

--- a/crates/guest-agent/tests/codex_session_resume.rs
+++ b/crates/guest-agent/tests/codex_session_resume.rs
@@ -176,6 +176,23 @@ async fn send_event_codex_ignores_empty_thread_id() {
 }
 
 #[tokio::test]
+async fn send_event_codex_ignores_malformed_thread_id() {
+    setup_env_once();
+    let _guard = TEST_MUTEX.lock().unwrap();
+    reset_session_files();
+
+    let masker = SecretMasker::from_raw("");
+    let mut event = json!({"type": "thread.started", "thread_id": "abc"});
+    let result = guest_agent::events::send_event(&http_client!(), &mut event, 1, &masker).await;
+    assert!(result.is_ok());
+
+    assert!(
+        !Path::new(guest_agent::paths::session_id_file()).exists(),
+        "malformed thread_id must not be persisted"
+    );
+}
+
+#[tokio::test]
 async fn read_session_history_resolves_codex_marker_end_to_end() {
     setup_env_once();
     let _guard = TEST_MUTEX.lock().unwrap();
@@ -334,6 +351,35 @@ async fn read_session_history_codex_marker_rejects_dash_only_thread_id() {
 
     let err = guest_agent::session_history::read_session_history(path_file.to_str().unwrap())
         .expect_err("dash-only codex thread id must not match every history file");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("Codex session file not found"),
+        "expected malformed thread id to fail fast, got: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn read_session_history_codex_marker_rejects_short_thread_id() {
+    setup_env_once();
+    let _guard = TEST_MUTEX.lock().unwrap();
+    reset_session_files();
+
+    let tmp = tempfile::tempdir().unwrap();
+    let sessions_dir = tmp.path().join("sessions");
+    write_session_file(
+        &sessions_dir,
+        &["2026", "04", "27"],
+        "rollout-abc.jsonl",
+        b"unrelated\n",
+    )
+    .unwrap();
+
+    let path_file = tmp.path().join("path.txt");
+    let marker = format!("CODEX_SEARCH:{}:abc", sessions_dir.to_string_lossy());
+    std::fs::write(&path_file, marker.as_bytes()).unwrap();
+
+    let err = guest_agent::session_history::read_session_history(path_file.to_str().unwrap())
+        .expect_err("short codex thread id must not match unrelated history files");
     let msg = err.to_string();
     assert!(
         msg.contains("Codex session file not found"),

--- a/crates/guest-agent/tests/codex_session_resume.rs
+++ b/crates/guest-agent/tests/codex_session_resume.rs
@@ -312,6 +312,53 @@ async fn read_session_history_codex_marker_with_no_match_fails_fast() {
     );
 }
 
+#[cfg(unix)]
+#[tokio::test]
+async fn read_session_history_codex_marker_skips_symlinks() {
+    use std::os::unix::fs::symlink;
+
+    setup_env_once();
+    let _guard = TEST_MUTEX.lock().unwrap();
+    reset_session_files();
+
+    let tmp = tempfile::tempdir().unwrap();
+    let sessions_dir = tmp.path().join("sessions");
+    let outside_dir = tmp.path().join("outside");
+    std::fs::create_dir_all(&sessions_dir).unwrap();
+    std::fs::create_dir_all(&outside_dir).unwrap();
+
+    let thread_id = "0193abcd-ef01-7234-89ab-cdef01234567";
+    let outside_history = outside_dir.join(format!("{thread_id}.jsonl"));
+    std::fs::write(&outside_history, b"outside-history\n").unwrap();
+
+    symlink(&outside_dir, sessions_dir.join("linked-outside")).unwrap();
+    symlink(
+        &outside_history,
+        sessions_dir.join(format!("{thread_id}.jsonl")),
+    )
+    .unwrap();
+    symlink(
+        "/definitely/missing/codex-history.jsonl",
+        sessions_dir.join("dangling.jsonl"),
+    )
+    .unwrap();
+
+    let path_file = tmp.path().join("path.txt");
+    let marker = format!(
+        "CODEX_SEARCH:{}:{thread_id}",
+        sessions_dir.to_string_lossy()
+    );
+    std::fs::write(&path_file, marker.as_bytes()).unwrap();
+
+    let err = guest_agent::session_history::read_session_history(path_file.to_str().unwrap())
+        .expect_err("codex lookup must not follow symlinked history paths");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("Codex session file not found"),
+        "expected symlinked candidates to be ignored, got: {msg}"
+    );
+}
+
 #[tokio::test]
 async fn read_session_history_resolves_claude_literal_path() {
     // Claude path goes through the same public entry but uses a literal


### PR DESCRIPTION
## Summary
- resolve Codex session history with a no-follow DFS that only recurses into real directories
- skip symlinked history candidates and return as soon as a real matching file is found
- add public-entry regression coverage for symlinked Codex session paths

Closes #13301

## Tests
- cargo test --manifest-path crates/Cargo.toml -p guest-agent --test codex_session_resume
- cargo fmt --manifest-path crates/Cargo.toml --all --check
- CARGO_BUILD_JOBS=1 cargo clippy --manifest-path crates/Cargo.toml -p guest-agent --all-targets --all-features --quiet
- cargo test --manifest-path crates/Cargo.toml -p guest-agent --quiet
- pre-commit hook: cargo-doc, cargo-clippy