### PR TITLE
feat(platform): unified Settings dialog grouping Personal / Workspace

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/settings/unified-settings-dialog.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/unified-settings-dialog.ts
@@ -1,0 +1,11 @@
+import { command, computed, state } from "ccstate";
+
+const internalUnifiedSettingsOpen$ = state(false);
+
+export const unifiedSettingsOpen$ = computed((get) => {
+  return get(internalUnifiedSettingsOpen$);
+});
+
+export const setUnifiedSettingsOpen$ = command(({ set }, open: boolean) => {
+  set(internalUnifiedSettingsOpen$, open);
+});

--- a/turbo/apps/platform/src/signals/zero-page/settings/unified-settings-tab.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/unified-settings-tab.ts
@@ -1,0 +1,30 @@
+import { command, computed, state } from "ccstate";
+
+export type UnifiedSettingsTabId =
+  // Personal
+  | "appearance"
+  | "timezone"
+  | "personal-models"
+  | "usage"
+  | "lab"
+  | "debug"
+  // Workspace
+  | "general"
+  | "members"
+  | "ws-models"
+  | "domains"
+  | "billing"
+  | "credit-balance"
+  | "invoices";
+
+const internalActiveTab$ = state<UnifiedSettingsTabId>("personal-models");
+
+export const activeUnifiedSettingsTab$ = computed((get) => {
+  return get(internalActiveTab$);
+});
+
+export const setActiveUnifiedSettingsTab$ = command(
+  ({ set }, tab: UnifiedSettingsTabId) => {
+    set(internalActiveTab$, tab);
+  },
+);

--- a/turbo/apps/platform/src/views/lab-page/lab-page.tsx
+++ b/turbo/apps/platform/src/views/lab-page/lab-page.tsx
@@ -11,7 +11,11 @@ import {
 import { detach, Reason } from "../../signals/utils.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 
-export function LabPage() {
+interface LabBodyProps {
+  showResetButton?: boolean;
+}
+
+export function LabBody({ showResetButton = false }: LabBodyProps = {}) {
   const features = useLastResolved(featureSwitch$);
   const [toggleLoadable, setFeature] = useLoadableSet(setFeatureSwitch$);
   const [resetLoadable, reset] = useLoadableSet(resetFeatureSwitches$);
@@ -34,6 +38,64 @@ export function LabPage() {
   };
 
   return (
+    <div className="flex flex-col gap-3">
+      {showResetButton && (
+        <div className="flex justify-end">
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={busy}
+            onPointerDown={handleReset}
+          >
+            {resetting ? "Resetting…" : "Reset all"}
+          </Button>
+        </div>
+      )}
+      <div className="zero-card divide-y divide-border">
+        {Object.values(FeatureSwitchKey)
+          .sort((a, b) => {
+            return a.localeCompare(b, undefined, { sensitivity: "base" });
+          })
+          .map((key) => {
+            const enabled = features?.[key] ?? false;
+            return (
+              <label
+                key={key}
+                className="flex items-center justify-between px-4 py-3 cursor-pointer hover:bg-muted/50 transition-colors"
+              >
+                <div className="flex flex-col">
+                  <span className="text-sm text-foreground">{key}</span>
+                  {descriptions[key] && (
+                    <span className="text-xs text-muted-foreground">
+                      {descriptions[key]}
+                    </span>
+                  )}
+                </div>
+                <Switch
+                  checked={enabled}
+                  disabled={busy}
+                  onCheckedChange={(checked) => {
+                    handleToggle(key, checked);
+                  }}
+                />
+              </label>
+            );
+          })}
+      </div>
+    </div>
+  );
+}
+
+export function LabPage() {
+  const [resetLoadable, reset] = useLoadableSet(resetFeatureSwitches$);
+  const resetting = resetLoadable.state === "loading";
+  const pageSignal = useGet(pageSignal$);
+
+  const handleReset = () => {
+    detach(reset(pageSignal), Reason.DomCallback, "resetFeatureSwitches");
+  };
+
+  return (
     <div className="flex flex-1 flex-col min-h-0">
       <header className="shrink-0 px-4 sm:px-6 pt-10 pb-3">
         <div className="mx-auto max-w-[900px] flex items-center justify-between">
@@ -48,7 +110,7 @@ export function LabPage() {
           <Button
             variant="outline"
             size="sm"
-            disabled={busy}
+            disabled={resetting}
             onPointerDown={handleReset}
           >
             {resetting ? "Resetting…" : "Reset all"}
@@ -58,37 +120,7 @@ export function LabPage() {
 
       <div className="flex-1 overflow-y-auto px-4 sm:px-6 pb-10">
         <div className="mx-auto max-w-[900px]">
-          <div className="zero-card divide-y divide-border">
-            {Object.values(FeatureSwitchKey)
-              .sort((a, b) => {
-                return a.localeCompare(b, undefined, { sensitivity: "base" });
-              })
-              .map((key) => {
-                const enabled = features?.[key] ?? false;
-                return (
-                  <label
-                    key={key}
-                    className="flex items-center justify-between px-4 py-3 cursor-pointer hover:bg-muted/50 transition-colors"
-                  >
-                    <div className="flex flex-col">
-                      <span className="text-sm text-foreground">{key}</span>
-                      {descriptions[key] && (
-                        <span className="text-xs text-muted-foreground">
-                          {descriptions[key]}
-                        </span>
-                      )}
-                    </div>
-                    <Switch
-                      checked={enabled}
-                      disabled={busy}
-                      onCheckedChange={(checked) => {
-                        handleToggle(key, checked);
-                      }}
-                    />
-                  </label>
-                );
-              })}
-          </div>
+          <LabBody />
         </div>
       </div>
     </div>

--- a/turbo/apps/platform/src/views/zero-page/components/settings/unified-settings-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/unified-settings-dialog.tsx
@@ -1,0 +1,366 @@
+// TODO(handoff): wire signal-based open state and active-tab state, replace local React state.
+// TODO(handoff): once this dialog ships, deprecate the standalone /settings, /usage, /_/lab
+// routes and the Preferences / Usage / Lab items from zero-sidebar-account.tsx.
+// oxlint-disable max-lines-per-function
+import type { ReactNode } from "react";
+import { useLoadable, useLastResolved, useGet, useSet } from "ccstate-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  cn,
+} from "@vm0/ui";
+import {
+  IconPalette,
+  IconClock,
+  IconCpu,
+  IconChartBar,
+  IconFlask,
+  IconBug,
+  IconBuilding,
+  IconUsers,
+  IconWorldWww,
+  IconCreditCard,
+  IconCoins,
+  IconFileInvoice,
+} from "@tabler/icons-react";
+
+import { OrgGeneralTab } from "../org-manage/org-general-tab.tsx";
+import { OrgProvidersTab } from "../org-manage/org-providers-tab.tsx";
+import { OrgMembersTab } from "../org-manage/org-members-tab.tsx";
+import { OrgDomainsTab } from "../org-manage/org-domains-tab.tsx";
+import { OrgBillingTab } from "../org-manage/org-billing-tab.tsx";
+import { OrgUsageTab } from "../org-manage/org-usage-tab.tsx";
+import { OrgInvoicesTab } from "../org-manage/org-invoices-tab.tsx";
+import { PersonalProvidersTab } from "../preferences/personal-providers-tab.tsx";
+import { TimezoneSettings } from "./timezone-settings.tsx";
+import {
+  AppearanceSettings,
+  SendModeSettings,
+  CaptureNetworkBodiesSettings,
+} from "../../zero-account-page.tsx";
+import { LabBody } from "../../../lab-page/lab-page.tsx";
+import { UsageBody } from "../../zero-usage-page.tsx";
+import { isOrgAdmin$ } from "../../../../signals/org.ts";
+import { featureSwitch$ } from "../../../../signals/external/feature-switch.ts";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import {
+  activeUnifiedSettingsTab$,
+  setActiveUnifiedSettingsTab$,
+  type UnifiedSettingsTabId,
+} from "../../../../signals/zero-page/settings/unified-settings-tab.ts";
+
+type NavIcon = (props: { size?: number; className?: string }) => ReactNode;
+
+type SettingsTabId = UnifiedSettingsTabId;
+
+interface TabMeta {
+  title: string;
+  description: string;
+}
+
+const TAB_META = {
+  appearance: {
+    title: "Appearance",
+    description: "Theme and chat input shortcuts.",
+  },
+  timezone: {
+    title: "Time zone",
+    description:
+      "How Zero interprets times in your conversations and schedules.",
+  },
+  "personal-models": {
+    title: "Personal models",
+    description:
+      "Connect your own Claude Code or ChatGPT credentials. These power coding agents you spawn from your account.",
+  },
+  usage: {
+    title: "Usage",
+    description:
+      "Your credit consumption across chats, schedules, and channels.",
+  },
+  lab: {
+    title: "Lab",
+    description: "Toggle experimental features on or off.",
+  },
+  debug: {
+    title: "Debug",
+    description: "Diagnostics for engineering. Off by default.",
+  },
+  general: {
+    title: "General",
+    description: "Manage your workspace profile and settings.",
+  },
+  members: {
+    title: "Members",
+    description: "Manage who has access to this workspace.",
+  },
+  "ws-models": {
+    title: "Models configuration",
+    description:
+      "Manage workspace models, set the default model, and choose how each model is routed.",
+  },
+  domains: {
+    title: "Domains",
+    description: "Manage verified domains for your workspace.",
+  },
+  billing: {
+    title: "Billing",
+    description: "Manage your plan and payment method.",
+  },
+  "credit-balance": {
+    title: "Credit balance",
+    description:
+      "Credit balance and per-member credit consumption this billing period.",
+  },
+  invoices: {
+    title: "Invoices",
+    description: "View and download past invoices.",
+  },
+} as const satisfies Record<SettingsTabId, TabMeta>;
+
+interface SidebarItem {
+  id: SettingsTabId;
+  label: string;
+  icon: NavIcon;
+}
+
+interface SidebarGroup {
+  label: string;
+  items: readonly SidebarItem[];
+}
+
+const PERSONAL_GROUP_BASE: readonly SidebarItem[] = [
+  { id: "appearance", label: "Appearance", icon: IconPalette as NavIcon },
+  { id: "timezone", label: "Time zone", icon: IconClock as NavIcon },
+  { id: "personal-models", label: "Personal models", icon: IconCpu as NavIcon },
+  { id: "usage", label: "Usage", icon: IconChartBar as NavIcon },
+  { id: "lab", label: "Lab", icon: IconFlask as NavIcon },
+];
+
+const WORKSPACE_GROUP_BASE: readonly SidebarItem[] = [
+  { id: "general", label: "General", icon: IconBuilding as NavIcon },
+  { id: "members", label: "Members", icon: IconUsers as NavIcon },
+];
+
+const WORKSPACE_ADMIN_CONFIG: readonly SidebarItem[] = [
+  { id: "ws-models", label: "Models configuration", icon: IconCpu as NavIcon },
+  { id: "domains", label: "Domains", icon: IconWorldWww as NavIcon },
+];
+
+const WORKSPACE_BILLING: readonly SidebarItem[] = [
+  { id: "billing", label: "Billing", icon: IconCreditCard as NavIcon },
+  { id: "credit-balance", label: "Credit balance", icon: IconCoins as NavIcon },
+  { id: "invoices", label: "Invoices", icon: IconFileInvoice as NavIcon },
+];
+
+function TabBody({ tab }: { tab: SettingsTabId }) {
+  switch (tab) {
+    case "appearance": {
+      return (
+        <div className="flex flex-col gap-6">
+          <AppearanceSettings />
+          <SendModeSettings />
+        </div>
+      );
+    }
+    case "timezone": {
+      return <TimezoneSettings />;
+    }
+    case "personal-models": {
+      return <PersonalProvidersTab />;
+    }
+    case "usage": {
+      return <UsageBody />;
+    }
+    case "lab": {
+      return <LabBody showResetButton />;
+    }
+    case "debug": {
+      return (
+        <div className="flex flex-col gap-6">
+          <CaptureNetworkBodiesSettings />
+        </div>
+      );
+    }
+    case "general": {
+      return <OrgGeneralTab />;
+    }
+    case "members": {
+      return <OrgMembersTab />;
+    }
+    case "ws-models": {
+      return <OrgProvidersTab />;
+    }
+    case "domains": {
+      return <OrgDomainsTab />;
+    }
+    case "billing": {
+      return <OrgBillingTab />;
+    }
+    case "credit-balance": {
+      return <OrgUsageTab />;
+    }
+    case "invoices": {
+      return <OrgInvoicesTab />;
+    }
+  }
+}
+
+interface UnifiedSettingsDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function UnifiedSettingsDialog({
+  open,
+  onOpenChange,
+}: UnifiedSettingsDialogProps) {
+  const activeTab = useGet(activeUnifiedSettingsTab$);
+  const setActiveTab = useSet(setActiveUnifiedSettingsTab$);
+  const isAdminLoadable = useLoadable(isOrgAdmin$);
+  const isAdmin =
+    isAdminLoadable.state === "hasData" ? isAdminLoadable.data : false;
+  const features = useLastResolved(featureSwitch$);
+  const showDebug = features?.[FeatureSwitchKey.ZeroDebug] ?? false;
+
+  const personalItems: SidebarItem[] = [
+    ...PERSONAL_GROUP_BASE,
+    ...(showDebug
+      ? [{ id: "debug" as const, label: "Debug", icon: IconBug as NavIcon }]
+      : []),
+  ];
+
+  const workspaceItems: SidebarItem[] = [
+    ...WORKSPACE_GROUP_BASE,
+    ...(isAdmin ? WORKSPACE_ADMIN_CONFIG : []),
+    ...(isAdmin ? WORKSPACE_BILLING : []),
+  ];
+
+  const sidebarGroups: SidebarGroup[] = [
+    { label: "Personal", items: personalItems },
+    { label: "Workspace", items: workspaceItems },
+  ];
+
+  const meta = TAB_META[activeTab];
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="zero-app flex flex-col w-[calc(100vw-2rem)] max-w-[1200px] h-[92dvh] sm:h-[85vh] p-0 gap-0 overflow-hidden zero-border rounded-xl bg-card">
+        <DialogTitle className="sr-only">Settings</DialogTitle>
+        <DialogDescription className="sr-only">
+          Personal preferences and workspace configuration.
+        </DialogDescription>
+
+        <div className="flex flex-col sm:flex-row h-full min-h-0">
+          {/* Mobile: dropdown nav */}
+          <div className="sm:hidden shrink-0 px-4 pr-14 pt-4 pb-4 border-b border-border/50 bg-[hsl(var(--gray-0))]">
+            <Select
+              value={activeTab}
+              onValueChange={(v) => {
+                return setActiveTab(v as SettingsTabId);
+              }}
+            >
+              <SelectTrigger className="h-9 w-full">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {sidebarGroups.flatMap((group) => {
+                  return group.items.map((item) => {
+                    return (
+                      <SelectItem key={item.id} value={item.id}>
+                        {item.label}
+                      </SelectItem>
+                    );
+                  });
+                })}
+              </SelectContent>
+            </Select>
+          </div>
+
+          {/* Desktop: sidebar nav with Personal / Workspace groups */}
+          <nav className="hidden sm:flex sm:flex-col w-56 shrink-0 p-3 pt-3 pb-4 gap-4 overflow-y-auto zero-border-r bg-[hsl(var(--gray-0))]">
+            {sidebarGroups.map((group) => {
+              if (group.items.length === 0) {
+                return null;
+              }
+              return (
+                <div key={group.label} className="shrink-0">
+                  <div className="h-7 flex items-center pl-2">
+                    <span className="text-[13px] leading-4 text-sidebar-foreground/50 font-medium">
+                      {group.label}
+                    </span>
+                  </div>
+                  <div className="flex flex-col gap-1">
+                    {group.items.map((item) => {
+                      const Icon = item.icon;
+                      const isActive = activeTab === item.id;
+                      return (
+                        <button
+                          key={item.id}
+                          type="button"
+                          onClick={() => {
+                            return setActiveTab(item.id);
+                          }}
+                          className={cn(
+                            "flex w-full h-8 items-center gap-2 rounded-lg p-2 text-left text-sm leading-5 transition-colors duration-200",
+                            isActive
+                              ? "text-primary-foreground font-medium"
+                              : "text-sidebar-foreground hover:bg-sidebar-accent",
+                          )}
+                          style={
+                            isActive
+                              ? { backgroundColor: "hsl(var(--primary))" }
+                              : undefined
+                          }
+                        >
+                          <Icon
+                            size={16}
+                            className={cn(
+                              "shrink-0",
+                              isActive ? "opacity-100" : "opacity-50",
+                            )}
+                          />
+                          <span className="truncate">{item.label}</span>
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
+              );
+            })}
+          </nav>
+
+          {/* Content area */}
+          <div
+            id="unified-settings-content"
+            className="relative flex-1 min-w-0 min-h-0 flex flex-col overflow-hidden"
+            style={{ backgroundColor: "hsl(var(--background))" }}
+          >
+            <header className="shrink-0 px-4 sm:px-10 pt-6 sm:pt-8 pb-1">
+              <div className="flex min-h-7 items-center gap-2">
+                <h2 className="hidden h-7 items-center text-xl font-semibold tracking-tight text-foreground sm:flex">
+                  {meta.title}
+                </h2>
+              </div>
+              <p className="mt-1 max-w-3xl text-sm text-muted-foreground">
+                {meta.description}
+              </p>
+            </header>
+            <div className="flex-1 overflow-y-auto px-4 sm:px-10 pb-10 pt-4 sm:pt-6 [scrollbar-gutter:stable]">
+              <TabBody tab={activeTab} />
+            </div>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export type { SettingsTabId };

--- a/turbo/apps/platform/src/views/zero-page/zero-account-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-account-page.tsx
@@ -35,7 +35,7 @@ import {
   updateCaptureNetworkBodies$,
 } from "../../signals/zero-page/settings/preferences-page.ts";
 
-function AppearanceSettings() {
+export function AppearanceSettings() {
   const THEME_OPTIONS = [
     { value: "light" as ThemePreference, label: "Light", icon: IconSun },
     { value: "dark" as ThemePreference, label: "Dark", icon: IconMoon },
@@ -99,7 +99,7 @@ function AppearanceSettings() {
   );
 }
 
-function SendModeSettings() {
+export function SendModeSettings() {
   const SEND_OPTIONS = [
     { value: "enter" as SendMode, label: "Enter" },
     { value: "cmd-enter" as SendMode, label: "⌘ Enter" },
@@ -177,7 +177,7 @@ function SendModeSettings() {
 
 const CAPTURE_RUN_COUNT = 3;
 
-function CaptureNetworkBodiesSettings() {
+export function CaptureNetworkBodiesSettings() {
   const remainingLoadable = useLoadable(captureNetworkBodiesRemaining$);
   const remaining =
     remainingLoadable.state === "hasData" ? remainingLoadable.data : 0;

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -19,6 +19,7 @@ import {
   IconLayoutSidebarLeftCollapse,
   IconPlug,
   IconSparkles,
+  IconSettings,
 } from "@tabler/icons-react";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import {
@@ -57,6 +58,11 @@ import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
 import { slackOrgScopeMismatch$ } from "../../signals/zero-page/zero-slack.ts";
 import { BillingDialog } from "./billing-dialog.tsx";
 import { ManagePinnedAgentsDialog } from "./zero-sidebar-dialogs.tsx";
+import { UnifiedSettingsDialog } from "./components/settings/unified-settings-dialog.tsx";
+import {
+  unifiedSettingsOpen$,
+  setUnifiedSettingsOpen$,
+} from "../../signals/zero-page/settings/unified-settings-dialog.ts";
 
 import { AccountDropdown } from "./zero-sidebar-account.tsx";
 import { ChatThreadsSection } from "./sidebar-threads.tsx";
@@ -165,8 +171,12 @@ function ManagePinnedAgentsDialogContainer() {
   );
 }
 
+interface SidebarNavContentProps {
+  onOpenSettings: () => void;
+}
+
 // Nav content for both sidebars: subscribes to feature flags, default agent name, slack scope
-function SidebarNavContent() {
+function SidebarNavContent({ onOpenSettings }: SidebarNavContentProps) {
   const activeId = useGet(activeRoute$);
   const off = useGet(sidebarOff$);
   const toggleOff = useSet(toggleSidebarOff$);
@@ -302,6 +312,21 @@ function SidebarNavContent() {
 
           <div className="flex w-full shrink-0 flex-col items-center gap-1 pb-2 pt-1">
             <TooltipProvider delayDuration={200}>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    type="button"
+                    onClick={onOpenSettings}
+                    className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-sidebar-foreground transition-colors duration-200 hover:bg-sidebar-accent"
+                    aria-label="Settings"
+                  >
+                    <IconSettings size={16} className="shrink-0" />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent side="right">
+                  <p className="text-xs">Settings</p>
+                </TooltipContent>
+              </Tooltip>
               <Tooltip>
                 <TooltipTrigger asChild>
                   <Link
@@ -512,6 +537,14 @@ function SidebarNavContent() {
                 );
               },
             )}
+            <button
+              type="button"
+              onClick={onOpenSettings}
+              className="flex w-full h-8 items-center gap-2 rounded-lg p-2 text-left text-sm leading-5 text-sidebar-foreground transition-colors duration-200 hover:bg-sidebar-accent"
+            >
+              <IconSettings size={16} className="shrink-0" />
+              <span className="truncate flex-1">Settings</span>
+            </button>
             <div className="h-px bg-border/30 mx-1 my-1" />
             {/* Insights + Account */}
             <div className="flex items-center gap-1">
@@ -552,12 +585,24 @@ function SidebarNavContent() {
   );
 }
 
+function UnifiedSettingsDialogContainer() {
+  const open = useGet(unifiedSettingsOpen$);
+  const setOpen = useSet(setUnifiedSettingsOpen$);
+  return <UnifiedSettingsDialog open={open} onOpenChange={setOpen} />;
+}
+
 export function ZeroSidebar() {
+  const setSettingsOpen = useSet(setUnifiedSettingsOpen$);
   return (
     <>
-      <SidebarNavContent />
+      <SidebarNavContent
+        onOpenSettings={() => {
+          return setSettingsOpen(true);
+        }}
+      />
       <ManagePinnedAgentsDialogContainer />
       <BillingDialog />
+      <UnifiedSettingsDialogContainer />
     </>
   );
 }

--- a/turbo/apps/platform/src/views/zero-page/zero-usage-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-usage-page.tsx
@@ -1,6 +1,17 @@
 import { UsageInsightView } from "../usage-page/components/usage-insight-view.tsx";
 import { UsageInsightSelectors } from "../usage-page/components/usage-insight-selectors.tsx";
 
+export function UsageBody() {
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-start justify-end gap-4 flex-wrap">
+        <UsageInsightSelectors />
+      </div>
+      <UsageInsightView />
+    </div>
+  );
+}
+
 export function ZeroUsagePage() {
   return (
     <div className="flex flex-1 flex-col min-h-0 overflow-auto [scrollbar-gutter:stable]">


### PR DESCRIPTION
## Summary

Adds a single **Settings** entry in the `zero-sidebar` footer (just below *Where Zero works*) that opens a unified dialog consolidating personal preferences with workspace settings.

![mockup](https://github.com/vm0-ai/vm0/releases/download/web-v12.374.1/unified-settings-mockup.png)

**Personal group** (consolidates the current `/settings` Preferences tabs, `/usage`, and `/_/lab` standalone routes):
- Appearance · Time zone · Personal models · Usage · Lab · Debug
- Debug remains gated by `FeatureSwitchKey.ZeroDebug`

**Workspace group** (composes the existing `org-manage-dialog` tabs):
- General · Members · Models configuration · Domains · Billing · Credit balance · Invoices
- Configuration and billing rows remain admin-gated via `isOrgAdmin$`, matching today's `org-manage-dialog` behavior

## Why a UI-fidelity PR

This is intentionally **additive**:
- New dialog + new sidebar entry + open/active-tab signals are added
- Old `/settings`, `/usage`, `/_/lab` routes still work
- Old Preferences / Usage / Lab items in the account dropdown still work
- `org-manage-dialog` is untouched (the new dialog reuses its individual `Org*Tab` components)

Engineering can deprecate the duplicates in a follow-up PR once the new entry is proven, without coordinating with this PR's review.

## What I changed

- **New** `src/views/zero-page/components/settings/unified-settings-dialog.tsx` — composes the existing tab components
- **New** `src/signals/zero-page/settings/unified-settings-dialog.ts` — open/close state
- **New** `src/signals/zero-page/settings/unified-settings-tab.ts` — active-tab state
- **Edit** `zero-sidebar.tsx` — added Settings button in both collapsed and expanded footer; renders `<UnifiedSettingsDialogContainer/>`
- **Edit** `zero-account-page.tsx` — exported the inline `AppearanceSettings`, `SendModeSettings`, `CaptureNetworkBodiesSettings` so the dialog can reuse them
- **Edit** `lab-page.tsx` — extracted feature-switch list into an exported `LabBody` component; `LabPage` now wraps it
- **Edit** `zero-usage-page.tsx` — extracted body into exported `UsageBody` component; `ZeroUsagePage` unchanged

## Verification

- `pnpm -F @vm0/app check-types` — ✅
- `pnpm -F @vm0/app lint` — ✅ (oxlint + oxlint type-aware + eslint, 0 warnings 0 errors)
- Targeted vitest: `zero-sidebar.test.tsx`, `zero-sidebar-display.test.tsx`, `zero-sidebar-interaction.test.tsx`, `zero-account-page.test.tsx` — all 37 tests pass
- I was **not able to browser-test** this in my environment (no dev server) — visual review needed before merge

## Handoff notes for whoever picks this up

Search the diff for `TODO(handoff)`:

1. The standalone routes (`/settings`, `/usage`, `/_/lab`) and the `Preferences / Usage / Lab` items in `zero-sidebar-account.tsx` can be removed in a follow-up once this entry is live and stable.
2. URL-deep-linking: `org-manage-dialog` has a `?settings=<tab>` URL param handler in `signals/zero-page/settings/org-manage-dialog.ts` — we could add an equivalent for the unified dialog if we want shareable deep links.
3. The Lab body's existing `Reset all` button is rendered when `showResetButton` is passed; inside the dialog it sits inline at the top right of the tab body. If we want it pinned to the dialog header instead, that's a small refactor.

## Test plan

- [ ] Open the sidebar → click `Settings` below *Where Zero works* → dialog opens on `Personal models`
- [ ] Toggle through every Personal tab — verify content matches the current standalone pages
- [ ] As an org admin, toggle through every Workspace tab — verify content matches `org-manage-dialog`
- [ ] As a non-admin, verify configuration + billing rows are hidden under Workspace
- [ ] Mobile: dropdown nav (sm:hidden) shows all visible tabs and switches correctly
- [ ] Collapsed sidebar (icon-only): `Settings` cog tooltip + button opens the dialog
- [ ] Old surfaces still work: account-menu Preferences / Usage / Lab links still navigate to their old pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)