### PR TITLE
[codex] fix desktop auth callback handoff

### DIFF
--- a/turbo/apps/desktop/forge.config.js
+++ b/turbo/apps/desktop/forge.config.js
@@ -4,6 +4,16 @@ module.exports = {
     executableName: "Zero",
     appBundleId: "ai.vm0.zero.desktop",
     asar: false,
+    osxSign: {
+      hardenedRuntime: false,
+      identity: "-",
+      identityValidation: false,
+      optionsForFile: () => ({
+        hardenedRuntime: false,
+      }),
+      preAutoEntitlements: false,
+      preEmbedProvisioningProfile: false,
+    },
     protocols: [
       {
         name: "Zero Desktop Auth",

--- a/turbo/apps/desktop/src/desktop-auth.ts
+++ b/turbo/apps/desktop/src/desktop-auth.ts
@@ -4,15 +4,17 @@ const DESKTOP_AUTH_HOST = "auth";
 const DESKTOP_AUTH_CALLBACK_PATH = "/callback";
 const DESKTOP_AUTH_CONSUME_PATH = "/desktop-auth/consume";
 const DESKTOP_AUTH_START_WEB_PATH = "/desktop-auth/start";
-const DESKTOP_AUTH_START_PATHS = new Set([
-  "/desktop-auth/start",
-  "/sign-in",
-  "/sign-up",
-]);
+const DESKTOP_SIGNED_OUT_PATHS = new Set(["/sign-in", "/sign-up"]);
 const DESKTOP_AUTH_CODE_PATTERN = /^[A-Za-z0-9_-]{32,128}$/;
+const DESKTOP_AUTH_START_RETRY_MS = 30_000;
 
 interface DesktopAuthCallback {
   readonly code: string;
+}
+
+interface DesktopAuthStartGate {
+  readonly shouldOpen: () => boolean;
+  readonly suppressRetry: () => void;
 }
 
 function parseUrl(rawUrl: string): URL | null {
@@ -45,6 +47,19 @@ export function parseDesktopAuthCallback(
   return { code };
 }
 
+export function parseDesktopAuthCallbackArgv(
+  argv: readonly string[],
+): DesktopAuthCallback | null {
+  for (const arg of argv) {
+    const callback = parseDesktopAuthCallback(arg);
+    if (callback) {
+      return callback;
+    }
+  }
+
+  return null;
+}
+
 export function buildDesktopAuthConsumeUrl(
   platformUrl: URL,
   code: string,
@@ -66,6 +81,42 @@ export function isDesktopAuthStartNavigation(
   return Boolean(
     url &&
     allowedAppOrigins.has(url.origin) &&
-    DESKTOP_AUTH_START_PATHS.has(url.pathname),
+    url.pathname === DESKTOP_AUTH_START_WEB_PATH,
   );
+}
+
+export function isDesktopSignedOutNavigation(
+  rawUrl: string,
+  allowedAppOrigins: ReadonlySet<string>,
+): boolean {
+  const url = parseUrl(rawUrl);
+  return Boolean(
+    url &&
+    allowedAppOrigins.has(url.origin) &&
+    DESKTOP_SIGNED_OUT_PATHS.has(url.pathname),
+  );
+}
+
+export function createDesktopAuthStartGate(
+  now: () => number = Date.now,
+): DesktopAuthStartGate {
+  let openedAtMs: number | null = null;
+
+  return {
+    shouldOpen: () => {
+      const currentMs = now();
+      if (
+        openedAtMs !== null &&
+        currentMs - openedAtMs < DESKTOP_AUTH_START_RETRY_MS
+      ) {
+        return false;
+      }
+
+      openedAtMs = currentMs;
+      return true;
+    },
+    suppressRetry: () => {
+      openedAtMs = now();
+    },
+  };
 }

--- a/turbo/apps/desktop/src/main.ts
+++ b/turbo/apps/desktop/src/main.ts
@@ -1,19 +1,26 @@
 import path from "node:path";
-import { app, BrowserWindow, shell, type WebContents } from "electron";
+import { app, BrowserWindow, shell } from "electron";
 import { resolveDesktopConfig } from "./config";
 import {
   DESKTOP_AUTH_PROTOCOL,
   buildDesktopAuthConsumeUrl,
   buildDesktopAuthStartUrl,
+  createDesktopAuthStartGate,
   isDesktopAuthStartNavigation,
+  isDesktopSignedOutNavigation,
+  parseDesktopAuthCallbackArgv,
   parseDesktopAuthCallback,
 } from "./desktop-auth";
+import { buildSignedOutPageUrl } from "./signed-out-page";
 import { decideWindowOpen, isAllowedAppNavigation } from "./window-policy";
 
 const APP_NAME = "Zero";
 const config = resolveDesktopConfig();
+const desktopAuthStartUrl = buildDesktopAuthStartUrl(config.platformUrl);
+const signedOutPageUrl = buildSignedOutPageUrl(desktopAuthStartUrl);
 let mainWindow: BrowserWindow | null = null;
 let pendingDesktopAuthCode: string | null = null;
+const desktopAuthStartGate = createDesktopAuthStartGate();
 
 function preloadPath(): string {
   return path.join(__dirname, "preload.js");
@@ -28,8 +35,60 @@ function openDesktopAuthStart(rawUrl: string): boolean {
     return false;
   }
 
-  openExternal(buildDesktopAuthStartUrl(config.platformUrl));
+  if (desktopAuthStartGate.shouldOpen()) {
+    openExternal(desktopAuthStartUrl);
+  }
   return true;
+}
+
+function openDesktopAuthCallback(rawUrl: string): boolean {
+  const callback = parseDesktopAuthCallback(rawUrl);
+  if (!callback) {
+    return false;
+  }
+
+  desktopAuthStartGate.suppressRetry();
+
+  if (!app.isReady()) {
+    pendingDesktopAuthCode = callback.code;
+    return true;
+  }
+
+  void openDesktopAuthConsume(callback.code);
+  return true;
+}
+
+function showSignedOutPage(window: BrowserWindow): void {
+  void window.loadURL(signedOutPageUrl);
+}
+
+function shouldShowSignedOutPage(rawUrl: string): boolean {
+  return isDesktopSignedOutNavigation(rawUrl, config.allowedAppOrigins);
+}
+
+interface PreventableNavigationEvent {
+  readonly preventDefault: () => void;
+}
+
+function handleAuthNavigation(
+  window: BrowserWindow,
+  event: PreventableNavigationEvent,
+  url: string,
+): boolean {
+  if (openDesktopAuthCallback(url)) {
+    event.preventDefault();
+    return true;
+  }
+  if (openDesktopAuthStart(url)) {
+    event.preventDefault();
+    return true;
+  }
+  if (shouldShowSignedOutPage(url)) {
+    event.preventDefault();
+    showSignedOutPage(window);
+    return true;
+  }
+  return false;
 }
 
 function browserWindowOptions() {
@@ -46,9 +105,18 @@ function browserWindowOptions() {
   } satisfies Electron.BrowserWindowConstructorOptions;
 }
 
-function installChildWindowPolicy(webContents: WebContents): void {
+function installChildWindowPolicy(window: BrowserWindow): void {
+  const { webContents } = window;
+
   webContents.setWindowOpenHandler(({ url }) => {
+    if (openDesktopAuthCallback(url)) {
+      return { action: "deny" };
+    }
     if (openDesktopAuthStart(url)) {
+      return { action: "deny" };
+    }
+    if (shouldShowSignedOutPage(url)) {
+      showSignedOutPage(window);
       return { action: "deny" };
     }
 
@@ -62,8 +130,7 @@ function installChildWindowPolicy(webContents: WebContents): void {
 
 function installMainWindowPolicy(window: BrowserWindow): void {
   window.webContents.on("will-navigate", (event, url) => {
-    if (openDesktopAuthStart(url)) {
-      event.preventDefault();
+    if (handleAuthNavigation(window, event, url)) {
       return;
     }
 
@@ -77,8 +144,22 @@ function installMainWindowPolicy(window: BrowserWindow): void {
     }
   });
 
+  window.webContents.on("will-redirect", (event) => {
+    if (!event.isMainFrame) {
+      return;
+    }
+    handleAuthNavigation(window, event, event.url);
+  });
+
   window.webContents.setWindowOpenHandler(({ url }) => {
+    if (openDesktopAuthCallback(url)) {
+      return { action: "deny" };
+    }
     if (openDesktopAuthStart(url)) {
+      return { action: "deny" };
+    }
+    if (shouldShowSignedOutPage(url)) {
+      showSignedOutPage(window);
       return { action: "deny" };
     }
 
@@ -96,7 +177,7 @@ function installMainWindowPolicy(window: BrowserWindow): void {
   });
 
   window.webContents.on("did-create-window", (childWindow) => {
-    installChildWindowPolicy(childWindow.webContents);
+    installChildWindowPolicy(childWindow);
   });
 }
 
@@ -135,17 +216,34 @@ async function openDesktopAuthConsume(code: string): Promise<void> {
 }
 
 function handleDesktopAuthCallback(rawUrl: string): void {
-  const callback = parseDesktopAuthCallback(rawUrl);
+  openDesktopAuthCallback(rawUrl);
+}
+
+function handleDesktopAuthCallbackArgv(argv: readonly string[]): boolean {
+  const callback = parseDesktopAuthCallbackArgv(argv);
   if (!callback) {
-    return;
+    return false;
   }
 
+  desktopAuthStartGate.suppressRetry();
   if (!app.isReady()) {
     pendingDesktopAuthCode = callback.code;
-    return;
+    return true;
   }
 
   void openDesktopAuthConsume(callback.code);
+  return true;
+}
+
+function queueDesktopAuthCallbackArgv(argv: readonly string[]): boolean {
+  const callback = parseDesktopAuthCallbackArgv(argv);
+  if (!callback) {
+    return false;
+  }
+
+  desktopAuthStartGate.suppressRetry();
+  pendingDesktopAuthCode = callback.code;
+  return true;
 }
 
 function registerDesktopAuthProtocol(): void {
@@ -172,31 +270,48 @@ if (process.platform !== "darwin") {
 
 app.name = APP_NAME;
 
-app.on("open-url", (event, url) => {
-  event.preventDefault();
-  handleDesktopAuthCallback(url);
-});
+const hasSingleInstanceLock = app.requestSingleInstanceLock();
 
-void app.whenReady().then(async () => {
-  registerDesktopAuthProtocol();
+if (!hasSingleInstanceLock) {
+  app.quit();
+} else {
+  app.on("second-instance", (_event, argv) => {
+    if (handleDesktopAuthCallbackArgv(argv)) {
+      return;
+    }
 
-  const pendingCode = pendingDesktopAuthCode;
-  pendingDesktopAuthCode = null;
-  await createMainWindow(
-    pendingCode
-      ? buildDesktopAuthConsumeUrl(config.platformUrl, pendingCode)
-      : undefined,
-  );
-
-  app.on("activate", () => {
-    if (BrowserWindow.getAllWindows().length === 0) {
-      void createMainWindow();
+    if (mainWindow && !mainWindow.isDestroyed()) {
+      mainWindow.focus();
     }
   });
-});
 
-app.on("window-all-closed", () => {
-  if (process.platform !== "darwin") {
-    app.quit();
-  }
-});
+  app.on("open-url", (event, url) => {
+    event.preventDefault();
+    handleDesktopAuthCallback(url);
+  });
+
+  void app.whenReady().then(async () => {
+    registerDesktopAuthProtocol();
+    queueDesktopAuthCallbackArgv(process.argv);
+
+    const pendingCode = pendingDesktopAuthCode;
+    pendingDesktopAuthCode = null;
+    await createMainWindow(
+      pendingCode
+        ? buildDesktopAuthConsumeUrl(config.platformUrl, pendingCode)
+        : undefined,
+    );
+
+    app.on("activate", () => {
+      if (BrowserWindow.getAllWindows().length === 0) {
+        void createMainWindow();
+      }
+    });
+  });
+
+  app.on("window-all-closed", () => {
+    if (process.platform !== "darwin") {
+      app.quit();
+    }
+  });
+}

--- a/turbo/apps/desktop/src/signed-out-page.ts
+++ b/turbo/apps/desktop/src/signed-out-page.ts
@@ -1,0 +1,113 @@
+function escapeHtml(value: string): string {
+  return value.replace(/[&<>"']/g, (char) => {
+    switch (char) {
+      case "&":
+        return "&amp;";
+      case "<":
+        return "&lt;";
+      case ">":
+        return "&gt;";
+      case '"':
+        return "&quot;";
+      case "'":
+        return "&#39;";
+      default:
+        return char;
+    }
+  });
+}
+
+export function buildSignedOutPageUrl(authStartUrl: string): string {
+  const escapedAuthStartUrl = escapeHtml(authStartUrl);
+  const html = `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; navigate-to http: https:;">
+    <title>Zero</title>
+    <style>
+      :root {
+        color-scheme: dark;
+        background: #19191b;
+        color: #f5f5f4;
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        min-height: 100vh;
+        margin: 0;
+        display: grid;
+        place-items: center;
+        background: #19191b;
+      }
+
+      main {
+        width: min(100% - 48px, 360px);
+        display: grid;
+        gap: 18px;
+        justify-items: center;
+        text-align: center;
+      }
+
+      .mark {
+        width: 48px;
+        height: 48px;
+        border: 1px solid rgba(255, 255, 255, 0.16);
+        border-radius: 8px;
+        display: grid;
+        place-items: center;
+        background: rgba(255, 255, 255, 0.06);
+        font-size: 24px;
+        font-weight: 650;
+      }
+
+      h1 {
+        margin: 0;
+        font-size: 24px;
+        line-height: 1.2;
+        font-weight: 650;
+      }
+
+      p {
+        margin: 0;
+        color: #b7b7ae;
+        font-size: 14px;
+        line-height: 1.6;
+      }
+
+      a {
+        min-width: 160px;
+        min-height: 40px;
+        border-radius: 7px;
+        display: inline-grid;
+        place-items: center;
+        background: #f5f5f4;
+        color: #19191b;
+        font-size: 14px;
+        font-weight: 600;
+        text-decoration: none;
+      }
+
+      a:focus-visible {
+        outline: 2px solid #7dd3fc;
+        outline-offset: 4px;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <div class="mark" aria-hidden="true">Z</div>
+      <h1>Sign in to Zero</h1>
+      <p>Use your browser to sign in securely, then return here automatically.</p>
+      <a href="${escapedAuthStartUrl}">Sign in</a>
+    </main>
+  </body>
+</html>`;
+
+  return `data:text/html;charset=utf-8,${encodeURIComponent(html)}`;
+}

--- a/turbo/apps/desktop/src/window-policy.test.ts
+++ b/turbo/apps/desktop/src/window-policy.test.ts
@@ -3,9 +3,13 @@ import { resolveDesktopConfig } from "./config";
 import {
   buildDesktopAuthConsumeUrl,
   buildDesktopAuthStartUrl,
+  createDesktopAuthStartGate,
   isDesktopAuthStartNavigation,
+  isDesktopSignedOutNavigation,
+  parseDesktopAuthCallbackArgv,
   parseDesktopAuthCallback,
 } from "./desktop-auth";
+import { buildSignedOutPageUrl } from "./signed-out-page";
 import { decideWindowOpen, isAllowedAppNavigation } from "./window-policy";
 
 describe("resolveDesktopConfig", () => {
@@ -136,13 +140,32 @@ describe("desktop auth", () => {
     );
   });
 
-  it("detects app sign-in navigation that should open in the system browser", () => {
+  it("deduplicates repeated desktop auth start attempts", () => {
+    let now = 1_000;
+    const gate = createDesktopAuthStartGate(() => now);
+
+    expect(gate.shouldOpen()).toBe(true);
+    expect(gate.shouldOpen()).toBe(false);
+
+    now += 30_000;
+    expect(gate.shouldOpen()).toBe(true);
+    expect(gate.shouldOpen()).toBe(false);
+
+    now += 30_000;
+    gate.suppressRetry();
+    expect(gate.shouldOpen()).toBe(false);
+
+    now += 30_000;
+    expect(gate.shouldOpen()).toBe(true);
+  });
+
+  it("detects explicit desktop auth start navigation", () => {
     expect(
       isDesktopAuthStartNavigation(
         "https://app.vm0.ai/sign-in",
         allowedOrigins,
       ),
-    ).toBe(true);
+    ).toBe(false);
     expect(
       isDesktopAuthStartNavigation(
         "https://app.vm0.ai/desktop-auth/start",
@@ -157,10 +180,63 @@ describe("desktop auth", () => {
     ).toBe(false);
   });
 
+  it("detects app sign-in navigation that should show the signed-out page", () => {
+    expect(
+      isDesktopSignedOutNavigation(
+        "https://app.vm0.ai/sign-in",
+        allowedOrigins,
+      ),
+    ).toBe(true);
+    expect(
+      isDesktopSignedOutNavigation(
+        "https://www.vm0.ai/sign-up?redirect_url=https%3A%2F%2Fapp.vm0.ai%2F",
+        allowedOrigins,
+      ),
+    ).toBe(true);
+    expect(
+      isDesktopSignedOutNavigation(
+        "https://app.vm0.ai/desktop-auth/start",
+        allowedOrigins,
+      ),
+    ).toBe(false);
+    expect(
+      isDesktopSignedOutNavigation(
+        "https://accounts.google.com/signin",
+        allowedOrigins,
+      ),
+    ).toBe(false);
+  });
+
+  it("builds a local signed-out page with an explicit auth start link", () => {
+    const pageUrl = buildSignedOutPageUrl(
+      "https://app.vm0.ai/desktop-auth/start",
+    );
+    const html = decodeURIComponent(pageUrl.split(",")[1] ?? "");
+
+    expect(pageUrl.startsWith("data:text/html;charset=utf-8,")).toBe(true);
+    expect(html).toContain('href="https://app.vm0.ai/desktop-auth/start"');
+    expect(html).toContain("Sign in to Zero");
+  });
+
   it("parses a valid desktop callback code", () => {
     expect(
       parseDesktopAuthCallback(`vm0://auth/callback?code=${code}`),
     ).toStrictEqual({ code });
+  });
+
+  it("parses desktop callbacks from launch arguments", () => {
+    expect(
+      parseDesktopAuthCallbackArgv([
+        "/Applications/Zero.app/Contents/MacOS/Zero",
+        `vm0://auth/callback?code=${code}`,
+      ]),
+    ).toStrictEqual({ code });
+    expect(
+      parseDesktopAuthCallbackArgv([
+        "/Applications/Zero.app/Contents/MacOS/Zero",
+        "--some-flag",
+      ]),
+    ).toBe(null);
   });
 
   it("rejects unsafe desktop callbacks", () => {

--- a/turbo/apps/platform/src/signals/__tests__/desktop-auth-setup.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/desktop-auth-setup.test.ts
@@ -67,6 +67,12 @@ describe("desktop auth setup", () => {
   });
 
   it("consumes a desktop callback code into the Electron web session through the platform router", async () => {
+    const replace = vi
+      .spyOn(window.location, "replace")
+      .mockImplementation(() => {
+        return undefined;
+      });
+
     server.use(
       mockApi(desktopAuthConsumeContract.consume, ({ body, respond }) => {
         expect(body).toStrictEqual({ code: "desktop-code" });
@@ -89,5 +95,6 @@ describe("desktop auth setup", () => {
     expect(mockedClerk.setActive).toHaveBeenCalledWith({
       session: "test-created-session-id",
     });
+    expect(replace).toHaveBeenCalledWith("/");
   });
 });

--- a/turbo/apps/platform/src/signals/__tests__/realtime.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/realtime.test.ts
@@ -16,7 +16,11 @@ import {
 import { server } from "../../mocks/server.ts";
 import { apiRealtimeHandlers } from "../../mocks/handlers/api-realtime.ts";
 import { mockApi } from "../../mocks/msw-contract.ts";
-import { mockUser, clearMockedAuth } from "../../__tests__/mock-auth.ts";
+import {
+  mockUser,
+  clearMockedAuth,
+  mockedClerk,
+} from "../../__tests__/mock-auth.ts";
 
 // ---------------------------------------------------------------------------
 // setAblyLoop$ with mock Ably channel
@@ -45,6 +49,19 @@ afterEach(() => {
 });
 
 describe("setAblyLoop$ with mock Ably", () => {
+  it("does not start realtime while signed out", async () => {
+    const store = createStore();
+    const controller = new AbortController();
+
+    clearMockedAuth();
+    mockedClerk.redirectToSignIn.mockClear();
+
+    await store.set(setupRealtime$, controller.signal);
+
+    expect(getAuthTokenHistory()).toStrictEqual([]);
+    expect(mockedClerk.redirectToSignIn).not.toHaveBeenCalled();
+  });
+
   it("queues subscriptions started before realtime connects", async () => {
     const { store, controller } = setupTestStore();
 

--- a/turbo/apps/platform/src/signals/desktop-auth-setup.ts
+++ b/turbo/apps/platform/src/signals/desktop-auth-setup.ts
@@ -94,6 +94,6 @@ export const setupDesktopAuthConsumePage$ = command(
     await clerk.setActive({ session: signIn.createdSessionId });
     signal.throwIfAborted();
 
-    set(detachedNavigateTo$, "/", { replace: true });
+    window.location.replace("/");
   },
 );

--- a/turbo/apps/platform/src/signals/realtime.ts
+++ b/turbo/apps/platform/src/signals/realtime.ts
@@ -2,6 +2,7 @@ import { command, state, type Command, type Setter } from "ccstate";
 import { platformRealtimeTokenContract } from "@vm0/api-contracts/contracts/realtime";
 import { Realtime, type RealtimeChannel, type InboundMessage } from "ably";
 import { zeroClient$ } from "./api-client.ts";
+import { clerk$ } from "./auth.ts";
 import { createAblyAuthCallback } from "../lib/ably-auth.ts";
 import { createDeferredPromise, throwIfAbort } from "./utils.ts";
 import { logger } from "./log.ts";
@@ -155,6 +156,13 @@ async function runWithChannel({
  */
 export const setupRealtime$ = command(
   async ({ get, set }, signal: AbortSignal) => {
+    const clerk = await get(clerk$);
+    signal.throwIfAborted();
+
+    if (!clerk.user) {
+      return;
+    }
+
     const createClient = get(zeroClient$);
     const client = createClient(platformRealtimeTokenContract);
 


### PR DESCRIPTION
## Summary

Fix the desktop sign-in callback path so the Electron app does not return to the local signed-out page after the browser completes login.

## Root Cause

Electron was receiving `vm0://auth/callback` and loading `/desktop-auth/consume?code=...`, but platform bootstrap started realtime before the desktop consume route established a Clerk session. The unauthenticated realtime token request returned 401, which triggered `clerk.redirectToSignIn()`. Electron intercepted that navigation and showed the local `Sign in to Zero` page again.

## Changes

- Show a local signed-out page in Electron and only open the browser when the user explicitly clicks Sign in.
- Handle desktop auth callbacks from app launch args, second-instance args, `open-url`, window navigation, and child-window attempts.
- Skip platform realtime startup while Clerk has no signed-in user.
- Reload the platform after `clerk.setActive()` completes on `/desktop-auth/consume` so bootstrap runs with the new Electron session.
- Keep macOS packaging locally buildable with ad-hoc signing while preserving `asar: false` from current `main`.

## Validation

- `pnpm -F @vm0/desktop test`
- `pnpm exec vitest run src/signals/__tests__/desktop-auth-setup.test.ts src/signals/__tests__/realtime.test.ts` from `turbo/apps/platform`
- `pnpm -F @vm0/desktop check-types`
- `pnpm -F @vm0/desktop lint`
- `pnpm -F @vm0/app check-types`
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/desktop make`
- `codesign --verify --deep --strict --verbose=2 turbo/apps/desktop/out/Zero-darwin-arm64/Zero.app`

## Manual Verification

With the packaged app pointed at local platform (`VM0_DESKTOP_PLATFORM_URL=http://localhost:3002`), triggering `vm0://auth/callback?code=...` moved the app from the local signed-out page to `/desktop-auth/consume?code=...` instead of redirecting back to sign-in. A fake code then fails at the expected consume API step, not at Electron callback handling.