### PR TITLE
refactor(vsock-host): track bounded normal operations

### DIFF
--- a/crates/vsock-host/src/exec_operation.rs
+++ b/crates/vsock-host/src/exec_operation.rs
@@ -8,7 +8,10 @@ use tokio::io::AsyncWriteExt;
 use tokio::sync::{mpsc, oneshot};
 use tokio::time::Instant;
 
-use crate::{ConnectionState, ExecResult, Shared};
+use crate::{
+    ConnectionState, ExecResult, Shared, normal_operation_transition_error,
+    operation_tracker::NormalOperationToken,
+};
 use vsock_proto::{
     ExecCapturedOutput, ExecOutputPolicy, ExecOutputStream, ExecTermination, MSG_EXEC_CANCEL,
     MSG_EXEC_START, RawMessage,
@@ -166,6 +169,7 @@ impl Default for Operations {
 }
 
 struct ExecOperation {
+    normal_operation: NormalOperationToken,
     diagnostic: ExecOperationDiagnostic,
     result_tx: oneshot::Sender<io::Result<ExecOperationResult>>,
     stream_tx: Option<mpsc::Sender<ExecOutputEvent>>,
@@ -393,6 +397,7 @@ impl ExecOperationHandle {
             seq,
             &payload,
             Some(self.diagnostic.frame("cancel")),
+            None,
         )
         .await?;
         tracing::info!(
@@ -535,6 +540,7 @@ impl Drop for ExecOperationCancelOnDropGuard {
                     seq,
                     &payload,
                     Some(diagnostic.frame("drop-cancel")),
+                    None,
                 ),
             )
             .await;
@@ -837,56 +843,94 @@ pub(crate) fn dispatch_output(shared: &Arc<Shared>, msg: &RawMessage) -> io::Res
 }
 
 pub(crate) fn dispatch_result(shared: &Arc<Shared>, msg: &RawMessage) -> io::Result<()> {
-    let (operation, decoded) = {
+    let Some((diagnostic, result_tx, stream_overflowed, decoded)) = ({
         let mut guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
         match &mut *guard {
             ConnectionState::Connected { operations, .. } if operations.contains(msg.seq) => {
                 let decoded = vsock_proto::decode_exec_result(&msg.payload)
                     .map_err(exec_operation_protocol_error)?;
-                (operations.take(msg.seq), decoded)
+                let Some(operation) = operations.take(msg.seq) else {
+                    return Ok(());
+                };
+                validate_result(&operation, &decoded)?;
+                let ExecOperation {
+                    normal_operation,
+                    diagnostic,
+                    result_tx,
+                    stream_overflowed,
+                    ..
+                } = operation;
+                normal_operation
+                    .complete()
+                    .map_err(normal_operation_transition_error)?;
+                Some((diagnostic, result_tx, stream_overflowed, decoded))
             }
-            ConnectionState::Connected { .. } | ConnectionState::Closed { .. } => {
-                return Ok(());
-            }
+            ConnectionState::Connected { .. } | ConnectionState::Closed { .. } => None,
         }
+    }) else {
+        return Ok(());
     };
 
-    if let Some(operation) = operation {
-        validate_result(&operation, &decoded)?;
-        operation
-            .diagnostic
-            .log_terminal(&decoded, operation.stream_overflowed);
-        let ExecOperation {
-            result_tx,
-            stream_overflowed,
-            ..
-        } = operation;
-        let result = owned_result(decoded, stream_overflowed);
-        let _ = result_tx.send(Ok(result));
-    }
+    diagnostic.log_terminal(&decoded, stream_overflowed);
+    let result = owned_result(decoded, stream_overflowed);
+    let _ = result_tx.send(Ok(result));
 
     Ok(())
 }
 
 pub(crate) fn dispatch_error(shared: &Arc<Shared>, msg: &RawMessage) -> io::Result<bool> {
-    let operation = {
+    let Some((diagnostic, result_tx, err)) = ({
         let mut guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
         match &mut *guard {
-            ConnectionState::Connected { operations, .. } => operations.take(msg.seq),
-            ConnectionState::Closed { .. } => None,
+            ConnectionState::Connected { operations, .. } if operations.contains(msg.seq) => {
+                let err = vsock_proto::decode_error(&msg.payload)
+                    .map(|message| io::Error::other(message.to_string()))
+                    .map_err(exec_operation_protocol_error)?;
+                let Some(operation) = operations.take(msg.seq) else {
+                    return Ok(false);
+                };
+                let ExecOperation {
+                    normal_operation,
+                    diagnostic,
+                    result_tx,
+                    ..
+                } = operation;
+                normal_operation
+                    .complete()
+                    .map_err(normal_operation_transition_error)?;
+                Some((diagnostic, result_tx, err))
+            }
+            ConnectionState::Connected { .. } | ConnectionState::Closed { .. } => None,
         }
+    }) else {
+        return Ok(false);
     };
 
-    if let Some(operation) = operation {
-        let err = vsock_proto::decode_error(&msg.payload)
-            .map(|message| io::Error::other(message.to_string()))
-            .map_err(exec_operation_protocol_error)?;
-        operation.diagnostic.log_error_response(&err);
-        let _ = operation.result_tx.send(Err(err));
-        return Ok(true);
-    }
+    diagnostic.log_error_response(&err);
+    let _ = result_tx.send(Err(err));
+    Ok(true)
+}
 
-    Ok(false)
+fn mark_exec_operation_possible_guest_write(shared: &Arc<Shared>, seq: u32) -> io::Result<()> {
+    let mut guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
+    match &mut *guard {
+        ConnectionState::Connected { operations, .. } => {
+            let Some(operation) = operations.get_mut(seq) else {
+                return Err(io::Error::new(
+                    io::ErrorKind::ConnectionReset,
+                    "exec operation closed before frame write",
+                ));
+            };
+            operation
+                .normal_operation
+                .mark_possible_guest_write_started()
+                .map_err(normal_operation_transition_error)
+        }
+        ConnectionState::Closed { .. } => Err(io::Error::new(
+            io::ErrorKind::ConnectionReset,
+            "connection closed",
+        )),
+    }
 }
 
 async fn write_frame(
@@ -895,6 +939,7 @@ async fn write_frame(
     seq: u32,
     payload: &[u8],
     diagnostic: Option<ExecOperationFrameDiagnostic>,
+    normal_operation_seq: Option<u32>,
 ) -> io::Result<()> {
     let data = vsock_proto::encode(msg_type, seq, payload)
         .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e.to_string()))?;
@@ -904,6 +949,9 @@ async fn write_frame(
     let wait_started_at = Instant::now();
     let mut writer = shared.writer.lock().await;
     let wait_elapsed_ms = wait_started_at.elapsed().as_millis();
+    if let Some(normal_operation_seq) = normal_operation_seq {
+        mark_exec_operation_possible_guest_write(shared, normal_operation_seq)?;
+    }
     state.store(EXEC_OPERATION_FRAME_WRITE_STARTED, Ordering::Release);
     let write_started_at = Instant::now();
     let result = writer.write_all(&data).await;
@@ -1089,7 +1137,9 @@ pub(crate) async fn start_exec_operation_on_shared(
     let (result_tx, result_rx) = oneshot::channel();
     let seq = shared.next_seq();
     let diagnostic = ExecOperationDiagnostic::new(seq, request.label, request.expected_exit_codes);
+    let normal_operation = shared.reserve_normal_operation()?;
     let operation = ExecOperation {
+        normal_operation,
         diagnostic: diagnostic.clone(),
         result_tx,
         stream_tx,
@@ -1123,6 +1173,7 @@ pub(crate) async fn start_exec_operation_on_shared(
         seq,
         &payload,
         Some(diagnostic.frame("start")),
+        Some(seq),
     )
     .await?;
     registration_guard.disarm();
@@ -1271,7 +1322,9 @@ mod tests {
 
     fn exec_operation_for_snapshot(seq: u32, label: &str) -> ExecOperation {
         let (result_tx, _result_rx) = oneshot::channel();
+        let normal_operations = crate::operation_tracker::NormalOperationTracker::new();
         ExecOperation {
+            normal_operation: normal_operations.reserve().unwrap(),
             diagnostic: ExecOperationDiagnostic::new(seq, label, &[]),
             result_tx,
             stream_tx: None,

--- a/crates/vsock-host/src/file.rs
+++ b/crates/vsock-host/src/file.rs
@@ -12,7 +12,7 @@ use vsock_proto::{
 
 use crate::{
     ExecCaptureRequest, ExecOperationResult, ExecOutputEvent, ExecOwnedCapturedOutput,
-    ExecStreamRequest, Shared, VsockHost, exec_operation,
+    ExecStreamRequest, Shared, VsockHost, exec_operation, normal_request_on_shared,
 };
 
 const COPY_TEMP_CREATE_ATTEMPTS: usize = 16;
@@ -26,6 +26,7 @@ static COPY_TEMP_NONCE: AtomicU64 = AtomicU64::new(1);
 /// Maximum content per write_file message. Leaves headroom below
 /// [`vsock_proto::MAX_MESSAGE_SIZE`] for the path and frame overhead.
 const WRITE_FILE_CHUNK_LIMIT: usize = 15 * 1024 * 1024;
+const WRITE_FILE_TERMINAL_MSG_TYPES: &[u8] = &[MSG_ERROR, MSG_WRITE_FILE_RESULT];
 
 /// Timeout (ms) for short helper commands (mv, rm) used during chunked writes.
 const HELPER_EXEC_TIMEOUT_MS: u32 = 5000;
@@ -529,7 +530,9 @@ impl VsockHost {
     /// Non-sudo writes create missing parent directories on the guest.
     pub async fn write_file(&self, path: &str, content: &[u8], sudo: bool) -> io::Result<()> {
         if content.len() <= WRITE_FILE_CHUNK_LIMIT {
-            return self.write_file_chunk(path, content, sudo, false).await;
+            return self
+                .write_file_chunk(path, content, sudo, false, true)
+                .await;
         }
 
         // Write chunks to a per-call temp file, then atomic rename. The
@@ -543,7 +546,8 @@ impl VsockHost {
 
         let result = async {
             for (i, chunk) in content.chunks(WRITE_FILE_CHUNK_LIMIT).enumerate() {
-                self.write_file_chunk(&tmp, chunk, sudo, i > 0).await?;
+                self.write_file_chunk(&tmp, chunk, sudo, i > 0, false)
+                    .await?;
             }
             io::Result::Ok(())
         }
@@ -597,11 +601,23 @@ impl VsockHost {
         content: &[u8],
         sudo: bool,
         append: bool,
+        tracked: bool,
     ) -> io::Result<()> {
         let payload = vsock_proto::encode_write_file(path, content, sudo, append)
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e.to_string()))?;
         let timeout = Duration::from_secs(300);
-        let resp = self.request(MSG_WRITE_FILE, &payload, timeout).await?;
+        let resp = if tracked {
+            normal_request_on_shared(
+                &self.shared,
+                MSG_WRITE_FILE,
+                &payload,
+                WRITE_FILE_TERMINAL_MSG_TYPES,
+                timeout,
+            )
+            .await?
+        } else {
+            self.request(MSG_WRITE_FILE, &payload, timeout).await?
+        };
 
         if resp.msg_type == MSG_ERROR {
             let msg = vsock_proto::decode_error(&resp.payload)

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -187,12 +187,6 @@ impl Shared {
     fn close_with_reason(&self, reason: &'static str, kind: ConnectionCloseKind) {
         let maps_to_drop = {
             let mut guard = self.state.lock().unwrap_or_else(|e| e.into_inner());
-            // Serialize tracker close/poison with terminal dispatch, which
-            // completes tracker tokens under this same state lock.
-            match kind {
-                ConnectionCloseKind::Closed => self.normal_operations.mark_closed(),
-                ConnectionCloseKind::Poisoned => self.normal_operations.mark_not_parkable(),
-            }
             match std::mem::replace(
                 &mut *guard,
                 ConnectionState::Closed {
@@ -204,6 +198,12 @@ impl Shared {
                     operations,
                     process,
                 } => {
+                    // Serialize tracker close/poison with terminal dispatch,
+                    // which completes tracker tokens under this same state lock.
+                    match kind {
+                        ConnectionCloseKind::Closed => self.normal_operations.mark_closed(),
+                        ConnectionCloseKind::Poisoned => self.normal_operations.mark_not_parkable(),
+                    }
                     let exec_operation_snapshot = operations.close_snapshot();
                     let (closed_process, process_maps) = process.close();
                     *guard = ConnectionState::Closed {

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -38,7 +38,10 @@ use tokio::sync::{Notify, oneshot};
 use tokio::task::JoinHandle;
 use tokio::time::{self, Instant};
 
-use operation_tracker::NormalOperationTracker;
+use operation_tracker::{
+    NormalOperationRejection, NormalOperationToken, NormalOperationTracker,
+    NormalOperationTransitionError,
+};
 use vsock_proto::{
     Decoder, MSG_ERROR, MSG_EXEC_OUTPUT, MSG_EXEC_RESULT, MSG_OPERATIONS_QUIESCED,
     MSG_OPERATIONS_RESUMED, MSG_PING, MSG_PONG, MSG_PROCESS_EXIT, MSG_QUIESCE_OPERATIONS,
@@ -79,8 +82,8 @@ pub struct ExecResult {
 /// without taking the corresponding lock.
 enum ConnectionState {
     Connected {
-        /// Pending request responses: seq → oneshot sender.
-        pending: HashMap<u32, oneshot::Sender<RawMessage>>,
+        /// Pending request responses: seq → response route.
+        pending: HashMap<u32, PendingResponse>,
         /// Active exec-operation state owned by the exec_operation module.
         operations: exec_operation::Operations,
         /// Active spawn_process operation state owned by the process module.
@@ -138,6 +141,12 @@ struct PendingRequestGuard {
     seq: u32,
 }
 
+struct PendingResponse {
+    response_tx: oneshot::Sender<RawMessage>,
+    normal_operation: Option<NormalOperationToken>,
+    normal_terminal_msg_types: &'static [u8],
+}
+
 impl PendingRequestGuard {
     fn new(shared: Arc<Shared>, seq: u32) -> Self {
         Self { shared, seq }
@@ -176,12 +185,14 @@ impl Shared {
     }
 
     fn close_with_reason(&self, reason: &'static str, kind: ConnectionCloseKind) {
-        match kind {
-            ConnectionCloseKind::Closed => self.normal_operations.mark_closed(),
-            ConnectionCloseKind::Poisoned => self.normal_operations.mark_not_parkable(),
-        }
         let maps_to_drop = {
             let mut guard = self.state.lock().unwrap_or_else(|e| e.into_inner());
+            // Serialize tracker close/poison with terminal dispatch, which
+            // completes tracker tokens under this same state lock.
+            match kind {
+                ConnectionCloseKind::Closed => self.normal_operations.mark_closed(),
+                ConnectionCloseKind::Poisoned => self.normal_operations.mark_not_parkable(),
+            }
             match std::mem::replace(
                 &mut *guard,
                 ConnectionState::Closed {
@@ -233,6 +244,12 @@ impl Shared {
         if let ConnectionState::Connected { operations, .. } = &mut *guard {
             operations.remove(seq);
         }
+    }
+
+    fn reserve_normal_operation(&self) -> io::Result<NormalOperationToken> {
+        self.normal_operations
+            .reserve()
+            .map_err(normal_operation_rejection_error)
     }
 }
 
@@ -344,15 +361,38 @@ async fn reader_loop(
                     shared.poison_connection();
                     return;
                 }
-                let response_sender = {
+                let mut normal_operation_transition_failed = false;
+                let pending_response = {
                     let mut guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
                     match &mut *guard {
-                        ConnectionState::Connected { pending, .. } => pending.remove(&msg.seq),
+                        ConnectionState::Connected { pending, .. } => {
+                            if let Some(mut pending_response) = pending.remove(&msg.seq) {
+                                if pending_response
+                                    .normal_terminal_msg_types
+                                    .contains(&msg.msg_type)
+                                    && let Some(normal_operation) =
+                                        pending_response.normal_operation.take()
+                                    && normal_operation
+                                        .complete()
+                                        .map_err(normal_operation_transition_error)
+                                        .is_err()
+                                {
+                                    normal_operation_transition_failed = true;
+                                }
+                                Some(pending_response)
+                            } else {
+                                None
+                            }
+                        }
                         ConnectionState::Closed { .. } => None,
                     }
                 };
-                if let Some(tx) = response_sender {
-                    let _ = tx.send(msg);
+                if normal_operation_transition_failed {
+                    shared.poison_connection();
+                    return;
+                }
+                if let Some(pending_response) = pending_response {
+                    let _ = pending_response.response_tx.send(msg);
                 }
             }
         }
@@ -401,7 +441,14 @@ async fn request_raw_on_shared(
                 ));
             }
             ConnectionState::Connected { pending, .. } => {
-                pending.insert(seq, tx);
+                pending.insert(
+                    seq,
+                    PendingResponse {
+                        response_tx: tx,
+                        normal_operation: None,
+                        normal_terminal_msg_types: &[],
+                    },
+                );
             }
         }
     }
@@ -426,6 +473,128 @@ async fn request_raw_on_shared(
             Err(io::Error::new(io::ErrorKind::TimedOut, "request timeout"))
         }
     }
+}
+
+async fn normal_request_on_shared(
+    shared: &Arc<Shared>,
+    msg_type: u8,
+    payload: &[u8],
+    terminal_msg_types: &'static [u8],
+    timeout: Duration,
+) -> io::Result<RawMessage> {
+    let seq = shared.next_seq();
+    normal_request_raw_on_shared(shared, msg_type, seq, payload, terminal_msg_types, timeout).await
+}
+
+async fn normal_request_raw_on_shared(
+    shared: &Arc<Shared>,
+    msg_type: u8,
+    seq: u32,
+    payload: &[u8],
+    terminal_msg_types: &'static [u8],
+    timeout: Duration,
+) -> io::Result<RawMessage> {
+    let data = vsock_proto::encode(msg_type, seq, payload)
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e.to_string()))?;
+    let normal_operation = shared.reserve_normal_operation()?;
+
+    let (tx, rx) = oneshot::channel();
+    {
+        let mut guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
+        match &mut *guard {
+            ConnectionState::Closed { .. } => {
+                return Err(io::Error::new(
+                    io::ErrorKind::ConnectionReset,
+                    "connection closed",
+                ));
+            }
+            ConnectionState::Connected { pending, .. } => {
+                pending.insert(
+                    seq,
+                    PendingResponse {
+                        response_tx: tx,
+                        normal_operation: Some(normal_operation),
+                        normal_terminal_msg_types: terminal_msg_types,
+                    },
+                );
+            }
+        }
+    }
+    let _pending_guard = PendingRequestGuard::new(Arc::clone(shared), seq);
+
+    let mut writer = shared.writer.lock().await;
+    mark_pending_normal_operation_possible_guest_write(shared, seq)?;
+    if let Err(error) = writer.write_all(&data).await {
+        shared.poison_connection();
+        return Err(error);
+    }
+    drop(writer);
+
+    tokio::select! {
+        biased;
+        result = rx => {
+            result.map_err(|_| io::Error::new(
+                    io::ErrorKind::ConnectionReset,
+                    "connection closed",
+                ))
+        }
+        _ = tokio::time::sleep(timeout) => {
+            Err(io::Error::new(io::ErrorKind::TimedOut, "request timeout"))
+        }
+    }
+}
+
+fn mark_pending_normal_operation_possible_guest_write(
+    shared: &Arc<Shared>,
+    seq: u32,
+) -> io::Result<()> {
+    let mut guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
+    match &mut *guard {
+        ConnectionState::Connected { pending, .. } => {
+            let Some(pending_response) = pending.get_mut(&seq) else {
+                return Err(io::Error::new(
+                    io::ErrorKind::ConnectionReset,
+                    "normal request closed before frame write",
+                ));
+            };
+            let Some(normal_operation) = pending_response.normal_operation.as_mut() else {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "normal request missing operation token",
+                ));
+            };
+            normal_operation
+                .mark_possible_guest_write_started()
+                .map_err(normal_operation_transition_error)
+        }
+        ConnectionState::Closed { .. } => Err(io::Error::new(
+            io::ErrorKind::ConnectionReset,
+            "connection closed",
+        )),
+    }
+}
+
+fn normal_operation_rejection_error(error: NormalOperationRejection) -> io::Error {
+    match error {
+        NormalOperationRejection::Fenced => io::Error::new(
+            io::ErrorKind::WouldBlock,
+            "normal operations are currently fenced",
+        ),
+        NormalOperationRejection::NotParkable => io::Error::new(
+            io::ErrorKind::ConnectionReset,
+            "normal operations are not available on this connection",
+        ),
+        NormalOperationRejection::Closed => {
+            io::Error::new(io::ErrorKind::ConnectionReset, "connection closed")
+        }
+    }
+}
+
+fn normal_operation_transition_error(error: NormalOperationTransitionError) -> io::Error {
+    io::Error::new(
+        io::ErrorKind::InvalidData,
+        format!("normal operation transition failed: {error:?}"),
+    )
 }
 
 fn protocol_invalid_data(error: impl ToString) -> io::Error {

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -565,6 +565,7 @@ async fn normal_request_raw_on_shared(
     }
     write_guard.mark_returned();
     drop(writer);
+    drop(write_guard);
 
     tokio::select! {
         biased;

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -147,6 +147,12 @@ struct PendingResponse {
     normal_terminal_msg_types: &'static [u8],
 }
 
+struct PendingNormalRequestWriteGuard {
+    shared: Arc<Shared>,
+    write_started: bool,
+    write_returned: bool,
+}
+
 impl PendingRequestGuard {
     fn new(shared: Arc<Shared>, seq: u32) -> Self {
         Self { shared, seq }
@@ -156,6 +162,32 @@ impl PendingRequestGuard {
 impl Drop for PendingRequestGuard {
     fn drop(&mut self) {
         self.shared.remove_pending(self.seq);
+    }
+}
+
+impl PendingNormalRequestWriteGuard {
+    fn new(shared: Arc<Shared>) -> Self {
+        Self {
+            shared,
+            write_started: false,
+            write_returned: false,
+        }
+    }
+
+    fn mark_started(&mut self) {
+        self.write_started = true;
+    }
+
+    fn mark_returned(&mut self) {
+        self.write_returned = true;
+    }
+}
+
+impl Drop for PendingNormalRequestWriteGuard {
+    fn drop(&mut self) {
+        if self.write_started && !self.write_returned {
+            self.shared.poison_connection();
+        }
     }
 }
 
@@ -522,12 +554,16 @@ async fn normal_request_raw_on_shared(
     }
     let _pending_guard = PendingRequestGuard::new(Arc::clone(shared), seq);
 
+    let mut write_guard = PendingNormalRequestWriteGuard::new(Arc::clone(shared));
     let mut writer = shared.writer.lock().await;
     mark_pending_normal_operation_possible_guest_write(shared, seq)?;
+    write_guard.mark_started();
     if let Err(error) = writer.write_all(&data).await {
+        write_guard.mark_returned();
         shared.poison_connection();
         return Err(error);
     }
+    write_guard.mark_returned();
     drop(writer);
 
     tokio::select! {

--- a/crates/vsock-host/src/tests/connection.rs
+++ b/crates/vsock-host/src/tests/connection.rs
@@ -341,6 +341,33 @@ async fn connection_close_marks_normal_operations_closed() {
 }
 
 #[tokio::test]
+async fn late_poison_after_connection_close_does_not_reclassify_readiness() {
+    let (host_stream, mut guest) = make_pair();
+
+    let guest_task = tokio::spawn(async move {
+        let mut decoder = Decoder::new();
+        mock_handshake(&mut guest, &mut decoder).await;
+        drop(guest);
+    });
+
+    let host = host_from_stream(host_stream).await.unwrap();
+    host.wait_until_closed(Duration::from_secs(5))
+        .await
+        .unwrap();
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Closed
+    );
+
+    poison_connection(&host);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Closed
+    );
+    guest_task.await.unwrap();
+}
+
+#[tokio::test]
 async fn connection_poison_marks_normal_operations_not_parkable() {
     let (host_stream, mut guest) = make_pair();
 

--- a/crates/vsock-host/src/tests/connection.rs
+++ b/crates/vsock-host/src/tests/connection.rs
@@ -10,9 +10,9 @@ use vsock_proto::{
 };
 
 use super::support::{
-    fence_normal_operations, host_from_stream, make_pair, mock_handshake,
-    normal_operation_readiness, poison_connection, read_guest_message, send_exec_result,
-    setup_host_and_guest,
+    drop_started_pending_normal_request_write_guard, fence_normal_operations, host_from_stream,
+    make_pair, mock_handshake, normal_operation_readiness, poison_connection, read_guest_message,
+    send_exec_result, setup_host_and_guest,
 };
 use crate::{VsockHost, operation_tracker::NormalOperationReadiness};
 
@@ -389,6 +389,21 @@ async fn connection_poison_marks_normal_operations_not_parkable() {
         .await
         .unwrap()
         .unwrap();
+}
+
+#[tokio::test]
+async fn cancelled_normal_request_frame_write_poisons_connection() {
+    let (host, _guest, _decoder) = setup_host_and_guest().await;
+
+    drop_started_pending_normal_request_write_guard(&host);
+
+    host.wait_until_closed(Duration::from_secs(5))
+        .await
+        .unwrap();
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::NotParkable
+    );
 }
 
 /// Two concurrent exec calls get the correct response matched by seq.

--- a/crates/vsock-host/src/tests/connection.rs
+++ b/crates/vsock-host/src/tests/connection.rs
@@ -10,8 +10,9 @@ use vsock_proto::{
 };
 
 use super::support::{
-    host_from_stream, make_pair, mock_handshake, normal_operation_readiness, poison_connection,
-    read_guest_message, send_exec_result,
+    fence_normal_operations, host_from_stream, make_pair, mock_handshake,
+    normal_operation_readiness, poison_connection, read_guest_message, send_exec_result,
+    setup_host_and_guest,
 };
 use crate::{VsockHost, operation_tracker::NormalOperationReadiness};
 
@@ -115,6 +116,28 @@ async fn resume_operations_sends_request_and_accepts_empty_ack() {
     host.resume_operations(Duration::from_secs(2))
         .await
         .unwrap();
+}
+
+#[tokio::test]
+async fn lifecycle_request_bypasses_normal_operation_fence() {
+    let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+    let _fence = fence_normal_operations(&host);
+
+    let err = host.exec("blocked", 5000, &[], false).await.unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::WouldBlock);
+
+    let quiesce_task = {
+        let host = Arc::clone(&host);
+        tokio::spawn(async move { host.quiesce_operations(Duration::from_secs(2)).await })
+    };
+
+    let msg = read_guest_message(&mut guest, &mut decoder).await;
+    assert_eq!(msg.msg_type, MSG_QUIESCE_OPERATIONS);
+    let resp = vsock_proto::encode(MSG_OPERATIONS_QUIESCED, msg.seq, &[]).unwrap();
+    guest.write_all(&resp).await.unwrap();
+
+    quiesce_task.await.unwrap().unwrap();
 }
 
 #[tokio::test]

--- a/crates/vsock-host/src/tests/exec_operation/cancel.rs
+++ b/crates/vsock-host/src/tests/exec_operation/cancel.rs
@@ -5,11 +5,13 @@ use std::time::Duration;
 use vsock_proto::{ExecTermination, MSG_EXEC_CANCEL, MSG_EXEC_START};
 
 use super::super::support::{
-    assert_connection_accepts_exec_operation, is_connected, operation_count, read_guest_message,
-    send_exec_result, setup_host_and_guest, wait_for_operation_count,
+    assert_connection_accepts_exec_operation, is_connected, normal_operation_readiness,
+    operation_count, read_guest_message, send_exec_result, setup_host_and_guest,
+    wait_for_operation_count,
 };
 use super::start_capture_operation;
 use crate::exec_operation as exec_operation_impl;
+use crate::operation_tracker::NormalOperationReadiness;
 
 #[tokio::test]
 async fn exec_start_cancelled_before_write_does_not_poison_or_send_frame() {
@@ -57,7 +59,7 @@ async fn exec_start_cancelled_before_write_does_not_poison_or_send_frame() {
 }
 
 #[tokio::test]
-async fn exec_operation_handle_drop_after_full_write_sends_no_cancel() {
+async fn exec_operation_handle_drop_after_full_write_marks_not_parkable() {
     let (host, mut guest, mut decoder) = setup_host_and_guest().await;
     let host = Arc::new(host);
     let handle = start_capture_operation(&host, "drop-after-write").await;
@@ -65,26 +67,10 @@ async fn exec_operation_handle_drop_after_full_write_sends_no_cancel() {
     assert_eq!(msg.msg_type, MSG_EXEC_START);
     drop(handle);
     assert_eq!(operation_count(&host), 0);
-
-    let exec_task = {
-        let host = Arc::clone(&host);
-        tokio::spawn(async move { host.exec("echo ok", 5000, &[], false).await })
-    };
-    let msg = read_guest_message(&mut guest, &mut decoder).await;
     assert_eq!(
-        msg.msg_type, MSG_EXEC_START,
-        "drop must not send exec cancel"
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::NotParkable
     );
-    send_exec_result(
-        &mut guest,
-        msg.seq,
-        ExecTermination::Exited { exit_code: 0 },
-        b"ok",
-        b"",
-    )
-    .await;
-    let exec_result = exec_task.await.unwrap().unwrap();
-    assert_eq!(exec_result.stdout, b"ok");
     assert!(is_connected(&host));
 }
 

--- a/crates/vsock-host/src/tests/exec_operation/cancel.rs
+++ b/crates/vsock-host/src/tests/exec_operation/cancel.rs
@@ -33,6 +33,10 @@ async fn exec_start_cancelled_before_write_does_not_poison_or_send_frame() {
     task.abort();
     let _ = task.await;
     assert_eq!(operation_count(&host), 0);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Idle
+    );
     assert!(is_connected(&host));
 
     drop(writer_guard);
@@ -67,6 +71,12 @@ async fn exec_operation_handle_drop_after_full_write_marks_not_parkable() {
     assert_eq!(msg.msg_type, MSG_EXEC_START);
     drop(handle);
     assert_eq!(operation_count(&host), 0);
+    let mut buf = [0u8; 1024];
+    match guest.try_read(&mut buf) {
+        Err(err) if err.kind() == io::ErrorKind::WouldBlock => {}
+        Ok(n) => panic!("drop must not send exec cancel; read {n} bytes"),
+        Err(err) => panic!("unexpected read error after handle drop: {err}"),
+    }
     assert_eq!(
         normal_operation_readiness(&host),
         NormalOperationReadiness::NotParkable

--- a/crates/vsock-host/src/tests/exec_operation/exec.rs
+++ b/crates/vsock-host/src/tests/exec_operation/exec.rs
@@ -1,9 +1,15 @@
 use std::io;
+use std::sync::Arc;
 
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use vsock_proto::{Decoder, ExecTermination, MSG_ERROR, MSG_EXEC_START};
 
-use super::super::support::{host_from_stream, make_pair, mock_handshake, send_exec_result};
+use super::super::support::{
+    host_from_stream, make_pair, mock_handshake, normal_operation_readiness, read_guest_message,
+    send_exec_result, setup_host_and_guest, wait_for_operation_count,
+};
+use super::start_capture_operation;
+use crate::operation_tracker::NormalOperationReadiness;
 
 #[tokio::test]
 async fn test_exec() {
@@ -42,21 +48,52 @@ async fn test_exec() {
     assert!(result.stderr.is_empty());
 }
 
+#[tokio::test]
+async fn exec_operation_tracks_until_terminal_result() {
+    let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+    let exec_task = {
+        let host = Arc::clone(&host);
+        tokio::spawn(async move { host.exec("echo tracked", 5000, &[], false).await })
+    };
+
+    let msg = read_guest_message(&mut guest, &mut decoder).await;
+    assert_eq!(msg.msg_type, MSG_EXEC_START);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Busy
+    );
+
+    send_exec_result(
+        &mut guest,
+        msg.seq,
+        ExecTermination::Exited { exit_code: 0 },
+        b"tracked\n",
+        b"",
+    )
+    .await;
+
+    let result = exec_task.await.unwrap().unwrap();
+    assert_eq!(result.stdout, b"tracked\n");
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Idle
+    );
+}
+
 /// `host.exec` with `timeout_ms == 0` must reject at the boundary rather
 /// than send the request to the guest — an unbounded exec would leak a
 /// guest-side orphan when the host's outer timeout fires.
 #[tokio::test]
 async fn test_exec_rejects_zero_timeout() {
-    let (host_stream, mut guest) = make_pair();
+    let (host, _guest, _decoder) = setup_host_and_guest().await;
 
-    tokio::spawn(async move {
-        let mut decoder = Decoder::new();
-        mock_handshake(&mut guest, &mut decoder).await;
-    });
-
-    let host = host_from_stream(host_stream).await.unwrap();
     let err = host.exec("echo hi", 0, &[], false).await.unwrap_err();
     assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Idle
+    );
 }
 
 #[tokio::test]
@@ -79,4 +116,58 @@ async fn test_exec_error_response() {
     let host = host_from_stream(host_stream).await.unwrap();
     let err = host.exec("badcmd", 5000, &[], false).await.unwrap_err();
     assert!(err.to_string().contains("command not found"));
+}
+
+#[tokio::test]
+async fn exec_operation_error_response_releases_tracker() {
+    let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+    let exec_task = {
+        let host = Arc::clone(&host);
+        tokio::spawn(async move { host.exec("badcmd", 5000, &[], false).await })
+    };
+
+    let msg = read_guest_message(&mut guest, &mut decoder).await;
+    assert_eq!(msg.msg_type, MSG_EXEC_START);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Busy
+    );
+
+    let payload = vsock_proto::encode_error("command not found");
+    let resp = vsock_proto::encode(MSG_ERROR, msg.seq, &payload).unwrap();
+    guest.write_all(&resp).await.unwrap();
+
+    let err = exec_task.await.unwrap().unwrap_err();
+    assert!(err.to_string().contains("command not found"));
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Idle
+    );
+}
+
+#[tokio::test]
+async fn dropping_exec_handle_after_start_marks_tracker_not_parkable() {
+    let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+    let handle = start_capture_operation(&host, "drop-after-start").await;
+    let msg = read_guest_message(&mut guest, &mut decoder).await;
+    assert_eq!(msg.msg_type, MSG_EXEC_START);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Busy
+    );
+
+    drop(handle);
+    wait_for_operation_count(&host, 0).await;
+
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::NotParkable
+    );
+    let err = host
+        .exec("blocked-after-drop", 5000, &[], false)
+        .await
+        .unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::ConnectionReset);
 }

--- a/crates/vsock-host/src/tests/exec_operation/lifecycle.rs
+++ b/crates/vsock-host/src/tests/exec_operation/lifecycle.rs
@@ -6,11 +6,14 @@ use tokio::io::AsyncWriteExt;
 use vsock_proto::{ExecOutputPolicy, ExecOutputStream, ExecTermination, MSG_ERROR, MSG_EXEC_START};
 
 use super::super::support::{
-    assert_connection_accepts_exec_operation, is_connected, operation_count, read_guest_message,
-    send_exec_output, send_exec_result, setup_host_and_guest,
+    assert_connection_accepts_exec_operation, is_connected, normal_operation_readiness,
+    operation_count, read_guest_message, send_exec_output, send_exec_result, setup_host_and_guest,
 };
 use super::start_capture_operation;
-use crate::{ExecOperationRequest, ExecOwnedCapturedOutput, ExecStreamRequest};
+use crate::{
+    ExecOperationRequest, ExecOwnedCapturedOutput, ExecStreamRequest,
+    operation_tracker::NormalOperationReadiness,
+};
 
 #[tokio::test]
 async fn exec_operation_wait_timeout_cleans_operation_state() {
@@ -74,6 +77,10 @@ async fn exec_operation_connection_close_wakes_result_and_stream() {
     let err = handle.wait(Duration::from_secs(5)).await.unwrap_err();
     assert_eq!(err.kind(), io::ErrorKind::ConnectionReset);
     assert!(rx.recv().await.is_none());
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::NotParkable
+    );
 }
 
 #[tokio::test]

--- a/crates/vsock-host/src/tests/exec_operation/lifecycle.rs
+++ b/crates/vsock-host/src/tests/exec_operation/lifecycle.rs
@@ -26,6 +26,10 @@ async fn exec_operation_wait_timeout_cleans_operation_state() {
     let err = handle.wait(Duration::ZERO).await.unwrap_err();
     assert_eq!(err.kind(), io::ErrorKind::TimedOut);
     assert_eq!(operation_count(&host), 0);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::NotParkable
+    );
     assert!(is_connected(&host));
 }
 

--- a/crates/vsock-host/src/tests/exec_operation/malformed.rs
+++ b/crates/vsock-host/src/tests/exec_operation/malformed.rs
@@ -6,11 +6,11 @@ use tokio::io::AsyncWriteExt;
 use vsock_proto::{ExecTermination, MSG_ERROR, MSG_EXEC_OUTPUT, MSG_EXEC_RESULT, MSG_EXEC_START};
 
 use super::super::support::{
-    assert_connection_accepts_exec_operation, operation_count, read_guest_message,
-    send_exec_result, setup_host_and_guest, wait_for_operation_count,
+    assert_connection_accepts_exec_operation, normal_operation_readiness, operation_count,
+    read_guest_message, send_exec_result, setup_host_and_guest, wait_for_operation_count,
 };
 use super::start_capture_operation;
-use crate::ExecOwnedCapturedOutput;
+use crate::{ExecOwnedCapturedOutput, operation_tracker::NormalOperationReadiness};
 
 #[tokio::test]
 async fn malformed_exec_error_poisons_connection() {
@@ -25,6 +25,10 @@ async fn malformed_exec_error_poisons_connection() {
     host.wait_until_closed(Duration::from_secs(5))
         .await
         .unwrap();
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::NotParkable
+    );
     let err = handle.wait(Duration::from_secs(5)).await.unwrap_err();
     assert_eq!(err.kind(), io::ErrorKind::ConnectionReset);
 }
@@ -95,12 +99,12 @@ async fn malformed_exec_frames_after_handle_drop_are_ignored() {
     drop(handle);
     wait_for_operation_count(&host, 0).await;
 
-    let output_frame = vsock_proto::encode(MSG_EXEC_OUTPUT, msg.seq, &[0]).unwrap();
-    guest.write_all(&output_frame).await.unwrap();
-    let result_frame = vsock_proto::encode(MSG_EXEC_RESULT, msg.seq, &[0]).unwrap();
-    guest.write_all(&result_frame).await.unwrap();
-
-    assert_connection_accepts_exec_operation(&host, &mut guest, &mut decoder).await;
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::NotParkable
+    );
+    let err = host.exec("after-drop", 5000, &[], false).await.unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::ConnectionReset);
 }
 
 #[tokio::test]

--- a/crates/vsock-host/src/tests/file.rs
+++ b/crates/vsock-host/src/tests/file.rs
@@ -805,6 +805,31 @@ async fn dropping_write_file_after_request_marks_tracker_not_parkable() {
 }
 
 #[tokio::test]
+async fn write_file_connection_close_after_request_marks_tracker_not_parkable() {
+    let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+    let write_task = {
+        let host = Arc::clone(&host);
+        tokio::spawn(async move { host.write_file("/tmp/pending.txt", b"hello", false).await })
+    };
+
+    let msg = read_guest_message(&mut guest, &mut decoder).await;
+    assert_eq!(msg.msg_type, MSG_WRITE_FILE);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Busy
+    );
+
+    drop(guest);
+    let err = write_task.await.unwrap().unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::ConnectionReset);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::NotParkable
+    );
+}
+
+#[tokio::test]
 async fn test_write_file_chunked() {
     let (host_stream, mut guest) = make_pair();
 

--- a/crates/vsock-host/src/tests/file.rs
+++ b/crates/vsock-host/src/tests/file.rs
@@ -6,17 +6,17 @@ use std::time::Duration;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::sync::oneshot;
 use vsock_proto::{
-    Decoder, ExecCapturedOutput, ExecOutputPolicy, ExecOutputStream, ExecTermination,
+    Decoder, ExecCapturedOutput, ExecOutputPolicy, ExecOutputStream, ExecTermination, MSG_ERROR,
     MSG_EXEC_CANCEL, MSG_EXEC_START, MSG_WRITE_FILE, MSG_WRITE_FILE_RESULT,
 };
 
 use super::support::{
     assert_connection_accepts_exec_operation, host_from_stream, make_pair, mock_handshake,
-    operation_count, read_guest_message, send_exec_output, send_exec_result, send_raw_exec_result,
-    send_stream_exec_result, setup_host_and_guest,
+    normal_operation_readiness, operation_count, read_guest_message, send_exec_output,
+    send_exec_result, send_raw_exec_result, send_stream_exec_result, setup_host_and_guest,
 };
-use crate::CopyFileOptions;
 use crate::file as file_impl;
+use crate::{CopyFileOptions, operation_tracker::NormalOperationReadiness};
 
 #[tokio::test]
 async fn copy_file_rejects_max_bytes_above_stream_budget() {
@@ -662,6 +662,146 @@ async fn test_write_file() {
     host.write_file("/tmp/test.txt", b"hello", false)
         .await
         .unwrap();
+}
+
+#[tokio::test]
+async fn write_file_tracks_until_result() {
+    let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+    let write_task = {
+        let host = Arc::clone(&host);
+        tokio::spawn(async move { host.write_file("/tmp/tracked.txt", b"hello", false).await })
+    };
+
+    let msg = read_guest_message(&mut guest, &mut decoder).await;
+    assert_eq!(msg.msg_type, MSG_WRITE_FILE);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Busy
+    );
+
+    let payload = vsock_proto::encode_write_file_result(true, "");
+    let resp = vsock_proto::encode(MSG_WRITE_FILE_RESULT, msg.seq, &payload).unwrap();
+    guest.write_all(&resp).await.unwrap();
+
+    write_task.await.unwrap().unwrap();
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Idle
+    );
+}
+
+#[tokio::test]
+async fn write_file_guest_failure_releases_tracker() {
+    let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+    let write_task = {
+        let host = Arc::clone(&host);
+        tokio::spawn(async move { host.write_file("/tmp/tracked.txt", b"bad", false).await })
+    };
+
+    let msg = read_guest_message(&mut guest, &mut decoder).await;
+    assert_eq!(msg.msg_type, MSG_WRITE_FILE);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Busy
+    );
+
+    let payload = vsock_proto::encode_write_file_result(false, "permission denied");
+    let resp = vsock_proto::encode(MSG_WRITE_FILE_RESULT, msg.seq, &payload).unwrap();
+    guest.write_all(&resp).await.unwrap();
+
+    let err = write_task.await.unwrap().unwrap_err();
+    assert!(err.to_string().contains("permission denied"));
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Idle
+    );
+}
+
+#[tokio::test]
+async fn write_file_error_response_releases_tracker() {
+    let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+    let write_task = {
+        let host = Arc::clone(&host);
+        tokio::spawn(async move { host.write_file("/tmp/tracked.txt", b"bad", false).await })
+    };
+
+    let msg = read_guest_message(&mut guest, &mut decoder).await;
+    assert_eq!(msg.msg_type, MSG_WRITE_FILE);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Busy
+    );
+
+    let payload = vsock_proto::encode_error("guest write failed");
+    let resp = vsock_proto::encode(MSG_ERROR, msg.seq, &payload).unwrap();
+    guest.write_all(&resp).await.unwrap();
+
+    let err = write_task.await.unwrap().unwrap_err();
+    assert!(err.to_string().contains("guest write failed"));
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Idle
+    );
+}
+
+#[tokio::test]
+async fn write_file_unexpected_response_keeps_tracker_fail_closed() {
+    let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+    let write_task = {
+        let host = Arc::clone(&host);
+        tokio::spawn(async move { host.write_file("/tmp/tracked.txt", b"bad", false).await })
+    };
+
+    let msg = read_guest_message(&mut guest, &mut decoder).await;
+    assert_eq!(msg.msg_type, MSG_WRITE_FILE);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Busy
+    );
+
+    let resp = vsock_proto::encode(MSG_EXEC_START, msg.seq, &[]).unwrap();
+    guest.write_all(&resp).await.unwrap();
+
+    let err = write_task.await.unwrap().unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::NotParkable
+    );
+}
+
+#[tokio::test]
+async fn dropping_write_file_after_request_marks_tracker_not_parkable() {
+    let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+    let write_task = {
+        let host = Arc::clone(&host);
+        tokio::spawn(async move { host.write_file("/tmp/pending.txt", b"hello", false).await })
+    };
+
+    let msg = read_guest_message(&mut guest, &mut decoder).await;
+    assert_eq!(msg.msg_type, MSG_WRITE_FILE);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Busy
+    );
+
+    write_task.abort();
+    let _ = write_task.await;
+
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::NotParkable
+    );
+    let err = host
+        .exec("blocked-after-write-drop", 5000, &[], false)
+        .await
+        .unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::ConnectionReset);
 }
 
 #[tokio::test]

--- a/crates/vsock-host/src/tests/file.rs
+++ b/crates/vsock-host/src/tests/file.rs
@@ -805,6 +805,34 @@ async fn dropping_write_file_after_request_marks_tracker_not_parkable() {
 }
 
 #[tokio::test]
+async fn write_file_cancelled_before_frame_write_does_not_poison_or_send_frame() {
+    let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+    let writer_guard = host.shared.writer.lock().await;
+    let write_task = {
+        let host = Arc::clone(&host);
+        tokio::spawn(async move { host.write_file("/tmp/blocked.txt", b"hello", false).await })
+    };
+
+    tokio::time::timeout(Duration::from_secs(5), async {
+        while normal_operation_readiness(&host) != NormalOperationReadiness::Busy {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .unwrap();
+    write_task.abort();
+    let _ = write_task.await;
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Idle
+    );
+
+    drop(writer_guard);
+    assert_connection_accepts_exec_operation(&host, &mut guest, &mut decoder).await;
+}
+
+#[tokio::test]
 async fn write_file_connection_close_after_request_marks_tracker_not_parkable() {
     let (host, mut guest, mut decoder) = setup_host_and_guest().await;
     let host = Arc::new(host);

--- a/crates/vsock-host/src/tests/support.rs
+++ b/crates/vsock-host/src/tests/support.rs
@@ -10,7 +10,10 @@ use vsock_proto::{
     MSG_EXEC_RESULT, MSG_EXEC_START, MSG_PING, MSG_PONG, MSG_READY, RawMessage,
 };
 
-use crate::{ConnectionState, VsockHost, operation_tracker::NormalOperationReadiness};
+use crate::{
+    ConnectionState, VsockHost,
+    operation_tracker::{NormalOperationFence, NormalOperationReadiness},
+};
 
 pub(crate) fn make_pair() -> (UnixStream, UnixStream) {
     UnixStream::pair().unwrap()
@@ -50,6 +53,13 @@ pub(crate) fn is_connected(host: &VsockHost) -> bool {
 
 pub(crate) fn normal_operation_readiness(host: &VsockHost) -> NormalOperationReadiness {
     host.shared.normal_operations.readiness()
+}
+
+pub(crate) fn fence_normal_operations(host: &VsockHost) -> NormalOperationFence {
+    host.shared
+        .normal_operations
+        .try_fence()
+        .expect("normal operations should fence")
 }
 
 pub(crate) fn poison_connection(host: &VsockHost) {

--- a/crates/vsock-host/src/tests/support.rs
+++ b/crates/vsock-host/src/tests/support.rs
@@ -66,6 +66,12 @@ pub(crate) fn poison_connection(host: &VsockHost) {
     host.shared.poison_connection();
 }
 
+pub(crate) fn drop_started_pending_normal_request_write_guard(host: &VsockHost) {
+    let mut guard = crate::PendingNormalRequestWriteGuard::new(Arc::clone(&host.shared));
+    guard.mark_started();
+    drop(guard);
+}
+
 pub(crate) async fn read_guest_message(
     stream: &mut UnixStream,
     decoder: &mut Decoder,


### PR DESCRIPTION
## Summary
- route bounded exec operations through NormalOperationTracker and complete them from terminal exec dispatch
- add an opt-in tracked normal request helper and use it for small write_file requests
- keep lifecycle/control requests and large composite write_file chunks outside this PR scope
- add tracker readiness coverage for exec success/error/drop/malformed cases, write_file success/error/drop/unexpected response, and lifecycle fence bypass

## Tests
- cargo fmt --manifest-path crates/Cargo.toml --check -p vsock-host
- cargo clippy --manifest-path crates/Cargo.toml -p vsock-host --all-targets --all-features
- cargo test --manifest-path crates/Cargo.toml -p vsock-host
- git diff --check
- CARGO_BUILD_JOBS=1 git commit ... (pre-commit: cargo fmt, workspace clippy, workspace docs)

Closes #13455