### PR TITLE
refactor: proxy test slack conversations history route to api

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/test-slack-mock.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/test-slack-mock.test.ts
@@ -87,6 +87,17 @@ describe("POST /api/test/slack-mock/*", () => {
     await expect(response.text()).resolves.toBe("Not found");
   });
 
+  it("returns 404 for conversations.history outside allowed test environments", async () => {
+    mockEnv("ENV", "production");
+
+    const response = await requestApp(`${BASE_ROUTE}/conversations.history`, {
+      method: "POST",
+    });
+
+    expect(response.status).toBe(404);
+    await expect(response.text()).resolves.toBe("Not found");
+  });
+
   it("returns fixed Slack auth.test and oauth.v2.access fixture payloads", async () => {
     mockEnv("ENV", "development");
 

--- a/turbo/apps/web/__tests__/api-backend-rewrite-proxy.test.ts
+++ b/turbo/apps/web/__tests__/api-backend-rewrite-proxy.test.ts
@@ -318,6 +318,27 @@ describe("API backend rewrite proxy behavior", () => {
     ).toBe(false);
   });
 
+  it("matches the test Slack conversations.history mock rewrite path exactly", () => {
+    expect(
+      matchesApiBackendRewritePath(
+        "/api/test/slack-mock/conversations.history",
+      ),
+    ).toBe(true);
+    expect(
+      matchesApiBackendRewritePath(
+        "/api/test/slack-mock/conversations.history/extra",
+      ),
+    ).toBe(false);
+    expect(
+      matchesApiBackendRewritePath("/api/test/slack-mock/conversations"),
+    ).toBe(false);
+    expect(
+      matchesApiBackendRewritePath(
+        "/api/test/slack-mock/conversations.historys",
+      ),
+    ).toBe(false);
+  });
+
   it("matches the cron aggregate insights rewrite path exactly", () => {
     expect(matchesApiBackendRewritePath("/api/cron/aggregate-insights")).toBe(
       true,

--- a/turbo/apps/web/__tests__/security-headers.test.ts
+++ b/turbo/apps/web/__tests__/security-headers.test.ts
@@ -366,6 +366,15 @@ const TEST_SLACK_MOCK_CHAT_POST_MESSAGE_NEXT_NEGATIVE_PATHS = [
   "/api/test/slack-mock/chat.post",
   "/api/test/slack-mock/chat.postMessages",
 ] as const;
+const TEST_SLACK_MOCK_CONVERSATIONS_HISTORY_REWRITE_SOURCE =
+  "/api/test/slack-mock/conversations.history";
+const TEST_SLACK_MOCK_CONVERSATIONS_HISTORY_PATH =
+  "/api/test/slack-mock/conversations.history";
+const TEST_SLACK_MOCK_CONVERSATIONS_HISTORY_NEXT_NEGATIVE_PATHS = [
+  "/api/test/slack-mock/conversations.history/extra",
+  "/api/test/slack-mock/conversations",
+  "/api/test/slack-mock/conversations.historys",
+] as const;
 const CRON_AGGREGATE_INSIGHTS_REWRITE_SOURCE = "/api/cron/aggregate-insights";
 const CRON_AGGREGATE_INSIGHTS_PATH = "/api/cron/aggregate-insights";
 const CRON_AGGREGATE_INSIGHTS_NEXT_NEGATIVE_PATHS = [
@@ -1422,6 +1431,11 @@ describe("API backend rewrites", () => {
           source: TEST_SLACK_MOCK_CHAT_POST_MESSAGE_REWRITE_SOURCE,
           destination:
             "https://api.example.test/api/test/slack-mock/chat.postMessage",
+        },
+        {
+          source: TEST_SLACK_MOCK_CONVERSATIONS_HISTORY_REWRITE_SOURCE,
+          destination:
+            "https://api.example.test/api/test/slack-mock/conversations.history",
         },
         {
           source: CRON_AGGREGATE_INSIGHTS_REWRITE_SOURCE,
@@ -3435,6 +3449,37 @@ describe("API backend rewrites", () => {
 
     expect(matcher(TEST_SLACK_MOCK_CHAT_POST_MESSAGE_PATH)).toStrictEqual({});
     for (const pathname of TEST_SLACK_MOCK_CHAT_POST_MESSAGE_NEXT_NEGATIVE_PATHS) {
+      expect(matcher(pathname)).toBe(false);
+    }
+  });
+
+  it("should match only the exact test Slack conversations.history mock rewrite", async () => {
+    vi.stubEnv("VM0_API_BACKEND_URL", "https://api.example.test");
+
+    const rewrites = await getBeforeFileRewrites();
+    const rewrite = rewrites.find((entry) => {
+      return (
+        entry.source === TEST_SLACK_MOCK_CONVERSATIONS_HISTORY_REWRITE_SOURCE
+      );
+    });
+    expect(rewrite).toStrictEqual({
+      source: TEST_SLACK_MOCK_CONVERSATIONS_HISTORY_REWRITE_SOURCE,
+      destination:
+        "https://api.example.test/api/test/slack-mock/conversations.history",
+    });
+
+    const matcher = getPathMatch(
+      TEST_SLACK_MOCK_CONVERSATIONS_HISTORY_REWRITE_SOURCE,
+      {
+        removeUnnamedParams: true,
+        strict: true,
+      },
+    );
+
+    expect(matcher(TEST_SLACK_MOCK_CONVERSATIONS_HISTORY_PATH)).toStrictEqual(
+      {},
+    );
+    for (const pathname of TEST_SLACK_MOCK_CONVERSATIONS_HISTORY_NEXT_NEGATIVE_PATHS) {
       expect(matcher(pathname)).toBe(false);
     }
   });

--- a/turbo/apps/web/api-backend-rewrites.js
+++ b/turbo/apps/web/api-backend-rewrites.js
@@ -365,6 +365,10 @@ export const API_BACKEND_REWRITES = [
     "/api/test/slack-mock/chat.postEphemeral",
     "/api/test/slack-mock/chat.postEphemeral",
   ],
+  [
+    "/api/test/slack-mock/conversations.history",
+    "/api/test/slack-mock/conversations.history",
+  ],
   ["/api/test/slack-state", "/api/test/slack-state"],
   ["/api/test/telegram-dispatch-probe", "/api/test/telegram-dispatch-probe"],
   ["/api/user/export", "/api/user/export"],

--- a/turbo/apps/web/app/api/test/slack-mock/conversations.history/route.ts
+++ b/turbo/apps/web/app/api/test/slack-mock/conversations.history/route.ts
@@ -1,9 +1,0 @@
-import { NextResponse } from "next/server";
-import { isTestEndpointAllowed } from "../../../../../src/lib/auth/test-endpoint-guard";
-
-export async function POST(request: Request) {
-  if (!isTestEndpointAllowed(request)) {
-    return new NextResponse("Not found", { status: 404 });
-  }
-  return NextResponse.json({ ok: true, messages: [], has_more: false });
-}

--- a/turbo/apps/web/custom-eslint/baselines/web-api-routes.ts
+++ b/turbo/apps/web/custom-eslint/baselines/web-api-routes.ts
@@ -24,7 +24,6 @@ export const WEB_API_ROUTE_BASELINE = [
   "app/api/telegram/register/route.ts",
   "app/api/telegram/setup-status/route.ts",
   "app/api/telegram/webhook/[telegramBotId]/route.ts",
-  "app/api/test/slack-mock/conversations.history/route.ts",
   "app/api/test/slack-mock/conversations.open/route.ts",
   "app/api/test/slack-mock/conversations.replies/route.ts",
   "app/api/test/slack-mock/oauth.v2.access/route.ts",


### PR DESCRIPTION
## Summary

- cut over `/api/test/slack-mock/conversations.history` from the legacy web route to an exact web-to-api rewrite
- remove the web API route baseline entry and delete the legacy Next route implementation
- add route-specific API production-guard coverage plus web rewrite/security exact-match assertions

Closes #14031
Parent epic: #13376

## Validation

- `pnpm -F api exec vitest run src/signals/routes/__tests__/test-slack-mock.test.ts`
- `pnpm -F web exec vitest run __tests__/api-backend-rewrite-proxy.test.ts __tests__/security-headers.test.ts custom-eslint/__tests__/no-new-api-routes.test.ts`
- `pnpm -F api lint`
- `pnpm -F web lint`
- `pnpm -F api check-types`
- `pnpm -F web check-types`
- `git diff --check`
- pre-commit: `pnpm knip --cache` and `pnpm check-types`