### PR TITLE
fix: keep stripe webhooks on web origin

### DIFF
--- a/turbo/apps/web/__tests__/api-backend-rewrite-proxy.test.ts
+++ b/turbo/apps/web/__tests__/api-backend-rewrite-proxy.test.ts
@@ -1123,6 +1123,14 @@ describe("API backend rewrite proxy behavior", () => {
     expect(matchesApiBackendRewritePath("/api/webhooks")).toBe(false);
   });
 
+  it("matches the Stripe webhook rewrite path exactly", () => {
+    expect(matchesApiBackendRewritePath("/api/webhooks/stripe")).toBe(true);
+    expect(matchesApiBackendRewritePath("/api/webhooks/stripe/extra")).toBe(
+      false,
+    );
+    expect(matchesApiBackendRewritePath("/api/webhooks")).toBe(false);
+  });
+
   it("matches the storages commit rewrite path exactly", () => {
     expect(matchesApiBackendRewritePath("/api/storages/commit")).toBe(true);
     expect(matchesApiBackendRewritePath("/api/storages/commit/extra")).toBe(
@@ -2501,6 +2509,45 @@ describe("API backend rewrite proxy behavior", () => {
         expect(payload.headers["x-github-event"]).toBe("ping");
         expect(payload.headers["x-hub-signature-256"]).toBe(
           "sha256=test-signature",
+        );
+        expect(payload.body).toBe(webhookBody);
+      },
+    );
+  });
+
+  it("forwards Stripe webhook POST bodies and signature headers", async () => {
+    await withRewriteProxy(
+      async (request) => {
+        return Response.json({
+          method: request.method,
+          url: request.url,
+          headers: request.headers,
+          body: await readRequestBody(request),
+        });
+      },
+      async (origin) => {
+        const webhookBody = JSON.stringify({
+          id: "evt_stripe_1",
+          type: "invoice.paid",
+        });
+        const response = await fetch(
+          `${origin}/api/webhooks/stripe?from=stripe`,
+          {
+            method: "POST",
+            headers: {
+              "content-type": "application/json",
+              "stripe-signature": "t=1710000000,v1=test-signature",
+            },
+            body: webhookBody,
+          },
+        );
+
+        const payload = (await response.json()) as EchoPayload;
+        expect(payload.method).toBe("POST");
+        expect(payload.url).toBe("/api/webhooks/stripe?from=stripe");
+        expect(payload.headers["content-type"]).toContain("application/json");
+        expect(payload.headers["stripe-signature"]).toBe(
+          "t=1710000000,v1=test-signature",
         );
         expect(payload.body).toBe(webhookBody);
       },

--- a/turbo/apps/web/__tests__/proxy.sandbox-token.test.ts
+++ b/turbo/apps/web/__tests__/proxy.sandbox-token.test.ts
@@ -518,4 +518,29 @@ describe("proxy middleware: sandbox token handling", () => {
       false,
     );
   });
+
+  it("should not add OAuth web origin headers for Stripe provider webhooks", async () => {
+    const request = new NextRequest("https://www.vm0.ai/api/webhooks/stripe", {
+      method: "POST",
+      headers: {
+        "stripe-signature": "t=1710000000,v1=test-signature",
+      },
+    });
+
+    const response = await middleware(request, createMockEvent());
+    if (!response) {
+      throw new Error("Expected middleware response");
+    }
+
+    expect(capturedClerkRequest).toBeUndefined();
+    expect(response.headers.get("x-middleware-request-x-forwarded-host")).toBe(
+      "www.vm0.ai",
+    );
+    expect(response.headers.get("x-middleware-request-x-forwarded-proto")).toBe(
+      "https",
+    );
+    expect(response.headers.has("x-middleware-request-x-vm0-web-origin")).toBe(
+      false,
+    );
+  });
 });

--- a/turbo/apps/web/__tests__/security-headers.test.ts
+++ b/turbo/apps/web/__tests__/security-headers.test.ts
@@ -604,6 +604,12 @@ const GITHUB_WEBHOOK_NEXT_NEGATIVE_PATHS = [
   "/api/webhooks/github/extra",
   "/api/webhooks",
 ] as const;
+const STRIPE_WEBHOOK_REWRITE_SOURCE = "/api/webhooks/stripe";
+const STRIPE_WEBHOOK_PATH = "/api/webhooks/stripe";
+const STRIPE_WEBHOOK_NEXT_NEGATIVE_PATHS = [
+  "/api/webhooks/stripe/extra",
+  "/api/webhooks",
+] as const;
 const STORAGES_COMMIT_REWRITE_SOURCE = "/api/storages/commit";
 const STORAGES_COMMIT_PATH = "/api/storages/commit";
 const STORAGES_COMMIT_NEXT_NEGATIVE_PATHS = [
@@ -1692,6 +1698,10 @@ describe("API backend rewrites", () => {
         {
           source: GITHUB_WEBHOOK_REWRITE_SOURCE,
           destination: "https://api.example.test/api/webhooks/github",
+        },
+        {
+          source: STRIPE_WEBHOOK_REWRITE_SOURCE,
+          destination: "https://api.example.test/api/webhooks/stripe",
         },
         {
           source: STORAGES_COMMIT_REWRITE_SOURCE,
@@ -3613,6 +3623,29 @@ describe("API backend rewrites", () => {
 
     expect(matcher(GITHUB_WEBHOOK_PATH)).toStrictEqual({});
     for (const pathname of GITHUB_WEBHOOK_NEXT_NEGATIVE_PATHS) {
+      expect(matcher(pathname)).toBe(false);
+    }
+  });
+
+  it("should match only the exact Stripe webhook rewrite", async () => {
+    vi.stubEnv("VM0_API_BACKEND_URL", "https://api.example.test");
+
+    const rewrites = await getBeforeFileRewrites();
+    const rewrite = rewrites.find((entry) => {
+      return entry.source === STRIPE_WEBHOOK_REWRITE_SOURCE;
+    });
+    expect(rewrite).toStrictEqual({
+      source: STRIPE_WEBHOOK_REWRITE_SOURCE,
+      destination: "https://api.example.test/api/webhooks/stripe",
+    });
+
+    const matcher = getPathMatch(STRIPE_WEBHOOK_REWRITE_SOURCE, {
+      removeUnnamedParams: true,
+      strict: true,
+    });
+
+    expect(matcher(STRIPE_WEBHOOK_PATH)).toStrictEqual({});
+    for (const pathname of STRIPE_WEBHOOK_NEXT_NEGATIVE_PATHS) {
       expect(matcher(pathname)).toBe(false);
     }
   });

--- a/turbo/apps/web/api-backend-rewrites.js
+++ b/turbo/apps/web/api-backend-rewrites.js
@@ -140,6 +140,7 @@ const GITHUB_OAUTH_INSTALL_REWRITE_SOURCE = "/api/github/oauth/install";
 const GITHUB_OAUTH_PATH_RE = /^\/api\/github\/oauth\/(?:callback|install)$/;
 const INTEGRATIONS_GITHUB_REWRITE_SOURCE = "/api/integrations/github";
 const GITHUB_WEBHOOK_REWRITE_SOURCE = "/api/webhooks/github";
+const STRIPE_WEBHOOK_REWRITE_SOURCE = "/api/webhooks/stripe";
 const TELEGRAM_WEBHOOK_REWRITE_SOURCE = "/api/telegram/webhook/:telegramBotId";
 const TELEGRAM_WEBHOOK_PATH_RE = /^\/api\/telegram\/webhook\/[^/]+$/;
 const TELEGRAM_AUTH_CALLBACK_REWRITE_SOURCE =
@@ -363,6 +364,7 @@ export const API_BACKEND_REWRITES = [
   [GITHUB_OAUTH_INSTALL_REWRITE_SOURCE, "/api/github/oauth/install"],
   [INTEGRATIONS_GITHUB_REWRITE_SOURCE, "/api/integrations/github"],
   [GITHUB_WEBHOOK_REWRITE_SOURCE, "/api/webhooks/github"],
+  [STRIPE_WEBHOOK_REWRITE_SOURCE, "/api/webhooks/stripe"],
   [
     TELEGRAM_AUTH_CALLBACK_REWRITE_SOURCE,
     "/api/integrations/telegram/auth-callback",


### PR DESCRIPTION
## Summary
- add an exact web-to-API rewrite for `/api/webhooks/stripe`
- cover the Stripe webhook route in rewrite matcher and Next rewrite-output tests
- verify the rewrite proxy preserves Stripe webhook POST body and `stripe-signature` without adding the OAuth web-origin header

Fixes #14047

## Validation
- `pnpm -F web exec vitest run __tests__/api-backend-rewrite-proxy.test.ts __tests__/proxy.sandbox-token.test.ts __tests__/security-headers.test.ts`
- `pnpm format`
- `pnpm -F web lint`
- `pnpm check-types`
- `git diff --check`
