### PR TITLE
fix: preserve web origin for api backend rewrites

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/connectors-type-callback.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors-type-callback.test.ts
@@ -28,6 +28,7 @@ const store = createStore();
 const mocks = createZeroRouteMocks(context);
 
 const BASE_URL = "https://app.vm0.test";
+const WEB_ORIGIN = "https://www.vm0.ai";
 const GITHUB_TOKEN_URL = "https://github.com/login/oauth/access_token";
 const GITHUB_USER_URL = "https://api.github.com/user";
 const GMAIL_TOKEN_URL = "https://oauth2.googleapis.com/token";
@@ -86,6 +87,8 @@ function callbackHeaders(args: {
   readonly sessionId?: string;
   readonly codeVerifier?: string;
   readonly oauthContext?: string;
+  readonly forwardedHost?: string;
+  readonly forwardedProto?: string;
 }): HeadersInit {
   const cookies = ["__session=opaque"];
   if (args.stateCookie) {
@@ -108,7 +111,14 @@ function callbackHeaders(args: {
       `connector_oauth_context=${encodeURIComponent(args.oauthContext)}`,
     );
   }
-  return { cookie: cookies.join("; ") };
+  const headers: Record<string, string> = { cookie: cookies.join("; ") };
+  if (args.forwardedHost) {
+    headers["x-forwarded-host"] = args.forwardedHost;
+  }
+  if (args.forwardedProto) {
+    headers["x-forwarded-proto"] = args.forwardedProto;
+  }
+  return headers;
 }
 
 function authenticate(args: {
@@ -1327,6 +1337,34 @@ describe("GET /api/connectors/:type/callback", () => {
     );
   });
 
+  it("uses the forwarded web origin for callback error redirects", async () => {
+    const orgId = `org_${randomUUID()}`;
+    const userId = `user_${randomUUID()}`;
+    orgIds.push(orgId);
+    authenticate({ userId, orgId });
+
+    const response = await requestCallback({
+      type: "github",
+      query: { code: "code-123", state: "returned-state" },
+      headers: callbackHeaders({
+        stateCookie: "saved-state",
+        forwardedHost: "www.vm0.ai",
+        forwardedProto: "https",
+      }),
+    });
+
+    expect(response.status).toBe(307);
+    const location = response.headers.get("location");
+    expect(location).not.toBeNull();
+    const url = new URL(location!);
+    expect(url.origin).toBe(WEB_ORIGIN);
+    expect(url.pathname).toBe("/connector/error");
+    expect(url.searchParams.get("type")).toBe("github");
+    expect(url.searchParams.get("message")).toBe(
+      "Invalid state - please try again",
+    );
+  });
+
   it("marks CLI sessions as error when user info fetch fails", async () => {
     const orgId = `org_${randomUUID()}`;
     const userId = `user_${randomUUID()}`;
@@ -1493,6 +1531,41 @@ describe("GET /api/connectors/:type/callback", () => {
     expect(decryptSecretValue(secret!.encryptedValue)).toBe(
       "dynamic-access-token",
     );
+  });
+
+  it("uses the forwarded web origin for token exchange and success redirects", async () => {
+    const dynamicOAuth = useDynamicTestOAuthExchange();
+    restoreDynamicTestOAuthExchange = dynamicOAuth.restore;
+    const { exchanges } = dynamicOAuth;
+    const orgId = `org_${randomUUID()}`;
+    const userId = `user_${randomUUID()}`;
+    orgIds.push(orgId);
+    authenticate({ userId, orgId });
+
+    const response = await requestCallback({
+      type: "test-oauth",
+      query: { code: "code-123", state: "state-123" },
+      headers: callbackHeaders({
+        stateCookie: "state-123",
+        codeVerifier: "pkce-verifier",
+        oauthContext: "dynamic-oauth-context; tenant=example",
+        forwardedHost: "www.vm0.ai",
+        forwardedProto: "https",
+      }),
+    });
+
+    expect(response.status).toBe(307);
+    expect(exchanges).toHaveLength(1);
+    expect(exchanges[0]?.redirectUri).toBe(
+      `${WEB_ORIGIN}/api/connectors/test-oauth/callback`,
+    );
+    const location = response.headers.get("location");
+    expect(location).not.toBeNull();
+    const url = new URL(location!);
+    expect(url.origin).toBe(WEB_ORIGIN);
+    expect(url.pathname).toBe("/connector/success");
+    expect(url.searchParams.get("type")).toBe("test-oauth");
+    expect(url.searchParams.get("username")).toBe("dynamic-user");
   });
 
   it("stores a Slack user OAuth token without an expiry", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-authorize.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-authorize.test.ts
@@ -107,15 +107,23 @@ function useDynamicTestOAuthAuthorize(): () => void {
 
 async function requestAuthorize(
   type: string,
-  options: { readonly session?: string; readonly authenticated?: boolean } = {},
+  options: {
+    readonly session?: string;
+    readonly authenticated?: boolean;
+    readonly headers?: HeadersInit;
+  } = {},
 ): Promise<Response> {
   if (options.authenticated) {
     mocks.clerk.session(`user_${randomUUID()}`, `org_${randomUUID()}`);
   }
+  const headers = new Headers(options.headers);
+  if (options.authenticated) {
+    headers.set("cookie", "__session=opaque");
+  }
   const app = createApp({ signal: context.signal });
   return await app.request(authorizeUrl(type, options.session), {
     method: "GET",
-    headers: options.authenticated ? sessionHeaders() : undefined,
+    headers,
   });
 }
 
@@ -161,6 +169,24 @@ describe("GET /api/zero/connectors/:type/authorize", () => {
     expect(url.searchParams.get("redirect_url")).toBe(authorizeUrl("github"));
   });
 
+  it("redirects unauthenticated users to sign-in on the forwarded web origin", async () => {
+    const response = await requestAuthorize("github", {
+      headers: {
+        "x-forwarded-host": "www.vm0.ai",
+        "x-forwarded-proto": "https",
+      },
+    });
+
+    expect(response.status).toBe(307);
+    const location = response.headers.get("location");
+    expect(location).not.toBeNull();
+    const url = new URL(location!);
+    expect(`${url.origin}${url.pathname}`).toBe("https://www.vm0.ai/sign-in");
+    expect(url.searchParams.get("redirect_url")).toBe(
+      "https://www.vm0.ai/api/zero/connectors/github/authorize",
+    );
+  });
+
   it("redirects to GitHub OAuth and sets the state cookie", async () => {
     const response = await requestAuthorize("github", { authenticated: true });
 
@@ -184,6 +210,24 @@ describe("GET /api/zero/connectors/:type/authorize", () => {
         return cookie.startsWith("connector_oauth_state=");
       }),
     ).toBeTruthy();
+  });
+
+  it("uses the forwarded web origin for OAuth callback URLs", async () => {
+    const response = await requestAuthorize("github", {
+      authenticated: true,
+      headers: {
+        "x-forwarded-host": "www.vm0.ai",
+        "x-forwarded-proto": "https",
+      },
+    });
+
+    expect(response.status).toBe(307);
+    const location = response.headers.get("location");
+    expect(location).not.toBeNull();
+    const url = new URL(location!);
+    expect(url.searchParams.get("redirect_uri")).toBe(
+      "https://www.vm0.ai/api/connectors/github/callback",
+    );
   });
 
   it("stores the connector session id when provided", async () => {

--- a/turbo/apps/web/__tests__/proxy.sandbox-token.test.ts
+++ b/turbo/apps/web/__tests__/proxy.sandbox-token.test.ts
@@ -207,6 +207,12 @@ describe("proxy middleware: sandbox token handling", () => {
     expect(
       response.headers.get("x-middleware-request-x-vercel-protection-bypass"),
     ).toBe("preview-secret");
+    expect(response.headers.get("x-middleware-request-x-forwarded-host")).toBe(
+      "pr-13380-www.vm6.ai",
+    );
+    expect(response.headers.get("x-middleware-request-x-forwarded-proto")).toBe(
+      "https",
+    );
     expect(
       response.headers.get("x-middleware-request-x-vm0-test-endpoint-bypass"),
     ).toBeNull();
@@ -244,5 +250,32 @@ describe("proxy middleware: sandbox token handling", () => {
     expect(
       response.headers.get("x-middleware-request-x-vm0-test-endpoint-bypass"),
     ).toBe("preview-secret");
+  });
+
+  it("should preserve web origin headers for API backend OAuth authorize routes", async () => {
+    const request = new NextRequest(
+      "https://www.vm0.ai/api/zero/connectors/google-calendar/authorize",
+      {
+        headers: {
+          cookie: "__session=opaque",
+        },
+      },
+    );
+
+    const response = await middleware(request, createMockEvent());
+    if (!response) {
+      throw new Error("Expected middleware response");
+    }
+
+    expect(capturedClerkRequest).toBeUndefined();
+    expect(response.headers.get("x-middleware-request-cookie")).toBe(
+      "__session=opaque",
+    );
+    expect(response.headers.get("x-middleware-request-x-forwarded-host")).toBe(
+      "www.vm0.ai",
+    );
+    expect(response.headers.get("x-middleware-request-x-forwarded-proto")).toBe(
+      "https",
+    );
   });
 });

--- a/turbo/apps/web/__tests__/proxy.sandbox-token.test.ts
+++ b/turbo/apps/web/__tests__/proxy.sandbox-token.test.ts
@@ -278,4 +278,31 @@ describe("proxy middleware: sandbox token handling", () => {
       "https",
     );
   });
+
+  it("should preserve web origin headers for API backend OAuth callback routes", async () => {
+    const request = new NextRequest(
+      "https://www.vm0.ai/api/connectors/google-calendar/callback?code=code-123&state=state-123",
+      {
+        headers: {
+          cookie: "__session=opaque; connector_oauth_state=state-123",
+        },
+      },
+    );
+
+    const response = await middleware(request, createMockEvent());
+    if (!response) {
+      throw new Error("Expected middleware response");
+    }
+
+    expect(capturedClerkRequest).toBeUndefined();
+    expect(response.headers.get("x-middleware-request-cookie")).toBe(
+      "__session=opaque; connector_oauth_state=state-123",
+    );
+    expect(response.headers.get("x-middleware-request-x-forwarded-host")).toBe(
+      "www.vm0.ai",
+    );
+    expect(response.headers.get("x-middleware-request-x-forwarded-proto")).toBe(
+      "https",
+    );
+  });
 });

--- a/turbo/apps/web/proxy.ts
+++ b/turbo/apps/web/proxy.ts
@@ -77,6 +77,11 @@ const TEST_ENDPOINT_BYPASS_HEADER = "x-vm0-test-endpoint-bypass";
 
 function apiBackendProxyPassThrough(request: NextRequest): NextResponse {
   const requestHeaders = new Headers(request.headers);
+  requestHeaders.set("x-forwarded-host", request.nextUrl.host);
+  requestHeaders.set(
+    "x-forwarded-proto",
+    request.nextUrl.protocol.slice(0, -1),
+  );
   const bypass = env().VERCEL_AUTOMATION_BYPASS_SECRET;
   if (bypass) {
     requestHeaders.set("x-vercel-protection-bypass", bypass);


### PR DESCRIPTION
## Summary
- forward the original web host/proto through API-backend rewrite middleware
- cover OAuth authorize rewrite behavior in web middleware tests
- verify API authorize routes consume forwarded origin for sign-in and callback URLs

## Tests
- pnpm -F web exec vitest run __tests__/proxy.sandbox-token.test.ts
- pnpm -F api exec vitest run src/signals/routes/__tests__/zero-connectors-authorize.test.ts
- pnpm -F web lint
- pnpm -F api lint
- pnpm check-types (via lefthook pre-commit)
