### PR TITLE
refactor: route connector modal content by auth method

### DIFF
--- a/turbo/apps/platform/src/views/conn/__tests__/add-connection-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/conn/__tests__/add-connection-dialog.test.tsx
@@ -8,7 +8,7 @@
  */
 
 import { describe, expect, it, vi } from "vitest";
-import { screen, waitFor } from "@testing-library/react";
+import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ConnectorType } from "@vm0/connectors/connectors";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
@@ -89,6 +89,78 @@ describe("connect modal - content by auth method", () => {
     expect(screen.getByText("Save")).toBeInTheDocument();
   });
 
+  it("shows Remote Agent connector-specific API content", async () => {
+    await openConnectModal("remote-agent", {
+      featureSwitches: { [FeatureSwitchKey.RemoteAgent]: true },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Online hosts")).toBeInTheDocument();
+    });
+    const dialog = screen.getByRole("dialog");
+    expect(within(dialog).getByText(/No online hosts yet/)).toBeInTheDocument();
+    expect(within(dialog).queryByText("Save")).not.toBeInTheDocument();
+    expect(within(dialog).queryByText(/Sign in with/)).not.toBeInTheDocument();
+  });
+
+  it("shows Local Browser connector-specific API content", async () => {
+    await openConnectModal("local-browser", {
+      featureSwitches: { [FeatureSwitchKey.LocalBrowserUse]: true },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Browser extension")).toBeInTheDocument();
+    });
+    const dialog = screen.getByRole("dialog");
+    expect(within(dialog).getByText("Browser hosts")).toBeInTheDocument();
+    expect(within(dialog).queryByText("Save")).not.toBeInTheDocument();
+    expect(within(dialog).queryByText(/Sign in with/)).not.toBeInTheDocument();
+  });
+
+  it("keeps API-only content visible while OAuth is settling elsewhere", async () => {
+    vi.spyOn(window, "open").mockReturnValue({ closed: false } as Window);
+
+    let callCount = 0;
+    server.use(
+      mockApi(zeroConnectorsMainContract.list, ({ respond, never }) => {
+        callCount++;
+        if (callCount === 1) {
+          return respond(200, {
+            connectors: [],
+            configuredTypes: [],
+            connectorProvidedSecretNames: [],
+          });
+        }
+        return never();
+      }),
+    );
+
+    await openConnectModal("github", {
+      featureSwitches: { [FeatureSwitchKey.RemoteAgent]: true },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Sign in with GitHub")).toBeInTheDocument();
+    });
+
+    click(screen.getByText("Sign in with GitHub"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Connecting...")).toBeInTheDocument();
+    });
+
+    context.store.set(setSelectedConnectorType$, "remote-agent");
+
+    await waitFor(() => {
+      expect(screen.getByText("Online hosts")).toBeInTheDocument();
+    });
+    const dialog = screen.getByRole("dialog");
+    expect(
+      within(dialog).queryByText("Saving permissions..."),
+    ).not.toBeInTheDocument();
+    expect(within(dialog).queryByText("Connecting...")).not.toBeInTheDocument();
+  });
+
   it("shows OAuth and API token choices when both auth methods are available", async () => {
     await openConnectModal("deel", {
       featureSwitches: { [FeatureSwitchKey.DeelConnector]: true },
@@ -98,8 +170,27 @@ describe("connect modal - content by auth method", () => {
       expect(screen.getByText("Sign in with Deel")).toBeInTheDocument();
     });
 
-    expect(screen.getByText("or")).toBeInTheDocument();
     expect(screen.getByText("API Token")).toBeInTheDocument();
+    expect(screen.getByText("or")).toBeInTheDocument();
+    expect(screen.getByText("Save")).toBeInTheDocument();
+  });
+
+  it("hides CLI auth when other auth methods have modal UI", async () => {
+    await openConnectModal("stripe", {
+      featureSwitches: {
+        [FeatureSwitchKey.StripeConnector]: true,
+        [FeatureSwitchKey.CliAuthStripe]: true,
+      },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Sign in with Stripe")).toBeInTheDocument();
+    });
+
+    expect(
+      screen.queryByText("CLI authentication is not available yet"),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText("Stripe CLI")).not.toBeInTheDocument();
     expect(screen.getByText("Save")).toBeInTheDocument();
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx
@@ -15,8 +15,10 @@ import {
 } from "@vm0/ui/components/ui/dialog";
 import {
   CONNECTOR_TYPES,
+  type ConnectorAuthMethodType,
   type ConnectorType,
 } from "@vm0/connectors/connectors";
+import type { ReactElement } from "react";
 import type { LocalBrowserHost } from "@vm0/api-contracts/contracts/zero-local-browser";
 import { isGoogleOAuthConnector } from "@vm0/connectors/connector-utils";
 import {
@@ -168,6 +170,26 @@ type ConnectModalContentProps = {
   item: ConnectorTypeWithStatus;
   onSuccess: () => void | Promise<void>;
   showPermissionDialogOnConnect: boolean;
+};
+
+type ConnectMethodContentProps = ConnectModalContentProps & {
+  connectAndSettle: ConnectAndSettleFn;
+  submitApiToken: SubmitApiTokenFn;
+  credentialSubmitting: boolean;
+  signal: AbortSignal;
+};
+
+type ApiConnectContentComponent = (
+  props: ConnectModalContentProps,
+) => ReactElement;
+
+type ConnectMethodContentComponent = (
+  props: ConnectMethodContentProps,
+) => ReactElement;
+
+type ConnectMethodContentEntry = {
+  authMethod: ConnectorAuthMethodType;
+  Content: ConnectMethodContentComponent;
 };
 
 // ---------------------------------------------------------------------------
@@ -591,36 +613,18 @@ function LocalBrowserConnectContent({
   );
 }
 
-// ---------------------------------------------------------------------------
-// Connect modal content (OAuth button + token form, or just token form)
-// ---------------------------------------------------------------------------
-
-function getConnectorSpecificConnectContent({
-  item,
-  onSuccess,
-  showPermissionDialogOnConnect,
-}: ConnectModalContentProps) {
-  if (item.type === REMOTE_AGENT_CONNECTOR_TYPE) {
-    return (
-      <RemoteAgentConnectContent
-        item={item}
-        onSuccess={onSuccess}
-        showPermissionDialogOnConnect={showPermissionDialogOnConnect}
-      />
-    );
-  }
-
-  if (item.type === LOCAL_BROWSER_CONNECTOR_TYPE) {
-    return (
-      <LocalBrowserConnectContent
-        item={item}
-        onSuccess={onSuccess}
-        showPermissionDialogOnConnect={showPermissionDialogOnConnect}
-      />
-    );
-  }
-
-  return null;
+function UnavailableConnectMethodsContent() {
+  return (
+    <div className="rounded-md border border-dashed border-border bg-muted/30 p-3">
+      <p className="text-sm font-medium text-foreground">
+        Connection methods unavailable
+      </p>
+      <p className="mt-1 text-sm text-muted-foreground">
+        This connector has available connection methods, but none of them can be
+        configured from this dialog yet.
+      </p>
+    </div>
+  );
 }
 
 function getOAuthProgressContent({
@@ -697,6 +701,108 @@ function AuthMethodDivider() {
   );
 }
 
+function OAuthConnectMethodContent(props: ConnectMethodContentProps) {
+  return (
+    <OAuthConnectButton
+      item={props.item}
+      label={CONNECTOR_TYPES[props.item.type].label}
+      onSuccess={props.onSuccess}
+      showPermissionDialogOnConnect={props.showPermissionDialogOnConnect}
+      connectAndSettle={props.connectAndSettle}
+      signal={props.signal}
+    />
+  );
+}
+
+function ApiTokenConnectMethodContent(props: ConnectMethodContentProps) {
+  return (
+    <ApiTokenForm
+      type={props.item.type}
+      item={props.item}
+      onSuccess={props.onSuccess}
+      showPermissionDialogOnConnect={props.showPermissionDialogOnConnect}
+      submit={props.submitApiToken}
+      submitting={props.credentialSubmitting}
+    />
+  );
+}
+
+function getApiConnectContentComponent(
+  type: ConnectorType,
+): ApiConnectContentComponent | null {
+  switch (type) {
+    case REMOTE_AGENT_CONNECTOR_TYPE: {
+      return RemoteAgentConnectContent;
+    }
+    case LOCAL_BROWSER_CONNECTOR_TYPE: {
+      return LocalBrowserConnectContent;
+    }
+    default: {
+      return null;
+    }
+  }
+}
+
+function getConnectMethodContentComponent(
+  item: ConnectorTypeWithStatus,
+  authMethod: ConnectorAuthMethodType,
+): ConnectMethodContentComponent | null {
+  switch (authMethod) {
+    case "oauth": {
+      return OAuthConnectMethodContent;
+    }
+    case "api-token": {
+      return ApiTokenConnectMethodContent;
+    }
+    case "cli-auth": {
+      return null;
+    }
+    case "api": {
+      return getApiConnectContentComponent(item.type);
+    }
+  }
+}
+
+function getConnectMethodContentEntries(
+  item: ConnectorTypeWithStatus,
+): ConnectMethodContentEntry[] {
+  return item.availableAuthMethods.flatMap((authMethod) => {
+    const Content = getConnectMethodContentComponent(item, authMethod);
+    return Content ? [{ authMethod, Content }] : [];
+  });
+}
+
+function ConnectMethodsContent({
+  entries,
+  availableAuthMethodCount,
+  props,
+}: {
+  entries: readonly ConnectMethodContentEntry[];
+  availableAuthMethodCount: number;
+  props: ConnectMethodContentProps;
+}) {
+  if (availableAuthMethodCount === 0) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        No connection method is available.
+      </p>
+    );
+  }
+
+  if (entries.length === 0) {
+    return <UnavailableConnectMethodsContent />;
+  }
+
+  return entries.map(({ authMethod, Content }, index) => {
+    return (
+      <div key={authMethod} className="contents">
+        {index > 0 && <AuthMethodDivider />}
+        <Content {...props} />
+      </div>
+    );
+  });
+}
+
 function StandardConnectMethodsContent({
   item,
   onSuccess,
@@ -711,38 +817,29 @@ function StandardConnectMethodsContent({
   credentialSubmitting: boolean;
   signal: AbortSignal;
 }) {
-  const config = CONNECTOR_TYPES[item.type];
-  const hasOAuth = item.availableAuthMethods.includes("oauth");
-  const hasApiToken = item.availableAuthMethods.includes("api-token");
-  const isGoogleOAuth = hasOAuth && isGoogleOAuthConnector(item.type);
+  const entries = getConnectMethodContentEntries(item);
+  const isGoogleOAuth =
+    entries.some((entry) => {
+      return entry.authMethod === "oauth";
+    }) && isGoogleOAuthConnector(item.type);
 
   return (
     <div className="flex flex-col gap-4">
       {isGoogleOAuth && <GoogleOAuthNotice />}
 
-      {hasOAuth && (
-        <OAuthConnectButton
-          item={item}
-          label={config.label}
-          onSuccess={onSuccess}
-          showPermissionDialogOnConnect={showPermissionDialogOnConnect}
-          connectAndSettle={connectAndSettle}
-          signal={signal}
-        />
-      )}
-
-      {hasOAuth && hasApiToken && <AuthMethodDivider />}
-
-      {hasApiToken && (
-        <ApiTokenForm
-          type={item.type}
-          item={item}
-          onSuccess={onSuccess}
-          showPermissionDialogOnConnect={showPermissionDialogOnConnect}
-          submit={submitApiToken}
-          submitting={credentialSubmitting}
-        />
-      )}
+      <ConnectMethodsContent
+        entries={entries}
+        availableAuthMethodCount={item.availableAuthMethods.length}
+        props={{
+          item,
+          onSuccess,
+          showPermissionDialogOnConnect,
+          connectAndSettle,
+          submitApiToken,
+          credentialSubmitting,
+          signal,
+        }}
+      />
     </div>
   );
 }
@@ -760,16 +857,12 @@ function ConnectModalContent({
   const credentialSubmitting = apiTokenLoadable.state === "loading";
   const isPolling = pollingType === item.type;
 
-  const connectorSpecificContent = getConnectorSpecificConnectContent({
-    item,
-    onSuccess,
-    showPermissionDialogOnConnect,
-  });
-  if (connectorSpecificContent) {
-    return connectorSpecificContent;
-  }
-
-  const progressContent = getOAuthProgressContent({ isPolling, settling });
+  const progressContent = item.availableAuthMethods.includes("oauth")
+    ? getOAuthProgressContent({
+        isPolling,
+        settling,
+      })
+    : null;
   if (progressContent) {
     return progressContent;
   }
@@ -788,7 +881,7 @@ function ConnectModalContent({
 }
 
 // ---------------------------------------------------------------------------
-// Connect modal (opened when clicking Connect on a connector with api-token)
+// Connect modal opened when configuring a connector.
 // ---------------------------------------------------------------------------
 
 export function ConnectModal({


### PR DESCRIPTION
## Summary
- route connect modal content through auth-method content entries
- keep connector-specific API content for Remote Agent and Local Browser in the same auth-method flow
- hide CLI auth when no modal UI exists yet and guard OAuth progress to OAuth-capable connectors

## Tests
- pnpm --dir turbo --filter @vm0/app exec vitest run src/views/conn/__tests__/add-connection-dialog.test.tsx src/views/zero-page/__tests__/zero-connectors-page-interaction.test.tsx
- pnpm --dir turbo --filter @vm0/app lint
- pnpm --dir turbo --filter @vm0/app check-types
- git diff --check