### PR TITLE
fix: preserve utf-8 boundaries in vsock error payloads

### DIFF
--- a/crates/vsock-proto/src/payloads/error.rs
+++ b/crates/vsock-proto/src/payloads/error.rs
@@ -4,7 +4,7 @@ use crate::read::read_u16_at;
 
 /// Encode error payload: `[2B error_len][error]`.
 ///
-/// Error message is truncated to 65535 bytes if longer.
+/// Error message is truncated to at most 65535 bytes at a UTF-8 boundary.
 pub fn encode_error(message: &str) -> Vec<u8> {
     let (msg, msg_len) = truncate_utf8_to_u16_bytes(message);
     let mut p = Vec::with_capacity(2 + msg_len as usize);

--- a/crates/vsock-proto/src/payloads/error.rs
+++ b/crates/vsock-proto/src/payloads/error.rs
@@ -67,8 +67,9 @@ mod tests {
 
     #[test]
     fn error_payload_truncates_oversized_utf8_at_character_boundary() {
-        let prefix = "A".repeat(u16::MAX as usize - 1);
-        let message = format!("{prefix}é");
+        let emoji = "\u{1F600}";
+        let prefix = "A".repeat(u16::MAX as usize - (emoji.len() - 1));
+        let message = format!("{prefix}{emoji}");
         let payload = encode_error(&message);
 
         let declared_len = u16::from_be_bytes(payload.get(..2).unwrap().try_into().unwrap());

--- a/crates/vsock-proto/src/payloads/error.rs
+++ b/crates/vsock-proto/src/payloads/error.rs
@@ -1,3 +1,4 @@
+use super::truncate_utf8_to_u16_bytes;
 use crate::error::ProtocolError;
 use crate::read::read_u16_at;
 
@@ -5,12 +6,10 @@ use crate::read::read_u16_at;
 ///
 /// Error message is truncated to 65535 bytes if longer.
 pub fn encode_error(message: &str) -> Vec<u8> {
-    let msg = message.as_bytes();
-    let msg_len = msg.len().min(u16::MAX as usize) as u16;
+    let (msg, msg_len) = truncate_utf8_to_u16_bytes(message);
     let mut p = Vec::with_capacity(2 + msg_len as usize);
     p.extend_from_slice(&msg_len.to_be_bytes());
-    // msg_len <= msg.len() is guaranteed by .min() above
-    p.extend_from_slice(msg.get(..msg_len as usize).unwrap_or(msg));
+    p.extend_from_slice(msg);
     p
 }
 
@@ -36,5 +35,43 @@ mod tests {
         let payload = encode_error("something went wrong");
         let msg = decode_error(&payload).unwrap();
         assert_eq!(msg, "something went wrong");
+    }
+
+    #[test]
+    fn error_payload_truncates_oversized_ascii_to_u16_max() {
+        let message = "A".repeat(u16::MAX as usize + 1);
+        let payload = encode_error(&message);
+
+        assert_eq!(payload.len(), 2 + u16::MAX as usize);
+        assert_eq!(payload.get(..2), Some(u16::MAX.to_be_bytes().as_slice()));
+
+        let msg = decode_error(&payload).unwrap();
+        assert_eq!(msg.len(), u16::MAX as usize);
+        assert!(msg.bytes().all(|byte| byte == b'A'));
+    }
+
+    #[test]
+    fn error_payload_truncates_oversized_utf8_at_character_boundary() {
+        let prefix = "A".repeat(u16::MAX as usize - 1);
+        let message = format!("{prefix}é");
+        let payload = encode_error(&message);
+
+        let declared_len = u16::from_be_bytes(payload.get(..2).unwrap().try_into().unwrap());
+        assert_eq!(declared_len as usize, prefix.len());
+        assert_eq!(payload.len(), 2 + prefix.len());
+
+        let msg = decode_error(&payload).unwrap();
+        assert_eq!(msg, prefix);
+    }
+
+    #[test]
+    fn decode_error_rejects_invalid_utf8() {
+        let payload = [0, 1, 0xC3];
+        let err = decode_error(&payload).unwrap_err();
+
+        assert!(matches!(
+            err,
+            ProtocolError::InvalidPayload("invalid UTF-8 in error")
+        ));
     }
 }

--- a/crates/vsock-proto/src/payloads/error.rs
+++ b/crates/vsock-proto/src/payloads/error.rs
@@ -51,6 +51,21 @@ mod tests {
     }
 
     #[test]
+    fn error_payload_keeps_utf8_character_ending_at_u16_max() {
+        let prefix = "A".repeat(u16::MAX as usize - "é".len());
+        let expected = format!("{prefix}é");
+        let message = format!("{expected}B");
+        let payload = encode_error(&message);
+
+        let declared_len = u16::from_be_bytes(payload.get(..2).unwrap().try_into().unwrap());
+        assert_eq!(declared_len as usize, expected.len());
+        assert_eq!(payload.len(), 2 + expected.len());
+
+        let msg = decode_error(&payload).unwrap();
+        assert_eq!(msg, expected);
+    }
+
+    #[test]
     fn error_payload_truncates_oversized_utf8_at_character_boundary() {
         let prefix = "A".repeat(u16::MAX as usize - 1);
         let message = format!("{prefix}é");

--- a/crates/vsock-proto/src/payloads/mod.rs
+++ b/crates/vsock-proto/src/payloads/mod.rs
@@ -5,3 +5,12 @@ pub(crate) mod process;
 pub(crate) mod process_control;
 pub(crate) mod spawn_process;
 pub(crate) mod write_file;
+
+fn truncate_utf8_to_u16_bytes(value: &str) -> (&[u8], u16) {
+    let mut end = value.len().min(u16::MAX as usize);
+    while !value.is_char_boundary(end) {
+        end -= 1;
+    }
+    let (prefix, _) = value.split_at(end);
+    (prefix.as_bytes(), end as u16)
+}

--- a/crates/vsock-proto/src/payloads/write_file.rs
+++ b/crates/vsock-proto/src/payloads/write_file.rs
@@ -1,3 +1,4 @@
+use super::truncate_utf8_to_u16_bytes;
 use crate::error::ProtocolError;
 use crate::read::{read_u8_at, read_u16_at, read_u32_at};
 use crate::wire::{WRITE_FILE_FLAG_APPEND, WRITE_FILE_FLAG_SUDO};
@@ -37,13 +38,11 @@ pub fn encode_write_file(
 ///
 /// Error message is truncated to 65535 bytes if longer.
 pub fn encode_write_file_result(success: bool, error: &str) -> Vec<u8> {
-    let err = error.as_bytes();
-    let err_len = err.len().min(u16::MAX as usize) as u16;
+    let (err, err_len) = truncate_utf8_to_u16_bytes(error);
     let mut p = Vec::with_capacity(3 + err_len as usize);
     p.push(u8::from(success));
     p.extend_from_slice(&err_len.to_be_bytes());
-    // err_len <= err.len() is guaranteed by .min() above
-    p.extend_from_slice(err.get(..err_len as usize).unwrap_or(err));
+    p.extend_from_slice(err);
     p
 }
 
@@ -160,6 +159,22 @@ mod tests {
         let (success, error) = decode_write_file_result(&payload).unwrap();
         assert!(!success);
         assert_eq!(error, "permission denied");
+    }
+
+    #[test]
+    fn write_file_result_truncates_oversized_utf8_at_character_boundary() {
+        let prefix = "A".repeat(u16::MAX as usize - 1);
+        let error = format!("{prefix}é");
+        let payload = encode_write_file_result(false, &error);
+
+        assert_eq!(payload.first(), Some(&0));
+        let declared_len = u16::from_be_bytes(payload.get(1..3).unwrap().try_into().unwrap());
+        assert_eq!(declared_len as usize, prefix.len());
+        assert_eq!(payload.len(), 3 + prefix.len());
+
+        let (success, decoded_error) = decode_write_file_result(&payload).unwrap();
+        assert!(!success);
+        assert_eq!(decoded_error, prefix);
     }
 
     #[test]

--- a/crates/vsock-proto/src/payloads/write_file.rs
+++ b/crates/vsock-proto/src/payloads/write_file.rs
@@ -36,7 +36,7 @@ pub fn encode_write_file(
 
 /// Encode write_file_result payload: `[1B success][2B error_len][error]`.
 ///
-/// Error message is truncated to 65535 bytes if longer.
+/// Error message is truncated to at most 65535 bytes at a UTF-8 boundary.
 pub fn encode_write_file_result(success: bool, error: &str) -> Vec<u8> {
     let (err, err_len) = truncate_utf8_to_u16_bytes(error);
     let mut p = Vec::with_capacity(3 + err_len as usize);


### PR DESCRIPTION
## Summary
- add a private vsock payload helper for UTF-8-safe truncation into u16 byte length fields
- use it for error and write_file_result error payload encoding
- add regression coverage for ASCII truncation, UTF-8 boundary truncation, and malformed error payload decoding

## Tests
- cargo test --manifest-path crates/Cargo.toml -p vsock-proto
- cargo fmt -p vsock-proto --check (from crates/)
- cargo clippy --manifest-path crates/Cargo.toml -p vsock-proto --all-targets -- -D warnings

Closes #13582