### PR TITLE
fix(ably-subscriber): avoid overflowing channel deadlines

### DIFF
--- a/crates/ably-subscriber/src/connection.rs
+++ b/crates/ably-subscriber/src/connection.rs
@@ -659,7 +659,8 @@ fn retry_delay(initial_timeout: Duration, retry_attempt: u32) -> Duration {
         .unwrap_or_default()
         .subsec_nanos() as u128;
     let jitter_per_mille = 800 + (nanos % 200);
-    Duration::from_millis(upper_ms.saturating_mul(jitter_per_mille) as u64 / 1000)
+    let jittered_ms = upper_ms.saturating_mul(jitter_per_mille) / 1000;
+    Duration::from_millis(u64::try_from(jittered_ms).unwrap_or(u64::MAX))
 }
 
 async fn sleep_until_optional(deadline: Option<Instant>) {
@@ -691,7 +692,7 @@ fn request_channel_attach(p: &mut EventLoopState) -> bool {
     }
 
     p.channel_retry_at = None;
-    p.channel_operation_deadline = Some(Instant::now() + p.timing.realtime_request_timeout);
+    p.channel_operation_deadline = checked_deadline_after(p.timing.realtime_request_timeout);
     true
 }
 
@@ -701,9 +702,10 @@ fn schedule_channel_retry(p: &mut EventLoopState) {
         && p.lifecycle.connection.send_events()
     {
         p.channel_retry_count += 1;
-        p.channel_retry_at = Some(
-            Instant::now() + retry_delay(p.timing.channel_retry_timeout, p.channel_retry_count),
-        );
+        p.channel_retry_at = checked_deadline_after(retry_delay(
+            p.timing.channel_retry_timeout,
+            p.channel_retry_count,
+        ));
     } else {
         p.channel_retry_at = None;
     }
@@ -1889,6 +1891,13 @@ mod tests {
         let _ = idle_deadline(state.max_idle_interval, Duration::from_secs(10));
         let _ = checked_deadline_from(Instant::now(), state.connection_state_ttl);
         let _ = state.token_renewal_at;
+    }
+
+    #[test]
+    fn retry_delay_saturates_huge_timeout_without_truncating() {
+        let delay = retry_delay(Duration::MAX, 1);
+
+        assert_eq!(delay, Duration::from_millis(u64::MAX));
     }
 
     #[test]

--- a/crates/ably-subscriber/tests/integration.rs
+++ b/crates/ably-subscriber/tests/integration.rs
@@ -1571,6 +1571,90 @@ async fn server_sends_detached_reattach() {
     server_task.await.unwrap();
 }
 
+#[tokio::test]
+async fn huge_realtime_request_timeout_allows_detached_reattach() {
+    let http = MockServer::start();
+    let ws = MockAblyServer::start().await.unwrap();
+    mock_token_endpoint(&http, "testKey.testId");
+
+    let ws_port = ws.port;
+    let (after_reattach_seen_tx, after_reattach_seen_rx) = tokio::sync::oneshot::channel::<()>();
+    let server_task = tokio::spawn(async move {
+        let mut conn = ws.accept_and_handshake("ch", "conn-1").await.unwrap();
+
+        let detached = ProtocolMessage {
+            action: action::DETACHED,
+            channel: Some("ch".into()),
+            error: Some(ErrorInfo {
+                code: 80003,
+                status_code: Some(500),
+                message: "channel detached".into(),
+            }),
+            ..Default::default()
+        };
+        conn.send(tungstenite::Message::Binary(
+            encode_msg(&detached).unwrap().into(),
+        ))
+        .await
+        .unwrap();
+
+        let msg = tokio::time::timeout(Duration::from_secs(5), read_protocol_msg(&mut conn))
+            .await
+            .expect("timed out waiting for ATTACH after DETACHED")
+            .unwrap();
+        assert_eq!(msg.action, action::ATTACH);
+        assert_eq!(msg.channel.as_deref(), Some("ch"));
+
+        let attached = ProtocolMessage {
+            action: action::ATTACHED,
+            channel: Some("ch".into()),
+            channel_serial: Some("serial-2".into()),
+            ..Default::default()
+        };
+        conn.send(tungstenite::Message::Binary(
+            encode_msg(&attached).unwrap().into(),
+        ))
+        .await
+        .unwrap();
+
+        send_message(
+            &mut conn,
+            "ch",
+            "after-huge-timeout-reattach",
+            serde_json::json!("ok"),
+        )
+        .await
+        .unwrap();
+        wait_for_test_observation(
+            after_reattach_seen_rx,
+            "after huge-timeout reattach message",
+        )
+        .await;
+    });
+
+    let mut timing = TimingConfig::default();
+    timing.realtime_request_timeout = Duration::MAX;
+    let mut sub = subscribe(test_config_with_timing(ws_port, http.port(), "ch", timing))
+        .await
+        .unwrap();
+
+    assert!(matches!(sub.next().await.unwrap(), Event::Connected));
+
+    let event = tokio::time::timeout(Duration::from_secs(5), sub.next())
+        .await
+        .expect("timed out waiting for message after huge-timeout reattach")
+        .unwrap();
+    match event {
+        Event::Message(msg) => {
+            assert_eq!(msg.name.as_deref(), Some("after-huge-timeout-reattach"));
+            after_reattach_seen_tx.send(()).unwrap();
+        }
+        other => panic!("expected Message, got {other:?}"),
+    }
+
+    server_task.await.unwrap();
+}
+
 // ---------------------------------------------------------------------------
 // Test 12: close subscription sends CLOSE to server
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Use checked deadline construction for Ably channel attach and retry timers.
- Saturate `retry_delay()`'s final millisecond conversion instead of truncating huge `Duration` values.
- Add regression coverage for `Duration::MAX` public `TimingConfig` values.

Closes #13383

## Tests

- `cargo test --manifest-path crates/Cargo.toml -p ably-subscriber retry_delay_saturates_huge_timeout_without_truncating`
- `cargo test --manifest-path crates/Cargo.toml -p ably-subscriber huge_realtime_request_timeout_allows_detached_reattach`
- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `cargo test --manifest-path crates/Cargo.toml -p ably-subscriber`
- `cargo clippy --manifest-path crates/Cargo.toml -p ably-subscriber --all-targets --all-features`
- pre-commit hook: `cargo-fmt`, `cargo-clippy`, `cargo-doc`
