### PR TITLE
feat(zero-host): add org hash to hosted site domain to prevent slug conflicts

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-host.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-host.test.ts
@@ -145,8 +145,10 @@ describe("POST /api/zero/host/deployments/prepare", () => {
       [200],
     );
 
-    expect(response.body.publicSlug).toBe("demo-site");
-    expect(response.body.url).toBe("https://demo-site.sites.example.com");
+    expect(response.body.publicSlug).toMatch(/^demo-site-[a-f0-9]{8}$/);
+    expect(response.body.url).toMatch(
+      /^https:\/\/demo-site-[a-f0-9]{8}\.sites\.example\.com$/,
+    );
     expect(response.body.uploads).toHaveLength(2);
     expect(
       response.body.uploads.map((upload) => {
@@ -210,7 +212,7 @@ describe("POST /api/zero/host/deployments/:deploymentId/complete", () => {
       [200],
     );
 
-    const prefix = `sites/demo-site/deployments/${prepared.body.deploymentId}`;
+    const prefix = `sites/${prepared.body.publicSlug}/deployments/${prepared.body.deploymentId}`;
     const puts = mockUploadedKeys([
       `${prefix}/index.html`,
       `${prefix}/assets/index-a1b2c3d4.js`,
@@ -228,11 +230,13 @@ describe("POST /api/zero/host/deployments/:deploymentId/complete", () => {
     expect(completed.body).toMatchObject({
       deploymentId: prepared.body.deploymentId,
       status: "ready",
-      url: "https://demo-site.sites.example.com",
     });
+    expect(completed.body.url).toMatch(
+      /^https:\/\/demo-site-[a-f0-9]{8}\.sites\.example\.com$/,
+    );
     expect(puts).toStrictEqual([
       `${prefix}/manifest.json`,
-      "sites/demo-site/active.json",
+      `sites/${prepared.body.publicSlug}/active.json`,
     ]);
 
     const writeDb = store.set(writeDb$);

--- a/turbo/apps/api/src/signals/services/zero-host.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-host.service.ts
@@ -339,7 +339,11 @@ export const prepareHostedSiteDeployment$ = command(
 
     const writeDb = set(writeDb$);
     const now = nowDate();
-    const publicSlug = args.body.site;
+    const orgHash = createHash("sha256")
+      .update(args.orgId)
+      .digest("hex")
+      .substring(0, 8);
+    const publicSlug = `${args.body.site}-${orgHash}`;
     const url = publicUrl(publicSlug);
 
     const siteAndDeployment = await createHostedSiteDeployment(


### PR DESCRIPTION
## Summary
- Append 8-char `sha256(orgId)` hex hash to `publicSlug` so different orgs can use the same site slug without domain conflicts
- Domain format changes from `{slug}.sites.vm0.io` to `{slug}-{hash}.sites.vm0.io`
- Worker regex (`siteSlugFromHost`) is already compatible — no changes needed
- DB `publicSlug` column (varchar 96) fits `slug(63) + hyphen(1) + hash(8) = 72` chars

## Test plan
- [x] Updated test assertions to match new hashed `publicSlug` and `url` patterns
- [ ] Verify host-worker can resolve hashed domains (regex already tested compatible)
- [ ] Deploy and verify existing sites continue to serve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)