### PR TITLE
fix: keep desktop auth in electron session

### DIFF
--- a/turbo/apps/desktop/src/window-policy.test.ts
+++ b/turbo/apps/desktop/src/window-policy.test.ts
@@ -73,6 +73,51 @@ describe("window policy", () => {
     ).toStrictEqual({ action: "allow-in-app" });
   });
 
+  it("allows Clerk development frontend API navigation inside Electron", () => {
+    expect(
+      isAllowedAppNavigation(
+        "https://mock-instance.clerk.accounts.dev/v1/client",
+        allowedOrigins,
+      ),
+    ).toBe(true);
+  });
+
+  it("opens same-site Clerk frontend API windows inside Electron", () => {
+    expect(
+      decideWindowOpen(
+        "https://clerk.vm0.ai/v1/oauth_callback",
+        allowedOrigins,
+      ),
+    ).toStrictEqual({ action: "allow-in-app" });
+  });
+
+  it("opens Google OAuth windows inside Electron", () => {
+    expect(
+      decideWindowOpen(
+        "https://accounts.google.com/o/oauth2/v2/auth?redirect_uri=https%3A%2F%2Fmock-instance.clerk.accounts.dev%2Fv1%2Foauth_callback&state=abc",
+        allowedOrigins,
+      ),
+    ).toStrictEqual({ action: "allow-in-app" });
+  });
+
+  it("opens GitHub OAuth windows inside Electron", () => {
+    expect(
+      decideWindowOpen(
+        "https://github.com/login/oauth/authorize?client_id=clerk&redirect_uri=https%3A%2F%2Fclerk.vm0.ai%2Fv1%2Foauth_callback&state=abc",
+        allowedOrigins,
+      ),
+    ).toStrictEqual({ action: "allow-in-app" });
+  });
+
+  it("keeps ordinary GitHub links external", () => {
+    expect(
+      decideWindowOpen("https://github.com/vm0-ai/vm0", allowedOrigins),
+    ).toStrictEqual({
+      action: "open-external",
+      url: "https://github.com/vm0-ai/vm0",
+    });
+  });
+
   it("opens ordinary http links externally", () => {
     expect(
       decideWindowOpen("https://example.com/docs", allowedOrigins),

--- a/turbo/apps/desktop/src/window-policy.ts
+++ b/turbo/apps/desktop/src/window-policy.ts
@@ -4,6 +4,29 @@ type WindowOpenDecision =
   | { readonly action: "deny" };
 
 const EXTERNAL_PROTOCOLS = new Set(["http:", "https:", "mailto:"]);
+const CLERK_DEVELOPMENT_HOST_SUFFIX = ".clerk.accounts.dev";
+const SAME_SITE_AUTH_SUBDOMAINS = new Set(["accounts", "auth", "clerk"]);
+const DEDICATED_AUTH_HOSTS = new Set([
+  "accounts.google.com",
+  "appleid.apple.com",
+  "auth.atlassian.com",
+  "login.live.com",
+  "login.microsoft.com",
+  "login.microsoftonline.com",
+]);
+const AUTH_REDIRECT_PARAM_NAMES = [
+  "redirect",
+  "redirect_uri",
+  "redirect_url",
+  "redirectUrl",
+  "return_to",
+  "returnUrl",
+] as const;
+const GENERAL_AUTH_HOST_PATH_PREFIXES = new Map<string, readonly string[]>([
+  ["github.com", ["/login", "/login/oauth"]],
+  ["gitlab.com", ["/oauth", "/users/sign_in"]],
+  ["slack.com", ["/oauth", "/openid", "/signin", "/sign_in"]],
+]);
 
 function parseUrl(rawUrl: string): URL | null {
   try {
@@ -11,6 +34,119 @@ function parseUrl(rawUrl: string): URL | null {
   } catch {
     return null;
   }
+}
+
+function hostnameMatchesSuffix(hostname: string, suffix: string): boolean {
+  return hostname === suffix.slice(1) || hostname.endsWith(suffix);
+}
+
+function rootDomain(hostname: string): string | null {
+  const labels = hostname.split(".");
+  if (labels.length < 2) {
+    return null;
+  }
+  return labels.slice(-2).join(".");
+}
+
+function isAllowedSameSiteAuthHost(
+  url: URL,
+  allowedAppOrigins: ReadonlySet<string>,
+): boolean {
+  const [subdomain] = url.hostname.split(".");
+  if (!subdomain || !SAME_SITE_AUTH_SUBDOMAINS.has(subdomain)) {
+    return false;
+  }
+
+  const urlRootDomain = rootDomain(url.hostname);
+  if (!urlRootDomain) {
+    return false;
+  }
+
+  return [...allowedAppOrigins].some((origin) => {
+    const allowedUrl = parseUrl(origin);
+    return (
+      allowedUrl?.protocol === "https:" &&
+      rootDomain(allowedUrl.hostname) === urlRootDomain
+    );
+  });
+}
+
+function isClerkFrontendUrl(
+  url: URL,
+  allowedAppOrigins: ReadonlySet<string>,
+): boolean {
+  return (
+    url.protocol === "https:" &&
+    (hostnameMatchesSuffix(url.hostname, CLERK_DEVELOPMENT_HOST_SUFFIX) ||
+      isAllowedSameSiteAuthHost(url, allowedAppOrigins))
+  );
+}
+
+function isAllowedAuthRedirectValue(
+  rawRedirectUrl: string,
+  allowedAppOrigins: ReadonlySet<string>,
+): boolean {
+  const redirectUrl = parseUrl(rawRedirectUrl);
+  if (!redirectUrl) {
+    return false;
+  }
+
+  return (
+    allowedAppOrigins.has(redirectUrl.origin) ||
+    isClerkFrontendUrl(redirectUrl, allowedAppOrigins)
+  );
+}
+
+function hasAllowedAuthRedirect(
+  url: URL,
+  allowedAppOrigins: ReadonlySet<string>,
+): boolean {
+  return AUTH_REDIRECT_PARAM_NAMES.some((paramName) => {
+    const redirectValue = url.searchParams.get(paramName);
+    return (
+      redirectValue !== null &&
+      isAllowedAuthRedirectValue(redirectValue, allowedAppOrigins)
+    );
+  });
+}
+
+function hasOAuthHint(url: URL): boolean {
+  return (
+    url.searchParams.has("client_id") ||
+    url.searchParams.has("scope") ||
+    url.searchParams.has("state") ||
+    url.searchParams.has("return_to") ||
+    url.pathname.includes("oauth") ||
+    url.pathname.includes("oidc") ||
+    url.pathname.includes("sso")
+  );
+}
+
+function isKnownAuthProviderUrl(url: URL): boolean {
+  if (DEDICATED_AUTH_HOSTS.has(url.hostname)) {
+    return true;
+  }
+
+  const pathPrefixes = GENERAL_AUTH_HOST_PATH_PREFIXES.get(url.hostname);
+  if (!pathPrefixes || !hasOAuthHint(url)) {
+    return false;
+  }
+
+  return pathPrefixes.some(
+    (pathPrefix) =>
+      url.pathname === pathPrefix || url.pathname.startsWith(`${pathPrefix}/`),
+  );
+}
+
+function isAuthFlowUrl(
+  url: URL,
+  allowedAppOrigins: ReadonlySet<string>,
+): boolean {
+  return (
+    isClerkFrontendUrl(url, allowedAppOrigins) ||
+    hasAllowedAuthRedirect(url, allowedAppOrigins) ||
+    (url.protocol === "https:" && isKnownAuthProviderUrl(url))
+  );
 }
 
 export function isAllowedAppNavigation(
@@ -21,7 +157,9 @@ export function isAllowedAppNavigation(
   if (!url) {
     return false;
   }
-  return allowedAppOrigins.has(url.origin);
+  return (
+    allowedAppOrigins.has(url.origin) || isAuthFlowUrl(url, allowedAppOrigins)
+  );
 }
 
 export function decideWindowOpen(
@@ -34,6 +172,10 @@ export function decideWindowOpen(
   }
 
   if (allowedAppOrigins.has(url.origin)) {
+    return { action: "allow-in-app" };
+  }
+
+  if (isAuthFlowUrl(url, allowedAppOrigins)) {
     return { action: "allow-in-app" };
   }
 


### PR DESCRIPTION
## Summary
- allow Clerk frontend API and OAuth/SSO auth URLs to open inside the Electron desktop session
- keep ordinary external links opening in the system browser
- add window policy coverage for Clerk FAPI, Google OAuth, GitHub OAuth, and ordinary GitHub links

## Tests
- pnpm -F @vm0/desktop test
- pnpm -F @vm0/desktop lint
- pnpm -F @vm0/desktop check-types
- pnpm -F @vm0/desktop build
- pnpm -F @vm0/desktop exec prettier --check src/window-policy.ts src/window-policy.test.ts
- git diff --check
- pre-commit hook: prettier, knip, turbo check-types