### PR TITLE
test: preserve coalesced vsock test frames

### DIFF
--- a/crates/vsock-host/src/tests/connection.rs
+++ b/crates/vsock-host/src/tests/connection.rs
@@ -120,7 +120,7 @@ async fn resume_operations_sends_request_and_accepts_empty_ack() {
 
 #[tokio::test]
 async fn lifecycle_request_bypasses_normal_operation_fence() {
-    let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+    let (host, mut guest) = setup_host_and_guest().await;
     let host = Arc::new(host);
     let _fence = fence_normal_operations(&host);
 
@@ -132,7 +132,7 @@ async fn lifecycle_request_bypasses_normal_operation_fence() {
         tokio::spawn(async move { host.quiesce_operations(Duration::from_secs(2)).await })
     };
 
-    let msg = read_guest_message(&mut guest, &mut decoder).await;
+    let msg = read_guest_message(&mut guest).await;
     assert_eq!(msg.msg_type, MSG_QUIESCE_OPERATIONS);
     let resp = vsock_proto::encode(MSG_OPERATIONS_QUIESCED, msg.seq, &[]).unwrap();
     guest.write_all(&resp).await.unwrap();
@@ -231,7 +231,7 @@ async fn quiesce_operations_times_out_and_late_ack_is_ignored() {
         let mut decoder = Decoder::new();
         mock_handshake(&mut guest, &mut decoder).await;
 
-        let quiesce = read_guest_message(&mut guest, &mut decoder).await;
+        let quiesce = read_guest_message(&mut guest).await;
         assert_eq!(quiesce.msg_type, MSG_QUIESCE_OPERATIONS);
         quiesce_seen_tx.send(()).unwrap();
 
@@ -239,7 +239,7 @@ async fn quiesce_operations_times_out_and_late_ack_is_ignored() {
         let late = vsock_proto::encode(MSG_OPERATIONS_QUIESCED, quiesce.seq, &[]).unwrap();
         guest.write_all(&late).await.unwrap();
 
-        let resume = read_guest_message(&mut guest, &mut decoder).await;
+        let resume = read_guest_message(&mut guest).await;
         assert_eq!(resume.msg_type, MSG_RESUME_OPERATIONS);
         let resp = vsock_proto::encode(MSG_OPERATIONS_RESUMED, resume.seq, &[]).unwrap();
         guest.write_all(&resp).await.unwrap();
@@ -393,7 +393,7 @@ async fn connection_poison_marks_normal_operations_not_parkable() {
 
 #[tokio::test]
 async fn cancelled_normal_request_frame_write_poisons_connection() {
-    let (host, _guest, _decoder) = setup_host_and_guest().await;
+    let (host, _guest) = setup_host_and_guest().await;
 
     drop_started_pending_normal_request_write_guard(&host);
 

--- a/crates/vsock-host/src/tests/exec_operation/cancel.rs
+++ b/crates/vsock-host/src/tests/exec_operation/cancel.rs
@@ -15,7 +15,7 @@ use crate::operation_tracker::NormalOperationReadiness;
 
 #[tokio::test]
 async fn exec_start_cancelled_before_write_does_not_poison_or_send_frame() {
-    let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+    let (host, mut guest) = setup_host_and_guest().await;
     let host = Arc::new(host);
     let writer_guard = host.shared.writer.lock().await;
     let task = {
@@ -44,7 +44,7 @@ async fn exec_start_cancelled_before_write_does_not_poison_or_send_frame() {
         let host = Arc::clone(&host);
         tokio::spawn(async move { host.exec("echo ok", 5000, &[], false).await })
     };
-    let msg = read_guest_message(&mut guest, &mut decoder).await;
+    let msg = read_guest_message(&mut guest).await;
     assert_eq!(
         msg.msg_type, MSG_EXEC_START,
         "start frame should not be written"
@@ -64,10 +64,10 @@ async fn exec_start_cancelled_before_write_does_not_poison_or_send_frame() {
 
 #[tokio::test]
 async fn exec_operation_handle_drop_after_full_write_marks_not_parkable() {
-    let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+    let (host, mut guest) = setup_host_and_guest().await;
     let host = Arc::new(host);
     let handle = start_capture_operation(&host, "drop-after-write").await;
-    let msg = read_guest_message(&mut guest, &mut decoder).await;
+    let msg = read_guest_message(&mut guest).await;
     assert_eq!(msg.msg_type, MSG_EXEC_START);
     drop(handle);
     assert_eq!(operation_count(&host), 0);
@@ -86,14 +86,14 @@ async fn exec_operation_handle_drop_after_full_write_marks_not_parkable() {
 
 #[tokio::test]
 async fn exec_cancel_sends_cancel_and_waits_for_cancelled_result() {
-    let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+    let (host, mut guest) = setup_host_and_guest().await;
     let handle = start_capture_operation(&host, "cancel").await;
-    let start = read_guest_message(&mut guest, &mut decoder).await;
+    let start = read_guest_message(&mut guest).await;
     assert_eq!(start.msg_type, MSG_EXEC_START);
 
     let cancel_task =
         tokio::spawn(async move { handle.cancel_and_wait(Duration::from_secs(5)).await });
-    let cancel = read_guest_message(&mut guest, &mut decoder).await;
+    let cancel = read_guest_message(&mut guest).await;
     assert_eq!(cancel.msg_type, MSG_EXEC_CANCEL);
     assert_eq!(cancel.seq, start.seq);
     vsock_proto::decode_exec_cancel(&cancel.payload).unwrap();
@@ -105,10 +105,10 @@ async fn exec_cancel_sends_cancel_and_waits_for_cancelled_result() {
 
 #[tokio::test]
 async fn exec_cancel_after_terminal_result_returns_result_without_cancel_frame() {
-    let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+    let (host, mut guest) = setup_host_and_guest().await;
     let host = Arc::new(host);
     let handle = start_capture_operation(&host, "already-done").await;
-    let start = read_guest_message(&mut guest, &mut decoder).await;
+    let start = read_guest_message(&mut guest).await;
     assert_eq!(start.msg_type, MSG_EXEC_START);
     send_exec_result(
         &mut guest,
@@ -126,20 +126,20 @@ async fn exec_cancel_after_terminal_result_returns_result_without_cancel_frame()
         .unwrap();
     assert_eq!(result.termination, ExecTermination::Exited { exit_code: 0 });
 
-    assert_connection_accepts_exec_operation(&host, &mut guest, &mut decoder).await;
+    assert_connection_accepts_exec_operation(&host, &mut guest).await;
 }
 
 #[tokio::test]
 async fn exec_cancel_non_cancelled_terminal_result_cleans_operation_without_poisoning() {
-    let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+    let (host, mut guest) = setup_host_and_guest().await;
     let host = Arc::new(host);
     let handle = start_capture_operation(&host, "cancel-race").await;
-    let start = read_guest_message(&mut guest, &mut decoder).await;
+    let start = read_guest_message(&mut guest).await;
     assert_eq!(start.msg_type, MSG_EXEC_START);
 
     let cancel_task =
         tokio::spawn(async move { handle.cancel_and_wait(Duration::from_secs(5)).await });
-    let cancel = read_guest_message(&mut guest, &mut decoder).await;
+    let cancel = read_guest_message(&mut guest).await;
     assert_eq!(cancel.msg_type, MSG_EXEC_CANCEL);
     assert_eq!(cancel.seq, start.seq);
 
@@ -156,18 +156,18 @@ async fn exec_cancel_non_cancelled_terminal_result_cleans_operation_without_pois
     assert_eq!(operation_count(&host), 0);
     assert!(is_connected(&host));
 
-    assert_connection_accepts_exec_operation(&host, &mut guest, &mut decoder).await;
+    assert_connection_accepts_exec_operation(&host, &mut guest).await;
 }
 
 #[tokio::test]
 async fn exec_cancel_result_timeout_poisons_connection() {
-    let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+    let (host, mut guest) = setup_host_and_guest().await;
     let handle = start_capture_operation(&host, "cancel-timeout").await;
-    let start = read_guest_message(&mut guest, &mut decoder).await;
+    let start = read_guest_message(&mut guest).await;
     assert_eq!(start.msg_type, MSG_EXEC_START);
 
     let cancel_task = tokio::spawn(async move { handle.cancel_and_wait(Duration::ZERO).await });
-    let cancel = read_guest_message(&mut guest, &mut decoder).await;
+    let cancel = read_guest_message(&mut guest).await;
     assert_eq!(cancel.msg_type, MSG_EXEC_CANCEL);
     assert_eq!(cancel.seq, start.seq);
 
@@ -180,7 +180,7 @@ async fn exec_cancel_result_timeout_poisons_connection() {
 
 #[tokio::test]
 async fn exec_operation_frame_write_guard_started_drop_poisons_connection() {
-    let (host, _guest, _decoder) = setup_host_and_guest().await;
+    let (host, _guest) = setup_host_and_guest().await;
     exec_operation_impl::test_support::drop_started_frame_write_guard(Arc::clone(&host.shared));
     host.wait_until_closed(Duration::from_secs(5))
         .await

--- a/crates/vsock-host/src/tests/exec_operation/capture.rs
+++ b/crates/vsock-host/src/tests/exec_operation/capture.rs
@@ -16,7 +16,7 @@ use crate::{ExecCaptureRequest, ExecOperationRequest, ExecOwnedCapturedOutput};
 
 #[tokio::test]
 async fn exec_operation_capture_sends_start_and_receives_result() {
-    let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+    let (host, mut guest) = setup_host_and_guest().await;
     let host = Arc::new(host);
     let task = {
         let host = Arc::clone(&host);
@@ -36,7 +36,7 @@ async fn exec_operation_capture_sends_start_and_receives_result() {
         })
     };
 
-    let msg = read_guest_message(&mut guest, &mut decoder).await;
+    let msg = read_guest_message(&mut guest).await;
     assert_eq!(msg.msg_type, MSG_EXEC_START);
     let decoded = vsock_proto::decode_exec_start(&msg.payload).unwrap();
     assert_eq!(decoded.timeout_ms, 7000);
@@ -78,7 +78,7 @@ async fn exec_operation_capture_sends_start_and_receives_result() {
 
 #[tokio::test]
 async fn exec_start_sends_expected_exit_codes() {
-    let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+    let (host, mut guest) = setup_host_and_guest().await;
 
     let handle = host
         .start_exec_operation(ExecOperationRequest {
@@ -95,7 +95,7 @@ async fn exec_start_sends_expected_exit_codes() {
         .await
         .unwrap();
 
-    let msg = read_guest_message(&mut guest, &mut decoder).await;
+    let msg = read_guest_message(&mut guest).await;
     let decoded = vsock_proto::decode_exec_start(&msg.payload).unwrap();
     assert_eq!(decoded.expected_exit_codes, vec![66]);
 
@@ -116,7 +116,7 @@ async fn exec_start_sends_expected_exit_codes() {
 
 #[tokio::test]
 async fn exec_operation_capture_repeated_short_operations_soak() {
-    let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+    let (host, mut guest) = setup_host_and_guest().await;
     let host = Arc::new(host);
 
     for i in 0..8 {
@@ -136,7 +136,7 @@ async fn exec_operation_capture_repeated_short_operations_soak() {
             .await
             .unwrap();
 
-        let msg = read_guest_message(&mut guest, &mut decoder).await;
+        let msg = read_guest_message(&mut guest).await;
         assert_eq!(msg.msg_type, MSG_EXEC_START);
         let stdout = format!("ok-{i}");
         send_exec_result(
@@ -160,12 +160,12 @@ async fn exec_operation_capture_repeated_short_operations_soak() {
         assert!(is_connected(&host));
     }
 
-    assert_connection_accepts_exec_operation(&host, &mut guest, &mut decoder).await;
+    assert_connection_accepts_exec_operation(&host, &mut guest).await;
 }
 
 #[tokio::test]
 async fn exec_operation_capture_large_stdout_stderr_within_limits_soak() {
-    let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+    let (host, mut guest) = setup_host_and_guest().await;
     let stdout = vec![b'o'; 64 * 1024];
     let stderr = vec![b'e'; 64 * 1024];
     let handle = host
@@ -187,7 +187,7 @@ async fn exec_operation_capture_large_stdout_stderr_within_limits_soak() {
         .await
         .unwrap();
 
-    let msg = read_guest_message(&mut guest, &mut decoder).await;
+    let msg = read_guest_message(&mut guest).await;
     assert_eq!(msg.msg_type, MSG_EXEC_START);
     send_exec_result(
         &mut guest,
@@ -219,7 +219,7 @@ async fn exec_operation_capture_large_stdout_stderr_within_limits_soak() {
 
 #[tokio::test]
 async fn exec_result_preserves_non_default_metadata() {
-    let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+    let (host, mut guest) = setup_host_and_guest().await;
     let handle = host
         .start_exec_operation(ExecOperationRequest {
             timeout_ms: 5000,
@@ -234,7 +234,7 @@ async fn exec_result_preserves_non_default_metadata() {
         })
         .await
         .unwrap();
-    let msg = read_guest_message(&mut guest, &mut decoder).await;
+    let msg = read_guest_message(&mut guest).await;
     assert_eq!(msg.msg_type, MSG_EXEC_START);
 
     let payload = vsock_proto::encode_exec_result(
@@ -267,7 +267,7 @@ async fn exec_result_preserves_non_default_metadata() {
 
 #[tokio::test]
 async fn exec_result_capture_for_discard_policy_poisons_connection() {
-    let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+    let (host, mut guest) = setup_host_and_guest().await;
     let handle = host
         .start_exec_operation(ExecOperationRequest {
             timeout_ms: 5000,
@@ -283,7 +283,7 @@ async fn exec_result_capture_for_discard_policy_poisons_connection() {
         .await
         .unwrap();
 
-    let msg = read_guest_message(&mut guest, &mut decoder).await;
+    let msg = read_guest_message(&mut guest).await;
     let payload = vsock_proto::encode_exec_result(
         ExecTermination::Exited { exit_code: 0 },
         1,
@@ -306,7 +306,7 @@ async fn exec_result_capture_for_discard_policy_poisons_connection() {
 
 #[tokio::test]
 async fn exec_result_over_capture_limit_poisons_connection() {
-    let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+    let (host, mut guest) = setup_host_and_guest().await;
     let handle = host
         .start_exec_operation(ExecOperationRequest {
             timeout_ms: 5000,
@@ -322,7 +322,7 @@ async fn exec_result_over_capture_limit_poisons_connection() {
         .await
         .unwrap();
 
-    let msg = read_guest_message(&mut guest, &mut decoder).await;
+    let msg = read_guest_message(&mut guest).await;
     let payload = vsock_proto::encode_exec_result(
         ExecTermination::Exited { exit_code: 0 },
         1,
@@ -345,7 +345,7 @@ async fn exec_result_over_capture_limit_poisons_connection() {
 
 #[tokio::test]
 async fn exec_result_discard_for_capture_policy_poisons_connection() {
-    let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+    let (host, mut guest) = setup_host_and_guest().await;
     let handle = host
         .start_exec_operation(ExecOperationRequest {
             timeout_ms: 5000,
@@ -361,7 +361,7 @@ async fn exec_result_discard_for_capture_policy_poisons_connection() {
         .await
         .unwrap();
 
-    let msg = read_guest_message(&mut guest, &mut decoder).await;
+    let msg = read_guest_message(&mut guest).await;
     let payload = vsock_proto::encode_exec_result(
         ExecTermination::Exited { exit_code: 0 },
         1,
@@ -381,7 +381,7 @@ async fn exec_result_discard_for_capture_policy_poisons_connection() {
 
 #[tokio::test]
 async fn exec_result_zero_capture_limit_accepts_empty_capture() {
-    let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+    let (host, mut guest) = setup_host_and_guest().await;
     let handle = host
         .start_exec_operation(ExecOperationRequest {
             timeout_ms: 5000,
@@ -397,7 +397,7 @@ async fn exec_result_zero_capture_limit_accepts_empty_capture() {
         .await
         .unwrap();
 
-    let msg = read_guest_message(&mut guest, &mut decoder).await;
+    let msg = read_guest_message(&mut guest).await;
     let payload = vsock_proto::encode_exec_result(
         ExecTermination::Exited { exit_code: 0 },
         1,
@@ -434,11 +434,11 @@ async fn exec_result_zero_capture_limit_accepts_empty_capture() {
 
 #[tokio::test]
 async fn exec_operations_dispatch_out_of_order_results_by_seq() {
-    let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+    let (host, mut guest) = setup_host_and_guest().await;
     let first = start_capture_operation(&host, "cmd-a").await;
     let second = start_capture_operation(&host, "cmd-b").await;
 
-    let mut messages = read_guest_messages(&mut guest, &mut decoder, 2).await;
+    let mut messages = read_guest_messages(&mut guest, 2).await;
     let msg_a = messages.remove(0);
     let msg_b = messages.remove(0);
     assert_eq!(msg_a.msg_type, MSG_EXEC_START);

--- a/crates/vsock-host/src/tests/exec_operation/exec.rs
+++ b/crates/vsock-host/src/tests/exec_operation/exec.rs
@@ -50,14 +50,14 @@ async fn test_exec() {
 
 #[tokio::test]
 async fn exec_operation_tracks_until_terminal_result() {
-    let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+    let (host, mut guest) = setup_host_and_guest().await;
     let host = Arc::new(host);
     let exec_task = {
         let host = Arc::clone(&host);
         tokio::spawn(async move { host.exec("echo tracked", 5000, &[], false).await })
     };
 
-    let msg = read_guest_message(&mut guest, &mut decoder).await;
+    let msg = read_guest_message(&mut guest).await;
     assert_eq!(msg.msg_type, MSG_EXEC_START);
     assert_eq!(
         normal_operation_readiness(&host),
@@ -86,7 +86,7 @@ async fn exec_operation_tracks_until_terminal_result() {
 /// guest-side orphan when the host's outer timeout fires.
 #[tokio::test]
 async fn test_exec_rejects_zero_timeout() {
-    let (host, _guest, _decoder) = setup_host_and_guest().await;
+    let (host, _guest) = setup_host_and_guest().await;
 
     let err = host.exec("echo hi", 0, &[], false).await.unwrap_err();
     assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
@@ -120,14 +120,14 @@ async fn test_exec_error_response() {
 
 #[tokio::test]
 async fn exec_operation_error_response_releases_tracker() {
-    let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+    let (host, mut guest) = setup_host_and_guest().await;
     let host = Arc::new(host);
     let exec_task = {
         let host = Arc::clone(&host);
         tokio::spawn(async move { host.exec("badcmd", 5000, &[], false).await })
     };
 
-    let msg = read_guest_message(&mut guest, &mut decoder).await;
+    let msg = read_guest_message(&mut guest).await;
     assert_eq!(msg.msg_type, MSG_EXEC_START);
     assert_eq!(
         normal_operation_readiness(&host),
@@ -148,10 +148,10 @@ async fn exec_operation_error_response_releases_tracker() {
 
 #[tokio::test]
 async fn dropping_exec_handle_after_start_marks_tracker_not_parkable() {
-    let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+    let (host, mut guest) = setup_host_and_guest().await;
     let host = Arc::new(host);
     let handle = start_capture_operation(&host, "drop-after-start").await;
-    let msg = read_guest_message(&mut guest, &mut decoder).await;
+    let msg = read_guest_message(&mut guest).await;
     assert_eq!(msg.msg_type, MSG_EXEC_START);
     assert_eq!(
         normal_operation_readiness(&host),

--- a/crates/vsock-host/src/tests/exec_operation/lifecycle.rs
+++ b/crates/vsock-host/src/tests/exec_operation/lifecycle.rs
@@ -17,9 +17,9 @@ use crate::{
 
 #[tokio::test]
 async fn exec_operation_wait_timeout_cleans_operation_state() {
-    let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+    let (host, mut guest) = setup_host_and_guest().await;
     let handle = start_capture_operation(&host, "timeout").await;
-    let msg = read_guest_message(&mut guest, &mut decoder).await;
+    let msg = read_guest_message(&mut guest).await;
     assert_eq!(msg.msg_type, MSG_EXEC_START);
     assert_eq!(operation_count(&host), 1);
 
@@ -35,10 +35,10 @@ async fn exec_operation_wait_timeout_cleans_operation_state() {
 
 #[tokio::test]
 async fn exec_error_response_completes_operation_without_timeout() {
-    let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+    let (host, mut guest) = setup_host_and_guest().await;
     let host = Arc::new(host);
     let handle = start_capture_operation(&host, "error-response").await;
-    let msg = read_guest_message(&mut guest, &mut decoder).await;
+    let msg = read_guest_message(&mut guest).await;
     assert_eq!(msg.msg_type, MSG_EXEC_START);
 
     let payload = vsock_proto::encode_error("exec operation already active");
@@ -50,12 +50,12 @@ async fn exec_error_response_completes_operation_without_timeout() {
     assert_eq!(err.to_string(), "exec operation already active");
     assert_eq!(operation_count(&host), 0);
 
-    assert_connection_accepts_exec_operation(&host, &mut guest, &mut decoder).await;
+    assert_connection_accepts_exec_operation(&host, &mut guest).await;
 }
 
 #[tokio::test]
 async fn exec_operation_connection_close_wakes_result_and_stream() {
-    let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+    let (host, mut guest) = setup_host_and_guest().await;
     let mut handle = host
         .exec_operation_stream(ExecStreamRequest {
             timeout_ms: 5000,
@@ -74,7 +74,7 @@ async fn exec_operation_connection_close_wakes_result_and_stream() {
         .await
         .unwrap();
     let mut rx = handle.take_stream_receiver().unwrap();
-    let msg = read_guest_message(&mut guest, &mut decoder).await;
+    let msg = read_guest_message(&mut guest).await;
     assert_eq!(msg.msg_type, MSG_EXEC_START);
 
     drop(guest);
@@ -89,7 +89,7 @@ async fn exec_operation_connection_close_wakes_result_and_stream() {
 
 #[tokio::test]
 async fn exec_start_after_connection_close_returns_connection_reset() {
-    let (host, guest, _decoder) = setup_host_and_guest().await;
+    let (host, guest) = setup_host_and_guest().await;
     drop(guest);
     host.wait_until_closed(Duration::from_secs(5))
         .await
@@ -118,7 +118,7 @@ async fn exec_start_after_connection_close_returns_connection_reset() {
 
 #[tokio::test]
 async fn host_drop_closes_active_exec_result_and_stream() {
-    let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+    let (host, mut guest) = setup_host_and_guest().await;
     let mut handle = host
         .exec_operation_stream(ExecStreamRequest {
             timeout_ms: 5000,
@@ -137,7 +137,7 @@ async fn host_drop_closes_active_exec_result_and_stream() {
         .await
         .unwrap();
     let mut rx = handle.take_stream_receiver().unwrap();
-    let msg = read_guest_message(&mut guest, &mut decoder).await;
+    let msg = read_guest_message(&mut guest).await;
     assert_eq!(msg.msg_type, MSG_EXEC_START);
 
     drop(host);
@@ -152,9 +152,9 @@ async fn host_drop_closes_active_exec_result_and_stream() {
 
 #[tokio::test]
 async fn exec_output_after_result_does_not_poison_or_resurrect_state() {
-    let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+    let (host, mut guest) = setup_host_and_guest().await;
     let handle = start_capture_operation(&host, "done").await;
-    let msg = read_guest_message(&mut guest, &mut decoder).await;
+    let msg = read_guest_message(&mut guest).await;
     send_exec_result(
         &mut guest,
         msg.seq,
@@ -178,7 +178,7 @@ async fn exec_output_after_result_does_not_poison_or_resurrect_state() {
     .await;
 
     let exec_task = tokio::spawn(async move { host.exec("echo ok", 5000, &[], false).await });
-    let exec_msg = read_guest_message(&mut guest, &mut decoder).await;
+    let exec_msg = read_guest_message(&mut guest).await;
     assert_eq!(exec_msg.msg_type, MSG_EXEC_START);
     let decoded = vsock_proto::decode_exec_start(&exec_msg.payload).unwrap();
     assert_eq!(decoded.command, "echo ok");
@@ -196,10 +196,10 @@ async fn exec_output_after_result_does_not_poison_or_resurrect_state() {
 
 #[tokio::test]
 async fn duplicate_exec_result_after_completion_is_ignored() {
-    let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+    let (host, mut guest) = setup_host_and_guest().await;
     let host = Arc::new(host);
     let handle = start_capture_operation(&host, "duplicate-result").await;
-    let msg = read_guest_message(&mut guest, &mut decoder).await;
+    let msg = read_guest_message(&mut guest).await;
     assert_eq!(msg.msg_type, MSG_EXEC_START);
 
     send_exec_result(
@@ -229,5 +229,5 @@ async fn duplicate_exec_result_after_completion_is_ignored() {
     )
     .await;
 
-    assert_connection_accepts_exec_operation(&host, &mut guest, &mut decoder).await;
+    assert_connection_accepts_exec_operation(&host, &mut guest).await;
 }

--- a/crates/vsock-host/src/tests/exec_operation/malformed.rs
+++ b/crates/vsock-host/src/tests/exec_operation/malformed.rs
@@ -14,9 +14,9 @@ use crate::{ExecOwnedCapturedOutput, operation_tracker::NormalOperationReadiness
 
 #[tokio::test]
 async fn malformed_exec_error_poisons_connection() {
-    let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+    let (host, mut guest) = setup_host_and_guest().await;
     let handle = start_capture_operation(&host, "bad-error").await;
-    let msg = read_guest_message(&mut guest, &mut decoder).await;
+    let msg = read_guest_message(&mut guest).await;
     assert_eq!(msg.msg_type, MSG_EXEC_START);
 
     let frame = vsock_proto::encode(MSG_ERROR, msg.seq, &[0]).unwrap();
@@ -35,9 +35,9 @@ async fn malformed_exec_error_poisons_connection() {
 
 #[tokio::test]
 async fn malformed_exec_output_poisons_connection() {
-    let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+    let (host, mut guest) = setup_host_and_guest().await;
     let handle = start_capture_operation(&host, "bad-output").await;
-    let msg = read_guest_message(&mut guest, &mut decoder).await;
+    let msg = read_guest_message(&mut guest).await;
     let frame = vsock_proto::encode(MSG_EXEC_OUTPUT, msg.seq, &[0]).unwrap();
     guest.write_all(&frame).await.unwrap();
 
@@ -50,9 +50,9 @@ async fn malformed_exec_output_poisons_connection() {
 
 #[tokio::test]
 async fn malformed_exec_result_poisons_connection() {
-    let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+    let (host, mut guest) = setup_host_and_guest().await;
     let handle = start_capture_operation(&host, "bad-result").await;
-    let msg = read_guest_message(&mut guest, &mut decoder).await;
+    let msg = read_guest_message(&mut guest).await;
     let frame = vsock_proto::encode(MSG_EXEC_RESULT, msg.seq, &[0]).unwrap();
     guest.write_all(&frame).await.unwrap();
 
@@ -65,10 +65,10 @@ async fn malformed_exec_result_poisons_connection() {
 
 #[tokio::test]
 async fn malformed_exec_output_after_result_is_ignored() {
-    let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+    let (host, mut guest) = setup_host_and_guest().await;
     let host = Arc::new(host);
     let handle = start_capture_operation(&host, "done").await;
-    let msg = read_guest_message(&mut guest, &mut decoder).await;
+    let msg = read_guest_message(&mut guest).await;
     send_exec_result(
         &mut guest,
         msg.seq,
@@ -84,15 +84,15 @@ async fn malformed_exec_output_after_result_is_ignored() {
     let frame = vsock_proto::encode(MSG_EXEC_OUTPUT, msg.seq, &[0]).unwrap();
     guest.write_all(&frame).await.unwrap();
 
-    assert_connection_accepts_exec_operation(&host, &mut guest, &mut decoder).await;
+    assert_connection_accepts_exec_operation(&host, &mut guest).await;
 }
 
 #[tokio::test]
 async fn malformed_exec_frames_after_handle_drop_are_ignored() {
-    let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+    let (host, mut guest) = setup_host_and_guest().await;
     let host = Arc::new(host);
     let handle = start_capture_operation(&host, "abandoned").await;
-    let msg = read_guest_message(&mut guest, &mut decoder).await;
+    let msg = read_guest_message(&mut guest).await;
     assert_eq!(msg.msg_type, MSG_EXEC_START);
     assert_eq!(operation_count(&host), 1);
 
@@ -109,10 +109,10 @@ async fn malformed_exec_frames_after_handle_drop_are_ignored() {
 
 #[tokio::test]
 async fn malformed_duplicate_exec_result_after_completion_is_ignored() {
-    let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+    let (host, mut guest) = setup_host_and_guest().await;
     let host = Arc::new(host);
     let handle = start_capture_operation(&host, "malformed-duplicate-result").await;
-    let msg = read_guest_message(&mut guest, &mut decoder).await;
+    let msg = read_guest_message(&mut guest).await;
     assert_eq!(msg.msg_type, MSG_EXEC_START);
 
     send_exec_result(
@@ -136,5 +136,5 @@ async fn malformed_duplicate_exec_result_after_completion_is_ignored() {
     let frame = vsock_proto::encode(MSG_EXEC_RESULT, msg.seq, &[0]).unwrap();
     guest.write_all(&frame).await.unwrap();
 
-    assert_connection_accepts_exec_operation(&host, &mut guest, &mut decoder).await;
+    assert_connection_accepts_exec_operation(&host, &mut guest).await;
 }

--- a/crates/vsock-host/src/tests/exec_operation/stream.rs
+++ b/crates/vsock-host/src/tests/exec_operation/stream.rs
@@ -12,7 +12,7 @@ use crate::{ExecOperationRequest, ExecStreamRequest, exec_operation as exec_oper
 
 #[tokio::test]
 async fn exec_operation_stream_rejects_zero_capacity_without_sending_frame() {
-    let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+    let (host, mut guest) = setup_host_and_guest().await;
     let host = Arc::new(host);
 
     let err = match host
@@ -38,12 +38,12 @@ async fn exec_operation_stream_rejects_zero_capacity_without_sending_frame() {
     assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
     assert_eq!(operation_count(&host), 0);
 
-    assert_connection_accepts_exec_operation(&host, &mut guest, &mut decoder).await;
+    assert_connection_accepts_exec_operation(&host, &mut guest).await;
 }
 
 #[tokio::test]
 async fn exec_operation_stream_rejects_oversized_capacity_without_sending_frame() {
-    let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+    let (host, mut guest) = setup_host_and_guest().await;
     let host = Arc::new(host);
 
     let err = match host
@@ -69,12 +69,12 @@ async fn exec_operation_stream_rejects_oversized_capacity_without_sending_frame(
     assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
     assert_eq!(operation_count(&host), 0);
 
-    assert_connection_accepts_exec_operation(&host, &mut guest, &mut decoder).await;
+    assert_connection_accepts_exec_operation(&host, &mut guest).await;
 }
 
 #[tokio::test]
 async fn exec_start_stream_policy_uses_default_receiver() {
-    let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+    let (host, mut guest) = setup_host_and_guest().await;
     let host = Arc::new(host);
 
     let mut handle = host
@@ -97,7 +97,7 @@ async fn exec_start_stream_policy_uses_default_receiver() {
         .unwrap();
     let mut rx = handle.take_stream_receiver().unwrap();
 
-    let msg = read_guest_message(&mut guest, &mut decoder).await;
+    let msg = read_guest_message(&mut guest).await;
     assert_eq!(msg.msg_type, MSG_EXEC_START);
     send_exec_output(
         &mut guest,
@@ -125,7 +125,7 @@ async fn exec_start_stream_policy_uses_default_receiver() {
 
 #[tokio::test]
 async fn exec_start_rejects_receiver_without_stream_policy() {
-    let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+    let (host, mut guest) = setup_host_and_guest().await;
     let host = Arc::new(host);
 
     let err = match host
@@ -148,12 +148,12 @@ async fn exec_start_rejects_receiver_without_stream_policy() {
     assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
     assert_eq!(operation_count(&host), 0);
 
-    assert_connection_accepts_exec_operation(&host, &mut guest, &mut decoder).await;
+    assert_connection_accepts_exec_operation(&host, &mut guest).await;
 }
 
 #[tokio::test]
 async fn exec_operation_stream_rejects_non_streaming_policy() {
-    let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+    let (host, mut guest) = setup_host_and_guest().await;
     let host = Arc::new(host);
 
     let err = match host
@@ -176,12 +176,12 @@ async fn exec_operation_stream_rejects_non_streaming_policy() {
     assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
     assert_eq!(operation_count(&host), 0);
 
-    assert_connection_accepts_exec_operation(&host, &mut guest, &mut decoder).await;
+    assert_connection_accepts_exec_operation(&host, &mut guest).await;
 }
 
 #[tokio::test]
 async fn exec_start_encode_error_does_not_register_or_send_frame() {
-    let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+    let (host, mut guest) = setup_host_and_guest().await;
     let host = Arc::new(host);
 
     let err = match host
@@ -207,12 +207,12 @@ async fn exec_start_encode_error_does_not_register_or_send_frame() {
     assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
     assert_eq!(operation_count(&host), 0);
 
-    assert_connection_accepts_exec_operation(&host, &mut guest, &mut decoder).await;
+    assert_connection_accepts_exec_operation(&host, &mut guest).await;
 }
 
 #[tokio::test]
 async fn exec_start_rejects_zero_timeout_without_sending_frame() {
-    let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+    let (host, mut guest) = setup_host_and_guest().await;
     let host = Arc::new(host);
 
     let err = match host
@@ -235,12 +235,12 @@ async fn exec_start_rejects_zero_timeout_without_sending_frame() {
     assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
     assert_eq!(operation_count(&host), 0);
 
-    assert_connection_accepts_exec_operation(&host, &mut guest, &mut decoder).await;
+    assert_connection_accepts_exec_operation(&host, &mut guest).await;
 }
 
 #[tokio::test]
 async fn exec_operation_stream_dispatches_stdout_stderr_and_closes_on_result() {
-    let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+    let (host, mut guest) = setup_host_and_guest().await;
     let mut handle = host
         .exec_operation_stream(ExecStreamRequest {
             timeout_ms: 5000,
@@ -263,7 +263,7 @@ async fn exec_operation_stream_dispatches_stdout_stderr_and_closes_on_result() {
         .unwrap();
     let mut rx = handle.take_stream_receiver().unwrap();
 
-    let msg = read_guest_message(&mut guest, &mut decoder).await;
+    let msg = read_guest_message(&mut guest).await;
     assert_eq!(msg.msg_type, MSG_EXEC_START);
     send_exec_output(
         &mut guest,
@@ -309,7 +309,7 @@ async fn exec_operation_stream_dispatches_stdout_stderr_and_closes_on_result() {
 
 #[tokio::test]
 async fn exec_operation_stream_full_channel_closes_stream_and_marks_result() {
-    let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+    let (host, mut guest) = setup_host_and_guest().await;
     let mut handle = host
         .exec_operation_stream(ExecStreamRequest {
             timeout_ms: 5000,
@@ -329,7 +329,7 @@ async fn exec_operation_stream_full_channel_closes_stream_and_marks_result() {
         .unwrap();
     let mut rx = handle.take_stream_receiver().unwrap();
 
-    let msg = read_guest_message(&mut guest, &mut decoder).await;
+    let msg = read_guest_message(&mut guest).await;
     send_exec_output(
         &mut guest,
         msg.seq,
@@ -366,7 +366,7 @@ async fn exec_operation_stream_full_channel_closes_stream_and_marks_result() {
 
 #[tokio::test]
 async fn exec_operation_stream_many_chunks_soak_does_not_block_terminal_result() {
-    let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+    let (host, mut guest) = setup_host_and_guest().await;
     let mut handle = host
         .exec_operation_stream(ExecStreamRequest {
             timeout_ms: 5000,
@@ -386,7 +386,7 @@ async fn exec_operation_stream_many_chunks_soak_does_not_block_terminal_result()
         .unwrap();
     let mut rx = handle.take_stream_receiver().unwrap();
 
-    let msg = read_guest_message(&mut guest, &mut decoder).await;
+    let msg = read_guest_message(&mut guest).await;
     assert_eq!(msg.msg_type, MSG_EXEC_START);
     for output_seq in 0..32 {
         send_exec_output(
@@ -424,7 +424,7 @@ async fn exec_operation_stream_many_chunks_soak_does_not_block_terminal_result()
 
 #[tokio::test]
 async fn exec_output_for_non_streamed_side_poisons_connection() {
-    let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+    let (host, mut guest) = setup_host_and_guest().await;
     let handle = host
         .exec_operation_stream(ExecStreamRequest {
             timeout_ms: 5000,
@@ -443,7 +443,7 @@ async fn exec_output_for_non_streamed_side_poisons_connection() {
         .await
         .unwrap();
 
-    let msg = read_guest_message(&mut guest, &mut decoder).await;
+    let msg = read_guest_message(&mut guest).await;
     send_exec_output(
         &mut guest,
         msg.seq,
@@ -463,7 +463,7 @@ async fn exec_output_for_non_streamed_side_poisons_connection() {
 
 #[tokio::test]
 async fn exec_output_seq_gap_poisons_connection() {
-    let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+    let (host, mut guest) = setup_host_and_guest().await;
     let handle = host
         .exec_operation_stream(ExecStreamRequest {
             timeout_ms: 5000,
@@ -482,7 +482,7 @@ async fn exec_output_seq_gap_poisons_connection() {
         .await
         .unwrap();
 
-    let msg = read_guest_message(&mut guest, &mut decoder).await;
+    let msg = read_guest_message(&mut guest).await;
     send_exec_output(
         &mut guest,
         msg.seq,
@@ -502,7 +502,7 @@ async fn exec_output_seq_gap_poisons_connection() {
 
 #[tokio::test]
 async fn exec_output_zero_stream_limit_accepts_empty_truncation_marker() {
-    let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+    let (host, mut guest) = setup_host_and_guest().await;
     let mut handle = host
         .exec_operation_stream(ExecStreamRequest {
             timeout_ms: 5000,
@@ -522,7 +522,7 @@ async fn exec_output_zero_stream_limit_accepts_empty_truncation_marker() {
         .unwrap();
     let mut rx = handle.take_stream_receiver().unwrap();
 
-    let msg = read_guest_message(&mut guest, &mut decoder).await;
+    let msg = read_guest_message(&mut guest).await;
     send_exec_output(&mut guest, msg.seq, 0, ExecOutputStream::Stdout, b"", true).await;
     send_discarded_exec_result(
         &mut guest,
@@ -541,7 +541,7 @@ async fn exec_output_zero_stream_limit_accepts_empty_truncation_marker() {
 
 #[tokio::test]
 async fn exec_output_empty_non_truncated_poisons_connection() {
-    let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+    let (host, mut guest) = setup_host_and_guest().await;
     let handle = host
         .exec_operation_stream(ExecStreamRequest {
             timeout_ms: 5000,
@@ -560,7 +560,7 @@ async fn exec_output_empty_non_truncated_poisons_connection() {
         .await
         .unwrap();
 
-    let msg = read_guest_message(&mut guest, &mut decoder).await;
+    let msg = read_guest_message(&mut guest).await;
     send_exec_output(&mut guest, msg.seq, 0, ExecOutputStream::Stdout, b"", false).await;
 
     host.wait_until_closed(Duration::from_secs(5))
@@ -572,7 +572,7 @@ async fn exec_output_empty_non_truncated_poisons_connection() {
 
 #[tokio::test]
 async fn exec_output_over_requested_chunk_limit_poisons_connection() {
-    let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+    let (host, mut guest) = setup_host_and_guest().await;
     let handle = host
         .exec_operation_stream(ExecStreamRequest {
             timeout_ms: 5000,
@@ -591,7 +591,7 @@ async fn exec_output_over_requested_chunk_limit_poisons_connection() {
         .await
         .unwrap();
 
-    let msg = read_guest_message(&mut guest, &mut decoder).await;
+    let msg = read_guest_message(&mut guest).await;
     send_exec_output(
         &mut guest,
         msg.seq,
@@ -611,7 +611,7 @@ async fn exec_output_over_requested_chunk_limit_poisons_connection() {
 
 #[tokio::test]
 async fn exec_output_over_requested_stream_limit_poisons_connection() {
-    let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+    let (host, mut guest) = setup_host_and_guest().await;
     let handle = host
         .exec_operation_stream(ExecStreamRequest {
             timeout_ms: 5000,
@@ -630,7 +630,7 @@ async fn exec_output_over_requested_stream_limit_poisons_connection() {
         .await
         .unwrap();
 
-    let msg = read_guest_message(&mut guest, &mut decoder).await;
+    let msg = read_guest_message(&mut guest).await;
     send_exec_output(
         &mut guest,
         msg.seq,
@@ -659,7 +659,7 @@ async fn exec_output_over_requested_stream_limit_poisons_connection() {
 
 #[tokio::test]
 async fn exec_output_after_truncation_poisons_connection() {
-    let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+    let (host, mut guest) = setup_host_and_guest().await;
     let handle = host
         .exec_operation_stream(ExecStreamRequest {
             timeout_ms: 5000,
@@ -678,7 +678,7 @@ async fn exec_output_after_truncation_poisons_connection() {
         .await
         .unwrap();
 
-    let msg = read_guest_message(&mut guest, &mut decoder).await;
+    let msg = read_guest_message(&mut guest).await;
     send_exec_output(&mut guest, msg.seq, 0, ExecOutputStream::Stdout, b"", true).await;
     send_exec_output(
         &mut guest,
@@ -699,7 +699,7 @@ async fn exec_output_after_truncation_poisons_connection() {
 
 #[tokio::test]
 async fn exec_operation_stream_dropped_receiver_does_not_block_result() {
-    let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+    let (host, mut guest) = setup_host_and_guest().await;
     let mut handle = host
         .exec_operation_stream(ExecStreamRequest {
             timeout_ms: 5000,
@@ -719,7 +719,7 @@ async fn exec_operation_stream_dropped_receiver_does_not_block_result() {
         .unwrap();
     drop(handle.take_stream_receiver());
 
-    let msg = read_guest_message(&mut guest, &mut decoder).await;
+    let msg = read_guest_message(&mut guest).await;
     send_exec_output(
         &mut guest,
         msg.seq,

--- a/crates/vsock-host/src/tests/file.rs
+++ b/crates/vsock-host/src/tests/file.rs
@@ -20,7 +20,7 @@ use crate::{CopyFileOptions, operation_tracker::NormalOperationReadiness};
 
 #[tokio::test]
 async fn copy_file_rejects_max_bytes_above_stream_budget() {
-    let (host, _guest, _decoder) = setup_host_and_guest().await;
+    let (host, _guest) = setup_host_and_guest().await;
     let err = host
         .copy_file(
             "/tmp/large.log",
@@ -40,14 +40,14 @@ async fn copy_file_rejects_max_bytes_above_stream_budget() {
 
 #[tokio::test]
 async fn read_file_returns_content_and_missing() {
-    let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+    let (host, mut guest) = setup_host_and_guest().await;
     let host = Arc::new(host);
 
     let read_task = {
         let host = Arc::clone(&host);
         tokio::spawn(async move { host.read_file("/tmp/session.txt", 1024, 5000).await })
     };
-    let msg = read_guest_message(&mut guest, &mut decoder).await;
+    let msg = read_guest_message(&mut guest).await;
     assert_eq!(msg.msg_type, MSG_EXEC_START);
     let decoded = vsock_proto::decode_exec_start(&msg.payload).unwrap();
     assert_eq!(decoded.label, "read-file");
@@ -68,7 +68,7 @@ async fn read_file_returns_content_and_missing() {
         let host = Arc::clone(&host);
         tokio::spawn(async move { host.read_file("/tmp/missing.txt", 1024, 5000).await })
     };
-    let msg = read_guest_message(&mut guest, &mut decoder).await;
+    let msg = read_guest_message(&mut guest).await;
     assert_eq!(msg.msg_type, MSG_EXEC_START);
     let decoded = vsock_proto::decode_exec_start(&msg.payload).unwrap();
     assert_eq!(decoded.expected_exit_codes, vec![66]);
@@ -86,10 +86,10 @@ async fn read_file_returns_content_and_missing() {
 
 #[tokio::test]
 async fn read_file_errors_on_truncated_stdout() {
-    let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+    let (host, mut guest) = setup_host_and_guest().await;
     let read_task = tokio::spawn(async move { host.read_file("/tmp/large.txt", 5, 5000).await });
 
-    let msg = read_guest_message(&mut guest, &mut decoder).await;
+    let msg = read_guest_message(&mut guest).await;
     assert_eq!(msg.msg_type, MSG_EXEC_START);
     let payload = vsock_proto::encode_exec_result(
         ExecTermination::Exited { exit_code: 0 },
@@ -113,7 +113,7 @@ async fn read_file_errors_on_truncated_stdout() {
 
 #[tokio::test]
 async fn read_file_rejects_invalid_max_bytes_without_sending_frame() {
-    let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+    let (host, mut guest) = setup_host_and_guest().await;
     let host = Arc::new(host);
 
     let err = host.read_file("/tmp/empty.txt", 0, 5000).await.unwrap_err();
@@ -128,16 +128,16 @@ async fn read_file_rejects_invalid_max_bytes_without_sending_frame() {
 
     assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
     assert_eq!(operation_count(&host), 0);
-    assert_connection_accepts_exec_operation(&host, &mut guest, &mut decoder).await;
+    assert_connection_accepts_exec_operation(&host, &mut guest).await;
 }
 
 #[tokio::test]
 async fn read_file_quotes_guest_path_with_single_quote() {
-    let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+    let (host, mut guest) = setup_host_and_guest().await;
     let read_task =
         tokio::spawn(async move { host.read_file("/tmp/session'one.txt", 1024, 5000).await });
 
-    let msg = read_guest_message(&mut guest, &mut decoder).await;
+    let msg = read_guest_message(&mut guest).await;
     assert_eq!(msg.msg_type, MSG_EXEC_START);
     let decoded = vsock_proto::decode_exec_start(&msg.payload).unwrap();
     assert_eq!(
@@ -159,7 +159,7 @@ async fn read_file_quotes_guest_path_with_single_quote() {
 
 #[tokio::test]
 async fn copy_file_streams_to_temp_then_renames() {
-    let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+    let (host, mut guest) = setup_host_and_guest().await;
     let unique = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap()
@@ -182,7 +182,7 @@ async fn copy_file_streams_to_temp_then_renames() {
         .await
     });
 
-    let msg = read_guest_message(&mut guest, &mut decoder).await;
+    let msg = read_guest_message(&mut guest).await;
     assert_eq!(msg.msg_type, MSG_EXEC_START);
     let decoded = vsock_proto::decode_exec_start(&msg.payload).unwrap();
     assert_eq!(decoded.label, "copy-file");
@@ -239,7 +239,7 @@ async fn copy_file_streams_to_temp_then_renames() {
 
 #[tokio::test]
 async fn copy_file_rejects_invalid_options_without_sending_frame_or_creating_parent() {
-    let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+    let (host, mut guest) = setup_host_and_guest().await;
     let host = Arc::new(host);
     let unique = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
@@ -282,12 +282,12 @@ async fn copy_file_rejects_invalid_options_without_sending_frame_or_creating_par
     assert!(!dir.exists());
     assert_eq!(operation_count(&host), 0);
 
-    assert_connection_accepts_exec_operation(&host, &mut guest, &mut decoder).await;
+    assert_connection_accepts_exec_operation(&host, &mut guest).await;
 }
 
 #[tokio::test]
 async fn copy_file_creates_parent_and_quotes_guest_path_with_single_quote() {
-    let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+    let (host, mut guest) = setup_host_and_guest().await;
     let unique = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap()
@@ -312,7 +312,7 @@ async fn copy_file_creates_parent_and_quotes_guest_path_with_single_quote() {
         .await
     });
 
-    let msg = read_guest_message(&mut guest, &mut decoder).await;
+    let msg = read_guest_message(&mut guest).await;
     assert_eq!(msg.msg_type, MSG_EXEC_START);
     let decoded = vsock_proto::decode_exec_start(&msg.payload).unwrap();
     assert_eq!(
@@ -344,7 +344,7 @@ async fn copy_file_creates_parent_and_quotes_guest_path_with_single_quote() {
 
 #[tokio::test]
 async fn copy_file_removes_temp_without_publishing_on_stream_truncation() {
-    let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+    let (host, mut guest) = setup_host_and_guest().await;
     let unique = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap()
@@ -371,7 +371,7 @@ async fn copy_file_removes_temp_without_publishing_on_stream_truncation() {
         .await
     });
 
-    let msg = read_guest_message(&mut guest, &mut decoder).await;
+    let msg = read_guest_message(&mut guest).await;
     send_exec_output(
         &mut guest,
         msg.seq,
@@ -382,7 +382,7 @@ async fn copy_file_removes_temp_without_publishing_on_stream_truncation() {
     )
     .await;
 
-    let cancel = read_guest_message(&mut guest, &mut decoder).await;
+    let cancel = read_guest_message(&mut guest).await;
     assert_eq!(cancel.msg_type, MSG_EXEC_CANCEL);
     assert_eq!(cancel.seq, msg.seq);
     send_stream_exec_result(&mut guest, msg.seq, ExecTermination::Cancelled, b"").await;
@@ -403,7 +403,7 @@ async fn copy_file_removes_temp_without_publishing_on_stream_truncation() {
 
 #[tokio::test]
 async fn copy_file_nonzero_exit_removes_temp_without_publishing_partial_output() {
-    let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+    let (host, mut guest) = setup_host_and_guest().await;
     let unique = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap()
@@ -430,7 +430,7 @@ async fn copy_file_nonzero_exit_removes_temp_without_publishing_partial_output()
         .await
     });
 
-    let msg = read_guest_message(&mut guest, &mut decoder).await;
+    let msg = read_guest_message(&mut guest).await;
     send_exec_output(
         &mut guest,
         msg.seq,
@@ -464,7 +464,7 @@ async fn copy_file_nonzero_exit_removes_temp_without_publishing_partial_output()
 
 #[tokio::test]
 async fn copy_file_missing_ok_leaves_no_final_or_temp_file() {
-    let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+    let (host, mut guest) = setup_host_and_guest().await;
     let unique = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap()
@@ -490,7 +490,7 @@ async fn copy_file_missing_ok_leaves_no_final_or_temp_file() {
         .await
     });
 
-    let msg = read_guest_message(&mut guest, &mut decoder).await;
+    let msg = read_guest_message(&mut guest).await;
     assert_eq!(msg.msg_type, MSG_EXEC_START);
     let decoded = vsock_proto::decode_exec_start(&msg.payload).unwrap();
     assert_eq!(decoded.expected_exit_codes, vec![66]);
@@ -518,7 +518,7 @@ async fn copy_file_missing_ok_leaves_no_final_or_temp_file() {
 
 #[tokio::test]
 async fn copy_file_missing_without_missing_ok_preserves_existing_file_and_removes_temp() {
-    let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+    let (host, mut guest) = setup_host_and_guest().await;
     let unique = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap()
@@ -545,7 +545,7 @@ async fn copy_file_missing_without_missing_ok_preserves_existing_file_and_remove
         .await
     });
 
-    let msg = read_guest_message(&mut guest, &mut decoder).await;
+    let msg = read_guest_message(&mut guest).await;
     assert_eq!(msg.msg_type, MSG_EXEC_START);
     let decoded = vsock_proto::decode_exec_start(&msg.payload).unwrap();
     assert!(decoded.expected_exit_codes.is_empty());
@@ -573,7 +573,7 @@ async fn copy_file_missing_without_missing_ok_preserves_existing_file_and_remove
 
 #[tokio::test]
 async fn copy_file_cancellation_cancels_guest_exec_operation_and_removes_temp() {
-    let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+    let (host, mut guest) = setup_host_and_guest().await;
     let host = Arc::new(host);
     let unique = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
@@ -602,7 +602,7 @@ async fn copy_file_cancellation_cancels_guest_exec_operation_and_removes_temp() 
             .await
     });
 
-    let start = read_guest_message(&mut guest, &mut decoder).await;
+    let start = read_guest_message(&mut guest).await;
     assert_eq!(start.msg_type, MSG_EXEC_START);
     let temp_paths: Vec<_> = std::fs::read_dir(&dir)
         .unwrap()
@@ -618,7 +618,7 @@ async fn copy_file_cancellation_cancels_guest_exec_operation_and_removes_temp() 
     copy_task.abort();
     assert!(copy_task.await.unwrap_err().is_cancelled());
 
-    let cancel = read_guest_message(&mut guest, &mut decoder).await;
+    let cancel = read_guest_message(&mut guest).await;
     assert_eq!(cancel.msg_type, MSG_EXEC_CANCEL);
     assert_eq!(cancel.seq, start.seq);
     assert!(!host_path.exists());
@@ -666,14 +666,14 @@ async fn test_write_file() {
 
 #[tokio::test]
 async fn write_file_tracks_until_result() {
-    let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+    let (host, mut guest) = setup_host_and_guest().await;
     let host = Arc::new(host);
     let write_task = {
         let host = Arc::clone(&host);
         tokio::spawn(async move { host.write_file("/tmp/tracked.txt", b"hello", false).await })
     };
 
-    let msg = read_guest_message(&mut guest, &mut decoder).await;
+    let msg = read_guest_message(&mut guest).await;
     assert_eq!(msg.msg_type, MSG_WRITE_FILE);
     assert_eq!(
         normal_operation_readiness(&host),
@@ -693,14 +693,14 @@ async fn write_file_tracks_until_result() {
 
 #[tokio::test]
 async fn write_file_guest_failure_releases_tracker() {
-    let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+    let (host, mut guest) = setup_host_and_guest().await;
     let host = Arc::new(host);
     let write_task = {
         let host = Arc::clone(&host);
         tokio::spawn(async move { host.write_file("/tmp/tracked.txt", b"bad", false).await })
     };
 
-    let msg = read_guest_message(&mut guest, &mut decoder).await;
+    let msg = read_guest_message(&mut guest).await;
     assert_eq!(msg.msg_type, MSG_WRITE_FILE);
     assert_eq!(
         normal_operation_readiness(&host),
@@ -721,14 +721,14 @@ async fn write_file_guest_failure_releases_tracker() {
 
 #[tokio::test]
 async fn write_file_error_response_releases_tracker() {
-    let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+    let (host, mut guest) = setup_host_and_guest().await;
     let host = Arc::new(host);
     let write_task = {
         let host = Arc::clone(&host);
         tokio::spawn(async move { host.write_file("/tmp/tracked.txt", b"bad", false).await })
     };
 
-    let msg = read_guest_message(&mut guest, &mut decoder).await;
+    let msg = read_guest_message(&mut guest).await;
     assert_eq!(msg.msg_type, MSG_WRITE_FILE);
     assert_eq!(
         normal_operation_readiness(&host),
@@ -749,14 +749,14 @@ async fn write_file_error_response_releases_tracker() {
 
 #[tokio::test]
 async fn write_file_unexpected_response_keeps_tracker_fail_closed() {
-    let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+    let (host, mut guest) = setup_host_and_guest().await;
     let host = Arc::new(host);
     let write_task = {
         let host = Arc::clone(&host);
         tokio::spawn(async move { host.write_file("/tmp/tracked.txt", b"bad", false).await })
     };
 
-    let msg = read_guest_message(&mut guest, &mut decoder).await;
+    let msg = read_guest_message(&mut guest).await;
     assert_eq!(msg.msg_type, MSG_WRITE_FILE);
     assert_eq!(
         normal_operation_readiness(&host),
@@ -776,14 +776,14 @@ async fn write_file_unexpected_response_keeps_tracker_fail_closed() {
 
 #[tokio::test]
 async fn dropping_write_file_after_request_marks_tracker_not_parkable() {
-    let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+    let (host, mut guest) = setup_host_and_guest().await;
     let host = Arc::new(host);
     let write_task = {
         let host = Arc::clone(&host);
         tokio::spawn(async move { host.write_file("/tmp/pending.txt", b"hello", false).await })
     };
 
-    let msg = read_guest_message(&mut guest, &mut decoder).await;
+    let msg = read_guest_message(&mut guest).await;
     assert_eq!(msg.msg_type, MSG_WRITE_FILE);
     assert_eq!(
         normal_operation_readiness(&host),
@@ -806,7 +806,7 @@ async fn dropping_write_file_after_request_marks_tracker_not_parkable() {
 
 #[tokio::test]
 async fn write_file_cancelled_before_frame_write_does_not_poison_or_send_frame() {
-    let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+    let (host, mut guest) = setup_host_and_guest().await;
     let host = Arc::new(host);
     let writer_guard = host.shared.writer.lock().await;
     let write_task = {
@@ -829,19 +829,19 @@ async fn write_file_cancelled_before_frame_write_does_not_poison_or_send_frame()
     );
 
     drop(writer_guard);
-    assert_connection_accepts_exec_operation(&host, &mut guest, &mut decoder).await;
+    assert_connection_accepts_exec_operation(&host, &mut guest).await;
 }
 
 #[tokio::test]
 async fn write_file_connection_close_after_request_marks_tracker_not_parkable() {
-    let (host, mut guest, mut decoder) = setup_host_and_guest().await;
+    let (host, mut guest) = setup_host_and_guest().await;
     let host = Arc::new(host);
     let write_task = {
         let host = Arc::clone(&host);
         tokio::spawn(async move { host.write_file("/tmp/pending.txt", b"hello", false).await })
     };
 
-    let msg = read_guest_message(&mut guest, &mut decoder).await;
+    let msg = read_guest_message(&mut guest).await;
     assert_eq!(msg.msg_type, MSG_WRITE_FILE);
     assert_eq!(
         normal_operation_readiness(&host),

--- a/crates/vsock-host/src/tests/process.rs
+++ b/crates/vsock-host/src/tests/process.rs
@@ -114,7 +114,7 @@ async fn test_spawn_process_control_uses_operation_seq_and_nonce() {
         let mut decoder = Decoder::new();
         mock_handshake(&mut guest, &mut decoder).await;
 
-        let spawn = read_guest_message(&mut guest, &mut decoder).await;
+        let spawn = read_guest_message(&mut guest).await;
         assert_eq!(spawn.msg_type, MSG_SPAWN_PROCESS);
         let decoded_spawn = vsock_proto::decode_spawn_process(&spawn.payload).unwrap();
         let control_nonce = decoded_spawn
@@ -125,7 +125,7 @@ async fn test_spawn_process_control_uses_operation_seq_and_nonce() {
         let resp = vsock_proto::encode(MSG_SPAWN_PROCESS_RESULT, spawn.seq, &payload).unwrap();
         guest.write_all(&resp).await.unwrap();
 
-        let control = read_guest_message(&mut guest, &mut decoder).await;
+        let control = read_guest_message(&mut guest).await;
         assert_eq!(control.msg_type, MSG_PROCESS_CONTROL);
         let decoded_control = vsock_proto::decode_process_control(&control.payload).unwrap();
         assert_eq!(decoded_control.target_seq, spawn.seq);
@@ -175,7 +175,7 @@ async fn test_spawn_process_concurrent_controls_route_by_request_seq() {
         let mut decoder = Decoder::new();
         mock_handshake(&mut guest, &mut decoder).await;
 
-        let spawn = read_guest_message(&mut guest, &mut decoder).await;
+        let spawn = read_guest_message(&mut guest).await;
         assert_eq!(spawn.msg_type, MSG_SPAWN_PROCESS);
         let decoded_spawn = vsock_proto::decode_spawn_process(&spawn.payload).unwrap();
         let control_nonce = decoded_spawn.control_nonce.unwrap();
@@ -184,7 +184,7 @@ async fn test_spawn_process_concurrent_controls_route_by_request_seq() {
         let resp = vsock_proto::encode(MSG_SPAWN_PROCESS_RESULT, spawn.seq, &payload).unwrap();
         guest.write_all(&resp).await.unwrap();
 
-        let controls = read_guest_messages(&mut guest, &mut decoder, 2).await;
+        let controls = read_guest_messages(&mut guest, 2).await;
         let mut seen = Vec::new();
         for control in controls {
             assert_eq!(control.msg_type, MSG_PROCESS_CONTROL);
@@ -257,7 +257,7 @@ async fn test_spawn_process_control_inactive_status_returns_not_found() {
         let mut decoder = Decoder::new();
         mock_handshake(&mut guest, &mut decoder).await;
 
-        let spawn = read_guest_message(&mut guest, &mut decoder).await;
+        let spawn = read_guest_message(&mut guest).await;
         assert_eq!(spawn.msg_type, MSG_SPAWN_PROCESS);
         let decoded_spawn = vsock_proto::decode_spawn_process(&spawn.payload).unwrap();
         let control_nonce = decoded_spawn.control_nonce.unwrap();
@@ -266,7 +266,7 @@ async fn test_spawn_process_control_inactive_status_returns_not_found() {
         let resp = vsock_proto::encode(MSG_SPAWN_PROCESS_RESULT, spawn.seq, &payload).unwrap();
         guest.write_all(&resp).await.unwrap();
 
-        let control = read_guest_message(&mut guest, &mut decoder).await;
+        let control = read_guest_message(&mut guest).await;
         let decoded_control = vsock_proto::decode_process_control(&control.payload).unwrap();
         assert_eq!(decoded_control.target_seq, spawn.seq);
         assert_eq!(decoded_control.control_nonce, control_nonce);
@@ -307,7 +307,7 @@ async fn test_spawn_process_control_nonce_mismatch_status_returns_permission_den
         let mut decoder = Decoder::new();
         mock_handshake(&mut guest, &mut decoder).await;
 
-        let spawn = read_guest_message(&mut guest, &mut decoder).await;
+        let spawn = read_guest_message(&mut guest).await;
         assert_eq!(spawn.msg_type, MSG_SPAWN_PROCESS);
         let decoded_spawn = vsock_proto::decode_spawn_process(&spawn.payload).unwrap();
         let control_nonce = decoded_spawn.control_nonce.unwrap();
@@ -316,7 +316,7 @@ async fn test_spawn_process_control_nonce_mismatch_status_returns_permission_den
         let resp = vsock_proto::encode(MSG_SPAWN_PROCESS_RESULT, spawn.seq, &payload).unwrap();
         guest.write_all(&resp).await.unwrap();
 
-        let control = read_guest_message(&mut guest, &mut decoder).await;
+        let control = read_guest_message(&mut guest).await;
         let decoded_control = vsock_proto::decode_process_control(&control.payload).unwrap();
         assert_eq!(decoded_control.control_nonce, control_nonce);
 
@@ -356,7 +356,7 @@ async fn test_spawn_process_control_unsupported_status_returns_unsupported() {
         let mut decoder = Decoder::new();
         mock_handshake(&mut guest, &mut decoder).await;
 
-        let spawn = read_guest_message(&mut guest, &mut decoder).await;
+        let spawn = read_guest_message(&mut guest).await;
         assert_eq!(spawn.msg_type, MSG_SPAWN_PROCESS);
         let decoded_spawn = vsock_proto::decode_spawn_process(&spawn.payload).unwrap();
         let control_nonce = decoded_spawn.control_nonce.unwrap();
@@ -365,7 +365,7 @@ async fn test_spawn_process_control_unsupported_status_returns_unsupported() {
         let resp = vsock_proto::encode(MSG_SPAWN_PROCESS_RESULT, spawn.seq, &payload).unwrap();
         guest.write_all(&resp).await.unwrap();
 
-        let control = read_guest_message(&mut guest, &mut decoder).await;
+        let control = read_guest_message(&mut guest).await;
         let decoded_control = vsock_proto::decode_process_control(&control.payload).unwrap();
 
         send_process_control_result(
@@ -404,7 +404,7 @@ async fn test_spawn_process_control_malformed_result_poisons_connection() {
         let mut decoder = Decoder::new();
         mock_handshake(&mut guest, &mut decoder).await;
 
-        let spawn = read_guest_message(&mut guest, &mut decoder).await;
+        let spawn = read_guest_message(&mut guest).await;
         assert_eq!(spawn.msg_type, MSG_SPAWN_PROCESS);
         let decoded_spawn = vsock_proto::decode_spawn_process(&spawn.payload).unwrap();
         let control_nonce = decoded_spawn.control_nonce.unwrap();
@@ -413,7 +413,7 @@ async fn test_spawn_process_control_malformed_result_poisons_connection() {
         let resp = vsock_proto::encode(MSG_SPAWN_PROCESS_RESULT, spawn.seq, &payload).unwrap();
         guest.write_all(&resp).await.unwrap();
 
-        let control = read_guest_message(&mut guest, &mut decoder).await;
+        let control = read_guest_message(&mut guest).await;
         let decoded_control = vsock_proto::decode_process_control(&control.payload).unwrap();
 
         send_process_control_result(
@@ -460,7 +460,7 @@ async fn test_spawn_process_control_result_nonce_mismatch_poisons_connection() {
         let mut decoder = Decoder::new();
         mock_handshake(&mut guest, &mut decoder).await;
 
-        let spawn = read_guest_message(&mut guest, &mut decoder).await;
+        let spawn = read_guest_message(&mut guest).await;
         assert_eq!(spawn.msg_type, MSG_SPAWN_PROCESS);
         let decoded_spawn = vsock_proto::decode_spawn_process(&spawn.payload).unwrap();
         let mut wrong_nonce = decoded_spawn.control_nonce.unwrap();
@@ -470,7 +470,7 @@ async fn test_spawn_process_control_result_nonce_mismatch_poisons_connection() {
         let resp = vsock_proto::encode(MSG_SPAWN_PROCESS_RESULT, spawn.seq, &payload).unwrap();
         guest.write_all(&resp).await.unwrap();
 
-        let control = read_guest_message(&mut guest, &mut decoder).await;
+        let control = read_guest_message(&mut guest).await;
         let decoded_control = vsock_proto::decode_process_control(&control.payload).unwrap();
 
         send_process_control_result(
@@ -517,7 +517,7 @@ async fn test_spawn_process_control_result_message_id_mismatch_poisons_connectio
         let mut decoder = Decoder::new();
         mock_handshake(&mut guest, &mut decoder).await;
 
-        let spawn = read_guest_message(&mut guest, &mut decoder).await;
+        let spawn = read_guest_message(&mut guest).await;
         assert_eq!(spawn.msg_type, MSG_SPAWN_PROCESS);
         let decoded_spawn = vsock_proto::decode_spawn_process(&spawn.payload).unwrap();
         let control_nonce = decoded_spawn.control_nonce.unwrap();
@@ -526,7 +526,7 @@ async fn test_spawn_process_control_result_message_id_mismatch_poisons_connectio
         let resp = vsock_proto::encode(MSG_SPAWN_PROCESS_RESULT, spawn.seq, &payload).unwrap();
         guest.write_all(&resp).await.unwrap();
 
-        let control = read_guest_message(&mut guest, &mut decoder).await;
+        let control = read_guest_message(&mut guest).await;
         let decoded_control = vsock_proto::decode_process_control(&control.payload).unwrap();
 
         send_process_control_result(
@@ -573,16 +573,16 @@ async fn test_spawn_process_control_timeout_cleans_pending_without_poisoning() {
         let mut decoder = Decoder::new();
         mock_handshake(&mut guest, &mut decoder).await;
 
-        let spawn = read_guest_message(&mut guest, &mut decoder).await;
+        let spawn = read_guest_message(&mut guest).await;
         assert_eq!(spawn.msg_type, MSG_SPAWN_PROCESS);
         let payload = vsock_proto::encode_spawn_process_result(45);
         let resp = vsock_proto::encode(MSG_SPAWN_PROCESS_RESULT, spawn.seq, &payload).unwrap();
         guest.write_all(&resp).await.unwrap();
 
-        let control = read_guest_message(&mut guest, &mut decoder).await;
+        let control = read_guest_message(&mut guest).await;
         assert_eq!(control.msg_type, MSG_PROCESS_CONTROL);
 
-        let exec = read_guest_message(&mut guest, &mut decoder).await;
+        let exec = read_guest_message(&mut guest).await;
         assert_eq!(exec.msg_type, MSG_EXEC_START);
         send_exec_result(
             &mut guest,

--- a/crates/vsock-host/src/tests/support.rs
+++ b/crates/vsock-host/src/tests/support.rs
@@ -6,8 +6,9 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::UnixStream;
 use tokio::time::Instant;
 use vsock_proto::{
-    Decoder, ExecCapturedOutput, ExecOutputStream, ExecTermination, MSG_EXEC_OUTPUT,
-    MSG_EXEC_RESULT, MSG_EXEC_START, MSG_PING, MSG_PONG, MSG_READY, RawMessage,
+    Decoder, ExecCapturedOutput, ExecOutputStream, ExecTermination, HEADER_SIZE, MAX_MESSAGE_SIZE,
+    MIN_BODY_SIZE, MSG_EXEC_OUTPUT, MSG_EXEC_RESULT, MSG_EXEC_START, MSG_PING, MSG_PONG, MSG_READY,
+    RawMessage,
 };
 
 use crate::{
@@ -72,43 +73,59 @@ pub(crate) fn drop_started_pending_normal_request_write_guard(host: &VsockHost) 
     drop(guard);
 }
 
-pub(crate) async fn read_guest_message(
-    stream: &mut UnixStream,
-    decoder: &mut Decoder,
-) -> RawMessage {
-    let mut buf = [0u8; 4096];
-    loop {
-        let n = stream.read(&mut buf).await.unwrap();
-        assert_ne!(n, 0, "connection closed before message");
-        let mut msgs = decoder.decode(&buf[..n]).unwrap();
-        if !msgs.is_empty() {
-            return msgs.remove(0);
-        }
+pub(crate) async fn read_guest_message(stream: &mut UnixStream) -> RawMessage {
+    let mut header = [0u8; HEADER_SIZE];
+    stream.read_exact(&mut header).await.unwrap();
+
+    let body_len = u32::from_be_bytes(header) as usize;
+    assert!(
+        (MIN_BODY_SIZE..=MAX_MESSAGE_SIZE).contains(&body_len),
+        "invalid message body length: {body_len}",
+    );
+
+    let mut body = vec![0u8; body_len];
+    stream.read_exact(&mut body).await.unwrap();
+
+    RawMessage {
+        msg_type: body[0],
+        seq: u32::from_be_bytes(body[1..MIN_BODY_SIZE].try_into().unwrap()),
+        payload: body[MIN_BODY_SIZE..].to_vec(),
     }
 }
 
-pub(crate) async fn read_guest_messages(
-    stream: &mut UnixStream,
-    decoder: &mut Decoder,
-    count: usize,
-) -> Vec<RawMessage> {
+pub(crate) async fn read_guest_messages(stream: &mut UnixStream, count: usize) -> Vec<RawMessage> {
     let mut messages = Vec::new();
-    let mut buf = [0u8; 4096];
     while messages.len() < count {
-        let n = stream.read(&mut buf).await.unwrap();
-        assert_ne!(n, 0, "connection closed before messages");
-        messages.extend(decoder.decode(&buf[..n]).unwrap());
+        messages.push(read_guest_message(stream).await);
     }
     messages
 }
 
-pub(crate) async fn setup_host_and_guest() -> (VsockHost, UnixStream, Decoder) {
+#[tokio::test]
+async fn read_guest_message_preserves_coalesced_frames() {
+    let (mut writer, mut reader) = make_pair();
+    let mut frames = vsock_proto::encode(MSG_EXEC_START, 7, b"first").unwrap();
+    frames.extend_from_slice(&vsock_proto::encode(MSG_EXEC_RESULT, 8, b"second").unwrap());
+    writer.write_all(&frames).await.unwrap();
+
+    let first = read_guest_message(&mut reader).await;
+    let second = read_guest_message(&mut reader).await;
+
+    assert_eq!(first.msg_type, MSG_EXEC_START);
+    assert_eq!(first.seq, 7);
+    assert_eq!(first.payload, b"first");
+    assert_eq!(second.msg_type, MSG_EXEC_RESULT);
+    assert_eq!(second.seq, 8);
+    assert_eq!(second.payload, b"second");
+}
+
+pub(crate) async fn setup_host_and_guest() -> (VsockHost, UnixStream) {
     let (host_stream, mut guest) = make_pair();
     let host_task = tokio::spawn(async move { host_from_stream(host_stream).await.unwrap() });
     let mut decoder = Decoder::new();
     mock_handshake(&mut guest, &mut decoder).await;
     let host = host_task.await.unwrap();
-    (host, guest, decoder)
+    (host, guest)
 }
 
 fn exec_result_payload(termination: ExecTermination, stdout: &[u8], stderr: &[u8]) -> Vec<u8> {
@@ -209,13 +226,12 @@ pub(crate) async fn wait_for_operation_count(host: &VsockHost, expected: usize) 
 pub(crate) async fn assert_connection_accepts_exec_operation(
     host: &Arc<VsockHost>,
     guest: &mut UnixStream,
-    decoder: &mut Decoder,
 ) {
     let exec_task = {
         let host = Arc::clone(host);
         tokio::spawn(async move { host.exec("echo ok", 5000, &[], false).await })
     };
-    let msg = read_guest_message(guest, decoder).await;
+    let msg = read_guest_message(guest).await;
     assert_eq!(msg.msg_type, MSG_EXEC_START);
     let decoded = vsock_proto::decode_exec_start(&msg.payload).unwrap();
     assert_eq!(decoded.command, "echo ok");


### PR DESCRIPTION
## Summary
- change vsock-host test helpers to read exactly one length-prefixed frame per call
- remove decoder plumbing from shared guest-message helpers and setup helper call sites
- add regression coverage for two coalesced frames written in one buffer

## Testing
- cargo fmt --manifest-path crates/Cargo.toml --all --check
- cargo clippy --manifest-path crates/Cargo.toml -p vsock-host --all-targets --all-features -- -D warnings
- cargo test --manifest-path crates/Cargo.toml -p vsock-host

Closes #13527