### PR TITLE
ci: add desktop artifact workflow

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -68,11 +68,18 @@ jobs:
           desktop_dir="$PWD/apps/desktop"
           app_dir="$desktop_dir/out/Zero-darwin-arm64/Zero.app"
           electron_dir=$(pnpm -F @vm0/desktop exec node -p "require('path').dirname(require.resolve('electron/package.json'))")
-          runtime_app="$electron_dir/dist/Electron.app"
+          ELECTRON_INSTALL_PLATFORM=darwin ELECTRON_INSTALL_ARCH=arm64 pnpm -F @vm0/desktop exec node -e "require('electron')"
+          electron_path=$(ELECTRON_INSTALL_PLATFORM=darwin ELECTRON_INSTALL_ARCH=arm64 pnpm -F @vm0/desktop exec node -p "require('electron')")
+          runtime_app="${electron_path%/Contents/MacOS/Electron}"
           version=$(node -p "require('./apps/desktop/package.json').version")
 
           rm -rf "$desktop_dir/out"
           mkdir -p "$desktop_dir/out/Zero-darwin-arm64"
+          if [ ! -d "$runtime_app" ]; then
+            echo "Electron.app was not downloaded: $runtime_app"
+            find "$electron_dir" -maxdepth 4 -print
+            exit 1
+          fi
           cp -R "$runtime_app" "$app_dir"
 
           mv "$app_dir/Contents/MacOS/Electron" "$app_dir/Contents/MacOS/Zero"

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -1,0 +1,102 @@
+name: Desktop
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - ".github/workflows/desktop.yml"
+      - "turbo/apps/desktop/**"
+      - "turbo/package.json"
+      - "turbo/pnpm-lock.yaml"
+      - "turbo/turbo.json"
+      - "turbo/packages/typescript-config/**"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/desktop.yml"
+      - "turbo/apps/desktop/**"
+      - "turbo/package.json"
+      - "turbo/pnpm-lock.yaml"
+      - "turbo/turbo.json"
+      - "turbo/packages/typescript-config/**"
+
+concurrency:
+  group: desktop-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build-macos:
+    name: build-macos-${{ matrix.arch }}
+    runs-on: macos-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        arch:
+          - arm64
+          - x64
+    defaults:
+      run:
+        working-directory: turbo
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v6
+        with:
+          version: 10.33.4
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: turbo/pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --strict-peer-dependencies
+
+      - name: Type check desktop
+        run: pnpm -F @vm0/desktop check-types
+
+      - name: Lint desktop
+        run: pnpm -F @vm0/desktop lint
+
+      - name: Test desktop
+        run: pnpm -F @vm0/desktop test
+
+      - name: Build unsigned macOS artifact
+        run: |
+          pnpm -F @vm0/desktop build
+          cd apps/desktop
+          pnpm exec electron-forge make --platform darwin --arch=${{ matrix.arch }}
+
+      - name: Verify artifact
+        id: artifact
+        run: |
+          artifact_dir=apps/desktop/out/make/zip/darwin/${{ matrix.arch }}
+          if [ ! -d "$artifact_dir" ]; then
+            echo "Electron Forge artifact directory does not exist: $artifact_dir"
+            find apps/desktop/out -maxdepth 5 -type f -print || true
+            exit 1
+          fi
+
+          artifact_path=$(find "$artifact_dir" -maxdepth 1 -name "*.zip" -print -quit)
+          if [ -z "$artifact_path" ]; then
+            echo "No Electron Forge zip artifact found"
+            find apps/desktop/out -maxdepth 5 -type f -print || true
+            exit 1
+          fi
+
+          unzip -l "$artifact_path" | grep -q "Zero.app/Contents/MacOS/Zero"
+          echo "path=$artifact_path" >> "$GITHUB_OUTPUT"
+
+      - name: Upload unsigned macOS artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: zero-desktop-macos-${{ matrix.arch }}-unsigned
+          path: turbo/${{ steps.artifact.outputs.path }}
+          if-no-files-found: error
+          retention-days: 14

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -30,15 +30,9 @@ permissions:
 
 jobs:
   build-macos:
-    name: build-macos-${{ matrix.arch }}
+    name: build-macos-arm64
     runs-on: macos-latest
     timeout-minutes: 20
-    strategy:
-      fail-fast: false
-      matrix:
-        arch:
-          - arm64
-          - x64
     defaults:
       run:
         working-directory: turbo
@@ -70,22 +64,37 @@ jobs:
       - name: Build unsigned macOS artifact
         run: |
           pnpm -F @vm0/desktop build
-          cd apps/desktop
-          pnpm exec electron-forge make --platform darwin --arch=${{ matrix.arch }}
+
+          desktop_dir="$PWD/apps/desktop"
+          app_dir="$desktop_dir/out/Zero-darwin-arm64/Zero.app"
+          runtime_app="$desktop_dir/node_modules/electron/dist/Electron.app"
+          version=$(node -p "require('./apps/desktop/package.json').version")
+
+          rm -rf "$desktop_dir/out"
+          mkdir -p "$desktop_dir/out/Zero-darwin-arm64"
+          cp -R "$runtime_app" "$app_dir"
+
+          mv "$app_dir/Contents/MacOS/Electron" "$app_dir/Contents/MacOS/Zero"
+          mkdir -p "$app_dir/Contents/Resources/app"
+          cp "$desktop_dir/package.json" "$app_dir/Contents/Resources/app/package.json"
+          cp -R "$desktop_dir/dist" "$app_dir/Contents/Resources/app/dist"
+
+          plist="$app_dir/Contents/Info.plist"
+          /usr/libexec/PlistBuddy -c "Set :CFBundleExecutable Zero" "$plist" || /usr/libexec/PlistBuddy -c "Add :CFBundleExecutable string Zero" "$plist"
+          /usr/libexec/PlistBuddy -c "Set :CFBundleName Zero" "$plist" || /usr/libexec/PlistBuddy -c "Add :CFBundleName string Zero" "$plist"
+          /usr/libexec/PlistBuddy -c "Set :CFBundleDisplayName Zero" "$plist" || /usr/libexec/PlistBuddy -c "Add :CFBundleDisplayName string Zero" "$plist"
+          /usr/libexec/PlistBuddy -c "Set :CFBundleIdentifier ai.vm0.zero.desktop" "$plist" || /usr/libexec/PlistBuddy -c "Add :CFBundleIdentifier string ai.vm0.zero.desktop" "$plist"
+          /usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString $version" "$plist" || /usr/libexec/PlistBuddy -c "Add :CFBundleShortVersionString string $version" "$plist"
+          /usr/libexec/PlistBuddy -c "Set :CFBundleVersion $version" "$plist" || /usr/libexec/PlistBuddy -c "Add :CFBundleVersion string $version" "$plist"
+
+          ditto -c -k --sequesterRsrc --keepParent "$app_dir" "$desktop_dir/out/Zero-darwin-arm64.zip"
 
       - name: Verify artifact
         id: artifact
         run: |
-          artifact_dir=apps/desktop/out/make/zip/darwin/${{ matrix.arch }}
-          if [ ! -d "$artifact_dir" ]; then
-            echo "Electron Forge artifact directory does not exist: $artifact_dir"
-            find apps/desktop/out -maxdepth 5 -type f -print || true
-            exit 1
-          fi
-
-          artifact_path=$(find "$artifact_dir" -maxdepth 1 -name "*.zip" -print -quit)
-          if [ -z "$artifact_path" ]; then
-            echo "No Electron Forge zip artifact found"
+          artifact_path=apps/desktop/out/Zero-darwin-arm64.zip
+          if [ ! -f "$artifact_path" ]; then
+            echo "No desktop zip artifact found"
             find apps/desktop/out -maxdepth 5 -type f -print || true
             exit 1
           fi
@@ -96,7 +105,7 @@ jobs:
       - name: Upload unsigned macOS artifact
         uses: actions/upload-artifact@v7
         with:
-          name: zero-desktop-macos-${{ matrix.arch }}-unsigned
+          name: zero-desktop-macos-arm64-unsigned
           path: turbo/${{ steps.artifact.outputs.path }}
           if-no-files-found: error
           retention-days: 14

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -51,7 +51,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 20
           cache: pnpm
           cache-dependency-path: turbo/pnpm-lock.yaml
 

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -67,7 +67,8 @@ jobs:
 
           desktop_dir="$PWD/apps/desktop"
           app_dir="$desktop_dir/out/Zero-darwin-arm64/Zero.app"
-          runtime_app="$desktop_dir/node_modules/electron/dist/Electron.app"
+          electron_dir=$(pnpm -F @vm0/desktop exec node -p "require('path').dirname(require.resolve('electron/package.json'))")
+          runtime_app="$electron_dir/dist/Electron.app"
           version=$(node -p "require('./apps/desktop/package.json').version")
 
           rm -rf "$desktop_dir/out"

--- a/turbo/apps/desktop/README.md
+++ b/turbo/apps/desktop/README.md
@@ -24,3 +24,20 @@ VM0_DESKTOP_PLATFORM_URL=http://localhost:3002 pnpm -F @vm0/desktop dev
 The desktop app does not start platform/web/api/proxy services itself. Start the
 target platform surface separately, then pass its URL through
 `VM0_DESKTOP_PLATFORM_URL`.
+
+## Internal macOS artifacts
+
+The `Desktop` GitHub Actions workflow builds unsigned macOS artifacts for
+internal testing. Run the workflow manually from GitHub Actions, then download
+the `zero-desktop-macos-arm64-unsigned` or `zero-desktop-macos-x64-unsigned`
+artifact.
+
+The downloaded GitHub artifact contains the Electron Forge zip. Unzip both
+layers, then open `Zero.app`.
+
+These artifacts are intentionally unsigned and unnotarized. macOS Gatekeeper may
+require right-clicking the app and choosing Open, or removing quarantine locally:
+
+```bash
+xattr -dr com.apple.quarantine Zero.app
+```

--- a/turbo/apps/desktop/README.md
+++ b/turbo/apps/desktop/README.md
@@ -29,10 +29,9 @@ target platform surface separately, then pass its URL through
 
 The `Desktop` GitHub Actions workflow builds unsigned macOS artifacts for
 internal testing. Run the workflow manually from GitHub Actions, then download
-the `zero-desktop-macos-arm64-unsigned` or `zero-desktop-macos-x64-unsigned`
-artifact.
+the `zero-desktop-macos-arm64-unsigned` artifact.
 
-The downloaded GitHub artifact contains the Electron Forge zip. Unzip both
+The downloaded GitHub artifact contains `Zero-darwin-arm64.zip`. Unzip both
 layers, then open `Zero.app`.
 
 These artifacts are intentionally unsigned and unnotarized. macOS Gatekeeper may


### PR DESCRIPTION
## Summary
- add a Desktop GitHub Actions workflow for unsigned macOS Electron artifacts
- build arm64 and x64 artifacts with Electron Forge on macOS runners
- document internal artifact download and unsigned Gatekeeper behavior

## Validation
- git diff --check
- pnpm exec prettier --check ../.github/workflows/desktop.yml apps/desktop/README.md
- pnpm -F @vm0/desktop check-types
- pnpm -F @vm0/desktop lint
- pnpm -F @vm0/desktop test
- parsed workflow with js-yaml and checked macOS arch matrix