### PR TITLE
refactor: upgrade exec start protocol schema

### DIFF
--- a/crates/vsock-guest/src/connection.rs
+++ b/crates/vsock-guest/src/connection.rs
@@ -206,7 +206,13 @@ impl ConnectionDispatcher {
         if reject_operation_if_quiescing(&self.operation_state, msg.seq, &self.writer)? {
             return Ok(());
         }
-        let decoded = vsock_proto::decode_exec_start(&msg.payload).map_err(to_io_error)?;
+        let decoded = match vsock_proto::decode_exec_start(&msg.payload) {
+            Ok(decoded) => decoded,
+            Err(error) => {
+                send_error_response(msg.seq, &error.to_string(), &self.writer)?;
+                return Ok(());
+            }
+        };
         let request = match ExecOperationWorkerRequest::from_decoded(msg.seq, decoded) {
             Ok(request) => request,
             Err(error) => {

--- a/crates/vsock-guest/src/connection.rs
+++ b/crates/vsock-guest/src/connection.rs
@@ -207,13 +207,20 @@ impl ConnectionDispatcher {
             return Ok(());
         }
         let decoded = vsock_proto::decode_exec_start(&msg.payload).map_err(to_io_error)?;
+        let request = match ExecOperationWorkerRequest::from_decoded(msg.seq, decoded) {
+            Ok(request) => request,
+            Err(error) => {
+                send_error_response(msg.seq, &error.to_string(), &self.writer)?;
+                return Ok(());
+            }
+        };
         let Some(operation_guard) =
             acquire_operation_guard(&self.operation_state, msg.seq, &self.writer)?
         else {
             return Ok(());
         };
         start_exec_operation(
-            ExecOperationWorkerRequest::from_decoded(msg.seq, decoded),
+            request,
             operation_guard,
             self.writer.clone(),
             self.connection_cancel.clone(),

--- a/crates/vsock-guest/src/exec_operation.rs
+++ b/crates/vsock-guest/src/exec_operation.rs
@@ -8,8 +8,9 @@ use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
 
 use vsock_proto::{
-    self, ExecCapturedOutput, ExecOutputPolicy, ExecOutputStream, ExecTermination, MSG_ERROR,
-    MSG_EXEC_OUTPUT, MSG_EXEC_RESULT,
+    self, ExecCapturedOutput, ExecControlPolicy, ExecLifecyclePolicy, ExecOutputPolicy,
+    ExecOutputStream, ExecTermination, ExecTimeoutPolicy, MSG_ERROR, MSG_EXEC_OUTPUT,
+    MSG_EXEC_RESULT,
 };
 
 use crate::drain::{BoundedDrainResult, BoundedStreamConfig, drain_bounded_cancellable};
@@ -140,10 +141,32 @@ pub(crate) struct ExecOperationWorkerRequest {
 }
 
 impl ExecOperationWorkerRequest {
-    pub(crate) fn from_decoded(seq: u32, decoded: vsock_proto::DecodedExecStart<'_>) -> Self {
-        Self {
+    pub(crate) fn from_decoded(
+        seq: u32,
+        decoded: vsock_proto::DecodedExecStart<'_>,
+    ) -> io::Result<Self> {
+        if decoded.lifecycle != ExecLifecyclePolicy::OneShot {
+            return Err(io::Error::new(
+                io::ErrorKind::Unsupported,
+                "exec supervised lifecycle is not supported",
+            ));
+        }
+        let ExecTimeoutPolicy::Duration { timeout_ms } = decoded.timeout else {
+            return Err(io::Error::new(
+                io::ErrorKind::Unsupported,
+                "exec timeout policy none is not supported",
+            ));
+        };
+        if decoded.control != ExecControlPolicy::Disabled {
+            return Err(io::Error::new(
+                io::ErrorKind::Unsupported,
+                "exec control policy is not supported",
+            ));
+        }
+
+        Ok(Self {
             seq,
-            timeout_ms: decoded.timeout_ms,
+            timeout_ms,
             command: decoded.command.to_owned(),
             env: decoded
                 .env
@@ -155,7 +178,7 @@ impl ExecOperationWorkerRequest {
             stdout: decoded.stdout,
             stderr: decoded.stderr,
             expected_exit_codes: decoded.expected_exit_codes,
-        }
+        })
     }
 }
 

--- a/crates/vsock-guest/src/exec_operation.rs
+++ b/crates/vsock-guest/src/exec_operation.rs
@@ -157,6 +157,12 @@ impl ExecOperationWorkerRequest {
                 "exec timeout policy none is not supported",
             ));
         };
+        if timeout_ms == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "exec timeout duration must be positive",
+            ));
+        }
         if decoded.control != ExecControlPolicy::Disabled {
             return Err(io::Error::new(
                 io::ErrorKind::Unsupported,

--- a/crates/vsock-guest/tests/connection/exec_operation.rs
+++ b/crates/vsock-guest/tests/connection/exec_operation.rs
@@ -114,6 +114,24 @@ fn exec_operation_rejects_unsupported_start_policies() {
         "exec timeout policy none is not supported"
     );
 
+    let mut zero_timeout_payload = vsock_proto::encode_exec_start(
+        1,
+        "printf should-not-run",
+        &[],
+        false,
+        "test",
+        ExecOutputPolicy::Discard,
+        ExecOutputPolicy::Discard,
+    )
+    .unwrap();
+    zero_timeout_payload[2..6].copy_from_slice(&0u32.to_be_bytes());
+    let zero_timeout_msg = vsock_proto::encode(MSG_EXEC_START, 109, &zero_timeout_payload).unwrap();
+    host_stream.write_all(&zero_timeout_msg).unwrap();
+    assert_eq!(
+        read_error_response(&mut host_stream, 109),
+        "invalid payload: exec start timeout duration must be positive"
+    );
+
     send_exec_start_request(
         &mut host_stream,
         105,
@@ -334,7 +352,7 @@ fn exec_operation_stream_disconnect_cancels_child() {
         &mut host_stream,
         117,
         &command,
-        0,
+        LONG_RUNNING_EXEC_TIMEOUT_MS,
         ExecOutputPolicy::Stream {
             limit_bytes: 1024 * 1024,
             chunk_limit_bytes: 16,
@@ -585,7 +603,7 @@ fn exec_operation_explicit_cancel_kills_child_and_returns_cancelled() {
         &mut host_stream,
         111,
         &command,
-        0,
+        LONG_RUNNING_EXEC_TIMEOUT_MS,
         ExecOutputPolicy::Capture { limit_bytes: 64 },
         ExecOutputPolicy::Capture { limit_bytes: 64 },
     );
@@ -616,7 +634,7 @@ fn exec_operation_connection_close_cancels_child() {
         &mut host_stream,
         112,
         &command,
-        0,
+        LONG_RUNNING_EXEC_TIMEOUT_MS,
         ExecOutputPolicy::Capture { limit_bytes: 64 },
         ExecOutputPolicy::Capture { limit_bytes: 64 },
     );
@@ -643,7 +661,7 @@ fn exec_operation_duplicate_start_returns_error_without_cancelling_active_exec_o
         &mut host_stream,
         113,
         &command,
-        0,
+        LONG_RUNNING_EXEC_TIMEOUT_MS,
         ExecOutputPolicy::Capture { limit_bytes: 64 },
         ExecOutputPolicy::Capture { limit_bytes: 64 },
     );
@@ -693,7 +711,7 @@ fn exec_operation_different_sequences_run_concurrently_and_cancel_independently(
         &mut host_stream,
         120,
         &blocked_command,
-        0,
+        LONG_RUNNING_EXEC_TIMEOUT_MS,
         ExecOutputPolicy::Capture { limit_bytes: 64 },
         ExecOutputPolicy::Capture { limit_bytes: 64 },
     );
@@ -798,7 +816,7 @@ fn exec_operation_returns_when_orphaned_grandchild_holds_stdout() {
         &mut host_stream,
         122,
         &command,
-        0,
+        LONG_RUNNING_EXEC_TIMEOUT_MS,
         ExecOutputPolicy::Capture { limit_bytes: 1024 },
         ExecOutputPolicy::Capture { limit_bytes: 1024 },
     );
@@ -836,7 +854,7 @@ fn exec_operation_captures_grandchild_output_before_drain_deadline() {
         &mut host_stream,
         123,
         "echo stdout-early; echo stderr-early >&2; { sleep 1; echo stdout-late; echo stderr-late >&2; } &",
-        0,
+        LONG_RUNNING_EXEC_TIMEOUT_MS,
         ExecOutputPolicy::Capture { limit_bytes: 1024 },
         ExecOutputPolicy::Capture { limit_bytes: 1024 },
     );

--- a/crates/vsock-guest/tests/connection/exec_operation.rs
+++ b/crates/vsock-guest/tests/connection/exec_operation.rs
@@ -2,7 +2,8 @@ use std::io::Write;
 use std::time::Duration;
 
 use vsock_proto::{
-    self, ExecOutputPolicy, ExecOutputStream, ExecTermination, MSG_ERROR, MSG_EXEC_START,
+    self, ExecControlPolicy, ExecLifecyclePolicy, ExecOutputPolicy, ExecOutputStream,
+    ExecTermination, ExecTimeoutPolicy, MSG_ERROR, MSG_EXEC_START,
 };
 
 use super::support::*;
@@ -38,7 +39,8 @@ fn exec_operation_expected_nonzero_exit_still_returns_result() {
 
     let payload = vsock_proto::encode_exec_start_with_expected_exit_codes(
         vsock_proto::ExecStartEncodeRequest {
-            timeout_ms: 5000,
+            lifecycle: ExecLifecyclePolicy::OneShot,
+            timeout: ExecTimeoutPolicy::Duration { timeout_ms: 5000 },
             command: "exit 66",
             env: &[],
             sudo: false,
@@ -46,6 +48,7 @@ fn exec_operation_expected_nonzero_exit_still_returns_result() {
             stdout: ExecOutputPolicy::Capture { limit_bytes: 1024 },
             stderr: ExecOutputPolicy::Capture { limit_bytes: 1024 },
             expected_exit_codes: &[66],
+            control: ExecControlPolicy::Disabled,
         },
     );
     let msg = vsock_proto::encode(MSG_EXEC_START, 102, &payload.unwrap()).unwrap();
@@ -60,6 +63,79 @@ fn exec_operation_expected_nonzero_exit_still_returns_result() {
     assert_eq!(result.stdout, Some(Vec::new()));
     assert_eq!(result.stderr, Some(Vec::new()));
     assert!(result.diagnostic.is_empty());
+
+    finish_guest_connection(handle, host_stream);
+}
+
+#[test]
+fn exec_operation_rejects_unsupported_start_policies() {
+    let (handle, mut host_stream) = start_guest_connection();
+
+    send_exec_start_request(
+        &mut host_stream,
+        103,
+        vsock_proto::ExecStartEncodeRequest {
+            lifecycle: ExecLifecyclePolicy::Supervised,
+            timeout: ExecTimeoutPolicy::Duration { timeout_ms: 5000 },
+            command: "sleep 1",
+            env: &[],
+            sudo: false,
+            label: "test",
+            stdout: ExecOutputPolicy::Discard,
+            stderr: ExecOutputPolicy::Discard,
+            expected_exit_codes: &[],
+            control: ExecControlPolicy::Disabled,
+        },
+    );
+    assert_eq!(
+        read_error_response(&mut host_stream, 103),
+        "exec supervised lifecycle is not supported"
+    );
+
+    send_exec_start_request(
+        &mut host_stream,
+        104,
+        vsock_proto::ExecStartEncodeRequest {
+            lifecycle: ExecLifecyclePolicy::OneShot,
+            timeout: ExecTimeoutPolicy::None,
+            command: "sleep 1",
+            env: &[],
+            sudo: false,
+            label: "test",
+            stdout: ExecOutputPolicy::Discard,
+            stderr: ExecOutputPolicy::Discard,
+            expected_exit_codes: &[],
+            control: ExecControlPolicy::Disabled,
+        },
+    );
+    assert_eq!(
+        read_error_response(&mut host_stream, 104),
+        "exec timeout policy none is not supported"
+    );
+
+    send_exec_start_request(
+        &mut host_stream,
+        105,
+        vsock_proto::ExecStartEncodeRequest {
+            lifecycle: ExecLifecyclePolicy::OneShot,
+            timeout: ExecTimeoutPolicy::Duration { timeout_ms: 5000 },
+            command: "sleep 1",
+            env: &[],
+            sudo: false,
+            label: "test",
+            stdout: ExecOutputPolicy::Discard,
+            stderr: ExecOutputPolicy::Discard,
+            expected_exit_codes: &[],
+            control: ExecControlPolicy::Enabled {
+                control_nonce: *b"0123456789abcdef",
+                sink: false,
+            },
+        },
+    );
+    assert_eq!(
+        read_error_response(&mut host_stream, 105),
+        "exec control policy is not supported"
+    );
 
     finish_guest_connection(handle, host_stream);
 }

--- a/crates/vsock-guest/tests/connection/exec_operation.rs
+++ b/crates/vsock-guest/tests/connection/exec_operation.rs
@@ -77,7 +77,7 @@ fn exec_operation_rejects_unsupported_start_policies() {
         vsock_proto::ExecStartEncodeRequest {
             lifecycle: ExecLifecyclePolicy::Supervised,
             timeout: ExecTimeoutPolicy::Duration { timeout_ms: 5000 },
-            command: "sleep 1",
+            command: "printf should-not-run",
             env: &[],
             sudo: false,
             label: "test",
@@ -98,7 +98,7 @@ fn exec_operation_rejects_unsupported_start_policies() {
         vsock_proto::ExecStartEncodeRequest {
             lifecycle: ExecLifecyclePolicy::OneShot,
             timeout: ExecTimeoutPolicy::None,
-            command: "sleep 1",
+            command: "printf should-not-run",
             env: &[],
             sudo: false,
             label: "test",
@@ -119,7 +119,7 @@ fn exec_operation_rejects_unsupported_start_policies() {
         vsock_proto::ExecStartEncodeRequest {
             lifecycle: ExecLifecyclePolicy::OneShot,
             timeout: ExecTimeoutPolicy::Duration { timeout_ms: 5000 },
-            command: "sleep 1",
+            command: "printf should-not-run",
             env: &[],
             sudo: false,
             label: "test",

--- a/crates/vsock-guest/tests/connection/exec_operation.rs
+++ b/crates/vsock-guest/tests/connection/exec_operation.rs
@@ -3,7 +3,8 @@ use std::time::Duration;
 
 use vsock_proto::{
     self, ExecControlPolicy, ExecLifecyclePolicy, ExecOutputPolicy, ExecOutputStream,
-    ExecTermination, ExecTimeoutPolicy, MSG_ERROR, MSG_EXEC_START,
+    ExecTermination, ExecTimeoutPolicy, MSG_ERROR, MSG_EXEC_START, MSG_OPERATIONS_QUIESCED,
+    MSG_OPERATIONS_RESUMED,
 };
 
 use super::support::*;
@@ -136,6 +137,31 @@ fn exec_operation_rejects_unsupported_start_policies() {
         read_error_response(&mut host_stream, 105),
         "exec control policy is not supported"
     );
+
+    send_quiesce_operations(&mut host_stream, 106);
+    let quiesced = read_message(&mut host_stream);
+    assert_eq!(quiesced.msg_type, MSG_OPERATIONS_QUIESCED);
+    assert_eq!(quiesced.seq, 106);
+    assert!(quiesced.payload.is_empty());
+
+    send_resume_operations(&mut host_stream, 107);
+    let resumed = read_message(&mut host_stream);
+    assert_eq!(resumed.msg_type, MSG_OPERATIONS_RESUMED);
+    assert_eq!(resumed.seq, 107);
+    assert!(resumed.payload.is_empty());
+
+    send_exec_start(
+        &mut host_stream,
+        108,
+        "printf ok",
+        5000,
+        ExecOutputPolicy::Capture { limit_bytes: 64 },
+        ExecOutputPolicy::Discard,
+    );
+    let (chunks, result) = read_exec_result(&mut host_stream, 108);
+    assert!(chunks.is_empty());
+    assert_eq!(result.termination, ExecTermination::Exited { exit_code: 0 });
+    assert_eq!(result.stdout, Some(b"ok".to_vec()));
 
     finish_guest_connection(handle, host_stream);
 }

--- a/crates/vsock-guest/tests/connection/quiesce.rs
+++ b/crates/vsock-guest/tests/connection/quiesce.rs
@@ -15,7 +15,7 @@ fn quiesce_busy_fences_new_exec_operations_until_pending_exec_finishes() {
         &mut host_stream,
         201,
         "sleep 60",
-        0,
+        LONG_RUNNING_EXEC_TIMEOUT_MS,
         ExecOutputPolicy::Capture { limit_bytes: 64 },
         ExecOutputPolicy::Discard,
     );
@@ -286,7 +286,7 @@ fn resume_operations_reopens_after_busy_quiesce_with_pending_operation() {
         &mut host_stream,
         241,
         "sleep 60",
-        0,
+        LONG_RUNNING_EXEC_TIMEOUT_MS,
         ExecOutputPolicy::Capture { limit_bytes: 64 },
         ExecOutputPolicy::Discard,
     );

--- a/crates/vsock-guest/tests/connection/support.rs
+++ b/crates/vsock-guest/tests/connection/support.rs
@@ -11,6 +11,7 @@ use vsock_proto::{
 
 pub(crate) const EXIT_CODE_TIMEOUT: i32 = 124;
 pub(crate) const DRAIN_DEADLINE_SECS: u64 = 5;
+pub(crate) const LONG_RUNNING_EXEC_TIMEOUT_MS: u32 = 60_000;
 pub(crate) const LARGE_ENV_COMMAND: &str =
     "printf '%s:%s:%s:%s:%s\\n' \"$SMALL\" \"${#BIG_A}\" \"${#BIG_B}\" \"${#BIG_C}\" \"${#BIG_D}\"";
 

--- a/crates/vsock-guest/tests/connection/support.rs
+++ b/crates/vsock-guest/tests/connection/support.rs
@@ -202,6 +202,23 @@ pub(crate) fn send_exec_start_with_env(
     stream.write_all(&msg).unwrap();
 }
 
+pub(crate) fn send_exec_start_request(
+    stream: &mut impl std::io::Write,
+    seq: u32,
+    request: vsock_proto::ExecStartEncodeRequest<'_>,
+) {
+    let payload = vsock_proto::encode_exec_start_with_expected_exit_codes(request).unwrap();
+    let msg = vsock_proto::encode(MSG_EXEC_START, seq, &payload).unwrap();
+    stream.write_all(&msg).unwrap();
+}
+
+pub(crate) fn read_error_response(stream: &mut impl std::io::Read, seq: u32) -> String {
+    let msg = read_message(stream);
+    assert_eq!(msg.msg_type, MSG_ERROR);
+    assert_eq!(msg.seq, seq);
+    vsock_proto::decode_error(&msg.payload).unwrap().to_owned()
+}
+
 pub(crate) fn send_exec_cancel(stream: &mut impl std::io::Write, seq: u32) {
     let payload = vsock_proto::encode_exec_cancel();
     let msg = vsock_proto::encode(MSG_EXEC_CANCEL, seq, &payload).unwrap();

--- a/crates/vsock-host/src/exec_operation.rs
+++ b/crates/vsock-host/src/exec_operation.rs
@@ -14,8 +14,8 @@ use crate::{
     operation_tracker::{NormalOperationToken, NormalOperationTransitionHandle},
 };
 use vsock_proto::{
-    ExecCapturedOutput, ExecOutputPolicy, ExecOutputStream, ExecTermination, MSG_EXEC_CANCEL,
-    MSG_EXEC_START, RawMessage,
+    ExecCapturedOutput, ExecControlPolicy, ExecLifecyclePolicy, ExecOutputPolicy, ExecOutputStream,
+    ExecTermination, ExecTimeoutPolicy, MSG_EXEC_CANCEL, MSG_EXEC_START, RawMessage,
 };
 
 pub(crate) const DEFAULT_EXEC_CAPTURE_LIMIT_BYTES: u32 = 1024 * 1024;
@@ -1203,7 +1203,10 @@ async fn start_exec_operation_on_shared_with_tracking(
 
     let payload = vsock_proto::encode_exec_start_with_expected_exit_codes(
         vsock_proto::ExecStartEncodeRequest {
-            timeout_ms: request.timeout_ms,
+            lifecycle: ExecLifecyclePolicy::OneShot,
+            timeout: ExecTimeoutPolicy::Duration {
+                timeout_ms: request.timeout_ms,
+            },
             command: request.command,
             env: request.env,
             sudo: request.sudo,
@@ -1211,6 +1214,7 @@ async fn start_exec_operation_on_shared_with_tracking(
             stdout: request.stdout,
             stderr: request.stderr,
             expected_exit_codes: request.expected_exit_codes,
+            control: ExecControlPolicy::Disabled,
         },
     )
     .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e.to_string()))?;

--- a/crates/vsock-host/src/tests/exec_operation/capture.rs
+++ b/crates/vsock-host/src/tests/exec_operation/capture.rs
@@ -39,7 +39,12 @@ async fn exec_operation_capture_sends_start_and_receives_result() {
     let msg = read_guest_message(&mut guest).await;
     assert_eq!(msg.msg_type, MSG_EXEC_START);
     let decoded = vsock_proto::decode_exec_start(&msg.payload).unwrap();
-    assert_eq!(decoded.timeout_ms, 7000);
+    assert_eq!(
+        decoded.timeout,
+        vsock_proto::ExecTimeoutPolicy::Duration { timeout_ms: 7000 }
+    );
+    assert_eq!(decoded.lifecycle, vsock_proto::ExecLifecyclePolicy::OneShot);
+    assert_eq!(decoded.control, vsock_proto::ExecControlPolicy::Disabled);
     assert_eq!(decoded.command, "printf hello");
     assert_eq!(decoded.env, vec![("A", "B")]);
     assert!(decoded.sudo);

--- a/crates/vsock-host/src/tests/exec_operation/exec.rs
+++ b/crates/vsock-host/src/tests/exec_operation/exec.rs
@@ -26,7 +26,12 @@ async fn test_exec() {
 
         let d = vsock_proto::decode_exec_start(&msgs[0].payload).unwrap();
         assert_eq!(d.command, "echo hello");
-        assert_eq!(d.timeout_ms, 5000);
+        assert_eq!(
+            d.timeout,
+            vsock_proto::ExecTimeoutPolicy::Duration { timeout_ms: 5000 }
+        );
+        assert_eq!(d.lifecycle, vsock_proto::ExecLifecyclePolicy::OneShot);
+        assert_eq!(d.control, vsock_proto::ExecControlPolicy::Disabled);
         assert!(d.env.is_empty());
         assert!(!d.sudo);
         assert_eq!(d.label, "exec");

--- a/crates/vsock-proto/src/lib.rs
+++ b/crates/vsock-proto/src/lib.rs
@@ -28,7 +28,7 @@
 //! | 0x08 | H→G       | shutdown          | (empty) |
 //! | 0x09 | G→H       | shutdown_ack      | (empty) |
 //! | 0x0A | G→H       | stdout_chunk      | `[4B pid][data]` (`spawn_process` uses the original request seq; pid is metadata, not the routing key) |
-//! | 0x0B | H→G       | exec_start     | `[1B version][1B lifecycle][timeout_policy][1B flags][4B cmd_len][command][4B env_count]... [2B label_len][label][stdout_policy][stderr_policy][2B expected_exit_count][4B exit_code]...[control_policy]` |
+//! | 0x0B | H→G       | exec_start     | `[1B lifecycle][timeout_policy][1B flags][4B cmd_len][command][4B env_count]... [2B label_len][label][stdout_policy][stderr_policy][2B expected_exit_count][4B exit_code]...[control_policy]` |
 //! | 0x0C | G→H       | exec_output    | `[1B stream][4B output_seq][1B flags][4B chunk_len][chunk]` |
 //! | 0x0D | G→H       | exec_result    | `[1B termination]...[4B duration_ms][stdout][stderr][2B diagnostic_len][diagnostic]` |
 //! | 0x0E | H→G       | exec_cancel    | (empty) |
@@ -72,12 +72,12 @@ pub use payloads::empty::decode_empty_payload;
 pub use payloads::error::{decode_error, encode_error};
 pub use payloads::exec_operation::{
     DecodedExecControl, DecodedExecControlResult, DecodedExecOutput, DecodedExecResult,
-    DecodedExecStart, DecodedExecStarted, EXEC_START_VERSION_V1, ExecCapturedOutput,
-    ExecControlPolicy, ExecControlStatus, ExecLifecyclePolicy, ExecOutputPolicy, ExecOutputStream,
-    ExecStartEncodeRequest, ExecTermination, ExecTimeoutPolicy, decode_exec_cancel,
-    decode_exec_control, decode_exec_control_result, decode_exec_output, decode_exec_result,
-    decode_exec_start, decode_exec_started, encode_exec_cancel, encode_exec_control,
-    encode_exec_control_result, encode_exec_output, encode_exec_result, encode_exec_start,
+    DecodedExecStart, DecodedExecStarted, ExecCapturedOutput, ExecControlPolicy, ExecControlStatus,
+    ExecLifecyclePolicy, ExecOutputPolicy, ExecOutputStream, ExecStartEncodeRequest,
+    ExecTermination, ExecTimeoutPolicy, decode_exec_cancel, decode_exec_control,
+    decode_exec_control_result, decode_exec_output, decode_exec_result, decode_exec_start,
+    decode_exec_started, encode_exec_cancel, encode_exec_control, encode_exec_control_result,
+    encode_exec_output, encode_exec_result, encode_exec_start,
     encode_exec_start_with_expected_exit_codes, encode_exec_started,
 };
 pub use payloads::process::{

--- a/crates/vsock-proto/src/lib.rs
+++ b/crates/vsock-proto/src/lib.rs
@@ -49,8 +49,13 @@
 //! and process_control messages.
 //! `exec_output.output_seq` is per exec operation and starts at 0,
 //! incrementing by 1 for each output frame across stdout and stderr.
+//! `exec_start.lifecycle` uses 0=one_shot and 1=supervised.
+//! `exec_start.timeout_policy` uses 0=`[4B timeout_ms]` and 1=no timeout.
+//! `exec_start.flags` currently uses `SUDO=0x01`.
 //! `exec_start.expected_exit_count` may be zero, but the count field is
 //! always present.
+//! `exec_start.control_policy` uses 0=disabled, or 1 followed by
+//! `[1B control_flags][16B nonce]` where `control_flags` uses `SINK=0x01`.
 //! `process_control_result.status` uses 0=delivered, 1=inactive,
 //! 2=nonce_mismatch, 3=unsupported, 4=rejected, 5=sink_unavailable,
 //! 6=sink_timeout, 7=queue_full, and 8=sink_error.

--- a/crates/vsock-proto/src/lib.rs
+++ b/crates/vsock-proto/src/lib.rs
@@ -28,7 +28,7 @@
 //! | 0x08 | H→G       | shutdown          | (empty) |
 //! | 0x09 | G→H       | shutdown_ack      | (empty) |
 //! | 0x0A | G→H       | stdout_chunk      | `[4B pid][data]` (`spawn_process` uses the original request seq; pid is metadata, not the routing key) |
-//! | 0x0B | H→G       | exec_start     | `[4B timeout_ms][1B flags][4B cmd_len][command][4B env_count]... [2B label_len][label][stdout_policy][stderr_policy][2B expected_exit_count][4B exit_code]...` |
+//! | 0x0B | H→G       | exec_start     | `[1B version][1B lifecycle][timeout_policy][1B flags][4B cmd_len][command][4B env_count]... [2B label_len][label][stdout_policy][stderr_policy][2B expected_exit_count][4B exit_code]...[control_policy]` |
 //! | 0x0C | G→H       | exec_output    | `[1B stream][4B output_seq][1B flags][4B chunk_len][chunk]` |
 //! | 0x0D | G→H       | exec_result    | `[1B termination]...[4B duration_ms][stdout][stderr][2B diagnostic_len][diagnostic]` |
 //! | 0x0E | H→G       | exec_cancel    | (empty) |
@@ -38,11 +38,15 @@
 //! | 0x12 | G→H       | operations_resumed | (empty) |
 //! | 0x13 | H→G       | process_control | `[4B target_seq][4B request_timeout_ms][16B nonce][2B message_id_len][message_id][4B payload_len][payload]` |
 //! | 0x14 | G→H       | process_control_result | `[4B target_seq][16B nonce][2B message_id_len][message_id][1B status][2B diagnostic_len][diagnostic]` |
+//! | 0x15 | G→H       | exec_started | `[4B pid]` |
+//! | 0x16 | H→G       | exec_control | `[4B target_seq][4B request_timeout_ms][16B nonce][2B message_id_len][message_id][4B payload_len][payload]` |
+//! | 0x17 | G→H       | exec_control_result | `[4B target_seq][16B nonce][2B message_id_len][message_id][1B status][2B diagnostic_len][diagnostic]` |
 //! | 0xFF | G→H       | error             | `[2B error_len][error]` |
 //!
 //! Exec operation and process operation messages are request-scoped; host/guest
 //! dispatch layers must use a non-zero sequence number for exec
-//! start/output/result/cancel, spawn_process, and process_control messages.
+//! start/started/output/result/cancel/control/control_result, spawn_process,
+//! and process_control messages.
 //! `exec_output.output_seq` is per exec operation and starts at 0,
 //! incrementing by 1 for each output frame across stdout and stderr.
 //! `exec_start.expected_exit_count` may be zero, but the count field is
@@ -50,6 +54,7 @@
 //! `process_control_result.status` uses 0=delivered, 1=inactive,
 //! 2=nonce_mismatch, 3=unsupported, 4=rejected, 5=sink_unavailable,
 //! 6=sink_timeout, 7=queue_full, and 8=sink_error.
+//! `exec_control_result.status` uses the same values.
 //! `process_control.request_timeout_ms` is the caller-visible budget, counted
 //! from guest receipt through local sink connection, request write, and response
 //! read. Host encoders round non-zero sub-millisecond durations up to 1ms and
@@ -66,11 +71,14 @@ pub use frame::{Decoder, RawMessage, encode};
 pub use payloads::empty::decode_empty_payload;
 pub use payloads::error::{decode_error, encode_error};
 pub use payloads::exec_operation::{
-    DecodedExecOutput, DecodedExecResult, DecodedExecStart, ExecCapturedOutput, ExecOutputPolicy,
-    ExecOutputStream, ExecStartEncodeRequest, ExecTermination, decode_exec_cancel,
-    decode_exec_output, decode_exec_result, decode_exec_start, encode_exec_cancel,
-    encode_exec_output, encode_exec_result, encode_exec_start,
-    encode_exec_start_with_expected_exit_codes,
+    DecodedExecControl, DecodedExecControlResult, DecodedExecOutput, DecodedExecResult,
+    DecodedExecStart, DecodedExecStarted, EXEC_START_VERSION_V1, ExecCapturedOutput,
+    ExecControlPolicy, ExecControlStatus, ExecLifecyclePolicy, ExecOutputPolicy, ExecOutputStream,
+    ExecStartEncodeRequest, ExecTermination, ExecTimeoutPolicy, decode_exec_cancel,
+    decode_exec_control, decode_exec_control_result, decode_exec_output, decode_exec_result,
+    decode_exec_start, decode_exec_started, encode_exec_cancel, encode_exec_control,
+    encode_exec_control_result, encode_exec_output, encode_exec_result, encode_exec_start,
+    encode_exec_start_with_expected_exit_codes, encode_exec_started,
 };
 pub use payloads::process::{
     ProcessExit, decode_process_exit, decode_stdout_chunk, encode_process_exit, encode_stdout_chunk,
@@ -90,10 +98,11 @@ pub use payloads::write_file::{
 };
 pub use wire::{
     EXEC_CAPTURED_OUTPUT_FLAG_TRUNCATED, EXEC_FLAG_SUDO, EXEC_OUTPUT_FLAG_TRUNCATED, HEADER_SIZE,
-    MAX_MESSAGE_SIZE, MIN_BODY_SIZE, MSG_ERROR, MSG_EXEC_CANCEL, MSG_EXEC_OUTPUT, MSG_EXEC_RESULT,
-    MSG_EXEC_START, MSG_OPERATIONS_QUIESCED, MSG_OPERATIONS_RESUMED, MSG_PING, MSG_PONG,
-    MSG_PROCESS_CONTROL, MSG_PROCESS_CONTROL_RESULT, MSG_PROCESS_EXIT, MSG_QUIESCE_OPERATIONS,
-    MSG_READY, MSG_RESUME_OPERATIONS, MSG_SHUTDOWN, MSG_SHUTDOWN_ACK, MSG_SPAWN_PROCESS,
+    MAX_MESSAGE_SIZE, MIN_BODY_SIZE, MSG_ERROR, MSG_EXEC_CANCEL, MSG_EXEC_CONTROL,
+    MSG_EXEC_CONTROL_RESULT, MSG_EXEC_OUTPUT, MSG_EXEC_RESULT, MSG_EXEC_START, MSG_EXEC_STARTED,
+    MSG_OPERATIONS_QUIESCED, MSG_OPERATIONS_RESUMED, MSG_PING, MSG_PONG, MSG_PROCESS_CONTROL,
+    MSG_PROCESS_CONTROL_RESULT, MSG_PROCESS_EXIT, MSG_QUIESCE_OPERATIONS, MSG_READY,
+    MSG_RESUME_OPERATIONS, MSG_SHUTDOWN, MSG_SHUTDOWN_ACK, MSG_SPAWN_PROCESS,
     MSG_SPAWN_PROCESS_RESULT, MSG_STDOUT_CHUNK, MSG_WRITE_FILE, MSG_WRITE_FILE_RESULT,
     SPAWN_PROCESS_FLAG_CONTROL_NONCE, SPAWN_PROCESS_FLAG_CONTROL_SINK,
     SPAWN_PROCESS_FLAG_STREAM_STDOUT, SPAWN_PROCESS_FLAG_SUDO, VSOCK_PORT, WRITE_FILE_FLAG_APPEND,

--- a/crates/vsock-proto/src/lib.rs
+++ b/crates/vsock-proto/src/lib.rs
@@ -50,7 +50,8 @@
 //! `exec_output.output_seq` is per exec operation and starts at 0,
 //! incrementing by 1 for each output frame across stdout and stderr.
 //! `exec_start.lifecycle` uses 0=one_shot and 1=supervised.
-//! `exec_start.timeout_policy` uses 0=`[4B timeout_ms]` and 1=no timeout.
+//! `exec_start.timeout_policy` uses 0=`[4B positive timeout_ms]` and
+//! 1=no timeout.
 //! `exec_start.flags` currently uses `SUDO=0x01`.
 //! `exec_start.expected_exit_count` may be zero, but the count field is
 //! always present.

--- a/crates/vsock-proto/src/payloads/exec_operation.rs
+++ b/crates/vsock-proto/src/payloads/exec_operation.rs
@@ -21,8 +21,6 @@ const EXEC_OUTPUT_POLICY_CAPTURE: u8 = 0x01;
 const EXEC_OUTPUT_POLICY_STREAM: u8 = 0x02;
 const EXEC_OUTPUT_POLICY_CAPTURE_AND_STREAM: u8 = 0x03;
 
-pub const EXEC_START_VERSION_V1: u8 = 0x01;
-
 const EXEC_LIFECYCLE_ONE_SHOT: u8 = 0x00;
 const EXEC_LIFECYCLE_SUPERVISED: u8 = 0x01;
 
@@ -334,7 +332,7 @@ pub fn encode_exec_start(
 /// Encode exec_start payload.
 ///
 /// Wire format:
-/// `[1B version][1B lifecycle][timeout_policy][1B flags][4B cmd_len][command][4B env_count]... [2B label_len][label][stdout_policy][stderr_policy][2B expected_exit_count][4B exit_code]...[control_policy]`.
+/// `[1B lifecycle][timeout_policy][1B flags][4B cmd_len][command][4B env_count]... [2B label_len][label][stdout_policy][stderr_policy][2B expected_exit_count][4B exit_code]...[control_policy]`.
 pub fn encode_exec_start_with_expected_exit_codes(
     request: ExecStartEncodeRequest<'_>,
 ) -> Result<Vec<u8>, ProtocolError> {
@@ -363,7 +361,7 @@ pub fn encode_exec_start_with_expected_exit_codes(
     let timeout_policy_len = exec_timeout_policy_encoded_len(request.timeout);
     let control_policy_len = exec_control_policy_encoded_len(request.control);
 
-    let mut payload_len = 1 + 1 + timeout_policy_len + 1 + 4;
+    let mut payload_len = 1 + timeout_policy_len + 1 + 4;
     payload_len = checked_payload_len_add(payload_len, cmd.len())?;
     payload_len = checked_payload_len_add(payload_len, 4)?;
     for (key, val) in request.env {
@@ -385,7 +383,6 @@ pub fn encode_exec_start_with_expected_exit_codes(
     ensure_payload_fits_message(payload_len)?;
 
     let mut p = Vec::with_capacity(payload_len);
-    p.push(EXEC_START_VERSION_V1);
     append_exec_lifecycle(&mut p, request.lifecycle);
     append_exec_timeout_policy(&mut p, request.timeout);
     p.push(if request.sudo { EXEC_FLAG_SUDO } else { 0 });
@@ -701,10 +698,6 @@ fn decode_exec_control_policy(
 /// Decode exec_start payload into a [`DecodedExecStart`] struct.
 pub fn decode_exec_start(payload: &[u8]) -> Result<DecodedExecStart<'_>, ProtocolError> {
     let mut offset = 0;
-    let version = read_u8(payload, &mut offset, "exec start version truncated")?;
-    if version != EXEC_START_VERSION_V1 {
-        return Err(ProtocolError::InvalidPayload("exec start version invalid"));
-    }
     let lifecycle = decode_exec_lifecycle(payload, &mut offset)?;
     let timeout = decode_exec_timeout_policy(payload, &mut offset)?;
     let flags = read_u8(payload, &mut offset, "exec start flags truncated")?;

--- a/crates/vsock-proto/src/payloads/exec_operation.rs
+++ b/crates/vsock-proto/src/payloads/exec_operation.rs
@@ -277,6 +277,15 @@ fn append_exec_control_policy(p: &mut Vec<u8>, control: ExecControlPolicy) {
     }
 }
 
+fn validate_exec_timeout_policy(timeout: ExecTimeoutPolicy) -> Result<(), ProtocolError> {
+    if let ExecTimeoutPolicy::Duration { timeout_ms: 0 } = timeout {
+        return Err(ProtocolError::InvalidPayload(
+            "exec start timeout duration must be positive",
+        ));
+    }
+    Ok(())
+}
+
 fn append_exec_output_policy(p: &mut Vec<u8>, policy: ExecOutputPolicy) {
     match policy {
         ExecOutputPolicy::Discard => p.push(EXEC_OUTPUT_POLICY_DISCARD),
@@ -333,6 +342,9 @@ pub fn encode_exec_start(
 ///
 /// Wire format:
 /// `[1B lifecycle][timeout_policy][1B flags][4B cmd_len][command][4B env_count]... [2B label_len][label][stdout_policy][stderr_policy][2B expected_exit_count][4B exit_code]...[control_policy]`.
+///
+/// Duration timeout policies require a positive `timeout_ms`; use the explicit
+/// no-timeout policy for unbounded operation lifetimes.
 pub fn encode_exec_start_with_expected_exit_codes(
     request: ExecStartEncodeRequest<'_>,
 ) -> Result<Vec<u8>, ProtocolError> {
@@ -360,6 +372,7 @@ pub fn encode_exec_start_with_expected_exit_codes(
     let stderr_policy_len = exec_output_policy_encoded_len(request.stderr)?;
     let timeout_policy_len = exec_timeout_policy_encoded_len(request.timeout);
     let control_policy_len = exec_control_policy_encoded_len(request.control);
+    validate_exec_timeout_policy(request.timeout)?;
 
     let mut payload_len = 1 + timeout_policy_len + 1 + 4;
     payload_len = checked_payload_len_add(payload_len, cmd.len())?;
@@ -653,6 +666,11 @@ fn decode_exec_timeout_policy(
     match read_u8(payload, offset, "exec start timeout policy truncated")? {
         EXEC_TIMEOUT_DURATION => {
             let timeout_ms = read_u32(payload, offset, "exec start timeout truncated")?;
+            if timeout_ms == 0 {
+                return Err(ProtocolError::InvalidPayload(
+                    "exec start timeout duration must be positive",
+                ));
+            }
             Ok(ExecTimeoutPolicy::Duration { timeout_ms })
         }
         EXEC_TIMEOUT_NONE => Ok(ExecTimeoutPolicy::None),

--- a/crates/vsock-proto/src/payloads/exec_operation.rs
+++ b/crates/vsock-proto/src/payloads/exec_operation.rs
@@ -1,8 +1,9 @@
 use crate::error::ProtocolError;
 use crate::payloads::process_control::{
-    DecodedProcessControl, DecodedProcessControlResult, PROCESS_CONTROL_NONCE_LEN,
-    ProcessControlNonce, ProcessControlStatus, decode_process_control,
-    decode_process_control_result, encode_process_control, encode_process_control_result,
+    DecodedProcessControl, DecodedProcessControlResult, EXEC_CONTROL_CODEC_ERRORS,
+    EXEC_CONTROL_RESULT_CODEC_ERRORS, PROCESS_CONTROL_NONCE_LEN, ProcessControlNonce,
+    ProcessControlStatus, decode_control_result_with_errors, decode_control_with_errors,
+    encode_control_result_with_errors, encode_control_with_errors,
 };
 use crate::read::{
     checked_payload_len_add, ensure_payload_fits_message, ensure_u16_len, ensure_u32_len,
@@ -430,12 +431,13 @@ pub fn encode_exec_control(
     payload: &[u8],
     request_timeout_ms: u32,
 ) -> Result<Vec<u8>, ProtocolError> {
-    encode_process_control(
+    encode_control_with_errors(
         target_seq,
         control_nonce,
         message_id,
         payload,
         request_timeout_ms,
+        EXEC_CONTROL_CODEC_ERRORS,
     )
 }
 
@@ -447,7 +449,14 @@ pub fn encode_exec_control_result(
     status: ExecControlStatus,
     diagnostic: &str,
 ) -> Result<Vec<u8>, ProtocolError> {
-    encode_process_control_result(target_seq, control_nonce, message_id, status, diagnostic)
+    encode_control_result_with_errors(
+        target_seq,
+        control_nonce,
+        message_id,
+        status,
+        diagnostic,
+        EXEC_CONTROL_RESULT_CODEC_ERRORS,
+    )
 }
 
 /// Encode exec_output payload: `[1B stream][4B output_seq][1B flags][4B chunk_len][chunk]`.
@@ -819,7 +828,7 @@ pub fn decode_exec_control(payload: &[u8]) -> Result<DecodedExecControl<'_>, Pro
         control_nonce,
         message_id,
         payload: message_payload,
-    } = decode_process_control(payload)?;
+    } = decode_control_with_errors(payload, EXEC_CONTROL_CODEC_ERRORS)?;
     Ok(DecodedExecControl {
         target_seq,
         request_timeout_ms,
@@ -839,7 +848,7 @@ pub fn decode_exec_control_result(
         message_id,
         status,
         diagnostic,
-    } = decode_process_control_result(payload)?;
+    } = decode_control_result_with_errors(payload, EXEC_CONTROL_RESULT_CODEC_ERRORS)?;
     Ok(DecodedExecControlResult {
         target_seq,
         control_nonce,

--- a/crates/vsock-proto/src/payloads/exec_operation.rs
+++ b/crates/vsock-proto/src/payloads/exec_operation.rs
@@ -1,4 +1,9 @@
 use crate::error::ProtocolError;
+use crate::payloads::process_control::{
+    DecodedProcessControl, DecodedProcessControlResult, PROCESS_CONTROL_NONCE_LEN,
+    ProcessControlNonce, ProcessControlStatus, decode_process_control,
+    decode_process_control_result, encode_process_control, encode_process_control_result,
+};
 use crate::read::{
     checked_payload_len_add, ensure_payload_fits_message, ensure_u16_len, ensure_u32_len,
     expect_consumed, read_i32, read_slice, read_str, read_u8, read_u16, read_u32,
@@ -14,6 +19,18 @@ const EXEC_OUTPUT_POLICY_DISCARD: u8 = 0x00;
 const EXEC_OUTPUT_POLICY_CAPTURE: u8 = 0x01;
 const EXEC_OUTPUT_POLICY_STREAM: u8 = 0x02;
 const EXEC_OUTPUT_POLICY_CAPTURE_AND_STREAM: u8 = 0x03;
+
+pub const EXEC_START_VERSION_V1: u8 = 0x01;
+
+const EXEC_LIFECYCLE_ONE_SHOT: u8 = 0x00;
+const EXEC_LIFECYCLE_SUPERVISED: u8 = 0x01;
+
+const EXEC_TIMEOUT_DURATION: u8 = 0x00;
+const EXEC_TIMEOUT_NONE: u8 = 0x01;
+
+const EXEC_CONTROL_DISABLED: u8 = 0x00;
+const EXEC_CONTROL_ENABLED: u8 = 0x01;
+const EXEC_CONTROL_FLAG_SINK: u8 = 0x01;
 
 const EXEC_TERMINATION_EXITED: u8 = 0x00;
 const EXEC_TERMINATION_TIMED_OUT: u8 = 0x01;
@@ -62,6 +79,36 @@ pub enum ExecOutputPolicy {
     },
 }
 
+/// Exec process lifecycle policy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExecLifecyclePolicy {
+    /// Run a command to completion and report one terminal result.
+    OneShot,
+    /// Start a long-running process that will acknowledge its pid.
+    Supervised,
+}
+
+/// Exec timeout policy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExecTimeoutPolicy {
+    /// Kill the operation after `timeout_ms`.
+    Duration { timeout_ms: u32 },
+    /// Do not apply a protocol-level timeout.
+    None,
+}
+
+/// Exec control channel policy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExecControlPolicy {
+    /// Do not enable exec control messages for this operation.
+    Disabled,
+    /// Enable exec control messages using a per-operation nonce.
+    Enabled {
+        control_nonce: ProcessControlNonce,
+        sink: bool,
+    },
+}
+
 /// Exec terminal state.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ExecTermination {
@@ -81,7 +128,8 @@ pub enum ExecCapturedOutput<'a> {
 
 /// Parameters for encoding an exec_start payload with extended metadata.
 pub struct ExecStartEncodeRequest<'a> {
-    pub timeout_ms: u32,
+    pub lifecycle: ExecLifecyclePolicy,
+    pub timeout: ExecTimeoutPolicy,
     pub command: &'a str,
     pub env: &'a [(&'a str, &'a str)],
     pub sudo: bool,
@@ -89,12 +137,14 @@ pub struct ExecStartEncodeRequest<'a> {
     pub stdout: ExecOutputPolicy,
     pub stderr: ExecOutputPolicy,
     pub expected_exit_codes: &'a [i32],
+    pub control: ExecControlPolicy,
 }
 
 /// Decoded exec_start payload.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DecodedExecStart<'a> {
-    pub timeout_ms: u32,
+    pub lifecycle: ExecLifecyclePolicy,
+    pub timeout: ExecTimeoutPolicy,
     pub command: &'a str,
     pub env: Vec<(&'a str, &'a str)>,
     pub sudo: bool,
@@ -102,6 +152,36 @@ pub struct DecodedExecStart<'a> {
     pub stdout: ExecOutputPolicy,
     pub stderr: ExecOutputPolicy,
     pub expected_exit_codes: Vec<i32>,
+    pub control: ExecControlPolicy,
+}
+
+/// Decoded exec_started payload.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DecodedExecStarted {
+    pub pid: u32,
+}
+
+/// Exec control request status.
+pub type ExecControlStatus = ProcessControlStatus;
+
+/// Decoded exec_control payload.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DecodedExecControl<'a> {
+    pub target_seq: u32,
+    pub request_timeout_ms: u32,
+    pub control_nonce: ProcessControlNonce,
+    pub message_id: &'a str,
+    pub payload: &'a [u8],
+}
+
+/// Decoded exec_control_result payload.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DecodedExecControlResult<'a> {
+    pub target_seq: u32,
+    pub control_nonce: ProcessControlNonce,
+    pub message_id: &'a str,
+    pub status: ExecControlStatus,
+    pub diagnostic: &'a str,
 }
 
 /// Decoded exec_output payload.
@@ -153,6 +233,51 @@ fn exec_output_policy_encoded_len(policy: ExecOutputPolicy) -> Result<usize, Pro
     }
 }
 
+fn exec_timeout_policy_encoded_len(timeout: ExecTimeoutPolicy) -> usize {
+    match timeout {
+        ExecTimeoutPolicy::Duration { .. } => 1 + 4,
+        ExecTimeoutPolicy::None => 1,
+    }
+}
+
+fn exec_control_policy_encoded_len(control: ExecControlPolicy) -> usize {
+    match control {
+        ExecControlPolicy::Disabled => 1,
+        ExecControlPolicy::Enabled { .. } => 1 + 1 + PROCESS_CONTROL_NONCE_LEN,
+    }
+}
+
+fn append_exec_lifecycle(p: &mut Vec<u8>, lifecycle: ExecLifecyclePolicy) {
+    p.push(match lifecycle {
+        ExecLifecyclePolicy::OneShot => EXEC_LIFECYCLE_ONE_SHOT,
+        ExecLifecyclePolicy::Supervised => EXEC_LIFECYCLE_SUPERVISED,
+    });
+}
+
+fn append_exec_timeout_policy(p: &mut Vec<u8>, timeout: ExecTimeoutPolicy) {
+    match timeout {
+        ExecTimeoutPolicy::Duration { timeout_ms } => {
+            p.push(EXEC_TIMEOUT_DURATION);
+            p.extend_from_slice(&timeout_ms.to_be_bytes());
+        }
+        ExecTimeoutPolicy::None => p.push(EXEC_TIMEOUT_NONE),
+    }
+}
+
+fn append_exec_control_policy(p: &mut Vec<u8>, control: ExecControlPolicy) {
+    match control {
+        ExecControlPolicy::Disabled => p.push(EXEC_CONTROL_DISABLED),
+        ExecControlPolicy::Enabled {
+            control_nonce,
+            sink,
+        } => {
+            p.push(EXEC_CONTROL_ENABLED);
+            p.push(if sink { EXEC_CONTROL_FLAG_SINK } else { 0 });
+            p.extend_from_slice(&control_nonce);
+        }
+    }
+}
+
 fn append_exec_output_policy(p: &mut Vec<u8>, policy: ExecOutputPolicy) {
     match policy {
         ExecOutputPolicy::Discard => p.push(EXEC_OUTPUT_POLICY_DISCARD),
@@ -192,7 +317,8 @@ pub fn encode_exec_start(
     stderr: ExecOutputPolicy,
 ) -> Result<Vec<u8>, ProtocolError> {
     encode_exec_start_with_expected_exit_codes(ExecStartEncodeRequest {
-        timeout_ms,
+        lifecycle: ExecLifecyclePolicy::OneShot,
+        timeout: ExecTimeoutPolicy::Duration { timeout_ms },
         command,
         env,
         sudo,
@@ -200,13 +326,14 @@ pub fn encode_exec_start(
         stdout,
         stderr,
         expected_exit_codes: &[],
+        control: ExecControlPolicy::Disabled,
     })
 }
 
 /// Encode exec_start payload.
 ///
 /// Wire format:
-/// `[4B timeout_ms][1B flags][4B cmd_len][command][4B env_count]... [2B label_len][label][stdout_policy][stderr_policy][2B expected_exit_count][4B exit_code]...`.
+/// `[1B version][1B lifecycle][timeout_policy][1B flags][4B cmd_len][command][4B env_count]... [2B label_len][label][stdout_policy][stderr_policy][2B expected_exit_count][4B exit_code]...[control_policy]`.
 pub fn encode_exec_start_with_expected_exit_codes(
     request: ExecStartEncodeRequest<'_>,
 ) -> Result<Vec<u8>, ProtocolError> {
@@ -232,8 +359,10 @@ pub fn encode_exec_start_with_expected_exit_codes(
 
     let stdout_policy_len = exec_output_policy_encoded_len(request.stdout)?;
     let stderr_policy_len = exec_output_policy_encoded_len(request.stderr)?;
+    let timeout_policy_len = exec_timeout_policy_encoded_len(request.timeout);
+    let control_policy_len = exec_control_policy_encoded_len(request.control);
 
-    let mut payload_len = 4 + 1 + 4;
+    let mut payload_len = 1 + 1 + timeout_policy_len + 1 + 4;
     payload_len = checked_payload_len_add(payload_len, cmd.len())?;
     payload_len = checked_payload_len_add(payload_len, 4)?;
     for (key, val) in request.env {
@@ -251,10 +380,13 @@ pub fn encode_exec_start_with_expected_exit_codes(
     payload_len = checked_payload_len_add(payload_len, stderr_policy_len)?;
     payload_len = checked_payload_len_add(payload_len, 2)?;
     payload_len = checked_payload_len_add(payload_len, request.expected_exit_codes.len() * 4)?;
+    payload_len = checked_payload_len_add(payload_len, control_policy_len)?;
     ensure_payload_fits_message(payload_len)?;
 
     let mut p = Vec::with_capacity(payload_len);
-    p.extend_from_slice(&request.timeout_ms.to_be_bytes());
+    p.push(EXEC_START_VERSION_V1);
+    append_exec_lifecycle(&mut p, request.lifecycle);
+    append_exec_timeout_policy(&mut p, request.timeout);
     p.push(if request.sudo { EXEC_FLAG_SUDO } else { 0 });
     p.extend_from_slice(&cmd_len.to_be_bytes());
     p.extend_from_slice(cmd);
@@ -275,8 +407,47 @@ pub fn encode_exec_start_with_expected_exit_codes(
     for exit_code in request.expected_exit_codes {
         p.extend_from_slice(&exit_code.to_be_bytes());
     }
+    append_exec_control_policy(&mut p, request.control);
     debug_assert_eq!(p.len(), payload_len);
     Ok(p)
+}
+
+/// Encode exec_started payload: `[4B pid]`.
+pub fn encode_exec_started(pid: u32) -> Result<Vec<u8>, ProtocolError> {
+    if pid == 0 {
+        return Err(ProtocolError::InvalidPayload(
+            "exec started pid must be non-zero",
+        ));
+    }
+    Ok(pid.to_be_bytes().to_vec())
+}
+
+/// Encode exec_control payload.
+pub fn encode_exec_control(
+    target_seq: u32,
+    control_nonce: ProcessControlNonce,
+    message_id: &str,
+    payload: &[u8],
+    request_timeout_ms: u32,
+) -> Result<Vec<u8>, ProtocolError> {
+    encode_process_control(
+        target_seq,
+        control_nonce,
+        message_id,
+        payload,
+        request_timeout_ms,
+    )
+}
+
+/// Encode exec_control_result payload.
+pub fn encode_exec_control_result(
+    target_seq: u32,
+    control_nonce: ProcessControlNonce,
+    message_id: &str,
+    status: ExecControlStatus,
+    diagnostic: &str,
+) -> Result<Vec<u8>, ProtocolError> {
+    encode_process_control_result(target_seq, control_nonce, message_id, status, diagnostic)
 }
 
 /// Encode exec_output payload: `[1B stream][4B output_seq][1B flags][4B chunk_len][chunk]`.
@@ -456,10 +627,77 @@ fn decode_exec_output_policy(
     }
 }
 
+fn decode_exec_lifecycle(
+    payload: &[u8],
+    offset: &mut usize,
+) -> Result<ExecLifecyclePolicy, ProtocolError> {
+    match read_u8(payload, offset, "exec start lifecycle truncated")? {
+        EXEC_LIFECYCLE_ONE_SHOT => Ok(ExecLifecyclePolicy::OneShot),
+        EXEC_LIFECYCLE_SUPERVISED => Ok(ExecLifecyclePolicy::Supervised),
+        _ => Err(ProtocolError::InvalidPayload(
+            "exec start lifecycle invalid",
+        )),
+    }
+}
+
+fn decode_exec_timeout_policy(
+    payload: &[u8],
+    offset: &mut usize,
+) -> Result<ExecTimeoutPolicy, ProtocolError> {
+    match read_u8(payload, offset, "exec start timeout policy truncated")? {
+        EXEC_TIMEOUT_DURATION => {
+            let timeout_ms = read_u32(payload, offset, "exec start timeout truncated")?;
+            Ok(ExecTimeoutPolicy::Duration { timeout_ms })
+        }
+        EXEC_TIMEOUT_NONE => Ok(ExecTimeoutPolicy::None),
+        _ => Err(ProtocolError::InvalidPayload(
+            "exec start timeout policy invalid",
+        )),
+    }
+}
+
+fn decode_exec_control_policy(
+    payload: &[u8],
+    offset: &mut usize,
+) -> Result<ExecControlPolicy, ProtocolError> {
+    match read_u8(payload, offset, "exec start control policy truncated")? {
+        EXEC_CONTROL_DISABLED => Ok(ExecControlPolicy::Disabled),
+        EXEC_CONTROL_ENABLED => {
+            let flags = read_u8(payload, offset, "exec start control flags truncated")?;
+            if flags & !EXEC_CONTROL_FLAG_SINK != 0 {
+                return Err(ProtocolError::InvalidPayload(
+                    "exec start control unknown flags",
+                ));
+            }
+            let nonce_bytes = read_slice(
+                payload,
+                offset,
+                PROCESS_CONTROL_NONCE_LEN,
+                "exec start control nonce truncated",
+            )?;
+            let control_nonce: ProcessControlNonce = nonce_bytes
+                .try_into()
+                .map_err(|_| ProtocolError::InvalidPayload("exec start control nonce invalid"))?;
+            Ok(ExecControlPolicy::Enabled {
+                control_nonce,
+                sink: flags & EXEC_CONTROL_FLAG_SINK != 0,
+            })
+        }
+        _ => Err(ProtocolError::InvalidPayload(
+            "exec start control policy invalid",
+        )),
+    }
+}
+
 /// Decode exec_start payload into a [`DecodedExecStart`] struct.
 pub fn decode_exec_start(payload: &[u8]) -> Result<DecodedExecStart<'_>, ProtocolError> {
     let mut offset = 0;
-    let timeout_ms = read_u32(payload, &mut offset, "exec start timeout truncated")?;
+    let version = read_u8(payload, &mut offset, "exec start version truncated")?;
+    if version != EXEC_START_VERSION_V1 {
+        return Err(ProtocolError::InvalidPayload("exec start version invalid"));
+    }
+    let lifecycle = decode_exec_lifecycle(payload, &mut offset)?;
+    let timeout = decode_exec_timeout_policy(payload, &mut offset)?;
     let flags = read_u8(payload, &mut offset, "exec start flags truncated")?;
     if flags & !EXEC_FLAG_SUDO != 0 {
         return Err(ProtocolError::InvalidPayload("exec start unknown flags"));
@@ -544,9 +782,11 @@ pub fn decode_exec_start(payload: &[u8]) -> Result<DecodedExecStart<'_>, Protoco
             "exec start expected exit truncated",
         )?);
     }
+    let control = decode_exec_control_policy(payload, &mut offset)?;
     expect_consumed(payload, offset, "exec start trailing bytes")?;
     Ok(DecodedExecStart {
-        timeout_ms,
+        lifecycle,
+        timeout,
         command,
         env,
         sudo: (flags & EXEC_FLAG_SUDO) != 0,
@@ -554,6 +794,58 @@ pub fn decode_exec_start(payload: &[u8]) -> Result<DecodedExecStart<'_>, Protoco
         stdout,
         stderr,
         expected_exit_codes,
+        control,
+    })
+}
+
+/// Decode exec_started payload into a [`DecodedExecStarted`] struct.
+pub fn decode_exec_started(payload: &[u8]) -> Result<DecodedExecStarted, ProtocolError> {
+    let mut offset = 0;
+    let pid = read_u32(payload, &mut offset, "exec started pid truncated")?;
+    if pid == 0 {
+        return Err(ProtocolError::InvalidPayload(
+            "exec started pid must be non-zero",
+        ));
+    }
+    expect_consumed(payload, offset, "exec started trailing bytes")?;
+    Ok(DecodedExecStarted { pid })
+}
+
+/// Decode exec_control payload into a [`DecodedExecControl`] struct.
+pub fn decode_exec_control(payload: &[u8]) -> Result<DecodedExecControl<'_>, ProtocolError> {
+    let DecodedProcessControl {
+        target_seq,
+        request_timeout_ms,
+        control_nonce,
+        message_id,
+        payload: message_payload,
+    } = decode_process_control(payload)?;
+    Ok(DecodedExecControl {
+        target_seq,
+        request_timeout_ms,
+        control_nonce,
+        message_id,
+        payload: message_payload,
+    })
+}
+
+/// Decode exec_control_result payload into a [`DecodedExecControlResult`] struct.
+pub fn decode_exec_control_result(
+    payload: &[u8],
+) -> Result<DecodedExecControlResult<'_>, ProtocolError> {
+    let DecodedProcessControlResult {
+        target_seq,
+        control_nonce,
+        message_id,
+        status,
+        diagnostic,
+    } = decode_process_control_result(payload)?;
+    Ok(DecodedExecControlResult {
+        target_seq,
+        control_nonce,
+        message_id,
+        status,
+        diagnostic,
     })
 }
 

--- a/crates/vsock-proto/src/payloads/exec_operation/tests.rs
+++ b/crates/vsock-proto/src/payloads/exec_operation/tests.rs
@@ -1,6 +1,9 @@
 use super::*;
 use crate::wire::MAX_PAYLOAD_SIZE;
 
+const ONE_SHOT_DURATION_START_HEADER_LEN: usize = 1 + 1 + 1 + 4 + 1;
+const NONCE: ProcessControlNonce = *b"0123456789abcdef";
+
 #[test]
 fn exec_start_roundtrip_discard_policies() {
     let payload = encode_exec_start(
@@ -18,7 +21,8 @@ fn exec_start_roundtrip_discard_policies() {
     assert_eq!(
         decoded,
         DecodedExecStart {
-            timeout_ms: 5000,
+            lifecycle: ExecLifecyclePolicy::OneShot,
+            timeout: ExecTimeoutPolicy::Duration { timeout_ms: 5000 },
             command: "echo ready",
             env: Vec::new(),
             sudo: false,
@@ -26,6 +30,7 @@ fn exec_start_roundtrip_discard_policies() {
             stdout: ExecOutputPolicy::Discard,
             stderr: ExecOutputPolicy::Discard,
             expected_exit_codes: Vec::new(),
+            control: ExecControlPolicy::Disabled,
         }
     );
 }
@@ -43,9 +48,9 @@ fn exec_start_wire_layout_places_label_before_output_policies() {
     )
     .unwrap();
 
-    let label_len_offset = 4 + 1 + 4 + "cmd".len() + 4;
+    let label_len_offset = ONE_SHOT_DURATION_START_HEADER_LEN + 4 + "cmd".len() + 4;
     assert_eq!(
-        &payload[label_len_offset..],
+        &payload[label_len_offset..payload.len() - 1],
         &[
             0,
             3,
@@ -78,7 +83,11 @@ fn exec_start_roundtrip_env_sudo_label_and_capture() {
     .unwrap();
 
     let decoded = decode_exec_start(&payload).unwrap();
-    assert_eq!(decoded.timeout_ms, 3000);
+    assert_eq!(decoded.lifecycle, ExecLifecyclePolicy::OneShot);
+    assert_eq!(
+        decoded.timeout,
+        ExecTimeoutPolicy::Duration { timeout_ms: 3000 }
+    );
     assert_eq!(decoded.command, "printenv");
     assert_eq!(
         decoded.env,
@@ -91,6 +100,7 @@ fn exec_start_roundtrip_env_sudo_label_and_capture() {
         ExecOutputPolicy::Capture { limit_bytes: 4096 }
     );
     assert_eq!(decoded.label, "setup");
+    assert_eq!(decoded.control, ExecControlPolicy::Disabled);
 }
 
 #[test]
@@ -124,7 +134,8 @@ fn exec_start_roundtrip_stream_policy_allows_zero_stream_limit() {
 #[test]
 fn exec_start_roundtrip_expected_exit_codes() {
     let payload = encode_exec_start_with_expected_exit_codes(ExecStartEncodeRequest {
-        timeout_ms: 1000,
+        lifecycle: ExecLifecyclePolicy::OneShot,
+        timeout: ExecTimeoutPolicy::Duration { timeout_ms: 1000 },
         command: "optional-file",
         env: &[],
         sudo: false,
@@ -132,12 +143,52 @@ fn exec_start_roundtrip_expected_exit_codes() {
         stdout: ExecOutputPolicy::Capture { limit_bytes: 4096 },
         stderr: ExecOutputPolicy::Discard,
         expected_exit_codes: &[66, -9],
+        control: ExecControlPolicy::Disabled,
     })
     .unwrap();
 
     let decoded = decode_exec_start(&payload).unwrap();
     assert_eq!(decoded.label, "read-file");
     assert_eq!(decoded.expected_exit_codes, vec![66, -9]);
+}
+
+#[test]
+fn exec_start_roundtrip_supervised_no_timeout_and_control_enabled() {
+    let payload = encode_exec_start_with_expected_exit_codes(ExecStartEncodeRequest {
+        lifecycle: ExecLifecyclePolicy::Supervised,
+        timeout: ExecTimeoutPolicy::None,
+        command: "daemon",
+        env: &[("A", "B")],
+        sudo: true,
+        label: "supervised",
+        stdout: ExecOutputPolicy::Stream {
+            limit_bytes: 1024,
+            chunk_limit_bytes: 128,
+        },
+        stderr: ExecOutputPolicy::CaptureAndStream {
+            capture_limit_bytes: 256,
+            stream_limit_bytes: 512,
+            chunk_limit_bytes: 64,
+        },
+        expected_exit_codes: &[0],
+        control: ExecControlPolicy::Enabled {
+            control_nonce: NONCE,
+            sink: true,
+        },
+    })
+    .unwrap();
+
+    let decoded = decode_exec_start(&payload).unwrap();
+    assert_eq!(decoded.lifecycle, ExecLifecyclePolicy::Supervised);
+    assert_eq!(decoded.timeout, ExecTimeoutPolicy::None);
+    assert!(decoded.sudo);
+    assert_eq!(
+        decoded.control,
+        ExecControlPolicy::Enabled {
+            control_nonce: NONCE,
+            sink: true,
+        }
+    );
 }
 
 #[test]
@@ -312,7 +363,7 @@ fn exec_start_rejects_unknown_flags() {
         ExecOutputPolicy::Discard,
     )
     .unwrap();
-    payload[4] = 0x80;
+    payload[ONE_SHOT_DURATION_START_HEADER_LEN - 1] = 0x80;
 
     let err = decode_exec_start(&payload).unwrap_err();
     assert!(matches!(
@@ -333,7 +384,7 @@ fn exec_start_rejects_invalid_utf8_fields() {
         ExecOutputPolicy::Discard,
     )
     .unwrap();
-    payload[9] = 0xFF;
+    payload[ONE_SHOT_DURATION_START_HEADER_LEN + 4] = 0xFF;
     assert!(matches!(
         decode_exec_start(&payload),
         Err(ProtocolError::InvalidPayload("invalid UTF-8 in command"))
@@ -349,7 +400,7 @@ fn exec_start_rejects_invalid_utf8_fields() {
         ExecOutputPolicy::Discard,
     )
     .unwrap();
-    let key_offset = 4 + 1 + 4 + "cmd".len() + 4 + 4;
+    let key_offset = ONE_SHOT_DURATION_START_HEADER_LEN + 4 + "cmd".len() + 4 + 4;
     payload[key_offset] = 0xFF;
     assert!(matches!(
         decode_exec_start(&payload),
@@ -383,7 +434,15 @@ fn exec_start_rejects_invalid_utf8_fields() {
         ExecOutputPolicy::Discard,
     )
     .unwrap();
-    let label_offset = 4 + 1 + 4 + "cmd".len() + 4 + 4 + "K".len() + 4 + "V".len() + 2;
+    let label_offset = ONE_SHOT_DURATION_START_HEADER_LEN
+        + 4
+        + "cmd".len()
+        + 4
+        + 4
+        + "K".len()
+        + 4
+        + "V".len()
+        + 2;
     payload[label_offset] = 0xFF;
     assert!(matches!(
         decode_exec_start(&payload),
@@ -424,7 +483,7 @@ fn exec_start_rejects_malformed_env_count_without_preallocating() {
         ExecOutputPolicy::Discard,
     )
     .unwrap();
-    let env_count_offset = 4 + 1 + 4;
+    let env_count_offset = ONE_SHOT_DURATION_START_HEADER_LEN + 4;
     payload[env_count_offset..env_count_offset + 4].copy_from_slice(&u32::MAX.to_be_bytes());
 
     assert!(matches!(
@@ -461,7 +520,7 @@ fn exec_start_rejects_env_count_above_limit() {
         ExecOutputPolicy::Discard,
     )
     .unwrap();
-    let env_count_offset = 4 + 1 + 4;
+    let env_count_offset = ONE_SHOT_DURATION_START_HEADER_LEN + 4;
     payload[env_count_offset..env_count_offset + 4]
         .copy_from_slice(&((MAX_EXEC_ENV_VARS as u32) + 1).to_be_bytes());
 
@@ -478,15 +537,44 @@ fn exec_start_rejects_truncated_fields() {
     assert!(matches!(
         decode_exec_start(&[]),
         Err(ProtocolError::InvalidPayload(
-            "exec start timeout truncated"
+            "exec start version truncated"
         ))
     ));
     assert!(matches!(
-        decode_exec_start(&[0; 4]),
+        decode_exec_start(&[EXEC_START_VERSION_V1]),
+        Err(ProtocolError::InvalidPayload(
+            "exec start lifecycle truncated"
+        ))
+    ));
+    assert!(matches!(
+        decode_exec_start(&[EXEC_START_VERSION_V1, EXEC_LIFECYCLE_ONE_SHOT]),
+        Err(ProtocolError::InvalidPayload(
+            "exec start timeout policy truncated"
+        ))
+    ));
+    assert!(matches!(
+        decode_exec_start(&[
+            EXEC_START_VERSION_V1,
+            EXEC_LIFECYCLE_ONE_SHOT,
+            EXEC_TIMEOUT_DURATION,
+            0,
+            0,
+            0,
+            1,
+        ]),
         Err(ProtocolError::InvalidPayload("exec start flags truncated"))
     ));
     assert!(matches!(
-        decode_exec_start(&[0; 8]),
+        decode_exec_start(&[
+            EXEC_START_VERSION_V1,
+            EXEC_LIFECYCLE_ONE_SHOT,
+            EXEC_TIMEOUT_DURATION,
+            0,
+            0,
+            0,
+            1,
+            0,
+        ]),
         Err(ProtocolError::InvalidPayload(
             "exec start command_len truncated"
         ))
@@ -502,7 +590,7 @@ fn exec_start_rejects_truncated_fields() {
         ExecOutputPolicy::Discard,
     )
     .unwrap();
-    payload.truncate(10);
+    payload.truncate(ONE_SHOT_DURATION_START_HEADER_LEN + 4 + 2);
     assert!(matches!(
         decode_exec_start(&payload),
         Err(ProtocolError::InvalidPayload(
@@ -520,7 +608,7 @@ fn exec_start_rejects_truncated_fields() {
         ExecOutputPolicy::Discard,
     )
     .unwrap();
-    let env_count_offset = 4 + 1 + 4 + "cmd".len();
+    let env_count_offset = ONE_SHOT_DURATION_START_HEADER_LEN + 4 + "cmd".len();
     payload.truncate(env_count_offset + 3);
     assert!(matches!(
         decode_exec_start(&payload),
@@ -539,7 +627,7 @@ fn exec_start_rejects_truncated_fields() {
         ExecOutputPolicy::Discard,
     )
     .unwrap();
-    let label_len_offset = 4 + 1 + 4 + "cmd".len() + 4;
+    let label_len_offset = ONE_SHOT_DURATION_START_HEADER_LEN + 4 + "cmd".len() + 4;
     payload.truncate(label_len_offset + 1);
     assert!(matches!(
         decode_exec_start(&payload),
@@ -558,7 +646,7 @@ fn exec_start_rejects_truncated_fields() {
         ExecOutputPolicy::Discard,
     )
     .unwrap();
-    let label_start = 4 + 1 + 4 + "cmd".len() + 4 + 2;
+    let label_start = ONE_SHOT_DURATION_START_HEADER_LEN + 4 + "cmd".len() + 4 + 2;
     payload.truncate(label_start + 1);
     assert!(matches!(
         decode_exec_start(&payload),
@@ -578,7 +666,7 @@ fn exec_start_rejects_invalid_policy_tag() {
         ExecOutputPolicy::Discard,
     )
     .unwrap();
-    let stdout_policy_offset = 4 + 1 + 4 + "cmd".len() + 4 + 2;
+    let stdout_policy_offset = ONE_SHOT_DURATION_START_HEADER_LEN + 4 + "cmd".len() + 4 + 2;
     payload[stdout_policy_offset] = 0x99;
 
     let err = decode_exec_start(&payload).unwrap_err();
@@ -621,7 +709,7 @@ fn exec_start_rejects_zero_stream_chunk_limit() {
         ExecOutputPolicy::Discard,
     )
     .unwrap();
-    let chunk_limit_offset = 4 + 1 + 4 + "cmd".len() + 4 + 2 + 1 + 4;
+    let chunk_limit_offset = ONE_SHOT_DURATION_START_HEADER_LEN + 4 + "cmd".len() + 4 + 2 + 1 + 4;
     payload[chunk_limit_offset..chunk_limit_offset + 4].copy_from_slice(&0u32.to_be_bytes());
 
     let err = decode_exec_start(&payload).unwrap_err();
@@ -635,7 +723,8 @@ fn exec_start_rejects_zero_stream_chunk_limit() {
 fn exec_start_rejects_expected_exit_count_above_limit() {
     let expected_exit_codes = vec![0; MAX_EXEC_EXPECTED_EXIT_CODES + 1];
     let err = encode_exec_start_with_expected_exit_codes(ExecStartEncodeRequest {
-        timeout_ms: 1,
+        lifecycle: ExecLifecyclePolicy::OneShot,
+        timeout: ExecTimeoutPolicy::Duration { timeout_ms: 1 },
         command: "cmd",
         env: &[],
         sudo: false,
@@ -643,6 +732,7 @@ fn exec_start_rejects_expected_exit_count_above_limit() {
         stdout: ExecOutputPolicy::Discard,
         stderr: ExecOutputPolicy::Discard,
         expected_exit_codes: &expected_exit_codes,
+        control: ExecControlPolicy::Disabled,
     })
     .unwrap_err();
     assert!(matches!(
@@ -660,8 +750,8 @@ fn exec_start_rejects_expected_exit_count_above_limit() {
         ExecOutputPolicy::Discard,
     )
     .unwrap();
-    let count_offset = payload.len() - 2;
-    payload[count_offset..]
+    let count_offset = payload.len() - 1 - 2;
+    payload[count_offset..count_offset + 2]
         .copy_from_slice(&((MAX_EXEC_EXPECTED_EXIT_CODES as u16) + 1).to_be_bytes());
     let err = decode_exec_start(&payload).unwrap_err();
     assert!(matches!(
@@ -673,7 +763,8 @@ fn exec_start_rejects_expected_exit_count_above_limit() {
 #[test]
 fn exec_start_rejects_truncated_expected_exit_codes() {
     let mut payload = encode_exec_start_with_expected_exit_codes(ExecStartEncodeRequest {
-        timeout_ms: 1,
+        lifecycle: ExecLifecyclePolicy::OneShot,
+        timeout: ExecTimeoutPolicy::Duration { timeout_ms: 1 },
         command: "cmd",
         env: &[],
         sudo: false,
@@ -681,9 +772,10 @@ fn exec_start_rejects_truncated_expected_exit_codes() {
         stdout: ExecOutputPolicy::Discard,
         stderr: ExecOutputPolicy::Discard,
         expected_exit_codes: &[66],
+        control: ExecControlPolicy::Disabled,
     })
     .unwrap();
-    payload.pop();
+    payload.truncate(payload.len() - 2);
 
     let err = decode_exec_start(&payload).unwrap_err();
     assert!(matches!(
@@ -707,7 +799,8 @@ fn exec_start_rejects_truncated_policy_fields() {
         ExecOutputPolicy::Discard,
     )
     .unwrap();
-    let stream_chunk_limit_offset = 4 + 1 + 4 + "cmd".len() + 4 + 2 + 1 + 4;
+    let stream_chunk_limit_offset =
+        ONE_SHOT_DURATION_START_HEADER_LEN + 4 + "cmd".len() + 4 + 2 + 1 + 4;
     stream_payload.truncate(stream_chunk_limit_offset + 3);
     assert!(matches!(
         decode_exec_start(&stream_payload),
@@ -730,12 +823,229 @@ fn exec_start_rejects_truncated_policy_fields() {
         ExecOutputPolicy::Discard,
     )
     .unwrap();
-    let capture_and_stream_chunk_limit_offset = 4 + 1 + 4 + "cmd".len() + 4 + 2 + 1 + 4 + 4;
+    let capture_and_stream_chunk_limit_offset =
+        ONE_SHOT_DURATION_START_HEADER_LEN + 4 + "cmd".len() + 4 + 2 + 1 + 4 + 4;
     capture_and_stream_payload.truncate(capture_and_stream_chunk_limit_offset + 3);
     assert!(matches!(
         decode_exec_start(&capture_and_stream_payload),
         Err(ProtocolError::InvalidPayload(
             "exec capture-and-stream chunk limit truncated"
+        ))
+    ));
+}
+
+#[test]
+fn exec_start_rejects_invalid_version_lifecycle_timeout_and_control() {
+    let mut payload = encode_exec_start(
+        1,
+        "cmd",
+        &[],
+        false,
+        "",
+        ExecOutputPolicy::Discard,
+        ExecOutputPolicy::Discard,
+    )
+    .unwrap();
+    payload[0] = 0x02;
+    assert!(matches!(
+        decode_exec_start(&payload),
+        Err(ProtocolError::InvalidPayload("exec start version invalid"))
+    ));
+
+    let mut payload = encode_exec_start(
+        1,
+        "cmd",
+        &[],
+        false,
+        "",
+        ExecOutputPolicy::Discard,
+        ExecOutputPolicy::Discard,
+    )
+    .unwrap();
+    payload[1] = 0xFE;
+    assert!(matches!(
+        decode_exec_start(&payload),
+        Err(ProtocolError::InvalidPayload(
+            "exec start lifecycle invalid"
+        ))
+    ));
+
+    let mut payload = encode_exec_start(
+        1,
+        "cmd",
+        &[],
+        false,
+        "",
+        ExecOutputPolicy::Discard,
+        ExecOutputPolicy::Discard,
+    )
+    .unwrap();
+    payload[2] = 0xFE;
+    assert!(matches!(
+        decode_exec_start(&payload),
+        Err(ProtocolError::InvalidPayload(
+            "exec start timeout policy invalid"
+        ))
+    ));
+
+    let mut payload = encode_exec_start_with_expected_exit_codes(ExecStartEncodeRequest {
+        lifecycle: ExecLifecyclePolicy::Supervised,
+        timeout: ExecTimeoutPolicy::None,
+        command: "cmd",
+        env: &[],
+        sudo: false,
+        label: "",
+        stdout: ExecOutputPolicy::Discard,
+        stderr: ExecOutputPolicy::Discard,
+        expected_exit_codes: &[],
+        control: ExecControlPolicy::Enabled {
+            control_nonce: NONCE,
+            sink: false,
+        },
+    })
+    .unwrap();
+    let control_tag_offset = payload.len() - (1 + 1 + PROCESS_CONTROL_NONCE_LEN);
+    payload[control_tag_offset] = 0xFE;
+    assert!(matches!(
+        decode_exec_start(&payload),
+        Err(ProtocolError::InvalidPayload(
+            "exec start control policy invalid"
+        ))
+    ));
+}
+
+#[test]
+fn exec_start_rejects_control_unknown_flags_and_truncated_nonce() {
+    let mut payload = encode_exec_start_with_expected_exit_codes(ExecStartEncodeRequest {
+        lifecycle: ExecLifecyclePolicy::Supervised,
+        timeout: ExecTimeoutPolicy::None,
+        command: "cmd",
+        env: &[],
+        sudo: false,
+        label: "",
+        stdout: ExecOutputPolicy::Discard,
+        stderr: ExecOutputPolicy::Discard,
+        expected_exit_codes: &[],
+        control: ExecControlPolicy::Enabled {
+            control_nonce: NONCE,
+            sink: false,
+        },
+    })
+    .unwrap();
+    let control_flags_offset = payload.len() - (1 + PROCESS_CONTROL_NONCE_LEN);
+    payload[control_flags_offset] = 0x80;
+    assert!(matches!(
+        decode_exec_start(&payload),
+        Err(ProtocolError::InvalidPayload(
+            "exec start control unknown flags"
+        ))
+    ));
+
+    let mut payload = encode_exec_start_with_expected_exit_codes(ExecStartEncodeRequest {
+        lifecycle: ExecLifecyclePolicy::Supervised,
+        timeout: ExecTimeoutPolicy::None,
+        command: "cmd",
+        env: &[],
+        sudo: false,
+        label: "",
+        stdout: ExecOutputPolicy::Discard,
+        stderr: ExecOutputPolicy::Discard,
+        expected_exit_codes: &[],
+        control: ExecControlPolicy::Enabled {
+            control_nonce: NONCE,
+            sink: false,
+        },
+    })
+    .unwrap();
+    payload.pop();
+    assert!(matches!(
+        decode_exec_start(&payload),
+        Err(ProtocolError::InvalidPayload(
+            "exec start control nonce truncated"
+        ))
+    ));
+}
+
+#[test]
+fn exec_started_roundtrip_and_rejects_malformed_payloads() {
+    let payload = encode_exec_started(42).unwrap();
+    assert_eq!(decode_exec_started(&payload).unwrap().pid, 42);
+
+    assert!(matches!(
+        encode_exec_started(0),
+        Err(ProtocolError::InvalidPayload(
+            "exec started pid must be non-zero"
+        ))
+    ));
+    assert!(matches!(
+        decode_exec_started(&[0, 0, 0]),
+        Err(ProtocolError::InvalidPayload("exec started pid truncated"))
+    ));
+    assert!(matches!(
+        decode_exec_started(&[0, 0, 0, 0]),
+        Err(ProtocolError::InvalidPayload(
+            "exec started pid must be non-zero"
+        ))
+    ));
+    let mut trailing = payload;
+    trailing.push(0);
+    assert!(matches!(
+        decode_exec_started(&trailing),
+        Err(ProtocolError::InvalidPayload("exec started trailing bytes"))
+    ));
+}
+
+#[test]
+fn exec_control_roundtrip_and_rejects_malformed_payloads() {
+    let payload = encode_exec_control(7, NONCE, "message", b"body", 5000).unwrap();
+    let decoded = decode_exec_control(&payload).unwrap();
+    assert_eq!(decoded.target_seq, 7);
+    assert_eq!(decoded.request_timeout_ms, 5000);
+    assert_eq!(decoded.control_nonce, NONCE);
+    assert_eq!(decoded.message_id, "message");
+    assert_eq!(decoded.payload, b"body");
+
+    let err = encode_exec_control(0, NONCE, "message", b"body", 5000).unwrap_err();
+    assert!(matches!(
+        err,
+        ProtocolError::InvalidPayload("process_control target_seq must be non-zero")
+    ));
+
+    let mut trailing = payload;
+    trailing.push(0);
+    assert!(matches!(
+        decode_exec_control(&trailing),
+        Err(ProtocolError::InvalidPayload(
+            "process_control trailing bytes"
+        ))
+    ));
+}
+
+#[test]
+fn exec_control_result_roundtrip_and_rejects_malformed_payloads() {
+    let payload =
+        encode_exec_control_result(7, NONCE, "message", ExecControlStatus::Delivered, "ok")
+            .unwrap();
+    let decoded = decode_exec_control_result(&payload).unwrap();
+    assert_eq!(decoded.target_seq, 7);
+    assert_eq!(decoded.control_nonce, NONCE);
+    assert_eq!(decoded.message_id, "message");
+    assert_eq!(decoded.status, ExecControlStatus::Delivered);
+    assert_eq!(decoded.diagnostic, "ok");
+
+    let err = encode_exec_control_result(0, NONCE, "message", ExecControlStatus::Delivered, "")
+        .unwrap_err();
+    assert!(matches!(
+        err,
+        ProtocolError::InvalidPayload("process_control_result target_seq must be non-zero")
+    ));
+
+    let mut trailing = payload;
+    trailing.push(0);
+    assert!(matches!(
+        decode_exec_control_result(&trailing),
+        Err(ProtocolError::InvalidPayload(
+            "process_control_result trailing bytes"
         ))
     ));
 }

--- a/crates/vsock-proto/src/payloads/exec_operation/tests.rs
+++ b/crates/vsock-proto/src/payloads/exec_operation/tests.rs
@@ -1028,6 +1028,9 @@ fn exec_control_roundtrip_and_rejects_malformed_payloads() {
     assert_eq!(decoded.message_id, "message");
     assert_eq!(decoded.payload, b"body");
 
+    let empty_payload = encode_exec_control(7, NONCE, "message", b"", 5000).unwrap();
+    assert_eq!(decode_exec_control(&empty_payload).unwrap().payload, b"");
+
     let err = encode_exec_control(0, NONCE, "message", b"body", 5000).unwrap_err();
     assert!(matches!(
         err,
@@ -1077,6 +1080,46 @@ fn exec_control_roundtrip_and_rejects_malformed_payloads() {
         decode_exec_control(&trailing),
         Err(ProtocolError::InvalidPayload("exec_control trailing bytes"))
     ));
+}
+
+#[test]
+fn exec_control_rejects_truncated_fields() {
+    let payload = encode_exec_control(7, NONCE, "message", b"body", 5000).unwrap();
+    let request_timeout_offset = 4;
+    let nonce_offset = request_timeout_offset + 4;
+    let message_id_len_offset = nonce_offset + PROCESS_CONTROL_NONCE_LEN;
+    let message_id_offset = message_id_len_offset + 2;
+    let payload_len_offset = message_id_offset + "message".len();
+    let payload_offset = payload_len_offset + 4;
+
+    assert_invalid_payload(
+        decode_exec_control(&payload[..3]).unwrap_err(),
+        "exec_control target_seq truncated",
+    );
+    assert_invalid_payload(
+        decode_exec_control(&payload[..request_timeout_offset + 3]).unwrap_err(),
+        "exec_control request_timeout_ms truncated",
+    );
+    assert_invalid_payload(
+        decode_exec_control(&payload[..nonce_offset + PROCESS_CONTROL_NONCE_LEN - 1]).unwrap_err(),
+        "exec_control nonce truncated",
+    );
+    assert_invalid_payload(
+        decode_exec_control(&payload[..message_id_len_offset + 1]).unwrap_err(),
+        "exec_control message_id_len truncated",
+    );
+    assert_invalid_payload(
+        decode_exec_control(&payload[..message_id_offset + 2]).unwrap_err(),
+        "exec_control message_id truncated",
+    );
+    assert_invalid_payload(
+        decode_exec_control(&payload[..payload_len_offset + 3]).unwrap_err(),
+        "exec_control payload_len truncated",
+    );
+    assert_invalid_payload(
+        decode_exec_control(&payload[..payload_offset + 2]).unwrap_err(),
+        "exec_control payload truncated",
+    );
 }
 
 #[test]
@@ -1149,6 +1192,47 @@ fn exec_control_result_roundtrip_and_rejects_malformed_payloads() {
             "exec_control_result trailing bytes"
         ))
     ));
+}
+
+#[test]
+fn exec_control_result_rejects_truncated_fields() {
+    let payload =
+        encode_exec_control_result(7, NONCE, "message", ExecControlStatus::Delivered, "ok")
+            .unwrap();
+    let message_id_len_offset = 4 + PROCESS_CONTROL_NONCE_LEN;
+    let message_id_offset = message_id_len_offset + 2;
+    let status_offset = message_id_offset + "message".len();
+    let diagnostic_len_offset = status_offset + 1;
+    let diagnostic_offset = diagnostic_len_offset + 2;
+
+    assert_invalid_payload(
+        decode_exec_control_result(&payload[..3]).unwrap_err(),
+        "exec_control_result target_seq truncated",
+    );
+    assert_invalid_payload(
+        decode_exec_control_result(&payload[..4 + PROCESS_CONTROL_NONCE_LEN - 1]).unwrap_err(),
+        "exec_control_result nonce truncated",
+    );
+    assert_invalid_payload(
+        decode_exec_control_result(&payload[..message_id_len_offset + 1]).unwrap_err(),
+        "exec_control_result message_id_len truncated",
+    );
+    assert_invalid_payload(
+        decode_exec_control_result(&payload[..message_id_offset + 2]).unwrap_err(),
+        "exec_control_result message_id truncated",
+    );
+    assert_invalid_payload(
+        decode_exec_control_result(&payload[..status_offset]).unwrap_err(),
+        "exec_control_result status truncated",
+    );
+    assert_invalid_payload(
+        decode_exec_control_result(&payload[..diagnostic_len_offset + 1]).unwrap_err(),
+        "exec_control_result diagnostic_len truncated",
+    );
+    assert_invalid_payload(
+        decode_exec_control_result(&payload[..diagnostic_offset + 1]).unwrap_err(),
+        "exec_control_result diagnostic truncated",
+    );
 }
 
 #[test]

--- a/crates/vsock-proto/src/payloads/exec_operation/tests.rs
+++ b/crates/vsock-proto/src/payloads/exec_operation/tests.rs
@@ -1008,16 +1008,14 @@ fn exec_control_roundtrip_and_rejects_malformed_payloads() {
     let err = encode_exec_control(0, NONCE, "message", b"body", 5000).unwrap_err();
     assert!(matches!(
         err,
-        ProtocolError::InvalidPayload("process_control target_seq must be non-zero")
+        ProtocolError::InvalidPayload("exec_control target_seq must be non-zero")
     ));
 
     let mut trailing = payload;
     trailing.push(0);
     assert!(matches!(
         decode_exec_control(&trailing),
-        Err(ProtocolError::InvalidPayload(
-            "process_control trailing bytes"
-        ))
+        Err(ProtocolError::InvalidPayload("exec_control trailing bytes"))
     ));
 }
 
@@ -1037,7 +1035,17 @@ fn exec_control_result_roundtrip_and_rejects_malformed_payloads() {
         .unwrap_err();
     assert!(matches!(
         err,
-        ProtocolError::InvalidPayload("process_control_result target_seq must be non-zero")
+        ProtocolError::InvalidPayload("exec_control_result target_seq must be non-zero")
+    ));
+
+    let mut unknown_status = payload.clone();
+    let status_offset = 4 + PROCESS_CONTROL_NONCE_LEN + 2 + "message".len();
+    unknown_status[status_offset] = 0xFE;
+    assert!(matches!(
+        decode_exec_control_result(&unknown_status),
+        Err(ProtocolError::InvalidPayload(
+            "exec_control_result status invalid"
+        ))
     ));
 
     let mut trailing = payload;
@@ -1045,7 +1053,7 @@ fn exec_control_result_roundtrip_and_rejects_malformed_payloads() {
     assert!(matches!(
         decode_exec_control_result(&trailing),
         Err(ProtocolError::InvalidPayload(
-            "process_control_result trailing bytes"
+            "exec_control_result trailing bytes"
         ))
     ));
 }

--- a/crates/vsock-proto/src/payloads/exec_operation/tests.rs
+++ b/crates/vsock-proto/src/payloads/exec_operation/tests.rs
@@ -805,6 +805,24 @@ fn exec_start_rejects_expected_exit_count_above_limit() {
 }
 
 #[test]
+fn exec_start_rejects_truncated_expected_exit_count() {
+    let mut payload = encode_exec_start(
+        1,
+        "cmd",
+        &[],
+        false,
+        "",
+        ExecOutputPolicy::Discard,
+        ExecOutputPolicy::Discard,
+    )
+    .unwrap();
+    payload.truncate(payload.len() - 2);
+
+    let err = decode_exec_start(&payload).unwrap_err();
+    assert_invalid_payload(err, "exec start expected_exit_count truncated");
+}
+
+#[test]
 fn exec_start_rejects_truncated_expected_exit_codes() {
     let mut payload = encode_exec_start_with_expected_exit_codes(ExecStartEncodeRequest {
         lifecycle: ExecLifecyclePolicy::OneShot,

--- a/crates/vsock-proto/src/payloads/exec_operation/tests.rs
+++ b/crates/vsock-proto/src/payloads/exec_operation/tests.rs
@@ -1,8 +1,13 @@
 use super::*;
+use crate::payloads::process_control::PROCESS_CONTROL_MAX_PAYLOAD_BYTES;
 use crate::wire::MAX_PAYLOAD_SIZE;
 
 const ONE_SHOT_DURATION_START_HEADER_LEN: usize = 1 + 1 + 4 + 1;
 const NONCE: ProcessControlNonce = *b"0123456789abcdef";
+
+fn assert_invalid_payload(err: ProtocolError, expected: &'static str) {
+    assert!(matches!(err, ProtocolError::InvalidPayload(msg) if msg == expected));
+}
 
 #[test]
 fn exec_start_roundtrip_discard_policies() {
@@ -547,6 +552,12 @@ fn exec_start_rejects_truncated_fields() {
         ))
     ));
     assert!(matches!(
+        decode_exec_start(&[EXEC_LIFECYCLE_ONE_SHOT, EXEC_TIMEOUT_DURATION, 0, 0, 0]),
+        Err(ProtocolError::InvalidPayload(
+            "exec start timeout truncated"
+        ))
+    ));
+    assert!(matches!(
         decode_exec_start(&[EXEC_LIFECYCLE_ONE_SHOT, EXEC_TIMEOUT_DURATION, 0, 0, 0, 1,]),
         Err(ProtocolError::InvalidPayload("exec start flags truncated"))
     ));
@@ -636,6 +647,24 @@ fn exec_start_rejects_truncated_fields() {
     assert!(matches!(
         decode_exec_start(&payload),
         Err(ProtocolError::InvalidPayload("exec start label truncated"))
+    ));
+
+    let mut payload = encode_exec_start(
+        1,
+        "cmd",
+        &[],
+        false,
+        "ok",
+        ExecOutputPolicy::Discard,
+        ExecOutputPolicy::Discard,
+    )
+    .unwrap();
+    payload.pop();
+    assert!(matches!(
+        decode_exec_start(&payload),
+        Err(ProtocolError::InvalidPayload(
+            "exec start control policy truncated"
+        ))
     ));
 }
 
@@ -901,6 +930,31 @@ fn exec_start_rejects_control_unknown_flags_and_truncated_nonce() {
         },
     })
     .unwrap();
+    let control_tag_offset = payload.len() - (1 + 1 + PROCESS_CONTROL_NONCE_LEN);
+    payload.truncate(control_tag_offset + 1);
+    assert!(matches!(
+        decode_exec_start(&payload),
+        Err(ProtocolError::InvalidPayload(
+            "exec start control flags truncated"
+        ))
+    ));
+
+    let mut payload = encode_exec_start_with_expected_exit_codes(ExecStartEncodeRequest {
+        lifecycle: ExecLifecyclePolicy::Supervised,
+        timeout: ExecTimeoutPolicy::None,
+        command: "cmd",
+        env: &[],
+        sudo: false,
+        label: "",
+        stdout: ExecOutputPolicy::Discard,
+        stderr: ExecOutputPolicy::Discard,
+        expected_exit_codes: &[],
+        control: ExecControlPolicy::Enabled {
+            control_nonce: NONCE,
+            sink: false,
+        },
+    })
+    .unwrap();
     let control_flags_offset = payload.len() - (1 + PROCESS_CONTROL_NONCE_LEN);
     payload[control_flags_offset] = 0x80;
     assert!(matches!(
@@ -980,6 +1034,43 @@ fn exec_control_roundtrip_and_rejects_malformed_payloads() {
         ProtocolError::InvalidPayload("exec_control target_seq must be non-zero")
     ));
 
+    let err = encode_exec_control(7, NONCE, "", b"body", 5000).unwrap_err();
+    assert_invalid_payload(err, "exec_control message_id empty");
+
+    let too_large = vec![0; PROCESS_CONTROL_MAX_PAYLOAD_BYTES + 1];
+    let err = encode_exec_control(7, NONCE, "message", &too_large, 5000).unwrap_err();
+    assert!(matches!(
+        err,
+        ProtocolError::PayloadTooLarge("payload", size) if size == too_large.len()
+    ));
+
+    let mut empty_message_id = encode_exec_control(7, NONCE, "message", b"body", 5000).unwrap();
+    let message_id_len_offset = 4 + 4 + PROCESS_CONTROL_NONCE_LEN;
+    empty_message_id[message_id_len_offset..message_id_len_offset + 2]
+        .copy_from_slice(&0u16.to_be_bytes());
+    assert_invalid_payload(
+        decode_exec_control(&empty_message_id).unwrap_err(),
+        "exec_control message_id empty",
+    );
+
+    let mut invalid_message_id = encode_exec_control(7, NONCE, "message", b"body", 5000).unwrap();
+    let message_id_offset = 4 + 4 + PROCESS_CONTROL_NONCE_LEN + 2;
+    invalid_message_id[message_id_offset] = 0xFF;
+    assert_invalid_payload(
+        decode_exec_control(&invalid_message_id).unwrap_err(),
+        "invalid UTF-8 in exec_control message_id",
+    );
+
+    let mut oversized_payload_len =
+        encode_exec_control(7, NONCE, "message", b"body", 5000).unwrap();
+    let payload_len_offset = 4 + 4 + PROCESS_CONTROL_NONCE_LEN + 2 + "message".len();
+    oversized_payload_len[payload_len_offset..payload_len_offset + 4]
+        .copy_from_slice(&((PROCESS_CONTROL_MAX_PAYLOAD_BYTES as u32) + 1).to_be_bytes());
+    assert_invalid_payload(
+        decode_exec_control(&oversized_payload_len).unwrap_err(),
+        "exec_control payload too large",
+    );
+
     let mut trailing = payload;
     trailing.push(0);
     assert!(matches!(
@@ -1007,6 +1098,31 @@ fn exec_control_result_roundtrip_and_rejects_malformed_payloads() {
         ProtocolError::InvalidPayload("exec_control_result target_seq must be non-zero")
     ));
 
+    let err =
+        encode_exec_control_result(7, NONCE, "", ExecControlStatus::Delivered, "").unwrap_err();
+    assert_invalid_payload(err, "exec_control_result message_id empty");
+
+    let mut empty_message_id =
+        encode_exec_control_result(7, NONCE, "message", ExecControlStatus::Delivered, "ok")
+            .unwrap();
+    let message_id_len_offset = 4 + PROCESS_CONTROL_NONCE_LEN;
+    empty_message_id[message_id_len_offset..message_id_len_offset + 2]
+        .copy_from_slice(&0u16.to_be_bytes());
+    assert_invalid_payload(
+        decode_exec_control_result(&empty_message_id).unwrap_err(),
+        "exec_control_result message_id empty",
+    );
+
+    let mut invalid_message_id =
+        encode_exec_control_result(7, NONCE, "message", ExecControlStatus::Delivered, "ok")
+            .unwrap();
+    let message_id_offset = 4 + PROCESS_CONTROL_NONCE_LEN + 2;
+    invalid_message_id[message_id_offset] = 0xFF;
+    assert_invalid_payload(
+        decode_exec_control_result(&invalid_message_id).unwrap_err(),
+        "invalid UTF-8 in exec_control_result message_id",
+    );
+
     let mut unknown_status = payload.clone();
     let status_offset = 4 + PROCESS_CONTROL_NONCE_LEN + 2 + "message".len();
     unknown_status[status_offset] = 0xFE;
@@ -1016,6 +1132,14 @@ fn exec_control_result_roundtrip_and_rejects_malformed_payloads() {
             "exec_control_result status invalid"
         ))
     ));
+
+    let mut invalid_diagnostic = payload.clone();
+    let diagnostic_offset = status_offset + 1 + 2;
+    invalid_diagnostic[diagnostic_offset] = 0xFF;
+    assert_invalid_payload(
+        decode_exec_control_result(&invalid_diagnostic).unwrap_err(),
+        "invalid UTF-8 in exec_control_result diagnostic",
+    );
 
     let mut trailing = payload;
     trailing.push(0);

--- a/crates/vsock-proto/src/payloads/exec_operation/tests.rs
+++ b/crates/vsock-proto/src/payloads/exec_operation/tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::wire::MAX_PAYLOAD_SIZE;
 
-const ONE_SHOT_DURATION_START_HEADER_LEN: usize = 1 + 1 + 1 + 4 + 1;
+const ONE_SHOT_DURATION_START_HEADER_LEN: usize = 1 + 1 + 4 + 1;
 const NONCE: ProcessControlNonce = *b"0123456789abcdef";
 
 #[test]
@@ -537,36 +537,21 @@ fn exec_start_rejects_truncated_fields() {
     assert!(matches!(
         decode_exec_start(&[]),
         Err(ProtocolError::InvalidPayload(
-            "exec start version truncated"
-        ))
-    ));
-    assert!(matches!(
-        decode_exec_start(&[EXEC_START_VERSION_V1]),
-        Err(ProtocolError::InvalidPayload(
             "exec start lifecycle truncated"
         ))
     ));
     assert!(matches!(
-        decode_exec_start(&[EXEC_START_VERSION_V1, EXEC_LIFECYCLE_ONE_SHOT]),
+        decode_exec_start(&[EXEC_LIFECYCLE_ONE_SHOT]),
         Err(ProtocolError::InvalidPayload(
             "exec start timeout policy truncated"
         ))
     ));
     assert!(matches!(
-        decode_exec_start(&[
-            EXEC_START_VERSION_V1,
-            EXEC_LIFECYCLE_ONE_SHOT,
-            EXEC_TIMEOUT_DURATION,
-            0,
-            0,
-            0,
-            1,
-        ]),
+        decode_exec_start(&[EXEC_LIFECYCLE_ONE_SHOT, EXEC_TIMEOUT_DURATION, 0, 0, 0, 1,]),
         Err(ProtocolError::InvalidPayload("exec start flags truncated"))
     ));
     assert!(matches!(
         decode_exec_start(&[
-            EXEC_START_VERSION_V1,
             EXEC_LIFECYCLE_ONE_SHOT,
             EXEC_TIMEOUT_DURATION,
             0,
@@ -835,7 +820,7 @@ fn exec_start_rejects_truncated_policy_fields() {
 }
 
 #[test]
-fn exec_start_rejects_invalid_version_lifecycle_timeout_and_control() {
+fn exec_start_rejects_invalid_lifecycle_timeout_and_control() {
     let mut payload = encode_exec_start(
         1,
         "cmd",
@@ -846,23 +831,7 @@ fn exec_start_rejects_invalid_version_lifecycle_timeout_and_control() {
         ExecOutputPolicy::Discard,
     )
     .unwrap();
-    payload[0] = 0x02;
-    assert!(matches!(
-        decode_exec_start(&payload),
-        Err(ProtocolError::InvalidPayload("exec start version invalid"))
-    ));
-
-    let mut payload = encode_exec_start(
-        1,
-        "cmd",
-        &[],
-        false,
-        "",
-        ExecOutputPolicy::Discard,
-        ExecOutputPolicy::Discard,
-    )
-    .unwrap();
-    payload[1] = 0xFE;
+    payload[0] = 0xFE;
     assert!(matches!(
         decode_exec_start(&payload),
         Err(ProtocolError::InvalidPayload(
@@ -880,7 +849,7 @@ fn exec_start_rejects_invalid_version_lifecycle_timeout_and_control() {
         ExecOutputPolicy::Discard,
     )
     .unwrap();
-    payload[2] = 0xFE;
+    payload[1] = 0xFE;
     assert!(matches!(
         decode_exec_start(&payload),
         Err(ProtocolError::InvalidPayload(

--- a/crates/vsock-proto/src/payloads/exec_operation/tests.rs
+++ b/crates/vsock-proto/src/payloads/exec_operation/tests.rs
@@ -197,6 +197,36 @@ fn exec_start_roundtrip_supervised_no_timeout_and_control_enabled() {
 }
 
 #[test]
+fn exec_start_rejects_zero_duration_timeout() {
+    let err = encode_exec_start(
+        0,
+        "cmd",
+        &[],
+        false,
+        "",
+        ExecOutputPolicy::Discard,
+        ExecOutputPolicy::Discard,
+    )
+    .unwrap_err();
+    assert_invalid_payload(err, "exec start timeout duration must be positive");
+
+    let mut payload = encode_exec_start(
+        1,
+        "cmd",
+        &[],
+        false,
+        "",
+        ExecOutputPolicy::Discard,
+        ExecOutputPolicy::Discard,
+    )
+    .unwrap();
+    payload[2..6].copy_from_slice(&0u32.to_be_bytes());
+
+    let err = decode_exec_start(&payload).unwrap_err();
+    assert_invalid_payload(err, "exec start timeout duration must be positive");
+}
+
+#[test]
 fn exec_start_roundtrip_capture_and_stream_policy() {
     let payload = encode_exec_start(
         1000,

--- a/crates/vsock-proto/src/payloads/process_control.rs
+++ b/crates/vsock-proto/src/payloads/process_control.rs
@@ -52,6 +52,108 @@ pub struct DecodedProcessControlResult<'a> {
     pub diagnostic: &'a str,
 }
 
+#[derive(Clone, Copy)]
+pub(crate) struct ControlCodecErrors {
+    target_seq_zero: &'static str,
+    message_id_empty: &'static str,
+    target_seq_truncated: &'static str,
+    request_timeout_ms_truncated: &'static str,
+    nonce_truncated: &'static str,
+    nonce_invalid: &'static str,
+    message_id_len_truncated: &'static str,
+    message_id_truncated: &'static str,
+    message_id_utf8: &'static str,
+    payload_len_truncated: &'static str,
+    payload_too_large: &'static str,
+    payload_truncated: &'static str,
+    trailing_bytes: &'static str,
+}
+
+#[derive(Clone, Copy)]
+pub(crate) struct ControlResultCodecErrors {
+    target_seq_zero: &'static str,
+    message_id_empty: &'static str,
+    target_seq_truncated: &'static str,
+    nonce_truncated: &'static str,
+    nonce_invalid: &'static str,
+    message_id_len_truncated: &'static str,
+    message_id_truncated: &'static str,
+    message_id_utf8: &'static str,
+    status_truncated: &'static str,
+    status_invalid: &'static str,
+    diagnostic_len_truncated: &'static str,
+    diagnostic_truncated: &'static str,
+    diagnostic_utf8: &'static str,
+    trailing_bytes: &'static str,
+}
+
+const PROCESS_CONTROL_CODEC_ERRORS: ControlCodecErrors = ControlCodecErrors {
+    target_seq_zero: "process_control target_seq must be non-zero",
+    message_id_empty: "process_control message_id empty",
+    target_seq_truncated: "process_control target_seq truncated",
+    request_timeout_ms_truncated: "process_control request_timeout_ms truncated",
+    nonce_truncated: "process_control nonce truncated",
+    nonce_invalid: "process_control nonce invalid",
+    message_id_len_truncated: "process_control message_id_len truncated",
+    message_id_truncated: "process_control message_id truncated",
+    message_id_utf8: "invalid UTF-8 in process_control message_id",
+    payload_len_truncated: "process_control payload_len truncated",
+    payload_too_large: "process_control payload too large",
+    payload_truncated: "process_control payload truncated",
+    trailing_bytes: "process_control trailing bytes",
+};
+
+pub(crate) const EXEC_CONTROL_CODEC_ERRORS: ControlCodecErrors = ControlCodecErrors {
+    target_seq_zero: "exec_control target_seq must be non-zero",
+    message_id_empty: "exec_control message_id empty",
+    target_seq_truncated: "exec_control target_seq truncated",
+    request_timeout_ms_truncated: "exec_control request_timeout_ms truncated",
+    nonce_truncated: "exec_control nonce truncated",
+    nonce_invalid: "exec_control nonce invalid",
+    message_id_len_truncated: "exec_control message_id_len truncated",
+    message_id_truncated: "exec_control message_id truncated",
+    message_id_utf8: "invalid UTF-8 in exec_control message_id",
+    payload_len_truncated: "exec_control payload_len truncated",
+    payload_too_large: "exec_control payload too large",
+    payload_truncated: "exec_control payload truncated",
+    trailing_bytes: "exec_control trailing bytes",
+};
+
+const PROCESS_CONTROL_RESULT_CODEC_ERRORS: ControlResultCodecErrors = ControlResultCodecErrors {
+    target_seq_zero: "process_control_result target_seq must be non-zero",
+    message_id_empty: "process_control_result message_id empty",
+    target_seq_truncated: "process_control_result target_seq truncated",
+    nonce_truncated: "process_control_result nonce truncated",
+    nonce_invalid: "process_control_result nonce invalid",
+    message_id_len_truncated: "process_control_result message_id_len truncated",
+    message_id_truncated: "process_control_result message_id truncated",
+    message_id_utf8: "invalid UTF-8 in process_control_result message_id",
+    status_truncated: "process_control_result status truncated",
+    status_invalid: "process_control_result status invalid",
+    diagnostic_len_truncated: "process_control_result diagnostic_len truncated",
+    diagnostic_truncated: "process_control_result diagnostic truncated",
+    diagnostic_utf8: "invalid UTF-8 in process_control_result diagnostic",
+    trailing_bytes: "process_control_result trailing bytes",
+};
+
+pub(crate) const EXEC_CONTROL_RESULT_CODEC_ERRORS: ControlResultCodecErrors =
+    ControlResultCodecErrors {
+        target_seq_zero: "exec_control_result target_seq must be non-zero",
+        message_id_empty: "exec_control_result message_id empty",
+        target_seq_truncated: "exec_control_result target_seq truncated",
+        nonce_truncated: "exec_control_result nonce truncated",
+        nonce_invalid: "exec_control_result nonce invalid",
+        message_id_len_truncated: "exec_control_result message_id_len truncated",
+        message_id_truncated: "exec_control_result message_id truncated",
+        message_id_utf8: "invalid UTF-8 in exec_control_result message_id",
+        status_truncated: "exec_control_result status truncated",
+        status_invalid: "exec_control_result status invalid",
+        diagnostic_len_truncated: "exec_control_result diagnostic_len truncated",
+        diagnostic_truncated: "exec_control_result diagnostic truncated",
+        diagnostic_utf8: "invalid UTF-8 in exec_control_result diagnostic",
+        trailing_bytes: "exec_control_result trailing bytes",
+    };
+
 fn status_to_wire(status: ProcessControlStatus) -> u8 {
     match status {
         ProcessControlStatus::Delivered => PROCESS_CONTROL_STATUS_DELIVERED,
@@ -66,7 +168,10 @@ fn status_to_wire(status: ProcessControlStatus) -> u8 {
     }
 }
 
-fn status_from_wire(value: u8) -> Result<ProcessControlStatus, ProtocolError> {
+fn status_from_wire(
+    value: u8,
+    invalid_payload_message: &'static str,
+) -> Result<ProcessControlStatus, ProtocolError> {
     match value {
         PROCESS_CONTROL_STATUS_DELIVERED => Ok(ProcessControlStatus::Delivered),
         PROCESS_CONTROL_STATUS_INACTIVE => Ok(ProcessControlStatus::Inactive),
@@ -77,9 +182,7 @@ fn status_from_wire(value: u8) -> Result<ProcessControlStatus, ProtocolError> {
         PROCESS_CONTROL_STATUS_SINK_TIMEOUT => Ok(ProcessControlStatus::SinkTimeout),
         PROCESS_CONTROL_STATUS_QUEUE_FULL => Ok(ProcessControlStatus::QueueFull),
         PROCESS_CONTROL_STATUS_SINK_ERROR => Ok(ProcessControlStatus::SinkError),
-        _ => Err(ProtocolError::InvalidPayload(
-            "process_control_result status invalid",
-        )),
+        _ => Err(ProtocolError::InvalidPayload(invalid_payload_message)),
     }
 }
 
@@ -107,15 +210,29 @@ pub fn encode_process_control(
     payload: &[u8],
     request_timeout_ms: u32,
 ) -> Result<Vec<u8>, ProtocolError> {
+    encode_control_with_errors(
+        target_seq,
+        control_nonce,
+        message_id,
+        payload,
+        request_timeout_ms,
+        PROCESS_CONTROL_CODEC_ERRORS,
+    )
+}
+
+pub(crate) fn encode_control_with_errors(
+    target_seq: u32,
+    control_nonce: ProcessControlNonce,
+    message_id: &str,
+    payload: &[u8],
+    request_timeout_ms: u32,
+    errors: ControlCodecErrors,
+) -> Result<Vec<u8>, ProtocolError> {
     if target_seq == 0 {
-        return Err(ProtocolError::InvalidPayload(
-            "process_control target_seq must be non-zero",
-        ));
+        return Err(ProtocolError::InvalidPayload(errors.target_seq_zero));
     }
     if message_id.is_empty() {
-        return Err(ProtocolError::InvalidPayload(
-            "process_control message_id empty",
-        ));
+        return Err(ProtocolError::InvalidPayload(errors.message_id_empty));
     }
     if payload.len() > PROCESS_CONTROL_MAX_PAYLOAD_BYTES {
         return Err(ProtocolError::PayloadTooLarge("payload", payload.len()));
@@ -137,61 +254,45 @@ pub fn encode_process_control(
 }
 
 pub fn decode_process_control(payload: &[u8]) -> Result<DecodedProcessControl<'_>, ProtocolError> {
+    decode_control_with_errors(payload, PROCESS_CONTROL_CODEC_ERRORS)
+}
+
+pub(crate) fn decode_control_with_errors(
+    payload: &[u8],
+    errors: ControlCodecErrors,
+) -> Result<DecodedProcessControl<'_>, ProtocolError> {
     let mut offset = 0;
-    let target_seq = read_u32(payload, &mut offset, "process_control target_seq truncated")?;
+    let target_seq = read_u32(payload, &mut offset, errors.target_seq_truncated)?;
     if target_seq == 0 {
-        return Err(ProtocolError::InvalidPayload(
-            "process_control target_seq must be non-zero",
-        ));
+        return Err(ProtocolError::InvalidPayload(errors.target_seq_zero));
     }
-    let request_timeout_ms = read_u32(
-        payload,
-        &mut offset,
-        "process_control request_timeout_ms truncated",
-    )?;
+    let request_timeout_ms = read_u32(payload, &mut offset, errors.request_timeout_ms_truncated)?;
     let nonce_bytes = read_slice(
         payload,
         &mut offset,
         PROCESS_CONTROL_NONCE_LEN,
-        "process_control nonce truncated",
+        errors.nonce_truncated,
     )?;
     let control_nonce: ProcessControlNonce = nonce_bytes
         .try_into()
-        .map_err(|_| ProtocolError::InvalidPayload("process_control nonce invalid"))?;
-    let message_id_len = read_u16(
-        payload,
-        &mut offset,
-        "process_control message_id_len truncated",
-    )? as usize;
+        .map_err(|_| ProtocolError::InvalidPayload(errors.nonce_invalid))?;
+    let message_id_len = read_u16(payload, &mut offset, errors.message_id_len_truncated)? as usize;
     if message_id_len == 0 {
-        return Err(ProtocolError::InvalidPayload(
-            "process_control message_id empty",
-        ));
+        return Err(ProtocolError::InvalidPayload(errors.message_id_empty));
     }
     let message_id = read_str(
         payload,
         &mut offset,
         message_id_len,
-        "process_control message_id truncated",
-        "invalid UTF-8 in process_control message_id",
+        errors.message_id_truncated,
+        errors.message_id_utf8,
     )?;
-    let payload_len = read_u32(
-        payload,
-        &mut offset,
-        "process_control payload_len truncated",
-    )? as usize;
+    let payload_len = read_u32(payload, &mut offset, errors.payload_len_truncated)? as usize;
     if payload_len > PROCESS_CONTROL_MAX_PAYLOAD_BYTES {
-        return Err(ProtocolError::InvalidPayload(
-            "process_control payload too large",
-        ));
+        return Err(ProtocolError::InvalidPayload(errors.payload_too_large));
     }
-    let message_payload = read_slice(
-        payload,
-        &mut offset,
-        payload_len,
-        "process_control payload truncated",
-    )?;
-    expect_consumed(payload, offset, "process_control trailing bytes")?;
+    let message_payload = read_slice(payload, &mut offset, payload_len, errors.payload_truncated)?;
+    expect_consumed(payload, offset, errors.trailing_bytes)?;
 
     Ok(DecodedProcessControl {
         target_seq,
@@ -209,15 +310,29 @@ pub fn encode_process_control_result(
     status: ProcessControlStatus,
     diagnostic: &str,
 ) -> Result<Vec<u8>, ProtocolError> {
+    encode_control_result_with_errors(
+        target_seq,
+        control_nonce,
+        message_id,
+        status,
+        diagnostic,
+        PROCESS_CONTROL_RESULT_CODEC_ERRORS,
+    )
+}
+
+pub(crate) fn encode_control_result_with_errors(
+    target_seq: u32,
+    control_nonce: ProcessControlNonce,
+    message_id: &str,
+    status: ProcessControlStatus,
+    diagnostic: &str,
+    errors: ControlResultCodecErrors,
+) -> Result<Vec<u8>, ProtocolError> {
     if target_seq == 0 {
-        return Err(ProtocolError::InvalidPayload(
-            "process_control_result target_seq must be non-zero",
-        ));
+        return Err(ProtocolError::InvalidPayload(errors.target_seq_zero));
     }
     if message_id.is_empty() {
-        return Err(ProtocolError::InvalidPayload(
-            "process_control_result message_id empty",
-        ));
+        return Err(ProtocolError::InvalidPayload(errors.message_id_empty));
     }
     let message_id_len = ensure_u16_len("message_id", message_id.len())?;
     let diagnostic_len = ensure_u16_len("diagnostic", diagnostic.len())?;
@@ -238,61 +353,51 @@ pub fn encode_process_control_result(
 pub fn decode_process_control_result(
     payload: &[u8],
 ) -> Result<DecodedProcessControlResult<'_>, ProtocolError> {
+    decode_control_result_with_errors(payload, PROCESS_CONTROL_RESULT_CODEC_ERRORS)
+}
+
+pub(crate) fn decode_control_result_with_errors(
+    payload: &[u8],
+    errors: ControlResultCodecErrors,
+) -> Result<DecodedProcessControlResult<'_>, ProtocolError> {
     let mut offset = 0;
-    let target_seq = read_u32(
-        payload,
-        &mut offset,
-        "process_control_result target_seq truncated",
-    )?;
+    let target_seq = read_u32(payload, &mut offset, errors.target_seq_truncated)?;
     if target_seq == 0 {
-        return Err(ProtocolError::InvalidPayload(
-            "process_control_result target_seq must be non-zero",
-        ));
+        return Err(ProtocolError::InvalidPayload(errors.target_seq_zero));
     }
     let nonce_bytes = read_slice(
         payload,
         &mut offset,
         PROCESS_CONTROL_NONCE_LEN,
-        "process_control_result nonce truncated",
+        errors.nonce_truncated,
     )?;
     let control_nonce: ProcessControlNonce = nonce_bytes
         .try_into()
-        .map_err(|_| ProtocolError::InvalidPayload("process_control_result nonce invalid"))?;
-    let message_id_len = read_u16(
-        payload,
-        &mut offset,
-        "process_control_result message_id_len truncated",
-    )? as usize;
+        .map_err(|_| ProtocolError::InvalidPayload(errors.nonce_invalid))?;
+    let message_id_len = read_u16(payload, &mut offset, errors.message_id_len_truncated)? as usize;
     if message_id_len == 0 {
-        return Err(ProtocolError::InvalidPayload(
-            "process_control_result message_id empty",
-        ));
+        return Err(ProtocolError::InvalidPayload(errors.message_id_empty));
     }
     let message_id = read_str(
         payload,
         &mut offset,
         message_id_len,
-        "process_control_result message_id truncated",
-        "invalid UTF-8 in process_control_result message_id",
+        errors.message_id_truncated,
+        errors.message_id_utf8,
     )?;
-    let status = status_from_wire(read_u8(
-        payload,
-        &mut offset,
-        "process_control_result status truncated",
-    )?)?;
-    let diagnostic_len = read_u16(
-        payload,
-        &mut offset,
-        "process_control_result diagnostic_len truncated",
-    )? as usize;
+    let status = status_from_wire(
+        read_u8(payload, &mut offset, errors.status_truncated)?,
+        errors.status_invalid,
+    )?;
+    let diagnostic_len = read_u16(payload, &mut offset, errors.diagnostic_len_truncated)? as usize;
     let diagnostic = read_str(
         payload,
         &mut offset,
         diagnostic_len,
-        "process_control_result diagnostic truncated",
-        "invalid UTF-8 in process_control_result diagnostic",
+        errors.diagnostic_truncated,
+        errors.diagnostic_utf8,
     )?;
-    expect_consumed(payload, offset, "process_control_result trailing bytes")?;
+    expect_consumed(payload, offset, errors.trailing_bytes)?;
 
     Ok(DecodedProcessControlResult {
         target_seq,

--- a/crates/vsock-proto/src/wire.rs
+++ b/crates/vsock-proto/src/wire.rs
@@ -70,6 +70,15 @@ pub const MSG_PROCESS_CONTROL: u8 = 0x13;
 /// Guest-to-host process control delivery result.
 pub const MSG_PROCESS_CONTROL_RESULT: u8 = 0x14;
 
+/// Guest-to-host exec operation start acknowledgement.
+pub const MSG_EXEC_STARTED: u8 = 0x15;
+
+/// Host-to-guest control message for an active exec operation.
+pub const MSG_EXEC_CONTROL: u8 = 0x16;
+
+/// Guest-to-host exec control delivery result.
+pub const MSG_EXEC_CONTROL_RESULT: u8 = 0x17;
+
 /// Guest-to-host protocol error response.
 pub const MSG_ERROR: u8 = 0xFF;
 
@@ -127,5 +136,8 @@ mod tests {
         assert_eq!(MSG_EXEC_OUTPUT, 0x0C);
         assert_eq!(MSG_EXEC_RESULT, 0x0D);
         assert_eq!(MSG_EXEC_CANCEL, 0x0E);
+        assert_eq!(MSG_EXEC_STARTED, 0x15);
+        assert_eq!(MSG_EXEC_CONTROL, 0x16);
+        assert_eq!(MSG_EXEC_CONTROL_RESULT, 0x17);
     }
 }


### PR DESCRIPTION
## Summary

- Upgrade the existing `exec_start` payload schema with lifecycle, timeout, and control policies.
- Add exec-centered `exec_started`, `exec_control`, and `exec_control_result` helpers and wire ids.
- Preserve current host one-shot behavior and make the guest reject unsupported supervised/no-timeout/control-enabled starts without launching work.

## Verification

- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p vsock-proto -p vsock-host -p vsock-guest --all-targets -- -D warnings`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-proto -p vsock-host -p vsock-guest`

Closes #13746