### PR TITLE
feat: add OAuth client plumbing

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/connectors-type-callback.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors-type-callback.test.ts
@@ -45,6 +45,7 @@ function callbackHeaders(args: {
   readonly stateCookie?: string;
   readonly sessionId?: string;
   readonly codeVerifier?: string;
+  readonly oauthContext?: string;
 }): HeadersInit {
   const cookies = ["__session=opaque"];
   if (args.stateCookie) {
@@ -55,6 +56,9 @@ function callbackHeaders(args: {
   }
   if (args.codeVerifier) {
     cookies.push(`connector_oauth_pkce=${args.codeVerifier}`);
+  }
+  if (args.oauthContext) {
+    cookies.push(`connector_oauth_context=${args.oauthContext}`);
   }
   return { cookie: cookies.join("; ") };
 }
@@ -274,6 +278,37 @@ describe("GET /api/connectors/:type/callback", () => {
     expect(url.searchParams.get("message")).toBe("Not authenticated");
   });
 
+  it("rejects refresh-only connector callbacks", async () => {
+    const orgId = `org_${randomUUID()}`;
+    const userId = `user_${randomUUID()}`;
+    orgIds.push(orgId);
+    authenticate({ userId, orgId });
+
+    const response = await requestCallback({
+      type: "codex-oauth",
+      query: { code: "code-123", state: "state-123" },
+      headers: callbackHeaders({ stateCookie: "state-123" }),
+    });
+
+    expect(response.status).toBe(307);
+    const location = response.headers.get("location");
+    expect(location).not.toBeNull();
+    const url = new URL(location!);
+    expect(url.pathname).toBe("/connector/error");
+    expect(url.searchParams.get("type")).toBe("codex-oauth");
+    expect(url.searchParams.get("message")).toBe(
+      "OAuth authorization failed. Please try again.",
+    );
+    expect(response.headers.getSetCookie()).toStrictEqual(
+      expect.arrayContaining([
+        "connector_oauth_state=; Max-Age=0; Path=/",
+        "connector_oauth_session=; Max-Age=0; Path=/",
+        "connector_oauth_pkce=; Max-Age=0; Path=/",
+        "connector_oauth_context=; Max-Age=0; Path=/",
+      ]),
+    );
+  });
+
   it("rejects state mismatch and clears OAuth cookies", async () => {
     const orgId = `org_${randomUUID()}`;
     const userId = `user_${randomUUID()}`;
@@ -300,6 +335,7 @@ describe("GET /api/connectors/:type/callback", () => {
         "connector_oauth_state=; Max-Age=0; Path=/",
         "connector_oauth_session=; Max-Age=0; Path=/",
         "connector_oauth_pkce=; Max-Age=0; Path=/",
+        "connector_oauth_context=; Max-Age=0; Path=/",
       ]),
     );
   });
@@ -324,6 +360,7 @@ describe("GET /api/connectors/:type/callback", () => {
       headers: callbackHeaders({
         stateCookie: "state-123",
         sessionId,
+        oauthContext: "opaque-provider-context",
       }),
     });
 
@@ -339,6 +376,7 @@ describe("GET /api/connectors/:type/callback", () => {
         "connector_oauth_state=; Max-Age=0; Path=/",
         "connector_oauth_session=; Max-Age=0; Path=/",
         "connector_oauth_pkce=; Max-Age=0; Path=/",
+        "connector_oauth_context=; Max-Age=0; Path=/",
       ]),
     );
 

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-authorize.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-authorize.test.ts
@@ -166,7 +166,7 @@ describe("GET /api/zero/connectors/:type/authorize", () => {
     ).toBeFalsy();
   });
 
-  it("returns 400 for refresh-only codex-oauth connector", async () => {
+  it("returns 400 for model-provider stored OAuth connectors", async () => {
     const response = await requestAuthorize("codex-oauth", {
       authenticated: true,
     });

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-authorize.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-authorize.test.ts
@@ -174,8 +174,7 @@ describe("GET /api/zero/connectors/:type/authorize", () => {
     expect(response.status).toBe(400);
     const body = await response.json();
     expect(body).toStrictEqual({
-      error:
-        "codex-oauth does not use browser OAuth authorization; use the codex auth.json paste flow",
+      error: "codex-oauth does not use connector OAuth authorization",
     });
   });
 

--- a/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
+++ b/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
@@ -1,6 +1,10 @@
 import { command } from "ccstate";
 import { connectorsTypeCallbackContract } from "@vm0/api-contracts/contracts/connectors-type-callback";
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
+import {
+  getConnectorOAuthCredentials,
+  getConnectorOAuthConfig,
+  getConnectorOAuthStorage,
+} from "@vm0/connectors/connector-utils";
 import {
   connectorTypeSchema,
   type ConnectorType,
@@ -26,6 +30,7 @@ import type { RouteEntry } from "../route";
 const STATE_COOKIE_NAME = "connector_oauth_state";
 const SESSION_COOKIE_NAME = "connector_oauth_session";
 const PKCE_COOKIE_NAME = "connector_oauth_pkce";
+const OAUTH_CONTEXT_COOKIE_NAME = "connector_oauth_context";
 const REDIRECT_STATUS = 307;
 
 type OAuthConnectorType = Exclude<ConnectorType, "computer">;
@@ -79,6 +84,10 @@ function clearOAuthCookies(response: Response): void {
     "Set-Cookie",
     buildDeleteCookieHeader(PKCE_COOKIE_NAME),
   );
+  response.headers.append(
+    "Set-Cookie",
+    buildDeleteCookieHeader(OAUTH_CONTEXT_COOKIE_NAME),
+  );
 }
 
 function redirectWithError(
@@ -115,22 +124,51 @@ async function exchangeTokenForConnector(args: {
   readonly redirectUri: string;
   readonly state: string | undefined;
   readonly codeVerifier: string | undefined;
+  readonly oauthContext: string | undefined;
 }): Promise<OAuthTokenResult> {
+  if (getConnectorOAuthStorage(args.connectorType) !== "connector") {
+    throw new Error(`${args.connectorType} OAuth not configured`);
+  }
   const handler = PROVIDER_HANDLERS[args.connectorType];
   const env = providerEnv();
-  const clientId = handler.getClientId(env);
-  const clientSecret = handler.getClientSecret(env);
-  if (!clientId || !clientSecret) {
+  const credentials = getConnectorOAuthCredentials(
+    args.connectorType,
+    (name) => {
+      return env[name];
+    },
+  );
+  if (!credentials?.configured) {
     throw new Error(`${args.connectorType} OAuth not configured`);
   }
 
+  if (credentials.client?.clientRegistration === "dynamic") {
+    if (!handler.exchangeCodeWithoutClient) {
+      throw new Error(`${args.connectorType} OAuth not configured`);
+    }
+    return await handler.exchangeCodeWithoutClient(
+      args.code,
+      args.redirectUri,
+      args.state,
+      args.codeVerifier,
+      args.oauthContext,
+    );
+  }
+
+  if (
+    !credentials.clientId ||
+    (credentials.client?.clientType === "confidential" &&
+      !credentials.clientSecret)
+  ) {
+    throw new Error(`${args.connectorType} OAuth not configured`);
+  }
   return await handler.exchangeCode(
-    clientId,
-    clientSecret,
+    credentials.clientId,
+    credentials.clientSecret ?? "",
     args.code,
     args.redirectUri,
     args.state,
     args.codeVerifier,
+    args.oauthContext,
   );
 }
 
@@ -235,6 +273,7 @@ const callbackConnectorInner$ = command(
     const savedState = getCookie(request, STATE_COOKIE_NAME);
     const sessionId = getCookie(request, SESSION_COOKIE_NAME);
     const codeVerifier = getCookie(request, PKCE_COOKIE_NAME);
+    const oauthContext = getCookie(request, OAUTH_CONTEXT_COOKIE_NAME);
 
     if (query.error) {
       return redirectWithError(
@@ -284,6 +323,7 @@ const callbackConnectorInner$ = command(
           redirectUri,
           state,
           codeVerifier,
+          oauthContext,
         });
         signal.throwIfAborted();
 

--- a/turbo/apps/api/src/signals/routes/zero-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/zero-connectors.ts
@@ -19,9 +19,11 @@ import {
   getConnectorOAuthConfig,
   getConnectorOAuthStorage,
   isGoogleOAuthConnector,
+  isConnectorOAuthAuthorizeType,
 } from "@vm0/connectors/connector-utils";
 import {
   connectorTypeSchema,
+  type ConnectorOAuthAuthorizeType,
   type ConnectorType,
 } from "@vm0/connectors/connectors";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
@@ -75,8 +77,6 @@ type ConnectorAuthorizeRoute = AppRoute & {
   readonly pathParams: z.ZodType<{ readonly type: string }>;
   readonly query: z.ZodType<{ readonly session?: string }>;
 };
-
-type ConnectorOAuthAuthorizeType = Exclude<ConnectorType, "computer">;
 
 const connectorReadAuth = {
   requireOrganization: true,
@@ -615,7 +615,7 @@ export function createAuthorizeConnectorInner(route: ConnectorAuthorizeRoute) {
         400,
       );
     }
-    if (oauthStorage !== "connector") {
+    if (!isConnectorOAuthAuthorizeType(type)) {
       return jsonResponse(
         { error: `${type} does not use connector OAuth authorization` },
         400,

--- a/turbo/apps/api/src/signals/routes/zero-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/zero-connectors.ts
@@ -76,7 +76,7 @@ type ConnectorAuthorizeRoute = AppRoute & {
   readonly query: z.ZodType<{ readonly session?: string }>;
 };
 
-type OAuthConnectorType = Exclude<ConnectorType, "computer">;
+type ConnectorOAuthAuthorizeType = Exclude<ConnectorType, "computer">;
 
 const connectorReadAuth = {
   requireOrganization: true,
@@ -177,13 +177,6 @@ function redirectResponse(url: string): Response {
   });
 }
 
-function connectorOAuthAuthorizationError(type: OAuthConnectorType): string {
-  if (type === "codex-oauth") {
-    return "codex-oauth does not use browser OAuth authorization; use the codex auth.json paste flow";
-  }
-  return `${type} does not use connector OAuth authorization`;
-}
-
 async function base64UrlSha256(value: string): Promise<string> {
   const data = new TextEncoder().encode(value);
   const hash = await crypto.subtle.digest("SHA-256", data);
@@ -227,7 +220,7 @@ function deterministicPkceSuffix(type: ConnectorType): string | undefined {
 }
 
 async function buildAuthorizeUrl(args: {
-  readonly type: OAuthConnectorType;
+  readonly type: ConnectorOAuthAuthorizeType;
   readonly clientRegistration: "static" | "dynamic" | undefined;
   readonly clientId: string | undefined;
   readonly redirectUri: string;
@@ -316,7 +309,7 @@ async function buildAuthorizeUrl(args: {
 }
 
 function buildConnectorSpecificAuthorizeUrl(args: {
-  readonly type: OAuthConnectorType;
+  readonly type: ConnectorOAuthAuthorizeType;
   readonly authorizationUrl: string;
   readonly clientId: string;
   readonly redirectUri: string;
@@ -356,7 +349,7 @@ function buildConnectorSpecificAuthorizeUrl(args: {
 }
 
 async function buildDynamicAuthorizeUrl(args: {
-  readonly type: OAuthConnectorType;
+  readonly type: ConnectorOAuthAuthorizeType;
   readonly redirectUri: string;
   readonly state: string;
 }): Promise<{
@@ -624,7 +617,7 @@ export function createAuthorizeConnectorInner(route: ConnectorAuthorizeRoute) {
     }
     if (oauthStorage !== "connector") {
       return jsonResponse(
-        { error: connectorOAuthAuthorizationError(type) },
+        { error: `${type} does not use connector OAuth authorization` },
         400,
       );
     }

--- a/turbo/apps/api/src/signals/routes/zero-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/zero-connectors.ts
@@ -15,9 +15,9 @@ import {
   zeroLocalAgentConnectorContract,
 } from "@vm0/api-contracts/contracts/zero-connectors";
 import {
-  getConnectorAuthMethods,
+  getConnectorOAuthCredentials,
   getConnectorOAuthConfig,
-  getConnectorOAuthEnvKeys,
+  getConnectorOAuthStorage,
   isGoogleOAuthConnector,
 } from "@vm0/connectors/connector-utils";
 import {
@@ -25,6 +25,10 @@ import {
   type ConnectorType,
 } from "@vm0/connectors/connectors";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import {
+  type AuthUrlResult,
+  PROVIDER_HANDLERS,
+} from "@vm0/connectors/oauth-providers";
 import { isFeatureEnabled } from "@vm0/core/feature-switch";
 import { connectorSessions } from "@vm0/db/schema/connector-session";
 import { and, eq } from "drizzle-orm";
@@ -59,6 +63,7 @@ import type { RouteEntry } from "../route";
 const STATE_COOKIE_NAME = "connector_oauth_state";
 const SESSION_COOKIE_NAME = "connector_oauth_session";
 const PKCE_COOKIE_NAME = "connector_oauth_pkce";
+const OAUTH_CONTEXT_COOKIE_NAME = "connector_oauth_context";
 const COOKIE_MAX_AGE = 15 * 60;
 const REDIRECT_STATUS = 307;
 const CONNECTOR_SESSION_TTL_SECONDS = 15 * 60;
@@ -70,6 +75,8 @@ type ConnectorAuthorizeRoute = AppRoute & {
   readonly pathParams: z.ZodType<{ readonly type: string }>;
   readonly query: z.ZodType<{ readonly session?: string }>;
 };
+
+type OAuthConnectorType = Exclude<ConnectorType, "computer">;
 
 const connectorReadAuth = {
   requireOrganization: true,
@@ -128,10 +135,6 @@ function generateConnectorSessionCode(
   return code;
 }
 
-function isRefreshOnlyConnectorType(type: ConnectorType): boolean {
-  return type === "codex-oauth";
-}
-
 function buildCookieHeader(
   name: string,
   value: string,
@@ -172,6 +175,13 @@ function redirectResponse(url: string): Response {
     status: REDIRECT_STATUS,
     headers: { location: url },
   });
+}
+
+function connectorOAuthAuthorizationError(type: OAuthConnectorType): string {
+  if (type === "codex-oauth") {
+    return "codex-oauth does not use browser OAuth authorization; use the codex auth.json paste flow";
+  }
+  return `${type} does not use connector OAuth authorization`;
 }
 
 async function base64UrlSha256(value: string): Promise<string> {
@@ -217,48 +227,39 @@ function deterministicPkceSuffix(type: ConnectorType): string | undefined {
 }
 
 async function buildAuthorizeUrl(args: {
-  readonly type: ConnectorType;
-  readonly clientId: string;
+  readonly type: OAuthConnectorType;
+  readonly clientRegistration: "static" | "dynamic" | undefined;
+  readonly clientId: string | undefined;
   readonly redirectUri: string;
   readonly state: string;
-}): Promise<{ readonly url: string; readonly codeVerifier?: string } | null> {
+}): Promise<{
+  readonly url: string;
+  readonly codeVerifier?: string;
+  readonly oauthContext?: string;
+} | null> {
   const oauthConfig = getConnectorOAuthConfig(args.type);
   if (!oauthConfig?.authorizationUrl) {
     return null;
   }
 
-  if (args.type === "github") {
-    return {
-      url: `${oauthConfig.authorizationUrl}?${new URLSearchParams({
-        client_id: args.clientId,
-        redirect_uri: args.redirectUri,
-        scope: oauthConfig.scopes.join(" "),
-        state: args.state,
-      }).toString()}`,
-    };
+  if (args.clientRegistration === "dynamic") {
+    return buildDynamicAuthorizeUrl(args);
   }
 
-  if (args.type === "slack") {
-    return {
-      url: `${oauthConfig.authorizationUrl}?${new URLSearchParams({
-        client_id: args.clientId,
-        redirect_uri: args.redirectUri,
-        user_scope: oauthConfig.scopes.join(","),
-        state: args.state,
-      }).toString()}`,
-    };
+  if (!args.clientId) {
+    return null;
   }
 
-  if (args.type === "notion") {
-    return {
-      url: `${oauthConfig.authorizationUrl}?${new URLSearchParams({
-        client_id: args.clientId,
-        redirect_uri: args.redirectUri,
-        state: args.state,
-        response_type: "code",
-        owner: "user",
-      }).toString()}`,
-    };
+  const connectorSpecificUrl = buildConnectorSpecificAuthorizeUrl({
+    type: args.type,
+    authorizationUrl: oauthConfig.authorizationUrl,
+    clientId: args.clientId,
+    redirectUri: args.redirectUri,
+    scopes: oauthConfig.scopes,
+    state: args.state,
+  });
+  if (connectorSpecificUrl) {
+    return { url: connectorSpecificUrl };
   }
 
   const params = new URLSearchParams({
@@ -312,6 +313,74 @@ async function buildAuthorizeUrl(args: {
   }
 
   return { url: `${oauthConfig.authorizationUrl}?${params.toString()}` };
+}
+
+function buildConnectorSpecificAuthorizeUrl(args: {
+  readonly type: OAuthConnectorType;
+  readonly authorizationUrl: string;
+  readonly clientId: string;
+  readonly redirectUri: string;
+  readonly scopes: readonly string[];
+  readonly state: string;
+}): string | undefined {
+  switch (args.type) {
+    case "github": {
+      return `${args.authorizationUrl}?${new URLSearchParams({
+        client_id: args.clientId,
+        redirect_uri: args.redirectUri,
+        scope: args.scopes.join(" "),
+        state: args.state,
+      }).toString()}`;
+    }
+    case "slack": {
+      return `${args.authorizationUrl}?${new URLSearchParams({
+        client_id: args.clientId,
+        redirect_uri: args.redirectUri,
+        user_scope: args.scopes.join(","),
+        state: args.state,
+      }).toString()}`;
+    }
+    case "notion": {
+      return `${args.authorizationUrl}?${new URLSearchParams({
+        client_id: args.clientId,
+        redirect_uri: args.redirectUri,
+        state: args.state,
+        response_type: "code",
+        owner: "user",
+      }).toString()}`;
+    }
+    default: {
+      return undefined;
+    }
+  }
+}
+
+async function buildDynamicAuthorizeUrl(args: {
+  readonly type: OAuthConnectorType;
+  readonly redirectUri: string;
+  readonly state: string;
+}): Promise<{
+  readonly url: string;
+  readonly codeVerifier?: string;
+  readonly oauthContext?: string;
+} | null> {
+  const handler = PROVIDER_HANDLERS[args.type];
+  const authResult = await handler.buildAuthUrlWithoutClient?.(
+    args.redirectUri,
+    args.state,
+  );
+  if (!authResult) {
+    return null;
+  }
+  return normalizeAuthUrlResult(authResult);
+}
+
+function normalizeAuthUrlResult(authResult: string | AuthUrlResult): {
+  readonly url: string;
+  readonly codeVerifier?: string;
+  readonly oauthContext?: string;
+} {
+  return typeof authResult === "string" ? { url: authResult } : authResult;
 }
 
 const getConnectorListInner$ = computed(async (get) => {
@@ -546,18 +615,16 @@ export function createAuthorizeConnectorInner(route: ConnectorAuthorizeRoute) {
       );
     }
 
-    if (isRefreshOnlyConnectorType(type)) {
+    const oauthStorage = getConnectorOAuthStorage(type);
+    if (!oauthStorage) {
       return jsonResponse(
-        {
-          error:
-            "codex-oauth does not use browser OAuth authorization; use the codex auth.json paste flow",
-        },
+        { error: `${type} connector does not use OAuth` },
         400,
       );
     }
-    if (!("oauth" in getConnectorAuthMethods(type))) {
+    if (oauthStorage !== "connector") {
       return jsonResponse(
-        { error: `${type} connector does not use OAuth` },
+        { error: connectorOAuthAuthorizationError(type) },
         400,
       );
     }
@@ -577,15 +644,17 @@ export function createAuthorizeConnectorInner(route: ConnectorAuthorizeRoute) {
 
     const state = generateState();
     const redirectUri = `${origin}/api/connectors/${type}/callback`;
-    const envKeys = getConnectorOAuthEnvKeys(type);
-    const clientId = envKeys ? optionalEnv(envKeys.clientId) : undefined;
-    if (!clientId) {
+    const credentials = getConnectorOAuthCredentials(type, optionalEnv, {
+      requireClientSecret: false,
+    });
+    if (!credentials?.configured) {
       return jsonResponse({ error: `${type} OAuth not configured` }, 500);
     }
 
     const authResult = await buildAuthorizeUrl({
       type,
-      clientId,
+      clientRegistration: credentials.client?.clientRegistration,
+      clientId: credentials.clientId,
       redirectUri,
       state,
     });
@@ -612,6 +681,16 @@ export function createAuthorizeConnectorInner(route: ConnectorAuthorizeRoute) {
         buildCookieHeader(
           PKCE_COOKIE_NAME,
           authResult.codeVerifier,
+          COOKIE_MAX_AGE,
+        ),
+      );
+    }
+    if (authResult.oauthContext) {
+      response.headers.append(
+        "Set-Cookie",
+        buildCookieHeader(
+          OAUTH_CONTEXT_COOKIE_NAME,
+          authResult.oauthContext,
           COOKIE_MAX_AGE,
         ),
       );

--- a/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
@@ -1,6 +1,11 @@
 import { Buffer } from "node:buffer";
 
 import type { SecretConnectorMetadata } from "@vm0/api-contracts/contracts/runners";
+import {
+  getConnectorOAuthCredentials,
+  getConnectorOAuthStorage,
+} from "@vm0/connectors/connector-utils";
+import { connectorTypeSchema } from "@vm0/connectors/connectors";
 import { basicAuthTemplateRe } from "@vm0/connectors/firewall-types";
 import type { FeatureSwitchContext } from "@vm0/core/feature-switch";
 import {
@@ -136,14 +141,13 @@ interface RefreshAccessTokenArgs extends SecretTokenLookupArgs {
 interface RefreshTokenContext {
   readonly refreshTokenSecret: string;
   readonly currentRefreshToken: string;
-  readonly clientId: string;
+  readonly clientId: string | undefined;
   readonly clientSecret: string | undefined;
   readonly accessTokenSecret: string;
   readonly secretUserId: string;
 }
 
 type RefreshableProviderHandler = ProviderHandler & {
-  readonly refreshToken: NonNullable<ProviderHandler["refreshToken"]>;
   readonly getRefreshSecretName: NonNullable<
     ProviderHandler["getRefreshSecretName"]
   >;
@@ -197,8 +201,12 @@ const REFRESH_BUFFER_SECS = 60;
 const DEFAULT_ACCESS_TOKEN_EXPIRES_IN_SECS = 3600;
 const TEMPLATE_RE = /\$\{\{\s*(secrets|vars)\.([a-zA-Z_][a-zA-Z0-9_]*)\s*\}\}/g;
 
-function getRefreshSourceType(handlerKey: string): OAuthSecretSource {
-  return handlerKey === "codex-oauth" ? "model-provider" : "connector";
+function getOAuthSecretSource(handlerKey: string): OAuthSecretSource {
+  const parsed = connectorTypeSchema.safeParse(handlerKey);
+  return parsed.success &&
+    getConnectorOAuthStorage(parsed.data) === "model-provider"
+    ? "model-provider"
+    : "connector";
 }
 
 function sourceHandlerToProviderType(handlerKey: string): string | undefined {
@@ -220,7 +228,7 @@ function resolveRefreshMetadata(
   metadata: SecretConnectorMetadata | undefined,
 ): SecretConnectorMetadata {
   const sourceType =
-    metadata?.sourceType ?? getRefreshSourceType(connectorType);
+    metadata?.sourceType ?? getOAuthSecretSource(connectorType);
   return {
     sourceType,
     sourceUserId:
@@ -474,10 +482,10 @@ async function getExpiryByHandlerKey(
   metadataByConnector: Map<string, SecretConnectorMetadata>,
 ): Promise<Map<string, number | null>> {
   const connectorOnly = connectorTypes.filter((connectorType) => {
-    return getRefreshSourceType(connectorType) === "connector";
+    return getOAuthSecretSource(connectorType) === "connector";
   });
   const modelProviderHandlerKeys = connectorTypes.filter((connectorType) => {
-    return getRefreshSourceType(connectorType) === "model-provider";
+    return getOAuthSecretSource(connectorType) === "model-provider";
   });
 
   const [connectorExpiry, modelProviderEntries] = await Promise.all([
@@ -516,12 +524,11 @@ function prepareRefreshTokenContext(args: RefreshAccessTokenArgs): {
   readonly context: RefreshTokenContext;
 } | null {
   const handler = providerHandler(args.connectorType);
-  if (!handler?.refreshToken || !handler.getRefreshSecretName) {
+  if (!handler?.getRefreshSecretName) {
     return null;
   }
   const refreshableHandler: RefreshableProviderHandler = {
     ...handler,
-    refreshToken: handler.refreshToken,
     getRefreshSecretName: handler.getRefreshSecretName,
   };
   if (args.sourceType === "model-provider" && !args.metadataKey) {
@@ -538,8 +545,42 @@ function prepareRefreshTokenContext(args: RefreshAccessTokenArgs): {
   }
 
   const env = currentProviderEnv();
-  const clientId = handler.getClientId(env);
-  if (!clientId) {
+  const connectorType = args.connectorType as keyof typeof PROVIDER_HANDLERS;
+  const credentials = getConnectorOAuthCredentials(
+    connectorType,
+    (name) => {
+      return env[name];
+    },
+    { requireClientSecret: false },
+  );
+  if (!credentials?.configured) {
+    L.debug(
+      `${args.connectorType} OAuth credentials not configured, skipping token refresh`,
+    );
+    return null;
+  }
+  if (
+    credentials.client?.clientRegistration === "dynamic" &&
+    !refreshableHandler.refreshTokenWithoutClient
+  ) {
+    L.debug(
+      `${args.connectorType} dynamic OAuth refresh not supported, skipping token refresh`,
+    );
+    return null;
+  }
+  if (
+    credentials.client?.clientRegistration !== "dynamic" &&
+    !refreshableHandler.refreshToken
+  ) {
+    L.debug(
+      `${args.connectorType} OAuth refresh not supported, skipping token refresh`,
+    );
+    return null;
+  }
+  if (
+    credentials.client?.clientRegistration !== "dynamic" &&
+    !credentials.clientId
+  ) {
     L.debug(
       `${args.connectorType} OAuth client ID not configured, skipping token refresh`,
     );
@@ -551,8 +592,8 @@ function prepareRefreshTokenContext(args: RefreshAccessTokenArgs): {
     context: {
       refreshTokenSecret,
       currentRefreshToken,
-      clientId,
-      clientSecret: refreshableHandler.getClientSecret(env),
+      clientId: credentials.clientId,
+      clientSecret: credentials.clientSecret,
       accessTokenSecret: refreshableHandler.getSecretName(),
       secretUserId: resolveSecretUserId(
         args.sourceType,
@@ -674,11 +715,15 @@ async function refreshConnectorAccessToken(
   }
 
   const refreshResult = await settle(
-    prepared.handler.refreshToken(
-      prepared.context.clientId,
-      prepared.context.clientSecret ?? "",
-      prepared.context.currentRefreshToken,
-    ),
+    prepared.context.clientId
+      ? prepared.handler.refreshToken!(
+          prepared.context.clientId,
+          prepared.context.clientSecret ?? "",
+          prepared.context.currentRefreshToken,
+        )
+      : prepared.handler.refreshTokenWithoutClient!(
+          prepared.context.currentRefreshToken,
+        ),
   );
 
   if (!refreshResult.ok) {

--- a/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
@@ -430,7 +430,9 @@ async function revokeConnectorToken(args: {
 }): Promise<void> {
   const envKeys = getConnectorOAuthEnvKeys(args.type);
   const clientId = envKeys ? optionalEnv(envKeys.clientId) : undefined;
-  const clientSecret = envKeys ? optionalEnv(envKeys.clientSecret) : undefined;
+  const clientSecret = envKeys?.clientSecret
+    ? optionalEnv(envKeys.clientSecret)
+    : undefined;
   if (!clientId || !clientSecret) {
     return;
   }

--- a/turbo/apps/web/app/api/connectors/[type]/authorize/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/connectors/[type]/authorize/__tests__/route.test.ts
@@ -172,7 +172,7 @@ describe("GET /api/connectors/:type/authorize - OAuth Authorize", () => {
 
     expect(response.status).toBe(400);
     expect(data.error).toBe(
-      "codex-oauth does not use browser OAuth authorization; use the codex auth.json paste flow",
+      "codex-oauth does not use connector OAuth authorization",
     );
   });
 

--- a/turbo/apps/web/app/api/connectors/[type]/authorize/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/connectors/[type]/authorize/__tests__/route.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { GET } from "../route";
-import { createTestRequest } from "../../../../../../src/__tests__/api-test-helpers";
+import {
+  createTestRequest,
+  findTestConnectorTokenExpiresAt,
+} from "../../../../../../src/__tests__/api-test-helpers";
 import { testContext } from "../../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
 import { reloadEnv } from "../../../../../../src/env";
@@ -132,7 +135,31 @@ describe("GET /api/connectors/:type/authorize - OAuth Authorize", () => {
     expect(sessionCookie).toBeUndefined();
   });
 
-  it("should return 400 for refresh-only codex-oauth connector", async () => {
+  it("deletes existing connector before authorization URL creation", async () => {
+    const user = await context.setupUser();
+    vi.stubEnv("GH_OAUTH_CLIENT_ID", "");
+    vi.stubEnv("GH_OAUTH_CLIENT_SECRET", "");
+    reloadEnv();
+    await context.createConnector(user.orgId, {
+      userId: user.userId,
+      type: "github",
+      authMethod: "oauth",
+    });
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/connectors/github/authorize",
+    );
+    const response = await GET(request, {
+      params: Promise.resolve({ type: "github" }),
+    });
+
+    expect(response.status).toBe(500);
+    await expect(
+      findTestConnectorTokenExpiresAt(user.orgId, "github"),
+    ).resolves.toBeUndefined();
+  });
+
+  it("should return 400 for model-provider stored OAuth connectors", async () => {
     await context.setupUser();
 
     const request = createTestRequest(
@@ -144,7 +171,9 @@ describe("GET /api/connectors/:type/authorize - OAuth Authorize", () => {
     const data = await response.json();
 
     expect(response.status).toBe(400);
-    expect(data.error).toContain("auth.json paste flow");
+    expect(data.error).toBe(
+      "codex-oauth does not use browser OAuth authorization; use the codex auth.json paste flow",
+    );
   });
 
   describe("Slack connector", () => {

--- a/turbo/apps/web/app/api/connectors/[type]/authorize/route.ts
+++ b/turbo/apps/web/app/api/connectors/[type]/authorize/route.ts
@@ -16,6 +16,7 @@ import {
 import {
   getConnectorOAuthCredentials,
   getConnectorOAuthStorage,
+  isConnectorOAuthAuthorizeType,
 } from "@vm0/connectors/connector-utils";
 import { deleteConnector } from "../../../../../src/lib/zero/connector/connector-service";
 import { logger } from "../../../../../src/lib/shared/logger";
@@ -38,8 +39,6 @@ const SESSION_COOKIE_NAME = "connector_oauth_session";
 const PKCE_COOKIE_NAME = "connector_oauth_pkce";
 const OAUTH_CONTEXT_COOKIE_NAME = "connector_oauth_context";
 const COOKIE_MAX_AGE = 15 * 60; // 15 minutes
-
-type ConnectorOAuthAuthorizeType = Exclude<ConnectorType, "computer">;
 
 /**
  * Generate a random state string for CSRF protection
@@ -71,27 +70,6 @@ function buildCookieHeader(
     parts.push("Secure");
   }
   return parts.join("; ");
-}
-
-function rejectUnsupportedConnectorOAuth(
-  connectorType: ConnectorOAuthAuthorizeType,
-): NextResponse | undefined {
-  const oauthStorage = getConnectorOAuthStorage(connectorType);
-  if (!oauthStorage) {
-    return NextResponse.json(
-      { error: `${connectorType} connector does not use OAuth` },
-      { status: 400 },
-    );
-  }
-
-  if (oauthStorage !== "connector") {
-    return NextResponse.json(
-      { error: `${connectorType} does not use connector OAuth authorization` },
-      { status: 400 },
-    );
-  }
-
-  return undefined;
 }
 
 export async function GET(
@@ -135,10 +113,19 @@ export async function GET(
     );
   }
 
-  const unsupportedOAuthResponse =
-    rejectUnsupportedConnectorOAuth(connectorType);
-  if (unsupportedOAuthResponse) {
-    return unsupportedOAuthResponse;
+  const oauthStorage = getConnectorOAuthStorage(connectorType);
+  if (!oauthStorage) {
+    return NextResponse.json(
+      { error: `${connectorType} connector does not use OAuth` },
+      { status: 400 },
+    );
+  }
+
+  if (!isConnectorOAuthAuthorizeType(connectorType)) {
+    return NextResponse.json(
+      { error: `${connectorType} does not use connector OAuth authorization` },
+      { status: 400 },
+    );
   }
 
   // Auto-disconnect existing connector before re-authorizing.

--- a/turbo/apps/web/app/api/connectors/[type]/authorize/route.ts
+++ b/turbo/apps/web/app/api/connectors/[type]/authorize/route.ts
@@ -39,7 +39,7 @@ const PKCE_COOKIE_NAME = "connector_oauth_pkce";
 const OAUTH_CONTEXT_COOKIE_NAME = "connector_oauth_context";
 const COOKIE_MAX_AGE = 15 * 60; // 15 minutes
 
-type BrowserOAuthConnectorType = Exclude<ConnectorType, "computer">;
+type ConnectorOAuthAuthorizeType = Exclude<ConnectorType, "computer">;
 
 /**
  * Generate a random state string for CSRF protection
@@ -73,17 +73,8 @@ function buildCookieHeader(
   return parts.join("; ");
 }
 
-function connectorOAuthAuthorizationError(
-  connectorType: BrowserOAuthConnectorType,
-): string {
-  if (connectorType === "codex-oauth") {
-    return "codex-oauth does not use browser OAuth authorization; use the codex auth.json paste flow";
-  }
-  return `${connectorType} does not use connector OAuth authorization`;
-}
-
 function rejectUnsupportedConnectorOAuth(
-  connectorType: BrowserOAuthConnectorType,
+  connectorType: ConnectorOAuthAuthorizeType,
 ): NextResponse | undefined {
   const oauthStorage = getConnectorOAuthStorage(connectorType);
   if (!oauthStorage) {
@@ -95,7 +86,7 @@ function rejectUnsupportedConnectorOAuth(
 
   if (oauthStorage !== "connector") {
     return NextResponse.json(
-      { error: connectorOAuthAuthorizationError(connectorType) },
+      { error: `${connectorType} does not use connector OAuth authorization` },
       { status: 400 },
     );
   }

--- a/turbo/apps/web/app/api/connectors/[type]/authorize/route.ts
+++ b/turbo/apps/web/app/api/connectors/[type]/authorize/route.ts
@@ -1,5 +1,8 @@
 import { NextResponse } from "next/server";
-import { connectorTypeSchema } from "@vm0/connectors/connectors";
+import {
+  connectorTypeSchema,
+  type ConnectorType,
+} from "@vm0/connectors/connectors";
 import { env } from "../../../../../src/env";
 import { initServices } from "../../../../../src/lib/init-services";
 import { getAuthContext } from "../../../../../src/lib/auth/get-auth-context";
@@ -10,6 +13,10 @@ import {
   PROVIDER_HANDLERS,
   providerEnvFromObject,
 } from "@vm0/connectors/oauth-providers";
+import {
+  getConnectorOAuthCredentials,
+  getConnectorOAuthStorage,
+} from "@vm0/connectors/connector-utils";
 import { deleteConnector } from "../../../../../src/lib/zero/connector/connector-service";
 import { logger } from "../../../../../src/lib/shared/logger";
 import { and, eq } from "drizzle-orm";
@@ -29,8 +36,10 @@ const log = logger("api:connectors:authorize");
 const STATE_COOKIE_NAME = "connector_oauth_state";
 const SESSION_COOKIE_NAME = "connector_oauth_session";
 const PKCE_COOKIE_NAME = "connector_oauth_pkce";
+const OAUTH_CONTEXT_COOKIE_NAME = "connector_oauth_context";
 const COOKIE_MAX_AGE = 15 * 60; // 15 minutes
-const REFRESH_ONLY_CONNECTOR_TYPES = new Set<string>(["codex-oauth"]);
+
+type BrowserOAuthConnectorType = Exclude<ConnectorType, "computer">;
 
 /**
  * Generate a random state string for CSRF protection
@@ -62,6 +71,36 @@ function buildCookieHeader(
     parts.push("Secure");
   }
   return parts.join("; ");
+}
+
+function connectorOAuthAuthorizationError(
+  connectorType: BrowserOAuthConnectorType,
+): string {
+  if (connectorType === "codex-oauth") {
+    return "codex-oauth does not use browser OAuth authorization; use the codex auth.json paste flow";
+  }
+  return `${connectorType} does not use connector OAuth authorization`;
+}
+
+function rejectUnsupportedConnectorOAuth(
+  connectorType: BrowserOAuthConnectorType,
+): NextResponse | undefined {
+  const oauthStorage = getConnectorOAuthStorage(connectorType);
+  if (!oauthStorage) {
+    return NextResponse.json(
+      { error: `${connectorType} connector does not use OAuth` },
+      { status: 400 },
+    );
+  }
+
+  if (oauthStorage !== "connector") {
+    return NextResponse.json(
+      { error: connectorOAuthAuthorizationError(connectorType) },
+      { status: 400 },
+    );
+  }
+
+  return undefined;
 }
 
 export async function GET(
@@ -105,14 +144,10 @@ export async function GET(
     );
   }
 
-  if (REFRESH_ONLY_CONNECTOR_TYPES.has(connectorType)) {
-    return NextResponse.json(
-      {
-        error:
-          "codex-oauth does not use browser OAuth authorization; use the codex auth.json paste flow",
-      },
-      { status: 400 },
-    );
+  const unsupportedOAuthResponse =
+    rejectUnsupportedConnectorOAuth(connectorType);
+  if (unsupportedOAuthResponse) {
+    return unsupportedOAuthResponse;
   }
 
   // Auto-disconnect existing connector before re-authorizing.
@@ -152,14 +187,31 @@ export async function GET(
   // Build authorization URL via provider registry
   const currentEnv = providerEnvFromObject(env());
   const handler = PROVIDER_HANDLERS[connectorType];
-  const clientId = handler.getClientId(currentEnv);
-  if (!clientId) {
+  const credentials = getConnectorOAuthCredentials(
+    connectorType,
+    (name) => {
+      return currentEnv[name];
+    },
+    { requireClientSecret: false },
+  );
+  if (!credentials?.configured) {
     return NextResponse.json(
       { error: `${connectorType} OAuth not configured` },
       { status: 500 },
     );
   }
-  const authResult = await handler.buildAuthUrl(clientId, redirectUri, state);
+  const authResult =
+    credentials.client?.clientRegistration === "dynamic"
+      ? await handler.buildAuthUrlWithoutClient?.(redirectUri, state)
+      : credentials.clientId
+        ? await handler.buildAuthUrl(credentials.clientId, redirectUri, state)
+        : undefined;
+  if (!authResult) {
+    return NextResponse.json(
+      { error: `${connectorType} OAuth not configured` },
+      { status: 500 },
+    );
+  }
 
   // Normalize result — handlers may return a plain URL string or { url, codeVerifier }
   const isAuthUrlResult = (v: string | AuthUrlResult): v is AuthUrlResult => {
@@ -168,6 +220,9 @@ export async function GET(
   const authUrl = isAuthUrlResult(authResult) ? authResult.url : authResult;
   const codeVerifier = isAuthUrlResult(authResult)
     ? authResult.codeVerifier
+    : undefined;
+  const oauthContext = isAuthUrlResult(authResult)
+    ? authResult.oauthContext
     : undefined;
 
   // Create redirect response with state cookie
@@ -182,6 +237,17 @@ export async function GET(
     response.headers.append(
       "Set-Cookie",
       buildCookieHeader(PKCE_COOKIE_NAME, codeVerifier, COOKIE_MAX_AGE),
+    );
+  }
+
+  if (oauthContext) {
+    response.headers.append(
+      "Set-Cookie",
+      buildCookieHeader(
+        OAUTH_CONTEXT_COOKIE_NAME,
+        oauthContext,
+        COOKIE_MAX_AGE,
+      ),
     );
   }
 

--- a/turbo/apps/web/app/api/connectors/[type]/callback/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/connectors/[type]/callback/__tests__/route.test.ts
@@ -927,6 +927,7 @@ function createCallbackRequest(options: {
   errorDescription?: string;
   savedState?: string;
   sessionId?: string;
+  oauthContext?: string;
   connectorType?: string;
 }) {
   const type = options.connectorType ?? "github";
@@ -945,6 +946,9 @@ function createCallbackRequest(options: {
   }
   if (options.sessionId) {
     cookies.push(`connector_oauth_session=${options.sessionId}`);
+  }
+  if (options.oauthContext) {
+    cookies.push(`connector_oauth_context=${options.oauthContext}`);
   }
 
   return createTestRequest(url.toString(), {
@@ -1039,6 +1043,26 @@ describe("GET /api/connectors/:type/callback - OAuth Callback", () => {
       const location = response.headers.get("location");
       expect(location).toContain("/connector/error");
       expect(location).toContain("Not+authenticated");
+    });
+
+    it("should redirect with error for refresh-only connector callbacks", async () => {
+      await context.setupUser();
+
+      const request = createCallbackRequest({
+        connectorType: "codex-oauth",
+        code: "test-code",
+        state: "test-state",
+        savedState: "test-state",
+      });
+      const response = await GET(request, {
+        params: Promise.resolve({ type: "codex-oauth" }),
+      });
+
+      expect(response.status).toBe(307);
+      const location = response.headers.get("location");
+      expect(location).toContain("/connector/error");
+      expect(location).toContain("codex-oauth");
+      expect(location).toContain("OAuth+authorization+failed");
     });
 
     it("should redirect with error when OAuth provider returns error", async () => {
@@ -1174,6 +1198,7 @@ describe("GET /api/connectors/:type/callback - OAuth Callback", () => {
         code: "valid-code",
         state: "test-state",
         savedState: "test-state",
+        oauthContext: "opaque-provider-context",
       });
       const response = await GET(request, {
         params: Promise.resolve({ type: "github" }),
@@ -1219,7 +1244,11 @@ describe("GET /api/connectors/:type/callback - OAuth Callback", () => {
       const stateCookie = cookies.find((c) => {
         return c.startsWith("connector_oauth_state=");
       });
+      const contextCookie = cookies.find((c) => {
+        return c.startsWith("connector_oauth_context=");
+      });
       expect(stateCookie).toContain("Max-Age=0");
+      expect(contextCookie).toContain("Max-Age=0");
     });
   });
 

--- a/turbo/apps/web/app/api/connectors/[type]/callback/route.ts
+++ b/turbo/apps/web/app/api/connectors/[type]/callback/route.ts
@@ -4,7 +4,11 @@ import {
   type ConnectorType,
   connectorTypeSchema,
 } from "@vm0/connectors/connectors";
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
+import {
+  getConnectorOAuthCredentials,
+  getConnectorOAuthConfig,
+  getConnectorOAuthStorage,
+} from "@vm0/connectors/connector-utils";
 import { env } from "../../../../../src/env";
 import { initServices } from "../../../../../src/lib/init-services";
 import { getAuthContext } from "../../../../../src/lib/auth/get-auth-context";
@@ -34,6 +38,7 @@ const log = logger("api:connectors:callback");
 const STATE_COOKIE_NAME = "connector_oauth_state";
 const SESSION_COOKIE_NAME = "connector_oauth_session";
 const PKCE_COOKIE_NAME = "connector_oauth_pkce";
+const OAUTH_CONTEXT_COOKIE_NAME = "connector_oauth_context";
 
 /**
  * Parse cookies from request header
@@ -67,21 +72,46 @@ async function exchangeTokenForConnector(
   redirectUri: string,
   state?: string,
   codeVerifier?: string,
+  oauthContext?: string,
 ): Promise<OAuthTokenResult> {
+  if (getConnectorOAuthStorage(connectorType) !== "connector") {
+    throw new Error(`${connectorType} OAuth not configured`);
+  }
   const currentEnv = providerEnvFromObject(env());
   const handler = PROVIDER_HANDLERS[connectorType];
-  const clientId = handler.getClientId(currentEnv);
-  const clientSecret = handler.getClientSecret(currentEnv);
-  if (!clientId || !clientSecret) {
+  const credentials = getConnectorOAuthCredentials(connectorType, (name) => {
+    return currentEnv[name];
+  });
+  if (!credentials?.configured) {
+    throw new Error(`${connectorType} OAuth not configured`);
+  }
+  if (credentials.client?.clientRegistration === "dynamic") {
+    if (!handler.exchangeCodeWithoutClient) {
+      throw new Error(`${connectorType} OAuth not configured`);
+    }
+    return handler.exchangeCodeWithoutClient(
+      code,
+      redirectUri,
+      state,
+      codeVerifier,
+      oauthContext,
+    );
+  }
+  if (
+    !credentials.clientId ||
+    (credentials.client?.clientType === "confidential" &&
+      !credentials.clientSecret)
+  ) {
     throw new Error(`${connectorType} OAuth not configured`);
   }
   return handler.exchangeCode(
-    clientId,
-    clientSecret,
+    credentials.clientId,
+    credentials.clientSecret ?? "",
     code,
     redirectUri,
     state,
     codeVerifier,
+    oauthContext,
   );
 }
 
@@ -132,6 +162,7 @@ export async function GET(
   const savedState = getCookie(request, STATE_COOKIE_NAME);
   const sessionId = getCookie(request, SESSION_COOKIE_NAME);
   const codeVerifier = getCookie(request, PKCE_COOKIE_NAME);
+  const oauthContext = getCookie(request, OAUTH_CONTEXT_COOKIE_NAME);
 
   // Get code and state from query params
   const code = url.searchParams.get("code");
@@ -182,6 +213,7 @@ export async function GET(
         redirectUri,
         state ?? undefined,
         codeVerifier,
+        oauthContext,
       );
 
     const { userId } = authCtx;
@@ -257,6 +289,10 @@ export async function GET(
       "Set-Cookie",
       buildDeleteCookieHeader(PKCE_COOKIE_NAME),
     );
+    response.headers.append(
+      "Set-Cookie",
+      buildDeleteCookieHeader(OAUTH_CONTEXT_COOKIE_NAME),
+    );
     return response;
   } catch (err) {
     const internalMessage = err instanceof Error ? err.message : "OAuth failed";
@@ -312,6 +348,10 @@ function redirectWithError(
     response.headers.append(
       "Set-Cookie",
       buildDeleteCookieHeader(PKCE_COOKIE_NAME),
+    );
+    response.headers.append(
+      "Set-Cookie",
+      buildDeleteCookieHeader(OAUTH_CONTEXT_COOKIE_NAME),
     );
   }
   return response;

--- a/turbo/apps/web/app/api/webhooks/agent/firewall/auth/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/firewall/auth/route.ts
@@ -16,7 +16,7 @@ import {
   type OAuthSecretSource,
 } from "../../../../../../src/lib/zero/connector/connector-service";
 import {
-  getRefreshSourceType,
+  getOAuthSecretSource,
   SOURCE_HANDLER_TO_PROVIDER_TYPE,
 } from "../../../../../../src/lib/zero/handler-key-bridge";
 import { ORG_SENTINEL_USER_ID } from "../../../../../../src/lib/zero/org/org-sentinel";
@@ -75,7 +75,7 @@ function resolveRefreshMetadata(
   metadata: SecretConnectorMetadata | undefined,
 ): SecretConnectorMetadata {
   const sourceType =
-    metadata?.sourceType ?? getRefreshSourceType(connectorType);
+    metadata?.sourceType ?? getOAuthSecretSource(connectorType);
   return {
     sourceType,
     sourceUserId:
@@ -152,10 +152,10 @@ async function getExpiryByHandlerKey(
   metadataByConnector: Map<string, SecretConnectorMetadata>,
 ): Promise<Map<string, number | null>> {
   const connectorOnly = connectorTypes.filter((ct) => {
-    return getRefreshSourceType(ct) === "connector";
+    return getOAuthSecretSource(ct) === "connector";
   });
   const modelProviderHandlerKeys = connectorTypes.filter((ct) => {
-    return getRefreshSourceType(ct) === "model-provider";
+    return getOAuthSecretSource(ct) === "model-provider";
   });
   const [connectorExpiry, modelProviderEntries] = await Promise.all([
     getConnectorExpiry(orgId, userId, connectorOnly),

--- a/turbo/apps/web/src/lib/zero/__tests__/handler-key-bridge.test.ts
+++ b/turbo/apps/web/src/lib/zero/__tests__/handler-key-bridge.test.ts
@@ -4,7 +4,7 @@ import {
   HANDLER_KEY_SOURCE_TYPE,
   MODEL_PROVIDER_HANDLER_KEY,
   SOURCE_HANDLER_TO_PROVIDER_TYPE,
-  getRefreshSourceType,
+  getOAuthSecretSource,
 } from "../handler-key-bridge";
 
 describe("handler-key bridge tables stay in sync", () => {
@@ -46,14 +46,14 @@ describe("handler-key bridge tables stay in sync", () => {
   });
 });
 
-describe("getRefreshSourceType", () => {
+describe("getOAuthSecretSource", () => {
   it("returns 'model-provider' for bridged handler keys", () => {
-    expect(getRefreshSourceType("codex-oauth")).toBe("model-provider");
+    expect(getOAuthSecretSource("codex-oauth")).toBe("model-provider");
   });
 
   it("returns 'connector' for unbridged handler keys (default)", () => {
-    expect(getRefreshSourceType("github")).toBe("connector");
-    expect(getRefreshSourceType("notion")).toBe("connector");
-    expect(getRefreshSourceType("totally-unknown")).toBe("connector");
+    expect(getOAuthSecretSource("github")).toBe("connector");
+    expect(getOAuthSecretSource("notion")).toBe("connector");
+    expect(getOAuthSecretSource("totally-unknown")).toBe("connector");
   });
 });

--- a/turbo/apps/web/src/lib/zero/connector/connector-service.ts
+++ b/turbo/apps/web/src/lib/zero/connector/connector-service.ts
@@ -2,6 +2,8 @@ import { eq, and, inArray } from "drizzle-orm";
 import {
   deriveApiTokenConnectedTypes,
   getApiTokenFieldsByType,
+  getConnectorOAuthCredentials,
+  type ConnectorOAuthCredentials,
 } from "@vm0/connectors/connector-utils";
 import type {
   ConnectorAuthMethodType,
@@ -60,6 +62,30 @@ const log = logger("service:connector");
  * always judge freshness and trigger a refresh. See #9836.
  */
 const DEFAULT_ACCESS_TOKEN_EXPIRES_IN_SECS = 3600;
+
+type BrowserOAuthConnectorType = Exclude<ConnectorType, "computer">;
+type ProviderHandler =
+  (typeof PROVIDER_HANDLERS)[keyof typeof PROVIDER_HANDLERS];
+
+interface RefreshTokenResult {
+  readonly accessToken: string;
+  readonly refreshToken: string | null;
+  readonly expiresIn?: number;
+}
+
+interface RefreshConnectorAccessTokenContext {
+  readonly connectorType: string;
+  readonly typedConnectorType: BrowserOAuthConnectorType;
+  readonly handler: ProviderHandler;
+  readonly sourceType: OAuthSecretSource;
+  readonly refreshTokenSecret: string;
+  readonly currentRefreshToken: string;
+  readonly clientId: string | undefined;
+  readonly clientSecret: string | undefined;
+  readonly accessTokenSecret: string;
+  readonly secretUserId: string;
+  readonly metadataKey: string | undefined;
+}
 
 /**
  * Validate and parse connector type from database value
@@ -611,6 +637,233 @@ export async function deleteConnector(
  * Returns null if refresh token is unavailable, OAuth credentials are missing,
  * or the refresh fails (caller should fall back to the existing access token).
  */
+function canRefreshConnectorAccessToken(params: {
+  readonly connectorType: string;
+  readonly handler: ProviderHandler;
+  readonly credentials: ConnectorOAuthCredentials | undefined;
+}): boolean {
+  if (!params.credentials?.configured) {
+    log.debug(
+      `${params.connectorType} OAuth credentials not configured, skipping token refresh`,
+    );
+    return false;
+  }
+  if (
+    params.credentials.client?.clientRegistration === "dynamic" &&
+    !params.handler.refreshTokenWithoutClient
+  ) {
+    log.debug(
+      `${params.connectorType} dynamic OAuth refresh not supported, skipping token refresh`,
+    );
+    return false;
+  }
+  if (
+    params.credentials.client?.clientRegistration !== "dynamic" &&
+    !params.handler.refreshToken
+  ) {
+    log.debug(
+      `${params.connectorType} OAuth refresh not supported, skipping token refresh`,
+    );
+    return false;
+  }
+  if (
+    params.credentials.client?.clientRegistration !== "dynamic" &&
+    !params.credentials.clientId
+  ) {
+    log.debug(
+      `${params.connectorType} OAuth client ID not configured, skipping token refresh`,
+    );
+    return false;
+  }
+  return true;
+}
+
+function prepareRefreshConnectorAccessTokenContext(params: {
+  readonly connectorType: string;
+  readonly userId: string;
+  readonly connectorSecrets: Record<string, string>;
+  readonly options: {
+    readonly sourceType?: OAuthSecretSource;
+    readonly metadataKey?: string;
+    readonly sourceUserId?: string;
+  };
+}): RefreshConnectorAccessTokenContext | null {
+  const typeResult = connectorTypeSchema.safeParse(params.connectorType);
+  if (!typeResult.success || typeResult.data === "computer") {
+    return null;
+  }
+  const typedConnectorType = typeResult.data;
+  const sourceType: OAuthSecretSource =
+    params.options.sourceType ?? "connector";
+  const handler = PROVIDER_HANDLERS[typedConnectorType];
+  if (!handler?.getRefreshSecretName) {
+    return null;
+  }
+  if (sourceType === "model-provider" && !params.options.metadataKey) {
+    throw new Error(
+      `metadataKey required for model-provider source on ${params.connectorType}`,
+    );
+  }
+
+  const refreshTokenSecret = handler.getRefreshSecretName();
+  const currentRefreshToken = params.connectorSecrets[refreshTokenSecret];
+  if (!currentRefreshToken) {
+    log.debug(`No ${params.connectorType} refresh token available, skipping`);
+    return null;
+  }
+
+  const env = providerEnvFromObject(globalThis.services.env);
+  const credentials = getConnectorOAuthCredentials(
+    typedConnectorType,
+    (name) => {
+      return env[name];
+    },
+    { requireClientSecret: false },
+  );
+  if (
+    !canRefreshConnectorAccessToken({
+      connectorType: params.connectorType,
+      handler,
+      credentials,
+    })
+  ) {
+    return null;
+  }
+
+  return {
+    connectorType: params.connectorType,
+    typedConnectorType,
+    handler,
+    sourceType,
+    refreshTokenSecret,
+    currentRefreshToken,
+    clientId: credentials?.clientId,
+    clientSecret: credentials?.clientSecret,
+    accessTokenSecret: handler.getSecretName(),
+    secretUserId: resolveSecretUserId(
+      sourceType,
+      params.userId,
+      params.options.sourceUserId,
+    ),
+    metadataKey: params.options.metadataKey,
+  };
+}
+
+async function refreshPreparedConnectorAccessToken(
+  context: RefreshConnectorAccessTokenContext,
+): Promise<RefreshTokenResult> {
+  if (context.clientId) {
+    return await context.handler.refreshToken!(
+      context.clientId,
+      context.clientSecret ?? "",
+      context.currentRefreshToken,
+    );
+  }
+  return await context.handler.refreshTokenWithoutClient!(
+    context.currentRefreshToken,
+  );
+}
+
+async function persistRefreshSuccess(params: {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly context: RefreshConnectorAccessTokenContext;
+  readonly result: RefreshTokenResult;
+  readonly connectorSecrets: Record<string, string>;
+}): Promise<void> {
+  await upsertConnectorSecret(
+    params.orgId,
+    params.context.secretUserId,
+    params.context.accessTokenSecret,
+    params.result.accessToken,
+    params.context.sourceType,
+  );
+  if (params.result.refreshToken) {
+    await upsertConnectorSecret(
+      params.orgId,
+      params.context.secretUserId,
+      params.context.refreshTokenSecret,
+      params.result.refreshToken,
+      params.context.sourceType,
+    );
+  }
+
+  const expiresAt = new Date(
+    Date.now() +
+      (params.result.expiresIn ?? DEFAULT_ACCESS_TOKEN_EXPIRES_IN_SECS) * 1000,
+  );
+  if (params.context.sourceType === "model-provider") {
+    await globalThis.services.db
+      .update(modelProviders)
+      .set({
+        tokenExpiresAt: expiresAt,
+        needsReconnect: false,
+        lastRefreshErrorCode: null,
+        updatedAt: new Date(),
+      })
+      .where(
+        and(
+          eq(modelProviders.orgId, params.orgId),
+          eq(modelProviders.userId, params.context.secretUserId),
+          eq(modelProviders.type, params.context.metadataKey!),
+        ),
+      );
+  } else {
+    await globalThis.services.db
+      .update(connectors)
+      .set({ tokenExpiresAt: expiresAt, updatedAt: new Date() })
+      .where(
+        and(
+          eq(connectors.orgId, params.orgId),
+          eq(connectors.userId, params.userId),
+          eq(connectors.type, params.context.connectorType),
+        ),
+      );
+  }
+
+  params.connectorSecrets[params.context.accessTokenSecret] =
+    params.result.accessToken;
+  if (params.result.refreshToken) {
+    params.connectorSecrets[params.context.refreshTokenSecret] =
+      params.result.refreshToken;
+  }
+}
+
+async function persistRefreshFailure(params: {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly context: RefreshConnectorAccessTokenContext;
+  readonly errorCode: string | null;
+}): Promise<void> {
+  if (params.context.sourceType === "model-provider") {
+    await globalThis.services.db
+      .update(modelProviders)
+      .set({
+        needsReconnect: true,
+        lastRefreshErrorCode: params.errorCode,
+        updatedAt: new Date(),
+      })
+      .where(
+        and(
+          eq(modelProviders.orgId, params.orgId),
+          eq(modelProviders.userId, params.context.secretUserId),
+          eq(modelProviders.type, params.context.metadataKey!),
+        ),
+      );
+  } else {
+    await globalThis.services.db
+      .update(connectors)
+      .set({ needsReconnect: true, updatedAt: new Date() })
+      .where(
+        and(
+          eq(connectors.orgId, params.orgId),
+          eq(connectors.userId, params.userId),
+          eq(connectors.type, params.context.connectorType),
+        ),
+      );
+  }
+}
+
 export async function refreshConnectorAccessToken(
   connectorType: string,
   orgId: string,
@@ -622,112 +875,25 @@ export async function refreshConnectorAccessToken(
     sourceUserId?: string;
   } = {},
 ): Promise<string | null> {
-  const sourceType: OAuthSecretSource = options.sourceType ?? "connector";
-  const handler =
-    PROVIDER_HANDLERS[connectorType as keyof typeof PROVIDER_HANDLERS];
-  if (!handler?.refreshToken || !handler.getRefreshSecretName) {
-    return null;
-  }
-  if (sourceType === "model-provider" && !options.metadataKey) {
-    throw new Error(
-      `metadataKey required for model-provider source on ${connectorType}`,
-    );
-  }
-
-  const refreshTokenSecret = handler.getRefreshSecretName();
-  const currentRefreshToken = connectorSecrets[refreshTokenSecret];
-  if (!currentRefreshToken) {
-    log.debug(`No ${connectorType} refresh token available, skipping`);
-    return null;
-  }
-
-  const env = providerEnvFromObject(globalThis.services.env);
-  const clientId = handler.getClientId(env);
-  if (!clientId) {
-    log.debug(
-      `${connectorType} OAuth client ID not configured, skipping token refresh`,
-    );
-    return null;
-  }
-  // clientSecret may legitimately be undefined for PKCE-only handlers
-  // (e.g. codex-oauth). The handler's refreshToken is the source of truth
-  // for credential needs — if a non-PKCE handler is misconfigured the
-  // upstream call will fail and the catch below records the error.
-  const clientSecret = handler.getClientSecret(env);
-
-  const accessTokenSecret = handler.getSecretName();
-
-  const secretUserId = resolveSecretUserId(
-    sourceType,
+  const context = prepareRefreshConnectorAccessTokenContext({
+    connectorType,
     userId,
-    options.sourceUserId,
-  );
+    connectorSecrets,
+    options,
+  });
+  if (!context) {
+    return null;
+  }
 
   try {
-    const result = await handler.refreshToken(
-      clientId,
-      clientSecret ?? "",
-      currentRefreshToken,
-    );
-
-    // Persist new tokens to database
-    await upsertConnectorSecret(
+    const result = await refreshPreparedConnectorAccessToken(context);
+    await persistRefreshSuccess({
       orgId,
-      secretUserId,
-      accessTokenSecret,
-      result.accessToken,
-      sourceType,
-    );
-    if (result.refreshToken) {
-      await upsertConnectorSecret(
-        orgId,
-        secretUserId,
-        refreshTokenSecret,
-        result.refreshToken,
-        sourceType,
-      );
-    }
-
-    // Update tokenExpiresAt so subsequent expiry checks are accurate.
-    const expiresAt = new Date(
-      Date.now() +
-        (result.expiresIn ?? DEFAULT_ACCESS_TOKEN_EXPIRES_IN_SECS) * 1000,
-    );
-    if (sourceType === "model-provider") {
-      await globalThis.services.db
-        .update(modelProviders)
-        .set({
-          tokenExpiresAt: expiresAt,
-          needsReconnect: false,
-          lastRefreshErrorCode: null,
-          updatedAt: new Date(),
-        })
-        .where(
-          and(
-            eq(modelProviders.orgId, orgId),
-            eq(modelProviders.userId, secretUserId),
-            // metadataKey is non-null due to the upfront guard
-            eq(modelProviders.type, options.metadataKey!),
-          ),
-        );
-    } else {
-      await globalThis.services.db
-        .update(connectors)
-        .set({ tokenExpiresAt: expiresAt, updatedAt: new Date() })
-        .where(
-          and(
-            eq(connectors.orgId, orgId),
-            eq(connectors.userId, userId),
-            eq(connectors.type, connectorType),
-          ),
-        );
-    }
-
-    // Update in-memory secrets map so subsequent mapping uses fresh token
-    connectorSecrets[accessTokenSecret] = result.accessToken;
-    if (result.refreshToken) {
-      connectorSecrets[refreshTokenSecret] = result.refreshToken;
-    }
+      userId,
+      context,
+      result,
+      connectorSecrets,
+    });
 
     log.debug(`${connectorType} access token refreshed successfully`);
     return result.accessToken;
@@ -742,35 +908,7 @@ export async function refreshConnectorAccessToken(
       errorCode,
     });
 
-    // Mark provider/connector as needing reconnect so the UI can surface the
-    // failure. For model-provider sources, also persist the typed error code.
-    if (sourceType === "model-provider") {
-      await globalThis.services.db
-        .update(modelProviders)
-        .set({
-          needsReconnect: true,
-          lastRefreshErrorCode: errorCode,
-          updatedAt: new Date(),
-        })
-        .where(
-          and(
-            eq(modelProviders.orgId, orgId),
-            eq(modelProviders.userId, secretUserId),
-            eq(modelProviders.type, options.metadataKey!),
-          ),
-        );
-    } else {
-      await globalThis.services.db
-        .update(connectors)
-        .set({ needsReconnect: true, updatedAt: new Date() })
-        .where(
-          and(
-            eq(connectors.orgId, orgId),
-            eq(connectors.userId, userId),
-            eq(connectors.type, connectorType),
-          ),
-        );
-    }
+    await persistRefreshFailure({ orgId, userId, context, errorCode });
     return null;
   }
 }

--- a/turbo/apps/web/src/lib/zero/connector/providers/__tests__/codex-oauth.test.ts
+++ b/turbo/apps/web/src/lib/zero/connector/providers/__tests__/codex-oauth.test.ts
@@ -284,6 +284,9 @@ describe("connector/providers/codex-oauth", () => {
       expect(url.searchParams.get("state")).toBe("state-1");
       expect(url.searchParams.get("code_challenge_method")).toBe("S256");
       expect(url.searchParams.get("code_challenge")).toBeTruthy();
+      if (!result.codeVerifier) {
+        throw new Error("Expected PKCE code verifier");
+      }
       expect(result.codeVerifier.length).toBeGreaterThan(20);
     });
 

--- a/turbo/apps/web/src/lib/zero/handler-key-bridge.ts
+++ b/turbo/apps/web/src/lib/zero/handler-key-bridge.ts
@@ -42,11 +42,11 @@ export const SOURCE_HANDLER_TO_PROVIDER_TYPE: Record<
 };
 
 /**
- * Resolve the secret source for a connector handler key.
+ * Resolve the OAuth secret source for a connector handler key.
  * Returns "model-provider" for handlers that back model-provider OAuth types,
  * "connector" for everything else (the default).
  */
-export function getRefreshSourceType(
+export function getOAuthSecretSource(
   handlerKey: string,
 ): "connector" | "model-provider" {
   return HANDLER_KEY_SOURCE_TYPE[handlerKey] ?? "connector";

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -409,7 +409,6 @@ describe("getConfiguredConnectorTypes", () => {
     const activeOAuthTypes = connectorTypeSchema.options.filter((type) => {
       return (
         getConnectorOAuthConfig(type) &&
-        isConnectorOAuthAuthorizeType(type) &&
         !oauthTypesWithoutRuntimeClientCredentials.has(type)
       );
     });
@@ -419,6 +418,7 @@ describe("getConfiguredConnectorTypes", () => {
     });
 
     expect(configuredTypes).toEqual(expect.arrayContaining(activeOAuthTypes));
+    expect(configuredTypes).toContain("codex-oauth");
   });
 
   it("includes computer only when both ngrok env vars are configured", () => {

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -405,13 +405,11 @@ describe("getConfiguredConnectorTypes", () => {
   });
 
   it("includes active OAuth connectors when their runtime env is configured", () => {
-    const oauthTypesWithoutRuntimeClientCredentials = new Set([
-      "codex-oauth",
-      "mailchimp",
-    ]);
+    const oauthTypesWithoutRuntimeClientCredentials = new Set(["mailchimp"]);
     const activeOAuthTypes = connectorTypeSchema.options.filter((type) => {
       return (
         getConnectorOAuthConfig(type) &&
+        isConnectorOAuthAuthorizeType(type) &&
         !oauthTypesWithoutRuntimeClientCredentials.has(type)
       );
     });

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -298,6 +298,13 @@ describe("getConfiguredConnectorTypes", () => {
     expect(configuredTypes).toContain("openai");
   });
 
+  it("includes static OAuth connectors without environment credentials", () => {
+    const configuredTypes = getConfiguredConnectorTypes(emptyEnv);
+
+    expect(configuredTypes).toContain("codex-oauth");
+    expect(configuredTypes).toContain("test-oauth");
+  });
+
   it("includes OAuth connectors only when client id and secret are configured", () => {
     const env = new Map([
       ["AIRTABLE_OAUTH_CLIENT_ID", "airtable-client-id"],

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -8,7 +8,10 @@ import {
   getConnectorEnvironmentMapping,
   getConnectorProvidedSecretNames,
   getConnectorAuthMethods,
+  getConnectorOAuthClientConfig,
+  getConnectorOAuthCredentials,
   getConnectorOAuthConfig,
+  getConnectorOAuthStorage,
   getConfiguredConnectorTypes,
   isGoogleOAuthConnector,
 } from "../connector-utils";
@@ -307,6 +310,69 @@ describe("getConfiguredConnectorTypes", () => {
 
     expect(configuredTypes).toContain("airtable");
     expect(configuredTypes).not.toContain("sentry");
+  });
+
+  it("derives static confidential OAuth credentials from connector config", () => {
+    const credentials = getConnectorOAuthCredentials("github", (name) => {
+      return (
+        {
+          GH_OAUTH_CLIENT_ID: "github-client-id",
+          GH_OAUTH_CLIENT_SECRET: "github-client-secret",
+        } as Record<string, string>
+      )[name];
+    });
+
+    expect(credentials).toStrictEqual({
+      configured: true,
+      client: getConnectorOAuthClientConfig("github"),
+      clientId: "github-client-id",
+      clientSecret: "github-client-secret",
+    });
+  });
+
+  it("does not configure static confidential OAuth when the secret is missing", () => {
+    const credentials = getConnectorOAuthCredentials("github", (name) => {
+      return name === "GH_OAUTH_CLIENT_ID" ? "github-client-id" : undefined;
+    });
+
+    expect(credentials).toStrictEqual({
+      configured: false,
+      client: getConnectorOAuthClientConfig("github"),
+      clientId: "github-client-id",
+    });
+  });
+
+  it("can derive a static OAuth client id without requiring the client secret", () => {
+    const credentials = getConnectorOAuthCredentials(
+      "github",
+      (name) => {
+        return name === "GH_OAUTH_CLIENT_ID" ? "github-client-id" : undefined;
+      },
+      { requireClientSecret: false },
+    );
+
+    expect(credentials).toStrictEqual({
+      configured: true,
+      client: getConnectorOAuthClientConfig("github"),
+      clientId: "github-client-id",
+      clientSecret: undefined,
+    });
+  });
+
+  it("supports literal static OAuth clients without environment credentials", () => {
+    const credentials = getConnectorOAuthCredentials("test-oauth", emptyEnv);
+
+    expect(credentials).toStrictEqual({
+      configured: true,
+      client: getConnectorOAuthClientConfig("test-oauth"),
+      clientId: "test-oauth-client",
+      clientSecret: "test-oauth-secret",
+    });
+  });
+
+  it("derives OAuth storage from connector config", () => {
+    expect(getConnectorOAuthStorage("github")).toBe("connector");
+    expect(getConnectorOAuthStorage("codex-oauth")).toBe("model-provider");
   });
 
   it("includes all connectors that share a configured OAuth app", () => {

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -14,6 +14,7 @@ import {
   getConnectorOAuthStorage,
   getConfiguredConnectorTypes,
   isGoogleOAuthConnector,
+  isConnectorOAuthAuthorizeType,
 } from "../connector-utils";
 import { FeatureSwitchKey } from "../feature-switch-key";
 
@@ -373,6 +374,12 @@ describe("getConfiguredConnectorTypes", () => {
   it("derives OAuth storage from connector config", () => {
     expect(getConnectorOAuthStorage("github")).toBe("connector");
     expect(getConnectorOAuthStorage("codex-oauth")).toBe("model-provider");
+  });
+
+  it("identifies connector OAuth authorize types", () => {
+    expect(isConnectorOAuthAuthorizeType("github")).toBe(true);
+    expect(isConnectorOAuthAuthorizeType("codex-oauth")).toBe(false);
+    expect(isConnectorOAuthAuthorizeType("computer")).toBe(false);
   });
 
   it("includes all connectors that share a configured OAuth app", () => {

--- a/turbo/packages/connectors/src/connector-utils.ts
+++ b/turbo/packages/connectors/src/connector-utils.ts
@@ -189,13 +189,10 @@ export function getConnectorOAuthCredentials(
   return { configured: true, client, clientId, clientSecret };
 }
 
-function hasConfiguredConnectorOAuth(
+function hasConfiguredOAuth(
   readEnv: ConnectorEnvReader,
   type: ConnectorType,
 ): boolean {
-  if (getConnectorOAuthStorage(type) !== "connector") {
-    return false;
-  }
   return getConnectorOAuthCredentials(type, readEnv)?.configured ?? false;
 }
 
@@ -231,7 +228,7 @@ export function getConfiguredConnectorTypes(
   for (const type of Object.keys(CONNECTOR_TYPES) as ConnectorType[]) {
     const defaultAuthMethod = getConnectorDefaultAuthMethod(type);
     if (
-      hasConfiguredConnectorOAuth(readEnv, type) ||
+      hasConfiguredOAuth(readEnv, type) ||
       defaultAuthMethod === "api-token"
     ) {
       configured.add(type);

--- a/turbo/packages/connectors/src/connector-utils.ts
+++ b/turbo/packages/connectors/src/connector-utils.ts
@@ -189,7 +189,7 @@ export function getConnectorOAuthCredentials(
   return { configured: true, client, clientId, clientSecret };
 }
 
-function hasConfiguredOAuth(
+function hasConfiguredConnectorOAuth(
   readEnv: ConnectorEnvReader,
   type: ConnectorType,
 ): boolean {
@@ -231,7 +231,7 @@ export function getConfiguredConnectorTypes(
   for (const type of Object.keys(CONNECTOR_TYPES) as ConnectorType[]) {
     const defaultAuthMethod = getConnectorDefaultAuthMethod(type);
     if (
-      hasConfiguredOAuth(readEnv, type) ||
+      hasConfiguredConnectorOAuth(readEnv, type) ||
       defaultAuthMethod === "api-token"
     ) {
       configured.add(type);

--- a/turbo/packages/connectors/src/connector-utils.ts
+++ b/turbo/packages/connectors/src/connector-utils.ts
@@ -5,7 +5,9 @@ import {
   type ConnectorAuthMethodConfig,
   type ConnectorAuthMethodType,
   type ConnectorConfig,
+  type ConnectorOAuthClientConfig,
   type ConnectorOAuthConfig,
+  type ConnectorOAuthStorage,
   type ConnectorSecretConfig,
   type ConnectorType,
 } from "./connectors";
@@ -105,212 +107,107 @@ export type ConnectorEnvReader = (name: string) => string | undefined;
 
 export interface ConnectorOAuthEnvKeys {
   readonly clientId: string;
-  readonly clientSecret: string;
+  readonly clientSecret?: string;
 }
 
-const OAUTH_ENV_KEYS_BY_CONNECTOR: Partial<
-  Record<ConnectorType, ConnectorOAuthEnvKeys>
-> = {
-  ahrefs: {
-    clientId: "AHREFS_OAUTH_CLIENT_ID",
-    clientSecret: "AHREFS_OAUTH_CLIENT_SECRET",
-  },
-  airtable: {
-    clientId: "AIRTABLE_OAUTH_CLIENT_ID",
-    clientSecret: "AIRTABLE_OAUTH_CLIENT_SECRET",
-  },
-  asana: {
-    clientId: "ASANA_OAUTH_CLIENT_ID",
-    clientSecret: "ASANA_OAUTH_CLIENT_SECRET",
-  },
-  canva: {
-    clientId: "CANVA_OAUTH_CLIENT_ID",
-    clientSecret: "CANVA_OAUTH_CLIENT_SECRET",
-  },
-  close: {
-    clientId: "CLOSE_OAUTH_CLIENT_ID",
-    clientSecret: "CLOSE_OAUTH_CLIENT_SECRET",
-  },
-  deel: {
-    clientId: "DEEL_OAUTH_CLIENT_ID",
-    clientSecret: "DEEL_OAUTH_CLIENT_SECRET",
-  },
-  docusign: {
-    clientId: "DOCUSIGN_OAUTH_CLIENT_ID",
-    clientSecret: "DOCUSIGN_OAUTH_CLIENT_SECRET",
-  },
-  dropbox: {
-    clientId: "DROPBOX_OAUTH_CLIENT_ID",
-    clientSecret: "DROPBOX_OAUTH_CLIENT_SECRET",
-  },
-  figma: {
-    clientId: "FIGMA_OAUTH_CLIENT_ID",
-    clientSecret: "FIGMA_OAUTH_CLIENT_SECRET",
-  },
-  "garmin-connect": {
-    clientId: "GARMIN_CONNECT_OAUTH_CLIENT_ID",
-    clientSecret: "GARMIN_CONNECT_OAUTH_CLIENT_SECRET",
-  },
-  github: {
-    clientId: "GH_OAUTH_CLIENT_ID",
-    clientSecret: "GH_OAUTH_CLIENT_SECRET",
-  },
-  gmail: {
-    clientId: "GOOGLE_OAUTH_CLIENT_ID",
-    clientSecret: "GOOGLE_OAUTH_CLIENT_SECRET",
-  },
-  "google-ads": {
-    clientId: "GOOGLE_OAUTH_CLIENT_ID",
-    clientSecret: "GOOGLE_OAUTH_CLIENT_SECRET",
-  },
-  "google-calendar": {
-    clientId: "GOOGLE_OAUTH_CLIENT_ID",
-    clientSecret: "GOOGLE_OAUTH_CLIENT_SECRET",
-  },
-  "google-docs": {
-    clientId: "GOOGLE_OAUTH_CLIENT_ID",
-    clientSecret: "GOOGLE_OAUTH_CLIENT_SECRET",
-  },
-  "google-drive": {
-    clientId: "GOOGLE_OAUTH_CLIENT_ID",
-    clientSecret: "GOOGLE_OAUTH_CLIENT_SECRET",
-  },
-  "google-meet": {
-    clientId: "GOOGLE_OAUTH_CLIENT_ID",
-    clientSecret: "GOOGLE_OAUTH_CLIENT_SECRET",
-  },
-  "google-sheets": {
-    clientId: "GOOGLE_OAUTH_CLIENT_ID",
-    clientSecret: "GOOGLE_OAUTH_CLIENT_SECRET",
-  },
-  gumroad: {
-    clientId: "GUMROAD_OAUTH_CLIENT_ID",
-    clientSecret: "GUMROAD_OAUTH_CLIENT_SECRET",
-  },
-  hubspot: {
-    clientId: "HUBSPOT_OAUTH_CLIENT_ID",
-    clientSecret: "HUBSPOT_OAUTH_CLIENT_SECRET",
-  },
-  "intervals-icu": {
-    clientId: "INTERVALS_ICU_OAUTH_CLIENT_ID",
-    clientSecret: "INTERVALS_ICU_OAUTH_CLIENT_SECRET",
-  },
-  linear: {
-    clientId: "LINEAR_OAUTH_CLIENT_ID",
-    clientSecret: "LINEAR_OAUTH_CLIENT_SECRET",
-  },
-  mercury: {
-    clientId: "MERCURY_OAUTH_CLIENT_ID",
-    clientSecret: "MERCURY_OAUTH_CLIENT_SECRET",
-  },
-  "meta-ads": {
-    clientId: "META_ADS_OAUTH_CLIENT_ID",
-    clientSecret: "META_ADS_OAUTH_CLIENT_SECRET",
-  },
-  monday: {
-    clientId: "MONDAY_OAUTH_CLIENT_ID",
-    clientSecret: "MONDAY_OAUTH_CLIENT_SECRET",
-  },
-  neon: {
-    clientId: "NEON_OAUTH_CLIENT_ID",
-    clientSecret: "NEON_OAUTH_CLIENT_SECRET",
-  },
-  notion: {
-    clientId: "NOTION_OAUTH_CLIENT_ID",
-    clientSecret: "NOTION_OAUTH_CLIENT_SECRET",
-  },
-  "outlook-calendar": {
-    clientId: "MICROSOFT_OAUTH_CLIENT_ID",
-    clientSecret: "MICROSOFT_OAUTH_CLIENT_SECRET",
-  },
-  "outlook-mail": {
-    clientId: "MICROSOFT_OAUTH_CLIENT_ID",
-    clientSecret: "MICROSOFT_OAUTH_CLIENT_SECRET",
-  },
-  posthog: {
-    clientId: "POSTHOG_OAUTH_CLIENT_ID",
-    clientSecret: "POSTHOG_OAUTH_CLIENT_SECRET",
-  },
-  reddit: {
-    clientId: "REDDIT_OAUTH_CLIENT_ID",
-    clientSecret: "REDDIT_OAUTH_CLIENT_SECRET",
-  },
-  sentry: {
-    clientId: "SENTRY_OAUTH_CLIENT_ID",
-    clientSecret: "SENTRY_OAUTH_CLIENT_SECRET",
-  },
-  slack: {
-    clientId: "SLACK_CLIENT_ID",
-    clientSecret: "SLACK_CLIENT_SECRET",
-  },
-  spotify: {
-    clientId: "SPOTIFY_OAUTH_CLIENT_ID",
-    clientSecret: "SPOTIFY_OAUTH_CLIENT_SECRET",
-  },
-  strava: {
-    clientId: "STRAVA_OAUTH_CLIENT_ID",
-    clientSecret: "STRAVA_OAUTH_CLIENT_SECRET",
-  },
-  stripe: {
-    clientId: "STRIPE_OAUTH_CLIENT_ID",
-    clientSecret: "STRIPE_OAUTH_CLIENT_SECRET",
-  },
-  supabase: {
-    clientId: "SUPABASE_OAUTH_CLIENT_ID",
-    clientSecret: "SUPABASE_OAUTH_CLIENT_SECRET",
-  },
-  todoist: {
-    clientId: "TODOIST_OAUTH_CLIENT_ID",
-    clientSecret: "TODOIST_OAUTH_CLIENT_SECRET",
-  },
-  vercel: {
-    clientId: "VERCEL_OAUTH_CLIENT_ID",
-    clientSecret: "VERCEL_OAUTH_CLIENT_SECRET",
-  },
-  webflow: {
-    clientId: "WEBFLOW_OAUTH_CLIENT_ID",
-    clientSecret: "WEBFLOW_OAUTH_CLIENT_SECRET",
-  },
-  x: {
-    clientId: "X_OAUTH_CLIENT_ID",
-    clientSecret: "X_OAUTH_CLIENT_SECRET",
-  },
-  xero: {
-    clientId: "XERO_OAUTH_CLIENT_ID",
-    clientSecret: "XERO_OAUTH_CLIENT_SECRET",
-  },
-  zoom: {
-    clientId: "ZOOM_OAUTH_CLIENT_ID",
-    clientSecret: "ZOOM_OAUTH_CLIENT_SECRET",
-  },
-};
+export interface ConnectorOAuthCredentials {
+  readonly configured: boolean;
+  readonly clientId?: string;
+  readonly clientSecret?: string;
+  readonly client: ConnectorOAuthClientConfig | undefined;
+}
 
-const STATIC_OAUTH_CONFIGURED_CONNECTOR_TYPES = new Set<ConnectorType>([
-  "test-oauth",
-]);
+export interface ConnectorOAuthCredentialsOptions {
+  readonly requireClientSecret?: boolean;
+}
 
 function hasEnvValue(readEnv: ConnectorEnvReader, name: string): boolean {
   return Boolean(readEnv(name));
+}
+
+export function getConnectorOAuthClientConfig(
+  type: ConnectorType,
+): ConnectorOAuthClientConfig | undefined {
+  return getConnectorOAuthConfig(type)?.client;
+}
+
+export function getConnectorOAuthStorage(
+  type: ConnectorType,
+): ConnectorOAuthStorage | undefined {
+  const oauthConfig = getConnectorOAuthConfig(type);
+  if (!oauthConfig) {
+    return undefined;
+  }
+  return oauthConfig.storage ?? "connector";
+}
+
+export function getConnectorOAuthCredentials(
+  type: ConnectorType,
+  readEnv: ConnectorEnvReader,
+  options: ConnectorOAuthCredentialsOptions = {},
+): ConnectorOAuthCredentials | undefined {
+  const client = getConnectorOAuthClientConfig(type);
+  if (!client) {
+    return getConnectorOAuthConfig(type)
+      ? { configured: false, client }
+      : undefined;
+  }
+
+  if (client.clientRegistration === "dynamic") {
+    return { configured: true, client };
+  }
+
+  if ("clientId" in client) {
+    return {
+      configured: true,
+      client,
+      clientId: client.clientId,
+      clientSecret:
+        client.clientType === "confidential" ? client.clientSecret : undefined,
+    };
+  }
+
+  const clientId = readEnv(client.clientIdEnv);
+  if (!clientId) {
+    return { configured: false, client };
+  }
+  if (client.clientType === "public") {
+    return { configured: true, client, clientId };
+  }
+
+  const clientSecret = readEnv(client.clientSecretEnv);
+  if (!clientSecret && options.requireClientSecret !== false) {
+    return { configured: false, client, clientId };
+  }
+  return { configured: true, client, clientId, clientSecret };
 }
 
 function hasConfiguredOAuth(
   readEnv: ConnectorEnvReader,
   type: ConnectorType,
 ): boolean {
-  if (STATIC_OAUTH_CONFIGURED_CONNECTOR_TYPES.has(type)) {
-    return true;
+  if (getConnectorOAuthStorage(type) !== "connector") {
+    return false;
   }
-  const keys = OAUTH_ENV_KEYS_BY_CONNECTOR[type];
-  return keys
-    ? hasEnvValue(readEnv, keys.clientId) &&
-        hasEnvValue(readEnv, keys.clientSecret)
-    : false;
+  return getConnectorOAuthCredentials(type, readEnv)?.configured ?? false;
 }
 
 export function getConnectorOAuthEnvKeys(
   type: ConnectorType,
 ): ConnectorOAuthEnvKeys | undefined {
-  return OAUTH_ENV_KEYS_BY_CONNECTOR[type];
+  const client = getConnectorOAuthClientConfig(type);
+  if (
+    !client ||
+    client.clientRegistration !== "static" ||
+    !("clientIdEnv" in client)
+  ) {
+    return undefined;
+  }
+  return {
+    clientId: client.clientIdEnv,
+    clientSecret:
+      client.clientType === "confidential" ? client.clientSecretEnv : undefined,
+  };
 }
 
 /**

--- a/turbo/packages/connectors/src/connector-utils.ts
+++ b/turbo/packages/connectors/src/connector-utils.ts
@@ -7,6 +7,7 @@ import {
   type ConnectorConfig,
   type ConnectorOAuthClientConfig,
   type ConnectorOAuthConfig,
+  type ConnectorOAuthAuthorizeType,
   type ConnectorOAuthStorage,
   type ConnectorSecretConfig,
   type ConnectorType,
@@ -139,6 +140,12 @@ export function getConnectorOAuthStorage(
     return undefined;
   }
   return oauthConfig.storage ?? "connector";
+}
+
+export function isConnectorOAuthAuthorizeType(
+  type: ConnectorType,
+): type is ConnectorOAuthAuthorizeType {
+  return getConnectorOAuthStorage(type) === "connector";
 }
 
 export function getConnectorOAuthCredentials(

--- a/turbo/packages/connectors/src/connectors.ts
+++ b/turbo/packages/connectors/src/connectors.ts
@@ -227,10 +227,56 @@ export interface ConnectorAuthMethodConfig {
 /**
  * OAuth configuration for connectors that support OAuth flow.
  */
+export type ConnectorOAuthTokenEndpointAuthMethod =
+  | "none"
+  | "client_secret_basic"
+  | "client_secret_post";
+
+export type ConnectorOAuthStorage = "connector" | "model-provider";
+
+export type ConnectorOAuthClientConfig =
+  | {
+      readonly clientRegistration: "static";
+      readonly clientType: "confidential";
+      readonly tokenEndpointAuthMethod:
+        | "client_secret_basic"
+        | "client_secret_post";
+      readonly clientIdEnv: string;
+      readonly clientSecretEnv: string;
+    }
+  | {
+      readonly clientRegistration: "static";
+      readonly clientType: "confidential";
+      readonly tokenEndpointAuthMethod:
+        | "client_secret_basic"
+        | "client_secret_post";
+      readonly clientId: string;
+      readonly clientSecret: string;
+    }
+  | {
+      readonly clientRegistration: "static";
+      readonly clientType: "public";
+      readonly tokenEndpointAuthMethod: "none";
+      readonly clientIdEnv: string;
+    }
+  | {
+      readonly clientRegistration: "static";
+      readonly clientType: "public";
+      readonly tokenEndpointAuthMethod: "none";
+      readonly clientId: string;
+    }
+  | {
+      readonly clientRegistration: "dynamic";
+      readonly clientType: "public";
+      readonly tokenEndpointAuthMethod: "none";
+    };
+
 export interface ConnectorOAuthConfig {
   authorizationUrl?: string;
   tokenUrl: string;
   scopes: string[];
+  client?: ConnectorOAuthClientConfig;
+  storage?: ConnectorOAuthStorage;
 }
 
 /**

--- a/turbo/packages/connectors/src/connectors.ts
+++ b/turbo/packages/connectors/src/connectors.ts
@@ -686,6 +686,15 @@ const CONNECTOR_TYPES_DEF = {
 } as const satisfies Record<string, ConnectorConfig>;
 
 export type ConnectorType = keyof typeof CONNECTOR_TYPES_DEF;
+export type ConnectorOAuthAuthorizeType = {
+  [Type in ConnectorType]: (typeof CONNECTOR_TYPES_DEF)[Type] extends {
+    readonly oauth: infer OAuth;
+  }
+    ? OAuth extends { readonly storage: "model-provider" }
+      ? never
+      : Type
+    : never;
+}[ConnectorType];
 export type ConnectorCliAuthConnectorType = {
   [Type in ConnectorType]: "cli-auth" extends keyof (typeof CONNECTOR_TYPES_DEF)[Type]["authMethods"]
     ? Type

--- a/turbo/packages/connectors/src/connectors/ahrefs.ts
+++ b/turbo/packages/connectors/src/connectors/ahrefs.ts
@@ -43,6 +43,13 @@ export const ahrefs = {
     oauth: {
       authorizationUrl: "https://app.ahrefs.com/api/auth",
       tokenUrl: "https://app.ahrefs.com/api/token",
+      client: {
+        clientRegistration: "static",
+        clientType: "confidential",
+        tokenEndpointAuthMethod: "client_secret_post",
+        clientIdEnv: "AHREFS_OAUTH_CLIENT_ID",
+        clientSecretEnv: "AHREFS_OAUTH_CLIENT_SECRET",
+      },
       scopes: ["api"],
     },
   },

--- a/turbo/packages/connectors/src/connectors/airtable.ts
+++ b/turbo/packages/connectors/src/connectors/airtable.ts
@@ -29,6 +29,13 @@ export const airtable = {
     oauth: {
       authorizationUrl: "https://airtable.com/oauth2/v1/authorize",
       tokenUrl: "https://airtable.com/oauth2/v1/token",
+      client: {
+        clientRegistration: "static",
+        clientType: "confidential",
+        tokenEndpointAuthMethod: "client_secret_basic",
+        clientIdEnv: "AIRTABLE_OAUTH_CLIENT_ID",
+        clientSecretEnv: "AIRTABLE_OAUTH_CLIENT_SECRET",
+      },
       scopes: [
         "data.records:read",
         "data.records:write",

--- a/turbo/packages/connectors/src/connectors/asana.ts
+++ b/turbo/packages/connectors/src/connectors/asana.ts
@@ -29,6 +29,13 @@ export const asana = {
     oauth: {
       authorizationUrl: "https://app.asana.com/-/oauth_authorize",
       tokenUrl: "https://app.asana.com/-/oauth_token",
+      client: {
+        clientRegistration: "static",
+        clientType: "confidential",
+        tokenEndpointAuthMethod: "client_secret_post",
+        clientIdEnv: "ASANA_OAUTH_CLIENT_ID",
+        clientSecretEnv: "ASANA_OAUTH_CLIENT_SECRET",
+      },
       scopes: [],
     },
   },

--- a/turbo/packages/connectors/src/connectors/canva.ts
+++ b/turbo/packages/connectors/src/connectors/canva.ts
@@ -31,6 +31,13 @@ export const canva = {
     oauth: {
       authorizationUrl: "https://www.canva.com/api/oauth/authorize",
       tokenUrl: "https://api.canva.com/rest/v1/oauth/token",
+      client: {
+        clientRegistration: "static",
+        clientType: "confidential",
+        tokenEndpointAuthMethod: "client_secret_basic",
+        clientIdEnv: "CANVA_OAUTH_CLIENT_ID",
+        clientSecretEnv: "CANVA_OAUTH_CLIENT_SECRET",
+      },
       scopes: [
         "asset:read",
         "asset:write",

--- a/turbo/packages/connectors/src/connectors/close.ts
+++ b/turbo/packages/connectors/src/connectors/close.ts
@@ -31,6 +31,13 @@ export const close = {
     oauth: {
       authorizationUrl: "https://app.close.com/oauth2/authorize/",
       tokenUrl: "https://api.close.com/oauth2/token/",
+      client: {
+        clientRegistration: "static",
+        clientType: "confidential",
+        tokenEndpointAuthMethod: "client_secret_post",
+        clientIdEnv: "CLOSE_OAUTH_CLIENT_ID",
+        clientSecretEnv: "CLOSE_OAUTH_CLIENT_SECRET",
+      },
       scopes: ["all.full_access", "offline_access"],
     },
   },

--- a/turbo/packages/connectors/src/connectors/codex-oauth.ts
+++ b/turbo/packages/connectors/src/connectors/codex-oauth.ts
@@ -23,6 +23,13 @@ export const codexOauth = {
     oauth: {
       authorizationUrl: "https://auth.openai.com/oauth/authorize",
       tokenUrl: "https://auth.openai.com/oauth/token",
+      storage: "model-provider",
+      client: {
+        clientRegistration: "static",
+        clientType: "public",
+        tokenEndpointAuthMethod: "none",
+        clientId: "app_EMoamEEZ73f0CkXaXp7hrann",
+      },
       scopes: [
         "openid",
         "profile",

--- a/turbo/packages/connectors/src/connectors/deel.ts
+++ b/turbo/packages/connectors/src/connectors/deel.ts
@@ -42,6 +42,13 @@ export const deel = {
     oauth: {
       authorizationUrl: "https://app.deel.com/oauth2/authorize",
       tokenUrl: "https://app.deel.com/oauth2/tokens",
+      client: {
+        clientRegistration: "static",
+        clientType: "confidential",
+        tokenEndpointAuthMethod: "client_secret_basic",
+        clientIdEnv: "DEEL_OAUTH_CLIENT_ID",
+        clientSecretEnv: "DEEL_OAUTH_CLIENT_SECRET",
+      },
       scopes: [
         "contracts:read",
         "people:read",

--- a/turbo/packages/connectors/src/connectors/docusign.ts
+++ b/turbo/packages/connectors/src/connectors/docusign.ts
@@ -31,6 +31,13 @@ export const docusign = {
     oauth: {
       authorizationUrl: "https://account-d.docusign.com/oauth/auth",
       tokenUrl: "https://account-d.docusign.com/oauth/token",
+      client: {
+        clientRegistration: "static",
+        clientType: "confidential",
+        tokenEndpointAuthMethod: "client_secret_basic",
+        clientIdEnv: "DOCUSIGN_OAUTH_CLIENT_ID",
+        clientSecretEnv: "DOCUSIGN_OAUTH_CLIENT_SECRET",
+      },
       scopes: ["signature", "extended", "openid"],
     },
   },

--- a/turbo/packages/connectors/src/connectors/dropbox.ts
+++ b/turbo/packages/connectors/src/connectors/dropbox.ts
@@ -42,6 +42,13 @@ export const dropbox = {
     oauth: {
       authorizationUrl: "https://www.dropbox.com/oauth2/authorize",
       tokenUrl: "https://api.dropboxapi.com/oauth2/token",
+      client: {
+        clientRegistration: "static",
+        clientType: "confidential",
+        tokenEndpointAuthMethod: "client_secret_post",
+        clientIdEnv: "DROPBOX_OAUTH_CLIENT_ID",
+        clientSecretEnv: "DROPBOX_OAUTH_CLIENT_SECRET",
+      },
       scopes: [
         "account_info.read",
         "files.metadata.read",

--- a/turbo/packages/connectors/src/connectors/figma.ts
+++ b/turbo/packages/connectors/src/connectors/figma.ts
@@ -42,6 +42,13 @@ export const figma = {
     oauth: {
       authorizationUrl: "https://www.figma.com/oauth",
       tokenUrl: "https://api.figma.com/v1/oauth/token",
+      client: {
+        clientRegistration: "static",
+        clientType: "confidential",
+        tokenEndpointAuthMethod: "client_secret_basic",
+        clientIdEnv: "FIGMA_OAUTH_CLIENT_ID",
+        clientSecretEnv: "FIGMA_OAUTH_CLIENT_SECRET",
+      },
       scopes: [
         "current_user:read",
         "file_content:read",

--- a/turbo/packages/connectors/src/connectors/garmin-connect.ts
+++ b/turbo/packages/connectors/src/connectors/garmin-connect.ts
@@ -31,6 +31,13 @@ export const garminConnect = {
     oauth: {
       authorizationUrl: "https://connect.garmin.com/oauth2Confirm",
       tokenUrl: "https://diauth.garmin.com/di-oauth2-service/oauth/token",
+      client: {
+        clientRegistration: "static",
+        clientType: "confidential",
+        tokenEndpointAuthMethod: "client_secret_post",
+        clientIdEnv: "GARMIN_CONNECT_OAUTH_CLIENT_ID",
+        clientSecretEnv: "GARMIN_CONNECT_OAUTH_CLIENT_SECRET",
+      },
       scopes: [],
     },
   },

--- a/turbo/packages/connectors/src/connectors/github.ts
+++ b/turbo/packages/connectors/src/connectors/github.ts
@@ -27,6 +27,13 @@ export const github = {
     oauth: {
       authorizationUrl: "https://github.com/login/oauth/authorize",
       tokenUrl: "https://github.com/login/oauth/access_token",
+      client: {
+        clientRegistration: "static",
+        clientType: "confidential",
+        tokenEndpointAuthMethod: "client_secret_post",
+        clientIdEnv: "GH_OAUTH_CLIENT_ID",
+        clientSecretEnv: "GH_OAUTH_CLIENT_SECRET",
+      },
       scopes: ["repo", "project", "workflow"],
     },
   },

--- a/turbo/packages/connectors/src/connectors/gmail.ts
+++ b/turbo/packages/connectors/src/connectors/gmail.ts
@@ -29,6 +29,13 @@ export const gmail = {
     oauth: {
       authorizationUrl: "https://accounts.google.com/o/oauth2/v2/auth",
       tokenUrl: "https://oauth2.googleapis.com/token",
+      client: {
+        clientRegistration: "static",
+        clientType: "confidential",
+        tokenEndpointAuthMethod: "client_secret_post",
+        clientIdEnv: "GOOGLE_OAUTH_CLIENT_ID",
+        clientSecretEnv: "GOOGLE_OAUTH_CLIENT_SECRET",
+      },
       scopes: ["https://www.googleapis.com/auth/gmail.modify"],
     },
   },

--- a/turbo/packages/connectors/src/connectors/google-ads.ts
+++ b/turbo/packages/connectors/src/connectors/google-ads.ts
@@ -32,6 +32,13 @@ export const googleAds = {
     oauth: {
       authorizationUrl: "https://accounts.google.com/o/oauth2/v2/auth",
       tokenUrl: "https://oauth2.googleapis.com/token",
+      client: {
+        clientRegistration: "static",
+        clientType: "confidential",
+        tokenEndpointAuthMethod: "client_secret_post",
+        clientIdEnv: "GOOGLE_OAUTH_CLIENT_ID",
+        clientSecretEnv: "GOOGLE_OAUTH_CLIENT_SECRET",
+      },
       scopes: [
         "https://www.googleapis.com/auth/adwords",
         "https://www.googleapis.com/auth/userinfo.email",

--- a/turbo/packages/connectors/src/connectors/google-calendar.ts
+++ b/turbo/packages/connectors/src/connectors/google-calendar.ts
@@ -30,6 +30,13 @@ export const googleCalendar = {
     oauth: {
       authorizationUrl: "https://accounts.google.com/o/oauth2/v2/auth",
       tokenUrl: "https://oauth2.googleapis.com/token",
+      client: {
+        clientRegistration: "static",
+        clientType: "confidential",
+        tokenEndpointAuthMethod: "client_secret_post",
+        clientIdEnv: "GOOGLE_OAUTH_CLIENT_ID",
+        clientSecretEnv: "GOOGLE_OAUTH_CLIENT_SECRET",
+      },
       scopes: [
         "https://www.googleapis.com/auth/calendar",
         "https://www.googleapis.com/auth/userinfo.email",

--- a/turbo/packages/connectors/src/connectors/google-docs.ts
+++ b/turbo/packages/connectors/src/connectors/google-docs.ts
@@ -28,6 +28,13 @@ export const googleDocs = {
     oauth: {
       authorizationUrl: "https://accounts.google.com/o/oauth2/v2/auth",
       tokenUrl: "https://oauth2.googleapis.com/token",
+      client: {
+        clientRegistration: "static",
+        clientType: "confidential",
+        tokenEndpointAuthMethod: "client_secret_post",
+        clientIdEnv: "GOOGLE_OAUTH_CLIENT_ID",
+        clientSecretEnv: "GOOGLE_OAUTH_CLIENT_SECRET",
+      },
       scopes: [
         "https://www.googleapis.com/auth/documents",
         "https://www.googleapis.com/auth/userinfo.email",

--- a/turbo/packages/connectors/src/connectors/google-drive.ts
+++ b/turbo/packages/connectors/src/connectors/google-drive.ts
@@ -28,6 +28,13 @@ export const googleDrive = {
     oauth: {
       authorizationUrl: "https://accounts.google.com/o/oauth2/v2/auth",
       tokenUrl: "https://oauth2.googleapis.com/token",
+      client: {
+        clientRegistration: "static",
+        clientType: "confidential",
+        tokenEndpointAuthMethod: "client_secret_post",
+        clientIdEnv: "GOOGLE_OAUTH_CLIENT_ID",
+        clientSecretEnv: "GOOGLE_OAUTH_CLIENT_SECRET",
+      },
       scopes: [
         "https://www.googleapis.com/auth/drive",
         "https://www.googleapis.com/auth/userinfo.email",

--- a/turbo/packages/connectors/src/connectors/google-meet.ts
+++ b/turbo/packages/connectors/src/connectors/google-meet.ts
@@ -29,6 +29,13 @@ export const googleMeet = {
     oauth: {
       authorizationUrl: "https://accounts.google.com/o/oauth2/v2/auth",
       tokenUrl: "https://oauth2.googleapis.com/token",
+      client: {
+        clientRegistration: "static",
+        clientType: "confidential",
+        tokenEndpointAuthMethod: "client_secret_post",
+        clientIdEnv: "GOOGLE_OAUTH_CLIENT_ID",
+        clientSecretEnv: "GOOGLE_OAUTH_CLIENT_SECRET",
+      },
       scopes: [
         "https://www.googleapis.com/auth/meetings.space.created",
         // Use meetings.space.readonly (not meetings.conferencerecords.readonly) — confirmed

--- a/turbo/packages/connectors/src/connectors/google-sheets.ts
+++ b/turbo/packages/connectors/src/connectors/google-sheets.ts
@@ -28,6 +28,13 @@ export const googleSheets = {
     oauth: {
       authorizationUrl: "https://accounts.google.com/o/oauth2/v2/auth",
       tokenUrl: "https://oauth2.googleapis.com/token",
+      client: {
+        clientRegistration: "static",
+        clientType: "confidential",
+        tokenEndpointAuthMethod: "client_secret_post",
+        clientIdEnv: "GOOGLE_OAUTH_CLIENT_ID",
+        clientSecretEnv: "GOOGLE_OAUTH_CLIENT_SECRET",
+      },
       scopes: [
         "https://www.googleapis.com/auth/spreadsheets",
         "https://www.googleapis.com/auth/userinfo.email",

--- a/turbo/packages/connectors/src/connectors/gumroad.ts
+++ b/turbo/packages/connectors/src/connectors/gumroad.ts
@@ -38,6 +38,13 @@ export const gumroad = {
     oauth: {
       authorizationUrl: "https://gumroad.com/oauth/authorize",
       tokenUrl: "https://gumroad.com/oauth/token",
+      client: {
+        clientRegistration: "static",
+        clientType: "confidential",
+        tokenEndpointAuthMethod: "client_secret_post",
+        clientIdEnv: "GUMROAD_OAUTH_CLIENT_ID",
+        clientSecretEnv: "GUMROAD_OAUTH_CLIENT_SECRET",
+      },
       scopes: [
         "view_profile",
         "edit_products",

--- a/turbo/packages/connectors/src/connectors/hubspot.ts
+++ b/turbo/packages/connectors/src/connectors/hubspot.ts
@@ -29,6 +29,13 @@ export const hubspot = {
     oauth: {
       authorizationUrl: "https://app.hubspot.com/oauth/authorize",
       tokenUrl: "https://api.hubapi.com/oauth/v1/token",
+      client: {
+        clientRegistration: "static",
+        clientType: "confidential",
+        tokenEndpointAuthMethod: "client_secret_post",
+        clientIdEnv: "HUBSPOT_OAUTH_CLIENT_ID",
+        clientSecretEnv: "HUBSPOT_OAUTH_CLIENT_SECRET",
+      },
       scopes: [
         "crm.objects.contacts.read",
         "crm.objects.contacts.write",

--- a/turbo/packages/connectors/src/connectors/intervals-icu.ts
+++ b/turbo/packages/connectors/src/connectors/intervals-icu.ts
@@ -25,6 +25,13 @@ export const intervalsIcu = {
     oauth: {
       authorizationUrl: "https://intervals.icu/oauth/authorize",
       tokenUrl: "https://intervals.icu/api/oauth/token",
+      client: {
+        clientRegistration: "static",
+        clientType: "confidential",
+        tokenEndpointAuthMethod: "client_secret_post",
+        clientIdEnv: "INTERVALS_ICU_OAUTH_CLIENT_ID",
+        clientSecretEnv: "INTERVALS_ICU_OAUTH_CLIENT_SECRET",
+      },
       scopes: ["ACTIVITY", "WELLNESS", "CALENDAR", "SETTINGS", "LIBRARY"],
     },
   },

--- a/turbo/packages/connectors/src/connectors/linear.ts
+++ b/turbo/packages/connectors/src/connectors/linear.ts
@@ -29,6 +29,13 @@ export const linear = {
     oauth: {
       authorizationUrl: "https://linear.app/oauth/authorize",
       tokenUrl: "https://api.linear.app/oauth/token",
+      client: {
+        clientRegistration: "static",
+        clientType: "confidential",
+        tokenEndpointAuthMethod: "client_secret_post",
+        clientIdEnv: "LINEAR_OAUTH_CLIENT_ID",
+        clientSecretEnv: "LINEAR_OAUTH_CLIENT_SECRET",
+      },
       scopes: [
         "read",
         "write",

--- a/turbo/packages/connectors/src/connectors/mercury.ts
+++ b/turbo/packages/connectors/src/connectors/mercury.ts
@@ -43,6 +43,13 @@ export const mercury = {
     oauth: {
       authorizationUrl: "https://oauth2.mercury.com/oauth2/auth",
       tokenUrl: "https://oauth2.mercury.com/oauth2/token",
+      client: {
+        clientRegistration: "static",
+        clientType: "confidential",
+        tokenEndpointAuthMethod: "client_secret_post",
+        clientIdEnv: "MERCURY_OAUTH_CLIENT_ID",
+        clientSecretEnv: "MERCURY_OAUTH_CLIENT_SECRET",
+      },
       scopes: ["offline_access"],
     },
   },

--- a/turbo/packages/connectors/src/connectors/meta-ads.ts
+++ b/turbo/packages/connectors/src/connectors/meta-ads.ts
@@ -27,6 +27,13 @@ export const metaAds = {
     oauth: {
       authorizationUrl: "https://www.facebook.com/v22.0/dialog/oauth",
       tokenUrl: "https://graph.facebook.com/v22.0/oauth/access_token",
+      client: {
+        clientRegistration: "static",
+        clientType: "confidential",
+        tokenEndpointAuthMethod: "client_secret_post",
+        clientIdEnv: "META_ADS_OAUTH_CLIENT_ID",
+        clientSecretEnv: "META_ADS_OAUTH_CLIENT_SECRET",
+      },
       scopes: ["ads_management", "ads_read", "business_management"],
     },
   },

--- a/turbo/packages/connectors/src/connectors/monday.ts
+++ b/turbo/packages/connectors/src/connectors/monday.ts
@@ -29,6 +29,13 @@ export const monday = {
     oauth: {
       authorizationUrl: "https://auth.monday.com/oauth2/authorize",
       tokenUrl: "https://auth.monday.com/oauth2/token",
+      client: {
+        clientRegistration: "static",
+        clientType: "confidential",
+        tokenEndpointAuthMethod: "client_secret_post",
+        clientIdEnv: "MONDAY_OAUTH_CLIENT_ID",
+        clientSecretEnv: "MONDAY_OAUTH_CLIENT_SECRET",
+      },
       scopes: [
         "me:read",
         "boards:read",

--- a/turbo/packages/connectors/src/connectors/neon.ts
+++ b/turbo/packages/connectors/src/connectors/neon.ts
@@ -43,6 +43,13 @@ export const neon = {
     oauth: {
       authorizationUrl: "https://oauth2.neon.tech/oauth2/auth",
       tokenUrl: "https://oauth2.neon.tech/oauth2/token",
+      client: {
+        clientRegistration: "static",
+        clientType: "confidential",
+        tokenEndpointAuthMethod: "client_secret_post",
+        clientIdEnv: "NEON_OAUTH_CLIENT_ID",
+        clientSecretEnv: "NEON_OAUTH_CLIENT_SECRET",
+      },
       scopes: [
         "openid",
         "offline_access",

--- a/turbo/packages/connectors/src/connectors/notion.ts
+++ b/turbo/packages/connectors/src/connectors/notion.ts
@@ -29,6 +29,13 @@ export const notion = {
     oauth: {
       authorizationUrl: "https://api.notion.com/v1/oauth/authorize",
       tokenUrl: "https://api.notion.com/v1/oauth/token",
+      client: {
+        clientRegistration: "static",
+        clientType: "confidential",
+        tokenEndpointAuthMethod: "client_secret_basic",
+        clientIdEnv: "NOTION_OAUTH_CLIENT_ID",
+        clientSecretEnv: "NOTION_OAUTH_CLIENT_SECRET",
+      },
       scopes: [],
     },
   },

--- a/turbo/packages/connectors/src/connectors/outlook-calendar.ts
+++ b/turbo/packages/connectors/src/connectors/outlook-calendar.ts
@@ -32,6 +32,13 @@ export const outlookCalendar = {
       authorizationUrl:
         "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
       tokenUrl: "https://login.microsoftonline.com/common/oauth2/v2.0/token",
+      client: {
+        clientRegistration: "static",
+        clientType: "confidential",
+        tokenEndpointAuthMethod: "client_secret_post",
+        clientIdEnv: "MICROSOFT_OAUTH_CLIENT_ID",
+        clientSecretEnv: "MICROSOFT_OAUTH_CLIENT_SECRET",
+      },
       scopes: ["Calendars.ReadWrite", "User.Read", "offline_access"],
     },
   },

--- a/turbo/packages/connectors/src/connectors/outlook-mail.ts
+++ b/turbo/packages/connectors/src/connectors/outlook-mail.ts
@@ -31,6 +31,13 @@ export const outlookMail = {
       authorizationUrl:
         "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
       tokenUrl: "https://login.microsoftonline.com/common/oauth2/v2.0/token",
+      client: {
+        clientRegistration: "static",
+        clientType: "confidential",
+        tokenEndpointAuthMethod: "client_secret_post",
+        clientIdEnv: "MICROSOFT_OAUTH_CLIENT_ID",
+        clientSecretEnv: "MICROSOFT_OAUTH_CLIENT_SECRET",
+      },
       scopes: ["Mail.ReadWrite", "Mail.Send", "User.Read", "offline_access"],
     },
   },

--- a/turbo/packages/connectors/src/connectors/posthog.ts
+++ b/turbo/packages/connectors/src/connectors/posthog.ts
@@ -43,6 +43,13 @@ export const posthog = {
     oauth: {
       authorizationUrl: "https://us.posthog.com/oauth/authorize",
       tokenUrl: "https://us.posthog.com/oauth/token",
+      client: {
+        clientRegistration: "static",
+        clientType: "confidential",
+        tokenEndpointAuthMethod: "client_secret_post",
+        clientIdEnv: "POSTHOG_OAUTH_CLIENT_ID",
+        clientSecretEnv: "POSTHOG_OAUTH_CLIENT_SECRET",
+      },
       scopes: [
         "openid",
         "profile",

--- a/turbo/packages/connectors/src/connectors/reddit.ts
+++ b/turbo/packages/connectors/src/connectors/reddit.ts
@@ -31,6 +31,13 @@ export const reddit = {
     oauth: {
       authorizationUrl: "https://www.reddit.com/api/v1/authorize",
       tokenUrl: "https://www.reddit.com/api/v1/access_token",
+      client: {
+        clientRegistration: "static",
+        clientType: "confidential",
+        tokenEndpointAuthMethod: "client_secret_basic",
+        clientIdEnv: "REDDIT_OAUTH_CLIENT_ID",
+        clientSecretEnv: "REDDIT_OAUTH_CLIENT_SECRET",
+      },
       scopes: ["identity", "read"],
     },
   },

--- a/turbo/packages/connectors/src/connectors/sentry.ts
+++ b/turbo/packages/connectors/src/connectors/sentry.ts
@@ -29,6 +29,13 @@ export const sentry = {
     oauth: {
       authorizationUrl: "https://sentry.io/oauth/authorize/",
       tokenUrl: "https://sentry.io/oauth/token/",
+      client: {
+        clientRegistration: "static",
+        clientType: "confidential",
+        tokenEndpointAuthMethod: "client_secret_post",
+        clientIdEnv: "SENTRY_OAUTH_CLIENT_ID",
+        clientSecretEnv: "SENTRY_OAUTH_CLIENT_SECRET",
+      },
       scopes: [
         "org:read",
         "project:read",

--- a/turbo/packages/connectors/src/connectors/slack.ts
+++ b/turbo/packages/connectors/src/connectors/slack.ts
@@ -25,6 +25,13 @@ export const slack = {
     oauth: {
       authorizationUrl: "https://slack.com/oauth/v2/authorize",
       tokenUrl: "https://slack.com/api/oauth.v2.access",
+      client: {
+        clientRegistration: "static",
+        clientType: "confidential",
+        tokenEndpointAuthMethod: "client_secret_post",
+        clientIdEnv: "SLACK_CLIENT_ID",
+        clientSecretEnv: "SLACK_CLIENT_SECRET",
+      },
       // Note: Slack does not approve `search:read` or user `*:history`
       // scopes outside of RTS / MCP applications. The personal connector
       // intentionally omits them. Bot-side history access is provided

--- a/turbo/packages/connectors/src/connectors/spotify.ts
+++ b/turbo/packages/connectors/src/connectors/spotify.ts
@@ -31,6 +31,13 @@ export const spotify = {
     oauth: {
       authorizationUrl: "https://accounts.spotify.com/authorize",
       tokenUrl: "https://accounts.spotify.com/api/token",
+      client: {
+        clientRegistration: "static",
+        clientType: "confidential",
+        tokenEndpointAuthMethod: "client_secret_basic",
+        clientIdEnv: "SPOTIFY_OAUTH_CLIENT_ID",
+        clientSecretEnv: "SPOTIFY_OAUTH_CLIENT_SECRET",
+      },
       scopes: [
         "ugc-image-upload",
         "user-read-playback-state",

--- a/turbo/packages/connectors/src/connectors/strava.ts
+++ b/turbo/packages/connectors/src/connectors/strava.ts
@@ -29,6 +29,13 @@ export const strava = {
     oauth: {
       authorizationUrl: "https://www.strava.com/oauth/authorize",
       tokenUrl: "https://www.strava.com/oauth/token",
+      client: {
+        clientRegistration: "static",
+        clientType: "confidential",
+        tokenEndpointAuthMethod: "client_secret_post",
+        clientIdEnv: "STRAVA_OAUTH_CLIENT_ID",
+        clientSecretEnv: "STRAVA_OAUTH_CLIENT_SECRET",
+      },
       scopes: [
         "read",
         "profile:read_all",

--- a/turbo/packages/connectors/src/connectors/stripe.ts
+++ b/turbo/packages/connectors/src/connectors/stripe.ts
@@ -65,6 +65,13 @@ export const stripe = {
     oauth: {
       authorizationUrl: "https://connect.stripe.com/oauth/authorize",
       tokenUrl: "https://connect.stripe.com/oauth/token",
+      client: {
+        clientRegistration: "static",
+        clientType: "confidential",
+        tokenEndpointAuthMethod: "client_secret_post",
+        clientIdEnv: "STRIPE_OAUTH_CLIENT_ID",
+        clientSecretEnv: "STRIPE_OAUTH_CLIENT_SECRET",
+      },
       scopes: ["read_write"],
     },
   },

--- a/turbo/packages/connectors/src/connectors/supabase.ts
+++ b/turbo/packages/connectors/src/connectors/supabase.ts
@@ -43,6 +43,13 @@ export const supabase = {
     oauth: {
       authorizationUrl: "https://api.supabase.com/v1/oauth/authorize",
       tokenUrl: "https://api.supabase.com/v1/oauth/token",
+      client: {
+        clientRegistration: "static",
+        clientType: "confidential",
+        tokenEndpointAuthMethod: "client_secret_basic",
+        clientIdEnv: "SUPABASE_OAUTH_CLIENT_ID",
+        clientSecretEnv: "SUPABASE_OAUTH_CLIENT_SECRET",
+      },
       scopes: [
         "organizations:read",
         "projects:read",

--- a/turbo/packages/connectors/src/connectors/test-oauth.ts
+++ b/turbo/packages/connectors/src/connectors/test-oauth.ts
@@ -34,6 +34,13 @@ export const testOauth = {
       // the preview-URL host changes per deploy.
       authorizationUrl: "/api/test/oauth-provider/authorize",
       tokenUrl: "/api/test/oauth-provider/token",
+      client: {
+        clientRegistration: "static",
+        clientType: "confidential",
+        tokenEndpointAuthMethod: "client_secret_post",
+        clientId: "test-oauth-client",
+        clientSecret: "test-oauth-secret",
+      },
       scopes: ["read"],
     },
   },

--- a/turbo/packages/connectors/src/connectors/todoist.ts
+++ b/turbo/packages/connectors/src/connectors/todoist.ts
@@ -25,6 +25,13 @@ export const todoist = {
     oauth: {
       authorizationUrl: "https://todoist.com/oauth/authorize",
       tokenUrl: "https://todoist.com/oauth/access_token",
+      client: {
+        clientRegistration: "static",
+        clientType: "confidential",
+        tokenEndpointAuthMethod: "client_secret_post",
+        clientIdEnv: "TODOIST_OAUTH_CLIENT_ID",
+        clientSecretEnv: "TODOIST_OAUTH_CLIENT_SECRET",
+      },
       scopes: ["data:read_write", "data:delete", "project:delete"],
     },
   },

--- a/turbo/packages/connectors/src/connectors/vercel.ts
+++ b/turbo/packages/connectors/src/connectors/vercel.ts
@@ -24,6 +24,13 @@ export const vercel = {
     defaultAuthMethod: "oauth",
     oauth: {
       tokenUrl: "https://api.vercel.com/v2/oauth/access_token",
+      client: {
+        clientRegistration: "static",
+        clientType: "confidential",
+        tokenEndpointAuthMethod: "client_secret_post",
+        clientIdEnv: "VERCEL_OAUTH_CLIENT_ID",
+        clientSecretEnv: "VERCEL_OAUTH_CLIENT_SECRET",
+      },
       scopes: [],
     },
   },

--- a/turbo/packages/connectors/src/connectors/webflow.ts
+++ b/turbo/packages/connectors/src/connectors/webflow.ts
@@ -38,6 +38,13 @@ export const webflow = {
     oauth: {
       authorizationUrl: "https://webflow.com/oauth/authorize",
       tokenUrl: "https://api.webflow.com/oauth/access_token",
+      client: {
+        clientRegistration: "static",
+        clientType: "confidential",
+        tokenEndpointAuthMethod: "client_secret_post",
+        clientIdEnv: "WEBFLOW_OAUTH_CLIENT_ID",
+        clientSecretEnv: "WEBFLOW_OAUTH_CLIENT_SECRET",
+      },
       scopes: [
         "authorized_user:read",
         "sites:read",

--- a/turbo/packages/connectors/src/connectors/x.ts
+++ b/turbo/packages/connectors/src/connectors/x.ts
@@ -29,6 +29,13 @@ export const x = {
     oauth: {
       authorizationUrl: "https://twitter.com/i/oauth2/authorize",
       tokenUrl: "https://api.twitter.com/2/oauth2/token",
+      client: {
+        clientRegistration: "static",
+        clientType: "confidential",
+        tokenEndpointAuthMethod: "client_secret_basic",
+        clientIdEnv: "X_OAUTH_CLIENT_ID",
+        clientSecretEnv: "X_OAUTH_CLIENT_SECRET",
+      },
       // https://docs.x.com/fundamentals/authentication/oauth-2-0/authorization-code
       scopes: [
         "tweet.read", // All the Tweets you can view, including Tweets from protected accounts.

--- a/turbo/packages/connectors/src/connectors/xero.ts
+++ b/turbo/packages/connectors/src/connectors/xero.ts
@@ -29,6 +29,13 @@ export const xero = {
     oauth: {
       authorizationUrl: "https://login.xero.com/identity/connect/authorize",
       tokenUrl: "https://identity.xero.com/connect/token",
+      client: {
+        clientRegistration: "static",
+        clientType: "confidential",
+        tokenEndpointAuthMethod: "client_secret_post",
+        clientIdEnv: "XERO_OAUTH_CLIENT_ID",
+        clientSecretEnv: "XERO_OAUTH_CLIENT_SECRET",
+      },
       scopes: [
         "openid",
         "profile",

--- a/turbo/packages/connectors/src/connectors/zoom.ts
+++ b/turbo/packages/connectors/src/connectors/zoom.ts
@@ -31,6 +31,13 @@ export const zoom = {
     oauth: {
       authorizationUrl: "https://zoom.us/oauth/authorize",
       tokenUrl: "https://zoom.us/oauth/token",
+      client: {
+        clientRegistration: "static",
+        clientType: "confidential",
+        tokenEndpointAuthMethod: "client_secret_basic",
+        clientIdEnv: "ZOOM_OAUTH_CLIENT_ID",
+        clientSecretEnv: "ZOOM_OAUTH_CLIENT_SECRET",
+      },
       // Granular scopes (Zoom's "resource:action:target" format). Covers the
       // core read/write flows documented in the zoom skill: users, meetings,
       // past-meeting data, cloud recordings, and webinars.

--- a/turbo/packages/connectors/src/oauth-providers/provider-types.ts
+++ b/turbo/packages/connectors/src/oauth-providers/provider-types.ts
@@ -31,12 +31,17 @@ export interface OAuthTokenResult {
  */
 export interface AuthUrlResult {
   url: string;
-  codeVerifier: string;
+  codeVerifier?: string;
+  oauthContext?: string;
 }
 
 export interface ProviderHandler {
   buildAuthUrl(
     clientId: string,
+    redirectUri: string,
+    state: string,
+  ): string | AuthUrlResult | Promise<string | AuthUrlResult>;
+  buildAuthUrlWithoutClient?(
     redirectUri: string,
     state: string,
   ): string | AuthUrlResult | Promise<string | AuthUrlResult>;
@@ -47,6 +52,14 @@ export interface ProviderHandler {
     redirectUri: string,
     state?: string,
     codeVerifier?: string,
+    oauthContext?: string,
+  ): Promise<OAuthTokenResult>;
+  exchangeCodeWithoutClient?(
+    code: string,
+    redirectUri: string,
+    state?: string,
+    codeVerifier?: string,
+    oauthContext?: string,
   ): Promise<OAuthTokenResult>;
   getClientId(currentEnv: ProviderEnv): string | undefined;
   getClientSecret(currentEnv: ProviderEnv): string | undefined;
@@ -57,6 +70,11 @@ export interface ProviderHandler {
     clientSecret: string,
     refreshToken: string,
   ): Promise<{
+    accessToken: string;
+    refreshToken: string | null;
+    expiresIn?: number;
+  }>;
+  refreshTokenWithoutClient?(refreshToken: string): Promise<{
     accessToken: string;
     refreshToken: string | null;
     expiresIn?: number;


### PR DESCRIPTION
## Summary
- move OAuth client credential metadata into connector definitions
- add shared helpers for OAuth client credentials and connector/model-provider storage
- update API and web OAuth authorize/callback paths to use the shared plumbing while preserving existing connector behavior

Closes #13887

## Testing
- pnpm format
- pnpm turbo run lint
- pnpm check-types
- pnpm -F api exec vitest run src/signals/routes/__tests__/zero-connectors-authorize.test.ts src/signals/routes/__tests__/connectors-type-callback.test.ts src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
- pnpm -F web exec vitest run app/api/connectors/[type]/authorize/__tests__/route.test.ts app/api/connectors/[type]/callback/__tests__/route.test.ts src/lib/zero/__tests__/handler-key-bridge.test.ts app/api/webhooks/agent/firewall/auth/__tests__/route.test.ts
- pnpm -F @vm0/connectors exec vitest run src/__tests__/connectors.test.ts
- pre-commit hook: prettier, knip, check-types

Note: full pnpm vitest was started but not completed after broad unrelated cross-suite failures appeared; the focused OAuth/connectors suites above passed.