### PR TITLE
refactor(guest-agent): extract CLI event delivery state

### DIFF
--- a/crates/guest-agent/src/cli/event_delivery.rs
+++ b/crates/guest-agent/src/cli/event_delivery.rs
@@ -1,0 +1,89 @@
+//! CLI stdout event delivery state.
+//!
+//! Event schema transformation and HTTP posting stay in `events`; this module
+//! only owns execution-delivery state consumed by `execute_cli`.
+
+pub(super) struct PreparedEvent {
+    pub(super) sequence: u32,
+    pub(super) payload: serde_json::Value,
+}
+
+#[derive(Default)]
+pub(super) struct AckedEventPrefix {
+    next_expected: u32,
+    last_contiguous: Option<u32>,
+    prefix_broken: bool,
+}
+
+impl AckedEventPrefix {
+    pub(super) fn record_success(&mut self, sequence: u32) {
+        if self.prefix_broken {
+            return;
+        }
+
+        if sequence == self.next_expected {
+            self.last_contiguous = Some(sequence);
+            self.next_expected = sequence.saturating_add(1);
+        } else if sequence > self.next_expected {
+            self.prefix_broken = true;
+        }
+    }
+
+    pub(super) fn record_failure(&mut self, sequence: u32) {
+        if sequence >= self.next_expected {
+            self.prefix_broken = true;
+        }
+    }
+
+    pub(super) fn last_contiguous(&self) -> Option<u32> {
+        self.last_contiguous
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn acked_event_prefix_advances_on_contiguous_successes() {
+        let mut prefix = AckedEventPrefix::default();
+
+        prefix.record_success(0);
+        prefix.record_success(1);
+        prefix.record_success(2);
+
+        assert_eq!(prefix.last_contiguous(), Some(2));
+    }
+
+    #[test]
+    fn acked_event_prefix_stops_at_first_failed_event() {
+        let mut prefix = AckedEventPrefix::default();
+
+        prefix.record_success(0);
+        prefix.record_failure(1);
+        prefix.record_success(2);
+
+        assert_eq!(prefix.last_contiguous(), Some(0));
+    }
+
+    #[test]
+    fn acked_event_prefix_has_no_watermark_when_first_event_fails() {
+        let mut prefix = AckedEventPrefix::default();
+
+        prefix.record_failure(0);
+        prefix.record_success(1);
+
+        assert_eq!(prefix.last_contiguous(), None);
+    }
+
+    #[test]
+    fn acked_event_prefix_rejects_success_gap() {
+        let mut prefix = AckedEventPrefix::default();
+
+        prefix.record_success(0);
+        prefix.record_success(2);
+        prefix.record_success(3);
+
+        assert_eq!(prefix.last_contiguous(), Some(0));
+    }
+}

--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -2,6 +2,7 @@
 
 mod command;
 mod diagnostics;
+mod event_delivery;
 
 pub use command::build_cli_command;
 
@@ -13,6 +14,7 @@ use crate::http::HttpClient;
 use crate::masker::SecretMasker;
 use crate::paths;
 use crate::timing;
+use event_delivery::{AckedEventPrefix, PreparedEvent};
 use guest_common::telemetry::record_sandbox_op;
 use guest_common::{log_info, log_warn};
 use std::collections::HashMap;
@@ -228,43 +230,6 @@ fn setup_codex_chatgpt() -> Result<(), AgentError> {
         log_info!(LOG_TAG, "Codex ChatGPT-OAuth auth.json written");
     }
     result
-}
-
-struct PreparedEvent {
-    sequence: u32,
-    payload: serde_json::Value,
-}
-
-#[derive(Default)]
-struct AckedEventPrefix {
-    next_expected: u32,
-    last_contiguous: Option<u32>,
-    prefix_broken: bool,
-}
-
-impl AckedEventPrefix {
-    fn record_success(&mut self, sequence: u32) {
-        if self.prefix_broken {
-            return;
-        }
-
-        if sequence == self.next_expected {
-            self.last_contiguous = Some(sequence);
-            self.next_expected = sequence.saturating_add(1);
-        } else if sequence > self.next_expected {
-            self.prefix_broken = true;
-        }
-    }
-
-    fn record_failure(&mut self, sequence: u32) {
-        if sequence >= self.next_expected {
-            self.prefix_broken = true;
-        }
-    }
-
-    fn last_contiguous(&self) -> Option<u32> {
-        self.last_contiguous
-    }
 }
 
 /// Summary of Claude Code's terminal `type=result` event.
@@ -922,53 +887,6 @@ mod tests {
         CliFrameworkBehavior::new(env::Framework::ClaudeCode)
             .track_claude_tool_events(&tool_result, &mut tracker);
         assert!(tracker.is_empty());
-    }
-
-    // -----------------------------------------------------------------
-    // AckedEventPrefix
-    // -----------------------------------------------------------------
-
-    #[test]
-    fn acked_event_prefix_advances_on_contiguous_successes() {
-        let mut prefix = AckedEventPrefix::default();
-
-        prefix.record_success(0);
-        prefix.record_success(1);
-        prefix.record_success(2);
-
-        assert_eq!(prefix.last_contiguous(), Some(2));
-    }
-
-    #[test]
-    fn acked_event_prefix_stops_at_first_failed_event() {
-        let mut prefix = AckedEventPrefix::default();
-
-        prefix.record_success(0);
-        prefix.record_failure(1);
-        prefix.record_success(2);
-
-        assert_eq!(prefix.last_contiguous(), Some(0));
-    }
-
-    #[test]
-    fn acked_event_prefix_has_no_watermark_when_first_event_fails() {
-        let mut prefix = AckedEventPrefix::default();
-
-        prefix.record_failure(0);
-        prefix.record_success(1);
-
-        assert_eq!(prefix.last_contiguous(), None);
-    }
-
-    #[test]
-    fn acked_event_prefix_rejects_success_gap() {
-        let mut prefix = AckedEventPrefix::default();
-
-        prefix.record_success(0);
-        prefix.record_success(2);
-        prefix.record_success(3);
-
-        assert_eq!(prefix.last_contiguous(), Some(0));
     }
 
     // -----------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Extract CLI event delivery state into `crates/guest-agent/src/cli/event_delivery.rs`
- Move `PreparedEvent`, `AckedEventPrefix`, and ACK watermark tests with the state they cover
- Keep event schema transformation/posting in `events.rs` and leave sender close/await/abort ordering unchanged

Closes #13449
Parent #13382

## Verification
- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `cargo test --manifest-path crates/Cargo.toml --target-dir /tmp/vm4-guest-agent-13449-target -p guest-agent acked_event_prefix`
- `cargo test --manifest-path crates/Cargo.toml --target-dir /tmp/vm4-guest-agent-13449-target -p guest-agent --test no_api_mode`
- `cargo test --manifest-path crates/Cargo.toml --target-dir /tmp/vm4-guest-agent-13449-target -p guest-agent --test codex_jsonl_failure_logging`
- `cargo test --manifest-path crates/Cargo.toml --target-dir /tmp/vm4-guest-agent-13449-target -p guest-agent`
- `cargo clippy --manifest-path crates/Cargo.toml --target-dir /tmp/vm4-guest-agent-13449-target -p guest-agent --all-targets -- -D warnings`
- `cd crates && CARGO_BUILD_JOBS=1 cargo clippy --all-targets --all-features`
- `cd crates && CARGO_BUILD_JOBS=1 cargo doc --workspace --all-features --no-deps`