### PR TITLE
fix(e2e): update smoke test for "Get Started" onboarding button

### DIFF
--- a/e2e/playwright/tests/smoke.spec.ts
+++ b/e2e/playwright/tests/smoke.spec.ts
@@ -66,11 +66,11 @@ async function completeOnboarding(page: import("@playwright/test").Page) {
     await page.getByRole("button", { name: "Next" }).click();
   }
 
-  // Step 2: choose tools. This is the terminal step — "Continue in web"
+  // Step 2: choose tools. This is the terminal step — "Get Started"
   // finishes onboarding and navigates into the web chat. The step 1 → step 2
   // transition runs the eager-init API, so allow plenty of time.
   const chooseTools = page.getByTestId("onboarding-step-select-connectors");
   if (await tryAwaitVisible(chooseTools, 15_000)) {
-    await page.getByRole("button", { name: "Continue in web" }).click();
+    await page.getByRole("button", { name: "Get Started" }).click();
   }
 }


### PR DESCRIPTION
## Summary
- PR #13350 renamed the onboarding step 2 terminal button from "Continue in web" to "Get Started" but did not update the Playwright smoke test (`e2e/playwright/tests/smoke.spec.ts`).
- As a result, `cli-e2e-02-playwright` fails on every merge-queue temp commit built on top of `618e2d2`, ejecting PRs (e.g. #13349) with `failed_checks`.
- This updates the smoke test selector and comment to match the new button label.

## Test plan
- [ ] `cli-e2e-02-playwright` passes in the merge queue