### PR TITLE
ci: add final runner upgrade exit check

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -1361,6 +1361,8 @@ jobs:
               systemctl is-active --quiet "vm0-runner-${svc}" || return 0
               sleep 1
             done
+            # One final check covers units that exit during the last sleep.
+            systemctl is-active --quiet "vm0-runner-${svc}" || return 0
             fail "$svc still active after ${budget}s (stuck on drain?)"
           }
 


### PR DESCRIPTION
## Summary

- Add one final `systemctl is-active` check after the bounded `runner-upgrade-local` wait loop.
- Avoid a boundary false negative when the runner exits during the final polling sleep.

Closes #13704

## Verification

- `git diff --check`
- `actionlint .github/workflows/crates.yml`
- pre-commit hooks on commit