### PR TITLE
fix: route api chat runs through zero run service

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-chat-messages.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-chat-messages.test.ts
@@ -1199,6 +1199,57 @@ describe("POST /api/zero/chat/messages", () => {
     });
   });
 
+  it("mounts custom skills for deepseek web chat runs", async () => {
+    const fixture = await track(seedFixture());
+    const writeDb = store.set(writeDb$);
+    await removeComposeFrameworkApiKey(fixture);
+    await writeDb
+      .update(zeroAgents)
+      .set({ customSkills: ["pp"] })
+      .where(eq(zeroAgents.id, fixture.agentId));
+    await seedModelProvider(fixture, "claude-sonnet-4-6", {
+      type: "anthropic-api-key",
+      isDefault: true,
+      secretValue: "default-anthropic-key",
+    });
+    const deepseekProviderId = await seedModelProvider(
+      fixture,
+      "deepseek-v4-flash",
+      {
+        type: "deepseek-api-key",
+        isDefault: false,
+        secretValue: "selected-deepseek-key",
+      },
+    );
+
+    const response = await send({
+      agentId: fixture.agentId,
+      prompt: "use the pp skill",
+      modelSelection: {
+        modelProviderId: deepseekProviderId,
+        selectedModel: "deepseek-v4-pro",
+      },
+    });
+
+    const [run] = await writeDb
+      .select({ additionalVolumes: agentRuns.additionalVolumes })
+      .from(agentRuns)
+      .where(eq(agentRuns.id, response.body.runId!))
+      .limit(1);
+    const volumes = run?.additionalVolumes ?? [];
+    expect(volumes).toContainEqual(
+      expect.objectContaining({
+        name: "custom-skill@pp",
+        mountPath: "/home/user/.claude/skills/pp",
+      }),
+    );
+    expect(
+      volumes.some((volume) => {
+        return volume.mountPath === "/home/user/.claude/skills/deep-dive";
+      }),
+    ).toBeTruthy();
+  });
+
   it("honors org-scoped model-first route credentials during run creation", async () => {
     const fixture = await track(seedFixture());
     const writeDb = store.set(writeDb$);

--- a/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
@@ -41,7 +41,8 @@ import {
 import { now, nowDate } from "../external/time";
 import { badRequestMessage, notFound, providerDeleted } from "../../lib/error";
 import { env } from "../../lib/env";
-import { createAgentRun$ } from "../services/agent-run-create.service";
+import type { AuthContext } from "../../types/auth";
+import { createZeroRun$ } from "../services/zero-runs-create.service";
 import {
   cancelRun$,
   dispatchCancelSideEffects$,
@@ -176,6 +177,7 @@ interface IncompleteRoundRow extends WebChatIncompleteRoundMessage {
 }
 
 type IncomingModelSelection = NormalSendBody["modelSelection"];
+type OrganizationAuthContext = AuthContext & { readonly orgId: string };
 
 type SignalGetter = {
   <T>(signal: import("ccstate").Computed<T>): T;
@@ -184,6 +186,7 @@ type SignalGetter = {
 
 interface NormalSendArgs {
   readonly body: NormalSendBody;
+  readonly auth: OrganizationAuthContext;
   readonly userId: string;
   readonly orgId: string;
   readonly apiStartTime: number;
@@ -1953,20 +1956,15 @@ const createNormalChatRun$ = command(
     }
 
     const runResult = await set(
-      createAgentRun$,
+      createZeroRun$,
       {
-        userId: args.userId,
-        orgId: args.orgId,
+        auth: args.auth,
         apiStartTime: args.apiStartTime,
         chatThreadId: prepared.thread.threadId,
-        includeZeroTokenSecret: true,
         modelProviderId: modelPin.modelProviderId ?? undefined,
         modelProviderCredentialScope:
           modelPin.modelProviderCredentialScope ?? undefined,
-        modelProviderType:
-          providerAdmission.effectiveModelProvider ?? undefined,
         selectedModelOverride: modelPin.selectedModel ?? undefined,
-        validateEnvironmentReferences: false,
         callbacks: [
           {
             url: chatCallbackUrl(),
@@ -1979,20 +1977,22 @@ const createNormalChatRun$ = command(
         ],
         body: {
           prompt: fullPrompt,
-          agentComposeId: args.body.agentId,
+          agentId: args.body.agentId,
           ...(prepared.thread.sessionId
             ? { sessionId: prepared.thread.sessionId }
             : {}),
-          triggerSource: "web" as const,
-          appendSystemPrompt: buildAppendSystemPrompt(
-            prepared.thread.incompleteContext,
-            prepared.priorContext,
-            prepared.goalSetup.goalContext,
-          ),
-          vars: { ZERO_AGENT_ID: args.body.agentId },
+          ...(providerAdmission.effectiveModelProvider
+            ? { modelProvider: providerAdmission.effectiveModelProvider }
+            : {}),
           debugNoMockClaude: args.body.debugNoMockClaude,
           debugNoMockCodex: args.body.debugNoMockCodex,
         },
+        triggerSource: "web",
+        appendSystemPrompt: buildAppendSystemPrompt(
+          prepared.thread.incompleteContext,
+          prepared.priorContext,
+          prepared.goalSetup.goalContext,
+        ),
       },
       signal,
     );
@@ -2103,6 +2103,7 @@ const sendChatMessageInner$ = command(
       sendNormalMessage$,
       {
         body: body.data,
+        auth,
         userId: auth.userId,
         orgId: auth.orgId,
         apiStartTime: now(),

--- a/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
@@ -6,6 +6,7 @@ import {
   connectorTypeSchema,
   type ConnectorType,
 } from "@vm0/connectors/connectors";
+import type { ModelProviderCredentialScope } from "@vm0/api-contracts/contracts/model-providers";
 import { resolveFirewallPolicies } from "@vm0/connectors/firewalls";
 import {
   toFirewallPolicies,
@@ -580,6 +581,9 @@ export const createZeroRun$ = command(
         | "agentphoneHandle"
       >;
       readonly callbacks?: readonly RunCallback[];
+      readonly chatThreadId?: string;
+      readonly modelProviderId?: string;
+      readonly modelProviderCredentialScope?: ModelProviderCredentialScope;
       readonly selectedModelOverride?: string;
       readonly zeroRunMetadata?: ZeroRunMetadata;
     },
@@ -657,10 +661,13 @@ export const createZeroRun$ = command(
           appendSystemPrompt: args.appendSystemPrompt,
         }),
         apiStartTime: args.apiStartTime,
-        modelProviderId: agent.modelProviderId ?? undefined,
+        modelProviderId:
+          args.modelProviderId ?? agent.modelProviderId ?? undefined,
+        modelProviderCredentialScope: args.modelProviderCredentialScope,
         modelProviderType: args.body.modelProvider,
         selectedModelOverride:
           args.selectedModelOverride ?? agent.selectedModel ?? undefined,
+        chatThreadId: args.chatThreadId,
         extraEnvironment: { ZERO_AGENT_ID: agent.id },
         callbacks: [
           ...(callbacksForTriggerAgent(triggerAgentId) ?? []),


### PR DESCRIPTION
## Summary

- Route API backend web chat run creation through `createZeroRun$` instead of calling `createAgentRun$` directly.
- Extend `createZeroRun$` with the chat-specific run metadata and model-first provider pin inputs needed by `/api/zero/chat/messages`.
- Add a DeepSeek web chat regression test that verifies custom skills mount under `/home/user/.claude/skills`.

Fixes #13355

## Test plan

- `pnpm install`
- `pnpm prettier --write apps/api/src/signals/services/zero-runs-create.service.ts apps/api/src/signals/routes/zero-chat-messages.ts apps/api/src/signals/routes/__tests__/zero-chat-messages.test.ts`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-chat-messages.test.ts`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-runs-create.test.ts`
- `pnpm -F api check-types`
- `pnpm -F api lint`
- pre-commit hook: `prettier`, `knip --cache`, `turbo run check-types --concurrency=1`
