### PR TITLE
fix: block telegram connect before onboarding

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-telegram.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-telegram.test.ts
@@ -26,6 +26,7 @@ import {
   deleteTelegramFixture$,
   freezeTelegramFixture,
   makeTelegramFixtureBuilder,
+  seedOrgDefaultAgent$,
   seedTelegramInstallation$,
   seedTelegramUserLink$,
   type TelegramFixture,
@@ -794,6 +795,20 @@ describe("POST /api/integrations/telegram/link", () => {
     };
   }
 
+  async function seedDefaultAgentForLink(
+    orgId: string,
+    userId: string,
+  ): Promise<void> {
+    const builder = makeTelegramFixtureBuilder(orgId);
+    const agent = await store.set(
+      seedOrgDefaultAgent$,
+      { orgId, userId },
+      context.signal,
+    );
+    builder.composeIds.push(agent.composeId);
+    fixtures.push(freezeTelegramFixture(builder));
+  }
+
   it("returns 401 when not authenticated", async () => {
     const client = setupApp({ context })(zeroIntegrationsTelegramContract);
 
@@ -913,8 +928,45 @@ describe("POST /api/integrations/telegram/link", () => {
     });
   });
 
-  it("links the official bot account via Telegram Login Widget auth", async () => {
+  it("returns 409 when connecting the official bot before onboarding creates a default agent", async () => {
     const { token } = await seedLinkContext();
+    const telegramUserId = Number(newTelegramBotId());
+    const client = setupApp({ context })(zeroIntegrationsTelegramContract);
+    server.use(telegramOauthHead("0"));
+
+    const response = await accept(
+      client.link({
+        headers: { authorization: `Bearer ${token}` },
+        body: {
+          telegramBotId: OFFICIAL_TELEGRAM_BOT_ID,
+          telegramAuth: makeTelegramAuth(
+            telegramUserId,
+            "official_tg",
+            OFFICIAL_BOT_TOKEN,
+          ),
+        },
+      }),
+      [409],
+    );
+
+    expect(response.body.error.code).toBe("CONFLICT");
+    expect(response.body.error.message).toBe(
+      "Finish onboarding before connecting Telegram. Telegram needs a default agent for this workspace.",
+    );
+
+    const status = await accept(
+      client.getLinkStatus({
+        query: { botId: OFFICIAL_TELEGRAM_BOT_ID },
+        headers: { authorization: `Bearer ${token}` },
+      }),
+      [200],
+    );
+    expect(status.body.linked).toBeFalsy();
+  });
+
+  it("links the official bot account via Telegram Login Widget auth", async () => {
+    const { token, orgId, userId } = await seedLinkContext();
+    await seedDefaultAgentForLink(orgId, userId);
     const telegramUserId = Number(newTelegramBotId());
     const client = setupApp({ context })(zeroIntegrationsTelegramContract);
 

--- a/turbo/apps/api/src/signals/routes/integrations-telegram-link.ts
+++ b/turbo/apps/api/src/signals/routes/integrations-telegram-link.ts
@@ -4,8 +4,11 @@ import {
   OFFICIAL_TELEGRAM_BOT_ID,
   zeroIntegrationsTelegramContract,
 } from "@vm0/api-contracts/contracts/zero-integrations-telegram";
+import { agentComposes } from "@vm0/db/schema/agent-compose";
+import { orgMetadata } from "@vm0/db/schema/org-metadata";
 import { telegramInstallations } from "@vm0/db/schema/telegram-installation";
 import { telegramOfficialUserLinks } from "@vm0/db/schema/telegram-official-user-link";
+import { telegramUserAgentPreferences } from "@vm0/db/schema/telegram-user-agent-preference";
 import { telegramUserLinks } from "@vm0/db/schema/telegram-user-link";
 import type { z } from "zod";
 
@@ -13,7 +16,7 @@ import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
 import { waitUntil } from "../context/wait-until";
 import { bodyResultOf, queryOf } from "../context/request";
-import { writeDb$ } from "../external/db";
+import { writeDb$, type Db } from "../external/db";
 import {
   getOfficialTelegramBotConfig,
   isOfficialTelegramBotId,
@@ -87,6 +90,14 @@ function invalidConnectSignatureResponse() {
     400,
     "Invalid or expired connect link. Please use /connect again in Telegram.",
     "BAD_REQUEST",
+  );
+}
+
+function missingOfficialAgentResponse() {
+  return errorResult(
+    409,
+    "Finish onboarding before connecting Telegram. Telegram needs a default agent for this workspace.",
+    "CONFLICT",
   );
 }
 
@@ -192,6 +203,63 @@ async function publishTelegramUserChanged(userId: string): Promise<void> {
   }
 }
 
+async function resolveOfficialConnectComposeId(
+  db: Db,
+  auth: OrganizationAuth,
+): Promise<string | null> {
+  const [preference] = await db
+    .select({
+      selectedComposeId: telegramUserAgentPreferences.selectedComposeId,
+    })
+    .from(telegramUserAgentPreferences)
+    .where(
+      and(
+        eq(telegramUserAgentPreferences.vm0UserId, auth.userId),
+        eq(telegramUserAgentPreferences.orgId, auth.orgId),
+      ),
+    )
+    .limit(1);
+
+  const preferredComposeId = preference?.selectedComposeId ?? null;
+  if (preferredComposeId) {
+    const [compose] = await db
+      .select({ id: agentComposes.id })
+      .from(agentComposes)
+      .where(
+        and(
+          eq(agentComposes.id, preferredComposeId),
+          eq(agentComposes.orgId, auth.orgId),
+        ),
+      )
+      .limit(1);
+    if (compose) {
+      return compose.id;
+    }
+  }
+
+  const [metadata] = await db
+    .select({ defaultAgentId: orgMetadata.defaultAgentId })
+    .from(orgMetadata)
+    .where(eq(orgMetadata.orgId, auth.orgId))
+    .limit(1);
+  const defaultAgentId = metadata?.defaultAgentId ?? null;
+  if (!defaultAgentId) {
+    return null;
+  }
+
+  const [compose] = await db
+    .select({ id: agentComposes.id })
+    .from(agentComposes)
+    .where(
+      and(
+        eq(agentComposes.id, defaultAgentId),
+        eq(agentComposes.orgId, auth.orgId),
+      ),
+    )
+    .limit(1);
+  return compose?.id ?? null;
+}
+
 const unlinkInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   const auth = get(organizationAuthContext$);
   const { botId } = get(queryOf(zeroIntegrationsTelegramContract.unlink));
@@ -280,6 +348,13 @@ const linkOfficialInner$ = command(
         return invalidTelegramAuthResponse();
       }
 
+      const db = set(writeDb$);
+      const composeId = await resolveOfficialConnectComposeId(db, args.auth);
+      signal.throwIfAborted();
+      if (!composeId) {
+        return missingOfficialAgentResponse();
+      }
+
       const telegramUserId = String(telegramAuth.id);
       const result = await set(
         linkOfficialTelegramUserToVm0User$,
@@ -317,6 +392,13 @@ const linkOfficialInner$ = command(
         })
       ) {
         return invalidConnectSignatureResponse();
+      }
+
+      const db = set(writeDb$);
+      const composeId = await resolveOfficialConnectComposeId(db, args.auth);
+      signal.throwIfAborted();
+      if (!composeId) {
+        return missingOfficialAgentResponse();
       }
 
       const result = await set(

--- a/turbo/apps/web/app/api/integrations/telegram/link/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/integrations/telegram/link/__tests__/route.test.ts
@@ -12,12 +12,14 @@ import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
 import { server } from "../../../../../../src/mocks/server";
 import { http } from "../../../../../../src/__tests__/msw";
 import {
+  createTestCompose,
   createTestTelegramInstallation,
   findTestOfficialTelegramUserLink,
   findTestOfficialTelegramUserLinksByVm0UserId,
   findTestTelegramUserLinksByVm0UserId,
   insertTestOfficialTelegramUserLink,
   insertTestTelegramUserLink,
+  setDefaultAgentByComposeId,
   signTestConnectParams,
 } from "../../../../../../src/__tests__/api-test-helpers";
 import { signConnectParams } from "../../../../../../src/lib/zero/telegram/connect-token";
@@ -102,6 +104,11 @@ function setupOfficialTelegramEnv() {
   vi.stubEnv("TELEGRAM_OFFICIAL_BOT_USERNAME", OFFICIAL_BOT_USERNAME);
   vi.stubEnv("TELEGRAM_OFFICIAL_WEBHOOK_SECRET", "official-webhook-secret");
   reloadEnv();
+}
+
+async function createDefaultAgentForOrg(orgId: string): Promise<void> {
+  const compose = await createTestCompose(uniqueId("agent"));
+  await setDefaultAgentByComposeId(orgId, compose.composeId);
 }
 
 describe("/api/integrations/telegram/link", () => {
@@ -450,9 +457,42 @@ describe("/api/integrations/telegram/link", () => {
       expect(userLinks[0]?.telegramDisplayName).toBe("Test");
     });
 
+    it("returns 409 when connecting the official bot before onboarding creates a default agent", async () => {
+      setupOfficialTelegramEnv();
+      await context.setupUser();
+      const telegramUserId = Number(uniqueNumericId());
+      const telegramAuth = makeTelegramAuth(
+        telegramUserId,
+        "official_tg",
+        OFFICIAL_BOT_TOKEN,
+      );
+
+      const response = await POST(
+        linkRequest("POST", {
+          telegramBotId: OFFICIAL_TELEGRAM_BOT_ID,
+          telegramAuth,
+        }),
+      );
+      const data = await response.json();
+
+      expect(response.status).toBe(409);
+      expect(data.error).toEqual({
+        message:
+          "Finish onboarding before connecting Telegram. Telegram needs a default agent for this workspace.",
+        code: "CONFLICT",
+      });
+
+      const statusResponse = await GET(
+        linkRequest("GET", undefined, { botId: OFFICIAL_TELEGRAM_BOT_ID }),
+      );
+      const statusData = await statusResponse.json();
+      expect(statusData.linked).toBe(false);
+    });
+
     it("links the official bot account via telegramAuth", async () => {
       setupOfficialTelegramEnv();
       const user = await context.setupUser();
+      await createDefaultAgentForOrg(user.orgId);
       const telegramUserId = Number(uniqueNumericId());
       const telegramAuth = makeTelegramAuth(
         telegramUserId,
@@ -486,7 +526,8 @@ describe("/api/integrations/telegram/link", () => {
 
     it("requires disconnect before moving an official Telegram user to another org", async () => {
       setupOfficialTelegramEnv();
-      await context.setupUser();
+      const user = await context.setupUser();
+      await createDefaultAgentForOrg(user.orgId);
       const otherOrgId = uniqueId("org");
       const telegramUserId = Number(uniqueNumericId());
       await insertTestOfficialTelegramUserLink({

--- a/turbo/apps/web/app/api/integrations/telegram/link/route.ts
+++ b/turbo/apps/web/app/api/integrations/telegram/link/route.ts
@@ -4,9 +4,12 @@ import { z } from "zod";
 import { initServices } from "../../../../../src/lib/init-services";
 import { env } from "../../../../../src/env";
 import { getAuthContext } from "../../../../../src/lib/auth/get-auth-context";
+import { agentComposes } from "@vm0/db/schema/agent-compose";
+import { orgMetadata } from "@vm0/db/schema/org-metadata";
 import { telegramUserLinks } from "@vm0/db/schema/telegram-user-link";
 import { telegramOfficialUserLinks } from "@vm0/db/schema/telegram-official-user-link";
 import { telegramInstallations } from "@vm0/db/schema/telegram-installation";
+import { telegramUserAgentPreferences } from "@vm0/db/schema/telegram-user-agent-preference";
 import {
   ensureOrgAndArtifact,
   formatTelegramUserDisplayName,
@@ -109,6 +112,73 @@ function officialLinkConflictResponse(
     { error: { message, code: "CONFLICT" } },
     { status: 409 },
   );
+}
+
+function missingOfficialAgentResponse() {
+  return NextResponse.json(
+    {
+      error: {
+        message:
+          "Finish onboarding before connecting Telegram. Telegram needs a default agent for this workspace.",
+        code: "CONFLICT",
+      },
+    },
+    { status: 409 },
+  );
+}
+
+async function resolveOfficialConnectComposeId(
+  userId: string,
+  orgId: string,
+): Promise<string | null> {
+  const [preference] = await globalThis.services.db
+    .select({
+      selectedComposeId: telegramUserAgentPreferences.selectedComposeId,
+    })
+    .from(telegramUserAgentPreferences)
+    .where(
+      and(
+        eq(telegramUserAgentPreferences.vm0UserId, userId),
+        eq(telegramUserAgentPreferences.orgId, orgId),
+      ),
+    )
+    .limit(1);
+
+  const preferredComposeId = preference?.selectedComposeId ?? null;
+  if (preferredComposeId) {
+    const [compose] = await globalThis.services.db
+      .select({ id: agentComposes.id })
+      .from(agentComposes)
+      .where(
+        and(
+          eq(agentComposes.id, preferredComposeId),
+          eq(agentComposes.orgId, orgId),
+        ),
+      )
+      .limit(1);
+    if (compose) {
+      return compose.id;
+    }
+  }
+
+  const [metadata] = await globalThis.services.db
+    .select({ defaultAgentId: orgMetadata.defaultAgentId })
+    .from(orgMetadata)
+    .where(eq(orgMetadata.orgId, orgId))
+    .limit(1);
+  const defaultAgentId = metadata?.defaultAgentId ?? null;
+  if (!defaultAgentId) {
+    return null;
+  }
+
+  const [compose] = await globalThis.services.db
+    .select({ id: agentComposes.id })
+    .from(agentComposes)
+    .where(
+      and(eq(agentComposes.id, defaultAgentId), eq(agentComposes.orgId, orgId)),
+    )
+    .limit(1);
+  return compose?.id ?? null;
 }
 
 async function linkUserOrConflict(params: {
@@ -459,6 +529,11 @@ async function linkOfficialWithTelegramAuth(
     return invalidTelegramAuthResponse();
   }
 
+  const composeId = await resolveOfficialConnectComposeId(userId, orgId);
+  if (!composeId) {
+    return missingOfficialAgentResponse();
+  }
+
   const telegramUserId = String(body.telegramAuth.id);
   const conflictResponse = await linkOfficialUserOrConflict({
     telegramUserId,
@@ -496,6 +571,11 @@ async function linkOfficialWithConnectSignature(
     )
   ) {
     return invalidConnectSignatureResponse();
+  }
+
+  const composeId = await resolveOfficialConnectComposeId(userId, orgId);
+  if (!composeId) {
+    return missingOfficialAgentResponse();
   }
 
   const telegramUserId = connectSignature.telegramUserId;


### PR DESCRIPTION
## Summary
- block official Telegram account linking when the active workspace has no usable default or preferred agent
- mirror the guard in the legacy web route while the API migration is in progress
- add API and web route coverage for the pre-onboarding official bot path

Fixes #13779

## Test plan
- pnpm format
- pnpm lint
- pnpm check-types
- pnpm -F api exec vitest run src/signals/routes/__tests__/zero-integrations-telegram.test.ts
- pnpm -F web exec vitest run app/api/integrations/telegram/link/__tests__/route.test.ts
- OPENAI_API_KEY= ANTHROPIC_API_KEY= pnpm -F api exec vitest run src/signals/routes/__tests__/zero-chat-messages.test.ts src/signals/routes/__tests__/cron-reconcile-billing-entitlements.test.ts
- pnpm test (local run failed in unrelated model-provider key-pool/billing tests because this dev database has seeded VM0 API keys and stale billing rows)
