### PR TITLE
refactor: align sandbox gate with vsock write boundary

### DIFF
--- a/crates/sandbox-fc/src/control.rs
+++ b/crates/sandbox-fc/src/control.rs
@@ -441,36 +441,36 @@ async fn handle_connection(
 
 /// Execute an [`ExecRequest`] through the sandbox operation gate.
 async fn execute(request: ExecRequest, guest_operations: &GuestOperationGate) -> ExecResponse {
-    let mut operation = match guest_operations.begin_control_operation().await {
+    let operation = match guest_operations.begin_control_operation().await {
         Ok(operation) => operation,
         Err(error) => {
             return ExecResponse::Error {
                 error: control_start_error(error),
             };
         }
-    };
-    if let Err(error) = operation.mark_writing() {
-        return ExecResponse::Error {
-            error: format!("operation gate transition failed: {error:?}"),
-        };
     }
+    .into_write_boundary();
 
     let vsock = operation.guest();
+    let write_observer = operation.write_observer();
     let timeout_ms = request.timeout_secs.saturating_mul(1000);
     let env: &[(&str, &str)] = &[];
 
     let result = vsock
-        .exec_capture(vsock_host::ExecCaptureRequest {
-            command: &request.command,
-            timeout_ms,
-            env,
-            sudo: request.sudo,
-            label: "runner-exec",
-            stdout_limit_bytes: RUNNER_EXEC_CAPTURE_LIMIT_BYTES,
-            stderr_limit_bytes: RUNNER_EXEC_CAPTURE_LIMIT_BYTES,
-            expected_exit_codes: &[],
-            wait_timeout: Duration::from_millis(timeout_ms as u64 + 5000),
-        })
+        .exec_capture_with_write_observer(
+            vsock_host::ExecCaptureRequest {
+                command: &request.command,
+                timeout_ms,
+                env,
+                sudo: request.sudo,
+                label: "runner-exec",
+                stdout_limit_bytes: RUNNER_EXEC_CAPTURE_LIMIT_BYTES,
+                stderr_limit_bytes: RUNNER_EXEC_CAPTURE_LIMIT_BYTES,
+                expected_exit_codes: &[],
+                wait_timeout: Duration::from_millis(timeout_ms as u64 + 5000),
+            },
+            write_observer,
+        )
         .await;
 
     match result {
@@ -491,7 +491,7 @@ async fn execute(request: ExecRequest, guest_operations: &GuestOperationGate) ->
         Err(e) => {
             let message = format!("exec failed: {e}");
             if guest_error_is_terminal(&e, false)
-                && let Err(error) = operation.complete()
+                && let Err(error) = operation.complete_if_write_started()
             {
                 return ExecResponse::Error {
                     error: format!("operation gate completion failed: {error:?}"),

--- a/crates/sandbox-fc/src/guest_operations.rs
+++ b/crates/sandbox-fc/src/guest_operations.rs
@@ -1,9 +1,11 @@
-use std::sync::Arc;
+use std::io;
+use std::sync::{Arc, Mutex};
 
-use vsock_host::VsockHost;
+use vsock_host::{FrameWriteObserver, VsockHost};
 
 use crate::park_coordinator::{
-    CoordinatorState, LeaseRejection, OperationLease, OperationTransitionError, ParkCoordinator,
+    CoordinatorState, LeaseRejection, OperationId, OperationLease, OperationLiveness,
+    OperationTransitionError, ParkCoordinator,
 };
 use crate::sandbox::SandboxState;
 
@@ -95,25 +97,126 @@ pub(crate) struct GuestOperation {
 }
 
 impl GuestOperation {
+    pub(crate) fn into_write_boundary(self) -> GuestOperationWriteBoundary {
+        GuestOperationWriteBoundary::new(self.guest, self.lease)
+    }
+}
+
+pub(crate) struct GuestOperationWriteBoundary {
+    guest: Arc<VsockHost>,
+    state: Arc<Mutex<GuestOperationWriteBoundaryState>>,
+}
+
+struct GuestOperationWriteBoundaryState {
+    operation_id: OperationId,
+    lease: Option<OperationLease>,
+    write_started: bool,
+}
+
+impl GuestOperationWriteBoundary {
+    fn new(guest: Arc<VsockHost>, lease: OperationLease) -> Self {
+        Self {
+            guest,
+            state: Arc::new(Mutex::new(GuestOperationWriteBoundaryState {
+                operation_id: lease.id(),
+                lease: Some(lease),
+                write_started: false,
+            })),
+        }
+    }
+
     pub(crate) fn guest(&self) -> Arc<VsockHost> {
         Arc::clone(&self.guest)
     }
 
-    pub(crate) fn mark_writing(&mut self) -> Result<(), OperationTransitionError> {
-        self.lease.mark_writing()
+    pub(crate) fn write_observer(&self) -> FrameWriteObserver {
+        let state = Arc::clone(&self.state);
+        FrameWriteObserver::new(move || {
+            let mut state = lock_write_boundary_state(&state);
+            state.record_write_start().map_err(|error| {
+                io::Error::other(format!("operation gate write-start transition: {error:?}"))
+            })
+        })
     }
 
-    pub(crate) fn mark_in_guest(&mut self) -> Result<(), OperationTransitionError> {
-        self.lease.mark_in_guest()
+    pub(crate) fn has_write_started(&self) -> bool {
+        lock_write_boundary_state(&self.state).write_started
     }
 
     pub(crate) fn complete(self) -> Result<(), OperationTransitionError> {
-        self.lease.complete()
+        let mut state = lock_write_boundary_state(&self.state);
+        state.complete()
     }
 
-    pub(crate) fn into_lease(self) -> OperationLease {
-        self.lease
+    pub(crate) fn complete_if_write_started(self) -> Result<(), OperationTransitionError> {
+        if self.has_write_started() {
+            self.complete()
+        } else {
+            Ok(())
+        }
     }
+
+    pub(crate) fn into_in_guest_lease(self) -> Result<OperationLease, OperationTransitionError> {
+        let mut state = lock_write_boundary_state(&self.state);
+        state.take_in_guest_lease()
+    }
+}
+
+impl GuestOperationWriteBoundaryState {
+    fn record_write_start(&mut self) -> Result<(), OperationTransitionError> {
+        if self.write_started {
+            return Ok(());
+        }
+
+        let Some(lease) = self.lease.as_mut() else {
+            return Err(OperationTransitionError::UnknownOperation {
+                operation_id: self.operation_id,
+            });
+        };
+
+        lease.mark_writing()?;
+        self.write_started = true;
+        Ok(())
+    }
+
+    fn take_lease(&mut self) -> Result<OperationLease, OperationTransitionError> {
+        self.lease
+            .take()
+            .ok_or(OperationTransitionError::UnknownOperation {
+                operation_id: self.operation_id,
+            })
+    }
+
+    fn complete(&mut self) -> Result<(), OperationTransitionError> {
+        let lease = self.take_lease()?;
+        if !self.write_started {
+            return Err(OperationTransitionError::InvalidTransition {
+                operation_id: self.operation_id,
+                from: OperationLiveness::Reserved,
+                to: OperationLiveness::Terminal,
+            });
+        }
+        lease.complete()
+    }
+
+    fn take_in_guest_lease(&mut self) -> Result<OperationLease, OperationTransitionError> {
+        let mut lease = self.take_lease()?;
+        if !self.write_started {
+            return Err(OperationTransitionError::InvalidTransition {
+                operation_id: self.operation_id,
+                from: OperationLiveness::Reserved,
+                to: OperationLiveness::InGuest,
+            });
+        }
+        lease.mark_in_guest()?;
+        Ok(lease)
+    }
+}
+
+fn lock_write_boundary_state(
+    state: &Mutex<GuestOperationWriteBoundaryState>,
+) -> std::sync::MutexGuard<'_, GuestOperationWriteBoundaryState> {
+    state.lock().unwrap_or_else(|error| error.into_inner())
 }
 
 #[cfg(test)]
@@ -135,6 +238,92 @@ mod tests {
             .begin_prepare_park()
             .expect("operation start failure should not leave an active lease");
         coordinator.abort_prepare_park(&attempt).unwrap();
+    }
+
+    fn write_boundary_state(coordinator: &ParkCoordinator) -> GuestOperationWriteBoundaryState {
+        let lease = coordinator.reserve_operation().expect("reserve operation");
+        GuestOperationWriteBoundaryState {
+            operation_id: lease.id(),
+            lease: Some(lease),
+            write_started: false,
+        }
+    }
+
+    #[test]
+    fn write_boundary_drop_before_write_start_is_clean() {
+        let coordinator = ParkCoordinator::new();
+        let state = write_boundary_state(&coordinator);
+
+        drop(state);
+
+        assert_eq!(coordinator.active_operation_count(), 0);
+        assert_prepare_can_start(&coordinator);
+    }
+
+    #[test]
+    fn write_boundary_first_write_blocks_park_until_complete() {
+        let coordinator = ParkCoordinator::new();
+        let mut state = write_boundary_state(&coordinator);
+
+        state.record_write_start().expect("record write start");
+
+        assert!(state.write_started);
+        assert_eq!(coordinator.active_operation_count(), 1);
+        assert!(matches!(
+            coordinator.begin_prepare_park(),
+            Err(crate::park_coordinator::PrepareParkError::Busy)
+        ));
+
+        state.complete().expect("complete operation");
+        assert_prepare_can_start(&coordinator);
+    }
+
+    #[test]
+    fn write_boundary_repeated_write_start_is_idempotent() {
+        let coordinator = ParkCoordinator::new();
+        let mut state = write_boundary_state(&coordinator);
+
+        state.record_write_start().expect("first write start");
+        state.record_write_start().expect("second write start");
+
+        state.complete().expect("complete operation");
+        assert_prepare_can_start(&coordinator);
+    }
+
+    #[test]
+    fn write_boundary_completion_before_write_start_is_rejected_cleanly() {
+        let coordinator = ParkCoordinator::new();
+        let mut state = write_boundary_state(&coordinator);
+
+        assert!(matches!(
+            state.complete(),
+            Err(OperationTransitionError::InvalidTransition {
+                from: OperationLiveness::Reserved,
+                to: OperationLiveness::Terminal,
+                ..
+            })
+        ));
+
+        assert_eq!(coordinator.active_operation_count(), 0);
+        assert_prepare_can_start(&coordinator);
+    }
+
+    #[test]
+    fn write_boundary_in_guest_requires_write_start() {
+        let coordinator = ParkCoordinator::new();
+        let mut state = write_boundary_state(&coordinator);
+
+        assert!(matches!(
+            state.take_in_guest_lease(),
+            Err(OperationTransitionError::InvalidTransition {
+                from: OperationLiveness::Reserved,
+                to: OperationLiveness::InGuest,
+                ..
+            })
+        ));
+
+        assert_eq!(coordinator.active_operation_count(), 0);
+        assert_prepare_can_start(&coordinator);
     }
 
     #[test]

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -699,7 +699,7 @@ impl FirecrackerSandbox {
     async fn run_bounded_guest_operation<T, Fut>(
         &self,
         operation: SandboxOperation,
-        call: impl FnOnce(Arc<VsockHost>) -> Fut,
+        call: impl FnOnce(Arc<VsockHost>, vsock_host::FrameWriteObserver) -> Fut,
     ) -> sandbox::Result<T>
     where
         Fut: Future<Output = io::Result<T>>,
@@ -709,14 +709,15 @@ impl FirecrackerSandbox {
             BackendCrashed,
         }
 
-        let mut guest = self.begin_guest_operation(operation).await?;
-        guest
-            .mark_writing()
-            .map_err(|error| Self::operation_gate_transition_error(operation, error))?;
+        let guest = self
+            .begin_guest_operation(operation)
+            .await?
+            .into_write_boundary();
         let vsock = guest.guest();
+        let write_observer = guest.write_observer();
 
         let outcome = tokio::select! {
-            result = call(vsock) => {
+            result = call(vsock, write_observer) => {
                 GuestCallOutcome::Returned(result)
             }
             () = wait_for_backend_crash(self.state_tx.subscribe()) => {
@@ -737,7 +738,7 @@ impl FirecrackerSandbox {
                 let result = Err(Self::operation_error(operation, error, backend_crashed));
                 if is_terminal {
                     guest
-                        .complete()
+                        .complete_if_write_started()
                         .map_err(|error| Self::operation_gate_transition_error(operation, error))?;
                 }
                 result
@@ -1509,19 +1510,22 @@ impl Sandbox for FirecrackerSandbox {
         let limits = request.output_limits;
         let timeout_ms = request.timeout_ms();
 
-        self.run_bounded_guest_operation(operation, |guest| async move {
+        self.run_bounded_guest_operation(operation, |guest, write_observer| async move {
             guest
-                .exec_capture(vsock_host::ExecCaptureRequest {
-                    command: request.cmd,
-                    timeout_ms,
-                    env: request.env,
-                    sudo: request.sudo,
-                    label: "sandbox-exec",
-                    stdout_limit_bytes: limits.stdout_limit_bytes,
-                    stderr_limit_bytes: limits.stderr_limit_bytes,
-                    expected_exit_codes: &[],
-                    wait_timeout: Duration::from_millis(timeout_ms as u64 + 5000),
-                })
+                .exec_capture_with_write_observer(
+                    vsock_host::ExecCaptureRequest {
+                        command: request.cmd,
+                        timeout_ms,
+                        env: request.env,
+                        sudo: request.sudo,
+                        label: "sandbox-exec",
+                        stdout_limit_bytes: limits.stdout_limit_bytes,
+                        stderr_limit_bytes: limits.stderr_limit_bytes,
+                        expected_exit_codes: &[],
+                        wait_timeout: Duration::from_millis(timeout_ms as u64 + 5000),
+                    },
+                    write_observer,
+                )
                 .await
                 .map(|result| ExecResult {
                     exit_code: result.exit_code,
@@ -1537,8 +1541,10 @@ impl Sandbox for FirecrackerSandbox {
     async fn read_file(&self, path: &str, max_bytes: u64) -> sandbox::Result<Option<Vec<u8>>> {
         let operation = SandboxOperation::Exec;
 
-        self.run_bounded_guest_operation(operation, |guest| async move {
-            guest.read_file(path, max_bytes, 5000).await
+        self.run_bounded_guest_operation(operation, |guest, write_observer| async move {
+            guest
+                .read_file_with_write_observer(path, max_bytes, 5000, write_observer)
+                .await
         })
         .await
     }
@@ -1552,9 +1558,9 @@ impl Sandbox for FirecrackerSandbox {
         let operation = SandboxOperation::Exec;
         let timeout_ms = u32::try_from(options.timeout.as_millis()).unwrap_or(u32::MAX);
 
-        self.run_bounded_guest_operation(operation, |guest| async move {
+        self.run_bounded_guest_operation(operation, |guest, write_observer| async move {
             guest
-                .copy_file(
+                .copy_file_with_write_observer(
                     path,
                     host_path,
                     vsock_host::CopyFileOptions {
@@ -1562,6 +1568,7 @@ impl Sandbox for FirecrackerSandbox {
                         timeout_ms,
                         missing_ok: options.missing_ok,
                     },
+                    write_observer,
                 )
                 .await
                 .map(|result| CopyFileResult {
@@ -1574,8 +1581,10 @@ impl Sandbox for FirecrackerSandbox {
     async fn write_file(&self, path: &str, content: &[u8]) -> sandbox::Result<()> {
         let operation = SandboxOperation::WriteFile;
 
-        self.run_bounded_guest_operation(operation, |guest| async move {
-            guest.write_file(path, content, false).await
+        self.run_bounded_guest_operation(operation, |guest, write_observer| async move {
+            guest
+                .write_file_with_write_observer(path, content, false, write_observer)
+                .await
         })
         .await
     }
@@ -1585,31 +1594,42 @@ impl Sandbox for FirecrackerSandbox {
         request: &SpawnProcessRequest<'_>,
     ) -> sandbox::Result<GuestProcessHandle> {
         let operation = SandboxOperation::SpawnProcess;
-        let mut guest = self.begin_guest_operation(operation).await?;
-        guest
-            .mark_writing()
-            .map_err(|error| Self::operation_gate_transition_error(operation, error))?;
+        let guest = self
+            .begin_guest_operation(operation)
+            .await?
+            .into_write_boundary();
         let vsock = guest.guest();
+        let write_observer = guest.write_observer();
 
         let spawn_future: Pin<
             Box<dyn Future<Output = io::Result<vsock_host::GuestProcessHandle>> + Send + '_>,
         > = match request.control {
-            SpawnProcessControl::None => Box::pin(vsock.spawn_process(
-                request.cmd,
-                request.timeout_ms(),
-                request.env,
-                request.sudo,
-                request.output.streams_stdout(),
-                request.output.guest_log_path(),
-            )),
-            SpawnProcessControl::Enabled => Box::pin(vsock.spawn_process_with_control_sink(
-                request.cmd,
-                request.timeout_ms(),
-                request.env,
-                request.sudo,
-                request.output.streams_stdout(),
-                request.output.guest_log_path(),
-            )),
+            SpawnProcessControl::None => {
+                Box::pin(vsock.spawn_process_with_request_and_write_observer(
+                    vsock_host::ProcessSpawnRequest {
+                        command: request.cmd,
+                        timeout_ms: request.timeout_ms(),
+                        env: request.env,
+                        sudo: request.sudo,
+                        stream_stdout: request.output.streams_stdout(),
+                        stdout_log_path: request.output.guest_log_path(),
+                    },
+                    write_observer,
+                ))
+            }
+            SpawnProcessControl::Enabled => Box::pin(
+                vsock.spawn_process_with_control_sink_request_and_write_observer(
+                    vsock_host::ProcessSpawnRequest {
+                        command: request.cmd,
+                        timeout_ms: request.timeout_ms(),
+                        env: request.env,
+                        sudo: request.sudo,
+                        stream_stdout: request.output.streams_stdout(),
+                        stdout_log_path: request.output.guest_log_path(),
+                    },
+                    write_observer,
+                ),
+            ),
         };
 
         tokio::select! {
@@ -1622,15 +1642,12 @@ impl Sandbox for FirecrackerSandbox {
                         let result = Err(Self::operation_error(operation, error, backend_crashed));
                         if is_terminal {
                             guest
-                                .complete()
+                                .complete_if_write_started()
                                 .map_err(|error| Self::operation_gate_transition_error(operation, error))?;
                         }
                         return result;
                     }
                 };
-                guest
-                    .mark_in_guest()
-                    .map_err(|error| Self::operation_gate_transition_error(operation, error))?;
                 let pid = handle.pid();
                 let process_control = (request.control == SpawnProcessControl::Enabled).then(|| {
                     let control = handle.control_handle();
@@ -1649,7 +1666,9 @@ impl Sandbox for FirecrackerSandbox {
                     .streams_stdout()
                     .then(|| handle.take_stdout_receiver())
                     .flatten();
-                let lease = guest.into_lease();
+                let lease = guest
+                    .into_in_guest_lease()
+                    .map_err(|error| Self::operation_gate_transition_error(operation, error))?;
                 let exit = gated_spawn_exit_future(
                     async move {
                         let event = handle.wait().await?;

--- a/crates/vsock-host/src/exec_operation.rs
+++ b/crates/vsock-host/src/exec_operation.rs
@@ -9,7 +9,7 @@ use tokio::sync::{mpsc, oneshot};
 use tokio::time::Instant;
 
 use crate::{
-    CompositeNormalOperation, ConnectionState, ExecResult, Shared,
+    CompositeNormalOperation, ConnectionState, ExecResult, FrameWriteObserver, Shared,
     normal_operation_transition_error,
     operation_tracker::{NormalOperationToken, NormalOperationTransitionHandle},
 };
@@ -478,6 +478,7 @@ impl ExecOperationHandle {
             &payload,
             Some(self.diagnostic.frame("cancel")),
             None,
+            FrameWriteObserver::default(),
         )
         .await?;
         tracing::info!(
@@ -609,6 +610,7 @@ impl Drop for ExecOperationCancelOnDropGuard {
                     &payload,
                     Some(diagnostic.frame("drop-cancel")),
                     None,
+                    FrameWriteObserver::default(),
                 ),
             )
             .await;
@@ -1009,6 +1011,7 @@ async fn write_frame(
     payload: &[u8],
     diagnostic: Option<ExecOperationFrameDiagnostic>,
     normal_operation_seq: Option<u32>,
+    write_observer: FrameWriteObserver,
 ) -> io::Result<()> {
     let data = vsock_proto::encode(msg_type, seq, payload)
         .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e.to_string()))?;
@@ -1021,6 +1024,7 @@ async fn write_frame(
     if let Some(normal_operation_seq) = normal_operation_seq {
         mark_exec_operation_possible_guest_write(shared, normal_operation_seq)?;
     }
+    write_observer.record_write_start()?;
     state.store(EXEC_OPERATION_FRAME_WRITE_STARTED, Ordering::Release);
     let write_started_at = Instant::now();
     let result = writer.write_all(&data).await;
@@ -1144,14 +1148,20 @@ pub(crate) async fn start_exec_operation_on_shared(
     shared: &Arc<Shared>,
     request: ExecOperationRequest<'_>,
 ) -> io::Result<ExecOperationHandle> {
-    start_exec_operation_on_shared_with_tracking(shared, request, ExecOperationTracking::Tracked)
-        .await
+    start_exec_operation_on_shared_with_tracking(
+        shared,
+        request,
+        ExecOperationTracking::Tracked,
+        FrameWriteObserver::default(),
+    )
+    .await
 }
 
 async fn start_exec_operation_on_shared_with_tracking(
     shared: &Arc<Shared>,
     request: ExecOperationRequest<'_>,
     tracking: ExecOperationTracking<'_>,
+    write_observer: FrameWriteObserver,
 ) -> io::Result<ExecOperationHandle> {
     if request.timeout_ms == 0 {
         return Err(io::Error::new(
@@ -1261,6 +1271,7 @@ async fn start_exec_operation_on_shared_with_tracking(
         &payload,
         Some(diagnostic.frame("start")),
         tracks_normal_operation.then_some(seq),
+        write_observer,
     )
     .await?;
     registration_guard.disarm();
@@ -1304,6 +1315,7 @@ async fn exec_operation_capture_on_shared_with_tracking(
     shared: &Arc<Shared>,
     request: ExecCaptureRequest<'_>,
     tracking: ExecOperationTracking<'_>,
+    write_observer: FrameWriteObserver,
 ) -> io::Result<ExecOperationResult> {
     let handle = start_exec_operation_on_shared_with_tracking(
         shared,
@@ -1323,6 +1335,7 @@ async fn exec_operation_capture_on_shared_with_tracking(
             stream_queue_capacity: None,
         },
         tracking,
+        write_observer,
     )
     .await?;
     handle.wait(request.wait_timeout).await
@@ -1332,14 +1345,20 @@ pub(crate) async fn exec_operation_stream_on_shared(
     shared: &Arc<Shared>,
     request: ExecStreamRequest<'_>,
 ) -> io::Result<ExecOperationHandle> {
-    exec_operation_stream_on_shared_with_tracking(shared, request, ExecOperationTracking::Tracked)
-        .await
+    exec_operation_stream_on_shared_with_tracking(
+        shared,
+        request,
+        ExecOperationTracking::Tracked,
+        FrameWriteObserver::default(),
+    )
+    .await
 }
 
 async fn exec_operation_stream_on_shared_with_tracking(
     shared: &Arc<Shared>,
     request: ExecStreamRequest<'_>,
     tracking: ExecOperationTracking<'_>,
+    write_observer: FrameWriteObserver,
 ) -> io::Result<ExecOperationHandle> {
     if !output_policy_streams(request.stdout) && !output_policy_streams(request.stderr) {
         return Err(io::Error::new(
@@ -1362,19 +1381,22 @@ async fn exec_operation_stream_on_shared_with_tracking(
             stream_queue_capacity: request.stream_queue_capacity,
         },
         tracking,
+        write_observer,
     )
     .await
 }
 
-pub(crate) async fn exec_operation_stream_with_composite_on_shared(
+pub(crate) async fn exec_operation_stream_with_composite_on_shared_and_observer(
     shared: &Arc<Shared>,
     request: ExecStreamRequest<'_>,
     normal_operation: &mut CompositeNormalOperation,
+    write_observer: FrameWriteObserver,
 ) -> io::Result<ExecOperationHandle> {
     exec_operation_stream_on_shared_with_tracking(
         shared,
         request,
         ExecOperationTracking::Composite(normal_operation),
+        write_observer,
     )
     .await
 }
@@ -1404,12 +1426,13 @@ pub(crate) async fn exec_on_shared(
     .await
 }
 
-pub(crate) async fn exec_cleanup_untracked_on_shared(
+pub(crate) async fn exec_cleanup_untracked_on_shared_with_write_observer(
     shared: &Arc<Shared>,
     command: &str,
     timeout_ms: u32,
     env: &[(&str, &str)],
     sudo: bool,
+    write_observer: FrameWriteObserver,
 ) -> io::Result<ExecResult> {
     let result = exec_operation_capture_on_shared_with_tracking(
         shared,
@@ -1425,18 +1448,20 @@ pub(crate) async fn exec_cleanup_untracked_on_shared(
             wait_timeout: Duration::from_millis(timeout_ms as u64),
         },
         ExecOperationTracking::Untracked,
+        write_observer,
     )
     .await?;
     result_to_exec_result(result)
 }
 
-pub(crate) async fn exec_cleanup_with_composite_on_shared(
+pub(crate) async fn exec_cleanup_with_composite_on_shared_and_observer(
     shared: &Arc<Shared>,
     command: &str,
     timeout_ms: u32,
     env: &[(&str, &str)],
     sudo: bool,
     normal_operation: &mut CompositeNormalOperation,
+    write_observer: FrameWriteObserver,
 ) -> io::Result<ExecResult> {
     let result = exec_operation_capture_on_shared_with_tracking(
         shared,
@@ -1452,20 +1477,23 @@ pub(crate) async fn exec_cleanup_with_composite_on_shared(
             wait_timeout: Duration::from_millis(timeout_ms as u64),
         },
         ExecOperationTracking::Composite(normal_operation),
+        write_observer,
     )
     .await?;
     result_to_exec_result(result)
 }
 
-pub(crate) async fn exec_capture_with_composite_on_shared(
+pub(crate) async fn exec_capture_with_composite_on_shared_and_observer(
     shared: &Arc<Shared>,
     request: ExecCaptureRequest<'_>,
     normal_operation: &mut CompositeNormalOperation,
+    write_observer: FrameWriteObserver,
 ) -> io::Result<ExecResult> {
     let result = exec_operation_capture_on_shared_with_tracking(
         shared,
         request,
         ExecOperationTracking::Composite(normal_operation),
+        write_observer,
     )
     .await?;
     result_to_exec_result(result)
@@ -1475,13 +1503,27 @@ pub(crate) async fn exec_capture_on_shared(
     shared: &Arc<Shared>,
     request: ExecCaptureRequest<'_>,
 ) -> io::Result<ExecResult> {
+    exec_capture_on_shared_with_write_observer(shared, request, FrameWriteObserver::default()).await
+}
+
+pub(crate) async fn exec_capture_on_shared_with_write_observer(
+    shared: &Arc<Shared>,
+    request: ExecCaptureRequest<'_>,
+    write_observer: FrameWriteObserver,
+) -> io::Result<ExecResult> {
     if request.timeout_ms == 0 {
         return Err(io::Error::new(
             io::ErrorKind::InvalidInput,
             "exec requires a positive timeout; use spawn_process for unbounded commands",
         ));
     }
-    let result = exec_operation_capture_on_shared(shared, request).await?;
+    let result = exec_operation_capture_on_shared_with_tracking(
+        shared,
+        request,
+        ExecOperationTracking::Tracked,
+        write_observer,
+    )
+    .await?;
     result_to_exec_result(result)
 }
 

--- a/crates/vsock-host/src/file.rs
+++ b/crates/vsock-host/src/file.rs
@@ -2,7 +2,7 @@ use std::future::Future;
 use std::io;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::Duration;
 
 use tokio::io::AsyncWriteExt;
@@ -116,6 +116,7 @@ struct ChunkedWriteCleanupGuard {
     command: String,
     sudo: bool,
     write_observer: FrameWriteObserver,
+    cleanup_armed: Arc<AtomicBool>,
 }
 
 impl ChunkedWriteCleanupGuard {
@@ -124,12 +125,14 @@ impl ChunkedWriteCleanupGuard {
         command: String,
         sudo: bool,
         write_observer: FrameWriteObserver,
+        cleanup_armed: Arc<AtomicBool>,
     ) -> Self {
         Self {
             shared: Some(shared),
             command,
             sudo,
             write_observer,
+            cleanup_armed,
         }
     }
 
@@ -141,6 +144,11 @@ impl ChunkedWriteCleanupGuard {
         &mut self,
         normal_operation: &mut CompositeNormalOperation,
     ) -> io::Result<()> {
+        if !self.cleanup_armed.load(Ordering::Acquire) {
+            self.disarm();
+            return Ok(());
+        }
+
         let result = if let Some(shared) = self.shared.as_ref() {
             cleanup_timeout(
                 exec_operation::exec_cleanup_with_composite_on_shared_and_observer(
@@ -192,6 +200,9 @@ impl Drop for ChunkedWriteCleanupGuard {
         let Some(shared) = self.shared.take() else {
             return;
         };
+        if !self.cleanup_armed.load(Ordering::Acquire) {
+            return;
+        }
 
         let command = std::mem::take(&mut self.command);
         let sudo = self.sudo;
@@ -213,6 +224,17 @@ impl Drop for ChunkedWriteCleanupGuard {
             });
         }
     }
+}
+
+fn write_observer_that_arms_cleanup(
+    write_observer: FrameWriteObserver,
+    cleanup_armed: Arc<AtomicBool>,
+) -> FrameWriteObserver {
+    FrameWriteObserver::new(move || {
+        write_observer.record_write_start()?;
+        cleanup_armed.store(true, Ordering::Release);
+        Ok(())
+    })
 }
 
 struct HostTempFileGuard {
@@ -744,11 +766,15 @@ impl VsockHost {
         let tmp = format!("{path}.vm0tmp-{}", self.shared.next_seq());
         let quoted_tmp = shell_quote(&tmp);
         let rm_tmp = format!("rm -f -- {quoted_tmp}");
+        let cleanup_armed = Arc::new(AtomicBool::new(false));
+        let write_observer =
+            write_observer_that_arms_cleanup(write_observer, Arc::clone(&cleanup_armed));
         let mut cleanup_guard = ChunkedWriteCleanupGuard::new(
             Arc::clone(&self.shared),
             rm_tmp,
             sudo,
             write_observer.clone(),
+            cleanup_armed,
         );
 
         let result = async {

--- a/crates/vsock-host/src/file.rs
+++ b/crates/vsock-host/src/file.rs
@@ -736,8 +736,8 @@ impl VsockHost {
             .await
     }
 
-    /// Write a file on the guest and report when the first helper frame is
-    /// about to be written to the guest.
+    /// Write a file on the guest and report before each helper frame is
+    /// written to the guest.
     pub async fn write_file_with_write_observer(
         &self,
         path: &str,

--- a/crates/vsock-host/src/file.rs
+++ b/crates/vsock-host/src/file.rs
@@ -206,7 +206,7 @@ impl Drop for ChunkedWriteCleanupGuard {
 
         let command = std::mem::take(&mut self.command);
         let sudo = self.sudo;
-        let write_observer = self.write_observer.clone();
+        let write_observer = FrameWriteObserver::default();
         if let Ok(handle) = tokio::runtime::Handle::try_current() {
             handle.spawn(async move {
                 let _ = cleanup_timeout(

--- a/crates/vsock-host/src/file.rs
+++ b/crates/vsock-host/src/file.rs
@@ -13,8 +13,9 @@ use vsock_proto::{
 
 use crate::{
     CompositeNormalOperation, ExecCaptureRequest, ExecOperationResult, ExecOutputEvent,
-    ExecOwnedCapturedOutput, ExecResult, ExecStreamRequest, Shared, VsockHost, exec_operation,
-    normal_request_on_shared, request_on_shared_with_composite_operation,
+    ExecOwnedCapturedOutput, ExecResult, ExecStreamRequest, FrameWriteObserver, Shared, VsockHost,
+    exec_operation, normal_request_on_shared_with_write_observer,
+    request_on_shared_with_composite_operation_and_observer,
 };
 
 const COPY_TEMP_CREATE_ATTEMPTS: usize = 16;
@@ -66,6 +67,14 @@ struct CopyFileToTempError {
     terminal_proven: bool,
 }
 
+struct CopyFileToTempRequest<'a> {
+    path: &'a str,
+    stream_limit_bytes: u32,
+    timeout_ms: u32,
+    missing_ok: bool,
+    write_observer: FrameWriteObserver,
+}
+
 impl CopyFileToTempError {
     fn unproven(error: io::Error) -> Self {
         Self {
@@ -106,14 +115,21 @@ struct ChunkedWriteCleanupGuard {
     shared: Option<Arc<Shared>>,
     command: String,
     sudo: bool,
+    write_observer: FrameWriteObserver,
 }
 
 impl ChunkedWriteCleanupGuard {
-    fn new(shared: Arc<Shared>, command: String, sudo: bool) -> Self {
+    fn new(
+        shared: Arc<Shared>,
+        command: String,
+        sudo: bool,
+        write_observer: FrameWriteObserver,
+    ) -> Self {
         Self {
             shared: Some(shared),
             command,
             sudo,
+            write_observer,
         }
     }
 
@@ -127,13 +143,14 @@ impl ChunkedWriteCleanupGuard {
     ) -> io::Result<()> {
         let result = if let Some(shared) = self.shared.as_ref() {
             cleanup_timeout(
-                exec_operation::exec_cleanup_with_composite_on_shared(
+                exec_operation::exec_cleanup_with_composite_on_shared_and_observer(
                     shared,
                     &self.command,
                     CLEANUP_EXEC_TIMEOUT_MS,
                     &[],
                     self.sudo,
                     normal_operation,
+                    self.write_observer.clone(),
                 ),
                 CLEANUP_EXEC_TIMEOUT_MS,
             )
@@ -178,15 +195,17 @@ impl Drop for ChunkedWriteCleanupGuard {
 
         let command = std::mem::take(&mut self.command);
         let sudo = self.sudo;
+        let write_observer = self.write_observer.clone();
         if let Ok(handle) = tokio::runtime::Handle::try_current() {
             handle.spawn(async move {
                 let _ = cleanup_timeout(
-                    exec_operation::exec_cleanup_untracked_on_shared(
+                    exec_operation::exec_cleanup_untracked_on_shared_with_write_observer(
                         &shared,
                         &command,
                         CLEANUP_EXEC_TIMEOUT_MS,
                         &[],
                         sudo,
+                        write_observer,
                     ),
                     CLEANUP_EXEC_TIMEOUT_MS,
                 )
@@ -389,6 +408,24 @@ impl VsockHost {
         max_bytes: u64,
         timeout_ms: u32,
     ) -> io::Result<Option<Vec<u8>>> {
+        self.read_file_with_write_observer(
+            path,
+            max_bytes,
+            timeout_ms,
+            FrameWriteObserver::default(),
+        )
+        .await
+    }
+
+    /// Read a small file and report when the helper exec frame is about to be
+    /// written to the guest.
+    pub async fn read_file_with_write_observer(
+        &self,
+        path: &str,
+        max_bytes: u64,
+        timeout_ms: u32,
+        write_observer: FrameWriteObserver,
+    ) -> io::Result<Option<Vec<u8>>> {
         let stdout_limit_bytes = u32::try_from(max_bytes).map_err(|_| {
             io::Error::new(
                 io::ErrorKind::InvalidInput,
@@ -408,17 +445,20 @@ impl VsockHost {
             path = shell_quote(path)
         );
         let result = self
-            .exec_capture(ExecCaptureRequest {
-                timeout_ms,
-                command: &command,
-                env: &[],
-                sudo: false,
-                label: "read-file",
-                stdout_limit_bytes,
-                stderr_limit_bytes: exec_operation::SMALL_EXEC_CAPTURE_LIMIT_BYTES,
-                expected_exit_codes: &[MISSING_FILE_EXIT_CODE],
-                wait_timeout: Duration::from_millis(timeout_ms as u64 + 5000),
-            })
+            .exec_capture_with_write_observer(
+                ExecCaptureRequest {
+                    timeout_ms,
+                    command: &command,
+                    env: &[],
+                    sudo: false,
+                    label: "read-file",
+                    stdout_limit_bytes,
+                    stderr_limit_bytes: exec_operation::SMALL_EXEC_CAPTURE_LIMIT_BYTES,
+                    expected_exit_codes: &[MISSING_FILE_EXIT_CODE],
+                    wait_timeout: Duration::from_millis(timeout_ms as u64 + 5000),
+                },
+                write_observer,
+            )
             .await?;
         if result.exit_code == MISSING_FILE_EXIT_CODE {
             return Ok(None);
@@ -449,6 +489,19 @@ impl VsockHost {
         path: &str,
         host_path: &Path,
         options: CopyFileOptions,
+    ) -> io::Result<CopyFileResult> {
+        self.copy_file_with_write_observer(path, host_path, options, FrameWriteObserver::default())
+            .await
+    }
+
+    /// Stream a guest file to a host path and report when the helper exec
+    /// frame is about to be written to the guest.
+    pub async fn copy_file_with_write_observer(
+        &self,
+        path: &str,
+        host_path: &Path,
+        options: CopyFileOptions,
+        write_observer: FrameWriteObserver,
     ) -> io::Result<CopyFileResult> {
         if options.max_bytes == 0 {
             return Err(io::Error::new(
@@ -487,11 +540,14 @@ impl VsockHost {
         let mut normal_operation = CompositeNormalOperation::reserve(&self.shared)?;
         let copy_result = self
             .copy_file_to_temp(
-                path,
+                CopyFileToTempRequest {
+                    path,
+                    stream_limit_bytes,
+                    timeout_ms: options.timeout_ms,
+                    missing_ok: options.missing_ok,
+                    write_observer,
+                },
                 temp_file,
-                stream_limit_bytes,
-                options.timeout_ms,
-                options.missing_ok,
                 &mut normal_operation,
             )
             .await;
@@ -527,13 +583,17 @@ impl VsockHost {
 
     async fn copy_file_to_temp(
         &self,
-        path: &str,
+        request: CopyFileToTempRequest<'_>,
         mut temp_file: tokio::fs::File,
-        stream_limit_bytes: u32,
-        timeout_ms: u32,
-        missing_ok: bool,
         normal_operation: &mut CompositeNormalOperation,
     ) -> Result<CopyFileOutcome, CopyFileToTempError> {
+        let CopyFileToTempRequest {
+            path,
+            stream_limit_bytes,
+            timeout_ms,
+            missing_ok,
+            write_observer,
+        } = request;
         const MISSING_FILE_EXIT_CODE: i32 = 66;
         let command = format!(
             "if test -f {path}; then cat -- {path}; else exit {MISSING_FILE_EXIT_CODE}; fi",
@@ -544,28 +604,30 @@ impl VsockHost {
         } else {
             &[]
         };
-        let mut handle = exec_operation::exec_operation_stream_with_composite_on_shared(
-            &self.shared,
-            ExecStreamRequest {
-                timeout_ms,
-                command: &command,
-                env: &[],
-                sudo: false,
-                label: "copy-file",
-                stdout: ExecOutputPolicy::Stream {
-                    limit_bytes: stream_limit_bytes,
-                    chunk_limit_bytes: COPY_FILE_STREAM_CHUNK_LIMIT,
+        let mut handle =
+            exec_operation::exec_operation_stream_with_composite_on_shared_and_observer(
+                &self.shared,
+                ExecStreamRequest {
+                    timeout_ms,
+                    command: &command,
+                    env: &[],
+                    sudo: false,
+                    label: "copy-file",
+                    stdout: ExecOutputPolicy::Stream {
+                        limit_bytes: stream_limit_bytes,
+                        chunk_limit_bytes: COPY_FILE_STREAM_CHUNK_LIMIT,
+                    },
+                    stderr: ExecOutputPolicy::Capture {
+                        limit_bytes: exec_operation::SMALL_EXEC_CAPTURE_LIMIT_BYTES,
+                    },
+                    expected_exit_codes,
+                    stream_queue_capacity: Some(COPY_FILE_STREAM_QUEUE_CAPACITY),
                 },
-                stderr: ExecOutputPolicy::Capture {
-                    limit_bytes: exec_operation::SMALL_EXEC_CAPTURE_LIMIT_BYTES,
-                },
-                expected_exit_codes,
-                stream_queue_capacity: Some(COPY_FILE_STREAM_QUEUE_CAPACITY),
-            },
-            normal_operation,
-        )
-        .await
-        .map_err(CopyFileToTempError::unproven)?;
+                normal_operation,
+                write_observer,
+            )
+            .await
+            .map_err(CopyFileToTempError::unproven)?;
         let mut cancel_on_drop = exec_operation::ExecOperationCancelOnDropGuard::new(&handle);
         let mut stream_rx = handle.take_stream_receiver().ok_or_else(|| {
             CopyFileToTempError::unproven(io::Error::new(
@@ -648,9 +710,29 @@ impl VsockHost {
     ///
     /// Non-sudo writes create missing parent directories on the guest.
     pub async fn write_file(&self, path: &str, content: &[u8], sudo: bool) -> io::Result<()> {
+        self.write_file_with_write_observer(path, content, sudo, FrameWriteObserver::default())
+            .await
+    }
+
+    /// Write a file on the guest and report when the first helper frame is
+    /// about to be written to the guest.
+    pub async fn write_file_with_write_observer(
+        &self,
+        path: &str,
+        content: &[u8],
+        sudo: bool,
+        write_observer: FrameWriteObserver,
+    ) -> io::Result<()> {
         if content.len() <= WRITE_FILE_CHUNK_LIMIT {
             return self
-                .write_file_chunk(path, content, sudo, false, WriteFileChunkTracking::Tracked)
+                .write_file_chunk(
+                    path,
+                    content,
+                    sudo,
+                    false,
+                    WriteFileChunkTracking::Tracked,
+                    write_observer,
+                )
                 .await;
         }
 
@@ -662,8 +744,12 @@ impl VsockHost {
         let tmp = format!("{path}.vm0tmp-{}", self.shared.next_seq());
         let quoted_tmp = shell_quote(&tmp);
         let rm_tmp = format!("rm -f -- {quoted_tmp}");
-        let mut cleanup_guard =
-            ChunkedWriteCleanupGuard::new(Arc::clone(&self.shared), rm_tmp, sudo);
+        let mut cleanup_guard = ChunkedWriteCleanupGuard::new(
+            Arc::clone(&self.shared),
+            rm_tmp,
+            sudo,
+            write_observer.clone(),
+        );
 
         let result = async {
             for (i, chunk) in content.chunks(WRITE_FILE_CHUNK_LIMIT).enumerate() {
@@ -673,6 +759,7 @@ impl VsockHost {
                     sudo,
                     i > 0,
                     WriteFileChunkTracking::Composite(&mut normal_operation),
+                    write_observer.clone(),
                 )
                 .await?;
             }
@@ -692,7 +779,7 @@ impl VsockHost {
 
         // Atomic rename temp → target.
         let mv_cmd = format!("mv -f -- {quoted_tmp} {}", shell_quote(path));
-        match exec_operation::exec_capture_with_composite_on_shared(
+        match exec_operation::exec_capture_with_composite_on_shared_and_observer(
             &self.shared,
             ExecCaptureRequest {
                 command: &mv_cmd,
@@ -706,6 +793,7 @@ impl VsockHost {
                 wait_timeout: Duration::from_millis(HELPER_EXEC_TIMEOUT_MS as u64 + 5000),
             },
             &mut normal_operation,
+            write_observer,
         )
         .await
         {
@@ -745,29 +833,32 @@ impl VsockHost {
         sudo: bool,
         append: bool,
         tracking: WriteFileChunkTracking<'_>,
+        write_observer: FrameWriteObserver,
     ) -> io::Result<()> {
         let payload = vsock_proto::encode_write_file(path, content, sudo, append)
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e.to_string()))?;
         let timeout = Duration::from_secs(300);
         let resp = match tracking {
             WriteFileChunkTracking::Tracked => {
-                normal_request_on_shared(
+                normal_request_on_shared_with_write_observer(
                     &self.shared,
                     MSG_WRITE_FILE,
                     &payload,
                     WRITE_FILE_TERMINAL_MSG_TYPES,
                     timeout,
+                    write_observer,
                 )
                 .await?
             }
             WriteFileChunkTracking::Composite(normal_operation) => {
-                request_on_shared_with_composite_operation(
+                request_on_shared_with_composite_operation_and_observer(
                     &self.shared,
                     MSG_WRITE_FILE,
                     &payload,
                     WRITE_FILE_TERMINAL_MSG_TYPES,
                     timeout,
                     normal_operation,
+                    write_observer,
                 )
                 .await?
             }

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -60,6 +60,37 @@ pub use process::{
 
 const READ_BUF_SIZE: usize = 64 * 1024;
 
+/// Observer called when a request frame reaches the guest-write boundary.
+///
+/// The callback is synchronous because it runs while the shared writer lock is
+/// held, immediately before frame bytes are written.
+#[derive(Clone)]
+pub struct FrameWriteObserver {
+    record_write_start: Arc<dyn Fn() -> io::Result<()> + Send + Sync>,
+}
+
+impl FrameWriteObserver {
+    pub fn new(record_write_start: impl Fn() -> io::Result<()> + Send + Sync + 'static) -> Self {
+        Self {
+            record_write_start: Arc::new(record_write_start),
+        }
+    }
+
+    pub fn noop() -> Self {
+        Self::new(|| Ok(()))
+    }
+
+    fn record_write_start(&self) -> io::Result<()> {
+        (self.record_write_start)()
+    }
+}
+
+impl Default for FrameWriteObserver {
+    fn default() -> Self {
+        Self::noop()
+    }
+}
+
 /// Result of executing a command on the guest.
 #[derive(Debug, Clone)]
 pub struct ExecResult {
@@ -68,6 +99,16 @@ pub struct ExecResult {
     pub stderr: Vec<u8>,
     pub stdout_truncated: bool,
     pub stderr_truncated: bool,
+}
+
+/// Request parameters for spawning a process on the guest.
+pub struct ProcessSpawnRequest<'a> {
+    pub command: &'a str,
+    pub timeout_ms: u32,
+    pub env: &'a [(&'a str, &'a str)],
+    pub sudo: bool,
+    pub stream_stdout: bool,
+    pub stdout_log_path: Option<&'a str>,
 }
 
 /// Connection lifecycle, expressed as data rather than a separate atomic flag.
@@ -592,47 +633,37 @@ async fn request_raw_on_shared(
     }
 }
 
-async fn normal_request_on_shared(
+async fn normal_request_on_shared_with_write_observer(
     shared: &Arc<Shared>,
     msg_type: u8,
     payload: &[u8],
     terminal_msg_types: &'static [u8],
     timeout: Duration,
+    write_observer: FrameWriteObserver,
 ) -> io::Result<RawMessage> {
     let seq = shared.next_seq();
-    normal_request_raw_on_shared(shared, msg_type, seq, payload, terminal_msg_types, timeout).await
-}
-
-async fn request_on_shared_with_composite_operation(
-    shared: &Arc<Shared>,
-    msg_type: u8,
-    payload: &[u8],
-    terminal_msg_types: &'static [u8],
-    timeout: Duration,
-    normal_operation: &mut CompositeNormalOperation,
-) -> io::Result<RawMessage> {
-    let seq = shared.next_seq();
-    request_raw_on_shared_with_composite_operation(
+    normal_request_raw_on_shared_with_write_observer(
         shared,
         msg_type,
         seq,
         payload,
         terminal_msg_types,
         timeout,
-        normal_operation,
+        write_observer,
     )
     .await
 }
 
-async fn request_raw_on_shared_with_composite_operation(
+async fn request_on_shared_with_composite_operation_and_observer(
     shared: &Arc<Shared>,
     msg_type: u8,
-    seq: u32,
     payload: &[u8],
     terminal_msg_types: &'static [u8],
     timeout: Duration,
     normal_operation: &mut CompositeNormalOperation,
+    write_observer: FrameWriteObserver,
 ) -> io::Result<RawMessage> {
+    let seq = shared.next_seq();
     let data = vsock_proto::encode(msg_type, seq, payload)
         .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e.to_string()))?;
 
@@ -663,7 +694,8 @@ async fn request_raw_on_shared_with_composite_operation(
     let _pending_guard = PendingRequestGuard::new(Arc::clone(shared), seq);
 
     write_request_frame(shared, &data, || {
-        normal_operation.mark_possible_guest_write_started()
+        normal_operation.mark_possible_guest_write_started()?;
+        write_observer.record_write_start()
     })
     .await?;
 
@@ -681,13 +713,14 @@ async fn request_raw_on_shared_with_composite_operation(
     }
 }
 
-async fn normal_request_raw_on_shared(
+async fn normal_request_raw_on_shared_with_write_observer(
     shared: &Arc<Shared>,
     msg_type: u8,
     seq: u32,
     payload: &[u8],
     terminal_msg_types: &'static [u8],
     timeout: Duration,
+    write_observer: FrameWriteObserver,
 ) -> io::Result<RawMessage> {
     let data = vsock_proto::encode(msg_type, seq, payload)
         .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e.to_string()))?;
@@ -718,7 +751,8 @@ async fn normal_request_raw_on_shared(
     let _pending_guard = PendingRequestGuard::new(Arc::clone(shared), seq);
 
     write_request_frame(shared, &data, || {
-        mark_pending_normal_operation_possible_guest_write(shared, seq)
+        mark_pending_normal_operation_possible_guest_write(shared, seq)?;
+        write_observer.record_write_start()
     })
     .await?;
 
@@ -1092,6 +1126,21 @@ impl VsockHost {
         exec_operation::exec_capture_on_shared(&self.shared, request).await
     }
 
+    /// Execute a capture-style command and report when its start frame is
+    /// about to be written to the guest.
+    pub async fn exec_capture_with_write_observer(
+        &self,
+        request: ExecCaptureRequest<'_>,
+        write_observer: FrameWriteObserver,
+    ) -> io::Result<ExecResult> {
+        exec_operation::exec_capture_on_shared_with_write_observer(
+            &self.shared,
+            request,
+            write_observer,
+        )
+        .await
+    }
+
     /// Spawn a process on the guest and monitor for exit.
     ///
     /// Returns immediately with a handle. Use [`GuestProcessHandle::wait`] to
@@ -1114,6 +1163,35 @@ impl VsockHost {
         stream_stdout: bool,
         stdout_log_path: Option<&str>,
     ) -> io::Result<GuestProcessHandle> {
+        self.spawn_process_with_request_and_write_observer(
+            ProcessSpawnRequest {
+                command,
+                timeout_ms,
+                env,
+                sudo,
+                stream_stdout,
+                stdout_log_path,
+            },
+            FrameWriteObserver::default(),
+        )
+        .await
+    }
+
+    /// Spawn a process and report when its request frame is about to be
+    /// written to the guest.
+    pub async fn spawn_process_with_request_and_write_observer(
+        &self,
+        request: ProcessSpawnRequest<'_>,
+        write_observer: FrameWriteObserver,
+    ) -> io::Result<GuestProcessHandle> {
+        let ProcessSpawnRequest {
+            command,
+            timeout_ms,
+            env,
+            sudo,
+            stream_stdout,
+            stdout_log_path,
+        } = request;
         process::spawn_process_on_shared(
             &self.shared,
             process::SpawnProcessOnSharedRequest {
@@ -1124,6 +1202,7 @@ impl VsockHost {
                 stream_stdout,
                 stdout_log_path,
                 control_sink: false,
+                write_observer,
             },
         )
         .await
@@ -1140,6 +1219,35 @@ impl VsockHost {
         stream_stdout: bool,
         stdout_log_path: Option<&str>,
     ) -> io::Result<GuestProcessHandle> {
+        self.spawn_process_with_control_sink_request_and_write_observer(
+            ProcessSpawnRequest {
+                command,
+                timeout_ms,
+                env,
+                sudo,
+                stream_stdout,
+                stdout_log_path,
+            },
+            FrameWriteObserver::default(),
+        )
+        .await
+    }
+
+    /// Spawn a process with an operation-bound control sink and report when
+    /// its request frame is about to be written to the guest.
+    pub async fn spawn_process_with_control_sink_request_and_write_observer(
+        &self,
+        request: ProcessSpawnRequest<'_>,
+        write_observer: FrameWriteObserver,
+    ) -> io::Result<GuestProcessHandle> {
+        let ProcessSpawnRequest {
+            command,
+            timeout_ms,
+            env,
+            sudo,
+            stream_stdout,
+            stdout_log_path,
+        } = request;
         process::spawn_process_on_shared(
             &self.shared,
             process::SpawnProcessOnSharedRequest {
@@ -1150,6 +1258,7 @@ impl VsockHost {
                 stream_stdout,
                 stdout_log_path,
                 control_sink: true,
+                write_observer,
             },
         )
         .await

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -63,7 +63,10 @@ const READ_BUF_SIZE: usize = 64 * 1024;
 /// Observer called when a request frame reaches the guest-write boundary.
 ///
 /// The callback is synchronous because it runs while the shared writer lock is
-/// held, immediately before frame bytes are written.
+/// held, immediately before frame bytes are written. Keep the callback fast and
+/// do not call back into the same [`VsockHost`], because that can deadlock on
+/// the writer lock. Multi-frame helper operations may invoke the same observer
+/// more than once.
 #[derive(Clone)]
 pub struct FrameWriteObserver {
     record_write_start: Arc<dyn Fn() -> io::Result<()> + Send + Sync>,

--- a/crates/vsock-host/src/process.rs
+++ b/crates/vsock-host/src/process.rs
@@ -12,7 +12,7 @@ use vsock_proto::{
 };
 
 use crate::{
-    ConnectionState, PendingRequestGuard, PendingResponse, Shared,
+    ConnectionState, FrameWriteObserver, PendingRequestGuard, PendingResponse, Shared,
     operation_tracker::NormalOperationToken, request_on_shared,
 };
 
@@ -50,6 +50,7 @@ pub(crate) struct SpawnProcessOnSharedRequest<'a> {
     pub(crate) stream_stdout: bool,
     pub(crate) stdout_log_path: Option<&'a str>,
     pub(crate) control_sink: bool,
+    pub(crate) write_observer: FrameWriteObserver,
 }
 
 /// Process lifecycle state while the vsock connection is open.
@@ -673,6 +674,7 @@ async fn spawn_process_on_shared_with_response_timeout(
         stream_stdout,
         stdout_log_path,
         control_sink,
+        write_observer,
     } = request;
     let control_nonce = *uuid::Uuid::new_v4().as_bytes();
     let payload = if control_sink {
@@ -750,6 +752,7 @@ async fn spawn_process_on_shared_with_response_timeout(
         let mut write_guard = ProcessOperationFrameWriteGuard::new(Arc::clone(shared));
         let mut writer = shared.writer.lock().await;
         mark_process_operation_possible_guest_write(shared, seq)?;
+        write_observer.record_write_start()?;
         write_guard.mark_started();
         registration_guard.keep_on_drop();
         if let Err(error) = writer.write_all(&data).await {
@@ -831,6 +834,7 @@ pub(crate) mod test_support {
                 stream_stdout,
                 stdout_log_path: None,
                 control_sink: false,
+                write_observer: FrameWriteObserver::default(),
             },
             response_timeout,
         )

--- a/crates/vsock-host/src/tests/exec_operation/cancel.rs
+++ b/crates/vsock-host/src/tests/exec_operation/cancel.rs
@@ -169,6 +169,33 @@ async fn exec_write_observer_fires_at_frame_write_boundary() {
 }
 
 #[tokio::test]
+async fn exec_write_observer_error_cleans_registration_without_sending_frame() {
+    let (host, guest) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+
+    let err = host
+        .exec_capture_with_write_observer(
+            capture_request("observer-error"),
+            FrameWriteObserver::new(|| Err(io::Error::other("observer failed"))),
+        )
+        .await
+        .unwrap_err();
+
+    assert!(err.to_string().contains("observer failed"));
+    match guest.try_read(&mut [0u8; 1]) {
+        Err(err) if err.kind() == io::ErrorKind::WouldBlock => {}
+        Ok(n) => panic!("observer error must not send exec frame; read {n} bytes"),
+        Err(err) => panic!("unexpected read error after observer error: {err}"),
+    }
+    assert_eq!(operation_count(&host), 0);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::NotParkable
+    );
+    assert!(is_connected(&host));
+}
+
+#[tokio::test]
 async fn exec_operation_handle_drop_after_full_write_marks_not_parkable() {
     let (host, mut guest) = setup_host_and_guest().await;
     let host = Arc::new(host);

--- a/crates/vsock-host/src/tests/exec_operation/cancel.rs
+++ b/crates/vsock-host/src/tests/exec_operation/cancel.rs
@@ -1,5 +1,6 @@
 use std::io;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 
 use vsock_proto::{ExecTermination, MSG_EXEC_CANCEL, MSG_EXEC_START};
@@ -12,6 +13,21 @@ use super::super::support::{
 use super::start_capture_operation;
 use crate::exec_operation as exec_operation_impl;
 use crate::operation_tracker::NormalOperationReadiness;
+use crate::{ExecCaptureRequest, FrameWriteObserver};
+
+fn capture_request(command: &str) -> ExecCaptureRequest<'_> {
+    ExecCaptureRequest {
+        timeout_ms: 5000,
+        command,
+        env: &[],
+        sudo: false,
+        label: "test-command",
+        stdout_limit_bytes: 1024,
+        stderr_limit_bytes: 1024,
+        expected_exit_codes: &[],
+        wait_timeout: Duration::from_secs(5),
+    }
+}
 
 #[tokio::test]
 async fn exec_start_cancelled_before_write_does_not_poison_or_send_frame() {
@@ -60,6 +76,96 @@ async fn exec_start_cancelled_before_write_does_not_poison_or_send_frame() {
     let exec_result = exec_task.await.unwrap().unwrap();
     assert_eq!(exec_result.stdout, b"ok");
     assert!(is_connected(&host));
+}
+
+#[tokio::test]
+async fn exec_write_observer_does_not_fire_before_frame_write() {
+    let (host, _guest) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+    let write_start_count = Arc::new(AtomicUsize::new(0));
+    let writer_guard = host.shared.writer.lock().await;
+    let task = {
+        let host = Arc::clone(&host);
+        let write_start_count = Arc::clone(&write_start_count);
+        tokio::spawn(async move {
+            host.exec_capture_with_write_observer(
+                capture_request("blocked"),
+                FrameWriteObserver::new(move || {
+                    write_start_count.fetch_add(1, Ordering::SeqCst);
+                    Ok(())
+                }),
+            )
+            .await
+        })
+    };
+
+    tokio::time::timeout(Duration::from_secs(5), async {
+        while operation_count(&host) == 0 {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .unwrap();
+
+    task.abort();
+    let _ = task.await;
+    assert_eq!(write_start_count.load(Ordering::SeqCst), 0);
+    assert_eq!(operation_count(&host), 0);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Idle
+    );
+    assert!(is_connected(&host));
+
+    drop(writer_guard);
+}
+
+#[tokio::test]
+async fn exec_write_observer_fires_at_frame_write_boundary() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+    let write_start_count = Arc::new(AtomicUsize::new(0));
+    let writer_guard = host.shared.writer.lock().await;
+    let task = {
+        let host = Arc::clone(&host);
+        let write_start_count = Arc::clone(&write_start_count);
+        tokio::spawn(async move {
+            host.exec_capture_with_write_observer(
+                capture_request("observed"),
+                FrameWriteObserver::new(move || {
+                    write_start_count.fetch_add(1, Ordering::SeqCst);
+                    Ok(())
+                }),
+            )
+            .await
+        })
+    };
+
+    tokio::time::timeout(Duration::from_secs(5), async {
+        while operation_count(&host) == 0 {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .unwrap();
+    assert_eq!(write_start_count.load(Ordering::SeqCst), 0);
+
+    drop(writer_guard);
+    let msg = read_guest_message(&mut guest).await;
+    assert_eq!(msg.msg_type, MSG_EXEC_START);
+    assert_eq!(write_start_count.load(Ordering::SeqCst), 1);
+    send_exec_result(
+        &mut guest,
+        msg.seq,
+        ExecTermination::Exited { exit_code: 0 },
+        b"ok",
+        b"",
+    )
+    .await;
+
+    let result = task.await.unwrap().unwrap();
+    assert_eq!(result.stdout, b"ok");
+    assert_eq!(write_start_count.load(Ordering::SeqCst), 1);
 }
 
 #[tokio::test]

--- a/crates/vsock-host/src/tests/file.rs
+++ b/crates/vsock-host/src/tests/file.rs
@@ -13,8 +13,9 @@ use vsock_proto::{
 
 use super::support::{
     assert_connection_accepts_exec_operation, host_from_stream, make_pair, mock_handshake,
-    normal_operation_readiness, operation_count, read_guest_message, send_exec_output,
-    send_exec_result, send_raw_exec_result, send_stream_exec_result, setup_host_and_guest,
+    normal_operation_readiness, operation_count, pending_request_count, read_guest_message,
+    send_exec_output, send_exec_result, send_raw_exec_result, send_stream_exec_result,
+    setup_host_and_guest,
 };
 use crate::file as file_impl;
 use crate::{CopyFileOptions, FrameWriteObserver, operation_tracker::NormalOperationReadiness};
@@ -1199,6 +1200,51 @@ async fn write_file_cancelled_before_frame_write_does_not_poison_or_send_frame()
     write_task.abort();
     let _ = write_task.await;
     assert_eq!(write_start_count.load(Ordering::SeqCst), 0);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Idle
+    );
+
+    drop(writer_guard);
+    assert_connection_accepts_exec_operation(&host, &mut guest).await;
+}
+
+#[tokio::test]
+async fn write_file_chunked_cancelled_before_first_frame_write_does_not_cleanup() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+    let write_start_count = Arc::new(AtomicUsize::new(0));
+    let writer_guard = host.shared.writer.lock().await;
+    let content = vec![0xABu8; file_impl::test_support::WRITE_FILE_CHUNK_LIMIT + 1];
+    let write_task = {
+        let host = Arc::clone(&host);
+        let write_start_count = Arc::clone(&write_start_count);
+        tokio::spawn(async move {
+            host.write_file_with_write_observer(
+                "/tmp/big-blocked.bin",
+                &content,
+                false,
+                FrameWriteObserver::new(move || {
+                    write_start_count.fetch_add(1, Ordering::SeqCst);
+                    Ok(())
+                }),
+            )
+            .await
+        })
+    };
+
+    tokio::time::timeout(Duration::from_secs(5), async {
+        while pending_request_count(&host) != 1 {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .unwrap();
+    write_task.abort();
+    let _ = write_task.await;
+
+    assert_eq!(write_start_count.load(Ordering::SeqCst), 0);
+    assert_eq!(pending_request_count(&host), 0);
     assert_eq!(
         normal_operation_readiness(&host),
         NormalOperationReadiness::Idle

--- a/crates/vsock-host/src/tests/file.rs
+++ b/crates/vsock-host/src/tests/file.rs
@@ -1744,6 +1744,82 @@ async fn write_file_chunked_cleanup_error_retries_untracked_on_drop() {
 }
 
 #[tokio::test]
+async fn write_file_chunked_cleanup_retry_does_not_reuse_write_observer() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+    let write_start_count = Arc::new(AtomicUsize::new(0));
+
+    let chunk_limit = file_impl::test_support::WRITE_FILE_CHUNK_LIMIT;
+    let content = vec![0xABu8; chunk_limit + 100];
+    let write_task = {
+        let host = Arc::clone(&host);
+        let write_start_count = Arc::clone(&write_start_count);
+        tokio::spawn(async move {
+            host.write_file_with_write_observer(
+                "/tmp/big.bin",
+                &content,
+                false,
+                FrameWriteObserver::new(move || {
+                    let count = write_start_count.fetch_add(1, Ordering::SeqCst);
+                    if count >= 3 {
+                        return Err(io::Error::other("write observer is no longer active"));
+                    }
+                    Ok(())
+                }),
+            )
+            .await
+        })
+    };
+
+    let first = read_guest_message(&mut guest).await;
+    assert_eq!(first.msg_type, MSG_WRITE_FILE);
+    let payload = vsock_proto::encode_write_file_result(true, "");
+    guest
+        .write_all(&vsock_proto::encode(MSG_WRITE_FILE_RESULT, first.seq, &payload).unwrap())
+        .await
+        .unwrap();
+
+    let second = read_guest_message(&mut guest).await;
+    assert_eq!(second.msg_type, MSG_WRITE_FILE);
+    let payload = vsock_proto::encode_write_file_result(false, "disk full");
+    guest
+        .write_all(&vsock_proto::encode(MSG_WRITE_FILE_RESULT, second.seq, &payload).unwrap())
+        .await
+        .unwrap();
+
+    let cleanup = read_guest_message(&mut guest).await;
+    assert_eq!(cleanup.msg_type, MSG_EXEC_START);
+    let decoded = vsock_proto::decode_exec_start(&cleanup.payload).unwrap();
+    assert_eq!(decoded.label, "exec-cleanup");
+    let payload = vsock_proto::encode_error("cleanup unavailable");
+    guest
+        .write_all(&vsock_proto::encode(MSG_ERROR, cleanup.seq, &payload).unwrap())
+        .await
+        .unwrap();
+
+    let err = write_task.await.unwrap().unwrap_err();
+    assert!(err.to_string().contains("disk full"));
+    assert_eq!(write_start_count.load(Ordering::SeqCst), 3);
+
+    let retry = tokio::time::timeout(Duration::from_secs(2), read_guest_message(&mut guest))
+        .await
+        .expect("cleanup retry was not sent after observer became inactive");
+    assert_eq!(retry.msg_type, MSG_EXEC_START);
+    let decoded = vsock_proto::decode_exec_start(&retry.payload).unwrap();
+    assert_eq!(decoded.label, "exec-cleanup");
+    assert!(decoded.command.contains("rm -f --"));
+    send_exec_result(
+        &mut guest,
+        retry.seq,
+        ExecTermination::Exited { exit_code: 0 },
+        &[],
+        &[],
+    )
+    .await;
+    assert_eq!(write_start_count.load(Ordering::SeqCst), 3);
+}
+
+#[tokio::test]
 async fn write_file_chunked_cleanup_nonzero_exit_retries_untracked_on_drop() {
     let (host, mut guest) = setup_host_and_guest().await;
     let host = Arc::new(host);

--- a/crates/vsock-host/src/tests/file.rs
+++ b/crates/vsock-host/src/tests/file.rs
@@ -1,6 +1,7 @@
 use std::io;
 use std::path::Path;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -16,7 +17,7 @@ use super::support::{
     send_exec_result, send_raw_exec_result, send_stream_exec_result, setup_host_and_guest,
 };
 use crate::file as file_impl;
-use crate::{CopyFileOptions, operation_tracker::NormalOperationReadiness};
+use crate::{CopyFileOptions, FrameWriteObserver, operation_tracker::NormalOperationReadiness};
 
 #[tokio::test]
 async fn copy_file_rejects_max_bytes_above_stream_budget() {
@@ -1169,10 +1170,23 @@ async fn dropping_write_file_after_request_marks_tracker_not_parkable() {
 async fn write_file_cancelled_before_frame_write_does_not_poison_or_send_frame() {
     let (host, mut guest) = setup_host_and_guest().await;
     let host = Arc::new(host);
+    let write_start_count = Arc::new(AtomicUsize::new(0));
     let writer_guard = host.shared.writer.lock().await;
     let write_task = {
         let host = Arc::clone(&host);
-        tokio::spawn(async move { host.write_file("/tmp/blocked.txt", b"hello", false).await })
+        let write_start_count = Arc::clone(&write_start_count);
+        tokio::spawn(async move {
+            host.write_file_with_write_observer(
+                "/tmp/blocked.txt",
+                b"hello",
+                false,
+                FrameWriteObserver::new(move || {
+                    write_start_count.fetch_add(1, Ordering::SeqCst);
+                    Ok(())
+                }),
+            )
+            .await
+        })
     };
 
     tokio::time::timeout(Duration::from_secs(5), async {
@@ -1184,6 +1198,7 @@ async fn write_file_cancelled_before_frame_write_does_not_poison_or_send_frame()
     .unwrap();
     write_task.abort();
     let _ = write_task.await;
+    assert_eq!(write_start_count.load(Ordering::SeqCst), 0);
     assert_eq!(
         normal_operation_readiness(&host),
         NormalOperationReadiness::Idle

--- a/crates/vsock-host/src/tests/file.rs
+++ b/crates/vsock-host/src/tests/file.rs
@@ -1210,6 +1210,34 @@ async fn write_file_cancelled_before_frame_write_does_not_poison_or_send_frame()
 }
 
 #[tokio::test]
+async fn write_file_observer_error_cleans_pending_without_sending_frame() {
+    let (host, guest) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+
+    let err = host
+        .write_file_with_write_observer(
+            "/tmp/observer-error.txt",
+            b"hello",
+            false,
+            FrameWriteObserver::new(|| Err(io::Error::other("observer failed"))),
+        )
+        .await
+        .unwrap_err();
+
+    assert!(err.to_string().contains("observer failed"));
+    match guest.try_read(&mut [0u8; 1]) {
+        Err(err) if err.kind() == io::ErrorKind::WouldBlock => {}
+        Ok(n) => panic!("observer error must not send write_file frame; read {n} bytes"),
+        Err(err) => panic!("unexpected read error after observer error: {err}"),
+    }
+    assert_eq!(pending_request_count(&host), 0);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::NotParkable
+    );
+}
+
+#[tokio::test]
 async fn write_file_chunked_cancelled_before_first_frame_write_does_not_cleanup() {
     let (host, mut guest) = setup_host_and_guest().await;
     let host = Arc::new(host);

--- a/crates/vsock-host/src/tests/file.rs
+++ b/crates/vsock-host/src/tests/file.rs
@@ -1209,6 +1209,41 @@ async fn write_file_cancelled_before_frame_write_does_not_poison_or_send_frame()
 }
 
 #[tokio::test]
+async fn write_file_chunked_rejects_invalid_path_before_cleanup_or_write() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+    let write_start_count = Arc::new(AtomicUsize::new(0));
+    let path = format!("/{}", "a".repeat(u16::MAX as usize));
+    let content = vec![0u8; file_impl::test_support::WRITE_FILE_CHUNK_LIMIT + 1];
+
+    let err = host
+        .write_file_with_write_observer(
+            &path,
+            &content,
+            false,
+            FrameWriteObserver::new({
+                let write_start_count = Arc::clone(&write_start_count);
+                move || {
+                    write_start_count.fetch_add(1, Ordering::SeqCst);
+                    Ok(())
+                }
+            }),
+        )
+        .await
+        .unwrap_err();
+
+    assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+    assert_eq!(write_start_count.load(Ordering::SeqCst), 0);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Idle
+    );
+    assert_eq!(operation_count(&host), 0);
+
+    assert_connection_accepts_exec_operation(&host, &mut guest).await;
+}
+
+#[tokio::test]
 async fn write_file_connection_close_after_request_marks_tracker_not_parkable() {
     let (host, mut guest) = setup_host_and_guest().await;
     let host = Arc::new(host);

--- a/crates/vsock-host/src/tests/process.rs
+++ b/crates/vsock-host/src/tests/process.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 
 use super::support::{
     host_from_stream, make_pair, mock_handshake, normal_operation_readiness, read_guest_message,
-    read_guest_messages, send_exec_result,
+    read_guest_messages, send_exec_result, setup_host_and_guest,
 };
 use crate::{
     ConnectionState, FrameWriteObserver, GuestProcessHandle, VsockHost,
@@ -1875,6 +1875,43 @@ async fn test_spawn_process_cancel_before_frame_write_cleans_registration() {
     assert_eq!(
         normal_operation_readiness(&host),
         NormalOperationReadiness::Idle
+    );
+}
+
+#[tokio::test]
+async fn test_spawn_process_write_observer_error_cleans_registration_without_sending_frame() {
+    let (host, guest) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+
+    let err = host
+        .spawn_process_with_request_and_write_observer(
+            crate::ProcessSpawnRequest {
+                command: "observer-error",
+                timeout_ms: 0,
+                env: &[],
+                sudo: false,
+                stream_stdout: true,
+                stdout_log_path: None,
+            },
+            FrameWriteObserver::new(|| Err(io::Error::other("observer failed"))),
+        )
+        .await
+        .unwrap_err();
+
+    assert!(err.to_string().contains("observer failed"));
+    match guest.try_read(&mut [0u8; 1]) {
+        Err(err) if err.kind() == io::ErrorKind::WouldBlock => {}
+        Ok(n) => panic!("observer error must not send spawn_process frame; read {n} bytes"),
+        Err(err) => panic!("unexpected read error after observer error: {err}"),
+    }
+    assert_eq!(
+        registration_counts(&host),
+        (0, 0, 0),
+        "spawn_process observer error must clean pending registrations",
+    );
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::NotParkable
     );
 }
 

--- a/crates/vsock-host/src/tests/process.rs
+++ b/crates/vsock-host/src/tests/process.rs
@@ -2,6 +2,7 @@ use std::future::Future;
 use std::io;
 use std::pin::Pin;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::task::{Context, Poll};
 use std::time::Duration;
 
@@ -10,8 +11,8 @@ use super::support::{
     read_guest_messages, send_exec_result,
 };
 use crate::{
-    ConnectionState, GuestProcessHandle, VsockHost, operation_tracker::NormalOperationReadiness,
-    process as process_impl,
+    ConnectionState, FrameWriteObserver, GuestProcessHandle, VsockHost,
+    operation_tracker::NormalOperationReadiness, process as process_impl,
 };
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::sync::{Notify, oneshot};
@@ -1827,8 +1828,25 @@ async fn test_spawn_process_cancel_before_frame_write_cleans_registration() {
     });
 
     let host = Arc::new(host_from_stream(host_stream).await.unwrap());
+    let write_start_count = Arc::new(AtomicUsize::new(0));
     let writer_guard = host.shared.writer.lock().await;
-    let mut spawn = Box::pin(host.spawn_process("cancel-before-write", 0, &[], false, true, None));
+    let mut spawn = Box::pin(host.spawn_process_with_request_and_write_observer(
+        crate::ProcessSpawnRequest {
+            command: "cancel-before-write",
+            timeout_ms: 0,
+            env: &[],
+            sudo: false,
+            stream_stdout: true,
+            stdout_log_path: None,
+        },
+        FrameWriteObserver::new({
+            let write_start_count = Arc::clone(&write_start_count);
+            move || {
+                write_start_count.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            }
+        }),
+    ));
     assert!(
         matches!(poll_once(spawn.as_mut()), Poll::Pending),
         "spawn_process should wait for writer lock",
@@ -1836,6 +1854,7 @@ async fn test_spawn_process_cancel_before_frame_write_cleans_registration() {
     assert_eq!(registration_counts(&host), (1, 1, 1));
 
     drop(spawn);
+    assert_eq!(write_start_count.load(Ordering::SeqCst), 0);
     assert_eq!(
         registration_counts(&host),
         (0, 0, 0),

--- a/crates/vsock-host/src/tests/support.rs
+++ b/crates/vsock-host/src/tests/support.rs
@@ -47,6 +47,14 @@ pub(crate) fn operation_count(host: &VsockHost) -> usize {
     }
 }
 
+pub(crate) fn pending_request_count(host: &VsockHost) -> usize {
+    let guard = host.shared.state.lock().unwrap_or_else(|e| e.into_inner());
+    match &*guard {
+        ConnectionState::Connected { pending, .. } => pending.len(),
+        ConnectionState::Closed { .. } => 0,
+    }
+}
+
 pub(crate) fn is_connected(host: &VsockHost) -> bool {
     let guard = host.shared.state.lock().unwrap_or_else(|e| e.into_inner());
     matches!(&*guard, ConnectionState::Connected { .. })


### PR DESCRIPTION
## Summary

- Add a typed `FrameWriteObserver` in `vsock-host` and invoke it at the existing pre-`write_all` frame boundary for normal requests, exec, spawn, and file helper paths.
- Add a first-write latch in `sandbox-fc` so guest operations stay `Reserved` until vsock-host reports the first possible guest frame write.
- Update bounded operations, spawn, and control exec to complete only after write-start evidence, while preserving dirty behavior after possible guest writes.
- Add regression coverage for latch idempotency and observer behavior before/at the frame write boundary.

Closes #13721

## Tests

- `cargo test --manifest-path crates/Cargo.toml -p sandbox-fc guest_operations`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox-fc control`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-host cancel_before_frame_write`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-host before_write`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-host write_file_cancelled_before_frame_write`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-host exec_write_observer_fires_at_frame_write_boundary`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-host`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox-fc`
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p vsock-host -p sandbox-fc --all-targets --all-features -- -D warnings`
- pre-commit hook: `cargo-doc`, `cargo-clippy`, file-size check
