### PR TITLE
perf(runner): chunk network log uploads

### DIFF
--- a/crates/runner/src/network_logs.rs
+++ b/crates/runner/src/network_logs.rs
@@ -2,6 +2,7 @@ use std::path::Path;
 
 use api_contracts::generated::routes;
 use serde::{Deserialize, Serialize};
+use tokio::io::{AsyncBufReadExt, BufReader};
 use tracing::{info, warn};
 
 use crate::http::HttpClient;
@@ -25,8 +26,13 @@ struct NetworkLogPayload {
     network_logs: Vec<NetworkLog>,
 }
 
+const NETWORK_LOG_UPLOAD_MAX_BATCH_ENTRIES: usize = 500;
+const NETWORK_LOG_UPLOAD_MAX_BATCH_BYTES: usize = 1024 * 1024;
+const NETWORK_LOG_UPLOAD_PAYLOAD_OVERHEAD_BYTES: usize = 64;
+const NETWORK_LOG_UPLOAD_ENTRY_OVERHEAD_BYTES: usize = 1;
+
 /// Upload network logs from the per-run JSONL file.
-/// Reads the file at `path`, POSTs to telemetry endpoint,
+/// Reads the file at `path`, POSTs bounded batches to telemetry endpoint,
 /// and keeps the local file for debugging/log GC. Best-effort — failures only warn.
 pub async fn upload_network_logs(
     http: &HttpClient,
@@ -34,8 +40,8 @@ pub async fn upload_network_logs(
     sandbox_token: &str,
     path: &Path,
 ) {
-    let content = match tokio::fs::read_to_string(path).await {
-        Ok(c) => c,
+    let file = match tokio::fs::File::open(path).await {
+        Ok(file) => file,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => return,
         Err(e) => {
             warn!(run_id = %run_id, error = %e, "failed to read network logs");
@@ -43,23 +49,119 @@ pub async fn upload_network_logs(
         }
     };
 
-    let logs: Vec<NetworkLog> = content
-        .lines()
-        .filter(|line| !line.trim().is_empty())
-        .filter_map(|line| match serde_json::from_str(line) {
-            Ok(log) => Some(log),
+    let mut lines = BufReader::new(file).lines();
+    let mut batch = Vec::with_capacity(NETWORK_LOG_UPLOAD_MAX_BATCH_ENTRIES);
+    let mut batch_bytes = empty_batch_estimated_bytes(&run_id);
+    let mut batch_index = 0usize;
+    let mut total_uploaded = 0usize;
+
+    loop {
+        let line = match lines.next_line().await {
+            Ok(Some(line)) => line,
+            Ok(None) => break,
+            Err(e) => {
+                warn!(run_id = %run_id, error = %e, "failed to read network logs");
+                return;
+            }
+        };
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+
+        let log = match serde_json::from_str(line) {
+            Ok(log) => log,
             Err(e) => {
                 warn!(run_id = %run_id, error = %e, "malformed network log line");
-                None
+                continue;
             }
-        })
-        .collect();
+        };
+        let entry_bytes = estimated_entry_bytes(line);
 
-    if logs.is_empty() {
+        if !batch.is_empty()
+            && (batch.len() >= NETWORK_LOG_UPLOAD_MAX_BATCH_ENTRIES
+                || batch_bytes.saturating_add(entry_bytes) > NETWORK_LOG_UPLOAD_MAX_BATCH_BYTES)
+            && !flush_network_log_batch(
+                http,
+                run_id,
+                sandbox_token,
+                &mut batch,
+                &mut batch_bytes,
+                &mut batch_index,
+                &mut total_uploaded,
+            )
+            .await
+        {
+            return;
+        }
+
+        batch.push(log);
+        batch_bytes = batch_bytes.saturating_add(entry_bytes);
+
+        if (batch.len() >= NETWORK_LOG_UPLOAD_MAX_BATCH_ENTRIES
+            || batch_bytes >= NETWORK_LOG_UPLOAD_MAX_BATCH_BYTES)
+            && !flush_network_log_batch(
+                http,
+                run_id,
+                sandbox_token,
+                &mut batch,
+                &mut batch_bytes,
+                &mut batch_index,
+                &mut total_uploaded,
+            )
+            .await
+        {
+            return;
+        }
+    }
+
+    if !flush_network_log_batch(
+        http,
+        run_id,
+        sandbox_token,
+        &mut batch,
+        &mut batch_bytes,
+        &mut batch_index,
+        &mut total_uploaded,
+    )
+    .await
+    {
         return;
     }
 
-    info!(run_id = %run_id, count = logs.len(), "uploading network logs");
+    if total_uploaded > 0 {
+        info!(
+            run_id = %run_id,
+            batches = batch_index,
+            count = total_uploaded,
+            "uploaded network logs"
+        );
+    }
+}
+
+async fn flush_network_log_batch(
+    http: &HttpClient,
+    run_id: RunId,
+    sandbox_token: &str,
+    batch: &mut Vec<NetworkLog>,
+    batch_bytes: &mut usize,
+    batch_index: &mut usize,
+    total_uploaded: &mut usize,
+) -> bool {
+    if batch.is_empty() {
+        return true;
+    }
+
+    *batch_index += 1;
+    let batch_index = *batch_index;
+    let logs = std::mem::replace(
+        batch,
+        Vec::with_capacity(NETWORK_LOG_UPLOAD_MAX_BATCH_ENTRIES),
+    );
+    *batch_bytes = empty_batch_estimated_bytes(&run_id);
+    let count = logs.len();
+
+    info!(run_id = %run_id, batch_index, count, "uploading network log batch");
 
     let payload = NetworkLogPayload {
         run_id: run_id.to_string(),
@@ -75,14 +177,37 @@ pub async fn upload_network_logs(
     match result {
         Ok(resp) if resp.status().is_success() => {
             // File is kept locally for debugging; gc_job_logs deletes after 7 days.
+            *total_uploaded += count;
+            true
         }
         Ok(resp) => {
-            warn!(run_id = %run_id, status = %resp.status(), "network logs upload rejected");
+            warn!(
+                run_id = %run_id,
+                batch_index,
+                status = %resp.status(),
+                "network logs upload rejected"
+            );
+            false
         }
         Err(e) => {
-            warn!(run_id = %run_id, error = %e, "network logs upload failed");
+            warn!(
+                run_id = %run_id,
+                batch_index,
+                error = %e,
+                "network logs upload failed"
+            );
+            false
         }
     }
+}
+
+fn empty_batch_estimated_bytes(run_id: &RunId) -> usize {
+    NETWORK_LOG_UPLOAD_PAYLOAD_OVERHEAD_BYTES + run_id.to_string().len()
+}
+
+fn estimated_entry_bytes(line: &str) -> usize {
+    line.len()
+        .saturating_add(NETWORK_LOG_UPLOAD_ENTRY_OVERHEAD_BYTES)
 }
 
 #[cfg(test)]
@@ -103,6 +228,14 @@ mod tests {
 
     fn network_log_file(dir: &tempfile::TempDir) -> std::path::PathBuf {
         dir.path().join("network.jsonl")
+    }
+
+    fn network_log_content(logs: &[serde_json::Value]) -> String {
+        logs.iter()
+            .map(|log| serde_json::to_string(log).unwrap())
+            .collect::<Vec<_>>()
+            .join("\n")
+            + "\n"
     }
 
     #[test]
@@ -193,19 +326,128 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn upload_network_logs_splits_batches_by_entry_limit() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = network_log_file(&dir);
+        let run_id = RunId::nil();
+        let logs: Vec<_> = (0..=NETWORK_LOG_UPLOAD_MAX_BATCH_ENTRIES)
+            .map(|idx| {
+                json!({
+                    "timestamp": "2026-02-15T10:00:00Z",
+                    "host": format!("host-{idx}.example"),
+                    "sequence": idx,
+                })
+            })
+            .collect();
+        let content = network_log_content(&logs);
+        tokio::fs::write(&path, &content).await.unwrap();
+
+        let server = MockServer::start_async().await;
+        let first_expected = json!({
+            "runId": run_id.to_string(),
+            "networkLogs": logs[..NETWORK_LOG_UPLOAD_MAX_BATCH_ENTRIES].to_vec(),
+        });
+        let second_expected = json!({
+            "runId": run_id.to_string(),
+            "networkLogs": logs[NETWORK_LOG_UPLOAD_MAX_BATCH_ENTRIES..].to_vec(),
+        });
+        let first_upload = server
+            .mock_async(move |when, then| {
+                when.method(POST)
+                    .path("/api/webhooks/agent/telemetry")
+                    .json_body(first_expected.clone());
+                then.status(200);
+            })
+            .await;
+        let second_upload = server
+            .mock_async(move |when, then| {
+                when.method(POST)
+                    .path("/api/webhooks/agent/telemetry")
+                    .json_body(second_expected.clone());
+                then.status(200);
+            })
+            .await;
+
+        let http = http_for_server(&server);
+        upload_network_logs(&http, run_id, SANDBOX_TOKEN, &path).await;
+
+        first_upload.assert_calls_async(1).await;
+        second_upload.assert_calls_async(1).await;
+        assert_eq!(tokio::fs::read_to_string(&path).await.unwrap(), content);
+    }
+
+    #[tokio::test]
+    async fn upload_network_logs_splits_batches_by_estimated_bytes() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = network_log_file(&dir);
+        let run_id = RunId::nil();
+        let large_value = "x".repeat(NETWORK_LOG_UPLOAD_MAX_BATCH_BYTES / 2);
+        let first = json!({
+            "timestamp": "2026-02-15T10:00:00Z",
+            "host": "large-first.example",
+            "body": large_value,
+        });
+        let second = json!({
+            "timestamp": "2026-02-15T10:00:01Z",
+            "host": "large-second.example",
+            "body": large_value,
+        });
+        let logs = vec![first.clone(), second.clone()];
+        let content = network_log_content(&logs);
+        tokio::fs::write(&path, &content).await.unwrap();
+
+        let server = MockServer::start_async().await;
+        let first_expected = json!({
+            "runId": run_id.to_string(),
+            "networkLogs": [first],
+        });
+        let second_expected = json!({
+            "runId": run_id.to_string(),
+            "networkLogs": [second],
+        });
+        let first_upload = server
+            .mock_async(move |when, then| {
+                when.method(POST)
+                    .path("/api/webhooks/agent/telemetry")
+                    .json_body(first_expected.clone());
+                then.status(200);
+            })
+            .await;
+        let second_upload = server
+            .mock_async(move |when, then| {
+                when.method(POST)
+                    .path("/api/webhooks/agent/telemetry")
+                    .json_body(second_expected.clone());
+                then.status(200);
+            })
+            .await;
+
+        let http = http_for_server(&server);
+        upload_network_logs(&http, run_id, SANDBOX_TOKEN, &path).await;
+
+        first_upload.assert_calls_async(1).await;
+        second_upload.assert_calls_async(1).await;
+    }
+
+    #[tokio::test]
     async fn upload_network_logs_skips_malformed_lines() {
         let dir = tempfile::tempdir().unwrap();
         let path = network_log_file(&dir);
         let run_id = RunId::nil();
-        let valid = json!({
+        let first = json!({
             "timestamp": "2026-02-15T10:00:00Z",
-            "host": "valid.example",
+            "host": "first-valid.example",
+        });
+        let second = json!({
+            "timestamp": "2026-02-15T10:00:01Z",
+            "host": "second-valid.example",
         });
         tokio::fs::write(
             &path,
             format!(
-                "{}\nnot json with invalid.example\n\n",
-                serde_json::to_string(&valid).unwrap()
+                "{}\nnot json with invalid.example\n{}\n\n",
+                serde_json::to_string(&first).unwrap(),
+                serde_json::to_string(&second).unwrap()
             ),
         )
         .await
@@ -214,7 +456,7 @@ mod tests {
         let server = MockServer::start_async().await;
         let expected = json!({
             "runId": run_id.to_string(),
-            "networkLogs": [valid],
+            "networkLogs": [first, second],
         });
         let upload = server
             .mock_async(move |when, then| {
@@ -229,6 +471,71 @@ mod tests {
         upload_network_logs(&http, run_id, SANDBOX_TOKEN, &path).await;
 
         upload.assert_calls_async(1).await;
+    }
+
+    #[tokio::test]
+    async fn upload_network_logs_stops_after_rejected_batch() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = network_log_file(&dir);
+        let run_id = RunId::nil();
+        let logs: Vec<_> = (0..(NETWORK_LOG_UPLOAD_MAX_BATCH_ENTRIES * 2 + 1))
+            .map(|idx| {
+                json!({
+                    "timestamp": "2026-02-15T10:00:00Z",
+                    "host": format!("host-{idx}.example"),
+                    "sequence": idx,
+                })
+            })
+            .collect();
+        tokio::fs::write(&path, network_log_content(&logs))
+            .await
+            .unwrap();
+
+        let server = MockServer::start_async().await;
+        let first_expected = json!({
+            "runId": run_id.to_string(),
+            "networkLogs": logs[..NETWORK_LOG_UPLOAD_MAX_BATCH_ENTRIES].to_vec(),
+        });
+        let second_expected = json!({
+            "runId": run_id.to_string(),
+            "networkLogs": logs[NETWORK_LOG_UPLOAD_MAX_BATCH_ENTRIES..NETWORK_LOG_UPLOAD_MAX_BATCH_ENTRIES * 2].to_vec(),
+        });
+        let third_expected = json!({
+            "runId": run_id.to_string(),
+            "networkLogs": logs[NETWORK_LOG_UPLOAD_MAX_BATCH_ENTRIES * 2..].to_vec(),
+        });
+        let first_upload = server
+            .mock_async(move |when, then| {
+                when.method(POST)
+                    .path("/api/webhooks/agent/telemetry")
+                    .json_body(first_expected.clone());
+                then.status(200);
+            })
+            .await;
+        let second_upload = server
+            .mock_async(move |when, then| {
+                when.method(POST)
+                    .path("/api/webhooks/agent/telemetry")
+                    .json_body(second_expected.clone());
+                then.status(500);
+            })
+            .await;
+        let third_upload = server
+            .mock_async(move |when, then| {
+                when.method(POST)
+                    .path("/api/webhooks/agent/telemetry")
+                    .json_body(third_expected.clone());
+                then.status(200);
+            })
+            .await;
+
+        let http = http_for_server(&server);
+        upload_network_logs(&http, run_id, SANDBOX_TOKEN, &path).await;
+
+        first_upload.assert_calls_async(1).await;
+        second_upload.assert_calls_async(1).await;
+        third_upload.assert_calls_async(0).await;
+        assert!(path.exists());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- Stream per-run network JSONL with `BufReader::lines()` instead of reading the whole file into memory.
- Upload network logs as sequential bounded telemetry batches by entry count and estimated bytes while preserving the existing `{ runId, networkLogs }` API contract.
- Stop after the first rejected/failed batch without retry or sleep, and keep the local network log file for debugging/GC.

Closes #13525

## Verification
- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `CARGO_BUILD_JOBS=1 CARGO_INCREMENTAL=0 cargo test --manifest-path crates/Cargo.toml --target-dir /tmp/vm4-runner-network-log-upload-target -p runner network_logs`
- `CARGO_BUILD_JOBS=1 CARGO_INCREMENTAL=0 cargo clippy --manifest-path crates/Cargo.toml --target-dir /tmp/vm4-runner-network-log-upload-target -p runner --all-targets -- -D warnings`
- `git diff --check`
- `CARGO_BUILD_JOBS=1 cargo clippy --all-targets --all-features` from `crates/`
