### PR TITLE
fix: make vsock-host request writes cancel-safe

### DIFF
--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -152,7 +152,7 @@ enum PendingNormalOperation {
     Composite(NormalOperationTransitionHandle),
 }
 
-struct PendingNormalRequestWriteGuard {
+struct RequestWriteGuard {
     shared: Arc<Shared>,
     write_started: bool,
     write_returned: bool,
@@ -170,7 +170,7 @@ impl Drop for PendingRequestGuard {
     }
 }
 
-impl PendingNormalRequestWriteGuard {
+impl RequestWriteGuard {
     fn new(shared: Arc<Shared>) -> Self {
         Self {
             shared,
@@ -188,7 +188,7 @@ impl PendingNormalRequestWriteGuard {
     }
 }
 
-impl Drop for PendingNormalRequestWriteGuard {
+impl Drop for RequestWriteGuard {
     fn drop(&mut self) {
         if self.write_started && !self.write_returned {
             self.shared.poison_connection();
@@ -511,6 +511,24 @@ async fn request_on_shared(
     request_raw_on_shared(shared, msg_type, seq, payload, timeout).await
 }
 
+async fn write_request_frame(
+    shared: &Arc<Shared>,
+    data: &[u8],
+    before_write: impl FnOnce() -> io::Result<()>,
+) -> io::Result<()> {
+    let mut write_guard = RequestWriteGuard::new(Arc::clone(shared));
+    let mut writer = shared.writer.lock().await;
+    before_write()?;
+    write_guard.mark_started();
+    if let Err(error) = writer.write_all(data).await {
+        write_guard.mark_returned();
+        shared.poison_connection();
+        return Err(error);
+    }
+    write_guard.mark_returned();
+    Ok(())
+}
+
 /// Send a request with a pre-allocated sequence number.
 async fn request_raw_on_shared(
     shared: &Arc<Shared>,
@@ -551,9 +569,11 @@ async fn request_raw_on_shared(
     }
     let _pending_guard = PendingRequestGuard::new(Arc::clone(shared), seq);
 
-    // The guard removes the pending entry on write failure, timeout, or
-    // cancellation before reader_loop dispatches a response.
-    shared.writer.lock().await.write_all(&data).await?;
+    // The pending guard removes the pending entry on write failure, timeout,
+    // or cancellation before reader_loop dispatches a response. The write
+    // helper separately poisons the connection if cancellation interrupts an
+    // in-progress frame write.
+    write_request_frame(shared, &data, || Ok(())).await?;
 
     // `rx` returns `Ok(msg)` when the reader dispatches a response and
     // `Err(RecvError)` when `close()` drops the `Connected` variant. The
@@ -642,18 +662,10 @@ async fn request_raw_on_shared_with_composite_operation(
     }
     let _pending_guard = PendingRequestGuard::new(Arc::clone(shared), seq);
 
-    let mut write_guard = PendingNormalRequestWriteGuard::new(Arc::clone(shared));
-    let mut writer = shared.writer.lock().await;
-    normal_operation.mark_possible_guest_write_started()?;
-    write_guard.mark_started();
-    if let Err(error) = writer.write_all(&data).await {
-        write_guard.mark_returned();
-        shared.poison_connection();
-        return Err(error);
-    }
-    write_guard.mark_returned();
-    drop(writer);
-    drop(write_guard);
+    write_request_frame(shared, &data, || {
+        normal_operation.mark_possible_guest_write_started()
+    })
+    .await?;
 
     tokio::select! {
         biased;
@@ -705,18 +717,10 @@ async fn normal_request_raw_on_shared(
     }
     let _pending_guard = PendingRequestGuard::new(Arc::clone(shared), seq);
 
-    let mut write_guard = PendingNormalRequestWriteGuard::new(Arc::clone(shared));
-    let mut writer = shared.writer.lock().await;
-    mark_pending_normal_operation_possible_guest_write(shared, seq)?;
-    write_guard.mark_started();
-    if let Err(error) = writer.write_all(&data).await {
-        write_guard.mark_returned();
-        shared.poison_connection();
-        return Err(error);
-    }
-    write_guard.mark_returned();
-    drop(writer);
-    drop(write_guard);
+    write_request_frame(shared, &data, || {
+        mark_pending_normal_operation_possible_guest_write(shared, seq)
+    })
+    .await?;
 
     tokio::select! {
         biased;

--- a/crates/vsock-host/src/tests/connection.rs
+++ b/crates/vsock-host/src/tests/connection.rs
@@ -10,9 +10,9 @@ use vsock_proto::{
 };
 
 use super::support::{
-    drop_started_pending_normal_request_write_guard, fence_normal_operations, host_from_stream,
-    make_pair, mock_handshake, normal_operation_readiness, poison_connection, read_guest_message,
-    send_exec_result, setup_host_and_guest,
+    drop_idle_request_write_guard, drop_started_request_write_guard, fence_normal_operations,
+    host_from_stream, is_connected, make_pair, mock_handshake, normal_operation_readiness,
+    poison_connection, read_guest_message, send_exec_result, setup_host_and_guest,
 };
 use crate::{VsockHost, operation_tracker::NormalOperationReadiness};
 
@@ -253,6 +253,7 @@ async fn quiesce_operations_times_out_and_late_ack_is_ignored() {
         .await
         .unwrap()
         .unwrap();
+    assert!(is_connected(&host));
     send_late_ack.send(()).unwrap();
     host.resume_operations(Duration::from_secs(2))
         .await
@@ -392,10 +393,23 @@ async fn connection_poison_marks_normal_operations_not_parkable() {
 }
 
 #[tokio::test]
-async fn cancelled_normal_request_frame_write_poisons_connection() {
+async fn cancelled_request_before_frame_write_does_not_poison_connection() {
     let (host, _guest) = setup_host_and_guest().await;
 
-    drop_started_pending_normal_request_write_guard(&host);
+    drop_idle_request_write_guard(&host);
+
+    assert!(is_connected(&host));
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Idle
+    );
+}
+
+#[tokio::test]
+async fn cancelled_request_frame_write_poisons_connection() {
+    let (host, _guest) = setup_host_and_guest().await;
+
+    drop_started_request_write_guard(&host);
 
     host.wait_until_closed(Duration::from_secs(5))
         .await

--- a/crates/vsock-host/src/tests/support.rs
+++ b/crates/vsock-host/src/tests/support.rs
@@ -67,8 +67,13 @@ pub(crate) fn poison_connection(host: &VsockHost) {
     host.shared.poison_connection();
 }
 
-pub(crate) fn drop_started_pending_normal_request_write_guard(host: &VsockHost) {
-    let mut guard = crate::PendingNormalRequestWriteGuard::new(Arc::clone(&host.shared));
+pub(crate) fn drop_idle_request_write_guard(host: &VsockHost) {
+    let guard = crate::RequestWriteGuard::new(Arc::clone(&host.shared));
+    drop(guard);
+}
+
+pub(crate) fn drop_started_request_write_guard(host: &VsockHost) {
+    let mut guard = crate::RequestWriteGuard::new(Arc::clone(&host.shared));
     guard.mark_started();
     drop(guard);
 }


### PR DESCRIPTION
## Summary

- add a shared cancel-safe request frame write helper for `vsock-host` request-style writes
- route plain, normal, and composite normal request writes through the helper
- add regression coverage for pre-write and in-progress request write cancellation behavior
- assert lifecycle request timeout after a completed frame write keeps the connection usable

Closes #13714

## Tests

- `cargo test --manifest-path crates/Cargo.toml -p vsock-host cancelled_request -- --nocapture`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-host quiesce_operations_times_out_and_late_ack_is_ignored -- --nocapture`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-host test_spawn_process_control_timeout_cleans_pending_without_poisoning -- --nocapture`
- `cargo fmt --manifest-path crates/vsock-host/Cargo.toml -- --check`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-host`
