### PR TITLE
fix: keep github webhooks on web origin

### DIFF
--- a/turbo/apps/web/__tests__/api-backend-rewrite-proxy.test.ts
+++ b/turbo/apps/web/__tests__/api-backend-rewrite-proxy.test.ts
@@ -1105,6 +1105,14 @@ describe("API backend rewrite proxy behavior", () => {
     expect(matchesApiBackendRewritePath("/api/integrations")).toBe(false);
   });
 
+  it("matches the GitHub webhook rewrite path exactly", () => {
+    expect(matchesApiBackendRewritePath("/api/webhooks/github")).toBe(true);
+    expect(matchesApiBackendRewritePath("/api/webhooks/github/extra")).toBe(
+      false,
+    );
+    expect(matchesApiBackendRewritePath("/api/webhooks")).toBe(false);
+  });
+
   it("matches the storages commit rewrite path exactly", () => {
     expect(matchesApiBackendRewritePath("/api/storages/commit")).toBe(true);
     expect(matchesApiBackendRewritePath("/api/storages/commit/extra")).toBe(
@@ -2440,6 +2448,48 @@ describe("API backend rewrite proxy behavior", () => {
         expect(payload.headers["x-webhook-id"]).toBe("webhook-agentphone-1");
         expect(payload.headers["x-webhook-timestamp"]).toBe("1710000000");
         expect(payload.headers["x-webhook-signature"]).toBe(
+          "sha256=test-signature",
+        );
+        expect(payload.body).toBe(webhookBody);
+      },
+    );
+  });
+
+  it("forwards GitHub webhook POST bodies and signature headers", async () => {
+    await withRewriteProxy(
+      async (request) => {
+        return Response.json({
+          method: request.method,
+          url: request.url,
+          headers: request.headers,
+          body: await readRequestBody(request),
+        });
+      },
+      async (origin) => {
+        const webhookBody = JSON.stringify({
+          zen: "Non-blocking webhook migrations",
+        });
+        const response = await fetch(
+          `${origin}/api/webhooks/github?from=github`,
+          {
+            method: "POST",
+            headers: {
+              "content-type": "application/json",
+              "x-github-delivery": "delivery-github-1",
+              "x-github-event": "ping",
+              "x-hub-signature-256": "sha256=test-signature",
+            },
+            body: webhookBody,
+          },
+        );
+
+        const payload = (await response.json()) as EchoPayload;
+        expect(payload.method).toBe("POST");
+        expect(payload.url).toBe("/api/webhooks/github?from=github");
+        expect(payload.headers["content-type"]).toContain("application/json");
+        expect(payload.headers["x-github-delivery"]).toBe("delivery-github-1");
+        expect(payload.headers["x-github-event"]).toBe("ping");
+        expect(payload.headers["x-hub-signature-256"]).toBe(
           "sha256=test-signature",
         );
         expect(payload.body).toBe(webhookBody);

--- a/turbo/apps/web/__tests__/proxy.sandbox-token.test.ts
+++ b/turbo/apps/web/__tests__/proxy.sandbox-token.test.ts
@@ -491,4 +491,31 @@ describe("proxy middleware: sandbox token handling", () => {
       false,
     );
   });
+
+  it("should not add OAuth web origin headers for GitHub provider webhooks", async () => {
+    const request = new NextRequest("https://www.vm0.ai/api/webhooks/github", {
+      method: "POST",
+      headers: {
+        "x-github-delivery": "delivery-github-1",
+        "x-github-event": "ping",
+        "x-hub-signature-256": "sha256=test-signature",
+      },
+    });
+
+    const response = await middleware(request, createMockEvent());
+    if (!response) {
+      throw new Error("Expected middleware response");
+    }
+
+    expect(capturedClerkRequest).toBeUndefined();
+    expect(response.headers.get("x-middleware-request-x-forwarded-host")).toBe(
+      "www.vm0.ai",
+    );
+    expect(response.headers.get("x-middleware-request-x-forwarded-proto")).toBe(
+      "https",
+    );
+    expect(response.headers.has("x-middleware-request-x-vm0-web-origin")).toBe(
+      false,
+    );
+  });
 });

--- a/turbo/apps/web/__tests__/security-headers.test.ts
+++ b/turbo/apps/web/__tests__/security-headers.test.ts
@@ -591,6 +591,12 @@ const INTEGRATIONS_GITHUB_NEXT_NEGATIVE_PATHS = [
   "/api/integrations/github/extra",
   "/api/integrations",
 ] as const;
+const GITHUB_WEBHOOK_REWRITE_SOURCE = "/api/webhooks/github";
+const GITHUB_WEBHOOK_PATH = "/api/webhooks/github";
+const GITHUB_WEBHOOK_NEXT_NEGATIVE_PATHS = [
+  "/api/webhooks/github/extra",
+  "/api/webhooks",
+] as const;
 const STORAGES_COMMIT_REWRITE_SOURCE = "/api/storages/commit";
 const STORAGES_COMMIT_PATH = "/api/storages/commit";
 const STORAGES_COMMIT_NEXT_NEGATIVE_PATHS = [
@@ -1675,6 +1681,10 @@ describe("API backend rewrites", () => {
         {
           source: INTEGRATIONS_GITHUB_REWRITE_SOURCE,
           destination: "https://api.example.test/api/integrations/github",
+        },
+        {
+          source: GITHUB_WEBHOOK_REWRITE_SOURCE,
+          destination: "https://api.example.test/api/webhooks/github",
         },
         {
           source: STORAGES_COMMIT_REWRITE_SOURCE,
@@ -3545,6 +3555,29 @@ describe("API backend rewrites", () => {
 
     expect(matcher(INTEGRATIONS_GITHUB_PATH)).toStrictEqual({});
     for (const pathname of INTEGRATIONS_GITHUB_NEXT_NEGATIVE_PATHS) {
+      expect(matcher(pathname)).toBe(false);
+    }
+  });
+
+  it("should match only the exact GitHub webhook rewrite", async () => {
+    vi.stubEnv("VM0_API_BACKEND_URL", "https://api.example.test");
+
+    const rewrites = await getBeforeFileRewrites();
+    const rewrite = rewrites.find((entry) => {
+      return entry.source === GITHUB_WEBHOOK_REWRITE_SOURCE;
+    });
+    expect(rewrite).toStrictEqual({
+      source: GITHUB_WEBHOOK_REWRITE_SOURCE,
+      destination: "https://api.example.test/api/webhooks/github",
+    });
+
+    const matcher = getPathMatch(GITHUB_WEBHOOK_REWRITE_SOURCE, {
+      removeUnnamedParams: true,
+      strict: true,
+    });
+
+    expect(matcher(GITHUB_WEBHOOK_PATH)).toStrictEqual({});
+    for (const pathname of GITHUB_WEBHOOK_NEXT_NEGATIVE_PATHS) {
       expect(matcher(pathname)).toBe(false);
     }
   });

--- a/turbo/apps/web/api-backend-rewrites.js
+++ b/turbo/apps/web/api-backend-rewrites.js
@@ -139,6 +139,7 @@ const GITHUB_OAUTH_CALLBACK_REWRITE_SOURCE = "/api/github/oauth/callback";
 const GITHUB_OAUTH_INSTALL_REWRITE_SOURCE = "/api/github/oauth/install";
 const GITHUB_OAUTH_PATH_RE = /^\/api\/github\/oauth\/(?:callback|install)$/;
 const INTEGRATIONS_GITHUB_REWRITE_SOURCE = "/api/integrations/github";
+const GITHUB_WEBHOOK_REWRITE_SOURCE = "/api/webhooks/github";
 const TELEGRAM_WEBHOOK_REWRITE_SOURCE = "/api/telegram/webhook/:telegramBotId";
 const TELEGRAM_WEBHOOK_PATH_RE = /^\/api\/telegram\/webhook\/[^/]+$/;
 const TELEGRAM_AUTH_CALLBACK_REWRITE_SOURCE =
@@ -361,6 +362,7 @@ export const API_BACKEND_REWRITES = [
   [GITHUB_OAUTH_CALLBACK_REWRITE_SOURCE, "/api/github/oauth/callback"],
   [GITHUB_OAUTH_INSTALL_REWRITE_SOURCE, "/api/github/oauth/install"],
   [INTEGRATIONS_GITHUB_REWRITE_SOURCE, "/api/integrations/github"],
+  [GITHUB_WEBHOOK_REWRITE_SOURCE, "/api/webhooks/github"],
   [
     TELEGRAM_AUTH_CALLBACK_REWRITE_SOURCE,
     "/api/integrations/telegram/auth-callback",


### PR DESCRIPTION
## Summary
- add an exact web-to-API rewrite for `/api/webhooks/github`
- cover the GitHub webhook route in rewrite matcher and Next rewrite-output tests
- verify the rewrite proxy preserves GitHub webhook POST body and signature headers without adding the OAuth web-origin header

Fixes #14046

## Validation
- `pnpm -F web exec vitest run __tests__/api-backend-rewrite-proxy.test.ts __tests__/proxy.sandbox-token.test.ts __tests__/security-headers.test.ts`
- `pnpm format`
- `pnpm -F web lint`
- `pnpm check-types`
- `git diff --check`
