### PR TITLE
feat: add agentphone group mention handling

### DIFF
--- a/turbo/apps/api/src/signals/external/agentphone-client.ts
+++ b/turbo/apps/api/src/signals/external/agentphone-client.ts
@@ -58,7 +58,9 @@ export function isAgentPhoneApiError(
 export async function sendAgentPhoneMessage(
   opts: {
     readonly agentphoneAgentId: string;
-    readonly toNumber: string;
+    readonly toNumber?: string | null;
+    readonly conversationId?: string | null;
+    readonly replyToMessageId?: string | null;
     readonly body: string;
     readonly mediaUrl?: string | null;
     readonly mediaUrls?: readonly string[] | null;
@@ -73,7 +75,11 @@ export async function sendAgentPhoneMessage(
     },
     body: JSON.stringify({
       agent_id: opts.agentphoneAgentId,
-      to_number: opts.toNumber,
+      ...(opts.toNumber ? { to_number: opts.toNumber } : {}),
+      ...(opts.conversationId ? { conversation_id: opts.conversationId } : {}),
+      ...(opts.replyToMessageId
+        ? { reply_to_message_id: opts.replyToMessageId }
+        : {}),
       body: opts.body,
       ...(opts.mediaUrl ? { media_url: opts.mediaUrl } : {}),
       ...(opts.mediaUrls?.length ? { media_urls: opts.mediaUrls } : {}),
@@ -103,7 +109,10 @@ export async function sendAgentPhoneMessage(
     channel: typeof result.channel === "string" ? result.channel : null,
     fromNumber:
       typeof result.from_number === "string" ? result.from_number : null,
-    toNumber: typeof result.to_number === "string" ? result.to_number : null,
+    toNumber:
+      typeof result.to_number === "string"
+        ? result.to_number
+        : (opts.toNumber ?? null),
     mediaUrls,
   };
 }

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-agentphone-routes.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-agentphone-routes.test.ts
@@ -240,6 +240,9 @@ const trackAgentPhoneGroupFixture = createFixtureTracker(
       .delete(orgMetadata)
       .where(eq(orgMetadata.orgId, fixture.orgId));
     await writeDb
+      .delete(orgMembersMetadata)
+      .where(eq(orgMembersMetadata.orgId, fixture.orgId));
+    await writeDb
       .delete(agentComposeVersions)
       .where(eq(agentComposeVersions.composeId, fixture.composeId));
     await writeDb
@@ -266,6 +269,7 @@ function uniquePhone(): string {
 
 function configureAgentPhoneEnv(): void {
   mockEnv("SECRETS_ENCRYPTION_KEY", "a".repeat(64));
+  mockEnv("R2_USER_ARTIFACTS_BUCKET_NAME", "test-user-artifacts");
   mockEnv("R2_USER_STORAGES_BUCKET_NAME", "test-user-storages");
   mockOptionalEnv("RUNNER_DEFAULT_GROUP", "vm0/test");
   mockOptionalEnv("AGENTPHONE_API_BASE_URL", "https://api.agentphone.to");
@@ -384,6 +388,12 @@ async function seedAgentPhoneGroupFixture(): Promise<AgentPhoneGroupFixture> {
   await writeDb.insert(orgMetadata).values({
     orgId,
     defaultAgentId: composeId,
+    credits: 100_000,
+  });
+  await writeDb.insert(orgMembersMetadata).values({
+    orgId,
+    userId,
+    timezone: "UTC",
   });
   await seedAgentPhoneLink({ phoneHandle, userId, orgId });
 
@@ -1167,7 +1177,7 @@ describe("AgentPhone migrated API routes", () => {
         agent_id: "agt-agentphone",
         conversation_id: conversationId,
         reply_to_message_id: "ap-group-trigger",
-        body: "Group failure",
+        body: "Oops, something went wrong. Please try again later.",
       }),
     );
     expect(sendCalls[0]?.to_number).toBeUndefined();
@@ -1249,7 +1259,7 @@ describe("AgentPhone migrated API routes", () => {
       contentType: "image/png",
       size: 123,
     });
-    expect(response.body.fileUrl).toContain("/f/");
+    expect(response.body.fileUrl).toContain("https://cdn.vm7.io/artifacts/");
   });
 
   it("post /api/zero/integrations/phone/upload-file/complete sends uploaded media", async () => {
@@ -1263,8 +1273,8 @@ describe("AgentPhone migrated API routes", () => {
     await seedAgentPhoneLink({ phoneHandle, userId, orgId });
     mocks.s3.listObjects([
       {
-        bucket: "test-user-storages",
-        key: `uploads/${userId}/${uploadId}/photo.png`,
+        bucket: "test-user-artifacts",
+        key: `artifacts/${userId}/${uploadId}/photo.png`,
         size: 456,
       },
     ]);

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-agentphone-routes.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-agentphone-routes.test.ts
@@ -397,12 +397,15 @@ async function seedAgentPhoneMessage(args: {
   readonly phoneHandle: string;
   readonly userLinkId: string;
   readonly agentphoneAgentId: string;
+  readonly conversationId?: string | null;
+  readonly channel?: "imessage" | "sms";
+  readonly body?: string;
   readonly mediaUrl?: string | null;
   readonly direction?: "inbound" | "outbound";
 }): Promise<void> {
   await writeDb.insert(agentphoneMessages).values({
     agentphoneMessageId: args.messageId,
-    conversationId: null,
+    conversationId: args.conversationId ?? null,
     agentphoneAgentId: args.agentphoneAgentId,
     agentphoneUserLinkId: args.userLinkId,
     phoneHandle: args.phoneHandle,
@@ -410,8 +413,8 @@ async function seedAgentPhoneMessage(args: {
       args.direction === "outbound" ? "+19039853128" : args.phoneHandle,
     toNumber: args.direction === "outbound" ? args.phoneHandle : "+19039853128",
     direction: args.direction ?? "inbound",
-    channel: "sms",
-    body: "hello",
+    channel: args.channel ?? "sms",
+    body: args.body ?? "hello",
     mediaUrl: args.mediaUrl ?? null,
     isBot: args.direction === "outbound",
   });
@@ -947,6 +950,99 @@ describe("AgentPhone migrated API routes", () => {
       isGroup: true,
       rootMessageId: `group:${fixture.conversationId}`,
     });
+  });
+
+  it("does not send signed connect links to iMessage groups", async () => {
+    configureAgentPhoneEnv();
+    const phoneHandle = uniquePhone();
+    const conversationId = uniqueId("conv");
+    const messageId = uniqueId("ap-group-unlinked");
+    await trackPhoneHandle(Promise.resolve({ phoneHandle }));
+    const sendCalls = agentPhoneSendMessage();
+
+    const accepted = await postAgentPhoneWebhook({
+      event: "agent.message",
+      channel: "imessage",
+      data: {
+        id: messageId,
+        agentId: "agt-agentphone",
+        from: phoneHandle,
+        to: "+19039853128",
+        body: "@Zero hello",
+        conversationId,
+        isGroup: true,
+      },
+    });
+    expect(accepted.status).toBe(200);
+    await clearAllDetached();
+
+    expect(sendCalls[0]).toStrictEqual(
+      expect.objectContaining({
+        agent_id: "agt-agentphone",
+        conversation_id: conversationId,
+        reply_to_message_id: messageId,
+      }),
+    );
+    expect(sendCalls[0]?.to_number).toBeUndefined();
+    expect(sendCalls[0]?.body).toContain("message Zero directly");
+    expect(sendCalls[0]?.body).not.toContain("/agentphone/connect?");
+  });
+
+  it("blocks group account commands from conversation-only participants", async () => {
+    configureAgentPhoneEnv();
+    const fixture = await seedAgentPhoneGroupFixture();
+    const userLink = await readAgentPhoneLink(fixture.phoneHandle);
+    if (!userLink) {
+      throw new Error("seeded AgentPhone group fixture has no user link");
+    }
+    const senderPhoneHandle = uniquePhone();
+    const messageId = uniqueId("ap-group-command");
+    await trackPhoneHandle(Promise.resolve({ phoneHandle: senderPhoneHandle }));
+    await seedAgentPhoneMessage({
+      messageId: uniqueId("ap-group-linked"),
+      phoneHandle: fixture.phoneHandle,
+      userLinkId: userLink.id,
+      agentphoneAgentId: "agt-agentphone",
+      conversationId: fixture.conversationId,
+      channel: "imessage",
+      body: "@Zero hello",
+    });
+    const sendCalls = agentPhoneSendMessage();
+
+    const accepted = await postAgentPhoneWebhook({
+      event: "agent.message",
+      channel: "imessage",
+      data: {
+        id: messageId,
+        agentId: "agt-agentphone",
+        from: senderPhoneHandle,
+        to: "+19039853128",
+        body: "/disconnect @Zero",
+        conversationId: fixture.conversationId,
+        isGroup: true,
+      },
+    });
+    expect(accepted.status).toBe(200);
+    await clearAllDetached();
+
+    await expect(
+      readAgentPhoneLink(fixture.phoneHandle),
+    ).resolves.toMatchObject({
+      id: userLink.id,
+      vm0UserId: fixture.userId,
+      orgId: fixture.orgId,
+    });
+    await expect(latestRunForAgentPhoneGroup(fixture)).resolves.toBeUndefined();
+    expect(sendCalls[0]).toStrictEqual(
+      expect.objectContaining({
+        agent_id: "agt-agentphone",
+        conversation_id: fixture.conversationId,
+        reply_to_message_id: messageId,
+      }),
+    );
+    expect(sendCalls[0]?.to_number).toBeUndefined();
+    expect(sendCalls[0]?.body).toContain("Only the linked sender");
+    expect(sendCalls[0]?.body).not.toContain("/agentphone/connect?");
   });
 
   it.each([

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-agentphone-routes.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-agentphone-routes.test.ts
@@ -20,13 +20,14 @@ import { agentphoneUserLinks } from "@vm0/db/schema/agentphone-user-link";
 import { orgMembersMetadata } from "@vm0/db/schema/org-members-metadata";
 import { orgMetadata } from "@vm0/db/schema/org-metadata";
 import { orgModelPolicies } from "@vm0/db/schema/org-model-policy";
+import { runnerJobQueue } from "@vm0/db/schema/runner-job-queue";
 import { runUploadedFiles } from "@vm0/db/schema/run-uploaded-file";
 import { storages, storageVersions } from "@vm0/db/schema/storage";
 import { vm0ApiKeys } from "@vm0/db/schema/vm0-api-key";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
 import { createStore } from "ccstate";
-import { and, eq, inArray } from "drizzle-orm";
+import { and, desc, eq, inArray } from "drizzle-orm";
 import { http, HttpResponse } from "msw";
 
 import { createApp } from "../../../app-factory";
@@ -52,7 +53,9 @@ import {
 
 interface AgentPhoneSendMessageBody {
   readonly agent_id: string;
-  readonly to_number: string;
+  readonly to_number?: string;
+  readonly conversation_id?: string;
+  readonly reply_to_message_id?: string;
   readonly body: string;
   readonly media_url?: string;
 }
@@ -64,6 +67,14 @@ interface RunFixture {
   readonly versionId?: string;
   readonly orgId: string;
   readonly userId: string;
+}
+
+interface AgentPhoneGroupFixture {
+  readonly phoneHandle: string;
+  readonly conversationId: string;
+  readonly userId: string;
+  readonly orgId: string;
+  readonly composeId: string;
 }
 
 const AGENTPHONE_WEBHOOK_SECRET = ["agentphone", "webhook", "secret"].join("-");
@@ -180,6 +191,66 @@ const trackRun = createFixtureTracker(async (fixture: RunFixture) => {
   await writeDb.delete(orgMetadata).where(eq(orgMetadata.orgId, fixture.orgId));
 });
 
+const trackAgentPhoneGroupFixture = createFixtureTracker(
+  async (fixture: AgentPhoneGroupFixture) => {
+    const runRows = await writeDb
+      .select({ id: agentRuns.id })
+      .from(agentRuns)
+      .where(
+        and(
+          eq(agentRuns.orgId, fixture.orgId),
+          eq(agentRuns.userId, fixture.userId),
+        ),
+      );
+    const runIds = runRows.map((row) => {
+      return row.id;
+    });
+
+    if (runIds.length > 0) {
+      await writeDb
+        .delete(runnerJobQueue)
+        .where(inArray(runnerJobQueue.runId, runIds));
+      await writeDb
+        .delete(agentRunCallbacks)
+        .where(inArray(agentRunCallbacks.runId, runIds));
+      await writeDb.delete(zeroRuns).where(inArray(zeroRuns.id, runIds));
+      await writeDb.delete(agentRuns).where(inArray(agentRuns.id, runIds));
+    }
+
+    await writeDb
+      .delete(agentSessions)
+      .where(
+        and(
+          eq(agentSessions.orgId, fixture.orgId),
+          eq(agentSessions.userId, fixture.userId),
+        ),
+      );
+    await writeDb
+      .delete(agentphoneMessages)
+      .where(eq(agentphoneMessages.conversationId, fixture.conversationId));
+    await writeDb
+      .delete(agentphoneThreadSessions)
+      .where(
+        eq(agentphoneThreadSessions.conversationId, fixture.conversationId),
+      );
+    await writeDb
+      .delete(agentphoneUserLinks)
+      .where(eq(agentphoneUserLinks.phoneHandle, fixture.phoneHandle));
+    await writeDb
+      .delete(orgMetadata)
+      .where(eq(orgMetadata.orgId, fixture.orgId));
+    await writeDb
+      .delete(agentComposeVersions)
+      .where(eq(agentComposeVersions.composeId, fixture.composeId));
+    await writeDb
+      .delete(zeroAgents)
+      .where(eq(zeroAgents.id, fixture.composeId));
+    await writeDb
+      .delete(agentComposes)
+      .where(eq(agentComposes.id, fixture.composeId));
+  },
+);
+
 function currentSecond(): number {
   return Math.floor(now() / 1000);
 }
@@ -195,16 +266,25 @@ function uniquePhone(): string {
 
 function configureAgentPhoneEnv(): void {
   mockEnv("SECRETS_ENCRYPTION_KEY", "a".repeat(64));
-  mockEnv("R2_USER_ARTIFACTS_BUCKET_NAME", "test-user-artifacts");
+  mockEnv("R2_USER_STORAGES_BUCKET_NAME", "test-user-storages");
+  mockOptionalEnv("RUNNER_DEFAULT_GROUP", "vm0/test");
   mockOptionalEnv("AGENTPHONE_API_BASE_URL", "https://api.agentphone.to");
   mockOptionalEnv("AGENTPHONE_API_KEY", "agentphone-test-key");
   mockOptionalEnv("AGENTPHONE_PHONE_NUMBER", "+19039853128");
   mockOptionalEnv("AGENTPHONE_WEBHOOK_SECRET", AGENTPHONE_WEBHOOK_SECRET);
+  context.mocks.s3.send.mockResolvedValue({});
 }
 
 function agentPhoneSendMessage() {
   const calls: AgentPhoneSendMessageBody[] = [];
   server.use(
+    http.post("https://api.agentphone.to/v1/conversations/:id/typing", () => {
+      return HttpResponse.json({
+        conversationId: "conv-test",
+        channel: "iMessage",
+        status: "typing indicator sent",
+      });
+    }),
     http.post("https://api.agentphone.to/v1/messages", async ({ request }) => {
       const body = (await request.json()) as AgentPhoneSendMessageBody;
       calls.push(body);
@@ -213,7 +293,7 @@ function agentPhoneSendMessage() {
         status: "sent",
         channel: "sms",
         from_number: "+19039853128",
-        to_number: body.to_number,
+        to_number: body.to_number ?? body.conversation_id ?? null,
         media_urls: body.media_url ? [body.media_url] : [],
       });
     }),
@@ -266,6 +346,52 @@ async function seedAgentPhoneLink(args: {
   return row.id;
 }
 
+async function seedAgentPhoneGroupFixture(): Promise<AgentPhoneGroupFixture> {
+  const phoneHandle = uniquePhone();
+  const userId = uniqueId("user");
+  const orgId = uniqueId("org");
+  const composeId = randomUUID();
+  const versionId = randomUUID();
+  const conversationId = uniqueId("conv");
+
+  await writeDb.insert(agentComposes).values({
+    id: composeId,
+    userId,
+    orgId,
+    name: "agentphone-group-agent",
+    headVersionId: versionId,
+  });
+  await writeDb.insert(agentComposeVersions).values({
+    id: versionId,
+    composeId,
+    content: {
+      version: "1.0",
+      agents: {
+        zero: {
+          framework: "claude-code",
+          environment: { ANTHROPIC_API_KEY: "test-key" },
+        },
+      },
+    },
+    createdBy: userId,
+  });
+  await writeDb.insert(zeroAgents).values({
+    id: composeId,
+    owner: userId,
+    orgId,
+    name: "zero",
+  });
+  await writeDb.insert(orgMetadata).values({
+    orgId,
+    defaultAgentId: composeId,
+  });
+  await seedAgentPhoneLink({ phoneHandle, userId, orgId });
+
+  return trackAgentPhoneGroupFixture(
+    Promise.resolve({ phoneHandle, conversationId, userId, orgId, composeId }),
+  );
+}
+
 async function seedAgentPhoneMessage(args: {
   readonly messageId: string;
   readonly phoneHandle: string;
@@ -313,6 +439,22 @@ function signAgentPhoneWebhook(rawBody: string, timestamp: string): string {
   return `sha256=${createHmac("sha256", AGENTPHONE_WEBHOOK_SECRET)
     .update(`${timestamp}.${rawBody}`)
     .digest("hex")}`;
+}
+
+function postAgentPhoneWebhook(body: unknown): Promise<Response> {
+  const rawBody = JSON.stringify(body);
+  const timestamp = String(currentSecond());
+  return Promise.resolve(
+    createApp({ signal: context.signal }).request("/api/agentphone/webhook", {
+      method: "POST",
+      headers: {
+        "x-webhook-timestamp": timestamp,
+        "x-webhook-signature": signAgentPhoneWebhook(rawBody, timestamp),
+        "x-webhook-id": uniqueId("webhook"),
+      },
+      body: rawBody,
+    }),
+  );
 }
 
 async function seedRun(args: {
@@ -470,6 +612,21 @@ async function seedAgentPhoneModelReuseFixture(args: {
   );
 
   return { composeId, previousSessionId, userLinkId };
+}
+
+async function latestRunForAgentPhoneGroup(fixture: AgentPhoneGroupFixture) {
+  const [run] = await writeDb
+    .select()
+    .from(agentRuns)
+    .where(
+      and(
+        eq(agentRuns.orgId, fixture.orgId),
+        eq(agentRuns.userId, fixture.userId),
+      ),
+    )
+    .orderBy(desc(agentRuns.createdAt))
+    .limit(1);
+  return run;
 }
 
 function callbackHeaders(rawBody: string) {
@@ -711,6 +868,87 @@ describe("AgentPhone migrated API routes", () => {
     expect(run?.sessionId).not.toBe(previousSessionId);
   });
 
+  it("stores non-addressed iMessage group messages without creating a run", async () => {
+    configureAgentPhoneEnv();
+    const fixture = await seedAgentPhoneGroupFixture();
+    const messageId = uniqueId("ap-group-ambient");
+    const sendCalls = agentPhoneSendMessage();
+
+    const accepted = await postAgentPhoneWebhook({
+      event: "agent.message",
+      channel: "imessage",
+      data: {
+        id: messageId,
+        agentId: "agt-agentphone",
+        from: fixture.phoneHandle,
+        to: "+19039853128",
+        body: "ambient group chatter",
+        conversationId: fixture.conversationId,
+        isGroup: true,
+      },
+    });
+    expect(accepted.status).toBe(200);
+    await clearAllDetached();
+
+    await expect(readAgentPhoneMessage(messageId)).resolves.toMatchObject({
+      conversationId: fixture.conversationId,
+      phoneHandle: fixture.phoneHandle,
+      direction: "inbound",
+    });
+    await expect(latestRunForAgentPhoneGroup(fixture)).resolves.toBeUndefined();
+    expect(sendCalls).toHaveLength(0);
+  });
+
+  it("creates a run for an addressed iMessage group message with group context", async () => {
+    configureAgentPhoneEnv();
+    const fixture = await seedAgentPhoneGroupFixture();
+    const messageId = uniqueId("ap-group-mentioned");
+    const priorMessageId = uniqueId("ap-group-prior");
+    agentPhoneSendMessage();
+
+    const accepted = await postAgentPhoneWebhook({
+      event: "agent.message",
+      channel: "imessage",
+      data: {
+        id: messageId,
+        agentId: "agt-agentphone",
+        from: fixture.phoneHandle,
+        to: "+19039853128",
+        body: "@Zero summarize this thread",
+        conversationId: fixture.conversationId,
+        isGroup: true,
+      },
+      recentHistory: [
+        {
+          id: priorMessageId,
+          content: "Earlier group context",
+          direction: "inbound",
+          channel: "imessage",
+          from: "+15559990000",
+          at: "2026-05-18T00:00:00.000Z",
+        },
+      ],
+    });
+    expect(accepted.status).toBe(200);
+    await clearAllDetached();
+
+    const run = await latestRunForAgentPhoneGroup(fixture);
+    expect(run?.prompt).toBe("summarize this thread");
+    expect(run?.appendSystemPrompt).toContain("Conversation type: group");
+    expect(run?.appendSystemPrompt).toContain("Earlier group context");
+
+    const [callback] = await writeDb
+      .select()
+      .from(agentRunCallbacks)
+      .where(eq(agentRunCallbacks.runId, run!.id))
+      .limit(1);
+    expect(callback?.payload).toMatchObject({
+      conversationId: fixture.conversationId,
+      isGroup: true,
+      rootMessageId: `group:${fixture.conversationId}`,
+    });
+  });
+
   it.each([
     {
       scenario: "formats generic failed run output like Web",
@@ -774,6 +1012,69 @@ describe("AgentPhone migrated API routes", () => {
         body: example.expectedBody,
       }),
     );
+  });
+
+  it("post /api/internal/callbacks/agentphone replies to iMessage groups by conversation", async () => {
+    configureAgentPhoneEnv();
+    const userId = uniqueId("user");
+    const orgId = uniqueId("org");
+    const linkedPhoneHandle = uniquePhone();
+    const senderPhoneHandle = uniquePhone();
+    const conversationId = uniqueId("conv");
+    const userLinkId = await seedAgentPhoneLink({
+      phoneHandle: linkedPhoneHandle,
+      userId,
+      orgId,
+    });
+    const run = await seedRun({ userId, orgId });
+    const { callbackId } = await store.set(
+      seedAgentRunCallback$,
+      {
+        runId: run.runId,
+        url: "http://api.test/api/internal/callbacks/agentphone",
+        payload: {},
+      },
+      context.signal,
+    );
+    const sendCalls = agentPhoneSendMessage();
+    const app = createApp({ signal: context.signal });
+    const rawBody = JSON.stringify({
+      callbackId,
+      runId: run.runId,
+      status: "failed",
+      error: "Group failure",
+      payload: {
+        messageId: "ap-group-trigger",
+        conversationId,
+        channel: "imessage",
+        isGroup: true,
+        rootMessageId: `group:${conversationId}`,
+        phoneHandle: senderPhoneHandle,
+        fromNumber: senderPhoneHandle,
+        toNumber: "+19039853128",
+        userLinkId,
+        agentId: run.composeId,
+        agentphoneAgentId: "agt-agentphone",
+        existingSessionId: null,
+      },
+    });
+
+    const response = await app.request("/api/internal/callbacks/agentphone", {
+      method: "POST",
+      headers: callbackHeaders(rawBody),
+      body: rawBody,
+    });
+
+    expect(response.status).toBe(200);
+    expect(sendCalls[0]).toStrictEqual(
+      expect.objectContaining({
+        agent_id: "agt-agentphone",
+        conversation_id: conversationId,
+        reply_to_message_id: "ap-group-trigger",
+        body: "Group failure",
+      }),
+    );
+    expect(sendCalls[0]?.to_number).toBeUndefined();
   });
 
   it("post /api/zero/integrations/phone/message sends and records a linked phone message", async () => {
@@ -852,7 +1153,7 @@ describe("AgentPhone migrated API routes", () => {
       contentType: "image/png",
       size: 123,
     });
-    expect(response.body.fileUrl).toContain("https://cdn.vm7.io/artifacts/");
+    expect(response.body.fileUrl).toContain("/f/");
   });
 
   it("post /api/zero/integrations/phone/upload-file/complete sends uploaded media", async () => {
@@ -866,8 +1167,8 @@ describe("AgentPhone migrated API routes", () => {
     await seedAgentPhoneLink({ phoneHandle, userId, orgId });
     mocks.s3.listObjects([
       {
-        bucket: "test-user-artifacts",
-        key: `artifacts/${userId}/${uploadId}/photo.png`,
+        bucket: "test-user-storages",
+        key: `uploads/${userId}/${uploadId}/photo.png`,
         size: 456,
       },
     ]);

--- a/turbo/apps/api/src/signals/routes/internal-callbacks-agentphone.ts
+++ b/turbo/apps/api/src/signals/routes/internal-callbacks-agentphone.ts
@@ -5,6 +5,7 @@ import {
   type AgentPhoneCallbackPayload,
 } from "@vm0/api-contracts/contracts/internal-callbacks-agentphone";
 import { agentRuns } from "@vm0/db/schema/agent-run";
+import { agentphoneUserLinks } from "@vm0/db/schema/agentphone-user-link";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
 import { eq } from "drizzle-orm";
 
@@ -57,6 +58,12 @@ type GetFeatureOverrides = (
   orgId: string,
   userId: string,
 ) => Promise<Record<string, boolean>>;
+
+type AgentPhoneCallbackCompletionResponse =
+  | { readonly status: 200; readonly body: { readonly success: true } }
+  | { readonly status: 502; readonly body: { readonly error: string } };
+
+type SentAgentPhoneMessage = Awaited<ReturnType<typeof sendAgentPhoneMessage>>;
 
 function successResponse(): {
   readonly status: 200;
@@ -169,12 +176,119 @@ async function staleLinkDisconnected(args: {
   readonly payload: AgentPhoneCallbackPayload;
   readonly channel: AgentPhoneChannel;
 }): Promise<boolean> {
+  if (args.payload.isGroup && args.payload.conversationId) {
+    const [userLink] = await args.db
+      .select({ id: agentphoneUserLinks.id })
+      .from(agentphoneUserLinks)
+      .where(eq(agentphoneUserLinks.id, args.payload.userLinkId))
+      .limit(1);
+    return !userLink;
+  }
+
   const currentUserLink = await resolveAgentPhoneUserLink(
     args.db,
     args.payload.phoneHandle,
     args.channel,
   );
   return currentUserLink?.id !== args.payload.userLinkId;
+}
+
+function agentPhoneCallbackRootMessageId(
+  payload: AgentPhoneCallbackPayload,
+): string {
+  return (
+    payload.rootMessageId ??
+    (payload.isGroup && payload.conversationId
+      ? `group:${payload.conversationId}`
+      : "dm")
+  );
+}
+
+async function sendAgentPhoneCompletionMessage(args: {
+  readonly payload: AgentPhoneCallbackPayload;
+  readonly body: string;
+  readonly signal: AbortSignal;
+}): Promise<
+  | { readonly ok: true; readonly sent: SentAgentPhoneMessage }
+  | {
+      readonly ok: false;
+      readonly response: AgentPhoneCallbackCompletionResponse;
+    }
+> {
+  const sendResult = await settle(
+    sendAgentPhoneMessage(
+      {
+        agentphoneAgentId: args.payload.agentphoneAgentId,
+        ...(args.payload.isGroup && args.payload.conversationId
+          ? {
+              conversationId: args.payload.conversationId,
+              replyToMessageId: args.payload.messageId,
+            }
+          : { toNumber: args.payload.phoneHandle }),
+        body: args.body,
+      },
+      args.signal,
+    ),
+  );
+  if (sendResult.ok) {
+    return { ok: true, sent: sendResult.value };
+  }
+  if (isAgentPhoneApiError(sendResult.error)) {
+    return {
+      ok: false,
+      response: {
+        status: 502 as const,
+        body: {
+          error: `AgentPhone API error: ${
+            sendResult.error.body || `HTTP ${sendResult.error.status}`
+          }`,
+        },
+      },
+    };
+  }
+  throw sendResult.error;
+}
+
+async function recordAgentPhoneCompletion(args: {
+  readonly db: Db;
+  readonly payload: AgentPhoneCallbackPayload;
+  readonly run: RunContext | undefined;
+  readonly status: "completed" | "failed";
+  readonly body: string;
+  readonly sent: SentAgentPhoneMessage;
+  readonly userChannel: AgentPhoneChannel;
+  readonly signal: AbortSignal;
+}): Promise<void> {
+  await storeOutboundAgentPhoneMessage(args.db, {
+    agentphoneMessageId: args.sent.id,
+    conversationId: args.payload.conversationId,
+    agentphoneAgentId: args.payload.agentphoneAgentId,
+    userLinkId: args.payload.userLinkId,
+    phoneHandle: args.payload.phoneHandle,
+    fromNumber: args.sent.fromNumber ?? args.payload.toNumber,
+    toNumber: args.sent.toNumber ?? args.payload.phoneHandle,
+    body: args.body,
+    channel: args.sent.channel,
+    userChannel: args.userChannel,
+  });
+  args.signal.throwIfAborted();
+
+  if (!args.run) {
+    return;
+  }
+
+  await saveAgentPhoneThreadSession(args.db, {
+    userLinkId: args.payload.userLinkId,
+    conversationId: args.payload.conversationId,
+    rootMessageId: agentPhoneCallbackRootMessageId(args.payload),
+    existingSessionId: args.payload.existingSessionId ?? undefined,
+    newSessionId: args.payload.existingSessionId
+      ? undefined
+      : args.run.sessionId,
+    messageId: args.payload.messageId,
+    runStatus: args.status,
+  });
+  args.signal.throwIfAborted();
 }
 
 async function handleCompletion(args: {
@@ -186,10 +300,7 @@ async function handleCompletion(args: {
   readonly getFeatureOverrides: GetFeatureOverrides;
   readonly formatRunError: FormatRunError;
   readonly signal: AbortSignal;
-}): Promise<
-  | { readonly status: 200; readonly body: { readonly success: true } }
-  | { readonly status: 502; readonly body: { readonly error: string } }
-> {
+}): Promise<AgentPhoneCallbackCompletionResponse> {
   const payloadChannel = args.payload.channel ?? "";
   const userChannel: AgentPhoneChannel = isAgentPhoneChannel(payloadChannel)
     ? payloadChannel
@@ -259,57 +370,26 @@ async function handleCompletion(args: {
     footerText,
   });
 
-  const sendResult = await settle(
-    sendAgentPhoneMessage(
-      {
-        agentphoneAgentId: args.payload.agentphoneAgentId,
-        toNumber: args.payload.phoneHandle,
-        body,
-      },
-      args.signal,
-    ),
-  );
-  if (!sendResult.ok) {
-    if (isAgentPhoneApiError(sendResult.error)) {
-      return {
-        status: 502 as const,
-        body: {
-          error: `AgentPhone API error: ${
-            sendResult.error.body || `HTTP ${sendResult.error.status}`
-          }`,
-        },
-      };
-    }
-    throw sendResult.error;
-  }
-  const sent = sendResult.value;
-  args.signal.throwIfAborted();
-
-  await storeOutboundAgentPhoneMessage(args.db, {
-    agentphoneMessageId: sent.id,
-    conversationId: args.payload.conversationId,
-    agentphoneAgentId: args.payload.agentphoneAgentId,
-    userLinkId: args.payload.userLinkId,
-    phoneHandle: args.payload.phoneHandle,
-    fromNumber: sent.fromNumber ?? args.payload.toNumber,
-    toNumber: sent.toNumber ?? args.payload.phoneHandle,
+  const sendResult = await sendAgentPhoneCompletionMessage({
+    payload: args.payload,
     body,
-    channel: sent.channel,
-    userChannel,
+    signal: args.signal,
   });
+  if (!sendResult.ok) {
+    return sendResult.response;
+  }
   args.signal.throwIfAborted();
 
-  if (run) {
-    await saveAgentPhoneThreadSession(args.db, {
-      userLinkId: args.payload.userLinkId,
-      conversationId: args.payload.conversationId,
-      existingSessionId: args.payload.existingSessionId ?? undefined,
-      newSessionId: args.payload.existingSessionId ? undefined : run.sessionId,
-      messageId: args.payload.messageId,
-      runStatus: args.status,
-    });
-    args.signal.throwIfAborted();
-  }
+  await recordAgentPhoneCompletion({
+    db: args.db,
+    payload: args.payload,
+    run,
+    status: args.status,
+    body,
+    sent: sendResult.sent,
+    userChannel,
+    signal: args.signal,
+  });
 
   return successResponse();
 }

--- a/turbo/apps/api/src/signals/routes/zero-integrations-agentphone.ts
+++ b/turbo/apps/api/src/signals/routes/zero-integrations-agentphone.ts
@@ -29,10 +29,11 @@ import {
   linkAgentPhoneUserToVm0User,
   normalizeAgentPhoneHandle,
   publishAgentPhoneUserChanged,
-  resolveAgentPhoneUserLink,
+  resolveAgentPhoneUserLinkForEvent,
   storeInboundAgentPhoneMessage,
   verifyAgentPhoneConnectSignature,
   verifyAgentPhoneWebhook,
+  type AgentPhoneRecentHistoryMessage,
   type AgentPhoneChannel,
   type AgentPhoneMessageEvent,
 } from "../services/zero-agentphone.service";
@@ -618,12 +619,166 @@ function stringValue(
   return undefined;
 }
 
+function booleanValue(
+  source: Record<string, unknown>,
+  keys: readonly string[],
+): boolean | undefined {
+  for (const key of keys) {
+    const value = source[key];
+    if (typeof value === "boolean") {
+      return value;
+    }
+    if (typeof value === "string") {
+      const normalized = value.trim().toLowerCase();
+      if (normalized === "true" || normalized === "yes") {
+        return true;
+      }
+      if (normalized === "false" || normalized === "no") {
+        return false;
+      }
+    }
+  }
+  return undefined;
+}
+
+function arrayValue(source: Record<string, unknown>, keys: readonly string[]) {
+  for (const key of keys) {
+    const value = source[key];
+    if (Array.isArray(value)) {
+      return value;
+    }
+  }
+  return [];
+}
+
 function parseDate(value: unknown): Date | null {
   if (typeof value !== "string" || !value.trim()) {
     return null;
   }
   const date = new Date(value);
   return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function isZeroMentionText(value: string): boolean {
+  return /(^|\s)@(zero|vm0)\b/iu.test(value);
+}
+
+function mentionMatchesZero(value: unknown): boolean {
+  if (typeof value === "string") {
+    return isZeroMentionText(value.startsWith("@") ? value : `@${value}`);
+  }
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+
+  const mention = value as Record<string, unknown>;
+  return ["text", "name", "username", "handle", "value"].some((key) => {
+    const field = mention[key];
+    return typeof field === "string" && mentionMatchesZero(field);
+  });
+}
+
+function extractAgentPhoneIsGroup(
+  body: Record<string, unknown>,
+  data: Record<string, unknown>,
+): boolean {
+  const explicit =
+    booleanValue(data, ["isGroup", "is_group", "group"]) ??
+    booleanValue(body, ["isGroup", "is_group", "group"]);
+  if (explicit !== undefined) {
+    return explicit;
+  }
+
+  const type = (
+    stringValue(data, ["conversationType", "conversation_type", "chatType"]) ??
+    stringValue(body, ["conversationType", "conversation_type", "chatType"]) ??
+    ""
+  ).toLowerCase();
+  if (["group", "group_chat", "imessage_group"].includes(type)) {
+    return true;
+  }
+
+  return (
+    arrayValue(data, ["participants", "participantNumbers", "recipients"])
+      .length > 2 ||
+    arrayValue(body, ["participants", "participantNumbers", "recipients"])
+      .length > 2
+  );
+}
+
+function extractAgentPhoneMentioned(
+  body: Record<string, unknown>,
+  data: Record<string, unknown>,
+  messageBody: string,
+): boolean {
+  const explicit =
+    booleanValue(data, [
+      "mentioned",
+      "isMentioned",
+      "is_mentioned",
+      "mentionsAgent",
+      "mentions_agent",
+    ]) ??
+    booleanValue(body, [
+      "mentioned",
+      "isMentioned",
+      "is_mentioned",
+      "mentionsAgent",
+      "mentions_agent",
+    ]);
+  if (explicit !== undefined) {
+    return explicit;
+  }
+
+  return (
+    arrayValue(data, ["mentions", "mentionedUsers", "mentioned_users"]).some(
+      mentionMatchesZero,
+    ) ||
+    arrayValue(body, ["mentions", "mentionedUsers", "mentioned_users"]).some(
+      mentionMatchesZero,
+    ) ||
+    isZeroMentionText(messageBody)
+  );
+}
+
+function recentHistoryMessage(
+  value: unknown,
+): AgentPhoneRecentHistoryMessage | null {
+  if (typeof value !== "object" || value === null) {
+    return null;
+  }
+  const item = value as Record<string, unknown>;
+  const content =
+    stringValue(item, ["content", "message", "body", "text"]) ?? null;
+  const mediaUrl = stringValue(item, ["mediaUrl", "media_url"]);
+  if (!content && !mediaUrl) {
+    return null;
+  }
+
+  return {
+    messageId: stringValue(item, ["messageId", "message_id", "id"]) ?? null,
+    content: content ?? (mediaUrl ? `[AgentPhone file] ${mediaUrl}` : null),
+    direction: stringValue(item, ["direction"]) ?? null,
+    channel: stringValue(item, ["channel"]) ?? null,
+    fromNumber:
+      stringValue(item, ["from", "fromNumber", "from_number"]) ?? null,
+    toNumber: stringValue(item, ["to", "toNumber", "to_number"]) ?? null,
+    at: stringValue(item, ["at", "timestamp", "receivedAt"]) ?? null,
+  };
+}
+
+function extractAgentPhoneRecentHistory(
+  body: Record<string, unknown>,
+  data: Record<string, unknown>,
+): readonly AgentPhoneRecentHistoryMessage[] {
+  return [
+    ...arrayValue(body, ["recentHistory", "recent_history"]),
+    ...arrayValue(data, ["recentHistory", "recent_history"]),
+  ]
+    .map(recentHistoryMessage)
+    .filter((item): item is AgentPhoneRecentHistoryMessage => {
+      return item !== null;
+    });
 }
 
 function extractAgentPhoneEvent(
@@ -653,6 +808,9 @@ function extractAgentPhoneEvent(
     stringValue(data, ["conversationId", "conversation_id"]) ??
     stringValue(body, ["conversationId", "conversation_id"]) ??
     null;
+  const isGroup = extractAgentPhoneIsGroup(body, data);
+  const mentioned = extractAgentPhoneMentioned(body, data, messageBody);
+  const recentHistory = extractAgentPhoneRecentHistory(body, data);
 
   if (!messageId || !agentphoneAgentId || !fromNumber || !toNumber) {
     log.warn("Missing required fields in AgentPhone webhook", {
@@ -672,6 +830,8 @@ function extractAgentPhoneEvent(
     channel,
     messageId,
     conversationId,
+    isGroup,
+    mentioned,
     agentphoneAgentId,
     fromNumber,
     toNumber,
@@ -681,6 +841,7 @@ function extractAgentPhoneEvent(
       parseDate(data.receivedAt) ??
       parseDate(data.received_at) ??
       parseDate(body.timestamp),
+    recentHistory,
   };
 }
 
@@ -696,6 +857,50 @@ function agentPhoneWebhookConfig(): AgentPhoneWebhookConfig | undefined {
     return undefined;
   }
   return { webhookSecret, officialPhoneNumber };
+}
+
+function shouldAcceptAgentPhoneEvent(args: {
+  readonly event: AgentPhoneMessageEvent;
+  readonly config: AgentPhoneWebhookConfig;
+  readonly channel: AgentPhoneChannel;
+  readonly webhookId: string | null;
+}): boolean {
+  if (
+    normalizeAgentPhoneHandle(args.event.toNumber, "sms") !==
+    normalizeAgentPhoneHandle(args.config.officialPhoneNumber, "sms")
+  ) {
+    return false;
+  }
+
+  const normalizedFrom = normalizeAgentPhoneHandle(
+    args.event.fromNumber,
+    args.channel,
+  );
+  log.debug("AgentPhone webhook accepted", {
+    webhookId: args.webhookId,
+    channel: args.channel,
+    fromShape: describeAgentPhoneHandleShape(args.event.fromNumber),
+    fromHandleNormalized: Boolean(normalizedFrom),
+    hasMedia: Boolean(args.event.mediaUrl),
+  });
+
+  if (
+    !normalizedFrom ||
+    !isValidAgentPhoneHandle(normalizedFrom, args.channel)
+  ) {
+    log.warn("AgentPhone webhook from-handle is not usable", {
+      webhookId: args.webhookId,
+      channel: args.channel,
+      fromShape: describeAgentPhoneHandleShape(args.event.fromNumber),
+    });
+    return false;
+  }
+
+  return true;
+}
+
+function shouldDispatchAgentPhoneEvent(event: AgentPhoneMessageEvent): boolean {
+  return !(event.channel === "imessage" && event.isGroup && !event.mentioned);
 }
 
 const webhook$ = command(async ({ get, set }, signal: AbortSignal) => {
@@ -754,39 +959,18 @@ const webhook$ = command(async ({ get, set }, signal: AbortSignal) => {
   }
 
   if (
-    normalizeAgentPhoneHandle(event.toNumber, "sms") !==
-    normalizeAgentPhoneHandle(config.officialPhoneNumber, "sms")
+    !shouldAcceptAgentPhoneEvent({
+      event,
+      config,
+      channel: rawChannel,
+      webhookId,
+    })
   ) {
     return okText();
   }
 
-  const normalizedFrom = normalizeAgentPhoneHandle(
-    event.fromNumber,
-    rawChannel,
-  );
-  log.debug("AgentPhone webhook accepted", {
-    webhookId,
-    channel: rawChannel,
-    fromShape: describeAgentPhoneHandleShape(event.fromNumber),
-    fromHandleNormalized: Boolean(normalizedFrom),
-    hasMedia: Boolean(event.mediaUrl),
-  });
-
-  if (!normalizedFrom || !isValidAgentPhoneHandle(normalizedFrom, rawChannel)) {
-    log.warn("AgentPhone webhook from-handle is not usable", {
-      webhookId,
-      channel: rawChannel,
-      fromShape: describeAgentPhoneHandleShape(event.fromNumber),
-    });
-    return okText();
-  }
-
   const writeDb = set(writeDb$);
-  const userLink = await resolveAgentPhoneUserLink(
-    writeDb,
-    event.fromNumber,
-    rawChannel,
-  );
+  const userLink = await resolveAgentPhoneUserLinkForEvent(writeDb, event);
   signal.throwIfAborted();
 
   const stored = await storeInboundAgentPhoneMessage(writeDb, {
@@ -795,6 +979,10 @@ const webhook$ = command(async ({ get, set }, signal: AbortSignal) => {
   });
   signal.throwIfAborted();
   if (!stored.inserted) {
+    return okText();
+  }
+
+  if (!shouldDispatchAgentPhoneEvent(event)) {
     return okText();
   }
 

--- a/turbo/apps/api/src/signals/services/zero-agentphone.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-agentphone.service.ts
@@ -65,6 +65,10 @@ const ORG_SENTINEL_USER_ID = "__org__";
 const MAX_CONTEXT_MESSAGES = 10;
 const AGENTPHONE_SMS_MMS_SLASH_COMMAND_RISK_MESSAGE =
   "Note: SMS and MMS replies may not be delivered reliably. For the most reliable experience, use iMessage with this AgentPhone number.";
+const AGENTPHONE_GROUP_CONNECT_IN_DM_MESSAGE =
+  "To connect this phone number, message Zero directly in a 1:1 iMessage conversation.";
+const AGENTPHONE_GROUP_ACCOUNT_COMMAND_MESSAGE =
+  "Only the linked sender can use AgentPhone account commands in a group. Message Zero directly to connect or manage your link.";
 
 const AGENTPHONE_DM_ROOT_MESSAGE_ID = "dm";
 export type AgentPhoneChannel = "imessage" | "sms" | "mms";
@@ -206,6 +210,19 @@ function shouldIgnoreAgentPhoneGroupMessage(
   event: AgentPhoneMessageEvent,
 ): boolean {
   return isAgentPhoneGroupEvent(event) && !event.mentioned;
+}
+
+function isAgentPhoneGroupAccountCommand(
+  event: AgentPhoneMessageEvent,
+  commandName: string | undefined,
+): boolean {
+  return (
+    isAgentPhoneGroupEvent(event) &&
+    (commandName === "connect" ||
+      commandName === "disconnect" ||
+      commandName === "new_session" ||
+      commandName === "model")
+  );
 }
 
 function stripZeroMention(text: string): string {
@@ -1444,6 +1461,54 @@ async function sendConnectPrompt(
   );
 }
 
+async function sendGroupConnectInDmPrompt(
+  event: AgentPhoneMessageEvent,
+  signal: AbortSignal,
+): Promise<void> {
+  await sendAgentPhoneText(
+    event,
+    AGENTPHONE_GROUP_CONNECT_IN_DM_MESSAGE,
+    signal,
+  );
+}
+
+async function sendGroupAccountCommandBlockedMessage(
+  event: AgentPhoneMessageEvent,
+  signal: AbortSignal,
+): Promise<void> {
+  await sendAgentPhoneText(
+    event,
+    AGENTPHONE_GROUP_ACCOUNT_COMMAND_MESSAGE,
+    signal,
+  );
+}
+
+async function blockUnauthorizedGroupAccountCommand(args: {
+  readonly db: Db;
+  readonly event: AgentPhoneMessageEvent;
+  readonly commandText: string | undefined;
+  readonly userLink: AgentPhoneUserLink | null;
+  readonly signal: AbortSignal;
+}): Promise<boolean> {
+  if (!isAgentPhoneGroupAccountCommand(args.event, args.commandText)) {
+    return false;
+  }
+
+  const directUserLink = await resolveAgentPhoneUserLink(
+    args.db,
+    args.event.fromNumber,
+    args.event.channel,
+  );
+  args.signal.throwIfAborted();
+
+  if (directUserLink && directUserLink.id === args.userLink?.id) {
+    return false;
+  }
+
+  await sendGroupAccountCommandBlockedMessage(args.event, args.signal);
+  return true;
+}
+
 async function handleConnectCommand(args: {
   readonly event: AgentPhoneMessageEvent;
   readonly userLink: AgentPhoneUserLink | null;
@@ -1746,6 +1811,34 @@ async function dispatchAgentPhoneCommand(args: {
   }
 }
 
+async function handleAgentPhoneCommandIfPresent(args: {
+  readonly get: ComputedGetter;
+  readonly set: ComputedSetter;
+  readonly db: Db;
+  readonly event: AgentPhoneMessageEvent;
+  readonly userLink: AgentPhoneUserLink | null;
+  readonly signal: AbortSignal;
+}): Promise<boolean> {
+  const commandText = parseAgentPhoneCommand(args.event.body);
+  if (commandText === undefined) {
+    return false;
+  }
+
+  if (await blockUnauthorizedGroupAccountCommand({ ...args, commandText })) {
+    return true;
+  }
+
+  return dispatchAgentPhoneCommand({
+    get: args.get,
+    set: args.set,
+    db: args.db,
+    command: commandText,
+    event: args.event,
+    userLink: args.userLink,
+    signal: args.signal,
+  });
+}
+
 async function runAgentForAgentPhone(
   set: ComputedSetter,
   args: {
@@ -1918,13 +2011,11 @@ export const handleAgentPhoneMessage$ = command(
       return;
     }
 
-    const commandText = parseAgentPhoneCommand(params.event.body);
     if (
-      await dispatchAgentPhoneCommand({
+      await handleAgentPhoneCommandIfPresent({
         get,
         set,
         db,
-        command: commandText,
         event: params.event,
         userLink: params.userLink,
         signal,
@@ -1934,6 +2025,11 @@ export const handleAgentPhoneMessage$ = command(
     }
 
     if (!params.userLink) {
+      if (isAgentPhoneGroupEvent(params.event)) {
+        await sendGroupConnectInDmPrompt(params.event, signal);
+        return;
+      }
+
       await sendConnectPrompt(params.event, undefined, signal);
       return;
     }

--- a/turbo/apps/api/src/signals/services/zero-agentphone.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-agentphone.service.ts
@@ -1,4 +1,9 @@
-import { createHmac, randomBytes, timingSafeEqual } from "node:crypto";
+import {
+  createHash,
+  createHmac,
+  randomBytes,
+  timingSafeEqual,
+} from "node:crypto";
 import { gzipSync } from "node:zlib";
 
 import { command, type Getter, type Setter } from "ccstate";
@@ -24,7 +29,7 @@ import { agentphoneMessages } from "@vm0/db/schema/agentphone-message";
 import { agentphoneThreadSessions } from "@vm0/db/schema/agentphone-thread-session";
 import { agentphoneUserAgentPreferences } from "@vm0/db/schema/agentphone-user-agent-preference";
 import { agentphoneUserLinks } from "@vm0/db/schema/agentphone-user-link";
-import { and, desc, eq } from "drizzle-orm";
+import { and, desc, eq, isNotNull } from "drizzle-orm";
 
 import { env, optionalEnv } from "../../lib/env";
 import { inferMimetype } from "../../lib/mimetype";
@@ -61,27 +66,42 @@ const MAX_CONTEXT_MESSAGES = 10;
 const AGENTPHONE_SMS_MMS_SLASH_COMMAND_RISK_MESSAGE =
   "Note: SMS and MMS replies may not be delivered reliably. For the most reliable experience, use iMessage with this AgentPhone number.";
 
-const AGENTPHONE_ROOT_MESSAGE_ID = "dm";
+const AGENTPHONE_DM_ROOT_MESSAGE_ID = "dm";
 export type AgentPhoneChannel = "imessage" | "sms" | "mms";
 type AgentPhoneUserLink = typeof agentphoneUserLinks.$inferSelect;
+
+export interface AgentPhoneRecentHistoryMessage {
+  readonly messageId?: string | null;
+  readonly content: string | null;
+  readonly direction: string | null;
+  readonly channel: string | null;
+  readonly fromNumber?: string | null;
+  readonly toNumber?: string | null;
+  readonly at?: string | null;
+}
 
 export interface AgentPhoneMessageEvent {
   readonly webhookId: string | null;
   readonly channel: AgentPhoneChannel;
   readonly messageId: string;
   readonly conversationId: string | null;
+  readonly isGroup: boolean;
+  readonly mentioned: boolean;
   readonly agentphoneAgentId: string;
   readonly fromNumber: string;
   readonly toNumber: string;
   readonly body: string;
   readonly mediaUrl: string | null;
   readonly receivedAt: Date | null;
+  readonly recentHistory: readonly AgentPhoneRecentHistoryMessage[];
 }
 
 interface AgentPhoneCallbackContext {
   readonly messageId: string;
   readonly conversationId: string | null;
   readonly channel: AgentPhoneChannel;
+  readonly isGroup: boolean;
+  readonly rootMessageId: string;
   readonly phoneHandle: string;
   readonly fromNumber: string;
   readonly toNumber: string;
@@ -161,6 +181,38 @@ export function describeAgentPhoneHandleShape(
     return "phone";
   }
   return "other";
+}
+
+function isAgentPhoneGroupEvent(event: AgentPhoneMessageEvent): boolean {
+  return event.channel === "imessage" && event.isGroup;
+}
+
+function agentPhoneThreadRootMessageId(event: AgentPhoneMessageEvent): string {
+  if (!isAgentPhoneGroupEvent(event) || !event.conversationId) {
+    return AGENTPHONE_DM_ROOT_MESSAGE_ID;
+  }
+
+  const root = `group:${event.conversationId}`;
+  if (root.length <= 255) {
+    return root;
+  }
+
+  return `group:${createHash("sha256")
+    .update(event.conversationId)
+    .digest("hex")}`;
+}
+
+function shouldIgnoreAgentPhoneGroupMessage(
+  event: AgentPhoneMessageEvent,
+): boolean {
+  return isAgentPhoneGroupEvent(event) && !event.mentioned;
+}
+
+function stripZeroMention(text: string): string {
+  return text
+    .replace(/(^|\s)@(zero|vm0)\b/giu, " ")
+    .replace(/[ \t]{2,}/gu, " ")
+    .trim();
 }
 
 function normalizeHandleForConnect(handle: string): string {
@@ -502,6 +554,64 @@ export async function resolveAgentPhoneUserLink(
   return touchAgentPhoneUserLink(db, userLink, normalized, channel);
 }
 
+async function resolveAgentPhoneUserLinkById(
+  db: ReadonlyDb,
+  userLinkId: string,
+): Promise<AgentPhoneUserLink | null> {
+  const [userLink] = await db
+    .select()
+    .from(agentphoneUserLinks)
+    .where(eq(agentphoneUserLinks.id, userLinkId))
+    .limit(1);
+  return userLink ?? null;
+}
+
+async function resolveAgentPhoneConversationUserLink(
+  db: ReadonlyDb,
+  conversationId: string,
+): Promise<AgentPhoneUserLink | null> {
+  const [session] = await db
+    .select({ userLinkId: agentphoneThreadSessions.agentphoneUserLinkId })
+    .from(agentphoneThreadSessions)
+    .where(eq(agentphoneThreadSessions.conversationId, conversationId))
+    .orderBy(desc(agentphoneThreadSessions.updatedAt))
+    .limit(1);
+  if (session) {
+    return resolveAgentPhoneUserLinkById(db, session.userLinkId);
+  }
+
+  const [message] = await db
+    .select({ userLinkId: agentphoneMessages.agentphoneUserLinkId })
+    .from(agentphoneMessages)
+    .where(
+      and(
+        eq(agentphoneMessages.conversationId, conversationId),
+        isNotNull(agentphoneMessages.agentphoneUserLinkId),
+      ),
+    )
+    .orderBy(desc(agentphoneMessages.createdAt))
+    .limit(1);
+  return message?.userLinkId
+    ? resolveAgentPhoneUserLinkById(db, message.userLinkId)
+    : null;
+}
+
+export async function resolveAgentPhoneUserLinkForEvent(
+  db: Db,
+  event: AgentPhoneMessageEvent,
+): Promise<AgentPhoneUserLink | null> {
+  const direct = await resolveAgentPhoneUserLink(
+    db,
+    event.fromNumber,
+    event.channel,
+  );
+  if (direct || !isAgentPhoneGroupEvent(event) || !event.conversationId) {
+    return direct;
+  }
+
+  return resolveAgentPhoneConversationUserLink(db, event.conversationId);
+}
+
 export async function resolveAgentPhoneUserLinkForOwner(
   db: Db,
   params: {
@@ -748,6 +858,7 @@ async function resolveAgentPhoneAgent(
 async function lookupAgentPhoneThreadSession(
   db: ReadonlyDb,
   userLinkId: string,
+  rootMessageId: string,
 ): Promise<ThreadSessionLookup> {
   const [session] = await db
     .select({
@@ -758,7 +869,7 @@ async function lookupAgentPhoneThreadSession(
     .where(
       and(
         eq(agentphoneThreadSessions.agentphoneUserLinkId, userLinkId),
-        eq(agentphoneThreadSessions.rootMessageId, AGENTPHONE_ROOT_MESSAGE_ID),
+        eq(agentphoneThreadSessions.rootMessageId, rootMessageId),
       ),
     )
     .limit(1);
@@ -774,9 +885,14 @@ async function resolveCompatibleAgentPhoneThreadSession(args: {
   readonly userLinkId: string;
   readonly userId: string;
   readonly agentComposeId: string;
+  readonly rootMessageId: string;
   readonly modelRoute: ModelRoutePin | undefined;
 }): Promise<ThreadSessionLookup> {
-  const session = await lookupAgentPhoneThreadSession(args.db, args.userLinkId);
+  const session = await lookupAgentPhoneThreadSession(
+    args.db,
+    args.userLinkId,
+    args.rootMessageId,
+  );
   if (!session.existingSessionId) {
     return session;
   }
@@ -819,6 +935,7 @@ export async function saveAgentPhoneThreadSession(
   opts: {
     readonly userLinkId: string;
     readonly conversationId: string | null;
+    readonly rootMessageId: string;
     readonly existingSessionId: string | undefined;
     readonly newSessionId: string | undefined;
     readonly messageId: string;
@@ -837,10 +954,7 @@ export async function saveAgentPhoneThreadSession(
       .where(
         and(
           eq(agentphoneThreadSessions.agentphoneUserLinkId, opts.userLinkId),
-          eq(
-            agentphoneThreadSessions.rootMessageId,
-            AGENTPHONE_ROOT_MESSAGE_ID,
-          ),
+          eq(agentphoneThreadSessions.rootMessageId, opts.rootMessageId),
         ),
       )
       .returning({ id: agentphoneThreadSessions.id });
@@ -854,7 +968,7 @@ export async function saveAgentPhoneThreadSession(
       .values({
         agentphoneUserLinkId: opts.userLinkId,
         conversationId: opts.conversationId,
-        rootMessageId: AGENTPHONE_ROOT_MESSAGE_ID,
+        rootMessageId: opts.rootMessageId,
         agentSessionId: opts.newSessionId,
         lastProcessedMessageId: opts.messageId,
       })
@@ -876,10 +990,7 @@ export async function saveAgentPhoneThreadSession(
       .where(
         and(
           eq(agentphoneThreadSessions.agentphoneUserLinkId, opts.userLinkId),
-          eq(
-            agentphoneThreadSessions.rootMessageId,
-            AGENTPHONE_ROOT_MESSAGE_ID,
-          ),
+          eq(agentphoneThreadSessions.rootMessageId, opts.rootMessageId),
         ),
       );
   }
@@ -961,6 +1072,9 @@ async function fetchAgentPhoneContext(
     readonly userLinkId: string;
     readonly phoneHandle: string;
     readonly channel: AgentPhoneChannel;
+    readonly conversationId: string | null;
+    readonly isGroup: boolean;
+    readonly recentHistory: readonly AgentPhoneRecentHistoryMessage[];
     readonly currentMessageId?: string;
   },
 ): Promise<{ readonly executionContext: string }> {
@@ -968,36 +1082,93 @@ async function fetchAgentPhoneContext(
     params.phoneHandle,
     params.channel,
   );
-  const messages = await db
-    .select({
-      messageId: agentphoneMessages.agentphoneMessageId,
-      body: agentphoneMessages.body,
-      mediaUrl: agentphoneMessages.mediaUrl,
-      isBot: agentphoneMessages.isBot,
-      direction: agentphoneMessages.direction,
-    })
-    .from(agentphoneMessages)
-    .where(
-      and(
-        eq(agentphoneMessages.agentphoneUserLinkId, params.userLinkId),
-        eq(agentphoneMessages.phoneHandle, phoneHandle),
-      ),
-    )
-    .orderBy(desc(agentphoneMessages.createdAt))
-    .limit(MAX_CONTEXT_MESSAGES);
+  const providerContext = formatAgentPhoneRecentHistoryContext(
+    params.recentHistory,
+    params.currentMessageId,
+    params.isGroup,
+  );
+  if (providerContext) {
+    return { executionContext: providerContext };
+  }
 
-  const chronological = messages.reverse().filter((message) => {
+  const messages =
+    params.isGroup && params.conversationId
+      ? await db
+          .select({
+            messageId: agentphoneMessages.agentphoneMessageId,
+            body: agentphoneMessages.body,
+            mediaUrl: agentphoneMessages.mediaUrl,
+            isBot: agentphoneMessages.isBot,
+            direction: agentphoneMessages.direction,
+            fromNumber: agentphoneMessages.fromNumber,
+          })
+          .from(agentphoneMessages)
+          .where(
+            and(
+              eq(agentphoneMessages.agentphoneUserLinkId, params.userLinkId),
+              eq(agentphoneMessages.conversationId, params.conversationId),
+            ),
+          )
+          .orderBy(desc(agentphoneMessages.createdAt))
+          .limit(MAX_CONTEXT_MESSAGES)
+      : await db
+          .select({
+            messageId: agentphoneMessages.agentphoneMessageId,
+            body: agentphoneMessages.body,
+            mediaUrl: agentphoneMessages.mediaUrl,
+            isBot: agentphoneMessages.isBot,
+            direction: agentphoneMessages.direction,
+            fromNumber: agentphoneMessages.fromNumber,
+          })
+          .from(agentphoneMessages)
+          .where(
+            and(
+              eq(agentphoneMessages.agentphoneUserLinkId, params.userLinkId),
+              eq(agentphoneMessages.phoneHandle, phoneHandle),
+            ),
+          )
+          .orderBy(desc(agentphoneMessages.createdAt))
+          .limit(MAX_CONTEXT_MESSAGES);
+
+  return {
+    executionContext: formatAgentPhoneStoredContext({
+      messages,
+      currentMessageId: params.currentMessageId,
+      fallbackSender: phoneHandle,
+      isGroup: params.isGroup,
+    }),
+  };
+}
+
+function formatAgentPhoneStoredContext(params: {
+  readonly messages: readonly {
+    readonly messageId: string;
+    readonly body: string | null;
+    readonly mediaUrl: string | null;
+    readonly isBot: boolean;
+    readonly direction: string;
+    readonly fromNumber: string;
+  }[];
+  readonly currentMessageId?: string;
+  readonly fallbackSender: string;
+  readonly isGroup: boolean;
+}): string {
+  const chronological = [...params.messages].reverse().filter((message) => {
     return (
       !params.currentMessageId || message.messageId !== params.currentMessageId
     );
   });
   if (chronological.length === 0) {
-    return { executionContext: "" };
+    return "";
   }
 
   const total = chronological.length;
   const formatted = chronological.map((message, index) => {
-    const sender = message.isBot ? "BOT" : phoneHandle;
+    const sender = message.isBot
+      ? "BOT"
+      : params.isGroup
+        ? message.fromNumber
+        : params.fallbackSender;
     const parts = [
       "---",
       "",
@@ -1020,33 +1191,88 @@ async function fetchAgentPhoneContext(
     return parts.join("\n");
   });
 
-  return {
-    executionContext: [
-      "# AgentPhone Message Context",
-      "",
-      "The messages below are from the user's text message conversation with the shared Zero number. Messages closer to RELATIVE_INDEX 0 are more recent.",
-      "",
-      formatted.join("\n\n"),
-      "",
-      "---",
-    ].join("\n"),
-  };
+  return buildAgentPhoneContextBlock(formatted, params.isGroup);
 }
 
-function enrichAgentPhonePrompt(
-  prompt: string,
-  phoneHandle: string,
-  channel: AgentPhoneChannel,
-  messageId: string,
-  mediaUrl: string | null,
-): {
+function formatAgentPhoneRecentHistoryContext(
+  recentHistory: readonly AgentPhoneRecentHistoryMessage[],
+  currentMessageId: string | undefined,
+  isGroup: boolean,
+): string {
+  const chronological = recentHistory
+    .filter((message) => {
+      return !currentMessageId || message.messageId !== currentMessageId;
+    })
+    .slice(-MAX_CONTEXT_MESSAGES);
+
+  if (chronological.length === 0) {
+    return "";
+  }
+
+  const total = chronological.length;
+  const formatted = chronological.map((message, index) => {
+    const sender = message.fromNumber ?? message.direction ?? "unknown";
+    return [
+      "---",
+      "",
+      `- RELATIVE_INDEX: ${index - total}`,
+      message.messageId ? `- MSG_ID: ${message.messageId}` : null,
+      `- SENDER: {id: ${sender}}`,
+      message.direction ? `- DIRECTION: ${message.direction}` : null,
+      message.channel ? `- CHANNEL: ${message.channel}` : null,
+      message.at ? `- AT: ${message.at}` : null,
+      "",
+      message.content ?? "",
+    ]
+      .filter((part): part is string => {
+        return part !== null;
+      })
+      .join("\n");
+  });
+
+  return buildAgentPhoneContextBlock(formatted, isGroup);
+}
+
+function buildAgentPhoneContextBlock(
+  formattedMessages: readonly string[],
+  isGroup: boolean,
+): string {
+  return [
+    "# AgentPhone Message Context",
+    "",
+    isGroup
+      ? "The messages below are from an iMessage group conversation with the shared Zero number. Messages closer to RELATIVE_INDEX 0 are more recent."
+      : "The messages below are from the user's text message conversation with the shared Zero number. Messages closer to RELATIVE_INDEX 0 are more recent.",
+    "",
+    formattedMessages.join("\n\n"),
+    "",
+    "---",
+  ].join("\n");
+}
+
+function enrichAgentPhonePrompt(opts: {
+  readonly prompt: string;
+  readonly phoneHandle: string;
+  readonly channel: AgentPhoneChannel;
+  readonly messageId: string;
+  readonly mediaUrl: string | null;
+  readonly isGroup: boolean;
+}): {
   readonly prompt: string;
   readonly userInfoExtras: { readonly agentphoneHandle: string };
 } {
-  const normalized = normalizeAgentPhoneHandle(phoneHandle, channel);
-  const parts = [prompt.trim()];
-  if (mediaUrl) {
-    parts.push(formatAgentPhoneFileForContext({ messageId, mediaUrl }));
+  const normalized = normalizeAgentPhoneHandle(opts.phoneHandle, opts.channel);
+  const promptText = opts.isGroup
+    ? stripZeroMention(opts.prompt)
+    : opts.prompt.trim();
+  const parts = [promptText];
+  if (opts.mediaUrl) {
+    parts.push(
+      formatAgentPhoneFileForContext({
+        messageId: opts.messageId,
+        mediaUrl: opts.mediaUrl,
+      }),
+    );
   }
   return {
     prompt: parts.filter(Boolean).join("\n\n"),
@@ -1064,6 +1290,7 @@ function buildAgentPhonePrompt(
     readonly phoneHandle: string;
     readonly conversationId?: string | null;
     readonly channel?: string | null;
+    readonly isGroup?: boolean;
     readonly messageId?: string;
     readonly agentphoneAgentId?: string;
   },
@@ -1077,6 +1304,9 @@ function buildAgentPhonePrompt(
   }
   if (opts.channel) {
     headerParts.push(`Channel: ${opts.channel}`);
+  }
+  if (opts.isGroup !== undefined) {
+    headerParts.push(`Conversation type: ${opts.isGroup ? "group" : "dm"}`);
   }
   if (opts.conversationId) {
     headerParts.push(`Conversation ID: ${opts.conversationId}`);
@@ -1127,7 +1357,12 @@ async function sendAgentPhoneText(
   await sendAgentPhoneMessage(
     {
       agentphoneAgentId: event.agentphoneAgentId,
-      toNumber: event.fromNumber,
+      ...(isAgentPhoneGroupEvent(event) && event.conversationId
+        ? {
+            conversationId: event.conversationId,
+            replyToMessageId: event.messageId,
+          }
+        : { toNumber: event.fromNumber }),
       body,
     },
     signal,
@@ -1268,7 +1503,10 @@ async function handleNewSessionCommand(args: {
     .where(
       and(
         eq(agentphoneThreadSessions.agentphoneUserLinkId, args.userLink.id),
-        eq(agentphoneThreadSessions.rootMessageId, AGENTPHONE_ROOT_MESSAGE_ID),
+        eq(
+          agentphoneThreadSessions.rootMessageId,
+          agentPhoneThreadRootMessageId(args.event),
+        ),
       ),
     );
   args.signal.throwIfAborted();
@@ -1549,6 +1787,7 @@ async function runAgentForAgentPhone(
           phoneHandle: args.event.fromNumber,
           conversationId: args.event.conversationId,
           channel: args.event.channel,
+          isGroup: isAgentPhoneGroupEvent(args.event),
           messageId: args.event.messageId,
           agentphoneAgentId: args.event.agentphoneAgentId,
         },
@@ -1643,6 +1882,27 @@ async function sendAgentPhoneFailedRunResult(args: {
   );
 }
 
+async function handleAgentPhoneRunResult(args: {
+  readonly get: ComputedGetter;
+  readonly event: AgentPhoneMessageEvent;
+  readonly userLink: AgentPhoneUserLink;
+  readonly result: RunAgentResult;
+  readonly signal: AbortSignal;
+}): Promise<void> {
+  if (args.result.status === "queued") {
+    await sendAgentPhoneText(
+      args.event,
+      "Run queued because the concurrency limit was reached. It will start automatically when a slot is available.",
+      args.signal,
+    );
+    return;
+  }
+
+  if (args.result.status === "failed") {
+    await sendAgentPhoneFailedRunResult(args);
+  }
+}
+
 export const handleAgentPhoneMessage$ = command(
   async (
     { get, set },
@@ -1654,6 +1914,10 @@ export const handleAgentPhoneMessage$ = command(
     signal: AbortSignal,
   ): Promise<void> => {
     const db = set(writeDb$);
+    if (shouldIgnoreAgentPhoneGroupMessage(params.event)) {
+      return;
+    }
+
     const commandText = parseAgentPhoneCommand(params.event.body);
     if (
       await dispatchAgentPhoneCommand({
@@ -1697,30 +1961,37 @@ export const handleAgentPhoneMessage$ = command(
     });
     signal.throwIfAborted();
 
+    const rootMessageId = agentPhoneThreadRootMessageId(params.event);
     const session = await resolveCompatibleAgentPhoneThreadSession({
       db,
       userLinkId: params.userLink.id,
       userId: params.userLink.vm0UserId,
       agentComposeId: agent.composeId,
+      rootMessageId,
       modelRoute,
     });
     signal.throwIfAborted();
 
+    const isGroup = isAgentPhoneGroupEvent(params.event);
     const { executionContext } = await fetchAgentPhoneContext(db, {
       userLinkId: params.userLink.id,
       phoneHandle: params.event.fromNumber,
       channel: params.event.channel,
+      conversationId: params.event.conversationId,
+      isGroup,
+      recentHistory: params.event.recentHistory,
       currentMessageId: params.event.messageId,
     });
     signal.throwIfAborted();
 
-    const { prompt, userInfoExtras } = enrichAgentPhonePrompt(
-      params.event.body,
-      params.event.fromNumber,
-      params.event.channel,
-      params.event.messageId,
-      params.event.mediaUrl,
-    );
+    const { prompt, userInfoExtras } = enrichAgentPhonePrompt({
+      prompt: params.event.body,
+      phoneHandle: params.event.fromNumber,
+      channel: params.event.channel,
+      messageId: params.event.messageId,
+      mediaUrl: params.event.mediaUrl,
+      isGroup,
+    });
 
     const result = await runAgentForAgentPhone(
       set,
@@ -1743,6 +2014,8 @@ export const handleAgentPhoneMessage$ = command(
           messageId: params.event.messageId,
           conversationId: params.event.conversationId,
           channel: params.event.channel,
+          isGroup,
+          rootMessageId,
           phoneHandle: params.event.fromNumber,
           fromNumber: params.event.fromNumber,
           toNumber: params.event.toNumber,
@@ -1755,24 +2028,13 @@ export const handleAgentPhoneMessage$ = command(
       signal,
     );
 
-    if (result.status === "queued") {
-      await sendAgentPhoneText(
-        params.event,
-        "Run queued because the concurrency limit was reached. It will start automatically when a slot is available.",
-        signal,
-      );
-      return;
-    }
-
-    if (result.status === "failed") {
-      await sendAgentPhoneFailedRunResult({
-        get,
-        event: params.event,
-        userLink: params.userLink,
-        result,
-        signal,
-      });
-    }
+    await handleAgentPhoneRunResult({
+      get,
+      event: params.event,
+      userLink: params.userLink,
+      result,
+      signal,
+    });
   },
 );
 

--- a/turbo/packages/api-contracts/src/contracts/internal-callbacks-agentphone.ts
+++ b/turbo/packages/api-contracts/src/contracts/internal-callbacks-agentphone.ts
@@ -15,6 +15,8 @@ export const agentPhoneCallbackPayloadSchema = z
     messageId: z.string(),
     conversationId: z.string().nullable(),
     channel: z.string().optional(),
+    isGroup: z.boolean().optional(),
+    rootMessageId: z.string().optional(),
     phoneHandle: z.string(),
     fromNumber: z.string(),
     toNumber: z.string(),


### PR DESCRIPTION
## Summary
- detect AgentPhone iMessage group webhooks and only dispatch runs when Zero is mentioned
- keep group conversations on a conversation-scoped thread root and reply by conversation ID instead of DM phone number
- include provider recent history in AgentPhone run context and cover group webhook/callback behavior in tests

## Testing
- pnpm lint (apps/api)
- pnpm check-types (apps/api)
- pnpm exec vitest run src/signals/routes/__tests__/zero-integrations-agentphone-routes.test.ts (apps/api)
- pnpm lint (packages/api-contracts)
- pnpm check-types (packages/api-contracts)
- pre-commit: pnpm check-types (repo turbo, all scoped packages)

Refs #13558