### PR TITLE
refactor(onboarding): rename final step button to "Get Started"

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/zero-onboarding-actions.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-onboarding-actions.ts
@@ -151,7 +151,7 @@ export const onboardingNextDisabled$ = computed(async (get) => {
 
 /**
  * Label on the primary forward button. "Try It" finishes a use-case flow,
- * "Continue in web" finishes the regular admin flow, "Next" advances step 1.
+ * "Get Started" finishes the regular admin flow, "Next" advances step 1.
  */
 export const onboardingNextLabel$ = computed(async (get) => {
   const step = await get(onboardingEffectiveStep$);
@@ -160,7 +160,7 @@ export const onboardingNextLabel$ = computed(async (get) => {
     return "Try It";
   }
   if (step === "2") {
-    return "Continue in web";
+    return "Get Started";
   }
   return "Next";
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/onboarding-chat-intro.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/onboarding-chat-intro.test.tsx
@@ -55,7 +55,7 @@ async function walkAdminToContinue() {
   click(screen.getByTestId("connector-card-github"));
 
   await waitFor(() => {
-    expect(screen.getByText(/Continue in web/)).toBeInTheDocument();
+    expect(screen.getByText(/Get Started/)).toBeInTheDocument();
   });
 }
 
@@ -93,7 +93,7 @@ describe("onboarding → chat page (no auto-intro)", () => {
       }),
     );
 
-    click(screen.getByText(/Continue in web/));
+    click(screen.getByText(/Get Started/));
 
     // Should navigate directly to the agent chat page
     await waitFor(() => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/onboarding-continue-web-blank-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/onboarding-continue-web-blank-page.test.tsx
@@ -23,7 +23,7 @@ const MOCK_AGENT_ID = "d0000000-0000-4000-a000-000000000001";
 
 function mockAdminOnboardingDeferred() {
   // The first setup call (step 1 eager-init) resolves immediately; the second
-  // call (step 2 connector authorize, triggered by "Continue in web") is
+  // call (step 2 connector authorize, triggered by "Get Started") is
   // deferred so we can observe the skeleton while the command is in-flight.
   const completeDeferred = createDeferredPromise<void>(context.signal);
   let setupCalls = 0;
@@ -88,7 +88,7 @@ describe("onboarding continue in web → skeleton → chat page (#7902)", () => 
     click(screen.getByTestId("connector-card-github"));
 
     await waitFor(() => {
-      expect(screen.getByText(/Continue in web/)).toBeInTheDocument();
+      expect(screen.getByText(/Get Started/)).toBeInTheDocument();
     });
 
     // Skeleton should be hidden after onboarding page loaded
@@ -99,7 +99,7 @@ describe("onboarding continue in web → skeleton → chat page (#7902)", () => 
 
     // Click starts the async onboarding completion; the setup API is deferred
     // so the command is in-flight while we assert skeleton visibility.
-    click(screen.getByText(/Continue in web/));
+    click(screen.getByText(/Get Started/));
 
     // Skeleton must be visible during the transition (the fix for #7902)
     await waitFor(() => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/onboarding-continue-web.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/onboarding-continue-web.test.tsx
@@ -68,7 +68,7 @@ function switchToAdminComplete() {
 }
 
 // Step 1 (name workspace) → step 2 (choose tools, pick a connector). Step 2's
-// "Continue in web" is the terminal step of the regular admin flow.
+// "Get Started" is the terminal step of the regular admin flow.
 async function walkAdminToContinue() {
   await waitFor(() => {
     expect(screen.getByText(/Name your workspace/)).toBeInTheDocument();
@@ -84,7 +84,7 @@ async function walkAdminToContinue() {
   click(screen.getByTestId("connector-card-github"));
 
   await waitFor(() => {
-    expect(screen.getByText(/Continue in web/)).toBeInTheDocument();
+    expect(screen.getByText(/Get Started/)).toBeInTheDocument();
   });
 }
 
@@ -97,7 +97,7 @@ describe("onboarding continue in web → agent chat page", () => {
 
     switchToAdminComplete();
 
-    click(screen.getByText(/Continue in web/));
+    click(screen.getByText(/Get Started/));
 
     await waitFor(() => {
       expect(pathname()).toBe(`/agents/${MOCK_AGENT_ID}/chat`);
@@ -110,7 +110,7 @@ describe("onboarding continue in web → agent chat page", () => {
 // ---------------------------------------------------------------------------
 
 describe("prompt param forwarding", () => {
-  it("should forward ?prompt= to chat page via Continue in web", async () => {
+  it("should forward ?prompt= to chat page via Get Started", async () => {
     mockAdminOnboarding();
 
     detachedSetupPage({ context, path: "/onboarding?prompt=hello%20world" });
@@ -118,7 +118,7 @@ describe("prompt param forwarding", () => {
 
     switchToAdminComplete();
 
-    click(screen.getByText(/Continue in web/));
+    click(screen.getByText(/Get Started/));
 
     await waitFor(() => {
       expect(pathname()).toBe(`/agents/${MOCK_AGENT_ID}/chat`);
@@ -139,7 +139,7 @@ describe("prompt param forwarding", () => {
 
     switchToAdminComplete();
 
-    click(screen.getByText(/Continue in web/));
+    click(screen.getByText(/Get Started/));
 
     await waitFor(() => {
       expect(pathname()).toBe(`/agents/${MOCK_AGENT_ID}/chat`);

--- a/turbo/apps/platform/src/views/zero-page/__tests__/onboarding-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/onboarding-navigation.test.tsx
@@ -126,12 +126,12 @@ describe("onboarding navigation", () => {
     // find it instead of treating it as missing and looping back.
     registerAgent(MOCK_AGENT_ID);
 
-    // "Continue in web" finishes onboarding (step 2 is the terminal step) and
+    // "Get Started" finishes onboarding (step 2 is the terminal step) and
     // navigates into the web chat.
     await waitFor(() => {
-      expect(screen.getByText(/Continue in web/)).toBeInTheDocument();
+      expect(screen.getByText(/Get Started/)).toBeInTheDocument();
     });
-    click(screen.getByText(/Continue in web/));
+    click(screen.getByText(/Get Started/));
 
     await waitFor(() => {
       expect(pathname()).not.toBe("/onboarding");

--- a/turbo/apps/platform/src/views/zero-page/__tests__/talk-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/talk-navigation.test.tsx
@@ -314,13 +314,13 @@ describe("talk navigation", () => {
     });
     click(screen.getByTestId("connector-card-github"));
 
-    // Click "Continue in web" which triggers:
+    // Click "Get Started" which triggers:
     // 1. completeZeroOnboarding$ (re-runs setup to authorize the connector)
     // 2. navigate to /agents/:id/chat
     await waitFor(() => {
-      expect(screen.getByText(/Continue in web/)).toBeInTheDocument();
+      expect(screen.getByText(/Get Started/)).toBeInTheDocument();
     });
-    click(screen.getByText(/Continue in web/));
+    click(screen.getByText(/Get Started/));
 
     // The final URL should be /agents/:id/chat (no auto-intro message)
     await waitFor(() => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-onboarding.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-onboarding.test.tsx
@@ -144,7 +144,7 @@ describe("zero onboarding - step 2: choose tools", () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByText(/Continue in web/)).toBeInTheDocument();
+      expect(screen.getByText(/Get Started/)).toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
## Summary
- Rename the terminal onboarding button (regular admin flow, step 2) from "Continue in web" to "Get Started"
- "Continue in web" was confusing since the user is already in the web app; "Get Started" better reflects that the button finishes onboarding and opens the agent chat
- Updated all affected `zero-page` test matchers and comments

## Test plan
- [x] `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__` — 1127 passed
- [ ] Manually verify the onboarding wizard shows "Get Started" on the final admin step

🤖 Generated with [Claude Code](https://claude.com/claude-code)