### PR TITLE
refactor: split zero sidebar nav and fix dropped mod+shift+arrow keypress

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -1501,9 +1501,13 @@ function ChatArtifactsDrawer({ thread }: { thread: ChatThreadSignals }) {
 // ZeroSessionChatPage — real conversation backed by agent runs
 // ---------------------------------------------------------------------------
 
-function ChatThread({ thread }: { thread: ChatThreadSignals }) {
-  const onKeyDown = useChatThreadKeyDown(thread);
-
+function ChatThread({
+  thread,
+  onKeyDown,
+}: {
+  thread: ChatThreadSignals;
+  onKeyDown: (event: ReactKeyboardEvent<HTMLElement>) => void;
+}) {
   return (
     <section
       aria-label="Chat thread"
@@ -1524,6 +1528,12 @@ export function ZeroChatThreadPage() {
   const rightThread = useGet(currentRightThread$);
   const lightboxUrl = useGet(attachmentLightboxUrl$);
   const setKeyboardScrollRoot = useSet(setChatKeyboardScrollRoot$);
+  // Lifted from ChatThread so the keyboard handler's sidebarChatThreads$
+  // snapshot survives keyed ChatThread remounts during thread navigation.
+  // Otherwise a second mod+shift+arrow press lands on a freshly mounted
+  // ChatThread whose useLastResolved has no cached value yet, leading to an
+  // empty threads list and a silently dropped keypress.
+  const makeChatThreadKeyDown = useChatThreadKeyDownFactory();
 
   return (
     <>
@@ -1532,12 +1542,20 @@ export function ZeroChatThreadPage() {
         className="flex flex-1 min-h-0 bg-transparent"
       >
         {leftThread && (
-          <ChatThread key={leftThread.threadId} thread={leftThread} />
+          <ChatThread
+            key={leftThread.threadId}
+            thread={leftThread}
+            onKeyDown={makeChatThreadKeyDown(leftThread)}
+          />
         )}
         {rightThread && (
           <>
             <div className="w-px shrink-0 bg-border/60" aria-hidden="true" />
-            <ChatThread key={rightThread.threadId} thread={rightThread} />
+            <ChatThread
+              key={rightThread.threadId}
+              thread={rightThread}
+              onKeyDown={makeChatThreadKeyDown(rightThread)}
+            />
           </>
         )}
       </div>
@@ -1584,7 +1602,9 @@ function resolveSessionError(
   return null;
 }
 
-function useChatThreadKeyDown(thread: ChatThreadSignals) {
+// Lifted to ZeroChatThreadPage so the useLastResolved(sidebarChatThreads$)
+// snapshot survives keyed ChatThread remounts during thread navigation.
+function useChatThreadKeyDownFactory() {
   const pageSignal = useGet(pageSignal$);
   const scrollCurrentThread = useSet(scrollCurrentThread$);
   const navigateToAdjacentThread = useSet(navigateToAdjacentThread$);
@@ -1595,50 +1615,52 @@ function useChatThreadKeyDown(thread: ChatThreadSignals) {
   // (e.g. an IDB miss + remote refetch).
   const sidebarThreads = useLastResolved(sidebarChatThreads$) ?? [];
 
-  return onDomEventFn(async (event: ReactKeyboardEvent<HTMLElement>) => {
-    if (event.defaultPrevented) {
-      return;
-    }
-    if (matchShortcut("mod+arrowup", event)) {
-      event.preventDefault();
-      scrollCurrentThread(thread, "top");
-      return;
-    }
-    if (matchShortcut("mod+arrowdown", event)) {
-      event.preventDefault();
-      scrollCurrentThread(thread, "bottom");
-      return;
-    }
-    if (matchShortcut("mod+shift+arrowup", event)) {
-      event.preventDefault();
-      await navigateToAdjacentThread(
-        {
-          currentThreadId: thread.threadId,
-          direction: "prev",
-          threads: sidebarThreads,
-        },
-        pageSignal,
-      );
-      return;
-    }
-    if (matchShortcut("mod+shift+arrowdown", event)) {
-      event.preventDefault();
-      await navigateToAdjacentThread(
-        {
-          currentThreadId: thread.threadId,
-          direction: "next",
-          threads: sidebarThreads,
-        },
-        pageSignal,
-      );
-      return;
-    }
+  return (thread: ChatThreadSignals) => {
+    return onDomEventFn(async (event: ReactKeyboardEvent<HTMLElement>) => {
+      if (event.defaultPrevented) {
+        return;
+      }
+      if (matchShortcut("mod+arrowup", event)) {
+        event.preventDefault();
+        scrollCurrentThread(thread, "top");
+        return;
+      }
+      if (matchShortcut("mod+arrowdown", event)) {
+        event.preventDefault();
+        scrollCurrentThread(thread, "bottom");
+        return;
+      }
+      if (matchShortcut("mod+shift+arrowup", event)) {
+        event.preventDefault();
+        await navigateToAdjacentThread(
+          {
+            currentThreadId: thread.threadId,
+            direction: "prev",
+            threads: sidebarThreads,
+          },
+          pageSignal,
+        );
+        return;
+      }
+      if (matchShortcut("mod+shift+arrowdown", event)) {
+        event.preventDefault();
+        await navigateToAdjacentThread(
+          {
+            currentThreadId: thread.threadId,
+            direction: "next",
+            threads: sidebarThreads,
+          },
+          pageSignal,
+        );
+        return;
+      }
 
-    if (matchShortcut("shift+/", event) && !isEditableTarget(event.target)) {
-      event.preventDefault();
-      setShortcutHelpOpen(true);
-    }
-  });
+      if (matchShortcut("shift+/", event) && !isEditableTarget(event.target)) {
+        event.preventDefault();
+        setShortcutHelpOpen(true);
+      }
+    });
+  };
 }
 
 function ChatThreadContent({ thread }: { thread: ChatThreadSignals }) {

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -1,5 +1,3 @@
-// TODO(#8609): split large components to comply with max-lines-per-function (128)
-// oxlint-disable max-lines-per-function
 import type { ReactNode } from "react";
 import {
   useLastLoadable,
@@ -175,35 +173,14 @@ function ManagePinnedAgentsDialogContainer() {
   );
 }
 
-// Nav content for both sidebars: subscribes to feature flags, default agent name, slack scope
-function SidebarNavContent() {
-  const activeId = useGet(activeRoute$);
-  const off = useGet(sidebarOff$);
-  const toggleOff = useSet(toggleSidebarOff$);
-  const expanded = useGet(sidebarExpanded$);
-  const setExpanded = useSet(setSidebarExpanded$);
-  const onCollapse = () => {
-    setExpanded(false);
-    return toggleOff();
-  };
-  const rawOnSelect = useSet(handleZeroNavSelect$);
-  const onAccountAction = useSet(handleZeroAccountAction$);
-  const pageSignal = useGet(pageSignal$);
-  const onSelect = (id: SidebarNavId) => {
-    rawOnSelect(id, pageSignal);
-    setExpanded(false);
-  };
-  const isScrolled = useGet(isScrolled$);
-  const setIsScrolledFn = useSet(setIsScrolled$);
-  const manageCollapsed = useGet(manageSectionCollapsed$);
-  const setManageCollapsed = useSet(setManageSectionCollapsed$);
+// Shared subscription hooks. Each sibling component pulls its own state from
+// signals via these instead of receiving anything from a parent through props.
 
+function useResolvedNavItems() {
   const features = useLastResolved(featureSwitch$);
   const defaultDisplayName = useLastResolved(defaultAgentName$) ?? "Zero";
-  const slackScopeMismatch = useLastResolved(slackOrgScopeMismatch$) ?? false;
   const desktopLocalAgentAvailable =
     typeof window !== "undefined" && Boolean(window.vm0DesktopLocalAgent);
-
   const manageNav = MANAGE_NAV.filter((item) => {
     if (item.id === "activities") {
       return features?.[FeatureSwitchKey.ZeroDebug];
@@ -222,7 +199,87 @@ function SidebarNavContent() {
       label: item.label.replace("Zero", defaultDisplayName),
     };
   });
+  return { manageNav, footerNav };
+}
 
+function useNavSelect() {
+  const rawOnSelect = useSet(handleZeroNavSelect$);
+  const setExpanded = useSet(setSidebarExpanded$);
+  const pageSignal = useGet(pageSignal$);
+  return (id: SidebarNavId) => {
+    rawOnSelect(id, pageSignal);
+    setExpanded(false);
+  };
+}
+
+function useSidebarCollapseToggle() {
+  const toggleOff = useSet(toggleSidebarOff$);
+  const setExpanded = useSet(setSidebarExpanded$);
+  return () => {
+    setExpanded(false);
+    toggleOff();
+  };
+}
+
+// Wraps AccountDropdown with the handler subscription so siblings don't have
+// to thread onAccountAction through props.
+function AccountDropdownContainer({
+  collapsed = false,
+}: {
+  collapsed?: boolean;
+}) {
+  const onAccountAction = useSet(handleZeroAccountAction$);
+  return (
+    <AccountDropdown onAccountAction={onAccountAction} collapsed={collapsed} />
+  );
+}
+
+// --- Collapsed icon-only sidebar (desktop, only when sidebarOff) ---
+
+function CollapsedSidebar() {
+  const off = useGet(sidebarOff$);
+  if (!off) {
+    return null;
+  }
+  return (
+    <aside className="zero-nav box-border hidden md:flex h-full w-16 shrink-0 flex-col border-r-[0.7px] border-sidebar-border bg-sidebar px-2 transition-all duration-300">
+      <CollapsedExpandButton />
+      <CollapsedNavList />
+      <CollapsedFooter />
+    </aside>
+  );
+}
+
+function CollapsedExpandButton() {
+  const onCollapse = useSidebarCollapseToggle();
+  return (
+    <div className="flex w-full shrink-0 justify-center pt-3 pb-1">
+      <TooltipProvider delayDuration={200}>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-sidebar-foreground/70 transition-colors hover:bg-[hsl(var(--gray-200))] hover:text-sidebar-foreground"
+              onClick={onCollapse}
+              aria-label="Expand sidebar"
+            >
+              <IconLayoutSidebarLeftCollapse size={18} className="rotate-180" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="right">
+            <p className="text-xs">Expand sidebar</p>
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+    </div>
+  );
+}
+
+function CollapsedNavList() {
+  const activeId = useGet(activeRoute$);
+  const slackScopeMismatch = useLastResolved(slackOrgScopeMismatch$) ?? false;
+  const onSelect = useNavSelect();
+  const { manageNav, footerNav } = useResolvedNavItems();
   const allNavItems = [
     ...manageNav.map(({ id, activeKeys, pathname: p, label, icon }) => {
       return { id, activeKeys, pathname: p, label, icon };
@@ -238,345 +295,357 @@ function SidebarNavContent() {
       return { id, activeKeys, pathname: p, label, icon };
     }),
   ];
-
   return (
-    <>
-      {/* Collapsed icon-only sidebar — desktop only, only rendered when sidebarOff */}
-      {off && (
-        <aside className="zero-nav box-border hidden md:flex h-full w-16 shrink-0 flex-col border-r-[0.7px] border-sidebar-border bg-sidebar px-2 transition-all duration-300">
-          <div className="flex w-full shrink-0 justify-center pt-3 pb-1">
-            <TooltipProvider delayDuration={200}>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <button
-                    type="button"
-                    className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-sidebar-foreground/70 transition-colors hover:bg-[hsl(var(--gray-200))] hover:text-sidebar-foreground"
-                    onClick={onCollapse}
-                    aria-label="Expand sidebar"
-                  >
-                    <IconLayoutSidebarLeftCollapse
-                      size={18}
-                      className="rotate-180"
-                    />
-                  </button>
-                </TooltipTrigger>
-                <TooltipContent side="right">
-                  <p className="text-xs">Expand sidebar</p>
-                </TooltipContent>
-              </Tooltip>
-            </TooltipProvider>
-          </div>
-
-          <nav className="flex min-h-0 w-full min-w-0 flex-1 flex-col items-center gap-1 pb-2 pt-0">
-            <TooltipProvider delayDuration={100}>
-              {allNavItems.map(
-                ({ id, activeKeys, pathname: navPath, label, icon: Icon }) => {
-                  const isActive =
-                    activeId !== null &&
-                    (activeKeys as readonly RouteKey[]).includes(activeId);
-                  return (
-                    <div
-                      key={id}
-                      className="flex w-full shrink-0 justify-center"
-                    >
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <Link
-                            pathname={
-                              navPath as Parameters<typeof Link>[0]["pathname"]
-                            }
-                            onClick={(e) => {
-                              if (e.metaKey || e.ctrlKey || e.shiftKey) {
-                                return;
-                              }
-                              e.preventDefault();
-                              if (id === "chat") {
-                                onSelect("chat");
-                              } else {
-                                onSelect(id);
-                              }
-                            }}
-                            className={`inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg transition-colors duration-200 ${
-                              isActive
-                                ? "bg-gray-200 text-gray-900"
-                                : "text-sidebar-foreground hover:bg-sidebar-accent"
-                            }`}
-                          >
-                            <span className="relative inline-flex">
-                              <Icon size={16} className="shrink-0" />
-                              {id === "works" && slackScopeMismatch && (
-                                <span className="absolute -top-0.5 -right-0.5 h-2 w-2 rounded-full bg-red-500" />
-                              )}
-                            </span>
-                          </Link>
-                        </TooltipTrigger>
-                        <TooltipContent side="right">
-                          <p className="text-xs">{label}</p>
-                        </TooltipContent>
-                      </Tooltip>
-                    </div>
-                  );
-                },
-              )}
-            </TooltipProvider>
-          </nav>
-
-          <div className="flex w-full shrink-0 flex-col items-center gap-1 pb-2 pt-1">
-            <TooltipProvider delayDuration={200}>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Link
-                    pathname="/insights"
-                    onClick={(e) => {
-                      if (e.metaKey || e.ctrlKey || e.shiftKey) {
-                        return;
-                      }
-                      e.preventDefault();
-                      onSelect("insights");
-                    }}
-                    className={`inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg transition-colors duration-200 ${
-                      activeId === "insights"
-                        ? "bg-gray-200 text-gray-900"
-                        : "text-sidebar-foreground hover:bg-sidebar-accent"
-                    }`}
-                  >
-                    <IconSparkles size={16} className="shrink-0" />
-                  </Link>
-                </TooltipTrigger>
-                <TooltipContent side="right">
-                  <p className="text-xs">Insights &amp; Usage</p>
-                </TooltipContent>
-              </Tooltip>
-            </TooltipProvider>
-            <AccountDropdown onAccountAction={onAccountAction} collapsed />
-          </div>
-        </aside>
-      )}
-
-      {/* Expanded full sidebar — desktop default, mobile overlay when expanded */}
-      <aside
-        data-sidebar-off={off || undefined}
-        data-sidebar-expanded={expanded || undefined}
-        className="zero-nav hidden md:flex data-[sidebar-off]:md:hidden data-[sidebar-expanded]:max-md:flex h-full w-[300px] shrink-0 flex-col border-r-[0.7px] border-sidebar-border bg-sidebar transition-all duration-300 max-md:fixed max-md:inset-y-0 max-md:left-0 max-md:z-40 max-md:shadow-xl"
-      >
-        {/* Organization switcher */}
-        <div
-          className="shrink-0 px-2 pb-0"
-          style={{ paddingTop: "calc(0.375rem + var(--sat))" }}
-        >
-          <div className="flex items-center justify-between gap-2 rounded-lg py-0.5">
-            <div className="min-w-0 flex-1">
-              <ZeroOrgSwitcher />
-            </div>
-            <TooltipProvider delayDuration={200}>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <button
-                    type="button"
-                    className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-sidebar-foreground/70 hover:text-sidebar-foreground hover:bg-[hsl(var(--gray-200))] transition-colors"
-                    onClick={onCollapse}
-                    aria-label="Collapse sidebar"
-                  >
-                    <IconLayoutSidebarLeftCollapse size={18} />
-                  </button>
-                </TooltipTrigger>
-                <TooltipContent side="bottom">
-                  <p className="text-xs">Collapse sidebar</p>
-                </TooltipContent>
-              </Tooltip>
-            </TooltipProvider>
-          </div>
-        </div>
-
-        <nav
-          aria-label="Sidebar"
-          className="flex-1 flex flex-col min-h-0 overflow-hidden p-2 pt-1"
-        >
-          {/* Manage section */}
-          <div className="shrink-0">
-            <div
-              className="group flex h-8 shrink-0 cursor-pointer items-center justify-between rounded-lg pl-2 pr-0 hover:bg-sidebar-accent transition-colors"
-              onClick={() => {
-                return setManageCollapsed(!manageCollapsed);
-              }}
-            >
-              <span className="flex flex-1 items-center gap-1 truncate text-[13px] font-medium leading-4 text-sidebar-foreground/50 group-hover:text-sidebar-foreground transition-colors">
-                Manage
-                <span className="shrink-0 opacity-0 group-hover:opacity-100 transition-opacity duration-200">
-                  <IconChevronRight
-                    size={12}
-                    stroke={2}
-                    className={manageCollapsed ? "" : "rotate-90"}
-                  />
-                </span>
-              </span>
-            </div>
-            {!manageCollapsed && (
-              <div className="flex flex-col gap-1">
-                {manageNav.map(
-                  ({
-                    id,
-                    activeKeys,
-                    pathname: navPath,
-                    label,
-                    icon: Icon,
-                  }) => {
-                    const isActive =
-                      activeId !== null &&
-                      (activeKeys as readonly RouteKey[]).includes(activeId);
-                    return (
-                      <Link
-                        key={id}
-                        pathname={
-                          navPath as Parameters<typeof Link>[0]["pathname"]
-                        }
-                        onClick={(e) => {
-                          if (e.metaKey || e.ctrlKey || e.shiftKey) {
-                            return;
-                          }
-                          e.preventDefault();
-                          onSelect(id);
-                        }}
-                        aria-current={isActive ? "page" : undefined}
-                        className={`flex w-full h-8 items-center gap-2 rounded-lg p-2 text-left text-sm leading-5 transition-colors duration-200 ${
-                          isActive
-                            ? "bg-gray-200 text-gray-900 font-medium"
-                            : "text-sidebar-foreground hover:bg-sidebar-accent"
-                        }`}
-                      >
-                        <Icon size={16} className="shrink-0" />
-                        <span className="truncate">{label}</span>
-                      </Link>
-                    );
-                  },
-                )}
-              </div>
-            )}
-          </div>
-
-          {/* Scrollable: Pinned + Recent chats */}
-          <OverlayScrollArea
-            className="flex-1 min-h-0 -mx-2 px-2 mt-2 pt-2"
-            data-testid="sidebar-scroll-area"
-            onScroll={(e) => {
-              return setIsScrolledFn(e.currentTarget.scrollTop > 0);
-            }}
-            style={{
-              boxShadow: isScrolled
-                ? "0 -1px 0 0 hsl(var(--border) / 0.4)"
-                : "none",
-            }}
-          >
-            <PinnedAgentListSection />
-            <ChatThreadsSectionWithKey />
-          </OverlayScrollArea>
-        </nav>
-
-        {/* Upgrade card */}
-        <div className="px-2">
-          <SidebarUpgradeCard />
-        </div>
-
-        {/* Footer nav */}
-        <div className="p-2">
-          <div className="flex flex-col gap-1">
-            {footerNav.map(
-              ({
-                id,
-                activeKeys,
-                pathname: navPath,
-                label,
-                icon: Icon,
-                iconImg,
-              }) => {
-                const isActive =
-                  activeId !== null &&
-                  (activeKeys as readonly RouteKey[]).includes(activeId);
-                return (
-                  <Link
-                    key={id}
-                    pathname={navPath as Parameters<typeof Link>[0]["pathname"]}
-                    onClick={(e) => {
-                      if (e.metaKey || e.ctrlKey || e.shiftKey) {
-                        return;
-                      }
-                      e.preventDefault();
-                      onSelect(id);
-                    }}
-                    className={`flex w-full h-8 items-center gap-2 rounded-lg p-2 text-left text-sm leading-5 transition-colors duration-200 ${
-                      isActive
-                        ? "bg-gray-200 text-gray-900 font-medium"
-                        : "text-sidebar-foreground hover:bg-sidebar-accent"
-                    }`}
-                  >
-                    {iconImg ? (
-                      <span className="inline-flex h-3.5 w-3.5 shrink-0 items-center justify-center overflow-hidden">
-                        <img
-                          src={iconImg}
-                          alt=""
-                          className="h-3.5 w-3.5 scale-[2.2]"
-                          width={14}
-                          height={14}
-                        />
-                      </span>
-                    ) : (
-                      <Icon size={16} className="shrink-0" />
-                    )}
-                    <span className="truncate flex-1">{label}</span>
-                    {id === "works" && slackScopeMismatch && (
-                      <span
-                        data-testid="slack-scope-mismatch-indicator"
-                        className="h-2 w-2 shrink-0 rounded-full bg-red-500"
-                      />
-                    )}
-                  </Link>
-                );
-              },
-            )}
-            <div className="h-px bg-border/30 mx-1 my-1" />
-            {/* Insights + Account */}
-            <div className="flex items-center gap-1">
-              <div className="flex-1 min-w-0">
-                <AccountDropdown onAccountAction={onAccountAction} />
-              </div>
-              <TooltipProvider delayDuration={200}>
+    <nav className="flex min-h-0 w-full min-w-0 flex-1 flex-col items-center gap-1 pb-2 pt-0">
+      <TooltipProvider delayDuration={100}>
+        {allNavItems.map(
+          ({ id, activeKeys, pathname: navPath, label, icon: Icon }) => {
+            const isActive =
+              activeId !== null &&
+              (activeKeys as readonly RouteKey[]).includes(activeId);
+            return (
+              <div key={id} className="flex w-full shrink-0 justify-center">
                 <Tooltip>
                   <TooltipTrigger asChild>
                     <Link
-                      pathname="/insights"
+                      pathname={
+                        navPath as Parameters<typeof Link>[0]["pathname"]
+                      }
                       onClick={(e) => {
                         if (e.metaKey || e.ctrlKey || e.shiftKey) {
                           return;
                         }
                         e.preventDefault();
-                        onSelect("insights");
+                        onSelect(id);
                       }}
                       className={`inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg transition-colors duration-200 ${
-                        activeId === "insights"
+                        isActive
                           ? "bg-gray-200 text-gray-900"
                           : "text-sidebar-foreground hover:bg-sidebar-accent"
                       }`}
                     >
-                      <IconSparkles size={16} className="shrink-0" />
+                      <span className="relative inline-flex">
+                        <Icon size={16} className="shrink-0" />
+                        {id === "works" && slackScopeMismatch && (
+                          <span className="absolute -top-0.5 -right-0.5 h-2 w-2 rounded-full bg-red-500" />
+                        )}
+                      </span>
                     </Link>
                   </TooltipTrigger>
-                  <TooltipContent side="top">
-                    <p className="text-xs">Insights &amp; Usage</p>
+                  <TooltipContent side="right">
+                    <p className="text-xs">{label}</p>
                   </TooltipContent>
                 </Tooltip>
-              </TooltipProvider>
-            </div>
-          </div>
+              </div>
+            );
+          },
+        )}
+      </TooltipProvider>
+    </nav>
+  );
+}
+
+function CollapsedFooter() {
+  const activeId = useGet(activeRoute$);
+  const onSelect = useNavSelect();
+  return (
+    <div className="flex w-full shrink-0 flex-col items-center gap-1 pb-2 pt-1">
+      <TooltipProvider delayDuration={200}>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Link
+              pathname="/insights"
+              onClick={(e) => {
+                if (e.metaKey || e.ctrlKey || e.shiftKey) {
+                  return;
+                }
+                e.preventDefault();
+                onSelect("insights");
+              }}
+              className={`inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg transition-colors duration-200 ${
+                activeId === "insights"
+                  ? "bg-gray-200 text-gray-900"
+                  : "text-sidebar-foreground hover:bg-sidebar-accent"
+              }`}
+            >
+              <IconSparkles size={16} className="shrink-0" />
+            </Link>
+          </TooltipTrigger>
+          <TooltipContent side="right">
+            <p className="text-xs">Insights &amp; Usage</p>
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+      <AccountDropdownContainer collapsed />
+    </div>
+  );
+}
+
+// --- Expanded full sidebar (desktop default, mobile overlay when expanded) ---
+
+function ExpandedSidebar() {
+  const off = useGet(sidebarOff$);
+  const expanded = useGet(sidebarExpanded$);
+  return (
+    <aside
+      data-sidebar-off={off || undefined}
+      data-sidebar-expanded={expanded || undefined}
+      className="zero-nav hidden md:flex data-[sidebar-off]:md:hidden data-[sidebar-expanded]:max-md:flex h-full w-[300px] shrink-0 flex-col border-r-[0.7px] border-sidebar-border bg-sidebar transition-all duration-300 max-md:fixed max-md:inset-y-0 max-md:left-0 max-md:z-40 max-md:shadow-xl"
+    >
+      <ExpandedHeader />
+      <ExpandedMainNav />
+      <ExpandedUpgradeSection />
+      <ExpandedFooter />
+    </aside>
+  );
+}
+
+function ExpandedHeader() {
+  const onCollapse = useSidebarCollapseToggle();
+  return (
+    <div
+      className="shrink-0 px-2 pb-0"
+      style={{ paddingTop: "calc(0.375rem + var(--sat))" }}
+    >
+      <div className="flex items-center justify-between gap-2 rounded-lg py-0.5">
+        <div className="min-w-0 flex-1">
+          <ZeroOrgSwitcher />
         </div>
-      </aside>
-    </>
+        <TooltipProvider delayDuration={200}>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-sidebar-foreground/70 hover:text-sidebar-foreground hover:bg-[hsl(var(--gray-200))] transition-colors"
+                onClick={onCollapse}
+                aria-label="Collapse sidebar"
+              >
+                <IconLayoutSidebarLeftCollapse size={18} />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">
+              <p className="text-xs">Collapse sidebar</p>
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      </div>
+    </div>
+  );
+}
+
+function ExpandedMainNav() {
+  return (
+    <nav
+      aria-label="Sidebar"
+      className="flex-1 flex flex-col min-h-0 overflow-hidden p-2 pt-1"
+    >
+      <ExpandedManageSection />
+      <ExpandedScrollArea />
+    </nav>
+  );
+}
+
+function ExpandedManageSection() {
+  const activeId = useGet(activeRoute$);
+  const onSelect = useNavSelect();
+  const { manageNav } = useResolvedNavItems();
+  const manageCollapsed = useGet(manageSectionCollapsed$);
+  const setManageCollapsed = useSet(setManageSectionCollapsed$);
+  return (
+    <div className="shrink-0">
+      <div
+        className="group flex h-8 shrink-0 cursor-pointer items-center justify-between rounded-lg pl-2 pr-0 hover:bg-sidebar-accent transition-colors"
+        onClick={() => {
+          return setManageCollapsed(!manageCollapsed);
+        }}
+      >
+        <span className="flex flex-1 items-center gap-1 truncate text-[13px] font-medium leading-4 text-sidebar-foreground/50 group-hover:text-sidebar-foreground transition-colors">
+          Manage
+          <span className="shrink-0 opacity-0 group-hover:opacity-100 transition-opacity duration-200">
+            <IconChevronRight
+              size={12}
+              stroke={2}
+              className={manageCollapsed ? "" : "rotate-90"}
+            />
+          </span>
+        </span>
+      </div>
+      {!manageCollapsed && (
+        <div className="flex flex-col gap-1">
+          {manageNav.map(
+            ({ id, activeKeys, pathname: navPath, label, icon: Icon }) => {
+              const isActive =
+                activeId !== null &&
+                (activeKeys as readonly RouteKey[]).includes(activeId);
+              return (
+                <Link
+                  key={id}
+                  pathname={navPath as Parameters<typeof Link>[0]["pathname"]}
+                  onClick={(e) => {
+                    if (e.metaKey || e.ctrlKey || e.shiftKey) {
+                      return;
+                    }
+                    e.preventDefault();
+                    onSelect(id);
+                  }}
+                  aria-current={isActive ? "page" : undefined}
+                  className={`flex w-full h-8 items-center gap-2 rounded-lg p-2 text-left text-sm leading-5 transition-colors duration-200 ${
+                    isActive
+                      ? "bg-gray-200 text-gray-900 font-medium"
+                      : "text-sidebar-foreground hover:bg-sidebar-accent"
+                  }`}
+                >
+                  <Icon size={16} className="shrink-0" />
+                  <span className="truncate">{label}</span>
+                </Link>
+              );
+            },
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ExpandedScrollArea() {
+  const isScrolled = useGet(isScrolled$);
+  const setIsScrolledFn = useSet(setIsScrolled$);
+  return (
+    <OverlayScrollArea
+      className="flex-1 min-h-0 -mx-2 px-2 mt-2 pt-2"
+      data-testid="sidebar-scroll-area"
+      onScroll={(e) => {
+        return setIsScrolledFn(e.currentTarget.scrollTop > 0);
+      }}
+      style={{
+        boxShadow: isScrolled ? "0 -1px 0 0 hsl(var(--border) / 0.4)" : "none",
+      }}
+    >
+      <PinnedAgentListSection />
+      <ChatThreadsSectionWithKey />
+    </OverlayScrollArea>
+  );
+}
+
+function ExpandedUpgradeSection() {
+  return (
+    <div className="px-2">
+      <SidebarUpgradeCard />
+    </div>
+  );
+}
+
+function ExpandedFooter() {
+  const activeId = useGet(activeRoute$);
+  const onSelect = useNavSelect();
+  const slackScopeMismatch = useLastResolved(slackOrgScopeMismatch$) ?? false;
+  const { footerNav } = useResolvedNavItems();
+  return (
+    <div className="p-2">
+      <div className="flex flex-col gap-1">
+        {footerNav.map(
+          ({
+            id,
+            activeKeys,
+            pathname: navPath,
+            label,
+            icon: Icon,
+            iconImg,
+          }) => {
+            const isActive =
+              activeId !== null &&
+              (activeKeys as readonly RouteKey[]).includes(activeId);
+            return (
+              <Link
+                key={id}
+                pathname={navPath as Parameters<typeof Link>[0]["pathname"]}
+                onClick={(e) => {
+                  if (e.metaKey || e.ctrlKey || e.shiftKey) {
+                    return;
+                  }
+                  e.preventDefault();
+                  onSelect(id);
+                }}
+                className={`flex w-full h-8 items-center gap-2 rounded-lg p-2 text-left text-sm leading-5 transition-colors duration-200 ${
+                  isActive
+                    ? "bg-gray-200 text-gray-900 font-medium"
+                    : "text-sidebar-foreground hover:bg-sidebar-accent"
+                }`}
+              >
+                {iconImg ? (
+                  <span className="inline-flex h-3.5 w-3.5 shrink-0 items-center justify-center overflow-hidden">
+                    <img
+                      src={iconImg}
+                      alt=""
+                      className="h-3.5 w-3.5 scale-[2.2]"
+                      width={14}
+                      height={14}
+                    />
+                  </span>
+                ) : (
+                  <Icon size={16} className="shrink-0" />
+                )}
+                <span className="truncate flex-1">{label}</span>
+                {id === "works" && slackScopeMismatch && (
+                  <span
+                    data-testid="slack-scope-mismatch-indicator"
+                    className="h-2 w-2 shrink-0 rounded-full bg-red-500"
+                  />
+                )}
+              </Link>
+            );
+          },
+        )}
+        <div className="h-px bg-border/30 mx-1 my-1" />
+        <ExpandedFooterAccountInsights />
+      </div>
+    </div>
+  );
+}
+
+function ExpandedFooterAccountInsights() {
+  const activeId = useGet(activeRoute$);
+  const onSelect = useNavSelect();
+  return (
+    <div className="flex items-center gap-1">
+      <div className="flex-1 min-w-0">
+        <AccountDropdownContainer />
+      </div>
+      <TooltipProvider delayDuration={200}>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Link
+              pathname="/insights"
+              onClick={(e) => {
+                if (e.metaKey || e.ctrlKey || e.shiftKey) {
+                  return;
+                }
+                e.preventDefault();
+                onSelect("insights");
+              }}
+              className={`inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg transition-colors duration-200 ${
+                activeId === "insights"
+                  ? "bg-gray-200 text-gray-900"
+                  : "text-sidebar-foreground hover:bg-sidebar-accent"
+              }`}
+            >
+              <IconSparkles size={16} className="shrink-0" />
+            </Link>
+          </TooltipTrigger>
+          <TooltipContent side="top">
+            <p className="text-xs">Insights &amp; Usage</p>
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+    </div>
   );
 }
 
 export function ZeroSidebar() {
   return (
     <>
-      <SidebarNavContent />
+      <CollapsedSidebar />
+      <ExpandedSidebar />
       <ManagePinnedAgentsDialogContainer />
       <BillingDialog />
     </>


### PR DESCRIPTION
## Summary

Two related changes in the Zero sidebar / chat thread navigation:

1. **Split `SidebarNavContent`** (`zero-sidebar.tsx`) into self-contained components — `CollapsedSidebar`, `ExpandedSidebar`, and their sub-sections. Each child subscribes to its own signals via shared subscription hooks (`useResolvedNavItems`, `useNavSelect`, `useSidebarCollapseToggle`) instead of receiving state through props. Drops the 385-line `SidebarNavContent` function and removes the `oxlint-disable max-lines-per-function` override.

2. **Fix dropped `mod+shift+arrowdown`/`arrowup` keypress** (`zero-chat-thread-page.tsx`). `ChatThread` is keyed by `threadId` and remounts on every thread switch. The inner `useChatThreadKeyDown` calls `useLastResolved(sidebarChatThreads$)`, which is a per-component local snapshot — on a freshly mounted `ChatThread` it returns `undefined` until the signal resolves, yielding `threads=[]` via the `?? []` fallback. A second keypress fired within that window (typical fast user, ~50ms) hit `navigateToAdjacentThread$` with empty threads → `findIndex` returns `-1` → silent BAIL. The fix lifts `useChatThreadKeyDown` (renamed to `useChatThreadKeyDownFactory`) to `ZeroChatThreadPage`, which is not remounted by thread navigation (URL is updated via `pushPathSilently$`), so the snapshot survives across thread switches.

## Verification

- Browser-instrumented two-press test (`50ms` between presses):
  - Before: press 1 navigates after ~90ms; press 2 hits empty `threads` → BAIL → no DOM change.
  - After: press 1 highlights thread 2 after ~93ms; press 2 highlights thread 3 after ~71ms. Both presses landed.
- Visual highlight timing: press → DOM `bg-gray-200` class swap takes ~60–90ms (URL push is ~3ms; the rest is route → component re-render → commit).

## Test plan

- [ ] `cd turbo && pnpm -F @vm0/app check-types`
- [ ] `cd turbo && pnpm -F @vm0/app lint`
- [ ] `cd turbo && pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/ src/signals/chat-page/__tests__/`
- [ ] Manually: open a chat thread, focus the chat section, press `mod+shift+arrowdown` twice in rapid succession — the sidebar highlight should advance by two threads, not one.
- [ ] Manually: collapse/expand sidebar, switch between agents, and confirm pinned/manage/footer sections behave as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)