### PR TITLE
refactor: track spawn process lifetime in vsock-host

### DIFF
--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -483,6 +483,11 @@ async fn reader_loop(
                 }
                 if let Some(pending_response) = pending_response {
                     let _ = pending_response.response_tx.send(msg);
+                } else if msg.msg_type != MSG_SPAWN_PROCESS_RESULT
+                    && process::reject_unexpected_process_response(&shared, &msg).is_err()
+                {
+                    shared.poison_connection();
+                    return;
                 }
             }
         }

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -454,6 +454,13 @@ async fn reader_loop(
                     shared.poison_connection();
                     return;
                 }
+                if msg.msg_type != MSG_SPAWN_PROCESS_RESULT
+                    && process::reject_unexpected_process_response(&shared, msg.seq, msg.msg_type)
+                        .is_err()
+                {
+                    shared.poison_connection();
+                    return;
+                }
                 let mut normal_operation_transition_failed = false;
                 let pending_response = {
                     let mut guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
@@ -483,11 +490,6 @@ async fn reader_loop(
                 }
                 if let Some(pending_response) = pending_response {
                     let _ = pending_response.response_tx.send(msg);
-                } else if msg.msg_type != MSG_SPAWN_PROCESS_RESULT
-                    && process::reject_unexpected_process_response(&shared, &msg).is_err()
-                {
-                    shared.poison_connection();
-                    return;
                 }
             }
         }

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -421,6 +421,10 @@ async fn reader_loop(
                         return;
                     }
                 }
+                if process::record_spawn_process_error(&shared, &msg).is_err() {
+                    shared.poison_connection();
+                    return;
+                }
             }
 
             if msg.msg_type == MSG_EXEC_OUTPUT {
@@ -1060,8 +1064,8 @@ impl VsockHost {
     ///
     /// `timeout_ms` must be positive. Callers needing unbounded commands
     /// should use [`spawn_process`](Self::spawn_process), which decouples the
-    /// host request/response cycle from the command's lifetime and does not
-    /// leak a guest-side orphan when the host stops waiting.
+    /// host request/response cycle from the command's lifetime and keeps
+    /// host-side lifecycle tracking until the guest reports process exit.
     pub async fn exec(
         &self,
         command: &str,
@@ -1080,7 +1084,9 @@ impl VsockHost {
     /// Spawn a process on the guest and monitor for exit.
     ///
     /// Returns immediately with a handle. Use [`GuestProcessHandle::wait`] to
-    /// wait for completion.
+    /// wait for completion. Dropping the handle does not cancel the guest
+    /// process; the host continues tracking lifecycle frames until process exit
+    /// or connection close.
     ///
     /// When `stream_stdout` is true, stdout chunks are streamed to the host via
     /// `MSG_STDOUT_CHUNK`. `stdout_log_path`, when present, additionally asks

--- a/crates/vsock-host/src/process.rs
+++ b/crates/vsock-host/src/process.rs
@@ -16,6 +16,8 @@ use crate::{
     operation_tracker::NormalOperationToken, request_on_shared,
 };
 
+const SPAWN_PROCESS_RESPONSE_TIMEOUT: Duration = Duration::from_secs(30);
+
 /// Event emitted when a spawned process exits.
 #[derive(Debug, Clone)]
 pub struct ProcessExitEvent {
@@ -173,6 +175,10 @@ impl ProcessOperationRegistrationGuard {
 
     fn keep_on_drop(&mut self) {
         self.state = ProcessOperationRegistrationState::KeepOnDrop;
+    }
+
+    fn remove_on_drop(&mut self) {
+        self.state = ProcessOperationRegistrationState::RemoveOnDrop;
     }
 
     fn disarm(&mut self) {
@@ -650,6 +656,15 @@ pub(crate) async fn spawn_process_on_shared(
     shared: &Arc<Shared>,
     request: SpawnProcessOnSharedRequest<'_>,
 ) -> io::Result<GuestProcessHandle> {
+    spawn_process_on_shared_with_response_timeout(shared, request, SPAWN_PROCESS_RESPONSE_TIMEOUT)
+        .await
+}
+
+async fn spawn_process_on_shared_with_response_timeout(
+    shared: &Arc<Shared>,
+    request: SpawnProcessOnSharedRequest<'_>,
+    response_timeout: Duration,
+) -> io::Result<GuestProcessHandle> {
     let SpawnProcessOnSharedRequest {
         command,
         timeout_ms,
@@ -754,7 +769,8 @@ pub(crate) async fn spawn_process_on_shared(
                     "connection closed",
                 ))?
             }
-            _ = tokio::time::sleep(Duration::from_secs(30)) => {
+            _ = tokio::time::sleep(response_timeout) => {
+                registration_guard.remove_on_drop();
                 return Err(io::Error::new(io::ErrorKind::TimedOut, "request timeout"));
             }
         }
@@ -798,6 +814,28 @@ pub(crate) async fn spawn_process_on_shared(
 #[cfg(test)]
 pub(crate) mod test_support {
     use super::*;
+
+    pub(crate) async fn spawn_process_with_response_timeout(
+        shared: &Arc<Shared>,
+        command: &str,
+        stream_stdout: bool,
+        response_timeout: Duration,
+    ) -> io::Result<GuestProcessHandle> {
+        spawn_process_on_shared_with_response_timeout(
+            shared,
+            SpawnProcessOnSharedRequest {
+                command,
+                timeout_ms: 0,
+                env: &[],
+                sudo: false,
+                stream_stdout,
+                stdout_log_path: None,
+                control_sink: false,
+            },
+            response_timeout,
+        )
+        .await
+    }
 
     pub(crate) fn drop_started_frame_write_guard(shared: Arc<Shared>) {
         let mut guard = ProcessOperationFrameWriteGuard::new(shared);

--- a/crates/vsock-host/src/process.rs
+++ b/crates/vsock-host/src/process.rs
@@ -182,8 +182,14 @@ impl ProcessOperationRegistrationGuard {
 
 impl Drop for ProcessOperationRegistrationGuard {
     fn drop(&mut self) {
-        if self.state == ProcessOperationRegistrationState::RemoveOnDrop {
-            remove_process_operation(&self.shared, self.seq);
+        match self.state {
+            ProcessOperationRegistrationState::RemoveOnDrop => {
+                remove_process_operation(&self.shared, self.seq);
+            }
+            ProcessOperationRegistrationState::KeepOnDrop => {
+                clear_process_stdout_sender(&self.shared, self.seq);
+            }
+            ProcessOperationRegistrationState::Disarmed => {}
         }
     }
 }
@@ -298,6 +304,14 @@ impl GuestProcessHandle {
             .await
             .map_err(|_| io::Error::new(io::ErrorKind::ConnectionReset, "connection closed"))?;
         Ok(event)
+    }
+}
+
+impl Drop for GuestProcessHandle {
+    fn drop(&mut self) {
+        if self.stdout_rx.is_some() {
+            clear_process_stdout_sender(&self.control.shared, self.control.target_seq);
+        }
     }
 }
 

--- a/crates/vsock-host/src/process.rs
+++ b/crates/vsock-host/src/process.rs
@@ -84,6 +84,10 @@ impl ConnectedProcessState {
         self.operations.get_mut(&seq)
     }
 
+    fn contains_operation(&self, seq: u32) -> bool {
+        self.operations.contains_key(&seq)
+    }
+
     fn take_operation(&mut self, seq: u32) -> Option<ProcessOperation> {
         self.operations.remove(&seq)
     }
@@ -520,6 +524,26 @@ pub(crate) fn record_spawn_process_result(
         let pid = vsock_proto::decode_spawn_process_result(&msg.payload)
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
         operation.pid = Some(pid);
+    }
+    Ok(())
+}
+
+pub(crate) fn reject_unexpected_process_response(
+    shared: &Arc<Shared>,
+    msg: &RawMessage,
+) -> io::Result<()> {
+    let guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
+    let ConnectionState::Connected { process, .. } = &*guard else {
+        return Ok(());
+    };
+    if process.contains_operation(msg.seq) {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "unexpected response type for spawn_process: 0x{:02X}",
+                msg.msg_type
+            ),
+        ));
     }
     Ok(())
 }

--- a/crates/vsock-host/src/process.rs
+++ b/crates/vsock-host/src/process.rs
@@ -530,19 +530,17 @@ pub(crate) fn record_spawn_process_result(
 
 pub(crate) fn reject_unexpected_process_response(
     shared: &Arc<Shared>,
-    msg: &RawMessage,
+    seq: u32,
+    msg_type: u8,
 ) -> io::Result<()> {
     let guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
     let ConnectionState::Connected { process, .. } = &*guard else {
         return Ok(());
     };
-    if process.contains_operation(msg.seq) {
+    if process.contains_operation(seq) {
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,
-            format!(
-                "unexpected response type for spawn_process: 0x{:02X}",
-                msg.msg_type
-            ),
+            format!("unexpected response type for spawn_process: 0x{msg_type:02X}"),
         ));
     }
     Ok(())

--- a/crates/vsock-host/src/process.rs
+++ b/crates/vsock-host/src/process.rs
@@ -287,9 +287,12 @@ impl GuestProcessHandle {
         })?;
 
         // `wait` consumes the handle, so an unclaimed stdout receiver can no
-        // longer be observed by the caller. Drop it before waiting to avoid
-        // buffering streamed stdout in an unbounded channel with no reader.
-        drop(self.stdout_rx.take());
+        // longer be observed by the caller. Drop it before waiting and clear
+        // the sender to avoid retaining an unused channel for long-lived
+        // processes that never emit another stdout chunk.
+        if self.stdout_rx.take().is_some() {
+            clear_process_stdout_sender(&self.control.shared, self.control.target_seq);
+        }
 
         let event = rx
             .await
@@ -452,6 +455,15 @@ fn remove_process_operation(shared: &Arc<Shared>, seq: u32) {
     let mut guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
     if let ConnectionState::Connected { process, .. } = &mut *guard {
         process.remove_operation(seq);
+    }
+}
+
+fn clear_process_stdout_sender(shared: &Arc<Shared>, seq: u32) {
+    let mut guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
+    if let ConnectionState::Connected { process, .. } = &mut *guard
+        && let Some(operation) = process.operation_mut(seq)
+    {
+        operation.stdout_tx = None;
     }
 }
 

--- a/crates/vsock-host/src/process.rs
+++ b/crates/vsock-host/src/process.rs
@@ -746,3 +746,14 @@ pub(crate) async fn spawn_process_on_shared(
         exit_rx: Some(exit_rx),
     })
 }
+
+#[cfg(test)]
+pub(crate) mod test_support {
+    use super::*;
+
+    pub(crate) fn drop_started_frame_write_guard(shared: Arc<Shared>) {
+        let mut guard = ProcessOperationFrameWriteGuard::new(shared);
+        guard.mark_started();
+        drop(guard);
+    }
+}

--- a/crates/vsock-host/src/process.rs
+++ b/crates/vsock-host/src/process.rs
@@ -4,13 +4,17 @@ use std::io;
 use std::sync::Arc;
 use std::time::Duration;
 
+use tokio::io::AsyncWriteExt;
 use tokio::sync::{mpsc, oneshot};
 use vsock_proto::{
     MSG_ERROR, MSG_PROCESS_CONTROL, MSG_PROCESS_CONTROL_RESULT, MSG_SPAWN_PROCESS,
     MSG_SPAWN_PROCESS_RESULT, ProcessControlNonce, ProcessControlStatus, RawMessage,
 };
 
-use crate::{ConnectionState, Shared, request_on_shared, request_raw_on_shared};
+use crate::{
+    ConnectionState, PendingRequestGuard, PendingResponse, Shared,
+    operation_tracker::NormalOperationToken, request_on_shared,
+};
 
 /// Event emitted when a spawned process exits.
 #[derive(Debug, Clone)]
@@ -33,6 +37,7 @@ struct ProcessOperation {
     streams_stdout: bool,
     stdout_tx: Option<mpsc::UnboundedSender<Vec<u8>>>,
     exit_tx: oneshot::Sender<ProcessExitEvent>,
+    normal_operation: NormalOperationToken,
 }
 
 pub(crate) struct SpawnProcessOnSharedRequest<'a> {
@@ -143,7 +148,14 @@ pub(crate) struct ProcessOperationMap {
 struct ProcessOperationRegistrationGuard {
     shared: Arc<Shared>,
     seq: u32,
-    disarmed: bool,
+    state: ProcessOperationRegistrationState,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ProcessOperationRegistrationState {
+    RemoveOnDrop,
+    KeepOnDrop,
+    Disarmed,
 }
 
 impl ProcessOperationRegistrationGuard {
@@ -151,36 +163,70 @@ impl ProcessOperationRegistrationGuard {
         Self {
             shared,
             seq,
-            disarmed: false,
+            state: ProcessOperationRegistrationState::RemoveOnDrop,
         }
     }
 
+    fn keep_on_drop(&mut self) {
+        self.state = ProcessOperationRegistrationState::KeepOnDrop;
+    }
+
     fn disarm(&mut self) {
-        self.disarmed = true;
+        self.state = ProcessOperationRegistrationState::Disarmed;
     }
 }
 
 impl Drop for ProcessOperationRegistrationGuard {
     fn drop(&mut self) {
-        if !self.disarmed {
+        if self.state == ProcessOperationRegistrationState::RemoveOnDrop {
             remove_process_operation(&self.shared, self.seq);
+        }
+    }
+}
+
+struct ProcessOperationFrameWriteGuard {
+    shared: Arc<Shared>,
+    write_started: bool,
+    write_returned: bool,
+}
+
+impl ProcessOperationFrameWriteGuard {
+    fn new(shared: Arc<Shared>) -> Self {
+        Self {
+            shared,
+            write_started: false,
+            write_returned: false,
+        }
+    }
+
+    fn mark_started(&mut self) {
+        self.write_started = true;
+    }
+
+    fn mark_returned(&mut self) {
+        self.write_returned = true;
+    }
+}
+
+impl Drop for ProcessOperationFrameWriteGuard {
+    fn drop(&mut self) {
+        if self.write_started && !self.write_returned {
+            self.shared.poison_connection();
         }
     }
 }
 
 /// Handle for a spawn_process operation.
 ///
-/// Dropping the handle removes the host-side operation registration. It does
-/// not send a guest-side cancellation request; this matches the previous
-/// host-side wait timeout/drop behavior.
+/// Dropping the handle does not remove host-side process tracking or send a
+/// guest-side cancellation request. The connection remains busy until the guest
+/// reports a terminal process_exit frame or the connection closes.
 ///
 /// If stdout streaming is enabled, call [`take_stdout_receiver`](Self::take_stdout_receiver)
 /// before [`wait`](Self::wait). Waiting consumes the handle and drops any
 /// unclaimed stdout receiver so streamed output is not buffered without a
 /// reader.
 pub struct GuestProcessHandle {
-    shared: Arc<Shared>,
-    seq: Option<u32>,
     pid: u32,
     control: GuestProcessControlHandle,
     stdout_rx: Option<mpsc::UnboundedReceiver<Vec<u8>>>,
@@ -198,7 +244,7 @@ pub struct GuestProcessControlHandle {
 impl fmt::Debug for GuestProcessHandle {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("GuestProcessHandle")
-            .field("seq", &self.seq)
+            .field("seq", &self.control.target_seq)
             .field("pid", &self.pid)
             .field("has_stdout_receiver", &self.stdout_rx.is_some())
             .field("has_exit_receiver", &self.exit_rx.is_some())
@@ -244,7 +290,6 @@ impl GuestProcessHandle {
         let event = rx
             .await
             .map_err(|_| io::Error::new(io::ErrorKind::ConnectionReset, "connection closed"))?;
-        self.seq = None;
         Ok(event)
     }
 }
@@ -399,19 +444,59 @@ fn duration_to_request_timeout_ms(timeout: Duration) -> u32 {
         .max(1)
 }
 
-impl Drop for GuestProcessHandle {
-    fn drop(&mut self) {
-        if let Some(seq) = self.seq.take() {
-            remove_process_operation(&self.shared, seq);
-        }
-    }
-}
-
 fn remove_process_operation(shared: &Arc<Shared>, seq: u32) {
     let mut guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
     if let ConnectionState::Connected { process, .. } = &mut *guard {
         process.remove_operation(seq);
     }
+}
+
+fn mark_process_operation_possible_guest_write(shared: &Arc<Shared>, seq: u32) -> io::Result<()> {
+    let mut guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
+    match &mut *guard {
+        ConnectionState::Connected { process, .. } => {
+            let Some(operation) = process.operation_mut(seq) else {
+                return Err(io::Error::new(
+                    io::ErrorKind::ConnectionReset,
+                    "spawn_process operation closed before frame write",
+                ));
+            };
+            operation
+                .normal_operation
+                .mark_possible_guest_write_started()
+                .map_err(crate::normal_operation_transition_error)
+        }
+        ConnectionState::Closed { .. } => Err(io::Error::new(
+            io::ErrorKind::ConnectionReset,
+            "connection closed",
+        )),
+    }
+}
+
+pub(crate) fn record_spawn_process_error(shared: &Arc<Shared>, msg: &RawMessage) -> io::Result<()> {
+    let mut guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
+    let ConnectionState::Connected { process, .. } = &mut *guard else {
+        return Ok(());
+    };
+    let Some(operation) = process.operation_mut(msg.seq) else {
+        return Ok(());
+    };
+    if operation.pid.is_some() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "error response arrived after spawn_process_result",
+        ));
+    }
+    vsock_proto::decode_error(&msg.payload)
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
+    let Some(operation) = process.take_operation(msg.seq) else {
+        return Ok(());
+    };
+    operation
+        .normal_operation
+        .complete()
+        .map_err(crate::normal_operation_transition_error)?;
+    Ok(())
 }
 
 pub(crate) fn record_spawn_process_result(
@@ -432,12 +517,8 @@ pub(crate) fn record_spawn_process_result(
             ));
         }
 
-        let pid = match vsock_proto::decode_spawn_process_result(&msg.payload) {
-            Ok(pid) => pid,
-            // Initial malformed responses are still delivered to the pending
-            // request path, which returns InvalidData and drops the operation.
-            Err(_) => return Ok(()),
-        };
+        let pid = vsock_proto::decode_spawn_process_result(&msg.payload)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
         operation.pid = Some(pid);
     }
     Ok(())
@@ -479,7 +560,7 @@ pub(crate) fn dispatch_stdout_chunk(shared: &Arc<Shared>, msg: &RawMessage) -> i
 }
 
 pub(crate) fn dispatch_process_exit(shared: &Arc<Shared>, msg: &RawMessage) -> io::Result<()> {
-    let (operation, pid, exit_code, stdout, stderr) = {
+    let (exit_tx, pid, exit_code, stdout, stderr) = {
         let mut guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
         let ConnectionState::Connected { process, .. } = &mut *guard else {
             return Ok(());
@@ -494,7 +575,15 @@ pub(crate) fn dispatch_process_exit(shared: &Arc<Shared>, msg: &RawMessage) -> i
         let Some(operation) = process.take_operation(msg.seq) else {
             return Ok(());
         };
-        (operation, pid, exit_code, stdout, stderr)
+        let ProcessOperation {
+            exit_tx,
+            normal_operation,
+            ..
+        } = operation;
+        normal_operation
+            .complete()
+            .map_err(crate::normal_operation_transition_error)?;
+        (exit_tx, pid, exit_code, stdout, stderr)
     };
 
     let event = ProcessExitEvent {
@@ -504,7 +593,7 @@ pub(crate) fn dispatch_process_exit(shared: &Arc<Shared>, msg: &RawMessage) -> i
         stderr: stderr.to_vec(),
     };
 
-    let _ = operation.exit_tx.send(event);
+    let _ = exit_tx.send(event);
 
     Ok(())
 }
@@ -554,6 +643,10 @@ pub(crate) async fn spawn_process_on_shared(
     };
     let (exit_tx, exit_rx) = oneshot::channel();
     let seq = shared.next_seq();
+    let normal_operation = shared.reserve_normal_operation()?;
+    let (tx, rx) = oneshot::channel();
+    let data = vsock_proto::encode(MSG_SPAWN_PROCESS, seq, &payload)
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e.to_string()))?;
     {
         let mut guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
         match &mut *guard {
@@ -563,7 +656,9 @@ pub(crate) async fn spawn_process_on_shared(
                     "connection closed",
                 ));
             }
-            ConnectionState::Connected { process, .. } => {
+            ConnectionState::Connected {
+                pending, process, ..
+            } => {
                 process.insert_operation(
                     seq,
                     ProcessOperation {
@@ -571,43 +666,76 @@ pub(crate) async fn spawn_process_on_shared(
                         streams_stdout: stream_stdout,
                         stdout_tx,
                         exit_tx,
+                        normal_operation,
+                    },
+                );
+                pending.insert(
+                    seq,
+                    PendingResponse {
+                        response_tx: tx,
+                        normal_operation: None,
+                        normal_terminal_msg_types: &[],
                     },
                 );
             }
         }
     }
     let mut registration_guard = ProcessOperationRegistrationGuard::new(Arc::clone(shared), seq);
+    let _pending_guard = PendingRequestGuard::new(Arc::clone(shared), seq);
 
-    let resp = request_raw_on_shared(
-        shared,
-        MSG_SPAWN_PROCESS,
-        seq,
-        &payload,
-        Duration::from_secs(30),
-    )
-    .await?;
+    let resp = {
+        let mut write_guard = ProcessOperationFrameWriteGuard::new(Arc::clone(shared));
+        let mut writer = shared.writer.lock().await;
+        mark_process_operation_possible_guest_write(shared, seq)?;
+        write_guard.mark_started();
+        registration_guard.keep_on_drop();
+        if let Err(error) = writer.write_all(&data).await {
+            write_guard.mark_returned();
+            shared.poison_connection();
+            return Err(error);
+        }
+        write_guard.mark_returned();
+        drop(writer);
+        drop(write_guard);
+
+        tokio::select! {
+            biased;
+            result = rx => {
+                result.map_err(|_| io::Error::new(
+                    io::ErrorKind::ConnectionReset,
+                    "connection closed",
+                ))?
+            }
+            _ = tokio::time::sleep(Duration::from_secs(30)) => {
+                return Err(io::Error::new(io::ErrorKind::TimedOut, "request timeout"));
+            }
+        }
+    };
 
     if resp.msg_type == MSG_ERROR {
-        let msg = vsock_proto::decode_error(&resp.payload)
-            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
+        let msg = vsock_proto::decode_error(&resp.payload).map_err(|e| {
+            shared.poison_connection();
+            io::Error::new(io::ErrorKind::InvalidData, e.to_string())
+        })?;
         return Err(io::Error::other(msg));
     }
 
     if resp.msg_type != MSG_SPAWN_PROCESS_RESULT {
+        shared.poison_connection();
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,
             format!("unexpected response type: 0x{:02X}", resp.msg_type),
         ));
     }
 
-    let pid = vsock_proto::decode_spawn_process_result(&resp.payload)
-        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
+    let pid = vsock_proto::decode_spawn_process_result(&resp.payload).map_err(|e| {
+        shared.poison_connection();
+        io::Error::new(io::ErrorKind::InvalidData, e.to_string())
+    })?;
 
     registration_guard.disarm();
 
     Ok(GuestProcessHandle {
-        shared: Arc::clone(shared),
-        seq: Some(seq),
         pid,
         control: GuestProcessControlHandle {
             shared: Arc::clone(shared),

--- a/crates/vsock-host/src/tests/process.rs
+++ b/crates/vsock-host/src/tests/process.rs
@@ -1234,6 +1234,42 @@ async fn test_spawn_process_connection_closed_before_result_cleans_up() {
 }
 
 #[tokio::test]
+async fn test_spawn_process_response_timeout_cleans_registration() {
+    let (host_stream, mut guest) = make_pair();
+
+    tokio::spawn(async move {
+        let mut decoder = Decoder::new();
+        mock_handshake(&mut guest, &mut decoder).await;
+
+        let spawn = read_guest_message(&mut guest).await;
+        assert_eq!(spawn.msg_type, MSG_SPAWN_PROCESS);
+
+        let mut discard = [0u8; 1];
+        let _ = guest.read(&mut discard).await;
+    });
+
+    let host = host_from_stream(host_stream).await.unwrap();
+    let err = process_impl::test_support::spawn_process_with_response_timeout(
+        &host.shared,
+        "no-result",
+        true,
+        Duration::ZERO,
+    )
+    .await
+    .unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::TimedOut);
+    assert_eq!(
+        registration_counts(&host),
+        (0, 0, 0),
+        "spawn_process response timeout must clean pending process registrations",
+    );
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::NotParkable
+    );
+}
+
+#[tokio::test]
 async fn test_malformed_unsolicited_process_frames_are_ignored() {
     let (host_stream, mut guest) = make_pair();
 

--- a/crates/vsock-host/src/tests/process.rs
+++ b/crates/vsock-host/src/tests/process.rs
@@ -1133,7 +1133,7 @@ async fn test_unexpected_spawn_process_response_type_closes_and_cleans_up() {
         .spawn_process("unexpected-response", 0, &[], false, true, None)
         .await
         .unwrap_err();
-    assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    assert_eq!(err.kind(), io::ErrorKind::ConnectionReset);
     assert_eq!(
         registration_counts(&host),
         (0, 0, 0),

--- a/crates/vsock-host/src/tests/process.rs
+++ b/crates/vsock-host/src/tests/process.rs
@@ -1551,6 +1551,67 @@ async fn test_spawn_process_cancel_after_frame_keeps_tracker_busy_until_close() 
 }
 
 #[tokio::test]
+async fn test_unexpected_spawn_process_response_after_waiter_drop_closes_and_cleans_up() {
+    let (host_stream, mut guest) = make_pair();
+    let request_seen = Arc::new(Notify::new());
+    let release_guest = Arc::new(Notify::new());
+
+    {
+        let request_seen = Arc::clone(&request_seen);
+        let release_guest = Arc::clone(&release_guest);
+        tokio::spawn(async move {
+            let mut decoder = Decoder::new();
+            mock_handshake(&mut guest, &mut decoder).await;
+
+            let spawn = read_guest_message(&mut guest).await;
+            assert_eq!(spawn.msg_type, MSG_SPAWN_PROCESS);
+            request_seen.notify_one();
+
+            release_guest.notified().await;
+            let response = vsock_proto::encode(MSG_PROCESS_CONTROL_RESULT, spawn.seq, &[]).unwrap();
+            guest.write_all(&response).await.unwrap();
+
+            let mut discard = [0u8; 1];
+            let _ = guest.read(&mut discard).await;
+        });
+    }
+
+    let host = Arc::new(host_from_stream(host_stream).await.unwrap());
+    let task_host = Arc::clone(&host);
+    let task = tokio::spawn(async move {
+        task_host
+            .spawn_process("dropped-waiter", 0, &[], false, true, None)
+            .await
+    });
+
+    tokio::time::timeout(Duration::from_secs(5), request_seen.notified())
+        .await
+        .expect("guest should receive spawn_process request");
+
+    task.abort();
+    let _ = task.await;
+    assert_eq!(
+        registration_counts(&host),
+        (0, 1, 1),
+        "aborted spawn_process future after frame write must keep process tracking",
+    );
+
+    release_guest.notify_one();
+    host.wait_until_closed(Duration::from_secs(5))
+        .await
+        .expect("unexpected detached spawn response should close host");
+    assert_eq!(
+        registration_counts(&host),
+        (0, 0, 0),
+        "unexpected detached spawn response must clean process registrations",
+    );
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::NotParkable
+    );
+}
+
+#[tokio::test]
 async fn test_spawn_process_cancel_before_frame_write_cleans_registration() {
     let (host_stream, mut guest) = make_pair();
 

--- a/crates/vsock-host/src/tests/process.rs
+++ b/crates/vsock-host/src/tests/process.rs
@@ -1429,6 +1429,72 @@ async fn test_spawn_process_cancel_after_frame_keeps_tracker_busy_until_close() 
 }
 
 #[tokio::test]
+async fn test_spawn_process_cancel_before_frame_write_cleans_registration() {
+    let (host_stream, mut guest) = make_pair();
+
+    tokio::spawn(async move {
+        let mut decoder = Decoder::new();
+        mock_handshake(&mut guest, &mut decoder).await;
+
+        let spawn = read_guest_message(&mut guest).await;
+        assert_eq!(spawn.msg_type, MSG_SPAWN_PROCESS);
+        let payload = vsock_proto::encode_spawn_process_result(123);
+        let response = vsock_proto::encode(MSG_SPAWN_PROCESS_RESULT, spawn.seq, &payload).unwrap();
+        guest.write_all(&response).await.unwrap();
+
+        let exit_payload = vsock_proto::encode_process_exit(123, 0, b"", b"");
+        let exit = vsock_proto::encode(MSG_PROCESS_EXIT, spawn.seq, &exit_payload).unwrap();
+        guest.write_all(&exit).await.unwrap();
+
+        let mut discard = [0u8; 1];
+        let _ = guest.read(&mut discard).await;
+    });
+
+    let host = Arc::new(host_from_stream(host_stream).await.unwrap());
+    let writer_guard = host.shared.writer.lock().await;
+    let spawn_task = {
+        let host = Arc::clone(&host);
+        tokio::spawn(async move {
+            host.spawn_process("cancel-before-write", 0, &[], false, true, None)
+                .await
+        })
+    };
+
+    tokio::time::timeout(Duration::from_secs(5), async {
+        while registration_counts(&host) == (0, 0, 0) {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("spawn_process should register before waiting for writer lock");
+    assert_eq!(registration_counts(&host), (1, 1, 1));
+
+    spawn_task.abort();
+    let _ = spawn_task.await;
+    assert_eq!(
+        registration_counts(&host),
+        (0, 0, 0),
+        "spawn_process cancelled before frame write must clean pending registrations",
+    );
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Idle
+    );
+
+    drop(writer_guard);
+    let handle = host
+        .spawn_process("next-spawn", 0, &[], false, false, None)
+        .await
+        .unwrap();
+    let event = wait_spawn(handle).await.unwrap();
+    assert_eq!(event.pid, 123);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Idle
+    );
+}
+
+#[tokio::test]
 async fn test_spawn_process_frame_write_guard_started_drop_poisons_connection() {
     let (host_stream, mut guest) = make_pair();
 

--- a/crates/vsock-host/src/tests/process.rs
+++ b/crates/vsock-host/src/tests/process.rs
@@ -1355,6 +1355,8 @@ async fn test_dropped_stdout_receiver_removes_stream_sender() {
             let msgs = decoder.decode(&buf[..n]).unwrap();
             assert_eq!(msgs[0].msg_type, MSG_SPAWN_PROCESS);
             let spawn_seq = msgs[0].seq;
+            let decoded_spawn = vsock_proto::decode_spawn_process(&msgs[0].payload).unwrap();
+            let control_nonce = decoded_spawn.control_nonce.unwrap();
 
             let payload = vsock_proto::encode_spawn_process_result(555);
             let resp = vsock_proto::encode(MSG_SPAWN_PROCESS_RESULT, spawn_seq, &payload).unwrap();
@@ -1364,6 +1366,23 @@ async fn test_dropped_stdout_receiver_removes_stream_sender() {
             let chunk_payload = vsock_proto::encode_stdout_chunk(555, b"orphaned chunk");
             let chunk = vsock_proto::encode(MSG_STDOUT_CHUNK, spawn_seq, &chunk_payload).unwrap();
             guest.write_all(&chunk).await.unwrap();
+
+            let control = read_guest_message(&mut guest).await;
+            assert_eq!(control.msg_type, MSG_PROCESS_CONTROL);
+            let decoded_control = vsock_proto::decode_process_control(&control.payload).unwrap();
+            assert_eq!(decoded_control.target_seq, spawn_seq);
+            assert_eq!(decoded_control.control_nonce, control_nonce);
+            assert_eq!(decoded_control.message_id, "after-orphaned-chunk");
+            send_process_control_result(
+                &mut guest,
+                control.seq,
+                decoded_control.target_seq,
+                decoded_control.control_nonce,
+                decoded_control.message_id,
+                ProcessControlStatus::Delivered,
+                "",
+            )
+            .await;
 
             send_exit.notified().await;
             let exit_payload = vsock_proto::encode_process_exit(555, 0, b"", b"");
@@ -1390,16 +1409,15 @@ async fn test_dropped_stdout_receiver_removes_stream_sender() {
     drop(handle.take_stdout_receiver());
     send_chunk.notify_one();
 
-    tokio::time::timeout(Duration::from_secs(5), async {
-        loop {
-            if registration_counts(&host) == (0, 1, 0) {
-                break;
-            }
-            tokio::task::yield_now().await;
-        }
-    })
-    .await
-    .expect("dropped stdout receiver should remove stream sender");
+    handle
+        .control("after-orphaned-chunk", b"", Duration::from_secs(5))
+        .await
+        .expect("control response after stdout chunk should succeed");
+    assert_eq!(
+        registration_counts(&host),
+        (0, 1, 0),
+        "dropped stdout receiver should remove stream sender",
+    );
 
     send_exit.notify_one();
     let event = wait_spawn(handle).await.unwrap();

--- a/crates/vsock-host/src/tests/process.rs
+++ b/crates/vsock-host/src/tests/process.rs
@@ -1462,23 +1462,17 @@ async fn test_wait_drops_unclaimed_stdout_receiver() {
 
     let wait = handle.wait();
     tokio::pin!(wait);
-    tokio::select! {
-        biased;
-        result = &mut wait => panic!("spawn wait completed before exit: {result:?}"),
-        _ = tokio::task::yield_now() => {}
-    }
+    assert!(
+        matches!(poll_once(wait.as_mut()), Poll::Pending),
+        "spawn wait should remain pending before exit",
+    );
+    assert_eq!(
+        registration_counts(&host),
+        (0, 1, 0),
+        "wait should clear unclaimed stdout sender before waiting for exit",
+    );
 
     send_chunk.notify_one();
-    tokio::time::timeout(Duration::from_secs(5), async {
-        loop {
-            if registration_counts(&host) == (0, 1, 0) {
-                break;
-            }
-            tokio::task::yield_now().await;
-        }
-    })
-    .await
-    .expect("wait should drop unclaimed stdout receiver before buffering chunks");
 
     send_exit.notify_one();
     let event = tokio::time::timeout(Duration::from_secs(5), &mut wait)

--- a/crates/vsock-host/src/tests/process.rs
+++ b/crates/vsock-host/src/tests/process.rs
@@ -1038,6 +1038,41 @@ async fn test_spawn_process_error_response_cleans_up() {
 }
 
 #[tokio::test]
+async fn test_malformed_spawn_process_error_response_closes_and_cleans_up() {
+    let (host_stream, mut guest) = make_pair();
+
+    tokio::spawn(async move {
+        let mut decoder = Decoder::new();
+        mock_handshake(&mut guest, &mut decoder).await;
+
+        let spawn = read_guest_message(&mut guest).await;
+        assert_eq!(spawn.msg_type, MSG_SPAWN_PROCESS);
+        let err_resp = vsock_proto::encode(MSG_ERROR, spawn.seq, b"\x00").unwrap();
+        guest.write_all(&err_resp).await.unwrap();
+
+        let mut discard = [0u8; 1];
+        let _ = guest.read(&mut discard).await;
+    });
+
+    let host = host_from_stream(host_stream).await.unwrap();
+
+    let err = host
+        .spawn_process("malformed-error", 0, &[], false, true, None)
+        .await
+        .unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::ConnectionReset);
+    assert_eq!(
+        registration_counts(&host),
+        (0, 0, 0),
+        "malformed spawn_process error must clean operation registration",
+    );
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::NotParkable
+    );
+}
+
+#[tokio::test]
 async fn test_spawn_process_malformed_result_cleans_up() {
     let (host_stream, mut guest) = make_pair();
 
@@ -1068,6 +1103,84 @@ async fn test_spawn_process_malformed_result_cleans_up() {
         registration_counts(&host),
         (0, 0, 0),
         "malformed streaming spawn_process result must clean operation registration",
+    );
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::NotParkable
+    );
+}
+
+#[tokio::test]
+async fn test_unexpected_spawn_process_response_type_closes_and_cleans_up() {
+    let (host_stream, mut guest) = make_pair();
+
+    tokio::spawn(async move {
+        let mut decoder = Decoder::new();
+        mock_handshake(&mut guest, &mut decoder).await;
+
+        let spawn = read_guest_message(&mut guest).await;
+        assert_eq!(spawn.msg_type, MSG_SPAWN_PROCESS);
+        let response = vsock_proto::encode(MSG_PROCESS_CONTROL_RESULT, spawn.seq, &[]).unwrap();
+        guest.write_all(&response).await.unwrap();
+
+        let mut discard = [0u8; 1];
+        let _ = guest.read(&mut discard).await;
+    });
+
+    let host = host_from_stream(host_stream).await.unwrap();
+
+    let err = host
+        .spawn_process("unexpected-response", 0, &[], false, true, None)
+        .await
+        .unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    assert_eq!(
+        registration_counts(&host),
+        (0, 0, 0),
+        "unexpected spawn_process response must clean operation registration",
+    );
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::NotParkable
+    );
+}
+
+#[tokio::test]
+async fn test_error_after_spawn_process_result_closes_and_cleans_up() {
+    let (host_stream, mut guest) = make_pair();
+
+    tokio::spawn(async move {
+        let mut decoder = Decoder::new();
+        mock_handshake(&mut guest, &mut decoder).await;
+
+        let spawn = read_guest_message(&mut guest).await;
+        assert_eq!(spawn.msg_type, MSG_SPAWN_PROCESS);
+        let result_payload = vsock_proto::encode_spawn_process_result(123);
+        let result =
+            vsock_proto::encode(MSG_SPAWN_PROCESS_RESULT, spawn.seq, &result_payload).unwrap();
+        guest.write_all(&result).await.unwrap();
+
+        let err_payload = vsock_proto::encode_error("late process error");
+        let err_resp = vsock_proto::encode(MSG_ERROR, spawn.seq, &err_payload).unwrap();
+        guest.write_all(&err_resp).await.unwrap();
+
+        let mut discard = [0u8; 1];
+        let _ = guest.read(&mut discard).await;
+    });
+
+    let host = host_from_stream(host_stream).await.unwrap();
+    let handle = host
+        .spawn_process("late-error", 0, &[], false, false, None)
+        .await
+        .unwrap();
+    assert_eq!(handle.pid(), 123);
+
+    let err = wait_spawn(handle).await.unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::ConnectionReset);
+    assert_eq!(
+        registration_counts(&host),
+        (0, 0, 0),
+        "late spawn_process error must close and clean registrations",
     );
     assert_eq!(
         normal_operation_readiness(&host),

--- a/crates/vsock-host/src/tests/process.rs
+++ b/crates/vsock-host/src/tests/process.rs
@@ -1270,6 +1270,79 @@ async fn test_spawn_process_response_timeout_cleans_registration() {
 }
 
 #[tokio::test]
+async fn test_late_spawn_process_frames_after_response_timeout_are_ignored() {
+    let (host_stream, mut guest) = make_pair();
+    let (spawn_seq_tx, spawn_seq_rx) = oneshot::channel();
+    let release_guest = Arc::new(Notify::new());
+
+    {
+        let release_guest = Arc::clone(&release_guest);
+        tokio::spawn(async move {
+            let mut decoder = Decoder::new();
+            mock_handshake(&mut guest, &mut decoder).await;
+
+            let spawn = read_guest_message(&mut guest).await;
+            assert_eq!(spawn.msg_type, MSG_SPAWN_PROCESS);
+            spawn_seq_tx.send(spawn.seq).unwrap();
+
+            release_guest.notified().await;
+            let result_payload = vsock_proto::encode_spawn_process_result(123);
+            let result =
+                vsock_proto::encode(MSG_SPAWN_PROCESS_RESULT, spawn.seq, &result_payload).unwrap();
+            let chunk_payload = vsock_proto::encode_stdout_chunk(123, b"late output");
+            let chunk = vsock_proto::encode(MSG_STDOUT_CHUNK, spawn.seq, &chunk_payload).unwrap();
+            let exit_payload = vsock_proto::encode_process_exit(123, 0, b"", b"");
+            let exit = vsock_proto::encode(MSG_PROCESS_EXIT, spawn.seq, &exit_payload).unwrap();
+
+            let mut frames = result;
+            frames.extend_from_slice(&chunk);
+            frames.extend_from_slice(&exit);
+            guest.write_all(&frames).await.unwrap();
+        });
+    }
+
+    let host = host_from_stream(host_stream).await.unwrap();
+    let err = process_impl::test_support::spawn_process_with_response_timeout(
+        &host.shared,
+        "late-result-after-timeout",
+        true,
+        Duration::ZERO,
+    )
+    .await
+    .unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::TimedOut);
+    assert_eq!(
+        registration_counts(&host),
+        (0, 0, 0),
+        "spawn_process response timeout must remove pending process registrations",
+    );
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::NotParkable
+    );
+
+    let spawn_seq = tokio::time::timeout(Duration::from_secs(5), spawn_seq_rx)
+        .await
+        .expect("guest should receive spawn_process request")
+        .unwrap();
+    assert_ne!(spawn_seq, 0);
+
+    release_guest.notify_one();
+    host.wait_until_closed(Duration::from_secs(5))
+        .await
+        .expect("guest close should close host");
+    assert_eq!(
+        registration_counts(&host),
+        (0, 0, 0),
+        "late process frames after timeout must not recreate registrations",
+    );
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::NotParkable
+    );
+}
+
+#[tokio::test]
 async fn test_malformed_unsolicited_process_frames_are_ignored() {
     let (host_stream, mut guest) = make_pair();
 

--- a/crates/vsock-host/src/tests/process.rs
+++ b/crates/vsock-host/src/tests/process.rs
@@ -1526,8 +1526,8 @@ async fn test_spawn_process_cancel_after_frame_keeps_tracker_busy_until_close() 
     let _ = task.await;
     assert_eq!(
         registration_counts(&host),
-        (0, 1, 1),
-        "aborted spawn_process future after frame write must keep process tracking",
+        (0, 1, 0),
+        "aborted spawn_process future after frame write must keep process tracking without orphaning stdout sender",
     );
     assert_eq!(
         normal_operation_readiness(&host),
@@ -1586,8 +1586,8 @@ async fn test_unexpected_spawn_process_response_after_waiter_drop_closes_and_cle
     let _ = task.await;
     assert_eq!(
         registration_counts(&host),
-        (0, 1, 1),
-        "aborted spawn_process future after frame write must keep process tracking",
+        (0, 1, 0),
+        "aborted spawn_process future after frame write must keep process tracking without orphaning stdout sender",
     );
 
     release_guest.notify_one();
@@ -1602,6 +1602,78 @@ async fn test_unexpected_spawn_process_response_after_waiter_drop_closes_and_cle
     assert_eq!(
         normal_operation_readiness(&host),
         NormalOperationReadiness::NotParkable
+    );
+}
+
+#[tokio::test]
+async fn test_spawn_process_result_after_waiter_drop_tracks_until_exit() {
+    let (host_stream, mut guest) = make_pair();
+    let request_seen = Arc::new(Notify::new());
+    let release_guest = Arc::new(Notify::new());
+
+    {
+        let request_seen = Arc::clone(&request_seen);
+        let release_guest = Arc::clone(&release_guest);
+        tokio::spawn(async move {
+            let mut decoder = Decoder::new();
+            mock_handshake(&mut guest, &mut decoder).await;
+
+            let spawn = read_guest_message(&mut guest).await;
+            assert_eq!(spawn.msg_type, MSG_SPAWN_PROCESS);
+            request_seen.notify_one();
+
+            release_guest.notified().await;
+            let result_payload = vsock_proto::encode_spawn_process_result(124);
+            let result =
+                vsock_proto::encode(MSG_SPAWN_PROCESS_RESULT, spawn.seq, &result_payload).unwrap();
+            guest.write_all(&result).await.unwrap();
+
+            let chunk_payload = vsock_proto::encode_stdout_chunk(124, b"detached output");
+            let chunk = vsock_proto::encode(MSG_STDOUT_CHUNK, spawn.seq, &chunk_payload).unwrap();
+            guest.write_all(&chunk).await.unwrap();
+
+            let exit_payload = vsock_proto::encode_process_exit(124, 0, b"", b"");
+            let exit = vsock_proto::encode(MSG_PROCESS_EXIT, spawn.seq, &exit_payload).unwrap();
+            guest.write_all(&exit).await.unwrap();
+        });
+    }
+
+    let host = Arc::new(host_from_stream(host_stream).await.unwrap());
+    let task_host = Arc::clone(&host);
+    let task = tokio::spawn(async move {
+        task_host
+            .spawn_process("dropped-waiter-valid-result", 0, &[], false, true, None)
+            .await
+    });
+
+    tokio::time::timeout(Duration::from_secs(5), request_seen.notified())
+        .await
+        .expect("guest should receive spawn_process request");
+
+    task.abort();
+    let _ = task.await;
+    assert_eq!(
+        registration_counts(&host),
+        (0, 1, 0),
+        "aborted spawn_process future must keep process tracking without orphaning stdout sender",
+    );
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Busy
+    );
+
+    release_guest.notify_one();
+    host.wait_until_closed(Duration::from_secs(5))
+        .await
+        .expect("valid detached lifecycle frames should drain before close");
+    assert_eq!(
+        registration_counts(&host),
+        (0, 0, 0),
+        "detached spawn_process exit must clean process registration",
+    );
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Closed
     );
 }
 
@@ -1723,7 +1795,7 @@ async fn test_late_malformed_lifecycle_after_handle_drop_poisons_tracker() {
         .unwrap();
     assert_eq!(handle.pid(), 66);
     drop(handle);
-    assert_eq!(registration_counts(&host), (0, 1, 1));
+    assert_eq!(registration_counts(&host), (0, 1, 0));
     assert_eq!(
         normal_operation_readiness(&host),
         NormalOperationReadiness::Busy

--- a/crates/vsock-host/src/tests/process.rs
+++ b/crates/vsock-host/src/tests/process.rs
@@ -8,6 +8,7 @@ use super::support::{
 };
 use crate::{
     ConnectionState, GuestProcessHandle, VsockHost, operation_tracker::NormalOperationReadiness,
+    process as process_impl,
 };
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::sync::{Notify, oneshot};
@@ -1421,6 +1422,30 @@ async fn test_spawn_process_cancel_after_frame_keeps_tracker_busy_until_close() 
     host.wait_until_closed(Duration::from_secs(5))
         .await
         .expect("guest close should close host");
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::NotParkable
+    );
+}
+
+#[tokio::test]
+async fn test_spawn_process_frame_write_guard_started_drop_poisons_connection() {
+    let (host_stream, mut guest) = make_pair();
+
+    tokio::spawn(async move {
+        let mut decoder = Decoder::new();
+        mock_handshake(&mut guest, &mut decoder).await;
+        let mut discard = [0u8; 1];
+        let _ = guest.read(&mut discard).await;
+    });
+
+    let host = host_from_stream(host_stream).await.unwrap();
+
+    process_impl::test_support::drop_started_frame_write_guard(Arc::clone(&host.shared));
+
+    host.wait_until_closed(Duration::from_secs(5))
+        .await
+        .unwrap();
     assert_eq!(
         normal_operation_readiness(&host),
         NormalOperationReadiness::NotParkable

--- a/crates/vsock-host/src/tests/process.rs
+++ b/crates/vsock-host/src/tests/process.rs
@@ -3,10 +3,12 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use super::support::{
-    host_from_stream, make_pair, mock_handshake, read_guest_message, read_guest_messages,
-    send_exec_result,
+    host_from_stream, make_pair, mock_handshake, normal_operation_readiness, read_guest_message,
+    read_guest_messages, send_exec_result,
 };
-use crate::{ConnectionState, GuestProcessHandle, VsockHost};
+use crate::{
+    ConnectionState, GuestProcessHandle, VsockHost, operation_tracker::NormalOperationReadiness,
+};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::sync::{Notify, oneshot};
 use vsock_proto::{
@@ -104,6 +106,10 @@ async fn test_spawn_process_and_wait() {
     assert_eq!(event.pid, 42);
     assert_eq!(event.exit_code, 0);
     assert_eq!(event.stdout, b"done");
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Idle
+    );
 }
 
 #[tokio::test]
@@ -305,7 +311,11 @@ async fn test_spawn_process_with_control_sink_sets_control_sink_flag() {
         .unwrap();
     assert_eq!(handle.pid(), 43);
     drop(handle);
-    assert_eq!(registration_counts(&host), (0, 0, 0));
+    assert_eq!(registration_counts(&host), (0, 1, 0));
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Busy
+    );
 }
 
 #[tokio::test]
@@ -582,6 +592,10 @@ async fn test_spawn_process_control_sink_statuses_use_default_error_mapping() {
             .await;
         }
 
+        let exit_payload = vsock_proto::encode_process_exit(50, 0, b"", b"");
+        let exit_msg = vsock_proto::encode(MSG_PROCESS_EXIT, spawn.seq, &exit_payload).unwrap();
+        guest.write_all(&exit_msg).await.unwrap();
+
         let mut discard = [0u8; 1];
         let _ = guest.read(&mut discard).await;
     });
@@ -627,8 +641,12 @@ async fn test_spawn_process_control_sink_statuses_use_default_error_mapping() {
         assert_eq!(err.to_string(), message);
     }
 
-    drop(handle);
-    assert_eq!(registration_counts(&host), (0, 0, 0));
+    let event = wait_spawn(handle).await.unwrap();
+    assert_eq!(event.exit_code, 0);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Idle
+    );
 }
 
 #[tokio::test]
@@ -829,6 +847,9 @@ async fn test_spawn_process_control_timeout_cleans_pending_without_poisoning() {
             b"",
         )
         .await;
+        let exit_payload = vsock_proto::encode_process_exit(45, 0, b"", b"");
+        let exit_msg = vsock_proto::encode(MSG_PROCESS_EXIT, spawn.seq, &exit_payload).unwrap();
+        guest.write_all(&exit_msg).await.unwrap();
 
         let mut discard = [0u8; 1];
         let _ = guest.read(&mut discard).await;
@@ -848,8 +869,12 @@ async fn test_spawn_process_control_timeout_cleans_pending_without_poisoning() {
 
     let exec_result = host.exec("echo ok", 5000, &[], false).await.unwrap();
     assert_eq!(exec_result.stdout, b"ok");
-    drop(handle);
-    assert_eq!(registration_counts(&host), (0, 0, 0));
+    let event = wait_spawn(handle).await.unwrap();
+    assert_eq!(event.exit_code, 0);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Idle
+    );
 }
 
 #[tokio::test]
@@ -876,6 +901,9 @@ async fn test_spawn_process_control_rejects_payload_over_local_ipc_limit_before_
             b"",
         )
         .await;
+        let exit_payload = vsock_proto::encode_process_exit(51, 0, b"", b"");
+        let exit_msg = vsock_proto::encode(MSG_PROCESS_EXIT, spawn.seq, &exit_payload).unwrap();
+        guest.write_all(&exit_msg).await.unwrap();
 
         let mut discard = [0u8; 1];
         let _ = guest.read(&mut discard).await;
@@ -900,8 +928,12 @@ async fn test_spawn_process_control_rejects_payload_over_local_ipc_limit_before_
 
     let exec_result = host.exec("echo ok", 5000, &[], false).await.unwrap();
     assert_eq!(exec_result.stdout, b"ok");
-    drop(handle);
-    assert_eq!(registration_counts(&host), (0, 0, 0));
+    let event = wait_spawn(handle).await.unwrap();
+    assert_eq!(event.exit_code, 0);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Idle
+    );
 }
 
 #[tokio::test]
@@ -983,6 +1015,10 @@ async fn test_spawn_process_error_response_cleans_up() {
         (0, 0, 0),
         "streaming spawn_process error must clean operation registration",
     );
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Idle
+    );
 
     let handle = host
         .spawn_process("good-cmd", 0, &[], false, false, None)
@@ -1007,13 +1043,6 @@ async fn test_spawn_process_malformed_result_cleans_up() {
             vsock_proto::encode(MSG_SPAWN_PROCESS_RESULT, msgs[0].seq, bad_payload).unwrap();
         guest.write_all(&bad_resp).await.unwrap();
 
-        let n = guest.read(&mut buf).await.unwrap();
-        let msgs = decoder.decode(&buf[..n]).unwrap();
-        let ok_payload = vsock_proto::encode_spawn_process_result(333);
-        let ok_resp =
-            vsock_proto::encode(MSG_SPAWN_PROCESS_RESULT, msgs[0].seq, &ok_payload).unwrap();
-        guest.write_all(&ok_resp).await.unwrap();
-
         let mut discard = [0u8; 1];
         let _ = guest.read(&mut discard).await;
     });
@@ -1024,18 +1053,16 @@ async fn test_spawn_process_malformed_result_cleans_up() {
         .spawn_process("bad-payload-cmd", 0, &[], false, true, None)
         .await
         .unwrap_err();
-    assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    assert_eq!(err.kind(), io::ErrorKind::ConnectionReset);
     assert_eq!(
         registration_counts(&host),
         (0, 0, 0),
         "malformed streaming spawn_process result must clean operation registration",
     );
-
-    let handle = host
-        .spawn_process("good-cmd", 0, &[], false, false, None)
-        .await
-        .unwrap();
-    assert_eq!(handle.pid(), 333);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::NotParkable
+    );
 }
 
 #[tokio::test]
@@ -1076,6 +1103,10 @@ async fn test_spawn_process_connection_closed_before_result_cleans_up() {
         registration_counts(&host),
         (0, 0, 0),
         "connection close while spawn_process is pending must clean registrations",
+    );
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::NotParkable
     );
 }
 
@@ -1228,6 +1259,10 @@ async fn test_dropped_stdout_receiver_removes_stream_sender() {
         .unwrap();
     assert_eq!(handle.pid(), 555);
     assert_eq!(registration_counts(&host), (0, 1, 1));
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Busy
+    );
 
     drop(handle.take_stdout_receiver());
     send_chunk.notify_one();
@@ -1246,6 +1281,10 @@ async fn test_dropped_stdout_receiver_removes_stream_sender() {
     send_exit.notify_one();
     let event = wait_spawn(handle).await.unwrap();
     assert_eq!(event.exit_code, 0);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Idle
+    );
 }
 
 #[tokio::test]
@@ -1293,6 +1332,10 @@ async fn test_wait_drops_unclaimed_stdout_receiver() {
         .unwrap();
     assert_eq!(handle.pid(), 556);
     assert_eq!(registration_counts(&host), (0, 1, 1));
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Busy
+    );
 
     let wait = handle.wait();
     tokio::pin!(wait);
@@ -1320,10 +1363,14 @@ async fn test_wait_drops_unclaimed_stdout_receiver() {
         .expect("spawn wait should complete")
         .unwrap();
     assert_eq!(event.exit_code, 0);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Idle
+    );
 }
 
 #[tokio::test]
-async fn test_spawn_process_cancel_cleans_up_registrations() {
+async fn test_spawn_process_cancel_after_frame_keeps_tracker_busy_until_close() {
     let (host_stream, mut guest) = make_pair();
     let request_seen = Arc::new(Notify::new());
     let release_guest = Arc::new(Notify::new());
@@ -1362,15 +1409,26 @@ async fn test_spawn_process_cancel_cleans_up_registrations() {
     let _ = task.await;
     assert_eq!(
         registration_counts(&host),
-        (0, 0, 0),
-        "aborted spawn_process future must clean pending registrations",
+        (0, 1, 1),
+        "aborted spawn_process future after frame write must keep process tracking",
+    );
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Busy
     );
 
     release_guest.notify_one();
+    host.wait_until_closed(Duration::from_secs(5))
+        .await
+        .expect("guest close should close host");
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::NotParkable
+    );
 }
 
 #[tokio::test]
-async fn test_late_malformed_lifecycle_after_handle_drop_is_ignored() {
+async fn test_late_malformed_lifecycle_after_handle_drop_poisons_tracker() {
     let (host_stream, mut guest) = make_pair();
     let release_late_frames = Arc::new(Notify::new());
 
@@ -1396,17 +1454,6 @@ async fn test_late_malformed_lifecycle_after_handle_drop_is_ignored() {
             guest.write_all(&bad_stdout).await.unwrap();
             guest.write_all(&bad_exit).await.unwrap();
 
-            let n = guest.read(&mut buf).await.unwrap();
-            let msgs = decoder.decode(&buf[..n]).unwrap();
-            assert_eq!(msgs[0].msg_type, MSG_SPAWN_PROCESS);
-            let next_seq = msgs[0].seq;
-            let payload = vsock_proto::encode_spawn_process_result(67);
-            let resp = vsock_proto::encode(MSG_SPAWN_PROCESS_RESULT, next_seq, &payload).unwrap();
-            guest.write_all(&resp).await.unwrap();
-            let exit_payload = vsock_proto::encode_process_exit(67, 0, b"still-alive", b"");
-            let exit_msg = vsock_proto::encode(MSG_PROCESS_EXIT, next_seq, &exit_payload).unwrap();
-            guest.write_all(&exit_msg).await.unwrap();
-
             let mut discard = [0u8; 1];
             let _ = guest.read(&mut discard).await;
         });
@@ -1419,17 +1466,20 @@ async fn test_late_malformed_lifecycle_after_handle_drop_is_ignored() {
         .unwrap();
     assert_eq!(handle.pid(), 66);
     drop(handle);
-    assert_eq!(registration_counts(&host), (0, 0, 0));
+    assert_eq!(registration_counts(&host), (0, 1, 1));
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Busy
+    );
 
     release_late_frames.notify_one();
-
-    let next = host
-        .spawn_process("next-spawn", 0, &[], false, false, None)
+    host.wait_until_closed(Duration::from_secs(5))
         .await
-        .unwrap();
-    let event = wait_spawn(next).await.unwrap();
-    assert_eq!(event.pid, 67);
-    assert_eq!(event.stdout, b"still-alive");
+        .expect("malformed detached lifecycle frame should close host");
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::NotParkable
+    );
 }
 
 #[tokio::test]
@@ -1626,6 +1676,10 @@ async fn test_malformed_active_process_exit_closes_and_cleans_up() {
         (0, 0, 0),
         "malformed active process_exit must close and clean registrations",
     );
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::NotParkable
+    );
 }
 
 #[tokio::test]
@@ -1668,6 +1722,10 @@ async fn test_mismatched_active_process_exit_pid_closes_and_cleans_up() {
         registration_counts(&host),
         (0, 0, 0),
         "mismatched active process_exit pid must close and clean registrations",
+    );
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::NotParkable
     );
 }
 
@@ -1714,6 +1772,10 @@ async fn assert_bad_active_stdout_chunk_closes_and_cleans_up(payload: Vec<u8>) {
         registration_counts(&host),
         (0, 0, 0),
         "bad active stdout_chunk must close and clean registrations",
+    );
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::NotParkable
     );
 }
 
@@ -1772,6 +1834,10 @@ async fn test_buffered_active_stdout_chunk_closes_and_cleans_up() {
         (0, 0, 0),
         "stdout_chunk for buffered spawn_process must close and clean registrations",
     );
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::NotParkable
+    );
 }
 
 #[tokio::test]
@@ -1816,6 +1882,10 @@ async fn test_duplicate_spawn_process_result_cannot_overwrite_pid() {
         (0, 0, 0),
         "duplicate spawn_process_result must not overwrite recorded pid",
     );
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::NotParkable
+    );
 }
 
 #[tokio::test]
@@ -1858,6 +1928,10 @@ async fn test_duplicate_spawn_process_result_same_pid_closes_and_cleans_up() {
         registration_counts(&host),
         (0, 0, 0),
         "duplicate same-pid spawn_process_result must close and clean registrations",
+    );
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::NotParkable
     );
 }
 
@@ -1902,26 +1976,40 @@ async fn test_malformed_duplicate_spawn_process_result_closes_and_cleans_up() {
         (0, 0, 0),
         "malformed duplicate spawn_process_result must close and clean registrations",
     );
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::NotParkable
+    );
 }
 
 #[tokio::test]
-async fn test_spawn_process_wait_future_drop_cleans_registration() {
+async fn test_spawn_process_wait_future_drop_keeps_tracker_busy_until_exit() {
     let (host_stream, mut guest) = make_pair();
+    let send_exit = Arc::new(Notify::new());
 
-    tokio::spawn(async move {
-        let mut decoder = Decoder::new();
-        mock_handshake(&mut guest, &mut decoder).await;
+    {
+        let send_exit = Arc::clone(&send_exit);
+        tokio::spawn(async move {
+            let mut decoder = Decoder::new();
+            mock_handshake(&mut guest, &mut decoder).await;
 
-        let mut buf = [0u8; 4096];
-        let n = guest.read(&mut buf).await.unwrap();
-        let msgs = decoder.decode(&buf[..n]).unwrap();
-        let payload = vsock_proto::encode_spawn_process_result(55);
-        let resp = vsock_proto::encode(MSG_SPAWN_PROCESS_RESULT, msgs[0].seq, &payload).unwrap();
-        guest.write_all(&resp).await.unwrap();
+            let mut buf = [0u8; 4096];
+            let n = guest.read(&mut buf).await.unwrap();
+            let msgs = decoder.decode(&buf[..n]).unwrap();
+            let spawn_seq = msgs[0].seq;
+            let payload = vsock_proto::encode_spawn_process_result(55);
+            let resp = vsock_proto::encode(MSG_SPAWN_PROCESS_RESULT, spawn_seq, &payload).unwrap();
+            guest.write_all(&resp).await.unwrap();
 
-        let mut discard = [0u8; 1];
-        let _ = guest.read(&mut discard).await;
-    });
+            send_exit.notified().await;
+            let exit_payload = vsock_proto::encode_process_exit(55, 0, b"", b"");
+            let exit_msg = vsock_proto::encode(MSG_PROCESS_EXIT, spawn_seq, &exit_payload).unwrap();
+            guest.write_all(&exit_msg).await.unwrap();
+
+            let mut discard = [0u8; 1];
+            let _ = guest.read(&mut discard).await;
+        });
+    }
 
     let host = host_from_stream(host_stream).await.unwrap();
     let handle = host
@@ -1932,7 +2020,23 @@ async fn test_spawn_process_wait_future_drop_cleans_registration() {
 
     let wait = handle.wait();
     drop(wait);
-    assert_eq!(registration_counts(&host), (0, 0, 0));
+    assert_eq!(registration_counts(&host), (0, 1, 0));
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Busy
+    );
+
+    send_exit.notify_one();
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            if normal_operation_readiness(&host) == NormalOperationReadiness::Idle {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("detached process exit should release tracker");
 }
 
 #[tokio::test]
@@ -2006,6 +2110,81 @@ async fn test_concurrent_spawn_process_routes_by_seq_not_pid() {
     assert_eq!(second_exit.stderr, b"second err");
     assert_eq!(first_exit.exit_code, 11);
     assert_eq!(first_exit.stderr, b"first err");
+}
+
+#[tokio::test]
+async fn test_concurrent_same_pid_processes_keep_independent_tracker_tokens() {
+    let (host_stream, mut guest) = make_pair();
+    let send_first_exit = Arc::new(Notify::new());
+    let send_second_exit = Arc::new(Notify::new());
+
+    {
+        let send_first_exit = Arc::clone(&send_first_exit);
+        let send_second_exit = Arc::clone(&send_second_exit);
+        tokio::spawn(async move {
+            let mut decoder = Decoder::new();
+            mock_handshake(&mut guest, &mut decoder).await;
+
+            let first = read_guest_message(&mut guest).await;
+            assert_eq!(first.msg_type, MSG_SPAWN_PROCESS);
+            let payload = vsock_proto::encode_spawn_process_result(999);
+            let response =
+                vsock_proto::encode(MSG_SPAWN_PROCESS_RESULT, first.seq, &payload).unwrap();
+            guest.write_all(&response).await.unwrap();
+
+            let second = read_guest_message(&mut guest).await;
+            assert_eq!(second.msg_type, MSG_SPAWN_PROCESS);
+            let payload = vsock_proto::encode_spawn_process_result(999);
+            let response =
+                vsock_proto::encode(MSG_SPAWN_PROCESS_RESULT, second.seq, &payload).unwrap();
+            guest.write_all(&response).await.unwrap();
+
+            send_first_exit.notified().await;
+            let exit_payload = vsock_proto::encode_process_exit(999, 11, b"", b"");
+            let exit = vsock_proto::encode(MSG_PROCESS_EXIT, first.seq, &exit_payload).unwrap();
+            guest.write_all(&exit).await.unwrap();
+
+            send_second_exit.notified().await;
+            let exit_payload = vsock_proto::encode_process_exit(999, 22, b"", b"");
+            let exit = vsock_proto::encode(MSG_PROCESS_EXIT, second.seq, &exit_payload).unwrap();
+            guest.write_all(&exit).await.unwrap();
+
+            let mut discard = [0u8; 1];
+            let _ = guest.read(&mut discard).await;
+        });
+    }
+
+    let host = host_from_stream(host_stream).await.unwrap();
+    let first = host
+        .spawn_process("first", 0, &[], false, false, None)
+        .await
+        .unwrap();
+    let second = host
+        .spawn_process("second", 0, &[], false, false, None)
+        .await
+        .unwrap();
+    assert_eq!(first.pid(), 999);
+    assert_eq!(second.pid(), 999);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Busy
+    );
+
+    send_first_exit.notify_one();
+    let first_exit = wait_spawn(first).await.unwrap();
+    assert_eq!(first_exit.exit_code, 11);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Busy
+    );
+
+    send_second_exit.notify_one();
+    let second_exit = wait_spawn(second).await.unwrap();
+    assert_eq!(second_exit.exit_code, 22);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Idle
+    );
 }
 
 #[tokio::test]

--- a/crates/vsock-host/src/tests/process.rs
+++ b/crates/vsock-host/src/tests/process.rs
@@ -1,5 +1,8 @@
+use std::future::Future;
 use std::io;
+use std::pin::Pin;
 use std::sync::Arc;
+use std::task::{Context, Poll};
 use std::time::Duration;
 
 use super::support::{
@@ -35,6 +38,12 @@ async fn wait_spawn(handle: GuestProcessHandle) -> io::Result<crate::ProcessExit
     tokio::time::timeout(Duration::from_secs(5), handle.wait())
         .await
         .expect("spawn_process exit should arrive before timeout")
+}
+
+fn poll_once<F: Future>(future: Pin<&mut F>) -> Poll<F::Output> {
+    let waker = std::task::Waker::noop();
+    let mut cx = Context::from_waker(waker);
+    future.poll(&mut cx)
 }
 
 async fn send_process_control_result(
@@ -1452,25 +1461,14 @@ async fn test_spawn_process_cancel_before_frame_write_cleans_registration() {
 
     let host = Arc::new(host_from_stream(host_stream).await.unwrap());
     let writer_guard = host.shared.writer.lock().await;
-    let spawn_task = {
-        let host = Arc::clone(&host);
-        tokio::spawn(async move {
-            host.spawn_process("cancel-before-write", 0, &[], false, true, None)
-                .await
-        })
-    };
-
-    tokio::time::timeout(Duration::from_secs(5), async {
-        while registration_counts(&host) == (0, 0, 0) {
-            tokio::task::yield_now().await;
-        }
-    })
-    .await
-    .expect("spawn_process should register before waiting for writer lock");
+    let mut spawn = Box::pin(host.spawn_process("cancel-before-write", 0, &[], false, true, None));
+    assert!(
+        matches!(poll_once(spawn.as_mut()), Poll::Pending),
+        "spawn_process should wait for writer lock",
+    );
     assert_eq!(registration_counts(&host), (1, 1, 1));
 
-    spawn_task.abort();
-    let _ = spawn_task.await;
+    drop(spawn);
     assert_eq!(
         registration_counts(&host),
         (0, 0, 0),
@@ -2096,9 +2094,6 @@ async fn test_spawn_process_wait_future_drop_keeps_tracker_busy_until_exit() {
             let exit_payload = vsock_proto::encode_process_exit(55, 0, b"", b"");
             let exit_msg = vsock_proto::encode(MSG_PROCESS_EXIT, spawn_seq, &exit_payload).unwrap();
             guest.write_all(&exit_msg).await.unwrap();
-
-            let mut discard = [0u8; 1];
-            let _ = guest.read(&mut discard).await;
         });
     }
 
@@ -2118,16 +2113,13 @@ async fn test_spawn_process_wait_future_drop_keeps_tracker_busy_until_exit() {
     );
 
     send_exit.notify_one();
-    tokio::time::timeout(Duration::from_secs(5), async {
-        loop {
-            if normal_operation_readiness(&host) == NormalOperationReadiness::Idle {
-                break;
-            }
-            tokio::task::yield_now().await;
-        }
-    })
-    .await
-    .expect("detached process exit should release tracker");
+    host.wait_until_closed(Duration::from_secs(5))
+        .await
+        .expect("detached process exit should release tracker before connection close");
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Closed
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- store spawn_process normal-operation tokens in the process routing map
- keep spawned process operations busy past pid ack and complete them on process_exit
- preserve detached terminal-proof tracking after handle/wait future drop and fail closed on malformed lifecycle frames

## Tests
- cargo fmt --manifest-path crates/Cargo.toml --check -p vsock-host
- cargo test --manifest-path crates/Cargo.toml -p vsock-host
- cargo clippy --manifest-path crates/Cargo.toml -p vsock-host --all-targets --all-features -- -D warnings
- pre-commit lefthook crates cargo-doc/cargo-fmt/cargo-clippy

Closes #13457