### PR TITLE
refactor: gate process control requests

### DIFF
--- a/crates/sandbox-fc/src/control.rs
+++ b/crates/sandbox-fc/src/control.rs
@@ -448,10 +448,10 @@ async fn execute(request: ExecRequest, guest_operations: &GuestOperationGate) ->
                 error: control_start_error(error),
             };
         }
-    }
-    .into_write_boundary();
+    };
 
     let vsock = operation.guest();
+    let operation = operation.into_write_boundary();
     let write_observer = operation.write_observer();
     let timeout_ms = request.timeout_secs.saturating_mul(1000);
     let env: &[(&str, &str)] = &[];

--- a/crates/sandbox-fc/src/guest_operations.rs
+++ b/crates/sandbox-fc/src/guest_operations.rs
@@ -97,13 +97,16 @@ pub(crate) struct GuestOperation {
 }
 
 impl GuestOperation {
+    pub(crate) fn guest(&self) -> Arc<VsockHost> {
+        Arc::clone(&self.guest)
+    }
+
     pub(crate) fn into_write_boundary(self) -> GuestOperationWriteBoundary {
-        GuestOperationWriteBoundary::new(self.guest, self.lease)
+        GuestOperationWriteBoundary::new(self.lease)
     }
 }
 
 pub(crate) struct GuestOperationWriteBoundary {
-    guest: Arc<VsockHost>,
     state: Arc<Mutex<GuestOperationWriteBoundaryState>>,
 }
 
@@ -114,19 +117,14 @@ struct GuestOperationWriteBoundaryState {
 }
 
 impl GuestOperationWriteBoundary {
-    fn new(guest: Arc<VsockHost>, lease: OperationLease) -> Self {
+    pub(crate) fn new(lease: OperationLease) -> Self {
         Self {
-            guest,
             state: Arc::new(Mutex::new(GuestOperationWriteBoundaryState {
                 operation_id: lease.id(),
                 lease: Some(lease),
                 write_started: false,
             })),
         }
-    }
-
-    pub(crate) fn guest(&self) -> Arc<VsockHost> {
-        Arc::clone(&self.guest)
     }
 
     pub(crate) fn write_observer(&self) -> FrameWriteObserver {

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -747,6 +747,93 @@ impl FirecrackerSandbox {
         }
     }
 
+    fn current_state_from(state: &AtomicU8) -> SandboxState {
+        SandboxState::from_u8(state.load(Ordering::Acquire))
+    }
+
+    fn operation_start_io_error(
+        operation: SandboxOperation,
+        error: GuestOperationStartError,
+        current_state: SandboxState,
+    ) -> io::Error {
+        let error = match error {
+            GuestOperationStartError::BackendCrashed => Self::backend_crashed_error(operation),
+            GuestOperationStartError::NotRunning { state } => {
+                Self::operation_unavailable_error(operation, state)
+            }
+            GuestOperationStartError::NoGuest => {
+                Self::operation_unavailable_error(operation, current_state)
+            }
+            GuestOperationStartError::GateClosed { state } => {
+                Self::operation_gate_closed_error(operation, state)
+            }
+        };
+        io::Error::other(error)
+    }
+
+    fn operation_transition_io_error(
+        operation: SandboxOperation,
+        error: OperationTransitionError,
+    ) -> io::Error {
+        io::Error::other(Self::operation_gate_transition_error(operation, error))
+    }
+
+    async fn process_control(
+        gate: GuestOperationGate,
+        state: Arc<AtomicU8>,
+        state_tx: watch::Sender<SandboxState>,
+        control: vsock_host::GuestProcessControlHandle,
+        message_id: String,
+        payload: Vec<u8>,
+        timeout: Duration,
+    ) -> io::Result<ProcessControlAck> {
+        enum ControlOutcome {
+            Returned(io::Result<vsock_host::ProcessControlOutcome>),
+            BackendCrashed,
+        }
+
+        let operation = SandboxOperation::ProcessControl;
+        let guest = gate
+            .begin_sandbox_operation(|| Self::current_state_from(&state))
+            .await
+            .map_err(|error| {
+                Self::operation_start_io_error(operation, error, Self::current_state_from(&state))
+            })?
+            .into_write_boundary();
+        let write_observer = guest.write_observer();
+
+        let outcome = tokio::select! {
+            result = control.control_with_write_observer(
+                &message_id,
+                &payload,
+                timeout,
+                write_observer,
+            ) => ControlOutcome::Returned(result),
+            () = wait_for_backend_crash(state_tx.subscribe()) => ControlOutcome::BackendCrashed,
+        };
+
+        match outcome {
+            ControlOutcome::Returned(Ok(outcome)) => {
+                guest
+                    .complete()
+                    .map_err(|error| Self::operation_transition_io_error(operation, error))?;
+                let ack = outcome.into_ack()?;
+                Ok(ProcessControlAck {
+                    message_id: ack.message_id,
+                })
+            }
+            ControlOutcome::Returned(Err(error)) => {
+                if Self::current_state_from(&state) == SandboxState::Crashed {
+                    return Err(io::Error::other(Self::backend_crashed_error(operation)));
+                }
+                Err(error)
+            }
+            ControlOutcome::BackendCrashed => {
+                Err(io::Error::other(Self::backend_crashed_error(operation)))
+            }
+        }
+    }
+
     /// Atomically transition between states using CAS. Returns `true` if the
     /// transition succeeded, `false` if the current state did not match `from`.
     fn transition(&self, from: SandboxState, to: SandboxState) -> bool {
@@ -1651,13 +1738,19 @@ impl Sandbox for FirecrackerSandbox {
                 let pid = handle.pid();
                 let process_control = (request.control == SpawnProcessControl::Enabled).then(|| {
                     let control = handle.control_handle();
+                    let gate = self.guest_operations();
+                    let state = Arc::clone(&self.state);
+                    let state_tx = self.state_tx.clone();
                     GuestProcessControlHandle::new(move |message_id, payload, timeout| {
                         let control = control.clone();
+                        let gate = gate.clone();
+                        let state = Arc::clone(&state);
+                        let state_tx = state_tx.clone();
                         Box::pin(async move {
-                            let ack = control.control(&message_id, &payload, timeout).await?;
-                            Ok(ProcessControlAck {
-                                message_id: ack.message_id,
-                            })
+                            Self::process_control(
+                                gate, state, state_tx, control, message_id, payload, timeout,
+                            )
+                            .await
                         })
                     })
                 });
@@ -2434,6 +2527,156 @@ async fn unpark_inner(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::UnixStream;
+    use tokio::time::Instant;
+    use vsock_proto::{
+        Decoder, HEADER_SIZE, MAX_MESSAGE_SIZE, MIN_BODY_SIZE, MSG_PING, MSG_PONG,
+        MSG_PROCESS_CONTROL, MSG_PROCESS_CONTROL_RESULT, MSG_PROCESS_EXIT, MSG_READY,
+        MSG_SPAWN_PROCESS, MSG_SPAWN_PROCESS_RESULT, ProcessControlStatus, RawMessage,
+    };
+
+    struct ProcessControlFixture {
+        host: Arc<VsockHost>,
+        handle: vsock_host::GuestProcessHandle,
+        guest: UnixStream,
+        spawn_seq: u32,
+        pid: u32,
+    }
+
+    async fn connect_mock_guest(vsock_path: &str) -> UnixStream {
+        let listener_path = format!("{vsock_path}_{}", vsock_proto::VSOCK_PORT);
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            match UnixStream::connect(&listener_path).await {
+                Ok(stream) => return stream,
+                Err(error)
+                    if error.kind() == io::ErrorKind::NotFound && Instant::now() < deadline =>
+                {
+                    tokio::task::yield_now().await;
+                }
+                Err(error) => panic!("connect mock guest: {error}"),
+            }
+        }
+    }
+
+    async fn read_vsock_message(stream: &mut UnixStream) -> RawMessage {
+        let mut header = [0u8; HEADER_SIZE];
+        stream.read_exact(&mut header).await.unwrap();
+
+        let body_len = u32::from_be_bytes(header) as usize;
+        assert!(
+            (MIN_BODY_SIZE..=MAX_MESSAGE_SIZE).contains(&body_len),
+            "invalid message body length: {body_len}",
+        );
+
+        let mut body = vec![0u8; body_len];
+        stream.read_exact(&mut body).await.unwrap();
+
+        RawMessage {
+            msg_type: body[0],
+            seq: u32::from_be_bytes(body[1..MIN_BODY_SIZE].try_into().unwrap()),
+            payload: body[MIN_BODY_SIZE..].to_vec(),
+        }
+    }
+
+    async fn mock_vsock_handshake(stream: &mut UnixStream, decoder: &mut Decoder) {
+        let ready = vsock_proto::encode(MSG_READY, 0, &[]).unwrap();
+        stream.write_all(&ready).await.unwrap();
+
+        let mut buf = [0u8; 1024];
+        let n = stream.read(&mut buf).await.unwrap();
+        let msgs = decoder.decode(&buf[..n]).unwrap();
+        assert_eq!(msgs[0].msg_type, MSG_PING);
+
+        let pong = vsock_proto::encode(MSG_PONG, msgs[0].seq, &[]).unwrap();
+        stream.write_all(&pong).await.unwrap();
+    }
+
+    async fn setup_process_control_fixture() -> ProcessControlFixture {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let vsock_path = temp_dir
+            .path()
+            .join("process-control")
+            .to_string_lossy()
+            .into_owned();
+        let wait_vsock_path = vsock_path.clone();
+        let host_task = tokio::spawn(async move {
+            VsockHost::wait_for_connection(&wait_vsock_path, Duration::from_secs(5))
+                .await
+                .unwrap()
+        });
+        let mut guest = connect_mock_guest(&vsock_path).await;
+        let mut decoder = Decoder::new();
+        mock_vsock_handshake(&mut guest, &mut decoder).await;
+        let host = Arc::new(host_task.await.unwrap());
+
+        let spawn_host = Arc::clone(&host);
+        let spawn_task = tokio::spawn(async move {
+            spawn_host
+                .spawn_process("sleep 60", 0, &[], false, false, None)
+                .await
+                .unwrap()
+        });
+        let spawn = read_vsock_message(&mut guest).await;
+        assert_eq!(spawn.msg_type, MSG_SPAWN_PROCESS);
+
+        let pid = 73;
+        let payload = vsock_proto::encode_spawn_process_result(pid);
+        let response = vsock_proto::encode(MSG_SPAWN_PROCESS_RESULT, spawn.seq, &payload).unwrap();
+        guest.write_all(&response).await.unwrap();
+        let handle = spawn_task.await.unwrap();
+
+        ProcessControlFixture {
+            host,
+            handle,
+            guest,
+            spawn_seq: spawn.seq,
+            pid,
+        }
+    }
+
+    fn process_control_gate(host: Arc<VsockHost>) -> (GuestOperationGate, ParkCoordinator) {
+        let coordinator = ParkCoordinator::new();
+        let guest = Arc::new(tokio::sync::Mutex::new(Some(host)));
+        (
+            GuestOperationGate::new(guest, coordinator.clone()),
+            coordinator,
+        )
+    }
+
+    fn running_process_state() -> (Arc<AtomicU8>, watch::Sender<SandboxState>) {
+        let state = Arc::new(AtomicU8::new(SandboxState::Running as u8));
+        let (state_tx, _state_rx) = watch::channel(SandboxState::Running);
+        (state, state_tx)
+    }
+
+    async fn send_process_control_result(
+        stream: &mut UnixStream,
+        request: RawMessage,
+        status: ProcessControlStatus,
+        diagnostic: &str,
+    ) {
+        assert_eq!(request.msg_type, MSG_PROCESS_CONTROL);
+        let decoded = vsock_proto::decode_process_control(&request.payload).unwrap();
+        let payload = vsock_proto::encode_process_control_result(
+            decoded.target_seq,
+            decoded.control_nonce,
+            decoded.message_id,
+            status,
+            diagnostic,
+        )
+        .unwrap();
+        let response =
+            vsock_proto::encode(MSG_PROCESS_CONTROL_RESULT, request.seq, &payload).unwrap();
+        stream.write_all(&response).await.unwrap();
+    }
+
+    async fn send_process_exit(stream: &mut UnixStream, spawn_seq: u32, pid: u32) {
+        let payload = vsock_proto::encode_process_exit(pid, 0, b"", b"");
+        let response = vsock_proto::encode(MSG_PROCESS_EXIT, spawn_seq, &payload).unwrap();
+        stream.write_all(&response).await.unwrap();
+    }
 
     fn monitored_cat_process() -> tokio::process::Child {
         tokio::process::Command::new("cat")
@@ -3351,6 +3594,7 @@ mod tests {
             SandboxOperation::Exec,
             SandboxOperation::WriteFile,
             SandboxOperation::SpawnProcess,
+            SandboxOperation::ProcessControl,
             SandboxOperation::WaitExit,
         ] {
             let err = FirecrackerSandbox::operation_error(
@@ -3369,6 +3613,7 @@ mod tests {
             SandboxOperation::Exec,
             SandboxOperation::WriteFile,
             SandboxOperation::SpawnProcess,
+            SandboxOperation::ProcessControl,
             SandboxOperation::WaitExit,
         ] {
             let err =
@@ -3376,6 +3621,178 @@ mod tests {
 
             assert_operation_reason(err, SandboxOperationReason::BackendCrashed);
         }
+    }
+
+    #[tokio::test]
+    async fn process_control_rejects_closed_operation_gate_without_dirtying() {
+        let ProcessControlFixture {
+            host,
+            handle,
+            mut guest,
+            spawn_seq,
+            pid,
+        } = setup_process_control_fixture().await;
+        let control = handle.control_handle();
+        let (gate, coordinator) = process_control_gate(Arc::clone(&host));
+        let attempt = coordinator
+            .begin_prepare_park()
+            .expect("begin prepare park");
+        let (state, state_tx) = running_process_state();
+
+        let error = FirecrackerSandbox::process_control(
+            gate,
+            state,
+            state_tx,
+            control,
+            "gate-closed".to_owned(),
+            b"payload".to_vec(),
+            Duration::from_secs(5),
+        )
+        .await
+        .unwrap_err();
+
+        assert!(
+            error.to_string().contains("sandbox operation gate closed"),
+            "unexpected error: {error}",
+        );
+        assert_eq!(coordinator.active_operation_count(), 0);
+        coordinator.abort_prepare_park(&attempt).unwrap();
+        assert_eq!(coordinator.state(), CoordinatorState::Open);
+
+        send_process_exit(&mut guest, spawn_seq, pid).await;
+        handle.wait().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn process_control_local_validation_failure_keeps_gate_clean() {
+        let ProcessControlFixture {
+            host,
+            handle,
+            mut guest,
+            spawn_seq,
+            pid,
+        } = setup_process_control_fixture().await;
+        let control = handle.control_handle();
+        let (gate, coordinator) = process_control_gate(Arc::clone(&host));
+        let (state, state_tx) = running_process_state();
+        let too_large = vec![0; vsock_proto::PROCESS_CONTROL_MAX_PAYLOAD_BYTES + 1];
+
+        let error = FirecrackerSandbox::process_control(
+            gate.clone(),
+            Arc::clone(&state),
+            state_tx.clone(),
+            control.clone(),
+            "too-large".to_owned(),
+            too_large,
+            Duration::from_secs(5),
+        )
+        .await
+        .unwrap_err();
+
+        assert_eq!(error.kind(), io::ErrorKind::InvalidInput);
+        assert_eq!(coordinator.state(), CoordinatorState::Open);
+        assert_eq!(coordinator.active_operation_count(), 0);
+
+        let control_task = tokio::spawn(FirecrackerSandbox::process_control(
+            gate,
+            state,
+            state_tx,
+            control,
+            "valid-after-local-failure".to_owned(),
+            b"payload".to_vec(),
+            Duration::from_secs(5),
+        ));
+        let request = read_vsock_message(&mut guest).await;
+        send_process_control_result(&mut guest, request, ProcessControlStatus::Delivered, "").await;
+
+        let ack = control_task.await.unwrap().unwrap();
+        assert_eq!(ack.message_id, "valid-after-local-failure");
+        assert_eq!(coordinator.state(), CoordinatorState::Open);
+
+        send_process_exit(&mut guest, spawn_seq, pid).await;
+        handle.wait().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn process_control_guest_status_completes_gate() {
+        let ProcessControlFixture {
+            host,
+            handle,
+            mut guest,
+            spawn_seq,
+            pid,
+        } = setup_process_control_fixture().await;
+        let control = handle.control_handle();
+        let (gate, coordinator) = process_control_gate(Arc::clone(&host));
+        let (state, state_tx) = running_process_state();
+
+        let control_task = tokio::spawn(FirecrackerSandbox::process_control(
+            gate,
+            state,
+            state_tx,
+            control,
+            "sink-timeout".to_owned(),
+            b"payload".to_vec(),
+            Duration::from_secs(5),
+        ));
+        let request = read_vsock_message(&mut guest).await;
+        send_process_control_result(
+            &mut guest,
+            request,
+            ProcessControlStatus::SinkTimeout,
+            "guest sink timed out",
+        )
+        .await;
+
+        let error = control_task.await.unwrap().unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::TimedOut);
+        assert_eq!(error.to_string(), "guest sink timed out");
+        assert_eq!(coordinator.state(), CoordinatorState::Open);
+        assert_eq!(coordinator.active_operation_count(), 0);
+
+        send_process_exit(&mut guest, spawn_seq, pid).await;
+        handle.wait().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn process_control_timeout_after_guest_write_marks_gate_dirty() {
+        let ProcessControlFixture {
+            host,
+            handle,
+            mut guest,
+            spawn_seq,
+            pid,
+        } = setup_process_control_fixture().await;
+        let control = handle.control_handle();
+        let (gate, coordinator) = process_control_gate(Arc::clone(&host));
+        let (state, state_tx) = running_process_state();
+
+        let control_task = tokio::spawn(FirecrackerSandbox::process_control(
+            gate,
+            state,
+            state_tx,
+            control,
+            "timeout-after-write".to_owned(),
+            b"payload".to_vec(),
+            Duration::from_millis(10),
+        ));
+        let request = read_vsock_message(&mut guest).await;
+        assert_eq!(request.msg_type, MSG_PROCESS_CONTROL);
+
+        let error = tokio::time::timeout(Duration::from_secs(1), control_task)
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::TimedOut);
+        assert!(matches!(
+            coordinator.state(),
+            CoordinatorState::Dirty { .. }
+        ));
+        assert_eq!(coordinator.active_operation_count(), 0);
+
+        send_process_exit(&mut guest, spawn_seq, pid).await;
+        handle.wait().await.unwrap();
     }
 
     #[tokio::test]
@@ -4045,7 +4462,6 @@ mod tests {
 
     use std::path::PathBuf;
     use std::sync::atomic::AtomicU32;
-    use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::UnixListener;
     use tokio::sync::Mutex as TokioMutex;
 

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -3831,7 +3831,7 @@ mod tests {
             control,
             "timeout-after-write".to_owned(),
             b"payload".to_vec(),
-            Duration::from_millis(10),
+            Duration::ZERO,
         ));
         let request = read_vsock_message(&mut guest).await;
         assert_eq!(request.msg_type, MSG_PROCESS_CONTROL);

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -2754,6 +2754,22 @@ mod tests {
         stream.write_all(&response).await.unwrap();
     }
 
+    async fn send_mismatched_process_control_result(stream: &mut UnixStream, request: RawMessage) {
+        assert_eq!(request.msg_type, MSG_PROCESS_CONTROL);
+        let decoded = vsock_proto::decode_process_control(&request.payload).unwrap();
+        let payload = vsock_proto::encode_process_control_result(
+            decoded.target_seq + 1,
+            decoded.control_nonce,
+            decoded.message_id,
+            ProcessControlStatus::Delivered,
+            "",
+        )
+        .unwrap();
+        let response =
+            vsock_proto::encode(MSG_PROCESS_CONTROL_RESULT, request.seq, &payload).unwrap();
+        stream.write_all(&response).await.unwrap();
+    }
+
     async fn send_process_exit(stream: &mut UnixStream, spawn_seq: u32, pid: u32) {
         let payload = vsock_proto::encode_process_exit(pid, 0, b"", b"");
         let response = vsock_proto::encode(MSG_PROCESS_EXIT, spawn_seq, &payload).unwrap();
@@ -3901,6 +3917,93 @@ mod tests {
         assert_eq!(error.kind(), io::ErrorKind::Other);
         assert_eq!(error.to_string(), "guest rejected control");
         assert_eq!(coordinator.state(), CoordinatorState::Open);
+        assert_eq!(coordinator.active_operation_count(), 0);
+
+        send_process_exit(&mut guest, spawn_seq, pid).await;
+        handle.wait().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn process_control_protocol_error_after_guest_write_marks_gate_dirty() {
+        let ProcessControlFixture {
+            host: _host,
+            handle,
+            mut guest,
+            spawn_seq: _,
+            pid: _,
+        } = setup_process_control_fixture().await;
+        let control = handle.control_handle();
+        let coordinator = ParkCoordinator::new();
+        let (state, state_tx) = running_process_state();
+
+        let control_task = tokio::spawn(FirecrackerSandbox::process_control(
+            coordinator.clone(),
+            state,
+            state_tx.subscribe(),
+            control,
+            "malformed-result".to_owned(),
+            b"payload".to_vec(),
+            Duration::from_secs(5),
+        ));
+        let request = read_vsock_message(&mut guest).await;
+        send_mismatched_process_control_result(&mut guest, request).await;
+
+        let error = control_task.await.unwrap().unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+        assert!(
+            error
+                .to_string()
+                .contains("process_control_result target seq mismatch"),
+            "unexpected error: {error}",
+        );
+        assert!(matches!(
+            coordinator.state(),
+            CoordinatorState::Dirty { .. }
+        ));
+        assert_eq!(coordinator.active_operation_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn process_control_backend_crash_after_guest_write_marks_gate_dirty() {
+        let ProcessControlFixture {
+            host: _host,
+            handle,
+            mut guest,
+            spawn_seq,
+            pid,
+        } = setup_process_control_fixture().await;
+        let control = handle.control_handle();
+        let coordinator = ParkCoordinator::new();
+        let (state, state_tx) = running_process_state();
+
+        let control_task = tokio::spawn(FirecrackerSandbox::process_control(
+            coordinator.clone(),
+            Arc::clone(&state),
+            state_tx.subscribe(),
+            control,
+            "backend-crash".to_owned(),
+            b"payload".to_vec(),
+            Duration::from_secs(5),
+        ));
+        let request = read_vsock_message(&mut guest).await;
+        assert_eq!(request.msg_type, MSG_PROCESS_CONTROL);
+
+        state.store(SandboxState::Crashed as u8, Ordering::Release);
+        state_tx.send(SandboxState::Crashed).unwrap();
+
+        let error = tokio::time::timeout(Duration::from_secs(1), control_task)
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap_err();
+        assert!(
+            error.to_string().contains("firecracker process crashed"),
+            "unexpected error: {error}",
+        );
+        assert!(matches!(
+            coordinator.state(),
+            CoordinatorState::Dirty { .. }
+        ));
         assert_eq!(coordinator.active_operation_count(), 0);
 
         send_process_exit(&mut guest, spawn_seq, pid).await;

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -2743,6 +2743,17 @@ mod tests {
         stream.write_all(&response).await.unwrap();
     }
 
+    async fn send_process_control_error(
+        stream: &mut UnixStream,
+        request: RawMessage,
+        message: &str,
+    ) {
+        assert_eq!(request.msg_type, MSG_PROCESS_CONTROL);
+        let payload = vsock_proto::encode_error(message);
+        let response = vsock_proto::encode(vsock_proto::MSG_ERROR, request.seq, &payload).unwrap();
+        stream.write_all(&response).await.unwrap();
+    }
+
     async fn send_process_exit(stream: &mut UnixStream, spawn_seq: u32, pid: u32) {
         let payload = vsock_proto::encode_process_exit(pid, 0, b"", b"");
         let response = vsock_proto::encode(MSG_PROCESS_EXIT, spawn_seq, &payload).unwrap();
@@ -3854,6 +3865,41 @@ mod tests {
         let error = control_task.await.unwrap().unwrap_err();
         assert_eq!(error.kind(), io::ErrorKind::TimedOut);
         assert_eq!(error.to_string(), "guest sink timed out");
+        assert_eq!(coordinator.state(), CoordinatorState::Open);
+        assert_eq!(coordinator.active_operation_count(), 0);
+
+        send_process_exit(&mut guest, spawn_seq, pid).await;
+        handle.wait().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn process_control_guest_error_completes_gate() {
+        let ProcessControlFixture {
+            host: _host,
+            handle,
+            mut guest,
+            spawn_seq,
+            pid,
+        } = setup_process_control_fixture().await;
+        let control = handle.control_handle();
+        let coordinator = ParkCoordinator::new();
+        let (state, state_tx) = running_process_state();
+
+        let control_task = tokio::spawn(FirecrackerSandbox::process_control(
+            coordinator.clone(),
+            state,
+            state_tx,
+            control,
+            "guest-error".to_owned(),
+            b"payload".to_vec(),
+            Duration::from_secs(5),
+        ));
+        let request = read_vsock_message(&mut guest).await;
+        send_process_control_error(&mut guest, request, "guest rejected control").await;
+
+        let error = control_task.await.unwrap().unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::Other);
+        assert_eq!(error.to_string(), "guest rejected control");
         assert_eq!(coordinator.state(), CoordinatorState::Open);
         assert_eq!(coordinator.active_operation_count(), 0);
 

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -2672,6 +2672,56 @@ mod tests {
         (state, state_tx)
     }
 
+    fn state_after_first_read(next_state: SandboxState) -> impl Fn() -> SandboxState {
+        let reads = std::sync::atomic::AtomicUsize::new(0);
+        move || {
+            if reads.fetch_add(1, Ordering::SeqCst) == 0 {
+                SandboxState::Running
+            } else {
+                next_state
+            }
+        }
+    }
+
+    #[test]
+    fn process_control_boundary_stop_after_reserve_releases_lease() {
+        let coordinator = ParkCoordinator::new();
+
+        let error = match FirecrackerSandbox::begin_process_control_boundary(
+            &coordinator,
+            state_after_first_read(SandboxState::Stopped),
+        ) {
+            Ok(_) => panic!("expected process control boundary to reject stopped state"),
+            Err(error) => error,
+        };
+
+        assert_eq!(
+            error,
+            GuestOperationStartError::NotRunning {
+                state: SandboxState::Stopped
+            }
+        );
+        assert_eq!(coordinator.state(), CoordinatorState::Open);
+        assert_eq!(coordinator.active_operation_count(), 0);
+    }
+
+    #[test]
+    fn process_control_boundary_crash_after_reserve_releases_lease() {
+        let coordinator = ParkCoordinator::new();
+
+        let error = match FirecrackerSandbox::begin_process_control_boundary(
+            &coordinator,
+            state_after_first_read(SandboxState::Crashed),
+        ) {
+            Ok(_) => panic!("expected process control boundary to reject crashed state"),
+            Err(error) => error,
+        };
+
+        assert_eq!(error, GuestOperationStartError::BackendCrashed);
+        assert_eq!(coordinator.state(), CoordinatorState::Open);
+        assert_eq!(coordinator.active_operation_count(), 0);
+    }
+
     async fn send_process_control_result(
         stream: &mut UnixStream,
         request: RawMessage,

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -3842,6 +3842,7 @@ mod tests {
         let ack = control_task.await.unwrap().unwrap();
         assert_eq!(ack.message_id, "valid-after-local-failure");
         assert_eq!(coordinator.state(), CoordinatorState::Open);
+        assert_eq!(coordinator.active_operation_count(), 0);
 
         send_process_exit(&mut guest, spawn_seq, pid).await;
         handle.wait().await.unwrap();

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -3925,6 +3925,80 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn process_control_concurrent_requests_release_gate_leases() {
+        let ProcessControlFixture {
+            host: _host,
+            handle,
+            mut guest,
+            spawn_seq,
+            pid,
+        } = setup_process_control_fixture().await;
+        let control = handle.control_handle();
+        let coordinator = ParkCoordinator::new();
+        let (state, state_tx) = running_process_state();
+
+        let first_task = tokio::spawn(FirecrackerSandbox::process_control(
+            coordinator.clone(),
+            Arc::clone(&state),
+            state_tx.subscribe(),
+            control.clone(),
+            "concurrent-a".to_owned(),
+            b"payload-a".to_vec(),
+            Duration::from_secs(5),
+        ));
+        let second_task = tokio::spawn(FirecrackerSandbox::process_control(
+            coordinator.clone(),
+            state,
+            state_tx.subscribe(),
+            control,
+            "concurrent-b".to_owned(),
+            b"payload-b".to_vec(),
+            Duration::from_secs(5),
+        ));
+
+        let first_request = read_vsock_message(&mut guest).await;
+        let second_request = read_vsock_message(&mut guest).await;
+        let mut message_ids = [
+            vsock_proto::decode_process_control(&first_request.payload)
+                .unwrap()
+                .message_id
+                .to_owned(),
+            vsock_proto::decode_process_control(&second_request.payload)
+                .unwrap()
+                .message_id
+                .to_owned(),
+        ];
+        message_ids.sort();
+        assert_eq!(message_ids, ["concurrent-a", "concurrent-b"]);
+        assert_eq!(coordinator.active_operation_count(), 2);
+
+        send_process_control_result(
+            &mut guest,
+            second_request,
+            ProcessControlStatus::Delivered,
+            "",
+        )
+        .await;
+        send_process_control_result(
+            &mut guest,
+            first_request,
+            ProcessControlStatus::Delivered,
+            "",
+        )
+        .await;
+
+        let first_ack = first_task.await.unwrap().unwrap();
+        let second_ack = second_task.await.unwrap().unwrap();
+        assert_eq!(first_ack.message_id, "concurrent-a");
+        assert_eq!(second_ack.message_id, "concurrent-b");
+        assert_eq!(coordinator.state(), CoordinatorState::Open);
+        assert_eq!(coordinator.active_operation_count(), 0);
+
+        send_process_exit(&mut guest, spawn_seq, pid).await;
+        handle.wait().await.unwrap();
+    }
+
+    #[tokio::test]
     async fn process_control_protocol_error_after_guest_write_marks_gate_dirty() {
         let ProcessControlFixture {
             host: _host,

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -30,13 +30,14 @@ use crate::config::FirecrackerConfig;
 use crate::control;
 use crate::factory::InvariantConfig;
 use crate::guest_operations::{
-    GuestOperation, GuestOperationGate, GuestOperationStartError, guest_error_is_terminal,
+    GuestOperation, GuestOperationGate, GuestOperationStartError, GuestOperationWriteBoundary,
+    guest_error_is_terminal,
 };
 use crate::leaked_resources::LeakedResources;
 use crate::network::{NetnsInfo, NetnsLease};
 use crate::park_coordinator::{
-    CoordinatorState, DirtyReason, OperationLease, OperationTransitionError, ParkAttempt,
-    ParkCoordinator, PrepareParkError, PrepareParkEvidence,
+    CoordinatorState, DirtyReason, LeaseRejection, OperationLease, OperationTransitionError,
+    ParkAttempt, ParkCoordinator, PrepareParkError, PrepareParkEvidence,
 };
 use crate::paths::{SandboxPaths, SockPaths};
 use crate::process::{kill_process_group, kill_process_group_by_pid};
@@ -709,11 +710,9 @@ impl FirecrackerSandbox {
             BackendCrashed,
         }
 
-        let guest = self
-            .begin_guest_operation(operation)
-            .await?
-            .into_write_boundary();
-        let vsock = guest.guest();
+        let guest_operation = self.begin_guest_operation(operation).await?;
+        let vsock = guest_operation.guest();
+        let guest = guest_operation.into_write_boundary();
         let write_observer = guest.write_observer();
 
         let outcome = tokio::select! {
@@ -751,6 +750,33 @@ impl FirecrackerSandbox {
         SandboxState::from_u8(state.load(Ordering::Acquire))
     }
 
+    fn begin_process_control_boundary(
+        coordinator: &ParkCoordinator,
+        current_state: impl Fn() -> SandboxState,
+    ) -> Result<GuestOperationWriteBoundary, GuestOperationStartError> {
+        match current_state() {
+            SandboxState::Running => {}
+            SandboxState::Crashed => return Err(GuestOperationStartError::BackendCrashed),
+            state => return Err(GuestOperationStartError::NotRunning { state }),
+        }
+
+        let lease = coordinator
+            .reserve_operation()
+            .map_err(|error| match error {
+                LeaseRejection::GateClosed { state } => {
+                    GuestOperationStartError::GateClosed { state }
+                }
+            })?;
+
+        match current_state() {
+            SandboxState::Running => {}
+            SandboxState::Crashed => return Err(GuestOperationStartError::BackendCrashed),
+            state => return Err(GuestOperationStartError::NotRunning { state }),
+        }
+
+        Ok(GuestOperationWriteBoundary::new(lease))
+    }
+
     fn operation_start_io_error(
         operation: SandboxOperation,
         error: GuestOperationStartError,
@@ -779,7 +805,7 @@ impl FirecrackerSandbox {
     }
 
     async fn process_control(
-        gate: GuestOperationGate,
+        coordinator: ParkCoordinator,
         state: Arc<AtomicU8>,
         state_tx: watch::Sender<SandboxState>,
         control: vsock_host::GuestProcessControlHandle,
@@ -793,13 +819,15 @@ impl FirecrackerSandbox {
         }
 
         let operation = SandboxOperation::ProcessControl;
-        let guest = gate
-            .begin_sandbox_operation(|| Self::current_state_from(&state))
-            .await
-            .map_err(|error| {
-                Self::operation_start_io_error(operation, error, Self::current_state_from(&state))
-            })?
-            .into_write_boundary();
+        let guest =
+            Self::begin_process_control_boundary(&coordinator, || Self::current_state_from(&state))
+                .map_err(|error| {
+                    Self::operation_start_io_error(
+                        operation,
+                        error,
+                        Self::current_state_from(&state),
+                    )
+                })?;
         let write_observer = guest.write_observer();
 
         let outcome = tokio::select! {
@@ -1681,11 +1709,9 @@ impl Sandbox for FirecrackerSandbox {
         request: &SpawnProcessRequest<'_>,
     ) -> sandbox::Result<GuestProcessHandle> {
         let operation = SandboxOperation::SpawnProcess;
-        let guest = self
-            .begin_guest_operation(operation)
-            .await?
-            .into_write_boundary();
-        let vsock = guest.guest();
+        let guest_operation = self.begin_guest_operation(operation).await?;
+        let vsock = guest_operation.guest();
+        let guest = guest_operation.into_write_boundary();
         let write_observer = guest.write_observer();
 
         let spawn_future: Pin<
@@ -1738,17 +1764,17 @@ impl Sandbox for FirecrackerSandbox {
                 let pid = handle.pid();
                 let process_control = (request.control == SpawnProcessControl::Enabled).then(|| {
                     let control = handle.control_handle();
-                    let gate = self.guest_operations();
+                    let coordinator = self.park_coordinator.clone();
                     let state = Arc::clone(&self.state);
                     let state_tx = self.state_tx.clone();
                     GuestProcessControlHandle::new(move |message_id, payload, timeout| {
                         let control = control.clone();
-                        let gate = gate.clone();
+                        let coordinator = coordinator.clone();
                         let state = Arc::clone(&state);
                         let state_tx = state_tx.clone();
                         Box::pin(async move {
                             Self::process_control(
-                                gate, state, state_tx, control, message_id, payload, timeout,
+                                coordinator, state, state_tx, control, message_id, payload, timeout,
                             )
                             .await
                         })
@@ -2636,18 +2662,13 @@ mod tests {
         }
     }
 
-    fn process_control_gate(host: Arc<VsockHost>) -> (GuestOperationGate, ParkCoordinator) {
-        let coordinator = ParkCoordinator::new();
-        let guest = Arc::new(tokio::sync::Mutex::new(Some(host)));
-        (
-            GuestOperationGate::new(guest, coordinator.clone()),
-            coordinator,
-        )
+    fn running_process_state() -> (Arc<AtomicU8>, watch::Sender<SandboxState>) {
+        process_state(SandboxState::Running)
     }
 
-    fn running_process_state() -> (Arc<AtomicU8>, watch::Sender<SandboxState>) {
-        let state = Arc::new(AtomicU8::new(SandboxState::Running as u8));
-        let (state_tx, _state_rx) = watch::channel(SandboxState::Running);
+    fn process_state(sandbox_state: SandboxState) -> (Arc<AtomicU8>, watch::Sender<SandboxState>) {
+        let state = Arc::new(AtomicU8::new(sandbox_state as u8));
+        let (state_tx, _state_rx) = watch::channel(sandbox_state);
         (state, state_tx)
     }
 
@@ -3626,21 +3647,21 @@ mod tests {
     #[tokio::test]
     async fn process_control_rejects_closed_operation_gate_without_dirtying() {
         let ProcessControlFixture {
-            host,
+            host: _host,
             handle,
             mut guest,
             spawn_seq,
             pid,
         } = setup_process_control_fixture().await;
         let control = handle.control_handle();
-        let (gate, coordinator) = process_control_gate(Arc::clone(&host));
+        let coordinator = ParkCoordinator::new();
         let attempt = coordinator
             .begin_prepare_park()
             .expect("begin prepare park");
         let (state, state_tx) = running_process_state();
 
         let error = FirecrackerSandbox::process_control(
-            gate,
+            coordinator.clone(),
             state,
             state_tx,
             control,
@@ -3664,21 +3685,57 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn process_control_local_validation_failure_keeps_gate_clean() {
+    async fn process_control_rejects_stopped_state_without_dirtying() {
         let ProcessControlFixture {
-            host,
+            host: _host,
             handle,
             mut guest,
             spawn_seq,
             pid,
         } = setup_process_control_fixture().await;
         let control = handle.control_handle();
-        let (gate, coordinator) = process_control_gate(Arc::clone(&host));
+        let coordinator = ParkCoordinator::new();
+        let (state, state_tx) = process_state(SandboxState::Stopped);
+
+        let error = FirecrackerSandbox::process_control(
+            coordinator.clone(),
+            state,
+            state_tx,
+            control,
+            "stopped".to_owned(),
+            b"payload".to_vec(),
+            Duration::from_secs(5),
+        )
+        .await
+        .unwrap_err();
+
+        assert!(
+            error.to_string().contains("sandbox not running"),
+            "unexpected error: {error}",
+        );
+        assert_eq!(coordinator.state(), CoordinatorState::Open);
+        assert_eq!(coordinator.active_operation_count(), 0);
+
+        send_process_exit(&mut guest, spawn_seq, pid).await;
+        handle.wait().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn process_control_local_validation_failure_keeps_gate_clean() {
+        let ProcessControlFixture {
+            host: _host,
+            handle,
+            mut guest,
+            spawn_seq,
+            pid,
+        } = setup_process_control_fixture().await;
+        let control = handle.control_handle();
+        let coordinator = ParkCoordinator::new();
         let (state, state_tx) = running_process_state();
         let too_large = vec![0; vsock_proto::PROCESS_CONTROL_MAX_PAYLOAD_BYTES + 1];
 
         let error = FirecrackerSandbox::process_control(
-            gate.clone(),
+            coordinator.clone(),
             Arc::clone(&state),
             state_tx.clone(),
             control.clone(),
@@ -3694,7 +3751,7 @@ mod tests {
         assert_eq!(coordinator.active_operation_count(), 0);
 
         let control_task = tokio::spawn(FirecrackerSandbox::process_control(
-            gate,
+            coordinator.clone(),
             state,
             state_tx,
             control,
@@ -3716,18 +3773,18 @@ mod tests {
     #[tokio::test]
     async fn process_control_guest_status_completes_gate() {
         let ProcessControlFixture {
-            host,
+            host: _host,
             handle,
             mut guest,
             spawn_seq,
             pid,
         } = setup_process_control_fixture().await;
         let control = handle.control_handle();
-        let (gate, coordinator) = process_control_gate(Arc::clone(&host));
+        let coordinator = ParkCoordinator::new();
         let (state, state_tx) = running_process_state();
 
         let control_task = tokio::spawn(FirecrackerSandbox::process_control(
-            gate,
+            coordinator.clone(),
             state,
             state_tx,
             control,
@@ -3757,18 +3814,18 @@ mod tests {
     #[tokio::test]
     async fn process_control_timeout_after_guest_write_marks_gate_dirty() {
         let ProcessControlFixture {
-            host,
+            host: _host,
             handle,
             mut guest,
             spawn_seq,
             pid,
         } = setup_process_control_fixture().await;
         let control = handle.control_handle();
-        let (gate, coordinator) = process_control_gate(Arc::clone(&host));
+        let coordinator = ParkCoordinator::new();
         let (state, state_tx) = running_process_state();
 
         let control_task = tokio::spawn(FirecrackerSandbox::process_control(
-            gate,
+            coordinator.clone(),
             state,
             state_tx,
             control,

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -807,7 +807,7 @@ impl FirecrackerSandbox {
     async fn process_control(
         coordinator: ParkCoordinator,
         state: Arc<AtomicU8>,
-        state_tx: watch::Sender<SandboxState>,
+        state_rx: watch::Receiver<SandboxState>,
         control: vsock_host::GuestProcessControlHandle,
         message_id: String,
         payload: Vec<u8>,
@@ -837,7 +837,7 @@ impl FirecrackerSandbox {
                 timeout,
                 write_observer,
             ) => ControlOutcome::Returned(result),
-            () = wait_for_backend_crash(state_tx.subscribe()) => ControlOutcome::BackendCrashed,
+            () = wait_for_backend_crash(state_rx) => ControlOutcome::BackendCrashed,
         };
 
         match outcome {
@@ -1766,15 +1766,15 @@ impl Sandbox for FirecrackerSandbox {
                     let control = handle.control_handle();
                     let coordinator = self.park_coordinator.clone();
                     let state = Arc::clone(&self.state);
-                    let state_tx = self.state_tx.clone();
+                    let state_rx = self.state_tx.subscribe();
                     GuestProcessControlHandle::new(move |message_id, payload, timeout| {
                         let control = control.clone();
                         let coordinator = coordinator.clone();
                         let state = Arc::clone(&state);
-                        let state_tx = state_tx.clone();
+                        let state_rx = state_rx.clone();
                         Box::pin(async move {
                             Self::process_control(
-                                coordinator, state, state_tx, control, message_id, payload, timeout,
+                                coordinator, state, state_rx, control, message_id, payload, timeout,
                             )
                             .await
                         })
@@ -3724,7 +3724,7 @@ mod tests {
         let error = FirecrackerSandbox::process_control(
             coordinator.clone(),
             state,
-            state_tx,
+            state_tx.subscribe(),
             control,
             "gate-closed".to_owned(),
             b"payload".to_vec(),
@@ -3761,7 +3761,7 @@ mod tests {
         let error = FirecrackerSandbox::process_control(
             coordinator.clone(),
             state,
-            state_tx,
+            state_tx.subscribe(),
             control,
             "stopped".to_owned(),
             b"payload".to_vec(),
@@ -3798,7 +3798,7 @@ mod tests {
         let error = FirecrackerSandbox::process_control(
             coordinator.clone(),
             Arc::clone(&state),
-            state_tx.clone(),
+            state_tx.subscribe(),
             control.clone(),
             "too-large".to_owned(),
             too_large,
@@ -3814,7 +3814,7 @@ mod tests {
         let control_task = tokio::spawn(FirecrackerSandbox::process_control(
             coordinator.clone(),
             state,
-            state_tx,
+            state_tx.subscribe(),
             control,
             "valid-after-local-failure".to_owned(),
             b"payload".to_vec(),
@@ -3847,7 +3847,7 @@ mod tests {
         let control_task = tokio::spawn(FirecrackerSandbox::process_control(
             coordinator.clone(),
             state,
-            state_tx,
+            state_tx.subscribe(),
             control,
             "sink-timeout".to_owned(),
             b"payload".to_vec(),
@@ -3888,7 +3888,7 @@ mod tests {
         let control_task = tokio::spawn(FirecrackerSandbox::process_control(
             coordinator.clone(),
             state,
-            state_tx,
+            state_tx.subscribe(),
             control,
             "guest-error".to_owned(),
             b"payload".to_vec(),
@@ -3923,7 +3923,7 @@ mod tests {
         let control_task = tokio::spawn(FirecrackerSandbox::process_control(
             coordinator.clone(),
             state,
-            state_tx,
+            state_tx.subscribe(),
             control,
             "timeout-after-write".to_owned(),
             b"payload".to_vec(),

--- a/crates/sandbox/src/error.rs
+++ b/crates/sandbox/src/error.rs
@@ -88,6 +88,8 @@ pub enum SandboxOperation {
     WriteFile,
     /// [`Sandbox::spawn_process`](crate::Sandbox::spawn_process).
     SpawnProcess,
+    /// [`GuestProcessControlHandle::control`](crate::GuestProcessControlHandle::control).
+    ProcessControl,
     /// [`Sandbox::wait_exit`](crate::Sandbox::wait_exit).
     WaitExit,
 }
@@ -98,6 +100,7 @@ impl fmt::Display for SandboxOperation {
             Self::Exec => f.write_str("exec"),
             Self::WriteFile => f.write_str("write file"),
             Self::SpawnProcess => f.write_str("spawn process"),
+            Self::ProcessControl => f.write_str("process control"),
             Self::WaitExit => f.write_str("wait exit"),
         }
     }

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -55,7 +55,8 @@ pub use exec_operation::{
 };
 pub use file::{CopyFileOptions, CopyFileResult};
 pub use process::{
-    GuestProcessControlHandle, GuestProcessHandle, ProcessControlAck, ProcessExitEvent,
+    GuestProcessControlHandle, GuestProcessHandle, ProcessControlAck, ProcessControlGuestStatus,
+    ProcessControlOutcome, ProcessExitEvent,
 };
 
 const READ_BUF_SIZE: usize = 64 * 1024;

--- a/crates/vsock-host/src/operation_tracker.rs
+++ b/crates/vsock-host/src/operation_tracker.rs
@@ -202,6 +202,14 @@ impl NormalOperationToken {
     pub(crate) fn complete(mut self) -> Result<(), NormalOperationTransitionError> {
         let mut inner = lock_inner(&self.inner);
         let Some(_phase) = inner.operations.remove(&self.id) else {
+            if matches!(inner.state, TrackerState::NotParkable) {
+                // A possible guest write can fail closed and clear all tracked
+                // operations before an independent terminal event completes an
+                // older token. The connection is already not parkable, so late
+                // completion only needs to release this token.
+                self.released = true;
+                return Ok(());
+            }
             return Err(NormalOperationTransitionError::UnknownOperation {
                 operation_id: self.id,
             });
@@ -622,7 +630,7 @@ mod tests {
     }
 
     #[test]
-    fn complete_after_not_parkable_returns_unknown_and_preserves_state() {
+    fn complete_after_not_parkable_is_idempotent_and_preserves_state() {
         let tracker = NormalOperationTracker::new();
         let mut token = reserve(&tracker);
         token
@@ -631,11 +639,9 @@ mod tests {
 
         tracker.mark_not_parkable();
 
-        let err = token.complete().unwrap_err();
-        assert!(matches!(
-            err,
-            NormalOperationTransitionError::UnknownOperation { .. }
-        ));
+        token
+            .complete()
+            .expect("operation completion should release token");
         assert_eq!(tracker.readiness(), NormalOperationReadiness::NotParkable);
     }
 

--- a/crates/vsock-host/src/process.rs
+++ b/crates/vsock-host/src/process.rs
@@ -38,19 +38,29 @@ pub struct ProcessControlAck {
 /// Guest-side terminal status for a process-control request.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ProcessControlGuestStatus {
+    /// Status returned by the guest process-control sink.
     pub status: ProcessControlStatus,
+    /// Optional diagnostic supplied by the guest.
     pub diagnostic: String,
 }
 
-/// Typed process-control outcome.
+/// Terminal guest response for a process-control request.
+///
+/// Transport errors and host-side timeouts are still returned as
+/// [`io::Error`]. This type only represents responses that came back from the
+/// guest and therefore prove the request reached a terminal guest-side state.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ProcessControlOutcome {
+    /// The control payload was delivered to the guest process sink.
     Delivered(ProcessControlAck),
+    /// The guest returned a non-delivered process-control status.
     GuestStatus(ProcessControlGuestStatus),
+    /// The guest returned a protocol-level error frame for this request.
     GuestError(String),
 }
 
 impl ProcessControlOutcome {
+    /// Convert the typed guest response into the legacy acknowledgement API.
     pub fn into_ack(self) -> io::Result<ProcessControlAck> {
         match self {
             Self::Delivered(ack) => Ok(ack),
@@ -381,6 +391,11 @@ impl GuestProcessControlHandle {
         .into_ack()
     }
 
+    /// Send a control payload and report the exact guest terminal outcome.
+    ///
+    /// The `write_observer` fires immediately before the request frame is
+    /// written. Callers that gate sandbox reuse use this boundary to distinguish
+    /// pre-write validation failures from post-write uncertainty.
     pub async fn control_with_write_observer(
         &self,
         message_id: &str,

--- a/crates/vsock-host/src/process.rs
+++ b/crates/vsock-host/src/process.rs
@@ -13,10 +13,11 @@ use vsock_proto::{
 
 use crate::{
     ConnectionState, FrameWriteObserver, PendingRequestGuard, PendingResponse, Shared,
-    operation_tracker::NormalOperationToken, request_on_shared,
+    normal_request_on_shared_with_write_observer, operation_tracker::NormalOperationToken,
 };
 
 const SPAWN_PROCESS_RESPONSE_TIMEOUT: Duration = Duration::from_secs(30);
+const PROCESS_CONTROL_TERMINAL_MSG_TYPES: &[u8] = &[MSG_PROCESS_CONTROL_RESULT, MSG_ERROR];
 
 /// Event emitted when a spawned process exits.
 #[derive(Debug, Clone)]
@@ -32,6 +33,34 @@ pub struct ProcessExitEvent {
 pub struct ProcessControlAck {
     pub target_seq: u32,
     pub message_id: String,
+}
+
+/// Guest-side terminal status for a process-control request.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProcessControlGuestStatus {
+    pub status: ProcessControlStatus,
+    pub diagnostic: String,
+}
+
+/// Typed process-control outcome.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ProcessControlOutcome {
+    Delivered(ProcessControlAck),
+    GuestStatus(ProcessControlGuestStatus),
+    GuestError(String),
+}
+
+impl ProcessControlOutcome {
+    pub fn into_ack(self) -> io::Result<ProcessControlAck> {
+        match self {
+            Self::Delivered(ack) => Ok(ack),
+            Self::GuestStatus(status) => Err(process_control_status_error(
+                status.status,
+                &status.diagnostic,
+            )),
+            Self::GuestError(message) => Err(io::Error::other(message)),
+        }
+    }
 }
 
 struct ProcessOperation {
@@ -342,6 +371,23 @@ impl GuestProcessControlHandle {
         payload: &[u8],
         timeout: Duration,
     ) -> io::Result<ProcessControlAck> {
+        self.control_with_write_observer(
+            message_id,
+            payload,
+            timeout,
+            FrameWriteObserver::default(),
+        )
+        .await?
+        .into_ack()
+    }
+
+    pub async fn control_with_write_observer(
+        &self,
+        message_id: &str,
+        payload: &[u8],
+        timeout: Duration,
+        write_observer: FrameWriteObserver,
+    ) -> io::Result<ProcessControlOutcome> {
         let request_timeout_ms = duration_to_request_timeout_ms(timeout);
         let request = vsock_proto::encode_process_control(
             self.target_seq,
@@ -351,20 +397,27 @@ impl GuestProcessControlHandle {
             request_timeout_ms,
         )
         .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e.to_string()))?;
-        let response =
-            request_on_shared(&self.shared, MSG_PROCESS_CONTROL, &request, timeout).await?;
-        self.decode_control_response(message_id, response)
+        let response = normal_request_on_shared_with_write_observer(
+            &self.shared,
+            MSG_PROCESS_CONTROL,
+            &request,
+            PROCESS_CONTROL_TERMINAL_MSG_TYPES,
+            timeout,
+            write_observer,
+        )
+        .await?;
+        self.decode_control_outcome(message_id, response)
     }
 
-    fn decode_control_response(
+    fn decode_control_outcome(
         &self,
         message_id: &str,
         response: RawMessage,
-    ) -> io::Result<ProcessControlAck> {
+    ) -> io::Result<ProcessControlOutcome> {
         if response.msg_type == MSG_ERROR {
             let msg =
                 vsock_proto::decode_error(&response.payload).map_err(|e| self.protocol_error(e))?;
-            return Err(io::Error::other(msg.to_owned()));
+            return Ok(ProcessControlOutcome::GuestError(msg.to_owned()));
         }
         if response.msg_type != MSG_PROCESS_CONTROL_RESULT {
             return Err(self.protocol_error(format!(
@@ -390,75 +443,56 @@ impl GuestProcessControlHandle {
             )));
         }
         match result.status {
-            ProcessControlStatus::Delivered => Ok(ProcessControlAck {
-                target_seq: result.target_seq,
-                message_id: result.message_id.to_owned(),
-            }),
-            ProcessControlStatus::Inactive => Err(io::Error::new(
-                io::ErrorKind::NotFound,
-                if result.diagnostic.is_empty() {
-                    "process operation is not active".to_owned()
-                } else {
-                    result.diagnostic.to_owned()
-                },
-            )),
-            ProcessControlStatus::NonceMismatch => Err(io::Error::new(
-                io::ErrorKind::PermissionDenied,
-                if result.diagnostic.is_empty() {
-                    "process operation nonce mismatch".to_owned()
-                } else {
-                    result.diagnostic.to_owned()
-                },
-            )),
-            ProcessControlStatus::Unsupported => Err(io::Error::new(
-                io::ErrorKind::Unsupported,
-                if result.diagnostic.is_empty() {
-                    "process control is not supported by this operation".to_owned()
-                } else {
-                    result.diagnostic.to_owned()
-                },
-            )),
-            ProcessControlStatus::Rejected => Err(io::Error::new(
-                io::ErrorKind::PermissionDenied,
-                if result.diagnostic.is_empty() {
-                    "process control request rejected".to_owned()
-                } else {
-                    result.diagnostic.to_owned()
-                },
-            )),
-            ProcessControlStatus::SinkUnavailable => Err(io::Error::new(
-                io::ErrorKind::NotConnected,
-                if result.diagnostic.is_empty() {
-                    "process control sink is not connected".to_owned()
-                } else {
-                    result.diagnostic.to_owned()
-                },
-            )),
-            ProcessControlStatus::SinkTimeout => Err(io::Error::new(
-                io::ErrorKind::TimedOut,
-                if result.diagnostic.is_empty() {
-                    "process control sink timed out".to_owned()
-                } else {
-                    result.diagnostic.to_owned()
-                },
-            )),
-            ProcessControlStatus::QueueFull => Err(io::Error::new(
-                io::ErrorKind::WouldBlock,
-                if result.diagnostic.is_empty() {
-                    "process control queue is full".to_owned()
-                } else {
-                    result.diagnostic.to_owned()
-                },
-            )),
-            ProcessControlStatus::SinkError => Err(io::Error::new(
-                io::ErrorKind::BrokenPipe,
-                if result.diagnostic.is_empty() {
-                    "process control sink error".to_owned()
-                } else {
-                    result.diagnostic.to_owned()
+            ProcessControlStatus::Delivered => {
+                Ok(ProcessControlOutcome::Delivered(ProcessControlAck {
+                    target_seq: result.target_seq,
+                    message_id: result.message_id.to_owned(),
+                }))
+            }
+            status => Ok(ProcessControlOutcome::GuestStatus(
+                ProcessControlGuestStatus {
+                    status,
+                    diagnostic: result.diagnostic.to_owned(),
                 },
             )),
         }
+    }
+}
+
+fn process_control_status_error(status: ProcessControlStatus, diagnostic: &str) -> io::Error {
+    let message = if diagnostic.is_empty() {
+        default_process_control_status_message(status).to_owned()
+    } else {
+        diagnostic.to_owned()
+    };
+    io::Error::new(process_control_status_error_kind(status), message)
+}
+
+fn process_control_status_error_kind(status: ProcessControlStatus) -> io::ErrorKind {
+    match status {
+        ProcessControlStatus::Delivered => io::ErrorKind::Other,
+        ProcessControlStatus::Inactive => io::ErrorKind::NotFound,
+        ProcessControlStatus::NonceMismatch => io::ErrorKind::PermissionDenied,
+        ProcessControlStatus::Unsupported => io::ErrorKind::Unsupported,
+        ProcessControlStatus::Rejected => io::ErrorKind::PermissionDenied,
+        ProcessControlStatus::SinkUnavailable => io::ErrorKind::NotConnected,
+        ProcessControlStatus::SinkTimeout => io::ErrorKind::TimedOut,
+        ProcessControlStatus::QueueFull => io::ErrorKind::WouldBlock,
+        ProcessControlStatus::SinkError => io::ErrorKind::BrokenPipe,
+    }
+}
+
+fn default_process_control_status_message(status: ProcessControlStatus) -> &'static str {
+    match status {
+        ProcessControlStatus::Delivered => "process control request delivered",
+        ProcessControlStatus::Inactive => "process operation is not active",
+        ProcessControlStatus::NonceMismatch => "process operation nonce mismatch",
+        ProcessControlStatus::Unsupported => "process control is not supported by this operation",
+        ProcessControlStatus::Rejected => "process control request rejected",
+        ProcessControlStatus::SinkUnavailable => "process control sink is not connected",
+        ProcessControlStatus::SinkTimeout => "process control sink timed out",
+        ProcessControlStatus::QueueFull => "process control queue is full",
+        ProcessControlStatus::SinkError => "process control sink error",
     }
 }
 

--- a/crates/vsock-host/src/tests/process.rs
+++ b/crates/vsock-host/src/tests/process.rs
@@ -787,6 +787,10 @@ async fn test_spawn_process_control_with_observer_returns_typed_guest_error() {
         outcome,
         ProcessControlOutcome::GuestError("guest rejected control".to_owned())
     );
+    let err = outcome.into_ack().unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::Other);
+    assert_eq!(err.to_string(), "guest rejected control");
+
     let event = wait_spawn(handle).await.unwrap();
     assert_eq!(event.exit_code, 0);
     assert_eq!(

--- a/crates/vsock-host/src/tests/process.rs
+++ b/crates/vsock-host/src/tests/process.rs
@@ -11,8 +11,9 @@ use super::support::{
     read_guest_messages, send_exec_result, setup_host_and_guest,
 };
 use crate::{
-    ConnectionState, FrameWriteObserver, GuestProcessHandle, VsockHost,
-    operation_tracker::NormalOperationReadiness, process as process_impl,
+    ConnectionState, FrameWriteObserver, GuestProcessHandle, ProcessControlGuestStatus,
+    ProcessControlOutcome, VsockHost, operation_tracker::NormalOperationReadiness,
+    process as process_impl,
 };
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::sync::{Notify, oneshot};
@@ -661,6 +662,140 @@ async fn test_spawn_process_control_sink_statuses_use_default_error_mapping() {
 }
 
 #[tokio::test]
+async fn test_spawn_process_control_with_observer_returns_typed_guest_status() {
+    let (host_stream, mut guest) = make_pair();
+
+    tokio::spawn(async move {
+        let mut decoder = Decoder::new();
+        mock_handshake(&mut guest, &mut decoder).await;
+
+        let spawn = read_guest_message(&mut guest).await;
+        assert_eq!(spawn.msg_type, MSG_SPAWN_PROCESS);
+        let decoded_spawn = vsock_proto::decode_spawn_process(&spawn.payload).unwrap();
+        let control_nonce = decoded_spawn.control_nonce.unwrap();
+
+        let payload = vsock_proto::encode_spawn_process_result(53);
+        let resp = vsock_proto::encode(MSG_SPAWN_PROCESS_RESULT, spawn.seq, &payload).unwrap();
+        guest.write_all(&resp).await.unwrap();
+
+        let control = read_guest_message(&mut guest).await;
+        let decoded_control = vsock_proto::decode_process_control(&control.payload).unwrap();
+        assert_eq!(decoded_control.control_nonce, control_nonce);
+        send_process_control_result(
+            &mut guest,
+            control.seq,
+            decoded_control.target_seq,
+            decoded_control.control_nonce,
+            decoded_control.message_id,
+            ProcessControlStatus::SinkTimeout,
+            "guest sink timed out",
+        )
+        .await;
+
+        let exit_payload = vsock_proto::encode_process_exit(53, 0, b"", b"");
+        let exit_msg = vsock_proto::encode(MSG_PROCESS_EXIT, spawn.seq, &exit_payload).unwrap();
+        guest.write_all(&exit_msg).await.unwrap();
+
+        let mut discard = [0u8; 1];
+        let _ = guest.read(&mut discard).await;
+    });
+
+    let host = host_from_stream(host_stream).await.unwrap();
+    let handle = host
+        .spawn_process("sleep 1", 0, &[], false, false, None)
+        .await
+        .unwrap();
+    let write_start_count = Arc::new(AtomicUsize::new(0));
+    let outcome = handle
+        .control_handle()
+        .control_with_write_observer(
+            "message-typed-sink-timeout",
+            b"payload",
+            Duration::from_secs(5),
+            FrameWriteObserver::new({
+                let write_start_count = Arc::clone(&write_start_count);
+                move || {
+                    write_start_count.fetch_add(1, Ordering::SeqCst);
+                    Ok(())
+                }
+            }),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(write_start_count.load(Ordering::SeqCst), 1);
+    assert_eq!(
+        outcome,
+        ProcessControlOutcome::GuestStatus(ProcessControlGuestStatus {
+            status: ProcessControlStatus::SinkTimeout,
+            diagnostic: "guest sink timed out".to_owned(),
+        })
+    );
+    let err = outcome.into_ack().unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::TimedOut);
+    assert_eq!(err.to_string(), "guest sink timed out");
+
+    let event = wait_spawn(handle).await.unwrap();
+    assert_eq!(event.exit_code, 0);
+}
+
+#[tokio::test]
+async fn test_spawn_process_control_with_observer_returns_typed_guest_error() {
+    let (host_stream, mut guest) = make_pair();
+
+    tokio::spawn(async move {
+        let mut decoder = Decoder::new();
+        mock_handshake(&mut guest, &mut decoder).await;
+
+        let spawn = read_guest_message(&mut guest).await;
+        assert_eq!(spawn.msg_type, MSG_SPAWN_PROCESS);
+
+        let payload = vsock_proto::encode_spawn_process_result(54);
+        let resp = vsock_proto::encode(MSG_SPAWN_PROCESS_RESULT, spawn.seq, &payload).unwrap();
+        guest.write_all(&resp).await.unwrap();
+
+        let control = read_guest_message(&mut guest).await;
+        let error_payload = vsock_proto::encode_error("guest rejected control");
+        let error = vsock_proto::encode(MSG_ERROR, control.seq, &error_payload).unwrap();
+        guest.write_all(&error).await.unwrap();
+
+        let exit_payload = vsock_proto::encode_process_exit(54, 0, b"", b"");
+        let exit_msg = vsock_proto::encode(MSG_PROCESS_EXIT, spawn.seq, &exit_payload).unwrap();
+        guest.write_all(&exit_msg).await.unwrap();
+
+        let mut discard = [0u8; 1];
+        let _ = guest.read(&mut discard).await;
+    });
+
+    let host = host_from_stream(host_stream).await.unwrap();
+    let handle = host
+        .spawn_process("sleep 1", 0, &[], false, false, None)
+        .await
+        .unwrap();
+    let outcome = handle
+        .control_handle()
+        .control_with_write_observer(
+            "message-guest-error",
+            b"payload",
+            Duration::from_secs(5),
+            FrameWriteObserver::default(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        outcome,
+        ProcessControlOutcome::GuestError("guest rejected control".to_owned())
+    );
+    let event = wait_spawn(handle).await.unwrap();
+    assert_eq!(event.exit_code, 0);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Idle
+    );
+}
+
+#[tokio::test]
 async fn test_spawn_process_control_malformed_result_poisons_connection() {
     let (host_stream, mut guest) = make_pair();
 
@@ -830,8 +965,9 @@ async fn test_spawn_process_control_result_message_id_mismatch_poisons_connectio
 }
 
 #[tokio::test]
-async fn test_spawn_process_control_timeout_cleans_pending_without_poisoning() {
+async fn test_spawn_process_control_timeout_after_write_marks_not_parkable() {
     let (host_stream, mut guest) = make_pair();
+    let (send_exit, exit_after_assert) = oneshot::channel();
 
     tokio::spawn(async move {
         let mut decoder = Decoder::new();
@@ -848,16 +984,7 @@ async fn test_spawn_process_control_timeout_cleans_pending_without_poisoning() {
         let decoded_control = vsock_proto::decode_process_control(&control.payload).unwrap();
         assert_eq!(decoded_control.request_timeout_ms, 0);
 
-        let exec = read_guest_message(&mut guest).await;
-        assert_eq!(exec.msg_type, MSG_EXEC_START);
-        send_exec_result(
-            &mut guest,
-            exec.seq,
-            ExecTermination::Exited { exit_code: 0 },
-            b"ok",
-            b"",
-        )
-        .await;
+        let _ = exit_after_assert.await;
         let exit_payload = vsock_proto::encode_process_exit(45, 0, b"", b"");
         let exit_msg = vsock_proto::encode(MSG_PROCESS_EXIT, spawn.seq, &exit_payload).unwrap();
         guest.write_all(&exit_msg).await.unwrap();
@@ -877,14 +1004,16 @@ async fn test_spawn_process_control_timeout_cleans_pending_without_poisoning() {
         .unwrap_err();
     assert_eq!(err.kind(), io::ErrorKind::TimedOut);
     assert_eq!(registration_counts(&host), (0, 1, 0));
-
-    let exec_result = host.exec("echo ok", 5000, &[], false).await.unwrap();
-    assert_eq!(exec_result.stdout, b"ok");
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::NotParkable
+    );
+    send_exit.send(()).unwrap();
     let event = wait_spawn(handle).await.unwrap();
     assert_eq!(event.exit_code, 0);
     assert_eq!(
         normal_operation_readiness(&host),
-        NormalOperationReadiness::Idle
+        NormalOperationReadiness::NotParkable
     );
 }
 
@@ -926,8 +1055,21 @@ async fn test_spawn_process_control_rejects_payload_over_local_ipc_limit_before_
         .await
         .unwrap();
     let too_large = vec![0; vsock_proto::PROCESS_CONTROL_MAX_PAYLOAD_BYTES + 1];
+    let write_start_count = Arc::new(AtomicUsize::new(0));
     let err = handle
-        .control("message-too-large", &too_large, Duration::from_secs(5))
+        .control_handle()
+        .control_with_write_observer(
+            "message-too-large",
+            &too_large,
+            Duration::from_secs(5),
+            FrameWriteObserver::new({
+                let write_start_count = Arc::clone(&write_start_count);
+                move || {
+                    write_start_count.fetch_add(1, Ordering::SeqCst);
+                    Ok(())
+                }
+            }),
+        )
         .await
         .unwrap_err();
     assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
@@ -935,6 +1077,7 @@ async fn test_spawn_process_control_rejects_payload_over_local_ipc_limit_before_
         err.to_string().contains("payload field too large"),
         "unexpected error: {err}",
     );
+    assert_eq!(write_start_count.load(Ordering::SeqCst), 0);
     assert_eq!(registration_counts(&host), (0, 1, 0));
 
     let exec_result = host.exec("echo ok", 5000, &[], false).await.unwrap();


### PR DESCRIPTION
Closes #13722

## Summary
- route operation-bound process-control through the sandbox operation gate and vsock write observer
- preserve clean gate state for pre-write validation failures and mark dirty/not-parkable for post-write uncertainty
- add typed vsock-host process-control outcomes so guest terminal statuses can complete the gate before surfacing errors

## Tests
- cargo test --manifest-path crates/Cargo.toml -p vsock-host
- cargo test --manifest-path crates/Cargo.toml -p sandbox-fc --lib
- cargo test --manifest-path crates/Cargo.toml -p sandbox
- cargo check --manifest-path crates/Cargo.toml -p runner --all-targets
- pre-commit: cargo fmt, cargo doc, cargo clippy