### PR TITLE
refactor(vsock-host): add normal operation tracker

### DIFF
--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -20,6 +20,7 @@
 
 mod exec_operation;
 mod file;
+mod operation_tracker;
 mod process;
 #[cfg(test)]
 mod tests;
@@ -37,6 +38,7 @@ use tokio::sync::{Notify, oneshot};
 use tokio::task::JoinHandle;
 use tokio::time::{self, Instant};
 
+use operation_tracker::NormalOperationTracker;
 use vsock_proto::{
     Decoder, MSG_ERROR, MSG_EXEC_OUTPUT, MSG_EXEC_RESULT, MSG_OPERATIONS_QUIESCED,
     MSG_OPERATIONS_RESUMED, MSG_PING, MSG_PONG, MSG_PROCESS_EXIT, MSG_QUIESCE_OPERATIONS,
@@ -101,6 +103,11 @@ struct Shared {
     /// Single source of truth for connection liveness plus all per-connection
     /// registration tables. See [`ConnectionState`].
     state: std::sync::Mutex<ConnectionState>,
+    /// Authoritative lifecycle tracker for logical normal guest operations.
+    ///
+    /// Routing maps stay inside [`ConnectionState`]; this tracker records the
+    /// neutral operation-readiness facts that sandbox policy can consume later.
+    normal_operations: NormalOperationTracker,
     /// Notified when the connection closes. Pure signalling — all state is in
     /// `state`.
     close_notify: Notify,
@@ -163,10 +170,14 @@ impl Shared {
     /// binding to write the whole variant back unchanged, so double-close is a
     /// structural no-op rather than a convention.
     fn close(&self) {
-        self.close_with_reason("connection closed");
+        self.close_with_reason("connection closed", ConnectionCloseKind::Closed);
     }
 
-    fn close_with_reason(&self, reason: &'static str) {
+    fn close_with_reason(&self, reason: &'static str, kind: ConnectionCloseKind) {
+        match kind {
+            ConnectionCloseKind::Closed => self.normal_operations.mark_closed(),
+            ConnectionCloseKind::Poisoned => self.normal_operations.mark_not_parkable(),
+        }
         let maps_to_drop = {
             let mut guard = self.state.lock().unwrap_or_else(|e| e.into_inner());
             match std::mem::replace(
@@ -204,7 +215,7 @@ impl Shared {
     }
 
     fn poison_connection(&self) {
-        self.close_with_reason("connection poisoned");
+        self.close_with_reason("connection poisoned", ConnectionCloseKind::Poisoned);
         let _ = nix::sys::socket::shutdown(self.fd, nix::sys::socket::Shutdown::Both);
     }
 
@@ -221,6 +232,12 @@ impl Shared {
             operations.remove(seq);
         }
     }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ConnectionCloseKind {
+    Closed,
+    Poisoned,
 }
 
 /// Host-side vsock endpoint.
@@ -491,6 +508,7 @@ impl VsockHost {
                 operations: exec_operation::Operations::new(),
                 process: process::ConnectedProcessState::new(),
             }),
+            normal_operations: NormalOperationTracker::new(),
             close_notify: Notify::new(),
         });
 

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -103,7 +103,7 @@ struct Shared {
     /// Single source of truth for connection liveness plus all per-connection
     /// registration tables. See [`ConnectionState`].
     state: std::sync::Mutex<ConnectionState>,
-    /// Authoritative lifecycle tracker for logical normal guest operations.
+    /// Connection-local tracker for logical normal guest operations.
     ///
     /// Routing maps stay inside [`ConnectionState`]; this tracker records the
     /// neutral operation-readiness facts that sandbox policy can consume later.

--- a/crates/vsock-host/src/operation_tracker.rs
+++ b/crates/vsock-host/src/operation_tracker.rs
@@ -73,14 +73,21 @@ impl NormalOperationTracker {
 
     pub(crate) fn mark_not_parkable(&self) {
         let mut inner = self.inner();
-        if !matches!(inner.state, TrackerState::Closed) {
-            inner.state = TrackerState::NotParkable;
-            inner.operations.clear();
-        }
+        inner.state = TrackerState::NotParkable;
+        inner.operations.clear();
     }
 
     pub(crate) fn mark_closed(&self) {
         let mut inner = self.inner();
+        if inner
+            .operations
+            .values()
+            .any(|phase| *phase == OperationPhase::PossibleGuestWrite)
+        {
+            inner.state = TrackerState::NotParkable;
+            inner.operations.clear();
+            return;
+        }
         if matches!(
             inner.state,
             TrackerState::Open | TrackerState::Fenced { .. }
@@ -395,11 +402,44 @@ mod tests {
     }
 
     #[test]
+    fn close_with_reserved_operation_is_closed() {
+        let tracker = NormalOperationTracker::new();
+        let _token = reserve(&tracker);
+
+        tracker.mark_closed();
+
+        assert_eq!(tracker.readiness(), NormalOperationReadiness::Closed);
+    }
+
+    #[test]
+    fn close_with_possible_guest_write_is_not_parkable() {
+        let tracker = NormalOperationTracker::new();
+        let mut token = reserve(&tracker);
+        token
+            .mark_possible_guest_write_started()
+            .expect("mark write started");
+
+        tracker.mark_closed();
+
+        assert_eq!(tracker.readiness(), NormalOperationReadiness::NotParkable);
+    }
+
+    #[test]
     fn not_parkable_state_survives_later_close() {
         let tracker = NormalOperationTracker::new();
 
         tracker.mark_not_parkable();
         tracker.mark_closed();
+
+        assert_eq!(tracker.readiness(), NormalOperationReadiness::NotParkable);
+    }
+
+    #[test]
+    fn not_parkable_state_overrides_prior_close() {
+        let tracker = NormalOperationTracker::new();
+
+        tracker.mark_closed();
+        tracker.mark_not_parkable();
 
         assert_eq!(tracker.readiness(), NormalOperationReadiness::NotParkable);
     }

--- a/crates/vsock-host/src/operation_tracker.rs
+++ b/crates/vsock-host/src/operation_tracker.rs
@@ -424,10 +424,12 @@ mod tests {
     #[test]
     fn close_with_reserved_operation_is_closed() {
         let tracker = NormalOperationTracker::new();
-        let _token = reserve(&tracker);
+        let token = reserve(&tracker);
 
         tracker.mark_closed();
 
+        assert_eq!(tracker.readiness(), NormalOperationReadiness::Closed);
+        drop(token);
         assert_eq!(tracker.readiness(), NormalOperationReadiness::Closed);
     }
 
@@ -515,5 +517,35 @@ mod tests {
             NormalOperationTransitionError::UnknownOperation { .. }
         ));
         assert_eq!(tracker.readiness(), NormalOperationReadiness::NotParkable);
+    }
+
+    #[test]
+    fn mark_possible_guest_write_after_close_returns_unknown_and_preserves_state() {
+        let tracker = NormalOperationTracker::new();
+        let mut token = reserve(&tracker);
+
+        tracker.mark_closed();
+
+        let err = token.mark_possible_guest_write_started().unwrap_err();
+        assert!(matches!(
+            err,
+            NormalOperationTransitionError::UnknownOperation { .. }
+        ));
+        assert_eq!(tracker.readiness(), NormalOperationReadiness::Closed);
+    }
+
+    #[test]
+    fn complete_after_close_returns_unknown_and_preserves_state() {
+        let tracker = NormalOperationTracker::new();
+        let token = reserve(&tracker);
+
+        tracker.mark_closed();
+
+        let err = token.complete().unwrap_err();
+        assert!(matches!(
+            err,
+            NormalOperationTransitionError::UnknownOperation { .. }
+        ));
+        assert_eq!(tracker.readiness(), NormalOperationReadiness::Closed);
     }
 }

--- a/crates/vsock-host/src/operation_tracker.rs
+++ b/crates/vsock-host/src/operation_tracker.rs
@@ -61,7 +61,6 @@ impl NormalOperationTracker {
                 Ok(NormalOperationFence {
                     id,
                     inner: Arc::clone(&self.inner),
-                    released: false,
                 })
             }
             TrackerState::Open => Err(NormalOperationFenceRejection::Busy),
@@ -244,19 +243,14 @@ impl Drop for NormalOperationToken {
 pub(crate) struct NormalOperationFence {
     id: NormalOperationFenceId,
     inner: Arc<Mutex<Inner>>,
-    released: bool,
 }
 
 impl Drop for NormalOperationFence {
     fn drop(&mut self) {
-        if self.released {
-            return;
-        }
         let mut inner = lock_inner(&self.inner);
         if matches!(inner.state, TrackerState::Fenced { id } if id == self.id) {
             inner.state = TrackerState::Open;
         }
-        self.released = true;
     }
 }
 

--- a/crates/vsock-host/src/operation_tracker.rs
+++ b/crates/vsock-host/src/operation_tracker.rs
@@ -359,6 +359,17 @@ mod tests {
     }
 
     #[test]
+    fn second_fence_is_rejected_while_fenced() {
+        let tracker = NormalOperationTracker::new();
+        let _fence = fence(&tracker);
+
+        assert!(matches!(
+            tracker.try_fence(),
+            Err(NormalOperationFenceRejection::AlreadyFenced)
+        ));
+    }
+
+    #[test]
     fn dropping_fence_reopens_tracker() {
         let tracker = NormalOperationTracker::new();
         let fence = fence(&tracker);
@@ -381,6 +392,21 @@ mod tests {
         assert!(matches!(
             tracker.try_fence(),
             Err(NormalOperationFenceRejection::NotParkable)
+        ));
+    }
+
+    #[test]
+    fn close_while_fenced_does_not_reopen_on_fence_drop() {
+        let tracker = NormalOperationTracker::new();
+        let fence = fence(&tracker);
+
+        tracker.mark_closed();
+        drop(fence);
+
+        assert_eq!(tracker.readiness(), NormalOperationReadiness::Closed);
+        assert!(matches!(
+            tracker.try_fence(),
+            Err(NormalOperationFenceRejection::Closed)
         ));
     }
 
@@ -425,6 +451,20 @@ mod tests {
     }
 
     #[test]
+    fn close_with_mixed_reserved_and_possible_guest_write_is_not_parkable() {
+        let tracker = NormalOperationTracker::new();
+        let _reserved_token = reserve(&tracker);
+        let mut write_token = reserve(&tracker);
+        write_token
+            .mark_possible_guest_write_started()
+            .expect("mark write started");
+
+        tracker.mark_closed();
+
+        assert_eq!(tracker.readiness(), NormalOperationReadiness::NotParkable);
+    }
+
+    #[test]
     fn not_parkable_state_survives_later_close() {
         let tracker = NormalOperationTracker::new();
 
@@ -441,6 +481,45 @@ mod tests {
         tracker.mark_closed();
         tracker.mark_not_parkable();
 
+        assert_eq!(tracker.readiness(), NormalOperationReadiness::NotParkable);
+    }
+
+    #[test]
+    fn second_possible_guest_write_mark_is_invalid_transition() {
+        let tracker = NormalOperationTracker::new();
+        let mut token = reserve(&tracker);
+        token
+            .mark_possible_guest_write_started()
+            .expect("mark write started");
+
+        let err = token.mark_possible_guest_write_started().unwrap_err();
+
+        assert!(matches!(
+            err,
+            NormalOperationTransitionError::InvalidTransition {
+                from: OperationPhase::PossibleGuestWrite,
+                to: OperationPhase::PossibleGuestWrite,
+                ..
+            }
+        ));
+        assert_eq!(tracker.readiness(), NormalOperationReadiness::Busy);
+    }
+
+    #[test]
+    fn complete_after_not_parkable_returns_unknown_and_preserves_state() {
+        let tracker = NormalOperationTracker::new();
+        let mut token = reserve(&tracker);
+        token
+            .mark_possible_guest_write_started()
+            .expect("mark write started");
+
+        tracker.mark_not_parkable();
+
+        let err = token.complete().unwrap_err();
+        assert!(matches!(
+            err,
+            NormalOperationTransitionError::UnknownOperation { .. }
+        ));
         assert_eq!(tracker.readiness(), NormalOperationReadiness::NotParkable);
     }
 }

--- a/crates/vsock-host/src/operation_tracker.rs
+++ b/crates/vsock-host/src/operation_tracker.rs
@@ -1,0 +1,406 @@
+#![cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "normal operation tracker APIs are introduced before command/file/process callers migrate to them"
+    )
+)]
+
+use std::collections::BTreeMap;
+use std::sync::{Arc, Mutex, MutexGuard};
+
+#[derive(Clone, Debug)]
+pub(crate) struct NormalOperationTracker {
+    inner: Arc<Mutex<Inner>>,
+}
+
+impl NormalOperationTracker {
+    pub(crate) fn new() -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(Inner {
+                state: TrackerState::Open,
+                next_operation_id: 1,
+                next_fence_id: 1,
+                operations: BTreeMap::new(),
+            })),
+        }
+    }
+
+    pub(crate) fn readiness(&self) -> NormalOperationReadiness {
+        self.inner().readiness()
+    }
+
+    pub(crate) fn reserve(&self) -> Result<NormalOperationToken, NormalOperationRejection> {
+        let mut inner = self.inner();
+        match inner.state {
+            TrackerState::Open => {
+                let id = NormalOperationId(inner.next_operation_id);
+                inner.next_operation_id += 1;
+                inner
+                    .operations
+                    .insert(id, OperationPhase::ReservedBeforeWrite);
+                Ok(NormalOperationToken {
+                    id,
+                    inner: Arc::clone(&self.inner),
+                    released: false,
+                })
+            }
+            TrackerState::Fenced { .. } => Err(NormalOperationRejection::Fenced),
+            TrackerState::NotParkable => Err(NormalOperationRejection::NotParkable),
+            TrackerState::Closed => Err(NormalOperationRejection::Closed),
+        }
+    }
+
+    pub(crate) fn try_fence(&self) -> Result<NormalOperationFence, NormalOperationFenceRejection> {
+        let mut inner = self.inner();
+        match inner.state {
+            TrackerState::Open if inner.operations.is_empty() => {
+                let id = NormalOperationFenceId(inner.next_fence_id);
+                inner.next_fence_id += 1;
+                inner.state = TrackerState::Fenced { id };
+                Ok(NormalOperationFence {
+                    id,
+                    inner: Arc::clone(&self.inner),
+                    released: false,
+                })
+            }
+            TrackerState::Open => Err(NormalOperationFenceRejection::Busy),
+            TrackerState::Fenced { .. } => Err(NormalOperationFenceRejection::AlreadyFenced),
+            TrackerState::NotParkable => Err(NormalOperationFenceRejection::NotParkable),
+            TrackerState::Closed => Err(NormalOperationFenceRejection::Closed),
+        }
+    }
+
+    pub(crate) fn mark_not_parkable(&self) {
+        let mut inner = self.inner();
+        if !matches!(inner.state, TrackerState::Closed) {
+            inner.state = TrackerState::NotParkable;
+            inner.operations.clear();
+        }
+    }
+
+    pub(crate) fn mark_closed(&self) {
+        let mut inner = self.inner();
+        if matches!(
+            inner.state,
+            TrackerState::Open | TrackerState::Fenced { .. }
+        ) {
+            inner.state = TrackerState::Closed;
+            inner.operations.clear();
+        }
+    }
+
+    fn inner(&self) -> MutexGuard<'_, Inner> {
+        lock_inner(&self.inner)
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum NormalOperationReadiness {
+    Idle,
+    Busy,
+    Fenced,
+    NotParkable,
+    Closed,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum NormalOperationRejection {
+    Fenced,
+    NotParkable,
+    Closed,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum NormalOperationFenceRejection {
+    Busy,
+    AlreadyFenced,
+    NotParkable,
+    Closed,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum NormalOperationTransitionError {
+    UnknownOperation {
+        operation_id: NormalOperationId,
+    },
+    InvalidTransition {
+        operation_id: NormalOperationId,
+        from: OperationPhase,
+        to: OperationPhase,
+    },
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) struct NormalOperationId(u64);
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct NormalOperationFenceId(u64);
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum OperationPhase {
+    ReservedBeforeWrite,
+    PossibleGuestWrite,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum TrackerState {
+    Open,
+    Fenced { id: NormalOperationFenceId },
+    NotParkable,
+    Closed,
+}
+
+#[derive(Debug)]
+struct Inner {
+    state: TrackerState,
+    next_operation_id: u64,
+    next_fence_id: u64,
+    operations: BTreeMap<NormalOperationId, OperationPhase>,
+}
+
+impl Inner {
+    fn readiness(&self) -> NormalOperationReadiness {
+        match self.state {
+            TrackerState::Open if self.operations.is_empty() => NormalOperationReadiness::Idle,
+            TrackerState::Open => NormalOperationReadiness::Busy,
+            TrackerState::Fenced { .. } => NormalOperationReadiness::Fenced,
+            TrackerState::NotParkable => NormalOperationReadiness::NotParkable,
+            TrackerState::Closed => NormalOperationReadiness::Closed,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct NormalOperationToken {
+    id: NormalOperationId,
+    inner: Arc<Mutex<Inner>>,
+    released: bool,
+}
+
+impl NormalOperationToken {
+    pub(crate) fn mark_possible_guest_write_started(
+        &mut self,
+    ) -> Result<(), NormalOperationTransitionError> {
+        let mut inner = lock_inner(&self.inner);
+        let Some(phase) = inner.operations.get_mut(&self.id) else {
+            return Err(NormalOperationTransitionError::UnknownOperation {
+                operation_id: self.id,
+            });
+        };
+        match *phase {
+            OperationPhase::ReservedBeforeWrite => {
+                *phase = OperationPhase::PossibleGuestWrite;
+                Ok(())
+            }
+            OperationPhase::PossibleGuestWrite => {
+                Err(NormalOperationTransitionError::InvalidTransition {
+                    operation_id: self.id,
+                    from: OperationPhase::PossibleGuestWrite,
+                    to: OperationPhase::PossibleGuestWrite,
+                })
+            }
+        }
+    }
+
+    pub(crate) fn complete(mut self) -> Result<(), NormalOperationTransitionError> {
+        let mut inner = lock_inner(&self.inner);
+        let Some(_phase) = inner.operations.remove(&self.id) else {
+            return Err(NormalOperationTransitionError::UnknownOperation {
+                operation_id: self.id,
+            });
+        };
+        self.released = true;
+        Ok(())
+    }
+}
+
+impl Drop for NormalOperationToken {
+    fn drop(&mut self) {
+        if self.released {
+            return;
+        }
+        let mut inner = lock_inner(&self.inner);
+        match inner.operations.remove(&self.id) {
+            Some(OperationPhase::ReservedBeforeWrite) | None => {}
+            Some(OperationPhase::PossibleGuestWrite) => {
+                if !matches!(inner.state, TrackerState::Closed) {
+                    inner.state = TrackerState::NotParkable;
+                    inner.operations.clear();
+                }
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct NormalOperationFence {
+    id: NormalOperationFenceId,
+    inner: Arc<Mutex<Inner>>,
+    released: bool,
+}
+
+impl Drop for NormalOperationFence {
+    fn drop(&mut self) {
+        if self.released {
+            return;
+        }
+        let mut inner = lock_inner(&self.inner);
+        if matches!(inner.state, TrackerState::Fenced { id } if id == self.id) {
+            inner.state = TrackerState::Open;
+        }
+        self.released = true;
+    }
+}
+
+fn lock_inner(inner: &Mutex<Inner>) -> MutexGuard<'_, Inner> {
+    inner.lock().unwrap_or_else(|error| error.into_inner())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn reserve(tracker: &NormalOperationTracker) -> NormalOperationToken {
+        tracker.reserve().expect("operation should reserve")
+    }
+
+    fn fence(tracker: &NormalOperationTracker) -> NormalOperationFence {
+        tracker.try_fence().expect("tracker should fence")
+    }
+
+    #[test]
+    fn new_tracker_starts_idle() {
+        let tracker = NormalOperationTracker::new();
+
+        assert_eq!(tracker.readiness(), NormalOperationReadiness::Idle);
+    }
+
+    #[test]
+    fn reserve_makes_tracker_busy() {
+        let tracker = NormalOperationTracker::new();
+        let _token = reserve(&tracker);
+
+        assert_eq!(tracker.readiness(), NormalOperationReadiness::Busy);
+    }
+
+    #[test]
+    fn drop_before_possible_guest_write_returns_to_idle() {
+        let tracker = NormalOperationTracker::new();
+        let token = reserve(&tracker);
+
+        drop(token);
+
+        assert_eq!(tracker.readiness(), NormalOperationReadiness::Idle);
+    }
+
+    #[test]
+    fn complete_after_possible_guest_write_returns_to_idle() {
+        let tracker = NormalOperationTracker::new();
+        let mut token = reserve(&tracker);
+        token
+            .mark_possible_guest_write_started()
+            .expect("mark write started");
+
+        token.complete().expect("operation should complete");
+
+        assert_eq!(tracker.readiness(), NormalOperationReadiness::Idle);
+    }
+
+    #[test]
+    fn drop_after_possible_guest_write_is_not_parkable() {
+        let tracker = NormalOperationTracker::new();
+        let mut token = reserve(&tracker);
+        token
+            .mark_possible_guest_write_started()
+            .expect("mark write started");
+
+        drop(token);
+
+        assert_eq!(tracker.readiness(), NormalOperationReadiness::NotParkable);
+        assert!(matches!(
+            tracker.reserve(),
+            Err(NormalOperationRejection::NotParkable)
+        ));
+    }
+
+    #[test]
+    fn fence_succeeds_only_when_idle() {
+        let tracker = NormalOperationTracker::new();
+        let token = reserve(&tracker);
+
+        assert!(matches!(
+            tracker.try_fence(),
+            Err(NormalOperationFenceRejection::Busy)
+        ));
+
+        drop(token);
+        let _fence = fence(&tracker);
+
+        assert_eq!(tracker.readiness(), NormalOperationReadiness::Fenced);
+    }
+
+    #[test]
+    fn fence_rejects_normal_operation_reservation() {
+        let tracker = NormalOperationTracker::new();
+        let _fence = fence(&tracker);
+
+        assert!(matches!(
+            tracker.reserve(),
+            Err(NormalOperationRejection::Fenced)
+        ));
+    }
+
+    #[test]
+    fn dropping_fence_reopens_tracker() {
+        let tracker = NormalOperationTracker::new();
+        let fence = fence(&tracker);
+
+        drop(fence);
+
+        assert_eq!(tracker.readiness(), NormalOperationReadiness::Idle);
+        assert!(tracker.reserve().is_ok());
+    }
+
+    #[test]
+    fn poison_while_fenced_does_not_reopen_on_fence_drop() {
+        let tracker = NormalOperationTracker::new();
+        let fence = fence(&tracker);
+
+        tracker.mark_not_parkable();
+        drop(fence);
+
+        assert_eq!(tracker.readiness(), NormalOperationReadiness::NotParkable);
+        assert!(matches!(
+            tracker.try_fence(),
+            Err(NormalOperationFenceRejection::NotParkable)
+        ));
+    }
+
+    #[test]
+    fn close_rejects_future_reservation_and_fencing() {
+        let tracker = NormalOperationTracker::new();
+
+        tracker.mark_closed();
+
+        assert_eq!(tracker.readiness(), NormalOperationReadiness::Closed);
+        assert!(matches!(
+            tracker.reserve(),
+            Err(NormalOperationRejection::Closed)
+        ));
+        assert!(matches!(
+            tracker.try_fence(),
+            Err(NormalOperationFenceRejection::Closed)
+        ));
+    }
+
+    #[test]
+    fn not_parkable_state_survives_later_close() {
+        let tracker = NormalOperationTracker::new();
+
+        tracker.mark_not_parkable();
+        tracker.mark_closed();
+
+        assert_eq!(tracker.readiness(), NormalOperationReadiness::NotParkable);
+    }
+}

--- a/crates/vsock-host/src/tests/connection.rs
+++ b/crates/vsock-host/src/tests/connection.rs
@@ -13,7 +13,7 @@ use super::support::{
     host_from_stream, make_pair, mock_handshake, normal_operation_readiness, poison_connection,
     read_guest_message, send_exec_result,
 };
-use crate::{operation_tracker::NormalOperationReadiness, VsockHost};
+use crate::{VsockHost, operation_tracker::NormalOperationReadiness};
 
 #[tokio::test]
 async fn wait_for_connection_removes_listener_socket_on_abort() {

--- a/crates/vsock-host/src/tests/connection.rs
+++ b/crates/vsock-host/src/tests/connection.rs
@@ -299,7 +299,7 @@ async fn test_request_after_close_returns_immediately() {
 async fn connection_close_marks_normal_operations_closed() {
     let (host_stream, mut guest) = make_pair();
 
-    tokio::spawn(async move {
+    let guest_task = tokio::spawn(async move {
         let mut decoder = Decoder::new();
         mock_handshake(&mut guest, &mut decoder).await;
         drop(guest);
@@ -314,13 +314,14 @@ async fn connection_close_marks_normal_operations_closed() {
         normal_operation_readiness(&host),
         NormalOperationReadiness::Closed
     );
+    guest_task.await.unwrap();
 }
 
 #[tokio::test]
 async fn connection_poison_marks_normal_operations_not_parkable() {
     let (host_stream, mut guest) = make_pair();
 
-    tokio::spawn(async move {
+    let guest_task = tokio::spawn(async move {
         let mut decoder = Decoder::new();
         mock_handshake(&mut guest, &mut decoder).await;
         let mut buf = [0u8; 1];
@@ -334,6 +335,10 @@ async fn connection_poison_marks_normal_operations_not_parkable() {
         normal_operation_readiness(&host),
         NormalOperationReadiness::NotParkable
     );
+    tokio::time::timeout(Duration::from_secs(5), guest_task)
+        .await
+        .unwrap()
+        .unwrap();
 }
 
 /// Two concurrent exec calls get the correct response matched by seq.

--- a/crates/vsock-host/src/tests/connection.rs
+++ b/crates/vsock-host/src/tests/connection.rs
@@ -10,9 +10,10 @@ use vsock_proto::{
 };
 
 use super::support::{
-    host_from_stream, make_pair, mock_handshake, read_guest_message, send_exec_result,
+    host_from_stream, make_pair, mock_handshake, normal_operation_readiness, poison_connection,
+    read_guest_message, send_exec_result,
 };
-use crate::VsockHost;
+use crate::{operation_tracker::NormalOperationReadiness, VsockHost};
 
 #[tokio::test]
 async fn wait_for_connection_removes_listener_socket_on_abort() {
@@ -291,6 +292,47 @@ async fn test_request_after_close_returns_immediately() {
         ),
         "expected ConnectionReset or BrokenPipe, got {:?}",
         err.kind()
+    );
+}
+
+#[tokio::test]
+async fn connection_close_marks_normal_operations_closed() {
+    let (host_stream, mut guest) = make_pair();
+
+    tokio::spawn(async move {
+        let mut decoder = Decoder::new();
+        mock_handshake(&mut guest, &mut decoder).await;
+        drop(guest);
+    });
+
+    let host = host_from_stream(host_stream).await.unwrap();
+    host.wait_until_closed(Duration::from_secs(5))
+        .await
+        .unwrap();
+
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Closed
+    );
+}
+
+#[tokio::test]
+async fn connection_poison_marks_normal_operations_not_parkable() {
+    let (host_stream, mut guest) = make_pair();
+
+    tokio::spawn(async move {
+        let mut decoder = Decoder::new();
+        mock_handshake(&mut guest, &mut decoder).await;
+        let mut buf = [0u8; 1];
+        let _ = guest.read(&mut buf).await;
+    });
+
+    let host = host_from_stream(host_stream).await.unwrap();
+    poison_connection(&host);
+
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::NotParkable
     );
 }
 

--- a/crates/vsock-host/src/tests/support.rs
+++ b/crates/vsock-host/src/tests/support.rs
@@ -10,7 +10,7 @@ use vsock_proto::{
     MSG_EXEC_RESULT, MSG_EXEC_START, MSG_PING, MSG_PONG, MSG_READY, RawMessage,
 };
 
-use crate::{ConnectionState, VsockHost};
+use crate::{ConnectionState, VsockHost, operation_tracker::NormalOperationReadiness};
 
 pub(crate) fn make_pair() -> (UnixStream, UnixStream) {
     UnixStream::pair().unwrap()
@@ -46,6 +46,14 @@ pub(crate) fn operation_count(host: &VsockHost) -> usize {
 pub(crate) fn is_connected(host: &VsockHost) -> bool {
     let guard = host.shared.state.lock().unwrap_or_else(|e| e.into_inner());
     matches!(&*guard, ConnectionState::Connected { .. })
+}
+
+pub(crate) fn normal_operation_readiness(host: &VsockHost) -> NormalOperationReadiness {
+    host.shared.normal_operations.readiness()
+}
+
+pub(crate) fn poison_connection(host: &VsockHost) {
+    host.shared.poison_connection();
 }
 
 pub(crate) async fn read_guest_message(


### PR DESCRIPTION
## Summary

- add a neutral `NormalOperationTracker` in `vsock-host`
- attach one tracker to each `Shared` connection and update it on close/poison
- cover token, fence, close, and poison semantics with focused tests

## Tests

- `cargo test --manifest-path crates/Cargo.toml -p vsock-host`
- `cargo clippy --manifest-path crates/Cargo.toml -p vsock-host --all-targets --all-features`
- pre-commit: cargo fmt, cargo clippy, cargo doc

Closes #13454
