### PR TITLE
refactor: clarify connector utility semantics

### DIFF
--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -307,11 +307,11 @@ describe("getRuntimeAvailableConnectorTypes", () => {
   });
 
   it("includes api-token default connectors without environment credentials or feature switches", () => {
-    const configuredTypes = getRuntimeAvailableConnectorTypes(emptyEnv);
+    const runtimeAvailableTypes = getRuntimeAvailableConnectorTypes(emptyEnv);
 
-    expect(configuredTypes).toContain("amplitude");
-    expect(configuredTypes).toContain("bentoml");
-    expect(configuredTypes).toContain("openai");
+    expect(runtimeAvailableTypes).toContain("amplitude");
+    expect(runtimeAvailableTypes).toContain("bentoml");
+    expect(runtimeAvailableTypes).toContain("openai");
   });
 
   it("includes OAuth connectors only when client id and secret are configured", () => {
@@ -321,12 +321,12 @@ describe("getRuntimeAvailableConnectorTypes", () => {
       ["SENTRY_OAUTH_CLIENT_ID", "sentry-client-id"],
     ]);
 
-    const configuredTypes = getRuntimeAvailableConnectorTypes((name) => {
+    const runtimeAvailableTypes = getRuntimeAvailableConnectorTypes((name) => {
       return env.get(name);
     });
 
-    expect(configuredTypes).toContain("airtable");
-    expect(configuredTypes).not.toContain("sentry");
+    expect(runtimeAvailableTypes).toContain("airtable");
+    expect(runtimeAvailableTypes).not.toContain("sentry");
   });
 
   it("includes all connectors that share a configured OAuth app", () => {
@@ -335,11 +335,11 @@ describe("getRuntimeAvailableConnectorTypes", () => {
       ["GOOGLE_OAUTH_CLIENT_SECRET", "google-client-secret"],
     ]);
 
-    const configuredTypes = getRuntimeAvailableConnectorTypes((name) => {
+    const runtimeAvailableTypes = getRuntimeAvailableConnectorTypes((name) => {
       return env.get(name);
     });
 
-    expect(configuredTypes).toEqual(
+    expect(runtimeAvailableTypes).toEqual(
       expect.arrayContaining([
         "gmail",
         "google-calendar",
@@ -363,11 +363,13 @@ describe("getRuntimeAvailableConnectorTypes", () => {
       );
     });
 
-    const configuredTypes = getRuntimeAvailableConnectorTypes(() => {
+    const runtimeAvailableTypes = getRuntimeAvailableConnectorTypes(() => {
       return "configured";
     });
 
-    expect(configuredTypes).toEqual(expect.arrayContaining(activeOAuthTypes));
+    expect(runtimeAvailableTypes).toEqual(
+      expect.arrayContaining(activeOAuthTypes),
+    );
   });
 
   it("includes computer only when both ngrok env vars are configured", () => {
@@ -390,24 +392,26 @@ describe("getRuntimeAvailableConnectorTypes", () => {
   });
 
   it("excludes API-managed local connectors without special runtime env support", () => {
-    const configuredTypes = getRuntimeAvailableConnectorTypes(emptyEnv);
+    const runtimeAvailableTypes = getRuntimeAvailableConnectorTypes(emptyEnv);
 
-    expect(configuredTypes).not.toContain("local-agent");
-    expect(configuredTypes).not.toContain("local-browser");
+    expect(runtimeAvailableTypes).not.toContain("local-agent");
+    expect(runtimeAvailableTypes).not.toContain("local-browser");
   });
 
   it("does not include Stripe without OAuth runtime env despite alternative auth methods", () => {
-    const configuredTypes = getRuntimeAvailableConnectorTypes(emptyEnv);
+    const runtimeAvailableTypes = getRuntimeAvailableConnectorTypes(emptyEnv);
 
     expect(getConnectorAuthMethod("stripe", "api-token")).toBeDefined();
     expect(getConnectorAuthMethod("stripe", "cli-auth")).toBeDefined();
-    expect(configuredTypes).not.toContain("stripe");
+    expect(runtimeAvailableTypes).not.toContain("stripe");
   });
 
   it("returns connector types in sorted order", () => {
-    const configuredTypes = getRuntimeAvailableConnectorTypes(emptyEnv);
+    const runtimeAvailableTypes = getRuntimeAvailableConnectorTypes(emptyEnv);
 
-    expect(configuredTypes).toStrictEqual([...configuredTypes].sort());
+    expect(runtimeAvailableTypes).toStrictEqual(
+      [...runtimeAvailableTypes].sort(),
+    );
   });
 });
 

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -3,6 +3,7 @@ import { CONNECTOR_TYPES, connectorTypeSchema } from "../connectors";
 import {
   getAvailableConnectorAuthMethods,
   hasRequiredScopes,
+  getConnectorAuthMethod,
   getConnectorManagedSecretNames,
   getConnectorTypeForSecretName,
   getConnectorEnvironmentMapping,
@@ -10,6 +11,7 @@ import {
   getConnectorAuthMethods,
   getConnectorOAuthConfig,
   getConfiguredConnectorTypes,
+  getRuntimeAvailableConnectorTypes,
   isGoogleOAuthConnector,
 } from "../connector-utils";
 import { FeatureSwitchKey } from "../feature-switch-key";
@@ -60,6 +62,13 @@ describe("hasRequiredScopes", () => {
 });
 
 describe("connector auth method config", () => {
+  it("returns a single auth method config when present", () => {
+    expect(getConnectorAuthMethod("stripe", "cli-auth")?.label).toBe(
+      "Sign in with Stripe",
+    );
+    expect(getConnectorAuthMethod("github", "api-token")).toBeUndefined();
+  });
+
   it("declares Stripe CLI auth as a gated connection flow with modes", () => {
     const method = CONNECTOR_TYPES.stripe.authMethods["cli-auth"];
 
@@ -276,15 +285,32 @@ describe("getConnectorEnvironmentMapping", () => {
   });
 });
 
-describe("getConfiguredConnectorTypes", () => {
+describe("getRuntimeAvailableConnectorTypes", () => {
   const emptyEnv = () => {
     return undefined;
   };
 
-  it("includes api-token connectors without environment credentials", () => {
-    const configuredTypes = getConfiguredConnectorTypes(emptyEnv);
+  it("keeps getConfiguredConnectorTypes compatible with runtime availability", () => {
+    const env = new Map([
+      ["AIRTABLE_OAUTH_CLIENT_ID", "airtable-client-id"],
+      ["AIRTABLE_OAUTH_CLIENT_SECRET", "airtable-client-secret"],
+      ["NGROK_API_KEY", "ngrok-api-key"],
+      ["NGROK_COMPUTER_CONNECTOR_DOMAIN", "computer.example.com"],
+    ]);
+    const readEnv = (name: string) => {
+      return env.get(name);
+    };
+
+    expect(getConfiguredConnectorTypes(readEnv)).toStrictEqual(
+      getRuntimeAvailableConnectorTypes(readEnv),
+    );
+  });
+
+  it("includes api-token default connectors without environment credentials or feature switches", () => {
+    const configuredTypes = getRuntimeAvailableConnectorTypes(emptyEnv);
 
     expect(configuredTypes).toContain("amplitude");
+    expect(configuredTypes).toContain("bentoml");
     expect(configuredTypes).toContain("openai");
   });
 
@@ -295,7 +321,7 @@ describe("getConfiguredConnectorTypes", () => {
       ["SENTRY_OAUTH_CLIENT_ID", "sentry-client-id"],
     ]);
 
-    const configuredTypes = getConfiguredConnectorTypes((name) => {
+    const configuredTypes = getRuntimeAvailableConnectorTypes((name) => {
       return env.get(name);
     });
 
@@ -309,7 +335,7 @@ describe("getConfiguredConnectorTypes", () => {
       ["GOOGLE_OAUTH_CLIENT_SECRET", "google-client-secret"],
     ]);
 
-    const configuredTypes = getConfiguredConnectorTypes((name) => {
+    const configuredTypes = getRuntimeAvailableConnectorTypes((name) => {
       return env.get(name);
     });
 
@@ -337,7 +363,7 @@ describe("getConfiguredConnectorTypes", () => {
       );
     });
 
-    const configuredTypes = getConfiguredConnectorTypes(() => {
+    const configuredTypes = getRuntimeAvailableConnectorTypes(() => {
       return "configured";
     });
 
@@ -352,19 +378,34 @@ describe("getConfiguredConnectorTypes", () => {
     ]);
 
     expect(
-      getConfiguredConnectorTypes((name) => {
+      getRuntimeAvailableConnectorTypes((name) => {
         return partialComputerEnv.get(name);
       }),
     ).not.toContain("computer");
     expect(
-      getConfiguredConnectorTypes((name) => {
+      getRuntimeAvailableConnectorTypes((name) => {
         return fullComputerEnv.get(name);
       }),
     ).toContain("computer");
   });
 
+  it("excludes API-managed local connectors without special runtime env support", () => {
+    const configuredTypes = getRuntimeAvailableConnectorTypes(emptyEnv);
+
+    expect(configuredTypes).not.toContain("local-agent");
+    expect(configuredTypes).not.toContain("local-browser");
+  });
+
+  it("does not include Stripe without OAuth runtime env despite alternative auth methods", () => {
+    const configuredTypes = getRuntimeAvailableConnectorTypes(emptyEnv);
+
+    expect(getConnectorAuthMethod("stripe", "api-token")).toBeDefined();
+    expect(getConnectorAuthMethod("stripe", "cli-auth")).toBeDefined();
+    expect(configuredTypes).not.toContain("stripe");
+  });
+
   it("returns connector types in sorted order", () => {
-    const configuredTypes = getConfiguredConnectorTypes(emptyEnv);
+    const configuredTypes = getRuntimeAvailableConnectorTypes(emptyEnv);
 
     expect(configuredTypes).toStrictEqual([...configuredTypes].sort());
   });

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -314,6 +314,12 @@ describe("getRuntimeAvailableConnectorTypes", () => {
     expect(runtimeAvailableTypes).toContain("openai");
   });
 
+  it("includes static OAuth test connectors without runtime environment credentials", () => {
+    const runtimeAvailableTypes = getRuntimeAvailableConnectorTypes(emptyEnv);
+
+    expect(runtimeAvailableTypes).toContain("test-oauth");
+  });
+
   it("includes OAuth connectors only when client id and secret are configured", () => {
     const env = new Map([
       ["AIRTABLE_OAUTH_CLIENT_ID", "airtable-client-id"],
@@ -326,6 +332,22 @@ describe("getRuntimeAvailableConnectorTypes", () => {
     });
 
     expect(runtimeAvailableTypes).toContain("airtable");
+    expect(runtimeAvailableTypes).not.toContain("sentry");
+  });
+
+  it("treats empty OAuth environment values as not configured", () => {
+    const env = new Map([
+      ["AIRTABLE_OAUTH_CLIENT_ID", "airtable-client-id"],
+      ["AIRTABLE_OAUTH_CLIENT_SECRET", ""],
+      ["SENTRY_OAUTH_CLIENT_ID", ""],
+      ["SENTRY_OAUTH_CLIENT_SECRET", "sentry-client-secret"],
+    ]);
+
+    const runtimeAvailableTypes = getRuntimeAvailableConnectorTypes((name) => {
+      return env.get(name);
+    });
+
+    expect(runtimeAvailableTypes).not.toContain("airtable");
     expect(runtimeAvailableTypes).not.toContain("sentry");
   });
 

--- a/turbo/packages/connectors/src/connector-utils.ts
+++ b/turbo/packages/connectors/src/connector-utils.ts
@@ -345,7 +345,7 @@ export function getConnectorOAuthEnvKeys(
 export function getRuntimeAvailableConnectorTypes(
   readEnv: ConnectorEnvReader,
 ): ConnectorType[] {
-  const configured = new Set<ConnectorType>();
+  const runtimeAvailable = new Set<ConnectorType>();
 
   for (const type of Object.keys(CONNECTOR_TYPES) as ConnectorType[]) {
     const defaultAuthMethod = getConnectorDefaultAuthMethod(type);
@@ -353,7 +353,7 @@ export function getRuntimeAvailableConnectorTypes(
       hasConfiguredOAuth(readEnv, type) ||
       defaultAuthMethod === "api-token"
     ) {
-      configured.add(type);
+      runtimeAvailable.add(type);
     }
   }
 
@@ -361,10 +361,10 @@ export function getRuntimeAvailableConnectorTypes(
     hasEnvValue(readEnv, "NGROK_API_KEY") &&
     hasEnvValue(readEnv, "NGROK_COMPUTER_CONNECTOR_DOMAIN")
   ) {
-    configured.add("computer");
+    runtimeAvailable.add("computer");
   }
 
-  return [...configured].sort();
+  return [...runtimeAvailable].sort();
 }
 
 /**

--- a/turbo/packages/connectors/src/connector-utils.ts
+++ b/turbo/packages/connectors/src/connector-utils.ts
@@ -12,12 +12,35 @@ import {
 import type { FeatureSwitchKey } from "./feature-switch-key";
 
 /**
+ * Connector utility vocabulary:
+ *
+ * - Available auth methods are user-selectable connection flows after
+ *   feature-switch filtering.
+ * - Runtime available connector types are connector types the current server
+ *   environment can offer as connection candidates.
+ * - User connected connector types come from persisted OAuth rows or inferred
+ *   api-token state from user secrets and variables.
+ * - Runtime injection happens later when a run receives env vars, secrets,
+ *   variables, and firewall context.
+ */
+
+/**
  * Get auth methods for a connector type
  */
 export function getConnectorAuthMethods(
   type: ConnectorType,
 ): Partial<Record<ConnectorAuthMethodType, ConnectorAuthMethodConfig>> {
   return CONNECTOR_TYPES[type].authMethods;
+}
+
+/**
+ * Get one auth method config for a connector type.
+ */
+export function getConnectorAuthMethod(
+  type: ConnectorType,
+  authMethod: ConnectorAuthMethodType,
+): ConnectorAuthMethodConfig | undefined {
+  return getConnectorAuthMethods(type)[authMethod];
 }
 
 /**
@@ -48,7 +71,7 @@ export function isConnectorAuthMethodAvailable(
   authMethod: ConnectorAuthMethodType,
   featureStates: ConnectorFeatureStates,
 ): boolean {
-  const method = CONNECTOR_TYPES[type].authMethods[authMethod];
+  const method = getConnectorAuthMethod(type, authMethod);
   if (!method) {
     return false;
   }
@@ -79,12 +102,11 @@ export function getAvailableConnectorAuthMethods(
   featureStates: ConnectorFeatureStates,
   options: AvailableConnectorAuthMethodsOptions = {},
 ): ConnectorAuthMethodType[] {
-  const methods = CONNECTOR_TYPES[type].authMethods;
   const apiAuthMethodPolicy = options.apiAuthMethodPolicy ?? "exclude";
   const availableAuthMethods: ConnectorAuthMethodType[] = [];
 
   for (const authMethod of CONNECTOR_AUTH_METHOD_TYPES) {
-    if (!methods[authMethod]) {
+    if (!getConnectorAuthMethod(type, authMethod)) {
       continue;
     }
     if (
@@ -314,12 +336,13 @@ export function getConnectorOAuthEnvKeys(
 }
 
 /**
- * Return connector types configured by platform/runtime environment.
+ * Return connector types the current runtime can offer as connection candidates.
  *
- * This is intentionally the shared source of truth for the Web and API
- * implementations of GET /api/zero/connectors.
+ * This is not user connected state and it does not evaluate feature switches.
+ * It includes API-token default connectors because they do not require server
+ * credentials, while OAuth connectors require their runtime OAuth env to exist.
  */
-export function getConfiguredConnectorTypes(
+export function getRuntimeAvailableConnectorTypes(
   readEnv: ConnectorEnvReader,
 ): ConnectorType[] {
   const configured = new Set<ConnectorType>();
@@ -345,14 +368,25 @@ export function getConfiguredConnectorTypes(
 }
 
 /**
+ * Compatibility wrapper for existing configuredTypes response semantics.
+ *
+ * The API response field and existing call sites still use "configuredTypes";
+ * new connector utility code should prefer getRuntimeAvailableConnectorTypes.
+ */
+export function getConfiguredConnectorTypes(
+  readEnv: ConnectorEnvReader,
+): ConnectorType[] {
+  return getRuntimeAvailableConnectorTypes(readEnv);
+}
+
+/**
  * Get secrets config for a specific auth method
  */
 export function getConnectorSecretsForAuthMethod(
   type: ConnectorType,
   authMethod: ConnectorAuthMethodType,
 ): Record<string, ConnectorSecretConfig> | undefined {
-  const authMethods = getConnectorAuthMethods(type);
-  return authMethods[authMethod]?.secrets;
+  return getConnectorAuthMethod(type, authMethod)?.secrets;
 }
 
 /**
@@ -605,10 +639,7 @@ export function getConnectorTypeForSecretName(
 export function getApiTokenRequiredSecretNames(
   type: ConnectorType,
 ): string[] | null {
-  const config = CONNECTOR_TYPES[type];
-  const apiTokenConfig = config.authMethods["api-token"] as
-    | ConnectorAuthMethodConfig
-    | undefined;
+  const apiTokenConfig = getConnectorAuthMethod(type, "api-token");
   if (!apiTokenConfig) return null;
 
   return Object.entries(apiTokenConfig.secrets)
@@ -627,10 +658,7 @@ export function getApiTokenRequiredSecretNames(
 export function getApiTokenFieldsByType(
   type: ConnectorType,
 ): { secrets: string[]; variables: string[] } | null {
-  const config = CONNECTOR_TYPES[type];
-  const apiTokenConfig = config.authMethods["api-token"] as
-    | ConnectorAuthMethodConfig
-    | undefined;
+  const apiTokenConfig = getConnectorAuthMethod(type, "api-token");
   if (!apiTokenConfig) return null;
 
   const secretNames: string[] = [];


### PR DESCRIPTION
## Summary
- Add getRuntimeAvailableConnectorTypes as the clearer name for current connector runtime availability semantics
- Keep getConfiguredConnectorTypes as a compatibility wrapper for existing configuredTypes callers
- Add a single auth method accessor and expand connector utility tests for current edge cases

Closes #13876

## Tests
- pnpm -F @vm0/connectors exec vitest src/__tests__/connectors.test.ts
- pnpm -F @vm0/connectors check-types
- pnpm -F @vm0/connectors lint
- pre-commit: prettier, knip, turbo check-types