### PR TITLE
test: avoid overwriting restored image pricing

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-image-io-generate.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-image-io-generate.test.ts
@@ -329,13 +329,8 @@ async function restoreImagePricingRows(
         };
       }),
     )
-    .onConflictDoUpdate({
+    .onConflictDoNothing({
       target: [usagePricing.kind, usagePricing.provider, usagePricing.category],
-      set: {
-        unitPrice: sql`excluded.unit_price`,
-        unitSize: sql`excluded.unit_size`,
-        updatedAt: sql`now()`,
-      },
     });
 }
 


### PR DESCRIPTION
## Summary
- make image pricing test cleanup insert missing rows without overwriting existing rows
- keep concurrent pricing seeders from having their unit price or updatedAt reset during cleanup

## Testing
- pnpm --filter api test src/signals/routes/__tests__/zero-image-io-generate.test.ts src/signals/routes/__tests__/zero-presentation-io-generate.test.ts
- pnpm --filter api exec tsc --noEmit --pretty false
- pnpm --filter api lint