### PR TITLE
refactor(runner): encode idle park ownership state

### DIFF
--- a/crates/runner/src/cmd/start/heartbeat.rs
+++ b/crates/runner/src/cmd/start/heartbeat.rs
@@ -128,7 +128,9 @@ pub(super) fn collect_heartbeat_state(
 mod tests {
     use super::*;
     use crate::config;
-    use crate::idle_pool::{IdlePoolConfig, ParkCandidate, ParkCandidateParts, ParkResult};
+    use crate::idle_pool::{
+        IdlePoolConfig, ParkResult, ParkedIdleCandidate, SyntheticParkedIdleCandidateParts,
+    };
     use sandbox::{SandboxFactory, SandboxId};
     use sandbox_mock::{MockSandbox, MockSandboxFactory};
 
@@ -147,9 +149,9 @@ mod tests {
         m
     }
 
-    fn make_park_candidate(session_id: &str) -> ParkCandidate {
+    fn make_synthetic_parked_candidate(session_id: &str) -> ParkedIdleCandidate {
         let budget = Arc::new(ResourceBudget::new(1, 1, 1.0, 0));
-        ParkCandidate::from_parked_parts(ParkCandidateParts {
+        ParkedIdleCandidate::synthetic_for_test(SyntheticParkedIdleCandidateParts {
             sandbox: Box::new(MockSandbox::new("test")),
             factory: Arc::new(Box::new(MockSandboxFactory::new()) as Box<dyn SandboxFactory>),
             session_id: session_id.into(),
@@ -199,7 +201,7 @@ mod tests {
             max_idle: 0,
         });
         assert!(matches!(
-            pool.park(make_park_candidate("sess-1")),
+            pool.park(make_synthetic_parked_candidate("sess-1")),
             ParkResult::Parked,
         ));
         let profiles = test_profiles();
@@ -228,8 +230,8 @@ mod tests {
             default_timeout: Duration::from_secs(300),
             max_idle: 0,
         });
-        let _ = pool.park(make_park_candidate("sess-1"));
-        let _ = pool.park(make_park_candidate("sess-2"));
+        let _ = pool.park(make_synthetic_parked_candidate("sess-1"));
+        let _ = pool.park(make_synthetic_parked_candidate("sess-2"));
         let profiles = test_profiles();
 
         let state = collect_heartbeat_state(
@@ -251,7 +253,7 @@ mod tests {
             default_timeout: Duration::from_secs(300),
             max_idle: 0,
         });
-        let _ = pool.park(make_park_candidate("sess-1"));
+        let _ = pool.park(make_synthetic_parked_candidate("sess-1"));
         let profiles = test_profiles();
 
         let state = collect_heartbeat_state(

--- a/crates/runner/src/cmd/start/idle_lifecycle.rs
+++ b/crates/runner/src/cmd/start/idle_lifecycle.rs
@@ -179,7 +179,8 @@ mod tests {
     use sandbox_mock::{MockSandbox, MockSandboxFactory};
 
     use crate::idle_pool::{
-        IdlePool, IdlePoolConfig, ParkCandidate, ParkCandidateParts, ParkResult,
+        IdlePool, IdlePoolConfig, ParkResult, ParkedIdleCandidate,
+        SyntheticParkedIdleCandidateParts,
     };
     use crate::resource_budget::ResourceBudget;
 
@@ -241,16 +242,17 @@ mod tests {
     async fn idle_destroy_panic_releases_budget_lease() {
         let budget = Arc::new(ResourceBudget::new(2, 4096, 1.0, 0));
         let lease = ResourceBudget::try_reserve_lease(&budget, 2, 4096).unwrap();
-        let candidate = ParkCandidate::from_parked_parts(ParkCandidateParts {
-            sandbox: Box::new(MockSandbox::new("panic-destroy")),
-            factory: Arc::new(Box::new(PanickingDestroyFactory) as Box<dyn SandboxFactory>),
-            session_id: "sess-panic".into(),
-            sandbox_id: SandboxId::new_v4(),
-            profile_name: "vm0/default".into(),
-            budget_lease: lease,
-            source_ip: "10.0.0.1".into(),
-            storage_fingerprints: crate::idle_pool::StorageFingerprints::default(),
-        });
+        let candidate =
+            ParkedIdleCandidate::synthetic_for_test(SyntheticParkedIdleCandidateParts {
+                sandbox: Box::new(MockSandbox::new("panic-destroy")),
+                factory: Arc::new(Box::new(PanickingDestroyFactory) as Box<dyn SandboxFactory>),
+                session_id: "sess-panic".into(),
+                sandbox_id: SandboxId::new_v4(),
+                profile_name: "vm0/default".into(),
+                budget_lease: lease,
+                source_ip: "10.0.0.1".into(),
+                storage_fingerprints: crate::idle_pool::StorageFingerprints::default(),
+            });
         let mut pool = IdlePool::new(IdlePoolConfig {
             default_timeout: Duration::from_secs(300),
             max_idle: 0,
@@ -282,18 +284,19 @@ mod tests {
         let budget = Arc::new(ResourceBudget::new(2, 4096, 1.0, 0));
         let lease = ResourceBudget::try_reserve_lease(&budget, 2, 4096).unwrap();
         let destroy_count = Arc::new(AtomicUsize::new(0));
-        let candidate = ParkCandidate::from_parked_parts(ParkCandidateParts {
-            sandbox,
-            factory: Arc::new(Box::new(RecordingDestroyFactory {
-                destroy_count: Arc::clone(&destroy_count),
-            }) as Box<dyn SandboxFactory>),
-            session_id: "sess-stop-panic".into(),
-            sandbox_id: SandboxId::new_v4(),
-            profile_name: "vm0/default".into(),
-            budget_lease: lease,
-            source_ip: "10.0.0.1".into(),
-            storage_fingerprints: crate::idle_pool::StorageFingerprints::default(),
-        });
+        let candidate =
+            ParkedIdleCandidate::synthetic_for_test(SyntheticParkedIdleCandidateParts {
+                sandbox,
+                factory: Arc::new(Box::new(RecordingDestroyFactory {
+                    destroy_count: Arc::clone(&destroy_count),
+                }) as Box<dyn SandboxFactory>),
+                session_id: "sess-stop-panic".into(),
+                sandbox_id: SandboxId::new_v4(),
+                profile_name: "vm0/default".into(),
+                budget_lease: lease,
+                source_ip: "10.0.0.1".into(),
+                storage_fingerprints: crate::idle_pool::StorageFingerprints::default(),
+            });
         let mut pool = IdlePool::new(IdlePoolConfig {
             default_timeout: Duration::from_secs(300),
             max_idle: 0,

--- a/crates/runner/src/cmd/start/job_lifecycle.rs
+++ b/crates/runner/src/cmd/start/job_lifecycle.rs
@@ -78,11 +78,11 @@ impl ActiveBudgetLease {
         Self(lease)
     }
 
-    pub(super) fn into_park_candidate_lease(self) -> BudgetLease {
+    pub(super) fn into_idle_park_lease(self) -> BudgetLease {
         self.0
     }
 
-    pub(super) fn from_rejected_park(lease: BudgetLease) -> Self {
+    pub(super) fn from_idle_park_lease(lease: BudgetLease) -> Self {
         Self(lease)
     }
 }
@@ -318,9 +318,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn completion_ready_idle_owned_does_not_release_park_candidate_budget() {
+    async fn completion_ready_idle_owned_does_not_release_idle_park_budget() {
         let (budget, lease) = test_budget_lease();
-        let park_candidate_lease = ActiveBudgetLease::new(lease).into_park_candidate_lease();
+        let idle_park_lease = ActiveBudgetLease::new(lease).into_idle_park_lease();
         let budget_count_at_complete = Arc::new(AtomicUsize::new(usize::MAX));
         let active_runs_at_complete = Arc::new(AtomicUsize::new(usize::MAX));
         let dir = tempfile::tempdir().unwrap();
@@ -354,7 +354,7 @@ mod tests {
             cleanup_state.disposition(),
             RunCleanupDisposition::StatusRemoved,
         );
-        drop(park_candidate_lease);
+        drop(idle_park_lease);
         assert_eq!(budget.allocated().2, 0);
     }
 
@@ -420,7 +420,7 @@ mod tests {
 
         CompletionReady::new(
             test_completion_payload(run_id, sandbox_id),
-            BudgetOwnership::active(ActiveBudgetLease::from_rejected_park(lease)),
+            BudgetOwnership::active(ActiveBudgetLease::from_idle_park_lease(lease)),
         )
         .complete_and_release(&provider, &ownership, &cleanup_state)
         .await;

--- a/crates/runner/src/cmd/start/job_spawn.rs
+++ b/crates/runner/src/cmd/start/job_spawn.rs
@@ -382,7 +382,8 @@ mod tests {
     use super::super::job_lifecycle::RunCleanupState;
     use super::super::orphan_reap::OrphanedActiveRuns;
     use crate::idle_pool::{
-        IdlePool, IdlePoolConfig, ParkCandidate, ParkCandidateParts, ParkResult,
+        IdlePool, IdlePoolConfig, ParkResult, ParkedIdleCandidate,
+        SyntheticParkedIdleCandidateParts,
     };
     use crate::ids::RunId;
     use crate::resource_budget::ResourceBudget;
@@ -600,16 +601,17 @@ mod tests {
         let sandbox_id = SandboxId::new_v4();
         let budget = Arc::new(ResourceBudget::new(2, 4096, 1.0, 0));
         let lease = ResourceBudget::try_reserve_lease(&budget, 2, 4096).unwrap();
-        let candidate = ParkCandidate::from_parked_parts(ParkCandidateParts {
-            sandbox: Box::new(MockSandbox::new("idle-owned-cleanup")),
-            factory: Arc::new(Box::new(MockSandboxFactory::new()) as Box<dyn SandboxFactory>),
-            session_id: "sess-idle-owned-cleanup".into(),
-            sandbox_id,
-            profile_name: "vm0/default".into(),
-            budget_lease: lease,
-            source_ip: "10.0.0.1".into(),
-            storage_fingerprints: crate::idle_pool::StorageFingerprints::default(),
-        });
+        let candidate =
+            ParkedIdleCandidate::synthetic_for_test(SyntheticParkedIdleCandidateParts {
+                sandbox: Box::new(MockSandbox::new("idle-owned-cleanup")),
+                factory: Arc::new(Box::new(MockSandboxFactory::new()) as Box<dyn SandboxFactory>),
+                session_id: "sess-idle-owned-cleanup".into(),
+                sandbox_id,
+                profile_name: "vm0/default".into(),
+                budget_lease: lease,
+                source_ip: "10.0.0.1".into(),
+                storage_fingerprints: crate::idle_pool::StorageFingerprints::default(),
+            });
         assert!(matches!(
             fixture.idle_pool.lock().await.park(candidate),
             ParkResult::Parked

--- a/crates/runner/src/cmd/start/orphan_reap.rs
+++ b/crates/runner/src/cmd/start/orphan_reap.rs
@@ -325,8 +325,8 @@ async fn reap_orphaned_active_runs_with_firecrackers(
 mod tests {
     use super::*;
     use crate::idle_pool::{
-        IdlePool, IdlePoolConfig, ParkCandidate, ParkCandidateParts, ParkResult,
-        StorageFingerprints,
+        IdlePool, IdlePoolConfig, ParkResult, ParkedIdleCandidate, StorageFingerprints,
+        SyntheticParkedIdleCandidateParts,
     };
     use crate::resource_budget::ResourceBudget;
     use sandbox::SandboxFactory;
@@ -418,16 +418,17 @@ mod tests {
         let current_sandbox_id = SandboxId::new_v4();
         let budget = Arc::new(ResourceBudget::new(2, 4096, 1.0, 0));
         let lease = ResourceBudget::try_reserve_lease(&budget, 2, 4096).unwrap();
-        let candidate = ParkCandidate::from_parked_parts(ParkCandidateParts {
-            sandbox: Box::new(MockSandbox::new("stale-idle-owned-reaper")),
-            factory: Arc::new(Box::new(MockSandboxFactory::new()) as Box<dyn SandboxFactory>),
-            session_id: "sess-stale-idle-owned-reaper".into(),
-            sandbox_id: stale_sandbox_id,
-            profile_name: "vm0/default".into(),
-            budget_lease: lease,
-            source_ip: "10.0.0.1".into(),
-            storage_fingerprints: StorageFingerprints::default(),
-        });
+        let candidate =
+            ParkedIdleCandidate::synthetic_for_test(SyntheticParkedIdleCandidateParts {
+                sandbox: Box::new(MockSandbox::new("stale-idle-owned-reaper")),
+                factory: Arc::new(Box::new(MockSandboxFactory::new()) as Box<dyn SandboxFactory>),
+                session_id: "sess-stale-idle-owned-reaper".into(),
+                sandbox_id: stale_sandbox_id,
+                profile_name: "vm0/default".into(),
+                budget_lease: lease,
+                source_ip: "10.0.0.1".into(),
+                storage_fingerprints: StorageFingerprints::default(),
+            });
         assert!(matches!(
             idle_pool.lock().await.park(candidate),
             ParkResult::Parked
@@ -473,16 +474,17 @@ mod tests {
         let sandbox_id = SandboxId::new_v4();
         let budget = Arc::new(ResourceBudget::new(2, 4096, 1.0, 0));
         let lease = ResourceBudget::try_reserve_lease(&budget, 2, 4096).unwrap();
-        let candidate = ParkCandidate::from_parked_parts(ParkCandidateParts {
-            sandbox: Box::new(MockSandbox::new("idle-owned-reaper")),
-            factory: Arc::new(Box::new(MockSandboxFactory::new()) as Box<dyn SandboxFactory>),
-            session_id: "sess-idle-owned-reaper".into(),
-            sandbox_id,
-            profile_name: "vm0/default".into(),
-            budget_lease: lease,
-            source_ip: "10.0.0.1".into(),
-            storage_fingerprints: StorageFingerprints::default(),
-        });
+        let candidate =
+            ParkedIdleCandidate::synthetic_for_test(SyntheticParkedIdleCandidateParts {
+                sandbox: Box::new(MockSandbox::new("idle-owned-reaper")),
+                factory: Arc::new(Box::new(MockSandboxFactory::new()) as Box<dyn SandboxFactory>),
+                session_id: "sess-idle-owned-reaper".into(),
+                sandbox_id,
+                profile_name: "vm0/default".into(),
+                budget_lease: lease,
+                source_ip: "10.0.0.1".into(),
+                storage_fingerprints: StorageFingerprints::default(),
+            });
         assert!(matches!(
             idle_pool.lock().await.park(candidate),
             ParkResult::Parked

--- a/crates/runner/src/cmd/start/sandbox_finalization.rs
+++ b/crates/runner/src/cmd/start/sandbox_finalization.rs
@@ -22,7 +22,8 @@ use super::ownership::OwnershipTransitions;
 #[cfg(test)]
 use super::{OuterJobPanicPoint, StartLoopTestObserver, maybe_panic_outer_job};
 use crate::idle_pool::{
-    DestroyOutcome, ParkCandidate, ParkCandidateParts, ParkResult, ParkingGate, StorageFingerprints,
+    DestroyOutcome, IdleParkActiveParts, IdleParkRequest, ParkResult, ParkingGate,
+    StorageFingerprints,
 };
 use crate::ids::RunId;
 use crate::network_log_drain::NetworkLogDrainCoordinator;
@@ -59,7 +60,7 @@ pub(super) async fn finalize_sandbox_for_completion(
     completion_payload: CompletionPayload,
     ctx: FinalizeContext,
 ) -> CompletionReady {
-    let Some(mut sandbox) = sandbox else {
+    let Some(sandbox) = sandbox else {
         return CompletionReady::new(completion_payload, BudgetOwnership::active(active_lease));
     };
 
@@ -103,38 +104,66 @@ pub(super) async fn finalize_sandbox_for_completion(
         // Inflate the guest balloon BEFORE acquiring the pool lock —
         // the HTTP call to Firecracker can take milliseconds, and we
         // must not block other take/park operations on it.
-        if let Err(e) = park_sandbox_panic_safe(sandbox.as_mut()).await {
-            warn!(
-                run_id = %run_id,
-                session_id,
-                error = %e,
-                "sandbox park failed, destroying instead of parking"
-            );
-            let destroy_outcome = stop_and_destroy_sandbox(
-                sandbox,
-                &**factory,
-                ActiveCleanupContext {
+        let park_request = IdleParkRequest::new(
+            sandbox,
+            Arc::clone(&factory),
+            session_id.clone(),
+            sandbox_id,
+            profile_name.clone(),
+            active_lease.into_idle_park_lease(),
+            source_ip,
+            storage_fingerprints,
+        );
+        let candidate = match park_request.park_for_idle().await {
+            Ok(candidate) => candidate,
+            Err(failure) => {
+                let failure = failure.into_active_parts();
+                let IdleParkActiveParts {
+                    sandbox,
+                    factory: failure_factory,
+                    budget_lease,
+                } = failure.active;
+                warn!(
+                    run_id = %run_id,
+                    session_id,
+                    error = %failure.error,
+                    "sandbox park failed, destroying instead of parking"
+                );
+                let destroy_outcome = stop_and_destroy_sandbox(
+                    sandbox,
+                    &**failure_factory,
+                    ActiveCleanupContext {
+                        run_id,
+                        sandbox_id,
+                        profile_name: &profile_name,
+                        session_id: Some(&session_id),
+                        reason: "park_failed",
+                        network_log_session: network_log_session.take(),
+                        network_log_drain: network_log_drain.clone(),
+                    },
+                )
+                .await;
+                if destroy_outcome == DestroyOutcome::Completed {
+                    cleanup_state.mark_destroy_completed();
+                }
+                #[cfg(test)]
+                maybe_panic_outer_job(
+                    outer_job_panic,
+                    OuterJobPanicPoint::DestroyCompleted,
                     run_id,
-                    sandbox_id,
-                    profile_name: &profile_name,
-                    session_id: Some(&session_id),
-                    reason: "park_failed",
-                    network_log_session: network_log_session.take(),
-                    network_log_drain: network_log_drain.clone(),
-                },
-            )
-            .await;
-            if destroy_outcome == DestroyOutcome::Completed {
-                cleanup_state.mark_destroy_completed();
+                );
+                return CompletionReady::new(
+                    completion_payload,
+                    BudgetOwnership::active(ActiveBudgetLease::from_idle_park_lease(budget_lease)),
+                );
             }
-            #[cfg(test)]
-            maybe_panic_outer_job(
-                outer_job_panic,
-                OuterJobPanicPoint::DestroyCompleted,
-                run_id,
-            );
-            BudgetOwnership::active(active_lease)
-        } else if cancel.is_cancelled() {
+        };
+        if cancel.is_cancelled() {
+            let IdleParkActiveParts {
+                sandbox,
+                factory: candidate_factory,
+                budget_lease,
+            } = candidate.into_active_parts();
             close_network_log_session(run_id, network_log_session.take(), &network_log_drain).await;
             info!(
                 run_id = %run_id,
@@ -143,7 +172,7 @@ pub(super) async fn finalize_sandbox_for_completion(
             );
             let destroy_outcome = stop_and_destroy_sandbox(
                 sandbox,
-                &**factory,
+                &**candidate_factory,
                 ActiveCleanupContext {
                     run_id,
                     sandbox_id,
@@ -164,7 +193,7 @@ pub(super) async fn finalize_sandbox_for_completion(
                 OuterJobPanicPoint::DestroyCompleted,
                 run_id,
             );
-            BudgetOwnership::active(active_lease)
+            BudgetOwnership::active(ActiveBudgetLease::from_idle_park_lease(budget_lease))
         } else {
             close_network_log_session(run_id, network_log_session.take(), &network_log_drain).await;
             #[cfg(test)]
@@ -177,9 +206,14 @@ pub(super) async fn finalize_sandbox_for_completion(
                     "job cancelled before idle pool ownership transfer, destroying VM"
                 );
                 drop(pool);
+                let IdleParkActiveParts {
+                    sandbox,
+                    factory: candidate_factory,
+                    budget_lease,
+                } = candidate.into_active_parts();
                 let destroy_outcome = stop_and_destroy_sandbox(
                     sandbox,
-                    &**factory,
+                    &**candidate_factory,
                     ActiveCleanupContext {
                         run_id,
                         sandbox_id,
@@ -202,19 +236,9 @@ pub(super) async fn finalize_sandbox_for_completion(
                 );
                 return CompletionReady::new(
                     completion_payload,
-                    BudgetOwnership::active(active_lease),
+                    BudgetOwnership::active(ActiveBudgetLease::from_idle_park_lease(budget_lease)),
                 );
             }
-            let candidate = ParkCandidate::from_parked_parts(ParkCandidateParts {
-                sandbox,
-                factory,
-                session_id: session_id.clone(),
-                sandbox_id,
-                profile_name,
-                budget_lease: active_lease.into_park_candidate_lease(),
-                source_ip,
-                storage_fingerprints,
-            });
             match pool.park(candidate) {
                 ParkResult::Parked => {
                     info!(run_id = %run_id, session_id, "VM parked for reuse");
@@ -285,7 +309,7 @@ pub(super) async fn finalize_sandbox_for_completion(
                         OuterJobPanicPoint::DestroyCompleted,
                         run_id,
                     );
-                    BudgetOwnership::active(ActiveBudgetLease::from_rejected_park(lease))
+                    BudgetOwnership::active(ActiveBudgetLease::from_idle_park_lease(lease))
                 }
             }
         }
@@ -333,14 +357,6 @@ async fn close_network_log_session(
 ) {
     if let Some(session) = session {
         session.close_for_upload(run_id, drain).await;
-    }
-}
-
-async fn park_sandbox_panic_safe(sandbox: &mut dyn Sandbox) -> Result<(), String> {
-    match AssertUnwindSafe(sandbox.park()).catch_unwind().await {
-        Ok(Ok(())) => Ok(()),
-        Ok(Err(e)) => Err(e.to_string()),
-        Err(_) => Err("sandbox park panicked".into()),
     }
 }
 

--- a/crates/runner/src/cmd/start/sandbox_finalization.rs
+++ b/crates/runner/src/cmd/start/sandbox_finalization.rs
@@ -22,8 +22,8 @@ use super::ownership::OwnershipTransitions;
 #[cfg(test)]
 use super::{OuterJobPanicPoint, StartLoopTestObserver, maybe_panic_outer_job};
 use crate::idle_pool::{
-    DestroyOutcome, IdleParkActiveParts, IdleParkRequest, ParkResult, ParkingGate,
-    StorageFingerprints,
+    DestroyOutcome, IdleParkActiveParts, IdleParkRequest, IdleParkRequestParts, ParkResult,
+    ParkingGate, StorageFingerprints,
 };
 use crate::ids::RunId;
 use crate::network_log_drain::NetworkLogDrainCoordinator;
@@ -104,16 +104,16 @@ pub(super) async fn finalize_sandbox_for_completion(
         // Inflate the guest balloon BEFORE acquiring the pool lock —
         // the HTTP call to Firecracker can take milliseconds, and we
         // must not block other take/park operations on it.
-        let park_request = IdleParkRequest::new(
+        let park_request = IdleParkRequest::new(IdleParkRequestParts {
             sandbox,
-            Arc::clone(&factory),
-            session_id.clone(),
+            factory: Arc::clone(&factory),
+            session_id: session_id.clone(),
             sandbox_id,
-            profile_name.clone(),
-            active_lease.into_idle_park_lease(),
+            profile_name: profile_name.clone(),
+            budget_lease: active_lease.into_idle_park_lease(),
             source_ip,
             storage_fingerprints,
-        );
+        });
         let candidate = match park_request.park_for_idle().await {
             Ok(candidate) => candidate,
             Err(failure) => {

--- a/crates/runner/src/cmd/start/tests/budget.rs
+++ b/crates/runner/src/cmd/start/tests/budget.rs
@@ -1,6 +1,6 @@
 use super::super::*;
 use super::support::{
-    TestParkCandidateSpec, context_with_session, minimal_context, mock_run_config,
+    TestParkedIdleCandidateSpec, context_with_session, minimal_context, mock_run_config,
     mock_run_config_with_overrides, push_job, seed_idle_pool, seed_idle_pool_expired,
     seed_idle_pool_with_timing, shutdown, status_idle_sessions, test_profiles, two_profiles,
     wait_budget_count, wait_cancel_token, wait_discover_entered,
@@ -213,7 +213,7 @@ async fn budget_exhausted_reclaims_expired_before_oldest_idle() {
     seed_idle_pool_with_timing(
         &idle_pool,
         &budget,
-        TestParkCandidateSpec {
+        TestParkedIdleCandidateSpec {
             session_id: "sess-old-active",
             profile_name: "vm0/default",
             vcpu: 2,
@@ -226,7 +226,7 @@ async fn budget_exhausted_reclaims_expired_before_oldest_idle() {
     seed_idle_pool_with_timing(
         &idle_pool,
         &budget,
-        TestParkCandidateSpec {
+        TestParkedIdleCandidateSpec {
             session_id: "sess-expired-newer",
             profile_name: "vm0/large",
             vcpu: 4,
@@ -284,7 +284,7 @@ async fn budget_exhausted_evicts_oldest_when_expired_reclaim_insufficient() {
     seed_idle_pool_with_timing(
         &idle_pool,
         &budget,
-        TestParkCandidateSpec {
+        TestParkedIdleCandidateSpec {
             session_id: "sess-old-active",
             profile_name: "vm0/large",
             vcpu: 4,
@@ -297,7 +297,7 @@ async fn budget_exhausted_evicts_oldest_when_expired_reclaim_insufficient() {
     seed_idle_pool_with_timing(
         &idle_pool,
         &budget,
-        TestParkCandidateSpec {
+        TestParkedIdleCandidateSpec {
             session_id: "sess-new-active",
             profile_name: "vm0/default",
             vcpu: 2,
@@ -310,7 +310,7 @@ async fn budget_exhausted_evicts_oldest_when_expired_reclaim_insufficient() {
     seed_idle_pool_with_timing(
         &idle_pool,
         &budget,
-        TestParkCandidateSpec {
+        TestParkedIdleCandidateSpec {
             session_id: "sess-expired-small",
             profile_name: "vm0/default",
             // Intentionally smaller than the current min profile. With

--- a/crates/runner/src/cmd/start/tests/support/idle_pool.rs
+++ b/crates/runner/src/cmd/start/tests/support/idle_pool.rs
@@ -1,16 +1,16 @@
 use super::super::super::*;
 
-use crate::idle_pool::{ParkCandidate, ParkCandidateParts, ParkResult};
+use crate::idle_pool::{ParkResult, ParkedIdleCandidate, SyntheticParkedIdleCandidateParts};
 use crate::resource_budget::BudgetLease;
 use sandbox::{SandboxFactory, SandboxId};
 use sandbox_mock::{MockSandbox, MockSandboxFactory};
 
-fn make_test_park_candidate(
+fn make_synthetic_parked_candidate(
     session_id: &str,
     profile_name: &str,
     budget_lease: BudgetLease,
-) -> ParkCandidate {
-    ParkCandidate::from_parked_parts(ParkCandidateParts {
+) -> ParkedIdleCandidate {
+    ParkedIdleCandidate::synthetic_for_test(SyntheticParkedIdleCandidateParts {
         sandbox: Box::new(MockSandbox::new("idle-test")),
         factory: Arc::new(Box::new(MockSandboxFactory::new()) as Box<dyn SandboxFactory>),
         session_id: session_id.into(),
@@ -34,7 +34,7 @@ pub(in super::super) async fn seed_idle_pool(
     memory_mb: u32,
 ) -> SandboxId {
     let budget_lease = ResourceBudget::try_reserve_lease(budget, vcpu, memory_mb).unwrap();
-    let candidate = make_test_park_candidate(session_id, profile_name, budget_lease);
+    let candidate = make_synthetic_parked_candidate(session_id, profile_name, budget_lease);
     let sandbox_id = candidate.sandbox_id();
     let mut guard = pool.lock().await;
     let result = guard.park(candidate);
@@ -79,16 +79,18 @@ pub(in super::super) async fn seed_idle_pool_with_overrides(
         ResourceBudget::try_reserve_lease(budget, vcpu, memory_mb).expect("reserve budget");
 
     let mut guard = pool.lock().await;
-    let result = guard.park(ParkCandidate::from_parked_parts(ParkCandidateParts {
-        sandbox,
-        factory: factory_arc,
-        session_id: session_id.to_string(),
-        sandbox_id,
-        profile_name: profile_name.into(),
-        budget_lease,
-        source_ip: "10.0.0.1".into(),
-        storage_fingerprints: crate::idle_pool::StorageFingerprints::default(),
-    }));
+    let result = guard.park(ParkedIdleCandidate::synthetic_for_test(
+        SyntheticParkedIdleCandidateParts {
+            sandbox,
+            factory: factory_arc,
+            session_id: session_id.to_string(),
+            sandbox_id,
+            profile_name: profile_name.into(),
+            budget_lease,
+            source_ip: "10.0.0.1".into(),
+            storage_fingerprints: crate::idle_pool::StorageFingerprints::default(),
+        },
+    ));
     assert!(matches!(result, ParkResult::Parked));
     sandbox_id
 }
@@ -102,7 +104,7 @@ pub(in super::super) async fn seed_idle_pool_expired(
     memory_mb: u32,
 ) {
     let budget_lease = ResourceBudget::try_reserve_lease(budget, vcpu, memory_mb).unwrap();
-    let candidate = make_test_park_candidate(session_id, profile_name, budget_lease);
+    let candidate = make_synthetic_parked_candidate(session_id, profile_name, budget_lease);
     let mut guard = pool.lock().await;
     let result = guard.park_at_for_test(
         candidate,
@@ -112,7 +114,7 @@ pub(in super::super) async fn seed_idle_pool_expired(
     assert!(matches!(result, ParkResult::Parked));
 }
 
-pub(in super::super) struct TestParkCandidateSpec<'a> {
+pub(in super::super) struct TestParkedIdleCandidateSpec<'a> {
     pub(in super::super) session_id: &'a str,
     pub(in super::super) profile_name: &'a str,
     pub(in super::super) vcpu: u32,
@@ -124,11 +126,12 @@ pub(in super::super) struct TestParkCandidateSpec<'a> {
 pub(in super::super) async fn seed_idle_pool_with_timing(
     pool: &SharedIdlePool,
     budget: &Arc<ResourceBudget>,
-    spec: TestParkCandidateSpec<'_>,
+    spec: TestParkedIdleCandidateSpec<'_>,
 ) {
     let budget_lease =
         ResourceBudget::try_reserve_lease(budget, spec.vcpu, spec.memory_mb).unwrap();
-    let candidate = make_test_park_candidate(spec.session_id, spec.profile_name, budget_lease);
+    let candidate =
+        make_synthetic_parked_candidate(spec.session_id, spec.profile_name, budget_lease);
     let mut guard = pool.lock().await;
     let result = guard.park_at_for_test(candidate, spec.parked_at, spec.idle_timeout);
     assert!(matches!(result, ParkResult::Parked));

--- a/crates/runner/src/cmd/start/tests/support/mod.rs
+++ b/crates/runner/src/cmd/start/tests/support/mod.rs
@@ -9,8 +9,8 @@ pub(super) use self::env::{
     mock_run_config_with_overrides, test_profiles, two_profiles,
 };
 pub(super) use self::idle_pool::{
-    TestParkCandidateSpec, seed_idle_pool, seed_idle_pool_expired, seed_idle_pool_with_overrides,
-    seed_idle_pool_with_timing,
+    TestParkedIdleCandidateSpec, seed_idle_pool, seed_idle_pool_expired,
+    seed_idle_pool_with_overrides, seed_idle_pool_with_timing,
 };
 pub(super) use self::jobs::{context_with_session, minimal_context, push_job, shutdown};
 pub(super) use self::status::{

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -2980,26 +2980,27 @@ mod tests {
         session_id: &str,
     ) -> (ReusableIdleSandbox, crate::resource_budget::BudgetLease) {
         use crate::idle_pool::{
-            IdlePool, IdlePoolConfig, IdleUnparkResult, ParkCandidate, ParkCandidateParts,
-            ParkResult,
+            IdlePool, IdlePoolConfig, IdleUnparkResult, ParkResult, ParkedIdleCandidate,
+            SyntheticParkedIdleCandidateParts,
         };
 
         let mut pool = IdlePool::new(IdlePoolConfig {
             default_timeout: std::time::Duration::from_secs(300),
             max_idle: 0,
         });
-        let candidate = ParkCandidate::from_parked_parts(ParkCandidateParts {
-            sandbox,
-            factory: std::sync::Arc::new(
-                Box::new(MockSandboxFactory::new()) as Box<dyn SandboxFactory>
-            ),
-            session_id: session_id.into(),
-            sandbox_id: SandboxId::new_v4(),
-            profile_name: "vm0/default".into(),
-            budget_lease: test_budget_lease(),
-            source_ip,
-            storage_fingerprints: crate::idle_pool::StorageFingerprints::default(),
-        });
+        let candidate =
+            ParkedIdleCandidate::synthetic_for_test(SyntheticParkedIdleCandidateParts {
+                sandbox,
+                factory: std::sync::Arc::new(
+                    Box::new(MockSandboxFactory::new()) as Box<dyn SandboxFactory>
+                ),
+                session_id: session_id.into(),
+                sandbox_id: SandboxId::new_v4(),
+                profile_name: "vm0/default".into(),
+                budget_lease: test_budget_lease(),
+                source_ip,
+                storage_fingerprints: crate::idle_pool::StorageFingerprints::default(),
+            });
         assert!(matches!(pool.park(candidate), ParkResult::Parked));
         let entry = pool.take(session_id).expect("idle entry should exist");
         match entry.try_unpark().await {
@@ -3342,7 +3343,8 @@ mod tests {
     #[tokio::test]
     async fn idle_pool_park_and_reuse_cycle() {
         use crate::idle_pool::{
-            IdlePool, IdlePoolConfig, ParkCandidate, ParkCandidateParts, ParkResult,
+            IdlePool, IdlePoolConfig, ParkResult, ParkedIdleCandidate,
+            SyntheticParkedIdleCandidateParts,
         };
 
         let dir = tempfile::tempdir().unwrap();
@@ -3372,7 +3374,7 @@ mod tests {
             max_idle: 0,
         });
 
-        let entry = ParkCandidate::from_parked_parts(ParkCandidateParts {
+        let entry = ParkedIdleCandidate::synthetic_for_test(SyntheticParkedIdleCandidateParts {
             sandbox,
             factory: std::sync::Arc::new(
                 Box::new(MockSandboxFactory::new()) as Box<dyn SandboxFactory>
@@ -3413,7 +3415,9 @@ mod tests {
 
     #[tokio::test]
     async fn idle_pool_profile_mismatch_returns_none() {
-        use crate::idle_pool::{IdlePool, IdlePoolConfig, ParkCandidate, ParkCandidateParts};
+        use crate::idle_pool::{
+            IdlePool, IdlePoolConfig, ParkedIdleCandidate, SyntheticParkedIdleCandidateParts,
+        };
 
         let mut pool = IdlePool::new(IdlePoolConfig {
             default_timeout: std::time::Duration::from_secs(300),
@@ -3421,7 +3425,7 @@ mod tests {
         });
 
         // Park with profile "vm0/default"
-        let entry = ParkCandidate::from_parked_parts(ParkCandidateParts {
+        let entry = ParkedIdleCandidate::synthetic_for_test(SyntheticParkedIdleCandidateParts {
             sandbox: Box::new(sandbox_mock::MockSandbox::new("test")),
             factory: std::sync::Arc::new(
                 Box::new(sandbox_mock::MockSandboxFactory::new()) as Box<dyn SandboxFactory>

--- a/crates/runner/src/idle_pool.rs
+++ b/crates/runner/src/idle_pool.rs
@@ -945,6 +945,86 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn idle_park_request_success_preserves_reuse_metadata() {
+        let overrides = Arc::new(MockSandboxOverrides::new());
+        let sandbox_id = SandboxId::new_v4();
+        let session_id = "session-metadata";
+        let profile_name = "vm0/large";
+        let source_ip = "10.99.0.42";
+        let budget_lease = make_budget_lease(2, 2048);
+        let factory: Arc<Box<dyn SandboxFactory>> = Arc::new(Box::new(
+            MockSandboxFactory::with_overrides(Arc::clone(&overrides)),
+        ));
+        let sandbox = factory
+            .create(SandboxConfig {
+                id: sandbox_id,
+                resources: ResourceLimits {
+                    cpu_count: budget_lease.vcpu(),
+                    memory_mb: budget_lease.memory_mb(),
+                },
+            })
+            .await
+            .expect("create sandbox");
+        let storage_fingerprints = StorageFingerprints {
+            storages: HashMap::from([(
+                "/mnt/storage".into(),
+                ("storage-a".into(), "storage-version-2".into()),
+            )]),
+            artifacts: HashMap::from([(
+                "/workspace".into(),
+                ("artifact-a".into(), "artifact-version-3".into()),
+            )]),
+        };
+        let expected_storage_fingerprints = storage_fingerprints.clone();
+        let request = IdleParkRequest::new(
+            sandbox,
+            factory,
+            session_id.into(),
+            sandbox_id,
+            profile_name.into(),
+            budget_lease,
+            source_ip.into(),
+            storage_fingerprints,
+        );
+
+        let candidate = match request.park_for_idle().await {
+            Ok(candidate) => candidate,
+            Err(_) => panic!("park should succeed"),
+        };
+
+        assert_eq!(overrides.park_call_count(), 1);
+        assert_eq!(candidate.session_id(), session_id);
+        assert_eq!(candidate.sandbox_id(), sandbox_id);
+        assert_eq!(candidate.profile_name, profile_name);
+
+        let mut pool = IdlePool::new(pool_config(0));
+        assert!(matches!(pool.park(candidate), ParkResult::Parked));
+        let entry = pool.take(session_id).expect("idle entry should be parked");
+        assert_eq!(entry.profile_name(), profile_name);
+
+        let IdleUnparkResult::Reused {
+            sandbox,
+            budget_lease,
+        } = entry.try_unpark().await
+        else {
+            panic!("unpark should succeed");
+        };
+        assert_eq!(sandbox.sandbox_id(), sandbox_id);
+        let reused_parts = sandbox.into_parts();
+        assert_eq!(reused_parts.source_ip, source_ip);
+        assert_eq!(
+            reused_parts.storage_fingerprints.storages,
+            expected_storage_fingerprints.storages
+        );
+        assert_eq!(
+            reused_parts.storage_fingerprints.artifacts,
+            expected_storage_fingerprints.artifacts
+        );
+        assert_eq!(budget_lease.vcpu(), 2);
+        assert_eq!(budget_lease.memory_mb(), 2048);
+    }
+
+    #[tokio::test]
     async fn idle_park_request_error_returns_owned_failure_parts() {
         let overrides = Arc::new(MockSandboxOverrides::new());
         overrides.push_park_result(Err(sandbox::SandboxError::IdleTransition {

--- a/crates/runner/src/idle_pool.rs
+++ b/crates/runner/src/idle_pool.rs
@@ -148,9 +148,25 @@ impl Default for ParkingGate {
     }
 }
 
+/// One-shot request to transition an active sandbox into same-session idle
+/// ownership.
+pub(crate) struct IdleParkRequest {
+    sandbox: Box<dyn Sandbox>,
+    factory: Arc<Box<dyn SandboxFactory>>,
+    session_id: String,
+    sandbox_id: SandboxId,
+    profile_name: String,
+    budget_lease: BudgetLease,
+    source_ip: String,
+    storage_fingerprints: StorageFingerprints,
+}
+
 /// Active-owned sandbox after `Sandbox::park()` succeeds, before idle-pool
 /// ownership is accepted.
-pub struct ParkCandidate {
+///
+/// This state proves only same-session idle park. It does not imply clean
+/// cross-run reuse, snapshot readiness, or any broader VM correctness.
+pub struct ParkedIdleCandidate {
     sandbox: Box<dyn Sandbox>,
     factory: Arc<Box<dyn SandboxFactory>>,
     session_id: String,
@@ -166,7 +182,8 @@ pub struct ParkCandidate {
     storage_fingerprints: StorageFingerprints,
 }
 
-pub(crate) struct ParkCandidateParts {
+#[cfg(test)]
+pub(crate) struct SyntheticParkedIdleCandidateParts {
     pub sandbox: Box<dyn Sandbox>,
     pub factory: Arc<Box<dyn SandboxFactory>>,
     pub session_id: String,
@@ -177,9 +194,100 @@ pub(crate) struct ParkCandidateParts {
     pub storage_fingerprints: StorageFingerprints,
 }
 
-impl ParkCandidate {
-    /// Build a candidate only after `Sandbox::park()` has returned success.
-    pub(crate) fn from_parked_parts(parts: ParkCandidateParts) -> Self {
+#[must_use = "idle park failures must be explicitly destroyed or otherwise handled"]
+pub(crate) struct IdleParkFailure {
+    sandbox: Box<dyn Sandbox>,
+    factory: Arc<Box<dyn SandboxFactory>>,
+    budget_lease: BudgetLease,
+    error: String,
+}
+
+pub(crate) struct IdleParkActiveParts {
+    pub(crate) sandbox: Box<dyn Sandbox>,
+    pub(crate) factory: Arc<Box<dyn SandboxFactory>>,
+    pub(crate) budget_lease: BudgetLease,
+}
+
+pub(crate) struct IdleParkFailureParts {
+    pub(crate) active: IdleParkActiveParts,
+    pub(crate) error: String,
+}
+
+impl IdleParkRequest {
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn new(
+        sandbox: Box<dyn Sandbox>,
+        factory: Arc<Box<dyn SandboxFactory>>,
+        session_id: String,
+        sandbox_id: SandboxId,
+        profile_name: String,
+        budget_lease: BudgetLease,
+        source_ip: String,
+        storage_fingerprints: StorageFingerprints,
+    ) -> Self {
+        Self {
+            sandbox,
+            factory,
+            session_id,
+            sandbox_id,
+            profile_name,
+            budget_lease,
+            source_ip,
+            storage_fingerprints,
+        }
+    }
+
+    pub(crate) async fn park_for_idle(mut self) -> Result<ParkedIdleCandidate, IdleParkFailure> {
+        match AssertUnwindSafe(self.sandbox.park()).catch_unwind().await {
+            Ok(Ok(())) => Ok(ParkedIdleCandidate {
+                sandbox: self.sandbox,
+                factory: self.factory,
+                session_id: self.session_id,
+                sandbox_id: self.sandbox_id,
+                profile_name: self.profile_name,
+                budget_lease: self.budget_lease,
+                source_ip: self.source_ip,
+                storage_fingerprints: self.storage_fingerprints,
+            }),
+            Ok(Err(e)) => Err(self.into_failure(e.to_string())),
+            Err(_) => Err(self.into_failure("sandbox park panicked".into())),
+        }
+    }
+
+    fn into_failure(self, error: String) -> IdleParkFailure {
+        IdleParkFailure {
+            sandbox: self.sandbox,
+            factory: self.factory,
+            budget_lease: self.budget_lease,
+            error,
+        }
+    }
+}
+
+impl IdleParkFailure {
+    pub(crate) fn into_active_parts(self) -> IdleParkFailureParts {
+        let Self {
+            sandbox,
+            factory,
+            budget_lease,
+            error,
+        } = self;
+        IdleParkFailureParts {
+            active: IdleParkActiveParts {
+                sandbox,
+                factory,
+                budget_lease,
+            },
+            error,
+        }
+    }
+}
+
+impl ParkedIdleCandidate {
+    /// Build a synthetic candidate for tests that seed idle-pool state without
+    /// running a real park transition.
+    #[cfg(test)]
+    pub(crate) fn synthetic_for_test(parts: SyntheticParkedIdleCandidateParts) -> Self {
         Self {
             sandbox: parts.sandbox,
             factory: parts.factory,
@@ -227,7 +335,21 @@ impl ParkCandidate {
         }
     }
 
-    fn into_rejected(self) -> RejectedParkCandidate {
+    pub(crate) fn into_active_parts(self) -> IdleParkActiveParts {
+        let Self {
+            sandbox,
+            factory,
+            budget_lease,
+            ..
+        } = self;
+        IdleParkActiveParts {
+            sandbox,
+            factory,
+            budget_lease,
+        }
+    }
+
+    fn into_rejected(self) -> RejectedParkedIdleCandidate {
         let Self {
             sandbox,
             factory,
@@ -235,7 +357,7 @@ impl ParkCandidate {
             ..
         } = self;
 
-        RejectedParkCandidate {
+        RejectedParkedIdleCandidate {
             payload: IdleDestroyPayload { sandbox, factory },
             budget_lease,
         }
@@ -244,7 +366,7 @@ impl ParkCandidate {
 
 /// A pool-owned sandbox waiting for reuse.
 ///
-/// Only `IdlePool` can create this from a [`ParkCandidate`]. This keeps
+/// Only `IdlePool` can create this from a [`ParkedIdleCandidate`]. This keeps
 /// rejected active-job parks out of the idle-owned lifecycle state.
 pub struct IdleEntry {
     sandbox: Box<dyn Sandbox>,
@@ -399,13 +521,13 @@ impl IdleDestroyJob {
 ///
 /// The lease belongs back to the active job so completion accounting can stay
 /// reserved until physical destroy and provider completion finish.
-#[must_use = "rejected park candidates must be destroyed while their lease stays active"]
-pub struct RejectedParkCandidate {
+#[must_use = "rejected parked idle candidates must be destroyed while their lease stays active"]
+pub struct RejectedParkedIdleCandidate {
     payload: IdleDestroyPayload,
     budget_lease: BudgetLease,
 }
 
-impl RejectedParkCandidate {
+impl RejectedParkedIdleCandidate {
     pub(crate) fn into_active_destroy_parts(self) -> (IdleDestroyPayload, BudgetLease) {
         let Self {
             payload,
@@ -537,14 +659,14 @@ impl IdlePool {
     /// for this session if one existed (caller must destroy it).
     ///
     /// Returns `Rejected(candidate)` if parking is closed/soft-draining or at capacity.
-    pub fn park(&mut self, candidate: ParkCandidate) -> ParkResult {
+    pub fn park(&mut self, candidate: ParkedIdleCandidate) -> ParkResult {
         self.park_at(candidate, Instant::now(), self.config.default_timeout)
     }
 
     #[cfg(test)]
     pub fn park_at_for_test(
         &mut self,
-        candidate: ParkCandidate,
+        candidate: ParkedIdleCandidate,
         parked_at: Instant,
         idle_timeout: Duration,
     ) -> ParkResult {
@@ -553,7 +675,7 @@ impl IdlePool {
 
     fn park_at(
         &mut self,
-        candidate: ParkCandidate,
+        candidate: ParkedIdleCandidate,
         parked_at: Instant,
         idle_timeout: Duration,
     ) -> ParkResult {
@@ -716,7 +838,7 @@ pub enum ParkResult {
     /// Successfully parked; the returned job destroys the replaced idle VM.
     Replaced(IdleDestroyJob),
     /// Parking is closed/soft-draining or at capacity; the entry could not be parked.
-    Rejected(RejectedParkCandidate),
+    Rejected(RejectedParkedIdleCandidate),
 }
 
 #[cfg(test)]
@@ -727,19 +849,23 @@ mod tests {
 
     use crate::resource_budget::ResourceBudget;
 
-    use sandbox_mock::{MockSandbox, MockSandboxFactory};
+    use sandbox::{ResourceLimits, SandboxConfig};
+    use sandbox_mock::{MockSandbox, MockSandboxFactory, MockSandboxOverrides};
 
     fn make_budget_lease(vcpu: u32, memory_mb: u32) -> BudgetLease {
         let budget = Arc::new(ResourceBudget::new(1, 1, 1.0, 0));
         ResourceBudget::try_reserve_lease(&budget, vcpu, memory_mb).unwrap()
     }
 
-    fn make_candidate_for(session_id: &str, vcpu: u32, memory_mb: u32) -> ParkCandidate {
+    fn make_candidate_for(session_id: &str, vcpu: u32, memory_mb: u32) -> ParkedIdleCandidate {
         make_candidate_for_with_lease(session_id, make_budget_lease(vcpu, memory_mb))
     }
 
-    fn make_candidate_for_with_lease(session_id: &str, budget_lease: BudgetLease) -> ParkCandidate {
-        ParkCandidate::from_parked_parts(ParkCandidateParts {
+    fn make_candidate_for_with_lease(
+        session_id: &str,
+        budget_lease: BudgetLease,
+    ) -> ParkedIdleCandidate {
+        ParkedIdleCandidate::synthetic_for_test(SyntheticParkedIdleCandidateParts {
             sandbox: Box::new(MockSandbox::new("test")),
             factory: Arc::new(Box::new(MockSandboxFactory::new()) as Box<dyn SandboxFactory>),
             session_id: session_id.into(),
@@ -754,7 +880,7 @@ mod tests {
     fn park_at(
         pool: &mut IdlePool,
         session_id: &str,
-        candidate: ParkCandidate,
+        candidate: ParkedIdleCandidate,
         parked_at: Instant,
         idle_timeout: Duration,
     ) -> ParkResult {
@@ -767,6 +893,104 @@ mod tests {
             default_timeout: Duration::from_secs(300),
             max_idle,
         }
+    }
+
+    async fn make_idle_park_request(
+        overrides: Arc<MockSandboxOverrides>,
+        session_id: &str,
+        budget_lease: BudgetLease,
+    ) -> IdleParkRequest {
+        let sandbox_id = SandboxId::new_v4();
+        let factory: Arc<Box<dyn SandboxFactory>> =
+            Arc::new(Box::new(MockSandboxFactory::with_overrides(overrides)));
+        let sandbox = factory
+            .create(SandboxConfig {
+                id: sandbox_id,
+                resources: ResourceLimits {
+                    cpu_count: budget_lease.vcpu(),
+                    memory_mb: budget_lease.memory_mb(),
+                },
+            })
+            .await
+            .expect("create sandbox");
+        IdleParkRequest::new(
+            sandbox,
+            factory,
+            session_id.into(),
+            sandbox_id,
+            "vm0/default".into(),
+            budget_lease,
+            "10.0.0.1".into(),
+            StorageFingerprints::default(),
+        )
+    }
+
+    #[tokio::test]
+    async fn idle_park_request_success_returns_parked_candidate() {
+        let overrides = Arc::new(MockSandboxOverrides::new());
+        let request = make_idle_park_request(
+            Arc::clone(&overrides),
+            "session-1",
+            make_budget_lease(2, 2048),
+        )
+        .await;
+
+        let candidate = match request.park_for_idle().await {
+            Ok(candidate) => candidate,
+            Err(_) => panic!("park should succeed"),
+        };
+
+        assert_eq!(overrides.park_call_count(), 1);
+        assert_eq!(candidate.session_id(), "session-1");
+    }
+
+    #[tokio::test]
+    async fn idle_park_request_error_returns_owned_failure_parts() {
+        let overrides = Arc::new(MockSandboxOverrides::new());
+        overrides.push_park_result(Err(sandbox::SandboxError::IdleTransition {
+            transition: sandbox::SandboxIdleTransition::Park,
+            message: "simulated park error".into(),
+        }));
+        let request = make_idle_park_request(
+            Arc::clone(&overrides),
+            "session-1",
+            make_budget_lease(2, 2048),
+        )
+        .await;
+
+        let failure = match request.park_for_idle().await {
+            Ok(_) => panic!("park should fail"),
+            Err(failure) => failure,
+        };
+        let failure = failure.into_active_parts();
+
+        assert_eq!(overrides.park_call_count(), 1);
+        assert!(failure.error.contains("simulated park error"));
+        assert_eq!(failure.active.budget_lease.vcpu(), 2);
+        assert_eq!(failure.active.budget_lease.memory_mb(), 2048);
+    }
+
+    #[tokio::test]
+    async fn idle_park_request_panic_returns_owned_failure_parts() {
+        let overrides = Arc::new(MockSandboxOverrides::new());
+        overrides.push_park_panic("simulated park panic");
+        let request = make_idle_park_request(
+            Arc::clone(&overrides),
+            "session-1",
+            make_budget_lease(2, 2048),
+        )
+        .await;
+
+        let failure = match request.park_for_idle().await {
+            Ok(_) => panic!("park should panic"),
+            Err(failure) => failure,
+        };
+        let failure = failure.into_active_parts();
+
+        assert_eq!(overrides.park_call_count(), 1);
+        assert_eq!(failure.error, "sandbox park panicked");
+        assert_eq!(failure.active.budget_lease.vcpu(), 2);
+        assert_eq!(failure.active.budget_lease.memory_mb(), 2048);
     }
 
     #[test]
@@ -842,7 +1066,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn rejected_park_candidate_returns_active_owned_lease() {
+    async fn rejected_parked_idle_candidate_returns_active_owned_lease() {
         let mut pool = IdlePool::new(pool_config(1));
         let _ = pool.park(make_candidate_for("existing", 2, 2048));
 
@@ -851,7 +1075,7 @@ mod tests {
         let result = pool.park(make_candidate_for_with_lease("rejected", rejected_lease));
 
         let ParkResult::Rejected(rejected) = result else {
-            panic!("expected rejected park candidate");
+            panic!("expected rejected parked idle candidate");
         };
         assert_eq!(
             rejected_budget.allocated().2,

--- a/crates/runner/src/idle_pool.rs
+++ b/crates/runner/src/idle_pool.rs
@@ -152,14 +152,19 @@ impl Default for ParkingGate {
 /// ownership.
 #[must_use = "idle park requests own active sandbox and budget; call park_for_idle"]
 pub(crate) struct IdleParkRequest {
-    sandbox: Box<dyn Sandbox>,
-    factory: Arc<Box<dyn SandboxFactory>>,
-    session_id: String,
-    sandbox_id: SandboxId,
-    profile_name: String,
-    budget_lease: BudgetLease,
-    source_ip: String,
-    storage_fingerprints: StorageFingerprints,
+    parts: IdleParkRequestParts,
+}
+
+#[must_use = "idle park request parts own active sandbox and budget"]
+pub(crate) struct IdleParkRequestParts {
+    pub(crate) sandbox: Box<dyn Sandbox>,
+    pub(crate) factory: Arc<Box<dyn SandboxFactory>>,
+    pub(crate) session_id: String,
+    pub(crate) sandbox_id: SandboxId,
+    pub(crate) profile_name: String,
+    pub(crate) budget_lease: BudgetLease,
+    pub(crate) source_ip: String,
+    pub(crate) storage_fingerprints: StorageFingerprints,
 }
 
 /// Active-owned sandbox after `Sandbox::park()` succeeds, before idle-pool
@@ -218,19 +223,13 @@ pub(crate) struct IdleParkFailureParts {
 }
 
 impl IdleParkRequest {
-    #[allow(clippy::too_many_arguments)]
-    pub(crate) fn new(
-        sandbox: Box<dyn Sandbox>,
-        factory: Arc<Box<dyn SandboxFactory>>,
-        session_id: String,
-        sandbox_id: SandboxId,
-        profile_name: String,
-        budget_lease: BudgetLease,
-        source_ip: String,
-        storage_fingerprints: StorageFingerprints,
-    ) -> Self {
-        Self {
-            sandbox,
+    pub(crate) fn new(parts: IdleParkRequestParts) -> Self {
+        Self { parts }
+    }
+
+    pub(crate) async fn park_for_idle(self) -> Result<ParkedIdleCandidate, IdleParkFailure> {
+        let IdleParkRequestParts {
+            mut sandbox,
             factory,
             session_id,
             sandbox_id,
@@ -238,32 +237,31 @@ impl IdleParkRequest {
             budget_lease,
             source_ip,
             storage_fingerprints,
-        }
-    }
+        } = self.parts;
 
-    pub(crate) async fn park_for_idle(mut self) -> Result<ParkedIdleCandidate, IdleParkFailure> {
-        match AssertUnwindSafe(self.sandbox.park()).catch_unwind().await {
+        match AssertUnwindSafe(sandbox.park()).catch_unwind().await {
             Ok(Ok(())) => Ok(ParkedIdleCandidate {
-                sandbox: self.sandbox,
-                factory: self.factory,
-                session_id: self.session_id,
-                sandbox_id: self.sandbox_id,
-                profile_name: self.profile_name,
-                budget_lease: self.budget_lease,
-                source_ip: self.source_ip,
-                storage_fingerprints: self.storage_fingerprints,
+                sandbox,
+                factory,
+                session_id,
+                sandbox_id,
+                profile_name,
+                budget_lease,
+                source_ip,
+                storage_fingerprints,
             }),
-            Ok(Err(e)) => Err(self.into_failure(e.to_string())),
-            Err(_) => Err(self.into_failure("sandbox park panicked".into())),
-        }
-    }
-
-    fn into_failure(self, error: String) -> IdleParkFailure {
-        IdleParkFailure {
-            sandbox: self.sandbox,
-            factory: self.factory,
-            budget_lease: self.budget_lease,
-            error,
+            Ok(Err(e)) => Err(IdleParkFailure {
+                sandbox,
+                factory,
+                budget_lease,
+                error: e.to_string(),
+            }),
+            Err(_) => Err(IdleParkFailure {
+                sandbox,
+                factory,
+                budget_lease,
+                error: "sandbox park panicked".into(),
+            }),
         }
     }
 }
@@ -917,16 +915,16 @@ mod tests {
             })
             .await
             .expect("create sandbox");
-        IdleParkRequest::new(
+        IdleParkRequest::new(IdleParkRequestParts {
             sandbox,
             factory,
-            session_id.into(),
+            session_id: session_id.into(),
             sandbox_id,
-            "vm0/default".into(),
+            profile_name: "vm0/default".into(),
             budget_lease,
-            "10.0.0.1".into(),
-            StorageFingerprints::default(),
-        )
+            source_ip: "10.0.0.1".into(),
+            storage_fingerprints: StorageFingerprints::default(),
+        })
     }
 
     #[tokio::test]
@@ -980,16 +978,16 @@ mod tests {
             )]),
         };
         let expected_storage_fingerprints = storage_fingerprints.clone();
-        let request = IdleParkRequest::new(
+        let request = IdleParkRequest::new(IdleParkRequestParts {
             sandbox,
             factory,
-            session_id.into(),
+            session_id: session_id.into(),
             sandbox_id,
-            profile_name.into(),
+            profile_name: profile_name.into(),
             budget_lease,
-            source_ip.into(),
+            source_ip: source_ip.into(),
             storage_fingerprints,
-        );
+        });
 
         let candidate = match request.park_for_idle().await {
             Ok(candidate) => candidate,

--- a/crates/runner/src/idle_pool.rs
+++ b/crates/runner/src/idle_pool.rs
@@ -150,6 +150,7 @@ impl Default for ParkingGate {
 
 /// One-shot request to transition an active sandbox into same-session idle
 /// ownership.
+#[must_use = "idle park requests own active sandbox and budget; call park_for_idle"]
 pub(crate) struct IdleParkRequest {
     sandbox: Box<dyn Sandbox>,
     factory: Arc<Box<dyn SandboxFactory>>,
@@ -166,6 +167,7 @@ pub(crate) struct IdleParkRequest {
 ///
 /// This state proves only same-session idle park. It does not imply clean
 /// cross-run reuse, snapshot readiness, or any broader VM correctness.
+#[must_use = "parked idle candidates must be accepted by the idle pool or explicitly destroyed"]
 pub struct ParkedIdleCandidate {
     sandbox: Box<dyn Sandbox>,
     factory: Arc<Box<dyn SandboxFactory>>,
@@ -202,12 +204,14 @@ pub(crate) struct IdleParkFailure {
     error: String,
 }
 
+#[must_use = "active idle-park parts still own a sandbox and budget lease"]
 pub(crate) struct IdleParkActiveParts {
     pub(crate) sandbox: Box<dyn Sandbox>,
     pub(crate) factory: Arc<Box<dyn SandboxFactory>>,
     pub(crate) budget_lease: BudgetLease,
 }
 
+#[must_use = "idle park failure parts must be logged and cleaned up"]
 pub(crate) struct IdleParkFailureParts {
     pub(crate) active: IdleParkActiveParts,
     pub(crate) error: String,
@@ -305,7 +309,7 @@ impl ParkedIdleCandidate {
     }
 
     #[cfg(test)]
-    pub fn sandbox_id(&self) -> SandboxId {
+    pub(crate) fn sandbox_id(&self) -> SandboxId {
         self.sandbox_id
     }
 


### PR DESCRIPTION
## Summary
- replace raw idle-pool candidate construction with an IdleParkRequest -> ParkedIdleCandidate ownership transition
- return owned active resources through IdleParkFailure on park error/panic so destroy and budget accounting stay explicit
- migrate idle-pool seeding tests to explicit synthetic parked candidates

Closes #13389

## Tests
- cargo test --manifest-path crates/Cargo.toml -p runner
- cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets -- -D warnings
- pre-commit crates cargo-fmt/cargo-doc/cargo-clippy via lefthook