### PR TITLE
fix: remove legacy sandbox CLI auth

### DIFF
--- a/turbo/apps/api/src/signals/auth/__tests__/tokens.test.ts
+++ b/turbo/apps/api/src/signals/auth/__tests__/tokens.test.ts
@@ -96,4 +96,19 @@ describe("auth tokens", () => {
       jobId: "job_compose",
     });
   });
+
+  it("rejects CLI-scoped tokens behind the sandbox prefix", () => {
+    const nowSeconds = currentSecond();
+    const legacyCliToken = signSandboxJwtForTests({
+      scope: "cli",
+      userId: "user_legacy",
+      orgId: "org_legacy",
+      tokenId: "token_legacy",
+      iat: nowSeconds,
+      exp: nowSeconds + 60,
+    });
+
+    expect(isSandboxToken(legacyCliToken)).toBeTruthy();
+    expect(verifyCliToken(legacyCliToken)).toBeNull();
+  });
 });

--- a/turbo/apps/api/src/signals/auth/auth-context.ts
+++ b/turbo/apps/api/src/signals/auth/auth-context.ts
@@ -220,17 +220,9 @@ const resolvedAuthContext$ = command(
     }
 
     if (isSandboxToken(token)) {
-      const cliAuth = verifyCliToken(token);
-      if (!cliAuth) {
-        const result = await set(sandboxTokenAuth$, token, options, signal);
-        if (result) {
-          return result;
-        }
-      } else {
-        const result = await set(cliAuth$, cliAuth, signal);
-        if (result) {
-          return result;
-        }
+      const result = await set(sandboxTokenAuth$, token, options, signal);
+      if (result) {
+        return result;
       }
       return null;
     }

--- a/turbo/apps/api/src/signals/auth/runner-auth.ts
+++ b/turbo/apps/api/src/signals/auth/runner-auth.ts
@@ -9,7 +9,7 @@ import {
   cliTokenRecord,
   updateCliTokenLastUsedAt$,
 } from "../services/auth.service";
-import { isPatToken, isSandboxToken, verifyCliToken } from "./tokens";
+import { isPatToken, verifyCliToken } from "./tokens";
 
 const L = logger("RunnerAuth");
 
@@ -46,12 +46,9 @@ export const runnerAuth$ = command(
 
     const token = authHeader.slice("Bearer ".length);
 
-    if (isPatToken(token) || isSandboxToken(token)) {
+    if (isPatToken(token)) {
       const cliAuth = verifyCliToken(token);
       if (!cliAuth) {
-        if (isSandboxToken(token)) {
-          L.debug("Rejected non-CLI sandbox JWT token on runner endpoint");
-        }
         return null;
       }
 

--- a/turbo/apps/api/src/signals/auth/tokens.ts
+++ b/turbo/apps/api/src/signals/auth/tokens.ts
@@ -210,11 +210,8 @@ export function verifyComposeJobToken(token: string): ComposeJobAuth | null {
 }
 
 export function verifyCliToken(token: string): CliAuth | null {
-  const prefix = token.startsWith(PAT_TOKEN_PREFIX)
-    ? PAT_TOKEN_PREFIX
-    : SANDBOX_TOKEN_PREFIX;
   const parsed = cliTokenPayloadSchema.safeParse(
-    verifyPrefixedToken(token, prefix),
+    verifyPrefixedToken(token, PAT_TOKEN_PREFIX),
   );
 
   if (!parsed.success) {

--- a/turbo/apps/cli/src/commands/__tests__/whoami.test.ts
+++ b/turbo/apps/cli/src/commands/__tests__/whoami.test.ts
@@ -20,6 +20,15 @@ function buildFakeCliJwt(payload: Record<string, unknown>): string {
   ).toString("base64url");
   const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
   const sig = Buffer.from("fake-signature").toString("base64url");
+  return `vm0_pat_${header}.${body}.${sig}`;
+}
+
+function buildFakeZeroJwt(payload: Record<string, unknown>): string {
+  const header = Buffer.from(
+    JSON.stringify({ alg: "HS256", typ: "JWT" }),
+  ).toString("base64url");
+  const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
+  const sig = Buffer.from("fake-signature").toString("base64url");
   return `vm0_sandbox_${header}.${body}.${sig}`;
 }
 
@@ -76,7 +85,7 @@ describe("whoami command", () => {
       vi.stubEnv("CLI_AGENT_TYPE", "claude");
       vi.stubEnv(
         "ZERO_TOKEN",
-        buildFakeCliJwt({
+        buildFakeZeroJwt({
           scope: "zero",
           orgId: "active-org",
           capabilities: [],

--- a/turbo/apps/cli/src/commands/zero/__tests__/whoami.test.ts
+++ b/turbo/apps/cli/src/commands/zero/__tests__/whoami.test.ts
@@ -20,17 +20,25 @@ vi.mock("os", async (importOriginal) => {
   };
 });
 
-/**
- * Build a valid ZERO_TOKEN for testing.
- * Format: vm0_sandbox_<header>.<payload>.<signature>
- */
-function buildZeroToken(payload: Record<string, unknown>): string {
+function buildJwt(payload: Record<string, unknown>, prefix: string): string {
   const header = Buffer.from(JSON.stringify({ alg: "HS256" })).toString(
     "base64url",
   );
   const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
   const signature = "test-signature";
-  return `vm0_sandbox_${header}.${body}.${signature}`;
+  return `${prefix}${header}.${body}.${signature}`;
+}
+
+/**
+ * Build a valid ZERO_TOKEN for testing.
+ * Format: vm0_sandbox_<header>.<payload>.<signature>
+ */
+function buildZeroToken(payload: Record<string, unknown>): string {
+  return buildJwt(payload, "vm0_sandbox_");
+}
+
+function buildCliToken(payload: Record<string, unknown>): string {
+  return buildJwt(payload, "vm0_pat_");
 }
 
 describe("zero whoami command", () => {
@@ -895,7 +903,7 @@ describe("zero whoami command", () => {
     });
 
     it("should display active org from CLI JWT token", async () => {
-      const cliJwt = buildZeroToken({
+      const cliJwt = buildCliToken({
         scope: "cli",
         orgId: "test-org-slug",
         userId: "user-1",

--- a/turbo/apps/cli/src/commands/zero/org/__tests__/leave.test.ts
+++ b/turbo/apps/cli/src/commands/zero/org/__tests__/leave.test.ts
@@ -25,7 +25,7 @@ function buildFakeCliJwt(payload: Record<string, unknown>): string {
   ).toString("base64url");
   const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
   const sig = Buffer.from("fake-signature").toString("base64url");
-  return `vm0_sandbox_${header}.${body}.${sig}`;
+  return `vm0_pat_${header}.${body}.${sig}`;
 }
 
 describe("zero org leave command", () => {

--- a/turbo/apps/cli/src/commands/zero/org/__tests__/list.test.ts
+++ b/turbo/apps/cli/src/commands/zero/org/__tests__/list.test.ts
@@ -25,7 +25,7 @@ function buildFakeCliJwt(payload: Record<string, unknown>): string {
   ).toString("base64url");
   const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
   const sig = Buffer.from("fake-signature").toString("base64url");
-  return `vm0_sandbox_${header}.${body}.${sig}`;
+  return `vm0_pat_${header}.${body}.${sig}`;
 }
 
 describe("zero org list command", () => {

--- a/turbo/apps/cli/src/commands/zero/org/__tests__/set.test.ts
+++ b/turbo/apps/cli/src/commands/zero/org/__tests__/set.test.ts
@@ -25,7 +25,7 @@ function buildFakeCliJwt(payload: Record<string, unknown>): string {
   ).toString("base64url");
   const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
   const sig = Buffer.from("fake-signature").toString("base64url");
-  return `vm0_sandbox_${header}.${body}.${sig}`;
+  return `vm0_pat_${header}.${body}.${sig}`;
 }
 
 describe("zero org set command", () => {

--- a/turbo/apps/cli/src/commands/zero/org/__tests__/use.test.ts
+++ b/turbo/apps/cli/src/commands/zero/org/__tests__/use.test.ts
@@ -25,7 +25,7 @@ function buildFakeCliJwt(payload: Record<string, unknown>): string {
   ).toString("base64url");
   const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
   const sig = Buffer.from("fake-signature").toString("base64url");
-  return `vm0_sandbox_${header}.${body}.${sig}`;
+  return `vm0_pat_${header}.${body}.${sig}`;
 }
 
 describe("zero org use command", () => {

--- a/turbo/apps/cli/src/lib/api/__tests__/cli-token.test.ts
+++ b/turbo/apps/cli/src/lib/api/__tests__/cli-token.test.ts
@@ -38,7 +38,7 @@ describe("decodeCliTokenPayload", () => {
     expect(decodeCliTokenPayload("vm0_live_abc123")).toBeUndefined();
   });
 
-  it("should decode CLI JWT with legacy vm0_sandbox_ prefix (backward compat)", () => {
+  it("should return undefined for CLI JWT with legacy vm0_sandbox_ prefix", () => {
     const token = buildCliJwt(
       {
         userId: "user-1",
@@ -51,14 +51,7 @@ describe("decodeCliTokenPayload", () => {
       "vm0_sandbox_",
     );
     const result = decodeCliTokenPayload(token);
-    expect(result).toEqual({
-      userId: "user-1",
-      orgId: "org-1",
-      tokenId: "tok-1",
-      scope: "cli",
-      iat: 1000,
-      exp: 2000,
-    });
+    expect(result).toBeUndefined();
   });
 
   it("should return undefined for zero-scoped tokens", () => {

--- a/turbo/apps/cli/src/lib/api/cli-token.ts
+++ b/turbo/apps/cli/src/lib/api/cli-token.ts
@@ -19,14 +19,10 @@ export function decodeCliTokenPayload(
   if (!raw) return undefined;
 
   const patPrefix = "vm0_pat_";
-  const legacyPrefix = "vm0_sandbox_";
 
   let jwt: string;
   if (raw.startsWith(patPrefix)) {
     jwt = raw.slice(patPrefix.length);
-  } else if (raw.startsWith(legacyPrefix)) {
-    // Backward compat: accept old vm0_sandbox_ prefix during transition
-    jwt = raw.slice(legacyPrefix.length);
   } else {
     return undefined;
   }

--- a/turbo/apps/web/src/lib/auth/__tests__/sandbox-token.test.ts
+++ b/turbo/apps/web/src/lib/auth/__tests__/sandbox-token.test.ts
@@ -729,17 +729,13 @@ describe("sandbox-token", () => {
       expect(isSandboxToken(token)).toBe(false);
     });
 
-    it("should verify CLI token with legacy vm0_sandbox_ prefix (backward compat)", async () => {
+    it("should reject CLI token with legacy vm0_sandbox_ prefix", async () => {
       const token = await generateCliToken("user-123", "org-789", "token-id-1");
-      // Replace vm0_pat_ prefix with vm0_sandbox_ to simulate old token
       const legacyToken =
         SANDBOX_TOKEN_PREFIX + token.slice(PAT_TOKEN_PREFIX.length);
       const auth = verifyCliToken(legacyToken);
 
-      expect(auth).not.toBeNull();
-      expect(auth?.userId).toBe("user-123");
-      expect(auth?.orgId).toBe("org-789");
-      expect(auth?.tokenId).toBe("token-id-1");
+      expect(auth).toBeNull();
     });
   });
 });

--- a/turbo/apps/web/src/lib/auth/get-auth-context.ts
+++ b/turbo/apps/web/src/lib/auth/get-auth-context.ts
@@ -95,35 +95,6 @@ export async function getAuthContext(
     }
 
     if (isSandboxToken(token)) {
-      // TODO: Remove vm0_sandbox_ CLI backward compat after transition (~June 2026)
-      // Try CLI JWT (backward compat: old vm0_sandbox_ prefix with scope "cli")
-      const cliAuth = verifyCliToken(token);
-      if (cliAuth) {
-        const resolved = await resolveCliTokenFromDb(cliAuth);
-        if (!resolved) return null;
-        // Resolve org role so downstream admin checks work correctly
-        if (resolved.orgId) {
-          const membership = await getMemberRole(
-            resolved.orgId,
-            resolved.userId,
-          );
-          if (!membership) {
-            // User no longer a member — omit orgId to force resolveOrg rejection
-            return { userId: resolved.userId, tokenType: "pat" };
-          }
-          return {
-            userId: resolved.userId,
-            orgId: resolved.orgId,
-            orgRole: membership.role,
-            tokenType: "pat",
-          };
-        }
-        return {
-          userId: resolved.userId,
-          orgId: resolved.orgId,
-          tokenType: "pat",
-        };
-      }
       return authenticateSandboxToken(token, options);
     }
     // Unknown Bearer shape (e.g. a Clerk session JWT forwarded by the

--- a/turbo/apps/web/src/lib/auth/runner-auth.ts
+++ b/turbo/apps/web/src/lib/auth/runner-auth.ts
@@ -6,7 +6,7 @@
  */
 
 import { initServices } from "../init-services";
-import { isSandboxToken, isPatToken, verifyCliToken } from "./sandbox-token";
+import { isPatToken, verifyCliToken } from "./sandbox-token";
 import { resolveCliTokenFromDb } from "./get-auth-context";
 import { logger } from "../shared/logger";
 import { timingSafeEqual } from "crypto";
@@ -67,7 +67,7 @@ function validateOfficialRunnerSecret(providedSecret: string): boolean {
  *    - Validated against OFFICIAL_RUNNER_SECRET env var
  *    - Returns { type: 'official-runner' }
  *
- * 2. User runner: Uses CLI JWT token (`vm0_sandbox_` prefix with scope "cli")
+ * 2. User runner: Uses CLI JWT token (`vm0_pat_` prefix with scope "cli")
  *    - Validated via JWT signature + cli_tokens table revocation check
  *    - Returns { type: 'user', userId }
  *
@@ -94,25 +94,6 @@ export async function getRunnerAuth(
       }
       return { type: "user", userId: resolved.userId };
     }
-    return null;
-  }
-
-  // Handle sandbox-prefixed JWT tokens
-  if (isSandboxToken(token)) {
-    // TODO: Remove vm0_sandbox_ CLI backward compat after transition (~June 2026)
-    // Backward compat: accept old vm0_sandbox_ prefix with scope "cli"
-    const cliAuth = verifyCliToken(token);
-    if (cliAuth) {
-      initServices();
-      const resolved = await resolveCliTokenFromDb(cliAuth);
-      if (!resolved) {
-        return null;
-      }
-      return { type: "user", userId: resolved.userId };
-    }
-
-    // Reject other sandbox JWT tokens (sandbox, zero, compose-job)
-    log.debug("Rejected non-CLI sandbox JWT token on runner endpoint");
     return null;
   }
 

--- a/turbo/apps/web/src/lib/auth/sandbox-token.ts
+++ b/turbo/apps/web/src/lib/auth/sandbox-token.ts
@@ -532,15 +532,10 @@ export async function generateCliToken(
  * @param token - The full prefixed token (without "Bearer " prefix)
  */
 export function verifyCliToken(token: string): CliAuth | null {
-  let rawJwt: string;
-  if (token.startsWith(PAT_TOKEN_PREFIX)) {
-    rawJwt = token.slice(PAT_TOKEN_PREFIX.length);
-  } else if (token.startsWith(SANDBOX_TOKEN_PREFIX)) {
-    // Backward compat: accept old vm0_sandbox_ prefix for CLI tokens during transition
-    rawJwt = token.slice(SANDBOX_TOKEN_PREFIX.length);
-  } else {
+  if (!token.startsWith(PAT_TOKEN_PREFIX)) {
     return null;
   }
+  const rawJwt = token.slice(PAT_TOKEN_PREFIX.length);
   const payload = verifyJwtPayload(rawJwt);
   if (!payload) {
     return null;


### PR DESCRIPTION
## Summary
- remove the `vm0_sandbox_` backward-compat path for CLI/PAT authentication in API, web, runner auth, and CLI token decoding
- keep runtime sandbox token handling on `vm0_sandbox_` for sandbox/zero/compose-job tokens
- update CLI/auth tests so CLI JWT fixtures use `vm0_pat_` and legacy sandbox-prefixed CLI JWTs are rejected

Closes #13496.

## Tests
- `pnpm format`
- `pnpm turbo run lint`
- `pnpm check-types`
- `pnpm vitest` (1057 files, 11439 tests)
- `pnpm knip`