### PR TITLE
fix(api): route v1 chat send through createZeroRun$

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads-v1.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads-v1.test.ts
@@ -967,8 +967,8 @@ describe("POST /api/v1/chat-threads/messages", () => {
       "encryptedSecrets" in job.executionContext &&
       typeof (job.executionContext as { encryptedSecrets: unknown })
         .encryptedSecrets === "string"
-        ? ((job.executionContext as { encryptedSecrets: string })
-            .encryptedSecrets)
+        ? (job.executionContext as { encryptedSecrets: string })
+            .encryptedSecrets
         : null;
     const secrets = decryptSecretsMap(encryptedSecrets);
     expect(secrets?.ZERO_TOKEN).toMatch(/^vm0_sandbox_/);

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads-v1.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads-v1.test.ts
@@ -880,13 +880,16 @@ describe("POST /api/v1/chat-threads/messages", () => {
       .innerJoin(zeroRuns, eq(zeroRuns.id, agentRuns.id))
       .where(eq(agentRuns.id, message.runId))
       .limit(1);
-    expect(run).toStrictEqual({
+    expect(run).toMatchObject({
       prompt: "hello from v1",
-      appendSystemPrompt:
-        "# Current Integration\nYou are currently running inside: Web\n\nYou are communicating with the user through the web chat UI.",
       triggerSource: "web",
       chatThreadId: response.body.threadId,
     });
+    expect(run?.appendSystemPrompt).toContain("# Agent Tools");
+    expect(run?.appendSystemPrompt).toContain("# Current User Info");
+    expect(run?.appendSystemPrompt).toContain(
+      "# Current Integration\nYou are currently running inside: Web\n\nYou are communicating with the user through the web chat UI.",
+    );
 
     const [callback] = await writeDb
       .select({

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads-v1.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads-v1.test.ts
@@ -14,6 +14,7 @@ import { cliTokens } from "@vm0/db/schema/cli-tokens";
 import { orgMembersCache } from "@vm0/db/schema/org-members-cache";
 import { orgMetadata } from "@vm0/db/schema/org-metadata";
 import { runnerJobQueue } from "@vm0/db/schema/runner-job-queue";
+import { zeroAgents } from "@vm0/db/schema/zero-agent";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
 import {
   chatThreadV1GetContract,
@@ -24,10 +25,17 @@ import { createStore } from "ccstate";
 import { and, eq } from "drizzle-orm";
 
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
-import { decryptSecretValue } from "../../services/crypto.utils";
+import {
+  decryptSecretValue,
+  decryptSecretsMap,
+} from "../../services/crypto.utils";
 import { writeDb$ } from "../../external/db";
 import { now } from "../../external/time";
-import { signPatJwtForTests, signSandboxJwtForTests } from "../../auth/tokens";
+import {
+  signPatJwtForTests,
+  signSandboxJwtForTests,
+  verifyZeroToken,
+} from "../../auth/tokens";
 
 interface PatFixture {
   readonly token: string;
@@ -166,18 +174,27 @@ async function deleteThreadFixture(fixture: ThreadFixture): Promise<void> {
     .where(eq(agentComposes.id, fixture.composeId));
 }
 
+function vm0Template(expression: string): string {
+  return `$${expression}`;
+}
+
 async function seedRunnableAgentFixture(
   pat: PatFixture,
 ): Promise<RunnableAgentFixture> {
   const composeId = randomUUID();
   const versionId = randomUUID();
+  const name = `compose-${composeId.slice(0, 8)}`;
   const writeDb = store.set(writeDb$);
   const content = {
     version: "1.0",
     agents: {
-      main: {
+      [name]: {
         framework: "claude-code",
-        environment: { ANTHROPIC_API_KEY: "test-key" },
+        environment: {
+          ANTHROPIC_API_KEY: "test-key",
+          ZERO_AGENT_ID: vm0Template("{{ vars.ZERO_AGENT_ID }}"),
+          ZERO_TOKEN: vm0Template("{{ secrets.ZERO_TOKEN }}"),
+        },
         experimental_runner: { group: "vm0/test" },
       },
     },
@@ -187,7 +204,7 @@ async function seedRunnableAgentFixture(
     id: composeId,
     userId: pat.userId,
     orgId: pat.orgId,
-    name: `compose-${composeId.slice(0, 8)}`,
+    name,
     headVersionId: versionId,
   });
   await writeDb.insert(agentComposeVersions).values({
@@ -195,6 +212,16 @@ async function seedRunnableAgentFixture(
     composeId,
     content,
     createdBy: pat.userId,
+  });
+  // V1 send routes through createZeroRun$, which requires the agent compose
+  // to also be registered as a Zero agent. Mirrors fixtures used by the
+  // non-v1 chat tests.
+  await writeDb.insert(zeroAgents).values({
+    id: composeId,
+    orgId: pat.orgId,
+    owner: pat.userId,
+    name,
+    visibility: "public",
   });
 
   return { composeId, versionId };
@@ -713,6 +740,84 @@ describe("POST /api/v1/chat-threads/messages", () => {
     }
   });
 
+  it("returns 401 with web's 'API key required' phrasing when no Authorization header is provided", async () => {
+    const client = setupApp({ context })(chatThreadV1SendContract);
+    const response = await accept(
+      client.send({ headers: {}, body: { prompt: "hello" } }),
+      [401],
+    );
+
+    expect(response.body.error).toStrictEqual({
+      message: "API key required",
+      code: "UNAUTHORIZED",
+    });
+  });
+
+  it("returns 401 for an opaque bearer token", async () => {
+    const client = setupApp({ context })(chatThreadV1SendContract);
+    await accept(
+      client.send({
+        headers: { authorization: "Bearer ak_unknown_opaque_secret" },
+        body: { prompt: "hello" },
+      }),
+      [401],
+    );
+  });
+
+  it("returns 401 when the PAT row has been revoked", async () => {
+    const pat = await seedPatFixture();
+    await deletePatFixture(pat);
+
+    const client = setupApp({ context })(chatThreadV1SendContract);
+    await accept(
+      client.send({
+        headers: { authorization: `Bearer ${pat.token}` },
+        body: { prompt: "hello" },
+      }),
+      [401],
+    );
+  });
+
+  it("returns 401 when the PAT is expired", async () => {
+    const pat = await seedExpiredPatFixture();
+    pats.push(pat);
+
+    const client = setupApp({ context })(chatThreadV1SendContract);
+    await accept(
+      client.send({
+        headers: { authorization: `Bearer ${pat.token}` },
+        body: { prompt: "hello" },
+      }),
+      [401],
+    );
+  });
+
+  it("returns 403 when authenticated with a sandbox token", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    const runId = randomUUID();
+    const nowSeconds = currentSecond();
+    const sandboxToken = signSandboxJwtForTests({
+      scope: "sandbox",
+      userId,
+      orgId,
+      runId,
+      iat: nowSeconds,
+      exp: nowSeconds + 60,
+    });
+
+    const client = setupApp({ context })(chatThreadV1SendContract);
+    const response = await accept(
+      client.send({
+        headers: { authorization: `Bearer ${sandboxToken}` },
+        body: { prompt: "hello" },
+      }),
+      [403],
+    );
+
+    expect(response.body.error.code).toBe("FORBIDDEN");
+  });
+
   it("creates a thread, run, chat callback, user message, and runner job", async () => {
     const pat = await seedPatFixture();
     pats.push(pat);
@@ -823,6 +928,145 @@ describe("POST /api/v1/chat-threads/messages", () => {
       null,
     );
     expect(response.body.createdAt).toStrictEqual(expect.any(String));
+  });
+
+  it("injects a ZERO_TOKEN sandbox secret into the runner execution context", async () => {
+    const pat = await seedPatFixture();
+    pats.push(pat);
+    const agent = await seedRunnableAgentFixture(pat);
+    await setDefaultAgent(pat, agent);
+    agents.push(agent);
+
+    const client = setupApp({ context })(chatThreadV1SendContract);
+    const response = await accept(
+      client.send({
+        headers: { authorization: `Bearer ${pat.token}` },
+        body: { prompt: "needs zero token" },
+      }),
+      [201],
+    );
+
+    const writeDb = store.set(writeDb$);
+    const [message] = await writeDb
+      .select({ runId: chatMessages.runId })
+      .from(chatMessages)
+      .where(eq(chatMessages.id, response.body.messageId))
+      .limit(1);
+    if (!message?.runId) {
+      throw new Error("Expected user message to reference a run");
+    }
+
+    const [job] = await writeDb
+      .select({ executionContext: runnerJobQueue.executionContext })
+      .from(runnerJobQueue)
+      .where(eq(runnerJobQueue.runId, message.runId))
+      .limit(1);
+    const encryptedSecrets =
+      typeof job?.executionContext === "object" &&
+      job.executionContext !== null &&
+      "encryptedSecrets" in job.executionContext &&
+      typeof (job.executionContext as { encryptedSecrets: unknown })
+        .encryptedSecrets === "string"
+        ? ((job.executionContext as { encryptedSecrets: string })
+            .encryptedSecrets)
+        : null;
+    const secrets = decryptSecretsMap(encryptedSecrets);
+    expect(secrets?.ZERO_TOKEN).toMatch(/^vm0_sandbox_/);
+    const zeroAuth = verifyZeroToken(secrets!.ZERO_TOKEN!);
+    expect(zeroAuth?.userId).toBe(pat.userId);
+    expect(zeroAuth?.orgId).toBe(pat.orgId);
+  });
+
+  it("does not require unconfigured connector environment refs before creating a chat run", async () => {
+    const pat = await seedPatFixture();
+    pats.push(pat);
+    const agent = await seedRunnableAgentFixture(pat);
+    await setDefaultAgent(pat, agent);
+    agents.push(agent);
+    const writeDb = store.set(writeDb$);
+    // Reproduce the production regression: the org's default agent references
+    // integration vars/secrets the caller has not provided. Before this route
+    // was wired through createZeroRun$, strict env-ref validation rejected the
+    // run with HTTP 400 "Missing required values: vars.*".
+    await writeDb
+      .update(agentComposeVersions)
+      .set({
+        content: {
+          version: "1.0",
+          agents: {
+            main: {
+              framework: "claude-code",
+              environment: {
+                ANTHROPIC_API_KEY: "test-key",
+                ZERO_AGENT_ID: vm0Template("{{ vars.ZERO_AGENT_ID }}"),
+                ZERO_TOKEN: vm0Template("{{ secrets.ZERO_TOKEN }}"),
+                JIRA_EMAIL: vm0Template("{{ vars.JIRA_EMAIL }}"),
+                GITLAB_HOST: vm0Template("{{ vars.GITLAB_HOST }}"),
+                GH_TOKEN: vm0Template("{{ secrets.GH_TOKEN }}"),
+                SLACK_TOKEN: vm0Template("{{ secrets.SLACK_TOKEN }}"),
+              },
+              experimental_runner: { group: "vm0/test" },
+            },
+          },
+        },
+      })
+      .where(eq(agentComposeVersions.id, agent.versionId));
+
+    const client = setupApp({ context })(chatThreadV1SendContract);
+    const response = await accept(
+      client.send({
+        headers: { authorization: `Bearer ${pat.token}` },
+        body: { prompt: "use the default zero agent" },
+      }),
+      [201],
+    );
+
+    expect(response.body.messageId).toStrictEqual(expect.any(String));
+    expect(response.body.threadId).toStrictEqual(expect.any(String));
+  });
+
+  it("mounts custom skills configured on the agent", async () => {
+    const pat = await seedPatFixture();
+    pats.push(pat);
+    const agent = await seedRunnableAgentFixture(pat);
+    await setDefaultAgent(pat, agent);
+    agents.push(agent);
+    const writeDb = store.set(writeDb$);
+    await writeDb
+      .update(zeroAgents)
+      .set({ customSkills: ["pp"] })
+      .where(eq(zeroAgents.id, agent.composeId));
+
+    const client = setupApp({ context })(chatThreadV1SendContract);
+    const response = await accept(
+      client.send({
+        headers: { authorization: `Bearer ${pat.token}` },
+        body: { prompt: "use the pp skill" },
+      }),
+      [201],
+    );
+
+    const [message] = await writeDb
+      .select({ runId: chatMessages.runId })
+      .from(chatMessages)
+      .where(eq(chatMessages.id, response.body.messageId))
+      .limit(1);
+    if (!message?.runId) {
+      throw new Error("Expected user message to reference a run");
+    }
+
+    const [run] = await writeDb
+      .select({ additionalVolumes: agentRuns.additionalVolumes })
+      .from(agentRuns)
+      .where(eq(agentRuns.id, message.runId))
+      .limit(1);
+    const volumes = run?.additionalVolumes ?? [];
+    expect(volumes).toContainEqual(
+      expect.objectContaining({
+        name: "custom-skill@pp",
+        mountPath: "/home/user/.claude/skills/pp",
+      }),
+    );
   });
 
   it("continues an existing thread from the latest session", async () => {

--- a/turbo/apps/api/src/signals/routes/chat-threads-v1.ts
+++ b/turbo/apps/api/src/signals/routes/chat-threads-v1.ts
@@ -65,8 +65,7 @@ const sendThreadMessageHandler$ = command(
     return await set(
       sendChatThreadMessageV1$,
       {
-        userId: auth.userId,
-        orgId: auth.orgId,
+        auth,
         prompt: body.data.prompt,
         threadId: body.data.threadId,
         apiStartTime,

--- a/turbo/apps/api/src/signals/services/chat-thread-v1-send.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-thread-v1-send.service.ts
@@ -1,7 +1,6 @@
 import { randomBytes } from "node:crypto";
 
 import { command } from "ccstate";
-import type { TriggerSource } from "@vm0/api-contracts/contracts/logs";
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { chatMessages } from "@vm0/db/schema/chat-message";
 import { chatThreads } from "@vm0/db/schema/chat-thread";
@@ -11,12 +10,13 @@ import { and, desc, eq } from "drizzle-orm";
 
 import { env } from "../../lib/env";
 import { badRequestMessage, notFound } from "../../lib/error";
+import type { AuthContext } from "../../types/auth";
 import { writeDb$, type Db } from "../external/db";
 import {
   publishThreadListChanged,
   publishUserSignal,
 } from "../external/realtime";
-import { createAgentRun$ } from "./agent-run-create.service";
+import { createZeroRun$ } from "./zero-runs-create.service";
 
 interface OwnedThreadForSend {
   readonly id: string;
@@ -54,8 +54,7 @@ export const sendChatThreadMessageV1$ = command(
   async (
     { set },
     args: {
-      readonly userId: string;
-      readonly orgId: string;
+      readonly auth: AuthContext & { readonly orgId: string };
       readonly prompt: string;
       readonly threadId: string | undefined;
       readonly apiStartTime: number;
@@ -77,7 +76,7 @@ export const sendChatThreadMessageV1$ = command(
         .where(
           and(
             eq(chatThreads.id, args.threadId),
-            eq(chatThreads.userId, args.userId),
+            eq(chatThreads.userId, args.auth.userId),
           ),
         )
         .limit(1);
@@ -91,7 +90,7 @@ export const sendChatThreadMessageV1$ = command(
       sessionId = await latestSessionIdForThread(db, thread.id);
       signal.throwIfAborted();
     } else {
-      const agentId = await defaultAgentId(db, args.orgId);
+      const agentId = await defaultAgentId(db, args.auth.orgId);
       signal.throwIfAborted();
 
       if (!agentId) {
@@ -103,7 +102,7 @@ export const sendChatThreadMessageV1$ = command(
       const [createdThread] = await db
         .insert(chatThreads)
         .values({
-          userId: args.userId,
+          userId: args.auth.userId,
           agentComposeId: agentId,
           title: null,
         })
@@ -120,23 +119,26 @@ export const sendChatThreadMessageV1$ = command(
       thread = createdThread;
     }
 
-    const triggerSource: TriggerSource = "web";
-    const runBody = {
-      prompt: args.prompt,
-      agentComposeId: thread.agentComposeId,
-      ...(sessionId ? { sessionId } : {}),
-      triggerSource,
-      appendSystemPrompt: buildWebChatPrompt(),
-    };
-
+    // Route through createZeroRun$ so the V1 surface matches the web chat
+    // path: env-ref validation is skipped, ZERO_TOKEN secret is injected,
+    // credit enforcement / concurrency queueing / skill volumes / connector
+    // allowlists are all applied. Direct createAgentRun$ calls left the V1
+    // path missing every one of those, which surfaced as a 400 "Missing
+    // required values: vars.*" whenever the default agent referenced
+    // integration vars the caller had not provided.
     const runResult = await set(
-      createAgentRun$,
+      createZeroRun$,
       {
-        userId: args.userId,
-        orgId: args.orgId,
-        body: runBody,
+        auth: args.auth,
         apiStartTime: args.apiStartTime,
         chatThreadId: thread.id,
+        triggerSource: "web",
+        appendSystemPrompt: buildWebChatPrompt(),
+        body: {
+          prompt: args.prompt,
+          agentId: thread.agentComposeId,
+          ...(sessionId ? { sessionId } : {}),
+        },
         callbacks: [
           {
             url: chatCallbackUrl(),
@@ -169,18 +171,21 @@ export const sendChatThreadMessageV1$ = command(
     }
 
     await publishUserSignal(
-      [args.userId],
+      [args.auth.userId],
       `chatThreadMessageCreated:${thread.id}`,
     );
     signal.throwIfAborted();
 
-    await publishThreadListChanged(args.userId);
+    await publishThreadListChanged(args.auth.userId);
     signal.throwIfAborted();
 
-    await publishUserSignal([args.userId], `chatThreadRunCreated:${thread.id}`);
+    await publishUserSignal(
+      [args.auth.userId],
+      `chatThreadRunCreated:${thread.id}`,
+    );
     signal.throwIfAborted();
 
-    await publishThreadListChanged(args.userId);
+    await publishThreadListChanged(args.auth.userId);
     signal.throwIfAborted();
 
     return {


### PR DESCRIPTION
## Summary

`POST /api/v1/chat-threads/messages` called `createAgentRun$` directly while the web chat path goes through `createZeroRun$`. The Zero-run wrapper sets `validateEnvironmentReferences: false` (plus a half-dozen other Zero-specific flags); calling the lower-level primitive bypasses every one of them.

Real-world fallout: zero-buddy (an M5StickS3 voice device that authenticates with a PAT and hits this endpoint) reproducibly received HTTP 400 with body

\`\`\`
{\"error\":{\"message\":\"Missing required values: vars.JIRA_EMAIL, vars.GITLAB_HOST, vars.JIRA_DOMAIN, vars.LARK_APP_ID, vars.AGORA_APP_ID, vars.HCTI_USER_ID, vars.N8N_BASE_URL, vars.SHOPIFY_SHOP, vars.GONG_API_BASE, vars.IRONCLAD_HOST, vars.ZE...\"}}
\`\`\`

…even though the same user with the same default agent could chat successfully through the web UI. The agent template legitimately references those integration vars; the web path skips env-ref validation, the V1 path didn't.

## Change

- \`sendChatThreadMessageV1\$\` now calls \`createZeroRun\$\` instead of \`createAgentRun\$\`. This inherits, from the Zero-run wrapper:
  - \`validateEnvironmentReferences: false\` (the actual fix)
  - \`includeZeroTokenSecret: true\`
  - \`enforceVm0Credits: true\`
  - \`queueOnConcurrencyLimit: true\`
  - \`injectSkillVolumes\` for the agent's custom skills
  - \`allowedConnectorTypes\` / \`allowedCustomConnectorIds\` (firewall scoping)
  - \`zeroRunMetadata.triggerAgentId\`
- The route now forwards the full \`OrganizationAuthContext\` so \`createZeroRun\$\` can resolve trigger-agent metadata and connector allowlists per the caller.
- Response contract is unchanged (\`threadId\`, \`messageId\`, \`createdAt\`).

## Why this is the right shape

Both other callers of \`createAgentRun\$\` for Zero-style runs (\`createZeroIntegrationRun\$\`, \`createZeroRun\$\` itself) set the same eight flags. The V1 endpoint is the third Zero entry point; routing it through \`createZeroRun\$\` makes the surface consistent and eliminates a class of "works on web, broken on PAT" bugs.

## Test plan

- [ ] CI: \`apps/api\` tests (\`turbo/apps/api/src/signals/routes/__tests__/chat-threads-v1.test.ts\`) — the existing fixtures use a clean agent so behavior at the boundary is unchanged.
- [ ] Manual smoke from zero-buddy on \`firmware-78313cb\`: long-press BtnA → speak → expect 201, not 400. (Serial captured the original 400 with the full error body; same capture script will confirm the fix.)