### PR TITLE
fix: align external run error copy

### DIFF
--- a/turbo/apps/api/src/signals/services/zero-agentphone.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-agentphone.service.ts
@@ -2,7 +2,7 @@ import { createHmac, randomBytes, timingSafeEqual } from "node:crypto";
 import { gzipSync } from "node:zlib";
 
 import { command, type Getter, type Setter } from "ccstate";
-import { RUN_ERROR_GUIDANCE } from "@vm0/api-contracts/contracts/errors";
+import { formatRunErrorForExternalSurface } from "@vm0/api-contracts/contracts/errors";
 import {
   getCanonicalModelDisplayName,
   getVm0VisibleModels,
@@ -1580,12 +1580,12 @@ async function runAgentForAgentPhone(
     };
   }
 
-  const guidance = RUN_ERROR_GUIDANCE[result.body.error.code];
   return {
     status: "failed",
-    response: guidance
-      ? `${guidance.title}: ${guidance.guidance}`
-      : result.body.error.message,
+    response: formatRunErrorForExternalSurface({
+      code: result.body.error.code,
+      message: result.body.error.message,
+    }),
   };
 }
 

--- a/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
@@ -11,8 +11,9 @@ import {
   persistedAttachmentSchema,
 } from "@vm0/api-contracts/contracts/chat-threads";
 import {
+  CHAT_RUN_TRANSIENT_ERROR_MESSAGE,
   formatChatgptCodexUsageLimitError,
-  RUN_ERROR_GUIDANCE,
+  isActionableRunError,
 } from "@vm0/api-contracts/contracts/errors";
 import { modelProviderTypeSchema } from "@vm0/api-contracts/contracts/model-providers";
 import { agentComposes } from "@vm0/db/schema/agent-compose";
@@ -50,22 +51,7 @@ import { listS3Objects } from "../external/s3";
 
 const REPORT_ERROR_STREAK_THRESHOLD = 2;
 
-const CHAT_RUN_TRANSIENT_ERROR_MESSAGE =
-  "Oops, something went wrong. Please try again later.";
 const CHAT_RUN_REPORTABLE_ERROR_MESSAGE = "An unexpected error occurred.";
-
-const ACTIONABLE_ERROR_SNIPPETS = [
-  ...Object.values(RUN_ERROR_GUIDANCE).flatMap((guidance) => {
-    return [guidance.title, guidance.guidance];
-  }),
-  "Cannot continue session",
-  "Invalid signature in thinking block",
-  "Run cancelled",
-  "usage limit",
-  "usage_limit",
-  "usage-limit",
-  "UsageLimit",
-] as const;
 
 const EXT_MIMETYPE_MAP: Readonly<Record<string, string>> = {
   png: "image/png",
@@ -218,13 +204,6 @@ function hasAgentSessionId(
     typeof (value as { readonly agentSessionId: unknown }).agentSessionId ===
       "string"
   );
-}
-
-function isActionableRunError(errorMessage: string): boolean {
-  const normalized = errorMessage.toLowerCase();
-  return ACTIONABLE_ERROR_SNIPPETS.some((snippet) => {
-    return normalized.includes(snippet.toLowerCase());
-  });
 }
 
 function buildReportableErrorMessage(runId: string): string {

--- a/turbo/apps/api/src/signals/services/zero-slack-webhooks.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-slack-webhooks.service.ts
@@ -9,7 +9,7 @@ import {
   isSupportedRunModel,
   type SupportedRunModel,
 } from "@vm0/api-contracts/contracts/model-providers";
-import { RUN_ERROR_GUIDANCE } from "@vm0/api-contracts/contracts/errors";
+import { formatRunErrorForExternalSurface } from "@vm0/api-contracts/contracts/errors";
 import { slackOrgCallbackPayloadSchema } from "@vm0/api-contracts/contracts/internal-callbacks-slack-org";
 import { agentSessions } from "@vm0/db/schema/agent-session";
 import { conversations } from "@vm0/db/schema/conversation";
@@ -1017,12 +1017,12 @@ async function runAgentForSlackOrg(
     };
   }
 
-  const guidance = RUN_ERROR_GUIDANCE[result.body.error.code];
   return {
     status: "failed",
-    response: guidance
-      ? `${guidance.title}: ${guidance.guidance}`
-      : result.body.error.message,
+    response: formatRunErrorForExternalSurface({
+      code: result.body.error.code,
+      message: result.body.error.message,
+    }),
   };
 }
 

--- a/turbo/apps/api/src/signals/services/zero-telegram-post.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-telegram-post.service.ts
@@ -1,7 +1,7 @@
 import { createHmac, randomBytes, timingSafeEqual } from "node:crypto";
 
 import { command, type Getter, type Setter } from "ccstate";
-import { RUN_ERROR_GUIDANCE } from "@vm0/api-contracts/contracts/errors";
+import { formatRunErrorForExternalSurface } from "@vm0/api-contracts/contracts/errors";
 import {
   getCanonicalModelDisplayName,
   getVm0VisibleModels,
@@ -1716,12 +1716,12 @@ async function runAgentForTelegram(
     };
   }
 
-  const guidance = RUN_ERROR_GUIDANCE[result.body.error.code];
   return {
     status: "failed",
-    response: guidance
-      ? `${guidance.title}: ${guidance.guidance}`
-      : result.body.error.message,
+    response: formatRunErrorForExternalSurface({
+      code: result.body.error.code,
+      message: result.body.error.message,
+    }),
   };
 }
 

--- a/turbo/apps/web/src/lib/zero/slack-org/handlers/run-agent.ts
+++ b/turbo/apps/web/src/lib/zero/slack-org/handlers/run-agent.ts
@@ -1,4 +1,4 @@
-import { RUN_ERROR_GUIDANCE } from "@vm0/api-contracts/contracts/errors";
+import { formatRunErrorForExternalSurface } from "@vm0/api-contracts/contracts/errors";
 import { isRunDispatchError } from "../../../infra/run";
 import type { SlackOrgCallbackPayload } from "../../../infra/callback/callback-payloads";
 import { isApiError } from "@vm0/api-services/errors";
@@ -85,14 +85,13 @@ function translateSlackRunError(
   logContext: LogContext,
 ): RunAgentResult {
   if (isApiError(error)) {
-    const guidance = RUN_ERROR_GUIDANCE[error.code];
-    const response = guidance
-      ? `${guidance.title}: ${guidance.guidance}`
-      : error.message;
     log.warn(`Pre-run check failed: ${error.code}`, logContext);
     return {
       status: "failed",
-      response,
+      response: formatRunErrorForExternalSurface({
+        code: error.code,
+        message: error.message,
+      }),
       runId: undefined,
       errorCode: error.code,
     };
@@ -101,8 +100,13 @@ function translateSlackRunError(
   log.error("Error running agent for Slack org:", error);
   return {
     status: "failed",
-    response:
-      "Something went wrong while starting the agent. Please try again later.",
+    response: formatRunErrorForExternalSurface({
+      code: "UNKNOWN",
+      message:
+        error instanceof Error
+          ? error.message
+          : "Something went wrong while starting the agent.",
+    }),
     runId,
   };
 }

--- a/turbo/apps/web/src/lib/zero/telegram/handlers/run-agent.ts
+++ b/turbo/apps/web/src/lib/zero/telegram/handlers/run-agent.ts
@@ -1,7 +1,7 @@
 import { isRunDispatchError } from "../../../infra/run";
 import { createZeroRun } from "../../zero-run-service";
 import { isApiError } from "@vm0/api-services/errors";
-import { RUN_ERROR_GUIDANCE } from "@vm0/api-contracts/contracts/errors";
+import { formatRunErrorForExternalSurface } from "@vm0/api-contracts/contracts/errors";
 import { logger } from "../../../shared/logger";
 import type { TelegramCallbackPayload } from "../../../infra/callback/callback-payloads";
 import type { UserInfoOptions } from "../../integration-prompt";
@@ -64,23 +64,31 @@ function translateTelegramRunError(
 ): RunAgentResult {
   const { composeId, agentName, userId } = params;
   if (isApiError(error)) {
-    const guidance = RUN_ERROR_GUIDANCE[error.code];
-    const response = guidance
-      ? `${guidance.title}: ${guidance.guidance}`
-      : error.message;
     log.warn(`Pre-run check failed: ${error.code}`, {
       composeId,
       agentName,
       userId,
     });
-    return { status: "failed", response, runId: undefined };
+    return {
+      status: "failed",
+      response: formatRunErrorForExternalSurface({
+        code: error.code,
+        message: error.message,
+      }),
+      runId: undefined,
+    };
   }
   const runId = isRunDispatchError(error) ? error.runId : undefined;
   log.error("Failed to create run", { composeId, agentName, userId, error });
   return {
     status: "failed",
-    response:
-      "Something went wrong while starting the agent. Please try again later.",
+    response: formatRunErrorForExternalSurface({
+      code: "UNKNOWN",
+      message:
+        error instanceof Error
+          ? error.message
+          : "Something went wrong while starting the agent.",
+    }),
     runId,
   };
 }

--- a/turbo/packages/api-contracts/src/contracts/__tests__/errors.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/errors.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+
+import { formatRunErrorForExternalSurface } from "../errors";
+
+describe("formatRunErrorForExternalSurface", () => {
+  it("preserves allowlisted run errors like Web chat", () => {
+    expect(
+      formatRunErrorForExternalSurface({
+        code: "NO_MODEL_PROVIDER",
+        message: "No model provider configured",
+      }),
+    ).toBe("No model provider configured");
+  });
+
+  it("preserves non-guidance allowlisted run errors", () => {
+    expect(
+      formatRunErrorForExternalSurface({
+        code: "UNKNOWN",
+        message: "Cannot continue session with this provider",
+      }),
+    ).toBe("Cannot continue session with this provider");
+  });
+
+  it("preserves ChatGPT Codex usage limit guidance", () => {
+    expect(
+      formatRunErrorForExternalSurface({
+        code: "UNKNOWN",
+        message:
+          "ChatGPT Codex usage limit reached. Visit chatgpt.com/codex/settings/usage.",
+      }),
+    ).toContain("ChatGPT Codex usage limit reached.");
+  });
+
+  it("falls back to the Web generic message for unallowlisted errors", () => {
+    expect(
+      formatRunErrorForExternalSurface({
+        code: "UNKNOWN",
+        message: "Something failed",
+      }),
+    ).toBe("Oops, something went wrong. Please try again later.");
+  });
+});

--- a/turbo/packages/api-contracts/src/contracts/errors.ts
+++ b/turbo/packages/api-contracts/src/contracts/errors.ts
@@ -116,6 +116,50 @@ export const RUN_ERROR_GUIDANCE: Record<
   },
 };
 
+export const CHAT_RUN_TRANSIENT_ERROR_MESSAGE =
+  "Oops, something went wrong. Please try again later.";
+
+export const ACTIONABLE_RUN_ERROR_SNIPPETS = [
+  ...Object.values(RUN_ERROR_GUIDANCE).flatMap((guidance) => {
+    return [guidance.title, guidance.guidance];
+  }),
+  "Cannot continue session",
+  "Invalid signature in thinking block",
+  "Run cancelled",
+  "usage limit",
+  "usage_limit",
+  "usage-limit",
+  "UsageLimit",
+] as const;
+
+export function isActionableRunError(errorMessage: string): boolean {
+  const normalized = errorMessage.toLowerCase();
+  return ACTIONABLE_RUN_ERROR_SNIPPETS.some((snippet) => {
+    return normalized.includes(snippet.toLowerCase());
+  });
+}
+
+/**
+ * Plain-text run error copy that matches the Web chat error behavior.
+ * Actionable allowlisted errors are shown as-is; generic failures are hidden
+ * behind the same transient "Oops" message Web chat uses.
+ */
+export function formatRunErrorForExternalSurface(params: {
+  readonly code: string;
+  readonly message: string;
+}): string {
+  const errorMessage = params.message.trim() || "Run failed";
+  const chatgptCodexUsageLimitMessage =
+    formatChatgptCodexUsageLimitError(errorMessage);
+  if (chatgptCodexUsageLimitMessage) {
+    return chatgptCodexUsageLimitMessage;
+  }
+
+  return isActionableRunError(errorMessage)
+    ? errorMessage
+    : CHAT_RUN_TRANSIENT_ERROR_MESSAGE;
+}
+
 const CHATGPT_CODEX_USAGE_DETAILS_URL =
   "https://chatgpt.com/codex/settings/usage";
 

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -23,10 +23,14 @@ export {
   type HealthRouteResponse,
 } from "./health";
 export {
+  ACTIONABLE_RUN_ERROR_SNIPPETS,
   apiErrorSchema,
   ApiError,
+  CHAT_RUN_TRANSIENT_ERROR_MESSAGE,
   createErrorResponse,
   formatChatgptCodexUsageLimitError,
+  formatRunErrorForExternalSurface,
+  isActionableRunError,
   RUN_ERROR_GUIDANCE,
   type ApiErrorKey,
   type ApiErrorResponse,


### PR DESCRIPTION
## Summary
- Add a shared formatter for external run error copy that mirrors Web chat behavior: allowlisted/actionable errors are shown, unallowlisted failures fall back to the Web generic "Oops" message.
- Use the formatter in Slack, Telegram, and AgentPhone run-start failure paths across web and api services.
- Add contract tests for allowlisted, ChatGPT Codex usage-limit, and generic fallback behavior.

## Tests
- corepack pnpm -F @vm0/api-contracts test -- src/contracts/__tests__/errors.test.ts
- corepack pnpm -F @vm0/api-contracts check-types
- corepack pnpm -F @vm0/api-contracts lint
- corepack pnpm -F web check-types
- corepack pnpm -F web lint
- NODE_OPTIONS=--max-old-space-size=4096 corepack pnpm -F api check-types
- corepack pnpm -F api lint

Note: api check-types OOMed under the default Node heap in this fresh environment; it passed with a 4GB heap.