### PR TITLE
feat: enable remote agent globally

### DIFF
--- a/turbo/apps/web/app/api/cron/process-usage-events/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/cron/process-usage-events/__tests__/route.test.ts
@@ -103,7 +103,7 @@ describe("GET /api/cron/process-usage-events", () => {
   });
 
   it("charges model token categories with legacy per-token rounding", async () => {
-    const provider = "claude-sonnet-4-6";
+    const provider = uniqueId("legacy-token-provider");
     const events = [
       {
         category: TOKEN_CATEGORY_INPUT,

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -68,6 +68,10 @@ describe("isFeatureEnabled", () => {
     ).toBe(true);
   });
 
+  it("should enable remote agent globally", () => {
+    expect(isFeatureEnabled(FeatureSwitchKey.RemoteAgent, {})).toBe(true);
+  });
+
   it("should enable CLI auth switches for staff orgs only by default", () => {
     expect(isFeatureEnabled(FeatureSwitchKey.CliAuth, {})).toBe(false);
     expect(isFeatureEnabled(FeatureSwitchKey.CliAuthStripe, {})).toBe(false);

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -201,8 +201,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     maintainer: "lancy@vm0.ai",
     description:
       "Enable remote-agent device pairing and local Codex/Claude host heartbeat endpoints.",
-    enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+    enabled: true,
   },
   [FeatureSwitchKey.Lab]: {
     maintainer: "ethan@vm0.ai",


### PR DESCRIPTION
## Summary
- Enable the `RemoteAgent` feature switch globally by setting `enabled: true` and removing the staff-org hash gate.
- Add a core feature-switch assertion that remote agent is enabled without org overrides.
- Isolate a usage-pricing rounding test provider name so full-suite runs do not collide with shared pricing rows.

## Tests
- `pnpm -F @vm0/core exec vitest src/__tests__/feature-switch.test.ts`
- `pnpm -F web exec vitest app/api/cron/process-usage-events/__tests__/route.test.ts`
- `pnpm -F api exec vitest src/signals/routes/__tests__/zero-connectors-cli-auth-stripe.test.ts src/signals/routes/__tests__/zero-local-browser-commands.test.ts src/signals/routes/__tests__/zero-local-browser-runtime.test.ts src/signals/routes/__tests__/zero-connectors-local-browser-connect.test.ts src/signals/routes/__tests__/cron-reconcile-billing-entitlements.test.ts`
- `pnpm format`
- `pnpm turbo run lint`
- `pnpm check-types`
- `pnpm vitest`
- `pnpm knip`
