### PR TITLE
ci: deploy API preview for web backend rewrites

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -211,13 +211,28 @@ jobs:
 
       - name: Detect web API backend proxy changes
         id: detect-api-backend
+        env:
+          WEB_CHANGED: ${{ steps.detect.outputs.web-changed }}
+          CLI_CHANGED: ${{ steps.detect.outputs.cli-changed }}
+          CRATES_CHANGED: ${{ steps.detect-crates.outputs.crates-changed }}
+          CI_CHANGED: ${{ steps.detect-ci.outputs.ci-changed }}
+          E2E_CHANGED: ${{ steps.detect-e2e.outputs.e2e-changed }}
         run: |
           BASE_REF="${{ steps.detect.outputs.base-ref }}"
-          if git diff --name-only "$BASE_REF" HEAD | grep -q "^turbo/apps/web/next\.config\.js$"; then
-            echo "Web API backend proxy changes detected"
+          # Web previews are built with VM0_API_BACKEND_URL pointing at the
+          # matching PR API alias. Runner E2E now exercises web-to-api rewrite
+          # routes, so these preview runs need a real API deployment even when
+          # the API source itself did not change.
+          if [[ "$WEB_CHANGED" == "true" ||
+                "$CLI_CHANGED" == "true" ||
+                "$CRATES_CHANGED" == "true" ||
+                "$CI_CHANGED" == "true" ||
+                "$E2E_CHANGED" == "true" ]] ||
+             git diff --name-only "$BASE_REF" HEAD | grep -qE "^turbo/apps/web/(api-backend-rewrites\.js|next\.config\.js|proxy\.ts)$"; then
+            echo "API backend preview needed for web preview E2E"
             echo "api-backend-needed=true" >> "$GITHUB_OUTPUT"
           else
-            echo "No web API backend proxy changes"
+            echo "No API backend preview needed"
             echo "api-backend-needed=false" >> "$GITHUB_OUTPUT"
           fi
 


### PR DESCRIPTION
## Summary

- make the Turbo workflow deploy a matching API preview whenever web/CLI/crates/CI/E2E preview runs can exercise web-to-api rewrite routes
- include the new `apps/web/api-backend-rewrites.js` registry in the API-backend detector, not only `next.config.js`
- unblock route-cleanup PRs whose web preview points `VM0_API_BACKEND_URL` at `pr-*-api.vm6.ai`

## Root Cause

After #13380, `/api/zero/user-preferences` is served through the web-to-api rewrite registry. Runner E2E calls `zero preference --timezone`, so web previews need a real API preview alias. The detector still only checked `turbo/apps/web/next.config.js`, so route-cleanup PRs that changed only `api-backend-rewrites.js` skipped API deployment and returned 404 from the rewritten user-preferences request.

## Validation

- `/tmp/actionlint/actionlint .github/workflows/turbo.yml`
- `git diff --check`
- local shell simulation for `api-backend-needed=true` when `WEB_CHANGED=true`
- local shell simulation for `api-backend-needed=false` when all relevant flags are false

Refs #13376
Refs #13401
