### PR TITLE
feat: add local browser platform connector

### DIFF
--- a/turbo/apps/platform/src/mocks/handlers/api-local-browser.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-local-browser.ts
@@ -1,0 +1,95 @@
+import {
+  zeroLocalBrowserDeviceClaimContract,
+  zeroLocalBrowserHostsContract,
+  type LocalBrowserHost,
+} from "@vm0/api-contracts/contracts/zero-local-browser";
+import { zeroLocalBrowserConnectorContract } from "@vm0/api-contracts/contracts/zero-connectors";
+import { mockApi } from "../msw-contract.ts";
+import { upsertMockConnector } from "./api-connectors.ts";
+
+let mockLocalBrowserHosts: LocalBrowserHost[] = [];
+let mockClaimedDeviceCodes: string[] = [];
+
+export function setMockLocalBrowserHosts(hosts: LocalBrowserHost[]): void {
+  mockLocalBrowserHosts = hosts;
+}
+
+export function getMockClaimedLocalBrowserDeviceCodes(): readonly string[] {
+  return mockClaimedDeviceCodes;
+}
+
+export function resetMockLocalBrowserHosts(): void {
+  mockLocalBrowserHosts = [];
+  mockClaimedDeviceCodes = [];
+}
+
+export const apiLocalBrowserHandlers = [
+  mockApi(zeroLocalBrowserHostsContract.list, ({ respond }) => {
+    return respond(200, { hosts: mockLocalBrowserHosts });
+  }),
+  mockApi(zeroLocalBrowserHostsContract.delete, ({ params, respond }) => {
+    const existing = mockLocalBrowserHosts.find((host) => {
+      return host.id === params.hostId;
+    });
+    if (!existing) {
+      return respond(404, {
+        error: {
+          message: "Local browser host not found",
+          code: "NOT_FOUND",
+        },
+      });
+    }
+    mockLocalBrowserHosts = mockLocalBrowserHosts.filter((host) => {
+      return host.id !== params.hostId;
+    });
+    return respond(200, { ok: true });
+  }),
+  mockApi(zeroLocalBrowserDeviceClaimContract.claim, ({ body, respond }) => {
+    mockClaimedDeviceCodes = [...mockClaimedDeviceCodes, body.deviceCode];
+    if (mockLocalBrowserHosts.length === 0) {
+      const now = new Date().toISOString();
+      mockLocalBrowserHosts = [
+        {
+          id: "browser-host-online",
+          displayName: "Chrome",
+          browser: "Chrome",
+          extensionVersion: "0.1.0",
+          supportedCapabilities: ["tabs.list", "page.snapshot"],
+          status: "online",
+          lastSeenAt: now,
+          createdAt: now,
+        },
+      ];
+    }
+    return respond(200, { status: "approved" });
+  }),
+  mockApi(zeroLocalBrowserConnectorContract.create, ({ respond }) => {
+    const hasOnlineHost = mockLocalBrowserHosts.some((host) => {
+      return host.status === "online";
+    });
+    if (!hasOnlineHost) {
+      return respond(409, {
+        error: {
+          message: "Pair an online browser host before connecting",
+          code: "CONFLICT",
+        },
+      });
+    }
+
+    const now = new Date().toISOString();
+    const connector = {
+      id: "00000000-0000-4000-8000-000000000001",
+      type: "local-browser" as const,
+      authMethod: "api",
+      externalId: null,
+      externalUsername: null,
+      externalEmail: null,
+      oauthScopes: null,
+      needsReconnect: false,
+      createdAt: now,
+      updatedAt: now,
+    };
+    upsertMockConnector(connector);
+    return respond(200, connector);
+  }),
+];

--- a/turbo/apps/platform/src/mocks/handlers/index.ts
+++ b/turbo/apps/platform/src/mocks/handlers/index.ts
@@ -95,6 +95,10 @@ import {
   apiRemoteAgentHandlers,
   resetMockRemoteAgentHosts,
 } from "./api-remote-agent.ts";
+import {
+  apiLocalBrowserHandlers,
+  resetMockLocalBrowserHosts,
+} from "./api-local-browser.ts";
 
 export const handlers = [
   ...apiConnectorsHandlers,
@@ -130,6 +134,7 @@ export const handlers = [
   ...apiVoiceChatHandlers,
   ...apiVoiceIoHandlers,
   ...apiRemoteAgentHandlers,
+  ...apiLocalBrowserHandlers,
 ];
 
 export function resetAllMockHandlers(): void {
@@ -161,4 +166,5 @@ export function resetAllMockHandlers(): void {
   resetMockOnboardingStatus();
   resetMockVoiceChat();
   resetMockRemoteAgentHosts();
+  resetMockLocalBrowserHosts();
 }

--- a/turbo/apps/platform/src/signals/bootstrap.ts
+++ b/turbo/apps/platform/src/signals/bootstrap.ts
@@ -38,7 +38,10 @@ import { setupChatPage$ } from "./chat-page/chat-page-setup.ts";
 import { setupInternalConnectorLogos$ } from "./internal-connector-logos-setup.ts";
 import { setupOnboardingPage$ } from "./onboarding-page/onboarding-page-setup.ts";
 import { setupIdeationPage$ } from "./zero-page/ideation-page-setup.ts";
-import { setupConnectorsPage$ } from "./connectors-page/connectors-page-setup.ts";
+import {
+  setupConnectorsPage$,
+  setupLocalBrowserConnectPage$,
+} from "./connectors-page/connectors-page-setup.ts";
 import { setupDirectedConnectPage$ } from "./connectors-page/directed-connect-page-setup.ts";
 import { setupDirectedAuthorizePage$ } from "./connectors-page/directed-authorize-page-setup.ts";
 import { setupSignInTokenPage$ } from "./sign-in-token-setup.ts";
@@ -122,6 +125,10 @@ const ROUTE_CONFIG = [
   {
     path: ROUTES.connectors,
     setup: setupAuthPageWrapper(setupConnectorsPage$),
+  },
+  {
+    path: ROUTES.localBrowserConnect,
+    setup: setupAuthPageWrapper(setupLocalBrowserConnectPage$),
   },
   {
     path: ROUTES.agentIdeas,

--- a/turbo/apps/platform/src/signals/connectors-page/connectors-page-setup.ts
+++ b/turbo/apps/platform/src/signals/connectors-page/connectors-page-setup.ts
@@ -5,6 +5,10 @@ import { updateDocumentTitle$ } from "../document-title.ts";
 import { updatePage$ } from "../react-router.ts";
 import { onboardGuard$ } from "../zero-page/onboard-guard.ts";
 import { hideAppSkeleton$ } from "../app-skeleton.ts";
+import {
+  LOCAL_BROWSER_CONNECTOR_TYPE,
+  setSelectedConnectorType$,
+} from "../zero-page/settings/connectors.ts";
 export const setupConnectorsPage$ = command(
   async ({ set }, signal: AbortSignal) => {
     set(updatePage$, createElement(ZeroConnectorsPage), "sidebar");
@@ -12,5 +16,12 @@ export const setupConnectorsPage$ = command(
     await set(hideAppSkeleton$, signal);
 
     await set(onboardGuard$, signal);
+  },
+);
+
+export const setupLocalBrowserConnectPage$ = command(
+  async ({ set }, signal: AbortSignal) => {
+    set(setSelectedConnectorType$, LOCAL_BROWSER_CONNECTOR_TYPE);
+    await set(setupConnectorsPage$, signal);
   },
 );

--- a/turbo/apps/platform/src/signals/route-paths.ts
+++ b/turbo/apps/platform/src/signals/route-paths.ts
@@ -16,6 +16,7 @@ export const ROUTES = {
   works: "/works",
   ideas: "/ideas",
   connectors: "/connectors",
+  localBrowserConnect: "/zero/connectors/local-browser",
   directedConnect: "/connectors/:type/connect",
   directedAuthorize: "/connectors/:type/authorize",
   settings: "/settings",

--- a/turbo/apps/platform/src/signals/zero-page/settings/__tests__/local-browser-connector.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/__tests__/local-browser-connector.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it, vi } from "vitest";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import { setupPage } from "../../../../__tests__/page-helper.ts";
+import { testContext } from "../../../__tests__/test-helpers.ts";
+import {
+  getMockClaimedLocalBrowserDeviceCodes,
+  setMockLocalBrowserHosts,
+} from "../../../../mocks/handlers/api-local-browser.ts";
+import {
+  allConnectorTypes$,
+  connectLocalBrowserConnector$,
+  localBrowserExtensionStatus$,
+  pairLocalBrowserExtension$,
+  permissionDialogType$,
+} from "../connectors.ts";
+
+const context = testContext();
+
+function installLocalBrowserExtensionResponder(signal: AbortSignal) {
+  const postMessageSpy = vi.spyOn(window, "postMessage");
+  postMessageSpy.mockImplementation((message: unknown) => {
+    if (typeof message !== "object" || message === null) {
+      return;
+    }
+    const request = message as Record<string, unknown>;
+    if (request.source !== "vm0-local-browser-web") {
+      return;
+    }
+    const requestId = request.requestId;
+    if (typeof requestId !== "string") {
+      return;
+    }
+
+    const response =
+      request.type === "vm0.localBrowser.detect"
+        ? {
+            source: "vm0-local-browser-extension",
+            type: "vm0.localBrowser.detected",
+            requestId,
+            browser: "Chrome",
+            extensionVersion: "0.1.0",
+          }
+        : request.type === "vm0.localBrowser.pair"
+          ? {
+              source: "vm0-local-browser-extension",
+              type: "vm0.localBrowser.pairingStarted",
+              requestId,
+              deviceCode: "device-code-123",
+            }
+          : null;
+    if (!response) {
+      return;
+    }
+
+    queueMicrotask(() => {
+      window.dispatchEvent(
+        new MessageEvent("message", {
+          data: response,
+          origin: window.location.origin,
+          source: window,
+        }),
+      );
+    });
+  });
+  signal.addEventListener(
+    "abort",
+    () => {
+      postMessageSpy.mockRestore();
+    },
+    { once: true },
+  );
+}
+
+describe("local-browser connector", () => {
+  it("is hidden when the local-browser feature switch is disabled", async () => {
+    await setupPage({
+      context,
+      path: "/",
+      withoutRender: true,
+      featureSwitches: { [FeatureSwitchKey.LocalBrowserUse]: false },
+    });
+
+    const connectors = await context.store.get(allConnectorTypes$);
+
+    expect(
+      connectors.some((connector) => {
+        return connector.type === "local-browser";
+      }),
+    ).toBeFalsy();
+  });
+
+  it("shows online browser hosts without treating them as connected", async () => {
+    setMockLocalBrowserHosts([
+      {
+        id: "browser-online",
+        displayName: "Work browser",
+        browser: "Chrome",
+        extensionVersion: "0.1.0",
+        supportedCapabilities: ["tabs.list", "page.snapshot"],
+        status: "online",
+        lastSeenAt: "2026-05-12T00:00:00.000Z",
+        createdAt: "2026-05-12T00:00:00.000Z",
+      },
+      {
+        id: "browser-offline",
+        displayName: "Old browser",
+        browser: "Edge",
+        extensionVersion: "0.1.0",
+        supportedCapabilities: ["tabs.list"],
+        status: "offline",
+        lastSeenAt: "2026-05-11T00:00:00.000Z",
+        createdAt: "2026-05-11T00:00:00.000Z",
+      },
+    ]);
+    await setupPage({
+      context,
+      path: "/",
+      withoutRender: true,
+      featureSwitches: { [FeatureSwitchKey.LocalBrowserUse]: true },
+    });
+
+    const connectors = await context.store.get(allConnectorTypes$);
+    const localBrowser = connectors.find((connector) => {
+      return connector.type === "local-browser";
+    });
+
+    expect(localBrowser?.availableAuthMethods).toStrictEqual(["api"]);
+    expect(localBrowser?.connected).toBeFalsy();
+    expect(localBrowser?.localBrowserHosts).toStrictEqual([
+      expect.objectContaining({
+        id: "browser-online",
+        displayName: "Work browser",
+      }),
+    ]);
+  });
+
+  it("pairs the browser extension through the web bridge", async () => {
+    installLocalBrowserExtensionResponder(context.signal);
+    await setupPage({
+      context,
+      path: "/",
+      withoutRender: true,
+      featureSwitches: { [FeatureSwitchKey.LocalBrowserUse]: true },
+    });
+
+    await context.store.set(pairLocalBrowserExtension$, context.signal);
+
+    expect(getMockClaimedLocalBrowserDeviceCodes()).toStrictEqual([
+      "device-code-123",
+    ]);
+    expect(context.store.get(localBrowserExtensionStatus$).status).toBe(
+      "available",
+    );
+  });
+
+  it("opens the agent auth dialog after connecting from settings", async () => {
+    setMockLocalBrowserHosts([
+      {
+        id: "browser-online",
+        displayName: "Work browser",
+        browser: "Chrome",
+        extensionVersion: "0.1.0",
+        supportedCapabilities: ["tabs.list", "page.snapshot"],
+        status: "online",
+        lastSeenAt: "2026-05-12T00:00:00.000Z",
+        createdAt: "2026-05-12T00:00:00.000Z",
+      },
+    ]);
+    await setupPage({
+      context,
+      path: "/",
+      withoutRender: true,
+      featureSwitches: { [FeatureSwitchKey.LocalBrowserUse]: true },
+    });
+
+    await context.store.set(
+      connectLocalBrowserConnector$,
+      { showPermissionDialog: true },
+      context.signal,
+    );
+
+    expect(context.store.get(permissionDialogType$)).toBe("local-browser");
+  });
+});

--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -14,7 +14,14 @@ import {
   type RemoteAgentHostListResponse,
 } from "@vm0/api-contracts/contracts/zero-remote-agent";
 import {
+  zeroLocalBrowserDeviceClaimContract,
+  zeroLocalBrowserHostsContract,
+  type LocalBrowserHost,
+  type LocalBrowserHostListResponse,
+} from "@vm0/api-contracts/contracts/zero-local-browser";
+import {
   zeroConnectorScopeDiffContract,
+  zeroLocalBrowserConnectorContract,
   zeroConnectorsMainContract,
   zeroRemoteAgentConnectorContract,
 } from "@vm0/api-contracts/contracts/zero-connectors";
@@ -45,7 +52,14 @@ const { get$: hiddenConnectorTypesRaw$, set$: setHiddenConnectorTypes$ } =
   localStorageSignals(HIDDEN_CONNECTIONS_STORAGE_KEY);
 export const REMOTE_AGENT_CONNECTOR_TYPE =
   "remote-agent" as const satisfies ConnectorType;
+export const LOCAL_BROWSER_CONNECTOR_TYPE =
+  "local-browser" as const satisfies ConnectorType;
 const REMOTE_AGENT_HOSTS_CHANGED_TOPIC = "remote-agent:hosts-changed";
+const LOCAL_BROWSER_HOSTS_CHANGED_TOPIC = "local-browser:hosts-changed";
+const LOCAL_BROWSER_WEB_MESSAGE_SOURCE = "vm0-local-browser-web";
+const LOCAL_BROWSER_EXTENSION_MESSAGE_SOURCE = "vm0-local-browser-extension";
+const LOCAL_BROWSER_EXTENSION_DETECT_TIMEOUT_MS = 1000;
+const LOCAL_BROWSER_EXTENSION_PAIR_TIMEOUT_MS = 10_000;
 
 type PostConnectOptions = {
   readonly showPermissionDialog?: boolean;
@@ -78,9 +92,12 @@ export interface ConnectorTypeWithStatus {
   needsReconnect: boolean;
   /** Online remote-agent hosts for the virtual remote-agent connector. */
   remoteAgentHosts?: RemoteAgentHost[];
+  /** Online local browser hosts for the virtual local-browser connector. */
+  localBrowserHosts?: LocalBrowserHost[];
 }
 
 const internalReloadRemoteAgentHosts$ = state(0);
+const internalReloadLocalBrowserHosts$ = state(0);
 
 export function getRemoteAgentOnlineHosts(
   hosts: readonly RemoteAgentHost[],
@@ -105,14 +122,48 @@ export const remoteAgentHosts$ = computed(
   },
 );
 
+export function getLocalBrowserOnlineHosts(
+  hosts: readonly LocalBrowserHost[],
+): LocalBrowserHost[] {
+  return hosts.filter((host) => {
+    return host.status === "online";
+  });
+}
+
+export const localBrowserHosts$ = computed(
+  async (get): Promise<LocalBrowserHostListResponse> => {
+    get(internalReloadLocalBrowserHosts$);
+    const features = await get(featureSwitch$);
+    if (!features?.[FeatureSwitchKey.LocalBrowserUse]) {
+      return { hosts: [] };
+    }
+
+    const createClient = get(zeroClient$);
+    const client = createClient(zeroLocalBrowserHostsContract);
+    const result = await accept(client.list(), [200]);
+    return result.body as LocalBrowserHostListResponse;
+  },
+);
+
 const reloadRemoteAgentHosts$ = command(({ set }) => {
   set(internalReloadRemoteAgentHosts$, (x) => {
     return x + 1;
   });
 });
 
+const reloadLocalBrowserHosts$ = command(({ set }) => {
+  set(internalReloadLocalBrowserHosts$, (x) => {
+    return x + 1;
+  });
+});
+
 const reloadRemoteAgentHostsFromRealtime$ = command(({ set }) => {
   set(reloadRemoteAgentHosts$);
+  return false;
+});
+
+const reloadLocalBrowserHostsFromRealtime$ = command(({ set }) => {
+  set(reloadLocalBrowserHosts$);
   return false;
 });
 
@@ -126,6 +177,18 @@ const watchRemoteAgentHosts$ = command(async ({ set }, signal: AbortSignal) => {
   );
 });
 
+const watchLocalBrowserHosts$ = command(
+  async ({ set }, signal: AbortSignal) => {
+    set(reloadLocalBrowserHosts$);
+    await set(
+      setAblyLoop$,
+      LOCAL_BROWSER_HOSTS_CHANGED_TOPIC,
+      reloadLocalBrowserHostsFromRealtime$,
+      signal,
+    );
+  },
+);
+
 export const remoteAgentHostsWatcherRef$ = onRef(
   command(async ({ set }, _el: HTMLElement, signal: AbortSignal) => {
     await set(watchRemoteAgentHosts$, signal);
@@ -134,6 +197,14 @@ export const remoteAgentHostsWatcherRef$ = onRef(
 
 function isRemoteAgentConnector(type: ConnectorType): boolean {
   return type === REMOTE_AGENT_CONNECTOR_TYPE;
+}
+
+function isLocalBrowserConnector(type: ConnectorType): boolean {
+  return type === LOCAL_BROWSER_CONNECTOR_TYPE;
+}
+
+function isHostBackedConnector(type: ConnectorType): boolean {
+  return isRemoteAgentConnector(type) || isLocalBrowserConnector(type);
 }
 
 function isConnectorFlagEnabled(
@@ -158,7 +229,7 @@ function getAvailableAuthMethodsForConnector(
   if ("api-token" in methods && (flagEnabled || !config.strictFeatureFlag)) {
     availableAuthMethods.push("api-token");
   }
-  if (isRemoteAgentConnector(type) && flagEnabled && "api" in methods) {
+  if (isHostBackedConnector(type) && flagEnabled && "api" in methods) {
     availableAuthMethods.push("api");
   }
 
@@ -170,10 +241,12 @@ function buildConnectorTypeStatus(params: {
   readonly connector: ConnectorResponse | null;
   readonly features: Record<string, boolean> | null | undefined;
   readonly remoteAgentOnlineHosts: RemoteAgentHost[];
+  readonly localBrowserOnlineHosts: LocalBrowserHost[];
 }): ConnectorTypeWithStatus {
   const config = CONNECTOR_TYPES[params.type];
   const flag = config.featureFlag;
   const isRemoteAgent = isRemoteAgentConnector(params.type);
+  const isLocalBrowser = isLocalBrowserConnector(params.type);
   const availableAuthMethods = getAvailableAuthMethodsForConnector(
     params.type,
     isConnectorFlagEnabled(params.type, params.features),
@@ -184,7 +257,7 @@ function buildConnectorTypeStatus(params: {
   return {
     type: params.type,
     label:
-      flag && !hasApiToken && !isRemoteAgent
+      flag && !hasApiToken && !isRemoteAgent && !isLocalBrowser
         ? `[Experimental] ${config.label}`
         : config.label,
     helpText: config.helpText,
@@ -194,14 +267,18 @@ function buildConnectorTypeStatus(params: {
     connector: params.connector,
     availableAuthMethods,
     scopeMismatch:
-      !isRemoteAgent &&
+      !isHostBackedConnector(params.type) &&
       params.connector !== null &&
       params.connector.authMethod === "oauth" &&
       !hasRequiredScopes(params.type, params.connector.oauthScopes),
     needsReconnect:
-      !isRemoteAgent && (params.connector?.needsReconnect ?? false),
+      !isHostBackedConnector(params.type) &&
+      (params.connector?.needsReconnect ?? false),
     ...(isRemoteAgent
       ? { remoteAgentHosts: params.remoteAgentOnlineHosts }
+      : {}),
+    ...(isLocalBrowser
+      ? { localBrowserHosts: params.localBrowserOnlineHosts }
       : {}),
   };
 }
@@ -253,8 +330,14 @@ export const allConnectorTypes$ = computed(async (get) => {
   const remoteAgentHostList = features?.[FeatureSwitchKey.RemoteAgent]
     ? await get(remoteAgentHosts$)
     : { hosts: [] };
+  const localBrowserHostList = features?.[FeatureSwitchKey.LocalBrowserUse]
+    ? await get(localBrowserHosts$)
+    : { hosts: [] };
   const remoteAgentOnlineHosts = getRemoteAgentOnlineHosts(
     remoteAgentHostList.hosts,
+  );
+  const localBrowserOnlineHosts = getLocalBrowserOnlineHosts(
+    localBrowserHostList.hosts,
   );
 
   const items = (Object.keys(CONNECTOR_TYPES) as ConnectorType[])
@@ -272,6 +355,7 @@ export const allConnectorTypes$ = computed(async (get) => {
         connector: connectorMap.get(type) ?? null,
         features,
         remoteAgentOnlineHosts,
+        localBrowserOnlineHosts,
       });
     });
 
@@ -470,6 +554,292 @@ export const justConnectedTypes$ = computed((get) => {
   return get(internalJustConnectedTypes$);
 });
 
+export type LocalBrowserExtensionStatus =
+  | { readonly status: "unknown" }
+  | { readonly status: "checking" }
+  | {
+      readonly status: "available";
+      readonly browser?: string;
+      readonly extensionVersion?: string;
+    }
+  | { readonly status: "missing" }
+  | { readonly status: "pairing" }
+  | { readonly status: "error"; readonly message: string };
+
+type LocalBrowserExtensionResponse =
+  | {
+      readonly type: "detected";
+      readonly browser?: string;
+      readonly extensionVersion?: string;
+    }
+  | {
+      readonly type: "pairingStarted";
+      readonly deviceCode: string;
+      readonly userCode?: string;
+    }
+  | { readonly type: "error"; readonly message: string };
+
+const internalLocalBrowserExtensionStatus$ = state<LocalBrowserExtensionStatus>(
+  { status: "unknown" },
+);
+
+export const localBrowserExtensionStatus$ = computed((get) => {
+  return get(internalLocalBrowserExtensionStatus$);
+});
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+function parseLocalBrowserExtensionResponse(
+  data: unknown,
+  requestId: string,
+): LocalBrowserExtensionResponse | null {
+  if (!isRecord(data)) {
+    return null;
+  }
+  if (data.source !== LOCAL_BROWSER_EXTENSION_MESSAGE_SOURCE) {
+    return null;
+  }
+  if (data.requestId !== requestId) {
+    return null;
+  }
+
+  if (data.type === "vm0.localBrowser.detected") {
+    return {
+      type: "detected",
+      browser: stringValue(data.browser),
+      extensionVersion: stringValue(data.extensionVersion),
+    };
+  }
+
+  if (data.type === "vm0.localBrowser.pairingStarted") {
+    const deviceCode = stringValue(data.deviceCode);
+    if (!deviceCode) {
+      return {
+        type: "error",
+        message: "Local browser extension did not return a device code",
+      };
+    }
+    return {
+      type: "pairingStarted",
+      deviceCode,
+      userCode: stringValue(data.userCode),
+    };
+  }
+
+  if (data.type === "vm0.localBrowser.error") {
+    return {
+      type: "error",
+      message: stringValue(data.message) ?? "Local browser extension failed",
+    };
+  }
+
+  return null;
+}
+
+function createLocalBrowserRequestId(): string {
+  return `local-browser-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+function sendLocalBrowserExtensionRequest(
+  type: "detect" | "pair",
+  timeoutMs: number,
+  signal: AbortSignal,
+): Promise<LocalBrowserExtensionResponse> {
+  signal.throwIfAborted();
+
+  const requestId = createLocalBrowserRequestId();
+  const deferred = Promise.withResolvers<LocalBrowserExtensionResponse>();
+  let settled = false;
+  let timeoutId: ReturnType<typeof window.setTimeout> | undefined;
+
+  function cleanup() {
+    window.removeEventListener("message", onMessage);
+    signal.removeEventListener("abort", onAbort);
+    if (timeoutId !== undefined) {
+      window.clearTimeout(timeoutId);
+      timeoutId = undefined;
+    }
+  }
+
+  function resolve(response: LocalBrowserExtensionResponse) {
+    if (settled) {
+      return;
+    }
+    settled = true;
+    cleanup();
+    if (response.type === "error") {
+      deferred.reject(new Error(response.message));
+      return;
+    }
+    deferred.resolve(response);
+  }
+
+  function reject(error: unknown) {
+    if (settled) {
+      return;
+    }
+    settled = true;
+    cleanup();
+    deferred.reject(error);
+  }
+
+  function onAbort() {
+    reject(signal.reason);
+  }
+
+  function onMessage(event: MessageEvent<unknown>) {
+    if (event.source && event.source !== window) {
+      return;
+    }
+    if (event.origin && event.origin !== window.location.origin) {
+      return;
+    }
+    const response = parseLocalBrowserExtensionResponse(event.data, requestId);
+    if (!response) {
+      return;
+    }
+    resolve(response);
+  }
+
+  window.addEventListener("message", onMessage);
+  signal.addEventListener("abort", onAbort, { once: true });
+  timeoutId = window.setTimeout(() => {
+    reject(new Error("Local browser extension did not respond"));
+  }, timeoutMs);
+  window.postMessage(
+    {
+      source: LOCAL_BROWSER_WEB_MESSAGE_SOURCE,
+      type: `vm0.localBrowser.${type}`,
+      requestId,
+    },
+    window.location.origin,
+  );
+
+  return deferred.promise;
+}
+
+function localBrowserErrorMessage(error: unknown): string {
+  return error instanceof Error
+    ? error.message
+    : "Local browser extension pairing failed";
+}
+
+export const detectLocalBrowserExtension$ = command(
+  async ({ set }, signal: AbortSignal): Promise<void> => {
+    set(internalLocalBrowserExtensionStatus$, { status: "checking" });
+    const [result] = await Promise.allSettled([
+      sendLocalBrowserExtensionRequest(
+        "detect",
+        LOCAL_BROWSER_EXTENSION_DETECT_TIMEOUT_MS,
+        signal,
+      ),
+    ]);
+    signal.throwIfAborted();
+    if (result.status === "rejected") {
+      set(internalLocalBrowserExtensionStatus$, {
+        status: "missing",
+      });
+      return;
+    }
+
+    const response = result.value;
+    if (response.type !== "detected") {
+      set(internalLocalBrowserExtensionStatus$, {
+        status: "error",
+        message: "Unexpected local browser extension response",
+      });
+      return;
+    }
+    set(internalLocalBrowserExtensionStatus$, {
+      status: "available",
+      browser: response.browser,
+      extensionVersion: response.extensionVersion,
+    });
+  },
+);
+
+export const pairLocalBrowserExtension$ = command(
+  async ({ get, set }, signal: AbortSignal): Promise<void> => {
+    set(internalLocalBrowserExtensionStatus$, { status: "pairing" });
+    const [result] = await Promise.allSettled([
+      sendLocalBrowserExtensionRequest(
+        "pair",
+        LOCAL_BROWSER_EXTENSION_PAIR_TIMEOUT_MS,
+        signal,
+      ),
+    ]);
+    signal.throwIfAborted();
+    if (result.status === "rejected") {
+      const message = localBrowserErrorMessage(result.reason);
+      if (message.includes("did not respond")) {
+        set(internalLocalBrowserExtensionStatus$, { status: "missing" });
+      } else {
+        set(internalLocalBrowserExtensionStatus$, {
+          status: "error",
+          message,
+        });
+      }
+      toast.error(message, { id: "local-browser-extension-pair-error" });
+      throw result.reason;
+    }
+
+    const response = result.value;
+    if (response.type !== "pairingStarted") {
+      const message = "Unexpected local browser extension response";
+      set(internalLocalBrowserExtensionStatus$, {
+        status: "error",
+        message,
+      });
+      toast.error(message, { id: "local-browser-extension-pair-error" });
+      throw new Error(message);
+    }
+
+    const createClient = get(zeroClient$);
+    const client = createClient(zeroLocalBrowserDeviceClaimContract, {
+      apiBase: "api",
+    });
+    const [claimResult] = await Promise.allSettled([
+      accept(
+        client.claim({
+          body: { deviceCode: response.deviceCode },
+          fetchOptions: { signal },
+        }),
+        [200],
+      ),
+    ]);
+    signal.throwIfAborted();
+    if (claimResult.status === "rejected") {
+      const message = localBrowserErrorMessage(claimResult.reason);
+      set(internalLocalBrowserExtensionStatus$, {
+        status: "error",
+        message,
+      });
+      toast.error(message, { id: "local-browser-extension-pair-error" });
+      throw claimResult.reason;
+    }
+
+    set(reloadLocalBrowserHosts$);
+    set(internalLocalBrowserExtensionStatus$, { status: "available" });
+    toast.success("Browser extension paired", {
+      id: "local-browser-extension-paired",
+    });
+  },
+);
+
+export const localBrowserConnectionRef$ = onRef(
+  command(async ({ set }, _el: HTMLElement, signal: AbortSignal) => {
+    set(reloadLocalBrowserHosts$);
+    await set(detectLocalBrowserExtension$, signal);
+    await set(watchLocalBrowserHosts$, signal);
+  }),
+);
+
 export const connectRemoteAgentConnector$ = command(
   async (
     { get, set },
@@ -508,6 +878,66 @@ export const connectRemoteAgentConnector$ = command(
     if (options.showPermissionDialog) {
       set(internalPermissionDialogType$, REMOTE_AGENT_CONNECTOR_TYPE);
     }
+  },
+);
+
+export const connectLocalBrowserConnector$ = command(
+  async (
+    { get, set },
+    options: PostConnectOptions,
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const createClient = get(zeroClient$);
+    const client = createClient(zeroLocalBrowserConnectorContract, {
+      apiBase: "api",
+    });
+    await accept(
+      client.create({
+        body: {},
+        fetchOptions: { signal },
+      }),
+      [200],
+    );
+    signal.throwIfAborted();
+
+    set(internalJustConnectedTypes$, (prev) => {
+      return new Set([...prev, LOCAL_BROWSER_CONNECTOR_TYPE]);
+    });
+    set(reloadConnectors$);
+    set(reloadLocalBrowserHosts$);
+
+    const hidden = new Set(get(hiddenConnectorTypes$));
+    hidden.delete(LOCAL_BROWSER_CONNECTOR_TYPE);
+    set(setHiddenConnectorTypes$, JSON.stringify([...hidden]));
+
+    toast.success(
+      `${CONNECTOR_TYPES[LOCAL_BROWSER_CONNECTOR_TYPE].label} connected`,
+      {
+        id: `connector-connected-${LOCAL_BROWSER_CONNECTOR_TYPE}`,
+      },
+    );
+    if (options.showPermissionDialog) {
+      set(internalPermissionDialogType$, LOCAL_BROWSER_CONNECTOR_TYPE);
+    }
+  },
+);
+
+export const deleteLocalBrowserHost$ = command(
+  async ({ get, set }, hostId: string, signal: AbortSignal): Promise<void> => {
+    const createClient = get(zeroClient$);
+    const client = createClient(zeroLocalBrowserHostsContract);
+    await accept(
+      client.delete({
+        params: { hostId },
+        fetchOptions: { signal },
+      }),
+      [200],
+    );
+    signal.throwIfAborted();
+    set(reloadLocalBrowserHosts$);
+    toast.success("Browser host removed", {
+      id: `local-browser-host-removed-${hostId}`,
+    });
   },
 );
 

--- a/turbo/apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx
@@ -17,6 +17,7 @@ import {
   CONNECTOR_TYPES,
   type ConnectorType,
 } from "@vm0/connectors/connectors";
+import type { LocalBrowserHost } from "@vm0/api-contracts/contracts/zero-local-browser";
 import { isGoogleOAuthConnector } from "@vm0/connectors/connector-utils";
 import {
   allConnectorTypes$,
@@ -26,13 +27,23 @@ import {
   setTokenFormValue$,
   clearTokenForm$,
   connectRemoteAgentConnector$,
+  connectLocalBrowserConnector$,
+  deleteLocalBrowserHost$,
+  detectLocalBrowserExtension$,
+  pairLocalBrowserExtension$,
   tokenFormValuesFor$,
   selectedConnectorType$,
   isStandaloneMode,
   REMOTE_AGENT_CONNECTOR_TYPE,
+  LOCAL_BROWSER_CONNECTOR_TYPE,
   getRemoteAgentOnlineHosts,
+  getLocalBrowserOnlineHosts,
+  localBrowserConnectionRef$,
+  localBrowserExtensionStatus$,
+  localBrowserHosts$,
   remoteAgentHostsWatcherRef$,
   remoteAgentHosts$,
+  type LocalBrowserExtensionStatus,
   type ConnectorTypeWithStatus,
 } from "../../../../signals/zero-page/settings/connectors.ts";
 import { hasTokenInputValue } from "../../../../signals/zero-page/settings/token-input.ts";
@@ -75,6 +86,10 @@ function connectedStatusText(item: ConnectorTypeWithStatus): string {
     const count = item.remoteAgentHosts?.length ?? 0;
     return count === 1 ? "1 host online" : `${count} hosts online`;
   }
+  if (item.type === LOCAL_BROWSER_CONNECTOR_TYPE) {
+    const count = item.localBrowserHosts?.length ?? 0;
+    return count === 1 ? "1 browser online" : `${count} browsers online`;
+  }
   if (item.needsReconnect) {
     return "Connection expired";
   }
@@ -93,6 +108,42 @@ function formatRemoteAgentBackends(backends: readonly string[]): string {
       return backend === "claude-code" ? "Claude Code" : "Codex";
     })
     .join(", ");
+}
+
+function formatLocalBrowserCapabilities(
+  capabilities: readonly string[],
+): string {
+  if (capabilities.length === 0) {
+    return "Browser automation";
+  }
+  return capabilities.slice(0, 3).join(", ");
+}
+
+function localBrowserExtensionStatusText(
+  status: LocalBrowserExtensionStatus,
+): string {
+  switch (status.status) {
+    case "checking": {
+      return "Checking extension...";
+    }
+    case "available": {
+      return status.browser
+        ? `${status.browser} extension ready`
+        : "Extension ready";
+    }
+    case "pairing": {
+      return "Pairing extension...";
+    }
+    case "missing": {
+      return "Extension not detected";
+    }
+    case "error": {
+      return status.message;
+    }
+    case "unknown": {
+      return "Extension status unknown";
+    }
+  }
 }
 
 type PostConnectOptions = {
@@ -295,6 +346,238 @@ function RemoteAgentConnectContent({
   );
 }
 
+function LocalBrowserExtensionPanel({
+  status,
+  checking,
+  pairing,
+  onDetect,
+  onPair,
+}: {
+  status: LocalBrowserExtensionStatus;
+  checking: boolean;
+  pairing: boolean;
+  onDetect: (event: unknown) => void;
+  onPair: (event: unknown) => void;
+}) {
+  return (
+    <div className="flex flex-col gap-2 rounded-lg border border-border/60 px-3 py-2.5">
+      <div className="flex items-center justify-between gap-3">
+        <span className="text-sm font-medium text-foreground">
+          Browser extension
+        </span>
+        <span className="text-xs text-muted-foreground">
+          {localBrowserExtensionStatusText(status)}
+        </span>
+      </div>
+      <div className="flex gap-2">
+        <Button
+          type="button"
+          variant="outline"
+          onClick={onDetect}
+          disabled={checking}
+          className="h-8 flex-1"
+        >
+          {checking ? "Checking..." : "Check extension"}
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          onClick={onPair}
+          disabled={checking || pairing}
+          className="h-8 flex-1"
+        >
+          {pairing ? "Pairing..." : "Pair extension"}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function LocalBrowserHostList({
+  hosts,
+  loading,
+  deletingHost,
+  onDeleteHost,
+}: {
+  hosts: readonly LocalBrowserHost[];
+  loading: boolean;
+  deletingHost: boolean;
+  onDeleteHost: (hostId: string) => void;
+}) {
+  if (loading && hosts.length === 0) {
+    return <p className="text-sm text-muted-foreground">Loading browsers...</p>;
+  }
+
+  if (hosts.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        No paired browsers yet. Pair the extension above; this list updates
+        automatically.
+      </p>
+    );
+  }
+
+  return (
+    <div className="flex flex-col divide-y divide-border/50 rounded-lg border border-border/60">
+      {hosts.map((host) => {
+        const isOnline = host.status === "online";
+        return (
+          <div
+            key={host.id}
+            className="flex items-center justify-between gap-3 px-3 py-2"
+          >
+            <div className="min-w-0 flex-1">
+              <div className="flex items-center gap-2">
+                <span
+                  className={`h-1.5 w-1.5 shrink-0 rounded-full ${
+                    isOnline ? "bg-emerald-500" : "bg-muted-foreground/40"
+                  }`}
+                />
+                <span className="min-w-0 truncate text-sm font-medium text-foreground">
+                  {host.displayName}
+                </span>
+              </div>
+              <span className="block truncate text-xs text-muted-foreground">
+                {host.browser} {host.extensionVersion} -{" "}
+                {formatLocalBrowserCapabilities(host.supportedCapabilities)}
+              </span>
+            </div>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              disabled={deletingHost}
+              onClick={() => {
+                onDeleteHost(host.id);
+              }}
+              className="h-8 shrink-0 px-2 text-xs"
+            >
+              Revoke
+            </Button>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function LocalBrowserConnectContent({
+  item,
+  onSuccess,
+  showPermissionDialogOnConnect,
+}: {
+  item: ConnectorTypeWithStatus;
+  onSuccess: () => void | Promise<void>;
+  showPermissionDialogOnConnect: boolean;
+}) {
+  const config = CONNECTOR_TYPES[item.type];
+  const localBrowserConfig = config.authMethods.api;
+  const hostListLoadable = useLastLoadable(localBrowserHosts$);
+  const watchConnectionRef = useSet(localBrowserConnectionRef$);
+  const extensionStatus = useGet(localBrowserExtensionStatus$);
+  const [detectLoadable, detectExtension] = useLoadableSet(
+    detectLocalBrowserExtension$,
+  );
+  const [pairLoadable, pairExtension] = useLoadableSet(
+    pairLocalBrowserExtension$,
+  );
+  const [deleteHostLoadable, deleteHost] = useLoadableSet(
+    deleteLocalBrowserHost$,
+  );
+  const [connectLoadable, connectLocalBrowser] = useLoadableSet(
+    connectLocalBrowserConnector$,
+  );
+  const pageSignal = useGet(pageSignal$);
+  const hosts =
+    hostListLoadable.state === "hasData"
+      ? hostListLoadable.data.hosts
+      : (item.localBrowserHosts ?? []);
+  const onlineHosts = getLocalBrowserOnlineHosts(hosts);
+  const loadingHosts = hostListLoadable.state === "loading";
+  const checkingExtension =
+    extensionStatus.status === "checking" || detectLoadable.state === "loading";
+  const pairingExtension =
+    extensionStatus.status === "pairing" || pairLoadable.state === "loading";
+  const connecting = connectLoadable.state === "loading";
+  const deletingHost = deleteHostLoadable.state === "loading";
+  const canConnect = !item.connected && onlineHosts.length > 0 && !connecting;
+
+  const handleDetect = onDomEventFn(async () => {
+    if (checkingExtension) {
+      return;
+    }
+    await detectExtension(pageSignal);
+  });
+
+  const handlePair = onDomEventFn(async () => {
+    if (pairingExtension || checkingExtension) {
+      return;
+    }
+    await pairExtension(pageSignal);
+  });
+
+  const handleConnect = onDomEventFn(async () => {
+    if (!canConnect) {
+      return;
+    }
+    await connectLocalBrowser(
+      { showPermissionDialog: showPermissionDialogOnConnect },
+      pageSignal,
+    );
+    await onSuccess();
+  });
+
+  const handleDeleteHost = (hostId: string) => {
+    detach(deleteHost(hostId, pageSignal), Reason.DomCallback);
+  };
+
+  return (
+    <div ref={watchConnectionRef} className="flex flex-col gap-3">
+      {localBrowserConfig?.helpText && (
+        <div
+          className="text-sm text-muted-foreground leading-relaxed whitespace-pre-line [&_a]:text-primary [&_a]:underline"
+          dangerouslySetInnerHTML={{
+            __html: renderMarkdown(localBrowserConfig.helpText),
+          }}
+        />
+      )}
+
+      <LocalBrowserExtensionPanel
+        status={extensionStatus}
+        checking={checkingExtension}
+        pairing={pairingExtension}
+        onDetect={handleDetect}
+        onPair={handlePair}
+      />
+
+      <div className="mt-1 flex items-center justify-between gap-3">
+        <h3 className="text-sm font-medium text-foreground">Browser hosts</h3>
+        <span className="text-xs text-muted-foreground">
+          {loadingHosts ? "Checking..." : "Updates automatically"}
+        </span>
+      </div>
+
+      <LocalBrowserHostList
+        hosts={hosts}
+        loading={loadingHosts}
+        deletingHost={deletingHost}
+        onDeleteHost={handleDeleteHost}
+      />
+
+      {!item.connected && (
+        <Button
+          type="button"
+          onClick={handleConnect}
+          disabled={!canConnect}
+          className="w-full"
+        >
+          {connecting ? "Connecting..." : "Connect"}
+        </Button>
+      )}
+    </div>
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Connect modal content (OAuth button + token form, or just token form)
 // ---------------------------------------------------------------------------
@@ -323,6 +606,16 @@ function ConnectModalContent({
   if (item.type === REMOTE_AGENT_CONNECTOR_TYPE) {
     return (
       <RemoteAgentConnectContent
+        item={item}
+        onSuccess={onSuccess}
+        showPermissionDialogOnConnect={showPermissionDialogOnConnect}
+      />
+    );
+  }
+
+  if (item.type === LOCAL_BROWSER_CONNECTOR_TYPE) {
+    return (
+      <LocalBrowserConnectContent
         item={item}
         onSuccess={onSuccess}
         showPermissionDialogOnConnect={showPermissionDialogOnConnect}

--- a/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
@@ -41,6 +41,8 @@ import {
   pollingConnectorType$,
   justConnectedTypes$,
   REMOTE_AGENT_CONNECTOR_TYPE,
+  LOCAL_BROWSER_CONNECTOR_TYPE,
+  getLocalBrowserOnlineHosts,
   scopeReviewType$,
   setScopeReviewType$,
   permissionDialogType$,
@@ -297,6 +299,60 @@ function ConnectorCategoryGroupSection({
   );
 }
 
+type HostStatusInfo = {
+  readonly names: readonly string[];
+  readonly emptyLabel: string;
+};
+
+function getHostStatusInfo(
+  connector: ConnectorTypeWithStatus,
+): HostStatusInfo | null {
+  if (connector.type === REMOTE_AGENT_CONNECTOR_TYPE) {
+    return {
+      names: (connector.remoteAgentHosts ?? []).map((host) => {
+        return host.displayName;
+      }),
+      emptyLabel: "No online hosts",
+    };
+  }
+
+  if (connector.type === LOCAL_BROWSER_CONNECTOR_TYPE) {
+    return {
+      names: getLocalBrowserOnlineHosts(connector.localBrowserHosts ?? []).map(
+        (host) => {
+          return `${host.displayName} (${host.browser})`;
+        },
+      ),
+      emptyLabel: "No browser online",
+    };
+  }
+
+  return null;
+}
+
+function HostBackedConnectorStatus({ info }: { info: HostStatusInfo }) {
+  const visibleNames = info.names.slice(0, 2).join(", ");
+  const extra = info.names.length > 2 ? ` +${info.names.length - 2}` : "";
+  const hasOnlineHosts = info.names.length > 0;
+  const label = !hasOnlineHosts
+    ? info.emptyLabel
+    : `${visibleNames}${extra} online`;
+
+  return (
+    <span
+      className="flex items-center gap-2 text-xs text-muted-foreground truncate"
+      title={hasOnlineHosts ? info.names.join(", ") : info.emptyLabel}
+    >
+      <span
+        className={`h-1.5 w-1.5 rounded-full shrink-0 ${
+          hasOnlineHosts ? "bg-emerald-500" : "bg-muted-foreground/40"
+        }`}
+      />
+      <span className="truncate">{label}</span>
+    </span>
+  );
+}
+
 function GlobalConnectorCard({
   connector,
   isPolling,
@@ -359,30 +415,9 @@ function GlobalConnectorCard({
       );
     }
     if (connector.connected) {
-      if (connector.type === REMOTE_AGENT_CONNECTOR_TYPE) {
-        const hosts = connector.remoteAgentHosts ?? [];
-        const names = hosts.map((host) => {
-          return host.displayName;
-        });
-        const visibleNames = names.slice(0, 2).join(", ");
-        const extra = names.length > 2 ? ` +${names.length - 2}` : "";
-        const hasOnlineHosts = names.length > 0;
-        const label = !hasOnlineHosts
-          ? "No online hosts"
-          : `${visibleNames}${extra} online`;
-        return (
-          <span
-            className="flex items-center gap-2 text-xs text-muted-foreground truncate"
-            title={hasOnlineHosts ? names.join(", ") : "No online hosts"}
-          >
-            <span
-              className={`h-1.5 w-1.5 rounded-full shrink-0 ${
-                hasOnlineHosts ? "bg-emerald-500" : "bg-muted-foreground/40"
-              }`}
-            />
-            <span className="truncate">{label}</span>
-          </span>
-        );
+      const hostStatusInfo = getHostStatusInfo(connector);
+      if (hostStatusInfo) {
+        return <HostBackedConnectorStatus info={hostStatusInfo} />;
       }
       return (
         <span className="flex items-center gap-2 text-xs text-muted-foreground truncate">


### PR DESCRIPTION
## Summary
- expose Local Browser as a host-backed API connector when the feature flag is enabled
- add platform pairing bridge for the browser extension, host list/revoke UI, connect flow, and /zero/connectors/local-browser route
- add local-browser MSW handlers and connector signal tests

## Verification
- pnpm --filter @vm0/app check-types
- pnpm --filter @vm0/app lint
- pnpm --filter @vm0/app test src/signals/zero-page/settings/__tests__/local-browser-connector.test.ts src/signals/zero-page/settings/__tests__/remote-agent-connector.test.ts
- pre-commit: prettier, knip, turbo check-types