### PR TITLE
feat: add desktop local agent management

### DIFF
--- a/turbo/apps/desktop/src/desktop-local-agent-api.ts
+++ b/turbo/apps/desktop/src/desktop-local-agent-api.ts
@@ -1,0 +1,220 @@
+import type { Session } from "electron";
+import type {
+  DesktopLocalAgentBackend,
+  DesktopLocalAgentHostStartResponse,
+  DesktopLocalAgentJobNextResponse,
+} from "./desktop-local-agent-types";
+
+interface ApiErrorBody {
+  readonly error?: {
+    readonly message?: string;
+  };
+}
+
+export interface DesktopLocalAgentApiClient {
+  readonly startHost: (params: {
+    readonly hostName: string;
+    readonly hostId?: string;
+    readonly supportedBackends: readonly DesktopLocalAgentBackend[];
+    readonly signal?: AbortSignal;
+  }) => Promise<DesktopLocalAgentHostStartResponse>;
+  readonly heartbeat: (params: {
+    readonly hostToken: string;
+    readonly hostName: string;
+    readonly supportedBackends: readonly DesktopLocalAgentBackend[];
+    readonly signal?: AbortSignal;
+  }) => Promise<void>;
+  readonly claimNextJob: (params: {
+    readonly hostToken: string;
+    readonly supportedBackends: readonly DesktopLocalAgentBackend[];
+    readonly signal?: AbortSignal;
+  }) => Promise<DesktopLocalAgentJobNextResponse>;
+  readonly completeJob: (params: {
+    readonly hostToken: string;
+    readonly jobId: string;
+    readonly status: "succeeded" | "failed";
+    readonly output?: string;
+    readonly error?: string;
+    readonly exitCode?: number;
+    readonly signal?: AbortSignal;
+  }) => Promise<void>;
+  readonly closeHost: (params: {
+    readonly hostToken: string;
+    readonly signal?: AbortSignal;
+  }) => Promise<void>;
+}
+
+function replaceHostPrefix(hostname: string, target: string): string {
+  return hostname.replace(/(^|-)(api|app|platform|www)\./, `$1${target}.`);
+}
+
+function resolveLocalAgentApiBaseUrl(platformUrl: URL): URL {
+  if (
+    platformUrl.hostname === "localhost" ||
+    platformUrl.hostname === "127.0.0.1"
+  ) {
+    return new URL(platformUrl.toString());
+  }
+
+  const url = new URL(platformUrl.toString());
+  url.hostname = replaceHostPrefix(url.hostname, "api");
+  url.pathname = "/";
+  url.search = "";
+  url.hash = "";
+  return url;
+}
+
+function normalizeBaseUrl(baseUrl: URL): string {
+  return baseUrl.toString().replace(/\/$/, "");
+}
+
+function parseErrorBody(value: unknown): string | null {
+  if (typeof value !== "object" || value === null) {
+    return null;
+  }
+  const body = value as ApiErrorBody;
+  return body.error?.message ?? null;
+}
+
+async function readJson(response: Response): Promise<unknown> {
+  const text = await response.text();
+  if (text.length === 0) {
+    return {};
+  }
+  return JSON.parse(text) as unknown;
+}
+
+async function parseResponse<T>(response: Response): Promise<T> {
+  const body = await readJson(response);
+  if (!response.ok) {
+    throw new Error(
+      parseErrorBody(body) ?? `Local agent API returned ${response.status}`,
+    );
+  }
+  return body as T;
+}
+
+function bearerHeaders(hostToken: string): HeadersInit {
+  return {
+    authorization: `Bearer ${hostToken}`,
+    "content-type": "application/json",
+  };
+}
+
+async function cookieHeaderForSession(
+  electronSession: Session,
+  urls: readonly URL[],
+): Promise<string> {
+  const pairs = new Map<string, string>();
+  for (const url of urls) {
+    const cookies = await electronSession.cookies.get({ url: url.toString() });
+    for (const cookie of cookies) {
+      pairs.set(cookie.name, `${cookie.name}=${cookie.value}`);
+    }
+  }
+  return [...pairs.values()].join("; ");
+}
+
+function optionalJsonBody(body: object): string {
+  return JSON.stringify(body);
+}
+
+export function createDesktopLocalAgentApiClient(params: {
+  readonly platformUrl: URL;
+  readonly session: Session;
+}): DesktopLocalAgentApiClient {
+  const apiBaseUrl = resolveLocalAgentApiBaseUrl(params.platformUrl);
+  const apiBase = normalizeBaseUrl(apiBaseUrl);
+
+  const sessionHeaders = async (): Promise<HeadersInit> => {
+    const cookie = await cookieHeaderForSession(params.session, [
+      params.platformUrl,
+      apiBaseUrl,
+    ]);
+    return {
+      "content-type": "application/json",
+      ...(cookie.length > 0 ? { cookie } : {}),
+    };
+  };
+
+  return {
+    async startHost(startParams) {
+      const response = await fetch(
+        `${apiBase}/api/zero/local-agent/hosts/start`,
+        {
+          method: "POST",
+          headers: await sessionHeaders(),
+          body: optionalJsonBody({
+            hostName: startParams.hostName,
+            supportedBackends: startParams.supportedBackends,
+            ...(startParams.hostId ? { hostId: startParams.hostId } : {}),
+          }),
+          signal: startParams.signal,
+        },
+      );
+      return parseResponse<DesktopLocalAgentHostStartResponse>(response);
+    },
+    async heartbeat(heartbeatParams) {
+      const response = await fetch(
+        `${apiBase}/api/zero/local-agent/heartbeat`,
+        {
+          method: "POST",
+          headers: bearerHeaders(heartbeatParams.hostToken),
+          body: optionalJsonBody({
+            hostName: heartbeatParams.hostName,
+            supportedBackends: heartbeatParams.supportedBackends,
+            realtimeConnected: false,
+          }),
+          signal: heartbeatParams.signal,
+        },
+      );
+      await parseResponse<{ readonly ok: true; readonly hostId: string }>(
+        response,
+      );
+    },
+    async claimNextJob(claimParams) {
+      const response = await fetch(
+        `${apiBase}/api/zero/local-agent/host/jobs/next`,
+        {
+          method: "POST",
+          headers: bearerHeaders(claimParams.hostToken),
+          body: optionalJsonBody({
+            supportedBackends: claimParams.supportedBackends,
+          }),
+          signal: claimParams.signal,
+        },
+      );
+      return parseResponse<DesktopLocalAgentJobNextResponse>(response);
+    },
+    async completeJob(completeParams) {
+      const response = await fetch(
+        `${apiBase}/api/zero/local-agent/host/jobs/${completeParams.jobId}/complete`,
+        {
+          method: "POST",
+          headers: bearerHeaders(completeParams.hostToken),
+          body: optionalJsonBody({
+            status: completeParams.status,
+            output: completeParams.output,
+            error: completeParams.error,
+            exitCode: completeParams.exitCode,
+          }),
+          signal: completeParams.signal,
+        },
+      );
+      await parseResponse<{ readonly ok: true }>(response);
+    },
+    async closeHost(closeParams) {
+      const response = await fetch(
+        `${apiBase}/api/zero/local-agent/hosts/close`,
+        {
+          method: "POST",
+          headers: {
+            authorization: `Bearer ${closeParams.hostToken}`,
+          },
+          signal: closeParams.signal,
+        },
+      );
+      await parseResponse<{ readonly ok: true }>(response);
+    },
+  };
+}

--- a/turbo/apps/desktop/src/desktop-local-agent-electron.ts
+++ b/turbo/apps/desktop/src/desktop-local-agent-electron.ts
@@ -1,0 +1,95 @@
+import type { IpcMainInvokeEvent } from "electron";
+import { BrowserWindow, dialog, ipcMain, shell } from "electron";
+import { DESKTOP_LOCAL_AGENT_CHANNELS } from "./desktop-local-agent-ipc-channels";
+import type { DesktopLocalAgentManager } from "./desktop-local-agent-manager";
+import type { DesktopLocalAgentAddOptions } from "./desktop-local-agent-types";
+
+function stringArg(value: unknown): string {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error("Expected local agent id");
+  }
+  return value;
+}
+
+function addOptionsArg(value: unknown): DesktopLocalAgentAddOptions {
+  if (typeof value !== "object" || value === null) {
+    return {};
+  }
+  const options = value as DesktopLocalAgentAddOptions;
+  return {
+    ...(options.backend ? { backend: options.backend } : {}),
+    ...(options.permissionMode
+      ? { permissionMode: options.permissionMode }
+      : {}),
+  };
+}
+
+export function notifyDesktopLocalAgentsChanged(): void {
+  for (const window of BrowserWindow.getAllWindows()) {
+    if (!window.isDestroyed()) {
+      window.webContents.send(DESKTOP_LOCAL_AGENT_CHANNELS.changed);
+    }
+  }
+}
+
+export function installDesktopLocalAgentIpc(
+  manager: DesktopLocalAgentManager,
+): void {
+  ipcMain.handle(
+    DESKTOP_LOCAL_AGENT_CHANNELS.setEnabled,
+    async (_event: IpcMainInvokeEvent, enabled: unknown) => {
+      await manager.setEnabled(enabled === true);
+    },
+  );
+  ipcMain.handle(DESKTOP_LOCAL_AGENT_CHANNELS.list, async () => {
+    return manager.list();
+  });
+  ipcMain.handle(DESKTOP_LOCAL_AGENT_CHANNELS.detectBackends, async () => {
+    return manager.detectBackends();
+  });
+  ipcMain.handle(
+    DESKTOP_LOCAL_AGENT_CHANNELS.add,
+    async (_event: IpcMainInvokeEvent, options: unknown) => {
+      return manager.add(addOptionsArg(options));
+    },
+  );
+  ipcMain.handle(
+    DESKTOP_LOCAL_AGENT_CHANNELS.start,
+    async (_event: IpcMainInvokeEvent, id: unknown) => {
+      return manager.start(stringArg(id));
+    },
+  );
+  ipcMain.handle(
+    DESKTOP_LOCAL_AGENT_CHANNELS.stop,
+    async (_event: IpcMainInvokeEvent, id: unknown) => {
+      return manager.stop(stringArg(id));
+    },
+  );
+  ipcMain.handle(
+    DESKTOP_LOCAL_AGENT_CHANNELS.remove,
+    async (_event: IpcMainInvokeEvent, id: unknown) => {
+      await manager.remove(stringArg(id));
+    },
+  );
+  ipcMain.handle(
+    DESKTOP_LOCAL_AGENT_CHANNELS.openFolder,
+    async (_event: IpcMainInvokeEvent, id: unknown) => {
+      await manager.openFolder(stringArg(id));
+    },
+  );
+}
+
+export async function selectLocalAgentFolder(): Promise<string | null> {
+  const result = await dialog.showOpenDialog({
+    properties: ["openDirectory"],
+    title: "Add local agent",
+  });
+  return result.canceled ? null : (result.filePaths[0] ?? null);
+}
+
+export async function openLocalAgentFolder(folderPath: string): Promise<void> {
+  const error = await shell.openPath(folderPath);
+  if (error.length > 0) {
+    throw new Error(error);
+  }
+}

--- a/turbo/apps/desktop/src/desktop-local-agent-electron.ts
+++ b/turbo/apps/desktop/src/desktop-local-agent-electron.ts
@@ -2,7 +2,12 @@ import type { IpcMainInvokeEvent } from "electron";
 import { BrowserWindow, dialog, ipcMain, shell } from "electron";
 import { DESKTOP_LOCAL_AGENT_CHANNELS } from "./desktop-local-agent-ipc-channels";
 import type { DesktopLocalAgentManager } from "./desktop-local-agent-manager";
+import { isDesktopLocalAgentPageUrl } from "./desktop-local-agent-page-url";
 import type { DesktopLocalAgentAddOptions } from "./desktop-local-agent-types";
+
+interface DesktopLocalAgentIpcOptions {
+  readonly allowedAppOrigins: ReadonlySet<string>;
+}
 
 function stringArg(value: unknown): string {
   if (typeof value !== "string" || value.length === 0) {
@@ -34,46 +39,66 @@ export function notifyDesktopLocalAgentsChanged(): void {
 
 export function installDesktopLocalAgentIpc(
   manager: DesktopLocalAgentManager,
+  options: DesktopLocalAgentIpcOptions,
 ): void {
+  const assertLocalAgentPage = (event: IpcMainInvokeEvent): void => {
+    if (
+      !isDesktopLocalAgentPageUrl(
+        event.senderFrame?.url ?? "",
+        options.allowedAppOrigins,
+      )
+    ) {
+      throw new Error("Desktop local agent is unavailable on this page");
+    }
+  };
+
   ipcMain.handle(
     DESKTOP_LOCAL_AGENT_CHANNELS.setEnabled,
-    async (_event: IpcMainInvokeEvent, enabled: unknown) => {
+    async (event: IpcMainInvokeEvent, enabled: unknown) => {
+      assertLocalAgentPage(event);
       await manager.setEnabled(enabled === true);
     },
   );
-  ipcMain.handle(DESKTOP_LOCAL_AGENT_CHANNELS.list, async () => {
+  ipcMain.handle(DESKTOP_LOCAL_AGENT_CHANNELS.list, async (event) => {
+    assertLocalAgentPage(event);
     return manager.list();
   });
-  ipcMain.handle(DESKTOP_LOCAL_AGENT_CHANNELS.detectBackends, async () => {
+  ipcMain.handle(DESKTOP_LOCAL_AGENT_CHANNELS.detectBackends, async (event) => {
+    assertLocalAgentPage(event);
     return manager.detectBackends();
   });
   ipcMain.handle(
     DESKTOP_LOCAL_AGENT_CHANNELS.add,
-    async (_event: IpcMainInvokeEvent, options: unknown) => {
-      return manager.add(addOptionsArg(options));
+    async (event: IpcMainInvokeEvent, addOptions: unknown) => {
+      assertLocalAgentPage(event);
+      return manager.add(addOptionsArg(addOptions));
     },
   );
   ipcMain.handle(
     DESKTOP_LOCAL_AGENT_CHANNELS.start,
-    async (_event: IpcMainInvokeEvent, id: unknown) => {
+    async (event: IpcMainInvokeEvent, id: unknown) => {
+      assertLocalAgentPage(event);
       return manager.start(stringArg(id));
     },
   );
   ipcMain.handle(
     DESKTOP_LOCAL_AGENT_CHANNELS.stop,
-    async (_event: IpcMainInvokeEvent, id: unknown) => {
+    async (event: IpcMainInvokeEvent, id: unknown) => {
+      assertLocalAgentPage(event);
       return manager.stop(stringArg(id));
     },
   );
   ipcMain.handle(
     DESKTOP_LOCAL_AGENT_CHANNELS.remove,
-    async (_event: IpcMainInvokeEvent, id: unknown) => {
+    async (event: IpcMainInvokeEvent, id: unknown) => {
+      assertLocalAgentPage(event);
       await manager.remove(stringArg(id));
     },
   );
   ipcMain.handle(
     DESKTOP_LOCAL_AGENT_CHANNELS.openFolder,
-    async (_event: IpcMainInvokeEvent, id: unknown) => {
+    async (event: IpcMainInvokeEvent, id: unknown) => {
+      assertLocalAgentPage(event);
       await manager.openFolder(stringArg(id));
     },
   );

--- a/turbo/apps/desktop/src/desktop-local-agent-ipc-channels.ts
+++ b/turbo/apps/desktop/src/desktop-local-agent-ipc-channels.ts
@@ -1,0 +1,11 @@
+export const DESKTOP_LOCAL_AGENT_CHANNELS = {
+  setEnabled: "desktop-local-agent:set-enabled",
+  list: "desktop-local-agent:list",
+  detectBackends: "desktop-local-agent:detect-backends",
+  add: "desktop-local-agent:add",
+  start: "desktop-local-agent:start",
+  stop: "desktop-local-agent:stop",
+  remove: "desktop-local-agent:remove",
+  openFolder: "desktop-local-agent:open-folder",
+  changed: "desktop-local-agent:changed",
+} as const;

--- a/turbo/apps/desktop/src/desktop-local-agent-manager.test.ts
+++ b/turbo/apps/desktop/src/desktop-local-agent-manager.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it, vi } from "vitest";
+import type { DesktopLocalAgentApiClient } from "./desktop-local-agent-api";
+import { DesktopLocalAgentManager } from "./desktop-local-agent-manager";
+import type {
+  DesktopLocalAgentBackendProbe,
+  DesktopLocalAgentEntry,
+} from "./desktop-local-agent-types";
+
+const CODEX_PROBES: DesktopLocalAgentBackendProbe[] = [
+  {
+    backend: "codex",
+    command: "codex",
+    available: true,
+    version: "codex 1.0.0",
+  },
+  {
+    backend: "claude-code",
+    command: "claude",
+    available: true,
+    version: "claude 1.0.0",
+  },
+];
+
+function createHarness(
+  options: {
+    readonly folders?: readonly string[];
+    readonly initialEntries?: readonly DesktopLocalAgentEntry[];
+  } = {},
+) {
+  let entries = [...(options.initialEntries ?? [])];
+  const folders = [...(options.folders ?? ["/workspace/alpha"])];
+  const startedHosts: string[] = [];
+  const closedHosts: string[] = [];
+  const api: DesktopLocalAgentApiClient = {
+    async startHost(params) {
+      startedHosts.push(params.hostName);
+      return {
+        hostId: `host-${startedHosts.length}`,
+        hostToken: `token-${startedHosts.length}`,
+      };
+    },
+    async heartbeat() {},
+    async claimNextJob() {
+      return { status: "idle" };
+    },
+    async completeJob() {},
+    async closeHost(params) {
+      closedHosts.push(params.hostToken);
+    },
+  };
+  const manager = new DesktopLocalAgentManager({
+    store: {
+      async load() {
+        return entries;
+      },
+      async save(nextEntries) {
+        entries = [...nextEntries];
+      },
+    },
+    api,
+    async selectFolder() {
+      return folders.shift() ?? null;
+    },
+    async openFolder() {},
+    detectBackends: vi.fn(async () => {
+      return CODEX_PROBES;
+    }),
+    executeBackend: vi.fn(async () => {
+      return { output: "ok", exitCode: 0 };
+    }),
+    randomId: vi
+      .fn()
+      .mockReturnValueOnce("agent-1")
+      .mockReturnValueOnce("agent-2"),
+  });
+
+  return { manager, startedHosts, closedHosts };
+}
+
+describe("DesktopLocalAgentManager", () => {
+  it("keeps native access disabled until the feature switch enables it", async () => {
+    const { manager } = createHarness();
+
+    await expect(manager.list()).rejects.toThrow("disabled");
+    await manager.setEnabled(true);
+
+    await expect(manager.list()).resolves.toStrictEqual([]);
+  });
+
+  it("adds a Codex workspace with workspace-write permissions by default", async () => {
+    const { manager, startedHosts, closedHosts } = createHarness();
+
+    await manager.setEnabled(true);
+    const entry = await manager.add();
+
+    expect(entry).toMatchObject({
+      id: "agent-1",
+      name: "alpha",
+      folderPath: "/workspace/alpha",
+      backend: "codex",
+      permissionMode: "workspace-write",
+      status: "online",
+      hostId: "host-1",
+    });
+    expect(startedHosts).toStrictEqual(["alpha"]);
+
+    await manager.stopAll();
+    expect(closedHosts).toStrictEqual(["token-1"]);
+  });
+
+  it("runs multiple configured workspaces independently", async () => {
+    const { manager, startedHosts, closedHosts } = createHarness({
+      folders: ["/workspace/alpha", "/workspace/beta"],
+    });
+
+    await manager.setEnabled(true);
+    await manager.add();
+    await manager.add();
+
+    expect(startedHosts).toStrictEqual(["alpha", "beta"]);
+    expect(await manager.list()).toMatchObject([
+      { name: "alpha", status: "online" },
+      { name: "beta", status: "online" },
+    ]);
+
+    await manager.stop("agent-1");
+    expect(await manager.list()).toMatchObject([
+      { name: "alpha", status: "stopped" },
+      { name: "beta", status: "online" },
+    ]);
+    expect(closedHosts).toStrictEqual(["token-1"]);
+
+    await manager.stopAll();
+    expect(closedHosts).toStrictEqual(["token-1", "token-2"]);
+  });
+
+  it("restores persisted agents as stopped without autostarting them", async () => {
+    const { manager, startedHosts } = createHarness({
+      initialEntries: [
+        {
+          id: "agent-1",
+          name: "alpha",
+          folderPath: "/workspace/alpha",
+          backend: "codex",
+          permissionMode: "workspace-write",
+          status: "online",
+          hostId: "host-1",
+          lastHeartbeatAt: "2026-05-19T00:00:00.000Z",
+        },
+      ],
+    });
+
+    await manager.setEnabled(true);
+
+    expect(await manager.list()).toStrictEqual([
+      {
+        id: "agent-1",
+        name: "alpha",
+        folderPath: "/workspace/alpha",
+        backend: "codex",
+        permissionMode: "workspace-write",
+        status: "stopped",
+        hostId: "host-1",
+        lastHeartbeatAt: "2026-05-19T00:00:00.000Z",
+      },
+    ]);
+    expect(startedHosts).toStrictEqual([]);
+  });
+});

--- a/turbo/apps/desktop/src/desktop-local-agent-manager.test.ts
+++ b/turbo/apps/desktop/src/desktop-local-agent-manager.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import type { DesktopLocalAgentApiClient } from "./desktop-local-agent-api";
 import { DesktopLocalAgentManager } from "./desktop-local-agent-manager";
+import type { executeLocalAgentBackend } from "./desktop-local-agent-runtime";
 import type {
   DesktopLocalAgentBackendProbe,
   DesktopLocalAgentEntry,
@@ -25,12 +26,20 @@ function createHarness(
   options: {
     readonly folders?: readonly string[];
     readonly initialEntries?: readonly DesktopLocalAgentEntry[];
+    readonly apiOverrides?: Partial<DesktopLocalAgentApiClient>;
+    readonly executeBackend?: typeof executeLocalAgentBackend;
   } = {},
 ) {
   let entries = [...(options.initialEntries ?? [])];
   const folders = [...(options.folders ?? ["/workspace/alpha"])];
   const startedHosts: string[] = [];
   const closedHosts: string[] = [];
+  const completedJobs: Array<{
+    readonly jobId: string;
+    readonly status: "succeeded" | "failed";
+    readonly error: string | undefined;
+    readonly signalAborted: boolean;
+  }> = [];
   const api: DesktopLocalAgentApiClient = {
     async startHost(params) {
       startedHosts.push(params.hostName);
@@ -43,7 +52,14 @@ function createHarness(
     async claimNextJob() {
       return { status: "idle" };
     },
-    async completeJob() {},
+    async completeJob(params) {
+      completedJobs.push({
+        jobId: params.jobId,
+        status: params.status,
+        error: params.error,
+        signalAborted: params.signal?.aborted ?? false,
+      });
+    },
     async closeHost(params) {
       closedHosts.push(params.hostToken);
     },
@@ -57,7 +73,7 @@ function createHarness(
         entries = [...nextEntries];
       },
     },
-    api,
+    api: { ...api, ...options.apiOverrides },
     async selectFolder() {
       return folders.shift() ?? null;
     },
@@ -65,16 +81,18 @@ function createHarness(
     detectBackends: vi.fn(async () => {
       return CODEX_PROBES;
     }),
-    executeBackend: vi.fn(async () => {
-      return { output: "ok", exitCode: 0 };
-    }),
+    executeBackend:
+      options.executeBackend ??
+      vi.fn(async () => {
+        return { output: "ok", exitCode: 0 };
+      }),
     randomId: vi
       .fn()
       .mockReturnValueOnce("agent-1")
       .mockReturnValueOnce("agent-2"),
   });
 
-  return { manager, startedHosts, closedHosts };
+  return { manager, startedHosts, closedHosts, completedJobs };
 }
 
 describe("DesktopLocalAgentManager", () => {
@@ -82,6 +100,8 @@ describe("DesktopLocalAgentManager", () => {
     const { manager } = createHarness();
 
     await expect(manager.list()).rejects.toThrow("disabled");
+    await expect(manager.stop("agent-1")).rejects.toThrow("disabled");
+    await expect(manager.remove("agent-1")).rejects.toThrow("disabled");
     await manager.setEnabled(true);
 
     await expect(manager.list()).resolves.toStrictEqual([]);
@@ -165,5 +185,63 @@ describe("DesktopLocalAgentManager", () => {
       },
     ]);
     expect(startedHosts).toStrictEqual([]);
+  });
+
+  it("fails an active job before closing the host when stopped", async () => {
+    let claimCount = 0;
+    const executeBackend = vi.fn<typeof executeLocalAgentBackend>(
+      async (params) => {
+        return await new Promise((resolve) => {
+          params.signal?.addEventListener(
+            "abort",
+            () => {
+              resolve({
+                output: "",
+                error: "Local agent job was stopped",
+                exitCode: 1,
+              });
+            },
+            { once: true },
+          );
+        });
+      },
+    );
+    const { manager, closedHosts, completedJobs } = createHarness({
+      executeBackend,
+      apiOverrides: {
+        async claimNextJob() {
+          claimCount += 1;
+          if (claimCount === 1) {
+            return {
+              status: "job",
+              job: {
+                id: "job-1",
+                backend: "codex",
+                prompt: "run task",
+              },
+            };
+          }
+          return { status: "idle" };
+        },
+      },
+    });
+
+    await manager.setEnabled(true);
+    await manager.add();
+    await vi.waitFor(() => {
+      expect(executeBackend).toHaveBeenCalled();
+    });
+
+    await manager.stop("agent-1");
+
+    expect(completedJobs).toStrictEqual([
+      {
+        jobId: "job-1",
+        status: "failed",
+        error: "Local agent job was stopped",
+        signalAborted: false,
+      },
+    ]);
+    expect(closedHosts).toStrictEqual(["token-1"]);
   });
 });

--- a/turbo/apps/desktop/src/desktop-local-agent-manager.ts
+++ b/turbo/apps/desktop/src/desktop-local-agent-manager.ts
@@ -1,0 +1,443 @@
+import path from "node:path";
+import type { DesktopLocalAgentApiClient } from "./desktop-local-agent-api";
+import {
+  defaultPermissionMode,
+  type detectLocalAgentBackends,
+  type executeLocalAgentBackend,
+} from "./desktop-local-agent-runtime";
+import type {
+  DesktopLocalAgentAddOptions,
+  DesktopLocalAgentBackend,
+  DesktopLocalAgentBackendProbe,
+  DesktopLocalAgentEntry,
+  DesktopLocalAgentExecutionResult,
+} from "./desktop-local-agent-types";
+
+const HEARTBEAT_INTERVAL_MS = 60_000;
+const IDLE_POLL_INTERVAL_MS = 2_000;
+
+interface DesktopLocalAgentStore {
+  readonly load: () => Promise<DesktopLocalAgentEntry[]>;
+  readonly save: (entries: readonly DesktopLocalAgentEntry[]) => Promise<void>;
+}
+
+interface DesktopLocalAgentManagerDependencies {
+  readonly store: DesktopLocalAgentStore;
+  readonly api: DesktopLocalAgentApiClient;
+  readonly selectFolder: () => Promise<string | null>;
+  readonly openFolder: (folderPath: string) => Promise<void>;
+  readonly detectBackends: typeof detectLocalAgentBackends;
+  readonly executeBackend: typeof executeLocalAgentBackend;
+  readonly now?: () => number;
+  readonly randomId?: () => string;
+  readonly onChange?: () => void;
+}
+
+interface RunningAgent {
+  readonly controller: AbortController;
+  readonly hostToken: string;
+  readonly promise: Promise<void>;
+}
+
+function cloneEntry(entry: DesktopLocalAgentEntry): DesktopLocalAgentEntry {
+  return { ...entry };
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function delay(ms: number, signal: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal.aborted) {
+      reject(signal.reason);
+      return;
+    }
+    const timer = setTimeout(resolve, ms);
+    signal.addEventListener(
+      "abort",
+      () => {
+        clearTimeout(timer);
+        reject(signal.reason);
+      },
+      { once: true },
+    );
+  });
+}
+
+function stoppedEntry(entry: DesktopLocalAgentEntry): DesktopLocalAgentEntry {
+  const { errorMessage: _errorMessage, ...rest } = entry;
+  return {
+    ...rest,
+    status: "stopped",
+  };
+}
+
+function preferredBackend(
+  probes: readonly DesktopLocalAgentBackendProbe[],
+  requested?: DesktopLocalAgentBackend,
+): DesktopLocalAgentBackend {
+  if (requested) {
+    return requested;
+  }
+  const availableCodex = probes.find((probe) => {
+    return probe.backend === "codex" && probe.available;
+  });
+  if (availableCodex) {
+    return "codex";
+  }
+  const firstAvailable = probes.find((probe) => {
+    return probe.available;
+  });
+  return firstAvailable?.backend ?? "codex";
+}
+
+function uniqueName(
+  basename: string,
+  entries: readonly DesktopLocalAgentEntry[],
+): string {
+  const names = new Set(
+    entries.map((entry) => {
+      return entry.name;
+    }),
+  );
+  if (!names.has(basename)) {
+    return basename;
+  }
+
+  let index = 2;
+  while (names.has(`${basename} ${index}`)) {
+    index += 1;
+  }
+  return `${basename} ${index}`;
+}
+
+export class DesktopLocalAgentManager {
+  private entries: DesktopLocalAgentEntry[] | null = null;
+  private readonly runningAgents = new Map<string, RunningAgent>();
+  private nativeEnabled = false;
+
+  constructor(private readonly deps: DesktopLocalAgentManagerDependencies) {}
+
+  async setEnabled(enabled: boolean): Promise<void> {
+    this.nativeEnabled = enabled;
+    if (!enabled) {
+      await this.stopAll();
+    }
+  }
+
+  isEnabled(): boolean {
+    return this.nativeEnabled;
+  }
+
+  hasRunningAgents(): boolean {
+    return this.runningAgents.size > 0;
+  }
+
+  async list(): Promise<DesktopLocalAgentEntry[]> {
+    this.assertEnabled();
+    await this.ensureLoaded();
+    return this.entriesOrThrow().map(cloneEntry);
+  }
+
+  async detectBackends(): Promise<DesktopLocalAgentBackendProbe[]> {
+    this.assertEnabled();
+    return this.deps.detectBackends();
+  }
+
+  async add(
+    options: DesktopLocalAgentAddOptions = {},
+  ): Promise<DesktopLocalAgentEntry | null> {
+    this.assertEnabled();
+    await this.ensureLoaded();
+    const folderPath = await this.deps.selectFolder();
+    if (!folderPath) {
+      return null;
+    }
+
+    const probes = await this.deps.detectBackends();
+    const backend = preferredBackend(probes, options.backend);
+    const permissionMode =
+      options.permissionMode ?? defaultPermissionMode(backend);
+    const entries = this.entriesOrThrow();
+    const basename = path.basename(folderPath) || folderPath;
+    const entry: DesktopLocalAgentEntry = {
+      id: this.randomId(),
+      name: uniqueName(basename, entries),
+      folderPath,
+      backend,
+      permissionMode,
+      status: "stopped",
+    };
+    entries.push(entry);
+    await this.persistAndNotify();
+    return this.start(entry.id);
+  }
+
+  async start(id: string): Promise<DesktopLocalAgentEntry> {
+    this.assertEnabled();
+    await this.ensureLoaded();
+    const entry = this.requireEntry(id);
+    const existing = this.runningAgents.get(id);
+    if (existing) {
+      return cloneEntry(entry);
+    }
+
+    this.updateEntry(id, { status: "starting" });
+    await this.persistAndNotify();
+
+    try {
+      const controller = new AbortController();
+      const supportedBackends = [entry.backend];
+      const host = await this.deps.api.startHost({
+        hostName: entry.name,
+        hostId: entry.hostId,
+        supportedBackends,
+        signal: controller.signal,
+      });
+      this.updateEntry(id, {
+        hostId: host.hostId,
+        status: "online",
+        errorMessage: undefined,
+      });
+      await this.persistAndNotify();
+
+      const promise = this.runLoop({
+        id,
+        hostToken: host.hostToken,
+        controller,
+      });
+      this.runningAgents.set(id, {
+        controller,
+        hostToken: host.hostToken,
+        promise,
+      });
+      void promise;
+      return cloneEntry(this.requireEntry(id));
+    } catch (error) {
+      this.updateEntry(id, {
+        status: "error",
+        errorMessage: errorMessage(error),
+      });
+      await this.persistAndNotify();
+      return cloneEntry(this.requireEntry(id));
+    }
+  }
+
+  async stop(id: string): Promise<DesktopLocalAgentEntry> {
+    await this.ensureLoaded();
+    const entry = this.requireEntry(id);
+    const running = this.runningAgents.get(id);
+    if (!running) {
+      this.updateEntry(id, { status: "stopped" });
+      await this.persistAndNotify();
+      return cloneEntry(this.requireEntry(entry.id));
+    }
+
+    this.updateEntry(id, { status: "stopping" });
+    await this.persistAndNotify();
+    running.controller.abort();
+    await this.closeRunningHost(running);
+    await running.promise.catch(() => {});
+    this.runningAgents.delete(id);
+    this.updateEntry(id, { status: "stopped", errorMessage: undefined });
+    await this.persistAndNotify();
+    return cloneEntry(this.requireEntry(id));
+  }
+
+  async stopAll(): Promise<void> {
+    await this.ensureLoaded();
+    await Promise.all(
+      [...this.runningAgents.keys()].map((id) => {
+        return this.stop(id).then(() => {});
+      }),
+    );
+  }
+
+  async remove(id: string): Promise<void> {
+    await this.stop(id).catch(() => {});
+    await this.ensureLoaded();
+    this.entries = this.entriesOrThrow().filter((entry) => {
+      return entry.id !== id;
+    });
+    await this.persistAndNotify();
+  }
+
+  async openFolder(id: string): Promise<void> {
+    this.assertEnabled();
+    await this.ensureLoaded();
+    const entry = this.requireEntry(id);
+    await this.deps.openFolder(entry.folderPath);
+  }
+
+  private async runLoop(params: {
+    readonly id: string;
+    readonly hostToken: string;
+    readonly controller: AbortController;
+  }): Promise<void> {
+    let nextHeartbeatAt = 0;
+    const signal = params.controller.signal;
+    try {
+      while (!signal.aborted) {
+        const entry = this.requireEntry(params.id);
+        const supportedBackends = [entry.backend];
+        if (Date.now() >= nextHeartbeatAt) {
+          await this.sendHeartbeat({
+            entry,
+            hostToken: params.hostToken,
+            supportedBackends,
+            signal,
+          });
+          nextHeartbeatAt = Date.now() + HEARTBEAT_INTERVAL_MS;
+        }
+        const nextJob = await this.deps.api.claimNextJob({
+          hostToken: params.hostToken,
+          supportedBackends,
+          signal,
+        });
+        if (nextJob.status === "idle") {
+          await delay(IDLE_POLL_INTERVAL_MS, signal);
+          continue;
+        }
+        await this.runJob({
+          entry,
+          hostToken: params.hostToken,
+          jobId: nextJob.job.id,
+          prompt: nextJob.job.prompt,
+          backend: nextJob.job.backend,
+          signal,
+        });
+      }
+    } catch (error) {
+      if (!signal.aborted) {
+        this.runningAgents.delete(params.id);
+        this.updateEntry(params.id, {
+          status: "error",
+          errorMessage: errorMessage(error),
+        });
+        await this.persistAndNotify();
+      }
+    }
+  }
+
+  private async runJob(params: {
+    readonly entry: DesktopLocalAgentEntry;
+    readonly hostToken: string;
+    readonly jobId: string;
+    readonly prompt: string;
+    readonly backend: DesktopLocalAgentBackend;
+    readonly signal: AbortSignal;
+  }): Promise<void> {
+    const result = await this.deps.executeBackend({
+      backend: params.backend,
+      prompt: params.prompt,
+      workdir: params.entry.folderPath,
+      permissionMode: params.entry.permissionMode,
+      signal: params.signal,
+    });
+    await this.completeJob({
+      hostToken: params.hostToken,
+      jobId: params.jobId,
+      result,
+      signal: params.signal,
+    });
+  }
+
+  private async completeJob(params: {
+    readonly hostToken: string;
+    readonly jobId: string;
+    readonly result: DesktopLocalAgentExecutionResult;
+    readonly signal: AbortSignal;
+  }): Promise<void> {
+    await this.deps.api.completeJob({
+      hostToken: params.hostToken,
+      jobId: params.jobId,
+      status: params.result.exitCode === 0 ? "succeeded" : "failed",
+      output: params.result.output,
+      error: params.result.error,
+      exitCode: params.result.exitCode,
+      signal: params.signal,
+    });
+  }
+
+  private async sendHeartbeat(params: {
+    readonly entry: DesktopLocalAgentEntry;
+    readonly hostToken: string;
+    readonly supportedBackends: readonly DesktopLocalAgentBackend[];
+    readonly signal: AbortSignal;
+  }): Promise<void> {
+    await this.deps.api.heartbeat({
+      hostToken: params.hostToken,
+      hostName: params.entry.name,
+      supportedBackends: params.supportedBackends,
+      signal: params.signal,
+    });
+    this.updateEntry(params.entry.id, {
+      status: "online",
+      lastHeartbeatAt: new Date(this.now()).toISOString(),
+      errorMessage: undefined,
+    });
+    await this.persistAndNotify();
+  }
+
+  private async closeRunningHost(running: RunningAgent): Promise<void> {
+    await this.deps.api
+      .closeHost({ hostToken: running.hostToken })
+      .catch(() => {});
+  }
+
+  private async ensureLoaded(): Promise<void> {
+    if (this.entries) {
+      return;
+    }
+    const entries = await this.deps.store.load();
+    this.entries = entries.map(stoppedEntry);
+    await this.deps.store.save(this.entries);
+  }
+
+  private entriesOrThrow(): DesktopLocalAgentEntry[] {
+    if (!this.entries) {
+      throw new Error("Desktop local agents have not loaded");
+    }
+    return this.entries;
+  }
+
+  private requireEntry(id: string): DesktopLocalAgentEntry {
+    const entry = this.entriesOrThrow().find((candidate) => {
+      return candidate.id === id;
+    });
+    if (!entry) {
+      throw new Error("Desktop local agent not found");
+    }
+    return entry;
+  }
+
+  private updateEntry(
+    id: string,
+    patch: Partial<DesktopLocalAgentEntry>,
+  ): void {
+    const entries = this.entriesOrThrow();
+    this.entries = entries.map((entry) => {
+      return entry.id === id ? { ...entry, ...patch } : entry;
+    });
+  }
+
+  private async persistAndNotify(): Promise<void> {
+    await this.deps.store.save(this.entriesOrThrow());
+    this.deps.onChange?.();
+  }
+
+  private assertEnabled(): void {
+    if (!this.nativeEnabled) {
+      throw new Error("Desktop local agent is disabled");
+    }
+  }
+
+  private now(): number {
+    return this.deps.now?.() ?? Date.now();
+  }
+
+  private randomId(): string {
+    return this.deps.randomId?.() ?? crypto.randomUUID();
+  }
+}

--- a/turbo/apps/desktop/src/desktop-local-agent-manager.ts
+++ b/turbo/apps/desktop/src/desktop-local-agent-manager.ts
@@ -225,6 +225,11 @@ export class DesktopLocalAgentManager {
   }
 
   async stop(id: string): Promise<DesktopLocalAgentEntry> {
+    this.assertEnabled();
+    return this.stopEntry(id);
+  }
+
+  private async stopEntry(id: string): Promise<DesktopLocalAgentEntry> {
     await this.ensureLoaded();
     const entry = this.requireEntry(id);
     const running = this.runningAgents.get(id);
@@ -237,8 +242,8 @@ export class DesktopLocalAgentManager {
     this.updateEntry(id, { status: "stopping" });
     await this.persistAndNotify();
     running.controller.abort();
-    await this.closeRunningHost(running);
     await running.promise.catch(() => {});
+    await this.closeRunningHost(running);
     this.runningAgents.delete(id);
     this.updateEntry(id, { status: "stopped", errorMessage: undefined });
     await this.persistAndNotify();
@@ -249,13 +254,14 @@ export class DesktopLocalAgentManager {
     await this.ensureLoaded();
     await Promise.all(
       [...this.runningAgents.keys()].map((id) => {
-        return this.stop(id).then(() => {});
+        return this.stopEntry(id).then(() => {});
       }),
     );
   }
 
   async remove(id: string): Promise<void> {
-    await this.stop(id).catch(() => {});
+    this.assertEnabled();
+    await this.stopEntry(id).catch(() => {});
     await this.ensureLoaded();
     this.entries = this.entriesOrThrow().filter((entry) => {
       return entry.id !== id;
@@ -339,7 +345,7 @@ export class DesktopLocalAgentManager {
       hostToken: params.hostToken,
       jobId: params.jobId,
       result,
-      signal: params.signal,
+      signal: params.signal.aborted ? undefined : params.signal,
     });
   }
 
@@ -347,7 +353,7 @@ export class DesktopLocalAgentManager {
     readonly hostToken: string;
     readonly jobId: string;
     readonly result: DesktopLocalAgentExecutionResult;
-    readonly signal: AbortSignal;
+    readonly signal?: AbortSignal;
   }): Promise<void> {
     await this.deps.api.completeJob({
       hostToken: params.hostToken,

--- a/turbo/apps/desktop/src/desktop-local-agent-page-url.test.ts
+++ b/turbo/apps/desktop/src/desktop-local-agent-page-url.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { isDesktopLocalAgentPageUrl } from "./desktop-local-agent-page-url";
+
+const ALLOWED_ORIGINS = new Set([
+  "https://app.vm0.ai",
+  "http://localhost:3000",
+]);
+
+describe("isDesktopLocalAgentPageUrl", () => {
+  it("allows the desktop local agent page from configured app origins", () => {
+    expect(
+      isDesktopLocalAgentPageUrl(
+        "https://app.vm0.ai/local-agents",
+        ALLOWED_ORIGINS,
+      ),
+    ).toBe(true);
+    expect(
+      isDesktopLocalAgentPageUrl(
+        "http://localhost:3000/local-agents/",
+        ALLOWED_ORIGINS,
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects other pages and origins", () => {
+    expect(
+      isDesktopLocalAgentPageUrl(
+        "https://app.vm0.ai/connectors",
+        ALLOWED_ORIGINS,
+      ),
+    ).toBe(false);
+    expect(
+      isDesktopLocalAgentPageUrl(
+        "https://evil.example/local-agents",
+        ALLOWED_ORIGINS,
+      ),
+    ).toBe(false);
+    expect(isDesktopLocalAgentPageUrl("not a url", ALLOWED_ORIGINS)).toBe(
+      false,
+    );
+  });
+});

--- a/turbo/apps/desktop/src/desktop-local-agent-page-url.ts
+++ b/turbo/apps/desktop/src/desktop-local-agent-page-url.ts
@@ -1,0 +1,16 @@
+const DESKTOP_LOCAL_AGENT_PATHS = new Set(["/local-agents", "/local-agents/"]);
+
+export function isDesktopLocalAgentPageUrl(
+  rawUrl: string,
+  allowedAppOrigins: ReadonlySet<string>,
+): boolean {
+  try {
+    const url = new URL(rawUrl);
+    return (
+      allowedAppOrigins.has(url.origin) &&
+      DESKTOP_LOCAL_AGENT_PATHS.has(url.pathname)
+    );
+  } catch {
+    return false;
+  }
+}

--- a/turbo/apps/desktop/src/desktop-local-agent-runtime.ts
+++ b/turbo/apps/desktop/src/desktop-local-agent-runtime.ts
@@ -1,0 +1,240 @@
+import { spawn } from "node:child_process";
+import type {
+  DesktopLocalAgentBackend,
+  DesktopLocalAgentBackendProbe,
+  DesktopLocalAgentExecutionResult,
+  DesktopLocalAgentPermissionMode,
+} from "./desktop-local-agent-types";
+
+const BACKEND_COMMANDS: ReadonlyArray<{
+  readonly backend: DesktopLocalAgentBackend;
+  readonly command: string;
+}> = [
+  { backend: "codex", command: "codex" },
+  { backend: "claude-code", command: "claude" },
+];
+
+const MAX_OUTPUT_BYTES = 256 * 1024;
+
+function firstLine(output: string): string | undefined {
+  const line = output
+    .split(/\r?\n/)
+    .map((value) => {
+      return value.trim();
+    })
+    .find((value) => {
+      return value.length > 0;
+    });
+  return line?.slice(0, 120);
+}
+
+function appendLimited(current: string, chunk: Buffer): string {
+  const next = current + chunk.toString("utf8");
+  if (Buffer.byteLength(next, "utf8") <= MAX_OUTPUT_BYTES) {
+    return next;
+  }
+  return next.slice(-MAX_OUTPUT_BYTES);
+}
+
+function unsupportedPermission(
+  backend: DesktopLocalAgentBackend,
+  mode: DesktopLocalAgentPermissionMode,
+): Error {
+  return new Error(`Unsupported ${backend} permission mode: ${mode}`);
+}
+
+function claudePermissionArgs(mode: DesktopLocalAgentPermissionMode): string[] {
+  if (mode === "default") {
+    return [];
+  }
+  if (
+    mode === "acceptEdits" ||
+    mode === "auto" ||
+    mode === "bypassPermissions" ||
+    mode === "dontAsk" ||
+    mode === "plan"
+  ) {
+    return ["--permission-mode", mode];
+  }
+  throw unsupportedPermission("claude-code", mode);
+}
+
+function codexPermissionArgs(mode: DesktopLocalAgentPermissionMode): string[] {
+  if (mode === "default") {
+    return [];
+  }
+  if (
+    mode === "read-only" ||
+    mode === "workspace-write" ||
+    mode === "danger-full-access"
+  ) {
+    return ["--sandbox", mode];
+  }
+  if (mode === "bypassPermissions") {
+    return ["--dangerously-bypass-approvals-and-sandbox"];
+  }
+  throw unsupportedPermission("codex", mode);
+}
+
+export function defaultPermissionMode(
+  backend: DesktopLocalAgentBackend,
+): DesktopLocalAgentPermissionMode {
+  return backend === "codex" ? "workspace-write" : "default";
+}
+
+function executionCommand(params: {
+  readonly backend: DesktopLocalAgentBackend;
+  readonly prompt: string;
+  readonly permissionMode: DesktopLocalAgentPermissionMode;
+}): { readonly command: string; readonly args: readonly string[] } {
+  if (params.backend === "claude-code") {
+    return {
+      command: "claude",
+      args: [
+        "-p",
+        ...claudePermissionArgs(params.permissionMode),
+        params.prompt,
+      ],
+    };
+  }
+  return {
+    command: "codex",
+    args: [
+      "exec",
+      ...codexPermissionArgs(params.permissionMode),
+      params.prompt,
+    ],
+  };
+}
+
+function probeBackend(
+  backend: DesktopLocalAgentBackend,
+  command: string,
+): Promise<DesktopLocalAgentBackendProbe> {
+  return new Promise((resolve) => {
+    const child = spawn(command, ["--version"], {
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    let output = "";
+    let settled = false;
+    const finish = (probe: DesktopLocalAgentBackendProbe): void => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timer);
+      resolve(probe);
+    };
+
+    const timer = setTimeout(() => {
+      child.kill();
+      finish({ backend, command, available: false });
+    }, 2_000);
+
+    child.stdout?.on("data", (chunk: Buffer) => {
+      output += chunk.toString("utf8");
+    });
+    child.stderr?.on("data", (chunk: Buffer) => {
+      output += chunk.toString("utf8");
+    });
+    child.on("error", () => {
+      finish({ backend, command, available: false });
+    });
+    child.on("close", (code) => {
+      finish({
+        backend,
+        command,
+        available: code === 0,
+        version: code === 0 ? firstLine(output) : undefined,
+      });
+    });
+  });
+}
+
+export function detectLocalAgentBackends(): Promise<
+  DesktopLocalAgentBackendProbe[]
+> {
+  return Promise.all(
+    BACKEND_COMMANDS.map(({ backend, command }) => {
+      return probeBackend(backend, command);
+    }),
+  );
+}
+
+export function executeLocalAgentBackend(params: {
+  readonly backend: DesktopLocalAgentBackend;
+  readonly prompt: string;
+  readonly workdir: string;
+  readonly permissionMode: DesktopLocalAgentPermissionMode;
+  readonly signal?: AbortSignal;
+}): Promise<DesktopLocalAgentExecutionResult> {
+  const { command, args } = executionCommand({
+    backend: params.backend,
+    prompt: params.prompt,
+    permissionMode: params.permissionMode,
+  });
+
+  return new Promise((resolve) => {
+    const child = spawn(command, [...args], {
+      cwd: params.workdir,
+      env: process.env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+    let settled = false;
+
+    const finish = (result: DesktopLocalAgentExecutionResult): void => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      params.signal?.removeEventListener("abort", abort);
+      resolve(result);
+    };
+
+    const abort = (): void => {
+      child.kill();
+      finish({
+        output: stdout.trimEnd(),
+        error: "Local agent job was stopped",
+        exitCode: 1,
+      });
+    };
+
+    if (params.signal?.aborted) {
+      abort();
+      return;
+    }
+    params.signal?.addEventListener("abort", abort, { once: true });
+
+    child.stdout?.on("data", (chunk: Buffer) => {
+      stdout = appendLimited(stdout, chunk);
+    });
+    child.stderr?.on("data", (chunk: Buffer) => {
+      stderr = appendLimited(stderr, chunk);
+    });
+    child.on("error", (error) => {
+      finish({
+        output: stdout,
+        error: error.message,
+        exitCode: 1,
+      });
+    });
+    child.on("close", (code) => {
+      const exitCode = code ?? 1;
+      const output = [stdout.trimEnd(), stderr.trimEnd()]
+        .filter((value) => {
+          return value.length > 0;
+        })
+        .join("\n");
+      finish({
+        output,
+        error: exitCode === 0 ? undefined : stderr.trim() || undefined,
+        exitCode,
+      });
+    });
+  });
+}

--- a/turbo/apps/desktop/src/desktop-local-agent-store.ts
+++ b/turbo/apps/desktop/src/desktop-local-agent-store.ts
@@ -1,0 +1,70 @@
+import path from "node:path";
+import fs from "node:fs/promises";
+import type { DesktopLocalAgentEntry } from "./desktop-local-agent-types";
+
+interface StoredLocalAgentFile {
+  readonly entries: readonly DesktopLocalAgentEntry[];
+}
+
+function isString(value: unknown): value is string {
+  return typeof value === "string";
+}
+
+function isDesktopLocalAgentEntry(
+  value: unknown,
+): value is DesktopLocalAgentEntry {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const entry = value as Partial<DesktopLocalAgentEntry>;
+  return (
+    isString(entry.id) &&
+    isString(entry.name) &&
+    isString(entry.folderPath) &&
+    (entry.backend === "codex" || entry.backend === "claude-code") &&
+    isString(entry.permissionMode) &&
+    isString(entry.status)
+  );
+}
+
+function parseStoredFile(value: unknown): StoredLocalAgentFile {
+  if (typeof value !== "object" || value === null) {
+    return { entries: [] };
+  }
+  const file = value as { readonly entries?: unknown };
+  if (!Array.isArray(file.entries)) {
+    return { entries: [] };
+  }
+  return {
+    entries: file.entries.filter(isDesktopLocalAgentEntry),
+  };
+}
+
+export function createDesktopLocalAgentStore(filePath: string) {
+  return {
+    async load(): Promise<DesktopLocalAgentEntry[]> {
+      try {
+        const raw = await fs.readFile(filePath, "utf8");
+        return [...parseStoredFile(JSON.parse(raw) as unknown).entries];
+      } catch (error) {
+        if (
+          typeof error === "object" &&
+          error !== null &&
+          "code" in error &&
+          error.code === "ENOENT"
+        ) {
+          return [];
+        }
+        throw error;
+      }
+    },
+    async save(entries: readonly DesktopLocalAgentEntry[]): Promise<void> {
+      await fs.mkdir(path.dirname(filePath), { recursive: true });
+      await fs.writeFile(
+        filePath,
+        `${JSON.stringify({ entries }, null, 2)}\n`,
+        "utf8",
+      );
+    },
+  };
+}

--- a/turbo/apps/desktop/src/desktop-local-agent-types.ts
+++ b/turbo/apps/desktop/src/desktop-local-agent-types.ts
@@ -1,0 +1,64 @@
+export type DesktopLocalAgentBackend = "codex" | "claude-code";
+
+export type DesktopLocalAgentPermissionMode =
+  | "default"
+  | "acceptEdits"
+  | "auto"
+  | "bypassPermissions"
+  | "dontAsk"
+  | "plan"
+  | "read-only"
+  | "workspace-write"
+  | "danger-full-access";
+
+export type DesktopLocalAgentStatus =
+  | "stopped"
+  | "starting"
+  | "online"
+  | "stopping"
+  | "error";
+
+export interface DesktopLocalAgentBackendProbe {
+  readonly backend: DesktopLocalAgentBackend;
+  readonly command: string;
+  readonly available: boolean;
+  readonly version?: string;
+}
+
+export interface DesktopLocalAgentEntry {
+  readonly id: string;
+  readonly name: string;
+  readonly folderPath: string;
+  readonly backend: DesktopLocalAgentBackend;
+  readonly permissionMode: DesktopLocalAgentPermissionMode;
+  readonly status: DesktopLocalAgentStatus;
+  readonly hostId?: string;
+  readonly lastHeartbeatAt?: string;
+  readonly errorMessage?: string;
+}
+
+export interface DesktopLocalAgentAddOptions {
+  readonly backend?: DesktopLocalAgentBackend;
+  readonly permissionMode?: DesktopLocalAgentPermissionMode;
+}
+
+export interface DesktopLocalAgentHostStartResponse {
+  readonly hostId: string;
+  readonly hostToken: string;
+}
+
+export interface DesktopLocalAgentJob {
+  readonly id: string;
+  readonly backend: DesktopLocalAgentBackend;
+  readonly prompt: string;
+}
+
+export type DesktopLocalAgentJobNextResponse =
+  | { readonly status: "idle" }
+  | { readonly status: "job"; readonly job: DesktopLocalAgentJob };
+
+export interface DesktopLocalAgentExecutionResult {
+  readonly output: string;
+  readonly error?: string;
+  readonly exitCode: number;
+}

--- a/turbo/apps/desktop/src/main.ts
+++ b/turbo/apps/desktop/src/main.ts
@@ -1,6 +1,19 @@
 import path from "node:path";
-import { app, BrowserWindow, shell } from "electron";
+import { app, BrowserWindow, session, shell } from "electron";
 import { resolveDesktopConfig } from "./config";
+import { createDesktopLocalAgentApiClient } from "./desktop-local-agent-api";
+import {
+  installDesktopLocalAgentIpc,
+  notifyDesktopLocalAgentsChanged,
+  openLocalAgentFolder,
+  selectLocalAgentFolder,
+} from "./desktop-local-agent-electron";
+import { DesktopLocalAgentManager } from "./desktop-local-agent-manager";
+import {
+  detectLocalAgentBackends,
+  executeLocalAgentBackend,
+} from "./desktop-local-agent-runtime";
+import { createDesktopLocalAgentStore } from "./desktop-local-agent-store";
 import {
   buildDesktopAuthConsumeUrl,
   buildDesktopAuthStartUrl,
@@ -21,6 +34,8 @@ const desktopAuthStartUrl = buildDesktopAuthStartUrl(
 const signedOutPageUrl = buildSignedOutPageUrl(desktopAuthStartUrl);
 let mainWindow: BrowserWindow | null = null;
 let pendingDesktopAuthCode: string | null = null;
+let desktopLocalAgentManager: DesktopLocalAgentManager | null = null;
+let quittingAfterLocalAgentStop = false;
 const desktopAuthStartGate = createDesktopAuthStartGate();
 
 function preloadPath(): string {
@@ -40,6 +55,32 @@ function applyDockIcon(): void {
   if (process.platform === "darwin" && app.dock) {
     app.dock.setIcon(appIconPath());
   }
+}
+
+function createDesktopLocalAgentManager(): DesktopLocalAgentManager {
+  const electronSession = session.fromPartition(config.sessionPartition);
+  return new DesktopLocalAgentManager({
+    store: createDesktopLocalAgentStore(
+      path.join(app.getPath("userData"), "local-agents.json"),
+    ),
+    api: createDesktopLocalAgentApiClient({
+      platformUrl: config.platformUrl,
+      session: electronSession,
+    }),
+    selectFolder: selectLocalAgentFolder,
+    openFolder: openLocalAgentFolder,
+    detectBackends: detectLocalAgentBackends,
+    executeBackend: executeLocalAgentBackend,
+    onChange: notifyDesktopLocalAgentsChanged,
+  });
+}
+
+function installDesktopLocalAgent(): void {
+  if (desktopLocalAgentManager) {
+    return;
+  }
+  desktopLocalAgentManager = createDesktopLocalAgentManager();
+  installDesktopLocalAgentIpc(desktopLocalAgentManager);
 }
 
 function openExternal(url: string): void {
@@ -315,9 +356,27 @@ if (!hasSingleInstanceLock) {
     handleDesktopAuthCallback(url);
   });
 
+  app.on("before-quit", (event) => {
+    const manager = desktopLocalAgentManager;
+    if (
+      !manager ||
+      !manager.hasRunningAgents() ||
+      quittingAfterLocalAgentStop
+    ) {
+      return;
+    }
+
+    event.preventDefault();
+    quittingAfterLocalAgentStop = true;
+    void manager.stopAll().finally(() => {
+      app.quit();
+    });
+  });
+
   void app.whenReady().then(async () => {
     applyDockIcon();
     registerDesktopAuthProtocol();
+    installDesktopLocalAgent();
     queueDesktopAuthCallbackArgv(process.argv);
 
     const pendingCode = pendingDesktopAuthCode;

--- a/turbo/apps/desktop/src/main.ts
+++ b/turbo/apps/desktop/src/main.ts
@@ -80,7 +80,9 @@ function installDesktopLocalAgent(): void {
     return;
   }
   desktopLocalAgentManager = createDesktopLocalAgentManager();
-  installDesktopLocalAgentIpc(desktopLocalAgentManager);
+  installDesktopLocalAgentIpc(desktopLocalAgentManager, {
+    allowedAppOrigins: config.allowedAppOrigins,
+  });
 }
 
 function openExternal(url: string): void {

--- a/turbo/apps/desktop/src/preload.ts
+++ b/turbo/apps/desktop/src/preload.ts
@@ -1,3 +1,47 @@
-// Intentionally empty for v1. Hosted platform content must not receive Node,
-// Electron, filesystem, process, or generic IPC access.
-export {};
+import { contextBridge, ipcRenderer } from "electron";
+import { DESKTOP_LOCAL_AGENT_CHANNELS } from "./desktop-local-agent-ipc-channels";
+import type {
+  DesktopLocalAgentAddOptions,
+  DesktopLocalAgentBackendProbe,
+  DesktopLocalAgentEntry,
+} from "./desktop-local-agent-types";
+
+const desktopLocalAgentApi = {
+  setEnabled(enabled: boolean): Promise<void> {
+    return ipcRenderer.invoke(DESKTOP_LOCAL_AGENT_CHANNELS.setEnabled, enabled);
+  },
+  list(): Promise<DesktopLocalAgentEntry[]> {
+    return ipcRenderer.invoke(DESKTOP_LOCAL_AGENT_CHANNELS.list);
+  },
+  detectBackends(): Promise<DesktopLocalAgentBackendProbe[]> {
+    return ipcRenderer.invoke(DESKTOP_LOCAL_AGENT_CHANNELS.detectBackends);
+  },
+  add(
+    options: DesktopLocalAgentAddOptions = {},
+  ): Promise<DesktopLocalAgentEntry | null> {
+    return ipcRenderer.invoke(DESKTOP_LOCAL_AGENT_CHANNELS.add, options);
+  },
+  start(id: string): Promise<DesktopLocalAgentEntry> {
+    return ipcRenderer.invoke(DESKTOP_LOCAL_AGENT_CHANNELS.start, id);
+  },
+  stop(id: string): Promise<DesktopLocalAgentEntry> {
+    return ipcRenderer.invoke(DESKTOP_LOCAL_AGENT_CHANNELS.stop, id);
+  },
+  remove(id: string): Promise<void> {
+    return ipcRenderer.invoke(DESKTOP_LOCAL_AGENT_CHANNELS.remove, id);
+  },
+  openFolder(id: string): Promise<void> {
+    return ipcRenderer.invoke(DESKTOP_LOCAL_AGENT_CHANNELS.openFolder, id);
+  },
+  subscribe(callback: () => void): () => void {
+    const listener = (): void => {
+      callback();
+    };
+    ipcRenderer.on(DESKTOP_LOCAL_AGENT_CHANNELS.changed, listener);
+    return () => {
+      ipcRenderer.off(DESKTOP_LOCAL_AGENT_CHANNELS.changed, listener);
+    };
+  },
+};
+
+contextBridge.exposeInMainWorld("vm0DesktopLocalAgent", desktopLocalAgentApi);

--- a/turbo/apps/platform/src/global.d.ts
+++ b/turbo/apps/platform/src/global.d.ts
@@ -5,9 +5,68 @@ interface VM0Global {
   inspectLogs: () => void;
 }
 
+type DesktopLocalAgentBackend = "codex" | "claude-code";
+
+type DesktopLocalAgentPermissionMode =
+  | "default"
+  | "acceptEdits"
+  | "auto"
+  | "bypassPermissions"
+  | "dontAsk"
+  | "plan"
+  | "read-only"
+  | "workspace-write"
+  | "danger-full-access";
+
+type DesktopLocalAgentStatus =
+  | "stopped"
+  | "starting"
+  | "online"
+  | "stopping"
+  | "error";
+
+interface DesktopLocalAgentBackendProbe {
+  readonly backend: DesktopLocalAgentBackend;
+  readonly command: string;
+  readonly available: boolean;
+  readonly version?: string;
+}
+
+interface DesktopLocalAgentEntry {
+  readonly id: string;
+  readonly name: string;
+  readonly folderPath: string;
+  readonly backend: DesktopLocalAgentBackend;
+  readonly permissionMode: DesktopLocalAgentPermissionMode;
+  readonly status: DesktopLocalAgentStatus;
+  readonly hostId?: string;
+  readonly lastHeartbeatAt?: string;
+  readonly errorMessage?: string;
+}
+
+interface DesktopLocalAgentAddOptions {
+  readonly backend?: DesktopLocalAgentBackend;
+  readonly permissionMode?: DesktopLocalAgentPermissionMode;
+}
+
+interface DesktopLocalAgentApi {
+  readonly setEnabled: (enabled: boolean) => Promise<void>;
+  readonly list: () => Promise<DesktopLocalAgentEntry[]>;
+  readonly detectBackends: () => Promise<DesktopLocalAgentBackendProbe[]>;
+  readonly add: (
+    options?: DesktopLocalAgentAddOptions,
+  ) => Promise<DesktopLocalAgentEntry | null>;
+  readonly start: (id: string) => Promise<DesktopLocalAgentEntry>;
+  readonly stop: (id: string) => Promise<DesktopLocalAgentEntry>;
+  readonly remove: (id: string) => Promise<void>;
+  readonly openFolder: (id: string) => Promise<void>;
+  readonly subscribe: (callback: () => void) => () => void;
+}
+
 declare global {
   interface Window {
     _vm0: VM0Global | undefined;
+    vm0DesktopLocalAgent?: DesktopLocalAgentApi;
     /**
      * Set inline in `index.html` at the start of `<head>` parsing. Used by
      * `captureFirstSkeletonHide` to measure total time from page entry to

--- a/turbo/apps/platform/src/signals/bootstrap.ts
+++ b/turbo/apps/platform/src/signals/bootstrap.ts
@@ -56,6 +56,7 @@ import { setupChatListPage$ } from "./zero-page/chat-list-page-setup.ts";
 import { setupLabPage$ } from "./lab-page/lab-page-setup.ts";
 import { setupNetworkInsightsPage$ } from "./network-insights/network-insights-page-setup.ts";
 import { setupUsagePage$ } from "./usage-page/usage-page-setup.ts";
+import { setupDesktopLocalAgentPage$ } from "./desktop-local-agent-page/desktop-local-agent-page-setup.ts";
 import { initSlackOrg$ as handleSlackRedirect$ } from "./zero-page/zero-slack.ts";
 import { setupSkeletonPage$, setupErrorPage$ } from "./skeleton-page-setup.ts";
 import { startSkeletonCycling$ } from "./app-skeleton.ts";
@@ -130,6 +131,10 @@ const ROUTE_CONFIG = [
   {
     path: ROUTES.connectors,
     setup: setupAuthPageWrapper(setupConnectorsPage$),
+  },
+  {
+    path: ROUTES.desktopLocalAgents,
+    setup: setupAuthPageWrapper(setupDesktopLocalAgentPage$),
   },
   {
     path: ROUTES.localBrowserConnect,

--- a/turbo/apps/platform/src/signals/desktop-local-agent-page/desktop-local-agent-page-setup.ts
+++ b/turbo/apps/platform/src/signals/desktop-local-agent-page/desktop-local-agent-page-setup.ts
@@ -1,0 +1,25 @@
+import { createElement } from "react";
+import { command } from "ccstate";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import { ZeroDesktopLocalAgentPage } from "../../views/zero-page/desktop-local-agent-page.tsx";
+import { featureSwitch$ } from "../external/feature-switch.ts";
+import { detachedNavigateTo$ } from "../route.ts";
+import { ROUTES } from "../route-paths.ts";
+import { updatePage$ } from "../react-router.ts";
+import { setupDesktopLocalAgentBridge$ } from "./desktop-local-agent-signals.ts";
+
+export const setupDesktopLocalAgentPage$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const enabled = get(featureSwitch$)[FeatureSwitchKey.DesktopLocalAgent];
+    const api = window.vm0DesktopLocalAgent;
+    if (!enabled || !api) {
+      await api?.setEnabled(false);
+      signal.throwIfAborted();
+      set(detachedNavigateTo$, ROUTES.home, { replace: true });
+      return;
+    }
+
+    set(updatePage$, createElement(ZeroDesktopLocalAgentPage), "sidebar");
+    await set(setupDesktopLocalAgentBridge$, signal);
+  },
+);

--- a/turbo/apps/platform/src/signals/desktop-local-agent-page/desktop-local-agent-signals.ts
+++ b/turbo/apps/platform/src/signals/desktop-local-agent-page/desktop-local-agent-signals.ts
@@ -1,0 +1,142 @@
+import { command, computed, state } from "ccstate";
+import { toast } from "@vm0/ui/components/ui/sonner";
+
+type DesktopLocalAgentApi = NonNullable<Window["vm0DesktopLocalAgent"]>;
+export type DesktopLocalAgentEntry = Awaited<
+  ReturnType<DesktopLocalAgentApi["list"]>
+>[number];
+type DesktopLocalAgentBackendProbe = Awaited<
+  ReturnType<DesktopLocalAgentApi["detectBackends"]>
+>[number];
+export type DesktopLocalAgentBackend = DesktopLocalAgentEntry["backend"];
+export type DesktopLocalAgentPermissionMode =
+  DesktopLocalAgentEntry["permissionMode"];
+
+interface DesktopLocalAgentData {
+  readonly entries: readonly DesktopLocalAgentEntry[];
+  readonly probes: readonly DesktopLocalAgentBackendProbe[];
+}
+
+const internalReload$ = state(0);
+const internalDialogOpen$ = state(false);
+const internalSelectedBackend$ = state<DesktopLocalAgentBackend>("codex");
+const internalPermissionMode$ =
+  state<DesktopLocalAgentPermissionMode>("workspace-write");
+
+function desktopLocalAgentApi(): DesktopLocalAgentApi {
+  const api = window.vm0DesktopLocalAgent;
+  if (!api) {
+    throw new Error("Zero Desktop local agent bridge is unavailable");
+  }
+  return api;
+}
+
+function defaultPermissionForBackend(
+  backend: DesktopLocalAgentBackend,
+): DesktopLocalAgentPermissionMode {
+  return backend === "codex" ? "workspace-write" : "default";
+}
+
+export const desktopLocalAgentData$ = computed(
+  async (get): Promise<DesktopLocalAgentData> => {
+    get(internalReload$);
+    const api = desktopLocalAgentApi();
+    const [entries, probes] = await Promise.all([
+      api.list(),
+      api.detectBackends(),
+    ]);
+    return { entries, probes };
+  },
+);
+
+export const desktopLocalAgentDialogOpen$ = computed((get) => {
+  return get(internalDialogOpen$);
+});
+
+export const desktopLocalAgentSelectedBackend$ = computed((get) => {
+  return get(internalSelectedBackend$);
+});
+
+export const desktopLocalAgentPermissionMode$ = computed((get) => {
+  return get(internalPermissionMode$);
+});
+
+export const setDesktopLocalAgentDialogOpen$ = command(
+  ({ set }, open: boolean) => {
+    set(internalDialogOpen$, open);
+  },
+);
+
+export const setDesktopLocalAgentSelectedBackend$ = command(
+  ({ set }, backend: DesktopLocalAgentBackend) => {
+    set(internalSelectedBackend$, backend);
+    set(internalPermissionMode$, defaultPermissionForBackend(backend));
+  },
+);
+
+export const setDesktopLocalAgentPermissionMode$ = command(
+  ({ set }, permissionMode: DesktopLocalAgentPermissionMode) => {
+    set(internalPermissionMode$, permissionMode);
+  },
+);
+
+export const setupDesktopLocalAgentBridge$ = command(
+  async ({ set }, signal: AbortSignal) => {
+    const api = desktopLocalAgentApi();
+    await api.setEnabled(true);
+    signal.throwIfAborted();
+
+    const unsubscribe = api.subscribe(() => {
+      set(internalReload$, (previous) => {
+        return previous + 1;
+      });
+    });
+    signal.addEventListener("abort", unsubscribe, { once: true });
+    set(internalReload$, (previous) => {
+      return previous + 1;
+    });
+  },
+);
+
+export const runDesktopLocalAgentAction$ = command(
+  async (
+    { set },
+    params: {
+      readonly id: string;
+      readonly action: "start" | "stop" | "openFolder" | "remove";
+    },
+    signal: AbortSignal,
+  ) => {
+    const api = desktopLocalAgentApi();
+    if (params.action === "start") {
+      await api.start(params.id);
+    } else if (params.action === "stop") {
+      await api.stop(params.id);
+    } else if (params.action === "openFolder") {
+      await api.openFolder(params.id);
+    } else {
+      await api.remove(params.id);
+    }
+    signal.throwIfAborted();
+    set(internalReload$, (previous) => {
+      return previous + 1;
+    });
+  },
+);
+
+export const addDesktopLocalAgent$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const entry = await desktopLocalAgentApi().add({
+      backend: get(internalSelectedBackend$),
+      permissionMode: get(internalPermissionMode$),
+    });
+    signal.throwIfAborted();
+    set(internalDialogOpen$, false);
+    if (entry) {
+      toast.success(`${entry.name} started`);
+    }
+    set(internalReload$, (previous) => {
+      return previous + 1;
+    });
+  },
+);

--- a/turbo/apps/platform/src/signals/route-paths.ts
+++ b/turbo/apps/platform/src/signals/route-paths.ts
@@ -16,6 +16,7 @@ export const ROUTES = {
   works: "/works",
   ideas: "/ideas",
   connectors: "/connectors",
+  desktopLocalAgents: "/local-agents",
   localBrowserConnect: "/zero/connectors/local-browser",
   directedConnect: "/connectors/:type/connect",
   directedAuthorize: "/connectors/:type/authorize",

--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-nav.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-nav.test.ts
@@ -47,6 +47,11 @@ describe("zero-nav", () => {
       expect(context.store.get(activeRoute$)).toBe("activities");
     });
 
+    it("should resolve /local-agents to 'desktopLocalAgents'", () => {
+      mockLocation({ pathname: "/local-agents", search: "" }, context.signal);
+      expect(context.store.get(activeRoute$)).toBe("desktopLocalAgents");
+    });
+
     it("should resolve /works to 'works'", () => {
       mockLocation({ pathname: "/works", search: "" }, context.signal);
       expect(context.store.get(activeRoute$)).toBe("works");

--- a/turbo/apps/platform/src/signals/zero-page/zero-nav.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-nav.ts
@@ -64,6 +64,7 @@ export type SidebarNavId =
   | "chat"
   | "agents"
   | "connectors"
+  | "localAgents"
   | "schedules"
   | "activities"
   | "insights"
@@ -89,6 +90,7 @@ export const handleZeroNavSelect$ = command(
         chat: ROUTES.home,
         agents: ROUTES.agents,
         connectors: ROUTES.connectors,
+        localAgents: ROUTES.desktopLocalAgents,
         schedules: ROUTES.schedules,
         activities: ROUTES.activities,
         insights: ROUTES.insights,

--- a/turbo/apps/platform/src/views/zero-page/__tests__/desktop-local-agent-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/desktop-local-agent-page.test.tsx
@@ -1,0 +1,88 @@
+import { screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import { setupPage } from "../../../__tests__/page-helper.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+
+const context = testContext();
+
+function installDesktopLocalAgentApi(
+  api: NonNullable<Window["vm0DesktopLocalAgent"]>,
+): void {
+  Object.defineProperty(window, "vm0DesktopLocalAgent", {
+    configurable: true,
+    writable: true,
+    value: api,
+  });
+}
+
+afterEach(() => {
+  Reflect.deleteProperty(window, "vm0DesktopLocalAgent");
+});
+
+describe("zero desktop local agent page", () => {
+  it("enables the desktop bridge and renders configured agents", async () => {
+    const setEnabled = vi.fn(() => {
+      return Promise.resolve();
+    });
+    installDesktopLocalAgentApi({
+      setEnabled,
+      list() {
+        return Promise.resolve([
+          {
+            id: "agent-1",
+            name: "alpha",
+            folderPath: "/workspace/alpha",
+            backend: "codex",
+            permissionMode: "workspace-write",
+            status: "online",
+            hostId: "host-1",
+            lastHeartbeatAt: "2026-05-19T00:00:00.000Z",
+          },
+        ]);
+      },
+      detectBackends() {
+        return Promise.resolve([
+          {
+            backend: "codex",
+            command: "codex",
+            available: true,
+            version: "codex 1.0.0",
+          },
+        ]);
+      },
+      add() {
+        return Promise.resolve(null);
+      },
+      start() {
+        return Promise.reject(new Error("not used"));
+      },
+      stop() {
+        return Promise.reject(new Error("not used"));
+      },
+      remove() {
+        return Promise.resolve();
+      },
+      openFolder() {
+        return Promise.resolve();
+      },
+      subscribe() {
+        return () => {};
+      },
+    });
+
+    await setupPage({
+      context,
+      path: "/local-agents",
+      featureSwitches: {
+        [FeatureSwitchKey.DesktopLocalAgent]: true,
+      },
+    });
+
+    await expect(screen.findByText("alpha")).resolves.toBeInTheDocument();
+    expect(screen.getByText("/workspace/alpha")).toBeInTheDocument();
+    expect(screen.getByText("workspace-write")).toBeInTheDocument();
+    expect(screen.getByText("online")).toBeInTheDocument();
+    expect(setEnabled).toHaveBeenCalledWith(true);
+  });
+});

--- a/turbo/apps/platform/src/views/zero-page/desktop-local-agent-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/desktop-local-agent-page.tsx
@@ -1,0 +1,450 @@
+import { useGet, useLastResolved, useLoadable, useSet } from "ccstate-react";
+import { useLoadableSet } from "ccstate-react/experimental";
+import {
+  IconDeviceDesktop,
+  IconFolderOpen,
+  IconFolderPlus,
+  IconLoader2,
+  IconPlayerPlay,
+  IconPlayerStop,
+  IconTrash,
+} from "@tabler/icons-react";
+import { Button } from "@vm0/ui/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@vm0/ui/components/ui/dialog";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@vm0/ui/components/ui/select";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@vm0/ui/components/ui/table";
+import { pageSignal$ } from "../../signals/page-signal.ts";
+import { detach, Reason } from "../../signals/utils.ts";
+import {
+  addDesktopLocalAgent$,
+  desktopLocalAgentData$,
+  desktopLocalAgentDialogOpen$,
+  desktopLocalAgentPermissionMode$,
+  desktopLocalAgentSelectedBackend$,
+  runDesktopLocalAgentAction$,
+  setDesktopLocalAgentDialogOpen$,
+  setDesktopLocalAgentPermissionMode$,
+  setDesktopLocalAgentSelectedBackend$,
+  type DesktopLocalAgentBackend,
+  type DesktopLocalAgentEntry,
+  type DesktopLocalAgentPermissionMode,
+} from "../../signals/desktop-local-agent-page/desktop-local-agent-signals.ts";
+
+type PermissionOption = {
+  readonly value: DesktopLocalAgentPermissionMode;
+  readonly label: string;
+};
+
+const BACKEND_LABELS = {
+  codex: "Codex",
+  "claude-code": "Claude Code",
+} as const satisfies Record<DesktopLocalAgentBackend, string>;
+
+const CODEX_PERMISSION_OPTIONS = [
+  { value: "workspace-write", label: "Workspace write" },
+  { value: "read-only", label: "Read only" },
+  { value: "danger-full-access", label: "Danger full access" },
+  { value: "bypassPermissions", label: "Bypass permissions" },
+  { value: "default", label: "Default" },
+] as const satisfies readonly PermissionOption[];
+
+const CLAUDE_PERMISSION_OPTIONS = [
+  { value: "default", label: "Default" },
+  { value: "acceptEdits", label: "Accept edits" },
+  { value: "auto", label: "Auto" },
+  { value: "bypassPermissions", label: "Bypass permissions" },
+  { value: "dontAsk", label: "Don't ask" },
+  { value: "plan", label: "Plan" },
+] as const satisfies readonly PermissionOption[];
+
+function permissionOptions(
+  backend: DesktopLocalAgentBackend,
+): readonly PermissionOption[] {
+  return backend === "codex"
+    ? CODEX_PERMISSION_OPTIONS
+    : CLAUDE_PERMISSION_OPTIONS;
+}
+
+function defaultBackendForProbes(
+  probes: readonly {
+    readonly backend: DesktopLocalAgentBackend;
+    readonly available: boolean;
+  }[],
+): DesktopLocalAgentBackend {
+  const codex = probes.find((probe) => {
+    return probe.backend === "codex" && probe.available;
+  });
+  if (codex) {
+    return "codex";
+  }
+  return (
+    probes.find((probe) => {
+      return probe.available;
+    })?.backend ?? "codex"
+  );
+}
+
+function formatDateTime(iso: string | undefined): string {
+  if (!iso) {
+    return "-";
+  }
+  return new Date(iso).toLocaleString();
+}
+
+function statusClassName(status: DesktopLocalAgentEntry["status"]): string {
+  if (status === "online") {
+    return "bg-emerald-500/10 text-emerald-700 dark:text-emerald-300";
+  }
+  if (status === "error") {
+    return "bg-destructive/10 text-destructive";
+  }
+  if (status === "starting" || status === "stopping") {
+    return "bg-amber-500/10 text-amber-700 dark:text-amber-300";
+  }
+  return "bg-muted text-muted-foreground";
+}
+
+function StatusBadge({ entry }: { readonly entry: DesktopLocalAgentEntry }) {
+  return (
+    <span
+      className={`inline-flex h-6 items-center rounded-md px-2 text-xs font-medium ${statusClassName(entry.status)}`}
+      title={entry.errorMessage}
+    >
+      {entry.status}
+    </span>
+  );
+}
+
+function BackendSelect() {
+  const backend = useGet(desktopLocalAgentSelectedBackend$);
+  const probes = useLastResolved(desktopLocalAgentData$)?.probes ?? [];
+  const setBackend = useSet(setDesktopLocalAgentSelectedBackend$);
+  return (
+    <div className="flex flex-col gap-2">
+      <label
+        htmlFor="desktop-local-agent-backend"
+        className="text-sm font-medium"
+      >
+        Backend
+      </label>
+      <Select
+        value={backend}
+        onValueChange={(value) => {
+          setBackend(value as DesktopLocalAgentBackend);
+        }}
+      >
+        <SelectTrigger id="desktop-local-agent-backend">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {(["codex", "claude-code"] as const).map((value) => {
+            const probe = probes.find((candidate) => {
+              return candidate.backend === value;
+            });
+            return (
+              <SelectItem key={value} value={value}>
+                {BACKEND_LABELS[value]}
+                {probe?.available === false ? " (not detected)" : ""}
+              </SelectItem>
+            );
+          })}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}
+
+function PermissionModeSelect() {
+  const backend = useGet(desktopLocalAgentSelectedBackend$);
+  const permissionMode = useGet(desktopLocalAgentPermissionMode$);
+  const setPermissionMode = useSet(setDesktopLocalAgentPermissionMode$);
+  return (
+    <div className="flex flex-col gap-2">
+      <label
+        htmlFor="desktop-local-agent-permission"
+        className="text-sm font-medium"
+      >
+        Permission mode
+      </label>
+      <Select
+        value={permissionMode}
+        onValueChange={(value) => {
+          setPermissionMode(value as DesktopLocalAgentPermissionMode);
+        }}
+      >
+        <SelectTrigger id="desktop-local-agent-permission">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {permissionOptions(backend).map((option) => {
+            return (
+              <SelectItem key={option.value} value={option.value}>
+                {option.label}
+              </SelectItem>
+            );
+          })}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}
+
+function AddLocalAgentDialog() {
+  const open = useGet(desktopLocalAgentDialogOpen$);
+  const [submitLoadable, submit] = useLoadableSet(addDesktopLocalAgent$);
+  const submitting = submitLoadable.state === "loading";
+  const setOpen = useSet(setDesktopLocalAgentDialogOpen$);
+  const pageSignal = useGet(pageSignal$);
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Add local agent</DialogTitle>
+          <DialogDescription>
+            Select a workspace folder and keep it available from Zero Desktop.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="flex flex-col gap-4 py-2">
+          <BackendSelect />
+          <PermissionModeSelect />
+        </div>
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => {
+              setOpen(false);
+            }}
+            disabled={submitting}
+          >
+            Cancel
+          </Button>
+          <Button
+            onClick={() => {
+              detach(submit(pageSignal), Reason.DomCallback);
+            }}
+            disabled={submitting}
+          >
+            {submitting ? (
+              <IconLoader2 size={16} className="animate-spin" />
+            ) : (
+              <IconFolderPlus size={16} />
+            )}
+            Select folder
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function DesktopLocalAgentRow({
+  entry,
+  pending,
+  onAction,
+}: {
+  readonly entry: DesktopLocalAgentEntry;
+  readonly pending: boolean;
+  readonly onAction: (
+    id: string,
+    action: "start" | "stop" | "openFolder" | "remove",
+  ) => void;
+}) {
+  const running =
+    entry.status === "online" ||
+    entry.status === "starting" ||
+    entry.status === "stopping";
+  return (
+    <TableRow>
+      <TableCell className="font-medium">{entry.name}</TableCell>
+      <TableCell className="max-w-[260px] truncate">
+        <code className="text-xs">{entry.folderPath}</code>
+      </TableCell>
+      <TableCell>{BACKEND_LABELS[entry.backend]}</TableCell>
+      <TableCell>{entry.permissionMode}</TableCell>
+      <TableCell>
+        <StatusBadge entry={entry} />
+      </TableCell>
+      <TableCell>
+        <code className="text-xs">{entry.hostId ?? "-"}</code>
+      </TableCell>
+      <TableCell>{formatDateTime(entry.lastHeartbeatAt)}</TableCell>
+      <TableCell>
+        <div className="flex items-center justify-end gap-1">
+          <Button
+            variant="ghost"
+            size="sm"
+            disabled={pending || entry.status === "starting"}
+            onClick={() => {
+              onAction(entry.id, running ? "stop" : "start");
+            }}
+            aria-label={`${running ? "Stop" : "Start"} ${entry.name}`}
+          >
+            {pending ? (
+              <IconLoader2 size={16} className="animate-spin" />
+            ) : running ? (
+              <IconPlayerStop size={16} />
+            ) : (
+              <IconPlayerPlay size={16} />
+            )}
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            disabled={pending}
+            onClick={() => {
+              onAction(entry.id, "openFolder");
+            }}
+            aria-label={`Open ${entry.name} folder`}
+          >
+            <IconFolderOpen size={16} />
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            disabled={pending}
+            onClick={() => {
+              onAction(entry.id, "remove");
+            }}
+            aria-label={`Remove ${entry.name}`}
+          >
+            <IconTrash size={16} className="text-muted-foreground" />
+          </Button>
+        </div>
+      </TableCell>
+    </TableRow>
+  );
+}
+
+function DesktopLocalAgentTable() {
+  const data = useLastResolved(desktopLocalAgentData$);
+  const entries = data?.entries ?? [];
+  const [actionLoadable, runAction] = useLoadableSet(
+    runDesktopLocalAgentAction$,
+  );
+  const pending = actionLoadable.state === "loading";
+  const pageSignal = useGet(pageSignal$);
+  if (entries.length === 0) {
+    return (
+      <div className="rounded-xl zero-border bg-card px-6 py-10 text-center text-sm text-muted-foreground">
+        No local agents yet.
+      </div>
+    );
+  }
+  const onAction = (
+    id: string,
+    action: "start" | "stop" | "openFolder" | "remove",
+  ) => {
+    detach(runAction({ id, action }, pageSignal), Reason.DomCallback);
+  };
+  return (
+    <div className="rounded-xl zero-border bg-card overflow-hidden">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Name</TableHead>
+            <TableHead>Folder</TableHead>
+            <TableHead>Backend</TableHead>
+            <TableHead>Permission</TableHead>
+            <TableHead>Status</TableHead>
+            <TableHead>Host</TableHead>
+            <TableHead>Last heartbeat</TableHead>
+            <TableHead className="w-[170px]" />
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {entries.map((entry) => {
+            return (
+              <DesktopLocalAgentRow
+                key={entry.id}
+                entry={entry}
+                pending={pending}
+                onAction={onAction}
+              />
+            );
+          })}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}
+
+function DesktopLocalAgentPageHeader() {
+  const setOpen = useSet(setDesktopLocalAgentDialogOpen$);
+  const setBackend = useSet(setDesktopLocalAgentSelectedBackend$);
+  const probes = useLastResolved(desktopLocalAgentData$)?.probes ?? [];
+  return (
+    <header className="hidden md:block shrink-0 bg-transparent px-4 sm:px-6 pt-10 pb-4">
+      <div className="mx-auto max-w-[1100px] flex items-center justify-between gap-4">
+        <div>
+          <h1 className="text-xl font-semibold tracking-tight text-foreground flex items-center gap-2">
+            <IconDeviceDesktop size={20} stroke={1.5} />
+            Local Agents
+          </h1>
+          <p className="text-sm text-muted-foreground mt-1">
+            Desktop-managed workspaces for Codex and Claude Code
+          </p>
+        </div>
+        <Button
+          onClick={() => {
+            setBackend(defaultBackendForProbes(probes));
+            setOpen(true);
+          }}
+        >
+          <IconFolderPlus size={16} />
+          Add local agent
+        </Button>
+      </div>
+    </header>
+  );
+}
+
+function DesktopLocalAgentPageBody() {
+  const dataLoadable = useLoadable(desktopLocalAgentData$);
+  return (
+    <main className="shrink-0 px-4 sm:px-6 pt-3 pb-16">
+      <div className="mx-auto max-w-[1100px] flex flex-col gap-6">
+        {dataLoadable.state === "loading" ? (
+          <div className="flex items-center justify-center py-10 text-muted-foreground">
+            <IconLoader2 size={20} className="animate-spin" />
+          </div>
+        ) : dataLoadable.state === "hasError" ? (
+          <div className="rounded-xl zero-border bg-card px-6 py-10 text-center text-sm text-destructive">
+            Failed to load local agents.
+          </div>
+        ) : (
+          <DesktopLocalAgentTable />
+        )}
+      </div>
+    </main>
+  );
+}
+
+export function ZeroDesktopLocalAgentPage() {
+  return (
+    <div className="flex flex-1 flex-col min-h-0 overflow-auto [scrollbar-gutter:stable]">
+      <DesktopLocalAgentPageHeader />
+      <DesktopLocalAgentPageBody />
+      <AddLocalAgentDialog />
+    </div>
+  );
+}

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -13,6 +13,7 @@ import {
   IconChartLine,
   IconLayoutGrid,
   IconCalendar,
+  IconDeviceDesktop,
   IconUsers,
   IconEdit,
   IconChevronRight,
@@ -74,9 +75,10 @@ interface ManageNavItem {
   readonly pathname: string;
   readonly label: string;
   readonly icon: NavIcon;
+  readonly featureGate?: FeatureSwitchKey;
 }
 
-const MANAGE_NAV = [
+const MANAGE_NAV: readonly ManageNavItem[] = [
   {
     id: "agents",
     activeKeys: ["agents", "agentDetail", "agentPermissions"],
@@ -92,6 +94,14 @@ const MANAGE_NAV = [
     icon: IconPlug as NavIcon,
   },
   {
+    id: "localAgents",
+    activeKeys: ["desktopLocalAgents"],
+    pathname: "/local-agents",
+    label: "Local agents",
+    icon: IconDeviceDesktop as NavIcon,
+    featureGate: FeatureSwitchKey.DesktopLocalAgent,
+  },
+  {
     id: "schedules",
     activeKeys: ["schedules", "scheduleDetail"],
     pathname: "/schedules",
@@ -105,7 +115,7 @@ const MANAGE_NAV = [
     label: "Activity logs",
     icon: IconChartLine as NavIcon,
   },
-] as const satisfies readonly ManageNavItem[];
+];
 
 interface FooterNavItem {
   readonly id: SidebarNavId;
@@ -191,9 +201,20 @@ function SidebarNavContent() {
   const features = useLastResolved(featureSwitch$);
   const defaultDisplayName = useLastResolved(defaultAgentName$) ?? "Zero";
   const slackScopeMismatch = useLastResolved(slackOrgScopeMismatch$) ?? false;
+  const desktopLocalAgentAvailable =
+    typeof window !== "undefined" && Boolean(window.vm0DesktopLocalAgent);
 
   const manageNav = MANAGE_NAV.filter((item) => {
-    return item.id !== "activities" || features?.[FeatureSwitchKey.ZeroDebug];
+    if (item.id === "activities") {
+      return features?.[FeatureSwitchKey.ZeroDebug];
+    }
+    if (item.featureGate && !features?.[item.featureGate]) {
+      return false;
+    }
+    if (item.id === "localAgents") {
+      return desktopLocalAgentAvailable;
+    }
+    return true;
   });
   const footerNav = FOOTER_NAV.map((item) => {
     return {

--- a/turbo/packages/connectors/src/feature-switch-key.ts
+++ b/turbo/packages/connectors/src/feature-switch-key.ts
@@ -35,6 +35,7 @@ export enum FeatureSwitchKey {
   ZeroDebug = "zeroDebug",
   ComputerUse = "computerUse",
   LocalBrowserUse = "localBrowserUse",
+  DesktopLocalAgent = "desktopLocalAgent",
   Lab = "lab",
   AuditLink = "auditLink",
   AudioOutput = "audioOutput",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -194,6 +194,13 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
+  [FeatureSwitchKey.DesktopLocalAgent]: {
+    maintainer: "lancy@vm0.ai",
+    description:
+      "Enable the Desktop-owned Local Agent page, folder selection, and native host lifecycle",
+    enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+  },
   [FeatureSwitchKey.Lab]: {
     maintainer: "ethan@vm0.ai",
     description: "Show the Lab page for toggling experimental features",


### PR DESCRIPTION
## Summary
- add the staff-gated `desktopLocalAgent` feature switch and Platform route/sidebar entry
- add a Desktop Local Agents management page for configured folders, backend selection, permission mode, status, host metadata, and lifecycle actions
- add Electron main/preload IPC plus a Desktop-owned local-agent manager for folder selection, persisted entries, multiple simultaneous host loops, heartbeat/job polling, and quit-time cleanup

## Validation
- `pnpm -F @vm0/desktop check-types`
- `pnpm -F @vm0/desktop lint`
- `pnpm -F @vm0/desktop test`
- `pnpm -F @vm0/desktop build`
- `pnpm -F @vm0/app check-types`
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/desktop-local-agent-page.test.tsx src/signals/zero-page/__tests__/zero-nav.test.ts`
- `pnpm -F @vm0/core check-types`
- `pnpm -F @vm0/core lint`
- `pnpm -F @vm0/connectors check-types`
- `pnpm -F @vm0/connectors lint`
- `pnpm knip`
- pre-commit: `turbo run check-types --concurrency=1`

Closes #14030