### PR TITLE
refactor: reduce connector registry coupling

### DIFF
--- a/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
@@ -11,6 +11,7 @@ import {
   getAvailableConnectorAuthMethods,
   getConnectorOAuthEnvKeys,
   getConnectorProvidedSecretNames,
+  getConnectorSecretNames,
   getRuntimeAvailableConnectorTypes,
   getScopeDiff,
   isConnectorAuthMethodAvailable,
@@ -720,12 +721,10 @@ export const deleteZeroConnectorLocalState$ = command(
       signal.throwIfAborted();
       deleted = true;
 
-      const config = CONNECTOR_TYPES[args.type];
-      const authMethodConfig =
-        config.authMethods[existing.authMethod as ConnectorAuthMethodType];
-      const secretNames = authMethodConfig
-        ? Object.keys(authMethodConfig.secrets)
-        : [];
+      const secretNames = getConnectorSecretNames(
+        args.type,
+        existing.authMethod as ConnectorAuthMethodType,
+      );
 
       for (const name of secretNames) {
         await writeDb

--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -11,7 +11,10 @@ import {
 } from "@vm0/connectors/connectors";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import {
+  getApiTokenFieldStorageType,
   getAvailableConnectorAuthMethods,
+  getConnectorAuthMethod,
+  getConnectorCliAuthModes,
   hasRequiredScopes,
 } from "@vm0/connectors/connector-utils";
 import {
@@ -248,7 +251,7 @@ function buildConnectorTypeStatus(params: {
   );
   const hasApiToken = availableAuthMethods.includes("api-token");
   const hasFeatureFlaggedMethod = availableAuthMethods.some((authMethod) => {
-    return !!config.authMethods[authMethod]?.featureFlag;
+    return !!getConnectorAuthMethod(params.type, authMethod)?.featureFlag;
   });
   const connected = params.connector !== null;
 
@@ -576,13 +579,13 @@ export const submitApiToken$ = command(
         const createClient = get(zeroClient$);
         const secretsClient = createClient(zeroSecretsContract);
         const variablesClient = createClient(zeroVariablesContract);
-        const apiTokenConfig = CONNECTOR_TYPES[type].authMethods["api-token"];
         const secrets = sanitizeTokenInputRecord(inputSecrets);
         for (const [name, value] of Object.entries(secrets)) {
           if (!value) {
             continue;
           }
-          const isVariable = apiTokenConfig?.secrets[name]?.type === "variable";
+          const isVariable =
+            getApiTokenFieldStorageType(type, name) === "variable";
           if (isVariable) {
             await accept(
               variablesClient.set({
@@ -1288,7 +1291,7 @@ function getConnectorCliAuthMode(
 }
 
 function connectorCliAuthRequiresMode(type: ConnectorType): boolean {
-  return (CONNECTOR_TYPES[type].cliAuth?.modes?.length ?? 0) > 0;
+  return getConnectorCliAuthModes(type).length > 0;
 }
 
 function connectorCliAuthModeIsAllowed(

--- a/turbo/apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx
@@ -21,7 +21,10 @@ import {
 } from "@vm0/connectors/connectors";
 import type { ReactElement } from "react";
 import type { LocalBrowserHost } from "@vm0/api-contracts/contracts/zero-local-browser";
-import { isGoogleOAuthConnector } from "@vm0/connectors/connector-utils";
+import {
+  getConnectorAuthMethod,
+  isGoogleOAuthConnector,
+} from "@vm0/connectors/connector-utils";
 import {
   allConnectorTypes$,
   connectorCliAuthState$,
@@ -206,8 +209,7 @@ function ApiTokenForm({
   submit: SubmitApiTokenFn;
   submitting: boolean;
 }) {
-  const config = CONNECTOR_TYPES[type];
-  const apiTokenConfig = config.authMethods["api-token"];
+  const apiTokenConfig = getConnectorAuthMethod(type, "api-token");
   const setFormValue = useSet(setTokenFormValue$);
   const clearForm = useSet(clearTokenForm$);
   const pageSignal = useGet(pageSignal$);
@@ -285,8 +287,7 @@ function LocalAgentConnectContent({
   onSuccess: () => void | Promise<void>;
   showPermissionDialogOnConnect: boolean;
 }) {
-  const config = CONNECTOR_TYPES[item.type];
-  const localAgentConfig = config.authMethods.api;
+  const localAgentConfig = getConnectorAuthMethod(item.type, "api");
   const hostListLoadable = useLastLoadable(localAgentHosts$);
   const watchHostsRef = useSet(localAgentHostsWatcherRef$);
   const [connectLoadable, connectLocalAgent] = useLoadableSet(
@@ -490,8 +491,7 @@ function LocalBrowserConnectContent({
   onSuccess: () => void | Promise<void>;
   showPermissionDialogOnConnect: boolean;
 }) {
-  const config = CONNECTOR_TYPES[item.type];
-  const localBrowserConfig = config.authMethods.api;
+  const localBrowserConfig = getConnectorAuthMethod(item.type, "api");
   const hostListLoadable = useLastLoadable(localBrowserHosts$);
   const watchConnectionRef = useSet(localBrowserConnectionRef$);
   const extensionStatus = useGet(localBrowserExtensionStatus$);
@@ -767,7 +767,7 @@ function ConnectMethodHeading({
     return null;
   }
 
-  const methodConfig = CONNECTOR_TYPES[item.type].authMethods[authMethod];
+  const methodConfig = getConnectorAuthMethod(item.type, authMethod);
   if (!methodConfig) {
     return null;
   }

--- a/turbo/apps/platform/src/views/zero-page/components/settings/cli-auth-connect-methods.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/cli-auth-connect-methods.tsx
@@ -1,10 +1,12 @@
 import { useGet, useSet } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
 import { Button } from "@vm0/ui/components/ui/button";
+import type { ConnectorType } from "@vm0/connectors/connectors";
 import {
-  CONNECTOR_TYPES,
-  type ConnectorType,
-} from "@vm0/connectors/connectors";
+  getConnectorAuthMethod,
+  getConnectorCliAuthFlow,
+  getConnectorCliAuthModes,
+} from "@vm0/connectors/connector-utils";
 import type { MouseEventHandler, ReactElement } from "react";
 
 import {
@@ -50,7 +52,7 @@ function stateForConnector(
 }
 
 function cliAuthModeOptions(type: ConnectorType): readonly CliAuthModeOption[] {
-  return CONNECTOR_TYPES[type].cliAuth?.modes ?? [];
+  return getConnectorCliAuthModes(type);
 }
 
 function CliAuthModePicker({
@@ -164,7 +166,7 @@ function BrowserVerificationCliAuthConnectMethodContent({
   signal,
 }: CliAuthConnectMethodContentProps) {
   const type = item.type;
-  const cliAuthConfig = CONNECTOR_TYPES[type].authMethods["cli-auth"];
+  const cliAuthConfig = getConnectorAuthMethod(type, "cli-auth");
   const rawState = useGet(connectorCliAuthState$);
   const cliAuthState = stateForConnector(rawState, type);
   const setMode = useSet(setConnectorCliAuthMode$);
@@ -258,7 +260,7 @@ function BrowserVerificationCliAuthConnectMethodContent({
 export function getCliAuthConnectMethodContentComponent(
   type: ConnectorType,
 ): CliAuthConnectMethodContentComponent | null {
-  switch (CONNECTOR_TYPES[type].cliAuth?.flow) {
+  switch (getConnectorCliAuthFlow(type)) {
     case "browser-verification": {
       return BrowserVerificationCliAuthConnectMethodContent;
     }

--- a/turbo/apps/platform/src/views/zero-page/zero-directed-connect-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-directed-connect-page.tsx
@@ -3,7 +3,10 @@ import {
   CONNECTOR_TYPES,
   type ConnectorType,
 } from "@vm0/connectors/connectors";
-import { isGoogleOAuthConnector } from "@vm0/connectors/connector-utils";
+import {
+  getConnectorAuthMethod,
+  isGoogleOAuthConnector,
+} from "@vm0/connectors/connector-utils";
 import { Input } from "@vm0/ui/components/ui/input";
 import {
   Dialog,
@@ -106,7 +109,7 @@ function ApiTokenForm({
   type: ConnectorType;
   onSuccess: () => void;
 }) {
-  const apiTokenConfig = CONNECTOR_TYPES[type].authMethods["api-token"];
+  const apiTokenConfig = getConnectorAuthMethod(type, "api-token");
   const submit = useSet(submitApiToken$);
   const setFormValue = useSet(setTokenFormValue$);
   const clearForm = useSet(clearTokenForm$);

--- a/turbo/apps/web/src/lib/zero/connector/connector-service.ts
+++ b/turbo/apps/web/src/lib/zero/connector/connector-service.ts
@@ -2,15 +2,13 @@ import { eq, and, inArray } from "drizzle-orm";
 import {
   deriveApiTokenConnectedTypes,
   getApiTokenFieldsByType,
+  getConnectorSecretNames,
 } from "@vm0/connectors/connector-utils";
 import type {
   ConnectorAuthMethodType,
   ConnectorType,
 } from "@vm0/connectors/connectors";
-import {
-  CONNECTOR_TYPES,
-  connectorTypeSchema,
-} from "@vm0/connectors/connectors";
+import { connectorTypeSchema } from "@vm0/connectors/connectors";
 import type { ConnectorResponse } from "@vm0/api-contracts/contracts/connector-schemas";
 import { connectors } from "@vm0/db/schema/connector";
 import { modelProviders } from "@vm0/db/schema/model-provider";
@@ -389,13 +387,10 @@ export async function deleteConnector(
     // OAuth connector: delete DB record + connector-type secrets
     await db.delete(connectors).where(eq(connectors.id, existing.id));
 
-    const secretNames: string[] = [];
-    const config = CONNECTOR_TYPES[type];
-    const authMethodConfig =
-      config.authMethods[existing.authMethod as ConnectorAuthMethodType];
-    if (authMethodConfig) {
-      secretNames.push(...Object.keys(authMethodConfig.secrets));
-    }
+    const secretNames = getConnectorSecretNames(
+      type,
+      existing.authMethod as ConnectorAuthMethodType,
+    );
 
     if (existing.authMethod === "oauth" && type !== "computer") {
       const handler =

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -1,9 +1,12 @@
 import { describe, it, expect } from "vitest";
-import { CONNECTOR_TYPES, connectorTypeSchema } from "../connectors";
+import { connectorTypeSchema } from "../connectors";
 import {
+  getApiTokenFieldStorageType,
   getAvailableConnectorAuthMethods,
   hasRequiredScopes,
   getConnectorAuthMethod,
+  getConnectorCliAuthFlow,
+  getConnectorCliAuthModes,
   getConnectorManagedSecretNames,
   getConnectorTypeForSecretName,
   getConnectorEnvironmentMapping,
@@ -70,13 +73,13 @@ describe("connector auth method config", () => {
   });
 
   it("declares Stripe CLI auth as a gated connection flow with modes", () => {
-    const method = CONNECTOR_TYPES.stripe.authMethods["cli-auth"];
+    const method = getConnectorAuthMethod("stripe", "cli-auth");
 
     expect(method).toBeDefined();
     expect(method?.secrets).toStrictEqual({});
     expect(method?.featureFlag).toBe(FeatureSwitchKey.CliAuthStripe);
-    expect(CONNECTOR_TYPES.stripe.cliAuth?.flow).toBe("browser-verification");
-    expect(CONNECTOR_TYPES.stripe.cliAuth?.modes).toStrictEqual([
+    expect(getConnectorCliAuthFlow("stripe")).toBe("browser-verification");
+    expect(getConnectorCliAuthModes("stripe")).toStrictEqual([
       {
         value: "test",
         label: "Test mode",
@@ -88,6 +91,18 @@ describe("connector auth method config", () => {
         description: "Import a Stripe live mode key.",
       },
     ]);
+  });
+
+  it("returns api-token field storage types with secret default", () => {
+    expect(getApiTokenFieldStorageType("zendesk", "ZENDESK_EMAIL")).toBe(
+      "variable",
+    );
+    expect(getApiTokenFieldStorageType("zendesk", "ZENDESK_API_TOKEN")).toBe(
+      "secret",
+    );
+    expect(getApiTokenFieldStorageType("zendesk", "UNKNOWN_FIELD")).toBe(
+      "secret",
+    );
   });
 });
 

--- a/turbo/packages/connectors/src/connector-utils.ts
+++ b/turbo/packages/connectors/src/connector-utils.ts
@@ -4,6 +4,8 @@ import {
   connectorTypeSchema,
   type ConnectorAuthMethodConfig,
   type ConnectorAuthMethodType,
+  type ConnectorCliAuthConfig,
+  type ConnectorCliAuthFlow,
   type ConnectorConfig,
   type ConnectorOAuthConfig,
   type ConnectorSecretConfig,
@@ -41,6 +43,30 @@ export function getConnectorAuthMethod(
   authMethod: ConnectorAuthMethodType,
 ): ConnectorAuthMethodConfig | undefined {
   return getConnectorAuthMethods(type)[authMethod];
+}
+
+/**
+ * Get CLI auth flow config for connector types that support provider CLI auth.
+ */
+export function getConnectorCliAuthConfig(
+  type: ConnectorType,
+): ConnectorCliAuthConfig | undefined {
+  return CONNECTOR_TYPES[type].cliAuth;
+}
+
+/**
+ * Get the frontend CLI auth flow for connector types that support it.
+ */
+export function getConnectorCliAuthFlow(
+  type: ConnectorType,
+): ConnectorCliAuthFlow | undefined {
+  return getConnectorCliAuthConfig(type)?.flow;
+}
+
+export function getConnectorCliAuthModes(
+  type: ConnectorType,
+): NonNullable<ConnectorCliAuthConfig["modes"]> {
+  return getConnectorCliAuthConfig(type)?.modes ?? [];
 }
 
 /**
@@ -672,6 +698,20 @@ export function getApiTokenFieldsByType(
     }
   }
   return { secrets: secretNames, variables: variableNames };
+}
+
+/**
+ * Return the storage target for a connector API-token field.
+ *
+ * Unknown fields preserve the historical form-submit behavior and are treated
+ * as encrypted secrets.
+ */
+export function getApiTokenFieldStorageType(
+  type: ConnectorType,
+  name: string,
+): "secret" | "variable" {
+  const fieldConfig = getConnectorAuthMethod(type, "api-token")?.secrets[name];
+  return fieldConfig?.type ?? "secret";
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add connector utility helpers for CLI auth metadata and API-token field storage lookup
- Migrate connector UI and API/web delete paths away from direct authMethods/cliAuth registry reads
- Cover the new helper behavior in connector utility tests

Closes #13878
Parent #13872

## Tests
- pnpm -F @vm0/connectors exec vitest src/__tests__/connectors.test.ts
- pnpm -F @vm0/app exec vitest src/signals/zero-page/__tests__/zero-connectors.test.ts src/views/conn/__tests__/add-connection-dialog.test.tsx src/views/zero-page/__tests__/zero-directed-connect-page.test.tsx
- pnpm -F api exec vitest src/signals/services/__tests__/zero-connector-data.service.test.ts
- pnpm -F web exec vitest app/api/zero/connectors/[type]/__tests__/route.test.ts app/api/zero/connectors/__tests__/route.test.ts
- pnpm -F @vm0/connectors check-types
- pnpm -F @vm0/connectors lint
- pnpm -F @vm0/app check-types
- pnpm -F @vm0/app lint
- pnpm -F api check-types
- pnpm -F api lint (passes; emits existing unrelated zero-presentation-io-generate.service.ts warning)
- pnpm -F web check-types
- pnpm -F web lint
- pre-commit: prettier, knip, turbo check-types