### PR TITLE
refactor: use runtime connector availability helper

### DIFF
--- a/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
@@ -9,9 +9,9 @@ import {
   deriveApiTokenConnectedTypes,
   getApiTokenFieldsByType,
   getAvailableConnectorAuthMethods,
-  getConfiguredConnectorTypes,
   getConnectorOAuthEnvKeys,
   getConnectorProvidedSecretNames,
+  getRuntimeAvailableConnectorTypes,
   getScopeDiff,
   isConnectorAuthMethodAvailable,
 } from "@vm0/connectors/connector-utils";
@@ -245,7 +245,7 @@ export function zeroConnectorList(args: {
     const connectorList = [...dbConnectors, ...derivedConnectors];
     return {
       connectors: connectorList,
-      configuredTypes: getConfiguredConnectorTypes((name) => {
+      configuredTypes: getRuntimeAvailableConnectorTypes((name) => {
         return optionalEnv(name);
       }),
       connectorProvidedSecretNames: [

--- a/turbo/apps/web/app/api/zero/connectors/route.ts
+++ b/turbo/apps/web/app/api/zero/connectors/route.ts
@@ -9,8 +9,8 @@ import {
 import { resolveOrg } from "../../../../src/lib/zero/org/resolve-org";
 import { listConnectors } from "../../../../src/lib/zero/connector/connector-service";
 import {
-  getConfiguredConnectorTypes,
   providerEnvFromObject,
+  getRuntimeAvailableConnectorTypes,
 } from "@vm0/connectors/oauth-providers";
 
 function unauthenticatedResponse() {
@@ -35,7 +35,7 @@ const router = tsr.router(zeroConnectorsMainContract, {
 
     const { org } = await resolveOrg(authCtx);
     const connectorList = await listConnectors(org.orgId, userId);
-    const configuredTypes = getConfiguredConnectorTypes(
+    const configuredTypes = getRuntimeAvailableConnectorTypes(
       providerEnvFromObject(globalThis.services.env),
     );
     const connectorProvidedSecretNames = [

--- a/turbo/packages/connectors/src/oauth-providers/provider-registry.ts
+++ b/turbo/packages/connectors/src/oauth-providers/provider-registry.ts
@@ -1,5 +1,5 @@
 import type { ConnectorType } from "@vm0/connectors/connectors";
-import { getConfiguredConnectorTypes as getConfiguredConnectorTypesFromEnv } from "@vm0/connectors/connector-utils";
+import { getRuntimeAvailableConnectorTypes as getRuntimeAvailableConnectorTypesFromEnv } from "@vm0/connectors/connector-utils";
 import {
   type AuthUrlResult,
   type OAuthTokenResult,
@@ -446,14 +446,23 @@ export const PROVIDER_HANDLERS: Record<
 };
 
 /**
- * Returns connector types whose OAuth credentials (or equivalent) are
- * configured in the current environment.
+ * Returns connector types the current runtime environment can offer as
+ * connection candidates.
+ */
+export function getRuntimeAvailableConnectorTypes(
+  currentEnv: ProviderEnv,
+): ConnectorType[] {
+  return getRuntimeAvailableConnectorTypesFromEnv((name) => {
+    const value = currentEnv[name];
+    return typeof value === "string" ? value : undefined;
+  });
+}
+
+/**
+ * Compatibility wrapper for existing configuredTypes response semantics.
  */
 export function getConfiguredConnectorTypes(
   currentEnv: ProviderEnv,
 ): ConnectorType[] {
-  return getConfiguredConnectorTypesFromEnv((name) => {
-    const value = currentEnv[name];
-    return typeof value === "string" ? value : undefined;
-  });
+  return getRuntimeAvailableConnectorTypes(currentEnv);
 }


### PR DESCRIPTION
## Summary
- Migrate API connector list code to use getRuntimeAvailableConnectorTypes while preserving the configuredTypes response field
- Add a provider-env-shaped getRuntimeAvailableConnectorTypes wrapper for web compatibility code
- Keep the existing oauth-providers getConfiguredConnectorTypes wrapper for compatibility

Closes #13877

## Tests
- pnpm -F api exec vitest src/signals/services/__tests__/zero-connector-data.service.test.ts src/signals/routes/__tests__/zero-connectors-search.test.ts
- pnpm -F web exec vitest app/api/zero/connectors/__tests__/route.test.ts
- pnpm -F api check-types
- pnpm -F api lint (passes; emits existing unrelated warning in zero-presentation-io-generate.service.ts)
- pnpm -F web check-types
- pnpm -F web lint
- pnpm -F @vm0/connectors check-types
- pnpm -F @vm0/connectors lint
- pre-commit: prettier, knip, turbo check-types