### PR TITLE
feat: add LinkedIn Insight Tag to www.vm0.ai and app.vm0.ai

### DIFF
--- a/turbo/apps/platform/index.html
+++ b/turbo/apps/platform/index.html
@@ -16,6 +16,29 @@
       gtag("js", new Date());
       gtag("config", "AW-18144854014");
     </script>
+    <!-- LinkedIn Insight Tag -->
+    <script>
+      _linkedin_partner_id = "9378804";
+      window._linkedin_data_partner_ids =
+        window._linkedin_data_partner_ids || [];
+      window._linkedin_data_partner_ids.push(_linkedin_partner_id);
+    </script>
+    <script>
+      (function (l) {
+        if (!l) {
+          window.lintrk = function (a, b) {
+            window.lintrk.q.push([a, b]);
+          };
+          window.lintrk.q = [];
+        }
+        var s = document.getElementsByTagName("script")[0];
+        var b = document.createElement("script");
+        b.type = "text/javascript";
+        b.async = true;
+        b.src = "https://snap.licdn.com/li.lms-analytics/insight.min.js";
+        s.parentNode.insertBefore(b, s);
+      })(window.lintrk);
+    </script>
     <script>
       // Mark <head> parse start as early as possible so we can measure the
       // total white-screen duration up to the first `hideAppSkeleton$` call.
@@ -138,5 +161,14 @@
       crossorigin="anonymous"
       defer
     ></script>
+    <noscript>
+      <img
+        height="1"
+        width="1"
+        style="display: none"
+        alt=""
+        src="https://px.ads.linkedin.com/collect/?pid=9378804&fmt=gif"
+      />
+    </noscript>
   </body>
 </html>

--- a/turbo/apps/web/app/layout.tsx
+++ b/turbo/apps/web/app/layout.tsx
@@ -309,15 +309,18 @@ export default async function RootLayout({
                 s.parentNode.insertBefore(b, s);})(window.lintrk);
             `}
           </Script>
-          <noscript>
-            <img
-              height="1"
-              width="1"
-              style={{ display: "none" }}
-              alt=""
-              src={`https://px.ads.linkedin.com/collect/?pid=${LINKEDIN_PARTNER_ID}&fmt=gif`}
-            />
-          </noscript>
+          {/*
+            LinkedIn's no-JS tracking pixel must render as raw HTML inside
+            <noscript> — next/image and the @next/next/no-img-element rule
+            both rely on client-side JS, which by definition cannot run here.
+            dangerouslySetInnerHTML keeps the pixel in pure HTML and stays
+            consistent with the JSON-LD blocks above.
+          */}
+          <noscript
+            dangerouslySetInnerHTML={{
+              __html: `<img height="1" width="1" style="display:none;" alt="" src="https://px.ads.linkedin.com/collect/?pid=${LINKEDIN_PARTNER_ID}&fmt=gif" />`,
+            }}
+          />
         </body>
       </html>
     </ClerkProvider>

--- a/turbo/apps/web/app/layout.tsx
+++ b/turbo/apps/web/app/layout.tsx
@@ -23,6 +23,7 @@ import "./docs.css";
 import "./use-cases.css";
 
 const GOOGLE_ADS_ID = "AW-18144854014";
+const LINKEDIN_PARTNER_ID = "9378804";
 
 const notoSans = Noto_Sans({
   subsets: ["latin"],
@@ -289,6 +290,34 @@ export default async function RootLayout({
             src="https://api.dashboard.instatus.com/widget?host=status.vm0.ai&code=02c0ef5a&locale=en"
             strategy="lazyOnload"
           />
+          <Script id="linkedin-insight-init" strategy="afterInteractive">
+            {`
+              _linkedin_partner_id = "${LINKEDIN_PARTNER_ID}";
+              window._linkedin_data_partner_ids = window._linkedin_data_partner_ids || [];
+              window._linkedin_data_partner_ids.push(_linkedin_partner_id);
+            `}
+          </Script>
+          <Script id="linkedin-insight-loader" strategy="afterInteractive">
+            {`
+              (function(l) {
+                if (!l){window.lintrk = function(a,b){window.lintrk.q.push([a,b])};
+                window.lintrk.q=[]}
+                var s = document.getElementsByTagName("script")[0];
+                var b = document.createElement("script");
+                b.type = "text/javascript";b.async = true;
+                b.src = "https://snap.licdn.com/li.lms-analytics/insight.min.js";
+                s.parentNode.insertBefore(b, s);})(window.lintrk);
+            `}
+          </Script>
+          <noscript>
+            <img
+              height="1"
+              width="1"
+              style={{ display: "none" }}
+              alt=""
+              src={`https://px.ads.linkedin.com/collect/?pid=${LINKEDIN_PARTNER_ID}&fmt=gif`}
+            />
+          </noscript>
         </body>
       </html>
     </ClerkProvider>


### PR DESCRIPTION
## Summary
Rolls out the LinkedIn Insight Tag (partner ID `9378804`) across both customer-facing surfaces so LinkedIn Ads attribution covers the full funnel:

- **`turbo/apps/web/app/layout.tsx`** (www.vm0.ai marketing site): pixel + script + noscript fallback wired via `next/script`.
- **`turbo/apps/platform/index.html`** (app.vm0.ai authenticated app): same partner ID and snippets installed next to the existing Google Ads gtag.

The platform app uses raw inline `<script>` tags (Vite, vanilla HTML). The marketing site uses `next/script` with `strategy="afterInteractive"` and `dangerouslySetInnerHTML` for the noscript pixel (to satisfy `@next/next/no-img-element` since `next/image` cannot render inside `<noscript>`).

## Why
LinkedIn Insight Tag coverage on every page a prospect can land on: marketing site for top-of-funnel + retargeting, platform for retention/repeat-visit signals. Without the platform install, logged-in pageviews don't feed LinkedIn audiences.

## Test plan
- [ ] CI green (lint, type-check, tests, deploy preview)
- [ ] www.vm0.ai preview: DevTools Network shows `snap.licdn.com/li.lms-analytics/insight.min.js`; `window._linkedin_data_partner_ids` is `['9378804']`
- [ ] app.vm0.ai preview: same two checks pass
- [ ] LinkedIn Insight Tag Chrome extension shows the tag active on both domains