### PR TITLE
feat(zero): always mount local-agent skill on every agent run

### DIFF
--- a/turbo/packages/core/src/zero-seed-skills.ts
+++ b/turbo/packages/core/src/zero-seed-skills.ts
@@ -25,6 +25,7 @@ export const SEED_SKILLS: readonly string[] = [
   "kb-authoring",
   "legal-briefing",
   "legal-risk-scoring",
+  "local-agent",
   "marketing-analytics",
   "nda-screening",
   "period-close",


### PR DESCRIPTION
## Summary
- Add `local-agent` to `SEED_SKILLS` so the `local-agent` skill mounts on every agent run regardless of per-agent connector authorization.

## Context
`local-agent:read` / `local-agent:write` capabilities are already granted unconditionally to every ZERO_TOKEN (`turbo/apps/web/src/lib/auth/sandbox-token.ts`), so `zero local-agent ...` CLI commands already work in every run. The missing piece was the **skill documentation**: `buildSystemSkillVolumes` derives the mount list from `[...SEED_SKILLS, ...allowedConnectorTypes]`, and `allowedConnectorTypes` comes from `user_connectors` (per-agent authorize). With `local-agent` not in `SEED_SKILLS`, agents had the capability but no docs unless the user explicitly authorized the connector for that agent.

Treating `local-agent` as a seed skill matches the way it's already a "virtual / always-available" connector (`NonFirewallConnectorType` in `turbo/packages/connectors/src/firewalls/index.ts`).

## Test plan
- [ ] CI lint, type-check, tests pass
- [ ] `cron-sync-skills` picks up `vm0-ai/vm0-skills/local-agent` (already exists, confirmed via `gh api`)
- [ ] New agent run mounts `/home/user/.claude/skills/local-agent/` without any `user_connectors` row

🤖 Generated with [Claude Code](https://claude.com/claude-code)