### PR TITLE
refactor: proxy test slack conversations replies route to api

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/test-slack-mock.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/test-slack-mock.test.ts
@@ -109,6 +109,17 @@ describe("POST /api/test/slack-mock/*", () => {
     await expect(response.text()).resolves.toBe("Not found");
   });
 
+  it("returns 404 for conversations.replies outside allowed test environments", async () => {
+    mockEnv("ENV", "production");
+
+    const response = await requestApp(`${BASE_ROUTE}/conversations.replies`, {
+      method: "POST",
+    });
+
+    expect(response.status).toBe(404);
+    await expect(response.text()).resolves.toBe("Not found");
+  });
+
   it("returns fixed Slack auth.test and oauth.v2.access fixture payloads", async () => {
     mockEnv("ENV", "development");
 

--- a/turbo/apps/web/__tests__/api-backend-rewrite-proxy.test.ts
+++ b/turbo/apps/web/__tests__/api-backend-rewrite-proxy.test.ts
@@ -339,6 +339,27 @@ describe("API backend rewrite proxy behavior", () => {
     ).toBe(false);
   });
 
+  it("matches the test Slack conversations.replies mock rewrite path exactly", () => {
+    expect(
+      matchesApiBackendRewritePath(
+        "/api/test/slack-mock/conversations.replies",
+      ),
+    ).toBe(true);
+    expect(
+      matchesApiBackendRewritePath(
+        "/api/test/slack-mock/conversations.replies/extra",
+      ),
+    ).toBe(false);
+    expect(
+      matchesApiBackendRewritePath("/api/test/slack-mock/conversations"),
+    ).toBe(false);
+    expect(
+      matchesApiBackendRewritePath(
+        "/api/test/slack-mock/conversations.repliess",
+      ),
+    ).toBe(false);
+  });
+
   it("matches the cron aggregate insights rewrite path exactly", () => {
     expect(matchesApiBackendRewritePath("/api/cron/aggregate-insights")).toBe(
       true,

--- a/turbo/apps/web/__tests__/security-headers.test.ts
+++ b/turbo/apps/web/__tests__/security-headers.test.ts
@@ -375,6 +375,15 @@ const TEST_SLACK_MOCK_CONVERSATIONS_HISTORY_NEXT_NEGATIVE_PATHS = [
   "/api/test/slack-mock/conversations",
   "/api/test/slack-mock/conversations.historys",
 ] as const;
+const TEST_SLACK_MOCK_CONVERSATIONS_REPLIES_REWRITE_SOURCE =
+  "/api/test/slack-mock/conversations.replies";
+const TEST_SLACK_MOCK_CONVERSATIONS_REPLIES_PATH =
+  "/api/test/slack-mock/conversations.replies";
+const TEST_SLACK_MOCK_CONVERSATIONS_REPLIES_NEXT_NEGATIVE_PATHS = [
+  "/api/test/slack-mock/conversations.replies/extra",
+  "/api/test/slack-mock/conversations",
+  "/api/test/slack-mock/conversations.repliess",
+] as const;
 const CRON_AGGREGATE_INSIGHTS_REWRITE_SOURCE = "/api/cron/aggregate-insights";
 const CRON_AGGREGATE_INSIGHTS_PATH = "/api/cron/aggregate-insights";
 const CRON_AGGREGATE_INSIGHTS_NEXT_NEGATIVE_PATHS = [
@@ -1513,6 +1522,11 @@ describe("API backend rewrites", () => {
           source: TEST_SLACK_MOCK_CONVERSATIONS_HISTORY_REWRITE_SOURCE,
           destination:
             "https://api.example.test/api/test/slack-mock/conversations.history",
+        },
+        {
+          source: TEST_SLACK_MOCK_CONVERSATIONS_REPLIES_REWRITE_SOURCE,
+          destination:
+            "https://api.example.test/api/test/slack-mock/conversations.replies",
         },
         {
           source: CRON_AGGREGATE_INSIGHTS_REWRITE_SOURCE,
@@ -3666,6 +3680,37 @@ describe("API backend rewrites", () => {
       {},
     );
     for (const pathname of TEST_SLACK_MOCK_CONVERSATIONS_HISTORY_NEXT_NEGATIVE_PATHS) {
+      expect(matcher(pathname)).toBe(false);
+    }
+  });
+
+  it("should match only the exact test Slack conversations.replies mock rewrite", async () => {
+    vi.stubEnv("VM0_API_BACKEND_URL", "https://api.example.test");
+
+    const rewrites = await getBeforeFileRewrites();
+    const rewrite = rewrites.find((entry) => {
+      return (
+        entry.source === TEST_SLACK_MOCK_CONVERSATIONS_REPLIES_REWRITE_SOURCE
+      );
+    });
+    expect(rewrite).toStrictEqual({
+      source: TEST_SLACK_MOCK_CONVERSATIONS_REPLIES_REWRITE_SOURCE,
+      destination:
+        "https://api.example.test/api/test/slack-mock/conversations.replies",
+    });
+
+    const matcher = getPathMatch(
+      TEST_SLACK_MOCK_CONVERSATIONS_REPLIES_REWRITE_SOURCE,
+      {
+        removeUnnamedParams: true,
+        strict: true,
+      },
+    );
+
+    expect(matcher(TEST_SLACK_MOCK_CONVERSATIONS_REPLIES_PATH)).toStrictEqual(
+      {},
+    );
+    for (const pathname of TEST_SLACK_MOCK_CONVERSATIONS_REPLIES_NEXT_NEGATIVE_PATHS) {
       expect(matcher(pathname)).toBe(false);
     }
   });

--- a/turbo/apps/web/api-backend-rewrites.js
+++ b/turbo/apps/web/api-backend-rewrites.js
@@ -392,6 +392,10 @@ export const API_BACKEND_REWRITES = [
     "/api/test/slack-mock/conversations.open",
     "/api/test/slack-mock/conversations.open",
   ],
+  [
+    "/api/test/slack-mock/conversations.replies",
+    "/api/test/slack-mock/conversations.replies",
+  ],
   ["/api/test/slack-state", "/api/test/slack-state"],
   ["/api/test/telegram-dispatch-probe", "/api/test/telegram-dispatch-probe"],
   ["/api/user/export", "/api/user/export"],

--- a/turbo/apps/web/app/api/test/slack-mock/conversations.replies/route.ts
+++ b/turbo/apps/web/app/api/test/slack-mock/conversations.replies/route.ts
@@ -1,9 +1,0 @@
-import { NextResponse } from "next/server";
-import { isTestEndpointAllowed } from "../../../../../src/lib/auth/test-endpoint-guard";
-
-export async function POST(request: Request) {
-  if (!isTestEndpointAllowed(request)) {
-    return new NextResponse("Not found", { status: 404 });
-  }
-  return NextResponse.json({ ok: true, messages: [], has_more: false });
-}

--- a/turbo/apps/web/custom-eslint/baselines/web-api-routes.ts
+++ b/turbo/apps/web/custom-eslint/baselines/web-api-routes.ts
@@ -22,7 +22,6 @@ export const WEB_API_ROUTE_BASELINE = [
   "app/api/telegram/register/route.ts",
   "app/api/telegram/setup-status/route.ts",
   "app/api/telegram/webhook/[telegramBotId]/route.ts",
-  "app/api/test/slack-mock/conversations.replies/route.ts",
   "app/api/test/slack-mock/oauth.v2.access/route.ts",
   "app/api/test/slack-mock/users.info/route.ts",
   "app/api/test/slack-mock/views.publish/route.ts",


### PR DESCRIPTION
## Summary

- Delete the legacy web `/api/test/slack-mock/conversations.replies` route implementation.
- Add the exact web-to-api backend rewrite and explicit web rewrite/security coverage for that path.
- Keep apps/api authoritative by adding route-specific production 404 coverage while preserving the existing success payload integration test.
- Shrink the web API route baseline.

## Validation

- `pnpm -F api exec vitest run src/signals/routes/__tests__/test-slack-mock.test.ts`
- `pnpm -F web exec vitest run __tests__/api-backend-rewrite-proxy.test.ts __tests__/security-headers.test.ts custom-eslint/__tests__/no-new-api-routes.test.ts`
- `pnpm -F api lint`
- `pnpm -F web lint`
- `pnpm -F api check-types`
- `pnpm -F web check-types`
- `git diff --check`
- pre-commit: prettier, knip, full `pnpm check-types`

Closes #14058
