### PR TITLE
refactor: remove web api route baseline hash

### DIFF
--- a/turbo/apps/web/custom-eslint/__tests__/no-new-api-routes.test.ts
+++ b/turbo/apps/web/custom-eslint/__tests__/no-new-api-routes.test.ts
@@ -7,18 +7,13 @@ import { fileURLToPath } from "node:url";
 import { RuleTester } from "@typescript-eslint/rule-tester";
 import { afterAll, afterEach, describe, expect, it } from "vitest";
 
-import {
-  computeWebApiRouteBaselineHash,
-  WEB_API_ROUTE_BASELINE,
-  WEB_API_ROUTE_BASELINE_HASH,
-} from "../baselines/web-api-routes.ts";
+import { WEB_API_ROUTE_BASELINE } from "../baselines/web-api-routes.ts";
 import {
   expandedBaselineRoutes,
   expandedBaselineRoutesSinceReference,
   extractWebApiRouteBaselineRoutes,
   missingBaselineRoutes,
   noNewApiRoutes,
-  webApiRouteBaselineHashIsCurrent,
   webApiRoutePath,
 } from "../rules/no-new-api-routes.ts";
 
@@ -88,21 +83,6 @@ describe("missingBaselineRoutes", () => {
 
     expect(missing).not.toContain(existingRoute);
     expect(missing).toContain(WEB_API_ROUTE_BASELINE[1]);
-  });
-});
-
-describe("web API route baseline hash", () => {
-  it("matches the committed route baseline", () => {
-    expect(webApiRouteBaselineHashIsCurrent()).toBe(true);
-  });
-
-  it("changes when a route is added to the baseline", () => {
-    expect(
-      computeWebApiRouteBaselineHash([
-        ...WEB_API_ROUTE_BASELINE,
-        "app/api/new-backend-only-route/route.ts",
-      ]),
-    ).not.toBe(WEB_API_ROUTE_BASELINE_HASH);
   });
 });
 

--- a/turbo/apps/web/custom-eslint/baselines/web-api-routes.ts
+++ b/turbo/apps/web/custom-eslint/baselines/web-api-routes.ts
@@ -1,5 +1,3 @@
-import { createHash } from "node:crypto";
-
 /**
  * Existing Next.js API routes in apps/web at the point web route growth was
  * frozen. New API routes should be implemented in apps/api instead.
@@ -201,15 +199,6 @@ export const WEB_API_ROUTE_BASELINE = [
   "app/api/zero/slack/oauth/connect/route.ts",
   "app/api/zero/slack/oauth/install/route.ts",
 ] as const;
-
-export const WEB_API_ROUTE_BASELINE_HASH =
-  "1789f2cb3958ecf8d5a047945148d8c2c8ff505daec6259565f2831a9376aecc";
-
-export function computeWebApiRouteBaselineHash(
-  routes: readonly string[] = WEB_API_ROUTE_BASELINE,
-): string {
-  return createHash("sha256").update(routes.join("\n")).digest("hex");
-}
 
 export const WEB_API_ROUTE_BASELINE_SET = new Set<string>(
   WEB_API_ROUTE_BASELINE,

--- a/turbo/apps/web/custom-eslint/rules/no-new-api-routes.ts
+++ b/turbo/apps/web/custom-eslint/rules/no-new-api-routes.ts
@@ -3,9 +3,7 @@ import { existsSync } from "node:fs";
 import * as path from "node:path";
 
 import {
-  computeWebApiRouteBaselineHash,
   WEB_API_ROUTE_BASELINE,
-  WEB_API_ROUTE_BASELINE_HASH,
   WEB_API_ROUTE_BASELINE_SET,
 } from "../baselines/web-api-routes.ts";
 import { createRule } from "../utils.ts";
@@ -17,7 +15,6 @@ const ROUTE_SUFFIX = "/route.ts";
 const BASELINE_FILE_FROM_WEB_ROOT = "custom-eslint/baselines/web-api-routes.ts";
 
 const reportedBaselineExpansionRoots = new Set<string>();
-const reportedBaselineHashRoots = new Set<string>();
 const reportedStaleBaselineRoots = new Set<string>();
 
 function normalizePath(value: string): string {
@@ -153,10 +150,6 @@ function staleBaselineMessageData(missingRoutes: readonly string[]): {
   };
 }
 
-export function webApiRouteBaselineHashIsCurrent(): boolean {
-  return computeWebApiRouteBaselineHash() === WEB_API_ROUTE_BASELINE_HASH;
-}
-
 export const noNewApiRoutes = createRule({
   name: "no-new-api-routes",
   defaultOptions: [],
@@ -175,8 +168,6 @@ export const noNewApiRoutes = createRule({
         "Web API route baseline cannot grow. Remove added baseline entries, add the route to apps/api, and use a Next.js rewrite when web compatibility is needed: {{routes}}",
       staleApiRouteBaseline:
         "Web API route baseline contains {{count}} deleted route(s). Remove stale baseline entries: {{routes}}",
-      changedApiRouteBaseline:
-        "Web API route baseline changed without updating WEB_API_ROUTE_BASELINE_HASH. Remove accidental baseline edits instead of allowlisting new web API routes.",
     },
   },
   create(context) {
@@ -203,16 +194,6 @@ export const noNewApiRoutes = createRule({
               node,
               messageId: "expandedApiRouteBaseline",
               data: staleBaselineMessageData(expandedRoutes),
-            });
-          }
-        }
-
-        if (!reportedBaselineHashRoots.has(webRoot)) {
-          reportedBaselineHashRoots.add(webRoot);
-          if (!webApiRouteBaselineHashIsCurrent()) {
-            context.report({
-              node,
-              messageId: "changedApiRouteBaseline",
             });
           }
         }


### PR DESCRIPTION
## Summary
- remove the committed `WEB_API_ROUTE_BASELINE_HASH` and hash computation from the web API route baseline
- keep the actual `no-new-api-routes` protections for new route rejection, baseline expansion, and stale baseline entries
- remove hash-specific custom ESLint tests while preserving baseline expansion coverage

Closes #13735.

## Validation
- `pnpm -F web exec vitest run custom-eslint/__tests__/no-new-api-routes.test.ts`
- `pnpm -F web lint`
- `pnpm -F web check-types`
- `pnpm exec prettier --write apps/web/custom-eslint/baselines/web-api-routes.ts apps/web/custom-eslint/rules/no-new-api-routes.ts apps/web/custom-eslint/__tests__/no-new-api-routes.test.ts`
- `git diff --check`
- `pnpm knip --cache`
- `pnpm check-types`
- pre-commit hook
