### PR TITLE
refactor: proxy test slack views publish route to api

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/test-slack-mock.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/test-slack-mock.test.ts
@@ -98,6 +98,17 @@ describe("POST /api/test/slack-mock/*", () => {
     await expect(response.text()).resolves.toBe("Not found");
   });
 
+  it("returns 404 for views.publish outside allowed test environments", async () => {
+    mockEnv("ENV", "production");
+
+    const response = await requestApp(`${BASE_ROUTE}/views.publish`, {
+      method: "POST",
+    });
+
+    expect(response.status).toBe(404);
+    await expect(response.text()).resolves.toBe("Not found");
+  });
+
   it("returns 404 for conversations.history outside allowed test environments", async () => {
     mockEnv("ENV", "production");
 

--- a/turbo/apps/web/__tests__/api-backend-rewrite-proxy.test.ts
+++ b/turbo/apps/web/__tests__/api-backend-rewrite-proxy.test.ts
@@ -1201,6 +1201,21 @@ describe("API backend rewrite proxy behavior", () => {
     ).toBe(false);
   });
 
+  it("matches the test slack mock views.publish rewrite path exactly", () => {
+    expect(
+      matchesApiBackendRewritePath("/api/test/slack-mock/views.publish"),
+    ).toBe(true);
+    expect(
+      matchesApiBackendRewritePath("/api/test/slack-mock/views.publish/extra"),
+    ).toBe(false);
+    expect(matchesApiBackendRewritePath("/api/test/slack-mock/views")).toBe(
+      false,
+    );
+    expect(
+      matchesApiBackendRewritePath("/api/test/slack-mock/views.published"),
+    ).toBe(false);
+  });
+
   it("matches the test slack state rewrite path exactly", () => {
     expect(matchesApiBackendRewritePath("/api/test/slack-state")).toBe(true);
     expect(matchesApiBackendRewritePath("/api/test/slack-state/extra")).toBe(

--- a/turbo/apps/web/__tests__/security-headers.test.ts
+++ b/turbo/apps/web/__tests__/security-headers.test.ts
@@ -401,6 +401,14 @@ const TEST_SLACK_MOCK_USERS_INFO_NEXT_NEGATIVE_PATHS = [
   "/api/test/slack-mock/users",
   "/api/test/slack-mock/users.infos",
 ] as const;
+const TEST_SLACK_MOCK_VIEWS_PUBLISH_REWRITE_SOURCE =
+  "/api/test/slack-mock/views.publish";
+const TEST_SLACK_MOCK_VIEWS_PUBLISH_PATH = "/api/test/slack-mock/views.publish";
+const TEST_SLACK_MOCK_VIEWS_PUBLISH_NEXT_NEGATIVE_PATHS = [
+  "/api/test/slack-mock/views.publish/extra",
+  "/api/test/slack-mock/views",
+  "/api/test/slack-mock/views.published",
+] as const;
 const CRON_AGGREGATE_INSIGHTS_REWRITE_SOURCE = "/api/cron/aggregate-insights";
 const CRON_AGGREGATE_INSIGHTS_PATH = "/api/cron/aggregate-insights";
 const CRON_AGGREGATE_INSIGHTS_NEXT_NEGATIVE_PATHS = [
@@ -1711,6 +1719,11 @@ describe("API backend rewrites", () => {
           source: TEST_SLACK_MOCK_OAUTH_ACCESS_REWRITE_SOURCE,
           destination:
             "https://api.example.test/api/test/slack-mock/oauth.v2.access",
+        },
+        {
+          source: TEST_SLACK_MOCK_VIEWS_PUBLISH_REWRITE_SOURCE,
+          destination:
+            "https://api.example.test/api/test/slack-mock/views.publish",
         },
         {
           source: TEST_SLACK_STATE_REWRITE_SOURCE,
@@ -3800,6 +3813,29 @@ describe("API backend rewrites", () => {
 
     expect(matcher(TEST_SLACK_MOCK_OAUTH_ACCESS_PATH)).toStrictEqual({});
     for (const pathname of TEST_SLACK_MOCK_OAUTH_ACCESS_NEXT_NEGATIVE_PATHS) {
+      expect(matcher(pathname)).toBe(false);
+    }
+  });
+
+  it("should match only the exact test slack mock views.publish rewrite", async () => {
+    vi.stubEnv("VM0_API_BACKEND_URL", "https://api.example.test");
+
+    const rewrites = await getBeforeFileRewrites();
+    const rewrite = rewrites.find((entry) => {
+      return entry.source === TEST_SLACK_MOCK_VIEWS_PUBLISH_REWRITE_SOURCE;
+    });
+    expect(rewrite).toStrictEqual({
+      source: TEST_SLACK_MOCK_VIEWS_PUBLISH_REWRITE_SOURCE,
+      destination: "https://api.example.test/api/test/slack-mock/views.publish",
+    });
+
+    const matcher = getPathMatch(TEST_SLACK_MOCK_VIEWS_PUBLISH_REWRITE_SOURCE, {
+      removeUnnamedParams: true,
+      strict: true,
+    });
+
+    expect(matcher(TEST_SLACK_MOCK_VIEWS_PUBLISH_PATH)).toStrictEqual({});
+    for (const pathname of TEST_SLACK_MOCK_VIEWS_PUBLISH_NEXT_NEGATIVE_PATHS) {
       expect(matcher(pathname)).toBe(false);
     }
   });

--- a/turbo/apps/web/api-backend-rewrites.js
+++ b/turbo/apps/web/api-backend-rewrites.js
@@ -449,6 +449,7 @@ export const API_BACKEND_REWRITES = [
     "/api/test/slack-mock/oauth.v2.access",
   ],
   ["/api/test/slack-mock/users.info", "/api/test/slack-mock/users.info"],
+  ["/api/test/slack-mock/views.publish", "/api/test/slack-mock/views.publish"],
   ["/api/test/slack-state", "/api/test/slack-state"],
   [
     TELEGRAM_WEBHOOK_REWRITE_SOURCE,

--- a/turbo/apps/web/app/api/test/slack-mock/views.publish/route.ts
+++ b/turbo/apps/web/app/api/test/slack-mock/views.publish/route.ts
@@ -1,9 +1,0 @@
-import { NextResponse } from "next/server";
-import { isTestEndpointAllowed } from "../../../../../src/lib/auth/test-endpoint-guard";
-
-export async function POST(request: Request) {
-  if (!isTestEndpointAllowed(request)) {
-    return new NextResponse("Not found", { status: 404 });
-  }
-  return NextResponse.json({ ok: true });
-}

--- a/turbo/apps/web/custom-eslint/baselines/web-api-routes.ts
+++ b/turbo/apps/web/custom-eslint/baselines/web-api-routes.ts
@@ -20,7 +20,6 @@ export const WEB_API_ROUTE_BASELINE = [
   "app/api/telegram/register/route.ts",
   "app/api/telegram/setup-status/route.ts",
   "app/api/telegram/webhook/[telegramBotId]/route.ts",
-  "app/api/test/slack-mock/views.publish/route.ts",
   "app/api/test/telegram-mock/[botToken]/[method]/route.ts",
   "app/api/test/telegram-state/route.ts",
   "app/api/webhooks/agent/checkpoints/prepare-history/route.ts",


### PR DESCRIPTION
## Summary
- remove the legacy web /api/test/slack-mock/views.publish route
- add an exact web-to-api rewrite for /api/test/slack-mock/views.publish
- add API production-guard coverage and web rewrite/baseline coverage

## Validation
- pnpm -F api exec vitest src/signals/routes/__tests__/test-slack-mock.test.ts
- pnpm -F web exec vitest __tests__/security-headers.test.ts __tests__/api-backend-rewrite-proxy.test.ts custom-eslint/__tests__/no-new-api-routes.test.ts src/lib/test-endpoints/__tests__/slack-mock-fixtures-drift.test.ts
- pnpm -F api lint
- pnpm -F web lint
- pnpm exec prettier --check apps/api/src/signals/routes/__tests__/test-slack-mock.test.ts apps/web/__tests__/api-backend-rewrite-proxy.test.ts apps/web/__tests__/security-headers.test.ts apps/web/api-backend-rewrites.js apps/web/custom-eslint/baselines/web-api-routes.ts
- pnpm -F api check-types
- pnpm -F web check-types
- pnpm knip
- git diff --check

Closes #14078