### PR TITLE
fix: generate FAL webhooks on web origin

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-image-io-generate.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-image-io-generate.test.ts
@@ -14,6 +14,7 @@ import { runUploadedFiles } from "@vm0/db/schema/run-uploaded-file";
 import { usageEvent } from "@vm0/db/schema/usage-event";
 import { usagePricing } from "@vm0/db/schema/usage-pricing";
 import { testContext } from "../../../__tests__/test-helpers";
+import { mockEnv } from "../../../lib/env";
 import { clearMockNow, mockNow } from "../../../lib/time";
 import { server } from "../../../mocks/server";
 import { signSandboxJwtForTests } from "../../auth/tokens";
@@ -64,6 +65,7 @@ const FAL_FLUX_PROVIDER_CREDITS_PER_MEGAPIXEL = 40;
 const FAL_FLUX_MARKED_UP_CREDITS_PER_MEGAPIXEL = Math.ceil(
   FAL_FLUX_PROVIDER_CREDITS_PER_MEGAPIXEL * IMAGE_PRICING_MARKUP_MULTIPLIER,
 );
+const WEB_ORIGIN = "https://www.vm0.test";
 const MISSING_PRICING_IMAGE_MODEL = "gpt-image-2";
 const IMAGE_PRICING_CATEGORIES = [
   "output_image.low.standard",
@@ -625,6 +627,7 @@ describe("POST /api/zero/image-io/generate", () => {
   let releasePendingFalResponse: (() => void) | null = null;
 
   beforeEach(() => {
+    mockEnv("VM0_WEB_URL", WEB_ORIGIN);
     context.mocks.clerk.authenticateRequest.mockReset();
     context.mocks.clerk.authenticateRequest.mockResolvedValue({
       isAuthenticated: false,
@@ -938,7 +941,11 @@ describe("POST /api/zero/image-io/generate", () => {
       prompt: "A small robot paints a sunflower.",
     });
     await clearAllDetached();
-    expect(readWebhookUrl(observedRequestUrl)).toContain(generationId);
+    const webhookUrl = new URL(readWebhookUrl(observedRequestUrl));
+    expect(webhookUrl.origin).toBe(WEB_ORIGIN);
+    expect(webhookUrl.pathname).toBe(
+      `/api/webhooks/built-in-generations/fal/${generationId}`,
+    );
     expect(context.mocks.ably.publish).toHaveBeenCalledWith(
       `built-in-generation:${generationId}`,
       expect.objectContaining({

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-video-io-generate.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-video-io-generate.test.ts
@@ -13,6 +13,7 @@ import { runUploadedFiles } from "@vm0/db/schema/run-uploaded-file";
 import { usageEvent } from "@vm0/db/schema/usage-event";
 import { usagePricing } from "@vm0/db/schema/usage-pricing";
 import { testContext } from "../../../__tests__/test-helpers";
+import { mockEnv } from "../../../lib/env";
 import { server } from "../../../mocks/server";
 import { signSandboxJwtForTests } from "../../auth/tokens";
 import { writeDb$ } from "../../external/db";
@@ -61,6 +62,7 @@ const SEEDANCE_STATUS_URL =
 const SEEDANCE_RESPONSE_URL =
   "https://queue.fal.run/bytedance/seedance-2.0/fast/text-to-video/requests/seedance-video-request/response";
 const SEEDANCE_VIDEO_URL = "https://v3b.fal.media/files/seedance-output.mp4";
+const WEB_ORIGIN = "https://www.vm0.test";
 const VIDEO_SECOND_PRICING_CATEGORIES = [
   "output_video_seconds.audio",
   "output_video_seconds.silent",
@@ -499,6 +501,7 @@ describe("POST /api/zero/video-io/generate", () => {
   );
 
   beforeEach(() => {
+    mockEnv("VM0_WEB_URL", WEB_ORIGIN);
     context.mocks.clerk.authenticateRequest.mockReset();
     context.mocks.clerk.authenticateRequest.mockResolvedValue({
       isAuthenticated: false,
@@ -689,7 +692,11 @@ describe("POST /api/zero/video-io/generate", () => {
       },
     });
     await clearAllDetached();
-    expect(readWebhookUrl(observedRequestUrl)).toContain(generationId);
+    const webhookUrl = new URL(readWebhookUrl(observedRequestUrl));
+    expect(webhookUrl.origin).toBe(WEB_ORIGIN);
+    expect(webhookUrl.pathname).toBe(
+      `/api/webhooks/built-in-generations/fal/${generationId}`,
+    );
     expect(context.mocks.ably.publish).toHaveBeenCalledWith(
       `built-in-generation:${generationId}`,
       expect.objectContaining({

--- a/turbo/apps/api/src/signals/services/built-in-generation-provider-webhooks.service.ts
+++ b/turbo/apps/api/src/signals/services/built-in-generation-provider-webhooks.service.ts
@@ -54,7 +54,7 @@ export function falBuiltInGenerationWebhookUrl(args: {
 }): string {
   const baseUrl = new URL(
     `/api/webhooks/built-in-generations/fal/${args.generationId}`,
-    env("VM0_API_URL"),
+    env("VM0_WEB_URL"),
   );
   baseUrl.searchParams.set(
     "token",

--- a/turbo/apps/web/__tests__/api-backend-rewrite-proxy.test.ts
+++ b/turbo/apps/web/__tests__/api-backend-rewrite-proxy.test.ts
@@ -1318,7 +1318,7 @@ describe("API backend rewrite proxy behavior", () => {
     ).toBe(false);
   });
 
-  it("matches built-in generation webhook rewrites", () => {
+  it("matches the FAL built-in generation webhook rewrite path exactly", () => {
     expect(
       matchesApiBackendRewritePath(
         "/api/webhooks/built-in-generations/fal/550e8400-e29b-41d4-a716-446655440000",
@@ -1328,7 +1328,12 @@ describe("API backend rewrite proxy behavior", () => {
       matchesApiBackendRewritePath(
         "/api/webhooks/built-in-generations/fal/550e8400-e29b-41d4-a716-446655440000/extra",
       ),
-    ).toBe(true);
+    ).toBe(false);
+    expect(
+      matchesApiBackendRewritePath(
+        "/api/webhooks/built-in-generations/fal/not-a-uuid",
+      ),
+    ).toBe(false);
     expect(matchesApiBackendRewritePath("/api/webhooks")).toBe(false);
     expect(
       matchesApiBackendRewritePath("/api/webhooks/built-in-generation"),
@@ -2625,6 +2630,46 @@ describe("API backend rewrite proxy behavior", () => {
         expect(payload.headers["stripe-signature"]).toBe(
           "t=1710000000,v1=test-signature",
         );
+        expect(payload.body).toBe(webhookBody);
+      },
+    );
+  });
+
+  it("forwards FAL built-in generation webhook POST bodies", async () => {
+    await withRewriteProxy(
+      async (request) => {
+        return Response.json({
+          method: request.method,
+          url: request.url,
+          headers: request.headers,
+          body: await readRequestBody(request),
+        });
+      },
+      async (origin) => {
+        const generationId = "550e8400-e29b-41d4-a716-446655440000";
+        const webhookBody = JSON.stringify({
+          status: "COMPLETED",
+          payload: {
+            images: [{ url: "https://fal.media/files/test.webp" }],
+          },
+        });
+        const response = await fetch(
+          `${origin}/api/webhooks/built-in-generations/fal/${generationId}?token=test-token`,
+          {
+            method: "POST",
+            headers: {
+              "content-type": "application/json",
+            },
+            body: webhookBody,
+          },
+        );
+
+        const payload = (await response.json()) as EchoPayload;
+        expect(payload.method).toBe("POST");
+        expect(payload.url).toBe(
+          `/api/webhooks/built-in-generations/fal/${generationId}?token=test-token`,
+        );
+        expect(payload.headers["content-type"]).toContain("application/json");
         expect(payload.body).toBe(webhookBody);
       },
     );

--- a/turbo/apps/web/__tests__/proxy.sandbox-token.test.ts
+++ b/turbo/apps/web/__tests__/proxy.sandbox-token.test.ts
@@ -570,4 +570,32 @@ describe("proxy middleware: sandbox token handling", () => {
       false,
     );
   });
+
+  it("should not add OAuth web origin headers for FAL provider webhooks", async () => {
+    const request = new NextRequest(
+      "https://www.vm0.ai/api/webhooks/built-in-generations/fal/550e8400-e29b-41d4-a716-446655440000?token=test-token",
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+      },
+    );
+
+    const response = await middleware(request, createMockEvent());
+    if (!response) {
+      throw new Error("Expected middleware response");
+    }
+
+    expect(capturedClerkRequest).toBeUndefined();
+    expect(response.headers.get("x-middleware-request-x-forwarded-host")).toBe(
+      "www.vm0.ai",
+    );
+    expect(response.headers.get("x-middleware-request-x-forwarded-proto")).toBe(
+      "https",
+    );
+    expect(response.headers.has("x-middleware-request-x-vm0-web-origin")).toBe(
+      false,
+    );
+  });
 });

--- a/turbo/apps/web/__tests__/security-headers.test.ts
+++ b/turbo/apps/web/__tests__/security-headers.test.ts
@@ -606,6 +606,15 @@ const INTEGRATIONS_GITHUB_NEXT_NEGATIVE_PATHS = [
   "/api/integrations/github/extra",
   "/api/integrations",
 ] as const;
+const BUILT_IN_GENERATIONS_FAL_WEBHOOK_REWRITE_SOURCE =
+  "/api/webhooks/built-in-generations/fal/:generationId([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})";
+const BUILT_IN_GENERATIONS_FAL_WEBHOOK_PATH =
+  "/api/webhooks/built-in-generations/fal/550e8400-e29b-41d4-a716-446655440000";
+const BUILT_IN_GENERATIONS_FAL_WEBHOOK_NEXT_NEGATIVE_PATHS = [
+  "/api/webhooks/built-in-generations/fal/not-a-uuid",
+  "/api/webhooks/built-in-generations/fal/550e8400-e29b-41d4-a716-446655440000/extra",
+  "/api/webhooks/built-in-generations",
+] as const;
 const CLERK_WEBHOOK_REWRITE_SOURCE = "/api/webhooks/clerk";
 const CLERK_WEBHOOK_PATH = "/api/webhooks/clerk";
 const CLERK_WEBHOOK_NEXT_NEGATIVE_PATHS = [
@@ -1719,6 +1728,11 @@ describe("API backend rewrites", () => {
         {
           source: INTEGRATIONS_GITHUB_REWRITE_SOURCE,
           destination: "https://api.example.test/api/integrations/github",
+        },
+        {
+          source: BUILT_IN_GENERATIONS_FAL_WEBHOOK_REWRITE_SOURCE,
+          destination:
+            "https://api.example.test/api/webhooks/built-in-generations/fal/:generationId",
         },
         {
           source: CLERK_WEBHOOK_REWRITE_SOURCE,
@@ -3656,6 +3670,35 @@ describe("API backend rewrites", () => {
 
     expect(matcher(GITHUB_WEBHOOK_PATH)).toStrictEqual({});
     for (const pathname of GITHUB_WEBHOOK_NEXT_NEGATIVE_PATHS) {
+      expect(matcher(pathname)).toBe(false);
+    }
+  });
+
+  it("should match only the exact FAL built-in generation webhook rewrite", async () => {
+    vi.stubEnv("VM0_API_BACKEND_URL", "https://api.example.test");
+
+    const rewrites = await getBeforeFileRewrites();
+    const rewrite = rewrites.find((entry) => {
+      return entry.source === BUILT_IN_GENERATIONS_FAL_WEBHOOK_REWRITE_SOURCE;
+    });
+    expect(rewrite).toStrictEqual({
+      source: BUILT_IN_GENERATIONS_FAL_WEBHOOK_REWRITE_SOURCE,
+      destination:
+        "https://api.example.test/api/webhooks/built-in-generations/fal/:generationId",
+    });
+
+    const matcher = getPathMatch(
+      BUILT_IN_GENERATIONS_FAL_WEBHOOK_REWRITE_SOURCE,
+      {
+        removeUnnamedParams: true,
+        strict: true,
+      },
+    );
+
+    expect(matcher(BUILT_IN_GENERATIONS_FAL_WEBHOOK_PATH)).toStrictEqual({
+      generationId: "550e8400-e29b-41d4-a716-446655440000",
+    });
+    for (const pathname of BUILT_IN_GENERATIONS_FAL_WEBHOOK_NEXT_NEGATIVE_PATHS) {
       expect(matcher(pathname)).toBe(false);
     }
   });

--- a/turbo/apps/web/api-backend-rewrites.js
+++ b/turbo/apps/web/api-backend-rewrites.js
@@ -142,6 +142,10 @@ const GITHUB_OAUTH_CALLBACK_REWRITE_SOURCE = "/api/github/oauth/callback";
 const GITHUB_OAUTH_INSTALL_REWRITE_SOURCE = "/api/github/oauth/install";
 const GITHUB_OAUTH_PATH_RE = /^\/api\/github\/oauth\/(?:callback|install)$/;
 const INTEGRATIONS_GITHUB_REWRITE_SOURCE = "/api/integrations/github";
+const BUILT_IN_GENERATIONS_FAL_WEBHOOK_REWRITE_SOURCE = `/api/webhooks/built-in-generations/fal/:generationId(${UUID_PATH_SEGMENT_PATTERN})`;
+const BUILT_IN_GENERATIONS_FAL_WEBHOOK_PATH_RE = new RegExp(
+  `^/api/webhooks/built-in-generations/fal/${UUID_PATH_SEGMENT_PATTERN}$`,
+);
 const CLERK_WEBHOOK_REWRITE_SOURCE = "/api/webhooks/clerk";
 const GITHUB_WEBHOOK_REWRITE_SOURCE = "/api/webhooks/github";
 const STRIPE_WEBHOOK_REWRITE_SOURCE = "/api/webhooks/stripe";
@@ -381,8 +385,9 @@ export const API_BACKEND_REWRITES = [
   ["/api/storages/prepare", "/api/storages/prepare"],
   ["/api/usage", "/api/usage"],
   [
-    "/api/webhooks/built-in-generations/:path*",
-    "/api/webhooks/built-in-generations/:path*",
+    BUILT_IN_GENERATIONS_FAL_WEBHOOK_REWRITE_SOURCE,
+    "/api/webhooks/built-in-generations/fal/:generationId",
+    BUILT_IN_GENERATIONS_FAL_WEBHOOK_PATH_RE,
   ],
   ["/api/integrations/agentphone/link", "/api/integrations/agentphone/link"],
   ["/api/internal/callbacks/agent", "/api/internal/callbacks/agent"],


### PR DESCRIPTION
## Summary

- Generate FAL built-in generation webhook URLs from `VM0_WEB_URL` instead of `VM0_API_URL`.
- Tighten the web-to-API rewrite to the exact FAL built-in generation webhook UUID path.
- Add API route and web rewrite/proxy coverage for the web-origin callback path.

Fixes #14049

## Testing

- `pnpm -F web exec vitest run __tests__/api-backend-rewrite-proxy.test.ts __tests__/proxy.sandbox-token.test.ts __tests__/security-headers.test.ts`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-image-io-generate.test.ts src/signals/routes/__tests__/zero-video-io-generate.test.ts`
- `pnpm format`
- `pnpm -F web lint`
- `pnpm -F api lint`
- `pnpm check-types`
- `git diff --check`

Note: `pnpm -F web db:migrate` was run locally before the API route tests because the test DB was missing the latest built-in generation tables after pulling main.