### PR TITLE
feat(api): support Stripe CLI auth modes

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-cli-auth-stripe.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-cli-auth-stripe.test.ts
@@ -108,10 +108,13 @@ function startOutput(
 }
 
 function stripeConfig(apiKey: string) {
+  const keyName = apiKey.includes("_live_")
+    ? "live_mode_api_key"
+    : "test_mode_api_key";
   return `[default]
 account_id = "acct_test"
 display_name = "Test Account"
-test_mode_api_key = "${apiKey}"
+${keyName} = "${apiKey}"
 test_mode_pub_key = "pk_test_123"
 `;
 }
@@ -317,12 +320,50 @@ describe("CLI auth for Stripe connector routes", () => {
     const response = await accept(
       client().start({
         headers: { authorization: "Bearer clerk-session" },
-        body: {},
+        body: { mode: "invalid" } as never,
       }),
       [403],
     );
 
     expect(response.body.error.code).toBe("FORBIDDEN");
+    expect(calls.create).toHaveLength(0);
+  });
+
+  it("rejects missing mode before creating a session or sandbox", async () => {
+    const { userId, orgId } = await setupUser();
+    const calls = mockStripeCliSandbox();
+
+    const response = await accept(
+      client().start({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {} as never,
+      }),
+      [400],
+    );
+
+    expect(response.body.error.code).toBe("BAD_REQUEST");
+    await expect(cliAuthStripeSessions(userId, orgId)).resolves.toStrictEqual(
+      [],
+    );
+    expect(calls.create).toHaveLength(0);
+  });
+
+  it("rejects invalid mode before creating a session or sandbox", async () => {
+    const { userId, orgId } = await setupUser();
+    const calls = mockStripeCliSandbox();
+
+    const response = await accept(
+      client().start({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { mode: "invalid" } as never,
+      }),
+      [400],
+    );
+
+    expect(response.body.error.code).toBe("BAD_REQUEST");
+    await expect(cliAuthStripeSessions(userId, orgId)).resolves.toStrictEqual(
+      [],
+    );
     expect(calls.create).toHaveLength(0);
   });
 
@@ -333,7 +374,7 @@ describe("CLI auth for Stripe connector routes", () => {
     const response = await accept(
       client().start({
         headers: { authorization: "Bearer clerk-session" },
-        body: {},
+        body: { mode: "test" },
       }),
       [200],
     );
@@ -341,6 +382,7 @@ describe("CLI auth for Stripe connector routes", () => {
     expect(response.body).toMatchObject({
       type: "stripe",
       status: "pending",
+      mode: "test",
       browserUrl:
         "https://dashboard.stripe.com/stripecli/confirm_auth?t=start-token",
       verificationCode: "enjoy-enough-outwit-win",
@@ -391,7 +433,7 @@ describe("CLI auth for Stripe connector routes", () => {
     const response = await accept(
       client().start({
         headers: { authorization: "Bearer clerk-session" },
-        body: {},
+        body: { mode: "test" },
       }),
       [503],
     );
@@ -420,7 +462,7 @@ describe("CLI auth for Stripe connector routes", () => {
     const response = await accept(
       client().start({
         headers: { authorization: "Bearer clerk-session" },
-        body: {},
+        body: { mode: "test" },
       }),
       [503],
     );
@@ -448,7 +490,7 @@ describe("CLI auth for Stripe connector routes", () => {
     await expect(
       client().start({
         headers: { authorization: "Bearer clerk-session" },
-        body: {},
+        body: { mode: "test" },
       }),
     ).rejects.toThrow();
 
@@ -471,7 +513,7 @@ describe("CLI auth for Stripe connector routes", () => {
     const response = await accept(
       client().start({
         headers: { authorization: "Bearer clerk-session" },
-        body: {},
+        body: { mode: "test" },
       }),
       [503],
     );
@@ -502,7 +544,7 @@ describe("CLI auth for Stripe connector routes", () => {
     const start = await accept(
       client().start({
         headers: { authorization: "Bearer clerk-session" },
-        body: {},
+        body: { mode: "test" },
       }),
       [200],
     );
@@ -549,7 +591,7 @@ describe("CLI auth for Stripe connector routes", () => {
         ),
       );
     expect(secret).toMatchObject({
-      description: "Stripe CLI test mode restricted key",
+      description: "Stripe CLI test mode API key",
       type: "user",
     });
     expect(decryptSecretValue(secret!.encryptedValue)).toBe("rk_test_imported");
@@ -594,7 +636,7 @@ describe("CLI auth for Stripe connector routes", () => {
     const start = await accept(
       client().start({
         headers: { authorization: "Bearer clerk-session" },
-        body: {},
+        body: { mode: "test" },
       }),
       [200],
     );
@@ -648,14 +690,14 @@ describe("CLI auth for Stripe connector routes", () => {
     expect(decryptSecretValue(secret!.encryptedValue)).toBe("sk_test_imported");
   });
 
-  it("rejects live mode Stripe keys and stops the sandbox", async () => {
+  it("rejects live mode Stripe keys for a test-mode session and stops the sandbox", async () => {
     const { userId, orgId } = await setupUser();
     const calls = mockStripeCliSandbox({ configApiKey: "rk_live_imported" });
 
     const start = await accept(
       client().start({
         headers: { authorization: "Bearer clerk-session" },
-        body: {},
+        body: { mode: "test" },
       }),
       [200],
     );
@@ -693,6 +735,119 @@ describe("CLI auth for Stripe connector routes", () => {
     expect(secretRows).toStrictEqual([]);
   });
 
+  it("completes live-mode CLI auth with a restricted live key", async () => {
+    const { userId, orgId } = await setupUser();
+    const calls = mockStripeCliSandbox({ configApiKey: "rk_live_imported" });
+
+    const start = await accept(
+      client().start({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { mode: "live" },
+      }),
+      [200],
+    );
+    expect(start.body.mode).toBe("live");
+
+    const complete = await accept(
+      client().complete({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { sessionToken: start.body.sessionToken },
+      }),
+      [200],
+    );
+
+    expect(complete.body.status).toBe("complete");
+    expect(calls.stop).toHaveLength(1);
+
+    const [secret] = await store
+      .set(writeDb$)
+      .select({
+        encryptedValue: secrets.encryptedValue,
+        description: secrets.description,
+      })
+      .from(secrets)
+      .where(
+        and(
+          eq(secrets.orgId, orgId),
+          eq(secrets.userId, userId),
+          eq(secrets.name, "STRIPE_TOKEN"),
+          eq(secrets.type, "user"),
+        ),
+      );
+    expect(secret).toMatchObject({
+      description: "Stripe CLI live mode API key",
+    });
+    expect(decryptSecretValue(secret!.encryptedValue)).toBe("rk_live_imported");
+  });
+
+  it("completes live-mode CLI auth with a secret live key", async () => {
+    const { userId, orgId } = await setupUser();
+    mockStripeCliSandbox({ configApiKey: "sk_live_imported" });
+
+    const start = await accept(
+      client().start({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { mode: "live" },
+      }),
+      [200],
+    );
+    const complete = await accept(
+      client().complete({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { sessionToken: start.body.sessionToken },
+      }),
+      [200],
+    );
+
+    expect(complete.body.status).toBe("complete");
+
+    const [secret] = await store
+      .set(writeDb$)
+      .select({ encryptedValue: secrets.encryptedValue })
+      .from(secrets)
+      .where(
+        and(
+          eq(secrets.orgId, orgId),
+          eq(secrets.userId, userId),
+          eq(secrets.name, "STRIPE_TOKEN"),
+          eq(secrets.type, "user"),
+        ),
+      );
+    expect(decryptSecretValue(secret!.encryptedValue)).toBe("sk_live_imported");
+  });
+
+  it("rejects test mode Stripe keys for a live-mode session and stops the sandbox", async () => {
+    const { userId, orgId } = await setupUser();
+    const calls = mockStripeCliSandbox({ configApiKey: "rk_test_imported" });
+
+    const start = await accept(
+      client().start({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { mode: "live" },
+      }),
+      [200],
+    );
+    const complete = await accept(
+      client().complete({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { sessionToken: start.body.sessionToken },
+      }),
+      [503],
+    );
+
+    expect(complete.body.error.code).toBe("CLI_AUTH_STRIPE_FAILED");
+    expect(complete.body.error.message).toBe(
+      "Stripe CLI config did not contain a live mode API key",
+    );
+    expect(calls.stop).toHaveLength(1);
+
+    const session = await onlyCliAuthStripeSession(userId, orgId);
+    expect(session).toMatchObject({
+      status: "error",
+      errorMessage: "Stripe CLI config did not contain a live mode API key",
+    });
+  });
+
   it("returns pending and keeps the sandbox alive when browser auth is not approved yet", async () => {
     const { userId, orgId } = await setupUser();
     const calls = mockStripeCliSandbox({ completeExitCode: 124 });
@@ -700,7 +855,7 @@ describe("CLI auth for Stripe connector routes", () => {
     const start = await accept(
       client().start({
         headers: { authorization: "Bearer clerk-session" },
-        body: {},
+        body: { mode: "test" },
       }),
       [200],
     );
@@ -730,7 +885,7 @@ describe("CLI auth for Stripe connector routes", () => {
     const start = await accept(
       client().start({
         headers: { authorization: "Bearer clerk-session" },
-        body: {},
+        body: { mode: "test" },
       }),
       [200],
     );
@@ -770,7 +925,7 @@ describe("CLI auth for Stripe connector routes", () => {
     const start = await accept(
       client().start({
         headers: { authorization: "Bearer clerk-session" },
-        body: {},
+        body: { mode: "test" },
       }),
       [200],
     );
@@ -814,7 +969,7 @@ describe("CLI auth for Stripe connector routes", () => {
     const start = await accept(
       client().start({
         headers: { authorization: "Bearer clerk-session" },
-        body: {},
+        body: { mode: "test" },
       }),
       [200],
     );
@@ -855,7 +1010,7 @@ describe("CLI auth for Stripe connector routes", () => {
     const start = await accept(
       client().start({
         headers: { authorization: "Bearer clerk-session" },
-        body: {},
+        body: { mode: "test" },
       }),
       [200],
     );
@@ -904,7 +1059,7 @@ describe("CLI auth for Stripe connector routes", () => {
     const start = await accept(
       client().start({
         headers: { authorization: "Bearer clerk-session" },
-        body: {},
+        body: { mode: "test" },
       }),
       [200],
     );
@@ -977,7 +1132,7 @@ describe("CLI auth for Stripe connector routes", () => {
     const start = await accept(
       client().start({
         headers: { authorization: "Bearer clerk-session" },
-        body: {},
+        body: { mode: "test" },
       }),
       [200],
     );
@@ -1006,7 +1161,7 @@ describe("CLI auth for Stripe connector routes", () => {
     const start = await accept(
       client().start({
         headers: { authorization: "Bearer clerk-session" },
-        body: {},
+        body: { mode: "test" },
       }),
       [200],
     );

--- a/turbo/apps/api/src/signals/routes/zero-connectors-cli-auth-stripe.ts
+++ b/turbo/apps/api/src/signals/routes/zero-connectors-cli-auth-stripe.ts
@@ -49,6 +49,7 @@ function isCliAuthStripeEnabled(params: {
 const completeCliAuthStripeBody$ = bodyResultOf(
   zeroCliAuthStripeContract.complete,
 );
+const startCliAuthStripeBody$ = bodyResultOf(zeroCliAuthStripeContract.start);
 
 function cliAuthStripeUnavailable(message: string, code: string) {
   return {
@@ -80,10 +81,17 @@ const startCliAuthStripeInner$ = command(
       return cliAuthStripeDisabled;
     }
 
+    const body = await get(startCliAuthStripeBody$);
+    signal.throwIfAborted();
+    if (!body.ok) {
+      return body.response;
+    }
+
     const result = await startCliAuthStripe({
       writeDb: set(writeDb$),
       orgId: auth.orgId,
       userId: auth.userId,
+      mode: body.data.mode,
       signal,
     });
     signal.throwIfAborted();
@@ -98,6 +106,7 @@ const startCliAuthStripeInner$ = command(
         sessionToken: result.sessionToken,
         type: "stripe" as const,
         status: "pending" as const,
+        mode: result.mode,
         browserUrl: result.browserUrl,
         verificationCode: result.verificationCode,
         expiresIn: result.expiresIn,

--- a/turbo/apps/api/src/signals/services/cli-auth-stripe.service.ts
+++ b/turbo/apps/api/src/signals/services/cli-auth-stripe.service.ts
@@ -59,7 +59,7 @@ const cliAuthStripeSessionTokenSchema = z.object({
 const cliAuthStripeProviderStateSchema = z.object({
   version: z.literal(1),
   type: z.literal("stripe"),
-  mode: z.enum(["test", "live"]).default("test"),
+  mode: z.enum(["test", "live"]),
   pollUrl: z.url(),
 });
 

--- a/turbo/apps/api/src/signals/services/cli-auth-stripe.service.ts
+++ b/turbo/apps/api/src/signals/services/cli-auth-stripe.service.ts
@@ -44,7 +44,6 @@ const CLI_AUTH_STRIPE_CONFIG_HOME = `${CLI_AUTH_STRIPE_ROOT}/config`;
 const CLI_AUTH_STRIPE_CONFIG_PATH = `${CLI_AUTH_STRIPE_CONFIG_HOME}/stripe/config.toml`;
 const CLI_AUTH_STRIPE_CONNECTOR_TYPE = "stripe";
 const CLI_AUTH_STRIPE_SOURCE = "stripe-cli";
-const CLI_AUTH_STRIPE_MODE: StripeCliAuthMode = "test";
 const STRIPE_TOKEN_SECRET_NAME = "STRIPE_TOKEN";
 const STRIPE_OAUTH_SECRET_NAMES = [
   "STRIPE_ACCESS_TOKEN",
@@ -60,6 +59,7 @@ const cliAuthStripeSessionTokenSchema = z.object({
 const cliAuthStripeProviderStateSchema = z.object({
   version: z.literal(1),
   type: z.literal("stripe"),
+  mode: z.enum(["test", "live"]).default("test"),
   pollUrl: z.url(),
 });
 
@@ -82,6 +82,7 @@ type CliAuthStripeStartResult =
       readonly sessionToken: string;
       readonly browserUrl: string;
       readonly verificationCode: string;
+      readonly mode: StripeCliAuthMode;
       readonly expiresIn: number;
       readonly interval: number;
     }
@@ -501,6 +502,7 @@ async function markCliAuthStripeSessionAwaitingApproval(args: {
   readonly writeDb: Db;
   readonly sessionId: string;
   readonly output: StripeCliAuthStartOutput;
+  readonly mode: StripeCliAuthMode;
 }) {
   await args.writeDb
     .update(connectorCliAuthSessions)
@@ -511,6 +513,7 @@ async function markCliAuthStripeSessionAwaitingApproval(args: {
       encryptedProviderState: encodeProviderState({
         version: 1,
         type: "stripe",
+        mode: args.mode,
         pollUrl: args.output.pollUrl,
       }),
       errorMessage: null,
@@ -523,6 +526,7 @@ export async function startCliAuthStripe(args: {
   readonly writeDb: Db;
   readonly orgId: string;
   readonly userId: string;
+  readonly mode: StripeCliAuthMode;
   readonly signal: AbortSignal;
   readonly now?: Date;
 }): Promise<CliAuthStripeStartResult> {
@@ -559,6 +563,7 @@ export async function startCliAuthStripe(args: {
       writeDb: args.writeDb,
       sessionId: session.id,
       output: startResult.output,
+      mode: args.mode,
     });
   });
   if ("error" in persistResult) {
@@ -579,6 +584,7 @@ export async function startCliAuthStripe(args: {
     }),
     browserUrl: startResult.output.browserUrl,
     verificationCode: startResult.output.verificationCode,
+    mode: args.mode,
     expiresIn: CLI_AUTH_STRIPE_SESSION_TTL_SECONDS,
     interval: CLI_AUTH_STRIPE_POLL_INTERVAL_SECONDS,
   };
@@ -667,6 +673,7 @@ async function importCliAuthStripeConnector(args: {
   readonly claimedAt: Date;
   readonly orgId: string;
   readonly userId: string;
+  readonly mode: StripeCliAuthMode;
   readonly apiKey: string;
   readonly signal: AbortSignal;
 }): Promise<CliAuthStripeCompleteResult> {
@@ -675,6 +682,7 @@ async function importCliAuthStripeConnector(args: {
   const encryptedValue = encryptSecretValue(args.apiKey);
   const updatedAt = nowDate();
   const writeDb = args.set(writeDb$);
+  const description = `Stripe CLI ${args.mode} mode API key`;
   await writeDb.transaction(async (tx) => {
     await tx
       .delete(connectors)
@@ -704,14 +712,14 @@ async function importCliAuthStripeConnector(args: {
         userId: args.userId,
         name: STRIPE_TOKEN_SECRET_NAME,
         encryptedValue,
-        description: "Stripe CLI test mode restricted key",
+        description,
         type: "user",
       })
       .onConflictDoUpdate({
         target: [secrets.orgId, secrets.userId, secrets.name, secrets.type],
         set: {
           encryptedValue,
-          description: "Stripe CLI test mode restricted key",
+          description,
           updatedAt,
         },
       });
@@ -788,6 +796,7 @@ async function completeCliAuthStripeInSandbox(args: {
 async function readCliAuthStripeApiKey(args: {
   readonly client: SandboxClient;
   readonly sandbox: SandboxHandle;
+  readonly mode: StripeCliAuthMode;
   readonly signal: AbortSignal;
 }): Promise<
   | { readonly ok: true; readonly apiKey: string }
@@ -831,10 +840,7 @@ async function readCliAuthStripeApiKey(args: {
 
   const configData = configResult.value.data;
   const apiKeyResult = await safeSync(() => {
-    return parseStripeCliAuthConfig(
-      configData.toString("utf8"),
-      CLI_AUTH_STRIPE_MODE,
-    );
+    return parseStripeCliAuthConfig(configData.toString("utf8"), args.mode);
   });
   if ("error" in apiKeyResult) {
     const message =
@@ -1182,6 +1188,7 @@ async function completeClaimedCliAuthStripe(args: {
   const apiKeyResult = await readCliAuthStripeApiKey({
     client: args.client,
     sandbox: args.sandbox,
+    mode: args.providerState.mode,
     signal: args.signal,
   });
   args.signal.throwIfAborted();
@@ -1208,6 +1215,7 @@ async function completeClaimedCliAuthStripe(args: {
       claimedAt,
       orgId: args.orgId,
       userId: args.userId,
+      mode: args.providerState.mode,
       apiKey: apiKeyResult.apiKey,
       signal: args.signal,
     });

--- a/turbo/packages/api-contracts/src/contracts/zero-connectors-cli-auth-stripe.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-connectors-cli-auth-stripe.ts
@@ -6,10 +6,13 @@ import { apiErrorSchema } from "./errors";
 
 const c = initContract();
 
+export const cliAuthStripeModeSchema = z.enum(["test", "live"]);
+
 const cliAuthStripeStartResponseSchema = z.object({
   sessionToken: z.string(),
   type: z.literal("stripe"),
   status: z.literal("pending"),
+  mode: cliAuthStripeModeSchema,
   browserUrl: z.url(),
   verificationCode: z.string().min(1),
   expiresIn: z.number().int().positive(),
@@ -37,7 +40,7 @@ export const zeroCliAuthStripeContract = c.router({
     method: "POST",
     path: "/api/zero/connectors/stripe/cli-auth/sessions",
     headers: authHeadersSchema,
-    body: z.object({}).optional(),
+    body: z.object({ mode: cliAuthStripeModeSchema }),
     responses: {
       200: cliAuthStripeStartResponseSchema,
       400: apiErrorSchema,


### PR DESCRIPTION
## Summary
- require explicit Stripe CLI auth mode on start and echo it in the start response
- persist the selected Stripe mode in encrypted provider state instead of a generic session field
- use the persisted mode during complete to import only matching test/live Stripe keys
- update Stripe secret copy from restricted key to API key

Closes #13132

## Tests
- pnpm --filter api lint
- pnpm --filter api check-types
- pnpm --filter @vm0/api-contracts lint
- pnpm --filter @vm0/api-contracts check-types
- pnpm exec vitest run src/signals/services/__tests__/cli-auth-stripe-parser.test.ts
- DATABASE_URL=<temp db> pnpm exec vitest run src/signals/routes/__tests__/zero-connectors-cli-auth-stripe.test.ts
- pre-commit: prettier, knip, turbo check-types