### PR TITLE
fix: preserve stderr for generic codex failures

### DIFF
--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -312,7 +312,8 @@ fn cli_failure_message(
         } else {
             Some(message)
         }
-    }) {
+    }) && (!is_generic_codex_failure_diagnostic(message) || stderr_lines.is_empty())
+    {
         return message.to_string();
     }
 
@@ -343,6 +344,10 @@ fn cli_failure_message(
         message_lines.push(line.into_owned());
     }
     message_lines.join(" ")
+}
+
+fn is_generic_codex_failure_diagnostic(message: &str) -> bool {
+    matches!(message.trim(), "error" | "turn failed" | "turn interrupted")
 }
 
 fn truncate_cli_stderr_line(line: &str) -> std::borrow::Cow<'_, str> {
@@ -699,6 +704,21 @@ mod tests {
             msg,
             "You've hit your usage limit. Visit https://chatgpt.com/codex/settings/usage to purchase more credits."
         );
+    }
+
+    #[test]
+    fn cli_failure_message_uses_stderr_over_generic_codex_failure_diagnostic() {
+        let stderr_lines = vec!["specific stderr failure".to_string()];
+        let msg = cli_failure_message(1, &stderr_lines, Some("turn failed"));
+
+        assert_eq!(msg, "specific stderr failure");
+    }
+
+    #[test]
+    fn cli_failure_message_uses_generic_codex_failure_diagnostic_without_stderr() {
+        let msg = cli_failure_message(1, &[], Some("turn failed"));
+
+        assert_eq!(msg, "turn failed");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Keep specific Codex JSONL diagnostics ahead of stderr noise.
- Fall back to stderr when Codex only produced a generic diagnostic such as `turn failed`.
- Add regression coverage for generic-diagnostic priority with and without stderr.

## Context

Follow-up split from review of #13713 after that PR merged. The merged PR preserves real Codex diagnostics, but generic fallback diagnostics should not hide a more actionable stderr message.

## Tests

- `cargo fmt --manifest-path crates/Cargo.toml --package guest-agent --check`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent cli_failure_message`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --test codex_jsonl_failure_logging`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-agent --all-targets -- -D warnings`
- pre-commit hook: `cargo-fmt`, `cargo-doc`, `cargo-clippy`
