### PR TITLE
refactor: implement supervised exec guest path

### DIFF
--- a/crates/vsock-guest/src/connection.rs
+++ b/crates/vsock-guest/src/connection.rs
@@ -6,9 +6,9 @@ use std::thread;
 use std::time::Duration;
 
 use vsock_proto::{
-    self, MSG_EXEC_CANCEL, MSG_EXEC_START, MSG_OPERATIONS_QUIESCED, MSG_OPERATIONS_RESUMED,
-    MSG_PROCESS_CONTROL, MSG_QUIESCE_OPERATIONS, MSG_READY, MSG_RESUME_OPERATIONS,
-    MSG_SPAWN_PROCESS, MSG_WRITE_FILE, RawMessage,
+    self, MSG_EXEC_CANCEL, MSG_EXEC_CONTROL, MSG_EXEC_START, MSG_OPERATIONS_QUIESCED,
+    MSG_OPERATIONS_RESUMED, MSG_PROCESS_CONTROL, MSG_QUIESCE_OPERATIONS, MSG_READY,
+    MSG_RESUME_OPERATIONS, MSG_SPAWN_PROCESS, MSG_WRITE_FILE, RawMessage,
 };
 
 use crate::error::to_io_error;
@@ -23,7 +23,8 @@ use crate::handlers::{
 use crate::log::log;
 use crate::monitor::{SpawnProcessRequest, handle_spawn_process as run_spawn_process};
 use crate::process_control::{
-    ProcessControlRegistry, handle_process_control as route_process_control,
+    ExecControlRegistry, ProcessControlRegistry, handle_exec_control as route_exec_control,
+    handle_process_control as route_process_control,
 };
 use crate::quiesce::{AcquireOperationError, OperationGuard, OperationState, QuiesceResult};
 use crate::writer::GuestWriter;
@@ -169,6 +170,7 @@ struct ConnectionDispatcher {
     writer: GuestWriter,
     connection_cancel: Arc<AtomicBool>,
     exec_operation_registry: ExecOperationRegistry,
+    exec_control_registry: ExecControlRegistry,
     process_control_registry: ProcessControlRegistry,
     operation_state: OperationState,
 }
@@ -179,6 +181,7 @@ impl ConnectionDispatcher {
             writer,
             connection_cancel,
             exec_operation_registry: ExecOperationRegistry::default(),
+            exec_control_registry: ExecControlRegistry::exec(),
             process_control_registry: ProcessControlRegistry::default(),
             operation_state: OperationState::default(),
         }
@@ -188,6 +191,7 @@ impl ConnectionDispatcher {
         match msg.msg_type {
             MSG_EXEC_START => self.handle_exec_start(msg)?,
             MSG_EXEC_CANCEL => self.handle_exec_cancel(msg)?,
+            MSG_EXEC_CONTROL => self.handle_exec_control(msg)?,
             MSG_SPAWN_PROCESS => self.handle_spawn_process(msg)?,
             MSG_PROCESS_CONTROL => self.handle_process_control(msg)?,
             MSG_WRITE_FILE => self.handle_write_file(msg)?,
@@ -213,7 +217,7 @@ impl ConnectionDispatcher {
                 return Ok(());
             }
         };
-        let request = match ExecOperationWorkerRequest::from_decoded(msg.seq, decoded) {
+        let mut request = match ExecOperationWorkerRequest::from_decoded(msg.seq, decoded) {
             Ok(request) => request,
             Err(error) => {
                 send_error_response(msg.seq, &error.to_string(), &self.writer)?;
@@ -225,6 +229,30 @@ impl ConnectionDispatcher {
         else {
             return Ok(());
         };
+        if let Some((control_nonce, control_sink)) = request.exec_control_registration() {
+            let registration = match self.exec_control_registry.register(
+                msg.seq,
+                Some(control_nonce),
+                control_sink,
+            ) {
+                Ok(registration) => registration,
+                Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
+                    operation_guard.release();
+                    send_error_response(msg.seq, "exec operation already active", &self.writer)?;
+                    return Ok(());
+                }
+                Err(error) => {
+                    operation_guard.release();
+                    send_error_response(
+                        msg.seq,
+                        &format!("exec control setup failed: {error}"),
+                        &self.writer,
+                    )?;
+                    return Ok(());
+                }
+            };
+            request.attach_exec_control(registration.guard, registration.bootstrap_endpoint);
+        }
         start_exec_operation(
             request,
             operation_guard,
@@ -241,6 +269,18 @@ impl ConnectionDispatcher {
         vsock_proto::decode_exec_cancel(&msg.payload).map_err(to_io_error)?;
         cancel_exec_operation(&self.exec_operation_registry, msg.seq);
         Ok(())
+    }
+
+    fn handle_exec_control(&self, msg: &RawMessage) -> io::Result<()> {
+        if !require_non_zero_sequence(msg.seq, "exec control", &self.writer)? {
+            return Ok(());
+        }
+        route_exec_control(
+            msg.seq,
+            &msg.payload,
+            &self.exec_control_registry,
+            &self.writer,
+        )
     }
 
     fn handle_spawn_process(&self, msg: &RawMessage) -> io::Result<()> {

--- a/crates/vsock-guest/src/exec_operation.rs
+++ b/crates/vsock-guest/src/exec_operation.rs
@@ -904,11 +904,12 @@ fn send_final_and_complete(
     let result = send_exec_result_after_lock(frame, writer, || {
         release_exec_control_guard(exec_control_guard);
         operation_guard.release();
+        registration.complete();
     });
-    registration.complete();
     if result.is_err() {
         release_exec_control_guard(exec_control_guard);
         operation_guard.release();
+        registration.complete();
     }
     if let Err(e) = result {
         log("ERROR", &format!("Failed to send exec_result: {e}"));
@@ -1077,15 +1078,12 @@ mod tests {
         crate::quiesce::OperationState::default().acquire().unwrap()
     }
 
-    fn wait_for_registry_release(registry: &ExecOperationRegistry, seq: u32) {
-        let deadline = Instant::now() + Duration::from_secs(3);
-        while Instant::now() < deadline {
-            if registry.register(seq, "test").is_ok() {
-                return;
-            }
-            std::thread::yield_now();
-        }
-        panic!("exec operation registry entry for seq={seq} was not released");
+    fn assert_registry_released(registry: &ExecOperationRegistry, seq: u32) {
+        let registration = registry.register(seq, "test");
+        assert!(
+            registration.is_ok(),
+            "exec operation registry entry for seq={seq} was not released"
+        );
     }
 
     #[test]
@@ -1163,7 +1161,7 @@ mod tests {
         let result = vsock_proto::decode_exec_result(&msg.payload).unwrap();
         assert_eq!(result.termination, ExecTermination::StartFailed);
         assert!(result.diagnostic.contains("exec operation worker thread"));
-        wait_for_registry_release(&registry, 42);
+        assert_registry_released(&registry, 42);
     }
 
     #[test]
@@ -1213,7 +1211,7 @@ mod tests {
         let result = vsock_proto::decode_exec_result(&msg.payload).unwrap();
         assert_eq!(result.termination, ExecTermination::WaitFailed);
         assert!(result.diagnostic.contains("stdout drain thread"));
-        wait_for_registry_release(&registry, 43);
+        assert_registry_released(&registry, 43);
     }
 
     #[test]
@@ -1239,7 +1237,7 @@ mod tests {
         let result = vsock_proto::decode_exec_result(&msg.payload).unwrap();
         assert_eq!(result.termination, ExecTermination::WaitFailed);
         assert!(result.diagnostic.contains("stderr drain thread"));
-        wait_for_registry_release(&registry, 45);
+        assert_registry_released(&registry, 45);
     }
 
     #[test]
@@ -1270,6 +1268,6 @@ mod tests {
         let result = vsock_proto::decode_exec_result(&msg.payload).unwrap();
         assert_eq!(result.termination, ExecTermination::WaitFailed);
         assert!(result.diagnostic.contains("output writer thread"));
-        wait_for_registry_release(&registry, 44);
+        assert_registry_released(&registry, 44);
     }
 }

--- a/crates/vsock-guest/src/exec_operation.rs
+++ b/crates/vsock-guest/src/exec_operation.rs
@@ -10,13 +10,14 @@ use std::time::{Duration, Instant};
 use vsock_proto::{
     self, ExecCapturedOutput, ExecControlPolicy, ExecLifecyclePolicy, ExecOutputPolicy,
     ExecOutputStream, ExecTermination, ExecTimeoutPolicy, MSG_ERROR, MSG_EXEC_OUTPUT,
-    MSG_EXEC_RESULT,
+    MSG_EXEC_RESULT, MSG_EXEC_STARTED, ProcessControlNonce,
 };
 
 use crate::drain::{BoundedDrainResult, BoundedStreamConfig, drain_bounded_cancellable};
 use crate::error::to_io_error;
 use crate::log::log;
 use crate::process::{extract_exit_code, kill_and_reap_child};
+use crate::process_control::ExecControlGuard;
 use crate::quiesce::OperationGuard;
 use crate::shell_command::{
     SpawnedShellCommand, format_env_diagnostics, spawn_shell_command_with_pipes,
@@ -126,11 +127,34 @@ struct WaitFailureContext<'a> {
     registration: &'a ExecOperationRegistration,
     writer: &'a GuestWriter,
     operation_guard: &'a OperationGuard,
+    exec_control_guard: Option<&'a ExecControlGuard>,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum ExecOperationLifecycle {
+    OneShot,
+    Supervised,
+}
+
+#[derive(Clone, Copy)]
+enum ExecOperationTimeout {
+    Duration { timeout_ms: u32 },
+    None,
+}
+
+impl ExecOperationTimeout {
+    fn wait_timeout_ms(self) -> u32 {
+        match self {
+            Self::Duration { timeout_ms } => timeout_ms,
+            Self::None => 0,
+        }
+    }
 }
 
 pub(crate) struct ExecOperationWorkerRequest {
     seq: u32,
-    timeout_ms: u32,
+    lifecycle: ExecOperationLifecycle,
+    timeout: ExecOperationTimeout,
     command: String,
     env: Vec<(String, String)>,
     sudo: bool,
@@ -138,6 +162,9 @@ pub(crate) struct ExecOperationWorkerRequest {
     stdout: ExecOutputPolicy,
     stderr: ExecOutputPolicy,
     expected_exit_codes: Vec<i32>,
+    control: ExecControlPolicy,
+    exec_control_guard: Option<ExecControlGuard>,
+    exec_control_bootstrap_endpoint: Option<String>,
 }
 
 impl ExecOperationWorkerRequest {
@@ -145,34 +172,43 @@ impl ExecOperationWorkerRequest {
         seq: u32,
         decoded: vsock_proto::DecodedExecStart<'_>,
     ) -> io::Result<Self> {
-        if decoded.lifecycle != ExecLifecyclePolicy::OneShot {
-            return Err(io::Error::new(
-                io::ErrorKind::Unsupported,
-                "exec supervised lifecycle is not supported",
-            ));
-        }
-        let ExecTimeoutPolicy::Duration { timeout_ms } = decoded.timeout else {
-            return Err(io::Error::new(
-                io::ErrorKind::Unsupported,
-                "exec timeout policy none is not supported",
-            ));
+        let lifecycle = match decoded.lifecycle {
+            ExecLifecyclePolicy::OneShot => ExecOperationLifecycle::OneShot,
+            ExecLifecyclePolicy::Supervised => ExecOperationLifecycle::Supervised,
         };
-        if timeout_ms == 0 {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidInput,
-                "exec timeout duration must be positive",
-            ));
-        }
-        if decoded.control != ExecControlPolicy::Disabled {
+        let timeout = match decoded.timeout {
+            ExecTimeoutPolicy::Duration { timeout_ms } => {
+                if timeout_ms == 0 {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        "exec timeout duration must be positive",
+                    ));
+                }
+                ExecOperationTimeout::Duration { timeout_ms }
+            }
+            ExecTimeoutPolicy::None => {
+                if lifecycle != ExecOperationLifecycle::Supervised {
+                    return Err(io::Error::new(
+                        io::ErrorKind::Unsupported,
+                        "exec timeout policy none requires supervised lifecycle",
+                    ));
+                }
+                ExecOperationTimeout::None
+            }
+        };
+        if lifecycle == ExecOperationLifecycle::OneShot
+            && decoded.control != ExecControlPolicy::Disabled
+        {
             return Err(io::Error::new(
                 io::ErrorKind::Unsupported,
-                "exec control policy is not supported",
+                "exec control policy requires supervised lifecycle",
             ));
         }
 
         Ok(Self {
             seq,
-            timeout_ms,
+            lifecycle,
+            timeout,
             command: decoded.command.to_owned(),
             env: decoded
                 .env
@@ -184,7 +220,30 @@ impl ExecOperationWorkerRequest {
             stdout: decoded.stdout,
             stderr: decoded.stderr,
             expected_exit_codes: decoded.expected_exit_codes,
+            control: decoded.control,
+            exec_control_guard: None,
+            exec_control_bootstrap_endpoint: None,
         })
+    }
+
+    pub(crate) fn exec_control_registration(&self) -> Option<(ProcessControlNonce, bool)> {
+        match self.control {
+            ExecControlPolicy::Disabled => None,
+            ExecControlPolicy::Enabled {
+                control_nonce,
+                sink,
+            } => Some((control_nonce, sink)),
+        }
+    }
+
+    pub(crate) fn attach_exec_control(
+        &mut self,
+        guard: ExecControlGuard,
+        bootstrap_endpoint: Option<String>,
+    ) {
+        debug_assert!(matches!(self.control, ExecControlPolicy::Enabled { .. }));
+        self.exec_control_guard = Some(guard);
+        self.exec_control_bootstrap_endpoint = bootstrap_endpoint;
     }
 }
 
@@ -338,34 +397,46 @@ fn run_exec_operation_worker<S>(
             },
             &writer,
             &operation_guard,
+            request.exec_control_guard.as_ref(),
         );
         return;
     }
 
     let env_refs = env_refs(&request.env);
-    let spawned = match spawn_shell_command_with_pipes(&request.command, &env_refs, request.sudo) {
-        Ok(spawned) => spawned,
-        Err(e) => {
-            let diagnostic = format!(
-                "Failed to execute: {e} ({})",
-                format_env_diagnostics(&request.command, &env_refs)
-            );
-            send_final_and_complete(
-                &registration,
-                ExecResultFrame {
-                    seq: request.seq,
-                    termination: ExecTermination::StartFailed,
-                    duration_ms: duration_ms(started),
-                    stdout: empty_output_for_policy(request.stdout),
-                    stderr: empty_output_for_policy(request.stderr),
-                    diagnostic: &diagnostic,
-                },
-                &writer,
-                &operation_guard,
-            );
-            return;
-        }
+    let mut env_with_control;
+    let effective_env = if let Some(endpoint) = request.exec_control_bootstrap_endpoint.as_deref() {
+        env_with_control = Vec::with_capacity(env_refs.len() + 1);
+        env_with_control.extend_from_slice(&env_refs);
+        env_with_control.push((process_control_ipc::BOOTSTRAP_ENV, endpoint));
+        env_with_control.as_slice()
+    } else {
+        env_refs.as_slice()
     };
+    let spawned =
+        match spawn_shell_command_with_pipes(&request.command, effective_env, request.sudo) {
+            Ok(spawned) => spawned,
+            Err(e) => {
+                let diagnostic = format!(
+                    "Failed to execute: {e} ({})",
+                    format_env_diagnostics(&request.command, &env_refs)
+                );
+                send_final_and_complete(
+                    &registration,
+                    ExecResultFrame {
+                        seq: request.seq,
+                        termination: ExecTermination::StartFailed,
+                        duration_ms: duration_ms(started),
+                        stdout: empty_output_for_policy(request.stdout),
+                        stderr: empty_output_for_policy(request.stderr),
+                        diagnostic: &diagnostic,
+                    },
+                    &writer,
+                    &operation_guard,
+                    request.exec_control_guard.as_ref(),
+                );
+                return;
+            }
+        };
 
     let SpawnedShellCommand {
         mut child,
@@ -380,7 +451,26 @@ fn run_exec_operation_worker<S>(
         registration: &registration,
         writer: &writer,
         operation_guard: &operation_guard,
+        exec_control_guard: request.exec_control_guard.as_ref(),
     };
+
+    if request.lifecycle == ExecOperationLifecycle::Supervised
+        && let Err(e) = send_exec_started(request.seq, child.id(), &writer)
+    {
+        log(
+            "WARN",
+            &format!(
+                "exec operation: failed to send exec_started seq={} label={}: {e}",
+                request.seq,
+                truncate_command_preview(&request.label)
+            ),
+        );
+        kill_and_reap_child(child);
+        release_exec_control_guard(request.exec_control_guard.as_ref());
+        operation_guard.release();
+        registration.complete();
+        return;
+    }
 
     let stdout = match child.stdout.take() {
         Some(stdout) => stdout,
@@ -489,6 +579,7 @@ fn run_exec_operation_worker<S>(
                 },
                 &writer,
                 &operation_guard,
+                request.exec_control_guard.as_ref(),
             );
             return;
         }
@@ -498,7 +589,7 @@ fn run_exec_operation_worker<S>(
 
     let outcome = wait_with_kill_timeout_or_cancelled_either(
         child,
-        request.timeout_ms,
+        request.timeout.wait_timeout_ms(),
         &connection_cancel,
         &exec_cancel,
     );
@@ -564,6 +655,7 @@ fn run_exec_operation_worker<S>(
         },
         &writer,
         &operation_guard,
+        request.exec_control_guard.as_ref(),
     );
 }
 
@@ -798,6 +890,7 @@ fn kill_and_send_wait_failed(child: Child, diagnostic: &str, failure: WaitFailur
         },
         failure.writer,
         failure.operation_guard,
+        failure.exec_control_guard,
     );
 }
 
@@ -806,12 +899,32 @@ fn send_final_and_complete(
     frame: ExecResultFrame<'_>,
     writer: &GuestWriter,
     operation_guard: &OperationGuard,
+    exec_control_guard: Option<&ExecControlGuard>,
 ) {
-    let result = send_exec_result_after_lock(frame, writer, || operation_guard.release());
+    let result = send_exec_result_after_lock(frame, writer, || {
+        release_exec_control_guard(exec_control_guard);
+        operation_guard.release();
+    });
     registration.complete();
+    if result.is_err() {
+        release_exec_control_guard(exec_control_guard);
+        operation_guard.release();
+    }
     if let Err(e) = result {
         log("ERROR", &format!("Failed to send exec_result: {e}"));
     }
+}
+
+fn release_exec_control_guard(guard: Option<&ExecControlGuard>) {
+    if let Some(guard) = guard {
+        guard.release();
+    }
+}
+
+fn send_exec_started(seq: u32, pid: u32, writer: &GuestWriter) -> io::Result<()> {
+    let payload = vsock_proto::encode_exec_started(pid).map_err(to_io_error)?;
+    let encoded = vsock_proto::encode(MSG_EXEC_STARTED, seq, &payload).map_err(to_io_error)?;
+    writer.write_frame(&encoded)
 }
 
 fn send_exec_result_after_lock<F>(
@@ -945,7 +1058,8 @@ mod tests {
     fn request(seq: u32, command: &str) -> ExecOperationWorkerRequest {
         ExecOperationWorkerRequest {
             seq,
-            timeout_ms: 0,
+            lifecycle: ExecOperationLifecycle::OneShot,
+            timeout: ExecOperationTimeout::Duration { timeout_ms: 0 },
             command: command.to_string(),
             env: Vec::new(),
             sudo: false,
@@ -953,6 +1067,9 @@ mod tests {
             stdout: ExecOutputPolicy::Capture { limit_bytes: 1024 },
             stderr: ExecOutputPolicy::Capture { limit_bytes: 1024 },
             expected_exit_codes: Vec::new(),
+            control: ExecControlPolicy::Disabled,
+            exec_control_guard: None,
+            exec_control_bootstrap_endpoint: None,
         }
     }
 

--- a/crates/vsock-guest/src/process_control.rs
+++ b/crates/vsock-guest/src/process_control.rs
@@ -1050,6 +1050,13 @@ mod tests {
 
     const NONCE: ProcessControlNonce = *b"0123456789abcdef";
 
+    fn unique_test_nonce(seed: u64) -> ProcessControlNonce {
+        let mut nonce = [0u8; 16];
+        nonce[..8].copy_from_slice(&u64::from(std::process::id()).to_be_bytes());
+        nonce[8..].copy_from_slice(&seed.to_be_bytes());
+        nonce
+    }
+
     fn resolve_error(
         registry: &ProcessControlRegistry,
         target_seq: u32,
@@ -1140,19 +1147,19 @@ mod tests {
 
     #[test]
     fn duplicate_control_sink_sequence_is_rejected_without_rebinding_endpoint() {
-        const SINK_NONCE: ProcessControlNonce = *b"8899aabbccddeeff";
+        let sink_nonce = unique_test_nonce(14);
 
         let registry = ProcessControlRegistry::default();
-        let first = registry.register(14, Some(SINK_NONCE), true).unwrap();
+        let first = registry.register(14, Some(sink_nonce), true).unwrap();
 
-        let error = match registry.register(14, Some(SINK_NONCE), true) {
+        let error = match registry.register(14, Some(sink_nonce), true) {
             Ok(_) => panic!("expected duplicate process control registration to fail"),
             Err(error) => error,
         };
 
         assert_eq!(error.kind(), io::ErrorKind::AlreadyExists);
         assert_eq!(error.to_string(), "process operation already active");
-        assert!(registry.resolve(14, SINK_NONCE).is_ok());
+        assert!(registry.resolve(14, sink_nonce).is_ok());
 
         first.guard.release();
     }
@@ -1173,19 +1180,20 @@ mod tests {
 
     #[test]
     fn control_sink_registration_exports_bootstrap_endpoint() {
+        let nonce = unique_test_nonce(7);
         let registry = ProcessControlRegistry::default();
-        let registration = registry.register(7, Some(NONCE), true).unwrap();
+        let registration = registry.register(7, Some(nonce), true).unwrap();
 
         assert!(registration.bootstrap_endpoint.is_some());
-        assert!(registry.resolve(7, NONCE).is_ok());
+        assert!(registry.resolve(7, nonce).is_ok());
     }
 
     #[test]
     fn handle_process_control_forwards_to_connected_sink() {
-        const FORWARD_NONCE: ProcessControlNonce = *b"fedcba9876543210";
+        let forward_nonce = unique_test_nonce(8);
 
         let registry = ProcessControlRegistry::default();
-        let registration = registry.register(8, Some(FORWARD_NONCE), true).unwrap();
+        let registration = registry.register(8, Some(forward_nonce), true).unwrap();
         let endpoint = registration.bootstrap_endpoint.clone().unwrap();
         let client = std::thread::spawn(move || {
             let mut stream = process_control_ipc::connect_abstract(&endpoint).unwrap();
@@ -1208,7 +1216,7 @@ mod tests {
         host.set_read_timeout(Some(Duration::from_secs(3))).unwrap();
         let writer = GuestWriter::new(guest);
         let payload =
-            vsock_proto::encode_process_control(8, FORWARD_NONCE, "msg-1", b"payload", 5000)
+            vsock_proto::encode_process_control(8, forward_nonce, "msg-1", b"payload", 5000)
                 .unwrap();
 
         handle_process_control(11, &payload, &registry, &writer).unwrap();
@@ -1224,16 +1232,16 @@ mod tests {
 
     #[test]
     fn handle_process_control_waits_for_sink_connection() {
-        const FORWARD_NONCE: ProcessControlNonce = *b"0123456789fedcba";
+        let forward_nonce = unique_test_nonce(9);
 
         let registry = ProcessControlRegistry::default();
-        let registration = registry.register(9, Some(FORWARD_NONCE), true).unwrap();
+        let registration = registry.register(9, Some(forward_nonce), true).unwrap();
         let endpoint = registration.bootstrap_endpoint.clone().unwrap();
         let (guest, mut host) = UnixStream::pair().unwrap();
         host.set_read_timeout(Some(Duration::from_secs(3))).unwrap();
         let writer = GuestWriter::new(guest);
         let payload =
-            vsock_proto::encode_process_control(9, FORWARD_NONCE, "msg-1", b"payload", 5000)
+            vsock_proto::encode_process_control(9, forward_nonce, "msg-1", b"payload", 5000)
                 .unwrap();
 
         handle_process_control(11, &payload, &registry, &writer).unwrap();
@@ -1293,17 +1301,17 @@ mod tests {
 
     #[test]
     fn timeout_before_sink_connection_does_not_poison_later_delivery() {
-        const FORWARD_NONCE: ProcessControlNonce = *b"77889900aabbccdd";
+        let forward_nonce = unique_test_nonce(16);
 
         let registry = ProcessControlRegistry::default();
-        let registration = registry.register(16, Some(FORWARD_NONCE), true).unwrap();
+        let registration = registry.register(16, Some(forward_nonce), true).unwrap();
         let endpoint = registration.bootstrap_endpoint.clone().unwrap();
         let (guest, mut host) = UnixStream::pair().unwrap();
         host.set_read_timeout(Some(Duration::from_secs(3))).unwrap();
         let writer = GuestWriter::new(guest);
         let payload = vsock_proto::encode_process_control(
             16,
-            FORWARD_NONCE,
+            forward_nonce,
             "msg-before-connect",
             b"payload",
             0,
@@ -1338,7 +1346,7 @@ mod tests {
 
         let payload = vsock_proto::encode_process_control(
             16,
-            FORWARD_NONCE,
+            forward_nonce,
             "msg-after-timeout",
             b"payload",
             5000,
@@ -1358,10 +1366,10 @@ mod tests {
 
     #[test]
     fn non_terminal_control_responses_do_not_close_sink() {
-        const FORWARD_NONCE: ProcessControlNonce = *b"aa22cc44ee66ff88";
+        let forward_nonce = unique_test_nonce(11);
 
         let registry = ProcessControlRegistry::default();
-        let registration = registry.register(11, Some(FORWARD_NONCE), true).unwrap();
+        let registration = registry.register(11, Some(forward_nonce), true).unwrap();
         let endpoint = registration.bootstrap_endpoint.clone().unwrap();
         let client = std::thread::spawn(move || {
             let mut stream = process_control_ipc::connect_abstract(&endpoint).unwrap();
@@ -1410,7 +1418,7 @@ mod tests {
 
         let payload = vsock_proto::encode_process_control(
             11,
-            FORWARD_NONCE,
+            forward_nonce,
             "msg-rejected",
             b"payload",
             5000,
@@ -1424,7 +1432,7 @@ mod tests {
         assert_eq!(diagnostic, "denied");
 
         let payload =
-            vsock_proto::encode_process_control(11, FORWARD_NONCE, "msg-error", b"payload", 5000)
+            vsock_proto::encode_process_control(11, forward_nonce, "msg-error", b"payload", 5000)
                 .unwrap();
         handle_process_control(22, &payload, &registry, &writer).unwrap();
         let (_, seq, status, message_id, diagnostic) = read_process_control_result(&mut host);
@@ -1435,7 +1443,7 @@ mod tests {
 
         let payload = vsock_proto::encode_process_control(
             11,
-            FORWARD_NONCE,
+            forward_nonce,
             "msg-after-error",
             b"payload",
             5000,
@@ -1453,15 +1461,15 @@ mod tests {
 
     #[test]
     fn pending_process_control_returns_inactive_when_operation_releases() {
-        const FORWARD_NONCE: ProcessControlNonce = *b"0011223344556677";
+        let forward_nonce = unique_test_nonce(10);
 
         let registry = ProcessControlRegistry::default();
-        let registration = registry.register(10, Some(FORWARD_NONCE), true).unwrap();
+        let registration = registry.register(10, Some(forward_nonce), true).unwrap();
         let (guest, mut host) = UnixStream::pair().unwrap();
         host.set_read_timeout(Some(Duration::from_secs(3))).unwrap();
         let writer = GuestWriter::new(guest);
         let payload =
-            vsock_proto::encode_process_control(10, FORWARD_NONCE, "msg-release", b"payload", 5000)
+            vsock_proto::encode_process_control(10, forward_nonce, "msg-release", b"payload", 5000)
                 .unwrap();
 
         handle_process_control(13, &payload, &registry, &writer).unwrap();
@@ -1686,12 +1694,12 @@ mod tests {
 
     #[test]
     fn failed_control_sink_handshake_returns_sink_error() {
-        const FORWARD_NONCE: ProcessControlNonce = *b"cc22dd44ee66aa88";
+        let forward_nonce = unique_test_nonce(13);
 
         let registry = ProcessControlRegistry::default();
-        let registration = registry.register(13, Some(FORWARD_NONCE), true).unwrap();
+        let registration = registry.register(13, Some(forward_nonce), true).unwrap();
         let endpoint = registration.bootstrap_endpoint.clone().unwrap();
-        let sink = registry.resolve(13, FORWARD_NONCE).unwrap();
+        let sink = registry.resolve(13, forward_nonce).unwrap();
 
         let stream = process_control_ipc::connect_abstract(&endpoint).unwrap();
         drop(stream);
@@ -1717,7 +1725,7 @@ mod tests {
         let writer = GuestWriter::new(guest);
         let payload = vsock_proto::encode_process_control(
             13,
-            FORWARD_NONCE,
+            forward_nonce,
             "msg-handshake-failed",
             b"payload",
             5000,
@@ -1737,12 +1745,12 @@ mod tests {
 
     #[test]
     fn operation_release_interrupts_control_sink_handshake() {
-        const HANDSHAKE_NONCE: ProcessControlNonce = *b"dd33ee55ff77aa99";
+        let handshake_nonce = unique_test_nonce(15);
 
         let registry = ProcessControlRegistry::default();
-        let registration = registry.register(15, Some(HANDSHAKE_NONCE), true).unwrap();
+        let registration = registry.register(15, Some(handshake_nonce), true).unwrap();
         let endpoint = registration.bootstrap_endpoint.clone().unwrap();
-        let sink = registry.resolve(15, HANDSHAKE_NONCE).unwrap();
+        let sink = registry.resolve(15, handshake_nonce).unwrap();
         let mut stream = process_control_ipc::connect_abstract(&endpoint).unwrap();
 
         let mut guard = sink.inner.lock().unwrap_or_else(|e| e.into_inner());

--- a/crates/vsock-guest/src/process_control.rs
+++ b/crates/vsock-guest/src/process_control.rs
@@ -7,7 +7,9 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use process_control_ipc::{ControlRequest, ControlResponseStatus};
-use vsock_proto::{MSG_PROCESS_CONTROL_RESULT, ProcessControlNonce, ProcessControlStatus};
+use vsock_proto::{
+    MSG_EXEC_CONTROL_RESULT, MSG_PROCESS_CONTROL_RESULT, ProcessControlNonce, ProcessControlStatus,
+};
 
 use crate::error::to_io_error;
 use crate::log::log;
@@ -18,12 +20,120 @@ const THREAD_PROCESS_CONTROL_FORWARD: &str = "vsock-process-control-forward";
 const CONTROL_ACCEPT_POLL_TIMEOUT: Duration = Duration::from_millis(100);
 const CONTROL_SINK_IO_TIMEOUT: Duration = Duration::from_secs(5);
 const MAX_PENDING_CONTROL_REQUESTS: usize = 8;
-const REQUEST_TIMEOUT_DIAGNOSTIC: &str = "process control request timed out";
+const PROCESS_REQUEST_TIMEOUT_DIAGNOSTIC: &str = "process control request timed out";
+const EXEC_REQUEST_TIMEOUT_DIAGNOSTIC: &str = "exec control request timed out";
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+enum OperationControlProtocol {
+    #[default]
+    Process,
+    Exec,
+}
+
+impl OperationControlProtocol {
+    fn log_name(self) -> &'static str {
+        match self {
+            Self::Process => "process_control",
+            Self::Exec => "exec_control",
+        }
+    }
+
+    fn accept_thread_name(self) -> &'static str {
+        match self {
+            Self::Process => THREAD_PROCESS_CONTROL_ACCEPT,
+            Self::Exec => THREAD_EXEC_CONTROL_ACCEPT,
+        }
+    }
+
+    fn forward_thread_name(self) -> &'static str {
+        match self {
+            Self::Process => THREAD_PROCESS_CONTROL_FORWARD,
+            Self::Exec => THREAD_EXEC_CONTROL_FORWARD,
+        }
+    }
+
+    fn result_msg_type(self) -> u8 {
+        match self {
+            Self::Process => MSG_PROCESS_CONTROL_RESULT,
+            Self::Exec => MSG_EXEC_CONTROL_RESULT,
+        }
+    }
+
+    fn operation_already_active_message(self) -> &'static str {
+        match self {
+            Self::Process => "process operation already active",
+            Self::Exec => "exec operation already active",
+        }
+    }
+
+    fn inactive_message(self) -> &'static str {
+        match self {
+            Self::Process => "process operation is not active",
+            Self::Exec => "exec operation is not active",
+        }
+    }
+
+    fn nonce_mismatch_message(self) -> &'static str {
+        match self {
+            Self::Process => "process operation nonce mismatch",
+            Self::Exec => "exec operation nonce mismatch",
+        }
+    }
+
+    fn sink_not_configured_message(self) -> &'static str {
+        match self {
+            Self::Process => "process control sink is not configured",
+            Self::Exec => "exec control sink is not configured",
+        }
+    }
+
+    fn queue_full_message(self) -> &'static str {
+        match self {
+            Self::Process => "process control queue is full",
+            Self::Exec => "exec control queue is full",
+        }
+    }
+
+    fn request_timeout_diagnostic(self) -> &'static str {
+        match self {
+            Self::Process => PROCESS_REQUEST_TIMEOUT_DIAGNOSTIC,
+            Self::Exec => EXEC_REQUEST_TIMEOUT_DIAGNOSTIC,
+        }
+    }
+
+    fn clone_sink_error_prefix(self) -> &'static str {
+        match self {
+            Self::Process => "failed to clone process control sink",
+            Self::Exec => "failed to clone exec control sink",
+        }
+    }
+
+    fn worker_start_error_prefix(self) -> &'static str {
+        match self {
+            Self::Process => "failed to start process control worker",
+            Self::Exec => "failed to start exec control worker",
+        }
+    }
+
+    fn message_id_mismatch_prefix(self) -> &'static str {
+        match self {
+            Self::Process => "process control sink message id mismatch",
+            Self::Exec => "exec control sink message id mismatch",
+        }
+    }
+}
+
+const THREAD_EXEC_CONTROL_ACCEPT: &str = "vsock-exec-control-accept";
+const THREAD_EXEC_CONTROL_FORWARD: &str = "vsock-exec-control-forward";
 
 #[derive(Clone, Default)]
 pub(crate) struct ProcessControlRegistry {
+    protocol: OperationControlProtocol,
     inner: Arc<Mutex<HashMap<u32, ProcessControlEntry>>>,
 }
+
+pub(crate) type ExecControlRegistry = ProcessControlRegistry;
+pub(crate) type ExecControlGuard = ProcessControlGuard;
 
 /// Active `spawn_process` registration for a seq.
 ///
@@ -49,6 +159,7 @@ pub(crate) struct ProcessControlGuard {
 }
 
 struct ControlSinkState {
+    protocol: OperationControlProtocol,
     inner: Mutex<ControlSinkInner>,
     ready: Condvar,
     active: AtomicBool,
@@ -105,6 +216,13 @@ impl Drop for PendingControlSlot {
 }
 
 impl ProcessControlRegistry {
+    pub(crate) fn exec() -> Self {
+        Self {
+            protocol: OperationControlProtocol::Exec,
+            inner: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
     pub(crate) fn register(
         &self,
         seq: u32,
@@ -114,7 +232,7 @@ impl ProcessControlRegistry {
         let (bootstrap_endpoint, accept_sink) = match control_nonce {
             Some(nonce) if control_sink => {
                 let endpoint = process_control_ipc::endpoint_name(seq, &nonce);
-                let sink = Arc::new(ControlSinkState::new());
+                let sink = Arc::new(ControlSinkState::new_for(self.protocol));
                 self.insert(
                     seq,
                     ProcessControlEntry::WithNonce {
@@ -135,7 +253,9 @@ impl ProcessControlRegistry {
         };
 
         let start_result = match (&bootstrap_endpoint, accept_sink) {
-            (Some(endpoint), Some(sink)) => start_control_sink_accept_thread(endpoint, sink),
+            (Some(endpoint), Some(sink)) => {
+                start_control_sink_accept_thread(self.protocol, endpoint, sink)
+            }
             _ => Ok(()),
         };
         if let Err(error) = start_result {
@@ -156,7 +276,7 @@ impl ProcessControlRegistry {
     fn insert(&self, seq: u32, entry: ProcessControlEntry) -> io::Result<()> {
         let mut active = self.inner.lock().unwrap_or_else(|e| e.into_inner());
         if active.contains_key(&seq) {
-            return Err(operation_already_active_error());
+            return Err(operation_already_active_error(self.protocol));
         }
         active.insert(seq, entry);
         Ok(())
@@ -190,25 +310,25 @@ impl ProcessControlRegistry {
         let Some(entry) = guard.get(&target_seq) else {
             return Err((
                 ProcessControlStatus::Inactive,
-                "process operation is not active",
+                self.protocol.inactive_message(),
             ));
         };
         let ProcessControlEntry::WithNonce { nonce, sink } = entry else {
             return Err((
                 ProcessControlStatus::Inactive,
-                "process operation is not active",
+                self.protocol.inactive_message(),
             ));
         };
         if *nonce != control_nonce {
             return Err((
                 ProcessControlStatus::NonceMismatch,
-                "process operation nonce mismatch",
+                self.protocol.nonce_mismatch_message(),
             ));
         }
         let Some(sink) = sink else {
             return Err((
                 ProcessControlStatus::Unsupported,
-                "process control sink is not configured",
+                self.protocol.sink_not_configured_message(),
             ));
         };
         Ok(Arc::clone(sink))
@@ -226,17 +346,21 @@ impl ProcessControlEntry {
     }
 }
 
-fn operation_already_active_error() -> io::Error {
+fn operation_already_active_error(protocol: OperationControlProtocol) -> io::Error {
     io::Error::new(
         io::ErrorKind::AlreadyExists,
-        "process operation already active",
+        protocol.operation_already_active_message(),
     )
 }
 
-fn start_control_sink_accept_thread(endpoint: &str, sink: Arc<ControlSinkState>) -> io::Result<()> {
+fn start_control_sink_accept_thread(
+    protocol: OperationControlProtocol,
+    endpoint: &str,
+    sink: Arc<ControlSinkState>,
+) -> io::Result<()> {
     let listener = process_control_ipc::bind_abstract_listener(endpoint)?;
     thread::Builder::new()
-        .name(THREAD_PROCESS_CONTROL_ACCEPT.to_owned())
+        .name(protocol.accept_thread_name().to_owned())
         .spawn(move || accept_control_sink(listener, sink))?;
     Ok(())
 }
@@ -258,8 +382,14 @@ impl Drop for ProcessControlGuard {
 }
 
 impl ControlSinkState {
+    #[cfg(test)]
     fn new() -> Self {
+        Self::new_for(OperationControlProtocol::Process)
+    }
+
+    fn new_for(protocol: OperationControlProtocol) -> Self {
         Self {
+            protocol,
             inner: Mutex::new(ControlSinkInner::Waiting),
             ready: Condvar::new(),
             active: AtomicBool::new(true),
@@ -278,7 +408,8 @@ impl ControlSinkState {
                 let mut guard = self.inner.lock().unwrap_or_else(|e| e.into_inner());
                 if !matches!(*guard, ControlSinkInner::Closed) {
                     *guard = ControlSinkInner::Failed(format!(
-                        "failed to clone process control sink: {error}"
+                        "{}: {error}",
+                        self.protocol.clone_sink_error_prefix()
                     ));
                 }
                 self.ready.notify_all();
@@ -351,7 +482,7 @@ impl ControlSinkState {
             if !self.active.load(Ordering::Acquire) {
                 return Err((
                     ProcessControlStatus::Inactive,
-                    "process operation is not active".to_owned(),
+                    self.protocol.inactive_message().to_owned(),
                 ));
             }
             match &*guard {
@@ -360,7 +491,7 @@ impl ControlSinkState {
                     let Some(wait) = duration_until(deadline) else {
                         return Err((
                             ProcessControlStatus::SinkTimeout,
-                            REQUEST_TIMEOUT_DIAGNOSTIC.to_owned(),
+                            self.protocol.request_timeout_diagnostic().to_owned(),
                         ));
                     };
                     let (next_guard, wait_result) = self
@@ -371,7 +502,7 @@ impl ControlSinkState {
                     if wait_result.timed_out() {
                         return Err((
                             ProcessControlStatus::SinkTimeout,
-                            REQUEST_TIMEOUT_DIAGNOSTIC.to_owned(),
+                            self.protocol.request_timeout_diagnostic().to_owned(),
                         ));
                     }
                 }
@@ -381,7 +512,7 @@ impl ControlSinkState {
                 ControlSinkInner::Closed => {
                     return Err((
                         ProcessControlStatus::Inactive,
-                        "process operation is not active".to_owned(),
+                        self.protocol.inactive_message().to_owned(),
                     ));
                 }
             }
@@ -400,13 +531,13 @@ impl ControlSinkState {
 
         let sink = Arc::clone(self);
         match thread::Builder::new()
-            .name(THREAD_PROCESS_CONTROL_FORWARD.to_owned())
+            .name(self.protocol.forward_thread_name().to_owned())
             .spawn(move || forward_control_request(sink, pending_slot, request, writer))
         {
             Ok(_) => None,
             Err(error) => Some((
                 ProcessControlStatus::SinkError,
-                format!("failed to start process control worker: {error}"),
+                format!("{}: {error}", self.protocol.worker_start_error_prefix()),
             )),
         }
     }
@@ -417,7 +548,7 @@ impl ControlSinkState {
         if !self.active.load(Ordering::Acquire) {
             return Err((
                 ProcessControlStatus::Inactive,
-                "process operation is not active".to_owned(),
+                self.protocol.inactive_message().to_owned(),
             ));
         }
 
@@ -426,7 +557,7 @@ impl ControlSinkState {
             self.pending.fetch_sub(1, Ordering::AcqRel);
             return Err((
                 ProcessControlStatus::QueueFull,
-                "process control queue is full".to_owned(),
+                self.protocol.queue_full_message().to_owned(),
             ));
         }
 
@@ -467,7 +598,11 @@ impl ControlStreamState {
         }
     }
 
-    fn lock_until(&self, deadline: Instant) -> io::Result<ControlStreamGuard<'_>> {
+    fn lock_until(
+        &self,
+        protocol: OperationControlProtocol,
+        deadline: Instant,
+    ) -> io::Result<ControlStreamGuard<'_>> {
         let mut locked = self.locked.lock().unwrap_or_else(|e| e.into_inner());
         loop {
             if !*locked {
@@ -480,7 +615,7 @@ impl ControlStreamState {
                 });
             }
             let Some(wait) = duration_until(deadline) else {
-                return Err(request_timeout_error());
+                return Err(request_timeout_error(protocol));
             };
             let (next_locked, wait_result) = self
                 .ready
@@ -488,7 +623,7 @@ impl ControlStreamState {
                 .unwrap_or_else(|e| e.into_inner());
             locked = next_locked;
             if wait_result.timed_out() {
-                return Err(request_timeout_error());
+                return Err(request_timeout_error(protocol));
             }
         }
     }
@@ -540,13 +675,19 @@ fn accept_control_sink(listener: std::os::unix::net::UnixListener, sink: Arc<Con
     };
     match result {
         Ok(stream) => {
-            log("INFO", "process_control: control sink connected");
+            log(
+                "INFO",
+                &format!("{}: control sink connected", sink.protocol.log_name()),
+            );
             sink.connect(stream);
         }
         Err(error) => {
             log(
                 "WARN",
-                &format!("process_control: control sink accept failed: {error}"),
+                &format!(
+                    "{}: control sink accept failed: {error}",
+                    sink.protocol.log_name()
+                ),
             );
             sink.fail(error.to_string());
         }
@@ -569,22 +710,28 @@ fn forward_control_request(
     } = request;
     let (status, diagnostic, mark_failed) = {
         match sink.wait_for_stream(deadline) {
-            Ok(stream) => match stream.lock_until(deadline) {
+            Ok(stream) => match stream.lock_until(sink.protocol, deadline) {
                 Ok(mut stream) => {
                     if !sink.active.load(Ordering::Acquire) {
                         (
                             ProcessControlStatus::Inactive,
-                            "process operation is not active".to_owned(),
+                            sink.protocol.inactive_message().to_owned(),
                             false,
                         )
                     } else if request_expired(deadline) {
                         (
                             ProcessControlStatus::SinkTimeout,
-                            REQUEST_TIMEOUT_DIAGNOSTIC.to_owned(),
+                            sink.protocol.request_timeout_diagnostic().to_owned(),
                             false,
                         )
                     } else {
-                        forward_to_connected_sink(&mut stream, &message_id, payload, deadline)
+                        forward_to_connected_sink(
+                            sink.protocol,
+                            &mut stream,
+                            &message_id,
+                            payload,
+                            deadline,
+                        )
                     }
                 }
                 Err(error) if is_timeout(&error) => {
@@ -606,10 +753,11 @@ fn forward_control_request(
         } else {
             (
                 ProcessControlStatus::Inactive,
-                "process operation is not active",
+                sink.protocol.inactive_message(),
             )
         };
-        let result_payload = vsock_proto::encode_process_control_result(
+        let result_payload = encode_control_result(
+            sink.protocol,
             target_seq,
             control_nonce,
             &message_id,
@@ -617,18 +765,26 @@ fn forward_control_request(
             diagnostic,
         )
         .map_err(to_io_error)?;
-        vsock_proto::encode(MSG_PROCESS_CONTROL_RESULT, response_seq, &result_payload)
-            .map_err(to_io_error)
+        vsock_proto::encode(
+            sink.protocol.result_msg_type(),
+            response_seq,
+            &result_payload,
+        )
+        .map_err(to_io_error)
     });
     if let Err(error) = result {
         log(
             "WARN",
-            &format!("process_control: failed to send control result: {error}"),
+            &format!(
+                "{}: failed to send control result: {error}",
+                sink.protocol.log_name()
+            ),
         );
     }
 }
 
 fn forward_to_connected_sink(
+    protocol: OperationControlProtocol,
     stream: &mut UnixStream,
     message_id: &str,
     payload: Vec<u8>,
@@ -638,7 +794,7 @@ fn forward_to_connected_sink(
         message_id: message_id.to_owned(),
         payload,
     };
-    let write_timeout = match control_sink_io_timeout(deadline) {
+    let write_timeout = match control_sink_io_timeout(protocol, deadline) {
         Ok(timeout) => timeout,
         Err(error) if is_timeout(&error) => {
             return return_control_result(ProcessControlStatus::SinkTimeout, error, false);
@@ -653,7 +809,7 @@ fn forward_to_connected_sink(
         };
     }
 
-    let read_timeout = match control_sink_io_timeout(deadline) {
+    let read_timeout = match control_sink_io_timeout(protocol, deadline) {
         Ok(timeout) => timeout,
         Err(error) if is_timeout(&error) => {
             return return_control_result(ProcessControlStatus::SinkTimeout, error, true);
@@ -664,8 +820,10 @@ fn forward_to_connected_sink(
         Ok(response) if response.message_id != message_id => (
             ProcessControlStatus::SinkError,
             format!(
-                "process control sink message id mismatch: expected {}, got {}",
-                message_id, response.message_id
+                "{}: expected {}, got {}",
+                protocol.message_id_mismatch_prefix(),
+                message_id,
+                response.message_id
             ),
             true,
         ),
@@ -710,15 +868,21 @@ fn duration_until(deadline: Instant) -> Option<Duration> {
     (now < deadline).then(|| deadline.duration_since(now))
 }
 
-fn control_sink_io_timeout(deadline: Instant) -> io::Result<Duration> {
+fn control_sink_io_timeout(
+    protocol: OperationControlProtocol,
+    deadline: Instant,
+) -> io::Result<Duration> {
     duration_until(deadline)
         .map(|remaining| remaining.min(CONTROL_SINK_IO_TIMEOUT))
         .filter(|timeout| !timeout.is_zero())
-        .ok_or_else(request_timeout_error)
+        .ok_or_else(|| request_timeout_error(protocol))
 }
 
-fn request_timeout_error() -> io::Error {
-    io::Error::new(io::ErrorKind::TimedOut, REQUEST_TIMEOUT_DIAGNOSTIC)
+fn request_timeout_error(protocol: OperationControlProtocol) -> io::Error {
+    io::Error::new(
+        io::ErrorKind::TimedOut,
+        protocol.request_timeout_diagnostic(),
+    )
 }
 
 fn write_control_request(
@@ -745,13 +909,77 @@ fn is_timeout(error: &io::Error) -> bool {
     )
 }
 
-pub(crate) fn handle_process_control(
+struct DecodedOperationControl<'a> {
+    target_seq: u32,
+    request_timeout_ms: u32,
+    control_nonce: ProcessControlNonce,
+    message_id: &'a str,
+    payload: &'a [u8],
+}
+
+fn decode_control_request<'a>(
+    protocol: OperationControlProtocol,
+    payload: &'a [u8],
+) -> Result<DecodedOperationControl<'a>, vsock_proto::ProtocolError> {
+    match protocol {
+        OperationControlProtocol::Process => {
+            let decoded = vsock_proto::decode_process_control(payload)?;
+            Ok(DecodedOperationControl {
+                target_seq: decoded.target_seq,
+                request_timeout_ms: decoded.request_timeout_ms,
+                control_nonce: decoded.control_nonce,
+                message_id: decoded.message_id,
+                payload: decoded.payload,
+            })
+        }
+        OperationControlProtocol::Exec => {
+            let decoded = vsock_proto::decode_exec_control(payload)?;
+            Ok(DecodedOperationControl {
+                target_seq: decoded.target_seq,
+                request_timeout_ms: decoded.request_timeout_ms,
+                control_nonce: decoded.control_nonce,
+                message_id: decoded.message_id,
+                payload: decoded.payload,
+            })
+        }
+    }
+}
+
+fn encode_control_result(
+    protocol: OperationControlProtocol,
+    target_seq: u32,
+    control_nonce: ProcessControlNonce,
+    message_id: &str,
+    status: ProcessControlStatus,
+    diagnostic: &str,
+) -> Result<Vec<u8>, vsock_proto::ProtocolError> {
+    match protocol {
+        OperationControlProtocol::Process => vsock_proto::encode_process_control_result(
+            target_seq,
+            control_nonce,
+            message_id,
+            status,
+            diagnostic,
+        ),
+        OperationControlProtocol::Exec => vsock_proto::encode_exec_control_result(
+            target_seq,
+            control_nonce,
+            message_id,
+            status,
+            diagnostic,
+        ),
+    }
+}
+
+fn handle_control(
+    protocol: OperationControlProtocol,
     seq: u32,
     payload: &[u8],
     registry: &ProcessControlRegistry,
     writer: &GuestWriter,
 ) -> io::Result<()> {
-    let request = vsock_proto::decode_process_control(payload).map_err(to_io_error)?;
+    debug_assert_eq!(registry.protocol, protocol);
+    let request = decode_control_request(protocol, payload).map_err(to_io_error)?;
     let owned = OwnedProcessControlRequest {
         response_seq: seq,
         target_seq: request.target_seq,
@@ -768,7 +996,8 @@ pub(crate) fn handle_process_control(
 
     if let Some((status, diagnostic)) = immediate {
         writer.write_generated_frame_after_lock(|| {
-            let result_payload = vsock_proto::encode_process_control_result(
+            let result_payload = encode_control_result(
+                protocol,
                 request.target_seq,
                 request.control_nonce,
                 request.message_id,
@@ -776,12 +1005,42 @@ pub(crate) fn handle_process_control(
                 &diagnostic,
             )
             .map_err(to_io_error)?;
-            vsock_proto::encode(MSG_PROCESS_CONTROL_RESULT, seq, &result_payload)
+            vsock_proto::encode(protocol.result_msg_type(), seq, &result_payload)
                 .map_err(to_io_error)
         })?;
     }
 
     Ok(())
+}
+
+pub(crate) fn handle_process_control(
+    seq: u32,
+    payload: &[u8],
+    registry: &ProcessControlRegistry,
+    writer: &GuestWriter,
+) -> io::Result<()> {
+    handle_control(
+        OperationControlProtocol::Process,
+        seq,
+        payload,
+        registry,
+        writer,
+    )
+}
+
+pub(crate) fn handle_exec_control(
+    seq: u32,
+    payload: &[u8],
+    registry: &ExecControlRegistry,
+    writer: &GuestWriter,
+) -> io::Result<()> {
+    handle_control(
+        OperationControlProtocol::Exec,
+        seq,
+        payload,
+        registry,
+        writer,
+    )
 }
 
 #[cfg(test)]
@@ -1028,7 +1287,7 @@ mod tests {
         assert_eq!(seq, 29);
         assert_eq!(status, ProcessControlStatus::SinkTimeout);
         assert_eq!(message_id, "msg-timeout");
-        assert_eq!(diagnostic, REQUEST_TIMEOUT_DIAGNOSTIC);
+        assert_eq!(diagnostic, PROCESS_REQUEST_TIMEOUT_DIAGNOSTIC);
         assert_eq!(sink.pending.load(Ordering::Acquire), 0);
     }
 
@@ -1058,7 +1317,7 @@ mod tests {
         assert_eq!(seq, 41);
         assert_eq!(status, ProcessControlStatus::SinkTimeout);
         assert_eq!(message_id, "msg-before-connect");
-        assert_eq!(diagnostic, REQUEST_TIMEOUT_DIAGNOSTIC);
+        assert_eq!(diagnostic, PROCESS_REQUEST_TIMEOUT_DIAGNOSTIC);
 
         let client = std::thread::spawn(move || {
             let mut stream = process_control_ipc::connect_abstract(&endpoint).unwrap();
@@ -1527,7 +1786,9 @@ mod tests {
             ControlSinkInner::Connected(connected) => Arc::clone(&connected.stream),
             _ => panic!("sink should be connected"),
         };
-        let stream_guard = stream.lock_until(request_deadline(5000)).unwrap();
+        let stream_guard = stream
+            .lock_until(OperationControlProtocol::Process, request_deadline(5000))
+            .unwrap();
         let (done_tx, done_rx) = std::sync::mpsc::channel();
 
         let worker = std::thread::spawn({
@@ -1559,7 +1820,9 @@ mod tests {
             ControlSinkInner::Connected(connected) => Arc::clone(&connected.stream),
             _ => panic!("sink should be connected"),
         };
-        let stream_guard = stream.lock_until(request_deadline(5000)).unwrap();
+        let stream_guard = stream
+            .lock_until(OperationControlProtocol::Process, request_deadline(5000))
+            .unwrap();
         let (done_tx, done_rx) = std::sync::mpsc::channel();
 
         let worker = std::thread::spawn({
@@ -1592,7 +1855,9 @@ mod tests {
             ControlSinkInner::Connected(connected) => Arc::clone(&connected.stream),
             _ => panic!("sink should be connected"),
         };
-        let stream_guard = stream.lock_until(request_deadline(5000)).unwrap();
+        let stream_guard = stream
+            .lock_until(OperationControlProtocol::Process, request_deadline(5000))
+            .unwrap();
         let (guest, mut host) = UnixStream::pair().unwrap();
         host.set_read_timeout(Some(Duration::from_secs(3))).unwrap();
 
@@ -1641,7 +1906,9 @@ mod tests {
             ControlSinkInner::Connected(connected) => Arc::clone(&connected.stream),
             _ => panic!("sink should be connected"),
         };
-        let stream_guard = stream.lock_until(request_deadline(5000)).unwrap();
+        let stream_guard = stream
+            .lock_until(OperationControlProtocol::Process, request_deadline(5000))
+            .unwrap();
         let pending_slot = sink.reserve_pending_slot().unwrap();
         let (guest, mut host) = UnixStream::pair().unwrap();
         host.set_read_timeout(Some(Duration::from_secs(3))).unwrap();
@@ -1673,7 +1940,7 @@ mod tests {
         assert_eq!(seq, 19);
         assert_eq!(status, ProcessControlStatus::SinkTimeout);
         assert_eq!(message_id, "msg-expired-behind-lock");
-        assert_eq!(diagnostic, REQUEST_TIMEOUT_DIAGNOSTIC);
+        assert_eq!(diagnostic, PROCESS_REQUEST_TIMEOUT_DIAGNOSTIC);
         assert_eq!(sink.pending.load(Ordering::Acquire), 0);
         assert!(matches!(
             *sink.inner.lock().unwrap_or_else(|e| e.into_inner()),

--- a/crates/vsock-guest/tests/connection/exec_operation.rs
+++ b/crates/vsock-guest/tests/connection/exec_operation.rs
@@ -458,6 +458,83 @@ fn supervised_exec_control_reports_unsupported_without_sink() {
 }
 
 #[test]
+fn supervised_exec_control_registries_are_isolated_per_connection() {
+    let (first_handle, mut first_stream) = start_guest_connection();
+    let (second_handle, mut second_stream) = start_guest_connection();
+
+    send_supervised_exec_start(
+        &mut first_stream,
+        209,
+        "sleep 60",
+        ExecTimeoutPolicy::None,
+        ExecOutputPolicy::Discard,
+        ExecControlPolicy::Enabled {
+            control_nonce: EXEC_CONTROL_NONCE,
+            sink: false,
+        },
+    );
+    send_supervised_exec_start(
+        &mut second_stream,
+        209,
+        "sleep 60",
+        ExecTimeoutPolicy::None,
+        ExecOutputPolicy::Discard,
+        ExecControlPolicy::Enabled {
+            control_nonce: EXEC_CONTROL_NONCE,
+            sink: false,
+        },
+    );
+
+    assert!(read_exec_started(&mut first_stream, 209) > 0);
+    assert!(read_exec_started(&mut second_stream, 209) > 0);
+
+    send_exec_control(
+        &mut first_stream,
+        312,
+        209,
+        EXEC_CONTROL_NONCE,
+        "message-first",
+    );
+    send_exec_control(
+        &mut second_stream,
+        312,
+        209,
+        EXEC_CONTROL_NONCE,
+        "message-second",
+    );
+
+    assert_exec_control_result(
+        &mut first_stream,
+        312,
+        209,
+        EXEC_CONTROL_NONCE,
+        "message-first",
+        ProcessControlStatus::Unsupported,
+        "exec control sink is not configured",
+    );
+    assert_exec_control_result(
+        &mut second_stream,
+        312,
+        209,
+        EXEC_CONTROL_NONCE,
+        "message-second",
+        ProcessControlStatus::Unsupported,
+        "exec control sink is not configured",
+    );
+
+    send_exec_cancel(&mut first_stream, 209);
+    send_exec_cancel(&mut second_stream, 209);
+
+    let (_chunks, first_result) = read_exec_result(&mut first_stream, 209);
+    let (_chunks, second_result) = read_exec_result(&mut second_stream, 209);
+    assert_eq!(first_result.termination, ExecTermination::Cancelled);
+    assert_eq!(second_result.termination, ExecTermination::Cancelled);
+
+    finish_guest_connection(first_handle, first_stream);
+    finish_guest_connection(second_handle, second_stream);
+}
+
+#[test]
 fn supervised_exec_control_duplicate_start_preserves_active_nonce() {
     let (handle, mut host_stream) = start_guest_connection();
 

--- a/crates/vsock-guest/tests/connection/exec_operation.rs
+++ b/crates/vsock-guest/tests/connection/exec_operation.rs
@@ -14,6 +14,13 @@ use super::support::*;
 const EXEC_CONTROL_NONCE: ProcessControlNonce = *b"exec-ctrl-000001";
 const EXEC_CONTROL_WRONG_NONCE: ProcessControlNonce = *b"exec-ctrl-999999";
 
+fn unique_exec_control_nonce(seed: u64) -> ProcessControlNonce {
+    let mut nonce = [0u8; 16];
+    nonce[..8].copy_from_slice(&u64::from(std::process::id()).to_be_bytes());
+    nonce[8..].copy_from_slice(&seed.to_be_bytes());
+    nonce
+}
+
 fn send_supervised_exec_start(
     stream: &mut impl std::io::Write,
     seq: u32,
@@ -345,7 +352,8 @@ fn supervised_exec_control_spawn_failure_releases_registration() {
 #[test]
 fn supervised_exec_control_forwards_to_bootstrap_sink() {
     let target_seq = 203;
-    let endpoint = process_control_ipc::endpoint_name(target_seq, &EXEC_CONTROL_NONCE);
+    let control_nonce = unique_exec_control_nonce(u64::from(target_seq));
+    let endpoint = process_control_ipc::endpoint_name(target_seq, &control_nonce);
     let command = "printf '%s' \"$VM0_PROCESS_CONTROL_ENDPOINT\"; sleep 60";
     let (handle, mut host_stream) = start_guest_connection();
 
@@ -367,7 +375,7 @@ fn supervised_exec_control_forwards_to_bootstrap_sink() {
             stderr: ExecOutputPolicy::Capture { limit_bytes: 1024 },
             expected_exit_codes: &[],
             control: ExecControlPolicy::Enabled {
-                control_nonce: EXEC_CONTROL_NONCE,
+                control_nonce,
                 sink: true,
             },
         },
@@ -396,18 +404,12 @@ fn supervised_exec_control_forwards_to_bootstrap_sink() {
         .unwrap();
     });
 
-    send_exec_control(
-        &mut host_stream,
-        303,
-        target_seq,
-        EXEC_CONTROL_NONCE,
-        "message",
-    );
+    send_exec_control(&mut host_stream, 303, target_seq, control_nonce, "message");
     assert_exec_control_result(
         &mut host_stream,
         303,
         target_seq,
-        EXEC_CONTROL_NONCE,
+        control_nonce,
         "message",
         ProcessControlStatus::Delivered,
         "ok",

--- a/crates/vsock-guest/tests/connection/exec_operation.rs
+++ b/crates/vsock-guest/tests/connection/exec_operation.rs
@@ -615,6 +615,60 @@ fn supervised_exec_control_duplicate_start_preserves_active_nonce() {
 }
 
 #[test]
+fn supervised_exec_duplicate_start_with_control_does_not_leak_registration() {
+    let (handle, mut host_stream) = start_guest_connection();
+
+    send_supervised_exec_start(
+        &mut host_stream,
+        210,
+        "sleep 60",
+        ExecTimeoutPolicy::None,
+        ExecOutputPolicy::Discard,
+        ExecControlPolicy::Disabled,
+    );
+    assert!(read_exec_started(&mut host_stream, 210) > 0);
+
+    send_supervised_exec_start(
+        &mut host_stream,
+        210,
+        "printf duplicate",
+        ExecTimeoutPolicy::None,
+        ExecOutputPolicy::Discard,
+        ExecControlPolicy::Enabled {
+            control_nonce: EXEC_CONTROL_NONCE,
+            sink: false,
+        },
+    );
+    assert_eq!(
+        read_error_response(&mut host_stream, 210),
+        "exec operation already active"
+    );
+
+    send_exec_control(
+        &mut host_stream,
+        313,
+        210,
+        EXEC_CONTROL_NONCE,
+        "message-duplicate-control",
+    );
+    assert_exec_control_result(
+        &mut host_stream,
+        313,
+        210,
+        EXEC_CONTROL_NONCE,
+        "message-duplicate-control",
+        ProcessControlStatus::Inactive,
+        "exec operation is not active",
+    );
+
+    send_exec_cancel(&mut host_stream, 210);
+    let (_chunks, result) = read_exec_result(&mut host_stream, 210);
+    assert_eq!(result.termination, ExecTermination::Cancelled);
+
+    finish_guest_connection(handle, host_stream);
+}
+
+#[test]
 fn supervised_exec_control_after_exit_returns_inactive() {
     let (handle, mut host_stream) = start_guest_connection();
 
@@ -656,22 +710,32 @@ fn supervised_exec_control_after_exit_returns_inactive() {
 
 #[test]
 fn supervised_exec_none_timeout_runs_until_cancelled() {
+    let pid_path = unique_pid_path("supervised-exec-cancel");
+    let mut child_guard = ProcessGroupFileGuard::new(pid_path.as_str());
     let (handle, mut host_stream) = start_guest_connection();
 
+    let command = format!("echo $$ > '{}'; sleep 60", pid_path.as_str());
     send_supervised_exec_start(
         &mut host_stream,
         205,
-        "sleep 60",
+        &command,
         ExecTimeoutPolicy::None,
         ExecOutputPolicy::Discard,
         ExecControlPolicy::Disabled,
     );
     assert!(read_exec_started(&mut host_stream, 205) > 0);
+    let pid = child_guard.read_pid();
+    assert!(
+        pid_alive(pid),
+        "supervised exec child should be running before cancel"
+    );
 
     send_exec_cancel(&mut host_stream, 205);
     let (_chunks, result) = read_exec_result(&mut host_stream, 205);
     assert_eq!(result.termination, ExecTermination::Cancelled);
     assert_eq!(result.stdout, None);
+    wait_for_pid_exit(pid, "supervised exec explicit cancel");
+    child_guard.disarm();
 
     finish_guest_connection(handle, host_stream);
 }

--- a/crates/vsock-guest/tests/connection/exec_operation.rs
+++ b/crates/vsock-guest/tests/connection/exec_operation.rs
@@ -5,13 +5,14 @@ use std::time::Duration;
 use vsock_proto::{
     self, ExecControlPolicy, ExecLifecyclePolicy, ExecOutputPolicy, ExecOutputStream,
     ExecStartEncodeRequest, ExecTermination, ExecTimeoutPolicy, MSG_ERROR, MSG_EXEC_CONTROL,
-    MSG_EXEC_CONTROL_RESULT, MSG_EXEC_RESULT, MSG_EXEC_START, MSG_EXEC_STARTED,
+    MSG_EXEC_CONTROL_RESULT, MSG_EXEC_OUTPUT, MSG_EXEC_RESULT, MSG_EXEC_START, MSG_EXEC_STARTED,
     MSG_OPERATIONS_QUIESCED, MSG_OPERATIONS_RESUMED, ProcessControlNonce, ProcessControlStatus,
 };
 
 use super::support::*;
 
 const EXEC_CONTROL_NONCE: ProcessControlNonce = *b"exec-ctrl-000001";
+const EXEC_CONTROL_WRONG_NONCE: ProcessControlNonce = *b"exec-ctrl-999999";
 
 fn send_supervised_exec_start(
     stream: &mut impl std::io::Write,
@@ -46,6 +47,16 @@ fn read_exec_started(stream: &mut impl std::io::Read, seq: u32) -> u32 {
     vsock_proto::decode_exec_started(&msg.payload).unwrap().pid
 }
 
+fn read_stdout_chunk(stream: &mut impl std::io::Read, seq: u32) -> Vec<u8> {
+    let msg = read_message(stream);
+    assert_eq!(msg.msg_type, MSG_EXEC_OUTPUT);
+    assert_eq!(msg.seq, seq);
+    let decoded = vsock_proto::decode_exec_output(&msg.payload).unwrap();
+    assert_eq!(decoded.stream, ExecOutputStream::Stdout);
+    assert!(!decoded.truncated);
+    decoded.chunk.to_vec()
+}
+
 fn send_exec_control(
     stream: &mut impl std::io::Write,
     request_seq: u32,
@@ -64,6 +75,8 @@ fn assert_exec_control_result(
     stream: &mut impl std::io::Read,
     request_seq: u32,
     expected_target_seq: u32,
+    expected_nonce: ProcessControlNonce,
+    expected_message_id: &str,
     expected_status: ProcessControlStatus,
     expected_diagnostic: &str,
 ) {
@@ -72,8 +85,8 @@ fn assert_exec_control_result(
     assert_eq!(msg.seq, request_seq);
     let decoded = vsock_proto::decode_exec_control_result(&msg.payload).unwrap();
     assert_eq!(decoded.target_seq, expected_target_seq);
-    assert_eq!(decoded.control_nonce, EXEC_CONTROL_NONCE);
-    assert_eq!(decoded.message_id, "message");
+    assert_eq!(decoded.control_nonce, expected_nonce);
+    assert_eq!(decoded.message_id, expected_message_id);
     assert_eq!(decoded.status, expected_status);
     assert_eq!(decoded.diagnostic, expected_diagnostic);
 }
@@ -297,7 +310,11 @@ fn supervised_exec_control_forwards_to_bootstrap_sink() {
             env: &[(process_control_ipc::BOOTSTRAP_ENV, "stale-endpoint")],
             sudo: false,
             label: "supervised-test",
-            stdout: ExecOutputPolicy::Capture { limit_bytes: 1024 },
+            stdout: ExecOutputPolicy::CaptureAndStream {
+                capture_limit_bytes: 1024,
+                stream_limit_bytes: 1024,
+                chunk_limit_bytes: 1024,
+            },
             stderr: ExecOutputPolicy::Capture { limit_bytes: 1024 },
             expected_exit_codes: &[],
             control: ExecControlPolicy::Enabled {
@@ -307,6 +324,10 @@ fn supervised_exec_control_forwards_to_bootstrap_sink() {
         },
     );
     assert!(read_exec_started(&mut host_stream, target_seq) > 0);
+    assert_eq!(
+        read_stdout_chunk(&mut host_stream, target_seq),
+        endpoint.as_bytes()
+    );
 
     let client_endpoint = endpoint.clone();
     let client = thread::spawn(move || {
@@ -337,6 +358,8 @@ fn supervised_exec_control_forwards_to_bootstrap_sink() {
         &mut host_stream,
         303,
         target_seq,
+        EXEC_CONTROL_NONCE,
+        "message",
         ProcessControlStatus::Delivered,
         "ok",
     );
@@ -372,6 +395,8 @@ fn supervised_exec_control_reports_unsupported_without_sink() {
         &mut host_stream,
         304,
         204,
+        EXEC_CONTROL_NONCE,
+        "message",
         ProcessControlStatus::Unsupported,
         "exec control sink is not configured",
     );
@@ -379,6 +404,126 @@ fn supervised_exec_control_reports_unsupported_without_sink() {
     send_exec_cancel(&mut host_stream, 204);
     let (_chunks, result) = read_exec_result(&mut host_stream, 204);
     assert_eq!(result.termination, ExecTermination::Cancelled);
+
+    finish_guest_connection(handle, host_stream);
+}
+
+#[test]
+fn supervised_exec_control_duplicate_start_preserves_active_nonce() {
+    let (handle, mut host_stream) = start_guest_connection();
+
+    send_supervised_exec_start(
+        &mut host_stream,
+        206,
+        "sleep 60",
+        ExecTimeoutPolicy::None,
+        ExecOutputPolicy::Discard,
+        ExecControlPolicy::Enabled {
+            control_nonce: EXEC_CONTROL_NONCE,
+            sink: false,
+        },
+    );
+    assert!(read_exec_started(&mut host_stream, 206) > 0);
+
+    send_supervised_exec_start(
+        &mut host_stream,
+        206,
+        "printf duplicate",
+        ExecTimeoutPolicy::None,
+        ExecOutputPolicy::Discard,
+        ExecControlPolicy::Enabled {
+            control_nonce: EXEC_CONTROL_WRONG_NONCE,
+            sink: false,
+        },
+    );
+    assert_eq!(
+        read_error_response(&mut host_stream, 206),
+        "exec operation already active"
+    );
+
+    send_exec_control(
+        &mut host_stream,
+        306,
+        206,
+        EXEC_CONTROL_WRONG_NONCE,
+        "message-wrong-nonce",
+    );
+    assert_exec_control_result(
+        &mut host_stream,
+        306,
+        206,
+        EXEC_CONTROL_WRONG_NONCE,
+        "message-wrong-nonce",
+        ProcessControlStatus::NonceMismatch,
+        "exec operation nonce mismatch",
+    );
+
+    send_exec_control(
+        &mut host_stream,
+        307,
+        206,
+        EXEC_CONTROL_NONCE,
+        "message-original-nonce",
+    );
+    assert_exec_control_result(
+        &mut host_stream,
+        307,
+        206,
+        EXEC_CONTROL_NONCE,
+        "message-original-nonce",
+        ProcessControlStatus::Unsupported,
+        "exec control sink is not configured",
+    );
+
+    send_exec_cancel(&mut host_stream, 206);
+    let (_chunks, result) = read_exec_result(&mut host_stream, 206);
+    assert_eq!(result.termination, ExecTermination::Cancelled);
+
+    send_quiesce_operations(&mut host_stream, 308);
+    let quiesced = read_message(&mut host_stream);
+    assert_eq!(quiesced.msg_type, MSG_OPERATIONS_QUIESCED);
+    assert_eq!(quiesced.seq, 308);
+    assert!(quiesced.payload.is_empty());
+
+    finish_guest_connection(handle, host_stream);
+}
+
+#[test]
+fn supervised_exec_control_after_exit_returns_inactive() {
+    let (handle, mut host_stream) = start_guest_connection();
+
+    send_supervised_exec_start(
+        &mut host_stream,
+        207,
+        "printf done",
+        ExecTimeoutPolicy::Duration { timeout_ms: 5000 },
+        ExecOutputPolicy::Capture { limit_bytes: 1024 },
+        ExecControlPolicy::Enabled {
+            control_nonce: EXEC_CONTROL_NONCE,
+            sink: false,
+        },
+    );
+    assert!(read_exec_started(&mut host_stream, 207) > 0);
+    let (_chunks, result) = read_exec_result(&mut host_stream, 207);
+    assert_eq!(result.termination, ExecTermination::Exited { exit_code: 0 });
+    assert_eq!(result.stdout, Some(b"done".to_vec()));
+
+    send_exec_control(
+        &mut host_stream,
+        309,
+        207,
+        EXEC_CONTROL_NONCE,
+        "message-after-exit",
+    );
+    assert_exec_control_result(
+        &mut host_stream,
+        309,
+        207,
+        EXEC_CONTROL_NONCE,
+        "message-after-exit",
+        ProcessControlStatus::Inactive,
+        "exec operation is not active",
+    );
 
     finish_guest_connection(handle, host_stream);
 }
@@ -989,7 +1134,7 @@ fn exec_operation_unknown_cancel_is_ignored() {
 }
 
 #[test]
-fn exec_operation_seq_zero_start_and_cancel_return_error() {
+fn exec_operation_seq_zero_start_cancel_and_control_return_error() {
     let (handle, mut host_stream) = start_guest_connection();
 
     send_exec_start(
@@ -1015,6 +1160,16 @@ fn exec_operation_seq_zero_start_and_cancel_return_error() {
     assert_eq!(cancel_error.seq, 0);
     assert!(
         vsock_proto::decode_error(&cancel_error.payload)
+            .unwrap()
+            .contains("non-zero sequence")
+    );
+
+    send_exec_control(&mut host_stream, 0, 1, EXEC_CONTROL_NONCE, "message-zero");
+    let control_error = read_message(&mut host_stream);
+    assert_eq!(control_error.msg_type, MSG_ERROR);
+    assert_eq!(control_error.seq, 0);
+    assert!(
+        vsock_proto::decode_error(&control_error.payload)
             .unwrap()
             .contains("non-zero sequence")
     );

--- a/crates/vsock-guest/tests/connection/exec_operation.rs
+++ b/crates/vsock-guest/tests/connection/exec_operation.rs
@@ -1,13 +1,96 @@
 use std::io::Write;
-use std::time::Duration;
+use std::thread;
+use std::time::{Duration, Instant};
 
 use vsock_proto::{
     self, ExecControlPolicy, ExecLifecyclePolicy, ExecOutputPolicy, ExecOutputStream,
-    ExecTermination, ExecTimeoutPolicy, MSG_ERROR, MSG_EXEC_START, MSG_OPERATIONS_QUIESCED,
-    MSG_OPERATIONS_RESUMED,
+    ExecStartEncodeRequest, ExecTermination, ExecTimeoutPolicy, MSG_ERROR, MSG_EXEC_CONTROL,
+    MSG_EXEC_CONTROL_RESULT, MSG_EXEC_RESULT, MSG_EXEC_START, MSG_EXEC_STARTED,
+    MSG_OPERATIONS_QUIESCED, MSG_OPERATIONS_RESUMED, ProcessControlNonce, ProcessControlStatus,
 };
 
 use super::support::*;
+
+const EXEC_CONTROL_NONCE: ProcessControlNonce = *b"exec-ctrl-000001";
+
+fn send_supervised_exec_start(
+    stream: &mut impl std::io::Write,
+    seq: u32,
+    command: &str,
+    timeout: ExecTimeoutPolicy,
+    stdout: ExecOutputPolicy,
+    control: ExecControlPolicy,
+) {
+    send_exec_start_request(
+        stream,
+        seq,
+        ExecStartEncodeRequest {
+            lifecycle: ExecLifecyclePolicy::Supervised,
+            timeout,
+            command,
+            env: &[],
+            sudo: false,
+            label: "supervised-test",
+            stdout,
+            stderr: ExecOutputPolicy::Capture { limit_bytes: 1024 },
+            expected_exit_codes: &[],
+            control,
+        },
+    );
+}
+
+fn read_exec_started(stream: &mut impl std::io::Read, seq: u32) -> u32 {
+    let msg = read_message(stream);
+    assert_eq!(msg.msg_type, MSG_EXEC_STARTED);
+    assert_eq!(msg.seq, seq);
+    vsock_proto::decode_exec_started(&msg.payload).unwrap().pid
+}
+
+fn send_exec_control(
+    stream: &mut impl std::io::Write,
+    request_seq: u32,
+    target_seq: u32,
+    control_nonce: ProcessControlNonce,
+    message_id: &str,
+) {
+    let payload =
+        vsock_proto::encode_exec_control(target_seq, control_nonce, message_id, b"payload", 5000)
+            .unwrap();
+    let msg = vsock_proto::encode(MSG_EXEC_CONTROL, request_seq, &payload).unwrap();
+    stream.write_all(&msg).unwrap();
+}
+
+fn assert_exec_control_result(
+    stream: &mut impl std::io::Read,
+    request_seq: u32,
+    expected_target_seq: u32,
+    expected_status: ProcessControlStatus,
+    expected_diagnostic: &str,
+) {
+    let msg = read_message(stream);
+    assert_eq!(msg.msg_type, MSG_EXEC_CONTROL_RESULT);
+    assert_eq!(msg.seq, request_seq);
+    let decoded = vsock_proto::decode_exec_control_result(&msg.payload).unwrap();
+    assert_eq!(decoded.target_seq, expected_target_seq);
+    assert_eq!(decoded.control_nonce, EXEC_CONTROL_NONCE);
+    assert_eq!(decoded.message_id, "message");
+    assert_eq!(decoded.status, expected_status);
+    assert_eq!(decoded.diagnostic, expected_diagnostic);
+}
+
+fn wait_for_file(path: &str) -> String {
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        match std::fs::read_to_string(path) {
+            Ok(value) if !value.is_empty() => return value,
+            Ok(_) | Err(_) if Instant::now() < deadline => {
+                thread::sleep(Duration::from_millis(10));
+            }
+            Ok(_) => panic!("file remained empty: {path}"),
+            Err(error) => panic!("file was not created before deadline: {path}: {error}"),
+        }
+    }
+}
 
 #[test]
 fn exec_operation_capture_only_stdout_stderr_success() {
@@ -69,33 +152,12 @@ fn exec_operation_expected_nonzero_exit_still_returns_result() {
 }
 
 #[test]
-fn exec_operation_rejects_unsupported_start_policies() {
+fn exec_operation_rejects_invalid_one_shot_start_policies() {
     let (handle, mut host_stream) = start_guest_connection();
 
     send_exec_start_request(
         &mut host_stream,
         103,
-        vsock_proto::ExecStartEncodeRequest {
-            lifecycle: ExecLifecyclePolicy::Supervised,
-            timeout: ExecTimeoutPolicy::Duration { timeout_ms: 5000 },
-            command: "printf should-not-run",
-            env: &[],
-            sudo: false,
-            label: "test",
-            stdout: ExecOutputPolicy::Discard,
-            stderr: ExecOutputPolicy::Discard,
-            expected_exit_codes: &[],
-            control: ExecControlPolicy::Disabled,
-        },
-    );
-    assert_eq!(
-        read_error_response(&mut host_stream, 103),
-        "exec supervised lifecycle is not supported"
-    );
-
-    send_exec_start_request(
-        &mut host_stream,
-        104,
         vsock_proto::ExecStartEncodeRequest {
             lifecycle: ExecLifecyclePolicy::OneShot,
             timeout: ExecTimeoutPolicy::None,
@@ -110,8 +172,8 @@ fn exec_operation_rejects_unsupported_start_policies() {
         },
     );
     assert_eq!(
-        read_error_response(&mut host_stream, 104),
-        "exec timeout policy none is not supported"
+        read_error_response(&mut host_stream, 103),
+        "exec timeout policy none requires supervised lifecycle"
     );
 
     let mut zero_timeout_payload = vsock_proto::encode_exec_start(
@@ -125,10 +187,10 @@ fn exec_operation_rejects_unsupported_start_policies() {
     )
     .unwrap();
     zero_timeout_payload[2..6].copy_from_slice(&0u32.to_be_bytes());
-    let zero_timeout_msg = vsock_proto::encode(MSG_EXEC_START, 109, &zero_timeout_payload).unwrap();
+    let zero_timeout_msg = vsock_proto::encode(MSG_EXEC_START, 104, &zero_timeout_payload).unwrap();
     host_stream.write_all(&zero_timeout_msg).unwrap();
     assert_eq!(
-        read_error_response(&mut host_stream, 109),
+        read_error_response(&mut host_stream, 104),
         "invalid payload: exec start timeout duration must be positive"
     );
 
@@ -153,7 +215,7 @@ fn exec_operation_rejects_unsupported_start_policies() {
     );
     assert_eq!(
         read_error_response(&mut host_stream, 105),
-        "exec control policy is not supported"
+        "exec control policy requires supervised lifecycle"
     );
 
     send_quiesce_operations(&mut host_stream, 106);
@@ -180,6 +242,166 @@ fn exec_operation_rejects_unsupported_start_policies() {
     assert!(chunks.is_empty());
     assert_eq!(result.termination, ExecTermination::Exited { exit_code: 0 });
     assert_eq!(result.stdout, Some(b"ok".to_vec()));
+
+    finish_guest_connection(handle, host_stream);
+}
+
+#[test]
+fn supervised_exec_sends_started_before_output() {
+    let (handle, mut host_stream) = start_guest_connection();
+
+    send_supervised_exec_start(
+        &mut host_stream,
+        201,
+        "printf ready",
+        ExecTimeoutPolicy::Duration { timeout_ms: 5000 },
+        ExecOutputPolicy::Stream {
+            limit_bytes: 1024,
+            chunk_limit_bytes: 1024,
+        },
+        ExecControlPolicy::Disabled,
+    );
+
+    assert!(read_exec_started(&mut host_stream, 201) > 0);
+    let (chunks, result) = read_exec_result(&mut host_stream, 201);
+
+    assert_eq!(result.termination, ExecTermination::Exited { exit_code: 0 });
+    assert_eq!(stdout_data(&chunks), b"ready".to_vec());
+
+    finish_guest_connection(handle, host_stream);
+}
+
+#[test]
+fn supervised_exec_spawn_failure_returns_start_failed_without_started_ack() {
+    let (handle, mut host_stream) = start_guest_connection();
+
+    send_supervised_exec_start(
+        &mut host_stream,
+        202,
+        "bad\0command",
+        ExecTimeoutPolicy::None,
+        ExecOutputPolicy::Capture { limit_bytes: 1024 },
+        ExecControlPolicy::Disabled,
+    );
+
+    let msg = read_message(&mut host_stream);
+    assert_eq!(msg.msg_type, MSG_EXEC_RESULT);
+    assert_eq!(msg.seq, 202);
+    let result = vsock_proto::decode_exec_result(&msg.payload).unwrap();
+    assert_eq!(result.termination, ExecTermination::StartFailed);
+    assert!(result.diagnostic.contains("Failed to execute"));
+
+    finish_guest_connection(handle, host_stream);
+}
+
+#[test]
+fn supervised_exec_control_forwards_to_bootstrap_sink() {
+    let endpoint_path = unique_tmp_path("supervised-exec-control-endpoint", ".txt");
+    let command = format!(
+        "printf '%s' \"$VM0_PROCESS_CONTROL_ENDPOINT\" > '{}'; sleep 60",
+        endpoint_path.as_str()
+    );
+    let (handle, mut host_stream) = start_guest_connection();
+
+    send_supervised_exec_start(
+        &mut host_stream,
+        203,
+        &command,
+        ExecTimeoutPolicy::None,
+        ExecOutputPolicy::Discard,
+        ExecControlPolicy::Enabled {
+            control_nonce: EXEC_CONTROL_NONCE,
+            sink: true,
+        },
+    );
+    assert!(read_exec_started(&mut host_stream, 203) > 0);
+
+    let endpoint = wait_for_file(endpoint_path.as_str());
+    let client = thread::spawn(move || {
+        let mut stream = process_control_ipc::connect_abstract(&endpoint).unwrap();
+        process_control_ipc::write_hello(&mut stream).unwrap();
+        let request = process_control_ipc::read_request(&mut stream).unwrap();
+        assert_eq!(request.message_id, "message");
+        assert_eq!(request.payload, b"payload");
+        process_control_ipc::write_response(
+            &mut stream,
+            &process_control_ipc::ControlResponse {
+                message_id: request.message_id,
+                status: process_control_ipc::ControlResponseStatus::Accepted,
+                diagnostic: "ok".to_owned(),
+            },
+        )
+        .unwrap();
+    });
+
+    send_exec_control(&mut host_stream, 303, 203, EXEC_CONTROL_NONCE, "message");
+    assert_exec_control_result(
+        &mut host_stream,
+        303,
+        203,
+        ProcessControlStatus::Delivered,
+        "ok",
+    );
+    client.join().unwrap();
+
+    send_exec_cancel(&mut host_stream, 203);
+    let (_chunks, result) = read_exec_result(&mut host_stream, 203);
+    assert_eq!(result.termination, ExecTermination::Cancelled);
+
+    finish_guest_connection(handle, host_stream);
+}
+
+#[test]
+fn supervised_exec_control_reports_unsupported_without_sink() {
+    let (handle, mut host_stream) = start_guest_connection();
+
+    send_supervised_exec_start(
+        &mut host_stream,
+        204,
+        "sleep 60",
+        ExecTimeoutPolicy::None,
+        ExecOutputPolicy::Discard,
+        ExecControlPolicy::Enabled {
+            control_nonce: EXEC_CONTROL_NONCE,
+            sink: false,
+        },
+    );
+    assert!(read_exec_started(&mut host_stream, 204) > 0);
+
+    send_exec_control(&mut host_stream, 304, 204, EXEC_CONTROL_NONCE, "message");
+    assert_exec_control_result(
+        &mut host_stream,
+        304,
+        204,
+        ProcessControlStatus::Unsupported,
+        "exec control sink is not configured",
+    );
+
+    send_exec_cancel(&mut host_stream, 204);
+    let (_chunks, result) = read_exec_result(&mut host_stream, 204);
+    assert_eq!(result.termination, ExecTermination::Cancelled);
+
+    finish_guest_connection(handle, host_stream);
+}
+
+#[test]
+fn supervised_exec_none_timeout_runs_until_cancelled() {
+    let (handle, mut host_stream) = start_guest_connection();
+
+    send_supervised_exec_start(
+        &mut host_stream,
+        205,
+        "sleep 60",
+        ExecTimeoutPolicy::None,
+        ExecOutputPolicy::Discard,
+        ExecControlPolicy::Disabled,
+    );
+    assert!(read_exec_started(&mut host_stream, 205) > 0);
+
+    send_exec_cancel(&mut host_stream, 205);
+    let (_chunks, result) = read_exec_result(&mut host_stream, 205);
+    assert_eq!(result.termination, ExecTermination::Cancelled);
+    assert_eq!(result.stdout, None);
 
     finish_guest_connection(handle, host_stream);
 }

--- a/crates/vsock-guest/tests/connection/exec_operation.rs
+++ b/crates/vsock-guest/tests/connection/exec_operation.rs
@@ -1410,16 +1410,23 @@ fn exec_operation_returns_when_orphaned_grandchild_holds_stdout() {
 fn exec_operation_captures_grandchild_output_before_drain_deadline() {
     use std::time::Instant;
 
+    let fifo_path = unique_tmp_path("exec-operation-grandchild-output", ".fifo");
     let (handle, mut host_stream) = start_guest_connection();
     host_stream
         .set_read_timeout(Some(Duration::from_secs(8)))
         .unwrap();
 
+    let command = format!(
+        "mkfifo '{}'; {{ cat '{}' >/dev/null; echo stdout-late; echo stderr-late >&2; }} & exec 3>'{}'; echo stdout-early; echo stderr-early >&2",
+        fifo_path.as_str(),
+        fifo_path.as_str(),
+        fifo_path.as_str()
+    );
     let start = Instant::now();
     send_exec_start(
         &mut host_stream,
         123,
-        "echo stdout-early; echo stderr-early >&2; { sleep 1; echo stdout-late; echo stderr-late >&2; } &",
+        &command,
         LONG_RUNNING_EXEC_TIMEOUT_MS,
         ExecOutputPolicy::Capture { limit_bytes: 1024 },
         ExecOutputPolicy::Capture { limit_bytes: 1024 },

--- a/crates/vsock-guest/tests/connection/exec_operation.rs
+++ b/crates/vsock-guest/tests/connection/exec_operation.rs
@@ -21,6 +21,10 @@ fn unique_exec_control_nonce(seed: u64) -> ProcessControlNonce {
     nonce
 }
 
+fn sleep_command_with_pid(pid_path: &str) -> String {
+    format!("printf '%s' \"$$\" > '{pid_path}'; sleep 60")
+}
+
 fn send_supervised_exec_start(
     stream: &mut impl std::io::Write,
     seq: u32,
@@ -351,10 +355,15 @@ fn supervised_exec_control_spawn_failure_releases_registration() {
 
 #[test]
 fn supervised_exec_control_forwards_to_bootstrap_sink() {
+    let pid_path = unique_pid_path("supervised-exec-bootstrap-sink");
+    let mut child_guard = ProcessGroupFileGuard::new(pid_path.as_str());
     let target_seq = 203;
     let control_nonce = unique_exec_control_nonce(u64::from(target_seq));
     let endpoint = process_control_ipc::endpoint_name(target_seq, &control_nonce);
-    let command = "printf '%s' \"$VM0_PROCESS_CONTROL_ENDPOINT\"; sleep 60";
+    let command = format!(
+        "printf '%s' \"$$\" > '{}'; printf '%s' \"$VM0_PROCESS_CONTROL_ENDPOINT\"; sleep 60",
+        pid_path.as_str()
+    );
     let (handle, mut host_stream) = start_guest_connection();
 
     send_exec_start_request(
@@ -363,7 +372,7 @@ fn supervised_exec_control_forwards_to_bootstrap_sink() {
         ExecStartEncodeRequest {
             lifecycle: ExecLifecyclePolicy::Supervised,
             timeout: ExecTimeoutPolicy::None,
-            command,
+            command: &command,
             env: &[(process_control_ipc::BOOTSTRAP_ENV, "stale-endpoint")],
             sudo: false,
             label: "supervised-test",
@@ -381,6 +390,7 @@ fn supervised_exec_control_forwards_to_bootstrap_sink() {
         },
     );
     assert!(read_exec_started(&mut host_stream, target_seq) > 0);
+    let pid = child_guard.read_pid();
     assert_eq!(
         read_stdout_chunk(&mut host_stream, target_seq),
         endpoint.as_bytes()
@@ -420,18 +430,23 @@ fn supervised_exec_control_forwards_to_bootstrap_sink() {
     let (_chunks, result) = read_exec_result(&mut host_stream, target_seq);
     assert_eq!(result.termination, ExecTermination::Cancelled);
     assert_eq!(result.stdout, Some(endpoint.into_bytes()));
+    wait_for_pid_exit(pid, "supervised exec bootstrap sink cleanup");
+    child_guard.disarm();
 
     finish_guest_connection(handle, host_stream);
 }
 
 #[test]
 fn supervised_exec_control_reports_unsupported_without_sink() {
+    let pid_path = unique_pid_path("supervised-exec-unsupported-control");
+    let mut child_guard = ProcessGroupFileGuard::new(pid_path.as_str());
     let (handle, mut host_stream) = start_guest_connection();
+    let command = sleep_command_with_pid(pid_path.as_str());
 
     send_supervised_exec_start(
         &mut host_stream,
         204,
-        "sleep 60",
+        &command,
         ExecTimeoutPolicy::None,
         ExecOutputPolicy::Discard,
         ExecControlPolicy::Enabled {
@@ -440,6 +455,7 @@ fn supervised_exec_control_reports_unsupported_without_sink() {
         },
     );
     assert!(read_exec_started(&mut host_stream, 204) > 0);
+    let pid = child_guard.read_pid();
 
     send_exec_control(&mut host_stream, 304, 204, EXEC_CONTROL_NONCE, "message");
     assert_exec_control_result(
@@ -455,19 +471,27 @@ fn supervised_exec_control_reports_unsupported_without_sink() {
     send_exec_cancel(&mut host_stream, 204);
     let (_chunks, result) = read_exec_result(&mut host_stream, 204);
     assert_eq!(result.termination, ExecTermination::Cancelled);
+    wait_for_pid_exit(pid, "supervised exec unsupported control cleanup");
+    child_guard.disarm();
 
     finish_guest_connection(handle, host_stream);
 }
 
 #[test]
 fn supervised_exec_control_registries_are_isolated_per_connection() {
+    let first_pid_path = unique_pid_path("supervised-exec-first-isolated");
+    let second_pid_path = unique_pid_path("supervised-exec-second-isolated");
+    let mut first_child_guard = ProcessGroupFileGuard::new(first_pid_path.as_str());
+    let mut second_child_guard = ProcessGroupFileGuard::new(second_pid_path.as_str());
     let (first_handle, mut first_stream) = start_guest_connection();
     let (second_handle, mut second_stream) = start_guest_connection();
+    let first_command = sleep_command_with_pid(first_pid_path.as_str());
+    let second_command = sleep_command_with_pid(second_pid_path.as_str());
 
     send_supervised_exec_start(
         &mut first_stream,
         209,
-        "sleep 60",
+        &first_command,
         ExecTimeoutPolicy::None,
         ExecOutputPolicy::Discard,
         ExecControlPolicy::Enabled {
@@ -478,7 +502,7 @@ fn supervised_exec_control_registries_are_isolated_per_connection() {
     send_supervised_exec_start(
         &mut second_stream,
         209,
-        "sleep 60",
+        &second_command,
         ExecTimeoutPolicy::None,
         ExecOutputPolicy::Discard,
         ExecControlPolicy::Enabled {
@@ -489,6 +513,8 @@ fn supervised_exec_control_registries_are_isolated_per_connection() {
 
     assert!(read_exec_started(&mut first_stream, 209) > 0);
     assert!(read_exec_started(&mut second_stream, 209) > 0);
+    let first_pid = first_child_guard.read_pid();
+    let second_pid = second_child_guard.read_pid();
 
     send_exec_control(
         &mut first_stream,
@@ -531,6 +557,10 @@ fn supervised_exec_control_registries_are_isolated_per_connection() {
     let (_chunks, second_result) = read_exec_result(&mut second_stream, 209);
     assert_eq!(first_result.termination, ExecTermination::Cancelled);
     assert_eq!(second_result.termination, ExecTermination::Cancelled);
+    wait_for_pid_exit(first_pid, "first supervised exec isolation cleanup");
+    wait_for_pid_exit(second_pid, "second supervised exec isolation cleanup");
+    first_child_guard.disarm();
+    second_child_guard.disarm();
 
     finish_guest_connection(first_handle, first_stream);
     finish_guest_connection(second_handle, second_stream);
@@ -538,12 +568,15 @@ fn supervised_exec_control_registries_are_isolated_per_connection() {
 
 #[test]
 fn supervised_exec_control_duplicate_start_preserves_active_nonce() {
+    let pid_path = unique_pid_path("supervised-exec-duplicate-control");
+    let mut child_guard = ProcessGroupFileGuard::new(pid_path.as_str());
     let (handle, mut host_stream) = start_guest_connection();
+    let command = sleep_command_with_pid(pid_path.as_str());
 
     send_supervised_exec_start(
         &mut host_stream,
         206,
-        "sleep 60",
+        &command,
         ExecTimeoutPolicy::None,
         ExecOutputPolicy::Discard,
         ExecControlPolicy::Enabled {
@@ -552,6 +585,7 @@ fn supervised_exec_control_duplicate_start_preserves_active_nonce() {
         },
     );
     assert!(read_exec_started(&mut host_stream, 206) > 0);
+    let pid = child_guard.read_pid();
 
     send_supervised_exec_start(
         &mut host_stream,
@@ -606,6 +640,8 @@ fn supervised_exec_control_duplicate_start_preserves_active_nonce() {
     send_exec_cancel(&mut host_stream, 206);
     let (_chunks, result) = read_exec_result(&mut host_stream, 206);
     assert_eq!(result.termination, ExecTermination::Cancelled);
+    wait_for_pid_exit(pid, "supervised exec duplicate control cleanup");
+    child_guard.disarm();
 
     send_quiesce_operations(&mut host_stream, 308);
     let quiesced = read_message(&mut host_stream);
@@ -618,17 +654,21 @@ fn supervised_exec_control_duplicate_start_preserves_active_nonce() {
 
 #[test]
 fn supervised_exec_duplicate_start_with_control_does_not_leak_registration() {
+    let pid_path = unique_pid_path("supervised-exec-duplicate-registration");
+    let mut child_guard = ProcessGroupFileGuard::new(pid_path.as_str());
     let (handle, mut host_stream) = start_guest_connection();
+    let command = sleep_command_with_pid(pid_path.as_str());
 
     send_supervised_exec_start(
         &mut host_stream,
         210,
-        "sleep 60",
+        &command,
         ExecTimeoutPolicy::None,
         ExecOutputPolicy::Discard,
         ExecControlPolicy::Disabled,
     );
     assert!(read_exec_started(&mut host_stream, 210) > 0);
+    let pid = child_guard.read_pid();
 
     send_supervised_exec_start(
         &mut host_stream,
@@ -666,6 +706,8 @@ fn supervised_exec_duplicate_start_with_control_does_not_leak_registration() {
     send_exec_cancel(&mut host_stream, 210);
     let (_chunks, result) = read_exec_result(&mut host_stream, 210);
     assert_eq!(result.termination, ExecTermination::Cancelled);
+    wait_for_pid_exit(pid, "supervised exec duplicate registration cleanup");
+    child_guard.disarm();
 
     finish_guest_connection(handle, host_stream);
 }

--- a/crates/vsock-guest/tests/connection/exec_operation.rs
+++ b/crates/vsock-guest/tests/connection/exec_operation.rs
@@ -1,6 +1,6 @@
 use std::io::Write;
 use std::thread;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use vsock_proto::{
     self, ExecControlPolicy, ExecLifecyclePolicy, ExecOutputPolicy, ExecOutputStream,
@@ -76,20 +76,6 @@ fn assert_exec_control_result(
     assert_eq!(decoded.message_id, "message");
     assert_eq!(decoded.status, expected_status);
     assert_eq!(decoded.diagnostic, expected_diagnostic);
-}
-
-fn wait_for_file(path: &str) -> String {
-    let deadline = Instant::now() + Duration::from_secs(5);
-    loop {
-        match std::fs::read_to_string(path) {
-            Ok(value) if !value.is_empty() => return value,
-            Ok(_) | Err(_) if Instant::now() < deadline => {
-                thread::sleep(Duration::from_millis(10));
-            }
-            Ok(_) => panic!("file remained empty: {path}"),
-            Err(error) => panic!("file was not created before deadline: {path}: {error}"),
-        }
-    }
 }
 
 #[test]
@@ -296,29 +282,35 @@ fn supervised_exec_spawn_failure_returns_start_failed_without_started_ack() {
 
 #[test]
 fn supervised_exec_control_forwards_to_bootstrap_sink() {
-    let endpoint_path = unique_tmp_path("supervised-exec-control-endpoint", ".txt");
-    let command = format!(
-        "printf '%s' \"$VM0_PROCESS_CONTROL_ENDPOINT\" > '{}'; sleep 60",
-        endpoint_path.as_str()
-    );
+    let target_seq = 203;
+    let endpoint = process_control_ipc::endpoint_name(target_seq, &EXEC_CONTROL_NONCE);
+    let command = "printf '%s' \"$VM0_PROCESS_CONTROL_ENDPOINT\"; sleep 60";
     let (handle, mut host_stream) = start_guest_connection();
 
-    send_supervised_exec_start(
+    send_exec_start_request(
         &mut host_stream,
-        203,
-        &command,
-        ExecTimeoutPolicy::None,
-        ExecOutputPolicy::Discard,
-        ExecControlPolicy::Enabled {
-            control_nonce: EXEC_CONTROL_NONCE,
-            sink: true,
+        target_seq,
+        ExecStartEncodeRequest {
+            lifecycle: ExecLifecyclePolicy::Supervised,
+            timeout: ExecTimeoutPolicy::None,
+            command,
+            env: &[(process_control_ipc::BOOTSTRAP_ENV, "stale-endpoint")],
+            sudo: false,
+            label: "supervised-test",
+            stdout: ExecOutputPolicy::Capture { limit_bytes: 1024 },
+            stderr: ExecOutputPolicy::Capture { limit_bytes: 1024 },
+            expected_exit_codes: &[],
+            control: ExecControlPolicy::Enabled {
+                control_nonce: EXEC_CONTROL_NONCE,
+                sink: true,
+            },
         },
     );
-    assert!(read_exec_started(&mut host_stream, 203) > 0);
+    assert!(read_exec_started(&mut host_stream, target_seq) > 0);
 
-    let endpoint = wait_for_file(endpoint_path.as_str());
+    let client_endpoint = endpoint.clone();
     let client = thread::spawn(move || {
-        let mut stream = process_control_ipc::connect_abstract(&endpoint).unwrap();
+        let mut stream = process_control_ipc::connect_abstract(&client_endpoint).unwrap();
         process_control_ipc::write_hello(&mut stream).unwrap();
         let request = process_control_ipc::read_request(&mut stream).unwrap();
         assert_eq!(request.message_id, "message");
@@ -334,19 +326,26 @@ fn supervised_exec_control_forwards_to_bootstrap_sink() {
         .unwrap();
     });
 
-    send_exec_control(&mut host_stream, 303, 203, EXEC_CONTROL_NONCE, "message");
+    send_exec_control(
+        &mut host_stream,
+        303,
+        target_seq,
+        EXEC_CONTROL_NONCE,
+        "message",
+    );
     assert_exec_control_result(
         &mut host_stream,
         303,
-        203,
+        target_seq,
         ProcessControlStatus::Delivered,
         "ok",
     );
     client.join().unwrap();
 
-    send_exec_cancel(&mut host_stream, 203);
-    let (_chunks, result) = read_exec_result(&mut host_stream, 203);
+    send_exec_cancel(&mut host_stream, target_seq);
+    let (_chunks, result) = read_exec_result(&mut host_stream, target_seq);
     assert_eq!(result.termination, ExecTermination::Cancelled);
+    assert_eq!(result.stdout, Some(endpoint.into_bytes()));
 
     finish_guest_connection(handle, host_stream);
 }

--- a/crates/vsock-guest/tests/connection/exec_operation.rs
+++ b/crates/vsock-guest/tests/connection/exec_operation.rs
@@ -294,6 +294,55 @@ fn supervised_exec_spawn_failure_returns_start_failed_without_started_ack() {
 }
 
 #[test]
+fn supervised_exec_control_spawn_failure_releases_registration() {
+    let (handle, mut host_stream) = start_guest_connection();
+
+    send_supervised_exec_start(
+        &mut host_stream,
+        208,
+        "bad\0command",
+        ExecTimeoutPolicy::None,
+        ExecOutputPolicy::Capture { limit_bytes: 1024 },
+        ExecControlPolicy::Enabled {
+            control_nonce: EXEC_CONTROL_NONCE,
+            sink: false,
+        },
+    );
+
+    let msg = read_message(&mut host_stream);
+    assert_eq!(msg.msg_type, MSG_EXEC_RESULT);
+    assert_eq!(msg.seq, 208);
+    let result = vsock_proto::decode_exec_result(&msg.payload).unwrap();
+    assert_eq!(result.termination, ExecTermination::StartFailed);
+    assert!(result.diagnostic.contains("Failed to execute"));
+
+    send_exec_control(
+        &mut host_stream,
+        310,
+        208,
+        EXEC_CONTROL_NONCE,
+        "message-after-start-failed",
+    );
+    assert_exec_control_result(
+        &mut host_stream,
+        310,
+        208,
+        EXEC_CONTROL_NONCE,
+        "message-after-start-failed",
+        ProcessControlStatus::Inactive,
+        "exec operation is not active",
+    );
+
+    send_quiesce_operations(&mut host_stream, 311);
+    let quiesced = read_message(&mut host_stream);
+    assert_eq!(quiesced.msg_type, MSG_OPERATIONS_QUIESCED);
+    assert_eq!(quiesced.seq, 311);
+    assert!(quiesced.payload.is_empty());
+
+    finish_guest_connection(handle, host_stream);
+}
+
+#[test]
 fn supervised_exec_control_forwards_to_bootstrap_sink() {
     let target_seq = 203;
     let endpoint = process_control_ipc::endpoint_name(target_seq, &EXEC_CONTROL_NONCE);

--- a/crates/vsock-guest/tests/connection/process_control.rs
+++ b/crates/vsock-guest/tests/connection/process_control.rs
@@ -8,6 +8,10 @@ use vsock_proto::{
 
 use super::support::*;
 
+fn sleep_command_with_pid(pid_path: &str) -> String {
+    format!("printf '%s' \"$$\" > '{pid_path}'; sleep 60")
+}
+
 #[test]
 fn process_messages_seq_zero_return_error() {
     const NONCE: vsock_proto::ProcessControlNonce = *b"0123456789abcdef";
@@ -43,6 +47,9 @@ fn process_control_validates_nonce_before_sink_dispatch() {
 
     const NONCE: vsock_proto::ProcessControlNonce = *b"0123456789abcdef";
 
+    let pid_path = unique_pid_path("process-control-nonce-validates");
+    let mut child_guard = ProcessGroupFileGuard::new(pid_path.as_str());
+    let command = sleep_command_with_pid(pid_path.as_str());
     let (guest_stream, mut host_stream) = StdUnixStream::pair().unwrap();
     let handle = thread::spawn(move || {
         let _ = handle_connection(guest_stream);
@@ -53,10 +60,11 @@ fn process_control_validates_nonce_before_sink_dispatch() {
         .set_read_timeout(Some(Duration::from_secs(5)))
         .unwrap();
 
-    send_spawn_process_with_control_nonce(&mut host_stream, 31, "sleep 60", NONCE);
+    send_spawn_process_with_control_nonce(&mut host_stream, 31, &command, NONCE);
     let result = read_message(&mut host_stream);
     assert_eq!(result.msg_type, MSG_SPAWN_PROCESS_RESULT);
     assert_eq!(result.seq, 31);
+    let pid = child_guard.read_pid();
 
     send_process_control(&mut host_stream, 32, 31, NONCE, "message-1");
     assert_process_control_result(
@@ -71,6 +79,8 @@ fn process_control_validates_nonce_before_sink_dispatch() {
 
     drop(host_stream);
     let _ = handle.join();
+    wait_for_pid_exit(pid, "process control nonce validation cleanup");
+    child_guard.disarm();
 }
 
 #[test]
@@ -80,6 +90,9 @@ fn process_control_rejects_nonce_mismatch() {
     const NONCE: vsock_proto::ProcessControlNonce = *b"0123456789abcdef";
     const WRONG_NONCE: vsock_proto::ProcessControlNonce = *b"fedcba9876543210";
 
+    let pid_path = unique_pid_path("process-control-nonce-mismatch");
+    let mut child_guard = ProcessGroupFileGuard::new(pid_path.as_str());
+    let command = sleep_command_with_pid(pid_path.as_str());
     let (guest_stream, mut host_stream) = StdUnixStream::pair().unwrap();
     let handle = thread::spawn(move || {
         let _ = handle_connection(guest_stream);
@@ -90,10 +103,11 @@ fn process_control_rejects_nonce_mismatch() {
         .set_read_timeout(Some(Duration::from_secs(5)))
         .unwrap();
 
-    send_spawn_process_with_control_nonce(&mut host_stream, 33, "sleep 60", NONCE);
+    send_spawn_process_with_control_nonce(&mut host_stream, 33, &command, NONCE);
     let result = read_message(&mut host_stream);
     assert_eq!(result.msg_type, MSG_SPAWN_PROCESS_RESULT);
     assert_eq!(result.seq, 33);
+    let pid = child_guard.read_pid();
 
     send_process_control(&mut host_stream, 34, 33, WRONG_NONCE, "message-2");
     assert_process_control_result(
@@ -108,6 +122,8 @@ fn process_control_rejects_nonce_mismatch() {
 
     drop(host_stream);
     let _ = handle.join();
+    wait_for_pid_exit(pid, "process control nonce mismatch cleanup");
+    child_guard.disarm();
 }
 
 #[test]
@@ -115,12 +131,16 @@ fn process_control_duplicate_spawn_seq_returns_error_without_replacing_active_no
     const NONCE: vsock_proto::ProcessControlNonce = *b"0123456789abcdef";
     const DUPLICATE_NONCE: vsock_proto::ProcessControlNonce = *b"fedcba9876543210";
 
+    let pid_path = unique_pid_path("process-control-duplicate-spawn");
+    let mut child_guard = ProcessGroupFileGuard::new(pid_path.as_str());
+    let command = sleep_command_with_pid(pid_path.as_str());
     let (handle, mut host_stream) = start_guest_connection();
 
-    send_spawn_process_with_control_nonce(&mut host_stream, 39, "sleep 60", NONCE);
+    send_spawn_process_with_control_nonce(&mut host_stream, 39, &command, NONCE);
     let result = read_message(&mut host_stream);
     assert_eq!(result.msg_type, MSG_SPAWN_PROCESS_RESULT);
     assert_eq!(result.seq, 39);
+    let pid = child_guard.read_pid();
 
     send_spawn_process_with_control_nonce(
         &mut host_stream,
@@ -146,16 +166,22 @@ fn process_control_duplicate_spawn_seq_returns_error_without_replacing_active_no
     );
 
     finish_guest_connection(handle, host_stream);
+    wait_for_pid_exit(pid, "process control duplicate spawn cleanup");
+    child_guard.disarm();
 }
 
 #[test]
 fn duplicate_spawn_seq_without_control_nonce_returns_error() {
+    let pid_path = unique_pid_path("process-control-duplicate-no-nonce");
+    let mut child_guard = ProcessGroupFileGuard::new(pid_path.as_str());
+    let command = sleep_command_with_pid(pid_path.as_str());
     let (handle, mut host_stream) = start_guest_connection();
 
-    send_spawn_process(&mut host_stream, 41, "sleep 60", None, 5000);
+    send_spawn_process(&mut host_stream, 41, &command, None, 5000);
     let result = read_message(&mut host_stream);
     assert_eq!(result.msg_type, MSG_SPAWN_PROCESS_RESULT);
     assert_eq!(result.seq, 41);
+    let pid = child_guard.read_pid();
 
     send_spawn_process(&mut host_stream, 41, "printf duplicate", None, 5000);
     let duplicate = read_message(&mut host_stream);
@@ -165,6 +191,8 @@ fn duplicate_spawn_seq_without_control_nonce_returns_error() {
     assert!(error.contains("already active"));
 
     finish_guest_connection(handle, host_stream);
+    wait_for_pid_exit(pid, "process control duplicate no nonce cleanup");
+    child_guard.disarm();
 }
 
 #[test]
@@ -227,6 +255,9 @@ fn process_control_without_registered_nonce_returns_inactive() {
 
     const NONCE: vsock_proto::ProcessControlNonce = *b"0123456789abcdef";
 
+    let pid_path = unique_pid_path("process-control-without-nonce");
+    let mut child_guard = ProcessGroupFileGuard::new(pid_path.as_str());
+    let command = sleep_command_with_pid(pid_path.as_str());
     let (guest_stream, mut host_stream) = StdUnixStream::pair().unwrap();
     let handle = thread::spawn(move || {
         let _ = handle_connection(guest_stream);
@@ -237,10 +268,11 @@ fn process_control_without_registered_nonce_returns_inactive() {
         .set_read_timeout(Some(Duration::from_secs(5)))
         .unwrap();
 
-    send_spawn_process(&mut host_stream, 37, "sleep 60", None, 5000);
+    send_spawn_process(&mut host_stream, 37, &command, None, 5000);
     let result = read_message(&mut host_stream);
     assert_eq!(result.msg_type, MSG_SPAWN_PROCESS_RESULT);
     assert_eq!(result.seq, 37);
+    let pid = child_guard.read_pid();
 
     send_process_control(&mut host_stream, 38, 37, NONCE, "message-4");
     assert_process_control_result(
@@ -255,6 +287,8 @@ fn process_control_without_registered_nonce_returns_inactive() {
 
     drop(host_stream);
     let _ = handle.join();
+    wait_for_pid_exit(pid, "process control without nonce cleanup");
+    child_guard.disarm();
 }
 
 #[test]

--- a/crates/vsock-guest/tests/connection/support.rs
+++ b/crates/vsock-guest/tests/connection/support.rs
@@ -733,7 +733,7 @@ fn process_group_has_live_member(pgid: u32) -> bool {
 pub(crate) fn pid_alive(pid: u32) -> bool {
     // SAFETY: `kill` with sig=0 is a no-op existence check.
     if unsafe { libc::kill(pid as i32, 0) != 0 } {
-        return false;
+        return process_group_has_live_member(pid);
     }
     match proc_stat(pid) {
         Some(stat) if stat.state == 'Z' => process_group_has_live_member(stat.pgid),
@@ -754,5 +754,40 @@ mod tests {
 
         assert_eq!(parsed.state, 'S');
         assert_eq!(parsed.pgid, 456);
+    }
+
+    #[test]
+    fn pid_alive_detects_live_group_after_leader_is_reaped() {
+        use std::os::unix::process::CommandExt;
+
+        let pid_path = unique_pid_path("reaped-leader-live-group");
+        let mut group_guard = ProcessGroupFileGuard::new(pid_path.as_str());
+        let mut child = std::process::Command::new("sh")
+            .arg("-c")
+            .arg(format!(
+                "printf '%s' \"$$\" > '{}'; sleep 30 & exit 0",
+                pid_path.as_str()
+            ))
+            .process_group(0)
+            .spawn()
+            .unwrap();
+        let pid = group_guard.read_pid();
+
+        child.wait().unwrap();
+
+        assert!(
+            pid_alive(pid),
+            "live process group should remain visible after leader is reaped"
+        );
+        kill_pid_group(pid);
+        let deadline = std::time::Instant::now() + Duration::from_secs(3);
+        while process_group_has_live_member(pid) {
+            assert!(
+                std::time::Instant::now() < deadline,
+                "cleanup should kill remaining process group members"
+            );
+            thread::sleep(Duration::from_millis(10));
+        }
+        group_guard.disarm();
     }
 }

--- a/crates/vsock-guest/tests/connection/support.rs
+++ b/crates/vsock-guest/tests/connection/support.rs
@@ -679,12 +679,17 @@ pub(crate) fn wait_for_pid_exit(pid: u32, context: &str) {
     }
 }
 
-/// Returns true iff `pid` is still a live (or zombie-but-unreaped) process
-/// the test owner has permission to signal. Implemented via `kill(pid, 0)`,
-/// the canonical existence check. After bash dies via SIGPIPE the kernel
-/// reaps it (we're not its parent — it was reparented to PID 1 when its
-/// process group died), so this transitions to false.
+fn pid_state(pid: u32) -> Option<char> {
+    let stat = std::fs::read_to_string(format!("/proc/{pid}/stat")).ok()?;
+    let state_start = stat.rfind(") ")? + 2;
+    stat[state_start..].chars().next()
+}
+
+/// Returns true iff `pid` is still running and signalable by the test owner.
+/// Zombie processes are already dead; some CI containers leave reparented
+/// zombies visible to `kill(pid, 0)` until PID 1 reaps them, so they must not
+/// keep cleanup assertions spinning.
 pub(crate) fn pid_alive(pid: u32) -> bool {
     // SAFETY: `kill` with sig=0 is a no-op existence check.
-    unsafe { libc::kill(pid as i32, 0) == 0 }
+    (unsafe { libc::kill(pid as i32, 0) == 0 }) && !matches!(pid_state(pid), Some('Z'))
 }

--- a/crates/vsock-guest/tests/connection/support.rs
+++ b/crates/vsock-guest/tests/connection/support.rs
@@ -679,17 +679,80 @@ pub(crate) fn wait_for_pid_exit(pid: u32, context: &str) {
     }
 }
 
-fn pid_state(pid: u32) -> Option<char> {
+#[derive(Clone, Copy)]
+struct ProcStat {
+    state: char,
+    pgid: u32,
+}
+
+fn parse_proc_stat(stat: &str) -> Option<ProcStat> {
+    let fields_start = stat.rfind(") ")? + 2;
+    let mut fields = stat[fields_start..].split_whitespace();
+    let state = fields.next()?.chars().next()?;
+    let _ppid = fields.next()?;
+    let pgid = fields.next()?.parse().ok()?;
+    Some(ProcStat { state, pgid })
+}
+
+fn proc_stat(pid: u32) -> Option<ProcStat> {
     let stat = std::fs::read_to_string(format!("/proc/{pid}/stat")).ok()?;
-    let state_start = stat.rfind(") ")? + 2;
-    stat[state_start..].chars().next()
+    parse_proc_stat(&stat)
+}
+
+fn process_group_has_live_member(pgid: u32) -> bool {
+    if pgid == 0 {
+        return false;
+    }
+    let Ok(entries) = std::fs::read_dir("/proc") else {
+        return true;
+    };
+    entries.filter_map(Result::ok).any(|entry| {
+        let file_name = entry.file_name();
+        let Some(pid_text) = file_name.to_str() else {
+            return false;
+        };
+        let Ok(pid) = pid_text.parse::<u32>() else {
+            return false;
+        };
+        let Some(stat) = proc_stat(pid) else {
+            return false;
+        };
+        if stat.pgid != pgid || stat.state == 'Z' {
+            return false;
+        }
+        // SAFETY: `kill` with sig=0 is a no-op existence check.
+        unsafe { libc::kill(pid as i32, 0) == 0 }
+    })
 }
 
 /// Returns true iff `pid` is still running and signalable by the test owner.
-/// Zombie processes are already dead; some CI containers leave reparented
-/// zombies visible to `kill(pid, 0)` until PID 1 reaps them, so they must not
-/// keep cleanup assertions spinning.
+/// Zombie leaders are dead, but their process group can still contain live
+/// children, so wait/cleanup only treat the group as exited once no live member
+/// remains. Some CI containers leave reparented zombies visible to
+/// `kill(pid, 0)` until PID 1 reaps them.
 pub(crate) fn pid_alive(pid: u32) -> bool {
     // SAFETY: `kill` with sig=0 is a no-op existence check.
-    (unsafe { libc::kill(pid as i32, 0) == 0 }) && !matches!(pid_state(pid), Some('Z'))
+    if unsafe { libc::kill(pid as i32, 0) != 0 } {
+        return false;
+    }
+    match proc_stat(pid) {
+        Some(stat) if stat.state == 'Z' => process_group_has_live_member(stat.pgid),
+        Some(_) => true,
+        None => true,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_proc_stat_handles_process_names_with_parentheses() {
+        let stat = "123 (name ) with parens) S 1 456 456 0 -1 4194304 1 2 3 4 5 6 7 8 20 0 1 0 0";
+
+        let parsed = parse_proc_stat(stat).unwrap();
+
+        assert_eq!(parsed.state, 'S');
+        assert_eq!(parsed.pgid, 456);
+    }
 }

--- a/crates/vsock-host/src/exec_operation.rs
+++ b/crates/vsock-host/src/exec_operation.rs
@@ -2308,6 +2308,8 @@ where
         }
         _ = tokio::time::sleep(request.start_timeout) => {
             let payload = vsock_proto::encode_exec_cancel();
+            shared.remove_operation(seq);
+            registration_guard.disarm();
             let cancel_result = tokio::time::timeout(
                 start_timeout_cancel_write_timeout,
                 write_frame(
@@ -2335,8 +2337,6 @@ where
                 ))
             });
             start_cancel_on_drop.disarm();
-            shared.remove_operation(seq);
-            registration_guard.disarm();
             cancel_result?;
             return Err(io::Error::new(
                 io::ErrorKind::TimedOut,

--- a/crates/vsock-host/src/exec_operation.rs
+++ b/crates/vsock-host/src/exec_operation.rs
@@ -2171,6 +2171,24 @@ async fn start_supervised_exec_on_shared_with_after_start_write<F>(
 where
     F: Future<Output = ()>,
 {
+    start_supervised_exec_on_shared_with_after_start_write_and_cancel_timeout(
+        shared,
+        request,
+        after_start_write,
+        EXEC_OPERATION_START_TIMEOUT_CANCEL_WRITE_TIMEOUT,
+    )
+    .await
+}
+
+async fn start_supervised_exec_on_shared_with_after_start_write_and_cancel_timeout<F>(
+    shared: &Arc<Shared>,
+    request: SupervisedExecRequest<'_>,
+    after_start_write: F,
+    start_timeout_cancel_write_timeout: Duration,
+) -> io::Result<SupervisedExecHandle>
+where
+    F: Future<Output = ()>,
+{
     let stream_queue_capacity = stream_queue_capacity_for(
         request.stdout,
         request.stderr,
@@ -2291,7 +2309,7 @@ where
         _ = tokio::time::sleep(request.start_timeout) => {
             let payload = vsock_proto::encode_exec_cancel();
             let cancel_result = tokio::time::timeout(
-                EXEC_OPERATION_START_TIMEOUT_CANCEL_WRITE_TIMEOUT,
+                start_timeout_cancel_write_timeout,
                 write_frame(
                     shared,
                     MSG_EXEC_CANCEL,
@@ -2601,12 +2619,18 @@ pub(crate) mod test_support {
         shared: &Arc<Shared>,
         request: SupervisedExecRequest<'_>,
         after_start_write: F,
+        start_timeout_cancel_write_timeout: Duration,
     ) -> io::Result<SupervisedExecHandle>
     where
         F: Future<Output = ()>,
     {
-        start_supervised_exec_on_shared_with_after_start_write(shared, request, after_start_write)
-            .await
+        start_supervised_exec_on_shared_with_after_start_write_and_cancel_timeout(
+            shared,
+            request,
+            after_start_write,
+            start_timeout_cancel_write_timeout,
+        )
+        .await
     }
 }
 

--- a/crates/vsock-host/src/exec_operation.rs
+++ b/crates/vsock-host/src/exec_operation.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::future::{Future, ready};
 use std::io;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU8, Ordering};
@@ -2153,6 +2154,17 @@ pub(crate) async fn start_supervised_exec_on_shared(
     shared: &Arc<Shared>,
     request: SupervisedExecRequest<'_>,
 ) -> io::Result<SupervisedExecHandle> {
+    start_supervised_exec_on_shared_with_after_start_write(shared, request, ready(())).await
+}
+
+async fn start_supervised_exec_on_shared_with_after_start_write<F>(
+    shared: &Arc<Shared>,
+    request: SupervisedExecRequest<'_>,
+    after_start_write: F,
+) -> io::Result<SupervisedExecHandle>
+where
+    F: Future<Output = ()>,
+{
     let stream_queue_capacity = stream_queue_capacity_for(
         request.stdout,
         request.stderr,
@@ -2250,6 +2262,7 @@ pub(crate) async fn start_supervised_exec_on_shared(
         start_cancel_on_drop.disarm();
         return Err(error);
     }
+    after_start_write.await;
 
     let pid = tokio::select! {
         biased;
@@ -2576,6 +2589,18 @@ pub(crate) mod test_support {
     pub(crate) fn drop_started_frame_write_guard(shared: Arc<Shared>) {
         let state = Arc::new(AtomicU8::new(EXEC_OPERATION_FRAME_WRITE_STARTED));
         drop(ExecOperationFrameWriteGuard::new(shared, state));
+    }
+
+    pub(crate) async fn start_supervised_exec_after_start_write<F>(
+        shared: &Arc<Shared>,
+        request: SupervisedExecRequest<'_>,
+        after_start_write: F,
+    ) -> io::Result<SupervisedExecHandle>
+    where
+        F: Future<Output = ()>,
+    {
+        start_supervised_exec_on_shared_with_after_start_write(shared, request, after_start_write)
+            .await
     }
 }
 

--- a/crates/vsock-host/src/exec_operation.rs
+++ b/crates/vsock-host/src/exec_operation.rs
@@ -31,6 +31,7 @@ const EXEC_OPERATION_CLOSE_ACTIVE_LOG_LIMIT: usize = 16;
 const EXEC_OPERATION_FRAME_WRITE_SLOW_THRESHOLD: Duration = Duration::from_millis(500);
 const EXEC_OPERATION_STAGE_SLOW_THRESHOLD: Duration = Duration::from_secs(5);
 const EXEC_OPERATION_DROP_CANCEL_WRITE_TIMEOUT: Duration = Duration::from_secs(1);
+const EXEC_OPERATION_START_TIMEOUT_CANCEL_WRITE_TIMEOUT: Duration = Duration::from_millis(250);
 const EXEC_OPERATION_FRAME_WRITE_NOT_STARTED: u8 = 0;
 const EXEC_OPERATION_FRAME_WRITE_STARTED: u8 = 1;
 const EXEC_OPERATION_FRAME_WRITE_COMPLETED: u8 = 2;
@@ -2267,16 +2268,31 @@ pub(crate) async fn start_supervised_exec_on_shared(
         }
         _ = tokio::time::sleep(request.start_timeout) => {
             let payload = vsock_proto::encode_exec_cancel();
-            let cancel_result = write_frame(
-                shared,
-                MSG_EXEC_CANCEL,
-                seq,
-                &payload,
-                Some(diagnostic.frame("start-timeout-cancel")),
-                None,
-                FrameWriteObserver::default(),
+            let cancel_result = tokio::time::timeout(
+                EXEC_OPERATION_START_TIMEOUT_CANCEL_WRITE_TIMEOUT,
+                write_frame(
+                    shared,
+                    MSG_EXEC_CANCEL,
+                    seq,
+                    &payload,
+                    Some(diagnostic.frame("start-timeout-cancel")),
+                    None,
+                    FrameWriteObserver::default(),
+                ),
             )
-            .await;
+            .await
+            .unwrap_or_else(|_| {
+                tracing::warn!(
+                    seq = seq,
+                    label = %diagnostic.label_log,
+                    elapsed_ms = diagnostic.elapsed_ms(),
+                    "supervised exec start timeout cancel write timed out"
+                );
+                Err(io::Error::new(
+                    io::ErrorKind::TimedOut,
+                    "supervised exec start timeout cancel write timed out",
+                ))
+            });
             start_cancel_on_drop.disarm();
             shared.remove_operation(seq);
             registration_guard.disarm();

--- a/crates/vsock-host/src/exec_operation.rs
+++ b/crates/vsock-host/src/exec_operation.rs
@@ -160,6 +160,9 @@ pub struct SupervisedExecRequest<'a> {
     ///
     /// If this elapses after the start frame is written, the host sends
     /// `MSG_EXEC_CANCEL` for the operation before returning a timeout error.
+    /// If that cancel frame cannot be written within the bounded fallback
+    /// window, the connection is poisoned because the guest process state is
+    /// no longer known.
     pub start_timeout: Duration,
 }
 
@@ -2288,6 +2291,7 @@ pub(crate) async fn start_supervised_exec_on_shared(
                     elapsed_ms = diagnostic.elapsed_ms(),
                     "supervised exec start timeout cancel write timed out"
                 );
+                shared.poison_connection();
                 Err(io::Error::new(
                     io::ErrorKind::TimedOut,
                     "supervised exec start timeout cancel write timed out",

--- a/crates/vsock-host/src/exec_operation.rs
+++ b/crates/vsock-host/src/exec_operation.rs
@@ -164,6 +164,10 @@ pub struct SupervisedExecRequest<'a> {
     /// If that cancel frame cannot be written within the bounded fallback
     /// window, the connection is poisoned because the guest process state is
     /// no longer known.
+    ///
+    /// A successful start-timeout cancellation still abandons terminal proof
+    /// for this operation, so the connection should not be reused for later
+    /// normal operations.
     pub start_timeout: Duration,
 }
 
@@ -862,7 +866,9 @@ impl SupervisedExecHandle {
     /// Wait for the terminal exec result.
     ///
     /// On timeout, this abandons the host-side operation registration but does
-    /// not send `MSG_EXEC_CANCEL`.
+    /// not send `MSG_EXEC_CANCEL`. Because the terminal proof is abandoned
+    /// after a guest write, the connection should not be reused for later
+    /// normal operations.
     pub async fn wait(self, timeout: Duration) -> io::Result<ExecOperationResult> {
         self.wait_with_timeout(timeout, false).await
     }

--- a/crates/vsock-host/src/exec_operation.rs
+++ b/crates/vsock-host/src/exec_operation.rs
@@ -116,22 +116,49 @@ pub struct ExecStreamRequest<'a> {
 /// Exec control policy for supervised host operations.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SupervisedExecControl {
+    /// Do not register an exec-control route for the operation.
     Disabled,
+    /// Register an exec-control route.
+    ///
+    /// When `sink` is true, the guest also exposes the bootstrap endpoint to
+    /// the child process through the process-control environment variable.
     Enabled { sink: bool },
 }
 
 /// Request parameters for starting a supervised exec operation.
 pub struct SupervisedExecRequest<'a> {
+    /// Guest-side process timeout policy.
+    ///
+    /// `ExecTimeoutPolicy::None` lets the process run until it exits, is
+    /// cancelled, or the connection closes.
     pub timeout: ExecTimeoutPolicy,
+    /// Shell command to run in the guest.
     pub command: &'a str,
+    /// Environment variables injected into the guest shell command.
     pub env: &'a [(&'a str, &'a str)],
+    /// Whether to run the command with guest-side sudo handling.
     pub sudo: bool,
+    /// Human-readable label used for diagnostics and logs.
     pub label: &'a str,
+    /// Stdout output policy requested from the guest.
     pub stdout: ExecOutputPolicy,
+    /// Stderr output policy requested from the guest.
     pub stderr: ExecOutputPolicy,
+    /// Exit codes that should not be treated as notable in diagnostics.
     pub expected_exit_codes: &'a [i32],
+    /// Optional exec-control route for this supervised operation.
     pub control: SupervisedExecControl,
+    /// Optional bounded host-side output event queue override.
+    ///
+    /// `None` uses the default queue capacity when either output policy
+    /// streams, and creates no queue when neither output policy streams.
+    /// `Some` is valid only when stdout or stderr streams; zero and oversized
+    /// capacities are rejected.
     pub stream_queue_capacity: Option<usize>,
+    /// Maximum time to wait for the guest `exec_started` acknowledgement.
+    ///
+    /// If this elapses after the start frame is written, the host sends
+    /// `MSG_EXEC_CANCEL` for the operation before returning a timeout error.
     pub start_timeout: Duration,
 }
 
@@ -784,14 +811,17 @@ pub struct SupervisedExecHandle {
 }
 
 impl SupervisedExecHandle {
+    /// Guest process id reported by the `exec_started` acknowledgement.
     pub fn pid(&self) -> u32 {
         self.pid
     }
 
+    /// Return a cloneable exec-control handle when control was enabled.
     pub fn control_handle(&self) -> Option<ExecControlHandle> {
         self.control.clone()
     }
 
+    /// Send an exec-control request for this supervised operation.
     pub async fn control(
         &self,
         message_id: &str,
@@ -810,6 +840,7 @@ impl SupervisedExecHandle {
             .await
     }
 
+    /// Take the bounded output event receiver for streaming operations.
     pub fn take_stream_receiver(&mut self) -> Option<mpsc::Receiver<ExecOutputEvent>> {
         self.stream_rx.take()
     }
@@ -823,10 +854,18 @@ impl SupervisedExecHandle {
         }
     }
 
+    /// Wait for the terminal exec result.
+    ///
+    /// On timeout, this abandons the host-side operation registration but does
+    /// not send `MSG_EXEC_CANCEL`.
     pub async fn wait(self, timeout: Duration) -> io::Result<ExecOperationResult> {
         self.wait_with_timeout(timeout, false).await
     }
 
+    /// Send `MSG_EXEC_CANCEL` and wait for the terminal exec result.
+    ///
+    /// If the terminal result is already available before cancel is sent, this
+    /// returns that result without sending a duplicate cancel frame.
     pub async fn cancel_and_wait(self, timeout: Duration) -> io::Result<ExecOperationResult> {
         let cancel_label_log = self.diagnostic.label_log.clone();
         let registered_at = self.diagnostic.registered_at;
@@ -980,6 +1019,7 @@ pub struct ExecControlHandle {
 }
 
 impl ExecControlHandle {
+    /// Send an exec-control request and require a delivered acknowledgement.
     pub async fn control(
         &self,
         message_id: &str,
@@ -996,6 +1036,7 @@ impl ExecControlHandle {
         .into_ack()
     }
 
+    /// Send an exec-control request and return the raw guest outcome.
     pub async fn control_with_write_observer(
         &self,
         message_id: &str,

--- a/crates/vsock-host/src/exec_operation.rs
+++ b/crates/vsock-host/src/exec_operation.rs
@@ -1023,6 +1023,14 @@ pub(crate) struct ExecOperationCancelOnDropGuard {
 }
 
 impl ExecOperationCancelOnDropGuard {
+    fn new_for_seq(shared: Arc<Shared>, seq: u32, diagnostic: ExecOperationDiagnostic) -> Self {
+        Self {
+            shared: Some(shared),
+            seq,
+            diagnostic,
+        }
+    }
+
     pub(crate) fn new(handle: &ExecOperationHandle) -> Option<Self> {
         Some(Self {
             shared: Some(Arc::clone(&handle.shared)),
@@ -2181,7 +2189,9 @@ pub(crate) async fn start_supervised_exec_on_shared(
     }
 
     let mut registration_guard = ExecOperationRegistrationGuard::new(Arc::clone(shared), seq);
-    write_frame(
+    let mut start_cancel_on_drop =
+        ExecOperationCancelOnDropGuard::new_for_seq(Arc::clone(shared), seq, diagnostic.clone());
+    let start_write_result = write_frame(
         shared,
         MSG_EXEC_START,
         seq,
@@ -2190,23 +2200,53 @@ pub(crate) async fn start_supervised_exec_on_shared(
         Some(seq),
         FrameWriteObserver::default(),
     )
-    .await?;
+    .await;
+    if let Err(error) = start_write_result {
+        start_cancel_on_drop.disarm();
+        return Err(error);
+    }
 
     let pid = tokio::select! {
         biased;
         result = start_rx => {
-            result.map_err(|_| io::Error::new(
-                io::ErrorKind::ConnectionReset,
-                "connection closed",
-            ))??
+            match result {
+                Ok(Ok(pid)) => pid,
+                Ok(Err(error)) => {
+                    start_cancel_on_drop.disarm();
+                    return Err(error);
+                }
+                Err(_) => {
+                    start_cancel_on_drop.disarm();
+                    return Err(io::Error::new(
+                        io::ErrorKind::ConnectionReset,
+                        "connection closed",
+                    ));
+                }
+            }
         }
         _ = tokio::time::sleep(request.start_timeout) => {
+            let payload = vsock_proto::encode_exec_cancel();
+            let cancel_result = write_frame(
+                shared,
+                MSG_EXEC_CANCEL,
+                seq,
+                &payload,
+                Some(diagnostic.frame("start-timeout-cancel")),
+                None,
+                FrameWriteObserver::default(),
+            )
+            .await;
+            start_cancel_on_drop.disarm();
+            shared.remove_operation(seq);
+            registration_guard.disarm();
+            cancel_result?;
             return Err(io::Error::new(
                 io::ErrorKind::TimedOut,
                 "supervised exec start acknowledgement timeout",
             ));
         }
     };
+    start_cancel_on_drop.disarm();
     registration_guard.disarm();
 
     Ok(SupervisedExecHandle {

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -1135,6 +1135,9 @@ impl VsockHost {
     /// If `request.start_timeout` elapses after the start frame is written,
     /// the host sends `MSG_EXEC_CANCEL` before returning a timeout error. If
     /// the bounded cancel write also times out, the connection is poisoned.
+    /// If the cancel write succeeds, the connection remains open but should
+    /// not be reused for later normal operations because terminal proof for the
+    /// timed-out operation was abandoned.
     pub async fn start_supervised_exec(
         &self,
         request: SupervisedExecRequest<'_>,

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -1131,6 +1131,9 @@ impl VsockHost {
     }
 
     /// Start a supervised exec operation and wait for its PID acknowledgement.
+    ///
+    /// If `request.start_timeout` elapses after the start frame is written,
+    /// the host sends `MSG_EXEC_CANCEL` before returning a timeout error.
     pub async fn start_supervised_exec(
         &self,
         request: SupervisedExecRequest<'_>,

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -1133,7 +1133,8 @@ impl VsockHost {
     /// Start a supervised exec operation and wait for its PID acknowledgement.
     ///
     /// If `request.start_timeout` elapses after the start frame is written,
-    /// the host sends `MSG_EXEC_CANCEL` before returning a timeout error.
+    /// the host sends `MSG_EXEC_CANCEL` before returning a timeout error. If
+    /// the bounded cancel write also times out, the connection is poisoned.
     pub async fn start_supervised_exec(
         &self,
         request: SupervisedExecRequest<'_>,

--- a/crates/vsock-host/src/tests/exec_operation/supervised.rs
+++ b/crates/vsock-host/src/tests/exec_operation/supervised.rs
@@ -1289,6 +1289,84 @@ async fn supervised_exec_late_start_frames_after_start_timeout_are_ignored() {
 }
 
 #[tokio::test]
+async fn supervised_exec_start_ack_timeout_removes_operation_before_cancel_write() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+    let (start_written_tx, start_written_rx) = tokio::sync::oneshot::channel();
+    let (allow_start_wait_tx, allow_start_wait_rx) = tokio::sync::oneshot::channel();
+    let task = {
+        let host = Arc::clone(&host);
+        tokio::spawn(async move {
+            exec_operation_impl::test_support::start_supervised_exec_after_start_write(
+                &host.shared,
+                SupervisedExecRequest {
+                    start_timeout: Duration::ZERO,
+                    ..supervised_request("blocked-start-timeout-late-result")
+                },
+                async move {
+                    let _ = start_written_tx.send(());
+                    let _ = allow_start_wait_rx.await;
+                },
+                Duration::from_secs(5),
+            )
+            .await
+        })
+    };
+
+    tokio::time::timeout(Duration::from_secs(5), start_written_rx)
+        .await
+        .expect("start frame write should complete")
+        .expect("start write hook should notify");
+    let writer_guard = host.shared.writer.lock().await;
+    let start = read_guest_message(&mut guest).await;
+    assert_eq!(start.msg_type, MSG_EXEC_START);
+    allow_start_wait_tx
+        .send(())
+        .expect("start wait hook should still be pending");
+
+    wait_for_operation_count(&host, 0).await;
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::NotParkable
+    );
+
+    send_exec_started(&mut guest, start.seq, 123).await;
+    send_discarded_exec_result(
+        &mut guest,
+        start.seq,
+        ExecTermination::Exited { exit_code: 0 },
+    )
+    .await;
+
+    drop(writer_guard);
+    let cancel = read_guest_message(&mut guest).await;
+    assert_eq!(cancel.msg_type, MSG_EXEC_CANCEL);
+    assert_eq!(cancel.seq, start.seq);
+    let err = match task.await.unwrap() {
+        Ok(_) => panic!("supervised exec should time out before exec_started"),
+        Err(err) => err,
+    };
+    assert_eq!(err.kind(), io::ErrorKind::TimedOut);
+
+    let quiesce_task = {
+        let host = Arc::clone(&host);
+        tokio::spawn(async move { host.quiesce_operations(Duration::from_secs(5)).await })
+    };
+    let quiesce = read_guest_message(&mut guest).await;
+    assert_eq!(quiesce.msg_type, MSG_QUIESCE_OPERATIONS);
+    let response = vsock_proto::encode(MSG_OPERATIONS_QUIESCED, quiesce.seq, &[]).unwrap();
+    guest.write_all(&response).await.unwrap();
+    quiesce_task.await.unwrap().unwrap();
+
+    assert!(is_connected(&host));
+    assert_eq!(operation_count(&host), 0);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::NotParkable
+    );
+}
+
+#[tokio::test]
 async fn supervised_exec_start_ack_timeout_cancel_write_is_bounded() {
     let (host, mut guest) = setup_host_and_guest().await;
     let host = Arc::new(host);

--- a/crates/vsock-host/src/tests/exec_operation/supervised.rs
+++ b/crates/vsock-host/src/tests/exec_operation/supervised.rs
@@ -1075,6 +1075,10 @@ async fn supervised_exec_terminal_wait_timeout_does_not_send_cancel() {
     let err = handle.wait(Duration::ZERO).await.unwrap_err();
     assert_eq!(err.kind(), io::ErrorKind::TimedOut);
     assert_eq!(operation_count(&host), 0);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::NotParkable
+    );
     match guest.try_read(&mut [0u8; 1]) {
         Err(err) if err.kind() == io::ErrorKind::WouldBlock => {}
         Ok(n) => panic!("terminal wait timeout must not send exec cancel; read {n} bytes"),

--- a/crates/vsock-host/src/tests/exec_operation/supervised.rs
+++ b/crates/vsock-host/src/tests/exec_operation/supervised.rs
@@ -12,9 +12,10 @@ use vsock_proto::{
 };
 
 use super::super::support::{
-    normal_operation_readiness, operation_count, read_guest_message, send_discarded_exec_result,
-    send_exec_control_result, send_exec_output, send_exec_result, send_exec_started,
-    setup_host_and_guest, wait_for_operation_count,
+    assert_connection_accepts_exec_operation, is_connected, normal_operation_readiness,
+    operation_count, read_guest_message, send_discarded_exec_result, send_exec_control_result,
+    send_exec_output, send_exec_result, send_exec_started, setup_host_and_guest,
+    wait_for_operation_count,
 };
 use super::start_capture_operation;
 use crate::exec_operation as exec_operation_impl;
@@ -420,6 +421,77 @@ async fn supervised_exec_cancel_on_drop_sends_exec_cancel() {
     send_exec_result(&mut guest, start.seq, ExecTermination::Cancelled, b"", b"").await;
     let result = handle.wait(Duration::from_secs(5)).await.unwrap();
     assert_eq!(result.termination, ExecTermination::Cancelled);
+}
+
+#[tokio::test]
+async fn supervised_exec_cancel_and_wait_sends_cancel_and_waits_for_cancelled_result() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+    let task = {
+        let host = Arc::clone(&host);
+        tokio::spawn(async move {
+            host.start_supervised_exec(supervised_request("cancel-and-wait"))
+                .await
+        })
+    };
+
+    let start = read_guest_message(&mut guest).await;
+    send_exec_started(&mut guest, start.seq, 123).await;
+    let handle = task.await.unwrap().unwrap();
+
+    let cancel_task =
+        tokio::spawn(async move { handle.cancel_and_wait(Duration::from_secs(5)).await });
+    let cancel = read_guest_message(&mut guest).await;
+    assert_eq!(cancel.msg_type, MSG_EXEC_CANCEL);
+    assert_eq!(cancel.seq, start.seq);
+    vsock_proto::decode_exec_cancel(&cancel.payload).unwrap();
+
+    send_exec_result(&mut guest, start.seq, ExecTermination::Cancelled, b"", b"").await;
+    let result = cancel_task.await.unwrap().unwrap();
+    assert_eq!(result.termination, ExecTermination::Cancelled);
+    assert_eq!(operation_count(&host), 0);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Idle
+    );
+}
+
+#[tokio::test]
+async fn supervised_exec_cancel_non_cancelled_terminal_result_cleans_without_poisoning() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+    let task = {
+        let host = Arc::clone(&host);
+        tokio::spawn(async move {
+            host.start_supervised_exec(supervised_request("cancel-race"))
+                .await
+        })
+    };
+
+    let start = read_guest_message(&mut guest).await;
+    send_exec_started(&mut guest, start.seq, 123).await;
+    let handle = task.await.unwrap().unwrap();
+
+    let cancel_task =
+        tokio::spawn(async move { handle.cancel_and_wait(Duration::from_secs(5)).await });
+    let cancel = read_guest_message(&mut guest).await;
+    assert_eq!(cancel.msg_type, MSG_EXEC_CANCEL);
+    assert_eq!(cancel.seq, start.seq);
+
+    send_exec_result(
+        &mut guest,
+        start.seq,
+        ExecTermination::Exited { exit_code: 0 },
+        b"",
+        b"",
+    )
+    .await;
+    let err = cancel_task.await.unwrap().unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::Other);
+    assert_eq!(operation_count(&host), 0);
+    assert!(is_connected(&host));
+
+    assert_connection_accepts_exec_operation(&host, &mut guest).await;
 }
 
 #[tokio::test]

--- a/crates/vsock-host/src/tests/exec_operation/supervised.rs
+++ b/crates/vsock-host/src/tests/exec_operation/supervised.rs
@@ -8,7 +8,7 @@ use tokio::io::AsyncWriteExt;
 use vsock_proto::{
     ExecCapturedOutput, ExecControlPolicy, ExecLifecyclePolicy, ExecOutputPolicy, ExecOutputStream,
     ExecTermination, ExecTimeoutPolicy, MSG_ERROR, MSG_EXEC_CANCEL, MSG_EXEC_CONTROL,
-    MSG_EXEC_START, ProcessControlStatus,
+    MSG_EXEC_START, MSG_OPERATIONS_QUIESCED, MSG_QUIESCE_OPERATIONS, ProcessControlStatus,
 };
 
 use super::super::support::{
@@ -1110,6 +1110,60 @@ async fn supervised_exec_start_ack_timeout_sends_cancel() {
         Ok(n) => panic!("start timeout must send exactly one exec cancel; read {n} extra bytes"),
         Err(err) => panic!("unexpected read error after start timeout: {err}"),
     }
+}
+
+#[tokio::test]
+async fn supervised_exec_late_start_frames_after_start_timeout_are_ignored() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+
+    let err = match host
+        .start_supervised_exec(SupervisedExecRequest {
+            start_timeout: Duration::ZERO,
+            ..supervised_request("late-start-after-timeout")
+        })
+        .await
+    {
+        Ok(_) => panic!("supervised exec should time out before exec_started"),
+        Err(err) => err,
+    };
+    assert_eq!(err.kind(), io::ErrorKind::TimedOut);
+
+    let start = read_guest_message(&mut guest).await;
+    assert_eq!(start.msg_type, MSG_EXEC_START);
+    let cancel = read_guest_message(&mut guest).await;
+    assert_eq!(cancel.msg_type, MSG_EXEC_CANCEL);
+    assert_eq!(cancel.seq, start.seq);
+    assert_eq!(operation_count(&host), 0);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::NotParkable
+    );
+
+    send_exec_started(&mut guest, start.seq, 123).await;
+    send_discarded_exec_result(
+        &mut guest,
+        start.seq,
+        ExecTermination::Exited { exit_code: 0 },
+    )
+    .await;
+
+    let quiesce_task = {
+        let host = Arc::clone(&host);
+        tokio::spawn(async move { host.quiesce_operations(Duration::from_secs(5)).await })
+    };
+    let quiesce = read_guest_message(&mut guest).await;
+    assert_eq!(quiesce.msg_type, MSG_QUIESCE_OPERATIONS);
+    let response = vsock_proto::encode(MSG_OPERATIONS_QUIESCED, quiesce.seq, &[]).unwrap();
+    guest.write_all(&response).await.unwrap();
+    quiesce_task.await.unwrap().unwrap();
+
+    assert!(is_connected(&host));
+    assert_eq!(operation_count(&host), 0);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::NotParkable
+    );
 }
 
 #[tokio::test]

--- a/crates/vsock-host/src/tests/exec_operation/supervised.rs
+++ b/crates/vsock-host/src/tests/exec_operation/supervised.rs
@@ -1189,6 +1189,7 @@ async fn supervised_exec_start_ack_timeout_cancel_write_is_bounded() {
                     let _ = start_written_tx.send(());
                     let _ = allow_start_wait_rx.await;
                 },
+                Duration::ZERO,
             )
             .await
         })

--- a/crates/vsock-host/src/tests/exec_operation/supervised.rs
+++ b/crates/vsock-host/src/tests/exec_operation/supervised.rs
@@ -1110,10 +1110,15 @@ async fn supervised_exec_start_ack_timeout_cancel_write_is_bounded() {
         "supervised exec start timeout cancel write timed out"
     );
     assert_eq!(operation_count(&host), 0);
+    host.wait_until_closed(Duration::from_secs(5))
+        .await
+        .unwrap();
+    assert!(!is_connected(&host));
 
     drop(writer_guard);
     match guest.try_read(&mut [0u8; 1]) {
         Err(err) if err.kind() == io::ErrorKind::WouldBlock => {}
+        Ok(0) => {}
         Ok(n) => panic!("bounded cancel write must not send after timing out; read {n} bytes"),
         Err(err) => panic!("unexpected read error after bounded cancel timeout: {err}"),
     }

--- a/crates/vsock-host/src/tests/exec_operation/supervised.rs
+++ b/crates/vsock-host/src/tests/exec_operation/supervised.rs
@@ -1078,6 +1078,48 @@ async fn supervised_exec_start_ack_timeout_sends_cancel() {
 }
 
 #[tokio::test]
+async fn supervised_exec_start_ack_timeout_cancel_write_is_bounded() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+    let task = {
+        let host = Arc::clone(&host);
+        tokio::spawn(async move {
+            host.start_supervised_exec(SupervisedExecRequest {
+                start_timeout: Duration::from_millis(100),
+                ..supervised_request("blocked-start-timeout-cancel")
+            })
+            .await
+        })
+    };
+
+    let start = read_guest_message(&mut guest).await;
+    assert_eq!(start.msg_type, MSG_EXEC_START);
+    let writer_guard = host.shared.writer.lock().await;
+
+    let result = tokio::time::timeout(Duration::from_secs(5), task)
+        .await
+        .expect("blocked start-timeout cancel write should be bounded")
+        .unwrap();
+    let err = match result {
+        Ok(_) => panic!("supervised exec should fail when start-timeout cancel write is blocked"),
+        Err(err) => err,
+    };
+    assert_eq!(err.kind(), io::ErrorKind::TimedOut);
+    assert_eq!(
+        err.to_string(),
+        "supervised exec start timeout cancel write timed out"
+    );
+    assert_eq!(operation_count(&host), 0);
+
+    drop(writer_guard);
+    match guest.try_read(&mut [0u8; 1]) {
+        Err(err) if err.kind() == io::ErrorKind::WouldBlock => {}
+        Ok(n) => panic!("bounded cancel write must not send after timing out; read {n} bytes"),
+        Err(err) => panic!("unexpected read error after bounded cancel timeout: {err}"),
+    }
+}
+
+#[tokio::test]
 async fn supervised_exec_start_wait_cancellation_sends_cancel() {
     let (host, mut guest) = setup_host_and_guest().await;
     let host = Arc::new(host);

--- a/crates/vsock-host/src/tests/exec_operation/supervised.rs
+++ b/crates/vsock-host/src/tests/exec_operation/supervised.rs
@@ -1116,20 +1116,36 @@ async fn supervised_exec_start_ack_timeout_sends_cancel() {
 async fn supervised_exec_start_ack_timeout_cancel_write_is_bounded() {
     let (host, mut guest) = setup_host_and_guest().await;
     let host = Arc::new(host);
+    let (start_written_tx, start_written_rx) = tokio::sync::oneshot::channel();
+    let (allow_start_wait_tx, allow_start_wait_rx) = tokio::sync::oneshot::channel();
     let task = {
         let host = Arc::clone(&host);
         tokio::spawn(async move {
-            host.start_supervised_exec(SupervisedExecRequest {
-                start_timeout: Duration::from_millis(100),
-                ..supervised_request("blocked-start-timeout-cancel")
-            })
+            exec_operation_impl::test_support::start_supervised_exec_after_start_write(
+                &host.shared,
+                SupervisedExecRequest {
+                    start_timeout: Duration::ZERO,
+                    ..supervised_request("blocked-start-timeout-cancel")
+                },
+                async move {
+                    let _ = start_written_tx.send(());
+                    let _ = allow_start_wait_rx.await;
+                },
+            )
             .await
         })
     };
 
+    tokio::time::timeout(Duration::from_secs(5), start_written_rx)
+        .await
+        .expect("start frame write should complete")
+        .expect("start write hook should notify");
+    let writer_guard = host.shared.writer.lock().await;
     let start = read_guest_message(&mut guest).await;
     assert_eq!(start.msg_type, MSG_EXEC_START);
-    let writer_guard = host.shared.writer.lock().await;
+    allow_start_wait_tx
+        .send(())
+        .expect("start wait hook should still be pending");
 
     let result = tokio::time::timeout(Duration::from_secs(5), task)
         .await

--- a/crates/vsock-host/src/tests/exec_operation/supervised.rs
+++ b/crates/vsock-host/src/tests/exec_operation/supervised.rs
@@ -599,6 +599,124 @@ async fn supervised_exec_control_uses_exec_control_messages() {
 }
 
 #[tokio::test]
+async fn supervised_exec_control_sub_millisecond_timeout_rounds_up_to_one_ms() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+    let task = {
+        let host = Arc::clone(&host);
+        tokio::spawn(async move {
+            host.start_supervised_exec(SupervisedExecRequest {
+                control: SupervisedExecControl::Enabled { sink: true },
+                ..supervised_request("control-sub-ms-timeout")
+            })
+            .await
+        })
+    };
+
+    let start = read_guest_message(&mut guest).await;
+    let decoded_start = vsock_proto::decode_exec_start(&start.payload).unwrap();
+    let ExecControlPolicy::Enabled { control_nonce, .. } = decoded_start.control else {
+        panic!("supervised exec should enable control");
+    };
+    send_exec_started(&mut guest, start.seq, 123).await;
+    let handle = task.await.unwrap().unwrap();
+
+    let control_task = tokio::spawn({
+        let control_handle = handle.control_handle().unwrap();
+        async move {
+            control_handle
+                .control("sub-ms-timeout", b"payload", Duration::from_nanos(1))
+                .await
+        }
+    });
+    let control = read_guest_message(&mut guest).await;
+    let decoded_control = vsock_proto::decode_exec_control(&control.payload).unwrap();
+    assert_eq!(decoded_control.target_seq, start.seq);
+    assert_eq!(decoded_control.control_nonce, control_nonce);
+    assert_eq!(decoded_control.message_id, "sub-ms-timeout");
+    assert_eq!(decoded_control.request_timeout_ms, 1);
+    let err = control_task.await.unwrap().unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::TimedOut);
+
+    send_exec_result(
+        &mut guest,
+        start.seq,
+        ExecTermination::Exited { exit_code: 0 },
+        b"",
+        b"",
+    )
+    .await;
+    handle.wait(Duration::from_secs(5)).await.unwrap();
+}
+
+#[tokio::test]
+async fn supervised_exec_control_large_timeout_saturates_request_timeout_ms() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+    let task = {
+        let host = Arc::clone(&host);
+        tokio::spawn(async move {
+            host.start_supervised_exec(SupervisedExecRequest {
+                control: SupervisedExecControl::Enabled { sink: true },
+                ..supervised_request("control-large-timeout")
+            })
+            .await
+        })
+    };
+
+    let start = read_guest_message(&mut guest).await;
+    let decoded_start = vsock_proto::decode_exec_start(&start.payload).unwrap();
+    let ExecControlPolicy::Enabled { control_nonce, .. } = decoded_start.control else {
+        panic!("supervised exec should enable control");
+    };
+    send_exec_started(&mut guest, start.seq, 123).await;
+    let handle = task.await.unwrap().unwrap();
+
+    let control_task = tokio::spawn({
+        let control_handle = handle.control_handle().unwrap();
+        async move {
+            control_handle
+                .control(
+                    "large-timeout",
+                    b"payload",
+                    Duration::from_millis(u64::from(u32::MAX) + 1),
+                )
+                .await
+        }
+    });
+    let control = read_guest_message(&mut guest).await;
+    let decoded_control = vsock_proto::decode_exec_control(&control.payload).unwrap();
+    assert_eq!(decoded_control.target_seq, start.seq);
+    assert_eq!(decoded_control.control_nonce, control_nonce);
+    assert_eq!(decoded_control.message_id, "large-timeout");
+    assert_eq!(decoded_control.request_timeout_ms, u32::MAX);
+
+    send_exec_control_result(
+        &mut guest,
+        control.seq,
+        start.seq,
+        control_nonce,
+        "large-timeout",
+        ProcessControlStatus::Delivered,
+        "",
+    )
+    .await;
+    let ack = control_task.await.unwrap().unwrap();
+    assert_eq!(ack.target_seq, start.seq);
+    assert_eq!(ack.message_id, "large-timeout");
+
+    send_exec_result(
+        &mut guest,
+        start.seq,
+        ExecTermination::Exited { exit_code: 0 },
+        b"",
+        b"",
+    )
+    .await;
+    handle.wait(Duration::from_secs(5)).await.unwrap();
+}
+
+#[tokio::test]
 async fn supervised_exec_control_disabled_returns_unsupported_without_frame() {
     let (host, mut guest) = setup_host_and_guest().await;
     let host = Arc::new(host);

--- a/crates/vsock-host/src/tests/exec_operation/supervised.rs
+++ b/crates/vsock-host/src/tests/exec_operation/supervised.rs
@@ -976,7 +976,7 @@ async fn supervised_exec_terminal_wait_timeout_does_not_send_cancel() {
 }
 
 #[tokio::test]
-async fn supervised_exec_start_ack_timeout_does_not_send_cancel() {
+async fn supervised_exec_start_ack_timeout_sends_cancel() {
     let (host, mut guest) = setup_host_and_guest().await;
     let host = Arc::new(host);
 
@@ -995,15 +995,18 @@ async fn supervised_exec_start_ack_timeout_does_not_send_cancel() {
 
     let start = read_guest_message(&mut guest).await;
     assert_eq!(start.msg_type, MSG_EXEC_START);
+    let cancel = read_guest_message(&mut guest).await;
+    assert_eq!(cancel.msg_type, MSG_EXEC_CANCEL);
+    assert_eq!(cancel.seq, start.seq);
     match guest.try_read(&mut [0u8; 1]) {
         Err(err) if err.kind() == io::ErrorKind::WouldBlock => {}
-        Ok(n) => panic!("start timeout must not send exec cancel; read {n} bytes"),
+        Ok(n) => panic!("start timeout must send exactly one exec cancel; read {n} extra bytes"),
         Err(err) => panic!("unexpected read error after start timeout: {err}"),
     }
 }
 
 #[tokio::test]
-async fn supervised_exec_start_wait_cancellation_cleans_registration_without_cancel() {
+async fn supervised_exec_start_wait_cancellation_sends_cancel() {
     let (host, mut guest) = setup_host_and_guest().await;
     let host = Arc::new(host);
     let task = {
@@ -1025,9 +1028,16 @@ async fn supervised_exec_start_wait_cancellation_cleans_registration_without_can
     };
     assert!(err.is_cancelled());
     assert_eq!(operation_count(&host), 0);
+    let cancel = tokio::time::timeout(Duration::from_secs(5), read_guest_message(&mut guest))
+        .await
+        .expect("cancelled start wait should send exec cancel");
+    assert_eq!(cancel.msg_type, MSG_EXEC_CANCEL);
+    assert_eq!(cancel.seq, start.seq);
     match guest.try_read(&mut [0u8; 1]) {
         Err(err) if err.kind() == io::ErrorKind::WouldBlock => {}
-        Ok(n) => panic!("cancelled start wait must not send exec cancel; read {n} bytes"),
+        Ok(n) => {
+            panic!("cancelled start wait must send exactly one exec cancel; read {n} extra bytes")
+        }
         Err(err) => panic!("unexpected read error after cancelled start wait: {err}"),
     }
 }

--- a/crates/vsock-host/src/tests/exec_operation/supervised.rs
+++ b/crates/vsock-host/src/tests/exec_operation/supervised.rs
@@ -148,6 +148,41 @@ async fn supervised_exec_start_failed_before_started_returns_error() {
 }
 
 #[tokio::test]
+async fn supervised_exec_error_before_started_returns_error_without_cancel() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+    let task = {
+        let host = Arc::clone(&host);
+        tokio::spawn(async move {
+            host.start_supervised_exec(supervised_request("guest-error-before-started"))
+                .await
+        })
+    };
+
+    let start = read_guest_message(&mut guest).await;
+    send_guest_error(&mut guest, start.seq, "guest rejected start").await;
+
+    let err = match task.await.unwrap() {
+        Ok(_) => panic!("supervised exec should fail when guest returns an error before started"),
+        Err(err) => err,
+    };
+    assert_eq!(err.kind(), io::ErrorKind::Other);
+    assert_eq!(err.to_string(), "guest rejected start");
+    assert_eq!(operation_count(&host), 0);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Idle
+    );
+    match guest.try_read(&mut [0u8; 1]) {
+        Err(err) if err.kind() == io::ErrorKind::WouldBlock => {}
+        Ok(n) => panic!("guest start error must not send exec cancel; read {n} bytes"),
+        Err(err) => panic!("unexpected read error after guest start error: {err}"),
+    }
+
+    assert_connection_accepts_exec_operation(&host, &mut guest).await;
+}
+
+#[tokio::test]
 async fn supervised_exec_output_before_started_poisons_connection() {
     let (host, mut guest) = setup_host_and_guest().await;
     let host = Arc::new(host);


### PR DESCRIPTION
## Summary
- add guest dispatch and shared operation-control routing for MSG_EXEC_CONTROL / MSG_EXEC_CONTROL_RESULT
- extend exec worker to support supervised lifecycle, MSG_EXEC_STARTED, no-timeout waits, and control bootstrap env injection
- add connection integration coverage for started ordering, StartFailed, exec control delivery/unsupported, and None timeout cancellation

Closes #13748

## Tests
- cargo fmt --manifest-path crates/Cargo.toml --all --check
- cargo test --manifest-path crates/Cargo.toml -p vsock-guest
- cargo test --manifest-path crates/Cargo.toml -p vsock-proto
- cargo test --manifest-path crates/Cargo.toml -p vsock-host
- cargo clippy --all-targets --all-features
- cargo doc --workspace --all-features --no-deps