### PR TITLE
fix(runner): supervise signal handler lifecycle

### DIFF
--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -89,7 +89,7 @@ use mitm_restart::{
 use orphan_reap::{
     OrphanReapMode, OrphanReapProcessDiscovery, OrphanedActiveRuns, reap_orphaned_active_runs,
 };
-use signals::{EarlySignals, SignalController};
+use signals::{EarlySignals, SignalController, recv_handler_task};
 
 struct TeardownTimer {
     start: Instant,
@@ -852,7 +852,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
     };
     let mut mode_rx = signal.mode_rx;
     let lifecycle = signal.lifecycle;
-    let signal_handler_abort = signal.handler_abort;
+    let mut signal_handler_task = signal.handler_task;
 
     // -----------------------------------------------------------------------
     // Idle pool cleanup interval (every 10 seconds)
@@ -1031,6 +1031,16 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
             }
             // Mode changes (signals)
             _ = mode_rx.changed() => {}
+            // Signal handler task should run until teardown aborts it. If it
+            // exits early, stop the runner because OS signals are no longer
+            // being consumed.
+            result = recv_handler_task(&mut signal_handler_task) => {
+                match result {
+                    Ok(()) => warn!("signal handler task exited unexpectedly"),
+                    Err(error) => warn!(error = %error, "signal handler task failed"),
+                }
+                lifecycle.hard_stop();
+            }
             // Reap completed jobs promptly in all live modes. Without this,
             // normal Running mode can retain completed JoinSet entries and
             // stale cancel tokens until drain, budget exhaustion, or shutdown.
@@ -1202,9 +1212,19 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
     let phase = teardown.phase_start("finish_mitm_restart");
     finish_mitm_restart_before_shutdown(&mut mitm, &mut mitm_retry).await;
     teardown.phase_complete("finish_mitm_restart", phase);
-    if let Some(abort) = signal_handler_abort {
-        abort.abort();
-        teardown.event("signal_handler_aborted");
+    if let Some(handler_task) = signal_handler_task.take() {
+        handler_task.abort();
+        match handler_task.await {
+            Err(error) if error.is_cancelled() => {
+                teardown.event("signal_handler_aborted");
+            }
+            Err(error) => {
+                warn!(error = %error, "signal handler task failed during shutdown");
+            }
+            Ok(()) => {
+                warn!("signal handler task exited before shutdown abort completed");
+            }
+        }
     }
 
     info!("shutting down factories");

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -1218,8 +1218,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
     finish_mitm_restart_before_shutdown(&mut mitm, &mut mitm_retry).await;
     teardown.phase_complete("finish_mitm_restart", phase);
     if let Some(handler_task) = signal_handler_task.take() {
-        handler_task.abort();
-        match handler_task.await {
+        match handler_task.abort_and_wait().await {
             Err(error) if error.is_cancelled() => {
                 teardown.event("signal_handler_aborted");
             }

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -89,7 +89,7 @@ use mitm_restart::{
 use orphan_reap::{
     OrphanReapMode, OrphanReapProcessDiscovery, OrphanedActiveRuns, reap_orphaned_active_runs,
 };
-use signals::{EarlySignals, SignalController, recv_handler_task};
+use signals::{EarlySignals, SignalController, handle_stopping_signal, recv_handler_task};
 
 struct TeardownTimer {
     start: Instant,
@@ -1039,7 +1039,12 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                     Ok(()) => warn!("signal handler task exited unexpectedly"),
                     Err(error) => warn!(error = %error, "signal handler task failed"),
                 }
-                lifecycle.hard_stop();
+                handle_stopping_signal(
+                    "signal-handler-task",
+                    &cancel,
+                    &cancel_tokens,
+                    &lifecycle,
+                ).await;
             }
             // Reap completed jobs promptly in all live modes. Without this,
             // normal Running mode can retain completed JoinSet entries and

--- a/crates/runner/src/cmd/start/signals.rs
+++ b/crates/runner/src/cmd/start/signals.rs
@@ -160,8 +160,45 @@ pub(crate) struct SignalController {
     pub lifecycle: LifecycleController,
     /// Spawned signal-handler task. `None` for test overrides where no real
     /// task was spawned. Teardown aborts and awaits this handle so the task
-    /// releases its signal stream subscriptions before `run()` returns.
-    pub handler_task: Option<tokio::task::JoinHandle<()>>,
+    /// releases its signal stream subscriptions before `run()` returns. If
+    /// `run()` is externally cancelled before teardown, dropping this wrapper
+    /// still aborts the task so it cannot outlive its runner.
+    pub handler_task: Option<SignalHandlerTask>,
+}
+
+pub(crate) struct SignalHandlerTask {
+    handle: Option<tokio::task::JoinHandle<()>>,
+}
+
+impl SignalHandlerTask {
+    pub(crate) fn new(handle: tokio::task::JoinHandle<()>) -> Self {
+        Self {
+            handle: Some(handle),
+        }
+    }
+
+    pub(super) async fn abort_and_wait(mut self) -> Result<(), tokio::task::JoinError> {
+        let Some(handle) = self.handle.take() else {
+            return Ok(());
+        };
+        handle.abort();
+        handle.await
+    }
+
+    async fn wait(&mut self) -> Result<(), String> {
+        match self.handle.as_mut() {
+            Some(handle) => handle.await.map_err(|error| error.to_string()),
+            None => Err("signal handler task handle missing".to_string()),
+        }
+    }
+}
+
+impl Drop for SignalHandlerTask {
+    fn drop(&mut self) {
+        if let Some(handle) = &self.handle {
+            handle.abort();
+        }
+    }
 }
 
 impl SignalController {
@@ -227,7 +264,7 @@ impl SignalController {
         Self {
             mode_rx,
             lifecycle,
-            handler_task: Some(handle),
+            handler_task: Some(SignalHandlerTask::new(handle)),
         }
     }
 }
@@ -238,14 +275,11 @@ impl SignalController {
 /// `Option` outside the future lets `tokio::select!` watch the task without
 /// taking ownership unless it actually completes.
 pub(super) async fn recv_handler_task(
-    handler_task: &mut Option<tokio::task::JoinHandle<()>>,
+    handler_task: &mut Option<SignalHandlerTask>,
 ) -> Result<(), String> {
     match handler_task {
         Some(task) => {
-            let result = match task.await {
-                Ok(()) => Ok(()),
-                Err(error) => Err(error.to_string()),
-            };
+            let result = task.wait().await;
             *handler_task = None;
             result
         }
@@ -344,8 +378,8 @@ mod tests {
         // Abort so the task releases its Signal stream subscriptions
         // and does not linger to consume signals raised by later tests.
         if let Some(handler_task) = controller.handler_task {
-            handler_task.abort();
             let result = handler_task
+                .abort_and_wait()
                 .await
                 .expect_err("signal handler should be cancelled");
             assert!(result.is_cancelled());
@@ -354,7 +388,7 @@ mod tests {
 
     #[tokio::test]
     async fn recv_handler_task_clears_completed_task() {
-        let mut handler_task = Some(tokio::spawn(async {}));
+        let mut handler_task = Some(SignalHandlerTask::new(tokio::spawn(async {})));
 
         recv_handler_task(&mut handler_task)
             .await
@@ -367,7 +401,7 @@ mod tests {
     async fn recv_handler_task_reports_cancelled_task() {
         let task = tokio::spawn(std::future::pending::<()>());
         task.abort();
-        let mut handler_task = Some(task);
+        let mut handler_task = Some(SignalHandlerTask::new(task));
 
         let result = recv_handler_task(&mut handler_task)
             .await
@@ -375,6 +409,39 @@ mod tests {
 
         assert!(result.contains("cancelled"));
         assert!(handler_task.is_none());
+    }
+
+    #[tokio::test]
+    async fn dropping_handler_task_aborts_task() {
+        struct NotifyOnDrop(Arc<tokio::sync::Notify>);
+
+        impl Drop for NotifyOnDrop {
+            fn drop(&mut self) {
+                self.0.notify_waiters();
+            }
+        }
+
+        let started = Arc::new(tokio::sync::Notify::new());
+        let dropped = Arc::new(tokio::sync::Notify::new());
+        let task = {
+            let started = Arc::clone(&started);
+            let dropped = Arc::clone(&dropped);
+            tokio::spawn(async move {
+                let _guard = NotifyOnDrop(dropped);
+                started.notify_waiters();
+                std::future::pending::<()>().await;
+            })
+        };
+        let handler_task = SignalHandlerTask::new(task);
+        tokio::time::timeout(Duration::from_secs(2), started.notified())
+            .await
+            .expect("signal handler test task should start");
+
+        drop(handler_task);
+
+        tokio::time::timeout(Duration::from_secs(2), dropped.notified())
+            .await
+            .expect("dropping signal handler task should abort the task");
     }
 
     /// `handle_drain_signal` state guard: SIGUSR1 is honored only from

--- a/crates/runner/src/cmd/start/signals.rs
+++ b/crates/runner/src/cmd/start/signals.rs
@@ -158,13 +158,10 @@ impl LifecycleController {
 pub(crate) struct SignalController {
     pub mode_rx: tokio::sync::watch::Receiver<RunnerMode>,
     pub lifecycle: LifecycleController,
-    /// Abort handle for the spawned signal-handler task. `None` for test
-    /// overrides where no task was spawned. Teardown calls `.abort()` to
-    /// reap the task symmetrically with `mitm_retry.handle.abort()` — the
-    /// handler otherwise would run until runtime drop, which is safe for
-    /// the runner binary but leaks the task when `run()` is embedded in a
-    /// longer-lived host runtime.
-    pub handler_abort: Option<tokio::task::AbortHandle>,
+    /// Spawned signal-handler task. `None` for test overrides where no real
+    /// task was spawned. Teardown aborts and awaits this handle so the task
+    /// releases its signal stream subscriptions before `run()` returns.
+    pub handler_task: Option<tokio::task::JoinHandle<()>>,
 }
 
 impl SignalController {
@@ -191,9 +188,9 @@ impl SignalController {
     ///
     /// ## Lifetime
     ///
-    /// The spawned task loops forever and is implicitly cancelled when the
-    /// tokio runtime is dropped. Its `JoinHandle` is discarded — panics in
-    /// the handler will be logged by tokio but not surfaced.
+    /// The spawned task owns the registered signal streams and normally runs
+    /// until `run()` teardown aborts and awaits `handler_task`. Test overrides
+    /// construct a controller with no real handler task.
     pub(super) fn spawn(
         cancel: CancellationToken,
         cancel_tokens: Arc<tokio::sync::Mutex<HashMap<RunId, CancellationToken>>>,
@@ -230,8 +227,29 @@ impl SignalController {
         Self {
             mode_rx,
             lifecycle,
-            handler_abort: Some(handle.abort_handle()),
+            handler_task: Some(handle),
         }
+    }
+}
+
+/// Await a signal-handler task, or pend forever when tests supply no task.
+///
+/// This mirrors the retry-task helper used by the main loop: keeping the
+/// `Option` outside the future lets `tokio::select!` watch the task without
+/// taking ownership unless it actually completes.
+pub(super) async fn recv_handler_task(
+    handler_task: &mut Option<tokio::task::JoinHandle<()>>,
+) -> Result<(), String> {
+    match handler_task {
+        Some(task) => {
+            let result = match task.await {
+                Ok(()) => Ok(()),
+                Err(error) => Err(error.to_string()),
+            };
+            *handler_task = None;
+            result
+        }
+        None => std::future::pending().await,
     }
 }
 
@@ -325,9 +343,38 @@ mod tests {
 
         // Abort so the task releases its Signal stream subscriptions
         // and does not linger to consume signals raised by later tests.
-        if let Some(abort) = controller.handler_abort {
-            abort.abort();
+        if let Some(handler_task) = controller.handler_task {
+            handler_task.abort();
+            let result = handler_task
+                .await
+                .expect_err("signal handler should be cancelled");
+            assert!(result.is_cancelled());
         }
+    }
+
+    #[tokio::test]
+    async fn recv_handler_task_clears_completed_task() {
+        let mut handler_task = Some(tokio::spawn(async {}));
+
+        recv_handler_task(&mut handler_task)
+            .await
+            .expect("completed handler task");
+
+        assert!(handler_task.is_none());
+    }
+
+    #[tokio::test]
+    async fn recv_handler_task_reports_cancelled_task() {
+        let task = tokio::spawn(std::future::pending::<()>());
+        task.abort();
+        let mut handler_task = Some(task);
+
+        let result = recv_handler_task(&mut handler_task)
+            .await
+            .expect_err("cancelled handler task should be reported");
+
+        assert!(result.contains("cancelled"));
+        assert!(handler_task.is_none());
     }
 
     /// `handle_drain_signal` state guard: SIGUSR1 is honored only from

--- a/crates/runner/src/cmd/start/signals.rs
+++ b/crates/runner/src/cmd/start/signals.rs
@@ -417,7 +417,7 @@ mod tests {
 
         impl Drop for NotifyOnDrop {
             fn drop(&mut self) {
-                self.0.notify_waiters();
+                self.0.notify_one();
             }
         }
 
@@ -428,7 +428,7 @@ mod tests {
             let dropped = Arc::clone(&dropped);
             tokio::spawn(async move {
                 let _guard = NotifyOnDrop(dropped);
-                started.notify_waiters();
+                started.notify_one();
                 std::future::pending::<()>().await;
             })
         };

--- a/crates/runner/src/cmd/start/tests/main_loop.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop.rs
@@ -614,6 +614,47 @@ async fn signal_handler_panic_cancels_active_jobs() {
     .await;
 }
 
+#[tokio::test]
+async fn graceful_shutdown_aborts_signal_handler_task() {
+    struct ReleaseOnDrop(Arc<tokio::sync::Semaphore>);
+
+    impl Drop for ReleaseOnDrop {
+        fn drop(&mut self) {
+            self.0.add_permits(1);
+        }
+    }
+
+    let started = Arc::new(tokio::sync::Notify::new());
+    let dropped = Arc::new(tokio::sync::Semaphore::new(0));
+    let handler_task = {
+        let started = Arc::clone(&started);
+        let dropped = Arc::clone(&dropped);
+        tokio::spawn(async move {
+            let _guard = ReleaseOnDrop(dropped);
+            started.notify_one();
+            std::future::pending::<()>().await;
+        })
+    };
+    tokio::time::timeout(Duration::from_secs(2), started.notified())
+        .await
+        .expect("signal handler test task should start");
+
+    let (mut config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
+    config.signal_source = SignalSource::Override(SignalController {
+        mode_rx: env.mode_tx.subscribe(),
+        lifecycle: env.lifecycle.clone(),
+        handler_task: Some(SignalHandlerTask::new(handler_task)),
+    });
+    let run_handle = tokio::spawn(run(config));
+    wait_discover_entered(&env, Duration::from_secs(2)).await;
+
+    shutdown(&env, run_handle).await;
+
+    let _permit = dropped
+        .try_acquire()
+        .expect("graceful shutdown should await signal handler task abort");
+}
+
 async fn assert_signal_handler_task_end_cancels_active_jobs(
     handler_task: tokio::task::JoinHandle<()>,
     trigger_handler_task_end: impl FnOnce(),

--- a/crates/runner/src/cmd/start/tests/main_loop.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop.rs
@@ -6,7 +6,7 @@ use super::support::{
     wait_discover_entered, wait_parking_state, wait_status_mode,
 };
 
-use super::super::signals::{SignalController, handle_resume_signal};
+use super::super::signals::{SignalController, SignalHandlerTask, handle_resume_signal};
 use crate::idle_pool::ParkingState;
 
 // -----------------------------------------------------------------------
@@ -598,7 +598,7 @@ async fn signal_handler_exit_cancels_active_jobs() {
     config.signal_source = SignalSource::Override(SignalController {
         mode_rx: env.mode_tx.subscribe(),
         lifecycle: env.lifecycle.clone(),
-        handler_task: Some(handler_task),
+        handler_task: Some(SignalHandlerTask::new(handler_task)),
     });
     let run_handle = tokio::spawn(run(config));
 

--- a/crates/runner/src/cmd/start/tests/main_loop.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop.rs
@@ -6,7 +6,7 @@ use super::support::{
     wait_discover_entered, wait_parking_state, wait_status_mode,
 };
 
-use super::super::signals::handle_resume_signal;
+use super::super::signals::{SignalController, handle_resume_signal};
 use crate::idle_pool::ParkingState;
 
 // -----------------------------------------------------------------------
@@ -573,6 +573,48 @@ async fn hard_shutdown_cancels_active_jobs() {
     }
 
     // The cancelled job reports the synthetic "cancelled by user" error.
+    let comps = env.handle.completions.lock().unwrap();
+    let c = comps
+        .iter()
+        .find(|c| c.run_id == run_id)
+        .expect("cancelled job should still report completion");
+    assert_eq!(c.error.as_deref(), Some("cancelled by user"));
+}
+
+#[tokio::test]
+async fn signal_handler_exit_cancels_active_jobs() {
+    let gate = Arc::new(tokio::sync::Notify::new());
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::with_wait_exit_gate(
+        gate,
+    ));
+    let (mut config, env) = mock_run_config_with_overrides(test_profiles(), 8, 32768, 4, overrides);
+    let handler_exit = Arc::new(tokio::sync::Notify::new());
+    let handler_task = {
+        let handler_exit = Arc::clone(&handler_exit);
+        tokio::spawn(async move {
+            handler_exit.notified().await;
+        })
+    };
+    config.signal_source = SignalSource::Override(SignalController {
+        mode_rx: env.mode_tx.subscribe(),
+        lifecycle: env.lifecycle.clone(),
+        handler_task: Some(handler_task),
+    });
+    let run_handle = tokio::spawn(run(config));
+
+    let run_id = RunId::new_v4();
+    push_job(&env, run_id, "vm0/default", Some(minimal_context(run_id)));
+    let _token = wait_cancel_token(&env.cancel_tokens, run_id, Duration::from_secs(5)).await;
+
+    handler_exit.notify_one();
+
+    match tokio::time::timeout(Duration::from_secs(3), run_handle).await {
+        Ok(Ok(Ok(()))) => {}
+        Ok(Ok(Err(e))) => panic!("run() returned error: {e}"),
+        Ok(Err(e)) => panic!("task panicked: {e}"),
+        Err(_) => panic!("signal handler exit should cancel active jobs and stop promptly"),
+    }
+
     let comps = env.handle.completions.lock().unwrap();
     let c = comps
         .iter()

--- a/crates/runner/src/cmd/start/tests/main_loop.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop.rs
@@ -583,11 +583,6 @@ async fn hard_shutdown_cancels_active_jobs() {
 
 #[tokio::test]
 async fn signal_handler_exit_cancels_active_jobs() {
-    let gate = Arc::new(tokio::sync::Notify::new());
-    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::with_wait_exit_gate(
-        gate,
-    ));
-    let (mut config, env) = mock_run_config_with_overrides(test_profiles(), 8, 32768, 4, overrides);
     let handler_exit = Arc::new(tokio::sync::Notify::new());
     let handler_task = {
         let handler_exit = Arc::clone(&handler_exit);
@@ -595,6 +590,39 @@ async fn signal_handler_exit_cancels_active_jobs() {
             handler_exit.notified().await;
         })
     };
+
+    assert_signal_handler_task_end_cancels_active_jobs(handler_task, || {
+        handler_exit.notify_one();
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn signal_handler_panic_cancels_active_jobs() {
+    let handler_panic = Arc::new(tokio::sync::Notify::new());
+    let handler_task = {
+        let handler_panic = Arc::clone(&handler_panic);
+        tokio::spawn(async move {
+            handler_panic.notified().await;
+            panic!("signal handler task panic");
+        })
+    };
+
+    assert_signal_handler_task_end_cancels_active_jobs(handler_task, || {
+        handler_panic.notify_one();
+    })
+    .await;
+}
+
+async fn assert_signal_handler_task_end_cancels_active_jobs(
+    handler_task: tokio::task::JoinHandle<()>,
+    trigger_handler_task_end: impl FnOnce(),
+) {
+    let gate = Arc::new(tokio::sync::Notify::new());
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::with_wait_exit_gate(
+        gate,
+    ));
+    let (mut config, env) = mock_run_config_with_overrides(test_profiles(), 8, 32768, 4, overrides);
     config.signal_source = SignalSource::Override(SignalController {
         mode_rx: env.mode_tx.subscribe(),
         lifecycle: env.lifecycle.clone(),
@@ -606,7 +634,7 @@ async fn signal_handler_exit_cancels_active_jobs() {
     push_job(&env, run_id, "vm0/default", Some(minimal_context(run_id)));
     let _token = wait_cancel_token(&env.cancel_tokens, run_id, Duration::from_secs(5)).await;
 
-    handler_exit.notify_one();
+    trigger_handler_task_end();
 
     match tokio::time::timeout(Duration::from_secs(3), run_handle).await {
         Ok(Ok(Ok(()))) => {}

--- a/crates/runner/src/cmd/start/tests/support/env.rs
+++ b/crates/runner/src/cmd/start/tests/support/env.rs
@@ -220,7 +220,7 @@ fn build_mock_run_config_with_runtime(
         signal_source: SignalSource::Override(SignalController {
             mode_rx,
             lifecycle: lifecycle.clone(),
-            handler_abort: None,
+            handler_task: None,
         }),
         outer_job_panic: None,
         test_observer: start_observer.clone(),


### PR DESCRIPTION
## Summary

- Store the signal handler `JoinHandle` instead of only keeping an `AbortHandle`.
- Monitor unexpected signal-handler task completion in the runner reactor and hard-stop the runner if signal handling dies.
- Abort and await the signal handler during teardown so the task is actually reaped.
- Update the stale lifetime docs and test override wiring.

Fixes #13384

## Tests

- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `cargo test --manifest-path crates/Cargo.toml -p runner signal`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features`
- `cargo test --manifest-path crates/Cargo.toml -p runner cmd::start`
- pre-commit: `cargo-fmt`, `cargo-clippy`, `cargo-doc`
