### PR TITLE
feat: add fal image-to-image generation

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-image-io-generate.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-image-io-generate.test.ts
@@ -56,6 +56,14 @@ const FAL_GPT_MINI_MEDIA_URL =
   "https://fal.media/files/test/gpt-image-1-mini.jpg";
 const FAL_QWEN_IMAGE_URL = "https://queue.fal.run/fal-ai/qwen-image";
 const FAL_MEDIA_URL = "https://fal.media/files/test/qwen.jpg";
+const FAL_FLUX_REDUX_URL = "https://queue.fal.run/fal-ai/flux-pro/v1.1/redux";
+const FAL_FLUX_MEDIA_URL = "https://fal.media/files/test/flux-redux.jpg";
+const MOCKUP_IMAGE_URL = "https://example.com/mockup.png";
+const IMAGE_PRICING_MARKUP_MULTIPLIER = 1.2;
+const FAL_FLUX_PROVIDER_CREDITS_PER_MEGAPIXEL = 40;
+const FAL_FLUX_MARKED_UP_CREDITS_PER_MEGAPIXEL = Math.ceil(
+  FAL_FLUX_PROVIDER_CREDITS_PER_MEGAPIXEL * IMAGE_PRICING_MARKUP_MULTIPLIER,
+);
 const MISSING_PRICING_IMAGE_MODEL = "gpt-image-2";
 const IMAGE_PRICING_CATEGORIES = [
   "output_image.low.standard",
@@ -324,6 +332,27 @@ async function upsertFalImagePricing(): Promise<void> {
       target: [usagePricing.kind, usagePricing.provider, usagePricing.category],
       set: {
         unitPrice: 24,
+        unitSize: 1,
+        updatedAt: sql`now()`,
+      },
+    });
+}
+
+async function upsertFluxImagePricing(): Promise<void> {
+  const writeDb = store.set(writeDb$);
+  await writeDb
+    .insert(usagePricing)
+    .values({
+      kind: "image",
+      provider: "fal-ai/flux-pro/v1.1",
+      category: "output_megapixel",
+      unitPrice: FAL_FLUX_MARKED_UP_CREDITS_PER_MEGAPIXEL,
+      unitSize: 1,
+    })
+    .onConflictDoUpdate({
+      target: [usagePricing.kind, usagePricing.provider, usagePricing.category],
+      set: {
+        unitPrice: FAL_FLUX_MARKED_UP_CREDITS_PER_MEGAPIXEL,
         unitSize: 1,
         updatedAt: sql`now()`,
       },
@@ -1308,6 +1337,123 @@ describe("POST /api/zero/image-io/generate", () => {
       status: "processed",
       billingError: null,
       creditsCharged: 48,
+    });
+  });
+
+  it("generates image-to-image through fal with 20 percent markup pricing", async () => {
+    const fixture = await track(seedImageFixture({ credits: 1000 }));
+    await upsertFluxImagePricing();
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    let observedAuthorization: string | null = null;
+    let observedBody: Record<string, unknown> | null = null;
+    let observedRequestUrl: string | null = null;
+    server.use(
+      http.post(FAL_FLUX_REDUX_URL, async ({ request }) => {
+        observedAuthorization = request.headers.get("authorization");
+        observedRequestUrl = request.url;
+        observedBody = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json(falQueueHandle("flux-redux-request"));
+      }),
+      http.get(FAL_FLUX_MEDIA_URL, () => {
+        return new HttpResponse(IMAGE_BYTES, {
+          headers: { "Content-Type": "image/jpeg" },
+        });
+      }),
+    );
+
+    const app = createApp({ signal: context.signal });
+    const response = await app.request("/api/zero/image-io/generate", {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({
+        prompt: "turn this wireframe into a polished product mockup",
+        model: "flux-pro-1.1",
+        imageUrl: MOCKUP_IMAGE_URL,
+        outputFormat: "jpeg",
+        seed: 42,
+      }),
+    });
+
+    expect(response.status).toBe(202);
+    const generationId = readAcceptedGenerationId(
+      await response.json(),
+      "image",
+      fixture.userId,
+    );
+
+    await postFalWebhook(app, observedRequestUrl, {
+      images: [
+        {
+          url: FAL_FLUX_MEDIA_URL,
+          width: 1536,
+          height: 1024,
+          content_type: "image/jpeg",
+        },
+      ],
+      prompt: "A polished product mockup.",
+      seed: 42,
+    });
+    await clearAllDetached();
+
+    const statusResponse = await app.request(
+      `/api/zero/built-in-generations/${generationId}`,
+      { headers: authHeaders() },
+    );
+    expect(statusResponse.status).toBe(200);
+    const body = readGenerationResult(await statusResponse.json());
+    expect(body).toMatchObject({
+      contentType: "image/jpeg",
+      size: IMAGE_BYTES.byteLength,
+      creditsCharged: 96,
+      model: "fal-ai/flux-pro/v1.1",
+      provider: "fal",
+      imageSize: "1536x1024",
+      outputFormat: "jpeg",
+      billingCategory: "output_megapixel",
+      billingQuantity: 2,
+      sourceUrl: FAL_FLUX_MEDIA_URL,
+      sourceImageUrls: [MOCKUP_IMAGE_URL],
+      seed: 42,
+    });
+    expect(body).not.toHaveProperty("imagePromptStrength");
+    expect(observedAuthorization).toBe("Key test-fal-key");
+    expect(observedBody).toMatchObject({
+      prompt: "turn this wireframe into a polished product mockup",
+      image_size: "landscape_4_3",
+      num_images: 1,
+      output_format: "jpeg",
+      seed: 42,
+      safety_tolerance: "4",
+      enhance_prompt: false,
+      image_url: MOCKUP_IMAGE_URL,
+    });
+    expect(observedBody).not.toHaveProperty("image_prompt_strength");
+
+    const usageRows = await store
+      .set(writeDb$)
+      .select()
+      .from(usageEvent)
+      .where(
+        and(
+          eq(usageEvent.orgId, fixture.orgId),
+          eq(usageEvent.userId, fixture.userId),
+          eq(usageEvent.kind, "image"),
+          eq(usageEvent.provider, "fal-ai/flux-pro/v1.1"),
+        ),
+      );
+    expect(usageRows).toHaveLength(1);
+    expect(usageRows[0]).toMatchObject({
+      idempotencyKey: builtInGenerationUsageIdempotencyKey({
+        generationId,
+        scope: "image",
+        category: "output_megapixel",
+      }),
+      category: "output_megapixel",
+      quantity: 2,
+      status: "processed",
+      billingError: null,
+      creditsCharged: 96,
     });
   });
 

--- a/turbo/apps/api/src/signals/routes/zero-image-io-generate.ts
+++ b/turbo/apps/api/src/signals/routes/zero-image-io-generate.ts
@@ -100,6 +100,10 @@ function imageRequestRecord(options: ImageOptions): Record<string, unknown> {
     ...(options.seed !== undefined ? { seed: options.seed } : {}),
     safetyTolerance: options.safetyTolerance,
     enhancePrompt: options.enhancePrompt,
+    sourceImageUrls: options.sourceImageUrls,
+    maskImageUrl: options.maskImageUrl,
+    inputFidelity: options.inputFidelity,
+    imagePromptStrength: options.imagePromptStrength,
   };
 }
 

--- a/turbo/apps/api/src/signals/services/zero-image-io-generate.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-image-io-generate.service.ts
@@ -50,6 +50,8 @@ const IMAGE_BACKGROUNDS = ["auto", "opaque", "transparent"] as const;
 const IMAGE_OUTPUT_FORMATS = ["png", "webp", "jpeg"] as const;
 const IMAGE_MODERATIONS = ["auto", "low"] as const;
 const IMAGE_SAFETY_TOLERANCES = ["1", "2", "3", "4", "5", "6"] as const;
+const IMAGE_INPUT_FIDELITIES = ["low", "high"] as const;
+const MAX_SOURCE_IMAGE_URLS = 10;
 const STANDARD_GPT_IMAGE_SIZES = [
   "auto",
   "1024x1024",
@@ -84,6 +86,8 @@ const IMAGE_MODEL_CONFIGS = {
   "gpt-image-2": {
     alias: "gpt-image-2",
     endpointId: "openai/gpt-image-2",
+    imageToImageEndpointId: "openai/gpt-image-2/edit",
+    sourceImageInput: "image_urls",
     provider: "fal",
     sizeMode: "flexible",
     sizeParameter: undefined,
@@ -99,10 +103,15 @@ const IMAGE_MODEL_CONFIGS = {
     supportsSeed: false,
     supportsSafetyTolerance: false,
     supportsEnhancePrompt: false,
+    supportsMaskImage: true,
+    supportsInputFidelity: false,
+    supportsImagePromptStrength: false,
   },
   "gpt-image-1.5": {
     alias: "gpt-image-1.5",
     endpointId: "fal-ai/gpt-image-1.5",
+    imageToImageEndpointId: "fal-ai/gpt-image-1.5/edit",
+    sourceImageInput: "image_urls",
     provider: "fal",
     sizeMode: "standard",
     sizeParameter: undefined,
@@ -118,10 +127,15 @@ const IMAGE_MODEL_CONFIGS = {
     supportsSeed: false,
     supportsSafetyTolerance: false,
     supportsEnhancePrompt: false,
+    supportsMaskImage: true,
+    supportsInputFidelity: true,
+    supportsImagePromptStrength: false,
   },
   "gpt-image-1": {
     alias: "gpt-image-1",
     endpointId: "fal-ai/gpt-image-1/text-to-image",
+    imageToImageEndpointId: "fal-ai/gpt-image-1/edit-image",
+    sourceImageInput: "image_urls",
     provider: "fal",
     sizeMode: "standard",
     sizeParameter: undefined,
@@ -137,10 +151,15 @@ const IMAGE_MODEL_CONFIGS = {
     supportsSeed: false,
     supportsSafetyTolerance: false,
     supportsEnhancePrompt: false,
+    supportsMaskImage: false,
+    supportsInputFidelity: true,
+    supportsImagePromptStrength: false,
   },
   "gpt-image-1-mini": {
     alias: "gpt-image-1-mini",
     endpointId: "fal-ai/gpt-image-1-mini",
+    imageToImageEndpointId: "fal-ai/gpt-image-1-mini/edit",
+    sourceImageInput: "image_urls",
     provider: "fal",
     sizeMode: "standard",
     sizeParameter: undefined,
@@ -156,10 +175,15 @@ const IMAGE_MODEL_CONFIGS = {
     supportsSeed: false,
     supportsSafetyTolerance: false,
     supportsEnhancePrompt: false,
+    supportsMaskImage: false,
+    supportsInputFidelity: false,
+    supportsImagePromptStrength: false,
   },
   "fal-ai/flux-pro/v1.1": {
     alias: "flux-pro-1.1",
     endpointId: "fal-ai/flux-pro/v1.1",
+    imageToImageEndpointId: "fal-ai/flux-pro/v1.1/redux",
+    sourceImageInput: "image_url",
     provider: "fal",
     sizeMode: "flexible",
     sizeParameter: "image_size",
@@ -175,10 +199,15 @@ const IMAGE_MODEL_CONFIGS = {
     supportsSeed: true,
     supportsSafetyTolerance: true,
     supportsEnhancePrompt: true,
+    supportsMaskImage: false,
+    supportsInputFidelity: false,
+    supportsImagePromptStrength: true,
   },
   "fal-ai/flux-pro/v1.1-ultra": {
     alias: "flux-pro-1.1-ultra",
     endpointId: "fal-ai/flux-pro/v1.1-ultra",
+    imageToImageEndpointId: "fal-ai/flux-pro/v1.1-ultra/redux",
+    sourceImageInput: "image_url",
     provider: "fal",
     sizeMode: "flexible",
     sizeParameter: "aspect_ratio",
@@ -194,10 +223,15 @@ const IMAGE_MODEL_CONFIGS = {
     supportsSeed: true,
     supportsSafetyTolerance: true,
     supportsEnhancePrompt: false,
+    supportsMaskImage: false,
+    supportsInputFidelity: false,
+    supportsImagePromptStrength: true,
   },
   "fal-ai/qwen-image": {
     alias: "qwen-image",
     endpointId: "fal-ai/qwen-image",
+    imageToImageEndpointId: "fal-ai/qwen-image-2/edit",
+    sourceImageInput: "image_url",
     provider: "fal",
     sizeMode: "flexible",
     sizeParameter: "image_size",
@@ -213,10 +247,15 @@ const IMAGE_MODEL_CONFIGS = {
     supportsSeed: true,
     supportsSafetyTolerance: false,
     supportsEnhancePrompt: false,
+    supportsMaskImage: false,
+    supportsInputFidelity: false,
+    supportsImagePromptStrength: false,
   },
   "fal-ai/bytedance/seedream/v4/text-to-image": {
     alias: "seedream4",
     endpointId: "fal-ai/bytedance/seedream/v4/text-to-image",
+    imageToImageEndpointId: "fal-ai/bytedance/seedream/v4/edit",
+    sourceImageInput: "image_urls",
     provider: "fal",
     sizeMode: "flexible",
     sizeParameter: "image_size",
@@ -232,6 +271,9 @@ const IMAGE_MODEL_CONFIGS = {
     supportsSeed: true,
     supportsSafetyTolerance: false,
     supportsEnhancePrompt: false,
+    supportsMaskImage: false,
+    supportsInputFidelity: false,
+    supportsImagePromptStrength: false,
   },
 } as const;
 
@@ -243,6 +285,7 @@ type ImageBackground = (typeof IMAGE_BACKGROUNDS)[number];
 type ImageOutputFormat = (typeof IMAGE_OUTPUT_FORMATS)[number];
 type ImageModeration = (typeof IMAGE_MODERATIONS)[number];
 type ImageSafetyTolerance = (typeof IMAGE_SAFETY_TOLERANCES)[number];
+type ImageInputFidelity = (typeof IMAGE_INPUT_FIDELITIES)[number];
 type ImagePricingCategory = (typeof IMAGE_PRICING_CATEGORIES)[number];
 export type ImageModel = keyof typeof IMAGE_MODEL_CONFIGS;
 export type ImageProvider = "fal";
@@ -289,6 +332,10 @@ export interface ImageOptions {
   readonly seed: number | undefined;
   readonly safetyTolerance: ImageSafetyTolerance;
   readonly enhancePrompt: boolean;
+  readonly sourceImageUrls: readonly string[];
+  readonly maskImageUrl: string | undefined;
+  readonly inputFidelity: ImageInputFidelity | undefined;
+  readonly imagePromptStrength: number | undefined;
 }
 
 export interface ParsedImageGeneration {
@@ -306,6 +353,10 @@ export interface ParsedImageGeneration {
   readonly billing: readonly ImageBillingEntry[];
   readonly sourceUrl: string | undefined;
   readonly seed: number | undefined;
+  readonly sourceImageUrls: readonly string[];
+  readonly maskImageUrl: string | undefined;
+  readonly inputFidelity: ImageInputFidelity | undefined;
+  readonly imagePromptStrength: number | undefined;
 }
 
 interface RecordedImage {
@@ -329,6 +380,10 @@ interface RecordedImage {
   readonly billingQuantity: number | undefined;
   readonly sourceUrl: string | undefined;
   readonly seed: number | undefined;
+  readonly sourceImageUrls: readonly string[];
+  readonly maskImageUrl: string | undefined;
+  readonly inputFidelity: ImageInputFidelity | undefined;
+  readonly imagePromptStrength: number | undefined;
 }
 
 interface ImageBillingEntry {
@@ -426,6 +481,46 @@ function readOptionalInteger(
   }
 
   return parsed;
+}
+
+function readOptionalNumberFromKeys(
+  body: Record<string, unknown>,
+  keys: readonly string[],
+): number | ErrorResponse | undefined {
+  for (const key of keys) {
+    const value = body[key];
+    if (value === undefined || value === null || value === "") {
+      continue;
+    }
+    const parsed =
+      typeof value === "number"
+        ? value
+        : typeof value === "string" && value.trim().length > 0
+          ? Number(value.trim())
+          : Number.NaN;
+    if (!Number.isFinite(parsed)) {
+      return badRequest(`${key} must be a number`);
+    }
+    return parsed;
+  }
+  return undefined;
+}
+
+function readOptionalStringFromKeys(
+  body: Record<string, unknown>,
+  keys: readonly string[],
+): string | ErrorResponse | undefined {
+  for (const key of keys) {
+    const value = body[key];
+    if (value === undefined || value === null || value === "") {
+      continue;
+    }
+    if (typeof value !== "string" || value.trim().length === 0) {
+      return badRequest(`${key} must be a non-empty string`);
+    }
+    return value.trim();
+  }
+  return undefined;
 }
 
 function includesString<T extends string>(
@@ -733,6 +828,143 @@ function parseEnhancePrompt(
   return enhancePrompt;
 }
 
+function appendSourceImageUrls(
+  target: string[],
+  value: unknown,
+  key: string,
+): ErrorResponse | null {
+  if (value === undefined || value === null || value === "") {
+    return null;
+  }
+
+  const values = Array.isArray(value) ? value : [value];
+  for (const item of values) {
+    if (typeof item !== "string" || item.trim().length === 0) {
+      return badRequest(`${key} must contain non-empty strings`);
+    }
+    target.push(item.trim());
+  }
+  return null;
+}
+
+function parseSourceImageUrls(
+  body: Record<string, unknown>,
+  modelConfig: ImageModelConfig,
+): readonly string[] | ErrorResponse {
+  const sourceImageUrls: string[] = [];
+  for (const key of [
+    "imageUrl",
+    "image_url",
+    "imageUrls",
+    "image_urls",
+    "sourceImageUrls",
+  ]) {
+    const error = appendSourceImageUrls(sourceImageUrls, body[key], key);
+    if (error) {
+      return error;
+    }
+  }
+
+  if (sourceImageUrls.length === 0) {
+    return sourceImageUrls;
+  }
+  if (sourceImageUrls.length > MAX_SOURCE_IMAGE_URLS) {
+    return badRequest(
+      `imageUrls supports at most ${MAX_SOURCE_IMAGE_URLS} images`,
+    );
+  }
+  if (
+    modelConfig.sourceImageInput === "image_url" &&
+    sourceImageUrls.length > 1
+  ) {
+    return badRequest(`${modelConfig.alias} accepts one source image`);
+  }
+
+  return sourceImageUrls;
+}
+
+function parseMaskImageUrl(
+  body: Record<string, unknown>,
+  modelConfig: ImageModelConfig,
+  hasSourceImages: boolean,
+): string | ErrorResponse | undefined {
+  const maskImageUrl = readOptionalStringFromKeys(body, [
+    "maskImageUrl",
+    "mask_image_url",
+  ]);
+  if (typeof maskImageUrl === "object") {
+    return maskImageUrl;
+  }
+  if (!maskImageUrl) {
+    return undefined;
+  }
+  if (!hasSourceImages) {
+    return badRequest("maskImageUrl requires imageUrl");
+  }
+  if (!modelConfig.supportsMaskImage) {
+    return badRequest(`maskImageUrl is not supported for ${modelConfig.alias}`);
+  }
+  return maskImageUrl;
+}
+
+function parseInputFidelity(
+  body: Record<string, unknown>,
+  modelConfig: ImageModelConfig,
+  hasSourceImages: boolean,
+): ImageInputFidelity | ErrorResponse | undefined {
+  const inputFidelity = readOptionalStringFromKeys(body, [
+    "inputFidelity",
+    "input_fidelity",
+  ]);
+  if (typeof inputFidelity === "object") {
+    return inputFidelity;
+  }
+  if (!inputFidelity) {
+    return undefined;
+  }
+  if (!includesString(IMAGE_INPUT_FIDELITIES, inputFidelity)) {
+    return badRequest(`Unsupported input fidelity: ${inputFidelity}`);
+  }
+  if (!hasSourceImages) {
+    return badRequest("inputFidelity requires imageUrl");
+  }
+  if (!modelConfig.supportsInputFidelity) {
+    return badRequest(
+      `inputFidelity is not supported for ${modelConfig.alias}`,
+    );
+  }
+  return inputFidelity;
+}
+
+function parseImagePromptStrength(
+  body: Record<string, unknown>,
+  modelConfig: ImageModelConfig,
+  hasSourceImages: boolean,
+): number | ErrorResponse | undefined {
+  const imagePromptStrength = readOptionalNumberFromKeys(body, [
+    "imagePromptStrength",
+    "image_prompt_strength",
+  ]);
+  if (typeof imagePromptStrength === "object") {
+    return imagePromptStrength;
+  }
+  if (imagePromptStrength !== undefined) {
+    if (imagePromptStrength < 0 || imagePromptStrength > 1) {
+      return badRequest("imagePromptStrength must be between 0 and 1");
+    }
+    if (!hasSourceImages) {
+      return badRequest("imagePromptStrength requires imageUrl");
+    }
+    if (!modelConfig.supportsImagePromptStrength) {
+      return badRequest(
+        `imagePromptStrength is not supported for ${modelConfig.alias}`,
+      );
+    }
+    return imagePromptStrength;
+  }
+  return undefined;
+}
+
 export function parseImageOptions(body: unknown): ImageOptions | ErrorResponse {
   if (!isRecord(body)) {
     return badRequest("Invalid JSON body");
@@ -749,7 +981,13 @@ export function parseImageOptions(body: unknown): ImageOptions | ErrorResponse {
   }
   const modelConfig = IMAGE_MODEL_CONFIGS[model];
 
-  const size = readString(body, "size", "1024x1024");
+  const sourceImageUrls = parseSourceImageUrls(body, modelConfig);
+  if (typeof sourceImageUrls === "object" && "status" in sourceImageUrls) {
+    return sourceImageUrls;
+  }
+  const hasSourceImages = sourceImageUrls.length > 0;
+
+  const size = readString(body, "size", hasSourceImages ? "auto" : "1024x1024");
   const sizeError = validateImageSize(model, size);
   if (sizeError) {
     return sizeError;
@@ -790,6 +1028,25 @@ export function parseImageOptions(body: unknown): ImageOptions | ErrorResponse {
     return enhancePrompt;
   }
 
+  const maskImageUrl = parseMaskImageUrl(body, modelConfig, hasSourceImages);
+  if (typeof maskImageUrl === "object") {
+    return maskImageUrl;
+  }
+
+  const inputFidelity = parseInputFidelity(body, modelConfig, hasSourceImages);
+  if (typeof inputFidelity === "object") {
+    return inputFidelity;
+  }
+
+  const imagePromptStrength = parseImagePromptStrength(
+    body,
+    modelConfig,
+    hasSourceImages,
+  );
+  if (typeof imagePromptStrength === "object") {
+    return imagePromptStrength;
+  }
+
   return {
     model,
     provider: modelConfig.provider,
@@ -803,6 +1060,10 @@ export function parseImageOptions(body: unknown): ImageOptions | ErrorResponse {
     seed,
     safetyTolerance,
     enhancePrompt,
+    sourceImageUrls,
+    maskImageUrl,
+    inputFidelity,
+    imagePromptStrength,
   };
 }
 
@@ -1057,11 +1318,29 @@ function falImageInput(options: ImageOptions): Record<string, unknown> {
     ...(modelConfig.supportsEnhancePrompt
       ? { enhance_prompt: options.enhancePrompt }
       : {}),
+    ...(options.sourceImageUrls.length > 0
+      ? modelConfig.sourceImageInput === "image_url"
+        ? { image_url: options.sourceImageUrls[0] }
+        : { image_urls: options.sourceImageUrls }
+      : {}),
+    ...(modelConfig.supportsMaskImage && options.maskImageUrl
+      ? { mask_image_url: options.maskImageUrl }
+      : {}),
+    ...(modelConfig.supportsInputFidelity && options.inputFidelity
+      ? { input_fidelity: options.inputFidelity }
+      : {}),
+    ...(modelConfig.supportsImagePromptStrength &&
+    options.imagePromptStrength !== undefined
+      ? { image_prompt_strength: options.imagePromptStrength }
+      : {}),
   };
 }
 
-function falImageEndpointId(model: ImageModel): string {
-  return IMAGE_MODEL_CONFIGS[model].endpointId;
+function falImageEndpointId(options: ImageOptions): string {
+  const modelConfig = IMAGE_MODEL_CONFIGS[options.model];
+  return options.sourceImageUrls.length > 0
+    ? modelConfig.imageToImageEndpointId
+    : modelConfig.endpointId;
 }
 
 async function readFalErrorBody(
@@ -1078,7 +1357,7 @@ async function submitFalImageGeneration(
   falKey: string,
   signal: AbortSignal,
 ): Promise<unknown | ErrorResponse> {
-  const endpointId = falImageEndpointId(options.model);
+  const endpointId = falImageEndpointId(options);
   const response = await fetch(`${FAL_IMAGE_RUN_URL_PREFIX}/${endpointId}`, {
     method: "POST",
     headers: falHeaders(falKey),
@@ -1106,7 +1385,7 @@ export async function submitFalImageQueueGeneration(
   webhookUrl: string,
   signal: AbortSignal,
 ): Promise<FalImageQueueHandle | ErrorResponse> {
-  const endpointId = falImageEndpointId(options.model);
+  const endpointId = falImageEndpointId(options);
   const queueUrl = new URL(`${FAL_IMAGE_QUEUE_URL_PREFIX}/${endpointId}`);
   queueUrl.searchParams.set("fal_webhook", webhookUrl);
   const response = await fetch(queueUrl, {
@@ -1276,6 +1555,10 @@ export async function downloadFalImage(
     billing: falBillingEntries(result.image, options),
     sourceUrl: result.image.url,
     seed: result.seed ?? options.seed,
+    sourceImageUrls: options.sourceImageUrls,
+    maskImageUrl: options.maskImageUrl,
+    inputFidelity: options.inputFidelity,
+    imagePromptStrength: options.imagePromptStrength,
   };
 }
 
@@ -1371,6 +1654,10 @@ export const recordGeneratedImage$ = command(
             safetyTolerance: params.generation.safetyTolerance,
             sourceUrl: params.generation.sourceUrl,
             seed: params.generation.seed,
+            sourceImageUrls: params.generation.sourceImageUrls,
+            maskImageUrl: params.generation.maskImageUrl,
+            inputFidelity: params.generation.inputFidelity,
+            imagePromptStrength: params.generation.imagePromptStrength,
           },
         },
         signal,
@@ -1432,6 +1719,10 @@ export const recordGeneratedImage$ = command(
       billingQuantity: params.generation.billing[0]?.quantity,
       sourceUrl: params.generation.sourceUrl,
       seed: params.generation.seed,
+      sourceImageUrls: params.generation.sourceImageUrls,
+      maskImageUrl: params.generation.maskImageUrl,
+      inputFidelity: params.generation.inputFidelity,
+      imagePromptStrength: params.generation.imagePromptStrength,
     };
   },
 );

--- a/turbo/apps/cli/src/commands/zero/built-in/generate/__tests__/image.test.ts
+++ b/turbo/apps/cli/src/commands/zero/built-in/generate/__tests__/image.test.ts
@@ -174,6 +174,57 @@ describe("zero built-in generate image command", () => {
     expect(stdout).toContain("Provider: fal");
   });
 
+  it("should pass image-to-image controls to the image API", async () => {
+    let capturedBody: unknown;
+    server.use(
+      http.post(IMAGE_URL, async ({ request }) => {
+        capturedBody = await request.json();
+
+        return HttpResponse.json({
+          ...IMAGE_RESULT,
+          model: "fal-ai/flux-pro/v1.1",
+          provider: "fal",
+          outputFormat: "jpeg",
+          sourceImageUrls: ["https://example.com/mockup.png"],
+          imagePromptStrength: 0.2,
+        });
+      }),
+    );
+
+    await zeroBuiltInCommand.parseAsync([
+      "node",
+      "cli",
+      "generate",
+      "image",
+      "--model",
+      "flux-pro-1.1",
+      "--prompt",
+      "Turn this mockup into a polished product shot",
+      "--image-url",
+      "https://example.com/mockup.png",
+      "--image-prompt-strength",
+      "0.2",
+      "--format",
+      "jpeg",
+    ]);
+
+    expect(capturedBody).toEqual({
+      prompt: "Turn this mockup into a polished product shot",
+      model: "flux-pro-1.1",
+      size: "auto",
+      quality: "medium",
+      background: "auto",
+      outputFormat: "jpeg",
+      moderation: "auto",
+      safetyTolerance: "4",
+      imageUrls: ["https://example.com/mockup.png"],
+      imagePromptStrength: 0.2,
+    });
+    const stdout = mockConsoleLog.mock.calls.flat().join("\n");
+    expect(stdout).toContain("Model: fal-ai/flux-pro/v1.1");
+    expect(stdout).toContain("Provider: fal");
+  });
+
   it("should print JSON metadata when --json is provided", async () => {
     server.use(
       http.post(IMAGE_URL, () => {
@@ -272,12 +323,13 @@ describe("zero built-in generate image command", () => {
     });
 
     imageCommand.outputHelp();
+    const normalizedHelpOutput = helpOutput.replace(/\s+/g, " ");
 
     expect(helpOutput).toContain("gpt-image-1.5");
     expect(helpOutput).toContain("gpt-image-1 (default)");
     expect(helpOutput).toContain("flux-pro-1.1");
     expect(helpOutput).toContain("qwen-image");
-    expect(helpOutput).toContain("support varies");
+    expect(normalizedHelpOutput).toContain("support varies");
     expect(helpOutput).toContain("3840x2160");
     expect(helpOutput).toContain("edges divisible by 16");
     expect(helpOutput).toContain("--compression <0-100>");
@@ -285,9 +337,13 @@ describe("zero built-in generate image command", () => {
     expect(helpOutput).toContain("Uses fal.ai for all image model execution");
     expect(helpOutput).toContain("--seed");
     expect(helpOutput).toContain("--safety-tolerance");
+    expect(helpOutput).toContain("--image-url");
+    expect(helpOutput).toContain("--image-prompt-strength");
+    expect(helpOutput).toContain("provider");
+    expect(helpOutput).toContain("default");
     expect(helpOutput).toContain("not support transparent");
     expect(helpOutput).toContain("backgrounds");
-    expect(helpOutput).toContain("image edits, reference images, masks");
+    expect(helpOutput).toContain("Image-to-image");
   });
 
   it("should surface API errors", async () => {

--- a/turbo/apps/cli/src/commands/zero/built-in/generate/image.ts
+++ b/turbo/apps/cli/src/commands/zero/built-in/generate/image.ts
@@ -6,5 +6,6 @@ export const imageCommand = createImageGenerateCommand({
   examples: `  Generate image:        zero built-in generate image --prompt "A watercolor fox"
   Pipe prompt:           cat prompt.txt | zero built-in generate image
   GPT Image model:       zero built-in generate image --model gpt-image-1.5 --prompt "A poster" --size 1024x1536 --quality high
-  Flux model:            zero built-in generate image --model flux-pro-1.1 --prompt "A product hero shot" --seed 42`,
+  Flux model:            zero built-in generate image --model flux-pro-1.1 --prompt "A product hero shot" --seed 42
+  Image-to-image:        zero built-in generate image --model flux-pro-1.1 --image-url https://example.com/mockup.png --prompt "Turn this mockup into a polished product shot"`,
 });

--- a/turbo/apps/cli/src/commands/zero/shared/image-generate.ts
+++ b/turbo/apps/cli/src/commands/zero/shared/image-generate.ts
@@ -16,6 +16,10 @@ interface ImageOptions {
   seed?: number;
   safetyTolerance: string;
   enhancePrompt?: boolean;
+  imageUrl: string[];
+  maskImageUrl?: string;
+  inputFidelity?: string;
+  imagePromptStrength?: string;
   json?: boolean;
 }
 
@@ -63,6 +67,33 @@ function parseSeed(value: string): number {
   return seed;
 }
 
+function collectString(value: string, previous: string[]): string[] {
+  return [...previous, value];
+}
+
+function parseInputFidelity(value: string | undefined): string | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (value !== "low" && value !== "high") {
+    throw new Error("--input-fidelity must be low or high");
+  }
+  return value;
+}
+
+function parseImagePromptStrength(
+  value: string | undefined,
+): number | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  const strength = Number(value);
+  if (!Number.isFinite(strength) || strength < 0 || strength > 1) {
+    throw new Error("--image-prompt-strength must be a number from 0 to 1");
+  }
+  return strength;
+}
+
 export function createImageGenerateCommand(
   config: ImageGenerateCommandConfig,
 ): Command {
@@ -100,6 +131,24 @@ export function createImageGenerateCommand(
     .option("--seed <integer>", "Deterministic seed for fal models", parseSeed)
     .option("--safety-tolerance <level>", "fal safety tolerance: 1-6", "4")
     .option("--enhance-prompt", "Enable fal prompt enhancement when supported")
+    .option(
+      "--image-url <url>",
+      "Source/mockup image URL for image-to-image; repeat for multi-image edit models",
+      collectString,
+      [],
+    )
+    .option(
+      "--mask-image-url <url>",
+      "Mask image URL for supported edit models",
+    )
+    .option(
+      "--input-fidelity <low|high>",
+      "Source-image fidelity for GPT edit models",
+    )
+    .option(
+      "--image-prompt-strength <0-1>",
+      "Reference strength override for Flux Redux",
+    )
     .option("--json", "Print metadata as JSON")
     .addHelpText(
       "after",
@@ -140,19 +189,28 @@ Options:
   - fal-only controls: --seed, --safety-tolerance for Flux, and
     --enhance-prompt for flux-pro-1.1. --compression and --moderation low are
     not supported on the fal-backed image path.
-  - This command generates one text-to-image result. GPT Image also
-    supports image edits, reference images, masks, partial-image streaming,
-    and multiple images per request, but those are not exposed by this
-    built-in Zero command yet.`,
+  - Image-to-image: pass --image-url to use the model's fal edit/redux endpoint.
+    Flux Redux accepts --image-prompt-strength to override the provider
+    default; GPT edit models accept --input-fidelity and supported models
+    accept --mask-image-url.`,
     )
     .action(
-      withErrorHandler(async (options: ImageOptions) => {
+      withErrorHandler(async (options: ImageOptions, command: Command) => {
         const prompt = readPrompt(options, config.usageCommand);
         const compression = parseCompression(options.compression);
+        const inputFidelity = parseInputFidelity(options.inputFidelity);
+        const imagePromptStrength = parseImagePromptStrength(
+          options.imagePromptStrength,
+        );
+        const hasSourceImage = options.imageUrl.length > 0;
+        const size =
+          hasSourceImage && command.getOptionValueSource("size") === "default"
+            ? "auto"
+            : options.size;
         const result = await generateWebImage({
           prompt,
           model: options.model,
-          size: options.size,
+          size,
           quality: options.quality,
           background: options.background,
           outputFormat: options.format,
@@ -161,6 +219,10 @@ Options:
           seed: options.seed,
           safetyTolerance: options.safetyTolerance,
           enhancePrompt: options.enhancePrompt,
+          imageUrls: options.imageUrl,
+          maskImageUrl: options.maskImageUrl,
+          inputFidelity,
+          imagePromptStrength,
         });
 
         if (options.json) {

--- a/turbo/apps/cli/src/lib/api/domains/web.ts
+++ b/turbo/apps/cli/src/lib/api/domains/web.ts
@@ -230,6 +230,10 @@ interface GenerateWebImageOptions {
   seed?: number;
   safetyTolerance?: string;
   enhancePrompt?: boolean;
+  imageUrls?: readonly string[];
+  maskImageUrl?: string;
+  inputFidelity?: string;
+  imagePromptStrength?: number;
 }
 
 interface GenerateWebImageResult {
@@ -259,6 +263,10 @@ interface GenerateWebImageResult {
   billingQuantity?: number;
   sourceUrl?: string;
   seed?: number;
+  sourceImageUrls?: string[];
+  maskImageUrl?: string;
+  inputFidelity?: string;
+  imagePromptStrength?: number;
 }
 
 interface GenerateWebVideoOptions {
@@ -850,6 +858,16 @@ export async function generateWebImage(
           : {}),
         ...(options.enhancePrompt !== undefined
           ? { enhancePrompt: options.enhancePrompt }
+          : {}),
+        ...(options.imageUrls && options.imageUrls.length > 0
+          ? { imageUrls: options.imageUrls }
+          : {}),
+        ...(options.maskImageUrl ? { maskImageUrl: options.maskImageUrl } : {}),
+        ...(options.inputFidelity
+          ? { inputFidelity: options.inputFidelity }
+          : {}),
+        ...(options.imagePromptStrength !== undefined
+          ? { imagePromptStrength: options.imagePromptStrength }
           : {}),
       }),
     },

--- a/turbo/packages/api-contracts/src/contracts/zero-image-io-generate.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-image-io-generate.ts
@@ -19,6 +19,16 @@ export const zeroImageIoGenerateRequestSchema = z
     seed: z.unknown().optional(),
     safetyTolerance: z.unknown().optional(),
     enhancePrompt: z.unknown().optional(),
+    imageUrl: z.unknown().optional(),
+    image_url: z.unknown().optional(),
+    imageUrls: z.unknown().optional(),
+    image_urls: z.unknown().optional(),
+    maskImageUrl: z.unknown().optional(),
+    mask_image_url: z.unknown().optional(),
+    inputFidelity: z.unknown().optional(),
+    input_fidelity: z.unknown().optional(),
+    imagePromptStrength: z.unknown().optional(),
+    image_prompt_strength: z.unknown().optional(),
   })
   .passthrough();
 
@@ -43,6 +53,10 @@ export const zeroImageIoGenerateResponseSchema = z.object({
   billingQuantity: z.number().optional(),
   sourceUrl: z.string().optional(),
   seed: z.number().optional(),
+  sourceImageUrls: z.array(z.string()).optional(),
+  maskImageUrl: z.string().optional(),
+  inputFidelity: z.string().optional(),
+  imagePromptStrength: z.number().optional(),
 });
 
 export type ZeroImageIoGenerateRequest = z.infer<


### PR DESCRIPTION
## Summary
- add image-to-image inputs to built-in image generation contracts, API metadata, and CLI request plumbing
- route Fal-backed models with source images to their edit/redux endpoints, including Flux Redux with default `image_prompt_strength: 0.2` for mockup preservation
- add CLI flags for source images, masks, input fidelity, and image prompt strength, plus coverage for the 20% mockup flow

## Tests
- `pnpm format`
- `pnpm check-types`
- `pnpm turbo run lint`
- `pnpm knip`
- `pnpm vitest`
