### PR TITLE
refactor: share guest-agent no-follow fs helpers

### DIFF
--- a/crates/guest-agent/src/artifact/archive.rs
+++ b/crates/guest-agent/src/artifact/archive.rs
@@ -1,4 +1,6 @@
 use super::FileEntry;
+#[cfg(target_os = "linux")]
+use crate::nofollow_fs::Dir;
 use flate2::Compression;
 use flate2::write::GzEncoder;
 use guest_common::log_warn;
@@ -11,10 +13,10 @@ use thiserror::Error;
 const LOG_TAG: &str = "sandbox:guest-agent";
 
 /// Walk directory and compute SHA-256 for each file, skipping `.git` and `.vm0`.
-#[cfg(unix)]
+#[cfg(target_os = "linux")]
 pub(super) fn collect_file_metadata(dir_path: &str) -> Vec<FileEntry> {
     let mut files = Vec::new();
-    let root = match open_archive_dir(Path::new(dir_path)) {
+    let root = match Dir::open(Path::new(dir_path)) {
         Ok(root) => root,
         Err(e) => {
             log_warn!(LOG_TAG, "Could not read artifact root {dir_path}: {e}");
@@ -25,18 +27,18 @@ pub(super) fn collect_file_metadata(dir_path: &str) -> Vec<FileEntry> {
     files
 }
 
-#[cfg(not(unix))]
+#[cfg(not(target_os = "linux"))]
 pub(super) fn collect_file_metadata(dir_path: &str) -> Vec<FileEntry> {
     log_warn!(
         LOG_TAG,
-        "Artifact metadata collection requires Unix no-follow path opening: {dir_path}"
+        "Artifact metadata collection requires Linux no-follow path opening: {dir_path}"
     );
     Vec::new()
 }
 
-#[cfg(unix)]
-fn walk_dir(current: &File, relative: &str, out: &mut Vec<FileEntry>) {
-    let entries = match read_dir_fd(current) {
+#[cfg(target_os = "linux")]
+fn walk_dir(current: &Dir, relative: &str, out: &mut Vec<FileEntry>) {
+    let entries = match current.read_dir() {
         Ok(e) => e,
         Err(_) => return,
     };
@@ -53,12 +55,12 @@ fn walk_dir(current: &File, relative: &str, out: &mut Vec<FileEntry>) {
             format!("{relative}/{name_str}")
         };
 
-        if let Ok(dir) = open_archive_child_dir(current, &name) {
+        if let Ok(dir) = current.open_child_dir(&name) {
             walk_dir(&dir, &rel, out);
             continue;
         }
 
-        let Ok(file) = open_archive_child_file(current, &name) else {
+        let Ok(file) = current.open_child_file(&name) else {
             continue;
         };
         let Ok(metadata) = file.metadata() else {
@@ -381,60 +383,9 @@ fn archive_mode(metadata: &Metadata) -> u32 {
     }
 }
 
-#[cfg(unix)]
-fn read_dir_fd(dir: &File) -> io::Result<fs::ReadDir> {
-    use std::os::fd::AsRawFd;
-
-    fs::read_dir(PathBuf::from(format!("/proc/self/fd/{}", dir.as_raw_fd())))
-}
-
-#[cfg(unix)]
-fn open_archive_dir(path: &Path) -> io::Result<File> {
-    use std::fs::OpenOptions;
-    use std::os::unix::fs::OpenOptionsExt;
-
-    OpenOptions::new()
-        .read(true)
-        .custom_flags(libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC)
-        .open(path)
-}
-
-#[cfg(unix)]
-fn open_archive_child_dir(parent: &File, name: &std::ffi::OsStr) -> io::Result<File> {
-    open_archive_child(
-        parent,
-        name,
-        libc::O_RDONLY | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC,
-    )
-}
-
-#[cfg(unix)]
-fn open_archive_child_file(parent: &File, name: &std::ffi::OsStr) -> io::Result<File> {
-    open_archive_child(
-        parent,
-        name,
-        libc::O_RDONLY | libc::O_NOFOLLOW | libc::O_CLOEXEC | libc::O_NONBLOCK,
-    )
-}
-
-#[cfg(unix)]
-fn open_archive_child(parent: &File, name: &std::ffi::OsStr, flags: i32) -> io::Result<File> {
-    use std::ffi::CString;
-    use std::os::fd::{AsRawFd, FromRawFd};
-    use std::os::unix::ffi::OsStrExt;
-
-    let name = CString::new(name.as_bytes())
-        .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
-    let fd = unsafe { libc::openat(parent.as_raw_fd(), name.as_ptr(), flags) };
-    if fd < 0 {
-        return Err(io::Error::last_os_error());
-    }
-    Ok(unsafe { File::from_raw_fd(fd) })
-}
-
-#[cfg(unix)]
+#[cfg(target_os = "linux")]
 fn open_archive_file(root: &Path, rel_path: &Path) -> io::Result<File> {
-    let mut dir = open_archive_dir(root)?;
+    let mut dir = Dir::open(root)?;
     let mut components = rel_path.components().peekable();
 
     while let Some(component) = components.next() {
@@ -446,9 +397,9 @@ fn open_archive_file(root: &Path, rel_path: &Path) -> io::Result<File> {
         };
         let is_last = components.peek().is_none();
         if is_last {
-            return open_archive_child_file(&dir, name);
+            return dir.open_child_file(name);
         } else {
-            dir = open_archive_child_dir(&dir, name)?;
+            dir = dir.open_child_dir(name)?;
         }
     }
 
@@ -458,15 +409,15 @@ fn open_archive_file(root: &Path, rel_path: &Path) -> io::Result<File> {
     ))
 }
 
-#[cfg(not(unix))]
+#[cfg(not(target_os = "linux"))]
 fn open_archive_file(_root: &Path, _rel_path: &Path) -> io::Result<File> {
     Err(io::Error::new(
         io::ErrorKind::Unsupported,
-        "artifact archive creation requires Unix no-follow path opening",
+        "artifact archive creation requires Linux no-follow path opening",
     ))
 }
 
-#[cfg(all(test, unix))]
+#[cfg(all(test, target_os = "linux"))]
 mod tests {
     use super::*;
     use std::ffi::CString;

--- a/crates/guest-agent/src/lib.rs
+++ b/crates/guest-agent/src/lib.rs
@@ -14,6 +14,7 @@ pub mod heartbeat;
 pub mod http;
 pub mod masker;
 pub mod metrics;
+mod nofollow_fs;
 pub mod paths;
 pub mod session_history;
 pub mod telemetry;

--- a/crates/guest-agent/src/nofollow_fs.rs
+++ b/crates/guest-agent/src/nofollow_fs.rs
@@ -64,6 +64,12 @@ impl Dir {
 
 #[cfg(target_os = "linux")]
 fn open_child(parent: &File, name: &OsStr, flags: i32) -> io::Result<File> {
+    if name.as_bytes().contains(&b'/') {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "child name must be a single path component",
+        ));
+    }
     let name = CString::new(name.as_bytes())
         .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
     // SAFETY: `parent.as_raw_fd()` is an open directory fd owned by `Dir`,
@@ -129,6 +135,18 @@ mod tests {
 
         let err = root
             .open_child_file(OsStr::from_bytes(b"bad\0name"))
+            .unwrap_err();
+
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+    }
+
+    #[test]
+    fn open_child_rejects_path_separator() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = Dir::open(dir.path()).unwrap();
+
+        let err = root
+            .open_child_file(OsStr::from_bytes(b"nested/file"))
             .unwrap_err();
 
         assert_eq!(err.kind(), io::ErrorKind::InvalidInput);

--- a/crates/guest-agent/src/nofollow_fs.rs
+++ b/crates/guest-agent/src/nofollow_fs.rs
@@ -1,0 +1,131 @@
+//! Linux fd-based no-follow filesystem primitives.
+//!
+//! This module owns the low-level invariant for opening directory trees
+//! without following symlinks: root directories are opened with
+//! `O_NOFOLLOW`, children are opened relative to their parent fd with
+//! `openat`, and directory iteration goes through `/proc/self/fd/{fd}`.
+//!
+//! Callers still own recursive traversal policy and business error
+//! handling. This module should only expose the primitive operations needed
+//! to safely open directories and regular-file candidates.
+
+#[cfg(target_os = "linux")]
+use std::ffi::{CString, OsStr};
+#[cfg(target_os = "linux")]
+use std::fs::{self, File, OpenOptions};
+#[cfg(target_os = "linux")]
+use std::io;
+#[cfg(target_os = "linux")]
+use std::os::fd::{AsRawFd, FromRawFd};
+#[cfg(target_os = "linux")]
+use std::os::unix::ffi::OsStrExt;
+#[cfg(target_os = "linux")]
+use std::os::unix::fs::OpenOptionsExt;
+#[cfg(target_os = "linux")]
+use std::path::{Path, PathBuf};
+
+#[cfg(target_os = "linux")]
+pub(crate) struct Dir(File);
+
+#[cfg(target_os = "linux")]
+impl Dir {
+    pub(crate) fn open(path: &Path) -> io::Result<Self> {
+        OpenOptions::new()
+            .read(true)
+            .custom_flags(libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC)
+            .open(path)
+            .map(Self)
+    }
+
+    pub(crate) fn read_dir(&self) -> io::Result<fs::ReadDir> {
+        fs::read_dir(PathBuf::from(format!(
+            "/proc/self/fd/{}",
+            self.0.as_raw_fd()
+        )))
+    }
+
+    pub(crate) fn open_child_dir(&self, name: &OsStr) -> io::Result<Self> {
+        open_child(
+            &self.0,
+            name,
+            libc::O_RDONLY | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+        )
+        .map(Self)
+    }
+
+    pub(crate) fn open_child_file(&self, name: &OsStr) -> io::Result<File> {
+        open_child(
+            &self.0,
+            name,
+            libc::O_RDONLY | libc::O_NOFOLLOW | libc::O_CLOEXEC | libc::O_NONBLOCK,
+        )
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn open_child(parent: &File, name: &OsStr, flags: i32) -> io::Result<File> {
+    let name = CString::new(name.as_bytes())
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
+    let fd = unsafe { libc::openat(parent.as_raw_fd(), name.as_ptr(), flags) };
+    if fd < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(unsafe { File::from_raw_fd(fd) })
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod tests {
+    use super::*;
+    use std::os::unix::fs::symlink;
+
+    #[test]
+    fn open_rejects_symlinked_root() {
+        let dir = tempfile::tempdir().unwrap();
+        let real = dir.path().join("real");
+        let link = dir.path().join("link");
+        fs::create_dir(&real).unwrap();
+        symlink(&real, &link).unwrap();
+
+        assert!(Dir::open(&link).is_err());
+    }
+
+    #[test]
+    fn open_child_dir_rejects_symlinked_child() {
+        let dir = tempfile::tempdir().unwrap();
+        let root_path = dir.path().join("root");
+        let outside = dir.path().join("outside");
+        fs::create_dir(&root_path).unwrap();
+        fs::create_dir(&outside).unwrap();
+        symlink(&outside, root_path.join("linked")).unwrap();
+
+        let root = Dir::open(&root_path).unwrap();
+
+        assert!(root.open_child_dir(OsStr::new("linked")).is_err());
+    }
+
+    #[test]
+    fn open_child_file_rejects_symlinked_child() {
+        let dir = tempfile::tempdir().unwrap();
+        let root_path = dir.path().join("root");
+        let outside = dir.path().join("outside.txt");
+        fs::create_dir(&root_path).unwrap();
+        fs::write(&outside, "outside").unwrap();
+        symlink(&outside, root_path.join("linked.txt")).unwrap();
+
+        let root = Dir::open(&root_path).unwrap();
+
+        assert!(root.open_child_file(OsStr::new("linked.txt")).is_err());
+    }
+
+    #[test]
+    fn open_child_rejects_nul_name() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = Dir::open(dir.path()).unwrap();
+
+        let err = root
+            .open_child_file(OsStr::from_bytes(b"bad\0name"))
+            .unwrap_err();
+
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+    }
+}

--- a/crates/guest-agent/src/nofollow_fs.rs
+++ b/crates/guest-agent/src/nofollow_fs.rs
@@ -66,10 +66,15 @@ impl Dir {
 fn open_child(parent: &File, name: &OsStr, flags: i32) -> io::Result<File> {
     let name = CString::new(name.as_bytes())
         .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
+    // SAFETY: `parent.as_raw_fd()` is an open directory fd owned by `Dir`,
+    // `name` is a NUL-terminated child basename produced by `CString`, and
+    // the flags do not request a mode argument.
     let fd = unsafe { libc::openat(parent.as_raw_fd(), name.as_ptr(), flags) };
     if fd < 0 {
         return Err(io::Error::last_os_error());
     }
+    // SAFETY: a non-negative `openat` result is a newly owned fd. Converting
+    // it into `File` transfers close responsibility to Rust.
     Ok(unsafe { File::from_raw_fd(fd) })
 }
 

--- a/crates/guest-agent/src/nofollow_fs.rs
+++ b/crates/guest-agent/src/nofollow_fs.rs
@@ -64,14 +64,14 @@ impl Dir {
 
 #[cfg(target_os = "linux")]
 fn open_child(parent: &File, name: &OsStr, flags: i32) -> io::Result<File> {
-    if name.as_bytes().contains(&b'/') {
+    let bytes = name.as_bytes();
+    if bytes.is_empty() || bytes == b"." || bytes == b".." || bytes.contains(&b'/') {
         return Err(io::Error::new(
             io::ErrorKind::InvalidInput,
-            "child name must be a single path component",
+            "child name must be a non-empty basename",
         ));
     }
-    let name = CString::new(name.as_bytes())
-        .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
+    let name = CString::new(bytes).map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
     // SAFETY: `parent.as_raw_fd()` is an open directory fd owned by `Dir`,
     // `name` is a NUL-terminated child basename produced by `CString`, and
     // the flags do not request a mode argument.
@@ -141,14 +141,18 @@ mod tests {
     }
 
     #[test]
-    fn open_child_rejects_path_separator() {
+    fn open_child_rejects_invalid_child_names() {
         let dir = tempfile::tempdir().unwrap();
         let root = Dir::open(dir.path()).unwrap();
 
-        let err = root
-            .open_child_file(OsStr::from_bytes(b"nested/file"))
-            .unwrap_err();
+        for name in [b"".as_slice(), b".", b"..", b"nested/file"] {
+            let err = root.open_child_file(OsStr::from_bytes(name)).unwrap_err();
 
-        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+            assert_eq!(
+                err.kind(),
+                io::ErrorKind::InvalidInput,
+                "name {name:?} should be rejected"
+            );
+        }
     }
 }

--- a/crates/guest-agent/src/session_history.rs
+++ b/crates/guest-agent/src/session_history.rs
@@ -24,6 +24,8 @@
 //! `read_session_history` surfaces the failure instead.
 
 use crate::error::AgentError;
+#[cfg(target_os = "linux")]
+use crate::nofollow_fs::Dir;
 use std::ffi::OsStr;
 use std::io;
 use std::path::{Path, PathBuf};
@@ -141,7 +143,7 @@ fn read_codex_session_history_impl(
     sessions_dir: &Path,
     id_norm: &str,
 ) -> Result<Option<Vec<u8>>, AgentError> {
-    let Ok(root) = open_codex_session_dir(sessions_dir) else {
+    let Ok(root) = Dir::open(sessions_dir) else {
         return Ok(None);
     };
     find_and_read_codex_session_file_recursive(&root, sessions_dir, id_norm)
@@ -149,11 +151,11 @@ fn read_codex_session_history_impl(
 
 #[cfg(target_os = "linux")]
 fn find_and_read_codex_session_file_recursive(
-    dir: &File,
+    dir: &Dir,
     dir_path: &Path,
     id_norm: &str,
 ) -> Result<Option<Vec<u8>>, AgentError> {
-    let Ok(entries) = read_dir_fd(dir) else {
+    let Ok(entries) = dir.read_dir() else {
         return Ok(None);
     };
 
@@ -164,7 +166,7 @@ fn find_and_read_codex_session_file_recursive(
         };
         let path = dir_path.join(&name);
         if file_type.is_dir() {
-            let Ok(child) = open_codex_child_dir(dir, &name) else {
+            let Ok(child) = dir.open_child_dir(&name) else {
                 continue;
             };
             if let Some(found) = find_and_read_codex_session_file_recursive(&child, &path, id_norm)?
@@ -172,7 +174,7 @@ fn find_and_read_codex_session_file_recursive(
                 return Ok(Some(found));
             }
         } else if file_type.is_file() && codex_session_filename_matches(&name, id_norm) {
-            let file = match open_codex_child_file(dir, &name) {
+            let file = match dir.open_child_file(&name) {
                 Ok(file) => file,
                 Err(e) if should_skip_raced_codex_entry(&e) => continue,
                 Err(e) => return Err(read_history_error(&path, e)),
@@ -199,57 +201,6 @@ fn codex_session_filename_matches(name: &OsStr, id_norm: &str) -> bool {
 
     let name_norm = name.replace('-', "").to_ascii_lowercase();
     name_norm.contains(id_norm)
-}
-
-#[cfg(target_os = "linux")]
-fn read_dir_fd(dir: &File) -> io::Result<std::fs::ReadDir> {
-    use std::os::fd::AsRawFd;
-
-    std::fs::read_dir(PathBuf::from(format!("/proc/self/fd/{}", dir.as_raw_fd())))
-}
-
-#[cfg(target_os = "linux")]
-fn open_codex_session_dir(path: &Path) -> io::Result<File> {
-    use std::fs::OpenOptions;
-    use std::os::unix::fs::OpenOptionsExt;
-
-    OpenOptions::new()
-        .read(true)
-        .custom_flags(libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC)
-        .open(path)
-}
-
-#[cfg(target_os = "linux")]
-fn open_codex_child_dir(parent: &File, name: &OsStr) -> io::Result<File> {
-    open_codex_child(
-        parent,
-        name,
-        libc::O_RDONLY | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC,
-    )
-}
-
-#[cfg(target_os = "linux")]
-fn open_codex_child_file(parent: &File, name: &OsStr) -> io::Result<File> {
-    open_codex_child(
-        parent,
-        name,
-        libc::O_RDONLY | libc::O_NOFOLLOW | libc::O_CLOEXEC | libc::O_NONBLOCK,
-    )
-}
-
-#[cfg(target_os = "linux")]
-fn open_codex_child(parent: &File, name: &OsStr, flags: i32) -> io::Result<File> {
-    use std::ffi::CString;
-    use std::os::fd::{AsRawFd, FromRawFd};
-    use std::os::unix::ffi::OsStrExt;
-
-    let name = CString::new(name.as_bytes())
-        .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
-    let fd = unsafe { libc::openat(parent.as_raw_fd(), name.as_ptr(), flags) };
-    if fd < 0 {
-        return Err(io::Error::last_os_error());
-    }
-    Ok(unsafe { File::from_raw_fd(fd) })
 }
 
 #[cfg(target_os = "linux")]


### PR DESCRIPTION
## Summary
- add a Linux-only guest-agent no-follow filesystem primitive around fd-relative opens
- move Codex session-history lookup and artifact archive traversal to the shared primitive
- keep caller-specific traversal policy and error handling in the existing modules

Closes #13331

## Testing
- CARGO_BUILD_JOBS=1 cargo test --manifest-path crates/Cargo.toml -p guest-agent --lib
- CARGO_BUILD_JOBS=1 cargo test --manifest-path crates/Cargo.toml -p guest-agent --test codex_session_resume
- CARGO_BUILD_JOBS=1 cargo clippy --manifest-path crates/Cargo.toml -p guest-agent --all-targets --all-features
- cargo fmt --manifest-path crates/Cargo.toml --all --check
- git diff --check

Note: the first commit attempt hit a transient cargo-doc E0460 artifact-cache race while lefthook ran cargo-doc alongside clippy; rerunning the same commit hook passed.