### PR TITLE
fix(web): prevent api route baseline growth

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -342,6 +342,8 @@ jobs:
       image: ghcr.io/vm0-ai/vm0-toolchain:20260419
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - uses: ./.github/actions/toolchain-init
       - name: Validate oxlintrc.json react allowImportNames
         working-directory: turbo

--- a/turbo/apps/web/custom-eslint/__tests__/no-new-api-routes.test.ts
+++ b/turbo/apps/web/custom-eslint/__tests__/no-new-api-routes.test.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from "node:child_process";
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -12,6 +13,9 @@ import {
   WEB_API_ROUTE_BASELINE_HASH,
 } from "../baselines/web-api-routes.ts";
 import {
+  expandedBaselineRoutes,
+  expandedBaselineRoutesSinceReference,
+  extractWebApiRouteBaselineRoutes,
   missingBaselineRoutes,
   noNewApiRoutes,
   webApiRouteBaselineHashIsCurrent,
@@ -99,5 +103,86 @@ describe("web API route baseline hash", () => {
         "app/api/new-backend-only-route/route.ts",
       ]),
     ).not.toBe(WEB_API_ROUTE_BASELINE_HASH);
+  });
+});
+
+describe("web API route baseline expansion", () => {
+  let tempGitDir: string | null = null;
+
+  afterEach(() => {
+    delete process.env.WEB_API_ROUTE_BASELINE_REFERENCE;
+    if (tempGitDir) {
+      rmSync(tempGitDir, { recursive: true, force: true });
+      tempGitDir = null;
+    }
+  });
+
+  it("extracts route entries from a baseline source file", () => {
+    expect(
+      extractWebApiRouteBaselineRoutes(`
+        export const WEB_API_ROUTE_BASELINE = [
+          "app/api/auth/me/route.ts",
+          "app/api/zero/chat/messages/route.ts",
+        ] as const;
+      `),
+    ).toEqual([
+      "app/api/auth/me/route.ts",
+      "app/api/zero/chat/messages/route.ts",
+    ]);
+  });
+
+  it("allows baseline routes to shrink without reporting additions", () => {
+    expect(
+      expandedBaselineRoutes(
+        ["app/api/auth/me/route.ts", "app/api/zero/chat/messages/route.ts"],
+        ["app/api/auth/me/route.ts"],
+      ),
+    ).toEqual([]);
+  });
+
+  it("reports routes added to the baseline", () => {
+    expect(
+      expandedBaselineRoutes(
+        ["app/api/auth/me/route.ts"],
+        ["app/api/auth/me/route.ts", "app/api/new-backend-only-route/route.ts"],
+      ),
+    ).toEqual(["app/api/new-backend-only-route/route.ts"]);
+  });
+
+  it("reports routes added since the configured git reference", () => {
+    tempGitDir = mkdtempSync(path.join(os.tmpdir(), "web-api-routes-git-"));
+    const baselinePath = path.join(
+      tempGitDir,
+      "custom-eslint/baselines/web-api-routes.ts",
+    );
+    mkdirSync(path.dirname(baselinePath), { recursive: true });
+    writeFileSync(
+      baselinePath,
+      `
+        export const WEB_API_ROUTE_BASELINE = [
+          "${WEB_API_ROUTE_BASELINE[0]}",
+        ] as const;
+      `,
+    );
+    execFileSync("git", ["init"], { cwd: tempGitDir });
+    execFileSync("git", ["add", "."], { cwd: tempGitDir });
+    execFileSync(
+      "git",
+      [
+        "-c",
+        "user.name=Test User",
+        "-c",
+        "user.email=test@example.com",
+        "commit",
+        "-m",
+        "seed baseline",
+      ],
+      { cwd: tempGitDir },
+    );
+    process.env.WEB_API_ROUTE_BASELINE_REFERENCE = "HEAD";
+
+    const expanded = expandedBaselineRoutesSinceReference(tempGitDir);
+
+    expect(expanded).toContain(WEB_API_ROUTE_BASELINE[1]);
   });
 });

--- a/turbo/apps/web/custom-eslint/baselines/web-api-routes.ts
+++ b/turbo/apps/web/custom-eslint/baselines/web-api-routes.ts
@@ -5,7 +5,8 @@ import { createHash } from "node:crypto";
  * frozen. New API routes should be implemented in apps/api instead.
  *
  * When a route is migrated out of apps/web, remove its entry here as part of
- * the same change. Do not add new entries without an intentional exception.
+ * the same change. Do not add new entries; the no-new-api-routes rule checks
+ * that this baseline only shrinks relative to the branch's git base.
  *
  * Intentional exception: model policy and user model preference routes live in
  * apps/web while the rest of Zero's bearer-token web API still authenticates

--- a/turbo/apps/web/custom-eslint/rules/no-new-api-routes.ts
+++ b/turbo/apps/web/custom-eslint/rules/no-new-api-routes.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import * as path from "node:path";
 
@@ -13,6 +14,9 @@ const APP_API_ROUTE_PREFIX = "app/api/";
 const APP_API_ROUTE_MARKER = "/app/api/";
 const ROUTE_SUFFIX = "/route.ts";
 
+const BASELINE_FILE_FROM_WEB_ROOT = "custom-eslint/baselines/web-api-routes.ts";
+
+const reportedBaselineExpansionRoots = new Set<string>();
 const reportedBaselineHashRoots = new Set<string>();
 const reportedStaleBaselineRoots = new Set<string>();
 
@@ -51,6 +55,89 @@ export function missingBaselineRoutes(webRoot: string): readonly string[] {
   });
 }
 
+export function expandedBaselineRoutes(
+  referenceRoutes: readonly string[],
+  routes: readonly string[] = WEB_API_ROUTE_BASELINE,
+): readonly string[] {
+  const referenceRouteSet = new Set<string>(referenceRoutes);
+  return routes.filter((routePath) => {
+    return !referenceRouteSet.has(routePath);
+  });
+}
+
+export function extractWebApiRouteBaselineRoutes(
+  source: string,
+): readonly string[] {
+  const routes: string[] = [];
+  const routePattern = /"((?:app\/api\/)[^"]+\/route\.ts)"/gu;
+  let match = routePattern.exec(source);
+  while (match) {
+    const routePath = match[1];
+    if (routePath) {
+      routes.push(routePath);
+    }
+    match = routePattern.exec(source);
+  }
+  return routes;
+}
+
+function gitOutput(cwd: string, args: readonly string[]): string | null {
+  try {
+    return execFileSync("git", [...args], {
+      cwd,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+function gitRootForWebRoot(webRoot: string): string | null {
+  return gitOutput(webRoot, ["rev-parse", "--show-toplevel"]);
+}
+
+function baselineReferenceForGitRoot(gitRoot: string): string | null {
+  const explicitReference =
+    process.env.WEB_API_ROUTE_BASELINE_REFERENCE?.trim();
+  if (explicitReference) {
+    return explicitReference;
+  }
+
+  const baseRef = process.env.GITHUB_BASE_REF?.trim();
+  const upstreamRef = baseRef ? `origin/${baseRef}` : "origin/main";
+  return gitOutput(gitRoot, ["merge-base", "HEAD", upstreamRef]);
+}
+
+export function expandedBaselineRoutesSinceReference(
+  webRoot: string,
+): readonly string[] {
+  const gitRoot = gitRootForWebRoot(webRoot);
+  if (!gitRoot) {
+    return [];
+  }
+
+  const reference = baselineReferenceForGitRoot(gitRoot);
+  if (!reference) {
+    return [];
+  }
+
+  const baselinePath = normalizePath(
+    path.relative(gitRoot, path.join(webRoot, BASELINE_FILE_FROM_WEB_ROOT)),
+  );
+  const referenceSource = gitOutput(gitRoot, [
+    "show",
+    `${reference}:${baselinePath}`,
+  ]);
+  if (!referenceSource) {
+    return [];
+  }
+
+  return expandedBaselineRoutes(
+    extractWebApiRouteBaselineRoutes(referenceSource),
+  );
+}
+
 function staleBaselineMessageData(missingRoutes: readonly string[]): {
   readonly count: string;
   readonly routes: string;
@@ -84,6 +171,8 @@ export const noNewApiRoutes = createRule({
     messages: {
       noNewApiRoute:
         "Do not add new API routes under apps/web/app/api. Add this route to apps/api and keep web as legacy/fallback only.",
+      expandedApiRouteBaseline:
+        "Web API route baseline cannot grow. Remove added baseline entries, add the route to apps/api, and use a Next.js rewrite when web compatibility is needed: {{routes}}",
       staleApiRouteBaseline:
         "Web API route baseline contains {{count}} deleted route(s). Remove stale baseline entries: {{routes}}",
       changedApiRouteBaseline:
@@ -106,6 +195,18 @@ export const noNewApiRoutes = createRule({
         }
 
         const webRoot = webRootFromFilename(context.filename);
+        if (!reportedBaselineExpansionRoots.has(webRoot)) {
+          reportedBaselineExpansionRoots.add(webRoot);
+          const expandedRoutes = expandedBaselineRoutesSinceReference(webRoot);
+          if (expandedRoutes.length > 0) {
+            context.report({
+              node,
+              messageId: "expandedApiRouteBaseline",
+              data: staleBaselineMessageData(expandedRoutes),
+            });
+          }
+        }
+
         if (!reportedBaselineHashRoots.has(webRoot)) {
           reportedBaselineHashRoots.add(webRoot);
           if (!webApiRouteBaselineHashIsCurrent()) {


### PR DESCRIPTION
## Summary
- fail the web no-new-api-routes lint rule when WEB_API_ROUTE_BASELINE grows relative to the branch git base
- keep baseline shrink/removal allowed and update the baseline comment to document that policy
- fetch full history for the lint-eslint CI job so the rule can compare against the PR base

## Tests
- pnpm -F web exec vitest run custom-eslint/__tests__/no-new-api-routes.test.ts
- pnpm -F web lint
- pnpm -F web check-types
- pnpm format
- git diff --check
- pre-commit: prettier, knip --cache, turbo run check-types --concurrency=1