### PR TITLE
refactor: track composite vsock file operations

### DIFF
--- a/crates/vsock-host/src/exec_operation.rs
+++ b/crates/vsock-host/src/exec_operation.rs
@@ -9,8 +9,8 @@ use tokio::sync::{mpsc, oneshot};
 use tokio::time::Instant;
 
 use crate::{
-    ConnectionState, ExecResult, Shared, normal_operation_transition_error,
-    operation_tracker::NormalOperationToken,
+    CompositeNormalOperation, ConnectionState, ExecResult, Shared,
+    normal_operation_transition_error, operation_tracker::NormalOperationToken,
 };
 use vsock_proto::{
     ExecCapturedOutput, ExecOutputPolicy, ExecOutputStream, ExecTermination, MSG_EXEC_CANCEL,
@@ -169,7 +169,7 @@ impl Default for Operations {
 }
 
 struct ExecOperation {
-    normal_operation: NormalOperationToken,
+    normal_operation: Option<NormalOperationToken>,
     diagnostic: ExecOperationDiagnostic,
     result_tx: oneshot::Sender<io::Result<ExecOperationResult>>,
     stream_tx: Option<mpsc::Sender<ExecOutputEvent>>,
@@ -179,6 +179,17 @@ struct ExecOperation {
     stderr_stream: Option<ExecStreamState>,
     expected_output_seq: u32,
     stream_overflowed: bool,
+}
+
+enum ExecOperationTracking<'a> {
+    Tracked,
+    Composite(&'a mut CompositeNormalOperation),
+    Untracked,
+}
+
+enum ExecFrameNormalOperation<'a> {
+    RegisteredSeq(u32),
+    Composite(&'a mut CompositeNormalOperation),
 }
 
 #[derive(Clone)]
@@ -860,9 +871,11 @@ pub(crate) fn dispatch_result(shared: &Arc<Shared>, msg: &RawMessage) -> io::Res
                     stream_overflowed,
                     ..
                 } = operation;
-                normal_operation
-                    .complete()
-                    .map_err(normal_operation_transition_error)?;
+                if let Some(normal_operation) = normal_operation {
+                    normal_operation
+                        .complete()
+                        .map_err(normal_operation_transition_error)?;
+                }
                 Some((diagnostic, result_tx, stream_overflowed, decoded))
             }
             ConnectionState::Connected { .. } | ConnectionState::Closed { .. } => None,
@@ -895,9 +908,11 @@ pub(crate) fn dispatch_error(shared: &Arc<Shared>, msg: &RawMessage) -> io::Resu
                     result_tx,
                     ..
                 } = operation;
-                normal_operation
-                    .complete()
-                    .map_err(normal_operation_transition_error)?;
+                if let Some(normal_operation) = normal_operation {
+                    normal_operation
+                        .complete()
+                        .map_err(normal_operation_transition_error)?;
+                }
                 Some((diagnostic, result_tx, err))
             }
             ConnectionState::Connected { .. } | ConnectionState::Closed { .. } => None,
@@ -921,10 +936,13 @@ fn mark_exec_operation_possible_guest_write(shared: &Arc<Shared>, seq: u32) -> i
                     "exec operation closed before frame write",
                 ));
             };
-            operation
-                .normal_operation
-                .mark_possible_guest_write_started()
-                .map_err(normal_operation_transition_error)
+            if let Some(normal_operation) = operation.normal_operation.as_mut() {
+                normal_operation
+                    .mark_possible_guest_write_started()
+                    .map_err(normal_operation_transition_error)
+            } else {
+                Ok(())
+            }
         }
         ConnectionState::Closed { .. } => Err(io::Error::new(
             io::ErrorKind::ConnectionReset,
@@ -939,7 +957,7 @@ async fn write_frame(
     seq: u32,
     payload: &[u8],
     diagnostic: Option<ExecOperationFrameDiagnostic>,
-    normal_operation_seq: Option<u32>,
+    normal_operation: Option<ExecFrameNormalOperation<'_>>,
 ) -> io::Result<()> {
     let data = vsock_proto::encode(msg_type, seq, payload)
         .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e.to_string()))?;
@@ -949,8 +967,15 @@ async fn write_frame(
     let wait_started_at = Instant::now();
     let mut writer = shared.writer.lock().await;
     let wait_elapsed_ms = wait_started_at.elapsed().as_millis();
-    if let Some(normal_operation_seq) = normal_operation_seq {
-        mark_exec_operation_possible_guest_write(shared, normal_operation_seq)?;
+    if let Some(normal_operation) = normal_operation {
+        match normal_operation {
+            ExecFrameNormalOperation::RegisteredSeq(seq) => {
+                mark_exec_operation_possible_guest_write(shared, seq)?;
+            }
+            ExecFrameNormalOperation::Composite(normal_operation) => {
+                normal_operation.mark_possible_guest_write_started()?;
+            }
+        }
     }
     state.store(EXEC_OPERATION_FRAME_WRITE_STARTED, Ordering::Release);
     let write_started_at = Instant::now();
@@ -1075,6 +1100,15 @@ pub(crate) async fn start_exec_operation_on_shared(
     shared: &Arc<Shared>,
     request: ExecOperationRequest<'_>,
 ) -> io::Result<ExecOperationHandle> {
+    start_exec_operation_on_shared_with_tracking(shared, request, ExecOperationTracking::Tracked)
+        .await
+}
+
+async fn start_exec_operation_on_shared_with_tracking(
+    shared: &Arc<Shared>,
+    request: ExecOperationRequest<'_>,
+    tracking: ExecOperationTracking<'_>,
+) -> io::Result<ExecOperationHandle> {
     if request.timeout_ms == 0 {
         return Err(io::Error::new(
             io::ErrorKind::InvalidInput,
@@ -1137,7 +1171,16 @@ pub(crate) async fn start_exec_operation_on_shared(
     let (result_tx, result_rx) = oneshot::channel();
     let seq = shared.next_seq();
     let diagnostic = ExecOperationDiagnostic::new(seq, request.label, request.expected_exit_codes);
-    let normal_operation = shared.reserve_normal_operation()?;
+    let tracks_self = matches!(tracking, ExecOperationTracking::Tracked);
+    let composite_operation = match tracking {
+        ExecOperationTracking::Composite(normal_operation) => Some(normal_operation),
+        ExecOperationTracking::Tracked | ExecOperationTracking::Untracked => None,
+    };
+    let normal_operation = if tracks_self {
+        Some(shared.reserve_normal_operation()?)
+    } else {
+        None
+    };
     let operation = ExecOperation {
         normal_operation,
         diagnostic: diagnostic.clone(),
@@ -1167,13 +1210,18 @@ pub(crate) async fn start_exec_operation_on_shared(
     }
 
     let mut registration_guard = ExecOperationRegistrationGuard::new(Arc::clone(shared), seq);
+    let normal_operation = if tracks_self {
+        Some(ExecFrameNormalOperation::RegisteredSeq(seq))
+    } else {
+        composite_operation.map(ExecFrameNormalOperation::Composite)
+    };
     write_frame(
         shared,
         MSG_EXEC_START,
         seq,
         &payload,
         Some(diagnostic.frame("start")),
-        Some(seq),
+        normal_operation,
     )
     .await?;
     registration_guard.disarm();
@@ -1213,9 +1261,46 @@ pub(crate) async fn exec_operation_capture_on_shared(
     handle.wait(request.wait_timeout).await
 }
 
+async fn exec_operation_capture_on_shared_with_tracking(
+    shared: &Arc<Shared>,
+    request: ExecCaptureRequest<'_>,
+    tracking: ExecOperationTracking<'_>,
+) -> io::Result<ExecOperationResult> {
+    let handle = start_exec_operation_on_shared_with_tracking(
+        shared,
+        ExecOperationRequest {
+            timeout_ms: request.timeout_ms,
+            command: request.command,
+            env: request.env,
+            sudo: request.sudo,
+            label: request.label,
+            stdout: ExecOutputPolicy::Capture {
+                limit_bytes: request.stdout_limit_bytes,
+            },
+            stderr: ExecOutputPolicy::Capture {
+                limit_bytes: request.stderr_limit_bytes,
+            },
+            expected_exit_codes: request.expected_exit_codes,
+            stream_queue_capacity: None,
+        },
+        tracking,
+    )
+    .await?;
+    handle.wait(request.wait_timeout).await
+}
+
 pub(crate) async fn exec_operation_stream_on_shared(
     shared: &Arc<Shared>,
     request: ExecStreamRequest<'_>,
+) -> io::Result<ExecOperationHandle> {
+    exec_operation_stream_on_shared_with_tracking(shared, request, ExecOperationTracking::Tracked)
+        .await
+}
+
+async fn exec_operation_stream_on_shared_with_tracking(
+    shared: &Arc<Shared>,
+    request: ExecStreamRequest<'_>,
+    tracking: ExecOperationTracking<'_>,
 ) -> io::Result<ExecOperationHandle> {
     if !output_policy_streams(request.stdout) && !output_policy_streams(request.stderr) {
         return Err(io::Error::new(
@@ -1224,7 +1309,7 @@ pub(crate) async fn exec_operation_stream_on_shared(
         ));
     }
 
-    start_exec_operation_on_shared(
+    start_exec_operation_on_shared_with_tracking(
         shared,
         ExecOperationRequest {
             timeout_ms: request.timeout_ms,
@@ -1237,6 +1322,20 @@ pub(crate) async fn exec_operation_stream_on_shared(
             expected_exit_codes: request.expected_exit_codes,
             stream_queue_capacity: request.stream_queue_capacity,
         },
+        tracking,
+    )
+    .await
+}
+
+pub(crate) async fn exec_operation_stream_with_composite_on_shared(
+    shared: &Arc<Shared>,
+    request: ExecStreamRequest<'_>,
+    normal_operation: &mut CompositeNormalOperation,
+) -> io::Result<ExecOperationHandle> {
+    exec_operation_stream_on_shared_with_tracking(
+        shared,
+        request,
+        ExecOperationTracking::Composite(normal_operation),
     )
     .await
 }
@@ -1266,14 +1365,14 @@ pub(crate) async fn exec_on_shared(
     .await
 }
 
-pub(crate) async fn exec_cleanup_on_shared(
+pub(crate) async fn exec_cleanup_untracked_on_shared(
     shared: &Arc<Shared>,
     command: &str,
     timeout_ms: u32,
     env: &[(&str, &str)],
     sudo: bool,
 ) -> io::Result<ExecResult> {
-    exec_capture_on_shared(
+    let result = exec_operation_capture_on_shared_with_tracking(
         shared,
         ExecCaptureRequest {
             timeout_ms,
@@ -1286,8 +1385,51 @@ pub(crate) async fn exec_cleanup_on_shared(
             expected_exit_codes: &[],
             wait_timeout: Duration::from_millis(timeout_ms as u64),
         },
+        ExecOperationTracking::Untracked,
     )
-    .await
+    .await?;
+    result_to_exec_result(result)
+}
+
+pub(crate) async fn exec_cleanup_with_composite_on_shared(
+    shared: &Arc<Shared>,
+    command: &str,
+    timeout_ms: u32,
+    env: &[(&str, &str)],
+    sudo: bool,
+    normal_operation: &mut CompositeNormalOperation,
+) -> io::Result<ExecResult> {
+    let result = exec_operation_capture_on_shared_with_tracking(
+        shared,
+        ExecCaptureRequest {
+            timeout_ms,
+            command,
+            env,
+            sudo,
+            label: "exec-cleanup",
+            stdout_limit_bytes: SMALL_EXEC_CAPTURE_LIMIT_BYTES,
+            stderr_limit_bytes: SMALL_EXEC_CAPTURE_LIMIT_BYTES,
+            expected_exit_codes: &[],
+            wait_timeout: Duration::from_millis(timeout_ms as u64),
+        },
+        ExecOperationTracking::Composite(normal_operation),
+    )
+    .await?;
+    result_to_exec_result(result)
+}
+
+pub(crate) async fn exec_capture_with_composite_on_shared(
+    shared: &Arc<Shared>,
+    request: ExecCaptureRequest<'_>,
+    normal_operation: &mut CompositeNormalOperation,
+) -> io::Result<ExecResult> {
+    let result = exec_operation_capture_on_shared_with_tracking(
+        shared,
+        request,
+        ExecOperationTracking::Composite(normal_operation),
+    )
+    .await?;
+    result_to_exec_result(result)
 }
 
 pub(crate) async fn exec_capture_on_shared(
@@ -1324,7 +1466,7 @@ mod tests {
         let (result_tx, _result_rx) = oneshot::channel();
         let normal_operations = crate::operation_tracker::NormalOperationTracker::new();
         ExecOperation {
-            normal_operation: normal_operations.reserve().unwrap(),
+            normal_operation: Some(normal_operations.reserve().unwrap()),
             diagnostic: ExecOperationDiagnostic::new(seq, label, &[]),
             result_tx,
             stream_tx: None,

--- a/crates/vsock-host/src/exec_operation.rs
+++ b/crates/vsock-host/src/exec_operation.rs
@@ -10,7 +10,8 @@ use tokio::time::Instant;
 
 use crate::{
     CompositeNormalOperation, ConnectionState, ExecResult, Shared,
-    normal_operation_transition_error, operation_tracker::NormalOperationToken,
+    normal_operation_transition_error,
+    operation_tracker::{NormalOperationToken, NormalOperationTransitionHandle},
 };
 use vsock_proto::{
     ExecCapturedOutput, ExecOutputPolicy, ExecOutputStream, ExecTermination, MSG_EXEC_CANCEL,
@@ -169,7 +170,7 @@ impl Default for Operations {
 }
 
 struct ExecOperation {
-    normal_operation: Option<NormalOperationToken>,
+    normal_operation: Option<ExecOperationNormalTracking>,
     diagnostic: ExecOperationDiagnostic,
     result_tx: oneshot::Sender<io::Result<ExecOperationResult>>,
     stream_tx: Option<mpsc::Sender<ExecOutputEvent>>,
@@ -181,15 +182,39 @@ struct ExecOperation {
     stream_overflowed: bool,
 }
 
-enum ExecOperationTracking<'a> {
-    Tracked,
-    Composite(&'a mut CompositeNormalOperation),
-    Untracked,
+enum ExecOperationNormalTracking {
+    Owned(NormalOperationToken),
+    Composite(NormalOperationTransitionHandle),
 }
 
-enum ExecFrameNormalOperation<'a> {
-    RegisteredSeq(u32),
-    Composite(&'a mut CompositeNormalOperation),
+impl ExecOperationNormalTracking {
+    fn mark_possible_guest_write_started(&mut self) -> io::Result<()> {
+        match self {
+            ExecOperationNormalTracking::Owned(normal_operation) => normal_operation
+                .mark_possible_guest_write_started()
+                .map_err(normal_operation_transition_error),
+            ExecOperationNormalTracking::Composite(normal_operation) => normal_operation
+                .mark_possible_guest_write_started()
+                .map_err(normal_operation_transition_error),
+        }
+    }
+
+    fn complete(self) -> io::Result<()> {
+        match self {
+            ExecOperationNormalTracking::Owned(normal_operation) => normal_operation
+                .complete()
+                .map_err(normal_operation_transition_error),
+            ExecOperationNormalTracking::Composite(normal_operation) => normal_operation
+                .mark_possible_guest_write_completed()
+                .map_err(normal_operation_transition_error),
+        }
+    }
+}
+
+enum ExecOperationTracking<'a> {
+    Tracked,
+    Composite(&'a CompositeNormalOperation),
+    Untracked,
 }
 
 #[derive(Clone)]
@@ -904,9 +929,7 @@ pub(crate) fn dispatch_result(shared: &Arc<Shared>, msg: &RawMessage) -> io::Res
                     ..
                 } = operation;
                 if let Some(normal_operation) = normal_operation {
-                    normal_operation
-                        .complete()
-                        .map_err(normal_operation_transition_error)?;
+                    normal_operation.complete()?;
                 }
                 Some((diagnostic, result_tx, stream_overflowed, decoded))
             }
@@ -941,9 +964,7 @@ pub(crate) fn dispatch_error(shared: &Arc<Shared>, msg: &RawMessage) -> io::Resu
                     ..
                 } = operation;
                 if let Some(normal_operation) = normal_operation {
-                    normal_operation
-                        .complete()
-                        .map_err(normal_operation_transition_error)?;
+                    normal_operation.complete()?;
                 }
                 Some((diagnostic, result_tx, err))
             }
@@ -969,9 +990,7 @@ fn mark_exec_operation_possible_guest_write(shared: &Arc<Shared>, seq: u32) -> i
                 ));
             };
             if let Some(normal_operation) = operation.normal_operation.as_mut() {
-                normal_operation
-                    .mark_possible_guest_write_started()
-                    .map_err(normal_operation_transition_error)
+                normal_operation.mark_possible_guest_write_started()
             } else {
                 Ok(())
             }
@@ -989,7 +1008,7 @@ async fn write_frame(
     seq: u32,
     payload: &[u8],
     diagnostic: Option<ExecOperationFrameDiagnostic>,
-    normal_operation: Option<ExecFrameNormalOperation<'_>>,
+    normal_operation_seq: Option<u32>,
 ) -> io::Result<()> {
     let data = vsock_proto::encode(msg_type, seq, payload)
         .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e.to_string()))?;
@@ -999,15 +1018,8 @@ async fn write_frame(
     let wait_started_at = Instant::now();
     let mut writer = shared.writer.lock().await;
     let wait_elapsed_ms = wait_started_at.elapsed().as_millis();
-    if let Some(normal_operation) = normal_operation {
-        match normal_operation {
-            ExecFrameNormalOperation::RegisteredSeq(seq) => {
-                mark_exec_operation_possible_guest_write(shared, seq)?;
-            }
-            ExecFrameNormalOperation::Composite(normal_operation) => {
-                normal_operation.mark_possible_guest_write_started()?;
-            }
-        }
+    if let Some(normal_operation_seq) = normal_operation_seq {
+        mark_exec_operation_possible_guest_write(shared, normal_operation_seq)?;
     }
     state.store(EXEC_OPERATION_FRAME_WRITE_STARTED, Ordering::Release);
     let write_started_at = Instant::now();
@@ -1203,16 +1215,16 @@ async fn start_exec_operation_on_shared_with_tracking(
     let (result_tx, result_rx) = oneshot::channel();
     let seq = shared.next_seq();
     let diagnostic = ExecOperationDiagnostic::new(seq, request.label, request.expected_exit_codes);
-    let tracks_self = matches!(tracking, ExecOperationTracking::Tracked);
-    let composite_operation = match tracking {
-        ExecOperationTracking::Composite(normal_operation) => Some(normal_operation),
-        ExecOperationTracking::Tracked | ExecOperationTracking::Untracked => None,
+    let normal_operation = match tracking {
+        ExecOperationTracking::Tracked => Some(ExecOperationNormalTracking::Owned(
+            shared.reserve_normal_operation()?,
+        )),
+        ExecOperationTracking::Composite(normal_operation) => Some(
+            ExecOperationNormalTracking::Composite(normal_operation.transition_handle()?),
+        ),
+        ExecOperationTracking::Untracked => None,
     };
-    let normal_operation = if tracks_self {
-        Some(shared.reserve_normal_operation()?)
-    } else {
-        None
-    };
+    let tracks_normal_operation = normal_operation.is_some();
     let operation = ExecOperation {
         normal_operation,
         diagnostic: diagnostic.clone(),
@@ -1242,18 +1254,13 @@ async fn start_exec_operation_on_shared_with_tracking(
     }
 
     let mut registration_guard = ExecOperationRegistrationGuard::new(Arc::clone(shared), seq);
-    let normal_operation = if tracks_self {
-        Some(ExecFrameNormalOperation::RegisteredSeq(seq))
-    } else {
-        composite_operation.map(ExecFrameNormalOperation::Composite)
-    };
     write_frame(
         shared,
         MSG_EXEC_START,
         seq,
         &payload,
         Some(diagnostic.frame("start")),
-        normal_operation,
+        tracks_normal_operation.then_some(seq),
     )
     .await?;
     registration_guard.disarm();
@@ -1498,7 +1505,9 @@ mod tests {
         let (result_tx, _result_rx) = oneshot::channel();
         let normal_operations = crate::operation_tracker::NormalOperationTracker::new();
         ExecOperation {
-            normal_operation: Some(normal_operations.reserve().unwrap()),
+            normal_operation: Some(ExecOperationNormalTracking::Owned(
+                normal_operations.reserve().unwrap(),
+            )),
             diagnostic: ExecOperationDiagnostic::new(seq, label, &[]),
             result_tx,
             stream_tx: None,

--- a/crates/vsock-host/src/exec_operation.rs
+++ b/crates/vsock-host/src/exec_operation.rs
@@ -375,6 +375,11 @@ pub struct ExecOperationHandle {
     stream_rx: Option<mpsc::Receiver<ExecOutputEvent>>,
 }
 
+struct ExecCancelWaitResult {
+    result: ExecOperationResult,
+    cancel_seq: Option<u32>,
+}
+
 impl ExecOperationHandle {
     /// Take the bounded output event receiver for streaming operations.
     pub fn take_stream_receiver(&mut self) -> Option<mpsc::Receiver<ExecOutputEvent>> {
@@ -393,9 +398,48 @@ impl ExecOperationHandle {
     ///
     /// If the terminal result is already available before cancel is sent, this
     /// returns that result without sending a duplicate cancel frame.
-    pub async fn cancel_and_wait(mut self, timeout: Duration) -> io::Result<ExecOperationResult> {
+    pub async fn cancel_and_wait(self, timeout: Duration) -> io::Result<ExecOperationResult> {
+        let cancel_label_log = self.diagnostic.label_log.clone();
+        let registered_at = self.diagnostic.registered_at;
+        let wait_result = self.cancel_and_wait_for_terminal_status(timeout).await?;
+        if wait_result.cancel_seq.is_none()
+            || wait_result.result.termination == ExecTermination::Cancelled
+        {
+            if let Some(seq) = wait_result.cancel_seq {
+                tracing::info!(
+                    seq = seq,
+                    label = %cancel_label_log,
+                    elapsed_ms = registered_at.elapsed().as_millis(),
+                    "exec operation cancel completed"
+                );
+            }
+            return Ok(wait_result.result);
+        }
+
+        Err(io::Error::other(format!(
+            "exec cancel returned terminal state: {:?}",
+            wait_result.result.termination
+        )))
+    }
+
+    pub(crate) async fn cancel_and_wait_for_terminal(
+        self,
+        timeout: Duration,
+    ) -> io::Result<ExecOperationResult> {
+        self.cancel_and_wait_for_terminal_status(timeout)
+            .await
+            .map(|wait_result| wait_result.result)
+    }
+
+    async fn cancel_and_wait_for_terminal_status(
+        mut self,
+        timeout: Duration,
+    ) -> io::Result<ExecCancelWaitResult> {
         if let Some(result) = self.try_take_ready_result()? {
-            return Ok(result);
+            return Ok(ExecCancelWaitResult {
+                result,
+                cancel_seq: None,
+            });
         }
 
         let seq = self.seq.ok_or_else(|| {
@@ -418,23 +462,11 @@ impl ExecOperationHandle {
             "exec operation cancel sent"
         );
 
-        let cancel_label_log = self.diagnostic.label_log.clone();
-        let registered_at = self.diagnostic.registered_at;
         let result = self.wait_with_timeout(timeout, true).await?;
-        if result.termination == ExecTermination::Cancelled {
-            tracing::info!(
-                seq = seq,
-                label = %cancel_label_log,
-                elapsed_ms = registered_at.elapsed().as_millis(),
-                "exec operation cancel completed"
-            );
-            return Ok(result);
-        }
-
-        Err(io::Error::other(format!(
-            "exec cancel returned terminal state: {:?}",
-            result.termination
-        )))
+        Ok(ExecCancelWaitResult {
+            result,
+            cancel_seq: Some(seq),
+        })
     }
 
     fn try_take_ready_result(&mut self) -> io::Result<Option<ExecOperationResult>> {

--- a/crates/vsock-host/src/file.rs
+++ b/crates/vsock-host/src/file.rs
@@ -554,14 +554,18 @@ impl VsockHost {
         match drain_result {
             Ok(Ok(())) => {}
             Ok(Err(err)) => {
-                let cancel_result = handle.cancel_and_wait(Duration::from_secs(1)).await;
+                let cancel_result = handle
+                    .cancel_and_wait_for_terminal(Duration::from_secs(1))
+                    .await;
                 if let Some(cancel_on_drop) = &mut cancel_on_drop {
                     cancel_on_drop.disarm();
                 }
                 return Err(CopyFileToTempError::after_cancel(err, cancel_result));
             }
             Err(_) => {
-                let cancel_result = handle.cancel_and_wait(Duration::from_secs(1)).await;
+                let cancel_result = handle
+                    .cancel_and_wait_for_terminal(Duration::from_secs(1))
+                    .await;
                 if let Some(cancel_on_drop) = &mut cancel_on_drop {
                     cancel_on_drop.disarm();
                 }

--- a/crates/vsock-host/src/file.rs
+++ b/crates/vsock-host/src/file.rs
@@ -11,8 +11,9 @@ use vsock_proto::{
 };
 
 use crate::{
-    ExecCaptureRequest, ExecOperationResult, ExecOutputEvent, ExecOwnedCapturedOutput,
-    ExecStreamRequest, Shared, VsockHost, exec_operation, normal_request_on_shared,
+    CompositeNormalOperation, ExecCaptureRequest, ExecOperationResult, ExecOutputEvent,
+    ExecOwnedCapturedOutput, ExecStreamRequest, Shared, VsockHost, exec_operation,
+    normal_request_on_shared, request_on_shared_with_composite_operation,
 };
 
 const COPY_TEMP_CREATE_ATTEMPTS: usize = 16;
@@ -59,6 +60,39 @@ enum CopyFileOutcome {
     Missing,
 }
 
+struct CopyFileToTempError {
+    error: io::Error,
+    terminal_proven: bool,
+}
+
+impl CopyFileToTempError {
+    fn unproven(error: io::Error) -> Self {
+        Self {
+            error,
+            terminal_proven: false,
+        }
+    }
+
+    fn terminal(error: io::Error) -> Self {
+        Self {
+            error,
+            terminal_proven: true,
+        }
+    }
+
+    fn after_cancel(error: io::Error, cancel_result: io::Result<ExecOperationResult>) -> Self {
+        Self {
+            error,
+            terminal_proven: cancel_result.is_ok(),
+        }
+    }
+}
+
+enum WriteFileChunkTracking<'a> {
+    Tracked,
+    Composite(&'a mut CompositeNormalOperation),
+}
+
 struct ChunkedWriteCleanupGuard {
     shared: Option<Arc<Shared>>,
     command: String,
@@ -78,18 +112,26 @@ impl ChunkedWriteCleanupGuard {
         self.shared = None;
     }
 
-    async fn cleanup_now(&mut self) {
-        if let Some(shared) = self.shared.as_ref() {
-            let _ = exec_operation::exec_cleanup_on_shared(
+    async fn cleanup_now(
+        &mut self,
+        normal_operation: &mut CompositeNormalOperation,
+    ) -> io::Result<()> {
+        let result = if let Some(shared) = self.shared.as_ref() {
+            exec_operation::exec_cleanup_with_composite_on_shared(
                 shared,
                 &self.command,
                 CLEANUP_EXEC_TIMEOUT_MS,
                 &[],
                 self.sudo,
+                normal_operation,
             )
-            .await;
-        }
+            .await
+            .map(|_| ())
+        } else {
+            Ok(())
+        };
         self.disarm();
+        result
     }
 }
 
@@ -103,7 +145,7 @@ impl Drop for ChunkedWriteCleanupGuard {
         let sudo = self.sudo;
         if let Ok(handle) = tokio::runtime::Handle::try_current() {
             handle.spawn(async move {
-                let _ = exec_operation::exec_cleanup_on_shared(
+                let _ = exec_operation::exec_cleanup_untracked_on_shared(
                     &shared,
                     &command,
                     CLEANUP_EXEC_TIMEOUT_MS,
@@ -160,6 +202,17 @@ fn copy_temp_path(host_path: &Path, process_id: u32, seq: u32, nonce: u64) -> Pa
         .map(|name| name.to_string_lossy())
         .unwrap_or_else(|| "copy".into());
     host_path.with_file_name(format!(".{file_name}.vm0tmp-{process_id}-{seq}-{nonce}"))
+}
+
+fn file_operation_error_is_terminal(error: &io::Error) -> bool {
+    !matches!(
+        error.kind(),
+        io::ErrorKind::TimedOut
+            | io::ErrorKind::ConnectionReset
+            | io::ErrorKind::BrokenPipe
+            | io::ErrorKind::UnexpectedEof
+            | io::ErrorKind::InvalidData
+    )
 }
 
 async fn remove_temp_file(path: &Path) {
@@ -393,6 +446,7 @@ impl VsockHost {
         let (temp_path, temp_file) =
             create_copy_temp_file(host_path, self.shared.next_seq()).await?;
         let mut temp_guard = HostTempFileGuard::new(temp_path);
+        let mut normal_operation = CompositeNormalOperation::reserve(&self.shared)?;
         let copy_result = self
             .copy_file_to_temp(
                 path,
@@ -400,6 +454,7 @@ impl VsockHost {
                 stream_limit_bytes,
                 options.timeout_ms,
                 options.missing_ok,
+                &mut normal_operation,
             )
             .await;
         match copy_result {
@@ -407,21 +462,27 @@ impl VsockHost {
                 match tokio::fs::rename(temp_guard.path(), host_path).await {
                     Ok(()) => {
                         temp_guard.disarm();
+                        normal_operation.complete()?;
                         Ok(CopyFileResult { bytes_copied })
                     }
                     Err(err) => {
                         temp_guard.remove_now().await;
+                        normal_operation.complete()?;
                         Err(err)
                     }
                 }
             }
             Ok(CopyFileOutcome::Missing) => {
                 temp_guard.remove_now().await;
+                normal_operation.complete()?;
                 Ok(CopyFileResult { bytes_copied: 0 })
             }
             Err(err) => {
                 temp_guard.remove_now().await;
-                Err(err)
+                if err.terminal_proven {
+                    normal_operation.complete()?;
+                }
+                Err(err.error)
             }
         }
     }
@@ -433,7 +494,8 @@ impl VsockHost {
         stream_limit_bytes: u32,
         timeout_ms: u32,
         missing_ok: bool,
-    ) -> io::Result<CopyFileOutcome> {
+        normal_operation: &mut CompositeNormalOperation,
+    ) -> Result<CopyFileOutcome, CopyFileToTempError> {
         const MISSING_FILE_EXIT_CODE: i32 = 66;
         let command = format!(
             "if test -f {path}; then cat -- {path}; else exit {MISSING_FILE_EXIT_CODE}; fi",
@@ -444,8 +506,9 @@ impl VsockHost {
         } else {
             &[]
         };
-        let mut handle = self
-            .exec_operation_stream(ExecStreamRequest {
+        let mut handle = exec_operation::exec_operation_stream_with_composite_on_shared(
+            &self.shared,
+            ExecStreamRequest {
                 timeout_ms,
                 command: &command,
                 env: &[],
@@ -460,14 +523,17 @@ impl VsockHost {
                 },
                 expected_exit_codes,
                 stream_queue_capacity: Some(COPY_FILE_STREAM_QUEUE_CAPACITY),
-            })
-            .await?;
+            },
+            normal_operation,
+        )
+        .await
+        .map_err(CopyFileToTempError::unproven)?;
         let mut cancel_on_drop = exec_operation::ExecOperationCancelOnDropGuard::new(&handle);
         let mut stream_rx = handle.take_stream_receiver().ok_or_else(|| {
-            io::Error::new(
+            CopyFileToTempError::unproven(io::Error::new(
                 io::ErrorKind::InvalidData,
                 "copy_file exec operation did not create a stream receiver",
-            )
+            ))
         })?;
         let wait_timeout = Duration::from_millis(timeout_ms as u64 + 5000);
         let mut bytes_copied = 0u64;
@@ -488,33 +554,44 @@ impl VsockHost {
         match drain_result {
             Ok(Ok(())) => {}
             Ok(Err(err)) => {
-                let _ = handle.cancel_and_wait(Duration::from_secs(1)).await;
+                let cancel_result = handle.cancel_and_wait(Duration::from_secs(1)).await;
                 if let Some(cancel_on_drop) = &mut cancel_on_drop {
                     cancel_on_drop.disarm();
                 }
-                return Err(err);
+                return Err(CopyFileToTempError::after_cancel(err, cancel_result));
             }
             Err(_) => {
-                let _ = handle.cancel_and_wait(Duration::from_secs(1)).await;
+                let cancel_result = handle.cancel_and_wait(Duration::from_secs(1)).await;
                 if let Some(cancel_on_drop) = &mut cancel_on_drop {
                     cancel_on_drop.disarm();
                 }
-                return Err(io::Error::new(
-                    io::ErrorKind::TimedOut,
-                    format!("copy_file stream drain timed out for {path}"),
+                return Err(CopyFileToTempError::after_cancel(
+                    io::Error::new(
+                        io::ErrorKind::TimedOut,
+                        format!("copy_file stream drain timed out for {path}"),
+                    ),
+                    cancel_result,
                 ));
             }
         };
 
-        let result = handle.wait(Duration::from_secs(5)).await?;
+        let result = handle
+            .wait(Duration::from_secs(5))
+            .await
+            .map_err(CopyFileToTempError::unproven)?;
         if let Some(cancel_on_drop) = &mut cancel_on_drop {
             cancel_on_drop.disarm();
         }
-        match validate_copy_exec_result(path, result, missing_ok)? {
+        match validate_copy_exec_result(path, result, missing_ok)
+            .map_err(CopyFileToTempError::terminal)?
+        {
             CopyFileExecStatus::Present => {}
             CopyFileExecStatus::Missing => return Ok(CopyFileOutcome::Missing),
         }
-        temp_file.flush().await?;
+        temp_file
+            .flush()
+            .await
+            .map_err(CopyFileToTempError::terminal)?;
 
         Ok(CopyFileOutcome::Copied { bytes_copied })
     }
@@ -531,9 +608,11 @@ impl VsockHost {
     pub async fn write_file(&self, path: &str, content: &[u8], sudo: bool) -> io::Result<()> {
         if content.len() <= WRITE_FILE_CHUNK_LIMIT {
             return self
-                .write_file_chunk(path, content, sudo, false, true)
+                .write_file_chunk(path, content, sudo, false, WriteFileChunkTracking::Tracked)
                 .await;
         }
+
+        let mut normal_operation = CompositeNormalOperation::reserve(&self.shared)?;
 
         // Write chunks to a per-call temp file, then atomic rename. The
         // suffix prevents concurrent large writes to the same destination
@@ -546,23 +625,34 @@ impl VsockHost {
 
         let result = async {
             for (i, chunk) in content.chunks(WRITE_FILE_CHUNK_LIMIT).enumerate() {
-                self.write_file_chunk(&tmp, chunk, sudo, i > 0, false)
-                    .await?;
+                self.write_file_chunk(
+                    &tmp,
+                    chunk,
+                    sudo,
+                    i > 0,
+                    WriteFileChunkTracking::Composite(&mut normal_operation),
+                )
+                .await?;
             }
             io::Result::Ok(())
         }
         .await;
 
-        if result.is_err() {
+        if let Err(error) = result {
             // Best-effort cleanup of the temp file.
-            cleanup_guard.cleanup_now().await;
-            return result;
+            let terminal_error = file_operation_error_is_terminal(&error);
+            let cleanup_result = cleanup_guard.cleanup_now(&mut normal_operation).await;
+            if terminal_error && cleanup_result.is_ok() {
+                normal_operation.complete()?;
+            }
+            return Err(error);
         }
 
         // Atomic rename temp → target.
         let mv_cmd = format!("mv -f -- {quoted_tmp} {}", shell_quote(path));
-        match self
-            .exec_capture(ExecCaptureRequest {
+        match exec_operation::exec_capture_with_composite_on_shared(
+            &self.shared,
+            ExecCaptureRequest {
                 command: &mv_cmd,
                 timeout_ms: HELPER_EXEC_TIMEOUT_MS,
                 env: &[],
@@ -572,23 +662,30 @@ impl VsockHost {
                 stderr_limit_bytes: exec_operation::SMALL_EXEC_CAPTURE_LIMIT_BYTES,
                 expected_exit_codes: &[],
                 wait_timeout: Duration::from_millis(HELPER_EXEC_TIMEOUT_MS as u64 + 5000),
-            })
-            .await
+            },
+            &mut normal_operation,
+        )
+        .await
         {
             Ok(r) if r.exit_code == 0 => {
                 cleanup_guard.disarm();
+                normal_operation.complete()?;
                 Ok(())
             }
             Ok(r) => {
-                cleanup_guard.cleanup_now().await;
-                Err(io::Error::other(format!(
+                let cleanup_result = cleanup_guard.cleanup_now(&mut normal_operation).await;
+                let error = io::Error::other(format!(
                     "failed to rename temp file to {path}: {}",
                     String::from_utf8_lossy(&r.stderr),
-                )))
+                ));
+                if cleanup_result.is_ok() {
+                    normal_operation.complete()?;
+                }
+                Err(error)
             }
             Err(e) => {
                 // Connection likely broken — short timeout to avoid blocking.
-                cleanup_guard.cleanup_now().await;
+                let _ = cleanup_guard.cleanup_now(&mut normal_operation).await;
                 Err(e)
             }
         }
@@ -601,22 +698,32 @@ impl VsockHost {
         content: &[u8],
         sudo: bool,
         append: bool,
-        tracked: bool,
+        tracking: WriteFileChunkTracking<'_>,
     ) -> io::Result<()> {
         let payload = vsock_proto::encode_write_file(path, content, sudo, append)
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e.to_string()))?;
         let timeout = Duration::from_secs(300);
-        let resp = if tracked {
-            normal_request_on_shared(
-                &self.shared,
-                MSG_WRITE_FILE,
-                &payload,
-                WRITE_FILE_TERMINAL_MSG_TYPES,
-                timeout,
-            )
-            .await?
-        } else {
-            self.request(MSG_WRITE_FILE, &payload, timeout).await?
+        let resp = match tracking {
+            WriteFileChunkTracking::Tracked => {
+                normal_request_on_shared(
+                    &self.shared,
+                    MSG_WRITE_FILE,
+                    &payload,
+                    WRITE_FILE_TERMINAL_MSG_TYPES,
+                    timeout,
+                )
+                .await?
+            }
+            WriteFileChunkTracking::Composite(normal_operation) => {
+                request_on_shared_with_composite_operation(
+                    &self.shared,
+                    MSG_WRITE_FILE,
+                    &payload,
+                    timeout,
+                    normal_operation,
+                )
+                .await?
+            }
         };
 
         if resp.msg_type == MSG_ERROR {

--- a/crates/vsock-host/src/file.rs
+++ b/crates/vsock-host/src/file.rs
@@ -1,3 +1,4 @@
+use std::future::Future;
 use std::io;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -117,13 +118,16 @@ impl ChunkedWriteCleanupGuard {
         normal_operation: &mut CompositeNormalOperation,
     ) -> io::Result<()> {
         let result = if let Some(shared) = self.shared.as_ref() {
-            exec_operation::exec_cleanup_with_composite_on_shared(
-                shared,
-                &self.command,
+            cleanup_timeout(
+                exec_operation::exec_cleanup_with_composite_on_shared(
+                    shared,
+                    &self.command,
+                    CLEANUP_EXEC_TIMEOUT_MS,
+                    &[],
+                    self.sudo,
+                    normal_operation,
+                ),
                 CLEANUP_EXEC_TIMEOUT_MS,
-                &[],
-                self.sudo,
-                normal_operation,
             )
             .await
             .and_then(validate_cleanup_result)
@@ -135,6 +139,15 @@ impl ChunkedWriteCleanupGuard {
         }
         result
     }
+}
+
+async fn cleanup_timeout<F>(cleanup: F, timeout_ms: u32) -> io::Result<ExecResult>
+where
+    F: Future<Output = io::Result<ExecResult>>,
+{
+    tokio::time::timeout(Duration::from_millis(timeout_ms as u64), cleanup)
+        .await
+        .map_err(|_| io::Error::new(io::ErrorKind::TimedOut, "cleanup command timed out"))?
 }
 
 fn validate_cleanup_result(result: ExecResult) -> io::Result<()> {
@@ -159,12 +172,15 @@ impl Drop for ChunkedWriteCleanupGuard {
         let sudo = self.sudo;
         if let Ok(handle) = tokio::runtime::Handle::try_current() {
             handle.spawn(async move {
-                let _ = exec_operation::exec_cleanup_untracked_on_shared(
-                    &shared,
-                    &command,
+                let _ = cleanup_timeout(
+                    exec_operation::exec_cleanup_untracked_on_shared(
+                        &shared,
+                        &command,
+                        CLEANUP_EXEC_TIMEOUT_MS,
+                        &[],
+                        sudo,
+                    ),
                     CLEANUP_EXEC_TIMEOUT_MS,
-                    &[],
-                    sudo,
                 )
                 .await;
             });

--- a/crates/vsock-host/src/file.rs
+++ b/crates/vsock-host/src/file.rs
@@ -723,6 +723,7 @@ impl VsockHost {
                     &self.shared,
                     MSG_WRITE_FILE,
                     &payload,
+                    WRITE_FILE_TERMINAL_MSG_TYPES,
                     timeout,
                     normal_operation,
                 )

--- a/crates/vsock-host/src/file.rs
+++ b/crates/vsock-host/src/file.rs
@@ -130,7 +130,9 @@ impl ChunkedWriteCleanupGuard {
         } else {
             Ok(())
         };
-        self.disarm();
+        if result.is_ok() {
+            self.disarm();
+        }
         result
     }
 }

--- a/crates/vsock-host/src/file.rs
+++ b/crates/vsock-host/src/file.rs
@@ -81,6 +81,14 @@ impl CopyFileToTempError {
         }
     }
 
+    fn from_exec_wait(error: io::Error) -> Self {
+        if file_operation_error_is_terminal(&error) {
+            Self::terminal(error)
+        } else {
+            Self::unproven(error)
+        }
+    }
+
     fn after_cancel(error: io::Error, cancel_result: io::Result<ExecOperationResult>) -> Self {
         Self {
             error,
@@ -612,7 +620,7 @@ impl VsockHost {
         let result = handle
             .wait(Duration::from_secs(5))
             .await
-            .map_err(CopyFileToTempError::unproven)?;
+            .map_err(CopyFileToTempError::from_exec_wait)?;
         if let Some(cancel_on_drop) = &mut cancel_on_drop {
             cancel_on_drop.disarm();
         }
@@ -719,7 +727,11 @@ impl VsockHost {
             }
             Err(e) => {
                 // Connection likely broken — short timeout to avoid blocking.
-                let _ = cleanup_guard.cleanup_now(&mut normal_operation).await;
+                let terminal_error = file_operation_error_is_terminal(&e);
+                let cleanup_result = cleanup_guard.cleanup_now(&mut normal_operation).await;
+                if terminal_error && cleanup_result.is_ok() {
+                    normal_operation.complete()?;
+                }
                 Err(e)
             }
         }

--- a/crates/vsock-host/src/file.rs
+++ b/crates/vsock-host/src/file.rs
@@ -12,7 +12,7 @@ use vsock_proto::{
 
 use crate::{
     CompositeNormalOperation, ExecCaptureRequest, ExecOperationResult, ExecOutputEvent,
-    ExecOwnedCapturedOutput, ExecStreamRequest, Shared, VsockHost, exec_operation,
+    ExecOwnedCapturedOutput, ExecResult, ExecStreamRequest, Shared, VsockHost, exec_operation,
     normal_request_on_shared, request_on_shared_with_composite_operation,
 };
 
@@ -126,7 +126,7 @@ impl ChunkedWriteCleanupGuard {
                 normal_operation,
             )
             .await
-            .map(|_| ())
+            .and_then(validate_cleanup_result)
         } else {
             Ok(())
         };
@@ -135,6 +135,18 @@ impl ChunkedWriteCleanupGuard {
         }
         result
     }
+}
+
+fn validate_cleanup_result(result: ExecResult) -> io::Result<()> {
+    if result.exit_code == 0 {
+        return Ok(());
+    }
+
+    Err(io::Error::other(format!(
+        "cleanup command failed with exit code {}: {}",
+        result.exit_code,
+        String::from_utf8_lossy(&result.stderr)
+    )))
 }
 
 impl Drop for ChunkedWriteCleanupGuard {

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -40,7 +40,7 @@ use tokio::time::{self, Instant};
 
 use operation_tracker::{
     NormalOperationRejection, NormalOperationToken, NormalOperationTracker,
-    NormalOperationTransitionError,
+    NormalOperationTransitionError, NormalOperationTransitionHandle,
 };
 use vsock_proto::{
     Decoder, MSG_ERROR, MSG_EXEC_OUTPUT, MSG_EXEC_RESULT, MSG_OPERATIONS_QUIESCED,
@@ -143,8 +143,13 @@ struct PendingRequestGuard {
 
 struct PendingResponse {
     response_tx: oneshot::Sender<RawMessage>,
-    normal_operation: Option<NormalOperationToken>,
+    normal_operation: Option<PendingNormalOperation>,
     normal_terminal_msg_types: &'static [u8],
+}
+
+enum PendingNormalOperation {
+    Owned(NormalOperationToken),
+    Composite(NormalOperationTransitionHandle),
 }
 
 struct PendingNormalRequestWriteGuard {
@@ -287,22 +292,28 @@ impl Shared {
 
 pub(crate) struct CompositeNormalOperation {
     normal_operation: Option<NormalOperationToken>,
-    possible_guest_write_started: bool,
 }
 
 impl CompositeNormalOperation {
     fn reserve(shared: &Arc<Shared>) -> io::Result<Self> {
         Ok(Self {
             normal_operation: Some(shared.reserve_normal_operation()?),
-            possible_guest_write_started: false,
         })
     }
 
-    fn mark_possible_guest_write_started(&mut self) -> io::Result<()> {
-        if self.possible_guest_write_started {
-            return Ok(());
-        }
+    fn transition_handle(&self) -> io::Result<NormalOperationTransitionHandle> {
+        self.normal_operation
+            .as_ref()
+            .map(NormalOperationToken::transition_handle)
+            .ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "composite normal operation already completed",
+                )
+            })
+    }
 
+    fn mark_possible_guest_write_started(&mut self) -> io::Result<()> {
         let normal_operation = self.normal_operation.as_mut().ok_or_else(|| {
             io::Error::new(
                 io::ErrorKind::InvalidData,
@@ -312,7 +323,6 @@ impl CompositeNormalOperation {
         normal_operation
             .mark_possible_guest_write_started()
             .map_err(normal_operation_transition_error)?;
-        self.possible_guest_write_started = true;
         Ok(())
     }
 
@@ -451,10 +461,7 @@ async fn reader_loop(
                                     .contains(&msg.msg_type)
                                     && let Some(normal_operation) =
                                         pending_response.normal_operation.take()
-                                    && normal_operation
-                                        .complete()
-                                        .map_err(normal_operation_transition_error)
-                                        .is_err()
+                                    && complete_pending_normal_operation(normal_operation).is_err()
                                 {
                                     normal_operation_transition_failed = true;
                                 }
@@ -569,6 +576,7 @@ async fn request_on_shared_with_composite_operation(
     shared: &Arc<Shared>,
     msg_type: u8,
     payload: &[u8],
+    terminal_msg_types: &'static [u8],
     timeout: Duration,
     normal_operation: &mut CompositeNormalOperation,
 ) -> io::Result<RawMessage> {
@@ -578,6 +586,7 @@ async fn request_on_shared_with_composite_operation(
         msg_type,
         seq,
         payload,
+        terminal_msg_types,
         timeout,
         normal_operation,
     )
@@ -589,6 +598,7 @@ async fn request_raw_on_shared_with_composite_operation(
     msg_type: u8,
     seq: u32,
     payload: &[u8],
+    terminal_msg_types: &'static [u8],
     timeout: Duration,
     normal_operation: &mut CompositeNormalOperation,
 ) -> io::Result<RawMessage> {
@@ -610,8 +620,10 @@ async fn request_raw_on_shared_with_composite_operation(
                     seq,
                     PendingResponse {
                         response_tx: tx,
-                        normal_operation: None,
-                        normal_terminal_msg_types: &[],
+                        normal_operation: Some(PendingNormalOperation::Composite(
+                            normal_operation.transition_handle()?,
+                        )),
+                        normal_terminal_msg_types: terminal_msg_types,
                     },
                 );
             }
@@ -673,7 +685,7 @@ async fn normal_request_raw_on_shared(
                     seq,
                     PendingResponse {
                         response_tx: tx,
-                        normal_operation: Some(normal_operation),
+                        normal_operation: Some(PendingNormalOperation::Owned(normal_operation)),
                         normal_terminal_msg_types: terminal_msg_types,
                     },
                 );
@@ -728,14 +740,36 @@ fn mark_pending_normal_operation_possible_guest_write(
                     "normal request missing operation token",
                 ));
             };
-            normal_operation
-                .mark_possible_guest_write_started()
-                .map_err(normal_operation_transition_error)
+            mark_pending_normal_operation_possible_guest_write_started(normal_operation)
         }
         ConnectionState::Closed { .. } => Err(io::Error::new(
             io::ErrorKind::ConnectionReset,
             "connection closed",
         )),
+    }
+}
+
+fn mark_pending_normal_operation_possible_guest_write_started(
+    normal_operation: &mut PendingNormalOperation,
+) -> io::Result<()> {
+    match normal_operation {
+        PendingNormalOperation::Owned(normal_operation) => normal_operation
+            .mark_possible_guest_write_started()
+            .map_err(normal_operation_transition_error),
+        PendingNormalOperation::Composite(normal_operation) => normal_operation
+            .mark_possible_guest_write_started()
+            .map_err(normal_operation_transition_error),
+    }
+}
+
+fn complete_pending_normal_operation(normal_operation: PendingNormalOperation) -> io::Result<()> {
+    match normal_operation {
+        PendingNormalOperation::Owned(normal_operation) => normal_operation
+            .complete()
+            .map_err(normal_operation_transition_error),
+        PendingNormalOperation::Composite(normal_operation) => normal_operation
+            .mark_possible_guest_write_completed()
+            .map_err(normal_operation_transition_error),
     }
 }
 

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -285,6 +285,53 @@ impl Shared {
     }
 }
 
+pub(crate) struct CompositeNormalOperation {
+    normal_operation: Option<NormalOperationToken>,
+    possible_guest_write_started: bool,
+}
+
+impl CompositeNormalOperation {
+    fn reserve(shared: &Arc<Shared>) -> io::Result<Self> {
+        Ok(Self {
+            normal_operation: Some(shared.reserve_normal_operation()?),
+            possible_guest_write_started: false,
+        })
+    }
+
+    fn mark_possible_guest_write_started(&mut self) -> io::Result<()> {
+        if self.possible_guest_write_started {
+            return Ok(());
+        }
+
+        let normal_operation = self.normal_operation.as_mut().ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "composite normal operation already completed",
+            )
+        })?;
+        normal_operation
+            .mark_possible_guest_write_started()
+            .map_err(normal_operation_transition_error)?;
+        self.possible_guest_write_started = true;
+        Ok(())
+    }
+
+    fn complete(mut self) -> io::Result<()> {
+        let normal_operation = self.normal_operation.take().ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "composite normal operation already completed",
+            )
+        })?;
+        // Terminal proof can race with connection close, which clears tracker
+        // operations. Completion is idempotent for the composite owner.
+        match normal_operation.complete() {
+            Ok(()) | Err(NormalOperationTransitionError::UnknownOperation { .. }) => Ok(()),
+            Err(error) => Err(normal_operation_transition_error(error)),
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum ConnectionCloseKind {
     Closed,
@@ -516,6 +563,87 @@ async fn normal_request_on_shared(
 ) -> io::Result<RawMessage> {
     let seq = shared.next_seq();
     normal_request_raw_on_shared(shared, msg_type, seq, payload, terminal_msg_types, timeout).await
+}
+
+async fn request_on_shared_with_composite_operation(
+    shared: &Arc<Shared>,
+    msg_type: u8,
+    payload: &[u8],
+    timeout: Duration,
+    normal_operation: &mut CompositeNormalOperation,
+) -> io::Result<RawMessage> {
+    let seq = shared.next_seq();
+    request_raw_on_shared_with_composite_operation(
+        shared,
+        msg_type,
+        seq,
+        payload,
+        timeout,
+        normal_operation,
+    )
+    .await
+}
+
+async fn request_raw_on_shared_with_composite_operation(
+    shared: &Arc<Shared>,
+    msg_type: u8,
+    seq: u32,
+    payload: &[u8],
+    timeout: Duration,
+    normal_operation: &mut CompositeNormalOperation,
+) -> io::Result<RawMessage> {
+    let data = vsock_proto::encode(msg_type, seq, payload)
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e.to_string()))?;
+
+    let (tx, rx) = oneshot::channel();
+    {
+        let mut guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
+        match &mut *guard {
+            ConnectionState::Closed { .. } => {
+                return Err(io::Error::new(
+                    io::ErrorKind::ConnectionReset,
+                    "connection closed",
+                ));
+            }
+            ConnectionState::Connected { pending, .. } => {
+                pending.insert(
+                    seq,
+                    PendingResponse {
+                        response_tx: tx,
+                        normal_operation: None,
+                        normal_terminal_msg_types: &[],
+                    },
+                );
+            }
+        }
+    }
+    let _pending_guard = PendingRequestGuard::new(Arc::clone(shared), seq);
+
+    let mut write_guard = PendingNormalRequestWriteGuard::new(Arc::clone(shared));
+    let mut writer = shared.writer.lock().await;
+    normal_operation.mark_possible_guest_write_started()?;
+    write_guard.mark_started();
+    if let Err(error) = writer.write_all(&data).await {
+        write_guard.mark_returned();
+        shared.poison_connection();
+        return Err(error);
+    }
+    write_guard.mark_returned();
+    drop(writer);
+    drop(write_guard);
+
+    tokio::select! {
+        biased;
+        result = rx => {
+            result.map_err(|_| io::Error::new(
+                io::ErrorKind::ConnectionReset,
+                "connection closed",
+            ))
+        }
+        _ = tokio::time::sleep(timeout) => {
+            Err(io::Error::new(io::ErrorKind::TimedOut, "request timeout"))
+        }
+    }
 }
 
 async fn normal_request_raw_on_shared(

--- a/crates/vsock-host/src/operation_tracker.rs
+++ b/crates/vsock-host/src/operation_tracker.rs
@@ -147,6 +147,7 @@ pub(crate) struct NormalOperationFenceId(u64);
 pub(crate) enum OperationPhase {
     ReservedBeforeWrite,
     PossibleGuestWrite,
+    GuestWriteCompleted,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -185,28 +186,17 @@ pub(crate) struct NormalOperationToken {
 }
 
 impl NormalOperationToken {
+    pub(crate) fn transition_handle(&self) -> NormalOperationTransitionHandle {
+        NormalOperationTransitionHandle {
+            id: self.id,
+            inner: Arc::clone(&self.inner),
+        }
+    }
+
     pub(crate) fn mark_possible_guest_write_started(
         &mut self,
     ) -> Result<(), NormalOperationTransitionError> {
-        let mut inner = lock_inner(&self.inner);
-        let Some(phase) = inner.operations.get_mut(&self.id) else {
-            return Err(NormalOperationTransitionError::UnknownOperation {
-                operation_id: self.id,
-            });
-        };
-        match *phase {
-            OperationPhase::ReservedBeforeWrite => {
-                *phase = OperationPhase::PossibleGuestWrite;
-                Ok(())
-            }
-            OperationPhase::PossibleGuestWrite => {
-                Err(NormalOperationTransitionError::InvalidTransition {
-                    operation_id: self.id,
-                    from: OperationPhase::PossibleGuestWrite,
-                    to: OperationPhase::PossibleGuestWrite,
-                })
-            }
-        }
+        self.transition_handle().mark_possible_guest_write_started()
     }
 
     pub(crate) fn complete(mut self) -> Result<(), NormalOperationTransitionError> {
@@ -221,6 +211,62 @@ impl NormalOperationToken {
     }
 }
 
+#[derive(Clone, Debug)]
+pub(crate) struct NormalOperationTransitionHandle {
+    id: NormalOperationId,
+    inner: Arc<Mutex<Inner>>,
+}
+
+impl NormalOperationTransitionHandle {
+    pub(crate) fn mark_possible_guest_write_started(
+        &self,
+    ) -> Result<(), NormalOperationTransitionError> {
+        let mut inner = lock_inner(&self.inner);
+        let Some(phase) = inner.operations.get_mut(&self.id) else {
+            return Err(NormalOperationTransitionError::UnknownOperation {
+                operation_id: self.id,
+            });
+        };
+        match *phase {
+            OperationPhase::ReservedBeforeWrite | OperationPhase::GuestWriteCompleted => {
+                *phase = OperationPhase::PossibleGuestWrite;
+                Ok(())
+            }
+            OperationPhase::PossibleGuestWrite => {
+                Err(NormalOperationTransitionError::InvalidTransition {
+                    operation_id: self.id,
+                    from: OperationPhase::PossibleGuestWrite,
+                    to: OperationPhase::PossibleGuestWrite,
+                })
+            }
+        }
+    }
+
+    pub(crate) fn mark_possible_guest_write_completed(
+        &self,
+    ) -> Result<(), NormalOperationTransitionError> {
+        let mut inner = lock_inner(&self.inner);
+        let Some(phase) = inner.operations.get_mut(&self.id) else {
+            return Err(NormalOperationTransitionError::UnknownOperation {
+                operation_id: self.id,
+            });
+        };
+        match *phase {
+            OperationPhase::PossibleGuestWrite => {
+                *phase = OperationPhase::GuestWriteCompleted;
+                Ok(())
+            }
+            OperationPhase::ReservedBeforeWrite | OperationPhase::GuestWriteCompleted => {
+                Err(NormalOperationTransitionError::InvalidTransition {
+                    operation_id: self.id,
+                    from: *phase,
+                    to: OperationPhase::GuestWriteCompleted,
+                })
+            }
+        }
+    }
+}
+
 impl Drop for NormalOperationToken {
     fn drop(&mut self) {
         if self.released {
@@ -229,7 +275,7 @@ impl Drop for NormalOperationToken {
         let mut inner = lock_inner(&self.inner);
         match inner.operations.remove(&self.id) {
             Some(OperationPhase::ReservedBeforeWrite) | None => {}
-            Some(OperationPhase::PossibleGuestWrite) => {
+            Some(OperationPhase::PossibleGuestWrite | OperationPhase::GuestWriteCompleted) => {
                 if !matches!(inner.state, TrackerState::Closed) {
                     inner.state = TrackerState::NotParkable;
                     inner.operations.clear();
@@ -323,6 +369,80 @@ mod tests {
             tracker.reserve(),
             Err(NormalOperationRejection::NotParkable)
         ));
+    }
+
+    #[test]
+    fn completed_guest_write_remains_busy_until_operation_complete() {
+        let tracker = NormalOperationTracker::new();
+        let mut token = reserve(&tracker);
+        let handle = token.transition_handle();
+        token
+            .mark_possible_guest_write_started()
+            .expect("mark write started");
+
+        handle
+            .mark_possible_guest_write_completed()
+            .expect("mark write completed");
+
+        assert_eq!(tracker.readiness(), NormalOperationReadiness::Busy);
+        token.complete().expect("operation should complete");
+        assert_eq!(tracker.readiness(), NormalOperationReadiness::Idle);
+    }
+
+    #[test]
+    fn completed_guest_write_can_start_another_guest_write() {
+        let tracker = NormalOperationTracker::new();
+        let mut token = reserve(&tracker);
+        let handle = token.transition_handle();
+        token
+            .mark_possible_guest_write_started()
+            .expect("mark first write started");
+        handle
+            .mark_possible_guest_write_completed()
+            .expect("mark first write completed");
+
+        token
+            .mark_possible_guest_write_started()
+            .expect("mark second write started");
+
+        drop(token);
+        assert_eq!(tracker.readiness(), NormalOperationReadiness::NotParkable);
+    }
+
+    #[test]
+    fn close_after_guest_write_completed_is_closed_not_not_parkable() {
+        let tracker = NormalOperationTracker::new();
+        let mut token = reserve(&tracker);
+        let handle = token.transition_handle();
+        token
+            .mark_possible_guest_write_started()
+            .expect("mark write started");
+        handle
+            .mark_possible_guest_write_completed()
+            .expect("mark write completed");
+
+        tracker.mark_closed();
+
+        assert_eq!(tracker.readiness(), NormalOperationReadiness::Closed);
+        drop(token);
+        assert_eq!(tracker.readiness(), NormalOperationReadiness::Closed);
+    }
+
+    #[test]
+    fn drop_after_guest_write_completed_without_complete_is_not_parkable() {
+        let tracker = NormalOperationTracker::new();
+        let mut token = reserve(&tracker);
+        let handle = token.transition_handle();
+        token
+            .mark_possible_guest_write_started()
+            .expect("mark write started");
+        handle
+            .mark_possible_guest_write_completed()
+            .expect("mark write completed");
+
+        drop(token);
+
+        assert_eq!(tracker.readiness(), NormalOperationReadiness::NotParkable);
     }
 
     #[test]

--- a/crates/vsock-host/src/tests/file.rs
+++ b/crates/vsock-host/src/tests/file.rs
@@ -413,6 +413,84 @@ async fn copy_file_removes_temp_without_publishing_on_stream_truncation() {
 }
 
 #[tokio::test]
+async fn copy_file_stream_error_releases_tracker_when_cancel_sees_terminal_result() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+    let unique = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let dir = std::env::temp_dir().join(format!(
+        "vsock-host-copy-cancel-terminal-{}-{unique}",
+        std::process::id()
+    ));
+    std::fs::create_dir_all(&dir).unwrap();
+    let host_path = dir.join("system.log");
+    std::fs::write(&host_path, b"old host log").unwrap();
+    let copy_path = host_path.clone();
+
+    let copy_task = {
+        let host = Arc::clone(&host);
+        tokio::spawn(async move {
+            host.copy_file(
+                "/tmp/vm0-system-run.log",
+                &copy_path,
+                CopyFileOptions {
+                    max_bytes: 1024,
+                    timeout_ms: 5000,
+                    missing_ok: false,
+                },
+            )
+            .await
+        })
+    };
+
+    let msg = read_guest_message(&mut guest).await;
+    assert_eq!(msg.msg_type, MSG_EXEC_START);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Busy
+    );
+    send_exec_output(
+        &mut guest,
+        msg.seq,
+        0,
+        ExecOutputStream::Stdout,
+        b"partial",
+        true,
+    )
+    .await;
+
+    let cancel = read_guest_message(&mut guest).await;
+    assert_eq!(cancel.msg_type, MSG_EXEC_CANCEL);
+    assert_eq!(cancel.seq, msg.seq);
+    send_stream_exec_result(
+        &mut guest,
+        msg.seq,
+        ExecTermination::Exited { exit_code: 0 },
+        b"",
+    )
+    .await;
+
+    let err = copy_task.await.unwrap().unwrap_err();
+    assert!(err.to_string().contains("truncated"));
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Idle
+    );
+    assert_eq!(std::fs::read(&host_path).unwrap(), b"old host log");
+    assert!(
+        std::fs::read_dir(&dir).unwrap().all(|entry| !entry
+            .unwrap()
+            .file_name()
+            .to_string_lossy()
+            .contains("vm0tmp")),
+        "failed copy temp file should be removed"
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[tokio::test]
 async fn copy_file_nonzero_exit_removes_temp_without_publishing_partial_output() {
     let (host, mut guest) = setup_host_and_guest().await;
     let unique = std::time::SystemTime::now()

--- a/crates/vsock-host/src/tests/file.rs
+++ b/crates/vsock-host/src/tests/file.rs
@@ -491,6 +491,68 @@ async fn copy_file_stream_error_releases_tracker_when_cancel_sees_terminal_resul
 }
 
 #[tokio::test]
+async fn copy_file_terminal_result_before_connection_close_keeps_tracker_closed_not_not_parkable() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+    let unique = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let dir = std::env::temp_dir().join(format!(
+        "vsock-host-copy-terminal-close-{}-{unique}",
+        std::process::id()
+    ));
+    std::fs::create_dir_all(&dir).unwrap();
+    let host_path = dir.join("system.log");
+    let copy_path = host_path.clone();
+
+    let copy_task = {
+        let host = Arc::clone(&host);
+        tokio::spawn(async move {
+            host.copy_file(
+                "/tmp/vm0-system-run.log",
+                &copy_path,
+                CopyFileOptions {
+                    max_bytes: 1024,
+                    timeout_ms: 5000,
+                    missing_ok: false,
+                },
+            )
+            .await
+        })
+    };
+
+    let msg = read_guest_message(&mut guest).await;
+    assert_eq!(msg.msg_type, MSG_EXEC_START);
+    send_exec_output(
+        &mut guest,
+        msg.seq,
+        0,
+        ExecOutputStream::Stdout,
+        b"complete\n",
+        false,
+    )
+    .await;
+    send_stream_exec_result(
+        &mut guest,
+        msg.seq,
+        ExecTermination::Exited { exit_code: 0 },
+        b"",
+    )
+    .await;
+    drop(guest);
+
+    let result = copy_task.await.unwrap().unwrap();
+    assert_eq!(result.bytes_copied, 9);
+    assert_eq!(std::fs::read(&host_path).unwrap(), b"complete\n");
+    assert_ne!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::NotParkable
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[tokio::test]
 async fn copy_file_nonzero_exit_removes_temp_without_publishing_partial_output() {
     let (host, mut guest) = setup_host_and_guest().await;
     let unique = std::time::SystemTime::now()

--- a/crates/vsock-host/src/tests/file.rs
+++ b/crates/vsock-host/src/tests/file.rs
@@ -1404,6 +1404,71 @@ async fn write_file_chunked_cleanup_error_retries_untracked_on_drop() {
 }
 
 #[tokio::test]
+async fn write_file_chunked_cleanup_nonzero_exit_retries_untracked_on_drop() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+
+    let chunk_limit = file_impl::test_support::WRITE_FILE_CHUNK_LIMIT;
+    let content = vec![0xABu8; chunk_limit + 100];
+    let write_task = {
+        let host = Arc::clone(&host);
+        tokio::spawn(async move { host.write_file("/tmp/big.bin", &content, false).await })
+    };
+
+    let first = read_guest_message(&mut guest).await;
+    assert_eq!(first.msg_type, MSG_WRITE_FILE);
+    let payload = vsock_proto::encode_write_file_result(true, "");
+    guest
+        .write_all(&vsock_proto::encode(MSG_WRITE_FILE_RESULT, first.seq, &payload).unwrap())
+        .await
+        .unwrap();
+
+    let second = read_guest_message(&mut guest).await;
+    assert_eq!(second.msg_type, MSG_WRITE_FILE);
+    let payload = vsock_proto::encode_write_file_result(false, "disk full");
+    guest
+        .write_all(&vsock_proto::encode(MSG_WRITE_FILE_RESULT, second.seq, &payload).unwrap())
+        .await
+        .unwrap();
+
+    let cleanup = read_guest_message(&mut guest).await;
+    assert_eq!(cleanup.msg_type, MSG_EXEC_START);
+    let decoded = vsock_proto::decode_exec_start(&cleanup.payload).unwrap();
+    assert_eq!(decoded.label, "exec-cleanup");
+    send_exec_result(
+        &mut guest,
+        cleanup.seq,
+        ExecTermination::Exited { exit_code: 1 },
+        &[],
+        b"permission denied",
+    )
+    .await;
+
+    let err = write_task.await.unwrap().unwrap_err();
+    assert!(err.to_string().contains("disk full"));
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::NotParkable
+    );
+
+    let retry = tokio::time::timeout(Duration::from_secs(2), read_guest_message(&mut guest))
+        .await
+        .expect("cleanup retry was not sent after nonzero cleanup exit");
+    assert_eq!(retry.msg_type, MSG_EXEC_START);
+    let decoded = vsock_proto::decode_exec_start(&retry.payload).unwrap();
+    assert_eq!(decoded.label, "exec-cleanup");
+    assert!(decoded.command.contains("rm -f --"));
+    send_exec_result(
+        &mut guest,
+        retry.seq,
+        ExecTermination::Exited { exit_code: 0 },
+        &[],
+        &[],
+    )
+    .await;
+}
+
+#[tokio::test]
 async fn test_write_file_at_chunk_limit_uses_single_message() {
     let (host_stream, mut guest) = make_pair();
 

--- a/crates/vsock-host/src/tests/file.rs
+++ b/crates/vsock-host/src/tests/file.rs
@@ -555,6 +555,64 @@ async fn copy_file_error_response_releases_tracker_after_temp_cleanup() {
 }
 
 #[tokio::test]
+async fn copy_file_connection_close_after_request_removes_temp_and_marks_not_parkable() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+    let unique = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let dir = std::env::temp_dir().join(format!(
+        "vsock-host-copy-connection-close-{}-{unique}",
+        std::process::id()
+    ));
+    std::fs::create_dir_all(&dir).unwrap();
+    let host_path = dir.join("system.log");
+    let copy_path = host_path.clone();
+
+    let copy_task = {
+        let host = Arc::clone(&host);
+        tokio::spawn(async move {
+            host.copy_file(
+                "/tmp/vm0-system-run.log",
+                &copy_path,
+                CopyFileOptions {
+                    max_bytes: 1024,
+                    timeout_ms: 5000,
+                    missing_ok: false,
+                },
+            )
+            .await
+        })
+    };
+
+    let msg = read_guest_message(&mut guest).await;
+    assert_eq!(msg.msg_type, MSG_EXEC_START);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Busy
+    );
+
+    drop(guest);
+    let err = copy_task.await.unwrap().unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::ConnectionReset);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::NotParkable
+    );
+    assert!(!host_path.exists());
+    assert!(
+        std::fs::read_dir(&dir).unwrap().all(|entry| !entry
+            .unwrap()
+            .file_name()
+            .to_string_lossy()
+            .contains("vm0tmp")),
+        "failed copy temp file should be removed"
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[tokio::test]
 async fn copy_file_terminal_result_before_connection_close_keeps_tracker_closed_not_not_parkable() {
     let (host, mut guest) = setup_host_and_guest().await;
     let host = Arc::new(host);
@@ -1456,6 +1514,58 @@ async fn write_file_chunked_error_response_cleans_up_and_releases_tracker() {
         normal_operation_readiness(&host),
         NormalOperationReadiness::Idle
     );
+}
+
+#[tokio::test]
+async fn write_file_chunked_unexpected_response_keeps_tracker_fail_closed() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+
+    let chunk_limit = file_impl::test_support::WRITE_FILE_CHUNK_LIMIT;
+    let content = vec![0xABu8; chunk_limit + 100];
+    let write_task = {
+        let host = Arc::clone(&host);
+        tokio::spawn(async move { host.write_file("/tmp/big.bin", &content, false).await })
+    };
+
+    let first = read_guest_message(&mut guest).await;
+    assert_eq!(first.msg_type, MSG_WRITE_FILE);
+    let payload = vsock_proto::encode_write_file_result(true, "");
+    guest
+        .write_all(&vsock_proto::encode(MSG_WRITE_FILE_RESULT, first.seq, &payload).unwrap())
+        .await
+        .unwrap();
+
+    let second = read_guest_message(&mut guest).await;
+    assert_eq!(second.msg_type, MSG_WRITE_FILE);
+    guest
+        .write_all(&vsock_proto::encode(MSG_EXEC_START, second.seq, &[]).unwrap())
+        .await
+        .unwrap();
+
+    let err = write_task.await.unwrap().unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::NotParkable
+    );
+
+    let cleanup_retry =
+        tokio::time::timeout(Duration::from_secs(2), read_guest_message(&mut guest))
+            .await
+            .expect("cleanup retry was not sent after unexpected response");
+    assert_eq!(cleanup_retry.msg_type, MSG_EXEC_START);
+    let decoded = vsock_proto::decode_exec_start(&cleanup_retry.payload).unwrap();
+    assert_eq!(decoded.label, "exec-cleanup");
+    assert!(decoded.command.contains("rm -f --"));
+    send_exec_result(
+        &mut guest,
+        cleanup_retry.seq,
+        ExecTermination::Exited { exit_code: 0 },
+        &[],
+        &[],
+    )
+    .await;
 }
 
 #[tokio::test]

--- a/crates/vsock-host/src/tests/file.rs
+++ b/crates/vsock-host/src/tests/file.rs
@@ -160,6 +160,7 @@ async fn read_file_quotes_guest_path_with_single_quote() {
 #[tokio::test]
 async fn copy_file_streams_to_temp_then_renames() {
     let (host, mut guest) = setup_host_and_guest().await;
+    let host = Arc::new(host);
     let unique = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap()
@@ -169,21 +170,27 @@ async fn copy_file_streams_to_temp_then_renames() {
     let host_path = dir.join("system.log");
     let copy_path = host_path.clone();
 
+    let task_host = Arc::clone(&host);
     let copy_task = tokio::spawn(async move {
-        host.copy_file(
-            "/tmp/vm0-system-run.log",
-            &copy_path,
-            CopyFileOptions {
-                max_bytes: 1024,
-                timeout_ms: 5000,
-                missing_ok: false,
-            },
-        )
-        .await
+        task_host
+            .copy_file(
+                "/tmp/vm0-system-run.log",
+                &copy_path,
+                CopyFileOptions {
+                    max_bytes: 1024,
+                    timeout_ms: 5000,
+                    missing_ok: false,
+                },
+            )
+            .await
     });
 
     let msg = read_guest_message(&mut guest).await;
     assert_eq!(msg.msg_type, MSG_EXEC_START);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Busy
+    );
     let decoded = vsock_proto::decode_exec_start(&msg.payload).unwrap();
     assert_eq!(decoded.label, "copy-file");
     assert_eq!(
@@ -225,6 +232,10 @@ async fn copy_file_streams_to_temp_then_renames() {
 
     let result = copy_task.await.unwrap().unwrap();
     assert_eq!(result.bytes_copied, 14);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Idle
+    );
     assert_eq!(std::fs::read(&host_path).unwrap(), b"line 1\nline 2\n");
     assert!(
         std::fs::read_dir(&dir).unwrap().all(|entry| !entry
@@ -465,6 +476,7 @@ async fn copy_file_nonzero_exit_removes_temp_without_publishing_partial_output()
 #[tokio::test]
 async fn copy_file_missing_ok_leaves_no_final_or_temp_file() {
     let (host, mut guest) = setup_host_and_guest().await;
+    let host = Arc::new(host);
     let unique = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap()
@@ -477,21 +489,27 @@ async fn copy_file_missing_ok_leaves_no_final_or_temp_file() {
     let host_path = dir.join("system.log");
     let copy_path = host_path.clone();
 
+    let task_host = Arc::clone(&host);
     let copy_task = tokio::spawn(async move {
-        host.copy_file(
-            "/tmp/missing.log",
-            &copy_path,
-            CopyFileOptions {
-                max_bytes: 1024,
-                timeout_ms: 5000,
-                missing_ok: true,
-            },
-        )
-        .await
+        task_host
+            .copy_file(
+                "/tmp/missing.log",
+                &copy_path,
+                CopyFileOptions {
+                    max_bytes: 1024,
+                    timeout_ms: 5000,
+                    missing_ok: true,
+                },
+            )
+            .await
     });
 
     let msg = read_guest_message(&mut guest).await;
     assert_eq!(msg.msg_type, MSG_EXEC_START);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Busy
+    );
     let decoded = vsock_proto::decode_exec_start(&msg.payload).unwrap();
     assert_eq!(decoded.expected_exit_codes, vec![66]);
     send_stream_exec_result(
@@ -504,6 +522,10 @@ async fn copy_file_missing_ok_leaves_no_final_or_temp_file() {
 
     let result = copy_task.await.unwrap().unwrap();
     assert_eq!(result.bytes_copied, 0);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Idle
+    );
     assert!(!host_path.exists());
     assert!(
         std::fs::read_dir(&dir).unwrap().all(|entry| !entry
@@ -604,6 +626,10 @@ async fn copy_file_cancellation_cancels_guest_exec_operation_and_removes_temp() 
 
     let start = read_guest_message(&mut guest).await;
     assert_eq!(start.msg_type, MSG_EXEC_START);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Busy
+    );
     let temp_paths: Vec<_> = std::fs::read_dir(&dir)
         .unwrap()
         .map(|entry| entry.unwrap().path())
@@ -617,6 +643,10 @@ async fn copy_file_cancellation_cancels_guest_exec_operation_and_removes_temp() 
 
     copy_task.abort();
     assert!(copy_task.await.unwrap_err().is_cancelled());
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::NotParkable
+    );
 
     let cancel = read_guest_message(&mut guest).await;
     assert_eq!(cancel.msg_type, MSG_EXEC_CANCEL);
@@ -938,6 +968,121 @@ async fn test_write_file_chunked() {
 }
 
 #[tokio::test]
+async fn write_file_chunked_tracks_one_operation_until_rename_result() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+
+    let chunk_limit = file_impl::test_support::WRITE_FILE_CHUNK_LIMIT;
+    let content = vec![0xABu8; chunk_limit + 100];
+    let write_task = {
+        let host = Arc::clone(&host);
+        tokio::spawn(async move { host.write_file("/tmp/big.bin", &content, false).await })
+    };
+
+    let first = read_guest_message(&mut guest).await;
+    assert_eq!(first.msg_type, MSG_WRITE_FILE);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Busy
+    );
+    let payload = vsock_proto::encode_write_file_result(true, "");
+    guest
+        .write_all(&vsock_proto::encode(MSG_WRITE_FILE_RESULT, first.seq, &payload).unwrap())
+        .await
+        .unwrap();
+
+    let second = read_guest_message(&mut guest).await;
+    assert_eq!(second.msg_type, MSG_WRITE_FILE);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Busy
+    );
+    let payload = vsock_proto::encode_write_file_result(true, "");
+    guest
+        .write_all(&vsock_proto::encode(MSG_WRITE_FILE_RESULT, second.seq, &payload).unwrap())
+        .await
+        .unwrap();
+
+    let rename = read_guest_message(&mut guest).await;
+    assert_eq!(rename.msg_type, MSG_EXEC_START);
+    let decoded = vsock_proto::decode_exec_start(&rename.payload).unwrap();
+    assert_eq!(decoded.label, "write-file-rename");
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Busy
+    );
+
+    send_exec_result(
+        &mut guest,
+        rename.seq,
+        ExecTermination::Exited { exit_code: 0 },
+        &[],
+        &[],
+    )
+    .await;
+
+    write_task.await.unwrap().unwrap();
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Idle
+    );
+}
+
+#[tokio::test]
+async fn write_file_chunked_failure_remains_busy_until_cleanup_result() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+
+    let chunk_limit = file_impl::test_support::WRITE_FILE_CHUNK_LIMIT;
+    let content = vec![0xABu8; chunk_limit + 100];
+    let write_task = {
+        let host = Arc::clone(&host);
+        tokio::spawn(async move { host.write_file("/tmp/big.bin", &content, false).await })
+    };
+
+    let first = read_guest_message(&mut guest).await;
+    assert_eq!(first.msg_type, MSG_WRITE_FILE);
+    let payload = vsock_proto::encode_write_file_result(true, "");
+    guest
+        .write_all(&vsock_proto::encode(MSG_WRITE_FILE_RESULT, first.seq, &payload).unwrap())
+        .await
+        .unwrap();
+
+    let second = read_guest_message(&mut guest).await;
+    assert_eq!(second.msg_type, MSG_WRITE_FILE);
+    let payload = vsock_proto::encode_write_file_result(false, "disk full");
+    guest
+        .write_all(&vsock_proto::encode(MSG_WRITE_FILE_RESULT, second.seq, &payload).unwrap())
+        .await
+        .unwrap();
+
+    let cleanup = read_guest_message(&mut guest).await;
+    assert_eq!(cleanup.msg_type, MSG_EXEC_START);
+    let decoded = vsock_proto::decode_exec_start(&cleanup.payload).unwrap();
+    assert_eq!(decoded.label, "exec-cleanup");
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Busy
+    );
+
+    send_exec_result(
+        &mut guest,
+        cleanup.seq,
+        ExecTermination::Exited { exit_code: 0 },
+        &[],
+        &[],
+    )
+    .await;
+
+    let err = write_task.await.unwrap().unwrap_err();
+    assert!(err.to_string().contains("disk full"));
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Idle
+    );
+}
+
+#[tokio::test]
 async fn test_write_file_at_chunk_limit_uses_single_message() {
     let (host_stream, mut guest) = make_pair();
 
@@ -1196,6 +1341,10 @@ async fn test_write_file_chunked_cleans_up_when_cancelled() {
         result = first_chunk_rx => result.unwrap(),
     }
     drop(write);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::NotParkable
+    );
 
     let cleanup_command = tokio::time::timeout(Duration::from_secs(2), cleanup_rx)
         .await

--- a/crates/vsock-host/src/tests/file.rs
+++ b/crates/vsock-host/src/tests/file.rs
@@ -491,6 +491,70 @@ async fn copy_file_stream_error_releases_tracker_when_cancel_sees_terminal_resul
 }
 
 #[tokio::test]
+async fn copy_file_error_response_releases_tracker_after_temp_cleanup() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+    let unique = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let dir = std::env::temp_dir().join(format!(
+        "vsock-host-copy-error-response-{}-{unique}",
+        std::process::id()
+    ));
+    std::fs::create_dir_all(&dir).unwrap();
+    let host_path = dir.join("system.log");
+    std::fs::write(&host_path, b"old host log").unwrap();
+    let copy_path = host_path.clone();
+
+    let copy_task = {
+        let host = Arc::clone(&host);
+        tokio::spawn(async move {
+            host.copy_file(
+                "/tmp/vm0-system-run.log",
+                &copy_path,
+                CopyFileOptions {
+                    max_bytes: 1024,
+                    timeout_ms: 5000,
+                    missing_ok: false,
+                },
+            )
+            .await
+        })
+    };
+
+    let msg = read_guest_message(&mut guest).await;
+    assert_eq!(msg.msg_type, MSG_EXEC_START);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Busy
+    );
+
+    let payload = vsock_proto::encode_error("guest copy failed");
+    guest
+        .write_all(&vsock_proto::encode(MSG_ERROR, msg.seq, &payload).unwrap())
+        .await
+        .unwrap();
+
+    let err = copy_task.await.unwrap().unwrap_err();
+    assert!(err.to_string().contains("guest copy failed"));
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Idle
+    );
+    assert_eq!(std::fs::read(&host_path).unwrap(), b"old host log");
+    assert!(
+        std::fs::read_dir(&dir).unwrap().all(|entry| !entry
+            .unwrap()
+            .file_name()
+            .to_string_lossy()
+            .contains("vm0tmp")),
+        "failed copy temp file should be removed"
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[tokio::test]
 async fn copy_file_terminal_result_before_connection_close_keeps_tracker_closed_not_not_parkable() {
     let (host, mut guest) = setup_host_and_guest().await;
     let host = Arc::new(host);
@@ -1335,6 +1399,122 @@ async fn write_file_chunked_failure_remains_busy_until_cleanup_result() {
 
     let err = write_task.await.unwrap().unwrap_err();
     assert!(err.to_string().contains("disk full"));
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Idle
+    );
+}
+
+#[tokio::test]
+async fn write_file_chunked_error_response_cleans_up_and_releases_tracker() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+
+    let chunk_limit = file_impl::test_support::WRITE_FILE_CHUNK_LIMIT;
+    let content = vec![0xABu8; chunk_limit + 100];
+    let write_task = {
+        let host = Arc::clone(&host);
+        tokio::spawn(async move { host.write_file("/tmp/big.bin", &content, false).await })
+    };
+
+    let first = read_guest_message(&mut guest).await;
+    assert_eq!(first.msg_type, MSG_WRITE_FILE);
+    let payload = vsock_proto::encode_write_file_result(true, "");
+    guest
+        .write_all(&vsock_proto::encode(MSG_WRITE_FILE_RESULT, first.seq, &payload).unwrap())
+        .await
+        .unwrap();
+
+    let second = read_guest_message(&mut guest).await;
+    assert_eq!(second.msg_type, MSG_WRITE_FILE);
+    let payload = vsock_proto::encode_error("guest write failed");
+    guest
+        .write_all(&vsock_proto::encode(MSG_ERROR, second.seq, &payload).unwrap())
+        .await
+        .unwrap();
+
+    let cleanup = read_guest_message(&mut guest).await;
+    assert_eq!(cleanup.msg_type, MSG_EXEC_START);
+    let decoded = vsock_proto::decode_exec_start(&cleanup.payload).unwrap();
+    assert_eq!(decoded.label, "exec-cleanup");
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Busy
+    );
+    send_exec_result(
+        &mut guest,
+        cleanup.seq,
+        ExecTermination::Exited { exit_code: 0 },
+        &[],
+        &[],
+    )
+    .await;
+
+    let err = write_task.await.unwrap().unwrap_err();
+    assert!(err.to_string().contains("guest write failed"));
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Idle
+    );
+}
+
+#[tokio::test]
+async fn write_file_chunked_rename_error_response_cleans_up_and_releases_tracker() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+
+    let chunk_limit = file_impl::test_support::WRITE_FILE_CHUNK_LIMIT;
+    let content = vec![0xABu8; chunk_limit + 100];
+    let write_task = {
+        let host = Arc::clone(&host);
+        tokio::spawn(async move { host.write_file("/tmp/big.bin", &content, false).await })
+    };
+
+    let first = read_guest_message(&mut guest).await;
+    assert_eq!(first.msg_type, MSG_WRITE_FILE);
+    let payload = vsock_proto::encode_write_file_result(true, "");
+    guest
+        .write_all(&vsock_proto::encode(MSG_WRITE_FILE_RESULT, first.seq, &payload).unwrap())
+        .await
+        .unwrap();
+
+    let second = read_guest_message(&mut guest).await;
+    assert_eq!(second.msg_type, MSG_WRITE_FILE);
+    let payload = vsock_proto::encode_write_file_result(true, "");
+    guest
+        .write_all(&vsock_proto::encode(MSG_WRITE_FILE_RESULT, second.seq, &payload).unwrap())
+        .await
+        .unwrap();
+
+    let rename = read_guest_message(&mut guest).await;
+    assert_eq!(rename.msg_type, MSG_EXEC_START);
+    let decoded = vsock_proto::decode_exec_start(&rename.payload).unwrap();
+    assert_eq!(decoded.label, "write-file-rename");
+    let payload = vsock_proto::encode_error("rename unavailable");
+    guest
+        .write_all(&vsock_proto::encode(MSG_ERROR, rename.seq, &payload).unwrap())
+        .await
+        .unwrap();
+
+    let cleanup = read_guest_message(&mut guest).await;
+    assert_eq!(cleanup.msg_type, MSG_EXEC_START);
+    let decoded = vsock_proto::decode_exec_start(&cleanup.payload).unwrap();
+    assert_eq!(decoded.label, "exec-cleanup");
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Busy
+    );
+    send_exec_result(
+        &mut guest,
+        cleanup.seq,
+        ExecTermination::Exited { exit_code: 0 },
+        &[],
+        &[],
+    )
+    .await;
+
+    let err = write_task.await.unwrap().unwrap_err();
+    assert!(err.to_string().contains("rename unavailable"));
     assert_eq!(
         normal_operation_readiness(&host),
         NormalOperationReadiness::Idle

--- a/crates/vsock-host/src/tests/file.rs
+++ b/crates/vsock-host/src/tests/file.rs
@@ -553,6 +553,75 @@ async fn copy_file_terminal_result_before_connection_close_keeps_tracker_closed_
 }
 
 #[tokio::test]
+async fn copy_file_rename_failure_removes_temp_and_releases_tracker() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+    let unique = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let dir = std::env::temp_dir().join(format!(
+        "vsock-host-copy-rename-failure-{}-{unique}",
+        std::process::id()
+    ));
+    std::fs::create_dir_all(&dir).unwrap();
+    let host_path = dir.join("system.log");
+    std::fs::create_dir_all(&host_path).unwrap();
+    let copy_path = host_path.clone();
+
+    let copy_task = {
+        let host = Arc::clone(&host);
+        tokio::spawn(async move {
+            host.copy_file(
+                "/tmp/vm0-system-run.log",
+                &copy_path,
+                CopyFileOptions {
+                    max_bytes: 1024,
+                    timeout_ms: 5000,
+                    missing_ok: false,
+                },
+            )
+            .await
+        })
+    };
+
+    let msg = read_guest_message(&mut guest).await;
+    assert_eq!(msg.msg_type, MSG_EXEC_START);
+    send_exec_output(
+        &mut guest,
+        msg.seq,
+        0,
+        ExecOutputStream::Stdout,
+        b"complete\n",
+        false,
+    )
+    .await;
+    send_stream_exec_result(
+        &mut guest,
+        msg.seq,
+        ExecTermination::Exited { exit_code: 0 },
+        b"",
+    )
+    .await;
+
+    copy_task.await.unwrap().unwrap_err();
+    assert!(host_path.is_dir());
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Idle
+    );
+    assert!(
+        std::fs::read_dir(&dir).unwrap().all(|entry| !entry
+            .unwrap()
+            .file_name()
+            .to_string_lossy()
+            .contains("vm0tmp")),
+        "failed copy temp file should be removed"
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[tokio::test]
 async fn copy_file_nonzero_exit_removes_temp_without_publishing_partial_output() {
     let (host, mut guest) = setup_host_and_guest().await;
     let unique = std::time::SystemTime::now()
@@ -1165,6 +1234,56 @@ async fn write_file_chunked_tracks_one_operation_until_rename_result() {
     assert_eq!(
         normal_operation_readiness(&host),
         NormalOperationReadiness::Idle
+    );
+}
+
+#[tokio::test]
+async fn write_file_chunked_rename_result_before_connection_close_keeps_tracker_closed_not_not_parkable()
+ {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+
+    let chunk_limit = file_impl::test_support::WRITE_FILE_CHUNK_LIMIT;
+    let content = vec![0xABu8; chunk_limit + 100];
+    let write_task = {
+        let host = Arc::clone(&host);
+        tokio::spawn(async move { host.write_file("/tmp/big.bin", &content, false).await })
+    };
+
+    let first = read_guest_message(&mut guest).await;
+    assert_eq!(first.msg_type, MSG_WRITE_FILE);
+    let payload = vsock_proto::encode_write_file_result(true, "");
+    guest
+        .write_all(&vsock_proto::encode(MSG_WRITE_FILE_RESULT, first.seq, &payload).unwrap())
+        .await
+        .unwrap();
+
+    let second = read_guest_message(&mut guest).await;
+    assert_eq!(second.msg_type, MSG_WRITE_FILE);
+    let payload = vsock_proto::encode_write_file_result(true, "");
+    guest
+        .write_all(&vsock_proto::encode(MSG_WRITE_FILE_RESULT, second.seq, &payload).unwrap())
+        .await
+        .unwrap();
+
+    let rename = read_guest_message(&mut guest).await;
+    assert_eq!(rename.msg_type, MSG_EXEC_START);
+    let decoded = vsock_proto::decode_exec_start(&rename.payload).unwrap();
+    assert_eq!(decoded.label, "write-file-rename");
+    send_exec_result(
+        &mut guest,
+        rename.seq,
+        ExecTermination::Exited { exit_code: 0 },
+        &[],
+        &[],
+    )
+    .await;
+    drop(guest);
+
+    write_task.await.unwrap().unwrap();
+    assert_ne!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::NotParkable
     );
 }
 

--- a/crates/vsock-host/src/tests/file.rs
+++ b/crates/vsock-host/src/tests/file.rs
@@ -1223,6 +1223,68 @@ async fn write_file_chunked_failure_remains_busy_until_cleanup_result() {
 }
 
 #[tokio::test]
+async fn write_file_chunked_cleanup_error_retries_untracked_on_drop() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+
+    let chunk_limit = file_impl::test_support::WRITE_FILE_CHUNK_LIMIT;
+    let content = vec![0xABu8; chunk_limit + 100];
+    let write_task = {
+        let host = Arc::clone(&host);
+        tokio::spawn(async move { host.write_file("/tmp/big.bin", &content, false).await })
+    };
+
+    let first = read_guest_message(&mut guest).await;
+    assert_eq!(first.msg_type, MSG_WRITE_FILE);
+    let payload = vsock_proto::encode_write_file_result(true, "");
+    guest
+        .write_all(&vsock_proto::encode(MSG_WRITE_FILE_RESULT, first.seq, &payload).unwrap())
+        .await
+        .unwrap();
+
+    let second = read_guest_message(&mut guest).await;
+    assert_eq!(second.msg_type, MSG_WRITE_FILE);
+    let payload = vsock_proto::encode_write_file_result(false, "disk full");
+    guest
+        .write_all(&vsock_proto::encode(MSG_WRITE_FILE_RESULT, second.seq, &payload).unwrap())
+        .await
+        .unwrap();
+
+    let cleanup = read_guest_message(&mut guest).await;
+    assert_eq!(cleanup.msg_type, MSG_EXEC_START);
+    let decoded = vsock_proto::decode_exec_start(&cleanup.payload).unwrap();
+    assert_eq!(decoded.label, "exec-cleanup");
+    let payload = vsock_proto::encode_error("cleanup unavailable");
+    guest
+        .write_all(&vsock_proto::encode(MSG_ERROR, cleanup.seq, &payload).unwrap())
+        .await
+        .unwrap();
+
+    let err = write_task.await.unwrap().unwrap_err();
+    assert!(err.to_string().contains("disk full"));
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::NotParkable
+    );
+
+    let retry = tokio::time::timeout(Duration::from_secs(2), read_guest_message(&mut guest))
+        .await
+        .expect("cleanup retry was not sent after cleanup error");
+    assert_eq!(retry.msg_type, MSG_EXEC_START);
+    let decoded = vsock_proto::decode_exec_start(&retry.payload).unwrap();
+    assert_eq!(decoded.label, "exec-cleanup");
+    assert!(decoded.command.contains("rm -f --"));
+    send_exec_result(
+        &mut guest,
+        retry.seq,
+        ExecTermination::Exited { exit_code: 0 },
+        &[],
+        &[],
+    )
+    .await;
+}
+
+#[tokio::test]
 async fn test_write_file_at_chunk_limit_uses_single_message() {
     let (host_stream, mut guest) = make_pair();
 


### PR DESCRIPTION
## Summary
- add a composite normal-operation scope for vsock file helpers
- route large write_file chunks, rename, and cleanup under one logical tracker token
- route copy_file stream/copy finalization under one logical tracker token without nested exec tracking
- extend vsock-host file tests for busy/idle and fail-closed cancellation behavior

Closes #13456

## Tests
- cargo fmt --manifest-path crates/Cargo.toml --check -p vsock-host
- cargo test --manifest-path crates/Cargo.toml -p vsock-host
- cargo clippy --manifest-path crates/Cargo.toml -p vsock-host --all-targets --all-features -- -D warnings
- pre-commit hook: cargo-fmt, cargo-clippy, cargo-doc