### PR TITLE
feat(sandbox-fc): gate guest operations for park

### DIFF
--- a/crates/sandbox-fc/src/control.rs
+++ b/crates/sandbox-fc/src/control.rs
@@ -635,7 +635,7 @@ fn resolve_control_socket_in(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::park_coordinator::ParkCoordinator;
+    use crate::park_coordinator::{CoordinatorState, ParkCoordinator};
     use tokio::sync::oneshot;
     use vsock_host::VsockHost;
     use vsock_proto::{Decoder, MSG_COMMAND_START, MSG_PING, MSG_PONG, MSG_READY, RawMessage};
@@ -903,7 +903,8 @@ mod tests {
 
         let sock_path = dir.path().join("control.sock");
         let guest = Arc::new(tokio::sync::Mutex::new(Some(Arc::new(vsock))));
-        let mut handle = bind_server(sock_path.clone(), test_gate(guest))
+        let (gate, coordinator) = test_gate_with_coordinator(guest);
+        let mut handle = bind_server(sock_path.clone(), gate)
             .unwrap()
             .spawn(CancellationToken::new());
         let client = tokio::spawn({
@@ -931,6 +932,10 @@ mod tests {
             .unwrap()
             .unwrap();
         assert!(client_result.is_err());
+        assert!(
+            matches!(coordinator.state(), CoordinatorState::Dirty { .. }),
+            "cancelled in-flight control exec should mark the operation gate dirty"
+        );
 
         guest_task.abort();
         let _ = guest_task.await;

--- a/crates/sandbox-fc/src/control.rs
+++ b/crates/sandbox-fc/src/control.rs
@@ -638,7 +638,9 @@ mod tests {
     use crate::park_coordinator::{CoordinatorState, ParkCoordinator};
     use tokio::sync::oneshot;
     use vsock_host::VsockHost;
-    use vsock_proto::{Decoder, MSG_COMMAND_START, MSG_PING, MSG_PONG, MSG_READY, RawMessage};
+    use vsock_proto::{
+        Decoder, MSG_COMMAND_START, MSG_ERROR, MSG_PING, MSG_PONG, MSG_READY, RawMessage,
+    };
 
     fn test_gate(guest: Arc<tokio::sync::Mutex<Option<Arc<VsockHost>>>>) -> GuestOperationGate {
         GuestOperationGate::new(guest, ParkCoordinator::new())
@@ -1000,6 +1002,54 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn control_exec_terminal_guest_error_completes_operation_gate() {
+        let dir = tempfile::tempdir().unwrap();
+        let vsock_base = dir.path().join("vsock");
+        let host_task = {
+            let vsock_base = vsock_base.display().to_string();
+            tokio::spawn(async move {
+                VsockHost::wait_for_connection(&vsock_base, Duration::from_secs(5)).await
+            })
+        };
+        let guest_task = tokio::spawn(mock_guest_errors_exec(vsock_base, "guest refused exec"));
+        let vsock = host_task.await.unwrap().unwrap();
+
+        let sock_path = dir.path().join("control.sock");
+        let guest = Arc::new(tokio::sync::Mutex::new(Some(Arc::new(vsock))));
+        let (gate, coordinator) = test_gate_with_coordinator(guest);
+        let mut handle = bind_server(sock_path.clone(), gate)
+            .unwrap()
+            .spawn(CancellationToken::new());
+
+        let request = ExecRequest {
+            command: "exit-before-start".into(),
+            timeout_secs: 5,
+            sudo: false,
+        };
+        let response = send_exec(&sock_path, &request, Duration::from_secs(5))
+            .await
+            .unwrap();
+
+        match response {
+            ExecResponse::Error { error } => {
+                assert!(
+                    error.contains("guest refused exec"),
+                    "unexpected error: {error}"
+                );
+            }
+            ExecResponse::Success { .. } => panic!("expected guest error"),
+        }
+        assert_eq!(coordinator.active_operation_count(), 0);
+        let attempt = coordinator
+            .begin_prepare_park()
+            .expect("terminal guest error should complete the operation");
+        coordinator.abort_prepare_park(&attempt).unwrap();
+
+        handle.shutdown().await;
+        guest_task.await.unwrap();
+    }
+
+    #[tokio::test]
     async fn bind_server_reports_bind_failure() {
         let dir = tempfile::tempdir().unwrap();
         let sock_path = dir.path().join("control.sock");
@@ -1070,6 +1120,29 @@ mod tests {
 
     async fn mock_guest_records_exec(vsock_base: PathBuf, exec_seen: oneshot::Sender<()>) {
         mock_guest_until_exec(vsock_base, exec_seen, false).await;
+    }
+
+    async fn mock_guest_errors_exec(vsock_base: PathBuf, error: &'static str) {
+        let listener_path = PathBuf::from(format!(
+            "{}_{}",
+            vsock_base.display(),
+            vsock_proto::VSOCK_PORT
+        ));
+        wait_for_socket_exists(&listener_path).await;
+
+        let mut stream = UnixStream::connect(&listener_path).await.unwrap();
+        let mut decoder = Decoder::new();
+        mock_vsock_handshake(&mut stream, &mut decoder).await;
+
+        loop {
+            let message = read_vsock_message(&mut stream, &mut decoder).await;
+            if message.msg_type == MSG_COMMAND_START {
+                let payload = vsock_proto::encode_error(error);
+                let frame = vsock_proto::encode(MSG_ERROR, message.seq, &payload).unwrap();
+                stream.write_all(&frame).await.unwrap();
+                return;
+            }
+        }
     }
 
     async fn mock_guest_until_exec(

--- a/crates/sandbox-fc/src/control.rs
+++ b/crates/sandbox-fc/src/control.rs
@@ -957,7 +957,7 @@ mod tests {
             })
         };
         let (exec_seen_tx, mut exec_seen_rx) = oneshot::channel();
-        let guest_task = tokio::spawn(mock_guest_holds_exec(vsock_base, exec_seen_tx));
+        let guest_task = tokio::spawn(mock_guest_records_exec(vsock_base, exec_seen_tx));
         let vsock = host_task.await.unwrap().unwrap();
 
         let sock_path = dir.path().join("control.sock");
@@ -1065,6 +1065,18 @@ mod tests {
     }
 
     async fn mock_guest_holds_exec(vsock_base: PathBuf, exec_seen: oneshot::Sender<()>) {
+        mock_guest_until_exec(vsock_base, exec_seen, true).await;
+    }
+
+    async fn mock_guest_records_exec(vsock_base: PathBuf, exec_seen: oneshot::Sender<()>) {
+        mock_guest_until_exec(vsock_base, exec_seen, false).await;
+    }
+
+    async fn mock_guest_until_exec(
+        vsock_base: PathBuf,
+        exec_seen: oneshot::Sender<()>,
+        hold_after_exec: bool,
+    ) {
         let listener_path = PathBuf::from(format!(
             "{}_{}",
             vsock_base.display(),
@@ -1089,7 +1101,9 @@ mod tests {
                     if let Some(tx) = exec_seen.take() {
                         let _ = tx.send(());
                     }
-                    tokio::time::sleep(Duration::from_secs(30)).await;
+                    if hold_after_exec {
+                        tokio::time::sleep(Duration::from_secs(30)).await;
+                    }
                     return;
                 }
             }

--- a/crates/sandbox-fc/src/control.rs
+++ b/crates/sandbox-fc/src/control.rs
@@ -1175,7 +1175,7 @@ mod tests {
                         let _ = tx.send(());
                     }
                     if hold_after_exec {
-                        tokio::time::sleep(Duration::from_secs(30)).await;
+                        std::future::pending::<()>().await;
                     }
                     return;
                 }

--- a/crates/sandbox-fc/src/control.rs
+++ b/crates/sandbox-fc/src/control.rs
@@ -24,8 +24,10 @@ use tokio::net::{UnixListener, UnixStream};
 use tokio::task::{JoinHandle, JoinSet};
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
-use vsock_host::VsockHost;
 
+use crate::guest_operations::{
+    GuestOperationGate, GuestOperationStartError, guest_error_is_terminal,
+};
 use crate::paths::{RuntimePaths, SockPaths};
 
 // -----------------------------------------------------------------------
@@ -108,7 +110,7 @@ async fn write_frame(stream: &mut UnixStream, data: &[u8]) -> io::Result<()> {
 pub(crate) struct BoundControlServer {
     sock_path: Option<SocketPathGuard>,
     listener: Option<UnixListener>,
-    guest: Arc<tokio::sync::Mutex<Option<Arc<VsockHost>>>>,
+    guest_operations: GuestOperationGate,
 }
 
 impl BoundControlServer {
@@ -125,7 +127,7 @@ impl BoundControlServer {
         let task = spawn_bound_server(
             listener,
             sock_path.clone(),
-            Arc::clone(&self.guest),
+            self.guest_operations.clone(),
             shutdown.clone(),
         );
         ControlServerHandle {
@@ -251,14 +253,14 @@ impl SocketPathGuard {
 /// Bind the control socket before spawning the accept loop.
 pub(crate) fn bind_server(
     sock_path: PathBuf,
-    guest: Arc<tokio::sync::Mutex<Option<Arc<VsockHost>>>>,
+    guest_operations: GuestOperationGate,
 ) -> io::Result<BoundControlServer> {
     let listener = bind_unix_listener(&sock_path)?;
     let sock_path = SocketPathGuard::new(sock_path);
     Ok(BoundControlServer {
         sock_path: Some(sock_path),
         listener: Some(listener),
-        guest,
+        guest_operations,
     })
 }
 
@@ -282,7 +284,7 @@ fn remove_socket_path(sock_path: &Path) {
 fn spawn_bound_server(
     listener: UnixListener,
     sock_path: SocketPathGuard,
-    guest: Arc<tokio::sync::Mutex<Option<Arc<VsockHost>>>>,
+    guest_operations: GuestOperationGate,
     shutdown: CancellationToken,
 ) -> JoinHandle<()> {
     tokio::spawn(async move {
@@ -311,10 +313,10 @@ fn spawn_bound_server(
                         }
                     };
 
-                    let guest = Arc::clone(&guest);
+                    let guest_operations = guest_operations.clone();
                     let handler_shutdown = shutdown.clone();
                     handlers.spawn(async move {
-                        if let Err(e) = handle_connection(stream, guest, handler_shutdown).await {
+                        if let Err(e) = handle_connection(stream, guest_operations, handler_shutdown).await {
                             warn!(error = %e, "control connection handler error");
                         }
                     });
@@ -367,7 +369,7 @@ async fn shutdown_handlers(handlers: &mut JoinSet<()>) {
 /// Handle a single control socket connection.
 async fn handle_connection(
     mut stream: UnixStream,
-    guest: Arc<tokio::sync::Mutex<Option<Arc<VsockHost>>>>,
+    guest_operations: GuestOperationGate,
     shutdown: CancellationToken,
 ) -> io::Result<()> {
     let frame = tokio::select! {
@@ -380,7 +382,7 @@ async fn handle_connection(
         Ok(request) => tokio::select! {
             biased;
             () = shutdown.cancelled() => return Ok(()),
-            response = execute(request, &guest) => response,
+            response = execute(request, &guest_operations) => response,
         },
         Err(e) => ExecResponse::Error {
             error: format!("invalid request: {e}"),
@@ -398,27 +400,27 @@ async fn handle_connection(
     Ok(())
 }
 
-/// Execute an [`ExecRequest`] against the sandbox's VsockHost.
-async fn execute(
-    request: ExecRequest,
-    guest: &Arc<tokio::sync::Mutex<Option<Arc<VsockHost>>>>,
-) -> ExecResponse {
-    let vsock = {
-        let lock = guest.lock().await;
-        match lock.as_ref() {
-            Some(v) => Arc::clone(v),
-            None => {
-                return ExecResponse::Error {
-                    error: "sandbox not running".into(),
-                };
-            }
+/// Execute an [`ExecRequest`] through the sandbox operation gate.
+async fn execute(request: ExecRequest, guest_operations: &GuestOperationGate) -> ExecResponse {
+    let mut operation = match guest_operations.begin_control_operation().await {
+        Ok(operation) => operation,
+        Err(error) => {
+            return ExecResponse::Error {
+                error: control_start_error(error),
+            };
         }
     };
+    if let Err(error) = operation.mark_writing() {
+        return ExecResponse::Error {
+            error: format!("operation gate transition failed: {error:?}"),
+        };
+    }
 
+    let vsock = operation.guest();
     let timeout_ms = request.timeout_secs.saturating_mul(1000);
     let env: &[(&str, &str)] = &[];
 
-    match vsock
+    let result = vsock
         .exec_capture(vsock_host::CommandCaptureRequest {
             command: &request.command,
             timeout_ms,
@@ -430,18 +432,47 @@ async fn execute(
             expected_exit_codes: &[],
             wait_timeout: Duration::from_millis(timeout_ms as u64 + 5000),
         })
-        .await
-    {
-        Ok(result) => ExecResponse::Success {
-            exit_code: result.exit_code,
-            stdout: BASE64.encode(&result.stdout),
-            stderr: BASE64.encode(&result.stderr),
-            stdout_truncated: result.stdout_truncated,
-            stderr_truncated: result.stderr_truncated,
-        },
-        Err(e) => ExecResponse::Error {
-            error: format!("exec failed: {e}"),
-        },
+        .await;
+
+    match result {
+        Ok(result) => {
+            if let Err(error) = operation.complete() {
+                return ExecResponse::Error {
+                    error: format!("operation gate completion failed: {error:?}"),
+                };
+            }
+            ExecResponse::Success {
+                exit_code: result.exit_code,
+                stdout: BASE64.encode(&result.stdout),
+                stderr: BASE64.encode(&result.stderr),
+                stdout_truncated: result.stdout_truncated,
+                stderr_truncated: result.stderr_truncated,
+            }
+        }
+        Err(e) => {
+            let message = format!("exec failed: {e}");
+            if guest_error_is_terminal(&e, false)
+                && let Err(error) = operation.complete()
+            {
+                return ExecResponse::Error {
+                    error: format!("operation gate completion failed: {error:?}"),
+                };
+            }
+            ExecResponse::Error { error: message }
+        }
+    }
+}
+
+fn control_start_error(error: GuestOperationStartError) -> String {
+    match error {
+        GuestOperationStartError::BackendCrashed => "sandbox backend crashed".into(),
+        GuestOperationStartError::NotRunning { state } => {
+            format!("sandbox not running (state={state})")
+        }
+        GuestOperationStartError::NoGuest => "sandbox not running".into(),
+        GuestOperationStartError::GateClosed { state } => {
+            format!("sandbox operation gate closed: {state:?}")
+        }
     }
 }
 
@@ -604,8 +635,24 @@ fn resolve_control_socket_in(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::park_coordinator::ParkCoordinator;
     use tokio::sync::oneshot;
+    use vsock_host::VsockHost;
     use vsock_proto::{Decoder, MSG_COMMAND_START, MSG_PING, MSG_PONG, MSG_READY, RawMessage};
+
+    fn test_gate(guest: Arc<tokio::sync::Mutex<Option<Arc<VsockHost>>>>) -> GuestOperationGate {
+        GuestOperationGate::new(guest, ParkCoordinator::new())
+    }
+
+    fn test_gate_with_coordinator(
+        guest: Arc<tokio::sync::Mutex<Option<Arc<VsockHost>>>>,
+    ) -> (GuestOperationGate, ParkCoordinator) {
+        let coordinator = ParkCoordinator::new();
+        (
+            GuestOperationGate::new(guest, coordinator.clone()),
+            coordinator,
+        )
+    }
 
     #[tokio::test]
     async fn exec_remote_empty_id() {
@@ -713,7 +760,7 @@ mod tests {
 
         // Server with no guest connected.
         let guest = Arc::new(tokio::sync::Mutex::new(None::<Arc<VsockHost>>));
-        let mut handle = bind_server(sock_path.clone(), guest)
+        let mut handle = bind_server(sock_path.clone(), test_gate(guest))
             .unwrap()
             .spawn(CancellationToken::new());
 
@@ -743,7 +790,7 @@ mod tests {
         let sock_path = dir.path().join("control.sock");
         let guest = Arc::new(tokio::sync::Mutex::new(None::<Arc<VsockHost>>));
 
-        let server = bind_server(sock_path.clone(), guest).unwrap();
+        let server = bind_server(sock_path.clone(), test_gate(guest)).unwrap();
         assert!(sock_path.exists());
 
         server.close();
@@ -758,7 +805,7 @@ mod tests {
         let guest = Arc::new(tokio::sync::Mutex::new(None::<Arc<VsockHost>>));
 
         {
-            let _server = bind_server(sock_path.clone(), guest).unwrap();
+            let _server = bind_server(sock_path.clone(), test_gate(guest)).unwrap();
             assert!(sock_path.exists());
         }
 
@@ -770,7 +817,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let sock_path = dir.path().join("control.sock");
         let guest = Arc::new(tokio::sync::Mutex::new(None::<Arc<VsockHost>>));
-        let mut handle = bind_server(sock_path.clone(), guest)
+        let mut handle = bind_server(sock_path.clone(), test_gate(guest))
             .unwrap()
             .spawn(CancellationToken::new());
 
@@ -790,7 +837,7 @@ mod tests {
         let sock_path = dir.path().join("control.sock");
         let guest = Arc::new(tokio::sync::Mutex::new(None::<Arc<VsockHost>>));
         let shutdown = CancellationToken::new();
-        let mut handle = bind_server(sock_path.clone(), guest)
+        let mut handle = bind_server(sock_path.clone(), test_gate(guest))
             .unwrap()
             .spawn(shutdown.clone());
 
@@ -807,7 +854,7 @@ mod tests {
         let sock_path = dir.path().join("control.sock");
         let guest = Arc::new(tokio::sync::Mutex::new(None::<Arc<VsockHost>>));
         let shutdown = CancellationToken::new();
-        let mut handle = bind_server(sock_path.clone(), guest)
+        let mut handle = bind_server(sock_path.clone(), test_gate(guest))
             .unwrap()
             .spawn(shutdown.clone());
         let mut stream = UnixStream::connect(&sock_path).await.unwrap();
@@ -827,7 +874,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let sock_path = dir.path().join("control.sock");
         let guest = Arc::new(tokio::sync::Mutex::new(None::<Arc<VsockHost>>));
-        let mut handle = bind_server(sock_path.clone(), guest)
+        let mut handle = bind_server(sock_path.clone(), test_gate(guest))
             .unwrap()
             .spawn(CancellationToken::new());
         let mut stream = UnixStream::connect(&sock_path).await.unwrap();
@@ -856,7 +903,7 @@ mod tests {
 
         let sock_path = dir.path().join("control.sock");
         let guest = Arc::new(tokio::sync::Mutex::new(Some(Arc::new(vsock))));
-        let mut handle = bind_server(sock_path.clone(), guest)
+        let mut handle = bind_server(sock_path.clone(), test_gate(guest))
             .unwrap()
             .spawn(CancellationToken::new());
         let client = tokio::spawn({
@@ -890,13 +937,66 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn control_exec_rejects_when_operation_gate_is_closing() {
+        let dir = tempfile::tempdir().unwrap();
+        let vsock_base = dir.path().join("vsock");
+        let host_task = {
+            let vsock_base = vsock_base.display().to_string();
+            tokio::spawn(async move {
+                VsockHost::wait_for_connection(&vsock_base, Duration::from_secs(5)).await
+            })
+        };
+        let (exec_seen_tx, mut exec_seen_rx) = oneshot::channel();
+        let guest_task = tokio::spawn(mock_guest_holds_exec(vsock_base, exec_seen_tx));
+        let vsock = host_task.await.unwrap().unwrap();
+
+        let sock_path = dir.path().join("control.sock");
+        let guest = Arc::new(tokio::sync::Mutex::new(Some(Arc::new(vsock))));
+        let (gate, coordinator) = test_gate_with_coordinator(guest);
+        let attempt = coordinator
+            .begin_prepare_park()
+            .expect("gate should enter closing state");
+        let mut handle = bind_server(sock_path.clone(), gate)
+            .unwrap()
+            .spawn(CancellationToken::new());
+
+        let request = ExecRequest {
+            command: "echo should-not-run".into(),
+            timeout_secs: 5,
+            sudo: false,
+        };
+        let response = send_exec(&sock_path, &request, Duration::from_secs(5))
+            .await
+            .unwrap();
+
+        match response {
+            ExecResponse::Error { error } => {
+                assert!(
+                    error.contains("operation gate closed"),
+                    "unexpected error: {error}"
+                );
+            }
+            ExecResponse::Success { .. } => panic!("expected gate-closed error"),
+        }
+        assert!(
+            exec_seen_rx.try_recv().is_err(),
+            "control exec should not send a guest command while the gate is closing"
+        );
+
+        handle.shutdown().await;
+        coordinator.abort_prepare_park(&attempt).unwrap();
+        guest_task.abort();
+        let _ = guest_task.await;
+    }
+
+    #[tokio::test]
     async fn bind_server_reports_bind_failure() {
         let dir = tempfile::tempdir().unwrap();
         let sock_path = dir.path().join("control.sock");
         let _existing = UnixListener::bind(&sock_path).unwrap();
         let guest = Arc::new(tokio::sync::Mutex::new(None::<Arc<VsockHost>>));
 
-        let result = bind_server(sock_path.clone(), guest);
+        let result = bind_server(sock_path.clone(), test_gate(guest));
 
         let Err(err) = result else {
             panic!("binding an occupied control socket should fail");

--- a/crates/sandbox-fc/src/control.rs
+++ b/crates/sandbox-fc/src/control.rs
@@ -1050,6 +1050,56 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn control_exec_transport_error_marks_operation_gate_dirty() {
+        let dir = tempfile::tempdir().unwrap();
+        let vsock_base = dir.path().join("vsock");
+        let host_task = {
+            let vsock_base = vsock_base.display().to_string();
+            tokio::spawn(async move {
+                VsockHost::wait_for_connection(&vsock_base, Duration::from_secs(5)).await
+            })
+        };
+        let (exec_seen_tx, exec_seen_rx) = oneshot::channel();
+        let guest_task = tokio::spawn(mock_guest_records_exec(vsock_base, exec_seen_tx));
+        let vsock = host_task.await.unwrap().unwrap();
+
+        let sock_path = dir.path().join("control.sock");
+        let guest = Arc::new(tokio::sync::Mutex::new(Some(Arc::new(vsock))));
+        let (gate, coordinator) = test_gate_with_coordinator(guest);
+        let mut handle = bind_server(sock_path.clone(), gate)
+            .unwrap()
+            .spawn(CancellationToken::new());
+
+        let request = ExecRequest {
+            command: "disconnect-after-start".into(),
+            timeout_secs: 5,
+            sudo: false,
+        };
+        let response = send_exec(&sock_path, &request, Duration::from_secs(5))
+            .await
+            .unwrap();
+
+        tokio::time::timeout(Duration::from_secs(1), exec_seen_rx)
+            .await
+            .unwrap()
+            .unwrap();
+        match response {
+            ExecResponse::Error { error } => {
+                assert!(error.contains("exec failed"), "unexpected error: {error}");
+            }
+            ExecResponse::Success { .. } => panic!("expected transport error"),
+        }
+        assert!(
+            matches!(coordinator.state(), CoordinatorState::Dirty { .. }),
+            "transport error after command write should dirty the operation gate"
+        );
+        assert_eq!(coordinator.active_operation_count(), 0);
+
+        handle.shutdown().await;
+        guest_task.await.unwrap();
+    }
+
+    #[tokio::test]
     async fn bind_server_reports_bind_failure() {
         let dir = tempfile::tempdir().unwrap();
         let sock_path = dir.path().join("control.sock");

--- a/crates/sandbox-fc/src/control.rs
+++ b/crates/sandbox-fc/src/control.rs
@@ -936,6 +936,11 @@ mod tests {
             matches!(coordinator.state(), CoordinatorState::Dirty { .. }),
             "cancelled in-flight control exec should mark the operation gate dirty"
         );
+        assert_eq!(
+            coordinator.active_operation_count(),
+            0,
+            "cancelled in-flight control exec should not leave an active operation"
+        );
 
         guest_task.abort();
         let _ = guest_task.await;

--- a/crates/sandbox-fc/src/guest_operations.rs
+++ b/crates/sandbox-fc/src/guest_operations.rs
@@ -1,0 +1,144 @@
+use std::sync::Arc;
+
+use vsock_host::VsockHost;
+
+use crate::park_coordinator::{
+    CoordinatorState, LeaseRejection, OperationLease, OperationTransitionError, ParkCoordinator,
+};
+use crate::sandbox::SandboxState;
+
+pub(crate) fn guest_error_is_terminal(error: &std::io::Error, backend_crashed: bool) -> bool {
+    if backend_crashed {
+        return false;
+    }
+
+    !matches!(
+        error.kind(),
+        std::io::ErrorKind::TimedOut
+            | std::io::ErrorKind::ConnectionReset
+            | std::io::ErrorKind::BrokenPipe
+            | std::io::ErrorKind::UnexpectedEof
+            | std::io::ErrorKind::InvalidData
+    )
+}
+
+#[derive(Clone)]
+pub(crate) struct GuestOperationGate {
+    guest: Arc<tokio::sync::Mutex<Option<Arc<VsockHost>>>>,
+    coordinator: ParkCoordinator,
+}
+
+impl GuestOperationGate {
+    pub(crate) fn new(
+        guest: Arc<tokio::sync::Mutex<Option<Arc<VsockHost>>>>,
+        coordinator: ParkCoordinator,
+    ) -> Self {
+        Self { guest, coordinator }
+    }
+
+    pub(crate) async fn begin_sandbox_operation(
+        &self,
+        current_state: impl Fn() -> SandboxState,
+    ) -> Result<GuestOperation, GuestOperationStartError> {
+        if current_state() == SandboxState::Crashed {
+            return Err(GuestOperationStartError::BackendCrashed);
+        }
+
+        let lease = self.reserve_lease()?;
+        let guest = self.guest.lock().await.as_ref().cloned();
+        let state = current_state();
+        if state == SandboxState::Crashed {
+            return Err(GuestOperationStartError::BackendCrashed);
+        }
+
+        let Some(guest) = guest else {
+            return Err(GuestOperationStartError::NotRunning { state });
+        };
+
+        Ok(GuestOperation { guest, lease })
+    }
+
+    pub(crate) async fn begin_control_operation(
+        &self,
+    ) -> Result<GuestOperation, GuestOperationStartError> {
+        let lease = self.reserve_lease()?;
+        let guest = self.guest.lock().await.as_ref().cloned();
+        let Some(guest) = guest else {
+            return Err(GuestOperationStartError::NoGuest);
+        };
+
+        Ok(GuestOperation { guest, lease })
+    }
+
+    fn reserve_lease(&self) -> Result<OperationLease, GuestOperationStartError> {
+        self.coordinator
+            .reserve_operation()
+            .map_err(|error| match error {
+                LeaseRejection::GateClosed { state } => {
+                    GuestOperationStartError::GateClosed { state }
+                }
+            })
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum GuestOperationStartError {
+    BackendCrashed,
+    NotRunning { state: SandboxState },
+    NoGuest,
+    GateClosed { state: CoordinatorState },
+}
+
+pub(crate) struct GuestOperation {
+    guest: Arc<VsockHost>,
+    lease: OperationLease,
+}
+
+impl GuestOperation {
+    pub(crate) fn guest(&self) -> Arc<VsockHost> {
+        Arc::clone(&self.guest)
+    }
+
+    pub(crate) fn mark_writing(&mut self) -> Result<(), OperationTransitionError> {
+        self.lease.mark_writing()
+    }
+
+    pub(crate) fn mark_in_guest(&mut self) -> Result<(), OperationTransitionError> {
+        self.lease.mark_in_guest()
+    }
+
+    pub(crate) fn complete(self) -> Result<(), OperationTransitionError> {
+        self.lease.complete()
+    }
+
+    pub(crate) fn into_lease(self) -> OperationLease {
+        self.lease
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn timeout_and_transport_errors_are_not_terminal_guest_evidence() {
+        for kind in [
+            std::io::ErrorKind::TimedOut,
+            std::io::ErrorKind::ConnectionReset,
+            std::io::ErrorKind::BrokenPipe,
+            std::io::ErrorKind::UnexpectedEof,
+            std::io::ErrorKind::InvalidData,
+        ] {
+            let error = std::io::Error::new(kind, "uncertain operation state");
+            assert!(!guest_error_is_terminal(&error, false));
+        }
+    }
+
+    #[test]
+    fn explicit_guest_errors_are_terminal_without_backend_crash() {
+        let error = std::io::Error::other("guest rejected request");
+
+        assert!(guest_error_is_terminal(&error, false));
+        assert!(!guest_error_is_terminal(&error, true));
+    }
+}

--- a/crates/sandbox-fc/src/guest_operations.rs
+++ b/crates/sandbox-fc/src/guest_operations.rs
@@ -119,6 +119,23 @@ impl GuestOperation {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    fn gate_without_guest() -> (GuestOperationGate, ParkCoordinator) {
+        let coordinator = ParkCoordinator::new();
+        let guest = Arc::new(tokio::sync::Mutex::new(None::<Arc<VsockHost>>));
+        (
+            GuestOperationGate::new(guest, coordinator.clone()),
+            coordinator,
+        )
+    }
+
+    fn assert_prepare_can_start(coordinator: &ParkCoordinator) {
+        let attempt = coordinator
+            .begin_prepare_park()
+            .expect("operation start failure should not leave an active lease");
+        coordinator.abort_prepare_park(&attempt).unwrap();
+    }
 
     #[test]
     fn timeout_and_transport_errors_are_not_terminal_guest_evidence() {
@@ -140,5 +157,85 @@ mod tests {
 
         assert!(guest_error_is_terminal(&error, false));
         assert!(!guest_error_is_terminal(&error, true));
+    }
+
+    #[tokio::test]
+    async fn control_operation_without_guest_releases_reserved_lease() {
+        let (gate, coordinator) = gate_without_guest();
+
+        let error = match gate.begin_control_operation().await {
+            Ok(_) => panic!("expected no-guest error"),
+            Err(error) => error,
+        };
+
+        assert_eq!(error, GuestOperationStartError::NoGuest);
+        assert_eq!(coordinator.active_operation_count(), 0);
+        assert_prepare_can_start(&coordinator);
+    }
+
+    #[tokio::test]
+    async fn sandbox_operation_without_guest_releases_reserved_lease() {
+        let (gate, coordinator) = gate_without_guest();
+
+        let error = match gate.begin_sandbox_operation(|| SandboxState::Running).await {
+            Ok(_) => panic!("expected not-running error"),
+            Err(error) => error,
+        };
+
+        assert_eq!(
+            error,
+            GuestOperationStartError::NotRunning {
+                state: SandboxState::Running
+            }
+        );
+        assert_eq!(coordinator.active_operation_count(), 0);
+        assert_prepare_can_start(&coordinator);
+    }
+
+    #[tokio::test]
+    async fn sandbox_crash_after_reserve_releases_reserved_lease() {
+        let (gate, coordinator) = gate_without_guest();
+        let calls = AtomicUsize::new(0);
+
+        let error = match gate
+            .begin_sandbox_operation(|| {
+                if calls.fetch_add(1, Ordering::SeqCst) == 0 {
+                    SandboxState::Running
+                } else {
+                    SandboxState::Crashed
+                }
+            })
+            .await
+        {
+            Ok(_) => panic!("expected backend-crashed error"),
+            Err(error) => error,
+        };
+
+        assert_eq!(error, GuestOperationStartError::BackendCrashed);
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+        assert_eq!(coordinator.active_operation_count(), 0);
+        assert_prepare_can_start(&coordinator);
+    }
+
+    #[tokio::test]
+    async fn closed_gate_rejects_without_active_lease() {
+        let (gate, coordinator) = gate_without_guest();
+        let attempt = coordinator
+            .begin_prepare_park()
+            .expect("gate should enter closing state");
+
+        let error = match gate.begin_control_operation().await {
+            Ok(_) => panic!("expected gate-closed error"),
+            Err(error) => error,
+        };
+
+        assert!(matches!(
+            error,
+            GuestOperationStartError::GateClosed {
+                state: CoordinatorState::ClosingForPark { .. }
+            }
+        ));
+        assert_eq!(coordinator.active_operation_count(), 0);
+        coordinator.abort_prepare_park(&attempt).unwrap();
     }
 }

--- a/crates/sandbox-fc/src/lib.rs
+++ b/crates/sandbox-fc/src/lib.rs
@@ -30,6 +30,7 @@ mod config;
 pub mod control;
 mod cow_pool;
 mod factory;
+mod guest_operations;
 mod leaked_resources;
 mod network;
 mod park_coordinator;

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -2200,6 +2200,32 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn gated_spawn_exit_future_error_marks_dirty() {
+        let coordinator = ParkCoordinator::new();
+        let lease = active_spawn_watch_lease(&coordinator);
+        let exit = gated_spawn_exit_future(
+            async { Err(io::Error::new(io::ErrorKind::ConnectionReset, "closed")) },
+            lease,
+        );
+
+        let error = match exit.await {
+            Ok(_) => panic!("expected spawn exit error"),
+            Err(error) => error,
+        };
+
+        assert_eq!(error.kind(), io::ErrorKind::ConnectionReset);
+        assert!(matches!(
+            coordinator.state(),
+            CoordinatorState::Dirty { .. }
+        ));
+        assert_eq!(
+            coordinator.active_operation_count(),
+            0,
+            "failed spawn exit future should not leave an active operation"
+        );
+    }
+
     /// Exercise the `monitor_process` crash detection flow through real child
     /// exit. A running process exit should mark the sandbox crashed and wake
     /// current subscribers.

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -1,7 +1,9 @@
 use std::ffi::OsString;
+use std::future::Future;
 use std::io;
 use std::os::unix::ffi::OsStringExt;
 use std::path::Path;
+use std::pin::Pin;
 use std::sync::atomic::{AtomicU8, Ordering};
 use std::sync::{Arc, Mutex, MutexGuard};
 use std::time::Duration;
@@ -26,9 +28,12 @@ use crate::balloon;
 use crate::config::FirecrackerConfig;
 use crate::control;
 use crate::factory::InvariantConfig;
+use crate::guest_operations::{
+    GuestOperation, GuestOperationGate, GuestOperationStartError, guest_error_is_terminal,
+};
 use crate::leaked_resources::LeakedResources;
 use crate::network::{NetnsInfo, NetnsLease};
-use crate::park_coordinator::ParkCoordinator;
+use crate::park_coordinator::{OperationLease, OperationTransitionError, ParkCoordinator};
 use crate::paths::{SandboxPaths, SockPaths};
 use crate::process::{kill_process_group, kill_process_group_by_pid};
 
@@ -474,9 +479,8 @@ pub struct FirecrackerSandbox {
     /// Wrapped in `Arc` so operations can clone the handle and release the
     /// mutex immediately, allowing concurrent vsock operations.
     guest: Arc<tokio::sync::Mutex<Option<Arc<VsockHost>>>>,
-    /// Host-side park coordinator staged for same-session idle park safety.
-    /// #13275 routes production guest operations through this gate.
-    _park_coordinator: ParkCoordinator,
+    /// Host-side park coordinator for same-session idle park safety.
+    park_coordinator: ParkCoordinator,
     /// Sender for leaked resource cleanup. When Drop fires without prior
     /// `factory.destroy()`, pool resources are sent here for async cleanup.
     leak_tx: Option<tokio::sync::mpsc::UnboundedSender<LeakedResources>>,
@@ -551,7 +555,7 @@ impl FirecrackerSandbox {
             state_publish_lock: Arc::new(Mutex::new(())),
             state_tx: watch::channel(SandboxState::Created).0,
             guest: Arc::new(tokio::sync::Mutex::new(None::<Arc<VsockHost>>)),
-            _park_coordinator: ParkCoordinator::new(),
+            park_coordinator: ParkCoordinator::new(),
             leak_tx,
             delete_workspace_on_leak_cleanup: true,
             destroyed: false,
@@ -624,6 +628,45 @@ impl FirecrackerSandbox {
         }
     }
 
+    fn operation_gate_closed_error(
+        operation: SandboxOperation,
+        state: crate::park_coordinator::CoordinatorState,
+    ) -> SandboxError {
+        SandboxError::InvalidState {
+            context: SandboxInvalidStateContext::Operation(operation),
+            state: format!("{state:?}"),
+            message: "sandbox operation gate closed".into(),
+        }
+    }
+
+    fn operation_gate_transition_error(
+        operation: SandboxOperation,
+        error: OperationTransitionError,
+    ) -> SandboxError {
+        SandboxError::Operation {
+            operation,
+            reason: SandboxOperationReason::Other,
+            message: format!("operation gate transition failed: {error:?}"),
+        }
+    }
+
+    fn operation_start_error(
+        &self,
+        operation: SandboxOperation,
+        error: GuestOperationStartError,
+    ) -> SandboxError {
+        match error {
+            GuestOperationStartError::BackendCrashed => Self::backend_crashed_error(operation),
+            GuestOperationStartError::NotRunning { state } => {
+                Self::operation_unavailable_error(operation, state)
+            }
+            GuestOperationStartError::NoGuest => self.not_running_error(operation),
+            GuestOperationStartError::GateClosed { state } => {
+                Self::operation_gate_closed_error(operation, state)
+            }
+        }
+    }
+
     fn has_backend_crashed(&self) -> bool {
         self.current_state() == SandboxState::Crashed
     }
@@ -632,20 +675,68 @@ impl FirecrackerSandbox {
         publish_process_state(&self.state, &self.state_publish_lock, &self.state_tx, state);
     }
 
-    async fn operation_guest(
+    fn guest_operations(&self) -> GuestOperationGate {
+        GuestOperationGate::new(Arc::clone(&self.guest), self.park_coordinator.clone())
+    }
+
+    async fn begin_guest_operation(
         &self,
         operation: SandboxOperation,
-    ) -> sandbox::Result<Arc<VsockHost>> {
-        if self.has_backend_crashed() {
-            return Err(Self::backend_crashed_error(operation));
+    ) -> sandbox::Result<GuestOperation> {
+        self.guest_operations()
+            .begin_sandbox_operation(|| self.current_state())
+            .await
+            .map_err(|error| self.operation_start_error(operation, error))
+    }
+
+    async fn run_bounded_guest_operation<T, Fut>(
+        &self,
+        operation: SandboxOperation,
+        call: impl FnOnce(Arc<VsockHost>) -> Fut,
+    ) -> sandbox::Result<T>
+    where
+        Fut: Future<Output = io::Result<T>>,
+    {
+        enum GuestCallOutcome<T> {
+            Returned(io::Result<T>),
+            BackendCrashed,
         }
 
-        let guest = self.guest.lock().await.as_ref().cloned();
-        if self.has_backend_crashed() {
-            return Err(Self::backend_crashed_error(operation));
-        }
+        let mut guest = self.begin_guest_operation(operation).await?;
+        guest
+            .mark_writing()
+            .map_err(|error| Self::operation_gate_transition_error(operation, error))?;
+        let vsock = guest.guest();
 
-        guest.ok_or_else(|| self.not_running_error(operation))
+        let outcome = tokio::select! {
+            result = call(vsock) => {
+                GuestCallOutcome::Returned(result)
+            }
+            () = wait_for_backend_crash(self.state_tx.subscribe()) => {
+                GuestCallOutcome::BackendCrashed
+            }
+        };
+
+        match outcome {
+            GuestCallOutcome::Returned(Ok(value)) => {
+                guest
+                    .complete()
+                    .map_err(|error| Self::operation_gate_transition_error(operation, error))?;
+                Ok(value)
+            }
+            GuestCallOutcome::Returned(Err(error)) => {
+                let backend_crashed = self.has_backend_crashed();
+                let is_terminal = guest_error_is_terminal(&error, backend_crashed);
+                let result = Err(Self::operation_error(operation, error, backend_crashed));
+                if is_terminal {
+                    guest
+                        .complete()
+                        .map_err(|error| Self::operation_gate_transition_error(operation, error))?;
+                }
+                result
+            }
+            GuestCallOutcome::BackendCrashed => Err(Self::backend_crashed_error(operation)),
+        }
     }
 
     /// Atomically transition between states using CAS. Returns `true` if the
@@ -969,6 +1060,22 @@ async fn wait_for_backend_crash(mut state_rx: watch::Receiver<SandboxState>) {
     }
 }
 
+fn gated_spawn_exit_future<F>(
+    exit: F,
+    lease: OperationLease,
+) -> Pin<Box<dyn Future<Output = io::Result<ProcessExit>> + Send + 'static>>
+where
+    F: Future<Output = io::Result<ProcessExit>> + Send + 'static,
+{
+    Box::pin(async move {
+        let process_exit = exit.await?;
+        lease
+            .complete()
+            .map_err(|error| io::Error::other(format!("operation gate completion: {error:?}")))?;
+        Ok(process_exit)
+    })
+}
+
 fn state_publish_guard(state_publish_lock: &Mutex<()>) -> MutexGuard<'_, ()> {
     state_publish_lock
         .lock()
@@ -1185,7 +1292,7 @@ impl Sandbox for FirecrackerSandbox {
 
         let control_sock_path = self.sock_paths.control_sock();
         let control_server =
-            match control::bind_server(control_sock_path.clone(), Arc::clone(&self.guest)) {
+            match control::bind_server(control_sock_path.clone(), self.guest_operations()) {
                 Ok(server) => server,
                 Err(e) => {
                     self.guest.lock().await.take();
@@ -1344,50 +1451,41 @@ impl Sandbox for FirecrackerSandbox {
 
     async fn exec(&self, request: &ExecRequest<'_>) -> sandbox::Result<ExecResult> {
         let operation = SandboxOperation::Exec;
-        let guest = self.operation_guest(operation).await?;
         let limits = request.output_limits;
+        let timeout_ms = request.timeout_ms();
 
-        tokio::select! {
-            result = guest.exec_capture(
-                vsock_host::CommandCaptureRequest {
+        self.run_bounded_guest_operation(operation, |guest| async move {
+            guest
+                .exec_capture(vsock_host::CommandCaptureRequest {
                     command: request.cmd,
-                    timeout_ms: request.timeout_ms(),
+                    timeout_ms,
                     env: request.env,
                     sudo: request.sudo,
                     label: "sandbox-exec",
                     stdout_limit_bytes: limits.stdout_limit_bytes,
                     stderr_limit_bytes: limits.stderr_limit_bytes,
                     expected_exit_codes: &[],
-                    wait_timeout: Duration::from_millis(request.timeout_ms() as u64 + 5000),
-                }
-            ) => {
-                let result = result.map_err(|e| Self::operation_error(operation, e, self.has_backend_crashed()))?;
-                Ok(ExecResult {
+                    wait_timeout: Duration::from_millis(timeout_ms as u64 + 5000),
+                })
+                .await
+                .map(|result| ExecResult {
                     exit_code: result.exit_code,
                     stdout: result.stdout,
                     stderr: result.stderr,
                     stdout_truncated: result.stdout_truncated,
                     stderr_truncated: result.stderr_truncated,
                 })
-            }
-            () = wait_for_backend_crash(self.state_tx.subscribe()) => {
-                Err(Self::backend_crashed_error(operation))
-            }
-        }
+        })
+        .await
     }
 
     async fn read_file(&self, path: &str, max_bytes: u64) -> sandbox::Result<Option<Vec<u8>>> {
         let operation = SandboxOperation::Exec;
-        let guest = self.operation_guest(operation).await?;
 
-        tokio::select! {
-            result = guest.read_file(path, max_bytes, 5000) => {
-                result.map_err(|e| Self::operation_error(operation, e, self.has_backend_crashed()))
-            }
-            () = wait_for_backend_crash(self.state_tx.subscribe()) => {
-                Err(Self::backend_crashed_error(operation))
-            }
-        }
+        self.run_bounded_guest_operation(operation, |guest| async move {
+            guest.read_file(path, max_bytes, 5000).await
+        })
+        .await
     }
 
     async fn copy_file(
@@ -1397,51 +1495,46 @@ impl Sandbox for FirecrackerSandbox {
         options: CopyFileOptions,
     ) -> sandbox::Result<CopyFileResult> {
         let operation = SandboxOperation::Exec;
-        let guest = self.operation_guest(operation).await?;
         let timeout_ms = u32::try_from(options.timeout.as_millis()).unwrap_or(u32::MAX);
 
-        tokio::select! {
-            result = guest.copy_file(
-                path,
-                host_path,
-                vsock_host::CopyFileOptions {
-                    max_bytes: options.max_bytes,
-                    timeout_ms,
-                    missing_ok: options.missing_ok,
-                },
-            ) => {
-                result
-                    .map(|result| CopyFileResult {
-                        bytes_copied: result.bytes_copied,
-                    })
-                    .map_err(|e| Self::operation_error(operation, e, self.has_backend_crashed()))
-            }
-            () = wait_for_backend_crash(self.state_tx.subscribe()) => {
-                Err(Self::backend_crashed_error(operation))
-            }
-        }
+        self.run_bounded_guest_operation(operation, |guest| async move {
+            guest
+                .copy_file(
+                    path,
+                    host_path,
+                    vsock_host::CopyFileOptions {
+                        max_bytes: options.max_bytes,
+                        timeout_ms,
+                        missing_ok: options.missing_ok,
+                    },
+                )
+                .await
+                .map(|result| CopyFileResult {
+                    bytes_copied: result.bytes_copied,
+                })
+        })
+        .await
     }
 
     async fn write_file(&self, path: &str, content: &[u8]) -> sandbox::Result<()> {
         let operation = SandboxOperation::WriteFile;
-        let guest = self.operation_guest(operation).await?;
 
-        tokio::select! {
-            result = guest.write_file(path, content, false) => {
-                result.map_err(|e| Self::operation_error(operation, e, self.has_backend_crashed()))
-            }
-            () = wait_for_backend_crash(self.state_tx.subscribe()) => {
-                Err(Self::backend_crashed_error(operation))
-            }
-        }
+        self.run_bounded_guest_operation(operation, |guest| async move {
+            guest.write_file(path, content, false).await
+        })
+        .await
     }
 
     async fn spawn_watch(&self, request: &SpawnWatchRequest<'_>) -> sandbox::Result<SpawnHandle> {
         let operation = SandboxOperation::SpawnWatch;
-        let guest = self.operation_guest(operation).await?;
+        let mut guest = self.begin_guest_operation(operation).await?;
+        guest
+            .mark_writing()
+            .map_err(|error| Self::operation_gate_transition_error(operation, error))?;
+        let vsock = guest.guest();
 
         tokio::select! {
-            result = guest.spawn_watch(
+            result = vsock.spawn_watch(
                 request.cmd,
                 request.timeout_ms(),
                 request.env,
@@ -1450,21 +1543,28 @@ impl Sandbox for FirecrackerSandbox {
                 request.output.guest_log_path(),
             ) => {
                 let mut handle = result.map_err(|e| Self::operation_error(operation, e, self.has_backend_crashed()))?;
+                guest
+                    .mark_in_guest()
+                    .map_err(|error| Self::operation_gate_transition_error(operation, error))?;
                 let pid = handle.pid();
                 let stdout_rx = request
                     .output
                     .streams_stdout()
                     .then(|| handle.take_stdout_receiver())
                     .flatten();
-                let exit = Box::pin(async move {
-                    let event = handle.wait().await?;
-                    Ok(ProcessExit {
-                        pid: event.pid,
-                        exit_code: event.exit_code,
-                        stdout: event.stdout,
-                        stderr: event.stderr,
-                    })
-                });
+                let lease = guest.into_lease();
+                let exit = gated_spawn_exit_future(
+                    async move {
+                        let event = handle.wait().await?;
+                        Ok(ProcessExit {
+                            pid: event.pid,
+                            exit_code: event.exit_code,
+                            stdout: event.stdout,
+                            stderr: event.stderr,
+                        })
+                    },
+                    lease,
+                );
                 Ok(SpawnHandle::new(pid, stdout_rx, exit))
             }
             () = wait_for_backend_crash(self.state_tx.subscribe()) => {
@@ -1764,6 +1864,7 @@ async fn unpark_inner(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::park_coordinator::{CoordinatorState, PrepareParkError};
 
     fn monitored_cat_process() -> tokio::process::Child {
         tokio::process::Command::new("cat")
@@ -1974,6 +2075,13 @@ mod tests {
         }
     }
 
+    fn active_spawn_watch_lease(coordinator: &ParkCoordinator) -> OperationLease {
+        let mut lease = coordinator.reserve_operation().expect("reserve operation");
+        lease.mark_writing().expect("mark writing");
+        lease.mark_in_guest().expect("mark in guest");
+        lease
+    }
+
     #[test]
     fn operation_error_classifies_io_timeout() {
         let err = FirecrackerSandbox::operation_error(
@@ -2029,6 +2137,51 @@ mod tests {
         }
     }
 
+    #[tokio::test]
+    async fn gated_spawn_exit_future_completes_lease_on_process_exit() {
+        let coordinator = ParkCoordinator::new();
+        let lease = active_spawn_watch_lease(&coordinator);
+        let exit = gated_spawn_exit_future(
+            async {
+                Ok(ProcessExit {
+                    pid: 42,
+                    exit_code: 0,
+                    stdout: Vec::new(),
+                    stderr: Vec::new(),
+                })
+            },
+            lease,
+        );
+
+        assert!(matches!(
+            coordinator.begin_prepare_park(),
+            Err(PrepareParkError::Busy)
+        ));
+
+        let result = exit.await.expect("process exit should complete");
+        assert_eq!(result.pid, 42);
+
+        let attempt = coordinator
+            .begin_prepare_park()
+            .expect("completed spawn_watch lease should allow prepare");
+        coordinator.abort_prepare_park(&attempt).unwrap();
+    }
+
+    #[test]
+    fn dropped_gated_spawn_exit_future_marks_dirty() {
+        let coordinator = ParkCoordinator::new();
+        let lease = active_spawn_watch_lease(&coordinator);
+        let exit =
+            gated_spawn_exit_future(std::future::pending::<io::Result<ProcessExit>>(), lease);
+
+        drop(exit);
+
+        assert!(matches!(
+            coordinator.state(),
+            CoordinatorState::Dirty { .. }
+        ));
+    }
+
     /// Exercise the `monitor_process` crash detection flow through real child
     /// exit. A running process exit should mark the sandbox crashed and wake
     /// current subscribers.
@@ -2077,9 +2230,12 @@ mod tests {
         let (state_tx, _state_rx) = watch::channel(SandboxState::Running);
         let guest = Arc::new(tokio::sync::Mutex::new(None::<Arc<VsockHost>>));
         let runtime_cancel = CancellationToken::new();
-        let mut control = crate::control::bind_server(sock_path.clone(), Arc::clone(&guest))
-            .unwrap()
-            .spawn(runtime_cancel.clone());
+        let mut control = crate::control::bind_server(
+            sock_path.clone(),
+            GuestOperationGate::new(Arc::clone(&guest), ParkCoordinator::new()),
+        )
+        .unwrap()
+        .spawn(runtime_cancel.clone());
         let mut child = monitored_cat_process();
         let stdin = child.stdin.take();
 

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -2193,6 +2193,11 @@ mod tests {
             coordinator.state(),
             CoordinatorState::Dirty { .. }
         ));
+        assert_eq!(
+            coordinator.active_operation_count(),
+            0,
+            "dropped spawn exit future should not leave an active operation"
+        );
     }
 
     /// Exercise the `monitor_process` crash detection flow through real child

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -1542,7 +1542,20 @@ impl Sandbox for FirecrackerSandbox {
                 request.output.streams_stdout(),
                 request.output.guest_log_path(),
             ) => {
-                let mut handle = result.map_err(|e| Self::operation_error(operation, e, self.has_backend_crashed()))?;
+                let mut handle = match result {
+                    Ok(handle) => handle,
+                    Err(error) => {
+                        let backend_crashed = self.has_backend_crashed();
+                        let is_terminal = guest_error_is_terminal(&error, backend_crashed);
+                        let result = Err(Self::operation_error(operation, error, backend_crashed));
+                        if is_terminal {
+                            guest
+                                .complete()
+                                .map_err(|error| Self::operation_gate_transition_error(operation, error))?;
+                        }
+                        return result;
+                    }
+                };
                 guest
                     .mark_in_guest()
                     .map_err(|error| Self::operation_gate_transition_error(operation, error))?;


### PR DESCRIPTION
## Summary

- route sandbox guest operations through a coordinator-backed guest operation gate
- route control-socket runner exec through the same gate
- keep spawn_watch leases active until process-exit evidence and dirty uncertain drops/timeouts

Closes #13275

## Tests

- cargo test --manifest-path crates/Cargo.toml -p sandbox-fc control -- --nocapture
- cargo test --manifest-path crates/Cargo.toml -p sandbox-fc gated_spawn -- --nocapture
- cargo test --manifest-path crates/Cargo.toml -p sandbox-fc park_coordinator -- --nocapture
- cargo clippy --manifest-path crates/Cargo.toml -p sandbox-fc --all-targets
- cargo test --manifest-path crates/Cargo.toml -p sandbox-fc -- --nocapture
- cargo fmt --manifest-path crates/Cargo.toml --all --check
- git diff --check

Note: pre-commit full crates clippy currently fails outside this PR in guest-agent with E0463: cannot find crate `guest_agent`; the targeted sandbox-fc clippy passes.