### PR TITLE
chore: update rootfs package versions

### DIFF
--- a/crates/runner/scripts/build-template.sh
+++ b/crates/runner/scripts/build-template.sh
@@ -315,10 +315,10 @@ install_packages() {
 
   # Step 2: Add external APT repositories (needs curl and gpg from step 1).
   sudo chroot "$ROOTFS_DIR" bash -c 'set -e
-  # NodeSource repository (Node.js 24)
+  # NodeSource repository (Node.js 26)
   curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
     | gpg --dearmor -o /usr/share/keyrings/nodesource.gpg
-  echo "deb [signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_24.x nodistro main" \
+  echo "deb [signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_26.x nodistro main" \
     > /etc/apt/sources.list.d/nodesource.list
   printf "Package: nodejs\nPin: origin deb.nodesource.com\nPin-Priority: 600\n" \
     > /etc/apt/preferences.d/nodesource

--- a/crates/runner/scripts/verify-rootfs.sh
+++ b/crates/runner/scripts/verify-rootfs.sh
@@ -190,7 +190,7 @@ else
   errors+=("gh CLI not found at /usr/bin/gh")
 fi
 
-# npm-global bins land in /usr/bin (NodeSource Node 24 sets npm prefix to /usr).
+# npm-global bins land in /usr/bin (NodeSource Node sets npm prefix to /usr).
 if [[ -f "${MOUNT_DIR}/usr/bin/codex" ]]; then
   echo "  codex CLI: found"
 else


### PR DESCRIPTION
Updates rootfs package versions in the current rootfs template build script.

Updated:
- NodeSource Node.js repository: 24.x -> 26.x

Checked and already current:
- Go: 1.26.3
- Claude Code: 2.1.143
- @openai/codex: 0.130.0
- @googleworkspace/cli: 0.22.5
- @xdevplatform/xurl: 1.0.3
- agent-browser: 0.27.0

Note: crates/runner/scripts/build-rootfs.sh is not present on latest main; the pinned rootfs build dependencies are now in crates/runner/scripts/build-template.sh.