### PR TITLE
fix: pass api feature flags to runner jobs

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/agent-runs-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/agent-runs-create.test.ts
@@ -17,8 +17,10 @@ import { runnerJobQueue } from "@vm0/db/schema/runner-job-queue";
 import { secrets as secretsTable } from "@vm0/db/schema/secret";
 import { storages, storageVersions } from "@vm0/db/schema/storage";
 import { userCache } from "@vm0/db/schema/user-cache";
+import { userFeatureSwitches } from "@vm0/db/schema/user-feature-switches";
 import { variables } from "@vm0/db/schema/variable";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
+import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import { createStore, command } from "ccstate";
 import { eq } from "drizzle-orm";
 import { describe, expect, it } from "vitest";
@@ -386,6 +388,40 @@ describe("POST /api/agent/runs", () => {
       prompt: "Create a run",
       appendSystemPrompt: "Be concise.",
       sessionId: null,
+    });
+  });
+
+  it("passes evaluated feature switches to the runner job context", async () => {
+    const fx = await fixture();
+    const db = store.set(writeDb$);
+    await db.insert(userFeatureSwitches).values({
+      orgId: fx.orgId,
+      userId: fx.userId,
+      switches: { [FeatureSwitchKey.ComputerUse]: true },
+    });
+    const compose = await createCompose({ fixture: fx });
+
+    const response = await accept(
+      runsClient().create({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          agentComposeId: compose.composeId,
+          prompt: "Create a run",
+        },
+      }),
+      [201],
+    );
+
+    const [job] = await db
+      .select({ executionContext: runnerJobQueue.executionContext })
+      .from(runnerJobQueue)
+      .where(eq(runnerJobQueue.runId, response.body.runId));
+    const executionContext = job?.executionContext as {
+      readonly featureFlags?: Record<string, boolean>;
+    };
+
+    expect(executionContext.featureFlags).toMatchObject({
+      [FeatureSwitchKey.ComputerUse]: true,
     });
   });
 

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-usage-insight.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-usage-insight.ts
@@ -10,6 +10,7 @@ import { agentSessions } from "@vm0/db/schema/agent-session";
 import { chatThreads } from "@vm0/db/schema/chat-thread";
 import { storages, storageVersions } from "@vm0/db/schema/storage";
 import { usageEvent } from "@vm0/db/schema/usage-event";
+import { userFeatureSwitches } from "@vm0/db/schema/user-feature-switches";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
 import { zeroAgentSchedules } from "@vm0/db/schema/zero-agent-schedule";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
@@ -129,6 +130,16 @@ export const deleteUsageInsightFixture$ = command(
     await db
       .delete(usageEvent)
       .where(and(eq(usageEvent.orgId, orgId), eq(usageEvent.userId, userId)));
+    signal.throwIfAborted();
+
+    await db
+      .delete(userFeatureSwitches)
+      .where(
+        and(
+          eq(userFeatureSwitches.orgId, orgId),
+          eq(userFeatureSwitches.userId, userId),
+        ),
+      );
     signal.throwIfAborted();
 
     const runRows = await db

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-runs-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-runs-create.test.ts
@@ -25,9 +25,11 @@ import { secrets } from "@vm0/db/schema/secret";
 import { userCache } from "@vm0/db/schema/user-cache";
 import { userCustomConnectors } from "@vm0/db/schema/user-custom-connector";
 import { userConnectors } from "@vm0/db/schema/user-connector";
+import { userFeatureSwitches } from "@vm0/db/schema/user-feature-switches";
 import { vm0ApiKeys } from "@vm0/db/schema/vm0-api-key";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
+import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import { command, createStore } from "ccstate";
 import { eq } from "drizzle-orm";
 import { describe, expect, it } from "vitest";
@@ -475,6 +477,12 @@ describe("POST /api/zero/runs", () => {
 
   it("queues zero runs at the org concurrency limit and dispatches them when drained", async () => {
     const fx = await fixture();
+    const db = store.set(writeDb$);
+    await db.insert(userFeatureSwitches).values({
+      orgId: fx.orgId,
+      userId: fx.userId,
+      switches: { [FeatureSwitchKey.ComputerUse]: true },
+    });
     const agent = await seedRunnableZeroAgent({ fixture: fx });
     const first = await accept(
       zeroRunsClient().create({
@@ -493,7 +501,6 @@ describe("POST /api/zero/runs", () => {
     );
 
     expect(queued.body.status).toBe("queued");
-    const db = store.set(writeDb$);
     const [queuedRun] = await db
       .select({ status: agentRuns.status })
       .from(agentRuns)
@@ -549,11 +556,22 @@ describe("POST /api/zero/runs", () => {
     const executionContext = runnerJob?.executionContext as {
       readonly environment?: Record<string, string>;
       readonly encryptedSecrets?: string | null;
+      readonly featureFlags?: Record<string, boolean>;
     };
     expect(executionContext.environment?.ZERO_AGENT_ID).toBe(agent.agentId);
-    expect(
-      decryptSecretsMap(executionContext.encryptedSecrets ?? null)?.ZERO_TOKEN,
-    ).toBeDefined();
+    expect(executionContext.featureFlags).toMatchObject({
+      [FeatureSwitchKey.ComputerUse]: true,
+    });
+    const zeroToken = decryptSecretsMap(
+      executionContext.encryptedSecrets ?? null,
+    )?.ZERO_TOKEN;
+    expect(zeroToken).toBeDefined();
+    if (!zeroToken) {
+      throw new Error("expected ZERO_TOKEN");
+    }
+    expect(verifyZeroToken(zeroToken)?.capabilities).toContain(
+      "computer-use:write",
+    );
   });
 
   it("rejects explicit VM0 runs when org credits are unavailable", async () => {

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -55,7 +55,10 @@ import {
   isSupportedFramework,
   type SupportedFramework,
 } from "@vm0/core/frameworks";
-import type { FeatureSwitchContext } from "@vm0/core/feature-switch";
+import {
+  getAllFeatureStates,
+  type FeatureSwitchContext,
+} from "@vm0/core/feature-switch";
 import { MOUNT_PATH_TEMPLATE } from "@vm0/api-contracts/contracts/composes";
 import { resolveSkillRef, parseGitHubTreeUrl } from "@vm0/core/github-url";
 import {
@@ -2431,6 +2434,7 @@ function buildStoredExecutionContext(args: {
   readonly additionalVolumes: readonly AdditionalVolume[] | undefined;
   readonly extraEnvironment: Record<string, string> | undefined;
   readonly userTimezone: string | undefined;
+  readonly featureSwitchContext: FeatureSwitchContext;
 }): BuiltStoredExecutionContext {
   const permissions = buildPermissionManifest({
     modelProvider: args.modelProvider,
@@ -2482,7 +2486,7 @@ function buildStoredExecutionContext(args: {
       tools: args.body.tools,
       settings: args.body.settings,
       experimentalProfile: runnerProfile(args.resolved.content),
-      featureFlags: {},
+      featureFlags: getAllFeatureStates(args.featureSwitchContext),
       billableFirewalls: billableFirewallsForPermissions({
         modelProvider: args.modelProvider,
         permissions,
@@ -2703,6 +2707,7 @@ async function buildRunnerJobPayload(
     readonly includeZeroTokenSecret: boolean | undefined;
     readonly extraEnvironment: Record<string, string> | undefined;
     readonly userTimezone: string | undefined;
+    readonly featureSwitchContext: FeatureSwitchContext;
   },
 ): Promise<ReturnType<typeof queuedRunnerJobPayload>> {
   const group =
@@ -2748,6 +2753,7 @@ async function buildRunnerJobPayload(
     runId: args.run.id,
     storageManifest,
     userTimezone: args.userTimezone,
+    featureSwitchContext: args.featureSwitchContext,
   });
   ingestRunContextSnapshot({
     runId: args.run.id,
@@ -2783,6 +2789,7 @@ async function dispatchRun(
     readonly includeZeroTokenSecret: boolean | undefined;
     readonly extraEnvironment: Record<string, string> | undefined;
     readonly userTimezone: string | undefined;
+    readonly featureSwitchContext: FeatureSwitchContext;
   },
 ): Promise<{ readonly status: RunStatus; readonly sandboxId?: string }> {
   await db
@@ -2835,6 +2842,7 @@ async function enqueueRunForConcurrency(
     readonly includeZeroTokenSecret: boolean | undefined;
     readonly extraEnvironment: Record<string, string> | undefined;
     readonly userTimezone: string | undefined;
+    readonly featureSwitchContext: FeatureSwitchContext;
   },
 ): Promise<void> {
   const payload = await buildRunnerJobPayload(get, db, args);
@@ -2895,6 +2903,7 @@ interface PreparedRunContext {
   readonly artifacts: readonly ContextArtifact[];
   readonly additionalVolumes: readonly AdditionalVolume[] | undefined;
   readonly userTimezone: string | undefined;
+  readonly featureSwitchContext: FeatureSwitchContext;
 }
 
 async function resolveRunModelProvider(
@@ -3234,6 +3243,7 @@ async function prepareRunContext(
     artifacts,
     additionalVolumes,
     userTimezone,
+    featureSwitchContext,
   };
 }
 
@@ -3304,6 +3314,7 @@ async function completeQueuedRun(input: {
       includeZeroTokenSecret: input.args.includeZeroTokenSecret,
       extraEnvironment: input.args.extraEnvironment,
       userTimezone: input.context.userTimezone,
+      featureSwitchContext: input.context.featureSwitchContext,
     }),
   );
   input.signal.throwIfAborted();
@@ -3341,6 +3352,7 @@ async function completePendingRun(input: {
       includeZeroTokenSecret: input.args.includeZeroTokenSecret,
       extraEnvironment: input.args.extraEnvironment,
       userTimezone: input.context.userTimezone,
+      featureSwitchContext: input.context.featureSwitchContext,
     }),
   );
   input.signal.throwIfAborted();

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -2721,7 +2721,7 @@ async function buildRunnerJobPayload(
 
   const profile = runnerProfile(args.resolved.content);
   const featureSwitchOverrides = args.includeZeroTokenSecret
-    ? await get(userFeatureSwitchOverrides(args.orgId, args.userId))
+    ? args.featureSwitchContext.overrides
     : undefined;
   const body = args.includeZeroTokenSecret
     ? withZeroTokenSecret(


### PR DESCRIPTION
## Summary
- pass evaluated feature switch states into apps/api runner execution contexts
- keep queued and immediate runner job creation using the same prepared feature switch context
- add route coverage for feature flags stored on runner jobs

## Tests
- pnpm -F api exec vitest run src/signals/routes/__tests__/agent-runs-create.test.ts
- pnpm -F api check-types
- pnpm -F api lint
- git diff --check
- pre-commit hook: prettier, knip, turbo check-types