### PR TITLE
fix: install pnpm in sandbox image

### DIFF
--- a/crates/runner/scripts/build-template.sh
+++ b/crates/runner/scripts/build-template.sh
@@ -448,7 +448,8 @@ install_runtimes() {
       @googleworkspace/cli@${GWS_CLI_VERSION} \
       @xdevplatform/xurl@${XURL_VERSION} \
       @openai/codex@${CODEX_CLI_VERSION} \
-      agent-browser@${AGENT_BROWSER_VERSION}
+      agent-browser@${AGENT_BROWSER_VERSION} \
+      pnpm@latest
     npm cache clean --force
   "
 

--- a/crates/runner/scripts/build-template.sh
+++ b/crates/runner/scripts/build-template.sh
@@ -116,6 +116,7 @@ CODEX_CLI_VERSION="0.131.0"
 GWS_CLI_VERSION="0.22.5"
 XURL_VERSION="1.0.3"
 AGENT_BROWSER_VERSION="0.27.0"
+PNPM_VERSION="10.33.4"
 
 # ---------------------------------------------------------------------------
 # Dependency checks
@@ -449,7 +450,7 @@ install_runtimes() {
       @xdevplatform/xurl@${XURL_VERSION} \
       @openai/codex@${CODEX_CLI_VERSION} \
       agent-browser@${AGENT_BROWSER_VERSION} \
-      pnpm@latest
+      pnpm@${PNPM_VERSION}
     npm cache clean --force
   "
 

--- a/crates/runner/scripts/verify-rootfs.sh
+++ b/crates/runner/scripts/verify-rootfs.sh
@@ -197,6 +197,12 @@ else
   errors+=("codex CLI not found at /usr/bin/codex")
 fi
 
+if [[ -f "${MOUNT_DIR}/usr/bin/pnpm" ]]; then
+  echo "  pnpm: found"
+else
+  errors+=("pnpm not found at /usr/bin/pnpm")
+fi
+
 # Check language runtimes
 # Some binaries use update-alternatives symlinks or versioned names (e.g.
 # php8.3 instead of php, javac under /usr/lib/jvm/). Use glob patterns

--- a/crates/runner/src/cmd/build.rs
+++ b/crates/runner/src/cmd/build.rs
@@ -4060,7 +4060,11 @@ exit 1
     #[test]
     fn template_installs_and_verifies_pnpm() {
         assert!(
-            TEMPLATE_BUILD_SCRIPT.contains("pnpm@latest"),
+            TEMPLATE_BUILD_SCRIPT.contains("PNPM_VERSION=\"10.33.4\""),
+            "build-template.sh should pin the pnpm version so template cache inputs are deterministic"
+        );
+        assert!(
+            TEMPLATE_BUILD_SCRIPT.contains("pnpm@${PNPM_VERSION}"),
             "build-template.sh should install pnpm into sandbox templates"
         );
         assert!(

--- a/crates/runner/src/cmd/build.rs
+++ b/crates/runner/src/cmd/build.rs
@@ -4058,6 +4058,18 @@ exit 1
     }
 
     #[test]
+    fn template_installs_and_verifies_pnpm() {
+        assert!(
+            TEMPLATE_BUILD_SCRIPT.contains("pnpm@latest"),
+            "build-template.sh should install pnpm into sandbox templates"
+        );
+        assert!(
+            VERIFY_SCRIPT.contains(r#""${MOUNT_DIR}/usr/bin/pnpm""#),
+            "verify-rootfs.sh should verify pnpm is present in sandbox images"
+        );
+    }
+
+    #[test]
     fn build_script_publishes_debootstrap_cache_atomically() {
         assert!(
             TEMPLATE_BUILD_SCRIPT.contains(r#"CACHE_TMP_TAR="${cache_tar}.tmp.$$""#),


### PR DESCRIPTION
## Summary
- install `pnpm@latest` in the sandbox rootfs template
- verify `/usr/bin/pnpm` exists during rootfs validation
- add a runner unit guard for pnpm install + verification coverage

## Tests
- `cargo fmt --check` from `crates/`
- `CARGO_BUILD_JOBS=1 cargo test -p runner template_installs_and_verifies_pnpm`
- `bash -n crates/runner/scripts/build-template.sh && bash -n crates/runner/scripts/verify-rootfs.sh`
- `git diff --check`

Note: an initial default-parallel `cargo test --manifest-path crates/Cargo.toml -p runner template_installs_and_verifies_pnpm` compile was killed by SIGKILL in this environment; rerunning with `CARGO_BUILD_JOBS=1` passed.