### PR TITLE
feat(platform): group agents page by visibility (Team / Private)

### DIFF
--- a/turbo/apps/platform/src/views/agents-page/agents-page.tsx
+++ b/turbo/apps/platform/src/views/agents-page/agents-page.tsx
@@ -5,6 +5,7 @@ import {
   IconLayoutGrid,
   IconList,
   IconLoader2,
+  IconLock,
   IconPlus,
   IconWand,
 } from "@tabler/icons-react";
@@ -546,6 +547,7 @@ type AgentProps = {
     id: string;
     displayName?: string | null;
     description?: string | null;
+    visibility?: "public" | "private" | null;
   };
 };
 
@@ -553,6 +555,7 @@ function AgentCard({ agent }: AgentProps) {
   const defaultAgentId = useLastResolved(defaultAgentId$);
   const lead = agent.id === defaultAgentId;
   const displayName = agent.displayName ?? agent.id;
+  const isPrivate = agent.visibility === "private";
   const description = defaultAgentId
     ? agent.description || (lead ? "Your core agent" : "Sub-agent")
     : "";
@@ -565,9 +568,19 @@ function AgentCard({ agent }: AgentProps) {
           className="h-10 w-10 shrink-0 rounded-full object-cover object-top"
         />
         <div className="flex-1 min-w-0">
-          <span className="text-sm font-medium text-foreground truncate block">
-            {displayName}
-          </span>
+          <div className="flex items-center gap-1.5 min-w-0">
+            <span className="text-sm font-medium text-foreground truncate">
+              {displayName}
+            </span>
+            {isPrivate && (
+              <IconLock
+                size={12}
+                stroke={1.5}
+                className="shrink-0 text-muted-foreground"
+                aria-label="Private agent"
+              />
+            )}
+          </div>
           <p className="text-xs text-muted-foreground mt-0.5 line-clamp-1">
             {description}
           </p>
@@ -582,6 +595,7 @@ function AgentListRow({ agent, isLast }: AgentProps & { isLast?: boolean }) {
   const lead = agent.id === defaultAgentId;
 
   const displayName = agent.displayName ?? agent.id;
+  const isPrivate = agent.visibility === "private";
   const description = defaultAgentId
     ? agent.description || (lead ? "Your core agent" : "Sub-agent")
     : "";
@@ -595,9 +609,19 @@ function AgentListRow({ agent, isLast }: AgentProps & { isLast?: boolean }) {
           className="h-10 w-10 shrink-0 rounded-full object-cover object-top"
         />
         <div className="flex-1 min-w-0">
-          <span className="text-sm font-medium text-foreground truncate block">
-            {displayName}
-          </span>
+          <div className="flex items-center gap-1.5 min-w-0">
+            <span className="text-sm font-medium text-foreground truncate">
+              {displayName}
+            </span>
+            {isPrivate && (
+              <IconLock
+                size={12}
+                stroke={1.5}
+                className="shrink-0 text-muted-foreground"
+                aria-label="Private agent"
+              />
+            )}
+          </div>
           <p className="text-xs text-muted-foreground mt-0.5 line-clamp-1">
             {description}
           </p>

--- a/turbo/apps/platform/src/views/agents-page/agents-page.tsx
+++ b/turbo/apps/platform/src/views/agents-page/agents-page.tsx
@@ -5,7 +5,6 @@ import {
   IconLayoutGrid,
   IconList,
   IconLoader2,
-  IconLock,
   IconPlus,
   IconWand,
 } from "@tabler/icons-react";
@@ -177,11 +176,10 @@ function AgentGridView() {
   const agents =
     agentsLoadable.state === "hasData" ? agentsLoadable.data : null;
 
-  return (
-    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
-      {loading &&
-        (!agents || agents.length === 0) &&
-        [1, 2, 3].map((i) => {
+  if (loading && (!agents || agents.length === 0)) {
+    return (
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+        {[1, 2, 3].map((i) => {
           return (
             <Card key={i} className="zero-card">
               <CardContent className="p-4">
@@ -195,19 +193,59 @@ function AgentGridView() {
             </Card>
           );
         })}
+      </div>
+    );
+  }
 
-      {agents?.map((agent) => {
-        return (
-          <Link
-            key={agent.id}
-            pathname="/agents/:agentId"
-            options={{ pathParams: { agentId: agent.id } }}
-            className="block no-underline text-inherit"
-          >
-            <AgentCard agent={agent} />
-          </Link>
-        );
-      })}
+  const teamAgents =
+    agents?.filter((a) => {
+      return a.visibility !== "private";
+    }) ?? [];
+  const privateAgents =
+    agents?.filter((a) => {
+      return a.visibility === "private";
+    }) ?? [];
+
+  return (
+    <div className="flex flex-col gap-6">
+      {teamAgents.length > 0 && (
+        <section className="flex flex-col gap-3">
+          <h2 className="text-sm font-medium text-muted-foreground">Team</h2>
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+            {teamAgents.map((agent) => {
+              return (
+                <Link
+                  key={agent.id}
+                  pathname="/agents/:agentId"
+                  options={{ pathParams: { agentId: agent.id } }}
+                  className="block no-underline text-inherit"
+                >
+                  <AgentCard agent={agent} />
+                </Link>
+              );
+            })}
+          </div>
+        </section>
+      )}
+      {privateAgents.length > 0 && (
+        <section className="flex flex-col gap-3">
+          <h2 className="text-sm font-medium text-muted-foreground">Private</h2>
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+            {privateAgents.map((agent) => {
+              return (
+                <Link
+                  key={agent.id}
+                  pathname="/agents/:agentId"
+                  options={{ pathParams: { agentId: agent.id } }}
+                  className="block no-underline text-inherit"
+                >
+                  <AgentCard agent={agent} />
+                </Link>
+              );
+            })}
+          </div>
+        </section>
+      )}
     </div>
   );
 }
@@ -218,11 +256,10 @@ function AgentListView() {
   const agents =
     agentsLoadable.state === "hasData" ? agentsLoadable.data : null;
 
-  return (
-    <div className="zero-card overflow-hidden">
-      {loading &&
-        (!agents || agents.length === 0) &&
-        [1, 2, 3].map((i, _, arr) => {
+  if (loading && (!agents || agents.length === 0)) {
+    return (
+      <div className="zero-card overflow-hidden">
+        {[1, 2, 3].map((i, _, arr) => {
           return (
             <div key={i}>
               <div className="flex items-center gap-3 px-5 py-4 animate-pulse">
@@ -238,19 +275,65 @@ function AgentListView() {
             </div>
           );
         })}
+      </div>
+    );
+  }
 
-      {agents?.map((agent, idx) => {
-        return (
-          <Link
-            key={agent.id}
-            pathname="/agents/:agentId"
-            options={{ pathParams: { agentId: agent.id } }}
-            className="block no-underline text-inherit"
-          >
-            <AgentListRow agent={agent} isLast={idx === agents.length - 1} />
-          </Link>
-        );
-      })}
+  const teamAgents =
+    agents?.filter((a) => {
+      return a.visibility !== "private";
+    }) ?? [];
+  const privateAgents =
+    agents?.filter((a) => {
+      return a.visibility === "private";
+    }) ?? [];
+
+  return (
+    <div className="flex flex-col gap-6">
+      {teamAgents.length > 0 && (
+        <section className="flex flex-col gap-3">
+          <h2 className="text-sm font-medium text-muted-foreground">Team</h2>
+          <div className="zero-card overflow-hidden">
+            {teamAgents.map((agent, idx) => {
+              return (
+                <Link
+                  key={agent.id}
+                  pathname="/agents/:agentId"
+                  options={{ pathParams: { agentId: agent.id } }}
+                  className="block no-underline text-inherit"
+                >
+                  <AgentListRow
+                    agent={agent}
+                    isLast={idx === teamAgents.length - 1}
+                  />
+                </Link>
+              );
+            })}
+          </div>
+        </section>
+      )}
+      {privateAgents.length > 0 && (
+        <section className="flex flex-col gap-3">
+          <h2 className="text-sm font-medium text-muted-foreground">Private</h2>
+          <div className="zero-card overflow-hidden">
+            {privateAgents.map((agent, idx) => {
+              return (
+                <Link
+                  key={agent.id}
+                  pathname="/agents/:agentId"
+                  options={{ pathParams: { agentId: agent.id } }}
+                  className="block no-underline text-inherit"
+                >
+                  <AgentListRow
+                    agent={agent}
+                    isLast={idx === privateAgents.length - 1}
+                  />
+                </Link>
+              );
+            })}
+          </div>
+        </section>
+      )}
     </div>
   );
 }
@@ -463,7 +546,6 @@ type AgentProps = {
     id: string;
     displayName?: string | null;
     description?: string | null;
-    visibility?: "public" | "private";
   };
 };
 
@@ -483,18 +565,9 @@ function AgentCard({ agent }: AgentProps) {
           className="h-10 w-10 shrink-0 rounded-full object-cover object-top"
         />
         <div className="flex-1 min-w-0">
-          <div className="flex min-w-0 items-center gap-1.5">
-            <span className="text-sm font-medium text-foreground truncate block">
-              {displayName}
-            </span>
-            {agent.visibility === "private" && (
-              <IconLock
-                size={12}
-                stroke={1.7}
-                className="shrink-0 text-muted-foreground"
-              />
-            )}
-          </div>
+          <span className="text-sm font-medium text-foreground truncate block">
+            {displayName}
+          </span>
           <p className="text-xs text-muted-foreground mt-0.5 line-clamp-1">
             {description}
           </p>
@@ -522,18 +595,9 @@ function AgentListRow({ agent, isLast }: AgentProps & { isLast?: boolean }) {
           className="h-10 w-10 shrink-0 rounded-full object-cover object-top"
         />
         <div className="flex-1 min-w-0">
-          <div className="flex min-w-0 items-center gap-1.5">
-            <span className="text-sm font-medium text-foreground truncate block">
-              {displayName}
-            </span>
-            {agent.visibility === "private" && (
-              <IconLock
-                size={12}
-                stroke={1.7}
-                className="shrink-0 text-muted-foreground"
-              />
-            )}
-          </div>
+          <span className="text-sm font-medium text-foreground truncate block">
+            {displayName}
+          </span>
           <p className="text-xs text-muted-foreground mt-0.5 line-clamp-1">
             {description}
           </p>


### PR DESCRIPTION
Closes #13828

## Summary

- Splits the Agents page grid and list views into two sections — **Team** (above) and **Private** (below).
- Section labels match the connector page treatment (`text-sm font-medium text-muted-foreground`), so the visual rhythm lines up with Model Providers.
- Removes the inline lock glyph next to private agent names — the section grouping carries the signal.
- The **Private** section is hidden entirely when the user has no private agents (no empty-state copy).

Visual only — no behavioral or data changes. \`+ New agent\`, Grid/List toggle, hover states, card styles all unchanged.

## Mockup

The direction Ming confirmed:

![mockup](https://www.vm0.ai/f/36PnTFtD4dBQ9zg5jj6E5r918aV/79ce4567-d55a-460a-a0ea-873b391e8971/final.png)

## Test plan

- [x] \`pnpm check-types\` — passes
- [x] \`pnpm lint\` — passes
- [ ] Manual: open \`/agents\` with a mix of team and private agents → confirm grouping, ordering, and that lock glyph is gone
- [ ] Manual: same as above with no private agents → confirm Private section is hidden
- [ ] Manual: switch Grid ↔ List → both views show the grouping