### PR TITLE
fix: sync web gpt-tokenizer lockfile

### DIFF
--- a/turbo/apps/web/package.json
+++ b/turbo/apps/web/package.json
@@ -50,7 +50,6 @@
     "croner": "^9.1.0",
     "drizzle-orm": "^0.45.2",
     "google-auth-library": "^10.6.2",
-    "gpt-tokenizer": "^3.4.0",
     "html-to-text": "^9.0.5",
     "import-in-the-middle": "^3.0.0",
     "next": "^16.2.6",


### PR DESCRIPTION
## Summary
- add the missing apps/web gpt-tokenizer importer entry to pnpm-lock.yaml
- unblock merge-group pnpm --frozen-lockfile installs after release commit f79a11fe3

## Validation
- pnpm install --frozen-lockfile --strict-peer-dependencies
- git diff --check