### PR TITLE
feat(platform): fire Google Ads conversion on subscription success

### DIFF
--- a/turbo/apps/platform/src/signals/bootstrap.ts
+++ b/turbo/apps/platform/src/signals/bootstrap.ts
@@ -303,6 +303,14 @@ const handleBillingRedirect$ = command(() => {
 
   // Defer toast until Toaster component is mounted
   if (billing === "pro" || billing === "team") {
+    // Fire Google Ads conversion event: subscription completed via Stripe
+    // checkout. The `billing` param is set only on Stripe success redirect
+    // and stripped above, so this fires at most once per real conversion.
+    type GtagFn = (...args: unknown[]) => void;
+    (window as Window & { gtag?: GtagFn }).gtag?.("event", "conversion", {
+      send_to: "AW-18144854014/3tdOCMimwK8cEP7_kcxD",
+    });
+
     const label = billing === "pro" ? "Pro" : "Team";
     window.addEventListener(
       "load",


### PR DESCRIPTION
## Summary
- Adds a `gtag('event', 'conversion', ...)` call to `handleBillingRedirect$` in `turbo/apps/platform/src/signals/bootstrap.ts`.
- Conversion label: `AW-18144854014/3tdOCMimwK8cEP7_kcxD` ("Subscribe" conversion action in Google Ads).
- Fires only when Stripe redirects back with `?billing=pro` or `?billing=team`, and only once per redirect (the param is stripped immediately on first read, so a refresh cannot re-fire).

Reuses the exact pattern already used by the existing onboarding conversion event in `onboarding-page-setup.ts` (same Google Ads ID, same `gtag` invocation shape).

## Why
Scarlett (marketing) needs subscription-level conversion attribution in Google Ads so she can see which keywords / campaigns drive paid subs. The Google Ads tag is already loaded site-wide on `apps/platform` (`turbo/apps/platform/index.html`); this PR just instructs it to fire the named conversion at the right moment.

## Behavior

- gtag is already loaded on `app.vm0.ai` (the platform app where the redirect lands), so no script-loading work is needed.
- The call uses optional chaining (`gtag?.(...)`), so a missing/blocked gtag is a silent no-op rather than a crash.
- No new dependencies, no API changes, no UI changes — just an additional analytics signal next to the existing toast.

## Test plan
- [ ] CI green (lint, type-check, tests, deploy)
- [ ] On Vercel preview: complete a Stripe test subscription (card `4242 4242 4242 4242`). After redirect back to `app.vm0.ai/...?billing=pro`, confirm in DevTools Network tab a request to `https://www.google.com/pagead/...` with `data` containing the `3tdOCMimwK8cEP7_kcxD` label.
- [ ] In Google Ads \xe2\x86\x92 Goals \xe2\x86\x92 Conversions \xe2\x86\x92 Summary, the "Subscribe" action moves from "No recent conversions" to "Recording conversions" within ~24h of the first paid test conversion.
- [ ] Refreshing the post-success page does NOT re-fire the event (the URL param is stripped on first read).