### PR TITLE
fix: add runner failure diagnostics

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -40,6 +40,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "agent-diagnostics"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1249,6 +1257,7 @@ checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 name = "guest-agent"
 version = "0.32.1"
 dependencies = [
+ "agent-diagnostics",
  "aho-corasick",
  "api-contracts",
  "base64",
@@ -2543,6 +2552,7 @@ name = "runner"
 version = "0.102.1"
 dependencies = [
  "ably-subscriber",
+ "agent-diagnostics",
  "api-contracts",
  "async-trait",
  "aws-sdk-s3",

--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "3"
 members = [
     "ably-subscriber",
+    "agent-diagnostics",
     "api-contracts",
     "guest-agent",
     "process-control-ipc",
@@ -29,6 +30,7 @@ edition = "2024"
 [workspace.dependencies]
 # Internal crates
 ably-subscriber = { path = "ably-subscriber" }
+agent-diagnostics = { path = "agent-diagnostics" }
 api-contracts = { path = "api-contracts" }
 guest-agent = { path = "guest-agent" }
 process-control-ipc = { path = "process-control-ipc" }

--- a/crates/agent-diagnostics/Cargo.toml
+++ b/crates/agent-diagnostics/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "agent-diagnostics"
+version = "0.1.0"
+edition.workspace = true
+
+[dependencies]
+serde = { workspace = true, features = ["derive"] }
+
+[dev-dependencies]
+serde_json.workspace = true
+
+[lints]
+workspace = true

--- a/crates/agent-diagnostics/src/lib.rs
+++ b/crates/agent-diagnostics/src/lib.rs
@@ -1,0 +1,236 @@
+//! Structured diagnostics shared by guest agents and runners.
+
+use serde::{Deserialize, Serialize};
+
+pub const FAILURE_DIAGNOSTIC_SCHEMA_VERSION: u8 = 1;
+
+#[must_use]
+pub fn failure_diagnostic_file(run_id: &str) -> String {
+    format!("/tmp/vm0-failure-diagnostic-{run_id}.json")
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FailureDiagnostic {
+    pub schema_version: u8,
+    pub failure_class: FailureClass,
+    pub framework: AgentFramework,
+    pub cli_exit_code: Option<i32>,
+    pub claude_num_turns: Option<u64>,
+    pub session_history_status: SessionHistoryStatus,
+    pub prompt_shape: PromptShape,
+    pub prompt_bytes: usize,
+    pub first_line_bytes: usize,
+}
+
+impl FailureDiagnostic {
+    #[must_use]
+    pub fn new(
+        failure_class: FailureClass,
+        framework: AgentFramework,
+        prompt: PromptMetadata,
+    ) -> Self {
+        Self {
+            schema_version: FAILURE_DIAGNOSTIC_SCHEMA_VERSION,
+            failure_class,
+            framework,
+            cli_exit_code: None,
+            claude_num_turns: None,
+            session_history_status: SessionHistoryStatus::Unknown,
+            prompt_shape: prompt.prompt_shape,
+            prompt_bytes: prompt.prompt_bytes,
+            first_line_bytes: prompt.first_line_bytes,
+        }
+    }
+
+    #[must_use]
+    pub fn with_cli_exit_code(mut self, cli_exit_code: i32) -> Self {
+        self.cli_exit_code = Some(cli_exit_code);
+        self
+    }
+
+    #[must_use]
+    pub fn with_claude_num_turns(mut self, claude_num_turns: Option<u64>) -> Self {
+        self.claude_num_turns = claude_num_turns;
+        self
+    }
+
+    #[must_use]
+    pub fn with_session_history_status(
+        mut self,
+        session_history_status: SessionHistoryStatus,
+    ) -> Self {
+        self.session_history_status = session_history_status;
+        self
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FailureClass {
+    WorkingDirSetupFailed,
+    CliExecutionError,
+    CliNonzero,
+    ClaudeZeroTurnNoHistory,
+    EventUploadFailed,
+    CheckpointFailed,
+}
+
+impl FailureClass {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::WorkingDirSetupFailed => "working_dir_setup_failed",
+            Self::CliExecutionError => "cli_execution_error",
+            Self::CliNonzero => "cli_nonzero",
+            Self::ClaudeZeroTurnNoHistory => "claude_zero_turn_no_history",
+            Self::EventUploadFailed => "event_upload_failed",
+            Self::CheckpointFailed => "checkpoint_failed",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentFramework {
+    ClaudeCode,
+    Codex,
+}
+
+impl AgentFramework {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::ClaudeCode => "claude_code",
+            Self::Codex => "codex",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SessionHistoryStatus {
+    Missing,
+    Empty,
+    Present,
+    Unknown,
+    NotApplicable,
+}
+
+impl SessionHistoryStatus {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Missing => "missing",
+            Self::Empty => "empty",
+            Self::Present => "present",
+            Self::Unknown => "unknown",
+            Self::NotApplicable => "not_applicable",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PromptShape {
+    Empty,
+    SlashLike,
+    Plain,
+}
+
+impl PromptShape {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Empty => "empty",
+            Self::SlashLike => "slash_like",
+            Self::Plain => "plain",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PromptMetadata {
+    pub prompt_shape: PromptShape,
+    pub prompt_bytes: usize,
+    pub first_line_bytes: usize,
+}
+
+impl PromptMetadata {
+    #[must_use]
+    pub fn from_prompt(prompt: &str) -> Self {
+        let raw_first_line = prompt.split_once('\n').map_or(prompt, |(line, _)| line);
+        let first_line = raw_first_line.strip_suffix('\r').unwrap_or(raw_first_line);
+        let trimmed = prompt.trim();
+        let prompt_shape = if trimmed.is_empty() {
+            PromptShape::Empty
+        } else if prompt.trim_start().starts_with('/') {
+            PromptShape::SlashLike
+        } else {
+            PromptShape::Plain
+        };
+
+        Self {
+            prompt_shape,
+            prompt_bytes: prompt.len(),
+            first_line_bytes: first_line.len(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn prompt_metadata_classifies_safe_shapes_without_content() {
+        let empty = PromptMetadata::from_prompt(" \n\t");
+        assert_eq!(empty.prompt_shape, PromptShape::Empty);
+        assert_eq!(empty.prompt_bytes, 3);
+        assert_eq!(empty.first_line_bytes, 1);
+
+        let slash = PromptMetadata::from_prompt("  /help\nsecret second line");
+        assert_eq!(slash.prompt_shape, PromptShape::SlashLike);
+        assert_eq!(slash.prompt_bytes, 26);
+        assert_eq!(slash.first_line_bytes, 7);
+
+        let plain = PromptMetadata::from_prompt("éplain\r\nsecond");
+        assert_eq!(plain.prompt_shape, PromptShape::Plain);
+        assert_eq!(plain.prompt_bytes, 15);
+        assert_eq!(plain.first_line_bytes, 7);
+    }
+
+    #[test]
+    fn failure_diagnostic_uses_camel_case_fields_and_snake_case_values() {
+        let diagnostic = FailureDiagnostic::new(
+            FailureClass::ClaudeZeroTurnNoHistory,
+            AgentFramework::ClaudeCode,
+            PromptMetadata::from_prompt("/help"),
+        )
+        .with_cli_exit_code(0)
+        .with_claude_num_turns(Some(0))
+        .with_session_history_status(SessionHistoryStatus::Missing);
+
+        let json = serde_json::to_value(&diagnostic).unwrap();
+        assert_eq!(json["schemaVersion"], 1);
+        assert_eq!(json["failureClass"], "claude_zero_turn_no_history");
+        assert_eq!(json["framework"], "claude_code");
+        assert_eq!(json["cliExitCode"], 0);
+        assert_eq!(json["claudeNumTurns"], 0);
+        assert_eq!(json["sessionHistoryStatus"], "missing");
+        assert_eq!(json["promptShape"], "slash_like");
+        assert_eq!(json["promptBytes"], 5);
+        assert_eq!(json["firstLineBytes"], 5);
+
+        let round_trip: FailureDiagnostic = serde_json::from_value(json).unwrap();
+        assert_eq!(round_trip, diagnostic);
+    }
+
+    #[test]
+    fn failure_diagnostic_path_is_run_scoped() {
+        assert_eq!(
+            failure_diagnostic_file("run-123"),
+            "/tmp/vm0-failure-diagnostic-run-123.json"
+        );
+    }
+}

--- a/crates/agent-diagnostics/src/lib.rs
+++ b/crates/agent-diagnostics/src/lib.rs
@@ -19,8 +19,8 @@ pub struct FailureDiagnostic {
     pub claude_num_turns: Option<u64>,
     pub session_history_status: SessionHistoryStatus,
     pub prompt_shape: PromptShape,
-    pub prompt_bytes: usize,
-    pub first_line_bytes: usize,
+    pub prompt_bytes: u64,
+    pub first_line_bytes: u64,
 }
 
 impl FailureDiagnostic {
@@ -152,8 +152,8 @@ impl PromptShape {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct PromptMetadata {
     pub prompt_shape: PromptShape,
-    pub prompt_bytes: usize,
-    pub first_line_bytes: usize,
+    pub prompt_bytes: u64,
+    pub first_line_bytes: u64,
 }
 
 impl PromptMetadata {
@@ -172,8 +172,8 @@ impl PromptMetadata {
 
         Self {
             prompt_shape,
-            prompt_bytes: prompt.len(),
-            first_line_bytes: first_line.len(),
+            prompt_bytes: prompt.len() as u64,
+            first_line_bytes: first_line.len() as u64,
         }
     }
 }

--- a/crates/guest-agent/Cargo.toml
+++ b/crates/guest-agent/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.32.1"
 edition.workspace = true
 
 [dependencies]
+agent-diagnostics.workspace = true
 aho-corasick.workspace = true
 api-contracts.workspace = true
 base64.workspace = true

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -1017,6 +1017,18 @@ mod tests {
             .block_on(complete_execution_writes_checkpoint_failure_diagnostic_inner());
     }
 
+    #[test]
+    fn complete_execution_preserves_existing_failure_diagnostic_when_events_fail() {
+        let _test_state_guard = lock_test_state();
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(
+                complete_execution_preserves_existing_failure_diagnostic_when_events_fail_inner(),
+            );
+    }
+
     async fn complete_execution_writes_event_upload_failure_diagnostic_inner() {
         let server = &*COMPLETE_EXECUTION_MOCK_SERVER;
         server.reset_async().await;
@@ -1155,6 +1167,83 @@ mod tests {
             diagnostic.session_history_status,
             SessionHistoryStatus::Missing
         );
+        telemetry_mock.assert_calls_async(1).await;
+
+        for path in cleanup_paths {
+            let _ = std::fs::remove_file(path);
+        }
+    }
+
+    async fn complete_execution_preserves_existing_failure_diagnostic_when_events_fail_inner() {
+        let server = &*COMPLETE_EXECUTION_MOCK_SERVER;
+        server.reset_async().await;
+        unsafe {
+            std::env::set_var("VM0_API_URL", server.base_url());
+            std::env::set_var("VM0_API_TOKEN", "test-token");
+            std::env::set_var("VM0_RUN_ID", "main-recovery-checkpoint");
+            std::env::set_var("VM0_WORKING_DIR", "/tmp/main-recovery-checkpoint");
+            std::env::set_var("VM0_PROMPT", "plain prompt");
+        }
+
+        let cleanup_paths = [
+            paths::session_id_file().to_string(),
+            paths::session_history_path_file().to_string(),
+            paths::checkpoint_error_file().to_string(),
+            paths::failure_diagnostic_file().to_string(),
+            paths::event_error_flag().to_string(),
+            paths::sandbox_ops_file().to_string(),
+            paths::telemetry_system_log_pos_file().to_string(),
+            paths::telemetry_metrics_pos_file().to_string(),
+            paths::telemetry_sandbox_ops_pos_file().to_string(),
+        ];
+        for path in &cleanup_paths {
+            let _ = std::fs::remove_file(path);
+        }
+        std::fs::write(paths::event_error_flag(), "").unwrap();
+
+        let telemetry_mock = server.mock(|when, then| {
+            when.method(POST).path("/api/webhooks/agent/telemetry");
+            then.status(200)
+                .header("Content-Type", "application/json")
+                .json_body(json!({}));
+        });
+
+        let masker = Arc::new(masker::SecretMasker::from_env());
+        let http = HttpClient::new().unwrap();
+        let telemetry = Telemetry::spawn(masker, http.clone());
+        let failure_message = "CLI failed before all events uploaded";
+        let failure_diagnostic = FailureDiagnostic::new(
+            FailureClass::CliNonzero,
+            AgentFramework::ClaudeCode,
+            PromptMetadata::from_prompt("plain prompt"),
+        )
+        .with_cli_exit_code(1)
+        .with_session_history_status(SessionHistoryStatus::Missing);
+        let exit_code = complete_execution(
+            1,
+            1,
+            Duration::ZERO,
+            CompletionState {
+                last_event_sequence: None,
+                failure_message: Some(failure_message),
+                failure_diagnostic: Some(failure_diagnostic.clone()),
+                skip_recovery_checkpoint_for_no_history: false,
+            },
+            &telemetry,
+            &http,
+        )
+        .await;
+        telemetry.shutdown().await;
+
+        assert_eq!(exit_code, 1);
+        assert_eq!(
+            std::fs::read_to_string(paths::checkpoint_error_file()).unwrap(),
+            failure_message
+        );
+        let diagnostic: FailureDiagnostic =
+            serde_json::from_slice(&std::fs::read(paths::failure_diagnostic_file()).unwrap())
+                .unwrap();
+        assert_eq!(diagnostic, failure_diagnostic);
         telemetry_mock.assert_calls_async(1).await;
 
         for path in cleanup_paths {

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -997,6 +997,171 @@ mod tests {
             .block_on(complete_execution_skips_recovery_checkpoint_for_no_history_inner());
     }
 
+    #[test]
+    fn complete_execution_writes_event_upload_failure_diagnostic() {
+        let _test_state_guard = lock_test_state();
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(complete_execution_writes_event_upload_failure_diagnostic_inner());
+    }
+
+    #[test]
+    fn complete_execution_writes_checkpoint_failure_diagnostic() {
+        let _test_state_guard = lock_test_state();
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(complete_execution_writes_checkpoint_failure_diagnostic_inner());
+    }
+
+    async fn complete_execution_writes_event_upload_failure_diagnostic_inner() {
+        let server = &*COMPLETE_EXECUTION_MOCK_SERVER;
+        server.reset_async().await;
+        unsafe {
+            std::env::set_var("VM0_API_URL", server.base_url());
+            std::env::set_var("VM0_API_TOKEN", "test-token");
+            std::env::set_var("VM0_RUN_ID", "main-recovery-checkpoint");
+            std::env::set_var("VM0_WORKING_DIR", "/tmp/main-recovery-checkpoint");
+            std::env::set_var("VM0_PROMPT", "/event-upload-failure");
+        }
+
+        let cleanup_paths = [
+            paths::session_id_file().to_string(),
+            paths::session_history_path_file().to_string(),
+            paths::checkpoint_error_file().to_string(),
+            paths::failure_diagnostic_file().to_string(),
+            paths::event_error_flag().to_string(),
+            paths::sandbox_ops_file().to_string(),
+            paths::telemetry_system_log_pos_file().to_string(),
+            paths::telemetry_metrics_pos_file().to_string(),
+            paths::telemetry_sandbox_ops_pos_file().to_string(),
+        ];
+        for path in &cleanup_paths {
+            let _ = std::fs::remove_file(path);
+        }
+        std::fs::write(paths::event_error_flag(), "").unwrap();
+
+        let telemetry_mock = server.mock(|when, then| {
+            when.method(POST).path("/api/webhooks/agent/telemetry");
+            then.status(200)
+                .header("Content-Type", "application/json")
+                .json_body(json!({}));
+        });
+
+        let masker = Arc::new(masker::SecretMasker::from_env());
+        let http = HttpClient::new().unwrap();
+        let telemetry = Telemetry::spawn(masker, http.clone());
+        let exit_code = complete_execution(
+            0,
+            0,
+            Duration::ZERO,
+            CompletionState {
+                last_event_sequence: None,
+                failure_message: None,
+                failure_diagnostic: None,
+                skip_recovery_checkpoint_for_no_history: false,
+            },
+            &telemetry,
+            &http,
+        )
+        .await;
+        telemetry.shutdown().await;
+
+        assert_eq!(exit_code, 1);
+        assert_eq!(
+            std::fs::read_to_string(paths::checkpoint_error_file()).unwrap(),
+            "Some events failed to send, marking run as failed"
+        );
+        let diagnostic: FailureDiagnostic =
+            serde_json::from_slice(&std::fs::read(paths::failure_diagnostic_file()).unwrap())
+                .unwrap();
+        assert_eq!(diagnostic.failure_class, FailureClass::EventUploadFailed);
+        assert_eq!(diagnostic.cli_exit_code, Some(0));
+        assert_eq!(
+            diagnostic.session_history_status,
+            SessionHistoryStatus::Missing
+        );
+        telemetry_mock.assert_calls_async(1).await;
+
+        for path in cleanup_paths {
+            let _ = std::fs::remove_file(path);
+        }
+    }
+
+    async fn complete_execution_writes_checkpoint_failure_diagnostic_inner() {
+        let server = &*COMPLETE_EXECUTION_MOCK_SERVER;
+        server.reset_async().await;
+        unsafe {
+            std::env::set_var("VM0_API_URL", server.base_url());
+            std::env::set_var("VM0_API_TOKEN", "test-token");
+            std::env::set_var("VM0_RUN_ID", "main-recovery-checkpoint");
+            std::env::set_var("VM0_WORKING_DIR", "/tmp/main-recovery-checkpoint");
+            std::env::set_var("VM0_PROMPT", "/checkpoint-failure");
+        }
+
+        let cleanup_paths = [
+            paths::session_id_file().to_string(),
+            paths::session_history_path_file().to_string(),
+            paths::checkpoint_error_file().to_string(),
+            paths::failure_diagnostic_file().to_string(),
+            paths::event_error_flag().to_string(),
+            paths::sandbox_ops_file().to_string(),
+            paths::telemetry_system_log_pos_file().to_string(),
+            paths::telemetry_metrics_pos_file().to_string(),
+            paths::telemetry_sandbox_ops_pos_file().to_string(),
+        ];
+        for path in &cleanup_paths {
+            let _ = std::fs::remove_file(path);
+        }
+
+        let telemetry_mock = server.mock(|when, then| {
+            when.method(POST).path("/api/webhooks/agent/telemetry");
+            then.status(200)
+                .header("Content-Type", "application/json")
+                .json_body(json!({}));
+        });
+
+        let masker = Arc::new(masker::SecretMasker::from_env());
+        let http = HttpClient::new().unwrap();
+        let telemetry = Telemetry::spawn(masker, http.clone());
+        let exit_code = complete_execution(
+            0,
+            0,
+            Duration::ZERO,
+            CompletionState {
+                last_event_sequence: None,
+                failure_message: None,
+                failure_diagnostic: None,
+                skip_recovery_checkpoint_for_no_history: false,
+            },
+            &telemetry,
+            &http,
+        )
+        .await;
+        telemetry.shutdown().await;
+
+        assert_eq!(exit_code, 1);
+        let error = std::fs::read_to_string(paths::checkpoint_error_file()).unwrap();
+        assert!(error.contains("Checkpoint failed"), "got: {error}");
+        let diagnostic: FailureDiagnostic =
+            serde_json::from_slice(&std::fs::read(paths::failure_diagnostic_file()).unwrap())
+                .unwrap();
+        assert_eq!(diagnostic.failure_class, FailureClass::CheckpointFailed);
+        assert_eq!(diagnostic.cli_exit_code, Some(0));
+        assert_eq!(
+            diagnostic.session_history_status,
+            SessionHistoryStatus::Missing
+        );
+        telemetry_mock.assert_calls_async(1).await;
+
+        for path in cleanup_paths {
+            let _ = std::fs::remove_file(path);
+        }
+    }
+
     async fn complete_execution_skips_recovery_checkpoint_for_no_history_inner() {
         let server = &*COMPLETE_EXECUTION_MOCK_SERVER;
         server.reset_async().await;

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -14,6 +14,9 @@ use guest_agent::metrics;
 use guest_agent::paths;
 use guest_agent::telemetry::{Telemetry, UploadMode};
 
+use agent_diagnostics::{
+    AgentFramework, FailureClass, FailureDiagnostic, PromptMetadata, SessionHistoryStatus,
+};
 use guest_common::telemetry::record_sandbox_op;
 use guest_common::{log_error, log_info, log_warn};
 use std::io::ErrorKind;
@@ -159,6 +162,9 @@ async fn execute(
         let msg = format!("Working dir setup failed: {e}");
         log_error!(LOG_TAG, "{msg}");
         write_guest_error_file(&msg);
+        write_guest_failure_diagnostic(&base_failure_diagnostic(
+            FailureClass::WorkingDirSetupFailed,
+        ));
         record_sandbox_op("working_dir_setup", wd_start.elapsed(), false, Some(&msg));
         return 1;
     }
@@ -187,49 +193,71 @@ async fn execute(
     log_info!(LOG_TAG, "▷ Execution");
     let cli_start = Instant::now();
     let mut last_event_sequence = None;
-    let (cli_exit_code, exit_code, error_message, skip_recovery_checkpoint_for_no_history) =
-        match cli::execute_cli(masker, heartbeat_handle, http.clone()).await {
-            Ok(cli_result) => {
-                last_event_sequence = cli_result.last_event_sequence;
-                let cli_exit_code = cli_result.exit_code;
-                if cli_exit_code != 0 {
-                    (
+    let (
+        cli_exit_code,
+        exit_code,
+        error_message,
+        skip_recovery_checkpoint_for_no_history,
+        failure_diagnostic,
+    ) = match cli::execute_cli(masker, heartbeat_handle, http.clone()).await {
+        Ok(cli_result) => {
+            last_event_sequence = cli_result.last_event_sequence;
+            let cli_exit_code = cli_result.exit_code;
+            if cli_exit_code != 0 {
+                let diagnostic = cli_result_failure_diagnostic(
+                    FailureClass::CliNonzero,
+                    cli_exit_code,
+                    cli_result.claude_result,
+                );
+                (
+                    cli_exit_code,
+                    cli_exit_code,
+                    cli_failure_message(
                         cli_exit_code,
-                        cli_exit_code,
-                        cli_failure_message(
-                            cli_exit_code,
-                            &cli_result.stderr_lines,
-                            cli_result.failure_diagnostic.as_deref(),
-                        ),
+                        &cli_result.stderr_lines,
+                        cli_result.failure_diagnostic.as_deref(),
+                    ),
+                    false,
+                    Some(diagnostic),
+                )
+            } else if env::has_api()
+                && is_claude_zero_turn_result(env::Framework::from_env(), &cli_result)
+            {
+                let history_check_start = Instant::now();
+                let session_history_status = claude_history_target_status();
+                if session_history_unavailable(session_history_status) {
+                    let msg = "Claude Code emitted a zero-turn result without creating session history; skipping checkpoint";
+                    record_sandbox_op(
+                        "session_history_available",
+                        history_check_start.elapsed(),
                         false,
-                    )
-                } else if env::has_api()
-                    && is_claude_zero_turn_result(env::Framework::from_env(), &cli_result)
-                {
-                    let history_check_start = Instant::now();
-                    if claude_history_target_unavailable() {
-                        let msg = "Claude Code emitted a zero-turn result without creating session history; skipping checkpoint";
-                        record_sandbox_op(
-                            "session_history_available",
-                            history_check_start.elapsed(),
-                            false,
-                            Some(msg),
-                        );
-                        log_info!(LOG_TAG, "{msg}");
-                        (cli_exit_code, 1, msg.to_string(), true)
-                    } else {
-                        (0, 0, String::new(), false)
-                    }
+                        Some(msg),
+                    );
+                    log_info!(LOG_TAG, "{msg}");
+                    let diagnostic = base_failure_diagnostic(FailureClass::ClaudeZeroTurnNoHistory)
+                        .with_cli_exit_code(cli_exit_code)
+                        .with_claude_num_turns(Some(0))
+                        .with_session_history_status(session_history_status);
+                    (cli_exit_code, 1, msg.to_string(), true, Some(diagnostic))
                 } else {
-                    (0, 0, String::new(), false)
+                    (0, 0, String::new(), false, None)
                 }
+            } else {
+                (0, 0, String::new(), false, None)
             }
-            Err(e) => {
-                let msg = e.to_string();
-                log_error!(LOG_TAG, "CLI execution failed: {msg}");
-                (1, 1, msg, false)
-            }
-        };
+        }
+        Err(e) => {
+            let msg = e.to_string();
+            log_error!(LOG_TAG, "CLI execution failed: {msg}");
+            (
+                1,
+                1,
+                msg,
+                false,
+                Some(base_failure_diagnostic(FailureClass::CliExecutionError)),
+            )
+        }
+    };
     let cli_elapsed = cli_start.elapsed();
     record_sandbox_op(
         "cli_execution",
@@ -249,6 +277,7 @@ async fn execute(
         CompletionState {
             last_event_sequence,
             failure_message: (exit_code != 0).then_some(error_message.as_str()),
+            failure_diagnostic,
             skip_recovery_checkpoint_for_no_history,
         },
         telemetry,
@@ -268,24 +297,73 @@ fn is_claude_zero_turn_result(
             .is_some_and(|result| result.num_turns == Some(0))
 }
 
-fn claude_history_target_unavailable() -> bool {
+fn cli_result_failure_diagnostic(
+    failure_class: FailureClass,
+    cli_exit_code: i32,
+    claude_result: Option<cli::ClaudeResultSummary>,
+) -> FailureDiagnostic {
+    let mut diagnostic = base_failure_diagnostic(failure_class)
+        .with_cli_exit_code(cli_exit_code)
+        .with_session_history_status(diagnostic_session_history_status());
+    if let Some(result) = claude_result {
+        diagnostic = diagnostic.with_claude_num_turns(result.num_turns);
+    }
+    diagnostic
+}
+
+fn base_failure_diagnostic(failure_class: FailureClass) -> FailureDiagnostic {
+    FailureDiagnostic::new(
+        failure_class,
+        diagnostic_framework(),
+        PromptMetadata::from_prompt(env::prompt()),
+    )
+}
+
+fn diagnostic_framework() -> AgentFramework {
+    match env::Framework::from_env() {
+        env::Framework::ClaudeCode => AgentFramework::ClaudeCode,
+        env::Framework::Codex => AgentFramework::Codex,
+    }
+}
+
+fn diagnostic_session_history_status() -> SessionHistoryStatus {
+    match env::Framework::from_env() {
+        env::Framework::ClaudeCode => claude_history_target_status(),
+        env::Framework::Codex => SessionHistoryStatus::NotApplicable,
+    }
+}
+
+fn session_history_unavailable(status: SessionHistoryStatus) -> bool {
+    matches!(
+        status,
+        SessionHistoryStatus::Missing | SessionHistoryStatus::Empty
+    )
+}
+
+fn claude_history_target_status() -> SessionHistoryStatus {
     let raw = match std::fs::read_to_string(paths::session_history_path_file()) {
         Ok(raw) => raw,
-        Err(e) if e.kind() == ErrorKind::NotFound => return true,
-        Err(_) => return false,
+        Err(e) if e.kind() == ErrorKind::NotFound => return SessionHistoryStatus::Missing,
+        Err(_) => return SessionHistoryStatus::Unknown,
     };
     let target = raw.trim();
     if target.is_empty() {
-        return true;
+        return SessionHistoryStatus::Missing;
     }
-    history_target_unavailable(Path::new(target))
+    history_target_status(Path::new(target))
 }
 
+#[cfg(test)]
 fn history_target_unavailable(path: &Path) -> bool {
+    session_history_unavailable(history_target_status(path))
+}
+
+fn history_target_status(path: &Path) -> SessionHistoryStatus {
     match path.metadata() {
-        Ok(metadata) => metadata.is_file() && metadata.len() == 0,
-        Err(e) if e.kind() == ErrorKind::NotFound => true,
-        Err(_) => false,
+        Ok(metadata) if metadata.is_file() && metadata.len() == 0 => SessionHistoryStatus::Empty,
+        Ok(_) => SessionHistoryStatus::Present,
+        Err(e) if e.kind() == ErrorKind::NotFound => SessionHistoryStatus::Missing,
+        Err(_) => SessionHistoryStatus::Unknown,
     }
 }
 
@@ -297,6 +375,23 @@ fn write_guest_error_file(message: &str) {
 
     if let Err(e) = std::fs::write(paths::checkpoint_error_file(), message) {
         log_warn!(LOG_TAG, "Failed to write guest error file: {e}");
+    }
+}
+
+fn write_guest_failure_diagnostic(diagnostic: &FailureDiagnostic) {
+    let bytes = match serde_json::to_vec(diagnostic) {
+        Ok(bytes) => bytes,
+        Err(e) => {
+            log_warn!(LOG_TAG, "Failed to serialize guest failure diagnostic: {e}");
+            return;
+        }
+    };
+
+    if let Err(e) = std::fs::write(paths::failure_diagnostic_file(), bytes) {
+        log_warn!(
+            LOG_TAG,
+            "Failed to write guest failure diagnostic file: {e}"
+        );
     }
 }
 
@@ -372,6 +467,7 @@ fn truncate_cli_stderr_line(line: &str) -> std::borrow::Cow<'_, str> {
 struct CompletionState<'a> {
     last_event_sequence: Option<u32>,
     failure_message: Option<&'a str>,
+    failure_diagnostic: Option<FailureDiagnostic>,
     skip_recovery_checkpoint_for_no_history: bool,
 }
 
@@ -389,6 +485,11 @@ async fn complete_execution(
     if let Some(message) = state.failure_message {
         write_guest_error_file(message);
     }
+    let mut wrote_failure_diagnostic = false;
+    if let Some(diagnostic) = &state.failure_diagnostic {
+        write_guest_failure_diagnostic(diagnostic);
+        wrote_failure_diagnostic = true;
+    }
 
     // Check if any events failed to send (before logging execution result)
     if std::path::Path::new(paths::event_error_flag()).exists() {
@@ -396,6 +497,13 @@ async fn complete_execution(
         log_error!(LOG_TAG, "{msg}");
         if !has_failure_message {
             write_guest_error_file(msg);
+        }
+        if !wrote_failure_diagnostic {
+            let diagnostic = base_failure_diagnostic(FailureClass::EventUploadFailed)
+                .with_cli_exit_code(cli_exit_code)
+                .with_session_history_status(diagnostic_session_history_status());
+            write_guest_failure_diagnostic(&diagnostic);
+            wrote_failure_diagnostic = true;
         }
         exit_code = 1;
     }
@@ -464,6 +572,12 @@ async fn complete_execution(
                     cp_start.elapsed().as_secs()
                 );
                 write_guest_error_file(&msg);
+                if !wrote_failure_diagnostic {
+                    let diagnostic = base_failure_diagnostic(FailureClass::CheckpointFailed)
+                        .with_cli_exit_code(cli_exit_code)
+                        .with_session_history_status(diagnostic_session_history_status());
+                    write_guest_failure_diagnostic(&diagnostic);
+                }
                 exit_code = 1;
 
                 // Failure path: don't call /complete from guest. The runner's
@@ -891,10 +1005,12 @@ mod tests {
             std::env::set_var("VM0_API_TOKEN", "test-token");
             std::env::set_var("VM0_RUN_ID", "main-recovery-checkpoint");
             std::env::set_var("VM0_WORKING_DIR", "/tmp/main-recovery-checkpoint");
+            std::env::set_var("VM0_PROMPT", "/help");
         }
 
         let cleanup_paths = [
             paths::checkpoint_error_file().to_string(),
+            paths::failure_diagnostic_file().to_string(),
             paths::event_error_flag().to_string(),
             paths::sandbox_ops_file().to_string(),
             paths::telemetry_system_log_pos_file().to_string(),
@@ -925,6 +1041,14 @@ mod tests {
         let http = HttpClient::new().unwrap();
         let telemetry = Telemetry::spawn(masker, http.clone());
         let failure_message = "Claude Code emitted a zero-turn result without creating session history; skipping checkpoint";
+        let failure_diagnostic = FailureDiagnostic::new(
+            FailureClass::ClaudeZeroTurnNoHistory,
+            AgentFramework::ClaudeCode,
+            PromptMetadata::from_prompt("/help"),
+        )
+        .with_cli_exit_code(0)
+        .with_claude_num_turns(Some(0))
+        .with_session_history_status(SessionHistoryStatus::Missing);
         let exit_code = complete_execution(
             0,
             1,
@@ -932,6 +1056,7 @@ mod tests {
             CompletionState {
                 last_event_sequence: None,
                 failure_message: Some(failure_message),
+                failure_diagnostic: Some(failure_diagnostic.clone()),
                 skip_recovery_checkpoint_for_no_history: true,
             },
             &telemetry,
@@ -945,6 +1070,10 @@ mod tests {
             std::fs::read_to_string(paths::checkpoint_error_file()).unwrap(),
             failure_message
         );
+        let diagnostic: FailureDiagnostic =
+            serde_json::from_slice(&std::fs::read(paths::failure_diagnostic_file()).unwrap())
+                .unwrap();
+        assert_eq!(diagnostic, failure_diagnostic);
         assert_eq!(prepare_mock.calls_async().await, 0);
         assert_eq!(checkpoint_mock.calls_async().await, 0);
 
@@ -961,12 +1090,14 @@ mod tests {
             std::env::set_var("VM0_API_TOKEN", "test-token");
             std::env::set_var("VM0_RUN_ID", "main-recovery-checkpoint");
             std::env::set_var("VM0_WORKING_DIR", "/tmp/main-recovery-checkpoint");
+            std::env::set_var("VM0_PROMPT", "plain prompt");
         }
 
         let cleanup_paths = [
             paths::session_id_file().to_string(),
             paths::session_history_path_file().to_string(),
             paths::checkpoint_error_file().to_string(),
+            paths::failure_diagnostic_file().to_string(),
             paths::event_error_flag().to_string(),
             paths::sandbox_ops_file().to_string(),
             paths::telemetry_system_log_pos_file().to_string(),
@@ -1024,6 +1155,13 @@ mod tests {
         let http = HttpClient::new().unwrap();
         let telemetry = Telemetry::spawn(masker, http.clone());
         let failure_message = "You've hit your usage limit.";
+        let failure_diagnostic = FailureDiagnostic::new(
+            FailureClass::CliNonzero,
+            AgentFramework::ClaudeCode,
+            PromptMetadata::from_prompt("plain prompt"),
+        )
+        .with_cli_exit_code(1)
+        .with_session_history_status(SessionHistoryStatus::Present);
         let exit_code = complete_execution(
             1,
             1,
@@ -1031,6 +1169,7 @@ mod tests {
             CompletionState {
                 last_event_sequence: None,
                 failure_message: Some(failure_message),
+                failure_diagnostic: Some(failure_diagnostic.clone()),
                 skip_recovery_checkpoint_for_no_history: false,
             },
             &telemetry,
@@ -1044,6 +1183,10 @@ mod tests {
             std::fs::read_to_string(paths::checkpoint_error_file()).unwrap(),
             failure_message
         );
+        let diagnostic: FailureDiagnostic =
+            serde_json::from_slice(&std::fs::read(paths::failure_diagnostic_file()).unwrap())
+                .unwrap();
+        assert_eq!(diagnostic, failure_diagnostic);
         prepare_mock.assert_calls_async(1).await;
         upload_mock.assert_calls_async(1).await;
         checkpoint_mock.assert_calls_async(1).await;

--- a/crates/guest-agent/src/paths.rs
+++ b/crates/guest-agent/src/paths.rs
@@ -33,6 +33,8 @@ static EVENT_ERROR_FLAG: LazyLock<String> =
     LazyLock::new(|| format!("/tmp/vm0-event-error-{}", env::run_id()));
 static CHECKPOINT_ERROR_FILE: LazyLock<String> =
     LazyLock::new(|| format!("/tmp/vm0-checkpoint-error-{}", env::run_id()));
+static FAILURE_DIAGNOSTIC_FILE: LazyLock<String> =
+    LazyLock::new(|| agent_diagnostics::failure_diagnostic_file(env::run_id()));
 static SYSTEM_LOG_FILE: LazyLock<String> =
     LazyLock::new(|| format!("/tmp/vm0-system-{}.log", env::run_id()));
 static AGENT_LOG_FILE: LazyLock<String> =
@@ -45,6 +47,9 @@ pub fn event_error_flag() -> &'static str {
 }
 pub fn checkpoint_error_file() -> &'static str {
     &CHECKPOINT_ERROR_FILE
+}
+pub fn failure_diagnostic_file() -> &'static str {
+    &FAILURE_DIAGNOSTIC_FILE
 }
 pub fn system_log_file() -> &'static str {
     &SYSTEM_LOG_FILE

--- a/crates/guest-agent/tests/integration.rs
+++ b/crates/guest-agent/tests/integration.rs
@@ -162,6 +162,7 @@ fn cleanup_session_checkpoint_files() {
     let _ = std::fs::remove_file(guest_agent::paths::session_id_file());
     let _ = std::fs::remove_file(guest_agent::paths::session_history_path_file());
     let _ = std::fs::remove_file(guest_agent::paths::checkpoint_error_file());
+    let _ = std::fs::remove_file(guest_agent::paths::failure_diagnostic_file());
 }
 
 struct SessionCheckpointFilesGuard;

--- a/crates/runner/Cargo.toml
+++ b/crates/runner/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 
 [dependencies]
 ably-subscriber = { workspace = true }
+agent-diagnostics.workspace = true
 api-contracts.workspace = true
 sandbox = { workspace = true }
 nbd-cow = { workspace = true }

--- a/crates/runner/src/cmd/start/job_spawn.rs
+++ b/crates/runner/src/cmd/start/job_spawn.rs
@@ -167,21 +167,23 @@ pub(super) fn spawn_job(
             let (
                 exit_code,
                 err,
+                failure,
                 sandbox,
                 source_ip,
                 network_log_session,
                 guest_session_id,
                 telemetry,
             ) = match inner.await {
-                Ok((outcome, telemetry)) => {
-                    let err = if job_cancel.is_cancelled() {
-                        Some("cancelled by user".to_string())
-                    } else {
-                        outcome.error
-                    };
+                Ok((mut outcome, telemetry)) => {
+                    if job_cancel.is_cancelled() {
+                        outcome.mark_cancelled();
+                    }
+                    let exit_code = outcome.exit_code();
+                    let err = outcome.error().map(ToOwned::to_owned);
                     (
-                        outcome.exit_code,
+                        exit_code,
                         err,
+                        outcome.failure,
                         outcome.sandbox,
                         outcome.source_ip,
                         outcome.network_log_session,
@@ -198,9 +200,15 @@ pub(super) fn spawn_job(
                         run_id,
                         sandbox_token.clone(),
                     );
+                    let failure = executor::ExecutionFailure::from_error(format!(
+                        "executor task panicked: {e}"
+                    ));
+                    let exit_code = failure.exit_code;
+                    let err = Some(failure.error.clone());
                     (
-                        1,
-                        Some(format!("executor task panicked: {e}")),
+                        exit_code,
+                        err,
+                        Some(failure),
                         None,
                         String::new(),
                         None,
@@ -211,14 +219,32 @@ pub(super) fn spawn_job(
             };
 
             // Single sink for any claimed job's terminal state. Cancellation gets
-            // its own info marker; everything else with `err` set is a failure
-            // (panics, executor internal errors, non-zero exits with
-            // stderr/guest error file); otherwise the job finished normally.
+            // its own info marker; every other failure is represented by a
+            // single object carrying the exit code, error, and optional
+            // guest-authored diagnostic.
             let cancelled_for_log = job_cancel.is_cancelled();
-            match (cancelled_for_log, err.as_deref()) {
+            match (cancelled_for_log, failure.as_ref()) {
                 (true, _) => info!(run_id = %run_id, exit_code, reused, "job cancelled"),
-                (false, Some(e)) => {
-                    error!(run_id = %run_id, exit_code, reused, error = %e, "job execution failed");
+                (false, Some(failure)) => {
+                    if let Some(diagnostic) = failure.diagnostic.as_ref() {
+                        error!(
+                            run_id = %run_id,
+                            exit_code,
+                            reused,
+                            error = %failure.error,
+                            failure_class = diagnostic.failure_class.as_str(),
+                            failure_framework = diagnostic.framework.as_str(),
+                            failure_cli_exit_code = diagnostic.cli_exit_code,
+                            failure_claude_num_turns = diagnostic.claude_num_turns,
+                            session_history_status = diagnostic.session_history_status.as_str(),
+                            prompt_shape = diagnostic.prompt_shape.as_str(),
+                            prompt_bytes = diagnostic.prompt_bytes,
+                            first_line_bytes = diagnostic.first_line_bytes,
+                            "job execution failed"
+                        );
+                    } else {
+                        error!(run_id = %run_id, exit_code, reused, error = %failure.error, "job execution failed");
+                    }
                 }
                 (false, None) => info!(run_id = %run_id, exit_code, reused, "job finished"),
             }

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -2810,6 +2810,32 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn read_guest_failure_diagnostic_file_returns_none_on_unsupported_schema() {
+        let sandbox = MockSandbox::new("test");
+        let mut diagnostic = FailureDiagnostic::new(
+            agent_diagnostics::FailureClass::CliNonzero,
+            agent_diagnostics::AgentFramework::ClaudeCode,
+            agent_diagnostics::PromptMetadata::from_prompt("/help"),
+        );
+        diagnostic.schema_version = FAILURE_DIAGNOSTIC_SCHEMA_VERSION + 1;
+        sandbox.push_read_file_result(Ok(Some(serde_json::to_vec(&diagnostic).unwrap())));
+
+        let diagnostic = read_guest_failure_diagnostic_file(&sandbox, RunId::nil()).await;
+
+        assert!(diagnostic.is_none());
+    }
+
+    #[tokio::test]
+    async fn read_guest_failure_diagnostic_file_returns_none_on_read_error() {
+        let sandbox = MockSandbox::new("test");
+        sandbox.push_read_file_result(Err(sandbox_exec_error("vsock timeout")));
+
+        let diagnostic = read_guest_failure_diagnostic_file(&sandbox, RunId::nil()).await;
+
+        assert!(diagnostic.is_none());
+    }
+
+    #[tokio::test]
     async fn read_guest_failure_diagnostic_file_returns_none_on_oversized_content() {
         let sandbox = MockSandbox::new("test");
         sandbox.push_read_file_result(Ok(Some(vec![

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -18,6 +18,9 @@ use std::collections::HashMap;
 use std::panic::AssertUnwindSafe;
 use std::time::{Duration, Instant};
 
+use agent_diagnostics::{
+    FAILURE_DIAGNOSTIC_SCHEMA_VERSION, FailureDiagnostic, failure_diagnostic_file,
+};
 use futures_util::FutureExt;
 use sandbox::{
     CopyFileOptions, EXEC_OUTPUT_LIMIT_1_MIB, EXEC_OUTPUT_LIMIT_64_KIB, ExecRequest, Sandbox,
@@ -75,8 +78,7 @@ pub struct JobParams {
 
 /// Outcome of a job execution, including the sandbox for possible reuse.
 pub struct ExecuteOutcome {
-    pub exit_code: i32,
-    pub error: Option<String>,
+    pub failure: Option<ExecutionFailure>,
     /// The sandbox after execution. `Some` when the sandbox is still alive
     /// and eligible for keep-alive parking. `None` when execution failed
     /// during create/start (sandbox was destroyed inline).
@@ -86,6 +88,95 @@ pub struct ExecuteOutcome {
     /// CLI-generated session ID read from the guest after execution.
     /// Used for first-run VM parking when `resume_session` is absent.
     pub guest_session_id: Option<String>,
+}
+
+impl ExecuteOutcome {
+    #[must_use]
+    pub fn exit_code(&self) -> i32 {
+        self.failure.as_ref().map_or(0, |failure| failure.exit_code)
+    }
+
+    #[must_use]
+    pub fn error(&self) -> Option<&str> {
+        self.failure.as_ref().map(|failure| failure.error.as_str())
+    }
+
+    pub fn mark_cancelled(&mut self) {
+        self.failure = Some(ExecutionFailure::cancelled());
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExecutionFailure {
+    pub exit_code: i32,
+    pub error: String,
+    pub diagnostic: Option<FailureDiagnostic>,
+}
+
+impl ExecutionFailure {
+    #[must_use]
+    pub fn new(
+        exit_code: i32,
+        error: impl Into<String>,
+        diagnostic: Option<FailureDiagnostic>,
+    ) -> Self {
+        let error = non_empty_failure_error(exit_code, error.into());
+        Self {
+            exit_code,
+            error,
+            diagnostic,
+        }
+    }
+
+    #[must_use]
+    pub fn from_error(error: impl Into<String>) -> Self {
+        Self::new(1, error, None)
+    }
+
+    #[must_use]
+    pub fn cancelled() -> Self {
+        Self::new(EXIT_SIGKILL, "cancelled by user", None)
+    }
+}
+
+struct AgentExecutionResult {
+    failure: Option<ExecutionFailure>,
+}
+
+impl AgentExecutionResult {
+    fn success() -> Self {
+        Self { failure: None }
+    }
+
+    fn failure(
+        exit_code: i32,
+        error: impl Into<String>,
+        diagnostic: Option<FailureDiagnostic>,
+    ) -> Self {
+        Self {
+            failure: Some(ExecutionFailure::new(exit_code, error, diagnostic)),
+        }
+    }
+
+    fn failure_from_error(error: impl Into<String>) -> Self {
+        Self::failure(1, error, None)
+    }
+
+    fn exit_code(&self) -> i32 {
+        self.failure.as_ref().map_or(0, |failure| failure.exit_code)
+    }
+}
+
+fn non_empty_failure_error(exit_code: i32, error: String) -> String {
+    if error.trim().is_empty() {
+        agent_exit_failure_message(exit_code)
+    } else {
+        error
+    }
+}
+
+fn agent_exit_failure_message(exit_code: i32) -> String {
+    format!("Agent exited with code {exit_code}")
 }
 
 /// Execute a single job inside a **new** Firecracker VM.
@@ -124,8 +215,7 @@ pub async fn execute_job(
     {
         Ok(outcome) => outcome,
         Err(e) => ExecuteOutcome {
-            exit_code: 1,
-            error: Some(e.to_string()),
+            failure: Some(ExecutionFailure::from_error(e.to_string())),
             sandbox: None,
             source_ip: String::new(),
             network_log_session: None,
@@ -282,21 +372,28 @@ async fn execute_new_sandbox(
             prev_storage: None,
         },
         telemetry,
-        cancel,
+        cancel.clone(),
     )
     .await;
 
     // Post-job: copy logs + unregister proxy registry (sandbox stays alive for possible reuse)
-    post_job_cleanup(sandbox.as_ref(), config, context, &source_ip).await;
+    post_job_cleanup(
+        sandbox.as_ref(),
+        config,
+        context,
+        &source_ip,
+        cancel.is_cancelled(),
+    )
+    .await;
 
-    let (exit_code, error) = match result {
-        Ok((code, err)) => (code, err),
-        Err(e) => (1, Some(e.to_string())),
+    let agent_result = match result {
+        Ok(result) => result,
+        Err(e) => AgentExecutionResult::failure_from_error(e.to_string()),
     };
 
     // Read CLI-generated session ID for first-run parking.
     // Only needed when resume_session is absent (first turn in a conversation).
-    let guest_session_id = if exit_code == 0 && context.session_id().is_none() {
+    let guest_session_id = if agent_result.exit_code() == 0 && context.session_id().is_none() {
         let id = read_guest_session_id(sandbox.as_ref(), context.run_id).await;
         if let Some(ref sid) = id {
             info!(run_id = %context.run_id, session_id = %sid, "read guest session ID for parking");
@@ -307,8 +404,7 @@ async fn execute_new_sandbox(
     };
 
     Ok(ExecuteOutcome {
-        exit_code,
-        error,
+        failure: agent_result.failure,
         sandbox: Some(sandbox),
         source_ip,
         network_log_session: Some(network_log_session),
@@ -358,20 +454,27 @@ async fn execute_reused_sandbox(
             prev_storage: Some(prev_storage),
         },
         telemetry,
-        cancel,
+        cancel.clone(),
     )
     .await;
 
     // Post-job cleanup (copy logs to host, unregister proxy registry)
-    post_job_cleanup(sandbox.as_ref(), config, context, source_ip).await;
+    post_job_cleanup(
+        sandbox.as_ref(),
+        config,
+        context,
+        source_ip,
+        cancel.is_cancelled(),
+    )
+    .await;
 
-    let (exit_code, error) = match result {
-        Ok((code, err)) => (code, err),
-        Err(e) => (1, Some(e.to_string())),
+    let agent_result = match result {
+        Ok(result) => result,
+        Err(e) => AgentExecutionResult::failure_from_error(e.to_string()),
     };
 
     // Read CLI-generated session ID for first-run parking.
-    let guest_session_id = if exit_code == 0 && context.session_id().is_none() {
+    let guest_session_id = if agent_result.exit_code() == 0 && context.session_id().is_none() {
         let id = read_guest_session_id(sandbox.as_ref(), context.run_id).await;
         if let Some(ref sid) = id {
             info!(run_id = %context.run_id, session_id = %sid, "read guest session ID for parking");
@@ -382,8 +485,7 @@ async fn execute_reused_sandbox(
     };
 
     ExecuteOutcome {
-        exit_code,
-        error,
+        failure: agent_result.failure,
         sandbox: Some(sandbox),
         source_ip: source_ip.to_string(),
         network_log_session: Some(network_log_session),
@@ -448,8 +550,9 @@ async fn post_job_cleanup(
     config: &ExecutorConfig,
     context: &ExecutionContext,
     source_ip: &str,
+    cancelled: bool,
 ) {
-    copy_guest_logs(sandbox, context, &config.log_paths).await;
+    copy_guest_logs(sandbox, context, &config.log_paths, cancelled).await;
     unregister_proxy_registry(config, context, source_ip).await;
 }
 
@@ -470,7 +573,7 @@ async fn run_in_sandbox(
     start: RunStart<'_>,
     telemetry: &mut JobTelemetry,
     cancel: CancellationToken,
-) -> RunnerResult<(i32, Option<String>)> {
+) -> RunnerResult<AgentExecutionResult> {
     // 1. Fix guest clock and reseed entropy (must happen before HTTPS calls).
     //    Needed after snapshot restore (frozen clock) and after idle reuse (drifted clock).
     if start.restore_guest_state {
@@ -627,13 +730,12 @@ async fn run_in_sandbox(
                 && check_host_oom(pid).await
             {
                 warn!(run_id = %context.run_id, pid, "host OOM kill detected for firecracker");
-                return Ok((
+                return Ok(AgentExecutionResult::failure(
                     1,
-                    Some(
-                        "Firecracker VM killed by host OOM killer \
+                    "Firecracker VM killed by host OOM killer \
                          (cgroup memory limit exceeded)"
-                            .into(),
-                    ),
+                        .to_string(),
+                    None,
                 ));
             }
             return Err(e.into());
@@ -664,7 +766,11 @@ async fn run_in_sandbox(
                 warn!(run_id = %context.run_id, "OOM kill detected via dmesg");
                 // Return exit code 1 with descriptive message instead of raw 137,
                 // so callers see a clear error rather than an opaque signal code.
-                return Ok((1, Some("Agent process killed by OOM killer".into())));
+                return Ok(AgentExecutionResult::failure(
+                    1,
+                    "Agent process killed by OOM killer",
+                    None,
+                ));
             }
             Err(e) => {
                 warn!(run_id = %context.run_id, error = %e, "failed to exec dmesg for OOM check");
@@ -673,25 +779,37 @@ async fn run_in_sandbox(
         }
     }
 
-    let error_msg = if cancel.is_cancelled() {
-        // Skip guest file reads — sandbox hasn't been stopped yet and the
-        // caller will override with "cancelled by user" anyway.
-        None
+    let failure = if cancel.is_cancelled() {
+        // Skip guest file reads — sandbox hasn't been stopped yet.
+        Some(ExecutionFailure::cancelled())
     } else if exit.exit_code != 0 {
         let stderr = String::from_utf8_lossy(&exit.stderr).to_string();
-        if !stderr.is_empty() {
-            Some(stderr)
+        let failure_diagnostic = read_guest_failure_diagnostic_file(sandbox, context.run_id).await;
+        let error = if !stderr.is_empty() {
+            stderr
         } else {
             // Stderr is empty (redirected to log file). Check for a structured
             // error file written by the guest-agent for final failure
             // handoff.
-            read_guest_error_file(sandbox, context.run_id).await
-        }
+            read_guest_error_file(sandbox, context.run_id)
+                .await
+                .unwrap_or_else(|| agent_exit_failure_message(exit.exit_code))
+        };
+        Some(ExecutionFailure::new(
+            exit.exit_code,
+            error,
+            failure_diagnostic,
+        ))
     } else {
         None
     };
 
-    Ok((exit.exit_code, error_msg))
+    Ok(match failure {
+        Some(failure) => AgentExecutionResult {
+            failure: Some(failure),
+        },
+        None => AgentExecutionResult::success(),
+    })
 }
 
 /// Read a structured error file from the guest filesystem.
@@ -715,6 +833,45 @@ async fn read_guest_error_file(sandbox: &dyn Sandbox, run_id: RunId) -> Option<S
             Some(msg).filter(|s| !s.is_empty())
         }
         _ => None,
+    }
+}
+
+/// Read structured guest failure diagnostics from the guest filesystem.
+///
+/// Diagnostics are optional and best-effort. They must never change the
+/// user-visible completion error or mask the original exit status.
+async fn read_guest_failure_diagnostic_file(
+    sandbox: &dyn Sandbox,
+    run_id: RunId,
+) -> Option<FailureDiagnostic> {
+    let path = failure_diagnostic_file(&run_id.to_string());
+    match sandbox.read_file(&path, SMALL_GUEST_FILE_MAX_BYTES).await {
+        Ok(Some(bytes)) if !bytes.iter().all(|byte| byte.is_ascii_whitespace()) => {
+            match serde_json::from_slice::<FailureDiagnostic>(&bytes) {
+                Ok(diagnostic)
+                    if diagnostic.schema_version == FAILURE_DIAGNOSTIC_SCHEMA_VERSION =>
+                {
+                    Some(diagnostic)
+                }
+                Ok(diagnostic) => {
+                    warn!(
+                        run_id = %run_id,
+                        schema_version = diagnostic.schema_version,
+                        "ignoring guest failure diagnostic with unsupported schema version"
+                    );
+                    None
+                }
+                Err(e) => {
+                    warn!(run_id = %run_id, error = %e, "failed to parse guest failure diagnostic");
+                    None
+                }
+            }
+        }
+        Ok(_) => None,
+        Err(e) => {
+            warn!(run_id = %run_id, error = %e, "failed to read guest failure diagnostic");
+            None
+        }
     }
 }
 
@@ -841,7 +998,26 @@ const GUEST_SANDBOX_OPS_LOG_SUFFIX: &str = ".jsonl";
 /// including setup output written before agent streaming starts. Agent stdout
 /// that is not written by guest-agent's logger is intentionally not part of
 /// the final system log.
-async fn copy_guest_logs(sandbox: &dyn Sandbox, context: &ExecutionContext, log_paths: &LogPaths) {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum GuestLogCopyFailureKind {
+    Failed,
+    SkippedAfterCancellation,
+}
+
+fn guest_log_copy_failure_kind(cancelled: bool) -> GuestLogCopyFailureKind {
+    if cancelled {
+        GuestLogCopyFailureKind::SkippedAfterCancellation
+    } else {
+        GuestLogCopyFailureKind::Failed
+    }
+}
+
+async fn copy_guest_logs(
+    sandbox: &dyn Sandbox,
+    context: &ExecutionContext,
+    log_paths: &LogPaths,
+    cancelled: bool,
+) {
     let run_id = context.run_id;
     let files = [
         (
@@ -871,7 +1047,14 @@ async fn copy_guest_logs(sandbox: &dyn Sandbox, context: &ExecutionContext, log_
             )
             .await
         {
-            warn!(run_id = %run_id, error = %e, guest_path = %guest_path, host_path = %host_path.display(), "failed to copy guest log");
+            match guest_log_copy_failure_kind(cancelled) {
+                GuestLogCopyFailureKind::SkippedAfterCancellation => {
+                    info!(run_id = %run_id, error = %e, guest_path = %guest_path, host_path = %host_path.display(), "guest log copy skipped after cancellation");
+                }
+                GuestLogCopyFailureKind::Failed => {
+                    warn!(run_id = %run_id, error = %e, guest_path = %guest_path, host_path = %host_path.display(), "failed to copy guest log");
+                }
+            }
         }
     }
 }
@@ -2568,6 +2751,73 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn read_guest_failure_diagnostic_file_returns_valid_diagnostic() {
+        let sandbox = MockSandbox::new("test");
+        let diagnostic = FailureDiagnostic::new(
+            agent_diagnostics::FailureClass::CliNonzero,
+            agent_diagnostics::AgentFramework::ClaudeCode,
+            agent_diagnostics::PromptMetadata::from_prompt("/help"),
+        )
+        .with_cli_exit_code(1)
+        .with_session_history_status(agent_diagnostics::SessionHistoryStatus::Present);
+        sandbox.push_read_file_result(Ok(Some(serde_json::to_vec(&diagnostic).unwrap())));
+
+        let read = read_guest_failure_diagnostic_file(&sandbox, RunId::nil()).await;
+
+        assert_eq!(read, Some(diagnostic));
+        let calls = sandbox.read_file_calls();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(
+            calls[0].path,
+            agent_diagnostics::failure_diagnostic_file(&RunId::nil().to_string())
+        );
+        assert_eq!(calls[0].max_bytes, SMALL_GUEST_FILE_MAX_BYTES);
+    }
+
+    #[tokio::test]
+    async fn read_guest_failure_diagnostic_file_returns_none_on_missing_file() {
+        let sandbox = MockSandbox::new("test");
+        sandbox.push_read_file_result(Ok(None));
+
+        let diagnostic = read_guest_failure_diagnostic_file(&sandbox, RunId::nil()).await;
+
+        assert!(diagnostic.is_none());
+    }
+
+    #[tokio::test]
+    async fn read_guest_failure_diagnostic_file_returns_none_on_empty_content() {
+        let sandbox = MockSandbox::new("test");
+        sandbox.push_read_file_result(Ok(Some(b" \n\t".to_vec())));
+
+        let diagnostic = read_guest_failure_diagnostic_file(&sandbox, RunId::nil()).await;
+
+        assert!(diagnostic.is_none());
+    }
+
+    #[tokio::test]
+    async fn read_guest_failure_diagnostic_file_returns_none_on_malformed_json() {
+        let sandbox = MockSandbox::new("test");
+        sandbox.push_read_file_result(Ok(Some(b"{not-json".to_vec())));
+
+        let diagnostic = read_guest_failure_diagnostic_file(&sandbox, RunId::nil()).await;
+
+        assert!(diagnostic.is_none());
+    }
+
+    #[tokio::test]
+    async fn read_guest_failure_diagnostic_file_returns_none_on_oversized_content() {
+        let sandbox = MockSandbox::new("test");
+        sandbox.push_read_file_result(Ok(Some(vec![
+            b' ';
+            SMALL_GUEST_FILE_MAX_BYTES as usize + 1
+        ])));
+
+        let diagnostic = read_guest_failure_diagnostic_file(&sandbox, RunId::nil()).await;
+
+        assert!(diagnostic.is_none());
+    }
+
+    #[tokio::test]
     async fn download_storages_success() {
         let sandbox = MockSandbox::new("test");
         // write_file succeeds by default, exec returns exit 0 by default.
@@ -2746,6 +2996,18 @@ mod tests {
     // copy_guest_logs tests
     // -----------------------------------------------------------------------
 
+    #[test]
+    fn guest_log_copy_failure_kind_tracks_cancellation() {
+        assert_eq!(
+            guest_log_copy_failure_kind(false),
+            GuestLogCopyFailureKind::Failed
+        );
+        assert_eq!(
+            guest_log_copy_failure_kind(true),
+            GuestLogCopyFailureKind::SkippedAfterCancellation
+        );
+    }
+
     #[tokio::test]
     async fn copy_guest_logs_writes_files_to_host() {
         let dir = tempfile::tempdir().unwrap();
@@ -2768,7 +3030,7 @@ mod tests {
                 .to_vec(),
         ));
 
-        copy_guest_logs(&sandbox, &ctx, &log_paths).await;
+        copy_guest_logs(&sandbox, &ctx, &log_paths, false).await;
 
         let system_log = tokio::fs::read_to_string(log_paths.system_log(ctx.run_id))
             .await
@@ -2808,7 +3070,7 @@ mod tests {
         sandbox.push_copy_file_result(Ok(b"system log\n".to_vec()));
         sandbox.push_copy_file_result(Ok(b"{\"cpu\":0.5}\n".to_vec()));
 
-        copy_guest_logs(&sandbox, &ctx, &log_paths).await;
+        copy_guest_logs(&sandbox, &ctx, &log_paths, false).await;
 
         let system_log = tokio::fs::read_to_string(log_paths.system_log(ctx.run_id))
             .await
@@ -2841,7 +3103,7 @@ mod tests {
         sandbox.push_copy_file_result(Err(sandbox_exec_error("No such file")));
         sandbox.push_copy_file_result(Err(sandbox_exec_error("No such file")));
 
-        copy_guest_logs(&sandbox, &ctx, &log_paths).await;
+        copy_guest_logs(&sandbox, &ctx, &log_paths, false).await;
 
         // Host files should not be created
         assert!(!log_paths.system_log(ctx.run_id).exists());
@@ -2860,7 +3122,7 @@ mod tests {
         sandbox.push_copy_file_result(Err(sandbox_exec_error("vsock down")));
         sandbox.push_copy_file_result(Err(sandbox_exec_error("vsock down")));
 
-        copy_guest_logs(&sandbox, &ctx, &log_paths).await;
+        copy_guest_logs(&sandbox, &ctx, &log_paths, false).await;
 
         assert!(!log_paths.system_log(ctx.run_id).exists());
         assert!(!log_paths.metrics_log(ctx.run_id).exists());
@@ -3049,7 +3311,7 @@ mod tests {
             cancel,
         )
         .await?;
-        Ok((outcome.exit_code, outcome.error))
+        Ok((outcome.exit_code(), outcome.error().map(ToOwned::to_owned)))
     }
 
     #[tokio::test]
@@ -3178,6 +3440,22 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn execute_inner_nonzero_without_guest_error_returns_failure_message() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_executor_config(dir.path()).await;
+        let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::with_wait_exit_code(7));
+        let factory = sandbox_mock::MockSandboxFactory::with_overrides(overrides);
+
+        let (exit_code, error) =
+            run_execute_inner(&factory, &minimal_context(), &config, &default_params())
+                .await
+                .unwrap();
+
+        assert_eq!(exit_code, 7);
+        assert_eq!(error.as_deref(), Some("Agent exited with code 7"));
+    }
+
+    #[tokio::test]
     async fn execute_inner_start_failure_destroy_panic_returns_start_error() {
         let dir = tempfile::tempdir().unwrap();
         let config = test_executor_config(dir.path()).await;
@@ -3230,8 +3508,8 @@ mod tests {
             cancel,
         )
         .await;
-        assert_eq!(outcome.exit_code, 0);
-        assert!(outcome.error.is_none());
+        assert_eq!(outcome.exit_code(), 0);
+        assert!(outcome.error().is_none());
         assert!(outcome.sandbox.is_some());
     }
 
@@ -3255,8 +3533,8 @@ mod tests {
             cancel,
         )
         .await;
-        assert_eq!(outcome.exit_code, 1);
-        assert!(outcome.error.unwrap().contains("boom"));
+        assert_eq!(outcome.exit_code(), 1);
+        assert!(outcome.error().unwrap().contains("boom"));
         assert!(outcome.sandbox.is_none());
     }
 
@@ -3284,7 +3562,7 @@ mod tests {
             cancel,
         )
         .await;
-        assert_eq!(outcome.exit_code, 0);
+        assert_eq!(outcome.exit_code(), 0);
         let sandbox = outcome.sandbox.expect("sandbox should be alive");
 
         // Reuse the sandbox for a second turn
@@ -3293,8 +3571,8 @@ mod tests {
         let cancel = tokio_util::sync::CancellationToken::new();
         let (reuse_outcome, _telemetry) =
             execute_job_reuse(idle_sandbox, minimal_context(), &config, cancel).await;
-        assert_eq!(reuse_outcome.exit_code, 0);
-        assert!(reuse_outcome.error.is_none());
+        assert_eq!(reuse_outcome.exit_code(), 0);
+        assert!(reuse_outcome.error().is_none());
         assert!(reuse_outcome.sandbox.is_some());
     }
 
@@ -3325,7 +3603,7 @@ mod tests {
             cancel,
         )
         .await;
-        assert_eq!(outcome.exit_code, 0);
+        assert_eq!(outcome.exit_code(), 0);
         let sandbox = outcome.sandbox.expect("sandbox should be alive");
 
         // Second turn: reuse with new session history
@@ -3343,7 +3621,7 @@ mod tests {
             make_reusable_idle_sandbox(sandbox, outcome.source_ip, "test-session").await;
         let (reuse_outcome, _telemetry) =
             execute_job_reuse(idle_sandbox, ctx2, &config, cancel).await;
-        assert_eq!(reuse_outcome.exit_code, 0);
+        assert_eq!(reuse_outcome.exit_code(), 0);
         assert!(reuse_outcome.sandbox.is_some());
     }
 
@@ -3372,7 +3650,7 @@ mod tests {
             cancel,
         )
         .await;
-        assert_eq!(outcome.exit_code, 0);
+        assert_eq!(outcome.exit_code(), 0);
         let sandbox = outcome.sandbox.expect("sandbox alive");
 
         // Park in idle pool
@@ -3416,7 +3694,7 @@ mod tests {
         };
         let (reuse_outcome, _telemetry) =
             execute_job_reuse(idle_sandbox, minimal_context(), &config, cancel).await;
-        assert_eq!(reuse_outcome.exit_code, 0);
+        assert_eq!(reuse_outcome.exit_code(), 0);
         assert!(reuse_outcome.sandbox.is_some());
     }
 
@@ -3470,8 +3748,8 @@ mod tests {
         let (outcome, _telemetry) =
             execute_job_reuse(idle_sandbox, minimal_context(), &config, cancel).await;
 
-        assert_eq!(outcome.exit_code, 1);
-        assert!(outcome.error.unwrap().contains("vsock broken"));
+        assert_eq!(outcome.exit_code(), 1);
+        assert!(outcome.error().unwrap().contains("vsock broken"));
         // Critical: sandbox must be returned so caller can stop + destroy it
         assert!(
             outcome.sandbox.is_some(),
@@ -3495,8 +3773,8 @@ mod tests {
         let (outcome, _telemetry) =
             execute_job_reuse(idle_sandbox, minimal_context(), &config, cancel).await;
 
-        assert_eq!(outcome.exit_code, 1);
-        assert!(outcome.error.unwrap().contains("reseed timeout"));
+        assert_eq!(outcome.exit_code(), 1);
+        assert!(outcome.error().unwrap().contains("reseed timeout"));
         assert!(
             outcome.sandbox.is_some(),
             "sandbox must be returned on reseed failure"
@@ -3525,8 +3803,8 @@ mod tests {
             make_reusable_idle_sandbox(Box::new(sandbox), "10.0.0.1".into(), "sess-abc").await;
         let (outcome, _telemetry) = execute_job_reuse(idle_sandbox, ctx, &config, cancel).await;
 
-        assert_eq!(outcome.exit_code, 1);
-        assert!(outcome.error.unwrap().contains("disk full"));
+        assert_eq!(outcome.exit_code(), 1);
+        assert!(outcome.error().unwrap().contains("disk full"));
         assert!(
             outcome.sandbox.is_some(),
             "sandbox must be returned on session restore failure"

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -718,9 +718,6 @@ async fn run_in_sandbox(
             warn!(run_id = %context.run_id, error = %e, "stdout stream task failed");
         }
     }
-    let success = result.as_ref().is_ok_and(|exit| exit.exit_code == 0);
-    let err = result.as_ref().err().map(|e| e.to_string());
-    telemetry.record("agent_execute", t.elapsed(), success, err.as_deref());
     let exit = match result {
         Ok(exit) => exit,
         Err(e) => {
@@ -730,14 +727,14 @@ async fn run_in_sandbox(
                 && check_host_oom(pid).await
             {
                 warn!(run_id = %context.run_id, pid, "host OOM kill detected for firecracker");
-                return Ok(AgentExecutionResult::failure(
-                    1,
-                    "Firecracker VM killed by host OOM killer \
-                         (cgroup memory limit exceeded)"
-                        .to_string(),
-                    None,
-                ));
+                let error = "Firecracker VM killed by host OOM killer \
+                             (cgroup memory limit exceeded)"
+                    .to_string();
+                telemetry.record("agent_execute", t.elapsed(), false, Some(&error));
+                return Ok(AgentExecutionResult::failure(1, error, None));
             }
+            let error = e.to_string();
+            telemetry.record("agent_execute", t.elapsed(), false, Some(&error));
             return Err(e.into());
         }
     };
@@ -766,11 +763,9 @@ async fn run_in_sandbox(
                 warn!(run_id = %context.run_id, "OOM kill detected via dmesg");
                 // Return exit code 1 with descriptive message instead of raw 137,
                 // so callers see a clear error rather than an opaque signal code.
-                return Ok(AgentExecutionResult::failure(
-                    1,
-                    "Agent process killed by OOM killer",
-                    None,
-                ));
+                let error = "Agent process killed by OOM killer";
+                telemetry.record("agent_execute", t.elapsed(), false, Some(error));
+                return Ok(AgentExecutionResult::failure(1, error, None));
             }
             Err(e) => {
                 warn!(run_id = %context.run_id, error = %e, "failed to exec dmesg for OOM check");
@@ -804,12 +799,22 @@ async fn run_in_sandbox(
         None
     };
 
-    Ok(match failure {
+    let agent_result = match failure {
         Some(failure) => AgentExecutionResult {
             failure: Some(failure),
         },
         None => AgentExecutionResult::success(),
-    })
+    };
+    telemetry.record(
+        "agent_execute",
+        t.elapsed(),
+        agent_result.failure.is_none(),
+        agent_result
+            .failure
+            .as_ref()
+            .map(|failure| failure.error.as_str()),
+    );
+    Ok(agent_result)
 }
 
 /// Read a structured error file from the guest filesystem.
@@ -3453,6 +3458,41 @@ mod tests {
 
         assert_eq!(exit_code, 7);
         assert_eq!(error.as_deref(), Some("Agent exited with code 7"));
+    }
+
+    #[tokio::test]
+    async fn execute_inner_nonzero_records_agent_execute_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_executor_config(dir.path()).await;
+        let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::with_wait_exit_code(7));
+        let factory = sandbox_mock::MockSandboxFactory::with_overrides(overrides);
+        let ctx = minimal_context();
+        let mut telemetry = test_telemetry(&config, &ctx);
+        let cancel = tokio_util::sync::CancellationToken::new();
+
+        let outcome = execute_new_sandbox(
+            &factory,
+            &ctx,
+            NewSandboxDispatch {
+                id: SandboxId::new_v4(),
+                reuse_result: SandboxReuseResult::PoolMiss,
+            },
+            &config,
+            &default_params(),
+            &mut telemetry,
+            cancel,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(outcome.exit_code(), 7);
+        let ops = telemetry.pending_ops_snapshot();
+        let agent_execute = ops
+            .iter()
+            .find(|op| op.0 == "agent_execute")
+            .expect("agent_execute telemetry should be recorded");
+        assert!(!agent_execute.1);
+        assert_eq!(agent_execute.2.as_deref(), Some("Agent exited with code 7"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- add a shared `agent-diagnostics` crate for guest-authored failure diagnostics
- have guest-agent write structured failure metadata for CLI, checkpoint, event upload, and zero-turn/no-history failures
- have runner read diagnostics best-effort and log structured failure fields from a unified `ExecutionFailure`

## Testing
- `cargo fmt --manifest-path crates/Cargo.toml --all`
- `cargo test --manifest-path crates/Cargo.toml -p agent-diagnostics`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent`
- `cargo test --manifest-path crates/Cargo.toml -p runner`
- pre-commit: `cargo-fmt`, `cargo-clippy`, `cargo-doc`

Part of #13847
