### PR TITLE
fix: clarify private agent creation visibility

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/zero-jobs-page.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-jobs-page.ts
@@ -30,7 +30,7 @@ export const setJobsNewName$ = command(({ set }, name: string) => {
 
 // -- Visibility -------------------------------------------------------------
 
-const internalVisibility$ = state<"public" | "private">("public");
+const internalVisibility$ = state<"public" | "private">("private");
 export const jobsVisibility$ = computed((get) => {
   return get(internalVisibility$);
 });
@@ -64,6 +64,6 @@ export const setJobsViewMode$ = command(({ set }, mode: "grid" | "list") => {
 
 export const resetJobsDialog$ = command(({ set }) => {
   set(internalNewName$, "");
-  set(internalVisibility$, "public");
+  set(internalVisibility$, "private");
   set(internalAvatarUrl$, randomSvgAvatarUrl());
 });

--- a/turbo/apps/platform/src/views/agents-page/agents-page.tsx
+++ b/turbo/apps/platform/src/views/agents-page/agents-page.tsx
@@ -19,7 +19,11 @@ import {
   DialogTitle,
   Button,
   Input,
-  Switch,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
   Tabs,
   TabsList,
   TabsTrigger,
@@ -91,7 +95,8 @@ export function AgentsPage() {
     if (!trimmed || creating) {
       return;
     }
-    await createSubagentFn(trimmed, avatarUrl, visibility, pageSignal);
+    const createVisibility = privateAgentsEnabled ? visibility : "public";
+    await createSubagentFn(trimmed, avatarUrl, createVisibility, pageSignal);
     setDialogOpen(false);
     resetDialog();
     toast.success(`${trimmed} created successfully`);
@@ -411,7 +416,7 @@ function CreateTeammateDialogContent({
           disabled={creating}
         />
         {showVisibility && (
-          <CreateAgentPublicToggle
+          <CreateAgentVisibilitySelect
             visibility={visibility}
             onVisibilityChange={onVisibilityChange}
             publicDisabled={publicDisabled}
@@ -444,7 +449,7 @@ function CreateTeammateDialogContent({
   );
 }
 
-function CreateAgentPublicToggle({
+function CreateAgentVisibilitySelect({
   visibility,
   onVisibilityChange,
   publicDisabled,
@@ -454,23 +459,33 @@ function CreateAgentPublicToggle({
   publicDisabled: boolean;
 }) {
   return (
-    <div className="flex w-full items-center justify-between gap-4 rounded-lg bg-muted/40 px-3 py-2.5">
-      <div className="min-w-0">
-        <p className="text-sm font-medium text-foreground">Make public</p>
-        <p className="mt-0.5 text-xs text-muted-foreground">
-          {publicDisabled
-            ? "Public agent limit reached."
-            : "Visible to everyone in this workspace."}
-        </p>
-      </div>
-      <Switch
-        checked={visibility === "public"}
-        disabled={publicDisabled}
-        onCheckedChange={(checked) => {
-          return onVisibilityChange(checked ? "public" : "private");
+    <div className="flex w-full flex-col gap-1.5">
+      <label className="text-sm font-medium text-foreground">Create as</label>
+      <Select
+        value={visibility}
+        onValueChange={(value) => {
+          onVisibilityChange(value as "public" | "private");
         }}
-        aria-label="Make public"
-      />
+      >
+        <TooltipProvider delayDuration={200}>
+          <Tooltip open={publicDisabled ? undefined : false}>
+            <TooltipTrigger asChild>
+              <SelectTrigger aria-label="Create as" className="w-full">
+                <SelectValue />
+              </SelectTrigger>
+            </TooltipTrigger>
+            <TooltipContent side="top">
+              <p className="text-xs">Public agent limit reached.</p>
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+        <SelectContent>
+          <SelectItem value="private">Private</SelectItem>
+          <SelectItem value="public" disabled={publicDisabled}>
+            {publicDisabled ? "Public (limit reached)" : "Public"}
+          </SelectItem>
+        </SelectContent>
+      </Select>
     </div>
   );
 }

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-jobs-page-interaction.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-jobs-page-interaction.test.tsx
@@ -10,11 +10,13 @@ import {
 import { pathname } from "../../../signals/location.ts";
 import { createMockApi } from "../../../mocks/msw-contract.ts";
 import {
+  type ZeroAgentRequest,
   zeroAgentsMainContract,
   zeroAgentInstructionsContract,
 } from "@vm0/api-contracts/contracts/zero-agents";
 import { zeroTeamContract } from "@vm0/api-contracts/contracts/zero-team";
 import { setMockTeam } from "../../../mocks/handlers/api-agents.ts";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 
 const context = testContext();
 const mockApi = createMockApi(context);
@@ -124,6 +126,58 @@ describe("zero jobs page - create agent dialog", () => {
     await waitFor(() => {
       expect(screen.getByText("Marketing Bot")).toBeInTheDocument();
     });
+  });
+
+  it("creates private agents by default when private agents are enabled", async () => {
+    let capturedPayload: ZeroAgentRequest | null = null;
+    server.use(
+      mockApi(zeroAgentsMainContract.create, ({ body, respond }) => {
+        capturedPayload = body;
+        return respond(201, {
+          agentId: "new-agent-id",
+          ownerId: "test-user-123",
+          description: null,
+          displayName: "Private Bot",
+          sound: null,
+          avatarUrl: null,
+          permissionPolicies: null,
+          customSkills: [],
+        });
+      }),
+      mockApi(zeroAgentInstructionsContract.update, ({ respond }) => {
+        return respond(200, {
+          agentId: "new-agent-id",
+          ownerId: "test-user-123",
+          description: null,
+          displayName: "Private Bot",
+          sound: null,
+          avatarUrl: null,
+          permissionPolicies: null,
+          customSkills: [],
+        });
+      }),
+    );
+    mockTeamAPI();
+    detachedSetupPage({
+      context,
+      path: "/agents",
+      featureSwitches: { [FeatureSwitchKey.PrivateAgents]: true },
+    });
+    await openDialog();
+
+    expect(screen.getByText("Create as")).toBeInTheDocument();
+    expect(
+      screen.getByRole("combobox", { name: "Create as" }),
+    ).toHaveTextContent("Private");
+
+    const input = screen.getByPlaceholderText("e.g. Research Assistant");
+    await fill(input, "Private Bot");
+    click(screen.getByText("Create"));
+
+    await waitFor(() => {
+      expect(capturedPayload).toBeTruthy();
+    });
+    expect(capturedPayload!.visibility).toBe("private");
   });
 
   it("closes the dialog when cancel is clicked (AGENT-D-015)", async () => {


### PR DESCRIPTION
## Summary
- Replace the create-agent "Make public" switch with a lower-emphasis "Create as" select
- Default new agent visibility state to private when the private-agents UI is available
- Keep public creation behavior unchanged when the feature is disabled, and add coverage for the private default

## Tests
- npx pnpm@10.33.4 --filter @vm0/app check-types
- npx pnpm@10.33.4 --filter @vm0/app lint
- npx pnpm@10.33.4 --filter @vm0/app exec vitest run src/views/zero-page/__tests__/zero-jobs-page-interaction.test.tsx --reporter=verbose