### PR TITLE
refactor(guest-agent): extract CLI termination FSM

### DIFF
--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -4,6 +4,7 @@ mod command;
 mod diagnostics;
 mod event_delivery;
 mod framework;
+mod termination;
 
 pub use command::build_cli_command;
 pub use framework::ClaudeResultSummary;
@@ -23,70 +24,10 @@ use guest_common::{log_info, log_warn};
 use std::collections::HashMap;
 use std::process::Stdio;
 use std::time::{Duration, Instant};
+use termination::{TerminationReason, TerminationState};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt};
 
 const LOG_TAG: &str = "sandbox:guest-agent";
-
-/// State machine driving forced CLI process-group termination. A single
-/// pinned deadline is resettable across phases; the enum value tells the
-/// lone select! branch what to do when the deadline fires.
-///
-/// | From             | Trigger        | To              | Action          |
-/// |------------------|----------------|-----------------|-----------------|
-/// | `Idle`           | `type=result`  | `SigtermPending`| arm delayed sigterm grace |
-/// | `Idle`           | forced kill    | `SigkillPending`| SIGTERM pgid, arm sigkill grace |
-/// | `SigtermPending` | deadline fires | `SigkillPending`| SIGTERM pgid, arm sigkill grace |
-/// | `SigkillPending` | deadline fires | `Done`          | SIGKILL pgid    |
-/// | _any pending_    | `child.wait()` | `Done`          | (no signal)     |
-///
-/// `Done` is sticky: a late second `type=result` on the same run cannot
-/// re-arm the deadline, and any in-flight signalling is one-shot.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum TerminationState {
-    Idle,
-    SigtermPending { reason: TerminationReason },
-    SigkillPending { reason: TerminationReason },
-    Done,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum TerminationReason {
-    PostResult,
-    StuckTool,
-    HeartbeatError,
-    HeartbeatPanic,
-}
-
-impl TerminationReason {
-    fn label(self) -> &'static str {
-        match self {
-            TerminationReason::PostResult => "post-result reap",
-            TerminationReason::StuckTool => "stuck-tool watchdog",
-            TerminationReason::HeartbeatError => "heartbeat error",
-            TerminationReason::HeartbeatPanic => "heartbeat panic",
-        }
-    }
-}
-
-impl TerminationState {
-    /// True while waiting for an armed SIGTERM or SIGKILL deadline to fire;
-    /// used as the select! branch's eligibility guard.
-    fn is_pending(self) -> bool {
-        matches!(
-            self,
-            TerminationState::SigtermPending { .. } | TerminationState::SigkillPending { .. }
-        )
-    }
-
-    /// Whether to arm the reap deadline on an incoming `type=result`
-    /// event. Only the initial Idle → SigtermPending transition should
-    /// fire — later events (or a result that races a CLI exit) must
-    /// not re-arm. Single source of truth consumed by both the
-    /// production guard in `execute_cli` and the FSM unit tests.
-    fn should_arm_post_result(self, cli_exited: bool) -> bool {
-        matches!(self, TerminationState::Idle) && !cli_exited
-    }
-}
 
 async fn tick_optional_interval(interval: &mut Option<tokio::time::Interval>) {
     match interval {
@@ -730,65 +671,4 @@ pub async fn execute_cli(
         last_event_sequence,
         claude_result,
     })
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    // -----------------------------------------------------------------
-    // TerminationState FSM
-    // -----------------------------------------------------------------
-
-    #[test]
-    fn termination_state_is_pending_only_between_arming_and_done() {
-        assert!(!TerminationState::Idle.is_pending());
-        assert!(
-            TerminationState::SigtermPending {
-                reason: TerminationReason::PostResult,
-            }
-            .is_pending()
-        );
-        assert!(
-            TerminationState::SigkillPending {
-                reason: TerminationReason::StuckTool,
-            }
-            .is_pending()
-        );
-        assert!(!TerminationState::Done.is_pending());
-    }
-
-    /// The arming guard must fire exactly once per run, on the first
-    /// `type=result` event, and only when the CLI is still alive. Any
-    /// later state — or a CLI that already exited — must be ignored
-    /// (Done is sticky; SigtermPending/SigkillPending already armed).
-    ///
-    /// Calls `TerminationState::should_arm_post_result` directly so
-    /// the test shares a single source of truth with the production
-    /// `select!` branch.
-    #[test]
-    fn termination_state_should_arm_post_result_matches_invariant() {
-        // Fire only from Idle with CLI still alive.
-        assert!(TerminationState::Idle.should_arm_post_result(false));
-
-        // CLI already exited → no arm, even from Idle.
-        assert!(!TerminationState::Idle.should_arm_post_result(true));
-
-        // Already armed → no re-arm.
-        assert!(
-            !TerminationState::SigtermPending {
-                reason: TerminationReason::PostResult,
-            }
-            .should_arm_post_result(false)
-        );
-        assert!(
-            !TerminationState::SigkillPending {
-                reason: TerminationReason::HeartbeatError,
-            }
-            .should_arm_post_result(false)
-        );
-
-        // Done is sticky.
-        assert!(!TerminationState::Done.should_arm_post_result(false));
-    }
 }

--- a/crates/guest-agent/src/cli/termination.rs
+++ b/crates/guest-agent/src/cli/termination.rs
@@ -1,0 +1,122 @@
+//! CLI process-group termination state machine.
+//!
+//! Signal sending, deadline reset timing, and child wait ordering remain in
+//! `execute_cli`; this module only owns the FSM state and guards.
+
+/// State machine driving forced CLI process-group termination. A single
+/// pinned deadline is resettable across phases; the enum value tells the
+/// lone select! branch what to do when the deadline fires.
+///
+/// | From             | Trigger        | To              | Action          |
+/// |------------------|----------------|-----------------|-----------------|
+/// | `Idle`           | `type=result`  | `SigtermPending`| arm delayed sigterm grace |
+/// | `Idle`           | forced kill    | `SigkillPending`| SIGTERM pgid, arm sigkill grace |
+/// | `SigtermPending` | deadline fires | `SigkillPending`| SIGTERM pgid, arm sigkill grace |
+/// | `SigkillPending` | deadline fires | `Done`          | SIGKILL pgid    |
+/// | _any pending_    | `child.wait()` | `Done`          | (no signal)     |
+///
+/// `Done` is sticky: a late second `type=result` on the same run cannot
+/// re-arm the deadline, and any in-flight signalling is one-shot.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum TerminationState {
+    Idle,
+    SigtermPending { reason: TerminationReason },
+    SigkillPending { reason: TerminationReason },
+    Done,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum TerminationReason {
+    PostResult,
+    StuckTool,
+    HeartbeatError,
+    HeartbeatPanic,
+}
+
+impl TerminationReason {
+    pub(super) fn label(self) -> &'static str {
+        match self {
+            TerminationReason::PostResult => "post-result reap",
+            TerminationReason::StuckTool => "stuck-tool watchdog",
+            TerminationReason::HeartbeatError => "heartbeat error",
+            TerminationReason::HeartbeatPanic => "heartbeat panic",
+        }
+    }
+}
+
+impl TerminationState {
+    /// True while waiting for an armed SIGTERM or SIGKILL deadline to fire;
+    /// used as the select! branch's eligibility guard.
+    pub(super) fn is_pending(self) -> bool {
+        matches!(
+            self,
+            TerminationState::SigtermPending { .. } | TerminationState::SigkillPending { .. }
+        )
+    }
+
+    /// Whether to arm the reap deadline on an incoming `type=result`
+    /// event. Only the initial Idle -> SigtermPending transition should
+    /// fire -- later events (or a result that races a CLI exit) must
+    /// not re-arm. Single source of truth consumed by both the
+    /// production guard in `execute_cli` and the FSM unit tests.
+    pub(super) fn should_arm_post_result(self, cli_exited: bool) -> bool {
+        matches!(self, TerminationState::Idle) && !cli_exited
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn termination_state_is_pending_only_between_arming_and_done() {
+        assert!(!TerminationState::Idle.is_pending());
+        assert!(
+            TerminationState::SigtermPending {
+                reason: TerminationReason::PostResult,
+            }
+            .is_pending()
+        );
+        assert!(
+            TerminationState::SigkillPending {
+                reason: TerminationReason::StuckTool,
+            }
+            .is_pending()
+        );
+        assert!(!TerminationState::Done.is_pending());
+    }
+
+    /// The arming guard must fire exactly once per run, on the first
+    /// `type=result` event, and only when the CLI is still alive. Any
+    /// later state -- or a CLI that already exited -- must be ignored
+    /// (Done is sticky; SigtermPending/SigkillPending already armed).
+    ///
+    /// Calls `TerminationState::should_arm_post_result` directly so
+    /// the test shares a single source of truth with the production
+    /// `select!` branch.
+    #[test]
+    fn termination_state_should_arm_post_result_matches_invariant() {
+        // Fire only from Idle with CLI still alive.
+        assert!(TerminationState::Idle.should_arm_post_result(false));
+
+        // CLI already exited -> no arm, even from Idle.
+        assert!(!TerminationState::Idle.should_arm_post_result(true));
+
+        // Already armed -> no re-arm.
+        assert!(
+            !TerminationState::SigtermPending {
+                reason: TerminationReason::PostResult,
+            }
+            .should_arm_post_result(false)
+        );
+        assert!(
+            !TerminationState::SigkillPending {
+                reason: TerminationReason::HeartbeatError,
+            }
+            .should_arm_post_result(false)
+        );
+
+        // Done is sticky.
+        assert!(!TerminationState::Done.should_arm_post_result(false));
+    }
+}


### PR DESCRIPTION
## Summary
- Extract the CLI process-group termination FSM into `crates/guest-agent/src/cli/termination.rs`.
- Move `TerminationState`, `TerminationReason`, labels, guards, and FSM unit tests together.
- Keep signal sending, deadline reset timing, and child wait ordering inside `execute_cli` unchanged.

Closes #13451
Parent #13382

## Verification
- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `git diff --check`
- `CARGO_BUILD_JOBS=1 CARGO_INCREMENTAL=0 cargo clippy --manifest-path crates/Cargo.toml --target-dir /tmp/vm4-guest-agent-13451-target -p guest-agent --all-targets -- -D warnings`
- `cargo test --manifest-path crates/Cargo.toml --target-dir /tmp/vm4-guest-agent-13451-target -p guest-agent termination_state`
- `cargo test --manifest-path crates/Cargo.toml --target-dir /tmp/vm4-guest-agent-13451-target -p guest-agent --test post_result_reap`
- `cargo test --manifest-path crates/Cargo.toml --target-dir /tmp/vm4-guest-agent-13451-target -p guest-agent --test post_result_reap_happy`
- `cargo test --manifest-path crates/Cargo.toml --target-dir /tmp/vm4-guest-agent-13451-target -p guest-agent --test post_result_reap_sigkill`
- `cargo test --manifest-path crates/Cargo.toml --target-dir /tmp/vm4-guest-agent-13451-target -p guest-agent --test heartbeat_reap_sigkill`
- `cargo test --manifest-path crates/Cargo.toml --target-dir /tmp/vm4-guest-agent-13451-target -p guest-agent --test heartbeat_panic_reap_sigkill`
- `cargo test --manifest-path crates/Cargo.toml --target-dir /tmp/vm4-guest-agent-13451-target -p guest-agent --test stuck_tool_reap_sigkill`
- `cargo test --manifest-path crates/Cargo.toml --target-dir /tmp/vm4-guest-agent-13451-target -p guest-agent --test stuck_tool_stdout_eof_reap_sigkill`
- `cargo test --manifest-path crates/Cargo.toml --target-dir /tmp/vm4-guest-agent-13451-target -p guest-agent`
- `CARGO_BUILD_JOBS=1 cargo clippy --all-targets --all-features` from `crates/`
- `CARGO_BUILD_JOBS=1 cargo doc --workspace --all-features --no-deps` from `crates/`