### PR TITLE
fix: accept ZERO_TOKEN on connector search route

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-search.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-search.test.ts
@@ -83,7 +83,7 @@ describe("GET /api/zero/connectors/search", () => {
   });
 
   it("returns connectors array with correct shape", async () => {
-    mocks.clerk.session(`user_${randomUUID()}`, null);
+    mocks.clerk.session(`user_${randomUUID()}`, `org_${randomUUID()}`);
 
     const client = setupApp({ context })(zeroConnectorsSearchContract);
     const response = await accept(
@@ -109,7 +109,7 @@ describe("GET /api/zero/connectors/search", () => {
   });
 
   it("filters connectors by keyword matching label", async () => {
-    mocks.clerk.session(`user_${randomUUID()}`, null);
+    mocks.clerk.session(`user_${randomUUID()}`, `org_${randomUUID()}`);
 
     const client = setupApp({ context })(zeroConnectorsSearchContract);
     const response = await accept(
@@ -131,7 +131,7 @@ describe("GET /api/zero/connectors/search", () => {
   });
 
   it("filters connectors by keyword matching description", async () => {
-    mocks.clerk.session(`user_${randomUUID()}`, null);
+    mocks.clerk.session(`user_${randomUUID()}`, `org_${randomUUID()}`);
 
     const client = setupApp({ context })(zeroConnectorsSearchContract);
     const response = await accept(
@@ -153,7 +153,7 @@ describe("GET /api/zero/connectors/search", () => {
   });
 
   it("returns empty array for non-matching keyword", async () => {
-    mocks.clerk.session(`user_${randomUUID()}`, null);
+    mocks.clerk.session(`user_${randomUUID()}`, `org_${randomUUID()}`);
 
     const client = setupApp({ context })(zeroConnectorsSearchContract);
     const response = await accept(
@@ -168,7 +168,7 @@ describe("GET /api/zero/connectors/search", () => {
   });
 
   it("performs case-insensitive keyword search", async () => {
-    mocks.clerk.session(`user_${randomUUID()}`, null);
+    mocks.clerk.session(`user_${randomUUID()}`, `org_${randomUUID()}`);
 
     const client = setupApp({ context })(zeroConnectorsSearchContract);
 
@@ -191,7 +191,7 @@ describe("GET /api/zero/connectors/search", () => {
   });
 
   it("hides feature-flagged connectors without api-token for non-enabled users", async () => {
-    mocks.clerk.session(`user_${randomUUID()}`, null);
+    mocks.clerk.session(`user_${randomUUID()}`, `org_${randomUUID()}`);
 
     const client = setupApp({ context })(zeroConnectorsSearchContract);
     const response = await accept(
@@ -250,7 +250,7 @@ describe("GET /api/zero/connectors/search", () => {
   });
 
   it("shows feature-flagged connector with api-token even when flag is disabled", async () => {
-    mocks.clerk.session(`user_${randomUUID()}`, null);
+    mocks.clerk.session(`user_${randomUUID()}`, `org_${randomUUID()}`);
 
     const client = setupApp({ context })(zeroConnectorsSearchContract);
     const response = await accept(
@@ -288,7 +288,7 @@ describe("GET /api/zero/connectors/search", () => {
   });
 
   it("includes connectors without feature flags", async () => {
-    mocks.clerk.session(`user_${randomUUID()}`, null);
+    mocks.clerk.session(`user_${randomUUID()}`, `org_${randomUUID()}`);
 
     const client = setupApp({ context })(zeroConnectorsSearchContract);
     const response = await accept(
@@ -315,7 +315,7 @@ describe("GET /api/zero/connectors/search", () => {
   });
 
   it("exposes openai as api-token only", async () => {
-    mocks.clerk.session(`user_${randomUUID()}`, null);
+    mocks.clerk.session(`user_${randomUUID()}`, `org_${randomUUID()}`);
 
     const client = setupApp({ context })(zeroConnectorsSearchContract);
     const response = await accept(
@@ -334,7 +334,7 @@ describe("GET /api/zero/connectors/search", () => {
   });
 
   it("shows zapier with api-token even when ZapierConnector flag is disabled", async () => {
-    mocks.clerk.session(`user_${randomUUID()}`, null);
+    mocks.clerk.session(`user_${randomUUID()}`, `org_${randomUUID()}`);
 
     const client = setupApp({ context })(zeroConnectorsSearchContract);
     const response = await accept(

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-search.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-search.test.ts
@@ -12,7 +12,14 @@ import { and, eq } from "drizzle-orm";
 import { afterEach } from "vitest";
 
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { now } from "../../../lib/time";
+import { signSandboxJwtForTests } from "../../auth/tokens";
 import { writeDb$ } from "../../external/db";
+import {
+  deleteOrgMembership$,
+  seedOrgMembership$,
+  type OrgMembershipFixture,
+} from "./helpers/zero-org-membership";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
 
 const context = testContext();
@@ -31,11 +38,16 @@ async function enableLocalBrowser(
   });
 }
 
+function currentSecond(): number {
+  return Math.floor(now() / 1000);
+}
+
 describe("GET /api/zero/connectors/search", () => {
   const seededFeatureSwitches: {
     readonly orgId: string;
     readonly userId: string;
   }[] = [];
+  const seededOrgs: OrgMembershipFixture[] = [];
 
   afterEach(async () => {
     const writeDb = store.set(writeDb$);
@@ -50,6 +62,12 @@ describe("GET /api/zero/connectors/search", () => {
               eq(userFeatureSwitches.userId, fixture.userId),
             ),
           );
+      }
+    }
+    while (seededOrgs.length > 0) {
+      const fixture = seededOrgs.pop();
+      if (fixture) {
+        await store.set(deleteOrgMembership$, fixture, context.signal);
       }
     }
   });
@@ -332,5 +350,72 @@ describe("GET /api/zero/connectors/search", () => {
     });
     expect(zapier).toBeDefined();
     expect(zapier?.authMethods).toContain("api-token");
+  });
+
+  it("accepts a ZERO_TOKEN carrying the connector:read capability", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    seededOrgs.push(
+      await store.set(
+        seedOrgMembership$,
+        { orgId, userId, role: "admin" },
+        context.signal,
+      ),
+    );
+    const seconds = currentSecond();
+    const token = signSandboxJwtForTests({
+      scope: "zero",
+      userId,
+      orgId,
+      runId: `run_${randomUUID()}`,
+      capabilities: ["connector:read"],
+      iat: seconds,
+      exp: seconds + 600,
+    });
+
+    const client = setupApp({ context })(zeroConnectorsSearchContract);
+    const response = await accept(
+      client.search({
+        query: {},
+        headers: { authorization: `Bearer ${token}` },
+      }),
+      [200],
+    );
+
+    expect(response.body.connectors).toBeInstanceOf(Array);
+    expect(response.body.connectors.length).toBeGreaterThan(0);
+  });
+
+  it("rejects a ZERO_TOKEN missing the connector:read capability with 403", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    seededOrgs.push(
+      await store.set(
+        seedOrgMembership$,
+        { orgId, userId, role: "admin" },
+        context.signal,
+      ),
+    );
+    const seconds = currentSecond();
+    const token = signSandboxJwtForTests({
+      scope: "zero",
+      userId,
+      orgId,
+      runId: `run_${randomUUID()}`,
+      capabilities: [],
+      iat: seconds,
+      exp: seconds + 600,
+    });
+
+    const client = setupApp({ context })(zeroConnectorsSearchContract);
+    const response = await accept(
+      client.search({
+        query: {},
+        headers: { authorization: `Bearer ${token}` },
+      }),
+      [403],
+    );
+
+    expect(response.body.error.code).toBe("FORBIDDEN");
   });
 });

--- a/turbo/apps/api/src/signals/routes/zero-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/zero-connectors.ts
@@ -462,7 +462,7 @@ const getScopeDiffInner$ = computed(async (get) => {
 });
 
 const searchConnectorsInner$ = computed(async (get) => {
-  const auth = get(authContext$);
+  const auth = get(organizationAuthContext$);
   const query = get(queryOf(zeroConnectorsSearchContract.search));
   const connectors = await get(
     zeroConnectorSearch({
@@ -778,7 +778,7 @@ export const zeroConnectorsRoutes: readonly RouteEntry[] = [
   },
   {
     route: zeroConnectorsSearchContract.search,
-    handler: authRoute({}, searchConnectorsInner$),
+    handler: authRoute(connectorReadAuth, searchConnectorsInner$),
   },
   {
     route: zeroConnectorsMainContract.list,

--- a/turbo/apps/web/app/api/zero/connectors/search/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/connectors/search/__tests__/route.test.ts
@@ -1,8 +1,15 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { GET } from "../route";
-import { createTestRequest } from "../../../../../../src/__tests__/api-test-helpers";
+import {
+  createTestRequest,
+  clearOrgMembersCacheEntry,
+} from "../../../../../../src/__tests__/api-test-helpers";
 import { testContext } from "../../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
+import {
+  generateZeroToken,
+  generateSandboxToken,
+} from "../../../../../../src/lib/auth/sandbox-token";
 import {
   CONNECTOR_TYPES,
   type ConnectorType,
@@ -10,11 +17,16 @@ import {
 
 const context = testContext();
 
-function searchConnectors(keyword?: string) {
+function searchConnectors(keyword?: string, token?: string) {
   const url = keyword
     ? `http://localhost:3000/api/zero/connectors/search?keyword=${encodeURIComponent(keyword)}`
     : "http://localhost:3000/api/zero/connectors/search";
-  return GET(createTestRequest(url));
+  return GET(
+    createTestRequest(
+      url,
+      token ? { headers: { authorization: `Bearer ${token}` } } : undefined,
+    ),
+  );
 }
 
 describe("GET /api/zero/connectors/search", () => {
@@ -183,5 +195,27 @@ describe("GET /api/zero/connectors/search", () => {
     });
     expect(zapier).toBeDefined();
     expect(zapier.authMethods).toContain("api-token");
+  });
+
+  it("accepts a ZERO_TOKEN carrying the connector:read capability", async () => {
+    const user = await context.setupUser();
+    await clearOrgMembersCacheEntry(user.orgId, user.userId);
+    const token = await generateZeroToken(user.userId, "run-1", user.orgId);
+
+    const response = await searchConnectors(undefined, token);
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.connectors).toBeInstanceOf(Array);
+    expect(data.connectors.length).toBeGreaterThan(0);
+  });
+
+  it("rejects a sandbox token lacking the connector:read capability with 403", async () => {
+    const user = await context.setupUser();
+    const token = await generateSandboxToken(user.userId, "run-1", user.orgId);
+
+    const response = await searchConnectors(undefined, token);
+    expect(response.status).toBe(403);
+    const data = await response.json();
+    expect(data.error.code).toBe("FORBIDDEN");
   });
 });

--- a/turbo/apps/web/app/api/zero/connectors/search/route.ts
+++ b/turbo/apps/web/app/api/zero/connectors/search/route.ts
@@ -10,15 +10,21 @@ import {
 import { getAllFeatureStates } from "@vm0/core/feature-switch";
 import { createErrorResponse } from "@vm0/api-contracts/contracts/errors";
 import { initServices } from "../../../../../src/lib/init-services";
-import { getAuthContext } from "../../../../../src/lib/auth/get-auth-context";
+import {
+  requireAuth,
+  isAuthError,
+} from "../../../../../src/lib/auth/require-auth";
 import { loadFeatureSwitchOverrides } from "../../../../../src/lib/zero/user/feature-switches-service";
 
 const router = tsr.router(zeroConnectorsSearchContract, {
   search: async ({ headers, query }) => {
     initServices();
 
-    const authCtx = await getAuthContext(headers.authorization);
-    if (!authCtx) {
+    const authCtx = await requireAuth(headers.authorization, {
+      requiredCapability: "connector:read",
+    });
+    if (isAuthError(authCtx)) return authCtx;
+    if (!authCtx.orgId) {
       return createErrorResponse("UNAUTHORIZED", "Not authenticated");
     }
 

--- a/turbo/packages/api-contracts/src/contracts/zero-connectors.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-connectors.ts
@@ -141,6 +141,7 @@ export const zeroConnectorsSearchContract = c.router({
     responses: {
       200: connectorSearchResponseSchema,
       401: apiErrorSchema,
+      403: apiErrorSchema,
     },
     summary: "Search available connector types",
   },


### PR DESCRIPTION
## Summary

`zero connector search` and `zero connector list` both 401 from inside an agent sandbox (`✗ ZERO_TOKEN is invalid or expired`), even though the token is valid — `zero whoami` works with the same token.

Root cause: the connector **search** route authenticates **without** requesting a capability, so the auth layer rejects every ZERO_TOKEN / sandbox token. The sibling **list** route correctly passes `connector:read`.

- `apps/web` `search/route.ts` called `getAuthContext(headers.authorization)` with no `requiredCapability` → `authenticateSandboxToken` rejects sandbox-prefixed tokens outright.
- `apps/api` `zero-connectors.ts` used `authRoute({}, searchConnectorsInner$)` → `zeroAuth$` returns `null` when neither `requiredCapability` nor `acceptAnySandboxCapability` is set.

`whoami` works because it only hits the list endpoint. This is a long-standing latent bug; **#12218** (2026-05-09) made it visible by routing `zero connector list` through the search endpoint.

## Changes

- **`apps/web`** — search route now uses `requireAuth(..., { requiredCapability: "connector:read" })` with `isAuthError`, matching the list route. Proper 401 (unauthenticated) vs 403 (valid token, missing capability) distinction.
- **`apps/api`** — search route now uses `authRoute(connectorReadAuth, searchConnectorsInner$)`; `searchConnectorsInner$` reads `organizationAuthContext$` for consistency with the list handler.
- **`api-contracts`** — `zeroConnectorsSearchContract.search` gains a `403` response (shared by both subpackages).
- **Tests** — both search route test files only exercised `Bearer clerk-session` (session tokens), which is why this slipped through. Added ZERO_TOKEN coverage on both sides: a token with `connector:read` → `200`, a token lacking it → `403`.

## Test plan

- [ ] `apps/web` — `vitest run app/api/zero/connectors/search/__tests__/route.test.ts`
- [ ] `apps/api` — `vitest run src/signals/routes/__tests__/zero-connectors-search.test.ts`
- [ ] CI: lint + check-types across `@vm0/web`, `@vm0/api`, `@vm0/api-contracts`
- [ ] Manual: from an agent sandbox, `zero connector list` and `zero connector search github` return results instead of `401`

Fixes #13348

🤖 Generated with [Claude Code](https://claude.com/claude-code)