### PR TITLE
fix: disable api sentry outside production

### DIFF
--- a/turbo/apps/api/src/__tests__/instrument.test.ts
+++ b/turbo/apps/api/src/__tests__/instrument.test.ts
@@ -42,6 +42,18 @@ describe("instrument", () => {
     expect(context.mocks.sentry.init).not.toHaveBeenCalled();
   });
 
+  it("does not initialize Sentry outside production", async () => {
+    await importInstrument((envModule) => {
+      envModule.mockEnv(
+        "SENTRY_DSN",
+        "https://examplePublicKey@o0.ingest.sentry.io/0",
+      );
+      envModule.mockEnv("ENV", "preview");
+    });
+
+    expect(context.mocks.sentry.init).not.toHaveBeenCalled();
+  });
+
   it("initializes Sentry with api metadata", async () => {
     await importInstrument((envModule) => {
       envModule.mockEnv(

--- a/turbo/apps/api/src/instrument.ts
+++ b/turbo/apps/api/src/instrument.ts
@@ -31,15 +31,17 @@ function setupOpenTelemetry() {
 
 function setupSentry() {
   const dsn = env("SENTRY_DSN");
-  const release = env("GIT_COMMIT_SHA");
+  const environment = env("ENV");
 
-  if (!dsn) {
+  if (!dsn || environment !== "production") {
     return;
   }
 
+  const release = env("GIT_COMMIT_SHA");
+
   init({
     dsn,
-    environment: env("ENV"),
+    environment,
     initialScope: {
       tags: {
         app: "api",


### PR DESCRIPTION
## Summary
- skip API Sentry initialization when ENV is not production
- keep OpenTelemetry/Axiom initialization unchanged
- add regression coverage for preview with SENTRY_DSN configured

## Tests
- pnpm -F api exec vitest run src/__tests__/instrument.test.ts
- pnpm -F api check-types