### PR TITLE
refactor: gate connector auth methods

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-search.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-search.test.ts
@@ -249,7 +249,7 @@ describe("GET /api/zero/connectors/search", () => {
     expect(localBrowser?.authMethods).toStrictEqual(["api"]);
   });
 
-  it("shows feature-flagged connector with api-token even when flag is disabled", async () => {
+  it("shows ungated api-token while hiding feature-gated oauth", async () => {
     mocks.clerk.session(`user_${randomUUID()}`, `org_${randomUUID()}`);
 
     const client = setupApp({ context })(zeroConnectorsSearchContract);
@@ -287,7 +287,7 @@ describe("GET /api/zero/connectors/search", () => {
     expect(computer).toBeUndefined();
   });
 
-  it("includes connectors without feature flags", async () => {
+  it("includes connectors with at least one ungated auth method", async () => {
     mocks.clerk.session(`user_${randomUUID()}`, `org_${randomUUID()}`);
 
     const client = setupApp({ context })(zeroConnectorsSearchContract);
@@ -302,7 +302,9 @@ describe("GET /api/zero/connectors/search", () => {
     const unflaggedTypes = (
       Object.keys(CONNECTOR_TYPES) as ConnectorType[]
     ).filter((type) => {
-      return !CONNECTOR_TYPES[type].featureFlag;
+      return Object.values(CONNECTOR_TYPES[type].authMethods).some((method) => {
+        return !method.featureFlag;
+      });
     });
     expect(unflaggedTypes.length).toBeGreaterThan(0);
 
@@ -333,7 +335,7 @@ describe("GET /api/zero/connectors/search", () => {
     expect(openai?.authMethods).toStrictEqual(["api-token"]);
   });
 
-  it("shows zapier with api-token even when ZapierConnector flag is disabled", async () => {
+  it("hides zapier when its api-token auth method is feature-gated", async () => {
     mocks.clerk.session(`user_${randomUUID()}`, `org_${randomUUID()}`);
 
     const client = setupApp({ context })(zeroConnectorsSearchContract);
@@ -348,8 +350,7 @@ describe("GET /api/zero/connectors/search", () => {
     const zapier = response.body.connectors.find((c) => {
       return c.id === "zapier";
     });
-    expect(zapier).toBeDefined();
-    expect(zapier?.authMethods).toContain("api-token");
+    expect(zapier).toBeUndefined();
   });
 
   it("accepts a ZERO_TOKEN carrying the connector:read capability", async () => {

--- a/turbo/apps/api/src/signals/routes/zero-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/zero-connectors.ts
@@ -368,6 +368,7 @@ const getComputerConnectorInner$ = computed(async (get) => {
       orgId: auth.orgId,
       userId: auth.userId,
       type: "computer",
+      includeHiddenStoredConnector: true,
     }),
   );
   if (!connector) {

--- a/turbo/apps/api/src/signals/services/__tests__/zero-connector-data.service.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/zero-connector-data.service.test.ts
@@ -1,12 +1,14 @@
 import { randomUUID } from "node:crypto";
 import { describe, expect, it } from "vitest";
 import { createStore } from "ccstate";
+import { connectors } from "@vm0/db/schema/connector";
 import { secrets } from "@vm0/db/schema/secret";
 import { userFeatureSwitches } from "@vm0/db/schema/user-feature-switches";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { mockOptionalEnv } from "../../../lib/env";
 import { writeDb$ } from "../../external/db";
 import {
+  zeroConnectorByType,
   zeroConnectorList,
   zeroConnectorSearch,
 } from "../zero-connector-data.service";
@@ -65,22 +67,65 @@ describe("zeroConnectorList", () => {
     expect(list.configuredTypes).toContain("computer");
     expect(list.configuredTypes).toContain("amplitude");
   });
+
+  it("keeps a stored oauth connector visible when another auth method is ungated", async () => {
+    const orgId = `org_${randomUUID()}`;
+    const userId = `user_${randomUUID()}`;
+
+    await writeDb.insert(connectors).values({
+      orgId,
+      userId,
+      type: "neon",
+      authMethod: "oauth",
+    });
+    await writeDb.insert(secrets).values({
+      orgId,
+      userId,
+      name: "NEON_TOKEN",
+      encryptedValue: "encrypted_neon_token",
+      type: "user",
+    });
+
+    const connector = await store.get(
+      zeroConnectorByType({ orgId, userId, type: "neon" }),
+    );
+
+    expect(connector?.authMethod).toBe("oauth");
+    expect(connector?.id).not.toBeNull();
+  });
+
+  it("hides a stored connector when all auth methods are feature-gated", async () => {
+    const orgId = `org_${randomUUID()}`;
+    const userId = `user_${randomUUID()}`;
+
+    await writeDb.insert(connectors).values({
+      orgId,
+      userId,
+      type: "google-ads",
+      authMethod: "oauth",
+    });
+
+    const connector = await store.get(
+      zeroConnectorByType({ orgId, userId, type: "google-ads" }),
+    );
+
+    expect(connector).toBeNull();
+  });
 });
 
 describe("zeroConnectorSearch", () => {
-  it("shows feature-flagged api-token connectors even when the flag is disabled", async () => {
+  it("hides feature-flagged api-token connectors when the flag is disabled", async () => {
     const orgId = `org_${randomUUID()}`;
     const userId = `user_${randomUUID()}`;
 
     const connectors = await store.get(
-      zeroConnectorSearch({ orgId, userId, keyword: undefined }),
+      zeroConnectorSearch({ orgId, userId, keyword: "zapier" }),
     );
 
     const zapier = connectors.find((connector) => {
       return connector.id === "zapier";
     });
-    expect(zapier).toBeDefined();
-    expect(zapier?.authMethods).toStrictEqual(["api-token"]);
+    expect(zapier).toBeUndefined();
   });
 
   it("shows feature-flagged api-token connectors when an override enables the flag", async () => {

--- a/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
@@ -369,6 +369,7 @@ export function zeroConnectorByType(args: {
   readonly orgId: string;
   readonly userId: string;
   readonly type: ConnectorType;
+  readonly includeHiddenStoredConnector?: boolean;
 }): Computed<Promise<ConnectorResponse | null>> {
   return computed(async (get): Promise<ConnectorResponse | null> => {
     const overrides = await get(
@@ -381,7 +382,10 @@ export function zeroConnectorByType(args: {
     });
     const storedConnector = await get(storedConnectorByType(args));
     if (storedConnector) {
-      if (storedConnectorTypeIsVisible(args.type, featureStates)) {
+      if (
+        args.includeHiddenStoredConnector ||
+        storedConnectorTypeIsVisible(args.type, featureStates)
+      ) {
         return storedConnector;
       }
     }

--- a/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
@@ -8,10 +8,12 @@ import type { ConnectorSearchAuthMethod } from "@vm0/api-contracts/contracts/zer
 import {
   deriveApiTokenConnectedTypes,
   getApiTokenFieldsByType,
+  getAvailableConnectorAuthMethods,
   getConfiguredConnectorTypes,
   getConnectorOAuthEnvKeys,
   getConnectorProvidedSecretNames,
   getScopeDiff,
+  isConnectorAuthMethodAvailable,
 } from "@vm0/connectors/connector-utils";
 import { PROVIDER_HANDLERS } from "@vm0/connectors/oauth-providers";
 import {
@@ -103,11 +105,11 @@ function storedConnectorTypeIsVisible(
   type: ConnectorType,
   featureStates: FeatureStates,
 ): boolean {
-  const config = CONNECTOR_TYPES[type];
-  if (!config.featureFlag || !config.strictFeatureFlag) {
-    return true;
-  }
-  return featureStates[config.featureFlag] ?? false;
+  return (
+    getAvailableConnectorAuthMethods(type, featureStates, {
+      apiAuthMethodPolicy: "include",
+    }).length > 0
+  );
 }
 
 function apiTokenConnectorTypes(args: {
@@ -211,6 +213,9 @@ export function zeroConnectorList(args: {
     const derivedConnectors: ConnectorResponse[] = derivedTypes
       .filter((type) => {
         return !dbTypes.has(type);
+      })
+      .filter((type) => {
+        return isConnectorAuthMethodAvailable(type, "api-token", featureStates);
       })
       .map((type) => {
         return {
@@ -374,12 +379,16 @@ export function zeroConnectorByType(args: {
       orgId: args.orgId,
       overrides,
     });
-    if (!storedConnectorTypeIsVisible(args.type, featureStates)) {
-      return null;
-    }
     const storedConnector = await get(storedConnectorByType(args));
     if (storedConnector) {
-      return storedConnector;
+      if (storedConnectorTypeIsVisible(args.type, featureStates)) {
+        return storedConnector;
+      }
+    }
+    if (
+      !isConnectorAuthMethodAvailable(args.type, "api-token", featureStates)
+    ) {
+      return null;
     }
     return get(apiTokenConnectorByType(args));
   });
@@ -1035,26 +1044,15 @@ export function zeroConnectorSearch(args: {
     const keyword = args.keyword?.toLowerCase();
     return (Object.keys(CONNECTOR_TYPES) as ConnectorType[]).flatMap((type) => {
       const config = CONNECTOR_TYPES[type];
-      const flag = config.featureFlag;
-      const flagEnabled = !flag || featureStates[flag];
-      const showOauth = flagEnabled && "oauth" in config.authMethods;
-      const showApiToken = "api-token" in config.authMethods;
-      const showApi = flagEnabled && "api" in config.authMethods;
+      const authMethods: ConnectorSearchAuthMethod[] =
+        getAvailableConnectorAuthMethods(type, featureStates, {
+          apiAuthMethodPolicy: "include",
+        });
 
-      if (!showOauth && !showApiToken && !showApi) {
+      if (authMethods.length === 0) {
         return [];
       }
 
-      const authMethods: ConnectorSearchAuthMethod[] = [];
-      if (showOauth) {
-        authMethods.push("oauth");
-      }
-      if (showApiToken) {
-        authMethods.push("api-token");
-      }
-      if (showApi) {
-        authMethods.push("api");
-      }
       const item = {
         id: type,
         label: config.label,

--- a/turbo/apps/cli/src/commands/zero/connector/__tests__/list.test.ts
+++ b/turbo/apps/cli/src/commands/zero/connector/__tests__/list.test.ts
@@ -249,7 +249,7 @@ describe("zero connector list command", () => {
     });
   });
 
-  describe("strictFeatureFlag filtering", () => {
+  describe("auth method feature flag filtering", () => {
     it("excludes zapier when ZapierConnector feature switch is disabled (default)", async () => {
       server.use(
         stubConnectors([connectedGithub]),
@@ -263,7 +263,7 @@ describe("zero connector list command", () => {
       expect(logCalls).not.toContain("zapier");
     });
 
-    it("includes connectors with api-token auth and no strictFeatureFlag even when their flag is disabled", async () => {
+    it("includes connectors with ungated api-token auth even when oauth is feature-gated", async () => {
       server.use(
         stubConnectors([connectedGithub]),
         stubAgent(AGENT_UUID, "test"),
@@ -273,7 +273,7 @@ describe("zero connector list command", () => {
       await listCommand.parseAsync(["node", "cli", "--agent", AGENT_UUID]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
-      // mercury has api-token auth and no strictFeatureFlag so it is always visible
+      // mercury has an ungated api-token auth method, so it is always visible.
       expect(logCalls).toContain("mercury");
     });
 

--- a/turbo/apps/cli/src/commands/zero/connector/__tests__/search.test.ts
+++ b/turbo/apps/cli/src/commands/zero/connector/__tests__/search.test.ts
@@ -356,7 +356,7 @@ describe("zero connector search command", () => {
     });
   });
 
-  describe("strictFeatureFlag filtering", () => {
+  describe("auth method feature flag filtering", () => {
     it("excludes zapier from search results when ZapierConnector feature switch is disabled (default)", async () => {
       server.use(
         stubConnectors([]),
@@ -382,7 +382,7 @@ describe("zero connector search command", () => {
       expect(output).not.toContain("zapier");
     });
 
-    it("includes connectors with api-token auth and no strictFeatureFlag even when their flag is disabled", async () => {
+    it("includes connectors with ungated api-token auth even when oauth is feature-gated", async () => {
       server.use(
         stubConnectors([]),
         stubAgent(AGENT_UUID, "test"),
@@ -402,7 +402,7 @@ describe("zero connector search command", () => {
       const types = dataRows.map((row) => {
         return row.split(/\s+/)[0];
       });
-      // mercury has api-token auth and no strictFeatureFlag so it is always visible
+      // mercury has an ungated api-token auth method, so it is always visible.
       expect(types).toContain("mercury");
     });
 

--- a/turbo/apps/cli/src/mocks/handlers/api-handlers.ts
+++ b/turbo/apps/cli/src/mocks/handlers/api-handlers.ts
@@ -8,8 +8,9 @@ function defaultAvailableConnectors() {
   return (Object.keys(CONNECTOR_TYPES) as ConnectorType[])
     .filter((type) => {
       const config = CONNECTOR_TYPES[type];
-      const hasApiToken = "api-token" in config.authMethods;
-      return !config.featureFlag || (hasApiToken && !config.strictFeatureFlag);
+      return Object.values(config.authMethods).some((method) => {
+        return !method.featureFlag;
+      });
     })
     .map((type) => {
       const config = CONNECTOR_TYPES[type];

--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-connectors.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-connectors.test.ts
@@ -128,7 +128,7 @@ describe("connectors", () => {
   });
 });
 
-describe("connectors — strictFeatureFlag", () => {
+describe("connectors — auth method feature flags", () => {
   it("hides zapier when ZapierConnector feature switch is disabled", async () => {
     detachedSetupPage({
       context,
@@ -162,7 +162,7 @@ describe("connectors — strictFeatureFlag", () => {
     expect(zapier?.availableAuthMethods).toContain("api-token");
   });
 
-  it("shows mercury (api-token, no strictFeatureFlag) even when its flag is disabled", async () => {
+  it("shows mercury because its api-token method is ungated", async () => {
     detachedSetupPage({
       context,
       path: "/",
@@ -174,7 +174,7 @@ describe("connectors — strictFeatureFlag", () => {
       return c.type === "mercury";
     });
 
-    // mercury has api-token auth and no strictFeatureFlag, so it is always visible
+    // mercury has an ungated api-token auth method, so it is always visible.
     expect(mercury).toBeDefined();
     expect(mercury?.availableAuthMethods).toContain("api-token");
   });

--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -3,11 +3,15 @@ import { toast } from "@vm0/ui/components/ui/sonner";
 import { accept } from "../../../lib/accept.ts";
 import {
   CONNECTOR_TYPES,
+  type ConnectorAuthMethodType,
   type ConnectorType,
   type ConnectorDisplayCategory,
 } from "@vm0/connectors/connectors";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
-import { hasRequiredScopes } from "@vm0/connectors/connector-utils";
+import {
+  getAvailableConnectorAuthMethods,
+  hasRequiredScopes,
+} from "@vm0/connectors/connector-utils";
 import {
   zeroRemoteAgentHostsContract,
   type RemoteAgentHost,
@@ -60,6 +64,10 @@ const LOCAL_BROWSER_WEB_MESSAGE_SOURCE = "vm0-local-browser-web";
 const LOCAL_BROWSER_EXTENSION_MESSAGE_SOURCE = "vm0-local-browser-extension";
 const LOCAL_BROWSER_EXTENSION_DETECT_TIMEOUT_MS = 1000;
 const LOCAL_BROWSER_EXTENSION_PAIR_TIMEOUT_MS = 10_000;
+const CONNECTOR_LIST_API_AUTH_METHOD_TYPES = [
+  REMOTE_AGENT_CONNECTOR_TYPE,
+  LOCAL_BROWSER_CONNECTOR_TYPE,
+] as const satisfies readonly ConnectorType[];
 
 type PostConnectOptions = {
   readonly showPermissionDialog?: boolean;
@@ -83,7 +91,7 @@ export interface ConnectorTypeWithStatus {
   connected: boolean;
   connector: ConnectorResponse | null;
   /** Auth methods available for this connector (considering feature flags). */
-  availableAuthMethods: string[];
+  availableAuthMethods: ConnectorAuthMethodType[];
   /** True if at least one agent references this connector (env mapping). */
   usedByAgent?: boolean;
   /** True if stored OAuth scopes don't cover all currently required scopes. */
@@ -207,35 +215,6 @@ function isHostBackedConnector(type: ConnectorType): boolean {
   return isRemoteAgentConnector(type) || isLocalBrowserConnector(type);
 }
 
-function isConnectorFlagEnabled(
-  type: ConnectorType,
-  features: Record<string, boolean> | null | undefined,
-): boolean {
-  const flag = CONNECTOR_TYPES[type].featureFlag;
-  return !flag || !!features?.[flag];
-}
-
-function getAvailableAuthMethodsForConnector(
-  type: ConnectorType,
-  flagEnabled: boolean,
-): string[] {
-  const config = CONNECTOR_TYPES[type];
-  const methods = config.authMethods;
-  const availableAuthMethods: string[] = [];
-
-  if (flagEnabled && "oauth" in methods) {
-    availableAuthMethods.push("oauth");
-  }
-  if ("api-token" in methods && (flagEnabled || !config.strictFeatureFlag)) {
-    availableAuthMethods.push("api-token");
-  }
-  if (isHostBackedConnector(type) && flagEnabled && "api" in methods) {
-    availableAuthMethods.push("api");
-  }
-
-  return availableAuthMethods;
-}
-
 function buildConnectorTypeStatus(params: {
   readonly type: ConnectorType;
   readonly connector: ConnectorResponse | null;
@@ -244,20 +223,29 @@ function buildConnectorTypeStatus(params: {
   readonly localBrowserOnlineHosts: LocalBrowserHost[];
 }): ConnectorTypeWithStatus {
   const config = CONNECTOR_TYPES[params.type];
-  const flag = config.featureFlag;
   const isRemoteAgent = isRemoteAgentConnector(params.type);
   const isLocalBrowser = isLocalBrowserConnector(params.type);
-  const availableAuthMethods = getAvailableAuthMethodsForConnector(
+  const availableAuthMethods = getAvailableConnectorAuthMethods(
     params.type,
-    isConnectorFlagEnabled(params.type, params.features),
+    params.features,
+    {
+      apiAuthMethodPolicy: {
+        includeForTypes: CONNECTOR_LIST_API_AUTH_METHOD_TYPES,
+      },
+    },
   );
   const hasApiToken = availableAuthMethods.includes("api-token");
+  const hasFeatureFlaggedMethod = availableAuthMethods.some((authMethod) => {
+    return !!config.authMethods[authMethod]?.featureFlag;
+  });
   const connected = params.connector !== null;
 
   return {
     type: params.type,
     label:
-      flag && !hasApiToken && !isRemoteAgent && !isLocalBrowser
+      hasFeatureFlaggedMethod &&
+      !hasApiToken &&
+      !isHostBackedConnector(params.type)
         ? `[Experimental] ${config.label}`
         : config.label,
     helpText: config.helpText,
@@ -343,10 +331,11 @@ export const allConnectorTypes$ = computed(async (get) => {
   const items = (Object.keys(CONNECTOR_TYPES) as ConnectorType[])
     .filter((type) => {
       return (
-        getAvailableAuthMethodsForConnector(
-          type,
-          isConnectorFlagEnabled(type, features),
-        ).length > 0
+        getAvailableConnectorAuthMethods(type, features, {
+          apiAuthMethodPolicy: {
+            includeForTypes: CONNECTOR_LIST_API_AUTH_METHOD_TYPES,
+          },
+        }).length > 0
       );
     })
     .map((type) => {

--- a/turbo/apps/web/app/api/zero/connectors/search/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/connectors/search/__tests__/route.test.ts
@@ -113,7 +113,7 @@ describe("GET /api/zero/connectors/search", () => {
     expect(response.status).toBe(200);
     const data = await response.json();
 
-    // computer has a feature flag and only "api" auth (no api-token, no oauth)
+    // computer only has a feature-gated "api" auth method.
     // A random test user won't have the flag enabled, so it should be hidden
     const computer = data.connectors.find((c: { id: string }) => {
       return c.id === "computer";
@@ -121,19 +121,19 @@ describe("GET /api/zero/connectors/search", () => {
     expect(computer).toBeUndefined();
   });
 
-  it("should show feature-flagged connector with api-token even when flag is disabled", async () => {
+  it("should show ungated api-token while hiding feature-gated oauth", async () => {
     const response = await searchConnectors();
     expect(response.status).toBe(200);
     const data = await response.json();
 
-    // neon has a feature flag AND api-token auth method
+    // neon gates oauth but leaves api-token available.
     // Even with flag disabled, it should be visible with only api-token
     const neon = data.connectors.find((c: { id: string }) => {
       return c.id === "neon";
     });
     expect(neon).toBeDefined();
     expect(neon.authMethods).toContain("api-token");
-    // oauth should NOT be included since the feature flag is disabled
+    // oauth should NOT be included since its feature flag is disabled.
     expect(neon.authMethods).not.toContain("oauth");
   });
 
@@ -146,23 +146,24 @@ describe("GET /api/zero/connectors/search", () => {
     expect(response.status).toBe(200);
     const data = await response.json();
 
-    // computer has a feature flag (ComputerConnector) that is disabled
+    // computer only has a feature-gated auth method, and the flag is disabled.
     const computer = data.connectors.find((c: { id: string }) => {
       return c.id === "computer";
     });
     expect(computer).toBeUndefined();
   });
 
-  it("should include connectors without feature flags", async () => {
+  it("should include connectors with at least one ungated auth method", async () => {
     const response = await searchConnectors();
     expect(response.status).toBe(200);
     const data = await response.json();
 
-    // Find a connector without a feature flag (e.g., github)
     const unflaggedTypes = (
       Object.keys(CONNECTOR_TYPES) as ConnectorType[]
     ).filter((type) => {
-      return !CONNECTOR_TYPES[type].featureFlag;
+      return Object.values(CONNECTOR_TYPES[type].authMethods).some((method) => {
+        return !method.featureFlag;
+      });
     });
     expect(unflaggedTypes.length).toBeGreaterThan(0);
 
@@ -185,7 +186,7 @@ describe("GET /api/zero/connectors/search", () => {
     expect(openai.authMethods).toEqual(["api-token"]);
   });
 
-  it("shows zapier with api-token even when ZapierConnector flag is disabled", async () => {
+  it("hides zapier when its api-token auth method is feature-gated", async () => {
     const response = await searchConnectors();
     expect(response.status).toBe(200);
     const data = await response.json();
@@ -193,8 +194,7 @@ describe("GET /api/zero/connectors/search", () => {
     const zapier = data.connectors.find((c: { id: string }) => {
       return c.id === "zapier";
     });
-    expect(zapier).toBeDefined();
-    expect(zapier.authMethods).toContain("api-token");
+    expect(zapier).toBeUndefined();
   });
 
   it("accepts a ZERO_TOKEN carrying the connector:read capability", async () => {

--- a/turbo/apps/web/app/api/zero/connectors/search/route.ts
+++ b/turbo/apps/web/app/api/zero/connectors/search/route.ts
@@ -1,12 +1,10 @@
 import { createHandler, tsr } from "../../../../../src/lib/ts-rest-handler";
-import {
-  zeroConnectorsSearchContract,
-  ConnectorSearchAuthMethod,
-} from "@vm0/api-contracts/contracts/zero-connectors";
+import { zeroConnectorsSearchContract } from "@vm0/api-contracts/contracts/zero-connectors";
 import {
   type ConnectorType,
   CONNECTOR_TYPES,
 } from "@vm0/connectors/connectors";
+import { getAvailableConnectorAuthMethods } from "@vm0/connectors/connector-utils";
 import { getAllFeatureStates } from "@vm0/core/feature-switch";
 import { createErrorResponse } from "@vm0/api-contracts/contracts/errors";
 import { initServices } from "../../../../../src/lib/init-services";
@@ -43,21 +41,13 @@ const router = tsr.router(zeroConnectorsSearchContract, {
       Object.keys(CONNECTOR_TYPES) as ConnectorType[]
     ).flatMap((type) => {
       const config = CONNECTOR_TYPES[type];
-      const flag = config.featureFlag;
-      const flagEnabled = !flag || !!featureStates[flag];
-      // api-token is always available; oauth requires the per-connector flag.
-      const showOauth = flagEnabled && "oauth" in config.authMethods;
-      const showApiToken = "api-token" in config.authMethods;
+      const availableAuthMethods = getAvailableConnectorAuthMethods(
+        type,
+        featureStates,
+      );
 
-      // Hidden unless at least one auth method shows.
-      if (!showOauth && !showApiToken) return [];
-
-      const availableAuthMethods: ConnectorSearchAuthMethod[] = [];
-      if (showOauth) {
-        availableAuthMethods.push("oauth");
-      }
-      if (showApiToken) {
-        availableAuthMethods.push("api-token");
+      if (availableAuthMethods.length === 0) {
+        return [];
       }
 
       const item = {

--- a/turbo/packages/connectors/src/connector-utils.ts
+++ b/turbo/packages/connectors/src/connector-utils.ts
@@ -1,4 +1,5 @@
 import {
+  CONNECTOR_AUTH_METHOD_TYPES,
   CONNECTOR_TYPES,
   connectorTypeSchema,
   type ConnectorAuthMethodConfig,
@@ -8,6 +9,7 @@ import {
   type ConnectorSecretConfig,
   type ConnectorType,
 } from "./connectors";
+import type { FeatureSwitchKey } from "./feature-switch-key";
 
 /**
  * Get auth methods for a connector type
@@ -25,6 +27,77 @@ export function getConnectorDefaultAuthMethod(
   type: ConnectorType,
 ): ConnectorAuthMethodType | undefined {
   return CONNECTOR_TYPES[type].defaultAuthMethod;
+}
+
+export type ConnectorFeatureStates =
+  | Partial<Record<FeatureSwitchKey, boolean>>
+  | null
+  | undefined;
+
+export type ApiAuthMethodPolicy =
+  | "exclude"
+  | "include"
+  | { readonly includeForTypes: readonly ConnectorType[] };
+
+export interface AvailableConnectorAuthMethodsOptions {
+  readonly apiAuthMethodPolicy?: ApiAuthMethodPolicy;
+}
+
+export function isConnectorAuthMethodAvailable(
+  type: ConnectorType,
+  authMethod: ConnectorAuthMethodType,
+  featureStates: ConnectorFeatureStates,
+): boolean {
+  const method = CONNECTOR_TYPES[type].authMethods[authMethod];
+  if (!method) {
+    return false;
+  }
+  return !method.featureFlag || !!featureStates?.[method.featureFlag];
+}
+
+function shouldIncludeApiAuthMethod(
+  type: ConnectorType,
+  policy: ApiAuthMethodPolicy | undefined,
+): boolean {
+  if (policy === "include") {
+    return true;
+  }
+  if (!policy || policy === "exclude") {
+    return false;
+  }
+  return policy.includeForTypes.includes(type);
+}
+
+/**
+ * Return user-selectable connector connection flows for a surface.
+ *
+ * This describes configured connection flows, not persisted connected state.
+ */
+export function getAvailableConnectorAuthMethods(
+  type: ConnectorType,
+  featureStates: ConnectorFeatureStates,
+  options: AvailableConnectorAuthMethodsOptions = {},
+): ConnectorAuthMethodType[] {
+  const methods = CONNECTOR_TYPES[type].authMethods;
+  const apiAuthMethodPolicy = options.apiAuthMethodPolicy ?? "exclude";
+  const availableAuthMethods: ConnectorAuthMethodType[] = [];
+
+  for (const authMethod of CONNECTOR_AUTH_METHOD_TYPES) {
+    if (!methods[authMethod]) {
+      continue;
+    }
+    if (
+      authMethod === "api" &&
+      !shouldIncludeApiAuthMethod(type, apiAuthMethodPolicy)
+    ) {
+      continue;
+    }
+    if (isConnectorAuthMethodAvailable(type, authMethod, featureStates)) {
+      availableAuthMethods.push(authMethod);
+    }
+  }
+
+  return availableAuthMethods;
 }
 
 export type ConnectorEnvReader = (name: string) => string | undefined;
@@ -302,14 +375,15 @@ export function getConnectorEnvironmentMapping(
 }
 
 /**
- * Connector types eligible for agent compose: GA (no feature flag) or
- * feature-flagged with an api-token auth method. Feature flags gate OAuth;
- * api-token is always available.
+ * Connector types eligible for agent compose without runtime feature context:
+ * include connectors with at least one always-available connection flow.
  */
 export function getEligibleConnectorTypes(): string[] {
   return Object.entries(CONNECTOR_TYPES)
     .filter(([, config]) => {
-      return !config.featureFlag || "api-token" in config.authMethods;
+      return Object.values(config.authMethods).some((method) => {
+        return !method.featureFlag;
+      });
     })
     .map(([type]) => {
       return type;

--- a/turbo/packages/connectors/src/connectors.ts
+++ b/turbo/packages/connectors/src/connectors.ts
@@ -210,6 +210,8 @@ export interface ConnectorSecretConfig {
 export interface ConnectorAuthMethodConfig {
   label: string;
   helpText?: string;
+  /** When set, this auth method is only available while the feature is enabled. */
+  featureFlag?: FeatureSwitchKey;
   secrets: Record<string, ConnectorSecretConfig>;
 }
 
@@ -229,9 +231,25 @@ export interface ConnectorOAuthConfig {
  *   `connectors` (with scopes, external identity, token refresh metadata).
  * - `api-token` — user supplies an API token via the UI. No DB row:
  *   enablement is derived from the presence of required secrets/variables.
- * - `api` — legacy placeholder; no active consumers.
+ * - `api` — connector-specific first-party flow, not the generic OAuth or
+ *   user-entered API-token setup.
  */
 export type ConnectorAuthMethodType = "oauth" | "api-token" | "api";
+
+export const CONNECTOR_AUTH_METHOD_TYPES = [
+  "oauth",
+  "api-token",
+  "api",
+] as const satisfies readonly ConnectorAuthMethodType[];
+
+type MissingConnectorAuthMethodType = Exclude<
+  ConnectorAuthMethodType,
+  (typeof CONNECTOR_AUTH_METHOD_TYPES)[number]
+>;
+
+type AssertNever<T extends never> = T;
+export type ConnectorAuthMethodTypesCoverUnion =
+  AssertNever<MissingConnectorAuthMethodType>;
 
 export type ConnectorDisplayCategory =
   | "ai-general-models"
@@ -348,12 +366,6 @@ export interface ConnectorConfig {
   readonly label: string;
   readonly helpText: string;
   readonly category: ConnectorDisplayCategory;
-  readonly featureFlag?: FeatureSwitchKey;
-  /**
-   * When true, the featureFlag gates this connector even when it has api-token
-   * auth (overrides the default api-token exception).
-   */
-  readonly strictFeatureFlag?: boolean;
   readonly authMethods: Partial<
     Record<ConnectorAuthMethodType, ConnectorAuthMethodConfig>
   >;

--- a/turbo/packages/connectors/src/connectors/ahrefs.ts
+++ b/turbo/packages/connectors/src/connectors/ahrefs.ts
@@ -1,5 +1,5 @@
-import { FeatureSwitchKey } from "../feature-switch-key";
 import type { ConnectorConfig } from "../connectors";
+import { FeatureSwitchKey } from "../feature-switch-key";
 
 export const ahrefs = {
   ahrefs: {
@@ -8,11 +8,11 @@ export const ahrefs = {
     environmentMapping: {
       AHREFS_TOKEN: "$secrets.AHREFS_ACCESS_TOKEN",
     },
-    featureFlag: FeatureSwitchKey.AhrefsConnector,
     helpText:
       "Connect your Ahrefs account to access SEO data, backlink analysis, and keyword research",
     authMethods: {
       oauth: {
+        featureFlag: FeatureSwitchKey.AhrefsConnector,
         label: "OAuth",
         helpText: "Sign in with Ahrefs to grant access.",
         secrets: {

--- a/turbo/packages/connectors/src/connectors/canva.ts
+++ b/turbo/packages/connectors/src/connectors/canva.ts
@@ -1,5 +1,5 @@
-import { FeatureSwitchKey } from "../feature-switch-key";
 import type { ConnectorConfig } from "../connectors";
+import { FeatureSwitchKey } from "../feature-switch-key";
 
 export const canva = {
   canva: {
@@ -8,11 +8,11 @@ export const canva = {
     environmentMapping: {
       CANVA_TOKEN: "$secrets.CANVA_ACCESS_TOKEN",
     },
-    featureFlag: FeatureSwitchKey.CanvaConnector,
     helpText:
       "Connect your Canva account to access designs, assets, and projects",
     authMethods: {
       oauth: {
+        featureFlag: FeatureSwitchKey.CanvaConnector,
         label: "OAuth (Recommended)",
         helpText: "Sign in with Canva to grant access.",
         secrets: {

--- a/turbo/packages/connectors/src/connectors/close.ts
+++ b/turbo/packages/connectors/src/connectors/close.ts
@@ -1,5 +1,5 @@
-import { FeatureSwitchKey } from "../feature-switch-key";
 import type { ConnectorConfig } from "../connectors";
+import { FeatureSwitchKey } from "../feature-switch-key";
 
 export const close = {
   close: {
@@ -8,11 +8,11 @@ export const close = {
     environmentMapping: {
       CLOSE_TOKEN: "$secrets.CLOSE_ACCESS_TOKEN",
     },
-    featureFlag: FeatureSwitchKey.CloseConnector,
     helpText:
       "Connect your Close account to manage leads, contacts, and opportunities",
     authMethods: {
       oauth: {
+        featureFlag: FeatureSwitchKey.CloseConnector,
         label: "OAuth (Recommended)",
         helpText: "Sign in with Close to grant access.",
         secrets: {

--- a/turbo/packages/connectors/src/connectors/computer.ts
+++ b/turbo/packages/connectors/src/connectors/computer.ts
@@ -1,5 +1,5 @@
-import { FeatureSwitchKey } from "../feature-switch-key";
 import type { ConnectorConfig } from "../connectors";
+import { FeatureSwitchKey } from "../feature-switch-key";
 
 export const computer = {
   computer: {
@@ -10,11 +10,11 @@ export const computer = {
         "$secrets.COMPUTER_CONNECTOR_BRIDGE_TOKEN",
       COMPUTER_CONNECTOR_DOMAIN: "$secrets.COMPUTER_CONNECTOR_DOMAIN",
     },
-    featureFlag: FeatureSwitchKey.ComputerConnector,
     helpText:
       "Expose local services to remote sandboxes via authenticated ngrok tunnels",
     authMethods: {
       api: {
+        featureFlag: FeatureSwitchKey.ComputerConnector,
         label: "API",
         helpText: "Server-provisioned ngrok tunnel credentials.",
         secrets: {

--- a/turbo/packages/connectors/src/connectors/deel.ts
+++ b/turbo/packages/connectors/src/connectors/deel.ts
@@ -1,5 +1,5 @@
-import { FeatureSwitchKey } from "../feature-switch-key";
 import type { ConnectorConfig } from "../connectors";
+import { FeatureSwitchKey } from "../feature-switch-key";
 
 export const deel = {
   deel: {
@@ -8,11 +8,11 @@ export const deel = {
     environmentMapping: {
       DEEL_TOKEN: "$secrets.DEEL_ACCESS_TOKEN",
     },
-    featureFlag: FeatureSwitchKey.DeelConnector,
     helpText:
       "Connect your Deel account to access HR, payroll, and contractor data",
     authMethods: {
       oauth: {
+        featureFlag: FeatureSwitchKey.DeelConnector,
         label: "OAuth (Recommended)",
         helpText: "Sign in with Deel to grant access.",
         secrets: {

--- a/turbo/packages/connectors/src/connectors/docusign.ts
+++ b/turbo/packages/connectors/src/connectors/docusign.ts
@@ -1,5 +1,5 @@
-import { FeatureSwitchKey } from "../feature-switch-key";
 import type { ConnectorConfig } from "../connectors";
+import { FeatureSwitchKey } from "../feature-switch-key";
 
 export const docusign = {
   docusign: {
@@ -8,11 +8,11 @@ export const docusign = {
     environmentMapping: {
       DOCUSIGN_TOKEN: "$secrets.DOCUSIGN_ACCESS_TOKEN",
     },
-    featureFlag: FeatureSwitchKey.DocuSignConnector,
     helpText:
       "Connect your DocuSign account to send and manage electronic signatures",
     authMethods: {
       oauth: {
+        featureFlag: FeatureSwitchKey.DocuSignConnector,
         label: "OAuth (Recommended)",
         helpText: "Sign in with DocuSign to grant access.",
         secrets: {

--- a/turbo/packages/connectors/src/connectors/dropbox.ts
+++ b/turbo/packages/connectors/src/connectors/dropbox.ts
@@ -1,5 +1,5 @@
-import { FeatureSwitchKey } from "../feature-switch-key";
 import type { ConnectorConfig } from "../connectors";
+import { FeatureSwitchKey } from "../feature-switch-key";
 
 export const dropbox = {
   dropbox: {
@@ -8,10 +8,10 @@ export const dropbox = {
     environmentMapping: {
       DROPBOX_TOKEN: "$secrets.DROPBOX_ACCESS_TOKEN",
     },
-    featureFlag: FeatureSwitchKey.DropboxConnector,
     helpText: "Connect your Dropbox account to access and manage files",
     authMethods: {
       oauth: {
+        featureFlag: FeatureSwitchKey.DropboxConnector,
         label: "OAuth (Recommended)",
         helpText: "Sign in with Dropbox to grant access.",
         secrets: {

--- a/turbo/packages/connectors/src/connectors/figma.ts
+++ b/turbo/packages/connectors/src/connectors/figma.ts
@@ -1,5 +1,5 @@
-import { FeatureSwitchKey } from "../feature-switch-key";
 import type { ConnectorConfig } from "../connectors";
+import { FeatureSwitchKey } from "../feature-switch-key";
 
 export const figma = {
   figma: {
@@ -8,10 +8,10 @@ export const figma = {
     environmentMapping: {
       FIGMA_TOKEN: "$secrets.FIGMA_ACCESS_TOKEN",
     },
-    featureFlag: FeatureSwitchKey.FigmaConnector,
     helpText: "Connect your Figma account to access design files and projects",
     authMethods: {
       oauth: {
+        featureFlag: FeatureSwitchKey.FigmaConnector,
         label: "OAuth (Recommended)",
         helpText: "Sign in with Figma to grant access.",
         secrets: {

--- a/turbo/packages/connectors/src/connectors/freshdesk.ts
+++ b/turbo/packages/connectors/src/connectors/freshdesk.ts
@@ -1,4 +1,3 @@
-import { FeatureSwitchKey } from "../feature-switch-key";
 import type { ConnectorConfig } from "../connectors";
 
 export const freshdesk = {
@@ -10,7 +9,6 @@ export const freshdesk = {
       FRESHDESK_TOKEN: "$secrets.FRESHDESK_TOKEN",
       FRESHDESK_DOMAIN: "$vars.FRESHDESK_DOMAIN",
     },
-    featureFlag: FeatureSwitchKey.FreshdeskConnector,
     helpText:
       "Connect your Freshdesk account to manage support tickets, contacts, companies, agents, and knowledge base articles",
     authMethods: {

--- a/turbo/packages/connectors/src/connectors/garmin-connect.ts
+++ b/turbo/packages/connectors/src/connectors/garmin-connect.ts
@@ -1,5 +1,5 @@
-import { FeatureSwitchKey } from "../feature-switch-key";
 import type { ConnectorConfig } from "../connectors";
+import { FeatureSwitchKey } from "../feature-switch-key";
 
 export const garminConnect = {
   "garmin-connect": {
@@ -8,11 +8,11 @@ export const garminConnect = {
     environmentMapping: {
       GARMIN_CONNECT_TOKEN: "$secrets.GARMIN_CONNECT_ACCESS_TOKEN",
     },
-    featureFlag: FeatureSwitchKey.GarminConnectConnector,
     helpText:
       "Connect your Garmin Connect account to access wellness and activity data",
     authMethods: {
       oauth: {
+        featureFlag: FeatureSwitchKey.GarminConnectConnector,
         label: "OAuth (Recommended)",
         helpText: "Sign in with Garmin Connect to grant access.",
         secrets: {

--- a/turbo/packages/connectors/src/connectors/google-ads.ts
+++ b/turbo/packages/connectors/src/connectors/google-ads.ts
@@ -1,12 +1,11 @@
-import { FeatureSwitchKey } from "../feature-switch-key";
 import type { ConnectorConfig } from "../connectors";
+import { FeatureSwitchKey } from "../feature-switch-key";
 
 export const googleAds = {
   "google-ads": {
     label: "Google Ads",
     category: "marketing-content-growth",
     tags: ["ads", "advertising", "google ads", "campaigns", "gaql"],
-    featureFlag: FeatureSwitchKey.GoogleAdsConnector,
     environmentMapping: {
       GOOGLE_ADS_TOKEN: "$secrets.GOOGLE_ADS_ACCESS_TOKEN",
     },
@@ -14,6 +13,7 @@ export const googleAds = {
       "Connect your Google Ads account to manage campaigns, ad groups, and performance reports",
     authMethods: {
       oauth: {
+        featureFlag: FeatureSwitchKey.GoogleAdsConnector,
         label: "OAuth (Recommended)",
         helpText: "Sign in with Google to grant Google Ads access.",
         secrets: {

--- a/turbo/packages/connectors/src/connectors/local-browser.ts
+++ b/turbo/packages/connectors/src/connectors/local-browser.ts
@@ -6,12 +6,11 @@ export const localBrowser = {
     label: "Local Browser",
     category: "data-automation-infrastructure",
     environmentMapping: {},
-    featureFlag: FeatureSwitchKey.LocalBrowserUse,
-    strictFeatureFlag: true,
     helpText:
       "Connect a local browser extension so Zero can use user-authorized browser context and page controls",
     authMethods: {
       api: {
+        featureFlag: FeatureSwitchKey.LocalBrowserUse,
         label: "Browser Extension",
         helpText:
           "1. Install the Zero Local Browser extension\n2. Pair the extension with your Zero account\n3. Keep the extension connected, then return here and click **Connect** once it appears online",

--- a/turbo/packages/connectors/src/connectors/mailchimp.ts
+++ b/turbo/packages/connectors/src/connectors/mailchimp.ts
@@ -1,5 +1,5 @@
-import { FeatureSwitchKey } from "../feature-switch-key";
 import type { ConnectorConfig } from "../connectors";
+import { FeatureSwitchKey } from "../feature-switch-key";
 
 export const mailchimp = {
   mailchimp: {
@@ -8,11 +8,11 @@ export const mailchimp = {
     environmentMapping: {
       MAILCHIMP_TOKEN: "$secrets.MAILCHIMP_ACCESS_TOKEN",
     },
-    featureFlag: FeatureSwitchKey.MailchimpConnector,
     helpText:
       "Connect your Mailchimp account to manage audiences, campaigns, templates, and automations",
     authMethods: {
       oauth: {
+        featureFlag: FeatureSwitchKey.MailchimpConnector,
         label: "OAuth (Recommended)",
         helpText: "Sign in with Mailchimp to grant access.",
         secrets: {

--- a/turbo/packages/connectors/src/connectors/mercury.ts
+++ b/turbo/packages/connectors/src/connectors/mercury.ts
@@ -1,5 +1,5 @@
-import { FeatureSwitchKey } from "../feature-switch-key";
 import type { ConnectorConfig } from "../connectors";
+import { FeatureSwitchKey } from "../feature-switch-key";
 
 export const mercury = {
   mercury: {
@@ -8,11 +8,11 @@ export const mercury = {
     environmentMapping: {
       MERCURY_TOKEN: "$secrets.MERCURY_ACCESS_TOKEN",
     },
-    featureFlag: FeatureSwitchKey.MercuryConnector,
     helpText:
       "Connect your Mercury account to access banking and financial data",
     authMethods: {
       oauth: {
+        featureFlag: FeatureSwitchKey.MercuryConnector,
         label: "OAuth (Recommended)",
         helpText: "Sign in with Mercury to grant access.",
         secrets: {

--- a/turbo/packages/connectors/src/connectors/meta-ads.ts
+++ b/turbo/packages/connectors/src/connectors/meta-ads.ts
@@ -1,5 +1,5 @@
-import { FeatureSwitchKey } from "../feature-switch-key";
 import type { ConnectorConfig } from "../connectors";
+import { FeatureSwitchKey } from "../feature-switch-key";
 
 export const metaAds = {
   "meta-ads": {
@@ -8,11 +8,11 @@ export const metaAds = {
     environmentMapping: {
       META_ADS_TOKEN: "$secrets.META_ADS_ACCESS_TOKEN",
     },
-    featureFlag: FeatureSwitchKey.MetaAdsConnector,
     helpText:
       "Connect your Meta Ads Manager account to manage ad campaigns, audiences, and insights",
     authMethods: {
       oauth: {
+        featureFlag: FeatureSwitchKey.MetaAdsConnector,
         label: "OAuth (Recommended)",
         helpText: "Sign in with Facebook to grant access to Ads Manager.",
         secrets: {

--- a/turbo/packages/connectors/src/connectors/neon.ts
+++ b/turbo/packages/connectors/src/connectors/neon.ts
@@ -1,5 +1,5 @@
-import { FeatureSwitchKey } from "../feature-switch-key";
 import type { ConnectorConfig } from "../connectors";
+import { FeatureSwitchKey } from "../feature-switch-key";
 
 export const neon = {
   neon: {
@@ -8,11 +8,11 @@ export const neon = {
     environmentMapping: {
       NEON_TOKEN: "$secrets.NEON_ACCESS_TOKEN",
     },
-    featureFlag: FeatureSwitchKey.NeonConnector,
     helpText:
       "Connect your Neon account to manage serverless Postgres databases and projects",
     authMethods: {
       oauth: {
+        featureFlag: FeatureSwitchKey.NeonConnector,
         label: "OAuth (Recommended)",
         helpText: "Sign in with Neon to grant access.",
         secrets: {

--- a/turbo/packages/connectors/src/connectors/outlook-calendar.ts
+++ b/turbo/packages/connectors/src/connectors/outlook-calendar.ts
@@ -1,5 +1,5 @@
-import { FeatureSwitchKey } from "../feature-switch-key";
 import type { ConnectorConfig } from "../connectors";
+import { FeatureSwitchKey } from "../feature-switch-key";
 
 export const outlookCalendar = {
   "outlook-calendar": {
@@ -8,11 +8,11 @@ export const outlookCalendar = {
     environmentMapping: {
       OUTLOOK_CALENDAR_TOKEN: "$secrets.OUTLOOK_CALENDAR_ACCESS_TOKEN",
     },
-    featureFlag: FeatureSwitchKey.OutlookCalendarConnector,
     helpText:
       "Connect your Microsoft account to access and manage Outlook calendar events",
     authMethods: {
       oauth: {
+        featureFlag: FeatureSwitchKey.OutlookCalendarConnector,
         label: "OAuth (Recommended)",
         helpText: "Sign in with Microsoft to grant Outlook Calendar access.",
         secrets: {

--- a/turbo/packages/connectors/src/connectors/outlook-mail.ts
+++ b/turbo/packages/connectors/src/connectors/outlook-mail.ts
@@ -1,5 +1,5 @@
-import { FeatureSwitchKey } from "../feature-switch-key";
 import type { ConnectorConfig } from "../connectors";
+import { FeatureSwitchKey } from "../feature-switch-key";
 
 export const outlookMail = {
   "outlook-mail": {
@@ -8,10 +8,10 @@ export const outlookMail = {
     environmentMapping: {
       OUTLOOK_MAIL_TOKEN: "$secrets.OUTLOOK_MAIL_ACCESS_TOKEN",
     },
-    featureFlag: FeatureSwitchKey.OutlookMailConnector,
     helpText: "Connect your Microsoft Outlook account to send and read emails",
     authMethods: {
       oauth: {
+        featureFlag: FeatureSwitchKey.OutlookMailConnector,
         label: "OAuth (Recommended)",
         helpText: "Sign in with Microsoft to grant Outlook Mail access.",
         secrets: {

--- a/turbo/packages/connectors/src/connectors/posthog.ts
+++ b/turbo/packages/connectors/src/connectors/posthog.ts
@@ -1,5 +1,5 @@
-import { FeatureSwitchKey } from "../feature-switch-key";
 import type { ConnectorConfig } from "../connectors";
+import { FeatureSwitchKey } from "../feature-switch-key";
 
 export const posthog = {
   posthog: {
@@ -8,11 +8,11 @@ export const posthog = {
     environmentMapping: {
       POSTHOG_TOKEN: "$secrets.POSTHOG_ACCESS_TOKEN",
     },
-    featureFlag: FeatureSwitchKey.PosthogConnector,
     helpText:
       "Connect your PostHog account to access product analytics, feature flags, and experiments",
     authMethods: {
       oauth: {
+        featureFlag: FeatureSwitchKey.PosthogConnector,
         label: "OAuth (Recommended)",
         helpText: "Sign in with PostHog to grant access.",
         secrets: {

--- a/turbo/packages/connectors/src/connectors/reddit.ts
+++ b/turbo/packages/connectors/src/connectors/reddit.ts
@@ -1,5 +1,5 @@
-import { FeatureSwitchKey } from "../feature-switch-key";
 import type { ConnectorConfig } from "../connectors";
+import { FeatureSwitchKey } from "../feature-switch-key";
 
 export const reddit = {
   reddit: {
@@ -8,11 +8,11 @@ export const reddit = {
     environmentMapping: {
       REDDIT_TOKEN: "$secrets.REDDIT_ACCESS_TOKEN",
     },
-    featureFlag: FeatureSwitchKey.RedditConnector,
     helpText:
       "Connect your Reddit account to access Reddit discussions and content",
     authMethods: {
       oauth: {
+        featureFlag: FeatureSwitchKey.RedditConnector,
         label: "OAuth (Recommended)",
         helpText: "Sign in with Reddit to grant access.",
         secrets: {

--- a/turbo/packages/connectors/src/connectors/remote-agent.ts
+++ b/turbo/packages/connectors/src/connectors/remote-agent.ts
@@ -6,12 +6,11 @@ export const remoteAgent = {
     label: "Remote Agent",
     category: "engineering-team-execution",
     environmentMapping: {},
-    featureFlag: FeatureSwitchKey.RemoteAgent,
-    strictFeatureFlag: true,
     helpText:
       "Run local Codex or Claude Code hosts, then call them from chat with `/remote-agent ${host} prompt`",
     authMethods: {
       api: {
+        featureFlag: FeatureSwitchKey.RemoteAgent,
         label: "CLI Host",
         helpText:
           "1. Run `npx -p @vm0/cli vm0 login`\n2. Start a host with `npx -p @vm0/cli vm0 remote-agent start`\n3. Keep the host process running, then return here and click **Connect** once it appears online\n4. Run a connected host from chat with `/remote-agent ${host} prompt`",

--- a/turbo/packages/connectors/src/connectors/resend.ts
+++ b/turbo/packages/connectors/src/connectors/resend.ts
@@ -1,4 +1,3 @@
-import { FeatureSwitchKey } from "../feature-switch-key";
 import type { ConnectorConfig } from "../connectors";
 
 export const resend = {
@@ -8,7 +7,6 @@ export const resend = {
     environmentMapping: {
       RESEND_TOKEN: "$secrets.RESEND_TOKEN",
     },
-    featureFlag: FeatureSwitchKey.ResendConnector,
     helpText:
       "Connect your Resend account to send transactional emails, manage domains, audiences, and contacts",
     authMethods: {

--- a/turbo/packages/connectors/src/connectors/spotify.ts
+++ b/turbo/packages/connectors/src/connectors/spotify.ts
@@ -1,5 +1,5 @@
-import { FeatureSwitchKey } from "../feature-switch-key";
 import type { ConnectorConfig } from "../connectors";
+import { FeatureSwitchKey } from "../feature-switch-key";
 
 export const spotify = {
   spotify: {
@@ -8,11 +8,11 @@ export const spotify = {
     environmentMapping: {
       SPOTIFY_TOKEN: "$secrets.SPOTIFY_ACCESS_TOKEN",
     },
-    featureFlag: FeatureSwitchKey.SpotifyConnector,
     helpText:
       "Connect your Spotify account to manage playlists, control playback, and access music data",
     authMethods: {
       oauth: {
+        featureFlag: FeatureSwitchKey.SpotifyConnector,
         label: "OAuth (Recommended)",
         helpText: "Sign in with Spotify to grant access.",
         secrets: {

--- a/turbo/packages/connectors/src/connectors/stability-ai.ts
+++ b/turbo/packages/connectors/src/connectors/stability-ai.ts
@@ -1,4 +1,3 @@
-import { FeatureSwitchKey } from "../feature-switch-key";
 import type { ConnectorConfig } from "../connectors";
 
 export const stabilityAi = {
@@ -9,7 +8,6 @@ export const stabilityAi = {
     environmentMapping: {
       STABILITY_TOKEN: "$secrets.STABILITY_TOKEN",
     },
-    featureFlag: FeatureSwitchKey.StabilityAiConnector,
     helpText:
       "Connect your Stability AI account to generate images using Stable Diffusion models",
     authMethods: {

--- a/turbo/packages/connectors/src/connectors/stripe.ts
+++ b/turbo/packages/connectors/src/connectors/stripe.ts
@@ -1,5 +1,5 @@
-import { FeatureSwitchKey } from "../feature-switch-key";
 import type { ConnectorConfig } from "../connectors";
+import { FeatureSwitchKey } from "../feature-switch-key";
 
 export const stripe = {
   stripe: {
@@ -9,11 +9,11 @@ export const stripe = {
     environmentMapping: {
       STRIPE_TOKEN: "$secrets.STRIPE_ACCESS_TOKEN",
     },
-    featureFlag: FeatureSwitchKey.StripeConnector,
     helpText:
       "Connect your Stripe account to manage payments, customers, and subscriptions",
     authMethods: {
       oauth: {
+        featureFlag: FeatureSwitchKey.StripeConnector,
         label: "OAuth (Recommended)",
         helpText: "Sign in with Stripe to grant access.",
         secrets: {

--- a/turbo/packages/connectors/src/connectors/supabase.ts
+++ b/turbo/packages/connectors/src/connectors/supabase.ts
@@ -1,5 +1,5 @@
-import { FeatureSwitchKey } from "../feature-switch-key";
 import type { ConnectorConfig } from "../connectors";
+import { FeatureSwitchKey } from "../feature-switch-key";
 
 export const supabase = {
   supabase: {
@@ -8,11 +8,11 @@ export const supabase = {
     environmentMapping: {
       SUPABASE_TOKEN: "$secrets.SUPABASE_ACCESS_TOKEN",
     },
-    featureFlag: FeatureSwitchKey.SupabaseConnector,
     helpText:
       "Connect your Supabase account to manage projects, databases, and APIs",
     authMethods: {
       oauth: {
+        featureFlag: FeatureSwitchKey.SupabaseConnector,
         label: "OAuth (Recommended)",
         helpText: "Sign in with Supabase to grant access.",
         secrets: {

--- a/turbo/packages/connectors/src/connectors/test-oauth.ts
+++ b/turbo/packages/connectors/src/connectors/test-oauth.ts
@@ -1,11 +1,10 @@
-import { FeatureSwitchKey } from "../feature-switch-key";
 import type { ConnectorConfig } from "../connectors";
+import { FeatureSwitchKey } from "../feature-switch-key";
 
 export const testOauth = {
   "test-oauth": {
     label: "Test OAuth (internal)",
     category: "data-automation-infrastructure",
-    featureFlag: FeatureSwitchKey.TestOauthConnector,
     environmentMapping: {
       TEST_OAUTH_TOKEN: "$secrets.TEST_OAUTH_ACCESS_TOKEN",
     },
@@ -13,6 +12,7 @@ export const testOauth = {
       "Synthetic OAuth 2.0 connector served by this app itself. For automated tests only — not a real third-party service.",
     authMethods: {
       oauth: {
+        featureFlag: FeatureSwitchKey.TestOauthConnector,
         label: "OAuth",
         helpText: "Test-only OAuth provider. Only reachable in dev/preview.",
         secrets: {

--- a/turbo/packages/connectors/src/connectors/webflow.ts
+++ b/turbo/packages/connectors/src/connectors/webflow.ts
@@ -1,5 +1,5 @@
-import { FeatureSwitchKey } from "../feature-switch-key";
 import type { ConnectorConfig } from "../connectors";
+import { FeatureSwitchKey } from "../feature-switch-key";
 
 export const webflow = {
   webflow: {
@@ -8,11 +8,11 @@ export const webflow = {
     environmentMapping: {
       WEBFLOW_TOKEN: "$secrets.WEBFLOW_ACCESS_TOKEN",
     },
-    featureFlag: FeatureSwitchKey.WebflowConnector,
     helpText:
       "Connect your Webflow account to manage sites, pages, CMS collections, and ecommerce",
     authMethods: {
       oauth: {
+        featureFlag: FeatureSwitchKey.WebflowConnector,
         label: "OAuth (Recommended)",
         helpText: "Sign in with Webflow to grant access.",
         secrets: {

--- a/turbo/packages/connectors/src/connectors/zapier.ts
+++ b/turbo/packages/connectors/src/connectors/zapier.ts
@@ -4,8 +4,6 @@ import { FeatureSwitchKey } from "../feature-switch-key";
 export const zapier = {
   zapier: {
     label: "Zapier",
-    featureFlag: FeatureSwitchKey.ZapierConnector,
-    strictFeatureFlag: true,
     category: "data-automation-infrastructure",
     environmentMapping: {
       ZAPIER_TOKEN: "$secrets.ZAPIER_TOKEN",
@@ -14,6 +12,7 @@ export const zapier = {
       "Connect your Zapier account to trigger zaps and use AI Actions (NLA) to automate workflows",
     authMethods: {
       "api-token": {
+        featureFlag: FeatureSwitchKey.ZapierConnector,
         label: "API Key",
         secrets: {
           ZAPIER_TOKEN: {

--- a/turbo/packages/connectors/src/connectors/zoom.ts
+++ b/turbo/packages/connectors/src/connectors/zoom.ts
@@ -1,5 +1,5 @@
-import { FeatureSwitchKey } from "../feature-switch-key";
 import type { ConnectorConfig } from "../connectors";
+import { FeatureSwitchKey } from "../feature-switch-key";
 
 export const zoom = {
   zoom: {
@@ -8,11 +8,11 @@ export const zoom = {
     environmentMapping: {
       ZOOM_TOKEN: "$secrets.ZOOM_ACCESS_TOKEN",
     },
-    featureFlag: FeatureSwitchKey.ZoomConnector,
     helpText:
       "Connect your Zoom account to schedule meetings, manage cloud recordings, and access webinar and participant data",
     authMethods: {
       oauth: {
+        featureFlag: FeatureSwitchKey.ZoomConnector,
         label: "OAuth (Recommended)",
         helpText: "Sign in with Zoom to grant access.",
         secrets: {


### PR DESCRIPTION
## Summary
- move connector feature flags from connector-level config to auth method config
- centralize auth method availability logic, including API-method inclusion policy
- update API, web, platform, and CLI catalog filtering to use method-level feature gates

## Tests
- pnpm --filter @vm0/connectors check-types
- pnpm --filter @vm0/connectors lint
- pnpm --filter @vm0/connectors test
- pnpm --filter api check-types
- pnpm --filter @vm0/app check-types
- pnpm --filter web check-types
- pnpm --filter @vm0/cli check-types
- pnpm --filter api lint
- pnpm --filter @vm0/app lint
- pnpm --filter web lint
- pnpm --filter @vm0/cli lint
- pnpm exec vitest run src/signals/services/__tests__/zero-connector-data.service.test.ts src/signals/routes/__tests__/zero-connectors-search.test.ts
- pnpm exec vitest run src/signals/zero-page/__tests__/zero-connectors.test.ts
- pnpm exec vitest run app/api/zero/connectors/search/__tests__/route.test.ts

Fixes #13372