### PR TITLE
docs(sandbox-fc): document exec control payloads

### DIFF
--- a/crates/sandbox-fc/src/control.rs
+++ b/crates/sandbox-fc/src/control.rs
@@ -9,8 +9,9 @@
 //! One request per connection, one response per connection.
 //!
 //! The request payload is [`ExecRequest`]. The response payload is
-//! [`ExecResponse`], serialized as an untagged JSON object: successful responses
-//! contain command result fields, and failed requests contain an `error` field.
+//! [`ExecResponse`], serialized as an untagged JSON object: command-result
+//! responses contain command result fields, and error responses contain an
+//! `error` field.
 
 use std::io;
 use std::path::{Path, PathBuf};

--- a/crates/sandbox-fc/src/control.rs
+++ b/crates/sandbox-fc/src/control.rs
@@ -7,6 +7,10 @@
 //!
 //! Length-prefixed JSON frames: `[4-byte big-endian length][JSON payload]`.
 //! One request per connection, one response per connection.
+//!
+//! The request payload is [`ExecRequest`]. The response payload is
+//! [`ExecResponse`], serialized as an untagged JSON object: successful responses
+//! contain command result fields, and failed requests contain an `error` field.
 
 use std::io;
 use std::path::{Path, PathBuf};
@@ -34,12 +38,20 @@ use crate::paths::{RuntimePaths, SockPaths};
 // Protocol types
 // -----------------------------------------------------------------------
 
-/// Request from `runner exec` client.
+/// Request from a `runner exec` client.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ExecRequest {
+    /// Command text to execute inside the guest.
     pub command: String,
+    /// Command timeout in seconds.
+    ///
+    /// When this field is omitted during JSON deserialization, it defaults to
+    /// 30 seconds.
     #[serde(default = "default_timeout")]
     pub timeout_secs: u32,
+    /// Whether to request sudo execution inside the guest.
+    ///
+    /// The guest command runner decides how sudo is applied.
     #[serde(default)]
     pub sudo: bool,
 }
@@ -48,18 +60,40 @@ fn default_timeout() -> u32 {
     30
 }
 
-/// Response to `runner exec` client.
+/// Response to a `runner exec` client.
+///
+/// This enum is serialized without a tag. Clients should distinguish variants
+/// by shape: a success response contains command result fields, while an error
+/// response contains only an `error` string.
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum ExecResponse {
+    /// Command completed and produced a captured result.
     Success {
+        /// Process exit code returned by the guest command runner.
         exit_code: i32,
+        /// Base64-encoded captured stdout bytes.
+        ///
+        /// This is not plain UTF-8 text. `FirecrackerControl::exec_remote`
+        /// decodes it before returning `sandbox::RemoteExecResult`.
         stdout: String,
+        /// Base64-encoded captured stderr bytes.
+        ///
+        /// This is not plain UTF-8 text. `FirecrackerControl::exec_remote`
+        /// decodes it before returning `sandbox::RemoteExecResult`.
         stderr: String,
+        /// Whether stdout was cut at the capture limit.
+        ///
+        /// Truncation is independent of the command exit code.
         stdout_truncated: bool,
+        /// Whether stderr was cut at the capture limit.
+        ///
+        /// Truncation is independent of the command exit code.
         stderr_truncated: bool,
     },
+    /// Request failed before a command result could be returned.
     Error {
+        /// Human-readable error message for operators and clients.
         error: String,
     },
 }
@@ -480,9 +514,13 @@ fn control_start_error(error: GuestOperationStartError) -> String {
 // Client
 // -----------------------------------------------------------------------
 
-/// Send an exec request to a control socket and return the response.
+/// Send an exec request to a control socket and return the wire response.
 ///
 /// Used by `runner exec` to communicate with a running sandbox.
+///
+/// The returned [`ExecResponse::Success`] still contains base64-encoded stdout
+/// and stderr. Use `FirecrackerControl::exec_remote` when the caller wants
+/// decoded byte buffers.
 pub async fn send_exec(
     sock_path: &Path,
     request: &ExecRequest,

--- a/crates/sandbox-fc/src/control.rs
+++ b/crates/sandbox-fc/src/control.rs
@@ -51,7 +51,8 @@ pub struct ExecRequest {
     pub timeout_secs: u32,
     /// Whether to request sudo execution inside the guest.
     ///
-    /// The guest command runner decides how sudo is applied.
+    /// When this field is omitted during JSON deserialization, it defaults to
+    /// `false`. The guest command runner decides how sudo is applied.
     #[serde(default)]
     pub sudo: bool,
 }
@@ -63,12 +64,15 @@ fn default_timeout() -> u32 {
 /// Response to a `runner exec` client.
 ///
 /// This enum is serialized without a tag. Clients should distinguish variants
-/// by shape: a success response contains command result fields, while an error
-/// response contains only an `error` string.
+/// by shape: a command result response contains command result fields, while an
+/// error response contains only an `error` string.
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum ExecResponse {
-    /// Command completed and produced a captured result.
+    /// Command execution produced a captured result.
+    ///
+    /// This variant does not imply a zero exit code; inspect `exit_code` for the
+    /// command's status.
     Success {
         /// Process exit code returned by the guest command runner.
         exit_code: i32,


### PR DESCRIPTION
## Summary

- Document the `runner exec` control socket request/response wire payloads.
- Clarify `ExecRequest.timeout_secs` defaulting, sudo behavior, untagged response shape, base64 stdout/stderr, and truncation flags.
- Clarify that `send_exec` returns the wire response while `FirecrackerControl::exec_remote` decodes output bytes.

Fixes #13328

## Tests

- `cargo test --manifest-path crates/Cargo.toml -p sandbox-fc exec_request -- --nocapture`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox-fc exec_response -- --nocapture`
- `RUSTDOCFLAGS='-D warnings' cargo doc --manifest-path crates/Cargo.toml -p sandbox-fc --no-deps`
- pre-commit hook: `cargo-fmt`, `cargo-doc`, `cargo-clippy`
