### PR TITLE
fix: gate KMS dual-write behind feature switch (default off)

### DIFF
--- a/turbo/apps/api/src/signals/services/__tests__/crypto.utils.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/crypto.utils.test.ts
@@ -122,10 +122,28 @@ describe("stored secret encryption", () => {
     expect(fakeKmsClient.calls).toHaveLength(0);
   });
 
-  it("dual-writes legacy AES and AWS KMS material when KMS is configured", async () => {
+  it("stays legacy-only when KMS env is set but StoredSecretKmsWrite is off", async () => {
     mockEnv("SECRETS_KMS_KEY_ID", "alias/vm0-secrets");
 
     const encrypted = await encryptStoredSecretValue("secret-value");
+
+    expect(inspectStoredSecretCiphertext(encrypted)).toStrictEqual({
+      format: "legacy",
+      hasLegacy: true,
+      hasKms: false,
+    });
+    await expect(decryptStoredSecretValue(encrypted)).resolves.toBe(
+      "secret-value",
+    );
+    expect(fakeKmsClient.calls).toHaveLength(0);
+  });
+
+  it("dual-writes legacy AES and AWS KMS material when KMS env is set and StoredSecretKmsWrite is on", async () => {
+    mockEnv("SECRETS_KMS_KEY_ID", "alias/vm0-secrets");
+
+    const encrypted = await encryptStoredSecretValue("secret-value", {
+      overrides: { [FeatureSwitchKey.StoredSecretKmsWrite]: true },
+    });
 
     expect(inspectStoredSecretCiphertext(encrypted)).toStrictEqual({
       format: "dual",
@@ -197,10 +215,13 @@ describe("stored secret encryption", () => {
     ).rejects.toThrow("Stored secret ciphertext does not include KMS data");
   });
 
-  it("dual-writes stored secrets maps when KMS is configured", async () => {
+  it("dual-writes stored secrets maps when KMS env is set and StoredSecretKmsWrite is on", async () => {
     mockEnv("SECRETS_KMS_KEY_ID", "alias/vm0-secrets");
 
-    const encrypted = await encryptStoredSecretsMap({ API_KEY: "secret" });
+    const encrypted = await encryptStoredSecretsMap(
+      { API_KEY: "secret" },
+      { overrides: { [FeatureSwitchKey.StoredSecretKmsWrite]: true } },
+    );
 
     expect(encrypted).not.toBeNull();
     if (!encrypted) {

--- a/turbo/apps/api/src/signals/services/crypto.utils.ts
+++ b/turbo/apps/api/src/signals/services/crypto.utils.ts
@@ -347,8 +347,13 @@ export async function decryptStoredSecretValueWithMode(
 
 export async function encryptStoredSecretValue(
   plaintext: string,
+  ctx: FeatureSwitchContext = {},
 ): Promise<string> {
   if (!env("SECRETS_KMS_KEY_ID")) {
+    return encryptSecretValue(plaintext);
+  }
+
+  if (!isFeatureEnabled(FeatureSwitchKey.StoredSecretKmsWrite, ctx)) {
     return encryptSecretValue(plaintext);
   }
 
@@ -367,12 +372,13 @@ export async function decryptStoredSecretValue(
 
 export async function encryptStoredSecretsMap(
   secrets: Record<string, string> | null | undefined,
+  ctx: FeatureSwitchContext = {},
 ): Promise<string | null> {
   if (!secrets) {
     return null;
   }
 
-  return await encryptStoredSecretValue(JSON.stringify(secrets));
+  return await encryptStoredSecretValue(JSON.stringify(secrets), ctx);
 }
 
 export async function decryptStoredSecretsMap(

--- a/turbo/packages/connectors/src/feature-switch-key.ts
+++ b/turbo/packages/connectors/src/feature-switch-key.ts
@@ -54,6 +54,7 @@ export enum FeatureSwitchKey {
   ApiBackend = "apiBackend",
   ConnectorCategories = "connectorCategories",
   StoredSecretKmsRead = "storedSecretKmsRead",
+  StoredSecretKmsWrite = "storedSecretKmsWrite",
 
   Trinity = "trinity",
   ZapierConnector = "zapierConnector",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -304,7 +304,13 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
   [FeatureSwitchKey.StoredSecretKmsRead]: {
     maintainer: "ethan@vm0.ai",
     description:
-      "Prefer AWS KMS material when reading stored-secret envelopes. Disabled keeps reading the legacy AES branch during rollout; writes still dual-write when SECRETS_KMS_KEY_ID is configured.",
+      "Prefer AWS KMS material when reading stored-secret envelopes. Disabled keeps reading the legacy AES branch during rollout. Read path is independent of StoredSecretKmsWrite — enable read only after dual-write has been on long enough to backfill existing rows.",
+    enabled: false,
+  },
+  [FeatureSwitchKey.StoredSecretKmsWrite]: {
+    maintainer: "ethan@vm0.ai",
+    description:
+      "Dual-write stored-secret values to AWS KMS in addition to the legacy AES branch. When OFF, writes stay legacy-only even if SECRETS_KMS_KEY_ID is configured — this gates the KMS GenerateDataKey call so a missing IAM grant does not 500 every secret save.",
     enabled: false,
   },
   [FeatureSwitchKey.Trinity]: {


### PR DESCRIPTION
## Summary
- Add `StoredSecretKmsWrite` feature switch (default OFF) and gate `encryptStoredSecretValue` / `encryptStoredSecretsMap` on it
- When `SECRETS_KMS_KEY_ID` is configured but the switch is off, writes stay legacy-only — no KMS `GenerateDataKey` call, so a missing IAM grant cannot 500 every connector secret save
- Update the `StoredSecretKmsRead` description to spell out the rollout order (write → backfill → read) and that the two switches are independent

## Why
PR #13693 (`chore: add kms dual-write for stored secrets`) shipped in v1.54.6 (`4170a3ca`) at 16:39 UTC and turned on dual-write whenever `SECRETS_KMS_KEY_ID` was set. The env var was set in prod, but the IAM user `vm0-kms-prod` in account `072707626411` was never granted `kms:GenerateDataKey` on the new key `a1b3922b-fab1-4ed3-aa9e-40f86f92a7a8`. Result: every `POST /api/zero/secrets` 500s on `AccessDeniedException` (Sentry [API-7](https://vm0.sentry.io/issues/7490315107/)).

Production was mitigated by unsetting the env var. This PR makes the safe path the default going forward — once the IAM grant is in place, we flip the switch (staff org first, then global) instead of relying on env-var presence alone.

## Behavior matrix

| `SECRETS_KMS_KEY_ID` | `StoredSecretKmsWrite` | Write path |
|---|---|---|
| unset | any | legacy AES only (unchanged) |
| set | off (default) | legacy AES only (new — was dual-write) |
| set | on | dual-write to legacy + KMS (unchanged) |

`encryptStoredSecretValueWithMode("kms" | "dual")` and the backfill script that uses it are unaffected — they bypass the gate by design.

## Test plan
- [x] `pnpm -F api exec vitest src/signals/services/__tests__/crypto.utils.test.ts` — split the dual-write test in two: one verifying legacy-only is the default when env is set, one verifying dual-write still works under the override
- [x] `pnpm -F api check-types`
- [x] `pnpm -F @vm0/core exec vitest src/__tests__/feature-switch.test.ts`
- [ ] CI to validate lint / full type-check / cross-package tests

## Rollout
1. Merge + deploy.
2. Get the IAM inline policy added on `vm0-kms-prod` in 072 (separately tracked — scheduled call to Lancy 07:00 CST).
3. Re-set `SECRETS_KMS_KEY_ID` in Vercel `vm0-api` env (currently unset as mitigation).
4. Flip `StoredSecretKmsWrite` on for staff org via feature-switch override, verify dual-write works end-to-end.
5. Flip global. Wait for backfill to drain. Then flip `StoredSecretKmsRead`.

cc @hulh122 — heads up, this changes the default write behavior of #13693. Once IAM is fixed, you'll need to flip the switch via the feature-switch overrides API per the rollout above.