### PR TITLE
fix: encode oauth callback cookies

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/connectors-type-callback.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors-type-callback.test.ts
@@ -89,13 +89,19 @@ function callbackHeaders(args: {
 }): HeadersInit {
   const cookies = ["__session=opaque"];
   if (args.stateCookie) {
-    cookies.push(`connector_oauth_state=${args.stateCookie}`);
+    cookies.push(
+      `connector_oauth_state=${encodeURIComponent(args.stateCookie)}`,
+    );
   }
   if (args.sessionId) {
-    cookies.push(`connector_oauth_session=${args.sessionId}`);
+    cookies.push(
+      `connector_oauth_session=${encodeURIComponent(args.sessionId)}`,
+    );
   }
   if (args.codeVerifier) {
-    cookies.push(`connector_oauth_pkce=${args.codeVerifier}`);
+    cookies.push(
+      `connector_oauth_pkce=${encodeURIComponent(args.codeVerifier)}`,
+    );
   }
   if (args.oauthContext) {
     cookies.push(`connector_oauth_context=${args.oauthContext}`);

--- a/turbo/apps/api/src/signals/routes/__tests__/connectors-type-callback.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors-type-callback.test.ts
@@ -104,7 +104,9 @@ function callbackHeaders(args: {
     );
   }
   if (args.oauthContext) {
-    cookies.push(`connector_oauth_context=${args.oauthContext}`);
+    cookies.push(
+      `connector_oauth_context=${encodeURIComponent(args.oauthContext)}`,
+    );
   }
   return { cookie: cookies.join("; ") };
 }
@@ -1444,7 +1446,7 @@ describe("GET /api/connectors/:type/callback", () => {
       headers: callbackHeaders({
         stateCookie: "state-123",
         codeVerifier: "pkce-verifier",
-        oauthContext: "dynamic-oauth-context",
+        oauthContext: "dynamic-oauth-context; tenant=example",
       }),
     });
 
@@ -1457,7 +1459,7 @@ describe("GET /api/connectors/:type/callback", () => {
       redirectUri: `${BASE_URL}/api/connectors/test-oauth/callback`,
       state: "state-123",
       codeVerifier: "pkce-verifier",
-      oauthContext: "dynamic-oauth-context",
+      oauthContext: "dynamic-oauth-context; tenant=example",
     });
     expect(response.headers.getSetCookie()).toStrictEqual(
       expect.arrayContaining([

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-authorize.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-authorize.test.ts
@@ -91,7 +91,7 @@ function useDynamicTestOAuthAuthorize(): () => void {
     expect(args.clientId).toBeUndefined();
     return {
       url: `https://dynamic-oauth.test/authorize?state=${args.state}`,
-      oauthContext: "dynamic-oauth-context",
+      oauthContext: "dynamic-oauth-context; tenant=example",
     };
   };
 
@@ -220,7 +220,7 @@ describe("GET /api/zero/connectors/:type/authorize", () => {
     expect(
       cookies.some((cookie) => {
         return cookie.startsWith(
-          "connector_oauth_context=dynamic-oauth-context",
+          "connector_oauth_context=dynamic-oauth-context%3B%20tenant%3Dexample",
         );
       }),
     ).toBeTruthy();

--- a/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
+++ b/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
@@ -43,7 +43,7 @@ function getCookie(request: Request, name: string): string | undefined {
   for (const cookie of cookieHeader.split(";")) {
     const [cookieName, ...rest] = cookie.trim().split("=");
     if (cookieName === name) {
-      return rest.join("=");
+      return decodeCookieComponent(rest.join("="));
     }
   }
   return undefined;

--- a/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
+++ b/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
@@ -1,3 +1,5 @@
+import { unescape as decodeCookieComponent } from "node:querystring";
+
 import { command } from "ccstate";
 import { connectorsTypeCallbackContract } from "@vm0/api-contracts/contracts/connectors-type-callback";
 import {

--- a/turbo/apps/api/src/signals/routes/zero-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/zero-connectors.ts
@@ -140,7 +140,7 @@ function buildCookieHeader(
   maxAge: number,
 ): string {
   const parts = [
-    `${name}=${value}`,
+    `${name}=${encodeURIComponent(value)}`,
     `Max-Age=${maxAge}`,
     "Path=/",
     "HttpOnly",


### PR DESCRIPTION
## Summary
- encode OAuth cookie values when setting authorize/callback cookies
- decode callback cookies before comparing state or passing OAuth context to provider exchange
- cover oauthContext values containing semicolon and whitespace

## Tests
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-connectors-authorize.test.ts src/signals/routes/__tests__/connectors-type-callback.test.ts`
- `pnpm -F api check-types`
- `pnpm -F api lint`
- pre-commit hook: prettier, knip, full `pnpm check-types`