### PR TITLE
fix: redirect to / when switching accounts

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar-account.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar-account.tsx
@@ -440,7 +440,10 @@ export function AccountDropdown({
       clerk?.setActive({
         session: sessionId,
         beforeEmit: () => {
-          return window.location.reload();
+          // Navigate to "/" rather than reloading the current URL: the new
+          // account may not have access to the current route (e.g. an org
+          // scoped chat/agent id), which would otherwise render as 404.
+          window.location.href = "/";
         },
       }),
       Reason.DomCallback,


### PR DESCRIPTION
## Summary

- 切换账号时之前会调用 `window.location.reload()` 保留当前 URL；如果新账号没有当前 route 的访问权限（例如 org-scoped 的 chat id / agent id），页面会直接 404。
- 改成在 `beforeEmit` 里跳到 `/`，与 org 切换 (`watchOrgSwitch$` 中 `location.href = "/"`) 保持一致行为。

## Test plan

- [ ] 在 sidebar 账号 dropdown 中走到 `Switch account`，从 A 账号切到 B 账号
- [ ] 切换前停留在 `/agents/:id` 或 `/chats/:threadId` 之类 org 隔离的 URL
- [ ] 切换后页面应落到 `/`，而不是 404 not found

🤖 Generated with [Claude Code](https://claude.com/claude-code)