### PR TITLE
feat: enable stored secret kms reads

### DIFF
--- a/turbo/apps/api/src/signals/services/__tests__/crypto.utils.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/crypto.utils.test.ts
@@ -140,7 +140,7 @@ describe("stored secret encryption", () => {
     expect(fakeKmsClient.calls).toHaveLength(0);
   });
 
-  it("dual-writes legacy AES and AWS KMS material by default when KMS env is set", async () => {
+  it("dual-writes legacy AES and reads AWS KMS material by default when KMS env is set", async () => {
     mockEnv("SECRETS_KMS_KEY_ID", "alias/vm0-secrets");
 
     const encrypted = await encryptStoredSecretValue("secret-value");
@@ -154,14 +154,16 @@ describe("stored secret encryption", () => {
     await expect(decryptStoredSecretValue(encrypted)).resolves.toBe(
       "secret-value",
     );
+    expect(fakeKmsClient.calls).toHaveLength(2);
+    expect(fakeKmsClient.calls[0]).toBeInstanceOf(GenerateDataKeyCommand);
+    expect(fakeKmsClient.calls[1]).toBeInstanceOf(DecryptCommand);
 
     await expect(
       decryptStoredSecretValue(encrypted, {
-        overrides: { [FeatureSwitchKey.StoredSecretKmsRead]: true },
+        overrides: { [FeatureSwitchKey.StoredSecretKmsRead]: false },
       }),
     ).resolves.toBe("secret-value");
     expect(fakeKmsClient.calls).toHaveLength(2);
-    expect(fakeKmsClient.calls[0]).toBeInstanceOf(GenerateDataKeyCommand);
   });
 
   it("can write and strictly read KMS-only ciphertext", async () => {

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -304,8 +304,8 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
   [FeatureSwitchKey.StoredSecretKmsRead]: {
     maintainer: "ethan@vm0.ai",
     description:
-      "Prefer AWS KMS material when reading stored-secret envelopes. Disabled keeps reading the legacy AES branch during rollout. Read path is independent of StoredSecretKmsWrite — enable read only after dual-write has been on long enough to backfill existing rows.",
-    enabled: false,
+      "Prefer AWS KMS material when reading stored-secret envelopes. Legacy AES remains as a fallback for old or explicitly legacy-only rows.",
+    enabled: true,
   },
   [FeatureSwitchKey.StoredSecretKmsWrite]: {
     maintainer: "ethan@vm0.ai",


### PR DESCRIPTION
## Summary
- Enable StoredSecretKmsRead by default so stored-secret reads prefer AWS KMS material.
- Keep legacy AES as the fallback for old or explicitly legacy-only secret envelopes.
- Update crypto coverage to assert the default read path calls KMS and the override still reads legacy AES.

## Tests
- pnpm -F api exec vitest run src/signals/services/__tests__/crypto.utils.test.ts
- pnpm -F api exec vitest run src/signals/services/__tests__/crypto.utils.test.ts src/signals/services/__tests__/zero-run-built-in-admission.service.test.ts src/signals/routes/__tests__/zero-image-io-generate.test.ts src/signals/routes/__tests__/zero-video-io-generate.test.ts src/signals/routes/__tests__/zero-voice-io-post.test.ts
- pnpm lint
- pnpm check-types
- pnpm format
- pnpm knip
- pnpm -F api exec vitest run src/signals/routes/__tests__/cron-drain-email-outbox.test.ts src/signals/routes/__tests__/zero-composes-by-name.test.ts

## Notes
- Full pnpm test was rerun after resetting the local dev DB; it finished with 10,760/10,762 passing. The two failing files above both passed when rerun directly and are outside this KMS change.