### PR TITLE
feat: add local-agent Claude args

### DIFF
--- a/turbo/apps/cli/src/commands/zero/local-agent/__tests__/local-agent.test.ts
+++ b/turbo/apps/cli/src/commands/zero/local-agent/__tests__/local-agent.test.ts
@@ -21,6 +21,15 @@ describe("local-agent command registration", () => {
     expect(subNames).not.toContain("connect");
     expect(subNames).not.toContain("host");
     expect(subNames).not.toContain("kill");
+
+    const start = localAgent!.commands.find((command) => {
+      return command.name() === "start";
+    });
+    expect(
+      start?.options.some((option) => {
+        return option.long === "--claude-arg";
+      }),
+    ).toBe(true);
   });
 
   it("registers list and run under zero", () => {

--- a/turbo/apps/cli/src/commands/zero/local-agent/host.ts
+++ b/turbo/apps/cli/src/commands/zero/local-agent/host.ts
@@ -42,6 +42,7 @@ interface HostStartOptions {
   name?: string;
   workdir?: string;
   backend?: string;
+  claudeArg?: string[];
   permissionMode?: string;
   hostId?: string;
   new?: boolean;
@@ -679,6 +680,7 @@ async function runHostLoop(params: {
   hostToken: string;
   hostName: string;
   supportedBackends: LocalAgentBackend[];
+  claudeArgs: string[];
   permissionMode: LocalAgentPermissionMode;
   workdir: string;
 }): Promise<void> {
@@ -769,6 +771,7 @@ async function runHostLoop(params: {
         backend: nextJob.job.backend,
         prompt: nextJob.job.prompt,
         workdir: params.workdir,
+        claudeArgs: params.claudeArgs,
         permissionMode: params.permissionMode,
       });
 
@@ -798,6 +801,14 @@ export const startCommand = new Command()
   .option("--name <name>", "New host name, or a closed host name to reactivate")
   .option("--workdir <path>", "Working directory for Codex/Claude jobs")
   .option("--backend <backend>", "codex or claude-code for a new host")
+  .option(
+    "--claude-arg <arg>",
+    "Additional argument to pass to Claude Code jobs",
+    (value: string, previous: string[]) => {
+      return [...previous, value];
+    },
+    [] as string[],
+  )
   .option("--permission-mode <mode>", "Permission mode for Codex/Claude jobs")
   .option(
     "--host-id <id>",
@@ -808,6 +819,7 @@ export const startCommand = new Command()
     withErrorHandler(async (options: HostStartOptions) => {
       const requestedHostName = options.name?.trim();
       const workdir = options.workdir?.trim() || process.cwd();
+      const claudeArgs = options.claudeArg ?? [];
       const savedHost = await getLocalAgentHost();
       const selection = await chooseHostForStart({
         requestedHostName,
@@ -835,6 +847,9 @@ export const startCommand = new Command()
             requestedBackend: options.backend,
           })
         : await chooseBackend(probes, options.backend);
+      if (claudeArgs.length > 0 && selectedBackend !== "claude-code") {
+        throw new Error("--claude-arg can only be used with Claude Code jobs");
+      }
       const permissionMode = selection.restoredHost
         ? chooseRestoredPermissionMode({
             backend: selectedBackend,
@@ -882,6 +897,7 @@ export const startCommand = new Command()
         hostToken: started.hostToken,
         hostName: selection.hostName,
         supportedBackends,
+        claudeArgs,
         permissionMode,
         workdir,
       });

--- a/turbo/apps/cli/src/lib/local-agent/__tests__/backends.test.ts
+++ b/turbo/apps/cli/src/lib/local-agent/__tests__/backends.test.ts
@@ -1,0 +1,82 @@
+import { EventEmitter } from "events";
+import { PassThrough } from "stream";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { executeLocalAgentBackend } from "../backends";
+
+const safeSpawnMock = vi.hoisted(() => {
+  return vi.fn();
+});
+
+vi.mock("../../utils/spawn", () => {
+  return {
+    safeSpawn: safeSpawnMock,
+  };
+});
+
+interface SpawnCall {
+  command: string;
+  args: string[];
+}
+
+const spawnCalls: SpawnCall[] = [];
+
+function mockSuccessfulSpawn(): void {
+  safeSpawnMock.mockImplementation((command: string, args: string[]) => {
+    spawnCalls.push({ command, args });
+
+    const child = new EventEmitter() as EventEmitter & {
+      stdout: PassThrough;
+      stderr: PassThrough;
+    };
+    child.stdout = new PassThrough();
+    child.stderr = new PassThrough();
+
+    queueMicrotask(() => {
+      child.emit("close", 0);
+    });
+
+    return child;
+  });
+}
+
+describe("local-agent backends", () => {
+  beforeEach(() => {
+    spawnCalls.length = 0;
+    safeSpawnMock.mockReset();
+    mockSuccessfulSpawn();
+  });
+
+  it("passes extra Claude args through to Claude Code jobs", async () => {
+    await executeLocalAgentBackend({
+      backend: "claude-code",
+      prompt: "summarize this",
+      workdir: "/tmp",
+      permissionMode: "default",
+      claudeArgs: ["--chrome", "--model=sonnet"],
+    });
+
+    expect(spawnCalls).toEqual([
+      {
+        command: "claude",
+        args: ["-p", "--chrome", "--model=sonnet", "summarize this"],
+      },
+    ]);
+  });
+
+  it("does not pass Claude args to Codex jobs", async () => {
+    await executeLocalAgentBackend({
+      backend: "codex",
+      prompt: "summarize this",
+      workdir: "/tmp",
+      permissionMode: "default",
+      claudeArgs: ["--chrome"],
+    });
+
+    expect(spawnCalls).toEqual([
+      {
+        command: "codex",
+        args: ["exec", "summarize this"],
+      },
+    ]);
+  });
+});

--- a/turbo/apps/cli/src/lib/local-agent/backends.ts
+++ b/turbo/apps/cli/src/lib/local-agent/backends.ts
@@ -137,11 +137,17 @@ function executionCommand(
   backend: LocalAgentBackend,
   prompt: string,
   permissionMode: LocalAgentPermissionMode,
+  claudeArgs: readonly string[] = [],
 ): { command: string; args: string[] } {
   if (backend === "claude-code") {
     return {
       command: "claude",
-      args: ["-p", ...claudePermissionArgs(permissionMode), prompt],
+      args: [
+        "-p",
+        ...claudePermissionArgs(permissionMode),
+        ...claudeArgs,
+        prompt,
+      ],
     };
   }
   return {
@@ -162,12 +168,14 @@ export async function executeLocalAgentBackend(params: {
   backend: LocalAgentBackend;
   prompt: string;
   workdir: string;
+  claudeArgs?: readonly string[];
   permissionMode: LocalAgentPermissionMode;
 }): Promise<LocalAgentExecutionResult> {
   const { command, args } = executionCommand(
     params.backend,
     params.prompt,
     params.permissionMode,
+    params.claudeArgs,
   );
 
   return new Promise((resolve) => {


### PR DESCRIPTION
## Summary
- Add repeatable `--claude-arg <arg>` to `vm0 local-agent start`.
- Pass those args only into Claude Code job execution before the prompt.
- Reject `--claude-arg` when the selected local-agent backend is not Claude Code.

## Validation
- `corepack pnpm exec vitest run src/lib/local-agent/__tests__/backends.test.ts src/commands/zero/local-agent/__tests__/local-agent.test.ts`
- `corepack pnpm -F @vm0/cli check-types`
- `corepack pnpm -F @vm0/cli lint`
