### PR TITLE
fix: keep agentphone webhook on web origin

### DIFF
--- a/turbo/apps/web/__tests__/api-backend-rewrite-proxy.test.ts
+++ b/turbo/apps/web/__tests__/api-backend-rewrite-proxy.test.ts
@@ -708,6 +708,21 @@ describe("API backend rewrite proxy behavior", () => {
     ).toBe(false);
   });
 
+  it("matches AgentPhone connect and webhook rewrite paths exactly", () => {
+    expect(matchesApiBackendRewritePath("/api/agentphone/connect")).toBe(true);
+    expect(matchesApiBackendRewritePath("/api/agentphone/webhook")).toBe(true);
+    expect(matchesApiBackendRewritePath("/api/agentphone/connect/extra")).toBe(
+      false,
+    );
+    expect(matchesApiBackendRewritePath("/api/agentphone/webhook/extra")).toBe(
+      false,
+    );
+    expect(matchesApiBackendRewritePath("/api/agentphone")).toBe(false);
+    expect(matchesApiBackendRewritePath("/api/agentphone/messages")).toBe(
+      false,
+    );
+  });
+
   it("matches only one segment for agent session by-id rewrites", () => {
     expect(
       matchesApiBackendRewritePath(
@@ -2282,6 +2297,55 @@ describe("API backend rewrite proxy behavior", () => {
         expect(authPayload.url).toBe(
           "/api/integrations/telegram/auth-callback?id=1001&hash=telegram-hash",
         );
+      },
+    );
+  });
+
+  it("forwards AgentPhone webhook POST bodies and signature headers", async () => {
+    await withRewriteProxy(
+      async (request) => {
+        return Response.json({
+          method: request.method,
+          url: request.url,
+          headers: request.headers,
+          body: await readRequestBody(request),
+        });
+      },
+      async (origin) => {
+        const webhookBody = JSON.stringify({
+          event: "agent.message",
+          data: {
+            messageId: "msg-agentphone-1",
+            agentId: "agt-agentphone",
+            from: "+15551234567",
+            to: "+15557654321",
+            body: "hello",
+          },
+        });
+        const response = await fetch(
+          `${origin}/api/agentphone/webhook?from=agentphone`,
+          {
+            method: "POST",
+            headers: {
+              "content-type": "application/json",
+              "x-webhook-id": "webhook-agentphone-1",
+              "x-webhook-timestamp": "1710000000",
+              "x-webhook-signature": "sha256=test-signature",
+            },
+            body: webhookBody,
+          },
+        );
+
+        const payload = (await response.json()) as EchoPayload;
+        expect(payload.method).toBe("POST");
+        expect(payload.url).toBe("/api/agentphone/webhook?from=agentphone");
+        expect(payload.headers["content-type"]).toContain("application/json");
+        expect(payload.headers["x-webhook-id"]).toBe("webhook-agentphone-1");
+        expect(payload.headers["x-webhook-timestamp"]).toBe("1710000000");
+        expect(payload.headers["x-webhook-signature"]).toBe(
+          "sha256=test-signature",
+        );
+        expect(payload.body).toBe(webhookBody);
       },
     );
   });

--- a/turbo/apps/web/__tests__/proxy.sandbox-token.test.ts
+++ b/turbo/apps/web/__tests__/proxy.sandbox-token.test.ts
@@ -401,4 +401,34 @@ describe("proxy middleware: sandbox token handling", () => {
       false,
     );
   });
+
+  it("should not add OAuth web origin headers for AgentPhone webhooks", async () => {
+    const request = new NextRequest(
+      "https://www.vm0.ai/api/agentphone/webhook",
+      {
+        method: "POST",
+        headers: {
+          "x-webhook-id": "webhook-agentphone-1",
+          "x-webhook-timestamp": "1710000000",
+          "x-webhook-signature": "sha256=test-signature",
+        },
+      },
+    );
+
+    const response = await middleware(request, createMockEvent());
+    if (!response) {
+      throw new Error("Expected middleware response");
+    }
+
+    expect(capturedClerkRequest).toBeUndefined();
+    expect(response.headers.get("x-middleware-request-x-forwarded-host")).toBe(
+      "www.vm0.ai",
+    );
+    expect(response.headers.get("x-middleware-request-x-forwarded-proto")).toBe(
+      "https",
+    );
+    expect(response.headers.has("x-middleware-request-x-vm0-web-origin")).toBe(
+      false,
+    );
+  });
 });

--- a/turbo/apps/web/__tests__/security-headers.test.ts
+++ b/turbo/apps/web/__tests__/security-headers.test.ts
@@ -461,6 +461,20 @@ const CONNECTORS_CALLBACK_NEXT_NEGATIVE_PATHS = [
   "/api/connectors/callback",
   "/api/connectors/github/callbacks",
 ] as const;
+const AGENTPHONE_CONNECT_REWRITE_SOURCE = "/api/agentphone/connect";
+const AGENTPHONE_CONNECT_PATH = "/api/agentphone/connect";
+const AGENTPHONE_CONNECT_NEXT_NEGATIVE_PATHS = [
+  "/api/agentphone/connect/extra",
+  "/api/agentphone",
+  "/api/agentphone/webhook",
+] as const;
+const AGENTPHONE_WEBHOOK_REWRITE_SOURCE = "/api/agentphone/webhook";
+const AGENTPHONE_WEBHOOK_PATH = "/api/agentphone/webhook";
+const AGENTPHONE_WEBHOOK_NEXT_NEGATIVE_PATHS = [
+  "/api/agentphone/webhook/extra",
+  "/api/agentphone",
+  "/api/agentphone/messages",
+] as const;
 const INTERNAL_CALLBACKS_AGENT_REWRITE_SOURCE = "/api/internal/callbacks/agent";
 const INTERNAL_CALLBACKS_AGENT_PATH = "/api/internal/callbacks/agent";
 const INTERNAL_CALLBACKS_AGENT_NEXT_NEGATIVE_PATHS = [
@@ -1658,8 +1672,12 @@ describe("API backend rewrites", () => {
           destination: "https://api.example.test/api/test/slack-state",
         },
         {
-          source: "/api/agentphone/:path*",
-          destination: "https://api.example.test/api/agentphone/:path*",
+          source: AGENTPHONE_CONNECT_REWRITE_SOURCE,
+          destination: "https://api.example.test/api/agentphone/connect",
+        },
+        {
+          source: AGENTPHONE_WEBHOOK_REWRITE_SOURCE,
+          destination: "https://api.example.test/api/agentphone/webhook",
         },
         {
           source: INTERNAL_CALLBACKS_AGENT_REWRITE_SOURCE,
@@ -3045,6 +3063,52 @@ describe("API backend rewrites", () => {
       type: "github",
     });
     for (const pathname of CONNECTORS_CALLBACK_NEXT_NEGATIVE_PATHS) {
+      expect(matcher(pathname)).toBe(false);
+    }
+  });
+
+  it("should match only the exact AgentPhone connect rewrite", async () => {
+    vi.stubEnv("VM0_API_BACKEND_URL", "https://api.example.test");
+
+    const rewrites = await getBeforeFileRewrites();
+    const rewrite = rewrites.find((entry) => {
+      return entry.source === AGENTPHONE_CONNECT_REWRITE_SOURCE;
+    });
+    expect(rewrite).toStrictEqual({
+      source: AGENTPHONE_CONNECT_REWRITE_SOURCE,
+      destination: "https://api.example.test/api/agentphone/connect",
+    });
+
+    const matcher = getPathMatch(AGENTPHONE_CONNECT_REWRITE_SOURCE, {
+      removeUnnamedParams: true,
+      strict: true,
+    });
+
+    expect(matcher(AGENTPHONE_CONNECT_PATH)).toStrictEqual({});
+    for (const pathname of AGENTPHONE_CONNECT_NEXT_NEGATIVE_PATHS) {
+      expect(matcher(pathname)).toBe(false);
+    }
+  });
+
+  it("should match only the exact AgentPhone webhook rewrite", async () => {
+    vi.stubEnv("VM0_API_BACKEND_URL", "https://api.example.test");
+
+    const rewrites = await getBeforeFileRewrites();
+    const rewrite = rewrites.find((entry) => {
+      return entry.source === AGENTPHONE_WEBHOOK_REWRITE_SOURCE;
+    });
+    expect(rewrite).toStrictEqual({
+      source: AGENTPHONE_WEBHOOK_REWRITE_SOURCE,
+      destination: "https://api.example.test/api/agentphone/webhook",
+    });
+
+    const matcher = getPathMatch(AGENTPHONE_WEBHOOK_REWRITE_SOURCE, {
+      removeUnnamedParams: true,
+      strict: true,
+    });
+
+    expect(matcher(AGENTPHONE_WEBHOOK_PATH)).toStrictEqual({});
+    for (const pathname of AGENTPHONE_WEBHOOK_NEXT_NEGATIVE_PATHS) {
       expect(matcher(pathname)).toBe(false);
     }
   });

--- a/turbo/apps/web/api-backend-rewrites.js
+++ b/turbo/apps/web/api-backend-rewrites.js
@@ -133,6 +133,8 @@ const AGENT_RUN_TELEMETRY_SYSTEM_LOG_PATH_RE = new RegExp(
 );
 const CONNECTORS_CALLBACK_REWRITE_SOURCE = "/api/connectors/:type/callback";
 const CONNECTORS_CALLBACK_PATH_RE = /^\/api\/connectors\/[^/]+\/callback$/;
+const AGENTPHONE_CONNECT_REWRITE_SOURCE = "/api/agentphone/connect";
+const AGENTPHONE_WEBHOOK_REWRITE_SOURCE = "/api/agentphone/webhook";
 const TELEGRAM_WEBHOOK_REWRITE_SOURCE = "/api/telegram/webhook/:telegramBotId";
 const TELEGRAM_WEBHOOK_PATH_RE = /^\/api\/telegram\/webhook\/[^/]+$/;
 const TELEGRAM_AUTH_CALLBACK_REWRITE_SOURCE =
@@ -316,7 +318,8 @@ export const API_BACKEND_REWRITES = [
   ],
   ["/api/device-token", "/api/device-token"],
   ["/api/device-token/poll", "/api/device-token/poll"],
-  ["/api/agentphone/:path*", "/api/agentphone/:path*"],
+  [AGENTPHONE_CONNECT_REWRITE_SOURCE, "/api/agentphone/connect"],
+  [AGENTPHONE_WEBHOOK_REWRITE_SOURCE, "/api/agentphone/webhook"],
   ["/api/email/unsubscribe", "/api/email/unsubscribe"],
   ["/api/generate-image", "/api/generate-image"],
   ["/api/github/oauth/callback", "/api/github/oauth/callback"],


### PR DESCRIPTION
## Summary
- replace the broad AgentPhone API backend rewrite with exact `/api/agentphone/connect` and `/api/agentphone/webhook` rewrites
- add rewrite-output and proxy coverage proving the AgentPhone webhook stays on the web origin while preserving POST bodies and provider signature headers
- confirm AgentPhone provider callbacks do not receive OAuth web-origin headers; `/api/internal/callbacks/agentphone` remains separate and internal/API-scoped

Closes #14044

## Validation
- `pnpm -F web exec vitest run __tests__/api-backend-rewrite-proxy.test.ts __tests__/proxy.sandbox-token.test.ts __tests__/security-headers.test.ts`
- `pnpm format`
- `pnpm -F web lint`
- `pnpm check-types`
- `git diff --check`
