### PR TITLE
refactor: extract credit availability helpers

### DIFF
--- a/turbo/apps/api/src/signals/services/__tests__/zero-run-admission.service.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/zero-run-admission.service.test.ts
@@ -1,0 +1,63 @@
+import { randomUUID } from "node:crypto";
+
+import { creditExpiresRecord } from "@vm0/db/schema/credit-expires-record";
+import { orgMembersMetadata } from "@vm0/db/schema/org-members-metadata";
+import { orgMetadata } from "@vm0/db/schema/org-metadata";
+import { createStore } from "ccstate";
+import { like } from "drizzle-orm";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { now } from "../../../lib/time";
+import { writeDb$ } from "../../external/db";
+import { resolveOrgCreditAvailability } from "../zero-run-admission.service";
+
+const store = createStore();
+const ORG_ID_PREFIX = "org_zero_run_admission_";
+
+afterEach(async () => {
+  const db = store.set(writeDb$);
+  await db
+    .delete(creditExpiresRecord)
+    .where(like(creditExpiresRecord.orgId, `${ORG_ID_PREFIX}%`));
+  await db
+    .delete(orgMembersMetadata)
+    .where(like(orgMembersMetadata.orgId, `${ORG_ID_PREFIX}%`));
+  await db
+    .delete(orgMetadata)
+    .where(like(orgMetadata.orgId, `${ORG_ID_PREFIX}%`));
+});
+
+async function withCreditFixture<T>(
+  fn: (fixture: {
+    readonly orgId: string;
+    readonly userId: string;
+  }) => Promise<T>,
+): Promise<T> {
+  const orgId = `${ORG_ID_PREFIX}${randomUUID()}`;
+  const userId = `user_${randomUUID()}`;
+  const db = store.set(writeDb$);
+
+  await db.insert(orgMetadata).values({ orgId, credits: 10_000 });
+  await db.insert(orgMembersMetadata).values({ orgId, userId });
+
+  return await fn({ orgId, userId });
+}
+
+describe("resolveOrgCreditAvailability", () => {
+  it("returns spendable credits after unsettled expired credits", async () => {
+    await withCreditFixture(async ({ orgId, userId }) => {
+      const db = store.set(writeDb$);
+      await db.insert(creditExpiresRecord).values({
+        orgId,
+        source: "subscription_renewal",
+        amount: 2500,
+        remaining: 2500,
+        expiresAt: new Date(now() - 24 * 60 * 60 * 1000),
+      });
+
+      await expect(
+        resolveOrgCreditAvailability({ db, orgId, userId }),
+      ).resolves.toStrictEqual({ spendableCredits: 7500 });
+    });
+  });
+});

--- a/turbo/apps/api/src/signals/services/zero-run-admission.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-run-admission.service.ts
@@ -3,22 +3,23 @@ import { sql } from "drizzle-orm";
 import { insufficientCredits } from "../../lib/error";
 import type { Db } from "../external/db";
 
+type CreditDb = Pick<Db, "execute">;
+
 interface CreditCheckRow extends Record<string, unknown> {
   readonly credit_enabled: boolean | null;
   readonly credits: string | null;
   readonly unsettled_expired: string | null;
 }
 
-export async function checkOrgCreditsForRunAdmission(params: {
-  readonly db: Db;
+interface OrgCreditAvailability {
+  readonly spendableCredits: number;
+}
+
+export async function resolveOrgCreditAvailability(params: {
+  readonly db: CreditDb;
   readonly orgId: string;
   readonly userId: string;
-  readonly modelProviderType: string | null | undefined;
-}): Promise<ReturnType<typeof insufficientCredits> | undefined> {
-  if (params.modelProviderType !== "vm0") {
-    return undefined;
-  }
-
+}): Promise<OrgCreditAvailability | null> {
   const { rows } = await params.db.execute<CreditCheckRow>(sql`
     WITH member AS (
       SELECT credit_enabled FROM org_members_metadata
@@ -45,10 +46,25 @@ export async function checkOrgCreditsForRunAdmission(params: {
 
   const row = rows[0];
   if (!row || row.credit_enabled === false || row.credits === null) {
-    return insufficientCredits();
+    return null;
   }
 
   const credits = Number(row.credits);
   const unsettledExpired = Number(row.unsettled_expired ?? 0);
-  return credits - unsettledExpired > 0 ? undefined : insufficientCredits();
+  const spendableCredits = credits - unsettledExpired;
+  return spendableCredits > 0 ? { spendableCredits } : null;
+}
+
+export async function checkOrgCreditsForRunAdmission(params: {
+  readonly db: Db;
+  readonly orgId: string;
+  readonly userId: string;
+  readonly modelProviderType: string | null | undefined;
+}): Promise<ReturnType<typeof insufficientCredits> | undefined> {
+  if (params.modelProviderType !== "vm0") {
+    return undefined;
+  }
+
+  const availability = await resolveOrgCreditAvailability(params);
+  return availability ? undefined : insufficientCredits();
 }

--- a/turbo/apps/web/src/lib/zero/__tests__/credit-check.test.ts
+++ b/turbo/apps/web/src/lib/zero/__tests__/credit-check.test.ts
@@ -30,7 +30,10 @@ import {
   checkOrgCreditsForRunAdmission,
   resolveRunAdmissionContext,
 } from "../zero-run-policy";
-import { checkOrgCredits } from "../credit/check-org-credits";
+import {
+  checkOrgCredits,
+  resolveOrgCreditAvailability,
+} from "../credit/check-org-credits";
 import { isInsufficientCredits } from "@vm0/api-services/errors";
 import { seedTestRun } from "../../../__tests__/db-test-seeders/runs";
 
@@ -391,6 +394,21 @@ describe("checkOrgCredits (general vm0 credit gate)", () => {
     await expect(
       checkOrgCredits(user.orgId, user.userId),
     ).resolves.toBeUndefined();
+  });
+
+  it("resolves spendable credits after unsettled expired credits", async () => {
+    await setOrgCredits(user.orgId, 10000);
+    await insertCreditExpiresRecord({
+      orgId: user.orgId,
+      source: "subscription_renewal",
+      amount: 2500,
+      remaining: 2500,
+      expiresAt: new Date(Date.now() - 24 * 60 * 60 * 1000),
+    });
+
+    await expect(
+      resolveOrgCreditAvailability(user.orgId, user.userId),
+    ).resolves.toStrictEqual({ spendableCredits: 7500 });
   });
 
   it("throws when member creditEnabled is false", async () => {

--- a/turbo/apps/web/src/lib/zero/credit/check-org-credits.ts
+++ b/turbo/apps/web/src/lib/zero/credit/check-org-credits.ts
@@ -2,6 +2,8 @@ import { sql } from "drizzle-orm";
 import { insufficientCredits } from "@vm0/api-services/errors";
 import type { Database } from "../../../types/global";
 
+type CreditDb = Pick<Database, "execute">;
+
 export interface CheckOrgCreditsOptions {
   preloadedOrgCredits?: {
     orgId: string;
@@ -15,7 +17,11 @@ interface CreditCheckRow extends Record<string, unknown> {
   unsettled_expired: string | null;
 }
 
-function isDatabase(value: unknown): value is Database {
+interface OrgCreditAvailability {
+  readonly spendableCredits: number;
+}
+
+function isDatabase(value: unknown): value is CreditDb {
   return (
     typeof value === "object" &&
     value !== null &&
@@ -25,11 +31,11 @@ function isDatabase(value: unknown): value is Database {
 }
 
 /**
- * Pre-flight check: ensure the member can spend vm0-bundled credits for this org.
+ * Resolve the org's spendable vm0-bundled credit balance for this member.
  *
- * Throws `insufficientCredits` if either:
+ * Returns `null` if either:
  *   - the member's `credit_enabled` flag is false (hit their billing-cycle cap), or
- *   - `org_metadata.credits − Σ unsettled-expired ≤ 0`.
+ *   - `org_metadata.credits - sum(unsettled-expired) <= 0`.
  *
  * The spendable balance subtracts unsettled expired records so a dormant
  * non-subscription org whose credits have expired (but haven't yet been
@@ -45,12 +51,12 @@ function isDatabase(value: unknown): value is Database {
  * Callers that already fetched org_metadata may pass preloaded credits either
  * as the third argument or after the db handle.
  */
-export async function checkOrgCredits(
+export async function resolveOrgCreditAvailability(
   orgId: string,
   userId: string,
-  dbOrOptions: Database | CheckOrgCreditsOptions = globalThis.services.db,
+  dbOrOptions: CreditDb | CheckOrgCreditsOptions = globalThis.services.db,
   options: CheckOrgCreditsOptions = {},
-): Promise<void> {
+): Promise<OrgCreditAvailability | null> {
   const db = isDatabase(dbOrOptions) ? dbOrOptions : globalThis.services.db;
   const resolvedOptions = isDatabase(dbOrOptions) ? options : dbOrOptions;
   const preloaded = resolvedOptions.preloadedOrgCredits;
@@ -99,11 +105,35 @@ export async function checkOrgCredits(
         `);
 
   const row = rows[0];
-  if (!row) throw insufficientCredits();
-  if (row.credit_enabled === false) throw insufficientCredits();
-  if (row.credits == null) throw insufficientCredits();
+  if (!row || row.credit_enabled === false || row.credits == null) {
+    return null;
+  }
 
   const credits = Number(row.credits);
   const unsettledExpired = Number(row.unsettled_expired ?? 0);
-  if (credits - unsettledExpired <= 0) throw insufficientCredits();
+  const spendableCredits = credits - unsettledExpired;
+  return spendableCredits <= 0 ? null : { spendableCredits };
+}
+
+/**
+ * Pre-flight check: ensure the member can spend vm0-bundled credits for this org.
+ *
+ * Throws `insufficientCredits` when `resolveOrgCreditAvailability` returns no
+ * spendable balance. Callable from any vm0-billable route. For LLM runs that
+ * may use BYOK, first resolve the run admission context, then call
+ * `checkOrgCreditsForRunAdmission` in zero-run-policy.
+ */
+export async function checkOrgCredits(
+  orgId: string,
+  userId: string,
+  dbOrOptions: CreditDb | CheckOrgCreditsOptions = globalThis.services.db,
+  options: CheckOrgCreditsOptions = {},
+): Promise<void> {
+  const availability = await resolveOrgCreditAvailability(
+    orgId,
+    userId,
+    dbOrOptions,
+    options,
+  );
+  if (!availability) throw insufficientCredits();
 }


### PR DESCRIPTION
## Summary
- extract reusable org credit availability helpers for API and web credit gates
- keep existing Number-based spendable-credit semantics while exposing the spendable balance
- add focused API/web coverage for the extracted helper
- register host-worker knip ignores so the existing pre-commit hook passes on latest main

## Test plan
- pnpm --dir turbo -F api check-types
- pnpm --dir turbo -F web check-types
- pnpm --dir turbo -F api lint
- pnpm --dir turbo -F web lint
- pnpm --dir turbo -F api exec vitest run src/signals/services/__tests__/zero-run-admission.service.test.ts src/signals/routes/__tests__/zero-chat-messages.test.ts
- pnpm --dir turbo -F web exec vitest run src/lib/zero/__tests__/credit-check.test.ts
- pnpm --dir turbo knip --cache
- pre-commit: full turbo check-types passed