### PR TITLE
feat: add local browser chrome extension

### DIFF
--- a/turbo/apps/local-browser-extension/.oxlintrc.json
+++ b/turbo/apps/local-browser-extension/.oxlintrc.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "../../node_modules/oxlint/configuration_schema.json",
+  "ignorePatterns": ["dist/**"]
+}

--- a/turbo/apps/local-browser-extension/README.md
+++ b/turbo/apps/local-browser-extension/README.md
@@ -1,0 +1,11 @@
+# VM0 Local Browser Extension
+
+This app builds the unpacked Chrome extension used by the Local Browser connector.
+
+```bash
+pnpm -F @vm0/local-browser-extension build
+```
+
+Load `turbo/apps/local-browser-extension/dist` from `chrome://extensions` with Developer Mode enabled.
+
+The extension pairs from the VM0 connector modal, stores a host token in `chrome.storage.local`, heartbeats the host, claims queued local-browser commands, executes structured tab/page actions, and completes the command through the API.

--- a/turbo/apps/local-browser-extension/eslint.config.mjs
+++ b/turbo/apps/local-browser-extension/eslint.config.mjs
@@ -1,0 +1,6 @@
+import { config, oxlint } from "@vm0/eslint-config/base";
+
+export default [
+  ...config,
+  ...oxlint.buildFromOxlintConfigFile("./.oxlintrc.json"),
+];

--- a/turbo/apps/local-browser-extension/package.json
+++ b/turbo/apps/local-browser-extension/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@vm0/local-browser-extension",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "node scripts/build.mjs",
+    "dev": "node scripts/build.mjs",
+    "lint": "oxlint && eslint . --max-warnings 0",
+    "check-types": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@vm0/api-contracts": "workspace:*",
+    "@vm0/eslint-config": "workspace:*",
+    "@vm0/typescript-config": "workspace:*",
+    "esbuild": "^0.27.4",
+    "eslint": "^9.34.0",
+    "oxlint": "^1.57.0",
+    "typescript": "5.9.3"
+  }
+}

--- a/turbo/apps/local-browser-extension/scripts/build.mjs
+++ b/turbo/apps/local-browser-extension/scripts/build.mjs
@@ -1,0 +1,94 @@
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { build } from "esbuild";
+
+const root = resolve(import.meta.dirname, "..");
+const dist = resolve(root, "dist");
+const pkg = JSON.parse(await readFile(resolve(root, "package.json"), "utf8"));
+async function writeManifest() {
+  const manifest = {
+    manifest_version: 3,
+    name: "VM0 Local Browser",
+    description: "Connect Chrome to VM0 Local Browser Use.",
+    version: pkg.version,
+    minimum_chrome_version: "120",
+    action: {
+      default_title: "VM0 Local Browser",
+      default_popup: "popup.html",
+    },
+    background: {
+      service_worker: "background.js",
+      type: "module",
+    },
+    permissions: ["alarms", "scripting", "storage", "tabs"],
+    host_permissions: ["http://*/*", "https://*/*"],
+    content_scripts: [
+      {
+        matches: [
+          "https://*.vm0.ai/*",
+          "https://*.vm7.ai/*",
+          "http://localhost/*",
+          "http://127.0.0.1/*",
+        ],
+        js: ["content.js"],
+        run_at: "document_idle",
+      },
+    ],
+  };
+
+  await writeFile(
+    resolve(dist, "manifest.json"),
+    `${JSON.stringify(manifest, null, 2)}\n`,
+  );
+}
+
+async function copyStaticFiles() {
+  const [html, css] = await Promise.all([
+    readFile(resolve(root, "src/popup/popup.html"), "utf8"),
+    readFile(resolve(root, "src/popup/popup.css"), "utf8"),
+  ]);
+  await Promise.all([
+    writeFile(resolve(dist, "popup.html"), html),
+    writeFile(resolve(dist, "popup.css"), css),
+  ]);
+}
+
+async function buildOnce() {
+  await rm(dist, { force: true, recursive: true });
+  await mkdir(dist, { recursive: true });
+  await Promise.all([
+    build({
+      bundle: true,
+      define: {
+        __EXTENSION_VERSION__: JSON.stringify(pkg.version),
+      },
+      entryPoints: [resolve(root, "src/background/index.ts")],
+      format: "esm",
+      outfile: resolve(dist, "background.js"),
+      platform: "browser",
+      sourcemap: true,
+      target: "chrome120",
+    }),
+    build({
+      bundle: true,
+      entryPoints: [resolve(root, "src/content/index.ts")],
+      format: "iife",
+      outfile: resolve(dist, "content.js"),
+      platform: "browser",
+      sourcemap: true,
+      target: "chrome120",
+    }),
+    build({
+      bundle: true,
+      entryPoints: [resolve(root, "src/popup/index.ts")],
+      format: "iife",
+      outfile: resolve(dist, "popup.js"),
+      platform: "browser",
+      sourcemap: true,
+      target: "chrome120",
+    }),
+  ]);
+  await Promise.all([writeManifest(), copyStaticFiles()]);
+}
+
+await buildOnce();

--- a/turbo/apps/local-browser-extension/src/background/browser-actions.ts
+++ b/turbo/apps/local-browser-extension/src/background/browser-actions.ts
@@ -1,0 +1,473 @@
+import type {
+  LocalBrowserCommandError,
+  LocalBrowserCommandErrorCode,
+  LocalBrowserCommandResult,
+  LocalBrowserReadCommandKind,
+  LocalBrowserTab,
+} from "@vm0/api-contracts/contracts/zero-local-browser";
+import type { LocalBrowserHostCommand } from "../shared/protocol";
+
+const MAX_SNAPSHOT_CHARS = 480_000;
+const MAX_SELECTION_CHARS = 64_000;
+const MAX_IMAGE_BASE64_CHARS = 1_900_000;
+
+export class LocalBrowserCommandFailure extends Error {
+  constructor(
+    readonly code: LocalBrowserCommandErrorCode,
+    message: string,
+  ) {
+    super(message);
+    this.name = "LocalBrowserCommandFailure";
+  }
+}
+
+function fail(
+  code: LocalBrowserCommandErrorCode,
+  message: string,
+): LocalBrowserCommandFailure {
+  return new LocalBrowserCommandFailure(code, message);
+}
+
+function chromeErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  if (typeof error === "string") {
+    return error;
+  }
+  return "Chrome extension API failed";
+}
+
+export function commandErrorFromUnknown(
+  error: unknown,
+): LocalBrowserCommandError {
+  if (error instanceof LocalBrowserCommandFailure) {
+    return {
+      code: error.code,
+      message: error.message,
+    };
+  }
+
+  const message = chromeErrorMessage(error);
+  if (
+    message.includes("Cannot access") ||
+    message.includes("permission") ||
+    message.includes("Permission")
+  ) {
+    return { code: "permission_denied", message };
+  }
+  if (
+    message.includes("No tab") ||
+    message.includes("Cannot find a tab") ||
+    message.includes("Invalid tab")
+  ) {
+    return { code: "no_active_tab", message };
+  }
+  return { code: "unsupported_page", message };
+}
+
+function tabIdNumber(tabId: string | undefined): number | null {
+  if (!tabId) {
+    return null;
+  }
+  const parsed = Number.parseInt(tabId, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+}
+
+function tabToResult(tab: ChromeTab): LocalBrowserTab {
+  return {
+    id: String(tab.id ?? ""),
+    active: tab.active,
+    faviconUrl: tab.favIconUrl,
+    title: tab.title,
+    url: tab.url,
+  };
+}
+
+function isHttpUrl(value: string | undefined): boolean {
+  if (!value) {
+    return false;
+  }
+  try {
+    const url = new URL(value);
+    return url.protocol === "http:" || url.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+function assertHttpUrl(value: string | undefined, message: string): string {
+  if (!isHttpUrl(value)) {
+    throw fail("unsupported_page", message);
+  }
+  return value as string;
+}
+
+async function getActiveTab(): Promise<ChromeTab> {
+  const currentWindowTabs = await chrome.tabs.query({
+    active: true,
+    currentWindow: true,
+  });
+  if (currentWindowTabs[0]?.id) {
+    return currentWindowTabs[0];
+  }
+
+  const focusedTabs = await chrome.tabs.query({
+    active: true,
+    lastFocusedWindow: true,
+  });
+  if (focusedTabs[0]?.id) {
+    return focusedTabs[0];
+  }
+
+  throw fail("no_active_tab", "No active Chrome tab is available");
+}
+
+async function getTargetTab(tabId: string | undefined): Promise<ChromeTab> {
+  const parsed = tabIdNumber(tabId);
+  if (parsed) {
+    return await chrome.tabs.get(parsed);
+  }
+  return await getActiveTab();
+}
+
+async function getInjectableTargetTab(
+  tabId: string | undefined,
+): Promise<ChromeTab> {
+  const tab = await getTargetTab(tabId);
+  if (!tab.id) {
+    throw fail("no_active_tab", "Target tab does not have an id");
+  }
+  assertHttpUrl(tab.url, "Local browser commands only support http(s) pages");
+  return tab;
+}
+
+async function runScript<TArgs extends unknown[], TResult>(
+  tabId: number,
+  func: (...args: TArgs) => TResult,
+  ...args: TArgs
+): Promise<Awaited<TResult>> {
+  const [result] = await chrome.scripting.executeScript({
+    args,
+    func,
+    target: { tabId },
+  });
+  if (!result) {
+    throw fail("unsupported_page", "No script result was returned");
+  }
+  return result.result as Awaited<TResult>;
+}
+
+function getPageSnapshot(maxChars: number) {
+  const parts = [
+    `Title: ${document.title}`,
+    `URL: ${location.href}`,
+    document.body?.innerText ?? "",
+  ];
+  const text = parts
+    .join("\n\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+  return {
+    contentType: "text/plain",
+    snapshot: text.slice(0, maxChars),
+    truncated: text.length > maxChars,
+  };
+}
+
+function getPageSelection(maxChars: number) {
+  const text = window.getSelection()?.toString() ?? "";
+  return {
+    text: text.slice(0, maxChars),
+  };
+}
+
+function clickPageTarget(params: {
+  readonly selector?: string;
+  readonly x?: number;
+  readonly y?: number;
+}) {
+  let element: Element | null = null;
+
+  if (params.selector) {
+    element = document.querySelector(params.selector);
+    if (!element) {
+      return {
+        ok: false,
+        message: `No element matched selector: ${params.selector}`,
+      };
+    }
+    element.scrollIntoView({ block: "center", inline: "center" });
+  } else if (params.x !== undefined && params.y !== undefined) {
+    element = document.elementFromPoint(params.x, params.y);
+    if (!element) {
+      return {
+        ok: false,
+        message: `No element found at (${params.x}, ${params.y})`,
+      };
+    }
+  }
+
+  if (!(element instanceof HTMLElement)) {
+    return { ok: false, message: "Target is not a clickable HTML element" };
+  }
+
+  element.focus();
+  element.click();
+  return { ok: true, details: "Clicked target" };
+}
+
+function typeIntoPageTarget(params: {
+  readonly selector: string;
+  readonly text: string;
+}) {
+  const element = document.querySelector(params.selector);
+  if (!(element instanceof HTMLElement)) {
+    return {
+      ok: false,
+      message: `No editable element matched selector: ${params.selector}`,
+    };
+  }
+
+  element.focus();
+  if (
+    element instanceof HTMLInputElement ||
+    element instanceof HTMLTextAreaElement
+  ) {
+    const start = element.selectionStart ?? element.value.length;
+    const end = element.selectionEnd ?? element.value.length;
+    element.value =
+      element.value.slice(0, start) + params.text + element.value.slice(end);
+    const nextPosition = start + params.text.length;
+    element.setSelectionRange(nextPosition, nextPosition);
+    element.dispatchEvent(new InputEvent("input", { bubbles: true }));
+    element.dispatchEvent(new Event("change", { bubbles: true }));
+    return { ok: true, details: "Typed text" };
+  }
+
+  if (element.isContentEditable) {
+    document.execCommand("insertText", false, params.text);
+    element.dispatchEvent(new InputEvent("input", { bubbles: true }));
+    return { ok: true, details: "Typed text" };
+  }
+
+  return { ok: false, message: "Target element is not editable" };
+}
+
+function scrollPage(params: {
+  readonly direction: "up" | "down";
+  readonly amount: number;
+}) {
+  const top = params.direction === "up" ? -params.amount : params.amount;
+  window.scrollBy({ behavior: "smooth", top });
+  return { ok: true, details: `Scrolled ${params.direction}` };
+}
+
+function assertPageActionResult(result: {
+  readonly ok: boolean;
+  readonly message?: string;
+  readonly details?: string;
+}): LocalBrowserCommandResult {
+  if (!result.ok) {
+    throw fail("unsupported_page", result.message ?? "Page action failed");
+  }
+  return {
+    ok: true,
+    ...(result.details ? { details: result.details } : {}),
+  };
+}
+
+async function captureActiveTabScreenshot(
+  tab: ChromeTab,
+): Promise<LocalBrowserCommandResult> {
+  if (!tab.active) {
+    throw fail(
+      "unsupported_page",
+      "Screenshot requires the target tab to be active and visible",
+    );
+  }
+
+  const windowId = tab.windowId;
+  let dataUrl = await chrome.tabs.captureVisibleTab(windowId, {
+    format: "png",
+  });
+  if (dataUrl.length > MAX_IMAGE_BASE64_CHARS) {
+    dataUrl = await chrome.tabs.captureVisibleTab(windowId, {
+      format: "jpeg",
+      quality: 75,
+    });
+  }
+
+  const match = /^data:(image\/(?:png|jpeg|webp));base64,(.*)$/u.exec(dataUrl);
+  if (!match) {
+    throw fail("unsupported_page", "Chrome returned an unsupported screenshot");
+  }
+
+  const imageBase64 = match[2] ?? "";
+  return {
+    imageBase64: imageBase64.slice(0, MAX_IMAGE_BASE64_CHARS),
+    mimeType: match[1] as "image/jpeg" | "image/png" | "image/webp",
+    truncated: imageBase64.length > MAX_IMAGE_BASE64_CHARS,
+  };
+}
+
+async function focusTab(tab: ChromeTab): Promise<void> {
+  if (!tab.id) {
+    throw fail("no_active_tab", "Target tab does not have an id");
+  }
+  await chrome.tabs.update(tab.id, { active: true });
+  if (tab.windowId !== undefined) {
+    await chrome.windows.update(tab.windowId, { focused: true });
+  }
+}
+
+function isReadCommandKind(
+  kind: LocalBrowserHostCommand["kind"],
+): kind is LocalBrowserReadCommandKind {
+  return (
+    kind === "tabs.list" ||
+    kind === "tabs.current" ||
+    kind === "page.snapshot" ||
+    kind === "page.screenshot" ||
+    kind === "page.selection" ||
+    kind === "page.metadata"
+  );
+}
+
+async function executeReadCommand(
+  command: LocalBrowserHostCommand,
+): Promise<LocalBrowserCommandResult> {
+  switch (command.kind) {
+    case "tabs.list": {
+      const tabs = await chrome.tabs.query({});
+      return {
+        tabs: tabs
+          .filter((tab) => {
+            return tab.id !== undefined;
+          })
+          .map(tabToResult),
+      };
+    }
+    case "tabs.current": {
+      const tab = await getTargetTab(command.payload.tabId);
+      return { tab: tabToResult(tab) };
+    }
+    case "page.metadata": {
+      const tab = await getTargetTab(command.payload.tabId);
+      return {
+        faviconUrl: tab.favIconUrl,
+        title: tab.title ?? "",
+        url: tab.url ?? "",
+      };
+    }
+    case "page.snapshot": {
+      const tab = await getInjectableTargetTab(command.payload.tabId);
+      return await runScript(tab.id ?? 0, getPageSnapshot, MAX_SNAPSHOT_CHARS);
+    }
+    case "page.selection": {
+      const tab = await getInjectableTargetTab(command.payload.tabId);
+      return await runScript(
+        tab.id ?? 0,
+        getPageSelection,
+        MAX_SELECTION_CHARS,
+      );
+    }
+    case "page.screenshot": {
+      const tab = await getTargetTab(command.payload.tabId);
+      assertHttpUrl(tab.url, "Screenshots only support http(s) pages");
+      return await captureActiveTabScreenshot(tab);
+    }
+    default:
+      throw fail("unsupported_command", `Unsupported command: ${command.kind}`);
+  }
+}
+
+async function executeWriteCommand(
+  command: LocalBrowserHostCommand,
+): Promise<LocalBrowserCommandResult> {
+  switch (command.kind) {
+    case "tabs.activate": {
+      const tab = await getTargetTab(command.payload.tabId);
+      await focusTab(tab);
+      return { ok: true, details: "Activated tab" };
+    }
+    case "tabs.open": {
+      const url = assertHttpUrl(
+        command.payload.url,
+        "tabs.open requires an http(s) URL",
+      );
+      const tab = await chrome.tabs.create({ url });
+      return { ok: true, details: `Opened tab ${tab.id ?? ""}`.trim() };
+    }
+    case "tabs.close": {
+      const parsed = tabIdNumber(command.payload.tabId);
+      if (!parsed) {
+        throw fail("no_active_tab", "tabs.close requires a tabId");
+      }
+      await chrome.tabs.remove(parsed);
+      return { ok: true, details: "Closed tab" };
+    }
+    case "page.navigate": {
+      const tab = await getTargetTab(command.payload.tabId);
+      if (!tab.id) {
+        throw fail("no_active_tab", "Target tab does not have an id");
+      }
+      const url = assertHttpUrl(
+        command.payload.url,
+        "page.navigate requires an http(s) URL",
+      );
+      await chrome.tabs.update(tab.id, { url });
+      return { ok: true, details: "Navigated tab" };
+    }
+    case "page.scroll": {
+      const tab = await getInjectableTargetTab(command.payload.tabId);
+      const direction = command.payload.direction;
+      const amount = command.payload.amount;
+      if (!direction || amount === undefined) {
+        throw fail(
+          "unsupported_command",
+          "page.scroll requires direction and amount",
+        );
+      }
+      const result = await runScript(tab.id ?? 0, scrollPage, {
+        amount,
+        direction,
+      });
+      return assertPageActionResult(result);
+    }
+    case "page.click": {
+      const tab = await getInjectableTargetTab(command.payload.tabId);
+      const result = await runScript(tab.id ?? 0, clickPageTarget, {
+        selector: command.payload.selector,
+        x: command.payload.x,
+        y: command.payload.y,
+      });
+      return assertPageActionResult(result);
+    }
+    case "page.type": {
+      const tab = await getInjectableTargetTab(command.payload.tabId);
+      if (!command.payload.selector || command.payload.text === undefined) {
+        throw fail(
+          "unsupported_command",
+          "page.type requires selector and text",
+        );
+      }
+      const result = await runScript(tab.id ?? 0, typeIntoPageTarget, {
+        selector: command.payload.selector,
+        text: command.payload.text,
+      });
+      return assertPageActionResult(result);
+    }
+    default:
+      throw fail("unsupported_command", `Unsupported command: ${command.kind}`);
+  }
+}
+
+export async function executeLocalBrowserCommand(
+  command: LocalBrowserHostCommand,
+): Promise<LocalBrowserCommandResult> {
+  if (isReadCommandKind(command.kind)) {
+    return await executeReadCommand(command);
+  }
+  return await executeWriteCommand(command);
+}

--- a/turbo/apps/local-browser-extension/src/background/index.ts
+++ b/turbo/apps/local-browser-extension/src/background/index.ts
@@ -1,0 +1,75 @@
+import type {
+  BridgeBackgroundMessage,
+  BridgeBackgroundResponse,
+} from "../shared/protocol";
+import {
+  detectExtension,
+  extensionStatus,
+  handleAlarm,
+  initializeRuntime,
+  openConnectorPage,
+  revokeHost,
+  startPairing,
+} from "./runtime";
+
+function isBackgroundMessage(value: unknown): value is BridgeBackgroundMessage {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const type = (value as Record<string, unknown>).type;
+  return (
+    type === "localBrowser.detect" ||
+    type === "localBrowser.pair" ||
+    type === "localBrowser.getStatus" ||
+    type === "localBrowser.revokeHost" ||
+    type === "localBrowser.openConnectorPage"
+  );
+}
+
+function errorResponse(error: unknown): BridgeBackgroundResponse {
+  return {
+    message:
+      error instanceof Error ? error.message : "Local browser extension failed",
+    ok: false,
+  };
+}
+
+async function handleMessage(
+  message: BridgeBackgroundMessage,
+): Promise<BridgeBackgroundResponse> {
+  switch (message.type) {
+    case "localBrowser.detect":
+      return await detectExtension();
+    case "localBrowser.pair":
+      return await startPairing(message.pageUrl);
+    case "localBrowser.getStatus":
+      return await extensionStatus();
+    case "localBrowser.revokeHost":
+      return await revokeHost();
+    case "localBrowser.openConnectorPage":
+      return await openConnectorPage();
+  }
+}
+
+chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
+  if (!isBackgroundMessage(message)) {
+    return false;
+  }
+
+  void handleMessage(message)
+    .then(sendResponse)
+    .catch((error: unknown) => {
+      sendResponse(errorResponse(error));
+    });
+  return true;
+});
+
+chrome.alarms.onAlarm.addListener(handleAlarm);
+chrome.runtime.onInstalled.addListener(() => {
+  void initializeRuntime();
+});
+chrome.runtime.onStartup.addListener(() => {
+  void initializeRuntime();
+});
+
+void initializeRuntime();

--- a/turbo/apps/local-browser-extension/src/background/runtime.ts
+++ b/turbo/apps/local-browser-extension/src/background/runtime.ts
@@ -1,0 +1,488 @@
+import type {
+  LocalBrowserCommandError,
+  LocalBrowserCommandResult,
+} from "@vm0/api-contracts/contracts/zero-local-browser";
+import {
+  claimNextCommand,
+  completeCommand,
+  heartbeatHost,
+  pollDevicePairing,
+  revokeCurrentHost,
+  startDevicePairing,
+} from "../shared/api";
+import {
+  SUPPORTED_CAPABILITIES,
+  statusFromState,
+  type BridgeBackgroundResponse,
+  type ExtensionState,
+  type LinkedHostState,
+  type PairingState,
+} from "../shared/protocol";
+import {
+  clearExtensionState,
+  loadExtensionState,
+  patchExtensionState,
+  saveExtensionState,
+} from "../shared/storage";
+import {
+  commandErrorFromUnknown,
+  executeLocalBrowserCommand,
+  LocalBrowserCommandFailure,
+} from "./browser-actions";
+
+const TICK_ALARM = "vm0-local-browser-tick";
+const HEARTBEAT_INTERVAL_MS = 30_000;
+const COMMAND_POLL_INTERVAL_MS = 2_000;
+const MAX_COMMANDS_PER_TICK = 5;
+const DEFAULT_COMMAND_TIMEOUT_MS = 15_000;
+
+let commandLoopRunning = false;
+let lastCommandPollAt = 0;
+
+function now(): number {
+  return Date.now();
+}
+
+function browserName(): string {
+  const userAgent = navigator.userAgent;
+  if (userAgent.includes("Edg/")) {
+    return "Microsoft Edge";
+  }
+  if (userAgent.includes("Chrome/")) {
+    return "Chrome";
+  }
+  return "Chromium";
+}
+
+function platformName(): string {
+  return navigator.platform || "this device";
+}
+
+function hostName(): string {
+  return `${browserName()} on ${platformName()}`;
+}
+
+function normalizeOrigin(url: URL): string {
+  return url.origin.endsWith("/") ? url.origin.slice(0, -1) : url.origin;
+}
+
+function rewriteApiHostname(hostname: string): string {
+  return hostname.replace(/(^|-)(platform|app|www|api)\./u, "$1api.");
+}
+
+function resolveBasesFromPageUrl(pageUrl: string): {
+  readonly apiBaseUrl: string;
+  readonly appBaseUrl: string;
+} {
+  const url = new URL(pageUrl);
+  if (url.hostname === "localhost" || url.hostname === "127.0.0.1") {
+    return {
+      apiBaseUrl: "http://localhost:3000",
+      appBaseUrl: normalizeOrigin(url),
+    };
+  }
+
+  const apiUrl = new URL(url.origin);
+  apiUrl.hostname = rewriteApiHostname(apiUrl.hostname);
+  return {
+    apiBaseUrl: normalizeOrigin(apiUrl),
+    appBaseUrl: normalizeOrigin(url),
+  };
+}
+
+function extensionVersion(): string {
+  return chrome.runtime.getManifest().version || __EXTENSION_VERSION__;
+}
+
+function toErrorMessage(error: unknown): string {
+  return error instanceof Error
+    ? error.message
+    : "Local browser runtime failed";
+}
+
+async function updateBadge(state: ExtensionState): Promise<void> {
+  if (!chrome.action) {
+    return;
+  }
+  const status = statusFromState(state);
+  if (status.paused) {
+    await chrome.action.setBadgeText({ text: "II" });
+    await chrome.action.setBadgeBackgroundColor({ color: "#6b7280" });
+    await chrome.action.setTitle({ title: "VM0 Local Browser paused" });
+    return;
+  }
+  if (status.linked) {
+    await chrome.action.setBadgeText({ text: "ON" });
+    await chrome.action.setBadgeBackgroundColor({ color: "#16a34a" });
+    await chrome.action.setTitle({ title: "VM0 Local Browser connected" });
+    return;
+  }
+  if (status.paired) {
+    await chrome.action.setBadgeText({ text: "..." });
+    await chrome.action.setBadgeBackgroundColor({ color: "#ca8a04" });
+    await chrome.action.setTitle({ title: "VM0 Local Browser pairing" });
+    return;
+  }
+  await chrome.action.setBadgeText({ text: "" });
+  await chrome.action.setTitle({ title: "VM0 Local Browser" });
+}
+
+async function saveError(message: string): Promise<void> {
+  const state = await patchExtensionState({
+    lastError: message,
+    lastStatusAt: now(),
+  });
+  await updateBadge(state);
+}
+
+async function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+): Promise<T> {
+  const controller = new AbortController();
+  const timeout = globalThis.setTimeout(() => {
+    controller.abort();
+  }, timeoutMs);
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<T>((_resolve, reject) => {
+        controller.signal.addEventListener(
+          "abort",
+          () => {
+            reject(
+              new LocalBrowserCommandFailure("timeout", "Command timed out"),
+            );
+          },
+          { once: true },
+        );
+      }),
+    ]);
+  } finally {
+    globalThis.clearTimeout(timeout);
+  }
+}
+
+async function createPairingState(pageUrl: string): Promise<PairingState> {
+  const bases = resolveBasesFromPageUrl(pageUrl);
+  const browser = browserName();
+  const response = await startDevicePairing({
+    apiBaseUrl: bases.apiBaseUrl,
+    browser,
+    extensionVersion: extensionVersion(),
+    hostName: hostName(),
+    supportedCapabilities: SUPPORTED_CAPABILITIES,
+  });
+  const timestamp = now();
+  return {
+    apiBaseUrl: bases.apiBaseUrl,
+    appBaseUrl: bases.appBaseUrl,
+    browser,
+    deviceCode: response.deviceCode,
+    expiresAt: timestamp + response.expiresIn * 1000,
+    hostName: hostName(),
+    intervalMs: response.interval * 1000,
+    nextPollAt: timestamp,
+    pollToken: response.pollToken,
+    userCode: response.userCode,
+  };
+}
+
+async function continuePairing(state: ExtensionState): Promise<ExtensionState> {
+  const pairing = state.pairing;
+  if (!pairing) {
+    return state;
+  }
+
+  const timestamp = now();
+  if (timestamp >= pairing.expiresAt) {
+    const nextState = {
+      ...state,
+      lastError: "Local browser pairing expired",
+      lastStatusAt: timestamp,
+      pairing: undefined,
+    };
+    await saveExtensionState(nextState);
+    await updateBadge(nextState);
+    return nextState;
+  }
+  if (timestamp < pairing.nextPollAt) {
+    return state;
+  }
+
+  const response = await pollDevicePairing({
+    apiBaseUrl: pairing.apiBaseUrl,
+    deviceCode: pairing.deviceCode,
+    pollToken: pairing.pollToken,
+  });
+
+  if (response.status === "pending") {
+    const nextState = {
+      ...state,
+      pairing: {
+        ...pairing,
+        nextPollAt: timestamp + pairing.intervalMs,
+      },
+    };
+    await saveExtensionState(nextState);
+    await updateBadge(nextState);
+    return nextState;
+  }
+
+  if (response.status === "expired" || !response.hostToken) {
+    const nextState = {
+      ...state,
+      lastError: "Local browser pairing expired",
+      lastStatusAt: timestamp,
+      pairing: undefined,
+    };
+    await saveExtensionState(nextState);
+    await updateBadge(nextState);
+    return nextState;
+  }
+
+  const host: LinkedHostState = {
+    apiBaseUrl: pairing.apiBaseUrl,
+    appBaseUrl: pairing.appBaseUrl,
+    browser: pairing.browser,
+    extensionVersion: extensionVersion(),
+    hostId: response.hostId,
+    hostName: pairing.hostName,
+    hostToken: response.hostToken,
+    linkedAt: timestamp,
+    supportedCapabilities: SUPPORTED_CAPABILITIES,
+  };
+  const nextState = {
+    ...state,
+    host,
+    lastError: undefined,
+    lastStatusAt: timestamp,
+    pairing: undefined,
+    paused: false,
+  };
+  await saveExtensionState(nextState);
+  await updateBadge(nextState);
+  return nextState;
+}
+
+async function heartbeatIfNeeded(
+  state: ExtensionState,
+): Promise<ExtensionState> {
+  const host = state.host;
+  if (!host) {
+    return state;
+  }
+  const timestamp = now();
+  if (
+    host.lastHeartbeatAt &&
+    timestamp - host.lastHeartbeatAt < HEARTBEAT_INTERVAL_MS
+  ) {
+    return state;
+  }
+
+  const response = await heartbeatHost({
+    apiBaseUrl: host.apiBaseUrl,
+    browser: host.browser,
+    extensionVersion: extensionVersion(),
+    hostName: host.hostName,
+    hostToken: host.hostToken,
+    supportedCapabilities: SUPPORTED_CAPABILITIES,
+  });
+  const nextHost = {
+    ...host,
+    hostId: response.hostId,
+    lastHeartbeatAt: timestamp,
+    supportedCapabilities: SUPPORTED_CAPABILITIES,
+  };
+  const nextState = {
+    ...state,
+    host: nextHost,
+    lastError: undefined,
+    lastStatusAt: timestamp,
+  };
+  await saveExtensionState(nextState);
+  await updateBadge(nextState);
+  return nextState;
+}
+
+function completionBodyFromResult(result: LocalBrowserCommandResult) {
+  return {
+    result,
+    status: "succeeded" as const,
+  };
+}
+
+function completionBodyFromError(error: LocalBrowserCommandError) {
+  return {
+    error,
+    status: "failed" as const,
+  };
+}
+
+async function completeClaimedCommand(
+  host: LinkedHostState,
+  commandId: string,
+  body:
+    | ReturnType<typeof completionBodyFromResult>
+    | ReturnType<typeof completionBodyFromError>,
+): Promise<void> {
+  await completeCommand({
+    apiBaseUrl: host.apiBaseUrl,
+    body,
+    commandId,
+    hostToken: host.hostToken,
+  });
+}
+
+async function drainCommands(state: ExtensionState): Promise<ExtensionState> {
+  const host = state.host;
+  if (!host || state.paused) {
+    return state;
+  }
+
+  const timestamp = now();
+  if (timestamp - lastCommandPollAt < COMMAND_POLL_INTERVAL_MS) {
+    return state;
+  }
+  if (commandLoopRunning) {
+    return state;
+  }
+
+  commandLoopRunning = true;
+  lastCommandPollAt = timestamp;
+  let lastCommandAt = host.lastCommandAt;
+  try {
+    for (let i = 0; i < MAX_COMMANDS_PER_TICK; i += 1) {
+      const next = await claimNextCommand({
+        apiBaseUrl: host.apiBaseUrl,
+        hostToken: host.hostToken,
+        supportedCapabilities: SUPPORTED_CAPABILITIES,
+      });
+      if (next.status === "idle") {
+        break;
+      }
+
+      let body:
+        | ReturnType<typeof completionBodyFromResult>
+        | ReturnType<typeof completionBodyFromError>;
+      try {
+        const result = await withTimeout(
+          executeLocalBrowserCommand(next.command),
+          next.command.timeoutMs ?? DEFAULT_COMMAND_TIMEOUT_MS,
+        );
+        body = completionBodyFromResult(result);
+      } catch (error) {
+        body = completionBodyFromError(commandErrorFromUnknown(error));
+      }
+      await completeClaimedCommand(host, next.command.id, body);
+      lastCommandAt = now();
+    }
+  } finally {
+    commandLoopRunning = false;
+  }
+
+  if (lastCommandAt === host.lastCommandAt) {
+    return state;
+  }
+
+  const nextState = {
+    ...state,
+    host: {
+      ...host,
+      lastCommandAt,
+    },
+    lastStatusAt: now(),
+  };
+  await saveExtensionState(nextState);
+  await updateBadge(nextState);
+  return nextState;
+}
+
+async function runtimeTick(): Promise<void> {
+  try {
+    let state = await loadExtensionState();
+    state = await continuePairing(state);
+    if (!state.paused) {
+      state = await heartbeatIfNeeded(state);
+      await drainCommands(state);
+    }
+  } catch (error) {
+    await saveError(toErrorMessage(error));
+  }
+}
+
+export async function initializeRuntime(): Promise<void> {
+  await chrome.alarms.create(TICK_ALARM, {
+    delayInMinutes: 0.05,
+    periodInMinutes: 0.5,
+  });
+  await updateBadge(await loadExtensionState());
+  await runtimeTick();
+}
+
+export function handleAlarm(alarm: ChromeAlarm): void {
+  if (alarm.name === TICK_ALARM) {
+    void runtimeTick();
+  }
+}
+
+export async function detectExtension(): Promise<BridgeBackgroundResponse> {
+  return {
+    browser: browserName(),
+    extensionVersion: extensionVersion(),
+    ok: true,
+    type: "detected",
+  };
+}
+
+export async function startPairing(
+  pageUrl: string,
+): Promise<BridgeBackgroundResponse> {
+  const pairing = await createPairingState(pageUrl);
+  const state = await patchExtensionState({
+    host: undefined,
+    lastError: undefined,
+    lastStatusAt: now(),
+    pairing,
+  });
+  await updateBadge(state);
+  void runtimeTick();
+  return {
+    deviceCode: pairing.deviceCode,
+    ok: true,
+    type: "pairingStarted",
+    userCode: pairing.userCode,
+  };
+}
+
+export async function extensionStatus(): Promise<BridgeBackgroundResponse> {
+  const state = await loadExtensionState();
+  return {
+    ok: true,
+    status: statusFromState(state),
+    type: "status",
+  };
+}
+
+export async function revokeHost(): Promise<BridgeBackgroundResponse> {
+  const state = await loadExtensionState();
+  if (state.host) {
+    await revokeCurrentHost({
+      apiBaseUrl: state.host.apiBaseUrl,
+      hostToken: state.host.hostToken,
+    });
+  }
+  await clearExtensionState();
+  await updateBadge({});
+  return { ok: true, type: "done" };
+}
+
+export async function openConnectorPage(): Promise<BridgeBackgroundResponse> {
+  const state = await loadExtensionState();
+  const appBaseUrl =
+    state.host?.appBaseUrl ?? state.pairing?.appBaseUrl ?? "https://app.vm0.ai";
+  await chrome.tabs.create({
+    url: `${appBaseUrl}/zero/connectors/local-browser`,
+  });
+  return { ok: true, type: "done" };
+}

--- a/turbo/apps/local-browser-extension/src/content/index.ts
+++ b/turbo/apps/local-browser-extension/src/content/index.ts
@@ -1,0 +1,86 @@
+import {
+  LOCAL_BROWSER_EXTENSION_MESSAGE_SOURCE,
+  isBridgeRequest,
+  messageFromBridgeRequest,
+  type BridgeBackgroundResponse,
+} from "../shared/protocol";
+
+function responseType(response: BridgeBackgroundResponse): string {
+  if (!response.ok) {
+    return "vm0.localBrowser.error";
+  }
+  if (response.type === "detected") {
+    return "vm0.localBrowser.detected";
+  }
+  if (response.type === "pairingStarted") {
+    return "vm0.localBrowser.pairingStarted";
+  }
+  return "vm0.localBrowser.error";
+}
+
+function postBridgeResponse(
+  requestId: string,
+  response: BridgeBackgroundResponse,
+): void {
+  window.postMessage(
+    {
+      source: LOCAL_BROWSER_EXTENSION_MESSAGE_SOURCE,
+      type: responseType(response),
+      requestId,
+      ...(response.ok && response.type === "detected"
+        ? {
+            browser: response.browser,
+            extensionVersion: response.extensionVersion,
+          }
+        : {}),
+      ...(response.ok && response.type === "pairingStarted"
+        ? {
+            deviceCode: response.deviceCode,
+            userCode: response.userCode,
+          }
+        : {}),
+      ...(!response.ok ? { message: response.message } : {}),
+    },
+    window.location.origin,
+  );
+}
+
+async function sendToBackground(
+  message: ReturnType<typeof messageFromBridgeRequest>,
+): Promise<BridgeBackgroundResponse> {
+  const response = await chrome.runtime.sendMessage(message);
+  if (typeof response === "object" && response !== null && "ok" in response) {
+    return response as BridgeBackgroundResponse;
+  }
+  return {
+    message: "Local browser extension returned an invalid response",
+    ok: false,
+  };
+}
+
+window.addEventListener("message", (event: MessageEvent<unknown>) => {
+  if (event.source && event.source !== window) {
+    return;
+  }
+  if (event.origin && event.origin !== window.location.origin) {
+    return;
+  }
+  if (!isBridgeRequest(event.data)) {
+    return;
+  }
+
+  const request = event.data;
+  void sendToBackground(messageFromBridgeRequest(request, window.location.href))
+    .then((response) => {
+      postBridgeResponse(request.requestId, response);
+    })
+    .catch((error: unknown) => {
+      postBridgeResponse(request.requestId, {
+        message:
+          error instanceof Error
+            ? error.message
+            : "Local browser extension failed",
+        ok: false,
+      });
+    });
+});

--- a/turbo/apps/local-browser-extension/src/content/index.ts
+++ b/turbo/apps/local-browser-extension/src/content/index.ts
@@ -58,7 +58,7 @@ async function sendToBackground(
   };
 }
 
-window.addEventListener("message", (event: MessageEvent<unknown>) => {
+function handleWindowMessage(event: MessageEvent<unknown>): void {
   if (event.source !== window) {
     return;
   }
@@ -83,4 +83,6 @@ window.addEventListener("message", (event: MessageEvent<unknown>) => {
         ok: false,
       });
     });
-});
+}
+
+window.addEventListener("message", handleWindowMessage);

--- a/turbo/apps/local-browser-extension/src/content/index.ts
+++ b/turbo/apps/local-browser-extension/src/content/index.ts
@@ -59,10 +59,10 @@ async function sendToBackground(
 }
 
 window.addEventListener("message", (event: MessageEvent<unknown>) => {
-  if (event.source && event.source !== window) {
+  if (event.source !== window) {
     return;
   }
-  if (event.origin && event.origin !== window.location.origin) {
+  if (event.origin !== window.location.origin) {
     return;
   }
   if (!isBridgeRequest(event.data)) {

--- a/turbo/apps/local-browser-extension/src/popup/index.ts
+++ b/turbo/apps/local-browser-extension/src/popup/index.ts
@@ -1,0 +1,112 @@
+import type {
+  BridgeBackgroundMessage,
+  BridgeBackgroundResponse,
+  ExtensionStatus,
+} from "../shared/protocol";
+
+function getElement(id: string): HTMLElement {
+  const element = document.getElementById(id);
+  if (!element) {
+    throw new Error(`Missing popup element: ${id}`);
+  }
+  return element;
+}
+
+function getButton(id: string): HTMLButtonElement {
+  const element = getElement(id);
+  if (!(element instanceof HTMLButtonElement)) {
+    throw new Error(`Popup element is not a button: ${id}`);
+  }
+  return element;
+}
+
+async function sendMessage(
+  message: BridgeBackgroundMessage,
+): Promise<BridgeBackgroundResponse> {
+  const response = await chrome.runtime.sendMessage(message);
+  if (typeof response === "object" && response !== null && "ok" in response) {
+    return response as BridgeBackgroundResponse;
+  }
+  return {
+    message: "Extension runtime returned an invalid response",
+    ok: false,
+  };
+}
+
+function formatDate(value: number | undefined): string {
+  if (!value) {
+    return "-";
+  }
+  return new Intl.DateTimeFormat(undefined, {
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  }).format(new Date(value));
+}
+
+function renderStatus(status: ExtensionStatus): void {
+  const subtitle = getElement("subtitle");
+  const dot = getElement("status-dot");
+  const hostName = getElement("host-name");
+  const apiBase = getElement("api-base");
+  const heartbeat = getElement("heartbeat");
+  const errorRow = getElement("error-row");
+  const lastError = getElement("last-error");
+  const revoke = getButton("revoke");
+
+  dot.className = "dot";
+  if (status.linked) {
+    dot.classList.add("online");
+    subtitle.textContent = status.paused ? "Connected, paused" : "Connected";
+  } else if (status.paired) {
+    dot.classList.add("pending");
+    subtitle.textContent = "Pairing in progress";
+  } else {
+    subtitle.textContent = "Not paired";
+  }
+
+  hostName.textContent = status.hostName ?? "Not paired";
+  apiBase.textContent = status.apiBaseUrl ?? "-";
+  heartbeat.textContent = formatDate(status.lastHeartbeatAt);
+  revoke.disabled = !status.linked && !status.paired;
+
+  if (status.lastError) {
+    errorRow.hidden = false;
+    lastError.textContent = status.lastError;
+  } else {
+    errorRow.hidden = true;
+    lastError.textContent = "-";
+  }
+}
+
+async function refresh(): Promise<void> {
+  const response = await sendMessage({ type: "localBrowser.getStatus" });
+  if (!response.ok || response.type !== "status") {
+    throw new Error(
+      response.ok ? "Unexpected status response" : response.message,
+    );
+  }
+  renderStatus(response.status);
+}
+
+function bindActions(): void {
+  getButton("open-connectors").addEventListener("click", () => {
+    void sendMessage({ type: "localBrowser.openConnectorPage" });
+  });
+  getButton("revoke").addEventListener("click", async () => {
+    const revoke = getButton("revoke");
+    revoke.disabled = true;
+    await sendMessage({ type: "localBrowser.revokeHost" });
+    await refresh();
+  });
+}
+
+bindActions();
+void refresh().catch((error: unknown) => {
+  renderStatus({
+    lastError: error instanceof Error ? error.message : "Failed to load status",
+    linked: false,
+    paired: false,
+    paused: false,
+  });
+});

--- a/turbo/apps/local-browser-extension/src/popup/popup.css
+++ b/turbo/apps/local-browser-extension/src/popup/popup.css
@@ -1,0 +1,157 @@
+:root {
+  color-scheme: light dark;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+}
+
+body {
+  background: #f8fafc;
+  color: #111827;
+  margin: 0;
+  min-width: 320px;
+}
+
+.shell {
+  display: grid;
+  gap: 16px;
+  padding: 16px;
+}
+
+.header {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+}
+
+h1 {
+  font-size: 16px;
+  line-height: 1.25;
+  margin: 0;
+}
+
+p {
+  color: #4b5563;
+  font-size: 12px;
+  line-height: 1.4;
+  margin: 4px 0 0;
+}
+
+.dot {
+  background: #9ca3af;
+  border-radius: 999px;
+  display: block;
+  height: 10px;
+  width: 10px;
+}
+
+.dot.online {
+  background: #16a34a;
+}
+
+.dot.pending {
+  background: #ca8a04;
+}
+
+.details {
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  display: grid;
+  overflow: hidden;
+}
+
+.details > div {
+  background: #ffffff;
+  display: grid;
+  gap: 2px;
+  padding: 10px 12px;
+}
+
+.details > div + div {
+  border-top: 1px solid #e5e7eb;
+}
+
+.label {
+  color: #6b7280;
+  font-size: 11px;
+  line-height: 1.2;
+  text-transform: uppercase;
+}
+
+strong {
+  font-size: 13px;
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+}
+
+.error-row strong {
+  color: #b91c1c;
+}
+
+.actions {
+  display: grid;
+  gap: 8px;
+  grid-template-columns: 1fr 1fr;
+}
+
+button {
+  background: #111827;
+  border: 1px solid #111827;
+  border-radius: 6px;
+  color: #ffffff;
+  cursor: pointer;
+  font: inherit;
+  font-size: 13px;
+  min-height: 36px;
+  padding: 8px 10px;
+}
+
+button.secondary {
+  background: #ffffff;
+  color: #111827;
+}
+
+button:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+@media (prefers-color-scheme: dark) {
+  body {
+    background: #030712;
+    color: #f9fafb;
+  }
+
+  p,
+  .label {
+    color: #9ca3af;
+  }
+
+  .details {
+    border-color: #1f2937;
+  }
+
+  .details > div {
+    background: #111827;
+  }
+
+  .details > div + div {
+    border-top-color: #1f2937;
+  }
+
+  button {
+    background: #f9fafb;
+    border-color: #f9fafb;
+    color: #111827;
+  }
+
+  button.secondary {
+    background: #111827;
+    color: #f9fafb;
+  }
+}

--- a/turbo/apps/local-browser-extension/src/popup/popup.html
+++ b/turbo/apps/local-browser-extension/src/popup/popup.html
@@ -1,0 +1,45 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="./popup.css" />
+    <title>VM0 Local Browser</title>
+  </head>
+  <body>
+    <main class="shell">
+      <header class="header">
+        <div>
+          <h1>VM0 Local Browser</h1>
+          <p id="subtitle">Checking status...</p>
+        </div>
+        <span id="status-dot" class="dot"></span>
+      </header>
+
+      <section class="details">
+        <div>
+          <span class="label">Host</span>
+          <strong id="host-name">Not paired</strong>
+        </div>
+        <div>
+          <span class="label">API</span>
+          <strong id="api-base">-</strong>
+        </div>
+        <div>
+          <span class="label">Last heartbeat</span>
+          <strong id="heartbeat">-</strong>
+        </div>
+        <div id="error-row" class="error-row" hidden>
+          <span class="label">Error</span>
+          <strong id="last-error">-</strong>
+        </div>
+      </section>
+
+      <div class="actions">
+        <button id="open-connectors" type="button">Open connector</button>
+        <button id="revoke" class="secondary" type="button">Revoke</button>
+      </div>
+    </main>
+    <script src="./popup.js"></script>
+  </body>
+</html>

--- a/turbo/apps/local-browser-extension/src/shared/api.ts
+++ b/turbo/apps/local-browser-extension/src/shared/api.ts
@@ -1,0 +1,206 @@
+import type {
+  DevicePollResponse,
+  DeviceStartResponse,
+  LocalBrowserCommandCompleteBody,
+  LocalBrowserHostCommandNextResponse,
+} from "./protocol";
+
+class LocalBrowserApiError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+    readonly code?: string,
+  ) {
+    super(message);
+    this.name = "LocalBrowserApiError";
+  }
+}
+
+type JsonRecord = Record<string, unknown>;
+
+function normalizeApiBaseUrl(apiBaseUrl: string): string {
+  return apiBaseUrl.endsWith("/") ? apiBaseUrl.slice(0, -1) : apiBaseUrl;
+}
+
+function isErrorBody(value: unknown): value is {
+  readonly error?: { readonly message?: string; readonly code?: string };
+} {
+  return typeof value === "object" && value !== null;
+}
+
+async function readJson(response: Response): Promise<unknown> {
+  const text = await response.text();
+  if (!text) {
+    return {};
+  }
+  return JSON.parse(text);
+}
+
+async function apiJson<T>(
+  apiBaseUrl: string,
+  path: string,
+  options: {
+    readonly method: "DELETE" | "GET" | "POST";
+    readonly body?: JsonRecord;
+    readonly hostToken?: string;
+    readonly signal?: AbortSignal;
+  },
+): Promise<T> {
+  const headers: Record<string, string> = {
+    Accept: "application/json",
+  };
+  if (options.body) {
+    headers["Content-Type"] = "application/json";
+  }
+  if (options.hostToken) {
+    headers.Authorization = `Bearer ${options.hostToken}`;
+  }
+
+  const response = await fetch(`${normalizeApiBaseUrl(apiBaseUrl)}${path}`, {
+    body: options.body ? JSON.stringify(options.body) : undefined,
+    credentials: "omit",
+    headers,
+    method: options.method,
+    signal: options.signal,
+  });
+  const json = await readJson(response);
+  if (!response.ok) {
+    const message =
+      isErrorBody(json) && json.error?.message
+        ? json.error.message
+        : `VM0 API request failed with ${response.status}`;
+    throw new LocalBrowserApiError(
+      message,
+      response.status,
+      isErrorBody(json) ? json.error?.code : undefined,
+    );
+  }
+  return json as T;
+}
+
+export async function startDevicePairing(params: {
+  readonly apiBaseUrl: string;
+  readonly hostName: string;
+  readonly browser: string;
+  readonly extensionVersion: string;
+  readonly supportedCapabilities: readonly string[];
+  readonly signal?: AbortSignal;
+}): Promise<DeviceStartResponse> {
+  return await apiJson<DeviceStartResponse>(
+    params.apiBaseUrl,
+    "/api/zero/local-browser/device/start",
+    {
+      body: {
+        browser: params.browser,
+        extensionVersion: params.extensionVersion,
+        hostName: params.hostName,
+        supportedCapabilities: [...params.supportedCapabilities],
+      },
+      method: "POST",
+      signal: params.signal,
+    },
+  );
+}
+
+export async function pollDevicePairing(params: {
+  readonly apiBaseUrl: string;
+  readonly deviceCode: string;
+  readonly pollToken: string;
+  readonly signal?: AbortSignal;
+}): Promise<DevicePollResponse> {
+  return await apiJson<DevicePollResponse>(
+    params.apiBaseUrl,
+    "/api/zero/local-browser/device/poll",
+    {
+      body: {
+        deviceCode: params.deviceCode,
+        pollToken: params.pollToken,
+      },
+      method: "POST",
+      signal: params.signal,
+    },
+  );
+}
+
+export async function heartbeatHost(params: {
+  readonly apiBaseUrl: string;
+  readonly hostToken: string;
+  readonly hostName: string;
+  readonly browser: string;
+  readonly extensionVersion: string;
+  readonly supportedCapabilities: readonly string[];
+  readonly signal?: AbortSignal;
+}): Promise<{ readonly ok: true; readonly hostId: string }> {
+  return await apiJson<{ readonly ok: true; readonly hostId: string }>(
+    params.apiBaseUrl,
+    "/api/zero/local-browser/heartbeat",
+    {
+      body: {
+        browser: params.browser,
+        extensionVersion: params.extensionVersion,
+        hostName: params.hostName,
+        supportedCapabilities: [...params.supportedCapabilities],
+      },
+      hostToken: params.hostToken,
+      method: "POST",
+      signal: params.signal,
+    },
+  );
+}
+
+export async function claimNextCommand(params: {
+  readonly apiBaseUrl: string;
+  readonly hostToken: string;
+  readonly supportedCapabilities: readonly string[];
+  readonly signal?: AbortSignal;
+}): Promise<LocalBrowserHostCommandNextResponse> {
+  return await apiJson<LocalBrowserHostCommandNextResponse>(
+    params.apiBaseUrl,
+    "/api/zero/local-browser/host/commands/next",
+    {
+      body: {
+        supportedCapabilities: [...params.supportedCapabilities],
+      },
+      hostToken: params.hostToken,
+      method: "POST",
+      signal: params.signal,
+    },
+  );
+}
+
+export async function completeCommand(params: {
+  readonly apiBaseUrl: string;
+  readonly hostToken: string;
+  readonly commandId: string;
+  readonly body: LocalBrowserCommandCompleteBody;
+  readonly signal?: AbortSignal;
+}): Promise<{ readonly ok: true }> {
+  return await apiJson<{ readonly ok: true }>(
+    params.apiBaseUrl,
+    `/api/zero/local-browser/host/commands/${encodeURIComponent(
+      params.commandId,
+    )}/complete`,
+    {
+      body: params.body,
+      hostToken: params.hostToken,
+      method: "POST",
+      signal: params.signal,
+    },
+  );
+}
+
+export async function revokeCurrentHost(params: {
+  readonly apiBaseUrl: string;
+  readonly hostToken: string;
+  readonly signal?: AbortSignal;
+}): Promise<{ readonly ok: true }> {
+  return await apiJson<{ readonly ok: true }>(
+    params.apiBaseUrl,
+    "/api/zero/local-browser/host",
+    {
+      hostToken: params.hostToken,
+      method: "DELETE",
+      signal: params.signal,
+    },
+  );
+}

--- a/turbo/apps/local-browser-extension/src/shared/protocol.ts
+++ b/turbo/apps/local-browser-extension/src/shared/protocol.ts
@@ -1,0 +1,207 @@
+import type {
+  LocalBrowserCommandError,
+  LocalBrowserCommandKind,
+  LocalBrowserCommandResult,
+} from "@vm0/api-contracts/contracts/zero-local-browser";
+
+const LOCAL_BROWSER_WEB_MESSAGE_SOURCE = "vm0-local-browser-web";
+export const LOCAL_BROWSER_EXTENSION_MESSAGE_SOURCE =
+  "vm0-local-browser-extension";
+
+export const SUPPORTED_CAPABILITIES = [
+  "tabs.list",
+  "tabs.current",
+  "page.snapshot",
+  "page.screenshot",
+  "page.selection",
+  "page.metadata",
+  "page.click",
+  "page.type",
+  "page.scroll",
+  "page.navigate",
+  "tabs.activate",
+  "tabs.open",
+  "tabs.close",
+] as const satisfies readonly LocalBrowserCommandKind[];
+
+export interface LocalBrowserCommandPayload {
+  readonly tabId?: string;
+  readonly selector?: string;
+  readonly x?: number;
+  readonly y?: number;
+  readonly text?: string;
+  readonly direction?: "up" | "down";
+  readonly amount?: number;
+  readonly url?: string;
+}
+
+export interface LocalBrowserHostCommand {
+  readonly id: string;
+  readonly kind: LocalBrowserCommandKind;
+  readonly payload: LocalBrowserCommandPayload;
+  readonly timeoutMs: number | null;
+}
+
+export type LocalBrowserHostCommandNextResponse =
+  | { readonly status: "idle" }
+  | {
+      readonly status: "command";
+      readonly command: LocalBrowserHostCommand;
+    };
+
+export type LocalBrowserCommandCompleteBody =
+  | {
+      readonly status: "succeeded";
+      readonly result: LocalBrowserCommandResult;
+    }
+  | {
+      readonly status: "failed";
+      readonly error: LocalBrowserCommandError;
+    };
+
+type BridgeRequestType = "detect" | "pair";
+
+interface BridgeRequest {
+  readonly source: typeof LOCAL_BROWSER_WEB_MESSAGE_SOURCE;
+  readonly type: `vm0.localBrowser.${BridgeRequestType}`;
+  readonly requestId: string;
+}
+
+export type BridgeBackgroundMessage =
+  | {
+      readonly type: "localBrowser.detect";
+      readonly pageUrl: string;
+    }
+  | {
+      readonly type: "localBrowser.pair";
+      readonly pageUrl: string;
+    }
+  | { readonly type: "localBrowser.getStatus" }
+  | { readonly type: "localBrowser.revokeHost" }
+  | { readonly type: "localBrowser.openConnectorPage" };
+
+export type BridgeBackgroundResponse =
+  | {
+      readonly ok: true;
+      readonly type: "detected";
+      readonly browser: string;
+      readonly extensionVersion: string;
+    }
+  | {
+      readonly ok: true;
+      readonly type: "pairingStarted";
+      readonly deviceCode: string;
+      readonly userCode: string;
+    }
+  | {
+      readonly ok: true;
+      readonly type: "status";
+      readonly status: ExtensionStatus;
+    }
+  | { readonly ok: true; readonly type: "done" }
+  | { readonly ok: false; readonly message: string };
+
+export interface DeviceStartResponse {
+  readonly deviceCode: string;
+  readonly userCode: string;
+  readonly expiresIn: number;
+  readonly interval: number;
+  readonly pollToken: string;
+}
+
+export type DevicePollResponse =
+  | { readonly status: "pending" }
+  | {
+      readonly status: "linked";
+      readonly hostId: string;
+      readonly hostToken?: string;
+    }
+  | { readonly status: "expired" };
+
+export interface LinkedHostState {
+  readonly apiBaseUrl: string;
+  readonly appBaseUrl: string;
+  readonly hostId: string;
+  readonly hostToken: string;
+  readonly hostName: string;
+  readonly browser: string;
+  readonly extensionVersion: string;
+  readonly supportedCapabilities: readonly string[];
+  readonly linkedAt: number;
+  readonly lastHeartbeatAt?: number;
+  readonly lastCommandAt?: number;
+}
+
+export interface PairingState {
+  readonly apiBaseUrl: string;
+  readonly appBaseUrl: string;
+  readonly deviceCode: string;
+  readonly userCode: string;
+  readonly pollToken: string;
+  readonly expiresAt: number;
+  readonly intervalMs: number;
+  readonly nextPollAt: number;
+  readonly hostName: string;
+  readonly browser: string;
+}
+
+export interface ExtensionState {
+  readonly host?: LinkedHostState;
+  readonly pairing?: PairingState;
+  readonly paused?: boolean;
+  readonly lastError?: string;
+  readonly lastStatusAt?: number;
+}
+
+export interface ExtensionStatus {
+  readonly linked: boolean;
+  readonly paired: boolean;
+  readonly paused: boolean;
+  readonly hostId?: string;
+  readonly hostName?: string;
+  readonly browser?: string;
+  readonly apiBaseUrl?: string;
+  readonly appBaseUrl?: string;
+  readonly lastHeartbeatAt?: number;
+  readonly lastCommandAt?: number;
+  readonly lastError?: string;
+}
+
+export function isBridgeRequest(value: unknown): value is BridgeRequest {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const record = value as Record<string, unknown>;
+  return (
+    record.source === LOCAL_BROWSER_WEB_MESSAGE_SOURCE &&
+    typeof record.requestId === "string" &&
+    (record.type === "vm0.localBrowser.detect" ||
+      record.type === "vm0.localBrowser.pair")
+  );
+}
+
+export function messageFromBridgeRequest(
+  request: BridgeRequest,
+  pageUrl: string,
+): BridgeBackgroundMessage {
+  if (request.type === "vm0.localBrowser.detect") {
+    return { type: "localBrowser.detect", pageUrl };
+  }
+  return { type: "localBrowser.pair", pageUrl };
+}
+
+export function statusFromState(state: ExtensionState): ExtensionStatus {
+  return {
+    linked: !!state.host,
+    paired: !!state.host || !!state.pairing,
+    paused: !!state.paused,
+    hostId: state.host?.hostId,
+    hostName: state.host?.hostName ?? state.pairing?.hostName,
+    browser: state.host?.browser ?? state.pairing?.browser,
+    apiBaseUrl: state.host?.apiBaseUrl ?? state.pairing?.apiBaseUrl,
+    appBaseUrl: state.host?.appBaseUrl ?? state.pairing?.appBaseUrl,
+    lastHeartbeatAt: state.host?.lastHeartbeatAt,
+    lastCommandAt: state.host?.lastCommandAt,
+    lastError: state.lastError,
+  };
+}

--- a/turbo/apps/local-browser-extension/src/shared/storage.ts
+++ b/turbo/apps/local-browser-extension/src/shared/storage.ts
@@ -1,0 +1,32 @@
+import type { ExtensionState } from "./protocol";
+
+const STORAGE_KEY = "vm0.localBrowser";
+
+function parseState(value: unknown): ExtensionState {
+  if (typeof value !== "object" || value === null) {
+    return {};
+  }
+  return value as ExtensionState;
+}
+
+export async function loadExtensionState(): Promise<ExtensionState> {
+  const values = await chrome.storage.local.get(STORAGE_KEY);
+  return parseState(values[STORAGE_KEY]);
+}
+
+export async function saveExtensionState(state: ExtensionState): Promise<void> {
+  await chrome.storage.local.set({ [STORAGE_KEY]: state });
+}
+
+export async function patchExtensionState(
+  patch: Partial<ExtensionState>,
+): Promise<ExtensionState> {
+  const current = await loadExtensionState();
+  const next = { ...current, ...patch };
+  await saveExtensionState(next);
+  return next;
+}
+
+export async function clearExtensionState(): Promise<void> {
+  await chrome.storage.local.remove(STORAGE_KEY);
+}

--- a/turbo/apps/local-browser-extension/src/types/chrome.d.ts
+++ b/turbo/apps/local-browser-extension/src/types/chrome.d.ts
@@ -1,0 +1,138 @@
+interface ChromeRuntimeManifest {
+  readonly version: string;
+}
+
+interface ChromeRuntimeMessageSender {
+  readonly tab?: ChromeTab;
+  readonly url?: string;
+}
+
+type ChromeMessageResponse = (response?: unknown) => void;
+
+interface ChromeRuntime {
+  readonly id: string;
+  readonly lastError?: { readonly message?: string };
+  getManifest(): ChromeRuntimeManifest;
+  getURL(path: string): string;
+  sendMessage(message: unknown): Promise<unknown>;
+  onMessage: {
+    addListener(
+      callback: (
+        message: unknown,
+        sender: ChromeRuntimeMessageSender,
+        sendResponse: ChromeMessageResponse,
+      ) => boolean | void,
+    ): void;
+  };
+  onInstalled: {
+    addListener(callback: () => void): void;
+  };
+  onStartup: {
+    addListener(callback: () => void): void;
+  };
+}
+
+interface ChromeStorageArea {
+  get(
+    keys?: string | string[] | Record<string, unknown>,
+  ): Promise<Record<string, unknown>>;
+  set(items: Record<string, unknown>): Promise<void>;
+  remove(keys: string | string[]): Promise<void>;
+}
+
+interface ChromeStorage {
+  readonly local: ChromeStorageArea;
+}
+
+interface ChromeTab {
+  readonly id?: number;
+  readonly windowId?: number;
+  readonly title?: string;
+  readonly url?: string;
+  readonly favIconUrl?: string;
+  readonly active?: boolean;
+}
+
+interface ChromeTabs {
+  query(queryInfo: {
+    readonly active?: boolean;
+    readonly currentWindow?: boolean;
+    readonly lastFocusedWindow?: boolean;
+  }): Promise<ChromeTab[]>;
+  get(tabId: number): Promise<ChromeTab>;
+  create(createProperties: { readonly url: string }): Promise<ChromeTab>;
+  update(
+    tabId: number,
+    updateProperties: {
+      readonly active?: boolean;
+      readonly url?: string;
+    },
+  ): Promise<ChromeTab>;
+  remove(tabId: number | number[]): Promise<void>;
+  captureVisibleTab(
+    windowId?: number,
+    options?: {
+      readonly format?: "jpeg" | "png";
+      readonly quality?: number;
+    },
+  ): Promise<string>;
+}
+
+interface ChromeWindows {
+  update(
+    windowId: number,
+    updateInfo: {
+      readonly focused?: boolean;
+    },
+  ): Promise<void>;
+}
+
+interface ChromeScriptingInjectionResult<T = unknown> {
+  readonly frameId: number;
+  readonly result?: T;
+}
+
+interface ChromeScripting {
+  executeScript<TArgs extends unknown[], TResult>(details: {
+    readonly target: { readonly tabId: number };
+    readonly func: (...args: TArgs) => TResult;
+    readonly args?: TArgs;
+  }): Promise<ChromeScriptingInjectionResult<Awaited<TResult>>[]>;
+}
+
+interface ChromeAlarm {
+  readonly name: string;
+}
+
+interface ChromeAlarms {
+  create(
+    name: string,
+    alarmInfo: {
+      readonly delayInMinutes?: number;
+      readonly periodInMinutes?: number;
+    },
+  ): Promise<void>;
+  clear(name: string): Promise<boolean>;
+  onAlarm: {
+    addListener(callback: (alarm: ChromeAlarm) => void): void;
+  };
+}
+
+interface ChromeAction {
+  setBadgeText(details: { readonly text: string }): Promise<void>;
+  setBadgeBackgroundColor(details: { readonly color: string }): Promise<void>;
+  setTitle(details: { readonly title: string }): Promise<void>;
+}
+
+interface ChromeApi {
+  readonly action?: ChromeAction;
+  readonly alarms: ChromeAlarms;
+  readonly runtime: ChromeRuntime;
+  readonly scripting: ChromeScripting;
+  readonly storage: ChromeStorage;
+  readonly tabs: ChromeTabs;
+  readonly windows: ChromeWindows;
+}
+
+declare const chrome: ChromeApi;
+declare const __EXTENSION_VERSION__: string;

--- a/turbo/apps/local-browser-extension/tsconfig.json
+++ b/turbo/apps/local-browser-extension/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "extends": "@vm0/typescript-config/base",
+  "compilerOptions": {
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "verbatimModuleSyntax": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "forceConsistentCasingInFileNames": true,
+    "noImplicitReturns": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -694,10 +694,10 @@ function sendLocalBrowserExtensionRequest(
   }
 
   function onMessage(event: MessageEvent<unknown>) {
-    if (event.source && event.source !== window) {
+    if (event.source !== window) {
       return;
     }
-    if (event.origin && event.origin !== window.location.origin) {
+    if (event.origin !== window.location.origin) {
       return;
     }
     const response = parseLocalBrowserExtensionResponse(event.data, requestId);

--- a/turbo/knip.json
+++ b/turbo/knip.json
@@ -82,6 +82,17 @@
       "ignoreDependencies": ["eslint", "oxlint", "wrangler"],
       "ignoreBinaries": ["eslint", "oxlint", "wrangler"]
     },
+    "apps/local-browser-extension": {
+      "entry": [
+        "scripts/build.mjs",
+        "src/background/index.ts",
+        "src/content/index.ts",
+        "src/popup/index.ts",
+        "src/popup/popup.css",
+        "src/popup/popup.html"
+      ],
+      "project": ["scripts/**/*.mjs", "src/**/*.{ts,css,html}"]
+    },
     "packages/core": {
       "entry": [
         "src/**/__tests__/**/*.{test,spec}.ts",

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -98,7 +98,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   apps/api:
     dependencies:
@@ -294,7 +294,7 @@ importers:
         version: 8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   apps/cli:
     dependencies:
@@ -376,7 +376,7 @@ importers:
         version: 6.24.1
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       yaml:
         specifier: '>=2.8.3'
         version: 2.8.3
@@ -404,6 +404,30 @@ importers:
       wrangler:
         specifier: ^4.90.1
         version: 4.91.0
+
+  apps/local-browser-extension:
+    devDependencies:
+      '@vm0/api-contracts':
+        specifier: workspace:*
+        version: link:../../packages/api-contracts
+      '@vm0/eslint-config':
+        specifier: workspace:*
+        version: link:../../packages/eslint-config
+      '@vm0/typescript-config':
+        specifier: workspace:*
+        version: link:../../packages/typescript-config
+      esbuild:
+        specifier: ^0.27.4
+        version: 0.27.4
+      eslint:
+        specifier: ^9.34.0
+        version: 9.39.4(jiti@2.6.1)
+      oxlint:
+        specifier: ^1.57.0
+        version: 1.57.0(oxlint-tsgolint@0.21.1)
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
 
   apps/platform:
     dependencies:
@@ -578,7 +602,7 @@ importers:
         version: 8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   apps/web:
     dependencies:
@@ -822,7 +846,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/api-contracts:
     dependencies:
@@ -862,7 +886,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/api-services:
     devDependencies:
@@ -886,7 +910,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/connectors:
     dependencies:
@@ -920,7 +944,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/core:
     dependencies:
@@ -954,7 +978,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/db:
     dependencies:
@@ -991,7 +1015,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/eslint-config:
     devDependencies:
@@ -1045,7 +1069,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       yaml:
         specifier: '>=2.8.3'
         version: 2.8.3
@@ -1155,7 +1179,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
 packages:
 
@@ -9555,6 +9579,7 @@ packages:
       '@vitest/ui': 4.1.5
       happy-dom: '*'
       jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true
@@ -14616,7 +14641,7 @@ snapshots:
       '@vitest/mocker': 4.1.5(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       playwright: 1.59.1
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -14630,7 +14655,7 @@ snapshots:
       '@vitest/mocker': 4.1.5(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       playwright: 1.59.1
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -14646,7 +14671,7 @@ snapshots:
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       ws: 8.20.0
     transitivePeerDependencies:
       - bufferutil
@@ -14664,7 +14689,7 @@ snapshots:
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       ws: 8.20.0
     transitivePeerDependencies:
       - bufferutil
@@ -14684,7 +14709,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
     optionalDependencies:
       '@vitest/browser': 4.1.5(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.5)
 
@@ -14742,7 +14767,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   '@vitest/utils@4.1.5':
     dependencies:
@@ -19046,7 +19071,7 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
-  vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3):
+  vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.5
       '@vitest/mocker': 4.1.5(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
@@ -19076,18 +19101,39 @@ snapshots:
       '@vitest/ui': 4.1.5(vitest@4.1.5)
       happy-dom: 20.9.0
     transitivePeerDependencies:
-      - '@vitejs/devtools'
-      - esbuild
-      - jiti
-      - less
       - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - terser
-      - tsx
-      - yaml
+
+  vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)):
+    dependencies:
+      '@vitest/expect': 4.1.5
+      '@vitest/mocker': 4.1.5(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/pretty-format': 4.1.5
+      '@vitest/runner': 4.1.5
+      '@vitest/snapshot': 4.1.5
+      '@vitest/spy': 4.1.5
+      '@vitest/utils': 4.1.5
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.1
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@types/node': 24.3.0
+      '@vitest/browser-playwright': 4.1.5(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(playwright@1.59.1)(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.5)
+      '@vitest/coverage-v8': 4.1.5(@vitest/browser@4.1.5)(vitest@4.1.5)
+      '@vitest/ui': 4.1.5(vitest@4.1.5)
+      happy-dom: 20.9.0
+    transitivePeerDependencies:
+      - msw
 
   vscode-languageserver-textdocument@1.0.12: {}
 


### PR DESCRIPTION
## Summary
- add a new `@vm0/local-browser-extension` MV3 app under `turbo/apps`
- bridge the platform connector modal to the extension through a content script
- implement extension pairing, host token persistence, heartbeat, command polling, command execution, completion, revoke, and popup status UI
- register extension entrypoints in knip so repository checks understand the MV3 build layout

## Verification
- `pnpm -F @vm0/local-browser-extension check-types`
- `pnpm -F @vm0/local-browser-extension lint`
- `pnpm -F @vm0/local-browser-extension build`
- pre-commit: `pnpm knip --cache`
- pre-commit: `pnpm check-types`

## Issues
- Updates #13234
