### PR TITLE
chore: update rootfs package versions

### DIFF
--- a/crates/runner/scripts/build-template.sh
+++ b/crates/runner/scripts/build-template.sh
@@ -111,7 +111,7 @@ CACHE_TMP_TAR=""
 
 # Pinned versions (changes here invalidate the template cache via script hash)
 GO_VERSION="1.26.3"
-CLAUDE_CODE_VERSION="2.1.141"
+CLAUDE_CODE_VERSION="2.1.142"
 CODEX_CLI_VERSION="0.130.0"
 GWS_CLI_VERSION="0.22.5"
 XURL_VERSION="1.0.3"


### PR DESCRIPTION
## Updates

- Claude Code CLI: 2.1.141 -> 2.1.142

## Verification

- Checked Go latest: 1.26.3
- Checked npm latest versions for @googleworkspace/cli, @xdevplatform/xurl, @openai/codex, and agent-browser; all already current
- Verified Claude Code 2.1.142 standalone manifest and linux-x64 binary are available from the configured GCS bucket
- Ran `bash -n crates/runner/scripts/build-template.sh`