### PR TITLE
feat(connectors): model CLI auth connection flow

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-cli-auth-stripe.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-cli-auth-stripe.test.ts
@@ -255,7 +255,6 @@ async function enableCliAuthStripe(userId: string, orgId: string) {
       orgId,
       userId,
       switches: {
-        [FeatureSwitchKey.CliAuth]: true,
         [FeatureSwitchKey.CliAuthStripe]: true,
       },
     })
@@ -263,7 +262,6 @@ async function enableCliAuthStripe(userId: string, orgId: string) {
       target: [userFeatureSwitches.orgId, userFeatureSwitches.userId],
       set: {
         switches: {
-          [FeatureSwitchKey.CliAuth]: true,
           [FeatureSwitchKey.CliAuthStripe]: true,
         },
       },
@@ -380,7 +378,7 @@ describe("CLI auth for Stripe connector routes", () => {
     return { userId, orgId };
   }
 
-  it("requires both CLI auth feature switches before creating a sandbox", async () => {
+  it("requires the Stripe CLI auth feature switch before creating a sandbox", async () => {
     const userId = `user_${randomUUID()}`;
     const orgId = `org_${randomUUID()}`;
     fixtures.push({ userId, orgId });

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-search.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-search.test.ts
@@ -30,11 +30,21 @@ async function enableLocalBrowser(
   orgId: string,
   userId: string,
 ): Promise<void> {
+  await enableFeatureSwitches(orgId, userId, {
+    [FeatureSwitchKey.LocalBrowserUse]: true,
+  });
+}
+
+async function enableFeatureSwitches(
+  orgId: string,
+  userId: string,
+  switches: Partial<Record<FeatureSwitchKey, boolean>>,
+): Promise<void> {
   const writeDb = store.set(writeDb$);
   await writeDb.insert(userFeatureSwitches).values({
     orgId,
     userId,
-    switches: { [FeatureSwitchKey.LocalBrowserUse]: true },
+    switches,
   });
 }
 
@@ -247,6 +257,32 @@ describe("GET /api/zero/connectors/search", () => {
     });
     expect(localBrowser).toBeDefined();
     expect(localBrowser?.authMethods).toStrictEqual(["api"]);
+  });
+
+  it("shows Stripe CLI auth when the feature switch is enabled", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    seededFeatureSwitches.push({ orgId, userId });
+    await enableFeatureSwitches(orgId, userId, {
+      [FeatureSwitchKey.CliAuthStripe]: true,
+      [FeatureSwitchKey.StripeConnector]: false,
+    });
+    mocks.clerk.session(userId, orgId);
+
+    const client = setupApp({ context })(zeroConnectorsSearchContract);
+    const response = await accept(
+      client.search({
+        query: { keyword: "stripe" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    const stripe = response.body.connectors.find((c) => {
+      return c.id === "stripe";
+    });
+    expect(stripe).toBeDefined();
+    expect(stripe?.authMethods).toStrictEqual(["api-token", "cli-auth"]);
   });
 
   it("shows ungated api-token while hiding feature-gated oauth", async () => {

--- a/turbo/apps/api/src/signals/routes/zero-connectors-cli-auth-stripe.ts
+++ b/turbo/apps/api/src/signals/routes/zero-connectors-cli-auth-stripe.ts
@@ -40,10 +40,7 @@ function isCliAuthStripeEnabled(params: {
     userId: params.userId,
     overrides: params.overrides,
   };
-  return (
-    isFeatureEnabled(FeatureSwitchKey.CliAuth, switchContext) &&
-    isFeatureEnabled(FeatureSwitchKey.CliAuthStripe, switchContext)
-  );
+  return isFeatureEnabled(FeatureSwitchKey.CliAuthStripe, switchContext);
 }
 
 const completeCliAuthStripeBody$ = bodyResultOf(

--- a/turbo/apps/api/src/signals/services/__tests__/zero-connector-data.service.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/zero-connector-data.service.test.ts
@@ -114,6 +114,31 @@ describe("zeroConnectorList", () => {
 });
 
 describe("zeroConnectorSearch", () => {
+  async function stripeSearchAuthMethods(
+    switches: Partial<Record<FeatureSwitchKey, boolean>>,
+  ) {
+    const orgId = `org_${randomUUID()}`;
+    const userId = `user_${randomUUID()}`;
+
+    if (Object.keys(switches).length > 0) {
+      await writeDb.insert(userFeatureSwitches).values({
+        orgId,
+        userId,
+        switches,
+      });
+    }
+
+    const connectors = await store.get(
+      zeroConnectorSearch({ orgId, userId, keyword: "stripe" }),
+    );
+
+    const stripe = connectors.find((connector) => {
+      return connector.id === "stripe";
+    });
+    expect(stripe).toBeDefined();
+    return stripe?.authMethods ?? [];
+  }
+
   it("hides feature-flagged api-token connectors when the flag is disabled", async () => {
     const orgId = `org_${randomUUID()}`;
     const userId = `user_${randomUUID()}`;
@@ -147,4 +172,24 @@ describe("zeroConnectorSearch", () => {
     });
     expect(zapier?.authMethods).toStrictEqual(["api-token"]);
   });
+
+  it.each([
+    ["no Stripe CLI auth switch", {}, false],
+    [
+      "Stripe CLI auth without StripeConnector",
+      {
+        [FeatureSwitchKey.CliAuthStripe]: true,
+        [FeatureSwitchKey.StripeConnector]: false,
+      },
+      true,
+    ],
+  ] as const)(
+    "sets Stripe API search CLI auth availability for %s",
+    async (_name, switches, expectedCliAuth) => {
+      const authMethods = await stripeSearchAuthMethods(switches);
+
+      expect(authMethods).toContain("api-token");
+      expect(authMethods.includes("cli-auth")).toBe(expectedCliAuth);
+    },
+  );
 });

--- a/turbo/apps/cli/src/mocks/handlers/api-handlers.ts
+++ b/turbo/apps/cli/src/mocks/handlers/api-handlers.ts
@@ -3,22 +3,23 @@ import {
   CONNECTOR_TYPES,
   type ConnectorType,
 } from "@vm0/connectors/connectors";
+import { getAvailableConnectorAuthMethods } from "@vm0/connectors/connector-utils";
 
 function defaultAvailableConnectors() {
   return (Object.keys(CONNECTOR_TYPES) as ConnectorType[])
-    .filter((type) => {
-      const config = CONNECTOR_TYPES[type];
-      return Object.values(config.authMethods).some((method) => {
-        return !method.featureFlag;
-      });
-    })
     .map((type) => {
-      const config = CONNECTOR_TYPES[type];
+      const authMethods = getAvailableConnectorAuthMethods(type, {});
+      return { type, authMethods };
+    })
+    .filter((item) => {
+      return item.authMethods.length > 0;
+    })
+    .map(({ type, authMethods }) => {
       return {
         id: type,
-        label: config.label,
-        description: config.helpText,
-        authMethods: Object.keys(config.authMethods),
+        label: CONNECTOR_TYPES[type].label,
+        description: CONNECTOR_TYPES[type].helpText,
+        authMethods,
       };
     });
 }

--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-connectors.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-connectors.test.ts
@@ -179,3 +179,43 @@ describe("connectors — auth method feature flags", () => {
     expect(mercury?.availableAuthMethods).toContain("api-token");
   });
 });
+
+describe("connectors — CLI auth availability", () => {
+  async function stripeAuthMethods(
+    featureSwitches: Partial<Record<FeatureSwitchKey, boolean>>,
+  ) {
+    detachedSetupPage({
+      context,
+      path: "/",
+      featureSwitches,
+      withoutRender: true,
+    });
+
+    const connectorTypes = await context.store.get(allConnectorTypes$);
+    const stripe = connectorTypes.find((c) => {
+      return c.type === "stripe";
+    });
+    expect(stripe).toBeDefined();
+    return stripe?.availableAuthMethods ?? [];
+  }
+
+  it.each([
+    ["no Stripe CLI auth switch", {}, false],
+    [
+      "Stripe CLI auth without StripeConnector",
+      {
+        [FeatureSwitchKey.CliAuthStripe]: true,
+        [FeatureSwitchKey.StripeConnector]: false,
+      },
+      true,
+    ],
+  ] as const)(
+    "sets Stripe CLI auth availability for %s",
+    async (_name, featureSwitches, expectedCliAuth) => {
+      const authMethods = await stripeAuthMethods(featureSwitches);
+
+      expect(authMethods).toContain("api-token");
+      expect(authMethods.includes("cli-auth")).toBe(expectedCliAuth);
+    },
+  );
+});

--- a/turbo/apps/web/app/api/zero/connectors/search/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/connectors/search/__tests__/route.test.ts
@@ -3,6 +3,7 @@ import { GET } from "../route";
 import {
   createTestRequest,
   clearOrgMembersCacheEntry,
+  seedUserFeatureSwitches,
 } from "../../../../../../src/__tests__/api-test-helpers";
 import { testContext } from "../../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
@@ -14,6 +15,7 @@ import {
   CONNECTOR_TYPES,
   type ConnectorType,
 } from "@vm0/connectors/connectors";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 
 const context = testContext();
 
@@ -135,6 +137,26 @@ describe("GET /api/zero/connectors/search", () => {
     expect(neon.authMethods).toContain("api-token");
     // oauth should NOT be included since its feature flag is disabled.
     expect(neon.authMethods).not.toContain("oauth");
+  });
+
+  it("should show Stripe CLI auth when the feature switch is enabled", async () => {
+    const userId = "test-user-connectors-search-stripe-cli-auth";
+    const orgId = "org_test_connectors_search_stripe_cli_auth";
+    mockClerk({ userId, orgId });
+    await seedUserFeatureSwitches(orgId, userId, {
+      [FeatureSwitchKey.CliAuthStripe]: true,
+      [FeatureSwitchKey.StripeConnector]: false,
+    });
+
+    const response = await searchConnectors("stripe");
+    expect(response.status).toBe(200);
+    const data = await response.json();
+
+    const stripe = data.connectors.find((c: { id: string }) => {
+      return c.id === "stripe";
+    });
+    expect(stripe).toBeDefined();
+    expect(stripe.authMethods).toEqual(["api-token", "cli-auth"]);
   });
 
   it("should hide feature-flagged connector when feature is disabled", async () => {

--- a/turbo/packages/api-contracts/src/contracts/zero-connectors.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-connectors.ts
@@ -106,7 +106,12 @@ export const zeroConnectorAuthorizeContract = c.router({
   },
 });
 
-const connectorSearchAuthMethodSchema = z.enum(["oauth", "api-token", "api"]);
+const connectorSearchAuthMethodSchema = z.enum([
+  "oauth",
+  "api-token",
+  "api",
+  "cli-auth",
+]);
 
 export type ConnectorSearchAuthMethod = z.infer<
   typeof connectorSearchAuthMethodSchema

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
-import { connectorTypeSchema } from "../connectors";
+import { CONNECTOR_TYPES, connectorTypeSchema } from "../connectors";
 import {
+  getAvailableConnectorAuthMethods,
   hasRequiredScopes,
   getConnectorManagedSecretNames,
   getConnectorTypeForSecretName,
@@ -11,6 +12,7 @@ import {
   getConfiguredConnectorTypes,
   isGoogleOAuthConnector,
 } from "../connector-utils";
+import { FeatureSwitchKey } from "../feature-switch-key";
 
 describe("hasRequiredScopes", () => {
   it("returns true for non-OAuth connector type", () => {
@@ -54,6 +56,41 @@ describe("hasRequiredScopes", () => {
         "user",
       ]),
     ).toBe(true);
+  });
+});
+
+describe("connector auth method config", () => {
+  it("declares Stripe CLI auth as a gated connection flow with modes", () => {
+    const method = CONNECTOR_TYPES.stripe.authMethods["cli-auth"];
+
+    expect(method).toBeDefined();
+    expect(method?.secrets).toStrictEqual({});
+    expect(method?.featureFlag).toBe(FeatureSwitchKey.CliAuthStripe);
+    expect(CONNECTOR_TYPES.stripe.cliAuth?.modes).toStrictEqual([
+      {
+        value: "test",
+        label: "Test mode",
+        description: "Import a Stripe test mode key.",
+      },
+      {
+        value: "live",
+        label: "Live mode",
+        description: "Import a Stripe live mode key.",
+      },
+    ]);
+  });
+});
+
+describe("getAvailableConnectorAuthMethods", () => {
+  it("exposes Stripe CLI auth only when its switch is enabled", () => {
+    expect(getAvailableConnectorAuthMethods("stripe", {})).toStrictEqual([
+      "api-token",
+    ]);
+    expect(
+      getAvailableConnectorAuthMethods("stripe", {
+        [FeatureSwitchKey.CliAuthStripe]: true,
+      }),
+    ).toStrictEqual(["api-token", "cli-auth"]);
   });
 });
 

--- a/turbo/packages/connectors/src/connector-utils.ts
+++ b/turbo/packages/connectors/src/connector-utils.ts
@@ -71,7 +71,8 @@ function shouldIncludeApiAuthMethod(
 /**
  * Return user-selectable connector connection flows for a surface.
  *
- * This describes configured connection flows, not persisted connected state.
+ * This does not describe persisted connected state. For example, a `cli-auth`
+ * flow can import an API key and still appear as `api-token` once connected.
  */
 export function getAvailableConnectorAuthMethods(
   type: ConnectorType,

--- a/turbo/packages/connectors/src/connectors.ts
+++ b/turbo/packages/connectors/src/connectors.ts
@@ -205,7 +205,7 @@ export interface ConnectorSecretConfig {
 }
 
 /**
- * Auth method configuration for connectors
+ * Auth method configuration for user-selectable connector connection flows.
  */
 export interface ConnectorAuthMethodConfig {
   label: string;
@@ -225,21 +225,44 @@ export interface ConnectorOAuthConfig {
 }
 
 /**
- * Connector auth method variants.
+ * CLI auth configuration for connectors that can import credentials through a
+ * provider CLI.
+ */
+export interface ConnectorCliAuthConfig {
+  modes?: readonly {
+    value: string;
+    label: string;
+    description?: string;
+  }[];
+}
+
+/**
+ * Connector auth method variants exposed as configured connection flows.
+ *
+ * These values describe the choices users can select when connecting a
+ * service. They are not necessarily the same as the persisted connected
+ * credential shape returned by connector APIs.
  *
  * - `oauth` — full OAuth 2.0 flow. Enablement stored as a DB row in
  *   `connectors` (with scopes, external identity, token refresh metadata).
  * - `api-token` — user supplies an API token via the UI. No DB row:
  *   enablement is derived from the presence of required secrets/variables.
- * - `api` — connector-specific first-party flow, not the generic OAuth or
- *   user-entered API-token setup.
+ * - `api` — service-managed connection flow for integrations established
+ *   outside OAuth or user-entered API-token forms.
+ * - `cli-auth` — user imports credentials through a provider CLI. The imported
+ *   result may still be stored as another credential shape such as `api-token`.
  */
-export type ConnectorAuthMethodType = "oauth" | "api-token" | "api";
+export type ConnectorAuthMethodType =
+  | "oauth"
+  | "api-token"
+  | "api"
+  | "cli-auth";
 
 export const CONNECTOR_AUTH_METHOD_TYPES = [
   "oauth",
   "api-token",
   "api",
+  "cli-auth",
 ] as const satisfies readonly ConnectorAuthMethodType[];
 
 type MissingConnectorAuthMethodType = Exclude<
@@ -371,6 +394,7 @@ export interface ConnectorConfig {
   >;
   readonly defaultAuthMethod?: ConnectorAuthMethodType;
   readonly oauth?: ConnectorOAuthConfig;
+  readonly cliAuth?: ConnectorCliAuthConfig;
   /** Environment mapping declaring which env vars this connector provides. */
   readonly environmentMapping: Record<string, string>;
   /**

--- a/turbo/packages/connectors/src/connectors/stripe.ts
+++ b/turbo/packages/connectors/src/connectors/stripe.ts
@@ -39,8 +39,28 @@ export const stripe = {
           },
         },
       },
+      "cli-auth": {
+        featureFlag: FeatureSwitchKey.CliAuthStripe,
+        label: "Stripe CLI",
+        helpText: "Sign in with the Stripe CLI to import an API key.",
+        secrets: {},
+      },
     },
     defaultAuthMethod: "oauth",
+    cliAuth: {
+      modes: [
+        {
+          value: "test",
+          label: "Test mode",
+          description: "Import a Stripe test mode key.",
+        },
+        {
+          value: "live",
+          label: "Live mode",
+          description: "Import a Stripe live mode key.",
+        },
+      ],
+    },
     oauth: {
       authorizationUrl: "https://connect.stripe.com/oauth/authorize",
       tokenUrl: "https://connect.stripe.com/oauth/token",

--- a/turbo/packages/connectors/src/feature-switch-key.ts
+++ b/turbo/packages/connectors/src/feature-switch-key.ts
@@ -24,7 +24,6 @@ export enum FeatureSwitchKey {
   GoogleAdsConnector = "googleAdsConnector",
   MetaAdsConnector = "metaAdsConnector",
   StripeConnector = "stripeConnector",
-  CliAuth = "cliAuth",
   CliAuthStripe = "cliAuthStripe",
   PosthogConnector = "posthogConnector",
   PwaOfflineCache = "pwaOfflineCache",

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -73,26 +73,15 @@ describe("isFeatureEnabled", () => {
     expect(isFeatureEnabled(FeatureSwitchKey.RemoteAgent, {})).toBe(true);
   });
 
-  it("should enable CLI auth switches for staff orgs only by default", () => {
-    expect(isFeatureEnabled(FeatureSwitchKey.CliAuth, {})).toBe(false);
+  it("should keep Stripe CLI auth disabled by default", () => {
     expect(isFeatureEnabled(FeatureSwitchKey.CliAuthStripe, {})).toBe(false);
 
-    expect(
-      isFeatureEnabled(FeatureSwitchKey.CliAuth, {
-        orgId: "org_3ANttyrbWYJk6JKRSTRLEsbsDLe",
-      }),
-    ).toBe(true);
     expect(
       isFeatureEnabled(FeatureSwitchKey.CliAuthStripe, {
         orgId: "org_3ANttyrbWYJk6JKRSTRLEsbsDLe",
       }),
-    ).toBe(true);
-
-    expect(
-      isFeatureEnabled(FeatureSwitchKey.CliAuth, {
-        orgId: "org_nonexistent",
-      }),
     ).toBe(false);
+
     expect(
       isFeatureEnabled(FeatureSwitchKey.CliAuthStripe, {
         orgId: "org_nonexistent",
@@ -198,28 +187,12 @@ describe("overrides", () => {
     ).toBe(false);
   });
 
-  it("should allow CLI auth switches to be overridden independently", () => {
-    expect(
-      isFeatureEnabled(FeatureSwitchKey.CliAuth, {
-        overrides: { [FeatureSwitchKey.CliAuth]: true },
-      }),
-    ).toBe(true);
+  it("should allow Stripe CLI auth to be overridden", () => {
     expect(
       isFeatureEnabled(FeatureSwitchKey.CliAuthStripe, {
         overrides: { [FeatureSwitchKey.CliAuthStripe]: true },
       }),
     ).toBe(true);
-
-    expect(
-      isFeatureEnabled(FeatureSwitchKey.CliAuthStripe, {
-        overrides: { [FeatureSwitchKey.CliAuth]: true },
-      }),
-    ).toBe(false);
-    expect(
-      isFeatureEnabled(FeatureSwitchKey.CliAuth, {
-        overrides: { [FeatureSwitchKey.CliAuthStripe]: true },
-      }),
-    ).toBe(false);
   });
 
   it("should behave identically when no overrides provided", () => {

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -134,19 +134,10 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     description: "Enable the Stripe payment connector integration",
     enabled: false,
   },
-  [FeatureSwitchKey.CliAuth]: {
-    maintainer: "liangyou@vm0.ai",
-    description:
-      "Gate CLI-based connector auth UI and API surfaces. Rollout control only; credential routes still require normal auth and ownership checks.",
-    enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
-  },
   [FeatureSwitchKey.CliAuthStripe]: {
     maintainer: "liangyou@vm0.ai",
-    description:
-      "Gate Stripe-specific CLI auth UI and API surfaces. CLI auth for Stripe consumers should also require CliAuth.",
+    description: "Gate Stripe-specific CLI auth UI and API surfaces.",
     enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.PosthogConnector]: {
     maintainer: "ethan@vm0.ai",


### PR DESCRIPTION
## Summary
- add `cli-auth` as a connector auth method type and include it in the zero connector search contract
- model Stripe CLI auth as connector config with test/live modes behind `CliAuthStripe`
- remove the global `CliAuth` switch so auth method availability is driven by method-level feature flags
- keep CLI/web test surfaces aligned with the real connector search availability helper

Closes #13372

## Tests
- `pnpm exec vitest run packages/core/src/__tests__/feature-switch.test.ts packages/connectors/src/__tests__/connectors.test.ts apps/api/src/signals/services/__tests__/zero-connector-data.service.test.ts apps/api/src/signals/routes/__tests__/zero-connectors-search.test.ts apps/api/src/signals/routes/__tests__/zero-connectors-cli-auth-stripe.test.ts apps/platform/src/signals/zero-page/__tests__/zero-connectors.test.ts`
- `pnpm exec vitest run apps/web/app/api/zero/connectors/search/__tests__/route.test.ts apps/cli/src/commands/zero/connector/__tests__/search.test.ts`
- `pnpm --filter @vm0/core check-types`
- `pnpm --filter @vm0/connectors check-types`
- `pnpm --filter api check-types`
- `pnpm --filter @vm0/app check-types`
- `pnpm --filter web check-types`
- `pnpm --filter @vm0/cli check-types`