### PR TITLE
fix: keep slack provider callbacks on web origin

### DIFF
--- a/turbo/apps/web/__tests__/api-backend-rewrite-proxy.test.ts
+++ b/turbo/apps/web/__tests__/api-backend-rewrite-proxy.test.ts
@@ -629,7 +629,24 @@ describe("API backend rewrite proxy behavior", () => {
       matchesApiBackendRewritePath("/api/zero/slack/oauth/install/extra"),
     ).toBe(false);
     expect(matchesApiBackendRewritePath("/api/zero/slack/oauth")).toBe(false);
-    expect(matchesApiBackendRewritePath("/api/zero/slack/events")).toBe(false);
+    expect(matchesApiBackendRewritePath("/api/zero/slack/oauth/events")).toBe(
+      false,
+    );
+  });
+
+  it("matches Slack provider callback rewrite paths exactly", () => {
+    expect(matchesApiBackendRewritePath("/api/zero/slack/events")).toBe(true);
+    expect(matchesApiBackendRewritePath("/api/zero/slack/commands")).toBe(true);
+    expect(matchesApiBackendRewritePath("/api/zero/slack/interactive")).toBe(
+      true,
+    );
+    expect(matchesApiBackendRewritePath("/api/zero/slack/events/extra")).toBe(
+      false,
+    );
+    expect(matchesApiBackendRewritePath("/api/zero/slack/command")).toBe(false);
+    expect(matchesApiBackendRewritePath("/api/zero/slack/interactions")).toBe(
+      false,
+    );
   });
 
   it("matches only one segment for agent session by-id rewrites", () => {
@@ -2068,6 +2085,75 @@ describe("API backend rewrite proxy behavior", () => {
         expect(payload.headers.cookie).toBe("session=opaque");
         expect(payload.headers["x-forwarded-host"]).toContain("127.0.0.1:");
         expect(payload.body).toBe(JSON.stringify({ device_type: "bb0" }));
+      },
+    );
+  });
+
+  it("forwards Slack provider callback POST bodies and signature headers", async () => {
+    await withRewriteProxy(
+      async (request) => {
+        return Response.json({
+          method: request.method,
+          url: request.url,
+          headers: request.headers,
+          body: await readRequestBody(request),
+        });
+      },
+      async (origin) => {
+        const callbackRequests = [
+          {
+            path: "/api/zero/slack/events",
+            contentType: "application/json",
+            body: JSON.stringify({
+              type: "url_verification",
+              challenge: "challenge-123",
+            }),
+          },
+          {
+            path: "/api/zero/slack/commands",
+            contentType: "application/x-www-form-urlencoded",
+            body: new URLSearchParams({
+              command: "/zero",
+              text: "help",
+            }).toString(),
+          },
+          {
+            path: "/api/zero/slack/interactive",
+            contentType: "application/x-www-form-urlencoded",
+            body: new URLSearchParams({
+              payload: JSON.stringify({ type: "block_actions" }),
+            }).toString(),
+          },
+        ] as const;
+
+        for (const callbackRequest of callbackRequests) {
+          const response = await fetch(
+            `${origin}${callbackRequest.path}?from=slack`,
+            {
+              method: "POST",
+              headers: {
+                "content-type": callbackRequest.contentType,
+                "x-slack-request-timestamp": "1710000000",
+                "x-slack-signature": "v0=test-signature",
+              },
+              body: callbackRequest.body,
+            },
+          );
+
+          const payload = (await response.json()) as EchoPayload;
+          expect(payload.method).toBe("POST");
+          expect(payload.url).toBe(`${callbackRequest.path}?from=slack`);
+          expect(payload.headers["content-type"]).toContain(
+            callbackRequest.contentType,
+          );
+          expect(payload.headers["x-slack-request-timestamp"]).toBe(
+            "1710000000",
+          );
+          expect(payload.headers["x-slack-signature"]).toBe(
+            "v0=test-signature",
+          );
+          expect(payload.body).toBe(callbackRequest.body);
+        }
       },
     );
   });

--- a/turbo/apps/web/__tests__/proxy.sandbox-token.test.ts
+++ b/turbo/apps/web/__tests__/proxy.sandbox-token.test.ts
@@ -344,4 +344,33 @@ describe("proxy middleware: sandbox token handling", () => {
       "https://www.vm0.ai",
     );
   });
+
+  it("should not add OAuth web origin headers for Slack provider callbacks", async () => {
+    const request = new NextRequest(
+      "https://www.vm0.ai/api/zero/slack/events",
+      {
+        method: "POST",
+        headers: {
+          "x-slack-request-timestamp": "1710000000",
+          "x-slack-signature": "v0=test-signature",
+        },
+      },
+    );
+
+    const response = await middleware(request, createMockEvent());
+    if (!response) {
+      throw new Error("Expected middleware response");
+    }
+
+    expect(capturedClerkRequest).toBeUndefined();
+    expect(response.headers.get("x-middleware-request-x-forwarded-host")).toBe(
+      "www.vm0.ai",
+    );
+    expect(response.headers.get("x-middleware-request-x-forwarded-proto")).toBe(
+      "https",
+    );
+    expect(response.headers.has("x-middleware-request-x-vm0-web-origin")).toBe(
+      false,
+    );
+  });
 });

--- a/turbo/apps/web/api-backend-rewrites.js
+++ b/turbo/apps/web/api-backend-rewrites.js
@@ -168,6 +168,9 @@ const ZERO_SLACK_OAUTH_CALLBACK_REWRITE_SOURCE =
   "/api/zero/slack/oauth/callback";
 const ZERO_SLACK_OAUTH_PATH_RE =
   /^\/api\/zero\/slack\/oauth\/(?:install|connect|callback)$/;
+const ZERO_SLACK_EVENTS_REWRITE_SOURCE = "/api/zero/slack/events";
+const ZERO_SLACK_COMMANDS_REWRITE_SOURCE = "/api/zero/slack/commands";
+const ZERO_SLACK_INTERACTIVE_REWRITE_SOURCE = "/api/zero/slack/interactive";
 const ZERO_CHAT_THREAD_ARTIFACTS_REWRITE_SOURCE =
   "/api/zero/chat-threads/:threadId/artifacts";
 const ZERO_CHAT_THREAD_ARTIFACTS_PATH_RE =
@@ -425,6 +428,9 @@ export const API_BACKEND_REWRITES = [
   [ZERO_SLACK_OAUTH_INSTALL_REWRITE_SOURCE, "/api/zero/slack/oauth/install"],
   [ZERO_SLACK_OAUTH_CONNECT_REWRITE_SOURCE, "/api/zero/slack/oauth/connect"],
   [ZERO_SLACK_OAUTH_CALLBACK_REWRITE_SOURCE, "/api/zero/slack/oauth/callback"],
+  [ZERO_SLACK_EVENTS_REWRITE_SOURCE, "/api/zero/slack/events"],
+  [ZERO_SLACK_COMMANDS_REWRITE_SOURCE, "/api/zero/slack/commands"],
+  [ZERO_SLACK_INTERACTIVE_REWRITE_SOURCE, "/api/zero/slack/interactive"],
   ["/api/zero/devices/bb0/confirm", "/api/zero/devices/bb0/confirm"],
   [
     "/api/zero/host/deployments/:deploymentId/complete",


### PR DESCRIPTION
## Summary

- add exact API backend rewrites for Slack provider callbacks on `/api/zero/slack/events`, `/api/zero/slack/commands`, and `/api/zero/slack/interactive`
- cover exact rewrite matching plus provider callback POST body/signature forwarding through the Next rewrite proxy
- verify Slack provider callbacks stay separate from browser OAuth by not receiving the OAuth-only `x-vm0-web-origin` header

Closes #14042

## Validation

- `pnpm format`
- `pnpm -F web exec vitest run __tests__/api-backend-rewrite-proxy.test.ts __tests__/proxy.sandbox-token.test.ts`
- `pnpm -F web lint`
- `pnpm check-types`