### PR TITLE
fix: manage runner memory prefetch lifecycle

### DIFF
--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -291,12 +291,12 @@ pub async fn run_start(
         })?;
 
     // Start background prefetch of snapshot memory for all profiles.
-    for profile in runner_config.profiles.values() {
-        let path = crate::paths::RootfsPaths::new(&home, &profile.rootfs_hash)
-            .snapshot(&profile.snapshot_hash)
-            .memory_bin();
-        tokio::task::spawn_blocking(move || prefetch::prefetch_memory(&path));
-    }
+    let memory_prefetch =
+        prefetch::MemoryPrefetchTasks::spawn(runner_config.profiles.values().map(|profile| {
+            crate::paths::RootfsPaths::new(&home, &profile.rootfs_hash)
+                .snapshot(&profile.snapshot_hash)
+                .memory_bin()
+        }));
 
     // Compute the smallest profile resources for budget pre-check.
     // When budget is exhausted for all profiles, we wait instead of polling.
@@ -478,6 +478,7 @@ pub async fn run_start(
         min_memory_mb,
         kmsg_handle,
         dns_handle,
+        memory_prefetch,
         signal_source: SignalSource::Real(signals),
         orphan_reap_process_discovery: None,
         #[cfg(test)]
@@ -514,6 +515,7 @@ struct RunConfig {
     min_memory_mb: u32,
     kmsg_handle: kmsg_log::KmsgHandle,
     dns_handle: dns::DnsProxy,
+    memory_prefetch: prefetch::MemoryPrefetchTasks,
     /// Deterministic process snapshot for orphan-reaper tests. Production leaves
     /// this unset and scans `/proc`.
     orphan_reap_process_discovery: Option<OrphanReapProcessDiscovery>,
@@ -816,6 +818,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
         min_memory_mb,
         kmsg_handle,
         dns_handle,
+        mut memory_prefetch,
         orphan_reap_process_discovery,
         signal_source,
         #[cfg(test)]
@@ -1131,6 +1134,8 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
     // Shutdown — drain idle pool, release discovery resources, then drain running jobs
     // -----------------------------------------------------------------------
     let teardown = TeardownTimer::start();
+    memory_prefetch.cancel();
+    teardown.event("memory_prefetch_cancelled");
 
     // Drop the pinned discover future before provider shutdown so any
     // provider-local discovery resources are released first. This also keeps
@@ -1288,6 +1293,10 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
     let phase = teardown.phase_start("dns_stop");
     dns_handle.stop().await;
     teardown.phase_complete("dns_stop", phase);
+
+    let phase = teardown.phase_start("memory_prefetch_drain");
+    memory_prefetch.drain().await;
+    teardown.phase_complete("memory_prefetch_drain", phase);
 
     let phase = teardown.phase_start("status_stopped");
     status.set_mode(RunnerMode::Stopped).await;

--- a/crates/runner/src/cmd/start/tests/main_loop.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop.rs
@@ -269,6 +269,54 @@ async fn shutdown_completes_without_deadlock() {
     }
 }
 
+#[tokio::test]
+async fn shutdown_drains_memory_prefetch_before_stopped() {
+    let (mut config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
+    let status_path = env._temp_dir.path().join("status.json");
+    let prefetch_cancel = tokio_util::sync::CancellationToken::new();
+    let task_cancel = prefetch_cancel.clone();
+    let (cancelled_tx, cancelled_rx) = tokio::sync::oneshot::channel();
+    let (release_tx, release_rx) = tokio::sync::oneshot::channel();
+    let handle = tokio::spawn(async move {
+        task_cancel.cancelled().await;
+        let _ = cancelled_tx.send(());
+        let _ = release_rx.await;
+    });
+    config.memory_prefetch =
+        crate::prefetch::MemoryPrefetchTasks::from_test_handle(prefetch_cancel, handle);
+    let run_handle = tokio::spawn(run(config));
+
+    wait_discover_entered(&env, Duration::from_secs(2)).await;
+    env.drain();
+    env.cancel.cancel();
+    tokio::time::timeout(Duration::from_secs(5), cancelled_rx)
+        .await
+        .expect("memory prefetch should be cancelled during teardown")
+        .expect("memory prefetch task should report cancellation");
+
+    assert!(
+        !run_handle.is_finished(),
+        "runner shutdown should wait for memory prefetch drain before returning",
+    );
+    let raw_status = tokio::fs::read_to_string(&status_path).await.unwrap();
+    let status: serde_json::Value = serde_json::from_str(&raw_status).unwrap();
+    assert_ne!(
+        status.get("mode").and_then(serde_json::Value::as_str),
+        Some("stopped"),
+        "runner must not write stopped status before memory prefetch drain finishes",
+    );
+
+    release_tx
+        .send(())
+        .expect("runner should still be waiting for prefetch release");
+    let result = tokio::time::timeout(Duration::from_secs(5), run_handle)
+        .await
+        .expect("run should finish after memory prefetch drains")
+        .expect("task should not panic");
+    assert!(result.is_ok());
+    wait_status_mode(&status_path, "stopped", Duration::from_secs(5)).await;
+}
+
 // -----------------------------------------------------------------------
 // Draining / resume / hard-shutdown state machine
 // -----------------------------------------------------------------------

--- a/crates/runner/src/cmd/start/tests/support/env.rs
+++ b/crates/runner/src/cmd/start/tests/support/env.rs
@@ -216,6 +216,7 @@ fn build_mock_run_config_with_runtime(
         min_memory_mb,
         kmsg_handle: kmsg_log::KmsgHandle::noop(),
         dns_handle: crate::dns::DnsProxy::noop(),
+        memory_prefetch: prefetch::MemoryPrefetchTasks::empty(),
         orphan_reap_process_discovery: None,
         signal_source: SignalSource::Override(SignalController {
             mode_rx,

--- a/crates/runner/src/prefetch.rs
+++ b/crates/runner/src/prefetch.rs
@@ -1,7 +1,83 @@
 use std::io::Read;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
+
+const MEMORY_PREFETCH_CHUNK_BYTES: usize = 1024 * 1024;
+
+#[derive(Debug, PartialEq, Eq)]
+enum PrefetchOutcome {
+    Complete { bytes: u64 },
+    Cancelled { bytes: u64 },
+}
+
+pub(crate) struct MemoryPrefetchTasks {
+    cancel: CancellationToken,
+    handles: Vec<JoinHandle<()>>,
+}
+
+impl MemoryPrefetchTasks {
+    pub(crate) fn spawn(paths: impl IntoIterator<Item = PathBuf>) -> Self {
+        let cancel = CancellationToken::new();
+        let mut unique_paths = Vec::new();
+        for path in paths {
+            if !unique_paths.contains(&path) {
+                unique_paths.push(path);
+            }
+        }
+
+        let handles = unique_paths
+            .into_iter()
+            .map(|path| {
+                let cancel = cancel.clone();
+                tokio::task::spawn_blocking(move || prefetch_memory_with_cancel(&path, &cancel))
+            })
+            .collect();
+
+        Self { cancel, handles }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn empty() -> Self {
+        Self {
+            cancel: CancellationToken::new(),
+            handles: Vec::new(),
+        }
+    }
+
+    pub(crate) fn cancel(&self) {
+        self.cancel.cancel();
+    }
+
+    pub(crate) async fn drain(&mut self) {
+        for handle in self.handles.drain(..) {
+            if let Err(error) = handle.await {
+                warn!(error = %error, "memory prefetch task failed");
+            }
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn task_count(&self) -> usize {
+        self.handles.len()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn from_test_handle(cancel: CancellationToken, handle: JoinHandle<()>) -> Self {
+        Self {
+            cancel,
+            handles: vec![handle],
+        }
+    }
+}
+
+impl Drop for MemoryPrefetchTasks {
+    fn drop(&mut self) {
+        self.cancel.cancel();
+    }
+}
 
 /// Read a file sequentially to populate the host page cache.
 ///
@@ -9,6 +85,15 @@ use tracing::{info, warn};
 /// page cache, guest memory accesses trigger host-side demand paging.
 /// This performs blocking I/O — callers should use `spawn_blocking`.
 pub fn prefetch_memory(path: &Path) {
+    prefetch_memory_with_cancel(path, &CancellationToken::new());
+}
+
+fn prefetch_memory_with_cancel(path: &Path, cancel: &CancellationToken) {
+    if cancel.is_cancelled() {
+        info!(bytes = 0_u64, path = %path.display(), "memory prefetch cancelled");
+        return;
+    }
+
     let mut file = match std::fs::File::open(path) {
         Ok(f) => f,
         Err(e) => {
@@ -16,24 +101,48 @@ pub fn prefetch_memory(path: &Path) {
             return;
         }
     };
-    let mut buf = vec![0u8; 1024 * 1024];
-    let mut total: u64 = 0;
-    loop {
-        match file.read(&mut buf) {
-            Ok(0) => break,
-            Ok(n) => total += n as u64,
-            Err(e) => {
-                warn!(error = %e, bytes = total, "memory prefetch: read failed");
-                return;
-            }
+
+    match prefetch_reader(&mut file, cancel) {
+        Ok(PrefetchOutcome::Complete { bytes }) => {
+            info!(bytes, path = %path.display(), "memory prefetch complete");
+        }
+        Ok(PrefetchOutcome::Cancelled { bytes }) => {
+            info!(bytes, path = %path.display(), "memory prefetch cancelled");
+        }
+        Err(e) => {
+            warn!(error = %e, path = %path.display(), "memory prefetch: read failed");
         }
     }
-    info!(bytes = total, path = %path.display(), "memory prefetch complete");
+}
+
+fn prefetch_reader<R: Read>(
+    reader: &mut R,
+    cancel: &CancellationToken,
+) -> std::io::Result<PrefetchOutcome> {
+    let mut buf = vec![0u8; MEMORY_PREFETCH_CHUNK_BYTES];
+    let mut total: u64 = 0;
+    loop {
+        if cancel.is_cancelled() {
+            return Ok(PrefetchOutcome::Cancelled { bytes: total });
+        }
+
+        let n = reader.read(&mut buf)?;
+        if n == 0 {
+            return Ok(PrefetchOutcome::Complete { bytes: total });
+        }
+        total += n as u64;
+
+        if cancel.is_cancelled() {
+            return Ok(PrefetchOutcome::Cancelled { bytes: total });
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::time::Duration;
+    use tokio::sync::oneshot;
 
     #[test]
     fn prefetch_memory_reads_file() {
@@ -55,5 +164,124 @@ mod tests {
         let path = dir.path().join("empty.bin");
         std::fs::write(&path, b"").unwrap();
         prefetch_memory(&path);
+    }
+
+    #[test]
+    fn prefetch_reader_stops_before_read_when_cancelled() {
+        let cancel = CancellationToken::new();
+        cancel.cancel();
+        let mut reader = TestReader::new(3, None, cancel.clone());
+
+        let outcome = prefetch_reader(&mut reader, &cancel).unwrap();
+
+        assert_eq!(outcome, PrefetchOutcome::Cancelled { bytes: 0 });
+        assert_eq!(reader.reads, 0);
+    }
+
+    #[test]
+    fn prefetch_reader_stops_between_chunks_when_cancelled() {
+        let cancel = CancellationToken::new();
+        let mut reader = TestReader::new(3, Some(1), cancel.clone());
+
+        let outcome = prefetch_reader(&mut reader, &cancel).unwrap();
+
+        assert_eq!(outcome, PrefetchOutcome::Cancelled { bytes: 1 });
+        assert_eq!(reader.reads, 1);
+    }
+
+    #[tokio::test]
+    async fn memory_prefetch_tasks_deduplicate_paths() {
+        let path = PathBuf::from("/nonexistent/memory.bin");
+        let mut tasks = MemoryPrefetchTasks::spawn([path.clone(), path]);
+
+        assert_eq!(tasks.task_count(), 1);
+
+        tasks.drain().await;
+        assert_eq!(tasks.task_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn memory_prefetch_tasks_cancel_and_drain() {
+        let cancel = CancellationToken::new();
+        let task_cancel = cancel.clone();
+        let (cancelled_tx, cancelled_rx) = oneshot::channel();
+        let (release_tx, release_rx) = oneshot::channel();
+        let handle = tokio::spawn(async move {
+            task_cancel.cancelled().await;
+            let _ = cancelled_tx.send(());
+            let _ = release_rx.await;
+        });
+        let mut tasks = MemoryPrefetchTasks::from_test_handle(cancel, handle);
+
+        tasks.cancel();
+        tokio::time::timeout(Duration::from_secs(5), cancelled_rx)
+            .await
+            .expect("prefetch task should observe cancellation")
+            .expect("prefetch task should report cancellation");
+        release_tx
+            .send(())
+            .expect("prefetch task should wait for release");
+        tasks.drain().await;
+
+        assert_eq!(tasks.task_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn memory_prefetch_tasks_drop_cancels() {
+        let cancel = CancellationToken::new();
+        let task_cancel = cancel.clone();
+        let (cancelled_tx, cancelled_rx) = oneshot::channel();
+        let handle = tokio::spawn(async move {
+            task_cancel.cancelled().await;
+            let _ = cancelled_tx.send(());
+        });
+
+        let tasks = MemoryPrefetchTasks::from_test_handle(cancel, handle);
+        drop(tasks);
+
+        tokio::time::timeout(Duration::from_secs(5), cancelled_rx)
+            .await
+            .expect("dropped prefetch owner should cancel task")
+            .expect("prefetch task should report cancellation");
+    }
+
+    struct TestReader {
+        remaining_reads: usize,
+        cancel_after_read: Option<usize>,
+        cancel: CancellationToken,
+        reads: usize,
+    }
+
+    impl TestReader {
+        fn new(
+            remaining_reads: usize,
+            cancel_after_read: Option<usize>,
+            cancel: CancellationToken,
+        ) -> Self {
+            Self {
+                remaining_reads,
+                cancel_after_read,
+                cancel,
+                reads: 0,
+            }
+        }
+    }
+
+    impl Read for TestReader {
+        fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+            if self.remaining_reads == 0 {
+                return Ok(0);
+            }
+
+            self.remaining_reads -= 1;
+            self.reads += 1;
+            buf[0] = 0;
+
+            if self.cancel_after_read == Some(self.reads) {
+                self.cancel.cancel();
+            }
+
+            Ok(1)
+        }
     }
 }

--- a/crates/runner/src/prefetch.rs
+++ b/crates/runner/src/prefetch.rs
@@ -7,10 +7,11 @@ use tracing::{info, warn};
 
 const MEMORY_PREFETCH_CHUNK_BYTES: usize = 1024 * 1024;
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug)]
 enum PrefetchOutcome {
     Complete { bytes: u64 },
     Cancelled { bytes: u64 },
+    ReadFailed { bytes: u64, error: std::io::Error },
 }
 
 pub(crate) struct MemoryPrefetchTasks {
@@ -103,37 +104,42 @@ fn prefetch_memory_with_cancel(path: &Path, cancel: &CancellationToken) {
     };
 
     match prefetch_reader(&mut file, cancel) {
-        Ok(PrefetchOutcome::Complete { bytes }) => {
+        PrefetchOutcome::Complete { bytes } => {
             info!(bytes, path = %path.display(), "memory prefetch complete");
         }
-        Ok(PrefetchOutcome::Cancelled { bytes }) => {
+        PrefetchOutcome::Cancelled { bytes } => {
             info!(bytes, path = %path.display(), "memory prefetch cancelled");
         }
-        Err(e) => {
-            warn!(error = %e, path = %path.display(), "memory prefetch: read failed");
+        PrefetchOutcome::ReadFailed { bytes, error } => {
+            warn!(error = %error, bytes, path = %path.display(), "memory prefetch: read failed");
         }
     }
 }
 
-fn prefetch_reader<R: Read>(
-    reader: &mut R,
-    cancel: &CancellationToken,
-) -> std::io::Result<PrefetchOutcome> {
+fn prefetch_reader<R: Read>(reader: &mut R, cancel: &CancellationToken) -> PrefetchOutcome {
     let mut buf = vec![0u8; MEMORY_PREFETCH_CHUNK_BYTES];
     let mut total: u64 = 0;
     loop {
         if cancel.is_cancelled() {
-            return Ok(PrefetchOutcome::Cancelled { bytes: total });
+            return PrefetchOutcome::Cancelled { bytes: total };
         }
 
-        let n = reader.read(&mut buf)?;
+        let n = match reader.read(&mut buf) {
+            Ok(n) => n,
+            Err(error) => {
+                return PrefetchOutcome::ReadFailed {
+                    bytes: total,
+                    error,
+                };
+            }
+        };
         if n == 0 {
-            return Ok(PrefetchOutcome::Complete { bytes: total });
+            return PrefetchOutcome::Complete { bytes: total };
         }
         total += n as u64;
 
         if cancel.is_cancelled() {
-            return Ok(PrefetchOutcome::Cancelled { bytes: total });
+            return PrefetchOutcome::Cancelled { bytes: total };
         }
     }
 }
@@ -172,9 +178,9 @@ mod tests {
         cancel.cancel();
         let mut reader = TestReader::new(3, None, cancel.clone());
 
-        let outcome = prefetch_reader(&mut reader, &cancel).unwrap();
+        let outcome = prefetch_reader(&mut reader, &cancel);
 
-        assert_eq!(outcome, PrefetchOutcome::Cancelled { bytes: 0 });
+        assert!(matches!(outcome, PrefetchOutcome::Cancelled { bytes: 0 }));
         assert_eq!(reader.reads, 0);
     }
 
@@ -183,10 +189,23 @@ mod tests {
         let cancel = CancellationToken::new();
         let mut reader = TestReader::new(3, Some(1), cancel.clone());
 
-        let outcome = prefetch_reader(&mut reader, &cancel).unwrap();
+        let outcome = prefetch_reader(&mut reader, &cancel);
 
-        assert_eq!(outcome, PrefetchOutcome::Cancelled { bytes: 1 });
+        assert!(matches!(outcome, PrefetchOutcome::Cancelled { bytes: 1 }));
         assert_eq!(reader.reads, 1);
+    }
+
+    #[test]
+    fn prefetch_reader_reports_bytes_read_before_failure() {
+        let cancel = CancellationToken::new();
+        let mut reader = FailingReader { reads: 0 };
+
+        let outcome = prefetch_reader(&mut reader, &cancel);
+
+        assert!(matches!(
+            outcome,
+            PrefetchOutcome::ReadFailed { bytes: 1, .. }
+        ));
     }
 
     #[tokio::test]
@@ -281,6 +300,21 @@ mod tests {
                 self.cancel.cancel();
             }
 
+            Ok(1)
+        }
+    }
+
+    struct FailingReader {
+        reads: usize,
+    }
+
+    impl Read for FailingReader {
+        fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+            if self.reads == 1 {
+                return Err(std::io::Error::other("boom"));
+            }
+            self.reads += 1;
+            buf[0] = 0;
             Ok(1)
         }
     }


### PR DESCRIPTION
## Summary
- add an owned cancellable memory prefetch task group for runner startup
- cancel prefetch at teardown start and drain it before writing stopped status
- cover prefetch cancellation, deduplication, drop cancellation, and runner shutdown ordering

Closes #13705

## Verification
- cargo test --manifest-path crates/Cargo.toml -p runner prefetch
- cargo test --manifest-path crates/Cargo.toml -p runner cmd::start
- cargo fmt --manifest-path crates/Cargo.toml --all --check
- cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets -- -D warnings
- cargo test --manifest-path crates/Cargo.toml -p runner
- git diff --check