### PR TITLE
chore: update rootfs package versions

### DIFF
--- a/crates/runner/scripts/build-template.sh
+++ b/crates/runner/scripts/build-template.sh
@@ -111,7 +111,7 @@ CACHE_TMP_TAR=""
 
 # Pinned versions (changes here invalidate the template cache via script hash)
 GO_VERSION="1.26.3"
-CLAUDE_CODE_VERSION="2.1.142"
+CLAUDE_CODE_VERSION="2.1.143"
 CODEX_CLI_VERSION="0.130.0"
 GWS_CLI_VERSION="0.22.5"
 XURL_VERSION="1.0.3"


### PR DESCRIPTION
## Updates

- Claude Code CLI: 2.1.142 -> 2.1.143

## Notes

Checked pinned versions in the rootfs template script. Other pinned versions were already current:
- Go: 1.26.3
- OpenAI Codex CLI: 0.130.0
- Google Workspace CLI: 0.22.5
- xurl: 1.0.3
- agent-browser: 0.27.0

The requested path `crates/runner/scripts/build-rootfs.sh` no longer exists on latest main; the rootfs pins are currently in `crates/runner/scripts/build-template.sh`.