### PR TITLE
fix: align chat rename dialog input with shared Input primitive

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
+++ b/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
@@ -24,6 +24,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
   Button,
+  Input,
   RunningIndicator,
   DropdownMenu,
   DropdownMenuTrigger,
@@ -541,7 +542,7 @@ function ChatThreadRenameDialog() {
           </DialogDescription>
         </DialogHeader>
         <div className="py-2">
-          <input
+          <Input
             type="text"
             autoFocus
             value={renameDialogInput}
@@ -554,7 +555,6 @@ function ChatThreadRenameDialog() {
               }
             }}
             placeholder="Chat title"
-            className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           />
         </div>
         <DialogFooter>


### PR DESCRIPTION
## Summary

- The `ChatThreadRenameDialog` in `sidebar-threads.tsx` used a raw `<input>` with hand-rolled Tailwind (`rounded-md border-input bg-background shadow-sm focus-visible:ring-2 focus-visible:ring-ring`), which looked inconsistent with every other rename/edit dialog in the app.
- Swap it for the shared `Input` primitive from `@vm0/ui`, matching:
  - `CustomConnectorRenameDialog` (custom connector rename)
  - `ZeroSettingsTab` Name field (agent rename)
  - `AgentListDialog` search box
- After: standard `rounded-lg`, `border-[0.7px]` gray border, `bg-input` background, and primary-color focus ring.

## Test plan

- [ ] Open the chat sidebar → kebab menu → "Rename chat" → confirm the input matches the other rename dialogs visually (radius, border weight, focus ring).
- [ ] Typing + Enter still submits the rename.
- [ ] Cancel still closes without renaming.
- [ ] `sidebar-threads-rename.test.tsx` passes (placeholder `Chat title` and native input dispatch still work since `Input` is a `forwardRef` over native `<input>`).