### PR TITLE
refactor: align process control timeout semantics

### DIFF
--- a/crates/vsock-guest/src/process_control.rs
+++ b/crates/vsock-guest/src/process_control.rs
@@ -1394,6 +1394,65 @@ mod tests {
     }
 
     #[test]
+    fn expired_connected_control_request_is_not_delivered() {
+        let sink = Arc::new(ControlSinkState::new());
+        let (stream, mut peer) = UnixStream::pair().unwrap();
+        peer.set_nonblocking(true).unwrap();
+        sink.connect(stream);
+        let stream = match &*sink.inner.lock().unwrap_or_else(|e| e.into_inner()) {
+            ControlSinkInner::Connected(connected) => Arc::clone(&connected.stream),
+            _ => panic!("sink should be connected"),
+        };
+        let stream_guard = stream.lock().unwrap_or_else(|e| e.into_inner());
+        let pending_slot = sink.reserve_pending_slot().unwrap();
+        let (guest, mut host) = UnixStream::pair().unwrap();
+        host.set_read_timeout(Some(Duration::from_secs(3))).unwrap();
+
+        let worker = std::thread::spawn({
+            let sink = Arc::clone(&sink);
+            move || {
+                forward_control_request(
+                    sink,
+                    pending_slot,
+                    OwnedProcessControlRequest {
+                        response_seq: 19,
+                        target_seq: 9,
+                        deadline: request_deadline(0),
+                        control_nonce: NONCE,
+                        message_id: "msg-expired-behind-lock".to_owned(),
+                        payload: b"payload".to_vec(),
+                    },
+                    GuestWriter::new(guest),
+                );
+            }
+        });
+
+        drop(stream_guard);
+        let (msg_type, seq, status, message_id, diagnostic) =
+            read_process_control_result(&mut host);
+        worker.join().unwrap();
+
+        assert_eq!(msg_type, MSG_PROCESS_CONTROL_RESULT);
+        assert_eq!(seq, 19);
+        assert_eq!(status, ProcessControlStatus::SinkTimeout);
+        assert_eq!(message_id, "msg-expired-behind-lock");
+        assert_eq!(diagnostic, REQUEST_TIMEOUT_DIAGNOSTIC);
+        assert_eq!(sink.pending.load(Ordering::Acquire), 0);
+        assert!(matches!(
+            *sink.inner.lock().unwrap_or_else(|e| e.into_inner()),
+            ControlSinkInner::Connected(_)
+        ));
+
+        let err = process_control_ipc::read_request(&mut peer).unwrap_err();
+        assert!(matches!(
+            err.kind(),
+            io::ErrorKind::WouldBlock
+                | io::ErrorKind::UnexpectedEof
+                | io::ErrorKind::ConnectionReset
+        ));
+    }
+
+    #[test]
     fn close_interrupts_inflight_control_request() {
         let sink = Arc::new(ControlSinkState::new());
         let (stream, mut peer) = UnixStream::pair().unwrap();

--- a/crates/vsock-guest/src/process_control.rs
+++ b/crates/vsock-guest/src/process_control.rs
@@ -73,6 +73,7 @@ struct ControlStreamGuard<'a> {
 
 enum ControlSinkInner {
     Waiting,
+    Handshaking(UnixStream),
     Connected(ConnectedControlSink),
     Failed(String),
     Closed,
@@ -295,14 +296,36 @@ impl ControlSinkState {
         self.ready.notify_all();
     }
 
+    fn begin_handshake(&self, stream: &UnixStream) -> io::Result<bool> {
+        let shutdown = stream.try_clone()?;
+        if !self.active.load(Ordering::Acquire) {
+            let _ = shutdown.shutdown(std::net::Shutdown::Both);
+            return Ok(false);
+        }
+
+        let mut guard = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        if !self.active.load(Ordering::Acquire) {
+            let _ = shutdown.shutdown(std::net::Shutdown::Both);
+            *guard = ControlSinkInner::Closed;
+            self.ready.notify_all();
+            return Ok(false);
+        }
+        if !matches!(*guard, ControlSinkInner::Waiting) {
+            let _ = shutdown.shutdown(std::net::Shutdown::Both);
+            return Ok(false);
+        }
+
+        *guard = ControlSinkInner::Handshaking(shutdown);
+        self.ready.notify_all();
+        Ok(true)
+    }
+
     fn fail(&self, message: String) {
         if !self.active.load(Ordering::Acquire) {
             return;
         }
         let mut guard = self.inner.lock().unwrap_or_else(|e| e.into_inner());
-        if let ControlSinkInner::Connected(connected) = &*guard {
-            connected.shutdown();
-        }
+        shutdown_sink_stream(&guard);
         {
             if !matches!(*guard, ControlSinkInner::Closed) {
                 *guard = ControlSinkInner::Failed(message);
@@ -314,9 +337,7 @@ impl ControlSinkState {
     fn close(&self) {
         self.active.store(false, Ordering::Release);
         let mut guard = self.inner.lock().unwrap_or_else(|e| e.into_inner());
-        if let ControlSinkInner::Connected(connected) = &*guard {
-            connected.shutdown();
-        }
+        shutdown_sink_stream(&guard);
         *guard = ControlSinkInner::Closed;
         self.ready.notify_all();
     }
@@ -335,7 +356,7 @@ impl ControlSinkState {
             }
             match &*guard {
                 ControlSinkInner::Connected(connected) => return Ok(Arc::clone(&connected.stream)),
-                ControlSinkInner::Waiting => {
+                ControlSinkInner::Waiting | ControlSinkInner::Handshaking(_) => {
                     let Some(wait) = duration_until(deadline) else {
                         return Err((
                             ProcessControlStatus::SinkTimeout,
@@ -410,6 +431,16 @@ impl ControlSinkState {
         }
 
         Ok(PendingControlSlot::new(Arc::clone(self)))
+    }
+}
+
+fn shutdown_sink_stream(inner: &ControlSinkInner) {
+    match inner {
+        ControlSinkInner::Handshaking(stream) => {
+            let _ = stream.shutdown(std::net::Shutdown::Both);
+        }
+        ControlSinkInner::Connected(connected) => connected.shutdown(),
+        ControlSinkInner::Waiting | ControlSinkInner::Failed(_) | ControlSinkInner::Closed => {}
     }
 }
 
@@ -492,6 +523,11 @@ fn accept_control_sink(listener: std::os::unix::net::UnixListener, sink: Arc<Con
         }
         match process_control_ipc::accept_with_timeout(&listener, CONTROL_ACCEPT_POLL_TIMEOUT) {
             Ok(mut stream) => {
+                match sink.begin_handshake(&stream) {
+                    Ok(true) => {}
+                    Ok(false) => return,
+                    Err(error) => break Err(error),
+                }
                 break stream
                     .set_read_timeout(Some(CONTROL_SINK_IO_TIMEOUT))
                     .and_then(|()| stream.set_write_timeout(Some(CONTROL_SINK_IO_TIMEOUT)))
@@ -1373,6 +1409,48 @@ mod tests {
         assert_eq!(status, ProcessControlStatus::SinkError);
         assert_eq!(message_id, "msg-handshake-failed");
         assert!(!diagnostic.is_empty());
+    }
+
+    #[test]
+    fn operation_release_interrupts_control_sink_handshake() {
+        const HANDSHAKE_NONCE: ProcessControlNonce = *b"dd33ee55ff77aa99";
+
+        let registry = ProcessControlRegistry::default();
+        let registration = registry.register(15, Some(HANDSHAKE_NONCE), true).unwrap();
+        let endpoint = registration.bootstrap_endpoint.clone().unwrap();
+        let sink = registry.resolve(15, HANDSHAKE_NONCE).unwrap();
+        let mut stream = process_control_ipc::connect_abstract(&endpoint).unwrap();
+
+        let mut guard = sink.inner.lock().unwrap_or_else(|e| e.into_inner());
+        let deadline = Instant::now() + Duration::from_secs(1);
+        while !matches!(&*guard, ControlSinkInner::Handshaking(_)) {
+            let now = Instant::now();
+            assert!(
+                now < deadline,
+                "control sink should enter handshaking after accept"
+            );
+            let (next_guard, _) = sink
+                .ready
+                .wait_timeout(guard, deadline.duration_since(now))
+                .unwrap_or_else(|e| e.into_inner());
+            guard = next_guard;
+        }
+        drop(guard);
+
+        registration.guard.release();
+
+        let guard = sink.inner.lock().unwrap_or_else(|e| e.into_inner());
+        assert!(matches!(*guard, ControlSinkInner::Closed));
+        drop(guard);
+
+        stream
+            .set_read_timeout(Some(Duration::from_millis(100)))
+            .unwrap();
+        let error = process_control_ipc::read_request(&mut stream).unwrap_err();
+        assert!(
+            !is_timeout(&error),
+            "operation release should interrupt the accepted handshake stream"
+        );
     }
 
     #[test]

--- a/crates/vsock-guest/src/process_control.rs
+++ b/crates/vsock-guest/src/process_control.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::io;
 use std::os::unix::net::UnixStream;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
-use std::sync::{Arc, Condvar, Mutex};
+use std::sync::{Arc, Condvar, Mutex, MutexGuard};
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -56,8 +56,19 @@ struct ControlSinkState {
 }
 
 struct ConnectedControlSink {
-    stream: Arc<Mutex<UnixStream>>,
+    stream: Arc<ControlStreamState>,
     shutdown: UnixStream,
+}
+
+struct ControlStreamState {
+    stream: Mutex<UnixStream>,
+    locked: Mutex<bool>,
+    ready: Condvar,
+}
+
+struct ControlStreamGuard<'a> {
+    state: &'a ControlStreamState,
+    stream: MutexGuard<'a, UnixStream>,
 }
 
 enum ControlSinkInner {
@@ -313,7 +324,7 @@ impl ControlSinkState {
     fn wait_for_stream(
         &self,
         deadline: Instant,
-    ) -> Result<Arc<Mutex<UnixStream>>, (ProcessControlStatus, String)> {
+    ) -> Result<Arc<ControlStreamState>, (ProcessControlStatus, String)> {
         let mut guard = self.inner.lock().unwrap_or_else(|e| e.into_inner());
         loop {
             if !self.active.load(Ordering::Acquire) {
@@ -406,13 +417,71 @@ impl ConnectedControlSink {
     fn new(stream: UnixStream) -> io::Result<Self> {
         let shutdown = stream.try_clone()?;
         Ok(Self {
-            stream: Arc::new(Mutex::new(stream)),
+            stream: Arc::new(ControlStreamState::new(stream)),
             shutdown,
         })
     }
 
     fn shutdown(&self) {
         let _ = self.shutdown.shutdown(std::net::Shutdown::Both);
+    }
+}
+
+impl ControlStreamState {
+    fn new(stream: UnixStream) -> Self {
+        Self {
+            stream: Mutex::new(stream),
+            locked: Mutex::new(false),
+            ready: Condvar::new(),
+        }
+    }
+
+    fn lock_until(&self, deadline: Instant) -> io::Result<ControlStreamGuard<'_>> {
+        let mut locked = self.locked.lock().unwrap_or_else(|e| e.into_inner());
+        loop {
+            if !*locked {
+                *locked = true;
+                drop(locked);
+                let stream = self.stream.lock().unwrap_or_else(|e| e.into_inner());
+                return Ok(ControlStreamGuard {
+                    state: self,
+                    stream,
+                });
+            }
+            let Some(wait) = duration_until(deadline) else {
+                return Err(request_timeout_error());
+            };
+            let (next_locked, wait_result) = self
+                .ready
+                .wait_timeout(locked, wait)
+                .unwrap_or_else(|e| e.into_inner());
+            locked = next_locked;
+            if wait_result.timed_out() {
+                return Err(request_timeout_error());
+            }
+        }
+    }
+}
+
+impl std::ops::Deref for ControlStreamGuard<'_> {
+    type Target = UnixStream;
+
+    fn deref(&self) -> &Self::Target {
+        &self.stream
+    }
+}
+
+impl std::ops::DerefMut for ControlStreamGuard<'_> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.stream
+    }
+}
+
+impl Drop for ControlStreamGuard<'_> {
+    fn drop(&mut self) {
+        let mut locked = self.state.locked.lock().unwrap_or_else(|e| e.into_inner());
+        *locked = false;
+        self.state.ready.notify_one();
     }
 }
 
@@ -464,24 +533,29 @@ fn forward_control_request(
     } = request;
     let (status, diagnostic, mark_failed) = {
         match sink.wait_for_stream(deadline) {
-            Ok(stream) => {
-                let mut stream = stream.lock().unwrap_or_else(|e| e.into_inner());
-                if !sink.active.load(Ordering::Acquire) {
-                    (
-                        ProcessControlStatus::Inactive,
-                        "process operation is not active".to_owned(),
-                        false,
-                    )
-                } else if request_expired(deadline) {
-                    (
-                        ProcessControlStatus::SinkTimeout,
-                        REQUEST_TIMEOUT_DIAGNOSTIC.to_owned(),
-                        false,
-                    )
-                } else {
-                    forward_to_connected_sink(&mut stream, &message_id, payload, deadline)
+            Ok(stream) => match stream.lock_until(deadline) {
+                Ok(mut stream) => {
+                    if !sink.active.load(Ordering::Acquire) {
+                        (
+                            ProcessControlStatus::Inactive,
+                            "process operation is not active".to_owned(),
+                            false,
+                        )
+                    } else if request_expired(deadline) {
+                        (
+                            ProcessControlStatus::SinkTimeout,
+                            REQUEST_TIMEOUT_DIAGNOSTIC.to_owned(),
+                            false,
+                        )
+                    } else {
+                        forward_to_connected_sink(&mut stream, &message_id, payload, deadline)
+                    }
                 }
-            }
+                Err(error) if is_timeout(&error) => {
+                    (ProcessControlStatus::SinkTimeout, error.to_string(), false)
+                }
+                Err(error) => (ProcessControlStatus::SinkError, error.to_string(), false),
+            },
             Err((status, diagnostic)) => (status, diagnostic, false),
         }
     };
@@ -604,7 +678,11 @@ fn control_sink_io_timeout(deadline: Instant) -> io::Result<Duration> {
     duration_until(deadline)
         .map(|remaining| remaining.min(CONTROL_SINK_IO_TIMEOUT))
         .filter(|timeout| !timeout.is_zero())
-        .ok_or_else(|| io::Error::new(io::ErrorKind::TimedOut, REQUEST_TIMEOUT_DIAGNOSTIC))
+        .ok_or_else(request_timeout_error)
+}
+
+fn request_timeout_error() -> io::Error {
+    io::Error::new(io::ErrorKind::TimedOut, REQUEST_TIMEOUT_DIAGNOSTIC)
 }
 
 fn write_control_request(
@@ -1289,7 +1367,7 @@ mod tests {
             ControlSinkInner::Connected(connected) => Arc::clone(&connected.stream),
             _ => panic!("sink should be connected"),
         };
-        let stream_guard = stream.lock().unwrap_or_else(|e| e.into_inner());
+        let stream_guard = stream.lock_until(request_deadline(5000)).unwrap();
         let (done_tx, done_rx) = std::sync::mpsc::channel();
 
         let worker = std::thread::spawn({
@@ -1321,7 +1399,7 @@ mod tests {
             ControlSinkInner::Connected(connected) => Arc::clone(&connected.stream),
             _ => panic!("sink should be connected"),
         };
-        let stream_guard = stream.lock().unwrap_or_else(|e| e.into_inner());
+        let stream_guard = stream.lock_until(request_deadline(5000)).unwrap();
         let (done_tx, done_rx) = std::sync::mpsc::channel();
 
         let worker = std::thread::spawn({
@@ -1354,7 +1432,7 @@ mod tests {
             ControlSinkInner::Connected(connected) => Arc::clone(&connected.stream),
             _ => panic!("sink should be connected"),
         };
-        let stream_guard = stream.lock().unwrap_or_else(|e| e.into_inner());
+        let stream_guard = stream.lock_until(request_deadline(5000)).unwrap();
         let (guest, mut host) = UnixStream::pair().unwrap();
         host.set_read_timeout(Some(Duration::from_secs(3))).unwrap();
 
@@ -1403,7 +1481,7 @@ mod tests {
             ControlSinkInner::Connected(connected) => Arc::clone(&connected.stream),
             _ => panic!("sink should be connected"),
         };
-        let stream_guard = stream.lock().unwrap_or_else(|e| e.into_inner());
+        let stream_guard = stream.lock_until(request_deadline(5000)).unwrap();
         let pending_slot = sink.reserve_pending_slot().unwrap();
         let (guest, mut host) = UnixStream::pair().unwrap();
         host.set_read_timeout(Some(Duration::from_secs(3))).unwrap();
@@ -1427,7 +1505,6 @@ mod tests {
             }
         });
 
-        drop(stream_guard);
         let (msg_type, seq, status, message_id, diagnostic) =
             read_process_control_result(&mut host);
         worker.join().unwrap();
@@ -1450,6 +1527,7 @@ mod tests {
                 | io::ErrorKind::UnexpectedEof
                 | io::ErrorKind::ConnectionReset
         ));
+        drop(stream_guard);
     }
 
     #[test]

--- a/crates/vsock-guest/src/process_control.rs
+++ b/crates/vsock-guest/src/process_control.rs
@@ -70,7 +70,7 @@ enum ControlSinkInner {
 struct OwnedProcessControlRequest {
     response_seq: u32,
     target_seq: u32,
-    request_timeout_ms: u32,
+    deadline: Instant,
     control_nonce: ProcessControlNonce,
     message_id: String,
     payload: Vec<u8>,
@@ -327,8 +327,8 @@ impl ControlSinkState {
                 ControlSinkInner::Waiting => {
                     let Some(wait) = duration_until(deadline) else {
                         return Err((
-                            ProcessControlStatus::SinkUnavailable,
-                            "process control sink is not connected".to_owned(),
+                            ProcessControlStatus::SinkTimeout,
+                            REQUEST_TIMEOUT_DIAGNOSTIC.to_owned(),
                         ));
                     };
                     let (next_guard, wait_result) = self
@@ -338,8 +338,8 @@ impl ControlSinkState {
                     guard = next_guard;
                     if wait_result.timed_out() {
                         return Err((
-                            ProcessControlStatus::SinkUnavailable,
-                            "process control sink is not connected".to_owned(),
+                            ProcessControlStatus::SinkTimeout,
+                            REQUEST_TIMEOUT_DIAGNOSTIC.to_owned(),
                         ));
                     }
                 }
@@ -457,12 +457,11 @@ fn forward_control_request(
     let OwnedProcessControlRequest {
         response_seq,
         target_seq,
-        request_timeout_ms,
+        deadline,
         control_nonce,
         message_id,
         payload,
     } = request;
-    let deadline = request_deadline(request_timeout_ms);
     let (status, diagnostic, mark_failed) = {
         match sink.wait_for_stream(deadline) {
             Ok(stream) => {
@@ -642,7 +641,7 @@ pub(crate) fn handle_process_control(
     let owned = OwnedProcessControlRequest {
         response_seq: seq,
         target_seq: request.target_seq,
-        request_timeout_ms: request.request_timeout_ms,
+        deadline: request_deadline(request.request_timeout_ms),
         control_nonce: request.control_nonce,
         message_id: request.message_id.to_owned(),
         payload: request.payload.to_vec(),
@@ -890,30 +889,33 @@ mod tests {
 
     #[test]
     fn pending_process_control_timeout_before_sink_connection_releases_slot() {
-        const FORWARD_NONCE: ProcessControlNonce = *b"4433221100ffeedd";
-
-        let registry = ProcessControlRegistry::default();
-        let registration = registry.register(19, Some(FORWARD_NONCE), true).unwrap();
-        let sink = registry.resolve(19, FORWARD_NONCE).unwrap();
+        let sink = Arc::new(ControlSinkState::new());
+        let pending_slot = sink.reserve_pending_slot().unwrap();
         let (guest, mut host) = UnixStream::pair().unwrap();
         host.set_read_timeout(Some(Duration::from_secs(3))).unwrap();
-        let writer = GuestWriter::new(guest);
-        let payload =
-            vsock_proto::encode_process_control(19, FORWARD_NONCE, "msg-timeout", b"payload", 0)
-                .unwrap();
 
-        handle_process_control(29, &payload, &registry, &writer).unwrap();
+        forward_control_request(
+            Arc::clone(&sink),
+            pending_slot,
+            OwnedProcessControlRequest {
+                response_seq: 29,
+                target_seq: 19,
+                deadline: request_deadline(0),
+                control_nonce: NONCE,
+                message_id: "msg-timeout".to_owned(),
+                payload: b"payload".to_vec(),
+            },
+            GuestWriter::new(guest),
+        );
 
         let (msg_type, seq, status, message_id, diagnostic) =
             read_process_control_result(&mut host);
         assert_eq!(msg_type, MSG_PROCESS_CONTROL_RESULT);
         assert_eq!(seq, 29);
-        assert_eq!(status, ProcessControlStatus::SinkUnavailable);
+        assert_eq!(status, ProcessControlStatus::SinkTimeout);
         assert_eq!(message_id, "msg-timeout");
-        assert_eq!(diagnostic, "process control sink is not connected");
+        assert_eq!(diagnostic, REQUEST_TIMEOUT_DIAGNOSTIC);
         assert_eq!(sink.pending.load(Ordering::Acquire), 0);
-
-        registration.guard.release();
     }
 
     #[test]
@@ -1056,7 +1058,7 @@ mod tests {
                 OwnedProcessControlRequest {
                     response_seq: 199,
                     target_seq: 12,
-                    request_timeout_ms: 5000,
+                    deadline: request_deadline(5000),
                     control_nonce: NONCE,
                     message_id: "msg-overflow".to_owned(),
                     payload: b"payload".to_vec(),
@@ -1116,7 +1118,7 @@ mod tests {
             OwnedProcessControlRequest {
                 response_seq: 12,
                 target_seq: 8,
-                request_timeout_ms: 5000,
+                deadline: request_deadline(5000),
                 control_nonce: NONCE,
                 message_id: "msg-send-fails".to_owned(),
                 payload: b"payload".to_vec(),
@@ -1158,7 +1160,7 @@ mod tests {
             OwnedProcessControlRequest {
                 response_seq: 12,
                 target_seq: 8,
-                request_timeout_ms: 5000,
+                deadline: request_deadline(5000),
                 control_nonce: NONCE,
                 message_id: "msg-original".to_owned(),
                 payload: b"payload".to_vec(),
@@ -1205,7 +1207,7 @@ mod tests {
             OwnedProcessControlRequest {
                 response_seq: 12,
                 target_seq: 8,
-                request_timeout_ms: 1,
+                deadline: request_deadline(1),
                 control_nonce: NONCE,
                 message_id: "msg-timeout".to_owned(),
                 payload: b"payload".to_vec(),
@@ -1361,7 +1363,7 @@ mod tests {
                 OwnedProcessControlRequest {
                     response_seq: 17,
                     target_seq: 9,
-                    request_timeout_ms: 5000,
+                    deadline: request_deadline(5000),
                     control_nonce: NONCE,
                     message_id: "msg-after-close".to_owned(),
                     payload: b"payload".to_vec(),
@@ -1417,7 +1419,7 @@ mod tests {
                     OwnedProcessControlRequest {
                         response_seq: 18,
                         target_seq: 9,
-                        request_timeout_ms: 5000,
+                        deadline: request_deadline(5000),
                         control_nonce: NONCE,
                         message_id: "msg-inflight-close".to_owned(),
                         payload: b"payload".to_vec(),

--- a/crates/vsock-guest/src/process_control.rs
+++ b/crates/vsock-guest/src/process_control.rs
@@ -15,9 +15,10 @@ use crate::writer::GuestWriter;
 
 const THREAD_PROCESS_CONTROL_ACCEPT: &str = "vsock-process-control-accept";
 const THREAD_PROCESS_CONTROL_FORWARD: &str = "vsock-process-control-forward";
-const CONTROL_ACCEPT_TIMEOUT: Duration = Duration::from_secs(30);
-const CONTROL_IO_TIMEOUT: Duration = Duration::from_secs(5);
+const CONTROL_ACCEPT_POLL_TIMEOUT: Duration = Duration::from_millis(100);
+const CONTROL_SINK_IO_TIMEOUT: Duration = Duration::from_secs(5);
 const MAX_PENDING_CONTROL_REQUESTS: usize = 8;
+const REQUEST_TIMEOUT_DIAGNOSTIC: &str = "process control request timed out";
 
 #[derive(Clone, Default)]
 pub(crate) struct ProcessControlRegistry {
@@ -69,6 +70,7 @@ enum ControlSinkInner {
 struct OwnedProcessControlRequest {
     response_seq: u32,
     target_seq: u32,
+    request_timeout_ms: u32,
     control_nonce: ProcessControlNonce,
     message_id: String,
     payload: Vec<u8>,
@@ -310,11 +312,8 @@ impl ControlSinkState {
 
     fn wait_for_stream(
         &self,
-        timeout: Duration,
+        deadline: Instant,
     ) -> Result<Arc<Mutex<UnixStream>>, (ProcessControlStatus, String)> {
-        let deadline = Instant::now()
-            .checked_add(timeout)
-            .unwrap_or_else(Instant::now);
         let mut guard = self.inner.lock().unwrap_or_else(|e| e.into_inner());
         loop {
             if !self.active.load(Ordering::Acquire) {
@@ -326,14 +325,12 @@ impl ControlSinkState {
             match &*guard {
                 ControlSinkInner::Connected(connected) => return Ok(Arc::clone(&connected.stream)),
                 ControlSinkInner::Waiting => {
-                    let now = Instant::now();
-                    if now >= deadline {
+                    let Some(wait) = duration_until(deadline) else {
                         return Err((
                             ProcessControlStatus::SinkUnavailable,
                             "process control sink is not connected".to_owned(),
                         ));
-                    }
-                    let wait = deadline.duration_since(now);
+                    };
                     let (next_guard, wait_result) = self
                         .ready
                         .wait_timeout(guard, wait)
@@ -420,26 +417,15 @@ impl ConnectedControlSink {
 }
 
 fn accept_control_sink(listener: std::os::unix::net::UnixListener, sink: Arc<ControlSinkState>) {
-    let deadline = Instant::now()
-        .checked_add(CONTROL_ACCEPT_TIMEOUT)
-        .unwrap_or_else(Instant::now);
     let result = loop {
         if !sink.active.load(Ordering::Acquire) {
             return;
         }
-        let now = Instant::now();
-        if now >= deadline {
-            break Err(io::Error::new(
-                io::ErrorKind::TimedOut,
-                "control endpoint accept timed out",
-            ));
-        }
-        let poll_timeout = deadline.duration_since(now).min(Duration::from_millis(100));
-        match process_control_ipc::accept_with_timeout(&listener, poll_timeout) {
+        match process_control_ipc::accept_with_timeout(&listener, CONTROL_ACCEPT_POLL_TIMEOUT) {
             Ok(mut stream) => {
                 break stream
-                    .set_read_timeout(Some(CONTROL_IO_TIMEOUT))
-                    .and_then(|()| stream.set_write_timeout(Some(CONTROL_IO_TIMEOUT)))
+                    .set_read_timeout(Some(CONTROL_SINK_IO_TIMEOUT))
+                    .and_then(|()| stream.set_write_timeout(Some(CONTROL_SINK_IO_TIMEOUT)))
                     .and_then(|()| process_control_ipc::read_hello(&mut stream))
                     .map(|()| stream);
             }
@@ -471,12 +457,14 @@ fn forward_control_request(
     let OwnedProcessControlRequest {
         response_seq,
         target_seq,
+        request_timeout_ms,
         control_nonce,
         message_id,
         payload,
     } = request;
+    let deadline = request_deadline(request_timeout_ms);
     let (status, diagnostic, mark_failed) = {
-        match sink.wait_for_stream(CONTROL_IO_TIMEOUT) {
+        match sink.wait_for_stream(deadline) {
             Ok(stream) => {
                 let mut stream = stream.lock().unwrap_or_else(|e| e.into_inner());
                 if !sink.active.load(Ordering::Acquire) {
@@ -485,38 +473,14 @@ fn forward_control_request(
                         "process operation is not active".to_owned(),
                         false,
                     )
+                } else if request_expired(deadline) {
+                    (
+                        ProcessControlStatus::SinkTimeout,
+                        REQUEST_TIMEOUT_DIAGNOSTIC.to_owned(),
+                        false,
+                    )
                 } else {
-                    let request_frame = ControlRequest {
-                        message_id: message_id.clone(),
-                        payload,
-                    };
-                    match process_control_ipc::write_request(&mut stream, &request_frame)
-                        .and_then(|()| process_control_ipc::read_response(&mut stream))
-                    {
-                        Ok(response) if response.message_id != message_id => (
-                            ProcessControlStatus::SinkError,
-                            format!(
-                                "process control sink message id mismatch: expected {}, got {}",
-                                message_id, response.message_id
-                            ),
-                            true,
-                        ),
-                        Ok(response) => match response.status {
-                            ControlResponseStatus::Accepted => {
-                                (ProcessControlStatus::Delivered, response.diagnostic, false)
-                            }
-                            ControlResponseStatus::Rejected => {
-                                (ProcessControlStatus::Rejected, response.diagnostic, false)
-                            }
-                            ControlResponseStatus::Error => {
-                                (ProcessControlStatus::SinkError, response.diagnostic, false)
-                            }
-                        },
-                        Err(error) if is_timeout(&error) => {
-                            (ProcessControlStatus::SinkTimeout, error.to_string(), true)
-                        }
-                        Err(error) => (ProcessControlStatus::SinkError, error.to_string(), true),
-                    }
+                    forward_to_connected_sink(&mut stream, &message_id, payload, deadline)
                 }
             }
             Err((status, diagnostic)) => (status, diagnostic, false),
@@ -555,6 +519,112 @@ fn forward_control_request(
     }
 }
 
+fn forward_to_connected_sink(
+    stream: &mut UnixStream,
+    message_id: &str,
+    payload: Vec<u8>,
+    deadline: Instant,
+) -> (ProcessControlStatus, String, bool) {
+    let request_frame = ControlRequest {
+        message_id: message_id.to_owned(),
+        payload,
+    };
+    let write_timeout = match control_sink_io_timeout(deadline) {
+        Ok(timeout) => timeout,
+        Err(error) if is_timeout(&error) => {
+            return return_control_result(ProcessControlStatus::SinkTimeout, error, false);
+        }
+        Err(error) => return return_control_result(ProcessControlStatus::SinkError, error, false),
+    };
+    if let Err(error) = write_control_request(stream, &request_frame, write_timeout) {
+        return if is_timeout(&error) {
+            return_control_result(ProcessControlStatus::SinkTimeout, error, true)
+        } else {
+            return_control_result(ProcessControlStatus::SinkError, error, true)
+        };
+    }
+
+    let read_timeout = match control_sink_io_timeout(deadline) {
+        Ok(timeout) => timeout,
+        Err(error) if is_timeout(&error) => {
+            return return_control_result(ProcessControlStatus::SinkTimeout, error, true);
+        }
+        Err(error) => return return_control_result(ProcessControlStatus::SinkError, error, true),
+    };
+    match read_control_response(stream, read_timeout) {
+        Ok(response) if response.message_id != message_id => (
+            ProcessControlStatus::SinkError,
+            format!(
+                "process control sink message id mismatch: expected {}, got {}",
+                message_id, response.message_id
+            ),
+            true,
+        ),
+        Ok(response) => match response.status {
+            ControlResponseStatus::Accepted => {
+                (ProcessControlStatus::Delivered, response.diagnostic, false)
+            }
+            ControlResponseStatus::Rejected => {
+                (ProcessControlStatus::Rejected, response.diagnostic, false)
+            }
+            ControlResponseStatus::Error => {
+                (ProcessControlStatus::SinkError, response.diagnostic, false)
+            }
+        },
+        Err(error) if is_timeout(&error) => {
+            (ProcessControlStatus::SinkTimeout, error.to_string(), true)
+        }
+        Err(error) => (ProcessControlStatus::SinkError, error.to_string(), true),
+    }
+}
+
+fn return_control_result(
+    status: ProcessControlStatus,
+    error: io::Error,
+    mark_failed: bool,
+) -> (ProcessControlStatus, String, bool) {
+    (status, error.to_string(), mark_failed)
+}
+
+fn request_deadline(request_timeout_ms: u32) -> Instant {
+    Instant::now()
+        .checked_add(Duration::from_millis(u64::from(request_timeout_ms)))
+        .unwrap_or_else(Instant::now)
+}
+
+fn request_expired(deadline: Instant) -> bool {
+    duration_until(deadline).is_none()
+}
+
+fn duration_until(deadline: Instant) -> Option<Duration> {
+    let now = Instant::now();
+    (now < deadline).then(|| deadline.duration_since(now))
+}
+
+fn control_sink_io_timeout(deadline: Instant) -> io::Result<Duration> {
+    duration_until(deadline)
+        .map(|remaining| remaining.min(CONTROL_SINK_IO_TIMEOUT))
+        .filter(|timeout| !timeout.is_zero())
+        .ok_or_else(|| io::Error::new(io::ErrorKind::TimedOut, REQUEST_TIMEOUT_DIAGNOSTIC))
+}
+
+fn write_control_request(
+    stream: &mut UnixStream,
+    request: &ControlRequest,
+    timeout: Duration,
+) -> io::Result<()> {
+    stream.set_write_timeout(Some(timeout))?;
+    process_control_ipc::write_request(stream, request)
+}
+
+fn read_control_response(
+    stream: &mut UnixStream,
+    timeout: Duration,
+) -> io::Result<process_control_ipc::ControlResponse> {
+    stream.set_read_timeout(Some(timeout))?;
+    process_control_ipc::read_response(stream)
+}
+
 fn is_timeout(error: &io::Error) -> bool {
     matches!(
         error.kind(),
@@ -572,6 +642,7 @@ pub(crate) fn handle_process_control(
     let owned = OwnedProcessControlRequest {
         response_seq: seq,
         target_seq: request.target_seq,
+        request_timeout_ms: request.request_timeout_ms,
         control_nonce: request.control_nonce,
         message_id: request.message_id.to_owned(),
         payload: request.payload.to_vec(),
@@ -765,7 +836,8 @@ mod tests {
         host.set_read_timeout(Some(Duration::from_secs(3))).unwrap();
         let writer = GuestWriter::new(guest);
         let payload =
-            vsock_proto::encode_process_control(8, FORWARD_NONCE, "msg-1", b"payload").unwrap();
+            vsock_proto::encode_process_control(8, FORWARD_NONCE, "msg-1", b"payload", 5000)
+                .unwrap();
 
         handle_process_control(11, &payload, &registry, &writer).unwrap();
 
@@ -789,7 +861,8 @@ mod tests {
         host.set_read_timeout(Some(Duration::from_secs(3))).unwrap();
         let writer = GuestWriter::new(guest);
         let payload =
-            vsock_proto::encode_process_control(9, FORWARD_NONCE, "msg-1", b"payload").unwrap();
+            vsock_proto::encode_process_control(9, FORWARD_NONCE, "msg-1", b"payload", 5000)
+                .unwrap();
 
         handle_process_control(11, &payload, &registry, &writer).unwrap();
 
@@ -813,6 +886,34 @@ mod tests {
         assert_eq!(seq, 11);
         assert_eq!(status, ProcessControlStatus::Delivered);
         assert_eq!(message_id, "msg-1");
+    }
+
+    #[test]
+    fn pending_process_control_timeout_before_sink_connection_releases_slot() {
+        const FORWARD_NONCE: ProcessControlNonce = *b"4433221100ffeedd";
+
+        let registry = ProcessControlRegistry::default();
+        let registration = registry.register(19, Some(FORWARD_NONCE), true).unwrap();
+        let sink = registry.resolve(19, FORWARD_NONCE).unwrap();
+        let (guest, mut host) = UnixStream::pair().unwrap();
+        host.set_read_timeout(Some(Duration::from_secs(3))).unwrap();
+        let writer = GuestWriter::new(guest);
+        let payload =
+            vsock_proto::encode_process_control(19, FORWARD_NONCE, "msg-timeout", b"payload", 0)
+                .unwrap();
+
+        handle_process_control(29, &payload, &registry, &writer).unwrap();
+
+        let (msg_type, seq, status, message_id, diagnostic) =
+            read_process_control_result(&mut host);
+        assert_eq!(msg_type, MSG_PROCESS_CONTROL_RESULT);
+        assert_eq!(seq, 29);
+        assert_eq!(status, ProcessControlStatus::SinkUnavailable);
+        assert_eq!(message_id, "msg-timeout");
+        assert_eq!(diagnostic, "process control sink is not connected");
+        assert_eq!(sink.pending.load(Ordering::Acquire), 0);
+
+        registration.guard.release();
     }
 
     #[test]
@@ -867,9 +968,14 @@ mod tests {
         host.set_read_timeout(Some(Duration::from_secs(3))).unwrap();
         let writer = GuestWriter::new(guest);
 
-        let payload =
-            vsock_proto::encode_process_control(11, FORWARD_NONCE, "msg-rejected", b"payload")
-                .unwrap();
+        let payload = vsock_proto::encode_process_control(
+            11,
+            FORWARD_NONCE,
+            "msg-rejected",
+            b"payload",
+            5000,
+        )
+        .unwrap();
         handle_process_control(21, &payload, &registry, &writer).unwrap();
         let (_, seq, status, message_id, diagnostic) = read_process_control_result(&mut host);
         assert_eq!(seq, 21);
@@ -878,7 +984,7 @@ mod tests {
         assert_eq!(diagnostic, "denied");
 
         let payload =
-            vsock_proto::encode_process_control(11, FORWARD_NONCE, "msg-error", b"payload")
+            vsock_proto::encode_process_control(11, FORWARD_NONCE, "msg-error", b"payload", 5000)
                 .unwrap();
         handle_process_control(22, &payload, &registry, &writer).unwrap();
         let (_, seq, status, message_id, diagnostic) = read_process_control_result(&mut host);
@@ -887,9 +993,14 @@ mod tests {
         assert_eq!(message_id, "msg-error");
         assert_eq!(diagnostic, "temporary error");
 
-        let payload =
-            vsock_proto::encode_process_control(11, FORWARD_NONCE, "msg-after-error", b"payload")
-                .unwrap();
+        let payload = vsock_proto::encode_process_control(
+            11,
+            FORWARD_NONCE,
+            "msg-after-error",
+            b"payload",
+            5000,
+        )
+        .unwrap();
         handle_process_control(23, &payload, &registry, &writer).unwrap();
         let (_, seq, status, message_id, diagnostic) = read_process_control_result(&mut host);
         assert_eq!(seq, 23);
@@ -910,7 +1021,7 @@ mod tests {
         host.set_read_timeout(Some(Duration::from_secs(3))).unwrap();
         let writer = GuestWriter::new(guest);
         let payload =
-            vsock_proto::encode_process_control(10, FORWARD_NONCE, "msg-release", b"payload")
+            vsock_proto::encode_process_control(10, FORWARD_NONCE, "msg-release", b"payload", 5000)
                 .unwrap();
 
         handle_process_control(13, &payload, &registry, &writer).unwrap();
@@ -945,6 +1056,7 @@ mod tests {
                 OwnedProcessControlRequest {
                     response_seq: 199,
                     target_seq: 12,
+                    request_timeout_ms: 5000,
                     control_nonce: NONCE,
                     message_id: "msg-overflow".to_owned(),
                     payload: b"payload".to_vec(),
@@ -1004,6 +1116,7 @@ mod tests {
             OwnedProcessControlRequest {
                 response_seq: 12,
                 target_seq: 8,
+                request_timeout_ms: 5000,
                 control_nonce: NONCE,
                 message_id: "msg-send-fails".to_owned(),
                 payload: b"payload".to_vec(),
@@ -1045,6 +1158,7 @@ mod tests {
             OwnedProcessControlRequest {
                 response_seq: 12,
                 target_seq: 8,
+                request_timeout_ms: 5000,
                 control_nonce: NONCE,
                 message_id: "msg-original".to_owned(),
                 payload: b"payload".to_vec(),
@@ -1091,6 +1205,7 @@ mod tests {
             OwnedProcessControlRequest {
                 response_seq: 12,
                 target_seq: 8,
+                request_timeout_ms: 1,
                 control_nonce: NONCE,
                 message_id: "msg-timeout".to_owned(),
                 payload: b"payload".to_vec(),
@@ -1148,6 +1263,7 @@ mod tests {
             FORWARD_NONCE,
             "msg-handshake-failed",
             b"payload",
+            5000,
         )
         .unwrap();
 
@@ -1245,6 +1361,7 @@ mod tests {
                 OwnedProcessControlRequest {
                     response_seq: 17,
                     target_seq: 9,
+                    request_timeout_ms: 5000,
                     control_nonce: NONCE,
                     message_id: "msg-after-close".to_owned(),
                     payload: b"payload".to_vec(),
@@ -1300,6 +1417,7 @@ mod tests {
                     OwnedProcessControlRequest {
                         response_seq: 18,
                         target_seq: 9,
+                        request_timeout_ms: 5000,
                         control_nonce: NONCE,
                         message_id: "msg-inflight-close".to_owned(),
                         payload: b"payload".to_vec(),

--- a/crates/vsock-guest/src/process_control.rs
+++ b/crates/vsock-guest/src/process_control.rs
@@ -1033,6 +1033,71 @@ mod tests {
     }
 
     #[test]
+    fn timeout_before_sink_connection_does_not_poison_later_delivery() {
+        const FORWARD_NONCE: ProcessControlNonce = *b"77889900aabbccdd";
+
+        let registry = ProcessControlRegistry::default();
+        let registration = registry.register(16, Some(FORWARD_NONCE), true).unwrap();
+        let endpoint = registration.bootstrap_endpoint.clone().unwrap();
+        let (guest, mut host) = UnixStream::pair().unwrap();
+        host.set_read_timeout(Some(Duration::from_secs(3))).unwrap();
+        let writer = GuestWriter::new(guest);
+        let payload = vsock_proto::encode_process_control(
+            16,
+            FORWARD_NONCE,
+            "msg-before-connect",
+            b"payload",
+            0,
+        )
+        .unwrap();
+
+        handle_process_control(41, &payload, &registry, &writer).unwrap();
+        let (msg_type, seq, status, message_id, diagnostic) =
+            read_process_control_result(&mut host);
+        assert_eq!(msg_type, MSG_PROCESS_CONTROL_RESULT);
+        assert_eq!(seq, 41);
+        assert_eq!(status, ProcessControlStatus::SinkTimeout);
+        assert_eq!(message_id, "msg-before-connect");
+        assert_eq!(diagnostic, REQUEST_TIMEOUT_DIAGNOSTIC);
+
+        let client = std::thread::spawn(move || {
+            let mut stream = process_control_ipc::connect_abstract(&endpoint).unwrap();
+            process_control_ipc::write_hello(&mut stream).unwrap();
+            let request = process_control_ipc::read_request(&mut stream).unwrap();
+            assert_eq!(request.message_id, "msg-after-timeout");
+            assert_eq!(request.payload, b"payload");
+            process_control_ipc::write_response(
+                &mut stream,
+                &process_control_ipc::ControlResponse {
+                    message_id: request.message_id,
+                    status: process_control_ipc::ControlResponseStatus::Accepted,
+                    diagnostic: String::new(),
+                },
+            )
+            .unwrap();
+        });
+
+        let payload = vsock_proto::encode_process_control(
+            16,
+            FORWARD_NONCE,
+            "msg-after-timeout",
+            b"payload",
+            5000,
+        )
+        .unwrap();
+        handle_process_control(42, &payload, &registry, &writer).unwrap();
+        let (msg_type, seq, status, message_id, diagnostic) =
+            read_process_control_result(&mut host);
+        assert_eq!(msg_type, MSG_PROCESS_CONTROL_RESULT);
+        assert_eq!(seq, 42);
+        assert_eq!(status, ProcessControlStatus::Delivered);
+        assert_eq!(message_id, "msg-after-timeout");
+        assert_eq!(diagnostic, "");
+
+        client.join().unwrap();
+    }
+
+    #[test]
     fn non_terminal_control_responses_do_not_close_sink() {
         const FORWARD_NONCE: ProcessControlNonce = *b"aa22cc44ee66ff88";
 

--- a/crates/vsock-guest/src/process_control.rs
+++ b/crates/vsock-guest/src/process_control.rs
@@ -1267,34 +1267,51 @@ mod tests {
     #[test]
     fn timed_out_control_sink_is_marked_failed() {
         let sink = Arc::new(ControlSinkState::new());
-        let (stream, _peer) = UnixStream::pair().unwrap();
-        stream
-            .set_read_timeout(Some(Duration::from_millis(1)))
-            .unwrap();
-        stream
-            .set_write_timeout(Some(Duration::from_secs(1)))
-            .unwrap();
+        let (stream, peer) = UnixStream::pair().unwrap();
         sink.connect(stream);
         let pending_slot = sink.reserve_pending_slot().unwrap();
+        let (request_read_tx, request_read_rx) = std::sync::mpsc::channel();
+        let (release_peer_tx, release_peer_rx) = std::sync::mpsc::channel();
+        let client = std::thread::spawn(move || {
+            let mut peer = peer;
+            let request = process_control_ipc::read_request(&mut peer).unwrap();
+            assert_eq!(request.message_id, "msg-timeout");
+            assert_eq!(request.payload, b"payload");
+            request_read_tx.send(()).unwrap();
+            let _ = release_peer_rx.recv_timeout(Duration::from_secs(3));
+        });
 
         let (guest, mut host) = UnixStream::pair().unwrap();
         host.set_read_timeout(Some(Duration::from_secs(3))).unwrap();
-        forward_control_request(
-            Arc::clone(&sink),
-            pending_slot,
-            OwnedProcessControlRequest {
-                response_seq: 12,
-                target_seq: 8,
-                deadline: request_deadline(1),
-                control_nonce: NONCE,
-                message_id: "msg-timeout".to_owned(),
-                payload: b"payload".to_vec(),
-            },
-            GuestWriter::new(guest),
-        );
+        let worker = std::thread::spawn({
+            let sink = Arc::clone(&sink);
+            move || {
+                forward_control_request(
+                    sink,
+                    pending_slot,
+                    OwnedProcessControlRequest {
+                        response_seq: 12,
+                        target_seq: 8,
+                        deadline: request_deadline(250),
+                        control_nonce: NONCE,
+                        message_id: "msg-timeout".to_owned(),
+                        payload: b"payload".to_vec(),
+                    },
+                    GuestWriter::new(guest),
+                );
+            }
+        });
+
+        request_read_rx
+            .recv_timeout(Duration::from_secs(3))
+            .expect("control request should be delivered before response timeout");
 
         let (msg_type, seq, status, message_id, diagnostic) =
             read_process_control_result(&mut host);
+        worker.join().unwrap();
+        let _ = release_peer_tx.send(());
+        client.join().unwrap();
+
         assert_eq!(msg_type, MSG_PROCESS_CONTROL_RESULT);
         assert_eq!(seq, 12);
         assert_eq!(status, ProcessControlStatus::SinkTimeout);

--- a/crates/vsock-guest/src/wait.rs
+++ b/crates/vsock-guest/src/wait.rs
@@ -399,28 +399,45 @@ mod tests {
 
     #[test]
     fn fast_exit_wait_does_not_pay_cancel_poll_interval_per_child() {
-        let iterations = 20;
-        let start = Instant::now();
+        let iterations = 20u32;
+        let mut baseline_total = Duration::default();
+        let mut timed_total = Duration::default();
 
-        for _ in 0..iterations {
+        fn wait_for_fast_child(timeout_ms: u32) -> Duration {
             let child = Command::new("sleep")
                 .arg("0.02")
                 .stdout(Stdio::null())
                 .stderr(Stdio::null())
                 .spawn()
                 .unwrap();
-            let outcome = wait_with_kill_timeout(child, 30_000);
+            let start = Instant::now();
+            let outcome = wait_with_kill_timeout(child, timeout_ms);
+            let elapsed = start.elapsed();
             assert!(
                 matches!(outcome, WaitOutcome::Exited(status) if status.success()),
                 "unexpected wait outcome"
             );
+            elapsed
         }
 
-        let elapsed = start.elapsed();
+        for i in 0..iterations {
+            if i % 2 == 0 {
+                baseline_total += wait_for_fast_child(0);
+                timed_total += wait_for_fast_child(30_000);
+            } else {
+                timed_total += wait_for_fast_child(30_000);
+                baseline_total += wait_for_fast_child(0);
+            }
+        }
+
+        let overhead = timed_total.saturating_sub(baseline_total);
+        let allowed_overhead =
+            Duration::from_millis(WATCHDOG_CANCEL_POLL_INTERVAL_MS * u64::from(iterations) / 2);
         assert!(
-            elapsed < Duration::from_millis(900),
-            "fast child exits should not accumulate the 50ms cancel poll interval per child; \
-             {iterations} waits took {elapsed:?}",
+            overhead < allowed_overhead,
+            "timed waits should not accumulate the {WATCHDOG_CANCEL_POLL_INTERVAL_MS}ms cancel \
+             poll interval per child; {iterations} timed waits took {timed_total:?}, baseline \
+             waits took {baseline_total:?}, overhead was {overhead:?}",
         );
     }
 

--- a/crates/vsock-guest/src/wait.rs
+++ b/crates/vsock-guest/src/wait.rs
@@ -404,8 +404,7 @@ mod tests {
         let mut timed_total = Duration::default();
 
         fn wait_for_fast_child(timeout_ms: u32) -> Duration {
-            let child = Command::new("sleep")
-                .arg("0.02")
+            let child = Command::new("true")
                 .stdout(Stdio::null())
                 .stderr(Stdio::null())
                 .spawn()

--- a/crates/vsock-guest/tests/connection.rs
+++ b/crates/vsock-guest/tests/connection.rs
@@ -1510,9 +1510,14 @@ fn send_process_control(
     control_nonce: vsock_proto::ProcessControlNonce,
     message_id: &str,
 ) {
-    let payload =
-        vsock_proto::encode_process_control(target_seq, control_nonce, message_id, b"payload")
-            .unwrap();
+    let payload = vsock_proto::encode_process_control(
+        target_seq,
+        control_nonce,
+        message_id,
+        b"payload",
+        5000,
+    )
+    .unwrap();
     let msg = vsock_proto::encode(MSG_PROCESS_CONTROL, request_seq, &payload).unwrap();
     stream.write_all(&msg).unwrap();
 }

--- a/crates/vsock-host/src/process.rs
+++ b/crates/vsock-host/src/process.rs
@@ -269,11 +269,13 @@ impl GuestProcessControlHandle {
         payload: &[u8],
         timeout: Duration,
     ) -> io::Result<ProcessControlAck> {
+        let request_timeout_ms = duration_to_request_timeout_ms(timeout);
         let request = vsock_proto::encode_process_control(
             self.target_seq,
             self.control_nonce,
             message_id,
             payload,
+            request_timeout_ms,
         )
         .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e.to_string()))?;
         let response =
@@ -385,6 +387,16 @@ impl GuestProcessControlHandle {
             )),
         }
     }
+}
+
+fn duration_to_request_timeout_ms(timeout: Duration) -> u32 {
+    if timeout.is_zero() {
+        return 0;
+    }
+
+    u32::try_from(timeout.as_millis())
+        .unwrap_or(u32::MAX)
+        .max(1)
 }
 
 impl Drop for GuestProcessHandle {

--- a/crates/vsock-host/src/tests/process.rs
+++ b/crates/vsock-host/src/tests/process.rs
@@ -169,6 +169,107 @@ async fn test_spawn_process_control_uses_operation_seq_and_nonce() {
 }
 
 #[tokio::test]
+async fn test_spawn_process_control_sub_millisecond_timeout_rounds_up_to_one_ms() {
+    let (host_stream, mut guest) = make_pair();
+    let (observed_tx, observed_rx) = oneshot::channel();
+    let (release_guest_tx, release_guest_rx) = oneshot::channel();
+
+    let guest_task = tokio::spawn(async move {
+        let mut decoder = Decoder::new();
+        mock_handshake(&mut guest, &mut decoder).await;
+
+        let spawn = read_guest_message(&mut guest).await;
+        assert_eq!(spawn.msg_type, MSG_SPAWN_PROCESS);
+
+        let payload = vsock_proto::encode_spawn_process_result(42);
+        let resp = vsock_proto::encode(MSG_SPAWN_PROCESS_RESULT, spawn.seq, &payload).unwrap();
+        guest.write_all(&resp).await.unwrap();
+
+        let control = read_guest_message(&mut guest).await;
+        assert_eq!(control.msg_type, MSG_PROCESS_CONTROL);
+        let decoded_control = vsock_proto::decode_process_control(&control.payload).unwrap();
+        observed_tx
+            .send(decoded_control.request_timeout_ms)
+            .unwrap();
+
+        let _ = release_guest_rx.await;
+    });
+
+    let host = host_from_stream(host_stream).await.unwrap();
+    let handle = host
+        .spawn_process("sleep 1", 0, &[], false, false, None)
+        .await
+        .unwrap();
+
+    let (control_result, observed_timeout_ms) =
+        tokio::time::timeout(Duration::from_secs(5), async {
+            tokio::join!(
+                handle.control("message-sub-ms", b"payload", Duration::from_nanos(1)),
+                observed_rx,
+            )
+        })
+        .await
+        .expect("control request should be written before timeout");
+
+    assert_eq!(observed_timeout_ms.unwrap(), 1);
+    assert_eq!(control_result.unwrap_err().kind(), io::ErrorKind::TimedOut);
+
+    let _ = release_guest_tx.send(());
+    guest_task.await.unwrap();
+}
+
+#[tokio::test]
+async fn test_spawn_process_control_large_timeout_saturates_request_timeout_ms() {
+    let (host_stream, mut guest) = make_pair();
+
+    tokio::spawn(async move {
+        let mut decoder = Decoder::new();
+        mock_handshake(&mut guest, &mut decoder).await;
+
+        let spawn = read_guest_message(&mut guest).await;
+        assert_eq!(spawn.msg_type, MSG_SPAWN_PROCESS);
+        let decoded_spawn = vsock_proto::decode_spawn_process(&spawn.payload).unwrap();
+        let control_nonce = decoded_spawn.control_nonce.unwrap();
+
+        let payload = vsock_proto::encode_spawn_process_result(42);
+        let resp = vsock_proto::encode(MSG_SPAWN_PROCESS_RESULT, spawn.seq, &payload).unwrap();
+        guest.write_all(&resp).await.unwrap();
+
+        let control = read_guest_message(&mut guest).await;
+        assert_eq!(control.msg_type, MSG_PROCESS_CONTROL);
+        let decoded_control = vsock_proto::decode_process_control(&control.payload).unwrap();
+        assert_eq!(decoded_control.request_timeout_ms, u32::MAX);
+
+        send_process_control_result(
+            &mut guest,
+            control.seq,
+            decoded_control.target_seq,
+            control_nonce,
+            decoded_control.message_id,
+            ProcessControlStatus::Delivered,
+            "",
+        )
+        .await;
+    });
+
+    let host = host_from_stream(host_stream).await.unwrap();
+    let handle = host
+        .spawn_process("sleep 1", 0, &[], false, false, None)
+        .await
+        .unwrap();
+
+    let ack = handle
+        .control(
+            "message-large-timeout",
+            b"payload",
+            Duration::from_millis(u64::from(u32::MAX) + 1),
+        )
+        .await
+        .unwrap();
+    assert_eq!(ack.message_id, "message-large-timeout");
+}
+
+#[tokio::test]
 async fn test_spawn_process_with_control_sink_sets_control_sink_flag() {
     let (host_stream, mut guest) = make_pair();
 

--- a/crates/vsock-host/src/tests/process.rs
+++ b/crates/vsock-host/src/tests/process.rs
@@ -129,6 +129,7 @@ async fn test_spawn_process_control_uses_operation_seq_and_nonce() {
         assert_eq!(control.msg_type, MSG_PROCESS_CONTROL);
         let decoded_control = vsock_proto::decode_process_control(&control.payload).unwrap();
         assert_eq!(decoded_control.target_seq, spawn.seq);
+        assert_eq!(decoded_control.request_timeout_ms, 5000);
         assert_eq!(decoded_control.control_nonce, control_nonce);
         assert_eq!(decoded_control.message_id, "message-1");
         assert_eq!(decoded_control.payload, b"payload");
@@ -714,6 +715,8 @@ async fn test_spawn_process_control_timeout_cleans_pending_without_poisoning() {
 
         let control = read_guest_message(&mut guest).await;
         assert_eq!(control.msg_type, MSG_PROCESS_CONTROL);
+        let decoded_control = vsock_proto::decode_process_control(&control.payload).unwrap();
+        assert_eq!(decoded_control.request_timeout_ms, 0);
 
         let exec = read_guest_message(&mut guest).await;
         assert_eq!(exec.msg_type, MSG_EXEC_START);

--- a/crates/vsock-proto/src/lib.rs
+++ b/crates/vsock-proto/src/lib.rs
@@ -36,7 +36,7 @@
 //! | 0x10 | G→H       | operations_quiesced    | (empty) |
 //! | 0x11 | H→G       | resume_operations | (empty) |
 //! | 0x12 | G→H       | operations_resumed | (empty) |
-//! | 0x13 | H→G       | process_control | `[4B target_seq][16B nonce][2B message_id_len][message_id][4B payload_len][payload]` |
+//! | 0x13 | H→G       | process_control | `[4B target_seq][4B request_timeout_ms][16B nonce][2B message_id_len][message_id][4B payload_len][payload]` |
 //! | 0x14 | G→H       | process_control_result | `[4B target_seq][16B nonce][2B message_id_len][message_id][1B status][2B diagnostic_len][diagnostic]` |
 //! | 0xFF | G→H       | error             | `[2B error_len][error]` |
 //!

--- a/crates/vsock-proto/src/lib.rs
+++ b/crates/vsock-proto/src/lib.rs
@@ -50,6 +50,10 @@
 //! `process_control_result.status` uses 0=delivered, 1=inactive,
 //! 2=nonce_mismatch, 3=unsupported, 4=rejected, 5=sink_unavailable,
 //! 6=sink_timeout, 7=queue_full, and 8=sink_error.
+//! `process_control.request_timeout_ms` is the caller-visible budget, counted
+//! from guest receipt through local sink connection, request write, and response
+//! read. Host encoders round non-zero sub-millisecond durations up to 1ms and
+//! saturate values that do not fit in `u32`.
 
 mod error;
 mod frame;

--- a/crates/vsock-proto/src/payloads/process_control.rs
+++ b/crates/vsock-proto/src/payloads/process_control.rs
@@ -37,6 +37,7 @@ pub enum ProcessControlStatus {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct DecodedProcessControl<'a> {
     pub target_seq: u32,
+    pub request_timeout_ms: u32,
     pub control_nonce: ProcessControlNonce,
     pub message_id: &'a str,
     pub payload: &'a [u8],
@@ -83,7 +84,7 @@ fn status_from_wire(value: u8) -> Result<ProcessControlStatus, ProtocolError> {
 }
 
 fn encoded_control_len(message_id_len: usize, payload_len: usize) -> Result<usize, ProtocolError> {
-    let mut total = 4 + PROCESS_CONTROL_NONCE_LEN + 2;
+    let mut total = 4 + 4 + PROCESS_CONTROL_NONCE_LEN + 2;
     total = checked_payload_len_add(total, message_id_len)?;
     total = checked_payload_len_add(total, 4)?;
     checked_payload_len_add(total, payload_len)
@@ -104,6 +105,7 @@ pub fn encode_process_control(
     control_nonce: ProcessControlNonce,
     message_id: &str,
     payload: &[u8],
+    request_timeout_ms: u32,
 ) -> Result<Vec<u8>, ProtocolError> {
     if target_seq == 0 {
         return Err(ProtocolError::InvalidPayload(
@@ -125,6 +127,7 @@ pub fn encode_process_control(
 
     let mut out = Vec::with_capacity(total_len);
     out.extend_from_slice(&target_seq.to_be_bytes());
+    out.extend_from_slice(&request_timeout_ms.to_be_bytes());
     out.extend_from_slice(&control_nonce);
     out.extend_from_slice(&message_id_len.to_be_bytes());
     out.extend_from_slice(message_id.as_bytes());
@@ -141,6 +144,11 @@ pub fn decode_process_control(payload: &[u8]) -> Result<DecodedProcessControl<'_
             "process_control target_seq must be non-zero",
         ));
     }
+    let request_timeout_ms = read_u32(
+        payload,
+        &mut offset,
+        "process_control request_timeout_ms truncated",
+    )?;
     let nonce_bytes = read_slice(
         payload,
         &mut offset,
@@ -187,6 +195,7 @@ pub fn decode_process_control(payload: &[u8]) -> Result<DecodedProcessControl<'_
 
     Ok(DecodedProcessControl {
         target_seq,
+        request_timeout_ms,
         control_nonce,
         message_id,
         payload: message_payload,
@@ -299,6 +308,7 @@ mod tests {
     use super::*;
 
     const NONCE: ProcessControlNonce = *b"0123456789abcdef";
+    const REQUEST_TIMEOUT_MS: u32 = 5000;
 
     fn assert_invalid_payload(err: ProtocolError, expected: &'static str) {
         assert!(matches!(err, ProtocolError::InvalidPayload(msg) if msg == expected));
@@ -306,10 +316,12 @@ mod tests {
 
     #[test]
     fn process_control_roundtrip() {
-        let encoded = encode_process_control(7, NONCE, "msg-1", b"hello").unwrap();
+        let encoded =
+            encode_process_control(7, NONCE, "msg-1", b"hello", REQUEST_TIMEOUT_MS).unwrap();
         let decoded = decode_process_control(&encoded).unwrap();
 
         assert_eq!(decoded.target_seq, 7);
+        assert_eq!(decoded.request_timeout_ms, REQUEST_TIMEOUT_MS);
         assert_eq!(decoded.control_nonce, NONCE);
         assert_eq!(decoded.message_id, "msg-1");
         assert_eq!(decoded.payload, b"hello");
@@ -317,7 +329,7 @@ mod tests {
 
     #[test]
     fn process_control_allows_empty_payload() {
-        let encoded = encode_process_control(7, NONCE, "msg-1", b"").unwrap();
+        let encoded = encode_process_control(7, NONCE, "msg-1", b"", REQUEST_TIMEOUT_MS).unwrap();
         let decoded = decode_process_control(&encoded).unwrap();
 
         assert_eq!(decoded.payload, b"");
@@ -326,14 +338,16 @@ mod tests {
     #[test]
     fn process_control_rejects_payload_over_local_ipc_limit() {
         let too_large = vec![0; PROCESS_CONTROL_MAX_PAYLOAD_BYTES + 1];
-        let err = encode_process_control(7, NONCE, "msg-1", &too_large).unwrap_err();
+        let err =
+            encode_process_control(7, NONCE, "msg-1", &too_large, REQUEST_TIMEOUT_MS).unwrap_err();
         assert!(matches!(
             err,
             ProtocolError::PayloadTooLarge("payload", size) if size == too_large.len()
         ));
 
-        let mut encoded = encode_process_control(7, NONCE, "msg-1", b"hello").unwrap();
-        let payload_len_offset = 4 + PROCESS_CONTROL_NONCE_LEN + 2 + "msg-1".len();
+        let mut encoded =
+            encode_process_control(7, NONCE, "msg-1", b"hello", REQUEST_TIMEOUT_MS).unwrap();
+        let payload_len_offset = 4 + 4 + PROCESS_CONTROL_NONCE_LEN + 2 + "msg-1".len();
         encoded[payload_len_offset..payload_len_offset + 4]
             .copy_from_slice(&((PROCESS_CONTROL_MAX_PAYLOAD_BYTES as u32) + 1).to_be_bytes());
 
@@ -343,13 +357,15 @@ mod tests {
 
     #[test]
     fn process_control_rejects_zero_target_seq() {
-        let err = encode_process_control(0, NONCE, "msg-1", b"payload").unwrap_err();
+        let err =
+            encode_process_control(0, NONCE, "msg-1", b"payload", REQUEST_TIMEOUT_MS).unwrap_err();
         assert!(matches!(
             err,
             ProtocolError::InvalidPayload("process_control target_seq must be non-zero")
         ));
 
-        let mut encoded = encode_process_control(7, NONCE, "msg-1", b"payload").unwrap();
+        let mut encoded =
+            encode_process_control(7, NONCE, "msg-1", b"payload", REQUEST_TIMEOUT_MS).unwrap();
         encoded[0..4].copy_from_slice(&0u32.to_be_bytes());
 
         let err = decode_process_control(&encoded).unwrap_err();
@@ -361,14 +377,15 @@ mod tests {
 
     #[test]
     fn process_control_rejects_empty_message_id() {
-        let err = encode_process_control(7, NONCE, "", b"payload").unwrap_err();
+        let err = encode_process_control(7, NONCE, "", b"payload", REQUEST_TIMEOUT_MS).unwrap_err();
         assert!(matches!(
             err,
             ProtocolError::InvalidPayload("process_control message_id empty")
         ));
 
-        let mut encoded = encode_process_control(7, NONCE, "msg-1", b"payload").unwrap();
-        let message_id_len_offset = 4 + PROCESS_CONTROL_NONCE_LEN;
+        let mut encoded =
+            encode_process_control(7, NONCE, "msg-1", b"payload", REQUEST_TIMEOUT_MS).unwrap();
+        let message_id_len_offset = 4 + 4 + PROCESS_CONTROL_NONCE_LEN;
         encoded[message_id_len_offset..message_id_len_offset + 2]
             .copy_from_slice(&0u16.to_be_bytes());
 
@@ -381,7 +398,8 @@ mod tests {
 
     #[test]
     fn process_control_rejects_trailing_bytes() {
-        let mut encoded = encode_process_control(7, NONCE, "msg-1", b"hello").unwrap();
+        let mut encoded =
+            encode_process_control(7, NONCE, "msg-1", b"hello", REQUEST_TIMEOUT_MS).unwrap();
         encoded.push(0);
 
         let err = decode_process_control(&encoded).unwrap_err();
@@ -390,8 +408,11 @@ mod tests {
 
     #[test]
     fn process_control_rejects_truncated_fields() {
-        let encoded = encode_process_control(7, NONCE, "msg-1", b"hello").unwrap();
-        let message_id_len_offset = 4 + PROCESS_CONTROL_NONCE_LEN;
+        let encoded =
+            encode_process_control(7, NONCE, "msg-1", b"hello", REQUEST_TIMEOUT_MS).unwrap();
+        let request_timeout_offset = 4;
+        let nonce_offset = request_timeout_offset + 4;
+        let message_id_len_offset = nonce_offset + PROCESS_CONTROL_NONCE_LEN;
         let message_id_offset = message_id_len_offset + 2;
         let payload_len_offset = message_id_offset + "msg-1".len();
         let payload_offset = payload_len_offset + 4;
@@ -401,7 +422,12 @@ mod tests {
             "process_control target_seq truncated",
         );
         assert_invalid_payload(
-            decode_process_control(&encoded[..4 + PROCESS_CONTROL_NONCE_LEN - 1]).unwrap_err(),
+            decode_process_control(&encoded[..request_timeout_offset + 3]).unwrap_err(),
+            "process_control request_timeout_ms truncated",
+        );
+        assert_invalid_payload(
+            decode_process_control(&encoded[..nonce_offset + PROCESS_CONTROL_NONCE_LEN - 1])
+                .unwrap_err(),
             "process_control nonce truncated",
         );
         assert_invalid_payload(
@@ -424,8 +450,9 @@ mod tests {
 
     #[test]
     fn process_control_rejects_invalid_utf8_message_id() {
-        let mut encoded = encode_process_control(7, NONCE, "msg-1", b"hello").unwrap();
-        let message_id_offset = 4 + PROCESS_CONTROL_NONCE_LEN + 2;
+        let mut encoded =
+            encode_process_control(7, NONCE, "msg-1", b"hello", REQUEST_TIMEOUT_MS).unwrap();
+        let message_id_offset = 4 + 4 + PROCESS_CONTROL_NONCE_LEN + 2;
         encoded[message_id_offset] = 0xFF;
 
         let err = decode_process_control(&encoded).unwrap_err();


### PR DESCRIPTION
## Summary

- add required `request_timeout_ms` to the process-control wire payload
- pass the host caller's control timeout through to the guest and use it as the guest-side request deadline
- split sink connection waiting from connected-sink IPC timeouts, and remove the fixed accept deadline
- cover request-timeout cleanup before sink connection and wire decode truncation behavior

Closes #13554

## Tests

- `cargo test --manifest-path crates/Cargo.toml -p vsock-proto process_control`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-guest process_control`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-host process_control`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-guest --test connection process_control`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-proto`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-guest`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-host`
- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p vsock-proto -p vsock-host -p vsock-guest --all-targets -- -D warnings`
- `cargo doc --manifest-path crates/Cargo.toml --workspace --all-features --no-deps`
