### PR TITLE
fix: keep resend inbound webhook on web origin

### DIFF
--- a/turbo/apps/web/__tests__/api-backend-rewrite-proxy.test.ts
+++ b/turbo/apps/web/__tests__/api-backend-rewrite-proxy.test.ts
@@ -1069,6 +1069,14 @@ describe("API backend rewrite proxy behavior", () => {
     expect(matchesApiBackendRewritePath("/api/email")).toBe(false);
   });
 
+  it("matches the inbound email provider webhook rewrite path exactly", () => {
+    expect(matchesApiBackendRewritePath("/api/zero/email/inbound")).toBe(true);
+    expect(matchesApiBackendRewritePath("/api/zero/email/inbound/extra")).toBe(
+      false,
+    );
+    expect(matchesApiBackendRewritePath("/api/zero/email")).toBe(false);
+  });
+
   it("matches the generate image rewrite path exactly", () => {
     expect(matchesApiBackendRewritePath("/api/generate-image")).toBe(true);
     expect(matchesApiBackendRewritePath("/api/generate-image/extra")).toBe(
@@ -2589,6 +2597,51 @@ describe("API backend rewrite proxy behavior", () => {
         expect(payload.url).toBe("/api/webhooks/clerk?from=clerk");
         expect(payload.headers["content-type"]).toContain("application/json");
         expect(payload.headers["svix-id"]).toBe("msg_clerk_1");
+        expect(payload.headers["svix-signature"]).toBe("v1,test-signature");
+        expect(payload.headers["svix-timestamp"]).toBe("1710000000");
+        expect(payload.body).toBe(webhookBody);
+      },
+    );
+  });
+
+  it("forwards inbound email webhook POST bodies and Svix signature headers", async () => {
+    await withRewriteProxy(
+      async (request) => {
+        return Response.json({
+          method: request.method,
+          url: request.url,
+          headers: request.headers,
+          body: await readRequestBody(request),
+        });
+      },
+      async (origin) => {
+        const webhookBody = JSON.stringify({
+          type: "email.received",
+          data: {
+            email_id: "email_inbound_1",
+            from: "sender@example.com",
+            to: ["agent@mail.example.com"],
+          },
+        });
+        const response = await fetch(
+          `${origin}/api/zero/email/inbound?from=resend`,
+          {
+            method: "POST",
+            headers: {
+              "content-type": "application/json",
+              "svix-id": "msg_resend_1",
+              "svix-signature": "v1,test-signature",
+              "svix-timestamp": "1710000000",
+            },
+            body: webhookBody,
+          },
+        );
+
+        const payload = (await response.json()) as EchoPayload;
+        expect(payload.method).toBe("POST");
+        expect(payload.url).toBe("/api/zero/email/inbound?from=resend");
+        expect(payload.headers["content-type"]).toContain("application/json");
+        expect(payload.headers["svix-id"]).toBe("msg_resend_1");
         expect(payload.headers["svix-signature"]).toBe("v1,test-signature");
         expect(payload.headers["svix-timestamp"]).toBe("1710000000");
         expect(payload.body).toBe(webhookBody);

--- a/turbo/apps/web/__tests__/proxy.sandbox-token.test.ts
+++ b/turbo/apps/web/__tests__/proxy.sandbox-token.test.ts
@@ -546,6 +546,36 @@ describe("proxy middleware: sandbox token handling", () => {
     );
   });
 
+  it("should not add OAuth web origin headers for inbound email provider webhooks", async () => {
+    const request = new NextRequest(
+      "https://www.vm0.ai/api/zero/email/inbound",
+      {
+        method: "POST",
+        headers: {
+          "svix-id": "msg_resend_1",
+          "svix-signature": "v1,test-signature",
+          "svix-timestamp": "1710000000",
+        },
+      },
+    );
+
+    const response = await middleware(request, createMockEvent());
+    if (!response) {
+      throw new Error("Expected middleware response");
+    }
+
+    expect(capturedClerkRequest).toBeUndefined();
+    expect(response.headers.get("x-middleware-request-x-forwarded-host")).toBe(
+      "www.vm0.ai",
+    );
+    expect(response.headers.get("x-middleware-request-x-forwarded-proto")).toBe(
+      "https",
+    );
+    expect(response.headers.has("x-middleware-request-x-vm0-web-origin")).toBe(
+      false,
+    );
+  });
+
   it("should not add OAuth web origin headers for Stripe provider webhooks", async () => {
     const request = new NextRequest("https://www.vm0.ai/api/webhooks/stripe", {
       method: "POST",

--- a/turbo/apps/web/__tests__/security-headers.test.ts
+++ b/turbo/apps/web/__tests__/security-headers.test.ts
@@ -575,6 +575,12 @@ const EMAIL_UNSUBSCRIBE_NEXT_NEGATIVE_PATHS = [
   "/api/email/unsubscribe/extra",
   "/api/email",
 ] as const;
+const ZERO_EMAIL_INBOUND_REWRITE_SOURCE = "/api/zero/email/inbound";
+const ZERO_EMAIL_INBOUND_PATH = "/api/zero/email/inbound";
+const ZERO_EMAIL_INBOUND_NEXT_NEGATIVE_PATHS = [
+  "/api/zero/email/inbound/extra",
+  "/api/zero/email",
+] as const;
 const GENERATE_IMAGE_REWRITE_SOURCE = "/api/generate-image";
 const GENERATE_IMAGE_PATH = "/api/generate-image";
 const GENERATE_IMAGE_NEXT_NEGATIVE_PATHS = [
@@ -1708,6 +1714,10 @@ describe("API backend rewrites", () => {
         {
           source: EMAIL_UNSUBSCRIBE_REWRITE_SOURCE,
           destination: "https://api.example.test/api/email/unsubscribe",
+        },
+        {
+          source: ZERO_EMAIL_INBOUND_REWRITE_SOURCE,
+          destination: "https://api.example.test/api/zero/email/inbound",
         },
         {
           source: GENERATE_IMAGE_REWRITE_SOURCE,
@@ -3532,6 +3542,29 @@ describe("API backend rewrites", () => {
 
     expect(matcher(EMAIL_UNSUBSCRIBE_PATH)).toStrictEqual({});
     for (const pathname of EMAIL_UNSUBSCRIBE_NEXT_NEGATIVE_PATHS) {
+      expect(matcher(pathname)).toBe(false);
+    }
+  });
+
+  it("should match only the exact inbound email provider webhook rewrite", async () => {
+    vi.stubEnv("VM0_API_BACKEND_URL", "https://api.example.test");
+
+    const rewrites = await getBeforeFileRewrites();
+    const rewrite = rewrites.find((entry) => {
+      return entry.source === ZERO_EMAIL_INBOUND_REWRITE_SOURCE;
+    });
+    expect(rewrite).toStrictEqual({
+      source: ZERO_EMAIL_INBOUND_REWRITE_SOURCE,
+      destination: "https://api.example.test/api/zero/email/inbound",
+    });
+
+    const matcher = getPathMatch(ZERO_EMAIL_INBOUND_REWRITE_SOURCE, {
+      removeUnnamedParams: true,
+      strict: true,
+    });
+
+    expect(matcher(ZERO_EMAIL_INBOUND_PATH)).toStrictEqual({});
+    for (const pathname of ZERO_EMAIL_INBOUND_NEXT_NEGATIVE_PATHS) {
       expect(matcher(pathname)).toBe(false);
     }
   });

--- a/turbo/apps/web/api-backend-rewrites.js
+++ b/turbo/apps/web/api-backend-rewrites.js
@@ -153,6 +153,7 @@ const TELEGRAM_WEBHOOK_REWRITE_SOURCE = "/api/telegram/webhook/:telegramBotId";
 const TELEGRAM_WEBHOOK_PATH_RE = /^\/api\/telegram\/webhook\/[^/]+$/;
 const TELEGRAM_AUTH_CALLBACK_REWRITE_SOURCE =
   "/api/integrations/telegram/auth-callback";
+const ZERO_EMAIL_INBOUND_REWRITE_SOURCE = "/api/zero/email/inbound";
 const V1_CHAT_THREADS_MESSAGES_REWRITE_SOURCE = "/api/v1/chat-threads/messages";
 const V1_CHAT_THREAD_DETAIL_REWRITE_SOURCE =
   "/api/v1/chat-threads/:threadId((?!messages$)[^/]+)";
@@ -367,6 +368,7 @@ export const API_BACKEND_REWRITES = [
   [AGENTPHONE_CONNECT_REWRITE_SOURCE, "/api/agentphone/connect"],
   [AGENTPHONE_WEBHOOK_REWRITE_SOURCE, "/api/agentphone/webhook"],
   ["/api/email/unsubscribe", "/api/email/unsubscribe"],
+  [ZERO_EMAIL_INBOUND_REWRITE_SOURCE, "/api/zero/email/inbound"],
   ["/api/generate-image", "/api/generate-image"],
   [GITHUB_OAUTH_CALLBACK_REWRITE_SOURCE, "/api/github/oauth/callback"],
   [GITHUB_OAUTH_INSTALL_REWRITE_SOURCE, "/api/github/oauth/install"],


### PR DESCRIPTION
## Summary
- add an exact web-to-API rewrite for `/api/zero/email/inbound`
- cover exact matching plus Svix signature header and raw body forwarding through the rewrite proxy
- assert provider webhooks do not receive the OAuth web-origin header

## Tests
- `pnpm -F web exec vitest run __tests__/api-backend-rewrite-proxy.test.ts __tests__/proxy.sandbox-token.test.ts __tests__/security-headers.test.ts`
- `pnpm format`
- `pnpm -F web lint`
- `pnpm check-types`
- `git diff --check`

Fixes #14051