### PR TITLE
chore: remove stale vsock tracker lint expectation

### DIFF
--- a/crates/vsock-host/src/operation_tracker.rs
+++ b/crates/vsock-host/src/operation_tracker.rs
@@ -1,11 +1,3 @@
-#![cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "normal operation tracker APIs are introduced before command/file/process callers migrate to them"
-    )
-)]
-
 use std::collections::BTreeMap;
 use std::sync::{Arc, Mutex, MutexGuard};
 
@@ -26,6 +18,7 @@ impl NormalOperationTracker {
         }
     }
 
+    #[cfg(test)]
     pub(crate) fn readiness(&self) -> NormalOperationReadiness {
         self.inner().readiness()
     }
@@ -101,6 +94,7 @@ impl NormalOperationTracker {
     }
 }
 
+#[cfg(test)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum NormalOperationReadiness {
     Idle,
@@ -167,6 +161,7 @@ struct Inner {
 }
 
 impl Inner {
+    #[cfg(test)]
     fn readiness(&self) -> NormalOperationReadiness {
         match self.state {
             TrackerState::Open if self.operations.is_empty() => NormalOperationReadiness::Idle,


### PR DESCRIPTION
## Summary
- remove the stale crate-level dead_code expectation from the vsock normal operation tracker
- scope the tracker readiness test seam to test builds only

## Tests
- cargo fmt --manifest-path crates/Cargo.toml --all --check
- CARGO_BUILD_JOBS=1 cargo test --manifest-path crates/Cargo.toml -p vsock-host operation_tracker
- CARGO_BUILD_JOBS=1 cargo clippy --manifest-path crates/Cargo.toml -p vsock-host --all-targets -- -D warnings
- pre-commit hook: cargo-fmt, cargo-clippy, cargo-doc

Related to #13391