### PR TITLE
Fix desktop auth browser handoff redirect

### DIFF
--- a/turbo/apps/desktop/src/desktop-auth.ts
+++ b/turbo/apps/desktop/src/desktop-auth.ts
@@ -3,8 +3,12 @@ export const DESKTOP_AUTH_PROTOCOL = "vm0";
 const DESKTOP_AUTH_HOST = "auth";
 const DESKTOP_AUTH_CALLBACK_PATH = "/callback";
 const DESKTOP_AUTH_CONSUME_PATH = "/desktop-auth/consume";
-const DESKTOP_AUTH_CALLBACK_WEB_PATH = "/desktop-auth/callback";
-const DESKTOP_AUTH_START_PATHS = new Set(["/sign-in", "/sign-up"]);
+const DESKTOP_AUTH_START_WEB_PATH = "/desktop-auth/start";
+const DESKTOP_AUTH_START_PATHS = new Set([
+  "/desktop-auth/start",
+  "/sign-in",
+  "/sign-up",
+]);
 const DESKTOP_AUTH_CODE_PATTERN = /^[A-Za-z0-9_-]{32,128}$/;
 
 interface DesktopAuthCallback {
@@ -51,10 +55,7 @@ export function buildDesktopAuthConsumeUrl(
 }
 
 export function buildDesktopAuthStartUrl(platformUrl: URL): string {
-  const signInUrl = new URL("/sign-in", platformUrl);
-  const callbackUrl = new URL(DESKTOP_AUTH_CALLBACK_WEB_PATH, platformUrl);
-  signInUrl.searchParams.set("redirect_url", callbackUrl.toString());
-  return signInUrl.toString();
+  return new URL(DESKTOP_AUTH_START_WEB_PATH, platformUrl).toString();
 }
 
 export function isDesktopAuthStartNavigation(

--- a/turbo/apps/desktop/src/window-policy.test.ts
+++ b/turbo/apps/desktop/src/window-policy.test.ts
@@ -130,9 +130,9 @@ describe("desktop auth", () => {
   const platformUrl = new URL("https://app.vm0.ai");
   const code = "abcdefghijklmnopqrstuvwxyzABCDEF0123456789_-";
 
-  it("builds the system-browser sign-in URL with a hosted callback", () => {
+  it("builds the system-browser desktop auth start URL", () => {
     expect(buildDesktopAuthStartUrl(platformUrl)).toBe(
-      "https://app.vm0.ai/sign-in?redirect_url=https%3A%2F%2Fapp.vm0.ai%2Fdesktop-auth%2Fcallback",
+      "https://app.vm0.ai/desktop-auth/start",
     );
   });
 
@@ -140,6 +140,12 @@ describe("desktop auth", () => {
     expect(
       isDesktopAuthStartNavigation(
         "https://app.vm0.ai/sign-in",
+        allowedOrigins,
+      ),
+    ).toBe(true);
+    expect(
+      isDesktopAuthStartNavigation(
+        "https://app.vm0.ai/desktop-auth/start",
         allowedOrigins,
       ),
     ).toBe(true);

--- a/turbo/apps/web/__tests__/proxy.locale-guard.test.ts
+++ b/turbo/apps/web/__tests__/proxy.locale-guard.test.ts
@@ -80,6 +80,7 @@ describe("localeGuardLayer", () => {
     });
 
     it("should keep desktop auth outside locale processing", () => {
+      expect(classifyRoute("/desktop-auth/start")).toBe("skip");
       expect(classifyRoute("/desktop-auth/consume")).toBe("skip");
       expect(classifyRoute("/desktop-auth/callback")).toBe("skip");
     });

--- a/turbo/apps/web/app/desktop-auth/callback/DesktopAuthCallbackClient.tsx
+++ b/turbo/apps/web/app/desktop-auth/callback/DesktopAuthCallbackClient.tsx
@@ -47,9 +47,7 @@ export function DesktopAuthCallbackClient() {
     didRun.current = true;
 
     if (!isSignedIn) {
-      window.location.href = `/sign-in?redirect_url=${encodeURIComponent(
-        "/desktop-auth/callback",
-      )}`;
+      window.location.replace("/desktop-auth/start");
       return;
     }
 

--- a/turbo/apps/web/app/desktop-auth/start/DesktopAuthStartClient.tsx
+++ b/turbo/apps/web/app/desktop-auth/start/DesktopAuthStartClient.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { SignIn, useAuth } from "@clerk/nextjs";
+import { useTheme } from "../../components/ThemeProvider";
+import { AuthLayout } from "../../components/auth/AuthLayout";
+import { getClerkAppearance } from "../../components/auth/clerk-appearance";
+
+const DESKTOP_AUTH_CALLBACK_PATH = "/desktop-auth/callback";
+
+export function DesktopAuthStartClient() {
+  const { isLoaded, isSignedIn } = useAuth();
+  const { theme } = useTheme();
+  const didRedirect = useRef(false);
+
+  useEffect(() => {
+    if (!isLoaded || !isSignedIn || didRedirect.current) {
+      return;
+    }
+
+    didRedirect.current = true;
+    window.location.replace(DESKTOP_AUTH_CALLBACK_PATH);
+  }, [isLoaded, isSignedIn]);
+
+  if (!isLoaded || isSignedIn) {
+    return (
+      <p style={{ padding: "2rem", fontFamily: "monospace" }}>Signing in...</p>
+    );
+  }
+
+  return (
+    <AuthLayout>
+      <SignIn
+        appearance={getClerkAppearance(theme)}
+        fallbackRedirectUrl={DESKTOP_AUTH_CALLBACK_PATH}
+        forceRedirectUrl={DESKTOP_AUTH_CALLBACK_PATH}
+        oauthFlow="redirect"
+        path="/desktop-auth/start"
+        routing="path"
+        signUpFallbackRedirectUrl={DESKTOP_AUTH_CALLBACK_PATH}
+        signUpForceRedirectUrl={DESKTOP_AUTH_CALLBACK_PATH}
+      />
+    </AuthLayout>
+  );
+}

--- a/turbo/apps/web/app/desktop-auth/start/[[...desktopAuthStart]]/page.tsx
+++ b/turbo/apps/web/app/desktop-auth/start/[[...desktopAuthStart]]/page.tsx
@@ -1,0 +1,10 @@
+import type { Metadata } from "next";
+import { DesktopAuthStartClient } from "../DesktopAuthStartClient";
+
+export const metadata: Metadata = {
+  robots: { index: false, follow: false },
+};
+
+export default function DesktopAuthStartPage() {
+  return <DesktopAuthStartClient />;
+}

--- a/turbo/apps/web/app/desktop-auth/start/__tests__/DesktopAuthStartClient.test.tsx
+++ b/turbo/apps/web/app/desktop-auth/start/__tests__/DesktopAuthStartClient.test.tsx
@@ -1,0 +1,117 @@
+// @vitest-environment happy-dom
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { AnchorHTMLAttributes, ReactNode } from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import { ThemeProvider } from "../../../components/ThemeProvider";
+import { DesktopAuthStartClient } from "../DesktopAuthStartClient";
+
+const clerkState = vi.hoisted(() => {
+  return {
+    auth: { isLoaded: true, isSignedIn: false },
+    signInProps: null as Record<string, unknown> | null,
+  };
+});
+
+vi.mock("@clerk/nextjs", () => {
+  return {
+    useAuth: () => {
+      return clerkState.auth;
+    },
+    SignIn: (props: Record<string, unknown>) => {
+      clerkState.signInProps = props;
+      return <div data-testid="desktop-sign-in" />;
+    },
+  };
+});
+
+vi.mock("next/link", () => {
+  return {
+    default: ({
+      href,
+      children,
+      className,
+      ...props
+    }: {
+      href: string;
+      children?: ReactNode;
+      className?: string;
+    } & AnchorHTMLAttributes<HTMLAnchorElement>) => {
+      return (
+        <a href={href} className={className} {...props}>
+          {children}
+        </a>
+      );
+    },
+  };
+});
+
+vi.mock("next/image", () => {
+  return {
+    default: ({ alt, src }: { alt: string; src: string }) => {
+      return <span data-alt={alt} data-src={src} />;
+    },
+  };
+});
+
+function mockMatchMedia() {
+  Object.defineProperty(window, "matchMedia", {
+    value: (query: string) => {
+      return {
+        matches: query === "(prefers-color-scheme: dark)",
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      };
+    },
+    configurable: true,
+  });
+}
+
+function renderStartClient() {
+  return render(
+    <ThemeProvider>
+      <DesktopAuthStartClient />
+    </ThemeProvider>,
+  );
+}
+
+describe("DesktopAuthStartClient", () => {
+  beforeEach(() => {
+    clerkState.auth = { isLoaded: true, isSignedIn: false };
+    clerkState.signInProps = null;
+    localStorage.clear();
+    document.documentElement.removeAttribute("data-theme");
+    mockMatchMedia();
+  });
+
+  it("renders Clerk sign-in with desktop callback redirects for signed-out users", () => {
+    renderStartClient();
+
+    expect(screen.getByTestId("desktop-sign-in")).toBeTruthy();
+    expect(clerkState.signInProps).toMatchObject({
+      fallbackRedirectUrl: "/desktop-auth/callback",
+      forceRedirectUrl: "/desktop-auth/callback",
+      oauthFlow: "redirect",
+      path: "/desktop-auth/start",
+      routing: "path",
+      signUpFallbackRedirectUrl: "/desktop-auth/callback",
+      signUpForceRedirectUrl: "/desktop-auth/callback",
+    });
+  });
+
+  it("redirects already signed-in browser sessions to the desktop callback", async () => {
+    clerkState.auth = { isLoaded: true, isSignedIn: true };
+    const replace = vi
+      .spyOn(window.location, "replace")
+      .mockImplementation(() => {
+        return undefined;
+      });
+
+    renderStartClient();
+
+    expect(screen.getByText("Signing in...")).toBeTruthy();
+    await waitFor(() => {
+      expect(replace).toHaveBeenCalledWith("/desktop-auth/callback");
+    });
+  });
+});

--- a/turbo/apps/web/proxy.ts
+++ b/turbo/apps/web/proxy.ts
@@ -52,6 +52,7 @@ const isPublicRoute = createRouteMatcher([
   "/sign-up(.*)",
   "/sign-in-token",
   "/:locale/sign-in-token",
+  "/desktop-auth/start(.*)",
   "/desktop-auth/callback(.*)",
   "/desktop-auth/consume(.*)",
   "/api/cli/auth/device",


### PR DESCRIPTION
## Summary
- route Electron desktop auth launches through a dedicated `/desktop-auth/start` page
- render Clerk SignIn there with desktop callback force/fallback redirects and path routing
- redirect already signed-in browser sessions directly to `/desktop-auth/callback` before Clerk sends them to the home URL

## Testing
- pnpm -F @vm0/desktop test
- pnpm -F @vm0/desktop lint
- pnpm -F @vm0/desktop check-types
- pnpm -F @vm0/desktop build
- pnpm -F web exec vitest run __tests__/proxy.locale-guard.test.ts app/desktop-auth/start/__tests__/DesktopAuthStartClient.test.tsx
- pnpm -F web lint
- pnpm -F web check-types
- pnpm -F api check-types
- pre-commit: prettier, knip, turbo check-types
