### PR TITLE
fix: replace oauth state on api-token connector connect

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-api-token-connect.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-api-token-connect.test.ts
@@ -1,0 +1,375 @@
+import { randomUUID } from "node:crypto";
+
+import {
+  zeroConnectorApiTokenContract,
+  zeroConnectorsByTypeContract,
+  zeroConnectorsMainContract,
+} from "@vm0/api-contracts/contracts/zero-connectors";
+import { connectorCliAuthSessions } from "@vm0/db/schema/connector-cli-auth-session";
+import { connectors } from "@vm0/db/schema/connector";
+import { secrets } from "@vm0/db/schema/secret";
+import { userFeatureSwitches } from "@vm0/db/schema/user-feature-switches";
+import { variables } from "@vm0/db/schema/variable";
+import { createStore } from "ccstate";
+import { and, eq, inArray } from "drizzle-orm";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { nowDate } from "../../../lib/time";
+import { writeDb$ } from "../../external/db";
+import { decryptSecretValue } from "../../services/crypto.utils";
+import {
+  deleteOrgMembership$,
+  seedOrgMembership$,
+  type OrgMembershipFixture,
+} from "./helpers/zero-org-membership";
+import {
+  createFixtureTracker,
+  createZeroRouteMocks,
+} from "./helpers/zero-route-test";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+
+async function cleanupOrgData(fixture: OrgMembershipFixture): Promise<void> {
+  const writeDb = store.set(writeDb$);
+  await writeDb
+    .delete(connectorCliAuthSessions)
+    .where(eq(connectorCliAuthSessions.orgId, fixture.orgId));
+  await writeDb.delete(connectors).where(eq(connectors.orgId, fixture.orgId));
+  await writeDb.delete(secrets).where(eq(secrets.orgId, fixture.orgId));
+  await writeDb.delete(variables).where(eq(variables.orgId, fixture.orgId));
+  await writeDb
+    .delete(userFeatureSwitches)
+    .where(eq(userFeatureSwitches.orgId, fixture.orgId));
+  await store.set(deleteOrgMembership$, fixture, context.signal);
+}
+
+function seedFixture(): Promise<OrgMembershipFixture> {
+  const orgId = `org_${randomUUID()}`;
+  const userId = `user_${randomUUID()}`;
+  return store.set(seedOrgMembership$, { orgId, userId }, context.signal);
+}
+
+function client() {
+  return setupApp({ context })(zeroConnectorApiTokenContract);
+}
+
+function listClient() {
+  return setupApp({ context })(zeroConnectorsMainContract);
+}
+
+function byTypeClient() {
+  return setupApp({ context })(zeroConnectorsByTypeContract);
+}
+
+async function userSecretValue(
+  fixture: OrgMembershipFixture,
+  name: string,
+): Promise<string | null> {
+  const [row] = await store
+    .set(writeDb$)
+    .select({ encryptedValue: secrets.encryptedValue })
+    .from(secrets)
+    .where(
+      and(
+        eq(secrets.orgId, fixture.orgId),
+        eq(secrets.userId, fixture.userId),
+        eq(secrets.name, name),
+        eq(secrets.type, "user"),
+      ),
+    )
+    .limit(1);
+  return row ? decryptSecretValue(row.encryptedValue) : null;
+}
+
+async function variableValue(
+  fixture: OrgMembershipFixture,
+  name: string,
+): Promise<string | null> {
+  const [row] = await store
+    .set(writeDb$)
+    .select({ value: variables.value })
+    .from(variables)
+    .where(
+      and(
+        eq(variables.orgId, fixture.orgId),
+        eq(variables.userId, fixture.userId),
+        eq(variables.name, name),
+      ),
+    )
+    .limit(1);
+  return row?.value ?? null;
+}
+
+describe("POST /api/zero/connectors/:type/api-token", () => {
+  const track = createFixtureTracker<OrgMembershipFixture>(cleanupOrgData);
+
+  it("connects a first-time API-token connector and splits secrets from variables", async () => {
+    const fixture = await track(seedFixture());
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      client().connect({
+        params: { type: "strapi" },
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          values: {
+            STRAPI_TOKEN: " strapi\n token ",
+            STRAPI_BASE_URL: " https://strapi.example.com\n",
+          },
+        },
+      }),
+      [200],
+    );
+
+    expect(response.body).toMatchObject({
+      id: null,
+      type: "strapi",
+      authMethod: "api-token",
+    });
+    await expect(userSecretValue(fixture, "STRAPI_TOKEN")).resolves.toBe(
+      "strapitoken",
+    );
+    await expect(variableValue(fixture, "STRAPI_BASE_URL")).resolves.toBe(
+      "https://strapi.example.com",
+    );
+  });
+
+  it("replaces an existing OAuth connector row and connector-scoped secrets", async () => {
+    const fixture = await track(seedFixture());
+    const writeDb = store.set(writeDb$);
+    await writeDb.insert(connectors).values({
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      type: "stripe",
+      authMethod: "oauth",
+      externalId: "acct_existing",
+      oauthScopes: JSON.stringify(["read_write"]),
+    });
+    await writeDb.insert(secrets).values([
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        name: "STRIPE_ACCESS_TOKEN",
+        encryptedValue: "encrypted-access",
+        type: "connector",
+      },
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        name: "STRIPE_REFRESH_TOKEN",
+        encryptedValue: "encrypted-refresh",
+        type: "connector",
+      },
+    ]);
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    await accept(
+      client().connect({
+        params: { type: "stripe" },
+        headers: { authorization: "Bearer clerk-session" },
+        body: { values: { STRIPE_TOKEN: "sk_test_replacement" } },
+      }),
+      [200],
+    );
+
+    const [connectorRows, connectorSecretRows, listResponse] =
+      await Promise.all([
+        writeDb
+          .select({ id: connectors.id })
+          .from(connectors)
+          .where(
+            and(
+              eq(connectors.orgId, fixture.orgId),
+              eq(connectors.userId, fixture.userId),
+              eq(connectors.type, "stripe"),
+            ),
+          ),
+        writeDb
+          .select({ id: secrets.id })
+          .from(secrets)
+          .where(
+            and(
+              eq(secrets.orgId, fixture.orgId),
+              eq(secrets.userId, fixture.userId),
+              eq(secrets.type, "connector"),
+              inArray(secrets.name, [
+                "STRIPE_ACCESS_TOKEN",
+                "STRIPE_REFRESH_TOKEN",
+              ]),
+            ),
+          ),
+        accept(
+          listClient().list({
+            headers: { authorization: "Bearer clerk-session" },
+          }),
+          [200],
+        ),
+      ]);
+
+    expect(connectorRows).toStrictEqual([]);
+    expect(connectorSecretRows).toStrictEqual([]);
+    await expect(userSecretValue(fixture, "STRIPE_TOKEN")).resolves.toBe(
+      "sk_test_replacement",
+    );
+    expect(
+      listResponse.body.connectors.find((connector) => {
+        return connector.type === "stripe";
+      }),
+    ).toMatchObject({ type: "stripe", authMethod: "api-token" });
+  });
+
+  it("deletes omitted optional API-token fields during replacement", async () => {
+    const fixture = await track(seedFixture());
+    const writeDb = store.set(writeDb$);
+    await writeDb.insert(secrets).values({
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      name: "AGORA_APP_CERTIFICATE",
+      encryptedValue: "encrypted-optional",
+      type: "user",
+    });
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    await accept(
+      client().connect({
+        params: { type: "agora" },
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          values: {
+            AGORA_CUSTOMER_ID: "customer",
+            AGORA_CUSTOMER_SECRET: "secret",
+            AGORA_APP_ID: "app",
+          },
+        },
+      }),
+      [200],
+    );
+
+    await expect(
+      userSecretValue(fixture, "AGORA_APP_CERTIFICATE"),
+    ).resolves.toBeNull();
+    await expect(userSecretValue(fixture, "AGORA_CUSTOMER_ID")).resolves.toBe(
+      "customer",
+    );
+    await expect(variableValue(fixture, "AGORA_APP_ID")).resolves.toBe("app");
+
+    const connector = await accept(
+      byTypeClient().get({
+        params: { type: "agora" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+    expect(connector.body).toMatchObject({
+      type: "agora",
+      authMethod: "api-token",
+    });
+  });
+
+  it("invalidates active Stripe CLI auth sessions", async () => {
+    const fixture = await track(seedFixture());
+    const writeDb = store.set(writeDb$);
+    await writeDb.insert(connectorCliAuthSessions).values({
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      connectorType: "stripe",
+      source: "stripe-cli",
+      status: "awaiting_user_approval",
+      approvalUrl: "https://dashboard.stripe.com/confirm",
+      verificationCode: "code",
+      expiresAt: new Date(nowDate().getTime() + 60_000),
+    });
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    await accept(
+      client().connect({
+        params: { type: "stripe" },
+        headers: { authorization: "Bearer clerk-session" },
+        body: { values: { STRIPE_TOKEN: "sk_test_replacement" } },
+      }),
+      [200],
+    );
+
+    const [session] = await writeDb
+      .select({
+        status: connectorCliAuthSessions.status,
+        errorMessage: connectorCliAuthSessions.errorMessage,
+        approvalUrl: connectorCliAuthSessions.approvalUrl,
+        verificationCode: connectorCliAuthSessions.verificationCode,
+      })
+      .from(connectorCliAuthSessions)
+      .where(
+        and(
+          eq(connectorCliAuthSessions.orgId, fixture.orgId),
+          eq(connectorCliAuthSessions.userId, fixture.userId),
+        ),
+      );
+
+    expect(session).toMatchObject({
+      status: "cancelled",
+      errorMessage:
+        "CLI auth for Stripe session was cancelled because Stripe credentials changed",
+      approvalUrl: null,
+      verificationCode: null,
+    });
+  });
+
+  it("rejects invalid API-token submissions without echoing values", async () => {
+    const fixture = await track(seedFixture());
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const missingRequired = await accept(
+      client().connect({
+        params: { type: "strapi" },
+        headers: { authorization: "Bearer clerk-session" },
+        body: { values: { STRAPI_BASE_URL: "https://strapi.example.com" } },
+      }),
+      [400],
+    );
+    const unknown = await accept(
+      client().connect({
+        params: { type: "strapi" },
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          values: {
+            STRAPI_TOKEN: "secret-token-value",
+            STRAPI_BASE_URL: "https://strapi.example.com",
+            EXTRA_TOKEN: "secret-extra-value",
+          },
+        },
+      }),
+      [400],
+    );
+    const unsupported = await accept(
+      client().connect({
+        params: { type: "github" },
+        headers: { authorization: "Bearer clerk-session" },
+        body: { values: { GITHUB_ACCESS_TOKEN: "ghp_secret" } },
+      }),
+      [400],
+    );
+    const disabled = await accept(
+      client().connect({
+        params: { type: "bentoml" },
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          values: {
+            BENTO_CLOUD_API_KEY: "secret-bento",
+            BENTO_CLOUD_API_ENDPOINT: "https://example.bentoml.cloud",
+          },
+        },
+      }),
+      [403],
+    );
+
+    expect(missingRequired.body.error.message).toContain("STRAPI_TOKEN");
+    expect(unknown.body.error.message).toContain("EXTRA_TOKEN");
+    expect(unknown.body.error.message).not.toContain("secret-extra-value");
+    expect(unsupported.body.error.message).toContain(
+      "does not support API-token auth",
+    );
+    expect(disabled.body.error.code).toBe("FORBIDDEN");
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/zero-connectors.ts
@@ -4,6 +4,7 @@ import { command, computed } from "ccstate";
 import type { AppRoute } from "@ts-rest/core";
 import {
   zeroComputerConnectorContract,
+  zeroConnectorApiTokenContract,
   zeroConnectorAuthorizeContract,
   zeroConnectorSessionsContract,
   zeroConnectorSessionByIdContract,
@@ -37,13 +38,14 @@ import {
 } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
 import { request$ } from "../context/hono";
-import { pathParamsOf, queryOf } from "../context/request";
+import { bodyResultOf, pathParamsOf, queryOf } from "../context/request";
 import { badRequestMessage, conflict, notFound } from "../../lib/error";
 import { env, optionalEnv } from "../../lib/env";
 import { nowDate } from "../../lib/time";
 import { writeDb$ } from "../external/db";
 import {
   deleteComputerConnector$,
+  connectApiTokenConnector$,
   deleteZeroConnectorLocalState$,
   zeroConnectorByType,
   zeroConnectorList,
@@ -423,6 +425,52 @@ const deleteConnectorByTypeInner$ = command(
   },
 );
 
+const connectApiTokenConnectorInner$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const auth = get(organizationAuthContext$);
+    const params = get(pathParamsOf(zeroConnectorApiTokenContract.connect));
+    const bodyResult = await get(
+      bodyResultOf(zeroConnectorApiTokenContract.connect),
+    );
+    signal.throwIfAborted();
+    if (!bodyResult.ok) {
+      return bodyResult.response;
+    }
+
+    const result = await set(
+      connectApiTokenConnector$,
+      {
+        orgId: auth.orgId,
+        userId: auth.userId,
+        type: params.type,
+        values: bodyResult.data.values,
+      },
+      signal,
+    );
+    signal.throwIfAborted();
+
+    switch (result.status) {
+      case "connected": {
+        return { status: 200 as const, body: result.connector };
+      }
+      case "bad_request": {
+        return badRequestMessage(result.message);
+      }
+      case "forbidden": {
+        return {
+          status: 403 as const,
+          body: {
+            error: {
+              message: result.message,
+              code: "FORBIDDEN" as const,
+            },
+          },
+        };
+      }
+    }
+  },
+);
+
 const getScopeDiffInner$ = computed(async (get) => {
   const auth = get(organizationAuthContext$);
   const params = get(pathParamsOf(zeroConnectorScopeDiffContract.getScopeDiff));
@@ -772,5 +820,9 @@ export const zeroConnectorsRoutes: readonly RouteEntry[] = [
   {
     route: zeroConnectorsByTypeContract.delete,
     handler: authRoute(connectorWriteAuth, deleteConnectorByTypeInner$),
+  },
+  {
+    route: zeroConnectorApiTokenContract.connect,
+    handler: authRoute(connectorWriteAuth, connectApiTokenConnectorInner$),
   },
 ];

--- a/turbo/apps/api/src/signals/services/cli-auth-invalidation.service.ts
+++ b/turbo/apps/api/src/signals/services/cli-auth-invalidation.service.ts
@@ -1,7 +1,12 @@
 import type { ConnectorType } from "@vm0/connectors/connectors";
 
 import type { Db } from "../external/db";
-import { invalidateActiveCliAuthStripeSessions } from "./cli-auth-stripe.service";
+import type { SandboxHandle } from "../external/sandbox";
+import {
+  cancelActiveCliAuthStripeSessionsForCredentialsChange,
+  cleanupInvalidatedCliAuthStripeSandboxes,
+  invalidateActiveCliAuthStripeSessions,
+} from "./cli-auth-stripe.service";
 
 type CliAuthInvalidationArgs = {
   readonly writeDb: Db;
@@ -23,6 +28,11 @@ const cliAuthInvalidatorsByConnectorType = Object.freeze<
 >({
   stripe: Object.freeze([invalidateActiveCliAuthStripeSessions]),
 });
+
+type PreparedCliAuthSessionInvalidation = {
+  readonly type: "stripe";
+  readonly sandboxes: readonly SandboxHandle[];
+};
 
 async function runCliAuthInvalidators(
   invalidators: readonly CliAuthInvalidator[],
@@ -60,4 +70,38 @@ export async function invalidateActiveCliAuthSessionsForConnectorType(
     cliAuthInvalidatorsByConnectorType[args.connectorType] ?? [],
     args,
   );
+}
+
+export async function prepareActiveCliAuthSessionInvalidationsForConnectorType(
+  args: CliAuthInvalidationArgs & { readonly connectorType: ConnectorType },
+): Promise<readonly PreparedCliAuthSessionInvalidation[]> {
+  if (args.connectorType !== "stripe") {
+    return [];
+  }
+
+  const sandboxes = await cancelActiveCliAuthStripeSessionsForCredentialsChange(
+    {
+      db: args.writeDb,
+      orgId: args.orgId,
+      userId: args.userId,
+    },
+  );
+  args.signal.throwIfAborted();
+  if (sandboxes.length === 0) {
+    return [];
+  }
+  return [{ type: "stripe", sandboxes }];
+}
+
+export async function cleanupPreparedCliAuthSessionInvalidations(
+  invalidations: readonly PreparedCliAuthSessionInvalidation[],
+) {
+  for (const invalidation of invalidations) {
+    switch (invalidation.type) {
+      case "stripe": {
+        await cleanupInvalidatedCliAuthStripeSandboxes(invalidation.sandboxes);
+        break;
+      }
+    }
+  }
 }

--- a/turbo/apps/api/src/signals/services/cli-auth-stripe.service.ts
+++ b/turbo/apps/api/src/signals/services/cli-auth-stripe.service.ts
@@ -469,6 +469,38 @@ async function cancelActiveCliAuthStripeSessions(args: {
   );
 }
 
+export async function cancelActiveCliAuthStripeSessionsForCredentialsChange(args: {
+  readonly db: Db;
+  readonly orgId: string;
+  readonly userId: string;
+  readonly message?: string;
+}): Promise<readonly SandboxHandle[]> {
+  const now = nowDate();
+  await lockCliAuthStripeOwner({
+    db: args.db,
+    orgId: args.orgId,
+    userId: args.userId,
+  });
+  return cancelActiveCliAuthStripeSessions({
+    db: args.db,
+    orgId: args.orgId,
+    userId: args.userId,
+    now,
+    message: args.message ?? CLI_AUTH_STRIPE_CREDENTIALS_CHANGED_MESSAGE,
+  });
+}
+
+export async function cleanupInvalidatedCliAuthStripeSandboxes(
+  sandboxes: readonly SandboxHandle[],
+) {
+  const client = getVercelSandboxClient();
+  await cleanupCliAuthStripeSandboxes({
+    client,
+    sandboxes,
+    reason: "stripe credentials changed",
+  });
+}
+
 export async function invalidateActiveCliAuthStripeSessions(args: {
   readonly writeDb: Db;
   readonly orgId: string;
@@ -476,27 +508,15 @@ export async function invalidateActiveCliAuthStripeSessions(args: {
   readonly signal: AbortSignal;
   readonly message?: string;
 }) {
-  const client = getVercelSandboxClient();
-  const now = nowDate();
-  const sandboxes = await args.writeDb.transaction(async (tx) => {
-    await lockCliAuthStripeOwner({
+  const sandboxes = await args.writeDb.transaction((tx) => {
+    return cancelActiveCliAuthStripeSessionsForCredentialsChange({
       db: tx,
       orgId: args.orgId,
       userId: args.userId,
-    });
-    return cancelActiveCliAuthStripeSessions({
-      db: tx,
-      orgId: args.orgId,
-      userId: args.userId,
-      now,
-      message: args.message ?? CLI_AUTH_STRIPE_CREDENTIALS_CHANGED_MESSAGE,
+      message: args.message,
     });
   });
-  await cleanupCliAuthStripeSandboxes({
-    client,
-    sandboxes,
-    reason: "stripe credentials changed",
-  });
+  await cleanupInvalidatedCliAuthStripeSandboxes(sandboxes);
   args.signal.throwIfAborted();
 }
 

--- a/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
@@ -20,6 +20,7 @@ import {
   CONNECTOR_TYPES,
   connectorTypeSchema,
   type ConnectorAuthMethodType,
+  type ConnectorSecretConfig,
   type ConnectorType,
 } from "@vm0/connectors/connectors";
 import { getAllFeatureStates } from "@vm0/core/feature-switch";
@@ -42,7 +43,11 @@ import {
 import { publishUserSignal } from "../external/realtime";
 import { decryptSecretValue, encryptSecretValue } from "./crypto.utils";
 import { userFeatureSwitchOverrides } from "./feature-switches.service";
-import { invalidateActiveCliAuthSessionsForConnectorType } from "./cli-auth-invalidation.service";
+import {
+  cleanupPreparedCliAuthSessionInvalidations,
+  invalidateActiveCliAuthSessionsForConnectorType,
+  prepareActiveCliAuthSessionInvalidationsForConnectorType,
+} from "./cli-auth-invalidation.service";
 
 type StoredConnectorRow = {
   readonly id: string;
@@ -72,6 +77,27 @@ interface ExternalUserInfo {
   readonly email: string | null;
 }
 
+type ApiTokenFieldSet = {
+  readonly secrets: readonly string[];
+  readonly variables: readonly string[];
+};
+
+type PreparedApiTokenFieldValue = {
+  readonly name: string;
+  readonly value: string;
+  readonly storage: "secret" | "variable";
+};
+
+type ConnectApiTokenConnectorResult =
+  | {
+      readonly status: "connected";
+      readonly connector: ConnectorResponse;
+    }
+  | {
+      readonly status: "bad_request" | "forbidden";
+      readonly message: string;
+    };
+
 function parseOauthScopes(value: string | null): string[] | null {
   return value ? oauthScopesSchema.parse(JSON.parse(value)) : null;
 }
@@ -81,6 +107,115 @@ function getSecretNameForConnector(type: ConnectorType): string {
     return COMPUTER_CONNECTOR_AUTH_TOKEN_SECRET;
   }
   return PROVIDER_HANDLERS[type].getSecretName();
+}
+
+function getApiTokenFieldConfig(
+  type: ConnectorType,
+): Record<string, ConnectorSecretConfig> | null {
+  return CONNECTOR_TYPES[type].authMethods["api-token"]?.secrets ?? null;
+}
+
+function getApiTokenConfiguredFieldsByType(
+  type: ConnectorType,
+): ApiTokenFieldSet | null {
+  const fieldConfig = getApiTokenFieldConfig(type);
+  if (!fieldConfig) {
+    return null;
+  }
+
+  const secretNames: string[] = [];
+  const variableNames: string[] = [];
+  for (const [name, config] of Object.entries(fieldConfig)) {
+    if (config.type === "variable") {
+      variableNames.push(name);
+    } else {
+      secretNames.push(name);
+    }
+  }
+
+  return {
+    secrets: secretNames,
+    variables: variableNames,
+  };
+}
+
+function sanitizeApiTokenValue(value: string): string {
+  return value.replace(/\s+/g, "");
+}
+
+function prepareApiTokenFieldValues(args: {
+  readonly type: ConnectorType;
+  readonly values: Record<string, string>;
+}):
+  | {
+      readonly ok: true;
+      readonly values: readonly PreparedApiTokenFieldValue[];
+    }
+  | { readonly ok: false; readonly message: string } {
+  const fieldConfig = getApiTokenFieldConfig(args.type);
+  if (!fieldConfig) {
+    return {
+      ok: false,
+      message: `${args.type} connector does not support API-token auth`,
+    };
+  }
+
+  const fieldNames = new Set(Object.keys(fieldConfig));
+  const unknownField = Object.keys(args.values).find((name) => {
+    return !fieldNames.has(name);
+  });
+  if (unknownField) {
+    return {
+      ok: false,
+      message: `Unknown API-token field: ${unknownField}`,
+    };
+  }
+
+  const prepared = new Map<string, PreparedApiTokenFieldValue>();
+  for (const [name, rawValue] of Object.entries(args.values)) {
+    const value = sanitizeApiTokenValue(rawValue);
+    if (!value) {
+      continue;
+    }
+    const config = fieldConfig[name];
+    if (!config) {
+      continue;
+    }
+    prepared.set(name, {
+      name,
+      value,
+      storage: config.type === "variable" ? "variable" : "secret",
+    });
+  }
+
+  const missingRequiredField = Object.entries(fieldConfig).find(
+    ([name, config]) => {
+      return config.required && !prepared.has(name);
+    },
+  );
+  if (missingRequiredField) {
+    return {
+      ok: false,
+      message: `Missing required API-token field: ${missingRequiredField[0]}`,
+    };
+  }
+
+  return { ok: true, values: [...prepared.values()] };
+}
+
+function apiTokenConnectorResponse(type: ConnectorType): ConnectorResponse {
+  return {
+    id: null,
+    type,
+    authMethod: "api-token",
+    externalId: null,
+    externalUsername: null,
+    externalEmail: null,
+    oauthScopes: null,
+    needsReconnect: false,
+    createdAt: "1970-01-01T00:00:00.000Z",
+    updatedAt: "1970-01-01T00:00:00.000Z",
+  };
 }
 
 function storedConnectorRowToResponse(
@@ -218,18 +353,7 @@ export function zeroConnectorList(args: {
         return isConnectorAuthMethodAvailable(type, "api-token", featureStates);
       })
       .map((type) => {
-        return {
-          id: null,
-          type,
-          authMethod: "api-token",
-          externalId: null,
-          externalUsername: null,
-          externalEmail: null,
-          oauthScopes: null,
-          needsReconnect: false,
-          createdAt: "1970-01-01T00:00:00.000Z",
-          updatedAt: "1970-01-01T00:00:00.000Z",
-        };
+        return apiTokenConnectorResponse(type);
       });
 
     const connectorList = [...dbConnectors, ...derivedConnectors];
@@ -350,18 +474,7 @@ function apiTokenConnectorByType(args: {
     }
 
     // Use a fixed timestamp — this connector is inferred, not explicitly created.
-    return {
-      id: null,
-      type: args.type,
-      authMethod: "api-token",
-      externalId: null,
-      externalUsername: null,
-      externalEmail: null,
-      oauthScopes: null,
-      needsReconnect: false,
-      createdAt: "1970-01-01T00:00:00.000Z",
-      updatedAt: "1970-01-01T00:00:00.000Z",
-    };
+    return apiTokenConnectorResponse(args.type);
   });
 }
 
@@ -529,6 +642,45 @@ async function revokeExistingConnectorToken(args: {
   args.signal.throwIfAborted();
 }
 
+async function readExistingConnectorTokenForRevocation(args: {
+  readonly db: Db;
+  readonly orgId: string;
+  readonly userId: string;
+  readonly type: ConnectorType;
+  readonly signal: AbortSignal;
+}): Promise<{
+  readonly type: ConnectorType;
+  readonly accessToken: string;
+} | null> {
+  const accessTokenName = revocableConnectorAccessTokenName(args.type);
+  if (!accessTokenName) {
+    return null;
+  }
+
+  const [accessTokenSecret] = await args.db
+    .select({ encryptedValue: secrets.encryptedValue })
+    .from(secrets)
+    .where(
+      and(
+        eq(secrets.orgId, args.orgId),
+        eq(secrets.userId, args.userId),
+        eq(secrets.name, accessTokenName),
+        eq(secrets.type, "connector"),
+      ),
+    )
+    .limit(1);
+  args.signal.throwIfAborted();
+
+  if (!accessTokenSecret?.encryptedValue) {
+    return null;
+  }
+
+  return {
+    type: args.type,
+    accessToken: decryptSecretValue(accessTokenSecret.encryptedValue),
+  };
+}
+
 async function hasApiTokenConnectorLocalState(args: {
   readonly db: Db;
   readonly orgId: string;
@@ -658,7 +810,7 @@ export const deleteZeroConnectorLocalState$ = command(
       .limit(1);
     signal.throwIfAborted();
 
-    const fields = getApiTokenFieldsByType(args.type);
+    const fields = getApiTokenConfiguredFieldsByType(args.type);
     const hasApiTokenState = existing
       ? false
       : await hasApiTokenConnectorLocalState({
@@ -736,6 +888,236 @@ export const deleteZeroConnectorLocalState$ = command(
   },
 );
 
+async function upsertUserSecret(
+  db: Db,
+  args: {
+    readonly orgId: string;
+    readonly userId: string;
+    readonly name: string;
+    readonly value: string;
+  },
+): Promise<void> {
+  const encryptedValue = encryptSecretValue(args.value);
+  await db
+    .insert(secrets)
+    .values({
+      orgId: args.orgId,
+      userId: args.userId,
+      name: args.name,
+      encryptedValue,
+      type: "user",
+      description: null,
+    })
+    .onConflictDoUpdate({
+      target: [secrets.orgId, secrets.userId, secrets.name, secrets.type],
+      set: {
+        encryptedValue,
+        description: null,
+        updatedAt: nowDate(),
+      },
+    });
+}
+
+async function upsertUserVariable(
+  db: Db,
+  args: {
+    readonly orgId: string;
+    readonly userId: string;
+    readonly name: string;
+    readonly value: string;
+  },
+): Promise<void> {
+  await db
+    .insert(variables)
+    .values({
+      orgId: args.orgId,
+      userId: args.userId,
+      name: args.name,
+      value: args.value,
+      description: null,
+    })
+    .onConflictDoUpdate({
+      target: [variables.orgId, variables.userId, variables.name],
+      set: {
+        value: args.value,
+        description: null,
+        updatedAt: nowDate(),
+      },
+    });
+}
+
+async function deleteStoredConnectorLocalState(args: {
+  readonly db: Db;
+  readonly orgId: string;
+  readonly userId: string;
+  readonly type: ConnectorType;
+  readonly existing: {
+    readonly id: string;
+    readonly authMethod: string;
+  } | null;
+  readonly signal: AbortSignal;
+}): Promise<void> {
+  if (!args.existing) {
+    return;
+  }
+
+  await args.db.delete(connectors).where(eq(connectors.id, args.existing.id));
+  args.signal.throwIfAborted();
+
+  const config = CONNECTOR_TYPES[args.type];
+  const authMethodConfig =
+    config.authMethods[args.existing.authMethod as ConnectorAuthMethodType];
+  const secretNames = authMethodConfig
+    ? Object.keys(authMethodConfig.secrets)
+    : [];
+
+  for (const name of secretNames) {
+    await args.db
+      .delete(secrets)
+      .where(
+        and(
+          eq(secrets.orgId, args.orgId),
+          eq(secrets.userId, args.userId),
+          eq(secrets.name, name),
+          eq(secrets.type, "connector"),
+        ),
+      );
+    args.signal.throwIfAborted();
+  }
+}
+
+export const connectApiTokenConnector$ = command(
+  async (
+    { get, set },
+    args: {
+      readonly orgId: string;
+      readonly userId: string;
+      readonly type: ConnectorType;
+      readonly values: Record<string, string>;
+    },
+    signal: AbortSignal,
+  ): Promise<ConnectApiTokenConnectorResult> => {
+    const prepared = prepareApiTokenFieldValues({
+      type: args.type,
+      values: args.values,
+    });
+    if (!prepared.ok) {
+      return { status: "bad_request", message: prepared.message };
+    }
+
+    const overrides = await get(
+      userFeatureSwitchOverrides(args.orgId, args.userId),
+    );
+    signal.throwIfAborted();
+    const featureStates = getAllFeatureStates({
+      userId: args.userId,
+      orgId: args.orgId,
+      overrides,
+    });
+    if (
+      !isConnectorAuthMethodAvailable(args.type, "api-token", featureStates)
+    ) {
+      return {
+        status: "forbidden",
+        message: `${args.type} API-token auth is not enabled`,
+      };
+    }
+
+    const writeDb = set(writeDb$);
+    const revocation = await readExistingConnectorTokenForRevocation({
+      db: writeDb,
+      orgId: args.orgId,
+      userId: args.userId,
+      type: args.type,
+      signal,
+    });
+    signal.throwIfAborted();
+
+    const apiTokenFields = getApiTokenConfiguredFieldsByType(args.type);
+    const cliAuthInvalidations = await writeDb.transaction(async (tx) => {
+      const [existing] = await tx
+        .select({ id: connectors.id, authMethod: connectors.authMethod })
+        .from(connectors)
+        .where(
+          and(
+            eq(connectors.orgId, args.orgId),
+            eq(connectors.userId, args.userId),
+            eq(connectors.type, args.type),
+          ),
+        )
+        .limit(1);
+      signal.throwIfAborted();
+
+      const invalidations =
+        await prepareActiveCliAuthSessionInvalidationsForConnectorType({
+          writeDb: tx,
+          orgId: args.orgId,
+          userId: args.userId,
+          connectorType: args.type,
+          signal,
+        });
+      signal.throwIfAborted();
+
+      await deleteStoredConnectorLocalState({
+        db: tx,
+        orgId: args.orgId,
+        userId: args.userId,
+        type: args.type,
+        existing: existing ?? null,
+        signal,
+      });
+
+      await deleteApiTokenConnectorLocalState({
+        db: tx,
+        orgId: args.orgId,
+        userId: args.userId,
+        fields: apiTokenFields,
+        signal,
+      });
+
+      for (const field of prepared.values) {
+        if (field.storage === "variable") {
+          await upsertUserVariable(tx, {
+            orgId: args.orgId,
+            userId: args.userId,
+            name: field.name,
+            value: field.value,
+          });
+        } else {
+          await upsertUserSecret(tx, {
+            orgId: args.orgId,
+            userId: args.userId,
+            name: field.name,
+            value: field.value,
+          });
+        }
+        signal.throwIfAborted();
+      }
+
+      return invalidations;
+    });
+    signal.throwIfAborted();
+
+    await cleanupPreparedCliAuthSessionInvalidations(cliAuthInvalidations);
+    signal.throwIfAborted();
+
+    if (revocation) {
+      await revokeConnectorToken(revocation).catch(() => {
+        return undefined;
+      });
+      signal.throwIfAborted();
+    }
+
+    await publishUserSignal([args.userId], "connector:changed");
+    signal.throwIfAborted();
+
+    return {
+      status: "connected",
+      connector: apiTokenConnectorResponse(args.type),
+    };
+  },
+);
+
 async function upsertConnectorSecret(
   db: Db,
   args: {
@@ -807,7 +1189,7 @@ export const upsertOAuthConnector$ = command(
       type: args.type,
       expiresIn: args.expiresIn,
     });
-    const apiTokenFields = getApiTokenFieldsByType(args.type);
+    const apiTokenFields = getApiTokenConfiguredFieldsByType(args.type);
 
     await invalidateActiveCliAuthSessionsForConnectorType({
       writeDb,

--- a/turbo/apps/platform/src/mocks/handlers/api-connectors.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-connectors.ts
@@ -4,6 +4,7 @@ import {
 } from "@vm0/connectors/connectors";
 import type { ConnectorResponse } from "@vm0/api-contracts/contracts/connector-schemas";
 import {
+  zeroConnectorApiTokenContract,
   zeroConnectorsByTypeContract,
   zeroConnectorScopeDiffContract,
   zeroConnectorsMainContract,
@@ -56,6 +57,24 @@ export const apiConnectorsHandlers = [
       return c.type !== type;
     });
     return respond(204);
+  }),
+
+  mockApi(zeroConnectorApiTokenContract.connect, ({ params, respond }) => {
+    const now = "1970-01-01T00:00:00.000Z";
+    const connector: ConnectorResponse = {
+      id: null,
+      type: params.type,
+      authMethod: "api-token",
+      externalId: null,
+      externalUsername: null,
+      externalEmail: null,
+      oauthScopes: null,
+      needsReconnect: false,
+      createdAt: now,
+      updatedAt: now,
+    };
+    upsertMockConnector(connector);
+    return respond(200, connector);
   }),
 
   mockApi(zeroConnectorScopeDiffContract.getScopeDiff, ({ respond }) => {

--- a/turbo/apps/platform/src/signals/zero-page/settings/__tests__/connect-connector.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/__tests__/connect-connector.test.ts
@@ -10,11 +10,10 @@ import {
 } from "../connectors.ts";
 import { triggerAblyEvent, hasSubscription } from "../../../../mocks/ably.ts";
 import type { ConnectorListResponse } from "@vm0/api-contracts/contracts/connector-schemas";
-import { zeroConnectorsMainContract } from "@vm0/api-contracts/contracts/zero-connectors";
 import {
-  zeroSecretsContract,
-  zeroVariablesContract,
-} from "@vm0/api-contracts/contracts/zero-secrets";
+  zeroConnectorApiTokenContract,
+  zeroConnectorsMainContract,
+} from "@vm0/api-contracts/contracts/zero-connectors";
 import { createMockApi } from "../../../../mocks/msw-contract.ts";
 
 const context = testContext();
@@ -332,33 +331,27 @@ describe("submitApiToken$", () => {
   it("strips whitespace from connector API token values before upload", async () => {
     detachedSetupPage({ context, path: "/", withoutRender: true });
 
-    const submitted: Record<string, string> = {};
+    let submitted: Record<string, string> | undefined;
 
     server.use(
-      mockApi(zeroSecretsContract.set, ({ body, respond }) => {
-        submitted[body.name] = body.value;
-        const now = new Date().toISOString();
-        return respond(201, {
-          id: crypto.randomUUID(),
-          name: body.name,
-          type: "user",
-          description: body.description ?? null,
-          createdAt: now,
-          updatedAt: now,
-        });
-      }),
-      mockApi(zeroVariablesContract.set, ({ body, respond }) => {
-        submitted[body.name] = body.value;
-        const now = new Date().toISOString();
-        return respond(201, {
-          id: crypto.randomUUID(),
-          name: body.name,
-          value: body.value,
-          description: body.description ?? null,
-          createdAt: now,
-          updatedAt: now,
-        });
-      }),
+      mockApi(
+        zeroConnectorApiTokenContract.connect,
+        ({ body, params, respond }) => {
+          submitted = body.values;
+          return respond(200, {
+            id: null,
+            type: params.type,
+            authMethod: "api-token",
+            externalId: null,
+            externalUsername: null,
+            externalEmail: null,
+            oauthScopes: null,
+            needsReconnect: false,
+            createdAt: "1970-01-01T00:00:00.000Z",
+            updatedAt: "1970-01-01T00:00:00.000Z",
+          });
+        },
+      ),
     );
 
     await context.store.set(
@@ -372,7 +365,7 @@ describe("submitApiToken$", () => {
       context.signal,
     );
 
-    expect(submitted).toMatchObject({
+    expect(submitted).toStrictEqual({
       STRAPI_TOKEN: "strapitoken",
       STRAPI_BASE_URL: "https://strapi.example.com",
     });
@@ -383,12 +376,12 @@ describe("submitApiToken$", () => {
 
     await context.store.set(
       submitApiToken$,
-      "github",
-      { GITHUB_PERSONAL_ACCESS_TOKEN: "ghp_test123" },
+      "axiom",
+      { AXIOM_TOKEN: "xaat_test123" },
       { showPermissionDialog: true },
       context.signal,
     );
 
-    expect(context.store.get(permissionDialogType$)).toBe("github");
+    expect(context.store.get(permissionDialogType$)).toBe("axiom");
   });
 });

--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -24,15 +24,12 @@ import {
   type LocalBrowserHostListResponse,
 } from "@vm0/api-contracts/contracts/zero-local-browser";
 import {
+  zeroConnectorApiTokenContract,
   zeroConnectorScopeDiffContract,
   zeroLocalBrowserConnectorContract,
   zeroConnectorsMainContract,
   zeroLocalAgentConnectorContract,
 } from "@vm0/api-contracts/contracts/zero-connectors";
-import {
-  zeroSecretsContract,
-  zeroVariablesContract,
-} from "@vm0/api-contracts/contracts/zero-secrets";
 import type {
   ConnectorListResponse,
   ConnectorResponse,
@@ -471,39 +468,21 @@ export const submitApiToken$ = command(
   async (
     { get, set },
     type: ConnectorType,
-    inputSecrets: Record<string, string>,
+    inputValues: Record<string, string>,
     options: PostConnectOptions,
     signal: AbortSignal,
   ) => {
     const createClient = get(zeroClient$);
-    const secretsClient = createClient(zeroSecretsContract);
-    const variablesClient = createClient(zeroVariablesContract);
-    const apiTokenConfig = CONNECTOR_TYPES[type].authMethods["api-token"];
-    const secrets = sanitizeTokenInputRecord(inputSecrets);
-    for (const [name, value] of Object.entries(secrets)) {
-      if (!value) {
-        continue;
-      }
-      const isVariable = apiTokenConfig?.secrets[name]?.type === "variable";
-      if (isVariable) {
-        await accept(
-          variablesClient.set({
-            body: { name, value },
-            fetchOptions: { signal },
-          }),
-          [200, 201],
-        );
-      } else {
-        await accept(
-          secretsClient.set({
-            body: { name, value },
-            fetchOptions: { signal },
-          }),
-          [200, 201],
-        );
-      }
-      signal.throwIfAborted();
-    }
+    const apiTokenClient = createClient(zeroConnectorApiTokenContract);
+    const values = sanitizeTokenInputRecord(inputValues);
+    await accept(
+      apiTokenClient.connect({
+        params: { type },
+        body: { values },
+        fetchOptions: { signal },
+      }),
+      [200],
+    );
     signal.throwIfAborted();
     set(internalJustConnectedTypes$, (prev) => {
       return new Set([...prev, type]);

--- a/turbo/apps/platform/src/views/conn/__tests__/add-connection-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/conn/__tests__/add-connection-dialog.test.tsx
@@ -12,8 +12,10 @@ import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ConnectorType } from "@vm0/connectors/connectors";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
-import { zeroConnectorsMainContract } from "@vm0/api-contracts/contracts/zero-connectors";
-import { zeroSecretsContract } from "@vm0/api-contracts/contracts/zero-secrets";
+import {
+  zeroConnectorApiTokenContract,
+  zeroConnectorsMainContract,
+} from "@vm0/api-contracts/contracts/zero-connectors";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { detachedSetupPage, click } from "../../../__tests__/page-helper.ts";
@@ -251,23 +253,29 @@ describe("connect modal - interactions", () => {
     });
   });
 
-  it("save button submits API token secrets (CONN-I-023)", async () => {
+  it("save button submits API token values (CONN-I-023)", async () => {
     const user = userEvent.setup();
-    let submittedSecret: { name: string; value: string } | undefined;
+    let submittedValues: Record<string, string> | undefined;
 
     server.use(
-      mockApi(zeroSecretsContract.set, ({ body, respond }) => {
-        submittedSecret = { name: body.name, value: body.value };
-        const now = new Date().toISOString();
-        return respond(201, {
-          id: crypto.randomUUID(),
-          name: body.name,
-          type: "user",
-          description: body.description ?? null,
-          createdAt: now,
-          updatedAt: now,
-        });
-      }),
+      mockApi(
+        zeroConnectorApiTokenContract.connect,
+        ({ body, params, respond }) => {
+          submittedValues = body.values;
+          return respond(200, {
+            id: null,
+            type: params.type,
+            authMethod: "api-token",
+            externalId: null,
+            externalUsername: null,
+            externalEmail: null,
+            oauthScopes: null,
+            needsReconnect: false,
+            createdAt: "1970-01-01T00:00:00.000Z",
+            updatedAt: "1970-01-01T00:00:00.000Z",
+          });
+        },
+      ),
     );
 
     await openConnectModal("axiom");
@@ -283,9 +291,9 @@ describe("connect modal - interactions", () => {
     click(screen.getByText("Save"));
 
     await waitFor(() => {
-      expect(submittedSecret).toBeDefined();
-      expect(submittedSecret?.name).toBe("AXIOM_TOKEN");
-      expect(submittedSecret?.value).toBe("test-token-value");
+      expect(submittedValues).toStrictEqual({
+        AXIOM_TOKEN: "test-token-value",
+      });
     });
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-directed-connect-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-directed-connect-page.test.tsx
@@ -16,7 +16,7 @@ import {
   CONNECTOR_TYPES,
   type ConnectorType,
 } from "@vm0/connectors/connectors";
-import { zeroSecretsContract } from "@vm0/api-contracts/contracts/zero-secrets";
+import { zeroConnectorApiTokenContract } from "@vm0/api-contracts/contracts/zero-connectors";
 import { zeroUserConnectorsContract } from "@vm0/api-contracts/contracts/user-connectors";
 import { setMockConnectors } from "../../../mocks/handlers/api-connectors.ts";
 import { createMockApi } from "../../../mocks/msw-contract.ts";
@@ -24,6 +24,21 @@ import { setMockTeam } from "../../../mocks/handlers/api-agents.ts";
 
 const context = testContext();
 const mockApi = createMockApi(context);
+
+function connectedApiTokenResponse(type: ConnectorType) {
+  return {
+    id: null,
+    type,
+    authMethod: "api-token" as const,
+    externalId: null,
+    externalUsername: null,
+    externalEmail: null,
+    oauthScopes: null,
+    needsReconnect: false,
+    createdAt: "1970-01-01T00:00:00.000Z",
+    updatedAt: "1970-01-01T00:00:00.000Z",
+  };
+}
 
 function mockConnectors(
   connectors: { type: ConnectorType; externalUsername?: string }[],
@@ -262,7 +277,7 @@ describe("directed connect page", () => {
     const user = userEvent.setup();
 
     server.use(
-      mockApi(zeroSecretsContract.set, ({ respond }) => {
+      mockApi(zeroConnectorApiTokenContract.connect, ({ respond }) => {
         return respond(401, {
           error: { message: "Invalid API token", code: "UNAUTHORIZED" },
         });
@@ -333,21 +348,16 @@ describe("directed connect page", () => {
 
   it("save button submits the api token to the server (CONN-I-049)", async () => {
     const user = userEvent.setup();
-    let capturedBody: { name: string; value: string } | undefined;
+    let capturedValues: Record<string, string> | undefined;
 
     server.use(
-      mockApi(zeroSecretsContract.set, ({ body, respond }) => {
-        capturedBody = { name: body.name, value: body.value };
-        const now = new Date().toISOString();
-        return respond(201, {
-          id: crypto.randomUUID(),
-          name: body.name,
-          type: "user",
-          description: body.description ?? null,
-          createdAt: now,
-          updatedAt: now,
-        });
-      }),
+      mockApi(
+        zeroConnectorApiTokenContract.connect,
+        ({ body, params, respond }) => {
+          capturedValues = body.values;
+          return respond(200, connectedApiTokenResponse(params.type));
+        },
+      ),
     );
 
     detachedSetupPage({ context, path: "/connectors/axiom/connect" });
@@ -381,9 +391,9 @@ describe("directed connect page", () => {
     click(saveBtn2!);
 
     await waitFor(() => {
-      expect(capturedBody).toBeDefined();
-      expect(capturedBody?.name).toBe("AXIOM_TOKEN");
-      expect(capturedBody?.value).toBe("test-token-value");
+      expect(capturedValues).toStrictEqual({
+        AXIOM_TOKEN: "test-token-value",
+      });
     });
   });
 
@@ -393,16 +403,8 @@ describe("directed connect page", () => {
 
     let authorizeCalled = false;
     server.use(
-      mockApi(zeroSecretsContract.set, ({ respond }) => {
-        const now = new Date().toISOString();
-        return respond(201, {
-          id: crypto.randomUUID(),
-          name: "AXIOM_TOKEN",
-          type: "user",
-          description: null,
-          createdAt: now,
-          updatedAt: now,
-        });
+      mockApi(zeroConnectorApiTokenContract.connect, ({ params, respond }) => {
+        return respond(200, connectedApiTokenResponse(params.type));
       }),
       mockApi(zeroUserConnectorsContract.update, ({ respond }) => {
         authorizeCalled = true;
@@ -511,16 +513,8 @@ describe("directed connect page", () => {
 
     let authorizeCalled = false;
     server.use(
-      mockApi(zeroSecretsContract.set, ({ respond }) => {
-        const now = new Date().toISOString();
-        return respond(201, {
-          id: crypto.randomUUID(),
-          name: "AXIOM_TOKEN",
-          type: "user",
-          description: null,
-          createdAt: now,
-          updatedAt: now,
-        });
+      mockApi(zeroConnectorApiTokenContract.connect, ({ params, respond }) => {
+        return respond(200, connectedApiTokenResponse(params.type));
       }),
       mockApi(zeroUserConnectorsContract.update, ({ respond }) => {
         authorizeCalled = true;

--- a/turbo/apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx
@@ -154,7 +154,7 @@ type PostConnectOptions = {
 
 type SubmitApiTokenFn = (
   type: ConnectorType,
-  inputSecrets: Record<string, string>,
+  inputValues: Record<string, string>,
   options: PostConnectOptions,
   signal: AbortSignal,
 ) => Promise<void>;
@@ -216,15 +216,15 @@ function ApiTokenForm({
   const setFormValue = useSet(setTokenFormValue$);
   const clearForm = useSet(clearTokenForm$);
   const pageSignal = useGet(pageSignal$);
-  const secretValues = useGet(tokenFormValuesFor$(type));
+  const tokenValues = useGet(tokenFormValuesFor$(type));
 
   if (!apiTokenConfig) {
     return null;
   }
 
-  const secretEntries = Object.entries(apiTokenConfig.secrets);
-  const allFilled = secretEntries.every(([name, cfg]) => {
-    return !cfg.required || hasTokenInputValue(secretValues[name]);
+  const tokenEntries = Object.entries(apiTokenConfig.secrets);
+  const allFilled = tokenEntries.every(([name, cfg]) => {
+    return !cfg.required || hasTokenInputValue(tokenValues[name]);
   });
 
   const handleSubmit = onDomEventFn(async () => {
@@ -233,7 +233,7 @@ function ApiTokenForm({
     }
     await submit(
       type,
-      secretValues,
+      tokenValues,
       {
         showPermissionDialog: showPermissionDialogOnConnect,
       },
@@ -258,7 +258,7 @@ function ApiTokenForm({
           }}
         />
       )}
-      {secretEntries.map(([name, secretConfig]) => {
+      {tokenEntries.map(([name, secretConfig]) => {
         return (
           <div key={name} className="flex flex-col gap-1.5">
             <label className="text-sm font-medium text-foreground">
@@ -267,7 +267,7 @@ function ApiTokenForm({
             <Input
               type="password"
               placeholder={secretConfig.placeholder}
-              value={secretValues[name] ?? ""}
+              value={tokenValues[name] ?? ""}
               onChange={(e) => {
                 return setFormValue(type, name, e.target.value);
               }}

--- a/turbo/apps/web/src/lib/zero/connector/connector-service.ts
+++ b/turbo/apps/web/src/lib/zero/connector/connector-service.ts
@@ -5,6 +5,7 @@ import {
 } from "@vm0/connectors/connector-utils";
 import type {
   ConnectorAuthMethodType,
+  ConnectorSecretConfig,
   ConnectorType,
 } from "@vm0/connectors/connectors";
 import {
@@ -61,6 +62,11 @@ const log = logger("service:connector");
  */
 const DEFAULT_ACCESS_TOKEN_EXPIRES_IN_SECS = 3600;
 
+type ApiTokenFieldSet = {
+  readonly secrets: readonly string[];
+  readonly variables: readonly string[];
+};
+
 /**
  * Validate and parse connector type from database value
  */
@@ -78,6 +84,48 @@ function parseConnectorType(type: string): ConnectorType {
 function getSecretNameForConnector(type: ConnectorType): string {
   if (type === "computer") return "COMPUTER_CONNECTOR_AUTHTOKEN";
   return PROVIDER_HANDLERS[type].getSecretName();
+}
+
+function getApiTokenFieldConfig(
+  type: ConnectorType,
+): Record<string, ConnectorSecretConfig> | null {
+  return CONNECTOR_TYPES[type].authMethods["api-token"]?.secrets ?? null;
+}
+
+function getApiTokenConfiguredFieldsByType(
+  type: ConnectorType,
+): ApiTokenFieldSet | null {
+  const fieldConfig = getApiTokenFieldConfig(type);
+  if (!fieldConfig) {
+    return null;
+  }
+
+  const secretNames: string[] = [];
+  const variableNames: string[] = [];
+  for (const [name, config] of Object.entries(fieldConfig)) {
+    if (config.type === "variable") {
+      variableNames.push(name);
+    } else {
+      secretNames.push(name);
+    }
+  }
+
+  return { secrets: secretNames, variables: variableNames };
+}
+
+function apiTokenConnectorResponse(type: ConnectorType): ConnectorResponse {
+  return {
+    id: null,
+    type,
+    authMethod: "api-token",
+    externalId: null,
+    externalUsername: null,
+    externalEmail: null,
+    oauthScopes: null,
+    needsReconnect: false,
+    createdAt: "1970-01-01T00:00:00.000Z",
+    updatedAt: "1970-01-01T00:00:00.000Z",
+  };
 }
 
 /**
@@ -186,18 +234,7 @@ export async function listConnectors(
       return !dbTypeSet.has(type);
     })
     .map((type) => {
-      return {
-        id: null,
-        type,
-        authMethod: "api-token",
-        externalId: null,
-        externalUsername: null,
-        externalEmail: null,
-        oauthScopes: null,
-        needsReconnect: false,
-        createdAt: "1970-01-01T00:00:00.000Z",
-        updatedAt: "1970-01-01T00:00:00.000Z",
-      };
+      return apiTokenConnectorResponse(type);
     });
 
   return [...dbConnectors, ...derivedConnectors];
@@ -299,18 +336,7 @@ export async function getConnector(
   if (!secretsOk || !variablesOk) return null;
 
   // Use a fixed timestamp — this connector is inferred, not explicitly created.
-  return {
-    id: null,
-    type,
-    authMethod: "api-token",
-    externalId: null,
-    externalUsername: null,
-    externalEmail: null,
-    oauthScopes: null,
-    needsReconnect: false,
-    createdAt: "1970-01-01T00:00:00.000Z",
-    updatedAt: "1970-01-01T00:00:00.000Z",
-  };
+  return apiTokenConnectorResponse(type);
 }
 
 interface ExternalUserInfo {
@@ -408,6 +434,8 @@ export async function upsertOAuthConnector(
   if (!connectorRow) {
     throw new Error("Failed to upsert connector");
   }
+
+  await deleteApiTokenConnectorLocalState(orgId, userId, type);
   log.debug("connector upserted", { connectorId: connectorRow.id, type });
 
   // Notify the operating user's open tabs (e.g. the connector settings page
@@ -434,6 +462,49 @@ export async function upsertOAuthConnector(
     created:
       connectorRow.createdAt.getTime() === connectorRow.updatedAt.getTime(),
   };
+}
+
+async function deleteApiTokenConnectorLocalState(
+  orgId: string,
+  userId: string,
+  type: ConnectorType,
+): Promise<boolean> {
+  const db = globalThis.services.db;
+  const fields = getApiTokenConfiguredFieldsByType(type);
+  if (!fields) {
+    return false;
+  }
+
+  let deleted = false;
+  for (const name of fields.secrets) {
+    const result = await db
+      .delete(secrets)
+      .where(
+        and(
+          eq(secrets.orgId, orgId),
+          eq(secrets.userId, userId),
+          eq(secrets.name, name),
+          eq(secrets.type, "user"),
+        ),
+      )
+      .returning({ id: secrets.id });
+    if (result.length > 0) deleted = true;
+  }
+  for (const name of fields.variables) {
+    const result = await db
+      .delete(variables)
+      .where(
+        and(
+          eq(variables.orgId, orgId),
+          eq(variables.userId, userId),
+          eq(variables.name, name),
+        ),
+      )
+      .returning({ id: variables.id });
+    if (result.length > 0) deleted = true;
+  }
+
+  return deleted;
 }
 
 /**
@@ -559,36 +630,8 @@ export async function deleteConnector(
   // forms during migrations or manual repairs, so a DELETE must remove every
   // trace or the UI will still treat the connector as connected via the
   // leftover secret.
-  const fields = getApiTokenFieldsByType(type);
-  if (fields) {
-    for (const name of fields.secrets) {
-      const result = await db
-        .delete(secrets)
-        .where(
-          and(
-            eq(secrets.orgId, orgId),
-            eq(secrets.userId, userId),
-            eq(secrets.name, name),
-            eq(secrets.type, "user"),
-          ),
-        )
-        .returning({ id: secrets.id });
-      if (result.length > 0) deleted = true;
-    }
-    for (const name of fields.variables) {
-      const result = await db
-        .delete(variables)
-        .where(
-          and(
-            eq(variables.orgId, orgId),
-            eq(variables.userId, userId),
-            eq(variables.name, name),
-          ),
-        )
-        .returning({ id: variables.id });
-      if (result.length > 0) deleted = true;
-    }
-  }
+  deleted =
+    (await deleteApiTokenConnectorLocalState(orgId, userId, type)) || deleted;
 
   if (!deleted) {
     throw notFound("Connector not found");

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -899,6 +899,7 @@ export {
 export {
   zeroConnectorsMainContract,
   zeroConnectorsByTypeContract,
+  zeroConnectorApiTokenContract,
   zeroConnectorScopeDiffContract,
   zeroConnectorsSearchContract,
   zeroConnectorSessionsContract,
@@ -907,8 +908,10 @@ export {
   zeroLocalBrowserConnectorContract,
   zeroLocalAgentConnectorContract,
   type ConnectorSearchAuthMethod,
+  type ConnectApiTokenConnectorRequest,
   type ZeroConnectorsMainContract,
   type ZeroConnectorsByTypeContract,
+  type ZeroConnectorApiTokenContract,
   type ZeroConnectorScopeDiffContract,
   type ZeroConnectorsSearchContract,
   type ZeroConnectorSessionsContract,

--- a/turbo/packages/api-contracts/src/contracts/zero-connectors.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-connectors.ts
@@ -64,6 +64,36 @@ export const zeroConnectorsByTypeContract = c.router({
   },
 });
 
+const connectApiTokenConnectorRequestSchema = z.object({
+  values: z.record(z.string(), z.string()),
+});
+
+export type ConnectApiTokenConnectorRequest = z.infer<
+  typeof connectApiTokenConnectorRequestSchema
+>;
+
+/**
+ * Zero contract for POST /api/zero/connectors/:type/api-token
+ * Connects a connector through its API-token auth method.
+ */
+export const zeroConnectorApiTokenContract = c.router({
+  connect: {
+    method: "POST",
+    path: "/api/zero/connectors/:type/api-token",
+    headers: authHeadersSchema,
+    pathParams: z.object({ type: connectorTypeSchema }),
+    body: connectApiTokenConnectorRequestSchema,
+    responses: {
+      200: connectorResponseSchema,
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      404: apiErrorSchema,
+    },
+    summary: "Connect a connector with API-token values",
+  },
+});
+
 /**
  * Zero contract for GET /api/zero/connectors/:type/scope-diff
  * App-layer endpoint (direct service call, no proxy)
@@ -282,6 +312,8 @@ export const zeroLocalBrowserConnectorContract = c.router({
 
 export type ZeroConnectorsMainContract = typeof zeroConnectorsMainContract;
 export type ZeroConnectorsByTypeContract = typeof zeroConnectorsByTypeContract;
+export type ZeroConnectorApiTokenContract =
+  typeof zeroConnectorApiTokenContract;
 export type ZeroConnectorScopeDiffContract =
   typeof zeroConnectorScopeDiffContract;
 export type ZeroConnectorAuthorizeContract =


### PR DESCRIPTION
Closes #13533.

## Summary
- add a connector-aware API-token connect contract and API route
- replace existing OAuth connector rows and connector-scoped secrets when connecting via API token
- replace API-token field state atomically, including optional fields, and invalidate Stripe CLI auth sessions
- update platform submit flow to call the connector-specific API-token endpoint

## Verification
- pnpm --filter api exec vitest run src/signals/routes/__tests__/zero-connectors-api-token-connect.test.ts src/signals/routes/__tests__/zero-connectors-by-type-delete.test.ts src/signals/routes/__tests__/zero-connectors-list.test.ts src/signals/routes/__tests__/zero-connectors-by-type-get.test.ts src/signals/routes/__tests__/zero-connectors-cli-auth-stripe.test.ts
- pnpm --filter @vm0/app exec vitest run src/signals/zero-page/settings/__tests__/connect-connector.test.ts src/views/conn/__tests__/add-connection-dialog.test.tsx src/views/zero-page/__tests__/zero-directed-connect-page.test.tsx
- pnpm --filter api lint
- pnpm --filter web lint
- pnpm --filter @vm0/api-contracts lint
- pnpm --filter api check-types && pnpm --filter @vm0/app check-types && pnpm --filter @vm0/api-contracts check-types && pnpm --filter web check-types
- pre-commit: pnpm check-types (turbo run check-types --concurrency=1)