### PR TITLE
refactor: separate guest-agent session metadata capture

### DIFF
--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -300,8 +300,12 @@ pub async fn execute_cli(
                                     diagnostic.message
                                 );
                             }
-                            // Prepare event (fast: mask secrets, add seq) and enqueue
-                            // for background sending.  Never blocks the reading loop.
+                            // Capture checkpoint metadata before event payload preparation
+                            // mutates the event through masking.
+                            events::capture_session_metadata(&event);
+
+                            // Prepare event payload (mask secrets, add seq) and enqueue
+                            // for background sending. Network I/O stays off the reading loop.
                             if let Some(payload) = events::prepare_event(&mut event, seq, masker)
                                 && event_tx
                                     .send(PreparedEvent {

--- a/crates/guest-agent/src/events.rs
+++ b/crates/guest-agent/src/events.rs
@@ -1,7 +1,7 @@
 //! Event sending — forwards masked JSONL events to the webhook endpoint.
 //!
-//! Extracts session ID from the `system/init` event and persists it for
-//! checkpoint use.
+//! Captures framework session metadata for checkpoint use and prepares masked
+//! event payloads for webhook delivery.
 
 use crate::constants;
 use crate::env;
@@ -26,30 +26,30 @@ pub(crate) struct CodexFailureDiagnostic {
 
 /// Send a single event to the webhook, masking secrets first.
 ///
-/// On the init event, extracts and persists the session ID and
-/// session history path.
+/// On framework session-start events, captures the session metadata needed by
+/// checkpoints before preparing the webhook payload.
 pub async fn send_event(
     http: &HttpClient,
     event: &mut Value,
     seq: u32,
     masker: &SecretMasker,
 ) -> Result<(), AgentError> {
+    capture_session_metadata(event);
+
     let Some(payload) = prepare_event(event, seq, masker) else {
         return Ok(());
     };
     post_event(http, &payload).await
 }
 
-/// Prepare an event for sending: extract session ID, add sequence number,
-/// mask secrets, and build the HTTP payload.
+/// Prepare an event webhook payload by adding a sequence number, masking
+/// secrets, and wrapping the event in the HTTP payload shape.
 ///
 /// Returns `None` if there is no API token (local/test mode) or the event
-/// should not be posted.  This function is fast (no I/O) and safe to call
-/// inline in the stdout reading loop.
+/// should not be posted. This function does not perform filesystem or network
+/// I/O; session metadata capture happens in `capture_session_metadata`, and
+/// network delivery happens in `post_event` / `send_event`.
 pub fn prepare_event(event: &mut Value, seq: u32, masker: &SecretMasker) -> Option<Value> {
-    // Extract session ID from init event (must happen before masking)
-    extract_session_id(event);
-
     // No API token → local/test mode; skip posting events.
     if !env::has_api() {
         return None;
@@ -250,8 +250,8 @@ pub(crate) fn extract_claude_tool_info(event: &Value) -> Vec<ClaudeToolEvent<'_>
     results
 }
 
-/// If this is a session-start event, extract the session id and write
-/// the session-history-path file.
+/// If this is a session-start event, capture the session id and persist the
+/// session-history-path metadata files for checkpoint use.
 ///
 /// Both frameworks emit a single id-bearing event near the top of their
 /// JSONL stream:
@@ -263,7 +263,7 @@ pub(crate) fn extract_claude_tool_info(event: &Value) -> Vec<ClaudeToolEvent<'_>
 /// - Codex: `CODEX_SEARCH:{sessions_dir}:{thread_id}` marker — codex
 ///   doesn't write the session file until turn-completion, so resolution
 ///   is deferred to checkpoint time.
-fn extract_session_id(event: &Value) {
+pub fn capture_session_metadata(event: &Value) {
     let parsed = match Framework::from_env() {
         Framework::ClaudeCode => extract_claude_session_id(event),
         Framework::Codex => extract_codex_thread_id(event),
@@ -679,7 +679,7 @@ mod tests {
         );
     }
 
-    // Note: end-to-end coverage of `extract_session_id` (including both
+    // Note: end-to-end coverage of `capture_session_metadata` (including both
     // the Claude `system/init` branch and the codex `thread.started`
     // branch) lives in the integration test suites:
     //   - `tests/integration.rs::send_event_extracts_claude_session_id`

--- a/crates/guest-agent/src/events.rs
+++ b/crates/guest-agent/src/events.rs
@@ -24,7 +24,7 @@ pub(crate) struct CodexFailureDiagnostic {
     pub message: String,
 }
 
-/// Send a single event to the webhook, masking secrets first.
+/// Send a single event to the webhook.
 ///
 /// On framework session-start events, captures the session metadata needed by
 /// checkpoints before preparing the webhook payload.

--- a/crates/guest-agent/src/events.rs
+++ b/crates/guest-agent/src/events.rs
@@ -47,8 +47,8 @@ pub async fn send_event(
 ///
 /// Returns `None` if there is no API token (local/test mode) or the event
 /// should not be posted. This function does not perform filesystem or network
-/// I/O; session metadata capture happens in `capture_session_metadata`, and
-/// network delivery happens in `post_event` / `send_event`.
+/// I/O; session metadata capture is handled separately before payload
+/// preparation, and network delivery happens in `post_event` / `send_event`.
 pub fn prepare_event(event: &mut Value, seq: u32, masker: &SecretMasker) -> Option<Value> {
     // No API token → local/test mode; skip posting events.
     if !env::has_api() {
@@ -263,7 +263,7 @@ pub(crate) fn extract_claude_tool_info(event: &Value) -> Vec<ClaudeToolEvent<'_>
 /// - Codex: `CODEX_SEARCH:{sessions_dir}:{thread_id}` marker — codex
 ///   doesn't write the session file until turn-completion, so resolution
 ///   is deferred to checkpoint time.
-pub fn capture_session_metadata(event: &Value) {
+pub(crate) fn capture_session_metadata(event: &Value) {
     let parsed = match Framework::from_env() {
         Framework::ClaudeCode => extract_claude_session_id(event),
         Framework::Codex => extract_codex_thread_id(event),

--- a/crates/guest-agent/src/session_history.rs
+++ b/crates/guest-agent/src/session_history.rs
@@ -1,7 +1,7 @@
 //! Session-history reader — abstracts over Claude (literal jsonl path) and
 //! codex (`CODEX_SEARCH:{dir}:{id}` marker → recursive scan + optional zstd decode).
 //!
-//! `events::capture_session_metadata` writes one of two payloads to
+//! The event metadata capture path writes one of two payloads to
 //! `paths::session_history_path_file()`:
 //!
 //! - Claude: a literal filesystem path to the `.jsonl` history file.

--- a/crates/guest-agent/src/session_history.rs
+++ b/crates/guest-agent/src/session_history.rs
@@ -1,7 +1,7 @@
 //! Session-history reader — abstracts over Claude (literal jsonl path) and
 //! codex (`CODEX_SEARCH:{dir}:{id}` marker → recursive scan + optional zstd decode).
 //!
-//! `events::extract_session_id` writes one of two payloads to
+//! `events::capture_session_metadata` writes one of two payloads to
 //! `paths::session_history_path_file()`:
 //!
 //! - Claude: a literal filesystem path to the `.jsonl` history file.

--- a/crates/guest-agent/tests/codex_session_resume.rs
+++ b/crates/guest-agent/tests/codex_session_resume.rs
@@ -17,7 +17,7 @@
 //!
 //! # Coverage
 //!
-//! - End-to-end `send_event` → `extract_session_id` → marker write for the
+//! - End-to-end `send_event` → `capture_session_metadata` → marker write for the
 //!   codex `thread.started` event shape.
 //! - `session_history::read_session_history` decodes the marker and walks the
 //!   `YYYY/MM/DD/` codex layout.
@@ -63,7 +63,7 @@ fn setup_env_once() {
 }
 
 /// Serialise tests — they share both LazyLock state and the run-id-scoped
-/// `/tmp/vm0-session-*.txt` files written by `extract_session_id`.
+/// `/tmp/vm0-session-*.txt` files written by `capture_session_metadata`.
 static TEST_MUTEX: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
 
 macro_rules! http_client {
@@ -73,7 +73,7 @@ macro_rules! http_client {
 }
 
 /// Wipe the per-run session-id / history-path files so each test starts
-/// from a clean slate. `extract_session_id` is idempotent (first id wins),
+/// from a clean slate. `capture_session_metadata` is idempotent (first id wins),
 /// so leaving stale files would mask real failures.
 fn reset_session_files() {
     let _ = std::fs::remove_file(guest_agent::paths::session_id_file());
@@ -113,8 +113,8 @@ async fn send_event_extracts_codex_thread_id_and_writes_marker() {
         "thread_id": "0193abcd-ef01-7234-89ab-cdef01234567"
     });
 
-    // No API token → send_event skips the HTTP POST but still runs
-    // extract_session_id, which is the part we want to assert.
+    // No API token → send_event skips the HTTP POST but still captures
+    // session metadata, which is the part we want to assert.
     let result = guest_agent::events::send_event(&http_client!(), &mut event, 1, &masker).await;
     assert!(
         result.is_ok(),

--- a/crates/guest-agent/tests/execute_cli_api_mode.rs
+++ b/crates/guest-agent/tests/execute_cli_api_mode.rs
@@ -6,6 +6,7 @@
 
 mod common;
 
+use base64::Engine;
 use guest_agent::http::HttpClient;
 use guest_agent::masker::SecretMasker;
 use httpmock::prelude::*;
@@ -79,7 +80,8 @@ async fn api_mode_execute_cli_captures_session_metadata_and_sends_events()
     let init_event = server.mock(|when, then| {
         when.method(POST)
             .path("/api/webhooks/agent/events")
-            .body_includes(r#""subtype":"init""#);
+            .body_includes(r#""subtype":"init""#)
+            .body_includes(r#""session_id":"***"#);
         then.status(200);
     });
     let result_event = server.mock(|when, then| {
@@ -89,7 +91,8 @@ async fn api_mode_execute_cli_captures_session_metadata_and_sends_events()
         then.status(200);
     });
 
-    let masker = SecretMasker::from_raw("");
+    let encoded_mock_session_prefix = base64::engine::general_purpose::STANDARD.encode("mock-");
+    let masker = SecretMasker::from_raw(&encoded_mock_session_prefix);
     let cli_result = tokio::time::timeout(
         Duration::from_secs(5),
         guest_agent::cli::execute_cli(

--- a/crates/guest-agent/tests/execute_cli_api_mode.rs
+++ b/crates/guest-agent/tests/execute_cli_api_mode.rs
@@ -1,0 +1,125 @@
+//! API-enabled `execute_cli` should capture session metadata from stdout events
+//! while still delivering webhook events.
+//!
+//! This test lives in its own binary because `guest_agent::env` and
+//! `guest_agent::paths` cache process-wide `VM0_*` values in `LazyLock`s.
+
+mod common;
+
+use guest_agent::http::HttpClient;
+use guest_agent::masker::SecretMasker;
+use httpmock::prelude::*;
+use std::path::Path;
+use std::time::Duration;
+
+struct RunFilesGuard {
+    ops_file: String,
+}
+
+impl RunFilesGuard {
+    fn new() -> Self {
+        let ops_file = guest_common::telemetry::sandbox_ops_log().to_string();
+        cleanup_run_files(&ops_file);
+        Self { ops_file }
+    }
+}
+
+impl Drop for RunFilesGuard {
+    fn drop(&mut self) {
+        cleanup_run_files(&self.ops_file);
+    }
+}
+
+fn cleanup_run_files(ops_file: &str) {
+    let _ = std::fs::remove_file(guest_agent::paths::agent_log_file());
+    let _ = std::fs::remove_file(guest_agent::paths::event_error_flag());
+    let _ = std::fs::remove_file(guest_agent::paths::session_id_file());
+    let _ = std::fs::remove_file(guest_agent::paths::session_history_path_file());
+    let _ = std::fs::remove_file(ops_file);
+}
+
+unsafe fn setup_api_env(mock_path: &Path, workdir: &Path, api_url: &str) -> Result<(), String> {
+    unsafe {
+        std::env::set_var("VM0_MOCK_CLAUDE_PATH", mock_path);
+        std::env::set_var("USE_MOCK_CLAUDE", "true");
+        std::env::set_var("VM0_POST_RESULT_SIGTERM_GRACE_SECS", "3");
+        std::env::set_var("VM0_POST_RESULT_SIGKILL_GRACE_SECS", "1");
+        let run_id = std::env::current_exe()
+            .ok()
+            .as_deref()
+            .and_then(Path::file_name)
+            .map(|name| name.to_string_lossy().into_owned())
+            .unwrap_or_else(|| "execute-cli-api-mode-test".to_string());
+        std::env::set_var("VM0_RUN_ID", run_id);
+        std::env::set_var("VM0_PROMPT", "@exit-after-result");
+        std::env::set_var("VM0_WORKING_DIR", workdir);
+        std::env::set_var("VM0_API_URL", api_url);
+        std::env::set_var("VM0_API_TOKEN", "test-token");
+        std::env::set_var("VM0_SANDBOX_ID", "00000000-0000-4000-8000-000000000abc");
+        std::env::set_var("VM0_SANDBOX_REUSE_RESULT", "reused");
+        std::env::set_var("HOME", workdir);
+    }
+    std::fs::create_dir_all(workdir).map_err(|e| format!("create workdir: {e}"))?;
+    std::env::set_current_dir(workdir).map_err(|e| format!("set_current_dir: {e}"))?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn api_mode_execute_cli_captures_session_metadata_and_sends_events()
+-> Result<(), Box<dyn std::error::Error>> {
+    let mock_cli = common::build_and_locate_mock()?;
+    let tmp = tempfile::tempdir()?;
+    let server = MockServer::start();
+
+    unsafe {
+        setup_api_env(&mock_cli, tmp.path(), &server.base_url())?;
+    }
+    let _run_files = RunFilesGuard::new();
+
+    let init_event = server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/webhooks/agent/events")
+            .body_includes(r#""subtype":"init""#);
+        then.status(200);
+    });
+    let result_event = server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/webhooks/agent/events")
+            .body_includes(r#""type":"result""#);
+        then.status(200);
+    });
+
+    let masker = SecretMasker::from_raw("");
+    let cli_result = tokio::time::timeout(
+        Duration::from_secs(5),
+        guest_agent::cli::execute_cli(
+            &masker,
+            common::spawn_dummy_heartbeat(),
+            HttpClient::for_current_env()?,
+        ),
+    )
+    .await
+    .expect("execute_cli should return promptly")?;
+
+    assert_eq!(cli_result.exit_code, common::CLEAN_EXIT);
+    assert_eq!(
+        cli_result.last_event_sequence,
+        Some(1),
+        "API mode should acknowledge the init and result events"
+    );
+    init_event.assert_calls_async(1).await;
+    result_event.assert_calls_async(1).await;
+
+    let session_id = std::fs::read_to_string(guest_agent::paths::session_id_file())?;
+    assert!(
+        session_id.starts_with("mock-"),
+        "execute_cli should capture the mock CLI session id, got {session_id}"
+    );
+    let history_path = std::fs::read_to_string(guest_agent::paths::session_history_path_file())?;
+    assert!(
+        history_path.contains(session_id.trim()),
+        "history path should contain the captured session id, got {history_path}"
+    );
+
+    Ok(())
+}

--- a/crates/guest-agent/tests/execute_cli_api_mode.rs
+++ b/crates/guest-agent/tests/execute_cli_api_mode.rs
@@ -95,7 +95,7 @@ async fn api_mode_execute_cli_captures_session_metadata_and_sends_events()
         guest_agent::cli::execute_cli(
             &masker,
             common::spawn_dummy_heartbeat(),
-            HttpClient::for_current_env()?,
+            HttpClient::with_retry_delay(Duration::ZERO)?,
         ),
     )
     .await

--- a/crates/guest-agent/tests/integration.rs
+++ b/crates/guest-agent/tests/integration.rs
@@ -957,11 +957,10 @@ async fn send_event_masks_secrets() {
 async fn send_event_captures_session_metadata_before_masking() {
     let _guard = TEST_MUTEX.lock().unwrap();
     let server = &*MOCK_SERVER;
+    let _session_files = SessionCheckpointFilesGuard::new();
 
     let sid_file = guest_agent::paths::session_id_file();
     let hist_file = guest_agent::paths::session_history_path_file();
-    let _ = std::fs::remove_file(sid_file);
-    let _ = std::fs::remove_file(hist_file);
 
     let mock = server.mock(|when, then| {
         when.method(POST)
@@ -1005,19 +1004,16 @@ async fn send_event_captures_session_metadata_before_masking() {
     );
 
     mock.delete_async().await;
-    let _ = std::fs::remove_file(sid_file);
-    let _ = std::fs::remove_file(hist_file);
 }
 
 #[tokio::test]
 async fn prepare_event_does_not_capture_session_metadata() {
     let _guard = TEST_MUTEX.lock().unwrap();
     let _server = &*MOCK_SERVER;
+    let _session_files = SessionCheckpointFilesGuard::new();
 
     let sid_file = guest_agent::paths::session_id_file();
     let hist_file = guest_agent::paths::session_history_path_file();
-    let _ = std::fs::remove_file(sid_file);
-    let _ = std::fs::remove_file(hist_file);
 
     let masker = SecretMasker::from_raw("");
     let mut event = json!({

--- a/crates/guest-agent/tests/integration.rs
+++ b/crates/guest-agent/tests/integration.rs
@@ -964,7 +964,9 @@ async fn send_event_captures_session_metadata_before_masking() {
     let _ = std::fs::remove_file(hist_file);
 
     let mock = server.mock(|when, then| {
-        when.method(POST).path("/api/webhooks/agent/events");
+        when.method(POST)
+            .path("/api/webhooks/agent/events")
+            .body_includes(r#""session_id":"***""#);
         then.status(200);
     });
 
@@ -984,7 +986,7 @@ async fn send_event_captures_session_metadata_before_masking() {
     mock.assert_calls_async(1).await;
     assert_eq!(
         event["session_id"], "***",
-        "webhook event payload should still be masked"
+        "send_event should leave the caller's event masked after payload preparation"
     );
 
     let stored = std::fs::read_to_string(sid_file).unwrap();

--- a/crates/guest-agent/tests/integration.rs
+++ b/crates/guest-agent/tests/integration.rs
@@ -953,6 +953,38 @@ async fn send_event_masks_secrets() {
     mock.delete_async().await;
 }
 
+#[tokio::test]
+async fn prepare_event_does_not_capture_session_metadata() {
+    let _guard = TEST_MUTEX.lock().unwrap();
+    let _server = &*MOCK_SERVER;
+
+    let sid_file = guest_agent::paths::session_id_file();
+    let hist_file = guest_agent::paths::session_history_path_file();
+    let _ = std::fs::remove_file(sid_file);
+    let _ = std::fs::remove_file(hist_file);
+
+    let masker = SecretMasker::from_raw("");
+    let mut event = json!({
+        "type": "system",
+        "subtype": "init",
+        "session_id": "ses-prepare-only"
+    });
+    let payload = guest_agent::events::prepare_event(&mut event, 1, &masker);
+
+    assert!(
+        payload.is_some(),
+        "prepare_event should still prepare a payload when the API token is configured"
+    );
+    assert!(
+        !std::path::Path::new(sid_file).exists(),
+        "prepare_event must not write the session ID file"
+    );
+    assert!(
+        !std::path::Path::new(hist_file).exists(),
+        "prepare_event must not write the session history path file"
+    );
+}
+
 // =========================================================================
 // Group 6: Session ID extraction
 // =========================================================================

--- a/crates/guest-agent/tests/integration.rs
+++ b/crates/guest-agent/tests/integration.rs
@@ -1037,6 +1037,46 @@ async fn prepare_event_does_not_capture_session_metadata() {
     );
 }
 
+#[tokio::test]
+async fn send_event_keeps_existing_session_metadata() {
+    let _guard = TEST_MUTEX.lock().unwrap();
+    let server = &*MOCK_SERVER;
+    let _session_files = SessionCheckpointFilesGuard::new();
+
+    let sid_file = guest_agent::paths::session_id_file();
+    let hist_file = guest_agent::paths::session_history_path_file();
+    std::fs::write(sid_file, "first-session").unwrap();
+    std::fs::write(hist_file, "/tmp/first-session.jsonl").unwrap();
+
+    let mock = server.mock(|when, then| {
+        when.method(POST).path("/api/webhooks/agent/events");
+        then.status(200);
+    });
+
+    let masker = SecretMasker::from_raw("");
+    let mut event = json!({
+        "type": "system",
+        "subtype": "init",
+        "session_id": "second-session"
+    });
+    let result = guest_agent::events::send_event(&http_client!(), &mut event, 1, &masker).await;
+
+    assert!(result.is_ok());
+    mock.assert_calls_async(1).await;
+    assert_eq!(
+        std::fs::read_to_string(sid_file).unwrap(),
+        "first-session",
+        "later id-bearing events must not replace checkpoint session metadata"
+    );
+    assert_eq!(
+        std::fs::read_to_string(hist_file).unwrap(),
+        "/tmp/first-session.jsonl",
+        "later id-bearing events must not replace checkpoint history metadata"
+    );
+
+    mock.delete_async().await;
+}
+
 // =========================================================================
 // Group 6: Session ID extraction
 // =========================================================================

--- a/crates/guest-agent/tests/integration.rs
+++ b/crates/guest-agent/tests/integration.rs
@@ -954,6 +954,60 @@ async fn send_event_masks_secrets() {
 }
 
 #[tokio::test]
+async fn send_event_captures_session_metadata_before_masking() {
+    let _guard = TEST_MUTEX.lock().unwrap();
+    let server = &*MOCK_SERVER;
+
+    let sid_file = guest_agent::paths::session_id_file();
+    let hist_file = guest_agent::paths::session_history_path_file();
+    let _ = std::fs::remove_file(sid_file);
+    let _ = std::fs::remove_file(hist_file);
+
+    let mock = server.mock(|when, then| {
+        when.method(POST).path("/api/webhooks/agent/events");
+        then.status(200);
+    });
+
+    let session_id = "ses-secret-123";
+    let engine = base64::engine::general_purpose::STANDARD;
+    let encoded_session_id = engine.encode(session_id);
+    let masker = SecretMasker::from_raw(&encoded_session_id);
+    let mut event = json!({
+        "type": "system",
+        "subtype": "init",
+        "session_id": session_id
+    });
+
+    let result = guest_agent::events::send_event(&http_client!(), &mut event, 1, &masker).await;
+
+    assert!(result.is_ok());
+    mock.assert_calls_async(1).await;
+    assert_eq!(
+        event["session_id"], "***",
+        "webhook event payload should still be masked"
+    );
+
+    let stored = std::fs::read_to_string(sid_file).unwrap();
+    assert_eq!(
+        stored, session_id,
+        "checkpoint metadata should capture the unmasked session id"
+    );
+    let history = std::fs::read_to_string(hist_file).unwrap();
+    assert!(
+        history.contains(session_id),
+        "history path should contain the unmasked session id, got: {history}"
+    );
+    assert!(
+        !history.contains("***"),
+        "history path must not be built from masked metadata, got: {history}"
+    );
+
+    mock.delete_async().await;
+    let _ = std::fs::remove_file(sid_file);
+    let _ = std::fs::remove_file(hist_file);
+}
+
+#[tokio::test]
 async fn prepare_event_does_not_capture_session_metadata() {
     let _guard = TEST_MUTEX.lock().unwrap();
     let _server = &*MOCK_SERVER;

--- a/crates/guest-agent/tests/no_api_mode.rs
+++ b/crates/guest-agent/tests/no_api_mode.rs
@@ -34,6 +34,7 @@ fn cleanup_session_files() {
 }
 
 fn cleanup_run_files(ops_file: &str) {
+    let _ = std::fs::remove_file(guest_agent::paths::agent_log_file());
     let _ = std::fs::remove_file(guest_agent::paths::event_error_flag());
     cleanup_session_files();
     let _ = std::fs::remove_file(ops_file);

--- a/crates/guest-agent/tests/no_api_mode.rs
+++ b/crates/guest-agent/tests/no_api_mode.rs
@@ -81,6 +81,8 @@ async fn no_api_mode_drains_background_webhook_users_without_network_client()
         std::fs::read_to_string(guest_agent::paths::session_id_file())?,
         "session-no-api"
     );
+    let _ = std::fs::remove_file(guest_agent::paths::session_id_file());
+    let _ = std::fs::remove_file(guest_agent::paths::session_history_path_file());
 
     let complete_log_path = tmp.path().join("complete-system.log");
     let complete_log_guard = SystemLogOverrideGuard::set(&complete_log_path);
@@ -106,6 +108,21 @@ async fn no_api_mode_drains_background_webhook_users_without_network_client()
     assert!(
         !std::path::Path::new(guest_agent::paths::event_error_flag()).exists(),
         "no-API execute_cli must not write event error flag"
+    );
+    let cli_session_id = std::fs::read_to_string(guest_agent::paths::session_id_file())?;
+    assert!(
+        cli_session_id.starts_with("mock-"),
+        "no-API execute_cli should capture session metadata from stdout events, got {cli_session_id}"
+    );
+    let cli_history_path =
+        std::fs::read_to_string(guest_agent::paths::session_history_path_file())?;
+    assert!(
+        cli_history_path.contains(cli_session_id.trim()),
+        "history path should contain the captured CLI session id, got {cli_history_path}"
+    );
+    assert!(
+        cli_history_path.trim_end().ends_with(".jsonl"),
+        "history path should be the Claude JSONL path captured from stdout events, got {cli_history_path}"
     );
     let ops = std::fs::read_to_string(ops_file)?;
     let cli_exit_metric_count = ops

--- a/crates/guest-agent/tests/no_api_mode.rs
+++ b/crates/guest-agent/tests/no_api_mode.rs
@@ -28,6 +28,39 @@ impl Drop for SystemLogOverrideGuard {
     }
 }
 
+fn cleanup_session_files() {
+    let _ = std::fs::remove_file(guest_agent::paths::session_id_file());
+    let _ = std::fs::remove_file(guest_agent::paths::session_history_path_file());
+}
+
+fn cleanup_run_files(ops_file: &str) {
+    let _ = std::fs::remove_file(guest_agent::paths::event_error_flag());
+    cleanup_session_files();
+    let _ = std::fs::remove_file(ops_file);
+}
+
+struct RunFilesGuard {
+    ops_file: String,
+}
+
+impl RunFilesGuard {
+    fn new() -> Self {
+        let ops_file = guest_common::telemetry::sandbox_ops_log().to_string();
+        cleanup_run_files(&ops_file);
+        Self { ops_file }
+    }
+
+    fn ops_file(&self) -> &str {
+        &self.ops_file
+    }
+}
+
+impl Drop for RunFilesGuard {
+    fn drop(&mut self) {
+        cleanup_run_files(&self.ops_file);
+    }
+}
+
 #[tokio::test]
 async fn no_api_mode_drains_background_webhook_users_without_network_client()
 -> Result<(), Box<dyn std::error::Error>> {
@@ -38,11 +71,8 @@ async fn no_api_mode_drains_background_webhook_users_without_network_client()
     }
 
     let http = HttpClient::for_current_env()?;
-    let _ = std::fs::remove_file(guest_agent::paths::event_error_flag());
-    let _ = std::fs::remove_file(guest_agent::paths::session_id_file());
-    let _ = std::fs::remove_file(guest_agent::paths::session_history_path_file());
-    let ops_file = guest_common::telemetry::sandbox_ops_log();
-    let _ = std::fs::remove_file(ops_file);
+    let run_files = RunFilesGuard::new();
+    let ops_file = run_files.ops_file();
 
     let disabled = http
         .post_json("http://127.0.0.1:1/should-not-send", &json!({}), 1)
@@ -81,8 +111,7 @@ async fn no_api_mode_drains_background_webhook_users_without_network_client()
         std::fs::read_to_string(guest_agent::paths::session_id_file())?,
         "session-no-api"
     );
-    let _ = std::fs::remove_file(guest_agent::paths::session_id_file());
-    let _ = std::fs::remove_file(guest_agent::paths::session_history_path_file());
+    cleanup_session_files();
 
     let complete_log_path = tmp.path().join("complete-system.log");
     let complete_log_guard = SystemLogOverrideGuard::set(&complete_log_path);
@@ -139,8 +168,5 @@ async fn no_api_mode_drains_background_webhook_users_without_network_client()
         "execute_cli should record exactly one last-read-event to CLI-exit sandbox op: {ops}"
     );
 
-    let _ = std::fs::remove_file(guest_agent::paths::event_error_flag());
-    let _ = std::fs::remove_file(guest_agent::paths::session_id_file());
-    let _ = std::fs::remove_file(guest_agent::paths::session_history_path_file());
     Ok(())
 }


### PR DESCRIPTION
## Summary

- split session metadata capture out of `prepare_event` into explicit `capture_session_metadata`
- keep `send_event` and the stdout event loop capturing session metadata before payload preparation
- add regression coverage that `prepare_event` no longer writes session metadata files

## Tests

- `cargo test --manifest-path crates/Cargo.toml -p guest-agent`
- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-agent --all-targets --all-features -- -D warnings`

Closes #13526
