### PR TITLE
fix: require local-agent realtime notifications

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-local-agent-heartbeat.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-local-agent-heartbeat.test.ts
@@ -1,0 +1,92 @@
+import { createHash, randomUUID } from "node:crypto";
+
+import { localAgentHosts } from "@vm0/db/schema/local-agent";
+import { createStore } from "ccstate";
+import { eq } from "drizzle-orm";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { createApp } from "../../../app-factory";
+import { testContext } from "../../../__tests__/test-helpers";
+import { nowDate } from "../../../lib/time";
+import { writeDb$ } from "../../external/db";
+import { ROUTES } from "../../route";
+
+const context = testContext();
+const store = createStore();
+
+function hashSecret(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+async function seedLocalAgentHost(args: {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly hostToken: string;
+}): Promise<string> {
+  const writeDb = store.set(writeDb$);
+  const now = nowDate();
+  const [host] = await writeDb
+    .insert(localAgentHosts)
+    .values({
+      orgId: args.orgId,
+      userId: args.userId,
+      displayName: "laptop",
+      tokenHash: hashSecret(args.hostToken),
+      supportedBackends: ["codex"],
+      status: "online",
+      lastSeenAt: now,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .returning({ id: localAgentHosts.id });
+
+  if (!host) {
+    throw new Error("Failed to seed local-agent host");
+  }
+  return host.id;
+}
+
+async function deleteLocalAgentHost(hostId: string): Promise<void> {
+  const writeDb = store.set(writeDb$);
+  await writeDb.delete(localAgentHosts).where(eq(localAgentHosts.id, hostId));
+}
+
+describe("POST /api/zero/local-agent/heartbeat", () => {
+  const hostIds: string[] = [];
+
+  afterEach(async () => {
+    while (hostIds.length > 0) {
+      const hostId = hostIds.pop();
+      if (hostId) {
+        await deleteLocalAgentHost(hostId);
+      }
+    }
+  });
+
+  it("accepts fallback heartbeat telemetry when realtime is unavailable", async () => {
+    const hostToken = `vm0_remote_host_${randomUUID()}`;
+    const hostId = await seedLocalAgentHost({
+      orgId: `org_${randomUUID()}`,
+      userId: `user_${randomUUID()}`,
+      hostToken,
+    });
+    hostIds.push(hostId);
+
+    const app = createApp({ signal: context.signal, routes: ROUTES });
+    const response = await app.request("/api/zero/local-agent/heartbeat", {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${hostToken}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        hostName: "laptop",
+        supportedBackends: ["codex"],
+        realtimeConnected: false,
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toStrictEqual({ ok: true, hostId });
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-local-agent.ts
+++ b/turbo/apps/api/src/signals/routes/zero-local-agent.ts
@@ -160,6 +160,9 @@ const heartbeatInner$ = command(async ({ get, set }, signal: AbortSignal) => {
       hostToken,
       hostName: bodyResult.data.hostName,
       supportedBackends: bodyResult.data.supportedBackends,
+      ...(bodyResult.data.realtimeConnected === undefined
+        ? {}
+        : { realtimeConnected: bodyResult.data.realtimeConnected }),
     },
     signal,
   );

--- a/turbo/apps/api/src/signals/services/zero-local-agent.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-local-agent.service.ts
@@ -509,6 +509,7 @@ export const heartbeatLocalAgentHost$ = command(
       readonly hostToken: string;
       readonly hostName: string;
       readonly supportedBackends: readonly LocalAgentBackend[];
+      readonly realtimeConnected?: boolean;
     },
     signal: AbortSignal,
   ): Promise<{ readonly hostId: string } | null> => {
@@ -550,6 +551,15 @@ export const heartbeatLocalAgentHost$ = command(
 
     if (!wasOnline) {
       await publishLocalAgentHostsChangedSafe(row.userId, signal);
+    }
+
+    if (params.realtimeConnected === false) {
+      L.warn("Local-agent realtime unavailable for host", {
+        hostId: row.id,
+        hostName: normalizeHostName(params.hostName),
+        realtimeConnected: params.realtimeConnected,
+        supportedBackends: normalizeBackends(params.supportedBackends),
+      });
     }
 
     return { hostId: row.id };

--- a/turbo/apps/cli/src/commands/zero/local-agent/host.ts
+++ b/turbo/apps/cli/src/commands/zero/local-agent/host.ts
@@ -35,8 +35,7 @@ import {
   type LocalAgentPermissionMode,
 } from "../../../lib/local-agent/backends";
 
-const HEARTBEAT_INTERVAL_MS = 30_000;
-const JOB_POLL_INTERVAL_MS = 2_000;
+const HEARTBEAT_INTERVAL_MS = 60_000;
 const ABLY_CONNECT_TIMEOUT_MS = 10_000;
 
 interface HostStartOptions {
@@ -56,7 +55,8 @@ interface PermissionModeChoice {
 }
 
 interface LocalAgentJobNotifier {
-  wait(timeoutMs: number): Promise<void>;
+  isConnected(): boolean;
+  wait(timeoutMs: number): Promise<boolean>;
   close(): void;
 }
 
@@ -67,12 +67,6 @@ interface StartHostSelection {
 }
 
 const NEW_HOST_SELECTION = "__new__";
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => {
-    setTimeout(resolve, ms);
-  });
-}
 
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
@@ -181,22 +175,33 @@ async function createLocalAgentJobNotifier(
     await channel.subscribe(subscription.eventName, onMessage);
 
     return {
-      wait(timeoutMs: number): Promise<void> {
-        if (pendingEvent || closed || timeoutMs <= 0) {
+      isConnected(): boolean {
+        return ably.connection.state === "connected";
+      },
+      wait(timeoutMs: number): Promise<boolean> {
+        if (pendingEvent || closed) {
           pendingEvent = false;
-          return Promise.resolve();
+          return Promise.resolve(true);
+        }
+        if (timeoutMs <= 0) {
+          return Promise.resolve(false);
         }
 
         return new Promise((resolve) => {
-          function done() {
+          const done = (notified: boolean) => {
             clearTimeout(timer);
-            if (wake === done) {
+            if (wake === onWake) {
               wake = null;
             }
-            resolve();
+            resolve(notified);
+          };
+          function onWake() {
+            done(true);
           }
-          const timer = setTimeout(done, timeoutMs);
-          wake = done;
+          const timer = setTimeout(() => {
+            done(false);
+          }, timeoutMs);
+          wake = onWake;
         });
       },
       close(): void {
@@ -740,7 +745,10 @@ async function runHostLoop(params: {
 
   const sendHeartbeat = async (): Promise<void> => {
     try {
-      await sendLocalAgentHeartbeat(params);
+      await sendLocalAgentHeartbeat({
+        ...params,
+        realtimeConnected: jobNotifier?.isConnected() ?? false,
+      });
       nextHeartbeatAt = Date.now() + HEARTBEAT_INTERVAL_MS;
       latestError = null;
     } catch (error) {
@@ -749,6 +757,7 @@ async function runHostLoop(params: {
         stopLoop();
         return;
       }
+      nextHeartbeatAt = Date.now() + HEARTBEAT_INTERVAL_MS;
       const message = error instanceof Error ? error.message : String(error);
       if (message !== latestError) {
         console.log(chalk.yellow(`Heartbeat failed: ${message}`));
@@ -761,23 +770,33 @@ async function runHostLoop(params: {
   process.once("SIGTERM", onStop);
 
   try {
-    try {
-      jobNotifier = await createLocalAgentJobNotifier(params.hostToken);
-    } catch (error) {
-      console.log(
-        chalk.yellow(
-          `Realtime job notifications unavailable, falling back to polling: ${errorMessage(error)}`,
-        ),
-      );
-    }
+    jobNotifier = await createLocalAgentJobNotifier(params.hostToken).catch(
+      (error: unknown) => {
+        throw new Error(
+          `Realtime job notifications unavailable: ${errorMessage(error)}`,
+        );
+      },
+    );
+    const notifier = jobNotifier;
 
     if (!stopped) {
       await sendHeartbeat();
     }
 
+    let shouldClaim = true;
     while (!stopped) {
       if (Date.now() >= nextHeartbeatAt) {
         await sendHeartbeat();
+      }
+      if (stopped) {
+        break;
+      }
+
+      if (!shouldClaim) {
+        shouldClaim = await notifier.wait(
+          Math.max(1, nextHeartbeatAt - Date.now()),
+        );
+        continue;
       }
 
       let nextJob;
@@ -793,17 +812,11 @@ async function runHostLoop(params: {
           continue;
         }
         const message = error instanceof Error ? error.message : String(error);
-        console.log(chalk.yellow(`Job poll failed: ${message}`));
-        await sleep(JOB_POLL_INTERVAL_MS);
-        continue;
+        throw new Error(`Failed to claim local-agent job: ${message}`);
       }
 
       if (nextJob.status === "idle") {
-        if (jobNotifier) {
-          await jobNotifier.wait(Math.max(1, nextHeartbeatAt - Date.now()));
-        } else {
-          await sleep(JOB_POLL_INTERVAL_MS);
-        }
+        shouldClaim = false;
         continue;
       }
 
@@ -833,6 +846,7 @@ async function runHostLoop(params: {
       const status =
         result.exitCode === 0 ? chalk.green("completed") : chalk.red("failed");
       console.log(`${status} ${nextJob.job.id}`);
+      shouldClaim = true;
     }
   } finally {
     jobNotifier?.close();

--- a/turbo/apps/cli/src/lib/api/domains/zero-local-agent.ts
+++ b/turbo/apps/cli/src/lib/api/domains/zero-local-agent.ts
@@ -74,6 +74,7 @@ export async function sendLocalAgentHeartbeat(params: {
   hostToken: string;
   hostName: string;
   supportedBackends: LocalAgentBackend[];
+  realtimeConnected?: boolean;
 }): Promise<{ hostId: string }> {
   const baseUrl = resolveLocalAgentApiBaseUrl(await getBaseUrl());
   const client = initClient(zeroLocalAgentHeartbeatContract, {
@@ -86,6 +87,9 @@ export async function sendLocalAgentHeartbeat(params: {
     body: {
       hostName: params.hostName,
       supportedBackends: params.supportedBackends,
+      ...(params.realtimeConnected === undefined
+        ? {}
+        : { realtimeConnected: params.realtimeConnected }),
     },
   });
 

--- a/turbo/packages/api-contracts/src/contracts/zero-local-agent.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-local-agent.ts
@@ -190,6 +190,7 @@ export const zeroLocalAgentHeartbeatContract = c.router({
     body: z.object({
       hostName: hostNameSchema,
       supportedBackends: supportedBackendsSchema,
+      realtimeConnected: z.boolean().optional(),
     }),
     responses: {
       200: localAgentHeartbeatResponseSchema,


### PR DESCRIPTION
## Summary
- require the local-agent host to connect to Ably before starting the job loop
- remove periodic jobs/next fallback polling; jobs are claimed on startup sync and Ably notifications only
- keep heartbeat and heartbeat retry cadence at 60s, and report realtime connection state for server-side warnings if the connection drops

## Tests
- pnpm -F api exec vitest run src/signals/routes/__tests__/zero-local-agent-heartbeat.test.ts src/signals/routes/__tests__/zero-local-agent-runs.test.ts
- pnpm -F @vm0/cli exec vitest run src/commands/zero/local-agent/__tests__/local-agent.test.ts src/commands/zero/local-agent/__tests__/runs.test.ts
- pnpm -F @vm0/api-contracts check-types && pnpm -F api check-types && pnpm -F @vm0/cli check-types
- pnpm -F api lint && pnpm -F @vm0/cli lint
- pnpm -F @vm0/api-contracts lint
- pre-commit hook: knip + turbo run check-types --concurrency=1