### PR TITLE
fix(i18n): fill missing de/es/ja translations

### DIFF
--- a/turbo/apps/web/messages/de.json
+++ b/turbo/apps/web/messages/de.json
@@ -1198,7 +1198,7 @@
           },
           {
             "name": "Zero",
-            "text": "Scheduled. Running weekdays at 08:30.\n\nRun from this morning:\n*GitHub* - 96 PRs merged today vs 14.3 avg 🔴 572% spike (coordinated test refactor). Issues closed: 71 vs 28.6 avg 🟢.\n*Linear* - 0 issues created this week, 3 in backlog.\n*Sentry* - connector not configured.\n*Plausible* - connector not configured."
+            "text": "Geplant. Läuft werktags um 08:30.\n\nLauf von heute Morgen:\n*GitHub* – 96 PRs heute gemergt vs. Durchschnitt 14,3 🔴 572 % Anstieg (koordinierter Test-Refactor). Geschlossene Issues: 71 vs. Durchschnitt 28,6 🟢.\n*Linear* – diese Woche 0 Issues erstellt, 3 im Backlog.\n*Sentry* – Connector nicht konfiguriert.\n*Plausible* – Connector nicht konfiguriert."
           }
         ],
         "steps": [
@@ -1289,7 +1289,7 @@
           },
           {
             "name": "Zero",
-            "text": "Customer 360 - Acme Corp\n\nOverview: Enterprise, 6 months in, primary contact: James Chen (CTO)\nRecent Activity: 3 email threads Apr 1–10, last meeting Apr 8, 2 open Linear issues\nOpen Items: Unanswered email Apr 9 re: API limits, feature request #812 unassigned\n\nSummary:\n• Health: Engaged but technical blockers slowing adoption\n• Risk: No response to Apr 9 email for 5 days\n• Next: Follow up on API limits today, share #812 resolution timeline"
+            "text": "Customer 360 – Acme Corp\n\nÜberblick: Enterprise, seit 6 Monaten Kunde, Hauptkontakt: James Chen (CTO)\nLetzte Aktivität: 3 E-Mail-Threads vom 1.–10. April, letztes Meeting 8. April, 2 offene Linear-Issues\nOffene Punkte: Unbeantwortete E-Mail vom 9. April zu API-Limits, Feature-Request #812 nicht zugewiesen\n\nFazit:\n• Health: Engagiert, aber technische Blocker bremsen die Adoption\n• Risiko: Seit 5 Tagen keine Antwort auf die E-Mail vom 9. April\n• Nächste Schritte: Heute zu API-Limits nachfassen, Zeitplan für #812 teilen"
           }
         ],
         "steps": [
@@ -1376,7 +1376,7 @@
           },
           {
             "name": "Zero",
-            "text": "No digest sent Apr 13 - no topics met the 2-source threshold."
+            "text": "Am 13. April kein Digest versendet – keine Themen erreichten die 2-Quellen-Schwelle."
           }
         ],
         "steps": [
@@ -1430,19 +1430,19 @@
       "pr-review": {
         "title": "KI-gestütztes Pull-Request-Code-Review",
         "description": "Zero liest Ihren PR-Diff, markiert kritische Probleme als P0, bewertet Verbesserungsmöglichkeiten und meldet sie in Slack, damit Ihr Team vor dem Merge handeln kann.",
-        "timeSaved": "~30 min saved per PR",
-        "scenario": "PRs pile up. Reviewers are busy. Someone hits 'approve' to clear their queue and a subtle bug ships. Zero gives every PR a thorough read without the queue. Point it at any PR number, and it returns a structured review - critical issues that must be fixed before merge, plus lower-priority suggestions - posted directly in Slack.",
+        "timeSaved": "~30 Min. pro PR gespart",
+        "scenario": "PRs stapeln sich. Reviewer sind beschäftigt. Jemand klickt 'genehmigen', um die Warteschlange zu leeren, und ein subtiler Bug geht in Produktion. Zero liest jeden PR gründlich – ohne Warteschlange. Zeigen Sie auf eine beliebige PR-Nummer, und Zero liefert ein strukturiertes Review – kritische Probleme, die vor dem Merge behoben werden müssen, plus Verbesserungsvorschläge mit niedrigerer Priorität – direkt in Slack gepostet.",
         "promptVariants": [
           {
-            "label": "Standard review",
+            "label": "Standard-Review",
             "prompt": "@Zero review vm0-ai/vm0#8886"
           },
           {
-            "label": "Focused review",
+            "label": "Fokussiertes Review",
             "prompt": "@Zero review vm0-ai/vm0#9215 - focus on the auth middleware changes and any potential security issues."
           },
           {
-            "label": "Re-review after fixes",
+            "label": "Re-Review nach Fixes",
             "prompt": "@Zero re-review vm0-ai/vm0#8886 - I pushed a second commit addressing your P0 feedback."
           }
         ],
@@ -1453,70 +1453,70 @@
           },
           {
             "name": "Zero",
-            "text": "Review for vm0-ai/vm0#8886 - 1 commit reviewed.\n\nP0 (must fix before merge):\n• createPlainSupportThread has 5 paths that return false instead of throwing - silent failures in prod.\n\nP1 (improvement):\n• Error messages don't include the SDK error code - harder to debug from logs."
+            "text": "Review für vm0-ai/vm0#8886 – 1 Commit überprüft.\n\nP0 (vor dem Merge zu beheben):\n• createPlainSupportThread hat 5 Pfade, die false zurückgeben statt zu werfen – stille Fehler in Produktion.\n\nP1 (Verbesserung):\n• Fehlermeldungen enthalten keinen SDK-Fehlercode – erschwert das Debuggen aus Logs."
           }
         ],
         "steps": [
           {
-            "title": "Zero reads the full diff",
-            "description": "Zero fetches the PR via GitHub, reads every changed file, and understands the intent of the change from the PR title, description, and commit messages."
+            "title": "Zero liest den vollständigen Diff",
+            "description": "Zero ruft den PR über GitHub ab, liest jede geänderte Datei und versteht die Absicht der Änderung anhand von PR-Titel, Beschreibung und Commit-Nachrichten."
           },
           {
-            "title": "Zero ranks issues by severity",
-            "description": "Findings are classified as P0 (must fix before merge - bugs, security issues, silent failures) or P1 (improvements - better error handling, test coverage, naming)."
+            "title": "Zero priorisiert Probleme nach Schweregrad",
+            "description": "Findings werden als P0 (vor dem Merge zu beheben – Bugs, Sicherheitsprobleme, stille Fehler) oder P1 (Verbesserungen – bessere Fehlerbehandlung, Testabdeckung, Benennung) klassifiziert."
           },
           {
-            "title": "Review posted to Slack",
-            "description": "Zero posts the full review in the Slack thread where it was requested, with specific file references and line numbers so the author knows exactly what to fix."
+            "title": "Review in Slack veröffentlicht",
+            "description": "Zero postet das vollständige Review im Slack-Thread, in dem es angefordert wurde – mit konkreten Dateiverweisen und Zeilennummern, damit der Autor genau weiß, was zu beheben ist."
           }
         ],
         "nextActions": [
           {
-            "title": "Create a GitHub issue from a finding",
-            "description": "Log a P0 as a tracked issue if it can't be fixed immediately",
+            "title": "GitHub-Issue aus einem Finding erstellen",
+            "description": "Loggen Sie ein P0 als verfolgtes Issue, wenn es nicht sofort behoben werden kann",
             "examplePrompt": "@Zero create a GitHub issue for the P0 in that review. Assign to Ethan and label as bug, priority-high."
           },
           {
-            "title": "Re-review after changes",
-            "description": "Verify that P0 feedback was addressed",
+            "title": "Re-Review nach Änderungen",
+            "description": "Prüfen, ob das P0-Feedback umgesetzt wurde",
             "examplePrompt": "@Zero re-review #8886, second commit - confirm the P0 is resolved."
           },
           {
-            "title": "Check CI status",
-            "description": "See if all checks pass before merging",
+            "title": "CI-Status prüfen",
+            "description": "Sehen, ob alle Checks vor dem Merge bestehen",
             "examplePrompt": "@Zero what's the CI status on vm0-ai/vm0#8886? Is it safe to merge?"
           }
         ],
         "integrations": [
           {
-            "description": "GitHub is required. Zero needs read access to pull requests and the full diff."
+            "description": "GitHub ist erforderlich. Zero benötigt Lesezugriff auf Pull Requests und den vollständigen Diff."
           },
           {
-            "description": "Slack is where the review request is made and where findings are delivered."
+            "description": "Slack ist der Ort, an dem das Review angefordert und die Findings geliefert werden."
           }
         ],
         "tips": [
-          "Include the specific concern in your prompt - 'focus on auth changes' or 'check for race conditions' - to get a more targeted review than a general diff scan.",
-          "Use re-review for iterative PRs. After the author pushes fixes, ask Zero to re-check only the P0 items to confirm they're resolved.",
-          "Set a team norm: Zero review before any merge to main. It catches the class of issues that slip through async human review."
+          "Geben Sie das konkrete Anliegen in Ihrem Prompt an – 'Fokus auf Auth-Änderungen' oder 'auf Race Conditions prüfen' – für ein gezielteres Review als ein allgemeiner Diff-Scan.",
+          "Nutzen Sie Re-Review für iterative PRs. Nachdem der Autor Fixes gepusht hat, bitten Sie Zero, nur die P0-Items erneut zu prüfen, um zu bestätigen, dass sie behoben sind.",
+          "Etablieren Sie eine Team-Regel: Zero-Review vor jedem Merge auf main. Es fängt die Art von Problemen ab, die durch asynchrones Human-Review schlüpfen."
         ]
       },
       "api-performance": {
         "title": "API-Performance-Engpässe untersuchen",
         "description": "Zero holt TP95-Daten aus Axiom, zeigt die langsamsten Endpoints, identifiziert Muster und erstellt ein GitHub-Issue mit den Ergebnissen aus einer Slack-Nachricht.",
-        "timeSaved": "~45 min saved",
-        "scenario": "TP95 spikes don't always page you. They sit in your metrics dashboards, quietly degrading user experience while your team is focused on shipping. Zero makes it easy to check any endpoint's performance on demand - pull the last 7 days of TP95 data, see which requests are slow, and get a GitHub issue filed automatically so nothing gets dropped.",
+        "timeSaved": "~45 Min. gespart",
+        "scenario": "TP95-Spitzen lösen nicht immer einen Pager aus. Sie sitzen in Ihren Metrik-Dashboards und verschlechtern leise die Nutzererfahrung, während Ihr Team auf das Shipping fokussiert ist. Zero macht es einfach, die Performance jedes Endpoints auf Anfrage zu prüfen – die letzten 7 Tage TP95-Daten abrufen, sehen, welche Requests langsam sind, und automatisch ein GitHub-Issue anlegen lassen, damit nichts verloren geht.",
         "promptVariants": [
           {
-            "label": "TP95 check",
+            "label": "TP95-Check",
             "prompt": "@Zero check Axiom for the POST /api/zero/runs endpoint - show me the TP95 for the last 7 days and flag any events over 5s."
           },
           {
-            "label": "File an issue",
+            "label": "Issue anlegen",
             "prompt": "@Zero pull Axiom TP95 for /api/zero/runs over the last 7 days and create a GitHub issue with the findings, assigned to Lancy."
           },
           {
-            "label": "Compare endpoints",
+            "label": "Endpoints vergleichen",
             "prompt": "@Zero compare the last 7 days of TP95 for /api/zero/runs vs /api/chat/send on Axiom. Which is slower and what's the pattern?"
           }
         ],
@@ -1527,70 +1527,70 @@
           },
           {
             "name": "Zero",
-            "text": "POST /api/zero/runs - 7-day TP95 summary:\n\nWorst: 6,857ms on Apr 12\nSlow events (>5s): 14 total\nRoot cause: sync dispatch pipeline blocks the response - it waits for sandbox allocation before returning.\n\nGitHub issue filed: vm0-ai/vm0#9682, assigned to Lancy."
+            "text": "POST /api/zero/runs – TP95-Zusammenfassung der letzten 7 Tage:\n\nSchlechtester Wert: 6.857 ms am 12. April\nLangsame Events (>5 s): 14 gesamt\nUrsache: Die synchrone Dispatch-Pipeline blockiert die Antwort – sie wartet auf die Sandbox-Zuweisung, bevor sie zurückkehrt.\n\nGitHub-Issue angelegt: vm0-ai/vm0#9682, zugewiesen an Lancy."
           }
         ],
         "steps": [
           {
-            "title": "Zero queries Axiom for the endpoint",
-            "description": "Zero pulls all request events for the specified endpoint over the time window, computing TP50, TP95, and TP99 per day."
+            "title": "Zero fragt Axiom für den Endpoint ab",
+            "description": "Zero zieht alle Request-Events für den angegebenen Endpoint im Zeitfenster und berechnet TP50, TP95 und TP99 pro Tag."
           },
           {
-            "title": "Zero surfaces slow events",
-            "description": "Zero filters for events above the threshold (default: 5 seconds), groups them by time of day and error pattern, and identifies the likely root cause."
+            "title": "Zero hebt langsame Events hervor",
+            "description": "Zero filtert Events oberhalb des Schwellenwerts (Standard: 5 Sekunden), gruppiert sie nach Tageszeit und Fehlermuster und identifiziert die wahrscheinliche Ursache."
           },
           {
-            "title": "GitHub issue created with findings",
-            "description": "Zero files a structured GitHub issue with the metric table, slow event list, and root cause analysis - ready for the engineering team to act on."
+            "title": "GitHub-Issue mit Findings erstellt",
+            "description": "Zero legt ein strukturiertes GitHub-Issue mit Metriktabelle, Liste langsamer Events und Ursachenanalyse an – bereit für die Bearbeitung durch das Engineering-Team."
           }
         ],
         "nextActions": [
           {
-            "title": "Assign and prioritize",
-            "description": "Route the issue to the right engineer",
+            "title": "Zuweisen und priorisieren",
+            "description": "Das Issue an den richtigen Engineer weiterleiten",
             "examplePrompt": "@Zero assign the Axiom issue to Ethan and add the label performance, priority-high."
           },
           {
-            "title": "Schedule regular monitoring",
-            "description": "Set up a weekly TP95 check for key endpoints",
+            "title": "Regelmäßige Überwachung einplanen",
+            "description": "Wöchentlichen TP95-Check für Schlüssel-Endpoints einrichten",
             "examplePrompt": "@Zero every Monday at 9am, pull the last 7 days of TP95 for /api/zero/runs and post to #dev. File a GitHub issue only if TP95 exceeds 3s."
           },
           {
-            "title": "Investigate a specific slow event",
-            "description": "Dig into a single outlier event",
+            "title": "Ein bestimmtes langsames Event untersuchen",
+            "description": "In ein einzelnes Ausreißer-Event eintauchen",
             "examplePrompt": "@Zero pull the full trace for the 6,857ms event on Apr 12 from Axiom and tell me where the time is spent."
           }
         ],
         "integrations": [
           {
-            "description": "Axiom is required. Zero queries your Axiom dataset for request events filtered by endpoint path and time window."
+            "description": "Axiom ist erforderlich. Zero fragt Ihr Axiom-Dataset nach Request-Events ab, gefiltert nach Endpoint-Pfad und Zeitfenster."
           },
           {
-            "description": "GitHub is optional. Zero creates issues from findings when asked, with the metric table embedded in the body."
+            "description": "GitHub ist optional. Zero erstellt auf Anfrage Issues aus den Findings, mit der Metriktabelle eingebettet im Body."
           }
         ],
         "tips": [
-          "Specify a threshold in your prompt - 'flag events over 3 seconds' - so Zero's findings match your SLO, not a generic cutoff.",
-          "Ask Zero to check the endpoint right after a deploy to catch regressions before they affect users at scale.",
-          "Combine with Daily Error Triage for a complete morning health check: errors from Sentry plus performance from Axiom in one brief."
+          "Geben Sie einen Schwellenwert im Prompt an – 'Events über 3 Sekunden markieren' – damit Zeros Findings zu Ihrem SLO passen, nicht zu einer generischen Grenze.",
+          "Bitten Sie Zero, den Endpoint direkt nach einem Deploy zu prüfen, um Regressionen abzufangen, bevor sie Nutzer im großen Maßstab betreffen.",
+          "Kombinieren Sie es mit Daily Error Triage für einen vollständigen morgendlichen Health-Check: Fehler aus Sentry plus Performance aus Axiom in einem Brief."
         ]
       },
       "production-db-query": {
         "title": "Produktionsdaten in natürlicher Sprache abfragen",
         "description": "Stellen Sie Zero eine Frage zu Ihren Produktionsdaten. Es schreibt das SQL, führt es schreibgeschützt aus und liefert die Antwort in Slack.",
-        "timeSaved": "~20 min saved",
-        "scenario": "A stakeholder asks how many users completed onboarding in the last 30 days. It's a simple question, but answering it means opening a DB client, finding the right table, writing a query, making sure you're on read-only credentials, running it, and formatting the result. Zero handles the whole chain - just ask the question in Slack.",
+        "timeSaved": "~20 Min. gespart",
+        "scenario": "Ein Stakeholder fragt, wie viele Nutzer in den letzten 30 Tagen das Onboarding abgeschlossen haben. Eine einfache Frage – aber sie zu beantworten bedeutet: einen DB-Client öffnen, die richtige Tabelle finden, eine Query schreiben, sicherstellen, dass man Read-Only-Credentials verwendet, ausführen und das Ergebnis formatieren. Zero erledigt die gesamte Kette – stellen Sie die Frage einfach in Slack.",
         "promptVariants": [
           {
-            "label": "Count query",
+            "label": "Count-Query",
             "prompt": "@Zero how many users signed up in the last 30 days? Query the production database."
           },
           {
-            "label": "Trend query",
+            "label": "Trend-Query",
             "prompt": "@Zero query production - show me daily active user counts for the last 14 days, broken down by plan tier."
           },
           {
-            "label": "Anomaly check",
+            "label": "Anomalie-Check",
             "prompt": "@Zero check production DB - are there any users with a free credit balance above 1000? List the top 10."
           }
         ],
@@ -1601,70 +1601,70 @@
           },
           {
             "name": "Zero",
-            "text": "Production DB query result (read-only):\n\nzero_runs created in last 7 days: 4,218\nBreakdown: Mon 523, Tue 641, Wed 688, Thu 712, Fri 654\nWeekend: 0 (expected - team usage pattern)\n\nQuery ran in 42ms."
+            "text": "Ergebnis der Produktions-DB-Query (read-only):\n\nzero_runs in den letzten 7 Tagen erstellt: 4.218\nVerteilung: Mo 523, Di 641, Mi 688, Do 712, Fr 654\nWochenende: 0 (erwartet – Team-Nutzungsmuster)\n\nQuery lief in 42 ms."
           }
         ],
         "steps": [
           {
-            "title": "Zero interprets your question",
-            "description": "Zero maps your plain-language question to the relevant tables and columns in your production schema."
+            "title": "Zero interpretiert Ihre Frage",
+            "description": "Zero mappt Ihre Frage in Alltagssprache auf die relevanten Tabellen und Spalten in Ihrem Produktions-Schema."
           },
           {
-            "title": "Zero runs a read-only query",
-            "description": "Zero executes only SELECT statements against production. No writes, no mutations. Credentials are retrieved securely via Doppler - they never appear in the conversation."
+            "title": "Zero führt eine Read-Only-Query aus",
+            "description": "Zero führt ausschließlich SELECT-Statements gegen Produktion aus. Keine Writes, keine Mutationen. Credentials werden sicher über Doppler bezogen – sie tauchen nie in der Konversation auf."
           },
           {
-            "title": "Results returned in Slack",
-            "description": "Zero posts the query result in the thread, formatted as a readable summary. For large result sets, it returns the key numbers and offers to export the full table."
+            "title": "Ergebnisse in Slack zurückgegeben",
+            "description": "Zero postet das Query-Ergebnis im Thread, formatiert als lesbare Zusammenfassung. Bei großen Result-Sets gibt Zero die Kernzahlen zurück und bietet an, die vollständige Tabelle zu exportieren."
           }
         ],
         "nextActions": [
           {
-            "title": "Export to a spreadsheet",
-            "description": "Get the full result set in a usable format",
+            "title": "In ein Spreadsheet exportieren",
+            "description": "Das vollständige Result-Set in nutzbarer Form erhalten",
             "examplePrompt": "@Zero re-run that query and export the results to a Google Sheet named 'DAU by Plan - April 2026'."
           },
           {
-            "title": "Schedule a recurring count",
-            "description": "Track a metric automatically",
+            "title": "Wiederkehrende Zählung einplanen",
+            "description": "Eine Metrik automatisch verfolgen",
             "examplePrompt": "@Zero every Monday morning, query production for last week's new user count and post to #metrics."
           },
           {
-            "title": "File an issue from a finding",
-            "description": "Escalate an anomaly you discovered",
+            "title": "Issue aus einem Finding anlegen",
+            "description": "Eine entdeckte Anomalie eskalieren",
             "examplePrompt": "@Zero create a GitHub issue for the users with credit balance above 1000 - title 'Credit balance anomaly', assign to Ethan."
           }
         ],
         "integrations": [
           {
-            "description": "vm0's production database skill is required. It provides a read-only connection to your Postgres instance via securely managed credentials - no manual setup needed."
+            "description": "Der Produktions-DB-Skill von vm0 ist erforderlich. Er stellt eine Read-Only-Verbindung zu Ihrer Postgres-Instanz über sicher verwaltete Credentials bereit – kein manuelles Setup nötig."
           },
           {
-            "description": "Slack is where you ask the question and receive the result."
+            "description": "Slack ist der Ort, an dem Sie die Frage stellen und das Ergebnis erhalten."
           }
         ],
         "tips": [
-          "Always specify 'production database' or 'prod DB' in your prompt so Zero knows which connection to use if you have multiple environments.",
-          "Zero runs only SELECT queries. If you need to modify data, Zero will flag it and ask you to handle it through the appropriate workflow instead.",
-          "For sensitive queries, prefix with 'do not log the results' - Zero will deliver the answer in an ephemeral message visible only to you."
+          "Geben Sie immer 'Produktionsdatenbank' oder 'Prod-DB' in Ihrem Prompt an, damit Zero weiß, welche Verbindung zu verwenden ist, wenn Sie mehrere Umgebungen haben.",
+          "Zero führt nur SELECT-Queries aus. Wenn Sie Daten ändern müssen, weist Zero darauf hin und bittet Sie, dies über den passenden Workflow zu erledigen.",
+          "Für sensible Queries setzen Sie 'Ergebnisse nicht loggen' davor – Zero liefert die Antwort als ephemeral message, sichtbar nur für Sie."
         ]
       },
       "security-compliance": {
         "title": "Infrastruktur-Compliance-Audits automatisieren",
         "description": "Zero prüft Ihre Infrastruktur gegen Compliance-Anforderungen über GitHub, Cloud-Anbieter und Dokumentation und postet einen strukturierten Befundbericht.",
-        "timeSaved": "~2 hrs saved",
-        "scenario": "Your compliance team flags a question: where is customer data stored, and does it meet regional requirements? Answering it means checking your cloud provider configs, reading your deployment settings, cross-referencing documentation, and writing a summary. Zero does all of this from one Slack message - checking your Vercel regions, Cloudflare R2 config, and infrastructure files, then posting a structured brief.",
+        "timeSaved": "~2 Std. gespart",
+        "scenario": "Ihr Compliance-Team stellt eine Frage: Wo werden Kundendaten gespeichert und erfüllen sie regionale Anforderungen? Die Antwort verlangt: Cloud-Provider-Konfigurationen prüfen, Deployment-Einstellungen lesen, Doku abgleichen und eine Zusammenfassung schreiben. Zero erledigt all das aus einer Slack-Nachricht – prüft Ihre Vercel-Regionen, die Cloudflare-R2-Konfiguration und Ihre Infrastruktur-Dateien und liefert einen strukturierten Brief.",
         "promptVariants": [
           {
-            "label": "Region audit",
+            "label": "Regionen-Audit",
             "prompt": "@Zero check our infrastructure for data residency - where are our Cloudflare R2 buckets located, what region does Vercel deploy to, and is there any cross-region replication configured?"
           },
           {
-            "label": "Security review",
+            "label": "Security-Review",
             "prompt": "@Zero audit our GitHub repo for any hardcoded secrets or API keys accidentally committed in the last 90 days."
           },
           {
-            "label": "Compliance brief",
+            "label": "Compliance-Brief",
             "prompt": "@Zero research our infrastructure setup and write a brief on whether we meet SOC 2 Type I requirements for data storage and access controls. Save it to Notion under 'Compliance > SOC 2 Prep'."
           }
         ],
@@ -1675,74 +1675,74 @@
           },
           {
             "name": "Zero",
-            "text": "Cloudflare R2: Region set to auto (Cloudflare selects nearest region). No cross-region replication configured.\n\nVercel: Defaults to iad1 (US East, Washington DC) for serverless functions. Static assets served from CDN edge globally.\n\nSummary: Data is US-based by default. If EU residency is required, both R2 and Vercel need explicit region configuration."
+            "text": "Cloudflare R2: Region auf auto gesetzt (Cloudflare wählt die nächstgelegene Region). Keine regionsübergreifende Replikation konfiguriert.\n\nVercel: Standard ist iad1 (US Ost, Washington DC) für Serverless Functions. Statische Assets werden global über CDN-Edge ausgeliefert.\n\nFazit: Daten liegen standardmäßig in den USA. Wenn EU-Residenz erforderlich ist, müssen sowohl R2 als auch Vercel explizit auf eine Region konfiguriert werden."
           }
         ],
         "steps": [
           {
-            "title": "Zero gathers config from your infrastructure",
-            "description": "Zero reads your repository configuration files, deployment configs, and checks connected cloud services for the relevant settings."
+            "title": "Zero sammelt die Konfiguration aus Ihrer Infrastruktur",
+            "description": "Zero liest Konfigurations- und Deployment-Dateien aus Ihrem Repository und prüft verbundene Cloud-Services auf die relevanten Einstellungen."
           },
           {
-            "title": "Zero cross-references against the compliance requirement",
-            "description": "Zero maps each finding against the specific requirement - data residency, access control, encryption - and flags any gaps."
+            "title": "Zero gleicht mit der Compliance-Anforderung ab",
+            "description": "Zero mappt jedes Finding auf die konkrete Anforderung – Datenresidenz, Zugriffskontrolle, Verschlüsselung – und markiert Lücken."
           },
           {
-            "title": "Findings brief posted and optionally saved",
-            "description": "Zero posts a structured brief in Slack with findings per service and a summary recommendation. On request, it saves the full report to Notion."
+            "title": "Findings-Brief gepostet und optional gespeichert",
+            "description": "Zero postet einen strukturierten Brief in Slack mit Findings pro Service und einer zusammenfassenden Empfehlung. Auf Anfrage speichert es den vollständigen Report in Notion."
           }
         ],
         "nextActions": [
           {
-            "title": "Save to Notion for the audit",
-            "description": "Archive the findings for your compliance record",
+            "title": "In Notion für das Audit speichern",
+            "description": "Die Findings für Ihren Compliance-Nachweis archivieren",
             "examplePrompt": "@Zero save the compliance brief to Notion under 'Compliance > Infrastructure Audit > April 2026'."
           },
           {
-            "title": "Create remediation issues",
-            "description": "Turn gaps into tracked engineering work",
+            "title": "Remediation-Issues anlegen",
+            "description": "Lücken in nachverfolgte Engineering-Arbeit überführen",
             "examplePrompt": "@Zero create GitHub issues for each gap in the compliance brief. Label them compliance and assign to Ethan."
           },
           {
-            "title": "Schedule a quarterly audit",
-            "description": "Make compliance checks a recurring practice",
+            "title": "Quartals-Audit einplanen",
+            "description": "Compliance-Checks zur wiederkehrenden Praxis machen",
             "examplePrompt": "@Zero every quarter, run this infrastructure compliance check and post findings to #compliance."
           }
         ],
         "integrations": [
           {
-            "description": "GitHub is required. Zero reads your infrastructure and deployment config files from the repository."
+            "description": "GitHub ist erforderlich. Zero liest Ihre Infrastruktur- und Deployment-Konfigurationsdateien aus dem Repository."
           },
           {
-            "description": "Notion is optional. Zero saves compliance briefs and findings for audit trail documentation."
+            "description": "Notion ist optional. Zero speichert Compliance-Briefs und Findings für die Audit-Trail-Dokumentation."
           }
         ],
         "tips": [
-          "Be specific about the compliance framework or requirement - 'SOC 2 data residency' produces a more useful brief than 'check if we're compliant.'",
-          "Ask Zero to DM you the sensitive findings rather than posting to a channel - some compliance gaps shouldn't be broadcast publicly.",
-          "Archive findings to Notion immediately. Compliance auditors want documentation of the process, not just the conclusion."
+          "Seien Sie konkret beim Compliance-Framework oder der Anforderung – 'SOC 2 Datenresidenz' liefert einen nützlicheren Brief als 'prüfen, ob wir compliant sind.'",
+          "Bitten Sie Zero, Ihnen sensible Findings per DM zu schicken statt in einen Channel zu posten – manche Compliance-Lücken sollten nicht öffentlich verbreitet werden.",
+          "Archivieren Sie Findings sofort in Notion. Compliance-Auditoren wollen die Dokumentation des Prozesses, nicht nur das Ergebnis."
         ]
       },
       "cross-tool-context": {
         "title": "Einheitlicher Projektstatus aus mehreren Tools",
         "description": "Fragen Sie Zero nach einem Projekt. Es durchsucht parallel Ihre Tools und fasst Status, Verantwortliche, Blocker und letzte Aktualisierung zusammen.",
-        "timeSaved": "~25 min saved",
-        "scenario": "Someone asks about the status of the Stripe integration. The last Slack thread is from two weeks ago. There's a Linear ticket but the status says 'In Progress' with no update. The Notion doc has a decision log from last month. GitHub has three open PRs. None of these sources tell the full story alone. Zero searches all four in parallel and gives you one answer.",
+        "timeSaved": "~25 Min. gespart",
+        "scenario": "Jemand fragt nach dem Status der Stripe-Integration. Der letzte Slack-Thread ist zwei Wochen alt. Es gibt ein Linear-Ticket, aber der Status sagt nur 'In Progress' ohne Update. Das Notion-Dokument enthält einen Entscheidungs-Log von letztem Monat. GitHub hat drei offene PRs. Keine dieser Quellen erzählt allein die volle Geschichte. Zero durchsucht alle vier parallel und gibt Ihnen eine Antwort.",
         "promptVariants": [
           {
-            "label": "Basic",
+            "label": "Basis",
             "prompt": "@Zero what's the current status of the Stripe integration? Search Slack (last 14 days), Notion, Linear, and GitHub. Return: current state, owner, blockers, and last meaningful update with source."
           },
           {
-            "label": "Deep dive",
+            "label": "Deep Dive",
             "prompt": "@Zero pull everything on the auth refactor from the last 30 days across Slack, Notion, Linear, and GitHub. Write a full status doc with owner, decision history, and what's next."
           },
           {
-            "label": "Scheduled",
+            "label": "Geplant",
             "prompt": "@Zero every Monday morning, DM me a status brief on the mobile SDK project - current state, owner, blockers, last update."
           },
           {
-            "label": "Conflict-aware",
+            "label": "Konflikt-bewusst",
             "prompt": "@Zero check Slack and Linear for the latest on the onboarding redesign and flag if the two sources disagree on status or ownership."
           }
         ],
@@ -1753,58 +1753,58 @@
           },
           {
             "name": "Zero",
-            "text": "Connector Architecture Refactor - Status Brief\n\nState: In progress - environment variables migrated from skill frontmatter to connector definitions. Core refactor merged.\nOwner: Lancy\nBlockers: None active.\nLast update: Apr 14 (GitHub) - PR #9312 merged.\n\nSources agree."
+            "text": "Connector-Architektur-Refactor – Status-Brief\n\nStand: In Arbeit – Umgebungsvariablen wurden vom Skill-Frontmatter zu Connector-Definitionen migriert. Kern-Refactor gemergt.\nOwner: Lancy\nBlocker: Keine aktiven.\nLetztes Update: 14. April (GitHub) – PR #9312 gemergt.\n\nQuellen stimmen überein."
           }
         ],
         "steps": [
           {
-            "title": "Zero searches all sources in parallel",
-            "description": "Zero queries Slack, Notion, Linear, and GitHub simultaneously for the topic within the specified time window - returning raw findings from each source."
+            "title": "Zero durchsucht alle Quellen parallel",
+            "description": "Zero fragt Slack, Notion, Linear und GitHub gleichzeitig zum Thema im angegebenen Zeitfenster ab – und liefert Roh-Findings aus jeder Quelle."
           },
           {
-            "title": "Zero synthesizes and flags conflicts",
-            "description": "Zero extracts state, owner, blockers, and last update per source. If sources disagree - e.g., Linear says 'Done' but Slack has an open question from yesterday - Zero flags the conflict explicitly."
+            "title": "Zero synthetisiert und markiert Konflikte",
+            "description": "Zero extrahiert Stand, Owner, Blocker und letztes Update pro Quelle. Wenn die Quellen sich widersprechen – z. B. Linear sagt 'Done', Slack hat aber eine offene Frage von gestern – markiert Zero den Konflikt explizit."
           },
           {
-            "title": "4-part brief delivered in Slack",
-            "description": "Zero returns: current state in one sentence, owner/DRI, active blockers, and the most recent meaningful update with its source citation."
+            "title": "Vierteiliger Brief in Slack geliefert",
+            "description": "Zero gibt zurück: aktueller Stand in einem Satz, Owner/DRI, aktive Blocker und das jüngste sinnvolle Update mit Quellenangabe."
           }
         ],
         "nextActions": [
           {
-            "title": "Log the brief to Notion",
-            "description": "Create a searchable record of the status snapshot",
+            "title": "Den Brief in Notion ablegen",
+            "description": "Einen durchsuchbaren Datensatz des Status-Snapshots anlegen",
             "examplePrompt": "@Zero save this status brief to Notion under 'Project Status > Stripe Integration > April 2026'."
           },
           {
-            "title": "Schedule weekly updates",
-            "description": "Get a status DM every Monday without asking",
+            "title": "Wöchentliche Updates einplanen",
+            "description": "Jeden Montag ein Status-DM erhalten, ohne danach zu fragen",
             "examplePrompt": "@Zero every Monday at 9am, DM me the status of the mobile SDK across Slack, Linear, and GitHub."
           },
           {
-            "title": "Escalate a blocker",
-            "description": "Turn a found blocker into a tracked issue",
+            "title": "Einen Blocker eskalieren",
+            "description": "Einen gefundenen Blocker in ein verfolgtes Issue überführen",
             "examplePrompt": "@Zero the blocker you found - create a GitHub issue for it and assign to the owner."
           }
         ],
         "integrations": [
           {
-            "description": "Slack is required. It's the primary source of async discussion and where the brief is delivered."
+            "description": "Slack ist erforderlich. Es ist die primäre Quelle für asynchrone Diskussionen und der Ort, an dem der Brief geliefert wird."
           },
           {
-            "description": "Linear is required. It's the source of truth for task ownership and current status."
+            "description": "Linear ist erforderlich. Es ist die Quelle der Wahrheit für Task-Ownership und aktuellen Status."
           },
           {
-            "description": "Notion is optional. Zero searches long-form decisions and context when included."
+            "description": "Notion ist optional. Zero durchsucht ausführliche Entscheidungen und Kontext, wenn es einbezogen wird."
           },
           {
-            "description": "GitHub is optional. Zero includes PR and commit activity for technical topics."
+            "description": "GitHub ist optional. Zero bezieht PR- und Commit-Aktivität für technische Themen ein."
           }
         ],
         "tips": [
-          "Be specific - 'the Stripe integration' works better than 'the payment feature.' Specific terms match across tools; vague ones don't.",
-          "Add a time window for long-running projects: 'focus on the last 14 days' prevents Zero from surfacing stale context as if it's current.",
-          "Pair with Document Decisions to auto-log the brief to Notion - useful for recurring reviews where you want a historical snapshot per week."
+          "Seien Sie spezifisch – 'die Stripe-Integration' funktioniert besser als 'das Payment-Feature'. Spezifische Begriffe matchen über Tools hinweg; vage nicht.",
+          "Fügen Sie ein Zeitfenster für langlaufende Projekte hinzu: 'Fokus auf die letzten 14 Tage' verhindert, dass Zero veralteten Kontext als aktuell präsentiert.",
+          "Kombinieren Sie es mit Document Decisions, um den Brief automatisch in Notion zu loggen – nützlich für wiederkehrende Reviews, bei denen Sie pro Woche einen historischen Snapshot wollen."
         ]
       },
       "multilingual-cms-publishing": {
@@ -2506,7 +2506,7 @@
             "prompt": "@Zero führe jetzt eine Kontrollverifizierung durch und poste die Ergebnisse."
           },
           {
-            "label": "Scoped",
+            "label": "Mit Geltungsbereich",
             "prompt": "@Zero verifiziere heute Vormittag nur die SOC-2-Kontrollen - GDPR- und HIPAA-Checks überspringen."
           }
         ],

--- a/turbo/apps/web/messages/es.json
+++ b/turbo/apps/web/messages/es.json
@@ -1198,7 +1198,7 @@
           },
           {
             "name": "Zero",
-            "text": "Scheduled. Running weekdays at 08:30.\n\nRun from this morning:\n*GitHub* - 96 PRs merged today vs 14.3 avg 🔴 572% spike (coordinated test refactor). Issues closed: 71 vs 28.6 avg 🟢.\n*Linear* - 0 issues created this week, 3 in backlog.\n*Sentry* - connector not configured.\n*Plausible* - connector not configured."
+            "text": "Programado. Se ejecuta de lunes a viernes a las 08:30.\n\nEjecución de esta mañana:\n*GitHub* – 96 PRs mergeados hoy vs. 14,3 de media 🔴 pico del 572 % (refactor de tests coordinado). Issues cerrados: 71 vs. 28,6 de media 🟢.\n*Linear* – 0 issues creados esta semana, 3 en el backlog.\n*Sentry* – conector no configurado.\n*Plausible* – conector no configurado."
           }
         ],
         "steps": [
@@ -1289,7 +1289,7 @@
           },
           {
             "name": "Zero",
-            "text": "Customer 360 - Acme Corp\n\nOverview: Enterprise, 6 months in, primary contact: James Chen (CTO)\nRecent Activity: 3 email threads Apr 1–10, last meeting Apr 8, 2 open Linear issues\nOpen Items: Unanswered email Apr 9 re: API limits, feature request #812 unassigned\n\nSummary:\n• Health: Engaged but technical blockers slowing adoption\n• Risk: No response to Apr 9 email for 5 days\n• Next: Follow up on API limits today, share #812 resolution timeline"
+            "text": "Customer 360 – Acme Corp\n\nResumen: Enterprise, 6 meses como cliente, contacto principal: James Chen (CTO)\nActividad reciente: 3 hilos de email entre el 1 y el 10 de abril, última reunión el 8 de abril, 2 issues abiertos en Linear\nPendientes: Email sin responder del 9 de abril sobre límites de API, solicitud de funcionalidad #812 sin asignar\n\nResumen:\n• Salud: Comprometidos, pero bloqueos técnicos están ralentizando la adopción\n• Riesgo: Sin respuesta al email del 9 de abril durante 5 días\n• Próximos pasos: Hacer seguimiento hoy sobre los límites de API, compartir el plazo de resolución de #812"
           }
         ],
         "steps": [
@@ -1376,7 +1376,7 @@
           },
           {
             "name": "Zero",
-            "text": "No digest sent Apr 13 - no topics met the 2-source threshold."
+            "text": "El 13 de abril no se envió digest – ningún tema alcanzó el umbral de 2 fuentes."
           }
         ],
         "steps": [
@@ -1430,19 +1430,19 @@
       "pr-review": {
         "title": "Revisión de código de PR con inteligencia artificial",
         "description": "Zero lee el diff de su PR, marca problemas críticos como P0, clasifica oportunidades de mejora y los reporta en Slack para que su equipo actúe antes del merge.",
-        "timeSaved": "~30 min saved per PR",
-        "scenario": "PRs pile up. Reviewers are busy. Someone hits 'approve' to clear their queue and a subtle bug ships. Zero gives every PR a thorough read without the queue. Point it at any PR number, and it returns a structured review - critical issues that must be fixed before merge, plus lower-priority suggestions - posted directly in Slack.",
+        "timeSaved": "~30 min ahorrados por PR",
+        "scenario": "Los PRs se acumulan. Los revisores están ocupados. Alguien pulsa 'aprobar' para vaciar su cola y un bug sutil llega a producción. Zero revisa cada PR a fondo sin cola. Apúntelo a cualquier número de PR y obtendrá una revisión estructurada – problemas críticos que deben corregirse antes del merge, más sugerencias de menor prioridad – publicada directamente en Slack.",
         "promptVariants": [
           {
-            "label": "Standard review",
+            "label": "Revisión estándar",
             "prompt": "@Zero review vm0-ai/vm0#8886"
           },
           {
-            "label": "Focused review",
+            "label": "Revisión enfocada",
             "prompt": "@Zero review vm0-ai/vm0#9215 - focus on the auth middleware changes and any potential security issues."
           },
           {
-            "label": "Re-review after fixes",
+            "label": "Re-revisión tras correcciones",
             "prompt": "@Zero re-review vm0-ai/vm0#8886 - I pushed a second commit addressing your P0 feedback."
           }
         ],
@@ -1453,70 +1453,70 @@
           },
           {
             "name": "Zero",
-            "text": "Review for vm0-ai/vm0#8886 - 1 commit reviewed.\n\nP0 (must fix before merge):\n• createPlainSupportThread has 5 paths that return false instead of throwing - silent failures in prod.\n\nP1 (improvement):\n• Error messages don't include the SDK error code - harder to debug from logs."
+            "text": "Revisión de vm0-ai/vm0#8886 – 1 commit revisado.\n\nP0 (debe corregirse antes del merge):\n• createPlainSupportThread tiene 5 rutas que devuelven false en lugar de lanzar – fallos silenciosos en producción.\n\nP1 (mejora):\n• Los mensajes de error no incluyen el código de error del SDK – dificulta el debug desde logs."
           }
         ],
         "steps": [
           {
-            "title": "Zero reads the full diff",
-            "description": "Zero fetches the PR via GitHub, reads every changed file, and understands the intent of the change from the PR title, description, and commit messages."
+            "title": "Zero lee el diff completo",
+            "description": "Zero obtiene el PR vía GitHub, lee cada archivo modificado y comprende la intención del cambio a partir del título, descripción y mensajes de commit."
           },
           {
-            "title": "Zero ranks issues by severity",
-            "description": "Findings are classified as P0 (must fix before merge - bugs, security issues, silent failures) or P1 (improvements - better error handling, test coverage, naming)."
+            "title": "Zero clasifica los problemas por severidad",
+            "description": "Los hallazgos se clasifican como P0 (corregir antes del merge – bugs, problemas de seguridad, fallos silenciosos) o P1 (mejoras – mejor manejo de errores, cobertura de tests, naming)."
           },
           {
-            "title": "Review posted to Slack",
-            "description": "Zero posts the full review in the Slack thread where it was requested, with specific file references and line numbers so the author knows exactly what to fix."
+            "title": "Revisión publicada en Slack",
+            "description": "Zero publica la revisión completa en el hilo de Slack donde se solicitó, con referencias a archivos y números de línea específicos para que el autor sepa exactamente qué corregir."
           }
         ],
         "nextActions": [
           {
-            "title": "Create a GitHub issue from a finding",
-            "description": "Log a P0 as a tracked issue if it can't be fixed immediately",
+            "title": "Crear un issue de GitHub desde un hallazgo",
+            "description": "Registre un P0 como issue rastreado si no puede corregirse de inmediato",
             "examplePrompt": "@Zero create a GitHub issue for the P0 in that review. Assign to Ethan and label as bug, priority-high."
           },
           {
-            "title": "Re-review after changes",
-            "description": "Verify that P0 feedback was addressed",
+            "title": "Re-revisión tras cambios",
+            "description": "Verifique que se abordó el feedback P0",
             "examplePrompt": "@Zero re-review #8886, second commit - confirm the P0 is resolved."
           },
           {
-            "title": "Check CI status",
-            "description": "See if all checks pass before merging",
+            "title": "Comprobar el estado de CI",
+            "description": "Verifique si todos los checks pasan antes del merge",
             "examplePrompt": "@Zero what's the CI status on vm0-ai/vm0#8886? Is it safe to merge?"
           }
         ],
         "integrations": [
           {
-            "description": "GitHub is required. Zero needs read access to pull requests and the full diff."
+            "description": "GitHub es obligatorio. Zero necesita acceso de lectura a los pull requests y al diff completo."
           },
           {
-            "description": "Slack is where the review request is made and where findings are delivered."
+            "description": "Slack es donde se solicita la revisión y donde se entregan los hallazgos."
           }
         ],
         "tips": [
-          "Include the specific concern in your prompt - 'focus on auth changes' or 'check for race conditions' - to get a more targeted review than a general diff scan.",
-          "Use re-review for iterative PRs. After the author pushes fixes, ask Zero to re-check only the P0 items to confirm they're resolved.",
-          "Set a team norm: Zero review before any merge to main. It catches the class of issues that slip through async human review."
+          "Incluya la preocupación específica en su prompt – 'enfócate en los cambios de auth' o 'verifica race conditions' – para obtener una revisión más dirigida que un escaneo general del diff.",
+          "Use re-revisión para PRs iterativos. Después de que el autor empuje correcciones, pídale a Zero que vuelva a revisar solo los ítems P0 para confirmar que están resueltos.",
+          "Establezca una norma de equipo: revisión de Zero antes de cualquier merge a main. Detecta la clase de problemas que se escapan a la revisión humana asíncrona."
         ]
       },
       "api-performance": {
         "title": "Investigar cuellos de botella en el rendimiento API",
         "description": "Zero extrae datos TP95 de Axiom, identifica los endpoints más lentos, detecta patrones y crea un issue en GitHub con los hallazgos desde Slack.",
-        "timeSaved": "~45 min saved",
-        "scenario": "TP95 spikes don't always page you. They sit in your metrics dashboards, quietly degrading user experience while your team is focused on shipping. Zero makes it easy to check any endpoint's performance on demand - pull the last 7 days of TP95 data, see which requests are slow, and get a GitHub issue filed automatically so nothing gets dropped.",
+        "timeSaved": "~45 min ahorrados",
+        "scenario": "Los picos de TP95 no siempre te despiertan. Se quedan en tus dashboards de métricas, degradando silenciosamente la experiencia de usuario mientras tu equipo se enfoca en entregar. Zero facilita comprobar el rendimiento de cualquier endpoint bajo demanda – obtener los últimos 7 días de datos TP95, ver qué requests son lentos y conseguir un issue de GitHub creado automáticamente para que nada se pierda.",
         "promptVariants": [
           {
-            "label": "TP95 check",
+            "label": "Comprobación TP95",
             "prompt": "@Zero check Axiom for the POST /api/zero/runs endpoint - show me the TP95 for the last 7 days and flag any events over 5s."
           },
           {
-            "label": "File an issue",
+            "label": "Crear un issue",
             "prompt": "@Zero pull Axiom TP95 for /api/zero/runs over the last 7 days and create a GitHub issue with the findings, assigned to Lancy."
           },
           {
-            "label": "Compare endpoints",
+            "label": "Comparar endpoints",
             "prompt": "@Zero compare the last 7 days of TP95 for /api/zero/runs vs /api/chat/send on Axiom. Which is slower and what's the pattern?"
           }
         ],
@@ -1527,70 +1527,70 @@
           },
           {
             "name": "Zero",
-            "text": "POST /api/zero/runs - 7-day TP95 summary:\n\nWorst: 6,857ms on Apr 12\nSlow events (>5s): 14 total\nRoot cause: sync dispatch pipeline blocks the response - it waits for sandbox allocation before returning.\n\nGitHub issue filed: vm0-ai/vm0#9682, assigned to Lancy."
+            "text": "POST /api/zero/runs – resumen TP95 de los últimos 7 días:\n\nPeor: 6.857 ms el 12 de abril\nEventos lentos (>5 s): 14 en total\nCausa raíz: la pipeline de despacho síncrono bloquea la respuesta – espera la asignación del sandbox antes de devolver.\n\nIssue de GitHub creado: vm0-ai/vm0#9682, asignado a Lancy."
           }
         ],
         "steps": [
           {
-            "title": "Zero queries Axiom for the endpoint",
-            "description": "Zero pulls all request events for the specified endpoint over the time window, computing TP50, TP95, and TP99 per day."
+            "title": "Zero consulta Axiom para el endpoint",
+            "description": "Zero extrae todos los eventos de request del endpoint indicado en la ventana de tiempo, calculando TP50, TP95 y TP99 por día."
           },
           {
-            "title": "Zero surfaces slow events",
-            "description": "Zero filters for events above the threshold (default: 5 seconds), groups them by time of day and error pattern, and identifies the likely root cause."
+            "title": "Zero destaca los eventos lentos",
+            "description": "Zero filtra los eventos por encima del umbral (por defecto: 5 segundos), los agrupa por hora del día y patrón de error, e identifica la causa raíz probable."
           },
           {
-            "title": "GitHub issue created with findings",
-            "description": "Zero files a structured GitHub issue with the metric table, slow event list, and root cause analysis - ready for the engineering team to act on."
+            "title": "Issue de GitHub creado con los hallazgos",
+            "description": "Zero crea un issue de GitHub estructurado con la tabla de métricas, la lista de eventos lentos y el análisis de causa raíz – listo para que el equipo de ingeniería actúe."
           }
         ],
         "nextActions": [
           {
-            "title": "Assign and prioritize",
-            "description": "Route the issue to the right engineer",
+            "title": "Asignar y priorizar",
+            "description": "Dirigir el issue al ingeniero adecuado",
             "examplePrompt": "@Zero assign the Axiom issue to Ethan and add the label performance, priority-high."
           },
           {
-            "title": "Schedule regular monitoring",
-            "description": "Set up a weekly TP95 check for key endpoints",
+            "title": "Programar monitoreo regular",
+            "description": "Configurar una comprobación TP95 semanal para endpoints clave",
             "examplePrompt": "@Zero every Monday at 9am, pull the last 7 days of TP95 for /api/zero/runs and post to #dev. File a GitHub issue only if TP95 exceeds 3s."
           },
           {
-            "title": "Investigate a specific slow event",
-            "description": "Dig into a single outlier event",
+            "title": "Investigar un evento lento específico",
+            "description": "Profundizar en un único evento atípico",
             "examplePrompt": "@Zero pull the full trace for the 6,857ms event on Apr 12 from Axiom and tell me where the time is spent."
           }
         ],
         "integrations": [
           {
-            "description": "Axiom is required. Zero queries your Axiom dataset for request events filtered by endpoint path and time window."
+            "description": "Axiom es obligatorio. Zero consulta tu dataset de Axiom para eventos de request filtrados por ruta de endpoint y ventana de tiempo."
           },
           {
-            "description": "GitHub is optional. Zero creates issues from findings when asked, with the metric table embedded in the body."
+            "description": "GitHub es opcional. Zero crea issues a partir de los hallazgos cuando se le pide, con la tabla de métricas incrustada en el cuerpo."
           }
         ],
         "tips": [
-          "Specify a threshold in your prompt - 'flag events over 3 seconds' - so Zero's findings match your SLO, not a generic cutoff.",
-          "Ask Zero to check the endpoint right after a deploy to catch regressions before they affect users at scale.",
-          "Combine with Daily Error Triage for a complete morning health check: errors from Sentry plus performance from Axiom in one brief."
+          "Especifique un umbral en su prompt – 'marca eventos por encima de 3 segundos' – para que los hallazgos de Zero coincidan con su SLO, no con un corte genérico.",
+          "Pida a Zero que compruebe el endpoint justo después de un deploy para detectar regresiones antes de que afecten a usuarios a escala.",
+          "Combínelo con Daily Error Triage para un chequeo de salud matutino completo: errores de Sentry más rendimiento de Axiom en un solo brief."
         ]
       },
       "production-db-query": {
         "title": "Consulta datos de producción en lenguaje natural",
         "description": "Haga una pregunta sobre sus datos de producción. Zero escribe el SQL, lo ejecuta en modo solo lectura y devuelve la respuesta en Slack.",
-        "timeSaved": "~20 min saved",
-        "scenario": "A stakeholder asks how many users completed onboarding in the last 30 days. It's a simple question, but answering it means opening a DB client, finding the right table, writing a query, making sure you're on read-only credentials, running it, and formatting the result. Zero handles the whole chain - just ask the question in Slack.",
+        "timeSaved": "~20 min ahorrados",
+        "scenario": "Un stakeholder pregunta cuántos usuarios completaron el onboarding en los últimos 30 días. Es una pregunta sencilla, pero responderla implica abrir un cliente de DB, encontrar la tabla correcta, escribir una query, asegurarse de usar credenciales de solo lectura, ejecutarla y formatear el resultado. Zero maneja toda la cadena – solo haga la pregunta en Slack.",
         "promptVariants": [
           {
-            "label": "Count query",
+            "label": "Consulta de conteo",
             "prompt": "@Zero how many users signed up in the last 30 days? Query the production database."
           },
           {
-            "label": "Trend query",
+            "label": "Consulta de tendencia",
             "prompt": "@Zero query production - show me daily active user counts for the last 14 days, broken down by plan tier."
           },
           {
-            "label": "Anomaly check",
+            "label": "Comprobación de anomalías",
             "prompt": "@Zero check production DB - are there any users with a free credit balance above 1000? List the top 10."
           }
         ],
@@ -1601,70 +1601,70 @@
           },
           {
             "name": "Zero",
-            "text": "Production DB query result (read-only):\n\nzero_runs created in last 7 days: 4,218\nBreakdown: Mon 523, Tue 641, Wed 688, Thu 712, Fri 654\nWeekend: 0 (expected - team usage pattern)\n\nQuery ran in 42ms."
+            "text": "Resultado de la consulta a la DB de producción (solo lectura):\n\nzero_runs creados en los últimos 7 días: 4.218\nDesglose: Lun 523, Mar 641, Mié 688, Jue 712, Vie 654\nFin de semana: 0 (esperado – patrón de uso del equipo)\n\nLa query se ejecutó en 42 ms."
           }
         ],
         "steps": [
           {
-            "title": "Zero interprets your question",
-            "description": "Zero maps your plain-language question to the relevant tables and columns in your production schema."
+            "title": "Zero interpreta tu pregunta",
+            "description": "Zero mapea tu pregunta en lenguaje natural a las tablas y columnas relevantes de tu esquema de producción."
           },
           {
-            "title": "Zero runs a read-only query",
-            "description": "Zero executes only SELECT statements against production. No writes, no mutations. Credentials are retrieved securely via Doppler - they never appear in the conversation."
+            "title": "Zero ejecuta una query de solo lectura",
+            "description": "Zero ejecuta solo sentencias SELECT contra producción. Sin writes, sin mutaciones. Las credenciales se obtienen de forma segura vía Doppler – nunca aparecen en la conversación."
           },
           {
-            "title": "Results returned in Slack",
-            "description": "Zero posts the query result in the thread, formatted as a readable summary. For large result sets, it returns the key numbers and offers to export the full table."
+            "title": "Resultados devueltos en Slack",
+            "description": "Zero publica el resultado en el hilo, formateado como un resumen legible. Para conjuntos de resultados grandes, devuelve las cifras clave y ofrece exportar la tabla completa."
           }
         ],
         "nextActions": [
           {
-            "title": "Export to a spreadsheet",
-            "description": "Get the full result set in a usable format",
+            "title": "Exportar a una hoja de cálculo",
+            "description": "Obtener el conjunto completo de resultados en un formato utilizable",
             "examplePrompt": "@Zero re-run that query and export the results to a Google Sheet named 'DAU by Plan - April 2026'."
           },
           {
-            "title": "Schedule a recurring count",
-            "description": "Track a metric automatically",
+            "title": "Programar un conteo recurrente",
+            "description": "Hacer seguimiento automático de una métrica",
             "examplePrompt": "@Zero every Monday morning, query production for last week's new user count and post to #metrics."
           },
           {
-            "title": "File an issue from a finding",
-            "description": "Escalate an anomaly you discovered",
+            "title": "Crear un issue desde un hallazgo",
+            "description": "Escalar una anomalía que ha descubierto",
             "examplePrompt": "@Zero create a GitHub issue for the users with credit balance above 1000 - title 'Credit balance anomaly', assign to Ethan."
           }
         ],
         "integrations": [
           {
-            "description": "vm0's production database skill is required. It provides a read-only connection to your Postgres instance via securely managed credentials - no manual setup needed."
+            "description": "La skill de base de datos de producción de vm0 es obligatoria. Proporciona una conexión de solo lectura a tu instancia de Postgres mediante credenciales gestionadas de forma segura – sin necesidad de configuración manual."
           },
           {
-            "description": "Slack is where you ask the question and receive the result."
+            "description": "Slack es donde haces la pregunta y recibes el resultado."
           }
         ],
         "tips": [
-          "Always specify 'production database' or 'prod DB' in your prompt so Zero knows which connection to use if you have multiple environments.",
-          "Zero runs only SELECT queries. If you need to modify data, Zero will flag it and ask you to handle it through the appropriate workflow instead.",
-          "For sensitive queries, prefix with 'do not log the results' - Zero will deliver the answer in an ephemeral message visible only to you."
+          "Especifique siempre 'base de datos de producción' o 'prod DB' en su prompt para que Zero sepa qué conexión usar si tiene varios entornos.",
+          "Zero solo ejecuta queries SELECT. Si necesita modificar datos, Zero lo señalará y le pedirá que lo haga mediante el flujo de trabajo apropiado.",
+          "Para consultas sensibles, anteponga 'no registrar los resultados' – Zero entregará la respuesta en un mensaje efímero visible solo para usted."
         ]
       },
       "security-compliance": {
         "title": "Automatiza auditorías de compliance de infraestructura",
         "description": "Zero verifica su infraestructura contra requisitos de compliance en GitHub, proveedores cloud y documentación, y publica un informe estructurado.",
-        "timeSaved": "~2 hrs saved",
-        "scenario": "Your compliance team flags a question: where is customer data stored, and does it meet regional requirements? Answering it means checking your cloud provider configs, reading your deployment settings, cross-referencing documentation, and writing a summary. Zero does all of this from one Slack message - checking your Vercel regions, Cloudflare R2 config, and infrastructure files, then posting a structured brief.",
+        "timeSaved": "~2 h ahorradas",
+        "scenario": "Su equipo de cumplimiento plantea una pregunta: ¿dónde se almacenan los datos de clientes y cumplen los requisitos regionales? Responderla implica revisar las configuraciones del proveedor de nube, leer los ajustes de despliegue, contrastar la documentación y redactar un resumen. Zero hace todo esto desde un solo mensaje de Slack – revisa sus regiones de Vercel, la configuración de Cloudflare R2 y los archivos de infraestructura, y publica un brief estructurado.",
         "promptVariants": [
           {
-            "label": "Region audit",
+            "label": "Auditoría de regiones",
             "prompt": "@Zero check our infrastructure for data residency - where are our Cloudflare R2 buckets located, what region does Vercel deploy to, and is there any cross-region replication configured?"
           },
           {
-            "label": "Security review",
+            "label": "Revisión de seguridad",
             "prompt": "@Zero audit our GitHub repo for any hardcoded secrets or API keys accidentally committed in the last 90 days."
           },
           {
-            "label": "Compliance brief",
+            "label": "Brief de cumplimiento",
             "prompt": "@Zero research our infrastructure setup and write a brief on whether we meet SOC 2 Type I requirements for data storage and access controls. Save it to Notion under 'Compliance > SOC 2 Prep'."
           }
         ],
@@ -1675,74 +1675,74 @@
           },
           {
             "name": "Zero",
-            "text": "Cloudflare R2: Region set to auto (Cloudflare selects nearest region). No cross-region replication configured.\n\nVercel: Defaults to iad1 (US East, Washington DC) for serverless functions. Static assets served from CDN edge globally.\n\nSummary: Data is US-based by default. If EU residency is required, both R2 and Vercel need explicit region configuration."
+            "text": "Cloudflare R2: Región configurada como auto (Cloudflare selecciona la región más cercana). No hay replicación entre regiones configurada.\n\nVercel: Por defecto iad1 (Este de EE. UU., Washington DC) para serverless functions. Los assets estáticos se sirven globalmente vía CDN edge.\n\nResumen: Los datos están en EE. UU. por defecto. Si se requiere residencia en la UE, tanto R2 como Vercel necesitan configuración explícita de región."
           }
         ],
         "steps": [
           {
-            "title": "Zero gathers config from your infrastructure",
-            "description": "Zero reads your repository configuration files, deployment configs, and checks connected cloud services for the relevant settings."
+            "title": "Zero recopila la configuración de su infraestructura",
+            "description": "Zero lee los archivos de configuración y despliegue de su repositorio y consulta los servicios cloud conectados para obtener los ajustes relevantes."
           },
           {
-            "title": "Zero cross-references against the compliance requirement",
-            "description": "Zero maps each finding against the specific requirement - data residency, access control, encryption - and flags any gaps."
+            "title": "Zero contrasta con el requisito de cumplimiento",
+            "description": "Zero mapea cada hallazgo contra el requisito específico – residencia de datos, control de acceso, cifrado – y marca cualquier brecha."
           },
           {
-            "title": "Findings brief posted and optionally saved",
-            "description": "Zero posts a structured brief in Slack with findings per service and a summary recommendation. On request, it saves the full report to Notion."
+            "title": "Brief de hallazgos publicado y opcionalmente guardado",
+            "description": "Zero publica un brief estructurado en Slack con hallazgos por servicio y una recomendación resumen. Bajo petición, guarda el informe completo en Notion."
           }
         ],
         "nextActions": [
           {
-            "title": "Save to Notion for the audit",
-            "description": "Archive the findings for your compliance record",
+            "title": "Guardar en Notion para la auditoría",
+            "description": "Archivar los hallazgos para su registro de cumplimiento",
             "examplePrompt": "@Zero save the compliance brief to Notion under 'Compliance > Infrastructure Audit > April 2026'."
           },
           {
-            "title": "Create remediation issues",
-            "description": "Turn gaps into tracked engineering work",
+            "title": "Crear issues de remediación",
+            "description": "Convertir las brechas en trabajo de ingeniería rastreado",
             "examplePrompt": "@Zero create GitHub issues for each gap in the compliance brief. Label them compliance and assign to Ethan."
           },
           {
-            "title": "Schedule a quarterly audit",
-            "description": "Make compliance checks a recurring practice",
+            "title": "Programar una auditoría trimestral",
+            "description": "Convertir los chequeos de cumplimiento en práctica recurrente",
             "examplePrompt": "@Zero every quarter, run this infrastructure compliance check and post findings to #compliance."
           }
         ],
         "integrations": [
           {
-            "description": "GitHub is required. Zero reads your infrastructure and deployment config files from the repository."
+            "description": "GitHub es obligatorio. Zero lee sus archivos de configuración de infraestructura y despliegue del repositorio."
           },
           {
-            "description": "Notion is optional. Zero saves compliance briefs and findings for audit trail documentation."
+            "description": "Notion es opcional. Zero guarda briefs y hallazgos de cumplimiento para la documentación del audit trail."
           }
         ],
         "tips": [
-          "Be specific about the compliance framework or requirement - 'SOC 2 data residency' produces a more useful brief than 'check if we're compliant.'",
-          "Ask Zero to DM you the sensitive findings rather than posting to a channel - some compliance gaps shouldn't be broadcast publicly.",
-          "Archive findings to Notion immediately. Compliance auditors want documentation of the process, not just the conclusion."
+          "Sea específico sobre el marco o requisito de cumplimiento – 'residencia de datos SOC 2' produce un brief más útil que 'comprueba si cumplimos.'",
+          "Pida a Zero que le envíe por DM los hallazgos sensibles en lugar de publicarlos en un canal – algunas brechas de cumplimiento no deben difundirse públicamente.",
+          "Archive los hallazgos en Notion de inmediato. Los auditores de cumplimiento quieren documentación del proceso, no solo de la conclusión."
         ]
       },
       "cross-tool-context": {
         "title": "Estado unificado del proyecto desde múltiples herramientas",
         "description": "Pregunte a Zero sobre cualquier proyecto. Busca en sus herramientas en paralelo y sintetiza un briefing con estado, responsable, bloqueos y última actualización.",
-        "timeSaved": "~25 min saved",
-        "scenario": "Someone asks about the status of the Stripe integration. The last Slack thread is from two weeks ago. There's a Linear ticket but the status says 'In Progress' with no update. The Notion doc has a decision log from last month. GitHub has three open PRs. None of these sources tell the full story alone. Zero searches all four in parallel and gives you one answer.",
+        "timeSaved": "~25 min ahorrados",
+        "scenario": "Alguien pregunta por el estado de la integración con Stripe. El último hilo de Slack es de hace dos semanas. Hay un ticket en Linear, pero el estado dice 'En curso' sin actualización. El documento de Notion tiene un registro de decisiones del mes pasado. GitHub tiene tres PRs abiertos. Ninguna de estas fuentes cuenta la historia completa por sí sola. Zero busca en las cuatro en paralelo y le da una sola respuesta.",
         "promptVariants": [
           {
-            "label": "Basic",
+            "label": "Básico",
             "prompt": "@Zero what's the current status of the Stripe integration? Search Slack (last 14 days), Notion, Linear, and GitHub. Return: current state, owner, blockers, and last meaningful update with source."
           },
           {
-            "label": "Deep dive",
+            "label": "En profundidad",
             "prompt": "@Zero pull everything on the auth refactor from the last 30 days across Slack, Notion, Linear, and GitHub. Write a full status doc with owner, decision history, and what's next."
           },
           {
-            "label": "Scheduled",
+            "label": "Programado",
             "prompt": "@Zero every Monday morning, DM me a status brief on the mobile SDK project - current state, owner, blockers, last update."
           },
           {
-            "label": "Conflict-aware",
+            "label": "Sensible a conflictos",
             "prompt": "@Zero check Slack and Linear for the latest on the onboarding redesign and flag if the two sources disagree on status or ownership."
           }
         ],
@@ -1753,58 +1753,58 @@
           },
           {
             "name": "Zero",
-            "text": "Connector Architecture Refactor - Status Brief\n\nState: In progress - environment variables migrated from skill frontmatter to connector definitions. Core refactor merged.\nOwner: Lancy\nBlockers: None active.\nLast update: Apr 14 (GitHub) - PR #9312 merged.\n\nSources agree."
+            "text": "Refactor de Arquitectura de Conectores – Brief de Estado\n\nEstado: En progreso – las variables de entorno se migraron del frontmatter de la skill a las definiciones del conector. Refactor central mergeado.\nResponsable: Lancy\nBloqueos: Ninguno activo.\nÚltima actualización: 14 de abril (GitHub) – PR #9312 mergeado.\n\nLas fuentes coinciden."
           }
         ],
         "steps": [
           {
-            "title": "Zero searches all sources in parallel",
-            "description": "Zero queries Slack, Notion, Linear, and GitHub simultaneously for the topic within the specified time window - returning raw findings from each source."
+            "title": "Zero busca en todas las fuentes en paralelo",
+            "description": "Zero consulta Slack, Notion, Linear y GitHub simultáneamente sobre el tema dentro de la ventana de tiempo indicada – devolviendo hallazgos en bruto de cada fuente."
           },
           {
-            "title": "Zero synthesizes and flags conflicts",
-            "description": "Zero extracts state, owner, blockers, and last update per source. If sources disagree - e.g., Linear says 'Done' but Slack has an open question from yesterday - Zero flags the conflict explicitly."
+            "title": "Zero sintetiza y marca conflictos",
+            "description": "Zero extrae estado, responsable, bloqueos y última actualización por fuente. Si las fuentes no coinciden – p. ej., Linear dice 'Hecho' pero Slack tiene una pregunta abierta de ayer – Zero marca el conflicto explícitamente."
           },
           {
-            "title": "4-part brief delivered in Slack",
-            "description": "Zero returns: current state in one sentence, owner/DRI, active blockers, and the most recent meaningful update with its source citation."
+            "title": "Brief de 4 partes entregado en Slack",
+            "description": "Zero devuelve: estado actual en una frase, responsable/DRI, bloqueos activos y la actualización más reciente y significativa con su cita de fuente."
           }
         ],
         "nextActions": [
           {
-            "title": "Log the brief to Notion",
-            "description": "Create a searchable record of the status snapshot",
+            "title": "Registrar el brief en Notion",
+            "description": "Crear un registro buscable del snapshot de estado",
             "examplePrompt": "@Zero save this status brief to Notion under 'Project Status > Stripe Integration > April 2026'."
           },
           {
-            "title": "Schedule weekly updates",
-            "description": "Get a status DM every Monday without asking",
+            "title": "Programar actualizaciones semanales",
+            "description": "Recibir un DM de estado cada lunes sin pedirlo",
             "examplePrompt": "@Zero every Monday at 9am, DM me the status of the mobile SDK across Slack, Linear, and GitHub."
           },
           {
-            "title": "Escalate a blocker",
-            "description": "Turn a found blocker into a tracked issue",
+            "title": "Escalar un bloqueo",
+            "description": "Convertir un bloqueo encontrado en un issue rastreado",
             "examplePrompt": "@Zero the blocker you found - create a GitHub issue for it and assign to the owner."
           }
         ],
         "integrations": [
           {
-            "description": "Slack is required. It's the primary source of async discussion and where the brief is delivered."
+            "description": "Slack es obligatorio. Es la fuente principal de discusión asíncrona y donde se entrega el brief."
           },
           {
-            "description": "Linear is required. It's the source of truth for task ownership and current status."
+            "description": "Linear es obligatorio. Es la fuente de la verdad para la propiedad de tareas y el estado actual."
           },
           {
-            "description": "Notion is optional. Zero searches long-form decisions and context when included."
+            "description": "Notion es opcional. Zero busca decisiones y contexto de formato largo cuando se incluye."
           },
           {
-            "description": "GitHub is optional. Zero includes PR and commit activity for technical topics."
+            "description": "GitHub es opcional. Zero incluye actividad de PRs y commits para temas técnicos."
           }
         ],
         "tips": [
-          "Be specific - 'the Stripe integration' works better than 'the payment feature.' Specific terms match across tools; vague ones don't.",
-          "Add a time window for long-running projects: 'focus on the last 14 days' prevents Zero from surfacing stale context as if it's current.",
-          "Pair with Document Decisions to auto-log the brief to Notion - useful for recurring reviews where you want a historical snapshot per week."
+          "Sea específico – 'la integración con Stripe' funciona mejor que 'la función de pagos.' Los términos específicos hacen match entre herramientas; los vagos no.",
+          "Añada una ventana de tiempo para proyectos de larga duración: 'enfócate en los últimos 14 días' evita que Zero presente contexto obsoleto como si fuera actual.",
+          "Combínelo con Document Decisions para auto-registrar el brief en Notion – útil para revisiones recurrentes donde quiere un snapshot histórico por semana."
         ]
       },
       "multilingual-cms-publishing": {
@@ -2583,7 +2583,7 @@
             "prompt": "@Zero redacta un post de blog a partir de este hilo: estructúralo, llena los huecos y dame una URL de preview."
           },
           {
-            "label": "Use-case page",
+            "label": "Página de caso de uso",
             "prompt": "@Zero redacta una página de use case para [descripción del flujo]: sigue la estructura estándar, propón metadata (slug, color, avatar) y crea un PR."
           }
         ],
@@ -3680,7 +3680,7 @@
     "filter": {
       "all": "Todos",
       "everyone": "Multifuncional",
-      "engineering": "Engineering",
+      "engineering": "Ingeniería",
       "product": "Producto",
       "marketing": "Marketing",
       "sales": "Ventas",

--- a/turbo/apps/web/messages/ja.json
+++ b/turbo/apps/web/messages/ja.json
@@ -1272,7 +1272,7 @@
           },
           {
             "name": "Zero",
-            "text": "Scheduled. Running weekdays at 08:30.\n\nRun from this morning:\n*GitHub* - 96 PRs merged today vs 14.3 avg 🔴 572% spike (coordinated test refactor). Issues closed: 71 vs 28.6 avg 🟢.\n*Linear* - 0 issues created this week, 3 in backlog.\n*Sentry* - connector not configured.\n*Plausible* - connector not configured."
+            "text": "スケジュール済み。平日08:30に実行。\n\n今朝の実行結果:\n*GitHub* — 本日マージ済みPR 96件、平均14.3に対し 🔴 572%スパイク(テストリファクタの一斉投入)。クローズ済みイシュー: 71件、平均28.6 🟢。\n*Linear* — 今週作成された新規イシュー 0件、バックログに3件。\n*Sentry* — コネクター未設定。\n*Plausible* — コネクター未設定。"
           }
         ],
         "steps": [
@@ -1363,7 +1363,7 @@
           },
           {
             "name": "Zero",
-            "text": "Customer 360 - Acme Corp\n\nOverview: Enterprise, 6 months in, primary contact: James Chen (CTO)\nRecent Activity: 3 email threads Apr 1–10, last meeting Apr 8, 2 open Linear issues\nOpen Items: Unanswered email Apr 9 re: API limits, feature request #812 unassigned\n\nSummary:\n• Health: Engaged but technical blockers slowing adoption\n• Risk: No response to Apr 9 email for 5 days\n• Next: Follow up on API limits today, share #812 resolution timeline"
+            "text": "Customer 360 — Acme Corp\n\n概要: エンタープライズ、契約から6か月、主要連絡先: James Chen(CTO)\n直近の動き: 4月1〜10日にメールスレッド3件、最後のミーティングは4月8日、Linearのオープンイシュー2件\n未対応: API上限についての4月9日のメールが未返信、機能リクエスト#812が未アサイン\n\nまとめ:\n• ヘルス: 関与は高いが、技術的なブロッカーが導入を遅らせている\n• リスク: 4月9日のメールへの返信が5日間ない\n• 次の一手: 本日中にAPI上限の件をフォロー、#812の解決スケジュールを共有"
           }
         ],
         "steps": [
@@ -1450,7 +1450,7 @@
           },
           {
             "name": "Zero",
-            "text": "No digest sent Apr 13 - no topics met the 2-source threshold."
+            "text": "4月13日はダイジェスト未送信 — 2情報源以上を満たすトピックがありませんでした。"
           }
         ],
         "steps": [
@@ -1504,19 +1504,19 @@
       "pr-review": {
         "title": "AI搭載プルリクエストコードレビュー",
         "description": "ZeroがPRのdiffを読み、重大な問題をP0として検出、改善提案を優先順位付けしてSlackに報告。マージ前にチームが対応できます。",
-        "timeSaved": "~30 min saved per PR",
-        "scenario": "PRs pile up. Reviewers are busy. Someone hits 'approve' to clear their queue and a subtle bug ships. Zero gives every PR a thorough read without the queue. Point it at any PR number, and it returns a structured review - critical issues that must be fixed before merge, plus lower-priority suggestions - posted directly in Slack.",
+        "timeSaved": "PRあたり約30分の短縮",
+        "scenario": "PRが溜まる。レビュアーは忙しい。誰かがキューを空にするために「承認」を押し、微妙なバグが本番に出荷される。Zeroはキューに関係なく、すべてのPRを丁寧に読み込みます。任意のPR番号を指定すれば、構造化されたレビューを返します——マージ前に必ず修正すべき重大な問題と、優先度の低い改善提案を、Slackに直接投稿します。",
         "promptVariants": [
           {
-            "label": "Standard review",
+            "label": "標準レビュー",
             "prompt": "@Zero review vm0-ai/vm0#8886"
           },
           {
-            "label": "Focused review",
+            "label": "重点レビュー",
             "prompt": "@Zero review vm0-ai/vm0#9215 - focus on the auth middleware changes and any potential security issues."
           },
           {
-            "label": "Re-review after fixes",
+            "label": "修正後の再レビュー",
             "prompt": "@Zero re-review vm0-ai/vm0#8886 - I pushed a second commit addressing your P0 feedback."
           }
         ],
@@ -1527,70 +1527,70 @@
           },
           {
             "name": "Zero",
-            "text": "Review for vm0-ai/vm0#8886 - 1 commit reviewed.\n\nP0 (must fix before merge):\n• createPlainSupportThread has 5 paths that return false instead of throwing - silent failures in prod.\n\nP1 (improvement):\n• Error messages don't include the SDK error code - harder to debug from logs."
+            "text": "vm0-ai/vm0#8886のレビュー — 1コミットを確認。\n\nP0(マージ前に要修正):\n• createPlainSupportThreadには、例外を投げる代わりにfalseを返す経路が5つあります — 本番でのサイレントな失敗。\n\nP1(改善):\n• エラーメッセージにSDKエラーコードが含まれていません — ログからのデバッグが難しくなります。"
           }
         ],
         "steps": [
           {
-            "title": "Zero reads the full diff",
-            "description": "Zero fetches the PR via GitHub, reads every changed file, and understands the intent of the change from the PR title, description, and commit messages."
+            "title": "Zeroが差分全体を読み込む",
+            "description": "ZeroはGitHub経由でPRを取得し、変更されたすべてのファイルを読み、PRタイトル・説明・コミットメッセージから変更の意図を理解します。"
           },
           {
-            "title": "Zero ranks issues by severity",
-            "description": "Findings are classified as P0 (must fix before merge - bugs, security issues, silent failures) or P1 (improvements - better error handling, test coverage, naming)."
+            "title": "Zeroが重要度で問題を分類する",
+            "description": "検出事項はP0(マージ前に要修正 — バグ、セキュリティ問題、サイレントな失敗)またはP1(改善 — より良いエラー処理、テストカバレッジ、命名)に分類されます。"
           },
           {
-            "title": "Review posted to Slack",
-            "description": "Zero posts the full review in the Slack thread where it was requested, with specific file references and line numbers so the author knows exactly what to fix."
+            "title": "レビューをSlackに投稿",
+            "description": "Zeroは依頼されたSlackスレッドにレビュー全文を投稿し、具体的なファイルや行番号も併記するため、作成者は何を修正すべきかを正確に把握できます。"
           }
         ],
         "nextActions": [
           {
-            "title": "Create a GitHub issue from a finding",
-            "description": "Log a P0 as a tracked issue if it can't be fixed immediately",
+            "title": "検出事項からGitHubイシューを作成",
+            "description": "すぐに修正できないP0は追跡可能なイシューとして記録します",
             "examplePrompt": "@Zero create a GitHub issue for the P0 in that review. Assign to Ethan and label as bug, priority-high."
           },
           {
-            "title": "Re-review after changes",
-            "description": "Verify that P0 feedback was addressed",
+            "title": "変更後の再レビュー",
+            "description": "P0フィードバックが対応されたかを確認します",
             "examplePrompt": "@Zero re-review #8886, second commit - confirm the P0 is resolved."
           },
           {
-            "title": "Check CI status",
-            "description": "See if all checks pass before merging",
+            "title": "CIステータスを確認",
+            "description": "マージ前にすべてのチェックが通っているかを確認します",
             "examplePrompt": "@Zero what's the CI status on vm0-ai/vm0#8886? Is it safe to merge?"
           }
         ],
         "integrations": [
           {
-            "description": "GitHub is required. Zero needs read access to pull requests and the full diff."
+            "description": "GitHubは必須です。ZeroはPRと差分全体への読み取りアクセスを必要とします。"
           },
           {
-            "description": "Slack is where the review request is made and where findings are delivered."
+            "description": "Slackはレビュー依頼を行い、検出事項を受け取る場所です。"
           }
         ],
         "tips": [
-          "Include the specific concern in your prompt - 'focus on auth changes' or 'check for race conditions' - to get a more targeted review than a general diff scan.",
-          "Use re-review for iterative PRs. After the author pushes fixes, ask Zero to re-check only the P0 items to confirm they're resolved.",
-          "Set a team norm: Zero review before any merge to main. It catches the class of issues that slip through async human review."
+          "プロンプトに具体的な関心事を含めてください — 「認証関連の変更に注目」や「レースコンディションを確認」と書けば、一般的な差分スキャンよりも的を絞ったレビューが得られます。",
+          "反復的なPRには再レビューを使ってください。作成者が修正をプッシュした後、P0項目のみを再確認するようZeroに依頼すれば、解消されたか確認できます。",
+          "チームのルールとして、mainへのマージ前に必ずZeroレビューを行いましょう。非同期な人間のレビューをすり抜けるタイプの問題を捕捉します。"
         ]
       },
       "api-performance": {
         "title": "APIパフォーマンスボトルネックの調査",
         "description": "ZeroがAxiomからTP95データを取得し、最も遅いエンドポイントを特定、パターンを分析してGitHub Issueを作成します。",
-        "timeSaved": "~45 min saved",
-        "scenario": "TP95 spikes don't always page you. They sit in your metrics dashboards, quietly degrading user experience while your team is focused on shipping. Zero makes it easy to check any endpoint's performance on demand - pull the last 7 days of TP95 data, see which requests are slow, and get a GitHub issue filed automatically so nothing gets dropped.",
+        "timeSaved": "約45分の短縮",
+        "scenario": "TP95のスパイクは常にページャーを鳴らすわけではありません。チームが出荷に集中している間、メトリクスダッシュボードに居座って静かにユーザー体験を悪化させます。Zeroを使えば、任意のエンドポイントのパフォーマンスをオンデマンドで確認できます——直近7日間のTP95データを引き出し、どのリクエストが遅いかを見て、GitHubイシューを自動作成して取りこぼしを防ぎます。",
         "promptVariants": [
           {
-            "label": "TP95 check",
+            "label": "TP95チェック",
             "prompt": "@Zero check Axiom for the POST /api/zero/runs endpoint - show me the TP95 for the last 7 days and flag any events over 5s."
           },
           {
-            "label": "File an issue",
+            "label": "イシューを起票",
             "prompt": "@Zero pull Axiom TP95 for /api/zero/runs over the last 7 days and create a GitHub issue with the findings, assigned to Lancy."
           },
           {
-            "label": "Compare endpoints",
+            "label": "エンドポイント比較",
             "prompt": "@Zero compare the last 7 days of TP95 for /api/zero/runs vs /api/chat/send on Axiom. Which is slower and what's the pattern?"
           }
         ],
@@ -1601,70 +1601,70 @@
           },
           {
             "name": "Zero",
-            "text": "POST /api/zero/runs - 7-day TP95 summary:\n\nWorst: 6,857ms on Apr 12\nSlow events (>5s): 14 total\nRoot cause: sync dispatch pipeline blocks the response - it waits for sandbox allocation before returning.\n\nGitHub issue filed: vm0-ai/vm0#9682, assigned to Lancy."
+            "text": "POST /api/zero/runs — 直近7日間のTP95サマリ:\n\n最悪値: 4月12日に6,857ms\n遅いイベント(>5秒): 計14件\n根本原因: 同期ディスパッチパイプラインがレスポンスをブロック — サンドボックスの割り当てを待ってから返しています。\n\nGitHubイシュー作成: vm0-ai/vm0#9682、Lancyに割り当て。"
           }
         ],
         "steps": [
           {
-            "title": "Zero queries Axiom for the endpoint",
-            "description": "Zero pulls all request events for the specified endpoint over the time window, computing TP50, TP95, and TP99 per day."
+            "title": "ZeroがAxiomでエンドポイントをクエリ",
+            "description": "Zeroは指定された期間における該当エンドポイントのリクエストイベントをすべて取得し、日次でTP50・TP95・TP99を算出します。"
           },
           {
-            "title": "Zero surfaces slow events",
-            "description": "Zero filters for events above the threshold (default: 5 seconds), groups them by time of day and error pattern, and identifies the likely root cause."
+            "title": "Zeroが遅いイベントを抽出",
+            "description": "Zeroは閾値(デフォルト: 5秒)を超えるイベントを抽出し、時間帯やエラーパターンでグループ化し、想定される根本原因を特定します。"
           },
           {
-            "title": "GitHub issue created with findings",
-            "description": "Zero files a structured GitHub issue with the metric table, slow event list, and root cause analysis - ready for the engineering team to act on."
+            "title": "検出事項を含むGitHubイシューを作成",
+            "description": "Zeroはメトリクス表・遅いイベント一覧・根本原因分析を含む構造化されたGitHubイシューを起票し、エンジニアリングチームがすぐに対応できる状態にします。"
           }
         ],
         "nextActions": [
           {
-            "title": "Assign and prioritize",
-            "description": "Route the issue to the right engineer",
+            "title": "担当者割り当てと優先度設定",
+            "description": "適切なエンジニアにイシューを振り分けます",
             "examplePrompt": "@Zero assign the Axiom issue to Ethan and add the label performance, priority-high."
           },
           {
-            "title": "Schedule regular monitoring",
-            "description": "Set up a weekly TP95 check for key endpoints",
+            "title": "定期的なモニタリングをスケジュール",
+            "description": "主要エンドポイントの週次TP95チェックを設定します",
             "examplePrompt": "@Zero every Monday at 9am, pull the last 7 days of TP95 for /api/zero/runs and post to #dev. File a GitHub issue only if TP95 exceeds 3s."
           },
           {
-            "title": "Investigate a specific slow event",
-            "description": "Dig into a single outlier event",
+            "title": "特定の遅いイベントを調査",
+            "description": "単一の外れ値イベントを深掘りします",
             "examplePrompt": "@Zero pull the full trace for the 6,857ms event on Apr 12 from Axiom and tell me where the time is spent."
           }
         ],
         "integrations": [
           {
-            "description": "Axiom is required. Zero queries your Axiom dataset for request events filtered by endpoint path and time window."
+            "description": "Axiomは必須です。Zeroはエンドポイントパスと時間ウィンドウでフィルタしたリクエストイベントについて、Axiomデータセットをクエリします。"
           },
           {
-            "description": "GitHub is optional. Zero creates issues from findings when asked, with the metric table embedded in the body."
+            "description": "GitHubは任意です。依頼に応じて、Zeroは検出事項からイシューを作成し、本文にメトリクス表を埋め込みます。"
           }
         ],
         "tips": [
-          "Specify a threshold in your prompt - 'flag events over 3 seconds' - so Zero's findings match your SLO, not a generic cutoff.",
-          "Ask Zero to check the endpoint right after a deploy to catch regressions before they affect users at scale.",
-          "Combine with Daily Error Triage for a complete morning health check: errors from Sentry plus performance from Axiom in one brief."
+          "プロンプトで閾値を指定してください — 「3秒を超えるイベントをフラグ」と書けば、汎用的なカットオフではなく自社のSLOに沿った検出になります。",
+          "デプロイ直後にエンドポイントを確認するようZeroに依頼し、ユーザーに大規模に影響する前にリグレッションを捉えましょう。",
+          "Daily Error Triageと組み合わせれば、SentryのエラーとAxiomのパフォーマンスが一つのブリーフにまとまり、朝のヘルスチェックが完結します。"
         ]
       },
       "production-db-query": {
         "title": "自然言語で本番データをクエリ",
         "description": "本番データについてZeroに質問するだけ。SQLを生成し、読み取り専用でライブデータベースに対して実行、結果をSlackで回答します。",
-        "timeSaved": "~20 min saved",
-        "scenario": "A stakeholder asks how many users completed onboarding in the last 30 days. It's a simple question, but answering it means opening a DB client, finding the right table, writing a query, making sure you're on read-only credentials, running it, and formatting the result. Zero handles the whole chain - just ask the question in Slack.",
+        "timeSaved": "約20分の短縮",
+        "scenario": "ステークホルダーが「直近30日でオンボーディングを完了したユーザーは何人?」と聞いてきます。簡単な質問ですが、答えるにはDBクライアントを開き、正しいテーブルを探し、クエリを書き、リードオンリーの認証情報を使っているか確認し、実行し、結果を整形する必要があります。Zeroはこの一連の流れをすべて処理します — Slackで質問するだけです。",
         "promptVariants": [
           {
-            "label": "Count query",
+            "label": "カウントクエリ",
             "prompt": "@Zero how many users signed up in the last 30 days? Query the production database."
           },
           {
-            "label": "Trend query",
+            "label": "トレンドクエリ",
             "prompt": "@Zero query production - show me daily active user counts for the last 14 days, broken down by plan tier."
           },
           {
-            "label": "Anomaly check",
+            "label": "異常値チェック",
             "prompt": "@Zero check production DB - are there any users with a free credit balance above 1000? List the top 10."
           }
         ],
@@ -1675,70 +1675,70 @@
           },
           {
             "name": "Zero",
-            "text": "Production DB query result (read-only):\n\nzero_runs created in last 7 days: 4,218\nBreakdown: Mon 523, Tue 641, Wed 688, Thu 712, Fri 654\nWeekend: 0 (expected - team usage pattern)\n\nQuery ran in 42ms."
+            "text": "本番DBクエリ結果(リードオンリー):\n\n直近7日間に作成されたzero_runs: 4,218\n内訳: 月 523、火 641、水 688、木 712、金 654\n週末: 0(想定どおり — チームの利用パターン)\n\nクエリ実行時間: 42ms。"
           }
         ],
         "steps": [
           {
-            "title": "Zero interprets your question",
-            "description": "Zero maps your plain-language question to the relevant tables and columns in your production schema."
+            "title": "Zeroが質問を解釈",
+            "description": "Zeroは自然言語の質問を、本番スキーマの該当テーブルとカラムにマッピングします。"
           },
           {
-            "title": "Zero runs a read-only query",
-            "description": "Zero executes only SELECT statements against production. No writes, no mutations. Credentials are retrieved securely via Doppler - they never appear in the conversation."
+            "title": "Zeroがリードオンリークエリを実行",
+            "description": "Zeroは本番に対してSELECT文のみを実行します。書き込みも変更もありません。認証情報はDoppler経由で安全に取得され、会話には一切現れません。"
           },
           {
-            "title": "Results returned in Slack",
-            "description": "Zero posts the query result in the thread, formatted as a readable summary. For large result sets, it returns the key numbers and offers to export the full table."
+            "title": "結果をSlackに返却",
+            "description": "Zeroはクエリ結果を読みやすいサマリとしてスレッドに投稿します。大きな結果セットの場合は主要な数値を返し、完全なテーブルのエクスポートも提案します。"
           }
         ],
         "nextActions": [
           {
-            "title": "Export to a spreadsheet",
-            "description": "Get the full result set in a usable format",
+            "title": "スプレッドシートにエクスポート",
+            "description": "完全な結果セットを使える形式で取得します",
             "examplePrompt": "@Zero re-run that query and export the results to a Google Sheet named 'DAU by Plan - April 2026'."
           },
           {
-            "title": "Schedule a recurring count",
-            "description": "Track a metric automatically",
+            "title": "定期的なカウントをスケジュール",
+            "description": "メトリクスを自動で追跡します",
             "examplePrompt": "@Zero every Monday morning, query production for last week's new user count and post to #metrics."
           },
           {
-            "title": "File an issue from a finding",
-            "description": "Escalate an anomaly you discovered",
+            "title": "検出事項からイシューを起票",
+            "description": "発見した異常をエスカレーションします",
             "examplePrompt": "@Zero create a GitHub issue for the users with credit balance above 1000 - title 'Credit balance anomaly', assign to Ethan."
           }
         ],
         "integrations": [
           {
-            "description": "vm0's production database skill is required. It provides a read-only connection to your Postgres instance via securely managed credentials - no manual setup needed."
+            "description": "vm0の本番データベーススキルが必須です。安全に管理された認証情報経由でPostgresインスタンスへのリードオンリー接続を提供します — 手動セットアップは不要です。"
           },
           {
-            "description": "Slack is where you ask the question and receive the result."
+            "description": "Slackは質問を投げ、結果を受け取る場所です。"
           }
         ],
         "tips": [
-          "Always specify 'production database' or 'prod DB' in your prompt so Zero knows which connection to use if you have multiple environments.",
-          "Zero runs only SELECT queries. If you need to modify data, Zero will flag it and ask you to handle it through the appropriate workflow instead.",
-          "For sensitive queries, prefix with 'do not log the results' - Zero will deliver the answer in an ephemeral message visible only to you."
+          "プロンプトには必ず「本番データベース」または「prod DB」と明記してください。複数環境がある場合、Zeroがどの接続を使うべきか判断できます。",
+          "ZeroはSELECTクエリのみを実行します。データを変更する必要がある場合、Zeroはそれを指摘し、適切なワークフローで対応するよう求めます。",
+          "機微なクエリでは「結果をログに残さない」と先に伝えてください — Zeroはあなたにのみ見えるエフェメラルメッセージで回答します。"
         ]
       },
       "security-compliance": {
         "title": "インフラコンプライアンス監査の自動化",
         "description": "ZeroがGitHub、クラウドプロバイダー、ドキュメントを横断してインフラをコンプライアンス要件と照合し、構造化された調査結果を投稿します。",
-        "timeSaved": "~2 hrs saved",
-        "scenario": "Your compliance team flags a question: where is customer data stored, and does it meet regional requirements? Answering it means checking your cloud provider configs, reading your deployment settings, cross-referencing documentation, and writing a summary. Zero does all of this from one Slack message - checking your Vercel regions, Cloudflare R2 config, and infrastructure files, then posting a structured brief.",
+        "timeSaved": "約2時間の短縮",
+        "scenario": "コンプライアンスチームから「顧客データはどこに保存され、地域要件を満たしているか?」という質問が来ます。回答するにはクラウドプロバイダの設定を確認し、デプロイ設定を読み、ドキュメントと突き合わせてサマリを書く必要があります。Zeroはこれをすべて1つのSlackメッセージで実行 — VercelのリージョンとCloudflare R2の設定、インフラファイルをチェックし、構造化されたブリーフを投稿します。",
         "promptVariants": [
           {
-            "label": "Region audit",
+            "label": "リージョン監査",
             "prompt": "@Zero check our infrastructure for data residency - where are our Cloudflare R2 buckets located, what region does Vercel deploy to, and is there any cross-region replication configured?"
           },
           {
-            "label": "Security review",
+            "label": "セキュリティレビュー",
             "prompt": "@Zero audit our GitHub repo for any hardcoded secrets or API keys accidentally committed in the last 90 days."
           },
           {
-            "label": "Compliance brief",
+            "label": "コンプライアンスブリーフ",
             "prompt": "@Zero research our infrastructure setup and write a brief on whether we meet SOC 2 Type I requirements for data storage and access controls. Save it to Notion under 'Compliance > SOC 2 Prep'."
           }
         ],
@@ -1749,74 +1749,74 @@
           },
           {
             "name": "Zero",
-            "text": "Cloudflare R2: Region set to auto (Cloudflare selects nearest region). No cross-region replication configured.\n\nVercel: Defaults to iad1 (US East, Washington DC) for serverless functions. Static assets served from CDN edge globally.\n\nSummary: Data is US-based by default. If EU residency is required, both R2 and Vercel need explicit region configuration."
+            "text": "Cloudflare R2: リージョンはauto設定(Cloudflareが最寄りのリージョンを選択)。クロスリージョンレプリケーションは未設定。\n\nVercel: サーバーレス関数はデフォルトでiad1(米国東部、ワシントンDC)。静的アセットはCDNエッジ経由でグローバル配信。\n\nまとめ: データはデフォルトで米国内に置かれます。EU内のデータ所在が必要な場合は、R2とVercelの両方で明示的なリージョン設定が必要です。"
           }
         ],
         "steps": [
           {
-            "title": "Zero gathers config from your infrastructure",
-            "description": "Zero reads your repository configuration files, deployment configs, and checks connected cloud services for the relevant settings."
+            "title": "Zeroがインフラから設定を収集",
+            "description": "Zeroはリポジトリの設定ファイルとデプロイ設定を読み、接続済みクラウドサービスから関連する設定を確認します。"
           },
           {
-            "title": "Zero cross-references against the compliance requirement",
-            "description": "Zero maps each finding against the specific requirement - data residency, access control, encryption - and flags any gaps."
+            "title": "Zeroがコンプライアンス要件と突き合わせ",
+            "description": "Zeroは各検出事項を具体的な要件 — データ所在、アクセス制御、暗号化 — と照合し、ギャップをフラグします。"
           },
           {
-            "title": "Findings brief posted and optionally saved",
-            "description": "Zero posts a structured brief in Slack with findings per service and a summary recommendation. On request, it saves the full report to Notion."
+            "title": "ブリーフを投稿、必要に応じて保存",
+            "description": "Zeroはサービスごとの検出事項とサマリの推奨事項を含む構造化ブリーフをSlackに投稿します。依頼に応じて、完全なレポートをNotionに保存します。"
           }
         ],
         "nextActions": [
           {
-            "title": "Save to Notion for the audit",
-            "description": "Archive the findings for your compliance record",
+            "title": "監査のためにNotionに保存",
+            "description": "コンプライアンス記録のために検出事項をアーカイブします",
             "examplePrompt": "@Zero save the compliance brief to Notion under 'Compliance > Infrastructure Audit > April 2026'."
           },
           {
-            "title": "Create remediation issues",
-            "description": "Turn gaps into tracked engineering work",
+            "title": "改善イシューを作成",
+            "description": "ギャップを追跡可能なエンジニアリング作業に変換します",
             "examplePrompt": "@Zero create GitHub issues for each gap in the compliance brief. Label them compliance and assign to Ethan."
           },
           {
-            "title": "Schedule a quarterly audit",
-            "description": "Make compliance checks a recurring practice",
+            "title": "四半期監査をスケジュール",
+            "description": "コンプライアンスチェックを定例化します",
             "examplePrompt": "@Zero every quarter, run this infrastructure compliance check and post findings to #compliance."
           }
         ],
         "integrations": [
           {
-            "description": "GitHub is required. Zero reads your infrastructure and deployment config files from the repository."
+            "description": "GitHubは必須です。Zeroはリポジトリからインフラ・デプロイ設定ファイルを読みます。"
           },
           {
-            "description": "Notion is optional. Zero saves compliance briefs and findings for audit trail documentation."
+            "description": "Notionは任意です。Zeroは監査トレイル文書のためにコンプライアンスブリーフと検出事項を保存します。"
           }
         ],
         "tips": [
-          "Be specific about the compliance framework or requirement - 'SOC 2 data residency' produces a more useful brief than 'check if we're compliant.'",
-          "Ask Zero to DM you the sensitive findings rather than posting to a channel - some compliance gaps shouldn't be broadcast publicly.",
-          "Archive findings to Notion immediately. Compliance auditors want documentation of the process, not just the conclusion."
+          "コンプライアンスフレームワークや要件を具体的に書いてください — 「SOC 2のデータ所在」のほうが「コンプライアンスに沿っているか確認して」よりも有用なブリーフになります。",
+          "機微な検出事項はチャンネル投稿ではなくDMで送るようZeroに依頼してください — 公にすべきでないコンプライアンスギャップもあります。",
+          "検出事項はすぐにNotionにアーカイブしましょう。コンプライアンス監査人は結論だけでなく、プロセスの記録も求めます。"
         ]
       },
       "cross-tool-context": {
         "title": "複数ツールからの統合プロジェクトステータス",
         "description": "Zeroにプロジェクトについて質問するだけ。ツールを並行検索し、状態、担当者、ブロッカー、最終更新をまとめたブリーフを作成します。",
-        "timeSaved": "~25 min saved",
-        "scenario": "Someone asks about the status of the Stripe integration. The last Slack thread is from two weeks ago. There's a Linear ticket but the status says 'In Progress' with no update. The Notion doc has a decision log from last month. GitHub has three open PRs. None of these sources tell the full story alone. Zero searches all four in parallel and gives you one answer.",
+        "timeSaved": "約25分の短縮",
+        "scenario": "誰かがStripe連携の状況を尋ねます。最後のSlackスレッドは2週間前。Linearチケットはありますが、ステータスは「進行中」のまま更新なし。Notionドキュメントには先月の意思決定ログ。GitHubにはオープンなPRが3件。どの情報源も単独では全体像を語りません。Zeroは4つすべてを並行検索し、1つの回答にまとめます。",
         "promptVariants": [
           {
-            "label": "Basic",
+            "label": "ベーシック",
             "prompt": "@Zero what's the current status of the Stripe integration? Search Slack (last 14 days), Notion, Linear, and GitHub. Return: current state, owner, blockers, and last meaningful update with source."
           },
           {
-            "label": "Deep dive",
+            "label": "深掘り",
             "prompt": "@Zero pull everything on the auth refactor from the last 30 days across Slack, Notion, Linear, and GitHub. Write a full status doc with owner, decision history, and what's next."
           },
           {
-            "label": "Scheduled",
+            "label": "スケジュール実行",
             "prompt": "@Zero every Monday morning, DM me a status brief on the mobile SDK project - current state, owner, blockers, last update."
           },
           {
-            "label": "Conflict-aware",
+            "label": "コンフリクト検知",
             "prompt": "@Zero check Slack and Linear for the latest on the onboarding redesign and flag if the two sources disagree on status or ownership."
           }
         ],
@@ -1827,58 +1827,58 @@
           },
           {
             "name": "Zero",
-            "text": "Connector Architecture Refactor - Status Brief\n\nState: In progress - environment variables migrated from skill frontmatter to connector definitions. Core refactor merged.\nOwner: Lancy\nBlockers: None active.\nLast update: Apr 14 (GitHub) - PR #9312 merged.\n\nSources agree."
+            "text": "コネクターアーキテクチャリファクタ — ステータスブリーフ\n\n状態: 進行中 — 環境変数をスキルのフロントマターからコネクター定義へ移行。コアリファクタはマージ済み。\n責任者: Lancy\nブロッカー: 現在なし。\n最終更新: 4月14日(GitHub) — PR #9312マージ。\n\n各情報源は一致しています。"
           }
         ],
         "steps": [
           {
-            "title": "Zero searches all sources in parallel",
-            "description": "Zero queries Slack, Notion, Linear, and GitHub simultaneously for the topic within the specified time window - returning raw findings from each source."
+            "title": "Zeroがすべての情報源を並行検索",
+            "description": "ZeroはSlack、Notion、Linear、GitHubに対し、指定された期間内で同時にトピックを検索し、各情報源から生の検出結果を返します。"
           },
           {
-            "title": "Zero synthesizes and flags conflicts",
-            "description": "Zero extracts state, owner, blockers, and last update per source. If sources disagree - e.g., Linear says 'Done' but Slack has an open question from yesterday - Zero flags the conflict explicitly."
+            "title": "Zeroが統合し、矛盾をフラグ",
+            "description": "Zeroは情報源ごとに状態・責任者・ブロッカー・最終更新を抽出します。情報源同士が食い違う場合 — 例: Linearは「完了」だがSlackには昨日のオープンな質問がある — Zeroは明示的にコンフリクトをフラグします。"
           },
           {
-            "title": "4-part brief delivered in Slack",
-            "description": "Zero returns: current state in one sentence, owner/DRI, active blockers, and the most recent meaningful update with its source citation."
+            "title": "Slackに4部構成のブリーフを配信",
+            "description": "Zeroは次を返します: 一文での現在の状態、責任者/DRI、アクティブなブロッカー、出典付きの最新の重要更新。"
           }
         ],
         "nextActions": [
           {
-            "title": "Log the brief to Notion",
-            "description": "Create a searchable record of the status snapshot",
+            "title": "ブリーフをNotionに記録",
+            "description": "ステータススナップショットを検索可能な記録として残します",
             "examplePrompt": "@Zero save this status brief to Notion under 'Project Status > Stripe Integration > April 2026'."
           },
           {
-            "title": "Schedule weekly updates",
-            "description": "Get a status DM every Monday without asking",
+            "title": "週次更新をスケジュール",
+            "description": "依頼なしで毎週月曜にステータスDMを受け取ります",
             "examplePrompt": "@Zero every Monday at 9am, DM me the status of the mobile SDK across Slack, Linear, and GitHub."
           },
           {
-            "title": "Escalate a blocker",
-            "description": "Turn a found blocker into a tracked issue",
+            "title": "ブロッカーをエスカレーション",
+            "description": "見つかったブロッカーを追跡可能なイシューに変換します",
             "examplePrompt": "@Zero the blocker you found - create a GitHub issue for it and assign to the owner."
           }
         ],
         "integrations": [
           {
-            "description": "Slack is required. It's the primary source of async discussion and where the brief is delivered."
+            "description": "Slackは必須です。非同期な議論の主要な情報源であり、ブリーフが配信される場所です。"
           },
           {
-            "description": "Linear is required. It's the source of truth for task ownership and current status."
+            "description": "Linearは必須です。タスクのオーナーシップと現在のステータスの真実の情報源です。"
           },
           {
-            "description": "Notion is optional. Zero searches long-form decisions and context when included."
+            "description": "Notionは任意です。指定された場合、Zeroは長文の意思決定やコンテキストを検索します。"
           },
           {
-            "description": "GitHub is optional. Zero includes PR and commit activity for technical topics."
+            "description": "GitHubは任意です。技術的なトピックではPRやコミットの活動も含めます。"
           }
         ],
         "tips": [
-          "Be specific - 'the Stripe integration' works better than 'the payment feature.' Specific terms match across tools; vague ones don't.",
-          "Add a time window for long-running projects: 'focus on the last 14 days' prevents Zero from surfacing stale context as if it's current.",
-          "Pair with Document Decisions to auto-log the brief to Notion - useful for recurring reviews where you want a historical snapshot per week."
+          "具体的にしてください — 「Stripe連携」のほうが「決済機能」よりもうまく機能します。具体的な用語はツールをまたいでマッチしますが、曖昧な用語は一致しません。",
+          "長期プロジェクトには期間ウィンドウを追加してください: 「直近14日に絞って」と書けば、古いコンテキストを最新であるかのようにZeroが提示するのを防げます。",
+          "Document Decisionsと組み合わせて、ブリーフを自動的にNotionに記録しましょう — 週ごとの履歴スナップショットを残したい定例レビューに有用です。"
         ]
       },
       "daily-email-triage": {
@@ -3680,7 +3680,7 @@
     "filter": {
       "all": "すべて",
       "everyone": "横断的",
-      "engineering": "Engineering",
+      "engineering": "エンジニアリング",
       "product": "プロダクト",
       "marketing": "マーケティング",
       "sales": "セールス",


### PR DESCRIPTION
## Summary

Five use cases shipped with only `title` + `description` translated to de/es/ja — everything else (`scenario`, `timeSaved`, `steps`, `tips`, `integrations`, `nextActions`, `promptVariants[].label`, Zero's Slack-preview responses) was still English. Filled them in.

Slugs covered:
- `pr-review`
- `api-performance`
- `production-db-query`
- `security-compliance`
- `cross-tool-context`

Also patched stragglers in `daily-engineering-brief`, `customer-360`, and `trending-topic-radar` where Zero's simulated Slack response was still English, plus `control-verification.promptVariants[2].label` (de) and `brief-to-draft-content.promptVariants[2].label` (es).

Fixed `filter.engineering` inconsistencies:
- `es`: "Engineering" → "Ingeniería"
- `ja`: "Engineering" → "エンジニアリング"

**Kept verbatim across all locales (intentional):**
- Personal names in `slackPreview[].name`
- `@Zero ...` command prompts in `promptVariants[].prompt` and `nextActions[].examplePrompt` — literal commands users would type
- The user-typed `@Zero` command in `slackPreview[0].text`
- Loanwords where the original translator chose consistently: de `Marketing`/`Support`/`Compliance`/`Engineering`/`Optional`/`Batch`, es `Marketing`

## Diff scope

No key paths added or removed — only leaf string values changed. Structure matches `en.json` exactly (verified all 2,475 useCases paths).

## Test plan
- [ ] `turbo/apps/web/src/__tests__/use-cases-data.test.ts` passes
- [ ] Spot-check pr-review, api-performance, production-db-query, security-compliance, cross-tool-context detail pages in each locale
- [ ] Verify the role filter chip in `/{de,es,ja}/use-cases` shows the corrected label

🤖 Generated with [Claude Code](https://claude.com/claude-code)