### PR TITLE
fix: reject malformed firecracker netns names

### DIFF
--- a/crates/runner/src/cmd/doctor.rs
+++ b/crates/runner/src/cmd/doctor.rs
@@ -988,14 +988,7 @@ async fn detect_orphan_namespaces() -> Vec<Warning> {
     };
 
     for line in output.lines() {
-        // ip netns list output: "vm0-ns-00-0a (id: 42)" or just "vm0-ns-00-0a"
-        let ns_name = line.split_whitespace().next().unwrap_or("");
-        if !ns_name.starts_with("vm0-ns-") {
-            continue;
-        }
-
-        // Extract pool index from name: vm0-ns-{pool_idx}-{ns_idx}
-        if let Some(pool_idx) = parse_pool_index(ns_name) {
+        if let Some((ns_name, pool_idx)) = parse_netns_list_line(line) {
             let lock_path = format!("/var/lock/vm0-netns-pool-{pool_idx}.lock");
             if is_lock_free(&lock_path).await {
                 warnings.push(Warning::OrphanNamespace {
@@ -1007,6 +1000,14 @@ async fn detect_orphan_namespaces() -> Vec<Warning> {
     }
 
     warnings
+}
+
+/// Parse `ip netns list` output line and return the namespace plus pool index.
+fn parse_netns_list_line(line: &str) -> Option<(&str, u32)> {
+    // ip netns list output: "vm0-ns-00-0a (id: 42)" or just "vm0-ns-00-0a"
+    let ns_name = line.split_whitespace().next()?;
+    let parsed = sandbox_fc::parse_netns_name(ns_name)?;
+    Some((ns_name, parsed.pool_index))
 }
 
 /// Scan for NBD devices whose owning process has exited without disconnecting.
@@ -1023,13 +1024,6 @@ async fn detect_nbd_orphans() -> Vec<Warning> {
         .into_iter()
         .map(|(device_index, pid)| Warning::OrphanNbdDevice { device_index, pid })
         .collect()
-}
-
-/// Parse pool index from namespace name: `vm0-ns-{XX}-{XX}` → pool_idx as u32.
-fn parse_pool_index(ns_name: &str) -> Option<u32> {
-    let rest = ns_name.strip_prefix("vm0-ns-")?;
-    let pool_hex = rest.split('-').next()?;
-    u32::from_str_radix(pool_hex, 16).ok()
 }
 
 /// Try non-blocking flock to check if a lock file is free (not held by anyone).
@@ -1251,17 +1245,26 @@ mod tests {
     }
 
     #[test]
-    fn parse_pool_index_valid() {
-        assert_eq!(parse_pool_index("vm0-ns-00-0a"), Some(0));
-        assert_eq!(parse_pool_index("vm0-ns-3f-ff"), Some(63));
-        assert_eq!(parse_pool_index("vm0-ns-0a-00"), Some(10));
+    fn parse_netns_list_line_valid() {
+        assert_eq!(
+            parse_netns_list_line("vm0-ns-00-0a (id: 42)"),
+            Some(("vm0-ns-00-0a", 0))
+        );
+        assert_eq!(
+            parse_netns_list_line("vm0-ns-3f-ff"),
+            Some(("vm0-ns-3f-ff", 63))
+        );
     }
 
     #[test]
-    fn parse_pool_index_invalid() {
-        assert_eq!(parse_pool_index("not-a-ns"), None);
-        assert_eq!(parse_pool_index("vm0-ns-"), None);
-        assert_eq!(parse_pool_index("vm0-ns-zz-00"), None);
+    fn parse_netns_list_line_ignores_malformed_names() {
+        assert_eq!(parse_netns_list_line("not-a-ns"), None);
+        assert_eq!(parse_netns_list_line("vm0-ns-"), None);
+        assert_eq!(parse_netns_list_line("vm0-ns-00"), None);
+        assert_eq!(parse_netns_list_line("vm0-ns-00-extra"), None);
+        assert_eq!(parse_netns_list_line("vm0-ns-00-zz"), None);
+        assert_eq!(parse_netns_list_line("vm0-ns-00-0a-extra"), None);
+        assert_eq!(parse_netns_list_line("vm0-ns-40-00"), None);
     }
 
     fn status_info(active: Vec<(&str, &str)>, idle_sandboxes: Vec<&str>) -> StatusInfo {

--- a/crates/runner/src/cmd/doctor.rs
+++ b/crates/runner/src/cmd/doctor.rs
@@ -1258,14 +1258,18 @@ mod tests {
 
     #[test]
     fn parse_netns_list_line_ignores_malformed_names() {
+        assert_eq!(parse_netns_list_line(""), None);
+        assert_eq!(parse_netns_list_line("   "), None);
         assert_eq!(parse_netns_list_line("not-a-ns"), None);
         assert_eq!(parse_netns_list_line("vm0-ns-"), None);
         assert_eq!(parse_netns_list_line("vm0-ns-00"), None);
         assert_eq!(parse_netns_list_line("vm0-ns-00-extra"), None);
         assert_eq!(parse_netns_list_line("vm0-ns-00-zz"), None);
         assert_eq!(parse_netns_list_line("vm0-ns-00-0a-extra"), None);
+        assert_eq!(parse_netns_list_line("vm0-ns-0A-00"), None);
         assert_eq!(parse_netns_list_line("vm0-ns-00-0A"), None);
         assert_eq!(parse_netns_list_line("vm0-ns-40-00"), None);
+        assert_eq!(parse_netns_list_line("vm0-ns-ff-00"), None);
     }
 
     fn status_info(active: Vec<(&str, &str)>, idle_sandboxes: Vec<&str>) -> StatusInfo {

--- a/crates/runner/src/cmd/doctor.rs
+++ b/crates/runner/src/cmd/doctor.rs
@@ -1264,6 +1264,7 @@ mod tests {
         assert_eq!(parse_netns_list_line("vm0-ns-00-extra"), None);
         assert_eq!(parse_netns_list_line("vm0-ns-00-zz"), None);
         assert_eq!(parse_netns_list_line("vm0-ns-00-0a-extra"), None);
+        assert_eq!(parse_netns_list_line("vm0-ns-00-0A"), None);
         assert_eq!(parse_netns_list_line("vm0-ns-40-00"), None);
     }
 

--- a/crates/sandbox-fc/src/lib.rs
+++ b/crates/sandbox-fc/src/lib.rs
@@ -45,7 +45,9 @@ pub use api::{ApiClient, ApiError, BalloonStatistics};
 pub use config::{FirecrackerConfig, SnapshotConfig};
 pub use control::FirecrackerControl;
 pub use factory::{PREWARM_SCRIPT, config_hash};
-pub use network::{NetnsInfo, NetnsLease, NetnsPool, NetnsPoolConfig};
+pub use network::{
+    NetnsInfo, NetnsLease, NetnsPool, NetnsPoolConfig, ParsedNetnsName, parse_netns_name,
+};
 pub use paths::{
     FactoryPaths, LockPaths, RuntimePaths, SandboxPaths, SnapshotOutputPaths, SockPaths,
 };

--- a/crates/sandbox-fc/src/network/mod.rs
+++ b/crates/sandbox-fc/src/network/mod.rs
@@ -5,4 +5,6 @@ mod pool;
 pub(crate) use guest::generate_boot_args;
 pub(crate) use guest::{GUEST_NETWORK, GuestNetwork};
 pub(crate) use pool::NetnsPoolHandle;
-pub use pool::{NetnsInfo, NetnsLease, NetnsPool, NetnsPoolConfig};
+pub use pool::{
+    NetnsInfo, NetnsLease, NetnsPool, NetnsPoolConfig, ParsedNetnsName, parse_netns_name,
+};

--- a/crates/sandbox-fc/src/network/pool.rs
+++ b/crates/sandbox-fc/src/network/pool.rs
@@ -452,12 +452,12 @@ fn generate_veth_ip_pair(pool_idx: u32, ns_idx: u32) -> (String, String) {
 /// Parse a Firecracker network namespace name.
 ///
 /// Returns `None` if the name doesn't match the expected format
-/// `vm0-ns-{XX}-{XX}` where each index is exactly 2 hex characters, or if
-/// either index is outside the supported bounds.
+/// `vm0-ns-{xx}-{xx}` where each index is exactly 2 lowercase hex
+/// characters, or if either index is outside the supported bounds.
 pub fn parse_netns_name(name: &str) -> Option<ParsedNetnsName> {
     let suffix = name.strip_prefix(NS_PREFIX)?;
     let (pool_hex, namespace_hex) = suffix.split_once('-')?;
-    if !is_hex2(pool_hex) || !is_hex2(namespace_hex) {
+    if !is_lower_hex2(pool_hex) || !is_lower_hex2(namespace_hex) {
         return None;
     }
 
@@ -473,9 +473,11 @@ pub fn parse_netns_name(name: &str) -> Option<ParsedNetnsName> {
     })
 }
 
-/// Check that a string is exactly 2 ASCII hex characters.
-fn is_hex2(s: &str) -> bool {
-    s.len() == 2 && s.bytes().all(|b| b.is_ascii_hexdigit())
+/// Check that a string is exactly 2 lowercase hex characters.
+fn is_lower_hex2(s: &str) -> bool {
+    s.len() == 2
+        && s.bytes()
+            .all(|b| b.is_ascii_hexdigit() && !b.is_ascii_uppercase())
 }
 
 // ---------------------------------------------------------------------------
@@ -2309,6 +2311,8 @@ mod tests {
     fn parse_netns_name_invalid_hex() {
         assert_eq!(parse_netns_name("vm0-ns-zz-00"), None);
         assert_eq!(parse_netns_name("vm0-ns-00-zz"), None);
+        assert_eq!(parse_netns_name("vm0-ns-0A-00"), None);
+        assert_eq!(parse_netns_name("vm0-ns-00-0A"), None);
     }
 
     #[test]

--- a/crates/sandbox-fc/src/network/pool.rs
+++ b/crates/sandbox-fc/src/network/pool.rs
@@ -92,6 +92,15 @@ const _: () = assert!(MAX_POOLS * MAX_NAMESPACES * 4 <= 65536);
 // Public types
 // ---------------------------------------------------------------------------
 
+/// Parsed Firecracker network namespace name.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ParsedNetnsName {
+    /// Network namespace pool index.
+    pub pool_index: u32,
+    /// Namespace index within the pool.
+    pub namespace_index: u32,
+}
+
 /// Monotonic in-process identity for [`NetnsPool`] instances.
 static NEXT_NETNS_POOL_INSTANCE_ID: AtomicU64 = AtomicU64::new(1);
 
@@ -440,20 +449,31 @@ fn generate_veth_ip_pair(pool_idx: u32, ns_idx: u32) -> (String, String) {
     (host_ip, peer_ip)
 }
 
-/// Parse a namespace name into (pool_idx, ns_idx) hex strings.
+/// Parse a Firecracker network namespace name.
 ///
 /// Returns `None` if the name doesn't match the expected format
-/// `vm0-ns-{XX}-{XX}` where each index is exactly 2 hex characters.
-fn parse_ns_name(name: &str) -> Option<(&str, &str)> {
+/// `vm0-ns-{XX}-{XX}` where each index is exactly 2 hex characters, or if
+/// either index is outside the supported bounds.
+pub fn parse_netns_name(name: &str) -> Option<ParsedNetnsName> {
     let suffix = name.strip_prefix(NS_PREFIX)?;
-    let (pool_idx, ns_idx) = suffix.split_once('-')?;
-    if !is_hex2(pool_idx) || !is_hex2(ns_idx) {
+    let (pool_hex, namespace_hex) = suffix.split_once('-')?;
+    if !is_hex2(pool_hex) || !is_hex2(namespace_hex) {
         return None;
     }
-    Some((pool_idx, ns_idx))
+
+    let pool_index = u32::from_str_radix(pool_hex, 16).ok()?;
+    let namespace_index = u32::from_str_radix(namespace_hex, 16).ok()?;
+    if pool_index >= MAX_POOLS || namespace_index >= MAX_NAMESPACES {
+        return None;
+    }
+
+    Some(ParsedNetnsName {
+        pool_index,
+        namespace_index,
+    })
 }
 
-/// Check that a string is exactly 2 lowercase hex characters.
+/// Check that a string is exactly 2 ASCII hex characters.
 fn is_hex2(s: &str) -> bool {
     s.len() == 2 && s.bytes().all(|b| b.is_ascii_hexdigit())
 }
@@ -2082,8 +2102,10 @@ pub async fn cleanup_namespaces_by_index(index: u32) {
     let mut set = tokio::task::JoinSet::new();
     for ns_name in ns_names {
         set.spawn(async move {
-            if let Some((pi, ni)) = parse_ns_name(&ns_name) {
-                let host_device = make_host_device(pi, ni);
+            if let Some(parsed) = parse_netns_name(&ns_name) {
+                let pool_idx = format_hex_index(parsed.pool_index);
+                let ns_idx = format_hex_index(parsed.namespace_index);
+                let host_device = make_host_device(&pool_idx, &ns_idx);
                 delete_namespace_resources(&ns_name, &host_device).await;
             }
         });
@@ -2246,25 +2268,53 @@ mod tests {
     }
 
     #[test]
-    fn parse_ns_name_valid() {
-        assert_eq!(parse_ns_name("vm0-ns-00-0a"), Some(("00", "0a")));
-        assert_eq!(parse_ns_name("vm0-ns-3f-ff"), Some(("3f", "ff")));
+    fn parse_netns_name_valid() {
+        assert_eq!(
+            parse_netns_name("vm0-ns-00-0a"),
+            Some(ParsedNetnsName {
+                pool_index: 0,
+                namespace_index: 10,
+            })
+        );
+        assert_eq!(
+            parse_netns_name("vm0-ns-3f-ff"),
+            Some(ParsedNetnsName {
+                pool_index: 63,
+                namespace_index: 255,
+            })
+        );
     }
 
     #[test]
-    fn parse_ns_name_wrong_prefix() {
-        assert_eq!(parse_ns_name("other-00-0a"), None);
+    fn parse_netns_name_wrong_prefix() {
+        assert_eq!(parse_netns_name("not-a-ns"), None);
+        assert_eq!(parse_netns_name("other-00-0a"), None);
     }
 
     #[test]
-    fn parse_ns_name_missing_separator() {
-        assert_eq!(parse_ns_name("vm0-ns-000a"), None);
+    fn parse_netns_name_missing_or_malformed_parts() {
+        assert_eq!(parse_netns_name("vm0-ns-"), None);
+        assert_eq!(parse_netns_name("vm0-ns-00"), None);
+        assert_eq!(parse_netns_name("vm0-ns-000a"), None);
+        assert_eq!(parse_netns_name("vm0-ns-00-0a-extra"), None);
     }
 
     #[test]
-    fn parse_ns_name_empty_parts() {
-        assert_eq!(parse_ns_name("vm0-ns--0a"), None);
-        assert_eq!(parse_ns_name("vm0-ns-00-"), None);
+    fn parse_netns_name_empty_parts() {
+        assert_eq!(parse_netns_name("vm0-ns--0a"), None);
+        assert_eq!(parse_netns_name("vm0-ns-00-"), None);
+    }
+
+    #[test]
+    fn parse_netns_name_invalid_hex() {
+        assert_eq!(parse_netns_name("vm0-ns-zz-00"), None);
+        assert_eq!(parse_netns_name("vm0-ns-00-zz"), None);
+    }
+
+    #[test]
+    fn parse_netns_name_rejects_out_of_range_pool() {
+        assert_eq!(parse_netns_name("vm0-ns-40-00"), None);
+        assert_eq!(parse_netns_name("vm0-ns-ff-00"), None);
     }
 
     #[test]
@@ -2272,10 +2322,15 @@ mod tests {
         let pool_idx = format_hex_index(5);
         let ns_idx = format_hex_index(42);
         let name = make_ns_name(&pool_idx, &ns_idx);
-        let (pi, ni) = parse_ns_name(&name).expect("should parse");
-        assert_eq!(pi, "05");
-        assert_eq!(ni, "2a");
-        assert_eq!(make_host_device(pi, ni), "vm0-ve-05-2a");
+        let parsed = parse_netns_name(&name).expect("should parse");
+        assert_eq!(parsed.pool_index, 5);
+        assert_eq!(parsed.namespace_index, 42);
+        let parsed_pool_idx = format_hex_index(parsed.pool_index);
+        let parsed_ns_idx = format_hex_index(parsed.namespace_index);
+        assert_eq!(
+            make_host_device(&parsed_pool_idx, &parsed_ns_idx),
+            "vm0-ve-05-2a"
+        );
     }
 
     #[test]
@@ -2390,14 +2445,14 @@ mod tests {
     }
 
     #[test]
-    fn parse_ns_name_extra_hyphens_rejected() {
+    fn parse_netns_name_extra_hyphens_rejected() {
         // Rejects malformed names that could produce device names exceeding IFNAMSIZ
-        assert_eq!(parse_ns_name("vm0-ns-00-0a-extra"), None);
+        assert_eq!(parse_netns_name("vm0-ns-00-0a-extra"), None);
     }
 
     #[test]
-    fn parse_ns_name_bare_prefix() {
-        assert_eq!(parse_ns_name("vm0-ns-"), None);
+    fn parse_netns_name_bare_prefix() {
+        assert_eq!(parse_netns_name("vm0-ns-"), None);
     }
 
     fn test_info(name: &str) -> NetnsInfo {

--- a/crates/sandbox-fc/src/network/pool.rs
+++ b/crates/sandbox-fc/src/network/pool.rs
@@ -2285,6 +2285,13 @@ mod tests {
                 namespace_index: 255,
             })
         );
+        assert_eq!(
+            parse_netns_name("vm0-ns-0a-00"),
+            Some(ParsedNetnsName {
+                pool_index: 10,
+                namespace_index: 0,
+            })
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- expose a canonical `sandbox-fc` parser for Firecracker network namespace names
- update namespace cleanup and `runner doctor` to use the shared parser
- reject malformed and out-of-range `vm0-ns-*` names before doctor checks pool locks

Closes #13908

## Tests

- `cargo test --manifest-path crates/Cargo.toml -p sandbox-fc parse_netns_name`
- `cargo test --manifest-path crates/Cargo.toml -p runner parse_netns_list_line`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox-fc`
- `cargo test --manifest-path crates/Cargo.toml -p runner`
- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p sandbox-fc -p runner --all-targets -- -D warnings`