### PR TITLE
fix: adjust org feature switch rollout

### DIFF
--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -111,6 +111,23 @@ describe("getAllFeatureStates", () => {
     expect(states[FeatureSwitchKey.Dummy]).toBe(true);
   });
 
+  it("should reflect the current staff org rollout matrix", () => {
+    const staffOrgStates = getAllFeatureStates({
+      orgId: "org_3ANttyrbWYJk6JKRSTRLEsbsDLe",
+    });
+    expect(staffOrgStates[FeatureSwitchKey.Lab]).toBe(true);
+    expect(staffOrgStates[FeatureSwitchKey.PwaOfflineCache]).toBe(true);
+    expect(staffOrgStates[FeatureSwitchKey.ChatHeaderNewButton]).toBe(false);
+    expect(staffOrgStates[FeatureSwitchKey.ChatMessageStartButton]).toBe(false);
+    expect(staffOrgStates[FeatureSwitchKey.ChatThreadRename]).toBe(false);
+
+    const otherOrgStates = getAllFeatureStates({
+      orgId: "org_nonexistent",
+    });
+    expect(otherOrgStates[FeatureSwitchKey.Lab]).toBe(false);
+    expect(otherOrgStates[FeatureSwitchKey.PwaOfflineCache]).toBe(false);
+  });
+
   it("should apply overrides to enable disabled features", () => {
     const states = getAllFeatureStates({
       overrides: { [FeatureSwitchKey.AhrefsConnector]: true },

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -155,6 +155,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     description:
       "Enable PWA offline caching (static asset cache-first, offline fallback page, and service worker updateViaCache: none)",
     enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.MailchimpConnector]: {
     maintainer: "ethan@vm0.ai",
@@ -205,6 +206,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     maintainer: "ethan@vm0.ai",
     description: "Show the Lab page for toggling experimental features",
     enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.AuditLink]: {
     maintainer: "ethan@vm0.ai",
@@ -233,7 +235,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     description:
       "Replace the Invite people button in the agent chat page header with a New button that creates a new chat thread",
     enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.AgentPhoneAppUi]: {
     maintainer: "linghan@vm0.ai",
@@ -247,7 +248,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     description:
       "Show an icon button in assistant message group actions that scrolls back to the start of that message group.",
     enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.Goal]: {
     maintainer: "ethan@vm0.ai",
@@ -261,7 +261,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     description:
       "Adds a Rename chat item to the sidebar thread kebab menu. When the user renames a thread, automated title generation is suppressed for that thread.",
     enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.DocsSite]: {
     maintainer: "linghan@vm0.ai",


### PR DESCRIPTION
## Summary
- enable `lab` and `pwaOfflineCache` for the staff org rollout
- remove staff org rollout from `chatThreadRename`, `chatHeaderNewButton`, and `chatMessageStartButton`
- add a feature-switch test covering the current staff org rollout matrix

## Validation
- `PATH="/tmp/corepack-bin:$PATH" pnpm -F @vm0/core check-types`
- `PATH="/tmp/corepack-bin:$PATH" pnpm -F @vm0/core lint`
- `PATH="/tmp/corepack-bin:$PATH" pnpm -F @vm0/core test -- src/__tests__/feature-switch.test.ts`
- `PATH="/tmp/corepack-bin:$PATH" pnpm exec prettier --check packages/core/src/feature-switch.ts packages/core/src/__tests__/feature-switch.test.ts`
- `git diff --check`