### PR TITLE
fix: use api vercel project id for sandbox auth

### DIFF
--- a/turbo/apps/api/src/signals/external/__tests__/sandbox.test.ts
+++ b/turbo/apps/api/src/signals/external/__tests__/sandbox.test.ts
@@ -195,9 +195,9 @@ describe("sandbox utilities", () => {
 });
 
 describe("Vercel sandbox client test override", () => {
-  it("uses access-token credentials outside Vercel when all local env vars exist", () => {
+  it("uses access-token credentials outside Vercel when API project env var exists", () => {
     mockOptionalEnv("VERCEL_TEAM_ID", "team_test");
-    mockOptionalEnv("VERCEL_PROJECT_ID", "project_test");
+    mockOptionalEnv("VERCEL_PROJECT_ID_API", "project_test");
     mockOptionalEnv("VERCEL_TOKEN", "token_test");
 
     expect(getVercelSandboxCredentials()).toStrictEqual({
@@ -231,7 +231,7 @@ describe("Vercel sandbox client test override", () => {
     expect(() => {
       getVercelSandboxCredentials();
     }).toThrow(
-      "Missing Vercel Sandbox access-token environment variables: VERCEL_TEAM_ID, VERCEL_PROJECT_ID",
+      "Missing Vercel Sandbox access-token environment variables: VERCEL_TEAM_ID, VERCEL_PROJECT_ID_API",
     );
   });
 

--- a/turbo/apps/api/src/signals/external/vercel-sandbox.ts
+++ b/turbo/apps/api/src/signals/external/vercel-sandbox.ts
@@ -53,7 +53,7 @@ export const VERCEL_SANDBOX_SMOKE_TIMEOUT_MS = 60 * 1000;
 
 const VERCEL_SANDBOX_ACCESS_TOKEN_ENV_NAMES = [
   "VERCEL_TEAM_ID",
-  "VERCEL_PROJECT_ID",
+  "VERCEL_PROJECT_ID_API",
   "VERCEL_TOKEN",
 ] as const;
 
@@ -83,11 +83,11 @@ export function getVercelSandboxCredentials():
   }
 
   const teamId = optionalEnv("VERCEL_TEAM_ID");
-  const projectId = optionalEnv("VERCEL_PROJECT_ID");
+  const projectId = optionalEnv("VERCEL_PROJECT_ID_API");
   const token = optionalEnv("VERCEL_TOKEN");
   const values = {
     VERCEL_TEAM_ID: teamId,
-    VERCEL_PROJECT_ID: projectId,
+    VERCEL_PROJECT_ID_API: projectId,
     VERCEL_TOKEN: token,
   };
   const missing = VERCEL_SANDBOX_ACCESS_TOKEN_ENV_NAMES.filter((name) => {

--- a/turbo/apps/web/.env.local.tpl
+++ b/turbo/apps/web/.env.local.tpl
@@ -11,7 +11,7 @@ E2B_TEMPLATE_NAME=vm0-claude-code-dev
 
 # Optional: Sandbox Runtime (Vercel Sandbox access-token auth)
 VERCEL_TEAM_ID=op://Development/vercel/VERCEL_TEAM_ID
-VERCEL_PROJECT_ID=op://Development/vercel/VERCEL_PROJECT_ID_API
+VERCEL_PROJECT_ID_API=op://Development/vercel/VERCEL_PROJECT_ID_API
 VERCEL_TOKEN=op://Development/vercel/VERCEL_TOKEN
 
 # Required: Object Storage (Cloudflare R2)


### PR DESCRIPTION
## Summary
- rename the local Vercel Sandbox project env template key to VERCEL_PROJECT_ID_API
- make local Vercel Sandbox access-token auth require VERCEL_PROJECT_ID_API
- update sandbox credential tests and missing-env messaging

## Verification
- pnpm -F api exec vitest run src/signals/external/__tests__/sandbox.test.ts
- pnpm -F api lint
- git diff --check
- localhost Vercel Sandbox smoke endpoint returned 200 and stopped the sandbox
- pre-commit hook: prettier, knip, turbo check-types