### PR TITLE
perf: reduce redundant chat load requests

### DIFF
--- a/turbo/apps/platform/src/signals/agent-chat.ts
+++ b/turbo/apps/platform/src/signals/agent-chat.ts
@@ -11,20 +11,55 @@ import { accept } from "../lib/accept.ts";
 import { pathParams$ } from "./route.ts";
 import { activeRoute$ } from "./active-route.ts";
 import { reloadChatThreadsCounter$ } from "./chat-thread-list-reload.ts";
+import { clerk$ } from "./auth.ts";
+import { readThreadMeta$ } from "./external/idb-thread-meta-store.ts";
 
 export { reloadChatThreads$ } from "./chat-thread-list-reload.ts";
 
 const internalChatAgentId$ = state<string | null>(null);
 
-export const currentChatAgentId$ = computed(
-  async (get): Promise<string | null> => {
-    return get(internalChatAgentId$) ?? (await get(defaultAgentId$));
-  },
-);
-
 export const setChatAgentId$ = command(({ set }, agentId: string | null) => {
   set(internalChatAgentId$, agentId);
 });
+
+export const currentChatThreadId$ = computed((get): string | null => {
+  const params = get(pathParams$);
+  const threadId = params?.threadId;
+  const route = get(activeRoute$);
+  if (route !== "chat") {
+    return null;
+  }
+  return typeof threadId === "string" ? threadId : null;
+});
+
+const currentChatThreadAgentId$ = computed(
+  async (get): Promise<string | null> => {
+    const threadId = get(currentChatThreadId$);
+    if (!threadId) {
+      return null;
+    }
+
+    const clerk = await get(clerk$);
+    const userId = clerk.user?.id;
+    const orgId = clerk.organization?.id;
+    if (!userId || !orgId) {
+      return null;
+    }
+
+    const meta = await readThreadMeta$(userId, orgId, threadId);
+    return meta?.agentId ?? null;
+  },
+);
+
+export const currentChatAgentId$ = computed(
+  async (get): Promise<string | null> => {
+    return (
+      (await get(currentChatThreadAgentId$)) ??
+      get(internalChatAgentId$) ??
+      (await get(defaultAgentId$))
+    );
+  },
+);
 
 export const currentChatAgent$ = computed(async (get) => {
   const agentId = await get(currentChatAgentId$);
@@ -37,16 +72,6 @@ export const currentChatAgent$ = computed(async (get) => {
 
 export const currentChatAgentDisplayName$ = computed(async (get) => {
   return (await get(currentChatAgent$))?.displayName;
-});
-
-export const currentChatThreadId$ = computed((get): string | null => {
-  const params = get(pathParams$);
-  const threadId = params?.threadId;
-  const route = get(activeRoute$);
-  if (route !== "chat") {
-    return null;
-  }
-  return typeof threadId === "string" ? threadId : null;
 });
 
 export interface ChatThread {

--- a/turbo/apps/platform/src/signals/agent-chat.ts
+++ b/turbo/apps/platform/src/signals/agent-chat.ts
@@ -5,7 +5,7 @@ import {
   type PersistedAttachment,
 } from "@vm0/api-contracts/contracts/chat-threads";
 import type { ModelProviderType } from "@vm0/api-contracts/contracts/model-providers";
-import { agentById, defaultAgentId$ } from "./agent.ts";
+import { agentById, currentAgentId$, defaultAgentId$ } from "./agent.ts";
 import { zeroClient$ } from "./api-client.ts";
 import { accept } from "../lib/accept.ts";
 import { pathParams$ } from "./route.ts";
@@ -56,8 +56,27 @@ export const currentChatAgentId$ = computed(
     return (
       (await get(currentChatThreadAgentId$)) ??
       get(internalChatAgentId$) ??
+      get(currentAgentId$) ??
       (await get(defaultAgentId$))
     );
+  },
+);
+
+const uuidPattern =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export const currentChatAgentRecordId$ = computed(
+  async (get): Promise<string | null> => {
+    const agentId = await get(currentChatAgentId$);
+    if (!agentId) {
+      return null;
+    }
+
+    if (uuidPattern.test(agentId)) {
+      return agentId;
+    }
+
+    return (await get(agentById(agentId))).agentId;
   },
 );
 

--- a/turbo/apps/platform/src/signals/chat-page/__tests__/pre-subscribe-catchup.test.ts
+++ b/turbo/apps/platform/src/signals/chat-page/__tests__/pre-subscribe-catchup.test.ts
@@ -1,0 +1,119 @@
+import { command, computed } from "ccstate";
+import { describe, expect, it } from "vitest";
+import type { PagedChatMessage } from "@vm0/api-contracts/contracts/chat-threads";
+import { testContext } from "../../__tests__/test-helpers.ts";
+import type { ChatThread } from "../../agent-chat.ts";
+import {
+  createChatThreadSignals,
+  ensureDraft$,
+} from "../create-chat-thread.ts";
+import type { ChatThreadDataSource } from "../chat-thread-data-source.ts";
+
+const context = testContext();
+
+function createThread(activeRunIds: string[]): ChatThread {
+  return {
+    id: "thread-pre-subscribe",
+    agentId: "agent-pre-subscribe",
+    title: null,
+    latestSessionId: null,
+    lastReadMessageId: null,
+    latestSessionProviderType: null,
+    activeRunIds,
+    activeRuns: activeRunIds.map((id) => {
+      return { id, status: "running" };
+    }),
+    isLegacySession: false,
+    draftContent: null,
+    draftAttachments: null,
+    modelProviderId: null,
+    selectedModel: null,
+  };
+}
+
+function createRemoteEmptyDataSource(input: {
+  activeRunIds: string[];
+  listAfterCalls: { count: number };
+}): ChatThreadDataSource {
+  const thread = createThread(input.activeRunIds);
+  const fallbackMessage: PagedChatMessage = {
+    id: "fallback-message",
+    role: "user",
+    content: null,
+    createdAt: "2026-05-15T00:00:00Z",
+  };
+
+  return {
+    getThread$: computed(() => {
+      return Promise.resolve(thread);
+    }),
+    reloadThread$: command(() => {}),
+    initialPage$: computed(() => {
+      return Promise.resolve({
+        messages: [],
+        hasHistoryBefore: false,
+        fetchedFromRemote: true,
+      });
+    }),
+    patchDraft$: command(() => {
+      return Promise.resolve();
+    }),
+    appendQueuedMessage$: command(() => {
+      return Promise.resolve(fallbackMessage);
+    }),
+    recallMessage$: command(() => {
+      return Promise.resolve(fallbackMessage);
+    }),
+    listMessagesAfter$: command(() => {
+      input.listAfterCalls.count += 1;
+      return Promise.resolve({ messages: [], reachedEnd: true });
+    }),
+    listMessagesBefore$: command(() => {
+      return Promise.resolve({ messages: [], hasMore: false });
+    }),
+    cancelRuns$: command(() => {
+      return Promise.resolve();
+    }),
+    markRead$: command(() => {
+      return Promise.resolve(null);
+    }),
+    subscribeRealtime$: command(() => {
+      return Promise.resolve();
+    }),
+  };
+}
+
+describe("subscribeChatThread$ pre-subscribe catch-up", () => {
+  it("skips the no-cursor catch-up after a fresh remote empty page on an idle thread", async () => {
+    const threadId = "thread-pre-subscribe-idle";
+    const listAfterCalls = { count: 0 };
+    const { draft } = context.store.set(ensureDraft$, threadId);
+    const thread = createChatThreadSignals(
+      threadId,
+      draft,
+      createRemoteEmptyDataSource({ activeRunIds: [], listAfterCalls }),
+    );
+
+    await context.store.set(thread.subscribeChatThread$, context.signal);
+
+    expect(listAfterCalls.count).toBe(0);
+  });
+
+  it("keeps the no-cursor catch-up for a fresh remote empty page with active runs", async () => {
+    const threadId = "thread-pre-subscribe-active";
+    const listAfterCalls = { count: 0 };
+    const { draft } = context.store.set(ensureDraft$, threadId);
+    const thread = createChatThreadSignals(
+      threadId,
+      draft,
+      createRemoteEmptyDataSource({
+        activeRunIds: ["run-pre-subscribe"],
+        listAfterCalls,
+      }),
+    );
+
+    await context.store.set(thread.subscribeChatThread$, context.signal);
+
+    expect(listAfterCalls.count).toBe(1);
+  });
+});

--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-data-source.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-data-source.ts
@@ -15,6 +15,7 @@ export interface InitialPage {
   messages: PagedChatMessage[];
   hasHistoryBefore: boolean;
   needsHistoryBackfill?: boolean;
+  fetchedFromRemote?: boolean;
 }
 
 export interface PatchDraftArgs {

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -1013,6 +1013,7 @@ function createPagedMessages(
   });
 
   return {
+    initialPage$,
     earliestChatMessageId$,
     latestChatMessageId$,
     groupedChatMessages$,
@@ -1219,6 +1220,7 @@ interface RunTrackingDeps {
   threadData$: Computed<Promise<ChatThread | null>>;
   interruptedRunIds$: Computed<Promise<Set<string>>>;
   latestChatMessageId$: Computed<Promise<string | undefined>>;
+  initialPage$: Computed<Promise<InitialPage>>;
   fetchNextPage$: Command<Promise<boolean>, [AbortSignal]>;
   backfillHistoryBoundary$: Command<Promise<void>, [AbortSignal]>;
   refreshLatestMessages$: Command<Promise<void>, [AbortSignal]>;
@@ -1277,6 +1279,7 @@ function createRunTracking({
   threadData$,
   interruptedRunIds$,
   latestChatMessageId$,
+  initialPage$,
   fetchNextPage$,
   backfillHistoryBoundary$,
   refreshLatestMessages$,
@@ -1304,20 +1307,33 @@ function createRunTracking({
     dataSource,
   });
 
+  const shouldRunPreSubscribeCatchup$ = command(
+    async ({ get }, signal: AbortSignal): Promise<boolean> => {
+      const initial = await get(initialPage$);
+      signal.throwIfAborted();
+      if (initial.messages.length > 0 || initial.fetchedFromRemote !== true) {
+        return true;
+      }
+
+      const thread = await get(threadData$);
+      signal.throwIfAborted();
+      return (thread?.activeRunIds.length ?? 0) > 0;
+    },
+  );
+
   const subscribeChatThread$ = command(async ({ set }, signal: AbortSignal) => {
     L.debug("subscribeChatThread$ start", { threadId });
 
     // Catch up any messages that arrived since the initial page was loaded.
-    // On IDB cache hit this fetches messages that arrived after the cache
-    // was written; on cache miss `fetchNextPage$` issues a no-cursor fetch
-    // (since the contract treats `sinceId` as optional) and ingests the
-    // server's latest page. This must run before the subscribe loop below
-    // because that loop never resolves — `setAblyLoop$` blocks on the
-    // realtime channel for the lifetime of the thread.
+    // Cache hits and active runs still need a catch-up fetch. A fresh remote
+    // empty page on an idle thread can skip it because it would repeat the same
+    // no-cursor request before the realtime loop starts.
     L.debug("subscribeChatThread$ pre-subscribe fetchNextPage$ start", {
       threadId,
     });
-    await set(fetchNextPage$, signal);
+    if (await set(shouldRunPreSubscribeCatchup$, signal)) {
+      await set(fetchNextPage$, signal);
+    }
     L.debug("subscribeChatThread$ pre-subscribe fetchNextPage$ done", {
       threadId,
     });
@@ -1885,6 +1901,7 @@ export function createChatThreadSignals(
     copyMessage$,
   } = createThreadUIState();
   const {
+    initialPage$,
     earliestChatMessageId$,
     latestChatMessageId$,
     groupedChatMessages$,
@@ -1909,6 +1926,7 @@ export function createChatThreadSignals(
     threadData$,
     interruptedRunIds$,
     latestChatMessageId$,
+    initialPage$,
     fetchNextPage$,
     backfillHistoryBoundary$,
     refreshLatestMessages$,

--- a/turbo/apps/platform/src/signals/chat-page/remote-chat-thread-data-source.ts
+++ b/turbo/apps/platform/src/signals/chat-page/remote-chat-thread-data-source.ts
@@ -316,7 +316,11 @@ export function createRemoteChatThreadDataSource(
       count: result.body.messages.length,
       hasHistoryBefore,
     });
-    return { messages: result.body.messages, hasHistoryBefore };
+    return {
+      messages: result.body.messages,
+      hasHistoryBefore,
+      fetchedFromRemote: true,
+    };
   });
 
   return {

--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -304,17 +304,26 @@ export function matchesConnectorSearch(
 }
 
 export const allConnectorTypes$ = computed(async (get) => {
-  const { connectors } = await get(connectors$);
+  const connectorListPromise = get(connectors$);
+  const features = get(featureSwitch$);
+  const remoteAgentHostListPromise = get(remoteAgentHosts$);
+  const localBrowserHostListPromise = features?.[
+    FeatureSwitchKey.LocalBrowserUse
+  ]
+    ? get(localBrowserHosts$)
+    : Promise.resolve({ hosts: [] } satisfies LocalBrowserHostListResponse);
+
+  const [{ connectors }, remoteAgentHostList, localBrowserHostList] =
+    await Promise.all([
+      connectorListPromise,
+      remoteAgentHostListPromise,
+      localBrowserHostListPromise,
+    ]);
   const connectorMap = new Map(
     connectors.map((c) => {
       return [c.type, c];
     }),
   );
-  const features = await get(featureSwitch$);
-  const remoteAgentHostList = await get(remoteAgentHosts$);
-  const localBrowserHostList = features?.[FeatureSwitchKey.LocalBrowserUse]
-    ? await get(localBrowserHosts$)
-    : { hosts: [] };
   const remoteAgentOnlineHosts = getRemoteAgentOnlineHosts(
     remoteAgentHostList.hosts,
   );

--- a/turbo/apps/platform/src/signals/zero-page/zero-connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-connectors.ts
@@ -2,7 +2,7 @@ import { command, computed } from "ccstate";
 import { zeroUserConnectorsContract } from "@vm0/api-contracts/contracts/user-connectors";
 import { reloadOnboardingStatus$ } from "./zero-onboarding.ts";
 import { zeroClient$ } from "../api-client.ts";
-import { currentChatAgentId$ } from "../agent-chat.ts";
+import { currentChatAgentRecordId$ } from "../agent-chat.ts";
 import { accept } from "../../lib/accept.ts";
 import {
   agentConnectorAuthorizationsReload$,
@@ -19,7 +19,7 @@ import {
 /** Connectors the current user has authorized for the current agent. */
 const authorizedConnectors$ = computed(async (get) => {
   get(agentConnectorAuthorizationsReload$);
-  const agentId = await get(currentChatAgentId$);
+  const agentId = await get(currentChatAgentRecordId$);
   if (!agentId) {
     return [];
   }
@@ -62,7 +62,7 @@ export const deauthorizeConnector$ = command(
 /** Persist the authorized connectors list to the server. */
 const syncAuthorizedConnectors$ = command(
   async ({ get, set }, connectorValues: string[], signal: AbortSignal) => {
-    const agentId = await get(currentChatAgentId$);
+    const agentId = await get(currentChatAgentRecordId$);
     signal.throwIfAborted();
     if (!agentId) {
       throw new Error("No agent available");

--- a/turbo/apps/platform/src/signals/zero-page/zero-connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-connectors.ts
@@ -2,7 +2,7 @@ import { command, computed } from "ccstate";
 import { zeroUserConnectorsContract } from "@vm0/api-contracts/contracts/user-connectors";
 import { reloadOnboardingStatus$ } from "./zero-onboarding.ts";
 import { zeroClient$ } from "../api-client.ts";
-import { currentChatAgent$ } from "../agent-chat.ts";
+import { currentChatAgentId$ } from "../agent-chat.ts";
 import { accept } from "../../lib/accept.ts";
 import {
   agentConnectorAuthorizationsReload$,
@@ -19,15 +19,12 @@ import {
 /** Connectors the current user has authorized for the current agent. */
 const authorizedConnectors$ = computed(async (get) => {
   get(agentConnectorAuthorizationsReload$);
-  const agent = await get(currentChatAgent$);
-  if (!agent) {
+  const agentId = await get(currentChatAgentId$);
+  if (!agentId) {
     return [];
   }
   const client = get(zeroClient$)(zeroUserConnectorsContract);
-  const result = await accept(
-    client.get({ params: { id: agent.agentId } }),
-    [200],
-  );
+  const result = await accept(client.get({ params: { id: agentId } }), [200]);
   return result.body.enabledTypes;
 });
 
@@ -65,16 +62,16 @@ export const deauthorizeConnector$ = command(
 /** Persist the authorized connectors list to the server. */
 const syncAuthorizedConnectors$ = command(
   async ({ get, set }, connectorValues: string[], signal: AbortSignal) => {
-    const agent = await get(currentChatAgent$);
+    const agentId = await get(currentChatAgentId$);
     signal.throwIfAborted();
-    if (!agent) {
+    if (!agentId) {
       throw new Error("No agent available");
     }
 
     const client = get(zeroClient$)(zeroUserConnectorsContract);
     await accept(
       client.update({
-        params: { id: agent.agentId },
+        params: { id: agentId },
         body: { enabledTypes: connectorValues },
       }),
       [200],

--- a/turbo/apps/web/package.json
+++ b/turbo/apps/web/package.json
@@ -50,7 +50,6 @@
     "croner": "^9.1.0",
     "drizzle-orm": "^0.45.2",
     "google-auth-library": "^10.6.2",
-    "gpt-tokenizer": "^3.4.0",
     "html-to-text": "^9.0.5",
     "import-in-the-middle": "^3.0.0",
     "next": "^16.2.6",

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -98,7 +98,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
 
   apps/api:
     dependencies:
@@ -294,7 +294,7 @@ importers:
         version: 8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
 
   apps/cli:
     dependencies:
@@ -376,7 +376,7 @@ importers:
         version: 6.24.1
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
       yaml:
         specifier: '>=2.8.3'
         version: 2.8.3
@@ -578,7 +578,7 @@ importers:
         version: 8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
 
   apps/web:
     dependencies:
@@ -819,7 +819,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
 
   packages/api-contracts:
     dependencies:
@@ -859,7 +859,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
 
   packages/api-services:
     devDependencies:
@@ -883,7 +883,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
 
   packages/connectors:
     dependencies:
@@ -917,7 +917,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
 
   packages/core:
     dependencies:
@@ -951,7 +951,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
 
   packages/db:
     dependencies:
@@ -988,7 +988,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
 
   packages/eslint-config:
     devDependencies:
@@ -1042,7 +1042,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
       yaml:
         specifier: '>=2.8.3'
         version: 2.8.3
@@ -1152,7 +1152,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
 
 packages:
 
@@ -9552,7 +9552,6 @@ packages:
       '@vitest/ui': 4.1.5
       happy-dom: '*'
       jsdom: '*'
-      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true
@@ -14614,7 +14613,7 @@ snapshots:
       '@vitest/mocker': 4.1.5(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       playwright: 1.59.1
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -14628,7 +14627,7 @@ snapshots:
       '@vitest/mocker': 4.1.5(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       playwright: 1.59.1
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -14644,7 +14643,7 @@ snapshots:
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
       ws: 8.20.0
     transitivePeerDependencies:
       - bufferutil
@@ -14662,7 +14661,7 @@ snapshots:
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
       ws: 8.20.0
     transitivePeerDependencies:
       - bufferutil
@@ -14682,7 +14681,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
     optionalDependencies:
       '@vitest/browser': 4.1.5(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.5)
 
@@ -14740,7 +14739,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
 
   '@vitest/utils@4.1.5':
     dependencies:
@@ -19044,7 +19043,7 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
-  vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)):
+  vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       '@vitest/expect': 4.1.5
       '@vitest/mocker': 4.1.5(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
@@ -19074,39 +19073,18 @@ snapshots:
       '@vitest/ui': 4.1.5(vitest@4.1.5)
       happy-dom: 20.9.0
     transitivePeerDependencies:
+      - '@vitejs/devtools'
+      - esbuild
+      - jiti
+      - less
       - msw
-
-  vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)):
-    dependencies:
-      '@vitest/expect': 4.1.5
-      '@vitest/mocker': 4.1.5(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
-      '@vitest/pretty-format': 4.1.5
-      '@vitest/runner': 4.1.5
-      '@vitest/snapshot': 4.1.5
-      '@vitest/spy': 4.1.5
-      '@vitest/utils': 4.1.5
-      es-module-lexer: 2.0.0
-      expect-type: 1.3.0
-      magic-string: 0.30.21
-      obug: 2.1.1
-      pathe: 2.0.3
-      picomatch: 4.0.4
-      std-env: 4.1.0
-      tinybench: 2.9.0
-      tinyexec: 1.1.1
-      tinyglobby: 0.2.16
-      tinyrainbow: 3.1.0
-      vite: 8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@opentelemetry/api': 1.9.1
-      '@types/node': 24.3.0
-      '@vitest/browser-playwright': 4.1.5(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(playwright@1.59.1)(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.5)
-      '@vitest/coverage-v8': 4.1.5(@vitest/browser@4.1.5)(vitest@4.1.5)
-      '@vitest/ui': 4.1.5(vitest@4.1.5)
-      happy-dom: 20.9.0
-    transitivePeerDependencies:
-      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - yaml
 
   vscode-languageserver-textdocument@1.0.12: {}
 


### PR DESCRIPTION
## Summary
- Skip the duplicate no-cursor message catch-up request when a fresh remote initial page already proves an idle chat thread has no messages.
- Load connector definitions and remote-agent hosts in parallel for connector status, with local-browser hosts still gated by the feature switch.
- Resolve chat agent context from cached thread metadata so connector authorization and the sidebar thread list can start earlier.
- Preserve non-UUID agent route compatibility by resolving connector authorization to the agent record id when needed.
- Remove unused `gpt-tokenizer` from `apps/web`; it remains declared in `apps/api`, where it is used.

## Validation
- `pnpm format`
- `pnpm turbo run lint`
- `pnpm check-types`
- `pnpm knip`
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-chat-page.test.tsx src/signals/chat-page/__tests__/pre-subscribe-catchup.test.ts src/signals/zero-page/__tests__/zero-added-connectors.test.ts src/signals/zero-page/__tests__/zero-connectors.test.ts src/signals/__tests__/agent.test.ts`
- GitHub Actions are green on `88101b2f7`.
