### PR TITLE
fix: clarify chatgpt codex usage limit errors

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-chat.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-chat.test.ts
@@ -334,10 +334,10 @@ describe("POST /api/internal/callbacks/chat", () => {
     expect(context.mocks.axiom.query).not.toHaveBeenCalled();
   });
 
-  it("preserves usage limit errors on failed callbacks", async () => {
+  it("preserves non-Codex usage limit errors on failed callbacks", async () => {
     const fixture = await track(seedChatCallbackFixture());
     const usageLimitError =
-      "usage_limit_reached: Your usage limit has been reached.";
+      "Claude usage limit reached. Visit https://claude.ai/settings/usage or try again at 6:17 AM.";
 
     const response = await postSignedCallback({
       callbackId: fixture.callbackId,
@@ -359,6 +359,34 @@ describe("POST /api/internal/callbacks/chat", () => {
     expect(errorMessage?.error).not.toBe(
       "Oops, something went wrong. Please try again later.",
     );
+    expect(context.mocks.axiom.query).not.toHaveBeenCalled();
+  });
+
+  it("renders ChatGPT Codex usage limit errors with VM0 guidance", async () => {
+    const fixture = await track(seedChatCallbackFixture());
+    const codexUsageLimitError =
+      "You've hit your usage limit. Visit https://chatgpt.com/codex/settings/usage to purchase more credits or try again at 6:17 AM.";
+    const expectedDisplayError =
+      "ChatGPT Codex usage limit reached. This limit resets at 6:17 AM. View details in [ChatGPT Codex usage settings](https://chatgpt.com/codex/settings/usage), or switch to another model to continue now.";
+
+    const response = await postSignedCallback({
+      callbackId: fixture.callbackId,
+      runId: fixture.runId,
+      status: "failed",
+      error: codexUsageLimitError,
+      payload: { threadId: fixture.threadId, agentId: fixture.agentId },
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toStrictEqual({ success: true });
+
+    const messages = await listMessages(fixture.threadId);
+    const errorMessage = messages.find((message) => {
+      return message.role === "assistant" && message.runId === fixture.runId;
+    });
+    expect(errorMessage?.error).toBe(expectedDisplayError);
+    expect(errorMessage?.content).toBe(expectedDisplayError);
+    expect(errorMessage?.error).not.toBe(codexUsageLimitError);
     expect(context.mocks.axiom.query).not.toHaveBeenCalled();
   });
 

--- a/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
@@ -10,7 +10,10 @@ import {
   type ResolvedAttachFile,
   persistedAttachmentSchema,
 } from "@vm0/api-contracts/contracts/chat-threads";
-import { RUN_ERROR_GUIDANCE } from "@vm0/api-contracts/contracts/errors";
+import {
+  formatChatgptCodexUsageLimitError,
+  RUN_ERROR_GUIDANCE,
+} from "@vm0/api-contracts/contracts/errors";
 import { modelProviderTypeSchema } from "@vm0/api-contracts/contracts/model-providers";
 import { agentComposes } from "@vm0/db/schema/agent-compose";
 import { agentRuns } from "@vm0/db/schema/agent-run";
@@ -50,8 +53,6 @@ const REPORT_ERROR_STREAK_THRESHOLD = 2;
 const CHAT_RUN_TRANSIENT_ERROR_MESSAGE =
   "Oops, something went wrong. Please try again later.";
 const CHAT_RUN_REPORTABLE_ERROR_MESSAGE = "An unexpected error occurred.";
-const CHATGPT_CODEX_USAGE_DETAILS_URL =
-  "https://chatgpt.com/codex/settings/usage";
 
 const ACTIONABLE_ERROR_SNIPPETS = [
   ...Object.values(RUN_ERROR_GUIDANCE).flatMap((guidance) => {
@@ -224,48 +225,6 @@ function isActionableRunError(errorMessage: string): boolean {
   return ACTIONABLE_ERROR_SNIPPETS.some((snippet) => {
     return normalized.includes(snippet.toLowerCase());
   });
-}
-
-function isChatgptCodexUsageLimitError(errorMessage: string): boolean {
-  const normalized = errorMessage.toLowerCase();
-  return (
-    normalized.includes("usage limit") &&
-    (normalized.includes("chatgpt.com/codex") ||
-      normalized.includes("codex/settings/usage") ||
-      normalized.includes("chatgpt codex"))
-  );
-}
-
-function extractChatgptCodexRetryPhrase(errorMessage: string): string | null {
-  const match = /\btry again\s+(at|after|in)\s+([^.;\n\r]+)/i.exec(
-    errorMessage,
-  );
-  if (!match) {
-    return null;
-  }
-
-  const preposition = match[1];
-  const retryAt = match[2]?.trim();
-  if (!preposition || !retryAt) {
-    return null;
-  }
-  if (retryAt.length > 80 || !/^[a-z0-9\s:,+/-]+$/i.test(retryAt)) {
-    return null;
-  }
-
-  return `${preposition.toLowerCase()} ${retryAt}`;
-}
-
-function formatChatgptCodexUsageLimitError(
-  errorMessage: string,
-): string | null {
-  if (!isChatgptCodexUsageLimitError(errorMessage)) {
-    return null;
-  }
-
-  const retryPhrase = extractChatgptCodexRetryPhrase(errorMessage);
-  const retrySentence = retryPhrase ? ` This limit resets ${retryPhrase}.` : "";
-  return `ChatGPT Codex usage limit reached.${retrySentence} View details in [ChatGPT Codex usage settings](${CHATGPT_CODEX_USAGE_DETAILS_URL}), or switch to another model to continue now.`;
 }
 
 function buildReportableErrorMessage(runId: string): string {

--- a/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
@@ -50,6 +50,8 @@ const REPORT_ERROR_STREAK_THRESHOLD = 2;
 const CHAT_RUN_TRANSIENT_ERROR_MESSAGE =
   "Oops, something went wrong. Please try again later.";
 const CHAT_RUN_REPORTABLE_ERROR_MESSAGE = "An unexpected error occurred.";
+const CHATGPT_CODEX_USAGE_DETAILS_URL =
+  "https://chatgpt.com/codex/settings/usage";
 
 const ACTIONABLE_ERROR_SNIPPETS = [
   ...Object.values(RUN_ERROR_GUIDANCE).flatMap((guidance) => {
@@ -222,6 +224,48 @@ function isActionableRunError(errorMessage: string): boolean {
   return ACTIONABLE_ERROR_SNIPPETS.some((snippet) => {
     return normalized.includes(snippet.toLowerCase());
   });
+}
+
+function isChatgptCodexUsageLimitError(errorMessage: string): boolean {
+  const normalized = errorMessage.toLowerCase();
+  return (
+    normalized.includes("usage limit") &&
+    (normalized.includes("chatgpt.com/codex") ||
+      normalized.includes("codex/settings/usage") ||
+      normalized.includes("chatgpt codex"))
+  );
+}
+
+function extractChatgptCodexRetryPhrase(errorMessage: string): string | null {
+  const match = /\btry again\s+(at|after|in)\s+([^.;\n\r]+)/i.exec(
+    errorMessage,
+  );
+  if (!match) {
+    return null;
+  }
+
+  const preposition = match[1];
+  const retryAt = match[2]?.trim();
+  if (!preposition || !retryAt) {
+    return null;
+  }
+  if (retryAt.length > 80 || !/^[a-z0-9\s:,+/-]+$/i.test(retryAt)) {
+    return null;
+  }
+
+  return `${preposition.toLowerCase()} ${retryAt}`;
+}
+
+function formatChatgptCodexUsageLimitError(
+  errorMessage: string,
+): string | null {
+  if (!isChatgptCodexUsageLimitError(errorMessage)) {
+    return null;
+  }
+
+  const retryPhrase = extractChatgptCodexRetryPhrase(errorMessage);
+  const retrySentence = retryPhrase ? ` This limit resets ${retryPhrase}.` : "";
+  return `ChatGPT Codex usage limit reached.${retrySentence} View details in [ChatGPT Codex usage settings](${CHATGPT_CODEX_USAGE_DETAILS_URL}), or switch to another model to continue now.`;
 }
 
 function buildReportableErrorMessage(runId: string): string {
@@ -417,6 +461,11 @@ export function formatChatRunErrorMessage(params: {
 }): Computed<Promise<string>> {
   return computed(async (get): Promise<string> => {
     const errorMessage = params.errorMessage.trim() || "Run failed";
+    const chatgptCodexUsageLimitMessage =
+      formatChatgptCodexUsageLimitError(errorMessage);
+    if (chatgptCodexUsageLimitMessage) {
+      return chatgptCodexUsageLimitMessage;
+    }
 
     if (isActionableRunError(errorMessage)) {
       return errorMessage;

--- a/turbo/apps/web/app/api/internal/callbacks/chat/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/chat/__tests__/route.test.ts
@@ -1024,12 +1024,12 @@ describe("POST /api/internal/callbacks/chat", () => {
       expect(errorMsg?.content).toBe(actionableError);
     });
 
-    it("should preserve usage limit failed run errors", async () => {
+    it("should preserve non-Codex usage limit failed run errors", async () => {
       const { threadId, runId, secret } = await setupRunAndThread({
         status: "failed",
       });
       const usageLimitError =
-        "Usage limit reached. Upgrade your plan or try again later.";
+        "Claude usage limit reached. Visit https://claude.ai/settings/usage or try again at 6:17 AM.";
 
       const response = await POST(
         createSignedCallbackRequest(
@@ -1055,6 +1055,39 @@ describe("POST /api/internal/callbacks/chat", () => {
       expect(errorMsg?.error).not.toBe(
         "Oops, something went wrong. Please try again later.",
       );
+    });
+
+    it("should render ChatGPT Codex usage limit errors with VM0 guidance", async () => {
+      const { threadId, runId, secret } = await setupRunAndThread({
+        status: "failed",
+      });
+      const codexUsageLimitError =
+        "You've hit your usage limit. Visit https://chatgpt.com/codex/settings/usage to purchase more credits or try again at 6:17 AM.";
+      const expectedDisplayError =
+        "ChatGPT Codex usage limit reached. This limit resets at 6:17 AM. View details in [ChatGPT Codex usage settings](https://chatgpt.com/codex/settings/usage), or switch to another model to continue now.";
+
+      const response = await POST(
+        createSignedCallbackRequest(
+          "http://localhost/api/internal/callbacks/chat",
+          {
+            runId,
+            status: "failed",
+            error: codexUsageLimitError,
+            payload: { threadId, agentId },
+          },
+          secret,
+        ),
+      );
+
+      expect(response.status).toBe(200);
+
+      const chatMessages = await getTestChatMessagesByThread(threadId);
+      const errorMsg = chatMessages.find((message) => {
+        return message.role === "assistant" && message.error !== null;
+      });
+      expect(errorMsg?.error).toBe(expectedDisplayError);
+      expect(errorMsg?.content).toBe(expectedDisplayError);
+      expect(errorMsg?.error).not.toBe(codexUsageLimitError);
     });
 
     it("should preserve user-cancelled run errors", async () => {

--- a/turbo/apps/web/app/api/webhooks/agent/complete/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/complete/route.ts
@@ -269,11 +269,11 @@ const router = tsr.router(webhookCompleteContract, {
       // Failure: store the runner's real error (e.g., codex CLI stderr)
       // verbatim in agent_runs.error. The frontend's formatChatRunErrorMessage
       // (chat-thread/chat-run-error-message.ts) decides what the user sees:
-      // matches ACTIONABLE_ERROR_SNIPPETS → render the underlying error;
+      // known actionable errors get product copy or the underlying error;
       // otherwise → polished generic UI ("Oops..." / "Report this issue"
       // with streak logic). Preserving the raw error here keeps the DB
-      // column debug-useful and lets future actionable mappings in
-      // RUN_ERROR_GUIDANCE light up automatically without a migration.
+      // column debug-useful and lets future actionable mappings light up
+      // automatically without a migration.
       errorMessage = body.error?.trim() || "Run failed without error message";
 
       // Also accept "timeout" so the sandbox's own exit-code-based error

--- a/turbo/apps/web/src/lib/zero/chat-thread/chat-run-error-message.ts
+++ b/turbo/apps/web/src/lib/zero/chat-thread/chat-run-error-message.ts
@@ -1,4 +1,7 @@
-import { RUN_ERROR_GUIDANCE } from "@vm0/api-contracts/contracts/errors";
+import {
+  formatChatgptCodexUsageLimitError,
+  RUN_ERROR_GUIDANCE,
+} from "@vm0/api-contracts/contracts/errors";
 import { asc, eq } from "drizzle-orm";
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
@@ -8,8 +11,6 @@ const REPORT_ERROR_STREAK_THRESHOLD = 2;
 const CHAT_RUN_TRANSIENT_ERROR_MESSAGE =
   "Oops, something went wrong. Please try again later.";
 const CHAT_RUN_REPORTABLE_ERROR_MESSAGE = "An unexpected error occurred.";
-const CHATGPT_CODEX_USAGE_DETAILS_URL =
-  "https://chatgpt.com/codex/settings/usage";
 
 const ACTIONABLE_ERROR_SNIPPETS = [
   ...Object.values(RUN_ERROR_GUIDANCE).flatMap((guidance) => {
@@ -29,48 +30,6 @@ function isActionableRunError(errorMessage: string): boolean {
   return ACTIONABLE_ERROR_SNIPPETS.some((snippet) => {
     return normalized.includes(snippet.toLowerCase());
   });
-}
-
-function isChatgptCodexUsageLimitError(errorMessage: string): boolean {
-  const normalized = errorMessage.toLowerCase();
-  return (
-    normalized.includes("usage limit") &&
-    (normalized.includes("chatgpt.com/codex") ||
-      normalized.includes("codex/settings/usage") ||
-      normalized.includes("chatgpt codex"))
-  );
-}
-
-function extractChatgptCodexRetryPhrase(errorMessage: string): string | null {
-  const match = /\btry again\s+(at|after|in)\s+([^.;\n\r]+)/i.exec(
-    errorMessage,
-  );
-  if (!match) {
-    return null;
-  }
-
-  const preposition = match[1];
-  const retryAt = match[2]?.trim();
-  if (!preposition || !retryAt) {
-    return null;
-  }
-  if (retryAt.length > 80 || !/^[a-z0-9\s:,+/-]+$/i.test(retryAt)) {
-    return null;
-  }
-
-  return `${preposition.toLowerCase()} ${retryAt}`;
-}
-
-function formatChatgptCodexUsageLimitError(
-  errorMessage: string,
-): string | null {
-  if (!isChatgptCodexUsageLimitError(errorMessage)) {
-    return null;
-  }
-
-  const retryPhrase = extractChatgptCodexRetryPhrase(errorMessage);
-  const retrySentence = retryPhrase ? ` This limit resets ${retryPhrase}.` : "";
-  return `ChatGPT Codex usage limit reached.${retrySentence} View details in [ChatGPT Codex usage settings](${CHATGPT_CODEX_USAGE_DETAILS_URL}), or switch to another model to continue now.`;
 }
 
 function buildReportableErrorMessage(runId: string): string {

--- a/turbo/apps/web/src/lib/zero/chat-thread/chat-run-error-message.ts
+++ b/turbo/apps/web/src/lib/zero/chat-thread/chat-run-error-message.ts
@@ -8,6 +8,8 @@ const REPORT_ERROR_STREAK_THRESHOLD = 2;
 const CHAT_RUN_TRANSIENT_ERROR_MESSAGE =
   "Oops, something went wrong. Please try again later.";
 const CHAT_RUN_REPORTABLE_ERROR_MESSAGE = "An unexpected error occurred.";
+const CHATGPT_CODEX_USAGE_DETAILS_URL =
+  "https://chatgpt.com/codex/settings/usage";
 
 const ACTIONABLE_ERROR_SNIPPETS = [
   ...Object.values(RUN_ERROR_GUIDANCE).flatMap((guidance) => {
@@ -27,6 +29,48 @@ function isActionableRunError(errorMessage: string): boolean {
   return ACTIONABLE_ERROR_SNIPPETS.some((snippet) => {
     return normalized.includes(snippet.toLowerCase());
   });
+}
+
+function isChatgptCodexUsageLimitError(errorMessage: string): boolean {
+  const normalized = errorMessage.toLowerCase();
+  return (
+    normalized.includes("usage limit") &&
+    (normalized.includes("chatgpt.com/codex") ||
+      normalized.includes("codex/settings/usage") ||
+      normalized.includes("chatgpt codex"))
+  );
+}
+
+function extractChatgptCodexRetryPhrase(errorMessage: string): string | null {
+  const match = /\btry again\s+(at|after|in)\s+([^.;\n\r]+)/i.exec(
+    errorMessage,
+  );
+  if (!match) {
+    return null;
+  }
+
+  const preposition = match[1];
+  const retryAt = match[2]?.trim();
+  if (!preposition || !retryAt) {
+    return null;
+  }
+  if (retryAt.length > 80 || !/^[a-z0-9\s:,+/-]+$/i.test(retryAt)) {
+    return null;
+  }
+
+  return `${preposition.toLowerCase()} ${retryAt}`;
+}
+
+function formatChatgptCodexUsageLimitError(
+  errorMessage: string,
+): string | null {
+  if (!isChatgptCodexUsageLimitError(errorMessage)) {
+    return null;
+  }
+
+  const retryPhrase = extractChatgptCodexRetryPhrase(errorMessage);
+  const retrySentence = retryPhrase ? ` This limit resets ${retryPhrase}.` : "";
+  return `ChatGPT Codex usage limit reached.${retrySentence} View details in [ChatGPT Codex usage settings](${CHATGPT_CODEX_USAGE_DETAILS_URL}), or switch to another model to continue now.`;
 }
 
 function buildReportableErrorMessage(runId: string): string {
@@ -74,6 +118,11 @@ export async function formatChatRunErrorMessage(params: {
   errorMessage: string;
 }): Promise<string> {
   const errorMessage = params.errorMessage.trim() || "Run failed";
+  const chatgptCodexUsageLimitMessage =
+    formatChatgptCodexUsageLimitError(errorMessage);
+  if (chatgptCodexUsageLimitMessage) {
+    return chatgptCodexUsageLimitMessage;
+  }
 
   if (isActionableRunError(errorMessage)) {
     return errorMessage;

--- a/turbo/packages/api-contracts/src/contracts/errors.ts
+++ b/turbo/packages/api-contracts/src/contracts/errors.ts
@@ -115,3 +115,48 @@ export const RUN_ERROR_GUIDANCE: Record<
       "Wait for your current run to complete before starting a new one.",
   },
 };
+
+const CHATGPT_CODEX_USAGE_DETAILS_URL =
+  "https://chatgpt.com/codex/settings/usage";
+
+function isChatgptCodexUsageLimitError(errorMessage: string): boolean {
+  const normalized = errorMessage.toLowerCase();
+  return (
+    normalized.includes("usage limit") &&
+    (normalized.includes("chatgpt.com/codex") ||
+      normalized.includes("codex/settings/usage") ||
+      normalized.includes("chatgpt codex"))
+  );
+}
+
+function extractChatgptCodexRetryPhrase(errorMessage: string): string | null {
+  const match = /\btry again\s+(at|after|in)\s+([^.;\n\r]+)/i.exec(
+    errorMessage,
+  );
+  if (!match) {
+    return null;
+  }
+
+  const preposition = match[1];
+  const retryAt = match[2]?.trim();
+  if (!preposition || !retryAt) {
+    return null;
+  }
+  if (retryAt.length > 80 || !/^[a-z0-9\s:,+/-]+$/i.test(retryAt)) {
+    return null;
+  }
+
+  return `${preposition.toLowerCase()} ${retryAt}`;
+}
+
+export function formatChatgptCodexUsageLimitError(
+  errorMessage: string,
+): string | null {
+  if (!isChatgptCodexUsageLimitError(errorMessage)) {
+    return null;
+  }
+
+  const retryPhrase = extractChatgptCodexRetryPhrase(errorMessage);
+  const retrySentence = retryPhrase ? ` This limit resets ${retryPhrase}.` : "";
+  return `ChatGPT Codex usage limit reached.${retrySentence} View details in [ChatGPT Codex usage settings](${CHATGPT_CODEX_USAGE_DETAILS_URL}), or switch to another model to continue now.`;
+}

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -26,6 +26,7 @@ export {
   apiErrorSchema,
   ApiError,
   createErrorResponse,
+  formatChatgptCodexUsageLimitError,
   RUN_ERROR_GUIDANCE,
   type ApiErrorKey,
   type ApiErrorResponse,


### PR DESCRIPTION
## Summary
- map ChatGPT Codex usage-limit failures to VM0 guidance in web and API chat error formatting
- keep non-Codex usage-limit errors, including Claude, unchanged
- cover both paths with callback regression tests

Fixes #13829

## Tests
- pnpm -F api exec vitest src/signals/routes/__tests__/internal-callbacks-chat.test.ts
- pnpm -F web exec vitest app/api/internal/callbacks/chat/__tests__/route.test.ts
- pre-commit: prettier, knip, check-types, commitlint