### PR TITLE
feat: enable stored secret kms writes

### DIFF
--- a/turbo/apps/api/src/signals/services/__tests__/crypto.utils.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/crypto.utils.test.ts
@@ -125,7 +125,9 @@ describe("stored secret encryption", () => {
   it("stays legacy-only when KMS env is set but StoredSecretKmsWrite is off", async () => {
     mockEnv("SECRETS_KMS_KEY_ID", "alias/vm0-secrets");
 
-    const encrypted = await encryptStoredSecretValue("secret-value");
+    const encrypted = await encryptStoredSecretValue("secret-value", {
+      overrides: { [FeatureSwitchKey.StoredSecretKmsWrite]: false },
+    });
 
     expect(inspectStoredSecretCiphertext(encrypted)).toStrictEqual({
       format: "legacy",
@@ -138,12 +140,10 @@ describe("stored secret encryption", () => {
     expect(fakeKmsClient.calls).toHaveLength(0);
   });
 
-  it("dual-writes legacy AES and AWS KMS material when KMS env is set and StoredSecretKmsWrite is on", async () => {
+  it("dual-writes legacy AES and AWS KMS material by default when KMS env is set", async () => {
     mockEnv("SECRETS_KMS_KEY_ID", "alias/vm0-secrets");
 
-    const encrypted = await encryptStoredSecretValue("secret-value", {
-      overrides: { [FeatureSwitchKey.StoredSecretKmsWrite]: true },
-    });
+    const encrypted = await encryptStoredSecretValue("secret-value");
 
     expect(inspectStoredSecretCiphertext(encrypted)).toStrictEqual({
       format: "dual",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -311,7 +311,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     maintainer: "ethan@vm0.ai",
     description:
       "Dual-write stored-secret values to AWS KMS in addition to the legacy AES branch. When OFF, writes stay legacy-only even if SECRETS_KMS_KEY_ID is configured — this gates the KMS GenerateDataKey call so a missing IAM grant does not 500 every secret save.",
-    enabled: false,
+    enabled: true,
   },
   [FeatureSwitchKey.Trinity]: {
     maintainer: "ethan@vm0.ai",


### PR DESCRIPTION
## Summary
- enable the `StoredSecretKmsWrite` feature switch by default so configured environments dual-write stored secrets to KMS for all users
- update stored secret encryption tests to cover the default dual-write path and explicit switch-off override

## Testing
- pnpm format
- pnpm turbo run lint
- pnpm check-types
- pnpm knip
- pnpm -F api exec vitest src/signals/services/__tests__/crypto.utils.test.ts
- pnpm vitest (fails locally: the database schema is inconsistent. Several API/web tests hit missing tables such as `run_built_in_admissions`, `built_in_generation_jobs`, and `desktop_auth_handoff_codes`; `pnpm -F web db:migrate` also fails because Drizzle attempts to create an existing `hosted_deployments` table.)