### PR TITLE
feat: add vsock operation quiesce protocol

### DIFF
--- a/crates/vsock-guest/src/command.rs
+++ b/crates/vsock-guest/src/command.rs
@@ -17,6 +17,7 @@ use crate::error::to_io_error;
 use crate::exec::{format_env_diagnostics, spawn_with_pipes, truncate_preview};
 use crate::log::log;
 use crate::process::{extract_exit_code, kill_and_reap_child};
+use crate::quiesce::OperationGuard;
 use crate::threading::{SystemThreadSpawner, ThreadSpawner};
 use crate::wait::{
     DRAIN_DEADLINE_SECS, WaitOutcome, await_drain_deadline,
@@ -120,6 +121,7 @@ struct WaitFailureContext<'a> {
     stderr_policy: CommandOutputPolicy,
     registration: &'a CommandRegistration,
     writer: &'a GuestWriter,
+    operation_guard: &'a OperationGuard,
 }
 
 pub(crate) struct CommandWorkerRequest {
@@ -186,12 +188,14 @@ struct CommandResultFrame<'a> {
 
 pub(crate) fn start_command_operation(
     request: CommandWorkerRequest,
+    operation_guard: OperationGuard,
     writer: GuestWriter,
     connection_cancel: Arc<AtomicBool>,
     registry: CommandRegistry,
 ) -> io::Result<()> {
     start_command_operation_with_spawner(
         request,
+        operation_guard,
         writer,
         connection_cancel,
         registry,
@@ -201,6 +205,7 @@ pub(crate) fn start_command_operation(
 
 fn start_command_operation_with_spawner<S>(
     request: CommandWorkerRequest,
+    operation_guard: OperationGuard,
     writer: GuestWriter,
     connection_cancel: Arc<AtomicBool>,
     registry: CommandRegistry,
@@ -221,6 +226,7 @@ where
     let stderr_policy = request.stderr;
     let worker_writer = writer.clone();
     let worker_spawner = spawner.clone();
+    let worker_operation_guard = operation_guard.clone();
     let result = spawner.spawn_unit(
         THREAD_COMMAND_WORKER,
         Box::new(move || {
@@ -230,6 +236,7 @@ where
                 connection_cancel,
                 command_cancel,
                 registration,
+                worker_operation_guard,
                 worker_spawner,
             );
         }),
@@ -243,6 +250,7 @@ where
                 "ERROR",
                 &format!("command: worker spawn failed seq={seq}: {e}"),
             );
+            operation_guard.release();
             send_command_result(
                 CommandResultFrame {
                     seq,
@@ -279,6 +287,7 @@ fn run_command_worker<S>(
     connection_cancel: Arc<AtomicBool>,
     command_cancel: Arc<AtomicBool>,
     registration: CommandRegistration,
+    operation_guard: OperationGuard,
     spawner: S,
 ) where
     S: ThreadSpawner,
@@ -296,6 +305,7 @@ fn run_command_worker<S>(
                 diagnostic: &diagnostic,
             },
             &writer,
+            &operation_guard,
         );
         return;
     }
@@ -319,6 +329,7 @@ fn run_command_worker<S>(
                     diagnostic: &diagnostic,
                 },
                 &writer,
+                &operation_guard,
             );
             return;
         }
@@ -336,6 +347,7 @@ fn run_command_worker<S>(
         stderr_policy: request.stderr,
         registration: &registration,
         writer: &writer,
+        operation_guard: &operation_guard,
     };
 
     let stdout = match child.stdout.take() {
@@ -444,6 +456,7 @@ fn run_command_worker<S>(
                     diagnostic: &format!("failed to spawn stderr drain thread: {e}"),
                 },
                 &writer,
+                &operation_guard,
             );
             return;
         }
@@ -518,6 +531,7 @@ fn run_command_worker<S>(
             diagnostic: &diagnostic,
         },
         &writer,
+        &operation_guard,
     );
 }
 
@@ -753,6 +767,7 @@ fn kill_and_send_wait_failed(child: Child, diagnostic: &str, failure: WaitFailur
             diagnostic,
         },
         failure.writer,
+        failure.operation_guard,
     );
 }
 
@@ -760,7 +775,9 @@ fn send_final_and_complete(
     registration: &CommandRegistration,
     frame: CommandResultFrame<'_>,
     writer: &GuestWriter,
+    operation_guard: &OperationGuard,
 ) {
+    operation_guard.release();
     let result = send_command_result(frame, writer);
     registration.complete();
     if let Err(e) = result {
@@ -907,6 +924,10 @@ mod tests {
         }
     }
 
+    fn operation_guard() -> OperationGuard {
+        crate::quiesce::OperationState::default().acquire().unwrap()
+    }
+
     fn wait_for_registry_release(registry: &CommandRegistry, seq: u32) {
         let deadline = Instant::now() + Duration::from_secs(3);
         while Instant::now() < deadline {
@@ -979,6 +1000,7 @@ mod tests {
 
         start_command_operation_with_spawner(
             request(42, "echo should-not-run"),
+            operation_guard(),
             writer,
             Arc::new(AtomicBool::new(false)),
             registry.clone(),
@@ -1005,6 +1027,7 @@ mod tests {
 
         start_command_operation_with_spawner(
             request(11, "echo duplicate"),
+            operation_guard(),
             writer,
             Arc::new(AtomicBool::new(false)),
             registry,
@@ -1027,6 +1050,7 @@ mod tests {
 
         start_command_operation_with_spawner(
             request(43, "sleep 60"),
+            operation_guard(),
             writer,
             Arc::new(AtomicBool::new(false)),
             registry.clone(),
@@ -1052,6 +1076,7 @@ mod tests {
 
         start_command_operation_with_spawner(
             request(45, "sleep 60"),
+            operation_guard(),
             writer,
             Arc::new(AtomicBool::new(false)),
             registry.clone(),
@@ -1082,6 +1107,7 @@ mod tests {
 
         start_command_operation_with_spawner(
             request,
+            operation_guard(),
             writer,
             Arc::new(AtomicBool::new(false)),
             registry.clone(),

--- a/crates/vsock-guest/src/command.rs
+++ b/crates/vsock-guest/src/command.rs
@@ -250,8 +250,7 @@ where
                 "ERROR",
                 &format!("command: worker spawn failed seq={seq}: {e}"),
             );
-            operation_guard.release();
-            send_command_result(
+            send_command_result_after_lock(
                 CommandResultFrame {
                     seq,
                     termination: CommandTermination::StartFailed,
@@ -261,6 +260,7 @@ where
                     diagnostic: &diagnostic,
                 },
                 &writer,
+                || operation_guard.release(),
             )
         }
     }
@@ -777,15 +777,21 @@ fn send_final_and_complete(
     writer: &GuestWriter,
     operation_guard: &OperationGuard,
 ) {
-    operation_guard.release();
-    let result = send_command_result(frame, writer);
+    let result = send_command_result_after_lock(frame, writer, || operation_guard.release());
     registration.complete();
     if let Err(e) = result {
         log("ERROR", &format!("Failed to send command_result: {e}"));
     }
 }
 
-fn send_command_result(frame: CommandResultFrame<'_>, writer: &GuestWriter) -> io::Result<()> {
+fn send_command_result_after_lock<F>(
+    frame: CommandResultFrame<'_>,
+    writer: &GuestWriter,
+    after_lock: F,
+) -> io::Result<()>
+where
+    F: FnOnce(),
+{
     let payload = vsock_proto::encode_command_result(
         frame.termination,
         frame.duration_ms,
@@ -796,7 +802,7 @@ fn send_command_result(frame: CommandResultFrame<'_>, writer: &GuestWriter) -> i
     .map_err(to_io_error)?;
     let encoded =
         vsock_proto::encode(MSG_COMMAND_RESULT, frame.seq, &payload).map_err(to_io_error)?;
-    writer.write_frame(&encoded)
+    writer.write_frame_after_lock(&encoded, after_lock)
 }
 
 fn captured_output(result: &BoundedDrainResult) -> CommandCapturedOutput<'_> {

--- a/crates/vsock-guest/src/connection.rs
+++ b/crates/vsock-guest/src/connection.rs
@@ -299,8 +299,9 @@ fn handle_connection_with_outcome(stream: UnixStream) -> io::Result<ConnectionEn
                     continue;
                 };
                 let response = handle_decoded_write_file_message(msg.seq, decoded)?;
-                operation_guard.release();
-                let result = writer.write_frame(&response);
+                let result = writer.write_frame_after_lock(&response, || {
+                    operation_guard.release();
+                });
                 result?;
             } else if msg.msg_type == MSG_QUIESCE_OPERATIONS {
                 handle_quiesce_operations(msg.seq, &msg.payload, &operation_state, &writer)?;

--- a/crates/vsock-guest/src/connection.rs
+++ b/crates/vsock-guest/src/connection.rs
@@ -5,16 +5,22 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::thread;
 use std::time::Duration;
 
-use vsock_proto::{self, MSG_COMMAND_CANCEL, MSG_COMMAND_START, MSG_READY, MSG_SPAWN_WATCH};
+use vsock_proto::{
+    self, MSG_COMMAND_CANCEL, MSG_COMMAND_START, MSG_OPERATIONS_QUIESCED, MSG_OPERATIONS_RESUMED,
+    MSG_QUIESCE_OPERATIONS, MSG_READY, MSG_RESUME_OPERATIONS, MSG_SPAWN_WATCH, MSG_WRITE_FILE,
+};
 
 use crate::command::{
     CommandRegistry, CommandWorkerRequest, cancel_command_operation, send_command_error,
     start_command_operation,
 };
 use crate::error::to_io_error;
-use crate::handlers::{MessageOutcome, handle_message};
+use crate::handlers::{
+    MessageOutcome, decode_write_file_message, handle_decoded_write_file_message, handle_message,
+};
 use crate::log::log;
 use crate::monitor::{SpawnWatchRequest, handle_spawn_watch};
+use crate::quiesce::{AcquireOperationError, OperationGuard, OperationState, QuiesceResult};
 use crate::writer::GuestWriter;
 
 // Vsock constants (only used on Linux)
@@ -38,6 +44,97 @@ impl Drop for ConnectionCancelGuard {
     fn drop(&mut self) {
         self.0.store(true, Ordering::Release);
     }
+}
+
+fn acquire_operation_guard(
+    operation_state: &OperationState,
+    seq: u32,
+    writer: &GuestWriter,
+) -> io::Result<Option<OperationGuard>> {
+    match operation_state.acquire() {
+        Ok(guard) => Ok(Some(guard)),
+        Err(AcquireOperationError::Quiescing) => {
+            send_command_error(seq, "guest operations are quiescing", writer)?;
+            Ok(None)
+        }
+    }
+}
+
+fn reject_operation_if_quiescing(
+    operation_state: &OperationState,
+    seq: u32,
+    writer: &GuestWriter,
+) -> io::Result<bool> {
+    if operation_state.is_quiescing() {
+        send_command_error(seq, "guest operations are quiescing", writer)?;
+        Ok(true)
+    } else {
+        Ok(false)
+    }
+}
+
+fn send_empty_response(msg_type: u8, seq: u32, writer: &GuestWriter) -> io::Result<()> {
+    let response = vsock_proto::encode(msg_type, seq, &[]).map_err(to_io_error)?;
+    writer.write_frame(&response)
+}
+
+fn validate_empty_control_payload(
+    seq: u32,
+    payload_name: &'static str,
+    payload: &[u8],
+    writer: &GuestWriter,
+) -> io::Result<bool> {
+    match vsock_proto::decode_empty_payload(payload_name, payload) {
+        Ok(()) => Ok(true),
+        Err(error) => {
+            send_command_error(seq, &error.to_string(), writer)?;
+            Ok(false)
+        }
+    }
+}
+
+fn handle_quiesce_operations(
+    seq: u32,
+    payload: &[u8],
+    operation_state: &OperationState,
+    writer: &GuestWriter,
+) -> io::Result<()> {
+    if !validate_empty_control_payload(
+        seq,
+        "quiesce_operations payload must be empty",
+        payload,
+        writer,
+    )? {
+        return Ok(());
+    }
+
+    match operation_state.enter_quiescing() {
+        QuiesceResult::Quiesced => send_empty_response(MSG_OPERATIONS_QUIESCED, seq, writer),
+        QuiesceResult::Busy { pending } => send_command_error(
+            seq,
+            &format!("guest operations still pending: {pending}"),
+            writer,
+        ),
+    }
+}
+
+fn handle_resume_operations(
+    seq: u32,
+    payload: &[u8],
+    operation_state: &OperationState,
+    writer: &GuestWriter,
+) -> io::Result<()> {
+    if !validate_empty_control_payload(
+        seq,
+        "resume_operations payload must be empty",
+        payload,
+        writer,
+    )? {
+        return Ok(());
+    }
+
+    operation_state.resume();
+    send_empty_response(MSG_OPERATIONS_RESUMED, seq, writer)
 }
 
 /// Connect to vsock (Linux only - this binary runs inside Firecracker VM)
@@ -107,6 +204,7 @@ fn handle_connection_with_outcome(stream: UnixStream) -> io::Result<ConnectionEn
     let connection_cancel = Arc::new(AtomicBool::new(false));
     let _cancel_on_drop = ConnectionCancelGuard(connection_cancel.clone());
     let command_registry = CommandRegistry::default();
+    let operation_state = OperationState::default();
 
     let mut decoder = vsock_proto::Decoder::new();
 
@@ -139,10 +237,19 @@ fn handle_connection_with_outcome(stream: UnixStream) -> io::Result<ConnectionEn
                     send_command_error(0, "command start requires non-zero sequence", &writer)?;
                     continue;
                 }
+                if reject_operation_if_quiescing(&operation_state, msg.seq, &writer)? {
+                    continue;
+                }
                 let decoded =
                     vsock_proto::decode_command_start(&msg.payload).map_err(to_io_error)?;
+                let Some(operation_guard) =
+                    acquire_operation_guard(&operation_state, msg.seq, &writer)?
+                else {
+                    continue;
+                };
                 start_command_operation(
                     CommandWorkerRequest::from_decoded(msg.seq, decoded),
+                    operation_guard,
                     writer.clone(),
                     connection_cancel.clone(),
                     command_registry.clone(),
@@ -155,7 +262,15 @@ fn handle_connection_with_outcome(stream: UnixStream) -> io::Result<ConnectionEn
                 vsock_proto::decode_command_cancel(&msg.payload).map_err(to_io_error)?;
                 cancel_command_operation(&command_registry, msg.seq);
             } else if msg.msg_type == MSG_SPAWN_WATCH {
+                if reject_operation_if_quiescing(&operation_state, msg.seq, &writer)? {
+                    continue;
+                }
                 let d = vsock_proto::decode_spawn_watch(&msg.payload).map_err(to_io_error)?;
+                let Some(operation_guard) =
+                    acquire_operation_guard(&operation_state, msg.seq, &writer)?
+                else {
+                    continue;
+                };
                 // handle_spawn_watch writes the response itself (before
                 // spawning the streaming thread) to prevent a race where
                 // stdout chunks could arrive at the host before the result.
@@ -169,9 +284,28 @@ fn handle_connection_with_outcome(stream: UnixStream) -> io::Result<ConnectionEn
                         stdout_log_path: d.stdout_log_path,
                     },
                     msg.seq,
+                    operation_guard,
                     writer.clone(),
                     connection_cancel.clone(),
                 )?;
+            } else if msg.msg_type == MSG_WRITE_FILE {
+                if reject_operation_if_quiescing(&operation_state, msg.seq, &writer)? {
+                    continue;
+                }
+                let decoded = decode_write_file_message(&msg)?;
+                let Some(operation_guard) =
+                    acquire_operation_guard(&operation_state, msg.seq, &writer)?
+                else {
+                    continue;
+                };
+                let response = handle_decoded_write_file_message(msg.seq, decoded)?;
+                operation_guard.release();
+                let result = writer.write_frame(&response);
+                result?;
+            } else if msg.msg_type == MSG_QUIESCE_OPERATIONS {
+                handle_quiesce_operations(msg.seq, &msg.payload, &operation_state, &writer)?;
+            } else if msg.msg_type == MSG_RESUME_OPERATIONS {
+                handle_resume_operations(msg.seq, &msg.payload, &operation_state, &writer)?;
             } else {
                 match handle_message(&msg)? {
                     MessageOutcome::Response(response) => {

--- a/crates/vsock-guest/src/handlers.rs
+++ b/crates/vsock-guest/src/handlers.rs
@@ -7,8 +7,7 @@ use std::sync::Mutex;
 use std::sync::atomic::AtomicBool;
 
 use vsock_proto::{
-    self, MSG_ERROR, MSG_PING, MSG_PONG, MSG_SHUTDOWN, MSG_WRITE_FILE, MSG_WRITE_FILE_RESULT,
-    RawMessage,
+    self, MSG_ERROR, MSG_PING, MSG_PONG, MSG_SHUTDOWN, MSG_WRITE_FILE_RESULT, RawMessage,
 };
 
 use crate::drain::drain_into_vec_cancellable;
@@ -31,6 +30,13 @@ static DEBUG_GUEST_WRITE_FILE_PATH: Mutex<Option<PathBuf>> = Mutex::new(None);
 pub(crate) enum MessageOutcome {
     Response(Vec<u8>),
     Shutdown(Vec<u8>),
+}
+
+pub(crate) struct DecodedWriteFileMessage<'a> {
+    path: &'a str,
+    content: &'a [u8],
+    use_sudo: bool,
+    append: bool,
 }
 
 /// Handle write_file message
@@ -215,10 +221,37 @@ pub(crate) fn set_debug_guest_write_file_path(path: PathBuf) -> Result<(), PathB
     Ok(())
 }
 
+pub(crate) fn decode_write_file_message(
+    msg: &RawMessage,
+) -> io::Result<DecodedWriteFileMessage<'_>> {
+    let (path, content, use_sudo, append) =
+        vsock_proto::decode_write_file(&msg.payload).map_err(to_io_error)?;
+    Ok(DecodedWriteFileMessage {
+        path,
+        content,
+        use_sudo,
+        append,
+    })
+}
+
+pub(crate) fn handle_decoded_write_file_message(
+    seq: u32,
+    decoded: DecodedWriteFileMessage<'_>,
+) -> io::Result<Vec<u8>> {
+    let (success, error) = handle_write_file(
+        decoded.path,
+        decoded.content,
+        decoded.use_sudo,
+        decoded.append,
+    );
+    let payload = vsock_proto::encode_write_file_result(success, &error);
+    vsock_proto::encode(MSG_WRITE_FILE_RESULT, seq, &payload).map_err(to_io_error)
+}
+
 /// Handle incoming message and return the connection-loop outcome.
 ///
-/// Command operation and `MSG_SPAWN_WATCH` are handled separately in
-/// `handle_connection` because they run in background threads.
+/// Command operation, `MSG_SPAWN_WATCH`, and guarded write-file operations are
+/// handled separately in `handle_connection`.
 pub(crate) fn handle_message(msg: &RawMessage) -> io::Result<MessageOutcome> {
     log(
         "INFO",
@@ -229,16 +262,6 @@ pub(crate) fn handle_message(msg: &RawMessage) -> io::Result<MessageOutcome> {
         MSG_PING => Ok(MessageOutcome::Response(
             vsock_proto::encode(MSG_PONG, msg.seq, &[]).map_err(to_io_error)?,
         )),
-        MSG_WRITE_FILE => {
-            let (path, content, use_sudo, append) =
-                vsock_proto::decode_write_file(&msg.payload).map_err(to_io_error)?;
-            let (success, error) = handle_write_file(path, content, use_sudo, append);
-            let payload = vsock_proto::encode_write_file_result(success, &error);
-            Ok(MessageOutcome::Response(
-                vsock_proto::encode(MSG_WRITE_FILE_RESULT, msg.seq, &payload)
-                    .map_err(to_io_error)?,
-            ))
-        }
         MSG_SHUTDOWN => Ok(MessageOutcome::Shutdown(handle_shutdown(msg.seq)?)),
         _ => {
             let payload =

--- a/crates/vsock-guest/src/lib.rs
+++ b/crates/vsock-guest/src/lib.rs
@@ -15,6 +15,7 @@ mod handlers;
 mod log;
 mod monitor;
 mod process;
+mod quiesce;
 mod shutdown;
 mod threading;
 mod user;

--- a/crates/vsock-guest/src/monitor.rs
+++ b/crates/vsock-guest/src/monitor.rs
@@ -130,8 +130,9 @@ where
                 format_env_diagnostics(request.command, request.env)
             ));
             let response = vsock_proto::encode(MSG_ERROR, seq, &payload).map_err(to_io_error)?;
-            operation_guard.release();
-            let result = writer.write_frame(&response);
+            let result = writer.write_frame_after_lock(&response, || {
+                operation_guard.release();
+            });
             result?;
             return Ok(());
         }
@@ -282,14 +283,14 @@ where
         }),
     );
     if let Err(e) = &result {
-        operation_guard.release();
-        send_process_exit(
+        send_process_exit_after_lock(
             seq,
             pid,
             1,
             &[],
             format!("Failed to spawn streaming monitor thread: {e}").as_bytes(),
             &exit_writer,
+            || operation_guard.release(),
         );
     }
     result.map(|_| ())
@@ -482,8 +483,9 @@ where
         ),
     );
 
-    operation_guard.release();
-    send_process_exit(seq, pid, exit_code, &[], &stderr, &writer);
+    send_process_exit_after_lock(seq, pid, exit_code, &[], &stderr, &writer, || {
+        operation_guard.release();
+    });
 }
 
 fn finish_streaming_setup_failure(failure: StreamingSetupFailure) {
@@ -510,8 +512,9 @@ fn finish_streaming_setup_failure(failure: StreamingSetupFailure) {
     if let Some(handle) = stdout_handle {
         let _ = handle.join();
     }
-    operation_guard.release();
-    send_process_exit(seq, pid, 1, &[], error.as_bytes(), &writer);
+    send_process_exit_after_lock(seq, pid, 1, &[], error.as_bytes(), &writer, || {
+        operation_guard.release();
+    });
 }
 
 /// Buffered monitor: waits for process exit while concurrently draining
@@ -564,34 +567,37 @@ where
                 ),
             );
 
-            monitor_operation_guard.release();
-            send_process_exit(seq, pid, exit_code, &stdout, &stderr, &writer);
+            send_process_exit_after_lock(seq, pid, exit_code, &stdout, &stderr, &writer, || {
+                monitor_operation_guard.release();
+            });
             drop(env_script);
         }),
     );
     if let Err(e) = &result {
-        operation_guard.release();
-        send_process_exit(
+        send_process_exit_after_lock(
             seq,
             pid,
             1,
             &[],
             format!("Failed to spawn buffered monitor thread: {e}").as_bytes(),
             &exit_writer,
+            || operation_guard.release(),
         );
     }
     result.map(|_| ())
 }
 
-/// Send a process_exit notification over vsock (best-effort).
-fn send_process_exit(
+fn send_process_exit_after_lock<F>(
     seq: u32,
     pid: u32,
     exit_code: i32,
     stdout: &[u8],
     stderr: &[u8],
     writer: &GuestWriter,
-) {
+    after_lock: F,
+) where
+    F: FnOnce(),
+{
     let payload = vsock_proto::encode_process_exit(pid, exit_code, stdout, stderr);
     let exit_msg = match vsock_proto::encode(MSG_PROCESS_EXIT, seq, &payload) {
         Ok(msg) => msg,
@@ -600,7 +606,7 @@ fn send_process_exit(
             return;
         }
     };
-    if let Err(e) = writer.write_frame(&exit_msg) {
+    if let Err(e) = writer.write_frame_after_lock(&exit_msg, after_lock) {
         log("ERROR", &format!("Failed to send process_exit: {}", e));
     }
 }

--- a/crates/vsock-guest/src/monitor.rs
+++ b/crates/vsock-guest/src/monitor.rs
@@ -11,6 +11,7 @@ use crate::error::to_io_error;
 use crate::exec::{EnvScriptGuard, format_env_diagnostics, spawn_with_pipes, truncate_preview};
 use crate::log::log;
 use crate::process::{ChildReapGuard, kill_and_reap_child};
+use crate::quiesce::OperationGuard;
 use crate::threading::{SystemThreadSpawner, ThreadSpawner};
 use crate::wait::{
     DRAIN_DEADLINE_SECS, await_drain_deadline, finalize_buffered_result, finalize_wait_outcome,
@@ -33,6 +34,7 @@ struct StreamingMonitorRequest {
     env_script: Option<EnvScriptGuard>,
     writer: GuestWriter,
     connection_cancel: Arc<AtomicBool>,
+    operation_guard: OperationGuard,
 }
 
 struct BufferedMonitorRequest {
@@ -43,6 +45,7 @@ struct BufferedMonitorRequest {
     env_script: Option<EnvScriptGuard>,
     writer: GuestWriter,
     connection_cancel: Arc<AtomicBool>,
+    operation_guard: OperationGuard,
 }
 
 struct StreamingSetupFailure {
@@ -55,6 +58,7 @@ struct StreamingSetupFailure {
     stdout_handle: Option<JoinHandle<()>>,
     env_script: Option<EnvScriptGuard>,
     writer: GuestWriter,
+    operation_guard: OperationGuard,
     error: String,
 }
 
@@ -81,15 +85,24 @@ pub(crate) struct SpawnWatchRequest<'a> {
 pub(crate) fn handle_spawn_watch(
     request: SpawnWatchRequest<'_>,
     seq: u32,
+    operation_guard: OperationGuard,
     writer: GuestWriter,
     connection_cancel: Arc<AtomicBool>,
 ) -> io::Result<()> {
-    handle_spawn_watch_with_spawner(request, seq, writer, connection_cancel, SystemThreadSpawner)
+    handle_spawn_watch_with_spawner(
+        request,
+        seq,
+        operation_guard,
+        writer,
+        connection_cancel,
+        SystemThreadSpawner,
+    )
 }
 
 fn handle_spawn_watch_with_spawner<S>(
     request: SpawnWatchRequest<'_>,
     seq: u32,
+    operation_guard: OperationGuard,
     writer: GuestWriter,
     connection_cancel: Arc<AtomicBool>,
     spawner: S,
@@ -117,7 +130,9 @@ where
                 format_env_diagnostics(request.command, request.env)
             ));
             let response = vsock_proto::encode(MSG_ERROR, seq, &payload).map_err(to_io_error)?;
-            writer.write_frame(&response)?;
+            operation_guard.release();
+            let result = writer.write_frame(&response);
+            result?;
             return Ok(());
         }
     };
@@ -143,11 +158,13 @@ where
         Ok(r) => r,
         Err(e) => {
             kill_and_reap_child(child);
+            operation_guard.release();
             return Err(to_io_error(e));
         }
     };
     if let Err(e) = writer.write_frame(&response) {
         kill_and_reap_child(child);
+        operation_guard.release();
         return Err(e);
     }
 
@@ -166,6 +183,7 @@ where
                 env_script,
                 writer,
                 connection_cancel,
+                operation_guard: operation_guard.clone(),
             },
             spawner,
         ) {
@@ -186,6 +204,7 @@ where
                 env_script,
                 writer,
                 connection_cancel,
+                operation_guard: operation_guard.clone(),
             },
             spawner,
         ) {
@@ -229,10 +248,12 @@ where
         env_script,
         writer,
         connection_cancel,
+        operation_guard,
     } = request;
     let child_guard = ChildReapGuard::new(child);
     let monitor_spawner = spawner.clone();
     let exit_writer = writer.clone();
+    let monitor_operation_guard = operation_guard.clone();
     let result = spawner.spawn_unit(
         THREAD_STREAM_MONITOR,
         Box::new(move || {
@@ -254,12 +275,14 @@ where
                     env_script,
                     writer,
                     connection_cancel,
+                    operation_guard: monitor_operation_guard,
                 },
                 monitor_spawner,
             );
         }),
     );
     if let Err(e) = &result {
+        operation_guard.release();
         send_process_exit(
             seq,
             pid,
@@ -286,6 +309,7 @@ where
         env_script,
         writer,
         connection_cancel,
+        operation_guard,
     } = request;
     let _env_script = env_script;
     let cancel = Arc::new(AtomicBool::new(false));
@@ -321,6 +345,7 @@ where
                     stdout_handle: None,
                     env_script: _env_script,
                     writer,
+                    operation_guard: operation_guard.clone(),
                     error: format!("Failed to spawn stderr drain thread: {e}"),
                 });
                 return;
@@ -402,6 +427,7 @@ where
                     stdout_handle: None,
                     env_script: _env_script,
                     writer,
+                    operation_guard: operation_guard.clone(),
                     error: format!("Failed to spawn stdout drain thread: {e}"),
                 });
                 return;
@@ -456,6 +482,7 @@ where
         ),
     );
 
+    operation_guard.release();
     send_process_exit(seq, pid, exit_code, &[], &stderr, &writer);
 }
 
@@ -470,6 +497,7 @@ fn finish_streaming_setup_failure(failure: StreamingSetupFailure) {
         stdout_handle,
         env_script,
         writer,
+        operation_guard,
         error,
     } = failure;
     let _env_script = env_script;
@@ -482,6 +510,7 @@ fn finish_streaming_setup_failure(failure: StreamingSetupFailure) {
     if let Some(handle) = stdout_handle {
         let _ = handle.join();
     }
+    operation_guard.release();
     send_process_exit(seq, pid, 1, &[], error.as_bytes(), &writer);
 }
 
@@ -499,10 +528,12 @@ where
         env_script,
         writer,
         connection_cancel,
+        operation_guard,
     } = request;
     let child_guard = ChildReapGuard::new(child);
     let exit_writer = writer.clone();
     let monitor_spawner = spawner.clone();
+    let monitor_operation_guard = operation_guard.clone();
     let result = spawner.spawn_unit(
         THREAD_BUFFERED_MONITOR,
         Box::new(move || {
@@ -533,11 +564,13 @@ where
                 ),
             );
 
+            monitor_operation_guard.release();
             send_process_exit(seq, pid, exit_code, &stdout, &stderr, &writer);
             drop(env_script);
         }),
     );
     if let Err(e) = &result {
+        operation_guard.release();
         send_process_exit(
             seq,
             pid,
@@ -602,6 +635,10 @@ mod tests {
         messages.remove(0)
     }
 
+    fn operation_guard() -> OperationGuard {
+        crate::quiesce::OperationState::default().acquire().unwrap()
+    }
+
     #[test]
     fn spawn_watch_outer_monitor_spawn_failure_reports_process_exit_and_reaps_child() {
         let (guest, mut host) = UnixStream::pair().unwrap();
@@ -619,6 +656,7 @@ mod tests {
                 stdout_log_path: None,
             },
             7,
+            operation_guard(),
             writer,
             cancel,
             FailingThreadSpawner::fail_once(THREAD_STREAM_MONITOR),
@@ -663,6 +701,7 @@ mod tests {
                 stdout_log_path: None,
             },
             8,
+            operation_guard(),
             writer,
             cancel,
             FailingThreadSpawner::fail_once(THREAD_STREAM_STDOUT),
@@ -707,6 +746,7 @@ mod tests {
                 stdout_log_path: None,
             },
             10,
+            operation_guard(),
             writer,
             cancel,
             FailingThreadSpawner::fail_once(THREAD_STREAM_STDERR),
@@ -751,6 +791,7 @@ mod tests {
                 stdout_log_path: None,
             },
             9,
+            operation_guard(),
             writer,
             cancel,
             FailingThreadSpawner::fail_once(THREAD_BUFFERED_MONITOR),
@@ -795,6 +836,7 @@ mod tests {
                 stdout_log_path: None,
             },
             11,
+            operation_guard(),
             writer,
             cancel,
             FailingThreadSpawner::fail_once(THREAD_DRAIN_STDOUT),

--- a/crates/vsock-guest/src/quiesce.rs
+++ b/crates/vsock-guest/src/quiesce.rs
@@ -1,0 +1,173 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+
+#[derive(Clone, Default)]
+pub(crate) struct OperationState {
+    inner: Arc<Mutex<Inner>>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Mode {
+    Open,
+    Quiescing,
+}
+
+struct Inner {
+    mode: Mode,
+    pending: usize,
+}
+
+impl Default for Inner {
+    fn default() -> Self {
+        Self {
+            mode: Mode::Open,
+            pending: 0,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum AcquireOperationError {
+    Quiescing,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum QuiesceResult {
+    Quiesced,
+    Busy { pending: usize },
+}
+
+#[derive(Clone)]
+pub(crate) struct OperationGuard {
+    inner: Arc<OperationGuardInner>,
+}
+
+struct OperationGuardInner {
+    state: OperationState,
+    released: AtomicBool,
+}
+
+impl OperationState {
+    pub(crate) fn acquire(&self) -> Result<OperationGuard, AcquireOperationError> {
+        let mut inner = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        if inner.mode == Mode::Quiescing {
+            return Err(AcquireOperationError::Quiescing);
+        }
+        inner.pending += 1;
+        Ok(OperationGuard {
+            inner: Arc::new(OperationGuardInner {
+                state: self.clone(),
+                released: AtomicBool::new(false),
+            }),
+        })
+    }
+
+    pub(crate) fn enter_quiescing(&self) -> QuiesceResult {
+        let mut inner = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        inner.mode = Mode::Quiescing;
+        if inner.pending == 0 {
+            QuiesceResult::Quiesced
+        } else {
+            QuiesceResult::Busy {
+                pending: inner.pending,
+            }
+        }
+    }
+
+    pub(crate) fn resume(&self) {
+        self.inner.lock().unwrap_or_else(|e| e.into_inner()).mode = Mode::Open;
+    }
+
+    pub(crate) fn is_quiescing(&self) -> bool {
+        self.inner.lock().unwrap_or_else(|e| e.into_inner()).mode == Mode::Quiescing
+    }
+
+    fn release_one(&self) {
+        let mut inner = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        inner.pending = inner.pending.saturating_sub(1);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn pending(&self) -> usize {
+        self.inner.lock().unwrap_or_else(|e| e.into_inner()).pending
+    }
+}
+
+impl OperationGuard {
+    pub(crate) fn release(&self) {
+        if !self.inner.released.swap(true, Ordering::AcqRel) {
+            self.inner.state.release_one();
+        }
+    }
+}
+
+impl Drop for OperationGuardInner {
+    fn drop(&mut self) {
+        if !self.released.swap(true, Ordering::AcqRel) {
+            self.state.release_one();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn acquire_counts_one_operation_until_last_guard_clone_drops() {
+        let state = OperationState::default();
+        let guard = state.acquire().unwrap();
+        let clone = guard.clone();
+
+        assert_eq!(state.pending(), 1);
+        drop(guard);
+        assert_eq!(state.pending(), 1);
+        drop(clone);
+        assert_eq!(state.pending(), 0);
+    }
+
+    #[test]
+    fn explicit_release_drops_pending_before_guard_clones_drop() {
+        let state = OperationState::default();
+        let guard = state.acquire().unwrap();
+        let clone = guard.clone();
+
+        guard.release();
+
+        assert_eq!(state.pending(), 0);
+        drop(guard);
+        drop(clone);
+        assert_eq!(state.pending(), 0);
+    }
+
+    #[test]
+    fn quiesce_fences_new_operations_even_when_busy() {
+        let state = OperationState::default();
+        let guard = state.acquire().unwrap();
+
+        assert_eq!(state.enter_quiescing(), QuiesceResult::Busy { pending: 1 });
+        assert!(matches!(
+            state.acquire(),
+            Err(AcquireOperationError::Quiescing)
+        ));
+
+        drop(guard);
+        assert_eq!(state.pending(), 0);
+    }
+
+    #[test]
+    fn resume_allows_operations_after_quiesce() {
+        let state = OperationState::default();
+
+        assert_eq!(state.enter_quiescing(), QuiesceResult::Quiesced);
+        assert!(matches!(
+            state.acquire(),
+            Err(AcquireOperationError::Quiescing)
+        ));
+        state.resume();
+
+        let guard = state.acquire().unwrap();
+        assert_eq!(state.pending(), 1);
+        drop(guard);
+    }
+}

--- a/crates/vsock-guest/src/writer.rs
+++ b/crates/vsock-guest/src/writer.rs
@@ -29,7 +29,33 @@ impl GuestWriter {
     }
 
     fn write_frame_with_deadline(&self, frame: &[u8], deadline: Duration) -> io::Result<()> {
+        self.write_frame_with_deadline_after_lock(frame, deadline, || {})
+    }
+
+    /// Run `after_lock` while holding the writer mutex, immediately before
+    /// sending `frame`.
+    ///
+    /// Guarded operations use this to mark themselves complete at the point
+    /// where no later lifecycle response can overtake their terminal frame on
+    /// the shared connection.
+    pub(crate) fn write_frame_after_lock<F>(&self, frame: &[u8], after_lock: F) -> io::Result<()>
+    where
+        F: FnOnce(),
+    {
+        self.write_frame_with_deadline_after_lock(frame, WRITE_DEADLINE, after_lock)
+    }
+
+    fn write_frame_with_deadline_after_lock<F>(
+        &self,
+        frame: &[u8],
+        deadline: Duration,
+        after_lock: F,
+    ) -> io::Result<()>
+    where
+        F: FnOnce(),
+    {
         let stream = self.stream.lock().unwrap_or_else(|e| e.into_inner());
+        after_lock();
         let result = send_frame(stream.as_raw_fd(), frame, deadline);
         if result.is_err() {
             // The protocol has no resync marker. After a timeout or partial
@@ -217,6 +243,42 @@ mod tests {
         drop(writer);
 
         assert_eq!(reader.join().unwrap(), expected);
+    }
+
+    #[test]
+    fn write_frame_after_lock_runs_hook_before_frame_and_blocks_other_writers() {
+        let (guest, mut peer) = UnixStream::pair().unwrap();
+        let writer = GuestWriter::new(guest);
+        let writer_a = writer.clone();
+        let writer_b = writer.clone();
+        let (entered_tx, entered_rx) = std::sync::mpsc::channel();
+        let (release_tx, release_rx) = std::sync::mpsc::channel();
+        let (second_ready_tx, second_ready_rx) = std::sync::mpsc::channel();
+
+        let first = std::thread::spawn(move || {
+            writer_a
+                .write_frame_after_lock(b"first", || {
+                    entered_tx.send(()).unwrap();
+                    release_rx.recv().unwrap();
+                })
+                .unwrap();
+        });
+        entered_rx.recv().unwrap();
+
+        let second = std::thread::spawn(move || {
+            second_ready_tx.send(()).unwrap();
+            writer_b.write_frame(b"second").unwrap();
+        });
+
+        second_ready_rx.recv().unwrap();
+        release_tx.send(()).unwrap();
+        first.join().unwrap();
+        second.join().unwrap();
+        drop(writer);
+
+        let mut received = Vec::new();
+        peer.read_to_end(&mut received).unwrap();
+        assert_eq!(received, b"firstsecond");
     }
 
     #[test]

--- a/crates/vsock-guest/tests/connection.rs
+++ b/crates/vsock-guest/tests/connection.rs
@@ -299,6 +299,11 @@ fn send_empty_control(stream: &mut impl std::io::Write, msg_type: u8, seq: u32) 
     stream.write_all(&msg).unwrap();
 }
 
+fn send_control_payload(stream: &mut impl std::io::Write, msg_type: u8, seq: u32, payload: &[u8]) {
+    let msg = vsock_proto::encode(msg_type, seq, payload).unwrap();
+    stream.write_all(&msg).unwrap();
+}
+
 fn send_quiesce_operations(stream: &mut impl std::io::Write, seq: u32) {
     send_empty_control(stream, MSG_QUIESCE_OPERATIONS, seq);
 }
@@ -1291,6 +1296,125 @@ fn resume_operations_is_idempotent() {
         CommandTermination::Exited { exit_code: 0 }
     );
     assert_eq!(result.stdout, Some(b"open".to_vec()));
+
+    finish_guest_connection(handle, host_stream);
+}
+
+#[test]
+fn malformed_quiesce_resume_payloads_do_not_change_state() {
+    let (handle, mut host_stream) = start_guest_connection();
+
+    send_control_payload(&mut host_stream, MSG_QUIESCE_OPERATIONS, 223, b"unexpected");
+    let quiesce_error = read_message(&mut host_stream);
+    assert_eq!(quiesce_error.msg_type, MSG_ERROR);
+    assert_eq!(quiesce_error.seq, 223);
+    assert!(
+        vsock_proto::decode_error(&quiesce_error.payload)
+            .unwrap()
+            .contains("quiesce_operations payload must be empty")
+    );
+
+    send_command_start(
+        &mut host_stream,
+        224,
+        "printf open",
+        5000,
+        CommandOutputPolicy::Capture { limit_bytes: 64 },
+        CommandOutputPolicy::Discard,
+    );
+    let (_chunks, open_result) = read_command_result(&mut host_stream, 224);
+    assert_eq!(
+        open_result.termination,
+        CommandTermination::Exited { exit_code: 0 }
+    );
+    assert_eq!(open_result.stdout, Some(b"open".to_vec()));
+
+    send_quiesce_operations(&mut host_stream, 225);
+    let quiesced = read_message(&mut host_stream);
+    assert_eq!(quiesced.msg_type, MSG_OPERATIONS_QUIESCED);
+    assert_eq!(quiesced.seq, 225);
+
+    send_control_payload(&mut host_stream, MSG_RESUME_OPERATIONS, 226, b"unexpected");
+    let resume_error = read_message(&mut host_stream);
+    assert_eq!(resume_error.msg_type, MSG_ERROR);
+    assert_eq!(resume_error.seq, 226);
+    assert!(
+        vsock_proto::decode_error(&resume_error.payload)
+            .unwrap()
+            .contains("resume_operations payload must be empty")
+    );
+
+    send_command_start(
+        &mut host_stream,
+        227,
+        "printf should-not-run",
+        5000,
+        CommandOutputPolicy::Capture { limit_bytes: 64 },
+        CommandOutputPolicy::Discard,
+    );
+    let fenced = read_message(&mut host_stream);
+    assert_eq!(fenced.msg_type, MSG_ERROR);
+    assert_eq!(fenced.seq, 227);
+    assert!(
+        vsock_proto::decode_error(&fenced.payload)
+            .unwrap()
+            .contains("guest operations are quiescing")
+    );
+
+    send_resume_operations(&mut host_stream, 228);
+    let resumed = read_message(&mut host_stream);
+    assert_eq!(resumed.msg_type, MSG_OPERATIONS_RESUMED);
+    assert_eq!(resumed.seq, 228);
+
+    finish_guest_connection(handle, host_stream);
+}
+
+#[test]
+fn resume_operations_reopens_after_busy_quiesce_with_pending_operation() {
+    let (handle, mut host_stream) = start_guest_connection();
+
+    send_command_start(
+        &mut host_stream,
+        241,
+        "sleep 60",
+        0,
+        CommandOutputPolicy::Capture { limit_bytes: 64 },
+        CommandOutputPolicy::Discard,
+    );
+
+    send_quiesce_operations(&mut host_stream, 242);
+    let busy = read_message(&mut host_stream);
+    assert_eq!(busy.msg_type, MSG_ERROR);
+    assert_eq!(busy.seq, 242);
+    assert!(
+        vsock_proto::decode_error(&busy.payload)
+            .unwrap()
+            .contains("guest operations still pending: 1")
+    );
+
+    send_resume_operations(&mut host_stream, 243);
+    let resumed = read_message(&mut host_stream);
+    assert_eq!(resumed.msg_type, MSG_OPERATIONS_RESUMED);
+    assert_eq!(resumed.seq, 243);
+
+    send_command_start(
+        &mut host_stream,
+        244,
+        "printf reopened",
+        5000,
+        CommandOutputPolicy::Capture { limit_bytes: 64 },
+        CommandOutputPolicy::Discard,
+    );
+    let (_chunks, reopened) = read_command_result(&mut host_stream, 244);
+    assert_eq!(
+        reopened.termination,
+        CommandTermination::Exited { exit_code: 0 }
+    );
+    assert_eq!(reopened.stdout, Some(b"reopened".to_vec()));
+
+    send_command_cancel(&mut host_stream, 241);
+    let (_chunks, cancelled) = read_command_result(&mut host_stream, 241);
+    assert_eq!(cancelled.termination, CommandTermination::Cancelled);
 
     finish_guest_connection(handle, host_stream);
 }

--- a/crates/vsock-guest/tests/connection.rs
+++ b/crates/vsock-guest/tests/connection.rs
@@ -13,8 +13,9 @@ use vsock_guest::{handle_connection, run};
 use vsock_proto::{
     self, CommandCapturedOutput, CommandOutputPolicy, CommandOutputStream, CommandTermination,
     MSG_COMMAND_CANCEL, MSG_COMMAND_OUTPUT, MSG_COMMAND_RESULT, MSG_COMMAND_START, MSG_ERROR,
-    MSG_PROCESS_EXIT, MSG_SHUTDOWN, MSG_SHUTDOWN_ACK, MSG_SPAWN_WATCH, MSG_SPAWN_WATCH_RESULT,
-    MSG_STDOUT_CHUNK,
+    MSG_OPERATIONS_QUIESCED, MSG_OPERATIONS_RESUMED, MSG_PROCESS_EXIT, MSG_QUIESCE_OPERATIONS,
+    MSG_RESUME_OPERATIONS, MSG_SHUTDOWN, MSG_SHUTDOWN_ACK, MSG_SPAWN_WATCH, MSG_SPAWN_WATCH_RESULT,
+    MSG_STDOUT_CHUNK, MSG_WRITE_FILE,
 };
 
 const EXIT_CODE_TIMEOUT: i32 = 124;
@@ -291,6 +292,19 @@ fn send_command_cancel(stream: &mut impl std::io::Write, seq: u32) {
     let payload = vsock_proto::encode_command_cancel();
     let msg = vsock_proto::encode(MSG_COMMAND_CANCEL, seq, &payload).unwrap();
     stream.write_all(&msg).unwrap();
+}
+
+fn send_empty_control(stream: &mut impl std::io::Write, msg_type: u8, seq: u32) {
+    let msg = vsock_proto::encode(msg_type, seq, &[]).unwrap();
+    stream.write_all(&msg).unwrap();
+}
+
+fn send_quiesce_operations(stream: &mut impl std::io::Write, seq: u32) {
+    send_empty_control(stream, MSG_QUIESCE_OPERATIONS, seq);
+}
+
+fn send_resume_operations(stream: &mut impl std::io::Write, seq: u32) {
+    send_empty_control(stream, MSG_RESUME_OPERATIONS, seq);
 }
 
 fn read_command_result(
@@ -1109,6 +1123,178 @@ fn command_seq_zero_start_and_cancel_return_error() {
     finish_guest_connection(handle, host_stream);
 }
 
+#[test]
+fn quiesce_busy_fences_new_commands_until_pending_command_finishes() {
+    let (handle, mut host_stream) = start_guest_connection();
+
+    send_command_start(
+        &mut host_stream,
+        201,
+        "sleep 60",
+        0,
+        CommandOutputPolicy::Capture { limit_bytes: 64 },
+        CommandOutputPolicy::Discard,
+    );
+
+    send_quiesce_operations(&mut host_stream, 202);
+    let busy = read_message(&mut host_stream);
+    assert_eq!(busy.msg_type, MSG_ERROR);
+    assert_eq!(busy.seq, 202);
+    assert!(
+        vsock_proto::decode_error(&busy.payload)
+            .unwrap()
+            .contains("guest operations still pending: 1")
+    );
+
+    send_command_start(
+        &mut host_stream,
+        203,
+        "printf should-not-run",
+        5000,
+        CommandOutputPolicy::Capture { limit_bytes: 64 },
+        CommandOutputPolicy::Discard,
+    );
+    let fenced = read_message(&mut host_stream);
+    assert_eq!(fenced.msg_type, MSG_ERROR);
+    assert_eq!(fenced.seq, 203);
+    assert!(
+        vsock_proto::decode_error(&fenced.payload)
+            .unwrap()
+            .contains("guest operations are quiescing")
+    );
+
+    send_command_cancel(&mut host_stream, 201);
+    let (_chunks, cancelled) = read_command_result(&mut host_stream, 201);
+    assert_eq!(cancelled.termination, CommandTermination::Cancelled);
+
+    send_quiesce_operations(&mut host_stream, 204);
+    let quiesced = read_message(&mut host_stream);
+    assert_eq!(quiesced.msg_type, MSG_OPERATIONS_QUIESCED);
+    assert_eq!(quiesced.seq, 204);
+    assert!(quiesced.payload.is_empty());
+
+    send_resume_operations(&mut host_stream, 205);
+    let resumed = read_message(&mut host_stream);
+    assert_eq!(resumed.msg_type, MSG_OPERATIONS_RESUMED);
+    assert_eq!(resumed.seq, 205);
+    assert!(resumed.payload.is_empty());
+
+    send_command_start(
+        &mut host_stream,
+        206,
+        "printf ok",
+        5000,
+        CommandOutputPolicy::Capture { limit_bytes: 64 },
+        CommandOutputPolicy::Discard,
+    );
+    let (_chunks, result) = read_command_result(&mut host_stream, 206);
+    assert_eq!(
+        result.termination,
+        CommandTermination::Exited { exit_code: 0 }
+    );
+    assert_eq!(result.stdout, Some(b"ok".to_vec()));
+
+    finish_guest_connection(handle, host_stream);
+}
+
+#[test]
+fn quiesced_connection_rejects_write_file_without_creating_file() {
+    let (handle, mut host_stream) = start_guest_connection();
+    let path = unique_tmp_path("quiesce-write-file", ".txt");
+
+    send_quiesce_operations(&mut host_stream, 211);
+    let quiesced = read_message(&mut host_stream);
+    assert_eq!(quiesced.msg_type, MSG_OPERATIONS_QUIESCED);
+
+    let payload = vsock_proto::encode_write_file(path.as_str(), b"blocked", false, false).unwrap();
+    let msg = vsock_proto::encode(MSG_WRITE_FILE, 212, &payload).unwrap();
+    host_stream.write_all(&msg).unwrap();
+
+    let fenced = read_message(&mut host_stream);
+    assert_eq!(fenced.msg_type, MSG_ERROR);
+    assert_eq!(fenced.seq, 212);
+    assert!(
+        vsock_proto::decode_error(&fenced.payload)
+            .unwrap()
+            .contains("guest operations are quiescing")
+    );
+    assert!(!std::path::Path::new(path.as_str()).exists());
+
+    send_resume_operations(&mut host_stream, 213);
+    let resumed = read_message(&mut host_stream);
+    assert_eq!(resumed.msg_type, MSG_OPERATIONS_RESUMED);
+
+    finish_guest_connection(handle, host_stream);
+}
+
+#[test]
+fn quiesced_connection_rejects_new_operation_without_decoding_payload() {
+    let (handle, mut host_stream) = start_guest_connection();
+
+    send_quiesce_operations(&mut host_stream, 216);
+    let quiesced = read_message(&mut host_stream);
+    assert_eq!(quiesced.msg_type, MSG_OPERATIONS_QUIESCED);
+
+    let malformed_start = vsock_proto::encode(MSG_COMMAND_START, 217, b"malformed").unwrap();
+    host_stream.write_all(&malformed_start).unwrap();
+    let fenced = read_message(&mut host_stream);
+    assert_eq!(fenced.msg_type, MSG_ERROR);
+    assert_eq!(fenced.seq, 217);
+    assert!(
+        vsock_proto::decode_error(&fenced.payload)
+            .unwrap()
+            .contains("guest operations are quiescing")
+    );
+
+    send_resume_operations(&mut host_stream, 218);
+    let resumed = read_message(&mut host_stream);
+    assert_eq!(resumed.msg_type, MSG_OPERATIONS_RESUMED);
+
+    send_command_start(
+        &mut host_stream,
+        219,
+        "printf ok",
+        5000,
+        CommandOutputPolicy::Capture { limit_bytes: 64 },
+        CommandOutputPolicy::Discard,
+    );
+    let (_chunks, result) = read_command_result(&mut host_stream, 219);
+    assert_eq!(
+        result.termination,
+        CommandTermination::Exited { exit_code: 0 }
+    );
+    assert_eq!(result.stdout, Some(b"ok".to_vec()));
+
+    finish_guest_connection(handle, host_stream);
+}
+
+#[test]
+fn resume_operations_is_idempotent() {
+    let (handle, mut host_stream) = start_guest_connection();
+
+    send_resume_operations(&mut host_stream, 221);
+    let resumed = read_message(&mut host_stream);
+    assert_eq!(resumed.msg_type, MSG_OPERATIONS_RESUMED);
+    assert_eq!(resumed.seq, 221);
+
+    send_command_start(
+        &mut host_stream,
+        222,
+        "printf open",
+        5000,
+        CommandOutputPolicy::Capture { limit_bytes: 64 },
+        CommandOutputPolicy::Discard,
+    );
+    let (_chunks, result) = read_command_result(&mut host_stream, 222);
+    assert_eq!(
+        result.termination,
+        CommandTermination::Exited { exit_code: 0 }
+    );
+    assert_eq!(result.stdout, Some(b"open".to_vec()));
+
+    finish_guest_connection(handle, host_stream);
+}
+
 /// Like `Read::read`, but retries on EINTR. `read_exact` retries
 /// internally; bare `read()` does not, and llvm-cov / profilers
 /// occasionally send signals that surface as EINTR on blocking reads.
@@ -1604,6 +1790,43 @@ fn read_spawn_watch_pid(stream: &mut impl std::io::Read, seq: u32) -> u32 {
             }
         }
     }
+}
+
+#[test]
+fn spawn_watch_remains_pending_after_spawn_result_until_process_exit() {
+    let (handle, mut host_stream) = start_guest_connection();
+
+    send_spawn_watch_buffered(&mut host_stream, 231, "sleep 60", 0);
+    let pid = read_spawn_watch_pid(&mut host_stream, 231);
+
+    send_quiesce_operations(&mut host_stream, 232);
+    let busy = read_message(&mut host_stream);
+    assert_eq!(busy.msg_type, MSG_ERROR);
+    assert_eq!(busy.seq, 232);
+    assert!(
+        vsock_proto::decode_error(&busy.payload)
+            .unwrap()
+            .contains("guest operations still pending: 1")
+    );
+
+    kill_pid_group(pid);
+    let exit = read_message(&mut host_stream);
+    assert_eq!(exit.msg_type, MSG_PROCESS_EXIT);
+    assert_eq!(exit.seq, 231);
+    let (exit_pid, _code, _stdout, _stderr) =
+        vsock_proto::decode_process_exit(&exit.payload).unwrap();
+    assert_eq!(exit_pid, pid);
+
+    send_quiesce_operations(&mut host_stream, 233);
+    let quiesced = read_message(&mut host_stream);
+    assert_eq!(quiesced.msg_type, MSG_OPERATIONS_QUIESCED);
+    assert_eq!(quiesced.seq, 233);
+
+    send_resume_operations(&mut host_stream, 234);
+    let resumed = read_message(&mut host_stream);
+    assert_eq!(resumed.msg_type, MSG_OPERATIONS_RESUMED);
+
+    finish_guest_connection(handle, host_stream);
 }
 
 fn read_pid_file(path: &str) -> u32 {

--- a/crates/vsock-guest/tests/connection.rs
+++ b/crates/vsock-guest/tests/connection.rs
@@ -1301,13 +1301,52 @@ fn resume_operations_is_idempotent() {
 }
 
 #[test]
+fn quiesce_operations_is_idempotent_while_quiesced() {
+    let (handle, mut host_stream) = start_guest_connection();
+
+    send_quiesce_operations(&mut host_stream, 223);
+    let first = read_message(&mut host_stream);
+    assert_eq!(first.msg_type, MSG_OPERATIONS_QUIESCED);
+    assert_eq!(first.seq, 223);
+
+    send_quiesce_operations(&mut host_stream, 224);
+    let second = read_message(&mut host_stream);
+    assert_eq!(second.msg_type, MSG_OPERATIONS_QUIESCED);
+    assert_eq!(second.seq, 224);
+
+    send_command_start(
+        &mut host_stream,
+        225,
+        "printf should-not-run",
+        5000,
+        CommandOutputPolicy::Capture { limit_bytes: 64 },
+        CommandOutputPolicy::Discard,
+    );
+    let fenced = read_message(&mut host_stream);
+    assert_eq!(fenced.msg_type, MSG_ERROR);
+    assert_eq!(fenced.seq, 225);
+    assert!(
+        vsock_proto::decode_error(&fenced.payload)
+            .unwrap()
+            .contains("guest operations are quiescing")
+    );
+
+    send_resume_operations(&mut host_stream, 226);
+    let resumed = read_message(&mut host_stream);
+    assert_eq!(resumed.msg_type, MSG_OPERATIONS_RESUMED);
+    assert_eq!(resumed.seq, 226);
+
+    finish_guest_connection(handle, host_stream);
+}
+
+#[test]
 fn malformed_quiesce_resume_payloads_do_not_change_state() {
     let (handle, mut host_stream) = start_guest_connection();
 
-    send_control_payload(&mut host_stream, MSG_QUIESCE_OPERATIONS, 223, b"unexpected");
+    send_control_payload(&mut host_stream, MSG_QUIESCE_OPERATIONS, 227, b"unexpected");
     let quiesce_error = read_message(&mut host_stream);
     assert_eq!(quiesce_error.msg_type, MSG_ERROR);
-    assert_eq!(quiesce_error.seq, 223);
+    assert_eq!(quiesce_error.seq, 227);
     assert!(
         vsock_proto::decode_error(&quiesce_error.payload)
             .unwrap()
@@ -1316,28 +1355,28 @@ fn malformed_quiesce_resume_payloads_do_not_change_state() {
 
     send_command_start(
         &mut host_stream,
-        224,
+        228,
         "printf open",
         5000,
         CommandOutputPolicy::Capture { limit_bytes: 64 },
         CommandOutputPolicy::Discard,
     );
-    let (_chunks, open_result) = read_command_result(&mut host_stream, 224);
+    let (_chunks, open_result) = read_command_result(&mut host_stream, 228);
     assert_eq!(
         open_result.termination,
         CommandTermination::Exited { exit_code: 0 }
     );
     assert_eq!(open_result.stdout, Some(b"open".to_vec()));
 
-    send_quiesce_operations(&mut host_stream, 225);
+    send_quiesce_operations(&mut host_stream, 229);
     let quiesced = read_message(&mut host_stream);
     assert_eq!(quiesced.msg_type, MSG_OPERATIONS_QUIESCED);
-    assert_eq!(quiesced.seq, 225);
+    assert_eq!(quiesced.seq, 229);
 
-    send_control_payload(&mut host_stream, MSG_RESUME_OPERATIONS, 226, b"unexpected");
+    send_control_payload(&mut host_stream, MSG_RESUME_OPERATIONS, 230, b"unexpected");
     let resume_error = read_message(&mut host_stream);
     assert_eq!(resume_error.msg_type, MSG_ERROR);
-    assert_eq!(resume_error.seq, 226);
+    assert_eq!(resume_error.seq, 230);
     assert!(
         vsock_proto::decode_error(&resume_error.payload)
             .unwrap()
@@ -1346,7 +1385,7 @@ fn malformed_quiesce_resume_payloads_do_not_change_state() {
 
     send_command_start(
         &mut host_stream,
-        227,
+        231,
         "printf should-not-run",
         5000,
         CommandOutputPolicy::Capture { limit_bytes: 64 },
@@ -1354,17 +1393,17 @@ fn malformed_quiesce_resume_payloads_do_not_change_state() {
     );
     let fenced = read_message(&mut host_stream);
     assert_eq!(fenced.msg_type, MSG_ERROR);
-    assert_eq!(fenced.seq, 227);
+    assert_eq!(fenced.seq, 231);
     assert!(
         vsock_proto::decode_error(&fenced.payload)
             .unwrap()
             .contains("guest operations are quiescing")
     );
 
-    send_resume_operations(&mut host_stream, 228);
+    send_resume_operations(&mut host_stream, 232);
     let resumed = read_message(&mut host_stream);
     assert_eq!(resumed.msg_type, MSG_OPERATIONS_RESUMED);
-    assert_eq!(resumed.seq, 228);
+    assert_eq!(resumed.seq, 232);
 
     finish_guest_connection(handle, host_stream);
 }

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -38,8 +38,9 @@ use tokio::task::JoinHandle;
 use tokio::time::{self, Instant};
 
 use vsock_proto::{
-    Decoder, MSG_COMMAND_OUTPUT, MSG_COMMAND_RESULT, MSG_ERROR, MSG_PING, MSG_PONG,
-    MSG_PROCESS_EXIT, MSG_READY, MSG_SHUTDOWN, MSG_SHUTDOWN_ACK, MSG_SPAWN_WATCH_RESULT,
+    Decoder, MSG_COMMAND_OUTPUT, MSG_COMMAND_RESULT, MSG_ERROR, MSG_OPERATIONS_QUIESCED,
+    MSG_OPERATIONS_RESUMED, MSG_PING, MSG_PONG, MSG_PROCESS_EXIT, MSG_QUIESCE_OPERATIONS,
+    MSG_READY, MSG_RESUME_OPERATIONS, MSG_SHUTDOWN, MSG_SHUTDOWN_ACK, MSG_SPAWN_WATCH_RESULT,
     MSG_STDOUT_CHUNK, RawMessage,
 };
 
@@ -408,6 +409,25 @@ async fn request_raw_on_shared(
     }
 }
 
+fn protocol_invalid_data(error: impl ToString) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, error.to_string())
+}
+
+fn lifecycle_error_from_response(response: &RawMessage) -> io::Error {
+    match vsock_proto::decode_error(&response.payload) {
+        Ok(message) => io::Error::other(message.to_owned()),
+        Err(error) => protocol_invalid_data(error),
+    }
+}
+
+fn validate_empty_lifecycle_response(
+    response: &RawMessage,
+    payload_name: &'static str,
+) -> io::Result<()> {
+    vsock_proto::decode_empty_payload(payload_name, &response.payload)
+        .map_err(protocol_invalid_data)
+}
+
 impl VsockHost {
     /// Wait for a guest to connect on the vsock UDS path.
     ///
@@ -552,6 +572,52 @@ impl VsockHost {
         timeout: Duration,
     ) -> io::Result<RawMessage> {
         request_on_shared(&self.shared, msg_type, payload, timeout).await
+    }
+
+    async fn lifecycle_request(
+        &self,
+        request_type: u8,
+        expected_response_type: u8,
+        response_payload_name: &'static str,
+        timeout: Duration,
+    ) -> io::Result<()> {
+        let response = self.request(request_type, &[], timeout).await?;
+        if response.msg_type == MSG_ERROR {
+            return Err(lifecycle_error_from_response(&response));
+        }
+        if response.msg_type != expected_response_type {
+            return Err(protocol_invalid_data(format!(
+                "unexpected lifecycle response type: expected 0x{expected_response_type:02X}, got 0x{:02X}",
+                response.msg_type,
+            )));
+        }
+        validate_empty_lifecycle_response(&response, response_payload_name)
+    }
+
+    /// Fence new guest operations before a higher-level lifecycle transition.
+    ///
+    /// This is a same-connection lifecycle check: the guest either reports no
+    /// in-flight operations with `operations_quiesced`, or returns `error` and keeps
+    /// the operation fence closed until [`resume_operations`](Self::resume_operations).
+    pub async fn quiesce_operations(&self, timeout: Duration) -> io::Result<()> {
+        self.lifecycle_request(
+            MSG_QUIESCE_OPERATIONS,
+            MSG_OPERATIONS_QUIESCED,
+            "operations_quiesced payload must be empty",
+            timeout,
+        )
+        .await
+    }
+
+    /// Resume guest operations after a failed or aborted quiesce attempt.
+    pub async fn resume_operations(&self, timeout: Duration) -> io::Result<()> {
+        self.lifecycle_request(
+            MSG_RESUME_OPERATIONS,
+            MSG_OPERATIONS_RESUMED,
+            "operations_resumed payload must be empty",
+            timeout,
+        )
+        .await
     }
 
     /// Start a request-scoped command operation using the unified command protocol.

--- a/crates/vsock-host/src/tests/connection.rs
+++ b/crates/vsock-host/src/tests/connection.rs
@@ -221,10 +221,7 @@ async fn quiesce_operations_times_out_and_late_ack_is_ignored() {
     });
 
     let host = host_from_stream(host_stream).await.unwrap();
-    let err = host
-        .quiesce_operations(Duration::from_millis(10))
-        .await
-        .unwrap_err();
+    let err = host.quiesce_operations(Duration::ZERO).await.unwrap_err();
     assert_eq!(err.kind(), io::ErrorKind::TimedOut);
 
     send_late_ack.send(()).unwrap();

--- a/crates/vsock-host/src/tests/connection.rs
+++ b/crates/vsock-host/src/tests/connection.rs
@@ -198,6 +198,7 @@ async fn quiesce_operations_rejects_non_empty_ack_payload() {
 #[tokio::test]
 async fn quiesce_operations_times_out_and_late_ack_is_ignored() {
     let (host_stream, mut guest) = make_pair();
+    let (send_late_ack, receive_late_ack) = tokio::sync::oneshot::channel();
 
     tokio::spawn(async move {
         let mut decoder = Decoder::new();
@@ -208,7 +209,7 @@ async fn quiesce_operations_times_out_and_late_ack_is_ignored() {
         let msgs = decoder.decode(&buf[..n]).unwrap();
         assert_eq!(msgs[0].msg_type, MSG_QUIESCE_OPERATIONS);
 
-        tokio::time::sleep(Duration::from_millis(50)).await;
+        receive_late_ack.await.unwrap();
         let late = vsock_proto::encode(MSG_OPERATIONS_QUIESCED, msgs[0].seq, &[]).unwrap();
         guest.write_all(&late).await.unwrap();
 
@@ -226,6 +227,7 @@ async fn quiesce_operations_times_out_and_late_ack_is_ignored() {
         .unwrap_err();
     assert_eq!(err.kind(), io::ErrorKind::TimedOut);
 
+    send_late_ack.send(()).unwrap();
     host.resume_operations(Duration::from_secs(2))
         .await
         .unwrap();

--- a/crates/vsock-host/src/tests/connection.rs
+++ b/crates/vsock-host/src/tests/connection.rs
@@ -3,7 +3,11 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
-use vsock_proto::{CommandTermination, Decoder, MSG_COMMAND_START, MSG_SHUTDOWN, MSG_SHUTDOWN_ACK};
+use vsock_proto::{
+    CommandTermination, Decoder, MSG_COMMAND_START, MSG_ERROR, MSG_OPERATIONS_QUIESCED,
+    MSG_OPERATIONS_RESUMED, MSG_QUIESCE_OPERATIONS, MSG_RESUME_OPERATIONS, MSG_SHUTDOWN,
+    MSG_SHUTDOWN_ACK,
+};
 
 use super::support::{host_from_stream, make_pair, mock_handshake, send_command_result};
 use crate::VsockHost;
@@ -60,6 +64,171 @@ async fn test_shutdown() {
 
     let host = host_from_stream(host_stream).await.unwrap();
     assert!(host.shutdown(Duration::from_secs(2)).await);
+}
+
+#[tokio::test]
+async fn quiesce_operations_sends_request_and_accepts_empty_ack() {
+    let (host_stream, mut guest) = make_pair();
+
+    tokio::spawn(async move {
+        let mut decoder = Decoder::new();
+        mock_handshake(&mut guest, &mut decoder).await;
+
+        let mut buf = [0u8; 4096];
+        let n = guest.read(&mut buf).await.unwrap();
+        let msgs = decoder.decode(&buf[..n]).unwrap();
+        assert_eq!(msgs[0].msg_type, MSG_QUIESCE_OPERATIONS);
+        assert!(msgs[0].payload.is_empty());
+
+        let resp = vsock_proto::encode(MSG_OPERATIONS_QUIESCED, msgs[0].seq, &[]).unwrap();
+        guest.write_all(&resp).await.unwrap();
+    });
+
+    let host = host_from_stream(host_stream).await.unwrap();
+    host.quiesce_operations(Duration::from_secs(2))
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn resume_operations_sends_request_and_accepts_empty_ack() {
+    let (host_stream, mut guest) = make_pair();
+
+    tokio::spawn(async move {
+        let mut decoder = Decoder::new();
+        mock_handshake(&mut guest, &mut decoder).await;
+
+        let mut buf = [0u8; 4096];
+        let n = guest.read(&mut buf).await.unwrap();
+        let msgs = decoder.decode(&buf[..n]).unwrap();
+        assert_eq!(msgs[0].msg_type, MSG_RESUME_OPERATIONS);
+        assert!(msgs[0].payload.is_empty());
+
+        let resp = vsock_proto::encode(MSG_OPERATIONS_RESUMED, msgs[0].seq, &[]).unwrap();
+        guest.write_all(&resp).await.unwrap();
+    });
+
+    let host = host_from_stream(host_stream).await.unwrap();
+    host.resume_operations(Duration::from_secs(2))
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn quiesce_operations_surfaces_guest_error() {
+    let (host_stream, mut guest) = make_pair();
+
+    tokio::spawn(async move {
+        let mut decoder = Decoder::new();
+        mock_handshake(&mut guest, &mut decoder).await;
+
+        let mut buf = [0u8; 4096];
+        let n = guest.read(&mut buf).await.unwrap();
+        let msgs = decoder.decode(&buf[..n]).unwrap();
+        assert_eq!(msgs[0].msg_type, MSG_QUIESCE_OPERATIONS);
+
+        let payload = vsock_proto::encode_error("guest operations still pending: 1");
+        let resp = vsock_proto::encode(MSG_ERROR, msgs[0].seq, &payload).unwrap();
+        guest.write_all(&resp).await.unwrap();
+    });
+
+    let host = host_from_stream(host_stream).await.unwrap();
+    let err = host
+        .quiesce_operations(Duration::from_secs(2))
+        .await
+        .unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::Other);
+    assert_eq!(err.to_string(), "guest operations still pending: 1");
+}
+
+#[tokio::test]
+async fn quiesce_operations_rejects_wrong_ack_type() {
+    let (host_stream, mut guest) = make_pair();
+
+    tokio::spawn(async move {
+        let mut decoder = Decoder::new();
+        mock_handshake(&mut guest, &mut decoder).await;
+
+        let mut buf = [0u8; 4096];
+        let n = guest.read(&mut buf).await.unwrap();
+        let msgs = decoder.decode(&buf[..n]).unwrap();
+        let resp = vsock_proto::encode(MSG_OPERATIONS_RESUMED, msgs[0].seq, &[]).unwrap();
+        guest.write_all(&resp).await.unwrap();
+    });
+
+    let host = host_from_stream(host_stream).await.unwrap();
+    let err = host
+        .quiesce_operations(Duration::from_secs(2))
+        .await
+        .unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    assert!(
+        err.to_string()
+            .contains("unexpected lifecycle response type")
+    );
+}
+
+#[tokio::test]
+async fn quiesce_operations_rejects_non_empty_ack_payload() {
+    let (host_stream, mut guest) = make_pair();
+
+    tokio::spawn(async move {
+        let mut decoder = Decoder::new();
+        mock_handshake(&mut guest, &mut decoder).await;
+
+        let mut buf = [0u8; 4096];
+        let n = guest.read(&mut buf).await.unwrap();
+        let msgs = decoder.decode(&buf[..n]).unwrap();
+        let resp = vsock_proto::encode(MSG_OPERATIONS_QUIESCED, msgs[0].seq, b"x").unwrap();
+        guest.write_all(&resp).await.unwrap();
+    });
+
+    let host = host_from_stream(host_stream).await.unwrap();
+    let err = host
+        .quiesce_operations(Duration::from_secs(2))
+        .await
+        .unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    assert!(
+        err.to_string()
+            .contains("operations_quiesced payload must be empty")
+    );
+}
+
+#[tokio::test]
+async fn quiesce_operations_times_out_and_late_ack_is_ignored() {
+    let (host_stream, mut guest) = make_pair();
+
+    tokio::spawn(async move {
+        let mut decoder = Decoder::new();
+        mock_handshake(&mut guest, &mut decoder).await;
+
+        let mut buf = [0u8; 4096];
+        let n = guest.read(&mut buf).await.unwrap();
+        let msgs = decoder.decode(&buf[..n]).unwrap();
+        assert_eq!(msgs[0].msg_type, MSG_QUIESCE_OPERATIONS);
+
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        let late = vsock_proto::encode(MSG_OPERATIONS_QUIESCED, msgs[0].seq, &[]).unwrap();
+        guest.write_all(&late).await.unwrap();
+
+        let n = guest.read(&mut buf).await.unwrap();
+        let msgs = decoder.decode(&buf[..n]).unwrap();
+        assert_eq!(msgs[0].msg_type, MSG_RESUME_OPERATIONS);
+        let resp = vsock_proto::encode(MSG_OPERATIONS_RESUMED, msgs[0].seq, &[]).unwrap();
+        guest.write_all(&resp).await.unwrap();
+    });
+
+    let host = host_from_stream(host_stream).await.unwrap();
+    let err = host
+        .quiesce_operations(Duration::from_millis(10))
+        .await
+        .unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::TimedOut);
+
+    host.resume_operations(Duration::from_secs(2))
+        .await
+        .unwrap();
 }
 
 #[tokio::test]

--- a/crates/vsock-proto/src/lib.rs
+++ b/crates/vsock-proto/src/lib.rs
@@ -32,6 +32,10 @@
 //! | 0x0C | G→H       | command_output    | `[1B stream][4B output_seq][1B flags][4B chunk_len][chunk]` |
 //! | 0x0D | G→H       | command_result    | `[1B termination]...[4B duration_ms][stdout][stderr][2B diagnostic_len][diagnostic]` |
 //! | 0x0E | H→G       | command_cancel    | (empty) |
+//! | 0x0F | H→G       | quiesce_operations  | (empty) |
+//! | 0x10 | G→H       | operations_quiesced    | (empty) |
+//! | 0x11 | H→G       | resume_operations | (empty) |
+//! | 0x12 | G→H       | operations_resumed | (empty) |
 //! | 0xFF | G→H       | error             | `[2B error_len][error]` |
 //!
 //! Command operation messages are request-scoped; host/guest dispatch layers
@@ -56,6 +60,7 @@ pub use payloads::command::{
     encode_command_cancel, encode_command_output, encode_command_result, encode_command_start,
     encode_command_start_with_expected_exit_codes,
 };
+pub use payloads::empty::decode_empty_payload;
 pub use payloads::error::{decode_error, encode_error};
 pub use payloads::process::{
     ProcessExit, decode_process_exit, decode_stdout_chunk, encode_process_exit, encode_stdout_chunk,
@@ -70,8 +75,10 @@ pub use payloads::write_file::{
 pub use wire::{
     COMMAND_CAPTURED_OUTPUT_FLAG_TRUNCATED, COMMAND_FLAG_SUDO, COMMAND_OUTPUT_FLAG_TRUNCATED,
     HEADER_SIZE, MAX_MESSAGE_SIZE, MIN_BODY_SIZE, MSG_COMMAND_CANCEL, MSG_COMMAND_OUTPUT,
-    MSG_COMMAND_RESULT, MSG_COMMAND_START, MSG_ERROR, MSG_PING, MSG_PONG, MSG_PROCESS_EXIT,
-    MSG_READY, MSG_SHUTDOWN, MSG_SHUTDOWN_ACK, MSG_SPAWN_WATCH, MSG_SPAWN_WATCH_RESULT,
-    MSG_STDOUT_CHUNK, MSG_WRITE_FILE, MSG_WRITE_FILE_RESULT, SPAWN_WATCH_FLAG_STREAM_STDOUT,
-    SPAWN_WATCH_FLAG_SUDO, VSOCK_PORT, WRITE_FILE_FLAG_APPEND, WRITE_FILE_FLAG_SUDO,
+    MSG_COMMAND_RESULT, MSG_COMMAND_START, MSG_ERROR, MSG_OPERATIONS_QUIESCED,
+    MSG_OPERATIONS_RESUMED, MSG_PING, MSG_PONG, MSG_PROCESS_EXIT, MSG_QUIESCE_OPERATIONS,
+    MSG_READY, MSG_RESUME_OPERATIONS, MSG_SHUTDOWN, MSG_SHUTDOWN_ACK, MSG_SPAWN_WATCH,
+    MSG_SPAWN_WATCH_RESULT, MSG_STDOUT_CHUNK, MSG_WRITE_FILE, MSG_WRITE_FILE_RESULT,
+    SPAWN_WATCH_FLAG_STREAM_STDOUT, SPAWN_WATCH_FLAG_SUDO, VSOCK_PORT, WRITE_FILE_FLAG_APPEND,
+    WRITE_FILE_FLAG_SUDO,
 };

--- a/crates/vsock-proto/src/payloads/empty.rs
+++ b/crates/vsock-proto/src/payloads/empty.rs
@@ -1,0 +1,29 @@
+use crate::error::ProtocolError;
+
+/// Decode an empty control-plane payload.
+pub fn decode_empty_payload(
+    payload_name: &'static str,
+    payload: &[u8],
+) -> Result<(), ProtocolError> {
+    if payload.is_empty() {
+        Ok(())
+    } else {
+        Err(ProtocolError::InvalidPayload(payload_name))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_payload_accepts_empty_slice() {
+        decode_empty_payload("test must be empty", &[]).unwrap();
+    }
+
+    #[test]
+    fn empty_payload_rejects_non_empty_slice() {
+        let err = decode_empty_payload("test must be empty", b"x").unwrap_err();
+        assert_eq!(err.to_string(), "invalid payload: test must be empty");
+    }
+}

--- a/crates/vsock-proto/src/payloads/mod.rs
+++ b/crates/vsock-proto/src/payloads/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod command;
+pub(crate) mod empty;
 pub(crate) mod error;
 pub(crate) mod process;
 pub(crate) mod spawn_watch;

--- a/crates/vsock-proto/src/wire.rs
+++ b/crates/vsock-proto/src/wire.rs
@@ -23,6 +23,10 @@ pub const MSG_COMMAND_START: u8 = 0x0B;
 pub const MSG_COMMAND_OUTPUT: u8 = 0x0C;
 pub const MSG_COMMAND_RESULT: u8 = 0x0D;
 pub const MSG_COMMAND_CANCEL: u8 = 0x0E;
+pub const MSG_QUIESCE_OPERATIONS: u8 = 0x0F;
+pub const MSG_OPERATIONS_QUIESCED: u8 = 0x10;
+pub const MSG_RESUME_OPERATIONS: u8 = 0x11;
+pub const MSG_OPERATIONS_RESUMED: u8 = 0x12;
 pub const MSG_ERROR: u8 = 0xFF;
 
 /// Default vsock port for host-guest communication.


### PR DESCRIPTION
## Summary
- add empty lifecycle control payloads and vsock quiesce/resume operation messages
- add host quiesce_operations/resume_operations APIs and guest operation fencing for command, spawn-watch, and write-file
- cover busy quiesce, resume, malformed fenced operations, and spawn-watch pending lifetime in tests

## Verification
- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `cargo check --manifest-path crates/Cargo.toml -p vsock-proto -p vsock-host -p vsock-guest`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-proto -p vsock-host -p vsock-guest`
- `git diff --check`

Closes #13276