### PR TITLE
feat: add connector OAuth client plumbing

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/connectors-type-callback.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors-type-callback.test.ts
@@ -1,6 +1,10 @@
 import { randomUUID } from "node:crypto";
 
-import type { ConnectorType } from "@vm0/connectors/connectors";
+import {
+  CONNECTOR_TYPES,
+  type ConnectorOAuthClientConfig,
+  type ConnectorType,
+} from "@vm0/connectors/connectors";
 import { PROVIDER_HANDLERS } from "@vm0/connectors/oauth-providers";
 import { connectors } from "@vm0/db/schema/connector";
 import { connectorSessions } from "@vm0/db/schema/connector-session";
@@ -81,6 +85,7 @@ function callbackHeaders(args: {
   readonly stateCookie?: string;
   readonly sessionId?: string;
   readonly codeVerifier?: string;
+  readonly oauthContext?: string;
 }): HeadersInit {
   const cookies = ["__session=opaque"];
   if (args.stateCookie) {
@@ -91,6 +96,9 @@ function callbackHeaders(args: {
   }
   if (args.codeVerifier) {
     cookies.push(`connector_oauth_pkce=${args.codeVerifier}`);
+  }
+  if (args.oauthContext) {
+    cookies.push(`connector_oauth_context=${args.oauthContext}`);
   }
   return { cookie: cookies.join("; ") };
 }
@@ -155,6 +163,81 @@ function mockOAuthEnv(): void {
   mockOptionalEnv("X_OAUTH_CLIENT_SECRET", "x-client-secret");
   mockOptionalEnv("XERO_OAUTH_CLIENT_ID", "xero-client-id");
   mockOptionalEnv("XERO_OAUTH_CLIENT_SECRET", "xero-client-secret");
+}
+
+const dynamicPublicClient = {
+  clientRegistration: "dynamic",
+  clientType: "public",
+  tokenEndpointAuthMethod: "none",
+} as const satisfies ConnectorOAuthClientConfig;
+
+type CapturedOAuthExchange = {
+  readonly clientId: string | undefined;
+  readonly clientSecret: string | undefined;
+  readonly code: string;
+  readonly redirectUri: string;
+  readonly state: string | undefined;
+  readonly codeVerifier: string | undefined;
+  readonly oauthContext: string | undefined;
+};
+
+function useDynamicTestOAuthExchange(): {
+  readonly exchanges: readonly CapturedOAuthExchange[];
+  readonly restore: () => void;
+} {
+  const exchanges: CapturedOAuthExchange[] = [];
+
+  return {
+    exchanges,
+    restore: configureDynamicTestOAuthExchange(exchanges),
+  };
+}
+
+function configureDynamicTestOAuthExchange(
+  exchanges: CapturedOAuthExchange[],
+): () => void {
+  const oauth = CONNECTOR_TYPES["test-oauth"].oauth;
+  if (!oauth) {
+    throw new Error("test-oauth OAuth config is missing");
+  }
+
+  const mutableOAuth = oauth as { client: ConnectorOAuthClientConfig };
+  const originalClient = oauth.client;
+  const handler = PROVIDER_HANDLERS["test-oauth"];
+  const originalExchangeCodeWithArgs = handler.exchangeCodeWithArgs;
+
+  mutableOAuth.client = dynamicPublicClient;
+  handler.exchangeCodeWithArgs = (args) => {
+    exchanges.push({
+      clientId: args.clientId,
+      clientSecret: args.clientSecret,
+      code: args.code,
+      redirectUri: args.redirectUri,
+      state: args.state,
+      codeVerifier: args.codeVerifier,
+      oauthContext: args.oauthContext,
+    });
+    return Promise.resolve({
+      accessToken: "dynamic-access-token",
+      refreshToken: "dynamic-refresh-token",
+      expiresIn: 3600,
+      scopes: ["read"],
+      userInfo: {
+        id: "dynamic-user-id",
+        username: "dynamic-user",
+        email: "dynamic@example.com",
+      },
+    });
+  };
+
+  return () => {
+    mutableOAuth.client = originalClient;
+    if (originalExchangeCodeWithArgs) {
+      handler.exchangeCodeWithArgs = originalExchangeCodeWithArgs;
+    } else {
+      delete handler.exchangeCodeWithArgs;
+    }
+  };
 }
 
 function mockGitHubOAuth(options: {
@@ -1025,12 +1108,16 @@ const providerUserInfoErrorCases = providerSuccessCases.filter(
 describe("GET /api/connectors/:type/callback", () => {
   const orgIds: string[] = [];
   const sessionIds: string[] = [];
+  let restoreDynamicTestOAuthExchange: (() => void) | undefined;
 
   beforeEach(() => {
     mockOAuthEnv();
   });
 
   afterEach(async () => {
+    restoreDynamicTestOAuthExchange?.();
+    restoreDynamicTestOAuthExchange = undefined;
+
     server.resetHandlers();
 
     const db = store.set(writeDb$);
@@ -1207,7 +1294,10 @@ describe("GET /api/connectors/:type/callback", () => {
     const response = await requestCallback({
       type: "github",
       query: { code: "code-123", state: "returned-state" },
-      headers: callbackHeaders({ stateCookie: "saved-state" }),
+      headers: callbackHeaders({
+        stateCookie: "saved-state",
+        oauthContext: "opaque-context",
+      }),
     });
 
     expect(response.status).toBe(307);
@@ -1224,6 +1314,7 @@ describe("GET /api/connectors/:type/callback", () => {
         "connector_oauth_state=; Max-Age=0; Path=/",
         "connector_oauth_session=; Max-Age=0; Path=/",
         "connector_oauth_pkce=; Max-Age=0; Path=/",
+        "connector_oauth_context=; Max-Age=0; Path=/",
       ]),
     );
   });
@@ -1281,6 +1372,7 @@ describe("GET /api/connectors/:type/callback", () => {
       headers: callbackHeaders({
         stateCookie: "state-123",
         sessionId,
+        oauthContext: "opaque-context",
       }),
     });
 
@@ -1296,6 +1388,7 @@ describe("GET /api/connectors/:type/callback", () => {
         "connector_oauth_state=; Max-Age=0; Path=/",
         "connector_oauth_session=; Max-Age=0; Path=/",
         "connector_oauth_pkce=; Max-Age=0; Path=/",
+        "connector_oauth_context=; Max-Age=0; Path=/",
       ]),
     );
 
@@ -1328,6 +1421,70 @@ describe("GET /api/connectors/:type/callback", () => {
       .where(eq(connectorSessions.id, sessionId));
     expect(session?.status).toBe("complete");
     expect(session?.completedAt).toBeInstanceOf(Date);
+  });
+
+  it("passes OAuth context to dynamic public connector exchange", async () => {
+    const dynamicOAuth = useDynamicTestOAuthExchange();
+    restoreDynamicTestOAuthExchange = dynamicOAuth.restore;
+    const { exchanges } = dynamicOAuth;
+    const orgId = `org_${randomUUID()}`;
+    const userId = `user_${randomUUID()}`;
+    orgIds.push(orgId);
+    authenticate({ userId, orgId });
+
+    const response = await requestCallback({
+      type: "test-oauth",
+      query: { code: "code-123", state: "state-123" },
+      headers: callbackHeaders({
+        stateCookie: "state-123",
+        codeVerifier: "pkce-verifier",
+        oauthContext: "dynamic-oauth-context",
+      }),
+    });
+
+    expect(response.status).toBe(307);
+    expect(exchanges).toHaveLength(1);
+    expect(exchanges[0]).toStrictEqual({
+      clientId: undefined,
+      clientSecret: undefined,
+      code: "code-123",
+      redirectUri: `${BASE_URL}/api/connectors/test-oauth/callback`,
+      state: "state-123",
+      codeVerifier: "pkce-verifier",
+      oauthContext: "dynamic-oauth-context",
+    });
+    expect(response.headers.getSetCookie()).toStrictEqual(
+      expect.arrayContaining([
+        "connector_oauth_state=; Max-Age=0; Path=/",
+        "connector_oauth_session=; Max-Age=0; Path=/",
+        "connector_oauth_pkce=; Max-Age=0; Path=/",
+        "connector_oauth_context=; Max-Age=0; Path=/",
+      ]),
+    );
+
+    const connector = await findConnector({
+      orgId,
+      userId,
+      type: "test-oauth",
+    });
+    expect(connector).toMatchObject({
+      type: "test-oauth",
+      authMethod: "oauth",
+      externalId: "dynamic-user-id",
+      externalUsername: "dynamic-user",
+      externalEmail: "dynamic@example.com",
+      needsReconnect: false,
+    });
+
+    const secret = await findSecret({
+      orgId,
+      userId,
+      name: "TEST_OAUTH_ACCESS_TOKEN",
+    });
+    expect(secret).toBeDefined();
+    expect(decryptSecretValue(secret!.encryptedValue)).toBe(
+      "dynamic-access-token",
+    );
   });
 
   it("stores a Slack user OAuth token without an expiry", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
@@ -4,8 +4,13 @@ import { randomUUID } from "node:crypto";
 import { createStore } from "ccstate";
 import { and, eq } from "drizzle-orm";
 import { HttpResponse, http } from "msw";
-import { beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { webhookFirewallAuthContract } from "@vm0/api-contracts/contracts/webhooks";
+import {
+  CONNECTOR_TYPES,
+  type ConnectorOAuthClientConfig,
+} from "@vm0/connectors/connectors";
+import { PROVIDER_HANDLERS } from "@vm0/connectors/oauth-providers";
 import { connectors } from "@vm0/db/schema/connector";
 import { creditExpiresRecord } from "@vm0/db/schema/credit-expires-record";
 import { modelProviders } from "@vm0/db/schema/model-provider";
@@ -238,6 +243,97 @@ async function seedExpiredNotionConnector(
   });
 }
 
+async function seedExpiredTestOAuthConnector(
+  fixture: FirewallFixture,
+): Promise<void> {
+  const db = store.set(writeDb$);
+  await db.insert(connectors).values({
+    orgId: fixture.orgId,
+    userId: fixture.userId,
+    type: "test-oauth",
+    authMethod: "oauth",
+    externalId: "test-oauth-user",
+    externalUsername: "test-oauth-user",
+    externalEmail: "test-oauth@example.com",
+    oauthScopes: JSON.stringify([]),
+    tokenExpiresAt: new Date(now() - 60_000),
+  });
+  await seedSecret({
+    orgId: fixture.orgId,
+    userId: fixture.userId,
+    name: "TEST_OAUTH_ACCESS_TOKEN",
+    value: "stale-test-oauth-token",
+    type: "connector",
+  });
+  await seedSecret({
+    orgId: fixture.orgId,
+    userId: fixture.userId,
+    name: "TEST_OAUTH_REFRESH_TOKEN",
+    value: "test-oauth-refresh-token",
+    type: "connector",
+  });
+}
+
+const dynamicPublicClient = {
+  clientRegistration: "dynamic",
+  clientType: "public",
+  tokenEndpointAuthMethod: "none",
+} as const satisfies ConnectorOAuthClientConfig;
+
+type CapturedOAuthRefresh = {
+  readonly clientId: string | undefined;
+  readonly clientSecret: string | undefined;
+  readonly refreshToken: string;
+};
+
+function useDynamicTestOAuthRefresh(): {
+  readonly refreshes: readonly CapturedOAuthRefresh[];
+  readonly restore: () => void;
+} {
+  const refreshes: CapturedOAuthRefresh[] = [];
+  return {
+    refreshes,
+    restore: configureDynamicTestOAuthRefresh(refreshes),
+  };
+}
+
+function configureDynamicTestOAuthRefresh(
+  refreshes: CapturedOAuthRefresh[],
+): () => void {
+  const oauth = CONNECTOR_TYPES["test-oauth"].oauth;
+  if (!oauth) {
+    throw new Error("test-oauth OAuth config is missing");
+  }
+
+  const mutableOAuth = oauth as { client: ConnectorOAuthClientConfig };
+  const originalClient = oauth.client;
+  const handler = PROVIDER_HANDLERS["test-oauth"];
+  const originalRefreshTokenWithArgs = handler.refreshTokenWithArgs;
+
+  mutableOAuth.client = dynamicPublicClient;
+  handler.refreshTokenWithArgs = (args) => {
+    refreshes.push({
+      clientId: args.clientId,
+      clientSecret: args.clientSecret,
+      refreshToken: args.refreshToken,
+    });
+    return Promise.resolve({
+      accessToken: "fresh-test-oauth-token",
+      refreshToken: "new-test-oauth-refresh-token",
+      expiresIn: 3600,
+    });
+  };
+
+  return () => {
+    mutableOAuth.client = originalClient;
+    if (originalRefreshTokenWithArgs) {
+      handler.refreshTokenWithArgs = originalRefreshTokenWithArgs;
+    } else {
+      delete handler.refreshTokenWithArgs;
+    }
+  };
+}
+
 async function seedExpiredCodexModelProvider(
   fixture: FirewallFixture,
 ): Promise<void> {
@@ -319,12 +415,19 @@ async function codexProviderState(fixture: FirewallFixture): Promise<{
   return row;
 }
 
-beforeEach(() => {
-  mockOptionalEnv("NOTION_OAUTH_CLIENT_ID", "notion-client");
-  mockOptionalEnv("NOTION_OAUTH_CLIENT_SECRET", "notion-secret");
-});
-
 describe("POST /api/webhooks/agent/firewall/auth", () => {
+  let restoreDynamicTestOAuthRefresh: (() => void) | undefined;
+
+  beforeEach(() => {
+    mockOptionalEnv("NOTION_OAUTH_CLIENT_ID", "notion-client");
+    mockOptionalEnv("NOTION_OAUTH_CLIENT_SECRET", "notion-secret");
+  });
+
+  afterEach(() => {
+    restoreDynamicTestOAuthRefresh?.();
+    restoreDynamicTestOAuthRefresh = undefined;
+  });
+
   it("rejects missing sandbox auth before parsing the body", async () => {
     const response = await accept(
       firewallClient().resolve({
@@ -709,6 +812,63 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
     const connector = await notionConnectorState(fixture);
     expect(connector.needsReconnect).toBeFalsy();
     expect(connector.tokenExpiresAt?.getTime()).toBeGreaterThan(now());
+  });
+
+  it("refreshes dynamic public connector OAuth tokens without env client credentials", async () => {
+    const dynamicOAuth = useDynamicTestOAuthRefresh();
+    restoreDynamicTestOAuthRefresh = dynamicOAuth.restore;
+    const { refreshes } = dynamicOAuth;
+    const fixture = await track(seedFixture());
+    await seedExpiredTestOAuthConnector(fixture);
+
+    const response = await accept(
+      firewallClient().resolve({
+        body: {
+          encryptedSecrets: encryptedSecrets({
+            TEST_OAUTH_ACCESS_TOKEN: "stale-test-oauth-token",
+          }),
+          authHeaders: {
+            Authorization: `Bearer ${secretTemplate("TEST_OAUTH_ACCESS_TOKEN")}`,
+          },
+          secretConnectorMap: {
+            TEST_OAUTH_ACCESS_TOKEN: "test-oauth",
+          },
+        },
+        headers: authHeaders(fixture),
+      }),
+      [200],
+    );
+
+    expect(refreshes).toStrictEqual([
+      {
+        clientId: undefined,
+        clientSecret: undefined,
+        refreshToken: "test-oauth-refresh-token",
+      },
+    ]);
+    expect(response.body.headers.Authorization).toBe(
+      "Bearer fresh-test-oauth-token",
+    );
+    expect(response.body.refreshedConnectors).toStrictEqual(["test-oauth"]);
+    expect(response.body.refreshedSecrets).toStrictEqual([
+      "TEST_OAUTH_ACCESS_TOKEN",
+    ]);
+    await expect(
+      readSecret({
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        name: "TEST_OAUTH_ACCESS_TOKEN",
+        type: "connector",
+      }),
+    ).resolves.toBe("fresh-test-oauth-token");
+    await expect(
+      readSecret({
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        name: "TEST_OAUTH_REFRESH_TOKEN",
+        type: "connector",
+      }),
+    ).resolves.toBe("new-test-oauth-refresh-token");
   });
 
   it("uses OAuth token expiry when it is earlier than billable credit lease", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-authorize.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-authorize.test.ts
@@ -1,5 +1,10 @@
 import { randomUUID } from "node:crypto";
 
+import {
+  CONNECTOR_TYPES,
+  type ConnectorOAuthClientConfig,
+} from "@vm0/connectors/connectors";
+import { PROVIDER_HANDLERS } from "@vm0/connectors/oauth-providers";
 import { connectors } from "@vm0/db/schema/connector";
 import { secrets } from "@vm0/db/schema/secret";
 import { createStore } from "ccstate";
@@ -64,6 +69,42 @@ function mockOAuthEnv(): void {
   mockOptionalEnv("X_OAUTH_CLIENT_SECRET", "x-test-client-secret");
 }
 
+const dynamicPublicClient = {
+  clientRegistration: "dynamic",
+  clientType: "public",
+  tokenEndpointAuthMethod: "none",
+} as const satisfies ConnectorOAuthClientConfig;
+
+function useDynamicTestOAuthAuthorize(): () => void {
+  const oauth = CONNECTOR_TYPES["test-oauth"].oauth;
+  if (!oauth) {
+    throw new Error("test-oauth OAuth config is missing");
+  }
+
+  const mutableOAuth = oauth as { client: ConnectorOAuthClientConfig };
+  const originalClient = oauth.client;
+  const handler = PROVIDER_HANDLERS["test-oauth"];
+  const originalBuildAuthUrlWithArgs = handler.buildAuthUrlWithArgs;
+
+  mutableOAuth.client = dynamicPublicClient;
+  handler.buildAuthUrlWithArgs = (args) => {
+    expect(args.clientId).toBeUndefined();
+    return {
+      url: `https://dynamic-oauth.test/authorize?state=${args.state}`,
+      oauthContext: "dynamic-oauth-context",
+    };
+  };
+
+  return () => {
+    mutableOAuth.client = originalClient;
+    if (originalBuildAuthUrlWithArgs) {
+      handler.buildAuthUrlWithArgs = originalBuildAuthUrlWithArgs;
+    } else {
+      delete handler.buildAuthUrlWithArgs;
+    }
+  };
+}
+
 async function requestAuthorize(
   type: string,
   options: { readonly session?: string; readonly authenticated?: boolean } = {},
@@ -80,12 +121,16 @@ async function requestAuthorize(
 
 describe("GET /api/zero/connectors/:type/authorize", () => {
   const orgIds: string[] = [];
+  let restoreDynamicTestOAuthAuthorize: (() => void) | undefined;
 
   beforeEach(() => {
     mockOAuthEnv();
   });
 
   afterEach(async () => {
+    restoreDynamicTestOAuthAuthorize?.();
+    restoreDynamicTestOAuthAuthorize = undefined;
+
     const db = store.set(writeDb$);
     while (orgIds.length > 0) {
       const orgId = orgIds.pop();
@@ -151,6 +196,32 @@ describe("GET /api/zero/connectors/:type/authorize", () => {
     expect(
       cookies.some((cookie) => {
         return cookie.startsWith("connector_oauth_session=session-123");
+      }),
+    ).toBeTruthy();
+  });
+
+  it("allows dynamic public OAuth authorize without env credentials", async () => {
+    restoreDynamicTestOAuthAuthorize = useDynamicTestOAuthAuthorize();
+
+    const response = await requestAuthorize("test-oauth", {
+      authenticated: true,
+    });
+
+    expect(response.status).toBe(307);
+    const location = response.headers.get("location");
+    expect(location).not.toBeNull();
+    const url = new URL(location!);
+    expect(`${url.origin}${url.pathname}`).toBe(
+      "https://dynamic-oauth.test/authorize",
+    );
+    expect(url.searchParams.get("state")).toMatch(/^[0-9a-f]{64}$/);
+
+    const cookies = response.headers.getSetCookie();
+    expect(
+      cookies.some((cookie) => {
+        return cookie.startsWith(
+          "connector_oauth_context=dynamic-oauth-context",
+        );
       }),
     ).toBeTruthy();
   });

--- a/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
+++ b/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
@@ -1,14 +1,17 @@
 import { command } from "ccstate";
 import { connectorsTypeCallbackContract } from "@vm0/api-contracts/contracts/connectors-type-callback";
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
+import {
+  getConnectorOAuthConfig,
+  getConnectorOAuthCredentials,
+} from "@vm0/connectors/connector-utils";
 import {
   connectorTypeSchema,
   type ConnectorType,
 } from "@vm0/connectors/connectors";
 import {
+  exchangeProviderCode,
   PROVIDER_HANDLERS,
   type OAuthTokenResult,
-  type ProviderEnv,
 } from "@vm0/connectors/oauth-providers";
 import { connectorSessions } from "@vm0/db/schema/connector-session";
 import { eq } from "drizzle-orm";
@@ -26,6 +29,7 @@ import type { RouteEntry } from "../route";
 const STATE_COOKIE_NAME = "connector_oauth_state";
 const SESSION_COOKIE_NAME = "connector_oauth_session";
 const PKCE_COOKIE_NAME = "connector_oauth_pkce";
+const OAUTH_CONTEXT_COOKIE_NAME = "connector_oauth_context";
 const REDIRECT_STATUS = 307;
 
 type OAuthConnectorType = Exclude<ConnectorType, "computer">;
@@ -79,6 +83,10 @@ function clearOAuthCookies(response: Response): void {
     "Set-Cookie",
     buildDeleteCookieHeader(PKCE_COOKIE_NAME),
   );
+  response.headers.append(
+    "Set-Cookie",
+    buildDeleteCookieHeader(OAUTH_CONTEXT_COOKIE_NAME),
+  );
 }
 
 function redirectWithError(
@@ -98,40 +106,32 @@ function redirectWithError(
   return response;
 }
 
-function providerEnv(): ProviderEnv {
-  return new Proxy(
-    {},
-    {
-      get: (_target, property) => {
-        return typeof property === "string" ? optionalEnv(property) : undefined;
-      },
-    },
-  ) as ProviderEnv;
-}
-
 async function exchangeTokenForConnector(args: {
   readonly connectorType: OAuthConnectorType;
   readonly code: string;
   readonly redirectUri: string;
   readonly state: string | undefined;
   readonly codeVerifier: string | undefined;
+  readonly oauthContext: string | undefined;
 }): Promise<OAuthTokenResult> {
   const handler = PROVIDER_HANDLERS[args.connectorType];
-  const env = providerEnv();
-  const clientId = handler.getClientId(env);
-  const clientSecret = handler.getClientSecret(env);
-  if (!clientId || !clientSecret) {
+  const credentials = getConnectorOAuthCredentials(
+    args.connectorType,
+    optionalEnv,
+  );
+  if (!credentials?.configured) {
     throw new Error(`${args.connectorType} OAuth not configured`);
   }
 
-  return await handler.exchangeCode(
-    clientId,
-    clientSecret,
-    args.code,
-    args.redirectUri,
-    args.state,
-    args.codeVerifier,
-  );
+  return await exchangeProviderCode(handler, {
+    clientId: credentials.clientId,
+    clientSecret: credentials.clientSecret,
+    code: args.code,
+    redirectUri: args.redirectUri,
+    state: args.state,
+    codeVerifier: args.codeVerifier,
+    oauthContext: args.oauthContext,
+  });
 }
 
 function getRequestedScopes(connectorType: ConnectorType): readonly string[] {
@@ -235,6 +235,7 @@ const callbackConnectorInner$ = command(
     const savedState = getCookie(request, STATE_COOKIE_NAME);
     const sessionId = getCookie(request, SESSION_COOKIE_NAME);
     const codeVerifier = getCookie(request, PKCE_COOKIE_NAME);
+    const oauthContext = getCookie(request, OAUTH_CONTEXT_COOKIE_NAME);
 
     if (query.error) {
       return redirectWithError(
@@ -284,6 +285,7 @@ const callbackConnectorInner$ = command(
           redirectUri,
           state,
           codeVerifier,
+          oauthContext,
         });
         signal.throwIfAborted();
 

--- a/turbo/apps/api/src/signals/routes/zero-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/zero-connectors.ts
@@ -16,8 +16,8 @@ import {
 } from "@vm0/api-contracts/contracts/zero-connectors";
 import {
   getConnectorAuthMethod,
+  getConnectorOAuthCredentials,
   getConnectorOAuthConfig,
-  getConnectorOAuthEnvKeys,
   isGoogleOAuthConnector,
 } from "@vm0/connectors/connector-utils";
 import {
@@ -25,6 +25,11 @@ import {
   type ConnectorType,
 } from "@vm0/connectors/connectors";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import {
+  buildProviderAuthUrl,
+  PROVIDER_HANDLERS,
+  type AuthUrlResult,
+} from "@vm0/connectors/oauth-providers";
 import { isFeatureEnabled } from "@vm0/core/feature-switch";
 import { connectorSessions } from "@vm0/db/schema/connector-session";
 import { and, eq } from "drizzle-orm";
@@ -59,6 +64,7 @@ import type { RouteEntry } from "../route";
 const STATE_COOKIE_NAME = "connector_oauth_state";
 const SESSION_COOKIE_NAME = "connector_oauth_session";
 const PKCE_COOKIE_NAME = "connector_oauth_pkce";
+const OAUTH_CONTEXT_COOKIE_NAME = "connector_oauth_context";
 const COOKIE_MAX_AGE = 15 * 60;
 const REDIRECT_STATUS = 307;
 const CONNECTOR_SESSION_TTL_SECONDS = 15 * 60;
@@ -217,7 +223,7 @@ async function buildAuthorizeUrl(args: {
   readonly clientId: string;
   readonly redirectUri: string;
   readonly state: string;
-}): Promise<{ readonly url: string; readonly codeVerifier?: string } | null> {
+}): Promise<AuthUrlResult | null> {
   const oauthConfig = getConnectorOAuthConfig(args.type);
   if (!oauthConfig?.authorizationUrl) {
     return null;
@@ -308,6 +314,25 @@ async function buildAuthorizeUrl(args: {
   }
 
   return { url: `${oauthConfig.authorizationUrl}?${params.toString()}` };
+}
+
+function normalizeAuthUrlResult(result: string | AuthUrlResult): AuthUrlResult {
+  return typeof result === "string" ? { url: result } : result;
+}
+
+async function buildProviderAuthorizeUrl(args: {
+  readonly type: Exclude<ConnectorType, "computer">;
+  readonly clientId?: string;
+  readonly redirectUri: string;
+  readonly state: string;
+}): Promise<AuthUrlResult> {
+  return normalizeAuthUrlResult(
+    await buildProviderAuthUrl(PROVIDER_HANDLERS[args.type], {
+      clientId: args.clientId,
+      redirectUri: args.redirectUri,
+      state: args.state,
+    }),
+  );
 }
 
 const getConnectorListInner$ = computed(async (get) => {
@@ -564,18 +589,23 @@ export function createAuthorizeConnectorInner(route: ConnectorAuthorizeRoute) {
 
     const state = generateState();
     const redirectUri = `${origin}/api/connectors/${type}/callback`;
-    const envKeys = getConnectorOAuthEnvKeys(type);
-    const clientId = envKeys ? optionalEnv(envKeys.clientId) : undefined;
-    if (!clientId) {
+    const credentials = getConnectorOAuthCredentials(type, optionalEnv);
+    if (!credentials?.configured) {
       return jsonResponse({ error: `${type} OAuth not configured` }, 500);
     }
 
-    const authResult = await buildAuthorizeUrl({
-      type,
-      clientId,
-      redirectUri,
-      state,
-    });
+    const authResult = credentials.clientId
+      ? await buildAuthorizeUrl({
+          type,
+          clientId: credentials.clientId,
+          redirectUri,
+          state,
+        })
+      : await buildProviderAuthorizeUrl({
+          type,
+          redirectUri,
+          state,
+        });
     signal.throwIfAborted();
     if (!authResult) {
       return jsonResponse({ error: `${type} OAuth not configured` }, 500);
@@ -599,6 +629,16 @@ export function createAuthorizeConnectorInner(route: ConnectorAuthorizeRoute) {
         buildCookieHeader(
           PKCE_COOKIE_NAME,
           authResult.codeVerifier,
+          COOKIE_MAX_AGE,
+        ),
+      );
+    }
+    if (authResult.oauthContext) {
+      response.headers.append(
+        "Set-Cookie",
+        buildCookieHeader(
+          OAUTH_CONTEXT_COOKIE_NAME,
+          authResult.oauthContext,
           COOKIE_MAX_AGE,
         ),
       );

--- a/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
@@ -1,10 +1,13 @@
 import { Buffer } from "node:buffer";
 
 import type { SecretConnectorMetadata } from "@vm0/api-contracts/contracts/runners";
+import { getConnectorOAuthCredentials } from "@vm0/connectors/connector-utils";
+import { connectorTypeSchema } from "@vm0/connectors/connectors";
 import { basicAuthTemplateRe } from "@vm0/connectors/firewall-types";
 import type { FeatureSwitchContext } from "@vm0/core/feature-switch";
 import {
   PROVIDER_HANDLERS,
+  refreshProviderToken,
   type ProviderEnv,
 } from "@vm0/connectors/oauth-providers";
 import {
@@ -142,14 +145,13 @@ interface RefreshAccessTokenArgs extends SecretTokenLookupArgs {
 interface RefreshTokenContext {
   readonly refreshTokenSecret: string;
   readonly currentRefreshToken: string;
-  readonly clientId: string;
+  readonly clientId: string | undefined;
   readonly clientSecret: string | undefined;
   readonly accessTokenSecret: string;
   readonly secretUserId: string;
 }
 
 type RefreshableProviderHandler = ProviderHandler & {
-  readonly refreshToken: NonNullable<ProviderHandler["refreshToken"]>;
   readonly getRefreshSecretName: NonNullable<
     ProviderHandler["getRefreshSecretName"]
   >;
@@ -532,12 +534,14 @@ function prepareRefreshTokenContext(args: RefreshAccessTokenArgs): {
   readonly context: RefreshTokenContext;
 } | null {
   const handler = providerHandler(args.connectorType);
-  if (!handler?.refreshToken || !handler.getRefreshSecretName) {
+  if (
+    !handler?.getRefreshSecretName ||
+    (!handler.refreshToken && !handler.refreshTokenWithArgs)
+  ) {
     return null;
   }
   const refreshableHandler: RefreshableProviderHandler = {
     ...handler,
-    refreshToken: handler.refreshToken,
     getRefreshSecretName: handler.getRefreshSecretName,
   };
   if (args.sourceType === "model-provider" && !args.metadataKey) {
@@ -553,13 +557,38 @@ function prepareRefreshTokenContext(args: RefreshAccessTokenArgs): {
     return null;
   }
 
+  let clientId: string | undefined;
+  let clientSecret: string | undefined;
   const env = currentProviderEnv();
-  const clientId = handler.getClientId(env);
-  if (!clientId) {
-    L.debug(
-      `${args.connectorType} OAuth client ID not configured, skipping token refresh`,
+  if (args.sourceType === "connector") {
+    const typeResult = connectorTypeSchema.safeParse(args.connectorType);
+    if (!typeResult.success) {
+      L.debug(`${args.connectorType} is not a connector type, skipping`);
+      return null;
+    }
+    const credentials = getConnectorOAuthCredentials(
+      typeResult.data,
+      (name) => {
+        return optionalEnv(name);
+      },
     );
-    return null;
+    if (!credentials?.configured) {
+      L.debug(
+        `${args.connectorType} OAuth credentials not configured, skipping token refresh`,
+      );
+      return null;
+    }
+    clientId = credentials.clientId;
+    clientSecret = credentials.clientSecret;
+  } else {
+    clientId = handler.getClientId(env);
+    if (!clientId) {
+      L.debug(
+        `${args.connectorType} OAuth client ID not configured, skipping token refresh`,
+      );
+      return null;
+    }
+    clientSecret = refreshableHandler.getClientSecret(env);
   }
 
   return {
@@ -568,7 +597,7 @@ function prepareRefreshTokenContext(args: RefreshAccessTokenArgs): {
       refreshTokenSecret,
       currentRefreshToken,
       clientId,
-      clientSecret: refreshableHandler.getClientSecret(env),
+      clientSecret,
       accessTokenSecret: refreshableHandler.getSecretName(),
       secretUserId: resolveSecretUserId(
         args.sourceType,
@@ -691,13 +720,19 @@ async function refreshConnectorAccessToken(
     return null;
   }
 
-  const refreshResult = await settle(
-    prepared.handler.refreshToken(
-      prepared.context.clientId,
-      prepared.context.clientSecret ?? "",
-      prepared.context.currentRefreshToken,
-    ),
-  );
+  const refreshPromise =
+    args.sourceType === "model-provider" && prepared.handler.refreshToken
+      ? prepared.handler.refreshToken(
+          prepared.context.clientId ?? "",
+          prepared.context.clientSecret ?? "",
+          prepared.context.currentRefreshToken,
+        )
+      : refreshProviderToken(prepared.handler, {
+          clientId: prepared.context.clientId,
+          clientSecret: prepared.context.clientSecret,
+          refreshToken: prepared.context.currentRefreshToken,
+        });
+  const refreshResult = await settle(refreshPromise);
 
   if (!refreshResult.ok) {
     const error = refreshResult.error;

--- a/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
@@ -434,7 +434,9 @@ async function revokeConnectorToken(args: {
 }): Promise<void> {
   const envKeys = getConnectorOAuthEnvKeys(args.type);
   const clientId = envKeys ? optionalEnv(envKeys.clientId) : undefined;
-  const clientSecret = envKeys ? optionalEnv(envKeys.clientSecret) : undefined;
+  const clientSecret = envKeys?.clientSecret
+    ? optionalEnv(envKeys.clientSecret)
+    : undefined;
   if (!clientId || !clientSecret) {
     return;
   }

--- a/turbo/apps/web/src/lib/zero/connector/connector-service.ts
+++ b/turbo/apps/web/src/lib/zero/connector/connector-service.ts
@@ -2,6 +2,7 @@ import { eq, and, inArray } from "drizzle-orm";
 import {
   deriveApiTokenConnectedTypes,
   getApiTokenFieldsByType,
+  getConnectorOAuthCredentials,
   getConnectorSecretNames,
 } from "@vm0/connectors/connector-utils";
 import type {
@@ -20,6 +21,7 @@ import { getSecretValue, upsertSecretByOrg } from "../secret/secret-service";
 import {
   PROVIDER_HANDLERS,
   providerEnvFromObject,
+  refreshProviderToken,
 } from "@vm0/connectors/oauth-providers";
 import {
   getModelProviderOAuthHandler,
@@ -48,6 +50,91 @@ function getOAuthHandler(
     return getModelProviderOAuthHandler(handlerKey);
   }
   return PROVIDER_HANDLERS[handlerKey as keyof typeof PROVIDER_HANDLERS];
+}
+
+interface OAuthClientCredentials {
+  readonly clientId: string | undefined;
+  readonly clientSecret: string | undefined;
+}
+
+function resolveConnectorRefreshCredentials(
+  connectorType: string,
+): OAuthClientCredentials | null {
+  const typeResult = connectorTypeSchema.safeParse(connectorType);
+  if (!typeResult.success) {
+    log.debug(`${connectorType} is not a connector type, skipping`);
+    return null;
+  }
+
+  const env = providerEnvFromObject(globalThis.services.env);
+  const credentials = getConnectorOAuthCredentials(typeResult.data, (name) => {
+    return env[name];
+  });
+  if (!credentials?.configured) {
+    log.debug(
+      `${connectorType} OAuth credentials not configured, skipping token refresh`,
+    );
+    return null;
+  }
+
+  return {
+    clientId: credentials.clientId,
+    clientSecret: credentials.clientSecret,
+  };
+}
+
+function resolveModelProviderRefreshCredentials(
+  connectorType: string,
+  handler: OAuthHandler,
+): OAuthClientCredentials | null {
+  const env = providerEnvFromObject(globalThis.services.env);
+  const clientId = handler.getClientId(env);
+  if (!clientId) {
+    log.debug(
+      `${connectorType} OAuth client ID not configured, skipping token refresh`,
+    );
+    return null;
+  }
+
+  return {
+    clientId,
+    clientSecret: handler.getClientSecret(env),
+  };
+}
+
+function resolveRefreshOAuthCredentials(args: {
+  readonly connectorType: string;
+  readonly sourceType: OAuthSecretSource;
+  readonly handler: OAuthHandler;
+}): OAuthClientCredentials | null {
+  if (args.sourceType === "connector") {
+    return resolveConnectorRefreshCredentials(args.connectorType);
+  }
+  return resolveModelProviderRefreshCredentials(
+    args.connectorType,
+    args.handler,
+  );
+}
+
+async function refreshOAuthToken(args: {
+  readonly sourceType: OAuthSecretSource;
+  readonly handler: OAuthHandler;
+  readonly credentials: OAuthClientCredentials;
+  readonly refreshToken: string;
+}) {
+  if (args.sourceType === "model-provider" && args.handler.refreshToken) {
+    return await args.handler.refreshToken(
+      args.credentials.clientId ?? "",
+      args.credentials.clientSecret ?? "",
+      args.refreshToken,
+    );
+  }
+
+  return await refreshProviderToken(args.handler, {
+    clientId: args.credentials.clientId,
+    clientSecret: args.credentials.clientSecret,
+    refreshToken: args.refreshToken,
+  });
 }
 
 /**
@@ -506,7 +593,10 @@ export async function refreshConnectorAccessToken(
 ): Promise<string | null> {
   const sourceType: OAuthSecretSource = options.sourceType ?? "connector";
   const handler = getOAuthHandler(connectorType, sourceType);
-  if (!handler?.refreshToken || !handler.getRefreshSecretName) {
+  if (
+    !handler?.getRefreshSecretName ||
+    (!handler.refreshToken && !handler.refreshTokenWithArgs)
+  ) {
     return null;
   }
   if (sourceType === "model-provider" && !options.metadataKey) {
@@ -522,19 +612,14 @@ export async function refreshConnectorAccessToken(
     return null;
   }
 
-  const env = providerEnvFromObject(globalThis.services.env);
-  const clientId = handler.getClientId(env);
-  if (!clientId) {
-    log.debug(
-      `${connectorType} OAuth client ID not configured, skipping token refresh`,
-    );
+  const credentials = resolveRefreshOAuthCredentials({
+    connectorType,
+    sourceType,
+    handler,
+  });
+  if (!credentials) {
     return null;
   }
-  // clientSecret may legitimately be undefined for PKCE-only handlers
-  // (e.g. codex-oauth-token). The handler's refreshToken is the source of truth
-  // for credential needs — if a non-PKCE handler is misconfigured the
-  // upstream call will fail and the catch below records the error.
-  const clientSecret = handler.getClientSecret(env);
 
   const accessTokenSecret = handler.getSecretName();
 
@@ -545,11 +630,12 @@ export async function refreshConnectorAccessToken(
   );
 
   try {
-    const result = await handler.refreshToken(
-      clientId,
-      clientSecret ?? "",
-      currentRefreshToken,
-    );
+    const result = await refreshOAuthToken({
+      sourceType,
+      handler,
+      credentials,
+      refreshToken: currentRefreshToken,
+    });
 
     // Persist new tokens to database
     await upsertConnectorSecret(

--- a/turbo/apps/web/src/lib/zero/connector/providers/__tests__/codex-oauth.test.ts
+++ b/turbo/apps/web/src/lib/zero/connector/providers/__tests__/codex-oauth.test.ts
@@ -286,7 +286,11 @@ describe("connector/providers/codex-oauth", () => {
       expect(url.searchParams.get("state")).toBe("state-1");
       expect(url.searchParams.get("code_challenge_method")).toBe("S256");
       expect(url.searchParams.get("code_challenge")).toBeTruthy();
-      expect(result.codeVerifier.length).toBeGreaterThan(20);
+      const { codeVerifier } = result;
+      if (!codeVerifier) {
+        throw new Error("Expected PKCE code verifier");
+      }
+      expect(codeVerifier.length).toBeGreaterThan(20);
     });
 
     it("exchangeCode requires a PKCE verifier", async () => {

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -12,9 +12,12 @@ import {
   getConnectorEnvironmentMapping,
   getConnectorProvidedSecretNames,
   getConnectorAuthMethods,
+  getConnectorOAuthClientConfig,
+  getConnectorOAuthCredentials,
   getConnectorOAuthConfig,
   getRuntimeAvailableConnectorTypes,
   isGoogleOAuthConnector,
+  resolveConnectorOAuthClientCredentials,
 } from "../connector-utils";
 import { FeatureSwitchKey } from "../feature-switch-key";
 
@@ -362,6 +365,89 @@ describe("getRuntimeAvailableConnectorTypes", () => {
     expect(runtimeAvailableTypes).not.toContain("sentry");
   });
 
+  it("derives static confidential OAuth credentials from connector config", () => {
+    const credentials = getConnectorOAuthCredentials("github", (name) => {
+      return (
+        {
+          GH_OAUTH_CLIENT_ID: "github-client-id",
+          GH_OAUTH_CLIENT_SECRET: "github-client-secret",
+        } as Record<string, string>
+      )[name];
+    });
+
+    expect(credentials).toStrictEqual({
+      configured: true,
+      client: getConnectorOAuthClientConfig("github"),
+      clientId: "github-client-id",
+      clientSecret: "github-client-secret",
+    });
+  });
+
+  it("does not configure static confidential OAuth when the secret is missing", () => {
+    const credentials = getConnectorOAuthCredentials("github", (name) => {
+      return name === "GH_OAUTH_CLIENT_ID" ? "github-client-id" : undefined;
+    });
+
+    expect(credentials).toStrictEqual({
+      configured: false,
+      client: getConnectorOAuthClientConfig("github"),
+      clientId: "github-client-id",
+    });
+  });
+
+  it("supports literal static OAuth clients without environment credentials", () => {
+    const credentials = getConnectorOAuthCredentials("test-oauth", emptyEnv);
+
+    expect(credentials).toStrictEqual({
+      configured: true,
+      client: getConnectorOAuthClientConfig("test-oauth"),
+      clientId: "test-oauth-client",
+      clientSecret: "test-oauth-secret",
+    });
+  });
+
+  it("supports static public OAuth clients with only a client id", () => {
+    const credentials = resolveConnectorOAuthClientCredentials(
+      {
+        clientRegistration: "static",
+        clientType: "public",
+        tokenEndpointAuthMethod: "none",
+        clientIdEnv: "PUBLIC_OAUTH_CLIENT_ID",
+      },
+      (name) => {
+        return name === "PUBLIC_OAUTH_CLIENT_ID"
+          ? "public-client-id"
+          : undefined;
+      },
+    );
+
+    expect(credentials).toStrictEqual({
+      configured: true,
+      client: {
+        clientRegistration: "static",
+        clientType: "public",
+        tokenEndpointAuthMethod: "none",
+        clientIdEnv: "PUBLIC_OAUTH_CLIENT_ID",
+      },
+      clientId: "public-client-id",
+    });
+  });
+
+  it("supports dynamic public OAuth clients without environment credentials", () => {
+    const client = {
+      clientRegistration: "dynamic",
+      clientType: "public",
+      tokenEndpointAuthMethod: "none",
+    } as const;
+
+    expect(
+      resolveConnectorOAuthClientCredentials(client, emptyEnv),
+    ).toStrictEqual({
+      configured: true,
+      client,
+    });
+  });
+
   it("includes all connectors that share a configured OAuth app", () => {
     const env = new Map([
       ["GOOGLE_OAUTH_CLIENT_ID", "google-client-id"],
@@ -385,12 +471,8 @@ describe("getRuntimeAvailableConnectorTypes", () => {
   });
 
   it("includes active OAuth connectors when their runtime env is configured", () => {
-    const oauthTypesWithoutRuntimeClientCredentials = new Set(["mailchimp"]);
     const activeOAuthTypes = connectorTypeSchema.options.filter((type) => {
-      return (
-        getConnectorOAuthConfig(type) &&
-        !oauthTypesWithoutRuntimeClientCredentials.has(type)
-      );
+      return getConnectorOAuthConfig(type);
     });
 
     const runtimeAvailableTypes = getRuntimeAvailableConnectorTypes(() => {

--- a/turbo/packages/connectors/src/connector-utils.ts
+++ b/turbo/packages/connectors/src/connector-utils.ts
@@ -7,6 +7,7 @@ import {
   type ConnectorCliAuthConfig,
   type ConnectorCliAuthFlow,
   type ConnectorConfig,
+  type ConnectorOAuthClientConfig,
   type ConnectorOAuthConfig,
   type ConnectorType,
 } from "./connectors";
@@ -152,212 +153,95 @@ export type ConnectorEnvReader = (name: string) => string | undefined;
 
 export interface ConnectorOAuthEnvKeys {
   readonly clientId: string;
-  readonly clientSecret: string;
+  readonly clientSecret?: string;
 }
 
-const OAUTH_ENV_KEYS_BY_CONNECTOR: Partial<
-  Record<ConnectorType, ConnectorOAuthEnvKeys>
-> = {
-  ahrefs: {
-    clientId: "AHREFS_OAUTH_CLIENT_ID",
-    clientSecret: "AHREFS_OAUTH_CLIENT_SECRET",
-  },
-  airtable: {
-    clientId: "AIRTABLE_OAUTH_CLIENT_ID",
-    clientSecret: "AIRTABLE_OAUTH_CLIENT_SECRET",
-  },
-  asana: {
-    clientId: "ASANA_OAUTH_CLIENT_ID",
-    clientSecret: "ASANA_OAUTH_CLIENT_SECRET",
-  },
-  canva: {
-    clientId: "CANVA_OAUTH_CLIENT_ID",
-    clientSecret: "CANVA_OAUTH_CLIENT_SECRET",
-  },
-  close: {
-    clientId: "CLOSE_OAUTH_CLIENT_ID",
-    clientSecret: "CLOSE_OAUTH_CLIENT_SECRET",
-  },
-  deel: {
-    clientId: "DEEL_OAUTH_CLIENT_ID",
-    clientSecret: "DEEL_OAUTH_CLIENT_SECRET",
-  },
-  docusign: {
-    clientId: "DOCUSIGN_OAUTH_CLIENT_ID",
-    clientSecret: "DOCUSIGN_OAUTH_CLIENT_SECRET",
-  },
-  dropbox: {
-    clientId: "DROPBOX_OAUTH_CLIENT_ID",
-    clientSecret: "DROPBOX_OAUTH_CLIENT_SECRET",
-  },
-  figma: {
-    clientId: "FIGMA_OAUTH_CLIENT_ID",
-    clientSecret: "FIGMA_OAUTH_CLIENT_SECRET",
-  },
-  "garmin-connect": {
-    clientId: "GARMIN_CONNECT_OAUTH_CLIENT_ID",
-    clientSecret: "GARMIN_CONNECT_OAUTH_CLIENT_SECRET",
-  },
-  github: {
-    clientId: "GH_OAUTH_CLIENT_ID",
-    clientSecret: "GH_OAUTH_CLIENT_SECRET",
-  },
-  gmail: {
-    clientId: "GOOGLE_OAUTH_CLIENT_ID",
-    clientSecret: "GOOGLE_OAUTH_CLIENT_SECRET",
-  },
-  "google-ads": {
-    clientId: "GOOGLE_OAUTH_CLIENT_ID",
-    clientSecret: "GOOGLE_OAUTH_CLIENT_SECRET",
-  },
-  "google-calendar": {
-    clientId: "GOOGLE_OAUTH_CLIENT_ID",
-    clientSecret: "GOOGLE_OAUTH_CLIENT_SECRET",
-  },
-  "google-docs": {
-    clientId: "GOOGLE_OAUTH_CLIENT_ID",
-    clientSecret: "GOOGLE_OAUTH_CLIENT_SECRET",
-  },
-  "google-drive": {
-    clientId: "GOOGLE_OAUTH_CLIENT_ID",
-    clientSecret: "GOOGLE_OAUTH_CLIENT_SECRET",
-  },
-  "google-meet": {
-    clientId: "GOOGLE_OAUTH_CLIENT_ID",
-    clientSecret: "GOOGLE_OAUTH_CLIENT_SECRET",
-  },
-  "google-sheets": {
-    clientId: "GOOGLE_OAUTH_CLIENT_ID",
-    clientSecret: "GOOGLE_OAUTH_CLIENT_SECRET",
-  },
-  gumroad: {
-    clientId: "GUMROAD_OAUTH_CLIENT_ID",
-    clientSecret: "GUMROAD_OAUTH_CLIENT_SECRET",
-  },
-  hubspot: {
-    clientId: "HUBSPOT_OAUTH_CLIENT_ID",
-    clientSecret: "HUBSPOT_OAUTH_CLIENT_SECRET",
-  },
-  "intervals-icu": {
-    clientId: "INTERVALS_ICU_OAUTH_CLIENT_ID",
-    clientSecret: "INTERVALS_ICU_OAUTH_CLIENT_SECRET",
-  },
-  linear: {
-    clientId: "LINEAR_OAUTH_CLIENT_ID",
-    clientSecret: "LINEAR_OAUTH_CLIENT_SECRET",
-  },
-  mercury: {
-    clientId: "MERCURY_OAUTH_CLIENT_ID",
-    clientSecret: "MERCURY_OAUTH_CLIENT_SECRET",
-  },
-  "meta-ads": {
-    clientId: "META_ADS_OAUTH_CLIENT_ID",
-    clientSecret: "META_ADS_OAUTH_CLIENT_SECRET",
-  },
-  monday: {
-    clientId: "MONDAY_OAUTH_CLIENT_ID",
-    clientSecret: "MONDAY_OAUTH_CLIENT_SECRET",
-  },
-  neon: {
-    clientId: "NEON_OAUTH_CLIENT_ID",
-    clientSecret: "NEON_OAUTH_CLIENT_SECRET",
-  },
-  notion: {
-    clientId: "NOTION_OAUTH_CLIENT_ID",
-    clientSecret: "NOTION_OAUTH_CLIENT_SECRET",
-  },
-  "outlook-calendar": {
-    clientId: "MICROSOFT_OAUTH_CLIENT_ID",
-    clientSecret: "MICROSOFT_OAUTH_CLIENT_SECRET",
-  },
-  "outlook-mail": {
-    clientId: "MICROSOFT_OAUTH_CLIENT_ID",
-    clientSecret: "MICROSOFT_OAUTH_CLIENT_SECRET",
-  },
-  posthog: {
-    clientId: "POSTHOG_OAUTH_CLIENT_ID",
-    clientSecret: "POSTHOG_OAUTH_CLIENT_SECRET",
-  },
-  reddit: {
-    clientId: "REDDIT_OAUTH_CLIENT_ID",
-    clientSecret: "REDDIT_OAUTH_CLIENT_SECRET",
-  },
-  sentry: {
-    clientId: "SENTRY_OAUTH_CLIENT_ID",
-    clientSecret: "SENTRY_OAUTH_CLIENT_SECRET",
-  },
-  slack: {
-    clientId: "SLACK_CLIENT_ID",
-    clientSecret: "SLACK_CLIENT_SECRET",
-  },
-  spotify: {
-    clientId: "SPOTIFY_OAUTH_CLIENT_ID",
-    clientSecret: "SPOTIFY_OAUTH_CLIENT_SECRET",
-  },
-  strava: {
-    clientId: "STRAVA_OAUTH_CLIENT_ID",
-    clientSecret: "STRAVA_OAUTH_CLIENT_SECRET",
-  },
-  stripe: {
-    clientId: "STRIPE_OAUTH_CLIENT_ID",
-    clientSecret: "STRIPE_OAUTH_CLIENT_SECRET",
-  },
-  supabase: {
-    clientId: "SUPABASE_OAUTH_CLIENT_ID",
-    clientSecret: "SUPABASE_OAUTH_CLIENT_SECRET",
-  },
-  todoist: {
-    clientId: "TODOIST_OAUTH_CLIENT_ID",
-    clientSecret: "TODOIST_OAUTH_CLIENT_SECRET",
-  },
-  vercel: {
-    clientId: "VERCEL_OAUTH_CLIENT_ID",
-    clientSecret: "VERCEL_OAUTH_CLIENT_SECRET",
-  },
-  webflow: {
-    clientId: "WEBFLOW_OAUTH_CLIENT_ID",
-    clientSecret: "WEBFLOW_OAUTH_CLIENT_SECRET",
-  },
-  x: {
-    clientId: "X_OAUTH_CLIENT_ID",
-    clientSecret: "X_OAUTH_CLIENT_SECRET",
-  },
-  xero: {
-    clientId: "XERO_OAUTH_CLIENT_ID",
-    clientSecret: "XERO_OAUTH_CLIENT_SECRET",
-  },
-  zoom: {
-    clientId: "ZOOM_OAUTH_CLIENT_ID",
-    clientSecret: "ZOOM_OAUTH_CLIENT_SECRET",
-  },
-};
-
-const STATIC_OAUTH_CONFIGURED_CONNECTOR_TYPES = new Set<ConnectorType>([
-  "test-oauth",
-]);
+export interface ConnectorOAuthCredentials {
+  readonly configured: boolean;
+  readonly client: ConnectorOAuthClientConfig;
+  readonly clientId?: string;
+  readonly clientSecret?: string;
+}
 
 function hasEnvValue(readEnv: ConnectorEnvReader, name: string): boolean {
   return Boolean(readEnv(name));
+}
+
+export function getConnectorOAuthClientConfig(
+  type: ConnectorType,
+): ConnectorOAuthClientConfig | undefined {
+  return getConnectorOAuthConfig(type)?.client;
+}
+
+export function resolveConnectorOAuthClientCredentials(
+  client: ConnectorOAuthClientConfig,
+  readEnv: ConnectorEnvReader,
+): ConnectorOAuthCredentials {
+  if (client.clientRegistration === "dynamic") {
+    return { configured: true, client };
+  }
+
+  if ("clientId" in client) {
+    return {
+      configured: true,
+      client,
+      clientId: client.clientId,
+      clientSecret:
+        client.clientType === "confidential" ? client.clientSecret : undefined,
+    };
+  }
+
+  const clientId = readEnv(client.clientIdEnv);
+  if (!clientId) {
+    return { configured: false, client };
+  }
+
+  if (client.clientType === "public") {
+    return { configured: true, client, clientId };
+  }
+
+  const clientSecret = readEnv(client.clientSecretEnv);
+  if (!clientSecret) {
+    return { configured: false, client, clientId };
+  }
+
+  return { configured: true, client, clientId, clientSecret };
+}
+
+export function getConnectorOAuthCredentials(
+  type: ConnectorType,
+  readEnv: ConnectorEnvReader,
+): ConnectorOAuthCredentials | undefined {
+  const client = getConnectorOAuthClientConfig(type);
+  if (!client) {
+    return undefined;
+  }
+  return resolveConnectorOAuthClientCredentials(client, readEnv);
 }
 
 function hasConfiguredOAuth(
   readEnv: ConnectorEnvReader,
   type: ConnectorType,
 ): boolean {
-  if (STATIC_OAUTH_CONFIGURED_CONNECTOR_TYPES.has(type)) {
-    return true;
-  }
-  const keys = OAUTH_ENV_KEYS_BY_CONNECTOR[type];
-  return keys
-    ? hasEnvValue(readEnv, keys.clientId) &&
-        hasEnvValue(readEnv, keys.clientSecret)
-    : false;
+  return getConnectorOAuthCredentials(type, readEnv)?.configured ?? false;
 }
 
 export function getConnectorOAuthEnvKeys(
   type: ConnectorType,
 ): ConnectorOAuthEnvKeys | undefined {
-  return OAUTH_ENV_KEYS_BY_CONNECTOR[type];
+  const client = getConnectorOAuthClientConfig(type);
+  if (
+    !client ||
+    client.clientRegistration !== "static" ||
+    !("clientIdEnv" in client)
+  ) {
+    return undefined;
+  }
+  return {
+    clientId: client.clientIdEnv,
+    clientSecret:
+      client.clientType === "confidential" ? client.clientSecretEnv : undefined,
+  };
 }
 
 /**

--- a/turbo/packages/connectors/src/connectors.ts
+++ b/turbo/packages/connectors/src/connectors.ts
@@ -245,9 +245,52 @@ export interface ConnectorAuthMethodConfig {
 /**
  * OAuth configuration for connectors that support OAuth flow.
  */
+export type ConnectorOAuthTokenEndpointAuthMethod =
+  | "none"
+  | "client_secret_basic"
+  | "client_secret_post";
+
+export type ConnectorOAuthClientConfig =
+  | {
+      readonly clientRegistration: "static";
+      readonly clientType: "confidential";
+      readonly tokenEndpointAuthMethod:
+        | "client_secret_basic"
+        | "client_secret_post";
+      readonly clientIdEnv: string;
+      readonly clientSecretEnv: string;
+    }
+  | {
+      readonly clientRegistration: "static";
+      readonly clientType: "confidential";
+      readonly tokenEndpointAuthMethod:
+        | "client_secret_basic"
+        | "client_secret_post";
+      readonly clientId: string;
+      readonly clientSecret: string;
+    }
+  | {
+      readonly clientRegistration: "static";
+      readonly clientType: "public";
+      readonly tokenEndpointAuthMethod: "none";
+      readonly clientIdEnv: string;
+    }
+  | {
+      readonly clientRegistration: "static";
+      readonly clientType: "public";
+      readonly tokenEndpointAuthMethod: "none";
+      readonly clientId: string;
+    }
+  | {
+      readonly clientRegistration: "dynamic";
+      readonly clientType: "public";
+      readonly tokenEndpointAuthMethod: "none";
+    };
+
 export interface ConnectorOAuthConfig {
   authorizationUrl?: string;
   tokenUrl: string;
+  client: ConnectorOAuthClientConfig;
   scopes: string[];
 }
 

--- a/turbo/packages/connectors/src/connectors/ahrefs.ts
+++ b/turbo/packages/connectors/src/connectors/ahrefs.ts
@@ -43,6 +43,13 @@ export const ahrefs = {
     oauth: {
       authorizationUrl: "https://app.ahrefs.com/api/auth",
       tokenUrl: "https://app.ahrefs.com/api/token",
+      client: {
+        clientRegistration: "static",
+        clientType: "confidential",
+        tokenEndpointAuthMethod: "client_secret_post",
+        clientIdEnv: "AHREFS_OAUTH_CLIENT_ID",
+        clientSecretEnv: "AHREFS_OAUTH_CLIENT_SECRET",
+      },
       scopes: ["api"],
     },
   },

--- a/turbo/packages/connectors/src/connectors/airtable.ts
+++ b/turbo/packages/connectors/src/connectors/airtable.ts
@@ -29,6 +29,13 @@ export const airtable = {
     oauth: {
       authorizationUrl: "https://airtable.com/oauth2/v1/authorize",
       tokenUrl: "https://airtable.com/oauth2/v1/token",
+      client: {
+        clientRegistration: "static",
+        clientType: "confidential",
+        tokenEndpointAuthMethod: "client_secret_basic",
+        clientIdEnv: "AIRTABLE_OAUTH_CLIENT_ID",
+        clientSecretEnv: "AIRTABLE_OAUTH_CLIENT_SECRET",
+      },
       scopes: [
         "data.records:read",
         "data.records:write",

--- a/turbo/packages/connectors/src/connectors/asana.ts
+++ b/turbo/packages/connectors/src/connectors/asana.ts
@@ -29,6 +29,13 @@ export const asana = {
     oauth: {
       authorizationUrl: "https://app.asana.com/-/oauth_authorize",
       tokenUrl: "https://app.asana.com/-/oauth_token",
+      client: {
+        clientRegistration: "static",
+        clientType: "confidential",
+        tokenEndpointAuthMethod: "client_secret_post",
+        clientIdEnv: "ASANA_OAUTH_CLIENT_ID",
+        clientSecretEnv: "ASANA_OAUTH_CLIENT_SECRET",
+      },
       scopes: [],
     },
   },

--- a/turbo/packages/connectors/src/connectors/canva.ts
+++ b/turbo/packages/connectors/src/connectors/canva.ts
@@ -31,6 +31,13 @@ export const canva = {
     oauth: {
       authorizationUrl: "https://www.canva.com/api/oauth/authorize",
       tokenUrl: "https://api.canva.com/rest/v1/oauth/token",
+      client: {
+        clientRegistration: "static",
+        clientType: "confidential",
+        tokenEndpointAuthMethod: "client_secret_basic",
+        clientIdEnv: "CANVA_OAUTH_CLIENT_ID",
+        clientSecretEnv: "CANVA_OAUTH_CLIENT_SECRET",
+      },
       scopes: [
         "asset:read",
         "asset:write",

--- a/turbo/packages/connectors/src/connectors/close.ts
+++ b/turbo/packages/connectors/src/connectors/close.ts
@@ -31,6 +31,13 @@ export const close = {
     oauth: {
       authorizationUrl: "https://app.close.com/oauth2/authorize/",
       tokenUrl: "https://api.close.com/oauth2/token/",
+      client: {
+        clientRegistration: "static",
+        clientType: "confidential",
+        tokenEndpointAuthMethod: "client_secret_post",
+        clientIdEnv: "CLOSE_OAUTH_CLIENT_ID",
+        clientSecretEnv: "CLOSE_OAUTH_CLIENT_SECRET",
+      },
       scopes: ["all.full_access", "offline_access"],
     },
   },

--- a/turbo/packages/connectors/src/connectors/deel.ts
+++ b/turbo/packages/connectors/src/connectors/deel.ts
@@ -42,6 +42,13 @@ export const deel = {
     oauth: {
       authorizationUrl: "https://app.deel.com/oauth2/authorize",
       tokenUrl: "https://app.deel.com/oauth2/tokens",
+      client: {
+        clientRegistration: "static",
+        clientType: "confidential",
+        tokenEndpointAuthMethod: "client_secret_basic",
+        clientIdEnv: "DEEL_OAUTH_CLIENT_ID",
+        clientSecretEnv: "DEEL_OAUTH_CLIENT_SECRET",
+      },
       scopes: [
         "contracts:read",
         "people:read",

--- a/turbo/packages/connectors/src/connectors/docusign.ts
+++ b/turbo/packages/connectors/src/connectors/docusign.ts
@@ -31,6 +31,13 @@ export const docusign = {
     oauth: {
       authorizationUrl: "https://account-d.docusign.com/oauth/auth",
       tokenUrl: "https://account-d.docusign.com/oauth/token",
+      client: {
+        clientRegistration: "static",
+        clientType: "confidential",
+        tokenEndpointAuthMethod: "client_secret_basic",
+        clientIdEnv: "DOCUSIGN_OAUTH_CLIENT_ID",
+        clientSecretEnv: "DOCUSIGN_OAUTH_CLIENT_SECRET",
+      },
       scopes: ["signature", "extended", "openid"],
     },
   },

--- a/turbo/packages/connectors/src/connectors/dropbox.ts
+++ b/turbo/packages/connectors/src/connectors/dropbox.ts
@@ -42,6 +42,13 @@ export const dropbox = {
     oauth: {
       authorizationUrl: "https://www.dropbox.com/oauth2/authorize",
       tokenUrl: "https://api.dropboxapi.com/oauth2/token",
+      client: {
+        clientRegistration: "static",
+        clientType: "confidential",
+        tokenEndpointAuthMethod: "client_secret_post",
+        clientIdEnv: "DROPBOX_OAUTH_CLIENT_ID",
+        clientSecretEnv: "DROPBOX_OAUTH_CLIENT_SECRET",
+      },
       scopes: [
         "account_info.read",
         "files.metadata.read",

--- a/turbo/packages/connectors/src/connectors/figma.ts
+++ b/turbo/packages/connectors/src/connectors/figma.ts
@@ -42,6 +42,13 @@ export const figma = {
     oauth: {
       authorizationUrl: "https://www.figma.com/oauth",
       tokenUrl: "https://api.figma.com/v1/oauth/token",
+      client: {
+        clientRegistration: "static",
+        clientType: "confidential",
+        tokenEndpointAuthMethod: "client_secret_basic",
+        clientIdEnv: "FIGMA_OAUTH_CLIENT_ID",
+        clientSecretEnv: "FIGMA_OAUTH_CLIENT_SECRET",
+      },
       scopes: [
         "current_user:read",
         "file_content:read",

--- a/turbo/packages/connectors/src/connectors/garmin-connect.ts
+++ b/turbo/packages/connectors/src/connectors/garmin-connect.ts
@@ -31,6 +31,13 @@ export const garminConnect = {
     oauth: {
       authorizationUrl: "https://connect.garmin.com/oauth2Confirm",
       tokenUrl: "https://diauth.garmin.com/di-oauth2-service/oauth/token",
+      client: {
+        clientRegistration: "static",
+        clientType: "confidential",
+        tokenEndpointAuthMethod: "client_secret_post",
+        clientIdEnv: "GARMIN_CONNECT_OAUTH_CLIENT_ID",
+        clientSecretEnv: "GARMIN_CONNECT_OAUTH_CLIENT_SECRET",
+      },
       scopes: [],
     },
   },

--- a/turbo/packages/connectors/src/connectors/github.ts
+++ b/turbo/packages/connectors/src/connectors/github.ts
@@ -27,6 +27,13 @@ export const github = {
     oauth: {
       authorizationUrl: "https://github.com/login/oauth/authorize",
       tokenUrl: "https://github.com/login/oauth/access_token",
+      client: {
+        clientRegistration: "static",
+        clientType: "confidential",
+        tokenEndpointAuthMethod: "client_secret_post",
+        clientIdEnv: "GH_OAUTH_CLIENT_ID",
+        clientSecretEnv: "GH_OAUTH_CLIENT_SECRET",
+      },
       scopes: ["repo", "project", "workflow"],
     },
   },

--- a/turbo/packages/connectors/src/connectors/gmail.ts
+++ b/turbo/packages/connectors/src/connectors/gmail.ts
@@ -29,6 +29,13 @@ export const gmail = {
     oauth: {
       authorizationUrl: "https://accounts.google.com/o/oauth2/v2/auth",
       tokenUrl: "https://oauth2.googleapis.com/token",
+      client: {
+        clientRegistration: "static",
+        clientType: "confidential",
+        tokenEndpointAuthMethod: "client_secret_post",
+        clientIdEnv: "GOOGLE_OAUTH_CLIENT_ID",
+        clientSecretEnv: "GOOGLE_OAUTH_CLIENT_SECRET",
+      },
       scopes: ["https://www.googleapis.com/auth/gmail.modify"],
     },
   },

--- a/turbo/packages/connectors/src/connectors/google-ads.ts
+++ b/turbo/packages/connectors/src/connectors/google-ads.ts
@@ -32,6 +32,13 @@ export const googleAds = {
     oauth: {
       authorizationUrl: "https://accounts.google.com/o/oauth2/v2/auth",
       tokenUrl: "https://oauth2.googleapis.com/token",
+      client: {
+        clientRegistration: "static",
+        clientType: "confidential",
+        tokenEndpointAuthMethod: "client_secret_post",
+        clientIdEnv: "GOOGLE_OAUTH_CLIENT_ID",
+        clientSecretEnv: "GOOGLE_OAUTH_CLIENT_SECRET",
+      },
       scopes: [
         "https://www.googleapis.com/auth/adwords",
         "https://www.googleapis.com/auth/userinfo.email",

--- a/turbo/packages/connectors/src/connectors/google-calendar.ts
+++ b/turbo/packages/connectors/src/connectors/google-calendar.ts
@@ -30,6 +30,13 @@ export const googleCalendar = {
     oauth: {
       authorizationUrl: "https://accounts.google.com/o/oauth2/v2/auth",
       tokenUrl: "https://oauth2.googleapis.com/token",
+      client: {
+        clientRegistration: "static",
+        clientType: "confidential",
+        tokenEndpointAuthMethod: "client_secret_post",
+        clientIdEnv: "GOOGLE_OAUTH_CLIENT_ID",
+        clientSecretEnv: "GOOGLE_OAUTH_CLIENT_SECRET",
+      },
       scopes: [
         "https://www.googleapis.com/auth/calendar",
         "https://www.googleapis.com/auth/userinfo.email",

--- a/turbo/packages/connectors/src/connectors/google-docs.ts
+++ b/turbo/packages/connectors/src/connectors/google-docs.ts
@@ -28,6 +28,13 @@ export const googleDocs = {
     oauth: {
       authorizationUrl: "https://accounts.google.com/o/oauth2/v2/auth",
       tokenUrl: "https://oauth2.googleapis.com/token",
+      client: {
+        clientRegistration: "static",
+        clientType: "confidential",
+        tokenEndpointAuthMethod: "client_secret_post",
+        clientIdEnv: "GOOGLE_OAUTH_CLIENT_ID",
+        clientSecretEnv: "GOOGLE_OAUTH_CLIENT_SECRET",
+      },
       scopes: [
         "https://www.googleapis.com/auth/documents",
         "https://www.googleapis.com/auth/userinfo.email",

--- a/turbo/packages/connectors/src/connectors/google-drive.ts
+++ b/turbo/packages/connectors/src/connectors/google-drive.ts
@@ -28,6 +28,13 @@ export const googleDrive = {
     oauth: {
       authorizationUrl: "https://accounts.google.com/o/oauth2/v2/auth",
       tokenUrl: "https://oauth2.googleapis.com/token",
+      client: {
+        clientRegistration: "static",
+        clientType: "confidential",
+        tokenEndpointAuthMethod: "client_secret_post",
+        clientIdEnv: "GOOGLE_OAUTH_CLIENT_ID",
+        clientSecretEnv: "GOOGLE_OAUTH_CLIENT_SECRET",
+      },
       scopes: [
         "https://www.googleapis.com/auth/drive",
         "https://www.googleapis.com/auth/userinfo.email",

--- a/turbo/packages/connectors/src/connectors/google-meet.ts
+++ b/turbo/packages/connectors/src/connectors/google-meet.ts
@@ -29,6 +29,13 @@ export const googleMeet = {
     oauth: {
       authorizationUrl: "https://accounts.google.com/o/oauth2/v2/auth",
       tokenUrl: "https://oauth2.googleapis.com/token",
+      client: {
+        clientRegistration: "static",
+        clientType: "confidential",
+        tokenEndpointAuthMethod: "client_secret_post",
+        clientIdEnv: "GOOGLE_OAUTH_CLIENT_ID",
+        clientSecretEnv: "GOOGLE_OAUTH_CLIENT_SECRET",
+      },
       scopes: [
         "https://www.googleapis.com/auth/meetings.space.created",
         // Use meetings.space.readonly (not meetings.conferencerecords.readonly) — confirmed

--- a/turbo/packages/connectors/src/connectors/google-sheets.ts
+++ b/turbo/packages/connectors/src/connectors/google-sheets.ts
@@ -28,6 +28,13 @@ export const googleSheets = {
     oauth: {
       authorizationUrl: "https://accounts.google.com/o/oauth2/v2/auth",
       tokenUrl: "https://oauth2.googleapis.com/token",
+      client: {
+        clientRegistration: "static",
+        clientType: "confidential",
+        tokenEndpointAuthMethod: "client_secret_post",
+        clientIdEnv: "GOOGLE_OAUTH_CLIENT_ID",
+        clientSecretEnv: "GOOGLE_OAUTH_CLIENT_SECRET",
+      },
       scopes: [
         "https://www.googleapis.com/auth/spreadsheets",
         "https://www.googleapis.com/auth/userinfo.email",

--- a/turbo/packages/connectors/src/connectors/gumroad.ts
+++ b/turbo/packages/connectors/src/connectors/gumroad.ts
@@ -38,6 +38,13 @@ export const gumroad = {
     oauth: {
       authorizationUrl: "https://gumroad.com/oauth/authorize",
       tokenUrl: "https://gumroad.com/oauth/token",
+      client: {
+        clientRegistration: "static",
+        clientType: "confidential",
+        tokenEndpointAuthMethod: "client_secret_post",
+        clientIdEnv: "GUMROAD_OAUTH_CLIENT_ID",
+        clientSecretEnv: "GUMROAD_OAUTH_CLIENT_SECRET",
+      },
       scopes: [
         "view_profile",
         "edit_products",

--- a/turbo/packages/connectors/src/connectors/hubspot.ts
+++ b/turbo/packages/connectors/src/connectors/hubspot.ts
@@ -29,6 +29,13 @@ export const hubspot = {
     oauth: {
       authorizationUrl: "https://app.hubspot.com/oauth/authorize",
       tokenUrl: "https://api.hubapi.com/oauth/v1/token",
+      client: {
+        clientRegistration: "static",
+        clientType: "confidential",
+        tokenEndpointAuthMethod: "client_secret_post",
+        clientIdEnv: "HUBSPOT_OAUTH_CLIENT_ID",
+        clientSecretEnv: "HUBSPOT_OAUTH_CLIENT_SECRET",
+      },
       scopes: [
         "crm.objects.contacts.read",
         "crm.objects.contacts.write",

--- a/turbo/packages/connectors/src/connectors/intervals-icu.ts
+++ b/turbo/packages/connectors/src/connectors/intervals-icu.ts
@@ -25,6 +25,13 @@ export const intervalsIcu = {
     oauth: {
       authorizationUrl: "https://intervals.icu/oauth/authorize",
       tokenUrl: "https://intervals.icu/api/oauth/token",
+      client: {
+        clientRegistration: "static",
+        clientType: "confidential",
+        tokenEndpointAuthMethod: "client_secret_post",
+        clientIdEnv: "INTERVALS_ICU_OAUTH_CLIENT_ID",
+        clientSecretEnv: "INTERVALS_ICU_OAUTH_CLIENT_SECRET",
+      },
       scopes: ["ACTIVITY", "WELLNESS", "CALENDAR", "SETTINGS", "LIBRARY"],
     },
   },

--- a/turbo/packages/connectors/src/connectors/linear.ts
+++ b/turbo/packages/connectors/src/connectors/linear.ts
@@ -29,6 +29,13 @@ export const linear = {
     oauth: {
       authorizationUrl: "https://linear.app/oauth/authorize",
       tokenUrl: "https://api.linear.app/oauth/token",
+      client: {
+        clientRegistration: "static",
+        clientType: "confidential",
+        tokenEndpointAuthMethod: "client_secret_post",
+        clientIdEnv: "LINEAR_OAUTH_CLIENT_ID",
+        clientSecretEnv: "LINEAR_OAUTH_CLIENT_SECRET",
+      },
       scopes: [
         "read",
         "write",

--- a/turbo/packages/connectors/src/connectors/mailchimp.ts
+++ b/turbo/packages/connectors/src/connectors/mailchimp.ts
@@ -39,6 +39,13 @@ export const mailchimp = {
     oauth: {
       authorizationUrl: "https://login.mailchimp.com/oauth2/authorize",
       tokenUrl: "https://login.mailchimp.com/oauth2/token",
+      client: {
+        clientRegistration: "static",
+        clientType: "confidential",
+        tokenEndpointAuthMethod: "client_secret_post",
+        clientIdEnv: "MAILCHIMP_OAUTH_CLIENT_ID",
+        clientSecretEnv: "MAILCHIMP_OAUTH_CLIENT_SECRET",
+      },
       scopes: [],
     },
   },

--- a/turbo/packages/connectors/src/connectors/mercury.ts
+++ b/turbo/packages/connectors/src/connectors/mercury.ts
@@ -43,6 +43,13 @@ export const mercury = {
     oauth: {
       authorizationUrl: "https://oauth2.mercury.com/oauth2/auth",
       tokenUrl: "https://oauth2.mercury.com/oauth2/token",
+      client: {
+        clientRegistration: "static",
+        clientType: "confidential",
+        tokenEndpointAuthMethod: "client_secret_post",
+        clientIdEnv: "MERCURY_OAUTH_CLIENT_ID",
+        clientSecretEnv: "MERCURY_OAUTH_CLIENT_SECRET",
+      },
       scopes: ["offline_access"],
     },
   },

--- a/turbo/packages/connectors/src/connectors/meta-ads.ts
+++ b/turbo/packages/connectors/src/connectors/meta-ads.ts
@@ -27,6 +27,13 @@ export const metaAds = {
     oauth: {
       authorizationUrl: "https://www.facebook.com/v22.0/dialog/oauth",
       tokenUrl: "https://graph.facebook.com/v22.0/oauth/access_token",
+      client: {
+        clientRegistration: "static",
+        clientType: "confidential",
+        tokenEndpointAuthMethod: "client_secret_post",
+        clientIdEnv: "META_ADS_OAUTH_CLIENT_ID",
+        clientSecretEnv: "META_ADS_OAUTH_CLIENT_SECRET",
+      },
       scopes: ["ads_management", "ads_read", "business_management"],
     },
   },

--- a/turbo/packages/connectors/src/connectors/monday.ts
+++ b/turbo/packages/connectors/src/connectors/monday.ts
@@ -29,6 +29,13 @@ export const monday = {
     oauth: {
       authorizationUrl: "https://auth.monday.com/oauth2/authorize",
       tokenUrl: "https://auth.monday.com/oauth2/token",
+      client: {
+        clientRegistration: "static",
+        clientType: "confidential",
+        tokenEndpointAuthMethod: "client_secret_post",
+        clientIdEnv: "MONDAY_OAUTH_CLIENT_ID",
+        clientSecretEnv: "MONDAY_OAUTH_CLIENT_SECRET",
+      },
       scopes: [
         "me:read",
         "boards:read",

--- a/turbo/packages/connectors/src/connectors/neon.ts
+++ b/turbo/packages/connectors/src/connectors/neon.ts
@@ -43,6 +43,13 @@ export const neon = {
     oauth: {
       authorizationUrl: "https://oauth2.neon.tech/oauth2/auth",
       tokenUrl: "https://oauth2.neon.tech/oauth2/token",
+      client: {
+        clientRegistration: "static",
+        clientType: "confidential",
+        tokenEndpointAuthMethod: "client_secret_post",
+        clientIdEnv: "NEON_OAUTH_CLIENT_ID",
+        clientSecretEnv: "NEON_OAUTH_CLIENT_SECRET",
+      },
       scopes: [
         "openid",
         "offline_access",

--- a/turbo/packages/connectors/src/connectors/notion.ts
+++ b/turbo/packages/connectors/src/connectors/notion.ts
@@ -29,6 +29,13 @@ export const notion = {
     oauth: {
       authorizationUrl: "https://api.notion.com/v1/oauth/authorize",
       tokenUrl: "https://api.notion.com/v1/oauth/token",
+      client: {
+        clientRegistration: "static",
+        clientType: "confidential",
+        tokenEndpointAuthMethod: "client_secret_basic",
+        clientIdEnv: "NOTION_OAUTH_CLIENT_ID",
+        clientSecretEnv: "NOTION_OAUTH_CLIENT_SECRET",
+      },
       scopes: [],
     },
   },

--- a/turbo/packages/connectors/src/connectors/outlook-calendar.ts
+++ b/turbo/packages/connectors/src/connectors/outlook-calendar.ts
@@ -32,6 +32,13 @@ export const outlookCalendar = {
       authorizationUrl:
         "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
       tokenUrl: "https://login.microsoftonline.com/common/oauth2/v2.0/token",
+      client: {
+        clientRegistration: "static",
+        clientType: "confidential",
+        tokenEndpointAuthMethod: "client_secret_post",
+        clientIdEnv: "MICROSOFT_OAUTH_CLIENT_ID",
+        clientSecretEnv: "MICROSOFT_OAUTH_CLIENT_SECRET",
+      },
       scopes: ["Calendars.ReadWrite", "User.Read", "offline_access"],
     },
   },

--- a/turbo/packages/connectors/src/connectors/outlook-mail.ts
+++ b/turbo/packages/connectors/src/connectors/outlook-mail.ts
@@ -31,6 +31,13 @@ export const outlookMail = {
       authorizationUrl:
         "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
       tokenUrl: "https://login.microsoftonline.com/common/oauth2/v2.0/token",
+      client: {
+        clientRegistration: "static",
+        clientType: "confidential",
+        tokenEndpointAuthMethod: "client_secret_post",
+        clientIdEnv: "MICROSOFT_OAUTH_CLIENT_ID",
+        clientSecretEnv: "MICROSOFT_OAUTH_CLIENT_SECRET",
+      },
       scopes: ["Mail.ReadWrite", "Mail.Send", "User.Read", "offline_access"],
     },
   },

--- a/turbo/packages/connectors/src/connectors/posthog.ts
+++ b/turbo/packages/connectors/src/connectors/posthog.ts
@@ -43,6 +43,13 @@ export const posthog = {
     oauth: {
       authorizationUrl: "https://us.posthog.com/oauth/authorize",
       tokenUrl: "https://us.posthog.com/oauth/token",
+      client: {
+        clientRegistration: "static",
+        clientType: "confidential",
+        tokenEndpointAuthMethod: "client_secret_post",
+        clientIdEnv: "POSTHOG_OAUTH_CLIENT_ID",
+        clientSecretEnv: "POSTHOG_OAUTH_CLIENT_SECRET",
+      },
       scopes: [
         "openid",
         "profile",

--- a/turbo/packages/connectors/src/connectors/reddit.ts
+++ b/turbo/packages/connectors/src/connectors/reddit.ts
@@ -31,6 +31,13 @@ export const reddit = {
     oauth: {
       authorizationUrl: "https://www.reddit.com/api/v1/authorize",
       tokenUrl: "https://www.reddit.com/api/v1/access_token",
+      client: {
+        clientRegistration: "static",
+        clientType: "confidential",
+        tokenEndpointAuthMethod: "client_secret_basic",
+        clientIdEnv: "REDDIT_OAUTH_CLIENT_ID",
+        clientSecretEnv: "REDDIT_OAUTH_CLIENT_SECRET",
+      },
       scopes: ["identity", "read"],
     },
   },

--- a/turbo/packages/connectors/src/connectors/sentry.ts
+++ b/turbo/packages/connectors/src/connectors/sentry.ts
@@ -29,6 +29,13 @@ export const sentry = {
     oauth: {
       authorizationUrl: "https://sentry.io/oauth/authorize/",
       tokenUrl: "https://sentry.io/oauth/token/",
+      client: {
+        clientRegistration: "static",
+        clientType: "confidential",
+        tokenEndpointAuthMethod: "client_secret_post",
+        clientIdEnv: "SENTRY_OAUTH_CLIENT_ID",
+        clientSecretEnv: "SENTRY_OAUTH_CLIENT_SECRET",
+      },
       scopes: [
         "org:read",
         "project:read",

--- a/turbo/packages/connectors/src/connectors/slack.ts
+++ b/turbo/packages/connectors/src/connectors/slack.ts
@@ -25,6 +25,13 @@ export const slack = {
     oauth: {
       authorizationUrl: "https://slack.com/oauth/v2/authorize",
       tokenUrl: "https://slack.com/api/oauth.v2.access",
+      client: {
+        clientRegistration: "static",
+        clientType: "confidential",
+        tokenEndpointAuthMethod: "client_secret_post",
+        clientIdEnv: "SLACK_CLIENT_ID",
+        clientSecretEnv: "SLACK_CLIENT_SECRET",
+      },
       // Note: Slack does not approve `search:read` or user `*:history`
       // scopes outside of RTS / MCP applications. The personal connector
       // intentionally omits them. Bot-side history access is provided

--- a/turbo/packages/connectors/src/connectors/spotify.ts
+++ b/turbo/packages/connectors/src/connectors/spotify.ts
@@ -31,6 +31,13 @@ export const spotify = {
     oauth: {
       authorizationUrl: "https://accounts.spotify.com/authorize",
       tokenUrl: "https://accounts.spotify.com/api/token",
+      client: {
+        clientRegistration: "static",
+        clientType: "confidential",
+        tokenEndpointAuthMethod: "client_secret_basic",
+        clientIdEnv: "SPOTIFY_OAUTH_CLIENT_ID",
+        clientSecretEnv: "SPOTIFY_OAUTH_CLIENT_SECRET",
+      },
       scopes: [
         "ugc-image-upload",
         "user-read-playback-state",

--- a/turbo/packages/connectors/src/connectors/strava.ts
+++ b/turbo/packages/connectors/src/connectors/strava.ts
@@ -29,6 +29,13 @@ export const strava = {
     oauth: {
       authorizationUrl: "https://www.strava.com/oauth/authorize",
       tokenUrl: "https://www.strava.com/oauth/token",
+      client: {
+        clientRegistration: "static",
+        clientType: "confidential",
+        tokenEndpointAuthMethod: "client_secret_post",
+        clientIdEnv: "STRAVA_OAUTH_CLIENT_ID",
+        clientSecretEnv: "STRAVA_OAUTH_CLIENT_SECRET",
+      },
       scopes: [
         "read",
         "profile:read_all",

--- a/turbo/packages/connectors/src/connectors/stripe.ts
+++ b/turbo/packages/connectors/src/connectors/stripe.ts
@@ -65,6 +65,13 @@ export const stripe = {
     oauth: {
       authorizationUrl: "https://connect.stripe.com/oauth/authorize",
       tokenUrl: "https://connect.stripe.com/oauth/token",
+      client: {
+        clientRegistration: "static",
+        clientType: "confidential",
+        tokenEndpointAuthMethod: "client_secret_post",
+        clientIdEnv: "STRIPE_OAUTH_CLIENT_ID",
+        clientSecretEnv: "STRIPE_OAUTH_CLIENT_SECRET",
+      },
       scopes: ["read_write"],
     },
   },

--- a/turbo/packages/connectors/src/connectors/supabase.ts
+++ b/turbo/packages/connectors/src/connectors/supabase.ts
@@ -43,6 +43,13 @@ export const supabase = {
     oauth: {
       authorizationUrl: "https://api.supabase.com/v1/oauth/authorize",
       tokenUrl: "https://api.supabase.com/v1/oauth/token",
+      client: {
+        clientRegistration: "static",
+        clientType: "confidential",
+        tokenEndpointAuthMethod: "client_secret_basic",
+        clientIdEnv: "SUPABASE_OAUTH_CLIENT_ID",
+        clientSecretEnv: "SUPABASE_OAUTH_CLIENT_SECRET",
+      },
       scopes: [
         "organizations:read",
         "projects:read",

--- a/turbo/packages/connectors/src/connectors/test-oauth.ts
+++ b/turbo/packages/connectors/src/connectors/test-oauth.ts
@@ -34,6 +34,13 @@ export const testOauth = {
       // the preview-URL host changes per deploy.
       authorizationUrl: "/api/test/oauth-provider/authorize",
       tokenUrl: "/api/test/oauth-provider/token",
+      client: {
+        clientRegistration: "static",
+        clientType: "confidential",
+        tokenEndpointAuthMethod: "client_secret_post",
+        clientId: "test-oauth-client",
+        clientSecret: "test-oauth-secret",
+      },
       scopes: ["read"],
     },
   },

--- a/turbo/packages/connectors/src/connectors/todoist.ts
+++ b/turbo/packages/connectors/src/connectors/todoist.ts
@@ -25,6 +25,13 @@ export const todoist = {
     oauth: {
       authorizationUrl: "https://todoist.com/oauth/authorize",
       tokenUrl: "https://todoist.com/oauth/access_token",
+      client: {
+        clientRegistration: "static",
+        clientType: "confidential",
+        tokenEndpointAuthMethod: "client_secret_post",
+        clientIdEnv: "TODOIST_OAUTH_CLIENT_ID",
+        clientSecretEnv: "TODOIST_OAUTH_CLIENT_SECRET",
+      },
       scopes: ["data:read_write", "data:delete", "project:delete"],
     },
   },

--- a/turbo/packages/connectors/src/connectors/vercel.ts
+++ b/turbo/packages/connectors/src/connectors/vercel.ts
@@ -24,6 +24,13 @@ export const vercel = {
     defaultAuthMethod: "oauth",
     oauth: {
       tokenUrl: "https://api.vercel.com/v2/oauth/access_token",
+      client: {
+        clientRegistration: "static",
+        clientType: "confidential",
+        tokenEndpointAuthMethod: "client_secret_post",
+        clientIdEnv: "VERCEL_OAUTH_CLIENT_ID",
+        clientSecretEnv: "VERCEL_OAUTH_CLIENT_SECRET",
+      },
       scopes: [],
     },
   },

--- a/turbo/packages/connectors/src/connectors/webflow.ts
+++ b/turbo/packages/connectors/src/connectors/webflow.ts
@@ -38,6 +38,13 @@ export const webflow = {
     oauth: {
       authorizationUrl: "https://webflow.com/oauth/authorize",
       tokenUrl: "https://api.webflow.com/oauth/access_token",
+      client: {
+        clientRegistration: "static",
+        clientType: "confidential",
+        tokenEndpointAuthMethod: "client_secret_post",
+        clientIdEnv: "WEBFLOW_OAUTH_CLIENT_ID",
+        clientSecretEnv: "WEBFLOW_OAUTH_CLIENT_SECRET",
+      },
       scopes: [
         "authorized_user:read",
         "sites:read",

--- a/turbo/packages/connectors/src/connectors/x.ts
+++ b/turbo/packages/connectors/src/connectors/x.ts
@@ -29,6 +29,13 @@ export const x = {
     oauth: {
       authorizationUrl: "https://twitter.com/i/oauth2/authorize",
       tokenUrl: "https://api.twitter.com/2/oauth2/token",
+      client: {
+        clientRegistration: "static",
+        clientType: "confidential",
+        tokenEndpointAuthMethod: "client_secret_basic",
+        clientIdEnv: "X_OAUTH_CLIENT_ID",
+        clientSecretEnv: "X_OAUTH_CLIENT_SECRET",
+      },
       // https://docs.x.com/fundamentals/authentication/oauth-2-0/authorization-code
       scopes: [
         "tweet.read", // All the Tweets you can view, including Tweets from protected accounts.

--- a/turbo/packages/connectors/src/connectors/xero.ts
+++ b/turbo/packages/connectors/src/connectors/xero.ts
@@ -29,6 +29,13 @@ export const xero = {
     oauth: {
       authorizationUrl: "https://login.xero.com/identity/connect/authorize",
       tokenUrl: "https://identity.xero.com/connect/token",
+      client: {
+        clientRegistration: "static",
+        clientType: "confidential",
+        tokenEndpointAuthMethod: "client_secret_post",
+        clientIdEnv: "XERO_OAUTH_CLIENT_ID",
+        clientSecretEnv: "XERO_OAUTH_CLIENT_SECRET",
+      },
       scopes: [
         "openid",
         "profile",

--- a/turbo/packages/connectors/src/connectors/zoom.ts
+++ b/turbo/packages/connectors/src/connectors/zoom.ts
@@ -31,6 +31,13 @@ export const zoom = {
     oauth: {
       authorizationUrl: "https://zoom.us/oauth/authorize",
       tokenUrl: "https://zoom.us/oauth/token",
+      client: {
+        clientRegistration: "static",
+        clientType: "confidential",
+        tokenEndpointAuthMethod: "client_secret_basic",
+        clientIdEnv: "ZOOM_OAUTH_CLIENT_ID",
+        clientSecretEnv: "ZOOM_OAUTH_CLIENT_SECRET",
+      },
       // Granular scopes (Zoom's "resource:action:target" format). Covers the
       // core read/write flows documented in the zoom skill: users, meetings,
       // past-meeting data, cloud recordings, and webinars.

--- a/turbo/packages/connectors/src/oauth-providers/provider-registry.ts
+++ b/turbo/packages/connectors/src/oauth-providers/provider-registry.ts
@@ -2,6 +2,14 @@ import type { ConnectorType } from "@vm0/connectors/connectors";
 import { getRuntimeAvailableConnectorTypes as getRuntimeAvailableConnectorTypesFromEnv } from "@vm0/connectors/connector-utils";
 import {
   type AuthUrlResult,
+  type OAuthAuthorizeArgs,
+  type OAuthExchangeArgs,
+  type OAuthRefreshArgs,
+  type OAuthRefreshResult,
+  buildProviderAuthUrl,
+  exchangeProviderCode,
+  refreshProviderToken,
+  providerEnvFromObject,
   type OAuthTokenResult,
   type ProviderHandler,
   type ProviderEnv,
@@ -225,9 +233,21 @@ import { gongHandler } from "./providers/gong-handler";
 import { ironcladHandler } from "./providers/ironclad-handler";
 import { snowflakeHandler } from "./providers/snowflake-handler";
 
-export type { AuthUrlResult, OAuthTokenResult };
+export type {
+  AuthUrlResult,
+  OAuthAuthorizeArgs,
+  OAuthExchangeArgs,
+  OAuthRefreshArgs,
+  OAuthRefreshResult,
+  OAuthTokenResult,
+};
 export type { ProviderEnv };
-export { providerEnvFromObject } from "./provider-types";
+export {
+  buildProviderAuthUrl,
+  exchangeProviderCode,
+  providerEnvFromObject,
+  refreshProviderToken,
+};
 
 export const PROVIDER_HANDLERS: Record<
   Exclude<ConnectorType, "computer">,

--- a/turbo/packages/connectors/src/oauth-providers/provider-types.ts
+++ b/turbo/packages/connectors/src/oauth-providers/provider-types.ts
@@ -31,7 +31,36 @@ export interface OAuthTokenResult {
  */
 export interface AuthUrlResult {
   url: string;
-  codeVerifier: string;
+  codeVerifier?: string;
+  oauthContext?: string;
+}
+
+export interface OAuthAuthorizeArgs {
+  readonly clientId?: string;
+  readonly redirectUri: string;
+  readonly state: string;
+}
+
+export interface OAuthExchangeArgs {
+  readonly clientId?: string;
+  readonly clientSecret?: string;
+  readonly code: string;
+  readonly redirectUri: string;
+  readonly state?: string;
+  readonly codeVerifier?: string;
+  readonly oauthContext?: string;
+}
+
+export interface OAuthRefreshArgs {
+  readonly clientId?: string;
+  readonly clientSecret?: string;
+  readonly refreshToken: string;
+}
+
+export interface OAuthRefreshResult {
+  readonly accessToken: string;
+  readonly refreshToken: string | null;
+  readonly expiresIn?: number;
 }
 
 export interface ProviderHandler {
@@ -39,6 +68,9 @@ export interface ProviderHandler {
     clientId: string,
     redirectUri: string,
     state: string,
+  ): string | AuthUrlResult | Promise<string | AuthUrlResult>;
+  buildAuthUrlWithArgs?(
+    args: OAuthAuthorizeArgs,
   ): string | AuthUrlResult | Promise<string | AuthUrlResult>;
   exchangeCode(
     clientId: string,
@@ -48,6 +80,7 @@ export interface ProviderHandler {
     state?: string,
     codeVerifier?: string,
   ): Promise<OAuthTokenResult>;
+  exchangeCodeWithArgs?(args: OAuthExchangeArgs): Promise<OAuthTokenResult>;
   getClientId(currentEnv: ProviderEnv): string | undefined;
   getClientSecret(currentEnv: ProviderEnv): string | undefined;
   getSecretName(): string;
@@ -56,14 +89,68 @@ export interface ProviderHandler {
     clientId: string,
     clientSecret: string,
     refreshToken: string,
-  ): Promise<{
-    accessToken: string;
-    refreshToken: string | null;
-    expiresIn?: number;
-  }>;
+  ): Promise<OAuthRefreshResult>;
+  refreshTokenWithArgs?(args: OAuthRefreshArgs): Promise<OAuthRefreshResult>;
   revokeToken?(
     clientId: string,
     clientSecret: string,
     accessToken: string,
   ): Promise<void>;
+}
+
+export async function buildProviderAuthUrl(
+  handler: ProviderHandler,
+  args: OAuthAuthorizeArgs,
+): Promise<string | AuthUrlResult> {
+  if (handler.buildAuthUrlWithArgs) {
+    return await handler.buildAuthUrlWithArgs(args);
+  }
+  if (!args.clientId) {
+    throw new Error("OAuth provider handler requires a client ID");
+  }
+  return await handler.buildAuthUrl(
+    args.clientId,
+    args.redirectUri,
+    args.state,
+  );
+}
+
+export async function exchangeProviderCode(
+  handler: ProviderHandler,
+  args: OAuthExchangeArgs,
+): Promise<OAuthTokenResult> {
+  if (handler.exchangeCodeWithArgs) {
+    return await handler.exchangeCodeWithArgs(args);
+  }
+  if (!args.clientId || !args.clientSecret) {
+    throw new Error("OAuth provider handler requires client credentials");
+  }
+  return await handler.exchangeCode(
+    args.clientId,
+    args.clientSecret,
+    args.code,
+    args.redirectUri,
+    args.state,
+    args.codeVerifier,
+  );
+}
+
+export async function refreshProviderToken(
+  handler: ProviderHandler,
+  args: OAuthRefreshArgs,
+): Promise<OAuthRefreshResult> {
+  if (handler.refreshTokenWithArgs) {
+    return await handler.refreshTokenWithArgs(args);
+  }
+  if (!handler.refreshToken) {
+    throw new Error("OAuth provider handler does not support token refresh");
+  }
+  if (!args.clientId || !args.clientSecret) {
+    throw new Error("OAuth provider handler requires client credentials");
+  }
+  return await handler.refreshToken(
+    args.clientId,
+    args.clientSecret,
+    args.refreshToken,
+  );
 }

--- a/turbo/packages/connectors/src/oauth-providers/providers/mailchimp-handler.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/mailchimp-handler.ts
@@ -25,11 +25,11 @@ export const mailchimpHandler: ProviderHandler = {
       },
     };
   },
-  getClientId: () => {
-    return undefined;
+  getClientId: (e) => {
+    return e.MAILCHIMP_OAUTH_CLIENT_ID;
   },
-  getClientSecret: () => {
-    return undefined;
+  getClientSecret: (e) => {
+    return e.MAILCHIMP_OAUTH_CLIENT_SECRET;
   },
   getSecretName: getMailchimpSecretName,
 };


### PR DESCRIPTION
Closes #13887

## Summary
- add `oauth.client` metadata for connector OAuth client registration, client type, and token endpoint auth method
- derive OAuth runtime availability and credentials from connector config instead of a separate env-key map
- add structured provider auth/exchange/refresh helpers plus opaque OAuth context cookie plumbing for API authorize/callback
- update API and web token refresh paths to support connector dynamic-public clients while preserving model-provider OAuth behavior
- add focused coverage for static confidential, static public, dynamic public authorize/callback/refresh, and existing connector OAuth regressions

## Tests
- `pnpm -F @vm0/connectors exec vitest run src/__tests__/connectors.test.ts src/oauth-providers/providers/__tests__/test-oauth.test.ts`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-connectors-authorize.test.ts src/signals/routes/__tests__/connectors-type-callback.test.ts src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/connectors-type-authorize.test.ts`
- `pnpm -F web exec vitest run __tests__/security-headers.test.ts __tests__/api-backend-rewrite-proxy.test.ts src/lib/zero/connector/providers/__tests__/codex-oauth.test.ts app/api/webhooks/agent/firewall/auth/__tests__/route.test.ts`
- `pnpm -F @vm0/connectors check-types`
- `pnpm -F api check-types`
- `pnpm -F web check-types`
- `pnpm -F @vm0/connectors lint`
- `pnpm -F api lint`
- `pnpm -F web lint`
- pre-commit hook: prettier, knip, full `pnpm check-types`