### PR TITLE
fix: preserve usage limit chat errors

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-chat.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-chat.test.ts
@@ -322,6 +322,34 @@ describe("POST /api/internal/callbacks/chat", () => {
     expect(context.mocks.axiom.query).not.toHaveBeenCalled();
   });
 
+  it("preserves usage limit errors on failed callbacks", async () => {
+    const fixture = await track(seedChatCallbackFixture());
+    const usageLimitError =
+      "usage_limit_reached: Your usage limit has been reached.";
+
+    const response = await postSignedCallback({
+      callbackId: fixture.callbackId,
+      runId: fixture.runId,
+      status: "failed",
+      error: usageLimitError,
+      payload: { threadId: fixture.threadId, agentId: fixture.agentId },
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toStrictEqual({ success: true });
+
+    const messages = await listMessages(fixture.threadId);
+    const errorMessage = messages.find((message) => {
+      return message.role === "assistant" && message.runId === fixture.runId;
+    });
+    expect(errorMessage?.error).toBe(usageLimitError);
+    expect(errorMessage?.content).toBe(usageLimitError);
+    expect(errorMessage?.error).not.toBe(
+      "Oops, something went wrong. Please try again later.",
+    );
+    expect(context.mocks.axiom.query).not.toHaveBeenCalled();
+  });
+
   it("auto-sends the oldest queued user message after a terminal callback", async () => {
     const fixture = await track(seedChatCallbackFixture());
     const db = store.set(writeDb$);

--- a/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
@@ -61,6 +61,10 @@ const ACTIONABLE_ERROR_SNIPPETS = [
   "Cannot continue session",
   "Invalid signature in thinking block",
   "Run cancelled",
+  "usage limit",
+  "usage_limit",
+  "usage-limit",
+  "UsageLimit",
 ] as const;
 
 const EXT_MIMETYPE_MAP: Readonly<Record<string, string>> = {

--- a/turbo/apps/web/app/api/internal/callbacks/chat/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/chat/__tests__/route.test.ts
@@ -1040,6 +1040,39 @@ describe("POST /api/internal/callbacks/chat", () => {
       expect(errorMsg?.content).toBe(actionableError);
     });
 
+    it("should preserve usage limit failed run errors", async () => {
+      const { threadId, runId, secret } = await setupRunAndThread({
+        status: "failed",
+      });
+      const usageLimitError =
+        "Usage limit reached. Upgrade your plan or try again later.";
+
+      const response = await POST(
+        createSignedCallbackRequest(
+          "http://localhost/api/internal/callbacks/chat",
+          {
+            runId,
+            status: "failed",
+            error: usageLimitError,
+            payload: { threadId, agentId },
+          },
+          secret,
+        ),
+      );
+
+      expect(response.status).toBe(200);
+
+      const chatMessages = await getTestChatMessagesByThread(threadId);
+      const errorMsg = chatMessages.find((message) => {
+        return message.role === "assistant" && message.error !== null;
+      });
+      expect(errorMsg?.error).toBe(usageLimitError);
+      expect(errorMsg?.content).toBe(usageLimitError);
+      expect(errorMsg?.error).not.toBe(
+        "Oops, something went wrong. Please try again later.",
+      );
+    });
+
     it("should preserve user-cancelled run errors", async () => {
       const { threadId, runId, secret } = await setupRunAndThread({
         status: "failed",

--- a/turbo/apps/web/src/lib/zero/chat-thread/chat-run-error-message.ts
+++ b/turbo/apps/web/src/lib/zero/chat-thread/chat-run-error-message.ts
@@ -16,6 +16,10 @@ const ACTIONABLE_ERROR_SNIPPETS = [
   "Cannot continue session",
   "Invalid signature in thinking block",
   "Run cancelled",
+  "usage limit",
+  "usage_limit",
+  "usage-limit",
+  "UsageLimit",
 ] as const;
 
 function isActionableRunError(errorMessage: string): boolean {


### PR DESCRIPTION
## Summary
- preserve usage-limit failures as actionable chat errors instead of generic fallback copy
- apply the same matching to Web and API chat callback formatting
- add regression coverage for both callback paths

## Tests
- pnpm --filter web check-types
- pnpm --filter api check-types
- pnpm --filter web exec oxlint src/lib/zero/chat-thread/chat-run-error-message.ts app/api/internal/callbacks/chat/__tests__/route.test.ts
- pnpm --filter api exec oxlint src/signals/services/zero-chat-thread.service.ts src/signals/routes/__tests__/internal-callbacks-chat.test.ts
- temporary Postgres DB: pnpm --filter web db:migrate && pnpm vitest run --project=web --project=api apps/web/app/api/internal/callbacks/chat/__tests__/route.test.ts apps/api/src/signals/routes/__tests__/internal-callbacks-chat.test.ts -t "usage limit"
- pre-commit: turbo run check-types --concurrency=1