### PR TITLE
perf: reduce redundant chat reload requests

### DIFF
--- a/turbo/apps/platform/src/signals/agent-chat.ts
+++ b/turbo/apps/platform/src/signals/agent-chat.ts
@@ -123,20 +123,43 @@ export interface ChatThread {
   selectedModel: string | null;
 }
 
-export const chatThreads$ = computed(async (get) => {
-  get(reloadChatThreadsCounter$);
+function createChatThreadsByAgentIdFactory() {
+  const cache = new Map<string, ReturnType<typeof createChatThreadsForAgent>>();
 
+  return (agentId: string) => {
+    const existing = cache.get(agentId);
+    if (existing) {
+      return existing;
+    }
+
+    const atom$ = createChatThreadsForAgent(agentId);
+    cache.set(agentId, atom$);
+    return atom$;
+  };
+}
+
+function createChatThreadsForAgent(agentId: string) {
+  return computed(async (get): Promise<ChatThreadListItem[]> => {
+    get(reloadChatThreadsCounter$);
+
+    const client = get(zeroClient$)(chatThreadsContract);
+    const result = await accept(
+      client.list({ query: { agentId: agentId } }),
+      [200],
+    );
+    return result.body.threads;
+  });
+}
+
+const chatThreadsByAgentId = createChatThreadsByAgentIdFactory();
+
+export const chatThreads$ = computed(async (get) => {
   const agentId = await get(currentChatAgentId$);
   if (!agentId) {
     return [];
   }
 
-  const client = get(zeroClient$)(chatThreadsContract);
-  const result = await accept(
-    client.list({ query: { agentId: agentId } }),
-    [200],
-  );
-  return result.body.threads;
+  return await get(chatThreadsByAgentId(agentId));
 });
 
 /**

--- a/turbo/apps/platform/src/signals/chat-page/__tests__/idb-cached-chat-thread-data-source.btest.ts
+++ b/turbo/apps/platform/src/signals/chat-page/__tests__/idb-cached-chat-thread-data-source.btest.ts
@@ -5,10 +5,18 @@ import {
   clearMockedAuth,
 } from "../../../__tests__/mock-auth.ts";
 import { testContext } from "../../__tests__/test-helpers.ts";
+import { createMockApi } from "../../../mocks/msw-contract.ts";
+import { worker } from "../../../mocks/browser.ts";
 import { createIdbCachedDataSource } from "../idb-cached-chat-thread-data-source.ts";
 import { createIdbMessageStores } from "../../external/idb-message-store.ts";
-import { patchThreadMeta$ } from "../../external/idb-thread-meta-store.ts";
-import type { PagedChatMessage } from "@vm0/api-contracts/contracts/chat-threads";
+import {
+  patchThreadMeta$,
+  readThreadMeta$,
+} from "../../external/idb-thread-meta-store.ts";
+import {
+  chatThreadMessagesContract,
+  type PagedChatMessage,
+} from "@vm0/api-contracts/contracts/chat-threads";
 
 function makeMsg(id: string, createdAt: string): PagedChatMessage {
   return {
@@ -31,6 +39,7 @@ function setupAuth() {
 }
 
 const context = testContext();
+const mockApi = createMockApi(context);
 
 describe("createIdbCachedDataSource initialPage cache-hit + thread meta", () => {
   it("cache hit defers history state when startMessageId is unknown", async () => {
@@ -124,5 +133,34 @@ describe("createIdbCachedDataSource listMessagesBefore cache-hit + thread meta",
         return m.id;
       }),
     ).toStrictEqual(["first"]);
+  });
+});
+
+describe("createIdbCachedDataSource listMessagesAfter bootstrap + thread meta", () => {
+  it("persists the start boundary when the bootstrap page has no older history", async () => {
+    setupAuth();
+    const threadId = `thread-after-bootstrap-${Date.now()}`;
+
+    worker.use(
+      mockApi(chatThreadMessagesContract.list, ({ respond }) => {
+        return respond(200, {
+          messages: [
+            makeMsg("boot-start", "2026-10-01T00:00:00Z"),
+            makeMsg("boot-latest", "2026-10-02T00:00:00Z"),
+          ],
+          hasHistoryBefore: false,
+        });
+      }),
+    );
+
+    const ds = createIdbCachedDataSource(threadId);
+    await context.store.set(
+      ds.listMessagesAfter$,
+      { threadId, sinceId: undefined },
+      context.signal,
+    );
+
+    const meta = await readThreadMeta$(USER_ID, ORG_ID, threadId);
+    expect(meta?.startMessageId).toBe("boot-start");
   });
 });

--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-data-source.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-data-source.ts
@@ -86,7 +86,11 @@ export interface ChatThreadDataSource {
     [RecallMessageArgs, AbortSignal]
   >;
   listMessagesAfter$: Command<
-    Promise<{ messages: PagedChatMessage[]; reachedEnd: boolean }>,
+    Promise<{
+      messages: PagedChatMessage[];
+      reachedEnd: boolean;
+      hasHistoryBefore?: boolean;
+    }>,
     [ListMessagesAfterArgs, AbortSignal]
   >;
   listMessagesBefore$: Command<

--- a/turbo/apps/platform/src/signals/chat-page/idb-cached-chat-thread-data-source.ts
+++ b/turbo/apps/platform/src/signals/chat-page/idb-cached-chat-thread-data-source.ts
@@ -140,6 +140,16 @@ function createListMessagesAfter(
           sinceId,
           count: result.messages.length,
         });
+        const firstMessage = result.messages[0];
+        if (
+          sinceId === undefined &&
+          result.hasHistoryBefore === false &&
+          firstMessage
+        ) {
+          await patchThreadMeta$(userId, orgId, tid, {
+            startMessageId: firstMessage.id,
+          });
+        }
       } else {
         L.debug("listAfter:skipCache", {
           threadId: tid,

--- a/turbo/apps/platform/src/signals/chat-page/remote-chat-thread-data-source.ts
+++ b/turbo/apps/platform/src/signals/chat-page/remote-chat-thread-data-source.ts
@@ -150,6 +150,7 @@ const listMessagesAfter$ = command(
     return {
       messages: result.body.messages,
       reachedEnd: result.body.messages.length < 50,
+      hasHistoryBefore: result.body.hasHistoryBefore,
     };
   },
 );
@@ -229,6 +230,55 @@ const markRead$ = command(
   },
 );
 
+function createThreadDataAtom(threadId: string) {
+  const reloadCounter$ = state(0);
+  const thread$ = computed(async (get): Promise<ChatThread | null> => {
+    get(reloadCounter$);
+    const threadClient = get(zeroClient$)(chatThreadByIdContract);
+    const threadResult = await accept(
+      threadClient.get({ params: { id: threadId } }),
+      [200, 404],
+      { toast: false },
+    );
+    if (threadResult.status === 404) {
+      return null;
+    }
+    const body = threadResult.body;
+    return {
+      id: threadId,
+      title: body.title ?? null,
+      agentId: body.agentId,
+      latestSessionId: body.latestSessionId ?? null,
+      lastReadMessageId: body.lastReadMessageId ?? null,
+      latestSessionProviderType: body.latestSessionProviderType ?? null,
+      activeRunIds: body.activeRunIds,
+      activeRuns: body.activeRuns ?? [],
+      isLegacySession: false,
+      draftContent: body.draftContent ?? null,
+      draftAttachments: body.draftAttachments ?? null,
+      modelProviderId: body.modelProviderId ?? null,
+      selectedModel: body.selectedModel ?? null,
+    };
+  });
+
+  return { reloadCounter$, thread$ };
+}
+
+function createThreadDataAtomFactory() {
+  const cache = new Map<string, ReturnType<typeof createThreadDataAtom>>();
+  return (threadId: string) => {
+    const existing = cache.get(threadId);
+    if (existing) {
+      return existing;
+    }
+    const atom = createThreadDataAtom(threadId);
+    cache.set(threadId, atom);
+    return atom;
+  };
+}
+
+const threadDataAtomById = createThreadDataAtomFactory();
+
 const subscribeRealtime$ = command(
   async (
     { set },
@@ -262,36 +312,7 @@ const subscribeRealtime$ = command(
 export function createRemoteChatThreadDataSource(
   threadId: string,
 ): ChatThreadDataSource {
-  const reloadCounter$ = state(0);
-
-  const getThread$ = computed(async (get): Promise<ChatThread | null> => {
-    get(reloadCounter$);
-    const threadClient = get(zeroClient$)(chatThreadByIdContract);
-    const threadResult = await accept(
-      threadClient.get({ params: { id: threadId } }),
-      [200, 404],
-      { toast: false },
-    );
-    if (threadResult.status === 404) {
-      return null;
-    }
-    const body = threadResult.body;
-    return {
-      id: threadId,
-      title: body.title ?? null,
-      agentId: body.agentId,
-      latestSessionId: body.latestSessionId ?? null,
-      lastReadMessageId: body.lastReadMessageId ?? null,
-      latestSessionProviderType: body.latestSessionProviderType ?? null,
-      activeRunIds: body.activeRunIds,
-      activeRuns: body.activeRuns ?? [],
-      isLegacySession: false,
-      draftContent: body.draftContent ?? null,
-      draftAttachments: body.draftAttachments ?? null,
-      modelProviderId: body.modelProviderId ?? null,
-      selectedModel: body.selectedModel ?? null,
-    };
-  });
+  const { reloadCounter$, thread$: getThread$ } = threadDataAtomById(threadId);
 
   const reloadThread$ = command(({ set }) => {
     set(reloadCounter$, (v) => {


### PR DESCRIPTION
## Summary
- Share remote thread detail atoms per thread so concurrent chat setup paths reuse the same `/api/zero/chat-threads/:id` request.
- Persist the IDB start boundary only when a no-cursor bootstrap message page explicitly reports `hasHistoryBefore=false`, avoiding a later empty `beforeId` backfill on refreshed message threads.
- Reuse stable per-agent thread-list atoms so sidebar consumers share the same list request instead of creating independent fetchers.
- Keep run realtime message refresh behavior conservative: `runCreated/runUpdated` still performs the original no-cursor latest-page refresh.

## Validation
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`
- `pnpm -F @vm0/app exec vitest run src/signals/chat-page/__tests__/pre-subscribe-catchup.test.ts src/signals/chat-page/__tests__/idb-cached-chat-thread-data-source.test.ts src/views/zero-page/__tests__/zero-chat-page.test.tsx src/signals/zero-page/__tests__/zero-added-connectors.test.ts src/signals/zero-page/__tests__/zero-connectors.test.ts src/signals/__tests__/agent.test.ts src/views/zero-page/__tests__/chat-realtime-catchup.test.tsx src/views/zero-page/__tests__/chat-title-refresh.test.tsx`
- `pnpm -F @vm0/app btest -- src/signals/chat-page/__tests__/idb-cached-chat-thread-data-source.btest.ts`
- pre-commit: `pnpm knip --cache` and repo `pnpm check-types` via lefthook