### PR TITLE
fix(api): resolve resume session history from R2 hash

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/agent-runs-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/agent-runs-create.test.ts
@@ -161,6 +161,39 @@ const seedConversationForSession$ = command(
   },
 );
 
+const seedHashConversationForSession$ = command(
+  async (
+    { set },
+    args: {
+      readonly runId: string;
+      readonly sessionId: string;
+      readonly hash: string;
+    },
+    signal: AbortSignal,
+  ): Promise<string> => {
+    const db = set(writeDb$);
+    const [conversation] = await db
+      .insert(conversations)
+      .values({
+        runId: args.runId,
+        cliAgentType: "claude-code",
+        cliAgentSessionId: `session-${args.runId}`,
+        cliAgentSessionHistoryHash: args.hash,
+      })
+      .returning({ id: conversations.id });
+    signal.throwIfAborted();
+    if (!conversation) {
+      throw new Error("conversation insert returned no row");
+    }
+    await db
+      .update(agentSessions)
+      .set({ conversationId: conversation.id })
+      .where(eq(agentSessions.id, args.sessionId));
+    signal.throwIfAborted();
+    return conversation.id;
+  },
+);
+
 const track = createFixtureTracker<UsageInsightFixture>((fixture) => {
   return store.set(deleteUsageInsightFixture$, fixture, context.signal);
 });
@@ -914,6 +947,86 @@ describe("POST /api/agent/runs", () => {
       sessionId: `session-${first.body.runId}`,
     });
     expect(conversationId).toBeDefined();
+  });
+
+  it("continues a session whose history is stored only in R2 (hash-only conversation)", async () => {
+    const fx = await fixture();
+    const compose = await createCompose({ fixture: fx });
+    const first = await accept(
+      runsClient().create({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { agentComposeId: compose.composeId, prompt: "first" },
+      }),
+      [201],
+    );
+
+    const hash = "a".repeat(64);
+    const sessionHistoryContent =
+      '{"type":"init"}\n{"type":"human","text":"hi"}\n';
+
+    await store.set(
+      seedHashConversationForSession$,
+      {
+        runId: first.body.runId,
+        sessionId: first.body.sessionId,
+        hash,
+      },
+      context.signal,
+    );
+    const db = store.set(writeDb$);
+    await db
+      .update(agentRuns)
+      .set({ status: "completed", completedAt: nowDate() })
+      .where(eq(agentRuns.id, first.body.runId));
+
+    context.mocks.s3.send.mockImplementation((cmd: unknown) => {
+      const input = (cmd as { readonly input?: { readonly Key?: string } })
+        .input;
+      if (input?.Key === `blobs/${hash}.blob`) {
+        return Promise.resolve({
+          Body: {
+            async *[Symbol.asyncIterator]() {
+              yield Buffer.from(sessionHistoryContent, "utf8");
+            },
+          },
+        });
+      }
+      return Promise.resolve({});
+    });
+
+    const continued = await accept(
+      runsClient().create({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { sessionId: first.body.sessionId, prompt: "continue" },
+      }),
+      [201],
+    );
+
+    expect(continued.body.sessionId).toBe(first.body.sessionId);
+
+    const [job] = await db
+      .select({ executionContext: runnerJobQueue.executionContext })
+      .from(runnerJobQueue)
+      .where(eq(runnerJobQueue.runId, continued.body.runId));
+    expect(job).toBeDefined();
+    const executionContext = job!.executionContext as {
+      readonly resumeSession: {
+        readonly sessionId: string;
+        readonly sessionHistory: string;
+      };
+    };
+    expect(executionContext.resumeSession.sessionId).toBe(
+      `session-${first.body.runId}`,
+    );
+    expect(executionContext.resumeSession.sessionHistory).toBe(
+      sessionHistoryContent,
+    );
+    expect(runContextSnapshot(continued.body.runId)).toMatchObject({
+      runId: continued.body.runId,
+      userId: fx.userId,
+      prompt: "continue",
+      sessionId: `session-${first.body.runId}`,
+    });
   });
 
   it("resumes from a checkpoint and stores resumedFromCheckpointId", async () => {

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -94,6 +94,7 @@ import {
   providerUnavailable,
 } from "../../lib/error";
 import { writeDb$, type Db } from "../external/db";
+import { downloadS3Buffer } from "../external/s3";
 import { getDatasetName, ingestToAxiom } from "../external/axiom";
 import {
   publishOrgSignal,
@@ -1875,6 +1876,7 @@ async function resolveByComposeId(
 }
 
 async function resolveBySessionId(
+  get: ComputedGetter,
   db: Db,
   sessionId: string,
   userId: string,
@@ -1909,7 +1911,7 @@ async function resolveBySessionId(
   const resumeSession =
     session.conversationId === null
       ? undefined
-      : await loadResumeSession(db, session.conversationId);
+      : await loadResumeSession(get, db, session.conversationId);
 
   return {
     ...resolved,
@@ -1921,6 +1923,7 @@ async function resolveBySessionId(
 }
 
 async function resolveByCheckpointId(
+  get: ComputedGetter,
   db: Db,
   checkpointId: string,
   userId: string,
@@ -1967,11 +1970,12 @@ async function resolveByCheckpointId(
       row.volumeVersionsSnapshot,
     ),
     resumedFromCheckpointId: checkpointId,
-    resumeSession: await loadResumeSession(db, row.conversationId),
+    resumeSession: await loadResumeSession(get, db, row.conversationId),
   };
 }
 
 async function loadResumeSession(
+  get: ComputedGetter,
   db: Db,
   conversationId: string,
 ): Promise<StoredExecutionContext["resumeSession"] | undefined> {
@@ -1979,22 +1983,64 @@ async function loadResumeSession(
     .select({
       cliAgentSessionId: conversations.cliAgentSessionId,
       cliAgentSessionHistory: conversations.cliAgentSessionHistory,
+      cliAgentSessionHistoryHash: conversations.cliAgentSessionHistoryHash,
     })
     .from(conversations)
     .where(eq(conversations.id, conversationId))
     .limit(1);
 
-  if (!conversation?.cliAgentSessionHistory) {
+  if (!conversation) {
+    return undefined;
+  }
+
+  const sessionHistory = await resolveConversationSessionHistory(get, {
+    hash: conversation.cliAgentSessionHistoryHash,
+    legacyText: conversation.cliAgentSessionHistory,
+  });
+
+  if (sessionHistory === null) {
     return undefined;
   }
 
   return {
     sessionId: conversation.cliAgentSessionId,
-    sessionHistory: conversation.cliAgentSessionHistory,
+    sessionHistory,
   };
 }
 
+async function resolveConversationSessionHistory(
+  get: ComputedGetter,
+  args: {
+    readonly hash: string | null;
+    readonly legacyText: string | null;
+  },
+): Promise<string | null> {
+  const { hash, legacyText } = args;
+  if (hash) {
+    const bucket = env("R2_USER_STORAGES_BUCKET_NAME");
+    const result = await safeAsync(() => {
+      return get(downloadS3Buffer(bucket, `blobs/${hash}.blob`));
+    });
+    if ("ok" in result) {
+      return result.ok.toString("utf8");
+    }
+    if (legacyText) {
+      L.warn(
+        "session history R2 retrieval failed; falling back to legacy TEXT",
+        { hash, error: result.error },
+      );
+      return legacyText;
+    }
+    throw result.error;
+  }
+  if (legacyText) {
+    return legacyText;
+  }
+  return null;
+}
+
 async function resolveCompose(
+  get: ComputedGetter,
   db: Db,
   body: CreateRunBody,
   userId: string,
@@ -2007,10 +2053,16 @@ async function resolveCompose(
   }
 
   if (body.checkpointId) {
-    return await resolveByCheckpointId(db, body.checkpointId, userId, orgId);
+    return await resolveByCheckpointId(
+      get,
+      db,
+      body.checkpointId,
+      userId,
+      orgId,
+    );
   }
   if (body.sessionId) {
-    return await resolveBySessionId(db, body.sessionId, userId, orgId);
+    return await resolveBySessionId(get, db, body.sessionId, userId, orgId);
   }
   if (body.agentComposeVersionId) {
     return await lookupComposeByVersion(db, body.agentComposeVersionId);
@@ -2783,6 +2835,7 @@ async function resolveRunModelProvider(
 }
 
 async function prepareRunContext(
+  get: ComputedGetter,
   db: Db,
   args: CreateAgentRunArgs,
   signal: AbortSignal,
@@ -2809,7 +2862,7 @@ async function prepareRunContext(
   signal.throwIfAborted();
   let body: CreateRunBody = { ...initialBody, vars: mergedVars };
 
-  const resolved = await resolveCompose(db, body, args.userId, args.orgId);
+  const resolved = await resolveCompose(get, db, body, args.userId, args.orgId);
   signal.throwIfAborted();
   if (isRouteError(resolved)) {
     return resolved;
@@ -3055,7 +3108,7 @@ export const createAgentRun$ = command(
     signal: AbortSignal,
   ): Promise<CreateRunRouteResult> => {
     const db = set(writeDb$);
-    const context = await prepareRunContext(db, args, signal);
+    const context = await prepareRunContext(get, db, args, signal);
     if (isRouteError(context)) {
       return context;
     }


### PR DESCRIPTION
## Summary

- `apps/api`'s `loadResumeSession` only read the legacy `cli_agent_session_history` TEXT column. After session history moved to R2 (`cli_agent_session_history_hash`), conversations created post-migration return `undefined` here, so `resumeSession.sessionId` is dropped from the runner job payload and every chat continuation lands as `noSessionId` — no sandbox reuse.
- Mirror the `apps/web` resolver (`resolve-session-history.ts`): read the hash column too, fetch the blob from R2 (`blobs/{hash}.blob` in `R2_USER_STORAGES_BUCKET_NAME`), keep legacy TEXT as a fallback.
- Thread the ccstate `Getter` down through `prepareRunContext` → `resolveCompose` → `resolveBy{Session,Checkpoint}Id` → `loadResumeSession` so the helper can call `downloadS3Buffer`.

Refs #13489.

## Test plan

- [x] `pnpm -F api check-types`
- [x] `pnpm -F api lint`
- [x] `pnpm -F api exec vitest run src/signals/routes/__tests__/agent-runs-create.test.ts` — 18 passed (includes the new hash-only continuation case)
- [ ] Once merged, watch \`agent_runs WHERE continued_from_session_id IS NOT NULL\` in Axiom for \`sandbox_reuse_result=reused\` recovering on apps/api-served chats

🤖 Generated with [Claude Code](https://claude.com/claude-code)