### PR TITLE
fix: proxy stripe cli auth session start

### DIFF
--- a/turbo/apps/web/__tests__/security-headers.test.ts
+++ b/turbo/apps/web/__tests__/security-headers.test.ts
@@ -54,6 +54,12 @@ const VOICE_CHAT_TOKEN_PATH = "/api/zero/voice-chat/token";
 const VOICE_CHAT_ITEM_APPEND_PATH = `${VOICE_CHAT_SESSION_PATH}/items`;
 const VOICE_CHAT_TASKS_PATH = `${VOICE_CHAT_SESSION_PATH}/tasks`;
 const VOICE_CHAT_TRIGGER_REASONING_PATH = `${VOICE_CHAT_SESSION_PATH}/trigger-reasoning`;
+const STRIPE_CLI_AUTH_SESSIONS_REWRITE_SOURCE =
+  "/api/zero/connectors/stripe/cli-auth/sessions";
+const STRIPE_CLI_AUTH_SESSIONS_PATH =
+  "/api/zero/connectors/stripe/cli-auth/sessions";
+const STRIPE_CLI_AUTH_SESSIONS_COMPLETE_PATH =
+  "/api/zero/connectors/stripe/cli-auth/sessions/complete";
 const VOICE_CHAT_ITEM_APPEND_NEXT_NEGATIVE_PATHS = [
   "/api/zero/voice-chat/token",
   "/api/zero/voice-chat/token/items",
@@ -284,6 +290,11 @@ describe("API backend rewrites", () => {
           destination: "https://api.example.test/api/user/export",
         },
         {
+          source: STRIPE_CLI_AUTH_SESSIONS_REWRITE_SOURCE,
+          destination:
+            "https://api.example.test/api/zero/connectors/stripe/cli-auth/sessions",
+        },
+        {
           source: "/api/zero/devices/bb0/confirm",
           destination: "https://api.example.test/api/zero/devices/bb0/confirm",
         },
@@ -402,6 +413,38 @@ describe("API backend rewrites", () => {
         },
       ]),
     );
+  });
+
+  it("should match only the exact Stripe CLI auth sessions rewrite", async () => {
+    vi.stubEnv("VM0_API_BACKEND_URL", "https://api.example.test");
+
+    const rewrites = await getBeforeFileRewrites();
+    const rewrite = rewrites.find((entry) => {
+      return entry.source === STRIPE_CLI_AUTH_SESSIONS_REWRITE_SOURCE;
+    });
+    const exactIndex = rewrites.findIndex((entry) => {
+      return entry.source === STRIPE_CLI_AUTH_SESSIONS_REWRITE_SOURCE;
+    });
+    const childIndex = rewrites.findIndex((entry) => {
+      return (
+        entry.source === `${STRIPE_CLI_AUTH_SESSIONS_REWRITE_SOURCE}/:path*`
+      );
+    });
+    expect(rewrite).toStrictEqual({
+      source: STRIPE_CLI_AUTH_SESSIONS_REWRITE_SOURCE,
+      destination:
+        "https://api.example.test/api/zero/connectors/stripe/cli-auth/sessions",
+    });
+    expect(exactIndex).toBeGreaterThanOrEqual(0);
+    expect(childIndex).toBeGreaterThan(exactIndex);
+
+    const matcher = getPathMatch(STRIPE_CLI_AUTH_SESSIONS_REWRITE_SOURCE, {
+      removeUnnamedParams: true,
+      strict: true,
+    });
+
+    expect(matcher(STRIPE_CLI_AUTH_SESSIONS_PATH)).toStrictEqual({});
+    expect(matcher(STRIPE_CLI_AUTH_SESSIONS_COMPLETE_PATH)).toBe(false);
   });
 
   it("should match only the exact push subscriptions rewrite", async () => {

--- a/turbo/apps/web/api-backend-rewrites.js
+++ b/turbo/apps/web/api-backend-rewrites.js
@@ -37,6 +37,10 @@ export const API_BACKEND_REWRITES = [
   ["/api/user/export", "/api/user/export"],
   ["/api/v1/audio/transcriptions", "/api/v1/audio/transcriptions"],
   [
+    "/api/zero/connectors/stripe/cli-auth/sessions",
+    "/api/zero/connectors/stripe/cli-auth/sessions",
+  ],
+  [
     "/api/zero/connectors/stripe/cli-auth/sessions/:path*",
     "/api/zero/connectors/stripe/cli-auth/sessions/:path*",
   ],


### PR DESCRIPTION
## Summary
- add an exact web rewrite for the Stripe CLI auth session start endpoint
- keep the existing child-path rewrite for completion routes
- cover the exact rewrite and ordering in web rewrite tests

## Testing
- pnpm exec vitest run __tests__/security-headers.test.ts
- pre-commit hook: prettier, knip, turbo check-types

## Notes
- Direct API backend returns JSON as expected; the failure was www.vm0.ai returning Vercel 308 before proxying.