### PR TITLE
chore(rust): update dependencies

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -2106,9 +2106,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
@@ -3171,9 +3171,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tar"
-version = "0.4.45"
+version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
 dependencies = [
  "filetime",
  "libc",
@@ -3382,9 +3382,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.10"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "bitflags",
  "bytes",


### PR DESCRIPTION
## Summary
- Updated Rust workspace lockfile under crates/.
- Updated 3 crates: num-conv 0.2.1 -> 0.2.2, tar 0.4.45 -> 0.4.46, tower-http 0.6.10 -> 0.6.11.

## Dependencies not updated
- crc 3.3.0 (available 3.4.0): blocked by crc-fast 1.9.0 requirement crc = ~3.3.
- crc-fast 1.9.0 (available 1.10.0): blocked by aws-smithy-checksums 0.64.7 requirement crc-fast = ~1.9.0.
- generic-array 0.14.7 (available 0.14.9): blocked by crypto-common 0.1.7 exact requirement generic-array = 0.14.7.

## Manual version bumps
- None. No direct vm0 Cargo.toml dependency had a safe minor/patch specifier bump available for the held transitive dependencies.

## Tests
- Passed: CARGO_BUILD_JOBS=1 CARGO_PROFILE_DEV_DEBUG=0 CLI_AGENT_TYPE=claude-code cargo test --workspace.
- Note: the first default run hit sandbox resource/env issues (disk pressure, then linker memory pressure; one guest-agent test uses the Claude default path and needs explicit CLI_AGENT_TYPE=claude-code in this environment).