### PR TITLE
fix: close local-agent host on shutdown

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-local-agent-hosts.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-local-agent-hosts.test.ts
@@ -1,0 +1,100 @@
+import { createHash, randomUUID } from "node:crypto";
+
+import { localAgentHosts } from "@vm0/db/schema/local-agent";
+import { createStore } from "ccstate";
+import { eq } from "drizzle-orm";
+import { afterEach } from "vitest";
+
+import { createApp } from "../../../app-factory";
+import { testContext } from "../../../__tests__/test-helpers";
+import { nowDate } from "../../../lib/time";
+import { writeDb$ } from "../../external/db";
+import { ROUTES } from "../../route";
+
+const context = testContext();
+const store = createStore();
+
+function hashToken(token: string): string {
+  return createHash("sha256").update(token).digest("hex");
+}
+
+async function seedLocalAgentHost(args: {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly hostToken: string;
+}): Promise<string> {
+  const writeDb = store.set(writeDb$);
+  const now = nowDate();
+  const [host] = await writeDb
+    .insert(localAgentHosts)
+    .values({
+      orgId: args.orgId,
+      userId: args.userId,
+      displayName: `host-${randomUUID()}`,
+      tokenHash: hashToken(args.hostToken),
+      supportedBackends: ["codex"],
+      status: "online",
+      lastSeenAt: now,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .returning({ id: localAgentHosts.id });
+
+  if (!host) {
+    throw new Error("Failed to seed local-agent host");
+  }
+  return host.id;
+}
+
+async function closeHost(hostToken: string): Promise<Response> {
+  const app = createApp({ signal: context.signal, routes: ROUTES });
+  return await app.request("/api/zero/local-agent/hosts/close", {
+    method: "POST",
+    headers: { authorization: `Bearer ${hostToken}` },
+  });
+}
+
+describe("POST /api/zero/local-agent/hosts/close", () => {
+  const orgIds: string[] = [];
+
+  afterEach(async () => {
+    const writeDb = store.set(writeDb$);
+    while (orgIds.length > 0) {
+      const orgId = orgIds.pop();
+      if (orgId) {
+        await writeDb
+          .delete(localAgentHosts)
+          .where(eq(localAgentHosts.orgId, orgId));
+      }
+    }
+  });
+
+  it("marks the authenticated local-agent host closed", async () => {
+    const orgId = `org_${randomUUID()}`;
+    const userId = `user_${randomUUID()}`;
+    const hostToken = `vm0_remote_host_${randomUUID()}`;
+    orgIds.push(orgId);
+    const hostId = await seedLocalAgentHost({ orgId, userId, hostToken });
+
+    const response = await closeHost(hostToken);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toStrictEqual({ ok: true });
+
+    const writeDb = store.set(writeDb$);
+    const [host] = await writeDb
+      .select({ status: localAgentHosts.status })
+      .from(localAgentHosts)
+      .where(eq(localAgentHosts.id, hostId));
+    expect(host?.status).toBe("closed");
+  });
+
+  it("rejects invalid local-agent host tokens", async () => {
+    const response = await closeHost("invalid-token");
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toMatchObject({
+      error: { code: "UNAUTHORIZED" },
+    });
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-local-agent.ts
+++ b/turbo/apps/api/src/signals/routes/zero-local-agent.ts
@@ -17,6 +17,7 @@ import { bodyResultOf, pathParamsOf, queryOf } from "../context/request";
 import {
   claimLocalAgentDeviceCode$,
   claimNextLocalAgentHostJob$,
+  closeLocalAgentHost$,
   completeLocalAgentHostJob$,
   createLocalAgentDeviceCode$,
   createLocalAgentHostRealtimeToken$,
@@ -262,6 +263,22 @@ const hostsDeleteInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   return { status: 200 as const, body: { ok: true as const } };
 });
 
+const hostsCloseInner$ = command(async ({ get, set }, signal: AbortSignal) => {
+  const hostToken = parseBearerToken(get(authorization$));
+  if (!hostToken) {
+    return unauthorizedLocalAgent;
+  }
+
+  const result = await set(closeLocalAgentHost$, { hostToken }, signal);
+  signal.throwIfAborted();
+
+  if (!result) {
+    return invalidLocalAgentToken;
+  }
+
+  return { status: 200 as const, body: { ok: true as const } };
+});
+
 const runListQuery$ = queryOf(zeroLocalAgentRunContract.list);
 const runListInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   const auth = get(organizationAuthContext$);
@@ -483,6 +500,10 @@ export const zeroLocalAgentRoutes: readonly RouteEntry[] = [
   {
     route: zeroLocalAgentHostsContract.delete,
     handler: authRoute(localAgentAuthOptions, hostsDeleteInner$),
+  },
+  {
+    route: zeroLocalAgentHostsContract.close,
+    handler: hostsCloseInner$,
   },
   {
     route: zeroLocalAgentRunContract.list,

--- a/turbo/apps/api/src/signals/services/zero-local-agent.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-local-agent.service.ts
@@ -556,6 +556,60 @@ export const heartbeatLocalAgentHost$ = command(
   },
 );
 
+export const closeLocalAgentHost$ = command(
+  async (
+    { set },
+    params: {
+      readonly hostToken: string;
+    },
+    signal: AbortSignal,
+  ): Promise<{ readonly hostId: string } | null> => {
+    const writeDb = set(writeDb$);
+    const now = nowDate();
+    const [existing] = await writeDb
+      .select()
+      .from(localAgentHosts)
+      .where(
+        and(
+          eq(localAgentHosts.tokenHash, hashSecret(params.hostToken)),
+          isNull(localAgentHosts.revokedAt),
+        ),
+      )
+      .limit(1);
+    signal.throwIfAborted();
+
+    if (!existing) {
+      return null;
+    }
+
+    const wasOnline = localAgentHostStatus(existing, now) === "online";
+    const [row] = await writeDb
+      .update(localAgentHosts)
+      .set({
+        status: "closed",
+        updatedAt: now,
+      })
+      .where(
+        and(
+          eq(localAgentHosts.id, existing.id),
+          isNull(localAgentHosts.revokedAt),
+        ),
+      )
+      .returning({ id: localAgentHosts.id, userId: localAgentHosts.userId });
+    signal.throwIfAborted();
+
+    if (!row) {
+      return null;
+    }
+
+    if (wasOnline) {
+      await publishLocalAgentHostsChangedSafe(row.userId, signal);
+    }
+
+    return { hostId: row.id };
+  },
+);
+
 export const createLocalAgentHostRealtimeToken$ = command(
   async (
     { set },

--- a/turbo/apps/cli/src/commands/zero/local-agent/__tests__/host.test.ts
+++ b/turbo/apps/cli/src/commands/zero/local-agent/__tests__/host.test.ts
@@ -1,0 +1,100 @@
+import type { LocalAgentHost } from "@vm0/api-contracts/contracts/zero-local-agent";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+  class MockApiRequestError extends Error {
+    readonly code: string;
+    readonly status: number;
+
+    constructor(message: string, code: string, status: number) {
+      super(message);
+      this.code = code;
+      this.status = status;
+    }
+  }
+
+  return {
+    ApiRequestError: MockApiRequestError,
+    claimNextLocalAgentHostJob: vi.fn(),
+    closeLocalAgentHost: vi.fn(),
+    completeLocalAgentHostJob: vi.fn(),
+    createLocalAgentHostRealtimeSubscription: vi.fn(),
+    isInteractive: vi.fn(),
+    listLocalAgentHosts: vi.fn(),
+    promptSelect: vi.fn(),
+    promptText: vi.fn(),
+    sendLocalAgentHeartbeat: vi.fn(),
+    startLocalAgentHost: vi.fn(),
+  };
+});
+
+vi.mock("../../../../lib/api", () => {
+  return {
+    ApiRequestError: mocks.ApiRequestError,
+    claimNextLocalAgentHostJob: mocks.claimNextLocalAgentHostJob,
+    closeLocalAgentHost: mocks.closeLocalAgentHost,
+    completeLocalAgentHostJob: mocks.completeLocalAgentHostJob,
+    createLocalAgentHostRealtimeSubscription:
+      mocks.createLocalAgentHostRealtimeSubscription,
+    listLocalAgentHosts: mocks.listLocalAgentHosts,
+    sendLocalAgentHeartbeat: mocks.sendLocalAgentHeartbeat,
+    startLocalAgentHost: mocks.startLocalAgentHost,
+  };
+});
+
+vi.mock("../../../../lib/utils/prompt-utils", () => {
+  return {
+    isInteractive: mocks.isInteractive,
+    promptSelect: mocks.promptSelect,
+    promptText: mocks.promptText,
+  };
+});
+
+describe("local-agent host start selection", () => {
+  const closedHost = {
+    id: "host-closed",
+    displayName: "laptop",
+    supportedBackends: ["codex"],
+    status: "closed",
+    lastSeenAt: "2026-05-18T00:00:00.000Z",
+    createdAt: "2026-05-18T00:00:00.000Z",
+  } satisfies LocalAgentHost;
+
+  beforeEach(() => {
+    mocks.claimNextLocalAgentHostJob.mockReset();
+    mocks.closeLocalAgentHost.mockReset();
+    mocks.completeLocalAgentHostJob.mockReset();
+    mocks.createLocalAgentHostRealtimeSubscription.mockReset();
+    mocks.isInteractive.mockReset();
+    mocks.listLocalAgentHosts.mockReset();
+    mocks.promptSelect.mockReset();
+    mocks.promptText.mockReset();
+    mocks.sendLocalAgentHeartbeat.mockReset();
+    mocks.startLocalAgentHost.mockReset();
+  });
+
+  it("restores a closed host when its name is typed from the new host prompt", async () => {
+    mocks.listLocalAgentHosts.mockResolvedValue({ hosts: [closedHost] });
+    mocks.isInteractive.mockReturnValue(true);
+    mocks.promptSelect.mockResolvedValue("__new__");
+    mocks.promptText.mockImplementation(
+      async (
+        _message: string,
+        _initial: string | undefined,
+        validate?: (value: string) => boolean | string,
+      ) => {
+        expect(validate?.("laptop")).toBe(true);
+        return "laptop";
+      },
+    );
+    const { chooseHostForStart } = await import("../host");
+
+    const selection = await chooseHostForStart({});
+
+    expect(selection).toStrictEqual({
+      hostId: "host-closed",
+      hostName: "laptop",
+      restoredHost: closedHost,
+    });
+  });
+});

--- a/turbo/apps/cli/src/commands/zero/local-agent/host.ts
+++ b/turbo/apps/cli/src/commands/zero/local-agent/host.ts
@@ -11,6 +11,7 @@ import { withErrorHandler } from "../../../lib/command/with-error-handler";
 import {
   ApiRequestError,
   claimNextLocalAgentHostJob,
+  closeLocalAgentHost,
   completeLocalAgentHostJob,
   createLocalAgentHostRealtimeSubscription,
   listLocalAgentHosts,
@@ -351,9 +352,43 @@ function assertHostNameAvailable(
   );
 }
 
+function hostsMatchingName(
+  hostName: string,
+  hosts: readonly LocalAgentHost[],
+): LocalAgentHost[] {
+  return hosts.filter((host) => {
+    return host.displayName === hostName;
+  });
+}
+
+function hostSelectionForName(
+  hostName: string,
+  hosts: readonly LocalAgentHost[],
+): StartHostSelection | null {
+  const matchingNameHosts = hostsMatchingName(hostName, hosts);
+  if (matchingNameHosts.length > 1) {
+    throw new Error(
+      `Multiple local-agent hosts are named ${hostName}. Use --host-id <id> to choose one.`,
+    );
+  }
+
+  const [host] = matchingNameHosts;
+  if (!host) {
+    return null;
+  }
+  if (host.status === "closed") {
+    return restoreHostSelection(host);
+  }
+
+  throw new Error(
+    `Local-agent host is already online: ${hostName}. Choose another --name or delete the existing host first.`,
+  );
+}
+
 async function promptNewHostName(params: {
   initialName: string;
   existingHosts: readonly LocalAgentHost[];
+  allowClosedReuse?: boolean;
 }): Promise<string> {
   const selected = await promptText(
     "Host name:",
@@ -363,14 +398,20 @@ async function promptNewHostName(params: {
       if (!hostName) {
         return "Host name is required";
       }
-      if (
-        params.existingHosts.some((host) => {
-          return host.displayName === hostName;
-        })
-      ) {
+      const matchingHosts = hostsMatchingName(hostName, params.existingHosts);
+      if (matchingHosts.length === 0) {
+        return true;
+      }
+      if (!params.allowClosedReuse) {
         return "A host with this name already exists";
       }
-      return true;
+      if (matchingHosts.length > 1) {
+        return "Multiple local-agent hosts have this name";
+      }
+      if (matchingHosts[0]?.status === "closed") {
+        return true;
+      }
+      return "A host with this name is already online";
     },
   );
   const hostName = selected?.trim();
@@ -386,7 +427,20 @@ async function promptNewHostName(params: {
   throw new Error("Host name selection cancelled");
 }
 
-async function chooseHostForStart(params: {
+async function promptStartHostSelection(params: {
+  initialName: string;
+  existingHosts: readonly LocalAgentHost[];
+}): Promise<StartHostSelection> {
+  const hostName = await promptNewHostName({
+    initialName: params.initialName,
+    existingHosts: params.existingHosts,
+    allowClosedReuse: true,
+  });
+
+  return hostSelectionForName(hostName, params.existingHosts) ?? { hostName };
+}
+
+export async function chooseHostForStart(params: {
   requestedHostName?: string;
   requestedHostId?: string;
   createNew?: boolean;
@@ -424,23 +478,10 @@ async function chooseHostForStart(params: {
   }
 
   if (requestedHostName) {
-    const matchingNameHosts = hosts.filter((host) => {
-      return host.displayName === requestedHostName;
-    });
-    if (matchingNameHosts.length > 1) {
-      throw new Error(
-        `Multiple local-agent hosts are named ${requestedHostName}. Use --host-id <id> to choose one.`,
-      );
-    }
-    const [host] = matchingNameHosts;
-    if (!host) {
-      return { hostName: requestedHostName };
-    }
-    if (host.status === "closed") {
-      return restoreHostSelection(host);
-    }
-    throw new Error(
-      `Local-agent host is already online: ${requestedHostName}. Choose another --name or delete the existing host first.`,
+    return (
+      hostSelectionForName(requestedHostName, hosts) ?? {
+        hostName: requestedHostName,
+      }
     );
   }
 
@@ -482,12 +523,10 @@ async function chooseHostForStart(params: {
       throw new Error("Local-agent host selection cancelled");
     }
     if (selected === NEW_HOST_SELECTION) {
-      return {
-        hostName: await promptNewHostName({
-          initialName: hostname(),
-          existingHosts: hosts,
-        }),
-      };
+      return promptStartHostSelection({
+        initialName: hostname(),
+        existingHosts: hosts,
+      });
     }
 
     const host = closedHosts.find((item) => {
@@ -686,12 +725,17 @@ async function runHostLoop(params: {
 }): Promise<void> {
   let latestError: string | null = null;
   let stopped = false;
+  let closeHostOnStop = false;
   let nextHeartbeatAt = 0;
   let jobNotifier: LocalAgentJobNotifier | null = null;
 
-  const onStop = () => {
+  const stopLoop = () => {
     stopped = true;
     jobNotifier?.close();
+  };
+  const onStop = () => {
+    closeHostOnStop = true;
+    stopLoop();
   };
 
   const sendHeartbeat = async (): Promise<void> => {
@@ -702,7 +746,7 @@ async function runHostLoop(params: {
     } catch (error) {
       if (isInvalidHostTokenError(error)) {
         console.log(chalk.yellow("Local-agent host was deleted; stopping."));
-        onStop();
+        stopLoop();
         return;
       }
       const message = error instanceof Error ? error.message : String(error);
@@ -713,22 +757,24 @@ async function runHostLoop(params: {
     }
   };
 
-  try {
-    jobNotifier = await createLocalAgentJobNotifier(params.hostToken);
-  } catch (error) {
-    console.log(
-      chalk.yellow(
-        `Realtime job notifications unavailable, falling back to polling: ${errorMessage(error)}`,
-      ),
-    );
-  }
-
-  await sendHeartbeat();
-
   process.once("SIGINT", onStop);
   process.once("SIGTERM", onStop);
 
   try {
+    try {
+      jobNotifier = await createLocalAgentJobNotifier(params.hostToken);
+    } catch (error) {
+      console.log(
+        chalk.yellow(
+          `Realtime job notifications unavailable, falling back to polling: ${errorMessage(error)}`,
+        ),
+      );
+    }
+
+    if (!stopped) {
+      await sendHeartbeat();
+    }
+
     while (!stopped) {
       if (Date.now() >= nextHeartbeatAt) {
         await sendHeartbeat();
@@ -743,7 +789,7 @@ async function runHostLoop(params: {
       } catch (error) {
         if (isInvalidHostTokenError(error)) {
           console.log(chalk.yellow("Local-agent host was deleted; stopping."));
-          onStop();
+          stopLoop();
           continue;
         }
         const message = error instanceof Error ? error.message : String(error);
@@ -792,6 +838,17 @@ async function runHostLoop(params: {
     jobNotifier?.close();
     process.removeListener("SIGINT", onStop);
     process.removeListener("SIGTERM", onStop);
+    if (closeHostOnStop) {
+      try {
+        await closeLocalAgentHost({ hostToken: params.hostToken });
+      } catch (error) {
+        console.log(
+          chalk.yellow(
+            `Failed to close local-agent host: ${errorMessage(error)}`,
+          ),
+        );
+      }
+    }
   }
 }
 

--- a/turbo/apps/cli/src/lib/api/domains/zero-local-agent.ts
+++ b/turbo/apps/cli/src/lib/api/domains/zero-local-agent.ts
@@ -176,6 +176,25 @@ export async function deleteLocalAgentHost(hostId: string): Promise<void> {
   handleError(result, "Failed to delete local-agent host");
 }
 
+export async function closeLocalAgentHost(params: {
+  hostToken: string;
+}): Promise<void> {
+  const baseUrl = resolveLocalAgentApiBaseUrl(await getBaseUrl());
+  const client = initClient(zeroLocalAgentHostsContract, {
+    baseUrl,
+    baseHeaders: buildBearerHeaders(params.hostToken),
+    jsonQuery: false as const,
+  });
+
+  const result = await client.close({});
+
+  if (result.status === 200) {
+    return;
+  }
+
+  handleError(result, "Failed to close local-agent host");
+}
+
 export async function getLocalAgentRun(
   jobId: string,
 ): Promise<LocalAgentRunResponse> {

--- a/turbo/apps/cli/src/lib/api/domains/zero-local-browser.ts
+++ b/turbo/apps/cli/src/lib/api/domains/zero-local-browser.ts
@@ -150,7 +150,7 @@ export async function listLocalBrowserHosts(): Promise<LocalBrowserHostListRespo
   const config = await getLocalBrowserClientConfig();
   const client = initClient(zeroLocalBrowserHostsContract, config);
 
-  const result = await client.list({});
+  const result = await client.list({ headers: {} });
 
   if (result.status === 200) {
     return result.body;

--- a/turbo/apps/cli/src/lib/api/index.ts
+++ b/turbo/apps/cli/src/lib/api/index.ts
@@ -200,6 +200,7 @@ export {
 // Domain modules - Zero Local Agent
 export {
   claimNextLocalAgentHostJob,
+  closeLocalAgentHost,
   completeLocalAgentHostJob,
   createLocalAgentRun,
   createLocalAgentHostRealtimeSubscription,

--- a/turbo/packages/api-contracts/src/contracts/zero-local-agent.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-local-agent.ts
@@ -126,6 +126,10 @@ export const localAgentHostDeleteResponseSchema = z.object({
   ok: z.literal(true),
 });
 
+export const localAgentHostCloseResponseSchema = z.object({
+  ok: z.literal(true),
+});
+
 export const zeroLocalAgentDeviceStartContract = c.router({
   start: {
     method: "POST",
@@ -309,6 +313,17 @@ export const zeroLocalAgentHostsContract = c.router({
     },
     summary: "Delete a local-agent host",
   },
+  close: {
+    method: "POST",
+    path: "/api/zero/local-agent/hosts/close",
+    headers: authHeadersSchema,
+    body: c.noBody(),
+    responses: {
+      200: localAgentHostCloseResponseSchema,
+      401: apiErrorSchema,
+    },
+    summary: "Mark the current local-agent host closed",
+  },
 });
 
 export const zeroLocalAgentHostJobsContract = c.router({
@@ -379,6 +394,9 @@ export type LocalAgentHostStartResponse = z.infer<
 >;
 export type LocalAgentHostDeleteResponse = z.infer<
   typeof localAgentHostDeleteResponseSchema
+>;
+export type LocalAgentHostCloseResponse = z.infer<
+  typeof localAgentHostCloseResponseSchema
 >;
 export type LocalAgentHostJobNextResponse = z.infer<
   typeof localAgentHostJobNextResponseSchema


### PR DESCRIPTION
## Summary
- add a host-token authenticated local-agent close endpoint that marks the current host closed immediately
- call the close endpoint when `vm0 local-agent start` stops from SIGINT/SIGTERM
- allow the interactive new-host prompt to restore a closed host when its name is typed
- fix a local-browser ts-rest list call to include empty headers so CLI typecheck passes

Closes #13508

## Tests
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-local-agent-hosts.test.ts`
- `pnpm -F @vm0/cli exec vitest run src/commands/zero/local-agent/__tests__/host.test.ts`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F @vm0/cli check-types`
- targeted eslint for changed API, CLI, and api-contracts files
- `git diff --check`

## Notes
- `pnpm check-types` is currently blocked by existing `apps/platform` ts-rest response typing errors (`body`/`status` on `never` and missing client headers) outside this change.
