### PR TITLE
test(runner): deduplicate orphan reaper fixtures

### DIFF
--- a/crates/runner/src/cmd/start/orphan_reap.rs
+++ b/crates/runner/src/cmd/start/orphan_reap.rs
@@ -505,13 +505,17 @@ mod tests {
 
         async fn assert_orphans(&self, expected: &[(RunId, SandboxId)]) {
             let remaining = self.orphans.snapshot().await;
-            assert_eq!(remaining.len(), expected.len());
-            for (remaining, (expected_run_id, expected_sandbox_id)) in
-                remaining.iter().zip(expected.iter())
-            {
-                assert_eq!(remaining.run_id, *expected_run_id);
-                assert_eq!(remaining.sandbox_id, *expected_sandbox_id);
-            }
+            let mut remaining = remaining
+                .iter()
+                .map(|record| (record.run_id.to_string(), record.sandbox_id.to_string()))
+                .collect::<Vec<_>>();
+            remaining.sort_unstable();
+            let mut expected = expected
+                .iter()
+                .map(|(run_id, sandbox_id)| (run_id.to_string(), sandbox_id.to_string()))
+                .collect::<Vec<_>>();
+            expected.sort_unstable();
+            assert_eq!(remaining, expected);
         }
 
         async fn assert_orphan_count(&self, expected: usize) {
@@ -529,12 +533,16 @@ mod tests {
                 .map(|idle_vms| {
                     idle_vms
                         .iter()
-                        .filter_map(|vm| {
-                            let session_id =
-                                vm.get("session_id").and_then(|session| session.as_str())?;
-                            let sandbox_id =
-                                vm.get("sandbox_id").and_then(|sandbox| sandbox.as_str())?;
-                            Some((session_id.to_string(), sandbox_id.to_string()))
+                        .map(|vm| {
+                            let session_id = vm
+                                .get("session_id")
+                                .and_then(|session| session.as_str())
+                                .expect("idle VM must include session_id");
+                            let sandbox_id = vm
+                                .get("sandbox_id")
+                                .and_then(|sandbox| sandbox.as_str())
+                                .expect("idle VM must include sandbox_id");
+                            (session_id.to_string(), sandbox_id.to_string())
                         })
                         .collect()
                 })
@@ -544,10 +552,16 @@ mod tests {
                 .as_array()
                 .unwrap()
                 .iter()
-                .filter_map(|run| {
-                    let run_id = run.get("run_id").and_then(|run_id| run_id.as_str())?;
-                    let sandbox_id = run.get("sandbox_id").and_then(|sandbox| sandbox.as_str())?;
-                    Some((run_id.to_string(), sandbox_id.to_string()))
+                .map(|run| {
+                    let run_id = run
+                        .get("run_id")
+                        .and_then(|run_id| run_id.as_str())
+                        .expect("active run must include run_id");
+                    let sandbox_id = run
+                        .get("sandbox_id")
+                        .and_then(|sandbox| sandbox.as_str())
+                        .expect("active run must include sandbox_id");
+                    (run_id.to_string(), sandbox_id.to_string())
                 })
                 .collect();
             active_runs.sort_unstable();

--- a/crates/runner/src/cmd/start/orphan_reap.rs
+++ b/crates/runner/src/cmd/start/orphan_reap.rs
@@ -685,6 +685,53 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn orphan_reaper_reconciles_idle_owned_records_when_discovery_is_incomplete() {
+        let fixture = OrphanReapFixture::new();
+        let idle_run_id = RunId::new_v4();
+        let idle_sandbox_id = SandboxId::new_v4();
+        let uncertain_run_id = RunId::new_v4();
+        let uncertain_sandbox_id = SandboxId::new_v4();
+        fixture
+            .park_idle_candidate(
+                "sess-incomplete-discovery-idle",
+                idle_sandbox_id,
+                "incomplete-discovery-idle-owned-reaper",
+            )
+            .await;
+        fixture
+            .add_active_orphan(idle_run_id, idle_sandbox_id)
+            .await;
+        fixture
+            .add_active_orphan(uncertain_run_id, uncertain_sandbox_id)
+            .await;
+        let unresolved_firecracker = process::FirecrackerProcessInfo {
+            pid: 1234,
+            ppid: Some(1),
+            sandbox_id: "pid-1234".to_string(),
+            base_dir: None,
+        };
+        let discovery = OrphanReapProcessDiscovery {
+            firecrackers: Arc::new(vec![unresolved_firecracker]),
+            incomplete_for_current_runner: true,
+        };
+
+        fixture
+            .reap_with_discovery(OrphanReapMode::ShutdownFinal, &discovery)
+            .await;
+
+        fixture
+            .assert_status(
+                &[("sess-incomplete-discovery-idle", idle_sandbox_id)],
+                &[(uncertain_run_id, uncertain_sandbox_id)],
+            )
+            .await;
+        fixture
+            .assert_orphans(&[(uncertain_run_id, uncertain_sandbox_id)])
+            .await;
+        fixture.destroy_all_idle_entries().await;
+    }
+
+    #[tokio::test]
     async fn orphan_reaper_immediate_mode_does_not_count_absent_scan() {
         let fixture = OrphanReapFixture::new();
         let run_id = RunId::new_v4();

--- a/crates/runner/src/cmd/start/orphan_reap.rs
+++ b/crates/runner/src/cmd/start/orphan_reap.rs
@@ -685,6 +685,42 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn orphan_reaper_reconciles_mixed_live_and_absent_records() {
+        let fixture = OrphanReapFixture::new();
+        let live_run_id = RunId::new_v4();
+        let live_sandbox_id = SandboxId::new_v4();
+        let absent_run_id = RunId::new_v4();
+        let absent_sandbox_id = SandboxId::new_v4();
+        fixture
+            .add_active_orphan(live_run_id, live_sandbox_id)
+            .await;
+        fixture
+            .add_active_orphan(absent_run_id, absent_sandbox_id)
+            .await;
+        let live_firecracker = process::FirecrackerProcessInfo {
+            pid: 1234,
+            ppid: Some(1),
+            sandbox_id: live_sandbox_id.to_string(),
+            base_dir: None,
+        };
+
+        fixture
+            .reap_current_orphans_with_firecrackers(
+                &[live_firecracker],
+                false,
+                OrphanReapMode::ShutdownFinal.absent_scans_before_remove(),
+            )
+            .await;
+
+        fixture
+            .assert_status(&[], &[(live_run_id, live_sandbox_id)])
+            .await;
+        fixture
+            .assert_orphans(&[(live_run_id, live_sandbox_id)])
+            .await;
+    }
+
+    #[tokio::test]
     async fn orphan_reaper_reconciles_idle_owned_records_when_discovery_is_incomplete() {
         let fixture = OrphanReapFixture::new();
         let idle_run_id = RunId::new_v4();

--- a/crates/runner/src/cmd/start/orphan_reap.rs
+++ b/crates/runner/src/cmd/start/orphan_reap.rs
@@ -566,8 +566,6 @@ mod tests {
         fixture
             .assert_orphans(&[(run_id, current_sandbox_id)])
             .await;
-
-        fixture.destroy_all_idle_entries().await;
     }
 
     #[tokio::test]
@@ -598,6 +596,8 @@ mod tests {
         fixture
             .assert_orphans(&[(run_id, current_sandbox_id)])
             .await;
+
+        fixture.destroy_all_idle_entries().await;
     }
 
     #[tokio::test]

--- a/crates/runner/src/cmd/start/orphan_reap.rs
+++ b/crates/runner/src/cmd/start/orphan_reap.rs
@@ -333,357 +333,371 @@ mod tests {
     use sandbox_mock::{MockSandbox, MockSandboxFactory};
     use std::time::Duration;
 
-    async fn status_idle_sessions_and_active_runs(
-        status_path: &std::path::Path,
-    ) -> (Vec<String>, Vec<String>) {
-        let raw = tokio::fs::read_to_string(status_path).await.unwrap();
-        let status: serde_json::Value = serde_json::from_str(&raw).unwrap();
-        let mut sessions: Vec<String> = status
-            .get("idle_vms")
-            .and_then(|v| v.as_array())
-            .map(|idle_vms| {
-                idle_vms
-                    .iter()
-                    .filter_map(|vm| {
-                        vm.get("session_id")
-                            .and_then(|session| session.as_str())
-                            .map(str::to_string)
-                    })
-                    .collect()
-            })
-            .unwrap_or_default();
-        sessions.sort_unstable();
-        let mut run_ids: Vec<String> = status["active_runs"]
-            .as_array()
-            .unwrap()
-            .iter()
-            .filter_map(|run| {
-                run.get("run_id")
-                    .and_then(|run_id| run_id.as_str())
-                    .map(str::to_string)
-            })
-            .collect();
-        run_ids.sort_unstable();
-        (sessions, run_ids)
+    struct OrphanReapFixture {
+        _dir: tempfile::TempDir,
+        status_path: std::path::PathBuf,
+        status: StatusTracker,
+        idle_pool: SharedIdlePool,
+        orphans: OrphanedActiveRuns,
+    }
+
+    impl OrphanReapFixture {
+        fn new() -> Self {
+            let dir = tempfile::tempdir().unwrap();
+            let status_path = dir.path().join("status.json");
+            let status = StatusTracker::new(status_path.clone(), 4, None, None);
+            let idle_pool: SharedIdlePool =
+                Arc::new(tokio::sync::Mutex::new(IdlePool::new(IdlePoolConfig {
+                    default_timeout: Duration::from_secs(300),
+                    max_idle: 10,
+                })));
+            Self {
+                _dir: dir,
+                status_path,
+                status,
+                idle_pool,
+                orphans: OrphanedActiveRuns::new(),
+            }
+        }
+
+        async fn add_active_orphan(&self, run_id: RunId, sandbox_id: SandboxId) {
+            self.status.add_run(run_id, sandbox_id).await;
+            self.orphans.insert(run_id, sandbox_id).await;
+        }
+
+        async fn park_idle_candidate(
+            &self,
+            session_id: &str,
+            sandbox_id: SandboxId,
+            mock_name: &str,
+        ) {
+            let budget = Arc::new(ResourceBudget::new(2, 4096, 1.0, 0));
+            let lease = ResourceBudget::try_reserve_lease(&budget, 2, 4096).unwrap();
+            let candidate =
+                ParkedIdleCandidate::synthetic_for_test(SyntheticParkedIdleCandidateParts {
+                    sandbox: Box::new(MockSandbox::new(mock_name)),
+                    factory: Arc::new(
+                        Box::new(MockSandboxFactory::new()) as Box<dyn SandboxFactory>
+                    ),
+                    session_id: session_id.into(),
+                    sandbox_id,
+                    profile_name: "vm0/default".into(),
+                    budget_lease: lease,
+                    source_ip: "10.0.0.1".into(),
+                    storage_fingerprints: StorageFingerprints::default(),
+                });
+            assert!(matches!(
+                self.idle_pool.lock().await.park(candidate),
+                ParkResult::Parked
+            ));
+        }
+
+        async fn reap(&self, mode: OrphanReapMode) {
+            reap_orphaned_active_runs(&self.orphans, &self.idle_pool, &self.status, mode, None)
+                .await;
+        }
+
+        async fn reap_records(&self, records: Vec<OrphanedActiveRun>, mode: OrphanReapMode) {
+            reap_orphaned_active_run_records(
+                &self.orphans,
+                &self.idle_pool,
+                &self.status,
+                records,
+                mode,
+                None,
+            )
+            .await;
+        }
+
+        async fn reap_current_orphans_with_firecrackers(
+            &self,
+            firecrackers: &[process::FirecrackerProcessInfo],
+            discovery_incomplete_for_current_runner: bool,
+            absent_scans_before_remove: u8,
+        ) {
+            self.reap_records_with_firecrackers(
+                self.orphans.snapshot().await,
+                firecrackers,
+                discovery_incomplete_for_current_runner,
+                absent_scans_before_remove,
+            )
+            .await;
+        }
+
+        async fn reap_records_with_firecrackers(
+            &self,
+            records: Vec<OrphanedActiveRun>,
+            firecrackers: &[process::FirecrackerProcessInfo],
+            discovery_incomplete_for_current_runner: bool,
+            absent_scans_before_remove: u8,
+        ) {
+            reap_orphaned_active_runs_with_firecrackers(
+                &self.orphans,
+                &self.status,
+                records,
+                firecrackers,
+                discovery_incomplete_for_current_runner,
+                absent_scans_before_remove,
+            )
+            .await;
+        }
+
+        async fn assert_status(
+            &self,
+            expected_idle_sessions: &[&str],
+            expected_active_runs: &[RunId],
+        ) {
+            let (idle_sessions, active_runs) = self.status_idle_sessions_and_active_runs().await;
+            let mut expected_idle_sessions = expected_idle_sessions
+                .iter()
+                .map(|session_id| (*session_id).to_string())
+                .collect::<Vec<_>>();
+            expected_idle_sessions.sort_unstable();
+            let mut expected_active_runs = expected_active_runs
+                .iter()
+                .map(RunId::to_string)
+                .collect::<Vec<_>>();
+            expected_active_runs.sort_unstable();
+
+            assert_eq!(idle_sessions, expected_idle_sessions);
+            assert_eq!(active_runs, expected_active_runs);
+        }
+
+        async fn assert_orphans(&self, expected: &[(RunId, SandboxId)]) {
+            let remaining = self.orphans.snapshot().await;
+            assert_eq!(remaining.len(), expected.len());
+            for (remaining, (expected_run_id, expected_sandbox_id)) in
+                remaining.iter().zip(expected.iter())
+            {
+                assert_eq!(remaining.run_id, *expected_run_id);
+                assert_eq!(remaining.sandbox_id, *expected_sandbox_id);
+            }
+        }
+
+        async fn assert_orphan_count(&self, expected: usize) {
+            assert_eq!(self.orphans.len().await, expected);
+        }
+
+        async fn status_idle_sessions_and_active_runs(&self) -> (Vec<String>, Vec<String>) {
+            let raw = tokio::fs::read_to_string(&self.status_path).await.unwrap();
+            let status: serde_json::Value = serde_json::from_str(&raw).unwrap();
+            let mut sessions: Vec<String> = status
+                .get("idle_vms")
+                .and_then(|v| v.as_array())
+                .map(|idle_vms| {
+                    idle_vms
+                        .iter()
+                        .filter_map(|vm| {
+                            vm.get("session_id")
+                                .and_then(|session| session.as_str())
+                                .map(str::to_string)
+                        })
+                        .collect()
+                })
+                .unwrap_or_default();
+            sessions.sort_unstable();
+            let mut run_ids: Vec<String> = status["active_runs"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .filter_map(|run| {
+                    run.get("run_id")
+                        .and_then(|run_id| run_id.as_str())
+                        .map(str::to_string)
+                })
+                .collect();
+            run_ids.sort_unstable();
+            (sessions, run_ids)
+        }
     }
 
     #[tokio::test]
     async fn orphan_reaper_stale_snapshot_does_not_remove_reinserted_active_run() {
-        let dir = tempfile::tempdir().unwrap();
-        let status_path = dir.path().join("status.json");
-        let status = StatusTracker::new(status_path.clone(), 4, None, None);
-        let orphans = OrphanedActiveRuns::new();
+        let fixture = OrphanReapFixture::new();
         let run_id = RunId::new_v4();
         let stale_sandbox_id = SandboxId::new_v4();
         let current_sandbox_id = SandboxId::new_v4();
-        status.add_run(run_id, stale_sandbox_id).await;
-        orphans.insert(run_id, stale_sandbox_id).await;
-        let stale_records = orphans.snapshot().await;
+        fixture.add_active_orphan(run_id, stale_sandbox_id).await;
+        let stale_records = fixture.orphans.snapshot().await;
 
-        status.add_run(run_id, current_sandbox_id).await;
-        orphans.insert(run_id, current_sandbox_id).await;
+        fixture.add_active_orphan(run_id, current_sandbox_id).await;
 
-        reap_orphaned_active_runs_with_firecrackers(
-            &orphans,
-            &status,
-            stale_records,
-            &[],
-            false,
-            OrphanReapMode::ShutdownFinal.absent_scans_before_remove(),
-        )
-        .await;
+        fixture
+            .reap_records_with_firecrackers(
+                stale_records,
+                &[],
+                false,
+                OrphanReapMode::ShutdownFinal.absent_scans_before_remove(),
+            )
+            .await;
 
-        let (_idle_sessions, active_runs) =
-            status_idle_sessions_and_active_runs(&status_path).await;
-        assert_eq!(active_runs, vec![run_id.to_string()]);
-        let remaining = orphans.snapshot().await;
-        assert_eq!(remaining.len(), 1);
-        assert_eq!(remaining[0].run_id, run_id);
-        assert_eq!(remaining[0].sandbox_id, current_sandbox_id);
+        fixture.assert_status(&[], &[run_id]).await;
+        fixture
+            .assert_orphans(&[(run_id, current_sandbox_id)])
+            .await;
     }
 
     #[tokio::test]
     async fn orphan_reaper_stale_idle_owned_snapshot_does_not_remove_reinserted_active_run() {
-        let dir = tempfile::tempdir().unwrap();
-        let status_path = dir.path().join("status.json");
-        let status = StatusTracker::new(status_path.clone(), 4, None, None);
-        let idle_pool: SharedIdlePool =
-            Arc::new(tokio::sync::Mutex::new(IdlePool::new(IdlePoolConfig {
-                default_timeout: Duration::from_secs(300),
-                max_idle: 10,
-            })));
-        let orphans = OrphanedActiveRuns::new();
+        let fixture = OrphanReapFixture::new();
         let run_id = RunId::new_v4();
         let stale_sandbox_id = SandboxId::new_v4();
         let current_sandbox_id = SandboxId::new_v4();
-        let budget = Arc::new(ResourceBudget::new(2, 4096, 1.0, 0));
-        let lease = ResourceBudget::try_reserve_lease(&budget, 2, 4096).unwrap();
-        let candidate =
-            ParkedIdleCandidate::synthetic_for_test(SyntheticParkedIdleCandidateParts {
-                sandbox: Box::new(MockSandbox::new("stale-idle-owned-reaper")),
-                factory: Arc::new(Box::new(MockSandboxFactory::new()) as Box<dyn SandboxFactory>),
-                session_id: "sess-stale-idle-owned-reaper".into(),
-                sandbox_id: stale_sandbox_id,
-                profile_name: "vm0/default".into(),
-                budget_lease: lease,
-                source_ip: "10.0.0.1".into(),
-                storage_fingerprints: StorageFingerprints::default(),
-            });
-        assert!(matches!(
-            idle_pool.lock().await.park(candidate),
-            ParkResult::Parked
-        ));
-        status.add_run(run_id, stale_sandbox_id).await;
-        orphans.insert(run_id, stale_sandbox_id).await;
-        let stale_records = orphans.snapshot().await;
+        fixture
+            .park_idle_candidate(
+                "sess-stale-idle-owned-reaper",
+                stale_sandbox_id,
+                "stale-idle-owned-reaper",
+            )
+            .await;
+        fixture.add_active_orphan(run_id, stale_sandbox_id).await;
+        let stale_records = fixture.orphans.snapshot().await;
 
-        status.add_run(run_id, current_sandbox_id).await;
-        orphans.insert(run_id, current_sandbox_id).await;
+        fixture.add_active_orphan(run_id, current_sandbox_id).await;
 
-        reap_orphaned_active_run_records(
-            &orphans,
-            &idle_pool,
-            &status,
-            stale_records,
-            OrphanReapMode::Immediate,
-            None,
-        )
-        .await;
+        fixture
+            .reap_records(stale_records, OrphanReapMode::Immediate)
+            .await;
 
-        let (_idle_sessions, active_runs) =
-            status_idle_sessions_and_active_runs(&status_path).await;
-        assert_eq!(active_runs, vec![run_id.to_string()]);
-        let remaining = orphans.snapshot().await;
-        assert_eq!(remaining.len(), 1);
-        assert_eq!(remaining[0].run_id, run_id);
-        assert_eq!(remaining[0].sandbox_id, current_sandbox_id);
+        fixture.assert_status(&[], &[run_id]).await;
+        fixture
+            .assert_orphans(&[(run_id, current_sandbox_id)])
+            .await;
     }
 
     #[tokio::test]
     async fn orphan_reaper_removes_active_run_when_idle_pool_owns_sandbox() {
-        let dir = tempfile::tempdir().unwrap();
-        let status_path = dir.path().join("status.json");
-        let status = StatusTracker::new(status_path.clone(), 4, None, None);
-        let idle_pool: SharedIdlePool =
-            Arc::new(tokio::sync::Mutex::new(IdlePool::new(IdlePoolConfig {
-                default_timeout: Duration::from_secs(300),
-                max_idle: 10,
-            })));
-        let orphans = OrphanedActiveRuns::new();
+        let fixture = OrphanReapFixture::new();
         let run_id = RunId::new_v4();
         let sandbox_id = SandboxId::new_v4();
-        let budget = Arc::new(ResourceBudget::new(2, 4096, 1.0, 0));
-        let lease = ResourceBudget::try_reserve_lease(&budget, 2, 4096).unwrap();
-        let candidate =
-            ParkedIdleCandidate::synthetic_for_test(SyntheticParkedIdleCandidateParts {
-                sandbox: Box::new(MockSandbox::new("idle-owned-reaper")),
-                factory: Arc::new(Box::new(MockSandboxFactory::new()) as Box<dyn SandboxFactory>),
-                session_id: "sess-idle-owned-reaper".into(),
-                sandbox_id,
-                profile_name: "vm0/default".into(),
-                budget_lease: lease,
-                source_ip: "10.0.0.1".into(),
-                storage_fingerprints: StorageFingerprints::default(),
-            });
-        assert!(matches!(
-            idle_pool.lock().await.park(candidate),
-            ParkResult::Parked
-        ));
-        status.add_run(run_id, sandbox_id).await;
-        orphans.insert(run_id, sandbox_id).await;
+        fixture
+            .park_idle_candidate("sess-idle-owned-reaper", sandbox_id, "idle-owned-reaper")
+            .await;
+        fixture.add_active_orphan(run_id, sandbox_id).await;
 
-        reap_orphaned_active_runs(
-            &orphans,
-            &idle_pool,
-            &status,
-            OrphanReapMode::Immediate,
-            None,
-        )
-        .await;
+        fixture.reap(OrphanReapMode::Immediate).await;
 
-        let (idle_sessions, active_runs) = status_idle_sessions_and_active_runs(&status_path).await;
-        assert_eq!(idle_sessions, vec!["sess-idle-owned-reaper"]);
-        assert!(active_runs.is_empty());
-        assert_eq!(orphans.len().await, 0);
+        fixture
+            .assert_status(&["sess-idle-owned-reaper"], &[])
+            .await;
+        fixture.assert_orphan_count(0).await;
     }
 
     #[tokio::test]
     async fn orphan_reaper_immediate_mode_does_not_count_absent_scan() {
-        let dir = tempfile::tempdir().unwrap();
-        let status_path = dir.path().join("status.json");
-        let status = StatusTracker::new(status_path.clone(), 4, None, None);
-        let idle_pool: SharedIdlePool =
-            Arc::new(tokio::sync::Mutex::new(IdlePool::new(IdlePoolConfig {
-                default_timeout: Duration::from_secs(300),
-                max_idle: 10,
-            })));
-        let orphans = OrphanedActiveRuns::new();
+        let fixture = OrphanReapFixture::new();
         let run_id = RunId::new_v4();
         let sandbox_id = SandboxId::new_v4();
-        status.add_run(run_id, sandbox_id).await;
-        orphans.insert(run_id, sandbox_id).await;
+        fixture.add_active_orphan(run_id, sandbox_id).await;
 
-        reap_orphaned_active_runs(
-            &orphans,
-            &idle_pool,
-            &status,
-            OrphanReapMode::Immediate,
-            None,
-        )
-        .await;
-        reap_orphaned_active_runs(
-            &orphans,
-            &idle_pool,
-            &status,
-            OrphanReapMode::ConfirmAbsent,
-            None,
-        )
-        .await;
+        fixture.reap(OrphanReapMode::Immediate).await;
+        fixture.reap(OrphanReapMode::ConfirmAbsent).await;
 
-        let (_idle_sessions, active_runs) =
-            status_idle_sessions_and_active_runs(&status_path).await;
-        assert_eq!(active_runs, vec![run_id.to_string()]);
-        assert_eq!(orphans.len().await, 1);
+        fixture.assert_status(&[], &[run_id]).await;
+        fixture.assert_orphan_count(1).await;
     }
 
     #[tokio::test]
     async fn orphan_reaper_removes_active_run_after_two_absent_scans() {
-        let dir = tempfile::tempdir().unwrap();
-        let status_path = dir.path().join("status.json");
-        let status = StatusTracker::new(status_path.clone(), 4, None, None);
-        let orphans = OrphanedActiveRuns::new();
+        let fixture = OrphanReapFixture::new();
         let run_id = RunId::new_v4();
         let sandbox_id = SandboxId::new_v4();
-        status.add_run(run_id, sandbox_id).await;
-        orphans.insert(run_id, sandbox_id).await;
+        fixture.add_active_orphan(run_id, sandbox_id).await;
 
-        reap_orphaned_active_runs_with_firecrackers(
-            &orphans,
-            &status,
-            orphans.snapshot().await,
-            &[],
-            false,
-            ORPHANED_ACTIVE_RUN_ABSENT_SCANS_BEFORE_REMOVE,
-        )
-        .await;
+        fixture
+            .reap_current_orphans_with_firecrackers(
+                &[],
+                false,
+                ORPHANED_ACTIVE_RUN_ABSENT_SCANS_BEFORE_REMOVE,
+            )
+            .await;
 
-        let (_idle_sessions, active_runs) =
-            status_idle_sessions_and_active_runs(&status_path).await;
-        assert_eq!(active_runs, vec![run_id.to_string()]);
-        assert_eq!(orphans.len().await, 1);
+        fixture.assert_status(&[], &[run_id]).await;
+        fixture.assert_orphan_count(1).await;
 
-        reap_orphaned_active_runs_with_firecrackers(
-            &orphans,
-            &status,
-            orphans.snapshot().await,
-            &[],
-            false,
-            ORPHANED_ACTIVE_RUN_ABSENT_SCANS_BEFORE_REMOVE,
-        )
-        .await;
+        fixture
+            .reap_current_orphans_with_firecrackers(
+                &[],
+                false,
+                ORPHANED_ACTIVE_RUN_ABSENT_SCANS_BEFORE_REMOVE,
+            )
+            .await;
 
-        let (_idle_sessions, active_runs) =
-            status_idle_sessions_and_active_runs(&status_path).await;
-        assert!(active_runs.is_empty());
-        assert_eq!(orphans.len().await, 0);
+        fixture.assert_status(&[], &[]).await;
+        fixture.assert_orphan_count(0).await;
     }
 
     #[tokio::test]
     async fn orphan_reaper_shutdown_final_removes_active_run_after_one_absent_scan() {
-        let dir = tempfile::tempdir().unwrap();
-        let status_path = dir.path().join("status.json");
-        let status = StatusTracker::new(status_path.clone(), 4, None, None);
-        let orphans = OrphanedActiveRuns::new();
+        let fixture = OrphanReapFixture::new();
         let run_id = RunId::new_v4();
         let sandbox_id = SandboxId::new_v4();
-        status.add_run(run_id, sandbox_id).await;
-        orphans.insert(run_id, sandbox_id).await;
+        fixture.add_active_orphan(run_id, sandbox_id).await;
 
-        reap_orphaned_active_runs_with_firecrackers(
-            &orphans,
-            &status,
-            orphans.snapshot().await,
-            &[],
-            false,
-            OrphanReapMode::ShutdownFinal.absent_scans_before_remove(),
-        )
-        .await;
+        fixture
+            .reap_current_orphans_with_firecrackers(
+                &[],
+                false,
+                OrphanReapMode::ShutdownFinal.absent_scans_before_remove(),
+            )
+            .await;
 
-        let (_idle_sessions, active_runs) =
-            status_idle_sessions_and_active_runs(&status_path).await;
-        assert!(active_runs.is_empty());
-        assert_eq!(orphans.len().await, 0);
+        fixture.assert_status(&[], &[]).await;
+        fixture.assert_orphan_count(0).await;
     }
 
     #[tokio::test]
     async fn orphan_reaper_defers_incomplete_discovery_without_resetting_absent_confirmation() {
-        let dir = tempfile::tempdir().unwrap();
-        let status_path = dir.path().join("status.json");
-        let status = StatusTracker::new(status_path.clone(), 4, None, None);
-        let orphans = OrphanedActiveRuns::new();
+        let fixture = OrphanReapFixture::new();
         let run_id = RunId::new_v4();
         let sandbox_id = SandboxId::new_v4();
-        status.add_run(run_id, sandbox_id).await;
-        orphans.insert(run_id, sandbox_id).await;
+        fixture.add_active_orphan(run_id, sandbox_id).await;
 
-        reap_orphaned_active_runs_with_firecrackers(
-            &orphans,
-            &status,
-            orphans.snapshot().await,
-            &[],
-            false,
-            ORPHANED_ACTIVE_RUN_ABSENT_SCANS_BEFORE_REMOVE,
-        )
-        .await;
+        fixture
+            .reap_current_orphans_with_firecrackers(
+                &[],
+                false,
+                ORPHANED_ACTIVE_RUN_ABSENT_SCANS_BEFORE_REMOVE,
+            )
+            .await;
         let unresolved_firecracker = process::FirecrackerProcessInfo {
             pid: 1234,
             ppid: Some(1),
             sandbox_id: "pid-1234".to_string(),
             base_dir: None,
         };
-        reap_orphaned_active_runs_with_firecrackers(
-            &orphans,
-            &status,
-            orphans.snapshot().await,
-            &[unresolved_firecracker],
-            true,
-            ORPHANED_ACTIVE_RUN_ABSENT_SCANS_BEFORE_REMOVE,
-        )
-        .await;
+        fixture
+            .reap_current_orphans_with_firecrackers(
+                &[unresolved_firecracker],
+                true,
+                ORPHANED_ACTIVE_RUN_ABSENT_SCANS_BEFORE_REMOVE,
+            )
+            .await;
 
-        let (_idle_sessions, active_runs) =
-            status_idle_sessions_and_active_runs(&status_path).await;
-        assert_eq!(active_runs, vec![run_id.to_string()]);
-        assert_eq!(orphans.len().await, 1);
+        fixture.assert_status(&[], &[run_id]).await;
+        fixture.assert_orphan_count(1).await;
 
-        reap_orphaned_active_runs_with_firecrackers(
-            &orphans,
-            &status,
-            orphans.snapshot().await,
-            &[],
-            false,
-            ORPHANED_ACTIVE_RUN_ABSENT_SCANS_BEFORE_REMOVE,
-        )
-        .await;
-        let (_idle_sessions, active_runs) =
-            status_idle_sessions_and_active_runs(&status_path).await;
+        fixture
+            .reap_current_orphans_with_firecrackers(
+                &[],
+                false,
+                ORPHANED_ACTIVE_RUN_ABSENT_SCANS_BEFORE_REMOVE,
+            )
+            .await;
+        let (_idle_sessions, active_runs) = fixture.status_idle_sessions_and_active_runs().await;
         assert!(
             active_runs.is_empty(),
             "incomplete discovery should not count as absent, but should not globally reset prior conclusive absence"
         );
-        assert_eq!(orphans.len().await, 0);
+        fixture.assert_orphan_count(0).await;
     }
 
     #[tokio::test]
     async fn orphan_reaper_preserves_active_run_when_firecracker_live() {
-        let dir = tempfile::tempdir().unwrap();
-        let status_path = dir.path().join("status.json");
-        let status = StatusTracker::new(status_path.clone(), 4, None, None);
-        let orphans = OrphanedActiveRuns::new();
+        let fixture = OrphanReapFixture::new();
         let run_id = RunId::new_v4();
         let sandbox_id = SandboxId::new_v4();
-        status.add_run(run_id, sandbox_id).await;
-        orphans.insert(run_id, sandbox_id).await;
+        fixture.add_active_orphan(run_id, sandbox_id).await;
         let firecracker = process::FirecrackerProcessInfo {
             pid: 1234,
             ppid: Some(1),
@@ -691,19 +705,15 @@ mod tests {
             base_dir: None,
         };
 
-        reap_orphaned_active_runs_with_firecrackers(
-            &orphans,
-            &status,
-            orphans.snapshot().await,
-            &[firecracker],
-            false,
-            ORPHANED_ACTIVE_RUN_ABSENT_SCANS_BEFORE_REMOVE,
-        )
-        .await;
+        fixture
+            .reap_current_orphans_with_firecrackers(
+                &[firecracker],
+                false,
+                ORPHANED_ACTIVE_RUN_ABSENT_SCANS_BEFORE_REMOVE,
+            )
+            .await;
 
-        let (_idle_sessions, active_runs) =
-            status_idle_sessions_and_active_runs(&status_path).await;
-        assert_eq!(active_runs, vec![run_id.to_string()]);
-        assert_eq!(orphans.len().await, 1);
+        fixture.assert_status(&[], &[run_id]).await;
+        fixture.assert_orphan_count(1).await;
     }
 }

--- a/crates/runner/src/cmd/start/orphan_reap.rs
+++ b/crates/runner/src/cmd/start/orphan_reap.rs
@@ -718,6 +718,64 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn orphan_reaper_live_firecracker_resets_absent_confirmation() {
+        let fixture = OrphanReapFixture::new();
+        let run_id = RunId::new_v4();
+        let sandbox_id = SandboxId::new_v4();
+        fixture.add_active_orphan(run_id, sandbox_id).await;
+
+        fixture
+            .reap_current_orphans_with_firecrackers(
+                &[],
+                false,
+                ORPHANED_ACTIVE_RUN_ABSENT_SCANS_BEFORE_REMOVE,
+            )
+            .await;
+
+        fixture.assert_status(&[], &[run_id]).await;
+        fixture.assert_orphan_count(1).await;
+
+        let firecracker = process::FirecrackerProcessInfo {
+            pid: 1234,
+            ppid: Some(1),
+            sandbox_id: sandbox_id.to_string(),
+            base_dir: None,
+        };
+        fixture
+            .reap_current_orphans_with_firecrackers(
+                &[firecracker],
+                false,
+                ORPHANED_ACTIVE_RUN_ABSENT_SCANS_BEFORE_REMOVE,
+            )
+            .await;
+
+        fixture.assert_status(&[], &[run_id]).await;
+        fixture.assert_orphan_count(1).await;
+
+        fixture
+            .reap_current_orphans_with_firecrackers(
+                &[],
+                false,
+                ORPHANED_ACTIVE_RUN_ABSENT_SCANS_BEFORE_REMOVE,
+            )
+            .await;
+
+        fixture.assert_status(&[], &[run_id]).await;
+        fixture.assert_orphan_count(1).await;
+
+        fixture
+            .reap_current_orphans_with_firecrackers(
+                &[],
+                false,
+                ORPHANED_ACTIVE_RUN_ABSENT_SCANS_BEFORE_REMOVE,
+            )
+            .await;
+
+        fixture.assert_status(&[], &[]).await;
+        fixture.assert_orphan_count(0).await;
+    }
+
+    #[tokio::test]
     async fn orphan_reaper_preserves_active_run_when_firecracker_live() {
         let fixture = OrphanReapFixture::new();
         let run_id = RunId::new_v4();

--- a/crates/runner/src/cmd/start/orphan_reap.rs
+++ b/crates/runner/src/cmd/start/orphan_reap.rs
@@ -386,10 +386,23 @@ mod tests {
                     source_ip: "10.0.0.1".into(),
                     storage_fingerprints: StorageFingerprints::default(),
                 });
-            assert!(matches!(
-                self.idle_pool.lock().await.park(candidate),
-                ParkResult::Parked
-            ));
+            let result = {
+                let mut idle_pool = self.idle_pool.lock().await;
+                idle_pool.park(candidate)
+            };
+            match result {
+                ParkResult::Parked => {}
+                ParkResult::Replaced(job) => {
+                    job.run().await;
+                    panic!("expected synthetic idle candidate to park without replacement");
+                }
+                ParkResult::Rejected(rejected) => {
+                    let (payload, lease) = rejected.into_active_destroy_parts();
+                    let _ = payload.stop_and_destroy().await;
+                    drop(lease);
+                    panic!("expected synthetic idle candidate to be accepted by the idle pool");
+                }
+            }
         }
 
         async fn reap(&self, mode: OrphanReapMode) {

--- a/crates/runner/src/cmd/start/orphan_reap.rs
+++ b/crates/runner/src/cmd/start/orphan_reap.rs
@@ -935,6 +935,64 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn orphan_reaper_live_firecracker_resets_absent_confirmation_when_discovery_incomplete() {
+        let fixture = OrphanReapFixture::new();
+        let run_id = RunId::new_v4();
+        let sandbox_id = SandboxId::new_v4();
+        fixture.add_active_orphan(run_id, sandbox_id).await;
+
+        fixture
+            .reap_current_orphans_with_firecrackers(
+                &[],
+                false,
+                ORPHANED_ACTIVE_RUN_ABSENT_SCANS_BEFORE_REMOVE,
+            )
+            .await;
+
+        fixture.assert_status(&[], &[(run_id, sandbox_id)]).await;
+        fixture.assert_orphan_count(1).await;
+
+        let firecracker = process::FirecrackerProcessInfo {
+            pid: 1234,
+            ppid: Some(1),
+            sandbox_id: sandbox_id.to_string(),
+            base_dir: None,
+        };
+        fixture
+            .reap_current_orphans_with_firecrackers(
+                &[firecracker],
+                true,
+                ORPHANED_ACTIVE_RUN_ABSENT_SCANS_BEFORE_REMOVE,
+            )
+            .await;
+
+        fixture.assert_status(&[], &[(run_id, sandbox_id)]).await;
+        fixture.assert_orphan_count(1).await;
+
+        fixture
+            .reap_current_orphans_with_firecrackers(
+                &[],
+                false,
+                ORPHANED_ACTIVE_RUN_ABSENT_SCANS_BEFORE_REMOVE,
+            )
+            .await;
+
+        fixture.assert_status(&[], &[(run_id, sandbox_id)]).await;
+        fixture.assert_orphan_count(1).await;
+
+        fixture
+            .reap_current_orphans_with_firecrackers(
+                &[],
+                false,
+                ORPHANED_ACTIVE_RUN_ABSENT_SCANS_BEFORE_REMOVE,
+            )
+            .await;
+
+        fixture.assert_status(&[], &[]).await;
+        fixture.assert_orphan_count(0).await;
+    }
+
+    #[tokio::test]
     async fn orphan_reaper_preserves_active_run_when_firecracker_live() {
         let fixture = OrphanReapFixture::new();
         let run_id = RunId::new_v4();

--- a/crates/runner/src/cmd/start/orphan_reap.rs
+++ b/crates/runner/src/cmd/start/orphan_reap.rs
@@ -469,22 +469,22 @@ mod tests {
 
         async fn assert_status(
             &self,
-            expected_idle_sessions: &[&str],
-            expected_active_runs: &[RunId],
+            expected_idle_vms: &[(&str, SandboxId)],
+            expected_active_runs: &[(RunId, SandboxId)],
         ) {
-            let (idle_sessions, active_runs) = self.status_idle_sessions_and_active_runs().await;
-            let mut expected_idle_sessions = expected_idle_sessions
+            let (idle_vms, active_runs) = self.status_idle_vms_and_active_runs().await;
+            let mut expected_idle_vms = expected_idle_vms
                 .iter()
-                .map(|session_id| (*session_id).to_string())
+                .map(|(session_id, sandbox_id)| ((*session_id).to_string(), sandbox_id.to_string()))
                 .collect::<Vec<_>>();
-            expected_idle_sessions.sort_unstable();
+            expected_idle_vms.sort_unstable();
             let mut expected_active_runs = expected_active_runs
                 .iter()
-                .map(RunId::to_string)
+                .map(|(run_id, sandbox_id)| (run_id.to_string(), sandbox_id.to_string()))
                 .collect::<Vec<_>>();
             expected_active_runs.sort_unstable();
 
-            assert_eq!(idle_sessions, expected_idle_sessions);
+            assert_eq!(idle_vms, expected_idle_vms);
             assert_eq!(active_runs, expected_active_runs);
         }
 
@@ -503,36 +503,40 @@ mod tests {
             assert_eq!(self.orphans.len().await, expected);
         }
 
-        async fn status_idle_sessions_and_active_runs(&self) -> (Vec<String>, Vec<String>) {
+        async fn status_idle_vms_and_active_runs(
+            &self,
+        ) -> (Vec<(String, String)>, Vec<(String, String)>) {
             let raw = tokio::fs::read_to_string(&self.status_path).await.unwrap();
             let status: serde_json::Value = serde_json::from_str(&raw).unwrap();
-            let mut sessions: Vec<String> = status
+            let mut idle_vms: Vec<(String, String)> = status
                 .get("idle_vms")
                 .and_then(|v| v.as_array())
                 .map(|idle_vms| {
                     idle_vms
                         .iter()
                         .filter_map(|vm| {
-                            vm.get("session_id")
-                                .and_then(|session| session.as_str())
-                                .map(str::to_string)
+                            let session_id =
+                                vm.get("session_id").and_then(|session| session.as_str())?;
+                            let sandbox_id =
+                                vm.get("sandbox_id").and_then(|sandbox| sandbox.as_str())?;
+                            Some((session_id.to_string(), sandbox_id.to_string()))
                         })
                         .collect()
                 })
                 .unwrap_or_default();
-            sessions.sort_unstable();
-            let mut run_ids: Vec<String> = status["active_runs"]
+            idle_vms.sort_unstable();
+            let mut active_runs: Vec<(String, String)> = status["active_runs"]
                 .as_array()
                 .unwrap()
                 .iter()
                 .filter_map(|run| {
-                    run.get("run_id")
-                        .and_then(|run_id| run_id.as_str())
-                        .map(str::to_string)
+                    let run_id = run.get("run_id").and_then(|run_id| run_id.as_str())?;
+                    let sandbox_id = run.get("sandbox_id").and_then(|sandbox| sandbox.as_str())?;
+                    Some((run_id.to_string(), sandbox_id.to_string()))
                 })
                 .collect();
-            run_ids.sort_unstable();
-            (sessions, run_ids)
+            active_runs.sort_unstable();
+            (idle_vms, active_runs)
         }
     }
 
@@ -556,7 +560,9 @@ mod tests {
             )
             .await;
 
-        fixture.assert_status(&[], &[run_id]).await;
+        fixture
+            .assert_status(&[], &[(run_id, current_sandbox_id)])
+            .await;
         fixture
             .assert_orphans(&[(run_id, current_sandbox_id)])
             .await;
@@ -584,7 +590,9 @@ mod tests {
             .reap_records(stale_records, OrphanReapMode::Immediate)
             .await;
 
-        fixture.assert_status(&[], &[run_id]).await;
+        fixture
+            .assert_status(&[], &[(run_id, current_sandbox_id)])
+            .await;
         fixture
             .assert_orphans(&[(run_id, current_sandbox_id)])
             .await;
@@ -603,7 +611,7 @@ mod tests {
         fixture.reap(OrphanReapMode::Immediate).await;
 
         fixture
-            .assert_status(&["sess-idle-owned-reaper"], &[])
+            .assert_status(&[("sess-idle-owned-reaper", sandbox_id)], &[])
             .await;
         fixture.assert_orphan_count(0).await;
     }
@@ -618,7 +626,7 @@ mod tests {
         fixture.reap(OrphanReapMode::Immediate).await;
         fixture.reap(OrphanReapMode::ConfirmAbsent).await;
 
-        fixture.assert_status(&[], &[run_id]).await;
+        fixture.assert_status(&[], &[(run_id, sandbox_id)]).await;
         fixture.assert_orphan_count(1).await;
     }
 
@@ -637,7 +645,7 @@ mod tests {
             )
             .await;
 
-        fixture.assert_status(&[], &[run_id]).await;
+        fixture.assert_status(&[], &[(run_id, sandbox_id)]).await;
         fixture.assert_orphan_count(1).await;
 
         fixture
@@ -699,7 +707,7 @@ mod tests {
             )
             .await;
 
-        fixture.assert_status(&[], &[run_id]).await;
+        fixture.assert_status(&[], &[(run_id, sandbox_id)]).await;
         fixture.assert_orphan_count(1).await;
 
         fixture
@@ -709,7 +717,7 @@ mod tests {
                 ORPHANED_ACTIVE_RUN_ABSENT_SCANS_BEFORE_REMOVE,
             )
             .await;
-        let (_idle_sessions, active_runs) = fixture.status_idle_sessions_and_active_runs().await;
+        let (_idle_vms, active_runs) = fixture.status_idle_vms_and_active_runs().await;
         assert!(
             active_runs.is_empty(),
             "incomplete discovery should not count as absent, but should not globally reset prior conclusive absence"
@@ -732,7 +740,7 @@ mod tests {
             )
             .await;
 
-        fixture.assert_status(&[], &[run_id]).await;
+        fixture.assert_status(&[], &[(run_id, sandbox_id)]).await;
         fixture.assert_orphan_count(1).await;
 
         let firecracker = process::FirecrackerProcessInfo {
@@ -749,7 +757,7 @@ mod tests {
             )
             .await;
 
-        fixture.assert_status(&[], &[run_id]).await;
+        fixture.assert_status(&[], &[(run_id, sandbox_id)]).await;
         fixture.assert_orphan_count(1).await;
 
         fixture
@@ -760,7 +768,7 @@ mod tests {
             )
             .await;
 
-        fixture.assert_status(&[], &[run_id]).await;
+        fixture.assert_status(&[], &[(run_id, sandbox_id)]).await;
         fixture.assert_orphan_count(1).await;
 
         fixture
@@ -796,7 +804,7 @@ mod tests {
             )
             .await;
 
-        fixture.assert_status(&[], &[run_id]).await;
+        fixture.assert_status(&[], &[(run_id, sandbox_id)]).await;
         fixture.assert_orphan_count(1).await;
     }
 }

--- a/crates/runner/src/cmd/start/orphan_reap.rs
+++ b/crates/runner/src/cmd/start/orphan_reap.rs
@@ -394,6 +394,7 @@ mod tests {
                 ParkResult::Parked => {}
                 ParkResult::Replaced(job) => {
                     job.run().await;
+                    self.destroy_all_idle_entries().await;
                     panic!("expected synthetic idle candidate to park without replacement");
                 }
                 ParkResult::Rejected(rejected) => {
@@ -402,6 +403,16 @@ mod tests {
                     drop(lease);
                     panic!("expected synthetic idle candidate to be accepted by the idle pool");
                 }
+            }
+        }
+
+        async fn destroy_all_idle_entries(&self) {
+            let jobs = {
+                let mut idle_pool = self.idle_pool.lock().await;
+                idle_pool.drain()
+            };
+            for job in jobs {
+                job.run().await;
             }
         }
 

--- a/crates/runner/src/cmd/start/orphan_reap.rs
+++ b/crates/runner/src/cmd/start/orphan_reap.rs
@@ -401,6 +401,7 @@ mod tests {
                     let (payload, lease) = rejected.into_active_destroy_parts();
                     let _ = payload.stop_and_destroy().await;
                     drop(lease);
+                    self.destroy_all_idle_entries().await;
                     panic!("expected synthetic idle candidate to be accepted by the idle pool");
                 }
             }

--- a/crates/runner/src/cmd/start/orphan_reap.rs
+++ b/crates/runner/src/cmd/start/orphan_reap.rs
@@ -422,6 +422,21 @@ mod tests {
                 .await;
         }
 
+        async fn reap_with_discovery(
+            &self,
+            mode: OrphanReapMode,
+            discovery: &OrphanReapProcessDiscovery,
+        ) {
+            reap_orphaned_active_runs(
+                &self.orphans,
+                &self.idle_pool,
+                &self.status,
+                mode,
+                Some(discovery),
+            )
+            .await;
+        }
+
         async fn reap_records(&self, records: Vec<OrphanedActiveRun>, mode: OrphanReapMode) {
             reap_orphaned_active_run_records(
                 &self.orphans,
@@ -614,6 +629,42 @@ mod tests {
 
         fixture
             .assert_status(&[("sess-idle-owned-reaper", sandbox_id)], &[])
+            .await;
+        fixture.assert_orphan_count(0).await;
+        fixture.destroy_all_idle_entries().await;
+    }
+
+    #[tokio::test]
+    async fn orphan_reaper_reconciles_mixed_idle_owned_and_absent_records() {
+        let fixture = OrphanReapFixture::new();
+        let idle_run_id = RunId::new_v4();
+        let idle_sandbox_id = SandboxId::new_v4();
+        let absent_run_id = RunId::new_v4();
+        let absent_sandbox_id = SandboxId::new_v4();
+        fixture
+            .park_idle_candidate(
+                "sess-mixed-idle",
+                idle_sandbox_id,
+                "mixed-idle-owned-reaper",
+            )
+            .await;
+        fixture
+            .add_active_orphan(idle_run_id, idle_sandbox_id)
+            .await;
+        fixture
+            .add_active_orphan(absent_run_id, absent_sandbox_id)
+            .await;
+        let discovery = OrphanReapProcessDiscovery {
+            firecrackers: Arc::new(Vec::new()),
+            incomplete_for_current_runner: false,
+        };
+
+        fixture
+            .reap_with_discovery(OrphanReapMode::ShutdownFinal, &discovery)
+            .await;
+
+        fixture
+            .assert_status(&[("sess-mixed-idle", idle_sandbox_id)], &[])
             .await;
         fixture.assert_orphan_count(0).await;
         fixture.destroy_all_idle_entries().await;

--- a/crates/runner/src/cmd/start/orphan_reap.rs
+++ b/crates/runner/src/cmd/start/orphan_reap.rs
@@ -566,6 +566,8 @@ mod tests {
         fixture
             .assert_orphans(&[(run_id, current_sandbox_id)])
             .await;
+
+        fixture.destroy_all_idle_entries().await;
     }
 
     #[tokio::test]
@@ -614,6 +616,7 @@ mod tests {
             .assert_status(&[("sess-idle-owned-reaper", sandbox_id)], &[])
             .await;
         fixture.assert_orphan_count(0).await;
+        fixture.destroy_all_idle_entries().await;
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- add a test-local orphan reaper fixture for shared status/orphan/idle-pool setup
- centralize synthetic idle candidate setup and repeated status/orphan assertions
- preserve existing orphan reaper lifecycle test cases and scenario-critical ordering

## Tests
- cargo fmt --manifest-path crates/Cargo.toml --all --check
- cargo test --manifest-path crates/Cargo.toml -p runner orphan_reaper
- cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets -- -D warnings

Closes #13584