### PR TITLE
feat(onboarding): order connectors by historical usage rank

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/zero-onboarding.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-onboarding.tsx
@@ -62,6 +62,70 @@ import { detach, Reason } from "../../signals/utils.ts";
 import { AccountDropdown } from "./zero-sidebar.tsx";
 import { handleZeroAccountAction$ } from "../../signals/zero-page/zero-nav.ts";
 
+// Onboarding connector ranking — ordered by historical org adoption
+// (2026-05-18 snapshot of the `connectors` table). Lower index = more
+// popular. Ties are listed alphabetically. Connectors not in this list
+// rank after all ranked entries and fall back to alphabetical order, so
+// newly added connectors stay discoverable without manual re-ranking.
+const ONBOARDING_CONNECTOR_RANK: readonly ConnectorType[] = [
+  "github",
+  "gmail",
+  "notion",
+  "x",
+  "google-drive",
+  "slack",
+  "google-sheets",
+  "google-calendar",
+  "google-docs",
+  "linear",
+  "intervals-icu",
+  "vercel",
+  "strava",
+  "google-meet",
+  "hubspot",
+  "local-agent",
+  "sentry",
+  "todoist",
+  "xero",
+  "airtable",
+  "docusign",
+  "google-ads",
+  "gumroad",
+  "spotify",
+];
+
+function compareConnectorTypesForOnboarding(
+  a: ConnectorType,
+  b: ConnectorType,
+): number {
+  const rankA = ONBOARDING_CONNECTOR_RANK.indexOf(a);
+  const rankB = ONBOARDING_CONNECTOR_RANK.indexOf(b);
+  if (rankA !== -1 && rankB !== -1) {
+    return rankA - rankB;
+  }
+  if (rankA !== -1) {
+    return -1;
+  }
+  if (rankB !== -1) {
+    return 1;
+  }
+  return a.localeCompare(b);
+}
+
+function getOnboardingConnectorEntries(): [
+  ConnectorType,
+  (typeof CONNECTOR_TYPES)[ConnectorType],
+][] {
+  return (
+    Object.entries(CONNECTOR_TYPES) as [
+      ConnectorType,
+      (typeof CONNECTOR_TYPES)[ConnectorType],
+    ][]
+  ).sort(([a], [b]) => {
+    return compareConnectorTypesForOnboarding(a, b);
+  });
+}
+
 // ---------------------------------------------------------------------------
 // Progress bar
 // ---------------------------------------------------------------------------
@@ -149,10 +213,7 @@ function SelectConnectorsContent() {
   const search = useGet(connectorSearch$);
   const setSearch = useSet(setConnectorSearch$);
 
-  const connectorEntries = Object.entries(CONNECTOR_TYPES) as [
-    ConnectorType,
-    (typeof CONNECTOR_TYPES)[ConnectorType],
-  ][];
+  const connectorEntries = getOnboardingConnectorEntries();
 
   const filtered = connectorEntries.filter(([type, config]) => {
     return matchesConnectorSearch(search, {
@@ -247,12 +308,7 @@ function ConnectStepContent() {
       }),
   );
 
-  const selectedEntries = (
-    Object.entries(CONNECTOR_TYPES) as [
-      ConnectorType,
-      (typeof CONNECTOR_TYPES)[ConnectorType],
-    ][]
-  ).filter(([type]) => {
+  const selectedEntries = getOnboardingConnectorEntries().filter(([type]) => {
     return effectiveConnectors.includes(type);
   });
 
@@ -523,12 +579,7 @@ function OrbitIllustration() {
   const selectedConnectors =
     useLastResolved(onboardingEffectiveConnectors$) ?? [];
 
-  const entries = (
-    Object.entries(CONNECTOR_TYPES) as [
-      ConnectorType,
-      (typeof CONNECTOR_TYPES)[ConnectorType],
-    ][]
-  ).filter(([type]) => {
+  const entries = getOnboardingConnectorEntries().filter(([type]) => {
     return selectedConnectors.includes(type);
   });
 


### PR DESCRIPTION
## Summary

Reorders the onboarding connector picker by historical adoption (#orgs that have authorized each connector), with alphabetical tiebreak. Applied at three call sites in `zero-onboarding.tsx`:

- **Step 2 — Choose your tools** (the main browsable picker)
- **Step 3 — Connect your apps** (the list of selected connectors)
- **Orbit illustration** (icons orbiting Zero on the right panel)

## Ranking source

Snapshot of \`public.connectors\` on 2026-05-18 (counted distinct \`org_id\` per \`type\`):

| Rank | Connector | Orgs |
|---|---|---|
| 1 | github | 53 |
| 2 | gmail | 24 |
| 3 | notion | 21 |
| 4 | x | 18 |
| 5 | google-drive | 12 |
| 6 | slack | 12 |
| 7 | google-sheets | 9 |
| 8 | google-calendar | 8 |
| 9 | google-docs | 6 |
| 10 | linear | 6 |
| 11 | intervals-icu | 5 |
| 12 | vercel | 5 |
| 13 | strava | 4 |
| 14–19 | google-meet · hubspot · local-agent · sentry · todoist · xero (each 2) | |
| 20–24 | airtable · docusign · google-ads · gumroad · spotify (each 1) | |

Connectors not in the rank list (0 historical authorizations) sort alphabetically after all ranked entries, so the picker still surfaces every connector and new connectors don't need a manual rank entry to stay visible.

\`remote-agent\` exists in the DB but no longer has a \`CONNECTOR_TYPES\` entry (removed alongside the RemoteAgent flag), so it's omitted.

## Notes

- Scope is intentionally limited to onboarding. The settings page (\`connectors.ts:348\`) keeps its own \"connected first, then insertion order\" sort.
- This is a presentation-only change — no schema, no API, no behavior change beyond list order.

## Test plan

- [ ] CI: lint, types, tests (existing onboarding tests use \`data-testid\`, not order)
- [ ] Manually walk through onboarding step 2 and confirm github/gmail/notion appear in the first row
- [ ] Confirm a brand-new test connector (not in the rank list) still renders in step 2, sorted alphabetically among other unranked entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)