### PR TITLE
fix: run host worker deploy step with bash

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1138,6 +1138,7 @@ jobs:
       - uses: ./.github/actions/toolchain-init
 
       - name: Deploy Host Worker to Cloudflare
+        shell: bash
         working-directory: turbo
         env:
           CF_ZERO_HOST_WORKER_DEPLOY_API_TOKEN: ${{ secrets.CF_ZERO_HOST_WORKER_DEPLOY_API_TOKEN }}


### PR DESCRIPTION
## Summary
- Force the Cloudflare host worker deploy step to run under bash
- Preserve existing token/account checks and wrangler deploy command

## Context
The prior deploy-host-worker run failed before deployment with `set: Illegal option -o pipefail` because the container step executed with `sh` while the script uses bash syntax.

## Testing
- Not run; workflow-only change