### PR TITLE
fix: preserve codex jsonl failure diagnostics

### DIFF
--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -90,6 +90,14 @@ pub struct CliExecutionResult {
     /// Claude Code's final result metadata, when a terminal result event was
     /// observed. Codex uses its own event schema and leaves this unset.
     pub claude_result: Option<ClaudeResultSummary>,
+
+    /// Best-effort, secret-masked terminal failure diagnostic parsed from CLI
+    /// stdout JSONL.
+    ///
+    /// Codex reports terminal failures as JSONL events on stdout, not stderr.
+    /// Keeping the diagnostic here lets the guest-agent surface the actual
+    /// failure reason in its final run error.
+    pub failure_diagnostic: Option<String>,
 }
 
 /// Execute the CLI process, streaming JSONL events and racing against heartbeat.
@@ -247,6 +255,7 @@ pub async fn execute_cli(
     let mut last_read_event_at: Option<Instant> = None;
     let mut cli_exit_at: Option<Instant> = None;
     let mut claude_result = None;
+    let mut failure_diagnostic = None;
     let event_result: Result<(), AgentError> = loop {
         tokio::select! {
             line_result = reader.next_line(), if !stdout_eof => {
@@ -294,12 +303,19 @@ pub async fn execute_cli(
                                 && let Some(diagnostic) =
                                     events::masked_codex_failure_diagnostic(&event, masker)
                             {
+                                let message = diagnostic.message;
                                 log_warn!(
                                     LOG_TAG,
                                     "Codex JSONL failure event seq={seq} type={}: {}",
                                     diagnostic.event_type,
-                                    diagnostic.message
+                                    message
                                 );
+                                if should_replace_failure_diagnostic(
+                                    failure_diagnostic.as_deref(),
+                                    &message,
+                                ) {
+                                    failure_diagnostic = Some(message);
+                                }
                             }
                             // Capture checkpoint metadata before event payload preparation
                             // mutates the event through masking.
@@ -603,5 +619,37 @@ pub async fn execute_cli(
         stderr_lines: masked_stderr_lines,
         last_event_sequence,
         claude_result,
+        failure_diagnostic,
     })
+}
+
+fn should_replace_failure_diagnostic(existing: Option<&str>, candidate: &str) -> bool {
+    match existing {
+        None => true,
+        Some(existing) => {
+            !events::is_generic_codex_failure_diagnostic(candidate)
+                || events::is_generic_codex_failure_diagnostic(existing)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::should_replace_failure_diagnostic;
+
+    #[test]
+    fn specific_codex_failure_diagnostic_survives_later_generic_event() {
+        assert!(!should_replace_failure_diagnostic(
+            Some("You've hit your usage limit."),
+            "turn failed",
+        ));
+    }
+
+    #[test]
+    fn specific_codex_failure_diagnostic_replaces_generic_event() {
+        assert!(should_replace_failure_diagnostic(
+            Some("error"),
+            "You've hit your usage limit.",
+        ));
+    }
 }

--- a/crates/guest-agent/src/events.rs
+++ b/crates/guest-agent/src/events.rs
@@ -87,6 +87,10 @@ pub(crate) fn masked_codex_failure_diagnostic(
     })
 }
 
+pub(crate) fn is_generic_codex_failure_diagnostic(message: &str) -> bool {
+    matches!(message.trim(), "error" | "turn failed" | "turn interrupted")
+}
+
 fn extract_codex_failure_diagnostic(event: &Value) -> Option<CodexFailureDiagnostic> {
     match event.get("type").and_then(Value::as_str)? {
         "error" => Some(CodexFailureDiagnostic {

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -158,6 +158,7 @@ async fn execute(
     {
         let msg = format!("Working dir setup failed: {e}");
         log_error!(LOG_TAG, "{msg}");
+        write_guest_error_file(&msg);
         record_sandbox_op("working_dir_setup", wd_start.elapsed(), false, Some(&msg));
         return 1;
     }
@@ -195,7 +196,11 @@ async fn execute(
                     (
                         cli_exit_code,
                         cli_exit_code,
-                        cli_failure_message(cli_exit_code, &cli_result.stderr_lines),
+                        cli_failure_message(
+                            cli_exit_code,
+                            &cli_result.stderr_lines,
+                            cli_result.failure_diagnostic.as_deref(),
+                        ),
                         false,
                     )
                 } else if env::has_api()
@@ -211,7 +216,6 @@ async fn execute(
                             Some(msg),
                         );
                         log_info!(LOG_TAG, "{msg}");
-                        let _ = std::fs::write(paths::checkpoint_error_file(), msg);
                         (cli_exit_code, 1, msg.to_string(), true)
                     } else {
                         (0, 0, String::new(), false)
@@ -242,8 +246,11 @@ async fn execute(
         cli_exit_code,
         exit_code,
         cli_elapsed,
-        last_event_sequence,
-        skip_recovery_checkpoint_for_no_history,
+        CompletionState {
+            last_event_sequence,
+            failure_message: (exit_code != 0).then_some(error_message.as_str()),
+            skip_recovery_checkpoint_for_no_history,
+        },
         telemetry,
         &http,
     )
@@ -282,7 +289,33 @@ fn history_target_unavailable(path: &Path) -> bool {
     }
 }
 
-fn cli_failure_message(code: i32, stderr_lines: &[String]) -> String {
+fn write_guest_error_file(message: &str) {
+    let message = message.trim();
+    if message.is_empty() {
+        return;
+    }
+
+    if let Err(e) = std::fs::write(paths::checkpoint_error_file(), message) {
+        log_warn!(LOG_TAG, "Failed to write guest error file: {e}");
+    }
+}
+
+fn cli_failure_message(
+    code: i32,
+    stderr_lines: &[String],
+    failure_diagnostic: Option<&str>,
+) -> String {
+    if let Some(message) = failure_diagnostic.and_then(|message| {
+        let message = message.trim();
+        if message.is_empty() {
+            None
+        } else {
+            Some(message)
+        }
+    }) {
+        return message.to_string();
+    }
+
     if stderr_lines.is_empty() {
         return format!("Agent exited with code {code}");
     }
@@ -331,18 +364,34 @@ fn truncate_cli_stderr_line(line: &str) -> std::borrow::Cow<'_, str> {
     std::borrow::Cow::Owned(truncated)
 }
 
+struct CompletionState<'a> {
+    last_event_sequence: Option<u32>,
+    failure_message: Option<&'a str>,
+    skip_recovery_checkpoint_for_no_history: bool,
+}
+
 async fn complete_execution(
     cli_exit_code: i32,
     mut exit_code: i32,
     cli_elapsed: Duration,
-    last_event_sequence: Option<u32>,
-    skip_recovery_checkpoint_for_no_history: bool,
+    state: CompletionState<'_>,
     telemetry: &Telemetry,
     http: &HttpClient,
 ) -> i32 {
+    let has_failure_message = state
+        .failure_message
+        .is_some_and(|message| !message.trim().is_empty());
+    if let Some(message) = state.failure_message {
+        write_guest_error_file(message);
+    }
+
     // Check if any events failed to send (before logging execution result)
     if std::path::Path::new(paths::event_error_flag()).exists() {
-        log_error!(LOG_TAG, "Some events failed to send, marking run as failed");
+        let msg = "Some events failed to send, marking run as failed";
+        log_error!(LOG_TAG, "{msg}");
+        if !has_failure_message {
+            write_guest_error_file(msg);
+        }
         exit_code = 1;
     }
 
@@ -396,7 +445,7 @@ async fn complete_execution(
                     http,
                     env::sandbox_id(),
                     env::sandbox_reuse_result(),
-                    last_event_sequence,
+                    state.last_event_sequence,
                 )
                 .await;
                 final_telemetry(telemetry).await;
@@ -409,7 +458,7 @@ async fn complete_execution(
                     "✗ Checkpoint failed ({}s)",
                     cp_start.elapsed().as_secs()
                 );
-                let _ = std::fs::write(paths::checkpoint_error_file(), &msg);
+                write_guest_error_file(&msg);
                 exit_code = 1;
 
                 // Failure path: don't call /complete from guest. The runner's
@@ -422,7 +471,7 @@ async fn complete_execution(
     } else {
         if cli_exit_code == 0 && exit_code == 0 {
             log_info!(LOG_TAG, "{agent_type} completed successfully");
-        } else if skip_recovery_checkpoint_for_no_history {
+        } else if state.skip_recovery_checkpoint_for_no_history {
             log_info!(
                 LOG_TAG,
                 "{agent_type} completed without resumable session history; marking run as failed"
@@ -435,7 +484,7 @@ async fn complete_execution(
         }
 
         if env::has_api() {
-            if skip_recovery_checkpoint_for_no_history {
+            if state.skip_recovery_checkpoint_for_no_history {
                 log_info!(
                     LOG_TAG,
                     "Skipping recovery checkpoint because no session history was created"
@@ -514,7 +563,7 @@ mod tests {
             .chain(std::iter::once(long_line.clone()))
             .chain((0..(MAX_LOGGED_CLI_STDERR_LINES - 2)).map(|i| format!("extra line {i}")))
             .collect::<Vec<_>>();
-        let msg = cli_failure_message(1, &stderr_lines);
+        let msg = cli_failure_message(1, &stderr_lines, None);
         assert!(
             !msg.contains("prefix line"),
             "returned error message should omit older stderr lines"
@@ -575,7 +624,7 @@ mod tests {
             .chain((1..MAX_LOGGED_CLI_STDERR_LINES).map(|i| format!("line {i}")))
             .collect::<Vec<_>>();
 
-        let msg = cli_failure_message(1, &stderr_lines);
+        let msg = cli_failure_message(1, &stderr_lines, None);
         assert!(
             msg.contains(&exact_limit_line),
             "returned error message should preserve line at exact size limit"
@@ -609,7 +658,7 @@ mod tests {
 
         let prefix = "x".repeat(MAX_LOGGED_CLI_STDERR_LINE_BYTES - 1);
         let stderr_line = format!("{prefix}é-tail");
-        let msg = cli_failure_message(1, &[stderr_line]);
+        let msg = cli_failure_message(1, &[stderr_line], None);
 
         assert!(
             msg.contains(&prefix),
@@ -636,12 +685,30 @@ mod tests {
     }
 
     #[test]
+    fn cli_failure_message_prefers_codex_failure_diagnostic() {
+        let stderr_lines = vec!["background task noise".to_string()];
+        let msg = cli_failure_message(
+            1,
+            &stderr_lines,
+            Some(
+                "You've hit your usage limit. Visit https://chatgpt.com/codex/settings/usage to purchase more credits.",
+            ),
+        );
+
+        assert_eq!(
+            msg,
+            "You've hit your usage limit. Visit https://chatgpt.com/codex/settings/usage to purchase more credits."
+        );
+    }
+
+    #[test]
     fn is_claude_zero_turn_result_requires_all_guards() {
         let zero_turn = cli::CliExecutionResult {
             exit_code: 0,
             stderr_lines: Vec::new(),
             last_event_sequence: None,
             claude_result: Some(cli::ClaudeResultSummary { num_turns: Some(0) }),
+            failure_diagnostic: None,
         };
         let one_turn = cli::CliExecutionResult {
             claude_result: Some(cli::ClaudeResultSummary { num_turns: Some(1) }),
@@ -837,11 +904,27 @@ mod tests {
         let masker = Arc::new(masker::SecretMasker::from_env());
         let http = HttpClient::new().unwrap();
         let telemetry = Telemetry::spawn(masker, http.clone());
-        let exit_code =
-            complete_execution(0, 1, Duration::ZERO, None, true, &telemetry, &http).await;
+        let failure_message = "Claude Code emitted a zero-turn result without creating session history; skipping checkpoint";
+        let exit_code = complete_execution(
+            0,
+            1,
+            Duration::ZERO,
+            CompletionState {
+                last_event_sequence: None,
+                failure_message: Some(failure_message),
+                skip_recovery_checkpoint_for_no_history: true,
+            },
+            &telemetry,
+            &http,
+        )
+        .await;
         telemetry.shutdown().await;
 
         assert_eq!(exit_code, 1);
+        assert_eq!(
+            std::fs::read_to_string(paths::checkpoint_error_file()).unwrap(),
+            failure_message
+        );
         assert_eq!(prepare_mock.calls_async().await, 0);
         assert_eq!(checkpoint_mock.calls_async().await, 0);
 
@@ -920,14 +1003,26 @@ mod tests {
         let masker = Arc::new(masker::SecretMasker::from_env());
         let http = HttpClient::new().unwrap();
         let telemetry = Telemetry::spawn(masker, http.clone());
-        let exit_code =
-            complete_execution(1, 1, Duration::ZERO, None, false, &telemetry, &http).await;
+        let failure_message = "You've hit your usage limit.";
+        let exit_code = complete_execution(
+            1,
+            1,
+            Duration::ZERO,
+            CompletionState {
+                last_event_sequence: None,
+                failure_message: Some(failure_message),
+                skip_recovery_checkpoint_for_no_history: false,
+            },
+            &telemetry,
+            &http,
+        )
+        .await;
         telemetry.shutdown().await;
 
         assert_eq!(exit_code, 1);
-        assert!(
-            !std::path::Path::new(paths::checkpoint_error_file()).exists(),
-            "recovery checkpoint failure must not write the success-path checkpoint error file"
+        assert_eq!(
+            std::fs::read_to_string(paths::checkpoint_error_file()).unwrap(),
+            failure_message
         );
         prepare_mock.assert_calls_async(1).await;
         upload_mock.assert_calls_async(1).await;

--- a/crates/guest-agent/tests/codex_jsonl_failure_logging.rs
+++ b/crates/guest-agent/tests/codex_jsonl_failure_logging.rs
@@ -50,6 +50,10 @@ async fn codex_jsonl_error_event_is_written_to_system_log() -> Result<(), Box<dy
     .expect("execute_cli should return promptly")?;
 
     assert_eq!(cli_result.exit_code, common::CLEAN_EXIT);
+    assert_eq!(
+        cli_result.failure_diagnostic.as_deref(),
+        Some("Mock error event for fixture testing")
+    );
     let system_log = std::fs::read_to_string(&system_log_path)?;
     assert!(
         system_log.contains(

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -683,8 +683,8 @@ async fn run_in_sandbox(
             Some(stderr)
         } else {
             // Stderr is empty (redirected to log file). Check for a structured
-            // error file written by the guest-agent (for checkpoint or
-            // no-history finalization failures).
+            // error file written by the guest-agent for final failure
+            // handoff.
             read_guest_error_file(sandbox, context.run_id).await
         }
     } else {
@@ -696,9 +696,9 @@ async fn run_in_sandbox(
 
 /// Read a structured error file from the guest filesystem.
 ///
-/// The guest-agent writes run-finalization errors to
-/// `/tmp/vm0-checkpoint-error-{run_id}` so the runner can surface them even
-/// though stdout/stderr are redirected to the system log file.
+/// The guest-agent writes final failure messages to
+/// `/tmp/vm0-checkpoint-error-{run_id}` so the runner can surface them through
+/// `/complete` even though stdout/stderr are redirected to the system log file.
 ///
 /// NOTE: This path must match the convention in `crates/guest-agent/src/paths.rs`
 /// (`checkpoint_error_file()`). The runner and guest-agent are separate binaries


### PR DESCRIPTION
## Summary

- Capture masked Codex terminal failure diagnostics from stdout JSONL events and carry them through `CliExecutionResult`.
- Prefer the captured Codex diagnostic over stderr noise when building the final guest-agent failure message.
- Write non-empty guest-agent failure messages to the runner-readable checkpoint error file so runner fallback `/complete` does not store `Run failed without error message`.
- Keep specific Codex diagnostics from being overwritten by later generic failure events.

## Context

Observed run fields:

- `modelProvider`: `codex-oauth-token`
- `selectedModel`: `gpt-5.5`
- Codex JSONL events included `error` and `turn.failed` with `You've hit your usage limit...purchase more credits...`
- Stored run error ended up as `Run failed without error message`

This PR is root-cause-only. It intentionally does not include the older web/API chat read-path changes from the closed PR.

## Tests

- `git diff --cached --check`
- `cargo fmt --manifest-path crates/Cargo.toml --package guest-agent --check`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --lib`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --bin guest-agent`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --test codex_jsonl_failure_logging`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-agent --all-targets -- -D warnings`
- pre-commit hook: `cargo-fmt`, `cargo-doc`, `cargo-clippy`
