### PR TITLE
feat: support custom connector host wildcards

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-custom-connectors-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-custom-connectors-create.test.ts
@@ -106,6 +106,22 @@ describe("POST /api/zero/custom-connectors", () => {
     ]);
   });
 
+  it("accepts a host wildcard prefix and stores the user-facing value", async () => {
+    const { userId, orgId } = uniqueOrg("zcc-wildcard");
+    mocks.clerk.session(userId, orgId, "org:admin");
+
+    const client = setupApp({ context })(zeroCustomConnectorsContract);
+    const response = await accept(
+      client.create({
+        body: { ...validBody(), prefixes: ["https://*.example.com/v1"] },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [201],
+    );
+    expect(response.body.slug).toMatch(/^example-com-/);
+    expect(response.body.prefixes).toStrictEqual(["https://*.example.com/v1/"]);
+  });
+
   it("rejects missing {{secret}} placeholder with 400", async () => {
     const { userId, orgId } = uniqueOrg("zcc-bad-template");
     mocks.clerk.session(userId, orgId, "org:admin");

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-runs-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-runs-create.test.ts
@@ -1202,7 +1202,7 @@ describe("POST /api/zero/runs", () => {
       orgId: fx.orgId,
       slug: "internal-api",
       displayName: "Internal API",
-      prefixes: ["https://internal.example.com/api/"],
+      prefixes: ["https://*.internal.example.com/api/"],
       headerName: "Authorization",
       headerTemplate: "Bearer {{secret}}",
       createdBy: fx.userId,
@@ -1237,6 +1237,7 @@ describe("POST /api/zero/runs", () => {
       readonly firewalls: readonly {
         readonly name: string;
         readonly apis: readonly {
+          readonly base: string;
           readonly auth?: { readonly headers?: Record<string, string> };
         }[];
       }[];
@@ -1248,6 +1249,9 @@ describe("POST /api/zero/runs", () => {
     const firewall = executionContext.firewalls.find((candidate) => {
       return candidate.name === "internal-api";
     });
+    expect(firewall?.apis[0]?.base).toBe(
+      "https://{hostWildcard1}.internal.example.com/api/",
+    );
     expect(firewall?.apis[0]?.auth?.headers?.Authorization).toBe(
       `Bearer \${{ secrets.${secretKey} }}`,
     );

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -37,6 +37,7 @@ import {
 } from "@vm0/connectors/firewalls";
 import { PROVIDER_HANDLERS } from "@vm0/connectors/oauth-providers";
 import {
+  expandHostWildcardsInBaseUrl,
   resolveFirewallBaseUrlVars,
   type ExpandedFirewallConfig,
   type FirewallPolicies,
@@ -1500,7 +1501,7 @@ async function loadCustomConnectorContext(
       description: row.displayName,
       apis: row.prefixes.map((prefix) => {
         return {
-          base: prefix,
+          base: expandHostWildcardsInBaseUrl(prefix),
           auth: {
             headers: {
               [row.headerName]: row.headerTemplate.replaceAll(

--- a/turbo/apps/api/src/signals/services/zero-custom-connector.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-custom-connector.service.ts
@@ -5,6 +5,10 @@ import {
   getAllBuiltinConnectorHosts,
   getBuiltinConnectorDisplayName,
 } from "@vm0/connectors/firewalls";
+import {
+  expandHostWildcardsInBaseUrl,
+  validateBaseUrl,
+} from "@vm0/connectors/firewall-types";
 import { orgCustomConnectors } from "@vm0/db/schema/org-custom-connector";
 import { orgCustomConnectorSecrets } from "@vm0/db/schema/org-custom-connector-secret";
 
@@ -76,7 +80,18 @@ function normalizePrefix(raw: string): string | BadRequestResponse {
   const pathname = url.pathname.endsWith("/")
     ? url.pathname
     : `${url.pathname}/`;
-  return `${url.origin}${pathname}`;
+  const normalized = `${url.origin}${pathname}`;
+  const firewallBase = expandHostWildcardsInBaseUrl(normalized);
+  try {
+    validateBaseUrl(firewallBase, "custom connector");
+  } catch (error) {
+    const message =
+      error instanceof Error
+        ? error.message.replace(firewallBase, normalized)
+        : "not a valid URL";
+    return badRequestMessage(`Invalid prefix URL: ${raw}: ${message}`);
+  }
+  return normalized;
 }
 
 function hostSlugFromPrefix(prefix: string): string {

--- a/turbo/apps/api/src/signals/services/zero-custom-connector.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-custom-connector.service.ts
@@ -15,7 +15,7 @@ import { orgCustomConnectorSecrets } from "@vm0/db/schema/org-custom-connector-s
 import { db$, writeDb$ } from "../external/db";
 import { badRequestMessage, notFound } from "../../lib/error";
 import { logger } from "../../lib/log";
-import { safeUrlParse } from "../utils";
+import { safeSync, safeUrlParse } from "../utils";
 
 const L = logger("CustomConnectorService");
 
@@ -82,12 +82,13 @@ function normalizePrefix(raw: string): string | BadRequestResponse {
     : `${url.pathname}/`;
   const normalized = `${url.origin}${pathname}`;
   const firewallBase = expandHostWildcardsInBaseUrl(normalized);
-  try {
+  const validation = safeSync(() => {
     validateBaseUrl(firewallBase, "custom connector");
-  } catch (error) {
+  });
+  if ("error" in validation) {
     const message =
-      error instanceof Error
-        ? error.message.replace(firewallBase, normalized)
+      validation.error instanceof Error
+        ? validation.error.message.replace(firewallBase, normalized)
         : "not a valid URL";
     return badRequestMessage(`Invalid prefix URL: ${raw}: ${message}`);
   }

--- a/turbo/apps/api/src/signals/utils.ts
+++ b/turbo/apps/api/src/signals/utils.ts
@@ -52,6 +52,18 @@ export function safeUrlParse(input: string): URL | undefined {
   }
 }
 
+export function safeSync<T>(
+  fn: () => T,
+): { readonly ok: T } | { readonly error: unknown } {
+  // eslint-disable-next-line no-restricted-syntax -- centralized guarded sync
+  try {
+    return { ok: fn() };
+  } catch (error) {
+    throwIfAbort(error);
+    return { error };
+  }
+}
+
 export function isValidTimeZone(input: string): boolean {
   // eslint-disable-next-line no-restricted-syntax -- centralized guarded Intl timezone validation
   try {

--- a/turbo/apps/web/app/api/zero/custom-connectors/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/custom-connectors/__tests__/route.test.ts
@@ -170,6 +170,19 @@ describe("POST /api/zero/custom-connectors", () => {
     expect(data.prefixes).toEqual(["https://api.example.com/v1/"]);
   });
 
+  it("accepts a host wildcard prefix and stores the user-facing value", async () => {
+    const userId = uniqueId("zcc-wildcard");
+    await setupAdminOrg(userId);
+
+    const res = await createSampleConnector({
+      prefixes: ["https://*.example.com/v1"],
+    });
+    expect(res.status).toBe(201);
+    const data = await res.json();
+    expect(data.slug).toMatch(/^example-com-/);
+    expect(data.prefixes).toEqual(["https://*.example.com/v1/"]);
+  });
+
   it("rejects non-admin members", async () => {
     const userId = uniqueId("zcc-member");
     await setupMemberOrg(userId);

--- a/turbo/apps/web/src/lib/zero/custom-connector/custom-connector-service.ts
+++ b/turbo/apps/web/src/lib/zero/custom-connector/custom-connector-service.ts
@@ -3,6 +3,10 @@ import {
   getAllBuiltinConnectorHosts,
   getBuiltinConnectorDisplayName,
 } from "@vm0/connectors/firewalls";
+import {
+  expandHostWildcardsInBaseUrl,
+  validateBaseUrl,
+} from "@vm0/connectors/firewall-types";
 import { orgCustomConnectors } from "@vm0/db/schema/org-custom-connector";
 import { orgCustomConnectorSecrets } from "@vm0/db/schema/org-custom-connector-secret";
 import { encryptSecretValue } from "../../shared/crypto";
@@ -63,7 +67,18 @@ function normalizePrefix(raw: string): string {
   const pathname = url.pathname.endsWith("/")
     ? url.pathname
     : `${url.pathname}/`;
-  return `${url.origin}${pathname}`;
+  const normalized = `${url.origin}${pathname}`;
+  const firewallBase = expandHostWildcardsInBaseUrl(normalized);
+  try {
+    validateBaseUrl(firewallBase, "custom connector");
+  } catch (error) {
+    const message =
+      error instanceof Error
+        ? error.message.replace(firewallBase, normalized)
+        : "not a valid URL";
+    throw badRequest(`Invalid prefix URL: ${raw}: ${message}`);
+  }
+  return normalized;
 }
 
 function hostSlugFromPrefix(prefix: string): string {

--- a/turbo/apps/web/src/lib/zero/custom-connector/resolve-custom-connectors.ts
+++ b/turbo/apps/web/src/lib/zero/custom-connector/resolve-custom-connectors.ts
@@ -1,5 +1,8 @@
 import { eq, and, inArray } from "drizzle-orm";
-import type { ExpandedFirewallConfig } from "@vm0/connectors/firewall-types";
+import {
+  expandHostWildcardsInBaseUrl,
+  type ExpandedFirewallConfig,
+} from "@vm0/connectors/firewall-types";
 import { orgCustomConnectors } from "@vm0/db/schema/org-custom-connector";
 import { orgCustomConnectorSecrets } from "@vm0/db/schema/org-custom-connector-secret";
 import { decryptSecretValue } from "../../shared/crypto";
@@ -91,7 +94,7 @@ export async function resolveCustomConnectorFirewalls(
       description: row.displayName,
       apis: prefixes.map((prefix) => {
         return {
-          base: prefix,
+          base: expandHostWildcardsInBaseUrl(prefix),
           auth: {
             headers: { [row.headerName]: resolvedTemplate },
           },

--- a/turbo/packages/api-contracts/src/contracts/zero-custom-connectors.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-custom-connectors.ts
@@ -27,9 +27,24 @@ export const customConnectorListResponseSchema = z.object({
   connectors: z.array(customConnectorResponseSchema),
 });
 
+const customConnectorPrefixSchema = z
+  .string()
+  .min(1)
+  .refine(
+    (value) => {
+      try {
+        new URL(value);
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    { message: "Invalid URL" },
+  );
+
 export const createCustomConnectorBodySchema = z.object({
   displayName: z.string().min(1).max(128),
-  prefixes: z.array(z.string().url()).min(1),
+  prefixes: z.array(customConnectorPrefixSchema).min(1),
   headerName: z.string().min(1).max(128),
   headerTemplate: z.string().min(1),
   slug: z.string().optional(),

--- a/turbo/packages/connectors/src/__tests__/firewall-expander.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewall-expander.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import {
+  expandHostWildcardsInBaseUrl,
   validateBaseUrl,
   hasBaseUrlParams,
   hasBaseUrlVars,
@@ -597,6 +598,28 @@ describe("validateBaseUrl", () => {
     expect(() => {
       return validateBaseUrl("https://api.example.com/v1-{version}", "fw");
     }).not.toThrow();
+  });
+});
+
+describe("expandHostWildcardsInBaseUrl", () => {
+  it("converts custom connector host wildcards to parameterized host segments", () => {
+    const expanded = expandHostWildcardsInBaseUrl("https://*.example.com/v1/");
+    expect(expanded).toBe("https://{hostWildcard1}.example.com/v1/");
+    expect(() => {
+      return validateBaseUrl(expanded, "fw");
+    }).not.toThrow();
+  });
+
+  it("converts each host wildcard into one host segment parameter", () => {
+    expect(expandHostWildcardsInBaseUrl("https://*.*.example.com/")).toBe(
+      "https://{hostWildcard1}.{hostWildcard2}.example.com/",
+    );
+  });
+
+  it("converts mixed-label host wildcards and leaves path wildcards literal", () => {
+    expect(
+      expandHostWildcardsInBaseUrl("https://api-*.example.com/files/*/"),
+    ).toBe("https://api-{hostWildcard1}.example.com/files/*/");
   });
 });
 

--- a/turbo/packages/connectors/src/firewall-types.ts
+++ b/turbo/packages/connectors/src/firewall-types.ts
@@ -300,6 +300,57 @@ export function hasBaseUrlParams(base: string): boolean {
   return stripped.includes("{") && stripped.includes("}");
 }
 
+const HOST_WILDCARD_PARAM_PREFIX = "hostWildcard";
+
+/**
+ * Convert user-facing `*` wildcards in a URL host into the existing
+ * parameterized host grammar understood by the firewall matcher.
+ *
+ * Examples:
+ *   - https://*.example.com/ -> https://{hostWildcard1}.example.com/
+ *   - https://api-*.example.com/ -> https://api-{hostWildcard1}.example.com/
+ *   - https://*.*.example.com/ -> https://{hostWildcard1}.{hostWildcard2}.example.com/
+ *
+ * Each `*` is a single host-label wildcard. Only the host is transformed.
+ * Path `*` characters remain literal.
+ */
+export function expandHostWildcardsInBaseUrl(base: string): string {
+  let url: URL;
+  try {
+    url = new URL(base);
+  } catch {
+    return base;
+  }
+
+  if (!url.hostname.includes("*")) {
+    return base;
+  }
+
+  let paramIndex = 0;
+  const host = url.hostname
+    .split(".")
+    .map((segment) => {
+      if (!segment.includes("*")) {
+        return segment;
+      }
+      let expanded = "";
+      for (let i = 0; i < segment.length; i++) {
+        const ch = segment[i]!;
+        if (ch === "*") {
+          paramIndex += 1;
+          expanded += `{${HOST_WILDCARD_PARAM_PREFIX}${paramIndex}}`;
+        } else {
+          expanded += ch;
+        }
+      }
+      return expanded;
+    })
+    .join(".");
+
+  const authority = url.port ? `${host}:${url.port}` : host;
+  return `${url.protocol}//${authority}${url.pathname}${url.search}${url.hash}`;
+}
+
 function errMsg(base: string, svc: string, detail: string): string {
   return `Invalid base URL "${base}" in firewall "${svc}": ${detail}`;
 }


### PR DESCRIPTION
## Summary
- support single-label `*` wildcards in custom connector hostnames while preserving the stored/displayed prefix
- expand wildcard hosts into existing parameterized firewall bases at run time
- keep path `*` characters literal; use `*.*.example.com` when matching two subdomain labels

## Verification
- `corepack pnpm exec vitest --run src/__tests__/firewall-expander.test.ts` (packages/connectors)
- `corepack pnpm -F @vm0/connectors lint`
- `corepack pnpm -F @vm0/connectors check-types`
- `corepack pnpm -F @vm0/api-contracts check-types`
- `NODE_OPTIONS=--max-old-space-size=8192 corepack pnpm -F api check-types`
- `NODE_OPTIONS=--max-old-space-size=8192 corepack pnpm -F web check-types`

Note: API/web DB-backed route tests were attempted earlier but require local Postgres; this environment returned `ECONNREFUSED 127.0.0.1:5432`.
