### PR TITLE
fix: enforce api start time milliseconds

### DIFF
--- a/crates/guest-agent/src/env.rs
+++ b/crates/guest-agent/src/env.rs
@@ -265,8 +265,8 @@ pub fn vercel_bypass() -> &'static str {
 pub fn resume_session_id() -> &'static str {
     &RESUME_SESSION_ID
 }
-/// Runner-provided API start timestamp from `VM0_API_START_TIME`; empty string
-/// means unset.
+/// Runner-provided Unix epoch millisecond API start timestamp from
+/// `VM0_API_START_TIME`; empty string means unset.
 pub fn api_start_time() -> &'static str {
     &API_START_TIME
 }

--- a/crates/guest-agent/src/timing.rs
+++ b/crates/guest-agent/src/timing.rs
@@ -3,21 +3,77 @@
 use crate::env;
 use guest_common::log_info;
 use guest_common::telemetry::record_sandbox_op;
+use std::time::{Duration, SystemTime};
 
 const LOG_TAG: &str = "sandbox:guest-agent";
+const MIN_PLAUSIBLE_API_START_TIME_MS: u64 = 1_000_000_000_000;
 
 /// Record an E2E duration from `VM0_API_START_TIME` to now under `op_name`.
 pub fn record_e2e_from_api(op_name: &str) {
-    let api_start = env::api_start_time();
-    if !api_start.is_empty()
-        && let Ok(api_ms) = api_start.parse::<u64>()
-    {
-        let now_ms = std::time::SystemTime::now()
-            .duration_since(std::time::SystemTime::UNIX_EPOCH)
-            .map(|d| d.as_millis() as u64)
-            .unwrap_or(0);
-        let e2e = now_ms.saturating_sub(api_ms);
-        record_sandbox_op(op_name, std::time::Duration::from_millis(e2e), true, None);
-        log_info!(LOG_TAG, "E2E {op_name}: {e2e}ms");
+    let now_ms = current_epoch_ms();
+    if let Some(duration) = e2e_duration_from_api_start(env::api_start_time(), now_ms) {
+        record_sandbox_op(op_name, duration, true, None);
+        log_info!(LOG_TAG, "E2E {op_name}: {}ms", duration.as_millis());
+    }
+}
+
+fn current_epoch_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+fn e2e_duration_from_api_start(api_start: &str, now_ms: u64) -> Option<Duration> {
+    let api_start_ms = parse_api_start_time_ms(api_start)?;
+    Some(Duration::from_millis(now_ms.saturating_sub(api_start_ms)))
+}
+
+fn parse_api_start_time_ms(api_start: &str) -> Option<u64> {
+    let api_start_ms = api_start.parse::<u64>().ok()?;
+    if api_start_ms < MIN_PLAUSIBLE_API_START_TIME_MS {
+        return None;
+    }
+
+    Some(api_start_ms)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn e2e_duration_from_api_start_returns_elapsed_duration() {
+        let duration = e2e_duration_from_api_start("1700000000000", 1_700_000_001_250);
+
+        assert_eq!(duration, Some(Duration::from_millis(1_250)));
+    }
+
+    #[test]
+    fn e2e_duration_from_api_start_clamps_future_start_to_zero() {
+        let duration = e2e_duration_from_api_start("1700000001250", 1_700_000_000_000);
+
+        assert_eq!(duration, Some(Duration::ZERO));
+    }
+
+    #[test]
+    fn e2e_duration_from_api_start_ignores_empty_input() {
+        let duration = e2e_duration_from_api_start("", 1_700_000_001_250);
+
+        assert_eq!(duration, None);
+    }
+
+    #[test]
+    fn e2e_duration_from_api_start_ignores_non_numeric_input() {
+        let duration = e2e_duration_from_api_start("not-a-timestamp", 1_700_000_001_250);
+
+        assert_eq!(duration, None);
+    }
+
+    #[test]
+    fn e2e_duration_from_api_start_ignores_seconds_shaped_input() {
+        let duration = e2e_duration_from_api_start("1700000000", 1_700_000_001_250);
+
+        assert_eq!(duration, None);
     }
 }

--- a/crates/guest-agent/src/timing.rs
+++ b/crates/guest-agent/src/timing.rs
@@ -1,20 +1,36 @@
 //! E2E timing helpers — measure durations from API start time.
 
 use crate::env;
-use guest_common::log_info;
 use guest_common::telemetry::record_sandbox_op;
+use guest_common::{log_info, log_warn};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, SystemTime};
 
 const LOG_TAG: &str = "sandbox:guest-agent";
-const MIN_PLAUSIBLE_API_START_TIME_MS: u64 = 1_000_000_000_000;
+const MIN_EPOCH_MS_TIMESTAMP: u64 = 1_000_000_000_000;
+static INVALID_API_START_TIME_WARNED: AtomicBool = AtomicBool::new(false);
 
 /// Record an E2E duration from `VM0_API_START_TIME` to now under `op_name`.
 pub fn record_e2e_from_api(op_name: &str) {
     let now_ms = current_epoch_ms();
-    if let Some(duration) = e2e_duration_from_api_start(env::api_start_time(), now_ms) {
+    let api_start = env::api_start_time();
+    if let Some(duration) = e2e_duration_from_api_start(api_start, now_ms) {
         record_sandbox_op(op_name, duration, true, None);
         log_info!(LOG_TAG, "E2E {op_name}: {}ms", duration.as_millis());
+    } else if !api_start.is_empty() {
+        warn_invalid_api_start_time_once(op_name, api_start);
     }
+}
+
+fn warn_invalid_api_start_time_once(op_name: &str, api_start: &str) {
+    if INVALID_API_START_TIME_WARNED.swap(true, Ordering::Relaxed) {
+        return;
+    }
+
+    log_warn!(
+        LOG_TAG,
+        "Skipping E2E {op_name}: invalid VM0_API_START_TIME={api_start:?}; expected Unix epoch milliseconds"
+    );
 }
 
 fn current_epoch_ms() -> u64 {
@@ -31,7 +47,7 @@ fn e2e_duration_from_api_start(api_start: &str, now_ms: u64) -> Option<Duration>
 
 fn parse_api_start_time_ms(api_start: &str) -> Option<u64> {
     let api_start_ms = api_start.parse::<u64>().ok()?;
-    if api_start_ms < MIN_PLAUSIBLE_API_START_TIME_MS {
+    if api_start_ms < MIN_EPOCH_MS_TIMESTAMP {
         return None;
     }
 

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -16,6 +16,7 @@
 
 use std::collections::HashMap;
 use std::panic::AssertUnwindSafe;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant};
 
 use agent_diagnostics::{
@@ -42,7 +43,8 @@ const EXIT_SIGNAL_KILL: i32 = 9;
 const DEFAULT_EXEC_TIMEOUT: Duration = Duration::from_secs(300);
 const SMALL_GUEST_FILE_MAX_BYTES: u64 = 64 * 1024;
 const GUEST_LOG_COPY_MAX_BYTES: u64 = 64 * 1024 * 1024;
-const MIN_PLAUSIBLE_API_START_TIME_MS: u64 = 1_000_000_000_000;
+const MIN_EPOCH_MS_TIMESTAMP: u64 = 1_000_000_000_000;
+static INVALID_API_START_TIME_WARNED: AtomicBool = AtomicBool::new(false);
 
 use crate::error::{RunnerError, RunnerResult};
 use crate::host_env::RUNNER_CONCURRENCY_FACTOR_ENV;
@@ -292,12 +294,32 @@ fn record_api_latency(action_type: &str, context: &ExecutionContext, telemetry: 
         let now_ms = chrono::Utc::now().timestamp_millis().max(0) as u64;
         if let Some(duration) = elapsed_since_api_start_ms(api_start_ms, now_ms) {
             telemetry.record(action_type, duration, true, None);
+        } else {
+            warn_invalid_api_start_time_once(action_type, context, api_start_ms);
         }
     }
 }
 
+fn warn_invalid_api_start_time_once(
+    action_type: &str,
+    context: &ExecutionContext,
+    api_start_ms: u64,
+) {
+    if INVALID_API_START_TIME_WARNED.swap(true, Ordering::Relaxed) {
+        return;
+    }
+
+    warn!(
+        run_id = %context.run_id,
+        api_start_ms,
+        min_epoch_ms_timestamp = MIN_EPOCH_MS_TIMESTAMP,
+        action_type,
+        "skipping API latency telemetry for invalid epoch-ms start timestamp"
+    );
+}
+
 fn elapsed_since_api_start_ms(api_start_ms: u64, now_ms: u64) -> Option<Duration> {
-    if api_start_ms < MIN_PLAUSIBLE_API_START_TIME_MS {
+    if api_start_ms < MIN_EPOCH_MS_TIMESTAMP {
         return None;
     }
 

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -42,6 +42,7 @@ const EXIT_SIGNAL_KILL: i32 = 9;
 const DEFAULT_EXEC_TIMEOUT: Duration = Duration::from_secs(300);
 const SMALL_GUEST_FILE_MAX_BYTES: u64 = 64 * 1024;
 const GUEST_LOG_COPY_MAX_BYTES: u64 = 64 * 1024 * 1024;
+const MIN_PLAUSIBLE_API_START_TIME_MS: u64 = 1_000_000_000_000;
 
 use crate::error::{RunnerError, RunnerResult};
 use crate::host_env::RUNNER_CONCURRENCY_FACTOR_ENV;
@@ -288,15 +289,19 @@ fn record_reuse_result(telemetry: &mut JobTelemetry, result: SandboxReuseResult)
 
 fn record_api_latency(action_type: &str, context: &ExecutionContext, telemetry: &mut JobTelemetry) {
     if let Some(api_start_ms) = context.api_start_time {
-        let now_ms = chrono::Utc::now().timestamp_millis() as f64;
-        let elapsed_ms = (now_ms - api_start_ms).max(0.0);
-        telemetry.record(
-            action_type,
-            Duration::from_millis(elapsed_ms as u64),
-            true,
-            None,
-        );
+        let now_ms = chrono::Utc::now().timestamp_millis().max(0) as u64;
+        if let Some(duration) = elapsed_since_api_start_ms(api_start_ms, now_ms) {
+            telemetry.record(action_type, duration, true, None);
+        }
     }
+}
+
+fn elapsed_since_api_start_ms(api_start_ms: u64, now_ms: u64) -> Option<Duration> {
+    if api_start_ms < MIN_PLAUSIBLE_API_START_TIME_MS {
+        return None;
+    }
+
+    Some(Duration::from_millis(now_ms.saturating_sub(api_start_ms)))
 }
 
 /// Dispatch inputs for the fresh-create path. Holds the UUID for the new VM
@@ -1487,7 +1492,7 @@ fn build_env_json_with_host_env(
         "VM0_API_START_TIME".into(),
         context
             .api_start_time
-            .map(|t| (t as u64).to_string())
+            .map(|t| t.to_string())
             .unwrap_or_default(),
     );
     // The API omits cli_agent_type for claude-code agents (the default).
@@ -2176,10 +2181,31 @@ mod tests {
     #[test]
     fn build_env_json_with_api_start_time() {
         let mut ctx = minimal_context();
-        ctx.api_start_time = Some(1_700_000_000.5);
+        ctx.api_start_time = Some(1_700_000_000_500);
 
         let env = build_env_for_test(&ctx, "http://localhost");
-        assert_eq!(env.get("VM0_API_START_TIME").unwrap(), "1700000000");
+        assert_eq!(env.get("VM0_API_START_TIME").unwrap(), "1700000000500");
+    }
+
+    #[test]
+    fn elapsed_since_api_start_ms_returns_elapsed_duration() {
+        let duration = elapsed_since_api_start_ms(1_700_000_000_000, 1_700_000_001_250);
+
+        assert_eq!(duration, Some(Duration::from_millis(1_250)));
+    }
+
+    #[test]
+    fn elapsed_since_api_start_ms_clamps_future_start_to_zero() {
+        let duration = elapsed_since_api_start_ms(1_700_000_001_250, 1_700_000_000_000);
+
+        assert_eq!(duration, Some(Duration::ZERO));
+    }
+
+    #[test]
+    fn elapsed_since_api_start_ms_rejects_seconds_shaped_start() {
+        let duration = elapsed_since_api_start_ms(1_700_000_000, 1_700_000_001_250);
+
+        assert_eq!(duration, None);
     }
 
     #[test]

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -28,7 +28,7 @@ pub struct Job {
 
 // ---------------------------------------------------------------------------
 // Claim (execution context)
-// Keep in sync with TS: packages/core/src/contracts/runners.ts → executionContextSchema
+// Keep in sync with TS: turbo/packages/api-contracts/src/contracts/runners.ts → executionContextSchema
 // ---------------------------------------------------------------------------
 
 #[derive(Debug, Deserialize)]
@@ -74,7 +74,7 @@ pub struct ExecutionContext {
     #[serde(default)]
     pub debug_no_mock_codex: Option<bool>,
     #[serde(default)]
-    pub api_start_time: Option<f64>,
+    pub api_start_time: Option<u64>,
     #[serde(default)]
     pub user_timezone: Option<String>,
     #[serde(default)]
@@ -445,7 +445,7 @@ mod tests {
             },
             "debugNoMockClaude": true,
             "debugNoMockCodex": true,
-            "apiStartTime": 1700000000000.0,
+            "apiStartTime": 1_700_000_000_000u64,
             "userTimezone": "America/New_York",
             "firewalls": [{
                 "name": "github",
@@ -473,6 +473,7 @@ mod tests {
         );
         assert!(ctx.debug_no_mock_claude.unwrap());
         assert!(ctx.debug_no_mock_codex.unwrap());
+        assert_eq!(ctx.api_start_time, Some(1_700_000_000_000));
         assert_eq!(ctx.firewalls.as_ref().unwrap()[0].name, "github");
         assert_eq!(ctx.disallowed_tools.as_ref().unwrap(), &["CronCreate"]);
         assert_eq!(ctx.tools.as_ref().unwrap(), &["Bash", "Read"]);

--- a/turbo/apps/api/src/signals/routes/runners.ts
+++ b/turbo/apps/api/src/signals/routes/runners.ts
@@ -1,5 +1,6 @@
 import { command } from "ccstate";
 import {
+  elapsedSinceApiStartMs,
   runnersHeartbeatContract,
   runnersJobClaimContract,
   runnersPollContract,
@@ -416,11 +417,15 @@ const claimInner$ = command(async ({ get, set }, signal: AbortSignal) => {
 
   const sandboxToken = generateSandboxToken(run.userId, run.id, run.orgId);
 
-  if (storedContext.apiStartTime) {
+  const apiToClaimMs = elapsedSinceApiStartMs(
+    storedContext.apiStartTime,
+    currentTime,
+  );
+  if (apiToClaimMs !== undefined) {
     recordSandboxOperation({
       sandboxType: "runner",
       actionType: "api_to_claim",
-      durationMs: currentTime - storedContext.apiStartTime,
+      durationMs: apiToClaimMs,
       success: true,
       runId,
     });

--- a/turbo/apps/web/app/api/runners/jobs/[id]/claim/route.ts
+++ b/turbo/apps/web/app/api/runners/jobs/[id]/claim/route.ts
@@ -4,6 +4,7 @@ import {
   TsRestResponse,
 } from "../../../../../../src/lib/ts-rest-handler";
 import {
+  elapsedSinceApiStartMs,
   runnersJobClaimContract,
   type StoredExecutionContext,
 } from "@vm0/api-contracts/contracts/runners";
@@ -150,11 +151,15 @@ const router = tsr.router(runnersJobClaimContract, {
     );
 
     // Record api_to_claim metric
-    if (storedContext.apiStartTime) {
+    const apiToClaimMs = elapsedSinceApiStartMs(
+      storedContext.apiStartTime,
+      now.getTime(),
+    );
+    if (apiToClaimMs !== undefined) {
       recordSandboxOperation({
         sandboxType: "runner",
         actionType: "api_to_claim",
-        durationMs: now.getTime() - storedContext.apiStartTime,
+        durationMs: apiToClaimMs,
         success: true,
         runId,
       });

--- a/turbo/apps/web/src/lib/infra/run/executors/runner-executor.ts
+++ b/turbo/apps/web/src/lib/infra/run/executors/runner-executor.ts
@@ -1,5 +1,6 @@
 import {
   DEFAULT_PROFILE,
+  elapsedSinceApiStartMs,
   type StoredExecutionContext,
 } from "@vm0/api-contracts/contracts/runners";
 import type { Firewalls } from "@vm0/connectors/firewall-types";
@@ -52,16 +53,22 @@ export async function executeRunnerJob(
   // Record api_to_dispatch metric. was_queued distinguishes runs that came
   // through the org queue (apiStartTime was reset at dequeue) from direct
   // dispatch, so latency queries can slice by dispatch path.
-  recordSandboxOperation({
-    sandboxType: "runner",
-    actionType: "api_to_executor",
-    durationMs: Date.now() - context.apiStartTime,
-    success: true,
-    runId: context.runId,
-    dimensions: {
-      was_queued: context.wasQueued,
-    },
-  });
+  const apiToExecutorMs = elapsedSinceApiStartMs(
+    context.apiStartTime,
+    Date.now(),
+  );
+  if (apiToExecutorMs !== undefined) {
+    recordSandboxOperation({
+      sandboxType: "runner",
+      actionType: "api_to_executor",
+      durationMs: apiToExecutorMs,
+      success: true,
+      runId: context.runId,
+      dimensions: {
+        was_queued: context.wasQueued,
+      },
+    });
+  }
 
   const runnerGroup = context.runnerGroup;
   const profile = context.experimentalProfile ?? DEFAULT_PROFILE;

--- a/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
@@ -136,6 +136,18 @@ describe("runner apiStartTime contract", () => {
     ).toBe(false);
   });
 
+  it("rejects seconds-shaped timestamps", () => {
+    const timestamp = 1_700_000_000;
+
+    expect(
+      storedExecutionContextSchema.shape.apiStartTime.safeParse(timestamp)
+        .success,
+    ).toBe(false);
+    expect(
+      executionContextSchema.shape.apiStartTime.safeParse(timestamp).success,
+    ).toBe(false);
+  });
+
   it("computes elapsed milliseconds for valid apiStartTime values", () => {
     expect(elapsedSinceApiStartMs(1_700_000_000_000, 1_700_000_001_250)).toBe(
       1_250,

--- a/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 
-import { storageManifestSchema } from "../runners";
+import {
+  elapsedSinceApiStartMs,
+  executionContextSchema,
+  storageManifestSchema,
+  storedExecutionContextSchema,
+} from "../runners";
 
 describe("runner storage manifest contract", () => {
   it("accepts the web-produced claim manifest shape", () => {
@@ -94,5 +99,64 @@ describe("runner storage manifest contract", () => {
       ],
       artifacts: [],
     });
+  });
+});
+
+describe("runner apiStartTime contract", () => {
+  it("accepts Unix epoch millisecond integers", () => {
+    const timestamp = 1_700_000_000_000;
+
+    expect(
+      storedExecutionContextSchema.shape.apiStartTime.safeParse(timestamp)
+        .success,
+    ).toBe(true);
+    expect(
+      executionContextSchema.shape.apiStartTime.safeParse(timestamp).success,
+    ).toBe(true);
+  });
+
+  it("rejects fractional timestamps", () => {
+    const timestamp = 1_700_000_000_000.5;
+
+    expect(
+      storedExecutionContextSchema.shape.apiStartTime.safeParse(timestamp)
+        .success,
+    ).toBe(false);
+    expect(
+      executionContextSchema.shape.apiStartTime.safeParse(timestamp).success,
+    ).toBe(false);
+  });
+
+  it("rejects negative timestamps", () => {
+    expect(
+      storedExecutionContextSchema.shape.apiStartTime.safeParse(-1).success,
+    ).toBe(false);
+    expect(
+      executionContextSchema.shape.apiStartTime.safeParse(-1).success,
+    ).toBe(false);
+  });
+
+  it("computes elapsed milliseconds for valid apiStartTime values", () => {
+    expect(elapsedSinceApiStartMs(1_700_000_000_000, 1_700_000_001_250)).toBe(
+      1_250,
+    );
+  });
+
+  it("clamps future apiStartTime values to zero elapsed milliseconds", () => {
+    expect(elapsedSinceApiStartMs(1_700_000_001_250, 1_700_000_000_000)).toBe(
+      0,
+    );
+  });
+
+  it("skips seconds-shaped apiStartTime values", () => {
+    expect(elapsedSinceApiStartMs(1_700_000_000, 1_700_000_001_250)).toBe(
+      undefined,
+    );
+  });
+
+  it("skips fractional apiStartTime values", () => {
+    expect(elapsedSinceApiStartMs(1_700_000_000_000.5, 1_700_000_001_250)).toBe(
+      undefined,
+    );
   });
 });

--- a/turbo/packages/api-contracts/src/contracts/runners.ts
+++ b/turbo/packages/api-contracts/src/contracts/runners.ts
@@ -8,6 +8,24 @@ import { apiErrorSchema } from "./errors";
 
 const c = initContract();
 
+export const MIN_PLAUSIBLE_API_START_TIME_MS = 1_000_000_000_000;
+const apiStartTimeSchema = z.number().int().nonnegative();
+
+export function elapsedSinceApiStartMs(
+  apiStartTimeMs: number | undefined,
+  nowMs: number,
+): number | undefined {
+  if (
+    apiStartTimeMs === undefined ||
+    !Number.isInteger(apiStartTimeMs) ||
+    apiStartTimeMs < MIN_PLAUSIBLE_API_START_TIME_MS
+  ) {
+    return undefined;
+  }
+
+  return Math.max(0, nowMs - apiStartTimeMs);
+}
+
 /**
  * Default profile when none is specified.
  * Must stay in sync with Rust: crates/runner/src/profile.rs → DEFAULT_PROFILE
@@ -141,8 +159,8 @@ export const storedExecutionContextSchema = z.object({
   debugNoMockCodex: z.boolean().optional(),
   // Capture HTTP request headers, request bodies, and response bodies in network logs
   captureNetworkBodies: z.boolean().optional(),
-  // Dispatch timestamp for E2E timing metrics
-  apiStartTime: z.number().optional(),
+  // Dispatch timestamp for E2E timing metrics, as Unix epoch milliseconds
+  apiStartTime: apiStartTimeSchema.optional(),
   // User's timezone preference (IANA format, e.g., "Asia/Shanghai")
   userTimezone: z.string().optional(),
   // Firewall for proxy-side token replacement (complete config, all permissions)
@@ -197,8 +215,8 @@ export const executionContextSchema = z.object({
   debugNoMockCodex: z.boolean().optional(),
   // Capture HTTP request headers, request bodies, and response bodies in network logs
   captureNetworkBodies: z.boolean().optional(),
-  // Dispatch timestamp for E2E timing metrics
-  apiStartTime: z.number().optional(),
+  // Dispatch timestamp for E2E timing metrics, as Unix epoch milliseconds
+  apiStartTime: apiStartTimeSchema.optional(),
   // User's timezone preference (IANA format, e.g., "Asia/Shanghai")
   userTimezone: z.string().optional(),
   // Firewall for proxy-side token replacement (complete config, all permissions)

--- a/turbo/packages/api-contracts/src/contracts/runners.ts
+++ b/turbo/packages/api-contracts/src/contracts/runners.ts
@@ -9,7 +9,10 @@ import { apiErrorSchema } from "./errors";
 const c = initContract();
 
 export const MIN_PLAUSIBLE_API_START_TIME_MS = 1_000_000_000_000;
-const apiStartTimeSchema = z.number().int().nonnegative();
+const apiStartTimeSchema = z
+  .number()
+  .int()
+  .min(MIN_PLAUSIBLE_API_START_TIME_MS);
 
 export function elapsedSinceApiStartMs(
   apiStartTimeMs: number | undefined,

--- a/turbo/packages/api-contracts/src/contracts/runners.ts
+++ b/turbo/packages/api-contracts/src/contracts/runners.ts
@@ -8,11 +8,8 @@ import { apiErrorSchema } from "./errors";
 
 const c = initContract();
 
-export const MIN_PLAUSIBLE_API_START_TIME_MS = 1_000_000_000_000;
-const apiStartTimeSchema = z
-  .number()
-  .int()
-  .min(MIN_PLAUSIBLE_API_START_TIME_MS);
+export const MIN_EPOCH_MS_TIMESTAMP = 1_000_000_000_000;
+const apiStartTimeSchema = z.number().int().min(MIN_EPOCH_MS_TIMESTAMP);
 
 export function elapsedSinceApiStartMs(
   apiStartTimeMs: number | undefined,
@@ -21,7 +18,7 @@ export function elapsedSinceApiStartMs(
   if (
     apiStartTimeMs === undefined ||
     !Number.isInteger(apiStartTimeMs) ||
-    apiStartTimeMs < MIN_PLAUSIBLE_API_START_TIME_MS
+    apiStartTimeMs < MIN_EPOCH_MS_TIMESTAMP
   ) {
     return undefined;
   }


### PR DESCRIPTION
## Summary
- define apiStartTime / VM0_API_START_TIME as epoch milliseconds across TS contracts, runner, and guest-agent
- skip implausible seconds-shaped timestamps before recording API-to-runner/guest telemetry
- add deterministic regression tests for contract validation and elapsed-duration helpers

Fixes #13909

## Tests
- cargo test --manifest-path crates/Cargo.toml -p runner api_start_time
- cargo test --manifest-path crates/Cargo.toml -p runner elapsed_since_api_start_ms
- cargo test --manifest-path crates/Cargo.toml -p runner types::tests::execution_context_all_optional_fields
- cargo test --manifest-path crates/Cargo.toml -p runner
- CARGO_BUILD_JOBS=1 cargo test --manifest-path crates/Cargo.toml -p guest-agent --lib timing
- CARGO_BUILD_JOBS=1 cargo test --manifest-path crates/Cargo.toml -p guest-agent -j 1
- cargo clippy --manifest-path crates/Cargo.toml -p runner -p guest-agent --all-targets --all-features -- -D warnings
- cargo fmt --manifest-path crates/Cargo.toml --all --check
- pnpm -F @vm0/api-contracts test -- src/contracts/__tests__/runners.test.ts
- pnpm -F @vm0/api-contracts check-types
- pnpm -F @vm0/api-contracts lint
- pnpm -F api exec vitest run src/signals/routes/__tests__/runners.test.ts
- pnpm -F web exec vitest run app/api/runners/jobs/[id]/claim/__tests__/route.test.ts
- pnpm -F api check-types
- pnpm -F web check-types
- pnpm -F api lint
- pnpm -F web lint
- pnpm knip --cache
- pre-commit hook: passed (cargo fmt/doc/clippy, prettier, knip, full turbo check-types)