### PR TITLE
fix: route hosted site API through web

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -213,7 +213,7 @@ jobs:
         id: detect-api-backend
         run: |
           BASE_REF="${{ steps.detect.outputs.base-ref }}"
-          if git diff --name-only "$BASE_REF" HEAD | grep -q "^turbo/apps/web/next\.config\.js$"; then
+          if git diff --name-only "$BASE_REF" HEAD | grep -qE "^turbo/apps/web/(next\.config\.js|api-backend-rewrites\.js)$"; then
             echo "Web API backend proxy changes detected"
             echo "api-backend-needed=true" >> "$GITHUB_OUTPUT"
           else

--- a/turbo/apps/web/__tests__/api-backend-rewrite-proxy.test.ts
+++ b/turbo/apps/web/__tests__/api-backend-rewrite-proxy.test.ts
@@ -8,6 +8,7 @@ import { createRequire } from "node:module";
 import { parse, type UrlWithParsedQuery } from "node:url";
 import { http as mswHttp, passthrough } from "msw";
 import { describe, expect, it } from "vitest";
+import { matchesApiBackendRewritePath } from "../api-backend-rewrites";
 import { server } from "../src/mocks/server";
 
 type ProxyRequest = (
@@ -130,6 +131,17 @@ async function withRewriteProxy<T>(
 }
 
 describe("API backend rewrite proxy behavior", () => {
+  it("routes hosted-site deployment endpoints to the API backend", () => {
+    expect(
+      matchesApiBackendRewritePath("/api/zero/host/deployments/prepare"),
+    ).toBe(true);
+    expect(
+      matchesApiBackendRewritePath(
+        "/api/zero/host/deployments/eca12aa0-4c26-48c7-85d8-b3af58d408c7/complete",
+      ),
+    ).toBe(true);
+  });
+
   it("forwards method, query, cookies, and request body", async () => {
     await withRewriteProxy(
       async (request) => {

--- a/turbo/apps/web/api-backend-rewrites.js
+++ b/turbo/apps/web/api-backend-rewrites.js
@@ -20,14 +20,8 @@ export const API_BACKEND_REWRITES = [
   ["/api/zero/presentation-io/generate", "/api/zero/presentation-io/generate"],
   ["/api/zero/remote-agent/:path*", "/api/zero/remote-agent/:path*"],
   ["/api/zero/video-io/generate", "/api/zero/video-io/generate"],
-  [
-    "/api/zero/host/deployments/prepare",
-    "/api/zero/host/deployments/prepare",
-  ],
-  [
-    "/api/zero/host/deployments/:path*",
-    "/api/zero/host/deployments/:path*",
-  ],
+  ["/api/zero/host/deployments/prepare", "/api/zero/host/deployments/prepare"],
+  ["/api/zero/host/deployments/:path*", "/api/zero/host/deployments/:path*"],
   [
     "/api/zero/integrations/phone/:path*",
     "/api/zero/integrations/phone/:path*",

--- a/turbo/apps/web/api-backend-rewrites.js
+++ b/turbo/apps/web/api-backend-rewrites.js
@@ -21,6 +21,14 @@ export const API_BACKEND_REWRITES = [
   ["/api/zero/remote-agent/:path*", "/api/zero/remote-agent/:path*"],
   ["/api/zero/video-io/generate", "/api/zero/video-io/generate"],
   [
+    "/api/zero/host/deployments/prepare",
+    "/api/zero/host/deployments/prepare",
+  ],
+  [
+    "/api/zero/host/deployments/:path*",
+    "/api/zero/host/deployments/:path*",
+  ],
+  [
     "/api/zero/integrations/phone/:path*",
     "/api/zero/integrations/phone/:path*",
   ],


### PR DESCRIPTION
## Summary
- route hosted-site deployment API calls from the web app to the API backend
- cover hosted-site prepare and complete paths in the API backend rewrite matcher test

## Context
`zero host` calls against `https://www.vm0.ai` were returning 404 because `/api/zero/host/deployments/*` was not included in the web app's API backend rewrite allowlist.

Separately, `https://diabetes-glucose-guide.sites.vm0.io` is currently returning Cloudflare `error code: 1002`. DNS for `*.sites.vm0.io` resolves directly to Cloudflare anycast IPs, so requests appear to be blocked before reaching `zero-host-worker`.

## Verification
- `node --input-type=module -e "import { matchesApiBackendRewritePath } from './turbo/apps/web/api-backend-rewrites.js'; if (!matchesApiBackendRewritePath('/api/zero/host/deployments/prepare')) throw new Error('prepare not matched'); if (!matchesApiBackendRewritePath('/api/zero/host/deployments/abc/complete')) throw new Error('complete not matched'); if (matchesApiBackendRewritePath('/api/zero/host')) throw new Error('unexpected broad match'); console.log('host rewrite checks passed');"`

Full vitest was not run locally because this clone does not have monorepo dependencies installed (`vitest: not found`).