### PR TITLE
fix: separate desktop development app identity

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -109,7 +109,7 @@ jobs:
           /usr/libexec/PlistBuddy -c "Print :CFBundleExecutable" "$plist" | grep -qx "Zero"
           /usr/libexec/PlistBuddy -c "Print :CFBundleIdentifier" "$plist" | grep -qx "ai.vm0.zero.desktop"
           /usr/libexec/PlistBuddy -c "Print :CFBundleURLTypes:0:CFBundleURLName" "$plist" | grep -qx "Zero Desktop Auth"
-          /usr/libexec/PlistBuddy -c "Print :CFBundleURLTypes:0:CFBundleURLSchemes:0" "$plist" | grep -qx "vm0"
+          /usr/libexec/PlistBuddy -c "Print :CFBundleURLTypes:0:CFBundleURLSchemes:0" "$plist" | grep -qx "ai.vm0.zero.desktop"
 
           unzip -l "$artifact_path" | grep -q "Zero.app/Contents/MacOS/Zero"
           unzip -l "$artifact_path" | grep -q "Zero.app/Contents/Resources/app/dist/main.js"

--- a/turbo/apps/api/src/signals/routes/__tests__/desktop-auth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/desktop-auth.test.ts
@@ -41,9 +41,12 @@ function mockSession(userId: string): void {
   });
 }
 
-function codeFromCallbackUrl(callbackUrl: string): string {
+function codeFromCallbackUrl(
+  callbackUrl: string,
+  expectedProtocol = "ai.vm0.zero.desktop:",
+): string {
   const url = new URL(callbackUrl);
-  expect(url.protocol).toBe("vm0:");
+  expect(url.protocol).toBe(expectedProtocol);
   expect(url.hostname).toBe("auth");
   expect(url.pathname).toBe("/callback");
   return url.searchParams.get("code") ?? "";
@@ -95,6 +98,25 @@ describe("desktop auth routes", () => {
     const rows = await handoffRowsForUser(userId);
     expect(rows).toHaveLength(1);
     expect(rows[0]?.codeHash).not.toBe(code);
+  });
+
+  it("creates a development callback URL when requested", async () => {
+    const userId = `user_desktop_${randomUUID()}`;
+    mockSession(userId);
+
+    const response = await accept(
+      handoffClient().create({
+        body: { callbackScheme: "ai.vm0.zero.desktop.dev" },
+        headers: authHeaders(),
+      }),
+      [200],
+    );
+
+    const code = codeFromCallbackUrl(
+      response.body.callbackUrl,
+      "ai.vm0.zero.desktop.dev:",
+    );
+    expect(code).not.toBe("");
   });
 
   it("consumes a handoff code once and returns a short-lived Clerk ticket", async () => {

--- a/turbo/apps/api/src/signals/routes/desktop-auth.ts
+++ b/turbo/apps/api/src/signals/routes/desktop-auth.ts
@@ -20,10 +20,17 @@ import {
 } from "../services/desktop-auth.service";
 import { settle } from "../utils";
 
+const createBody$ = bodyResultOf(desktopAuthHandoffContract.create);
 const consumeBody$ = bodyResultOf(desktopAuthConsumeContract.consume);
 
 const createDesktopAuthHandoff$ = command(
   async ({ get, set }, signal: AbortSignal) => {
+    const bodyResult = await get(createBody$);
+    signal.throwIfAborted();
+    if (!bodyResult.ok) {
+      return bodyResult.response;
+    }
+
     const auth = get(authContext$);
     const writeDb = set(writeDb$);
     const code = await createDesktopAuthHandoffCode(writeDb, {
@@ -34,7 +41,10 @@ const createDesktopAuthHandoff$ = command(
     return {
       status: 200 as const,
       body: {
-        callbackUrl: buildDesktopAuthCallbackUrl(code),
+        callbackUrl: buildDesktopAuthCallbackUrl(
+          code,
+          bodyResult.data?.callbackScheme,
+        ),
       },
     };
   },

--- a/turbo/apps/api/src/signals/services/desktop-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/desktop-auth.service.ts
@@ -1,11 +1,16 @@
 import { createHash, randomBytes } from "node:crypto";
+import {
+  defaultDesktopAuthCallbackScheme,
+  type DesktopAuthCallbackScheme,
+} from "@vm0/api-contracts/contracts/desktop-auth";
 import { desktopAuthHandoffCodes } from "@vm0/db/schema/desktop-auth-handoff-code";
 import { and, eq, gt, isNull } from "drizzle-orm";
 
 import { nowDate } from "../../lib/time";
 import type { Db } from "../external/db";
 
-const DESKTOP_AUTH_CALLBACK_URL = "vm0://auth/callback";
+const DESKTOP_AUTH_CALLBACK_HOST = "auth";
+const DESKTOP_AUTH_CALLBACK_PATH = "/callback";
 const DESKTOP_AUTH_HANDOFF_CODE_BYTES = 32;
 const DESKTOP_AUTH_HANDOFF_CODE_TTL_MS = 60 * 1000;
 const DESKTOP_AUTH_CODE_PATTERN = /^[A-Za-z0-9_-]{32,128}$/;
@@ -38,8 +43,13 @@ function assertValidDesktopAuthCode(code: string): void {
   }
 }
 
-export function buildDesktopAuthCallbackUrl(code: string): string {
-  const callbackUrl = new URL(DESKTOP_AUTH_CALLBACK_URL);
+export function buildDesktopAuthCallbackUrl(
+  code: string,
+  callbackScheme: DesktopAuthCallbackScheme = defaultDesktopAuthCallbackScheme,
+): string {
+  const callbackUrl = new URL(
+    `${callbackScheme}://${DESKTOP_AUTH_CALLBACK_HOST}${DESKTOP_AUTH_CALLBACK_PATH}`,
+  );
   callbackUrl.searchParams.set("code", code);
   return callbackUrl.toString();
 }

--- a/turbo/apps/desktop/forge.config.js
+++ b/turbo/apps/desktop/forge.config.js
@@ -1,8 +1,30 @@
+const desktopIdentities = require("./src/desktop-identities.json");
+
+const PRODUCTION_PLATFORM_HOSTNAME = "app.vm0.ai";
+
+function platformHostname(rawUrl) {
+  if (!rawUrl || !rawUrl.trim()) {
+    return PRODUCTION_PLATFORM_HOSTNAME;
+  }
+  return new URL(rawUrl).hostname;
+}
+
+function desktopIdentityForPlatformUrl(rawUrl) {
+  if (platformHostname(rawUrl) === PRODUCTION_PLATFORM_HOSTNAME) {
+    return desktopIdentities.production;
+  }
+  return desktopIdentities.development;
+}
+
+const desktopIdentity = desktopIdentityForPlatformUrl(
+  process.env.VM0_DESKTOP_PLATFORM_URL,
+);
+
 module.exports = {
   packagerConfig: {
-    name: "Zero",
-    executableName: "Zero",
-    appBundleId: "ai.vm0.zero.desktop",
+    name: desktopIdentity.displayName,
+    executableName: desktopIdentity.displayName,
+    appBundleId: desktopIdentity.bundleId,
     asar: false,
     osxSign: {
       hardenedRuntime: false,
@@ -16,8 +38,8 @@ module.exports = {
     },
     protocols: [
       {
-        name: "Zero Desktop Auth",
-        schemes: ["vm0"],
+        name: desktopIdentity.authProtocolName,
+        schemes: [desktopIdentity.authScheme],
       },
     ],
     ignore: [

--- a/turbo/apps/desktop/src/config.ts
+++ b/turbo/apps/desktop/src/config.ts
@@ -1,10 +1,24 @@
+import desktopIdentities from "./desktop-identities.json";
+
 const PRODUCTION_PLATFORM_URL = "https://app.vm0.ai";
 
 type DesktopEnvironment = "production" | "staging" | "development";
+type DesktopIdentityKind = "production" | "development";
+
+interface DesktopIdentity {
+  readonly displayName: string;
+  readonly bundleId: string;
+  readonly authProtocolName: string;
+  readonly authScheme: string;
+}
+
+const DESKTOP_IDENTITIES: Record<DesktopIdentityKind, DesktopIdentity> =
+  desktopIdentities;
 
 interface DesktopConfig {
   readonly platformUrl: URL;
   readonly environment: DesktopEnvironment;
+  readonly identity: DesktopIdentity;
   readonly sessionPartition: string;
   readonly allowedAppOrigins: ReadonlySet<string>;
 }
@@ -33,6 +47,15 @@ function environmentForPlatformUrl(
     return "staging";
   }
   return "development";
+}
+
+function identityForEnvironment(
+  environment: DesktopEnvironment,
+): DesktopIdentity {
+  if (environment === "production") {
+    return DESKTOP_IDENTITIES.production;
+  }
+  return DESKTOP_IDENTITIES.development;
 }
 
 function addDerivedOrigin(
@@ -75,6 +98,7 @@ export function resolveDesktopConfig(
   return {
     platformUrl,
     environment,
+    identity: identityForEnvironment(environment),
     sessionPartition: `persist:vm0-desktop-${environment}`,
     allowedAppOrigins: allowedOriginsForPlatformUrl(platformUrl),
   };

--- a/turbo/apps/desktop/src/desktop-auth.ts
+++ b/turbo/apps/desktop/src/desktop-auth.ts
@@ -1,9 +1,8 @@
-export const DESKTOP_AUTH_PROTOCOL = "vm0";
-
 const DESKTOP_AUTH_HOST = "auth";
 const DESKTOP_AUTH_CALLBACK_PATH = "/callback";
 const DESKTOP_AUTH_CONSUME_PATH = "/desktop-auth/consume";
 const DESKTOP_AUTH_START_WEB_PATH = "/desktop-auth/start";
+const DESKTOP_AUTH_CALLBACK_SCHEME_PARAM = "callbackScheme";
 const DESKTOP_SIGNED_OUT_PATHS = new Set(["/sign-in", "/sign-up"]);
 const DESKTOP_AUTH_CODE_PATTERN = /^[A-Za-z0-9_-]{32,128}$/;
 const DESKTOP_AUTH_START_RETRY_MS = 30_000;
@@ -27,6 +26,7 @@ function parseUrl(rawUrl: string): URL | null {
 
 export function parseDesktopAuthCallback(
   rawUrl: string,
+  authScheme: string,
 ): DesktopAuthCallback | null {
   const url = parseUrl(rawUrl);
   if (!url) {
@@ -35,7 +35,7 @@ export function parseDesktopAuthCallback(
 
   const code = url.searchParams.get("code");
   if (
-    url.protocol !== `${DESKTOP_AUTH_PROTOCOL}:` ||
+    url.protocol !== `${authScheme}:` ||
     url.hostname !== DESKTOP_AUTH_HOST ||
     url.pathname !== DESKTOP_AUTH_CALLBACK_PATH ||
     !code ||
@@ -49,9 +49,10 @@ export function parseDesktopAuthCallback(
 
 export function parseDesktopAuthCallbackArgv(
   argv: readonly string[],
+  authScheme: string,
 ): DesktopAuthCallback | null {
   for (const arg of argv) {
-    const callback = parseDesktopAuthCallback(arg);
+    const callback = parseDesktopAuthCallback(arg, authScheme);
     if (callback) {
       return callback;
     }
@@ -69,8 +70,13 @@ export function buildDesktopAuthConsumeUrl(
   return consumeUrl.toString();
 }
 
-export function buildDesktopAuthStartUrl(platformUrl: URL): string {
-  return new URL(DESKTOP_AUTH_START_WEB_PATH, platformUrl).toString();
+export function buildDesktopAuthStartUrl(
+  platformUrl: URL,
+  authScheme: string,
+): string {
+  const startUrl = new URL(DESKTOP_AUTH_START_WEB_PATH, platformUrl);
+  startUrl.searchParams.set(DESKTOP_AUTH_CALLBACK_SCHEME_PARAM, authScheme);
+  return startUrl.toString();
 }
 
 export function isDesktopAuthStartNavigation(

--- a/turbo/apps/desktop/src/desktop-identities.json
+++ b/turbo/apps/desktop/src/desktop-identities.json
@@ -1,0 +1,14 @@
+{
+  "production": {
+    "displayName": "Zero",
+    "bundleId": "ai.vm0.zero.desktop",
+    "authProtocolName": "Zero Desktop Auth",
+    "authScheme": "ai.vm0.zero.desktop"
+  },
+  "development": {
+    "displayName": "Zero Dev",
+    "bundleId": "ai.vm0.zero.desktop.dev",
+    "authProtocolName": "Zero Dev Desktop Auth",
+    "authScheme": "ai.vm0.zero.desktop.dev"
+  }
+}

--- a/turbo/apps/desktop/src/main.ts
+++ b/turbo/apps/desktop/src/main.ts
@@ -2,21 +2,22 @@ import path from "node:path";
 import { app, BrowserWindow, shell } from "electron";
 import { resolveDesktopConfig } from "./config";
 import {
-  DESKTOP_AUTH_PROTOCOL,
   buildDesktopAuthConsumeUrl,
   buildDesktopAuthStartUrl,
   createDesktopAuthStartGate,
   isDesktopAuthStartNavigation,
   isDesktopSignedOutNavigation,
-  parseDesktopAuthCallbackArgv,
   parseDesktopAuthCallback,
+  parseDesktopAuthCallbackArgv,
 } from "./desktop-auth";
 import { buildSignedOutPageUrl } from "./signed-out-page";
 import { decideWindowOpen, isAllowedAppNavigation } from "./window-policy";
 
-const APP_NAME = "Zero";
 const config = resolveDesktopConfig();
-const desktopAuthStartUrl = buildDesktopAuthStartUrl(config.platformUrl);
+const desktopAuthStartUrl = buildDesktopAuthStartUrl(
+  config.platformUrl,
+  config.identity.authScheme,
+);
 const signedOutPageUrl = buildSignedOutPageUrl(desktopAuthStartUrl);
 let mainWindow: BrowserWindow | null = null;
 let pendingDesktopAuthCode: string | null = null;
@@ -42,7 +43,7 @@ function openDesktopAuthStart(rawUrl: string): boolean {
 }
 
 function openDesktopAuthCallback(rawUrl: string): boolean {
-  const callback = parseDesktopAuthCallback(rawUrl);
+  const callback = parseDesktopAuthCallback(rawUrl, config.identity.authScheme);
   if (!callback) {
     return false;
   }
@@ -93,7 +94,7 @@ function handleAuthNavigation(
 
 function browserWindowOptions() {
   return {
-    title: APP_NAME,
+    title: config.identity.displayName,
     backgroundColor: "#19191b",
     webPreferences: {
       nodeIntegration: false,
@@ -220,7 +221,10 @@ function handleDesktopAuthCallback(rawUrl: string): void {
 }
 
 function handleDesktopAuthCallbackArgv(argv: readonly string[]): boolean {
-  const callback = parseDesktopAuthCallbackArgv(argv);
+  const callback = parseDesktopAuthCallbackArgv(
+    argv,
+    config.identity.authScheme,
+  );
   if (!callback) {
     return false;
   }
@@ -236,7 +240,10 @@ function handleDesktopAuthCallbackArgv(argv: readonly string[]): boolean {
 }
 
 function queueDesktopAuthCallbackArgv(argv: readonly string[]): boolean {
-  const callback = parseDesktopAuthCallbackArgv(argv);
+  const callback = parseDesktopAuthCallbackArgv(
+    argv,
+    config.identity.authScheme,
+  );
   if (!callback) {
     return false;
   }
@@ -254,21 +261,23 @@ function registerDesktopAuthProtocol(): void {
   if (process.defaultApp) {
     const entryPoint = process.argv[1];
     if (entryPoint) {
-      app.setAsDefaultProtocolClient(DESKTOP_AUTH_PROTOCOL, process.execPath, [
-        path.resolve(entryPoint),
-      ]);
+      app.setAsDefaultProtocolClient(
+        config.identity.authScheme,
+        process.execPath,
+        [path.resolve(entryPoint)],
+      );
       return;
     }
   }
 
-  app.setAsDefaultProtocolClient(DESKTOP_AUTH_PROTOCOL);
+  app.setAsDefaultProtocolClient(config.identity.authScheme);
 }
 
 if (process.platform !== "darwin") {
   console.warn("Zero Desktop POC is macOS-first and only packages for darwin.");
 }
 
-app.name = APP_NAME;
+app.name = config.identity.displayName;
 
 const hasSingleInstanceLock = app.requestSingleInstanceLock();
 

--- a/turbo/apps/desktop/src/window-policy.test.ts
+++ b/turbo/apps/desktop/src/window-policy.test.ts
@@ -18,6 +18,11 @@ describe("resolveDesktopConfig", () => {
 
     expect(config.platformUrl.toString()).toBe("https://app.vm0.ai/");
     expect(config.environment).toBe("production");
+    expect(config.identity).toMatchObject({
+      displayName: "Zero",
+      bundleId: "ai.vm0.zero.desktop",
+      authScheme: "ai.vm0.zero.desktop",
+    });
     expect(config.sessionPartition).toBe("persist:vm0-desktop-production");
     expect([...config.allowedAppOrigins].sort()).toStrictEqual([
       "https://api.vm0.ai",
@@ -30,6 +35,11 @@ describe("resolveDesktopConfig", () => {
     const config = resolveDesktopConfig("https://staging-app.vm6.ai/");
 
     expect(config.environment).toBe("staging");
+    expect(config.identity).toMatchObject({
+      displayName: "Zero Dev",
+      bundleId: "ai.vm0.zero.desktop.dev",
+      authScheme: "ai.vm0.zero.desktop.dev",
+    });
     expect(config.sessionPartition).toBe("persist:vm0-desktop-staging");
     expect(config.allowedAppOrigins.has("https://staging-app.vm6.ai")).toBe(
       true,
@@ -46,6 +56,11 @@ describe("resolveDesktopConfig", () => {
     const config = resolveDesktopConfig("https://app.vm7.ai/");
 
     expect(config.environment).toBe("development");
+    expect(config.identity).toMatchObject({
+      displayName: "Zero Dev",
+      bundleId: "ai.vm0.zero.desktop.dev",
+      authScheme: "ai.vm0.zero.desktop.dev",
+    });
     expect(config.sessionPartition).toBe("persist:vm0-desktop-development");
     expect(config.allowedAppOrigins.has("https://app.vm7.ai")).toBe(true);
     expect(config.allowedAppOrigins.has("https://www.vm7.ai")).toBe(true);
@@ -134,9 +149,20 @@ describe("desktop auth", () => {
   const platformUrl = new URL("https://app.vm0.ai");
   const code = "abcdefghijklmnopqrstuvwxyzABCDEF0123456789_-";
 
-  it("builds the system-browser desktop auth start URL", () => {
-    expect(buildDesktopAuthStartUrl(platformUrl)).toBe(
-      "https://app.vm0.ai/desktop-auth/start",
+  it("builds the production system-browser desktop auth start URL", () => {
+    expect(buildDesktopAuthStartUrl(platformUrl, "ai.vm0.zero.desktop")).toBe(
+      "https://app.vm0.ai/desktop-auth/start?callbackScheme=ai.vm0.zero.desktop",
+    );
+  });
+
+  it("builds the development system-browser desktop auth start URL", () => {
+    expect(
+      buildDesktopAuthStartUrl(
+        new URL("https://app.vm7.ai"),
+        "ai.vm0.zero.desktop.dev",
+      ),
+    ).toBe(
+      "https://app.vm7.ai/desktop-auth/start?callbackScheme=ai.vm0.zero.desktop.dev",
     );
   });
 
@@ -208,47 +234,91 @@ describe("desktop auth", () => {
   });
 
   it("builds a local signed-out page with an explicit auth start link", () => {
-    const pageUrl = buildSignedOutPageUrl(
-      "https://app.vm0.ai/desktop-auth/start",
+    const authStartUrl = buildDesktopAuthStartUrl(
+      platformUrl,
+      "ai.vm0.zero.desktop",
     );
+    const pageUrl = buildSignedOutPageUrl(authStartUrl);
     const html = decodeURIComponent(pageUrl.split(",")[1] ?? "");
 
     expect(pageUrl.startsWith("data:text/html;charset=utf-8,")).toBe(true);
-    expect(html).toContain('href="https://app.vm0.ai/desktop-auth/start"');
+    expect(html).toContain(
+      'href="https://app.vm0.ai/desktop-auth/start?callbackScheme=ai.vm0.zero.desktop"',
+    );
     expect(html).toContain("Sign in to Zero");
   });
 
   it("parses a valid desktop callback code", () => {
     expect(
-      parseDesktopAuthCallback(`vm0://auth/callback?code=${code}`),
+      parseDesktopAuthCallback(
+        `ai.vm0.zero.desktop://auth/callback?code=${code}`,
+        "ai.vm0.zero.desktop",
+      ),
+    ).toStrictEqual({ code });
+    expect(
+      parseDesktopAuthCallback(
+        `ai.vm0.zero.desktop.dev://auth/callback?code=${code}`,
+        "ai.vm0.zero.desktop.dev",
+      ),
     ).toStrictEqual({ code });
   });
 
   it("parses desktop callbacks from launch arguments", () => {
     expect(
-      parseDesktopAuthCallbackArgv([
-        "/Applications/Zero.app/Contents/MacOS/Zero",
-        `vm0://auth/callback?code=${code}`,
-      ]),
+      parseDesktopAuthCallbackArgv(
+        [
+          "/Applications/Zero.app/Contents/MacOS/Zero",
+          `ai.vm0.zero.desktop://auth/callback?code=${code}`,
+        ],
+        "ai.vm0.zero.desktop",
+      ),
     ).toStrictEqual({ code });
     expect(
-      parseDesktopAuthCallbackArgv([
-        "/Applications/Zero.app/Contents/MacOS/Zero",
-        "--some-flag",
-      ]),
+      parseDesktopAuthCallbackArgv(
+        ["/Applications/Zero.app/Contents/MacOS/Zero", "--some-flag"],
+        "ai.vm0.zero.desktop",
+      ),
     ).toBe(null);
   });
 
   it("rejects unsafe desktop callbacks", () => {
-    expect(parseDesktopAuthCallback("vm0://auth/callback?token=secret")).toBe(
-      null,
-    );
-    expect(parseDesktopAuthCallback("vm0://other/callback?code=abc")).toBe(
-      null,
-    );
+    expect(
+      parseDesktopAuthCallback(
+        "ai.vm0.zero.desktop://auth/callback?token=secret",
+        "ai.vm0.zero.desktop",
+      ),
+    ).toBe(null);
+    expect(
+      parseDesktopAuthCallback(
+        `ai.vm0.zero.desktop://auth/callback?code=${code}`,
+        "ai.vm0.zero.desktop.dev",
+      ),
+    ).toBe(null);
+    expect(
+      parseDesktopAuthCallback(
+        "ai.vm0.zero.desktop://other/callback?code=abc",
+        "ai.vm0.zero.desktop",
+      ),
+    ).toBe(null);
     expect(
       parseDesktopAuthCallback(
         "https://app.vm0.ai/desktop-auth/consume?code=abc",
+        "ai.vm0.zero.desktop",
+      ),
+    ).toBe(null);
+  });
+
+  it("does not treat legacy callbacks as valid", () => {
+    expect(
+      parseDesktopAuthCallback(
+        `vm0://auth/callback?code=${code}`,
+        "ai.vm0.zero.desktop",
+      ),
+    ).toBe(null);
+    expect(
+      parseDesktopAuthCallback(
+        `vm0://auth/callback?code=${code}`,
+        "ai.vm0.zero.desktop.dev",
       ),
     ).toBe(null);
   });

--- a/turbo/apps/platform/src/signals/__tests__/desktop-auth-setup.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/desktop-auth-setup.test.ts
@@ -43,9 +43,25 @@ describe("desktop auth setup", () => {
     expect(replace).toHaveBeenCalledWith("/desktop-auth/callback");
   });
 
+  it("preserves the requested desktop callback scheme from start to callback", async () => {
+    const replace = vi
+      .spyOn(window.location, "replace")
+      .mockImplementation(() => {
+        return undefined;
+      });
+
+    await setupSignedInDesktopAuthPage(
+      "/desktop-auth/start?callbackScheme=ai.vm0.zero.desktop.dev",
+    );
+
+    expect(replace).toHaveBeenCalledWith(
+      "/desktop-auth/callback?callbackScheme=ai.vm0.zero.desktop.dev",
+    );
+  });
+
   it("creates a handoff callback URL for signed-in browser sessions through the platform router", async () => {
     const callbackUrl =
-      "vm0://auth/callback?code=abcdefghijklmnopqrstuvwxyzABCDEF0123456789_-";
+      "ai.vm0.zero.desktop://auth/callback?code=abcdefghijklmnopqrstuvwxyzABCDEF0123456789_-";
     const assign = vi
       .spyOn(window.location, "assign")
       .mockImplementation(() => {
@@ -63,6 +79,31 @@ describe("desktop auth setup", () => {
     await setupSignedInDesktopAuthPage("/desktop-auth/callback");
 
     expect(authHeaders).toStrictEqual(["Bearer browser-session-token"]);
+    expect(assign).toHaveBeenCalledWith(callbackUrl);
+  });
+
+  it("requests a development handoff callback URL through the platform router", async () => {
+    const callbackUrl =
+      "ai.vm0.zero.desktop.dev://auth/callback?code=abcdefghijklmnopqrstuvwxyzABCDEF0123456789_-";
+    const assign = vi
+      .spyOn(window.location, "assign")
+      .mockImplementation(() => {
+        return undefined;
+      });
+
+    server.use(
+      mockApi(desktopAuthHandoffContract.create, ({ body, respond }) => {
+        expect(body).toStrictEqual({
+          callbackScheme: "ai.vm0.zero.desktop.dev",
+        });
+        return respond(200, { callbackUrl });
+      }),
+    );
+
+    await setupSignedInDesktopAuthPage(
+      "/desktop-auth/callback?callbackScheme=ai.vm0.zero.desktop.dev",
+    );
+
     expect(assign).toHaveBeenCalledWith(callbackUrl);
   });
 

--- a/turbo/apps/platform/src/signals/desktop-auth-setup.ts
+++ b/turbo/apps/platform/src/signals/desktop-auth-setup.ts
@@ -1,6 +1,8 @@
 import {
+  desktopAuthCallbackSchemeSchema,
   desktopAuthConsumeContract,
   desktopAuthHandoffContract,
+  type DesktopAuthCallbackScheme,
 } from "@vm0/api-contracts/contracts/desktop-auth";
 import { command } from "ccstate";
 
@@ -14,14 +16,40 @@ const L = logger("DesktopAuth");
 
 const DESKTOP_AUTH_START_PATH = "/desktop-auth/start";
 const DESKTOP_AUTH_CALLBACK_PATH = "/desktop-auth/callback";
+const DESKTOP_AUTH_CALLBACK_SCHEME_PARAM = "callbackScheme";
 
 function platformUrl(path: string): string {
   return new URL(path, window.location.origin).toString();
 }
 
-function webSignInUrl(): string {
+function desktopAuthCallbackScheme(
+  searchParams: URLSearchParams,
+): DesktopAuthCallbackScheme | undefined {
+  const rawScheme = searchParams.get(DESKTOP_AUTH_CALLBACK_SCHEME_PARAM);
+  const parsedScheme = desktopAuthCallbackSchemeSchema.safeParse(rawScheme);
+  if (parsedScheme.success) {
+    return parsedScheme.data;
+  }
+  return undefined;
+}
+
+function desktopAuthPathWithScheme(
+  path: string,
+  searchParams: URLSearchParams,
+): string {
+  const callbackScheme = desktopAuthCallbackScheme(searchParams);
+  if (!callbackScheme) {
+    return path;
+  }
+
+  const url = new URL(path, window.location.origin);
+  url.searchParams.set(DESKTOP_AUTH_CALLBACK_SCHEME_PARAM, callbackScheme);
+  return `${url.pathname}${url.search}`;
+}
+
+function webSignInUrl(callbackPath: string): string {
   const url = new URL("/sign-in", resolveWebOrigin());
-  url.searchParams.set("redirect_url", platformUrl(DESKTOP_AUTH_CALLBACK_PATH));
+  url.searchParams.set("redirect_url", platformUrl(callbackPath));
   return url.toString();
 }
 
@@ -30,12 +58,16 @@ export const setupDesktopAuthStartPage$ = command(
     const clerk = await get(clerk$);
     signal.throwIfAborted();
 
+    const callbackPath = desktopAuthPathWithScheme(
+      DESKTOP_AUTH_CALLBACK_PATH,
+      get(searchParams$),
+    );
     if (clerk.user) {
-      window.location.replace(DESKTOP_AUTH_CALLBACK_PATH);
+      window.location.replace(callbackPath);
       return;
     }
 
-    window.location.assign(webSignInUrl());
+    window.location.assign(webSignInUrl(callbackPath));
   },
 );
 
@@ -45,12 +77,20 @@ export const setupDesktopAuthCallbackPage$ = command(
     signal.throwIfAborted();
 
     if (!clerk.user) {
-      window.location.replace(DESKTOP_AUTH_START_PATH);
+      window.location.replace(
+        desktopAuthPathWithScheme(DESKTOP_AUTH_START_PATH, get(searchParams$)),
+      );
       return;
     }
 
     const client = get(zeroClient$)(desktopAuthHandoffContract);
-    const result = await accept(client.create({ body: {} }), [200]);
+    const callbackScheme = desktopAuthCallbackScheme(get(searchParams$));
+    const result = await accept(
+      client.create({
+        body: callbackScheme ? { callbackScheme } : {},
+      }),
+      [200],
+    );
     signal.throwIfAborted();
 
     window.location.assign(result.body.callbackUrl);

--- a/turbo/apps/web/app/desktop-auth/callback/DesktopAuthCallbackClient.tsx
+++ b/turbo/apps/web/app/desktop-auth/callback/DesktopAuthCallbackClient.tsx
@@ -2,13 +2,40 @@
 
 import { useEffect, useRef, useState } from "react";
 import { useAuth } from "@clerk/nextjs";
+import { useSearchParams } from "next/navigation";
 
 interface HandoffResponse {
   readonly callbackUrl?: string;
 }
 
+const DESKTOP_AUTH_START_PATH = "/desktop-auth/start";
+const DESKTOP_AUTH_CALLBACK_SCHEME_PARAM = "callbackScheme";
+const DESKTOP_AUTH_CALLBACK_SCHEMES = new Set([
+  "ai.vm0.zero.desktop",
+  "ai.vm0.zero.desktop.dev",
+]);
+
+function desktopAuthCallbackScheme(rawScheme: string | null): string | null {
+  if (!rawScheme || !DESKTOP_AUTH_CALLBACK_SCHEMES.has(rawScheme)) {
+    return null;
+  }
+  return rawScheme;
+}
+
+function desktopAuthStartPath(callbackScheme: string | null): string {
+  if (!callbackScheme) {
+    return DESKTOP_AUTH_START_PATH;
+  }
+
+  const searchParams = new URLSearchParams({
+    [DESKTOP_AUTH_CALLBACK_SCHEME_PARAM]: callbackScheme,
+  });
+  return `${DESKTOP_AUTH_START_PATH}?${searchParams.toString()}`;
+}
+
 async function createDesktopAuthHandoff(
   getToken: () => Promise<string | null>,
+  callbackScheme: string | null,
 ): Promise<string> {
   const token = await getToken();
   if (!token) {
@@ -21,7 +48,7 @@ async function createDesktopAuthHandoff(
       Authorization: `Bearer ${token}`,
       "Content-Type": "application/json",
     },
-    body: "{}",
+    body: JSON.stringify(callbackScheme ? { callbackScheme } : {}),
   });
   if (!response.ok) {
     throw new Error("Desktop sign-in failed.");
@@ -37,8 +64,12 @@ async function createDesktopAuthHandoff(
 
 export function DesktopAuthCallbackClient() {
   const { getToken, isLoaded, isSignedIn } = useAuth();
+  const searchParams = useSearchParams();
   const [error, setError] = useState("");
   const didRun = useRef(false);
+  const callbackScheme = desktopAuthCallbackScheme(
+    searchParams.get(DESKTOP_AUTH_CALLBACK_SCHEME_PARAM),
+  );
 
   useEffect(() => {
     if (!isLoaded || didRun.current) {
@@ -47,11 +78,11 @@ export function DesktopAuthCallbackClient() {
     didRun.current = true;
 
     if (!isSignedIn) {
-      window.location.replace("/desktop-auth/start");
+      window.location.replace(desktopAuthStartPath(callbackScheme));
       return;
     }
 
-    createDesktopAuthHandoff(getToken)
+    createDesktopAuthHandoff(getToken, callbackScheme)
       .then((callbackUrl) => {
         window.location.href = callbackUrl;
       })
@@ -60,7 +91,7 @@ export function DesktopAuthCallbackClient() {
           err instanceof Error ? err.message : "Desktop sign-in failed.",
         );
       });
-  }, [getToken, isLoaded, isSignedIn]);
+  }, [callbackScheme, getToken, isLoaded, isSignedIn]);
 
   if (error) {
     return (

--- a/turbo/apps/web/app/desktop-auth/start/DesktopAuthStartClient.tsx
+++ b/turbo/apps/web/app/desktop-auth/start/DesktopAuthStartClient.tsx
@@ -2,16 +2,37 @@
 
 import { useEffect, useRef } from "react";
 import { SignIn, useAuth } from "@clerk/nextjs";
+import { useSearchParams } from "next/navigation";
 import { useTheme } from "../../components/ThemeProvider";
 import { AuthLayout } from "../../components/auth/AuthLayout";
 import { getClerkAppearance } from "../../components/auth/clerk-appearance";
 
 const DESKTOP_AUTH_CALLBACK_PATH = "/desktop-auth/callback";
+const DESKTOP_AUTH_CALLBACK_SCHEME_PARAM = "callbackScheme";
+const DESKTOP_AUTH_CALLBACK_SCHEMES = new Set([
+  "ai.vm0.zero.desktop",
+  "ai.vm0.zero.desktop.dev",
+]);
+
+function desktopAuthCallbackPath(rawScheme: string | null): string {
+  if (!rawScheme || !DESKTOP_AUTH_CALLBACK_SCHEMES.has(rawScheme)) {
+    return DESKTOP_AUTH_CALLBACK_PATH;
+  }
+
+  const searchParams = new URLSearchParams({
+    [DESKTOP_AUTH_CALLBACK_SCHEME_PARAM]: rawScheme,
+  });
+  return `${DESKTOP_AUTH_CALLBACK_PATH}?${searchParams.toString()}`;
+}
 
 export function DesktopAuthStartClient() {
   const { isLoaded, isSignedIn } = useAuth();
+  const searchParams = useSearchParams();
   const { theme } = useTheme();
   const didRedirect = useRef(false);
+  const callbackPath = desktopAuthCallbackPath(
+    searchParams.get(DESKTOP_AUTH_CALLBACK_SCHEME_PARAM),
+  );
 
   useEffect(() => {
     if (!isLoaded || !isSignedIn || didRedirect.current) {
@@ -19,8 +40,8 @@ export function DesktopAuthStartClient() {
     }
 
     didRedirect.current = true;
-    window.location.replace(DESKTOP_AUTH_CALLBACK_PATH);
-  }, [isLoaded, isSignedIn]);
+    window.location.replace(callbackPath);
+  }, [callbackPath, isLoaded, isSignedIn]);
 
   if (!isLoaded || isSignedIn) {
     return (
@@ -32,13 +53,13 @@ export function DesktopAuthStartClient() {
     <AuthLayout>
       <SignIn
         appearance={getClerkAppearance(theme)}
-        fallbackRedirectUrl={DESKTOP_AUTH_CALLBACK_PATH}
-        forceRedirectUrl={DESKTOP_AUTH_CALLBACK_PATH}
+        fallbackRedirectUrl={callbackPath}
+        forceRedirectUrl={callbackPath}
         oauthFlow="redirect"
         path="/desktop-auth/start"
         routing="path"
-        signUpFallbackRedirectUrl={DESKTOP_AUTH_CALLBACK_PATH}
-        signUpForceRedirectUrl={DESKTOP_AUTH_CALLBACK_PATH}
+        signUpFallbackRedirectUrl={callbackPath}
+        signUpForceRedirectUrl={callbackPath}
       />
     </AuthLayout>
   );

--- a/turbo/apps/web/app/desktop-auth/start/__tests__/DesktopAuthStartClient.test.tsx
+++ b/turbo/apps/web/app/desktop-auth/start/__tests__/DesktopAuthStartClient.test.tsx
@@ -10,6 +10,7 @@ const clerkState = vi.hoisted(() => {
   return {
     auth: { isLoaded: true, isSignedIn: false },
     signInProps: null as Record<string, unknown> | null,
+    searchParams: new URLSearchParams(),
   };
 });
 
@@ -21,6 +22,14 @@ vi.mock("@clerk/nextjs", () => {
     SignIn: (props: Record<string, unknown>) => {
       clerkState.signInProps = props;
       return <div data-testid="desktop-sign-in" />;
+    },
+  };
+});
+
+vi.mock("next/navigation", () => {
+  return {
+    useSearchParams: () => {
+      return clerkState.searchParams;
     },
   };
 });
@@ -79,6 +88,7 @@ describe("DesktopAuthStartClient", () => {
   beforeEach(() => {
     clerkState.auth = { isLoaded: true, isSignedIn: false };
     clerkState.signInProps = null;
+    clerkState.searchParams = new URLSearchParams();
     localStorage.clear();
     document.documentElement.removeAttribute("data-theme");
     mockMatchMedia();
@@ -99,6 +109,25 @@ describe("DesktopAuthStartClient", () => {
     });
   });
 
+  it("preserves the callback scheme in Clerk redirects", () => {
+    clerkState.searchParams = new URLSearchParams({
+      callbackScheme: "ai.vm0.zero.desktop.dev",
+    });
+
+    renderStartClient();
+
+    expect(clerkState.signInProps).toMatchObject({
+      fallbackRedirectUrl:
+        "/desktop-auth/callback?callbackScheme=ai.vm0.zero.desktop.dev",
+      forceRedirectUrl:
+        "/desktop-auth/callback?callbackScheme=ai.vm0.zero.desktop.dev",
+      signUpFallbackRedirectUrl:
+        "/desktop-auth/callback?callbackScheme=ai.vm0.zero.desktop.dev",
+      signUpForceRedirectUrl:
+        "/desktop-auth/callback?callbackScheme=ai.vm0.zero.desktop.dev",
+    });
+  });
+
   it("redirects already signed-in browser sessions to the desktop callback", async () => {
     clerkState.auth = { isLoaded: true, isSignedIn: true };
     const replace = vi
@@ -112,6 +141,26 @@ describe("DesktopAuthStartClient", () => {
     expect(screen.getByText("Signing in...")).toBeTruthy();
     await waitFor(() => {
       expect(replace).toHaveBeenCalledWith("/desktop-auth/callback");
+    });
+  });
+
+  it("preserves the callback scheme when redirecting signed-in sessions", async () => {
+    clerkState.auth = { isLoaded: true, isSignedIn: true };
+    clerkState.searchParams = new URLSearchParams({
+      callbackScheme: "ai.vm0.zero.desktop.dev",
+    });
+    const replace = vi
+      .spyOn(window.location, "replace")
+      .mockImplementation(() => {
+        return undefined;
+      });
+
+    renderStartClient();
+
+    await waitFor(() => {
+      expect(replace).toHaveBeenCalledWith(
+        "/desktop-auth/callback?callbackScheme=ai.vm0.zero.desktop.dev",
+      );
     });
   });
 });

--- a/turbo/packages/api-contracts/src/contracts/desktop-auth.ts
+++ b/turbo/packages/api-contracts/src/contracts/desktop-auth.ts
@@ -4,16 +4,33 @@ import { apiErrorSchema } from "./errors";
 
 const c = initContract();
 
+export const desktopAuthCallbackSchemes = [
+  "ai.vm0.zero.desktop",
+  "ai.vm0.zero.desktop.dev",
+] as const;
+export const defaultDesktopAuthCallbackScheme = desktopAuthCallbackSchemes[0];
+export const desktopAuthCallbackSchemeSchema = z.enum(
+  desktopAuthCallbackSchemes,
+);
+export type DesktopAuthCallbackScheme = z.infer<
+  typeof desktopAuthCallbackSchemeSchema
+>;
+
 export const desktopAuthHandoffContract = c.router({
   create: {
     method: "POST",
     path: "/api/desktop-auth/handoff",
     headers: authHeadersSchema,
-    body: z.object({}).optional(),
+    body: z
+      .object({
+        callbackScheme: desktopAuthCallbackSchemeSchema.optional(),
+      })
+      .optional(),
     responses: {
       200: z.object({
         callbackUrl: z.string(),
       }),
+      400: apiErrorSchema,
       401: apiErrorSchema,
       403: apiErrorSchema,
       500: apiErrorSchema,


### PR DESCRIPTION
## Summary
- split desktop production and development identities for bundle id, display name, and auth URL scheme
- pass the desktop callback scheme through platform/web auth start and callback flows into the handoff API
- update desktop workflow verification and add regression coverage for config, URL generation, callback parsing, and handoff routing

Fixes #13974

## Tests
- pnpm -F @vm0/desktop check-types
- pnpm -F @vm0/desktop lint
- pnpm -F @vm0/desktop test
- pnpm -F @vm0/desktop build
- pnpm -F @vm0/api-contracts check-types
- pnpm -F api exec vitest src/signals/routes/__tests__/desktop-auth.test.ts
- pnpm -F @vm0/app exec vitest src/signals/__tests__/desktop-auth-setup.test.ts
- pnpm -F web exec vitest app/desktop-auth/start/__tests__/DesktopAuthStartClient.test.tsx
- pnpm -F api check-types
- pnpm -F @vm0/app check-types
- pnpm -F web check-types
- pnpm -F @vm0/api-contracts lint
- pnpm -F api lint
- pnpm -F @vm0/app lint
- pnpm -F web lint
- pnpm format
- pre-commit: turbo run check-types --concurrency=1
- node forge config verification for production and VM0_DESKTOP_PLATFORM_URL=https://app.vm7.ai