### PR TITLE
feat: add spawn process control plane

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -3653,6 +3653,7 @@ dependencies = [
  "nix",
  "tokio",
  "tracing",
+ "uuid",
  "vsock-proto",
 ]
 

--- a/crates/vsock-guest/src/connection.rs
+++ b/crates/vsock-guest/src/connection.rs
@@ -277,19 +277,14 @@ fn handle_connection_with_outcome(stream: UnixStream) -> io::Result<ConnectionEn
                 else {
                     continue;
                 };
-                let process_control_guard = match d.control_nonce {
-                    Some(nonce) => match process_control_registry.register(msg.seq, nonce) {
-                        Ok(guard) => Some(guard),
-                        Err(()) => {
-                            send_error_response(
-                                msg.seq,
-                                "process operation already active",
-                                &writer,
-                            )?;
-                            continue;
-                        }
-                    },
-                    None => None,
+                let process_control_guard = match process_control_registry
+                    .register(msg.seq, d.control_nonce)
+                {
+                    Ok(guard) => Some(guard),
+                    Err(()) => {
+                        send_error_response(msg.seq, "process operation already active", &writer)?;
+                        continue;
+                    }
                 };
                 // handle_spawn_process writes the response itself (before
                 // spawning the streaming thread) to prevent a race where

--- a/crates/vsock-guest/src/connection.rs
+++ b/crates/vsock-guest/src/connection.rs
@@ -273,9 +273,20 @@ fn handle_connection_with_outcome(stream: UnixStream) -> io::Result<ConnectionEn
                 else {
                     continue;
                 };
-                let process_control_guard = d
-                    .control_nonce
-                    .map(|nonce| process_control_registry.register(msg.seq, nonce));
+                let process_control_guard = match d.control_nonce {
+                    Some(nonce) => match process_control_registry.register(msg.seq, nonce) {
+                        Ok(guard) => Some(guard),
+                        Err(()) => {
+                            send_error_response(
+                                msg.seq,
+                                "process operation already active",
+                                &writer,
+                            )?;
+                            continue;
+                        }
+                    },
+                    None => None,
+                };
                 // handle_spawn_process writes the response itself (before
                 // spawning the streaming thread) to prevent a race where
                 // stdout chunks could arrive at the host before the result.

--- a/crates/vsock-guest/src/connection.rs
+++ b/crates/vsock-guest/src/connection.rs
@@ -264,6 +264,10 @@ fn handle_connection_with_outcome(stream: UnixStream) -> io::Result<ConnectionEn
                 vsock_proto::decode_exec_cancel(&msg.payload).map_err(to_io_error)?;
                 cancel_exec_operation(&exec_operation_registry, msg.seq);
             } else if msg.msg_type == MSG_SPAWN_PROCESS {
+                if msg.seq == 0 {
+                    send_error_response(0, "spawn process requires non-zero sequence", &writer)?;
+                    continue;
+                }
                 if reject_operation_if_quiescing(&operation_state, msg.seq, &writer)? {
                     continue;
                 }
@@ -306,6 +310,10 @@ fn handle_connection_with_outcome(stream: UnixStream) -> io::Result<ConnectionEn
                     connection_cancel.clone(),
                 )?;
             } else if msg.msg_type == MSG_PROCESS_CONTROL {
+                if msg.seq == 0 {
+                    send_error_response(0, "process control requires non-zero sequence", &writer)?;
+                    continue;
+                }
                 handle_process_control(msg.seq, &msg.payload, &process_control_registry, &writer)?;
             } else if msg.msg_type == MSG_WRITE_FILE {
                 if reject_operation_if_quiescing(&operation_state, msg.seq, &writer)? {

--- a/crates/vsock-guest/src/connection.rs
+++ b/crates/vsock-guest/src/connection.rs
@@ -7,7 +7,8 @@ use std::time::Duration;
 
 use vsock_proto::{
     self, MSG_EXEC_CANCEL, MSG_EXEC_START, MSG_OPERATIONS_QUIESCED, MSG_OPERATIONS_RESUMED,
-    MSG_QUIESCE_OPERATIONS, MSG_READY, MSG_RESUME_OPERATIONS, MSG_SPAWN_PROCESS, MSG_WRITE_FILE,
+    MSG_PROCESS_CONTROL, MSG_QUIESCE_OPERATIONS, MSG_READY, MSG_RESUME_OPERATIONS,
+    MSG_SPAWN_PROCESS, MSG_WRITE_FILE,
 };
 
 use crate::error::to_io_error;
@@ -20,6 +21,7 @@ use crate::handlers::{
 };
 use crate::log::log;
 use crate::monitor::{SpawnProcessRequest, handle_spawn_process};
+use crate::process_control::{ProcessControlRegistry, handle_process_control};
 use crate::quiesce::{AcquireOperationError, OperationGuard, OperationState, QuiesceResult};
 use crate::writer::GuestWriter;
 
@@ -204,6 +206,7 @@ fn handle_connection_with_outcome(stream: UnixStream) -> io::Result<ConnectionEn
     let connection_cancel = Arc::new(AtomicBool::new(false));
     let _cancel_on_drop = ConnectionCancelGuard(connection_cancel.clone());
     let exec_operation_registry = ExecOperationRegistry::default();
+    let process_control_registry = ProcessControlRegistry::default();
     let operation_state = OperationState::default();
 
     let mut decoder = vsock_proto::Decoder::new();
@@ -270,6 +273,9 @@ fn handle_connection_with_outcome(stream: UnixStream) -> io::Result<ConnectionEn
                 else {
                     continue;
                 };
+                let process_control_guard = d
+                    .control_nonce
+                    .map(|nonce| process_control_registry.register(msg.seq, nonce));
                 // handle_spawn_process writes the response itself (before
                 // spawning the streaming thread) to prevent a race where
                 // stdout chunks could arrive at the host before the result.
@@ -281,12 +287,15 @@ fn handle_connection_with_outcome(stream: UnixStream) -> io::Result<ConnectionEn
                         sudo: d.sudo,
                         stream_stdout: d.stream_stdout,
                         stdout_log_path: d.stdout_log_path,
+                        process_control_guard,
                     },
                     msg.seq,
                     operation_guard,
                     writer.clone(),
                     connection_cancel.clone(),
                 )?;
+            } else if msg.msg_type == MSG_PROCESS_CONTROL {
+                handle_process_control(msg.seq, &msg.payload, &process_control_registry, &writer)?;
             } else if msg.msg_type == MSG_WRITE_FILE {
                 if reject_operation_if_quiescing(&operation_state, msg.seq, &writer)? {
                     continue;

--- a/crates/vsock-guest/src/lib.rs
+++ b/crates/vsock-guest/src/lib.rs
@@ -14,6 +14,7 @@ mod handlers;
 mod log;
 mod monitor;
 mod process;
+mod process_control;
 mod quiesce;
 mod shell_command;
 mod shutdown;

--- a/crates/vsock-guest/src/monitor.rs
+++ b/crates/vsock-guest/src/monitor.rs
@@ -647,8 +647,24 @@ fn send_process_exit_after_lock<F>(
     let exit_msg = match vsock_proto::encode(MSG_PROCESS_EXIT, seq, &payload) {
         Ok(msg) => msg,
         Err(e) => {
-            log("ERROR", &format!("Failed to encode process_exit: {}", e));
-            return;
+            log(
+                "ERROR",
+                &format!("Failed to encode process_exit, sending fallback: {}", e),
+            );
+            let diagnostic = format!("process_exit output exceeded protocol limit: {e}");
+            let fallback_payload =
+                vsock_proto::encode_process_exit(pid, 1, &[], diagnostic.as_bytes());
+            match vsock_proto::encode(MSG_PROCESS_EXIT, seq, &fallback_payload) {
+                Ok(msg) => msg,
+                Err(fallback_error) => {
+                    log(
+                        "ERROR",
+                        &format!("Failed to encode fallback process_exit: {fallback_error}"),
+                    );
+                    after_lock();
+                    return;
+                }
+            }
         }
     };
     if let Err(e) = writer.write_frame_after_lock(&exit_msg, after_lock) {
@@ -688,6 +704,36 @@ mod tests {
 
     fn operation_guard() -> OperationGuard {
         crate::quiesce::OperationState::default().acquire().unwrap()
+    }
+
+    #[test]
+    fn oversized_process_exit_sends_fallback_and_releases_operation() {
+        let (guest, mut host) = UnixStream::pair().unwrap();
+        host.set_read_timeout(Some(Duration::from_secs(3))).unwrap();
+        let writer = GuestWriter::new(guest);
+        let operation_state = crate::quiesce::OperationState::default();
+        let operation_guard = operation_state.acquire().unwrap();
+        let stdout = vec![0u8; vsock_proto::MAX_MESSAGE_SIZE];
+
+        send_process_exit_after_lock(7, 123, 0, &stdout, &[], &writer, || {
+            operation_guard.release();
+        });
+
+        assert_eq!(operation_state.pending(), 0);
+
+        let exit = read_message(&mut host);
+        assert_eq!(exit.msg_type, MSG_PROCESS_EXIT);
+        assert_eq!(exit.seq, 7);
+        let (pid, code, fallback_stdout, fallback_stderr) =
+            vsock_proto::decode_process_exit(&exit.payload).unwrap();
+        assert_eq!(pid, 123);
+        assert_eq!(code, 1);
+        assert!(fallback_stdout.is_empty());
+        assert!(
+            String::from_utf8_lossy(fallback_stderr).contains("protocol limit"),
+            "unexpected stderr: {:?}",
+            String::from_utf8_lossy(fallback_stderr),
+        );
     }
 
     #[test]

--- a/crates/vsock-guest/src/monitor.rs
+++ b/crates/vsock-guest/src/monitor.rs
@@ -736,7 +736,8 @@ mod tests {
         const NONCE: vsock_proto::ProcessControlNonce = *b"0123456789abcdef";
 
         let registry = ProcessControlRegistry::default();
-        let guard_slot = new_process_control_guard_slot(Some(registry.register(7, NONCE).unwrap()));
+        let guard_slot =
+            new_process_control_guard_slot(Some(registry.register(7, Some(NONCE)).unwrap()));
         let task_guard_slot = guard_slot.clone();
 
         let result = FailingThreadSpawner::fail_once("test-monitor").spawn_unit(

--- a/crates/vsock-guest/src/monitor.rs
+++ b/crates/vsock-guest/src/monitor.rs
@@ -1,7 +1,7 @@
 use std::io::{self, Write};
 use std::process::{Child, ChildStdout};
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
 use std::thread::JoinHandle;
 
 use vsock_proto::{self, MSG_ERROR, MSG_PROCESS_EXIT, MSG_SPAWN_PROCESS_RESULT, MSG_STDOUT_CHUNK};
@@ -79,6 +79,22 @@ pub(crate) struct SpawnProcessRequest<'a> {
     pub(crate) process_control_guard: Option<ProcessControlGuard>,
 }
 
+type ProcessControlGuardSlot = Arc<Mutex<Option<ProcessControlGuard>>>;
+
+fn new_process_control_guard_slot(guard: Option<ProcessControlGuard>) -> ProcessControlGuardSlot {
+    Arc::new(Mutex::new(guard))
+}
+
+fn take_process_control_guard(slot: &ProcessControlGuardSlot) -> Option<ProcessControlGuard> {
+    slot.lock().unwrap_or_else(|e| e.into_inner()).take()
+}
+
+fn release_process_control_guard(guard: Option<ProcessControlGuard>) {
+    if let Some(guard) = guard {
+        guard.release();
+    }
+}
+
 /// Handle spawn_process: spawn the child, write `MSG_SPAWN_PROCESS_RESULT` over
 /// the wire, THEN start the background monitor. Returns immediately; exit is
 /// later reported via `MSG_PROCESS_EXIT`.
@@ -149,9 +165,7 @@ where
             ));
             let response = vsock_proto::encode(MSG_ERROR, seq, &payload).map_err(to_io_error)?;
             let result = writer.write_frame_after_lock(&response, || {
-                if let Some(guard) = process_control_guard {
-                    guard.release();
-                }
+                release_process_control_guard(process_control_guard);
                 operation_guard.release();
             });
             result?;
@@ -180,18 +194,14 @@ where
         Ok(r) => r,
         Err(e) => {
             kill_and_reap_child(child);
-            if let Some(guard) = process_control_guard {
-                guard.release();
-            }
+            release_process_control_guard(process_control_guard);
             operation_guard.release();
             return Err(to_io_error(e));
         }
     };
     if let Err(e) = writer.write_frame(&response) {
         kill_and_reap_child(child);
-        if let Some(guard) = process_control_guard {
-            guard.release();
-        }
+        release_process_control_guard(process_control_guard);
         operation_guard.release();
         return Err(e);
     }
@@ -285,14 +295,20 @@ where
     let monitor_spawner = spawner.clone();
     let exit_writer = writer.clone();
     let monitor_operation_guard = operation_guard.clone();
+    let process_control_guard_slot = new_process_control_guard_slot(process_control_guard);
+    let monitor_process_control_guard_slot = process_control_guard_slot.clone();
     let result = spawner.spawn_unit(
         THREAD_STREAM_MONITOR,
         Box::new(move || {
+            let process_control_guard =
+                take_process_control_guard(&monitor_process_control_guard_slot);
             let Some(child) = child_guard.into_child() else {
                 log(
                     "ERROR",
                     "spawn_process: streaming monitor child guard was empty",
                 );
+                release_process_control_guard(process_control_guard);
+                monitor_operation_guard.release();
                 return;
             };
             run_streaming_monitor(
@@ -314,6 +330,7 @@ where
         }),
     );
     if let Err(e) = &result {
+        let process_control_guard = take_process_control_guard(&process_control_guard_slot);
         send_process_exit_after_lock(
             seq,
             pid,
@@ -321,7 +338,10 @@ where
             &[],
             format!("Failed to spawn streaming monitor thread: {e}").as_bytes(),
             &exit_writer,
-            || operation_guard.release(),
+            || {
+                release_process_control_guard(process_control_guard);
+                operation_guard.release();
+            },
         );
     }
     result.map(|_| ())
@@ -518,9 +538,7 @@ where
     );
 
     send_process_exit_after_lock(seq, pid, exit_code, &[], &stderr, &writer, || {
-        if let Some(guard) = process_control_guard {
-            guard.release();
-        }
+        release_process_control_guard(process_control_guard);
         operation_guard.release();
     });
 }
@@ -551,9 +569,7 @@ fn finish_streaming_setup_failure(failure: StreamingSetupFailure) {
         let _ = handle.join();
     }
     send_process_exit_after_lock(seq, pid, 1, &[], error.as_bytes(), &writer, || {
-        if let Some(guard) = process_control_guard {
-            guard.release();
-        }
+        release_process_control_guard(process_control_guard);
         operation_guard.release();
     });
 }
@@ -579,14 +595,20 @@ where
     let exit_writer = writer.clone();
     let monitor_spawner = spawner.clone();
     let monitor_operation_guard = operation_guard.clone();
+    let process_control_guard_slot = new_process_control_guard_slot(process_control_guard);
+    let monitor_process_control_guard_slot = process_control_guard_slot.clone();
     let result = spawner.spawn_unit(
         THREAD_BUFFERED_MONITOR,
         Box::new(move || {
+            let process_control_guard =
+                take_process_control_guard(&monitor_process_control_guard_slot);
             let Some(child) = child_guard.into_child() else {
                 log(
                     "ERROR",
                     "spawn_process: buffered monitor child guard was empty",
                 );
+                release_process_control_guard(process_control_guard);
+                monitor_operation_guard.release();
                 return;
             };
             let (outcome, stdout, stderr_buf) =
@@ -610,15 +632,14 @@ where
             );
 
             send_process_exit_after_lock(seq, pid, exit_code, &stdout, &stderr, &writer, || {
-                if let Some(guard) = process_control_guard {
-                    guard.release();
-                }
+                release_process_control_guard(process_control_guard);
                 monitor_operation_guard.release();
             });
             drop(env_script);
         }),
     );
     if let Err(e) = &result {
+        let process_control_guard = take_process_control_guard(&process_control_guard_slot);
         send_process_exit_after_lock(
             seq,
             pid,
@@ -626,7 +647,10 @@ where
             &[],
             format!("Failed to spawn buffered monitor thread: {e}").as_bytes(),
             &exit_writer,
-            || operation_guard.release(),
+            || {
+                release_process_control_guard(process_control_guard);
+                operation_guard.release();
+            },
         );
     }
     result.map(|_| ())
@@ -675,6 +699,7 @@ fn send_process_exit_after_lock<F>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::process_control::ProcessControlRegistry;
     use crate::threading::test_support::FailingThreadSpawner;
     use crate::wait::THREAD_DRAIN_STDOUT;
     use std::io::Read;
@@ -704,6 +729,31 @@ mod tests {
 
     fn operation_guard() -> OperationGuard {
         crate::quiesce::OperationState::default().acquire().unwrap()
+    }
+
+    #[test]
+    fn process_control_guard_slot_survives_dropped_monitor_task() {
+        const NONCE: vsock_proto::ProcessControlNonce = *b"0123456789abcdef";
+
+        let registry = ProcessControlRegistry::default();
+        let guard_slot = new_process_control_guard_slot(Some(registry.register(7, NONCE)));
+        let task_guard_slot = guard_slot.clone();
+
+        let result = FailingThreadSpawner::fail_once("test-monitor").spawn_unit(
+            "test-monitor",
+            Box::new(move || {
+                release_process_control_guard(take_process_control_guard(&task_guard_slot));
+            }),
+        );
+
+        assert!(result.is_err());
+        assert!(
+            registry.contains(7),
+            "dropping an unstarted monitor task must not release process control early",
+        );
+
+        release_process_control_guard(take_process_control_guard(&guard_slot));
+        assert!(!registry.contains(7));
     }
 
     #[test]

--- a/crates/vsock-guest/src/monitor.rs
+++ b/crates/vsock-guest/src/monitor.rs
@@ -736,7 +736,7 @@ mod tests {
         const NONCE: vsock_proto::ProcessControlNonce = *b"0123456789abcdef";
 
         let registry = ProcessControlRegistry::default();
-        let guard_slot = new_process_control_guard_slot(Some(registry.register(7, NONCE)));
+        let guard_slot = new_process_control_guard_slot(Some(registry.register(7, NONCE).unwrap()));
         let task_guard_slot = guard_slot.clone();
 
         let result = FailingThreadSpawner::fail_once("test-monitor").spawn_unit(

--- a/crates/vsock-guest/src/monitor.rs
+++ b/crates/vsock-guest/src/monitor.rs
@@ -10,6 +10,7 @@ use crate::drain::{drain_into_vec_cancellable, drain_until_eof_or_cancelled};
 use crate::error::to_io_error;
 use crate::log::log;
 use crate::process::{ChildReapGuard, kill_and_reap_child};
+use crate::process_control::ProcessControlGuard;
 use crate::quiesce::OperationGuard;
 use crate::shell_command::{
     EnvScriptGuard, SpawnedShellCommand, format_env_diagnostics, spawn_shell_command_with_pipes,
@@ -38,6 +39,7 @@ struct StreamingMonitorRequest {
     writer: GuestWriter,
     connection_cancel: Arc<AtomicBool>,
     operation_guard: OperationGuard,
+    process_control_guard: Option<ProcessControlGuard>,
 }
 
 struct BufferedMonitorRequest {
@@ -49,6 +51,7 @@ struct BufferedMonitorRequest {
     writer: GuestWriter,
     connection_cancel: Arc<AtomicBool>,
     operation_guard: OperationGuard,
+    process_control_guard: Option<ProcessControlGuard>,
 }
 
 struct StreamingSetupFailure {
@@ -62,6 +65,7 @@ struct StreamingSetupFailure {
     env_script: Option<EnvScriptGuard>,
     writer: GuestWriter,
     operation_guard: OperationGuard,
+    process_control_guard: Option<ProcessControlGuard>,
     error: String,
 }
 
@@ -72,6 +76,7 @@ pub(crate) struct SpawnProcessRequest<'a> {
     pub(crate) sudo: bool,
     pub(crate) stream_stdout: bool,
     pub(crate) stdout_log_path: Option<&'a str>,
+    pub(crate) process_control_guard: Option<ProcessControlGuard>,
 }
 
 /// Handle spawn_process: spawn the child, write `MSG_SPAWN_PROCESS_RESULT` over
@@ -113,27 +118,40 @@ fn handle_spawn_process_with_spawner<S>(
 where
     S: ThreadSpawner,
 {
+    let SpawnProcessRequest {
+        timeout_ms,
+        command,
+        env,
+        sudo,
+        stream_stdout,
+        stdout_log_path,
+        process_control_guard,
+    } = request;
+
     log(
         "INFO",
         &format!(
             "spawn_process: {} (timeout={}ms, sudo={}, stream={}, {})",
-            truncate_command_preview(request.command),
-            request.timeout_ms,
-            request.sudo,
-            request.stream_stdout,
-            format_env_diagnostics(request.command, request.env),
+            truncate_command_preview(command),
+            timeout_ms,
+            sudo,
+            stream_stdout,
+            format_env_diagnostics(command, env),
         ),
     );
 
-    let spawned = match spawn_shell_command_with_pipes(request.command, request.env, request.sudo) {
+    let spawned = match spawn_shell_command_with_pipes(command, env, sudo) {
         Ok(c) => c,
         Err(e) => {
             let payload = vsock_proto::encode_error(&format!(
                 "Failed to spawn: {e} ({})",
-                format_env_diagnostics(request.command, request.env)
+                format_env_diagnostics(command, env)
             ));
             let response = vsock_proto::encode(MSG_ERROR, seq, &payload).map_err(to_io_error)?;
             let result = writer.write_frame_after_lock(&response, || {
+                if let Some(guard) = process_control_guard {
+                    guard.release();
+                }
                 operation_guard.release();
             });
             result?;
@@ -162,17 +180,23 @@ where
         Ok(r) => r,
         Err(e) => {
             kill_and_reap_child(child);
+            if let Some(guard) = process_control_guard {
+                guard.release();
+            }
             operation_guard.release();
             return Err(to_io_error(e));
         }
     };
     if let Err(e) = writer.write_frame(&response) {
         kill_and_reap_child(child);
+        if let Some(guard) = process_control_guard {
+            guard.release();
+        }
         operation_guard.release();
         return Err(e);
     }
 
-    if request.stream_stdout {
+    if stream_stdout {
         // Streaming mode: stream stdout to vsock chunks, optionally teeing to a guest file.
         // Take stdout from child so we can read it in a separate thread.
         let stdout_pipe = child.stdout.take();
@@ -181,13 +205,14 @@ where
                 seq,
                 pid,
                 child,
-                timeout_ms: request.timeout_ms,
+                timeout_ms,
                 stdout_pipe,
-                log_path: request.stdout_log_path.map(str::to_owned),
+                log_path: stdout_log_path.map(str::to_owned),
                 env_script,
                 writer,
                 connection_cancel,
                 operation_guard: operation_guard.clone(),
+                process_control_guard,
             },
             spawner,
         ) {
@@ -204,11 +229,12 @@ where
                 seq,
                 pid,
                 child,
-                timeout_ms: request.timeout_ms,
+                timeout_ms,
                 env_script,
                 writer,
                 connection_cancel,
                 operation_guard: operation_guard.clone(),
+                process_control_guard,
             },
             spawner,
         ) {
@@ -253,6 +279,7 @@ where
         writer,
         connection_cancel,
         operation_guard,
+        process_control_guard,
     } = request;
     let child_guard = ChildReapGuard::new(child);
     let monitor_spawner = spawner.clone();
@@ -280,6 +307,7 @@ where
                     writer,
                     connection_cancel,
                     operation_guard: monitor_operation_guard,
+                    process_control_guard,
                 },
                 monitor_spawner,
             );
@@ -314,6 +342,7 @@ where
         writer,
         connection_cancel,
         operation_guard,
+        process_control_guard,
     } = request;
     let _env_script = env_script;
     let cancel = Arc::new(AtomicBool::new(false));
@@ -350,6 +379,7 @@ where
                     env_script: _env_script,
                     writer,
                     operation_guard: operation_guard.clone(),
+                    process_control_guard,
                     error: format!("Failed to spawn stderr drain thread: {e}"),
                 });
                 return;
@@ -432,6 +462,7 @@ where
                     env_script: _env_script,
                     writer,
                     operation_guard: operation_guard.clone(),
+                    process_control_guard,
                     error: format!("Failed to spawn stdout drain thread: {e}"),
                 });
                 return;
@@ -487,6 +518,9 @@ where
     );
 
     send_process_exit_after_lock(seq, pid, exit_code, &[], &stderr, &writer, || {
+        if let Some(guard) = process_control_guard {
+            guard.release();
+        }
         operation_guard.release();
     });
 }
@@ -503,6 +537,7 @@ fn finish_streaming_setup_failure(failure: StreamingSetupFailure) {
         env_script,
         writer,
         operation_guard,
+        process_control_guard,
         error,
     } = failure;
     let _env_script = env_script;
@@ -516,6 +551,9 @@ fn finish_streaming_setup_failure(failure: StreamingSetupFailure) {
         let _ = handle.join();
     }
     send_process_exit_after_lock(seq, pid, 1, &[], error.as_bytes(), &writer, || {
+        if let Some(guard) = process_control_guard {
+            guard.release();
+        }
         operation_guard.release();
     });
 }
@@ -535,6 +573,7 @@ where
         writer,
         connection_cancel,
         operation_guard,
+        process_control_guard,
     } = request;
     let child_guard = ChildReapGuard::new(child);
     let exit_writer = writer.clone();
@@ -571,6 +610,9 @@ where
             );
 
             send_process_exit_after_lock(seq, pid, exit_code, &stdout, &stderr, &writer, || {
+                if let Some(guard) = process_control_guard {
+                    guard.release();
+                }
                 monitor_operation_guard.release();
             });
             drop(env_script);
@@ -663,6 +705,7 @@ mod tests {
                 sudo: false,
                 stream_stdout: true,
                 stdout_log_path: None,
+                process_control_guard: None,
             },
             7,
             operation_guard(),
@@ -708,6 +751,7 @@ mod tests {
                 sudo: false,
                 stream_stdout: true,
                 stdout_log_path: None,
+                process_control_guard: None,
             },
             8,
             operation_guard(),
@@ -753,6 +797,7 @@ mod tests {
                 sudo: false,
                 stream_stdout: true,
                 stdout_log_path: None,
+                process_control_guard: None,
             },
             10,
             operation_guard(),
@@ -798,6 +843,7 @@ mod tests {
                 sudo: false,
                 stream_stdout: false,
                 stdout_log_path: None,
+                process_control_guard: None,
             },
             9,
             operation_guard(),
@@ -843,6 +889,7 @@ mod tests {
                 sudo: false,
                 stream_stdout: false,
                 stdout_log_path: None,
+                process_control_guard: None,
             },
             11,
             operation_guard(),

--- a/crates/vsock-guest/src/process_control.rs
+++ b/crates/vsock-guest/src/process_control.rs
@@ -1,0 +1,148 @@
+use std::collections::HashMap;
+use std::io;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+
+use vsock_proto::{MSG_PROCESS_CONTROL_RESULT, ProcessControlNonce, ProcessControlStatus};
+
+use crate::error::to_io_error;
+use crate::writer::GuestWriter;
+
+#[derive(Clone, Default)]
+pub(crate) struct ProcessControlRegistry {
+    inner: Arc<Mutex<HashMap<u32, ProcessControlNonce>>>,
+}
+
+pub(crate) struct ProcessControlGuard {
+    registry: ProcessControlRegistry,
+    seq: u32,
+    released: AtomicBool,
+}
+
+impl ProcessControlRegistry {
+    pub(crate) fn register(
+        &self,
+        seq: u32,
+        control_nonce: ProcessControlNonce,
+    ) -> ProcessControlGuard {
+        self.inner
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .insert(seq, control_nonce);
+        ProcessControlGuard {
+            registry: self.clone(),
+            seq,
+            released: AtomicBool::new(false),
+        }
+    }
+
+    fn remove(&self, seq: u32) {
+        self.inner
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .remove(&seq);
+    }
+
+    fn status_for(
+        &self,
+        target_seq: u32,
+        control_nonce: ProcessControlNonce,
+    ) -> (ProcessControlStatus, &'static str) {
+        let guard = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        let Some(expected_nonce) = guard.get(&target_seq) else {
+            return (
+                ProcessControlStatus::Inactive,
+                "process operation is not active",
+            );
+        };
+        if *expected_nonce != control_nonce {
+            return (
+                ProcessControlStatus::NonceMismatch,
+                "process operation nonce mismatch",
+            );
+        }
+        (
+            ProcessControlStatus::Unsupported,
+            "process control sink is not configured",
+        )
+    }
+}
+
+impl ProcessControlGuard {
+    pub(crate) fn release(&self) {
+        if !self.released.swap(true, Ordering::AcqRel) {
+            self.registry.remove(self.seq);
+        }
+    }
+}
+
+impl Drop for ProcessControlGuard {
+    fn drop(&mut self) {
+        if !self.released.swap(true, Ordering::AcqRel) {
+            self.registry.remove(self.seq);
+        }
+    }
+}
+
+pub(crate) fn handle_process_control(
+    seq: u32,
+    payload: &[u8],
+    registry: &ProcessControlRegistry,
+    writer: &GuestWriter,
+) -> io::Result<()> {
+    let request = vsock_proto::decode_process_control(payload).map_err(to_io_error)?;
+    writer.write_generated_frame_after_lock(|| {
+        let (status, diagnostic) = registry.status_for(request.target_seq, request.control_nonce);
+        let result_payload = vsock_proto::encode_process_control_result(
+            request.target_seq,
+            request.control_nonce,
+            request.message_id,
+            status,
+            diagnostic,
+        )
+        .map_err(to_io_error)?;
+        vsock_proto::encode(MSG_PROCESS_CONTROL_RESULT, seq, &result_payload).map_err(to_io_error)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const NONCE: ProcessControlNonce = *b"0123456789abcdef";
+
+    #[test]
+    fn registered_operation_rejects_nonce_mismatch() {
+        let registry = ProcessControlRegistry::default();
+        let _guard = registry.register(7, NONCE);
+        let wrong_nonce = *b"fedcba9876543210";
+
+        let (status, diagnostic) = registry.status_for(7, wrong_nonce);
+
+        assert_eq!(status, ProcessControlStatus::NonceMismatch);
+        assert_eq!(diagnostic, "process operation nonce mismatch");
+    }
+
+    #[test]
+    fn released_operation_is_inactive() {
+        let registry = ProcessControlRegistry::default();
+        let guard = registry.register(7, NONCE);
+
+        guard.release();
+        let (status, diagnostic) = registry.status_for(7, NONCE);
+
+        assert_eq!(status, ProcessControlStatus::Inactive);
+        assert_eq!(diagnostic, "process operation is not active");
+    }
+
+    #[test]
+    fn valid_operation_is_currently_unsupported_until_sink_is_wired() {
+        let registry = ProcessControlRegistry::default();
+        let _guard = registry.register(7, NONCE);
+
+        let (status, diagnostic) = registry.status_for(7, NONCE);
+
+        assert_eq!(status, ProcessControlStatus::Unsupported);
+        assert_eq!(diagnostic, "process control sink is not configured");
+    }
+}

--- a/crates/vsock-guest/src/process_control.rs
+++ b/crates/vsock-guest/src/process_control.rs
@@ -191,11 +191,14 @@ mod tests {
     #[test]
     fn operation_without_control_nonce_still_reserves_sequence() {
         let registry = ProcessControlRegistry::default();
-        let _guard = registry.register(7, None).unwrap();
+        let guard = registry.register(7, None).unwrap();
 
         assert!(registry.register(7, Some(NONCE)).is_err());
         let (status, diagnostic) = registry.status_for(7, NONCE);
         assert_eq!(status, ProcessControlStatus::Inactive);
         assert_eq!(diagnostic, "process operation is not active");
+
+        drop(guard);
+        assert!(registry.register(7, Some(NONCE)).is_ok());
     }
 }

--- a/crates/vsock-guest/src/process_control.rs
+++ b/crates/vsock-guest/src/process_control.rs
@@ -24,16 +24,17 @@ impl ProcessControlRegistry {
         &self,
         seq: u32,
         control_nonce: ProcessControlNonce,
-    ) -> ProcessControlGuard {
-        self.inner
-            .lock()
-            .unwrap_or_else(|e| e.into_inner())
-            .insert(seq, control_nonce);
-        ProcessControlGuard {
+    ) -> Result<ProcessControlGuard, ()> {
+        let mut active = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        if active.contains_key(&seq) {
+            return Err(());
+        }
+        active.insert(seq, control_nonce);
+        Ok(ProcessControlGuard {
             registry: self.clone(),
             seq,
             released: AtomicBool::new(false),
-        }
+        })
     }
 
     fn remove(&self, seq: u32) {
@@ -122,7 +123,7 @@ mod tests {
     #[test]
     fn registered_operation_rejects_nonce_mismatch() {
         let registry = ProcessControlRegistry::default();
-        let _guard = registry.register(7, NONCE);
+        let _guard = registry.register(7, NONCE).unwrap();
         let wrong_nonce = *b"fedcba9876543210";
 
         let (status, diagnostic) = registry.status_for(7, wrong_nonce);
@@ -134,7 +135,7 @@ mod tests {
     #[test]
     fn released_operation_is_inactive() {
         let registry = ProcessControlRegistry::default();
-        let guard = registry.register(7, NONCE);
+        let guard = registry.register(7, NONCE).unwrap();
 
         guard.release();
         let (status, diagnostic) = registry.status_for(7, NONCE);
@@ -146,11 +147,25 @@ mod tests {
     #[test]
     fn valid_operation_is_currently_unsupported_until_sink_is_wired() {
         let registry = ProcessControlRegistry::default();
-        let _guard = registry.register(7, NONCE);
+        let _guard = registry.register(7, NONCE).unwrap();
 
         let (status, diagnostic) = registry.status_for(7, NONCE);
 
         assert_eq!(status, ProcessControlStatus::Unsupported);
         assert_eq!(diagnostic, "process control sink is not configured");
+    }
+
+    #[test]
+    fn duplicate_active_sequence_is_rejected_until_guard_releases() {
+        let registry = ProcessControlRegistry::default();
+        let first = registry.register(7, NONCE).unwrap();
+
+        assert!(registry.register(7, *b"fedcba9876543210").is_err());
+        let (status, diagnostic) = registry.status_for(7, NONCE);
+        assert_eq!(status, ProcessControlStatus::Unsupported);
+        assert_eq!(diagnostic, "process control sink is not configured");
+
+        first.release();
+        assert!(registry.register(7, *b"fedcba9876543210").is_ok());
     }
 }

--- a/crates/vsock-guest/src/process_control.rs
+++ b/crates/vsock-guest/src/process_control.rs
@@ -10,7 +10,16 @@ use crate::writer::GuestWriter;
 
 #[derive(Clone, Default)]
 pub(crate) struct ProcessControlRegistry {
-    inner: Arc<Mutex<HashMap<u32, ProcessControlNonce>>>,
+    inner: Arc<Mutex<HashMap<u32, ProcessControlEntry>>>,
+}
+
+/// Active `spawn_process` registration for a seq.
+///
+/// Operations without a control nonce still reserve their seq so malformed or
+/// duplicate spawn requests cannot run concurrently under the same routing key.
+enum ProcessControlEntry {
+    NoControl,
+    WithNonce(ProcessControlNonce),
 }
 
 pub(crate) struct ProcessControlGuard {
@@ -23,13 +32,17 @@ impl ProcessControlRegistry {
     pub(crate) fn register(
         &self,
         seq: u32,
-        control_nonce: ProcessControlNonce,
+        control_nonce: Option<ProcessControlNonce>,
     ) -> Result<ProcessControlGuard, ()> {
         let mut active = self.inner.lock().unwrap_or_else(|e| e.into_inner());
         if active.contains_key(&seq) {
             return Err(());
         }
-        active.insert(seq, control_nonce);
+        let entry = match control_nonce {
+            Some(nonce) => ProcessControlEntry::WithNonce(nonce),
+            None => ProcessControlEntry::NoControl,
+        };
+        active.insert(seq, entry);
         Ok(ProcessControlGuard {
             registry: self.clone(),
             seq,
@@ -58,7 +71,13 @@ impl ProcessControlRegistry {
         control_nonce: ProcessControlNonce,
     ) -> (ProcessControlStatus, &'static str) {
         let guard = self.inner.lock().unwrap_or_else(|e| e.into_inner());
-        let Some(expected_nonce) = guard.get(&target_seq) else {
+        let Some(entry) = guard.get(&target_seq) else {
+            return (
+                ProcessControlStatus::Inactive,
+                "process operation is not active",
+            );
+        };
+        let ProcessControlEntry::WithNonce(expected_nonce) = entry else {
             return (
                 ProcessControlStatus::Inactive,
                 "process operation is not active",
@@ -123,7 +142,7 @@ mod tests {
     #[test]
     fn registered_operation_rejects_nonce_mismatch() {
         let registry = ProcessControlRegistry::default();
-        let _guard = registry.register(7, NONCE).unwrap();
+        let _guard = registry.register(7, Some(NONCE)).unwrap();
         let wrong_nonce = *b"fedcba9876543210";
 
         let (status, diagnostic) = registry.status_for(7, wrong_nonce);
@@ -135,7 +154,7 @@ mod tests {
     #[test]
     fn released_operation_is_inactive() {
         let registry = ProcessControlRegistry::default();
-        let guard = registry.register(7, NONCE).unwrap();
+        let guard = registry.register(7, Some(NONCE)).unwrap();
 
         guard.release();
         let (status, diagnostic) = registry.status_for(7, NONCE);
@@ -147,7 +166,7 @@ mod tests {
     #[test]
     fn valid_operation_is_currently_unsupported_until_sink_is_wired() {
         let registry = ProcessControlRegistry::default();
-        let _guard = registry.register(7, NONCE).unwrap();
+        let _guard = registry.register(7, Some(NONCE)).unwrap();
 
         let (status, diagnostic) = registry.status_for(7, NONCE);
 
@@ -158,14 +177,25 @@ mod tests {
     #[test]
     fn duplicate_active_sequence_is_rejected_until_guard_releases() {
         let registry = ProcessControlRegistry::default();
-        let first = registry.register(7, NONCE).unwrap();
+        let first = registry.register(7, Some(NONCE)).unwrap();
 
-        assert!(registry.register(7, *b"fedcba9876543210").is_err());
+        assert!(registry.register(7, Some(*b"fedcba9876543210")).is_err());
         let (status, diagnostic) = registry.status_for(7, NONCE);
         assert_eq!(status, ProcessControlStatus::Unsupported);
         assert_eq!(diagnostic, "process control sink is not configured");
 
         first.release();
-        assert!(registry.register(7, *b"fedcba9876543210").is_ok());
+        assert!(registry.register(7, None).is_ok());
+    }
+
+    #[test]
+    fn operation_without_control_nonce_still_reserves_sequence() {
+        let registry = ProcessControlRegistry::default();
+        let _guard = registry.register(7, None).unwrap();
+
+        assert!(registry.register(7, Some(NONCE)).is_err());
+        let (status, diagnostic) = registry.status_for(7, NONCE);
+        assert_eq!(status, ProcessControlStatus::Inactive);
+        assert_eq!(diagnostic, "process operation is not active");
     }
 }

--- a/crates/vsock-guest/src/process_control.rs
+++ b/crates/vsock-guest/src/process_control.rs
@@ -43,6 +43,14 @@ impl ProcessControlRegistry {
             .remove(&seq);
     }
 
+    #[cfg(test)]
+    pub(crate) fn contains(&self, seq: u32) -> bool {
+        self.inner
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .contains_key(&seq)
+    }
+
     fn status_for(
         &self,
         target_seq: u32,

--- a/crates/vsock-guest/src/writer.rs
+++ b/crates/vsock-guest/src/writer.rs
@@ -45,6 +45,23 @@ impl GuestWriter {
         self.write_frame_with_deadline_after_lock(frame, WRITE_DEADLINE, after_lock)
     }
 
+    /// Build and send one frame while holding the writer mutex.
+    ///
+    /// Control paths that derive the response from operation state use this so
+    /// the state check and frame ordering are linearized with terminal frames.
+    pub(crate) fn write_generated_frame_after_lock<F>(&self, build_frame: F) -> io::Result<()>
+    where
+        F: FnOnce() -> io::Result<Vec<u8>>,
+    {
+        let stream = self.stream.lock().unwrap_or_else(|e| e.into_inner());
+        let frame = build_frame()?;
+        let result = send_frame(stream.as_raw_fd(), &frame, WRITE_DEADLINE);
+        if result.is_err() {
+            let _ = stream.shutdown(Shutdown::Both);
+        }
+        result
+    }
+
     fn write_frame_with_deadline_after_lock<F>(
         &self,
         frame: &[u8],

--- a/crates/vsock-guest/tests/connection.rs
+++ b/crates/vsock-guest/tests/connection.rs
@@ -1731,6 +1731,25 @@ fn process_control_duplicate_spawn_seq_returns_error_without_replacing_active_no
 }
 
 #[test]
+fn duplicate_spawn_seq_without_control_nonce_returns_error() {
+    let (handle, mut host_stream) = start_guest_connection();
+
+    send_spawn_process(&mut host_stream, 41, "sleep 60", None, 5000);
+    let result = read_message(&mut host_stream);
+    assert_eq!(result.msg_type, MSG_SPAWN_PROCESS_RESULT);
+    assert_eq!(result.seq, 41);
+
+    send_spawn_process(&mut host_stream, 41, "printf duplicate", None, 5000);
+    let duplicate = read_message(&mut host_stream);
+    assert_eq!(duplicate.msg_type, MSG_ERROR);
+    assert_eq!(duplicate.seq, 41);
+    let error = vsock_proto::decode_error(&duplicate.payload).unwrap();
+    assert!(error.contains("already active"));
+
+    finish_guest_connection(handle, host_stream);
+}
+
+#[test]
 fn process_control_without_registered_nonce_returns_inactive() {
     use std::os::unix::net::UnixStream as StdUnixStream;
 

--- a/crates/vsock-guest/tests/connection.rs
+++ b/crates/vsock-guest/tests/connection.rs
@@ -1664,6 +1664,44 @@ fn process_control_rejects_nonce_mismatch() {
 }
 
 #[test]
+fn process_control_duplicate_spawn_seq_returns_error_without_replacing_active_nonce() {
+    const NONCE: vsock_proto::ProcessControlNonce = *b"0123456789abcdef";
+    const DUPLICATE_NONCE: vsock_proto::ProcessControlNonce = *b"fedcba9876543210";
+
+    let (handle, mut host_stream) = start_guest_connection();
+
+    send_spawn_process_with_control_nonce(&mut host_stream, 39, "sleep 60", NONCE);
+    let result = read_message(&mut host_stream);
+    assert_eq!(result.msg_type, MSG_SPAWN_PROCESS_RESULT);
+    assert_eq!(result.seq, 39);
+
+    send_spawn_process_with_control_nonce(
+        &mut host_stream,
+        39,
+        "printf duplicate",
+        DUPLICATE_NONCE,
+    );
+    let duplicate = read_message(&mut host_stream);
+    assert_eq!(duplicate.msg_type, MSG_ERROR);
+    assert_eq!(duplicate.seq, 39);
+    let error = vsock_proto::decode_error(&duplicate.payload).unwrap();
+    assert!(error.contains("already active"));
+
+    send_process_control(&mut host_stream, 40, 39, NONCE, "message-duplicate");
+    assert_process_control_result(
+        &mut host_stream,
+        40,
+        39,
+        NONCE,
+        "message-duplicate",
+        ProcessControlStatus::Unsupported,
+        "process control sink is not configured",
+    );
+
+    finish_guest_connection(handle, host_stream);
+}
+
+#[test]
 fn process_control_without_registered_nonce_returns_inactive() {
     use std::os::unix::net::UnixStream as StdUnixStream;
 

--- a/crates/vsock-guest/tests/connection.rs
+++ b/crates/vsock-guest/tests/connection.rs
@@ -1664,6 +1664,42 @@ fn process_control_rejects_nonce_mismatch() {
 }
 
 #[test]
+fn process_control_without_registered_nonce_returns_inactive() {
+    use std::os::unix::net::UnixStream as StdUnixStream;
+
+    const NONCE: vsock_proto::ProcessControlNonce = *b"0123456789abcdef";
+
+    let (guest_stream, mut host_stream) = StdUnixStream::pair().unwrap();
+    let handle = thread::spawn(move || {
+        let _ = handle_connection(guest_stream);
+    });
+
+    read_and_discard_message(&mut host_stream);
+    host_stream
+        .set_read_timeout(Some(Duration::from_secs(5)))
+        .unwrap();
+
+    send_spawn_process(&mut host_stream, 37, "sleep 60", None, 5000);
+    let result = read_message(&mut host_stream);
+    assert_eq!(result.msg_type, MSG_SPAWN_PROCESS_RESULT);
+    assert_eq!(result.seq, 37);
+
+    send_process_control(&mut host_stream, 38, 37, NONCE, "message-4");
+    assert_process_control_result(
+        &mut host_stream,
+        38,
+        37,
+        NONCE,
+        "message-4",
+        ProcessControlStatus::Inactive,
+        "process operation is not active",
+    );
+
+    drop(host_stream);
+    let _ = handle.join();
+}
+
+#[test]
 fn process_control_after_exit_returns_inactive() {
     use std::os::unix::net::UnixStream as StdUnixStream;
 

--- a/crates/vsock-guest/tests/connection.rs
+++ b/crates/vsock-guest/tests/connection.rs
@@ -13,9 +13,10 @@ use vsock_guest::{handle_connection, run};
 use vsock_proto::{
     self, ExecCapturedOutput, ExecOutputPolicy, ExecOutputStream, ExecTermination, MSG_ERROR,
     MSG_EXEC_CANCEL, MSG_EXEC_OUTPUT, MSG_EXEC_RESULT, MSG_EXEC_START, MSG_OPERATIONS_QUIESCED,
-    MSG_OPERATIONS_RESUMED, MSG_PROCESS_EXIT, MSG_QUIESCE_OPERATIONS, MSG_RESUME_OPERATIONS,
-    MSG_SHUTDOWN, MSG_SHUTDOWN_ACK, MSG_SPAWN_PROCESS, MSG_SPAWN_PROCESS_RESULT, MSG_STDOUT_CHUNK,
-    MSG_WRITE_FILE,
+    MSG_OPERATIONS_RESUMED, MSG_PROCESS_CONTROL, MSG_PROCESS_CONTROL_RESULT, MSG_PROCESS_EXIT,
+    MSG_QUIESCE_OPERATIONS, MSG_RESUME_OPERATIONS, MSG_SHUTDOWN, MSG_SHUTDOWN_ACK,
+    MSG_SPAWN_PROCESS, MSG_SPAWN_PROCESS_RESULT, MSG_STDOUT_CHUNK, MSG_WRITE_FILE,
+    ProcessControlStatus,
 };
 
 const EXIT_CODE_TIMEOUT: i32 = 124;
@@ -1453,6 +1454,60 @@ fn send_spawn_process_with_env(
     stream.write_all(&msg).unwrap();
 }
 
+fn send_spawn_process_with_control_nonce(
+    stream: &mut impl std::io::Write,
+    seq: u32,
+    command: &str,
+    control_nonce: vsock_proto::ProcessControlNonce,
+) {
+    let payload = vsock_proto::encode_spawn_process_with_control_nonce(
+        5000,
+        command,
+        &[],
+        false,
+        true,
+        control_nonce,
+        None,
+    )
+    .unwrap();
+    let msg = vsock_proto::encode(MSG_SPAWN_PROCESS, seq, &payload).unwrap();
+    stream.write_all(&msg).unwrap();
+}
+
+fn send_process_control(
+    stream: &mut impl std::io::Write,
+    request_seq: u32,
+    target_seq: u32,
+    control_nonce: vsock_proto::ProcessControlNonce,
+    message_id: &str,
+) {
+    let payload =
+        vsock_proto::encode_process_control(target_seq, control_nonce, message_id, b"payload")
+            .unwrap();
+    let msg = vsock_proto::encode(MSG_PROCESS_CONTROL, request_seq, &payload).unwrap();
+    stream.write_all(&msg).unwrap();
+}
+
+fn assert_process_control_result(
+    stream: &mut impl std::io::Read,
+    request_seq: u32,
+    expected_target_seq: u32,
+    expected_nonce: vsock_proto::ProcessControlNonce,
+    expected_message_id: &str,
+    expected_status: ProcessControlStatus,
+    expected_diagnostic: &str,
+) {
+    let msg = read_message(stream);
+    assert_eq!(msg.msg_type, MSG_PROCESS_CONTROL_RESULT);
+    assert_eq!(msg.seq, request_seq);
+    let decoded = vsock_proto::decode_process_control_result(&msg.payload).unwrap();
+    assert_eq!(decoded.target_seq, expected_target_seq);
+    assert_eq!(decoded.control_nonce, expected_nonce);
+    assert_eq!(decoded.message_id, expected_message_id);
+    assert_eq!(decoded.status, expected_status);
+    assert_eq!(decoded.diagnostic, expected_diagnostic);
+}
+
 /// Read all streaming messages for a spawn_process command in a single loop.
 /// Uses one decoder to avoid losing messages when the OS batches multiple
 /// protocol frames into a single read buffer.
@@ -1530,6 +1585,115 @@ fn streaming_monitor_normal_exit() {
     assert!(pid > 0);
     assert_eq!(exit_code, 0);
     assert_eq!(String::from_utf8_lossy(&stdout_data).trim(), "hello");
+
+    drop(host_stream);
+    let _ = handle.join();
+}
+
+#[test]
+fn process_control_validates_nonce_before_sink_dispatch() {
+    use std::os::unix::net::UnixStream as StdUnixStream;
+
+    const NONCE: vsock_proto::ProcessControlNonce = *b"0123456789abcdef";
+
+    let (guest_stream, mut host_stream) = StdUnixStream::pair().unwrap();
+    let handle = thread::spawn(move || {
+        let _ = handle_connection(guest_stream);
+    });
+
+    read_and_discard_message(&mut host_stream);
+    host_stream
+        .set_read_timeout(Some(Duration::from_secs(5)))
+        .unwrap();
+
+    send_spawn_process_with_control_nonce(&mut host_stream, 31, "sleep 60", NONCE);
+    let result = read_message(&mut host_stream);
+    assert_eq!(result.msg_type, MSG_SPAWN_PROCESS_RESULT);
+    assert_eq!(result.seq, 31);
+
+    send_process_control(&mut host_stream, 32, 31, NONCE, "message-1");
+    assert_process_control_result(
+        &mut host_stream,
+        32,
+        31,
+        NONCE,
+        "message-1",
+        ProcessControlStatus::Unsupported,
+        "process control sink is not configured",
+    );
+
+    drop(host_stream);
+    let _ = handle.join();
+}
+
+#[test]
+fn process_control_rejects_nonce_mismatch() {
+    use std::os::unix::net::UnixStream as StdUnixStream;
+
+    const NONCE: vsock_proto::ProcessControlNonce = *b"0123456789abcdef";
+    const WRONG_NONCE: vsock_proto::ProcessControlNonce = *b"fedcba9876543210";
+
+    let (guest_stream, mut host_stream) = StdUnixStream::pair().unwrap();
+    let handle = thread::spawn(move || {
+        let _ = handle_connection(guest_stream);
+    });
+
+    read_and_discard_message(&mut host_stream);
+    host_stream
+        .set_read_timeout(Some(Duration::from_secs(5)))
+        .unwrap();
+
+    send_spawn_process_with_control_nonce(&mut host_stream, 33, "sleep 60", NONCE);
+    let result = read_message(&mut host_stream);
+    assert_eq!(result.msg_type, MSG_SPAWN_PROCESS_RESULT);
+    assert_eq!(result.seq, 33);
+
+    send_process_control(&mut host_stream, 34, 33, WRONG_NONCE, "message-2");
+    assert_process_control_result(
+        &mut host_stream,
+        34,
+        33,
+        WRONG_NONCE,
+        "message-2",
+        ProcessControlStatus::NonceMismatch,
+        "process operation nonce mismatch",
+    );
+
+    drop(host_stream);
+    let _ = handle.join();
+}
+
+#[test]
+fn process_control_after_exit_returns_inactive() {
+    use std::os::unix::net::UnixStream as StdUnixStream;
+
+    const NONCE: vsock_proto::ProcessControlNonce = *b"0123456789abcdef";
+
+    let (guest_stream, mut host_stream) = StdUnixStream::pair().unwrap();
+    let handle = thread::spawn(move || {
+        let _ = handle_connection(guest_stream);
+    });
+
+    read_and_discard_message(&mut host_stream);
+    host_stream
+        .set_read_timeout(Some(Duration::from_secs(5)))
+        .unwrap();
+
+    send_spawn_process_with_control_nonce(&mut host_stream, 35, "printf done", NONCE);
+    let (_pid, stdout_data, exit_code, stderr) = read_streaming_result(&mut host_stream, 35);
+    assert_eq!(stdout_data, b"done");
+    assert_eq!(exit_code, 0, "stderr: {}", String::from_utf8_lossy(&stderr));
+
+    send_process_control(&mut host_stream, 36, 35, NONCE, "message-3");
+    assert_process_control_result(
+        &mut host_stream,
+        36,
+        35,
+        NONCE,
+        "message-3",
+        ProcessControlStatus::Inactive,
+        "process operation is not active",
+    );
 
     drop(host_stream);
     let _ = handle.join();

--- a/crates/vsock-guest/tests/connection.rs
+++ b/crates/vsock-guest/tests/connection.rs
@@ -1097,6 +1097,35 @@ fn exec_operation_seq_zero_start_and_cancel_return_error() {
 }
 
 #[test]
+fn process_messages_seq_zero_return_error() {
+    const NONCE: vsock_proto::ProcessControlNonce = *b"0123456789abcdef";
+
+    let (handle, mut host_stream) = start_guest_connection();
+
+    send_spawn_process_with_control_nonce(&mut host_stream, 0, "printf should-not-run", NONCE);
+    let spawn_error = read_message(&mut host_stream);
+    assert_eq!(spawn_error.msg_type, MSG_ERROR);
+    assert_eq!(spawn_error.seq, 0);
+    assert!(
+        vsock_proto::decode_error(&spawn_error.payload)
+            .unwrap()
+            .contains("non-zero sequence")
+    );
+
+    send_process_control(&mut host_stream, 0, 1, NONCE, "message-zero");
+    let control_error = read_message(&mut host_stream);
+    assert_eq!(control_error.msg_type, MSG_ERROR);
+    assert_eq!(control_error.seq, 0);
+    assert!(
+        vsock_proto::decode_error(&control_error.payload)
+            .unwrap()
+            .contains("non-zero sequence")
+    );
+
+    finish_guest_connection(handle, host_stream);
+}
+
+#[test]
 fn quiesce_busy_fences_new_exec_operations_until_pending_exec_finishes() {
     let (handle, mut host_stream) = start_guest_connection();
 

--- a/crates/vsock-host/Cargo.toml
+++ b/crates/vsock-host/Cargo.toml
@@ -8,6 +8,7 @@ description = "Vsock host client for Firecracker VM communication"
 nix = { workspace = true, features = ["net"] }
 tokio = { workspace = true, features = ["net", "io-util", "time", "rt", "macros", "sync", "fs"] }
 tracing = { workspace = true }
+uuid = { workspace = true, features = ["v4"] }
 vsock-proto.workspace = true
 
 [lints]

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -49,7 +49,9 @@ pub use exec_operation::{
     ExecOutputEvent, ExecOwnedCapturedOutput, ExecStreamRequest,
 };
 pub use file::{CopyFileOptions, CopyFileResult};
-pub use process::{GuestProcessHandle, ProcessExitEvent};
+pub use process::{
+    GuestProcessControlHandle, GuestProcessHandle, ProcessControlAck, ProcessExitEvent,
+};
 
 const READ_BUF_SIZE: usize = 64 * 1024;
 

--- a/crates/vsock-host/src/process.rs
+++ b/crates/vsock-host/src/process.rs
@@ -248,6 +248,11 @@ impl fmt::Debug for GuestProcessControlHandle {
 }
 
 impl GuestProcessControlHandle {
+    fn protocol_error(&self, message: impl ToString) -> io::Error {
+        self.shared.poison_connection();
+        io::Error::new(io::ErrorKind::InvalidData, message.to_string())
+    }
+
     pub async fn control(
         &self,
         message_id: &str,
@@ -272,41 +277,32 @@ impl GuestProcessControlHandle {
         response: RawMessage,
     ) -> io::Result<ProcessControlAck> {
         if response.msg_type == MSG_ERROR {
-            let msg = vsock_proto::decode_error(&response.payload)
-                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
+            let msg =
+                vsock_proto::decode_error(&response.payload).map_err(|e| self.protocol_error(e))?;
             return Err(io::Error::other(msg.to_owned()));
         }
         if response.msg_type != MSG_PROCESS_CONTROL_RESULT {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                format!("unexpected response type: 0x{:02X}", response.msg_type),
-            ));
+            return Err(self.protocol_error(format!(
+                "unexpected response type: 0x{:02X}",
+                response.msg_type
+            )));
         }
         let result = vsock_proto::decode_process_control_result(&response.payload)
-            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
+            .map_err(|e| self.protocol_error(e))?;
         if result.target_seq != self.target_seq {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                format!(
-                    "process_control_result target seq mismatch: expected {}, got {}",
-                    self.target_seq, result.target_seq
-                ),
-            ));
+            return Err(self.protocol_error(format!(
+                "process_control_result target seq mismatch: expected {}, got {}",
+                self.target_seq, result.target_seq
+            )));
         }
         if result.control_nonce != self.control_nonce {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                "process_control_result nonce mismatch",
-            ));
+            return Err(self.protocol_error("process_control_result nonce mismatch"));
         }
         if result.message_id != message_id {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                format!(
-                    "process_control_result message_id mismatch: expected {message_id}, got {}",
-                    result.message_id
-                ),
-            ));
+            return Err(self.protocol_error(format!(
+                "process_control_result message_id mismatch: expected {message_id}, got {}",
+                result.message_id
+            )));
         }
         match result.status {
             ProcessControlStatus::Delivered => Ok(ProcessControlAck {

--- a/crates/vsock-host/src/process.rs
+++ b/crates/vsock-host/src/process.rs
@@ -5,9 +5,12 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use tokio::sync::{mpsc, oneshot};
-use vsock_proto::{MSG_ERROR, MSG_SPAWN_PROCESS, MSG_SPAWN_PROCESS_RESULT, RawMessage};
+use vsock_proto::{
+    MSG_ERROR, MSG_PROCESS_CONTROL, MSG_PROCESS_CONTROL_RESULT, MSG_SPAWN_PROCESS,
+    MSG_SPAWN_PROCESS_RESULT, ProcessControlNonce, ProcessControlStatus, RawMessage,
+};
 
-use crate::{ConnectionState, Shared, request_raw_on_shared};
+use crate::{ConnectionState, Shared, request_on_shared, request_raw_on_shared};
 
 /// Event emitted when a spawned process exits.
 #[derive(Debug, Clone)]
@@ -16,6 +19,13 @@ pub struct ProcessExitEvent {
     pub exit_code: i32,
     pub stdout: Vec<u8>,
     pub stderr: Vec<u8>,
+}
+
+/// Host-side result of a process-control request.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProcessControlAck {
+    pub target_seq: u32,
+    pub message_id: String,
 }
 
 struct ProcessOperation {
@@ -162,8 +172,17 @@ pub struct GuestProcessHandle {
     shared: Arc<Shared>,
     seq: Option<u32>,
     pid: u32,
+    control: GuestProcessControlHandle,
     stdout_rx: Option<mpsc::UnboundedReceiver<Vec<u8>>>,
     exit_rx: Option<oneshot::Receiver<ProcessExitEvent>>,
+}
+
+/// Cloneable handle for sending control messages to a live process operation.
+#[derive(Clone)]
+pub struct GuestProcessControlHandle {
+    shared: Arc<Shared>,
+    target_seq: u32,
+    control_nonce: ProcessControlNonce,
 }
 
 impl fmt::Debug for GuestProcessHandle {
@@ -180,6 +199,19 @@ impl fmt::Debug for GuestProcessHandle {
 impl GuestProcessHandle {
     pub fn pid(&self) -> u32 {
         self.pid
+    }
+
+    pub fn control_handle(&self) -> GuestProcessControlHandle {
+        self.control.clone()
+    }
+
+    pub async fn control(
+        &self,
+        message_id: &str,
+        payload: &[u8],
+        timeout: Duration,
+    ) -> io::Result<ProcessControlAck> {
+        self.control.control(message_id, payload, timeout).await
     }
 
     pub fn take_stdout_receiver(&mut self) -> Option<mpsc::UnboundedReceiver<Vec<u8>>> {
@@ -204,6 +236,108 @@ impl GuestProcessHandle {
             .map_err(|_| io::Error::new(io::ErrorKind::ConnectionReset, "connection closed"))?;
         self.seq = None;
         Ok(event)
+    }
+}
+
+impl fmt::Debug for GuestProcessControlHandle {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("GuestProcessControlHandle")
+            .field("target_seq", &self.target_seq)
+            .finish_non_exhaustive()
+    }
+}
+
+impl GuestProcessControlHandle {
+    pub async fn control(
+        &self,
+        message_id: &str,
+        payload: &[u8],
+        timeout: Duration,
+    ) -> io::Result<ProcessControlAck> {
+        let request = vsock_proto::encode_process_control(
+            self.target_seq,
+            self.control_nonce,
+            message_id,
+            payload,
+        )
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e.to_string()))?;
+        let response =
+            request_on_shared(&self.shared, MSG_PROCESS_CONTROL, &request, timeout).await?;
+        self.decode_control_response(message_id, response)
+    }
+
+    fn decode_control_response(
+        &self,
+        message_id: &str,
+        response: RawMessage,
+    ) -> io::Result<ProcessControlAck> {
+        if response.msg_type == MSG_ERROR {
+            let msg = vsock_proto::decode_error(&response.payload)
+                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
+            return Err(io::Error::other(msg.to_owned()));
+        }
+        if response.msg_type != MSG_PROCESS_CONTROL_RESULT {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("unexpected response type: 0x{:02X}", response.msg_type),
+            ));
+        }
+        let result = vsock_proto::decode_process_control_result(&response.payload)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
+        if result.target_seq != self.target_seq {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "process_control_result target seq mismatch: expected {}, got {}",
+                    self.target_seq, result.target_seq
+                ),
+            ));
+        }
+        if result.control_nonce != self.control_nonce {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "process_control_result nonce mismatch",
+            ));
+        }
+        if result.message_id != message_id {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "process_control_result message_id mismatch: expected {message_id}, got {}",
+                    result.message_id
+                ),
+            ));
+        }
+        match result.status {
+            ProcessControlStatus::Delivered => Ok(ProcessControlAck {
+                target_seq: result.target_seq,
+                message_id: result.message_id.to_owned(),
+            }),
+            ProcessControlStatus::Inactive => Err(io::Error::new(
+                io::ErrorKind::NotFound,
+                if result.diagnostic.is_empty() {
+                    "process operation is not active".to_owned()
+                } else {
+                    result.diagnostic.to_owned()
+                },
+            )),
+            ProcessControlStatus::NonceMismatch => Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                if result.diagnostic.is_empty() {
+                    "process operation nonce mismatch".to_owned()
+                } else {
+                    result.diagnostic.to_owned()
+                },
+            )),
+            ProcessControlStatus::Unsupported => Err(io::Error::new(
+                io::ErrorKind::Unsupported,
+                if result.diagnostic.is_empty() {
+                    "process control is not supported by this operation".to_owned()
+                } else {
+                    result.diagnostic.to_owned()
+                },
+            )),
+        }
     }
 }
 
@@ -326,12 +460,14 @@ pub(crate) async fn spawn_process_on_shared(
     stream_stdout: bool,
     stdout_log_path: Option<&str>,
 ) -> io::Result<GuestProcessHandle> {
-    let payload = vsock_proto::encode_spawn_process(
+    let control_nonce = *uuid::Uuid::new_v4().as_bytes();
+    let payload = vsock_proto::encode_spawn_process_with_control_nonce(
         timeout_ms,
         command,
         env,
         sudo,
         stream_stdout,
+        control_nonce,
         stdout_log_path,
     )
     .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e.to_string()))?;
@@ -399,6 +535,11 @@ pub(crate) async fn spawn_process_on_shared(
         shared: Arc::clone(shared),
         seq: Some(seq),
         pid,
+        control: GuestProcessControlHandle {
+            shared: Arc::clone(shared),
+            target_seq: seq,
+            control_nonce,
+        },
         stdout_rx,
         exit_rx: Some(exit_rx),
     })

--- a/crates/vsock-host/src/tests/process.rs
+++ b/crates/vsock-host/src/tests/process.rs
@@ -302,7 +302,7 @@ async fn test_spawn_process_control_timeout_cleans_pending_without_poisoning() {
         .await
         .unwrap();
     let err = handle
-        .control("message-4", b"payload", Duration::from_millis(1))
+        .control("message-4", b"payload", Duration::ZERO)
         .await
         .unwrap_err();
     assert_eq!(err.kind(), io::ErrorKind::TimedOut);

--- a/crates/vsock-host/src/tests/process.rs
+++ b/crates/vsock-host/src/tests/process.rs
@@ -3,7 +3,8 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use super::support::{
-    host_from_stream, make_pair, mock_handshake, read_guest_message, send_exec_result,
+    host_from_stream, make_pair, mock_handshake, read_guest_message, read_guest_messages,
+    send_exec_result,
 };
 use crate::{ConnectionState, GuestProcessHandle, VsockHost};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -52,6 +53,14 @@ async fn send_process_control_result(
     .unwrap();
     let response = vsock_proto::encode(MSG_PROCESS_CONTROL_RESULT, request_seq, &payload).unwrap();
     guest.write_all(&response).await.unwrap();
+}
+
+struct SeenProcessControl {
+    request_seq: u32,
+    target_seq: u32,
+    control_nonce: vsock_proto::ProcessControlNonce,
+    message_id: String,
+    payload: Vec<u8>,
 }
 
 #[tokio::test]
@@ -153,6 +162,88 @@ async fn test_spawn_process_control_uses_operation_seq_and_nonce() {
         .await
         .unwrap();
     assert_eq!(ack.message_id, "message-1");
+
+    let event = wait_spawn(handle).await.unwrap();
+    assert_eq!(event.exit_code, 0);
+}
+
+#[tokio::test]
+async fn test_spawn_process_concurrent_controls_route_by_request_seq() {
+    let (host_stream, mut guest) = make_pair();
+
+    tokio::spawn(async move {
+        let mut decoder = Decoder::new();
+        mock_handshake(&mut guest, &mut decoder).await;
+
+        let spawn = read_guest_message(&mut guest, &mut decoder).await;
+        assert_eq!(spawn.msg_type, MSG_SPAWN_PROCESS);
+        let decoded_spawn = vsock_proto::decode_spawn_process(&spawn.payload).unwrap();
+        let control_nonce = decoded_spawn.control_nonce.unwrap();
+
+        let payload = vsock_proto::encode_spawn_process_result(52);
+        let resp = vsock_proto::encode(MSG_SPAWN_PROCESS_RESULT, spawn.seq, &payload).unwrap();
+        guest.write_all(&resp).await.unwrap();
+
+        let controls = read_guest_messages(&mut guest, &mut decoder, 2).await;
+        let mut seen = Vec::new();
+        for control in controls {
+            assert_eq!(control.msg_type, MSG_PROCESS_CONTROL);
+            let decoded_control = vsock_proto::decode_process_control(&control.payload).unwrap();
+            assert_eq!(decoded_control.target_seq, spawn.seq);
+            assert_eq!(decoded_control.control_nonce, control_nonce);
+            seen.push(SeenProcessControl {
+                request_seq: control.seq,
+                target_seq: decoded_control.target_seq,
+                control_nonce: decoded_control.control_nonce,
+                message_id: decoded_control.message_id.to_owned(),
+                payload: decoded_control.payload.to_vec(),
+            });
+        }
+
+        let first_index = seen
+            .iter()
+            .position(|control| control.message_id == "message-a")
+            .unwrap();
+        let second_index = seen
+            .iter()
+            .position(|control| control.message_id == "message-b")
+            .unwrap();
+        assert_eq!(seen[first_index].payload, b"payload-a");
+        assert_eq!(seen[second_index].payload, b"payload-b");
+
+        for control in [&seen[second_index], &seen[first_index]] {
+            send_process_control_result(
+                &mut guest,
+                control.request_seq,
+                control.target_seq,
+                control.control_nonce,
+                &control.message_id,
+                ProcessControlStatus::Delivered,
+                "",
+            )
+            .await;
+        }
+
+        let exit_payload = vsock_proto::encode_process_exit(52, 0, b"done", b"");
+        let exit_msg = vsock_proto::encode(MSG_PROCESS_EXIT, spawn.seq, &exit_payload).unwrap();
+        guest.write_all(&exit_msg).await.unwrap();
+
+        let mut discard = [0u8; 1];
+        let _ = guest.read(&mut discard).await;
+    });
+
+    let host = host_from_stream(host_stream).await.unwrap();
+    let handle = host
+        .spawn_process("sleep 1", 0, &[], false, false, None)
+        .await
+        .unwrap();
+
+    let first = handle.control("message-a", b"payload-a", Duration::from_secs(5));
+    let second = handle.control("message-b", b"payload-b", Duration::from_secs(5));
+    let (first_ack, second_ack) = tokio::join!(first, second);
+
+    assert_eq!(first_ack.unwrap().message_id, "message-a");
+    assert_eq!(second_ack.unwrap().message_id, "message-b");
 
     let event = wait_spawn(handle).await.unwrap();
     assert_eq!(event.exit_code, 0);

--- a/crates/vsock-host/src/tests/process.rs
+++ b/crates/vsock-host/src/tests/process.rs
@@ -2,13 +2,16 @@ use std::io;
 use std::sync::Arc;
 use std::time::Duration;
 
-use super::support::{host_from_stream, make_pair, mock_handshake, send_exec_result};
+use super::support::{
+    host_from_stream, make_pair, mock_handshake, read_guest_message, send_exec_result,
+};
 use crate::{ConnectionState, GuestProcessHandle, VsockHost};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::sync::{Notify, oneshot};
 use vsock_proto::{
-    Decoder, ExecTermination, MSG_ERROR, MSG_EXEC_START, MSG_PROCESS_EXIT, MSG_SPAWN_PROCESS,
-    MSG_SPAWN_PROCESS_RESULT, MSG_STDOUT_CHUNK,
+    Decoder, ExecTermination, MSG_ERROR, MSG_EXEC_START, MSG_PROCESS_CONTROL,
+    MSG_PROCESS_CONTROL_RESULT, MSG_PROCESS_EXIT, MSG_SPAWN_PROCESS, MSG_SPAWN_PROCESS_RESULT,
+    MSG_STDOUT_CHUNK, ProcessControlStatus,
 };
 
 fn registration_counts(host: &VsockHost) -> (usize, usize, usize) {
@@ -28,6 +31,27 @@ async fn wait_spawn(handle: GuestProcessHandle) -> io::Result<crate::ProcessExit
     tokio::time::timeout(Duration::from_secs(5), handle.wait())
         .await
         .expect("spawn_process exit should arrive before timeout")
+}
+
+async fn send_process_control_result(
+    guest: &mut tokio::net::UnixStream,
+    request_seq: u32,
+    target_seq: u32,
+    control_nonce: vsock_proto::ProcessControlNonce,
+    message_id: &str,
+    status: ProcessControlStatus,
+    diagnostic: &str,
+) {
+    let payload = vsock_proto::encode_process_control_result(
+        target_seq,
+        control_nonce,
+        message_id,
+        status,
+        diagnostic,
+    )
+    .unwrap();
+    let response = vsock_proto::encode(MSG_PROCESS_CONTROL_RESULT, request_seq, &payload).unwrap();
+    guest.write_all(&response).await.unwrap();
 }
 
 #[tokio::test]
@@ -71,6 +95,117 @@ async fn test_spawn_process_and_wait() {
     assert_eq!(event.pid, 42);
     assert_eq!(event.exit_code, 0);
     assert_eq!(event.stdout, b"done");
+}
+
+#[tokio::test]
+async fn test_spawn_process_control_uses_operation_seq_and_nonce() {
+    let (host_stream, mut guest) = make_pair();
+
+    tokio::spawn(async move {
+        let mut decoder = Decoder::new();
+        mock_handshake(&mut guest, &mut decoder).await;
+
+        let spawn = read_guest_message(&mut guest, &mut decoder).await;
+        assert_eq!(spawn.msg_type, MSG_SPAWN_PROCESS);
+        let decoded_spawn = vsock_proto::decode_spawn_process(&spawn.payload).unwrap();
+        let control_nonce = decoded_spawn
+            .control_nonce
+            .expect("host spawn_process should include control nonce");
+
+        let payload = vsock_proto::encode_spawn_process_result(42);
+        let resp = vsock_proto::encode(MSG_SPAWN_PROCESS_RESULT, spawn.seq, &payload).unwrap();
+        guest.write_all(&resp).await.unwrap();
+
+        let control = read_guest_message(&mut guest, &mut decoder).await;
+        assert_eq!(control.msg_type, MSG_PROCESS_CONTROL);
+        let decoded_control = vsock_proto::decode_process_control(&control.payload).unwrap();
+        assert_eq!(decoded_control.target_seq, spawn.seq);
+        assert_eq!(decoded_control.control_nonce, control_nonce);
+        assert_eq!(decoded_control.message_id, "message-1");
+        assert_eq!(decoded_control.payload, b"payload");
+
+        send_process_control_result(
+            &mut guest,
+            control.seq,
+            decoded_control.target_seq,
+            decoded_control.control_nonce,
+            decoded_control.message_id,
+            ProcessControlStatus::Delivered,
+            "",
+        )
+        .await;
+
+        let exit_payload = vsock_proto::encode_process_exit(42, 0, b"done", b"");
+        let exit_msg = vsock_proto::encode(MSG_PROCESS_EXIT, spawn.seq, &exit_payload).unwrap();
+        guest.write_all(&exit_msg).await.unwrap();
+
+        let mut discard = [0u8; 1];
+        let _ = guest.read(&mut discard).await;
+    });
+
+    let host = host_from_stream(host_stream).await.unwrap();
+    let handle = host
+        .spawn_process("sleep 1", 0, &[], false, false, None)
+        .await
+        .unwrap();
+    let ack = handle
+        .control("message-1", b"payload", Duration::from_secs(5))
+        .await
+        .unwrap();
+    assert_eq!(ack.message_id, "message-1");
+
+    let event = wait_spawn(handle).await.unwrap();
+    assert_eq!(event.exit_code, 0);
+}
+
+#[tokio::test]
+async fn test_spawn_process_control_inactive_status_returns_not_found() {
+    let (host_stream, mut guest) = make_pair();
+
+    tokio::spawn(async move {
+        let mut decoder = Decoder::new();
+        mock_handshake(&mut guest, &mut decoder).await;
+
+        let spawn = read_guest_message(&mut guest, &mut decoder).await;
+        assert_eq!(spawn.msg_type, MSG_SPAWN_PROCESS);
+        let decoded_spawn = vsock_proto::decode_spawn_process(&spawn.payload).unwrap();
+        let control_nonce = decoded_spawn.control_nonce.unwrap();
+
+        let payload = vsock_proto::encode_spawn_process_result(43);
+        let resp = vsock_proto::encode(MSG_SPAWN_PROCESS_RESULT, spawn.seq, &payload).unwrap();
+        guest.write_all(&resp).await.unwrap();
+
+        let control = read_guest_message(&mut guest, &mut decoder).await;
+        let decoded_control = vsock_proto::decode_process_control(&control.payload).unwrap();
+        assert_eq!(decoded_control.target_seq, spawn.seq);
+        assert_eq!(decoded_control.control_nonce, control_nonce);
+
+        send_process_control_result(
+            &mut guest,
+            control.seq,
+            decoded_control.target_seq,
+            decoded_control.control_nonce,
+            decoded_control.message_id,
+            ProcessControlStatus::Inactive,
+            "process operation is not active",
+        )
+        .await;
+
+        let mut discard = [0u8; 1];
+        let _ = guest.read(&mut discard).await;
+    });
+
+    let host = host_from_stream(host_stream).await.unwrap();
+    let handle = host
+        .spawn_process("sleep 1", 0, &[], false, false, None)
+        .await
+        .unwrap();
+    let err = handle
+        .control("message-2", b"payload", Duration::from_secs(5))
+        .await
+        .unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::NotFound);
+    assert_eq!(err.to_string(), "process operation is not active");
 }
 
 #[tokio::test]

--- a/crates/vsock-host/src/tests/process.rs
+++ b/crates/vsock-host/src/tests/process.rs
@@ -209,6 +209,103 @@ async fn test_spawn_process_control_inactive_status_returns_not_found() {
 }
 
 #[tokio::test]
+async fn test_spawn_process_control_nonce_mismatch_status_returns_permission_denied() {
+    let (host_stream, mut guest) = make_pair();
+
+    tokio::spawn(async move {
+        let mut decoder = Decoder::new();
+        mock_handshake(&mut guest, &mut decoder).await;
+
+        let spawn = read_guest_message(&mut guest, &mut decoder).await;
+        assert_eq!(spawn.msg_type, MSG_SPAWN_PROCESS);
+        let decoded_spawn = vsock_proto::decode_spawn_process(&spawn.payload).unwrap();
+        let control_nonce = decoded_spawn.control_nonce.unwrap();
+
+        let payload = vsock_proto::encode_spawn_process_result(46);
+        let resp = vsock_proto::encode(MSG_SPAWN_PROCESS_RESULT, spawn.seq, &payload).unwrap();
+        guest.write_all(&resp).await.unwrap();
+
+        let control = read_guest_message(&mut guest, &mut decoder).await;
+        let decoded_control = vsock_proto::decode_process_control(&control.payload).unwrap();
+        assert_eq!(decoded_control.control_nonce, control_nonce);
+
+        send_process_control_result(
+            &mut guest,
+            control.seq,
+            decoded_control.target_seq,
+            decoded_control.control_nonce,
+            decoded_control.message_id,
+            ProcessControlStatus::NonceMismatch,
+            "process operation nonce mismatch",
+        )
+        .await;
+
+        let mut discard = [0u8; 1];
+        let _ = guest.read(&mut discard).await;
+    });
+
+    let host = host_from_stream(host_stream).await.unwrap();
+    let handle = host
+        .spawn_process("sleep 1", 0, &[], false, false, None)
+        .await
+        .unwrap();
+    let err = handle
+        .control("message-5", b"payload", Duration::from_secs(5))
+        .await
+        .unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::PermissionDenied);
+    assert_eq!(err.to_string(), "process operation nonce mismatch");
+}
+
+#[tokio::test]
+async fn test_spawn_process_control_unsupported_status_returns_unsupported() {
+    let (host_stream, mut guest) = make_pair();
+
+    tokio::spawn(async move {
+        let mut decoder = Decoder::new();
+        mock_handshake(&mut guest, &mut decoder).await;
+
+        let spawn = read_guest_message(&mut guest, &mut decoder).await;
+        assert_eq!(spawn.msg_type, MSG_SPAWN_PROCESS);
+        let decoded_spawn = vsock_proto::decode_spawn_process(&spawn.payload).unwrap();
+        let control_nonce = decoded_spawn.control_nonce.unwrap();
+
+        let payload = vsock_proto::encode_spawn_process_result(48);
+        let resp = vsock_proto::encode(MSG_SPAWN_PROCESS_RESULT, spawn.seq, &payload).unwrap();
+        guest.write_all(&resp).await.unwrap();
+
+        let control = read_guest_message(&mut guest, &mut decoder).await;
+        let decoded_control = vsock_proto::decode_process_control(&control.payload).unwrap();
+
+        send_process_control_result(
+            &mut guest,
+            control.seq,
+            decoded_control.target_seq,
+            control_nonce,
+            decoded_control.message_id,
+            ProcessControlStatus::Unsupported,
+            "process control sink is not configured",
+        )
+        .await;
+
+        let mut discard = [0u8; 1];
+        let _ = guest.read(&mut discard).await;
+    });
+
+    let host = host_from_stream(host_stream).await.unwrap();
+    let handle = host
+        .spawn_process("sleep 1", 0, &[], false, false, None)
+        .await
+        .unwrap();
+    let err = handle
+        .control("message-7", b"payload", Duration::from_secs(5))
+        .await
+        .unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::Unsupported);
+    assert_eq!(err.to_string(), "process control sink is not configured");
+}
+
+#[tokio::test]
 async fn test_spawn_process_control_malformed_result_poisons_connection() {
     let (host_stream, mut guest) = make_pair();
 
@@ -256,6 +353,119 @@ async fn test_spawn_process_control_malformed_result_poisons_connection() {
     assert!(
         err.to_string()
             .contains("process_control_result target seq mismatch"),
+        "unexpected error: {err}",
+    );
+    host.wait_until_closed(Duration::from_secs(5))
+        .await
+        .unwrap();
+    assert_eq!(registration_counts(&host), (0, 0, 0));
+}
+
+#[tokio::test]
+async fn test_spawn_process_control_result_nonce_mismatch_poisons_connection() {
+    let (host_stream, mut guest) = make_pair();
+
+    tokio::spawn(async move {
+        let mut decoder = Decoder::new();
+        mock_handshake(&mut guest, &mut decoder).await;
+
+        let spawn = read_guest_message(&mut guest, &mut decoder).await;
+        assert_eq!(spawn.msg_type, MSG_SPAWN_PROCESS);
+        let decoded_spawn = vsock_proto::decode_spawn_process(&spawn.payload).unwrap();
+        let mut wrong_nonce = decoded_spawn.control_nonce.unwrap();
+        wrong_nonce[0] ^= 0xFF;
+
+        let payload = vsock_proto::encode_spawn_process_result(47);
+        let resp = vsock_proto::encode(MSG_SPAWN_PROCESS_RESULT, spawn.seq, &payload).unwrap();
+        guest.write_all(&resp).await.unwrap();
+
+        let control = read_guest_message(&mut guest, &mut decoder).await;
+        let decoded_control = vsock_proto::decode_process_control(&control.payload).unwrap();
+
+        send_process_control_result(
+            &mut guest,
+            control.seq,
+            decoded_control.target_seq,
+            wrong_nonce,
+            decoded_control.message_id,
+            ProcessControlStatus::Delivered,
+            "",
+        )
+        .await;
+
+        let mut discard = [0u8; 1];
+        let _ = guest.read(&mut discard).await;
+    });
+
+    let host = host_from_stream(host_stream).await.unwrap();
+    let handle = host
+        .spawn_process("sleep 1", 0, &[], false, false, None)
+        .await
+        .unwrap();
+    let err = handle
+        .control("message-6", b"payload", Duration::from_secs(5))
+        .await
+        .unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    assert!(
+        err.to_string()
+            .contains("process_control_result nonce mismatch"),
+        "unexpected error: {err}",
+    );
+    host.wait_until_closed(Duration::from_secs(5))
+        .await
+        .unwrap();
+    assert_eq!(registration_counts(&host), (0, 0, 0));
+}
+
+#[tokio::test]
+async fn test_spawn_process_control_result_message_id_mismatch_poisons_connection() {
+    let (host_stream, mut guest) = make_pair();
+
+    tokio::spawn(async move {
+        let mut decoder = Decoder::new();
+        mock_handshake(&mut guest, &mut decoder).await;
+
+        let spawn = read_guest_message(&mut guest, &mut decoder).await;
+        assert_eq!(spawn.msg_type, MSG_SPAWN_PROCESS);
+        let decoded_spawn = vsock_proto::decode_spawn_process(&spawn.payload).unwrap();
+        let control_nonce = decoded_spawn.control_nonce.unwrap();
+
+        let payload = vsock_proto::encode_spawn_process_result(49);
+        let resp = vsock_proto::encode(MSG_SPAWN_PROCESS_RESULT, spawn.seq, &payload).unwrap();
+        guest.write_all(&resp).await.unwrap();
+
+        let control = read_guest_message(&mut guest, &mut decoder).await;
+        let decoded_control = vsock_proto::decode_process_control(&control.payload).unwrap();
+
+        send_process_control_result(
+            &mut guest,
+            control.seq,
+            decoded_control.target_seq,
+            control_nonce,
+            "wrong-message",
+            ProcessControlStatus::Delivered,
+            "",
+        )
+        .await;
+
+        let mut discard = [0u8; 1];
+        let _ = guest.read(&mut discard).await;
+    });
+
+    let host = host_from_stream(host_stream).await.unwrap();
+    let handle = host
+        .spawn_process("sleep 1", 0, &[], false, false, None)
+        .await
+        .unwrap();
+    let err = handle
+        .control("message-8", b"payload", Duration::from_secs(5))
+        .await
+        .unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    assert!(
+        err.to_string()
+            .contains("process_control_result message_id mismatch"),
         "unexpected error: {err}",
     );
     host.wait_until_closed(Duration::from_secs(5))

--- a/crates/vsock-host/src/tests/process.rs
+++ b/crates/vsock-host/src/tests/process.rs
@@ -209,6 +209,112 @@ async fn test_spawn_process_control_inactive_status_returns_not_found() {
 }
 
 #[tokio::test]
+async fn test_spawn_process_control_malformed_result_poisons_connection() {
+    let (host_stream, mut guest) = make_pair();
+
+    tokio::spawn(async move {
+        let mut decoder = Decoder::new();
+        mock_handshake(&mut guest, &mut decoder).await;
+
+        let spawn = read_guest_message(&mut guest, &mut decoder).await;
+        assert_eq!(spawn.msg_type, MSG_SPAWN_PROCESS);
+        let decoded_spawn = vsock_proto::decode_spawn_process(&spawn.payload).unwrap();
+        let control_nonce = decoded_spawn.control_nonce.unwrap();
+
+        let payload = vsock_proto::encode_spawn_process_result(44);
+        let resp = vsock_proto::encode(MSG_SPAWN_PROCESS_RESULT, spawn.seq, &payload).unwrap();
+        guest.write_all(&resp).await.unwrap();
+
+        let control = read_guest_message(&mut guest, &mut decoder).await;
+        let decoded_control = vsock_proto::decode_process_control(&control.payload).unwrap();
+
+        send_process_control_result(
+            &mut guest,
+            control.seq,
+            decoded_control.target_seq + 1,
+            control_nonce,
+            decoded_control.message_id,
+            ProcessControlStatus::Delivered,
+            "",
+        )
+        .await;
+
+        let mut discard = [0u8; 1];
+        let _ = guest.read(&mut discard).await;
+    });
+
+    let host = host_from_stream(host_stream).await.unwrap();
+    let handle = host
+        .spawn_process("sleep 1", 0, &[], false, false, None)
+        .await
+        .unwrap();
+    let err = handle
+        .control("message-3", b"payload", Duration::from_secs(5))
+        .await
+        .unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    assert!(
+        err.to_string()
+            .contains("process_control_result target seq mismatch"),
+        "unexpected error: {err}",
+    );
+    host.wait_until_closed(Duration::from_secs(5))
+        .await
+        .unwrap();
+    assert_eq!(registration_counts(&host), (0, 0, 0));
+}
+
+#[tokio::test]
+async fn test_spawn_process_control_timeout_cleans_pending_without_poisoning() {
+    let (host_stream, mut guest) = make_pair();
+
+    tokio::spawn(async move {
+        let mut decoder = Decoder::new();
+        mock_handshake(&mut guest, &mut decoder).await;
+
+        let spawn = read_guest_message(&mut guest, &mut decoder).await;
+        assert_eq!(spawn.msg_type, MSG_SPAWN_PROCESS);
+        let payload = vsock_proto::encode_spawn_process_result(45);
+        let resp = vsock_proto::encode(MSG_SPAWN_PROCESS_RESULT, spawn.seq, &payload).unwrap();
+        guest.write_all(&resp).await.unwrap();
+
+        let control = read_guest_message(&mut guest, &mut decoder).await;
+        assert_eq!(control.msg_type, MSG_PROCESS_CONTROL);
+
+        let exec = read_guest_message(&mut guest, &mut decoder).await;
+        assert_eq!(exec.msg_type, MSG_EXEC_START);
+        send_exec_result(
+            &mut guest,
+            exec.seq,
+            ExecTermination::Exited { exit_code: 0 },
+            b"ok",
+            b"",
+        )
+        .await;
+
+        let mut discard = [0u8; 1];
+        let _ = guest.read(&mut discard).await;
+    });
+
+    let host = host_from_stream(host_stream).await.unwrap();
+    let handle = host
+        .spawn_process("sleep 1", 0, &[], false, false, None)
+        .await
+        .unwrap();
+    let err = handle
+        .control("message-4", b"payload", Duration::from_millis(1))
+        .await
+        .unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::TimedOut);
+    assert_eq!(registration_counts(&host), (0, 1, 0));
+
+    let exec_result = host.exec("echo ok", 5000, &[], false).await.unwrap();
+    assert_eq!(exec_result.stdout, b"ok");
+    drop(handle);
+    assert_eq!(registration_counts(&host), (0, 0, 0));
+}
+
+#[tokio::test]
 async fn test_exit_event_before_wait() {
     let (host_stream, mut guest) = make_pair();
 

--- a/crates/vsock-proto/src/lib.rs
+++ b/crates/vsock-proto/src/lib.rs
@@ -40,12 +40,15 @@
 //! | 0x14 | G→H       | process_control_result | `[4B target_seq][16B nonce][2B message_id_len][message_id][1B status][2B diagnostic_len][diagnostic]` |
 //! | 0xFF | G→H       | error             | `[2B error_len][error]` |
 //!
-//! Exec operation messages are request-scoped; host/guest dispatch layers
-//! must use a non-zero sequence number for start/output/result/cancel.
+//! Exec operation and process operation messages are request-scoped; host/guest
+//! dispatch layers must use a non-zero sequence number for exec
+//! start/output/result/cancel, spawn_process, and process_control messages.
 //! `exec_output.output_seq` is per exec operation and starts at 0,
 //! incrementing by 1 for each output frame across stdout and stderr.
 //! `exec_start.expected_exit_count` may be zero, but the count field is
 //! always present.
+//! `process_control_result.status` uses 0=delivered, 1=inactive,
+//! 2=nonce_mismatch, and 3=unsupported.
 
 mod error;
 mod frame;

--- a/crates/vsock-proto/src/lib.rs
+++ b/crates/vsock-proto/src/lib.rs
@@ -22,7 +22,7 @@
 //! | 0x02 | G→H       | pong              | (empty) |
 //! | 0x03 | H→G       | write_file        | `[2B path_len][path][1B flags][4B content_len][content]` (flags: `SUDO=0x01`, `APPEND=0x02`) |
 //! | 0x04 | G→H       | write_file_result | `[1B success][2B error_len][error]` |
-//! | 0x05 | H→G       | spawn_process     | `[4B timeout_ms][1B flags][4B cmd_len][command]([4B env_count]([4B key_len][key][4B val_len][value])*)([2B log_path_len][log_path])` (flags: `SUDO=0x01`, `STREAM_STDOUT=0x02`) |
+//! | 0x05 | H→G       | spawn_process     | `[4B timeout_ms][1B flags][4B cmd_len][command]([4B env_count]([4B key_len][key][4B val_len][value])*)([16B control_nonce])([2B log_path_len][log_path])` (flags: `SUDO=0x01`, `STREAM_STDOUT=0x02`, `CONTROL_NONCE=0x04`) |
 //! | 0x06 | G→H       | spawn_process_result | `[4B pid]` |
 //! | 0x07 | G→H       | process_exit      | `[4B pid][4B exit_code][4B stdout_len][stdout][4B stderr_len][stderr]` (`spawn_process` uses the original request seq; pid is metadata, not the routing key) |
 //! | 0x08 | H→G       | shutdown          | (empty) |
@@ -36,6 +36,8 @@
 //! | 0x10 | G→H       | operations_quiesced    | (empty) |
 //! | 0x11 | H→G       | resume_operations | (empty) |
 //! | 0x12 | G→H       | operations_resumed | (empty) |
+//! | 0x13 | H→G       | process_control | `[4B target_seq][16B nonce][2B message_id_len][message_id][4B payload_len][payload]` |
+//! | 0x14 | G→H       | process_control_result | `[4B target_seq][16B nonce][2B message_id_len][message_id][1B status][2B diagnostic_len][diagnostic]` |
 //! | 0xFF | G→H       | error             | `[2B error_len][error]` |
 //!
 //! Exec operation messages are request-scoped; host/guest dispatch layers
@@ -65,9 +67,14 @@ pub use payloads::exec_operation::{
 pub use payloads::process::{
     ProcessExit, decode_process_exit, decode_stdout_chunk, encode_process_exit, encode_stdout_chunk,
 };
+pub use payloads::process_control::{
+    DecodedProcessControl, DecodedProcessControlResult, PROCESS_CONTROL_NONCE_LEN,
+    ProcessControlNonce, ProcessControlStatus, decode_process_control,
+    decode_process_control_result, encode_process_control, encode_process_control_result,
+};
 pub use payloads::spawn_process::{
     DecodedSpawnProcess, decode_spawn_process, decode_spawn_process_result, encode_spawn_process,
-    encode_spawn_process_result,
+    encode_spawn_process_result, encode_spawn_process_with_control_nonce,
 };
 pub use payloads::write_file::{
     decode_write_file, decode_write_file_result, encode_write_file, encode_write_file_result,
@@ -76,8 +83,9 @@ pub use wire::{
     EXEC_CAPTURED_OUTPUT_FLAG_TRUNCATED, EXEC_FLAG_SUDO, EXEC_OUTPUT_FLAG_TRUNCATED, HEADER_SIZE,
     MAX_MESSAGE_SIZE, MIN_BODY_SIZE, MSG_ERROR, MSG_EXEC_CANCEL, MSG_EXEC_OUTPUT, MSG_EXEC_RESULT,
     MSG_EXEC_START, MSG_OPERATIONS_QUIESCED, MSG_OPERATIONS_RESUMED, MSG_PING, MSG_PONG,
-    MSG_PROCESS_EXIT, MSG_QUIESCE_OPERATIONS, MSG_READY, MSG_RESUME_OPERATIONS, MSG_SHUTDOWN,
-    MSG_SHUTDOWN_ACK, MSG_SPAWN_PROCESS, MSG_SPAWN_PROCESS_RESULT, MSG_STDOUT_CHUNK,
-    MSG_WRITE_FILE, MSG_WRITE_FILE_RESULT, SPAWN_PROCESS_FLAG_STREAM_STDOUT,
-    SPAWN_PROCESS_FLAG_SUDO, VSOCK_PORT, WRITE_FILE_FLAG_APPEND, WRITE_FILE_FLAG_SUDO,
+    MSG_PROCESS_CONTROL, MSG_PROCESS_CONTROL_RESULT, MSG_PROCESS_EXIT, MSG_QUIESCE_OPERATIONS,
+    MSG_READY, MSG_RESUME_OPERATIONS, MSG_SHUTDOWN, MSG_SHUTDOWN_ACK, MSG_SPAWN_PROCESS,
+    MSG_SPAWN_PROCESS_RESULT, MSG_STDOUT_CHUNK, MSG_WRITE_FILE, MSG_WRITE_FILE_RESULT,
+    SPAWN_PROCESS_FLAG_CONTROL_NONCE, SPAWN_PROCESS_FLAG_STREAM_STDOUT, SPAWN_PROCESS_FLAG_SUDO,
+    VSOCK_PORT, WRITE_FILE_FLAG_APPEND, WRITE_FILE_FLAG_SUDO,
 };

--- a/crates/vsock-proto/src/payloads/mod.rs
+++ b/crates/vsock-proto/src/payloads/mod.rs
@@ -2,5 +2,6 @@ pub(crate) mod empty;
 pub(crate) mod error;
 pub(crate) mod exec_operation;
 pub(crate) mod process;
+pub(crate) mod process_control;
 pub(crate) mod spawn_process;
 pub(crate) mod write_file;

--- a/crates/vsock-proto/src/payloads/process_control.rs
+++ b/crates/vsock-proto/src/payloads/process_control.rs
@@ -289,8 +289,37 @@ mod tests {
     }
 
     #[test]
+    fn process_control_rejects_zero_target_seq() {
+        let err = encode_process_control(0, NONCE, "msg-1", b"payload").unwrap_err();
+        assert!(matches!(
+            err,
+            ProtocolError::InvalidPayload("process_control target_seq must be non-zero")
+        ));
+
+        let mut encoded = encode_process_control(7, NONCE, "msg-1", b"payload").unwrap();
+        encoded[0..4].copy_from_slice(&0u32.to_be_bytes());
+
+        let err = decode_process_control(&encoded).unwrap_err();
+        assert!(matches!(
+            err,
+            ProtocolError::InvalidPayload("process_control target_seq must be non-zero")
+        ));
+    }
+
+    #[test]
     fn process_control_rejects_empty_message_id() {
         let err = encode_process_control(7, NONCE, "", b"payload").unwrap_err();
+        assert!(matches!(
+            err,
+            ProtocolError::InvalidPayload("process_control message_id empty")
+        ));
+
+        let mut encoded = encode_process_control(7, NONCE, "msg-1", b"payload").unwrap();
+        let message_id_len_offset = 4 + PROCESS_CONTROL_NONCE_LEN;
+        encoded[message_id_len_offset..message_id_len_offset + 2]
+            .copy_from_slice(&0u16.to_be_bytes());
+
+        let err = decode_process_control(&encoded).unwrap_err();
         assert!(matches!(
             err,
             ProtocolError::InvalidPayload("process_control message_id empty")
@@ -329,6 +358,51 @@ mod tests {
     }
 
     #[test]
+    fn process_control_result_rejects_zero_target_seq() {
+        let err =
+            encode_process_control_result(0, NONCE, "msg-1", ProcessControlStatus::Delivered, "")
+                .unwrap_err();
+        assert!(matches!(
+            err,
+            ProtocolError::InvalidPayload("process_control_result target_seq must be non-zero")
+        ));
+
+        let mut encoded =
+            encode_process_control_result(7, NONCE, "msg-1", ProcessControlStatus::Delivered, "")
+                .unwrap();
+        encoded[0..4].copy_from_slice(&0u32.to_be_bytes());
+
+        let err = decode_process_control_result(&encoded).unwrap_err();
+        assert!(matches!(
+            err,
+            ProtocolError::InvalidPayload("process_control_result target_seq must be non-zero")
+        ));
+    }
+
+    #[test]
+    fn process_control_result_rejects_empty_message_id() {
+        let err = encode_process_control_result(7, NONCE, "", ProcessControlStatus::Delivered, "")
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            ProtocolError::InvalidPayload("process_control_result message_id empty")
+        ));
+
+        let mut encoded =
+            encode_process_control_result(7, NONCE, "msg-1", ProcessControlStatus::Delivered, "")
+                .unwrap();
+        let message_id_len_offset = 4 + PROCESS_CONTROL_NONCE_LEN;
+        encoded[message_id_len_offset..message_id_len_offset + 2]
+            .copy_from_slice(&0u16.to_be_bytes());
+
+        let err = decode_process_control_result(&encoded).unwrap_err();
+        assert!(matches!(
+            err,
+            ProtocolError::InvalidPayload("process_control_result message_id empty")
+        ));
+    }
+
+    #[test]
     fn process_control_result_rejects_unknown_status() {
         let mut encoded =
             encode_process_control_result(7, NONCE, "msg-1", ProcessControlStatus::Delivered, "")
@@ -340,6 +414,20 @@ mod tests {
         assert!(matches!(
             err,
             ProtocolError::InvalidPayload("process_control_result status invalid")
+        ));
+    }
+
+    #[test]
+    fn process_control_result_rejects_trailing_bytes() {
+        let mut encoded =
+            encode_process_control_result(7, NONCE, "msg-1", ProcessControlStatus::Delivered, "")
+                .unwrap();
+        encoded.push(0);
+
+        let err = decode_process_control_result(&encoded).unwrap_err();
+        assert!(matches!(
+            err,
+            ProtocolError::InvalidPayload("process_control_result trailing bytes")
         ));
     }
 }

--- a/crates/vsock-proto/src/payloads/process_control.rs
+++ b/crates/vsock-proto/src/payloads/process_control.rs
@@ -1,0 +1,345 @@
+use crate::error::ProtocolError;
+use crate::read::{
+    checked_payload_len_add, ensure_payload_fits_message, ensure_u16_len, ensure_u32_len,
+    expect_consumed, read_slice, read_str, read_u8, read_u16, read_u32,
+};
+
+pub const PROCESS_CONTROL_NONCE_LEN: usize = 16;
+
+pub type ProcessControlNonce = [u8; PROCESS_CONTROL_NONCE_LEN];
+
+const PROCESS_CONTROL_STATUS_DELIVERED: u8 = 0x00;
+const PROCESS_CONTROL_STATUS_INACTIVE: u8 = 0x01;
+const PROCESS_CONTROL_STATUS_NONCE_MISMATCH: u8 = 0x02;
+const PROCESS_CONTROL_STATUS_UNSUPPORTED: u8 = 0x03;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProcessControlStatus {
+    Delivered,
+    Inactive,
+    NonceMismatch,
+    Unsupported,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DecodedProcessControl<'a> {
+    pub target_seq: u32,
+    pub control_nonce: ProcessControlNonce,
+    pub message_id: &'a str,
+    pub payload: &'a [u8],
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DecodedProcessControlResult<'a> {
+    pub target_seq: u32,
+    pub control_nonce: ProcessControlNonce,
+    pub message_id: &'a str,
+    pub status: ProcessControlStatus,
+    pub diagnostic: &'a str,
+}
+
+fn status_to_wire(status: ProcessControlStatus) -> u8 {
+    match status {
+        ProcessControlStatus::Delivered => PROCESS_CONTROL_STATUS_DELIVERED,
+        ProcessControlStatus::Inactive => PROCESS_CONTROL_STATUS_INACTIVE,
+        ProcessControlStatus::NonceMismatch => PROCESS_CONTROL_STATUS_NONCE_MISMATCH,
+        ProcessControlStatus::Unsupported => PROCESS_CONTROL_STATUS_UNSUPPORTED,
+    }
+}
+
+fn status_from_wire(value: u8) -> Result<ProcessControlStatus, ProtocolError> {
+    match value {
+        PROCESS_CONTROL_STATUS_DELIVERED => Ok(ProcessControlStatus::Delivered),
+        PROCESS_CONTROL_STATUS_INACTIVE => Ok(ProcessControlStatus::Inactive),
+        PROCESS_CONTROL_STATUS_NONCE_MISMATCH => Ok(ProcessControlStatus::NonceMismatch),
+        PROCESS_CONTROL_STATUS_UNSUPPORTED => Ok(ProcessControlStatus::Unsupported),
+        _ => Err(ProtocolError::InvalidPayload(
+            "process_control_result status invalid",
+        )),
+    }
+}
+
+fn encoded_control_len(message_id_len: usize, payload_len: usize) -> Result<usize, ProtocolError> {
+    let mut total = 4 + PROCESS_CONTROL_NONCE_LEN + 2;
+    total = checked_payload_len_add(total, message_id_len)?;
+    total = checked_payload_len_add(total, 4)?;
+    checked_payload_len_add(total, payload_len)
+}
+
+fn encoded_result_len(
+    message_id_len: usize,
+    diagnostic_len: usize,
+) -> Result<usize, ProtocolError> {
+    let mut total = 4 + PROCESS_CONTROL_NONCE_LEN + 2;
+    total = checked_payload_len_add(total, message_id_len)?;
+    total = checked_payload_len_add(total, 1 + 2)?;
+    checked_payload_len_add(total, diagnostic_len)
+}
+
+pub fn encode_process_control(
+    target_seq: u32,
+    control_nonce: ProcessControlNonce,
+    message_id: &str,
+    payload: &[u8],
+) -> Result<Vec<u8>, ProtocolError> {
+    if target_seq == 0 {
+        return Err(ProtocolError::InvalidPayload(
+            "process_control target_seq must be non-zero",
+        ));
+    }
+    if message_id.is_empty() {
+        return Err(ProtocolError::InvalidPayload(
+            "process_control message_id empty",
+        ));
+    }
+    let message_id_len = ensure_u16_len("message_id", message_id.len())?;
+    let payload_len = ensure_u32_len("payload", payload.len())?;
+    let total_len = encoded_control_len(message_id.len(), payload.len())?;
+    ensure_payload_fits_message(total_len)?;
+
+    let mut out = Vec::with_capacity(total_len);
+    out.extend_from_slice(&target_seq.to_be_bytes());
+    out.extend_from_slice(&control_nonce);
+    out.extend_from_slice(&message_id_len.to_be_bytes());
+    out.extend_from_slice(message_id.as_bytes());
+    out.extend_from_slice(&payload_len.to_be_bytes());
+    out.extend_from_slice(payload);
+    Ok(out)
+}
+
+pub fn decode_process_control(payload: &[u8]) -> Result<DecodedProcessControl<'_>, ProtocolError> {
+    let mut offset = 0;
+    let target_seq = read_u32(payload, &mut offset, "process_control target_seq truncated")?;
+    if target_seq == 0 {
+        return Err(ProtocolError::InvalidPayload(
+            "process_control target_seq must be non-zero",
+        ));
+    }
+    let nonce_bytes = read_slice(
+        payload,
+        &mut offset,
+        PROCESS_CONTROL_NONCE_LEN,
+        "process_control nonce truncated",
+    )?;
+    let control_nonce: ProcessControlNonce = nonce_bytes
+        .try_into()
+        .map_err(|_| ProtocolError::InvalidPayload("process_control nonce invalid"))?;
+    let message_id_len = read_u16(
+        payload,
+        &mut offset,
+        "process_control message_id_len truncated",
+    )? as usize;
+    if message_id_len == 0 {
+        return Err(ProtocolError::InvalidPayload(
+            "process_control message_id empty",
+        ));
+    }
+    let message_id = read_str(
+        payload,
+        &mut offset,
+        message_id_len,
+        "process_control message_id truncated",
+        "invalid UTF-8 in process_control message_id",
+    )?;
+    let payload_len = read_u32(
+        payload,
+        &mut offset,
+        "process_control payload_len truncated",
+    )? as usize;
+    let message_payload = read_slice(
+        payload,
+        &mut offset,
+        payload_len,
+        "process_control payload truncated",
+    )?;
+    expect_consumed(payload, offset, "process_control trailing bytes")?;
+
+    Ok(DecodedProcessControl {
+        target_seq,
+        control_nonce,
+        message_id,
+        payload: message_payload,
+    })
+}
+
+pub fn encode_process_control_result(
+    target_seq: u32,
+    control_nonce: ProcessControlNonce,
+    message_id: &str,
+    status: ProcessControlStatus,
+    diagnostic: &str,
+) -> Result<Vec<u8>, ProtocolError> {
+    if target_seq == 0 {
+        return Err(ProtocolError::InvalidPayload(
+            "process_control_result target_seq must be non-zero",
+        ));
+    }
+    if message_id.is_empty() {
+        return Err(ProtocolError::InvalidPayload(
+            "process_control_result message_id empty",
+        ));
+    }
+    let message_id_len = ensure_u16_len("message_id", message_id.len())?;
+    let diagnostic_len = ensure_u16_len("diagnostic", diagnostic.len())?;
+    let total_len = encoded_result_len(message_id.len(), diagnostic.len())?;
+    ensure_payload_fits_message(total_len)?;
+
+    let mut out = Vec::with_capacity(total_len);
+    out.extend_from_slice(&target_seq.to_be_bytes());
+    out.extend_from_slice(&control_nonce);
+    out.extend_from_slice(&message_id_len.to_be_bytes());
+    out.extend_from_slice(message_id.as_bytes());
+    out.push(status_to_wire(status));
+    out.extend_from_slice(&diagnostic_len.to_be_bytes());
+    out.extend_from_slice(diagnostic.as_bytes());
+    Ok(out)
+}
+
+pub fn decode_process_control_result(
+    payload: &[u8],
+) -> Result<DecodedProcessControlResult<'_>, ProtocolError> {
+    let mut offset = 0;
+    let target_seq = read_u32(
+        payload,
+        &mut offset,
+        "process_control_result target_seq truncated",
+    )?;
+    if target_seq == 0 {
+        return Err(ProtocolError::InvalidPayload(
+            "process_control_result target_seq must be non-zero",
+        ));
+    }
+    let nonce_bytes = read_slice(
+        payload,
+        &mut offset,
+        PROCESS_CONTROL_NONCE_LEN,
+        "process_control_result nonce truncated",
+    )?;
+    let control_nonce: ProcessControlNonce = nonce_bytes
+        .try_into()
+        .map_err(|_| ProtocolError::InvalidPayload("process_control_result nonce invalid"))?;
+    let message_id_len = read_u16(
+        payload,
+        &mut offset,
+        "process_control_result message_id_len truncated",
+    )? as usize;
+    if message_id_len == 0 {
+        return Err(ProtocolError::InvalidPayload(
+            "process_control_result message_id empty",
+        ));
+    }
+    let message_id = read_str(
+        payload,
+        &mut offset,
+        message_id_len,
+        "process_control_result message_id truncated",
+        "invalid UTF-8 in process_control_result message_id",
+    )?;
+    let status = status_from_wire(read_u8(
+        payload,
+        &mut offset,
+        "process_control_result status truncated",
+    )?)?;
+    let diagnostic_len = read_u16(
+        payload,
+        &mut offset,
+        "process_control_result diagnostic_len truncated",
+    )? as usize;
+    let diagnostic = read_str(
+        payload,
+        &mut offset,
+        diagnostic_len,
+        "process_control_result diagnostic truncated",
+        "invalid UTF-8 in process_control_result diagnostic",
+    )?;
+    expect_consumed(payload, offset, "process_control_result trailing bytes")?;
+
+    Ok(DecodedProcessControlResult {
+        target_seq,
+        control_nonce,
+        message_id,
+        status,
+        diagnostic,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const NONCE: ProcessControlNonce = *b"0123456789abcdef";
+
+    #[test]
+    fn process_control_roundtrip() {
+        let encoded = encode_process_control(7, NONCE, "msg-1", b"hello").unwrap();
+        let decoded = decode_process_control(&encoded).unwrap();
+
+        assert_eq!(decoded.target_seq, 7);
+        assert_eq!(decoded.control_nonce, NONCE);
+        assert_eq!(decoded.message_id, "msg-1");
+        assert_eq!(decoded.payload, b"hello");
+    }
+
+    #[test]
+    fn process_control_allows_empty_payload() {
+        let encoded = encode_process_control(7, NONCE, "msg-1", b"").unwrap();
+        let decoded = decode_process_control(&encoded).unwrap();
+
+        assert_eq!(decoded.payload, b"");
+    }
+
+    #[test]
+    fn process_control_rejects_empty_message_id() {
+        let err = encode_process_control(7, NONCE, "", b"payload").unwrap_err();
+        assert!(matches!(
+            err,
+            ProtocolError::InvalidPayload("process_control message_id empty")
+        ));
+    }
+
+    #[test]
+    fn process_control_rejects_trailing_bytes() {
+        let mut encoded = encode_process_control(7, NONCE, "msg-1", b"hello").unwrap();
+        encoded.push(0);
+
+        let err = decode_process_control(&encoded).unwrap_err();
+        assert!(matches!(
+            err,
+            ProtocolError::InvalidPayload("process_control trailing bytes")
+        ));
+    }
+
+    #[test]
+    fn process_control_result_roundtrip() {
+        let encoded = encode_process_control_result(
+            7,
+            NONCE,
+            "msg-1",
+            ProcessControlStatus::Inactive,
+            "not active",
+        )
+        .unwrap();
+        let decoded = decode_process_control_result(&encoded).unwrap();
+
+        assert_eq!(decoded.target_seq, 7);
+        assert_eq!(decoded.control_nonce, NONCE);
+        assert_eq!(decoded.message_id, "msg-1");
+        assert_eq!(decoded.status, ProcessControlStatus::Inactive);
+        assert_eq!(decoded.diagnostic, "not active");
+    }
+
+    #[test]
+    fn process_control_result_rejects_unknown_status() {
+        let mut encoded =
+            encode_process_control_result(7, NONCE, "msg-1", ProcessControlStatus::Delivered, "")
+                .unwrap();
+        let status_offset = 4 + PROCESS_CONTROL_NONCE_LEN + 2 + "msg-1".len();
+        encoded[status_offset] = 0xFE;
+
+        let err = decode_process_control_result(&encoded).unwrap_err();
+        assert!(matches!(
+            err,
+            ProtocolError::InvalidPayload("process_control_result status invalid")
+        ));
+    }
+}

--- a/crates/vsock-proto/src/payloads/process_control.rs
+++ b/crates/vsock-proto/src/payloads/process_control.rs
@@ -269,6 +269,10 @@ mod tests {
 
     const NONCE: ProcessControlNonce = *b"0123456789abcdef";
 
+    fn assert_invalid_payload(err: ProtocolError, expected: &'static str) {
+        assert!(matches!(err, ProtocolError::InvalidPayload(msg) if msg == expected));
+    }
+
     #[test]
     fn process_control_roundtrip() {
         let encoded = encode_process_control(7, NONCE, "msg-1", b"hello").unwrap();
@@ -332,10 +336,51 @@ mod tests {
         encoded.push(0);
 
         let err = decode_process_control(&encoded).unwrap_err();
-        assert!(matches!(
-            err,
-            ProtocolError::InvalidPayload("process_control trailing bytes")
-        ));
+        assert_invalid_payload(err, "process_control trailing bytes");
+    }
+
+    #[test]
+    fn process_control_rejects_truncated_fields() {
+        let encoded = encode_process_control(7, NONCE, "msg-1", b"hello").unwrap();
+        let message_id_len_offset = 4 + PROCESS_CONTROL_NONCE_LEN;
+        let message_id_offset = message_id_len_offset + 2;
+        let payload_len_offset = message_id_offset + "msg-1".len();
+        let payload_offset = payload_len_offset + 4;
+
+        assert_invalid_payload(
+            decode_process_control(&encoded[..3]).unwrap_err(),
+            "process_control target_seq truncated",
+        );
+        assert_invalid_payload(
+            decode_process_control(&encoded[..4 + PROCESS_CONTROL_NONCE_LEN - 1]).unwrap_err(),
+            "process_control nonce truncated",
+        );
+        assert_invalid_payload(
+            decode_process_control(&encoded[..message_id_len_offset + 1]).unwrap_err(),
+            "process_control message_id_len truncated",
+        );
+        assert_invalid_payload(
+            decode_process_control(&encoded[..message_id_offset + 2]).unwrap_err(),
+            "process_control message_id truncated",
+        );
+        assert_invalid_payload(
+            decode_process_control(&encoded[..payload_len_offset + 3]).unwrap_err(),
+            "process_control payload_len truncated",
+        );
+        assert_invalid_payload(
+            decode_process_control(&encoded[..payload_offset + 2]).unwrap_err(),
+            "process_control payload truncated",
+        );
+    }
+
+    #[test]
+    fn process_control_rejects_invalid_utf8_message_id() {
+        let mut encoded = encode_process_control(7, NONCE, "msg-1", b"hello").unwrap();
+        let message_id_offset = 4 + PROCESS_CONTROL_NONCE_LEN + 2;
+        encoded[message_id_offset] = 0xFF;
+
+        let err = decode_process_control(&encoded).unwrap_err();
+        assert_invalid_payload(err, "invalid UTF-8 in process_control message_id");
     }
 
     #[test]
@@ -425,9 +470,82 @@ mod tests {
         encoded.push(0);
 
         let err = decode_process_control_result(&encoded).unwrap_err();
-        assert!(matches!(
-            err,
-            ProtocolError::InvalidPayload("process_control_result trailing bytes")
-        ));
+        assert_invalid_payload(err, "process_control_result trailing bytes");
+    }
+
+    #[test]
+    fn process_control_result_rejects_truncated_fields() {
+        let encoded = encode_process_control_result(
+            7,
+            NONCE,
+            "msg-1",
+            ProcessControlStatus::Delivered,
+            "diagnostic",
+        )
+        .unwrap();
+        let message_id_len_offset = 4 + PROCESS_CONTROL_NONCE_LEN;
+        let message_id_offset = message_id_len_offset + 2;
+        let status_offset = message_id_offset + "msg-1".len();
+        let diagnostic_len_offset = status_offset + 1;
+        let diagnostic_offset = diagnostic_len_offset + 2;
+
+        assert_invalid_payload(
+            decode_process_control_result(&encoded[..3]).unwrap_err(),
+            "process_control_result target_seq truncated",
+        );
+        assert_invalid_payload(
+            decode_process_control_result(&encoded[..4 + PROCESS_CONTROL_NONCE_LEN - 1])
+                .unwrap_err(),
+            "process_control_result nonce truncated",
+        );
+        assert_invalid_payload(
+            decode_process_control_result(&encoded[..message_id_len_offset + 1]).unwrap_err(),
+            "process_control_result message_id_len truncated",
+        );
+        assert_invalid_payload(
+            decode_process_control_result(&encoded[..message_id_offset + 2]).unwrap_err(),
+            "process_control_result message_id truncated",
+        );
+        assert_invalid_payload(
+            decode_process_control_result(&encoded[..status_offset]).unwrap_err(),
+            "process_control_result status truncated",
+        );
+        assert_invalid_payload(
+            decode_process_control_result(&encoded[..diagnostic_len_offset + 1]).unwrap_err(),
+            "process_control_result diagnostic_len truncated",
+        );
+        assert_invalid_payload(
+            decode_process_control_result(&encoded[..diagnostic_offset + 3]).unwrap_err(),
+            "process_control_result diagnostic truncated",
+        );
+    }
+
+    #[test]
+    fn process_control_result_rejects_invalid_utf8_strings() {
+        let mut encoded = encode_process_control_result(
+            7,
+            NONCE,
+            "msg-1",
+            ProcessControlStatus::Delivered,
+            "diagnostic",
+        )
+        .unwrap();
+        let message_id_offset = 4 + PROCESS_CONTROL_NONCE_LEN + 2;
+        encoded[message_id_offset] = 0xFF;
+        let err = decode_process_control_result(&encoded).unwrap_err();
+        assert_invalid_payload(err, "invalid UTF-8 in process_control_result message_id");
+
+        let mut encoded = encode_process_control_result(
+            7,
+            NONCE,
+            "msg-1",
+            ProcessControlStatus::Delivered,
+            "diagnostic",
+        )
+        .unwrap();
+        let diagnostic_offset = 4 + PROCESS_CONTROL_NONCE_LEN + 2 + "msg-1".len() + 1 + 2;
+        encoded[diagnostic_offset] = 0xFF;
+        let err = decode_process_control_result(&encoded).unwrap_err();
+        assert_invalid_payload(err, "invalid UTF-8 in process_control_result diagnostic");
     }
 }

--- a/crates/vsock-proto/src/payloads/spawn_process.rs
+++ b/crates/vsock-proto/src/payloads/spawn_process.rs
@@ -439,6 +439,18 @@ mod tests {
     }
 
     #[test]
+    fn decode_spawn_process_rejects_truncated_control_nonce() {
+        let mut payload = encode_spawn_process(1000, "cmd", &[], false, true, None).unwrap();
+        payload[4] |= SPAWN_PROCESS_FLAG_CONTROL_NONCE;
+
+        let err = decode_spawn_process_error(&payload);
+        assert!(matches!(
+            err,
+            ProtocolError::InvalidPayload("spawn_process control nonce truncated")
+        ));
+    }
+
+    #[test]
     fn decode_spawn_process_rejects_trailing_bytes_after_log_path() {
         let mut payload =
             encode_spawn_process(1000, "cmd", &[], false, true, Some("/tmp/log")).unwrap();

--- a/crates/vsock-proto/src/payloads/spawn_process.rs
+++ b/crates/vsock-proto/src/payloads/spawn_process.rs
@@ -1,6 +1,9 @@
 use crate::error::ProtocolError;
+use crate::payloads::process_control::{PROCESS_CONTROL_NONCE_LEN, ProcessControlNonce};
 use crate::read::{read_u8_at, read_u16_at, read_u32_at};
-use crate::wire::{SPAWN_PROCESS_FLAG_STREAM_STDOUT, SPAWN_PROCESS_FLAG_SUDO};
+use crate::wire::{
+    SPAWN_PROCESS_FLAG_CONTROL_NONCE, SPAWN_PROCESS_FLAG_STREAM_STDOUT, SPAWN_PROCESS_FLAG_SUDO,
+};
 
 /// Encode spawn_process payload: command fields + optional `[2B log_path_len][log_path]`.
 ///
@@ -16,6 +19,46 @@ pub fn encode_spawn_process(
     env: &[(&str, &str)],
     sudo: bool,
     stream_stdout: bool,
+    stdout_log_path: Option<&str>,
+) -> Result<Vec<u8>, ProtocolError> {
+    encode_spawn_process_inner(
+        timeout_ms,
+        command,
+        env,
+        sudo,
+        stream_stdout,
+        None,
+        stdout_log_path,
+    )
+}
+
+pub fn encode_spawn_process_with_control_nonce(
+    timeout_ms: u32,
+    command: &str,
+    env: &[(&str, &str)],
+    sudo: bool,
+    stream_stdout: bool,
+    control_nonce: ProcessControlNonce,
+    stdout_log_path: Option<&str>,
+) -> Result<Vec<u8>, ProtocolError> {
+    encode_spawn_process_inner(
+        timeout_ms,
+        command,
+        env,
+        sudo,
+        stream_stdout,
+        Some(control_nonce),
+        stdout_log_path,
+    )
+}
+
+fn encode_spawn_process_inner(
+    timeout_ms: u32,
+    command: &str,
+    env: &[(&str, &str)],
+    sudo: bool,
+    stream_stdout: bool,
+    control_nonce: Option<ProcessControlNonce>,
     stdout_log_path: Option<&str>,
 ) -> Result<Vec<u8>, ProtocolError> {
     if !stream_stdout && stdout_log_path.is_some() {
@@ -40,12 +83,16 @@ pub fn encode_spawn_process(
         Some(path) => Some((path.as_bytes(), path.len() as u16)),
         None => None,
     };
+    let nonce_size = control_nonce.map_or(0, |_| PROCESS_CONTROL_NONCE_LEN);
     let log_size = log_path.map_or(0, |(_, len)| 2 + len as usize);
-    let mut p = Vec::with_capacity(9 + cmd.len() + env_size + log_size);
+    let mut p = Vec::with_capacity(9 + cmd.len() + env_size + nonce_size + log_size);
     p.extend_from_slice(&timeout_ms.to_be_bytes());
     let mut flags = if sudo { SPAWN_PROCESS_FLAG_SUDO } else { 0 };
     if stream_stdout {
         flags |= SPAWN_PROCESS_FLAG_STREAM_STDOUT;
+    }
+    if control_nonce.is_some() {
+        flags |= SPAWN_PROCESS_FLAG_CONTROL_NONCE;
     }
     p.push(flags);
     p.extend_from_slice(&(cmd.len() as u32).to_be_bytes());
@@ -59,6 +106,9 @@ pub fn encode_spawn_process(
         p.extend_from_slice(kb);
         p.extend_from_slice(&(vb.len() as u32).to_be_bytes());
         p.extend_from_slice(vb);
+    }
+    if let Some(control_nonce) = control_nonce {
+        p.extend_from_slice(&control_nonce);
     }
     if let Some((path_bytes, path_len)) = log_path {
         p.extend_from_slice(&path_len.to_be_bytes());
@@ -169,10 +219,29 @@ pub fn decode_spawn_process(payload: &[u8]) -> Result<DecodedSpawnProcess<'_>, P
         command,
         env,
         sudo,
-        offset,
+        mut offset,
         raw_flags,
     } = decode_spawn_process_command_prefix(payload)?;
     let stream_flag = (raw_flags & SPAWN_PROCESS_FLAG_STREAM_STDOUT) != 0;
+    let control_nonce = if (raw_flags & SPAWN_PROCESS_FLAG_CONTROL_NONCE) != 0 {
+        let nonce_end =
+            offset
+                .checked_add(PROCESS_CONTROL_NONCE_LEN)
+                .ok_or(ProtocolError::InvalidPayload(
+                    "spawn_process control nonce truncated",
+                ))?;
+        let nonce: ProcessControlNonce = payload
+            .get(offset..nonce_end)
+            .ok_or(ProtocolError::InvalidPayload(
+                "spawn_process control nonce truncated",
+            ))?
+            .try_into()
+            .map_err(|_| ProtocolError::InvalidPayload("spawn_process control nonce invalid"))?;
+        offset = nonce_end;
+        Some(nonce)
+    } else {
+        None
+    };
     let stdout_log_path = if offset == payload.len() {
         None
     } else if offset + 2 <= payload.len() {
@@ -212,6 +281,7 @@ pub fn decode_spawn_process(payload: &[u8]) -> Result<DecodedSpawnProcess<'_>, P
         command,
         env,
         sudo,
+        control_nonce,
         stream_stdout: stream_flag,
         stdout_log_path,
     })
@@ -230,6 +300,8 @@ pub struct DecodedSpawnProcess<'a> {
     pub command: &'a str,
     pub env: Vec<(&'a str, &'a str)>,
     pub sudo: bool,
+    /// Host-generated nonce used to bind process-control requests to this process operation.
+    pub control_nonce: Option<ProcessControlNonce>,
     /// Whether vsock-guest should stream stdout chunks to the host.
     pub stream_stdout: bool,
     /// Optional guest-side file path where vsock-guest also tees stdout.
@@ -239,6 +311,8 @@ pub struct DecodedSpawnProcess<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    const NONCE: ProcessControlNonce = *b"0123456789abcdef";
 
     #[test]
     fn spawn_process_result_roundtrip() {
@@ -263,6 +337,27 @@ mod tests {
         assert_eq!(d.command, "echo hello");
         assert_eq!(d.env, vec![("FOO", "bar")]);
         assert!(!d.sudo);
+        assert!(d.stream_stdout);
+        assert_eq!(d.stdout_log_path.unwrap(), "/tmp/vm0-system-123.log");
+    }
+
+    #[test]
+    fn spawn_process_payload_roundtrip_with_control_nonce() {
+        let payload = encode_spawn_process_with_control_nonce(
+            5000,
+            "echo hello",
+            &[("FOO", "bar")],
+            false,
+            true,
+            NONCE,
+            Some("/tmp/vm0-system-123.log"),
+        )
+        .unwrap();
+        let d = decode_spawn_process(&payload).unwrap();
+        assert_eq!(d.timeout_ms, 5000);
+        assert_eq!(d.command, "echo hello");
+        assert_eq!(d.env, vec![("FOO", "bar")]);
+        assert_eq!(d.control_nonce, Some(NONCE));
         assert!(d.stream_stdout);
         assert_eq!(d.stdout_log_path.unwrap(), "/tmp/vm0-system-123.log");
     }

--- a/crates/vsock-proto/src/payloads/spawn_process.rs
+++ b/crates/vsock-proto/src/payloads/spawn_process.rs
@@ -5,6 +5,9 @@ use crate::wire::{
     SPAWN_PROCESS_FLAG_CONTROL_NONCE, SPAWN_PROCESS_FLAG_STREAM_STDOUT, SPAWN_PROCESS_FLAG_SUDO,
 };
 
+const SPAWN_PROCESS_KNOWN_FLAGS: u8 =
+    SPAWN_PROCESS_FLAG_SUDO | SPAWN_PROCESS_FLAG_STREAM_STDOUT | SPAWN_PROCESS_FLAG_CONTROL_NONCE;
+
 /// Encode spawn_process payload: command fields + optional `[2B log_path_len][log_path]`.
 ///
 /// `stream_stdout` controls whether stdout is streamed to the host via
@@ -145,6 +148,9 @@ fn decode_spawn_process_command_prefix(
     let flags = read_u8_at(payload, 4).ok_or(ProtocolError::InvalidPayload(
         "command fields payload too short",
     ))?;
+    if flags & !SPAWN_PROCESS_KNOWN_FLAGS != 0 {
+        return Err(ProtocolError::InvalidPayload("spawn_process flags invalid"));
+    }
     let sudo = (flags & SPAWN_PROCESS_FLAG_SUDO) != 0;
     let cmd_len = read_u32_at(payload, 5).ok_or(ProtocolError::InvalidPayload(
         "command fields payload too short",
@@ -456,6 +462,18 @@ mod tests {
         assert!(matches!(
             err,
             ProtocolError::InvalidPayload("spawn_process log_path requires stream flag")
+        ));
+    }
+
+    #[test]
+    fn decode_spawn_process_rejects_unknown_flags() {
+        let mut payload = encode_spawn_process(1000, "cmd", &[], false, false, None).unwrap();
+        payload[4] |= 0x80;
+
+        let err = decode_spawn_process_error(&payload);
+        assert!(matches!(
+            err,
+            ProtocolError::InvalidPayload("spawn_process flags invalid")
         ));
     }
 }

--- a/crates/vsock-proto/src/wire.rs
+++ b/crates/vsock-proto/src/wire.rs
@@ -27,6 +27,8 @@ pub const MSG_QUIESCE_OPERATIONS: u8 = 0x0F;
 pub const MSG_OPERATIONS_QUIESCED: u8 = 0x10;
 pub const MSG_RESUME_OPERATIONS: u8 = 0x11;
 pub const MSG_OPERATIONS_RESUMED: u8 = 0x12;
+pub const MSG_PROCESS_CONTROL: u8 = 0x13;
+pub const MSG_PROCESS_CONTROL_RESULT: u8 = 0x14;
 pub const MSG_ERROR: u8 = 0xFF;
 
 /// Default vsock port for host-guest communication.
@@ -35,6 +37,7 @@ pub const VSOCK_PORT: u32 = 1000;
 // Spawn-process payload flags.
 pub const SPAWN_PROCESS_FLAG_SUDO: u8 = 0x01;
 pub const SPAWN_PROCESS_FLAG_STREAM_STDOUT: u8 = 0x02;
+pub const SPAWN_PROCESS_FLAG_CONTROL_NONCE: u8 = 0x04;
 
 // Exec operation payload flags.
 pub const EXEC_FLAG_SUDO: u8 = 0x01;
@@ -55,6 +58,12 @@ mod tests {
     fn spawn_process_keeps_existing_wire_values() {
         assert_eq!(MSG_SPAWN_PROCESS, 0x05);
         assert_eq!(MSG_SPAWN_PROCESS_RESULT, 0x06);
+    }
+
+    #[test]
+    fn process_control_keeps_wire_values() {
+        assert_eq!(MSG_PROCESS_CONTROL, 0x13);
+        assert_eq!(MSG_PROCESS_CONTROL_RESULT, 0x14);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add process-control request/result payloads and wire types bound to spawn_process sequence + nonce
- generate a per-spawn control nonce on the host and expose a cloneable control handle
- add guest-side process-control registry with nonce validation and deterministic inactive/unsupported responses
- linearize control validation with process_exit writer ordering to avoid late-control races

This PR establishes the operation-bound control plane foundation. The guest-agent local sink is not wired yet; active validated controls currently return an explicit unsupported result until that follow-up lands.

## Tests
- cargo test --manifest-path crates/Cargo.toml -p vsock-proto
- cargo test --manifest-path crates/Cargo.toml -p vsock-host
- cargo test --manifest-path crates/Cargo.toml -p vsock-guest
- cargo test --manifest-path crates/Cargo.toml -p sandbox-fc
- cargo clippy --manifest-path crates/Cargo.toml -p vsock-proto -p vsock-host -p vsock-guest -p sandbox-fc --all-targets -- -D warnings

Refs #13363