### PR TITLE
docs(guest-agent): document CLI module boundaries

### DIFF
--- a/crates/guest-agent/src/cli/command.rs
+++ b/crates/guest-agent/src/cli/command.rs
@@ -1,3 +1,9 @@
+//! CLI command construction for Claude Code and Codex.
+//!
+//! This module owns framework-specific argv shape, mock binary selection, and
+//! Codex config override construction. Runtime process spawning stays in
+//! `execute_cli`.
+
 use crate::env;
 use crate::error::AgentError;
 use guest_common::log_info;

--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -1,4 +1,19 @@
-//! CLI command building and execution for Claude Code / Codex.
+//! Public facade for CLI setup and execution.
+//!
+//! This module keeps the external `guest_agent::cli` boundary stable while
+//! private submodules own focused execution policies:
+//!
+//! - `codex_setup`: pre-exec Codex auth/bootstrap.
+//! - `command`: Claude Code and Codex command construction.
+//! - `diagnostics`: bounded stderr tail collection.
+//! - `event_delivery`: event sender watermark state.
+//! - `framework`: Claude-vs-Codex behavior switches.
+//! - `termination`: process-group termination FSM.
+//!
+//! `execute_cli` intentionally remains the orchestration owner for process
+//! spawn, stdout JSONL reading, event sender shutdown, heartbeat races, and
+//! child reaping. Branch ordering and deadline reset timing in that control
+//! flow are part of the runtime contract.
 
 mod codex_setup;
 mod command;


### PR DESCRIPTION
## Summary
- Document the `guest_agent::cli` public facade and the focused private `cli/` submodules created by the extraction series.
- Clarify that `execute_cli` remains the orchestration owner for process spawn, stdout JSONL reading, event sender shutdown, heartbeat races, and child reaping.
- Add module docs for command construction ownership.

Closes #13382

## Verification
- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `git diff --check`
- `CARGO_BUILD_JOBS=1 CARGO_INCREMENTAL=0 cargo test --manifest-path crates/Cargo.toml --target-dir /tmp/vm4-guest-agent-13382-docs-target -p guest-agent`
- `CARGO_BUILD_JOBS=1 CARGO_INCREMENTAL=0 cargo clippy --manifest-path crates/Cargo.toml --target-dir /tmp/vm4-guest-agent-13382-docs-target -p guest-agent --all-targets -- -D warnings`
- `CARGO_BUILD_JOBS=1 cargo clippy --all-targets --all-features` from `crates/`
- `CARGO_BUILD_JOBS=1 cargo doc --workspace --all-features --no-deps` from `crates/`