### PR TITLE
fix: keep clerk webhooks on web origin

### DIFF
--- a/turbo/apps/web/__tests__/api-backend-rewrite-proxy.test.ts
+++ b/turbo/apps/web/__tests__/api-backend-rewrite-proxy.test.ts
@@ -1123,6 +1123,14 @@ describe("API backend rewrite proxy behavior", () => {
     expect(matchesApiBackendRewritePath("/api/webhooks")).toBe(false);
   });
 
+  it("matches the Clerk webhook rewrite path exactly", () => {
+    expect(matchesApiBackendRewritePath("/api/webhooks/clerk")).toBe(true);
+    expect(matchesApiBackendRewritePath("/api/webhooks/clerk/extra")).toBe(
+      false,
+    );
+    expect(matchesApiBackendRewritePath("/api/webhooks")).toBe(false);
+  });
+
   it("matches the Stripe webhook rewrite path exactly", () => {
     expect(matchesApiBackendRewritePath("/api/webhooks/stripe")).toBe(true);
     expect(matchesApiBackendRewritePath("/api/webhooks/stripe/extra")).toBe(
@@ -2520,6 +2528,47 @@ describe("API backend rewrite proxy behavior", () => {
         expect(payload.headers["x-hub-signature-256"]).toBe(
           "sha256=test-signature",
         );
+        expect(payload.body).toBe(webhookBody);
+      },
+    );
+  });
+
+  it("forwards Clerk webhook POST bodies and Svix signature headers", async () => {
+    await withRewriteProxy(
+      async (request) => {
+        return Response.json({
+          method: request.method,
+          url: request.url,
+          headers: request.headers,
+          body: await readRequestBody(request),
+        });
+      },
+      async (origin) => {
+        const webhookBody = JSON.stringify({
+          data: { id: "org_clerk_1" },
+          type: "organization.deleted",
+        });
+        const response = await fetch(
+          `${origin}/api/webhooks/clerk?from=clerk`,
+          {
+            method: "POST",
+            headers: {
+              "content-type": "application/json",
+              "svix-id": "msg_clerk_1",
+              "svix-signature": "v1,test-signature",
+              "svix-timestamp": "1710000000",
+            },
+            body: webhookBody,
+          },
+        );
+
+        const payload = (await response.json()) as EchoPayload;
+        expect(payload.method).toBe("POST");
+        expect(payload.url).toBe("/api/webhooks/clerk?from=clerk");
+        expect(payload.headers["content-type"]).toContain("application/json");
+        expect(payload.headers["svix-id"]).toBe("msg_clerk_1");
+        expect(payload.headers["svix-signature"]).toBe("v1,test-signature");
+        expect(payload.headers["svix-timestamp"]).toBe("1710000000");
         expect(payload.body).toBe(webhookBody);
       },
     );

--- a/turbo/apps/web/__tests__/proxy.sandbox-token.test.ts
+++ b/turbo/apps/web/__tests__/proxy.sandbox-token.test.ts
@@ -519,6 +519,33 @@ describe("proxy middleware: sandbox token handling", () => {
     );
   });
 
+  it("should not add OAuth web origin headers for Clerk provider webhooks", async () => {
+    const request = new NextRequest("https://www.vm0.ai/api/webhooks/clerk", {
+      method: "POST",
+      headers: {
+        "svix-id": "msg_clerk_1",
+        "svix-signature": "v1,test-signature",
+        "svix-timestamp": "1710000000",
+      },
+    });
+
+    const response = await middleware(request, createMockEvent());
+    if (!response) {
+      throw new Error("Expected middleware response");
+    }
+
+    expect(capturedClerkRequest).toBeUndefined();
+    expect(response.headers.get("x-middleware-request-x-forwarded-host")).toBe(
+      "www.vm0.ai",
+    );
+    expect(response.headers.get("x-middleware-request-x-forwarded-proto")).toBe(
+      "https",
+    );
+    expect(response.headers.has("x-middleware-request-x-vm0-web-origin")).toBe(
+      false,
+    );
+  });
+
   it("should not add OAuth web origin headers for Stripe provider webhooks", async () => {
     const request = new NextRequest("https://www.vm0.ai/api/webhooks/stripe", {
       method: "POST",

--- a/turbo/apps/web/__tests__/security-headers.test.ts
+++ b/turbo/apps/web/__tests__/security-headers.test.ts
@@ -598,6 +598,12 @@ const INTEGRATIONS_GITHUB_NEXT_NEGATIVE_PATHS = [
   "/api/integrations/github/extra",
   "/api/integrations",
 ] as const;
+const CLERK_WEBHOOK_REWRITE_SOURCE = "/api/webhooks/clerk";
+const CLERK_WEBHOOK_PATH = "/api/webhooks/clerk";
+const CLERK_WEBHOOK_NEXT_NEGATIVE_PATHS = [
+  "/api/webhooks/clerk/extra",
+  "/api/webhooks",
+] as const;
 const GITHUB_WEBHOOK_REWRITE_SOURCE = "/api/webhooks/github";
 const GITHUB_WEBHOOK_PATH = "/api/webhooks/github";
 const GITHUB_WEBHOOK_NEXT_NEGATIVE_PATHS = [
@@ -1700,6 +1706,10 @@ describe("API backend rewrites", () => {
         {
           source: INTEGRATIONS_GITHUB_REWRITE_SOURCE,
           destination: "https://api.example.test/api/integrations/github",
+        },
+        {
+          source: CLERK_WEBHOOK_REWRITE_SOURCE,
+          destination: "https://api.example.test/api/webhooks/clerk",
         },
         {
           source: GITHUB_WEBHOOK_REWRITE_SOURCE,
@@ -3633,6 +3643,29 @@ describe("API backend rewrites", () => {
 
     expect(matcher(GITHUB_WEBHOOK_PATH)).toStrictEqual({});
     for (const pathname of GITHUB_WEBHOOK_NEXT_NEGATIVE_PATHS) {
+      expect(matcher(pathname)).toBe(false);
+    }
+  });
+
+  it("should match only the exact Clerk webhook rewrite", async () => {
+    vi.stubEnv("VM0_API_BACKEND_URL", "https://api.example.test");
+
+    const rewrites = await getBeforeFileRewrites();
+    const rewrite = rewrites.find((entry) => {
+      return entry.source === CLERK_WEBHOOK_REWRITE_SOURCE;
+    });
+    expect(rewrite).toStrictEqual({
+      source: CLERK_WEBHOOK_REWRITE_SOURCE,
+      destination: "https://api.example.test/api/webhooks/clerk",
+    });
+
+    const matcher = getPathMatch(CLERK_WEBHOOK_REWRITE_SOURCE, {
+      removeUnnamedParams: true,
+      strict: true,
+    });
+
+    expect(matcher(CLERK_WEBHOOK_PATH)).toStrictEqual({});
+    for (const pathname of CLERK_WEBHOOK_NEXT_NEGATIVE_PATHS) {
       expect(matcher(pathname)).toBe(false);
     }
   });

--- a/turbo/apps/web/api-backend-rewrites.js
+++ b/turbo/apps/web/api-backend-rewrites.js
@@ -139,6 +139,7 @@ const GITHUB_OAUTH_CALLBACK_REWRITE_SOURCE = "/api/github/oauth/callback";
 const GITHUB_OAUTH_INSTALL_REWRITE_SOURCE = "/api/github/oauth/install";
 const GITHUB_OAUTH_PATH_RE = /^\/api\/github\/oauth\/(?:callback|install)$/;
 const INTEGRATIONS_GITHUB_REWRITE_SOURCE = "/api/integrations/github";
+const CLERK_WEBHOOK_REWRITE_SOURCE = "/api/webhooks/clerk";
 const GITHUB_WEBHOOK_REWRITE_SOURCE = "/api/webhooks/github";
 const STRIPE_WEBHOOK_REWRITE_SOURCE = "/api/webhooks/stripe";
 const TELEGRAM_WEBHOOK_REWRITE_SOURCE = "/api/telegram/webhook/:telegramBotId";
@@ -363,6 +364,7 @@ export const API_BACKEND_REWRITES = [
   [GITHUB_OAUTH_CALLBACK_REWRITE_SOURCE, "/api/github/oauth/callback"],
   [GITHUB_OAUTH_INSTALL_REWRITE_SOURCE, "/api/github/oauth/install"],
   [INTEGRATIONS_GITHUB_REWRITE_SOURCE, "/api/integrations/github"],
+  [CLERK_WEBHOOK_REWRITE_SOURCE, "/api/webhooks/clerk"],
   [GITHUB_WEBHOOK_REWRITE_SOURCE, "/api/webhooks/github"],
   [STRIPE_WEBHOOK_REWRITE_SOURCE, "/api/webhooks/stripe"],
   [


### PR DESCRIPTION
## Summary
- add an exact web-to-API rewrite for `/api/webhooks/clerk`
- cover matcher and Next rewrite-output behavior for the Clerk webhook path
- verify the web proxy preserves Clerk webhook POST bodies and Svix signature headers without adding the OAuth web-origin header

Fixes #14048

## Validation
- `pnpm -F web exec vitest run __tests__/api-backend-rewrite-proxy.test.ts __tests__/proxy.sandbox-token.test.ts __tests__/security-headers.test.ts`
- `pnpm format`
- `pnpm -F web lint`
- `pnpm check-types`
- `git diff --check`
