### PR TITLE
fix: specify neon database role in connection strings

### DIFF
--- a/.github/actions/neon-branch/action.yml
+++ b/.github/actions/neon-branch/action.yml
@@ -19,6 +19,10 @@ inputs:
     description: "Database name for connection string"
     required: false
     default: "neondb"
+  role-name:
+    description: "Database role name for connection string"
+    required: false
+    default: "neondb_owner"
   github-token:
     description: "GitHub token for deployment tracking"
     required: false
@@ -64,6 +68,7 @@ runs:
         NEON_PROJECT_ID: ${{ inputs.neon-project-id }}
         INPUT_BRANCH_NAME: ${{ inputs.branch-name }}
         INPUT_DATABASE_NAME: ${{ inputs.database-name }}
+        INPUT_ROLE_NAME: ${{ inputs.role-name }}
       run: |
         BRANCH_NAME="preview/$INPUT_BRANCH_NAME"
 
@@ -92,11 +97,11 @@ runs:
           exit 1
         fi
 
-        DATABASE_URL=$(neonctl connection-string "$BRANCH_NAME" --project-id "$NEON_PROJECT_ID" --database-name "$INPUT_DATABASE_NAME" --pooled)
+        DATABASE_URL=$(neonctl connection-string "$BRANCH_NAME" --project-id "$NEON_PROJECT_ID" --database-name "$INPUT_DATABASE_NAME" --role-name "$INPUT_ROLE_NAME" --pooled)
         if [ -z "$DATABASE_URL" ]; then
           echo "Error: Failed to get database URL from neonctl"
           echo "Attempting without --pooled flag..."
-          DATABASE_URL=$(neonctl connection-string "$BRANCH_NAME" --project-id "$NEON_PROJECT_ID" --database-name "$INPUT_DATABASE_NAME")
+          DATABASE_URL=$(neonctl connection-string "$BRANCH_NAME" --project-id "$NEON_PROJECT_ID" --database-name "$INPUT_DATABASE_NAME" --role-name "$INPUT_ROLE_NAME")
         fi
         echo "DATABASE_URL value: $DATABASE_URL"
         echo "database-url=$DATABASE_URL" >> $GITHUB_OUTPUT

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -156,7 +156,7 @@ jobs:
           CLERK_PUBLISHABLE_KEY: ${{ vars.CLERK_PUBLISHABLE_KEY }}
         run: |
           echo "Getting pooled database URL for smoke branch $BRANCH_NAME"
-          DATABASE_URL=$(neonctl connection-string "$BRANCH_NAME" --project-id "$NEON_PROJECT_ID" --database-name neondb --pooled)
+          DATABASE_URL=$(neonctl connection-string "$BRANCH_NAME" --project-id "$NEON_PROJECT_ID" --database-name neondb --role-name neondb_owner --pooled)
 
           echo "Running production migration smoke test on $BRANCH_NAME"
           cd turbo
@@ -185,7 +185,7 @@ jobs:
         id: get-db-url
         run: |
           # Get the production branch database URL.
-          DATABASE_URL=$(neonctl connection-string production --project-id ${{ vars.NEON_PROJECT_ID }} --database-name neondb --pooled)
+          DATABASE_URL=$(neonctl connection-string production --project-id ${{ vars.NEON_PROJECT_ID }} --database-name neondb --role-name neondb_owner --pooled)
           echo "database-url=$DATABASE_URL" >> "$GITHUB_OUTPUT"
         env:
           NEON_API_KEY: ${{ secrets.NEON_API_KEY }}
@@ -317,7 +317,7 @@ jobs:
         id: get-db-url
         run: |
           # Get the main branch database URL (production)
-          DATABASE_URL=$(neonctl connection-string production --project-id ${{ vars.NEON_PROJECT_ID }} --database-name neondb --pooled)
+          DATABASE_URL=$(neonctl connection-string production --project-id ${{ vars.NEON_PROJECT_ID }} --database-name neondb --role-name neondb_owner --pooled)
           echo "database-url=$DATABASE_URL" >> "$GITHUB_OUTPUT"
         env:
           NEON_API_KEY: ${{ secrets.NEON_API_KEY }}
@@ -436,7 +436,7 @@ jobs:
       - name: Get Production Database URL
         id: get-db-url
         run: |
-          DATABASE_URL=$(neonctl connection-string production --project-id ${{ vars.NEON_PROJECT_ID }} --database-name neondb --pooled)
+          DATABASE_URL=$(neonctl connection-string production --project-id ${{ vars.NEON_PROJECT_ID }} --database-name neondb --role-name neondb_owner --pooled)
           echo "database-url=$DATABASE_URL" >> "$GITHUB_OUTPUT"
         env:
           NEON_API_KEY: ${{ secrets.NEON_API_KEY }}

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -787,9 +787,9 @@ jobs:
               neonctl branches create --name "$BRANCH_NAME" --project-id "$NEON_PROJECT_ID"
             fi
 
-            DATABASE_URL=$(neonctl connection-string "$BRANCH_NAME" --project-id "$NEON_PROJECT_ID" --database-name neondb --pooled)
+            DATABASE_URL=$(neonctl connection-string "$BRANCH_NAME" --project-id "$NEON_PROJECT_ID" --database-name neondb --role-name neondb_owner --pooled)
             if [ -z "$DATABASE_URL" ]; then
-              DATABASE_URL=$(neonctl connection-string "$BRANCH_NAME" --project-id "$NEON_PROJECT_ID" --database-name neondb)
+              DATABASE_URL=$(neonctl connection-string "$BRANCH_NAME" --project-id "$NEON_PROJECT_ID" --database-name neondb --role-name neondb_owner)
             fi
             echo "$DATABASE_URL" > /tmp/neon-database-url
 


### PR DESCRIPTION
## Summary
- add `--role-name neondb_owner` to every `neonctl connection-string` call in CI/release workflows
- add a default `role-name` input to the reusable Neon branch action and pass it through pooled and non-pooled URL lookup paths

## Validation
- `rg -n "neonctl connection-string(?!.*--role-name)" .github -P` returned no matches
- YAML parse check for updated action/workflow files
- `npx -y prettier@3.6.2 --check .github/actions/neon-branch/action.yml .github/workflows/turbo.yml .github/workflows/release-please.yml`
- `npx -y neonctl@2.15.0 connection-string --help` confirms `--role-name` support
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/turbo.yml .github/workflows/release-please.yml`