### PR TITLE
fix: hide firewall permission management from members

### DIFF
--- a/turbo/apps/platform/src/views/fw/__tests__/permissions-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/fw/__tests__/permissions-dialog.test.tsx
@@ -243,25 +243,15 @@ describe("permissions dialog - grouped connector (Slack)", () => {
     });
   });
 
-  it("disables all policy pills and shows only Close in read-only mode (FW-V-001)", async () => {
+  it("allows org admins to manage permissions for agents owned by another user (FW-V-001)", async () => {
     mockAPIs({ connectorType: "slack", ownerId: "other-user-456" });
     detachedSetupPage({ context, path: "/agents/my-agent" });
     await openPermissionsDrawer("Slack");
 
-    // The footer "Close" button (text content) should be present
     await waitFor(() => {
-      const closeButtons = screen.getAllByRole("button").filter((el) => {
-        return el.textContent?.trim() === "Close";
-      });
-      // At least one of them is the footer close button (not the X icon)
-      const footerClose = closeButtons.find((b) => {
-        return b.textContent?.trim() === "Close";
-      });
-      expect(footerClose).toBeDefined();
+      expect(screen.getByText("Apply")).toBeInTheDocument();
     });
-    expect(screen.queryByText("Apply")).not.toBeInTheDocument();
 
-    // All policy pill buttons (Allow/Deny) should be disabled
     const allButtons = screen.getAllByRole("button");
     const policyButtons = allButtons.filter((b) => {
       return (
@@ -271,7 +261,7 @@ describe("permissions dialog - grouped connector (Slack)", () => {
     });
     expect(policyButtons.length).toBeGreaterThan(0);
     for (const btn of policyButtons) {
-      expect(btn).toBeDisabled();
+      expect(btn).toBeEnabled();
     }
   });
 });

--- a/turbo/apps/platform/src/views/permission-allow/permission-allow-page.tsx
+++ b/turbo/apps/platform/src/views/permission-allow/permission-allow-page.tsx
@@ -554,7 +554,7 @@ function RequestModeView() {
   const currentUser =
     userLoadable.state === "hasData" ? userLoadable.data : undefined;
   const isAdmin = adminLoadable.state === "hasData" && adminLoadable.data;
-  const canManagePermissions = currentUser?.id === agent.ownerId || isAdmin;
+  const canManagePermissions = isAdmin;
 
   return (
     <RequestStatusView
@@ -869,7 +869,7 @@ export function PermissionAllowPage() {
   const currentUser =
     userLoadable.state === "hasData" ? userLoadable.data : undefined;
   const isAdmin = adminLoadable.state === "hasData" && adminLoadable.data;
-  const canManagePermissions = currentUser?.id === agent.ownerId || isAdmin;
+  const canManagePermissions = isAdmin;
   const userName = resolveUserName(currentUser);
   const focusedPermission = findPermission(ref, permission);
 

--- a/turbo/apps/platform/src/views/team-page/zero-job-detail-page.tsx
+++ b/turbo/apps/platform/src/views/team-page/zero-job-detail-page.tsx
@@ -843,12 +843,7 @@ function AgentTabContent({
 
   switch (activeTab) {
     case "authorization": {
-      return (
-        <JobPermissionsTab
-          agentId={agentId}
-          displayName={displayName}
-        />
-      );
+      return <JobPermissionsTab agentId={agentId} displayName={displayName} />;
     }
     case "schedule": {
       return <JobScheduleTab displayName={displayName} />;

--- a/turbo/apps/platform/src/views/team-page/zero-job-detail-page.tsx
+++ b/turbo/apps/platform/src/views/team-page/zero-job-detail-page.tsx
@@ -409,11 +409,9 @@ function PermissionRow({
 function JobPermissionsTab({
   agentId,
   displayName,
-  ownerId,
 }: {
   agentId: string;
   displayName: string;
-  ownerId: string;
 }) {
   // Use useLastLoadable so the list keeps showing the previous data while the
   // signal refetches after a toggle/save or a permission-policy reload. This
@@ -438,16 +436,13 @@ function JobPermissionsTab({
   const savingType = useGet(permSavingType$);
   const setSavingType = useSet(setPermSavingType$);
 
-  const userLoadable = useLoadable(user$);
-  const currentUserId =
-    userLoadable.state === "hasData" ? userLoadable.data?.id : undefined;
-  const isOwner = currentUserId === ownerId;
-
   const connectorsLoading = connectorsLoadable.state === "loading";
 
   const allTypesLoadable = useLastLoadable(allConnectorTypes$);
   const allConnectors =
     allTypesLoadable.state === "hasData" ? allTypesLoadable.data : [];
+  const adminLoadable = useLoadable(isOrgAdmin$);
+  const isAdmin = adminLoadable.state === "hasData" && adminLoadable.data;
 
   const connectedConnectors = allConnectors.filter((c) => {
     return c.connected;
@@ -601,7 +596,7 @@ function JobPermissionsTab({
                       await handleToggle(c.type, checked);
                     })}
                     loading={savingType === c.type}
-                    showManage={hasConnectorPermissions(c.type)}
+                    showManage={isAdmin && hasConnectorPermissions(c.type)}
                     onManage={() => {
                       return setConnectorType(c.type);
                     }}
@@ -623,7 +618,7 @@ function JobPermissionsTab({
               connectorType={connectorType}
               displayName={displayName}
               initialPolicies={permissionPolicies ?? {}}
-              readOnly={!isOwner}
+              readOnly={!isAdmin}
               onApply={async (policies) => {
                 const saved = await savePermPol(agentId, policies, pageSignal);
                 if (saved !== undefined) {
@@ -824,7 +819,6 @@ function AgentTabContent({
   avatarUrl,
   resolvedSound,
   isDefaultAgent,
-  ownerId,
   visibility,
   canEditVisibility,
 }: {
@@ -835,7 +829,6 @@ function AgentTabContent({
   avatarUrl: string | null;
   resolvedSound: Tone;
   isDefaultAgent: boolean;
-  ownerId: string;
   visibility: "public" | "private";
   canEditVisibility: boolean;
 }) {
@@ -854,7 +847,6 @@ function AgentTabContent({
         <JobPermissionsTab
           agentId={agentId}
           displayName={displayName}
-          ownerId={ownerId}
         />
       );
     }
@@ -984,7 +976,6 @@ export function ZeroJobDetailPage() {
           avatarUrl={fields.avatarUrl}
           resolvedSound={fields.resolvedSound}
           isDefaultAgent={isDefaultAgent}
-          ownerId={fields.ownerId}
           visibility={fields.visibility}
           canEditVisibility={isOwner}
         />

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-job-detail-page-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-job-detail-page-display.test.tsx
@@ -238,6 +238,23 @@ describe("zero job detail page - connector display", () => {
       screen.getByLabelText(/Manage Slack permissions/i),
     ).toBeInTheDocument();
   });
+
+  it("should hide connector permission management for non-admin members", async () => {
+    mockAPIsWithConnectors();
+    setMockOrg({ role: "member" });
+    detachedSetupPage({ context, path: "/agents/my-agent" });
+
+    await waitFor(() => {
+      expect(screen.getByText("Slack")).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByRole("switch", { name: /Slack access/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByLabelText(/Manage Slack permissions/i),
+    ).not.toBeInTheDocument();
+  });
 });
 
 describe("zero job detail page - tab visibility", () => {


### PR DESCRIPTION
## Summary
- Hide connector firewall permission management buttons from non-admin org members
- Treat permission allow/request pages as admin-managed so members request approval instead of directly confirming changes
- Add coverage that member users still see connector access toggles but not the manage permissions entry

## Verification
- npx -y pnpm@10.33.4 --dir turbo --filter @vm0/app exec vitest run src/views/zero-page/__tests__/zero-job-detail-page-display.test.tsx --reporter=verbose --maxWorkers=1 --no-file-parallelism
- npx -y pnpm@10.33.4 --dir turbo --filter @vm0/app check-types