### PR TITLE
refactor: fence normal operations during sandbox park

### DIFF
--- a/crates/sandbox-fc/src/park_coordinator.rs
+++ b/crates/sandbox-fc/src/park_coordinator.rs
@@ -12,8 +12,9 @@
 //! Invariants:
 //! - A `Poisoned` operation keeps the coordinator `Dirty`; dirty sandboxes are
 //!   destroy-only and cannot re-enter the park lifecycle.
-//! - `ReadyForPark` means the host gate is closed and no operation that could
-//!   write to the guest is unresolved.
+//! - `ReadyForPark` means the host policy gate is closed, guest lifecycle
+//!   quiesce has completed, and the caller owns the authoritative `vsock-host`
+//!   normal-operation fence.
 //! - Coordinator locks are never held across `.await`.
 #![cfg_attr(not(test), allow(dead_code))]
 

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -1531,12 +1531,15 @@ impl Sandbox for FirecrackerSandbox {
     // memory again. Ordering: resume before deflate — the guest needs
     // running vCPUs to process the deflate.
     //
-    // Both methods propagate guest lifecycle, operation-gate, and Firecracker
-    // PATCH failures as `IdleTransition(Park|Unpark)` errors. On failure the
-    // caller (runner) destroys the sandbox and falls through to fresh-create.
-    // Firecracker's pause/resume returns 400 when the VM is already in the
-    // target state; within park/unpark this only happens after a partial retry,
-    // so 400 is treated as success (idempotent).
+    // Park first closes the sandbox policy gate, then acquires a host-side
+    // vsock normal-operation fence before guest lifecycle quiesce. Unpark
+    // resumes the guest, releases the vsock fence, then reopens the policy
+    // gate. Both methods propagate guest lifecycle, operation-gate, fence, and
+    // Firecracker PATCH failures as `IdleTransition(Park|Unpark)` errors. On
+    // failure the caller (runner) destroys the sandbox and falls through to
+    // fresh-create. Firecracker's pause/resume returns 400 when the VM is
+    // already in the target state; within park/unpark this only happens after
+    // a partial retry, so 400 is treated as success (idempotent).
     //
     // For profiles where `memory_mb <= MIN_GUEST_MIB` there is no memory
     // to reclaim (balloon is skipped), but vCPUs are still paused — timer
@@ -1979,6 +1982,7 @@ impl<Fence> Drop for ParkBoundaryGuard<Fence> {
                 let _ = self.coordinator.abort_prepare_park(&self.attempt);
             }
             ParkBoundaryGuardState::NormalOperationsFenced => {
+                drop(self.normal_operations_fence.take());
                 let _ = self.coordinator.abort_prepare_park(&self.attempt);
             }
             ParkBoundaryGuardState::GuestQuiesceStarted => {
@@ -3221,6 +3225,21 @@ mod tests {
         }
     }
 
+    struct ClosingStateFence {
+        coordinator: ParkCoordinator,
+        events: Arc<Mutex<Vec<&'static str>>>,
+    }
+
+    impl Drop for ClosingStateFence {
+        fn drop(&mut self) {
+            assert!(matches!(
+                self.coordinator.state(),
+                CoordinatorState::ClosingForPark { .. }
+            ));
+            self.events.lock().unwrap().push("release_fence");
+        }
+    }
+
     #[test]
     fn park_noop_with_parked_gate_succeeds() {
         let coordinator = ParkCoordinator::new();
@@ -3332,6 +3351,23 @@ mod tests {
                 "release_fence"
             ]
         );
+    }
+
+    #[test]
+    fn ready_for_park_boundary_cancel_after_fence_releases_before_reopening_gate() {
+        let coordinator = ParkCoordinator::new();
+        let attempt = coordinator.begin_prepare_park().unwrap();
+        let events = event_log();
+        let mut guard = ParkBoundaryGuard::new(coordinator.clone(), attempt);
+
+        guard.mark_normal_operations_fenced(ClosingStateFence {
+            coordinator: coordinator.clone(),
+            events: Arc::clone(&events),
+        });
+        drop(guard);
+
+        assert_eq!(logged_events(&events), vec!["release_fence"]);
+        assert!(matches!(coordinator.state(), CoordinatorState::Open));
     }
 
     #[tokio::test]

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -3517,12 +3517,19 @@ mod tests {
     async fn ready_for_park_boundary_quiesce_failure_marks_dirty_without_pause() {
         let coordinator = ParkCoordinator::new();
         let events = event_log();
+        let fence_events = Arc::clone(&events);
         let quiesce_events = Arc::clone(&events);
         let park_events = Arc::clone(&events);
 
-        let result = park_with_ready_for_park(
+        let result = super::park_with_ready_for_park(
             "test-sandbox",
             &coordinator,
+            || async move {
+                fence_events.lock().unwrap().push("fence");
+                Ok(RecordedFence {
+                    events: Arc::clone(&fence_events),
+                })
+            },
             || async move {
                 quiesce_events.lock().unwrap().push("guest_quiesce");
                 Err(io::Error::new(io::ErrorKind::TimedOut, "quiesce timeout"))
@@ -3534,25 +3541,35 @@ mod tests {
         )
         .await;
 
-        assert_idle_transition(result, SandboxIdleTransition::Park);
+        assert_idle_transition(result.map(drop), SandboxIdleTransition::Park);
         assert!(matches!(
             coordinator.state(),
             CoordinatorState::Dirty { .. }
         ));
-        assert_eq!(logged_events(&events), vec!["guest_quiesce"]);
+        assert_eq!(
+            logged_events(&events),
+            vec!["fence", "guest_quiesce", "release_fence"]
+        );
     }
 
     #[tokio::test]
     async fn ready_for_park_boundary_complete_prepare_failure_marks_dirty_without_pause() {
         let coordinator = ParkCoordinator::new();
         let events = event_log();
+        let fence_events = Arc::clone(&events);
         let quiesce_events = Arc::clone(&events);
         let park_events = Arc::clone(&events);
         let quiesce_state = coordinator.clone();
 
-        let result = park_with_ready_for_park(
+        let result = super::park_with_ready_for_park(
             "test-sandbox",
             &coordinator,
+            || async move {
+                fence_events.lock().unwrap().push("fence");
+                Ok(RecordedFence {
+                    events: Arc::clone(&fence_events),
+                })
+            },
             || async move {
                 quiesce_events.lock().unwrap().push("guest_quiesce");
                 quiesce_state.mark_dirty(DirtyReason::new("operation dropped during quiesce"));
@@ -3565,24 +3582,34 @@ mod tests {
         )
         .await;
 
-        assert_idle_transition(result, SandboxIdleTransition::Park);
+        assert_idle_transition(result.map(drop), SandboxIdleTransition::Park);
         assert!(matches!(
             coordinator.state(),
             CoordinatorState::Dirty { .. }
         ));
-        assert_eq!(logged_events(&events), vec!["guest_quiesce"]);
+        assert_eq!(
+            logged_events(&events),
+            vec!["fence", "guest_quiesce", "release_fence"]
+        );
     }
 
     #[tokio::test]
     async fn ready_for_park_boundary_firecracker_failure_after_quiesce_marks_dirty() {
         let coordinator = ParkCoordinator::new();
         let events = event_log();
+        let fence_events = Arc::clone(&events);
         let quiesce_events = Arc::clone(&events);
         let park_events = Arc::clone(&events);
 
-        let result = park_with_ready_for_park(
+        let result = super::park_with_ready_for_park(
             "test-sandbox",
             &coordinator,
+            || async move {
+                fence_events.lock().unwrap().push("fence");
+                Ok(RecordedFence {
+                    events: Arc::clone(&fence_events),
+                })
+            },
             || async move {
                 quiesce_events.lock().unwrap().push("guest_quiesce");
                 Ok(())
@@ -3597,14 +3624,19 @@ mod tests {
         )
         .await;
 
-        assert_idle_transition(result, SandboxIdleTransition::Park);
+        assert_idle_transition(result.map(drop), SandboxIdleTransition::Park);
         assert!(matches!(
             coordinator.state(),
             CoordinatorState::Dirty { .. }
         ));
         assert_eq!(
             logged_events(&events),
-            vec!["guest_quiesce", "firecracker_park"]
+            vec![
+                "fence",
+                "guest_quiesce",
+                "firecracker_park",
+                "release_fence"
+            ]
         );
     }
 
@@ -3612,13 +3644,20 @@ mod tests {
     async fn ready_for_park_boundary_mark_parked_failure_marks_dirty() {
         let coordinator = ParkCoordinator::new();
         let events = event_log();
+        let fence_events = Arc::clone(&events);
         let quiesce_events = Arc::clone(&events);
         let park_events = Arc::clone(&events);
         let park_state = coordinator.clone();
 
-        let result = park_with_ready_for_park(
+        let result = super::park_with_ready_for_park(
             "test-sandbox",
             &coordinator,
+            || async move {
+                fence_events.lock().unwrap().push("fence");
+                Ok(RecordedFence {
+                    events: Arc::clone(&fence_events),
+                })
+            },
             || async move {
                 quiesce_events.lock().unwrap().push("guest_quiesce");
                 Ok(())
@@ -3631,14 +3670,19 @@ mod tests {
         )
         .await;
 
-        assert_idle_transition(result, SandboxIdleTransition::Park);
+        assert_idle_transition(result.map(drop), SandboxIdleTransition::Park);
         assert!(matches!(
             coordinator.state(),
             CoordinatorState::Dirty { .. }
         ));
         assert_eq!(
             logged_events(&events),
-            vec!["guest_quiesce", "firecracker_park"]
+            vec![
+                "fence",
+                "guest_quiesce",
+                "firecracker_park",
+                "release_fence"
+            ]
         );
     }
 
@@ -3816,10 +3860,13 @@ mod tests {
         let coordinator = ParkCoordinator::new();
         mark_coordinator_parked(&coordinator);
         let events = event_log();
+        let mut fence = Some(RecordedFence {
+            events: Arc::clone(&events),
+        });
         let firecracker_events = Arc::clone(&events);
         let resume_events = Arc::clone(&events);
 
-        let result = unpark_with_ready_for_operations(
+        let result = super::unpark_with_ready_for_operations(
             "test-sandbox",
             &coordinator,
             || async move {
@@ -3836,10 +3883,14 @@ mod tests {
                     "resume failed",
                 ))
             },
+            || {
+                drop(fence.take());
+            },
         )
         .await;
 
         assert_idle_transition(result, SandboxIdleTransition::Unpark);
+        assert!(fence.is_some());
         assert_eq!(
             logged_events(&events),
             vec!["firecracker_unpark", "guest_resume"]
@@ -4033,9 +4084,10 @@ mod tests {
         let events = event_log();
         let firecracker_events = Arc::clone(&events);
         let resume_events = Arc::clone(&events);
+        let release_events = Arc::clone(&events);
         let resume_state = coordinator.clone();
 
-        let result = unpark_with_ready_for_operations(
+        let result = super::unpark_with_ready_for_operations(
             "test-sandbox",
             &coordinator,
             || async move {
@@ -4050,13 +4102,16 @@ mod tests {
                 resume_state.mark_dirty(DirtyReason::new("reopen race"));
                 Ok(())
             },
+            || {
+                release_events.lock().unwrap().push("release_fence");
+            },
         )
         .await;
 
         assert_idle_transition(result, SandboxIdleTransition::Unpark);
         assert_eq!(
             logged_events(&events),
-            vec!["firecracker_unpark", "guest_resume"]
+            vec!["firecracker_unpark", "guest_resume", "release_fence"]
         );
         assert!(matches!(
             coordinator.state(),

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -19,7 +19,7 @@ use tokio::io::{AsyncBufReadExt, AsyncRead, BufReader};
 use tokio::sync::{mpsc, watch};
 use tokio_util::sync::CancellationToken;
 use tracing::{info, trace, warn};
-use vsock_host::VsockHost;
+use vsock_host::{NormalOperationFence, NormalOperationFenceRejection, VsockHost};
 
 use crate::api::ApiError;
 use nbd_cow::PooledNbdCowDevice;
@@ -502,6 +502,8 @@ pub struct FirecrackerSandbox {
     /// touch the balloon controller, and to let `stop()` skip vsock
     /// graceful shutdown (guest can't respond with paused vCPUs).
     is_parked: bool,
+    /// Host-side normal-operation fence held while this sandbox is parked.
+    park_fence: Option<NormalOperationFence>,
 }
 
 pub(crate) struct SandboxNetwork {
@@ -568,6 +570,7 @@ impl FirecrackerSandbox {
             delete_workspace_on_leak_cleanup: true,
             destroyed: false,
             is_parked: false,
+            park_fence: None,
         }
     }
 
@@ -1546,16 +1549,33 @@ impl Sandbox for FirecrackerSandbox {
 
     async fn park(&mut self) -> sandbox::Result<()> {
         if self.is_parked {
+            if self.park_fence.is_none() {
+                let message = "sandbox is parked without a normal-operation fence";
+                self.park_coordinator.mark_dirty(DirtyReason::new(message));
+                return Err(idle_transition_error(SandboxIdleTransition::Park, message));
+            }
             return ensure_park_noop_state(&self.park_coordinator);
         }
 
         let coordinator = self.park_coordinator.clone();
         let guest = Arc::clone(&self.guest);
+        let fence_guest = Arc::clone(&guest);
         let id = self.id.clone();
         let api_sock = self.sock_paths.api_sock();
-        park_with_ready_for_park(
+        let normal_operations_fence = park_with_ready_for_park(
             &id,
             &coordinator,
+            || async move {
+                let guest = fence_guest.lock().await.as_ref().cloned().ok_or_else(|| {
+                    ParkNormalOperationFenceError::GuestUnavailable(io::Error::new(
+                        io::ErrorKind::NotConnected,
+                        "guest connection missing during park fence",
+                    ))
+                })?;
+                guest
+                    .try_fence_normal_operations()
+                    .map_err(ParkNormalOperationFenceError::Rejected)
+            },
             || async move {
                 let guest = guest.lock().await.as_ref().cloned().ok_or_else(|| {
                     io::Error::new(
@@ -1575,19 +1595,38 @@ impl Sandbox for FirecrackerSandbox {
                 )
             },
         )
-        .await
+        .await?;
+        self.park_fence = Some(normal_operations_fence);
+        Ok(())
     }
 
     async fn unpark(&mut self) -> sandbox::Result<()> {
         if !self.is_parked {
+            if self.park_fence.is_some() {
+                let message = "sandbox has a normal-operation fence while unpark is a no-op";
+                self.park_coordinator.mark_dirty(DirtyReason::new(message));
+                return Err(idle_transition_error(
+                    SandboxIdleTransition::Unpark,
+                    message,
+                ));
+            }
             return ensure_unpark_noop_state(&self.park_coordinator);
+        }
+        if self.park_fence.is_none() {
+            let message = "sandbox is parked without a normal-operation fence";
+            self.park_coordinator.mark_dirty(DirtyReason::new(message));
+            return Err(idle_transition_error(
+                SandboxIdleTransition::Unpark,
+                message,
+            ));
         }
 
         let coordinator = self.park_coordinator.clone();
         let guest = Arc::clone(&self.guest);
         let id = self.id.clone();
         let api_sock = self.sock_paths.api_sock();
-        unpark_with_ready_for_operations(
+        let mut normal_operations_fence = self.park_fence.take();
+        let result = unpark_with_ready_for_operations(
             &id,
             &coordinator,
             || {
@@ -1609,8 +1648,15 @@ impl Sandbox for FirecrackerSandbox {
                 })?;
                 guest.resume_operations(GUEST_PARK_LIFECYCLE_TIMEOUT).await
             },
+            || {
+                drop(normal_operations_fence.take());
+            },
         )
-        .await
+        .await;
+        if let Some(fence) = normal_operations_fence.take() {
+            self.park_fence = Some(fence);
+        }
+        result
     }
 
     // -- operations --
@@ -1849,24 +1895,37 @@ impl Sandbox for FirecrackerSandbox {
 
 enum ParkBoundaryGuardState {
     Closing,
+    NormalOperationsFenced,
     GuestQuiesceStarted,
     ReadyForPark,
     Disarmed,
 }
 
-struct ParkBoundaryGuard {
+enum ParkNormalOperationFenceError {
+    GuestUnavailable(io::Error),
+    Rejected(NormalOperationFenceRejection),
+}
+
+struct ParkBoundaryGuard<Fence> {
     coordinator: ParkCoordinator,
     attempt: ParkAttempt,
     state: ParkBoundaryGuardState,
+    normal_operations_fence: Option<Fence>,
 }
 
-impl ParkBoundaryGuard {
+impl<Fence> ParkBoundaryGuard<Fence> {
     fn new(coordinator: ParkCoordinator, attempt: ParkAttempt) -> Self {
         Self {
             coordinator,
             attempt,
             state: ParkBoundaryGuardState::Closing,
+            normal_operations_fence: None,
         }
+    }
+
+    fn mark_normal_operations_fenced(&mut self, fence: Fence) {
+        self.normal_operations_fence = Some(fence);
+        self.state = ParkBoundaryGuardState::NormalOperationsFenced;
     }
 
     fn mark_guest_quiesce_started(&mut self) {
@@ -1885,11 +1944,19 @@ impl ParkBoundaryGuard {
         self.state = ParkBoundaryGuardState::Disarmed;
     }
 
-    fn mark_parked(mut self) -> Result<(), PrepareParkError> {
+    fn mark_parked(mut self) -> Result<Fence, PrepareParkError> {
         match self.coordinator.mark_parked(&self.attempt) {
             Ok(()) => {
                 self.state = ParkBoundaryGuardState::Disarmed;
-                Ok(())
+                match self.normal_operations_fence.take() {
+                    Some(fence) => Ok(fence),
+                    None => {
+                        let reason =
+                            DirtyReason::new("park completed without a normal-operation fence");
+                        self.coordinator.mark_dirty(reason.clone());
+                        Err(PrepareParkError::Dirty { reason })
+                    }
+                }
             }
             Err(error) => {
                 let message = format!(
@@ -1905,10 +1972,13 @@ impl ParkBoundaryGuard {
     }
 }
 
-impl Drop for ParkBoundaryGuard {
+impl<Fence> Drop for ParkBoundaryGuard<Fence> {
     fn drop(&mut self) {
         match self.state {
             ParkBoundaryGuardState::Closing => {
+                let _ = self.coordinator.abort_prepare_park(&self.attempt);
+            }
+            ParkBoundaryGuardState::NormalOperationsFenced => {
                 let _ = self.coordinator.abort_prepare_park(&self.attempt);
             }
             ParkBoundaryGuardState::GuestQuiesceStarted => {
@@ -1976,13 +2046,16 @@ impl Drop for UnparkBoundaryGuard {
     }
 }
 
-async fn park_with_ready_for_park<Q, QF, P, PF>(
+async fn park_with_ready_for_park<Fence, F, FF, Q, QF, P, PF>(
     log_id: &str,
     coordinator: &ParkCoordinator,
+    fence_normal_operations: F,
     quiesce_guest: Q,
     park_firecracker: P,
-) -> sandbox::Result<()>
+) -> sandbox::Result<Fence>
 where
+    F: FnOnce() -> FF,
+    FF: Future<Output = Result<Fence, ParkNormalOperationFenceError>>,
     Q: FnOnce() -> QF,
     QF: Future<Output = io::Result<()>>,
     P: FnOnce() -> PF,
@@ -2020,6 +2093,60 @@ where
         }
     };
     let mut guard = ParkBoundaryGuard::new(coordinator.clone(), attempt);
+
+    info!(
+        id = %log_id,
+        transition = "park",
+        phase = "normal_operations_fence",
+        "sandbox park lifecycle normal-operation fence started"
+    );
+    match fence_normal_operations().await {
+        Ok(fence) => {
+            guard.mark_normal_operations_fenced(fence);
+        }
+        Err(ParkNormalOperationFenceError::Rejected(NormalOperationFenceRejection::Busy)) => {
+            warn!(
+                id = %log_id,
+                transition = "park",
+                phase = "normal_operations_fence",
+                reason_kind = "busy",
+                "sandbox park lifecycle normal-operation fence rejected"
+            );
+            return Err(idle_transition_error(
+                SandboxIdleTransition::Park,
+                "normal operations busy while preparing park",
+            ));
+        }
+        Err(ParkNormalOperationFenceError::Rejected(error)) => {
+            let message = format!(
+                "normal operation fence failed while preparing park: {}",
+                normal_operation_fence_rejection_message(error)
+            );
+            warn!(
+                id = %log_id,
+                transition = "park",
+                phase = "normal_operations_fence",
+                reason_kind = normal_operation_fence_rejection_reason_kind(error),
+                error = %message,
+                "sandbox park lifecycle normal-operation fence failed"
+            );
+            guard.mark_dirty(message.clone());
+            return Err(idle_transition_error(SandboxIdleTransition::Park, message));
+        }
+        Err(ParkNormalOperationFenceError::GuestUnavailable(error)) => {
+            let message = format!("guest connection unavailable while fencing park: {error}");
+            warn!(
+                id = %log_id,
+                transition = "park",
+                phase = "normal_operations_fence",
+                reason_kind = "protocol_or_transport",
+                error = %error,
+                "sandbox park lifecycle normal-operation fence failed"
+            );
+            guard.mark_dirty(message.clone());
+            return Err(idle_transition_error(SandboxIdleTransition::Park, message));
+        }
+    }
 
     info!(
         id = %log_id,
@@ -2082,23 +2209,26 @@ where
         return Err(error);
     }
 
-    if let Err(error) = guard.mark_parked() {
-        let reason_kind = prepare_park_error_reason_kind(&error);
-        let error_message = prepare_park_error_message(&error);
-        let message = format!(
-            "operation gate failed to mark parked after Firecracker park: {}",
-            error_message
-        );
-        warn!(
-            id = %log_id,
-            transition = "park",
-            phase = "parked",
-            reason_kind = reason_kind,
-            error = %error_message,
-            "sandbox park lifecycle failed to mark parked"
-        );
-        return Err(idle_transition_error(SandboxIdleTransition::Park, message));
-    }
+    let normal_operations_fence = match guard.mark_parked() {
+        Ok(fence) => fence,
+        Err(error) => {
+            let reason_kind = prepare_park_error_reason_kind(&error);
+            let error_message = prepare_park_error_message(&error);
+            let message = format!(
+                "operation gate failed to mark parked after Firecracker park: {}",
+                error_message
+            );
+            warn!(
+                id = %log_id,
+                transition = "park",
+                phase = "parked",
+                reason_kind = reason_kind,
+                error = %error_message,
+                "sandbox park lifecycle failed to mark parked"
+            );
+            return Err(idle_transition_error(SandboxIdleTransition::Park, message));
+        }
+    };
 
     info!(
         id = %log_id,
@@ -2106,20 +2236,22 @@ where
         phase = "parked",
         "sandbox park lifecycle marked parked"
     );
-    Ok(())
+    Ok(normal_operations_fence)
 }
 
-async fn unpark_with_ready_for_operations<U, UF, R, RF>(
+async fn unpark_with_ready_for_operations<U, UF, R, RF, F>(
     log_id: &str,
     coordinator: &ParkCoordinator,
     unpark_firecracker: U,
     resume_guest: R,
+    release_normal_operations_fence: F,
 ) -> sandbox::Result<()>
 where
     U: FnOnce() -> UF,
     UF: Future<Output = sandbox::Result<()>>,
     R: FnOnce() -> RF,
     RF: Future<Output = io::Result<()>>,
+    F: FnOnce(),
 {
     info!(
         id = %log_id,
@@ -2181,6 +2313,8 @@ where
             message,
         ));
     }
+
+    release_normal_operations_fence();
 
     if let Err(error) = coordinator.reopen_after_unpark() {
         let reason_kind = prepare_park_error_reason_kind(&error);
@@ -2288,6 +2422,26 @@ fn prepare_park_error_reason_kind(error: &PrepareParkError) -> &'static str {
         PrepareParkError::Dirty { .. } => "dirty",
         PrepareParkError::InvalidState { .. } => "invalid_state",
         PrepareParkError::StaleAttempt { .. } => "stale_attempt",
+    }
+}
+
+fn normal_operation_fence_rejection_message(error: NormalOperationFenceRejection) -> &'static str {
+    match error {
+        NormalOperationFenceRejection::Busy => "normal operations busy",
+        NormalOperationFenceRejection::AlreadyFenced => "normal operations already fenced",
+        NormalOperationFenceRejection::NotParkable => "normal operations not parkable",
+        NormalOperationFenceRejection::Closed => "guest connection closed",
+    }
+}
+
+fn normal_operation_fence_rejection_reason_kind(
+    error: NormalOperationFenceRejection,
+) -> &'static str {
+    match error {
+        NormalOperationFenceRejection::Busy => "busy",
+        NormalOperationFenceRejection::AlreadyFenced => "already_fenced",
+        NormalOperationFenceRejection::NotParkable => "not_parkable",
+        NormalOperationFenceRejection::Closed => "closed",
     }
 }
 
@@ -2561,6 +2715,53 @@ mod tests {
         MSG_PROCESS_CONTROL, MSG_PROCESS_CONTROL_RESULT, MSG_PROCESS_EXIT, MSG_READY,
         MSG_SPAWN_PROCESS, MSG_SPAWN_PROCESS_RESULT, ProcessControlStatus, RawMessage,
     };
+
+    struct TestNormalOperationFence;
+
+    async fn park_with_ready_for_park<Q, QF, P, PF>(
+        log_id: &str,
+        coordinator: &ParkCoordinator,
+        quiesce_guest: Q,
+        park_firecracker: P,
+    ) -> sandbox::Result<()>
+    where
+        Q: FnOnce() -> QF,
+        QF: Future<Output = io::Result<()>>,
+        P: FnOnce() -> PF,
+        PF: Future<Output = sandbox::Result<()>>,
+    {
+        super::park_with_ready_for_park(
+            log_id,
+            coordinator,
+            || async { Ok(TestNormalOperationFence) },
+            quiesce_guest,
+            park_firecracker,
+        )
+        .await
+        .map(drop)
+    }
+
+    async fn unpark_with_ready_for_operations<U, UF, R, RF>(
+        log_id: &str,
+        coordinator: &ParkCoordinator,
+        unpark_firecracker: U,
+        resume_guest: R,
+    ) -> sandbox::Result<()>
+    where
+        U: FnOnce() -> UF,
+        UF: Future<Output = sandbox::Result<()>>,
+        R: FnOnce() -> RF,
+        RF: Future<Output = io::Result<()>>,
+    {
+        super::unpark_with_ready_for_operations(
+            log_id,
+            coordinator,
+            unpark_firecracker,
+            resume_guest,
+            || {},
+        )
+        .await
+    }
 
     struct ProcessControlFixture {
         host: Arc<VsockHost>,
@@ -3010,6 +3211,16 @@ mod tests {
         events.lock().unwrap().clone()
     }
 
+    struct RecordedFence {
+        events: Arc<Mutex<Vec<&'static str>>>,
+    }
+
+    impl Drop for RecordedFence {
+        fn drop(&mut self) {
+            self.events.lock().unwrap().push("release_fence");
+        }
+    }
+
     #[test]
     fn park_noop_with_parked_gate_succeeds() {
         let coordinator = ParkCoordinator::new();
@@ -3076,6 +3287,107 @@ mod tests {
             vec!["guest_quiesce", "firecracker_park"]
         );
         assert!(matches!(coordinator.state(), CoordinatorState::Parked));
+    }
+
+    #[tokio::test]
+    async fn ready_for_park_boundary_fences_before_quiesce_and_holds_until_returned() {
+        let coordinator = ParkCoordinator::new();
+        let events = event_log();
+        let fence_events = Arc::clone(&events);
+        let quiesce_events = Arc::clone(&events);
+        let park_events = Arc::clone(&events);
+
+        let fence = super::park_with_ready_for_park(
+            "test-sandbox",
+            &coordinator,
+            || async move {
+                fence_events.lock().unwrap().push("fence");
+                Ok(RecordedFence {
+                    events: Arc::clone(&fence_events),
+                })
+            },
+            || async move {
+                quiesce_events.lock().unwrap().push("guest_quiesce");
+                Ok(())
+            },
+            || async move {
+                park_events.lock().unwrap().push("firecracker_park");
+                Ok(())
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            logged_events(&events),
+            vec!["fence", "guest_quiesce", "firecracker_park"]
+        );
+        drop(fence);
+        assert_eq!(
+            logged_events(&events),
+            vec![
+                "fence",
+                "guest_quiesce",
+                "firecracker_park",
+                "release_fence"
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn ready_for_park_boundary_busy_fence_aborts_without_dirtying() {
+        let coordinator = ParkCoordinator::new();
+        let events = event_log();
+        let fence_events = Arc::clone(&events);
+        let quiesce_events = Arc::clone(&events);
+        let park_events = Arc::clone(&events);
+
+        let result = super::park_with_ready_for_park(
+            "test-sandbox",
+            &coordinator,
+            || async move {
+                fence_events.lock().unwrap().push("fence");
+                Err::<RecordedFence, _>(ParkNormalOperationFenceError::Rejected(
+                    NormalOperationFenceRejection::Busy,
+                ))
+            },
+            || async move {
+                quiesce_events.lock().unwrap().push("guest_quiesce");
+                Ok(())
+            },
+            || async move {
+                park_events.lock().unwrap().push("firecracker_park");
+                Ok(())
+            },
+        )
+        .await;
+
+        assert_idle_transition(result.map(drop), SandboxIdleTransition::Park);
+        assert_eq!(logged_events(&events), vec!["fence"]);
+        assert!(matches!(coordinator.state(), CoordinatorState::Open));
+    }
+
+    #[tokio::test]
+    async fn ready_for_park_boundary_not_parkable_fence_marks_dirty() {
+        let coordinator = ParkCoordinator::new();
+        let result = super::park_with_ready_for_park(
+            "test-sandbox",
+            &coordinator,
+            || async {
+                Err::<RecordedFence, _>(ParkNormalOperationFenceError::Rejected(
+                    NormalOperationFenceRejection::NotParkable,
+                ))
+            },
+            || async { Ok(()) },
+            || async { Ok(()) },
+        )
+        .await;
+
+        assert_idle_transition(result.map(drop), SandboxIdleTransition::Park);
+        assert!(matches!(
+            coordinator.state(),
+            CoordinatorState::Dirty { .. }
+        ));
     }
 
     #[tokio::test]
@@ -3387,6 +3699,45 @@ mod tests {
         assert_eq!(
             logged_events(&events),
             vec!["firecracker_unpark", "guest_resume"]
+        );
+        assert!(matches!(coordinator.state(), CoordinatorState::Open));
+    }
+
+    #[tokio::test]
+    async fn ready_for_operations_boundary_releases_fence_before_reopening_gate() {
+        let coordinator = ParkCoordinator::new();
+        mark_coordinator_parked(&coordinator);
+        let events = event_log();
+        let firecracker_events = Arc::clone(&events);
+        let resume_events = Arc::clone(&events);
+        let release_events = Arc::clone(&events);
+        let release_state = coordinator.clone();
+
+        super::unpark_with_ready_for_operations(
+            "test-sandbox",
+            &coordinator,
+            || async move {
+                firecracker_events
+                    .lock()
+                    .unwrap()
+                    .push("firecracker_unpark");
+                Ok(())
+            },
+            || async move {
+                resume_events.lock().unwrap().push("guest_resume");
+                Ok(())
+            },
+            || {
+                assert!(matches!(release_state.state(), CoordinatorState::Parked));
+                release_events.lock().unwrap().push("release_fence");
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            logged_events(&events),
+            vec!["firecracker_unpark", "guest_resume", "release_fence"]
         );
         assert!(matches!(coordinator.state(), CoordinatorState::Open));
     }

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -1464,6 +1464,7 @@ impl Sandbox for FirecrackerSandbox {
             if self.current_state() == SandboxState::Crashed {
                 self.runtime.shutdown_services().await;
                 self.guest.lock().await.take();
+                release_park_state_for_termination(&mut self.is_parked, &mut self.park_fence);
                 self.runtime.kill_process().await;
             }
             return Ok(());
@@ -1484,14 +1485,15 @@ impl Sandbox for FirecrackerSandbox {
         // deflate failed), is_parked is true but vCPUs are actually running.
         // Skipping graceful shutdown is still correct — the sandbox was idle
         // with no user workload.
-        if !self.is_parked {
-            let guest = self.guest.lock().await.take();
-            if let Some(guest) = guest
-                && !guest.shutdown(SHUTDOWN_TIMEOUT).await
-            {
-                warn!(id = %self.id, "graceful shutdown timed out");
-            }
+        let was_parked = self.is_parked;
+        let guest = self.guest.lock().await.take();
+        if !was_parked
+            && let Some(guest) = guest
+            && !guest.shutdown(SHUTDOWN_TIMEOUT).await
+        {
+            warn!(id = %self.id, "graceful shutdown timed out");
         }
+        release_park_state_for_termination(&mut self.is_parked, &mut self.park_fence);
 
         self.runtime.kill_process().await;
         self.publish_state(SandboxState::Stopped);
@@ -1504,12 +1506,14 @@ impl Sandbox for FirecrackerSandbox {
             if self.current_state() == SandboxState::Crashed {
                 self.runtime.shutdown_services().await;
                 self.guest.lock().await.take();
+                release_park_state_for_termination(&mut self.is_parked, &mut self.park_fence);
                 self.runtime.kill_process().await;
             }
             return Ok(());
         }
         self.runtime.shutdown_services().await;
         self.guest.lock().await.take();
+        release_park_state_for_termination(&mut self.is_parked, &mut self.park_fence);
         self.runtime.kill_process().await;
         self.publish_state(SandboxState::Stopped);
         info!(id = %self.id, "sandbox killed");
@@ -2048,6 +2052,11 @@ impl Drop for UnparkBoundaryGuard {
             UnparkBoundaryGuardState::Disarmed => {}
         }
     }
+}
+
+fn release_park_state_for_termination<Fence>(is_parked: &mut bool, park_fence: &mut Option<Fence>) {
+    *is_parked = false;
+    drop(park_fence.take());
 }
 
 async fn park_with_ready_for_park<Fence, F, FF, Q, QF, P, PF>(
@@ -3239,6 +3248,21 @@ mod tests {
             ));
             self.events.lock().unwrap().push("release_fence");
         }
+    }
+
+    #[test]
+    fn termination_releases_park_fence_and_clears_parked_flag() {
+        let events = event_log();
+        let mut is_parked = true;
+        let mut fence = Some(RecordedFence {
+            events: Arc::clone(&events),
+        });
+
+        release_park_state_for_termination(&mut is_parked, &mut fence);
+
+        assert!(!is_parked);
+        assert!(fence.is_none());
+        assert_eq!(logged_events(&events), vec!["release_fence"]);
     }
 
     #[test]

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -3395,6 +3395,23 @@ mod tests {
         assert!(matches!(coordinator.state(), CoordinatorState::Open));
     }
 
+    #[test]
+    fn ready_for_park_boundary_missing_fence_marks_dirty_after_ready_for_park() {
+        let coordinator = ParkCoordinator::new();
+        let attempt = coordinator.begin_prepare_park().unwrap();
+        let mut guard: ParkBoundaryGuard<RecordedFence> =
+            ParkBoundaryGuard::new(coordinator.clone(), attempt);
+
+        guard.complete_prepare().unwrap();
+        let error = guard.mark_parked().unwrap_err();
+
+        assert!(matches!(error, PrepareParkError::Dirty { .. }));
+        assert!(matches!(
+            coordinator.state(),
+            CoordinatorState::Dirty { .. }
+        ));
+    }
+
     #[tokio::test]
     async fn ready_for_park_boundary_busy_fence_aborts_without_dirtying() {
         let coordinator = ParkCoordinator::new();

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -3452,6 +3452,40 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn ready_for_park_boundary_guest_unavailable_fence_marks_dirty_without_pause() {
+        let coordinator = ParkCoordinator::new();
+        let events = event_log();
+        let quiesce_events = Arc::clone(&events);
+        let park_events = Arc::clone(&events);
+
+        let result = super::park_with_ready_for_park(
+            "test-sandbox",
+            &coordinator,
+            || async {
+                Err::<RecordedFence, _>(ParkNormalOperationFenceError::GuestUnavailable(
+                    io::Error::new(io::ErrorKind::NotConnected, "guest missing"),
+                ))
+            },
+            || async move {
+                quiesce_events.lock().unwrap().push("guest_quiesce");
+                Ok(())
+            },
+            || async move {
+                park_events.lock().unwrap().push("firecracker_park");
+                Ok(())
+            },
+        )
+        .await;
+
+        assert_idle_transition(result.map(drop), SandboxIdleTransition::Park);
+        assert!(logged_events(&events).is_empty());
+        assert!(matches!(
+            coordinator.state(),
+            CoordinatorState::Dirty { .. }
+        ));
+    }
+
+    #[tokio::test]
     async fn ready_for_park_boundary_busy_prevents_quiesce_and_pause() {
         let coordinator = ParkCoordinator::new();
         let _lease = active_spawn_process_lease(&coordinator);

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -1628,17 +1628,21 @@ impl Sandbox for FirecrackerSandbox {
         let guest = Arc::clone(&self.guest);
         let id = self.id.clone();
         let api_sock = self.sock_paths.api_sock();
-        let mut normal_operations_fence = self.park_fence.take();
-        let result = unpark_with_ready_for_operations(
+        let memory_mb = self.config.resources.memory_mb;
+        let state_rx = self.state_tx.subscribe();
+        let is_parked = &mut self.is_parked;
+        let balloon_controller = self.runtime.balloon_mut();
+        let park_fence = &mut self.park_fence;
+        unpark_with_ready_for_operations(
             &id,
             &coordinator,
             || {
                 unpark_inner(
-                    &mut self.is_parked,
-                    self.config.resources.memory_mb,
-                    self.runtime.balloon_mut(),
+                    is_parked,
+                    memory_mb,
+                    balloon_controller,
                     &api_sock,
-                    self.state_tx.subscribe(),
+                    state_rx,
                     &id,
                 )
             },
@@ -1652,14 +1656,10 @@ impl Sandbox for FirecrackerSandbox {
                 guest.resume_operations(GUEST_PARK_LIFECYCLE_TIMEOUT).await
             },
             || {
-                drop(normal_operations_fence.take());
+                drop(park_fence.take());
             },
         )
-        .await;
-        if let Some(fence) = normal_operations_fence.take() {
-            self.park_fence = Some(fence);
-        }
-        result
+        .await
     }
 
     // -- operations --
@@ -3949,6 +3949,45 @@ mod tests {
         }
 
         assert_eq!(logged_events(&events), vec!["firecracker_unpark"]);
+        assert!(matches!(
+            coordinator.state(),
+            CoordinatorState::Dirty { .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn ready_for_operations_boundary_cancel_during_firecracker_unpark_keeps_fence() {
+        let coordinator = ParkCoordinator::new();
+        mark_coordinator_parked(&coordinator);
+        let events = event_log();
+        let mut fence = Some(RecordedFence {
+            events: Arc::clone(&events),
+        });
+        let (firecracker_started_tx, firecracker_started_rx) = tokio::sync::oneshot::channel();
+
+        {
+            let unpark = super::unpark_with_ready_for_operations(
+                "test-sandbox",
+                &coordinator,
+                || async move {
+                    let _ = firecracker_started_tx.send(());
+                    std::future::pending::<sandbox::Result<()>>().await
+                },
+                || async { Ok(()) },
+                || {
+                    drop(fence.take());
+                },
+            );
+            tokio::pin!(unpark);
+
+            tokio::select! {
+                result = &mut unpark => panic!("unpark completed unexpectedly: {result:?}"),
+                result = firecracker_started_rx => result.unwrap(),
+            }
+        }
+
+        assert!(fence.is_some());
+        assert!(logged_events(&events).is_empty());
         assert!(matches!(
             coordinator.state(),
             CoordinatorState::Dirty { .. }

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -3215,6 +3215,7 @@ mod tests {
         events.lock().unwrap().clone()
     }
 
+    #[derive(Debug)]
     struct RecordedFence {
         events: Arc<Mutex<Vec<&'static str>>>,
     }
@@ -3689,13 +3690,23 @@ mod tests {
     #[tokio::test]
     async fn ready_for_park_boundary_cancel_during_guest_quiesce_marks_dirty() {
         let coordinator = ParkCoordinator::new();
+        let events = event_log();
+        let fence_events = Arc::clone(&events);
+        let quiesce_events = Arc::clone(&events);
         let (quiesce_started_tx, quiesce_started_rx) = tokio::sync::oneshot::channel();
 
         {
-            let park = park_with_ready_for_park(
+            let park = super::park_with_ready_for_park(
                 "test-sandbox",
                 &coordinator,
                 || async move {
+                    fence_events.lock().unwrap().push("fence");
+                    Ok(RecordedFence {
+                        events: Arc::clone(&fence_events),
+                    })
+                },
+                || async move {
+                    quiesce_events.lock().unwrap().push("guest_quiesce");
                     let _ = quiesce_started_tx.send(());
                     std::future::pending::<io::Result<()>>().await
                 },
@@ -3709,6 +3720,10 @@ mod tests {
             }
         }
 
+        assert_eq!(
+            logged_events(&events),
+            vec!["fence", "guest_quiesce", "release_fence"]
+        );
         assert!(matches!(
             coordinator.state(),
             CoordinatorState::Dirty { .. }
@@ -3718,14 +3733,28 @@ mod tests {
     #[tokio::test]
     async fn ready_for_park_boundary_cancel_after_ready_for_park_marks_dirty() {
         let coordinator = ParkCoordinator::new();
+        let events = event_log();
+        let fence_events = Arc::clone(&events);
+        let quiesce_events = Arc::clone(&events);
+        let park_events = Arc::clone(&events);
         let (park_started_tx, park_started_rx) = tokio::sync::oneshot::channel();
 
         {
-            let park = park_with_ready_for_park(
+            let park = super::park_with_ready_for_park(
                 "test-sandbox",
                 &coordinator,
-                || async { Ok(()) },
                 || async move {
+                    fence_events.lock().unwrap().push("fence");
+                    Ok(RecordedFence {
+                        events: Arc::clone(&fence_events),
+                    })
+                },
+                || async move {
+                    quiesce_events.lock().unwrap().push("guest_quiesce");
+                    Ok(())
+                },
+                || async move {
+                    park_events.lock().unwrap().push("firecracker_park");
                     let _ = park_started_tx.send(());
                     std::future::pending::<sandbox::Result<()>>().await
                 },
@@ -3742,6 +3771,15 @@ mod tests {
             ));
         }
 
+        assert_eq!(
+            logged_events(&events),
+            vec![
+                "fence",
+                "guest_quiesce",
+                "firecracker_park",
+                "release_fence"
+            ]
+        );
         assert!(matches!(
             coordinator.state(),
             CoordinatorState::Dirty { .. }
@@ -3827,10 +3865,13 @@ mod tests {
         let coordinator = ParkCoordinator::new();
         mark_coordinator_parked(&coordinator);
         let events = event_log();
+        let mut fence = Some(RecordedFence {
+            events: Arc::clone(&events),
+        });
         let firecracker_events = Arc::clone(&events);
         let resume_events = Arc::clone(&events);
 
-        let result = unpark_with_ready_for_operations(
+        let result = super::unpark_with_ready_for_operations(
             "test-sandbox",
             &coordinator,
             || async move {
@@ -3847,10 +3888,14 @@ mod tests {
                 resume_events.lock().unwrap().push("guest_resume");
                 Ok(())
             },
+            || {
+                drop(fence.take());
+            },
         )
         .await;
 
         assert_idle_transition(result, SandboxIdleTransition::Unpark);
+        assert!(fence.is_some());
         assert_eq!(logged_events(&events), vec!["firecracker_unpark"]);
         assert!(matches!(coordinator.state(), CoordinatorState::Parked));
     }

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -682,7 +682,7 @@ async fn normal_request_on_shared_with_write_observer(
         payload,
         terminal_msg_types,
         timeout,
-        || Ok(()),
+        |_| Ok(()),
         write_observer,
     )
     .await
@@ -694,7 +694,7 @@ async fn normal_request_on_shared_with_pre_write_observer(
     payload: &[u8],
     terminal_msg_types: &'static [u8],
     timeout: Duration,
-    pre_write: impl FnOnce() -> io::Result<()>,
+    pre_write: impl FnOnce(&mut ConnectionState) -> io::Result<()>,
     write_observer: FrameWriteObserver,
 ) -> io::Result<RawMessage> {
     let seq = shared.next_seq();
@@ -727,8 +727,7 @@ async fn normal_request_on_shared_with_pre_write_observer(
     let _pending_guard = PendingRequestGuard::new(Arc::clone(shared), seq);
 
     write_request_frame(shared, &data, || {
-        pre_write()?;
-        mark_pending_normal_operation_possible_guest_write(shared, seq)?;
+        mark_pending_normal_operation_possible_guest_write(shared, seq, pre_write)?;
         write_observer.record_write_start()
     })
     .await?;
@@ -809,8 +808,10 @@ async fn request_on_shared_with_composite_operation_and_observer(
 fn mark_pending_normal_operation_possible_guest_write(
     shared: &Arc<Shared>,
     seq: u32,
+    pre_write: impl FnOnce(&mut ConnectionState) -> io::Result<()>,
 ) -> io::Result<()> {
     let mut guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
+    pre_write(&mut guard)?;
     match &mut *guard {
         ConnectionState::Connected { pending, .. } => {
             let Some(pending_response) = pending.get_mut(&seq) else {

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -676,17 +676,75 @@ async fn normal_request_on_shared_with_write_observer(
     timeout: Duration,
     write_observer: FrameWriteObserver,
 ) -> io::Result<RawMessage> {
-    let seq = shared.next_seq();
-    normal_request_raw_on_shared_with_write_observer(
+    normal_request_on_shared_with_pre_write_observer(
         shared,
         msg_type,
-        seq,
         payload,
         terminal_msg_types,
         timeout,
+        || Ok(()),
         write_observer,
     )
     .await
+}
+
+async fn normal_request_on_shared_with_pre_write_observer(
+    shared: &Arc<Shared>,
+    msg_type: u8,
+    payload: &[u8],
+    terminal_msg_types: &'static [u8],
+    timeout: Duration,
+    pre_write: impl FnOnce() -> io::Result<()>,
+    write_observer: FrameWriteObserver,
+) -> io::Result<RawMessage> {
+    let seq = shared.next_seq();
+    let data = vsock_proto::encode(msg_type, seq, payload)
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e.to_string()))?;
+    let normal_operation = shared.reserve_normal_operation()?;
+
+    let (tx, rx) = oneshot::channel();
+    {
+        let mut guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
+        match &mut *guard {
+            ConnectionState::Closed { .. } => {
+                return Err(io::Error::new(
+                    io::ErrorKind::ConnectionReset,
+                    "connection closed",
+                ));
+            }
+            ConnectionState::Connected { pending, .. } => {
+                pending.insert(
+                    seq,
+                    PendingResponse {
+                        response_tx: tx,
+                        normal_operation: Some(PendingNormalOperation::Owned(normal_operation)),
+                        normal_terminal_msg_types: terminal_msg_types,
+                    },
+                );
+            }
+        }
+    }
+    let _pending_guard = PendingRequestGuard::new(Arc::clone(shared), seq);
+
+    write_request_frame(shared, &data, || {
+        pre_write()?;
+        mark_pending_normal_operation_possible_guest_write(shared, seq)?;
+        write_observer.record_write_start()
+    })
+    .await?;
+
+    tokio::select! {
+        biased;
+        result = rx => {
+            result.map_err(|_| io::Error::new(
+                    io::ErrorKind::ConnectionReset,
+                    "connection closed",
+                ))
+        }
+        _ = tokio::time::sleep(timeout) => {
+            Err(io::Error::new(io::ErrorKind::TimedOut, "request timeout"))
+        }
+    }
 }
 
 async fn request_on_shared_with_composite_operation_and_observer(
@@ -741,63 +799,6 @@ async fn request_on_shared_with_composite_operation_and_observer(
                 io::ErrorKind::ConnectionReset,
                 "connection closed",
             ))
-        }
-        _ = tokio::time::sleep(timeout) => {
-            Err(io::Error::new(io::ErrorKind::TimedOut, "request timeout"))
-        }
-    }
-}
-
-async fn normal_request_raw_on_shared_with_write_observer(
-    shared: &Arc<Shared>,
-    msg_type: u8,
-    seq: u32,
-    payload: &[u8],
-    terminal_msg_types: &'static [u8],
-    timeout: Duration,
-    write_observer: FrameWriteObserver,
-) -> io::Result<RawMessage> {
-    let data = vsock_proto::encode(msg_type, seq, payload)
-        .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e.to_string()))?;
-    let normal_operation = shared.reserve_normal_operation()?;
-
-    let (tx, rx) = oneshot::channel();
-    {
-        let mut guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
-        match &mut *guard {
-            ConnectionState::Closed { .. } => {
-                return Err(io::Error::new(
-                    io::ErrorKind::ConnectionReset,
-                    "connection closed",
-                ));
-            }
-            ConnectionState::Connected { pending, .. } => {
-                pending.insert(
-                    seq,
-                    PendingResponse {
-                        response_tx: tx,
-                        normal_operation: Some(PendingNormalOperation::Owned(normal_operation)),
-                        normal_terminal_msg_types: terminal_msg_types,
-                    },
-                );
-            }
-        }
-    }
-    let _pending_guard = PendingRequestGuard::new(Arc::clone(shared), seq);
-
-    write_request_frame(shared, &data, || {
-        mark_pending_normal_operation_possible_guest_write(shared, seq)?;
-        write_observer.record_write_start()
-    })
-    .await?;
-
-    tokio::select! {
-        biased;
-        result = rx => {
-            result.map_err(|_| io::Error::new(
-                    io::ErrorKind::ConnectionReset,
-                    "connection closed",
-                ))
         }
         _ = tokio::time::sleep(timeout) => {
             Err(io::Error::new(io::ErrorKind::TimedOut, "request timeout"))

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -39,6 +39,7 @@ use tokio::task::JoinHandle;
 use tokio::time::{self, Instant};
 
 use operation_tracker::{
+    NormalOperationFenceRejection as TrackerNormalOperationFenceRejection,
     NormalOperationRejection, NormalOperationToken, NormalOperationTracker,
     NormalOperationTransitionError, NormalOperationTransitionHandle,
 };
@@ -92,6 +93,36 @@ impl FrameWriteObserver {
 impl Default for FrameWriteObserver {
     fn default() -> Self {
         Self::noop()
+    }
+}
+
+/// Opaque guard that fences new normal guest operations on a [`VsockHost`].
+///
+/// While this guard is alive, normal operations such as exec, file transfer, and
+/// spawn-process requests are rejected by the host-side operation tracker.
+/// Lifecycle requests such as quiesce/resume are not normal operations and can
+/// still be sent while the guard is held.
+#[derive(Debug)]
+pub struct NormalOperationFence {
+    _inner: operation_tracker::NormalOperationFence,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum NormalOperationFenceRejection {
+    Busy,
+    AlreadyFenced,
+    NotParkable,
+    Closed,
+}
+
+impl From<TrackerNormalOperationFenceRejection> for NormalOperationFenceRejection {
+    fn from(error: TrackerNormalOperationFenceRejection) -> Self {
+        match error {
+            TrackerNormalOperationFenceRejection::Busy => Self::Busy,
+            TrackerNormalOperationFenceRejection::AlreadyFenced => Self::AlreadyFenced,
+            TrackerNormalOperationFenceRejection::NotParkable => Self::NotParkable,
+            TrackerNormalOperationFenceRejection::Closed => Self::Closed,
+        }
     }
 }
 
@@ -1035,11 +1066,27 @@ impl VsockHost {
         validate_empty_lifecycle_response(&response, response_payload_name)
     }
 
-    /// Fence new guest operations before a higher-level lifecycle transition.
+    /// Try to fence new normal guest operations on this connection.
     ///
-    /// This is a same-connection lifecycle check: the guest either reports no
-    /// in-flight operations with `operations_quiesced`, or returns `error` and keeps
-    /// the operation fence closed until [`resume_operations`](Self::resume_operations).
+    /// The returned guard keeps normal operations fenced until it is dropped.
+    /// Lifecycle requests such as [`quiesce_operations`](Self::quiesce_operations)
+    /// and [`resume_operations`](Self::resume_operations) remain available while
+    /// the guard is held.
+    pub fn try_fence_normal_operations(
+        &self,
+    ) -> Result<NormalOperationFence, NormalOperationFenceRejection> {
+        self.shared
+            .normal_operations
+            .try_fence()
+            .map(|inner| NormalOperationFence { _inner: inner })
+            .map_err(Into::into)
+    }
+
+    /// Ask the guest to quiesce its own operation dispatcher.
+    ///
+    /// This does not fence host-side normal operations. Callers that need a
+    /// no-new-normal-operation boundary must hold a
+    /// [`NormalOperationFence`] before sending this lifecycle request.
     pub async fn quiesce_operations(&self, timeout: Duration) -> io::Result<()> {
         self.lifecycle_request(
             MSG_QUIESCE_OPERATIONS,

--- a/crates/vsock-host/src/process.rs
+++ b/crates/vsock-host/src/process.rs
@@ -412,6 +412,7 @@ impl GuestProcessControlHandle {
             request_timeout_ms,
         )
         .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e.to_string()))?;
+        ensure_process_control_target_active(&self.shared, self.target_seq)?;
         let response = normal_request_on_shared_with_write_observer(
             &self.shared,
             MSG_PROCESS_CONTROL,
@@ -519,6 +520,23 @@ fn duration_to_request_timeout_ms(timeout: Duration) -> u32 {
     u32::try_from(timeout.as_millis())
         .unwrap_or(u32::MAX)
         .max(1)
+}
+
+fn ensure_process_control_target_active(shared: &Arc<Shared>, target_seq: u32) -> io::Result<()> {
+    let guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
+    match &*guard {
+        ConnectionState::Connected { process, .. } if process.contains_operation(target_seq) => {
+            Ok(())
+        }
+        ConnectionState::Connected { .. } => Err(process_control_status_error(
+            ProcessControlStatus::Inactive,
+            "process operation is not active",
+        )),
+        ConnectionState::Closed { .. } => Err(io::Error::new(
+            io::ErrorKind::ConnectionReset,
+            "connection closed",
+        )),
+    }
 }
 
 fn remove_process_operation(shared: &Arc<Shared>, seq: u32) {

--- a/crates/vsock-host/src/process.rs
+++ b/crates/vsock-host/src/process.rs
@@ -419,9 +419,8 @@ impl GuestProcessControlHandle {
             PROCESS_CONTROL_TERMINAL_MSG_TYPES,
             timeout,
             {
-                let shared = Arc::clone(&self.shared);
                 let target_seq = self.target_seq;
-                move || ensure_process_control_target_active(&shared, target_seq)
+                move |state| ensure_process_control_target_active(state, target_seq)
             },
             write_observer,
         )
@@ -526,9 +525,11 @@ fn duration_to_request_timeout_ms(timeout: Duration) -> u32 {
         .max(1)
 }
 
-fn ensure_process_control_target_active(shared: &Arc<Shared>, target_seq: u32) -> io::Result<()> {
-    let guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
-    match &*guard {
+fn ensure_process_control_target_active(
+    state: &ConnectionState,
+    target_seq: u32,
+) -> io::Result<()> {
+    match state {
         ConnectionState::Connected { process, .. } if process.contains_operation(target_seq) => {
             Ok(())
         }

--- a/crates/vsock-host/src/process.rs
+++ b/crates/vsock-host/src/process.rs
@@ -13,7 +13,7 @@ use vsock_proto::{
 
 use crate::{
     ConnectionState, FrameWriteObserver, PendingRequestGuard, PendingResponse, Shared,
-    normal_request_on_shared_with_write_observer, operation_tracker::NormalOperationToken,
+    normal_request_on_shared_with_pre_write_observer, operation_tracker::NormalOperationToken,
 };
 
 const SPAWN_PROCESS_RESPONSE_TIMEOUT: Duration = Duration::from_secs(30);
@@ -412,13 +412,17 @@ impl GuestProcessControlHandle {
             request_timeout_ms,
         )
         .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e.to_string()))?;
-        ensure_process_control_target_active(&self.shared, self.target_seq)?;
-        let response = normal_request_on_shared_with_write_observer(
+        let response = normal_request_on_shared_with_pre_write_observer(
             &self.shared,
             MSG_PROCESS_CONTROL,
             &request,
             PROCESS_CONTROL_TERMINAL_MSG_TYPES,
             timeout,
+            {
+                let shared = Arc::clone(&self.shared);
+                let target_seq = self.target_seq;
+                move || ensure_process_control_target_active(&shared, target_seq)
+            },
             write_observer,
         )
         .await?;

--- a/crates/vsock-host/src/tests/connection.rs
+++ b/crates/vsock-host/src/tests/connection.rs
@@ -148,6 +148,10 @@ async fn normal_operation_fence_rejects_new_normal_operations_until_dropped() {
     let fence = host
         .try_fence_normal_operations()
         .expect("idle host should fence normal operations");
+    assert_eq!(
+        host.try_fence_normal_operations().unwrap_err(),
+        NormalOperationFenceRejection::AlreadyFenced
+    );
 
     let err = host.exec("blocked", 5000, &[], false).await.unwrap_err();
     assert_eq!(err.kind(), io::ErrorKind::WouldBlock);

--- a/crates/vsock-host/src/tests/connection.rs
+++ b/crates/vsock-host/src/tests/connection.rs
@@ -172,6 +172,7 @@ async fn normal_operation_fence_rejects_new_normal_operations_until_dropped() {
 async fn normal_operation_fence_reports_busy_closed_and_not_parkable() {
     let (host_stream, mut guest) = make_pair();
     let release_exec = Arc::new(tokio::sync::Notify::new());
+    let (request_seen_tx, request_seen_rx) = tokio::sync::oneshot::channel();
     let guest_task = {
         let release_exec = Arc::clone(&release_exec);
         tokio::spawn(async move {
@@ -179,6 +180,7 @@ async fn normal_operation_fence_reports_busy_closed_and_not_parkable() {
             mock_handshake(&mut guest, &mut decoder).await;
             let request = read_guest_message(&mut guest).await;
             assert_eq!(request.msg_type, MSG_EXEC_START);
+            let _ = request_seen_tx.send(());
             release_exec.notified().await;
             send_exec_result(
                 &mut guest,
@@ -197,13 +199,10 @@ async fn normal_operation_fence_reports_busy_closed_and_not_parkable() {
         let host = Arc::clone(&host);
         tokio::spawn(async move { host.exec("sleep", 5000, &[], false).await })
     };
-    tokio::time::timeout(Duration::from_secs(2), async {
-        while normal_operation_readiness(&host) != NormalOperationReadiness::Busy {
-            tokio::task::yield_now().await;
-        }
-    })
-    .await
-    .unwrap();
+    tokio::time::timeout(Duration::from_secs(2), request_seen_rx)
+        .await
+        .expect("guest should receive exec start before busy assertion")
+        .unwrap();
     assert_eq!(
         host.try_fence_normal_operations().unwrap_err(),
         NormalOperationFenceRejection::Busy

--- a/crates/vsock-host/src/tests/connection.rs
+++ b/crates/vsock-host/src/tests/connection.rs
@@ -14,7 +14,9 @@ use super::support::{
     host_from_stream, is_connected, make_pair, mock_handshake, normal_operation_readiness,
     poison_connection, read_guest_message, send_exec_result, setup_host_and_guest,
 };
-use crate::{VsockHost, operation_tracker::NormalOperationReadiness};
+use crate::{
+    NormalOperationFenceRejection, VsockHost, operation_tracker::NormalOperationReadiness,
+};
 
 #[tokio::test]
 async fn wait_for_connection_removes_listener_socket_on_abort() {
@@ -138,6 +140,92 @@ async fn lifecycle_request_bypasses_normal_operation_fence() {
     guest.write_all(&resp).await.unwrap();
 
     quiesce_task.await.unwrap().unwrap();
+}
+
+#[tokio::test]
+async fn normal_operation_fence_rejects_new_normal_operations_until_dropped() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let fence = host
+        .try_fence_normal_operations()
+        .expect("idle host should fence normal operations");
+
+    let err = host.exec("blocked", 5000, &[], false).await.unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::WouldBlock);
+
+    drop(fence);
+    let exec_task = tokio::spawn(async move { host.exec("echo ok", 5000, &[], false).await });
+    let request = read_guest_message(&mut guest).await;
+    assert_eq!(request.msg_type, MSG_EXEC_START);
+    send_exec_result(
+        &mut guest,
+        request.seq,
+        ExecTermination::Exited { exit_code: 0 },
+        b"ok",
+        b"",
+    )
+    .await;
+
+    assert_eq!(exec_task.await.unwrap().unwrap().stdout, b"ok");
+}
+
+#[tokio::test]
+async fn normal_operation_fence_reports_busy_closed_and_not_parkable() {
+    let (host_stream, mut guest) = make_pair();
+    let release_exec = Arc::new(tokio::sync::Notify::new());
+    let guest_task = {
+        let release_exec = Arc::clone(&release_exec);
+        tokio::spawn(async move {
+            let mut decoder = Decoder::new();
+            mock_handshake(&mut guest, &mut decoder).await;
+            let request = read_guest_message(&mut guest).await;
+            assert_eq!(request.msg_type, MSG_EXEC_START);
+            release_exec.notified().await;
+            send_exec_result(
+                &mut guest,
+                request.seq,
+                ExecTermination::Exited { exit_code: 0 },
+                b"done",
+                b"",
+            )
+            .await;
+            drop(guest);
+        })
+    };
+
+    let host = Arc::new(host_from_stream(host_stream).await.unwrap());
+    let exec_task = {
+        let host = Arc::clone(&host);
+        tokio::spawn(async move { host.exec("sleep", 5000, &[], false).await })
+    };
+    tokio::time::timeout(Duration::from_secs(2), async {
+        while normal_operation_readiness(&host) != NormalOperationReadiness::Busy {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .unwrap();
+    assert_eq!(
+        host.try_fence_normal_operations().unwrap_err(),
+        NormalOperationFenceRejection::Busy
+    );
+
+    release_exec.notify_one();
+    exec_task.await.unwrap().unwrap();
+    host.wait_until_closed(Duration::from_secs(5))
+        .await
+        .unwrap();
+    assert_eq!(
+        host.try_fence_normal_operations().unwrap_err(),
+        NormalOperationFenceRejection::Closed
+    );
+    guest_task.await.unwrap();
+
+    let (poisoned_host, _guest) = setup_host_and_guest().await;
+    poison_connection(&poisoned_host);
+    assert_eq!(
+        poisoned_host.try_fence_normal_operations().unwrap_err(),
+        NormalOperationFenceRejection::NotParkable
+    );
 }
 
 #[tokio::test]

--- a/crates/vsock-host/src/tests/process.rs
+++ b/crates/vsock-host/src/tests/process.rs
@@ -502,6 +502,68 @@ async fn test_spawn_process_control_after_exit_returns_inactive_without_guest_wr
 }
 
 #[tokio::test]
+async fn test_spawn_process_control_exit_before_frame_write_returns_inactive_without_guest_write() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+    let spawn_task = {
+        let host = Arc::clone(&host);
+        tokio::spawn(async move {
+            host.spawn_process(
+                "quick-exit-before-control-write",
+                0,
+                &[],
+                false,
+                false,
+                None,
+            )
+            .await
+            .unwrap()
+        })
+    };
+
+    let spawn = read_guest_message(&mut guest).await;
+    assert_eq!(spawn.msg_type, MSG_SPAWN_PROCESS);
+    let spawn_result = vsock_proto::encode_spawn_process_result(44);
+    let response = vsock_proto::encode(MSG_SPAWN_PROCESS_RESULT, spawn.seq, &spawn_result).unwrap();
+    guest.write_all(&response).await.unwrap();
+
+    let handle = spawn_task.await.unwrap();
+    let control = handle.control_handle();
+    let writer_guard = host.shared.writer.lock().await;
+    let mut control_call = Box::pin(control.control(
+        "message-after-delayed-exit",
+        b"payload",
+        Duration::from_secs(5),
+    ));
+    assert!(
+        matches!(poll_once(control_call.as_mut()), Poll::Pending),
+        "process control should wait for writer lock before frame write",
+    );
+
+    let exit_payload = vsock_proto::encode_process_exit(44, 0, b"", b"");
+    let exit = vsock_proto::encode(MSG_PROCESS_EXIT, spawn.seq, &exit_payload).unwrap();
+    guest.write_all(&exit).await.unwrap();
+    handle.wait().await.unwrap();
+
+    drop(writer_guard);
+    let err = tokio::time::timeout(Duration::from_secs(5), control_call)
+        .await
+        .expect("stale process control should return after writer lock release")
+        .unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::NotFound);
+    assert_eq!(err.to_string(), "process operation is not active");
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Idle
+    );
+    match guest.try_read(&mut [0u8; 1]) {
+        Err(error) if error.kind() == io::ErrorKind::WouldBlock => {}
+        Ok(n) => panic!("stale process control must not send a frame; read {n} bytes"),
+        Err(error) => panic!("unexpected read error after stale process control: {error}"),
+    }
+}
+
+#[tokio::test]
 async fn test_spawn_process_control_nonce_mismatch_status_returns_permission_denied() {
     let (host_stream, mut guest) = make_pair();
 

--- a/crates/vsock-host/src/tests/process.rs
+++ b/crates/vsock-host/src/tests/process.rs
@@ -463,6 +463,45 @@ async fn test_spawn_process_control_inactive_status_returns_not_found() {
 }
 
 #[tokio::test]
+async fn test_spawn_process_control_after_exit_returns_inactive_without_guest_write() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+    let spawn_task = {
+        let host = Arc::clone(&host);
+        tokio::spawn(async move {
+            host.spawn_process("quick-exit", 0, &[], false, false, None)
+                .await
+                .unwrap()
+        })
+    };
+
+    let spawn = read_guest_message(&mut guest).await;
+    assert_eq!(spawn.msg_type, MSG_SPAWN_PROCESS);
+    let spawn_result = vsock_proto::encode_spawn_process_result(44);
+    let response = vsock_proto::encode(MSG_SPAWN_PROCESS_RESULT, spawn.seq, &spawn_result).unwrap();
+    guest.write_all(&response).await.unwrap();
+
+    let handle = spawn_task.await.unwrap();
+    let control = handle.control_handle();
+    let exit_payload = vsock_proto::encode_process_exit(44, 0, b"", b"");
+    let exit = vsock_proto::encode(MSG_PROCESS_EXIT, spawn.seq, &exit_payload).unwrap();
+    guest.write_all(&exit).await.unwrap();
+    handle.wait().await.unwrap();
+
+    let err = control
+        .control("message-after-exit", b"payload", Duration::from_secs(5))
+        .await
+        .unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::NotFound);
+    assert_eq!(err.to_string(), "process operation is not active");
+    match guest.try_read(&mut [0u8; 1]) {
+        Err(error) if error.kind() == io::ErrorKind::WouldBlock => {}
+        Ok(n) => panic!("stale process control must not send a frame; read {n} bytes"),
+        Err(error) => panic!("unexpected read error after stale process control: {error}"),
+    }
+}
+
+#[tokio::test]
 async fn test_spawn_process_control_nonce_mismatch_status_returns_permission_denied() {
     let (host_stream, mut guest) = make_pair();
 

--- a/crates/vsock-host/src/tests/support.rs
+++ b/crates/vsock-host/src/tests/support.rs
@@ -11,10 +11,8 @@ use vsock_proto::{
     RawMessage,
 };
 
-use crate::{
-    ConnectionState, VsockHost,
-    operation_tracker::{NormalOperationFence, NormalOperationReadiness},
-};
+use crate::operation_tracker::NormalOperationReadiness;
+use crate::{ConnectionState, NormalOperationFence, VsockHost};
 
 pub(crate) fn make_pair() -> (UnixStream, UnixStream) {
     UnixStream::pair().unwrap()
@@ -65,9 +63,7 @@ pub(crate) fn normal_operation_readiness(host: &VsockHost) -> NormalOperationRea
 }
 
 pub(crate) fn fence_normal_operations(host: &VsockHost) -> NormalOperationFence {
-    host.shared
-        .normal_operations
-        .try_fence()
+    host.try_fence_normal_operations()
         .expect("normal operations should fence")
 }
 


### PR DESCRIPTION
## Summary

- expose an opaque `vsock-host` normal-operation fence API with neutral rejection reasons
- acquire and hold that fence across sandbox park, parked state, and unpark resume
- release the fence before reopening sandbox policy on successful unpark
- validate stale process-control handles before writing to guest state

Fixes #13458

## Tests

- `cargo test --manifest-path crates/Cargo.toml -p vsock-host`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox-fc`
- pre-commit: cargo fmt, cargo clippy, cargo doc
