### PR TITLE
feat: add vercel cli auth toolchain snapshot

### DIFF
--- a/.github/DEPLOYMENT_SETUP.md
+++ b/.github/DEPLOYMENT_SETUP.md
@@ -66,6 +66,12 @@ Configure these in your GitHub repository settings (Settings → Secrets and var
   - Find in Vercel project settings → General → Team ID
 - `VERCEL_PROJECT_ID_WEB`: Your Vercel project ID for web app
   - Find in Vercel project settings → General → Project ID
+- `VERCEL_PROJECT_ID_API`: Your Vercel project ID for API app
+  - Used by preview API deploys and Vercel Sandbox CLI auth toolchain snapshot builds
+- `VERCEL_CLI_AUTH_SNAPSHOT_ID`: Latest stable Vercel Sandbox CLI auth toolchain snapshot ID (Optional)
+  - Store as a repository variable, not a secret
+  - CI refreshes this value from the CLI Auth Toolchain Snapshot workflow
+  - Clearing this variable is safe; CLI auth falls back to fresh sandboxes and pinned CLI installs
 - `NEON_PROJECT_ID`: Your Neon project ID (Optional but Recommended)
   - Find in Neon console → Project Settings → General
 - `CLERK_PUBLISHABLE_KEY`: Your Clerk publishable key (Required)

--- a/.github/actions/web-api-env/action.yml
+++ b/.github/actions/web-api-env/action.yml
@@ -37,6 +37,10 @@ inputs:
     description: "Backend API URL used by web proxy routes"
     required: false
     default: ""
+  cli-auth-snapshot-id:
+    description: "Workflow-built CLI auth toolchain snapshot ID override"
+    required: false
+    default: ""
 
 runs:
   using: "composite"
@@ -53,6 +57,7 @@ runs:
         INPUT_APP_URL: ${{ inputs.app-url }}
         INPUT_API_URL: ${{ inputs.api-url }}
         INPUT_API_BACKEND_URL: ${{ inputs.api-backend-url }}
+        INPUT_CLI_AUTH_SNAPSHOT_ID: ${{ inputs.cli-auth-snapshot-id }}
       run: |
         set -euo pipefail
 
@@ -152,6 +157,7 @@ runs:
         if [[ "$INPUT_APP" == "api" ]]; then
           add_env VM0_WEB_URL "$web_url"
           add_env ENV "$deploy_env"
+          add_env VERCEL_CLI_AUTH_SNAPSHOT_ID "$(first_non_empty "$INPUT_CLI_AUTH_SNAPSHOT_ID" "$(repo_var VERCEL_CLI_AUTH_SNAPSHOT_ID)")"
         fi
         # Inject the workflow head commit explicitly so OTel / Sentry can tag
         # service.version and release on every deploy. Vercel CLI prebuilt

--- a/.github/workflows/cli-auth-toolchain-snapshot.yml
+++ b/.github/workflows/cli-auth-toolchain-snapshot.yml
@@ -1,0 +1,47 @@
+name: CLI Auth Toolchain Snapshot
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "17 3 * * 1"
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260419
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/toolchain-init
+
+      - name: Build CLI auth toolchain snapshot
+        id: snapshot
+        working-directory: turbo/apps/api
+        env:
+          GIT_COMMIT_SHA: ${{ github.sha }}
+          VERCEL_TEAM_ID: ${{ vars.VERCEL_TEAM_ID }}
+          VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID_API }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          result_file="$(mktemp)"
+          pnpm build:cli-auth-toolchain-snapshot -- --expiration-ms $((30 * 24 * 60 * 60 * 1000)) > "$result_file"
+          jq . "$result_file"
+
+          snapshot_id="$(jq -r '.snapshotId // ""' "$result_file")"
+          if [[ -z "$snapshot_id" ]]; then
+            echo "::error::CLI auth toolchain snapshot builder did not output snapshotId"
+            exit 1
+          fi
+          echo "snapshot-id=$snapshot_id" >> "$GITHUB_OUTPUT"
+
+      - name: Publish stable CLI auth snapshot variable
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SNAPSHOT_ID: ${{ steps.snapshot.outputs.snapshot-id }}
+        run: gh variable set VERCEL_CLI_AUTH_SNAPSHOT_ID --repo "$GITHUB_REPOSITORY" --body "$SNAPSHOT_ID"

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -82,6 +82,7 @@ jobs:
       crates-changed: ${{ steps.detect-crates.outputs.crates-changed }}
       ci-changed: ${{ steps.detect-ci.outputs.ci-changed }}
       e2e-changed: ${{ steps.detect-e2e.outputs.e2e-changed }}
+      cli-auth-toolchain-changed: ${{ steps.detect-cli-auth-toolchain.outputs.cli-auth-toolchain-changed }}
       api-backend-needed: ${{ steps.detect-api-backend.outputs.api-backend-needed }}
       turbo-runner-consumer-needed: ${{ steps.runner-e2e.outputs.turbo-runner-consumer-needed }}
       base-ref: ${{ steps.detect.outputs.base-ref }}
@@ -194,6 +195,18 @@ jobs:
           else
             echo "No E2E test changes"
             echo "e2e-changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Detect CLI auth toolchain changes
+        id: detect-cli-auth-toolchain
+        run: |
+          BASE_REF="${{ steps.detect.outputs.base-ref }}"
+          if git diff --name-only "$BASE_REF" HEAD | grep -qE "^(turbo/apps/api/scripts/build-cli-auth-toolchain-snapshot\.ts|turbo/apps/api/package\.json|turbo/pnpm-lock\.yaml|turbo/apps/api/src/signals/external/(sandbox|vercel-sandbox)\.ts|turbo/apps/api/src/signals/services/(cli-auth-toolchain|cli-auth-stripe|vercel-sandbox-smoke)\.service\.ts|turbo/apps/api/src/signals/routes/vercel-sandbox-smoke\.ts|turbo/apps/api/src/signals/(external|routes)/__tests__/(sandbox|zero-connectors-cli-auth-stripe|vercel-sandbox-smoke)\.test\.ts|e2e/tests/01-serial/ser-t08-vercel-sandbox-smoke\.bats|\.github/actions/web-api-env/action\.yml|\.github/workflows/(turbo|cli-auth-toolchain-snapshot)\.yml)$"; then
+            echo "CLI auth toolchain changes detected"
+            echo "cli-auth-toolchain-changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No CLI auth toolchain changes"
+            echo "cli-auth-toolchain-changed=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Detect web API backend proxy changes
@@ -702,12 +715,14 @@ jobs:
         needs.prepare.outputs.crates-changed == 'true' ||
         needs.prepare.outputs.ci-changed == 'true' ||
         needs.prepare.outputs.e2e-changed == 'true' ||
+        needs.prepare.outputs.cli-auth-toolchain-changed == 'true' ||
         needs.prepare.outputs.api-backend-needed == 'true'
       )
     outputs:
       preview-url: ${{ steps.alias.outputs.url || steps.deploy.outputs.url }}
       api-preview-url: ${{ steps.api-alias.outputs.url || steps.api-deploy.outputs.url }}
     permissions:
+      actions: write
       contents: read
       pull-requests: write
       issues: write
@@ -896,6 +911,46 @@ jobs:
           deployment-id: ${{ steps.deployment.outputs.deployment_id }}
           deployment-env: ${{ steps.deployment.outputs.env }}
 
+      - name: Build CLI auth toolchain snapshot
+        id: cli-auth-snapshot
+        if: |
+          needs.prepare.outputs.cli-auth-toolchain-changed == 'true' && (
+            github.event_name == 'pull_request' ||
+            (github.event_name == 'push' && github.ref == 'refs/heads/main')
+          )
+        working-directory: turbo/apps/api
+        env:
+          GIT_COMMIT_SHA: ${{ github.sha }}
+          VERCEL_TEAM_ID: ${{ vars.VERCEL_TEAM_ID }}
+          VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID_API }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            expiration_ms=$((7 * 24 * 60 * 60 * 1000))
+          else
+            expiration_ms=$((30 * 24 * 60 * 60 * 1000))
+          fi
+
+          result_file="$(mktemp)"
+          pnpm build:cli-auth-toolchain-snapshot -- --expiration-ms "$expiration_ms" > "$result_file"
+          jq . "$result_file"
+
+          snapshot_id="$(jq -r '.snapshotId // ""' "$result_file")"
+          if [[ -z "$snapshot_id" ]]; then
+            echo "::error::CLI auth toolchain snapshot builder did not output snapshotId"
+            exit 1
+          fi
+          echo "snapshot-id=$snapshot_id" >> "$GITHUB_OUTPUT"
+
+      - name: Publish stable CLI auth snapshot variable
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.cli-auth-snapshot.outputs.snapshot-id != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SNAPSHOT_ID: ${{ steps.cli-auth-snapshot.outputs.snapshot-id }}
+        run: gh variable set VERCEL_CLI_AUTH_SNAPSHOT_ID --repo "$GITHUB_REPOSITORY" --body "$SNAPSHOT_ID"
+
       - name: Resolve API deploy environment
         id: api-deploy-env
         # Web previews are built with VM0_API_BACKEND_URL pointing at the
@@ -909,6 +964,7 @@ jobs:
           needs.prepare.outputs.crates-changed == 'true' ||
           needs.prepare.outputs.ci-changed == 'true' ||
           needs.prepare.outputs.e2e-changed == 'true' ||
+          needs.prepare.outputs.cli-auth-toolchain-changed == 'true' ||
           needs.prepare.outputs.api-backend-needed == 'true'
         uses: ./.github/actions/web-api-env
         with:
@@ -919,6 +975,7 @@ jobs:
           web-url: ${{ needs.prepare.outputs.web-preview-url }}
           app-url: ${{ needs.prepare.outputs.app-preview-url }}
           api-url: ${{ needs.prepare.outputs.web-preview-url }}
+          cli-auth-snapshot-id: ${{ steps.cli-auth-snapshot.outputs.snapshot-id }}
         env:
           REPO_VARS_JSON: ${{ toJSON(vars) }}
           REPO_SECRETS_JSON: ${{ toJSON(secrets) }}
@@ -933,6 +990,7 @@ jobs:
           needs.prepare.outputs.crates-changed == 'true' ||
           needs.prepare.outputs.ci-changed == 'true' ||
           needs.prepare.outputs.e2e-changed == 'true' ||
+          needs.prepare.outputs.cli-auth-toolchain-changed == 'true' ||
           needs.prepare.outputs.api-backend-needed == 'true'
         uses: ./.github/actions/vercel-deploy
         with:
@@ -961,6 +1019,7 @@ jobs:
           needs.prepare.outputs.crates-changed == 'true' ||
           needs.prepare.outputs.ci-changed == 'true' ||
           needs.prepare.outputs.e2e-changed == 'true' ||
+          needs.prepare.outputs.cli-auth-toolchain-changed == 'true' ||
           needs.prepare.outputs.api-backend-needed == 'true'
         run: |
           set -euo pipefail
@@ -987,6 +1046,7 @@ jobs:
             needs.prepare.outputs.crates-changed == 'true' ||
             needs.prepare.outputs.ci-changed == 'true' ||
             needs.prepare.outputs.e2e-changed == 'true' ||
+            needs.prepare.outputs.cli-auth-toolchain-changed == 'true' ||
             needs.prepare.outputs.api-backend-needed == 'true'
           )
         uses: ./.github/actions/vercel-alias
@@ -1010,6 +1070,7 @@ jobs:
             needs.prepare.outputs.crates-changed == 'true' ||
             needs.prepare.outputs.ci-changed == 'true' ||
             needs.prepare.outputs.e2e-changed == 'true' ||
+            needs.prepare.outputs.cli-auth-toolchain-changed == 'true' ||
             needs.prepare.outputs.api-backend-needed == 'true'
           )
         uses: marocchino/sticky-pull-request-comment@v3

--- a/e2e/tests/01-serial/ser-t08-vercel-sandbox-smoke.bats
+++ b/e2e/tests/01-serial/ser-t08-vercel-sandbox-smoke.bats
@@ -66,13 +66,25 @@ setup_file() {
 
     if ! jq -e '
       .success == true and
-      .sandbox.runtime == "node24" and
-      (.sandbox.id | type == "string" and length > 0) and
-      .command.cmd == "node" and
-      .command.args == ["--version"] and
-      .command.exitCode == 0 and
-      (.command.stdout | test("^v[0-9]+\\.[0-9]+\\.[0-9]+")) and
-      .cleanup.status == "stopped"
+      (.checks | length == 2) and
+      (.checks[] | select(.name == "node") |
+        .sandbox.runtime == "node24" and
+        (.sandbox.id | type == "string" and length > 0) and
+        .command.cmd == "node" and
+        .command.args == ["--version"] and
+        .command.exitCode == 0 and
+        (.command.stdout | test("^v[0-9]+\\.[0-9]+\\.[0-9]+")) and
+        .cleanup.status == "stopped"
+      ) and
+      (.checks[] | select(.name == "cli-auth-stripe") |
+        .sandbox.runtime == "node24" and
+        (.sandbox.id | type == "string" and length > 0) and
+        .command.cmd == "stripe" and
+        .command.args == ["--version"] and
+        .command.exitCode == 0 and
+        (.command.stdout | test("^stripe version 1\\.40\\.9\\b")) and
+        .cleanup.status == "stopped"
+      )
     ' "$body_file" >/dev/null; then
         echo "# smoke endpoint returned unexpected success payload" >&2
         echo "# response body: $(cat "$body_file")" >&2

--- a/turbo/apps/api/package.json
+++ b/turbo/apps/api/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "vite build",
+    "build:cli-auth-toolchain-snapshot": "tsx scripts/build-cli-auth-toolchain-snapshot.ts",
     "dev": "VM0_DEBUG=* tsx watch --env-file=.env.local src/server.ts",
     "start": "tsx src/server.ts",
     "test": "vitest run",

--- a/turbo/apps/api/scripts/build-cli-auth-toolchain-snapshot.ts
+++ b/turbo/apps/api/scripts/build-cli-auth-toolchain-snapshot.ts
@@ -1,0 +1,166 @@
+import { Sandbox } from "@vercel/sandbox";
+
+import {
+  CLI_AUTH_TOOLCHAIN_MANIFEST_PATH,
+  CLI_AUTH_TOOLCHAIN_RUNTIME,
+  CLI_AUTH_TOOLCHAIN_STRIPE_BIN,
+  CLI_AUTH_TOOLCHAIN_STRIPE_VERSION,
+  cliAuthStripeInstallScript,
+  cliAuthStripeManifestScript,
+  cliAuthStripeVersionScript,
+} from "../src/signals/services/cli-auth-toolchain.service";
+
+const DEFAULT_EXPIRATION_MS = 30 * 24 * 60 * 60 * 1000;
+const EXPIRATION_ARG = "--expiration-ms";
+
+interface CommandSummary {
+  readonly exitCode: number;
+  readonly stdout: string;
+  readonly stderr: string;
+}
+
+interface ToolchainManifest {
+  readonly version: 1;
+  readonly runtime: typeof CLI_AUTH_TOOLCHAIN_RUNTIME;
+  readonly builtAt: string;
+  readonly gitCommitSha: string | null;
+  readonly tools: readonly {
+    readonly name: "stripe";
+    readonly version: typeof CLI_AUTH_TOOLCHAIN_STRIPE_VERSION;
+    readonly path: typeof CLI_AUTH_TOOLCHAIN_STRIPE_BIN;
+  }[];
+}
+
+function requiredEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`${name} is required`);
+  }
+  return value;
+}
+
+function expirationMsFromArgs(args: readonly string[]): number {
+  const index = args.indexOf(EXPIRATION_ARG);
+  if (index === -1) {
+    return DEFAULT_EXPIRATION_MS;
+  }
+  const value = args[index + 1];
+  if (!value) {
+    throw new Error(`${EXPIRATION_ARG} requires a value`);
+  }
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed < 0) {
+    throw new Error(`${EXPIRATION_ARG} must be a non-negative integer`);
+  }
+  return parsed;
+}
+
+async function runCheckedCommand(args: {
+  readonly sandbox: Sandbox;
+  readonly label: string;
+  readonly script: string;
+}): Promise<CommandSummary> {
+  const command = await args.sandbox.runCommand({
+    cmd: "sh",
+    args: ["-lc", args.script],
+  });
+  const [stdout, stderr] = await Promise.all([
+    command.stdout(),
+    command.stderr(),
+  ]);
+  if (command.exitCode !== 0) {
+    throw new Error(
+      `${args.label} failed with exit code ${String(
+        command.exitCode,
+      )}: ${stderr || stdout}`,
+    );
+  }
+  return {
+    exitCode: command.exitCode,
+    stdout,
+    stderr,
+  };
+}
+
+function manifest(): ToolchainManifest {
+  return {
+    version: 1,
+    runtime: CLI_AUTH_TOOLCHAIN_RUNTIME,
+    builtAt: new Date().toISOString(),
+    gitCommitSha: process.env.GIT_COMMIT_SHA || process.env.GITHUB_SHA || null,
+    tools: [
+      {
+        name: "stripe",
+        version: CLI_AUTH_TOOLCHAIN_STRIPE_VERSION,
+        path: CLI_AUTH_TOOLCHAIN_STRIPE_BIN,
+      },
+    ],
+  };
+}
+
+async function main(): Promise<void> {
+  const expiration = expirationMsFromArgs(process.argv.slice(2));
+  const credentials = {
+    teamId: requiredEnv("VERCEL_TEAM_ID"),
+    projectId: requiredEnv("VERCEL_PROJECT_ID"),
+    token: requiredEnv("VERCEL_TOKEN"),
+  };
+
+  const sandbox = await Sandbox.create({
+    ...credentials,
+    runtime: CLI_AUTH_TOOLCHAIN_RUNTIME,
+    timeout: 15 * 60 * 1000,
+  });
+  let snapshotted = false;
+
+  try {
+    const install = await runCheckedCommand({
+      sandbox,
+      label: "install Stripe CLI auth toolchain",
+      script: cliAuthStripeInstallScript(),
+    });
+    const verify = await runCheckedCommand({
+      sandbox,
+      label: "verify Stripe CLI auth toolchain",
+      script: cliAuthStripeVersionScript(),
+    });
+    const toolchainManifest = manifest();
+    await runCheckedCommand({
+      sandbox,
+      label: "write CLI auth toolchain manifest",
+      script: cliAuthStripeManifestScript(
+        JSON.stringify(toolchainManifest, null, 2),
+      ),
+    });
+    const snapshot = await sandbox.snapshot({ expiration });
+    snapshotted = true;
+
+    process.stdout.write(
+      `${JSON.stringify({
+        snapshotId: snapshot.snapshotId,
+        expiresAt: snapshot.expiresAt?.toISOString() ?? null,
+        manifestPath: CLI_AUTH_TOOLCHAIN_MANIFEST_PATH,
+        manifest: toolchainManifest,
+        verification: {
+          install,
+          stripeVersion: verify,
+        },
+      })}\n`,
+    );
+  } finally {
+    if (!snapshotted) {
+      await sandbox.stop().catch((error: unknown) => {
+        process.stderr.write(
+          `Failed to stop CLI auth toolchain builder sandbox after failure: ${String(
+            error,
+          )}\n`,
+        );
+      });
+    }
+  }
+}
+
+main().catch((error: unknown) => {
+  process.stderr.write(`${String(error)}\n`);
+  process.exitCode = 1;
+});

--- a/turbo/apps/api/src/signals/external/__tests__/sandbox.test.ts
+++ b/turbo/apps/api/src/signals/external/__tests__/sandbox.test.ts
@@ -235,6 +235,39 @@ describe("Vercel sandbox client test override", () => {
     );
   });
 
+  it("passes snapshot source through to Vercel sandbox creation", async () => {
+    const mocks = getApiTestMocks();
+    mockOptionalEnv("VERCEL_TEAM_ID", "team_test");
+    mockOptionalEnv("VERCEL_PROJECT_ID", "project_test");
+    mockOptionalEnv("VERCEL_TOKEN", "token_test");
+
+    await expect(
+      getVercelSandboxClient().create({
+        source: {
+          type: "snapshot",
+          snapshotId: "snap_test",
+        },
+        timeoutMs: 1234,
+      }),
+    ).resolves.toStrictEqual({ sandboxId: "sb_created" });
+
+    expect(mocks.vercelSandbox.create).toHaveBeenCalledWith({
+      teamId: "team_test",
+      projectId: "project_test",
+      token: "token_test",
+      timeout: 1234,
+      resources: undefined,
+      ports: undefined,
+      env: undefined,
+      networkPolicy: undefined,
+      signal: undefined,
+      source: {
+        type: "snapshot",
+        snapshotId: "snap_test",
+      },
+    });
+  });
+
   it("allows tests to override cleanup timeout", () => {
     expect(() => {
       mockSandboxCleanupTimeoutMs(1);

--- a/turbo/apps/api/src/signals/external/sandbox.ts
+++ b/turbo/apps/api/src/signals/external/sandbox.ts
@@ -42,8 +42,14 @@ export type SandboxNetworkPolicy =
       };
     };
 
+export type SandboxCreateSource = {
+  readonly type: "snapshot";
+  readonly snapshotId: string;
+};
+
 export interface CreateSandboxOptions {
   readonly runtime?: string;
+  readonly source?: SandboxCreateSource;
   readonly timeoutMs?: number;
   readonly resources?: SandboxResources;
   readonly ports?: readonly number[];

--- a/turbo/apps/api/src/signals/external/vercel-sandbox.ts
+++ b/turbo/apps/api/src/signals/external/vercel-sandbox.ts
@@ -45,6 +45,9 @@ type VercelSandboxCredentials = {
   readonly projectId: string;
   readonly token: string;
 };
+type VercelCreateSandboxParams = Parameters<
+  VercelSandboxSdk["Sandbox"]["create"]
+>[0];
 type VercelSandboxInstance = Awaited<ReturnType<typeof getSandbox>>;
 type VercelCommandOutput = Awaited<ReturnType<typeof collectVercelCommandLogs>>;
 
@@ -253,9 +256,8 @@ function createRealVercelSandboxClient(): SandboxClient {
     create(options = {}): Promise<SandboxHandle> {
       return vercelSandboxOperation("create", async () => {
         const Sandbox = await getVercelSandboxClass();
-        const sandbox = await Sandbox.create({
+        const baseParams = {
           ...getVercelSandboxCredentials(),
-          runtime: options.runtime,
           timeout: options.timeoutMs,
           resources: options.resources,
           ports: options.ports ? [...options.ports] : undefined,
@@ -264,7 +266,18 @@ function createRealVercelSandboxClient(): SandboxClient {
             | VercelNetworkPolicy
             | undefined,
           signal: options.signal,
-        });
+        } satisfies VercelCreateSandboxParams;
+        const sandbox = await Sandbox.create(
+          options.source
+            ? {
+                ...baseParams,
+                source: options.source,
+              }
+            : {
+                ...baseParams,
+                runtime: options.runtime,
+              },
+        );
 
         return { sandboxId: sandbox.sandboxId };
       });

--- a/turbo/apps/api/src/signals/routes/__tests__/vercel-sandbox-smoke.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/vercel-sandbox-smoke.test.ts
@@ -1,9 +1,11 @@
-import { mockEnv } from "../../../lib/env";
+import { mockEnv, mockOptionalEnv, clearMockedEnv } from "../../../lib/env";
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
 import {
+  clearMockSandboxClient,
   emptyBoundedTextOutput,
   mockSandboxClient,
   sandboxError,
+  type BoundedTextOutput,
   type CreateSandboxOptions,
   type RunSandboxCommandOptions,
   type SandboxCleanupResult,
@@ -19,19 +21,59 @@ function client() {
   return setupApp({ context })(vercelSandboxSmokeContract);
 }
 
+function textOutput(text: string): BoundedTextOutput {
+  return {
+    text,
+    bytes: Buffer.byteLength(text),
+    limitBytes: 4 * 1024,
+    truncated: false,
+  };
+}
+
+function commandResult(args: {
+  readonly exitCode: number | null;
+  readonly stdout?: string;
+  readonly stderr?: string;
+}): SandboxCommandResult {
+  return {
+    sandboxId: "sandbox_smoke_test",
+    commandId: "cmd_smoke_test",
+    detached: false,
+    exitCode: args.exitCode,
+    stdout:
+      args.stdout === undefined
+        ? emptyBoundedTextOutput(4 * 1024)
+        : textOutput(args.stdout),
+    stderr:
+      args.stderr === undefined
+        ? emptyBoundedTextOutput(4 * 1024)
+        : textOutput(args.stderr),
+  };
+}
+
+type CommandResultInput =
+  | SandboxCommandResult
+  | Promise<SandboxCommandResult>
+  | (() => SandboxCommandResult | Promise<SandboxCommandResult>);
+
+function resolveCommandResult(input: CommandResultInput) {
+  return typeof input === "function" ? input() : input;
+}
+
 function mockSandbox(
   args: {
     readonly createError?: unknown;
     readonly runError?: unknown;
     readonly stopError?: unknown;
-    readonly runResult?: SandboxCommandResult;
+    readonly runResults?: readonly CommandResultInput[];
     readonly stop?: (
       handle: SandboxHandle,
       options?: StopSandboxOptions,
     ) => Promise<SandboxCleanupResult>;
   } = {},
 ) {
-  const handle = { sandboxId: "sandbox_smoke_test" };
+  let createdSandboxCount = 0;
+  const runResults = [...(args.runResults ?? [])];
   const calls = {
     create: [] as CreateSandboxOptions[],
     run: [] as {
@@ -51,7 +93,10 @@ function mockSandbox(
         throw args.createError;
       }
 
-      return Promise.resolve(handle);
+      createdSandboxCount += 1;
+      return Promise.resolve({
+        sandboxId: `sandbox_smoke_test_${String(createdSandboxCount)}`,
+      });
     },
     get(sandboxId) {
       return Promise.resolve({ sandboxId });
@@ -61,8 +106,18 @@ function mockSandbox(
       if (args.runError !== undefined) {
         throw args.runError;
       }
+      const runResult = runResults.shift();
+      if (runResult) {
+        return Promise.resolve(resolveCommandResult(runResult));
+      }
+      const script = options.args?.join(" ") ?? "";
       return Promise.resolve(
-        args.runResult ?? commandResult({ exitCode: 0, stdout: "v24.0.0\n" }),
+        script.includes("stripe")
+          ? commandResult({
+              exitCode: 0,
+              stdout: "stripe version 1.40.9\n",
+            })
+          : commandResult({ exitCode: 0, stdout: "v24.0.0\n" }),
       );
     },
     readFile() {
@@ -94,36 +149,6 @@ function mockSandbox(
   return calls;
 }
 
-function textOutput(text: string) {
-  return {
-    text,
-    bytes: Buffer.byteLength(text),
-    limitBytes: 1024,
-    truncated: false,
-  };
-}
-
-function commandResult(args: {
-  readonly exitCode: number | null;
-  readonly stdout?: string;
-  readonly stderr?: string;
-}): SandboxCommandResult {
-  return {
-    sandboxId: "sandbox_smoke_test",
-    commandId: "cmd_smoke_test",
-    detached: false,
-    exitCode: args.exitCode,
-    stdout:
-      args.stdout === undefined
-        ? emptyBoundedTextOutput(1024)
-        : textOutput(args.stdout),
-    stderr:
-      args.stderr === undefined
-        ? emptyBoundedTextOutput(1024)
-        : textOutput(args.stderr),
-  };
-}
-
 function abortError(message: string): Error {
   const error = new Error(message);
   error.name = "AbortError";
@@ -133,6 +158,11 @@ function abortError(message: string): Error {
 describe("POST /api/internal/vercel-sandbox/smoke", () => {
   beforeEach(() => {
     mockEnv("CRON_SECRET", "test-cron-secret");
+  });
+
+  afterEach(() => {
+    clearMockedEnv();
+    clearMockSandboxClient();
   });
 
   it("requires the cron secret", async () => {
@@ -152,19 +182,7 @@ describe("POST /api/internal/vercel-sandbox/smoke", () => {
     expect(calls.stop).toHaveLength(0);
   });
 
-  it("does not create a sandbox when the authorization header is missing", async () => {
-    const calls = mockSandbox();
-
-    const response = await accept(client().smoke({ headers: {} }), [401]);
-
-    expect(response.body).toStrictEqual({
-      error: { message: "Invalid cron secret", code: "UNAUTHORIZED" },
-    });
-    expect(calls.create).toHaveLength(0);
-    expect(calls.stop).toHaveLength(0);
-  });
-
-  it("runs the fixed smoke command and stops the sandbox", async () => {
+  it("runs base and CLI auth toolchain smoke checks", async () => {
     const calls = mockSandbox();
 
     const response = await accept(
@@ -174,36 +192,81 @@ describe("POST /api/internal/vercel-sandbox/smoke", () => {
       [200],
     );
 
-    expect(response.body).toStrictEqual({
-      success: true,
-      sandbox: {
-        id: "sandbox_smoke_test",
-        runtime: "node24",
+    expect(response.body.checks).toStrictEqual([
+      {
+        name: "node",
+        sandbox: { id: "sandbox_smoke_test_1", runtime: "node24" },
+        command: {
+          cmd: "node",
+          args: ["--version"],
+          exitCode: 0,
+          stdout: "v24.0.0\n",
+          stderr: "",
+        },
+        cleanup: { status: "stopped" },
       },
-      command: {
-        cmd: "node",
-        args: ["--version"],
-        exitCode: 0,
-        stdout: "v24.0.0\n",
-        stderr: "",
+      {
+        name: "cli-auth-stripe",
+        sandbox: { id: "sandbox_smoke_test_2", runtime: "node24" },
+        command: {
+          cmd: "stripe",
+          args: ["--version"],
+          exitCode: 0,
+          stdout: "stripe version 1.40.9\n",
+          stderr: "",
+        },
+        cleanup: { status: "stopped" },
       },
-      cleanup: { status: "stopped" },
-    });
-    expect(calls.create).toHaveLength(1);
+    ]);
+    expect(calls.create).toHaveLength(2);
     expect(calls.create[0]).toMatchObject({
       runtime: "node24",
       timeoutMs: 60_000,
     });
-    expect(calls.run).toHaveLength(1);
+    expect(calls.create[1]).toMatchObject({
+      runtime: "node24",
+      timeoutMs: 60_000,
+    });
+    expect(calls.run).toHaveLength(2);
     expect(calls.run[0]?.options).toMatchObject({
       cmd: "node",
       args: ["--version"],
-      outputLimitBytes: 1024,
+      outputLimitBytes: 4 * 1024,
     });
-    expect(calls.stop).toHaveLength(1);
-    expect(calls.stop[0]?.handle).toStrictEqual({
-      sandboxId: "sandbox_smoke_test",
+    expect(calls.run[1]?.options.args?.[1]).toContain(
+      "stripe-linux-checksums.txt",
+    );
+    expect(calls.run[1]?.options.args?.[1]).toContain(
+      '/vercel/sandbox/cli-auth/toolchain/bin/stripe" --version',
+    );
+    expect(calls.stop).toHaveLength(2);
+  });
+
+  it("uses the configured CLI auth snapshot for the toolchain smoke check", async () => {
+    mockOptionalEnv("VERCEL_CLI_AUTH_SNAPSHOT_ID", "snap_cli_auth");
+    const calls = mockSandbox();
+
+    await accept(
+      client().smoke({
+        headers: { authorization: "Bearer test-cron-secret" },
+      }),
+      [200],
+    );
+
+    expect(calls.create[1]).toMatchObject({
+      source: {
+        type: "snapshot",
+        snapshotId: "snap_cli_auth",
+      },
+      timeoutMs: 60_000,
     });
+    expect(calls.create[1]?.runtime).toBeUndefined();
+    expect(calls.run[1]?.options.args?.[1]).not.toContain(
+      "stripe-linux-checksums.txt",
+    );
+    expect(calls.run[1]?.options.args?.[1]).toContain(
+      '/vercel/sandbox/cli-auth/toolchain/bin/stripe" --version',
+    );
   });
 
   it("returns a failure when sandbox creation fails", async () => {
@@ -220,42 +283,17 @@ describe("POST /api/internal/vercel-sandbox/smoke", () => {
 
     expect(response.body).toStrictEqual({
       error: {
-        message: "Vercel Sandbox smoke check failed during sandbox creation",
+        message:
+          "node Vercel Sandbox smoke check failed during sandbox creation",
         code: "VERCEL_SANDBOX_SMOKE_FAILED",
         phase: "create",
+        check: "node",
         cause: {
           name: "Error",
           message: "create failed token=[redacted]",
         },
       },
-    });
-    expect(calls.stop).toHaveLength(0);
-  });
-
-  it("redacts non-error sandbox creation failures", async () => {
-    const calls = mockSandbox({
-      createError:
-        'create failed Bearer sandbox-token password=plain-text VERCEL_OIDC_TOKEN=oidc-secret {"access_token":"json-secret"}',
-    });
-
-    const response = await accept(
-      client().smoke({
-        headers: { authorization: "Bearer test-cron-secret" },
-      }),
-      [503],
-    );
-
-    expect(response.body).toStrictEqual({
-      error: {
-        message: "Vercel Sandbox smoke check failed during sandbox creation",
-        code: "VERCEL_SANDBOX_SMOKE_FAILED",
-        phase: "create",
-        cause: {
-          name: "Error",
-          message:
-            'create failed Bearer [redacted] password=[redacted] VERCEL_OIDC_TOKEN=[redacted] {"access_token":"[redacted]"}',
-        },
-      },
+      checks: [],
     });
     expect(calls.stop).toHaveLength(0);
   });
@@ -274,16 +312,19 @@ describe("POST /api/internal/vercel-sandbox/smoke", () => {
 
     expect(response.body).toStrictEqual({
       error: {
-        message: "Vercel Sandbox smoke check failed during command execution",
+        message:
+          "node Vercel Sandbox smoke check failed during command execution",
         code: "VERCEL_SANDBOX_SMOKE_FAILED",
         phase: "run",
+        check: "node",
         cause: {
           name: "Error",
           message: "run failed",
         },
       },
+      checks: [],
       sandbox: {
-        id: "sandbox_smoke_test",
+        id: "sandbox_smoke_test_1",
         runtime: "node24",
       },
       cleanup: { status: "stopped" },
@@ -305,26 +346,22 @@ describe("POST /api/internal/vercel-sandbox/smoke", () => {
       [503],
     );
 
-    expect(response.body).toStrictEqual({
+    expect(response.body.error).toStrictEqual({
+      message:
+        "node Vercel Sandbox smoke check failed during command execution",
+      code: "VERCEL_SANDBOX_SMOKE_FAILED",
+      phase: "run",
+      check: "node",
+      cause: {
+        name: "Error",
+        message: "run failed",
+      },
+    });
+    expect(response.body.cleanup).toStrictEqual({
+      status: "failed",
       error: {
-        message: "Vercel Sandbox smoke check failed during command execution",
-        code: "VERCEL_SANDBOX_SMOKE_FAILED",
-        phase: "run",
-        cause: {
-          name: "Error",
-          message: "run failed",
-        },
-      },
-      sandbox: {
-        id: "sandbox_smoke_test",
-        runtime: "node24",
-      },
-      cleanup: {
-        status: "failed",
-        error: {
-          name: "Error",
-          message: "stop failed",
-        },
+        name: "Error",
+        message: "stop failed",
       },
     });
     expect(calls.run).toHaveLength(1);
@@ -344,9 +381,11 @@ describe("POST /api/internal/vercel-sandbox/smoke", () => {
     );
 
     expect(response.body.error).toStrictEqual({
-      message: "Vercel Sandbox smoke check failed during command execution",
+      message:
+        "node Vercel Sandbox smoke check failed during command execution",
       code: "VERCEL_SANDBOX_SMOKE_FAILED",
       phase: "run",
+      check: "node",
       cause: {
         name: "AbortError",
         message: "request aborted",
@@ -375,16 +414,19 @@ describe("POST /api/internal/vercel-sandbox/smoke", () => {
 
     expect(response.body).toStrictEqual({
       error: {
-        message: "Vercel Sandbox smoke check failed during sandbox cleanup",
+        message:
+          "node Vercel Sandbox smoke check failed during sandbox cleanup",
         code: "VERCEL_SANDBOX_SMOKE_FAILED",
         phase: "cleanup",
+        check: "node",
         cause: {
           name: "AbortError",
           message: "Sandbox cleanup timed out",
         },
       },
+      checks: [],
       sandbox: {
-        id: "sandbox_smoke_test",
+        id: "sandbox_smoke_test_1",
         runtime: "node24",
       },
       command: {
@@ -399,50 +441,6 @@ describe("POST /api/internal/vercel-sandbox/smoke", () => {
         error: {
           name: "AbortError",
           message: "Sandbox cleanup timed out",
-        },
-      },
-    });
-    expect(calls.stop).toHaveLength(1);
-  });
-
-  it("returns command diagnostics when cleanup fails", async () => {
-    const calls = mockSandbox({
-      stopError: new Error("stop failed"),
-    });
-
-    const response = await accept(
-      client().smoke({
-        headers: { authorization: "Bearer test-cron-secret" },
-      }),
-      [503],
-    );
-
-    expect(response.body).toStrictEqual({
-      error: {
-        message: "Vercel Sandbox smoke check failed during sandbox cleanup",
-        code: "VERCEL_SANDBOX_SMOKE_FAILED",
-        phase: "cleanup",
-        cause: {
-          name: "Error",
-          message: "stop failed",
-        },
-      },
-      sandbox: {
-        id: "sandbox_smoke_test",
-        runtime: "node24",
-      },
-      command: {
-        cmd: "node",
-        args: ["--version"],
-        exitCode: 0,
-        stdout: "v24.0.0\n",
-        stderr: "",
-      },
-      cleanup: {
-        status: "failed",
-        error: {
-          name: "Error",
-          message: "stop failed",
         },
       },
     });
@@ -451,11 +449,13 @@ describe("POST /api/internal/vercel-sandbox/smoke", () => {
 
   it("treats a non-zero command exit as a smoke failure", async () => {
     const calls = mockSandbox({
-      runResult: commandResult({
-        exitCode: 1,
-        stdout: "",
-        stderr: "unexpected\n",
-      }),
+      runResults: [
+        commandResult({
+          exitCode: 1,
+          stdout: "",
+          stderr: "unexpected\n",
+        }),
+      ],
     });
 
     const response = await accept(
@@ -466,6 +466,7 @@ describe("POST /api/internal/vercel-sandbox/smoke", () => {
     );
 
     expect(response.body.error.phase).toBe("run");
+    expect(response.body.error.check).toBe("node");
     expect(response.body.command).toStrictEqual({
       cmd: "node",
       args: ["--version"],
@@ -479,11 +480,13 @@ describe("POST /api/internal/vercel-sandbox/smoke", () => {
 
   it("treats a missing command exit code as a smoke failure", async () => {
     const calls = mockSandbox({
-      runResult: commandResult({
-        exitCode: null,
-        stdout: "started\n",
-        stderr: "",
-      }),
+      runResults: [
+        commandResult({
+          exitCode: null,
+          stdout: "started\n",
+          stderr: "",
+        }),
+      ],
     });
 
     const response = await accept(
@@ -494,9 +497,11 @@ describe("POST /api/internal/vercel-sandbox/smoke", () => {
     );
 
     expect(response.body.error).toStrictEqual({
-      message: "Vercel Sandbox smoke check failed during command execution",
+      message:
+        "node Vercel Sandbox smoke check failed during command execution",
       code: "VERCEL_SANDBOX_SMOKE_FAILED",
       phase: "run",
+      check: "node",
       cause: {
         name: "Error",
         message: "Smoke command did not produce an exit code",

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-cli-auth-stripe.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-cli-auth-stripe.test.ts
@@ -17,6 +17,7 @@ import { afterEach, describe, expect, it } from "vitest";
 
 import { getApiTestMocks } from "../../../__tests__/mocks";
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { clearMockedEnv, mockOptionalEnv } from "../../../lib/env";
 import { clearMockNow, mockNow, nowDate } from "../../../lib/time";
 import {
   clearMockSandboxClient,
@@ -92,9 +93,22 @@ type CommandResultInput =
   | SandboxCommandResult
   | Promise<SandboxCommandResult>
   | (() => SandboxCommandResult | Promise<SandboxCommandResult>);
+type CreateResultInput =
+  | SandboxHandle
+  | Promise<SandboxHandle>
+  | Error
+  | (() => SandboxHandle | Promise<SandboxHandle>);
 
 function resolveCommandResult(input: CommandResultInput) {
   return typeof input === "function" ? input() : input;
+}
+
+async function resolveCreateResult(input: CreateResultInput) {
+  const result = typeof input === "function" ? await input() : await input;
+  if (result instanceof Error) {
+    throw result;
+  }
+  return result;
 }
 
 function deferred<T>() {
@@ -144,6 +158,8 @@ function mockStripeCliSandbox(
     readonly startNextStep?: string;
     readonly startVerificationCode?: string;
     readonly startStderr?: string;
+    readonly createResults?: readonly CreateResultInput[];
+    readonly installResults?: readonly CommandResultInput[];
     readonly startResults?: readonly CommandResultInput[];
     readonly completeExitCode?: number;
     readonly completeResults?: readonly CommandResultInput[];
@@ -152,6 +168,8 @@ function mockStripeCliSandbox(
 ) {
   const firstSandboxId = "sandbox_stripe_cli_auth_test";
   let createdSandboxCount = 0;
+  const createResults = [...(args.createResults ?? [])];
+  const installResults = [...(args.installResults ?? [])];
   const startResults = [...(args.startResults ?? [])];
   const completeResults = [...(args.completeResults ?? [])];
   const calls = {
@@ -173,6 +191,10 @@ function mockStripeCliSandbox(
   mockSandboxClient({
     create(options = {}) {
       calls.create.push(options);
+      const createResult = createResults.shift();
+      if (createResult) {
+        return resolveCreateResult(createResult);
+      }
       const sandboxId =
         createdSandboxCount === 0
           ? firstSandboxId
@@ -186,6 +208,21 @@ function mockStripeCliSandbox(
     runCommand(commandHandle, options) {
       calls.run.push({ handle: commandHandle, options });
       const script = options.args?.[1] ?? "";
+      if (script.includes("stripe-linux-checksums.txt")) {
+        const installResult = installResults.shift();
+        if (installResult) {
+          return Promise.resolve(resolveCommandResult(installResult));
+        }
+        if (!script.includes("--non-interactive")) {
+          return Promise.resolve(
+            commandResult({
+              sandboxId: commandHandle.sandboxId,
+              exitCode: 0,
+              stderr: "stripe_1.40.9_linux_x86_64.tar.gz: OK\n",
+            }),
+          );
+        }
+      }
       if (script.includes("--non-interactive")) {
         const startResult = startResults.shift();
         if (startResult) {
@@ -359,6 +396,7 @@ describe("CLI auth for Stripe connector routes", () => {
   const fixtures: { readonly userId: string; readonly orgId: string }[] = [];
 
   afterEach(async () => {
+    clearMockedEnv();
     clearMockNow();
     clearMockSandboxClient();
     while (fixtures.length > 0) {
@@ -467,6 +505,9 @@ describe("CLI auth for Stripe connector routes", () => {
     });
     const startScript = calls.run[0]?.options.args?.[1] ?? "";
     expect(startScript).toContain("--non-interactive");
+    expect(startScript.indexOf("stripe-linux-checksums.txt")).toBeLessThan(
+      startScript.indexOf("--non-interactive"),
+    );
     expect(startScript).toContain(
       "releases/download/v1.40.9/stripe_1.40.9_linux_x86_64.tar.gz",
     );
@@ -489,6 +530,129 @@ describe("CLI auth for Stripe connector routes", () => {
     });
     expect(session.encryptedProviderState).toBeTruthy();
     expect(session.encryptedProviderState).not.toContain("poll-token");
+  });
+
+  it("uses the configured CLI auth snapshot without install preflight", async () => {
+    mockOptionalEnv("VERCEL_CLI_AUTH_SNAPSHOT_ID", "snap_cli_auth");
+    await setupUser();
+    const calls = mockStripeCliSandbox();
+
+    const response = await accept(
+      client().start({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { mode: "test" },
+      }),
+      [200],
+    );
+
+    expect(response.body.status).toBe("pending");
+    expect(calls.create).toHaveLength(1);
+    expect(calls.create[0]).toMatchObject({
+      source: {
+        type: "snapshot",
+        snapshotId: "snap_cli_auth",
+      },
+      timeoutMs: 15 * 60 * 1000,
+    });
+    expect(calls.create[0]?.runtime).toBeUndefined();
+    expect(calls.run).toHaveLength(1);
+    const startScript = calls.run[0]?.options.args?.[1] ?? "";
+    expect(startScript).toContain("--non-interactive");
+    expect(startScript).not.toContain("stripe-linux-checksums.txt");
+    expect(startScript).toContain(
+      "/vercel/sandbox/cli-auth/toolchain/bin/stripe",
+    );
+  });
+
+  it("falls back to a fresh sandbox when snapshot creation fails", async () => {
+    mockOptionalEnv("VERCEL_CLI_AUTH_SNAPSHOT_ID", "snap_cli_auth");
+    await setupUser();
+    const calls = mockStripeCliSandbox({
+      createResults: [new Error("snapshot expired")],
+    });
+
+    const response = await accept(
+      client().start({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { mode: "test" },
+      }),
+      [200],
+    );
+
+    expect(response.body.status).toBe("pending");
+    expect(calls.create).toHaveLength(2);
+    expect(calls.create[0]).toMatchObject({
+      source: {
+        type: "snapshot",
+        snapshotId: "snap_cli_auth",
+      },
+    });
+    expect(calls.create[1]).toMatchObject({
+      runtime: "node24",
+      timeoutMs: 15 * 60 * 1000,
+    });
+    expect(calls.run).toHaveLength(1);
+    expect(calls.run[0]?.options.args?.[1]).toContain(
+      "stripe-linux-checksums.txt",
+    );
+  });
+
+  it("repairs a snapshot sandbox with a missing Stripe CLI and retries once", async () => {
+    mockOptionalEnv("VERCEL_CLI_AUTH_SNAPSHOT_ID", "snap_cli_auth");
+    await setupUser();
+    const calls = mockStripeCliSandbox({
+      startResults: [
+        commandResult({
+          exitCode: 127,
+          stderr: "/vercel/sandbox/cli-auth/toolchain/bin/stripe: not found\n",
+        }),
+        commandResult({ exitCode: 0, stdout: startOutput() }),
+      ],
+    });
+
+    const response = await accept(
+      client().start({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { mode: "test" },
+      }),
+      [200],
+    );
+
+    expect(response.body.status).toBe("pending");
+    expect(calls.run).toHaveLength(3);
+    expect(calls.run[0]?.options.args?.[1]).not.toContain(
+      "stripe-linux-checksums.txt",
+    );
+    expect(calls.run[1]?.options.args?.[1]).toContain(
+      "stripe-linux-checksums.txt",
+    );
+    expect(calls.run[1]?.options.args?.[1]).not.toContain("--non-interactive");
+    expect(calls.run[2]?.options.args?.[1]).toContain("--non-interactive");
+  });
+
+  it("does not repair non-toolchain provider failures from snapshot sandboxes", async () => {
+    mockOptionalEnv("VERCEL_CLI_AUTH_SNAPSHOT_ID", "snap_cli_auth");
+    await setupUser();
+    const calls = mockStripeCliSandbox({
+      startResults: [
+        commandResult({
+          exitCode: 1,
+          stderr: "Stripe login failed\n",
+        }),
+      ],
+    });
+
+    const response = await accept(
+      client().start({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { mode: "test" },
+      }),
+      [503],
+    );
+
+    expect(response.body.error.code).toBe("CLI_AUTH_STRIPE_FAILED");
+    expect(calls.run).toHaveLength(1);
+    expect(calls.stop).toHaveLength(1);
   });
 
   it("reuses an active same-mode CLI auth session instead of starting another sandbox", async () => {

--- a/turbo/apps/api/src/signals/routes/vercel-sandbox-smoke.ts
+++ b/turbo/apps/api/src/signals/routes/vercel-sandbox-smoke.ts
@@ -22,11 +22,20 @@ const smokeSandboxSchema = z.object({
 });
 
 const smokeCommandSchema = z.object({
-  cmd: z.literal("node"),
-  args: z.tuple([z.literal("--version")]),
+  cmd: z.string(),
+  args: z.array(z.string()),
   exitCode: z.number().int(),
   stdout: z.string(),
   stderr: z.string(),
+});
+
+const smokeCheckNameSchema = z.enum(["node", "cli-auth-stripe"]);
+
+const smokeCheckSchema = z.object({
+  name: smokeCheckNameSchema,
+  sandbox: smokeSandboxSchema,
+  command: smokeCommandSchema,
+  cleanup: z.object({ status: z.literal("stopped") }),
 });
 
 const smokeCleanupSchema = z.discriminatedUnion("status", [
@@ -42,8 +51,10 @@ const smokeFailureSchema = z.object({
     message: z.string(),
     code: z.literal("VERCEL_SANDBOX_SMOKE_FAILED"),
     phase: z.enum(["create", "run", "cleanup"]),
+    check: smokeCheckNameSchema,
     cause: smokeErrorSchema,
   }),
+  checks: z.array(smokeCheckSchema),
   sandbox: smokeSandboxSchema.optional(),
   command: smokeCommandSchema.optional(),
   cleanup: smokeCleanupSchema.optional(),
@@ -67,9 +78,7 @@ export const vercelSandboxSmokeContract = c.router({
     responses: {
       200: z.object({
         success: z.literal(true),
-        sandbox: smokeSandboxSchema,
-        command: smokeCommandSchema,
-        cleanup: z.object({ status: z.literal("stopped") }),
+        checks: z.array(smokeCheckSchema),
       }),
       401: unauthorizedSchema,
       503: smokeFailureSchema,
@@ -83,13 +92,13 @@ function failureMessage(
 ) {
   switch (result.phase) {
     case "create": {
-      return "Vercel Sandbox smoke check failed during sandbox creation";
+      return `${result.checkName} Vercel Sandbox smoke check failed during sandbox creation`;
     }
     case "run": {
-      return "Vercel Sandbox smoke check failed during command execution";
+      return `${result.checkName} Vercel Sandbox smoke check failed during command execution`;
     }
     case "cleanup": {
-      return "Vercel Sandbox smoke check failed during sandbox cleanup";
+      return `${result.checkName} Vercel Sandbox smoke check failed during sandbox cleanup`;
     }
   }
 }
@@ -106,9 +115,7 @@ const vercelSandboxSmokeRoute$ = command(
         status: 200 as const,
         body: {
           success: true as const,
-          sandbox: result.sandbox,
-          command: result.command,
-          cleanup: result.cleanup,
+          checks: result.checks,
         },
       };
     }
@@ -120,8 +127,10 @@ const vercelSandboxSmokeRoute$ = command(
           message: failureMessage(result),
           code: "VERCEL_SANDBOX_SMOKE_FAILED" as const,
           phase: result.phase,
+          check: result.checkName,
           cause: result.error,
         },
+        checks: result.checks,
         ...(result.sandbox ? { sandbox: result.sandbox } : {}),
         ...(result.command ? { command: result.command } : {}),
         ...(result.cleanup ? { cleanup: result.cleanup } : {}),

--- a/turbo/apps/api/src/signals/services/cli-auth-stripe.service.ts
+++ b/turbo/apps/api/src/signals/services/cli-auth-stripe.service.ts
@@ -2,6 +2,7 @@ import { command, type Setter } from "ccstate";
 import type { ConnectorResponse } from "@vm0/api-contracts/contracts/connector-schemas";
 import { z } from "zod";
 
+import { optionalEnv } from "../../lib/env";
 import { nowDate } from "../../lib/time";
 import { logger } from "../../lib/log";
 import { getVercelSandboxClient } from "../external/vercel-sandbox";
@@ -9,6 +10,7 @@ import {
   sandboxOperation,
   type SandboxClient,
   type SandboxCommandResult,
+  type SandboxError,
   type SandboxHandle,
 } from "../external/sandbox";
 import { connectors } from "@vm0/db/schema/connector";
@@ -26,11 +28,13 @@ import {
   type StripeCliAuthMode,
   type StripeCliAuthStartOutput,
 } from "./cli-auth-stripe-parser";
+import {
+  CLI_AUTH_TOOLCHAIN_RUNTIME,
+  CLI_AUTH_TOOLCHAIN_SNAPSHOT_ID_ENV,
+  CLI_AUTH_TOOLCHAIN_STRIPE_BIN,
+  cliAuthStripeInstallScript,
+} from "./cli-auth-toolchain.service";
 
-const CLI_AUTH_STRIPE_RUNTIME = "node24";
-const CLI_AUTH_STRIPE_VERSION = "1.40.9";
-const CLI_AUTH_STRIPE_ARCHIVE = `stripe_${CLI_AUTH_STRIPE_VERSION}_linux_x86_64.tar.gz`;
-const CLI_AUTH_STRIPE_RELEASE_URL = `https://github.com/stripe/stripe-cli/releases/download/v${CLI_AUTH_STRIPE_VERSION}`;
 const CLI_AUTH_STRIPE_TIMEOUT_MS = 15 * 60 * 1000;
 const CLI_AUTH_STRIPE_SESSION_TTL_SECONDS = 10 * 60;
 const CLI_AUTH_STRIPE_POLL_INTERVAL_SECONDS = 5;
@@ -40,7 +44,6 @@ const CLI_AUTH_STRIPE_COMPLETING_STALE_MS = 2 * 60 * 1000;
 const CLI_AUTH_STRIPE_OUTPUT_LIMIT_BYTES = 16 * 1024;
 const CLI_AUTH_STRIPE_CONFIG_LIMIT_BYTES = 16 * 1024;
 const CLI_AUTH_STRIPE_ROOT = "/vercel/sandbox/cli-auth/stripe";
-const CLI_AUTH_STRIPE_BIN_DIR = `${CLI_AUTH_STRIPE_ROOT}/bin`;
 const CLI_AUTH_STRIPE_CONFIG_HOME = `${CLI_AUTH_STRIPE_ROOT}/config`;
 const CLI_AUTH_STRIPE_CONFIG_PATH = `${CLI_AUTH_STRIPE_CONFIG_HOME}/stripe/config.toml`;
 const CLI_AUTH_STRIPE_CONNECTOR_TYPE = "stripe";
@@ -130,8 +133,19 @@ type CliAuthStripePendingResult = Extract<
   CliAuthStripeCompleteResult,
   { readonly status: "pending" }
 >;
+type CliAuthStripeStartInSandboxResult =
+  | { readonly ok: true; readonly output: StripeCliAuthStartOutput }
+  | { readonly ok: false; readonly result: CliAuthStripeStartFailureResult };
+type CliAuthStripeStartInSandboxFailure = Extract<
+  CliAuthStripeStartInSandboxResult,
+  { readonly ok: false }
+>;
 type ConnectorCliAuthSession = typeof connectorCliAuthSessions.$inferSelect;
 type ConnectorCliAuthSessionStatus = ConnectorCliAuthSession["status"];
+type CliAuthStripeSandboxOrigin =
+  | "snapshot"
+  | "fresh-no-snapshot"
+  | "fresh-after-snapshot-failure";
 
 const CLI_AUTH_STRIPE_ACTIVE_STATUSES = [
   "initializing",
@@ -174,32 +188,25 @@ type PreparedCliAuthStripeStart =
     };
 
 function startCommandScript(): string {
+  return `${cliAuthStripeInstallScript()}
+${stripeLoginStartCommandScript()}`;
+}
+
+function stripeLoginStartCommandScript(): string {
   return String.raw`set -euo pipefail
-BIN_DIR="${CLI_AUTH_STRIPE_BIN_DIR}"
 CONFIG_HOME="${CLI_AUTH_STRIPE_CONFIG_HOME}"
-mkdir -p "$BIN_DIR" "$CONFIG_HOME"
-if [ ! -x "$BIN_DIR/stripe" ]; then
-  curl -fsSL "${CLI_AUTH_STRIPE_RELEASE_URL}/${CLI_AUTH_STRIPE_ARCHIVE}" -o "/tmp/${CLI_AUTH_STRIPE_ARCHIVE}"
-  curl -fsSL "${CLI_AUTH_STRIPE_RELEASE_URL}/stripe-linux-checksums.txt" -o /tmp/stripe-linux-checksums.txt
-  grep " ${CLI_AUTH_STRIPE_ARCHIVE}$" /tmp/stripe-linux-checksums.txt > /tmp/stripe-cli.sha256
-  (cd /tmp && sha256sum -c stripe-cli.sha256) >&2
-  tar -xzf "/tmp/${CLI_AUTH_STRIPE_ARCHIVE}" -C "$BIN_DIR" stripe
-  chmod +x "$BIN_DIR/stripe"
-fi
-export PATH="$BIN_DIR:$PATH"
+mkdir -p "$CONFIG_HOME"
 export XDG_CONFIG_HOME="$CONFIG_HOME"
 export STRIPE_DEVICE_NAME="\${STRIPE_DEVICE_NAME:-vm0-cli-auth}"
-stripe login --non-interactive`;
+"${CLI_AUTH_TOOLCHAIN_STRIPE_BIN}" login --non-interactive`;
 }
 
 function completeCommandScript(): string {
   return String.raw`set -euo pipefail
-BIN_DIR="${CLI_AUTH_STRIPE_BIN_DIR}"
 CONFIG_HOME="${CLI_AUTH_STRIPE_CONFIG_HOME}"
-test -x "$BIN_DIR/stripe"
-export PATH="$BIN_DIR:$PATH"
+test -x "${CLI_AUTH_TOOLCHAIN_STRIPE_BIN}"
 export XDG_CONFIG_HOME="$CONFIG_HOME"
-timeout ${CLI_AUTH_STRIPE_COMPLETE_TIMEOUT_SECONDS}s stripe login --complete "$STRIPE_POLL_URL"`;
+timeout ${CLI_AUTH_STRIPE_COMPLETE_TIMEOUT_SECONDS}s "${CLI_AUTH_TOOLCHAIN_STRIPE_BIN}" login --complete "$STRIPE_POLL_URL"`;
 }
 
 function tokenExpiresAt(now: Date): Date {
@@ -567,6 +574,95 @@ async function createCliAuthStripeSession(args: {
   return session;
 }
 
+async function createCliAuthStripeSandboxHandle(args: {
+  readonly client: SandboxClient;
+  readonly signal: AbortSignal;
+}): Promise<
+  | {
+      readonly ok: true;
+      readonly sandbox: SandboxHandle;
+      readonly origin: CliAuthStripeSandboxOrigin;
+    }
+  | { readonly ok: false; readonly error: SandboxError }
+> {
+  const snapshotId = optionalEnv(CLI_AUTH_TOOLCHAIN_SNAPSHOT_ID_ENV);
+  let snapshotCreateError: SandboxError | null = null;
+
+  if (snapshotId) {
+    const snapshotResult = await sandboxOperation("create", () => {
+      return args.client.create({
+        source: {
+          type: "snapshot",
+          snapshotId,
+        },
+        timeoutMs: CLI_AUTH_STRIPE_TIMEOUT_MS,
+        signal: args.signal,
+      });
+    });
+    if (snapshotResult.ok) {
+      L.debug("Created CLI auth Stripe sandbox from CLI auth snapshot", {
+        sandboxId: snapshotResult.value.sandboxId,
+        snapshotId,
+      });
+      return {
+        ok: true,
+        sandbox: snapshotResult.value,
+        origin: "snapshot",
+      };
+    }
+    snapshotCreateError = snapshotResult.error;
+    L.warn(
+      "Failed to create CLI auth Stripe sandbox from CLI auth snapshot; retrying fresh sandbox",
+      {
+        snapshotId,
+        error: snapshotCreateError,
+      },
+    );
+  } else {
+    L.debug(
+      "No CLI auth snapshot ID configured; creating fresh CLI auth Stripe sandbox",
+      {
+        env: CLI_AUTH_TOOLCHAIN_SNAPSHOT_ID_ENV,
+      },
+    );
+  }
+
+  const freshResult = await sandboxOperation("create", () => {
+    return args.client.create({
+      runtime: CLI_AUTH_TOOLCHAIN_RUNTIME,
+      timeoutMs: CLI_AUTH_STRIPE_TIMEOUT_MS,
+      signal: args.signal,
+    });
+  });
+
+  if (!freshResult.ok) {
+    if (snapshotCreateError) {
+      return {
+        ok: false,
+        error: {
+          ...freshResult.error,
+          message: `CLI auth snapshot sandbox creation failed: ${snapshotCreateError.message}; fresh sandbox creation failed: ${freshResult.error.message}`,
+        },
+      };
+    }
+    return { ok: false, error: freshResult.error };
+  }
+
+  L.debug("Created fresh CLI auth Stripe sandbox", {
+    sandboxId: freshResult.value.sandboxId,
+    reason: snapshotCreateError
+      ? "snapshot-create-failed"
+      : "snapshot-id-missing",
+  });
+  return {
+    ok: true,
+    sandbox: freshResult.value,
+    origin: snapshotCreateError
+      ? "fresh-after-snapshot-failure"
+      : "fresh-no-snapshot",
+  };
+}
+
 async function createCliAuthStripeSandbox(args: {
   readonly writeDb: Db;
   readonly client: SandboxClient;
@@ -577,15 +673,13 @@ async function createCliAuthStripeSandbox(args: {
       readonly ok: true;
       readonly sandbox: SandboxHandle;
       readonly session: ConnectorCliAuthSession;
+      readonly origin: CliAuthStripeSandboxOrigin;
     }
   | { readonly ok: false; readonly result: CliAuthStripeStartFailureResult }
 > {
-  const createResult = await sandboxOperation("create", () => {
-    return args.client.create({
-      runtime: CLI_AUTH_STRIPE_RUNTIME,
-      timeoutMs: CLI_AUTH_STRIPE_TIMEOUT_MS,
-      signal: args.signal,
-    });
+  const createResult = await createCliAuthStripeSandboxHandle({
+    client: args.client,
+    signal: args.signal,
   });
 
   if (!createResult.ok) {
@@ -606,7 +700,7 @@ async function createCliAuthStripeSandbox(args: {
     };
   }
 
-  const sandbox = createResult.value;
+  const sandbox = createResult.sandbox;
   const updateResult = await settle(
     args.writeDb
       .update(connectorCliAuthSessions)
@@ -645,7 +739,12 @@ async function createCliAuthStripeSandbox(args: {
   }
   args.signal.throwIfAborted();
 
-  return { ok: true, sandbox, session: updatedSession };
+  return {
+    ok: true,
+    sandbox,
+    session: updatedSession,
+    origin: createResult.origin,
+  };
 }
 
 function parseCliAuthStripeStartOutput(
@@ -669,88 +768,203 @@ function parseCliAuthStripeStartOutput(
   return { ok: true, output: parsedResult.ok };
 }
 
-async function runCliAuthStripeStartInSandbox(args: {
-  readonly writeDb: Db;
+function isCliAuthStripeToolchainFailure(
+  result: SandboxCommandResult,
+): boolean {
+  const text = commandText(result);
+  return (
+    result.exitCode === 126 ||
+    result.exitCode === 127 ||
+    /not found|no such file|permission denied/i.test(text) ||
+    /unknown flag.*non-interactive/i.test(text) ||
+    /unknown command.*login/i.test(text) ||
+    /unsupported.*non-interactive/i.test(text) ||
+    /requires.*stripe.*version/i.test(text)
+  );
+}
+
+async function runCliAuthStripeInstallInSandbox(args: {
   readonly client: SandboxClient;
   readonly sandbox: SandboxHandle;
-  readonly session: ConnectorCliAuthSession;
   readonly signal: AbortSignal;
 }): Promise<
-  | { readonly ok: true; readonly output: StripeCliAuthStartOutput }
-  | { readonly ok: false; readonly result: CliAuthStripeStartFailureResult }
+  { readonly ok: true } | { readonly ok: false; readonly message: string }
 > {
-  const runResult = await sandboxOperation("run", () => {
+  const installResult = await sandboxOperation("run", () => {
     return args.client.runCommand(args.sandbox, {
       cmd: "sh",
-      args: ["-lc", startCommandScript()],
+      args: ["-lc", cliAuthStripeInstallScript()],
       outputLimitBytes: CLI_AUTH_STRIPE_OUTPUT_LIMIT_BYTES,
       signal: args.signal,
     });
   });
 
-  if (!runResult.ok) {
-    await markCliAuthStripeSessionError({
-      writeDb: args.writeDb,
-      sessionId: args.session.id,
-      message: runResult.error.message,
-      expectedStatus: args.session.status,
-      expectedUpdatedAt: args.session.updatedAt,
-    });
-    await cleanupSandbox(args.client, args.sandbox);
-    args.signal.throwIfAborted();
+  if (!installResult.ok) {
+    return { ok: false, message: installResult.error.message };
+  }
+  if (installResult.value.exitCode !== 0) {
     return {
       ok: false,
-      result: {
-        ok: false,
-        code: "CLI_AUTH_STRIPE_FAILED",
-        message: runResult.error.message,
-      },
+      message: commandFailedMessage(
+        "CLI auth for Stripe bootstrap",
+        installResult.value,
+      ),
     };
   }
 
-  if (runResult.value.exitCode !== 0) {
+  L.debug("Installed and verified CLI auth Stripe toolchain", {
+    sandboxId: args.sandbox.sandboxId,
+  });
+  return { ok: true };
+}
+
+function runCliAuthStripeStartCommand(args: {
+  readonly client: SandboxClient;
+  readonly sandbox: SandboxHandle;
+  readonly signal: AbortSignal;
+  readonly script: string;
+}) {
+  return sandboxOperation("run", () => {
+    return args.client.runCommand(args.sandbox, {
+      cmd: "sh",
+      args: ["-lc", args.script],
+      outputLimitBytes: CLI_AUTH_STRIPE_OUTPUT_LIMIT_BYTES,
+      signal: args.signal,
+    });
+  });
+}
+
+async function failCliAuthStripeStartInSandbox(args: {
+  readonly writeDb: Db;
+  readonly client: SandboxClient;
+  readonly sandbox: SandboxHandle;
+  readonly session: ConnectorCliAuthSession;
+  readonly signal: AbortSignal;
+  readonly message: string;
+}): Promise<CliAuthStripeStartInSandboxFailure> {
+  await markCliAuthStripeSessionError({
+    writeDb: args.writeDb,
+    sessionId: args.session.id,
+    message: args.message,
+    expectedStatus: args.session.status,
+    expectedUpdatedAt: args.session.updatedAt,
+  });
+  await cleanupSandbox(args.client, args.sandbox);
+  args.signal.throwIfAborted();
+  return {
+    ok: false,
+    result: {
+      ok: false,
+      code: "CLI_AUTH_STRIPE_FAILED",
+      message: args.message,
+    },
+  };
+}
+
+async function repairCliAuthStripeSnapshotToolchain(args: {
+  readonly writeDb: Db;
+  readonly client: SandboxClient;
+  readonly sandbox: SandboxHandle;
+  readonly session: ConnectorCliAuthSession;
+  readonly signal: AbortSignal;
+  readonly exitCode: number | null;
+}): Promise<
+  | { readonly ok: true; readonly result: SandboxCommandResult }
+  | { readonly ok: false; readonly result: CliAuthStripeStartFailureResult }
+> {
+  L.warn(
+    "CLI auth Stripe snapshot sandbox is missing the expected toolchain; installing pinned CLI and retrying once",
+    {
+      sandboxId: args.sandbox.sandboxId,
+      exitCode: args.exitCode,
+    },
+  );
+  const installResult = await runCliAuthStripeInstallInSandbox({
+    client: args.client,
+    sandbox: args.sandbox,
+    signal: args.signal,
+  });
+  if (!installResult.ok) {
+    return failCliAuthStripeStartInSandbox({
+      ...args,
+      message: installResult.message,
+    });
+  }
+
+  const retryResult = await runCliAuthStripeStartCommand({
+    client: args.client,
+    sandbox: args.sandbox,
+    signal: args.signal,
+    script: stripeLoginStartCommandScript(),
+  });
+  if (!retryResult.ok) {
+    return failCliAuthStripeStartInSandbox({
+      ...args,
+      message: retryResult.error.message,
+    });
+  }
+
+  return { ok: true, result: retryResult.value };
+}
+
+async function runCliAuthStripeStartInSandbox(args: {
+  readonly writeDb: Db;
+  readonly client: SandboxClient;
+  readonly sandbox: SandboxHandle;
+  readonly session: ConnectorCliAuthSession;
+  readonly origin: CliAuthStripeSandboxOrigin;
+  readonly signal: AbortSignal;
+}): Promise<CliAuthStripeStartInSandboxResult> {
+  const runResult = await runCliAuthStripeStartCommand({
+    client: args.client,
+    sandbox: args.sandbox,
+    signal: args.signal,
+    script:
+      args.origin === "snapshot"
+        ? stripeLoginStartCommandScript()
+        : startCommandScript(),
+  });
+
+  if (!runResult.ok) {
+    return failCliAuthStripeStartInSandbox({
+      ...args,
+      message: runResult.error.message,
+    });
+  }
+
+  let commandResult = runResult.value;
+  if (
+    args.origin === "snapshot" &&
+    commandResult.exitCode !== 0 &&
+    isCliAuthStripeToolchainFailure(commandResult)
+  ) {
+    const repairResult = await repairCliAuthStripeSnapshotToolchain({
+      ...args,
+      exitCode: commandResult.exitCode,
+    });
+    if (!repairResult.ok) {
+      return repairResult;
+    }
+    commandResult = repairResult.result;
+  }
+
+  if (commandResult.exitCode !== 0) {
     const message = commandFailedMessage(
       "CLI auth for Stripe start",
-      runResult.value,
+      commandResult,
     );
-    await markCliAuthStripeSessionError({
-      writeDb: args.writeDb,
-      sessionId: args.session.id,
+    return failCliAuthStripeStartInSandbox({
+      ...args,
       message,
-      expectedStatus: args.session.status,
-      expectedUpdatedAt: args.session.updatedAt,
     });
-    await cleanupSandbox(args.client, args.sandbox);
-    args.signal.throwIfAborted();
-    return {
-      ok: false,
-      result: {
-        ok: false,
-        code: "CLI_AUTH_STRIPE_FAILED",
-        message,
-      },
-    };
   }
 
-  const parsedResult = await parseCliAuthStripeStartOutput(runResult.value);
+  const parsedResult = await parseCliAuthStripeStartOutput(commandResult);
   if (!parsedResult.ok) {
-    await markCliAuthStripeSessionError({
-      writeDb: args.writeDb,
-      sessionId: args.session.id,
+    return failCliAuthStripeStartInSandbox({
+      ...args,
       message: parsedResult.message,
-      expectedStatus: args.session.status,
-      expectedUpdatedAt: args.session.updatedAt,
     });
-    await cleanupSandbox(args.client, args.sandbox);
-    args.signal.throwIfAborted();
-    return {
-      ok: false,
-      result: {
-        ok: false,
-        code: "CLI_AUTH_STRIPE_FAILED",
-        message: parsedResult.message,
-      },
-    };
   }
 
   return { ok: true, output: parsedResult.output };
@@ -989,6 +1203,7 @@ export async function startCliAuthStripe(args: {
     client,
     sandbox: sandboxResult.sandbox,
     session: sandboxResult.session,
+    origin: sandboxResult.origin,
     signal: args.signal,
   });
   if (!startResult.ok) {

--- a/turbo/apps/api/src/signals/services/cli-auth-toolchain.service.ts
+++ b/turbo/apps/api/src/signals/services/cli-auth-toolchain.service.ts
@@ -1,0 +1,41 @@
+export const CLI_AUTH_TOOLCHAIN_RUNTIME = "node24";
+export const CLI_AUTH_TOOLCHAIN_SNAPSHOT_ID_ENV = "VERCEL_CLI_AUTH_SNAPSHOT_ID";
+const CLI_AUTH_TOOLCHAIN_ROOT = "/vercel/sandbox/cli-auth/toolchain";
+const CLI_AUTH_TOOLCHAIN_BIN_DIR = `${CLI_AUTH_TOOLCHAIN_ROOT}/bin`;
+export const CLI_AUTH_TOOLCHAIN_MANIFEST_PATH = `${CLI_AUTH_TOOLCHAIN_ROOT}/manifest.json`;
+
+export const CLI_AUTH_TOOLCHAIN_STRIPE_VERSION = "1.40.9";
+const CLI_AUTH_TOOLCHAIN_STRIPE_ARCHIVE = `stripe_${CLI_AUTH_TOOLCHAIN_STRIPE_VERSION}_linux_x86_64.tar.gz`;
+const CLI_AUTH_TOOLCHAIN_STRIPE_RELEASE_URL = `https://github.com/stripe/stripe-cli/releases/download/v${CLI_AUTH_TOOLCHAIN_STRIPE_VERSION}`;
+export const CLI_AUTH_TOOLCHAIN_STRIPE_BIN = `${CLI_AUTH_TOOLCHAIN_BIN_DIR}/stripe`;
+
+export function cliAuthStripeInstallScript(): string {
+  return String.raw`set -euo pipefail
+TOOLCHAIN_ROOT="${CLI_AUTH_TOOLCHAIN_ROOT}"
+BIN_DIR="${CLI_AUTH_TOOLCHAIN_BIN_DIR}"
+STRIPE_BIN="${CLI_AUTH_TOOLCHAIN_STRIPE_BIN}"
+mkdir -p "$BIN_DIR"
+if ! ([ -x "$STRIPE_BIN" ] && "$STRIPE_BIN" --version | grep -Eq "^stripe version ${CLI_AUTH_TOOLCHAIN_STRIPE_VERSION}\b"); then
+  rm -f "$STRIPE_BIN"
+  curl -fsSL "${CLI_AUTH_TOOLCHAIN_STRIPE_RELEASE_URL}/${CLI_AUTH_TOOLCHAIN_STRIPE_ARCHIVE}" -o "/tmp/${CLI_AUTH_TOOLCHAIN_STRIPE_ARCHIVE}"
+  curl -fsSL "${CLI_AUTH_TOOLCHAIN_STRIPE_RELEASE_URL}/stripe-linux-checksums.txt" -o /tmp/stripe-linux-checksums.txt
+  grep " ${CLI_AUTH_TOOLCHAIN_STRIPE_ARCHIVE}$" /tmp/stripe-linux-checksums.txt > /tmp/stripe-cli.sha256
+  (cd /tmp && sha256sum -c stripe-cli.sha256) >&2
+  tar -xzf "/tmp/${CLI_AUTH_TOOLCHAIN_STRIPE_ARCHIVE}" -C "$BIN_DIR" stripe
+  chmod +x "$STRIPE_BIN"
+fi
+"$STRIPE_BIN" --version | grep -Eq "^stripe version ${CLI_AUTH_TOOLCHAIN_STRIPE_VERSION}\b"`;
+}
+
+export function cliAuthStripeVersionScript(): string {
+  return String.raw`set -euo pipefail
+"${CLI_AUTH_TOOLCHAIN_STRIPE_BIN}" --version`;
+}
+
+export function cliAuthStripeManifestScript(manifestJson: string): string {
+  return String.raw`set -euo pipefail
+mkdir -p "${CLI_AUTH_TOOLCHAIN_ROOT}"
+cat > "${CLI_AUTH_TOOLCHAIN_MANIFEST_PATH}" <<'JSON'
+${manifestJson}
+JSON`;
+}

--- a/turbo/apps/api/src/signals/services/vercel-sandbox-smoke.service.ts
+++ b/turbo/apps/api/src/signals/services/vercel-sandbox-smoke.service.ts
@@ -1,3 +1,4 @@
+import { optionalEnv } from "../../lib/env";
 import {
   getVercelSandboxClient,
   VERCEL_SANDBOX_SMOKE_RUNTIME,
@@ -5,19 +6,30 @@ import {
 } from "../external/vercel-sandbox";
 import {
   sandboxOperation,
+  type CreateSandboxOptions,
   type SandboxCleanupResult,
   type SandboxCommandResult,
   type SandboxError,
   type SandboxHandle,
 } from "../external/sandbox";
+import {
+  CLI_AUTH_TOOLCHAIN_SNAPSHOT_ID_ENV,
+  cliAuthStripeInstallScript,
+  cliAuthStripeVersionScript,
+} from "./cli-auth-toolchain.service";
 
-const SMOKE_COMMAND = Object.freeze({
+const NODE_SMOKE_COMMAND = Object.freeze({
   cmd: "node",
   args: ["--version"] as const,
 });
-const SMOKE_OUTPUT_LIMIT_BYTES = 1024;
+const STRIPE_SMOKE_COMMAND = Object.freeze({
+  cmd: "stripe",
+  args: ["--version"] as const,
+});
+const SMOKE_OUTPUT_LIMIT_BYTES = 4 * 1024;
 
 export type VercelSandboxSmokePhase = "create" | "run" | "cleanup";
+export type VercelSandboxSmokeCheckName = "node" | "cli-auth-stripe";
 
 export interface VercelSandboxSmokeError {
   readonly message: string;
@@ -34,8 +46,8 @@ export type VercelSandboxSmokeCleanup =
     };
 
 export interface VercelSandboxSmokeCommand {
-  readonly cmd: typeof SMOKE_COMMAND.cmd;
-  readonly args: typeof SMOKE_COMMAND.args;
+  readonly cmd: string;
+  readonly args: readonly string[];
   readonly exitCode: number;
   readonly stdout: string;
   readonly stderr: string;
@@ -46,17 +58,49 @@ export interface VercelSandboxSmokeSandbox {
   readonly runtime: typeof VERCEL_SANDBOX_SMOKE_RUNTIME;
 }
 
+export interface VercelSandboxSmokeCheck {
+  readonly name: VercelSandboxSmokeCheckName;
+  readonly sandbox: VercelSandboxSmokeSandbox;
+  readonly command: VercelSandboxSmokeCommand;
+  readonly cleanup: { readonly status: "stopped" };
+}
+
+type SmokeCheckDefinition = {
+  readonly name: VercelSandboxSmokeCheckName;
+  readonly createOptions: CreateSandboxOptions;
+  readonly runCommand: {
+    readonly cmd: string;
+    readonly args: readonly string[];
+  };
+  readonly displayCommand: {
+    readonly cmd: string;
+    readonly args: readonly string[];
+  };
+};
+
+type SmokeCheckResult =
+  | { readonly ok: true; readonly check: VercelSandboxSmokeCheck }
+  | {
+      readonly ok: false;
+      readonly checkName: VercelSandboxSmokeCheckName;
+      readonly phase: VercelSandboxSmokePhase;
+      readonly error: VercelSandboxSmokeError;
+      readonly sandbox?: VercelSandboxSmokeSandbox;
+      readonly command?: VercelSandboxSmokeCommand;
+      readonly cleanup?: VercelSandboxSmokeCleanup;
+    };
+
 export type VercelSandboxSmokeResult =
   | {
       readonly ok: true;
-      readonly sandbox: VercelSandboxSmokeSandbox;
-      readonly command: VercelSandboxSmokeCommand;
-      readonly cleanup: { readonly status: "stopped" };
+      readonly checks: readonly VercelSandboxSmokeCheck[];
     }
   | {
       readonly ok: false;
+      readonly checkName: VercelSandboxSmokeCheckName;
       readonly phase: VercelSandboxSmokePhase;
       readonly error: VercelSandboxSmokeError;
+      readonly checks: readonly VercelSandboxSmokeCheck[];
       readonly sandbox?: VercelSandboxSmokeSandbox;
       readonly command?: VercelSandboxSmokeCommand;
       readonly cleanup?: VercelSandboxSmokeCleanup;
@@ -77,11 +121,12 @@ function sandboxInfo(sandbox: SandboxHandle): VercelSandboxSmokeSandbox {
 }
 
 function commandInfo(
+  definition: SmokeCheckDefinition,
   result: SandboxCommandResult & { readonly exitCode: number },
 ): VercelSandboxSmokeCommand {
   return {
-    cmd: SMOKE_COMMAND.cmd,
-    args: SMOKE_COMMAND.args,
+    cmd: definition.displayCommand.cmd,
+    args: definition.displayCommand.args,
     exitCode: result.exitCode,
     stdout: result.stdout.text,
     stderr: result.stderr.text,
@@ -101,14 +146,49 @@ function smokeCleanup(
   };
 }
 
-export async function runVercelSandboxSmoke(
+function cliAuthStripeSmokeDefinition(): SmokeCheckDefinition {
+  const snapshotId = optionalEnv(CLI_AUTH_TOOLCHAIN_SNAPSHOT_ID_ENV);
+  if (snapshotId) {
+    return {
+      name: "cli-auth-stripe",
+      createOptions: {
+        source: { type: "snapshot", snapshotId },
+        timeoutMs: VERCEL_SANDBOX_SMOKE_TIMEOUT_MS,
+      },
+      runCommand: {
+        cmd: "sh",
+        args: ["-lc", cliAuthStripeVersionScript()],
+      },
+      displayCommand: STRIPE_SMOKE_COMMAND,
+    };
+  }
+
+  return {
+    name: "cli-auth-stripe",
+    createOptions: {
+      runtime: VERCEL_SANDBOX_SMOKE_RUNTIME,
+      timeoutMs: VERCEL_SANDBOX_SMOKE_TIMEOUT_MS,
+    },
+    runCommand: {
+      cmd: "sh",
+      args: [
+        "-lc",
+        `${cliAuthStripeInstallScript()}
+${cliAuthStripeVersionScript()}`,
+      ],
+    },
+    displayCommand: STRIPE_SMOKE_COMMAND,
+  };
+}
+
+async function runSmokeCheck(
+  definition: SmokeCheckDefinition,
   signal: AbortSignal,
-): Promise<VercelSandboxSmokeResult> {
+): Promise<SmokeCheckResult> {
   const client = getVercelSandboxClient();
   const createResult = await sandboxOperation("create", () => {
     return client.create({
-      runtime: VERCEL_SANDBOX_SMOKE_RUNTIME,
-      timeoutMs: VERCEL_SANDBOX_SMOKE_TIMEOUT_MS,
+      ...definition.createOptions,
       signal,
     });
   });
@@ -116,6 +196,7 @@ export async function runVercelSandboxSmoke(
   if (!createResult.ok) {
     return {
       ok: false,
+      checkName: definition.name,
       phase: "create",
       error: smokeError(createResult.error),
     };
@@ -127,8 +208,8 @@ export async function runVercelSandboxSmoke(
 
   const runResult = await sandboxOperation("run", () => {
     return client.runCommand(sandbox, {
-      cmd: SMOKE_COMMAND.cmd,
-      args: SMOKE_COMMAND.args,
+      cmd: definition.runCommand.cmd,
+      args: definition.runCommand.args,
       outputLimitBytes: SMOKE_OUTPUT_LIMIT_BYTES,
       signal,
     });
@@ -141,7 +222,7 @@ export async function runVercelSandboxSmoke(
         message: "Smoke command did not produce an exit code",
       };
     } else {
-      command = commandInfo({
+      command = commandInfo(definition, {
         ...runResult.value,
         exitCode: runResult.value.exitCode,
       });
@@ -156,6 +237,7 @@ export async function runVercelSandboxSmoke(
   if (runError) {
     return {
       ok: false,
+      checkName: definition.name,
       phase: "run",
       error: runError,
       sandbox: sandboxPayload,
@@ -166,6 +248,7 @@ export async function runVercelSandboxSmoke(
   if (!command) {
     return {
       ok: false,
+      checkName: definition.name,
       phase: "run",
       error: {
         name: "Error",
@@ -179,6 +262,7 @@ export async function runVercelSandboxSmoke(
   if (command.exitCode !== 0) {
     return {
       ok: false,
+      checkName: definition.name,
       phase: "run",
       error: {
         name: "Error",
@@ -193,6 +277,7 @@ export async function runVercelSandboxSmoke(
   if (cleanup.status === "failed") {
     return {
       ok: false,
+      checkName: definition.name,
       phase: "cleanup",
       error: cleanup.error,
       sandbox: sandboxPayload,
@@ -203,8 +288,51 @@ export async function runVercelSandboxSmoke(
 
   return {
     ok: true,
-    sandbox: sandboxPayload,
-    command,
-    cleanup,
+    check: {
+      name: definition.name,
+      sandbox: sandboxPayload,
+      command,
+      cleanup,
+    },
+  };
+}
+
+export async function runVercelSandboxSmoke(
+  signal: AbortSignal,
+): Promise<VercelSandboxSmokeResult> {
+  const checks: VercelSandboxSmokeCheck[] = [];
+  const definitions: readonly SmokeCheckDefinition[] = [
+    {
+      name: "node",
+      createOptions: {
+        runtime: VERCEL_SANDBOX_SMOKE_RUNTIME,
+        timeoutMs: VERCEL_SANDBOX_SMOKE_TIMEOUT_MS,
+      },
+      runCommand: NODE_SMOKE_COMMAND,
+      displayCommand: NODE_SMOKE_COMMAND,
+    },
+    cliAuthStripeSmokeDefinition(),
+  ];
+
+  for (const definition of definitions) {
+    const result = await runSmokeCheck(definition, signal);
+    if (!result.ok) {
+      return {
+        ok: false,
+        checkName: result.checkName,
+        phase: result.phase,
+        error: result.error,
+        checks,
+        ...(result.sandbox ? { sandbox: result.sandbox } : {}),
+        ...(result.command ? { command: result.command } : {}),
+        ...(result.cleanup ? { cleanup: result.cleanup } : {}),
+      };
+    }
+    checks.push(result.check);
+  }
+
+  return {
+    ok: true,
+    checks,
   };
 }

--- a/turbo/turbo.json
+++ b/turbo/turbo.json
@@ -211,6 +211,11 @@
     "GEMINI_API_KEY",
     "DEV"
   ],
+  "globalPassThroughEnv": [
+    "GITHUB_SHA",
+    "GIT_COMMIT_SHA",
+    "VERCEL_CLI_AUTH_SNAPSHOT_ID"
+  ],
   "tasks": {
     "build": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
## Summary
- add generic Vercel Sandbox snapshot source support and snapshot-aware Stripe CLI auth runtime paths
- add reusable CLI auth toolchain install/version primitives plus a snapshot builder script
- wire CI snapshot creation/refresh and API deploy env precedence for VERCEL_CLI_AUTH_SNAPSHOT_ID
- expand Vercel Sandbox smoke coverage to validate node and Stripe CLI toolchain checks

## Verification
- pnpm -F api exec vitest run src/signals/external/__tests__/sandbox.test.ts src/signals/routes/__tests__/vercel-sandbox-smoke.test.ts src/signals/routes/__tests__/zero-connectors-cli-auth-stripe.test.ts
- pnpm -F api lint
- pnpm -F api check-types
- pnpm knip --cache
- pnpm format
- git diff --check
- pre-commit hook: prettier, knip, turbo check-types

Closes #13498