### PR TITLE
fix(web): drop non-string env values from run context response

### DIFF
--- a/turbo/apps/web/app/api/zero/runs/[id]/context/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/runs/[id]/context/__tests__/route.test.ts
@@ -112,6 +112,38 @@ describe("GET /api/zero/runs/:id/context", () => {
     expect(data.featureFlags).toEqual({ computerUse: true, voiceChat: false });
   });
 
+  it("should drop non-string environment values from the snapshot", async () => {
+    const userId = uniqueId("zctx-mixed");
+    await setupOrg(userId);
+    const compose = await createTestCompose(`agent-${uniqueId("zctx")}`);
+    const { runId } = await seedTestRun(userId, compose.composeId, {
+      status: "running",
+      prompt: "test prompt",
+    });
+
+    const snapshot = makeSnapshot(runId, userId);
+    const corruptedSnapshot = {
+      ...snapshot,
+      environment: {
+        NODE_ENV: "production",
+        API_KEY: "***",
+        // Simulates Axiom returning a non-string value (e.g. null after
+        // serialize/round-trip) — the route must not fail response validation.
+        AGENTMAIL_API_KEY: null,
+      },
+    } as unknown as RunContextSnapshot;
+    context.mocks.axiom.queryAxiom.mockResolvedValue([corruptedSnapshot]);
+
+    const response = await GET(createTestRequest(contextUrl(runId)));
+    expect(response.status).toBe(200);
+
+    const data = await response.json();
+    expect(data.environment).toEqual({
+      NODE_ENV: "production",
+      API_KEY: "***",
+    });
+  });
+
   it("should return 404 when run not found", async () => {
     const userId = uniqueId("zctx-nf");
     await setupOrg(userId);

--- a/turbo/apps/web/src/lib/infra/run/run-context-service.ts
+++ b/turbo/apps/web/src/lib/infra/run/run-context-service.ts
@@ -15,5 +15,27 @@ export async function queryRunContext(
 | limit 1`;
 
   const results = await queryAxiom<RunContextSnapshot>(apl);
-  return results[0] ?? null;
+  const snapshot = results[0];
+  if (!snapshot) {
+    return null;
+  }
+  // Axiom can return entries whose values lost their string type during
+  // serialize/round-trip (e.g. ingested as empty strings, returned as null).
+  // The ts-rest response schema requires Record<string, string>, so drop any
+  // non-string values to keep the contract intact.
+  return { ...snapshot, environment: filterStringValues(snapshot.environment) };
+}
+
+function filterStringValues(
+  value: Record<string, unknown> | null | undefined,
+): Record<string, string> {
+  if (!value) {
+    return {};
+  }
+  const entries = Object.entries(value).filter(
+    (entry): entry is [string, string] => {
+      return typeof entry[1] === "string";
+    },
+  );
+  return Object.fromEntries(entries);
 }


### PR DESCRIPTION
## Summary

- `GET /api/zero/runs/:id/context` on `apps/web` returned `snapshot.environment` directly from Axiom, but Axiom can round-trip values as `null`/non-string after ingestion.
- The ts-rest response schema requires `environment: z.record(z.string(), z.string())`, so any non-string value caused `[ts-rest] Response validation failed` — that's Sentry **[WEB-3N](https://vm0.sentry.io/issues/7465206960/)** (18 events).
- `apps/api`'s parallel implementation already filters via `stringRecordValue`. Per `CLAUDE.md` ("bug fixes and behavior or logic changes must update both implementations together"), this PR mirrors that normalization in `queryRunContext` so the response stays contract-compliant for both existing and new runs.

## Changes

- `turbo/apps/web/src/lib/infra/run/run-context-service.ts` — filter `snapshot.environment` to string-valued entries only.
- `turbo/apps/web/app/api/zero/runs/[id]/context/__tests__/route.test.ts` — add a case where Axiom returns a `null` env value and assert the route still returns 200 with the bad entry dropped.

## Test plan

- [ ] CI passes (lint, type-check, vitest); local DB unavailable so route test relies on CI.
- [ ] After deploy, WEB-3N stops accruing new events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)