### PR TITLE
docs: add API testing guide

### DIFF
--- a/.claude/skills/testing/SKILL.md
+++ b/.claude/skills/testing/SKILL.md
@@ -19,6 +19,7 @@ Read the testing guide and relevant reference based on context:
 | Patterns | [docs/testing.md](../../../docs/testing.md) | [patterns.md](../../../docs/testing/patterns.md) |
 | CLI (`turbo/apps/cli`) | [docs/testing.md](../../../docs/testing.md) | [cli-testing.md](../../../docs/testing/cli-testing.md) |
 | CLI E2E (`e2e/tests/`) | [docs/testing.md](../../../docs/testing.md) | [cli-e2e-testing.md](../../../docs/testing/cli-e2e-testing.md) |
+| API (`turbo/apps/api`) | [docs/testing.md](../../../docs/testing.md) | [api-testing.md](../../../docs/testing/api-testing.md) |
 | Web (`turbo/apps/web`) | [docs/testing.md](../../../docs/testing.md) | [web-testing.md](../../../docs/testing/web-testing.md) |
 | App (`turbo/apps/platform`) | [docs/testing.md](../../../docs/testing.md) | [app-testing.md](../../../docs/testing/app-testing.md) |
 | Rust (`crates/`) | [docs/testing.md](../../../docs/testing.md) | [rust-testing.md](../../../docs/testing/rust-testing.md) |

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -2,7 +2,7 @@
 
 ## Why We Care About Testing
 
-Good tests give us confidence to ship fast. Bad tests slow us down with false failures, missed bugs, and maintenance burden. After years of writing tests, we've learned that *how* you test matters more than *how much* you test.
+Good tests give us confidence to ship fast. Bad tests slow us down with false failures, missed bugs, and maintenance burden. After years of writing tests, we've learned that _how_ you test matters more than _how much_ you test.
 
 Kent C. Dodds summarized it well: **"Write tests. Not too many. Mostly integration."**
 
@@ -85,12 +85,12 @@ Here's a quick heuristic: **if the path in `vi.mock()` starts with `../` or `../
 
 ```typescript
 // ✅ Good: External packages
-vi.mock("@clerk/nextjs")
-vi.mock("@aws-sdk/client-s3")
+vi.mock("@clerk/nextjs");
+vi.mock("@aws-sdk/client-s3");
 
 // ❌ Bad: Internal code
-vi.mock("../../services/user-service")
-vi.mock("../utils/format")
+vi.mock("../../services/user-service");
+vi.mock("../utils/format");
 ```
 
 When you mock internal code, you're not testing real behavior. You're testing that your test correctly orchestrates mocks. That's a recipe for tests that pass while production breaks.
@@ -170,7 +170,7 @@ vi.useFakeTimers();
 vi.advanceTimersByTime(1000);
 
 // ✅ Mock only what you need
-vi.spyOn(Date, 'now').mockReturnValue(fixedTimestamp);
+vi.spyOn(Date, "now").mockReturnValue(fixedTimestamp);
 ```
 
 Fake timers can mask race conditions and timing bugs. If you need deterministic time, mock `Date.now()` specifically.
@@ -197,37 +197,52 @@ it("should create a compose", async () => {
   server.use(
     http.post("http://localhost:3000/api/composes", () => {
       return HttpResponse.json({ id: "cmp-123" });
-    })
+    }),
   );
 
   await composeCommand.parseAsync(["node", "cli", "vm0.yaml"]);
 
   expect(console.log).toHaveBeenCalledWith(
-    expect.stringContaining("Compose created")
+    expect.stringContaining("Compose created"),
   );
 });
 ```
 
 Console output and exit codes are valid assertions for CLI tests—that's the user interface.
 
-### Web Routes
+### API Routes
 
-Test route handlers directly, mock only external services:
+Test `apps/api` routes through the Hono app and the route's ts-rest contract,
+mocking only external services:
 
 ```typescript
-vi.mock("@clerk/nextjs/server");
+const context = testContext();
 
-it("should create a run", async () => {
-  mockAuth({ userId: "user-123" });
+it("should return the runner metadata", async () => {
+  mocks.clerk.session(userId, orgId);
+  const client = setupApp({ context })(zeroRunRunnerContract);
 
-  const response = await POST(request);
-  const data = await response.json();
+  const response = await accept(
+    client.getRunner({
+      params: { id: runId },
+      headers: { authorization: "Bearer clerk-session" },
+    }),
+    [200],
+  );
 
-  expect(data.status).toBe("pending");
+  expect(response.body).toStrictEqual({ sandboxReuseResult: "reused" });
 });
 ```
 
-Use real database operations for verification—if you created a run, query the database to confirm it exists.
+Use route calls, focused fixture helpers, and real database state. Do not mock
+internal API services when a route can exercise the behavior.
+
+### Web Route Compatibility
+
+For endpoints that still live in `apps/web`, test the legacy Next.js route
+handler directly. For endpoints migrated to `apps/api`, keep behavior tests in
+`apps/api` and use web tests only for rewrite, middleware, and security-header
+compatibility.
 
 ### Platform UI
 
@@ -250,20 +265,21 @@ Don't render components directly—use `setupPage()` which mirrors `main.ts` sta
 
 ### Deep Dives
 
-| Topic | Guide |
-|-------|-------|
+| Topic         | Guide                                                                                                               |
+| ------------- | ------------------------------------------------------------------------------------------------------------------- |
 | Anti-patterns | [anti-patterns.md](./testing/anti-patterns.md) — Detailed catalog of testing mistakes to avoid (AP-1 through AP-10) |
-| Patterns | [patterns.md](./testing/patterns.md) — Standard patterns, file structure, migration workflow |
+| Patterns      | [patterns.md](./testing/patterns.md) — Standard patterns, file structure, migration workflow                        |
 
 ### App-Specific Guides
 
-| App | Guide |
-|-----|-------|
-| CLI commands | [cli-testing.md](./testing/cli-testing.md) |
-| CLI E2E (BATS) | [cli-e2e-testing.md](./testing/cli-e2e-testing.md) |
-| Web routes | [web-testing.md](./testing/web-testing.md) |
-| App UI | [app-testing.md](./testing/app-testing.md) |
-| Rust crates | [rust-testing.md](./testing/rust-testing.md) |
-| Python addon | [mitm-addon-testing.md](./testing/mitm-addon-testing.md) |
+| App                                         | Guide                                                    |
+| ------------------------------------------- | -------------------------------------------------------- |
+| CLI commands                                | [cli-testing.md](./testing/cli-testing.md)               |
+| CLI E2E (BATS)                              | [cli-e2e-testing.md](./testing/cli-e2e-testing.md)       |
+| API routes                                  | [api-testing.md](./testing/api-testing.md)               |
+| Legacy web routes and rewrite compatibility | [web-testing.md](./testing/web-testing.md)               |
+| App UI                                      | [app-testing.md](./testing/app-testing.md)               |
+| Rust crates                                 | [rust-testing.md](./testing/rust-testing.md)             |
+| Python addon                                | [mitm-addon-testing.md](./testing/mitm-addon-testing.md) |
 
 For general code quality rules (no `any`, no lint suppressions, etc.), see [bad-smell.md](./bad-smell.md).

--- a/docs/testing/anti-patterns.md
+++ b/docs/testing/anti-patterns.md
@@ -378,7 +378,11 @@ When an API route wraps a service function, test through the route — not the s
 import { upsertOrgModelProvider } from "../../../lib/zero/model-provider/org-model-provider";
 
 it("should create a provider", async () => {
-  const result = await upsertOrgModelProvider(orgId, "anthropic-api-key", "sk-test");
+  const result = await upsertOrgModelProvider(
+    orgId,
+    "anthropic-api-key",
+    "sk-test",
+  );
   expect(result.type).toBe("anthropic-api-key");
 });
 ```
@@ -400,7 +404,10 @@ it("should create a provider", async () => {
 
 The service test passes even if the route handler has a bug in request parsing, auth checking, or response formatting. The route test catches all of these.
 
-**Exception**: Some service functions have no route — see the [Acceptable Service-Level Test Exceptions](web-testing.md#acceptable-service-level-test-exceptions) section in `web-testing.md` for the approved list.
+**Exception**: Some service functions have no route. For `apps/api`, see
+[Service-Level Exceptions](api-testing.md#service-level-exceptions). For legacy
+`apps/web` routes, see
+[Acceptable Service-Level Test Exceptions](web-testing.md#acceptable-service-level-test-exceptions).
 
 ---
 

--- a/docs/testing/api-testing.md
+++ b/docs/testing/api-testing.md
@@ -1,0 +1,220 @@
+# API Testing Patterns
+
+## Principle
+
+In the API app (`turbo/apps/api`), route behavior should be covered by
+**API route integration tests**. These tests exercise the real Hono app through
+`setupApp()` and the route's ts-rest contract, not by importing route handlers or
+service functions directly.
+
+Use this guide for endpoints implemented in `apps/api`, migrated from
+`apps/web`, or promoted to API-authoritative behavior.
+
+## File Location
+
+Place route tests under the API route test directory:
+
+```text
+turbo/apps/api/src/signals/routes/__tests__/
++-- zero-runs-runner.test.ts
++-- helpers/
+    +-- zero-route-test.ts
+```
+
+Shared fixture helpers for one route family belong in
+`turbo/apps/api/src/signals/routes/__tests__/helpers/`. Keep helpers scoped to
+the route family unless there is already a reusable helper with the same shape.
+
+## Route Test Structure
+
+```typescript
+import { randomUUID } from "node:crypto";
+
+import { zeroRunRunnerContract } from "@vm0/api-contracts/contracts/zero-runs";
+import { createStore } from "ccstate";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import {
+  deleteUsageInsightFixture$,
+  seedCompose$,
+  seedRun$,
+  seedUsageInsightFixture$,
+  type UsageInsightFixture,
+} from "./helpers/zero-usage-insight";
+import {
+  createFixtureTracker,
+  createZeroRouteMocks,
+} from "./helpers/zero-route-test";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+
+describe("GET /api/zero/runs/:id/runner", () => {
+  const track = createFixtureTracker<UsageInsightFixture>((fixture) => {
+    return store.set(deleteUsageInsightFixture$, fixture, context.signal);
+  });
+
+  it("returns the sandbox reuse result", async () => {
+    const fixture = await track(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    const compose = await store.set(
+      seedCompose$,
+      { orgId: fixture.orgId, userId: fixture.userId },
+      context.signal,
+    );
+    const { runId } = await store.set(
+      seedRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        composeId: compose.composeId,
+        status: "completed",
+        sandboxReuseResult: "reused",
+      },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(zeroRunRunnerContract);
+
+    const response = await accept(
+      client.getRunner({
+        params: { id: runId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({ sandboxReuseResult: "reused" });
+  });
+
+  it("returns 404 when the run does not exist", async () => {
+    const fixture = await track(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(zeroRunRunnerContract);
+
+    const response = await accept(
+      client.getRunner({
+        params: { id: randomUUID() },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [404],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Agent run not found",
+        code: "NOT_FOUND",
+      },
+    });
+  });
+});
+```
+
+Key points:
+
+1. Import the contract from `@vm0/api-contracts`, then call it through
+   `setupApp({ context })(contract)`.
+2. Use `accept()` to narrow the response type and produce useful failure output.
+3. Put `testContext()` and `createStore()` at module scope.
+4. Mock auth and external services through `context.mocks` or focused helper
+   wrappers such as `createZeroRouteMocks(context)`.
+5. Use fixture helpers and `createFixtureTracker()` for setup and cleanup when
+   the state is not reachable through an existing route.
+
+## What To Test
+
+Route tests should cover user-visible HTTP behavior:
+
+- authentication and organization membership
+- validation failures that callers can hit
+- permission and no-existence-leak behavior
+- success response bodies and status codes
+- persisted side effects when the response alone is not enough
+- external service calls at the boundary, using the centralized mocks
+
+`setupApp()` creates the Hono app with the real route registry and validates
+ts-rest responses. A route test should fail if the handler returns a body that no
+longer matches the contract.
+
+## Mocks
+
+Only mock external services. API tests use the shared mock registry in
+`turbo/apps/api/src/__tests__/mocks.ts` and reset it from
+`turbo/apps/api/src/__tests__/setup.ts`.
+
+Good examples:
+
+```typescript
+mocks.clerk.session(userId, orgId);
+context.mocks.slack.chat.postMessage.mockResolvedValue({ ok: true });
+context.mocks.axiom.query.mockResolvedValue({ buckets: [] });
+```
+
+Avoid `vi.mock()` for internal modules such as services, route files, database
+helpers, or ccstate signals. That bypasses the behavior the route integration
+test is supposed to cover.
+
+## Fixtures And Database State
+
+Prefer creating state through routes when a route exists. When a route needs
+database state that is not reachable through public HTTP behavior, use focused
+ccstate fixture helpers under `__tests__/helpers/`.
+
+Fixture helpers should:
+
+- create unique `orgId` and `userId` values
+- insert the minimum state needed for the route behavior
+- expose a cleanup command used through `createFixtureTracker()`
+- keep raw database operations out of the test body when possible
+
+Direct database reads in a test body are acceptable when they verify a persisted
+side effect that is not visible in the HTTP response. Direct writes should live
+in fixture helpers unless the setup is truly one-off and smaller than a helper.
+
+## Service-Level Exceptions
+
+Route tests are the default. A service-level test is acceptable only when there
+is no HTTP route that exercises the behavior, or when the behavior runs before a
+route handler can execute.
+
+Typical exceptions:
+
+- auth or middleware resolution
+- cron and internal queue operations without a client route
+- webhook verification helpers without a public wrapper
+- external client adapters
+- complex pure functions or state-machine transition tables
+
+If a route wraps the service, test through the route.
+
+## Migration From apps/web
+
+For migrated endpoints, put behavior coverage in `apps/api`. The web app should
+only keep compatibility coverage for routing concerns, such as:
+
+- exact `API_BACKEND_REWRITES` entries
+- middleware bypass matchers
+- security header behavior around proxied paths
+- legacy routes that still intentionally live in `apps/web`
+
+Do not add a new thin `apps/web/app/api/**/route.ts` proxy for migrated
+endpoints. Route the web-compatible path back to `apps/api` through the API
+backend rewrite configuration.
+
+## Commands
+
+Run route-focused tests from `turbo`:
+
+```shell
+pnpm -F api exec vitest run src/signals/routes/__tests__/zero-runs-runner.test.ts
+pnpm -F api lint
+pnpm -F api check-types
+```
+
+Run one Vitest process at a time.

--- a/docs/testing/patterns.md
+++ b/docs/testing/patterns.md
@@ -2,9 +2,11 @@
 
 This document describes our standard testing patterns. These aren't arbitrary conventions—they're the patterns that have proven to work well for our codebase, helping us write tests that give real confidence while remaining maintainable.
 
-## Pattern 1: API Route Tests
+## Pattern 1: Legacy Web API Route Tests
 
-Our most common test type. When testing Next.js API route handlers, we follow a specific structure that has evolved through practice.
+For `apps/web` routes that still intentionally live in Next.js, we follow a
+specific structure that has evolved through practice. For `apps/api` routes, use
+[api-testing.md](./api-testing.md) instead.
 
 ```typescript
 import { describe, it, expect, beforeEach, vi } from "vitest";
@@ -548,7 +550,7 @@ describe("org signals", () => {
 
 ## Standard Test File Structure
 
-Every web route test file should follow this structure:
+Every legacy web route test file should follow this structure:
 
 ```typescript
 import { describe, it, expect, beforeEach, vi } from "vitest";

--- a/docs/testing/web-testing.md
+++ b/docs/testing/web-testing.md
@@ -2,7 +2,12 @@
 
 ## Principle
 
-In the web app (`turbo/apps/web`), only write **Web Route Integration Tests** (`route.test.ts` files) - test API endpoints only.
+In the web app (`turbo/apps/web`), route tests are for legacy API endpoints
+that still intentionally live in `apps/web`. New or migrated endpoint behavior
+belongs in `apps/api`; see [api-testing.md](./api-testing.md).
+
+For migrated endpoints, web-side tests should cover compatibility only: exact
+API backend rewrites, middleware bypass behavior, and security headers.
 
 ## File Location
 
@@ -288,10 +293,10 @@ await completeTestRun(user.userId, runId);
 
 Only test route-level integration tests (primary) and pure functions (exception only):
 
-| Type                            | Location                | Examples                                     |
-| ------------------------------- | ----------------------- | -------------------------------------------- |
-| **Web Route Integration Tests** | `app/.../route.test.ts` | Validation, authorization, business logic    |
-| Pure function tests (exception) | `lib/.../xxx.test.ts`   | Extremely complex algorithmic functions only |
+| Type                                   | Location                | Examples                                     |
+| -------------------------------------- | ----------------------- | -------------------------------------------- |
+| **Legacy Web Route Integration Tests** | `app/.../route.test.ts` | Validation, authorization, business logic    |
+| Pure function tests (exception)        | `lib/.../xxx.test.ts`   | Extremely complex algorithmic functions only |
 
 ```typescript
 // Route-level test
@@ -322,7 +327,7 @@ Pure function tests are a **rare exception**, reserved only for:
 - **Security-critical functions** (cryptographic operations, token validation, permission checks)
 - **Extremely complex algorithms** where bugs would have severe consequences
 
-**NOT allowed** (test via Web Route Integration Tests instead): validators, parsers, formatters, simple utilities.
+**NOT allowed** (test via Legacy Web Route Integration Tests instead): validators, parsers, formatters, simple utilities.
 
 These tests should be simple and isolated - no mocks, no database operations, no external dependencies.
 
@@ -454,8 +459,8 @@ Functions only accessible internally:
 
 If the ESLint rule flags a service import in your test file:
 
-1. First verify no route exists — check `app/api/` for a handler that wraps the function
-2. If a route exists, migrate the test to use the route handler (see Web Route Integration Tests above)
+1. First verify no route exists — check `apps/web/app/api/` for a handler that wraps the function
+2. If a web route exists, migrate the test to use the route handler (see Legacy Web Route Integration Tests above)
 3. If no route exists, add an eslint-disable comment with a documented reason:
 
 ```typescript


### PR DESCRIPTION
## Summary
- add a dedicated docs/testing/api-testing.md guide for apps/api route integration tests
- update the main testing index and testing skill table to point to API-specific guidance
- clarify that web testing is now for legacy web routes and rewrite compatibility after API migration

## Validation
- pnpm --dir turbo exec prettier --check ../docs/testing.md ../docs/testing/api-testing.md ../docs/testing/web-testing.md ../docs/testing/patterns.md ../docs/testing/anti-patterns.md ../.claude/skills/testing/SKILL.md
- git diff --check