### PR TITLE
refactor: proxy test slack assistant status route to api

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/test-slack-mock.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/test-slack-mock.test.ts
@@ -51,6 +51,20 @@ describe("POST /api/test/slack-mock/*", () => {
     await expect(response.text()).resolves.toBe("Not found");
   });
 
+  it("returns 404 for assistant.threads.setStatus outside allowed test environments", async () => {
+    mockEnv("ENV", "production");
+
+    const response = await requestApp(
+      `${BASE_ROUTE}/assistant.threads.setStatus`,
+      {
+        method: "POST",
+      },
+    );
+
+    expect(response.status).toBe(404);
+    await expect(response.text()).resolves.toBe("Not found");
+  });
+
   it("returns fixed Slack auth.test and oauth.v2.access fixture payloads", async () => {
     mockEnv("ENV", "development");
 

--- a/turbo/apps/web/__tests__/api-backend-rewrite-proxy.test.ts
+++ b/turbo/apps/web/__tests__/api-backend-rewrite-proxy.test.ts
@@ -887,6 +887,23 @@ describe("API backend rewrite proxy behavior", () => {
     );
   });
 
+  it("matches the test slack mock assistant status rewrite path exactly", () => {
+    expect(
+      matchesApiBackendRewritePath(
+        "/api/test/slack-mock/assistant.threads.setStatus",
+      ),
+    ).toBe(true);
+    expect(
+      matchesApiBackendRewritePath(
+        "/api/test/slack-mock/assistant.threads.setStatus/extra",
+      ),
+    ).toBe(false);
+    expect(matchesApiBackendRewritePath("/api/test/slack-mock")).toBe(false);
+    expect(matchesApiBackendRewritePath("/api/test/slack-mock/auth.test")).toBe(
+      false,
+    );
+  });
+
   it("matches the test slack state rewrite path exactly", () => {
     expect(matchesApiBackendRewritePath("/api/test/slack-state")).toBe(true);
     expect(matchesApiBackendRewritePath("/api/test/slack-state/extra")).toBe(

--- a/turbo/apps/web/__tests__/security-headers.test.ts
+++ b/turbo/apps/web/__tests__/security-headers.test.ts
@@ -507,6 +507,15 @@ const TEST_SLACK_DISPATCH_PROBE_NEXT_NEGATIVE_PATHS = [
   "/api/test/slack-dispatch-probe/extra",
   "/api/test/slack-dispatch",
 ] as const;
+const TEST_SLACK_MOCK_ASSISTANT_STATUS_REWRITE_SOURCE =
+  "/api/test/slack-mock/assistant.threads.setStatus";
+const TEST_SLACK_MOCK_ASSISTANT_STATUS_PATH =
+  "/api/test/slack-mock/assistant.threads.setStatus";
+const TEST_SLACK_MOCK_ASSISTANT_STATUS_NEXT_NEGATIVE_PATHS = [
+  "/api/test/slack-mock/assistant.threads.setStatus/extra",
+  "/api/test/slack-mock",
+  "/api/test/slack-mock/auth.test",
+] as const;
 const TEST_SLACK_STATE_REWRITE_SOURCE = "/api/test/slack-state";
 const TEST_SLACK_STATE_PATH = "/api/test/slack-state";
 const TEST_SLACK_STATE_NEXT_NEGATIVE_PATHS = [
@@ -1419,6 +1428,11 @@ describe("API backend rewrites", () => {
         {
           source: TEST_SLACK_DISPATCH_PROBE_REWRITE_SOURCE,
           destination: "https://api.example.test/api/test/slack-dispatch-probe",
+        },
+        {
+          source: TEST_SLACK_MOCK_ASSISTANT_STATUS_REWRITE_SOURCE,
+          destination:
+            "https://api.example.test/api/test/slack-mock/assistant.threads.setStatus",
         },
         {
           source: TEST_SLACK_STATE_REWRITE_SOURCE,
@@ -3119,6 +3133,33 @@ describe("API backend rewrites", () => {
 
     expect(matcher(TEST_SLACK_DISPATCH_PROBE_PATH)).toStrictEqual({});
     for (const pathname of TEST_SLACK_DISPATCH_PROBE_NEXT_NEGATIVE_PATHS) {
+      expect(matcher(pathname)).toBe(false);
+    }
+  });
+
+  it("should match only the exact test slack mock assistant status rewrite", async () => {
+    vi.stubEnv("VM0_API_BACKEND_URL", "https://api.example.test");
+
+    const rewrites = await getBeforeFileRewrites();
+    const rewrite = rewrites.find((entry) => {
+      return entry.source === TEST_SLACK_MOCK_ASSISTANT_STATUS_REWRITE_SOURCE;
+    });
+    expect(rewrite).toStrictEqual({
+      source: TEST_SLACK_MOCK_ASSISTANT_STATUS_REWRITE_SOURCE,
+      destination:
+        "https://api.example.test/api/test/slack-mock/assistant.threads.setStatus",
+    });
+
+    const matcher = getPathMatch(
+      TEST_SLACK_MOCK_ASSISTANT_STATUS_REWRITE_SOURCE,
+      {
+        removeUnnamedParams: true,
+        strict: true,
+      },
+    );
+
+    expect(matcher(TEST_SLACK_MOCK_ASSISTANT_STATUS_PATH)).toStrictEqual({});
+    for (const pathname of TEST_SLACK_MOCK_ASSISTANT_STATUS_NEXT_NEGATIVE_PATHS) {
       expect(matcher(pathname)).toBe(false);
     }
   });

--- a/turbo/apps/web/api-backend-rewrites.js
+++ b/turbo/apps/web/api-backend-rewrites.js
@@ -337,6 +337,10 @@ export const API_BACKEND_REWRITES = [
   ["/api/test/oauth-provider/token", "/api/test/oauth-provider/token"],
   ["/api/test/oauth-provider/userinfo", "/api/test/oauth-provider/userinfo"],
   ["/api/test/slack-dispatch-probe", "/api/test/slack-dispatch-probe"],
+  [
+    "/api/test/slack-mock/assistant.threads.setStatus",
+    "/api/test/slack-mock/assistant.threads.setStatus",
+  ],
   ["/api/test/slack-state", "/api/test/slack-state"],
   ["/api/test/telegram-dispatch-probe", "/api/test/telegram-dispatch-probe"],
   ["/api/user/export", "/api/user/export"],

--- a/turbo/apps/web/app/api/test/slack-mock/assistant.threads.setStatus/route.ts
+++ b/turbo/apps/web/app/api/test/slack-mock/assistant.threads.setStatus/route.ts
@@ -1,9 +1,0 @@
-import { NextResponse } from "next/server";
-import { isTestEndpointAllowed } from "../../../../../src/lib/auth/test-endpoint-guard";
-
-export async function POST(request: Request) {
-  if (!isTestEndpointAllowed(request)) {
-    return new NextResponse("Not found", { status: 404 });
-  }
-  return NextResponse.json({ ok: true });
-}

--- a/turbo/apps/web/custom-eslint/baselines/web-api-routes.ts
+++ b/turbo/apps/web/custom-eslint/baselines/web-api-routes.ts
@@ -26,7 +26,6 @@ export const WEB_API_ROUTE_BASELINE = [
   "app/api/telegram/register/route.ts",
   "app/api/telegram/setup-status/route.ts",
   "app/api/telegram/webhook/[telegramBotId]/route.ts",
-  "app/api/test/slack-mock/assistant.threads.setStatus/route.ts",
   "app/api/test/slack-mock/auth.test/route.ts",
   "app/api/test/slack-mock/chat.postEphemeral/route.ts",
   "app/api/test/slack-mock/chat.postMessage/route.ts",


### PR DESCRIPTION
## Summary

- delete the legacy `apps/web` Slack mock `assistant.threads.setStatus` route
- add the exact `/api/test/slack-mock/assistant.threads.setStatus` web-to-api rewrite and shrink `WEB_API_ROUTE_BASELINE`
- add route-specific API integration coverage for the production test-endpoint guard and update web rewrite/security tests

## Validation

- `pnpm -F api exec vitest src/signals/routes/__tests__/test-slack-mock.test.ts`
- `pnpm -F web exec vitest __tests__/security-headers.test.ts __tests__/api-backend-rewrite-proxy.test.ts custom-eslint/__tests__/no-new-api-routes.test.ts`
- `pnpm -F api lint`
- `pnpm -F web lint`
- `git diff --check`
- pre-commit: prettier, knip, check-types

Fixes #14003
