### PR TITLE
fix: pass feature switch context to secret writes

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-user-data.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-user-data.ts
@@ -5,6 +5,7 @@ import type { SecretType } from "@vm0/api-contracts/contracts/secrets";
 import { command } from "ccstate";
 import { orgMembersMetadata } from "@vm0/db/schema/org-members-metadata";
 import { secrets } from "@vm0/db/schema/secret";
+import { userFeatureSwitches } from "@vm0/db/schema/user-feature-switches";
 import { variables } from "@vm0/db/schema/variable";
 import { and, eq } from "drizzle-orm";
 
@@ -182,6 +183,10 @@ export const deleteUserData$ = command(
     await writeDb.delete(variables).where(eq(variables.orgId, fixture.orgId));
     signal.throwIfAborted();
     await writeDb.delete(secrets).where(eq(secrets.orgId, fixture.orgId));
+    signal.throwIfAborted();
+    await writeDb
+      .delete(userFeatureSwitches)
+      .where(eq(userFeatureSwitches.orgId, fixture.orgId));
     signal.throwIfAborted();
   },
 );

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-secrets.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-secrets.test.ts
@@ -1,12 +1,28 @@
 import { randomUUID } from "node:crypto";
 
+import {
+  DecryptCommand,
+  type DecryptCommandOutput,
+  GenerateDataKeyCommand,
+  type GenerateDataKeyCommandOutput,
+} from "@aws-sdk/client-kms";
 import { zeroSecretsContract } from "@vm0/api-contracts/contracts/zero-secrets";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { createStore } from "ccstate";
 import { and, eq } from "drizzle-orm";
 import { secrets } from "@vm0/db/schema/secret";
+import { afterEach } from "vitest";
 
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { clearMockedEnv, mockEnv } from "../../../lib/env";
 import { writeDb$ } from "../../external/db";
+import {
+  resetSecretKmsClientForTests,
+  setSecretKmsClientForTests,
+  STORED_SECRET_ENVELOPE_PREFIX,
+  type SecretKmsClient,
+} from "../../services/crypto.utils";
+import { updateUserFeatureSwitches$ } from "../../services/feature-switches.service";
 import {
   createFixtureTracker,
   createZeroRouteMocks,
@@ -21,6 +37,68 @@ import {
 const context = testContext();
 const store = createStore();
 const mocks = createZeroRouteMocks(context);
+const dataKey = Buffer.from("0123456789abcdef0123456789abcdef", "utf8");
+
+type MockKmsCommand = GenerateDataKeyCommand | DecryptCommand;
+type MockKmsResponse = GenerateDataKeyCommandOutput | DecryptCommandOutput;
+
+function fakeKmsClient(): {
+  readonly calls: readonly MockKmsCommand[];
+  readonly client: SecretKmsClient;
+} {
+  const calls: MockKmsCommand[] = [];
+
+  function send(
+    command: GenerateDataKeyCommand,
+  ): Promise<GenerateDataKeyCommandOutput>;
+  function send(command: DecryptCommand): Promise<DecryptCommandOutput>;
+  function send(command: MockKmsCommand): Promise<MockKmsResponse> {
+    calls.push(command);
+
+    if (command instanceof GenerateDataKeyCommand) {
+      return Promise.resolve({
+        $metadata: {},
+        KeyId: command.input.KeyId,
+        CiphertextBlob: Buffer.from(
+          `encrypted-data-key:${command.input.KeyId}`,
+          "utf8",
+        ),
+        Plaintext: dataKey,
+      });
+    }
+
+    return Promise.resolve({ $metadata: {}, Plaintext: dataKey });
+  }
+
+  return { calls, client: { send } };
+}
+
+function storedSecretEnvelope(encryptedValue: string): {
+  readonly legacy?: string;
+  readonly kms?: {
+    readonly encryptedDataKey?: string;
+    readonly ciphertext?: string;
+  };
+} {
+  expect(encryptedValue.startsWith(STORED_SECRET_ENVELOPE_PREFIX)).toBe(true);
+  return JSON.parse(
+    Buffer.from(
+      encryptedValue.slice(STORED_SECRET_ENVELOPE_PREFIX.length),
+      "base64url",
+    ).toString("utf8"),
+  ) as {
+    readonly legacy?: string;
+    readonly kms?: {
+      readonly encryptedDataKey?: string;
+      readonly ciphertext?: string;
+    };
+  };
+}
+
+afterEach(() => {
+  clearMockedEnv();
+  resetSecretKmsClientForTests();
+});
 
 describe("GET /api/zero/secrets", () => {
   const track = createFixtureTracker<UserDataFixture>((fixture) => {
@@ -229,6 +307,59 @@ describe("POST /api/zero/secrets", () => {
     expect(rows).toHaveLength(1);
     expect(rows[0]?.type).toBe("user");
     expect(rows[0]?.encryptedValue).not.toBe("secret-value");
+  });
+
+  it("uses KMS data-key envelope encryption when the write switch is enabled", async () => {
+    const kms = fakeKmsClient();
+    setSecretKmsClientForTests(kms.client);
+    mockEnv("SECRETS_KMS_KEY_ID", "alias/vm0-secrets");
+    const fixture = await track(store.set(seedSecrets$, [], context.signal));
+    await store.set(
+      updateUserFeatureSwitches$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        switches: { [FeatureSwitchKey.StoredSecretKmsWrite]: true },
+      },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(zeroSecretsContract);
+
+    await accept(
+      client.set({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          name: "MY_SECRET",
+          value: "secret-value",
+        },
+      }),
+      [200],
+    );
+
+    const writeDb = store.set(writeDb$);
+    const [row] = await writeDb
+      .select({ encryptedValue: secrets.encryptedValue })
+      .from(secrets)
+      .where(
+        and(
+          eq(secrets.orgId, fixture.orgId),
+          eq(secrets.userId, fixture.userId),
+          eq(secrets.name, "MY_SECRET"),
+          eq(secrets.type, "user"),
+        ),
+      )
+      .limit(1);
+
+    expect(kms.calls).toHaveLength(1);
+    expect(kms.calls[0]).toBeInstanceOf(GenerateDataKeyCommand);
+    if (!row) {
+      throw new Error("Expected secret row to be written");
+    }
+    const envelope = storedSecretEnvelope(row.encryptedValue);
+    expect(envelope.legacy).toBeTruthy();
+    expect(envelope.kms?.encryptedDataKey).toBeTruthy();
   });
 
   it("updates an existing user secret without creating a duplicate", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-secrets.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-secrets.test.ts
@@ -80,7 +80,7 @@ function storedSecretEnvelope(encryptedValue: string): {
     readonly ciphertext?: string;
   };
 } {
-  expect(encryptedValue.startsWith(STORED_SECRET_ENVELOPE_PREFIX)).toBe(true);
+  expect(encryptedValue.startsWith(STORED_SECRET_ENVELOPE_PREFIX)).toBeTruthy();
   return JSON.parse(
     Buffer.from(
       encryptedValue.slice(STORED_SECRET_ENVELOPE_PREFIX.length),

--- a/turbo/apps/api/src/signals/routes/zero-custom-connectors-secret-set.ts
+++ b/turbo/apps/api/src/signals/routes/zero-custom-connectors-secret-set.ts
@@ -9,6 +9,7 @@ import { writeDb$ } from "../external/db";
 import { notFound } from "../../lib/error";
 import { nowDate } from "../../lib/time";
 import { encryptStoredSecretValue } from "../services/crypto.utils";
+import { userFeatureSwitchContext } from "../services/feature-switches.service";
 import { getCustomConnectorById } from "../services/zero-custom-connector.service";
 import type { RouteEntry } from "../route";
 
@@ -36,7 +37,15 @@ const setSecretInner$ = command(async ({ get, set }, signal: AbortSignal) => {
     return notFound("Custom connector not found");
   }
 
-  const encryptedValue = await encryptStoredSecretValue(bodyResult.data.value);
+  const featureSwitchContext = await get(
+    userFeatureSwitchContext(auth.orgId, auth.userId),
+  );
+  signal.throwIfAborted();
+
+  const encryptedValue = await encryptStoredSecretValue(
+    bodyResult.data.value,
+    featureSwitchContext,
+  );
   signal.throwIfAborted();
   const writeDb = set(writeDb$);
   await writeDb

--- a/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
@@ -26,7 +26,7 @@ import {
   decryptStoredSecretValue,
   encryptStoredSecretValue,
 } from "./crypto.utils";
-import { loadUserFeatureSwitchOverrides } from "./feature-switches.service";
+import { loadUserFeatureSwitchContext } from "./feature-switches.service";
 import { resolveOrgCreditAvailability } from "./zero-run-admission.service";
 
 type OAuthSecretSource = "connector" | "model-provider";
@@ -286,9 +286,13 @@ async function upsertSecretValue(
     readonly name: string;
     readonly value: string;
     readonly type: SecretType;
+    readonly featureSwitchContext: FeatureSwitchContext;
   },
 ): Promise<void> {
-  const encryptedValue = await encryptStoredSecretValue(args.value);
+  const encryptedValue = await encryptStoredSecretValue(
+    args.value,
+    args.featureSwitchContext,
+  );
   await db
     .insert(secretsTable)
     .values({
@@ -578,6 +582,7 @@ async function markRefreshSuccess(
     name: context.accessTokenSecret,
     value: result.accessToken,
     type: args.sourceType,
+    featureSwitchContext: args.featureSwitchContext,
   });
   if (result.refreshToken) {
     await upsertSecretValue(args.db, {
@@ -586,6 +591,7 @@ async function markRefreshSuccess(
       name: context.refreshTokenSecret,
       value: result.refreshToken,
       type: args.sourceType,
+      featureSwitchContext: args.featureSwitchContext,
     });
   }
 
@@ -965,16 +971,11 @@ async function refreshExpiredTokens(
     return emptyRefreshResult;
   }
 
-  const featureSwitchOverrides = await loadUserFeatureSwitchOverrides(
+  const featureSwitchContext = await loadUserFeatureSwitchContext(
     args.db,
     orgId,
     args.auth.userId,
   );
-  const featureSwitchContext = {
-    orgId,
-    userId: args.auth.userId,
-    overrides: featureSwitchOverrides,
-  } satisfies FeatureSwitchContext;
 
   const connectorTypes = [...new Set(refreshable.values())];
   const metadataByConnector = buildMetadataByConnector(

--- a/turbo/apps/api/src/signals/services/cli-auth-stripe.service.ts
+++ b/turbo/apps/api/src/signals/services/cli-auth-stripe.service.ts
@@ -1,5 +1,6 @@
 import { command, type Setter } from "ccstate";
 import type { ConnectorResponse } from "@vm0/api-contracts/contracts/connector-schemas";
+import type { FeatureSwitchContext } from "@vm0/core/feature-switch";
 import { z } from "zod";
 
 import { nowDate } from "../../lib/time";
@@ -23,6 +24,7 @@ import {
   encryptSecretValue,
   encryptStoredSecretValue,
 } from "./crypto.utils";
+import { userFeatureSwitchContext } from "./feature-switches.service";
 import {
   parseStripeCliAuthConfig,
   parseStripeCliAuthStartOutput as parseStripeCliAuthStartOutputText,
@@ -1127,11 +1129,15 @@ async function importCliAuthStripeConnector(args: {
   readonly userId: string;
   readonly mode: StripeCliAuthMode;
   readonly apiKey: string;
+  readonly featureSwitchContext: FeatureSwitchContext;
   readonly signal: AbortSignal;
 }): Promise<CliAuthStripeCompleteResult> {
   args.signal.throwIfAborted();
 
-  const encryptedValue = await encryptStoredSecretValue(args.apiKey);
+  const encryptedValue = await encryptStoredSecretValue(
+    args.apiKey,
+    args.featureSwitchContext,
+  );
   const updatedAt = nowDate();
   const writeDb = args.set(writeDb$);
   const description = `Stripe CLI ${args.mode} mode API key`;
@@ -1614,6 +1620,7 @@ async function completeClaimedCliAuthStripe(args: {
   readonly sandbox: SandboxHandle;
   readonly orgId: string;
   readonly userId: string;
+  readonly featureSwitchContext: FeatureSwitchContext;
   readonly signal: AbortSignal;
 }): Promise<CliAuthStripeCompleteResult> {
   const claimedAt = args.session.updatedAt;
@@ -1681,6 +1688,7 @@ async function completeClaimedCliAuthStripe(args: {
       userId: args.userId,
       mode: args.providerState.mode,
       apiKey: apiKeyResult.apiKey,
+      featureSwitchContext: args.featureSwitchContext,
       signal: args.signal,
     }),
   );
@@ -1721,7 +1729,7 @@ async function completeClaimedCliAuthStripe(args: {
 
 export const completeCliAuthStripe$ = command(
   async (
-    { set },
+    { get, set },
     args: {
       readonly orgId: string;
       readonly userId: string;
@@ -1731,6 +1739,11 @@ export const completeCliAuthStripe$ = command(
     signal: AbortSignal,
   ): Promise<CliAuthStripeCompleteResult> => {
     const writeDb = set(writeDb$);
+    const featureSwitchContext = await get(
+      userFeatureSwitchContext(args.orgId, args.userId),
+    );
+    signal.throwIfAborted();
+
     const client = getVercelSandboxClient();
     const prepared = await prepareCliAuthStripeCompletion({
       writeDb,
@@ -1750,6 +1763,7 @@ export const completeCliAuthStripe$ = command(
       client,
       orgId: args.orgId,
       userId: args.userId,
+      featureSwitchContext,
       session: prepared.session,
       providerState: prepared.providerState,
       sandbox: prepared.sandbox,

--- a/turbo/apps/api/src/signals/services/feature-switches.service.ts
+++ b/turbo/apps/api/src/signals/services/feature-switches.service.ts
@@ -1,11 +1,12 @@
 import { command, computed, type Computed } from "ccstate";
+import type { FeatureSwitchContext } from "@vm0/core/feature-switch";
 import { userFeatureSwitches } from "@vm0/db/schema/user-feature-switches";
 import { and, eq } from "drizzle-orm";
 
 import { db$, writeDb$, type ReadonlyDb } from "../external/db";
 import { nowDate } from "../external/time";
 
-export async function loadUserFeatureSwitchOverrides(
+async function loadUserFeatureSwitchOverrides(
   db: ReadonlyDb,
   orgId: string,
   userId: string,
@@ -31,6 +32,31 @@ export function userFeatureSwitchOverrides(
   return computed(async (get): Promise<Record<string, boolean>> => {
     const db = get(db$);
     return await loadUserFeatureSwitchOverrides(db, orgId, userId);
+  });
+}
+
+export async function loadUserFeatureSwitchContext(
+  db: ReadonlyDb,
+  orgId: string,
+  userId: string,
+): Promise<FeatureSwitchContext> {
+  return {
+    orgId,
+    userId,
+    overrides: await loadUserFeatureSwitchOverrides(db, orgId, userId),
+  };
+}
+
+export function userFeatureSwitchContext(
+  orgId: string,
+  userId: string,
+): Computed<Promise<FeatureSwitchContext>> {
+  return computed(async (get): Promise<FeatureSwitchContext> => {
+    return {
+      orgId,
+      userId,
+      overrides: await get(userFeatureSwitchOverrides(orgId, userId)),
+    };
   });
 }
 

--- a/turbo/apps/api/src/signals/services/zero-computer-connector.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-computer-connector.service.ts
@@ -1,6 +1,7 @@
 import { createHash, randomUUID } from "node:crypto";
 
 import type { ComputerConnectorCreateResponse } from "@vm0/api-contracts/contracts/connector-schemas";
+import type { FeatureSwitchContext } from "@vm0/core/feature-switch";
 import { connectors } from "@vm0/db/schema/connector";
 import { secrets } from "@vm0/db/schema/secret";
 import { and, eq } from "drizzle-orm";
@@ -23,6 +24,7 @@ import {
 } from "../external/ngrok-client";
 import { settle } from "../utils";
 import { encryptStoredSecretValue } from "./crypto.utils";
+import { userFeatureSwitchContext } from "./feature-switches.service";
 
 const log = logger("service:computer-connector");
 
@@ -58,6 +60,7 @@ interface ProvisionContext {
   readonly args: CreateComputerConnectorArgs;
   readonly apiKey: string;
   readonly refs: ProvisionedRefs;
+  readonly featureSwitchContext: FeatureSwitchContext;
 }
 
 function connectorSlug(orgId: string): string {
@@ -99,10 +102,14 @@ function buildTrafficPolicy(
 async function upsertConnectorSecret(
   db: Db,
   args: CreateComputerConnectorArgs,
+  featureSwitchContext: FeatureSwitchContext,
   name: (typeof COMPUTER_CONNECTOR_SECRET_NAMES)[number],
   value: string,
 ): Promise<void> {
-  const encryptedValue = await encryptStoredSecretValue(value);
+  const encryptedValue = await encryptStoredSecretValue(
+    value,
+    featureSwitchContext,
+  );
   await db
     .insert(secrets)
     .values({
@@ -276,6 +283,7 @@ async function provisionAndPersistConnector(
   await upsertConnectorSecret(
     db,
     args,
+    ctx.featureSwitchContext,
     "COMPUTER_CONNECTOR_BRIDGE_TOKEN",
     bridgeToken,
   );
@@ -283,11 +291,18 @@ async function provisionAndPersistConnector(
   await upsertConnectorSecret(
     db,
     args,
+    ctx.featureSwitchContext,
     "COMPUTER_CONNECTOR_DOMAIN_ID",
     refs.domainId,
   );
   signal.throwIfAborted();
-  await upsertConnectorSecret(db, args, "COMPUTER_CONNECTOR_DOMAIN", domain);
+  await upsertConnectorSecret(
+    db,
+    args,
+    ctx.featureSwitchContext,
+    "COMPUTER_CONNECTOR_DOMAIN",
+    domain,
+  );
   signal.throwIfAborted();
 
   log.debug("Computer connector created", {
@@ -307,11 +322,15 @@ async function provisionAndPersistConnector(
 
 export const createComputerConnector$ = command(
   async (
-    { set },
+    { get, set },
     args: CreateComputerConnectorArgs,
     signal: AbortSignal,
   ): Promise<CreateComputerConnectorResult> => {
     const db = set(writeDb$);
+    const featureSwitchContext = await get(
+      userFeatureSwitchContext(args.orgId, args.userId),
+    );
+    signal.throwIfAborted();
 
     const [existing] = await db
       .select({ id: connectors.id })
@@ -333,7 +352,10 @@ export const createComputerConnector$ = command(
 
     const refs: ProvisionedRefs = {};
     const result = await settle(
-      provisionAndPersistConnector({ db, args, apiKey, refs }, signal),
+      provisionAndPersistConnector(
+        { db, args, apiKey, refs, featureSwitchContext },
+        signal,
+      ),
     );
     signal.throwIfAborted();
 

--- a/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
@@ -48,7 +48,10 @@ import {
   decryptStoredSecretValue,
   encryptStoredSecretValue,
 } from "./crypto.utils";
-import { userFeatureSwitchOverrides } from "./feature-switches.service";
+import {
+  userFeatureSwitchContext,
+  userFeatureSwitchOverrides,
+} from "./feature-switches.service";
 import { invalidateActiveCliAuthSessionsForConnectorType } from "./cli-auth-invalidation.service";
 
 type StoredConnectorRow = {
@@ -765,9 +768,13 @@ async function upsertConnectorSecret(
     readonly name: string;
     readonly value: string;
     readonly description: string;
+    readonly featureSwitchContext: FeatureSwitchContext;
   },
 ): Promise<void> {
-  const encryptedValue = await encryptStoredSecretValue(args.value);
+  const encryptedValue = await encryptStoredSecretValue(
+    args.value,
+    args.featureSwitchContext,
+  );
   await db
     .insert(secrets)
     .values({
@@ -806,7 +813,7 @@ function connectorTokenExpiresAt(args: {
 
 export const upsertOAuthConnector$ = command(
   async (
-    { set },
+    { get, set },
     args: {
       readonly orgId: string;
       readonly userId: string;
@@ -839,12 +846,18 @@ export const upsertOAuthConnector$ = command(
     });
     signal.throwIfAborted();
 
+    const featureSwitchContext = await get(
+      userFeatureSwitchContext(args.orgId, args.userId),
+    );
+    signal.throwIfAborted();
+
     await upsertConnectorSecret(writeDb, {
       orgId: args.orgId,
       userId: args.userId,
       name: getSecretNameForConnector(args.type),
       value: args.accessToken,
       description: `OAuth token for ${args.type} connector`,
+      featureSwitchContext,
     });
     signal.throwIfAborted();
 
@@ -855,6 +868,7 @@ export const upsertOAuthConnector$ = command(
         name: args.refreshSecretName,
         value: args.refreshToken,
         description: `OAuth refresh token for ${args.type} connector`,
+        featureSwitchContext,
       });
       signal.throwIfAborted();
     }

--- a/turbo/apps/api/src/signals/services/zero-model-provider.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-model-provider.service.ts
@@ -13,6 +13,7 @@ import {
   type ModelProviderType,
   modelProviderTypeSchema,
 } from "@vm0/api-contracts/contracts/model-providers";
+import type { FeatureSwitchContext } from "@vm0/core/feature-switch";
 import { modelProviders } from "@vm0/db/schema/model-provider";
 import { secrets } from "@vm0/db/schema/secret";
 import { and, eq, inArray } from "drizzle-orm";
@@ -22,6 +23,7 @@ import { badRequestMessage, notFound } from "../../lib/error";
 import { logger } from "../../lib/log";
 import { nowDate } from "../external/time";
 import { encryptStoredSecretValue } from "./crypto.utils";
+import { userFeatureSwitchContext } from "./feature-switches.service";
 
 const L = logger("zero-model-provider.service");
 
@@ -408,9 +410,13 @@ async function upsertMultiAuthSecret(
     readonly name: string;
     readonly value: string;
     readonly description: string;
+    readonly featureSwitchContext: FeatureSwitchContext;
   },
 ): Promise<void> {
-  const encryptedValue = await encryptStoredSecretValue(args.value);
+  const encryptedValue = await encryptStoredSecretValue(
+    args.value,
+    args.featureSwitchContext,
+  );
   await writeDb
     .insert(secrets)
     .values({
@@ -439,7 +445,7 @@ async function upsertMultiAuthSecret(
  */
 export const upsertUserModelProvider$ = command(
   async (
-    { set },
+    { get, set },
     args: {
       readonly orgId: string;
       readonly userId: string;
@@ -471,7 +477,15 @@ export const upsertUserModelProvider$ = command(
     }
 
     const writeDb = set(writeDb$);
-    const encryptedValue = await encryptStoredSecretValue(args.secret);
+    const featureSwitchContext = await get(
+      userFeatureSwitchContext(args.orgId, args.userId),
+    );
+    signal.throwIfAborted();
+
+    const encryptedValue = await encryptStoredSecretValue(
+      args.secret,
+      featureSwitchContext,
+    );
     signal.throwIfAborted();
 
     L.debug("upserting model provider", {
@@ -581,6 +595,7 @@ async function persistMultiAuthSecrets(
     readonly type: ModelProviderType;
     readonly authMethod: string;
     readonly secretValues: Record<string, string>;
+    readonly featureSwitchContext: FeatureSwitchContext;
   },
   signal: AbortSignal,
 ): Promise<void> {
@@ -592,6 +607,7 @@ async function persistMultiAuthSecrets(
       name,
       value,
       description,
+      featureSwitchContext: args.featureSwitchContext,
     });
     signal.throwIfAborted();
   }
@@ -652,7 +668,7 @@ function validateMultiAuthUpsertInput(args: {
  */
 export const upsertUserMultiAuthModelProvider$ = command(
   async (
-    { set },
+    { get, set },
     args: {
       readonly orgId: string;
       readonly userId: string;
@@ -677,6 +693,10 @@ export const upsertUserMultiAuthModelProvider$ = command(
     }
 
     const writeDb = set(writeDb$);
+    const featureSwitchContext = await get(
+      userFeatureSwitchContext(args.orgId, args.userId),
+    );
+    signal.throwIfAborted();
 
     L.debug("upserting multi-auth model provider", {
       orgId: args.orgId,
@@ -713,7 +733,11 @@ export const upsertUserMultiAuthModelProvider$ = command(
 
     // Store/update all secrets atomically.
     const secretNames = Object.keys(args.secretValues);
-    await persistMultiAuthSecrets(writeDb, args, signal);
+    await persistMultiAuthSecrets(
+      writeDb,
+      { ...args, featureSwitchContext },
+      signal,
+    );
 
     // Atomic model provider upsert; metadata-aware conflict set clears stale flags.
     const insertValues = buildMultiAuthInsertValues({

--- a/turbo/apps/api/src/signals/services/zero-user-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-user-data.service.ts
@@ -34,6 +34,7 @@ import { nowDate } from "../../lib/time";
 import { db$, writeDb$ } from "../external/db";
 import { encryptStoredSecretValue } from "./crypto.utils";
 import { invalidateActiveCliAuthSessionsForSecretName } from "./cli-auth-invalidation.service";
+import { userFeatureSwitchContext } from "./feature-switches.service";
 import { isValidTimeZone } from "../utils";
 
 const API_KEY_PREFIX_LENGTH = 12;
@@ -432,7 +433,7 @@ export function userSecrets({
 
 export const setUserSecret$ = command(
   async (
-    { set },
+    { get, set },
     args: SetUserSecretArgs,
     signal: AbortSignal,
   ): Promise<SecretResponse> => {
@@ -446,7 +447,15 @@ export const setUserSecret$ = command(
     });
     signal.throwIfAborted();
 
-    const encryptedValue = await encryptStoredSecretValue(args.secret.value);
+    const featureSwitchContext = await get(
+      userFeatureSwitchContext(args.orgId, args.userId),
+    );
+    signal.throwIfAborted();
+
+    const encryptedValue = await encryptStoredSecretValue(
+      args.secret.value,
+      featureSwitchContext,
+    );
     signal.throwIfAborted();
     const updatedAt = nowDate();
     const [row] = await writeDb


### PR DESCRIPTION
## Summary
- pass user/org feature switch context into stored-secret write encryption paths
- add a route-level regression test proving POST /api/zero/secrets writes KMS data-key envelopes when storedSecretKmsWrite is enabled
- clean up test fixtures for feature-switch rows

## Tests
- git diff --check
- pnpm --filter api exec vitest run src/signals/routes/__tests__/zero-secrets.test.ts src/signals/services/__tests__/crypto.utils.test.ts
- pnpm --filter api check-types
- pre-commit hook: prettier, knip, full turbo check-types
