### PR TITLE
feat: harden cli auth lifecycle

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-authorize.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-authorize.test.ts
@@ -350,6 +350,34 @@ describe("GET /api/zero/connectors/:type/authorize", () => {
     );
   });
 
+  it("keeps existing local connector state when OAuth is not configured", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    orgIds.push(orgId);
+    mockOptionalEnv("GH_OAUTH_CLIENT_ID", undefined);
+    const db = store.set(writeDb$);
+    const [connector] = await db
+      .insert(connectors)
+      .values({ orgId, userId, type: "github", authMethod: "oauth" })
+      .returning({ id: connectors.id });
+    expect(connector).toBeDefined();
+
+    mocks.clerk.session(userId, orgId);
+    const app = createApp({ signal: context.signal });
+    const response = await app.request(authorizeUrl("github"), {
+      method: "GET",
+      headers: sessionHeaders(),
+    });
+
+    expect(response.status).toBe(500);
+    const survivors = await db
+      .select()
+      .from(connectors)
+      .where(eq(connectors.id, connector!.id));
+    expect(survivors).toHaveLength(1);
+    expect(context.mocks.ably.publish).not.toHaveBeenCalled();
+  });
+
   it("best-effort revokes GitHub grants before local cleanup", async () => {
     const userId = `user_${randomUUID()}`;
     const orgId = `org_${randomUUID()}`;

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-cli-auth-stripe.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-cli-auth-stripe.test.ts
@@ -952,6 +952,45 @@ describe("CLI auth for Stripe connector routes", () => {
     expect(calls.stop).toHaveLength(1);
   });
 
+  it("does not cancel pending CLI auth when deleting a missing connector", async () => {
+    const { userId, orgId } = await setupUser();
+    const calls = mockStripeCliSandbox({ configApiKey: "rk_test_imported" });
+
+    const start = await accept(
+      client().start({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { mode: "test" },
+      }),
+      [200],
+    );
+    await accept(
+      zeroConnectorsByTypeClient().delete({
+        headers: { authorization: "Bearer clerk-session" },
+        params: { type: "stripe" },
+      }),
+      [404],
+    );
+
+    expect(calls.stop).toHaveLength(0);
+    const session = await onlyCliAuthStripeSession(userId, orgId);
+    expect(session.status).toBe("awaiting_user_approval");
+
+    const complete = await accept(
+      client().complete({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { sessionToken: start.body.sessionToken },
+      }),
+      [200],
+    );
+
+    expect(complete.body.status).toBe("complete");
+    expect(calls.run).toHaveLength(2);
+    expect(calls.read).toHaveLength(1);
+    expect(calls.stop).toHaveLength(1);
+    const secret = await stripeTokenSecret(userId, orgId);
+    expect(decryptSecretValue(secret!.encryptedValue)).toBe("rk_test_imported");
+  });
+
   it("keeps a stale CLI auth completion from replacing a Stripe OAuth reconnect", async () => {
     const { userId, orgId } = await setupUser();
     const calls = mockStripeCliSandbox({ configApiKey: "rk_test_stale" });

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-cli-auth-stripe.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-cli-auth-stripe.test.ts
@@ -1,6 +1,11 @@
 import { randomUUID } from "node:crypto";
 
+import { zeroConnectorsByTypeContract } from "@vm0/api-contracts/contracts/zero-connectors";
 import { zeroCliAuthStripeContract } from "@vm0/api-contracts/contracts/zero-connectors-cli-auth-stripe";
+import {
+  zeroSecretsByNameContract,
+  zeroSecretsContract,
+} from "@vm0/api-contracts/contracts/zero-secrets";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { connectorCliAuthSessions } from "@vm0/db/schema/connector-cli-auth-session";
 import { connectors } from "@vm0/db/schema/connector";
@@ -28,6 +33,7 @@ import {
 } from "../../external/sandbox";
 import { writeDb$ } from "../../external/db";
 import { decryptSecretValue } from "../../services/crypto.utils";
+import { upsertOAuthConnector$ } from "../../services/zero-connector-data.service";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
 
 const context = testContext();
@@ -36,6 +42,18 @@ const mocks = createZeroRouteMocks(context);
 
 function client() {
   return setupApp({ context })(zeroCliAuthStripeContract);
+}
+
+function zeroSecretsClient() {
+  return setupApp({ context })(zeroSecretsContract);
+}
+
+function zeroSecretByNameClient() {
+  return setupApp({ context })(zeroSecretsByNameContract);
+}
+
+function zeroConnectorsByTypeClient() {
+  return setupApp({ context })(zeroConnectorsByTypeContract);
 }
 
 function textOutput(text: string): BoundedTextOutput {
@@ -126,12 +144,15 @@ function mockStripeCliSandbox(
     readonly startNextStep?: string;
     readonly startVerificationCode?: string;
     readonly startStderr?: string;
+    readonly startResults?: readonly CommandResultInput[];
     readonly completeExitCode?: number;
     readonly completeResults?: readonly CommandResultInput[];
     readonly configApiKey?: string;
   } = {},
 ) {
-  const handle = { sandboxId: "sandbox_stripe_cli_auth_test" };
+  const firstSandboxId = "sandbox_stripe_cli_auth_test";
+  let createdSandboxCount = 0;
+  const startResults = [...(args.startResults ?? [])];
   const completeResults = [...(args.completeResults ?? [])];
   const calls = {
     create: [] as CreateSandboxOptions[],
@@ -152,7 +173,12 @@ function mockStripeCliSandbox(
   mockSandboxClient({
     create(options = {}) {
       calls.create.push(options);
-      return Promise.resolve(handle);
+      const sandboxId =
+        createdSandboxCount === 0
+          ? firstSandboxId
+          : `${firstSandboxId}_${String(createdSandboxCount + 1)}`;
+      createdSandboxCount += 1;
+      return Promise.resolve({ sandboxId });
     },
     get(sandboxId) {
       return Promise.resolve({ sandboxId });
@@ -161,6 +187,10 @@ function mockStripeCliSandbox(
       calls.run.push({ handle: commandHandle, options });
       const script = options.args?.[1] ?? "";
       if (script.includes("--non-interactive")) {
+        const startResult = startResults.shift();
+        if (startResult) {
+          return Promise.resolve(resolveCommandResult(startResult));
+        }
         return Promise.resolve(
           commandResult({
             sandboxId: commandHandle.sandboxId,
@@ -285,6 +315,46 @@ async function onlyCliAuthStripeSession(userId: string, orgId: string) {
   const rows = await cliAuthStripeSessions(userId, orgId);
   expect(rows).toHaveLength(1);
   return rows[0]!;
+}
+
+async function stripeTokenSecret(userId: string, orgId: string) {
+  const [secret] = await store
+    .set(writeDb$)
+    .select({
+      encryptedValue: secrets.encryptedValue,
+      description: secrets.description,
+      type: secrets.type,
+    })
+    .from(secrets)
+    .where(
+      and(
+        eq(secrets.orgId, orgId),
+        eq(secrets.userId, userId),
+        eq(secrets.name, "STRIPE_TOKEN"),
+        eq(secrets.type, "user"),
+      ),
+    )
+    .limit(1);
+  return secret ?? null;
+}
+
+async function stripeConnector(userId: string, orgId: string) {
+  const [connector] = await store
+    .set(writeDb$)
+    .select({
+      authMethod: connectors.authMethod,
+      externalId: connectors.externalId,
+    })
+    .from(connectors)
+    .where(
+      and(
+        eq(connectors.orgId, orgId),
+        eq(connectors.userId, userId),
+        eq(connectors.type, "stripe"),
+      ),
+    )
+    .limit(1);
+  return connector ?? null;
 }
 
 describe("CLI auth for Stripe connector routes", () => {
@@ -421,6 +491,132 @@ describe("CLI auth for Stripe connector routes", () => {
     });
     expect(session.encryptedProviderState).toBeTruthy();
     expect(session.encryptedProviderState).not.toContain("poll-token");
+  });
+
+  it("reuses an active same-mode CLI auth session instead of starting another sandbox", async () => {
+    const { userId, orgId } = await setupUser();
+    const calls = mockStripeCliSandbox();
+
+    const firstStart = await accept(
+      client().start({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { mode: "test" },
+      }),
+      [200],
+    );
+    const secondStart = await accept(
+      client().start({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { mode: "test" },
+      }),
+      [200],
+    );
+
+    expect(secondStart.body).toMatchObject({
+      type: "stripe",
+      status: "pending",
+      mode: "test",
+      browserUrl: firstStart.body.browserUrl,
+      verificationCode: firstStart.body.verificationCode,
+    });
+    expect(calls.create).toHaveLength(1);
+    expect(calls.run).toHaveLength(1);
+    expect(calls.stop).toHaveLength(0);
+
+    const session = await onlyCliAuthStripeSession(userId, orgId);
+    expect(session.status).toBe("awaiting_user_approval");
+  });
+
+  it("does not start another sandbox while the first start is still initializing", async () => {
+    const { userId, orgId } = await setupUser();
+    const startCommandStarted = deferred<void>();
+    const startCommandResult = deferred<SandboxCommandResult>();
+    const calls = mockStripeCliSandbox({
+      startResults: [
+        () => {
+          startCommandStarted.resolve();
+          return startCommandResult.promise;
+        },
+      ],
+    });
+
+    const firstStart = accept(
+      client().start({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { mode: "test" },
+      }),
+      [200],
+    );
+    await startCommandStarted.promise;
+
+    const secondStart = await accept(
+      client().start({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { mode: "test" },
+      }),
+      [503],
+    );
+
+    expect(secondStart.body.error.code).toBe("CLI_AUTH_STRIPE_UNAVAILABLE");
+    expect(secondStart.body.error.message).toBe(
+      "CLI auth for Stripe session is already starting",
+    );
+    startCommandResult.resolve(
+      commandResult({ exitCode: 0, stdout: startOutput() }),
+    );
+    await firstStart;
+
+    expect(calls.create).toHaveLength(1);
+    expect(calls.run).toHaveLength(1);
+    expect(calls.stop).toHaveLength(0);
+
+    const session = await onlyCliAuthStripeSession(userId, orgId);
+    expect(session.status).toBe("awaiting_user_approval");
+  });
+
+  it("supersedes an active CLI auth session when the requested mode changes", async () => {
+    const { userId, orgId } = await setupUser();
+    const calls = mockStripeCliSandbox();
+
+    await accept(
+      client().start({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { mode: "test" },
+      }),
+      [200],
+    );
+    const liveStart = await accept(
+      client().start({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { mode: "live" },
+      }),
+      [200],
+    );
+
+    expect(liveStart.body.mode).toBe("live");
+    expect(calls.create).toHaveLength(2);
+    expect(calls.run).toHaveLength(2);
+    expect(calls.stop).toHaveLength(1);
+
+    const sessions = await cliAuthStripeSessions(userId, orgId);
+    expect(sessions).toHaveLength(2);
+    const cancelled = sessions.find((session) => {
+      return session.status === "cancelled";
+    });
+    const active = sessions.find((session) => {
+      return session.status === "awaiting_user_approval";
+    });
+    expect(cancelled).toMatchObject({
+      status: "cancelled",
+      errorMessage: "CLI auth for Stripe session was superseded",
+    });
+    expect(cancelled?.approvalUrl).toBeNull();
+    expect(cancelled?.verificationCode).toBeNull();
+    expect(cancelled?.encryptedProviderState).toBeNull();
+    expect(active).toMatchObject({
+      status: "awaiting_user_approval",
+      sandboxId: "sandbox_stripe_cli_auth_test_2",
+    });
   });
 
   it("stops the sandbox when Stripe returns an unexpected completion URL", async () => {
@@ -600,6 +796,210 @@ describe("CLI auth for Stripe connector routes", () => {
     expect(session.status).toBe("imported");
     expect(session.completedAt).toBeInstanceOf(Date);
     expect(session.errorMessage).toBeNull();
+    expect(session.approvalUrl).toBeNull();
+    expect(session.verificationCode).toBeNull();
+    expect(session.encryptedProviderState).toBeNull();
+  });
+
+  it("keeps a stale CLI auth completion from overwriting a manually set STRIPE_TOKEN", async () => {
+    const { userId, orgId } = await setupUser();
+    const calls = mockStripeCliSandbox({ configApiKey: "rk_test_stale" });
+
+    const start = await accept(
+      client().start({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { mode: "test" },
+      }),
+      [200],
+    );
+    await accept(
+      zeroSecretsClient().set({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          name: "STRIPE_TOKEN",
+          value: "rk_test_manual",
+          description: "Manual Stripe token",
+        },
+      }),
+      [200],
+    );
+
+    expect(calls.stop).toHaveLength(1);
+    const complete = await accept(
+      client().complete({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { sessionToken: start.body.sessionToken },
+      }),
+      [400],
+    );
+
+    expect(complete.body.error.message).toBe(
+      "CLI auth for Stripe session is not active",
+    );
+    expect(calls.run).toHaveLength(1);
+    expect(calls.read).toHaveLength(0);
+    expect(calls.stop).toHaveLength(1);
+
+    const secret = await stripeTokenSecret(userId, orgId);
+    expect(secret).toMatchObject({
+      description: "Manual Stripe token",
+      type: "user",
+    });
+    expect(decryptSecretValue(secret!.encryptedValue)).toBe("rk_test_manual");
+
+    const session = await onlyCliAuthStripeSession(userId, orgId);
+    expect(session).toMatchObject({
+      status: "cancelled",
+      errorMessage:
+        "CLI auth for Stripe session was cancelled because Stripe credentials changed",
+    });
+    expect(session.approvalUrl).toBeNull();
+    expect(session.verificationCode).toBeNull();
+    expect(session.encryptedProviderState).toBeNull();
+  });
+
+  it("keeps a stale CLI auth completion from recreating a deleted STRIPE_TOKEN", async () => {
+    const { userId, orgId } = await setupUser();
+    const calls = mockStripeCliSandbox({ configApiKey: "rk_test_stale" });
+
+    await accept(
+      zeroSecretsClient().set({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          name: "STRIPE_TOKEN",
+          value: "rk_test_existing",
+        },
+      }),
+      [200],
+    );
+    const start = await accept(
+      client().start({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { mode: "test" },
+      }),
+      [200],
+    );
+    await accept(
+      zeroSecretByNameClient().delete({
+        headers: { authorization: "Bearer clerk-session" },
+        params: { name: "STRIPE_TOKEN" },
+      }),
+      [204],
+    );
+
+    expect(calls.stop).toHaveLength(1);
+    const complete = await accept(
+      client().complete({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { sessionToken: start.body.sessionToken },
+      }),
+      [400],
+    );
+
+    expect(complete.body.error.message).toBe(
+      "CLI auth for Stripe session is not active",
+    );
+    await expect(stripeTokenSecret(userId, orgId)).resolves.toBeNull();
+    expect(calls.run).toHaveLength(1);
+    expect(calls.read).toHaveLength(0);
+    expect(calls.stop).toHaveLength(1);
+  });
+
+  it("keeps a stale CLI auth completion from recreating STRIPE_TOKEN after connector disconnect", async () => {
+    const { userId, orgId } = await setupUser();
+    const calls = mockStripeCliSandbox({ configApiKey: "rk_test_stale" });
+
+    await accept(
+      zeroSecretsClient().set({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          name: "STRIPE_TOKEN",
+          value: "rk_test_existing",
+        },
+      }),
+      [200],
+    );
+    const start = await accept(
+      client().start({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { mode: "test" },
+      }),
+      [200],
+    );
+    await accept(
+      zeroConnectorsByTypeClient().delete({
+        headers: { authorization: "Bearer clerk-session" },
+        params: { type: "stripe" },
+      }),
+      [204],
+    );
+
+    expect(calls.stop).toHaveLength(1);
+    const complete = await accept(
+      client().complete({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { sessionToken: start.body.sessionToken },
+      }),
+      [400],
+    );
+
+    expect(complete.body.error.message).toBe(
+      "CLI auth for Stripe session is not active",
+    );
+    await expect(stripeTokenSecret(userId, orgId)).resolves.toBeNull();
+    expect(calls.run).toHaveLength(1);
+    expect(calls.read).toHaveLength(0);
+    expect(calls.stop).toHaveLength(1);
+  });
+
+  it("keeps a stale CLI auth completion from replacing a Stripe OAuth reconnect", async () => {
+    const { userId, orgId } = await setupUser();
+    const calls = mockStripeCliSandbox({ configApiKey: "rk_test_stale" });
+
+    const start = await accept(
+      client().start({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { mode: "test" },
+      }),
+      [200],
+    );
+    await store.set(
+      upsertOAuthConnector$,
+      {
+        orgId,
+        userId,
+        type: "stripe",
+        accessToken: "oauth_access",
+        userInfo: {
+          id: "acct_oauth",
+          username: null,
+          email: null,
+        },
+        oauthScopes: ["read_write"],
+      },
+      context.signal,
+    );
+
+    expect(calls.stop).toHaveLength(1);
+    const complete = await accept(
+      client().complete({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { sessionToken: start.body.sessionToken },
+      }),
+      [400],
+    );
+
+    expect(complete.body.error.message).toBe(
+      "CLI auth for Stripe session is not active",
+    );
+    await expect(stripeConnector(userId, orgId)).resolves.toStrictEqual({
+      authMethod: "oauth",
+      externalId: "acct_oauth",
+    });
+    await expect(stripeTokenSecret(userId, orgId)).resolves.toBeNull();
+    expect(calls.run).toHaveLength(1);
+    expect(calls.read).toHaveLength(0);
+    expect(calls.stop).toHaveLength(1);
   });
 
   it("replaces existing Stripe OAuth local state while importing STRIPE_TOKEN", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-cli-auth-stripe.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-cli-auth-stripe.test.ts
@@ -1041,6 +1041,50 @@ describe("CLI auth for Stripe connector routes", () => {
     expect(calls.stop).toHaveLength(1);
   });
 
+  it("removes STRIPE_TOKEN when Stripe OAuth reconnect wins after CLI auth imported", async () => {
+    const { userId, orgId } = await setupUser();
+    mockStripeCliSandbox({ configApiKey: "rk_test_stale" });
+
+    const start = await accept(
+      client().start({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { mode: "test" },
+      }),
+      [200],
+    );
+    await accept(
+      client().complete({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { sessionToken: start.body.sessionToken },
+      }),
+      [200],
+    );
+    await expect(stripeTokenSecret(userId, orgId)).resolves.not.toBeNull();
+
+    await store.set(
+      upsertOAuthConnector$,
+      {
+        orgId,
+        userId,
+        type: "stripe",
+        accessToken: "oauth_access",
+        userInfo: {
+          id: "acct_oauth",
+          username: null,
+          email: null,
+        },
+        oauthScopes: ["read_write"],
+      },
+      context.signal,
+    );
+
+    await expect(stripeConnector(userId, orgId)).resolves.toStrictEqual({
+      authMethod: "oauth",
+      externalId: "acct_oauth",
+    });
+    await expect(stripeTokenSecret(userId, orgId)).resolves.toBeNull();
+  });
+
   it("replaces existing Stripe OAuth local state while importing STRIPE_TOKEN", async () => {
     const { userId, orgId } = await setupUser();
     const db = store.set(writeDb$);

--- a/turbo/apps/api/src/signals/routes/zero-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/zero-connectors.ts
@@ -610,13 +610,6 @@ export function createAuthorizeConnectorInner(route: ConnectorAuthorizeRoute) {
       );
     }
 
-    await set(
-      deleteZeroConnectorLocalState$,
-      { orgId: auth.orgId, userId: auth.userId, type },
-      signal,
-    );
-    signal.throwIfAborted();
-
     const state = generateState();
     const redirectUri = `${origin}/api/connectors/${type}/callback`;
     const envKeys = getConnectorOAuthEnvKeys(type);
@@ -635,6 +628,13 @@ export function createAuthorizeConnectorInner(route: ConnectorAuthorizeRoute) {
     if (!authResult) {
       return jsonResponse({ error: `${type} OAuth not configured` }, 500);
     }
+
+    await set(
+      deleteZeroConnectorLocalState$,
+      { orgId: auth.orgId, userId: auth.userId, type },
+      signal,
+    );
+    signal.throwIfAborted();
 
     const response = redirectResponse(authResult.url);
     response.headers.append(

--- a/turbo/apps/api/src/signals/routes/zero-secrets-delete.ts
+++ b/turbo/apps/api/src/signals/routes/zero-secrets-delete.ts
@@ -9,6 +9,10 @@ import { pathParamsOf } from "../context/request";
 import { writeDb$ } from "../external/db";
 import { notFound } from "../../lib/error";
 import type { RouteEntry } from "../route";
+import {
+  hasCliAuthInvalidatorsForSecretName,
+  invalidateActiveCliAuthSessionsForSecretName,
+} from "../services/cli-auth-invalidation.service";
 
 const deleteInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   const auth = get(organizationAuthContext$);
@@ -16,6 +20,35 @@ const deleteInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   signal.throwIfAborted();
 
   const writeDb = set(writeDb$);
+  if (hasCliAuthInvalidatorsForSecretName(params.name)) {
+    const [existing] = await writeDb
+      .select({ id: secrets.id })
+      .from(secrets)
+      .where(
+        and(
+          eq(secrets.orgId, auth.orgId),
+          eq(secrets.userId, auth.userId),
+          eq(secrets.name, params.name),
+          eq(secrets.type, "user"),
+        ),
+      )
+      .limit(1);
+    signal.throwIfAborted();
+
+    if (!existing) {
+      return notFound(`Secret "${params.name}" not found`);
+    }
+
+    await invalidateActiveCliAuthSessionsForSecretName({
+      writeDb,
+      orgId: auth.orgId,
+      userId: auth.userId,
+      secretName: params.name,
+      signal,
+    });
+    signal.throwIfAborted();
+  }
+
   // Match web's filter: only user-type secrets are deletable through this
   // route. Connector / model-provider secrets are managed via dedicated routes.
   const deleted = await writeDb

--- a/turbo/apps/api/src/signals/services/cli-auth-invalidation.service.ts
+++ b/turbo/apps/api/src/signals/services/cli-auth-invalidation.service.ts
@@ -1,0 +1,63 @@
+import type { ConnectorType } from "@vm0/connectors/connectors";
+
+import type { Db } from "../external/db";
+import { invalidateActiveCliAuthStripeSessions } from "./cli-auth-stripe.service";
+
+type CliAuthInvalidationArgs = {
+  readonly writeDb: Db;
+  readonly orgId: string;
+  readonly userId: string;
+  readonly signal: AbortSignal;
+};
+
+type CliAuthInvalidator = (args: CliAuthInvalidationArgs) => Promise<void>;
+
+const cliAuthInvalidatorsBySecretName = Object.freeze<
+  Readonly<Partial<Record<string, readonly CliAuthInvalidator[]>>>
+>({
+  STRIPE_TOKEN: Object.freeze([invalidateActiveCliAuthStripeSessions]),
+});
+
+const cliAuthInvalidatorsByConnectorType = Object.freeze<
+  Readonly<Partial<Record<ConnectorType, readonly CliAuthInvalidator[]>>>
+>({
+  stripe: Object.freeze([invalidateActiveCliAuthStripeSessions]),
+});
+
+async function runCliAuthInvalidators(
+  invalidators: readonly CliAuthInvalidator[],
+  args: CliAuthInvalidationArgs,
+) {
+  const seen = new Set<CliAuthInvalidator>();
+  for (const invalidate of invalidators) {
+    if (seen.has(invalidate)) {
+      continue;
+    }
+    seen.add(invalidate);
+    await invalidate(args);
+  }
+}
+
+export function hasCliAuthInvalidatorsForSecretName(
+  secretName: string,
+): boolean {
+  return Boolean(cliAuthInvalidatorsBySecretName[secretName]);
+}
+
+export async function invalidateActiveCliAuthSessionsForSecretName(
+  args: CliAuthInvalidationArgs & { readonly secretName: string },
+) {
+  await runCliAuthInvalidators(
+    cliAuthInvalidatorsBySecretName[args.secretName] ?? [],
+    args,
+  );
+}
+
+export async function invalidateActiveCliAuthSessionsForConnectorType(
+  args: CliAuthInvalidationArgs & { readonly connectorType: ConnectorType },
+) {
+  await runCliAuthInvalidators(
+    cliAuthInvalidatorsByConnectorType[args.connectorType] ?? [],
+    args,
+  );
+}

--- a/turbo/apps/api/src/signals/services/cli-auth-stripe.service.ts
+++ b/turbo/apps/api/src/signals/services/cli-auth-stripe.service.ts
@@ -501,14 +501,15 @@ async function markCliAuthStripeSessionError(args: {
   readonly expectedStatus?: ConnectorCliAuthSessionStatus;
   readonly expectedUpdatedAt?: Date;
 }) {
-  const where =
-    args.expectedStatus && args.expectedUpdatedAt
-      ? and(
-          eq(connectorCliAuthSessions.id, args.sessionId),
-          eq(connectorCliAuthSessions.status, args.expectedStatus),
-          eq(connectorCliAuthSessions.updatedAt, args.expectedUpdatedAt),
-        )
-      : eq(connectorCliAuthSessions.id, args.sessionId);
+  const predicates = [eq(connectorCliAuthSessions.id, args.sessionId)];
+  if (args.expectedStatus) {
+    predicates.push(eq(connectorCliAuthSessions.status, args.expectedStatus));
+  }
+  if (args.expectedUpdatedAt) {
+    predicates.push(
+      eq(connectorCliAuthSessions.updatedAt, args.expectedUpdatedAt),
+    );
+  }
   const [updated] = await args.writeDb
     .update(connectorCliAuthSessions)
     .set(
@@ -518,7 +519,7 @@ async function markCliAuthStripeSessionError(args: {
         message: args.message,
       }),
     )
-    .where(where)
+    .where(and(...predicates))
     .returning({ id: connectorCliAuthSessions.id });
   return Boolean(updated);
 }
@@ -539,7 +540,6 @@ async function markCliAuthStripeSessionExpired(args: {
       and(
         eq(connectorCliAuthSessions.id, args.session.id),
         eq(connectorCliAuthSessions.status, args.session.status),
-        eq(connectorCliAuthSessions.updatedAt, args.session.updatedAt),
       ),
     )
     .returning({ id: connectorCliAuthSessions.id });
@@ -596,7 +596,6 @@ async function createCliAuthStripeSandbox(args: {
       sessionId: args.session.id,
       message: createResult.error.message,
       expectedStatus: args.session.status,
-      expectedUpdatedAt: args.session.updatedAt,
     });
     args.signal.throwIfAborted();
     return {
@@ -621,7 +620,6 @@ async function createCliAuthStripeSandbox(args: {
         and(
           eq(connectorCliAuthSessions.id, args.session.id),
           eq(connectorCliAuthSessions.status, "initializing"),
-          eq(connectorCliAuthSessions.updatedAt, args.session.updatedAt),
         ),
       )
       .returning();

--- a/turbo/apps/api/src/signals/services/cli-auth-stripe.service.ts
+++ b/turbo/apps/api/src/signals/services/cli-auth-stripe.service.ts
@@ -423,7 +423,14 @@ async function terminalizeCliAuthStripeSessions(args: {
         message: args.message,
       }),
     )
-    .where(inArray(connectorCliAuthSessions.id, [...args.sessionIds]))
+    .where(
+      and(
+        inArray(connectorCliAuthSessions.id, [...args.sessionIds]),
+        inArray(connectorCliAuthSessions.status, [
+          ...CLI_AUTH_STRIPE_ACTIVE_STATUSES,
+        ]),
+      ),
+    )
     .returning({ sandboxId: connectorCliAuthSessions.sandboxId });
   return sandboxHandlesFromIds(
     rows.map((row) => {
@@ -1136,6 +1143,12 @@ async function importCliAuthStripeConnector(args: {
   const writeDb = args.set(writeDb$);
   const description = `Stripe CLI ${args.mode} mode API key`;
   await writeDb.transaction(async (tx) => {
+    await lockCliAuthStripeOwner({
+      db: tx,
+      orgId: args.orgId,
+      userId: args.userId,
+    });
+
     await tx
       .delete(connectors)
       .where(

--- a/turbo/apps/api/src/signals/services/cli-auth-stripe.service.ts
+++ b/turbo/apps/api/src/signals/services/cli-auth-stripe.service.ts
@@ -14,7 +14,7 @@ import {
 import { connectors } from "@vm0/db/schema/connector";
 import { connectorCliAuthSessions } from "@vm0/db/schema/connector-cli-auth-session";
 import { secrets } from "@vm0/db/schema/secret";
-import { and, eq, inArray, lt, or } from "drizzle-orm";
+import { and, eq, inArray, lt, or, sql } from "drizzle-orm";
 import { safeAsync, safeJsonParse } from "../utils";
 import { writeDb$, type Db } from "../external/db";
 import { publishUserSignal } from "../external/realtime";
@@ -35,6 +35,7 @@ const CLI_AUTH_STRIPE_TIMEOUT_MS = 15 * 60 * 1000;
 const CLI_AUTH_STRIPE_SESSION_TTL_SECONDS = 10 * 60;
 const CLI_AUTH_STRIPE_POLL_INTERVAL_SECONDS = 5;
 const CLI_AUTH_STRIPE_COMPLETE_TIMEOUT_SECONDS = 15;
+const CLI_AUTH_STRIPE_INITIALIZING_STALE_MS = 2 * 60 * 1000;
 const CLI_AUTH_STRIPE_COMPLETING_STALE_MS = 2 * 60 * 1000;
 const CLI_AUTH_STRIPE_OUTPUT_LIMIT_BYTES = 16 * 1024;
 const CLI_AUTH_STRIPE_CONFIG_LIMIT_BYTES = 16 * 1024;
@@ -125,7 +126,23 @@ type CliAuthStripeErrorResult = Extract<
   CliAuthStripeCompleteResult,
   { readonly status: "error" }
 >;
+type CliAuthStripePendingResult = Extract<
+  CliAuthStripeCompleteResult,
+  { readonly status: "pending" }
+>;
 type ConnectorCliAuthSession = typeof connectorCliAuthSessions.$inferSelect;
+type ConnectorCliAuthSessionStatus = ConnectorCliAuthSession["status"];
+
+const CLI_AUTH_STRIPE_ACTIVE_STATUSES = [
+  "initializing",
+  "awaiting_user_approval",
+  "completing",
+] as const satisfies readonly ConnectorCliAuthSessionStatus[];
+
+const CLI_AUTH_STRIPE_SUPERSEDED_MESSAGE =
+  "CLI auth for Stripe session was superseded";
+const CLI_AUTH_STRIPE_CREDENTIALS_CHANGED_MESSAGE =
+  "CLI auth for Stripe session was cancelled because Stripe credentials changed";
 
 type PreparedCliAuthStripeCompletion =
   | {
@@ -137,6 +154,23 @@ type PreparedCliAuthStripeCompletion =
   | {
       readonly ok: false;
       readonly result: CliAuthStripeCompleteResult;
+    };
+
+type PreparedCliAuthStripeStart =
+  | {
+      readonly kind: "created";
+      readonly session: ConnectorCliAuthSession;
+      readonly cleanupSandboxes: readonly SandboxHandle[];
+    }
+  | {
+      readonly kind: "reuse";
+      readonly result: Extract<CliAuthStripeStartResult, { readonly ok: true }>;
+      readonly cleanupSandboxes: readonly SandboxHandle[];
+    }
+  | {
+      readonly kind: "busy";
+      readonly result: CliAuthStripeStartFailureResult;
+      readonly cleanupSandboxes: readonly SandboxHandle[];
     };
 
 function startCommandScript(): string {
@@ -280,20 +314,213 @@ function sanitizeSessionError(message: string): string {
   return redactStripeCliAuthText(message).slice(0, 500);
 }
 
+function remainingSessionTtlSeconds(expiresAt: Date, now: Date): number {
+  return Math.max(1, Math.ceil((expiresAt.getTime() - now.getTime()) / 1000));
+}
+
+function sandboxHandlesFromIds(
+  sandboxIds: readonly (string | null)[],
+): readonly SandboxHandle[] {
+  return sandboxIds.flatMap((sandboxId) => {
+    return sandboxId ? [{ sandboxId }] : [];
+  });
+}
+
+async function cleanupCliAuthStripeSandboxes(args: {
+  readonly client: SandboxClient;
+  readonly sandboxes: readonly SandboxHandle[];
+  readonly reason: string;
+}) {
+  for (const sandbox of args.sandboxes) {
+    await cleanupSandboxSafely({
+      client: args.client,
+      sandbox,
+      reason: args.reason,
+    });
+  }
+}
+
+/**
+ * Serialize lifecycle mutations for one user's Stripe CLI auth flow.
+ *
+ * This follows the existing transaction-scoped advisory lock pattern used by
+ * queue, credit, and Stripe customer writes. The connector type/source suffix
+ * keeps the lock scope ready for future CLI auth providers.
+ */
+async function lockCliAuthStripeOwner(args: {
+  readonly db: Db;
+  readonly orgId: string;
+  readonly userId: string;
+}) {
+  await args.db.execute(
+    sql`SELECT pg_advisory_xact_lock(hashtext('cli_auth_stripe:' || ${args.orgId} || ':' || ${args.userId} || ':' || ${CLI_AUTH_STRIPE_CONNECTOR_TYPE} || ':' || ${CLI_AUTH_STRIPE_SOURCE}))`,
+  );
+}
+
+function cliAuthStripeOwnerWhere(args: {
+  readonly orgId: string;
+  readonly userId: string;
+}) {
+  return and(
+    eq(connectorCliAuthSessions.orgId, args.orgId),
+    eq(connectorCliAuthSessions.userId, args.userId),
+    eq(connectorCliAuthSessions.connectorType, CLI_AUTH_STRIPE_CONNECTOR_TYPE),
+    eq(connectorCliAuthSessions.source, CLI_AUTH_STRIPE_SOURCE),
+  );
+}
+
+function activeCliAuthStripeOwnerWhere(args: {
+  readonly orgId: string;
+  readonly userId: string;
+}) {
+  return and(
+    cliAuthStripeOwnerWhere(args),
+    inArray(connectorCliAuthSessions.status, [
+      ...CLI_AUTH_STRIPE_ACTIVE_STATUSES,
+    ]),
+  );
+}
+
+function terminalCliAuthStripeSessionSet(args: {
+  readonly status: Extract<
+    ConnectorCliAuthSessionStatus,
+    "cancelled" | "error" | "expired" | "imported"
+  >;
+  readonly now: Date;
+  readonly message?: string | null;
+}) {
+  return {
+    status: args.status,
+    approvalUrl: null,
+    verificationCode: null,
+    encryptedProviderState: null,
+    errorMessage: args.message ? sanitizeSessionError(args.message) : null,
+    completedAt: args.status === "imported" ? args.now : null,
+    cancelledAt: args.status === "cancelled" ? args.now : null,
+    updatedAt: args.now,
+  };
+}
+
+async function terminalizeCliAuthStripeSessions(args: {
+  readonly db: Db;
+  readonly sessionIds: readonly string[];
+  readonly status: Extract<
+    ConnectorCliAuthSessionStatus,
+    "cancelled" | "error" | "expired"
+  >;
+  readonly message?: string | null;
+  readonly now: Date;
+}): Promise<readonly SandboxHandle[]> {
+  if (args.sessionIds.length === 0) {
+    return [];
+  }
+  const rows = await args.db
+    .update(connectorCliAuthSessions)
+    .set(
+      terminalCliAuthStripeSessionSet({
+        status: args.status,
+        now: args.now,
+        message: args.message,
+      }),
+    )
+    .where(inArray(connectorCliAuthSessions.id, [...args.sessionIds]))
+    .returning({ sandboxId: connectorCliAuthSessions.sandboxId });
+  return sandboxHandlesFromIds(
+    rows.map((row) => {
+      return row.sandboxId;
+    }),
+  );
+}
+
+async function cancelActiveCliAuthStripeSessions(args: {
+  readonly db: Db;
+  readonly orgId: string;
+  readonly userId: string;
+  readonly now: Date;
+  readonly message: string;
+}): Promise<readonly SandboxHandle[]> {
+  const rows = await args.db
+    .update(connectorCliAuthSessions)
+    .set(
+      terminalCliAuthStripeSessionSet({
+        status: "cancelled",
+        now: args.now,
+        message: args.message,
+      }),
+    )
+    .where(
+      activeCliAuthStripeOwnerWhere({
+        orgId: args.orgId,
+        userId: args.userId,
+      }),
+    )
+    .returning({ sandboxId: connectorCliAuthSessions.sandboxId });
+  return sandboxHandlesFromIds(
+    rows.map((row) => {
+      return row.sandboxId;
+    }),
+  );
+}
+
+export async function invalidateActiveCliAuthStripeSessions(args: {
+  readonly writeDb: Db;
+  readonly orgId: string;
+  readonly userId: string;
+  readonly signal: AbortSignal;
+  readonly message?: string;
+}) {
+  const client = getVercelSandboxClient();
+  const now = nowDate();
+  const sandboxes = await args.writeDb.transaction(async (tx) => {
+    await lockCliAuthStripeOwner({
+      db: tx,
+      orgId: args.orgId,
+      userId: args.userId,
+    });
+    return cancelActiveCliAuthStripeSessions({
+      db: tx,
+      orgId: args.orgId,
+      userId: args.userId,
+      now,
+      message: args.message ?? CLI_AUTH_STRIPE_CREDENTIALS_CHANGED_MESSAGE,
+    });
+  });
+  args.signal.throwIfAborted();
+  await cleanupCliAuthStripeSandboxes({
+    client,
+    sandboxes,
+    reason: "stripe credentials changed",
+  });
+  args.signal.throwIfAborted();
+}
+
 async function markCliAuthStripeSessionError(args: {
   readonly writeDb: Db;
   readonly sessionId: string;
   readonly message: string;
+  readonly expectedStatus?: ConnectorCliAuthSessionStatus;
+  readonly expectedUpdatedAt?: Date;
 }) {
-  await args.writeDb
+  const where =
+    args.expectedStatus && args.expectedUpdatedAt
+      ? and(
+          eq(connectorCliAuthSessions.id, args.sessionId),
+          eq(connectorCliAuthSessions.status, args.expectedStatus),
+          eq(connectorCliAuthSessions.updatedAt, args.expectedUpdatedAt),
+        )
+      : eq(connectorCliAuthSessions.id, args.sessionId);
+  const [updated] = await args.writeDb
     .update(connectorCliAuthSessions)
-    .set({
-      status: "error",
-      errorMessage: sanitizeSessionError(args.message),
-      completedAt: null,
-      updatedAt: nowDate(),
-    })
-    .where(eq(connectorCliAuthSessions.id, args.sessionId));
+    .set(
+      terminalCliAuthStripeSessionSet({
+        status: "error",
+        now: nowDate(),
+        message: args.message,
+      }),
+    )
+    .where(where)
+    .returning({ id: connectorCliAuthSessions.id });
+  return Boolean(updated);
 }
 
 async function markCliAuthStripeSessionExpired(args: {
@@ -302,10 +529,12 @@ async function markCliAuthStripeSessionExpired(args: {
 }) {
   const [expired] = await args.writeDb
     .update(connectorCliAuthSessions)
-    .set({
-      status: "expired",
-      updatedAt: nowDate(),
-    })
+    .set(
+      terminalCliAuthStripeSessionSet({
+        status: "expired",
+        now: nowDate(),
+      }),
+    )
     .where(
       and(
         eq(connectorCliAuthSessions.id, args.session.id),
@@ -321,7 +550,6 @@ async function createCliAuthStripeSession(args: {
   readonly writeDb: Db;
   readonly orgId: string;
   readonly userId: string;
-  readonly signal: AbortSignal;
   readonly expiresAt: Date;
 }) {
   const [session] = await args.writeDb
@@ -334,8 +562,7 @@ async function createCliAuthStripeSession(args: {
       status: "initializing",
       expiresAt: args.expiresAt,
     })
-    .returning({ id: connectorCliAuthSessions.id });
-  args.signal.throwIfAborted();
+    .returning();
   if (!session) {
     throw new Error("Failed to create CLI auth for Stripe session");
   }
@@ -345,10 +572,14 @@ async function createCliAuthStripeSession(args: {
 async function createCliAuthStripeSandbox(args: {
   readonly writeDb: Db;
   readonly client: SandboxClient;
-  readonly sessionId: string;
+  readonly session: ConnectorCliAuthSession;
   readonly signal: AbortSignal;
 }): Promise<
-  | { readonly ok: true; readonly sandbox: SandboxHandle }
+  | {
+      readonly ok: true;
+      readonly sandbox: SandboxHandle;
+      readonly session: ConnectorCliAuthSession;
+    }
   | { readonly ok: false; readonly result: CliAuthStripeStartFailureResult }
 > {
   const createResult = await sandboxOperation("create", () => {
@@ -362,8 +593,10 @@ async function createCliAuthStripeSandbox(args: {
   if (!createResult.ok) {
     await markCliAuthStripeSessionError({
       writeDb: args.writeDb,
-      sessionId: args.sessionId,
+      sessionId: args.session.id,
       message: createResult.error.message,
+      expectedStatus: args.session.status,
+      expectedUpdatedAt: args.session.updatedAt,
     });
     args.signal.throwIfAborted();
     return {
@@ -384,15 +617,39 @@ async function createCliAuthStripeSandbox(args: {
         sandboxId: sandbox.sandboxId,
         updatedAt: nowDate(),
       })
-      .where(eq(connectorCliAuthSessions.id, args.sessionId));
+      .where(
+        and(
+          eq(connectorCliAuthSessions.id, args.session.id),
+          eq(connectorCliAuthSessions.status, "initializing"),
+          eq(connectorCliAuthSessions.updatedAt, args.session.updatedAt),
+        ),
+      )
+      .returning();
   });
   if ("error" in updateResult) {
     await cleanupSandbox(args.client, sandbox);
     throw updateResult.error;
   }
+  const updatedSession = updateResult.ok[0];
+  if (!updatedSession) {
+    await cleanupSandboxSafely({
+      client: args.client,
+      sandbox,
+      reason: "start session sandbox claim lost",
+    });
+    args.signal.throwIfAborted();
+    return {
+      ok: false,
+      result: {
+        ok: false,
+        code: "CLI_AUTH_STRIPE_UNAVAILABLE",
+        message: CLI_AUTH_STRIPE_SUPERSEDED_MESSAGE,
+      },
+    };
+  }
   args.signal.throwIfAborted();
 
-  return { ok: true, sandbox };
+  return { ok: true, sandbox, session: updatedSession };
 }
 
 async function parseCliAuthStripeStartOutput(
@@ -421,7 +678,7 @@ async function runCliAuthStripeStartInSandbox(args: {
   readonly writeDb: Db;
   readonly client: SandboxClient;
   readonly sandbox: SandboxHandle;
-  readonly sessionId: string;
+  readonly session: ConnectorCliAuthSession;
   readonly signal: AbortSignal;
 }): Promise<
   | { readonly ok: true; readonly output: StripeCliAuthStartOutput }
@@ -439,8 +696,10 @@ async function runCliAuthStripeStartInSandbox(args: {
   if (!runResult.ok) {
     await markCliAuthStripeSessionError({
       writeDb: args.writeDb,
-      sessionId: args.sessionId,
+      sessionId: args.session.id,
       message: runResult.error.message,
+      expectedStatus: args.session.status,
+      expectedUpdatedAt: args.session.updatedAt,
     });
     await cleanupSandbox(args.client, args.sandbox);
     args.signal.throwIfAborted();
@@ -461,8 +720,10 @@ async function runCliAuthStripeStartInSandbox(args: {
     );
     await markCliAuthStripeSessionError({
       writeDb: args.writeDb,
-      sessionId: args.sessionId,
+      sessionId: args.session.id,
       message,
+      expectedStatus: args.session.status,
+      expectedUpdatedAt: args.session.updatedAt,
     });
     await cleanupSandbox(args.client, args.sandbox);
     args.signal.throwIfAborted();
@@ -480,8 +741,10 @@ async function runCliAuthStripeStartInSandbox(args: {
   if (!parsedResult.ok) {
     await markCliAuthStripeSessionError({
       writeDb: args.writeDb,
-      sessionId: args.sessionId,
+      sessionId: args.session.id,
       message: parsedResult.message,
+      expectedStatus: args.session.status,
+      expectedUpdatedAt: args.session.updatedAt,
     });
     await cleanupSandbox(args.client, args.sandbox);
     args.signal.throwIfAborted();
@@ -500,11 +763,11 @@ async function runCliAuthStripeStartInSandbox(args: {
 
 async function markCliAuthStripeSessionAwaitingApproval(args: {
   readonly writeDb: Db;
-  readonly sessionId: string;
+  readonly session: ConnectorCliAuthSession;
   readonly output: StripeCliAuthStartOutput;
   readonly mode: StripeCliAuthMode;
 }) {
-  await args.writeDb
+  const [updated] = await args.writeDb
     .update(connectorCliAuthSessions)
     .set({
       status: "awaiting_user_approval",
@@ -519,7 +782,173 @@ async function markCliAuthStripeSessionAwaitingApproval(args: {
       errorMessage: null,
       updatedAt: nowDate(),
     })
-    .where(eq(connectorCliAuthSessions.id, args.sessionId));
+    .where(
+      and(
+        eq(connectorCliAuthSessions.id, args.session.id),
+        eq(connectorCliAuthSessions.status, "initializing"),
+        eq(connectorCliAuthSessions.updatedAt, args.session.updatedAt),
+      ),
+    )
+    .returning({ id: connectorCliAuthSessions.id });
+  return Boolean(updated);
+}
+
+function isFreshInitializingCliAuthStripeSession(
+  session: ConnectorCliAuthSession,
+  now: Date,
+): boolean {
+  return (
+    session.status === "initializing" &&
+    now.getTime() - session.updatedAt.getTime() <=
+      CLI_AUTH_STRIPE_INITIALIZING_STALE_MS &&
+    now <= session.expiresAt
+  );
+}
+
+function isFreshCompletingCliAuthStripeSession(
+  session: ConnectorCliAuthSession,
+  now: Date,
+): boolean {
+  return (
+    session.status === "completing" &&
+    !isStaleCompletingCliAuthStripeSession(session, now) &&
+    now <= session.expiresAt
+  );
+}
+
+async function reusableCliAuthStripeStartResult(args: {
+  readonly session: ConnectorCliAuthSession;
+  readonly mode: StripeCliAuthMode;
+  readonly now: Date;
+}): Promise<Extract<CliAuthStripeStartResult, { readonly ok: true }> | null> {
+  if (
+    args.session.status !== "awaiting_user_approval" ||
+    args.now > args.session.expiresAt ||
+    !args.session.sandboxId ||
+    !args.session.approvalUrl ||
+    !args.session.verificationCode
+  ) {
+    return null;
+  }
+  const providerState = await decodeProviderState(
+    args.session.encryptedProviderState,
+  );
+  if (!providerState || providerState.mode !== args.mode) {
+    return null;
+  }
+  return {
+    ok: true,
+    sessionToken: encodeSession({
+      version: 1,
+      sessionId: args.session.id,
+    }),
+    browserUrl: args.session.approvalUrl,
+    verificationCode: args.session.verificationCode,
+    mode: providerState.mode,
+    expiresIn: remainingSessionTtlSeconds(args.session.expiresAt, args.now),
+    interval: CLI_AUTH_STRIPE_POLL_INTERVAL_SECONDS,
+  };
+}
+
+function prepareCliAuthStripeStartSession(args: {
+  readonly writeDb: Db;
+  readonly orgId: string;
+  readonly userId: string;
+  readonly mode: StripeCliAuthMode;
+  readonly now: Date;
+}): Promise<PreparedCliAuthStripeStart> {
+  return args.writeDb.transaction(async (tx) => {
+    await lockCliAuthStripeOwner({
+      db: tx,
+      orgId: args.orgId,
+      userId: args.userId,
+    });
+
+    const activeSessions = await tx
+      .select()
+      .from(connectorCliAuthSessions)
+      .where(
+        activeCliAuthStripeOwnerWhere({
+          orgId: args.orgId,
+          userId: args.userId,
+        }),
+      )
+      .orderBy(connectorCliAuthSessions.createdAt);
+
+    const expiredSessionIds: string[] = [];
+    const cancelSessionIds: string[] = [];
+    let reusableResult: Extract<
+      CliAuthStripeStartResult,
+      { readonly ok: true }
+    > | null = null;
+    let hasFreshInProgressSession = false;
+
+    for (const session of activeSessions) {
+      if (args.now > session.expiresAt) {
+        expiredSessionIds.push(session.id);
+        continue;
+      }
+
+      const reusable = await reusableCliAuthStripeStartResult({
+        session,
+        mode: args.mode,
+        now: args.now,
+      });
+      if (reusable && !reusableResult) {
+        reusableResult = reusable;
+        continue;
+      }
+
+      if (
+        isFreshInitializingCliAuthStripeSession(session, args.now) ||
+        isFreshCompletingCliAuthStripeSession(session, args.now)
+      ) {
+        hasFreshInProgressSession = true;
+        continue;
+      }
+
+      cancelSessionIds.push(session.id);
+    }
+
+    const expiredSandboxes = await terminalizeCliAuthStripeSessions({
+      db: tx,
+      sessionIds: expiredSessionIds,
+      status: "expired",
+      now: args.now,
+    });
+    const cancelledSandboxes = await terminalizeCliAuthStripeSessions({
+      db: tx,
+      sessionIds: cancelSessionIds,
+      status: "cancelled",
+      message: CLI_AUTH_STRIPE_SUPERSEDED_MESSAGE,
+      now: args.now,
+    });
+    const cleanupSandboxes = [...expiredSandboxes, ...cancelledSandboxes];
+
+    if (hasFreshInProgressSession) {
+      return {
+        kind: "busy",
+        cleanupSandboxes,
+        result: {
+          ok: false,
+          code: "CLI_AUTH_STRIPE_UNAVAILABLE",
+          message: "CLI auth for Stripe session is already starting",
+        },
+      };
+    }
+
+    if (reusableResult) {
+      return { kind: "reuse", cleanupSandboxes, result: reusableResult };
+    }
+
+    const session = await createCliAuthStripeSession({
+      writeDb: tx,
+      orgId: args.orgId,
+      userId: args.userId,
+      expiresAt: tokenExpiresAt(args.now),
+    });
+    return { kind: "created", cleanupSandboxes, session };
+  });
 }
 
 export async function startCliAuthStripe(args: {
@@ -530,18 +959,31 @@ export async function startCliAuthStripe(args: {
   readonly signal: AbortSignal;
   readonly now?: Date;
 }): Promise<CliAuthStripeStartResult> {
-  const session = await createCliAuthStripeSession({
+  const now = args.now ?? nowDate();
+  const client = getVercelSandboxClient();
+  const prepared = await prepareCliAuthStripeStartSession({
     writeDb: args.writeDb,
     orgId: args.orgId,
     userId: args.userId,
-    signal: args.signal,
-    expiresAt: tokenExpiresAt(args.now ?? nowDate()),
+    mode: args.mode,
+    now,
   });
-  const client = getVercelSandboxClient();
+  args.signal.throwIfAborted();
+  await cleanupCliAuthStripeSandboxes({
+    client,
+    sandboxes: prepared.cleanupSandboxes,
+    reason: "start session superseded active session",
+  });
+  args.signal.throwIfAborted();
+
+  if (prepared.kind === "reuse" || prepared.kind === "busy") {
+    return prepared.result;
+  }
+
   const sandboxResult = await createCliAuthStripeSandbox({
     writeDb: args.writeDb,
     client,
-    sessionId: session.id,
+    session: prepared.session,
     signal: args.signal,
   });
   if (!sandboxResult.ok) {
@@ -552,7 +994,7 @@ export async function startCliAuthStripe(args: {
     writeDb: args.writeDb,
     client,
     sandbox: sandboxResult.sandbox,
-    sessionId: session.id,
+    session: sandboxResult.session,
     signal: args.signal,
   });
   if (!startResult.ok) {
@@ -561,7 +1003,7 @@ export async function startCliAuthStripe(args: {
   const persistResult = await safeAsync(() => {
     return markCliAuthStripeSessionAwaitingApproval({
       writeDb: args.writeDb,
-      sessionId: session.id,
+      session: sandboxResult.session,
       output: startResult.output,
       mode: args.mode,
     });
@@ -574,13 +1016,25 @@ export async function startCliAuthStripe(args: {
     });
     throw persistResult.error;
   }
+  if (!persistResult.ok) {
+    await cleanupSandboxSafely({
+      client,
+      sandbox: sandboxResult.sandbox,
+      reason: "start session persist claim lost",
+    });
+    return {
+      ok: false,
+      code: "CLI_AUTH_STRIPE_UNAVAILABLE",
+      message: CLI_AUTH_STRIPE_SUPERSEDED_MESSAGE,
+    };
+  }
   args.signal.throwIfAborted();
 
   return {
     ok: true,
     sessionToken: encodeSession({
       version: 1,
-      sessionId: session.id,
+      sessionId: prepared.session.id,
     }),
     browserUrl: startResult.output.browserUrl,
     verificationCode: startResult.output.verificationCode,
@@ -649,12 +1103,12 @@ async function markCliAuthStripeSessionImported(args: {
 }) {
   const [updated] = await args.tx
     .update(connectorCliAuthSessions)
-    .set({
-      status: "imported",
-      errorMessage: null,
-      completedAt: args.updatedAt,
-      updatedAt: args.updatedAt,
-    })
+    .set(
+      terminalCliAuthStripeSessionSet({
+        status: "imported",
+        now: args.updatedAt,
+      }),
+    )
     .where(
       claimedCliAuthStripeSessionWhere({
         sessionId: args.sessionId,
@@ -965,13 +1419,18 @@ async function handleMissingCliAuthStripeProviderState(args: {
   readonly client: SandboxClient;
   readonly session: ConnectorCliAuthSession;
   readonly signal: AbortSignal;
-}): Promise<CliAuthStripeErrorResult> {
+}): Promise<CliAuthStripeErrorResult | CliAuthStripePendingResult> {
   const message = "CLI auth for Stripe session is missing provider state";
-  await markCliAuthStripeSessionError({
+  const marked = await markCliAuthStripeSessionError({
     writeDb: args.writeDb,
     sessionId: args.session.id,
     message,
+    expectedStatus: args.session.status,
+    expectedUpdatedAt: args.session.updatedAt,
   });
+  if (!marked) {
+    return { status: "pending", errorMessage: null };
+  }
   if (args.session.sandboxId) {
     await cleanupSandbox(args.client, { sandboxId: args.session.sandboxId });
   }
@@ -1124,12 +1583,13 @@ async function markClaimedCliAuthStripeSessionError(args: {
 }) {
   const [updated] = await args.writeDb
     .update(connectorCliAuthSessions)
-    .set({
-      status: "error",
-      errorMessage: sanitizeSessionError(args.message),
-      completedAt: null,
-      updatedAt: nowDate(),
-    })
+    .set(
+      terminalCliAuthStripeSessionSet({
+        status: "error",
+        now: nowDate(),
+        message: args.message,
+      }),
+    )
     .where(
       claimedCliAuthStripeSessionWhere({
         sessionId: args.sessionId,

--- a/turbo/apps/api/src/signals/services/cli-auth-stripe.service.ts
+++ b/turbo/apps/api/src/signals/services/cli-auth-stripe.service.ts
@@ -492,7 +492,6 @@ export async function invalidateActiveCliAuthStripeSessions(args: {
       message: args.message ?? CLI_AUTH_STRIPE_CREDENTIALS_CHANGED_MESSAGE,
     });
   });
-  args.signal.throwIfAborted();
   await cleanupCliAuthStripeSandboxes({
     client,
     sandboxes,
@@ -973,7 +972,6 @@ export async function startCliAuthStripe(args: {
     mode: args.mode,
     now,
   });
-  args.signal.throwIfAborted();
   await cleanupCliAuthStripeSandboxes({
     client,
     sandboxes: prepared.cleanupSandboxes,

--- a/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
@@ -40,6 +40,7 @@ import {
 import { publishUserSignal } from "../external/realtime";
 import { decryptSecretValue, encryptSecretValue } from "./crypto.utils";
 import { userFeatureSwitchOverrides } from "./feature-switches.service";
+import { invalidateActiveCliAuthSessionsForConnectorType } from "./cli-auth-invalidation.service";
 
 type StoredConnectorRow = {
   readonly id: string;
@@ -528,6 +529,15 @@ export const deleteZeroConnectorLocalState$ = command(
     const writeDb = set(writeDb$);
     let deleted = false;
 
+    await invalidateActiveCliAuthSessionsForConnectorType({
+      writeDb,
+      orgId: args.orgId,
+      userId: args.userId,
+      connectorType: args.type,
+      signal,
+    });
+    signal.throwIfAborted();
+
     const [existing] = await writeDb
       .select({ id: connectors.id, authMethod: connectors.authMethod })
       .from(connectors)
@@ -692,6 +702,15 @@ export const upsertOAuthConnector$ = command(
       type: args.type,
       expiresIn: args.expiresIn,
     });
+
+    await invalidateActiveCliAuthSessionsForConnectorType({
+      writeDb,
+      orgId: args.orgId,
+      userId: args.userId,
+      connectorType: args.type,
+      signal,
+    });
+    signal.throwIfAborted();
 
     await upsertConnectorSecret(writeDb, {
       orgId: args.orgId,

--- a/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
@@ -570,6 +570,55 @@ async function hasApiTokenConnectorLocalState(args: {
   return false;
 }
 
+async function deleteApiTokenConnectorLocalState(args: {
+  readonly db: Db;
+  readonly orgId: string;
+  readonly userId: string;
+  readonly fields: {
+    readonly secrets: readonly string[];
+    readonly variables: readonly string[];
+  } | null;
+  readonly signal: AbortSignal;
+}): Promise<boolean> {
+  if (!args.fields) {
+    return false;
+  }
+
+  let deleted = false;
+  for (const name of args.fields.secrets) {
+    const result = await args.db
+      .delete(secrets)
+      .where(
+        and(
+          eq(secrets.orgId, args.orgId),
+          eq(secrets.userId, args.userId),
+          eq(secrets.name, name),
+          eq(secrets.type, "user"),
+        ),
+      )
+      .returning({ id: secrets.id });
+    args.signal.throwIfAborted();
+    deleted = deleted || result.length > 0;
+  }
+
+  for (const name of args.fields.variables) {
+    const result = await args.db
+      .delete(variables)
+      .where(
+        and(
+          eq(variables.orgId, args.orgId),
+          eq(variables.userId, args.userId),
+          eq(variables.name, name),
+        ),
+      )
+      .returning({ id: variables.id });
+    args.signal.throwIfAborted();
+    deleted = deleted || result.length > 0;
+  }
+
+  return deleted;
+}
+
 export const deleteZeroConnectorLocalState$ = command(
   async (
     { set },
@@ -656,38 +705,14 @@ export const deleteZeroConnectorLocalState$ = command(
       }
     }
 
-    if (fields) {
-      for (const name of fields.secrets) {
-        const result = await writeDb
-          .delete(secrets)
-          .where(
-            and(
-              eq(secrets.orgId, args.orgId),
-              eq(secrets.userId, args.userId),
-              eq(secrets.name, name),
-              eq(secrets.type, "user"),
-            ),
-          )
-          .returning({ id: secrets.id });
-        signal.throwIfAborted();
-        deleted = deleted || result.length > 0;
-      }
-
-      for (const name of fields.variables) {
-        const result = await writeDb
-          .delete(variables)
-          .where(
-            and(
-              eq(variables.orgId, args.orgId),
-              eq(variables.userId, args.userId),
-              eq(variables.name, name),
-            ),
-          )
-          .returning({ id: variables.id });
-        signal.throwIfAborted();
-        deleted = deleted || result.length > 0;
-      }
-    }
+    deleted =
+      (await deleteApiTokenConnectorLocalState({
+        db: writeDb,
+        orgId: args.orgId,
+        userId: args.userId,
+        fields,
+        signal,
+      })) || deleted;
 
     if (deleted) {
       await publishUserSignal([args.userId], "connector:changed");
@@ -769,6 +794,7 @@ export const upsertOAuthConnector$ = command(
       type: args.type,
       expiresIn: args.expiresIn,
     });
+    const apiTokenFields = getApiTokenFieldsByType(args.type);
 
     await invalidateActiveCliAuthSessionsForConnectorType({
       writeDb,
@@ -832,6 +858,15 @@ export const upsertOAuthConnector$ = command(
     if (!connectorRow) {
       throw new Error("Failed to upsert connector");
     }
+
+    await deleteApiTokenConnectorLocalState({
+      db: writeDb,
+      orgId: args.orgId,
+      userId: args.userId,
+      fields: apiTokenFields,
+      signal,
+    });
+    signal.throwIfAborted();
 
     await publishUserSignal([args.userId], "connector:changed");
     signal.throwIfAborted();

--- a/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
@@ -24,7 +24,7 @@ import { getAllFeatureStates } from "@vm0/core/feature-switch";
 import { connectors } from "@vm0/db/schema/connector";
 import { secrets } from "@vm0/db/schema/secret";
 import { variables } from "@vm0/db/schema/variable";
-import { and, eq } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
 import { z } from "zod";
 
 import { optionalEnv } from "../../lib/env";
@@ -516,6 +516,60 @@ async function revokeExistingConnectorToken(args: {
   args.signal.throwIfAborted();
 }
 
+async function hasApiTokenConnectorLocalState(args: {
+  readonly db: Db;
+  readonly orgId: string;
+  readonly userId: string;
+  readonly fields: {
+    readonly secrets: readonly string[];
+    readonly variables: readonly string[];
+  } | null;
+  readonly signal: AbortSignal;
+}): Promise<boolean> {
+  if (!args.fields) {
+    return false;
+  }
+
+  if (args.fields.secrets.length > 0) {
+    const [secret] = await args.db
+      .select({ id: secrets.id })
+      .from(secrets)
+      .where(
+        and(
+          eq(secrets.orgId, args.orgId),
+          eq(secrets.userId, args.userId),
+          eq(secrets.type, "user"),
+          inArray(secrets.name, [...args.fields.secrets]),
+        ),
+      )
+      .limit(1);
+    args.signal.throwIfAborted();
+    if (secret) {
+      return true;
+    }
+  }
+
+  if (args.fields.variables.length > 0) {
+    const [variable] = await args.db
+      .select({ id: variables.id })
+      .from(variables)
+      .where(
+        and(
+          eq(variables.orgId, args.orgId),
+          eq(variables.userId, args.userId),
+          inArray(variables.name, [...args.fields.variables]),
+        ),
+      )
+      .limit(1);
+    args.signal.throwIfAborted();
+    if (variable) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 export const deleteZeroConnectorLocalState$ = command(
   async (
     { set },
@@ -529,15 +583,6 @@ export const deleteZeroConnectorLocalState$ = command(
     const writeDb = set(writeDb$);
     let deleted = false;
 
-    await invalidateActiveCliAuthSessionsForConnectorType({
-      writeDb,
-      orgId: args.orgId,
-      userId: args.userId,
-      connectorType: args.type,
-      signal,
-    });
-    signal.throwIfAborted();
-
     const [existing] = await writeDb
       .select({ id: connectors.id, authMethod: connectors.authMethod })
       .from(connectors)
@@ -549,6 +594,29 @@ export const deleteZeroConnectorLocalState$ = command(
         ),
       )
       .limit(1);
+    signal.throwIfAborted();
+
+    const fields = getApiTokenFieldsByType(args.type);
+    const hasApiTokenState = existing
+      ? false
+      : await hasApiTokenConnectorLocalState({
+          db: writeDb,
+          orgId: args.orgId,
+          userId: args.userId,
+          fields,
+          signal,
+        });
+    if (!existing && !hasApiTokenState) {
+      return false;
+    }
+
+    await invalidateActiveCliAuthSessionsForConnectorType({
+      writeDb,
+      orgId: args.orgId,
+      userId: args.userId,
+      connectorType: args.type,
+      signal,
+    });
     signal.throwIfAborted();
 
     if (existing) {
@@ -588,7 +656,6 @@ export const deleteZeroConnectorLocalState$ = command(
       }
     }
 
-    const fields = getApiTokenFieldsByType(args.type);
     if (fields) {
       for (const name of fields.secrets) {
         const result = await writeDb

--- a/turbo/apps/api/src/signals/services/zero-user-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-user-data.service.ts
@@ -33,6 +33,7 @@ import { and, desc, eq } from "drizzle-orm";
 import { nowDate } from "../../lib/time";
 import { db$, writeDb$ } from "../external/db";
 import { encryptSecretValue } from "./crypto.utils";
+import { invalidateActiveCliAuthSessionsForSecretName } from "./cli-auth-invalidation.service";
 import { isValidTimeZone } from "../utils";
 
 const API_KEY_PREFIX_LENGTH = 12;
@@ -435,9 +436,18 @@ export const setUserSecret$ = command(
     args: SetUserSecretArgs,
     signal: AbortSignal,
   ): Promise<SecretResponse> => {
+    const writeDb = set(writeDb$);
+    await invalidateActiveCliAuthSessionsForSecretName({
+      writeDb,
+      orgId: args.orgId,
+      userId: args.userId,
+      secretName: args.secret.name,
+      signal,
+    });
+    signal.throwIfAborted();
+
     const encryptedValue = encryptSecretValue(args.secret.value);
     const updatedAt = nowDate();
-    const writeDb = set(writeDb$);
     const [row] = await writeDb
       .insert(secrets)
       .values({


### PR DESCRIPTION
Closes #13133

## Summary
- serialize Stripe CLI auth lifecycle state changes with a transaction-scoped advisory lock
- reuse active same-mode sessions, reject fresh in-progress starts, and supersede stale or mode-mismatched sessions
- add a CLI auth invalidation registry so secret/connector mutations cancel affected auth sessions before changing credentials
- clear approval/provider state on terminal sessions and add focused route coverage for stale completion races

## Tests
- pnpm --dir turbo --filter api lint
- pnpm --dir turbo --filter api check-types
- pnpm --dir turbo --filter api exec vitest run src/signals/services/__tests__/cli-auth-stripe-parser.test.ts
- pnpm --dir turbo --filter api exec vitest run src/signals/routes/__tests__/zero-connectors-cli-auth-stripe.test.ts
