### PR TITLE
fix: keep github oauth on web origin

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/github-oauth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/github-oauth.test.ts
@@ -29,6 +29,8 @@ const context = testContext();
 const store = createStore();
 const APP_ID = "123456";
 const APP_SLUG = "vm0-test";
+const API_ORIGIN = "https://api.vm0.ai";
+const WEB_ORIGIN = "https://www.vm0.ai";
 const TARGET_LOGIN = "test-org";
 const TARGET_TYPE = "Organization";
 
@@ -86,9 +88,21 @@ function newGithubUserId(): string {
   return String(randomInt(1_000_000_000, 9_999_999_999));
 }
 
-async function appRequest(path: string): Promise<Response> {
+async function appRequest(
+  path: string,
+  options: {
+    readonly origin?: string;
+    readonly headers?: HeadersInit;
+  } = {},
+): Promise<Response> {
   const app = createApp({ signal: context.signal });
-  return await app.request(`http://api.test${path}`, { method: "GET" });
+  return await app.request(
+    `${options.origin ?? "http://localhost:3000"}${path}`,
+    {
+      method: "GET",
+      headers: options.headers,
+    },
+  );
 }
 
 async function seedComposeFixture(
@@ -300,6 +314,54 @@ describe("GitHub OAuth API routes", () => {
     );
   });
 
+  it("uses the trusted web origin for GitHub callback redirect_uri", async () => {
+    mockGithubAppEnv({ credentials: false });
+
+    const response = await appRequest(
+      "/api/github/oauth/install?vm0UserId=user-1&composeId=compose-1",
+      {
+        origin: API_ORIGIN,
+        headers: {
+          "x-vm0-web-origin": WEB_ORIGIN,
+        },
+      },
+    );
+
+    expect(response.status).toBe(307);
+    const location = new URL(response.headers.get("location")!);
+    expect(location.searchParams.get("redirect_uri")).toBe(
+      `${WEB_ORIGIN}/api/github/oauth/callback`,
+    );
+  });
+
+  it("ignores untrusted web origins for GitHub callback redirect_uri", async () => {
+    mockGithubAppEnv({ credentials: false });
+
+    const response = await appRequest("/api/github/oauth/install", {
+      headers: {
+        "x-vm0-web-origin": "https://evil.example",
+      },
+    });
+
+    expect(response.status).toBe(307);
+    const location = new URL(response.headers.get("location")!);
+    expect(location.searchParams.get("redirect_uri")).toBe(
+      "http://localhost:3000/api/github/oauth/callback",
+    );
+  });
+
+  it("redirects direct API host install requests to the canonical web route", async () => {
+    mockGithubAppEnv({ credentials: false });
+
+    const path =
+      "/api/github/oauth/install?vm0UserId=user-1&composeId=compose-1";
+    const response = await appRequest(path, { origin: API_ORIGIN });
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toBe(`${WEB_ORIGIN}${path}`);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+  });
+
   it("redirects install requests to GitHub without state when no query is provided", async () => {
     const response = await appRequest("/api/github/oauth/install");
 
@@ -417,6 +479,16 @@ describe("GitHub OAuth API routes", () => {
     const location = response.headers.get("location");
     expect(location).toContain("/works");
     expect(location).not.toContain("error=");
+  });
+
+  it("redirects direct API host callback requests to the canonical web route", async () => {
+    const path =
+      "/api/github/oauth/callback?installation_id=12345&setup_action=update";
+    const response = await appRequest(path, { origin: API_ORIGIN });
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toBe(`${WEB_ORIGIN}${path}`);
+    expect(response.headers.get("cache-control")).toBe("no-store");
   });
 
   it("redirects callback with an error for invalid JSON state", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations-github-get.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations-github-get.test.ts
@@ -16,12 +16,13 @@ import { and, eq } from "drizzle-orm";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
-import { mockEnv, mockOptionalEnv } from "../../../lib/env";
+import { mockOptionalEnv } from "../../../lib/env";
 import { writeDb$ } from "../../external/db";
 
 const context = testContext();
 const store = createStore();
 const writeDb = store.set(writeDb$);
+const WEB_ORIGIN = "https://www.vm0.ai";
 
 interface GithubFixture {
   readonly orgId: string;
@@ -290,24 +291,44 @@ describe("GET /api/integrations/github", () => {
     const fixture = await seedDefaultAgentFixture();
     defaultAgentFixtures.push(fixture);
     mockSession(fixture.userId, fixture.orgId);
-    mockEnv("VM0_API_URL", "https://api.vm0.test");
     mockOptionalEnv("GITHUB_APP_SLUG", "vm0-test");
     const client = setupApp({ context })(integrationsGithubContract);
+    const headers: Record<string, string> = {
+      ...authHeaders(),
+      "x-vm0-web-origin": WEB_ORIGIN,
+    };
 
-    const response = await accept(
-      client.getInstallation({ headers: authHeaders() }),
-      [404],
-    );
+    const response = await accept(client.getInstallation({ headers }), [404]);
 
     expect(response.body).toStrictEqual({
       error: {
         message: "No GitHub installation found",
         code: "NOT_FOUND",
       },
-      installUrl: `https://api.vm0.test/api/github/oauth/install?vm0UserId=${encodeURIComponent(
+      installUrl: `${WEB_ORIGIN}/api/github/oauth/install?vm0UserId=${encodeURIComponent(
         fixture.userId,
       )}&composeId=${fixture.composeId}`,
     });
+  });
+
+  it("ignores untrusted web origins when building installUrl", async () => {
+    const fixture = await seedDefaultAgentFixture();
+    defaultAgentFixtures.push(fixture);
+    mockSession(fixture.userId, fixture.orgId);
+    mockOptionalEnv("GITHUB_APP_SLUG", "vm0-test");
+    const client = setupApp({ context })(integrationsGithubContract);
+    const headers: Record<string, string> = {
+      ...authHeaders(),
+      "x-vm0-web-origin": "https://evil.example",
+    };
+
+    const response = await accept(client.getInstallation({ headers }), [404]);
+
+    expect(response.body.installUrl).toBe(
+      `http://api.test/api/github/oauth/install?vm0UserId=${encodeURIComponent(
+        fixture.userId,
+      )}&composeId=${fixture.composeId}`,
+    );
   });
 
   it("returns linked installation data and agent data", async () => {

--- a/turbo/apps/api/src/signals/routes/github-oauth.ts
+++ b/turbo/apps/api/src/signals/routes/github-oauth.ts
@@ -2,6 +2,7 @@ import { command } from "ccstate";
 import { githubOauthContract } from "@vm0/api-contracts/contracts/github-oauth";
 
 import { queryOf } from "../context/request";
+import { request$ } from "../context/hono";
 import { writeDb$ } from "../external/db";
 import { env, optionalEnv } from "../../lib/env";
 import {
@@ -19,6 +20,10 @@ import {
 } from "../services/github-oauth.service";
 import { encryptSecretValue } from "../services/crypto.utils";
 import type { RouteEntry } from "../route";
+import {
+  getOAuthCanonicalRedirectUrl,
+  getOAuthWebOrigin,
+} from "./oauth-web-origin";
 
 const REDIRECT_STATUS = 307;
 
@@ -26,6 +31,13 @@ function redirectResponse(url: string): Response {
   return new Response(null, {
     status: REDIRECT_STATUS,
     headers: { location: url },
+  });
+}
+
+function noStoreRedirect(url: string): Response {
+  return new Response(null, {
+    status: REDIRECT_STATUS,
+    headers: { location: url, "Cache-Control": "no-store" },
   });
 }
 
@@ -40,8 +52,8 @@ function appUrl(path: string): string {
   return `${env("VM0_WEB_URL")}${path}`;
 }
 
-function callbackRedirectUri(): string {
-  return `${env("VM0_API_URL")}/api/github/oauth/callback`;
+function callbackRedirectUri(origin: string): string {
+  return `${origin}/api/github/oauth/callback`;
 }
 
 function worksErrorRedirect(message: string): Response {
@@ -52,6 +64,12 @@ function worksErrorRedirect(message: string): Response {
 
 const installGithubOauth$ = command(
   async ({ get, set }, signal: AbortSignal) => {
+    const request = get(request$).raw;
+    const canonicalRedirectUrl = getOAuthCanonicalRedirectUrl(request);
+    if (canonicalRedirectUrl) {
+      return noStoreRedirect(canonicalRedirectUrl);
+    }
+    const origin = getOAuthWebOrigin(request);
     const appSlug = optionalEnv("GITHUB_APP_SLUG");
     if (!appSlug) {
       return jsonErrorResponse("GitHub App integration is not configured", 503);
@@ -102,14 +120,20 @@ const installGithubOauth$ = command(
     if (state) {
       installUrl.searchParams.set("state", state);
     }
-    installUrl.searchParams.set("redirect_uri", callbackRedirectUri());
+    installUrl.searchParams.set("redirect_uri", callbackRedirectUri(origin));
 
-    return redirectResponse(installUrl.toString());
+    return noStoreRedirect(installUrl.toString());
   },
 );
 
 const callbackGithubOauth$ = command(
   async ({ get, set }, signal: AbortSignal) => {
+    const request = get(request$).raw;
+    const canonicalRedirectUrl = getOAuthCanonicalRedirectUrl(request);
+    if (canonicalRedirectUrl) {
+      return noStoreRedirect(canonicalRedirectUrl);
+    }
+
     const appId = optionalEnv("GITHUB_APP_ID");
     const privateKey = optionalEnv("GITHUB_APP_PRIVATE_KEY");
 

--- a/turbo/apps/api/src/signals/services/integrations-github.service.ts
+++ b/turbo/apps/api/src/signals/services/integrations-github.service.ts
@@ -14,11 +14,13 @@ import { orgMetadata } from "@vm0/db/schema/org-metadata";
 import { and, eq } from "drizzle-orm";
 
 import { authContext$ } from "../auth/auth-context";
+import { request$ } from "../context/hono";
 import { db$, writeDb$ } from "../external/db";
 import { tapError } from "../utils";
-import { env, optionalEnv } from "../../lib/env";
+import { optionalEnv } from "../../lib/env";
 import { logger } from "../../lib/log";
 import { now, nowDate } from "../../lib/time";
+import { getOAuthWebOrigin } from "../routes/oauth-web-origin";
 import { zeroConnectorList } from "./zero-connector-data.service";
 import { userSecrets, userVariables } from "./zero-user-data.service";
 
@@ -36,12 +38,13 @@ function errorResponse(
 function githubInstallUrl(
   userId: string,
   composeId: string | null,
+  origin: string,
 ): string | null {
   if (!optionalEnv("GITHUB_APP_SLUG")) {
     return null;
   }
 
-  const url = new URL("/api/github/oauth/install", env("VM0_API_URL"));
+  const url = new URL("/api/github/oauth/install", origin);
   url.searchParams.set("vm0UserId", userId);
   if (composeId) {
     url.searchParams.set("composeId", composeId);
@@ -297,6 +300,7 @@ export const updateGithubInstallation$ = command(
 
 export const getGithubInstallation$ = computed(async (get) => {
   const auth = get(authContext$);
+  const origin = getOAuthWebOrigin(get(request$).raw);
   const db = get(db$);
 
   const [result] = await db
@@ -337,7 +341,7 @@ export const getGithubInstallation$ = computed(async (get) => {
           message: "No GitHub installation found",
           code: "NOT_FOUND",
         },
-        installUrl: githubInstallUrl(auth.userId, defaultComposeId),
+        installUrl: githubInstallUrl(auth.userId, defaultComposeId, origin),
       },
     };
   }

--- a/turbo/apps/web/__tests__/api-backend-rewrite-proxy.test.ts
+++ b/turbo/apps/web/__tests__/api-backend-rewrite-proxy.test.ts
@@ -8,7 +8,10 @@ import { createRequire } from "node:module";
 import { parse, type UrlWithParsedQuery } from "node:url";
 import { http as mswHttp, passthrough } from "msw";
 import { describe, expect, it } from "vitest";
-import { matchesApiBackendRewritePath } from "../api-backend-rewrites";
+import {
+  matchesApiBackendRewritePath,
+  matchesGithubOAuthRewritePath,
+} from "../api-backend-rewrites";
 import { server } from "../src/mocks/server";
 
 type ProxyRequest = (
@@ -1043,6 +1046,24 @@ describe("API backend rewrite proxy behavior", () => {
       matchesApiBackendRewritePath("/api/github/oauth/install/extra"),
     ).toBe(false);
     expect(matchesApiBackendRewritePath("/api/github/oauth")).toBe(false);
+  });
+
+  it("matches GitHub OAuth web-origin rewrite paths exactly", () => {
+    expect(matchesGithubOAuthRewritePath("/api/github/oauth/callback")).toBe(
+      true,
+    );
+    expect(matchesGithubOAuthRewritePath("/api/github/oauth/install")).toBe(
+      true,
+    );
+    expect(matchesGithubOAuthRewritePath("/api/integrations/github")).toBe(
+      true,
+    );
+    expect(
+      matchesGithubOAuthRewritePath("/api/github/oauth/callback/extra"),
+    ).toBe(false);
+    expect(
+      matchesGithubOAuthRewritePath("/api/integrations/github/extra"),
+    ).toBe(false);
   });
 
   it("matches the logs search rewrite path exactly", () => {

--- a/turbo/apps/web/__tests__/proxy.sandbox-token.test.ts
+++ b/turbo/apps/web/__tests__/proxy.sandbox-token.test.ts
@@ -345,6 +345,66 @@ describe("proxy middleware: sandbox token handling", () => {
     );
   });
 
+  it("should preserve web origin headers for GitHub OAuth rewrite routes", async () => {
+    const request = new NextRequest(
+      "https://www.vm0.ai/api/github/oauth/install?vm0UserId=user_1&composeId=compose_1",
+      {
+        headers: {
+          cookie: "__session=opaque",
+        },
+      },
+    );
+
+    const response = await middleware(request, createMockEvent());
+    if (!response) {
+      throw new Error("Expected middleware response");
+    }
+
+    expect(capturedClerkRequest).toBeUndefined();
+    expect(response.headers.get("x-middleware-request-cookie")).toBe(
+      "__session=opaque",
+    );
+    expect(response.headers.get("x-middleware-request-x-forwarded-host")).toBe(
+      "www.vm0.ai",
+    );
+    expect(response.headers.get("x-middleware-request-x-forwarded-proto")).toBe(
+      "https",
+    );
+    expect(response.headers.get("x-middleware-request-x-vm0-web-origin")).toBe(
+      "https://www.vm0.ai",
+    );
+  });
+
+  it("should preserve web origin headers for GitHub integration status routes", async () => {
+    const request = new NextRequest(
+      "https://www.vm0.ai/api/integrations/github",
+      {
+        headers: {
+          cookie: "__session=opaque",
+        },
+      },
+    );
+
+    const response = await middleware(request, createMockEvent());
+    if (!response) {
+      throw new Error("Expected middleware response");
+    }
+
+    expect(capturedClerkRequest).toBeUndefined();
+    expect(response.headers.get("x-middleware-request-cookie")).toBe(
+      "__session=opaque",
+    );
+    expect(response.headers.get("x-middleware-request-x-forwarded-host")).toBe(
+      "www.vm0.ai",
+    );
+    expect(response.headers.get("x-middleware-request-x-forwarded-proto")).toBe(
+      "https",
+    );
+    expect(response.headers.get("x-middleware-request-x-vm0-web-origin")).toBe(
+      "https://www.vm0.ai",
+    );
+  });
+
   it("should not add OAuth web origin headers for Slack provider callbacks", async () => {
     const request = new NextRequest(
       "https://www.vm0.ai/api/zero/slack/events",

--- a/turbo/apps/web/api-backend-rewrites.js
+++ b/turbo/apps/web/api-backend-rewrites.js
@@ -135,6 +135,10 @@ const CONNECTORS_CALLBACK_REWRITE_SOURCE = "/api/connectors/:type/callback";
 const CONNECTORS_CALLBACK_PATH_RE = /^\/api\/connectors\/[^/]+\/callback$/;
 const AGENTPHONE_CONNECT_REWRITE_SOURCE = "/api/agentphone/connect";
 const AGENTPHONE_WEBHOOK_REWRITE_SOURCE = "/api/agentphone/webhook";
+const GITHUB_OAUTH_CALLBACK_REWRITE_SOURCE = "/api/github/oauth/callback";
+const GITHUB_OAUTH_INSTALL_REWRITE_SOURCE = "/api/github/oauth/install";
+const GITHUB_OAUTH_PATH_RE = /^\/api\/github\/oauth\/(?:callback|install)$/;
+const INTEGRATIONS_GITHUB_REWRITE_SOURCE = "/api/integrations/github";
 const TELEGRAM_WEBHOOK_REWRITE_SOURCE = "/api/telegram/webhook/:telegramBotId";
 const TELEGRAM_WEBHOOK_PATH_RE = /^\/api\/telegram\/webhook\/[^/]+$/;
 const TELEGRAM_AUTH_CALLBACK_REWRITE_SOURCE =
@@ -354,9 +358,9 @@ export const API_BACKEND_REWRITES = [
   [AGENTPHONE_WEBHOOK_REWRITE_SOURCE, "/api/agentphone/webhook"],
   ["/api/email/unsubscribe", "/api/email/unsubscribe"],
   ["/api/generate-image", "/api/generate-image"],
-  ["/api/github/oauth/callback", "/api/github/oauth/callback"],
-  ["/api/github/oauth/install", "/api/github/oauth/install"],
-  ["/api/integrations/github", "/api/integrations/github"],
+  [GITHUB_OAUTH_CALLBACK_REWRITE_SOURCE, "/api/github/oauth/callback"],
+  [GITHUB_OAUTH_INSTALL_REWRITE_SOURCE, "/api/github/oauth/install"],
+  [INTEGRATIONS_GITHUB_REWRITE_SOURCE, "/api/integrations/github"],
   [
     TELEGRAM_AUTH_CALLBACK_REWRITE_SOURCE,
     "/api/integrations/telegram/auth-callback",
@@ -827,9 +831,17 @@ export function matchesConnectorOAuthRewritePath(pathname) {
   );
 }
 
+export function matchesGithubOAuthRewritePath(pathname) {
+  return (
+    GITHUB_OAUTH_PATH_RE.test(pathname) ||
+    pathname === INTEGRATIONS_GITHUB_REWRITE_SOURCE
+  );
+}
+
 export function matchesOAuthWebOriginRewritePath(pathname) {
   return (
     matchesConnectorOAuthRewritePath(pathname) ||
-    ZERO_SLACK_OAUTH_PATH_RE.test(pathname)
+    ZERO_SLACK_OAUTH_PATH_RE.test(pathname) ||
+    matchesGithubOAuthRewritePath(pathname)
   );
 }

--- a/turbo/apps/web/proxy.ts
+++ b/turbo/apps/web/proxy.ts
@@ -77,7 +77,7 @@ const isPublicRoute = createRouteMatcher([
 const SANDBOX_TOKEN_PREFIX = "vm0_sandbox_";
 const PAT_TOKEN_PREFIX = "vm0_pat_";
 const TEST_ENDPOINT_BYPASS_HEADER = "x-vm0-test-endpoint-bypass";
-const CONNECTOR_OAUTH_WEB_ORIGIN_HEADER = "x-vm0-web-origin";
+const OAUTH_WEB_ORIGIN_HEADER = "x-vm0-web-origin";
 
 function apiBackendProxyPassThrough(request: NextRequest): NextResponse {
   const requestHeaders = new Headers(request.headers);
@@ -87,10 +87,7 @@ function apiBackendProxyPassThrough(request: NextRequest): NextResponse {
     request.nextUrl.protocol.slice(0, -1),
   );
   if (matchesOAuthWebOriginRewritePath(request.nextUrl.pathname)) {
-    requestHeaders.set(
-      CONNECTOR_OAUTH_WEB_ORIGIN_HEADER,
-      request.nextUrl.origin,
-    );
+    requestHeaders.set(OAUTH_WEB_ORIGIN_HEADER, request.nextUrl.origin);
   }
   const bypass = env().VERCEL_AUTOMATION_BYPASS_SECRET;
   if (bypass) {


### PR DESCRIPTION
## Summary

- Use the route-scoped `x-vm0-web-origin` contract for GitHub OAuth install/callback routes.
- Return GitHub install URLs from `/api/integrations/github` on the trusted web origin when called through the web rewrite.
- Canonicalize direct API-host GitHub OAuth install/callback browser entries back to the matching web route.
- Extend web proxy/header tests and API route tests for valid and invalid web-origin behavior.

Fixes #14045

## Validation

- `pnpm -F api exec vitest run src/signals/routes/__tests__/github-oauth.test.ts src/signals/routes/__tests__/integrations-github-get.test.ts`
- `pnpm -F web exec vitest run __tests__/api-backend-rewrite-proxy.test.ts __tests__/proxy.sandbox-token.test.ts __tests__/security-headers.test.ts`
- `pnpm format`
- `pnpm -F api lint`
- `pnpm -F web lint`
- `pnpm check-types`
- `git diff --check`
