### PR TITLE
refactor: extract stripe cli auth parser

### DIFF
--- a/turbo/apps/api/src/signals/services/__tests__/cli-auth-stripe-parser.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/cli-auth-stripe-parser.test.ts
@@ -297,9 +297,26 @@ test_mode_api_key = 123
   });
 
   it("rejects malformed TOML", () => {
-    expect(() => {
+    const parseMalformed = () => {
       parseStripeCliAuthConfig("[default", "test");
-    }).toThrow();
+    };
+
+    expect(parseMalformed).toThrow("Stripe CLI config is not valid TOML");
+  });
+
+  it("rejects malformed TOML without leaking config values", () => {
+    const parseMalformed = () => {
+      parseStripeCliAuthConfig(
+        `[default]
+test_mode_api_key = "sk_test_should_not_leak"
+bad =
+`,
+        "test",
+      );
+    };
+
+    expect(parseMalformed).toThrow("Stripe CLI config is not valid TOML");
+    expect(parseMalformed).not.toThrow(/sk_test_should_not_leak/);
   });
 });
 

--- a/turbo/apps/api/src/signals/services/__tests__/cli-auth-stripe-parser.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/cli-auth-stripe-parser.test.ts
@@ -1,0 +1,323 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  parseStripeCliAuthConfig,
+  parseStripeCliAuthStartOutput,
+  redactStripeCliAuthText,
+} from "../cli-auth-stripe-parser";
+
+function startOutput(
+  args: {
+    readonly browserUrl?: string;
+    readonly nextStep?: string;
+    readonly verificationCode?: string;
+  } = {},
+) {
+  return JSON.stringify({
+    browser_url:
+      args.browserUrl ??
+      "https://dashboard.stripe.com/stripecli/confirm_auth?t=start-token",
+    verification_code: args.verificationCode ?? "enjoy-enough-outwit-win",
+    next_step:
+      args.nextStep ??
+      "stripe login --complete 'https://dashboard.stripe.com/stripecli/auth/poll-token'",
+  });
+}
+
+describe("parseStripeCliAuthStartOutput", () => {
+  it("parses valid non-interactive JSON output", () => {
+    expect(parseStripeCliAuthStartOutput(startOutput())).toStrictEqual({
+      browserUrl:
+        "https://dashboard.stripe.com/stripecli/confirm_auth?t=start-token",
+      pollUrl: "https://dashboard.stripe.com/stripecli/auth/poll-token",
+      verificationCode: "enjoy-enough-outwit-win",
+    });
+  });
+
+  it("rejects invalid JSON", () => {
+    expect(() => {
+      parseStripeCliAuthStartOutput("{");
+    }).toThrow();
+  });
+
+  it("rejects missing browser URL", () => {
+    expect(() => {
+      parseStripeCliAuthStartOutput(
+        JSON.stringify({
+          verification_code: "code",
+          next_step:
+            "stripe login --complete https://dashboard.stripe.com/stripecli/auth/poll-token",
+        }),
+      );
+    }).toThrow();
+  });
+
+  it("rejects missing verification code", () => {
+    expect(() => {
+      parseStripeCliAuthStartOutput(
+        JSON.stringify({
+          browser_url:
+            "https://dashboard.stripe.com/stripecli/confirm_auth?t=start-token",
+          next_step:
+            "stripe login --complete https://dashboard.stripe.com/stripecli/auth/poll-token",
+        }),
+      );
+    }).toThrow();
+  });
+
+  it("rejects missing completion step", () => {
+    expect(() => {
+      parseStripeCliAuthStartOutput(
+        JSON.stringify({
+          browser_url:
+            "https://dashboard.stripe.com/stripecli/confirm_auth?t=start-token",
+          verification_code: "code",
+        }),
+      );
+    }).toThrow();
+  });
+
+  it("extracts a single-quoted completion URL", () => {
+    const result = parseStripeCliAuthStartOutput(
+      startOutput({
+        nextStep:
+          "stripe login --complete 'https://dashboard.stripe.com/stripecli/auth/single-quoted'",
+      }),
+    );
+
+    expect(result.pollUrl).toBe(
+      "https://dashboard.stripe.com/stripecli/auth/single-quoted",
+    );
+  });
+
+  it("extracts a double-quoted completion URL", () => {
+    const result = parseStripeCliAuthStartOutput(
+      startOutput({
+        nextStep:
+          'stripe login --complete "https://dashboard.stripe.com/stripecli/auth/double-quoted"',
+      }),
+    );
+
+    expect(result.pollUrl).toBe(
+      "https://dashboard.stripe.com/stripecli/auth/double-quoted",
+    );
+  });
+
+  it("extracts an unquoted completion URL", () => {
+    const result = parseStripeCliAuthStartOutput(
+      startOutput({
+        nextStep:
+          "stripe login --complete https://dashboard.stripe.com/stripecli/auth/unquoted",
+      }),
+    );
+
+    expect(result.pollUrl).toBe(
+      "https://dashboard.stripe.com/stripecli/auth/unquoted",
+    );
+  });
+
+  it("rejects next_step without a complete URL", () => {
+    expect(() => {
+      parseStripeCliAuthStartOutput(
+        startOutput({ nextStep: "stripe login --help" }),
+      );
+    }).toThrow("Stripe CLI response did not include a completion URL");
+  });
+
+  it("rejects non-HTTPS completion URLs", () => {
+    expect(() => {
+      parseStripeCliAuthStartOutput(
+        startOutput({
+          nextStep:
+            "stripe login --complete http://dashboard.stripe.com/stripecli/auth/poll-token",
+        }),
+      );
+    }).toThrow("Stripe CLI response did not include a completion URL");
+  });
+
+  it("rejects non-Stripe completion URL hosts", () => {
+    expect(() => {
+      parseStripeCliAuthStartOutput(
+        startOutput({
+          nextStep:
+            "stripe login --complete https://example.com/stripecli/auth/poll-token",
+        }),
+      );
+    }).toThrow("Stripe CLI response included an unexpected completion URL");
+  });
+
+  it("rejects unexpected Stripe dashboard completion paths", () => {
+    expect(() => {
+      parseStripeCliAuthStartOutput(
+        startOutput({
+          nextStep:
+            "stripe login --complete https://dashboard.stripe.com/settings",
+        }),
+      );
+    }).toThrow("Stripe CLI response included an unexpected completion URL");
+  });
+
+  it("rejects non-Stripe browser URL hosts", () => {
+    expect(() => {
+      parseStripeCliAuthStartOutput(
+        startOutput({
+          browserUrl: "https://example.com/stripecli/confirm_auth",
+        }),
+      );
+    }).toThrow("Stripe CLI response included an unexpected browser URL");
+  });
+
+  it("rejects unexpected Stripe dashboard browser paths", () => {
+    expect(() => {
+      parseStripeCliAuthStartOutput(
+        startOutput({ browserUrl: "https://dashboard.stripe.com/settings" }),
+      );
+    }).toThrow("Stripe CLI response included an unexpected browser URL");
+  });
+});
+
+describe("parseStripeCliAuthConfig", () => {
+  it("parses a default restricted test mode key", () => {
+    expect(
+      parseStripeCliAuthConfig(
+        `[default]
+test_mode_api_key = "rk_test_abc123"
+`,
+        "test",
+      ),
+    ).toBe("rk_test_abc123");
+  });
+
+  it("parses a default secret test mode key", () => {
+    expect(
+      parseStripeCliAuthConfig(
+        `[default]
+test_mode_api_key = "sk_test_abc123"
+`,
+        "test",
+      ),
+    ).toBe("sk_test_abc123");
+  });
+
+  it("parses a default restricted live mode key", () => {
+    expect(
+      parseStripeCliAuthConfig(
+        `[default]
+live_mode_api_key = "rk_live_abc123"
+`,
+        "live",
+      ),
+    ).toBe("rk_live_abc123");
+  });
+
+  it("parses a default secret live mode key", () => {
+    expect(
+      parseStripeCliAuthConfig(
+        `[default]
+live_mode_api_key = "sk_live_abc123"
+`,
+        "live",
+      ),
+    ).toBe("sk_live_abc123");
+  });
+
+  it("returns only the selected mode key when both modes are present", () => {
+    const config = `[default]
+test_mode_api_key = "rk_test_selected"
+live_mode_api_key = "rk_live_selected"
+display_name = "Should not be returned"
+`;
+
+    expect(parseStripeCliAuthConfig(config, "test")).toBe("rk_test_selected");
+    expect(parseStripeCliAuthConfig(config, "live")).toBe("rk_live_selected");
+  });
+
+  it("preserves top-level key fallback", () => {
+    expect(
+      parseStripeCliAuthConfig(
+        `test_mode_api_key = "rk_test_topLevel"
+`,
+        "test",
+      ),
+    ).toBe("rk_test_topLevel");
+  });
+
+  it("rejects missing selected mode key", () => {
+    expect(() => {
+      parseStripeCliAuthConfig(
+        `[default]
+live_mode_api_key = "rk_live_only"
+`,
+        "test",
+      );
+    }).toThrow("Stripe CLI config did not contain a test mode API key");
+  });
+
+  it("rejects a key with the wrong mode prefix", () => {
+    expect(() => {
+      parseStripeCliAuthConfig(
+        `[default]
+test_mode_api_key = "rk_live_wrong"
+`,
+        "test",
+      );
+    }).toThrow("Stripe CLI config did not contain a test mode API key");
+  });
+
+  it("rejects a non-string selected mode key", () => {
+    expect(() => {
+      parseStripeCliAuthConfig(
+        `[default]
+test_mode_api_key = 123
+`,
+        "test",
+      );
+    }).toThrow("Stripe CLI config did not contain a test mode API key");
+  });
+
+  it("rejects malformed TOML", () => {
+    expect(() => {
+      parseStripeCliAuthConfig("[default", "test");
+    }).toThrow();
+  });
+});
+
+describe("redactStripeCliAuthText", () => {
+  it("redacts bare Stripe restricted and secret keys", () => {
+    const redacted = redactStripeCliAuthText(
+      "rk_test_abc123 sk_test_def456 rk_live_ghi789 sk_live_placeholder_key",
+    );
+
+    expect(redacted).not.toContain("rk_test_abc123");
+    expect(redacted).not.toContain("sk_test_def456");
+    expect(redacted).not.toContain("rk_live_ghi789");
+    expect(redacted).not.toContain("sk_live_placeholder_key");
+    expect(redacted).toBe("[redacted] [redacted] [redacted] [redacted]");
+  });
+
+  it("redacts assignment-style secrets through sandbox redaction", () => {
+    const redacted = redactStripeCliAuthText(
+      "STRIPE_SECRET=sk_test_should_not_leak",
+    );
+
+    expect(redacted).toBe("STRIPE_SECRET=[redacted]");
+  });
+
+  it("redacts Stripe CLI auth URL tokens", () => {
+    const redacted = redactStripeCliAuthText(
+      "https://dashboard.stripe.com/stripecli/auth/poll-token",
+    );
+
+    expect(redacted).toBe("https://dashboard.stripe.com/stripecli/[redacted]");
+    expect(redacted).not.toContain("poll-token");
+  });
+
+  it("redacts Stripe CLI confirm-auth URL tokens", () => {
+    const redacted = redactStripeCliAuthText(
+      "https://dashboard.stripe.com/stripecli/confirm_auth?t=start-token",
+    );
+
+    expect(redacted).toBe("https://dashboard.stripe.com/stripecli/[redacted]");
+    expect(redacted).not.toContain("start-token");
+  });
+});

--- a/turbo/apps/api/src/signals/services/__tests__/cli-auth-stripe-parser.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/cli-auth-stripe-parser.test.ts
@@ -132,7 +132,17 @@ describe("parseStripeCliAuthStartOutput", () => {
             "stripe login --complete http://dashboard.stripe.com/stripecli/auth/poll-token",
         }),
       );
-    }).toThrow("Stripe CLI response did not include a completion URL");
+    }).toThrow("Stripe CLI response included an unexpected completion URL");
+  });
+
+  it("rejects malformed completion URL arguments", () => {
+    expect(() => {
+      parseStripeCliAuthStartOutput(
+        startOutput({
+          nextStep: "stripe login --complete not-a-url",
+        }),
+      );
+    }).toThrow("Stripe CLI response included an invalid completion URL");
   });
 
   it("rejects non-Stripe completion URL hosts", () => {
@@ -173,6 +183,17 @@ describe("parseStripeCliAuthStartOutput", () => {
         startOutput({ browserUrl: "https://dashboard.stripe.com/settings" }),
       );
     }).toThrow("Stripe CLI response included an unexpected browser URL");
+  });
+
+  it("accepts Stripe dashboard browser path children", () => {
+    const browserUrl =
+      "https://dashboard.stripe.com/stripecli/confirm_auth/start-token";
+
+    expect(
+      parseStripeCliAuthStartOutput(startOutput({ browserUrl })),
+    ).toMatchObject({
+      browserUrl,
+    });
   });
 });
 

--- a/turbo/apps/api/src/signals/services/cli-auth-stripe-parser.ts
+++ b/turbo/apps/api/src/signals/services/cli-auth-stripe-parser.ts
@@ -2,7 +2,7 @@ import { parse } from "smol-toml";
 import { z } from "zod";
 
 import { redactSandboxMessage } from "../external/sandbox";
-import { safeJsonParse, safeUrlParse } from "../utils";
+import { safeJsonParse, safeUrlParse, throwIfAbort } from "../utils";
 
 export type StripeCliAuthMode = "test" | "live";
 
@@ -89,11 +89,21 @@ function stripeCliAuthKeyPattern(mode: StripeCliAuthMode): RegExp {
     : /^(sk|rk)_live_[A-Za-z0-9]+$/;
 }
 
+function parseStripeCliAuthToml(configToml: string): unknown {
+  // eslint-disable-next-line no-restricted-syntax -- sanitize smol-toml parser errors because they include input excerpts that may contain Stripe keys
+  try {
+    return parse(configToml) as unknown;
+  } catch (error) {
+    throwIfAbort(error);
+    throw new Error("Stripe CLI config is not valid TOML");
+  }
+}
+
 export function parseStripeCliAuthConfig(
   configToml: string,
   mode: StripeCliAuthMode,
 ): string {
-  const parsed = parse(configToml) as unknown;
+  const parsed = parseStripeCliAuthToml(configToml);
   if (!isRecord(parsed)) {
     throw new Error("Stripe CLI config is not a TOML table");
   }

--- a/turbo/apps/api/src/signals/services/cli-auth-stripe-parser.ts
+++ b/turbo/apps/api/src/signals/services/cli-auth-stripe-parser.ts
@@ -24,7 +24,10 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function stripeCliAuthPathMatches(url: URL, label: "browser" | "completion") {
   if (label === "browser") {
-    return url.pathname === "/stripecli/confirm_auth";
+    return (
+      url.pathname === "/stripecli/confirm_auth" ||
+      url.pathname.startsWith("/stripecli/confirm_auth/")
+    );
   }
   return (
     url.pathname === "/stripecli/auth" ||
@@ -52,9 +55,8 @@ function validateStripeCliAuthUrl(
 }
 
 function extractStripeCliAuthPollUrl(nextStep: string): string {
-  const quoted = /--complete\s+(['"])(?<url>https:\/\/[^'"]+)\1/.exec(nextStep);
-  const unquoted =
-    quoted ?? /--complete\s+(?<url>https:\/\/\S+)/.exec(nextStep);
+  const quoted = /--complete\s+(['"])(?<url>[^'"]+)\1/.exec(nextStep);
+  const unquoted = quoted ?? /--complete\s+(?<url>\S+)/.exec(nextStep);
   const pollUrl = unquoted?.groups?.url;
   if (!pollUrl) {
     throw new Error("Stripe CLI response did not include a completion URL");

--- a/turbo/apps/api/src/signals/services/cli-auth-stripe-parser.ts
+++ b/turbo/apps/api/src/signals/services/cli-auth-stripe-parser.ts
@@ -1,0 +1,120 @@
+import { parse } from "smol-toml";
+import { z } from "zod";
+
+import { redactSandboxMessage } from "../external/sandbox";
+import { safeJsonParse, safeUrlParse } from "../utils";
+
+export type StripeCliAuthMode = "test" | "live";
+
+export interface StripeCliAuthStartOutput {
+  readonly browserUrl: string;
+  readonly pollUrl: string;
+  readonly verificationCode: string;
+}
+
+const stripeCliAuthOutputSchema = z.object({
+  browser_url: z.url(),
+  verification_code: z.string().min(1),
+  next_step: z.string().min(1),
+});
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stripeCliAuthPathMatches(url: URL, label: "browser" | "completion") {
+  if (label === "browser") {
+    return url.pathname === "/stripecli/confirm_auth";
+  }
+  return (
+    url.pathname === "/stripecli/auth" ||
+    url.pathname.startsWith("/stripecli/auth/")
+  );
+}
+
+function validateStripeCliAuthUrl(
+  url: string,
+  label: "browser" | "completion",
+): string {
+  const parsed = safeUrlParse(url);
+  if (!parsed) {
+    throw new Error(`Stripe CLI response included an invalid ${label} URL`);
+  }
+  if (
+    parsed.protocol !== "https:" ||
+    parsed.hostname !== "dashboard.stripe.com" ||
+    !stripeCliAuthPathMatches(parsed, label)
+  ) {
+    throw new Error(`Stripe CLI response included an unexpected ${label} URL`);
+  }
+
+  return url;
+}
+
+function extractStripeCliAuthPollUrl(nextStep: string): string {
+  const quoted = /--complete\s+(['"])(?<url>https:\/\/[^'"]+)\1/.exec(nextStep);
+  const unquoted =
+    quoted ?? /--complete\s+(?<url>https:\/\/\S+)/.exec(nextStep);
+  const pollUrl = unquoted?.groups?.url;
+  if (!pollUrl) {
+    throw new Error("Stripe CLI response did not include a completion URL");
+  }
+
+  return validateStripeCliAuthUrl(pollUrl, "completion");
+}
+
+export function parseStripeCliAuthStartOutput(
+  stdout: string,
+): StripeCliAuthStartOutput {
+  const output = stripeCliAuthOutputSchema.parse(safeJsonParse(stdout));
+  const pollUrl = extractStripeCliAuthPollUrl(output.next_step);
+  const browserUrl = validateStripeCliAuthUrl(output.browser_url, "browser");
+
+  return {
+    browserUrl,
+    pollUrl,
+    verificationCode: output.verification_code,
+  };
+}
+
+function stripeCliAuthKeyField(mode: StripeCliAuthMode): string {
+  return mode === "test" ? "test_mode_api_key" : "live_mode_api_key";
+}
+
+function stripeCliAuthKeyPattern(mode: StripeCliAuthMode): RegExp {
+  return mode === "test"
+    ? /^(sk|rk)_test_[A-Za-z0-9]+$/
+    : /^(sk|rk)_live_[A-Za-z0-9]+$/;
+}
+
+export function parseStripeCliAuthConfig(
+  configToml: string,
+  mode: StripeCliAuthMode,
+): string {
+  const parsed = parse(configToml) as unknown;
+  if (!isRecord(parsed)) {
+    throw new Error("Stripe CLI config is not a TOML table");
+  }
+
+  const defaultProfile = parsed.default;
+  const profile = isRecord(defaultProfile) ? defaultProfile : parsed;
+  const keyField = stripeCliAuthKeyField(mode);
+  const apiKey = profile[keyField];
+  if (
+    typeof apiKey !== "string" ||
+    !stripeCliAuthKeyPattern(mode).test(apiKey)
+  ) {
+    throw new Error(`Stripe CLI config did not contain a ${mode} mode API key`);
+  }
+
+  return apiKey;
+}
+
+export function redactStripeCliAuthText(value: string): string {
+  return redactSandboxMessage(value)
+    .replace(/\b(?:rk|sk)_(?:test|live)_[A-Za-z0-9_]+\b/g, "[redacted]")
+    .replace(
+      /https:\/\/dashboard\.stripe\.com\/stripecli\/(?:auth|confirm_auth)[^\s'"]*/g,
+      "https://dashboard.stripe.com/stripecli/[redacted]",
+    );
+}

--- a/turbo/apps/api/src/signals/services/cli-auth-stripe.service.ts
+++ b/turbo/apps/api/src/signals/services/cli-auth-stripe.service.ts
@@ -1,4 +1,3 @@
-import { parse } from "smol-toml";
 import { command, type Setter } from "ccstate";
 import type { ConnectorResponse } from "@vm0/api-contracts/contracts/connector-schemas";
 import { z } from "zod";
@@ -7,7 +6,6 @@ import { nowDate } from "../../lib/time";
 import { logger } from "../../lib/log";
 import { getVercelSandboxClient } from "../external/vercel-sandbox";
 import {
-  redactSandboxMessage,
   sandboxOperation,
   type SandboxClient,
   type SandboxCommandResult,
@@ -17,10 +15,17 @@ import { connectors } from "@vm0/db/schema/connector";
 import { connectorCliAuthSessions } from "@vm0/db/schema/connector-cli-auth-session";
 import { secrets } from "@vm0/db/schema/secret";
 import { and, eq, inArray, lt, or } from "drizzle-orm";
-import { safeAsync, safeJsonParse, safeUrlParse } from "../utils";
+import { safeAsync, safeJsonParse } from "../utils";
 import { writeDb$, type Db } from "../external/db";
 import { publishUserSignal } from "../external/realtime";
 import { decryptSecretValue, encryptSecretValue } from "./crypto.utils";
+import {
+  parseStripeCliAuthConfig,
+  parseStripeCliAuthStartOutput as parseStripeCliAuthStartOutputText,
+  redactStripeCliAuthText,
+  type StripeCliAuthMode,
+  type StripeCliAuthStartOutput,
+} from "./cli-auth-stripe-parser";
 
 const CLI_AUTH_STRIPE_RUNTIME = "node24";
 const CLI_AUTH_STRIPE_VERSION = "1.40.9";
@@ -39,18 +44,13 @@ const CLI_AUTH_STRIPE_CONFIG_HOME = `${CLI_AUTH_STRIPE_ROOT}/config`;
 const CLI_AUTH_STRIPE_CONFIG_PATH = `${CLI_AUTH_STRIPE_CONFIG_HOME}/stripe/config.toml`;
 const CLI_AUTH_STRIPE_CONNECTOR_TYPE = "stripe";
 const CLI_AUTH_STRIPE_SOURCE = "stripe-cli";
+const CLI_AUTH_STRIPE_MODE: StripeCliAuthMode = "test";
 const STRIPE_TOKEN_SECRET_NAME = "STRIPE_TOKEN";
 const STRIPE_OAUTH_SECRET_NAMES = [
   "STRIPE_ACCESS_TOKEN",
   "STRIPE_REFRESH_TOKEN",
 ] as const;
 const L = logger("CliAuthStripe");
-
-const cliAuthStripeOutputSchema = z.object({
-  browser_url: z.url(),
-  verification_code: z.string().min(1),
-  next_step: z.string().min(1),
-});
 
 const cliAuthStripeSessionTokenSchema = z.object({
   version: z.literal(1),
@@ -125,12 +125,6 @@ type CliAuthStripeErrorResult = Extract<
   { readonly status: "error" }
 >;
 type ConnectorCliAuthSession = typeof connectorCliAuthSessions.$inferSelect;
-
-type ParsedCliAuthStripeStartOutput = {
-  readonly browserUrl: string;
-  readonly pollUrl: string;
-  readonly verificationCode: string;
-};
 
 type PreparedCliAuthStripeCompletion =
   | {
@@ -224,54 +218,15 @@ async function decodeProviderState(
   return decoded.ok;
 }
 
-function extractPollUrl(nextStep: string): string {
-  const quoted = /--complete\s+(['"])(?<url>https:\/\/[^'"]+)\1/.exec(nextStep);
-  const unquoted =
-    quoted ?? /--complete\s+(?<url>https:\/\/\S+)/.exec(nextStep);
-  const pollUrl = unquoted?.groups?.url;
-  if (!pollUrl) {
-    throw new Error("Stripe CLI response did not include a completion URL");
-  }
-
-  validateStripeCliUrl(pollUrl, "completion");
-
-  return pollUrl;
-}
-
-function validateStripeCliUrl(
-  url: string,
-  label: "browser" | "completion",
-): string {
-  const parsed = safeUrlParse(url);
-  if (!parsed) {
-    throw new Error(`Stripe CLI response included an invalid ${label} URL`);
-  }
-  if (
-    parsed.protocol !== "https:" ||
-    parsed.hostname !== "dashboard.stripe.com"
-  ) {
-    throw new Error(`Stripe CLI response included an unexpected ${label} URL`);
-  }
-
-  return url;
-}
-
 function commandText(result: SandboxCommandResult): string {
   return [result.stdout.text, result.stderr.text].filter(Boolean).join("\n");
-}
-
-function redactCliAuthStripeCommandText(value: string): string {
-  return redactSandboxMessage(value).replace(
-    /https:\/\/dashboard\.stripe\.com\/stripecli\/(?:auth|confirm_auth)[^\s'"]*/g,
-    "https://dashboard.stripe.com/stripecli/[redacted]",
-  );
 }
 
 function commandFailedMessage(
   phase: string,
   result: SandboxCommandResult,
 ): string {
-  const output = redactCliAuthStripeCommandText(commandText(result).trim());
+  const output = redactStripeCliAuthText(commandText(result).trim());
   const suffix = output ? `: ${output.slice(0, 500)}` : "";
   return `${phase} exited with code ${String(result.exitCode)}${suffix}`;
 }
@@ -281,29 +236,6 @@ function isPendingCompletion(result: SandboxCommandResult): boolean {
     return true;
   }
   return /exceeded max attempts/i.test(commandText(result));
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function stripeApiKeyFromConfig(configToml: string): string {
-  const parsed = parse(configToml) as unknown;
-  if (!isRecord(parsed)) {
-    throw new Error("Stripe CLI config is not a TOML table");
-  }
-
-  const defaultProfile = parsed.default;
-  const profile = isRecord(defaultProfile) ? defaultProfile : parsed;
-  const apiKey = profile.test_mode_api_key;
-  if (
-    typeof apiKey !== "string" ||
-    !/^(sk|rk)_test_[A-Za-z0-9]+$/.test(apiKey)
-  ) {
-    throw new Error("Stripe CLI config did not contain a test mode API key");
-  }
-
-  return apiKey;
 }
 
 function stopSandbox(client: SandboxClient, sandbox: SandboxHandle) {
@@ -344,7 +276,7 @@ async function cleanupSandboxSafely(args: {
 }
 
 function sanitizeSessionError(message: string): string {
-  return redactCliAuthStripeCommandText(message).slice(0, 500);
+  return redactStripeCliAuthText(message).slice(0, 500);
 }
 
 async function markCliAuthStripeSessionError(args: {
@@ -465,21 +397,11 @@ async function createCliAuthStripeSandbox(args: {
 async function parseCliAuthStripeStartOutput(
   result: SandboxCommandResult,
 ): Promise<
-  | { readonly ok: true; readonly output: ParsedCliAuthStripeStartOutput }
+  | { readonly ok: true; readonly output: StripeCliAuthStartOutput }
   | { readonly ok: false; readonly message: string }
 > {
   const parsedResult = await safeSync(() => {
-    const output = cliAuthStripeOutputSchema.parse(
-      safeJsonParse(result.stdout.text),
-    );
-    const pollUrl = extractPollUrl(output.next_step);
-    const browserUrl = validateStripeCliUrl(output.browser_url, "browser");
-
-    return {
-      browserUrl,
-      pollUrl,
-      verificationCode: output.verification_code,
-    };
+    return parseStripeCliAuthStartOutputText(result.stdout.text);
   });
   if ("error" in parsedResult) {
     return {
@@ -500,7 +422,7 @@ async function runCliAuthStripeStartInSandbox(args: {
   readonly sessionId: string;
   readonly signal: AbortSignal;
 }): Promise<
-  | { readonly ok: true; readonly output: ParsedCliAuthStripeStartOutput }
+  | { readonly ok: true; readonly output: StripeCliAuthStartOutput }
   | { readonly ok: false; readonly result: CliAuthStripeStartFailureResult }
 > {
   const runResult = await sandboxOperation("run", () => {
@@ -577,7 +499,7 @@ async function runCliAuthStripeStartInSandbox(args: {
 async function markCliAuthStripeSessionAwaitingApproval(args: {
   readonly writeDb: Db;
   readonly sessionId: string;
-  readonly output: ParsedCliAuthStripeStartOutput;
+  readonly output: StripeCliAuthStartOutput;
 }) {
   await args.writeDb
     .update(connectorCliAuthSessions)
@@ -908,7 +830,10 @@ async function readCliAuthStripeApiKey(args: {
 
   const configData = configResult.value.data;
   const apiKeyResult = await safeSync(() => {
-    return stripeApiKeyFromConfig(configData.toString("utf8"));
+    return parseStripeCliAuthConfig(
+      configData.toString("utf8"),
+      CLI_AUTH_STRIPE_MODE,
+    );
   });
   if ("error" in apiKeyResult) {
     return {

--- a/turbo/apps/api/src/signals/services/cli-auth-stripe.service.ts
+++ b/turbo/apps/api/src/signals/services/cli-auth-stripe.service.ts
@@ -404,12 +404,13 @@ async function parseCliAuthStripeStartOutput(
     return parseStripeCliAuthStartOutputText(result.stdout.text);
   });
   if ("error" in parsedResult) {
+    const message =
+      parsedResult.error instanceof Error
+        ? parsedResult.error.message
+        : String(parsedResult.error);
     return {
       ok: false,
-      message:
-        parsedResult.error instanceof Error
-          ? parsedResult.error.message
-          : String(parsedResult.error),
+      message: redactStripeCliAuthText(message),
     };
   }
   return { ok: true, output: parsedResult.ok };
@@ -836,15 +837,16 @@ async function readCliAuthStripeApiKey(args: {
     );
   });
   if ("error" in apiKeyResult) {
+    const message =
+      apiKeyResult.error instanceof Error
+        ? apiKeyResult.error.message
+        : String(apiKeyResult.error);
     return {
       ok: false,
       result: {
         status: "error",
         code: "CLI_AUTH_STRIPE_FAILED",
-        message:
-          apiKeyResult.error instanceof Error
-            ? apiKeyResult.error.message
-            : String(apiKeyResult.error),
+        message: redactStripeCliAuthText(message),
       },
     };
   }


### PR DESCRIPTION
## Summary
- Extract Stripe CLI auth start/config parsing and redaction into a focused pure helper module.
- Keep runtime import behavior test-mode-only via an explicit mode constant.
- Add parser tests for URL extraction/validation, mode-aware TOML selection, and Stripe key/URL redaction.

## Verification
- pnpm --filter api exec vitest run src/signals/services/__tests__/cli-auth-stripe-parser.test.ts
- pnpm --filter api check-types
- pnpm --filter api lint
- pnpm exec prettier --check apps/api/src/signals/services/cli-auth-stripe-parser.ts apps/api/src/signals/services/__tests__/cli-auth-stripe-parser.test.ts apps/api/src/signals/services/cli-auth-stripe.service.ts
- pnpm knip --cache

## Notes
- Attempted route regression with pnpm --filter api exec vitest run src/signals/routes/__tests__/zero-connectors-cli-auth-stripe.test.ts, but the local test DB is missing connector_cli_auth_sessions (Postgres 42P01), so it fails before exercising this code path.

Closes #13129