### PR TITLE
refactor: rename spawn watch to spawn process

### DIFF
--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -21,7 +21,7 @@ use std::time::{Duration, Instant};
 use futures_util::FutureExt;
 use sandbox::{
     CopyFileOptions, EXEC_OUTPUT_LIMIT_1_MIB, EXEC_OUTPUT_LIMIT_64_KIB, ExecRequest, Sandbox,
-    SandboxConfig, SandboxFactory, SandboxId, SpawnOutputMode, SpawnWatchRequest,
+    SandboxConfig, SandboxFactory, SandboxId, SpawnProcessOutputMode, SpawnProcessRequest,
 };
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
@@ -552,16 +552,16 @@ async fn run_in_sandbox(
     let agent_cmd = format!("{} 2>&1", guest::RUN_AGENT);
     info!(run_id = %context.run_id, "spawning agent");
 
-    // JOB_TIMEOUT is used for both spawn_watch (guest-side kill) and wait_exit
+    // JOB_TIMEOUT is used for both spawn_process (guest-side kill) and wait_exit
     // (host-side watchdog) so neither side outlives the other.
     let t = Instant::now();
     let handle = sandbox
-        .spawn_watch(&SpawnWatchRequest {
+        .spawn_process(&SpawnProcessRequest {
             cmd: &agent_cmd,
             timeout: JOB_TIMEOUT,
             env: &env_refs,
             sudo: false,
-            output: SpawnOutputMode::Stream {
+            output: SpawnProcessOutputMode::Stream {
                 guest_log_path: None,
             },
         })
@@ -3073,7 +3073,7 @@ mod tests {
         assert_eq!(exit_code, 0);
         assert!(error_msg.is_none());
 
-        let calls = overrides.spawn_watch_calls();
+        let calls = overrides.spawn_process_calls();
         assert_eq!(calls.len(), 1);
         assert!(calls[0].streams_stdout);
         assert!(calls[0].guest_log_path.is_none());

--- a/crates/runner/src/proxy.rs
+++ b/crates/runner/src/proxy.rs
@@ -67,6 +67,10 @@ include!(concat!(env!("OUT_DIR"), "/addon_files.rs"));
 
 /// Timeout for waiting for mitmdump to become ready after spawn.
 const READY_TIMEOUT: Duration = Duration::from_secs(10);
+/// Short bounded retry for Linux `execve` returning ETXTBSY while a freshly
+/// installed/replaced mitmdump binary is still observed as writable.
+const TEXT_BUSY_SPAWN_RETRY_DELAY: Duration = Duration::from_millis(20);
+const TEXT_BUSY_SPAWN_MAX_RETRIES: usize = 5;
 
 /// Timeout for graceful shutdown before SIGKILL.
 ///
@@ -599,9 +603,7 @@ pub(crate) async fn spawn_mitmdump(
 
     info!(port, bin = %config.mitmdump_bin.display(), "starting mitmdump");
 
-    let mut child = cmd
-        .spawn()
-        .map_err(|e| RunnerError::Internal(format!("spawn mitmdump: {e}")))?;
+    let mut child = spawn_mitmdump_child(&mut cmd, &config.mitmdump_bin).await?;
 
     // Stream stdout to tracing; when the pipe closes (process exited),
     // send a crash notification unless we're in a graceful stop.
@@ -640,6 +642,50 @@ pub(crate) async fn spawn_mitmdump(
     }
 
     Ok(child)
+}
+
+fn is_text_file_busy(error: &std::io::Error) -> bool {
+    error.raw_os_error() == Some(nix::libc::ETXTBSY)
+}
+
+async fn spawn_mitmdump_child(
+    cmd: &mut tokio::process::Command,
+    bin: &Path,
+) -> RunnerResult<tokio::process::Child> {
+    spawn_mitmdump_child_with_retry(cmd, bin, TEXT_BUSY_SPAWN_RETRY_DELAY, |attempt, error| {
+        warn!(
+            attempt,
+            bin = %bin.display(),
+            error = %error,
+            "mitmdump binary is text-busy, retrying spawn"
+        );
+    })
+    .await
+}
+
+async fn spawn_mitmdump_child_with_retry(
+    cmd: &mut tokio::process::Command,
+    bin: &Path,
+    retry_delay: Duration,
+    mut on_text_busy: impl FnMut(usize, &std::io::Error),
+) -> RunnerResult<tokio::process::Child> {
+    let mut attempt = 0usize;
+    loop {
+        match cmd.spawn() {
+            Ok(child) => return Ok(child),
+            Err(error) if is_text_file_busy(&error) && attempt < TEXT_BUSY_SPAWN_MAX_RETRIES => {
+                attempt += 1;
+                on_text_busy(attempt, &error);
+                tokio::time::sleep(retry_delay).await;
+            }
+            Err(error) => {
+                return Err(RunnerError::Internal(format!(
+                    "spawn mitmdump {}: {error}",
+                    bin.display()
+                )));
+            }
+        }
+    }
 }
 
 /// Wait for mitmdump to start listening on `port` (TCP connect probe).
@@ -854,6 +900,59 @@ PY
         let mut perms = std::fs::metadata(path).unwrap().permissions();
         perms.set_mode(0o755);
         std::fs::set_permissions(path, perms).unwrap();
+    }
+
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn spawn_mitmdump_child_retries_text_busy_binary() {
+        let dir = tempfile::tempdir().unwrap();
+        let fake_mitmdump = dir.path().join("fake-mitmdump");
+        std::fs::write(
+            &fake_mitmdump,
+            r#"#!/usr/bin/env bash
+exit 0
+"#,
+        )
+        .unwrap();
+        let mut perms = std::fs::metadata(&fake_mitmdump).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&fake_mitmdump, perms).unwrap();
+
+        let busy_handle = Arc::new(std::sync::Mutex::new(Some(
+            std::fs::OpenOptions::new()
+                .write(true)
+                .open(&fake_mitmdump)
+                .unwrap(),
+        )));
+        let retry_count = Arc::new(std::sync::Mutex::new(0usize));
+
+        let mut cmd = tokio::process::Command::new(&fake_mitmdump);
+        cmd.stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .kill_on_drop(true);
+
+        let retry_busy_handle = Arc::clone(&busy_handle);
+        let retry_count_for_hook = Arc::clone(&retry_count);
+        let mut child = spawn_mitmdump_child_with_retry(
+            &mut cmd,
+            &fake_mitmdump,
+            Duration::ZERO,
+            move |_attempt, error| {
+                assert!(is_text_file_busy(error), "unexpected retry error: {error}");
+                *retry_count_for_hook.lock().unwrap() += 1;
+                retry_busy_handle.lock().unwrap().take();
+            },
+        )
+        .await
+        .unwrap();
+
+        let status = child.wait().await.unwrap();
+        assert!(status.success(), "fake mitmdump exited with {status}");
+        assert!(
+            *retry_count.lock().unwrap() >= 1,
+            "test did not exercise text-busy retry path",
+        );
     }
 
     async fn wait_for_reaped_pid(pid: nix::unistd::Pid) -> bool {

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -10,9 +10,9 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use sandbox::{
-    CopyFileOptions, CopyFileResult, ExecRequest, ExecResult, ProcessExit, Sandbox, SandboxConfig,
-    SandboxError, SandboxIdleTransition, SandboxInvalidStateContext, SandboxOperation,
-    SandboxOperationReason, SpawnHandle, SpawnWatchRequest,
+    CopyFileOptions, CopyFileResult, ExecRequest, ExecResult, GuestProcessHandle, ProcessExit,
+    Sandbox, SandboxConfig, SandboxError, SandboxIdleTransition, SandboxInvalidStateContext,
+    SandboxOperation, SandboxOperationReason, SpawnProcessRequest,
 };
 use tokio::io::{AsyncBufReadExt, AsyncRead, BufReader};
 use tokio::sync::{mpsc, watch};
@@ -1577,8 +1577,11 @@ impl Sandbox for FirecrackerSandbox {
         .await
     }
 
-    async fn spawn_watch(&self, request: &SpawnWatchRequest<'_>) -> sandbox::Result<SpawnHandle> {
-        let operation = SandboxOperation::SpawnWatch;
+    async fn spawn_process(
+        &self,
+        request: &SpawnProcessRequest<'_>,
+    ) -> sandbox::Result<GuestProcessHandle> {
+        let operation = SandboxOperation::SpawnProcess;
         let mut guest = self.begin_guest_operation(operation).await?;
         guest
             .mark_writing()
@@ -1586,7 +1589,7 @@ impl Sandbox for FirecrackerSandbox {
         let vsock = guest.guest();
 
         tokio::select! {
-            result = vsock.spawn_watch(
+            result = vsock.spawn_process(
                 request.cmd,
                 request.timeout_ms(),
                 request.env,
@@ -1630,7 +1633,7 @@ impl Sandbox for FirecrackerSandbox {
                     },
                     lease,
                 );
-                Ok(SpawnHandle::new(pid, stdout_rx, exit))
+                Ok(GuestProcessHandle::new(pid, stdout_rx, exit))
             }
             () = wait_for_backend_crash(self.state_tx.subscribe()) => {
                 Err(Self::backend_crashed_error(operation))
@@ -1640,7 +1643,7 @@ impl Sandbox for FirecrackerSandbox {
 
     async fn wait_exit(
         &self,
-        mut handle: SpawnHandle,
+        mut handle: GuestProcessHandle,
         timeout: Duration,
     ) -> sandbox::Result<ProcessExit> {
         let operation = SandboxOperation::WaitExit;
@@ -1649,7 +1652,7 @@ impl Sandbox for FirecrackerSandbox {
                 operation,
                 std::io::Error::new(
                     std::io::ErrorKind::ConnectionReset,
-                    "spawn_watch handle already consumed",
+                    "spawn_process handle already consumed",
                 ),
                 self.has_backend_crashed(),
             )
@@ -2445,7 +2448,7 @@ mod tests {
         }
     }
 
-    fn active_spawn_watch_lease(coordinator: &ParkCoordinator) -> OperationLease {
+    fn active_spawn_process_lease(coordinator: &ParkCoordinator) -> OperationLease {
         let mut lease = coordinator.reserve_operation().expect("reserve operation");
         lease.mark_writing().expect("mark writing");
         lease.mark_in_guest().expect("mark in guest");
@@ -2540,7 +2543,7 @@ mod tests {
     #[tokio::test]
     async fn ready_for_park_boundary_busy_prevents_quiesce_and_pause() {
         let coordinator = ParkCoordinator::new();
-        let _lease = active_spawn_watch_lease(&coordinator);
+        let _lease = active_spawn_process_lease(&coordinator);
         let events = event_log();
         let quiesce_events = Arc::clone(&events);
         let park_events = Arc::clone(&events);
@@ -3133,7 +3136,7 @@ mod tests {
         for operation in [
             SandboxOperation::Exec,
             SandboxOperation::WriteFile,
-            SandboxOperation::SpawnWatch,
+            SandboxOperation::SpawnProcess,
             SandboxOperation::WaitExit,
         ] {
             let err = FirecrackerSandbox::operation_error(
@@ -3151,7 +3154,7 @@ mod tests {
         for operation in [
             SandboxOperation::Exec,
             SandboxOperation::WriteFile,
-            SandboxOperation::SpawnWatch,
+            SandboxOperation::SpawnProcess,
             SandboxOperation::WaitExit,
         ] {
             let err =
@@ -3164,7 +3167,7 @@ mod tests {
     #[tokio::test]
     async fn gated_spawn_exit_future_completes_lease_on_process_exit() {
         let coordinator = ParkCoordinator::new();
-        let lease = active_spawn_watch_lease(&coordinator);
+        let lease = active_spawn_process_lease(&coordinator);
         let exit = gated_spawn_exit_future(
             async {
                 Ok(ProcessExit {
@@ -3187,14 +3190,14 @@ mod tests {
 
         let attempt = coordinator
             .begin_prepare_park()
-            .expect("completed spawn_watch lease should allow prepare");
+            .expect("completed spawn_process lease should allow prepare");
         coordinator.abort_prepare_park(&attempt).unwrap();
     }
 
     #[test]
     fn dropped_gated_spawn_exit_future_marks_dirty() {
         let coordinator = ParkCoordinator::new();
-        let lease = active_spawn_watch_lease(&coordinator);
+        let lease = active_spawn_process_lease(&coordinator);
         let exit =
             gated_spawn_exit_future(std::future::pending::<io::Result<ProcessExit>>(), lease);
 
@@ -3214,7 +3217,7 @@ mod tests {
     #[tokio::test]
     async fn gated_spawn_exit_future_error_marks_dirty() {
         let coordinator = ParkCoordinator::new();
-        let lease = active_spawn_watch_lease(&coordinator);
+        let lease = active_spawn_process_lease(&coordinator);
         let exit = gated_spawn_exit_future(
             async { Err(io::Error::new(io::ErrorKind::ConnectionReset, "closed")) },
             lease,

--- a/crates/sandbox-mock/src/lib.rs
+++ b/crates/sandbox-mock/src/lib.rs
@@ -2227,7 +2227,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn wait_exit_rejects_consumed_spawn_handle() {
+    async fn wait_exit_rejects_consumed_guest_process_handle() {
         let runtime = MockSandboxRuntime::new();
         let factory = runtime.create_factory(test_factory_config()).await.unwrap();
         let sandbox = factory.create(test_sandbox_config()).await.unwrap();

--- a/crates/sandbox-mock/src/lib.rs
+++ b/crates/sandbox-mock/src/lib.rs
@@ -52,7 +52,7 @@ pub struct ExecMatcher {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct SpawnWatchCall {
+pub struct SpawnProcessCall {
     pub streams_stdout: bool,
     pub guest_log_path: Option<String>,
 }
@@ -306,9 +306,9 @@ pub struct MockSandboxOverrides {
     /// FIFO queue of destroy behaviours consumed by every factory built with
     /// these overrides. Empty queue → default successful destroy.
     destroy_behaviors: Mutex<VecDeque<DestroyBehavior>>,
-    /// Recorded spawn_watch output modes across all sandboxes built from
+    /// Recorded spawn_process output modes across all sandboxes built from
     /// this override set.
-    spawn_watch_calls: Mutex<Vec<SpawnWatchCall>>,
+    spawn_process_calls: Mutex<Vec<SpawnProcessCall>>,
     /// Total `park()` calls across all sandboxes built from this override set.
     park_calls: Mutex<u32>,
     /// Total `unpark()` calls across all sandboxes built from this override set.
@@ -333,7 +333,7 @@ impl MockSandboxOverrides {
             unpark_behaviors: Mutex::new(VecDeque::new()),
             destroy_gate: Mutex::new(None),
             destroy_behaviors: Mutex::new(VecDeque::new()),
-            spawn_watch_calls: Mutex::new(Vec::new()),
+            spawn_process_calls: Mutex::new(Vec::new()),
             park_calls: Mutex::new(0),
             unpark_calls: Mutex::new(0),
             destroy_calls: Mutex::new(0),
@@ -500,10 +500,10 @@ impl MockSandboxOverrides {
         *self.destroy_calls.lock_ignoring_poison()
     }
 
-    /// Recorded spawn_watch calls across all sandboxes built from this
+    /// Recorded spawn_process calls across all sandboxes built from this
     /// override set, in call order.
-    pub fn spawn_watch_calls(&self) -> Vec<SpawnWatchCall> {
-        self.spawn_watch_calls.lock_ignoring_poison().clone()
+    pub fn spawn_process_calls(&self) -> Vec<SpawnProcessCall> {
+        self.spawn_process_calls.lock_ignoring_poison().clone()
     }
 }
 
@@ -548,7 +548,7 @@ pub struct MockSandbox {
     overrides: Option<Arc<MockSandboxOverrides>>,
     /// Holds the stdout channel sender alive when simulating a non-closing
     /// channel (e.g. wait_exit_error override). Without this, the sender is
-    /// dropped immediately in `spawn_watch` and the drain task exits.
+    /// dropped immediately in `spawn_process` and the drain task exits.
     stdout_tx: Mutex<Option<tokio::sync::mpsc::UnboundedSender<Vec<u8>>>>,
 }
 
@@ -858,12 +858,12 @@ impl Sandbox for MockSandbox {
             .unwrap_or(Ok(()))
     }
 
-    async fn spawn_watch(&self, request: &SpawnWatchRequest<'_>) -> Result<SpawnHandle> {
+    async fn spawn_process(&self, request: &SpawnProcessRequest<'_>) -> Result<GuestProcessHandle> {
         if let Some(overrides) = &self.overrides {
             overrides
-                .spawn_watch_calls
+                .spawn_process_calls
                 .lock_ignoring_poison()
-                .push(SpawnWatchCall {
+                .push(SpawnProcessCall {
                     streams_stdout: request.output.streams_stdout(),
                     guest_log_path: request.output.guest_log_path().map(str::to_owned),
                 });
@@ -878,19 +878,23 @@ impl Sandbox for MockSandbox {
         {
             *self.stdout_tx.lock_ignoring_poison() = Some(tx);
         }
-        Ok(SpawnHandle::new(
+        Ok(GuestProcessHandle::new(
             1,
             request.output.streams_stdout().then_some(rx),
             Box::pin(std::future::pending::<std::io::Result<ProcessExit>>()),
         ))
     }
 
-    async fn wait_exit(&self, mut handle: SpawnHandle, _timeout: Duration) -> Result<ProcessExit> {
+    async fn wait_exit(
+        &self,
+        mut handle: GuestProcessHandle,
+        _timeout: Duration,
+    ) -> Result<ProcessExit> {
         let Some(_exit) = handle.take_exit_future() else {
             return Err(SandboxError::Operation {
                 operation: SandboxOperation::WaitExit,
                 reason: SandboxOperationReason::Other,
-                message: "spawn_watch handle already consumed".to_string(),
+                message: "spawn_process handle already consumed".to_string(),
             });
         };
         // `wait_exit` consumes the handle; an unclaimed stream receiver can no
@@ -2159,29 +2163,29 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn overrides_record_spawn_watch_output_modes_in_order() {
+    async fn overrides_record_spawn_process_output_modes_in_order() {
         let overrides = Arc::new(MockSandboxOverrides::new());
         let factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));
         let sandbox = factory.create(test_sandbox_config()).await.unwrap();
         let buffered = sandbox
-            .spawn_watch(&SpawnWatchRequest {
+            .spawn_process(&SpawnProcessRequest {
                 cmd: "agent",
                 timeout: Duration::from_secs(5),
                 env: &[],
                 sudo: false,
-                output: SpawnOutputMode::Buffered,
+                output: SpawnProcessOutputMode::Buffered,
             })
             .await
             .unwrap();
         assert!(buffered.stdout_rx.is_none());
 
         let streamed = sandbox
-            .spawn_watch(&SpawnWatchRequest {
+            .spawn_process(&SpawnProcessRequest {
                 cmd: "agent",
                 timeout: Duration::from_secs(5),
                 env: &[],
                 sudo: false,
-                output: SpawnOutputMode::Stream {
+                output: SpawnProcessOutputMode::Stream {
                     guest_log_path: None,
                 },
             })
@@ -2190,12 +2194,12 @@ mod tests {
         assert!(streamed.stdout_rx.is_some());
 
         let tee = sandbox
-            .spawn_watch(&SpawnWatchRequest {
+            .spawn_process(&SpawnProcessRequest {
                 cmd: "agent",
                 timeout: Duration::from_secs(5),
                 env: &[],
                 sudo: false,
-                output: SpawnOutputMode::Stream {
+                output: SpawnProcessOutputMode::Stream {
                     guest_log_path: Some("/tmp/guest.log"),
                 },
             })
@@ -2204,17 +2208,17 @@ mod tests {
         assert!(tee.stdout_rx.is_some());
 
         assert_eq!(
-            overrides.spawn_watch_calls(),
+            overrides.spawn_process_calls(),
             vec![
-                SpawnWatchCall {
+                SpawnProcessCall {
                     streams_stdout: false,
                     guest_log_path: None,
                 },
-                SpawnWatchCall {
+                SpawnProcessCall {
                     streams_stdout: true,
                     guest_log_path: None,
                 },
-                SpawnWatchCall {
+                SpawnProcessCall {
                     streams_stdout: true,
                     guest_log_path: Some("/tmp/guest.log".to_string()),
                 },
@@ -2228,12 +2232,12 @@ mod tests {
         let factory = runtime.create_factory(test_factory_config()).await.unwrap();
         let sandbox = factory.create(test_sandbox_config()).await.unwrap();
         let mut handle = sandbox
-            .spawn_watch(&SpawnWatchRequest {
+            .spawn_process(&SpawnProcessRequest {
                 cmd: "agent",
                 timeout: Duration::from_secs(5),
                 env: &[],
                 sudo: false,
-                output: SpawnOutputMode::Buffered,
+                output: SpawnProcessOutputMode::Buffered,
             })
             .await
             .unwrap();
@@ -2261,7 +2265,7 @@ mod tests {
         let overrides = Arc::new(MockSandboxOverrides::with_wait_exit_gate(Arc::clone(&gate)));
         let sandbox = MockSandbox::with_overrides("test", overrides);
         let (stdout_tx, stdout_rx) = tokio::sync::mpsc::unbounded_channel();
-        let handle = SpawnHandle::new(
+        let handle = GuestProcessHandle::new(
             1,
             Some(stdout_rx),
             Box::pin(std::future::pending::<std::io::Result<ProcessExit>>()),

--- a/crates/sandbox/src/error.rs
+++ b/crates/sandbox/src/error.rs
@@ -86,8 +86,8 @@ pub enum SandboxOperation {
     Exec,
     /// [`Sandbox::write_file`](crate::Sandbox::write_file).
     WriteFile,
-    /// [`Sandbox::spawn_watch`](crate::Sandbox::spawn_watch).
-    SpawnWatch,
+    /// [`Sandbox::spawn_process`](crate::Sandbox::spawn_process).
+    SpawnProcess,
     /// [`Sandbox::wait_exit`](crate::Sandbox::wait_exit).
     WaitExit,
 }
@@ -97,7 +97,7 @@ impl fmt::Display for SandboxOperation {
         match self {
             Self::Exec => f.write_str("exec"),
             Self::WriteFile => f.write_str("write file"),
-            Self::SpawnWatch => f.write_str("spawn watch"),
+            Self::SpawnProcess => f.write_str("spawn process"),
             Self::WaitExit => f.write_str("wait exit"),
         }
     }

--- a/crates/sandbox/src/lib.rs
+++ b/crates/sandbox/src/lib.rs
@@ -42,6 +42,6 @@ pub use snapshot::{
 };
 pub use types::{
     CopyFileOptions, CopyFileResult, EXEC_OUTPUT_LIMIT_1_MIB, EXEC_OUTPUT_LIMIT_7_MIB,
-    EXEC_OUTPUT_LIMIT_64_KIB, ExecOutputLimits, ExecRequest, ExecResult, ProcessExit, SpawnHandle,
-    SpawnOutputMode, SpawnWatchRequest,
+    EXEC_OUTPUT_LIMIT_64_KIB, ExecOutputLimits, ExecRequest, ExecResult, GuestProcessHandle,
+    ProcessExit, SpawnProcessOutputMode, SpawnProcessRequest,
 };

--- a/crates/sandbox/src/sandbox.rs
+++ b/crates/sandbox/src/sandbox.rs
@@ -24,7 +24,7 @@
 //! # Operations
 //! Once running, callers invoke [`exec`](Sandbox::exec) /
 //! [`read_file`](Sandbox::read_file) / [`copy_file`](Sandbox::copy_file) /
-//! [`write_file`](Sandbox::write_file) / [`spawn_watch`](Sandbox::spawn_watch) /
+//! [`write_file`](Sandbox::write_file) / [`spawn_process`](Sandbox::spawn_process) /
 //! [`wait_exit`](Sandbox::wait_exit) via the host-to-guest IPC channel
 //! (vsock, in the Firecracker backend). Operations race against a crash
 //! notifier so that a dying backend process surfaces as a specific
@@ -38,8 +38,8 @@ use async_trait::async_trait;
 
 use crate::error::Result;
 use crate::types::{
-    CopyFileOptions, CopyFileResult, ExecRequest, ExecResult, ProcessExit, SpawnHandle,
-    SpawnWatchRequest,
+    CopyFileOptions, CopyFileResult, ExecRequest, ExecResult, GuestProcessHandle, ProcessExit,
+    SpawnProcessRequest,
 };
 
 /// A process-isolation environment that runs guest workloads for the runner.
@@ -65,7 +65,7 @@ use crate::types::{
 /// # Operations
 /// Once running, callers invoke [`exec`](Self::exec) /
 /// [`read_file`](Self::read_file) / [`copy_file`](Self::copy_file) /
-/// [`write_file`](Self::write_file) / [`spawn_watch`](Self::spawn_watch) /
+/// [`write_file`](Self::write_file) / [`spawn_process`](Self::spawn_process) /
 /// [`wait_exit`](Self::wait_exit) via the host-to-guest IPC channel
 /// (vsock, in the Firecracker backend). Operations race against a crash
 /// notifier so that a dying backend process surfaces as a specific
@@ -163,7 +163,7 @@ pub trait Sandbox: Send + Sync + Any {
     /// Transition the sandbox back to the active state.
     ///
     /// Must be called before any further work is dispatched via `exec` /
-    /// `spawn_watch` on a previously parked sandbox. Implementations
+    /// `spawn_process` on a previously parked sandbox. Implementations
     /// should restore whatever state `park()` altered (resume vCPUs,
     /// balloon deflate, respawn background tickers, etc).
     ///
@@ -190,8 +190,8 @@ pub trait Sandbox: Send + Sync + Any {
     // dying backend process surfaces as a specific error rather than an opaque
     // IPC timeout.
     //
-    // `wait_exit` is the exception: it consumes a `SpawnHandle` returned by
-    // `spawn_watch` and observes that handle's already-started backend exit
+    // `wait_exit` is the exception: it consumes a `GuestProcessHandle` returned by
+    // `spawn_process` and observes that handle's already-started backend exit
     // operation instead of starting new guest work.
 
     /// Run `request.cmd` in the guest, block until it exits or the
@@ -226,11 +226,11 @@ pub trait Sandbox: Send + Sync + Any {
     ///
     /// `request.output` controls whether stdout is buffered into the final
     /// [`ProcessExit`] or streamed in real time through
-    /// [`SpawnHandle::stdout_rx`], optionally
+    /// [`GuestProcessHandle::stdout_rx`], optionally
     /// teeing streamed chunks into a guest-side file.
     /// Callers that take `stdout_rx` are responsible for draining it while the
     /// process runs.
-    async fn spawn_watch(&self, request: &SpawnWatchRequest<'_>) -> Result<SpawnHandle>;
+    async fn spawn_process(&self, request: &SpawnProcessRequest<'_>) -> Result<GuestProcessHandle>;
     /// Wait for the process behind `handle` to exit, up to `timeout`.
     ///
     /// Consumes the handle. If `stdout_rx` was not taken before waiting, the
@@ -238,5 +238,6 @@ pub trait Sandbox: Send + Sync + Any {
     /// an error if the backend exit operation is no longer available, if the
     /// backing process crashes before an exit result is delivered, or if the
     /// timeout elapses before the guest process exits.
-    async fn wait_exit(&self, handle: SpawnHandle, timeout: Duration) -> Result<ProcessExit>;
+    async fn wait_exit(&self, handle: GuestProcessHandle, timeout: Duration)
+    -> Result<ProcessExit>;
 }

--- a/crates/sandbox/src/types.rs
+++ b/crates/sandbox/src/types.rs
@@ -57,9 +57,9 @@ impl ExecRequest<'_> {
     }
 }
 
-/// Request for a watched command whose process can outlive the initial spawn
-/// request and is supervised through [`SpawnHandle`].
-pub struct SpawnWatchRequest<'a> {
+/// Request for a guest process that can outlive the initial spawn request and
+/// is supervised through [`GuestProcessHandle`].
+pub struct SpawnProcessRequest<'a> {
     /// Shell command to run inside the guest.
     pub cmd: &'a str,
     /// Guest-side process timeout.
@@ -69,10 +69,10 @@ pub struct SpawnWatchRequest<'a> {
     /// Run the command with guest-side sudo privileges.
     pub sudo: bool,
     /// Buffered or streamed stdout behavior.
-    pub output: SpawnOutputMode<'a>,
+    pub output: SpawnProcessOutputMode<'a>,
 }
 
-impl SpawnWatchRequest<'_> {
+impl SpawnProcessRequest<'_> {
     /// Return the timeout as whole milliseconds, saturating at `u32::MAX`.
     pub fn timeout_ms(&self) -> u32 {
         duration_ms(self.timeout)
@@ -127,34 +127,34 @@ pub struct CopyFileResult {
     pub bytes_copied: u64,
 }
 
-/// Backend-owned future that resolves when a watched process exits.
+/// Backend-owned future that resolves when a spawned process exits.
 ///
-/// Sandbox implementations store this in [`SpawnHandle`] so
+/// Sandbox implementations store this in [`GuestProcessHandle`] so
 /// [`Sandbox::wait_exit`](crate::Sandbox::wait_exit) can consume the exact
-/// backend operation created by [`Sandbox::spawn_watch`](crate::Sandbox::spawn_watch).
-pub type SpawnExitFuture =
+/// backend operation created by [`Sandbox::spawn_process`](crate::Sandbox::spawn_process).
+pub type GuestProcessExitFuture =
     Pin<Box<dyn Future<Output = std::io::Result<ProcessExit>> + Send + 'static>>;
 
-/// Handle returned by [`Sandbox::spawn_watch`](crate::Sandbox::spawn_watch).
+/// Handle returned by [`Sandbox::spawn_process`](crate::Sandbox::spawn_process).
 ///
 /// The handle owns backend-specific exit state and must be consumed by
 /// [`Sandbox::wait_exit`](crate::Sandbox::wait_exit). When stdout streaming is
 /// enabled, callers may take [`stdout_rx`](Self::stdout_rx) before waiting; if
 /// they do, they must drain it while the process runs.
-pub struct SpawnHandle {
+pub struct GuestProcessHandle {
     pub pid: u32,
     /// Receives stdout chunks in real-time when the guest streams them.
     /// `None` when the backend does not support streaming.
     pub stdout_rx: Option<tokio::sync::mpsc::UnboundedReceiver<Vec<u8>>>,
-    exit: Option<SpawnExitFuture>,
+    exit: Option<GuestProcessExitFuture>,
 }
 
-impl SpawnHandle {
-    /// Construct a spawn handle from backend-owned process state.
+impl GuestProcessHandle {
+    /// Construct a guest process handle from backend-owned process state.
     pub fn new(
         pid: u32,
         stdout_rx: Option<tokio::sync::mpsc::UnboundedReceiver<Vec<u8>>>,
-        exit: SpawnExitFuture,
+        exit: GuestProcessExitFuture,
     ) -> Self {
         Self {
             pid,
@@ -168,18 +168,18 @@ impl SpawnHandle {
     /// This is intended for sandbox backend implementations of
     /// [`Sandbox::wait_exit`](crate::Sandbox::wait_exit); ordinary callers should
     /// pass the handle to that trait method instead.
-    pub fn take_exit_future(&mut self) -> Option<SpawnExitFuture> {
+    pub fn take_exit_future(&mut self) -> Option<GuestProcessExitFuture> {
         self.exit.take()
     }
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum SpawnOutputMode<'a> {
+pub enum SpawnProcessOutputMode<'a> {
     Buffered,
     Stream { guest_log_path: Option<&'a str> },
 }
 
-impl<'a> SpawnOutputMode<'a> {
+impl<'a> SpawnProcessOutputMode<'a> {
     pub fn streams_stdout(self) -> bool {
         matches!(self, Self::Stream { .. })
     }

--- a/crates/vsock-guest/src/connection.rs
+++ b/crates/vsock-guest/src/connection.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 
 use vsock_proto::{
     self, MSG_COMMAND_CANCEL, MSG_COMMAND_START, MSG_OPERATIONS_QUIESCED, MSG_OPERATIONS_RESUMED,
-    MSG_QUIESCE_OPERATIONS, MSG_READY, MSG_RESUME_OPERATIONS, MSG_SPAWN_WATCH, MSG_WRITE_FILE,
+    MSG_QUIESCE_OPERATIONS, MSG_READY, MSG_RESUME_OPERATIONS, MSG_SPAWN_PROCESS, MSG_WRITE_FILE,
 };
 
 use crate::command::{
@@ -19,7 +19,7 @@ use crate::handlers::{
     MessageOutcome, decode_write_file_message, handle_decoded_write_file_message, handle_message,
 };
 use crate::log::log;
-use crate::monitor::{SpawnWatchRequest, handle_spawn_watch};
+use crate::monitor::{SpawnProcessRequest, handle_spawn_process};
 use crate::quiesce::{AcquireOperationError, OperationGuard, OperationState, QuiesceResult};
 use crate::writer::GuestWriter;
 
@@ -261,21 +261,21 @@ fn handle_connection_with_outcome(stream: UnixStream) -> io::Result<ConnectionEn
                 }
                 vsock_proto::decode_command_cancel(&msg.payload).map_err(to_io_error)?;
                 cancel_command_operation(&command_registry, msg.seq);
-            } else if msg.msg_type == MSG_SPAWN_WATCH {
+            } else if msg.msg_type == MSG_SPAWN_PROCESS {
                 if reject_operation_if_quiescing(&operation_state, msg.seq, &writer)? {
                     continue;
                 }
-                let d = vsock_proto::decode_spawn_watch(&msg.payload).map_err(to_io_error)?;
+                let d = vsock_proto::decode_spawn_process(&msg.payload).map_err(to_io_error)?;
                 let Some(operation_guard) =
                     acquire_operation_guard(&operation_state, msg.seq, &writer)?
                 else {
                     continue;
                 };
-                // handle_spawn_watch writes the response itself (before
+                // handle_spawn_process writes the response itself (before
                 // spawning the streaming thread) to prevent a race where
                 // stdout chunks could arrive at the host before the result.
-                handle_spawn_watch(
-                    SpawnWatchRequest {
+                handle_spawn_process(
+                    SpawnProcessRequest {
                         timeout_ms: d.timeout_ms,
                         command: d.command,
                         env: &d.env,

--- a/crates/vsock-guest/src/exec.rs
+++ b/crates/vsock-guest/src/exec.rs
@@ -537,7 +537,7 @@ pub(crate) fn spawn_in_own_process_group(command: &mut Command) -> io::Result<Ch
 }
 
 /// Spawn `command` with stdout/stderr piped — used by both buffered exec and
-/// streaming spawn-watch.
+/// streaming spawned processes.
 pub(crate) fn spawn_with_pipes(
     command: &str,
     env: &[(&str, &str)],

--- a/crates/vsock-guest/src/handlers.rs
+++ b/crates/vsock-guest/src/handlers.rs
@@ -250,7 +250,7 @@ pub(crate) fn handle_decoded_write_file_message(
 
 /// Handle incoming message and return the connection-loop outcome.
 ///
-/// Command operation, `MSG_SPAWN_WATCH`, and guarded write-file operations are
+/// Command operation, `MSG_SPAWN_PROCESS`, and guarded write-file operations are
 /// handled separately in `handle_connection`.
 pub(crate) fn handle_message(msg: &RawMessage) -> io::Result<MessageOutcome> {
     log(

--- a/crates/vsock-guest/src/monitor.rs
+++ b/crates/vsock-guest/src/monitor.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::thread::JoinHandle;
 
-use vsock_proto::{self, MSG_ERROR, MSG_PROCESS_EXIT, MSG_SPAWN_WATCH_RESULT, MSG_STDOUT_CHUNK};
+use vsock_proto::{self, MSG_ERROR, MSG_PROCESS_EXIT, MSG_SPAWN_PROCESS_RESULT, MSG_STDOUT_CHUNK};
 
 use crate::drain::{drain_into_vec_cancellable, drain_until_eof_or_cancelled};
 use crate::error::to_io_error;
@@ -62,7 +62,7 @@ struct StreamingSetupFailure {
     error: String,
 }
 
-pub(crate) struct SpawnWatchRequest<'a> {
+pub(crate) struct SpawnProcessRequest<'a> {
     pub(crate) timeout_ms: u32,
     pub(crate) command: &'a str,
     pub(crate) env: &'a [(&'a str, &'a str)],
@@ -71,7 +71,7 @@ pub(crate) struct SpawnWatchRequest<'a> {
     pub(crate) stdout_log_path: Option<&'a str>,
 }
 
-/// Handle spawn_watch: spawn the child, write `MSG_SPAWN_WATCH_RESULT` over
+/// Handle spawn_process: spawn the child, write `MSG_SPAWN_PROCESS_RESULT` over
 /// the wire, THEN start the background monitor. Returns immediately; exit is
 /// later reported via `MSG_PROCESS_EXIT`.
 ///
@@ -81,15 +81,15 @@ pub(crate) struct SpawnWatchRequest<'a> {
 ///
 /// The result-before-monitor ordering is a protocol invariant: lifecycle frames
 /// are routed by the original request sequence number, but the host still
-/// validates their pid against the preceding `MSG_SPAWN_WATCH_RESULT`.
-pub(crate) fn handle_spawn_watch(
-    request: SpawnWatchRequest<'_>,
+/// validates their pid against the preceding `MSG_SPAWN_PROCESS_RESULT`.
+pub(crate) fn handle_spawn_process(
+    request: SpawnProcessRequest<'_>,
     seq: u32,
     operation_guard: OperationGuard,
     writer: GuestWriter,
     connection_cancel: Arc<AtomicBool>,
 ) -> io::Result<()> {
-    handle_spawn_watch_with_spawner(
+    handle_spawn_process_with_spawner(
         request,
         seq,
         operation_guard,
@@ -99,8 +99,8 @@ pub(crate) fn handle_spawn_watch(
     )
 }
 
-fn handle_spawn_watch_with_spawner<S>(
-    request: SpawnWatchRequest<'_>,
+fn handle_spawn_process_with_spawner<S>(
+    request: SpawnProcessRequest<'_>,
     seq: u32,
     operation_guard: OperationGuard,
     writer: GuestWriter,
@@ -113,7 +113,7 @@ where
     log(
         "INFO",
         &format!(
-            "spawn_watch: {} (timeout={}ms, sudo={}, stream={}, {})",
+            "spawn_process: {} (timeout={}ms, sudo={}, stream={}, {})",
             truncate_preview(request.command),
             request.timeout_ms,
             request.sudo,
@@ -143,19 +143,19 @@ where
     } = spawned;
 
     let pid = child.id();
-    log("INFO", &format!("spawn_watch: started pid={pid}"));
+    log("INFO", &format!("spawn_process: started pid={pid}"));
 
     // Write the response BEFORE spawning the monitor thread.
     // The monitor thread contends for the same writer mutex to send
     // stdout chunks / process_exit. Writing here guarantees the
-    // spawn_watch_result is on the wire first.
+    // spawn_process_result is on the wire first.
     //
     // If encoding or writing fails after spawn but before either monitor
     // takes ownership of `child`, we must reap here — `Child`'s `Drop`
     // does not wait, so a `?`-propagated error would leak the child as an
     // orphan/zombie inside the VM.
-    let payload = vsock_proto::encode_spawn_watch_result(pid);
-    let response = match vsock_proto::encode(MSG_SPAWN_WATCH_RESULT, seq, &payload) {
+    let payload = vsock_proto::encode_spawn_process_result(pid);
+    let response = match vsock_proto::encode(MSG_SPAWN_PROCESS_RESULT, seq, &payload) {
         Ok(r) => r,
         Err(e) => {
             kill_and_reap_child(child);
@@ -190,7 +190,7 @@ where
         ) {
             log(
                 "ERROR",
-                &format!("spawn_watch: failed to spawn streaming monitor for pid={pid}: {e}"),
+                &format!("spawn_process: failed to spawn streaming monitor for pid={pid}: {e}"),
             );
         }
     } else {
@@ -211,7 +211,7 @@ where
         ) {
             log(
                 "ERROR",
-                &format!("spawn_watch: failed to spawn buffered monitor for pid={pid}: {e}"),
+                &format!("spawn_process: failed to spawn buffered monitor for pid={pid}: {e}"),
             );
         }
     }
@@ -261,7 +261,7 @@ where
             let Some(child) = child_guard.into_child() else {
                 log(
                     "ERROR",
-                    "spawn_watch: streaming monitor child guard was empty",
+                    "spawn_process: streaming monitor child guard was empty",
                 );
                 return;
             };
@@ -374,7 +374,7 @@ where
                         Err(e) => {
                             log(
                                 "WARN",
-                                &format!("spawn_watch: failed to open log file {path}: {e}"),
+                                &format!("spawn_process: failed to open log file {path}: {e}"),
                             );
                             None
                         }
@@ -408,7 +408,7 @@ where
                     {
                         log(
                             "WARN",
-                            &format!("spawn_watch: failed to send stdout chunk: {e}"),
+                            &format!("spawn_process: failed to send stdout chunk: {e}"),
                         );
                         drain_cancel.store(true, Ordering::Release);
                     }
@@ -458,7 +458,7 @@ where
         log(
             "WARN",
             &format!(
-                "spawn_watch: pid={pid} drain deadline reached after \
+                "spawn_process: pid={pid} drain deadline reached after \
                      {DRAIN_DEADLINE_SECS}s, possible orphaned child process",
             ),
         );
@@ -476,7 +476,7 @@ where
     log(
         "INFO",
         &format!(
-            "spawn_watch: pid={} exited with code={}, stderr_len={} (streamed)",
+            "spawn_process: pid={} exited with code={}, stderr_len={} (streamed)",
             pid,
             exit_code,
             stderr.len()
@@ -543,7 +543,7 @@ where
             let Some(child) = child_guard.into_child() else {
                 log(
                     "ERROR",
-                    "spawn_watch: buffered monitor child guard was empty",
+                    "spawn_process: buffered monitor child guard was empty",
                 );
                 return;
             };
@@ -559,7 +559,7 @@ where
             log(
                 "INFO",
                 &format!(
-                    "spawn_watch: pid={} exited with code={}, stdout_len={}, stderr_len={}",
+                    "spawn_process: pid={} exited with code={}, stdout_len={}, stderr_len={}",
                     pid,
                     exit_code,
                     stdout.len(),
@@ -646,14 +646,14 @@ mod tests {
     }
 
     #[test]
-    fn spawn_watch_outer_monitor_spawn_failure_reports_process_exit_and_reaps_child() {
+    fn spawn_process_outer_monitor_spawn_failure_reports_process_exit_and_reaps_child() {
         let (guest, mut host) = UnixStream::pair().unwrap();
         host.set_read_timeout(Some(Duration::from_secs(3))).unwrap();
         let writer = GuestWriter::new(guest);
         let cancel = Arc::new(AtomicBool::new(false));
 
-        handle_spawn_watch_with_spawner(
-            SpawnWatchRequest {
+        handle_spawn_process_with_spawner(
+            SpawnProcessRequest {
                 timeout_ms: 0,
                 command: "sleep 60",
                 env: &[],
@@ -670,9 +670,9 @@ mod tests {
         .unwrap();
 
         let result = read_message(&mut host);
-        assert_eq!(result.msg_type, MSG_SPAWN_WATCH_RESULT);
+        assert_eq!(result.msg_type, MSG_SPAWN_PROCESS_RESULT);
         assert_eq!(result.seq, 7);
-        let pid = vsock_proto::decode_spawn_watch_result(&result.payload).unwrap();
+        let pid = vsock_proto::decode_spawn_process_result(&result.payload).unwrap();
 
         let exit = read_message(&mut host);
         assert_eq!(exit.msg_type, MSG_PROCESS_EXIT);
@@ -697,8 +697,8 @@ mod tests {
         let writer = GuestWriter::new(guest);
         let cancel = Arc::new(AtomicBool::new(false));
 
-        handle_spawn_watch_with_spawner(
-            SpawnWatchRequest {
+        handle_spawn_process_with_spawner(
+            SpawnProcessRequest {
                 timeout_ms: 0,
                 command: "sleep 60",
                 env: &[],
@@ -715,9 +715,9 @@ mod tests {
         .unwrap();
 
         let result = read_message(&mut host);
-        assert_eq!(result.msg_type, MSG_SPAWN_WATCH_RESULT);
+        assert_eq!(result.msg_type, MSG_SPAWN_PROCESS_RESULT);
         assert_eq!(result.seq, 8);
-        let pid = vsock_proto::decode_spawn_watch_result(&result.payload).unwrap();
+        let pid = vsock_proto::decode_spawn_process_result(&result.payload).unwrap();
 
         let exit = read_message(&mut host);
         assert_eq!(exit.msg_type, MSG_PROCESS_EXIT);
@@ -742,8 +742,8 @@ mod tests {
         let writer = GuestWriter::new(guest);
         let cancel = Arc::new(AtomicBool::new(false));
 
-        handle_spawn_watch_with_spawner(
-            SpawnWatchRequest {
+        handle_spawn_process_with_spawner(
+            SpawnProcessRequest {
                 timeout_ms: 0,
                 command: "sleep 60",
                 env: &[],
@@ -760,9 +760,9 @@ mod tests {
         .unwrap();
 
         let result = read_message(&mut host);
-        assert_eq!(result.msg_type, MSG_SPAWN_WATCH_RESULT);
+        assert_eq!(result.msg_type, MSG_SPAWN_PROCESS_RESULT);
         assert_eq!(result.seq, 10);
-        let pid = vsock_proto::decode_spawn_watch_result(&result.payload).unwrap();
+        let pid = vsock_proto::decode_spawn_process_result(&result.payload).unwrap();
 
         let exit = read_message(&mut host);
         assert_eq!(exit.msg_type, MSG_PROCESS_EXIT);
@@ -781,14 +781,14 @@ mod tests {
     }
 
     #[test]
-    fn buffered_spawn_watch_outer_monitor_spawn_failure_reports_process_exit_and_reaps_child() {
+    fn buffered_spawn_process_outer_monitor_spawn_failure_reports_process_exit_and_reaps_child() {
         let (guest, mut host) = UnixStream::pair().unwrap();
         host.set_read_timeout(Some(Duration::from_secs(3))).unwrap();
         let writer = GuestWriter::new(guest);
         let cancel = Arc::new(AtomicBool::new(false));
 
-        handle_spawn_watch_with_spawner(
-            SpawnWatchRequest {
+        handle_spawn_process_with_spawner(
+            SpawnProcessRequest {
                 timeout_ms: 0,
                 command: "sleep 60",
                 env: &[],
@@ -805,9 +805,9 @@ mod tests {
         .unwrap();
 
         let result = read_message(&mut host);
-        assert_eq!(result.msg_type, MSG_SPAWN_WATCH_RESULT);
+        assert_eq!(result.msg_type, MSG_SPAWN_PROCESS_RESULT);
         assert_eq!(result.seq, 9);
-        let pid = vsock_proto::decode_spawn_watch_result(&result.payload).unwrap();
+        let pid = vsock_proto::decode_spawn_process_result(&result.payload).unwrap();
 
         let exit = read_message(&mut host);
         assert_eq!(exit.msg_type, MSG_PROCESS_EXIT);
@@ -832,8 +832,8 @@ mod tests {
         let writer = GuestWriter::new(guest);
         let cancel = Arc::new(AtomicBool::new(false));
 
-        handle_spawn_watch_with_spawner(
-            SpawnWatchRequest {
+        handle_spawn_process_with_spawner(
+            SpawnProcessRequest {
                 timeout_ms: 0,
                 command: "sleep 60",
                 env: &[],
@@ -850,9 +850,9 @@ mod tests {
         .unwrap();
 
         let result = read_message(&mut host);
-        assert_eq!(result.msg_type, MSG_SPAWN_WATCH_RESULT);
+        assert_eq!(result.msg_type, MSG_SPAWN_PROCESS_RESULT);
         assert_eq!(result.seq, 11);
-        let pid = vsock_proto::decode_spawn_watch_result(&result.payload).unwrap();
+        let pid = vsock_proto::decode_spawn_process_result(&result.payload).unwrap();
 
         let exit = read_message(&mut host);
         assert_eq!(exit.msg_type, MSG_PROCESS_EXIT);

--- a/crates/vsock-guest/tests/connection.rs
+++ b/crates/vsock-guest/tests/connection.rs
@@ -14,8 +14,8 @@ use vsock_proto::{
     self, CommandCapturedOutput, CommandOutputPolicy, CommandOutputStream, CommandTermination,
     MSG_COMMAND_CANCEL, MSG_COMMAND_OUTPUT, MSG_COMMAND_RESULT, MSG_COMMAND_START, MSG_ERROR,
     MSG_OPERATIONS_QUIESCED, MSG_OPERATIONS_RESUMED, MSG_PROCESS_EXIT, MSG_QUIESCE_OPERATIONS,
-    MSG_RESUME_OPERATIONS, MSG_SHUTDOWN, MSG_SHUTDOWN_ACK, MSG_SPAWN_WATCH, MSG_SPAWN_WATCH_RESULT,
-    MSG_STDOUT_CHUNK, MSG_WRITE_FILE,
+    MSG_RESUME_OPERATIONS, MSG_SHUTDOWN, MSG_SHUTDOWN_ACK, MSG_SPAWN_PROCESS,
+    MSG_SPAWN_PROCESS_RESULT, MSG_STDOUT_CHUNK, MSG_WRITE_FILE,
 };
 
 const EXIT_CODE_TIMEOUT: i32 = 124;
@@ -198,7 +198,7 @@ fn run_sends_shutdown_ack_and_exits_without_waiting_for_disconnect() {
 }
 
 // -----------------------------------------------------------------------
-// Helpers for spawn_watch streaming tests
+// Helpers for spawn_process streaming tests
 // -----------------------------------------------------------------------
 
 /// Read one framed message from the stream.
@@ -1470,18 +1470,18 @@ fn read_retry_eintr(stream: &mut impl std::io::Read, buf: &mut [u8]) -> std::io:
     }
 }
 
-/// Send a MSG_SPAWN_WATCH message with streaming enabled.
-fn send_spawn_watch(
+/// Send a MSG_SPAWN_PROCESS message with streaming enabled.
+fn send_spawn_process(
     stream: &mut impl std::io::Write,
     seq: u32,
     command: &str,
     log_path: Option<&str>,
     timeout_ms: u32,
 ) {
-    send_spawn_watch_with_env(stream, seq, command, &[], log_path, timeout_ms);
+    send_spawn_process_with_env(stream, seq, command, &[], log_path, timeout_ms);
 }
 
-fn send_spawn_watch_with_env(
+fn send_spawn_process_with_env(
     stream: &mut impl std::io::Write,
     seq: u32,
     command: &str,
@@ -1490,12 +1490,12 @@ fn send_spawn_watch_with_env(
     timeout_ms: u32,
 ) {
     let payload =
-        vsock_proto::encode_spawn_watch(timeout_ms, command, env, false, true, log_path).unwrap();
-    let msg = vsock_proto::encode(MSG_SPAWN_WATCH, seq, &payload).unwrap();
+        vsock_proto::encode_spawn_process(timeout_ms, command, env, false, true, log_path).unwrap();
+    let msg = vsock_proto::encode(MSG_SPAWN_PROCESS, seq, &payload).unwrap();
     stream.write_all(&msg).unwrap();
 }
 
-/// Read all streaming messages for a spawn_watch command in a single loop.
+/// Read all streaming messages for a spawn_process command in a single loop.
 /// Uses one decoder to avoid losing messages when the OS batches multiple
 /// protocol frames into a single read buffer.
 ///
@@ -1512,9 +1512,9 @@ fn read_streaming_result(
         let n = read_retry_eintr(stream, &mut buf).unwrap();
         assert!(n > 0, "unexpected EOF waiting for streaming result");
         for msg in decoder.decode(buf.get(..n).unwrap_or_default()).unwrap() {
-            // Pick up the PID from spawn_watch_result
-            if msg.msg_type == MSG_SPAWN_WATCH_RESULT && msg.seq == seq {
-                pid = Some(vsock_proto::decode_spawn_watch_result(&msg.payload).unwrap());
+            // Pick up the PID from spawn_process_result
+            if msg.msg_type == MSG_SPAWN_PROCESS_RESULT && msg.seq == seq {
+                pid = Some(vsock_proto::decode_spawn_process_result(&msg.payload).unwrap());
                 continue;
             }
             let Some(p) = pid else { continue };
@@ -1556,7 +1556,7 @@ fn streaming_monitor_normal_exit() {
     read_and_discard_message(&mut host_stream);
 
     let log_path = unique_tmp_path("normal", ".log");
-    send_spawn_watch(
+    send_spawn_process(
         &mut host_stream,
         1,
         "echo hello",
@@ -1578,7 +1578,7 @@ fn streaming_monitor_normal_exit() {
 }
 
 #[test]
-fn streaming_spawn_watch_large_env_payload_succeeds() {
+fn streaming_spawn_process_large_env_payload_succeeds() {
     use std::os::unix::net::UnixStream as StdUnixStream;
 
     let values = large_env_values();
@@ -1593,7 +1593,7 @@ fn streaming_spawn_watch_large_env_payload_succeeds() {
         .set_read_timeout(Some(Duration::from_secs(5)))
         .unwrap();
 
-    send_spawn_watch_with_env(&mut host_stream, 1, LARGE_ENV_COMMAND, &env, None, 5000);
+    send_spawn_process_with_env(&mut host_stream, 1, LARGE_ENV_COMMAND, &env, None, 5000);
     let (_pid, stdout_data, exit_code, stderr) = read_streaming_result(&mut host_stream, 1);
 
     assert_eq!(exit_code, 0, "stderr: {}", String::from_utf8_lossy(&stderr));
@@ -1604,7 +1604,7 @@ fn streaming_spawn_watch_large_env_payload_succeeds() {
 }
 
 #[test]
-fn streaming_spawn_watch_invalid_env_payload_returns_error_without_leaking_value() {
+fn streaming_spawn_process_invalid_env_payload_returns_error_without_leaking_value() {
     use std::os::unix::net::UnixStream as StdUnixStream;
 
     let (guest_stream, mut host_stream) = StdUnixStream::pair().unwrap();
@@ -1617,7 +1617,7 @@ fn streaming_spawn_watch_invalid_env_payload_returns_error_without_leaking_value
         .unwrap();
 
     let secret = "do-not-print-this-secret";
-    send_spawn_watch_with_env(
+    send_spawn_process_with_env(
         &mut host_stream,
         1,
         "echo should-not-run",
@@ -1655,7 +1655,7 @@ fn streaming_monitor_clean_exit_returns_before_long_timeout() {
         .unwrap();
 
     let start = Instant::now();
-    send_spawn_watch(&mut host_stream, 1, "printf clean-exit", None, 60_000);
+    send_spawn_process(&mut host_stream, 1, "printf clean-exit", None, 60_000);
     let (pid, stdout_data, exit_code, stderr) = read_streaming_result(&mut host_stream, 1);
     let elapsed = start.elapsed();
 
@@ -1672,11 +1672,11 @@ fn streaming_monitor_clean_exit_returns_before_long_timeout() {
     let _ = handle.join();
 }
 
-/// `MSG_SPAWN_WATCH_RESULT` must arrive before stdout chunks for that request.
+/// `MSG_SPAWN_PROCESS_RESULT` must arrive before stdout chunks for that request.
 /// The host records the pid from the result and rejects lifecycle frames for
 /// that request until the pid is known.
 #[test]
-fn streaming_spawn_watch_result_precedes_stdout_chunks() {
+fn streaming_spawn_process_result_precedes_stdout_chunks() {
     use std::os::unix::net::UnixStream as StdUnixStream;
     use std::time::Instant;
 
@@ -1686,7 +1686,7 @@ fn streaming_spawn_watch_result_precedes_stdout_chunks() {
     });
 
     read_and_discard_message(&mut host_stream);
-    send_spawn_watch(&mut host_stream, 1, "printf ordered-output", None, 5000);
+    send_spawn_process(&mut host_stream, 1, "printf ordered-output", None, 5000);
 
     host_stream
         .set_read_timeout(Some(Duration::from_secs(5)))
@@ -1709,19 +1709,19 @@ fn streaming_spawn_watch_result_precedes_stdout_chunks() {
         let n = read_retry_eintr(&mut host_stream, &mut buf).unwrap();
         assert!(
             n > 0,
-            "unexpected EOF waiting for streaming spawn_watch result"
+            "unexpected EOF waiting for streaming spawn_process result"
         );
 
         for msg in decoder.decode(buf.get(..n).unwrap_or_default()).unwrap() {
-            if msg.msg_type == MSG_SPAWN_WATCH_RESULT && msg.seq == 1 {
-                assert!(pid.is_none(), "duplicate spawn_watch_result");
-                pid = Some(vsock_proto::decode_spawn_watch_result(&msg.payload).unwrap());
+            if msg.msg_type == MSG_SPAWN_PROCESS_RESULT && msg.seq == 1 {
+                assert!(pid.is_none(), "duplicate spawn_process_result");
+                pid = Some(vsock_proto::decode_spawn_process_result(&msg.payload).unwrap());
                 continue;
             }
 
             if msg.msg_type == MSG_STDOUT_CHUNK && msg.seq == 1 {
                 let Some(p) = pid else {
-                    panic!("stdout chunk arrived before spawn_watch_result");
+                    panic!("stdout chunk arrived before spawn_process_result");
                 };
                 let (chunk_pid, data) = vsock_proto::decode_stdout_chunk(&msg.payload).unwrap();
                 if chunk_pid == p {
@@ -1729,7 +1729,7 @@ fn streaming_spawn_watch_result_precedes_stdout_chunks() {
                 }
             } else if msg.msg_type == MSG_PROCESS_EXIT && msg.seq == 1 {
                 let Some(p) = pid else {
-                    panic!("process_exit arrived before spawn_watch_result");
+                    panic!("process_exit arrived before spawn_process_result");
                 };
                 let (exit_pid, code, _stdout, stderr) =
                     vsock_proto::decode_process_exit(&msg.payload).unwrap();
@@ -1764,7 +1764,7 @@ fn streaming_monitor_stream_only_does_not_write_guest_log() {
 
     let log_path = unique_tmp_path("stream-only", ".log");
     std::fs::write(log_path.as_str(), "preexisting\n").unwrap();
-    send_spawn_watch(&mut host_stream, 1, "echo stream-only", None, 5000);
+    send_spawn_process(&mut host_stream, 1, "echo stream-only", None, 5000);
 
     host_stream
         .set_read_timeout(Some(Duration::from_secs(10)))
@@ -1805,7 +1805,7 @@ fn streaming_monitor_drains_on_orphaned_stdout() {
     let log_path = unique_tmp_path("orphan", ".log");
     let orphan = OrphanProcessGuard::new("orphan-sleep");
     let command = orphan_sleep_command("orphan-test", orphan.pid_path());
-    send_spawn_watch(
+    send_spawn_process(
         &mut host_stream,
         1,
         &command,
@@ -1853,7 +1853,7 @@ fn streaming_monitor_timeout_kills_process() {
     // Command that runs longer than the timeout.
     // timeout_ms = 1000 (1s), command sleeps 60s → killed after 1s.
     let log_path = unique_tmp_path("timeout", ".log");
-    send_spawn_watch(
+    send_spawn_process(
         &mut host_stream,
         1,
         "echo timeout-test; sleep 60",
@@ -1885,17 +1885,17 @@ fn streaming_monitor_timeout_kills_process() {
 // Buffered (cancellable-drain) regression tests for #11077
 // -----------------------------------------------------------------------
 
-/// Send a `MSG_SPAWN_WATCH` with the buffered (no `stdout_log_path`) shape.
-fn send_spawn_watch_buffered(
+/// Send a `MSG_SPAWN_PROCESS` with the buffered (no `stdout_log_path`) shape.
+fn send_spawn_process_buffered(
     stream: &mut impl std::io::Write,
     seq: u32,
     command: &str,
     timeout_ms: u32,
 ) {
-    send_spawn_watch_buffered_with_env(stream, seq, command, &[], timeout_ms);
+    send_spawn_process_buffered_with_env(stream, seq, command, &[], timeout_ms);
 }
 
-fn send_spawn_watch_buffered_with_env(
+fn send_spawn_process_buffered_with_env(
     stream: &mut impl std::io::Write,
     seq: u32,
     command: &str,
@@ -1903,14 +1903,14 @@ fn send_spawn_watch_buffered_with_env(
     timeout_ms: u32,
 ) {
     let payload =
-        vsock_proto::encode_spawn_watch(timeout_ms, command, env, false, false, None).unwrap();
-    let msg = vsock_proto::encode(MSG_SPAWN_WATCH, seq, &payload).unwrap();
+        vsock_proto::encode_spawn_process(timeout_ms, command, env, false, false, None).unwrap();
+    let msg = vsock_proto::encode(MSG_SPAWN_PROCESS, seq, &payload).unwrap();
     stream.write_all(&msg).unwrap();
 }
 
-/// Read `MSG_SPAWN_WATCH_RESULT` + `MSG_PROCESS_EXIT` for a buffered
-/// spawn_watch and return `(pid, exit_code, stdout, stderr)`.
-fn read_buffered_spawn_watch_result(
+/// Read `MSG_SPAWN_PROCESS_RESULT` + `MSG_PROCESS_EXIT` for a buffered
+/// spawn_process and return `(pid, exit_code, stdout, stderr)`.
+fn read_buffered_spawn_process_result(
     stream: &mut impl std::io::Read,
     seq: u32,
 ) -> (u32, i32, Vec<u8>, Vec<u8>) {
@@ -1921,11 +1921,11 @@ fn read_buffered_spawn_watch_result(
         let n = read_retry_eintr(stream, &mut buf).unwrap();
         assert!(
             n > 0,
-            "unexpected EOF waiting for buffered spawn_watch result"
+            "unexpected EOF waiting for buffered spawn_process result"
         );
         for msg in decoder.decode(buf.get(..n).unwrap_or_default()).unwrap() {
-            if msg.msg_type == MSG_SPAWN_WATCH_RESULT && msg.seq == seq {
-                pid = Some(vsock_proto::decode_spawn_watch_result(&msg.payload).unwrap());
+            if msg.msg_type == MSG_SPAWN_PROCESS_RESULT && msg.seq == seq {
+                pid = Some(vsock_proto::decode_spawn_process_result(&msg.payload).unwrap());
                 continue;
             }
             let Some(p) = pid else { continue };
@@ -1941,26 +1941,26 @@ fn read_buffered_spawn_watch_result(
     }
 }
 
-fn read_spawn_watch_pid(stream: &mut impl std::io::Read, seq: u32) -> u32 {
+fn read_spawn_process_pid(stream: &mut impl std::io::Read, seq: u32) -> u32 {
     let mut decoder = vsock_proto::Decoder::new();
     let mut buf = [0u8; 4096];
     loop {
         let n = read_retry_eintr(stream, &mut buf).unwrap();
-        assert!(n > 0, "unexpected EOF waiting for spawn_watch pid");
+        assert!(n > 0, "unexpected EOF waiting for spawn_process pid");
         for msg in decoder.decode(buf.get(..n).unwrap_or_default()).unwrap() {
-            if msg.msg_type == MSG_SPAWN_WATCH_RESULT && msg.seq == seq {
-                return vsock_proto::decode_spawn_watch_result(&msg.payload).unwrap();
+            if msg.msg_type == MSG_SPAWN_PROCESS_RESULT && msg.seq == seq {
+                return vsock_proto::decode_spawn_process_result(&msg.payload).unwrap();
             }
         }
     }
 }
 
 #[test]
-fn spawn_watch_remains_pending_after_spawn_result_until_process_exit() {
+fn spawn_process_remains_pending_after_spawn_result_until_process_exit() {
     let (handle, mut host_stream) = start_guest_connection();
 
-    send_spawn_watch_buffered(&mut host_stream, 231, "sleep 60", 0);
-    let pid = read_spawn_watch_pid(&mut host_stream, 231);
+    send_spawn_process_buffered(&mut host_stream, 231, "sleep 60", 0);
+    let pid = read_spawn_process_pid(&mut host_stream, 231);
 
     send_quiesce_operations(&mut host_stream, 232);
     let busy = read_message(&mut host_stream);
@@ -2174,7 +2174,7 @@ fn pid_alive(pid: u32) -> bool {
 }
 
 #[test]
-fn spawn_watch_timeout_zero_silent_child_is_cancelled_on_host_disconnect() {
+fn spawn_process_timeout_zero_silent_child_is_cancelled_on_host_disconnect() {
     use std::os::unix::net::UnixStream as StdUnixStream;
 
     let (guest_stream, mut host_stream) = StdUnixStream::pair().unwrap();
@@ -2183,11 +2183,11 @@ fn spawn_watch_timeout_zero_silent_child_is_cancelled_on_host_disconnect() {
     });
     read_and_discard_message(&mut host_stream); // MSG_READY
 
-    send_spawn_watch(&mut host_stream, 1, "sleep 60", None, 0);
+    send_spawn_process(&mut host_stream, 1, "sleep 60", None, 0);
     host_stream
         .set_read_timeout(Some(Duration::from_secs(3)))
         .unwrap();
-    let pid = read_spawn_watch_pid(&mut host_stream, 1);
+    let pid = read_spawn_process_pid(&mut host_stream, 1);
     assert!(
         pid_alive(pid),
         "child should still be running before disconnect",
@@ -2195,11 +2195,11 @@ fn spawn_watch_timeout_zero_silent_child_is_cancelled_on_host_disconnect() {
 
     drop(host_stream);
     let _ = handle.join();
-    wait_for_pid_exit(pid, "spawn_watch host disconnect");
+    wait_for_pid_exit(pid, "spawn_process host disconnect");
 }
 
 #[test]
-fn spawn_watch_buffered_timeout_zero_silent_child_is_cancelled_on_host_disconnect() {
+fn spawn_process_buffered_timeout_zero_silent_child_is_cancelled_on_host_disconnect() {
     use std::os::unix::net::UnixStream as StdUnixStream;
 
     let (guest_stream, mut host_stream) = StdUnixStream::pair().unwrap();
@@ -2208,11 +2208,11 @@ fn spawn_watch_buffered_timeout_zero_silent_child_is_cancelled_on_host_disconnec
     });
     read_and_discard_message(&mut host_stream); // MSG_READY
 
-    send_spawn_watch_buffered(&mut host_stream, 1, "sleep 60", 0);
+    send_spawn_process_buffered(&mut host_stream, 1, "sleep 60", 0);
     host_stream
         .set_read_timeout(Some(Duration::from_secs(3)))
         .unwrap();
-    let pid = read_spawn_watch_pid(&mut host_stream, 1);
+    let pid = read_spawn_process_pid(&mut host_stream, 1);
     assert!(
         pid_alive(pid),
         "child should still be running before disconnect",
@@ -2220,11 +2220,11 @@ fn spawn_watch_buffered_timeout_zero_silent_child_is_cancelled_on_host_disconnec
 
     drop(host_stream);
     let _ = handle.join();
-    wait_for_pid_exit(pid, "buffered spawn_watch host disconnect");
+    wait_for_pid_exit(pid, "buffered spawn_process host disconnect");
 }
 
 #[test]
-fn buffered_spawn_watch_large_env_payload_succeeds() {
+fn buffered_spawn_process_large_env_payload_succeeds() {
     use std::os::unix::net::UnixStream as StdUnixStream;
 
     let values = large_env_values();
@@ -2239,8 +2239,8 @@ fn buffered_spawn_watch_large_env_payload_succeeds() {
         .set_read_timeout(Some(Duration::from_secs(5)))
         .unwrap();
 
-    send_spawn_watch_buffered_with_env(&mut host_stream, 1, LARGE_ENV_COMMAND, &env, 5000);
-    let (_pid, code, stdout, stderr) = read_buffered_spawn_watch_result(&mut host_stream, 1);
+    send_spawn_process_buffered_with_env(&mut host_stream, 1, LARGE_ENV_COMMAND, &env, 5000);
+    let (_pid, code, stdout, stderr) = read_buffered_spawn_process_result(&mut host_stream, 1);
 
     assert_eq!(code, 0, "stderr: {}", String::from_utf8_lossy(&stderr));
     assert_large_env_stdout(&stdout);
@@ -2274,7 +2274,7 @@ fn streaming_terminates_child_on_vsock_disconnect() {
     // streaming drain a chunk to forward at high frequency, so the post-
     // disconnect write failure is observed promptly.
     let log_path = unique_tmp_path("disco", ".log");
-    send_spawn_watch(
+    send_spawn_process(
         &mut host_stream,
         1,
         "while true; do echo tick; sleep 0.05; done",
@@ -2286,7 +2286,7 @@ fn streaming_terminates_child_on_vsock_disconnect() {
         .set_read_timeout(Some(Duration::from_secs(5)))
         .unwrap();
 
-    // Read until we observe both `MSG_SPAWN_WATCH_RESULT` (for the pid)
+    // Read until we observe both `MSG_SPAWN_PROCESS_RESULT` (for the pid)
     // and at least one `MSG_STDOUT_CHUNK` (proving the drain is live).
     let mut decoder = vsock_proto::Decoder::new();
     let mut buf = [0u8; 4096];
@@ -2296,12 +2296,12 @@ fn streaming_terminates_child_on_vsock_disconnect() {
     while pid.is_none() || !got_chunk {
         assert!(
             Instant::now() < stream_deadline,
-            "did not see spawn_watch_result + stdout chunk in time (pid={pid:?}, chunk={got_chunk})",
+            "did not see spawn_process_result + stdout chunk in time (pid={pid:?}, chunk={got_chunk})",
         );
         let n = read_retry_eintr(&mut host_stream, &mut buf).unwrap();
         for msg in decoder.decode(buf.get(..n).unwrap_or_default()).unwrap() {
-            if msg.msg_type == MSG_SPAWN_WATCH_RESULT && msg.seq == 1 {
-                pid = vsock_proto::decode_spawn_watch_result(&msg.payload).ok();
+            if msg.msg_type == MSG_SPAWN_PROCESS_RESULT && msg.seq == 1 {
+                pid = vsock_proto::decode_spawn_process_result(&msg.payload).ok();
             } else if msg.msg_type == MSG_STDOUT_CHUNK && msg.seq == 1 {
                 got_chunk = true;
             }
@@ -2326,7 +2326,7 @@ fn streaming_terminates_child_on_vsock_disconnect() {
     while pid_alive(pid) {
         if Instant::now() >= kill_deadline {
             // Best-effort cleanup before failing
-            // SAFETY: pid was obtained from MSG_SPAWN_WATCH_RESULT.
+            // SAFETY: pid was obtained from MSG_SPAWN_PROCESS_RESULT.
             unsafe {
                 libc::kill(pid as i32, libc::SIGKILL);
             }
@@ -2342,11 +2342,11 @@ fn streaming_terminates_child_on_vsock_disconnect() {
 /// the second pipe would fill, the child would block on its next write,
 /// and the test would hit the read timeout.
 ///
-/// Pins down the concurrent-drain invariant for buffered `MSG_SPAWN_WATCH`.
+/// Pins down the concurrent-drain invariant for buffered `MSG_SPAWN_PROCESS`.
 /// The streaming path in `spawn_streaming_monitor` follows the same
 /// stderr-thread-before-stdout-thread structure for the same reason.
 #[test]
-fn buffered_spawn_watch_concurrent_large_stdout_stderr() {
+fn buffered_spawn_process_concurrent_large_stdout_stderr() {
     use std::os::unix::net::UnixStream as StdUnixStream;
 
     let (guest_stream, mut host_stream) = StdUnixStream::pair().unwrap();
@@ -2366,13 +2366,13 @@ fn buffered_spawn_watch_concurrent_large_stdout_stderr() {
     // concurrently so stdout and stderr are interleaved producers.
     // 100 KB > the ~64 KB pipe buffer on Linux, so a single-threaded
     // drainer would visibly stall.
-    send_spawn_watch_buffered(
+    send_spawn_process_buffered(
         &mut host_stream,
         1,
         "{ yes A | head -c 102400; } & { yes B | head -c 102400 >&2; } & wait",
         10_000,
     );
-    let (pid, code, stdout, stderr) = read_buffered_spawn_watch_result(&mut host_stream, 1);
+    let (pid, code, stdout, stderr) = read_buffered_spawn_process_result(&mut host_stream, 1);
 
     assert!(pid > 0);
     assert_eq!(code, 0);
@@ -2395,13 +2395,13 @@ fn buffered_spawn_watch_concurrent_large_stdout_stderr() {
     let _ = handle.join();
 }
 
-/// Regression for #11077 (`MSG_SPAWN_WATCH` buffered side): symmetric to
+/// Regression for #11077 (`MSG_SPAWN_PROCESS` buffered side): symmetric to
 /// `streaming_monitor_drains_on_orphaned_stdout`. Pre-fix, the buffered
 /// monitor used the same `wait_with_output` and hung on a leaked stdout
 /// fd. Post-fix, drain threads observe the cancel flag at the deadline,
 /// drop the pipe read end, and the orphan's next write returns EPIPE.
 #[test]
-fn buffered_spawn_watch_returns_when_orphaned_grandchild_holds_stdout() {
+fn buffered_spawn_process_returns_when_orphaned_grandchild_holds_stdout() {
     use std::os::unix::net::UnixStream as StdUnixStream;
     use std::time::Instant;
 
@@ -2419,8 +2419,8 @@ fn buffered_spawn_watch_returns_when_orphaned_grandchild_holds_stdout() {
     let orphan = OrphanProcessGuard::new("orphan-buf-sleep");
     let command = orphan_sleep_command("orphan-buf", orphan.pid_path());
     let start = Instant::now();
-    send_spawn_watch_buffered(&mut host_stream, 1, &command, 0);
-    let (pid, code, stdout, _stderr) = read_buffered_spawn_watch_result(&mut host_stream, 1);
+    send_spawn_process_buffered(&mut host_stream, 1, &command, 0);
+    let (pid, code, stdout, _stderr) = read_buffered_spawn_process_result(&mut host_stream, 1);
     let elapsed = start.elapsed();
 
     assert!(pid > 0);

--- a/crates/vsock-host/src/command.rs
+++ b/crates/vsock-host/src/command.rs
@@ -1047,7 +1047,7 @@ pub(crate) async fn start_command_operation_on_shared(
     if request.timeout_ms == 0 {
         return Err(io::Error::new(
             io::ErrorKind::InvalidInput,
-            "command operation requires a positive timeout; use spawn_watch for unbounded commands",
+            "command operation requires a positive timeout; use spawn_process for unbounded commands",
         ));
     }
     if matches!(request.stream_queue_capacity, Some(0)) {
@@ -1264,7 +1264,7 @@ pub(crate) async fn exec_capture_on_shared(
     if request.timeout_ms == 0 {
         return Err(io::Error::new(
             io::ErrorKind::InvalidInput,
-            "exec requires a positive timeout; use spawn_watch for unbounded commands",
+            "exec requires a positive timeout; use spawn_process for unbounded commands",
         ));
     }
     let result = command_capture_on_shared(shared, request).await?;

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -40,7 +40,7 @@ use tokio::time::{self, Instant};
 use vsock_proto::{
     Decoder, MSG_COMMAND_OUTPUT, MSG_COMMAND_RESULT, MSG_ERROR, MSG_OPERATIONS_QUIESCED,
     MSG_OPERATIONS_RESUMED, MSG_PING, MSG_PONG, MSG_PROCESS_EXIT, MSG_QUIESCE_OPERATIONS,
-    MSG_READY, MSG_RESUME_OPERATIONS, MSG_SHUTDOWN, MSG_SHUTDOWN_ACK, MSG_SPAWN_WATCH_RESULT,
+    MSG_READY, MSG_RESUME_OPERATIONS, MSG_SHUTDOWN, MSG_SHUTDOWN_ACK, MSG_SPAWN_PROCESS_RESULT,
     MSG_STDOUT_CHUNK, RawMessage,
 };
 
@@ -49,7 +49,7 @@ pub use command::{
     CommandOutputEvent, CommandOwnedCapturedOutput, CommandStreamRequest,
 };
 pub use file::{CopyFileOptions, CopyFileResult};
-pub use process::{ProcessExitEvent, SpawnWatchHandle};
+pub use process::{GuestProcessHandle, ProcessExitEvent};
 
 const READ_BUF_SIZE: usize = 64 * 1024;
 
@@ -79,7 +79,7 @@ enum ConnectionState {
         pending: HashMap<u32, oneshot::Sender<RawMessage>>,
         /// Active command-operation state owned by the command module.
         operations: command::Operations,
-        /// Active spawn_watch operation state owned by the process module.
+        /// Active spawn_process operation state owned by the process module.
         process: process::ConnectedProcessState,
     },
     Closed {
@@ -263,7 +263,7 @@ impl Drop for VsockHost {
 
 /// Background reader task: owns the read half and decoder exclusively.
 ///
-/// Dispatches responses, command operations, and spawn_watch lifecycle frames
+/// Dispatches responses, command operations, and spawn_process lifecycle frames
 /// by seq number.
 async fn reader_loop(
     mut reader: tokio::net::unix::OwnedReadHalf,
@@ -319,8 +319,8 @@ async fn reader_loop(
                     return;
                 }
             } else {
-                if msg.msg_type == MSG_SPAWN_WATCH_RESULT
-                    && process::record_spawn_watch_result(&shared, &msg).is_err()
+                if msg.msg_type == MSG_SPAWN_PROCESS_RESULT
+                    && process::record_spawn_process_result(&shared, &msg).is_err()
                 {
                     shared.poison_connection();
                     return;
@@ -671,7 +671,7 @@ impl VsockHost {
     /// Execute a command on the guest.
     ///
     /// `timeout_ms` must be positive. Callers needing unbounded commands
-    /// should use [`spawn_watch`](Self::spawn_watch), which decouples the
+    /// should use [`spawn_process`](Self::spawn_process), which decouples the
     /// host request/response cycle from the command's lifetime and does not
     /// leak a guest-side orphan when the host stops waiting.
     pub async fn exec(
@@ -691,16 +691,16 @@ impl VsockHost {
 
     /// Spawn a process on the guest and monitor for exit.
     ///
-    /// Returns immediately with a handle. Use [`SpawnWatchHandle::wait`] to
+    /// Returns immediately with a handle. Use [`GuestProcessHandle::wait`] to
     /// wait for completion.
     ///
     /// When `stream_stdout` is true, stdout chunks are streamed to the host via
     /// `MSG_STDOUT_CHUNK`. `stdout_log_path`, when present, additionally asks
     /// the guest to tee those chunks into the given guest-side file.
-    /// Use [`SpawnWatchHandle::take_stdout_receiver`] to receive streamed chunks
+    /// Use [`GuestProcessHandle::take_stdout_receiver`] to receive streamed chunks
     /// when enabled. The receiver is closed when the process exits or the
     /// connection drops.
-    pub async fn spawn_watch(
+    pub async fn spawn_process(
         &self,
         command: &str,
         timeout_ms: u32,
@@ -708,8 +708,8 @@ impl VsockHost {
         sudo: bool,
         stream_stdout: bool,
         stdout_log_path: Option<&str>,
-    ) -> io::Result<SpawnWatchHandle> {
-        process::spawn_watch_on_shared(
+    ) -> io::Result<GuestProcessHandle> {
+        process::spawn_process_on_shared(
             &self.shared,
             command,
             timeout_ms,

--- a/crates/vsock-host/src/process.rs
+++ b/crates/vsock-host/src/process.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use tokio::sync::{mpsc, oneshot};
-use vsock_proto::{MSG_ERROR, MSG_SPAWN_WATCH, MSG_SPAWN_WATCH_RESULT, RawMessage};
+use vsock_proto::{MSG_ERROR, MSG_SPAWN_PROCESS, MSG_SPAWN_PROCESS_RESULT, RawMessage};
 
 use crate::{ConnectionState, Shared, request_raw_on_shared};
 
@@ -27,7 +27,7 @@ struct SpawnOperation {
 
 /// Process lifecycle state while the vsock connection is open.
 pub(crate) struct ConnectedProcessState {
-    /// Active spawn_watch operations keyed by request sequence number.
+    /// Active spawn_process operations keyed by request sequence number.
     operations: HashMap<u32, SpawnOperation>,
 }
 
@@ -98,7 +98,7 @@ fn require_recorded_lifecycle_pid(
     let expected = expected.ok_or_else(|| {
         io::Error::new(
             io::ErrorKind::InvalidData,
-            format!("{frame} arrived before spawn_watch_result for pid {actual}"),
+            format!("{frame} arrived before spawn_process_result for pid {actual}"),
         )
     })?;
     validate_lifecycle_pid(frame, Some(expected), actual)?;
@@ -148,7 +148,7 @@ impl Drop for SpawnOperationRegistrationGuard {
     }
 }
 
-/// Handle for a spawn_watch operation.
+/// Handle for a spawn_process operation.
 ///
 /// Dropping the handle removes the host-side operation registration. It does
 /// not send a guest-side cancellation request; this matches the previous
@@ -158,7 +158,7 @@ impl Drop for SpawnOperationRegistrationGuard {
 /// before [`wait`](Self::wait). Waiting consumes the handle and drops any
 /// unclaimed stdout receiver so streamed output is not buffered without a
 /// reader.
-pub struct SpawnWatchHandle {
+pub struct GuestProcessHandle {
     shared: Arc<Shared>,
     seq: Option<u32>,
     pid: u32,
@@ -166,9 +166,9 @@ pub struct SpawnWatchHandle {
     exit_rx: Option<oneshot::Receiver<ProcessExitEvent>>,
 }
 
-impl fmt::Debug for SpawnWatchHandle {
+impl fmt::Debug for GuestProcessHandle {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("SpawnWatchHandle")
+        f.debug_struct("GuestProcessHandle")
             .field("seq", &self.seq)
             .field("pid", &self.pid)
             .field("has_stdout_receiver", &self.stdout_rx.is_some())
@@ -177,7 +177,7 @@ impl fmt::Debug for SpawnWatchHandle {
     }
 }
 
-impl SpawnWatchHandle {
+impl GuestProcessHandle {
     pub fn pid(&self) -> u32 {
         self.pid
     }
@@ -190,7 +190,7 @@ impl SpawnWatchHandle {
         let rx = self.exit_rx.take().ok_or_else(|| {
             io::Error::new(
                 io::ErrorKind::ConnectionReset,
-                "spawn_watch operation closed",
+                "spawn_process operation closed",
             )
         })?;
 
@@ -207,7 +207,7 @@ impl SpawnWatchHandle {
     }
 }
 
-impl Drop for SpawnWatchHandle {
+impl Drop for GuestProcessHandle {
     fn drop(&mut self) {
         if let Some(seq) = self.seq.take() {
             remove_spawn_operation(&self.shared, seq);
@@ -222,22 +222,25 @@ fn remove_spawn_operation(shared: &Arc<Shared>, seq: u32) {
     }
 }
 
-pub(crate) fn record_spawn_watch_result(shared: &Arc<Shared>, msg: &RawMessage) -> io::Result<()> {
+pub(crate) fn record_spawn_process_result(
+    shared: &Arc<Shared>,
+    msg: &RawMessage,
+) -> io::Result<()> {
     let mut guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
     if let ConnectionState::Connected { process, .. } = &mut *guard
         && let Some(operation) = process.operation_mut(msg.seq)
     {
         if let Some(expected) = operation.pid {
-            let pid = vsock_proto::decode_spawn_watch_result(&msg.payload)
+            let pid = vsock_proto::decode_spawn_process_result(&msg.payload)
                 .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
-            validate_lifecycle_pid("spawn_watch_result", Some(expected), pid)?;
+            validate_lifecycle_pid("spawn_process_result", Some(expected), pid)?;
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
-                format!("duplicate spawn_watch_result for pid {pid}"),
+                format!("duplicate spawn_process_result for pid {pid}"),
             ));
         }
 
-        let pid = match vsock_proto::decode_spawn_watch_result(&msg.payload) {
+        let pid = match vsock_proto::decode_spawn_process_result(&msg.payload) {
             Ok(pid) => pid,
             // Initial malformed responses are still delivered to the pending
             // request path, which returns InvalidData and drops the operation.
@@ -263,7 +266,7 @@ pub(crate) fn dispatch_stdout_chunk(shared: &Arc<Shared>, msg: &RawMessage) -> i
         if !operation.streams_stdout {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
-                format!("stdout_chunk for non-streaming spawn_watch pid {pid}"),
+                format!("stdout_chunk for non-streaming spawn_process pid {pid}"),
             ));
         }
         (operation.stdout_tx.clone(), data)
@@ -314,7 +317,7 @@ pub(crate) fn dispatch_process_exit(shared: &Arc<Shared>, msg: &RawMessage) -> i
     Ok(())
 }
 
-pub(crate) async fn spawn_watch_on_shared(
+pub(crate) async fn spawn_process_on_shared(
     shared: &Arc<Shared>,
     command: &str,
     timeout_ms: u32,
@@ -322,8 +325,8 @@ pub(crate) async fn spawn_watch_on_shared(
     sudo: bool,
     stream_stdout: bool,
     stdout_log_path: Option<&str>,
-) -> io::Result<SpawnWatchHandle> {
-    let payload = vsock_proto::encode_spawn_watch(
+) -> io::Result<GuestProcessHandle> {
+    let payload = vsock_proto::encode_spawn_process(
         timeout_ms,
         command,
         env,
@@ -367,7 +370,7 @@ pub(crate) async fn spawn_watch_on_shared(
 
     let resp = request_raw_on_shared(
         shared,
-        MSG_SPAWN_WATCH,
+        MSG_SPAWN_PROCESS,
         seq,
         &payload,
         Duration::from_secs(30),
@@ -380,19 +383,19 @@ pub(crate) async fn spawn_watch_on_shared(
         return Err(io::Error::other(msg));
     }
 
-    if resp.msg_type != MSG_SPAWN_WATCH_RESULT {
+    if resp.msg_type != MSG_SPAWN_PROCESS_RESULT {
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,
             format!("unexpected response type: 0x{:02X}", resp.msg_type),
         ));
     }
 
-    let pid = vsock_proto::decode_spawn_watch_result(&resp.payload)
+    let pid = vsock_proto::decode_spawn_process_result(&resp.payload)
         .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
 
     registration_guard.disarm();
 
-    Ok(SpawnWatchHandle {
+    Ok(GuestProcessHandle {
         shared: Arc::clone(shared),
         seq: Some(seq),
         pid,

--- a/crates/vsock-host/src/process.rs
+++ b/crates/vsock-host/src/process.rs
@@ -18,7 +18,7 @@ pub struct ProcessExitEvent {
     pub stderr: Vec<u8>,
 }
 
-struct SpawnOperation {
+struct ProcessOperation {
     pid: Option<u32>,
     streams_stdout: bool,
     stdout_tx: Option<mpsc::UnboundedSender<Vec<u8>>>,
@@ -28,7 +28,7 @@ struct SpawnOperation {
 /// Process lifecycle state while the vsock connection is open.
 pub(crate) struct ConnectedProcessState {
     /// Active spawn_process operations keyed by request sequence number.
-    operations: HashMap<u32, SpawnOperation>,
+    operations: HashMap<u32, ProcessOperation>,
 }
 
 impl ConnectedProcessState {
@@ -47,7 +47,7 @@ impl ConnectedProcessState {
         )
     }
 
-    fn insert_operation(&mut self, seq: u32, operation: SpawnOperation) {
+    fn insert_operation(&mut self, seq: u32, operation: ProcessOperation) {
         self.operations.insert(seq, operation);
     }
 
@@ -55,11 +55,11 @@ impl ConnectedProcessState {
         self.operations.remove(&seq);
     }
 
-    fn operation_mut(&mut self, seq: u32) -> Option<&mut SpawnOperation> {
+    fn operation_mut(&mut self, seq: u32) -> Option<&mut ProcessOperation> {
         self.operations.get_mut(&seq)
     }
 
-    fn take_operation(&mut self, seq: u32) -> Option<SpawnOperation> {
+    fn take_operation(&mut self, seq: u32) -> Option<ProcessOperation> {
         self.operations.remove(&seq)
     }
 
@@ -114,19 +114,19 @@ impl ClosedProcessState {
     }
 }
 
-/// Spawn operation map moved out during close so drops happen outside
+/// Process operation map moved out during close so drops happen outside
 /// `Shared.state`.
 pub(crate) struct ProcessOperationMap {
-    _operations: HashMap<u32, SpawnOperation>,
+    _operations: HashMap<u32, ProcessOperation>,
 }
 
-struct SpawnOperationRegistrationGuard {
+struct ProcessOperationRegistrationGuard {
     shared: Arc<Shared>,
     seq: u32,
     disarmed: bool,
 }
 
-impl SpawnOperationRegistrationGuard {
+impl ProcessOperationRegistrationGuard {
     fn new(shared: Arc<Shared>, seq: u32) -> Self {
         Self {
             shared,
@@ -140,10 +140,10 @@ impl SpawnOperationRegistrationGuard {
     }
 }
 
-impl Drop for SpawnOperationRegistrationGuard {
+impl Drop for ProcessOperationRegistrationGuard {
     fn drop(&mut self) {
         if !self.disarmed {
-            remove_spawn_operation(&self.shared, self.seq);
+            remove_process_operation(&self.shared, self.seq);
         }
     }
 }
@@ -210,12 +210,12 @@ impl GuestProcessHandle {
 impl Drop for GuestProcessHandle {
     fn drop(&mut self) {
         if let Some(seq) = self.seq.take() {
-            remove_spawn_operation(&self.shared, seq);
+            remove_process_operation(&self.shared, seq);
         }
     }
 }
 
-fn remove_spawn_operation(shared: &Arc<Shared>, seq: u32) {
+fn remove_process_operation(shared: &Arc<Shared>, seq: u32) {
     let mut guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
     if let ConnectionState::Connected { process, .. } = &mut *guard {
         process.remove_operation(seq);
@@ -356,7 +356,7 @@ pub(crate) async fn spawn_process_on_shared(
             ConnectionState::Connected { process, .. } => {
                 process.insert_operation(
                     seq,
-                    SpawnOperation {
+                    ProcessOperation {
                         pid: None,
                         streams_stdout: stream_stdout,
                         stdout_tx,
@@ -366,7 +366,7 @@ pub(crate) async fn spawn_process_on_shared(
             }
         }
     }
-    let mut registration_guard = SpawnOperationRegistrationGuard::new(Arc::clone(shared), seq);
+    let mut registration_guard = ProcessOperationRegistrationGuard::new(Arc::clone(shared), seq);
 
     let resp = request_raw_on_shared(
         shared,

--- a/crates/vsock-host/src/tests/process.rs
+++ b/crates/vsock-host/src/tests/process.rs
@@ -3,12 +3,12 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use super::support::{host_from_stream, make_pair, mock_handshake, send_command_result};
-use crate::{ConnectionState, SpawnWatchHandle, VsockHost};
+use crate::{ConnectionState, GuestProcessHandle, VsockHost};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::sync::{Notify, oneshot};
 use vsock_proto::{
-    CommandTermination, Decoder, MSG_COMMAND_START, MSG_ERROR, MSG_PROCESS_EXIT, MSG_SPAWN_WATCH,
-    MSG_SPAWN_WATCH_RESULT, MSG_STDOUT_CHUNK,
+    CommandTermination, Decoder, MSG_COMMAND_START, MSG_ERROR, MSG_PROCESS_EXIT, MSG_SPAWN_PROCESS,
+    MSG_SPAWN_PROCESS_RESULT, MSG_STDOUT_CHUNK,
 };
 
 fn registration_counts(host: &VsockHost) -> (usize, usize, usize) {
@@ -24,14 +24,14 @@ fn registration_counts(host: &VsockHost) -> (usize, usize, usize) {
     }
 }
 
-async fn wait_spawn(handle: SpawnWatchHandle) -> io::Result<crate::ProcessExitEvent> {
+async fn wait_spawn(handle: GuestProcessHandle) -> io::Result<crate::ProcessExitEvent> {
     tokio::time::timeout(Duration::from_secs(5), handle.wait())
         .await
-        .expect("spawn_watch exit should arrive before timeout")
+        .expect("spawn_process exit should arrive before timeout")
 }
 
 #[tokio::test]
-async fn test_spawn_watch_and_wait() {
+async fn test_spawn_process_and_wait() {
     let (host_stream, mut guest) = make_pair();
 
     tokio::spawn(async move {
@@ -41,11 +41,11 @@ async fn test_spawn_watch_and_wait() {
         let mut buf = [0u8; 4096];
         let n = guest.read(&mut buf).await.unwrap();
         let msgs = decoder.decode(&buf[..n]).unwrap();
-        assert_eq!(msgs[0].msg_type, MSG_SPAWN_WATCH);
+        assert_eq!(msgs[0].msg_type, MSG_SPAWN_PROCESS);
         let spawn_seq = msgs[0].seq;
 
-        let payload = vsock_proto::encode_spawn_watch_result(42);
-        let resp = vsock_proto::encode(MSG_SPAWN_WATCH_RESULT, spawn_seq, &payload).unwrap();
+        let payload = vsock_proto::encode_spawn_process_result(42);
+        let resp = vsock_proto::encode(MSG_SPAWN_PROCESS_RESULT, spawn_seq, &payload).unwrap();
         guest.write_all(&resp).await.unwrap();
 
         let exit_payload = vsock_proto::encode_process_exit(42, 0, b"done", b"");
@@ -58,13 +58,13 @@ async fn test_spawn_watch_and_wait() {
 
     let host = host_from_stream(host_stream).await.unwrap();
     let mut handle = host
-        .spawn_watch("sleep 1", 0, &[], false, false, None)
+        .spawn_process("sleep 1", 0, &[], false, false, None)
         .await
         .unwrap();
     assert_eq!(handle.pid(), 42);
     assert!(
         handle.take_stdout_receiver().is_none(),
-        "buffered spawn_watch must not keep a stdout stream registered",
+        "buffered spawn_process must not keep a stdout stream registered",
     );
 
     let event = wait_spawn(handle).await.unwrap();
@@ -84,11 +84,11 @@ async fn test_exit_event_before_wait() {
         let mut buf = [0u8; 4096];
         let n = guest.read(&mut buf).await.unwrap();
         let msgs = decoder.decode(&buf[..n]).unwrap();
-        assert_eq!(msgs[0].msg_type, MSG_SPAWN_WATCH);
+        assert_eq!(msgs[0].msg_type, MSG_SPAWN_PROCESS);
         let spawn_seq = msgs[0].seq;
 
-        let payload = vsock_proto::encode_spawn_watch_result(99);
-        let resp = vsock_proto::encode(MSG_SPAWN_WATCH_RESULT, spawn_seq, &payload).unwrap();
+        let payload = vsock_proto::encode_spawn_process_result(99);
+        let resp = vsock_proto::encode(MSG_SPAWN_PROCESS_RESULT, spawn_seq, &payload).unwrap();
         let exit_payload = vsock_proto::encode_process_exit(99, 1, b"", b"error");
         let exit_msg = vsock_proto::encode(MSG_PROCESS_EXIT, spawn_seq, &exit_payload).unwrap();
 
@@ -102,7 +102,7 @@ async fn test_exit_event_before_wait() {
 
     let host = host_from_stream(host_stream).await.unwrap();
     let handle = host
-        .spawn_watch("false", 0, &[], false, false, None)
+        .spawn_process("false", 0, &[], false, false, None)
         .await
         .unwrap();
     assert_eq!(handle.pid(), 99);
@@ -113,7 +113,7 @@ async fn test_exit_event_before_wait() {
 }
 
 #[tokio::test]
-async fn test_spawn_watch_error_response_cleans_up() {
+async fn test_spawn_process_error_response_cleans_up() {
     let (host_stream, mut guest) = make_pair();
 
     tokio::spawn(async move {
@@ -123,17 +123,17 @@ async fn test_spawn_watch_error_response_cleans_up() {
         let mut buf = [0u8; 4096];
         let n = guest.read(&mut buf).await.unwrap();
         let msgs = decoder.decode(&buf[..n]).unwrap();
-        assert_eq!(msgs[0].msg_type, MSG_SPAWN_WATCH);
+        assert_eq!(msgs[0].msg_type, MSG_SPAWN_PROCESS);
         let err_payload = vsock_proto::encode_error("no such command");
         let err_resp = vsock_proto::encode(MSG_ERROR, msgs[0].seq, &err_payload).unwrap();
         guest.write_all(&err_resp).await.unwrap();
 
         let n = guest.read(&mut buf).await.unwrap();
         let msgs = decoder.decode(&buf[..n]).unwrap();
-        assert_eq!(msgs[0].msg_type, MSG_SPAWN_WATCH);
-        let ok_payload = vsock_proto::encode_spawn_watch_result(222);
+        assert_eq!(msgs[0].msg_type, MSG_SPAWN_PROCESS);
+        let ok_payload = vsock_proto::encode_spawn_process_result(222);
         let ok_resp =
-            vsock_proto::encode(MSG_SPAWN_WATCH_RESULT, msgs[0].seq, &ok_payload).unwrap();
+            vsock_proto::encode(MSG_SPAWN_PROCESS_RESULT, msgs[0].seq, &ok_payload).unwrap();
         guest.write_all(&ok_resp).await.unwrap();
 
         let mut discard = [0u8; 1];
@@ -143,25 +143,25 @@ async fn test_spawn_watch_error_response_cleans_up() {
     let host = host_from_stream(host_stream).await.unwrap();
 
     let err = host
-        .spawn_watch("bad-cmd", 0, &[], false, true, None)
+        .spawn_process("bad-cmd", 0, &[], false, true, None)
         .await
         .unwrap_err();
     assert!(err.to_string().contains("no such command"));
     assert_eq!(
         registration_counts(&host),
         (0, 0, 0),
-        "streaming spawn_watch error must clean operation registration",
+        "streaming spawn_process error must clean operation registration",
     );
 
     let handle = host
-        .spawn_watch("good-cmd", 0, &[], false, false, None)
+        .spawn_process("good-cmd", 0, &[], false, false, None)
         .await
         .unwrap();
     assert_eq!(handle.pid(), 222);
 }
 
 #[tokio::test]
-async fn test_spawn_watch_malformed_result_cleans_up() {
+async fn test_spawn_process_malformed_result_cleans_up() {
     let (host_stream, mut guest) = make_pair();
 
     tokio::spawn(async move {
@@ -173,14 +173,14 @@ async fn test_spawn_watch_malformed_result_cleans_up() {
         let msgs = decoder.decode(&buf[..n]).unwrap();
         let bad_payload = b"\x00\x01\x02";
         let bad_resp =
-            vsock_proto::encode(MSG_SPAWN_WATCH_RESULT, msgs[0].seq, bad_payload).unwrap();
+            vsock_proto::encode(MSG_SPAWN_PROCESS_RESULT, msgs[0].seq, bad_payload).unwrap();
         guest.write_all(&bad_resp).await.unwrap();
 
         let n = guest.read(&mut buf).await.unwrap();
         let msgs = decoder.decode(&buf[..n]).unwrap();
-        let ok_payload = vsock_proto::encode_spawn_watch_result(333);
+        let ok_payload = vsock_proto::encode_spawn_process_result(333);
         let ok_resp =
-            vsock_proto::encode(MSG_SPAWN_WATCH_RESULT, msgs[0].seq, &ok_payload).unwrap();
+            vsock_proto::encode(MSG_SPAWN_PROCESS_RESULT, msgs[0].seq, &ok_payload).unwrap();
         guest.write_all(&ok_resp).await.unwrap();
 
         let mut discard = [0u8; 1];
@@ -190,25 +190,25 @@ async fn test_spawn_watch_malformed_result_cleans_up() {
     let host = host_from_stream(host_stream).await.unwrap();
 
     let err = host
-        .spawn_watch("bad-payload-cmd", 0, &[], false, true, None)
+        .spawn_process("bad-payload-cmd", 0, &[], false, true, None)
         .await
         .unwrap_err();
     assert_eq!(err.kind(), io::ErrorKind::InvalidData);
     assert_eq!(
         registration_counts(&host),
         (0, 0, 0),
-        "malformed streaming spawn_watch result must clean operation registration",
+        "malformed streaming spawn_process result must clean operation registration",
     );
 
     let handle = host
-        .spawn_watch("good-cmd", 0, &[], false, false, None)
+        .spawn_process("good-cmd", 0, &[], false, false, None)
         .await
         .unwrap();
     assert_eq!(handle.pid(), 333);
 }
 
 #[tokio::test]
-async fn test_spawn_watch_connection_closed_before_result_cleans_up() {
+async fn test_spawn_process_connection_closed_before_result_cleans_up() {
     let (host_stream, mut guest) = make_pair();
     let request_seen = Arc::new(Notify::new());
 
@@ -221,7 +221,7 @@ async fn test_spawn_watch_connection_closed_before_result_cleans_up() {
             let mut buf = [0u8; 4096];
             let n = guest.read(&mut buf).await.unwrap();
             let msgs = decoder.decode(&buf[..n]).unwrap();
-            assert_eq!(msgs[0].msg_type, MSG_SPAWN_WATCH);
+            assert_eq!(msgs[0].msg_type, MSG_SPAWN_PROCESS);
             request_seen.notify_one();
             drop(guest);
         });
@@ -231,20 +231,20 @@ async fn test_spawn_watch_connection_closed_before_result_cleans_up() {
     let task_host = Arc::clone(&host);
     let task = tokio::spawn(async move {
         task_host
-            .spawn_watch("pending-result", 0, &[], false, true, None)
+            .spawn_process("pending-result", 0, &[], false, true, None)
             .await
     });
 
     tokio::time::timeout(Duration::from_secs(5), request_seen.notified())
         .await
-        .expect("guest should receive spawn_watch request");
+        .expect("guest should receive spawn_process request");
 
     let err = task.await.unwrap().unwrap_err();
     assert_eq!(err.kind(), io::ErrorKind::ConnectionReset);
     assert_eq!(
         registration_counts(&host),
         (0, 0, 0),
-        "connection close while spawn_watch is pending must clean registrations",
+        "connection close while spawn_process is pending must clean registrations",
     );
 }
 
@@ -265,11 +265,11 @@ async fn test_malformed_unsolicited_process_frames_are_ignored() {
         let mut buf = [0u8; 4096];
         let n = guest.read(&mut buf).await.unwrap();
         let msgs = decoder.decode(&buf[..n]).unwrap();
-        assert_eq!(msgs[0].msg_type, MSG_SPAWN_WATCH);
+        assert_eq!(msgs[0].msg_type, MSG_SPAWN_PROCESS);
         let spawn_seq = msgs[0].seq;
 
-        let payload = vsock_proto::encode_spawn_watch_result(444);
-        let resp = vsock_proto::encode(MSG_SPAWN_WATCH_RESULT, spawn_seq, &payload).unwrap();
+        let payload = vsock_proto::encode_spawn_process_result(444);
+        let resp = vsock_proto::encode(MSG_SPAWN_PROCESS_RESULT, spawn_seq, &payload).unwrap();
         guest.write_all(&resp).await.unwrap();
 
         let exit_payload = vsock_proto::encode_process_exit(444, 0, b"after-malformed", b"");
@@ -282,7 +282,7 @@ async fn test_malformed_unsolicited_process_frames_are_ignored() {
 
     let host = host_from_stream(host_stream).await.unwrap();
     let handle = host
-        .spawn_watch("after-malformed", 0, &[], false, false, None)
+        .spawn_process("after-malformed", 0, &[], false, false, None)
         .await
         .unwrap();
     assert_eq!(handle.pid(), 444);
@@ -306,7 +306,7 @@ async fn assert_lifecycle_before_result_closes(
         let mut buf = [0u8; 4096];
         let n = guest.read(&mut buf).await.unwrap();
         let msgs = decoder.decode(&buf[..n]).unwrap();
-        assert_eq!(msgs[0].msg_type, MSG_SPAWN_WATCH);
+        assert_eq!(msgs[0].msg_type, MSG_SPAWN_PROCESS);
         let spawn_seq = msgs[0].seq;
 
         let frame = vsock_proto::encode(msg_type, spawn_seq, &payload).unwrap();
@@ -319,7 +319,7 @@ async fn assert_lifecycle_before_result_closes(
     let host = host_from_stream(host_stream).await.unwrap();
     let result = tokio::time::timeout(
         Duration::from_secs(5),
-        host.spawn_watch("early-lifecycle", 0, &[], false, stream_stdout, None),
+        host.spawn_process("early-lifecycle", 0, &[], false, stream_stdout, None),
     )
     .await
     .expect("pre-result lifecycle frame should close connection promptly");
@@ -333,7 +333,7 @@ async fn assert_lifecycle_before_result_closes(
 }
 
 #[tokio::test]
-async fn test_stdout_chunk_before_spawn_watch_result_closes_and_cleans_up() {
+async fn test_stdout_chunk_before_spawn_process_result_closes_and_cleans_up() {
     assert_lifecycle_before_result_closes(
         MSG_STDOUT_CHUNK,
         vsock_proto::encode_stdout_chunk(777, b"early stdout"),
@@ -343,7 +343,7 @@ async fn test_stdout_chunk_before_spawn_watch_result_closes_and_cleans_up() {
 }
 
 #[tokio::test]
-async fn test_process_exit_before_spawn_watch_result_closes_and_cleans_up() {
+async fn test_process_exit_before_spawn_process_result_closes_and_cleans_up() {
     assert_lifecycle_before_result_closes(
         MSG_PROCESS_EXIT,
         vsock_proto::encode_process_exit(777, 0, b"early stdout", b""),
@@ -368,11 +368,11 @@ async fn test_dropped_stdout_receiver_removes_stream_sender() {
             let mut buf = [0u8; 4096];
             let n = guest.read(&mut buf).await.unwrap();
             let msgs = decoder.decode(&buf[..n]).unwrap();
-            assert_eq!(msgs[0].msg_type, MSG_SPAWN_WATCH);
+            assert_eq!(msgs[0].msg_type, MSG_SPAWN_PROCESS);
             let spawn_seq = msgs[0].seq;
 
-            let payload = vsock_proto::encode_spawn_watch_result(555);
-            let resp = vsock_proto::encode(MSG_SPAWN_WATCH_RESULT, spawn_seq, &payload).unwrap();
+            let payload = vsock_proto::encode_spawn_process_result(555);
+            let resp = vsock_proto::encode(MSG_SPAWN_PROCESS_RESULT, spawn_seq, &payload).unwrap();
             guest.write_all(&resp).await.unwrap();
 
             send_chunk.notified().await;
@@ -392,7 +392,7 @@ async fn test_dropped_stdout_receiver_removes_stream_sender() {
 
     let host = host_from_stream(host_stream).await.unwrap();
     let mut handle = host
-        .spawn_watch("streaming", 0, &[], false, true, None)
+        .spawn_process("streaming", 0, &[], false, true, None)
         .await
         .unwrap();
     assert_eq!(handle.pid(), 555);
@@ -433,11 +433,11 @@ async fn test_wait_drops_unclaimed_stdout_receiver() {
             let mut buf = [0u8; 4096];
             let n = guest.read(&mut buf).await.unwrap();
             let msgs = decoder.decode(&buf[..n]).unwrap();
-            assert_eq!(msgs[0].msg_type, MSG_SPAWN_WATCH);
+            assert_eq!(msgs[0].msg_type, MSG_SPAWN_PROCESS);
             let spawn_seq = msgs[0].seq;
 
-            let payload = vsock_proto::encode_spawn_watch_result(556);
-            let resp = vsock_proto::encode(MSG_SPAWN_WATCH_RESULT, spawn_seq, &payload).unwrap();
+            let payload = vsock_proto::encode_spawn_process_result(556);
+            let resp = vsock_proto::encode(MSG_SPAWN_PROCESS_RESULT, spawn_seq, &payload).unwrap();
             guest.write_all(&resp).await.unwrap();
 
             send_chunk.notified().await;
@@ -457,7 +457,7 @@ async fn test_wait_drops_unclaimed_stdout_receiver() {
 
     let host = host_from_stream(host_stream).await.unwrap();
     let handle = host
-        .spawn_watch("streaming", 0, &[], false, true, None)
+        .spawn_process("streaming", 0, &[], false, true, None)
         .await
         .unwrap();
     assert_eq!(handle.pid(), 556);
@@ -492,7 +492,7 @@ async fn test_wait_drops_unclaimed_stdout_receiver() {
 }
 
 #[tokio::test]
-async fn test_spawn_watch_cancel_cleans_up_registrations() {
+async fn test_spawn_process_cancel_cleans_up_registrations() {
     let (host_stream, mut guest) = make_pair();
     let request_seen = Arc::new(Notify::new());
     let release_guest = Arc::new(Notify::new());
@@ -507,7 +507,7 @@ async fn test_spawn_watch_cancel_cleans_up_registrations() {
             let mut buf = [0u8; 4096];
             let n = guest.read(&mut buf).await.unwrap();
             let msgs = decoder.decode(&buf[..n]).unwrap();
-            assert_eq!(msgs[0].msg_type, MSG_SPAWN_WATCH);
+            assert_eq!(msgs[0].msg_type, MSG_SPAWN_PROCESS);
             request_seen.notify_one();
 
             release_guest.notified().await;
@@ -518,13 +518,13 @@ async fn test_spawn_watch_cancel_cleans_up_registrations() {
     let task_host = Arc::clone(&host);
     let task = tokio::spawn(async move {
         task_host
-            .spawn_watch("long-running", 0, &[], false, true, None)
+            .spawn_process("long-running", 0, &[], false, true, None)
             .await
     });
 
     tokio::time::timeout(Duration::from_secs(5), request_seen.notified())
         .await
-        .expect("guest should receive spawn_watch request");
+        .expect("guest should receive spawn_process request");
     assert_eq!(registration_counts(&host), (1, 1, 1));
 
     task.abort();
@@ -532,7 +532,7 @@ async fn test_spawn_watch_cancel_cleans_up_registrations() {
     assert_eq!(
         registration_counts(&host),
         (0, 0, 0),
-        "aborted spawn_watch future must clean pending registrations",
+        "aborted spawn_process future must clean pending registrations",
     );
 
     release_guest.notify_one();
@@ -552,10 +552,11 @@ async fn test_late_malformed_lifecycle_after_handle_drop_is_ignored() {
             let mut buf = [0u8; 4096];
             let n = guest.read(&mut buf).await.unwrap();
             let msgs = decoder.decode(&buf[..n]).unwrap();
-            assert_eq!(msgs[0].msg_type, MSG_SPAWN_WATCH);
+            assert_eq!(msgs[0].msg_type, MSG_SPAWN_PROCESS);
             let dropped_seq = msgs[0].seq;
-            let payload = vsock_proto::encode_spawn_watch_result(66);
-            let resp = vsock_proto::encode(MSG_SPAWN_WATCH_RESULT, dropped_seq, &payload).unwrap();
+            let payload = vsock_proto::encode_spawn_process_result(66);
+            let resp =
+                vsock_proto::encode(MSG_SPAWN_PROCESS_RESULT, dropped_seq, &payload).unwrap();
             guest.write_all(&resp).await.unwrap();
 
             release_late_frames.notified().await;
@@ -566,10 +567,10 @@ async fn test_late_malformed_lifecycle_after_handle_drop_is_ignored() {
 
             let n = guest.read(&mut buf).await.unwrap();
             let msgs = decoder.decode(&buf[..n]).unwrap();
-            assert_eq!(msgs[0].msg_type, MSG_SPAWN_WATCH);
+            assert_eq!(msgs[0].msg_type, MSG_SPAWN_PROCESS);
             let next_seq = msgs[0].seq;
-            let payload = vsock_proto::encode_spawn_watch_result(67);
-            let resp = vsock_proto::encode(MSG_SPAWN_WATCH_RESULT, next_seq, &payload).unwrap();
+            let payload = vsock_proto::encode_spawn_process_result(67);
+            let resp = vsock_proto::encode(MSG_SPAWN_PROCESS_RESULT, next_seq, &payload).unwrap();
             guest.write_all(&resp).await.unwrap();
             let exit_payload = vsock_proto::encode_process_exit(67, 0, b"still-alive", b"");
             let exit_msg = vsock_proto::encode(MSG_PROCESS_EXIT, next_seq, &exit_payload).unwrap();
@@ -582,7 +583,7 @@ async fn test_late_malformed_lifecycle_after_handle_drop_is_ignored() {
 
     let host = host_from_stream(host_stream).await.unwrap();
     let handle = host
-        .spawn_watch("drop-before-late-frame", 0, &[], false, true, None)
+        .spawn_process("drop-before-late-frame", 0, &[], false, true, None)
         .await
         .unwrap();
     assert_eq!(handle.pid(), 66);
@@ -592,7 +593,7 @@ async fn test_late_malformed_lifecycle_after_handle_drop_is_ignored() {
     release_late_frames.notify_one();
 
     let next = host
-        .spawn_watch("next-spawn", 0, &[], false, false, None)
+        .spawn_process("next-spawn", 0, &[], false, false, None)
         .await
         .unwrap();
     let event = wait_spawn(next).await.unwrap();
@@ -601,7 +602,7 @@ async fn test_late_malformed_lifecycle_after_handle_drop_is_ignored() {
 }
 
 #[tokio::test]
-async fn test_spawn_watch_after_close_returns_immediately() {
+async fn test_spawn_process_after_close_returns_immediately() {
     let (host_stream, mut guest) = make_pair();
 
     tokio::spawn(async move {
@@ -618,10 +619,10 @@ async fn test_spawn_watch_after_close_returns_immediately() {
 
     let err = tokio::time::timeout(
         Duration::from_secs(5),
-        host.spawn_watch("long-running", 0, &[], false, false, None),
+        host.spawn_process("long-running", 0, &[], false, false, None),
     )
     .await
-    .expect("spawn_watch should return when the connection is already closed")
+    .expect("spawn_process should return when the connection is already closed")
     .unwrap_err();
     assert!(
         matches!(
@@ -634,7 +635,7 @@ async fn test_spawn_watch_after_close_returns_immediately() {
 }
 
 #[tokio::test]
-async fn test_spawn_watch_exit_before_wait() {
+async fn test_spawn_process_exit_before_wait() {
     let (host_stream, mut guest) = make_pair();
 
     tokio::spawn(async move {
@@ -644,11 +645,11 @@ async fn test_spawn_watch_exit_before_wait() {
         let mut buf = [0u8; 4096];
         let n = guest.read(&mut buf).await.unwrap();
         let msgs = decoder.decode(&buf[..n]).unwrap();
-        assert_eq!(msgs[0].msg_type, MSG_SPAWN_WATCH);
+        assert_eq!(msgs[0].msg_type, MSG_SPAWN_PROCESS);
         let spawn_seq = msgs[0].seq;
 
-        let payload = vsock_proto::encode_spawn_watch_result(88);
-        let resp = vsock_proto::encode(MSG_SPAWN_WATCH_RESULT, spawn_seq, &payload).unwrap();
+        let payload = vsock_proto::encode_spawn_process_result(88);
+        let resp = vsock_proto::encode(MSG_SPAWN_PROCESS_RESULT, spawn_seq, &payload).unwrap();
         guest.write_all(&resp).await.unwrap();
 
         let exit_payload = vsock_proto::encode_process_exit(88, 7, b"quick", b"");
@@ -661,7 +662,7 @@ async fn test_spawn_watch_exit_before_wait() {
 
     let host = host_from_stream(host_stream).await.unwrap();
     let handle = host
-        .spawn_watch("quick-exit", 0, &[], false, false, None)
+        .spawn_process("quick-exit", 0, &[], false, false, None)
         .await
         .unwrap();
     assert_eq!(handle.pid(), 88);
@@ -673,7 +674,7 @@ async fn test_spawn_watch_exit_before_wait() {
 }
 
 #[tokio::test]
-async fn test_spawn_watch_connection_closed_while_waiting() {
+async fn test_spawn_process_connection_closed_while_waiting() {
     let (host_stream, mut guest) = make_pair();
     let (close_tx, close_rx) = oneshot::channel();
 
@@ -684,10 +685,10 @@ async fn test_spawn_watch_connection_closed_while_waiting() {
         let mut buf = [0u8; 4096];
         let n = guest.read(&mut buf).await.unwrap();
         let msgs = decoder.decode(&buf[..n]).unwrap();
-        assert_eq!(msgs[0].msg_type, MSG_SPAWN_WATCH);
+        assert_eq!(msgs[0].msg_type, MSG_SPAWN_PROCESS);
 
-        let payload = vsock_proto::encode_spawn_watch_result(77);
-        let resp = vsock_proto::encode(MSG_SPAWN_WATCH_RESULT, msgs[0].seq, &payload).unwrap();
+        let payload = vsock_proto::encode_spawn_process_result(77);
+        let resp = vsock_proto::encode(MSG_SPAWN_PROCESS_RESULT, msgs[0].seq, &payload).unwrap();
         guest.write_all(&resp).await.unwrap();
 
         let _ = close_rx.await;
@@ -696,7 +697,7 @@ async fn test_spawn_watch_connection_closed_while_waiting() {
 
     let host = host_from_stream(host_stream).await.unwrap();
     let handle = host
-        .spawn_watch("long-running", 0, &[], false, false, None)
+        .spawn_process("long-running", 0, &[], false, false, None)
         .await
         .unwrap();
     assert_eq!(handle.pid(), 77);
@@ -709,7 +710,7 @@ async fn test_spawn_watch_connection_closed_while_waiting() {
 }
 
 #[tokio::test]
-async fn test_spawn_watch_exit_result_survives_close_before_wait() {
+async fn test_spawn_process_exit_result_survives_close_before_wait() {
     let (host_stream, mut guest) = make_pair();
 
     tokio::spawn(async move {
@@ -719,12 +720,12 @@ async fn test_spawn_watch_exit_result_survives_close_before_wait() {
         let mut buf = [0u8; 4096];
         let n = guest.read(&mut buf).await.unwrap();
         let msgs = decoder.decode(&buf[..n]).unwrap();
-        assert_eq!(msgs[0].msg_type, MSG_SPAWN_WATCH);
+        assert_eq!(msgs[0].msg_type, MSG_SPAWN_PROCESS);
         let spawn_seq = msgs[0].seq;
 
-        let result_payload = vsock_proto::encode_spawn_watch_result(111);
+        let result_payload = vsock_proto::encode_spawn_process_result(111);
         let result =
-            vsock_proto::encode(MSG_SPAWN_WATCH_RESULT, spawn_seq, &result_payload).unwrap();
+            vsock_proto::encode(MSG_SPAWN_PROCESS_RESULT, spawn_seq, &result_payload).unwrap();
         let exit_payload = vsock_proto::encode_process_exit(111, 3, b"early-output", b"err");
         let exit_msg = vsock_proto::encode(MSG_PROCESS_EXIT, spawn_seq, &exit_payload).unwrap();
 
@@ -736,7 +737,7 @@ async fn test_spawn_watch_exit_result_survives_close_before_wait() {
 
     let host = host_from_stream(host_stream).await.unwrap();
     let handle = host
-        .spawn_watch("quick-exit", 0, &[], false, false, None)
+        .spawn_process("quick-exit", 0, &[], false, false, None)
         .await
         .unwrap();
     assert_eq!(handle.pid(), 111);
@@ -765,12 +766,12 @@ async fn test_malformed_active_process_exit_closes_and_cleans_up() {
         let mut buf = [0u8; 4096];
         let n = guest.read(&mut buf).await.unwrap();
         let msgs = decoder.decode(&buf[..n]).unwrap();
-        assert_eq!(msgs[0].msg_type, MSG_SPAWN_WATCH);
+        assert_eq!(msgs[0].msg_type, MSG_SPAWN_PROCESS);
         let spawn_seq = msgs[0].seq;
 
-        let result_payload = vsock_proto::encode_spawn_watch_result(123);
+        let result_payload = vsock_proto::encode_spawn_process_result(123);
         let result =
-            vsock_proto::encode(MSG_SPAWN_WATCH_RESULT, spawn_seq, &result_payload).unwrap();
+            vsock_proto::encode(MSG_SPAWN_PROCESS_RESULT, spawn_seq, &result_payload).unwrap();
         let bad_exit = vsock_proto::encode(MSG_PROCESS_EXIT, spawn_seq, b"\x00").unwrap();
         let mut combined = result;
         combined.extend_from_slice(&bad_exit);
@@ -782,7 +783,7 @@ async fn test_malformed_active_process_exit_closes_and_cleans_up() {
 
     let host = host_from_stream(host_stream).await.unwrap();
     let handle = host
-        .spawn_watch("malformed-exit", 0, &[], false, false, None)
+        .spawn_process("malformed-exit", 0, &[], false, false, None)
         .await
         .unwrap();
     assert_eq!(handle.pid(), 123);
@@ -807,12 +808,12 @@ async fn test_mismatched_active_process_exit_pid_closes_and_cleans_up() {
         let mut buf = [0u8; 4096];
         let n = guest.read(&mut buf).await.unwrap();
         let msgs = decoder.decode(&buf[..n]).unwrap();
-        assert_eq!(msgs[0].msg_type, MSG_SPAWN_WATCH);
+        assert_eq!(msgs[0].msg_type, MSG_SPAWN_PROCESS);
         let spawn_seq = msgs[0].seq;
 
-        let result_payload = vsock_proto::encode_spawn_watch_result(123);
+        let result_payload = vsock_proto::encode_spawn_process_result(123);
         let result =
-            vsock_proto::encode(MSG_SPAWN_WATCH_RESULT, spawn_seq, &result_payload).unwrap();
+            vsock_proto::encode(MSG_SPAWN_PROCESS_RESULT, spawn_seq, &result_payload).unwrap();
         let wrong_pid_exit = vsock_proto::encode_process_exit(321, 0, b"wrong-pid", b"");
         let exit = vsock_proto::encode(MSG_PROCESS_EXIT, spawn_seq, &wrong_pid_exit).unwrap();
         let mut combined = result;
@@ -825,7 +826,7 @@ async fn test_mismatched_active_process_exit_pid_closes_and_cleans_up() {
 
     let host = host_from_stream(host_stream).await.unwrap();
     let handle = host
-        .spawn_watch("mismatched-exit-pid", 0, &[], false, false, None)
+        .spawn_process("mismatched-exit-pid", 0, &[], false, false, None)
         .await
         .unwrap();
     assert_eq!(handle.pid(), 123);
@@ -849,12 +850,12 @@ async fn assert_bad_active_stdout_chunk_closes_and_cleans_up(payload: Vec<u8>) {
         let mut buf = [0u8; 4096];
         let n = guest.read(&mut buf).await.unwrap();
         let msgs = decoder.decode(&buf[..n]).unwrap();
-        assert_eq!(msgs[0].msg_type, MSG_SPAWN_WATCH);
+        assert_eq!(msgs[0].msg_type, MSG_SPAWN_PROCESS);
         let spawn_seq = msgs[0].seq;
 
-        let result_payload = vsock_proto::encode_spawn_watch_result(123);
+        let result_payload = vsock_proto::encode_spawn_process_result(123);
         let result =
-            vsock_proto::encode(MSG_SPAWN_WATCH_RESULT, spawn_seq, &result_payload).unwrap();
+            vsock_proto::encode(MSG_SPAWN_PROCESS_RESULT, spawn_seq, &result_payload).unwrap();
         let chunk = vsock_proto::encode(MSG_STDOUT_CHUNK, spawn_seq, &payload).unwrap();
         let mut combined = result;
         combined.extend_from_slice(&chunk);
@@ -866,7 +867,7 @@ async fn assert_bad_active_stdout_chunk_closes_and_cleans_up(payload: Vec<u8>) {
 
     let host = host_from_stream(host_stream).await.unwrap();
     let mut handle = host
-        .spawn_watch("bad-stdout", 0, &[], false, true, None)
+        .spawn_process("bad-stdout", 0, &[], false, true, None)
         .await
         .unwrap();
     assert_eq!(handle.pid(), 123);
@@ -910,12 +911,12 @@ async fn test_buffered_active_stdout_chunk_closes_and_cleans_up() {
         let mut buf = [0u8; 4096];
         let n = guest.read(&mut buf).await.unwrap();
         let msgs = decoder.decode(&buf[..n]).unwrap();
-        assert_eq!(msgs[0].msg_type, MSG_SPAWN_WATCH);
+        assert_eq!(msgs[0].msg_type, MSG_SPAWN_PROCESS);
         let spawn_seq = msgs[0].seq;
 
-        let result_payload = vsock_proto::encode_spawn_watch_result(123);
+        let result_payload = vsock_proto::encode_spawn_process_result(123);
         let result =
-            vsock_proto::encode(MSG_SPAWN_WATCH_RESULT, spawn_seq, &result_payload).unwrap();
+            vsock_proto::encode(MSG_SPAWN_PROCESS_RESULT, spawn_seq, &result_payload).unwrap();
         let chunk_payload = vsock_proto::encode_stdout_chunk(123, b"unexpected stream");
         let chunk = vsock_proto::encode(MSG_STDOUT_CHUNK, spawn_seq, &chunk_payload).unwrap();
         let mut combined = result;
@@ -928,7 +929,7 @@ async fn test_buffered_active_stdout_chunk_closes_and_cleans_up() {
 
     let host = host_from_stream(host_stream).await.unwrap();
     let handle = host
-        .spawn_watch("buffered-bad-stdout", 0, &[], false, false, None)
+        .spawn_process("buffered-bad-stdout", 0, &[], false, false, None)
         .await
         .unwrap();
     assert_eq!(handle.pid(), 123);
@@ -938,12 +939,12 @@ async fn test_buffered_active_stdout_chunk_closes_and_cleans_up() {
     assert_eq!(
         registration_counts(&host),
         (0, 0, 0),
-        "stdout_chunk for buffered spawn_watch must close and clean registrations",
+        "stdout_chunk for buffered spawn_process must close and clean registrations",
     );
 }
 
 #[tokio::test]
-async fn test_duplicate_spawn_watch_result_cannot_overwrite_pid() {
+async fn test_duplicate_spawn_process_result_cannot_overwrite_pid() {
     let (host_stream, mut guest) = make_pair();
 
     tokio::spawn(async move {
@@ -953,17 +954,17 @@ async fn test_duplicate_spawn_watch_result_cannot_overwrite_pid() {
         let mut buf = [0u8; 4096];
         let n = guest.read(&mut buf).await.unwrap();
         let msgs = decoder.decode(&buf[..n]).unwrap();
-        assert_eq!(msgs[0].msg_type, MSG_SPAWN_WATCH);
+        assert_eq!(msgs[0].msg_type, MSG_SPAWN_PROCESS);
         let spawn_seq = msgs[0].seq;
 
-        let result_payload = vsock_proto::encode_spawn_watch_result(123);
+        let result_payload = vsock_proto::encode_spawn_process_result(123);
         let result =
-            vsock_proto::encode(MSG_SPAWN_WATCH_RESULT, spawn_seq, &result_payload).unwrap();
+            vsock_proto::encode(MSG_SPAWN_PROCESS_RESULT, spawn_seq, &result_payload).unwrap();
         guest.write_all(&result).await.unwrap();
 
-        let duplicate_payload = vsock_proto::encode_spawn_watch_result(321);
+        let duplicate_payload = vsock_proto::encode_spawn_process_result(321);
         let duplicate =
-            vsock_proto::encode(MSG_SPAWN_WATCH_RESULT, spawn_seq, &duplicate_payload).unwrap();
+            vsock_proto::encode(MSG_SPAWN_PROCESS_RESULT, spawn_seq, &duplicate_payload).unwrap();
         guest.write_all(&duplicate).await.unwrap();
 
         let mut discard = [0u8; 1];
@@ -972,7 +973,7 @@ async fn test_duplicate_spawn_watch_result_cannot_overwrite_pid() {
 
     let host = host_from_stream(host_stream).await.unwrap();
     let handle = host
-        .spawn_watch("duplicate-result", 0, &[], false, false, None)
+        .spawn_process("duplicate-result", 0, &[], false, false, None)
         .await
         .unwrap();
     assert_eq!(handle.pid(), 123);
@@ -982,12 +983,12 @@ async fn test_duplicate_spawn_watch_result_cannot_overwrite_pid() {
     assert_eq!(
         registration_counts(&host),
         (0, 0, 0),
-        "duplicate spawn_watch_result must not overwrite recorded pid",
+        "duplicate spawn_process_result must not overwrite recorded pid",
     );
 }
 
 #[tokio::test]
-async fn test_duplicate_spawn_watch_result_same_pid_closes_and_cleans_up() {
+async fn test_duplicate_spawn_process_result_same_pid_closes_and_cleans_up() {
     let (host_stream, mut guest) = make_pair();
 
     tokio::spawn(async move {
@@ -997,16 +998,16 @@ async fn test_duplicate_spawn_watch_result_same_pid_closes_and_cleans_up() {
         let mut buf = [0u8; 4096];
         let n = guest.read(&mut buf).await.unwrap();
         let msgs = decoder.decode(&buf[..n]).unwrap();
-        assert_eq!(msgs[0].msg_type, MSG_SPAWN_WATCH);
+        assert_eq!(msgs[0].msg_type, MSG_SPAWN_PROCESS);
         let spawn_seq = msgs[0].seq;
 
-        let result_payload = vsock_proto::encode_spawn_watch_result(123);
+        let result_payload = vsock_proto::encode_spawn_process_result(123);
         let result =
-            vsock_proto::encode(MSG_SPAWN_WATCH_RESULT, spawn_seq, &result_payload).unwrap();
+            vsock_proto::encode(MSG_SPAWN_PROCESS_RESULT, spawn_seq, &result_payload).unwrap();
         guest.write_all(&result).await.unwrap();
 
         let duplicate =
-            vsock_proto::encode(MSG_SPAWN_WATCH_RESULT, spawn_seq, &result_payload).unwrap();
+            vsock_proto::encode(MSG_SPAWN_PROCESS_RESULT, spawn_seq, &result_payload).unwrap();
         guest.write_all(&duplicate).await.unwrap();
 
         let mut discard = [0u8; 1];
@@ -1015,7 +1016,7 @@ async fn test_duplicate_spawn_watch_result_same_pid_closes_and_cleans_up() {
 
     let host = host_from_stream(host_stream).await.unwrap();
     let handle = host
-        .spawn_watch("duplicate-same-pid-result", 0, &[], false, false, None)
+        .spawn_process("duplicate-same-pid-result", 0, &[], false, false, None)
         .await
         .unwrap();
     assert_eq!(handle.pid(), 123);
@@ -1025,12 +1026,12 @@ async fn test_duplicate_spawn_watch_result_same_pid_closes_and_cleans_up() {
     assert_eq!(
         registration_counts(&host),
         (0, 0, 0),
-        "duplicate same-pid spawn_watch_result must close and clean registrations",
+        "duplicate same-pid spawn_process_result must close and clean registrations",
     );
 }
 
 #[tokio::test]
-async fn test_malformed_duplicate_spawn_watch_result_closes_and_cleans_up() {
+async fn test_malformed_duplicate_spawn_process_result_closes_and_cleans_up() {
     let (host_stream, mut guest) = make_pair();
 
     tokio::spawn(async move {
@@ -1040,16 +1041,16 @@ async fn test_malformed_duplicate_spawn_watch_result_closes_and_cleans_up() {
         let mut buf = [0u8; 4096];
         let n = guest.read(&mut buf).await.unwrap();
         let msgs = decoder.decode(&buf[..n]).unwrap();
-        assert_eq!(msgs[0].msg_type, MSG_SPAWN_WATCH);
+        assert_eq!(msgs[0].msg_type, MSG_SPAWN_PROCESS);
         let spawn_seq = msgs[0].seq;
 
-        let result_payload = vsock_proto::encode_spawn_watch_result(123);
+        let result_payload = vsock_proto::encode_spawn_process_result(123);
         let result =
-            vsock_proto::encode(MSG_SPAWN_WATCH_RESULT, spawn_seq, &result_payload).unwrap();
+            vsock_proto::encode(MSG_SPAWN_PROCESS_RESULT, spawn_seq, &result_payload).unwrap();
         guest.write_all(&result).await.unwrap();
 
         let duplicate =
-            vsock_proto::encode(MSG_SPAWN_WATCH_RESULT, spawn_seq, b"\x00\x01").unwrap();
+            vsock_proto::encode(MSG_SPAWN_PROCESS_RESULT, spawn_seq, b"\x00\x01").unwrap();
         guest.write_all(&duplicate).await.unwrap();
 
         let mut discard = [0u8; 1];
@@ -1058,7 +1059,7 @@ async fn test_malformed_duplicate_spawn_watch_result_closes_and_cleans_up() {
 
     let host = host_from_stream(host_stream).await.unwrap();
     let handle = host
-        .spawn_watch("malformed-duplicate-result", 0, &[], false, false, None)
+        .spawn_process("malformed-duplicate-result", 0, &[], false, false, None)
         .await
         .unwrap();
     assert_eq!(handle.pid(), 123);
@@ -1068,12 +1069,12 @@ async fn test_malformed_duplicate_spawn_watch_result_closes_and_cleans_up() {
     assert_eq!(
         registration_counts(&host),
         (0, 0, 0),
-        "malformed duplicate spawn_watch_result must close and clean registrations",
+        "malformed duplicate spawn_process_result must close and clean registrations",
     );
 }
 
 #[tokio::test]
-async fn test_spawn_watch_wait_future_drop_cleans_registration() {
+async fn test_spawn_process_wait_future_drop_cleans_registration() {
     let (host_stream, mut guest) = make_pair();
 
     tokio::spawn(async move {
@@ -1083,8 +1084,8 @@ async fn test_spawn_watch_wait_future_drop_cleans_registration() {
         let mut buf = [0u8; 4096];
         let n = guest.read(&mut buf).await.unwrap();
         let msgs = decoder.decode(&buf[..n]).unwrap();
-        let payload = vsock_proto::encode_spawn_watch_result(55);
-        let resp = vsock_proto::encode(MSG_SPAWN_WATCH_RESULT, msgs[0].seq, &payload).unwrap();
+        let payload = vsock_proto::encode_spawn_process_result(55);
+        let resp = vsock_proto::encode(MSG_SPAWN_PROCESS_RESULT, msgs[0].seq, &payload).unwrap();
         guest.write_all(&resp).await.unwrap();
 
         let mut discard = [0u8; 1];
@@ -1093,7 +1094,7 @@ async fn test_spawn_watch_wait_future_drop_cleans_registration() {
 
     let host = host_from_stream(host_stream).await.unwrap();
     let handle = host
-        .spawn_watch("long-running", 0, &[], false, false, None)
+        .spawn_process("long-running", 0, &[], false, false, None)
         .await
         .unwrap();
     assert_eq!(handle.pid(), 55);
@@ -1104,7 +1105,7 @@ async fn test_spawn_watch_wait_future_drop_cleans_registration() {
 }
 
 #[tokio::test]
-async fn test_concurrent_spawn_watch_routes_by_seq_not_pid() {
+async fn test_concurrent_spawn_process_routes_by_seq_not_pid() {
     let (host_stream, mut guest) = make_pair();
 
     tokio::spawn(async move {
@@ -1115,18 +1116,18 @@ async fn test_concurrent_spawn_watch_routes_by_seq_not_pid() {
 
         let n = guest.read(&mut buf).await.unwrap();
         let msgs = decoder.decode(&buf[..n]).unwrap();
-        assert_eq!(msgs[0].msg_type, MSG_SPAWN_WATCH);
+        assert_eq!(msgs[0].msg_type, MSG_SPAWN_PROCESS);
         let first_seq = msgs[0].seq;
-        let payload = vsock_proto::encode_spawn_watch_result(999);
-        let resp = vsock_proto::encode(MSG_SPAWN_WATCH_RESULT, first_seq, &payload).unwrap();
+        let payload = vsock_proto::encode_spawn_process_result(999);
+        let resp = vsock_proto::encode(MSG_SPAWN_PROCESS_RESULT, first_seq, &payload).unwrap();
         guest.write_all(&resp).await.unwrap();
 
         let n = guest.read(&mut buf).await.unwrap();
         let msgs = decoder.decode(&buf[..n]).unwrap();
-        assert_eq!(msgs[0].msg_type, MSG_SPAWN_WATCH);
+        assert_eq!(msgs[0].msg_type, MSG_SPAWN_PROCESS);
         let second_seq = msgs[0].seq;
-        let payload = vsock_proto::encode_spawn_watch_result(999);
-        let resp = vsock_proto::encode(MSG_SPAWN_WATCH_RESULT, second_seq, &payload).unwrap();
+        let payload = vsock_proto::encode_spawn_process_result(999);
+        let resp = vsock_proto::encode(MSG_SPAWN_PROCESS_RESULT, second_seq, &payload).unwrap();
         guest.write_all(&resp).await.unwrap();
 
         let second_chunk_payload = vsock_proto::encode_stdout_chunk(999, b"second");
@@ -1153,11 +1154,11 @@ async fn test_concurrent_spawn_watch_routes_by_seq_not_pid() {
 
     let host = host_from_stream(host_stream).await.unwrap();
     let mut first = host
-        .spawn_watch("first", 0, &[], false, true, None)
+        .spawn_process("first", 0, &[], false, true, None)
         .await
         .unwrap();
     let mut second = host
-        .spawn_watch("second", 0, &[], false, true, None)
+        .spawn_process("second", 0, &[], false, true, None)
         .await
         .unwrap();
     assert_eq!(first.pid(), 999);
@@ -1188,11 +1189,11 @@ async fn test_concurrent_exec_and_wait_exit() {
         let mut buf = [0u8; 4096];
         let n = guest.read(&mut buf).await.unwrap();
         let msgs = decoder.decode(&buf[..n]).unwrap();
-        assert_eq!(msgs[0].msg_type, MSG_SPAWN_WATCH);
+        assert_eq!(msgs[0].msg_type, MSG_SPAWN_PROCESS);
         let spawn_seq = msgs[0].seq;
 
-        let payload = vsock_proto::encode_spawn_watch_result(50);
-        let resp = vsock_proto::encode(MSG_SPAWN_WATCH_RESULT, spawn_seq, &payload).unwrap();
+        let payload = vsock_proto::encode_spawn_process_result(50);
+        let resp = vsock_proto::encode(MSG_SPAWN_PROCESS_RESULT, spawn_seq, &payload).unwrap();
         guest.write_all(&resp).await.unwrap();
 
         let n = guest.read(&mut buf).await.unwrap();
@@ -1220,7 +1221,7 @@ async fn test_concurrent_exec_and_wait_exit() {
 
     let host = Arc::new(host_from_stream(host_stream).await.unwrap());
     let handle = host
-        .spawn_watch("long-running", 0, &[], false, false, None)
+        .spawn_process("long-running", 0, &[], false, false, None)
         .await
         .unwrap();
     assert_eq!(handle.pid(), 50);

--- a/crates/vsock-proto/src/lib.rs
+++ b/crates/vsock-proto/src/lib.rs
@@ -22,8 +22,8 @@
 //! | 0x02 | G→H       | pong              | (empty) |
 //! | 0x03 | H→G       | write_file        | `[2B path_len][path][1B flags][4B content_len][content]` (flags: `SUDO=0x01`, `APPEND=0x02`) |
 //! | 0x04 | G→H       | write_file_result | `[1B success][2B error_len][error]` |
-//! | 0x05 | H→G       | spawn_process       | `[4B timeout_ms][1B flags][4B cmd_len][command]([4B env_count]([4B key_len][key][4B val_len][value])*)([2B log_path_len][log_path])` (flags: `SUDO=0x01`, `STREAM_STDOUT=0x02`) |
-//! | 0x06 | G→H       | spawn_process_result| `[4B pid]` |
+//! | 0x05 | H→G       | spawn_process     | `[4B timeout_ms][1B flags][4B cmd_len][command]([4B env_count]([4B key_len][key][4B val_len][value])*)([2B log_path_len][log_path])` (flags: `SUDO=0x01`, `STREAM_STDOUT=0x02`) |
+//! | 0x06 | G→H       | spawn_process_result | `[4B pid]` |
 //! | 0x07 | G→H       | process_exit      | `[4B pid][4B exit_code][4B stdout_len][stdout][4B stderr_len][stderr]` (`spawn_process` uses the original request seq; pid is metadata, not the routing key) |
 //! | 0x08 | H→G       | shutdown          | (empty) |
 //! | 0x09 | G→H       | shutdown_ack      | (empty) |

--- a/crates/vsock-proto/src/lib.rs
+++ b/crates/vsock-proto/src/lib.rs
@@ -22,12 +22,12 @@
 //! | 0x02 | G→H       | pong              | (empty) |
 //! | 0x03 | H→G       | write_file        | `[2B path_len][path][1B flags][4B content_len][content]` (flags: `SUDO=0x01`, `APPEND=0x02`) |
 //! | 0x04 | G→H       | write_file_result | `[1B success][2B error_len][error]` |
-//! | 0x05 | H→G       | spawn_watch       | `[4B timeout_ms][1B flags][4B cmd_len][command]([4B env_count]([4B key_len][key][4B val_len][value])*)([2B log_path_len][log_path])` (flags: `SUDO=0x01`, `STREAM_STDOUT=0x02`) |
-//! | 0x06 | G→H       | spawn_watch_result| `[4B pid]` |
-//! | 0x07 | G→H       | process_exit      | `[4B pid][4B exit_code][4B stdout_len][stdout][4B stderr_len][stderr]` (`spawn_watch` uses the original request seq; pid is metadata, not the routing key) |
+//! | 0x05 | H→G       | spawn_process       | `[4B timeout_ms][1B flags][4B cmd_len][command]([4B env_count]([4B key_len][key][4B val_len][value])*)([2B log_path_len][log_path])` (flags: `SUDO=0x01`, `STREAM_STDOUT=0x02`) |
+//! | 0x06 | G→H       | spawn_process_result| `[4B pid]` |
+//! | 0x07 | G→H       | process_exit      | `[4B pid][4B exit_code][4B stdout_len][stdout][4B stderr_len][stderr]` (`spawn_process` uses the original request seq; pid is metadata, not the routing key) |
 //! | 0x08 | H→G       | shutdown          | (empty) |
 //! | 0x09 | G→H       | shutdown_ack      | (empty) |
-//! | 0x0A | G→H       | stdout_chunk      | `[4B pid][data]` (`spawn_watch` uses the original request seq; pid is metadata, not the routing key) |
+//! | 0x0A | G→H       | stdout_chunk      | `[4B pid][data]` (`spawn_process` uses the original request seq; pid is metadata, not the routing key) |
 //! | 0x0B | H→G       | command_start     | `[4B timeout_ms][1B flags][4B cmd_len][command][4B env_count]... [2B label_len][label][stdout_policy][stderr_policy][2B expected_exit_count][4B exit_code]...` |
 //! | 0x0C | G→H       | command_output    | `[1B stream][4B output_seq][1B flags][4B chunk_len][chunk]` |
 //! | 0x0D | G→H       | command_result    | `[1B termination]...[4B duration_ms][stdout][stderr][2B diagnostic_len][diagnostic]` |
@@ -65,9 +65,9 @@ pub use payloads::error::{decode_error, encode_error};
 pub use payloads::process::{
     ProcessExit, decode_process_exit, decode_stdout_chunk, encode_process_exit, encode_stdout_chunk,
 };
-pub use payloads::spawn_watch::{
-    DecodedSpawnWatch, decode_spawn_watch, decode_spawn_watch_result, encode_spawn_watch,
-    encode_spawn_watch_result,
+pub use payloads::spawn_process::{
+    DecodedSpawnProcess, decode_spawn_process, decode_spawn_process_result, encode_spawn_process,
+    encode_spawn_process_result,
 };
 pub use payloads::write_file::{
     decode_write_file, decode_write_file_result, encode_write_file, encode_write_file_result,
@@ -77,8 +77,8 @@ pub use wire::{
     HEADER_SIZE, MAX_MESSAGE_SIZE, MIN_BODY_SIZE, MSG_COMMAND_CANCEL, MSG_COMMAND_OUTPUT,
     MSG_COMMAND_RESULT, MSG_COMMAND_START, MSG_ERROR, MSG_OPERATIONS_QUIESCED,
     MSG_OPERATIONS_RESUMED, MSG_PING, MSG_PONG, MSG_PROCESS_EXIT, MSG_QUIESCE_OPERATIONS,
-    MSG_READY, MSG_RESUME_OPERATIONS, MSG_SHUTDOWN, MSG_SHUTDOWN_ACK, MSG_SPAWN_WATCH,
-    MSG_SPAWN_WATCH_RESULT, MSG_STDOUT_CHUNK, MSG_WRITE_FILE, MSG_WRITE_FILE_RESULT,
-    SPAWN_WATCH_FLAG_STREAM_STDOUT, SPAWN_WATCH_FLAG_SUDO, VSOCK_PORT, WRITE_FILE_FLAG_APPEND,
+    MSG_READY, MSG_RESUME_OPERATIONS, MSG_SHUTDOWN, MSG_SHUTDOWN_ACK, MSG_SPAWN_PROCESS,
+    MSG_SPAWN_PROCESS_RESULT, MSG_STDOUT_CHUNK, MSG_WRITE_FILE, MSG_WRITE_FILE_RESULT,
+    SPAWN_PROCESS_FLAG_STREAM_STDOUT, SPAWN_PROCESS_FLAG_SUDO, VSOCK_PORT, WRITE_FILE_FLAG_APPEND,
     WRITE_FILE_FLAG_SUDO,
 };

--- a/crates/vsock-proto/src/payloads/mod.rs
+++ b/crates/vsock-proto/src/payloads/mod.rs
@@ -2,5 +2,5 @@ pub(crate) mod command;
 pub(crate) mod empty;
 pub(crate) mod error;
 pub(crate) mod process;
-pub(crate) mod spawn_watch;
+pub(crate) mod spawn_process;
 pub(crate) mod write_file;

--- a/crates/vsock-proto/src/payloads/spawn_process.rs
+++ b/crates/vsock-proto/src/payloads/spawn_process.rs
@@ -1,16 +1,16 @@
 use crate::error::ProtocolError;
 use crate::read::{read_u8_at, read_u16_at, read_u32_at};
-use crate::wire::{SPAWN_WATCH_FLAG_STREAM_STDOUT, SPAWN_WATCH_FLAG_SUDO};
+use crate::wire::{SPAWN_PROCESS_FLAG_STREAM_STDOUT, SPAWN_PROCESS_FLAG_SUDO};
 
-/// Encode spawn_watch payload: command fields + optional `[2B log_path_len][log_path]`.
+/// Encode spawn_process payload: command fields + optional `[2B log_path_len][log_path]`.
 ///
 /// `stream_stdout` controls whether stdout is streamed to the host via
 /// `MSG_STDOUT_CHUNK`. `stdout_log_path`, when present, additionally asks
 /// the guest to tee streamed stdout to that file.
 ///
 /// This always writes the env section (even when empty) so
-/// `decode_spawn_watch` can unambiguously find the log_path boundary.
-pub fn encode_spawn_watch(
+/// `decode_spawn_process` can unambiguously find the log_path boundary.
+pub fn encode_spawn_process(
     timeout_ms: u32,
     command: &str,
     env: &[(&str, &str)],
@@ -20,7 +20,7 @@ pub fn encode_spawn_watch(
 ) -> Result<Vec<u8>, ProtocolError> {
     if !stream_stdout && stdout_log_path.is_some() {
         return Err(ProtocolError::InvalidPayload(
-            "spawn_watch log_path requires stream flag",
+            "spawn_process log_path requires stream flag",
         ));
     }
     let cmd = command.as_bytes();
@@ -30,7 +30,9 @@ pub fn encode_spawn_watch(
         .sum::<usize>();
     let log_path = match stdout_log_path {
         Some("") => {
-            return Err(ProtocolError::InvalidPayload("spawn_watch log_path empty"));
+            return Err(ProtocolError::InvalidPayload(
+                "spawn_process log_path empty",
+            ));
         }
         Some(path) if path.len() > u16::MAX as usize => {
             return Err(ProtocolError::PayloadTooLarge("log_path", path.len()));
@@ -41,9 +43,9 @@ pub fn encode_spawn_watch(
     let log_size = log_path.map_or(0, |(_, len)| 2 + len as usize);
     let mut p = Vec::with_capacity(9 + cmd.len() + env_size + log_size);
     p.extend_from_slice(&timeout_ms.to_be_bytes());
-    let mut flags = if sudo { SPAWN_WATCH_FLAG_SUDO } else { 0 };
+    let mut flags = if sudo { SPAWN_PROCESS_FLAG_SUDO } else { 0 };
     if stream_stdout {
-        flags |= SPAWN_WATCH_FLAG_STREAM_STDOUT;
+        flags |= SPAWN_PROCESS_FLAG_STREAM_STDOUT;
     }
     p.push(flags);
     p.extend_from_slice(&(cmd.len() as u32).to_be_bytes());
@@ -65,12 +67,12 @@ pub fn encode_spawn_watch(
     Ok(p)
 }
 
-/// Encode spawn_watch_result payload: `[4B pid]`.
-pub fn encode_spawn_watch_result(pid: u32) -> Vec<u8> {
+/// Encode spawn_process_result payload: `[4B pid]`.
+pub fn encode_spawn_process_result(pid: u32) -> Vec<u8> {
     pid.to_be_bytes().to_vec()
 }
 
-struct DecodedSpawnWatchCommandPrefix<'a> {
+struct DecodedSpawnProcessCommandPrefix<'a> {
     timeout_ms: u32,
     command: &'a str,
     env: Vec<(&'a str, &'a str)>,
@@ -79,21 +81,21 @@ struct DecodedSpawnWatchCommandPrefix<'a> {
     raw_flags: u8,
 }
 
-/// Decode the command-shaped prefix used by spawn_watch payloads.
+/// Decode the command-shaped prefix used by spawn_process payloads.
 ///
 /// The env section is optional: if the payload ends right after the command, an
-/// empty vec is returned. `encode_spawn_watch` always writes the env section so
+/// empty vec is returned. `encode_spawn_process` always writes the env section so
 /// the optional log path remains unambiguous for new payloads.
-fn decode_spawn_watch_command_prefix(
+fn decode_spawn_process_command_prefix(
     payload: &[u8],
-) -> Result<DecodedSpawnWatchCommandPrefix<'_>, ProtocolError> {
+) -> Result<DecodedSpawnProcessCommandPrefix<'_>, ProtocolError> {
     let timeout_ms = read_u32_at(payload, 0).ok_or(ProtocolError::InvalidPayload(
         "command fields payload too short",
     ))?;
     let flags = read_u8_at(payload, 4).ok_or(ProtocolError::InvalidPayload(
         "command fields payload too short",
     ))?;
-    let sudo = (flags & SPAWN_WATCH_FLAG_SUDO) != 0;
+    let sudo = (flags & SPAWN_PROCESS_FLAG_SUDO) != 0;
     let cmd_len = read_u32_at(payload, 5).ok_or(ProtocolError::InvalidPayload(
         "command fields payload too short",
     ))? as usize;
@@ -104,7 +106,7 @@ fn decode_spawn_watch_command_prefix(
 
     let env_start = 9 + cmd_len;
     if env_start >= payload.len() {
-        return Ok(DecodedSpawnWatchCommandPrefix {
+        return Ok(DecodedSpawnProcessCommandPrefix {
             timeout_ms,
             command,
             env: Vec::new(),
@@ -146,7 +148,7 @@ fn decode_spawn_watch_command_prefix(
         env.push((key, val));
     }
 
-    Ok(DecodedSpawnWatchCommandPrefix {
+    Ok(DecodedSpawnProcessCommandPrefix {
         timeout_ms,
         command,
         env,
@@ -156,52 +158,56 @@ fn decode_spawn_watch_command_prefix(
     })
 }
 
-/// Decode spawn_watch payload. Extends command fields with streaming metadata.
+/// Decode spawn_process payload. Extends command fields with streaming metadata.
 ///
 /// Wire format: `[command fields...]([2B log_path_len][log_path])`.
 /// The log_path section is optional — if the payload ends after the command
 /// fields, `stdout_log_path` is `None`.
-pub fn decode_spawn_watch(payload: &[u8]) -> Result<DecodedSpawnWatch<'_>, ProtocolError> {
-    let DecodedSpawnWatchCommandPrefix {
+pub fn decode_spawn_process(payload: &[u8]) -> Result<DecodedSpawnProcess<'_>, ProtocolError> {
+    let DecodedSpawnProcessCommandPrefix {
         timeout_ms,
         command,
         env,
         sudo,
         offset,
         raw_flags,
-    } = decode_spawn_watch_command_prefix(payload)?;
-    let stream_flag = (raw_flags & SPAWN_WATCH_FLAG_STREAM_STDOUT) != 0;
+    } = decode_spawn_process_command_prefix(payload)?;
+    let stream_flag = (raw_flags & SPAWN_PROCESS_FLAG_STREAM_STDOUT) != 0;
     let stdout_log_path = if offset == payload.len() {
         None
     } else if offset + 2 <= payload.len() {
         let path_len = read_u16_at(payload, offset).ok_or(ProtocolError::InvalidPayload(
-            "spawn_watch log_path_len truncated",
+            "spawn_process log_path_len truncated",
         ))? as usize;
         if path_len == 0 {
-            return Err(ProtocolError::InvalidPayload("spawn_watch log_path empty"));
+            return Err(ProtocolError::InvalidPayload(
+                "spawn_process log_path empty",
+            ));
         } else {
             let path_end = offset + 2 + path_len;
             if path_end != payload.len() {
-                return Err(ProtocolError::InvalidPayload("spawn_watch trailing bytes"));
+                return Err(ProtocolError::InvalidPayload(
+                    "spawn_process trailing bytes",
+                ));
             }
             Some(
                 std::str::from_utf8(payload.get(offset + 2..path_end).ok_or(
-                    ProtocolError::InvalidPayload("spawn_watch log_path truncated"),
+                    ProtocolError::InvalidPayload("spawn_process log_path truncated"),
                 )?)
                 .map_err(|_| ProtocolError::InvalidPayload("invalid UTF-8 in log_path"))?,
             )
         }
     } else {
         return Err(ProtocolError::InvalidPayload(
-            "spawn_watch trailing byte after env",
+            "spawn_process trailing byte after env",
         ));
     };
     if !stream_flag && stdout_log_path.is_some() {
         return Err(ProtocolError::InvalidPayload(
-            "spawn_watch log_path requires stream flag",
+            "spawn_process log_path requires stream flag",
         ));
     }
-    Ok(DecodedSpawnWatch {
+    Ok(DecodedSpawnProcess {
         timeout_ms,
         command,
         env,
@@ -211,15 +217,15 @@ pub fn decode_spawn_watch(payload: &[u8]) -> Result<DecodedSpawnWatch<'_>, Proto
     })
 }
 
-/// Decode spawn_watch_result payload. Returns `pid`.
-pub fn decode_spawn_watch_result(payload: &[u8]) -> Result<u32, ProtocolError> {
+/// Decode spawn_process_result payload. Returns `pid`.
+pub fn decode_spawn_process_result(payload: &[u8]) -> Result<u32, ProtocolError> {
     read_u32_at(payload, 0).ok_or(ProtocolError::InvalidPayload(
-        "spawn_watch_result too short",
+        "spawn_process_result too short",
     ))
 }
 
-/// Decoded spawn_watch fields.
-pub struct DecodedSpawnWatch<'a> {
+/// Decoded spawn_process fields.
+pub struct DecodedSpawnProcess<'a> {
     pub timeout_ms: u32,
     pub command: &'a str,
     pub env: Vec<(&'a str, &'a str)>,
@@ -235,15 +241,15 @@ mod tests {
     use super::*;
 
     #[test]
-    fn spawn_watch_result_roundtrip() {
-        let payload = encode_spawn_watch_result(12345);
-        let pid = decode_spawn_watch_result(&payload).unwrap();
+    fn spawn_process_result_roundtrip() {
+        let payload = encode_spawn_process_result(12345);
+        let pid = decode_spawn_process_result(&payload).unwrap();
         assert_eq!(pid, 12345);
     }
 
     #[test]
-    fn spawn_watch_payload_roundtrip_with_log_path() {
-        let payload = encode_spawn_watch(
+    fn spawn_process_payload_roundtrip_with_log_path() {
+        let payload = encode_spawn_process(
             5000,
             "echo hello",
             &[("FOO", "bar")],
@@ -252,7 +258,7 @@ mod tests {
             Some("/tmp/vm0-system-123.log"),
         )
         .unwrap();
-        let d = decode_spawn_watch(&payload).unwrap();
+        let d = decode_spawn_process(&payload).unwrap();
         assert_eq!(d.timeout_ms, 5000);
         assert_eq!(d.command, "echo hello");
         assert_eq!(d.env, vec![("FOO", "bar")]);
@@ -262,9 +268,9 @@ mod tests {
     }
 
     #[test]
-    fn spawn_watch_payload_roundtrip_stream_only() {
-        let payload = encode_spawn_watch(3000, "ls", &[], true, true, None).unwrap();
-        let d = decode_spawn_watch(&payload).unwrap();
+    fn spawn_process_payload_roundtrip_stream_only() {
+        let payload = encode_spawn_process(3000, "ls", &[], true, true, None).unwrap();
+        let d = decode_spawn_process(&payload).unwrap();
         assert_eq!(d.timeout_ms, 3000);
         assert_eq!(d.command, "ls");
         assert!(d.env.is_empty());
@@ -274,85 +280,87 @@ mod tests {
     }
 
     #[test]
-    fn spawn_watch_payload_roundtrip_buffered() {
-        let payload = encode_spawn_watch(1000, "cmd", &[], false, false, None).unwrap();
-        let d = decode_spawn_watch(&payload).unwrap();
+    fn spawn_process_payload_roundtrip_buffered() {
+        let payload = encode_spawn_process(1000, "cmd", &[], false, false, None).unwrap();
+        let d = decode_spawn_process(&payload).unwrap();
         assert_eq!(d.command, "cmd");
         assert!(!d.stream_stdout);
         assert!(d.stdout_log_path.is_none());
     }
 
     #[test]
-    fn spawn_watch_log_path_requires_streaming() {
-        let err = encode_spawn_watch(1000, "cmd", &[], false, false, Some("/tmp/log")).unwrap_err();
+    fn spawn_process_log_path_requires_streaming() {
+        let err =
+            encode_spawn_process(1000, "cmd", &[], false, false, Some("/tmp/log")).unwrap_err();
         assert!(matches!(err, ProtocolError::InvalidPayload(_)));
     }
 
     #[test]
-    fn spawn_watch_log_path_too_long() {
+    fn spawn_process_log_path_too_long() {
         let long_path = "x".repeat(u16::MAX as usize + 1);
-        let err = encode_spawn_watch(1000, "cmd", &[], false, true, Some(&long_path)).unwrap_err();
+        let err =
+            encode_spawn_process(1000, "cmd", &[], false, true, Some(&long_path)).unwrap_err();
         assert!(matches!(
             err,
             ProtocolError::PayloadTooLarge("log_path", size) if size == long_path.len()
         ));
     }
 
-    fn decode_spawn_watch_error(payload: &[u8]) -> ProtocolError {
-        match decode_spawn_watch(payload) {
-            Ok(_) => panic!("expected spawn_watch payload to be rejected"),
+    fn decode_spawn_process_error(payload: &[u8]) -> ProtocolError {
+        match decode_spawn_process(payload) {
+            Ok(_) => panic!("expected spawn_process payload to be rejected"),
             Err(e) => e,
         }
     }
 
     #[test]
-    fn decode_spawn_watch_rejects_empty_log_path() {
-        let mut payload = encode_spawn_watch(1000, "cmd", &[], false, true, None).unwrap();
+    fn decode_spawn_process_rejects_empty_log_path() {
+        let mut payload = encode_spawn_process(1000, "cmd", &[], false, true, None).unwrap();
         payload.extend_from_slice(&0u16.to_be_bytes());
 
-        let err = decode_spawn_watch_error(&payload);
+        let err = decode_spawn_process_error(&payload);
         assert!(matches!(
             err,
-            ProtocolError::InvalidPayload("spawn_watch log_path empty")
+            ProtocolError::InvalidPayload("spawn_process log_path empty")
         ));
     }
 
     #[test]
-    fn decode_spawn_watch_rejects_trailing_byte_after_env() {
-        let mut payload = encode_spawn_watch(1000, "cmd", &[], false, true, None).unwrap();
+    fn decode_spawn_process_rejects_trailing_byte_after_env() {
+        let mut payload = encode_spawn_process(1000, "cmd", &[], false, true, None).unwrap();
         payload.push(0xFF);
 
-        let err = decode_spawn_watch_error(&payload);
+        let err = decode_spawn_process_error(&payload);
         assert!(matches!(
             err,
-            ProtocolError::InvalidPayload("spawn_watch trailing byte after env")
+            ProtocolError::InvalidPayload("spawn_process trailing byte after env")
         ));
     }
 
     #[test]
-    fn decode_spawn_watch_rejects_trailing_bytes_after_log_path() {
+    fn decode_spawn_process_rejects_trailing_bytes_after_log_path() {
         let mut payload =
-            encode_spawn_watch(1000, "cmd", &[], false, true, Some("/tmp/log")).unwrap();
+            encode_spawn_process(1000, "cmd", &[], false, true, Some("/tmp/log")).unwrap();
         payload.push(0xFF);
 
-        let err = decode_spawn_watch_error(&payload);
+        let err = decode_spawn_process_error(&payload);
         assert!(matches!(
             err,
-            ProtocolError::InvalidPayload("spawn_watch trailing bytes")
+            ProtocolError::InvalidPayload("spawn_process trailing bytes")
         ));
     }
 
     #[test]
-    fn decode_spawn_watch_rejects_log_path_without_stream_flag() {
-        let mut payload = encode_spawn_watch(1000, "cmd", &[], false, false, None).unwrap();
+    fn decode_spawn_process_rejects_log_path_without_stream_flag() {
+        let mut payload = encode_spawn_process(1000, "cmd", &[], false, false, None).unwrap();
         let path = b"/tmp/log";
         payload.extend_from_slice(&(path.len() as u16).to_be_bytes());
         payload.extend_from_slice(path);
 
-        let err = decode_spawn_watch_error(&payload);
+        let err = decode_spawn_process_error(&payload);
         assert!(matches!(
             err,
-            ProtocolError::InvalidPayload("spawn_watch log_path requires stream flag")
+            ProtocolError::InvalidPayload("spawn_process log_path requires stream flag")
         ));
     }
 }

--- a/crates/vsock-proto/src/wire.rs
+++ b/crates/vsock-proto/src/wire.rs
@@ -46,3 +46,14 @@ pub const WRITE_FILE_FLAG_SUDO: u8 = 0x01;
 pub const WRITE_FILE_FLAG_APPEND: u8 = 0x02;
 
 pub(crate) const MAX_PAYLOAD_SIZE: usize = MAX_MESSAGE_SIZE - MIN_BODY_SIZE;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn spawn_process_keeps_existing_wire_values() {
+        assert_eq!(MSG_SPAWN_PROCESS, 0x05);
+        assert_eq!(MSG_SPAWN_PROCESS_RESULT, 0x06);
+    }
+}

--- a/crates/vsock-proto/src/wire.rs
+++ b/crates/vsock-proto/src/wire.rs
@@ -13,8 +13,8 @@ pub const MSG_PING: u8 = 0x01;
 pub const MSG_PONG: u8 = 0x02;
 pub const MSG_WRITE_FILE: u8 = 0x03;
 pub const MSG_WRITE_FILE_RESULT: u8 = 0x04;
-pub const MSG_SPAWN_WATCH: u8 = 0x05;
-pub const MSG_SPAWN_WATCH_RESULT: u8 = 0x06;
+pub const MSG_SPAWN_PROCESS: u8 = 0x05;
+pub const MSG_SPAWN_PROCESS_RESULT: u8 = 0x06;
 pub const MSG_PROCESS_EXIT: u8 = 0x07;
 pub const MSG_SHUTDOWN: u8 = 0x08;
 pub const MSG_SHUTDOWN_ACK: u8 = 0x09;
@@ -32,9 +32,9 @@ pub const MSG_ERROR: u8 = 0xFF;
 /// Default vsock port for host-guest communication.
 pub const VSOCK_PORT: u32 = 1000;
 
-// Spawn-watch payload flags.
-pub const SPAWN_WATCH_FLAG_SUDO: u8 = 0x01;
-pub const SPAWN_WATCH_FLAG_STREAM_STDOUT: u8 = 0x02;
+// Spawn-process payload flags.
+pub const SPAWN_PROCESS_FLAG_SUDO: u8 = 0x01;
+pub const SPAWN_PROCESS_FLAG_STREAM_STDOUT: u8 = 0x02;
 
 // Command operation payload flags.
 pub const COMMAND_FLAG_SUDO: u8 = 0x01;

--- a/crates/vsock-test/tests/integration/exec.rs
+++ b/crates/vsock-test/tests/integration/exec.rs
@@ -134,9 +134,9 @@ async fn test_exec_while_waiting_for_exit() {
     // Spawn a long-running process. Use `exec` to replace the shell so the
     // PID we get is the actual sleep process (same pattern as sigterm/sigkill tests).
     let handle = h
-        .spawn_watch("exec sleep 60", 0, &[], false, false, None)
+        .spawn_process("exec sleep 60", 0, &[], false, false, None)
         .await
-        .expect("spawn_watch failed");
+        .expect("spawn_process failed");
     let pid = handle.pid();
 
     // Run spawn wait and exec concurrently on the same task via join!.

--- a/crates/vsock-test/tests/integration/main.rs
+++ b/crates/vsock-test/tests/integration/main.rs
@@ -8,7 +8,7 @@
 
 mod exec;
 mod shutdown;
-mod spawn_watch;
+mod spawn_process;
 mod stdout_streaming;
 mod support;
 mod write_file;

--- a/crates/vsock-test/tests/integration/spawn_process.rs
+++ b/crates/vsock-test/tests/integration/spawn_process.rs
@@ -2,16 +2,16 @@ use std::time::Duration;
 
 use crate::support::Harness;
 
-// ── spawn_watch ──────────────────────────────────────────────────────
+// ── spawn_process ──────────────────────────────────────────────────────
 
 #[tokio::test]
-async fn test_spawn_watch() {
+async fn test_spawn_process() {
     let h = Harness::new().await;
 
     let handle = h
-        .spawn_watch("echo done", 5000, &[], false, false, None)
+        .spawn_process("echo done", 5000, &[], false, false, None)
         .await
-        .expect("spawn_watch failed");
+        .expect("spawn_process failed");
     let pid = handle.pid();
     assert!(pid > 0);
 
@@ -27,13 +27,13 @@ async fn test_spawn_watch() {
 }
 
 #[tokio::test]
-async fn test_spawn_watch_exit_code() {
+async fn test_spawn_process_exit_code() {
     let h = Harness::new().await;
 
     let handle = h
-        .spawn_watch("exit 42", 5000, &[], false, false, None)
+        .spawn_process("exit 42", 5000, &[], false, false, None)
         .await
-        .expect("spawn_watch failed");
+        .expect("spawn_process failed");
 
     let event = h
         .wait_spawn(handle, Duration::from_secs(5))
@@ -45,13 +45,13 @@ async fn test_spawn_watch_exit_code() {
 }
 
 #[tokio::test]
-async fn test_spawn_watch_stderr() {
+async fn test_spawn_process_stderr() {
     let h = Harness::new().await;
 
     let handle = h
-        .spawn_watch("echo error >&2 && exit 1", 5000, &[], false, false, None)
+        .spawn_process("echo error >&2 && exit 1", 5000, &[], false, false, None)
         .await
-        .expect("spawn_watch failed");
+        .expect("spawn_process failed");
 
     let event = h
         .wait_spawn(handle, Duration::from_secs(5))
@@ -64,11 +64,11 @@ async fn test_spawn_watch_stderr() {
 }
 
 #[tokio::test]
-async fn test_spawn_watch_both_stdout_stderr() {
+async fn test_spawn_process_both_stdout_stderr() {
     let h = Harness::new().await;
 
     let handle = h
-        .spawn_watch(
+        .spawn_process(
             "echo out && echo err >&2 && exit 2",
             5000,
             &[],
@@ -77,7 +77,7 @@ async fn test_spawn_watch_both_stdout_stderr() {
             None,
         )
         .await
-        .expect("spawn_watch failed");
+        .expect("spawn_process failed");
 
     let event = h
         .wait_spawn(handle, Duration::from_secs(5))
@@ -91,13 +91,13 @@ async fn test_spawn_watch_both_stdout_stderr() {
 }
 
 #[tokio::test]
-async fn test_spawn_watch_no_output() {
+async fn test_spawn_process_no_output() {
     let h = Harness::new().await;
 
     let handle = h
-        .spawn_watch("true", 5000, &[], false, false, None)
+        .spawn_process("true", 5000, &[], false, false, None)
         .await
-        .expect("spawn_watch failed");
+        .expect("spawn_process failed");
 
     let event = h
         .wait_spawn(handle, Duration::from_secs(5))
@@ -111,19 +111,19 @@ async fn test_spawn_watch_no_output() {
 }
 
 #[tokio::test]
-async fn test_spawn_watch_concurrent() {
+async fn test_spawn_process_concurrent() {
     let h = Harness::new().await;
 
     // Spawn two processes — second finishes first
     let handle1 = h
-        .spawn_watch("sleep 0.1 && echo first", 5000, &[], false, false, None)
+        .spawn_process("sleep 0.1 && echo first", 5000, &[], false, false, None)
         .await
-        .expect("spawn_watch 1 failed");
+        .expect("spawn_process 1 failed");
     let pid1 = handle1.pid();
     let handle2 = h
-        .spawn_watch("echo second", 5000, &[], false, false, None)
+        .spawn_process("echo second", 5000, &[], false, false, None)
         .await
-        .expect("spawn_watch 2 failed");
+        .expect("spawn_process 2 failed");
     let pid2 = handle2.pid();
 
     assert_ne!(pid1, pid2);
@@ -146,13 +146,13 @@ async fn test_spawn_watch_concurrent() {
 }
 
 #[tokio::test]
-async fn test_spawn_watch_timeout() {
+async fn test_spawn_process_timeout() {
     let h = Harness::new().await;
 
     let handle = h
-        .spawn_watch("sleep 10", 100, &[], false, false, None)
+        .spawn_process("sleep 10", 100, &[], false, false, None)
         .await
-        .expect("spawn_watch failed");
+        .expect("spawn_process failed");
 
     let event = h
         .wait_spawn(handle, Duration::from_secs(5))
@@ -165,13 +165,13 @@ async fn test_spawn_watch_timeout() {
 }
 
 #[tokio::test]
-async fn test_spawn_watch_exit_before_wait() {
+async fn test_spawn_process_exit_before_wait() {
     let h = Harness::new().await;
 
     let handle = h
-        .spawn_watch("echo completed", 5000, &[], false, false, None)
+        .spawn_process("echo completed", 5000, &[], false, false, None)
         .await
-        .expect("spawn_watch failed");
+        .expect("spawn_process failed");
 
     // Use an exec round-trip as a synchronization barrier: by the time exec
     // returns, the exit event from "echo completed" has already been delivered
@@ -192,11 +192,11 @@ async fn test_spawn_watch_exit_before_wait() {
 }
 
 #[tokio::test]
-async fn test_spawn_watch_multiline() {
+async fn test_spawn_process_multiline() {
     let h = Harness::new().await;
 
     let handle = h
-        .spawn_watch(
+        .spawn_process(
             "printf 'line1\\nline2\\nline3\\n'",
             5000,
             &[],
@@ -205,7 +205,7 @@ async fn test_spawn_watch_multiline() {
             None,
         )
         .await
-        .expect("spawn_watch failed");
+        .expect("spawn_process failed");
 
     let event = h
         .wait_spawn(handle, Duration::from_secs(5))
@@ -218,11 +218,11 @@ async fn test_spawn_watch_multiline() {
 }
 
 #[tokio::test]
-async fn test_spawn_watch_large_output() {
+async fn test_spawn_process_large_output() {
     let h = Harness::new().await;
 
     let handle = h
-        .spawn_watch(
+        .spawn_process(
             "dd if=/dev/zero bs=1024 count=10 2>/dev/null | base64",
             5000,
             &[],
@@ -231,7 +231,7 @@ async fn test_spawn_watch_large_output() {
             None,
         )
         .await
-        .expect("spawn_watch failed");
+        .expect("spawn_process failed");
 
     let event = h
         .wait_spawn(handle, Duration::from_secs(10))
@@ -244,13 +244,13 @@ async fn test_spawn_watch_large_output() {
 }
 
 #[tokio::test]
-async fn test_spawn_watch_delayed_output() {
+async fn test_spawn_process_delayed_output() {
     let h = Harness::new().await;
 
     let handle = h
-        .spawn_watch("sleep 0.2 && echo delayed", 5000, &[], false, false, None)
+        .spawn_process("sleep 0.2 && echo delayed", 5000, &[], false, false, None)
         .await
-        .expect("spawn_watch failed");
+        .expect("spawn_process failed");
 
     let event = h
         .wait_spawn(handle, Duration::from_secs(5))
@@ -263,14 +263,14 @@ async fn test_spawn_watch_delayed_output() {
 }
 
 #[tokio::test]
-async fn test_spawn_watch_sigterm() {
+async fn test_spawn_process_sigterm() {
     let h = Harness::new().await;
 
     // Use `exec` to replace shell so the PID we get is the actual sleep process
     let handle = h
-        .spawn_watch("exec sleep 60", 0, &[], false, false, None)
+        .spawn_process("exec sleep 60", 0, &[], false, false, None)
         .await
-        .expect("spawn_watch failed");
+        .expect("spawn_process failed");
     let pid = handle.pid();
 
     // Kill process group with SIGTERM
@@ -293,13 +293,13 @@ async fn test_spawn_watch_sigterm() {
 }
 
 #[tokio::test]
-async fn test_spawn_watch_sigkill() {
+async fn test_spawn_process_sigkill() {
     let h = Harness::new().await;
 
     let handle = h
-        .spawn_watch("exec sleep 60", 0, &[], false, false, None)
+        .spawn_process("exec sleep 60", 0, &[], false, false, None)
         .await
-        .expect("spawn_watch failed");
+        .expect("spawn_process failed");
     let pid = handle.pid();
 
     h.exec(
@@ -321,22 +321,22 @@ async fn test_spawn_watch_sigkill() {
 }
 
 #[tokio::test]
-async fn test_spawn_watch_rapid_multiple() {
+async fn test_spawn_process_rapid_multiple() {
     let h = Harness::new().await;
 
     let mut handles = Vec::new();
     for i in 0..5 {
         let handle = h
-            .spawn_watch(&format!("echo p{i}"), 5000, &[], false, false, None)
+            .spawn_process(&format!("echo p{i}"), 5000, &[], false, false, None)
             .await
-            .expect("spawn_watch failed");
+            .expect("spawn_process failed");
         handles.push(handle);
     }
 
     // All PIDs should be unique
     let unique: std::collections::HashSet<_> = handles
         .iter()
-        .map(vsock_host::SpawnWatchHandle::pid)
+        .map(vsock_host::GuestProcessHandle::pid)
         .collect();
     assert_eq!(unique.len(), 5);
 
@@ -353,11 +353,11 @@ async fn test_spawn_watch_rapid_multiple() {
 }
 
 #[tokio::test]
-async fn test_spawn_watch_nonexistent_command() {
+async fn test_spawn_process_nonexistent_command() {
     let h = Harness::new().await;
 
     let handle = h
-        .spawn_watch(
+        .spawn_process(
             "nonexistent_command_12345 2>&1",
             5000,
             &[],
@@ -366,7 +366,7 @@ async fn test_spawn_watch_nonexistent_command() {
             None,
         )
         .await
-        .expect("spawn_watch failed");
+        .expect("spawn_process failed");
 
     let event = h
         .wait_spawn(handle, Duration::from_secs(5))
@@ -385,11 +385,11 @@ async fn test_spawn_watch_nonexistent_command() {
 }
 
 #[tokio::test]
-async fn test_spawn_watch_unicode() {
+async fn test_spawn_process_unicode() {
     let h = Harness::new().await;
 
     let handle = h
-        .spawn_watch(
+        .spawn_process(
             "printf '你好世界\\nこんにちは\\n🎉emoji🚀'",
             5000,
             &[],
@@ -398,7 +398,7 @@ async fn test_spawn_watch_unicode() {
             None,
         )
         .await
-        .expect("spawn_watch failed");
+        .expect("spawn_process failed");
 
     let event = h
         .wait_spawn(handle, Duration::from_secs(5))
@@ -414,11 +414,11 @@ async fn test_spawn_watch_unicode() {
 }
 
 #[tokio::test]
-async fn test_spawn_watch_interleaved_output() {
+async fn test_spawn_process_interleaved_output() {
     let h = Harness::new().await;
 
     let handle = h
-        .spawn_watch(
+        .spawn_process(
             "echo out1 && echo err1 >&2 && echo out2 && echo err2 >&2",
             5000,
             &[],
@@ -427,7 +427,7 @@ async fn test_spawn_watch_interleaved_output() {
             None,
         )
         .await
-        .expect("spawn_watch failed");
+        .expect("spawn_process failed");
 
     let event = h
         .wait_spawn(handle, Duration::from_secs(5))
@@ -443,11 +443,11 @@ async fn test_spawn_watch_interleaved_output() {
 }
 
 #[tokio::test]
-async fn test_spawn_watch_with_env() {
+async fn test_spawn_process_with_env() {
     let h = Harness::new().await;
 
     let handle = h
-        .spawn_watch(
+        .spawn_process(
             "echo $GREETING",
             5000,
             &[("GREETING", "hi_from_env")],
@@ -456,7 +456,7 @@ async fn test_spawn_watch_with_env() {
             None,
         )
         .await
-        .expect("spawn_watch failed");
+        .expect("spawn_process failed");
 
     let event = h
         .wait_spawn(handle, Duration::from_secs(5))

--- a/crates/vsock-test/tests/integration/stdout_streaming.rs
+++ b/crates/vsock-test/tests/integration/stdout_streaming.rs
@@ -7,16 +7,16 @@ use crate::support::{Harness, shell_quote_path};
 /// When stdout_log_path is set, stdout is streamed via MSG_STDOUT_CHUNK
 /// and teed to the specified file. process_exit.stdout should be empty.
 #[tokio::test]
-async fn test_spawn_watch_stdout_streaming() {
+async fn test_spawn_process_stdout_streaming() {
     let h = Harness::new().await;
 
     let log_file = h.dir.join("stream.log");
     let log_path = log_file.to_string_lossy().to_string();
 
     let mut handle = h
-        .spawn_watch("echo hello_stream", 5000, &[], false, true, Some(&log_path))
+        .spawn_process("echo hello_stream", 5000, &[], false, true, Some(&log_path))
         .await
-        .expect("spawn_watch failed");
+        .expect("spawn_process failed");
     let mut stdout_rx = handle.take_stdout_receiver().unwrap();
 
     let event = h
@@ -44,7 +44,7 @@ async fn test_spawn_watch_stdout_streaming() {
 
 /// Streaming stdout must be observable before the process reaches exit.
 #[tokio::test]
-async fn test_spawn_watch_stdout_streaming_delivers_before_exit() {
+async fn test_spawn_process_stdout_streaming_delivers_before_exit() {
     let h = Harness::new().await;
 
     let release_fifo = h.dir.join("release-streaming-process");
@@ -54,9 +54,9 @@ async fn test_spawn_watch_stdout_streaming_delivers_before_exit() {
     );
 
     let mut handle = h
-        .spawn_watch(&command, 5000, &[], false, true, None)
+        .spawn_process(&command, 5000, &[], false, true, None)
         .await
-        .expect("spawn_watch failed");
+        .expect("spawn_process failed");
     let mut stdout_rx = handle.take_stdout_receiver().unwrap();
 
     let chunk = tokio::time::timeout(Duration::from_secs(2), stdout_rx.recv())
@@ -79,16 +79,16 @@ async fn test_spawn_watch_stdout_streaming_delivers_before_exit() {
 
 /// Streaming can be enabled without a guest-side tee file.
 #[tokio::test]
-async fn test_spawn_watch_stdout_stream_only() {
+async fn test_spawn_process_stdout_stream_only() {
     let h = Harness::new().await;
 
     let existing_guest_log = h.dir.join("stream_only_guest.log");
     std::fs::write(&existing_guest_log, "preexisting\n").unwrap();
 
     let mut handle = h
-        .spawn_watch("echo stream_only", 5000, &[], false, true, None)
+        .spawn_process("echo stream_only", 5000, &[], false, true, None)
         .await
-        .expect("spawn_watch failed");
+        .expect("spawn_process failed");
     let mut stdout_rx = handle.take_stdout_receiver().unwrap();
 
     let event = h
@@ -111,7 +111,7 @@ async fn test_spawn_watch_stdout_stream_only() {
 
 /// Streaming with multiple chunks (large output).
 #[tokio::test]
-async fn test_spawn_watch_stdout_streaming_large() {
+async fn test_spawn_process_stdout_streaming_large() {
     let h = Harness::new().await;
 
     let log_file = h.dir.join("stream_large.log");
@@ -119,7 +119,7 @@ async fn test_spawn_watch_stdout_streaming_large() {
 
     // Generate ~20KB of output (well over the 8KB chunk size)
     let mut handle = h
-        .spawn_watch(
+        .spawn_process(
             "dd if=/dev/zero bs=1024 count=20 2>/dev/null | base64",
             5000,
             &[],
@@ -128,7 +128,7 @@ async fn test_spawn_watch_stdout_streaming_large() {
             Some(&log_path),
         )
         .await
-        .expect("spawn_watch failed");
+        .expect("spawn_process failed");
     let mut stdout_rx = handle.take_stdout_receiver().unwrap();
 
     let event = h
@@ -158,7 +158,7 @@ async fn test_spawn_watch_stdout_streaming_large() {
 
 /// stdout_log_path does not leak into child environment.
 #[tokio::test]
-async fn test_spawn_watch_stdout_log_path_not_in_env() {
+async fn test_spawn_process_stdout_log_path_not_in_env() {
     let h = Harness::new().await;
 
     let log_file = h.dir.join("no_leak.log");
@@ -167,9 +167,9 @@ async fn test_spawn_watch_stdout_log_path_not_in_env() {
     // The child prints its own env — stdout_log_path is a protocol parameter,
     // not an env var, so it should never appear in the child's environment.
     let handle = h
-        .spawn_watch("env", 5000, &[], false, true, Some(&log_path))
+        .spawn_process("env", 5000, &[], false, true, Some(&log_path))
         .await
-        .expect("spawn_watch failed");
+        .expect("spawn_process failed");
 
     let event = h
         .wait_spawn(handle, Duration::from_secs(5))
@@ -190,7 +190,7 @@ async fn test_spawn_watch_stdout_log_path_not_in_env() {
 /// Without the fix, the timeout killer thread was only spawned after the stdout
 /// loop finished, so a process producing output past the deadline would hang.
 #[tokio::test]
-async fn test_spawn_watch_stdout_streaming_timeout() {
+async fn test_spawn_process_stdout_streaming_timeout() {
     let h = Harness::new().await;
 
     let log_file = h.dir.join("stream_timeout.log");
@@ -198,7 +198,7 @@ async fn test_spawn_watch_stdout_streaming_timeout() {
 
     // Process that produces output forever — must be killed by the 100ms timeout.
     let mut handle = h
-        .spawn_watch(
+        .spawn_process(
             "while true; do echo tick; sleep 0.01; done",
             100,
             &[],
@@ -207,7 +207,7 @@ async fn test_spawn_watch_stdout_streaming_timeout() {
             Some(&log_path),
         )
         .await
-        .expect("spawn_watch failed");
+        .expect("spawn_process failed");
     let mut stdout_rx = handle.take_stdout_receiver().unwrap();
 
     let event = h

--- a/crates/vsock-test/tests/integration/support.rs
+++ b/crates/vsock-test/tests/integration/support.rs
@@ -134,7 +134,7 @@ impl Harness {
 
     pub(crate) async fn wait_spawn(
         &self,
-        handle: vsock_host::SpawnWatchHandle,
+        handle: vsock_host::GuestProcessHandle,
         timeout: Duration,
     ) -> io::Result<vsock_host::ProcessExitEvent> {
         tokio::time::timeout(timeout, handle.wait())


### PR DESCRIPTION
## Summary
- rename the sandbox/vsock spawn_watch API family to spawn_process
- rename protocol symbols, payload helpers, host/guest handlers, mocks, runner call sites, and tests
- preserve existing wire numeric values and process lifecycle behavior

Closes #13366

## Tests
- cargo fmt --manifest-path crates/Cargo.toml --all --check
- cargo test --manifest-path crates/Cargo.toml -p vsock-proto -p vsock-host -p vsock-guest -p sandbox -p sandbox-fc -p sandbox-mock -p runner --all-targets
- cargo test --manifest-path crates/Cargo.toml -p vsock-test --all-targets
- pre-commit: crates cargo-fmt, cargo-doc, cargo-clippy