### PR TITLE
fix: improve presentation generation and previews

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-presentation-io-generate.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-presentation-io-generate.test.ts
@@ -803,6 +803,8 @@ describe("POST /api/zero/presentation-io/generate", () => {
     expect(html).toContain("<img");
     expect(html).toContain(imageUrl);
     expect(html).toContain("Presentation controls");
+    expect(html).toContain("overflow-x: hidden;");
+    expect(html).toContain("overflow-y: auto;");
     expect(Number(body.size)).toBe(putBody.byteLength);
 
     const uploadRows = await store
@@ -835,6 +837,13 @@ describe("POST /api/zero/presentation-io/generate", () => {
       responseId: "resp_presentation_test",
       s3Key: `uploads/${fixture.userId}/${fileId}/${filename}`,
     });
+    const runUploadRows = await store
+      .set(writeDb$)
+      .select()
+      .from(runUploadedFiles)
+      .where(eq(runUploadedFiles.runId, runId));
+    expect(runUploadRows).toHaveLength(1);
+    expect(runUploadRows[0]?.externalId).toBe(fileId);
 
     const usageRows = await store
       .set(writeDb$)
@@ -914,5 +923,84 @@ describe("POST /api/zero/presentation-io/generate", () => {
       return total + (row.creditsCharged ?? 0);
     }, 0);
     expect(totalImageCredits).toBe(imageCreditsCharged);
+  });
+
+  it("returns the presentation when visual image generation fails", async () => {
+    const fixture = await track(seedPresentationFixture({ withPricing: true }));
+    const { pricing } = await ensurePresentationPricing();
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    const usage: PresentationUsage = {
+      inputTokens: 1200,
+      outputTokens: 420,
+      totalTokens: 1620,
+    };
+    const textCreditsCharged = expectedCredits(usage, pricing);
+    let calledImageGeneration = false;
+    server.use(
+      http.post(OPENAI_PRESENTATION_GENERATION_URL, () => {
+        return HttpResponse.json({
+          id: "resp_presentation_no_visuals",
+          output: [
+            {
+              type: "message",
+              content: [
+                {
+                  type: "output_text",
+                  text: presentationDeckJson(),
+                },
+              ],
+            },
+          ],
+          usage: {
+            input_tokens: usage.inputTokens,
+            output_tokens: usage.outputTokens,
+            total_tokens: usage.totalTokens,
+          },
+        });
+      }),
+      http.post(OPENAI_IMAGE_GENERATION_URL, () => {
+        calledImageGeneration = true;
+        return new HttpResponse("image generation timed out", { status: 504 });
+      }),
+    );
+
+    const app = createApp({ signal: context.signal });
+    const response = await app.request("/api/zero/presentation-io/generate", {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({
+        prompt: "API migration plan",
+        style: "swiss",
+        slideCount: 4,
+        imageCount: 1,
+        theme: "ikb",
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    const body: unknown = await response.json();
+    expect(body).toMatchObject({
+      imageCount: 0,
+      imageUrls: [],
+      creditsCharged: textCreditsCharged,
+      textCreditsCharged,
+      imageCreditsCharged: 0,
+      responseId: "resp_presentation_no_visuals",
+    });
+    expect(calledImageGeneration).toBeTruthy();
+
+    const putInputs = context.mocks.s3.send.mock.calls.map((call) => {
+      return commandInput(call[0]);
+    });
+    expect(
+      putInputs.some((input) => {
+        return input.ContentType === "image/webp";
+      }),
+    ).toBeFalsy();
+    expect(
+      putInputs.some((input) => {
+        return input.ContentType === "text/html";
+      }),
+    ).toBeTruthy();
   });
 });

--- a/turbo/apps/api/src/signals/routes/zero-presentation-io-generate.ts
+++ b/turbo/apps/api/src/signals/routes/zero-presentation-io-generate.ts
@@ -5,6 +5,7 @@ import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
 import { bodyResultOf } from "../context/request";
 import { logger } from "../../lib/log";
+import { now } from "../../lib/time";
 import type { RouteEntry } from "../route";
 import { env } from "../../lib/env";
 import { imagePricing$ } from "../services/zero-image-io-generate.service";
@@ -28,7 +29,7 @@ const presentationBody$ = bodyResultOf(zeroPresentationIoGenerateContract.post);
 
 const postPresentationInner$ = command(
   async ({ get, set }, signal: AbortSignal) => {
-    const deadlineAtMs = Date.now() + PRESENTATION_IO_SYNC_RESPONSE_BUDGET_MS;
+    const deadlineAtMs = now() + PRESENTATION_IO_SYNC_RESPONSE_BUDGET_MS;
     const auth = get(organizationAuthContext$);
     const bodyResult = await get(presentationBody$);
     signal.throwIfAborted();

--- a/turbo/apps/api/src/signals/routes/zero-presentation-io-generate.ts
+++ b/turbo/apps/api/src/signals/routes/zero-presentation-io-generate.ts
@@ -13,6 +13,7 @@ import {
   createOpenAiPresentationRequest,
   generatePresentationVisuals$,
   OPENAI_PRESENTATION_GENERATION_URL,
+  PRESENTATION_IO_SYNC_RESPONSE_BUDGET_MS,
   parsePresentationGenerationResult,
   parsePresentationOptions,
   presentationInsufficientCredits,
@@ -27,6 +28,7 @@ const presentationBody$ = bodyResultOf(zeroPresentationIoGenerateContract.post);
 
 const postPresentationInner$ = command(
   async ({ get, set }, signal: AbortSignal) => {
+    const deadlineAtMs = Date.now() + PRESENTATION_IO_SYNC_RESPONSE_BUDGET_MS;
     const auth = get(organizationAuthContext$);
     const bodyResult = await get(presentationBody$);
     signal.throwIfAborted();
@@ -115,6 +117,7 @@ const postPresentationInner$ = command(
               imagePricing,
               generation,
               options,
+              deadlineAtMs,
             },
             signal,
           )

--- a/turbo/apps/api/src/signals/services/zero-image-io-generate.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-image-io-generate.service.ts
@@ -606,6 +606,7 @@ export const recordGeneratedImage$ = command(
       readonly runId: string | undefined;
       readonly pricing: ImagePricing;
       readonly generation: ParsedImageGeneration;
+      readonly recordArtifact?: boolean;
     },
     signal: AbortSignal,
   ): Promise<RecordedImage> => {
@@ -627,34 +628,36 @@ export const recordGeneratedImage$ = command(
     signal.throwIfAborted();
 
     const url = buildFileUrl(params.userId, fileId, filename);
-    await set(
-      recordWebUploadedFile$,
-      {
-        runId: params.runId,
-        externalId: fileId,
-        userId: params.userId,
-        orgId: params.orgId,
-        filename,
-        contentType,
-        sizeBytes: params.generation.imageBytes.byteLength,
-        url,
-        s3Key,
-        metadata: {
-          generatedBy: "zero-official-image",
-          model: IMAGE_IO_MODEL,
-          imageSize: params.generation.imageSize,
-          quality: params.generation.quality,
-          background: params.generation.background,
-          outputFormat: params.generation.outputFormat,
-          ...(params.generation.outputCompression !== undefined
-            ? { outputCompression: params.generation.outputCompression }
-            : {}),
-          moderation: params.generation.moderation,
+    if (params.recordArtifact !== false) {
+      await set(
+        recordWebUploadedFile$,
+        {
+          runId: params.runId,
+          externalId: fileId,
+          userId: params.userId,
+          orgId: params.orgId,
+          filename,
+          contentType,
+          sizeBytes: params.generation.imageBytes.byteLength,
+          url,
+          s3Key,
+          metadata: {
+            generatedBy: "zero-official-image",
+            model: IMAGE_IO_MODEL,
+            imageSize: params.generation.imageSize,
+            quality: params.generation.quality,
+            background: params.generation.background,
+            outputFormat: params.generation.outputFormat,
+            ...(params.generation.outputCompression !== undefined
+              ? { outputCompression: params.generation.outputCompression }
+              : {}),
+            moderation: params.generation.moderation,
+          },
         },
-      },
-      signal,
-    );
-    signal.throwIfAborted();
+        signal,
+      );
+      signal.throwIfAborted();
+    }
 
     const usageRows = [
       {

--- a/turbo/apps/api/src/signals/services/zero-presentation-io-generate.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-presentation-io-generate.service.ts
@@ -8,6 +8,7 @@ import { and, eq, inArray, sql } from "drizzle-orm";
 
 import { buildFileUrl } from "../../lib/file-url";
 import { env } from "../../lib/env";
+import { logger } from "../../lib/log";
 import { db$, writeDb$ } from "../external/db";
 import { putS3Object } from "../external/s3";
 import {
@@ -31,6 +32,11 @@ const PRESENTATION_IO_MAX_SLIDES = 20;
 const PRESENTATION_IO_DEFAULT_IMAGE_COUNT = 2;
 const PRESENTATION_IO_MAX_IMAGES = 8;
 const PRESENTATION_CONTENT_TYPE = "text/html";
+const PRESENTATION_VISUAL_IMAGE_TIMEOUT_MS = 120_000;
+export const PRESENTATION_IO_SYNC_RESPONSE_BUDGET_MS = 90_000;
+const PRESENTATION_IO_RECORD_PRESENTATION_RESERVE_MS = 10_000;
+
+const L = logger("ZeroPresentationIoGenerate");
 
 const USAGE_KIND = "model";
 const USAGE_PROVIDER = PRESENTATION_IO_MODEL;
@@ -148,6 +154,18 @@ interface PresentationVisual {
   readonly imageId: string;
   readonly filename: string;
   readonly creditsCharged: number;
+}
+
+type ParsedPresentationVisualImageGeneration = Exclude<
+  ReturnType<typeof parseImageGenerationResult>,
+  { readonly status: number }
+>;
+
+interface GeneratedPresentationVisualImage {
+  readonly slideIndex: number;
+  readonly slide: SlideSpec;
+  readonly prompt: string;
+  readonly generation: ParsedPresentationVisualImageGeneration;
 }
 
 interface RecordedPresentation {
@@ -947,7 +965,8 @@ const DECK_BASE_STYLE = `
     * { box-sizing: border-box; }
     body {
       margin: 0;
-      overflow: hidden;
+      overflow-x: hidden;
+      overflow-y: auto;
       background: var(--bg);
       color: var(--text);
       font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
@@ -966,7 +985,8 @@ const DECK_BASE_STYLE = `
     .viewport {
       width: 100vw;
       height: 100vh;
-      overflow: hidden;
+      overflow-x: hidden;
+      overflow-y: auto;
     }
     .deck {
       display: flex;
@@ -1392,6 +1412,91 @@ function createVisualImageOptions(prompt: string) {
   };
 }
 
+function presentationVisualImageTimeoutMs(deadlineAtMs: number | undefined) {
+  if (deadlineAtMs === undefined) {
+    return PRESENTATION_VISUAL_IMAGE_TIMEOUT_MS;
+  }
+  const remainingMs =
+    deadlineAtMs - Date.now() - PRESENTATION_IO_RECORD_PRESENTATION_RESERVE_MS;
+  return Math.min(
+    PRESENTATION_VISUAL_IMAGE_TIMEOUT_MS,
+    Math.max(0, remainingMs),
+  );
+}
+
+async function generatePresentationVisualImage(
+  params: {
+    readonly slideIndex: number;
+    readonly slide: SlideSpec;
+    readonly prompt: string;
+    readonly timeoutMs: number;
+  },
+  signal: AbortSignal,
+): Promise<GeneratedPresentationVisualImage | null> {
+  const imageOptions = createVisualImageOptions(params.prompt);
+  const startedAt = Date.now();
+  try {
+    const response = await fetch(OPENAI_IMAGE_GENERATION_URL, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${env("OPENAI_API_KEY")}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model: IMAGE_IO_MODEL,
+        prompt: imageOptions.prompt,
+        n: 1,
+        size: imageOptions.size,
+        quality: imageOptions.quality,
+        background: imageOptions.background,
+        output_format: imageOptions.outputFormat,
+        moderation: imageOptions.moderation,
+      }),
+      signal: AbortSignal.any([signal, AbortSignal.timeout(params.timeoutMs)]),
+    });
+    signal.throwIfAborted();
+    if (!response.ok) {
+      L.warn("Presentation visual image request failed", {
+        slideIndex: params.slideIndex,
+        status: response.status,
+        durationMs: Date.now() - startedAt,
+      });
+      return null;
+    }
+
+    const responseBody: unknown = await response.json();
+    signal.throwIfAborted();
+    const generation = parseImageGenerationResult(responseBody, imageOptions);
+    if ("status" in generation) {
+      L.warn("Presentation visual image response could not be used", {
+        slideIndex: params.slideIndex,
+        code: generation.body.error.code,
+        durationMs: Date.now() - startedAt,
+      });
+      return null;
+    }
+
+    return {
+      slideIndex: params.slideIndex,
+      slide: params.slide,
+      prompt: params.prompt,
+      generation,
+    };
+  } catch (error) {
+    signal.throwIfAborted();
+    L.warn("Presentation visual image request skipped", {
+      slideIndex: params.slideIndex,
+      error:
+        error instanceof Error
+          ? { name: error.name, message: error.message }
+          : String(error),
+      durationMs: Date.now() - startedAt,
+      timeoutMs: params.timeoutMs,
+    });
+    return null;
+  }
+}
+
 export const generatePresentationVisuals$ = command(
   async (
     { set },
@@ -1402,6 +1507,7 @@ export const generatePresentationVisuals$ = command(
       readonly imagePricing: ImagePricing;
       readonly generation: ParsedPresentationGeneration;
       readonly options: PresentationOptions;
+      readonly deadlineAtMs?: number;
     },
     signal: AbortSignal,
   ): Promise<readonly PresentationVisual[] | ErrorResponse> => {
@@ -1413,78 +1519,70 @@ export const generatePresentationVisuals$ = command(
       return [];
     }
 
+    const imageTimeoutMs = presentationVisualImageTimeoutMs(
+      params.deadlineAtMs,
+    );
+    if (imageTimeoutMs <= 0) {
+      L.warn("Skipping presentation visual images to avoid request timeout", {
+        candidateCount: candidates.length,
+        deadlineAtMs: params.deadlineAtMs,
+      });
+      return [];
+    }
+
+    const generatedImages = await Promise.all(
+      candidates.map(([slideIndex, slide]) => {
+        return generatePresentationVisualImage(
+          {
+            slideIndex,
+            slide,
+            timeoutMs: imageTimeoutMs,
+            prompt: visualPromptForSlide({
+              deck: params.generation.deck,
+              slide,
+              options: params.options,
+            }),
+          },
+          signal,
+        );
+      }),
+    );
+    signal.throwIfAborted();
+
     const visuals: PresentationVisual[] = [];
-    let failedAttempts = 0;
-    for (const [slideIndex, slide] of candidates) {
-      const prompt = visualPromptForSlide({
-        deck: params.generation.deck,
-        slide,
-        options: params.options,
-      });
-      const imageOptions = createVisualImageOptions(prompt);
-      const response = await fetch(OPENAI_IMAGE_GENERATION_URL, {
-        method: "POST",
-        headers: {
-          Authorization: `Bearer ${env("OPENAI_API_KEY")}`,
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          model: IMAGE_IO_MODEL,
-          prompt: imageOptions.prompt,
-          n: 1,
-          size: imageOptions.size,
-          quality: imageOptions.quality,
-          background: imageOptions.background,
-          output_format: imageOptions.outputFormat,
-          moderation: imageOptions.moderation,
-        }),
-        signal,
-      });
-      signal.throwIfAborted();
-      if (!response.ok) {
-        failedAttempts += 1;
+    for (const image of generatedImages) {
+      if (!image) {
         continue;
       }
 
-      const responseBody: unknown = await response.json();
-      signal.throwIfAborted();
-      const imageGeneration = parseImageGenerationResult(
-        responseBody,
-        imageOptions,
-      );
-      if ("status" in imageGeneration) {
-        failedAttempts += 1;
+      let recordedImage;
+      try {
+        recordedImage = await set(
+          recordGeneratedImage$,
+          {
+            orgId: params.orgId,
+            userId: params.userId,
+            runId: params.runId,
+            pricing: params.imagePricing,
+            generation: image.generation,
+            recordArtifact: false,
+          },
+          signal,
+        );
+      } catch {
+        signal.throwIfAborted();
         continue;
       }
-
-      const recordedImage = await set(
-        recordGeneratedImage$,
-        {
-          orgId: params.orgId,
-          userId: params.userId,
-          runId: params.runId,
-          pricing: params.imagePricing,
-          generation: imageGeneration,
-        },
-        signal,
-      );
       signal.throwIfAborted();
       visuals.push({
-        slideIndex,
+        slideIndex: image.slideIndex,
         url: recordedImage.url,
-        alt: visualAltText(slide),
-        prompt,
+        alt: visualAltText(image.slide),
+        prompt: image.prompt,
         imageId: recordedImage.id,
         filename: recordedImage.filename,
         creditsCharged: recordedImage.creditsCharged,
       });
-    }
-
-    if (visuals.length === 0 && failedAttempts > 0) {
-      return badGateway(
-        "Presentation image generation failed",
-        "IMAGE_GENERATION_FAILED",
-      );
     }
 
     return visuals;

--- a/turbo/apps/api/src/signals/services/zero-presentation-io-generate.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-presentation-io-generate.service.ts
@@ -9,6 +9,7 @@ import { and, eq, inArray, sql } from "drizzle-orm";
 import { buildFileUrl } from "../../lib/file-url";
 import { env } from "../../lib/env";
 import { logger } from "../../lib/log";
+import { now } from "../../lib/time";
 import { db$, writeDb$ } from "../external/db";
 import { putS3Object } from "../external/s3";
 import {
@@ -20,7 +21,7 @@ import {
 } from "./zero-image-io-generate.service";
 import { recordWebUploadedFile$ } from "./run-uploaded-files.service";
 import { processOrgUsageEvents$ } from "./zero-credit-usage.service";
-import { safeJsonParse } from "../utils";
+import { safeAsync, safeJsonParse } from "../utils";
 
 export const OPENAI_PRESENTATION_GENERATION_URL =
   "https://api.openai.com/v1/responses";
@@ -1417,11 +1418,17 @@ function presentationVisualImageTimeoutMs(deadlineAtMs: number | undefined) {
     return PRESENTATION_VISUAL_IMAGE_TIMEOUT_MS;
   }
   const remainingMs =
-    deadlineAtMs - Date.now() - PRESENTATION_IO_RECORD_PRESENTATION_RESERVE_MS;
+    deadlineAtMs - now() - PRESENTATION_IO_RECORD_PRESENTATION_RESERVE_MS;
   return Math.min(
     PRESENTATION_VISUAL_IMAGE_TIMEOUT_MS,
     Math.max(0, remainingMs),
   );
+}
+
+function loggableError(error: unknown): unknown {
+  return error instanceof Error
+    ? { name: error.name, message: error.message }
+    : String(error);
 }
 
 async function generatePresentationVisualImage(
@@ -1434,8 +1441,8 @@ async function generatePresentationVisualImage(
   signal: AbortSignal,
 ): Promise<GeneratedPresentationVisualImage | null> {
   const imageOptions = createVisualImageOptions(params.prompt);
-  const startedAt = Date.now();
-  try {
+  const startedAt = now();
+  const result = await safeAsync(async () => {
     const response = await fetch(OPENAI_IMAGE_GENERATION_URL, {
       method: "POST",
       headers: {
@@ -1459,7 +1466,7 @@ async function generatePresentationVisualImage(
       L.warn("Presentation visual image request failed", {
         slideIndex: params.slideIndex,
         status: response.status,
-        durationMs: Date.now() - startedAt,
+        durationMs: now() - startedAt,
       });
       return null;
     }
@@ -1471,7 +1478,7 @@ async function generatePresentationVisualImage(
       L.warn("Presentation visual image response could not be used", {
         slideIndex: params.slideIndex,
         code: generation.body.error.code,
-        durationMs: Date.now() - startedAt,
+        durationMs: now() - startedAt,
       });
       return null;
     }
@@ -1482,19 +1489,20 @@ async function generatePresentationVisualImage(
       prompt: params.prompt,
       generation,
     };
-  } catch (error) {
+  });
+
+  if ("error" in result) {
     signal.throwIfAborted();
     L.warn("Presentation visual image request skipped", {
       slideIndex: params.slideIndex,
-      error:
-        error instanceof Error
-          ? { name: error.name, message: error.message }
-          : String(error),
-      durationMs: Date.now() - startedAt,
+      error: loggableError(result.error),
+      durationMs: now() - startedAt,
       timeoutMs: params.timeoutMs,
     });
     return null;
   }
+
+  return result.ok;
 }
 
 export const generatePresentationVisuals$ = command(
@@ -1555,9 +1563,8 @@ export const generatePresentationVisuals$ = command(
         continue;
       }
 
-      let recordedImage;
-      try {
-        recordedImage = await set(
+      const recordedImageResult = await safeAsync(() => {
+        return set(
           recordGeneratedImage$,
           {
             orgId: params.orgId,
@@ -1569,11 +1576,17 @@ export const generatePresentationVisuals$ = command(
           },
           signal,
         );
-      } catch {
+      });
+      signal.throwIfAborted();
+      if ("error" in recordedImageResult) {
+        L.warn("Presentation visual image record skipped", {
+          slideIndex: image.slideIndex,
+          error: loggableError(recordedImageResult.error),
+        });
         signal.throwIfAborted();
         continue;
       }
-      signal.throwIfAborted();
+      const recordedImage = recordedImageResult.ok;
       visuals.push({
         slideIndex: image.slideIndex,
         url: recordedImage.url,

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-interaction.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-interaction.test.tsx
@@ -193,6 +193,9 @@ describe("zero chat thread page - document preview opens global lightbox", () =>
   it("clicking html platform file url preview opens the shared attachment lightbox", async () => {
     const htmlUrl =
       "https://www.vm0.ai/f/user_123/3a474c61-ffe4-4e56-b9e7-0185b3dba9f7/report.html";
+    const writeTextSpy = vi
+      .spyOn(navigator.clipboard, "writeText")
+      .mockResolvedValue(undefined);
     server.use(
       http.get(htmlUrl, () => {
         return HttpResponse.html("<html><body>report preview</body></html>");
@@ -218,8 +221,31 @@ describe("zero chat thread page - document preview opens global lightbox", () =>
 
     await waitFor(() => {
       expect(screen.getByTestId("attachment-lightbox")).toBeInTheDocument();
-      expect(screen.getByTitle("report.html preview")).toBeInTheDocument();
+      expect(previewButton).toBeDisabled();
+      const iframe = screen.getByTitle("report.html preview");
+      expect(iframe).toHaveAttribute("sandbox", "allow-scripts");
+      expect(iframe).toHaveAttribute("scrolling", "yes");
+      expect(iframe).toHaveClass(
+        "relative",
+        "z-10",
+        "h-[min(78vh,900px)]",
+        "max-w-full",
+        "overflow-x-hidden",
+        "overscroll-contain",
+      );
+      expect(iframe.parentElement).toHaveClass(
+        "max-w-full",
+        "overflow-hidden",
+        "overscroll-contain",
+      );
+      expect(iframe.parentElement).not.toHaveClass(
+        "h-[min(78vh,900px)]",
+        "overflow-y-auto",
+      );
     });
+
+    await userEvent.click(screen.getByLabelText("Copy link"));
+    expect(writeTextSpy).toHaveBeenCalledWith(htmlUrl);
   });
 });
 

--- a/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
@@ -1,4 +1,4 @@
-import { useEffect, type MouseEvent, type ReactNode } from "react";
+import type { MouseEvent, ReactNode } from "react";
 import { useGet, useSet, useLoadable } from "ccstate-react";
 import { createPortal } from "react-dom";
 import {
@@ -287,27 +287,40 @@ async function copyAttachmentLinkToClipboard(url: string): Promise<void> {
   toast.error("Failed to copy link");
 }
 
-function useLightboxBodyScrollLock(): void {
-  useEffect(() => {
-    const bodyOverflow = document.body.style.overflow;
-    const bodyOverscrollBehavior = document.body.style.overscrollBehavior;
-    const rootOverflow = document.documentElement.style.overflow;
-    const rootOverscrollBehavior =
-      document.documentElement.style.overscrollBehavior;
+function LightboxBodyScrollLock() {
+  let restore: (() => void) | null = null;
 
-    document.body.style.overflow = "hidden";
-    document.body.style.overscrollBehavior = "contain";
-    document.documentElement.style.overflow = "hidden";
-    document.documentElement.style.overscrollBehavior = "contain";
+  return (
+    <span
+      ref={(node) => {
+        if (node === null) {
+          restore?.();
+          restore = null;
+          return;
+        }
 
-    return () => {
-      document.body.style.overflow = bodyOverflow;
-      document.body.style.overscrollBehavior = bodyOverscrollBehavior;
-      document.documentElement.style.overflow = rootOverflow;
-      document.documentElement.style.overscrollBehavior =
-        rootOverscrollBehavior;
-    };
-  }, []);
+        const bodyOverflow = document.body.style.overflow;
+        const bodyOverscrollBehavior = document.body.style.overscrollBehavior;
+        const rootOverflow = document.documentElement.style.overflow;
+        const rootOverscrollBehavior =
+          document.documentElement.style.overscrollBehavior;
+
+        document.body.style.overflow = "hidden";
+        document.body.style.overscrollBehavior = "contain";
+        document.documentElement.style.overflow = "hidden";
+        document.documentElement.style.overscrollBehavior = "contain";
+
+        restore = () => {
+          document.body.style.overflow = bodyOverflow;
+          document.body.style.overscrollBehavior = bodyOverscrollBehavior;
+          document.documentElement.style.overflow = rootOverflow;
+          document.documentElement.style.overscrollBehavior =
+            rootOverscrollBehavior;
+        };
+      }}
+      hidden
+    />
+  );
 }
 
 function isImageLightboxZoomAtReset(zoom: number): boolean {
@@ -506,6 +519,7 @@ function ImageLightbox({ url }: { url: string }) {
       aria-modal="true"
       data-testid="attachment-lightbox"
     >
+      <LightboxBodyScrollLock />
       <ImageLightboxContent
         closeLightbox={closeLightbox}
         pageSignal={pageSignal}
@@ -521,7 +535,6 @@ export function AttachmentLightbox() {
   const dialogRef = useSet(lightboxDialogRef$);
   const closeLightbox = useSet(closeLightbox$);
   const pageSignal = useGet(pageSignal$);
-  useLightboxBodyScrollLock();
 
   if (!preview) {
     return null;
@@ -548,6 +561,7 @@ export function AttachmentLightbox() {
       aria-modal="true"
       data-testid="attachment-lightbox"
     >
+      <LightboxBodyScrollLock />
       <div className="absolute top-4 right-4 z-20 flex items-center gap-2">
         <button
           type="button"

--- a/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
@@ -1,9 +1,10 @@
-import type { MouseEvent, ReactNode } from "react";
+import { useEffect, type MouseEvent, type ReactNode } from "react";
 import { useGet, useSet, useLoadable } from "ccstate-react";
 import { createPortal } from "react-dom";
 import {
   IconDownload,
   IconFileMusic,
+  IconLink,
   IconPhoto,
   IconVideo,
   IconLoader2,
@@ -12,10 +13,12 @@ import {
   IconZoomReset,
   IconX,
 } from "@tabler/icons-react";
+import { toast } from "@vm0/ui/components/ui/sonner";
 import type { ZeroChatAttachment } from "../../signals/chat-page/chat-message.ts";
 import { logger } from "../../signals/log.ts";
 import { detach, jsonParseOr, Reason } from "../../signals/utils.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
+import { writeToClipboard } from "../../signals/zero-page/clipboard.ts";
 import {
   IMAGE_LIGHTBOX_MAX_ZOOM,
   IMAGE_LIGHTBOX_MIN_ZOOM,
@@ -275,12 +278,45 @@ export async function downloadAttachmentUrl(
   }
 }
 
+async function copyAttachmentLinkToClipboard(url: string): Promise<void> {
+  const copied = await writeToClipboard(url);
+  if (copied) {
+    toast.success("Link copied");
+    return;
+  }
+  toast.error("Failed to copy link");
+}
+
+function useLightboxBodyScrollLock(): void {
+  useEffect(() => {
+    const bodyOverflow = document.body.style.overflow;
+    const bodyOverscrollBehavior = document.body.style.overscrollBehavior;
+    const rootOverflow = document.documentElement.style.overflow;
+    const rootOverscrollBehavior =
+      document.documentElement.style.overscrollBehavior;
+
+    document.body.style.overflow = "hidden";
+    document.body.style.overscrollBehavior = "contain";
+    document.documentElement.style.overflow = "hidden";
+    document.documentElement.style.overscrollBehavior = "contain";
+
+    return () => {
+      document.body.style.overflow = bodyOverflow;
+      document.body.style.overscrollBehavior = bodyOverscrollBehavior;
+      document.documentElement.style.overflow = rootOverflow;
+      document.documentElement.style.overscrollBehavior =
+        rootOverscrollBehavior;
+    };
+  }, []);
+}
+
 function isImageLightboxZoomAtReset(zoom: number): boolean {
   return Math.abs(zoom - 1) < 0.001;
 }
 
 function ImageLightboxControls({
   closeLightbox,
+  copyLink,
   download,
   resetZoom,
   zoom,
@@ -288,6 +324,7 @@ function ImageLightboxControls({
   zoomOut,
 }: {
   closeLightbox: () => void;
+  copyLink: () => void;
   download: () => void;
   resetZoom: () => void;
   zoom: number;
@@ -331,6 +368,14 @@ function ImageLightboxControls({
           <IconZoomReset size={18} stroke={2} />
         </button>
       </div>
+      <button
+        type="button"
+        onClick={copyLink}
+        className="p-2 rounded-full bg-black/50 text-white hover:bg-black/70 transition-colors cursor-pointer"
+        aria-label="Copy link"
+      >
+        <IconLink size={20} stroke={2} />
+      </button>
       <button
         type="button"
         onClick={download}
@@ -380,6 +425,13 @@ function ImageLightboxContent({
       "attachment download",
     );
   };
+  const copyLink = () => {
+    detach(
+      copyAttachmentLinkToClipboard(url),
+      Reason.DomCallback,
+      "attachment copy link",
+    );
+  };
 
   const { imageStatus, zoom } = imageState;
 
@@ -388,6 +440,7 @@ function ImageLightboxContent({
       <ImageLightboxKeyboardShortcuts />
       <ImageLightboxControls
         closeLightbox={closeLightbox}
+        copyLink={copyLink}
         download={download}
         resetZoom={resetZoom}
         zoom={zoom}
@@ -468,6 +521,7 @@ export function AttachmentLightbox() {
   const dialogRef = useSet(lightboxDialogRef$);
   const closeLightbox = useSet(closeLightbox$);
   const pageSignal = useGet(pageSignal$);
+  useLightboxBodyScrollLock();
 
   if (!preview) {
     return null;
@@ -494,7 +548,21 @@ export function AttachmentLightbox() {
       aria-modal="true"
       data-testid="attachment-lightbox"
     >
-      <div className="absolute top-4 right-4 flex items-center gap-2">
+      <div className="absolute top-4 right-4 z-20 flex items-center gap-2">
+        <button
+          type="button"
+          onClick={() => {
+            detach(
+              copyAttachmentLinkToClipboard(preview.url),
+              Reason.DomCallback,
+              "attachment copy link",
+            );
+          }}
+          className="p-2 rounded-full bg-black/50 text-white hover:bg-black/70 transition-colors cursor-pointer"
+          aria-label="Copy link"
+        >
+          <IconLink size={20} stroke={2} />
+        </button>
         <button
           type="button"
           onClick={() => {
@@ -520,7 +588,7 @@ export function AttachmentLightbox() {
           <IconX size={20} stroke={2} />
         </button>
       </div>
-      <div className="w-[min(92vw,1100px)] rounded-2xl bg-background shadow-2xl overflow-hidden animate-in zoom-in-95 duration-200">
+      <div className="relative z-10 w-[min(92vw,1100px)] min-w-0 rounded-2xl bg-background shadow-2xl overflow-hidden animate-in zoom-in-95 duration-200">
         <div className="flex items-center gap-3 border-b border-foreground/10 px-4 py-3">
           <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-muted">
             <FilePreviewIcon
@@ -551,12 +619,15 @@ export function AttachmentLightbox() {
         ) : preview.kind === "csv" ? (
           <CsvLightboxBody url={preview.url} signal={pageSignal} />
         ) : (
-          <iframe
-            src={preview.url}
-            title={`${preview.filename} preview`}
-            sandbox={preview.kind === "html" ? "" : undefined}
-            className="h-[min(78vh,900px)] w-full bg-background"
-          />
+          <div className="max-w-full overflow-hidden overscroll-contain bg-background">
+            <iframe
+              src={preview.url}
+              title={`${preview.filename} preview`}
+              sandbox={preview.kind === "html" ? "allow-scripts" : undefined}
+              scrolling="yes"
+              className="relative z-10 block h-[min(78vh,900px)] w-full max-w-full overflow-x-hidden overscroll-contain bg-background"
+            />
+          </div>
         )}
       </div>
     </div>,

--- a/turbo/apps/platform/src/views/zero-page/zero-attachment-preview.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-attachment-preview.tsx
@@ -14,7 +14,10 @@ import {
   textPreviewCollapsedByKey$,
   toggleTextPreviewCollapsed$,
 } from "../../signals/view-component-state.ts";
-import { openDocumentLightbox$ } from "../../signals/zero-page/zero-attachment-chips.ts";
+import {
+  lightboxUrl$,
+  openDocumentLightbox$,
+} from "../../signals/zero-page/zero-attachment-chips.ts";
 import {
   classifyChatAttachment,
   EMPTY_TEXT$,
@@ -181,6 +184,7 @@ function DocumentThumbnailPreview({
   kind: "markdown" | "csv" | "pdf" | "html";
 }) {
   const openDocumentLightbox = useSet(openDocumentLightbox$);
+  const lightboxOpen = useGet(lightboxUrl$) !== null;
   const accentClass =
     kind === "markdown"
       ? "from-emerald-500/15 via-lime-500/10 to-background"
@@ -194,10 +198,12 @@ function DocumentThumbnailPreview({
     <button
       type="button"
       data-testid={`attachment-preview-${kind}`}
-      onClick={() => {
+      onClick={(event) => {
+        event.currentTarget.blur();
         openDocumentLightbox({ kind, url, filename });
       }}
-      className="group/doc-preview inline-flex w-fit self-start align-top text-left"
+      disabled={lightboxOpen}
+      className={`${lightboxOpen ? "" : "group/doc-preview"} inline-flex w-fit self-start align-top text-left disabled:pointer-events-none`}
       aria-label={`Open ${kind} preview for ${filename}`}
       title={filename}
     >

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -626,23 +626,34 @@ function ArtifactPreviewOpenOverlay({
   filename: string;
   onOpen: () => void;
 }) {
+  const lightboxOpen = useGet(attachmentLightboxUrl$) !== null;
+
   return (
     <div className="group/artifact-preview relative h-full w-full">
       {children}
-      <div className="pointer-events-none absolute inset-0 flex items-center justify-center bg-black/0 opacity-0 transition-all duration-150 group-hover/artifact-preview:bg-black/30 group-hover/artifact-preview:opacity-100 group-focus-within/artifact-preview:bg-black/30 group-focus-within/artifact-preview:opacity-100">
-        <button
-          type="button"
-          onClick={onOpen}
-          aria-label={`Open preview for ${filename}`}
-          className="pointer-events-auto flex h-16 w-16 items-center justify-center rounded-lg text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/80"
-        >
+      <button
+        type="button"
+        onClick={(event) => {
+          event.currentTarget.blur();
+          onOpen();
+        }}
+        disabled={lightboxOpen}
+        aria-label={`Open preview for ${filename}`}
+        className={cn(
+          "absolute inset-0 flex items-center justify-center bg-black/0 opacity-0 transition-all duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-white/80",
+          lightboxOpen
+            ? "pointer-events-none"
+            : "group-hover/artifact-preview:bg-black/30 group-hover/artifact-preview:opacity-100 group-focus-within/artifact-preview:bg-black/30 group-focus-within/artifact-preview:opacity-100",
+        )}
+      >
+        <span className="flex h-16 w-16 items-center justify-center rounded-lg text-white">
           <IconFile
             size={24}
             stroke={1.8}
             className="drop-shadow transition-opacity"
           />
-        </button>
-      </div>
+        </span>
+      </button>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- make presentation visual generation best-effort with a sync response budget to avoid edge timeouts
- keep built-in presentation images out of run artifacts while still recording normal generated images
- improve attachment lightbox previews with script-enabled HTML, iframe-owned scrolling, copy-link controls, and click/hover fixes for inline previews

## Tests
- pnpm --filter api test src/signals/routes/__tests__/zero-presentation-io-generate.test.ts
- pnpm --filter @vm0/app test src/views/zero-page/__tests__/zero-chat-thread-page-interaction.test.tsx src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
- pnpm --filter api exec tsc --noEmit --pretty false --incremental false
- pnpm --filter @vm0/app exec tsc --noEmit --pretty false --incremental false
- pre-commit: prettier, knip, check-types
