### PR TITLE
fix: allow null values in run context environment schema

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/components/context-content.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/context-content.tsx
@@ -27,7 +27,7 @@ function KeyValueTable({
   keyLabel = "Name",
   valueLabel = "Value",
 }: {
-  data: Record<string, string>;
+  data: Record<string, string | null>;
   keyLabel?: string;
   valueLabel?: string;
 }) {
@@ -49,7 +49,7 @@ function KeyValueTable({
             <TableRow key={key}>
               <TableCell className="font-mono text-xs">{key}</TableCell>
               <TableCell className="font-mono text-xs break-all">
-                {value}
+                {value ?? <span className="text-muted-foreground">—</span>}
               </TableCell>
             </TableRow>
           );

--- a/turbo/packages/api-contracts/src/contracts/zero-runs.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-runs.ts
@@ -198,7 +198,7 @@ const runContextResponseSchema = z.object({
   sessionId: z.string().nullable(),
   secretNames: z.array(z.string()),
   vars: z.record(z.string(), z.string()).nullable(),
-  environment: z.record(z.string(), z.string()),
+  environment: z.record(z.string(), z.string().nullable()),
   firewalls: z.array(runContextFirewallSchema),
   networkPolicies: networkPoliciesSchema.nullable(),
   volumes: z.array(runContextVolumeSchema),


### PR DESCRIPTION
## Summary

Fixes Sentry issue **API-1** (`Error: [ts-rest] Response validation failed for GET /api/zero/runs/:id/context`).

- The `environment` field in the run context response schema was typed as `z.record(z.string(), z.string())`, but environment variable values stored in Axiom can be `null` at runtime (e.g. when a connector secret like `AGENTMAIL_API_KEY`, `AGENTPHONE_TOKEN`, or `ANTHROPIC_API_KEY` is referenced in the compose but not set). This caused the ts-rest response validator to throw a `ValidationError` with `"Invalid input: expected string, received null"`.
- Widen the schema to `z.record(z.string(), z.string().nullable())` so the response passes validation.
- Update `KeyValueTable` in `context-content.tsx` to render null environment values as a `—` dash instead of nothing.

## Root cause

`buildRunContextSnapshot` in `runner-executor.ts` iterates `context.environment` and sets `environment[key] = value`, but `value` can be `null` at runtime despite the TypeScript type saying `string`. These null values get ingested into Axiom, and when the context endpoint reads them back, ts-rest's response validator rejects them.

## Test plan

- [ ] Open the run context panel for a run that uses connector-backed secrets (e.g. Agentphone or Agentmail) — the page should load without a 500 error
- [ ] Env vars with resolved values display their value; null/missing ones display `—`
- [ ] CI passes (lint, type-check, tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)