### PR TITLE
fix: update image generation defaults

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-image-io-generate.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-image-io-generate.test.ts
@@ -518,6 +518,7 @@ describe("POST /api/zero/image-io/generate", () => {
       headers: authHeaders(),
       body: JSON.stringify({
         prompt: "a transparent badge",
+        model: "gpt-image-2",
         background: "transparent",
         outputFormat: "webp",
       }),
@@ -696,7 +697,7 @@ describe("POST /api/zero/image-io/generate", () => {
             },
           ],
           output_format: "webp",
-          size: "2048x1152",
+          size: "1024x1024",
           quality: "auto",
           background: "opaque",
           usage: {
@@ -723,7 +724,7 @@ describe("POST /api/zero/image-io/generate", () => {
       headers: { authorization: `Bearer ${token}` },
       body: JSON.stringify({
         prompt: "a small robot painting a sunflower",
-        size: "2048x1152",
+        size: "1024x1024",
         quality: "auto",
         background: "opaque",
         outputFormat: "webp",
@@ -766,7 +767,7 @@ describe("POST /api/zero/image-io/generate", () => {
       size: IMAGE_BYTES.byteLength,
       creditsCharged,
       model: IMAGE_IO_MODEL,
-      imageSize: "2048x1152",
+      imageSize: "1024x1024",
       quality: "auto",
       background: "opaque",
       outputFormat: "webp",
@@ -780,7 +781,7 @@ describe("POST /api/zero/image-io/generate", () => {
       model: IMAGE_IO_MODEL,
       prompt: "a small robot painting a sunflower",
       n: 1,
-      size: "2048x1152",
+      size: "1024x1024",
       quality: "auto",
       background: "opaque",
       output_format: "webp",
@@ -842,7 +843,7 @@ describe("POST /api/zero/image-io/generate", () => {
     expect(uploadRows[0]?.metadata).toMatchObject({
       generatedBy: "zero-official-image",
       model: IMAGE_IO_MODEL,
-      imageSize: "2048x1152",
+      imageSize: "1024x1024",
       quality: "auto",
       background: "opaque",
       outputFormat: "webp",

--- a/turbo/apps/api/src/signals/services/zero-image-io-generate.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-image-io-generate.service.ts
@@ -21,7 +21,7 @@ import {
 export const OPENAI_IMAGE_GENERATION_URL =
   "https://api.openai.com/v1/images/generations";
 const FAL_IMAGE_RUN_URL_PREFIX = "https://fal.run";
-export const IMAGE_IO_MODEL = "gpt-image-2";
+export const IMAGE_IO_MODEL = "gpt-image-1";
 const IMAGE_IO_MAX_PROMPT_LENGTH = 32_000;
 const IMAGE_IO_MIN_PIXELS = 655_360;
 const IMAGE_IO_MAX_PIXELS = 8_294_400;

--- a/turbo/apps/cli/src/commands/zero/built-in/generate/__tests__/image.test.ts
+++ b/turbo/apps/cli/src/commands/zero/built-in/generate/__tests__/image.test.ts
@@ -24,7 +24,7 @@ const IMAGE_RESULT = {
   size: 19,
   url: "http://localhost:3000/f/user-1/image-file-id/image-image-fi.png",
   creditsCharged: 65,
-  model: "gpt-image-2",
+  model: "gpt-image-1",
   provider: "openai",
   imageSize: "1024x1024",
   quality: "medium",
@@ -71,7 +71,7 @@ describe("zero built-in generate image command", () => {
 
         return HttpResponse.json({
           ...IMAGE_RESULT,
-          imageSize: "2048x1152",
+          imageSize: "1024x1024",
           quality: "auto",
           background: "opaque",
           outputFormat: "webp",
@@ -88,8 +88,6 @@ describe("zero built-in generate image command", () => {
       "image",
       "--prompt",
       "A watercolor fox",
-      "--size",
-      "2048x1152",
       "--quality",
       "auto",
       "--background",
@@ -104,8 +102,8 @@ describe("zero built-in generate image command", () => {
 
     expect(capturedBody).toEqual({
       prompt: "A watercolor fox",
-      model: "gpt-image-2",
-      size: "2048x1152",
+      model: "gpt-image-1",
+      size: "1024x1024",
       quality: "auto",
       background: "opaque",
       outputFormat: "webp",
@@ -116,13 +114,13 @@ describe("zero built-in generate image command", () => {
     const stdout = mockConsoleLog.mock.calls.flat().join("\n");
     expect(stdout).toContain(`Image generated: ${IMAGE_RESULT.url}`);
     expect(stdout).toContain(`File: ${IMAGE_RESULT.filename}`);
-    expect(stdout).toContain("Size: 2048x1152");
+    expect(stdout).toContain("Size: 1024x1024");
     expect(stdout).toContain("Quality: auto");
     expect(stdout).toContain("Format: webp");
     expect(stdout).toContain("Compression: 50");
     expect(stdout).toContain("Moderation: low");
     expect(stdout).toContain("Credits charged: 65");
-    expect(stdout).toContain("Model: gpt-image-2");
+    expect(stdout).toContain("Model: gpt-image-1");
     expect(stdout).toContain("Provider: openai");
   });
 
@@ -209,7 +207,7 @@ describe("zero built-in generate image command", () => {
       size: IMAGE_RESULT.size,
       url: IMAGE_RESULT.url,
       creditsCharged: 65,
-      model: "gpt-image-2",
+      model: IMAGE_RESULT.model,
       provider: "openai",
       imageSize: "1024x1024",
       quality: "medium",
@@ -283,6 +281,7 @@ describe("zero built-in generate image command", () => {
     imageCommand.outputHelp();
 
     expect(helpOutput).toContain("gpt-image-1.5");
+    expect(helpOutput).toContain("gpt-image-1 (default)");
     expect(helpOutput).toContain("flux-pro-1.1");
     expect(helpOutput).toContain("qwen-image");
     expect(helpOutput).toContain("support varies");

--- a/turbo/apps/cli/src/commands/zero/built-in/generate/__tests__/presentation.test.ts
+++ b/turbo/apps/cli/src/commands/zero/built-in/generate/__tests__/presentation.test.ts
@@ -12,6 +12,7 @@ import { http, HttpResponse } from "msw";
 import chalk from "chalk";
 import { server } from "../../../../../mocks/server";
 import { zeroBuiltInCommand } from "../../index";
+import { presentationCommand } from "../presentation";
 
 const PRESENTATION_URL =
   "http://localhost:3000/api/zero/presentation-io/generate";
@@ -213,6 +214,20 @@ describe("zero built-in generate presentation command", () => {
       textCreditsCharged: 24,
       title: "API Migration Plan",
     });
+  });
+
+  it("should describe the default image model in help", () => {
+    let helpOutput = "";
+    presentationCommand.configureOutput({
+      writeOut: (str: string) => {
+        helpOutput += str;
+      },
+    });
+
+    presentationCommand.outputHelp();
+
+    expect(helpOutput).toContain("Image model for generated visuals (default:");
+    expect(helpOutput).toContain("gpt-image-1): gpt-image-2");
   });
 
   it("should surface API errors", async () => {

--- a/turbo/apps/cli/src/commands/zero/doctor/__tests__/generate.test.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/__tests__/generate.test.ts
@@ -114,7 +114,7 @@ describe("zero doctor generate command", () => {
     expect(text).toContain("vm0");
     expect(text).toContain("Built-in image generation");
     expect(text).toContain(
-      "Models: OpenAI: gpt-image-2, gpt-image-1.5, gpt-image-1, gpt-image-1-mini; fal.ai: flux-pro-1.1, flux-pro-1.1-ultra, qwen-image, seedream4",
+      "Models: OpenAI: gpt-image-1 (default), gpt-image-2, gpt-image-1.5, gpt-image-1-mini; fal.ai: flux-pro-1.1, flux-pro-1.1-ultra, qwen-image, seedream4",
     );
     expect(text).toContain("Use: zero built-in generate image -h");
     expect(text).not.toContain("Use: zero built-in generate image --model");
@@ -192,8 +192,8 @@ describe("zero doctor generate command", () => {
     expect(json).toMatchObject({
       builtInProvider: {
         label: "Built-in OpenAI",
-        model: "gpt-image-2",
-        command: "zero built-in generate image --model gpt-image-2 -h",
+        model: "gpt-image-1",
+        command: "zero built-in generate image --model gpt-image-1 -h",
       },
     });
     expect(json).toMatchObject({

--- a/turbo/apps/cli/src/commands/zero/doctor/generate.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/generate.ts
@@ -34,6 +34,12 @@ const BUILT_IN_GENERATION_PROVIDERS: Partial<
   image: [
     {
       label: "Built-in OpenAI",
+      model: "gpt-image-1",
+      command: "zero built-in generate image --model gpt-image-1 -h",
+      reason: "available without connector setup",
+    },
+    {
+      label: "Built-in OpenAI",
       model: "gpt-image-2",
       command: "zero built-in generate image --model gpt-image-2 -h",
       reason: "available without connector setup",
@@ -42,12 +48,6 @@ const BUILT_IN_GENERATION_PROVIDERS: Partial<
       label: "Built-in OpenAI",
       model: "gpt-image-1.5",
       command: "zero built-in generate image --model gpt-image-1.5 -h",
-      reason: "available without connector setup",
-    },
-    {
-      label: "Built-in OpenAI",
-      model: "gpt-image-1",
-      command: "zero built-in generate image --model gpt-image-1 -h",
       reason: "available without connector setup",
     },
     {
@@ -144,7 +144,7 @@ const BUILT_IN_GENERATION_COMMANDS: Partial<
     label: "Built-in image generation",
     command: "zero built-in generate image -h",
     models:
-      "OpenAI: gpt-image-2, gpt-image-1.5, gpt-image-1, gpt-image-1-mini; fal.ai: flux-pro-1.1, flux-pro-1.1-ultra, qwen-image, seedream4",
+      "OpenAI: gpt-image-1 (default), gpt-image-2, gpt-image-1.5, gpt-image-1-mini; fal.ai: flux-pro-1.1, flux-pro-1.1-ultra, qwen-image, seedream4",
   },
   video: {
     label: "Built-in video generation",

--- a/turbo/apps/cli/src/commands/zero/shared/image-generate.ts
+++ b/turbo/apps/cli/src/commands/zero/shared/image-generate.ts
@@ -72,8 +72,8 @@ export function createImageGenerateCommand(
     .option("--prompt <text>", "Image prompt; can also be piped via stdin")
     .option(
       "--model <model>",
-      "Model: gpt-image-2, gpt-image-1.5, gpt-image-1, gpt-image-1-mini, flux-pro-1.1, flux-pro-1.1-ultra, qwen-image, or seedream4",
-      "gpt-image-2",
+      "Model: gpt-image-1 (default), gpt-image-2, gpt-image-1.5, gpt-image-1-mini, flux-pro-1.1, flux-pro-1.1-ultra, qwen-image, or seedream4",
+      "gpt-image-1",
     )
     .option(
       "--size <size>",
@@ -116,7 +116,7 @@ Notes:
   - Uses OpenAI for GPT Image models and fal.ai for non-OpenAI models
 
 Models:
-  - OpenAI: gpt-image-2 (default), gpt-image-1.5, gpt-image-1,
+  - OpenAI: gpt-image-1 (default), gpt-image-2, gpt-image-1.5,
     gpt-image-1-mini. OpenAI generations bill returned text/image/output
     token usage.
   - fal.ai: flux-pro-1.1, flux-pro-1.1-ultra, qwen-image, seedream4.

--- a/turbo/apps/cli/src/commands/zero/shared/presentation-generate.ts
+++ b/turbo/apps/cli/src/commands/zero/shared/presentation-generate.ts
@@ -91,7 +91,7 @@ export function createPresentationGenerateCommand(
     )
     .option(
       "--image-model <model>",
-      "Image model for generated visuals: gpt-image-2, gpt-image-1.5, gpt-image-1, gpt-image-1-mini, flux-pro-1.1, flux-pro-1.1-ultra, qwen-image, or seedream4",
+      "Image model for generated visuals (default: gpt-image-1): gpt-image-2, gpt-image-1.5, gpt-image-1, gpt-image-1-mini, flux-pro-1.1, flux-pro-1.1-ultra, qwen-image, or seedream4",
     )
     .option(
       "--theme <theme>",

--- a/turbo/apps/web/app/api/zero/image-io/generate/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/image-io/generate/__tests__/route.test.ts
@@ -35,7 +35,7 @@ const IMAGE_URL = "http://localhost:3000/api/zero/image-io/generate";
 const OPENAI_IMAGE_URL = "https://api.openai.com/v1/images/generations";
 const FAL_QWEN_IMAGE_URL = "https://fal.run/fal-ai/qwen-image";
 const FAL_MEDIA_URL = "https://fal.media/files/test/qwen.jpg";
-const MODEL = "gpt-image-2";
+const MODEL = "gpt-image-1";
 const IMAGE_BYTES = Buffer.from("fake image bytes");
 
 type ImageResponse = {
@@ -187,6 +187,7 @@ describe("POST /api/zero/image-io/generate", () => {
     const response = await POST(
       imageRequest({
         prompt: "a transparent badge",
+        model: "gpt-image-2",
         background: "transparent",
         outputFormat: "webp",
       }),
@@ -251,7 +252,7 @@ describe("POST /api/zero/image-io/generate", () => {
           model: MODEL,
           prompt: "a small robot painting a sunflower",
           n: 1,
-          size: "2048x1152",
+          size: "1024x1024",
           quality: "auto",
           background: "opaque",
           output_format: "webp",
@@ -268,7 +269,7 @@ describe("POST /api/zero/image-io/generate", () => {
             },
           ],
           output_format: "webp",
-          size: "2048x1152",
+          size: "1024x1024",
           quality: "auto",
           background: "opaque",
           usage: {
@@ -288,7 +289,7 @@ describe("POST /api/zero/image-io/generate", () => {
       imageRequest(
         {
           prompt: "a small robot painting a sunflower",
-          size: "2048x1152",
+          size: "1024x1024",
           quality: "auto",
           background: "opaque",
           outputFormat: "webp",
@@ -308,7 +309,7 @@ describe("POST /api/zero/image-io/generate", () => {
       creditsCharged: 78,
       model: MODEL,
       provider: "openai",
-      imageSize: "2048x1152",
+      imageSize: "1024x1024",
       quality: "auto",
       background: "opaque",
       outputFormat: "webp",
@@ -351,7 +352,7 @@ describe("POST /api/zero/image-io/generate", () => {
         model: MODEL,
         provider: "openai",
         s3Key: `uploads/${userId}/${body.id}/${body.filename}`,
-        imageSize: "2048x1152",
+        imageSize: "1024x1024",
         quality: "auto",
         background: "opaque",
         outputFormat: "webp",

--- a/turbo/apps/web/app/api/zero/image-io/generate/route.ts
+++ b/turbo/apps/web/app/api/zero/image-io/generate/route.ts
@@ -25,7 +25,7 @@ const log = logger("api:zero:image-io:generate");
 
 const OPENAI_IMAGE_URL = "https://api.openai.com/v1/images/generations";
 const FAL_IMAGE_RUN_URL_PREFIX = "https://fal.run";
-const DEFAULT_MODEL = "gpt-image-2";
+const DEFAULT_MODEL = "gpt-image-1";
 const USAGE_KIND = "image";
 const TEXT_INPUT_CATEGORY = "tokens.input.text";
 const IMAGE_INPUT_CATEGORY = "tokens.input.image";


### PR DESCRIPTION
## Summary
- change built-in image generation defaults to `gpt-image-1` in API, web compatibility route, CLI help, and doctor output
- show the presentation `--image-model` default in CLI help
- keep the existing `built-in` command spelling unchanged

## Tests
- `pnpm -F @vm0/cli exec vitest run src/commands/zero/built-in/generate/__tests__/image.test.ts src/commands/zero/built-in/generate/__tests__/presentation.test.ts src/commands/zero/doctor/__tests__/generate.test.ts`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-image-io-generate.test.ts`
- `pnpm -F web exec vitest run app/api/zero/image-io/generate/__tests__/route.test.ts`
- pre-commit hook: prettier, knip --cache, full `pnpm check-types`