### PR TITLE
feat: add interactive claude driver

### DIFF
--- a/crates/guest-agent/src/cli.rs
+++ b/crates/guest-agent/src/cli.rs
@@ -10,7 +10,14 @@ use crate::paths;
 use crate::timing;
 use guest_common::telemetry::record_sandbox_op;
 use guest_common::{log_info, log_warn};
+use serde_json::{Value, json};
 use std::collections::{HashMap, VecDeque};
+use std::ffi::CString;
+use std::fs::OpenOptions;
+use std::io::{Read as _, Seek as _, SeekFrom};
+use std::os::fd::{AsRawFd, FromRawFd};
+use std::os::unix::ffi::OsStrExt;
+use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
 use std::process::Stdio;
 use std::time::{Duration, Instant};
 use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncReadExt, AsyncWriteExt};
@@ -20,6 +27,10 @@ const STDERR_RESULT_MAX_LINES: usize = 200;
 const STDERR_RESULT_MAX_LINE_BYTES: usize = 16 * 1024;
 const STDERR_READ_BUFFER_BYTES: usize = 8 * 1024;
 const STDERR_OMITTED_LONG_LINE: &str = "[stderr line omitted: exceeded diagnostic size limit]";
+const INTERACTIVE_HOOK_POLL_MS: u64 = 50;
+const INTERACTIVE_TRANSCRIPT_TAIL_MS: u64 = 50;
+const INTERACTIVE_POST_STOP_DRAIN_MS: u64 = 1000;
+const INTERACTIVE_PROCESS_EXIT_GRACE_MS: u64 = 1000;
 
 /// State machine driving forced CLI process-group termination. A single
 /// pinned deadline is resettable across phases; the enum value tells the
@@ -211,6 +222,56 @@ fn build_claude_args(
     // (--disallowed-tools, --tools) do not consume the prompt.
     args.push("--".to_string());
     args.push(prompt.to_string());
+    args
+}
+
+fn build_interactive_claude_args(
+    resume_id: &str,
+    append_system_prompt: &str,
+    disallowed_tools: &str,
+    tools: &str,
+    settings: &str,
+) -> Vec<String> {
+    let mut args = vec!["--dangerously-skip-permissions".to_string()];
+
+    if !resume_id.is_empty() {
+        log_info!(LOG_TAG, "Resuming interactive Claude session: {resume_id}");
+        args.push("--resume".to_string());
+        args.push(resume_id.to_string());
+    } else {
+        log_info!(LOG_TAG, "Starting new interactive Claude session");
+    }
+
+    if !append_system_prompt.is_empty() {
+        args.push("--append-system-prompt".to_string());
+        args.push(append_system_prompt.to_string());
+    }
+
+    if !disallowed_tools.is_empty() {
+        args.push("--disallowed-tools".to_string());
+        for tool in disallowed_tools.split(',') {
+            let tool = tool.trim();
+            if !tool.is_empty() {
+                args.push(tool.to_string());
+            }
+        }
+    }
+
+    if !tools.is_empty() {
+        args.push("--tools".to_string());
+        for tool in tools.split(',') {
+            let tool = tool.trim();
+            if !tool.is_empty() {
+                args.push(tool.to_string());
+            }
+        }
+    }
+
+    if !settings.is_empty() {
+        args.push("--settings".to_string());
+        args.push(settings.to_string());
+    }
+
     args
 }
 
@@ -598,6 +659,858 @@ pub struct CliExecutionResult {
     pub claude_result: Option<ClaudeResultSummary>,
 }
 
+struct ClaudeHookHarness {
+    _temp_dir: tempfile::TempDir,
+    fifo_path: String,
+    settings_json: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ClaudeHookEventName {
+    SessionStart,
+    Stop,
+}
+
+struct ClaudeHookEvent {
+    name: ClaudeHookEventName,
+    payload: Value,
+}
+
+#[derive(Default)]
+struct TranscriptTail {
+    path: Option<String>,
+    offset: u64,
+    pending: Vec<u8>,
+}
+
+#[derive(Default)]
+struct ClaudeUsageSummary {
+    input_tokens: u64,
+    output_tokens: u64,
+    cache_read_input_tokens: u64,
+    cache_creation_input_tokens: u64,
+}
+
+#[derive(Default)]
+struct ClaudeTranscriptSummary {
+    session_id: Option<String>,
+    final_text: Option<String>,
+    saw_assistant: bool,
+    is_error: bool,
+    num_turns: u64,
+    total_cost_usd: f64,
+    duration_api_ms: u64,
+    usage: ClaudeUsageSummary,
+    saw_result: bool,
+}
+
+#[derive(Default)]
+struct InteractiveEventState {
+    seq: u32,
+    stuck_tool_tracker: HashMap<String, (String, Instant)>,
+    transcript_summary: ClaudeTranscriptSummary,
+    claude_result: Option<ClaudeResultSummary>,
+    last_read_event_at: Option<Instant>,
+}
+
+fn shell_single_quote(value: &str) -> String {
+    if value.is_empty() {
+        return "''".to_string();
+    }
+    format!("'{}'", value.replace('\'', "'\\''"))
+}
+
+fn interactive_hook_entry(script_path: &str, event: &str) -> Value {
+    let command = format!("{} {event}", shell_single_quote(script_path));
+    json!({
+        "matcher": "*",
+        "hooks": [{
+            "type": "command",
+            "command": command,
+        }],
+    })
+}
+
+fn build_interactive_settings(settings: &str, script_path: &str) -> Result<String, AgentError> {
+    let mut root = if settings.trim().is_empty() {
+        json!({})
+    } else {
+        serde_json::from_str::<Value>(settings).map_err(|e| {
+            AgentError::Execution(format!(
+                "invalid Claude settings JSON for interactive driver: {e}"
+            ))
+        })?
+    };
+
+    let root_obj = root.as_object_mut().ok_or_else(|| {
+        AgentError::Execution("Claude settings JSON must be an object".to_string())
+    })?;
+    let hooks_value = root_obj.entry("hooks").or_insert_with(|| json!({}));
+    let hooks_obj = hooks_value.as_object_mut().ok_or_else(|| {
+        AgentError::Execution("Claude settings hooks field must be an object".to_string())
+    })?;
+
+    for event in ["SessionStart", "Stop"] {
+        let event_hooks = hooks_obj.entry(event).or_insert_with(|| json!([]));
+        let event_hooks = event_hooks.as_array_mut().ok_or_else(|| {
+            AgentError::Execution(format!(
+                "Claude settings hooks.{event} field must be an array"
+            ))
+        })?;
+        event_hooks.insert(0, interactive_hook_entry(script_path, event));
+    }
+
+    serde_json::to_string(&root).map_err(|e| AgentError::Execution(e.to_string()))
+}
+
+impl ClaudeHookHarness {
+    fn create(settings: &str) -> Result<Self, AgentError> {
+        let temp_dir = tempfile::Builder::new()
+            .prefix("vm0-claude-interactive-")
+            .tempdir()?;
+        let fifo_path_buf = temp_dir.path().join("hooks.fifo");
+        let script_path_buf = temp_dir.path().join("hook.sh");
+        let fifo_c = CString::new(fifo_path_buf.as_os_str().as_bytes()).map_err(|e| {
+            AgentError::Execution(format!("invalid interactive hook FIFO path: {e}"))
+        })?;
+        let status = unsafe { libc::mkfifo(fifo_c.as_ptr(), 0o600) };
+        if status != 0 {
+            return Err(AgentError::Io(std::io::Error::last_os_error()));
+        }
+
+        let fifo_path = fifo_path_buf.to_string_lossy().into_owned();
+        let script_path = script_path_buf.to_string_lossy().into_owned();
+        let script = format!(
+            "#!/bin/sh\nset -eu\nfifo={}\npayload=$(cat)\nprintf '%s\\t%s\\n' \"$1\" \"$payload\" > \"$fifo\"\n",
+            shell_single_quote(&fifo_path)
+        );
+        std::fs::write(&script_path_buf, script)?;
+        std::fs::set_permissions(&script_path_buf, std::fs::Permissions::from_mode(0o700))?;
+        let settings_json = build_interactive_settings(settings, &script_path)?;
+
+        Ok(Self {
+            _temp_dir: temp_dir,
+            fifo_path,
+            settings_json,
+        })
+    }
+
+    fn open_fifo(&self) -> Result<std::fs::File, AgentError> {
+        OpenOptions::new()
+            .read(true)
+            .write(true)
+            .custom_flags(libc::O_NONBLOCK)
+            .open(&self.fifo_path)
+            .map_err(AgentError::Io)
+    }
+}
+
+fn drain_fifo_lines(
+    fifo: &mut std::fs::File,
+    buffer: &mut Vec<u8>,
+) -> Result<Vec<String>, AgentError> {
+    let mut read_buffer = [0u8; 4096];
+    loop {
+        match fifo.read(&mut read_buffer) {
+            Ok(0) => break,
+            Ok(read) => {
+                let Some(chunk) = read_buffer.get(..read) else {
+                    return Err(AgentError::Execution(
+                        "interactive hook FIFO read exceeded buffer length".to_string(),
+                    ));
+                };
+                buffer.extend_from_slice(chunk);
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => break,
+            Err(e) => return Err(AgentError::Io(e)),
+        }
+    }
+    Ok(drain_complete_lines(buffer))
+}
+
+fn drain_complete_lines(buffer: &mut Vec<u8>) -> Vec<String> {
+    let mut lines = Vec::new();
+    while let Some(pos) = buffer.iter().position(|byte| *byte == b'\n') {
+        let mut bytes = buffer.drain(..=pos).collect::<Vec<_>>();
+        if bytes.last() == Some(&b'\n') {
+            bytes.pop();
+        }
+        if bytes.last() == Some(&b'\r') {
+            bytes.pop();
+        }
+        if !bytes.is_empty() {
+            lines.push(String::from_utf8_lossy(&bytes).into_owned());
+        }
+    }
+    lines
+}
+
+fn parse_hook_line(line: &str) -> Option<ClaudeHookEvent> {
+    let (event_name, payload) = line.split_once('\t')?;
+    let name = match event_name {
+        "SessionStart" => ClaudeHookEventName::SessionStart,
+        "Stop" => ClaudeHookEventName::Stop,
+        _ => return None,
+    };
+    let payload = match serde_json::from_str::<Value>(payload) {
+        Ok(payload) => payload,
+        Err(e) => {
+            log_warn!(LOG_TAG, "Ignoring malformed Claude hook payload: {e}");
+            return None;
+        }
+    };
+    Some(ClaudeHookEvent { name, payload })
+}
+
+fn hook_string<'a>(payload: &'a Value, field: &str) -> Option<&'a str> {
+    payload.get(field).and_then(Value::as_str)
+}
+
+fn hook_session_id(payload: &Value) -> Option<&str> {
+    hook_string(payload, "session_id").or_else(|| hook_string(payload, "sessionId"))
+}
+
+fn hook_transcript_path(payload: &Value) -> Option<&str> {
+    hook_string(payload, "transcript_path")
+}
+
+fn persist_interactive_session(payload: &Value) {
+    if let Some(session_id) = hook_session_id(payload)
+        && !session_id.is_empty()
+        && !std::path::Path::new(paths::session_id_file()).exists()
+    {
+        log_info!(
+            LOG_TAG,
+            "Captured interactive Claude session ID: {session_id}"
+        );
+        let _ = std::fs::write(paths::session_id_file(), session_id);
+    }
+
+    if let Some(transcript_path) = hook_transcript_path(payload)
+        && !transcript_path.is_empty()
+        && !std::path::Path::new(paths::session_history_path_file()).exists()
+    {
+        let _ = std::fs::write(paths::session_history_path_file(), transcript_path);
+        log_info!(
+            LOG_TAG,
+            "Interactive Claude transcript will be at: {transcript_path}"
+        );
+    }
+}
+
+impl TranscriptTail {
+    fn set_path(&mut self, path: &str) {
+        if self.path.as_deref() == Some(path) {
+            return;
+        }
+        self.path = Some(path.to_string());
+        self.offset = 0;
+        self.pending.clear();
+    }
+
+    fn read_new_lines(&mut self) -> Result<Vec<String>, AgentError> {
+        let Some(path) = self.path.as_deref() else {
+            return Ok(Vec::new());
+        };
+        let mut file = match std::fs::File::open(path) {
+            Ok(file) => file,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+            Err(e) => return Err(AgentError::Io(e)),
+        };
+        file.seek(SeekFrom::Start(self.offset))?;
+        let mut bytes = Vec::new();
+        let read = file.read_to_end(&mut bytes)?;
+        self.offset = self.offset.saturating_add(read as u64);
+        if read == 0 {
+            return Ok(Vec::new());
+        }
+        self.pending.extend_from_slice(&bytes);
+        Ok(drain_complete_lines(&mut self.pending))
+    }
+
+    fn finish_pending_line(&mut self) -> Option<String> {
+        if self.pending.is_empty() {
+            return None;
+        }
+        let mut bytes = std::mem::take(&mut self.pending);
+        if bytes.last() == Some(&b'\r') {
+            bytes.pop();
+        }
+        if bytes.is_empty() {
+            return None;
+        }
+        Some(String::from_utf8_lossy(&bytes).into_owned())
+    }
+}
+
+impl ClaudeUsageSummary {
+    fn add_from_value(&mut self, usage: &Value) {
+        self.input_tokens = self.input_tokens.saturating_add(
+            usage
+                .get("input_tokens")
+                .and_then(Value::as_u64)
+                .unwrap_or(0),
+        );
+        self.output_tokens = self.output_tokens.saturating_add(
+            usage
+                .get("output_tokens")
+                .and_then(Value::as_u64)
+                .unwrap_or(0),
+        );
+        self.cache_read_input_tokens = self.cache_read_input_tokens.saturating_add(
+            usage
+                .get("cache_read_input_tokens")
+                .and_then(Value::as_u64)
+                .unwrap_or(0),
+        );
+        self.cache_creation_input_tokens = self.cache_creation_input_tokens.saturating_add(
+            usage
+                .get("cache_creation_input_tokens")
+                .and_then(Value::as_u64)
+                .unwrap_or(0),
+        );
+    }
+
+    fn to_json(&self) -> Value {
+        json!({
+            "input_tokens": self.input_tokens,
+            "output_tokens": self.output_tokens,
+            "cache_read_input_tokens": self.cache_read_input_tokens,
+            "cache_creation_input_tokens": self.cache_creation_input_tokens,
+        })
+    }
+}
+
+impl ClaudeTranscriptSummary {
+    fn update_from_event(&mut self, event: &Value) {
+        if self.session_id.is_none() {
+            self.session_id = event
+                .get("session_id")
+                .or_else(|| event.get("sessionId"))
+                .and_then(Value::as_str)
+                .filter(|value| !value.is_empty())
+                .map(ToOwned::to_owned);
+        }
+
+        match event.get("type").and_then(Value::as_str) {
+            Some("assistant") => {
+                self.saw_assistant = true;
+                self.num_turns = self.num_turns.saturating_add(1);
+                if let Some(text) = assistant_text(event)
+                    && !text.is_empty()
+                {
+                    self.final_text = Some(text);
+                }
+                if let Some(usage) = event.pointer("/message/usage") {
+                    self.usage.add_from_value(usage);
+                }
+            }
+            Some("result") => {
+                self.saw_result = true;
+                if let Some(result) = event.get("result").and_then(Value::as_str) {
+                    self.final_text = Some(result.to_string());
+                }
+                if let Some(is_error) = event.get("is_error").and_then(Value::as_bool) {
+                    self.is_error = is_error;
+                }
+                if let Some(num_turns) = event.get("num_turns").and_then(Value::as_u64) {
+                    self.num_turns = num_turns;
+                }
+                if let Some(total_cost_usd) = event.get("total_cost_usd").and_then(Value::as_f64) {
+                    self.total_cost_usd = total_cost_usd;
+                }
+                if let Some(duration_api_ms) = event.get("duration_api_ms").and_then(Value::as_u64)
+                {
+                    self.duration_api_ms = duration_api_ms;
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn result_event(&self, duration: Duration, fallback_text: Option<&str>) -> Value {
+        let result = self
+            .final_text
+            .as_deref()
+            .or(fallback_text)
+            .unwrap_or_default();
+        let is_error = self.is_error || (!self.saw_assistant && fallback_text.is_none());
+        json!({
+            "type": "result",
+            "subtype": if is_error { "error" } else { "success" },
+            "session_id": self.session_id.as_deref().unwrap_or_default(),
+            "result": result,
+            "is_error": is_error,
+            "duration_ms": duration.as_millis() as u64,
+            "duration_api_ms": self.duration_api_ms,
+            "num_turns": self.num_turns,
+            "total_cost_usd": self.total_cost_usd,
+            "usage": self.usage.to_json(),
+            "permission_denials": [],
+        })
+    }
+}
+
+fn assistant_text(event: &Value) -> Option<String> {
+    let contents = event.pointer("/message/content")?.as_array()?;
+    let mut text = String::new();
+    for content in contents {
+        if content.get("type").and_then(Value::as_str) == Some("text")
+            && let Some(block_text) = content.get("text").and_then(Value::as_str)
+        {
+            text.push_str(block_text);
+        }
+    }
+    Some(text)
+}
+
+fn normalize_claude_transcript_event(event: &mut Value) {
+    if event.get("session_id").is_some() {
+        return;
+    }
+    let Some(session_id) = event.get("sessionId").cloned() else {
+        return;
+    };
+    let Some(obj) = event.as_object_mut() else {
+        return;
+    };
+    obj.insert("session_id".to_string(), session_id);
+}
+
+async fn process_interactive_claude_event_line(
+    line: &str,
+    log_file: &mut tokio::fs::File,
+    masker: &SecretMasker,
+    behavior: CliFrameworkBehavior,
+    event_tx: &tokio::sync::mpsc::UnboundedSender<PreparedEvent>,
+    state: &mut InteractiveEventState,
+) -> Result<(), AgentError> {
+    let _ = log_file.write_all(line.as_bytes()).await;
+    let _ = log_file.write_all(b"\n").await;
+
+    let stripped = line.trim();
+    if stripped.is_empty() {
+        return Ok(());
+    }
+
+    let Ok(mut event) = serde_json::from_str::<Value>(stripped) else {
+        return Ok(());
+    };
+
+    normalize_claude_transcript_event(&mut event);
+    state.transcript_summary.update_from_event(&event);
+    state.last_read_event_at = Some(Instant::now());
+    if state.seq == 0 {
+        timing::record_e2e_from_api("api_to_cli_init");
+    }
+    if behavior.handles_claude_result_event(&event) {
+        state.claude_result = Some(ClaudeResultSummary::from_event(&event));
+        if let Some(result) = event.get("result").and_then(Value::as_str) {
+            println!("{result}");
+        }
+    }
+    behavior.track_claude_tool_events(&event, &mut state.stuck_tool_tracker);
+    if let Some(payload) = events::prepare_event(&mut event, state.seq, masker)
+        && event_tx
+            .send(PreparedEvent {
+                sequence: state.seq,
+                payload,
+            })
+            .is_err()
+    {
+        log_warn!(
+            LOG_TAG,
+            "Event channel closed, dropping event seq={}",
+            state.seq
+        );
+    }
+    state.seq += 1;
+    Ok(())
+}
+
+fn duplicate_file(file: &std::fs::File) -> Result<std::fs::File, AgentError> {
+    let fd = unsafe { libc::dup(file.as_raw_fd()) };
+    if fd < 0 {
+        return Err(AgentError::Io(std::io::Error::last_os_error()));
+    }
+    Ok(unsafe { std::fs::File::from_raw_fd(fd) })
+}
+
+fn open_pty() -> Result<(std::fs::File, std::fs::File), AgentError> {
+    let mut master = -1;
+    let mut slave = -1;
+    let status = unsafe {
+        libc::openpty(
+            &mut master,
+            &mut slave,
+            std::ptr::null_mut(),
+            std::ptr::null(),
+            std::ptr::null(),
+        )
+    };
+    if status != 0 {
+        return Err(AgentError::Io(std::io::Error::last_os_error()));
+    }
+    let master = unsafe { std::fs::File::from_raw_fd(master) };
+    let slave = unsafe { std::fs::File::from_raw_fd(slave) };
+    Ok((master, slave))
+}
+
+fn configure_claude_command_env(cmd: &mut tokio::process::Command) {
+    cmd.env("CLAUDE_CODE_DISABLE_BACKGROUND_TASKS", "1");
+    cmd.env("CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC", "1");
+    cmd.env("CLAUDE_CODE_DISABLE_FEEDBACK_SURVEY", "1");
+    cmd.env("CLAUDE_CODE_DISABLE_TERMINAL_TITLE", "1");
+    cmd.env("DISABLE_AUTOUPDATER", "1");
+    cmd.env("DISABLE_ERROR_REPORTING", "1");
+    cmd.env("DISABLE_INSTALLATION_CHECKS", "1");
+    cmd.env("DISABLE_TELEMETRY", "1");
+}
+
+fn signal_process_group(pgid: Option<i32>, signal: i32, reason: &str) {
+    if let Some(pid) = pgid {
+        log_warn!(LOG_TAG, "{reason}, signal={signal} pgid={pid}");
+        unsafe {
+            libc::kill(-pid, signal);
+        }
+    }
+}
+
+async fn execute_interactive_claude(
+    masker: &SecretMasker,
+    mut heartbeat_handle: tokio::task::JoinHandle<Result<(), AgentError>>,
+    http: HttpClient,
+) -> Result<CliExecutionResult, AgentError> {
+    let behavior = CliFrameworkBehavior::new(env::Framework::ClaudeCode);
+    log_info!(LOG_TAG, "Starting interactive Claude Code execution...");
+
+    let harness = ClaudeHookHarness::create(env::settings())?;
+    let args = build_interactive_claude_args(
+        env::resume_session_id(),
+        env::append_system_prompt(),
+        env::disallowed_tools(),
+        env::tools(),
+        &harness.settings_json,
+    );
+    let bin = if env::use_mock_claude() {
+        log_info!(LOG_TAG, "Using mock-claude for interactive testing");
+        env::mock_claude_path()
+    } else {
+        "claude".to_string()
+    };
+
+    let mut fifo = harness.open_fifo()?;
+    let (master, slave) = open_pty()?;
+    let master_writer = duplicate_file(&master)?;
+    let slave_stdin = duplicate_file(&slave)?;
+    let slave_stdout = duplicate_file(&slave)?;
+    let slave_stderr = duplicate_file(&slave)?;
+
+    let mut cmd = tokio::process::Command::new(&bin);
+    cmd.args(&args)
+        .stdin(Stdio::from(slave_stdin))
+        .stdout(Stdio::from(slave_stdout))
+        .stderr(Stdio::from(slave_stderr))
+        .kill_on_drop(true);
+    configure_claude_command_env(&mut cmd);
+    unsafe {
+        cmd.pre_exec(|| {
+            if libc::setsid() == -1 {
+                return Err(std::io::Error::last_os_error());
+            }
+            if libc::ioctl(0, libc::TIOCSCTTY, 0) == -1 {
+                return Err(std::io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
+
+    let mut log_file = tokio::fs::File::create(paths::agent_log_file()).await?;
+    let mut child = cmd.spawn()?;
+    drop(slave);
+
+    let pgid = child.id().map(|pid| pid as i32);
+    let mut pty_reader = tokio::fs::File::from_std(master);
+    let mut pty_writer = tokio::fs::File::from_std(master_writer);
+    let pty_drain = tokio::spawn(async move {
+        let mut buffer = [0u8; 8192];
+        loop {
+            match pty_reader.read(&mut buffer).await {
+                Ok(0) => break,
+                Ok(_) => {}
+                Err(_) => break,
+            }
+        }
+    });
+
+    let (event_tx, mut event_rx) = tokio::sync::mpsc::unbounded_channel::<PreparedEvent>();
+    let event_http = http.clone();
+    let event_sender = tokio::spawn(async move {
+        let mut acked_prefix = AckedEventPrefix::default();
+        while let Some(event) = event_rx.recv().await {
+            match events::post_event(&event_http, &event.payload).await {
+                Ok(()) => {
+                    acked_prefix.record_success(event.sequence);
+                }
+                Err(e) => {
+                    acked_prefix.record_failure(event.sequence);
+                    log_warn!(LOG_TAG, "Event send failed: {e}");
+                }
+            }
+        }
+        acked_prefix.last_contiguous()
+    });
+
+    let mut hook_buffer = Vec::new();
+    let mut transcript_tail = TranscriptTail::default();
+    let mut event_state = InteractiveEventState::default();
+    let mut fallback_final_text: Option<String> = None;
+    let mut prompt_sent = false;
+    let mut stop_seen = false;
+    let mut final_drain_armed = false;
+    let mut cli_status: Option<std::process::ExitStatus> = None;
+    let mut cli_exit_at: Option<Instant> = None;
+    let mut stuck_tool_check = {
+        let interval = Duration::from_secs(constants::STUCK_TOOL_CHECK_INTERVAL_SECS);
+        tokio::time::interval_at(tokio::time::Instant::now() + interval, interval)
+    };
+    const STUCK_TOOL_NAMES: &[&str] = &["WebSearch", "WebFetch"];
+
+    let mut hook_poll = tokio::time::interval(Duration::from_millis(INTERACTIVE_HOOK_POLL_MS));
+    let mut transcript_poll =
+        tokio::time::interval(Duration::from_millis(INTERACTIVE_TRANSCRIPT_TAIL_MS));
+    let post_stop_deadline = tokio::time::sleep(Duration::MAX);
+    tokio::pin!(post_stop_deadline);
+
+    let started_at = Instant::now();
+    let event_result: Result<(), AgentError> = loop {
+        tokio::select! {
+            _ = hook_poll.tick() => {
+                let lines = drain_fifo_lines(&mut fifo, &mut hook_buffer)?;
+                for line in lines {
+                    let Some(event) = parse_hook_line(&line) else {
+                        continue;
+                    };
+                    persist_interactive_session(&event.payload);
+                    if let Some(path) = hook_transcript_path(&event.payload) {
+                        transcript_tail.set_path(path);
+                    }
+
+                    match event.name {
+                        ClaudeHookEventName::SessionStart => {
+                            if !prompt_sent {
+                                pty_writer.write_all(env::prompt().as_bytes()).await?;
+                                pty_writer.write_all(b"\r").await?;
+                                pty_writer.flush().await?;
+                                prompt_sent = true;
+                            }
+                        }
+                        ClaudeHookEventName::Stop => {
+                            stop_seen = true;
+                            final_drain_armed = true;
+                            fallback_final_text = hook_string(&event.payload, "last_assistant_message")
+                                .map(ToOwned::to_owned);
+                            post_stop_deadline.as_mut().reset(
+                                tokio::time::Instant::now()
+                                    + Duration::from_millis(INTERACTIVE_POST_STOP_DRAIN_MS),
+                            );
+                        }
+                    }
+                }
+            }
+            _ = transcript_poll.tick() => {
+                for line in transcript_tail.read_new_lines()? {
+                    process_interactive_claude_event_line(
+                        &line,
+                        &mut log_file,
+                        masker,
+                        behavior,
+                        &event_tx,
+                        &mut event_state,
+                    )
+                    .await?;
+                }
+            }
+            status = child.wait(), if cli_status.is_none() => {
+                match status {
+                    Ok(status) => {
+                        cli_exit_at = Some(Instant::now());
+                        log_info!(LOG_TAG, "Interactive Claude process exited (status: {status})");
+                        cli_status = Some(status);
+                        if !stop_seen {
+                            final_drain_armed = true;
+                            post_stop_deadline.as_mut().reset(
+                                tokio::time::Instant::now()
+                                    + Duration::from_millis(INTERACTIVE_POST_STOP_DRAIN_MS),
+                            );
+                        }
+                    }
+                    Err(e) => break Err(AgentError::Io(e)),
+                }
+            }
+            _ = stuck_tool_check.tick() => {
+                let timeout_secs = env::stuck_tool_timeout_secs();
+                let stuck = event_state.stuck_tool_tracker
+                    .values()
+                    .filter(|(name, started)| {
+                        started.elapsed().as_secs() >= timeout_secs
+                            && STUCK_TOOL_NAMES.contains(&name.as_str())
+                    })
+                    .min_by_key(|(_, started)| *started)
+                    .map(|(name, started)| (name.clone(), started.elapsed().as_secs()));
+                if let Some((name, elapsed)) = stuck {
+                    let timeout_error = AgentError::Execution(format!(
+                        "Tool timeout: {name} exceeded {timeout_secs}s without returning a result"
+                    ));
+                    log_warn!(
+                        LOG_TAG,
+                        "Tool timeout: {name} stuck for {elapsed}s in interactive Claude"
+                    );
+                    signal_process_group(pgid, libc::SIGTERM, "Terminating stuck interactive Claude");
+                    break Err(timeout_error);
+                }
+            }
+            hb_result = &mut heartbeat_handle => {
+                match hb_result {
+                    Ok(Err(e)) => {
+                        signal_process_group(pgid, libc::SIGTERM, "Heartbeat failed for interactive Claude");
+                        break Err(e);
+                    }
+                    Ok(Ok(())) => break Ok(()),
+                    Err(e) => {
+                        signal_process_group(pgid, libc::SIGTERM, "Heartbeat task panicked for interactive Claude");
+                        break Err(AgentError::Execution(format!("heartbeat task panicked: {e}")));
+                    }
+                }
+            }
+            () = &mut post_stop_deadline, if final_drain_armed => {
+                break Ok(());
+            }
+        }
+    };
+
+    if event_result.is_ok() {
+        for line in transcript_tail.read_new_lines()? {
+            process_interactive_claude_event_line(
+                &line,
+                &mut log_file,
+                masker,
+                behavior,
+                &event_tx,
+                &mut event_state,
+            )
+            .await?;
+        }
+        if let Some(line) = transcript_tail.finish_pending_line() {
+            process_interactive_claude_event_line(
+                &line,
+                &mut log_file,
+                masker,
+                behavior,
+                &event_tx,
+                &mut event_state,
+            )
+            .await?;
+        }
+        if stop_seen && !event_state.transcript_summary.saw_result {
+            let result_event = event_state
+                .transcript_summary
+                .result_event(started_at.elapsed(), fallback_final_text.as_deref());
+            let result_line = serde_json::to_string(&result_event)
+                .map_err(|e| AgentError::Execution(e.to_string()))?;
+            process_interactive_claude_event_line(
+                &result_line,
+                &mut log_file,
+                masker,
+                behavior,
+                &event_tx,
+                &mut event_state,
+            )
+            .await?;
+        }
+    }
+
+    drop(event_tx);
+    let mut last_event_sequence = None;
+    if event_result.is_ok() {
+        match event_sender.await {
+            Ok(sequence) => {
+                last_event_sequence = sequence;
+            }
+            Err(e) => {
+                log_warn!(LOG_TAG, "Event sender task failed: {e}");
+            }
+        }
+    } else {
+        event_sender.abort();
+        let _ = event_sender.await;
+    }
+
+    let status = match cli_status {
+        Some(status) => status,
+        None => wait_or_kill_child(&mut child, pgid).await?,
+    };
+    if cli_exit_at.is_none() {
+        cli_exit_at = Some(Instant::now());
+    }
+    if let (Some(last_read_event_at), Some(cli_exit_at)) =
+        (event_state.last_read_event_at, cli_exit_at)
+    {
+        record_sandbox_op(
+            "last_read_event_to_cli_exit",
+            cli_exit_at
+                .checked_duration_since(last_read_event_at)
+                .unwrap_or(Duration::ZERO),
+            true,
+            None,
+        );
+    }
+    pty_drain.abort();
+    let _ = pty_drain.await;
+
+    event_result?;
+
+    let exit_code = if event_state.claude_result.is_some() {
+        if event_state.transcript_summary.is_error
+            || (stop_seen
+                && !event_state.transcript_summary.saw_assistant
+                && fallback_final_text.is_none())
+        {
+            1
+        } else {
+            0
+        }
+    } else {
+        status.code().unwrap_or(1)
+    };
+
+    Ok(CliExecutionResult {
+        exit_code,
+        stderr_lines: Vec::new(),
+        last_event_sequence,
+        claude_result: event_state.claude_result,
+    })
+}
+
+async fn wait_or_kill_child(
+    child: &mut tokio::process::Child,
+    pgid: Option<i32>,
+) -> Result<std::process::ExitStatus, AgentError> {
+    if let Some(status) = child.try_wait()? {
+        return Ok(status);
+    }
+    signal_process_group(pgid, libc::SIGTERM, "Terminating interactive Claude");
+    let wait = tokio::time::sleep(Duration::from_millis(INTERACTIVE_PROCESS_EXIT_GRACE_MS));
+    tokio::pin!(wait);
+    tokio::select! {
+        status = child.wait() => status.map_err(AgentError::Io),
+        () = &mut wait => {
+            signal_process_group(pgid, libc::SIGKILL, "Escalating interactive Claude termination");
+            child.wait().await.map_err(AgentError::Io)
+        }
+    }
+}
+
 /// Execute the CLI process, streaming JSONL events and racing against heartbeat.
 pub async fn execute_cli(
     masker: &SecretMasker,
@@ -605,6 +1518,12 @@ pub async fn execute_cli(
     http: HttpClient,
 ) -> Result<CliExecutionResult, AgentError> {
     let framework = env::Framework::from_env();
+    if matches!(framework, env::Framework::ClaudeCode)
+        && matches!(env::claude_driver(), env::ClaudeDriver::Interactive)
+    {
+        return execute_interactive_claude(masker, heartbeat_handle, http).await;
+    }
+
     let behavior = CliFrameworkBehavior::new(framework);
     log_info!(LOG_TAG, "Starting {} execution...", behavior.agent_type());
 
@@ -630,14 +1549,7 @@ pub async fn execute_cli(
             // update check, GitHub) add ~2s latency, background tasks can keep
             // a one-shot run alive after its final result, telemetry has no
             // receiver, and the CLI version is baked into the rootfs image.
-            cmd.env("CLAUDE_CODE_DISABLE_BACKGROUND_TASKS", "1");
-            cmd.env("CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC", "1");
-            cmd.env("CLAUDE_CODE_DISABLE_FEEDBACK_SURVEY", "1");
-            cmd.env("CLAUDE_CODE_DISABLE_TERMINAL_TITLE", "1");
-            cmd.env("DISABLE_AUTOUPDATER", "1");
-            cmd.env("DISABLE_ERROR_REPORTING", "1");
-            cmd.env("DISABLE_INSTALLATION_CHECKS", "1");
-            cmd.env("DISABLE_TELEMETRY", "1");
+            configure_claude_command_env(&mut cmd);
         }
         env::Framework::Codex => {
             // `codex login` and `codex exec` both honor CODEX_HOME; pin
@@ -1158,6 +2070,57 @@ mod tests {
         assert_prompt_with_separator(&args, "hello world");
         assert!(!args.contains(&"--append-system-prompt".to_string()));
         assert!(!args.contains(&"--resume".to_string()));
+    }
+
+    #[test]
+    fn build_interactive_claude_args_omits_print_mode() {
+        disable_system_log();
+        let args = build_interactive_claude_args(
+            "sess-123",
+            "Be helpful.",
+            "CronCreate,CronDelete",
+            "Bash,Read",
+            r#"{"hooks":{}}"#,
+        );
+
+        assert!(!args.contains(&"--print".to_string()));
+        assert!(!args.contains(&"--output-format".to_string()));
+        assert!(!args.contains(&"stream-json".to_string()));
+        assert!(args.contains(&"--dangerously-skip-permissions".to_string()));
+        assert!(args.contains(&"--resume".to_string()));
+        assert!(args.contains(&"--append-system-prompt".to_string()));
+        assert!(args.contains(&"--settings".to_string()));
+    }
+
+    #[test]
+    fn build_interactive_settings_merges_existing_hooks() {
+        let settings = r#"{"hooks":{"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"touch /tmp/original"}]}],"Stop":[{"matcher":"*","hooks":[{"type":"command","command":"touch /tmp/user-stop"}]}]}}"#;
+        let merged = build_interactive_settings(settings, "/tmp/vm0 hook.sh").unwrap();
+        let parsed = serde_json::from_str::<serde_json::Value>(&merged).unwrap();
+
+        let hooks = parsed.get("hooks").unwrap();
+        assert_eq!(
+            hooks
+                .get("PreToolUse")
+                .and_then(serde_json::Value::as_array)
+                .unwrap()
+                .len(),
+            1
+        );
+        let stop_hooks = hooks
+            .get("Stop")
+            .and_then(serde_json::Value::as_array)
+            .unwrap();
+        assert_eq!(stop_hooks.len(), 2);
+        let first_stop_command = stop_hooks[0]
+            .get("hooks")
+            .and_then(serde_json::Value::as_array)
+            .and_then(|items| items[0].get("command"))
+            .and_then(serde_json::Value::as_str)
+            .unwrap();
+        assert!(first_stop_command.contains("'"));
+        assert!(first_stop_command.ends_with(" Stop"));
+        assert!(hooks.get("SessionStart").is_some());
     }
 
     #[test]

--- a/crates/guest-agent/src/env.rs
+++ b/crates/guest-agent/src/env.rs
@@ -49,6 +49,25 @@ static FRAMEWORK: LazyLock<Framework> = LazyLock::new(|| match cli_agent_type() 
     }
 });
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ClaudeDriver {
+    Print,
+    Interactive,
+}
+
+static CLAUDE_DRIVER: LazyLock<ClaudeDriver> =
+    LazyLock::new(|| match env_or_empty("VM0_CLAUDE_DRIVER").as_str() {
+        "" | "print" => ClaudeDriver::Print,
+        "interactive" => ClaudeDriver::Interactive,
+        other => {
+            log_warn!(
+                LOG_TAG,
+                "Unknown VM0_CLAUDE_DRIVER={other:?}, defaulting to print"
+            );
+            ClaudeDriver::Print
+        }
+    });
+
 // ---------------------------------------------------------------------------
 // Core
 // ---------------------------------------------------------------------------
@@ -291,6 +310,10 @@ pub fn tools() -> &'static str {
 /// override.
 pub fn settings() -> &'static str {
     &SETTINGS
+}
+/// Claude Code driver selector from `VM0_CLAUDE_DRIVER`; defaults to print.
+pub fn claude_driver() -> ClaudeDriver {
+    *CLAUDE_DRIVER
 }
 /// Whether `USE_MOCK_CLAUDE` is exactly `"true"`; unset or any other value is
 /// false.

--- a/crates/guest-agent/src/events.rs
+++ b/crates/guest-agent/src/events.rs
@@ -294,7 +294,10 @@ fn extract_claude_session_id(event: &Value) -> Option<(String, String)> {
     if event_type != "system" || subtype != "init" {
         return None;
     }
-    let session_id = event.get("session_id").and_then(|v| v.as_str())?;
+    let session_id = event
+        .get("session_id")
+        .or_else(|| event.get("sessionId"))
+        .and_then(|v| v.as_str())?;
     if session_id.is_empty() {
         return None;
     }

--- a/crates/guest-agent/tests/interactive_claude_driver.rs
+++ b/crates/guest-agent/tests/interactive_claude_driver.rs
@@ -1,0 +1,47 @@
+//! Interactive Claude driver coverage lives in its own test binary because
+//! guest_agent::env caches environment variables with process-wide LazyLocks.
+
+mod common;
+
+use guest_agent::http::HttpClient;
+use guest_agent::masker::SecretMasker;
+use std::sync::Arc;
+use std::time::Duration;
+
+#[tokio::test]
+async fn interactive_claude_driver_replays_mock_transcript()
+-> Result<(), Box<dyn std::error::Error>> {
+    let mock = common::build_and_locate_mock()?;
+    let tmp = tempfile::tempdir()?;
+    unsafe {
+        common::setup_env(&mock, tmp.path(), "printf 'interactive-ok'", 3, 1)?;
+        std::env::set_var("VM0_CLAUDE_DRIVER", "interactive");
+    }
+
+    let _ = std::fs::remove_file(guest_agent::paths::session_id_file());
+    let _ = std::fs::remove_file(guest_agent::paths::session_history_path_file());
+
+    let http = HttpClient::for_current_env()?;
+    let masker = Arc::new(SecretMasker::from_raw(""));
+    let result = tokio::time::timeout(
+        Duration::from_secs(10),
+        guest_agent::cli::execute_cli(&masker, common::spawn_dummy_heartbeat(), http),
+    )
+    .await
+    .expect("interactive execute_cli should return promptly")?;
+
+    assert_eq!(result.exit_code, common::CLEAN_EXIT);
+    assert_eq!(result.last_event_sequence, None);
+    assert!(result.claude_result.is_some());
+
+    let session_history_path =
+        std::fs::read_to_string(guest_agent::paths::session_history_path_file())?;
+    let session_history = std::fs::read_to_string(session_history_path.trim())?;
+    assert!(session_history.contains("sessionId"));
+    assert!(session_history.contains("interactive-ok"));
+
+    let agent_log = std::fs::read_to_string(guest_agent::paths::agent_log_file())?;
+    assert!(agent_log.contains("interactive-ok"));
+    assert!(agent_log.contains("\"type\":\"result\""));
+    Ok(())
+}

--- a/crates/guest-mock-claude/src/main.rs
+++ b/crates/guest-mock-claude/src/main.rs
@@ -31,19 +31,22 @@
 //!                               happy path
 
 use serde_json::{Value, json};
-use std::io::Write;
+use std::io::{Read, Write};
+use std::os::fd::AsRawFd;
 use std::process::{Command, ExitCode, Stdio};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 /// Parsed command-line arguments.
 struct ParsedArgs {
     output_format: String,
+    settings: Option<String>,
     prompt: String,
 }
 
 /// Parse command-line arguments (matching the real Claude CLI interface).
 fn parse_args(args: &[String]) -> ParsedArgs {
     let mut output_format = "text".to_string();
+    let mut settings = None;
     let mut remaining: Vec<String> = Vec::new();
 
     let mut i = 0;
@@ -81,7 +84,8 @@ fn parse_args(args: &[String]) -> ParsedArgs {
             }
             "--settings" => {
                 // Skip the flag and its single JSON value argument
-                if args.get(i + 1).is_some() {
+                if let Some(value) = args.get(i + 1) {
+                    settings = Some(value.clone());
                     i += 2;
                 } else {
                     i += 1;
@@ -111,6 +115,7 @@ fn parse_args(args: &[String]) -> ParsedArgs {
 
     ParsedArgs {
         output_format,
+        settings,
         prompt,
     }
 }
@@ -142,6 +147,200 @@ fn build_session_history_path(session_id: &str, cwd: &str, home: &str) -> Option
 fn create_session_history(session_id: &str, cwd: &str) -> Option<String> {
     let home = std::env::var("HOME").unwrap_or_else(|_| "/home/user".to_string());
     build_session_history_path(session_id, cwd, &home)
+}
+
+fn hook_commands(settings: Option<&str>, event: &str) -> Vec<String> {
+    let Some(settings) = settings else {
+        return Vec::new();
+    };
+    let Ok(parsed) = serde_json::from_str::<Value>(settings) else {
+        return Vec::new();
+    };
+    let Some(entries) = parsed
+        .get("hooks")
+        .and_then(|hooks| hooks.get(event))
+        .and_then(Value::as_array)
+    else {
+        return Vec::new();
+    };
+
+    let mut commands = Vec::new();
+    for entry in entries {
+        let Some(hooks) = entry.get("hooks").and_then(Value::as_array) else {
+            continue;
+        };
+        for hook in hooks {
+            if hook.get("type").and_then(Value::as_str) != Some("command") {
+                continue;
+            }
+            if let Some(command) = hook.get("command").and_then(Value::as_str) {
+                commands.push(command.to_string());
+            }
+        }
+    }
+    commands
+}
+
+fn run_hook_commands(settings: Option<&str>, event: &str, payload: &Value) {
+    let payload = payload.to_string();
+    for command in hook_commands(settings, event) {
+        let Ok(mut child) = Command::new("sh")
+            .arg("-c")
+            .arg(command)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+        else {
+            continue;
+        };
+        if let Some(mut stdin) = child.stdin.take() {
+            let _ = stdin.write_all(payload.as_bytes());
+        }
+        let _ = child.wait();
+    }
+}
+
+fn read_interactive_prompt(timeout_ms: i32) -> String {
+    let stdin = std::io::stdin();
+    let fd = stdin.as_raw_fd();
+    let mut pollfd = libc::pollfd {
+        fd,
+        events: libc::POLLIN,
+        revents: 0,
+    };
+    let ready = unsafe { libc::poll(&mut pollfd, 1, timeout_ms) };
+    if ready <= 0 {
+        return String::new();
+    }
+
+    let mut stdin = stdin.lock();
+    let mut bytes = Vec::new();
+    let mut byte = [0u8; 1];
+    while let Ok(1) = stdin.read(&mut byte) {
+        if byte[0] == b'\r' || byte[0] == b'\n' {
+            break;
+        }
+        bytes.push(byte[0]);
+    }
+    String::from_utf8_lossy(&bytes).into_owned()
+}
+
+fn write_event(file: &mut std::fs::File, event: &Value) {
+    let _ = writeln!(file, "{event}");
+    let _ = file.flush();
+}
+
+fn run_interactive_mode(settings: Option<&str>, session_id: &str) -> ExitCode {
+    let cwd = std::env::current_dir()
+        .map(|p| p.to_string_lossy().into_owned())
+        .unwrap_or_else(|_| "/".to_string());
+    let Some(session_history_file) = create_session_history(session_id, &cwd) else {
+        return ExitCode::from(1);
+    };
+
+    let session_start = json!({
+        "hook_event_name": "SessionStart",
+        "session_id": session_id,
+        "transcript_path": session_history_file,
+        "cwd": cwd,
+    });
+    run_hook_commands(settings, "SessionStart", &session_start);
+
+    let prompt = read_interactive_prompt(1000);
+    let Ok(mut file) = std::fs::File::create(&session_history_file) else {
+        return ExitCode::from(1);
+    };
+
+    let init_event = json!({
+        "type": "system",
+        "subtype": "init",
+        "cwd": cwd,
+        "sessionId": session_id,
+        "tools": ["Bash"],
+        "model": "mock-claude"
+    });
+    write_event(&mut file, &init_event);
+
+    let text_event = json!({
+        "type": "assistant",
+        "sessionId": session_id,
+        "message": {
+            "role": "assistant",
+            "content": [{"type": "text", "text": "Executing command..."}]
+        }
+    });
+    write_event(&mut file, &text_event);
+
+    let tool_use_event = json!({
+        "type": "assistant",
+        "sessionId": session_id,
+        "message": {
+            "role": "assistant",
+            "content": [{
+                "type": "tool_use",
+                "id": "toolu_mock_001",
+                "name": "Bash",
+                "input": {"command": prompt}
+            }]
+        }
+    });
+    write_event(&mut file, &tool_use_event);
+
+    let (output, exit_code) = match Command::new("bash")
+        .args(["-c", &prompt])
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+    {
+        Ok(result) => {
+            let mut combined = String::from_utf8_lossy(&result.stdout).into_owned();
+            if !result.status.success() {
+                combined.push_str(&String::from_utf8_lossy(&result.stderr));
+            }
+            (combined, result.status.code().unwrap_or(1))
+        }
+        Err(_) => (String::new(), 1),
+    };
+    let is_error = exit_code != 0;
+
+    let tool_result_event = json!({
+        "type": "user",
+        "sessionId": session_id,
+        "message": {
+            "role": "user",
+            "content": [{
+                "type": "tool_result",
+                "tool_use_id": "toolu_mock_001",
+                "content": output,
+                "is_error": is_error
+            }]
+        }
+    });
+    write_event(&mut file, &tool_result_event);
+
+    let assistant_event = json!({
+        "type": "assistant",
+        "sessionId": session_id,
+        "message": {
+            "role": "assistant",
+            "content": [{"type": "text", "text": output}],
+            "usage": {"input_tokens": 1, "output_tokens": 1}
+        }
+    });
+    write_event(&mut file, &assistant_event);
+
+    let stop = json!({
+        "hook_event_name": "Stop",
+        "session_id": session_id,
+        "transcript_path": session_history_file,
+        "cwd": cwd,
+        "last_assistant_message": output,
+    });
+    run_hook_commands(settings, "Stop", &stop);
+
+    ExitCode::from(exit_code as u8)
 }
 
 /// Emit the init + result JSONL pair shared by post-result mock test
@@ -481,6 +680,8 @@ fn main() -> ExitCode {
 
     if parsed.output_format == "stream-json" {
         run_stream_json_mode(&parsed.prompt, &session_id)
+    } else if parsed.prompt.is_empty() && parsed.settings.is_some() {
+        run_interactive_mode(parsed.settings.as_deref(), &session_id)
     } else {
         run_text_mode(&parsed.prompt)
     }

--- a/crates/runner/src/cmd/start/tests/support/jobs.rs
+++ b/crates/runner/src/cmd/start/tests/support/jobs.rs
@@ -20,6 +20,7 @@ pub(in super::super) fn minimal_context(run_id: RunId) -> crate::types::Executio
         secret_connector_map: None,
         secret_connector_metadata_map: None,
         cli_agent_type: String::new(),
+        claude_driver: None,
         debug_no_mock_claude: None,
         debug_no_mock_codex: None,
         api_start_time: None,

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -1431,6 +1431,7 @@ const RUNNER_OWNED_ENV_KEYS: &[&str] = &[
     "VM0_WORKING_DIR",
     "VM0_API_START_TIME",
     "CLI_AGENT_TYPE",
+    "VM0_CLAUDE_DRIVER",
     "VM0_ARTIFACTS",
     "VM0_RESUME_SESSION_ID",
     "VM0_SECRET_VALUES",
@@ -1483,6 +1484,10 @@ fn insert_claude_code_env(
         && !settings.is_empty()
     {
         env.insert("VM0_SETTINGS".into(), settings.clone());
+    }
+
+    if context.claude_driver.as_deref() == Some("interactive") {
+        env.insert("VM0_CLAUDE_DRIVER".into(), "interactive".into());
     }
 }
 
@@ -1609,6 +1614,7 @@ mod tests {
             secret_connector_map: None,
             secret_connector_metadata_map: None,
             cli_agent_type: String::new(),
+            claude_driver: None,
             debug_no_mock_claude: None,
             debug_no_mock_codex: None,
             api_start_time: None,
@@ -1773,6 +1779,7 @@ mod tests {
             ("VM0_API_TOKEN".into(), "stolen".into()),
             ("VM0_FEATURE_FLAGS".into(), r#"{"bad":true}"#.into()),
             ("CLI_AGENT_TYPE".into(), "claude-code".into()),
+            ("VM0_CLAUDE_DRIVER".into(), "interactive".into()),
             ("USE_MOCK_CLAUDE".into(), "true".into()),
             ("USE_MOCK_CODEX".into(), "1".into()),
             ("VERCEL_PROTECTION_BYPASS".into(), "user-bypass".into()),
@@ -1789,6 +1796,7 @@ mod tests {
         assert_eq!(env.get("VM0_PROMPT").unwrap(), "test prompt");
         assert_eq!(env.get("VM0_API_TOKEN").unwrap(), "tok");
         assert_eq!(env.get("CLI_AGENT_TYPE").unwrap(), "codex");
+        assert!(!env.contains_key("VM0_CLAUDE_DRIVER"));
         assert!(!env.contains_key("VM0_FEATURE_FLAGS"));
         assert!(!env.contains_key("USE_MOCK_CLAUDE"));
         assert!(!env.contains_key("USE_MOCK_CODEX"));
@@ -2364,6 +2372,31 @@ mod tests {
         ctx.settings = Some(r#"{"hooks":{}}"#.into());
         let env = build_env_for_test(&ctx, "http://localhost");
         assert_eq!(env.get("VM0_SETTINGS").unwrap(), r#"{"hooks":{}}"#);
+    }
+
+    #[test]
+    fn build_env_json_with_interactive_claude_driver() {
+        let mut ctx = minimal_context();
+        ctx.claude_driver = Some("interactive".into());
+        let env = build_env_for_test(&ctx, "http://localhost");
+        assert_eq!(env.get("VM0_CLAUDE_DRIVER").unwrap(), "interactive");
+    }
+
+    #[test]
+    fn build_env_json_non_interactive_claude_driver_omitted() {
+        let mut ctx = minimal_context();
+        ctx.claude_driver = Some("print".into());
+        let env = build_env_for_test(&ctx, "http://localhost");
+        assert!(!env.contains_key("VM0_CLAUDE_DRIVER"));
+    }
+
+    #[test]
+    fn build_env_json_codex_ignores_claude_driver() {
+        let mut ctx = minimal_context();
+        ctx.cli_agent_type = "codex".into();
+        ctx.claude_driver = Some("interactive".into());
+        let env = build_env_for_test(&ctx, "http://localhost");
+        assert!(!env.contains_key("VM0_CLAUDE_DRIVER"));
     }
 
     #[test]

--- a/crates/runner/src/provider/local.rs
+++ b/crates/runner/src/provider/local.rs
@@ -693,6 +693,7 @@ impl JobProvider for LocalProvider {
             secret_connector_map: None,
             secret_connector_metadata_map: None,
             cli_agent_type: req.cli_agent_type,
+            claude_driver: None,
             debug_no_mock_claude: None,
             debug_no_mock_codex: None,
             api_start_time: None,

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -70,6 +70,8 @@ pub struct ExecutionContext {
     pub secret_connector_metadata_map: Option<HashMap<String, SecretConnectorMetadata>>,
     pub cli_agent_type: String,
     #[serde(default)]
+    pub claude_driver: Option<String>,
+    #[serde(default)]
     pub debug_no_mock_claude: Option<bool>,
     #[serde(default)]
     pub debug_no_mock_codex: Option<bool>,
@@ -443,6 +445,7 @@ mod tests {
                     "metadataKey": "codex-oauth-token"
                 }
             },
+            "claudeDriver": "interactive",
             "debugNoMockClaude": true,
             "debugNoMockCodex": true,
             "apiStartTime": 1700000000000.0,
@@ -471,6 +474,7 @@ mod tests {
             metadata["CHATGPT_ACCESS_TOKEN"].source_user_id.as_deref(),
             Some("user-123")
         );
+        assert_eq!(ctx.claude_driver.as_deref(), Some("interactive"));
         assert!(ctx.debug_no_mock_claude.unwrap());
         assert!(ctx.debug_no_mock_codex.unwrap());
         assert_eq!(ctx.firewalls.as_ref().unwrap()[0].name, "github");

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-runs-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-runs-create.test.ts
@@ -5,6 +5,7 @@ import type {
   FirewallPolicyValue,
   RawPermissionPolicies,
 } from "@vm0/connectors/firewall-types";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import {
   agentComposes,
   agentComposeVersions,
@@ -22,6 +23,7 @@ import { orgMetadata } from "@vm0/db/schema/org-metadata";
 import { orgMembersMetadata } from "@vm0/db/schema/org-members-metadata";
 import { runnerJobQueue } from "@vm0/db/schema/runner-job-queue";
 import { secrets } from "@vm0/db/schema/secret";
+import { userFeatureSwitches } from "@vm0/db/schema/user-feature-switches";
 import { userCache } from "@vm0/db/schema/user-cache";
 import { userCustomConnectors } from "@vm0/db/schema/user-custom-connector";
 import { userConnectors } from "@vm0/db/schema/user-connector";
@@ -29,7 +31,7 @@ import { vm0ApiKeys } from "@vm0/db/schema/vm0-api-key";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
 import { command, createStore } from "ccstate";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { describe, expect, it } from "vitest";
 
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
@@ -191,6 +193,20 @@ const trackModelProviders = createFixtureTracker<{ readonly orgId: string }>(
     );
   },
 );
+const trackFeatureSwitches = createFixtureTracker<{
+  readonly orgId: string;
+  readonly userId: string;
+}>(async (fixture) => {
+  const db = store.set(writeDb$);
+  await db
+    .delete(userFeatureSwitches)
+    .where(
+      and(
+        eq(userFeatureSwitches.orgId, fixture.orgId),
+        eq(userFeatureSwitches.userId, fixture.userId),
+      ),
+    );
+});
 const trackVm0ApiKey = createFixtureTracker<string>(async (label) => {
   const db = store.set(writeDb$);
   await db.delete(vm0ApiKeys).where(eq(vm0ApiKeys.label, label));
@@ -847,6 +863,116 @@ describe("POST /api/zero/runs", () => {
     expect(zeroRun).toStrictEqual({
       modelProvider: "anthropic-api-key",
       selectedModel: "claude-sonnet-4-6",
+    });
+  });
+
+  it("sets the interactive Claude driver only for Claude Code OAuth runs", async () => {
+    const fx = await fixture();
+    await trackModelProviders(Promise.resolve({ orgId: fx.orgId }));
+    await trackFeatureSwitches(
+      Promise.resolve({ orgId: fx.orgId, userId: fx.userId }),
+    );
+    const db = store.set(writeDb$);
+    await db.insert(userFeatureSwitches).values({
+      orgId: fx.orgId,
+      userId: fx.userId,
+      switches: { [FeatureSwitchKey.ClaudeInteractiveDriver]: true },
+    });
+    await store.set(
+      seedOrgModelProvider$,
+      {
+        orgId: fx.orgId,
+        type: "claude-code-oauth-token",
+        isDefault: true,
+        selectedModel: "claude-opus-4-6",
+        secretName: "CLAUDE_CODE_OAUTH_TOKEN",
+      },
+      context.signal,
+    );
+    const agent = await seedRunnableZeroAgent({
+      fixture: fx,
+      environment: {},
+    });
+    const oauthResponse = await accept(
+      zeroRunsClient().create({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          prompt: "use interactive claude driver",
+          agentId: agent.agentId,
+        },
+      }),
+      [201],
+    );
+
+    const [oauthJob] = await db
+      .select({ executionContext: runnerJobQueue.executionContext })
+      .from(runnerJobQueue)
+      .where(eq(runnerJobQueue.runId, oauthResponse.body.runId));
+    const oauthContext = oauthJob?.executionContext as {
+      readonly claudeDriver?: string;
+      readonly cliAgentType: string;
+      readonly environment: Record<string, string>;
+    };
+    expect(oauthContext.cliAgentType).toBe("claude-code");
+    expect(oauthContext.claudeDriver).toBe("interactive");
+    expect(oauthContext.environment).toMatchObject({
+      CLAUDE_CODE_OAUTH_TOKEN: "test-secret-value",
+    });
+
+    const anthropicFx = await fixture();
+    await trackModelProviders(Promise.resolve({ orgId: anthropicFx.orgId }));
+    await trackFeatureSwitches(
+      Promise.resolve({
+        orgId: anthropicFx.orgId,
+        userId: anthropicFx.userId,
+      }),
+    );
+    await db.insert(userFeatureSwitches).values({
+      orgId: anthropicFx.orgId,
+      userId: anthropicFx.userId,
+      switches: { [FeatureSwitchKey.ClaudeInteractiveDriver]: true },
+    });
+    await store.set(
+      seedOrgModelProvider$,
+      {
+        orgId: anthropicFx.orgId,
+        type: "anthropic-api-key",
+        isDefault: true,
+        selectedModel: "claude-sonnet-4-6",
+        secretName: "ANTHROPIC_API_KEY",
+      },
+      context.signal,
+    );
+    const anthropicAgent = await seedRunnableZeroAgent({
+      fixture: anthropicFx,
+      environment: {},
+    });
+    const anthropicResponse = await accept(
+      zeroRunsClient().create({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          prompt: "keep print driver for anthropic",
+          agentId: anthropicAgent.agentId,
+          modelProvider: "anthropic-api-key",
+        },
+      }),
+      [201],
+    );
+
+    const [anthropicJob] = await db
+      .select({ executionContext: runnerJobQueue.executionContext })
+      .from(runnerJobQueue)
+      .where(eq(runnerJobQueue.runId, anthropicResponse.body.runId));
+    const anthropicContext = anthropicJob?.executionContext as {
+      readonly claudeDriver?: string;
+      readonly cliAgentType: string;
+      readonly environment: Record<string, string>;
+    };
+
+    expect(anthropicContext.cliAgentType).toBe("claude-code");
+    expect(anthropicContext.claudeDriver).toBeUndefined();
+    expect(anthropicContext.environment).toMatchObject({
+      ANTHROPIC_API_KEY: "test-secret-value",
     });
   });
 

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -51,8 +51,10 @@ import {
 import {
   isSupportedFramework,
   MOUNT_PATH_TEMPLATE,
+  getAllFeatureStates,
   type SupportedFramework,
 } from "@vm0/core";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { resolveSkillRef, parseGitHubTreeUrl } from "@vm0/core/github-url";
 import {
   getCustomSkillStorageName,
@@ -255,6 +257,8 @@ interface BuiltStoredExecutionContext {
   readonly secretNames: readonly string[];
   readonly secretValues: readonly string[];
 }
+
+type ClaudeDriver = "print" | "interactive";
 
 type RunContextSnapshot = Omit<RunContextResponse, "vars"> & {
   readonly userId: string;
@@ -466,6 +470,32 @@ function modelProviderFramework(
   modelProvider: ResolvedModelProviderEnvironment,
 ): SupportedFramework {
   return getFrameworkForType(modelProvider.concreteType ?? modelProvider.type);
+}
+
+function resolveClaudeDriver(args: {
+  readonly modelProvider: ResolvedModelProviderEnvironment | null;
+  readonly featureFlags: Record<string, boolean>;
+}): ClaudeDriver {
+  if (
+    args.modelProvider?.type === "claude-code-oauth-token" &&
+    args.featureFlags[FeatureSwitchKey.ClaudeInteractiveDriver] === true
+  ) {
+    return "interactive";
+  }
+  return "print";
+}
+
+function featureSwitchOverridesForCore(
+  overrides: Record<string, boolean>,
+): Partial<Record<FeatureSwitchKey, boolean>> {
+  const result: Partial<Record<FeatureSwitchKey, boolean>> = {};
+  for (const key of Object.values(FeatureSwitchKey)) {
+    const value = overrides[key];
+    if (value !== undefined) {
+      result[key] = value;
+    }
+  }
+  return result;
 }
 
 function frameworkForProviderSelection(
@@ -2279,6 +2309,7 @@ function buildStoredExecutionContext(args: {
   readonly storageManifest: StorageManifest;
   readonly additionalVolumes: readonly AdditionalVolume[] | undefined;
   readonly extraEnvironment: Record<string, string> | undefined;
+  readonly featureFlags: Record<string, boolean>;
 }): BuiltStoredExecutionContext {
   const permissions = buildPermissionManifest({
     modelProvider: args.modelProvider,
@@ -2328,7 +2359,14 @@ function buildStoredExecutionContext(args: {
       tools: args.body.tools,
       settings: args.body.settings,
       experimentalProfile: runnerProfile(args.resolved.content),
-      featureFlags: {},
+      featureFlags: args.featureFlags,
+      claudeDriver:
+        resolveClaudeDriver({
+          modelProvider: args.modelProvider,
+          featureFlags: args.featureFlags,
+        }) === "interactive"
+          ? "interactive"
+          : undefined,
       billableFirewalls: billableFirewallsForPermissions({
         modelProvider: args.modelProvider,
         permissions,
@@ -2559,9 +2597,14 @@ async function buildRunnerJobPayload(
   }
 
   const profile = runnerProfile(args.resolved.content);
-  const featureSwitchOverrides = args.includeZeroTokenSecret
-    ? await get(userFeatureSwitchOverrides(args.orgId, args.userId))
-    : undefined;
+  const featureSwitchOverrides = await get(
+    userFeatureSwitchOverrides(args.orgId, args.userId),
+  );
+  const featureFlags = getAllFeatureStates({
+    userId: args.userId,
+    orgId: args.orgId,
+    overrides: featureSwitchOverridesForCore(featureSwitchOverrides),
+  });
   const body = args.includeZeroTokenSecret
     ? withZeroTokenSecret(
         args.body,
@@ -2591,6 +2634,7 @@ async function buildRunnerJobPayload(
     body,
     runId: args.run.id,
     storageManifest,
+    featureFlags,
   });
   ingestRunContextSnapshot({
     runId: args.run.id,

--- a/turbo/apps/web/app/api/agent/runs/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/route.ts
@@ -404,6 +404,7 @@ const router = tsr.router(runsMainContract, {
           additionalVolumes: finalAdditionalVolumes,
           environment: resolved.environment,
           userTimezone: resolved.userTimezone,
+          resolvedModelProvider: resolved.resolvedModelProvider,
           featureSwitchOverrides: resolved.featureSwitchOverrides,
           firewalls: resolved.firewalls,
           networkPolicies: resolved.networkPolicies,

--- a/turbo/apps/web/src/lib/infra/run/context/build-context.ts
+++ b/turbo/apps/web/src/lib/infra/run/context/build-context.ts
@@ -12,6 +12,7 @@ import type {
   NetworkPolicies,
 } from "@vm0/connectors/firewall-types";
 import type { SecretConnectorMetadata } from "@vm0/api-contracts/contracts/runners";
+import type { ModelProviderType } from "@vm0/api-contracts/contracts/model-providers";
 
 interface BuildInfraContextParams {
   runId: string;
@@ -32,6 +33,7 @@ interface BuildInfraContextParams {
   additionalVolumes?: AdditionalVolume[];
   environment?: Record<string, string>;
   userTimezone?: string;
+  resolvedModelProvider?: ModelProviderType;
   featureSwitchOverrides?: Partial<Record<FeatureSwitchKey, boolean>>;
   firewalls?: Firewalls;
   networkPolicies?: NetworkPolicies;
@@ -92,6 +94,7 @@ export function buildInfraExecutionContext(
     additionalVolumes: params.additionalVolumes,
     environment,
     userTimezone: params.userTimezone,
+    resolvedModelProvider: params.resolvedModelProvider,
     featureSwitchOverrides: params.featureSwitchOverrides,
     firewalls: params.firewalls,
     networkPolicies: params.networkPolicies,

--- a/turbo/apps/web/src/lib/infra/run/context/execution-preparer.ts
+++ b/turbo/apps/web/src/lib/infra/run/context/execution-preparer.ts
@@ -12,6 +12,7 @@ import { DEFAULT_PROFILE } from "@vm0/api-contracts/contracts/runners";
 import { badRequest } from "@vm0/api-services/errors";
 import { logger } from "../../../shared/logger";
 import { extractWorkingDir } from "../utils/extract-working-dir";
+import { resolveClaudeDriver } from "../utils/resolve-claude-driver";
 import {
   agentComposes,
   agentComposeVersions,
@@ -201,6 +202,11 @@ function buildPreparedContext(
   storageManifest: StorageManifest,
 ): PreparedContext {
   const metadata = extractMetadata(context);
+  const featureFlags = getAllFeatureStates({
+    userId: context.userId,
+    orgId: context.orgId,
+    overrides: context.featureSwitchOverrides,
+  });
 
   return {
     // Identity
@@ -249,10 +255,11 @@ function buildPreparedContext(
     runnerGroup,
 
     // Feature flags (evaluated once at preparation time)
-    featureFlags: getAllFeatureStates({
-      userId: context.userId,
-      orgId: context.orgId,
-      overrides: context.featureSwitchOverrides,
+    featureFlags,
+
+    claudeDriver: resolveClaudeDriver({
+      resolvedModelProvider: context.resolvedModelProvider,
+      featureFlags,
     }),
 
     // Metadata

--- a/turbo/apps/web/src/lib/infra/run/executors/runner-executor.ts
+++ b/turbo/apps/web/src/lib/infra/run/executors/runner-executor.ts
@@ -233,6 +233,8 @@ function buildStoredContext(
     secretConnectorMap: context.secretConnectorMap,
     secretConnectorMetadataMap: context.secretConnectorMetadataMap,
     cliAgentType: context.cliAgentType,
+    claudeDriver:
+      context.claudeDriver === "interactive" ? context.claudeDriver : undefined,
     firewalls: context.firewalls ?? undefined,
     networkPolicies: context.networkPolicies ?? undefined,
     disallowedTools: context.disallowedTools ?? undefined,

--- a/turbo/apps/web/src/lib/infra/run/executors/types.ts
+++ b/turbo/apps/web/src/lib/infra/run/executors/types.ts
@@ -5,6 +5,7 @@ import type {
   NetworkPolicies,
 } from "@vm0/connectors/firewall-types";
 import type { SecretConnectorMetadata } from "@vm0/api-contracts/contracts/runners";
+import type { ClaudeDriver } from "../utils/resolve-claude-driver";
 
 /**
  * Prepared execution context for executors
@@ -82,6 +83,8 @@ export interface PreparedContext {
 
   // Feature flags evaluated at job creation time (all switch states for user/org)
   featureFlags: Record<string, boolean> | null;
+
+  claudeDriver: ClaudeDriver;
 
   billableFirewalls: string[];
 

--- a/turbo/apps/web/src/lib/infra/run/types.ts
+++ b/turbo/apps/web/src/lib/infra/run/types.ts
@@ -6,6 +6,7 @@ import type {
   NetworkPolicies,
 } from "@vm0/connectors/firewall-types";
 import type { SecretConnectorMetadata } from "@vm0/api-contracts/contracts/runners";
+import type { ModelProviderType } from "@vm0/api-contracts/contracts/model-providers";
 
 /**
  * Artifact entry on an ExecutionContext: a name, optional version
@@ -96,6 +97,10 @@ export interface ExecutionContext {
   // User's timezone preference (IANA format, e.g., "Asia/Shanghai")
   // Injected as TZ environment variable in sandbox if not already set in environment
   userTimezone?: string;
+
+  // Resolved model provider for host-side runtime decisions. This is dispatch
+  // metadata only; the runner receives an already-computed driver selector.
+  resolvedModelProvider?: ModelProviderType;
 
   // Per-user Lab feature switch overrides loaded by the caller.
   featureSwitchOverrides?: Partial<Record<FeatureSwitchKey, boolean>>;

--- a/turbo/apps/web/src/lib/infra/run/utils/__tests__/resolve-claude-driver.test.ts
+++ b/turbo/apps/web/src/lib/infra/run/utils/__tests__/resolve-claude-driver.test.ts
@@ -1,0 +1,49 @@
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import { describe, expect, it } from "vitest";
+
+import { resolveClaudeDriver } from "../resolve-claude-driver";
+
+describe("resolveClaudeDriver", () => {
+  it("uses interactive only for claude-code-oauth-token when the switch is enabled", () => {
+    expect(
+      resolveClaudeDriver({
+        resolvedModelProvider: "claude-code-oauth-token",
+        featureFlags: {
+          [FeatureSwitchKey.ClaudeInteractiveDriver]: true,
+        },
+      }),
+    ).toBe("interactive");
+  });
+
+  it("keeps print mode when the switch is disabled", () => {
+    expect(
+      resolveClaudeDriver({
+        resolvedModelProvider: "claude-code-oauth-token",
+        featureFlags: {
+          [FeatureSwitchKey.ClaudeInteractiveDriver]: false,
+        },
+      }),
+    ).toBe("print");
+  });
+
+  it("keeps print mode for other Claude providers", () => {
+    expect(
+      resolveClaudeDriver({
+        resolvedModelProvider: "anthropic-api-key",
+        featureFlags: {
+          [FeatureSwitchKey.ClaudeInteractiveDriver]: true,
+        },
+      }),
+    ).toBe("print");
+  });
+
+  it("keeps print mode without a resolved provider", () => {
+    expect(
+      resolveClaudeDriver({
+        featureFlags: {
+          [FeatureSwitchKey.ClaudeInteractiveDriver]: true,
+        },
+      }),
+    ).toBe("print");
+  });
+});

--- a/turbo/apps/web/src/lib/infra/run/utils/resolve-claude-driver.ts
+++ b/turbo/apps/web/src/lib/infra/run/utils/resolve-claude-driver.ts
@@ -1,0 +1,22 @@
+import type { ModelProviderType } from "@vm0/api-contracts/contracts/model-providers";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+
+export type ClaudeDriver = "print" | "interactive";
+
+interface ResolveClaudeDriverParams {
+  readonly resolvedModelProvider?: ModelProviderType;
+  readonly featureFlags: Record<string, boolean>;
+}
+
+export function resolveClaudeDriver(
+  params: ResolveClaudeDriverParams,
+): ClaudeDriver {
+  if (
+    params.resolvedModelProvider === "claude-code-oauth-token" &&
+    params.featureFlags[FeatureSwitchKey.ClaudeInteractiveDriver] === true
+  ) {
+    return "interactive";
+  }
+
+  return "print";
+}

--- a/turbo/apps/web/src/lib/zero/build-zero-context.ts
+++ b/turbo/apps/web/src/lib/zero/build-zero-context.ts
@@ -1096,6 +1096,7 @@ export async function buildZeroExecutionContext(
       additionalVolumes,
       environment: runtimeEnvironment,
       userTimezone,
+      resolvedModelProvider,
       featureSwitchOverrides: params.featureSwitchOverrides,
       firewalls: permissionResult?.firewalls,
       networkPolicies: permissionResult?.networkPolicies,

--- a/turbo/packages/api-contracts/src/contracts/runners.ts
+++ b/turbo/packages/api-contracts/src/contracts/runners.ts
@@ -117,6 +117,8 @@ export const secretConnectorMetadataMapSchema = z.record(
   secretConnectorMetadataSchema,
 );
 
+export const claudeDriverSchema = z.enum(["print", "interactive"]);
+
 /**
  * Stored execution context (subset stored in database for late routing)
  * Contains prepared context without runtime-generated fields
@@ -135,6 +137,7 @@ export const storedExecutionContextSchema = z.object({
     .nullable()
     .optional(),
   cliAgentType: z.string(),
+  claudeDriver: claudeDriverSchema.optional(),
   // Debug flag to force real Claude in mock environments (internal use only)
   debugNoMockClaude: z.boolean().optional(),
   // Debug flag to force real Codex in mock environments (internal use only)
@@ -191,6 +194,7 @@ export const executionContextSchema = z.object({
     .nullable()
     .optional(),
   cliAgentType: z.string(),
+  claudeDriver: claudeDriverSchema.optional(),
   // Debug flag to force real Claude in mock environments (internal use only)
   debugNoMockClaude: z.boolean().optional(),
   // Debug flag to force real Codex in mock environments (internal use only)

--- a/turbo/packages/connectors/src/feature-switch-key.ts
+++ b/turbo/packages/connectors/src/feature-switch-key.ts
@@ -60,4 +60,5 @@ export enum FeatureSwitchKey {
   VoiceChatRealtimeBilling = "voiceChatRealtimeBilling",
   PrivateAgents = "privateAgents",
   HostedSites = "hostedSites",
+  ClaudeInteractiveDriver = "claudeInteractiveDriver",
 }

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -94,6 +94,24 @@ describe("isFeatureEnabled", () => {
       }),
     ).toBe(false);
   });
+
+  it("should enable Claude interactive driver for staff orgs only by default", () => {
+    expect(isFeatureEnabled(FeatureSwitchKey.ClaudeInteractiveDriver, {})).toBe(
+      false,
+    );
+
+    expect(
+      isFeatureEnabled(FeatureSwitchKey.ClaudeInteractiveDriver, {
+        orgId: "org_3ANttyrbWYJk6JKRSTRLEsbsDLe",
+      }),
+    ).toBe(true);
+
+    expect(
+      isFeatureEnabled(FeatureSwitchKey.ClaudeInteractiveDriver, {
+        orgId: "org_nonexistent",
+      }),
+    ).toBe(false);
+  });
 });
 
 describe("getAllFeatureStates", () => {

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -355,6 +355,13 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
+  [FeatureSwitchKey.ClaudeInteractiveDriver]: {
+    maintainer: "lancy@vm0.ai",
+    description:
+      "Enable the interactive Claude Code sandbox driver for claude-code-oauth-token model-provider runs. Staff-only during rollout.",
+    enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+  },
 };
 
 interface ResolvedHashes {


### PR DESCRIPTION
## Summary
- add the `claudeInteractiveDriver` feature switch and propagate `claudeDriver: interactive` for `claude-code-oauth-token` runs in both apps/api and apps/web
- teach runner/guest-agent to launch Claude Code through the interactive PTY driver without `--print`, replay transcript JSONL events, and preserve merged hook settings
- extend mock Claude and targeted tests for the interactive path

Closes #13406

## Validation
- `pnpm format`
- `pnpm -F api check-types`
- `pnpm -F web check-types`
- `pnpm -F @vm0/core check-types`
- `pnpm -F @vm0/connectors check-types`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F api lint`
- `pnpm -F web lint`
- `pnpm -F @vm0/core lint`
- `pnpm -F @vm0/connectors lint`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F @vm0/core exec vitest run src/__tests__/feature-switch.test.ts -t "Claude interactive driver"`
- `pnpm -F web exec vitest run src/lib/infra/run/utils/__tests__/resolve-claude-driver.test.ts`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-runs-create.test.ts -t "sets the interactive Claude driver"`
- `cargo fmt --check`
- `cargo clippy -p guest-agent -p guest-mock-claude -p runner --all-targets -- -D warnings`
- `cargo test -p guest-agent interactive_claude_driver_replays_mock_transcript --test interactive_claude_driver`
- `cargo test -p guest-agent build_interactive --lib`
- `cargo test -p guest-mock-claude`
- `cargo test -p runner claude_driver`
- `cargo test -p runner execution_context_all_optional_fields`
- pre-commit: cargo doc/fmt/clippy, prettier, knip, full `turbo run check-types --concurrency=1`