### PR TITLE
fix(web): sanitize run context telemetry responses

### DIFF
--- a/turbo/apps/web/app/api/zero/runs/[id]/context/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/runs/[id]/context/__tests__/route.test.ts
@@ -112,6 +112,60 @@ describe("GET /api/zero/runs/:id/context", () => {
     expect(data.featureFlags).toEqual({ computerUse: true, voiceChat: false });
   });
 
+  it("omits sparse null Axiom fields before response validation", async () => {
+    const userId = uniqueId("zctx-null");
+    await setupOrg(userId);
+    const compose = await createTestCompose(`agent-${uniqueId("zctx")}`);
+    const { runId } = await seedTestRun(userId, compose.composeId, {
+      status: "running",
+      prompt: "test prompt",
+    });
+
+    const snapshot = makeSnapshot(runId, userId);
+    context.mocks.axiom.queryAxiom.mockResolvedValue([
+      {
+        ...snapshot,
+        environment: {
+          OPENAI_API_KEY: null,
+          ZERO_TOKEN: "***",
+        } as unknown as RunContextSnapshot["environment"],
+        networkPolicies: {
+          github: {
+            allow: ["repo-read"],
+            deny: [],
+            ask: [],
+            unknownPolicy: "allow",
+          },
+          slack: {
+            allow: null,
+            deny: null,
+            ask: null,
+            unknownPolicy: null,
+          },
+        } as unknown as RunContextSnapshot["networkPolicies"],
+        featureFlags: {
+          apiBackend: true,
+          voiceChat: null,
+        } as unknown as RunContextSnapshot["featureFlags"],
+      },
+    ]);
+
+    const response = await GET(createTestRequest(contextUrl(runId)));
+    expect(response.status).toBe(200);
+
+    const data = await response.json();
+    expect(data.environment).toEqual({ ZERO_TOKEN: "***" });
+    expect(data.networkPolicies).toEqual({
+      github: {
+        allow: ["repo-read"],
+        deny: [],
+        ask: [],
+        unknownPolicy: "allow",
+      },
+    });
+    expect(data.featureFlags).toEqual({ apiBackend: true });
+  });
+
   it("should return 404 when run not found", async () => {
     const userId = uniqueId("zctx-nf");
     await setupOrg(userId);

--- a/turbo/apps/web/app/api/zero/runs/[id]/context/route.ts
+++ b/turbo/apps/web/app/api/zero/runs/[id]/context/route.ts
@@ -1,5 +1,8 @@
 import { createHandler, tsr } from "../../../../../../src/lib/ts-rest-handler";
-import { zeroRunContextContract } from "@vm0/api-contracts/contracts/zero-runs";
+import {
+  zeroRunContextContract,
+  type RunContextResponse,
+} from "@vm0/api-contracts/contracts/zero-runs";
 import { createErrorResponse } from "@vm0/api-contracts/contracts/errors";
 import { initServices } from "../../../../../../src/lib/init-services";
 import {
@@ -9,6 +12,65 @@ import {
 import { resolveOrg } from "../../../../../../src/lib/zero/org/resolve-org";
 import { getRunById } from "../../../../../../src/lib/infra/run/run-service";
 import { queryRunContext } from "../../../../../../src/lib/infra/run/run-context-service";
+
+// Older Axiom snapshots can contain null entries inside fields the contract
+// types as Record<string, string|boolean> (e.g. environment variables that
+// were never set). Drop them at the response boundary so ts-rest validation
+// does not reject historical data.
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function sanitizeStringRecord(value: unknown): Record<string, string> {
+  if (!isRecord(value)) return {};
+  return Object.fromEntries(
+    Object.entries(value).filter(
+      (entry): entry is [string, string] => typeof entry[1] === "string",
+    ),
+  );
+}
+
+function sanitizeBooleanRecord(
+  value: unknown,
+): Record<string, boolean> | null {
+  if (!isRecord(value)) return null;
+  const entries = Object.entries(value).filter(
+    (entry): entry is [string, boolean] => typeof entry[1] === "boolean",
+  );
+  return entries.length > 0 ? Object.fromEntries(entries) : null;
+}
+
+function sanitizeStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((item): item is string => typeof item === "string");
+}
+
+function networkPolicyValue(
+  value: unknown,
+): "allow" | "deny" | "ask" | undefined {
+  return value === "allow" || value === "deny" || value === "ask"
+    ? value
+    : undefined;
+}
+
+function sanitizeNetworkPolicies(
+  value: unknown,
+): RunContextResponse["networkPolicies"] {
+  if (!isRecord(value)) return null;
+  const policies: NonNullable<RunContextResponse["networkPolicies"]> = {};
+  for (const [name, rawPolicy] of Object.entries(value)) {
+    if (!isRecord(rawPolicy)) continue;
+    const unknownPolicy = networkPolicyValue(rawPolicy.unknownPolicy);
+    if (!unknownPolicy) continue;
+    policies[name] = {
+      allow: sanitizeStringArray(rawPolicy.allow),
+      deny: sanitizeStringArray(rawPolicy.deny),
+      ask: sanitizeStringArray(rawPolicy.ask),
+      unknownPolicy,
+    };
+  }
+  return Object.keys(policies).length > 0 ? policies : null;
+}
 
 const router = tsr.router(zeroRunContextContract, {
   getContext: async ({ params, headers }) => {
@@ -57,12 +119,12 @@ const router = tsr.router(zeroRunContextContract, {
         sessionId: snapshot.sessionId ?? null,
         secretNames: snapshot.secretNames,
         vars: (run.vars as Record<string, string> | undefined) ?? null,
-        environment: snapshot.environment,
+        environment: sanitizeStringRecord(snapshot.environment),
         firewalls: snapshot.firewalls,
-        networkPolicies: snapshot.networkPolicies ?? null,
+        networkPolicies: sanitizeNetworkPolicies(snapshot.networkPolicies),
         volumes: snapshot.volumes,
         artifact: snapshot.artifact,
-        featureFlags: snapshot.featureFlags,
+        featureFlags: sanitizeBooleanRecord(snapshot.featureFlags),
       },
     };
   },


### PR DESCRIPTION
## Summary
- Mirror PR #13245 (apps/api) on the apps/web implementation of `GET /api/zero/runs/:id/context`
- Older Axiom snapshots carry null entries inside `environment`, `featureFlags`, and `networkPolicies`; the contract types those as records of strings/booleans, so ts-rest response validation threw and surfaced as Sentry [VM0-WEB / 7465206960](https://vm0.sentry.io/issues/7465206960/) ("ts-rest Response validation failed for GET /api/zero/runs/:id/context")
- Drop the null entries at the response boundary, matching the api-side helpers so both implementations stay in sync (per CLAUDE.md: "For routes that still have implementations in both apps/web and apps/api, bug fixes ... must update both implementations together")

## Why this is safe
- The contract already treats `environment` as `Record<string, string>` and `featureFlags` / `networkPolicies` as nullable — clients never relied on null sentinels for these fields
- Apps/api has been using the same sanitization shape since #13245 (Sentry stopped firing on the api project after that deploy on May 14)
- Apps/web still hits these null records for legacy snapshots; the new "omits sparse null Axiom fields" test pins down the behavior

## Test plan
- [x] Added integration test mirroring `omits sparse null Axiom fields before response validation` from #13245
- [ ] CI lint + check-types + vitest (pnpm not available in the build sandbox)

🤖 Generated with [Claude Code](https://claude.com/claude-code)