### PR TITLE
fix: build run skill volumes from the model provider framework

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-runs-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-runs-create.test.ts
@@ -1408,6 +1408,62 @@ describe("POST /api/zero/runs", () => {
     expect(volumes[customIndex]?.system).toBeUndefined();
   });
 
+  it("mounts skills using the model provider framework, not the compose framework", async () => {
+    const fx = await fixture();
+    await trackModelProviders(Promise.resolve({ orgId: fx.orgId }));
+    // openai-api-key resolves to the codex framework.
+    const provider = await store.set(
+      seedOrgModelProvider$,
+      {
+        orgId: fx.orgId,
+        type: "openai-api-key",
+        isDefault: true,
+        selectedModel: "gpt-5.5",
+        secretName: "OPENAI_API_KEY",
+      },
+      context.signal,
+    );
+    // The compose declares the default claude-code framework, but the agent
+    // is pinned to a codex-framework model provider. Skill volume mount paths
+    // must follow the model provider's framework, not the compose's.
+    const agent = await seedRunnableZeroAgent({
+      fixture: fx,
+      environment: {},
+      modelProviderId: provider.id,
+      customSkills: ["research-kit"],
+    });
+
+    const response = await accept(
+      zeroRunsClient().create({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { prompt: "use skills", agentId: agent.agentId },
+      }),
+      [201],
+    );
+
+    const db = store.set(writeDb$);
+    const [run] = await db
+      .select({ additionalVolumes: agentRuns.additionalVolumes })
+      .from(agentRuns)
+      .where(eq(agentRuns.id, response.body.runId));
+    const volumes = run?.additionalVolumes ?? [];
+    expect(
+      volumes.some((volume) => {
+        return volume.mountPath === "/home/user/.codex/skills/research-kit";
+      }),
+    ).toBeTruthy();
+    expect(
+      volumes.some((volume) => {
+        return volume.mountPath === "/home/user/.codex/skills/deep-dive";
+      }),
+    ).toBeTruthy();
+    expect(
+      volumes.some((volume) => {
+        return volume.mountPath.startsWith("/home/user/.claude/skills/");
+      }),
+    ).toBeFalsy();
+  });
+
   it("builds runner firewalls from stored zero agent permission policies", async () => {
     const fx = await fixture();
     const agent = await seedRunnableZeroAgent({

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -418,6 +418,19 @@ function buildCustomSkillVolumes(
   });
 }
 
+function buildInjectedSkillVolumes(
+  args: CreateAgentRunArgs,
+  framework: SupportedFramework,
+): readonly AdditionalVolume[] | undefined {
+  if (!args.injectSkillVolumes) {
+    return undefined;
+  }
+  return [
+    ...buildSystemSkillVolumes(args.allowedConnectorTypes ?? [], framework),
+    ...buildCustomSkillVolumes(args.injectSkillVolumes.customSkills, framework),
+  ];
+}
+
 function isRouteError(value: unknown): value is CreateRunErrorResult {
   return (
     typeof value === "object" &&
@@ -2890,17 +2903,8 @@ async function prepareRunContext(
     framework,
     bodyArtifacts: body.artifacts,
   });
-  const skillVolumes = args.injectSkillVolumes
-    ? [
-        ...buildSystemSkillVolumes(args.allowedConnectorTypes ?? [], framework),
-        ...buildCustomSkillVolumes(
-          args.injectSkillVolumes.customSkills,
-          framework,
-        ),
-      ]
-    : undefined;
   const additionalVolumes = mergeAdditionalVolumes({
-    prepend: skillVolumes,
+    prepend: buildInjectedSkillVolumes(args, framework),
     base: body.additionalVolumes ?? resolved.additionalVolumes,
   });
 

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -53,6 +53,12 @@ import {
   MOUNT_PATH_TEMPLATE,
   type SupportedFramework,
 } from "@vm0/core";
+import { resolveSkillRef, parseGitHubTreeUrl } from "@vm0/core/github-url";
+import {
+  getCustomSkillStorageName,
+  getSkillStorageName,
+} from "@vm0/core/storage-names";
+import { SEED_SKILLS } from "@vm0/core/zero-seed-skills";
 import {
   expandVariables,
   extractAndGroupVariables,
@@ -291,7 +297,11 @@ interface CreateAgentRunArgs {
   readonly chatThreadId?: string;
   readonly includeZeroTokenSecret?: boolean;
   readonly extraEnvironment?: Record<string, string>;
-  readonly prependAdditionalVolumes?: readonly AdditionalVolume[];
+  // When set, system + custom skill volumes are built and prepended in
+  // prepareRunContext using the run's resolved (model-provider) framework.
+  readonly injectSkillVolumes?: {
+    readonly customSkills: readonly string[];
+  };
   readonly allowedConnectorTypes?: readonly ConnectorType[];
   readonly allowedCustomConnectorIds?: readonly string[];
   readonly validateEnvironmentReferences?: boolean;
@@ -355,6 +365,57 @@ function mergeAdditionalVolumes(args: {
   return args.prepend || args.base
     ? [...(args.prepend ?? []), ...(args.base ?? [])]
     : undefined;
+}
+
+function frameworkSkillsMountPath(framework: SupportedFramework): string {
+  return framework === "codex"
+    ? "/home/user/.codex/skills"
+    : "/home/user/.claude/skills";
+}
+
+function skillMountPath(
+  framework: SupportedFramework,
+  skillName: string,
+): string {
+  return `${frameworkSkillsMountPath(framework)}/${skillName}`;
+}
+
+// Skill volume mount paths are framework-specific. The framework MUST be the
+// one resolved from the model provider (see prepareRunContext), never the one
+// declared in the compose — a run can execute on a provider whose framework
+// differs from the compose, and skills mounted at the wrong path are invisible
+// to the agent.
+function buildSystemSkillVolumes(
+  connectorTypes: readonly ConnectorType[],
+  framework: SupportedFramework,
+): readonly AdditionalVolume[] {
+  const allSkillNames = [...new Set([...SEED_SKILLS, ...connectorTypes])];
+  return allSkillNames.flatMap((skillName) => {
+    const url = resolveSkillRef(skillName);
+    const parsed = parseGitHubTreeUrl(url);
+    if (!parsed) {
+      return [];
+    }
+    return [
+      {
+        name: getSkillStorageName(parsed.fullPath),
+        mountPath: skillMountPath(framework, parsed.skillName),
+        system: true,
+      },
+    ];
+  });
+}
+
+function buildCustomSkillVolumes(
+  customSkills: readonly string[],
+  framework: SupportedFramework,
+): readonly AdditionalVolume[] {
+  return customSkills.map((name) => {
+    return {
+      name: getCustomSkillStorageName(name),
+      mountPath: skillMountPath(framework, name),
+    };
+  });
 }
 
 function isRouteError(value: unknown): value is CreateRunErrorResult {
@@ -2829,8 +2890,17 @@ async function prepareRunContext(
     framework,
     bodyArtifacts: body.artifacts,
   });
+  const skillVolumes = args.injectSkillVolumes
+    ? [
+        ...buildSystemSkillVolumes(args.allowedConnectorTypes ?? [], framework),
+        ...buildCustomSkillVolumes(
+          args.injectSkillVolumes.customSkills,
+          framework,
+        ),
+      ]
+    : undefined;
   const additionalVolumes = mergeAdditionalVolumes({
-    prepend: args.prependAdditionalVolumes,
+    prepend: skillVolumes,
     base: body.additionalVolumes ?? resolved.additionalVolumes,
   });
 

--- a/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
@@ -12,13 +12,6 @@ import {
   type FirewallPolicyValue,
   type RawPermissionPolicies,
 } from "@vm0/connectors/firewall-types";
-import { isSupportedFramework, type SupportedFramework } from "@vm0/core";
-import { resolveSkillRef, parseGitHubTreeUrl } from "@vm0/core/github-url";
-import {
-  getCustomSkillStorageName,
-  getSkillStorageName,
-} from "@vm0/core/storage-names";
-import { SEED_SKILLS } from "@vm0/core/zero-seed-skills";
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { agentSessions } from "@vm0/db/schema/agent-session";
 import {
@@ -102,13 +95,6 @@ interface ZeroAgentComposeContent {
   readonly agents?: Record<string, ZeroAgentConfig | undefined>;
 }
 
-interface AdditionalVolume {
-  readonly name: string;
-  readonly version?: string;
-  readonly mountPath: string;
-  readonly system?: boolean;
-}
-
 interface RunCallback {
   readonly url: string;
   readonly secret: string;
@@ -138,73 +124,6 @@ function apiUrl(): string {
 
 function generateCallbackSecret(): string {
   return randomBytes(32).toString("hex");
-}
-
-function firstAgent(content: ZeroAgentComposeContent): ZeroAgentConfig | null {
-  if (content.agent) {
-    return content.agent;
-  }
-
-  const firstKey = Object.keys(content.agents ?? {})[0];
-  if (!firstKey) {
-    return null;
-  }
-  return content.agents?.[firstKey] ?? null;
-}
-
-function resolveAgentFramework(
-  content: ZeroAgentComposeContent,
-): SupportedFramework | null {
-  const framework = firstAgent(content)?.framework;
-  return isSupportedFramework(framework) ? framework : null;
-}
-
-function resolveFrameworkSkillsMountPath(
-  framework: SupportedFramework,
-): string {
-  return framework === "codex"
-    ? "/home/user/.codex/skills"
-    : "/home/user/.claude/skills";
-}
-
-function buildSkillMountPath(
-  framework: SupportedFramework,
-  skillName: string,
-): string {
-  return `${resolveFrameworkSkillsMountPath(framework)}/${skillName}`;
-}
-
-function buildSystemSkillVolumes(
-  connectorTypes: readonly ConnectorType[],
-  framework: SupportedFramework,
-): readonly AdditionalVolume[] {
-  const allSkillNames = [...new Set([...SEED_SKILLS, ...connectorTypes])];
-  return allSkillNames.flatMap((skillName) => {
-    const url = resolveSkillRef(skillName);
-    const parsed = parseGitHubTreeUrl(url);
-    if (!parsed) {
-      return [];
-    }
-    return [
-      {
-        name: getSkillStorageName(parsed.fullPath),
-        mountPath: buildSkillMountPath(framework, parsed.skillName),
-        system: true,
-      },
-    ];
-  });
-}
-
-function buildCustomSkillVolumes(
-  customSkills: readonly string[],
-  framework: SupportedFramework,
-): readonly AdditionalVolume[] {
-  return customSkills.map((name) => {
-    return {
-      name: getCustomSkillStorageName(name),
-      mountPath: buildSkillMountPath(framework, name),
-    };
-  });
 }
 
 function buildAgentIdentityPrompt(agent: ZeroAgentRunRecord): string | null {
@@ -609,18 +528,6 @@ export const createZeroIntegrationRun$ = command(
       [...allowedConnectorTypes],
     );
 
-    const framework = resolveAgentFramework(agent.content);
-    if (!framework) {
-      return badRequestMessage(
-        "Agent must have a supported framework configured",
-      );
-    }
-
-    const prependAdditionalVolumes = [
-      ...buildSystemSkillVolumes(allowedConnectorTypes, framework),
-      ...buildCustomSkillVolumes(agent.customSkills, framework),
-    ];
-
     return await set(
       createAgentRun$,
       {
@@ -643,7 +550,7 @@ export const createZeroIntegrationRun$ = command(
         includeZeroTokenSecret: true,
         enforceVm0Credits: true,
         queueOnConcurrencyLimit: true,
-        prependAdditionalVolumes,
+        injectSkillVolumes: { customSkills: agent.customSkills },
         allowedConnectorTypes,
         allowedCustomConnectorIds,
         validateEnvironmentReferences: false,
@@ -735,18 +642,6 @@ export const createZeroRun$ = command(
       [...allowedConnectorTypes],
     );
 
-    const framework = resolveAgentFramework(agent.content);
-    if (!framework) {
-      return badRequestMessage(
-        "Agent must have a supported framework configured",
-      );
-    }
-
-    const prependAdditionalVolumes = [
-      ...buildSystemSkillVolumes(allowedConnectorTypes, framework),
-      ...buildCustomSkillVolumes(agent.customSkills, framework),
-    ];
-
     return await set(
       createAgentRun$,
       {
@@ -774,7 +669,7 @@ export const createZeroRun$ = command(
         includeZeroTokenSecret: true,
         enforceVm0Credits: true,
         queueOnConcurrencyLimit: true,
-        prependAdditionalVolumes,
+        injectSkillVolumes: { customSkills: agent.customSkills },
         allowedConnectorTypes,
         allowedCustomConnectorIds,
         validateEnvironmentReferences: false,


### PR DESCRIPTION
## Summary

After enabling the `apiBackend` flag, runs were created without org/custom skills (and seed skills). Root cause: the API backend's run-create path built skill volume **mount paths** from the framework declared in the **compose** (`resolveAgentFramework(agent.content)`), while the rest of the run — and the runner itself — uses the framework resolved from the **model provider**.

When an agent runs on a model provider whose framework differs from the compose (e.g. a codex provider pinned on a `claude-code` compose, common with vm0-managed / personal providers), skills were mounted under `/home/user/.claude/skills/<name>` while the runner looked under `/home/user/.codex/skills/<name>`. The skill files were present but at the wrong path, so the agent couldn't see them.

The web path doesn't have this bug — it builds skill volumes with `runFramework`, which already factors in the model provider.

## Approach

The compose-declared framework is not authoritative for run execution and shouldn't drive skill mount paths — the framework is always resolved from the model provider. So skill volumes are now built inside `prepareRunContext` (`agent-run-create.service.ts`), right after the framework is resolved from the model provider — the same value already used for artifacts and everything else.

- **`agent-run-create.service.ts`** — skill volume builders (`buildSystemSkillVolumes` / `buildCustomSkillVolumes`) moved here. `prepareRunContext` builds them with the resolved framework. `CreateAgentRunArgs` swaps the pre-built `prependAdditionalVolumes` for `injectSkillVolumes` (just the `customSkills` spec); other `createAgentRun$` callers are unaffected.
- **`zero-runs-create.service.ts`** — drops `resolveAgentFramework` and the compose-only skill volume construction from both `createZeroRun$` and `createZeroIntegrationRun$`; they now pass `injectSkillVolumes` instead. (Compose schema validation still happens in `validateCompose` inside `prepareRunContext` — only the redundant compose-framework read is removed.)

## Test

Added a regression test in `zero-runs-create.test.ts`: an agent whose compose declares the default `claude-code` framework but is pinned to a codex-framework model provider (`openai-api-key`). The run's `additionalVolumes` must mount skills under `/home/user/.codex/skills/...` (model provider framework), never `/home/user/.claude/skills/...` (compose framework). Fails before this change, passes after.

## Test plan

- [ ] `apps/api` — `vitest run src/signals/routes/__tests__/zero-runs-create.test.ts`
- [ ] CI: lint + check-types for `@vm0/api`
- [ ] Manual: with `apiBackend` enabled, create a run for an agent with org/custom skills on a model provider whose framework differs from the compose — confirm skills are visible to the agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)