### PR TITLE
fix: add missing run in host-worker deploy pnpm command

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -622,7 +622,7 @@ jobs:
             echo "::error::CF_ACCOUNT_ID must be configured as a GitHub Actions variable or secret"
             exit 1
           fi
-          CLOUDFLARE_API_TOKEN="$CF_ZERO_HOST_WORKER_DEPLOY_API_TOKEN" pnpm -F @vm0/host-worker deploy
+          CLOUDFLARE_API_TOKEN="$CF_ZERO_HOST_WORKER_DEPLOY_API_TOKEN" pnpm -F @vm0/host-worker run deploy
 
       - name: Calculate duration
         id: duration


### PR DESCRIPTION
## Summary

`release-please.yml` was running `pnpm -F @vm0/host-worker deploy`, which pnpm interprets as its built-in `pnpm deploy` command (requires a target directory parameter) instead of running the package's `deploy` script.

## Root Cause

`pnpm deploy` is a built-in pnpm command for pruning workspace packages to a target directory. The workflow intended to execute `@vm0/host-worker`'s `deploy` script (which calls `wrangler deploy`), but missing `run` caused:

```
ERR_PNPM_INVALID_DEPLOY_TARGET This command requires one parameter
```

## Fix

Add `run` so pnpm executes the package script instead of the built-in command:

```diff
- CLOUDFLARE_API_TOKEN="..." pnpm -F @vm0/host-worker deploy
+ CLOUDFLARE_API_TOKEN="..." pnpm -F @vm0/host-worker run deploy
```

## Test plan

- [ ] Verify `deploy-host-worker-production` job passes in CI after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)