### PR TITLE
fix: keep connector OAuth on web host

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/connectors-type-callback.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors-type-callback.test.ts
@@ -28,6 +28,7 @@ const store = createStore();
 const mocks = createZeroRouteMocks(context);
 
 const BASE_URL = "https://app.vm0.test";
+const API_ORIGIN = "https://api.vm0.ai";
 const WEB_ORIGIN = "https://www.vm0.ai";
 const GITHUB_TOKEN_URL = "https://github.com/login/oauth/access_token";
 const GITHUB_USER_URL = "https://api.github.com/user";
@@ -72,8 +73,9 @@ type OAuthConnectorType = Exclude<ConnectorType, "computer">;
 function callbackUrl(
   type: string,
   query: Record<string, string | undefined>,
+  origin = BASE_URL,
 ): string {
-  const url = new URL(`/api/connectors/${type}/callback`, BASE_URL);
+  const url = new URL(`/api/connectors/${type}/callback`, origin);
   for (const [name, value] of Object.entries(query)) {
     if (value !== undefined) {
       url.searchParams.set(name, value);
@@ -87,8 +89,7 @@ function callbackHeaders(args: {
   readonly sessionId?: string;
   readonly codeVerifier?: string;
   readonly oauthContext?: string;
-  readonly forwardedHost?: string;
-  readonly forwardedProto?: string;
+  readonly webOrigin?: string;
 }): HeadersInit {
   const cookies = ["__session=opaque"];
   if (args.stateCookie) {
@@ -112,11 +113,8 @@ function callbackHeaders(args: {
     );
   }
   const headers: Record<string, string> = { cookie: cookies.join("; ") };
-  if (args.forwardedHost) {
-    headers["x-forwarded-host"] = args.forwardedHost;
-  }
-  if (args.forwardedProto) {
-    headers["x-forwarded-proto"] = args.forwardedProto;
+  if (args.webOrigin) {
+    headers["x-vm0-web-origin"] = args.webOrigin;
   }
   return headers;
 }
@@ -132,9 +130,10 @@ async function requestCallback(args: {
   readonly type: string;
   readonly query: Record<string, string | undefined>;
   readonly headers?: HeadersInit;
+  readonly origin?: string;
 }): Promise<Response> {
   const app = createApp({ signal: context.signal });
-  return await app.request(callbackUrl(args.type, args.query), {
+  return await app.request(callbackUrl(args.type, args.query, args.origin), {
     method: "GET",
     headers: args.headers,
   });
@@ -1337,7 +1336,7 @@ describe("GET /api/connectors/:type/callback", () => {
     );
   });
 
-  it("uses the forwarded web origin for callback error redirects", async () => {
+  it("uses the web rewrite origin for callback error redirects", async () => {
     const orgId = `org_${randomUUID()}`;
     const userId = `user_${randomUUID()}`;
     orgIds.push(orgId);
@@ -1346,10 +1345,10 @@ describe("GET /api/connectors/:type/callback", () => {
     const response = await requestCallback({
       type: "github",
       query: { code: "code-123", state: "returned-state" },
+      origin: API_ORIGIN,
       headers: callbackHeaders({
         stateCookie: "saved-state",
-        forwardedHost: "www.vm0.ai",
-        forwardedProto: "https",
+        webOrigin: WEB_ORIGIN,
       }),
     });
 
@@ -1362,6 +1361,20 @@ describe("GET /api/connectors/:type/callback", () => {
     expect(url.searchParams.get("type")).toBe("github");
     expect(url.searchParams.get("message")).toBe(
       "Invalid state - please try again",
+    );
+  });
+
+  it("redirects direct API host callback requests to the canonical web route", async () => {
+    const response = await requestCallback({
+      type: "github",
+      query: { code: "code-123", state: "state-123" },
+      headers: callbackHeaders({ stateCookie: "state-123" }),
+      origin: API_ORIGIN,
+    });
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toBe(
+      `${WEB_ORIGIN}/api/connectors/github/callback?code=code-123&state=state-123`,
     );
   });
 
@@ -1533,7 +1546,7 @@ describe("GET /api/connectors/:type/callback", () => {
     );
   });
 
-  it("uses the forwarded web origin for token exchange and success redirects", async () => {
+  it("uses the web rewrite origin for token exchange and success redirects", async () => {
     const dynamicOAuth = useDynamicTestOAuthExchange();
     restoreDynamicTestOAuthExchange = dynamicOAuth.restore;
     const { exchanges } = dynamicOAuth;
@@ -1545,12 +1558,12 @@ describe("GET /api/connectors/:type/callback", () => {
     const response = await requestCallback({
       type: "test-oauth",
       query: { code: "code-123", state: "state-123" },
+      origin: API_ORIGIN,
       headers: callbackHeaders({
         stateCookie: "state-123",
         codeVerifier: "pkce-verifier",
         oauthContext: "dynamic-oauth-context; tenant=example",
-        forwardedHost: "www.vm0.ai",
-        forwardedProto: "https",
+        webOrigin: WEB_ORIGIN,
       }),
     });
 

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-authorize.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-authorize.test.ts
@@ -25,9 +25,15 @@ const store = createStore();
 const mocks = createZeroRouteMocks(context);
 
 const BASE_URL = "https://app.vm0.test";
+const API_ORIGIN = "https://api.vm0.ai";
+const WEB_ORIGIN = "https://www.vm0.ai";
 
-function authorizeUrl(type: string, session?: string): string {
-  const url = new URL(`/api/zero/connectors/${type}/authorize`, BASE_URL);
+function authorizeUrl(
+  type: string,
+  session?: string,
+  origin = BASE_URL,
+): string {
+  const url = new URL(`/api/zero/connectors/${type}/authorize`, origin);
   if (session) {
     url.searchParams.set("session", session);
   }
@@ -111,6 +117,7 @@ async function requestAuthorize(
     readonly session?: string;
     readonly authenticated?: boolean;
     readonly headers?: HeadersInit;
+    readonly origin?: string;
   } = {},
 ): Promise<Response> {
   if (options.authenticated) {
@@ -121,10 +128,13 @@ async function requestAuthorize(
     headers.set("cookie", "__session=opaque");
   }
   const app = createApp({ signal: context.signal });
-  return await app.request(authorizeUrl(type, options.session), {
-    method: "GET",
-    headers,
-  });
+  return await app.request(
+    authorizeUrl(type, options.session, options.origin),
+    {
+      method: "GET",
+      headers,
+    },
+  );
 }
 
 describe("GET /api/zero/connectors/:type/authorize", () => {
@@ -169,11 +179,11 @@ describe("GET /api/zero/connectors/:type/authorize", () => {
     expect(url.searchParams.get("redirect_url")).toBe(authorizeUrl("github"));
   });
 
-  it("redirects unauthenticated users to sign-in on the forwarded web origin", async () => {
+  it("redirects unauthenticated users to sign-in on the web rewrite origin", async () => {
     const response = await requestAuthorize("github", {
+      origin: API_ORIGIN,
       headers: {
-        "x-forwarded-host": "www.vm0.ai",
-        "x-forwarded-proto": "https",
+        "x-vm0-web-origin": WEB_ORIGIN,
       },
     });
 
@@ -181,9 +191,20 @@ describe("GET /api/zero/connectors/:type/authorize", () => {
     const location = response.headers.get("location");
     expect(location).not.toBeNull();
     const url = new URL(location!);
-    expect(`${url.origin}${url.pathname}`).toBe("https://www.vm0.ai/sign-in");
+    expect(`${url.origin}${url.pathname}`).toBe(`${WEB_ORIGIN}/sign-in`);
     expect(url.searchParams.get("redirect_url")).toBe(
-      "https://www.vm0.ai/api/zero/connectors/github/authorize",
+      `${WEB_ORIGIN}/api/zero/connectors/github/authorize`,
+    );
+  });
+
+  it("redirects direct API host authorize requests to the canonical web route", async () => {
+    const response = await requestAuthorize("github", {
+      origin: API_ORIGIN,
+    });
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toBe(
+      `${WEB_ORIGIN}/api/zero/connectors/github/authorize`,
     );
   });
 
@@ -212,12 +233,12 @@ describe("GET /api/zero/connectors/:type/authorize", () => {
     ).toBeTruthy();
   });
 
-  it("uses the forwarded web origin for OAuth callback URLs", async () => {
+  it("uses the web rewrite origin for OAuth callback URLs", async () => {
     const response = await requestAuthorize("github", {
       authenticated: true,
+      origin: API_ORIGIN,
       headers: {
-        "x-forwarded-host": "www.vm0.ai",
-        "x-forwarded-proto": "https",
+        "x-vm0-web-origin": WEB_ORIGIN,
       },
     });
 
@@ -226,7 +247,7 @@ describe("GET /api/zero/connectors/:type/authorize", () => {
     expect(location).not.toBeNull();
     const url = new URL(location!);
     expect(url.searchParams.get("redirect_uri")).toBe(
-      "https://www.vm0.ai/api/connectors/github/callback",
+      `${WEB_ORIGIN}/api/connectors/github/callback`,
     );
   });
 

--- a/turbo/apps/api/src/signals/routes/connector-oauth-origin.ts
+++ b/turbo/apps/api/src/signals/routes/connector-oauth-origin.ts
@@ -1,0 +1,82 @@
+const WEB_ORIGIN_HEADER = "x-vm0-web-origin";
+
+function isLocalhost(hostname: string): boolean {
+  return hostname === "localhost" || hostname === "127.0.0.1";
+}
+
+function isVm0WebHost(hostname: string): boolean {
+  return (
+    hostname === "www.vm0.ai" ||
+    hostname === "www.vm6.ai" ||
+    hostname.endsWith("-www.vm6.ai") ||
+    hostname === "www.vm7.ai" ||
+    hostname.endsWith("-www.vm7.ai")
+  );
+}
+
+function isTrustedWebOrigin(origin: string): boolean {
+  if (!URL.canParse(origin)) {
+    return false;
+  }
+
+  const url = new URL(origin);
+  if (url.pathname !== "/" || url.search !== "" || url.hash !== "") {
+    return false;
+  }
+
+  if (isLocalhost(url.hostname)) {
+    return url.protocol === "http:" || url.protocol === "https:";
+  }
+
+  return url.protocol === "https:" && isVm0WebHost(url.hostname);
+}
+
+function canonicalWebOriginForApiHost(url: URL): string | null {
+  const webHostname = url.hostname.replace(/(^|-)api\./u, "$1www.");
+  if (webHostname === url.hostname) {
+    return null;
+  }
+
+  const webUrl = new URL(url.toString());
+  webUrl.hostname = webHostname;
+  webUrl.protocol = "https:";
+  webUrl.username = "";
+  webUrl.password = "";
+  webUrl.pathname = "/";
+  webUrl.search = "";
+  webUrl.hash = "";
+
+  if (!isTrustedWebOrigin(webUrl.origin)) {
+    return null;
+  }
+  return webUrl.origin;
+}
+
+export function getConnectorOAuthOrigin(request: Request): string {
+  const webOrigin = request.headers.get(WEB_ORIGIN_HEADER);
+  if (webOrigin && isTrustedWebOrigin(webOrigin)) {
+    return new URL(webOrigin).origin;
+  }
+
+  return new URL(request.url).origin;
+}
+
+export function getConnectorOAuthCanonicalRedirectUrl(
+  request: Request,
+): string | null {
+  const webOrigin = request.headers.get(WEB_ORIGIN_HEADER);
+  if (webOrigin && isTrustedWebOrigin(webOrigin)) {
+    return null;
+  }
+
+  const requestUrl = new URL(request.url);
+  const canonicalOrigin = canonicalWebOriginForApiHost(requestUrl);
+  if (!canonicalOrigin) {
+    return null;
+  }
+
+  return new URL(
+    `${requestUrl.pathname}${requestUrl.search}`,
+    canonicalOrigin,
+  ).toString();
+}

--- a/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
+++ b/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
@@ -27,6 +27,10 @@ import { optionalEnv } from "../../lib/env";
 import { upsertOAuthConnector$ } from "../services/zero-connector-data.service";
 import { settle } from "../utils";
 import type { RouteEntry } from "../route";
+import {
+  getConnectorOAuthCanonicalRedirectUrl,
+  getConnectorOAuthOrigin,
+} from "./connector-oauth-origin";
 
 const STATE_COOKIE_NAME = "connector_oauth_state";
 const SESSION_COOKIE_NAME = "connector_oauth_session";
@@ -35,6 +39,8 @@ const OAUTH_CONTEXT_COOKIE_NAME = "connector_oauth_context";
 const REDIRECT_STATUS = 307;
 
 type OAuthConnectorType = Exclude<ConnectorType, "computer">;
+
+const connectorCallbackAuth = { requireOrganization: true } as const;
 
 function getCookie(request: Request, name: string): string | undefined {
   const cookieHeader = request.headers.get("cookie");
@@ -49,16 +55,6 @@ function getCookie(request: Request, name: string): string | undefined {
     }
   }
   return undefined;
-}
-
-function getRequestOrigin(request: Request): string {
-  const url = new URL(request.url);
-  const forwardedHost = request.headers.get("x-forwarded-host");
-  const forwardedProto = request.headers.get("x-forwarded-proto");
-  if (forwardedHost) {
-    return `${forwardedProto ?? "https"}://${forwardedHost}`;
-  }
-  return url.origin;
 }
 
 function buildDeleteCookieHeader(name: string): string {
@@ -200,7 +196,11 @@ const callbackConnectorInner$ = command(
     const params = get(pathParamsOf(connectorsTypeCallbackContract.callback));
     const query = get(queryOf(connectorsTypeCallbackContract.callback));
     const request = get(request$).raw;
-    const origin = getRequestOrigin(request);
+    const canonicalRedirectUrl = getConnectorOAuthCanonicalRedirectUrl(request);
+    if (canonicalRedirectUrl) {
+      return redirectResponse(canonicalRedirectUrl);
+    }
+    const origin = getConnectorOAuthOrigin(request);
 
     const typeResult = connectorTypeSchema.safeParse(params.type);
     if (!typeResult.success) {
@@ -208,11 +208,7 @@ const callbackConnectorInner$ = command(
     }
     const connectorType = typeResult.data;
 
-    const auth = await set(
-      requiredAuthContext$,
-      { requireOrganization: true },
-      signal,
-    );
+    const auth = await set(requiredAuthContext$, connectorCallbackAuth, signal);
     signal.throwIfAborted();
     if ("status" in auth) {
       return redirectWithError(origin, params.type, "Not authenticated");

--- a/turbo/apps/api/src/signals/routes/zero-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/zero-connectors.ts
@@ -60,6 +60,10 @@ import { connectLocalBrowserConnector$ } from "../services/zero-local-browser.se
 import { connectLocalAgentConnector$ } from "../services/zero-local-agent.service";
 import { createComputerConnector$ } from "../services/zero-computer-connector.service";
 import type { RouteEntry } from "../route";
+import {
+  getConnectorOAuthCanonicalRedirectUrl,
+  getConnectorOAuthOrigin,
+} from "./connector-oauth-origin";
 
 const STATE_COOKIE_NAME = "connector_oauth_state";
 const SESSION_COOKIE_NAME = "connector_oauth_session";
@@ -150,16 +154,6 @@ function buildCookieHeader(
     parts.push("Secure");
   }
   return parts.join("; ");
-}
-
-function getRequestOrigin(request: Request): string {
-  const url = new URL(request.url);
-  const forwardedHost = request.headers.get("x-forwarded-host");
-  const forwardedProto = request.headers.get("x-forwarded-proto");
-  if (forwardedHost) {
-    return `${forwardedProto ?? "https"}://${forwardedHost}`;
-  }
-  return url.origin;
 }
 
 function jsonResponse(body: unknown, status: number): Response {
@@ -529,7 +523,11 @@ export function createAuthorizeConnectorInner(route: ConnectorAuthorizeRoute) {
     const params = get(pathParamsOf(route));
     const query = get(queryOf(route));
     const request = get(request$).raw;
-    const origin = getRequestOrigin(request);
+    const canonicalRedirectUrl = getConnectorOAuthCanonicalRedirectUrl(request);
+    if (canonicalRedirectUrl) {
+      return redirectResponse(canonicalRedirectUrl);
+    }
+    const origin = getConnectorOAuthOrigin(request);
     const requestUrl = new URL(request.url);
 
     const typeResult = connectorTypeSchema.safeParse(params.type);

--- a/turbo/apps/platform/src/signals/zero-page/settings/__tests__/connect-connector.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/__tests__/connect-connector.test.ts
@@ -148,6 +148,51 @@ describe("connectConnector$", () => {
     expect(context.store.get(pollingConnectorType$)).toBeNull();
   });
 
+  it("opens connector OAuth on the web host when apiBackend is enabled", async () => {
+    vi.stubGlobal("location", new URL("https://app.vm0.ai/connectors"));
+    detachedSetupPage({
+      context,
+      path: "/",
+      withoutRender: true,
+      featureSwitches: { apiBackend: true },
+    });
+
+    const mockWindow = { closed: false, close: vi.fn() };
+    const open = vi
+      .spyOn(window, "open")
+      .mockReturnValue(mockWindow as unknown as Window);
+
+    let pollCount = 0;
+    server.use(
+      mockApi(zeroConnectorsMainContract.list, ({ respond }) => {
+        pollCount++;
+        if (pollCount <= 1) {
+          return respond(200, makeEmptyConnectorResponse());
+        }
+        return respond(200, makeGithubConnectorResponse());
+      }),
+    );
+
+    const connectPromise = context.store.set(
+      connectConnector$,
+      "github",
+      {},
+      context.signal,
+    );
+
+    await vi.waitFor(() => {
+      expect(open).toHaveBeenCalledWith(
+        "https://www.vm0.ai/api/zero/connectors/github/authorize",
+        "_blank",
+        "width=600,height=700",
+      );
+      expect(hasSubscription("connector:changed")).toBeTruthy();
+    });
+    triggerAblyEvent("connector:changed");
+
+    await expect(connectPromise).resolves.toBeTruthy();
+  });
+
   it("keeps subscribing on reconnect until updatedAt changes", async () => {
     detachedSetupPage({ context, path: "/", withoutRender: true });
 

--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -49,7 +49,7 @@ import {
   deleteConnector$,
   reloadConnectors$,
 } from "../../external/connectors.ts";
-import { apiBaseForNavigation$ } from "../../fetch.ts";
+import { resolveApiBaseForNavigation } from "../../api-base.ts";
 import { zeroClient$, type ZeroClientFactory } from "../../api-client.ts";
 import {
   jsonParseOr,
@@ -1650,7 +1650,7 @@ export const connectConnector$ = command(
     options: PostConnectOptions,
     signal: AbortSignal,
   ) => {
-    const baseUrl = await get(apiBaseForNavigation$);
+    const baseUrl = resolveApiBaseForNavigation(false);
     signal.throwIfAborted();
 
     const flow = createConnectorConnectFlowState(type);

--- a/turbo/apps/web/__tests__/proxy.sandbox-token.test.ts
+++ b/turbo/apps/web/__tests__/proxy.sandbox-token.test.ts
@@ -213,6 +213,9 @@ describe("proxy middleware: sandbox token handling", () => {
     expect(response.headers.get("x-middleware-request-x-forwarded-proto")).toBe(
       "https",
     );
+    expect(response.headers.get("x-middleware-request-x-vm0-web-origin")).toBe(
+      null,
+    );
     expect(
       response.headers.get("x-middleware-request-x-vm0-test-endpoint-bypass"),
     ).toBeNull();
@@ -277,6 +280,9 @@ describe("proxy middleware: sandbox token handling", () => {
     expect(response.headers.get("x-middleware-request-x-forwarded-proto")).toBe(
       "https",
     );
+    expect(response.headers.get("x-middleware-request-x-vm0-web-origin")).toBe(
+      "https://www.vm0.ai",
+    );
   });
 
   it("should preserve web origin headers for API backend OAuth callback routes", async () => {
@@ -303,6 +309,9 @@ describe("proxy middleware: sandbox token handling", () => {
     );
     expect(response.headers.get("x-middleware-request-x-forwarded-proto")).toBe(
       "https",
+    );
+    expect(response.headers.get("x-middleware-request-x-vm0-web-origin")).toBe(
+      "https://www.vm0.ai",
     );
   });
 });

--- a/turbo/apps/web/api-backend-rewrites.js
+++ b/turbo/apps/web/api-backend-rewrites.js
@@ -643,3 +643,11 @@ export function matchesApiBackendRewritePath(pathname) {
     return pathname === source;
   });
 }
+
+export function matchesConnectorOAuthRewritePath(pathname) {
+  return (
+    CONNECTORS_AUTHORIZE_PATH_RE.test(pathname) ||
+    CONNECTORS_CALLBACK_PATH_RE.test(pathname) ||
+    ZERO_CONNECTORS_AUTHORIZE_PATH_RE.test(pathname)
+  );
+}

--- a/turbo/apps/web/proxy.ts
+++ b/turbo/apps/web/proxy.ts
@@ -12,7 +12,10 @@ import {
 } from "./proxy.layers";
 import { applyCorsHeaders, handleCors } from "./proxy.cors";
 import { env } from "./src/env";
-import { matchesApiBackendRewritePath } from "./api-backend-rewrites";
+import {
+  matchesApiBackendRewritePath,
+  matchesConnectorOAuthRewritePath,
+} from "./api-backend-rewrites";
 
 // ---------------------------------------------------------------------------
 // Clerk-specific route config
@@ -74,6 +77,7 @@ const isPublicRoute = createRouteMatcher([
 const SANDBOX_TOKEN_PREFIX = "vm0_sandbox_";
 const PAT_TOKEN_PREFIX = "vm0_pat_";
 const TEST_ENDPOINT_BYPASS_HEADER = "x-vm0-test-endpoint-bypass";
+const CONNECTOR_OAUTH_WEB_ORIGIN_HEADER = "x-vm0-web-origin";
 
 function apiBackendProxyPassThrough(request: NextRequest): NextResponse {
   const requestHeaders = new Headers(request.headers);
@@ -82,6 +86,12 @@ function apiBackendProxyPassThrough(request: NextRequest): NextResponse {
     "x-forwarded-proto",
     request.nextUrl.protocol.slice(0, -1),
   );
+  if (matchesConnectorOAuthRewritePath(request.nextUrl.pathname)) {
+    requestHeaders.set(
+      CONNECTOR_OAUTH_WEB_ORIGIN_HEADER,
+      request.nextUrl.origin,
+    );
+  }
   const bypass = env().VERCEL_AUTOMATION_BYPASS_SECRET;
   if (bypass) {
     requestHeaders.set("x-vercel-protection-bypass", bypass);


### PR DESCRIPTION
## Summary

Fixes #14021.

Keeps connector OAuth browser redirects on the web host for web-started flows instead of falling back to `api.vm0.ai` after API-backend rewrites.

Changes:
- keep platform connector OAuth popups on the web navigation base even when `apiBackend` is enabled
- add a route-scoped `x-vm0-web-origin` header for connector OAuth authorize/callback rewrites
- make API authorize/callback handlers consume only trusted web origins from that custom header
- canonicalize direct API-host connector OAuth requests back to the matching web route before state cookies are created
- cover authorize, callback token exchange, callback success/error redirects, proxy headers, and platform popup routing with regression tests

## Validation

- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-connectors-authorize.test.ts src/signals/routes/__tests__/connectors-type-callback.test.ts`
- `pnpm -F web exec vitest run __tests__/proxy.sandbox-token.test.ts`
- `pnpm -F @vm0/app exec vitest run src/signals/zero-page/settings/__tests__/connect-connector.test.ts`
- `pnpm -F api lint`
- `pnpm -F web lint`
- `pnpm -F @vm0/app lint`
- `pnpm check-types`
- pre-commit: prettier, knip, check-types
