### PR TITLE
fix: update brace expansion audit override

### DIFF
--- a/turbo/package.json
+++ b/turbo/package.json
@@ -54,7 +54,7 @@
       "glob": ">=10.5.0",
       "tar": ">=7.5.7",
       "@isaacs/brace-expansion": ">=5.0.1",
-      "brace-expansion": ">=5.0.5",
+      "brace-expansion": ">=5.0.6",
       "axios": ">=1.15.2",
       "follow-redirects": ">=1.16.0",
       "dompurify": ">=3.3.2",

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -11,7 +11,7 @@ overrides:
   glob: '>=10.5.0'
   tar: '>=7.5.7'
   '@isaacs/brace-expansion': '>=5.0.1'
-  brace-expansion: '>=5.0.5'
+  brace-expansion: '>=5.0.6'
   axios: '>=1.15.2'
   follow-redirects: '>=1.16.0'
   dompurify: '>=3.3.2'
@@ -6179,8 +6179,8 @@ packages:
   bowser@2.14.1:
     resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
 
-  brace-expansion@5.0.5:
-    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
     engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
@@ -15853,7 +15853,7 @@ snapshots:
 
   bowser@2.14.1: {}
 
-  brace-expansion@5.0.5:
+  brace-expansion@5.0.6:
     dependencies:
       balanced-match: 4.0.4
 
@@ -18409,7 +18409,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.5
+      brace-expansion: 5.0.6
 
   minimist@1.2.8: {}
 


### PR DESCRIPTION
## Summary
- bump the root brace-expansion override from >=5.0.5 to >=5.0.6
- refresh the pnpm lockfile so minimatch resolves the patched brace-expansion version

## Validation
- pnpm install --frozen-lockfile --strict-peer-dependencies
- pnpm audit --prod --ignore-registry-errors
- git diff --check