### PR TITLE
refactor: remove sandbox-fc operation lease mirror

### DIFF
--- a/crates/sandbox-fc/src/control.rs
+++ b/crates/sandbox-fc/src/control.rs
@@ -30,9 +30,7 @@ use tokio::task::{JoinHandle, JoinSet};
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
-use crate::guest_operations::{
-    GuestOperationGate, GuestOperationStartError, guest_error_is_terminal,
-};
+use crate::guest_operations::{GuestOperationStartError, GuestOperationStartGate};
 use crate::paths::{RuntimePaths, SockPaths};
 
 // -----------------------------------------------------------------------
@@ -149,7 +147,7 @@ async fn write_frame(stream: &mut UnixStream, data: &[u8]) -> io::Result<()> {
 pub(crate) struct BoundControlServer {
     sock_path: Option<SocketPathGuard>,
     listener: Option<UnixListener>,
-    guest_operations: GuestOperationGate,
+    guest_operations: GuestOperationStartGate,
 }
 
 impl BoundControlServer {
@@ -292,7 +290,7 @@ impl SocketPathGuard {
 /// Bind the control socket before spawning the accept loop.
 pub(crate) fn bind_server(
     sock_path: PathBuf,
-    guest_operations: GuestOperationGate,
+    guest_operations: GuestOperationStartGate,
 ) -> io::Result<BoundControlServer> {
     let listener = bind_unix_listener(&sock_path)?;
     let sock_path = SocketPathGuard::new(sock_path);
@@ -323,7 +321,7 @@ fn remove_socket_path(sock_path: &Path) {
 fn spawn_bound_server(
     listener: UnixListener,
     sock_path: SocketPathGuard,
-    guest_operations: GuestOperationGate,
+    guest_operations: GuestOperationStartGate,
     shutdown: CancellationToken,
 ) -> JoinHandle<()> {
     tokio::spawn(async move {
@@ -408,7 +406,7 @@ async fn shutdown_handlers(handlers: &mut JoinSet<()>) {
 /// Handle a single control socket connection.
 async fn handle_connection(
     mut stream: UnixStream,
-    guest_operations: GuestOperationGate,
+    guest_operations: GuestOperationStartGate,
     shutdown: CancellationToken,
 ) -> io::Result<()> {
     let frame = tokio::select! {
@@ -439,10 +437,10 @@ async fn handle_connection(
     Ok(())
 }
 
-/// Execute an [`ExecRequest`] through the sandbox operation gate.
-async fn execute(request: ExecRequest, guest_operations: &GuestOperationGate) -> ExecResponse {
-    let operation = match guest_operations.begin_control_operation().await {
-        Ok(operation) => operation,
+/// Execute an [`ExecRequest`] through the sandbox operation start gate.
+async fn execute(request: ExecRequest, guest_operations: &GuestOperationStartGate) -> ExecResponse {
+    let vsock = match guest_operations.begin_control_operation().await {
+        Ok(vsock) => vsock,
         Err(error) => {
             return ExecResponse::Error {
                 error: control_start_error(error),
@@ -450,55 +448,34 @@ async fn execute(request: ExecRequest, guest_operations: &GuestOperationGate) ->
         }
     };
 
-    let vsock = operation.guest();
-    let operation = operation.into_write_boundary();
-    let write_observer = operation.write_observer();
     let timeout_ms = request.timeout_secs.saturating_mul(1000);
     let env: &[(&str, &str)] = &[];
 
     let result = vsock
-        .exec_capture_with_write_observer(
-            vsock_host::ExecCaptureRequest {
-                command: &request.command,
-                timeout_ms,
-                env,
-                sudo: request.sudo,
-                label: "runner-exec",
-                stdout_limit_bytes: RUNNER_EXEC_CAPTURE_LIMIT_BYTES,
-                stderr_limit_bytes: RUNNER_EXEC_CAPTURE_LIMIT_BYTES,
-                expected_exit_codes: &[],
-                wait_timeout: Duration::from_millis(timeout_ms as u64 + 5000),
-            },
-            write_observer,
-        )
+        .exec_capture(vsock_host::ExecCaptureRequest {
+            command: &request.command,
+            timeout_ms,
+            env,
+            sudo: request.sudo,
+            label: "runner-exec",
+            stdout_limit_bytes: RUNNER_EXEC_CAPTURE_LIMIT_BYTES,
+            stderr_limit_bytes: RUNNER_EXEC_CAPTURE_LIMIT_BYTES,
+            expected_exit_codes: &[],
+            wait_timeout: Duration::from_millis(timeout_ms as u64 + 5000),
+        })
         .await;
 
     match result {
-        Ok(result) => {
-            if let Err(error) = operation.complete() {
-                return ExecResponse::Error {
-                    error: format!("operation gate completion failed: {error:?}"),
-                };
-            }
-            ExecResponse::Success {
-                exit_code: result.exit_code,
-                stdout: BASE64.encode(&result.stdout),
-                stderr: BASE64.encode(&result.stderr),
-                stdout_truncated: result.stdout_truncated,
-                stderr_truncated: result.stderr_truncated,
-            }
-        }
-        Err(e) => {
-            let message = format!("exec failed: {e}");
-            if guest_error_is_terminal(&e, false)
-                && let Err(error) = operation.complete_if_write_started()
-            {
-                return ExecResponse::Error {
-                    error: format!("operation gate completion failed: {error:?}"),
-                };
-            }
-            ExecResponse::Error { error: message }
-        }
+        Ok(result) => ExecResponse::Success {
+            exit_code: result.exit_code,
+            stdout: BASE64.encode(&result.stdout),
+            stderr: BASE64.encode(&result.stderr),
+            stdout_truncated: result.stdout_truncated,
+            stderr_truncated: result.stderr_truncated,
+        },
+        Err(e) => ExecResponse::Error {
+            error: format!("exec failed: {e}"),
+        },
     }
 }
 
@@ -680,21 +657,23 @@ mod tests {
     use super::*;
     use crate::park_coordinator::{CoordinatorState, ParkCoordinator};
     use tokio::sync::oneshot;
-    use vsock_host::VsockHost;
+    use vsock_host::{NormalOperationFenceRejection, VsockHost};
     use vsock_proto::{
         Decoder, MSG_ERROR, MSG_EXEC_START, MSG_PING, MSG_PONG, MSG_READY, RawMessage,
     };
 
-    fn test_gate(guest: Arc<tokio::sync::Mutex<Option<Arc<VsockHost>>>>) -> GuestOperationGate {
-        GuestOperationGate::new(guest, ParkCoordinator::new())
+    fn test_gate(
+        guest: Arc<tokio::sync::Mutex<Option<Arc<VsockHost>>>>,
+    ) -> GuestOperationStartGate {
+        GuestOperationStartGate::new(guest, ParkCoordinator::new())
     }
 
     fn test_gate_with_coordinator(
         guest: Arc<tokio::sync::Mutex<Option<Arc<VsockHost>>>>,
-    ) -> (GuestOperationGate, ParkCoordinator) {
+    ) -> (GuestOperationStartGate, ParkCoordinator) {
         let coordinator = ParkCoordinator::new();
         (
-            GuestOperationGate::new(guest, coordinator.clone()),
+            GuestOperationStartGate::new(guest, coordinator.clone()),
             coordinator,
         )
     }
@@ -944,10 +923,10 @@ mod tests {
         };
         let (exec_seen_tx, exec_seen_rx) = oneshot::channel();
         let guest_task = tokio::spawn(mock_guest_holds_exec(vsock_base, exec_seen_tx));
-        let vsock = host_task.await.unwrap().unwrap();
+        let vsock = Arc::new(host_task.await.unwrap().unwrap());
 
         let sock_path = dir.path().join("control.sock");
-        let guest = Arc::new(tokio::sync::Mutex::new(Some(Arc::new(vsock))));
+        let guest = Arc::new(tokio::sync::Mutex::new(Some(Arc::clone(&vsock))));
         let (gate, coordinator) = test_gate_with_coordinator(guest);
         let mut handle = bind_server(sock_path.clone(), gate)
             .unwrap()
@@ -977,14 +956,14 @@ mod tests {
             .unwrap()
             .unwrap();
         assert!(client_result.is_err());
+        assert_eq!(coordinator.state(), CoordinatorState::Open);
         assert!(
-            matches!(coordinator.state(), CoordinatorState::Dirty { .. }),
-            "cancelled in-flight control exec should mark the operation gate dirty"
-        );
-        assert_eq!(
-            coordinator.active_operation_count(),
-            0,
-            "cancelled in-flight control exec should not leave an active operation"
+            matches!(
+                vsock.try_fence_normal_operations(),
+                Err(NormalOperationFenceRejection::NotParkable
+                    | NormalOperationFenceRejection::Closed)
+            ),
+            "cancelled in-flight control exec should leave vsock-host not parkable"
         );
 
         guest_task.abort();
@@ -992,7 +971,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn control_exec_rejects_when_operation_gate_is_closing() {
+    async fn control_exec_rejects_when_policy_gate_is_closing() {
         let dir = tempfile::tempdir().unwrap();
         let vsock_base = dir.path().join("vsock");
         let host_task = {
@@ -1045,7 +1024,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn control_exec_terminal_guest_error_completes_operation_gate() {
+    async fn control_exec_terminal_guest_error_completes_vsock_operation() {
         let dir = tempfile::tempdir().unwrap();
         let vsock_base = dir.path().join("vsock");
         let host_task = {
@@ -1055,10 +1034,10 @@ mod tests {
             })
         };
         let guest_task = tokio::spawn(mock_guest_errors_exec(vsock_base, "guest refused exec"));
-        let vsock = host_task.await.unwrap().unwrap();
+        let vsock = Arc::new(host_task.await.unwrap().unwrap());
 
         let sock_path = dir.path().join("control.sock");
-        let guest = Arc::new(tokio::sync::Mutex::new(Some(Arc::new(vsock))));
+        let guest = Arc::new(tokio::sync::Mutex::new(Some(Arc::clone(&vsock))));
         let (gate, coordinator) = test_gate_with_coordinator(guest);
         let mut handle = bind_server(sock_path.clone(), gate)
             .unwrap()
@@ -1082,18 +1061,19 @@ mod tests {
             }
             ExecResponse::Success { .. } => panic!("expected guest error"),
         }
-        assert_eq!(coordinator.active_operation_count(), 0);
+        assert!(vsock.try_fence_normal_operations().is_ok());
         let attempt = coordinator
             .begin_prepare_park()
-            .expect("terminal guest error should complete the operation");
+            .expect("terminal guest error should leave park policy open");
         coordinator.abort_prepare_park(&attempt).unwrap();
 
         handle.shutdown().await;
-        guest_task.await.unwrap();
+        guest_task.abort();
+        let _ = guest_task.await;
     }
 
     #[tokio::test]
-    async fn control_exec_transport_error_marks_operation_gate_dirty() {
+    async fn control_exec_transport_error_makes_vsock_not_parkable() {
         let dir = tempfile::tempdir().unwrap();
         let vsock_base = dir.path().join("vsock");
         let host_task = {
@@ -1104,10 +1084,10 @@ mod tests {
         };
         let (exec_seen_tx, exec_seen_rx) = oneshot::channel();
         let guest_task = tokio::spawn(mock_guest_records_exec(vsock_base, exec_seen_tx));
-        let vsock = host_task.await.unwrap().unwrap();
+        let vsock = Arc::new(host_task.await.unwrap().unwrap());
 
         let sock_path = dir.path().join("control.sock");
-        let guest = Arc::new(tokio::sync::Mutex::new(Some(Arc::new(vsock))));
+        let guest = Arc::new(tokio::sync::Mutex::new(Some(Arc::clone(&vsock))));
         let (gate, coordinator) = test_gate_with_coordinator(guest);
         let mut handle = bind_server(sock_path.clone(), gate)
             .unwrap()
@@ -1132,11 +1112,15 @@ mod tests {
             }
             ExecResponse::Success { .. } => panic!("expected transport error"),
         }
+        assert_eq!(coordinator.state(), CoordinatorState::Open);
         assert!(
-            matches!(coordinator.state(), CoordinatorState::Dirty { .. }),
-            "transport error after command write should dirty the operation gate"
+            matches!(
+                vsock.try_fence_normal_operations(),
+                Err(NormalOperationFenceRejection::NotParkable
+                    | NormalOperationFenceRejection::Closed)
+            ),
+            "transport error after command write should leave vsock-host not parkable"
         );
-        assert_eq!(coordinator.active_operation_count(), 0);
 
         handle.shutdown().await;
         guest_task.await.unwrap();
@@ -1233,7 +1217,7 @@ mod tests {
                 let payload = vsock_proto::encode_error(error);
                 let frame = vsock_proto::encode(MSG_ERROR, message.seq, &payload).unwrap();
                 stream.write_all(&frame).await.unwrap();
-                return;
+                std::future::pending::<()>().await;
             }
         }
     }

--- a/crates/sandbox-fc/src/guest_operations.rs
+++ b/crates/sandbox-fc/src/guest_operations.rs
@@ -81,7 +81,11 @@ pub(crate) enum GuestOperationStartError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use futures_util::pin_mut;
+    use std::future::Future;
+    use std::pin::Pin;
     use std::sync::atomic::{AtomicU8, Ordering};
+    use std::task::{Context, Poll};
 
     fn gate_without_guest() -> (GuestOperationStartGate, ParkCoordinator) {
         let coordinator = ParkCoordinator::new();
@@ -102,17 +106,10 @@ mod tests {
         }
     }
 
-    fn signaled_state_reader(
-        state: Arc<AtomicU8>,
-        first_read: tokio::sync::oneshot::Sender<()>,
-    ) -> impl Fn() -> SandboxState + Send + 'static {
-        let first_read = std::sync::Mutex::new(Some(first_read));
-        move || {
-            if let Some(first_read) = first_read.lock().unwrap().take() {
-                let _ = first_read.send(());
-            }
-            state_from_atomic(&state)
-        }
+    fn assert_pending<F: Future>(future: Pin<&mut F>) {
+        let waker = futures_util::task::noop_waker_ref();
+        let mut cx = Context::from_waker(waker);
+        assert!(matches!(future.poll(&mut cx), Poll::Pending));
     }
 
     #[tokio::test]
@@ -165,22 +162,14 @@ mod tests {
         let gate = GuestOperationStartGate::new(Arc::clone(&guest), coordinator.clone());
         let locked_guest = guest.lock().await;
         let state = Arc::new(AtomicU8::new(SandboxState::Running as u8));
-        let (first_read_tx, first_read_rx) = tokio::sync::oneshot::channel();
 
-        let operation = {
-            let state = Arc::clone(&state);
-            tokio::spawn(async move {
-                gate.begin_sandbox_operation(signaled_state_reader(state, first_read_tx))
-                    .await
-            })
-        };
-        first_read_rx
-            .await
-            .expect("operation should pass the first state check");
+        let operation = gate.begin_sandbox_operation(|| state_from_atomic(&state));
+        pin_mut!(operation);
+        assert_pending(operation.as_mut());
         state.store(SandboxState::Crashed as u8, Ordering::Release);
         drop(locked_guest);
 
-        let result = operation.await.expect("operation task should complete");
+        let result = operation.await;
         assert_eq!(result.err(), Some(GuestOperationStartError::BackendCrashed));
         assert_eq!(coordinator.state(), CoordinatorState::Open);
     }
@@ -192,19 +181,14 @@ mod tests {
         let gate = GuestOperationStartGate::new(Arc::clone(&guest), coordinator.clone());
         let locked_guest = guest.lock().await;
         let state = Arc::new(AtomicU8::new(SandboxState::Running as u8));
-        let (first_read_tx, first_read_rx) = tokio::sync::oneshot::channel();
 
-        let operation = tokio::spawn(async move {
-            gate.begin_sandbox_operation(signaled_state_reader(state, first_read_tx))
-                .await
-        });
-        first_read_rx
-            .await
-            .expect("operation should pass the first policy check");
+        let operation = gate.begin_sandbox_operation(|| state_from_atomic(&state));
+        pin_mut!(operation);
+        assert_pending(operation.as_mut());
         let attempt = coordinator.begin_prepare_park().expect("begin prepare");
         drop(locked_guest);
 
-        let result = operation.await.expect("operation task should complete");
+        let result = operation.await;
         assert!(matches!(
             result,
             Err(GuestOperationStartError::GateClosed {
@@ -222,6 +206,29 @@ mod tests {
 
         assert_eq!(result.err(), Some(GuestOperationStartError::NoGuest));
         assert_eq!(coordinator.state(), CoordinatorState::Open);
+    }
+
+    #[tokio::test]
+    async fn control_operation_rechecks_policy_after_guest_lock_wait() {
+        let coordinator = ParkCoordinator::new();
+        let guest = Arc::new(tokio::sync::Mutex::new(None::<Arc<VsockHost>>));
+        let gate = GuestOperationStartGate::new(Arc::clone(&guest), coordinator.clone());
+        let locked_guest = guest.lock().await;
+
+        let operation = gate.begin_control_operation();
+        pin_mut!(operation);
+        assert_pending(operation.as_mut());
+        let attempt = coordinator.begin_prepare_park().expect("begin prepare");
+        drop(locked_guest);
+
+        let result = operation.await;
+        assert!(matches!(
+            result,
+            Err(GuestOperationStartError::GateClosed {
+                state: CoordinatorState::ClosingForPark { .. }
+            })
+        ));
+        coordinator.abort_prepare_park(&attempt).unwrap();
     }
 
     #[tokio::test]

--- a/crates/sandbox-fc/src/guest_operations.rs
+++ b/crates/sandbox-fc/src/guest_operations.rs
@@ -92,13 +92,26 @@ mod tests {
         )
     }
 
-    fn state_reader(state: &AtomicU8) -> impl Fn() -> SandboxState + '_ {
-        || match state.load(Ordering::Acquire) {
+    fn state_from_atomic(state: &AtomicU8) -> SandboxState {
+        match state.load(Ordering::Acquire) {
             value if value == SandboxState::Running as u8 => SandboxState::Running,
             value if value == SandboxState::Crashed as u8 => SandboxState::Crashed,
             value if value == SandboxState::Stopping as u8 => SandboxState::Stopping,
             value if value == SandboxState::Stopped as u8 => SandboxState::Stopped,
             _ => SandboxState::Created,
+        }
+    }
+
+    fn signaled_state_reader(
+        state: Arc<AtomicU8>,
+        first_read: tokio::sync::oneshot::Sender<()>,
+    ) -> impl Fn() -> SandboxState + Send + 'static {
+        let first_read = std::sync::Mutex::new(Some(first_read));
+        move || {
+            if let Some(first_read) = first_read.lock().unwrap().take() {
+                let _ = first_read.send(());
+            }
+            state_from_atomic(&state)
         }
     }
 
@@ -152,12 +165,18 @@ mod tests {
         let gate = GuestOperationStartGate::new(Arc::clone(&guest), coordinator.clone());
         let locked_guest = guest.lock().await;
         let state = Arc::new(AtomicU8::new(SandboxState::Running as u8));
+        let (first_read_tx, first_read_rx) = tokio::sync::oneshot::channel();
 
         let operation = {
             let state = Arc::clone(&state);
-            tokio::spawn(async move { gate.begin_sandbox_operation(state_reader(&state)).await })
+            tokio::spawn(async move {
+                gate.begin_sandbox_operation(signaled_state_reader(state, first_read_tx))
+                    .await
+            })
         };
-        tokio::task::yield_now().await;
+        first_read_rx
+            .await
+            .expect("operation should pass the first state check");
         state.store(SandboxState::Crashed as u8, Ordering::Release);
         drop(locked_guest);
 
@@ -167,14 +186,21 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn operation_rechecks_policy_after_guest_lock_wait() {
+    async fn sandbox_operation_rechecks_policy_after_guest_lock_wait() {
         let coordinator = ParkCoordinator::new();
         let guest = Arc::new(tokio::sync::Mutex::new(None::<Arc<VsockHost>>));
         let gate = GuestOperationStartGate::new(Arc::clone(&guest), coordinator.clone());
         let locked_guest = guest.lock().await;
+        let state = Arc::new(AtomicU8::new(SandboxState::Running as u8));
+        let (first_read_tx, first_read_rx) = tokio::sync::oneshot::channel();
 
-        let operation = tokio::spawn(async move { gate.begin_control_operation().await });
-        tokio::task::yield_now().await;
+        let operation = tokio::spawn(async move {
+            gate.begin_sandbox_operation(signaled_state_reader(state, first_read_tx))
+                .await
+        });
+        first_read_rx
+            .await
+            .expect("operation should pass the first policy check");
         let attempt = coordinator.begin_prepare_park().expect("begin prepare");
         drop(locked_guest);
 

--- a/crates/sandbox-fc/src/guest_operations.rs
+++ b/crates/sandbox-fc/src/guest_operations.rs
@@ -1,36 +1,23 @@
-use std::io;
-use std::sync::{Arc, Mutex};
+//! Policy-only admission gate for guest operations.
+//!
+//! `sandbox-fc` decides whether an operation may attempt to start. The
+//! authoritative normal-operation lifetime begins only when `vsock-host`
+//! acquires its normal-operation token.
 
-use vsock_host::{FrameWriteObserver, VsockHost};
+use std::sync::Arc;
 
-use crate::park_coordinator::{
-    CoordinatorState, LeaseRejection, OperationId, OperationLease, OperationLiveness,
-    OperationTransitionError, ParkCoordinator,
-};
+use vsock_host::VsockHost;
+
+use crate::park_coordinator::{CoordinatorState, OperationStartRejection, ParkCoordinator};
 use crate::sandbox::SandboxState;
 
-pub(crate) fn guest_error_is_terminal(error: &std::io::Error, backend_crashed: bool) -> bool {
-    if backend_crashed {
-        return false;
-    }
-
-    !matches!(
-        error.kind(),
-        std::io::ErrorKind::TimedOut
-            | std::io::ErrorKind::ConnectionReset
-            | std::io::ErrorKind::BrokenPipe
-            | std::io::ErrorKind::UnexpectedEof
-            | std::io::ErrorKind::InvalidData
-    )
-}
-
 #[derive(Clone)]
-pub(crate) struct GuestOperationGate {
+pub(crate) struct GuestOperationStartGate {
     guest: Arc<tokio::sync::Mutex<Option<Arc<VsockHost>>>>,
     coordinator: ParkCoordinator,
 }
 
-impl GuestOperationGate {
+impl GuestOperationStartGate {
     pub(crate) fn new(
         guest: Arc<tokio::sync::Mutex<Option<Arc<VsockHost>>>>,
         coordinator: ParkCoordinator,
@@ -41,42 +28,42 @@ impl GuestOperationGate {
     pub(crate) async fn begin_sandbox_operation(
         &self,
         current_state: impl Fn() -> SandboxState,
-    ) -> Result<GuestOperation, GuestOperationStartError> {
-        if current_state() == SandboxState::Crashed {
-            return Err(GuestOperationStartError::BackendCrashed);
+    ) -> Result<Arc<VsockHost>, GuestOperationStartError> {
+        match current_state() {
+            SandboxState::Crashed => return Err(GuestOperationStartError::BackendCrashed),
+            SandboxState::Running => {}
+            state => return Err(GuestOperationStartError::NotRunning { state }),
         }
 
-        let lease = self.reserve_lease()?;
+        self.ensure_policy_open()?;
         let guest = self.guest.lock().await.as_ref().cloned();
-        let state = current_state();
-        if state == SandboxState::Crashed {
-            return Err(GuestOperationStartError::BackendCrashed);
+
+        match current_state() {
+            SandboxState::Crashed => return Err(GuestOperationStartError::BackendCrashed),
+            SandboxState::Running => {}
+            state => return Err(GuestOperationStartError::NotRunning { state }),
         }
 
-        let Some(guest) = guest else {
-            return Err(GuestOperationStartError::NotRunning { state });
-        };
-
-        Ok(GuestOperation { guest, lease })
+        self.ensure_policy_open()?;
+        guest.ok_or(GuestOperationStartError::NotRunning {
+            state: SandboxState::Running,
+        })
     }
 
     pub(crate) async fn begin_control_operation(
         &self,
-    ) -> Result<GuestOperation, GuestOperationStartError> {
-        let lease = self.reserve_lease()?;
+    ) -> Result<Arc<VsockHost>, GuestOperationStartError> {
+        self.ensure_policy_open()?;
         let guest = self.guest.lock().await.as_ref().cloned();
-        let Some(guest) = guest else {
-            return Err(GuestOperationStartError::NoGuest);
-        };
-
-        Ok(GuestOperation { guest, lease })
+        self.ensure_policy_open()?;
+        guest.ok_or(GuestOperationStartError::NoGuest)
     }
 
-    fn reserve_lease(&self) -> Result<OperationLease, GuestOperationStartError> {
+    fn ensure_policy_open(&self) -> Result<(), GuestOperationStartError> {
         self.coordinator
-            .reserve_operation()
+            .ensure_operation_start_allowed()
             .map_err(|error| match error {
-                LeaseRejection::GateClosed { state } => {
+                OperationStartRejection::GateClosed { state } => {
                     GuestOperationStartError::GateClosed { state }
                 }
             })
@@ -91,338 +78,146 @@ pub(crate) enum GuestOperationStartError {
     GateClosed { state: CoordinatorState },
 }
 
-pub(crate) struct GuestOperation {
-    guest: Arc<VsockHost>,
-    lease: OperationLease,
-}
-
-impl GuestOperation {
-    pub(crate) fn guest(&self) -> Arc<VsockHost> {
-        Arc::clone(&self.guest)
-    }
-
-    pub(crate) fn into_write_boundary(self) -> GuestOperationWriteBoundary {
-        GuestOperationWriteBoundary::new(self.lease)
-    }
-}
-
-pub(crate) struct GuestOperationWriteBoundary {
-    state: Arc<Mutex<GuestOperationWriteBoundaryState>>,
-}
-
-struct GuestOperationWriteBoundaryState {
-    operation_id: OperationId,
-    lease: Option<OperationLease>,
-    write_started: bool,
-}
-
-impl GuestOperationWriteBoundary {
-    pub(crate) fn new(lease: OperationLease) -> Self {
-        Self {
-            state: Arc::new(Mutex::new(GuestOperationWriteBoundaryState {
-                operation_id: lease.id(),
-                lease: Some(lease),
-                write_started: false,
-            })),
-        }
-    }
-
-    pub(crate) fn write_observer(&self) -> FrameWriteObserver {
-        let state = Arc::clone(&self.state);
-        FrameWriteObserver::new(move || {
-            let mut state = lock_write_boundary_state(&state);
-            state.record_write_start().map_err(|error| {
-                io::Error::other(format!("operation gate write-start transition: {error:?}"))
-            })
-        })
-    }
-
-    pub(crate) fn has_write_started(&self) -> bool {
-        lock_write_boundary_state(&self.state).write_started
-    }
-
-    pub(crate) fn complete(self) -> Result<(), OperationTransitionError> {
-        let mut state = lock_write_boundary_state(&self.state);
-        state.complete()
-    }
-
-    pub(crate) fn complete_if_write_started(self) -> Result<(), OperationTransitionError> {
-        if self.has_write_started() {
-            self.complete()
-        } else {
-            Ok(())
-        }
-    }
-
-    pub(crate) fn into_in_guest_lease(self) -> Result<OperationLease, OperationTransitionError> {
-        let mut state = lock_write_boundary_state(&self.state);
-        state.take_in_guest_lease()
-    }
-}
-
-impl GuestOperationWriteBoundaryState {
-    fn record_write_start(&mut self) -> Result<(), OperationTransitionError> {
-        if self.write_started {
-            return Ok(());
-        }
-
-        let Some(lease) = self.lease.as_mut() else {
-            return Err(OperationTransitionError::UnknownOperation {
-                operation_id: self.operation_id,
-            });
-        };
-
-        lease.mark_writing()?;
-        self.write_started = true;
-        Ok(())
-    }
-
-    fn take_lease(&mut self) -> Result<OperationLease, OperationTransitionError> {
-        self.lease
-            .take()
-            .ok_or(OperationTransitionError::UnknownOperation {
-                operation_id: self.operation_id,
-            })
-    }
-
-    fn complete(&mut self) -> Result<(), OperationTransitionError> {
-        let lease = self.take_lease()?;
-        if !self.write_started {
-            return Err(OperationTransitionError::InvalidTransition {
-                operation_id: self.operation_id,
-                from: OperationLiveness::Reserved,
-                to: OperationLiveness::Terminal,
-            });
-        }
-        lease.complete()
-    }
-
-    fn take_in_guest_lease(&mut self) -> Result<OperationLease, OperationTransitionError> {
-        let mut lease = self.take_lease()?;
-        if !self.write_started {
-            return Err(OperationTransitionError::InvalidTransition {
-                operation_id: self.operation_id,
-                from: OperationLiveness::Reserved,
-                to: OperationLiveness::InGuest,
-            });
-        }
-        lease.mark_in_guest()?;
-        Ok(lease)
-    }
-}
-
-fn lock_write_boundary_state(
-    state: &Mutex<GuestOperationWriteBoundaryState>,
-) -> std::sync::MutexGuard<'_, GuestOperationWriteBoundaryState> {
-    state.lock().unwrap_or_else(|error| error.into_inner())
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::atomic::{AtomicU8, Ordering};
 
-    fn gate_without_guest() -> (GuestOperationGate, ParkCoordinator) {
+    fn gate_without_guest() -> (GuestOperationStartGate, ParkCoordinator) {
         let coordinator = ParkCoordinator::new();
         let guest = Arc::new(tokio::sync::Mutex::new(None::<Arc<VsockHost>>));
         (
-            GuestOperationGate::new(guest, coordinator.clone()),
+            GuestOperationStartGate::new(guest, coordinator.clone()),
             coordinator,
         )
     }
 
-    fn assert_prepare_can_start(coordinator: &ParkCoordinator) {
-        let attempt = coordinator
-            .begin_prepare_park()
-            .expect("operation start failure should not leave an active lease");
+    fn state_reader(state: &AtomicU8) -> impl Fn() -> SandboxState + '_ {
+        || match state.load(Ordering::Acquire) {
+            value if value == SandboxState::Running as u8 => SandboxState::Running,
+            value if value == SandboxState::Crashed as u8 => SandboxState::Crashed,
+            value if value == SandboxState::Stopping as u8 => SandboxState::Stopping,
+            value if value == SandboxState::Stopped as u8 => SandboxState::Stopped,
+            _ => SandboxState::Created,
+        }
+    }
+
+    #[tokio::test]
+    async fn sandbox_operation_requires_running_state() {
+        for state in [
+            SandboxState::Created,
+            SandboxState::Stopping,
+            SandboxState::Stopped,
+        ] {
+            let (gate, coordinator) = gate_without_guest();
+            let result = gate.begin_sandbox_operation(|| state).await;
+
+            assert_eq!(
+                result.err(),
+                Some(GuestOperationStartError::NotRunning { state })
+            );
+            assert_eq!(coordinator.state(), CoordinatorState::Open);
+        }
+    }
+
+    #[tokio::test]
+    async fn sandbox_operation_reports_backend_crash_before_guest_lookup() {
+        let (gate, coordinator) = gate_without_guest();
+
+        let result = gate.begin_sandbox_operation(|| SandboxState::Crashed).await;
+
+        assert_eq!(result.err(), Some(GuestOperationStartError::BackendCrashed));
+        assert_eq!(coordinator.state(), CoordinatorState::Open);
+    }
+
+    #[tokio::test]
+    async fn sandbox_operation_without_guest_reports_running_not_available() {
+        let (gate, coordinator) = gate_without_guest();
+
+        let result = gate.begin_sandbox_operation(|| SandboxState::Running).await;
+
+        assert_eq!(
+            result.err(),
+            Some(GuestOperationStartError::NotRunning {
+                state: SandboxState::Running
+            })
+        );
+        assert_eq!(coordinator.state(), CoordinatorState::Open);
+    }
+
+    #[tokio::test]
+    async fn sandbox_operation_rechecks_state_after_guest_lock_wait() {
+        let coordinator = ParkCoordinator::new();
+        let guest = Arc::new(tokio::sync::Mutex::new(None::<Arc<VsockHost>>));
+        let gate = GuestOperationStartGate::new(Arc::clone(&guest), coordinator.clone());
+        let locked_guest = guest.lock().await;
+        let state = Arc::new(AtomicU8::new(SandboxState::Running as u8));
+
+        let operation = {
+            let state = Arc::clone(&state);
+            tokio::spawn(async move { gate.begin_sandbox_operation(state_reader(&state)).await })
+        };
+        tokio::task::yield_now().await;
+        state.store(SandboxState::Crashed as u8, Ordering::Release);
+        drop(locked_guest);
+
+        let result = operation.await.expect("operation task should complete");
+        assert_eq!(result.err(), Some(GuestOperationStartError::BackendCrashed));
+        assert_eq!(coordinator.state(), CoordinatorState::Open);
+    }
+
+    #[tokio::test]
+    async fn operation_rechecks_policy_after_guest_lock_wait() {
+        let coordinator = ParkCoordinator::new();
+        let guest = Arc::new(tokio::sync::Mutex::new(None::<Arc<VsockHost>>));
+        let gate = GuestOperationStartGate::new(Arc::clone(&guest), coordinator.clone());
+        let locked_guest = guest.lock().await;
+
+        let operation = tokio::spawn(async move { gate.begin_control_operation().await });
+        tokio::task::yield_now().await;
+        let attempt = coordinator.begin_prepare_park().expect("begin prepare");
+        drop(locked_guest);
+
+        let result = operation.await.expect("operation task should complete");
+        assert!(matches!(
+            result,
+            Err(GuestOperationStartError::GateClosed {
+                state: CoordinatorState::ClosingForPark { .. }
+            })
+        ));
         coordinator.abort_prepare_park(&attempt).unwrap();
     }
 
-    fn write_boundary_state(coordinator: &ParkCoordinator) -> GuestOperationWriteBoundaryState {
-        let lease = coordinator.reserve_operation().expect("reserve operation");
-        GuestOperationWriteBoundaryState {
-            operation_id: lease.id(),
-            lease: Some(lease),
-            write_started: false,
-        }
-    }
+    #[tokio::test]
+    async fn control_operation_without_guest_reports_no_guest() {
+        let (gate, coordinator) = gate_without_guest();
 
-    #[test]
-    fn write_boundary_drop_before_write_start_is_clean() {
-        let coordinator = ParkCoordinator::new();
-        let state = write_boundary_state(&coordinator);
+        let result = gate.begin_control_operation().await;
 
-        drop(state);
-
-        assert_eq!(coordinator.active_operation_count(), 0);
-        assert_prepare_can_start(&coordinator);
-    }
-
-    #[test]
-    fn write_boundary_first_write_blocks_park_until_complete() {
-        let coordinator = ParkCoordinator::new();
-        let mut state = write_boundary_state(&coordinator);
-
-        state.record_write_start().expect("record write start");
-
-        assert!(state.write_started);
-        assert_eq!(coordinator.active_operation_count(), 1);
-        assert!(matches!(
-            coordinator.begin_prepare_park(),
-            Err(crate::park_coordinator::PrepareParkError::Busy)
-        ));
-
-        state.complete().expect("complete operation");
-        assert_prepare_can_start(&coordinator);
-    }
-
-    #[test]
-    fn write_boundary_repeated_write_start_is_idempotent() {
-        let coordinator = ParkCoordinator::new();
-        let mut state = write_boundary_state(&coordinator);
-
-        state.record_write_start().expect("first write start");
-        state.record_write_start().expect("second write start");
-
-        state.complete().expect("complete operation");
-        assert_prepare_can_start(&coordinator);
-    }
-
-    #[test]
-    fn write_boundary_completion_before_write_start_is_rejected_cleanly() {
-        let coordinator = ParkCoordinator::new();
-        let mut state = write_boundary_state(&coordinator);
-
-        assert!(matches!(
-            state.complete(),
-            Err(OperationTransitionError::InvalidTransition {
-                from: OperationLiveness::Reserved,
-                to: OperationLiveness::Terminal,
-                ..
-            })
-        ));
-
-        assert_eq!(coordinator.active_operation_count(), 0);
-        assert_prepare_can_start(&coordinator);
-    }
-
-    #[test]
-    fn write_boundary_in_guest_requires_write_start() {
-        let coordinator = ParkCoordinator::new();
-        let mut state = write_boundary_state(&coordinator);
-
-        assert!(matches!(
-            state.take_in_guest_lease(),
-            Err(OperationTransitionError::InvalidTransition {
-                from: OperationLiveness::Reserved,
-                to: OperationLiveness::InGuest,
-                ..
-            })
-        ));
-
-        assert_eq!(coordinator.active_operation_count(), 0);
-        assert_prepare_can_start(&coordinator);
-    }
-
-    #[test]
-    fn timeout_and_transport_errors_are_not_terminal_guest_evidence() {
-        for kind in [
-            std::io::ErrorKind::TimedOut,
-            std::io::ErrorKind::ConnectionReset,
-            std::io::ErrorKind::BrokenPipe,
-            std::io::ErrorKind::UnexpectedEof,
-            std::io::ErrorKind::InvalidData,
-        ] {
-            let error = std::io::Error::new(kind, "uncertain operation state");
-            assert!(!guest_error_is_terminal(&error, false));
-        }
-    }
-
-    #[test]
-    fn explicit_guest_errors_are_terminal_without_backend_crash() {
-        let error = std::io::Error::other("guest rejected request");
-
-        assert!(guest_error_is_terminal(&error, false));
-        assert!(!guest_error_is_terminal(&error, true));
+        assert_eq!(result.err(), Some(GuestOperationStartError::NoGuest));
+        assert_eq!(coordinator.state(), CoordinatorState::Open);
     }
 
     #[tokio::test]
-    async fn control_operation_without_guest_releases_reserved_lease() {
+    async fn closed_policy_gate_rejects_sandbox_and_control_operations() {
         let (gate, coordinator) = gate_without_guest();
+        let attempt = coordinator.begin_prepare_park().expect("begin prepare");
 
-        let error = match gate.begin_control_operation().await {
-            Ok(_) => panic!("expected no-guest error"),
-            Err(error) => error,
-        };
-
-        assert_eq!(error, GuestOperationStartError::NoGuest);
-        assert_eq!(coordinator.active_operation_count(), 0);
-        assert_prepare_can_start(&coordinator);
-    }
-
-    #[tokio::test]
-    async fn sandbox_operation_without_guest_releases_reserved_lease() {
-        let (gate, coordinator) = gate_without_guest();
-
-        let error = match gate.begin_sandbox_operation(|| SandboxState::Running).await {
-            Ok(_) => panic!("expected not-running error"),
-            Err(error) => error,
-        };
-
-        assert_eq!(
-            error,
-            GuestOperationStartError::NotRunning {
-                state: SandboxState::Running
-            }
-        );
-        assert_eq!(coordinator.active_operation_count(), 0);
-        assert_prepare_can_start(&coordinator);
-    }
-
-    #[tokio::test]
-    async fn sandbox_crash_after_reserve_releases_reserved_lease() {
-        let (gate, coordinator) = gate_without_guest();
-        let calls = AtomicUsize::new(0);
-
-        let error = match gate
-            .begin_sandbox_operation(|| {
-                if calls.fetch_add(1, Ordering::SeqCst) == 0 {
-                    SandboxState::Running
-                } else {
-                    SandboxState::Crashed
-                }
-            })
-            .await
-        {
-            Ok(_) => panic!("expected backend-crashed error"),
-            Err(error) => error,
-        };
-
-        assert_eq!(error, GuestOperationStartError::BackendCrashed);
-        assert_eq!(calls.load(Ordering::SeqCst), 2);
-        assert_eq!(coordinator.active_operation_count(), 0);
-        assert_prepare_can_start(&coordinator);
-    }
-
-    #[tokio::test]
-    async fn closed_gate_rejects_without_active_lease() {
-        let (gate, coordinator) = gate_without_guest();
-        let attempt = coordinator
-            .begin_prepare_park()
-            .expect("gate should enter closing state");
-
-        let error = match gate.begin_control_operation().await {
-            Ok(_) => panic!("expected gate-closed error"),
-            Err(error) => error,
-        };
+        let sandbox_result = gate.begin_sandbox_operation(|| SandboxState::Running).await;
+        let control_result = gate.begin_control_operation().await;
 
         assert!(matches!(
-            error,
-            GuestOperationStartError::GateClosed {
+            sandbox_result,
+            Err(GuestOperationStartError::GateClosed {
                 state: CoordinatorState::ClosingForPark { .. }
-            }
+            })
         ));
-        assert_eq!(coordinator.active_operation_count(), 0);
+        assert!(matches!(
+            control_result,
+            Err(GuestOperationStartError::GateClosed {
+                state: CoordinatorState::ClosingForPark { .. }
+            })
+        ));
         coordinator.abort_prepare_park(&attempt).unwrap();
     }
 }

--- a/crates/sandbox-fc/src/park_coordinator.rs
+++ b/crates/sandbox-fc/src/park_coordinator.rs
@@ -1,4 +1,4 @@
-//! Host-side park gate for same-session idle park.
+//! Host-side park policy gate for same-session idle park.
 //!
 //! `AgentQuiesced` is guest evidence that guest-agent-managed operations are
 //! fenced and settled. The host coordinator owns the stronger `ReadyForPark`
@@ -10,15 +10,16 @@
 //! authorize cross-run reuse or snapshot publication.
 //!
 //! Invariants:
-//! - A `Poisoned` operation keeps the coordinator `Dirty`; dirty sandboxes are
-//!   destroy-only and cannot re-enter the park lifecycle.
+//! - `sandbox-fc` owns park policy and operation-start admission only.
+//! - `vsock-host` owns normal guest operation lifetime. Its normal-operation
+//!   token acquisition is the authoritative operation lifetime linearization
+//!   point.
 //! - `ReadyForPark` means the host policy gate is closed, guest lifecycle
 //!   quiesce has completed, and the caller owns the authoritative `vsock-host`
 //!   normal-operation fence.
 //! - Coordinator locks are never held across `.await`.
 #![cfg_attr(not(test), allow(dead_code))]
 
-use std::collections::BTreeMap;
 use std::future::Future;
 use std::sync::{Arc, Mutex, MutexGuard};
 
@@ -32,9 +33,7 @@ impl ParkCoordinator {
         Self {
             inner: Arc::new(Mutex::new(Inner {
                 state: CoordinatorState::Open,
-                next_operation_id: 1,
                 next_attempt_id: 1,
-                operations: BTreeMap::new(),
             })),
         }
     }
@@ -43,25 +42,10 @@ impl ParkCoordinator {
         self.inner().state.clone()
     }
 
-    pub(crate) fn reserve_operation(&self) -> Result<OperationLease, LeaseRejection> {
-        let mut inner = self.inner();
-        match inner.state.clone() {
-            CoordinatorState::Open => {
-                let id = OperationId(inner.next_operation_id);
-                inner.next_operation_id += 1;
-                inner.operations.insert(
-                    id,
-                    OperationEntry {
-                        liveness: OperationLiveness::Reserved,
-                    },
-                );
-                Ok(OperationLease {
-                    id,
-                    inner: Arc::clone(&self.inner),
-                    released: false,
-                })
-            }
-            state => Err(LeaseRejection::GateClosed { state }),
+    pub(crate) fn ensure_operation_start_allowed(&self) -> Result<(), OperationStartRejection> {
+        match self.inner().state.clone() {
+            CoordinatorState::Open => Ok(()),
+            state => Err(OperationStartRejection::GateClosed { state }),
         }
     }
 
@@ -80,16 +64,6 @@ impl ParkCoordinator {
         let attempt_id = ParkAttemptId(inner.next_attempt_id);
         inner.next_attempt_id += 1;
         inner.state = CoordinatorState::ClosingForPark { attempt_id };
-
-        if let Some(reason) = inner.poisoned_reason() {
-            inner.mark_dirty(reason.clone());
-            return Err(PrepareParkError::Dirty { reason });
-        }
-
-        if inner.has_active_operations() {
-            inner.state = CoordinatorState::Open;
-            return Err(PrepareParkError::Busy);
-        }
 
         Ok(ParkAttempt { id: attempt_id })
     }
@@ -171,30 +145,6 @@ impl ParkCoordinator {
         self.inner().mark_dirty(reason);
     }
 
-    pub(crate) fn poison_unresolved_operations(&self, reason: DirtyReason) -> bool {
-        let mut inner = self.inner();
-        let mut poisoned = false;
-
-        for entry in inner.operations.values_mut() {
-            if entry.liveness.blocks_park() {
-                entry.liveness = OperationLiveness::Poisoned;
-                poisoned = true;
-            }
-        }
-        if poisoned {
-            inner.mark_dirty(reason);
-        }
-        poisoned
-    }
-
-    pub(crate) fn active_operation_count(&self) -> usize {
-        self.inner()
-            .operations
-            .values()
-            .filter(|entry| entry.liveness.blocks_park())
-            .count()
-    }
-
     fn inner(&self) -> MutexGuard<'_, Inner> {
         lock_inner(&self.inner)
     }
@@ -228,28 +178,6 @@ impl std::fmt::Display for DirtyReason {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
-pub(crate) struct OperationId(u64);
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(crate) enum OperationLiveness {
-    Reserved,
-    Writing,
-    InGuest,
-    Cancelling,
-    Terminal,
-    Poisoned,
-}
-
-impl OperationLiveness {
-    fn blocks_park(self) -> bool {
-        matches!(
-            self,
-            Self::Reserved | Self::Writing | Self::InGuest | Self::Cancelling
-        )
-    }
-}
-
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) struct ParkAttemptId(u64);
 
@@ -264,13 +192,12 @@ pub(crate) enum PrepareParkEvidence {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) enum LeaseRejection {
+pub(crate) enum OperationStartRejection {
     GateClosed { state: CoordinatorState },
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) enum PrepareParkError {
-    Busy,
     Dirty {
         reason: DirtyReason,
     },
@@ -283,149 +210,10 @@ pub(crate) enum PrepareParkError {
     },
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) enum OperationTransitionError {
-    UnknownOperation {
-        operation_id: OperationId,
-    },
-    InvalidTransition {
-        operation_id: OperationId,
-        from: OperationLiveness,
-        to: OperationLiveness,
-    },
-}
-
-#[derive(Debug)]
-pub(crate) struct OperationLease {
-    id: OperationId,
-    inner: Arc<Mutex<Inner>>,
-    released: bool,
-}
-
-impl OperationLease {
-    pub(crate) fn id(&self) -> OperationId {
-        self.id
-    }
-
-    pub(crate) fn mark_writing(&mut self) -> Result<(), OperationTransitionError> {
-        self.transition(OperationLiveness::Writing)
-    }
-
-    pub(crate) fn mark_in_guest(&mut self) -> Result<(), OperationTransitionError> {
-        self.transition(OperationLiveness::InGuest)
-    }
-
-    pub(crate) fn mark_cancelling(&mut self) -> Result<(), OperationTransitionError> {
-        self.transition(OperationLiveness::Cancelling)
-    }
-
-    pub(crate) fn complete(mut self) -> Result<(), OperationTransitionError> {
-        let mut inner = lock_inner(&self.inner);
-        let Some(entry) = inner.operations.get_mut(&self.id) else {
-            return Err(OperationTransitionError::UnknownOperation {
-                operation_id: self.id,
-            });
-        };
-
-        if !can_transition(entry.liveness, OperationLiveness::Terminal) {
-            return Err(OperationTransitionError::InvalidTransition {
-                operation_id: self.id,
-                from: entry.liveness,
-                to: OperationLiveness::Terminal,
-            });
-        }
-
-        entry.liveness = OperationLiveness::Terminal;
-        inner.operations.remove(&self.id);
-        self.released = true;
-        Ok(())
-    }
-
-    pub(crate) fn poison(mut self, reason: DirtyReason) -> Result<(), OperationTransitionError> {
-        let mut inner = lock_inner(&self.inner);
-        let Some(entry) = inner.operations.get_mut(&self.id) else {
-            return Err(OperationTransitionError::UnknownOperation {
-                operation_id: self.id,
-            });
-        };
-
-        if !can_transition(entry.liveness, OperationLiveness::Poisoned) {
-            return Err(OperationTransitionError::InvalidTransition {
-                operation_id: self.id,
-                from: entry.liveness,
-                to: OperationLiveness::Poisoned,
-            });
-        }
-
-        entry.liveness = OperationLiveness::Poisoned;
-        inner.mark_dirty(reason);
-        self.released = true;
-        Ok(())
-    }
-
-    fn transition(&mut self, to: OperationLiveness) -> Result<(), OperationTransitionError> {
-        let mut inner = lock_inner(&self.inner);
-        let Some(entry) = inner.operations.get_mut(&self.id) else {
-            return Err(OperationTransitionError::UnknownOperation {
-                operation_id: self.id,
-            });
-        };
-
-        if !can_transition(entry.liveness, to) {
-            return Err(OperationTransitionError::InvalidTransition {
-                operation_id: self.id,
-                from: entry.liveness,
-                to,
-            });
-        }
-
-        entry.liveness = to;
-        Ok(())
-    }
-}
-
-impl Drop for OperationLease {
-    fn drop(&mut self) {
-        if self.released {
-            return;
-        }
-
-        let mut inner = lock_inner(&self.inner);
-        let Some(liveness) = inner.operations.get(&self.id).map(|entry| entry.liveness) else {
-            return;
-        };
-
-        match liveness {
-            OperationLiveness::Reserved => {
-                inner.operations.remove(&self.id);
-            }
-            OperationLiveness::Writing
-            | OperationLiveness::InGuest
-            | OperationLiveness::Cancelling => {
-                if let Some(entry) = inner.operations.get_mut(&self.id) {
-                    entry.liveness = OperationLiveness::Poisoned;
-                }
-                inner.mark_dirty(DirtyReason::new(format!(
-                    "operation {} dropped after possible guest write",
-                    self.id.0
-                )));
-            }
-            OperationLiveness::Terminal | OperationLiveness::Poisoned => {}
-        }
-    }
-}
-
-#[derive(Clone, Copy, Debug)]
-struct OperationEntry {
-    liveness: OperationLiveness,
-}
-
 #[derive(Debug)]
 struct Inner {
     state: CoordinatorState,
-    next_operation_id: u64,
     next_attempt_id: u64,
-    operations: BTreeMap<OperationId, OperationEntry>,
 }
 
 struct ParkAttemptDropGuard {
@@ -472,36 +260,6 @@ impl Inner {
 
         self.state = CoordinatorState::Dirty { reason };
     }
-
-    fn has_active_operations(&self) -> bool {
-        self.operations
-            .values()
-            .any(|entry| entry.liveness.blocks_park())
-    }
-
-    fn poisoned_reason(&self) -> Option<DirtyReason> {
-        self.operations
-            .iter()
-            .find(|(_, entry)| entry.liveness == OperationLiveness::Poisoned)
-            .map(|(id, _)| DirtyReason::new(format!("operation {} poisoned", id.0)))
-    }
-}
-
-fn can_transition(from: OperationLiveness, to: OperationLiveness) -> bool {
-    matches!(
-        (from, to),
-        (OperationLiveness::Reserved, OperationLiveness::Writing)
-            | (OperationLiveness::Reserved, OperationLiveness::Poisoned)
-            | (OperationLiveness::Writing, OperationLiveness::InGuest)
-            | (OperationLiveness::Writing, OperationLiveness::Cancelling)
-            | (OperationLiveness::Writing, OperationLiveness::Terminal)
-            | (OperationLiveness::Writing, OperationLiveness::Poisoned)
-            | (OperationLiveness::InGuest, OperationLiveness::Cancelling)
-            | (OperationLiveness::InGuest, OperationLiveness::Terminal)
-            | (OperationLiveness::InGuest, OperationLiveness::Poisoned)
-            | (OperationLiveness::Cancelling, OperationLiveness::Terminal)
-            | (OperationLiveness::Cancelling, OperationLiveness::Poisoned)
-    )
 }
 
 fn lock_inner(inner: &Mutex<Inner>) -> MutexGuard<'_, Inner> {
@@ -534,13 +292,6 @@ mod tests {
         }
     }
 
-    fn assert_dirty_state(coordinator: &ParkCoordinator) {
-        assert!(matches!(
-            coordinator.state(),
-            CoordinatorState::Dirty { .. }
-        ));
-    }
-
     fn dirty_reason(coordinator: &ParkCoordinator) -> DirtyReason {
         match coordinator.state() {
             CoordinatorState::Dirty { reason } => reason,
@@ -548,290 +299,55 @@ mod tests {
         }
     }
 
-    fn operation_registry_len(coordinator: &ParkCoordinator) -> usize {
-        coordinator.inner().operations.len()
-    }
-
     #[test]
     fn initial_state_is_open() {
         let coordinator = ParkCoordinator::new();
 
         assert_eq!(coordinator.state(), CoordinatorState::Open);
+        assert_eq!(coordinator.ensure_operation_start_allowed(), Ok(()));
     }
 
     #[test]
-    fn poisoned_mutex_marks_coordinator_dirty() {
-        let coordinator = ParkCoordinator::new();
-        let poisoned_coordinator = coordinator.clone();
-
-        let join_result = std::thread::spawn(move || {
-            let _guard = poisoned_coordinator.inner();
-            panic!("poison coordinator lock");
-        })
-        .join();
-
-        assert!(join_result.is_err());
-        assert_eq!(
-            dirty_reason(&coordinator),
-            DirtyReason::new("park coordinator mutex poisoned")
-        );
+    fn operation_start_is_rejected_when_policy_gate_is_not_open() {
+        let closing = ParkCoordinator::new();
+        let closing_attempt = begin_attempt(&closing);
         assert!(matches!(
-            coordinator.reserve_operation(),
-            Err(LeaseRejection::GateClosed {
-                state: CoordinatorState::Dirty { .. }
-            })
-        ));
-    }
-
-    #[test]
-    fn reservations_succeed_only_when_open() {
-        let coordinator = ParkCoordinator::new();
-        let lease = coordinator.reserve_operation();
-        assert!(lease.is_ok());
-        drop(lease);
-
-        let attempt = begin_attempt(&coordinator);
-        assert!(matches!(
-            coordinator.reserve_operation(),
-            Err(LeaseRejection::GateClosed {
+            closing.ensure_operation_start_allowed(),
+            Err(OperationStartRejection::GateClosed {
                 state: CoordinatorState::ClosingForPark { .. }
             })
         ));
+        closing.abort_prepare_park(&closing_attempt).unwrap();
 
-        complete_attempt(&coordinator, &attempt);
+        let ready = ParkCoordinator::new();
+        let ready_attempt = begin_attempt(&ready);
+        complete_attempt(&ready, &ready_attempt);
         assert!(matches!(
-            coordinator.reserve_operation(),
-            Err(LeaseRejection::GateClosed {
+            ready.ensure_operation_start_allowed(),
+            Err(OperationStartRejection::GateClosed {
                 state: CoordinatorState::ReadyForPark { .. }
             })
         ));
 
-        assert!(coordinator.mark_parked(&attempt).is_ok());
-        assert!(matches!(
-            coordinator.reserve_operation(),
-            Err(LeaseRejection::GateClosed {
+        let parked = ParkCoordinator::new();
+        let parked_attempt = begin_attempt(&parked);
+        complete_attempt(&parked, &parked_attempt);
+        parked.mark_parked(&parked_attempt).unwrap();
+        assert_eq!(
+            parked.ensure_operation_start_allowed(),
+            Err(OperationStartRejection::GateClosed {
                 state: CoordinatorState::Parked
             })
-        ));
+        );
 
-        coordinator.mark_dirty(DirtyReason::new("test dirty"));
+        let dirty = ParkCoordinator::new();
+        dirty.mark_dirty(DirtyReason::new("test dirty"));
         assert!(matches!(
-            coordinator.reserve_operation(),
-            Err(LeaseRejection::GateClosed {
+            dirty.ensure_operation_start_allowed(),
+            Err(OperationStartRejection::GateClosed {
                 state: CoordinatorState::Dirty { .. }
             })
         ));
-    }
-
-    #[test]
-    fn dropping_reserved_lease_releases_without_dirtying() {
-        let coordinator = ParkCoordinator::new();
-        let lease = coordinator.reserve_operation();
-        assert!(lease.is_ok());
-        assert_eq!(coordinator.active_operation_count(), 1);
-
-        drop(lease);
-
-        assert_eq!(coordinator.active_operation_count(), 0);
-        assert_eq!(operation_registry_len(&coordinator), 0);
-        assert_eq!(coordinator.state(), CoordinatorState::Open);
-    }
-
-    #[test]
-    fn completed_operations_are_removed_from_registry() {
-        let coordinator = ParkCoordinator::new();
-        let mut lease = coordinator.reserve_operation().expect("reserve operation");
-        assert_eq!(operation_registry_len(&coordinator), 1);
-
-        assert!(lease.mark_writing().is_ok());
-        assert!(lease.mark_in_guest().is_ok());
-        assert!(lease.complete().is_ok());
-
-        assert_eq!(coordinator.active_operation_count(), 0);
-        assert_eq!(operation_registry_len(&coordinator), 0);
-        assert_eq!(coordinator.state(), CoordinatorState::Open);
-    }
-
-    #[test]
-    fn failed_reserved_complete_releases_without_dirtying() {
-        let coordinator = ParkCoordinator::new();
-        let lease = coordinator.reserve_operation().expect("reserve operation");
-        assert_eq!(operation_registry_len(&coordinator), 1);
-
-        assert!(matches!(
-            lease.complete(),
-            Err(OperationTransitionError::InvalidTransition {
-                from: OperationLiveness::Reserved,
-                to: OperationLiveness::Terminal,
-                ..
-            })
-        ));
-
-        assert_eq!(coordinator.active_operation_count(), 0);
-        assert_eq!(operation_registry_len(&coordinator), 0);
-        assert_eq!(coordinator.state(), CoordinatorState::Open);
-    }
-
-    #[test]
-    fn dropping_after_possible_write_marks_dirty() {
-        let coordinator = ParkCoordinator::new();
-        let mut lease = coordinator
-            .reserve_operation()
-            .expect("reserve operation before possible write");
-        assert!(lease.mark_writing().is_ok());
-
-        drop(lease);
-
-        assert_dirty_state(&coordinator);
-        assert!(matches!(
-            coordinator.begin_prepare_park(),
-            Err(PrepareParkError::Dirty { .. })
-        ));
-    }
-
-    #[test]
-    fn dropping_in_guest_or_cancelling_operation_marks_dirty() {
-        for enter_cancelling in [false, true] {
-            let coordinator = ParkCoordinator::new();
-            let mut lease = coordinator
-                .reserve_operation()
-                .expect("reserve operation before possible write");
-
-            assert!(lease.mark_writing().is_ok());
-            assert!(lease.mark_in_guest().is_ok());
-            if enter_cancelling {
-                assert!(lease.mark_cancelling().is_ok());
-            }
-
-            drop(lease);
-
-            assert_dirty_state(&coordinator);
-            assert_eq!(operation_registry_len(&coordinator), 1);
-        }
-    }
-
-    #[test]
-    fn active_operation_returns_busy_and_reopens_gate() {
-        let coordinator = ParkCoordinator::new();
-        let mut lease = coordinator.reserve_operation().expect("reserve operation");
-        assert!(lease.mark_writing().is_ok());
-
-        assert_eq!(
-            coordinator.begin_prepare_park(),
-            Err(PrepareParkError::Busy)
-        );
-        assert_eq!(coordinator.state(), CoordinatorState::Open);
-        assert!(coordinator.reserve_operation().is_ok());
-
-        assert!(lease.complete().is_ok());
-    }
-
-    #[test]
-    fn reserved_operation_returns_busy() {
-        let coordinator = ParkCoordinator::new();
-        let lease = coordinator.reserve_operation().expect("reserve operation");
-
-        assert_eq!(
-            coordinator.begin_prepare_park(),
-            Err(PrepareParkError::Busy)
-        );
-        assert_eq!(coordinator.state(), CoordinatorState::Open);
-
-        drop(lease);
-    }
-
-    #[test]
-    fn cancelling_operation_returns_busy_without_dirtying() {
-        let coordinator = ParkCoordinator::new();
-        let mut lease = coordinator.reserve_operation().expect("reserve operation");
-        assert!(lease.mark_writing().is_ok());
-        assert!(lease.mark_in_guest().is_ok());
-        assert!(lease.mark_cancelling().is_ok());
-
-        assert_eq!(
-            coordinator.begin_prepare_park(),
-            Err(PrepareParkError::Busy)
-        );
-        assert_eq!(coordinator.state(), CoordinatorState::Open);
-
-        assert!(lease.complete().is_ok());
-        assert_eq!(coordinator.state(), CoordinatorState::Open);
-    }
-
-    #[test]
-    fn poison_marks_dirty_permanently() {
-        let coordinator = ParkCoordinator::new();
-        let lease = coordinator.reserve_operation().expect("reserve operation");
-
-        assert!(
-            lease
-                .poison(DirtyReason::new("transport uncertain"))
-                .is_ok()
-        );
-        assert_dirty_state(&coordinator);
-        assert!(matches!(
-            coordinator.reserve_operation(),
-            Err(LeaseRejection::GateClosed {
-                state: CoordinatorState::Dirty { .. }
-            })
-        ));
-        assert!(matches!(
-            coordinator.begin_prepare_park(),
-            Err(PrepareParkError::Dirty { .. })
-        ));
-    }
-
-    #[test]
-    fn driver_shutdown_poisons_unresolved_operations() {
-        let coordinator = ParkCoordinator::new();
-        let mut lease = coordinator.reserve_operation().expect("reserve operation");
-        assert!(lease.mark_writing().is_ok());
-
-        assert!(coordinator.poison_unresolved_operations(DirtyReason::new("driver shutdown")));
-
-        assert_dirty_state(&coordinator);
-        drop(lease);
-        assert_dirty_state(&coordinator);
-    }
-
-    #[test]
-    fn driver_shutdown_poison_is_idempotent() {
-        let coordinator = ParkCoordinator::new();
-        let mut lease = coordinator.reserve_operation().expect("reserve operation");
-        assert!(lease.mark_writing().is_ok());
-
-        assert!(coordinator.poison_unresolved_operations(DirtyReason::new("driver shutdown")));
-        assert!(!coordinator.poison_unresolved_operations(DirtyReason::new("second shutdown")));
-
-        assert_eq!(
-            dirty_reason(&coordinator),
-            DirtyReason::new("driver shutdown")
-        );
-        drop(lease);
-        assert_eq!(
-            dirty_reason(&coordinator),
-            DirtyReason::new("driver shutdown")
-        );
-    }
-
-    #[test]
-    fn driver_shutdown_without_unresolved_operations_does_not_dirty() {
-        let coordinator = ParkCoordinator::new();
-
-        assert!(!coordinator.poison_unresolved_operations(DirtyReason::new("driver shutdown")));
-        assert_eq!(coordinator.state(), CoordinatorState::Open);
-    }
-
-    #[test]
-    fn first_dirty_reason_is_preserved() {
-        let coordinator = ParkCoordinator::new();
-        let mut lease = coordinator.reserve_operation().expect("reserve operation");
-        assert!(lease.mark_writing().is_ok());
-
-        coordinator.mark_dirty(DirtyReason::new("first cause"));
-        drop(lease);
-
-        assert_eq!(dirty_reason(&coordinator), DirtyReason::new("first cause"));
     }
 
     #[test]
@@ -863,6 +379,7 @@ mod tests {
 
         assert!(coordinator.reopen_after_unpark().is_ok());
         assert_eq!(coordinator.state(), CoordinatorState::Open);
+        assert_eq!(coordinator.ensure_operation_start_allowed(), Ok(()));
     }
 
     #[test]
@@ -956,25 +473,6 @@ mod tests {
         );
     }
 
-    #[test]
-    fn operation_transitions_are_validated() {
-        let coordinator = ParkCoordinator::new();
-        let mut lease = coordinator.reserve_operation().expect("reserve operation");
-        assert_eq!(lease.id(), OperationId(1));
-
-        assert!(matches!(
-            lease.mark_in_guest(),
-            Err(OperationTransitionError::InvalidTransition {
-                from: OperationLiveness::Reserved,
-                to: OperationLiveness::InGuest,
-                ..
-            })
-        ));
-        assert!(lease.mark_writing().is_ok());
-        assert!(lease.mark_in_guest().is_ok());
-        assert!(lease.complete().is_ok());
-    }
-
     #[tokio::test]
     async fn async_prepare_hook_runs_without_holding_coordinator_lock() {
         let coordinator = ParkCoordinator::new();
@@ -983,8 +481,8 @@ mod tests {
         let result = coordinator
             .prepare_park_with(|_| async move {
                 assert!(matches!(
-                    observed.reserve_operation(),
-                    Err(LeaseRejection::GateClosed {
+                    observed.ensure_operation_start_allowed(),
+                    Err(OperationStartRejection::GateClosed {
                         state: CoordinatorState::ClosingForPark { .. }
                     })
                 ));
@@ -1044,7 +542,7 @@ mod tests {
         assert!(join_error.is_cancelled());
 
         assert_eq!(coordinator.state(), CoordinatorState::Open);
-        assert!(coordinator.reserve_operation().is_ok());
+        assert_eq!(coordinator.ensure_operation_start_allowed(), Ok(()));
         assert_eq!(std::sync::Arc::strong_count(&coordinator.inner), 1);
         assert!(matches!(
             coordinator.complete_prepare_park(&stale_attempt, PrepareParkEvidence::AgentQuiesced),
@@ -1089,15 +587,15 @@ mod tests {
         );
         assert_eq!(std::sync::Arc::strong_count(&coordinator.inner), 1);
         assert!(matches!(
-            coordinator.reserve_operation(),
-            Err(LeaseRejection::GateClosed {
+            coordinator.ensure_operation_start_allowed(),
+            Err(OperationStartRejection::GateClosed {
                 state: CoordinatorState::Dirty { .. }
             })
         ));
     }
 
     #[test]
-    fn concurrent_prepare_and_reserve_are_linearized() {
+    fn concurrent_prepare_and_operation_start_admission_are_linearized() {
         for _ in 0..64 {
             let coordinator = ParkCoordinator::new();
             let barrier = std::sync::Arc::new(std::sync::Barrier::new(2));
@@ -1109,33 +607,26 @@ mod tests {
                 prepare_coordinator.begin_prepare_park()
             });
 
-            let reserve_coordinator = coordinator.clone();
-            let reserve_barrier = std::sync::Arc::clone(&barrier);
-            let reserve_thread = std::thread::spawn(move || {
-                reserve_barrier.wait();
-                reserve_coordinator.reserve_operation()
+            let start_coordinator = coordinator.clone();
+            let start_barrier = std::sync::Arc::clone(&barrier);
+            let start_thread = std::thread::spawn(move || {
+                start_barrier.wait();
+                start_coordinator.ensure_operation_start_allowed()
             });
 
             let prepare_result = prepare_thread
                 .join()
                 .expect("prepare thread should not panic");
-            let reserve_result = reserve_thread
-                .join()
-                .expect("reserve thread should not panic");
+            let start_result = start_thread.join().expect("start thread should not panic");
 
-            match (prepare_result, reserve_result) {
-                (
-                    Ok(attempt),
-                    Err(LeaseRejection::GateClosed {
-                        state: CoordinatorState::ClosingForPark { .. },
-                    }),
-                ) => {
+            match (prepare_result, start_result) {
+                (Ok(attempt), Err(OperationStartRejection::GateClosed { .. })) => {
                     assert!(coordinator.abort_prepare_park(&attempt).is_ok());
                 }
-                (Err(PrepareParkError::Busy), Ok(lease)) => {
-                    drop(lease);
+                (Ok(attempt), Ok(())) => {
+                    assert!(coordinator.abort_prepare_park(&attempt).is_ok());
                 }
-                other => panic!("unexpected concurrent prepare/reserve result: {other:?}"),
+                other => panic!("unexpected concurrent prepare/start result: {other:?}"),
             }
 
             assert_eq!(coordinator.state(), CoordinatorState::Open);
@@ -1143,78 +634,13 @@ mod tests {
     }
 
     #[test]
-    fn concurrent_prepare_and_reserved_drop_are_linearized() {
-        for _ in 0..64 {
-            let coordinator = ParkCoordinator::new();
-            let lease = coordinator.reserve_operation().expect("reserve operation");
-            let barrier = std::sync::Arc::new(std::sync::Barrier::new(2));
+    fn first_dirty_reason_is_preserved() {
+        let coordinator = ParkCoordinator::new();
 
-            let prepare_coordinator = coordinator.clone();
-            let prepare_barrier = std::sync::Arc::clone(&barrier);
-            let prepare_thread = std::thread::spawn(move || {
-                prepare_barrier.wait();
-                prepare_coordinator.begin_prepare_park()
-            });
+        coordinator.mark_dirty(DirtyReason::new("first cause"));
+        coordinator.mark_dirty(DirtyReason::new("second cause"));
 
-            let drop_barrier = std::sync::Arc::clone(&barrier);
-            let drop_thread = std::thread::spawn(move || {
-                drop_barrier.wait();
-                drop(lease);
-            });
-
-            let prepare_result = prepare_thread
-                .join()
-                .expect("prepare thread should not panic");
-            drop_thread.join().expect("drop thread should not panic");
-
-            match prepare_result {
-                Ok(attempt) => {
-                    assert!(coordinator.abort_prepare_park(&attempt).is_ok());
-                }
-                Err(PrepareParkError::Busy) => {}
-                other => panic!("unexpected concurrent prepare/drop result: {other:?}"),
-            }
-
-            assert_eq!(coordinator.state(), CoordinatorState::Open);
-            assert_eq!(coordinator.active_operation_count(), 0);
-            assert_eq!(operation_registry_len(&coordinator), 0);
-        }
-    }
-
-    #[test]
-    fn concurrent_prepare_and_possible_guest_write_drop_mark_dirty() {
-        for _ in 0..64 {
-            let coordinator = ParkCoordinator::new();
-            let mut lease = coordinator.reserve_operation().expect("reserve operation");
-            assert!(lease.mark_writing().is_ok());
-            let barrier = std::sync::Arc::new(std::sync::Barrier::new(2));
-
-            let prepare_coordinator = coordinator.clone();
-            let prepare_barrier = std::sync::Arc::clone(&barrier);
-            let prepare_thread = std::thread::spawn(move || {
-                prepare_barrier.wait();
-                prepare_coordinator.begin_prepare_park()
-            });
-
-            let drop_barrier = std::sync::Arc::clone(&barrier);
-            let drop_thread = std::thread::spawn(move || {
-                drop_barrier.wait();
-                drop(lease);
-            });
-
-            let prepare_result = prepare_thread
-                .join()
-                .expect("prepare thread should not panic");
-            drop_thread.join().expect("drop thread should not panic");
-
-            assert!(matches!(
-                prepare_result,
-                Err(PrepareParkError::Busy | PrepareParkError::Dirty { .. })
-            ));
-            assert_dirty_state(&coordinator);
-            assert_eq!(coordinator.active_operation_count(), 0);
-            assert_eq!(operation_registry_len(&coordinator), 1);
-        }
+        assert_eq!(dirty_reason(&coordinator), DirtyReason::new("first cause"));
     }
 
     #[test]
@@ -1224,17 +650,12 @@ mod tests {
         let first_attempt = begin_attempt(&first);
 
         assert!(matches!(
-            first.reserve_operation(),
-            Err(LeaseRejection::GateClosed {
+            first.ensure_operation_start_allowed(),
+            Err(OperationStartRejection::GateClosed {
                 state: CoordinatorState::ClosingForPark { .. }
             })
         ));
-
-        let second_lease = second
-            .reserve_operation()
-            .expect("second coordinator should stay open");
-        assert_eq!(second.state(), CoordinatorState::Open);
-        drop(second_lease);
+        assert_eq!(second.ensure_operation_start_allowed(), Ok(()));
 
         assert!(first.abort_prepare_park(&first_attempt).is_ok());
         assert_eq!(first.state(), CoordinatorState::Open);

--- a/crates/sandbox-fc/src/park_coordinator.rs
+++ b/crates/sandbox-fc/src/park_coordinator.rs
@@ -18,9 +18,6 @@
 //!   quiesce has completed, and the caller owns the authoritative `vsock-host`
 //!   normal-operation fence.
 //! - Coordinator locks are never held across `.await`.
-#![cfg_attr(not(test), allow(dead_code))]
-
-use std::future::Future;
 use std::sync::{Arc, Mutex, MutexGuard};
 
 #[derive(Clone, Debug)]
@@ -102,19 +99,6 @@ impl ParkCoordinator {
                 state,
             }),
         }
-    }
-
-    pub(crate) async fn prepare_park_with<F, Fut>(&self, hook: F) -> Result<(), PrepareParkError>
-    where
-        F: FnOnce(ParkAttempt) -> Fut,
-        Fut: Future<Output = PrepareParkEvidence>,
-    {
-        let attempt = self.begin_prepare_park()?;
-        let abort_on_drop = ParkAttemptDropGuard::new(Arc::clone(&self.inner), attempt);
-        let evidence = hook(attempt).await;
-        let result = self.complete_prepare_park(&attempt, evidence);
-        abort_on_drop.disarm();
-        result
     }
 
     pub(crate) fn mark_parked(&self, attempt: &ParkAttempt) -> Result<(), PrepareParkError> {
@@ -216,42 +200,6 @@ struct Inner {
     next_attempt_id: u64,
 }
 
-struct ParkAttemptDropGuard {
-    inner: Arc<Mutex<Inner>>,
-    attempt: ParkAttempt,
-    armed: bool,
-}
-
-impl ParkAttemptDropGuard {
-    fn new(inner: Arc<Mutex<Inner>>, attempt: ParkAttempt) -> Self {
-        Self {
-            inner,
-            attempt,
-            armed: true,
-        }
-    }
-
-    fn disarm(mut self) {
-        self.armed = false;
-    }
-}
-
-impl Drop for ParkAttemptDropGuard {
-    fn drop(&mut self) {
-        if !self.armed {
-            return;
-        }
-
-        let mut inner = lock_inner(&self.inner);
-        if matches!(
-            inner.state,
-            CoordinatorState::ClosingForPark { attempt_id } if attempt_id == self.attempt.id
-        ) {
-            inner.state = CoordinatorState::Open;
-        }
-    }
-}
-
 impl Inner {
     fn mark_dirty(&mut self, reason: DirtyReason) {
         if matches!(self.state, CoordinatorState::Dirty { .. }) {
@@ -305,6 +253,30 @@ mod tests {
 
         assert_eq!(coordinator.state(), CoordinatorState::Open);
         assert_eq!(coordinator.ensure_operation_start_allowed(), Ok(()));
+    }
+
+    #[test]
+    fn poisoned_mutex_marks_coordinator_dirty() {
+        let coordinator = ParkCoordinator::new();
+        let poisoned_coordinator = coordinator.clone();
+
+        let join_result = std::thread::spawn(move || {
+            let _guard = poisoned_coordinator.inner();
+            panic!("poison coordinator lock");
+        })
+        .join();
+
+        assert!(join_result.is_err());
+        assert_eq!(
+            dirty_reason(&coordinator),
+            DirtyReason::new("park coordinator mutex poisoned")
+        );
+        assert!(matches!(
+            coordinator.ensure_operation_start_allowed(),
+            Err(OperationStartRejection::GateClosed {
+                state: CoordinatorState::Dirty { .. }
+            })
+        ));
     }
 
     #[test]
@@ -471,127 +443,6 @@ mod tests {
             dirty_reason(&coordinator),
             DirtyReason::new("driver shutdown")
         );
-    }
-
-    #[tokio::test]
-    async fn async_prepare_hook_runs_without_holding_coordinator_lock() {
-        let coordinator = ParkCoordinator::new();
-        let observed = coordinator.clone();
-
-        let result = coordinator
-            .prepare_park_with(|_| async move {
-                assert!(matches!(
-                    observed.ensure_operation_start_allowed(),
-                    Err(OperationStartRejection::GateClosed {
-                        state: CoordinatorState::ClosingForPark { .. }
-                    })
-                ));
-                PrepareParkEvidence::AgentQuiesced
-            })
-            .await;
-
-        assert!(result.is_ok());
-        assert!(matches!(
-            coordinator.state(),
-            CoordinatorState::ReadyForPark { .. }
-        ));
-    }
-
-    #[tokio::test]
-    async fn successful_prepare_releases_attempt_guard_reference() {
-        let coordinator = ParkCoordinator::new();
-        assert_eq!(std::sync::Arc::strong_count(&coordinator.inner), 1);
-
-        let result = coordinator
-            .prepare_park_with(|_| async { PrepareParkEvidence::AgentQuiesced })
-            .await;
-
-        assert!(result.is_ok());
-        assert_eq!(std::sync::Arc::strong_count(&coordinator.inner), 1);
-        assert!(matches!(
-            coordinator.state(),
-            CoordinatorState::ReadyForPark { .. }
-        ));
-    }
-
-    #[tokio::test]
-    async fn dropped_prepare_future_reopens_gate_and_stales_attempt() {
-        let coordinator = ParkCoordinator::new();
-        let worker_coordinator = coordinator.clone();
-        let (attempt_tx, attempt_rx) = tokio::sync::oneshot::channel();
-
-        let task = tokio::spawn(async move {
-            worker_coordinator
-                .prepare_park_with(|attempt| async move {
-                    let _ = attempt_tx.send(attempt);
-                    std::future::pending::<PrepareParkEvidence>().await
-                })
-                .await
-        });
-
-        let stale_attempt = attempt_rx
-            .await
-            .expect("prepare hook should receive an attempt");
-        assert!(matches!(
-            coordinator.state(),
-            CoordinatorState::ClosingForPark { .. }
-        ));
-
-        task.abort();
-        let join_error = task.await.expect_err("prepare task should be aborted");
-        assert!(join_error.is_cancelled());
-
-        assert_eq!(coordinator.state(), CoordinatorState::Open);
-        assert_eq!(coordinator.ensure_operation_start_allowed(), Ok(()));
-        assert_eq!(std::sync::Arc::strong_count(&coordinator.inner), 1);
-        assert!(matches!(
-            coordinator.complete_prepare_park(&stale_attempt, PrepareParkEvidence::AgentQuiesced),
-            Err(PrepareParkError::StaleAttempt {
-                state: CoordinatorState::Open,
-                ..
-            })
-        ));
-    }
-
-    #[tokio::test]
-    async fn dropped_prepare_future_does_not_reopen_dirty_gate() {
-        let coordinator = ParkCoordinator::new();
-        let worker_coordinator = coordinator.clone();
-        let (attempt_tx, attempt_rx) = tokio::sync::oneshot::channel();
-
-        let task = tokio::spawn(async move {
-            worker_coordinator
-                .prepare_park_with(|attempt| async move {
-                    let _ = attempt_tx.send(attempt);
-                    std::future::pending::<PrepareParkEvidence>().await
-                })
-                .await
-        });
-
-        let _attempt = attempt_rx
-            .await
-            .expect("prepare hook should receive an attempt");
-        assert!(matches!(
-            coordinator.state(),
-            CoordinatorState::ClosingForPark { .. }
-        ));
-
-        coordinator.mark_dirty(DirtyReason::new("driver shutdown"));
-        task.abort();
-        let join_error = task.await.expect_err("prepare task should be aborted");
-        assert!(join_error.is_cancelled());
-
-        assert_eq!(
-            dirty_reason(&coordinator),
-            DirtyReason::new("driver shutdown")
-        );
-        assert_eq!(std::sync::Arc::strong_count(&coordinator.inner), 1);
-        assert!(matches!(
-            coordinator.ensure_operation_start_allowed(),
-            Err(OperationStartRejection::GateClosed {
-                state: CoordinatorState::Dirty { .. }
-            })
-        ));
     }
 
     #[test]

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -3,7 +3,6 @@ use std::future::Future;
 use std::io;
 use std::os::unix::ffi::OsStringExt;
 use std::path::Path;
-use std::pin::Pin;
 use std::sync::atomic::{AtomicU8, Ordering};
 use std::sync::{Arc, Mutex, MutexGuard};
 use std::time::Duration;
@@ -29,15 +28,12 @@ use crate::balloon;
 use crate::config::FirecrackerConfig;
 use crate::control;
 use crate::factory::InvariantConfig;
-use crate::guest_operations::{
-    GuestOperation, GuestOperationGate, GuestOperationStartError, GuestOperationWriteBoundary,
-    guest_error_is_terminal,
-};
+use crate::guest_operations::{GuestOperationStartError, GuestOperationStartGate};
 use crate::leaked_resources::LeakedResources;
 use crate::network::{NetnsInfo, NetnsLease};
 use crate::park_coordinator::{
-    CoordinatorState, DirtyReason, LeaseRejection, OperationLease, OperationTransitionError,
-    ParkAttempt, ParkCoordinator, PrepareParkError, PrepareParkEvidence,
+    CoordinatorState, DirtyReason, OperationStartRejection, ParkAttempt, ParkCoordinator,
+    PrepareParkError, PrepareParkEvidence,
 };
 use crate::paths::{SandboxPaths, SockPaths};
 use crate::process::{kill_process_group, kill_process_group_by_pid};
@@ -650,17 +646,6 @@ impl FirecrackerSandbox {
         }
     }
 
-    fn operation_gate_transition_error(
-        operation: SandboxOperation,
-        error: OperationTransitionError,
-    ) -> SandboxError {
-        SandboxError::Operation {
-            operation,
-            reason: SandboxOperationReason::Other,
-            message: format!("operation gate transition failed: {error:?}"),
-        }
-    }
-
     fn operation_start_error(
         &self,
         operation: SandboxOperation,
@@ -686,15 +671,15 @@ impl FirecrackerSandbox {
         publish_process_state(&self.state, &self.state_publish_lock, &self.state_tx, state);
     }
 
-    fn guest_operations(&self) -> GuestOperationGate {
-        GuestOperationGate::new(Arc::clone(&self.guest), self.park_coordinator.clone())
+    fn guest_operation_start_gate(&self) -> GuestOperationStartGate {
+        GuestOperationStartGate::new(Arc::clone(&self.guest), self.park_coordinator.clone())
     }
 
     async fn begin_guest_operation(
         &self,
         operation: SandboxOperation,
-    ) -> sandbox::Result<GuestOperation> {
-        self.guest_operations()
+    ) -> sandbox::Result<Arc<VsockHost>> {
+        self.guest_operation_start_gate()
             .begin_sandbox_operation(|| self.current_state())
             .await
             .map_err(|error| self.operation_start_error(operation, error))
@@ -703,7 +688,7 @@ impl FirecrackerSandbox {
     async fn run_bounded_guest_operation<T, Fut>(
         &self,
         operation: SandboxOperation,
-        call: impl FnOnce(Arc<VsockHost>, vsock_host::FrameWriteObserver) -> Fut,
+        call: impl FnOnce(Arc<VsockHost>) -> Fut,
     ) -> sandbox::Result<T>
     where
         Fut: Future<Output = io::Result<T>>,
@@ -713,13 +698,10 @@ impl FirecrackerSandbox {
             BackendCrashed,
         }
 
-        let guest_operation = self.begin_guest_operation(operation).await?;
-        let vsock = guest_operation.guest();
-        let guest = guest_operation.into_write_boundary();
-        let write_observer = guest.write_observer();
+        let vsock = self.begin_guest_operation(operation).await?;
 
         let outcome = tokio::select! {
-            result = call(vsock, write_observer) => {
+            result = call(vsock) => {
                 GuestCallOutcome::Returned(result)
             }
             () = wait_for_backend_crash(self.state_tx.subscribe()) => {
@@ -728,22 +710,10 @@ impl FirecrackerSandbox {
         };
 
         match outcome {
-            GuestCallOutcome::Returned(Ok(value)) => {
-                guest
-                    .complete()
-                    .map_err(|error| Self::operation_gate_transition_error(operation, error))?;
-                Ok(value)
-            }
+            GuestCallOutcome::Returned(Ok(value)) => Ok(value),
             GuestCallOutcome::Returned(Err(error)) => {
                 let backend_crashed = self.has_backend_crashed();
-                let is_terminal = guest_error_is_terminal(&error, backend_crashed);
-                let result = Err(Self::operation_error(operation, error, backend_crashed));
-                if is_terminal {
-                    guest
-                        .complete_if_write_started()
-                        .map_err(|error| Self::operation_gate_transition_error(operation, error))?;
-                }
-                result
+                Err(Self::operation_error(operation, error, backend_crashed))
             }
             GuestCallOutcome::BackendCrashed => Err(Self::backend_crashed_error(operation)),
         }
@@ -753,20 +723,20 @@ impl FirecrackerSandbox {
         SandboxState::from_u8(state.load(Ordering::Acquire))
     }
 
-    fn begin_process_control_boundary(
+    fn begin_process_control(
         coordinator: &ParkCoordinator,
         current_state: impl Fn() -> SandboxState,
-    ) -> Result<GuestOperationWriteBoundary, GuestOperationStartError> {
+    ) -> Result<(), GuestOperationStartError> {
         match current_state() {
             SandboxState::Running => {}
             SandboxState::Crashed => return Err(GuestOperationStartError::BackendCrashed),
             state => return Err(GuestOperationStartError::NotRunning { state }),
         }
 
-        let lease = coordinator
-            .reserve_operation()
+        coordinator
+            .ensure_operation_start_allowed()
             .map_err(|error| match error {
-                LeaseRejection::GateClosed { state } => {
+                OperationStartRejection::GateClosed { state } => {
                     GuestOperationStartError::GateClosed { state }
                 }
             })?;
@@ -777,7 +747,7 @@ impl FirecrackerSandbox {
             state => return Err(GuestOperationStartError::NotRunning { state }),
         }
 
-        Ok(GuestOperationWriteBoundary::new(lease))
+        Ok(())
     }
 
     fn operation_start_io_error(
@@ -800,13 +770,6 @@ impl FirecrackerSandbox {
         io::Error::other(error)
     }
 
-    fn operation_transition_io_error(
-        operation: SandboxOperation,
-        error: OperationTransitionError,
-    ) -> io::Error {
-        io::Error::other(Self::operation_gate_transition_error(operation, error))
-    }
-
     async fn process_control(
         coordinator: ParkCoordinator,
         state: Arc<AtomicU8>,
@@ -817,42 +780,30 @@ impl FirecrackerSandbox {
         timeout: Duration,
     ) -> io::Result<ProcessControlAck> {
         enum ControlOutcome {
-            Returned(io::Result<vsock_host::ProcessControlOutcome>),
+            Returned(io::Result<vsock_host::ProcessControlAck>),
             BackendCrashed,
         }
 
         let operation = SandboxOperation::ProcessControl;
-        let guest =
-            Self::begin_process_control_boundary(&coordinator, || Self::current_state_from(&state))
-                .map_err(|error| {
-                    Self::operation_start_io_error(
-                        operation,
-                        error,
-                        Self::current_state_from(&state),
-                    )
-                })?;
-        let write_observer = guest.write_observer();
+        Self::begin_process_control(&coordinator, || Self::current_state_from(&state)).map_err(
+            |error| {
+                Self::operation_start_io_error(operation, error, Self::current_state_from(&state))
+            },
+        )?;
 
         let outcome = tokio::select! {
-            result = control.control_with_write_observer(
+            result = control.control(
                 &message_id,
                 &payload,
                 timeout,
-                write_observer,
             ) => ControlOutcome::Returned(result),
             () = wait_for_backend_crash(state_rx) => ControlOutcome::BackendCrashed,
         };
 
         match outcome {
-            ControlOutcome::Returned(Ok(outcome)) => {
-                guest
-                    .complete()
-                    .map_err(|error| Self::operation_transition_io_error(operation, error))?;
-                let ack = outcome.into_ack()?;
-                Ok(ProcessControlAck {
-                    message_id: ack.message_id,
-                })
-            }
+            ControlOutcome::Returned(Ok(ack)) => Ok(ProcessControlAck {
+                message_id: ack.message_id,
+            }),
             ControlOutcome::Returned(Err(error)) => {
                 if Self::current_state_from(&state) == SandboxState::Crashed {
                     return Err(io::Error::other(Self::backend_crashed_error(operation)));
@@ -1186,22 +1137,6 @@ async fn wait_for_backend_crash(mut state_rx: watch::Receiver<SandboxState>) {
     }
 }
 
-fn gated_spawn_exit_future<F>(
-    exit: F,
-    lease: OperationLease,
-) -> Pin<Box<dyn Future<Output = io::Result<ProcessExit>> + Send + 'static>>
-where
-    F: Future<Output = io::Result<ProcessExit>> + Send + 'static,
-{
-    Box::pin(async move {
-        let process_exit = exit.await?;
-        lease
-            .complete()
-            .map_err(|error| io::Error::other(format!("operation gate completion: {error:?}")))?;
-        Ok(process_exit)
-    })
-}
-
 fn state_publish_guard(state_publish_lock: &Mutex<()>) -> MutexGuard<'_, ()> {
     state_publish_lock
         .lock()
@@ -1417,20 +1352,19 @@ impl Sandbox for FirecrackerSandbox {
         *self.guest.lock().await = Some(Arc::new(vsock_guest));
 
         let control_sock_path = self.sock_paths.control_sock();
-        let control_server =
-            match control::bind_server(control_sock_path.clone(), self.guest_operations()) {
-                Ok(server) => server,
-                Err(e) => {
-                    self.guest.lock().await.take();
-                    self.runtime.kill_process().await;
-                    return Err(SandboxError::Start {
-                        message: format!(
-                            "control socket bind {}: {e}",
-                            control_sock_path.display()
-                        ),
-                    });
-                }
-            };
+        let control_server = match control::bind_server(
+            control_sock_path.clone(),
+            self.guest_operation_start_gate(),
+        ) {
+            Ok(server) => server,
+            Err(e) => {
+                self.guest.lock().await.take();
+                self.runtime.kill_process().await;
+                return Err(SandboxError::Start {
+                    message: format!("control socket bind {}: {e}", control_sock_path.display()),
+                });
+            }
+        };
 
         // Use CAS to avoid overwriting Stopped if the process crashed between
         // spawn and vsock connect (the process monitor may have already
@@ -1678,22 +1612,19 @@ impl Sandbox for FirecrackerSandbox {
         let limits = request.output_limits;
         let timeout_ms = request.timeout_ms();
 
-        self.run_bounded_guest_operation(operation, |guest, write_observer| async move {
+        self.run_bounded_guest_operation(operation, |guest| async move {
             guest
-                .exec_capture_with_write_observer(
-                    vsock_host::ExecCaptureRequest {
-                        command: request.cmd,
-                        timeout_ms,
-                        env: request.env,
-                        sudo: request.sudo,
-                        label: "sandbox-exec",
-                        stdout_limit_bytes: limits.stdout_limit_bytes,
-                        stderr_limit_bytes: limits.stderr_limit_bytes,
-                        expected_exit_codes: &[],
-                        wait_timeout: Duration::from_millis(timeout_ms as u64 + 5000),
-                    },
-                    write_observer,
-                )
+                .exec_capture(vsock_host::ExecCaptureRequest {
+                    command: request.cmd,
+                    timeout_ms,
+                    env: request.env,
+                    sudo: request.sudo,
+                    label: "sandbox-exec",
+                    stdout_limit_bytes: limits.stdout_limit_bytes,
+                    stderr_limit_bytes: limits.stderr_limit_bytes,
+                    expected_exit_codes: &[],
+                    wait_timeout: Duration::from_millis(timeout_ms as u64 + 5000),
+                })
                 .await
                 .map(|result| ExecResult {
                     exit_code: result.exit_code,
@@ -1709,10 +1640,8 @@ impl Sandbox for FirecrackerSandbox {
     async fn read_file(&self, path: &str, max_bytes: u64) -> sandbox::Result<Option<Vec<u8>>> {
         let operation = SandboxOperation::Exec;
 
-        self.run_bounded_guest_operation(operation, |guest, write_observer| async move {
-            guest
-                .read_file_with_write_observer(path, max_bytes, 5000, write_observer)
-                .await
+        self.run_bounded_guest_operation(operation, |guest| async move {
+            guest.read_file(path, max_bytes, 5000).await
         })
         .await
     }
@@ -1726,9 +1655,9 @@ impl Sandbox for FirecrackerSandbox {
         let operation = SandboxOperation::Exec;
         let timeout_ms = u32::try_from(options.timeout.as_millis()).unwrap_or(u32::MAX);
 
-        self.run_bounded_guest_operation(operation, |guest, write_observer| async move {
+        self.run_bounded_guest_operation(operation, |guest| async move {
             guest
-                .copy_file_with_write_observer(
+                .copy_file(
                     path,
                     host_path,
                     vsock_host::CopyFileOptions {
@@ -1736,7 +1665,6 @@ impl Sandbox for FirecrackerSandbox {
                         timeout_ms,
                         missing_ok: options.missing_ok,
                     },
-                    write_observer,
                 )
                 .await
                 .map(|result| CopyFileResult {
@@ -1749,10 +1677,8 @@ impl Sandbox for FirecrackerSandbox {
     async fn write_file(&self, path: &str, content: &[u8]) -> sandbox::Result<()> {
         let operation = SandboxOperation::WriteFile;
 
-        self.run_bounded_guest_operation(operation, |guest, write_observer| async move {
-            guest
-                .write_file_with_write_observer(path, content, false, write_observer)
-                .await
+        self.run_bounded_guest_operation(operation, |guest| async move {
+            guest.write_file(path, content, false).await
         })
         .await
     }
@@ -1762,40 +1688,35 @@ impl Sandbox for FirecrackerSandbox {
         request: &SpawnProcessRequest<'_>,
     ) -> sandbox::Result<GuestProcessHandle> {
         let operation = SandboxOperation::SpawnProcess;
-        let guest_operation = self.begin_guest_operation(operation).await?;
-        let vsock = guest_operation.guest();
-        let guest = guest_operation.into_write_boundary();
-        let write_observer = guest.write_observer();
+        let vsock = self.begin_guest_operation(operation).await?;
 
-        let spawn_future: Pin<
-            Box<dyn Future<Output = io::Result<vsock_host::GuestProcessHandle>> + Send + '_>,
-        > = match request.control {
-            SpawnProcessControl::None => {
-                Box::pin(vsock.spawn_process_with_request_and_write_observer(
-                    vsock_host::ProcessSpawnRequest {
-                        command: request.cmd,
-                        timeout_ms: request.timeout_ms(),
-                        env: request.env,
-                        sudo: request.sudo,
-                        stream_stdout: request.output.streams_stdout(),
-                        stdout_log_path: request.output.guest_log_path(),
-                    },
-                    write_observer,
-                ))
+        let spawn_future = async move {
+            match request.control {
+                SpawnProcessControl::None => {
+                    vsock
+                        .spawn_process(
+                            request.cmd,
+                            request.timeout_ms(),
+                            request.env,
+                            request.sudo,
+                            request.output.streams_stdout(),
+                            request.output.guest_log_path(),
+                        )
+                        .await
+                }
+                SpawnProcessControl::Enabled => {
+                    vsock
+                        .spawn_process_with_control_sink(
+                            request.cmd,
+                            request.timeout_ms(),
+                            request.env,
+                            request.sudo,
+                            request.output.streams_stdout(),
+                            request.output.guest_log_path(),
+                        )
+                        .await
+                }
             }
-            SpawnProcessControl::Enabled => Box::pin(
-                vsock.spawn_process_with_control_sink_request_and_write_observer(
-                    vsock_host::ProcessSpawnRequest {
-                        command: request.cmd,
-                        timeout_ms: request.timeout_ms(),
-                        env: request.env,
-                        sudo: request.sudo,
-                        stream_stdout: request.output.streams_stdout(),
-                        stdout_log_path: request.output.guest_log_path(),
-                    },
-                    write_observer,
-                ),
-            ),
         };
 
         tokio::select! {
@@ -1804,14 +1725,7 @@ impl Sandbox for FirecrackerSandbox {
                     Ok(handle) => handle,
                     Err(error) => {
                         let backend_crashed = self.has_backend_crashed();
-                        let is_terminal = guest_error_is_terminal(&error, backend_crashed);
-                        let result = Err(Self::operation_error(operation, error, backend_crashed));
-                        if is_terminal {
-                            guest
-                                .complete_if_write_started()
-                                .map_err(|error| Self::operation_gate_transition_error(operation, error))?;
-                        }
-                        return result;
+                        return Err(Self::operation_error(operation, error, backend_crashed));
                     }
                 };
                 let pid = handle.pid();
@@ -1838,21 +1752,15 @@ impl Sandbox for FirecrackerSandbox {
                     .streams_stdout()
                     .then(|| handle.take_stdout_receiver())
                     .flatten();
-                let lease = guest
-                    .into_in_guest_lease()
-                    .map_err(|error| Self::operation_gate_transition_error(operation, error))?;
-                let exit = gated_spawn_exit_future(
-                    async move {
-                        let event = handle.wait().await?;
-                        Ok(ProcessExit {
-                            pid: event.pid,
-                            exit_code: event.exit_code,
-                            stdout: event.stdout,
-                            stderr: event.stderr,
-                        })
-                    },
-                    lease,
-                );
+                let exit = Box::pin(async move {
+                    let event = handle.wait().await?;
+                    Ok(ProcessExit {
+                        pid: event.pid,
+                        exit_code: event.exit_code,
+                        stdout: event.stdout,
+                        stderr: event.stderr,
+                    })
+                });
                 Ok(GuestProcessHandle::new(pid, stdout_rx, process_control, exit))
             }
             () = wait_for_backend_crash(self.state_tx.subscribe()) => {
@@ -1967,7 +1875,7 @@ impl<Fence> ParkBoundaryGuard<Fence> {
             }
             Err(error) => {
                 let message = format!(
-                    "operation gate failed to mark parked after Firecracker park: {}",
+                    "park policy failed to mark parked after Firecracker park: {}",
                     prepare_park_error_message(&error)
                 );
                 self.coordinator
@@ -2090,7 +1998,7 @@ where
                 PrepareParkError::InvalidState { .. } | PrepareParkError::StaleAttempt { .. }
             ) {
                 coordinator.mark_dirty(DirtyReason::new(format!(
-                    "operation gate failed to start park prepare: {}",
+                    "park policy failed to start park prepare: {}",
                     error_message
                 )));
             }
@@ -2186,7 +2094,7 @@ where
         let reason_kind = prepare_park_error_reason_kind(&error);
         let error_message = prepare_park_error_message(&error);
         let message = format!(
-            "operation gate failed to enter ReadyForPark: {}",
+            "park policy failed to enter ReadyForPark: {}",
             error_message
         );
         warn!(
@@ -2228,7 +2136,7 @@ where
             let reason_kind = prepare_park_error_reason_kind(&error);
             let error_message = prepare_park_error_message(&error);
             let message = format!(
-                "operation gate failed to mark parked after Firecracker park: {}",
+                "park policy failed to mark parked after Firecracker park: {}",
                 error_message
             );
             warn!(
@@ -2333,7 +2241,7 @@ where
         let reason_kind = prepare_park_error_reason_kind(&error);
         let error_message = prepare_park_error_message(&error);
         let message = format!(
-            "operation gate failed to reopen after unpark: {}",
+            "park policy failed to reopen after unpark: {}",
             error_message
         );
         warn!(
@@ -2366,10 +2274,10 @@ fn ensure_parked_before_unpark(coordinator: &ParkCoordinator) -> sandbox::Result
         CoordinatorState::Parked => Ok(()),
         CoordinatorState::Dirty { reason } => Err(idle_transition_error(
             SandboxIdleTransition::Unpark,
-            format!("operation gate dirty while unpark is starting: {reason}"),
+            format!("park policy dirty while unpark is starting: {reason}"),
         )),
         state => {
-            let message = format!("operation gate is {state:?} while unpark is starting");
+            let message = format!("park policy is {state:?} while unpark is starting");
             coordinator.mark_dirty(DirtyReason::new(message.clone()));
             Err(idle_transition_error(
                 SandboxIdleTransition::Unpark,
@@ -2384,10 +2292,10 @@ fn ensure_park_noop_state(coordinator: &ParkCoordinator) -> sandbox::Result<()> 
         CoordinatorState::Parked => Ok(()),
         CoordinatorState::Dirty { reason } => Err(idle_transition_error(
             SandboxIdleTransition::Park,
-            format!("operation gate dirty while park is a no-op: {reason}"),
+            format!("park policy dirty while park is a no-op: {reason}"),
         )),
         state => {
-            let message = format!("operation gate is {state:?} while park is a no-op");
+            let message = format!("park policy is {state:?} while park is a no-op");
             coordinator.mark_dirty(DirtyReason::new(message.clone()));
             Err(idle_transition_error(SandboxIdleTransition::Park, message))
         }
@@ -2399,10 +2307,10 @@ fn ensure_unpark_noop_state(coordinator: &ParkCoordinator) -> sandbox::Result<()
         CoordinatorState::Open => Ok(()),
         CoordinatorState::Dirty { reason } => Err(idle_transition_error(
             SandboxIdleTransition::Unpark,
-            format!("operation gate dirty while unpark is a no-op: {reason}"),
+            format!("park policy dirty while unpark is a no-op: {reason}"),
         )),
         state => {
-            let message = format!("operation gate is {state:?} while unpark is a no-op");
+            let message = format!("park policy is {state:?} while unpark is a no-op");
             coordinator.mark_dirty(DirtyReason::new(message.clone()));
             Err(idle_transition_error(
                 SandboxIdleTransition::Unpark,
@@ -2418,20 +2326,18 @@ fn prepare_park_error(transition: SandboxIdleTransition, error: PrepareParkError
 
 fn prepare_park_error_message(error: &PrepareParkError) -> String {
     match error {
-        PrepareParkError::Busy => "operation gate busy while preparing park".into(),
-        PrepareParkError::Dirty { reason } => format!("operation gate dirty: {reason}"),
+        PrepareParkError::Dirty { reason } => format!("park policy dirty: {reason}"),
         PrepareParkError::InvalidState { state } => {
-            format!("operation gate state {state:?} cannot continue park lifecycle")
+            format!("park policy state {state:?} cannot continue park lifecycle")
         }
         PrepareParkError::StaleAttempt { attempt_id, state } => {
-            format!("stale park attempt {attempt_id:?} while operation gate is {state:?}")
+            format!("stale park attempt {attempt_id:?} while park policy is {state:?}")
         }
     }
 }
 
 fn prepare_park_error_reason_kind(error: &PrepareParkError) -> &'static str {
     match error {
-        PrepareParkError::Busy => "busy",
         PrepareParkError::Dirty { .. } => "dirty",
         PrepareParkError::InvalidState { .. } => "invalid_state",
         PrepareParkError::StaleAttempt { .. } => "stale_attempt",
@@ -2898,10 +2804,10 @@ mod tests {
     }
 
     #[test]
-    fn process_control_boundary_stop_after_reserve_releases_lease() {
+    fn process_control_stop_after_policy_check_keeps_policy_open() {
         let coordinator = ParkCoordinator::new();
 
-        let error = match FirecrackerSandbox::begin_process_control_boundary(
+        let error = match FirecrackerSandbox::begin_process_control(
             &coordinator,
             state_after_first_read(SandboxState::Stopped),
         ) {
@@ -2916,14 +2822,13 @@ mod tests {
             }
         );
         assert_eq!(coordinator.state(), CoordinatorState::Open);
-        assert_eq!(coordinator.active_operation_count(), 0);
     }
 
     #[test]
-    fn process_control_boundary_crash_after_reserve_releases_lease() {
+    fn process_control_crash_after_policy_check_keeps_policy_open() {
         let coordinator = ParkCoordinator::new();
 
-        let error = match FirecrackerSandbox::begin_process_control_boundary(
+        let error = match FirecrackerSandbox::begin_process_control(
             &coordinator,
             state_after_first_read(SandboxState::Crashed),
         ) {
@@ -2933,7 +2838,6 @@ mod tests {
 
         assert_eq!(error, GuestOperationStartError::BackendCrashed);
         assert_eq!(coordinator.state(), CoordinatorState::Open);
-        assert_eq!(coordinator.active_operation_count(), 0);
     }
 
     async fn send_process_control_result(
@@ -3197,13 +3101,6 @@ mod tests {
             SandboxError::Operation { reason, .. } => assert_eq!(reason, expected),
             other => panic!("expected operation error, got {other:?}"),
         }
-    }
-
-    fn active_spawn_process_lease(coordinator: &ParkCoordinator) -> OperationLease {
-        let mut lease = coordinator.reserve_operation().expect("reserve operation");
-        lease.mark_writing().expect("mark writing");
-        lease.mark_in_guest().expect("mark in guest");
-        lease
     }
 
     fn mark_coordinator_parked(coordinator: &ParkCoordinator) {
@@ -3500,33 +3397,6 @@ mod tests {
             coordinator.state(),
             CoordinatorState::Dirty { .. }
         ));
-    }
-
-    #[tokio::test]
-    async fn ready_for_park_boundary_busy_prevents_quiesce_and_pause() {
-        let coordinator = ParkCoordinator::new();
-        let _lease = active_spawn_process_lease(&coordinator);
-        let events = event_log();
-        let quiesce_events = Arc::clone(&events);
-        let park_events = Arc::clone(&events);
-
-        let result = park_with_ready_for_park(
-            "test-sandbox",
-            &coordinator,
-            || async move {
-                quiesce_events.lock().unwrap().push("guest_quiesce");
-                Ok(())
-            },
-            || async move {
-                park_events.lock().unwrap().push("firecracker_park");
-                Ok(())
-            },
-        )
-        .await;
-
-        assert_idle_transition(result, SandboxIdleTransition::Park);
-        assert!(matches!(coordinator.state(), CoordinatorState::Open));
-        assert!(logged_events(&events).is_empty());
     }
 
     #[tokio::test]
@@ -4323,7 +4193,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn process_control_rejects_closed_operation_gate_without_dirtying() {
+    async fn process_control_rejects_closed_policy_gate_without_dirtying() {
         let ProcessControlFixture {
             host: _host,
             handle,
@@ -4354,7 +4224,6 @@ mod tests {
             error.to_string().contains("sandbox operation gate closed"),
             "unexpected error: {error}",
         );
-        assert_eq!(coordinator.active_operation_count(), 0);
         coordinator.abort_prepare_park(&attempt).unwrap();
         assert_eq!(coordinator.state(), CoordinatorState::Open);
 
@@ -4392,7 +4261,6 @@ mod tests {
             "unexpected error: {error}",
         );
         assert_eq!(coordinator.state(), CoordinatorState::Open);
-        assert_eq!(coordinator.active_operation_count(), 0);
 
         send_process_exit(&mut guest, spawn_seq, pid).await;
         handle.wait().await.unwrap();
@@ -4426,7 +4294,6 @@ mod tests {
 
         assert_eq!(error.kind(), io::ErrorKind::InvalidInput);
         assert_eq!(coordinator.state(), CoordinatorState::Open);
-        assert_eq!(coordinator.active_operation_count(), 0);
 
         let control_task = tokio::spawn(FirecrackerSandbox::process_control(
             coordinator.clone(),
@@ -4443,14 +4310,13 @@ mod tests {
         let ack = control_task.await.unwrap().unwrap();
         assert_eq!(ack.message_id, "valid-after-local-failure");
         assert_eq!(coordinator.state(), CoordinatorState::Open);
-        assert_eq!(coordinator.active_operation_count(), 0);
 
         send_process_exit(&mut guest, spawn_seq, pid).await;
         handle.wait().await.unwrap();
     }
 
     #[tokio::test]
-    async fn process_control_guest_status_completes_gate() {
+    async fn process_control_guest_status_keeps_policy_open() {
         let ProcessControlFixture {
             host: _host,
             handle,
@@ -4484,14 +4350,13 @@ mod tests {
         assert_eq!(error.kind(), io::ErrorKind::TimedOut);
         assert_eq!(error.to_string(), "guest sink timed out");
         assert_eq!(coordinator.state(), CoordinatorState::Open);
-        assert_eq!(coordinator.active_operation_count(), 0);
 
         send_process_exit(&mut guest, spawn_seq, pid).await;
         handle.wait().await.unwrap();
     }
 
     #[tokio::test]
-    async fn process_control_guest_error_completes_gate() {
+    async fn process_control_guest_error_keeps_policy_open() {
         let ProcessControlFixture {
             host: _host,
             handle,
@@ -4519,14 +4384,13 @@ mod tests {
         assert_eq!(error.kind(), io::ErrorKind::Other);
         assert_eq!(error.to_string(), "guest rejected control");
         assert_eq!(coordinator.state(), CoordinatorState::Open);
-        assert_eq!(coordinator.active_operation_count(), 0);
 
         send_process_exit(&mut guest, spawn_seq, pid).await;
         handle.wait().await.unwrap();
     }
 
     #[tokio::test]
-    async fn process_control_concurrent_requests_release_gate_leases() {
+    async fn process_control_allows_concurrent_requests_while_policy_open() {
         let ProcessControlFixture {
             host: _host,
             handle,
@@ -4571,7 +4435,6 @@ mod tests {
         ];
         message_ids.sort();
         assert_eq!(message_ids, ["concurrent-a", "concurrent-b"]);
-        assert_eq!(coordinator.active_operation_count(), 2);
 
         send_process_control_result(
             &mut guest,
@@ -4593,14 +4456,13 @@ mod tests {
         assert_eq!(first_ack.message_id, "concurrent-a");
         assert_eq!(second_ack.message_id, "concurrent-b");
         assert_eq!(coordinator.state(), CoordinatorState::Open);
-        assert_eq!(coordinator.active_operation_count(), 0);
 
         send_process_exit(&mut guest, spawn_seq, pid).await;
         handle.wait().await.unwrap();
     }
 
     #[tokio::test]
-    async fn process_control_protocol_error_after_guest_write_marks_gate_dirty() {
+    async fn process_control_protocol_error_after_guest_write_keeps_policy_open() {
         let ProcessControlFixture {
             host: _host,
             handle,
@@ -4632,15 +4494,11 @@ mod tests {
                 .contains("process_control_result target seq mismatch"),
             "unexpected error: {error}",
         );
-        assert!(matches!(
-            coordinator.state(),
-            CoordinatorState::Dirty { .. }
-        ));
-        assert_eq!(coordinator.active_operation_count(), 0);
+        assert_eq!(coordinator.state(), CoordinatorState::Open);
     }
 
     #[tokio::test]
-    async fn process_control_backend_crash_after_guest_write_marks_gate_dirty() {
+    async fn process_control_backend_crash_after_guest_write_keeps_policy_open() {
         let ProcessControlFixture {
             host: _host,
             handle,
@@ -4676,18 +4534,14 @@ mod tests {
             error.to_string().contains("firecracker process crashed"),
             "unexpected error: {error}",
         );
-        assert!(matches!(
-            coordinator.state(),
-            CoordinatorState::Dirty { .. }
-        ));
-        assert_eq!(coordinator.active_operation_count(), 0);
+        assert_eq!(coordinator.state(), CoordinatorState::Open);
 
         send_process_exit(&mut guest, spawn_seq, pid).await;
         handle.wait().await.unwrap();
     }
 
     #[tokio::test]
-    async fn process_control_timeout_after_guest_write_marks_gate_dirty() {
+    async fn process_control_timeout_after_guest_write_keeps_policy_open() {
         let ProcessControlFixture {
             host: _host,
             handle,
@@ -4717,90 +4571,10 @@ mod tests {
             .unwrap()
             .unwrap_err();
         assert_eq!(error.kind(), io::ErrorKind::TimedOut);
-        assert!(matches!(
-            coordinator.state(),
-            CoordinatorState::Dirty { .. }
-        ));
-        assert_eq!(coordinator.active_operation_count(), 0);
+        assert_eq!(coordinator.state(), CoordinatorState::Open);
 
         send_process_exit(&mut guest, spawn_seq, pid).await;
         handle.wait().await.unwrap();
-    }
-
-    #[tokio::test]
-    async fn gated_spawn_exit_future_completes_lease_on_process_exit() {
-        let coordinator = ParkCoordinator::new();
-        let lease = active_spawn_process_lease(&coordinator);
-        let exit = gated_spawn_exit_future(
-            async {
-                Ok(ProcessExit {
-                    pid: 42,
-                    exit_code: 0,
-                    stdout: Vec::new(),
-                    stderr: Vec::new(),
-                })
-            },
-            lease,
-        );
-
-        assert!(matches!(
-            coordinator.begin_prepare_park(),
-            Err(PrepareParkError::Busy)
-        ));
-
-        let result = exit.await.expect("process exit should complete");
-        assert_eq!(result.pid, 42);
-
-        let attempt = coordinator
-            .begin_prepare_park()
-            .expect("completed spawn_process lease should allow prepare");
-        coordinator.abort_prepare_park(&attempt).unwrap();
-    }
-
-    #[test]
-    fn dropped_gated_spawn_exit_future_marks_dirty() {
-        let coordinator = ParkCoordinator::new();
-        let lease = active_spawn_process_lease(&coordinator);
-        let exit =
-            gated_spawn_exit_future(std::future::pending::<io::Result<ProcessExit>>(), lease);
-
-        drop(exit);
-
-        assert!(matches!(
-            coordinator.state(),
-            CoordinatorState::Dirty { .. }
-        ));
-        assert_eq!(
-            coordinator.active_operation_count(),
-            0,
-            "dropped spawn exit future should not leave an active operation"
-        );
-    }
-
-    #[tokio::test]
-    async fn gated_spawn_exit_future_error_marks_dirty() {
-        let coordinator = ParkCoordinator::new();
-        let lease = active_spawn_process_lease(&coordinator);
-        let exit = gated_spawn_exit_future(
-            async { Err(io::Error::new(io::ErrorKind::ConnectionReset, "closed")) },
-            lease,
-        );
-
-        let error = match exit.await {
-            Ok(_) => panic!("expected spawn exit error"),
-            Err(error) => error,
-        };
-
-        assert_eq!(error.kind(), io::ErrorKind::ConnectionReset);
-        assert!(matches!(
-            coordinator.state(),
-            CoordinatorState::Dirty { .. }
-        ));
-        assert_eq!(
-            coordinator.active_operation_count(),
-            0,
-            "failed spawn exit future should not leave an active operation"
-        );
     }
 
     /// Exercise the `monitor_process` crash detection flow through real child
@@ -4853,7 +4627,7 @@ mod tests {
         let runtime_cancel = CancellationToken::new();
         let mut control = crate::control::bind_server(
             sock_path.clone(),
-            GuestOperationGate::new(Arc::clone(&guest), ParkCoordinator::new()),
+            GuestOperationStartGate::new(Arc::clone(&guest), ParkCoordinator::new()),
         )
         .unwrap()
         .spawn(runtime_cancel.clone());

--- a/crates/vsock-host/src/process.rs
+++ b/crates/vsock-host/src/process.rs
@@ -394,7 +394,7 @@ impl GuestProcessControlHandle {
     /// Send a control payload and report the exact guest terminal outcome.
     ///
     /// The `write_observer` fires immediately before the request frame is
-    /// written. Callers that gate sandbox reuse use this boundary to distinguish
+    /// written. Tests and diagnostics can use this boundary to distinguish
     /// pre-write validation failures from post-write uncertainty.
     pub async fn control_with_write_observer(
         &self,


### PR DESCRIPTION
## Summary
- shrink ParkCoordinator to park policy and start-admission state only
- replace GuestOperationGate with policy-only GuestOperationStartGate
- route sandbox/control operations through tracked vsock-host APIs without sandbox-side write observers or lease completion

Closes #13459

## Tests
- CARGO_BUILD_JOBS=1 cargo test --manifest-path crates/Cargo.toml -p sandbox-fc
- CARGO_BUILD_JOBS=1 cargo test --manifest-path crates/Cargo.toml -p vsock-host
- CARGO_BUILD_JOBS=1 cargo clippy --manifest-path crates/Cargo.toml -p sandbox-fc -p vsock-host --all-targets -- -D warnings