### PR TITLE
fix: preserve chat run failure errors

### DIFF
--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -158,6 +158,7 @@ async fn execute(
     {
         let msg = format!("Working dir setup failed: {e}");
         log_error!(LOG_TAG, "{msg}");
+        write_checkpoint_error_file(&msg);
         record_sandbox_op("working_dir_setup", wd_start.elapsed(), false, Some(&msg));
         return 1;
     }
@@ -211,7 +212,6 @@ async fn execute(
                             Some(msg),
                         );
                         log_info!(LOG_TAG, "{msg}");
-                        let _ = std::fs::write(paths::checkpoint_error_file(), msg);
                         (cli_exit_code, 1, msg.to_string(), true)
                     } else {
                         (0, 0, String::new(), false)
@@ -242,8 +242,11 @@ async fn execute(
         cli_exit_code,
         exit_code,
         cli_elapsed,
-        last_event_sequence,
-        skip_recovery_checkpoint_for_no_history,
+        CompletionState {
+            last_event_sequence,
+            failure_message: (exit_code != 0).then_some(error_message.as_str()),
+            skip_recovery_checkpoint_for_no_history,
+        },
         telemetry,
         &http,
     )
@@ -279,6 +282,17 @@ fn history_target_unavailable(path: &Path) -> bool {
         Ok(metadata) => metadata.is_file() && metadata.len() == 0,
         Err(e) if e.kind() == ErrorKind::NotFound => true,
         Err(_) => false,
+    }
+}
+
+fn write_checkpoint_error_file(message: &str) {
+    let message = message.trim();
+    if message.is_empty() {
+        return;
+    }
+
+    if let Err(e) = std::fs::write(paths::checkpoint_error_file(), message) {
+        log_warn!(LOG_TAG, "Failed to write checkpoint error file: {e}");
     }
 }
 
@@ -331,18 +345,34 @@ fn truncate_cli_stderr_line(line: &str) -> std::borrow::Cow<'_, str> {
     std::borrow::Cow::Owned(truncated)
 }
 
+struct CompletionState<'a> {
+    last_event_sequence: Option<u32>,
+    failure_message: Option<&'a str>,
+    skip_recovery_checkpoint_for_no_history: bool,
+}
+
 async fn complete_execution(
     cli_exit_code: i32,
     mut exit_code: i32,
     cli_elapsed: Duration,
-    last_event_sequence: Option<u32>,
-    skip_recovery_checkpoint_for_no_history: bool,
+    state: CompletionState<'_>,
     telemetry: &Telemetry,
     http: &HttpClient,
 ) -> i32 {
+    let has_failure_message = state
+        .failure_message
+        .is_some_and(|message| !message.trim().is_empty());
+    if let Some(message) = state.failure_message {
+        write_checkpoint_error_file(message);
+    }
+
     // Check if any events failed to send (before logging execution result)
     if std::path::Path::new(paths::event_error_flag()).exists() {
-        log_error!(LOG_TAG, "Some events failed to send, marking run as failed");
+        let msg = "Some events failed to send, marking run as failed";
+        log_error!(LOG_TAG, "{msg}");
+        if !has_failure_message {
+            write_checkpoint_error_file(msg);
+        }
         exit_code = 1;
     }
 
@@ -396,7 +426,7 @@ async fn complete_execution(
                     http,
                     env::sandbox_id(),
                     env::sandbox_reuse_result(),
-                    last_event_sequence,
+                    state.last_event_sequence,
                 )
                 .await;
                 final_telemetry(telemetry).await;
@@ -409,7 +439,7 @@ async fn complete_execution(
                     "✗ Checkpoint failed ({}s)",
                     cp_start.elapsed().as_secs()
                 );
-                let _ = std::fs::write(paths::checkpoint_error_file(), &msg);
+                write_checkpoint_error_file(&msg);
                 exit_code = 1;
 
                 // Failure path: don't call /complete from guest. The runner's
@@ -422,7 +452,7 @@ async fn complete_execution(
     } else {
         if cli_exit_code == 0 && exit_code == 0 {
             log_info!(LOG_TAG, "{agent_type} completed successfully");
-        } else if skip_recovery_checkpoint_for_no_history {
+        } else if state.skip_recovery_checkpoint_for_no_history {
             log_info!(
                 LOG_TAG,
                 "{agent_type} completed without resumable session history; marking run as failed"
@@ -435,7 +465,7 @@ async fn complete_execution(
         }
 
         if env::has_api() {
-            if skip_recovery_checkpoint_for_no_history {
+            if state.skip_recovery_checkpoint_for_no_history {
                 log_info!(
                     LOG_TAG,
                     "Skipping recovery checkpoint because no session history was created"
@@ -837,11 +867,27 @@ mod tests {
         let masker = Arc::new(masker::SecretMasker::from_env());
         let http = HttpClient::new().unwrap();
         let telemetry = Telemetry::spawn(masker, http.clone());
-        let exit_code =
-            complete_execution(0, 1, Duration::ZERO, None, true, &telemetry, &http).await;
+        let failure_message = "Claude Code emitted a zero-turn result without creating session history; skipping checkpoint";
+        let exit_code = complete_execution(
+            0,
+            1,
+            Duration::ZERO,
+            CompletionState {
+                last_event_sequence: None,
+                failure_message: Some(failure_message),
+                skip_recovery_checkpoint_for_no_history: true,
+            },
+            &telemetry,
+            &http,
+        )
+        .await;
         telemetry.shutdown().await;
 
         assert_eq!(exit_code, 1);
+        assert_eq!(
+            std::fs::read_to_string(paths::checkpoint_error_file()).unwrap(),
+            failure_message
+        );
         assert_eq!(prepare_mock.calls_async().await, 0);
         assert_eq!(checkpoint_mock.calls_async().await, 0);
 
@@ -920,14 +966,26 @@ mod tests {
         let masker = Arc::new(masker::SecretMasker::from_env());
         let http = HttpClient::new().unwrap();
         let telemetry = Telemetry::spawn(masker, http.clone());
-        let exit_code =
-            complete_execution(1, 1, Duration::ZERO, None, false, &telemetry, &http).await;
+        let failure_message = "You've hit your usage limit.";
+        let exit_code = complete_execution(
+            1,
+            1,
+            Duration::ZERO,
+            CompletionState {
+                last_event_sequence: None,
+                failure_message: Some(failure_message),
+                skip_recovery_checkpoint_for_no_history: false,
+            },
+            &telemetry,
+            &http,
+        )
+        .await;
         telemetry.shutdown().await;
 
         assert_eq!(exit_code, 1);
-        assert!(
-            !std::path::Path::new(paths::checkpoint_error_file()).exists(),
-            "recovery checkpoint failure must not write the success-path checkpoint error file"
+        assert_eq!(
+            std::fs::read_to_string(paths::checkpoint_error_file()).unwrap(),
+            failure_message
         );
         prepare_mock.assert_calls_async(1).await;
         upload_mock.assert_calls_async(1).await;

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-chat-threads.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-chat-threads.ts
@@ -155,6 +155,7 @@ export const deleteZeroChatThread$ = command(
 interface SeedChatMessageOptions {
   readonly role: "user" | "assistant";
   readonly content: string | null;
+  readonly error?: string | null;
   readonly attachFiles?: readonly string[];
   readonly createdAt?: Date;
   readonly sequenceNumber?: number | null;
@@ -176,6 +177,7 @@ export const seedZeroChatMessage$ = command(
       chatThreadId: fixture.threadId,
       role: options.role,
       content: options.content,
+      ...(options.error !== undefined ? { error: options.error } : {}),
       attachFiles: options.attachFiles ? [...options.attachFiles] : null,
       sequenceNumber: options.sequenceNumber ?? null,
       runId: options.runId ?? null,

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-chat-threads-messages.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-chat-threads-messages.test.ts
@@ -372,6 +372,60 @@ describe("GET /api/zero/chat-threads/:threadId/messages", () => {
     );
   });
 
+  it("uses actionable run error over stored transient paged assistant error", async () => {
+    const transientError =
+      "Oops, something went wrong. Please try again later.";
+    const usageLimitError = "You've hit your usage limit.";
+    const thread = await trackThread(
+      store.set(seedZeroChatThread$, {}, context.signal),
+    );
+    const { runId } = await store.set(
+      seedRun$,
+      {
+        orgId: thread.orgId,
+        userId: thread.userId,
+        composeId: thread.composeId,
+        status: "failed",
+        error: usageLimitError,
+      },
+      context.signal,
+    );
+    await store.set(
+      addRunToThread$,
+      { threadId: thread.threadId, runId, prompt: "hit limit" },
+      context.signal,
+    );
+    await store.set(
+      seedZeroChatMessage$,
+      thread,
+      {
+        role: "assistant",
+        content: transientError,
+        error: transientError,
+        runId,
+      },
+      context.signal,
+    );
+
+    mocks.clerk.session(thread.userId, thread.orgId);
+
+    const client = setupApp({ context })(chatThreadMessagesContract);
+    const response = await accept(
+      client.list({
+        params: { threadId: thread.threadId },
+        query: {},
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    const assistantMsg = response.body.messages.find((message) => {
+      return message.role === "assistant";
+    });
+    expect(assistantMsg?.error).toBe(usageLimitError);
+    expect(assistantMsg?.content).toBe(usageLimitError);
+  });
+
   it("does not expose run-level error on event-backed assistant rows", async () => {
     const thread = await trackThread(
       store.set(seedZeroChatThread$, {}, context.signal),

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-chat-threads.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-chat-threads.test.ts
@@ -508,6 +508,66 @@ describe("GET /api/zero/chat-threads/:id", () => {
     }
   });
 
+  it("uses actionable run error over stored transient assistant error", async () => {
+    const transientError =
+      "Oops, something went wrong. Please try again later.";
+    const usageLimitError = "You've hit your usage limit.";
+    const fixture = await track(
+      store.set(
+        seedZeroChatThread$,
+        { title: "Usage limit thread" },
+        context.signal,
+      ),
+    );
+    const { runId } = await store.set(
+      seedRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        composeId: fixture.composeId,
+        status: "failed",
+        error: usageLimitError,
+      },
+      context.signal,
+    );
+    await store.set(
+      addRunToThread$,
+      {
+        threadId: fixture.threadId,
+        runId,
+        prompt: "hit limit",
+      },
+      context.signal,
+    );
+    await store.set(
+      seedZeroChatMessage$,
+      fixture,
+      {
+        role: "assistant",
+        content: transientError,
+        error: transientError,
+        runId,
+      },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    const client = setupApp({ context })(chatThreadByIdContract);
+
+    const response = await accept(
+      client.get({
+        params: { id: fixture.threadId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    const assistantMsg = response.body.chatMessages.find((message) => {
+      return message.role === "assistant";
+    });
+    expect(assistantMsg?.error).toBe(usageLimitError);
+    expect(assistantMsg?.content).toBe(usageLimitError);
+  });
+
   it("returns activeRuns with live status for non-terminal runs", async () => {
     const fixture = await track(
       store.set(seedZeroChatThread$, { title: "Active runs" }, context.signal),

--- a/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
@@ -224,6 +224,40 @@ function isActionableRunError(errorMessage: string): boolean {
   });
 }
 
+function preferredActionableRunErrorForStoredTransient(params: {
+  readonly sequenceNumber: number | null;
+  readonly storedError: string | null;
+  readonly runError: string | null;
+}): string | null {
+  const storedError = params.storedError?.trim();
+  const runError = params.runError?.trim();
+  if (
+    params.sequenceNumber !== null ||
+    storedError !== CHAT_RUN_TRANSIENT_ERROR_MESSAGE ||
+    !runError ||
+    !isActionableRunError(runError)
+  ) {
+    return null;
+  }
+  return params.runError;
+}
+
+function effectiveChatErrorContent(params: {
+  readonly content: string | null;
+  readonly storedError: string | null;
+  readonly preferredRunError: string | null;
+  readonly effectiveError: string | undefined;
+}): string | null {
+  if (
+    params.preferredRunError !== null &&
+    params.effectiveError !== undefined &&
+    params.content === params.storedError
+  ) {
+    return params.effectiveError;
+  }
+  return params.content;
+}
+
 function buildReportableErrorMessage(runId: string): string {
   return `${CHAT_RUN_REPORTABLE_ERROR_MESSAGE} [Report this issue](/runs/${encodeURIComponent(runId)}/report-error)`;
 }
@@ -451,11 +485,19 @@ function toStoredMessage(
   return computed(
     async (get): Promise<ChatThreadDetail["chatMessages"][number]> => {
       const isPlaceholder = row.sequenceNumber === null;
+      const preferredRunError = preferredActionableRunErrorForStoredTransient({
+        sequenceNumber: row.sequenceNumber,
+        storedError: row.error,
+        runError: row.runError,
+      });
       const rawEffectiveError = isPlaceholder
-        ? (row.error ?? row.runError ?? undefined)
+        ? (preferredRunError ?? row.error ?? row.runError ?? undefined)
         : (row.error ?? undefined);
       const effectiveError =
-        rawEffectiveError && isPlaceholder && !row.error && row.runId
+        rawEffectiveError &&
+        isPlaceholder &&
+        (row.error === null || preferredRunError !== null) &&
+        row.runId
           ? await get(
               formatChatRunErrorMessage({
                 chatThreadId: threadId,
@@ -473,7 +515,12 @@ function toStoredMessage(
       const message = {
         id: row.id,
         role,
-        content: row.content,
+        content: effectiveChatErrorContent({
+          content: row.content,
+          storedError: row.error,
+          preferredRunError,
+          effectiveError,
+        }),
         runId: row.runId ?? undefined,
         revokesMessageId: row.revokesMessageId ?? undefined,
         interruptsRunId: row.interruptsRunId ?? undefined,
@@ -502,13 +549,21 @@ function toPagedMessage(
   row: ChatMessageRow,
 ): Computed<Promise<PagedChatMessage>> {
   return computed(async (get): Promise<PagedChatMessage> => {
+    const preferredRunError = preferredActionableRunErrorForStoredTransient({
+      sequenceNumber: row.sequenceNumber,
+      storedError: row.error,
+      runError: row.runError,
+    });
     const isLegacyPlaceholder =
       row.sequenceNumber === null && row.content === null && !row.error;
-    const rawEffectiveError = isLegacyPlaceholder
-      ? (row.runError ?? undefined)
-      : (row.error ?? undefined);
+    const rawEffectiveError =
+      preferredRunError !== null || isLegacyPlaceholder
+        ? (preferredRunError ?? row.runError ?? undefined)
+        : (row.error ?? undefined);
     const effectiveError =
-      rawEffectiveError && isLegacyPlaceholder && row.runId
+      rawEffectiveError &&
+      (preferredRunError !== null || isLegacyPlaceholder) &&
+      row.runId
         ? await get(
             formatChatRunErrorMessage({
               chatThreadId: threadId,
@@ -526,7 +581,12 @@ function toPagedMessage(
     const message = {
       id: row.id,
       role,
-      content: row.content,
+      content: effectiveChatErrorContent({
+        content: row.content,
+        storedError: row.error,
+        preferredRunError,
+        effectiveError,
+      }),
       runId: row.runId ?? undefined,
       revokesMessageId: row.revokesMessageId ?? undefined,
       interruptsRunId: row.interruptsRunId ?? undefined,

--- a/turbo/apps/web/app/api/zero/chat-threads/[id]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/chat-threads/[id]/__tests__/route.test.ts
@@ -596,6 +596,59 @@ describe("GET /api/zero/chat-threads/:id - Get Thread Detail", () => {
     }
   });
 
+  it("should use actionable run error over stored transient assistant error", async () => {
+    const transientError =
+      "Oops, something went wrong. Please try again later.";
+    const usageLimitError = "You've hit your usage limit.";
+    const createRes = await POST(
+      createTestRequest("http://localhost:3000/api/zero/chat-threads", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          agentId: testComposeId,
+          title: "Usage limit thread",
+        }),
+      }),
+    );
+    const { id: threadId } = await createRes.json();
+    const { runId } = await seedTestRun(testUserId, testComposeId, {
+      status: "running",
+      prompt: "hit limit",
+    });
+    await addTestRunToThread(threadId, runId, testUserId, "hit limit");
+    await transitionRunStatus(
+      runId,
+      {
+        status: "failed",
+        completedAt: new Date(),
+        error: usageLimitError,
+      },
+      ["pending", "running"],
+    );
+    await insertTestChatMessage({
+      chatThreadId: threadId,
+      userId: testUserId,
+      role: "assistant",
+      content: transientError,
+      error: transientError,
+      runId,
+    });
+
+    const response = await GET(
+      createTestRequest(
+        `http://localhost:3000/api/zero/chat-threads/${threadId}`,
+      ),
+    );
+    expect(response.status).toBe(200);
+    const data = await response.json();
+
+    const assistantMsg = data.chatMessages.find((m: { role: string }) => {
+      return m.role === "assistant";
+    });
+    expect(assistantMsg.error).toBe(usageLimitError);
+    expect(assistantMsg.content).toBe(usageLimitError);
+  });
+
   it("returns activeRuns with live status for non-terminal runs", async () => {
     // Setup: a thread with one queued run and one running run.
     // A completed run on the same thread is expected to be excluded.

--- a/turbo/apps/web/app/api/zero/chat-threads/[id]/messages/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/chat-threads/[id]/messages/__tests__/route.test.ts
@@ -358,6 +358,57 @@ describe("GET /api/zero/chat-threads/:threadId/messages", () => {
     );
   });
 
+  it("should use actionable run error over stored transient paged assistant error", async () => {
+    const transientError =
+      "Oops, something went wrong. Please try again later.";
+    const usageLimitError = "You've hit your usage limit.";
+    const createRes = await POST(
+      createTestRequest("http://localhost:3000/api/zero/chat-threads", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ agentId: testComposeId }),
+      }),
+    );
+    const { id: threadId } = await createRes.json();
+
+    const { runId } = await seedTestRun(testUserId, testComposeId, {
+      status: "running",
+      prompt: "hit limit",
+    });
+    await addTestRunToThread(threadId, runId, testUserId, "hit limit");
+    await transitionRunStatus(
+      runId,
+      {
+        status: "failed",
+        completedAt: new Date(),
+        error: usageLimitError,
+      },
+      ["pending", "running"],
+    );
+    await insertTestChatMessage({
+      chatThreadId: threadId,
+      userId: testUserId,
+      role: "assistant",
+      content: transientError,
+      error: transientError,
+      runId,
+    });
+
+    const response = await GET(
+      createTestRequest(
+        `http://localhost:3000/api/zero/chat-threads/${threadId}/messages`,
+      ),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    const assistantMsg = data.messages.find((m: { role: string }) => {
+      return m.role === "assistant";
+    });
+    expect(assistantMsg.error).toBe(usageLimitError);
+    expect(assistantMsg.content).toBe(usageLimitError);
+  });
+
   it("should not expose run-level error on event-backed assistant rows", async () => {
     const createRes = await POST(
       createTestRequest("http://localhost:3000/api/zero/chat-threads", {

--- a/turbo/apps/web/app/api/zero/chat-threads/[id]/messages/route.ts
+++ b/turbo/apps/web/app/api/zero/chat-threads/[id]/messages/route.ts
@@ -7,7 +7,11 @@ import {
   getPagedMessages,
   resolveAttachFileUrls,
 } from "../../../../../../src/lib/zero/chat-thread";
-import { formatChatRunErrorMessage } from "../../../../../../src/lib/zero/chat-thread/chat-run-error-message";
+import {
+  effectiveChatErrorContent,
+  formatChatRunErrorMessage,
+  preferredActionableRunErrorForStoredTransient,
+} from "../../../../../../src/lib/zero/chat-thread/chat-run-error-message";
 import { isNotFound } from "@vm0/api-services/errors";
 
 const router = tsr.router(chatThreadMessagesContract, {
@@ -37,15 +41,25 @@ const router = tsr.router(chatThreadMessagesContract, {
 
       const messages = await Promise.all(
         page.messages.map(async (row) => {
-          // Legacy placeholder rows (sequenceNumber IS NULL) fall back to runError;
-          // event-backed rows and error rows use their own error field.
+          // Legacy placeholder rows (sequenceNumber IS NULL) fall back to runError.
+          // Older transient error rows can also use an actionable runError so the
+          // user sees the concrete cause instead of the generic fallback.
+          const preferredRunError =
+            preferredActionableRunErrorForStoredTransient({
+              sequenceNumber: row.sequenceNumber,
+              storedError: row.error,
+              runError: row.runError,
+            });
           const isLegacyPlaceholder =
             row.sequenceNumber === null && row.content === null && !row.error;
-          const rawEffectiveError = isLegacyPlaceholder
-            ? (row.runError ?? undefined)
-            : (row.error ?? undefined);
+          const rawEffectiveError =
+            preferredRunError !== null || isLegacyPlaceholder
+              ? (preferredRunError ?? row.runError ?? undefined)
+              : (row.error ?? undefined);
           const effectiveError =
-            rawEffectiveError && isLegacyPlaceholder && row.runId
+            rawEffectiveError &&
+            (preferredRunError !== null || isLegacyPlaceholder) &&
+            row.runId
               ? await formatChatRunErrorMessage({
                   chatThreadId: params.threadId,
                   runId: row.runId,
@@ -60,7 +74,12 @@ const router = tsr.router(chatThreadMessagesContract, {
           const message = {
             id: row.id,
             role,
-            content: row.content,
+            content: effectiveChatErrorContent({
+              content: row.content,
+              storedError: row.error,
+              preferredRunError,
+              effectiveError,
+            }),
             runId: row.runId ?? undefined,
             revokesMessageId: row.revokesMessageId ?? undefined,
             interruptsRunId: row.interruptsRunId ?? undefined,

--- a/turbo/apps/web/src/__tests__/db-test-seeders/agents.ts
+++ b/turbo/apps/web/src/__tests__/db-test-seeders/agents.ts
@@ -588,6 +588,7 @@ export async function insertTestChatMessage(params: {
   userId?: string;
   role: "user" | "assistant";
   content: string | null;
+  error?: string | null;
   runId?: string | null;
   interruptsRunId?: string | null;
   archivedAt?: Date | null;
@@ -601,6 +602,7 @@ export async function insertTestChatMessage(params: {
       chatThreadId: params.chatThreadId,
       role: params.role,
       content: params.content,
+      error: params.error ?? null,
       runId: params.runId ?? null,
       interruptsRunId: params.interruptsRunId ?? null,
       archivedAt: params.archivedAt ?? null,

--- a/turbo/apps/web/src/lib/zero/chat-thread/chat-run-error-message.ts
+++ b/turbo/apps/web/src/lib/zero/chat-thread/chat-run-error-message.ts
@@ -29,6 +29,40 @@ function isActionableRunError(errorMessage: string): boolean {
   });
 }
 
+export function preferredActionableRunErrorForStoredTransient(params: {
+  readonly sequenceNumber: number | null;
+  readonly storedError: string | null;
+  readonly runError: string | null;
+}): string | null {
+  const storedError = params.storedError?.trim();
+  const runError = params.runError?.trim();
+  if (
+    params.sequenceNumber !== null ||
+    storedError !== CHAT_RUN_TRANSIENT_ERROR_MESSAGE ||
+    !runError ||
+    !isActionableRunError(runError)
+  ) {
+    return null;
+  }
+  return params.runError;
+}
+
+export function effectiveChatErrorContent(params: {
+  readonly content: string | null;
+  readonly storedError: string | null;
+  readonly preferredRunError: string | null;
+  readonly effectiveError: string | undefined;
+}): string | null {
+  if (
+    params.preferredRunError !== null &&
+    params.effectiveError !== undefined &&
+    params.content === params.storedError
+  ) {
+    return params.effectiveError;
+  }
+  return params.content;
+}
+
 function buildReportableErrorMessage(runId: string): string {
   return `${CHAT_RUN_REPORTABLE_ERROR_MESSAGE} [Report this issue](/runs/${encodeURIComponent(runId)}/report-error)`;
 }

--- a/turbo/apps/web/src/lib/zero/chat-thread/chat-thread-service.ts
+++ b/turbo/apps/web/src/lib/zero/chat-thread/chat-thread-service.ts
@@ -21,7 +21,11 @@ import {
   getLatestSessionIdForThread,
   publishThreadListChanged,
 } from "./chat-message-service";
-import { formatChatRunErrorMessage } from "./chat-run-error-message";
+import {
+  effectiveChatErrorContent,
+  formatChatRunErrorMessage,
+  preferredActionableRunErrorForStoredTransient,
+} from "./chat-run-error-message";
 import {
   type ChatThreadArtifactRun,
   type ChatThreadDetail,
@@ -631,12 +635,22 @@ export async function getChatThreadMessages(
       // The placeholder row (sequence_number IS NULL) is the only row that
       // falls back to agent_runs.error, covering the case where the terminal
       // callback failed to deliver and chat_messages.error was never written.
+      // If an older row already stored the transient generic message, prefer an
+      // actionable run-level error so the user can see the concrete cause.
       const isPlaceholder = row.sequenceNumber === null;
+      const preferredRunError = preferredActionableRunErrorForStoredTransient({
+        sequenceNumber: row.sequenceNumber,
+        storedError: row.error,
+        runError: row.runError,
+      });
       const rawEffectiveError = isPlaceholder
-        ? (row.error ?? row.runError ?? undefined)
+        ? (preferredRunError ?? row.error ?? row.runError ?? undefined)
         : (row.error ?? undefined);
       const effectiveError =
-        rawEffectiveError && isPlaceholder && !row.error && row.runId
+        rawEffectiveError &&
+        isPlaceholder &&
+        (row.error === null || preferredRunError !== null) &&
+        row.runId
           ? await formatChatRunErrorMessage({
               chatThreadId: threadId,
               runId: row.runId,
@@ -653,7 +667,12 @@ export async function getChatThreadMessages(
       const message = {
         id: row.id,
         role,
-        content: row.content,
+        content: effectiveChatErrorContent({
+          content: row.content,
+          storedError: row.error,
+          preferredRunError,
+          effectiveError,
+        }),
         runId: row.runId ?? undefined,
         revokesMessageId: row.revokesMessageId ?? undefined,
         interruptsRunId: row.interruptsRunId ?? undefined,


### PR DESCRIPTION
## Summary
- persist guest-agent failure messages to the runner-readable checkpoint error file so hosted runs include CLI failures in the complete webhook payload
- prefer actionable run-level errors over previously stored transient chat errors when reading chat threads and message pages
- keep assistant error content aligned with the recovered error text
- add API, legacy web, and guest-agent regression coverage for usage limit errors

## Context
Axiom showed fresh prod failures where the complete webhook only received `Run failed without error message`. The read-path fallback helps older rows where `agent_runs.error` already has the original message, but it cannot recover fresh hosted runs when the runner never receives the CLI stderr. This updates guest-agent finalization to write the failure message into `/tmp/vm0-checkpoint-error-{run_id}`, which runner already reads when process stderr is empty.

## Tests
- pnpm --dir turbo -F api exec vitest run src/signals/routes/__tests__/zero-chat-threads.test.ts src/signals/routes/__tests__/zero-chat-threads-messages.test.ts
- pnpm --dir turbo -F web exec vitest run 'app/api/zero/chat-threads/[id]/__tests__/route.test.ts' 'app/api/zero/chat-threads/[id]/messages/__tests__/route.test.ts'
- pnpm --dir turbo -F api lint
- pnpm --dir turbo -F web lint
- pnpm --dir turbo -F api check-types
- pnpm --dir turbo -F web check-types
- pnpm --dir turbo knip --cache
- cargo fmt --manifest-path crates/Cargo.toml --check --package guest-agent
- cargo clippy --manifest-path crates/Cargo.toml -p guest-agent --bin guest-agent -- -D warnings
- cargo test --manifest-path crates/Cargo.toml -p guest-agent --bin guest-agent
- cargo test --manifest-path crates/Cargo.toml -p runner read_guest_error_file