### PR TITLE
perf(nbd-cow): skip read-before-write for full-block writes

### DIFF
--- a/crates/nbd-cow/src/cow.rs
+++ b/crates/nbd-cow/src/cow.rs
@@ -174,7 +174,11 @@ impl CowLayer {
             let to_write = remaining_in_block.min(data.len() - pos);
 
             if !self.write_buffer.contains_key(&block_idx) {
-                let full_block = self.read_full_block(block_idx)?;
+                let full_block = if to_write == self.block_size {
+                    vec![0u8; self.block_size]
+                } else {
+                    self.read_full_block(block_idx)?
+                };
                 self.write_buffer.insert(block_idx, full_block);
             }
             let block_data = self


### PR DESCRIPTION
For block-aligned filesystem writes (e.g., ext4 page-cache writeback), the write covers an entire block, making the preceding read_full_block unnecessary. Allocate a zeroed buffer instead, avoiding one disk read per block.