### PR TITLE
feat: gate billable firewall auth on credits

### DIFF
--- a/crates/runner/mitm-addon/src/auth.py
+++ b/crates/runner/mitm-addon/src/auth.py
@@ -6,6 +6,7 @@ both standard header injection and auth.base URL rewriting.
 
 import asyncio
 import json
+import math
 import os
 import time
 import urllib.error
@@ -22,10 +23,23 @@ class ConnectorNotConfiguredError(Exception):
     """Raised when the auth endpoint returns 424 — connector not linked or misconfigured."""
 
 
+class InsufficientCreditsError(Exception):
+    """Raised when the auth endpoint denies billable firewall auth for credits."""
+
+
+class MissingAuthExpiryError(Exception):
+    """Raised when billable firewall auth succeeds without a valid cache expiry."""
+
+
 # Vercel bypass secret (still from environment as it's a secret)
 VERCEL_BYPASS = os.environ.get("VERCEL_AUTOMATION_BYPASS_SECRET", "")
 
 # Cache for firewall auth headers: (run_id, api_id) -> {"headers": dict, "expiresAt": float | None}
+#
+# expiresAt is the effective cache expiry returned by the server. For
+# non-billable auth it is just the auth-token expiry and may be None. For
+# billable auth it must be finite because the server folds the credit
+# authorization lease into this timestamp.
 _firewall_header_cache: dict[tuple[str, str], dict] = {}
 
 # Per-key locks to coalesce concurrent fetches for the same (run_id, api_id)
@@ -138,6 +152,7 @@ def _fetch_firewall_headers_sync(
     vars_map: dict | None = None,
     auth_base: str | None = None,
     auth_query: dict | None = None,
+    firewall_billable: bool = False,
     force_refresh: bool = False,
 ) -> dict:
     """Synchronous helper — runs in a thread to avoid blocking the event loop.
@@ -157,6 +172,8 @@ def _fetch_firewall_headers_sync(
         body["secretConnectorMetadataMap"] = secret_connector_metadata_map
     if vars_map:
         body["vars"] = vars_map
+    if firewall_billable:
+        body["firewallBillable"] = True
     if force_refresh:
         body["forceRefresh"] = True
     data = json.dumps(body).encode()
@@ -185,6 +202,10 @@ def _fetch_firewall_headers_sync(
                 raise ConnectorNotConfiguredError(
                     error_info.get("message", "Connector not configured"),
                 ) from None
+            if error_info.get("code") == "INSUFFICIENT_CREDITS":
+                raise InsufficientCreditsError(
+                    error_info.get("message", "Insufficient credits"),
+                ) from None
             raise
 
 
@@ -197,12 +218,15 @@ async def fetch_firewall_headers(
     vars_map: dict | None = None,
     auth_base: str | None = None,
     auth_query: dict | None = None,
+    firewall_billable: bool = False,
     force_refresh: bool = False,
 ) -> dict:
     """Resolve auth headers via server-side decryption.
 
     When secret_connector_map is provided, the auth endpoint can refresh
     expired OAuth tokens and returns an expiresAt timestamp for TTL caching.
+    For billable firewall auth, expiresAt is also bounded by the server-side
+    credit authorization lease.
 
     When force_refresh is True, the endpoint refreshes OAuth tokens regardless
     of DB tokenExpiresAt — used after the upstream returns 401 (#9860).
@@ -221,6 +245,7 @@ async def fetch_firewall_headers(
         vars_map,
         auth_base,
         auth_query,
+        firewall_billable,
         force_refresh,
     )
 
@@ -311,18 +336,30 @@ async def forward_request(
     return await asyncio.to_thread(_forward_request_sync, url, method, headers, body)
 
 
-def _build_cache_hit(cached: dict) -> dict | None:
+def _has_valid_expiry(value: object, now: float | None = None) -> bool:
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        return False
+    if not math.isfinite(value):
+        return False
+    return (time.time() if now is None else now) < value
+
+
+def _build_cache_hit(cached: dict, firewall_billable: bool = False) -> dict | None:
     """Check if a cached entry is still valid and return a cache-hit result."""
     expires_at = cached.get("expiresAt")
-    if expires_at is None or time.time() < expires_at:
-        return {
-            "headers": cached["headers"],
-            "resolved_secrets": cached.get("resolvedSecrets", []),
-            "cache_hit": True,
-            **({"base": cached["base"]} if "base" in cached else {}),
-            **({"query": cached["query"]} if "query" in cached else {}),
-        }
-    return None
+    now = time.time()
+    if expires_at is None:
+        if firewall_billable:
+            return None
+    elif not _has_valid_expiry(expires_at, now):
+        return None
+    return {
+        "headers": cached["headers"],
+        "resolved_secrets": cached.get("resolvedSecrets", []),
+        "cache_hit": True,
+        **({"base": cached["base"]} if "base" in cached else {}),
+        **({"query": cached["query"]} if "query" in cached else {}),
+    }
 
 
 async def get_firewall_headers(
@@ -336,6 +373,7 @@ async def get_firewall_headers(
     vars_map: dict | None = None,
     auth_base: str | None = None,
     auth_query: dict | None = None,
+    firewall_billable: bool = False,
 ) -> dict:
     """Get firewall auth headers with TTL-based caching.
 
@@ -352,7 +390,7 @@ async def get_firewall_headers(
     # Fast path: cache hit (no lock needed — single-threaded event loop)
     cached = _firewall_header_cache.get(cache_key)
     if cached:
-        hit = _build_cache_hit(cached)
+        hit = _build_cache_hit(cached, firewall_billable=firewall_billable)
         if hit:
             return hit
 
@@ -362,7 +400,7 @@ async def get_firewall_headers(
         # Double-check: another coroutine may have populated cache while we waited
         cached = _firewall_header_cache.get(cache_key)
         if cached:
-            hit = _build_cache_hit(cached)
+            hit = _build_cache_hit(cached, firewall_billable=firewall_billable)
             if hit:
                 return hit
 
@@ -386,8 +424,13 @@ async def get_firewall_headers(
             vars_map,
             auth_base,
             auth_query,
+            firewall_billable,
             force_refresh=force_refresh,
         )
+        if firewall_billable and not _has_valid_expiry(result.get("expiresAt")):
+            raise MissingAuthExpiryError(
+                "Billable firewall auth response did not include a valid cache expiry"
+            )
         headers = result["headers"]
         resolved_secrets = result.get("resolvedSecrets", [])
         cache_entry: dict = {
@@ -491,6 +534,7 @@ async def handle_firewall_request(
             vars_map,
             auth_base,
             auth_query,
+            flow.metadata["firewall_billable"],
         )
     except ConnectorNotConfiguredError as e:
         fw_name = match_info.get("name", "")
@@ -514,6 +558,29 @@ async def handle_firewall_request(
         flow.response = http.Response.make(
             424,
             json.dumps(error_body).encode(),
+            {"Content-Type": "application/json"},
+        )
+        return
+    except InsufficientCreditsError as e:
+        log_proxy_entry(
+            proxy_log_path,
+            "warn",
+            f"Billable firewall auth denied for {firewall_base}: {e}",
+            type="firewall",
+            firewall_base=firewall_base,
+        )
+        flow.metadata["firewall_action"] = "BLOCK"
+        flow.metadata["firewall_error"] = "insufficient_credits"
+        flow.response = http.Response.make(
+            402,
+            json.dumps(
+                {
+                    "error": "insufficient_credits",
+                    "message": str(e),
+                    "permission": match_info.get("name", ""),
+                    "base": firewall_base,
+                }
+            ).encode(),
             {"Content-Type": "application/json"},
         )
         return

--- a/crates/runner/mitm-addon/tests/test_connectors.py
+++ b/crates/runner/mitm-addon/tests/test_connectors.py
@@ -1280,6 +1280,7 @@ class TestGetFirewallHeaders:
             None,
             None,
             None,
+            False,
             force_refresh=False,
         )
 
@@ -1366,6 +1367,132 @@ class TestGetFirewallHeaders:
         assert headers["headers"] == cached_headers
         assert headers["cache_hit"] is True
         mock_fetch.assert_not_called()
+
+    async def test_billable_cache_hit_requires_valid_expiry(self, headers):
+        cache_key = ("run-1", "api-1")
+        cached_headers = {"Authorization": "Bearer cached-token"}
+        auth._firewall_header_cache[cache_key] = {
+            "headers": cached_headers,
+            "expiresAt": time.time() + 30,
+        }
+
+        mock_fetch = AsyncMock()
+        with patch.object(auth, "fetch_firewall_headers", mock_fetch):
+            headers = await auth.get_firewall_headers(
+                "run-1",
+                "api-1",
+                "iv:tag:data",
+                {},
+                "tok-xyz",
+                firewall_billable=True,
+            )
+
+        assert headers["headers"] == cached_headers
+        assert headers["cache_hit"] is True
+        mock_fetch.assert_not_called()
+
+    @pytest.mark.parametrize("expiry", [None, True, "123", float("inf"), float("nan")])
+    def test_expiry_validation_rejects_invalid_values(self, expiry):
+        assert auth._has_valid_expiry(expiry, now=time.time()) is False
+
+    @pytest.mark.parametrize("expiry", [True, "123", float("inf"), float("nan")])
+    async def test_cache_with_invalid_expiry_refetches(self, headers, expiry):
+        cache_key = ("run-1", "api-1")
+        auth._firewall_header_cache[cache_key] = {
+            "headers": {"Authorization": "Bearer malformed-token"},
+            "expiresAt": expiry,
+        }
+        fresh_headers = {"Authorization": "Bearer fresh-token"}
+        mock_fetch = AsyncMock(return_value={"headers": fresh_headers, "expiresAt": None})
+
+        with patch.object(auth, "fetch_firewall_headers", mock_fetch):
+            headers = await auth.get_firewall_headers(
+                "run-1", "api-1", "iv:tag:data", {}, "tok-xyz"
+            )
+
+        assert headers["headers"] == fresh_headers
+        assert headers["cache_hit"] is False
+        mock_fetch.assert_called_once()
+
+    async def test_billable_cache_without_expiry_refetches(self, headers):
+        cache_key = ("run-1", "api-1")
+        auth._firewall_header_cache[cache_key] = {
+            "headers": {"Authorization": "Bearer stale-token"},
+            "expiresAt": None,
+        }
+        fresh_headers = {"Authorization": "Bearer fresh-token"}
+        expires_at = time.time() + 30
+        mock_fetch = AsyncMock(
+            return_value={
+                "headers": fresh_headers,
+                "expiresAt": expires_at,
+            }
+        )
+
+        with patch.object(auth, "fetch_firewall_headers", mock_fetch):
+            headers = await auth.get_firewall_headers(
+                "run-1",
+                "api-1",
+                "iv:tag:data",
+                {},
+                "tok-xyz",
+                firewall_billable=True,
+            )
+
+        assert headers["headers"] == fresh_headers
+        assert headers["cache_hit"] is False
+        mock_fetch.assert_called_once()
+        assert mock_fetch.call_args.args[8] is True
+        assert auth._firewall_header_cache[cache_key]["expiresAt"] == expires_at
+
+    async def test_billable_cache_with_expired_expiry_refetches(self, headers):
+        cache_key = ("run-1", "api-1")
+        auth._firewall_header_cache[cache_key] = {
+            "headers": {"Authorization": "Bearer stale-token"},
+            "expiresAt": time.time() - 1,
+        }
+        fresh_headers = {"Authorization": "Bearer fresh-token"}
+        mock_fetch = AsyncMock(
+            return_value={
+                "headers": fresh_headers,
+                "expiresAt": time.time() + 30,
+            }
+        )
+
+        with patch.object(auth, "fetch_firewall_headers", mock_fetch):
+            headers = await auth.get_firewall_headers(
+                "run-1",
+                "api-1",
+                "iv:tag:data",
+                {},
+                "tok-xyz",
+                firewall_billable=True,
+            )
+
+        assert headers["headers"] == fresh_headers
+        assert headers["cache_hit"] is False
+        mock_fetch.assert_called_once()
+
+    async def test_billable_fetch_without_expiry_fails_closed(self, headers):
+        mock_fetch = AsyncMock(
+            return_value={
+                "headers": {"Authorization": "Bearer token"},
+                "expiresAt": None,
+            }
+        )
+
+        with (
+            patch.object(auth, "fetch_firewall_headers", mock_fetch),
+            pytest.raises(auth.MissingAuthExpiryError),
+        ):
+            await auth.get_firewall_headers(
+                "run-1",
+                "api-1",
+                "iv:tag:data",
+                {},
+                "tok-xyz",
+                firewall_billable=True,
+            )
 
     async def test_cache_hit_includes_base_when_present(self, headers):
         """Cached entry with 'base' returns it on cache hit."""
@@ -1821,6 +1948,34 @@ class TestFetchFirewallHeaders:
         body = json.loads(mock_req_cls.call_args[1]["data"])
         assert body["authBase"] == "${{ secrets.DISCORD_WEBHOOK_URL }}"
 
+    def test_includes_billable_firewall_flag_in_request_body(self, headers):
+        mock_resp = MagicMock()
+        mock_resp.__enter__.return_value = mock_resp
+        mock_resp.read.return_value = json.dumps(
+            {
+                "headers": {},
+                "expiresAt": time.time() + 30,
+            }
+        ).encode()
+
+        with (
+            patch("auth.urllib.request.Request") as mock_req_cls,
+            patch("auth.urllib.request.urlopen", return_value=mock_resp),
+            patch.object(auth, "VERCEL_BYPASS", ""),
+        ):
+            auth._fetch_firewall_headers_sync(
+                "iv:tag:data",
+                {},
+                "tok-xyz",
+                "https://api.vm0.ai",
+                firewall_billable=True,
+            )
+
+        body = json.loads(mock_req_cls.call_args[1]["data"])
+        assert body["firewallBillable"] is True
+        assert "firewallName" not in body
+        assert "modelUsageProvider" not in body
+
     def test_424_connector_not_configured_raises_custom_error(self):
         """Auth endpoint 424 CONNECTOR_NOT_CONFIGURED raises ConnectorNotConfiguredError."""
         error_body = json.dumps(
@@ -1849,6 +2004,34 @@ class TestFetchFirewallHeaders:
                     "iv:tag:data", {}, "tok-xyz", "https://api.vm0.ai"
                 )
             assert "Connector not configured" in str(exc_info.value)
+
+    def test_402_insufficient_credits_raises_custom_error(self):
+        error_body = json.dumps(
+            {
+                "error": {
+                    "message": "Insufficient credits",
+                    "code": "INSUFFICIENT_CREDITS",
+                }
+            }
+        ).encode()
+        http_error = urllib.error.HTTPError(
+            "https://api.vm0.ai/api/webhooks/agent/firewall/auth",
+            402,
+            "Payment Required",
+            {},
+            io.BytesIO(error_body),
+        )
+
+        with (
+            patch("auth.urllib.request.Request"),
+            patch("auth.urllib.request.urlopen", side_effect=http_error),
+            patch.object(auth, "VERCEL_BYPASS", ""),
+        ):
+            with pytest.raises(auth.InsufficientCreditsError) as exc_info:
+                auth._fetch_firewall_headers_sync(
+                    "iv:tag:data", {}, "tok-xyz", "https://api.vm0.ai"
+                )
+            assert "Insufficient credits" in str(exc_info.value)
 
     def test_non_connector_not_configured_error_reraised(self):
         """Non-CONNECTOR_NOT_CONFIGURED HTTP errors should be re-raised as HTTPError."""

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
@@ -7,7 +7,10 @@ import { HttpResponse, http } from "msw";
 import { beforeEach, describe, expect, it } from "vitest";
 import { webhookFirewallAuthContract } from "@vm0/api-contracts/contracts/webhooks";
 import { connectors } from "@vm0/db/schema/connector";
+import { creditExpiresRecord } from "@vm0/db/schema/credit-expires-record";
 import { modelProviders } from "@vm0/db/schema/model-provider";
+import { orgMembersMetadata } from "@vm0/db/schema/org-members-metadata";
+import { orgMetadata } from "@vm0/db/schema/org-metadata";
 import { secrets } from "@vm0/db/schema/secret";
 
 import { createApp } from "../../../app-factory";
@@ -123,6 +126,13 @@ const track = createFixtureTracker<FirewallFixture>(async (fixture) => {
     .delete(modelProviders)
     .where(eq(modelProviders.orgId, fixture.orgId));
   await db.delete(secrets).where(eq(secrets.orgId, fixture.orgId));
+  await db
+    .delete(creditExpiresRecord)
+    .where(eq(creditExpiresRecord.orgId, fixture.orgId));
+  await db
+    .delete(orgMembersMetadata)
+    .where(eq(orgMembersMetadata.orgId, fixture.orgId));
+  await db.delete(orgMetadata).where(eq(orgMetadata.orgId, fixture.orgId));
   await store.set(deleteUsageInsightFixture$, fixture, context.signal);
 });
 
@@ -140,6 +150,38 @@ async function seedSecret(args: {
     name: args.name,
     encryptedValue: encryptSecretValue(args.value),
     type: args.type,
+  });
+}
+
+async function seedCreditState(
+  fixture: FirewallFixture,
+  args: {
+    readonly credits: number;
+    readonly creditEnabled?: boolean;
+  },
+): Promise<void> {
+  const db = store.set(writeDb$);
+  await db.insert(orgMetadata).values({
+    orgId: fixture.orgId,
+    credits: args.credits,
+  });
+  await db.insert(orgMembersMetadata).values({
+    orgId: fixture.orgId,
+    userId: fixture.userId,
+    creditEnabled: args.creditEnabled ?? true,
+  });
+}
+
+async function seedOrgCredits(
+  fixture: FirewallFixture,
+  args: {
+    readonly credits: number;
+  },
+): Promise<void> {
+  const db = store.set(writeDb$);
+  await db.insert(orgMetadata).values({
+    orgId: fixture.orgId,
+    credits: args.credits,
   });
 }
 
@@ -464,6 +506,151 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
     });
   });
 
+  it("returns a bounded expiry for billable firewall auth", async () => {
+    const fixture = await track(seedFixture());
+    await seedCreditState(fixture, { credits: 10_000 });
+
+    const before = currentSecond();
+    const response = await accept(
+      firewallClient().resolve({
+        body: {
+          encryptedSecrets: encryptedSecrets({ API_TOKEN: "secret-token" }),
+          authHeaders: {
+            Authorization: `Bearer ${secretTemplate("API_TOKEN")}`,
+          },
+          firewallBillable: true,
+        },
+        headers: authHeaders(fixture),
+      }),
+      [200],
+    );
+
+    const after = currentSecond();
+    expect(response.body.headers.Authorization).toBe("Bearer secret-token");
+    expect(response.body.expiresAt).toBeGreaterThan(before);
+    expect(response.body.expiresAt).toBeLessThanOrEqual(after + 30);
+  });
+
+  it("allows billable firewall auth when member credit metadata is absent", async () => {
+    const fixture = await track(seedFixture());
+    await seedOrgCredits(fixture, { credits: 10_000 });
+
+    const response = await accept(
+      firewallClient().resolve({
+        body: {
+          encryptedSecrets: encryptedSecrets({ API_TOKEN: "secret-token" }),
+          authHeaders: {
+            Authorization: `Bearer ${secretTemplate("API_TOKEN")}`,
+          },
+          firewallBillable: true,
+        },
+        headers: authHeaders(fixture),
+      }),
+      [200],
+    );
+
+    expect(response.body.headers.Authorization).toBe("Bearer secret-token");
+    expect(response.body.expiresAt).toBeTypeOf("number");
+  });
+
+  it("denies billable firewall auth when expired credits have not been settled", async () => {
+    const fixture = await track(seedFixture());
+    await seedCreditState(fixture, { credits: 100 });
+
+    const db = store.set(writeDb$);
+    await db.insert(creditExpiresRecord).values({
+      orgId: fixture.orgId,
+      source: "starter_grant",
+      amount: 100,
+      remaining: 100,
+      expiresAt: new Date(now() - 60_000),
+    });
+
+    const response = await accept(
+      firewallClient().resolve({
+        body: {
+          encryptedSecrets: encryptedSecrets({ API_TOKEN: "secret-token" }),
+          authHeaders: {
+            Authorization: `Bearer ${secretTemplate("API_TOKEN")}`,
+          },
+          firewallBillable: true,
+        },
+        headers: authHeaders(fixture),
+      }),
+      [402],
+    );
+
+    expect(response.body.error.code).toBe("INSUFFICIENT_CREDITS");
+  });
+
+  it("denies billable firewall auth when credits are exhausted", async () => {
+    const fixture = await track(seedFixture());
+    await seedCreditState(fixture, { credits: 0 });
+
+    const response = await accept(
+      firewallClient().resolve({
+        body: {
+          encryptedSecrets: encryptedSecrets({ API_TOKEN: "secret-token" }),
+          authHeaders: {
+            Authorization: `Bearer ${secretTemplate("API_TOKEN")}`,
+          },
+          firewallBillable: true,
+        },
+        headers: authHeaders(fixture),
+      }),
+      [402],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message:
+          "Insufficient credits. Add credits or configure your own API key to continue.",
+        code: "INSUFFICIENT_CREDITS",
+      },
+    });
+  });
+
+  it("denies billable firewall auth when member credit is disabled", async () => {
+    const fixture = await track(seedFixture());
+    await seedCreditState(fixture, { credits: 10_000, creditEnabled: false });
+
+    const response = await accept(
+      firewallClient().resolve({
+        body: {
+          encryptedSecrets: encryptedSecrets({ API_TOKEN: "secret-token" }),
+          authHeaders: {
+            Authorization: `Bearer ${secretTemplate("API_TOKEN")}`,
+          },
+          firewallBillable: true,
+        },
+        headers: authHeaders(fixture),
+      }),
+      [402],
+    );
+
+    expect(response.body.error.code).toBe("INSUFFICIENT_CREDITS");
+  });
+
+  it("denies billable firewall auth when credit state is missing", async () => {
+    const fixture = await track(seedFixture());
+
+    const response = await accept(
+      firewallClient().resolve({
+        body: {
+          encryptedSecrets: encryptedSecrets({ API_TOKEN: "secret-token" }),
+          authHeaders: {
+            Authorization: `Bearer ${secretTemplate("API_TOKEN")}`,
+          },
+          firewallBillable: true,
+        },
+        headers: authHeaders(fixture),
+      }),
+      [402],
+    );
+
+    expect(response.body.error.code).toBe("INSUFFICIENT_CREDITS");
+  });
+
   it("refreshes expired connector OAuth tokens", async () => {
     const fixture = await track(seedFixture());
     await seedExpiredNotionConnector(fixture);
@@ -522,6 +709,88 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
     const connector = await notionConnectorState(fixture);
     expect(connector.needsReconnect).toBeFalsy();
     expect(connector.tokenExpiresAt?.getTime()).toBeGreaterThan(now());
+  });
+
+  it("uses OAuth token expiry when it is earlier than billable credit lease", async () => {
+    const fixture = await track(seedFixture());
+    await seedCreditState(fixture, { credits: 10_000 });
+    await seedExpiredNotionConnector(fixture);
+    server.use(
+      http.post("https://api.notion.com/v1/oauth/token", () => {
+        return HttpResponse.json({
+          access_token: "short-lived-notion-token",
+          expires_in: 10,
+        });
+      }),
+    );
+
+    const before = currentSecond();
+    const response = await accept(
+      firewallClient().resolve({
+        body: {
+          encryptedSecrets: encryptedSecrets({
+            NOTION_ACCESS_TOKEN: "stale-notion-token",
+          }),
+          authHeaders: {
+            Authorization: `Bearer ${secretTemplate("NOTION_ACCESS_TOKEN")}`,
+          },
+          secretConnectorMap: {
+            NOTION_ACCESS_TOKEN: "notion",
+          },
+          firewallBillable: true,
+        },
+        headers: authHeaders(fixture),
+      }),
+      [200],
+    );
+    const after = currentSecond();
+
+    expect(response.body.headers.Authorization).toBe(
+      "Bearer short-lived-notion-token",
+    );
+    expect(response.body.expiresAt).toBeGreaterThan(before);
+    expect(response.body.expiresAt).toBeLessThanOrEqual(after + 10);
+  });
+
+  it("uses billable credit lease when it is earlier than OAuth token expiry", async () => {
+    const fixture = await track(seedFixture());
+    await seedCreditState(fixture, { credits: 10_000 });
+    await seedExpiredNotionConnector(fixture);
+    server.use(
+      http.post("https://api.notion.com/v1/oauth/token", () => {
+        return HttpResponse.json({
+          access_token: "long-lived-notion-token",
+          expires_in: 3600,
+        });
+      }),
+    );
+
+    const before = currentSecond();
+    const response = await accept(
+      firewallClient().resolve({
+        body: {
+          encryptedSecrets: encryptedSecrets({
+            NOTION_ACCESS_TOKEN: "stale-notion-token",
+          }),
+          authHeaders: {
+            Authorization: `Bearer ${secretTemplate("NOTION_ACCESS_TOKEN")}`,
+          },
+          secretConnectorMap: {
+            NOTION_ACCESS_TOKEN: "notion",
+          },
+          firewallBillable: true,
+        },
+        headers: authHeaders(fixture),
+      }),
+      [200],
+    );
+    const after = currentSecond();
+
+    expect(response.body.headers.Authorization).toBe(
+      "Bearer long-lived-notion-token",
+    );
+    expect(response.body.expiresAt).toBeGreaterThan(before);
+    expect(response.body.expiresAt).toBeLessThanOrEqual(after + 30);
   });
 
   it("returns token-refresh-failed and marks connector reconnect when refresh fails", async () => {
@@ -622,7 +891,7 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
     });
   });
 
-  it("rejects model-provider refresh metadata for another user", async () => {
+  it("rejects model-provider refresh metadata for another user before billable credit auth", async () => {
     const fixture = await track(seedFixture());
 
     const response = await accept(
@@ -644,6 +913,7 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
               metadataKey: "codex-oauth-token",
             },
           },
+          firewallBillable: true,
         },
         headers: authHeaders(fixture),
       }),

--- a/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
@@ -14,7 +14,7 @@ import { secrets as secretsTable } from "@vm0/db/schema/secret";
 import { and, eq, inArray } from "drizzle-orm";
 
 import { optionalEnv } from "../../lib/env";
-import { badRequestMessage } from "../../lib/error";
+import { badRequestMessage, insufficientCredits } from "../../lib/error";
 import { logger } from "../../lib/log";
 import { nowDate } from "../../lib/time";
 import type { SandboxAuth } from "../../types/auth";
@@ -25,11 +25,16 @@ import {
   decryptSecretsMap,
   encryptSecretValue,
 } from "./crypto.utils";
+import { resolveOrgCreditAvailability } from "./zero-run-admission.service";
 
 type OAuthSecretSource = "connector" | "model-provider";
 type SecretType = OAuthSecretSource;
 type ProviderHandler =
   (typeof PROVIDER_HANDLERS)[keyof typeof PROVIDER_HANDLERS];
+
+const NORMAL_BILLABLE_FIREWALL_LEASE_SECONDS = 30;
+const LOW_BILLABLE_FIREWALL_LEASE_SECONDS = 5;
+const LOW_BILLABLE_FIREWALL_CREDIT_THRESHOLD = 1000;
 
 interface FirewallAuthBody {
   readonly encryptedSecrets: string;
@@ -39,6 +44,7 @@ interface FirewallAuthBody {
   readonly secretConnectorMap?: Record<string, string>;
   readonly secretConnectorMetadataMap?: Record<string, SecretConnectorMetadata>;
   readonly vars?: Record<string, string>;
+  readonly firewallBillable?: boolean;
   readonly forceRefresh?: boolean;
 }
 
@@ -64,6 +70,49 @@ interface ResolveResult {
     readonly resolvedSecrets: readonly string[];
     readonly refreshedConnectors: readonly string[];
     readonly refreshedSecrets: readonly string[];
+  };
+}
+
+function mergeExpiresAt(
+  expiresAt: number | null,
+  additionalExpiresAt: number | undefined,
+): number | null {
+  if (additionalExpiresAt === undefined) {
+    return expiresAt;
+  }
+  if (expiresAt === null) {
+    return additionalExpiresAt;
+  }
+  return Math.min(expiresAt, additionalExpiresAt);
+}
+
+async function resolveBillableFirewallCacheExpiry(params: {
+  readonly db: Db;
+  readonly auth: SandboxAuth;
+  readonly firewallBillable: boolean | undefined;
+}): Promise<
+  { readonly expiresAt?: number } | ReturnType<typeof insufficientCredits>
+> {
+  if (params.firewallBillable !== true) {
+    return {};
+  }
+
+  const availability = await resolveOrgCreditAvailability({
+    db: params.db,
+    orgId: params.auth.orgId,
+    userId: params.auth.userId,
+  });
+  if (!availability) {
+    return insufficientCredits();
+  }
+
+  const leaseSeconds =
+    availability.spendableCredits <= LOW_BILLABLE_FIREWALL_CREDIT_THRESHOLD
+      ? LOW_BILLABLE_FIREWALL_LEASE_SECONDS
+      : NORMAL_BILLABLE_FIREWALL_LEASE_SECONDS;
+
+  return {
+    expiresAt: Math.floor(nowDate().getTime() / 1000) + leaseSeconds,
   };
 }
 
@@ -1100,7 +1149,7 @@ export async function resolveFirewallAuth(
   | ResolveResult
   | ReturnType<typeof badRequestMessage>
   | {
-      readonly status: 403 | 424 | 502;
+      readonly status: 402 | 403 | 424 | 502;
       readonly body: {
         readonly error: {
           readonly message: string;
@@ -1144,31 +1193,41 @@ export async function resolveFirewallAuth(
     };
   }
 
+  if (
+    body.secretConnectorMap &&
+    hasForbiddenModelProviderOwner(
+      auth,
+      body.secretConnectorMap,
+      body.secretConnectorMetadataMap,
+      referenced.secrets,
+    )
+  ) {
+    return {
+      status: 403,
+      body: {
+        error: {
+          message: "Invalid model-provider secret owner",
+          code: "FORBIDDEN",
+        },
+      },
+    };
+  }
+
+  const billableCacheExpiry = await resolveBillableFirewallCacheExpiry({
+    db,
+    auth,
+    firewallBillable: body.firewallBillable,
+  });
+  if ("status" in billableCacheExpiry) {
+    return billableCacheExpiry;
+  }
+
   let expiresAt: number | null = null;
   let refreshedConnectors: readonly string[] = [];
   let refreshedSecrets: readonly string[] = [];
   let failedConnectors: readonly string[] = [];
 
   if (body.secretConnectorMap) {
-    if (
-      hasForbiddenModelProviderOwner(
-        auth,
-        body.secretConnectorMap,
-        body.secretConnectorMetadataMap,
-        referenced.secrets,
-      )
-    ) {
-      return {
-        status: 403,
-        body: {
-          error: {
-            message: "Invalid model-provider secret owner",
-            code: "FORBIDDEN",
-          },
-        },
-      };
-    }
-
     const result = await refreshExpiredTokens({
       db,
       auth,
@@ -1211,7 +1270,7 @@ export async function resolveFirewallAuth(
       headers: resolved.headers,
       base: resolved.base,
       query: resolved.query,
-      expiresAt,
+      expiresAt: mergeExpiresAt(expiresAt, billableCacheExpiry.expiresAt),
       resolvedSecrets: resolved.resolvedSecrets,
       refreshedConnectors,
       refreshedSecrets,

--- a/turbo/apps/web/app/api/webhooks/agent/firewall/auth/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/firewall/auth/__tests__/route.test.ts
@@ -5,7 +5,6 @@ import {
   createTestRequest,
   createTestCompose,
   createTestRun,
-  createTestSandboxToken,
   insertTestConnectorSecret,
   findTestConnectorTokenExpiresAt,
   findTestConnectorSecret,
@@ -13,6 +12,8 @@ import {
   setTestModelProviderTokenExpiresAt,
   insertUserMultiAuthModelProvider,
   ORG_SENTINEL_USER_ID,
+  insertOrgMembersEntry,
+  setOrgCredits,
 } from "../../../../../../../src/__tests__/api-test-helpers";
 import {
   testContext,
@@ -22,6 +23,7 @@ import { mockClerk } from "../../../../../../../src/__tests__/clerk-mock";
 import { server } from "../../../../../../../src/mocks/server";
 import { encryptSecretsMap } from "../../../../../../../src/lib/shared/crypto/secrets-encryption";
 import { insertTestUserModelProviderSecret } from "../../../../../../../src/__tests__/db-test-seeders/secrets";
+import { generateSandboxToken } from "../../../../../../../src/lib/auth/sandbox-token";
 
 const context = testContext();
 
@@ -62,7 +64,7 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
     );
     const { runId } = await createTestRun(composeId, "Test prompt");
     testRunId = runId;
-    testToken = await createTestSandboxToken(user.userId, testRunId);
+    testToken = await generateSandboxToken(user.userId, testRunId, user.orgId);
 
     mockClerk({ userId: null });
   });
@@ -403,6 +405,98 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
       expect(response.status).toBe(200);
       const data = await response.json();
       expect(data.headers.Authorization).toBe("Bearer ghp_test_token_123");
+    });
+  });
+
+  describe("Billable auth expiry", () => {
+    it("should bound expiresAt when billable firewall credits are available", async () => {
+      await setOrgCredits(user.orgId, 10_000);
+      await insertOrgMembersEntry({
+        orgId: user.orgId,
+        userId: user.userId,
+        creditEnabled: true,
+      });
+
+      const encrypted = encryptTestSecrets({
+        API_TOKEN: "secret-token",
+      });
+      const before = Math.floor(Date.now() / 1000);
+
+      const response = await POST(
+        makeRequest(
+          {
+            encryptedSecrets: encrypted,
+            authHeaders: {
+              Authorization: "Bearer ${{ secrets.API_TOKEN }}",
+            },
+            firewallBillable: true,
+          },
+          testToken,
+        ),
+      );
+
+      const after = Math.floor(Date.now() / 1000);
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.headers.Authorization).toBe("Bearer secret-token");
+      expect(data.expiresAt).toBeGreaterThan(before);
+      expect(data.expiresAt).toBeLessThanOrEqual(after + 30);
+    });
+
+    it("should allow billable firewall auth when member credit metadata is absent", async () => {
+      await setOrgCredits(user.orgId, 10_000);
+
+      const encrypted = encryptTestSecrets({
+        API_TOKEN: "secret-token",
+      });
+
+      const response = await POST(
+        makeRequest(
+          {
+            encryptedSecrets: encrypted,
+            authHeaders: {
+              Authorization: "Bearer ${{ secrets.API_TOKEN }}",
+            },
+            firewallBillable: true,
+          },
+          testToken,
+        ),
+      );
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.headers.Authorization).toBe("Bearer secret-token");
+      expect(data.expiresAt).toBeTypeOf("number");
+    });
+
+    it("should deny billable firewall auth when credits are exhausted", async () => {
+      await setOrgCredits(user.orgId, 0);
+      await insertOrgMembersEntry({
+        orgId: user.orgId,
+        userId: user.userId,
+        creditEnabled: true,
+      });
+
+      const encrypted = encryptTestSecrets({
+        API_TOKEN: "secret-token",
+      });
+
+      const response = await POST(
+        makeRequest(
+          {
+            encryptedSecrets: encrypted,
+            authHeaders: {
+              Authorization: "Bearer ${{ secrets.API_TOKEN }}",
+            },
+            firewallBillable: true,
+          },
+          testToken,
+        ),
+      );
+
+      expect(response.status).toBe(402);
+      const data = await response.json();
+      expect(data.error.code).toBe("INSUFFICIENT_CREDITS");
     });
   });
 
@@ -926,6 +1020,104 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
       const nowEpoch = Math.floor(Date.now() / 1000);
       expect(data.expiresAt).toBeGreaterThan(nowEpoch + 3500);
       expect(data.expiresAt).toBeLessThanOrEqual(nowEpoch + 3600);
+    });
+
+    it("should use OAuth token expiry when it is earlier than billable credit lease", async () => {
+      await setOrgCredits(user.orgId, 10_000);
+      await insertOrgMembersEntry({
+        orgId: user.orgId,
+        userId: user.userId,
+        creditEnabled: true,
+      });
+      await setupNotionConnector({
+        tokenExpiresAt: new Date(Date.now() - 60 * 1000),
+      });
+
+      server.use(
+        mswHttp.post(NOTION_TOKEN_URL, () => {
+          return HttpResponse.json({
+            access_token: "short-lived-notion-token",
+            expires_in: 10,
+          });
+        }),
+      );
+
+      const encrypted = encryptTestSecrets({
+        NOTION_ACCESS_TOKEN: "old-notion-token",
+        NOTION_REFRESH_TOKEN: "notion-refresh-token",
+      });
+      const before = Math.floor(Date.now() / 1000);
+
+      const response = await POST(
+        makeRequest(
+          {
+            encryptedSecrets: encrypted,
+            authHeaders: {
+              Authorization: "Bearer ${{ secrets.NOTION_ACCESS_TOKEN }}",
+            },
+            secretConnectorMap: { NOTION_ACCESS_TOKEN: "notion" },
+            firewallBillable: true,
+          },
+          testToken,
+        ),
+      );
+
+      const after = Math.floor(Date.now() / 1000);
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.headers.Authorization).toBe(
+        "Bearer short-lived-notion-token",
+      );
+      expect(data.expiresAt).toBeGreaterThan(before);
+      expect(data.expiresAt).toBeLessThanOrEqual(after + 10);
+    });
+
+    it("should use billable credit lease when it is earlier than OAuth token expiry", async () => {
+      await setOrgCredits(user.orgId, 10_000);
+      await insertOrgMembersEntry({
+        orgId: user.orgId,
+        userId: user.userId,
+        creditEnabled: true,
+      });
+      await setupNotionConnector({
+        tokenExpiresAt: new Date(Date.now() - 60 * 1000),
+      });
+
+      server.use(
+        mswHttp.post(NOTION_TOKEN_URL, () => {
+          return HttpResponse.json({
+            access_token: "long-lived-notion-token",
+            expires_in: 3600,
+          });
+        }),
+      );
+
+      const encrypted = encryptTestSecrets({
+        NOTION_ACCESS_TOKEN: "old-notion-token",
+        NOTION_REFRESH_TOKEN: "notion-refresh-token",
+      });
+      const before = Math.floor(Date.now() / 1000);
+
+      const response = await POST(
+        makeRequest(
+          {
+            encryptedSecrets: encrypted,
+            authHeaders: {
+              Authorization: "Bearer ${{ secrets.NOTION_ACCESS_TOKEN }}",
+            },
+            secretConnectorMap: { NOTION_ACCESS_TOKEN: "notion" },
+            firewallBillable: true,
+          },
+          testToken,
+        ),
+      );
+
+      const after = Math.floor(Date.now() / 1000);
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.headers.Authorization).toBe("Bearer long-lived-notion-token");
+      expect(data.expiresAt).toBeGreaterThan(before);
+      expect(data.expiresAt).toBeLessThanOrEqual(after + 30);
     });
 
     it("should proactively refresh token expiring within 60s buffer", async () => {
@@ -1734,7 +1926,7 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
       expect(row!.lastRefreshErrorCode).toBeNull();
     });
 
-    it("rejects forged personal codex-oauth-token owner metadata", async () => {
+    it("rejects forged personal codex-oauth-token owner metadata before billable credit auth", async () => {
       const encrypted = encryptTestSecrets({
         CHATGPT_ACCESS_TOKEN: "old-personal-chatgpt-at",
       });
@@ -1754,6 +1946,7 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
                 metadataKey: "codex-oauth-token",
               },
             },
+            firewallBillable: true,
           },
           testToken,
         ),

--- a/turbo/apps/web/app/api/webhooks/agent/firewall/auth/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/firewall/auth/route.ts
@@ -21,6 +21,11 @@ import {
 } from "../../../../../../src/lib/zero/handler-key-bridge";
 import { ORG_SENTINEL_USER_ID } from "../../../../../../src/lib/zero/org/org-sentinel";
 import { basicAuthTemplateRe } from "@vm0/connectors/firewall-types";
+import { resolveOrgCreditAvailability } from "../../../../../../src/lib/zero/credit/check-org-credits";
+
+const NORMAL_BILLABLE_FIREWALL_LEASE_SECONDS = 30;
+const LOW_BILLABLE_FIREWALL_LEASE_SECONDS = 5;
+const LOW_BILLABLE_FIREWALL_CREDIT_THRESHOLD = 1000;
 
 const bodySchema = z.object({
   encryptedSecrets: z.string().min(1),
@@ -39,6 +44,7 @@ const bodySchema = z.object({
     )
     .optional(),
   vars: z.record(z.string(), z.string()).optional(),
+  firewallBillable: z.boolean().optional(),
   // Set by the mitm addon after an upstream 401 so the refresh filter
   // below overrides DB tokenExpiresAt. Covers the case where the provider
   // silently invalidates a token while DB expiry is still in the future
@@ -120,6 +126,19 @@ interface RefreshResult {
   refreshedConnectors: string[];
   refreshedSecrets: string[];
   failedConnectors: string[];
+}
+
+function mergeExpiresAt(
+  expiresAt: number | null,
+  additionalExpiresAt: number | undefined,
+): number | null {
+  if (additionalExpiresAt === undefined) {
+    return expiresAt;
+  }
+  if (expiresAt === null) {
+    return additionalExpiresAt;
+  }
+  return Math.min(expiresAt, additionalExpiresAt);
 }
 
 /**
@@ -596,8 +615,12 @@ function resolveTemplates(
  *
  * Auth: Sandbox JWT
  * Body: { encryptedSecrets, authHeaders, authBase?, authQuery?, secretConnectorMap?,
- *         secretConnectorMetadataMap?, vars?, forceRefresh? }
- * Response: { headers, base?, query?, expiresAt?, resolvedSecrets, refreshedConnectors, refreshedSecrets }
+ *         secretConnectorMetadataMap?, vars?, firewallBillable?, forceRefresh? }
+ * Response: { headers, base?, query?, expiresAt?,
+ *             resolvedSecrets, refreshedConnectors, refreshedSecrets }
+ *           where expiresAt is the effective addon cache expiry. Billable
+ *           firewall auth folds credit re-check timing into this value.
+ *           or 402 { error } when a billable firewall request has no credits
  *           or 424 { error } when referenced secrets/vars are missing (connector not configured)
  *           or 502 { error } when token refresh fails
  */
@@ -652,6 +675,7 @@ export async function POST(request: Request) {
     secretConnectorMap,
     secretConnectorMetadataMap,
     vars,
+    firewallBillable,
     forceRefresh,
   } = parsed.data;
 
@@ -696,31 +720,57 @@ export async function POST(request: Request) {
     );
   }
 
+  if (
+    secretConnectorMap &&
+    hasForbiddenModelProviderOwner(
+      auth,
+      secretConnectorMap,
+      secretConnectorMetadataMap,
+      referenced.secrets,
+    )
+  ) {
+    return NextResponse.json(
+      {
+        error: {
+          message: "Invalid model-provider secret owner",
+          code: "FORBIDDEN",
+        },
+      },
+      { status: 403 },
+    );
+  }
+
+  let billableExpiresAt: number | undefined;
+  if (firewallBillable === true) {
+    const availability = await resolveOrgCreditAvailability(
+      auth.orgId,
+      auth.userId,
+    );
+    if (!availability) {
+      return NextResponse.json(
+        {
+          error: {
+            message:
+              "Insufficient credits. Add credits or configure your own API key to continue.",
+            code: "INSUFFICIENT_CREDITS",
+          },
+        },
+        { status: 402 },
+      );
+    }
+    const leaseSeconds =
+      availability.spendableCredits <= LOW_BILLABLE_FIREWALL_CREDIT_THRESHOLD
+        ? LOW_BILLABLE_FIREWALL_LEASE_SECONDS
+        : NORMAL_BILLABLE_FIREWALL_LEASE_SECONDS;
+    billableExpiresAt = Math.floor(Date.now() / 1000) + leaseSeconds;
+  }
+
   // Refresh expired OAuth tokens (mutates secrets map with fresh values)
   let expiresAt: number | null = null;
   let refreshedConnectors: string[] = [];
   let refreshedSecrets: string[] = [];
   let failedConnectors: string[] = [];
   if (secretConnectorMap) {
-    if (
-      hasForbiddenModelProviderOwner(
-        auth,
-        secretConnectorMap,
-        secretConnectorMetadataMap,
-        referenced.secrets,
-      )
-    ) {
-      return NextResponse.json(
-        {
-          error: {
-            message: "Invalid model-provider secret owner",
-            code: "FORBIDDEN",
-          },
-        },
-        { status: 403 },
-      );
-    }
-
     const result = await refreshExpiredTokens(
       auth,
       secrets,
@@ -763,7 +813,7 @@ export async function POST(request: Request) {
     headers,
     base,
     query,
-    expiresAt,
+    expiresAt: mergeExpiresAt(expiresAt, billableExpiresAt),
     resolvedSecrets,
     refreshedConnectors,
     refreshedSecrets,

--- a/turbo/packages/api-contracts/src/contracts/webhooks.ts
+++ b/turbo/packages/api-contracts/src/contracts/webhooks.ts
@@ -135,6 +135,9 @@ const firewallAuthResponseSchema = z.object({
   headers: z.record(z.string(), z.string()),
   base: z.string().optional(),
   query: z.record(z.string(), z.string()).optional(),
+  // Effective addon cache expiry as Unix seconds. OAuth token expiry is the
+  // normal source; billable firewall auth can shorten it to force credit
+  // re-authorization. Null means non-expiring only for non-billable auth.
   expiresAt: z.number().nullable(),
   resolvedSecrets: z.array(z.string()),
   refreshedConnectors: z.array(z.string()),
@@ -158,12 +161,16 @@ export const webhookFirewallAuthContract = c.router({
       secretConnectorMap: z.record(z.string(), z.string()).optional(),
       secretConnectorMetadataMap: secretConnectorMetadataMapSchema.optional(),
       vars: z.record(z.string(), z.string()).optional(),
+      // Set by mitm from billableFirewalls. Server uses this only to bound
+      // auth cache lifetime by the current credit authorization lease.
+      firewallBillable: z.boolean().optional(),
       forceRefresh: z.boolean().optional(),
     }),
     responses: {
       200: firewallAuthResponseSchema,
       400: apiErrorSchema,
       401: apiErrorSchema,
+      402: apiErrorSchema,
       403: apiErrorSchema,
       424: firewallAuthErrorSchema,
       502: firewallAuthErrorSchema,


### PR DESCRIPTION
## Summary

- gate every `firewallBillable` auth resolution on org/member credit availability
- bound billable firewall auth cache lifetime with the existing `expiresAt` response field
- make mitm refetch billable auth when the lease is missing or expired, while leaving non-billable caching unchanged
- cover both `apps/api` and legacy `apps/web` firewall auth paths

Closes #13358

## Tests

- `python3 -m pytest tests/test_connectors.py -k "GetFirewallHeaders or FetchFirewallHeaders" -v`
- `pnpm exec vitest run apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts --project api`
- `pnpm exec vitest run apps/web/app/api/webhooks/agent/firewall/auth/__tests__/route.test.ts --project web`
- `pnpm --filter api check-types`
- `pnpm --filter web check-types`
- pre-commit: `ruff`, `prettier`, `knip`, `turbo run check-types --concurrency=1`
