### PR TITLE
feat: enable private agents by default

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-skills.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-skills.ts
@@ -13,9 +13,10 @@ import {
 } from "@vm0/db/schema/agent-compose";
 import { storages, storageVersions } from "@vm0/db/schema/storage";
 import { userConnectors } from "@vm0/db/schema/user-connector";
+import { userFeatureSwitches } from "@vm0/db/schema/user-feature-switches";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
 import { zeroSkills } from "@vm0/db/schema/zero-skill";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 
 import type { TestContext } from "../../../../__tests__/test-helpers";
 import { writeDb$ } from "../../../external/db";
@@ -50,6 +51,15 @@ export const deleteSkillsForFixture$ = command(
     await db
       .delete(agentComposes)
       .where(eq(agentComposes.orgId, fixture.orgId));
+    signal.throwIfAborted();
+    await db
+      .delete(userFeatureSwitches)
+      .where(
+        and(
+          eq(userFeatureSwitches.orgId, fixture.orgId),
+          eq(userFeatureSwitches.userId, fixture.userId),
+        ),
+      );
     signal.throwIfAborted();
   },
 );

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-agents-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-agents-create.test.ts
@@ -2,11 +2,13 @@ import { randomUUID } from "node:crypto";
 
 import { zeroAgentsMainContract } from "@vm0/api-contracts/contracts/zero-agents";
 import { getInstructionsStorageName } from "@vm0/core/storage-names";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import {
   agentComposes,
   agentComposeVersions,
 } from "@vm0/db/schema/agent-compose";
 import { storages } from "@vm0/db/schema/storage";
+import { userFeatureSwitches } from "@vm0/db/schema/user-feature-switches";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
 import { createStore } from "ccstate";
 import { and, count, eq } from "drizzle-orm";
@@ -39,6 +41,18 @@ function authHeaders() {
 
 function agentsClient() {
   return setupApp({ context })(zeroAgentsMainContract);
+}
+
+async function setPrivateAgentsEnabled(
+  fixture: SkillsFixture,
+  enabled: boolean,
+): Promise<void> {
+  const writeDb = store.set(writeDb$);
+  await writeDb.insert(userFeatureSwitches).values({
+    orgId: fixture.orgId,
+    userId: fixture.userId,
+    switches: { [FeatureSwitchKey.PrivateAgents]: enabled },
+  });
 }
 
 function currentSecond(): number {
@@ -261,6 +275,7 @@ describe("POST /api/zero/agents", () => {
     const fixture = await track(
       store.set(seedSkillsFixture$, undefined, context.signal),
     );
+    await setPrivateAgentsEnabled(fixture, false);
     mocks.clerk.session(fixture.userId, fixture.orgId);
 
     const response = await accept(

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-agents-update.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-agents-update.test.ts
@@ -4,7 +4,9 @@ import {
   zeroAgentInstructionsContract,
   zeroAgentsByIdContract,
 } from "@vm0/api-contracts/contracts/zero-agents";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { agentComposes } from "@vm0/db/schema/agent-compose";
+import { userFeatureSwitches } from "@vm0/db/schema/user-feature-switches";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
 import { createStore } from "ccstate";
 import { eq } from "drizzle-orm";
@@ -43,6 +45,18 @@ function agentsClient() {
 
 function instructionsClient() {
   return setupApp({ context })(zeroAgentInstructionsContract);
+}
+
+async function setPrivateAgentsEnabled(
+  fixture: SkillsFixture,
+  enabled: boolean,
+): Promise<void> {
+  const writeDb = store.set(writeDb$);
+  await writeDb.insert(userFeatureSwitches).values({
+    orgId: fixture.orgId,
+    userId: fixture.userId,
+    switches: { [FeatureSwitchKey.PrivateAgents]: enabled },
+  });
 }
 
 function s3CommandInput(command: unknown): Record<string, unknown> {
@@ -303,6 +317,7 @@ describe("PUT /api/zero/agents/:id", () => {
     const fixture = await track(
       store.set(seedSkillsFixture$, undefined, context.signal),
     );
+    await setPrivateAgentsEnabled(fixture, false);
     const agent = await store.set(
       seedAgentForInstructions$,
       {
@@ -618,6 +633,7 @@ describe("PATCH /api/zero/agents/:id", () => {
     const fixture = await track(
       store.set(seedSkillsFixture$, undefined, context.signal),
     );
+    await setPrivateAgentsEnabled(fixture, false);
     const agent = await store.set(
       seedAgentForInstructions$,
       {

--- a/turbo/apps/web/app/api/zero/agents/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/agents/__tests__/route.test.ts
@@ -160,6 +160,12 @@ async function enablePrivateAgentsFor(userContext: UserContext) {
   });
 }
 
+async function disablePrivateAgentsFor(userContext: UserContext) {
+  await seedUserFeatureSwitches(userContext.orgId, userContext.userId, {
+    [FeatureSwitchKey.PrivateAgents]: false,
+  });
+}
+
 function getAgentInstructions(name: string, token: string) {
   return getInstructions(
     createTestRequest(
@@ -324,6 +330,8 @@ describe("Zero Agents API", () => {
     });
 
     it("should reject private agent creation when the feature is disabled", async () => {
+      await disablePrivateAgentsFor(user);
+
       const response = await postAgent(
         { displayName: "Private Agent", visibility: "private" },
         testCliToken,

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -9,6 +9,7 @@ import {
 describe("isFeatureEnabled", () => {
   it("should return true for globally enabled switch", () => {
     expect(isFeatureEnabled(FeatureSwitchKey.Dummy, {})).toBe(true);
+    expect(isFeatureEnabled(FeatureSwitchKey.PrivateAgents, {})).toBe(true);
   });
 
   it("should return true for globally enabled switch even with context", () => {
@@ -101,7 +102,7 @@ describe("getAllFeatureStates", () => {
     const states = getAllFeatureStates();
     // Globally enabled switches should be true
     expect(states[FeatureSwitchKey.Dummy]).toBe(true);
-    expect(states[FeatureSwitchKey.Dummy]).toBe(true);
+    expect(states[FeatureSwitchKey.PrivateAgents]).toBe(true);
   });
 
   it("should enable switches when orgId matches enabledOrgIdHashes", () => {

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -345,8 +345,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
       "Enable private agents. Private agents are visible only to their owner, " +
       "are excluded from the workspace public-agent limit, and can only be " +
       "managed or run by their owner.",
-    enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+    enabled: true,
   },
   [FeatureSwitchKey.HostedSites]: {
     maintainer: "lancy@vm0.ai",


### PR DESCRIPTION
## Summary
- Enable PrivateAgents globally by default.
- Keep disabled-private-agent route coverage by explicitly seeding false user overrides.

## Checks
- pnpm format
- pnpm turbo run lint
- pnpm check-types
- pnpm vitest
- pnpm knip