### PR TITLE
fix: preserve codex jsonl failure diagnostics

### DIFF
--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -90,6 +90,14 @@ pub struct CliExecutionResult {
     /// Claude Code's final result metadata, when a terminal result event was
     /// observed. Codex uses its own event schema and leaves this unset.
     pub claude_result: Option<ClaudeResultSummary>,
+
+    /// Best-effort, secret-masked terminal failure diagnostic parsed from CLI
+    /// stdout JSONL.
+    ///
+    /// Codex reports terminal failures as JSONL events on stdout, not stderr.
+    /// Keeping the diagnostic here lets the guest-agent surface the actual
+    /// failure reason in its final run error.
+    pub failure_diagnostic: Option<String>,
 }
 
 /// Execute the CLI process, streaming JSONL events and racing against heartbeat.
@@ -247,6 +255,7 @@ pub async fn execute_cli(
     let mut last_read_event_at: Option<Instant> = None;
     let mut cli_exit_at: Option<Instant> = None;
     let mut claude_result = None;
+    let mut failure_diagnostic = None;
     let event_result: Result<(), AgentError> = loop {
         tokio::select! {
             line_result = reader.next_line(), if !stdout_eof => {
@@ -294,12 +303,19 @@ pub async fn execute_cli(
                                 && let Some(diagnostic) =
                                     events::masked_codex_failure_diagnostic(&event, masker)
                             {
+                                let message = diagnostic.message;
                                 log_warn!(
                                     LOG_TAG,
                                     "Codex JSONL failure event seq={seq} type={}: {}",
                                     diagnostic.event_type,
-                                    diagnostic.message
+                                    message
                                 );
+                                if should_replace_failure_diagnostic(
+                                    failure_diagnostic.as_deref(),
+                                    &message,
+                                ) {
+                                    failure_diagnostic = Some(message);
+                                }
                             }
                             // Capture checkpoint metadata before event payload preparation
                             // mutates the event through masking.
@@ -603,5 +619,37 @@ pub async fn execute_cli(
         stderr_lines: masked_stderr_lines,
         last_event_sequence,
         claude_result,
+        failure_diagnostic,
     })
+}
+
+fn should_replace_failure_diagnostic(existing: Option<&str>, candidate: &str) -> bool {
+    match existing {
+        None => true,
+        Some(existing) => {
+            !events::is_generic_codex_failure_diagnostic(candidate)
+                || events::is_generic_codex_failure_diagnostic(existing)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::should_replace_failure_diagnostic;
+
+    #[test]
+    fn specific_codex_failure_diagnostic_survives_later_generic_event() {
+        assert!(!should_replace_failure_diagnostic(
+            Some("You've hit your usage limit."),
+            "turn failed",
+        ));
+    }
+
+    #[test]
+    fn specific_codex_failure_diagnostic_replaces_generic_event() {
+        assert!(should_replace_failure_diagnostic(
+            Some("error"),
+            "You've hit your usage limit.",
+        ));
+    }
 }

--- a/crates/guest-agent/src/events.rs
+++ b/crates/guest-agent/src/events.rs
@@ -87,6 +87,10 @@ pub(crate) fn masked_codex_failure_diagnostic(
     })
 }
 
+pub(crate) fn is_generic_codex_failure_diagnostic(message: &str) -> bool {
+    matches!(message.trim(), "error" | "turn failed" | "turn interrupted")
+}
+
 fn extract_codex_failure_diagnostic(event: &Value) -> Option<CodexFailureDiagnostic> {
     match event.get("type").and_then(Value::as_str)? {
         "error" => Some(CodexFailureDiagnostic {

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -196,7 +196,11 @@ async fn execute(
                     (
                         cli_exit_code,
                         cli_exit_code,
-                        cli_failure_message(cli_exit_code, &cli_result.stderr_lines),
+                        cli_failure_message(
+                            cli_exit_code,
+                            &cli_result.stderr_lines,
+                            cli_result.failure_diagnostic.as_deref(),
+                        ),
                         false,
                     )
                 } else if env::has_api()
@@ -296,7 +300,22 @@ fn write_checkpoint_error_file(message: &str) {
     }
 }
 
-fn cli_failure_message(code: i32, stderr_lines: &[String]) -> String {
+fn cli_failure_message(
+    code: i32,
+    stderr_lines: &[String],
+    failure_diagnostic: Option<&str>,
+) -> String {
+    if let Some(message) = failure_diagnostic.and_then(|message| {
+        let message = message.trim();
+        if message.is_empty() {
+            None
+        } else {
+            Some(message)
+        }
+    }) {
+        return message.to_string();
+    }
+
     if stderr_lines.is_empty() {
         return format!("Agent exited with code {code}");
     }
@@ -544,7 +563,7 @@ mod tests {
             .chain(std::iter::once(long_line.clone()))
             .chain((0..(MAX_LOGGED_CLI_STDERR_LINES - 2)).map(|i| format!("extra line {i}")))
             .collect::<Vec<_>>();
-        let msg = cli_failure_message(1, &stderr_lines);
+        let msg = cli_failure_message(1, &stderr_lines, None);
         assert!(
             !msg.contains("prefix line"),
             "returned error message should omit older stderr lines"
@@ -605,7 +624,7 @@ mod tests {
             .chain((1..MAX_LOGGED_CLI_STDERR_LINES).map(|i| format!("line {i}")))
             .collect::<Vec<_>>();
 
-        let msg = cli_failure_message(1, &stderr_lines);
+        let msg = cli_failure_message(1, &stderr_lines, None);
         assert!(
             msg.contains(&exact_limit_line),
             "returned error message should preserve line at exact size limit"
@@ -639,7 +658,7 @@ mod tests {
 
         let prefix = "x".repeat(MAX_LOGGED_CLI_STDERR_LINE_BYTES - 1);
         let stderr_line = format!("{prefix}é-tail");
-        let msg = cli_failure_message(1, &[stderr_line]);
+        let msg = cli_failure_message(1, &[stderr_line], None);
 
         assert!(
             msg.contains(&prefix),
@@ -666,12 +685,30 @@ mod tests {
     }
 
     #[test]
+    fn cli_failure_message_prefers_codex_failure_diagnostic() {
+        let stderr_lines = vec!["background task noise".to_string()];
+        let msg = cli_failure_message(
+            1,
+            &stderr_lines,
+            Some(
+                "You've hit your usage limit. Visit https://chatgpt.com/codex/settings/usage to purchase more credits.",
+            ),
+        );
+
+        assert_eq!(
+            msg,
+            "You've hit your usage limit. Visit https://chatgpt.com/codex/settings/usage to purchase more credits."
+        );
+    }
+
+    #[test]
     fn is_claude_zero_turn_result_requires_all_guards() {
         let zero_turn = cli::CliExecutionResult {
             exit_code: 0,
             stderr_lines: Vec::new(),
             last_event_sequence: None,
             claude_result: Some(cli::ClaudeResultSummary { num_turns: Some(0) }),
+            failure_diagnostic: None,
         };
         let one_turn = cli::CliExecutionResult {
             claude_result: Some(cli::ClaudeResultSummary { num_turns: Some(1) }),

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -158,6 +158,7 @@ async fn execute(
     {
         let msg = format!("Working dir setup failed: {e}");
         log_error!(LOG_TAG, "{msg}");
+        write_checkpoint_error_file(&msg);
         record_sandbox_op("working_dir_setup", wd_start.elapsed(), false, Some(&msg));
         return 1;
     }
@@ -211,7 +212,6 @@ async fn execute(
                             Some(msg),
                         );
                         log_info!(LOG_TAG, "{msg}");
-                        let _ = std::fs::write(paths::checkpoint_error_file(), msg);
                         (cli_exit_code, 1, msg.to_string(), true)
                     } else {
                         (0, 0, String::new(), false)
@@ -242,8 +242,11 @@ async fn execute(
         cli_exit_code,
         exit_code,
         cli_elapsed,
-        last_event_sequence,
-        skip_recovery_checkpoint_for_no_history,
+        CompletionState {
+            last_event_sequence,
+            failure_message: (exit_code != 0).then_some(error_message.as_str()),
+            skip_recovery_checkpoint_for_no_history,
+        },
         telemetry,
         &http,
     )
@@ -279,6 +282,17 @@ fn history_target_unavailable(path: &Path) -> bool {
         Ok(metadata) => metadata.is_file() && metadata.len() == 0,
         Err(e) if e.kind() == ErrorKind::NotFound => true,
         Err(_) => false,
+    }
+}
+
+fn write_checkpoint_error_file(message: &str) {
+    let message = message.trim();
+    if message.is_empty() {
+        return;
+    }
+
+    if let Err(e) = std::fs::write(paths::checkpoint_error_file(), message) {
+        log_warn!(LOG_TAG, "Failed to write checkpoint error file: {e}");
     }
 }
 
@@ -331,18 +345,34 @@ fn truncate_cli_stderr_line(line: &str) -> std::borrow::Cow<'_, str> {
     std::borrow::Cow::Owned(truncated)
 }
 
+struct CompletionState<'a> {
+    last_event_sequence: Option<u32>,
+    failure_message: Option<&'a str>,
+    skip_recovery_checkpoint_for_no_history: bool,
+}
+
 async fn complete_execution(
     cli_exit_code: i32,
     mut exit_code: i32,
     cli_elapsed: Duration,
-    last_event_sequence: Option<u32>,
-    skip_recovery_checkpoint_for_no_history: bool,
+    state: CompletionState<'_>,
     telemetry: &Telemetry,
     http: &HttpClient,
 ) -> i32 {
+    let has_failure_message = state
+        .failure_message
+        .is_some_and(|message| !message.trim().is_empty());
+    if let Some(message) = state.failure_message {
+        write_checkpoint_error_file(message);
+    }
+
     // Check if any events failed to send (before logging execution result)
     if std::path::Path::new(paths::event_error_flag()).exists() {
-        log_error!(LOG_TAG, "Some events failed to send, marking run as failed");
+        let msg = "Some events failed to send, marking run as failed";
+        log_error!(LOG_TAG, "{msg}");
+        if !has_failure_message {
+            write_checkpoint_error_file(msg);
+        }
         exit_code = 1;
     }
 
@@ -396,7 +426,7 @@ async fn complete_execution(
                     http,
                     env::sandbox_id(),
                     env::sandbox_reuse_result(),
-                    last_event_sequence,
+                    state.last_event_sequence,
                 )
                 .await;
                 final_telemetry(telemetry).await;
@@ -409,7 +439,7 @@ async fn complete_execution(
                     "✗ Checkpoint failed ({}s)",
                     cp_start.elapsed().as_secs()
                 );
-                let _ = std::fs::write(paths::checkpoint_error_file(), &msg);
+                write_checkpoint_error_file(&msg);
                 exit_code = 1;
 
                 // Failure path: don't call /complete from guest. The runner's
@@ -422,7 +452,7 @@ async fn complete_execution(
     } else {
         if cli_exit_code == 0 && exit_code == 0 {
             log_info!(LOG_TAG, "{agent_type} completed successfully");
-        } else if skip_recovery_checkpoint_for_no_history {
+        } else if state.skip_recovery_checkpoint_for_no_history {
             log_info!(
                 LOG_TAG,
                 "{agent_type} completed without resumable session history; marking run as failed"
@@ -435,7 +465,7 @@ async fn complete_execution(
         }
 
         if env::has_api() {
-            if skip_recovery_checkpoint_for_no_history {
+            if state.skip_recovery_checkpoint_for_no_history {
                 log_info!(
                     LOG_TAG,
                     "Skipping recovery checkpoint because no session history was created"
@@ -837,11 +867,27 @@ mod tests {
         let masker = Arc::new(masker::SecretMasker::from_env());
         let http = HttpClient::new().unwrap();
         let telemetry = Telemetry::spawn(masker, http.clone());
-        let exit_code =
-            complete_execution(0, 1, Duration::ZERO, None, true, &telemetry, &http).await;
+        let failure_message = "Claude Code emitted a zero-turn result without creating session history; skipping checkpoint";
+        let exit_code = complete_execution(
+            0,
+            1,
+            Duration::ZERO,
+            CompletionState {
+                last_event_sequence: None,
+                failure_message: Some(failure_message),
+                skip_recovery_checkpoint_for_no_history: true,
+            },
+            &telemetry,
+            &http,
+        )
+        .await;
         telemetry.shutdown().await;
 
         assert_eq!(exit_code, 1);
+        assert_eq!(
+            std::fs::read_to_string(paths::checkpoint_error_file()).unwrap(),
+            failure_message
+        );
         assert_eq!(prepare_mock.calls_async().await, 0);
         assert_eq!(checkpoint_mock.calls_async().await, 0);
 
@@ -920,14 +966,26 @@ mod tests {
         let masker = Arc::new(masker::SecretMasker::from_env());
         let http = HttpClient::new().unwrap();
         let telemetry = Telemetry::spawn(masker, http.clone());
-        let exit_code =
-            complete_execution(1, 1, Duration::ZERO, None, false, &telemetry, &http).await;
+        let failure_message = "You've hit your usage limit.";
+        let exit_code = complete_execution(
+            1,
+            1,
+            Duration::ZERO,
+            CompletionState {
+                last_event_sequence: None,
+                failure_message: Some(failure_message),
+                skip_recovery_checkpoint_for_no_history: false,
+            },
+            &telemetry,
+            &http,
+        )
+        .await;
         telemetry.shutdown().await;
 
         assert_eq!(exit_code, 1);
-        assert!(
-            !std::path::Path::new(paths::checkpoint_error_file()).exists(),
-            "recovery checkpoint failure must not write the success-path checkpoint error file"
+        assert_eq!(
+            std::fs::read_to_string(paths::checkpoint_error_file()).unwrap(),
+            failure_message
         );
         prepare_mock.assert_calls_async(1).await;
         upload_mock.assert_calls_async(1).await;

--- a/crates/guest-agent/tests/codex_jsonl_failure_logging.rs
+++ b/crates/guest-agent/tests/codex_jsonl_failure_logging.rs
@@ -50,6 +50,10 @@ async fn codex_jsonl_error_event_is_written_to_system_log() -> Result<(), Box<dy
     .expect("execute_cli should return promptly")?;
 
     assert_eq!(cli_result.exit_code, common::CLEAN_EXIT);
+    assert_eq!(
+        cli_result.failure_diagnostic.as_deref(),
+        Some("Mock error event for fixture testing")
+    );
     let system_log = std::fs::read_to_string(&system_log_path)?;
     assert!(
         system_log.contains(

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-chat-threads.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-chat-threads.ts
@@ -155,6 +155,7 @@ export const deleteZeroChatThread$ = command(
 interface SeedChatMessageOptions {
   readonly role: "user" | "assistant";
   readonly content: string | null;
+  readonly error?: string | null;
   readonly attachFiles?: readonly string[];
   readonly createdAt?: Date;
   readonly sequenceNumber?: number | null;
@@ -176,6 +177,7 @@ export const seedZeroChatMessage$ = command(
       chatThreadId: fixture.threadId,
       role: options.role,
       content: options.content,
+      ...(options.error !== undefined ? { error: options.error } : {}),
       attachFiles: options.attachFiles ? [...options.attachFiles] : null,
       sequenceNumber: options.sequenceNumber ?? null,
       runId: options.runId ?? null,

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-chat-threads-messages.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-chat-threads-messages.test.ts
@@ -375,7 +375,8 @@ describe("GET /api/zero/chat-threads/:threadId/messages", () => {
   it("uses actionable run error over stored transient paged assistant error", async () => {
     const transientError =
       "Oops, something went wrong. Please try again later.";
-    const usageLimitError = "You've hit your usage limit.";
+    const codexCreditError =
+      "You've hit your usage limit. Visit https://chatgpt.com/codex/settings/usage to purchase more credits or try again at 3:14 PM.";
     const thread = await trackThread(
       store.set(seedZeroChatThread$, {}, context.signal),
     );
@@ -386,7 +387,7 @@ describe("GET /api/zero/chat-threads/:threadId/messages", () => {
         userId: thread.userId,
         composeId: thread.composeId,
         status: "failed",
-        error: usageLimitError,
+        error: codexCreditError,
       },
       context.signal,
     );
@@ -422,8 +423,8 @@ describe("GET /api/zero/chat-threads/:threadId/messages", () => {
     const assistantMsg = response.body.messages.find((message) => {
       return message.role === "assistant";
     });
-    expect(assistantMsg?.error).toBe(usageLimitError);
-    expect(assistantMsg?.content).toBe(usageLimitError);
+    expect(assistantMsg?.error).toBe(codexCreditError);
+    expect(assistantMsg?.content).toBe(codexCreditError);
   });
 
   it("does not expose run-level error on event-backed assistant rows", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-chat-threads-messages.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-chat-threads-messages.test.ts
@@ -372,6 +372,60 @@ describe("GET /api/zero/chat-threads/:threadId/messages", () => {
     );
   });
 
+  it("uses actionable run error over stored transient paged assistant error", async () => {
+    const transientError =
+      "Oops, something went wrong. Please try again later.";
+    const usageLimitError = "You've hit your usage limit.";
+    const thread = await trackThread(
+      store.set(seedZeroChatThread$, {}, context.signal),
+    );
+    const { runId } = await store.set(
+      seedRun$,
+      {
+        orgId: thread.orgId,
+        userId: thread.userId,
+        composeId: thread.composeId,
+        status: "failed",
+        error: usageLimitError,
+      },
+      context.signal,
+    );
+    await store.set(
+      addRunToThread$,
+      { threadId: thread.threadId, runId, prompt: "hit limit" },
+      context.signal,
+    );
+    await store.set(
+      seedZeroChatMessage$,
+      thread,
+      {
+        role: "assistant",
+        content: transientError,
+        error: transientError,
+        runId,
+      },
+      context.signal,
+    );
+
+    mocks.clerk.session(thread.userId, thread.orgId);
+
+    const client = setupApp({ context })(chatThreadMessagesContract);
+    const response = await accept(
+      client.list({
+        params: { threadId: thread.threadId },
+        query: {},
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    const assistantMsg = response.body.messages.find((message) => {
+      return message.role === "assistant";
+    });
+    expect(assistantMsg?.error).toBe(usageLimitError);
+    expect(assistantMsg?.content).toBe(usageLimitError);
+  });
+
   it("does not expose run-level error on event-backed assistant rows", async () => {
     const thread = await trackThread(
       store.set(seedZeroChatThread$, {}, context.signal),

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-chat-threads.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-chat-threads.test.ts
@@ -511,7 +511,8 @@ describe("GET /api/zero/chat-threads/:id", () => {
   it("uses actionable run error over stored transient assistant error", async () => {
     const transientError =
       "Oops, something went wrong. Please try again later.";
-    const usageLimitError = "You've hit your usage limit.";
+    const codexCreditError =
+      "You've hit your usage limit. Visit https://chatgpt.com/codex/settings/usage to purchase more credits or try again at 3:14 PM.";
     const fixture = await track(
       store.set(
         seedZeroChatThread$,
@@ -526,7 +527,7 @@ describe("GET /api/zero/chat-threads/:id", () => {
         userId: fixture.userId,
         composeId: fixture.composeId,
         status: "failed",
-        error: usageLimitError,
+        error: codexCreditError,
       },
       context.signal,
     );
@@ -564,8 +565,8 @@ describe("GET /api/zero/chat-threads/:id", () => {
     const assistantMsg = response.body.chatMessages.find((message) => {
       return message.role === "assistant";
     });
-    expect(assistantMsg?.error).toBe(usageLimitError);
-    expect(assistantMsg?.content).toBe(usageLimitError);
+    expect(assistantMsg?.error).toBe(codexCreditError);
+    expect(assistantMsg?.content).toBe(codexCreditError);
   });
 
   it("returns activeRuns with live status for non-terminal runs", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-chat-threads.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-chat-threads.test.ts
@@ -508,6 +508,66 @@ describe("GET /api/zero/chat-threads/:id", () => {
     }
   });
 
+  it("uses actionable run error over stored transient assistant error", async () => {
+    const transientError =
+      "Oops, something went wrong. Please try again later.";
+    const usageLimitError = "You've hit your usage limit.";
+    const fixture = await track(
+      store.set(
+        seedZeroChatThread$,
+        { title: "Usage limit thread" },
+        context.signal,
+      ),
+    );
+    const { runId } = await store.set(
+      seedRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        composeId: fixture.composeId,
+        status: "failed",
+        error: usageLimitError,
+      },
+      context.signal,
+    );
+    await store.set(
+      addRunToThread$,
+      {
+        threadId: fixture.threadId,
+        runId,
+        prompt: "hit limit",
+      },
+      context.signal,
+    );
+    await store.set(
+      seedZeroChatMessage$,
+      fixture,
+      {
+        role: "assistant",
+        content: transientError,
+        error: transientError,
+        runId,
+      },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    const client = setupApp({ context })(chatThreadByIdContract);
+
+    const response = await accept(
+      client.get({
+        params: { id: fixture.threadId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    const assistantMsg = response.body.chatMessages.find((message) => {
+      return message.role === "assistant";
+    });
+    expect(assistantMsg?.error).toBe(usageLimitError);
+    expect(assistantMsg?.content).toBe(usageLimitError);
+  });
+
   it("returns activeRuns with live status for non-terminal runs", async () => {
     const fixture = await track(
       store.set(seedZeroChatThread$, { title: "Active runs" }, context.signal),

--- a/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
@@ -224,6 +224,40 @@ function isActionableRunError(errorMessage: string): boolean {
   });
 }
 
+function preferredActionableRunErrorForStoredTransient(params: {
+  readonly sequenceNumber: number | null;
+  readonly storedError: string | null;
+  readonly runError: string | null;
+}): string | null {
+  const storedError = params.storedError?.trim();
+  const runError = params.runError?.trim();
+  if (
+    params.sequenceNumber !== null ||
+    storedError !== CHAT_RUN_TRANSIENT_ERROR_MESSAGE ||
+    !runError ||
+    !isActionableRunError(runError)
+  ) {
+    return null;
+  }
+  return params.runError;
+}
+
+function effectiveChatErrorContent(params: {
+  readonly content: string | null;
+  readonly storedError: string | null;
+  readonly preferredRunError: string | null;
+  readonly effectiveError: string | undefined;
+}): string | null {
+  if (
+    params.preferredRunError !== null &&
+    params.effectiveError !== undefined &&
+    params.content === params.storedError
+  ) {
+    return params.effectiveError;
+  }
+  return params.content;
+}
+
 function buildReportableErrorMessage(runId: string): string {
   return `${CHAT_RUN_REPORTABLE_ERROR_MESSAGE} [Report this issue](/runs/${encodeURIComponent(runId)}/report-error)`;
 }
@@ -451,11 +485,19 @@ function toStoredMessage(
   return computed(
     async (get): Promise<ChatThreadDetail["chatMessages"][number]> => {
       const isPlaceholder = row.sequenceNumber === null;
+      const preferredRunError = preferredActionableRunErrorForStoredTransient({
+        sequenceNumber: row.sequenceNumber,
+        storedError: row.error,
+        runError: row.runError,
+      });
       const rawEffectiveError = isPlaceholder
-        ? (row.error ?? row.runError ?? undefined)
+        ? (preferredRunError ?? row.error ?? row.runError ?? undefined)
         : (row.error ?? undefined);
       const effectiveError =
-        rawEffectiveError && isPlaceholder && !row.error && row.runId
+        rawEffectiveError &&
+        isPlaceholder &&
+        (row.error === null || preferredRunError !== null) &&
+        row.runId
           ? await get(
               formatChatRunErrorMessage({
                 chatThreadId: threadId,
@@ -473,7 +515,12 @@ function toStoredMessage(
       const message = {
         id: row.id,
         role,
-        content: row.content,
+        content: effectiveChatErrorContent({
+          content: row.content,
+          storedError: row.error,
+          preferredRunError,
+          effectiveError,
+        }),
         runId: row.runId ?? undefined,
         revokesMessageId: row.revokesMessageId ?? undefined,
         interruptsRunId: row.interruptsRunId ?? undefined,
@@ -502,13 +549,21 @@ function toPagedMessage(
   row: ChatMessageRow,
 ): Computed<Promise<PagedChatMessage>> {
   return computed(async (get): Promise<PagedChatMessage> => {
+    const preferredRunError = preferredActionableRunErrorForStoredTransient({
+      sequenceNumber: row.sequenceNumber,
+      storedError: row.error,
+      runError: row.runError,
+    });
     const isLegacyPlaceholder =
       row.sequenceNumber === null && row.content === null && !row.error;
-    const rawEffectiveError = isLegacyPlaceholder
-      ? (row.runError ?? undefined)
-      : (row.error ?? undefined);
+    const rawEffectiveError =
+      preferredRunError !== null || isLegacyPlaceholder
+        ? (preferredRunError ?? row.runError ?? undefined)
+        : (row.error ?? undefined);
     const effectiveError =
-      rawEffectiveError && isLegacyPlaceholder && row.runId
+      rawEffectiveError &&
+      (preferredRunError !== null || isLegacyPlaceholder) &&
+      row.runId
         ? await get(
             formatChatRunErrorMessage({
               chatThreadId: threadId,
@@ -526,7 +581,12 @@ function toPagedMessage(
     const message = {
       id: row.id,
       role,
-      content: row.content,
+      content: effectiveChatErrorContent({
+        content: row.content,
+        storedError: row.error,
+        preferredRunError,
+        effectiveError,
+      }),
       runId: row.runId ?? undefined,
       revokesMessageId: row.revokesMessageId ?? undefined,
       interruptsRunId: row.interruptsRunId ?? undefined,

--- a/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
@@ -62,6 +62,10 @@ const ACTIONABLE_ERROR_SNIPPETS = [
   "usage_limit",
   "usage-limit",
   "UsageLimit",
+  "purchase more credits",
+  "current quota",
+  "insufficient_quota",
+  "billing details",
 ] as const;
 
 const EXT_MIMETYPE_MAP: Readonly<Record<string, string>> = {

--- a/turbo/apps/web/app/api/zero/chat-threads/[id]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/chat-threads/[id]/__tests__/route.test.ts
@@ -596,6 +596,59 @@ describe("GET /api/zero/chat-threads/:id - Get Thread Detail", () => {
     }
   });
 
+  it("should use actionable run error over stored transient assistant error", async () => {
+    const transientError =
+      "Oops, something went wrong. Please try again later.";
+    const usageLimitError = "You've hit your usage limit.";
+    const createRes = await POST(
+      createTestRequest("http://localhost:3000/api/zero/chat-threads", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          agentId: testComposeId,
+          title: "Usage limit thread",
+        }),
+      }),
+    );
+    const { id: threadId } = await createRes.json();
+    const { runId } = await seedTestRun(testUserId, testComposeId, {
+      status: "running",
+      prompt: "hit limit",
+    });
+    await addTestRunToThread(threadId, runId, testUserId, "hit limit");
+    await transitionRunStatus(
+      runId,
+      {
+        status: "failed",
+        completedAt: new Date(),
+        error: usageLimitError,
+      },
+      ["pending", "running"],
+    );
+    await insertTestChatMessage({
+      chatThreadId: threadId,
+      userId: testUserId,
+      role: "assistant",
+      content: transientError,
+      error: transientError,
+      runId,
+    });
+
+    const response = await GET(
+      createTestRequest(
+        `http://localhost:3000/api/zero/chat-threads/${threadId}`,
+      ),
+    );
+    expect(response.status).toBe(200);
+    const data = await response.json();
+
+    const assistantMsg = data.chatMessages.find((m: { role: string }) => {
+      return m.role === "assistant";
+    });
+    expect(assistantMsg.error).toBe(usageLimitError);
+    expect(assistantMsg.content).toBe(usageLimitError);
+  });
+
   it("returns activeRuns with live status for non-terminal runs", async () => {
     // Setup: a thread with one queued run and one running run.
     // A completed run on the same thread is expected to be excluded.

--- a/turbo/apps/web/app/api/zero/chat-threads/[id]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/chat-threads/[id]/__tests__/route.test.ts
@@ -599,7 +599,8 @@ describe("GET /api/zero/chat-threads/:id - Get Thread Detail", () => {
   it("should use actionable run error over stored transient assistant error", async () => {
     const transientError =
       "Oops, something went wrong. Please try again later.";
-    const usageLimitError = "You've hit your usage limit.";
+    const codexCreditError =
+      "You've hit your usage limit. Visit https://chatgpt.com/codex/settings/usage to purchase more credits or try again at 3:14 PM.";
     const createRes = await POST(
       createTestRequest("http://localhost:3000/api/zero/chat-threads", {
         method: "POST",
@@ -621,7 +622,7 @@ describe("GET /api/zero/chat-threads/:id - Get Thread Detail", () => {
       {
         status: "failed",
         completedAt: new Date(),
-        error: usageLimitError,
+        error: codexCreditError,
       },
       ["pending", "running"],
     );
@@ -645,8 +646,8 @@ describe("GET /api/zero/chat-threads/:id - Get Thread Detail", () => {
     const assistantMsg = data.chatMessages.find((m: { role: string }) => {
       return m.role === "assistant";
     });
-    expect(assistantMsg.error).toBe(usageLimitError);
-    expect(assistantMsg.content).toBe(usageLimitError);
+    expect(assistantMsg.error).toBe(codexCreditError);
+    expect(assistantMsg.content).toBe(codexCreditError);
   });
 
   it("returns activeRuns with live status for non-terminal runs", async () => {

--- a/turbo/apps/web/app/api/zero/chat-threads/[id]/messages/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/chat-threads/[id]/messages/__tests__/route.test.ts
@@ -358,6 +358,57 @@ describe("GET /api/zero/chat-threads/:threadId/messages", () => {
     );
   });
 
+  it("should use actionable run error over stored transient paged assistant error", async () => {
+    const transientError =
+      "Oops, something went wrong. Please try again later.";
+    const usageLimitError = "You've hit your usage limit.";
+    const createRes = await POST(
+      createTestRequest("http://localhost:3000/api/zero/chat-threads", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ agentId: testComposeId }),
+      }),
+    );
+    const { id: threadId } = await createRes.json();
+
+    const { runId } = await seedTestRun(testUserId, testComposeId, {
+      status: "running",
+      prompt: "hit limit",
+    });
+    await addTestRunToThread(threadId, runId, testUserId, "hit limit");
+    await transitionRunStatus(
+      runId,
+      {
+        status: "failed",
+        completedAt: new Date(),
+        error: usageLimitError,
+      },
+      ["pending", "running"],
+    );
+    await insertTestChatMessage({
+      chatThreadId: threadId,
+      userId: testUserId,
+      role: "assistant",
+      content: transientError,
+      error: transientError,
+      runId,
+    });
+
+    const response = await GET(
+      createTestRequest(
+        `http://localhost:3000/api/zero/chat-threads/${threadId}/messages`,
+      ),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    const assistantMsg = data.messages.find((m: { role: string }) => {
+      return m.role === "assistant";
+    });
+    expect(assistantMsg.error).toBe(usageLimitError);
+    expect(assistantMsg.content).toBe(usageLimitError);
+  });
+
   it("should not expose run-level error on event-backed assistant rows", async () => {
     const createRes = await POST(
       createTestRequest("http://localhost:3000/api/zero/chat-threads", {

--- a/turbo/apps/web/app/api/zero/chat-threads/[id]/messages/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/chat-threads/[id]/messages/__tests__/route.test.ts
@@ -361,7 +361,8 @@ describe("GET /api/zero/chat-threads/:threadId/messages", () => {
   it("should use actionable run error over stored transient paged assistant error", async () => {
     const transientError =
       "Oops, something went wrong. Please try again later.";
-    const usageLimitError = "You've hit your usage limit.";
+    const codexCreditError =
+      "You've hit your usage limit. Visit https://chatgpt.com/codex/settings/usage to purchase more credits or try again at 3:14 PM.";
     const createRes = await POST(
       createTestRequest("http://localhost:3000/api/zero/chat-threads", {
         method: "POST",
@@ -381,7 +382,7 @@ describe("GET /api/zero/chat-threads/:threadId/messages", () => {
       {
         status: "failed",
         completedAt: new Date(),
-        error: usageLimitError,
+        error: codexCreditError,
       },
       ["pending", "running"],
     );
@@ -405,8 +406,8 @@ describe("GET /api/zero/chat-threads/:threadId/messages", () => {
     const assistantMsg = data.messages.find((m: { role: string }) => {
       return m.role === "assistant";
     });
-    expect(assistantMsg.error).toBe(usageLimitError);
-    expect(assistantMsg.content).toBe(usageLimitError);
+    expect(assistantMsg.error).toBe(codexCreditError);
+    expect(assistantMsg.content).toBe(codexCreditError);
   });
 
   it("should not expose run-level error on event-backed assistant rows", async () => {

--- a/turbo/apps/web/app/api/zero/chat-threads/[id]/messages/route.ts
+++ b/turbo/apps/web/app/api/zero/chat-threads/[id]/messages/route.ts
@@ -7,7 +7,11 @@ import {
   getPagedMessages,
   resolveAttachFileUrls,
 } from "../../../../../../src/lib/zero/chat-thread";
-import { formatChatRunErrorMessage } from "../../../../../../src/lib/zero/chat-thread/chat-run-error-message";
+import {
+  effectiveChatErrorContent,
+  formatChatRunErrorMessage,
+  preferredActionableRunErrorForStoredTransient,
+} from "../../../../../../src/lib/zero/chat-thread/chat-run-error-message";
 import { isNotFound } from "@vm0/api-services/errors";
 
 const router = tsr.router(chatThreadMessagesContract, {
@@ -37,15 +41,25 @@ const router = tsr.router(chatThreadMessagesContract, {
 
       const messages = await Promise.all(
         page.messages.map(async (row) => {
-          // Legacy placeholder rows (sequenceNumber IS NULL) fall back to runError;
-          // event-backed rows and error rows use their own error field.
+          // Legacy placeholder rows (sequenceNumber IS NULL) fall back to runError.
+          // Older transient error rows can also use an actionable runError so the
+          // user sees the concrete cause instead of the generic fallback.
+          const preferredRunError =
+            preferredActionableRunErrorForStoredTransient({
+              sequenceNumber: row.sequenceNumber,
+              storedError: row.error,
+              runError: row.runError,
+            });
           const isLegacyPlaceholder =
             row.sequenceNumber === null && row.content === null && !row.error;
-          const rawEffectiveError = isLegacyPlaceholder
-            ? (row.runError ?? undefined)
-            : (row.error ?? undefined);
+          const rawEffectiveError =
+            preferredRunError !== null || isLegacyPlaceholder
+              ? (preferredRunError ?? row.runError ?? undefined)
+              : (row.error ?? undefined);
           const effectiveError =
-            rawEffectiveError && isLegacyPlaceholder && row.runId
+            rawEffectiveError &&
+            (preferredRunError !== null || isLegacyPlaceholder) &&
+            row.runId
               ? await formatChatRunErrorMessage({
                   chatThreadId: params.threadId,
                   runId: row.runId,
@@ -60,7 +74,12 @@ const router = tsr.router(chatThreadMessagesContract, {
           const message = {
             id: row.id,
             role,
-            content: row.content,
+            content: effectiveChatErrorContent({
+              content: row.content,
+              storedError: row.error,
+              preferredRunError,
+              effectiveError,
+            }),
             runId: row.runId ?? undefined,
             revokesMessageId: row.revokesMessageId ?? undefined,
             interruptsRunId: row.interruptsRunId ?? undefined,

--- a/turbo/apps/web/src/__tests__/db-test-seeders/agents.ts
+++ b/turbo/apps/web/src/__tests__/db-test-seeders/agents.ts
@@ -588,6 +588,7 @@ export async function insertTestChatMessage(params: {
   userId?: string;
   role: "user" | "assistant";
   content: string | null;
+  error?: string | null;
   runId?: string | null;
   interruptsRunId?: string | null;
   archivedAt?: Date | null;
@@ -601,6 +602,7 @@ export async function insertTestChatMessage(params: {
       chatThreadId: params.chatThreadId,
       role: params.role,
       content: params.content,
+      error: params.error ?? null,
       runId: params.runId ?? null,
       interruptsRunId: params.interruptsRunId ?? null,
       archivedAt: params.archivedAt ?? null,

--- a/turbo/apps/web/src/lib/zero/chat-thread/chat-run-error-message.ts
+++ b/turbo/apps/web/src/lib/zero/chat-thread/chat-run-error-message.ts
@@ -29,6 +29,40 @@ function isActionableRunError(errorMessage: string): boolean {
   });
 }
 
+export function preferredActionableRunErrorForStoredTransient(params: {
+  readonly sequenceNumber: number | null;
+  readonly storedError: string | null;
+  readonly runError: string | null;
+}): string | null {
+  const storedError = params.storedError?.trim();
+  const runError = params.runError?.trim();
+  if (
+    params.sequenceNumber !== null ||
+    storedError !== CHAT_RUN_TRANSIENT_ERROR_MESSAGE ||
+    !runError ||
+    !isActionableRunError(runError)
+  ) {
+    return null;
+  }
+  return params.runError;
+}
+
+export function effectiveChatErrorContent(params: {
+  readonly content: string | null;
+  readonly storedError: string | null;
+  readonly preferredRunError: string | null;
+  readonly effectiveError: string | undefined;
+}): string | null {
+  if (
+    params.preferredRunError !== null &&
+    params.effectiveError !== undefined &&
+    params.content === params.storedError
+  ) {
+    return params.effectiveError;
+  }
+  return params.content;
+}
+
 function buildReportableErrorMessage(runId: string): string {
   return `${CHAT_RUN_REPORTABLE_ERROR_MESSAGE} [Report this issue](/runs/${encodeURIComponent(runId)}/report-error)`;
 }

--- a/turbo/apps/web/src/lib/zero/chat-thread/chat-run-error-message.ts
+++ b/turbo/apps/web/src/lib/zero/chat-thread/chat-run-error-message.ts
@@ -20,6 +20,10 @@ const ACTIONABLE_ERROR_SNIPPETS = [
   "usage_limit",
   "usage-limit",
   "UsageLimit",
+  "purchase more credits",
+  "current quota",
+  "insufficient_quota",
+  "billing details",
 ] as const;
 
 function isActionableRunError(errorMessage: string): boolean {

--- a/turbo/apps/web/src/lib/zero/chat-thread/chat-thread-service.ts
+++ b/turbo/apps/web/src/lib/zero/chat-thread/chat-thread-service.ts
@@ -21,7 +21,11 @@ import {
   getLatestSessionIdForThread,
   publishThreadListChanged,
 } from "./chat-message-service";
-import { formatChatRunErrorMessage } from "./chat-run-error-message";
+import {
+  effectiveChatErrorContent,
+  formatChatRunErrorMessage,
+  preferredActionableRunErrorForStoredTransient,
+} from "./chat-run-error-message";
 import {
   type ChatThreadArtifactRun,
   type ChatThreadDetail,
@@ -631,12 +635,22 @@ export async function getChatThreadMessages(
       // The placeholder row (sequence_number IS NULL) is the only row that
       // falls back to agent_runs.error, covering the case where the terminal
       // callback failed to deliver and chat_messages.error was never written.
+      // If an older row already stored the transient generic message, prefer an
+      // actionable run-level error so the user can see the concrete cause.
       const isPlaceholder = row.sequenceNumber === null;
+      const preferredRunError = preferredActionableRunErrorForStoredTransient({
+        sequenceNumber: row.sequenceNumber,
+        storedError: row.error,
+        runError: row.runError,
+      });
       const rawEffectiveError = isPlaceholder
-        ? (row.error ?? row.runError ?? undefined)
+        ? (preferredRunError ?? row.error ?? row.runError ?? undefined)
         : (row.error ?? undefined);
       const effectiveError =
-        rawEffectiveError && isPlaceholder && !row.error && row.runId
+        rawEffectiveError &&
+        isPlaceholder &&
+        (row.error === null || preferredRunError !== null) &&
+        row.runId
           ? await formatChatRunErrorMessage({
               chatThreadId: threadId,
               runId: row.runId,
@@ -653,7 +667,12 @@ export async function getChatThreadMessages(
       const message = {
         id: row.id,
         role,
-        content: row.content,
+        content: effectiveChatErrorContent({
+          content: row.content,
+          storedError: row.error,
+          preferredRunError,
+          effectiveError,
+        }),
         runId: row.runId ?? undefined,
         revokesMessageId: row.revokesMessageId ?? undefined,
         interruptsRunId: row.interruptsRunId ?? undefined,


### PR DESCRIPTION
## Summary

- Capture masked Codex terminal failure diagnostics from stdout JSONL events and carry them through `CliExecutionResult`.
- Prefer the captured Codex diagnostic over stderr noise when building the final guest-agent failure message.
- Write the real failure message to the runner-readable checkpoint error file so fallback `/complete` does not store `Run failed without error message`.
- Keep specific Codex diagnostics from being overwritten by later generic failure events.
- Treat Codex credit/quota/billing messages as actionable chat run errors in both API and web read paths.

## Context

Observed run fields:

- `modelProvider`: `codex-oauth-token`
- `selectedModel`: `gpt-5.5`
- Codex JSONL events included `error` and `turn.failed` with `You've hit your usage limit...purchase more credits...`
- Stored run error ended up as `Run failed without error message`

## Tests

- `git diff --check`
- `cargo fmt --manifest-path crates/Cargo.toml --package guest-agent --check`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --lib`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --bin guest-agent`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --test codex_jsonl_failure_logging`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-agent --all-targets -- -D warnings`
- `pnpm --dir turbo exec prettier --check 'apps/api/src/signals/services/zero-chat-thread.service.ts' 'apps/api/src/signals/routes/__tests__/zero-chat-threads.test.ts' 'apps/api/src/signals/routes/__tests__/zero-chat-threads-messages.test.ts' 'apps/web/src/lib/zero/chat-thread/chat-run-error-message.ts' 'apps/web/app/api/zero/chat-threads/[id]/__tests__/route.test.ts' 'apps/web/app/api/zero/chat-threads/[id]/messages/__tests__/route.test.ts'`
- `pnpm --dir turbo -F api lint`
- `pnpm --dir turbo -F web lint`
- `pnpm --dir turbo -F api check-types`
- `pnpm --dir turbo -F web check-types`

Targeted vitest suites for the API/web read paths were attempted but did not run assertions in this local checkout because `turbo/packages/connectors/src/firewalls/bentoml.generated.ts` is missing during import.
