### PR TITLE
fix: pin integration model routes for runs

### DIFF
--- a/turbo/apps/api/src/signals/services/zero-agentphone.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-agentphone.service.ts
@@ -113,6 +113,13 @@ interface RunAgentResult {
   readonly runId?: string;
 }
 
+interface ModelRoutePin {
+  readonly modelProviderType: string;
+  readonly modelProviderId: string | null;
+  readonly modelProviderCredentialScope: "org" | "member";
+  readonly selectedModel: string;
+}
+
 type ComputedGetter = Getter;
 type ComputedSetter = Setter;
 
@@ -1507,13 +1514,36 @@ async function dispatchAgentPhoneCommand(args: {
   }
 }
 
-async function selectedModelOverrideForUser(
+async function resolveModelRouteForUser(
   get: ComputedGetter,
+  set: ComputedSetter,
   orgId: string,
   userId: string,
-): Promise<string | undefined> {
-  const preference = await get(userModelPreference({ orgId, userId }));
-  return preference.selectedModel ?? undefined;
+  signal: AbortSignal,
+): Promise<ModelRoutePin | undefined> {
+  const [preference, policies] = await Promise.all([
+    get(userModelPreference({ orgId, userId })),
+    set(listOrgModelPolicies$, { orgId, userId }, signal),
+  ]);
+  const selectedModel = preference.selectedModel;
+  const policy =
+    (selectedModel
+      ? policies.policies.find((candidate) => {
+          return candidate.model === selectedModel;
+        })
+      : undefined) ??
+    policies.policies.find((candidate) => {
+      return candidate.isDefault;
+    });
+  if (!policy) {
+    return undefined;
+  }
+  return {
+    modelProviderType: policy.defaultProviderType,
+    modelProviderId: policy.modelProviderId,
+    modelProviderCredentialScope: policy.credentialScope,
+    selectedModel: policy.model,
+  };
 }
 
 async function runAgentForAgentPhone(
@@ -1533,7 +1563,7 @@ async function runAgentForAgentPhone(
     readonly event: AgentPhoneMessageEvent;
     readonly callbackContext: AgentPhoneCallbackContext;
     readonly apiStartTime: number;
-    readonly selectedModelOverride: string | undefined;
+    readonly modelRoute: ModelRoutePin | undefined;
   },
   signal: AbortSignal,
 ): Promise<RunAgentResult> {
@@ -1545,6 +1575,9 @@ async function runAgentForAgentPhone(
         prompt: args.prompt,
         agentId: args.agent.agentId,
         sessionId: args.sessionId,
+        ...(args.modelRoute?.modelProviderType
+          ? { modelProvider: args.modelRoute.modelProviderType }
+          : {}),
       },
       apiStartTime: args.apiStartTime,
       triggerSource: "agentphone",
@@ -1560,7 +1593,10 @@ async function runAgentForAgentPhone(
         args.threadContext,
       ),
       userInfoExtras: args.userInfoExtras,
-      selectedModelOverride: args.selectedModelOverride,
+      modelProviderId: args.modelRoute?.modelProviderId ?? undefined,
+      modelProviderCredentialScope:
+        args.modelRoute?.modelProviderCredentialScope,
+      selectedModelOverride: args.modelRoute?.selectedModel,
       callbacks: [
         {
           url: `${env("VM0_API_URL")}/api/internal/callbacks/agentphone`,
@@ -1690,10 +1726,12 @@ export const handleAgentPhoneMessage$ = command(
     await refreshTypingIfSupported(params.event, signal);
     signal.throwIfAborted();
 
-    const selectedModelOverride = await selectedModelOverrideForUser(
+    const modelRoute = await resolveModelRouteForUser(
       get,
+      set,
       params.userLink.orgId,
       params.userLink.vm0UserId,
+      signal,
     );
     signal.throwIfAborted();
 
@@ -1702,7 +1740,7 @@ export const handleAgentPhoneMessage$ = command(
       userLinkId: params.userLink.id,
       userId: params.userLink.vm0UserId,
       agentComposeId: agent.composeId,
-      selectedModelOverride,
+      selectedModelOverride: modelRoute?.selectedModel,
     });
     signal.throwIfAborted();
 
@@ -1738,7 +1776,7 @@ export const handleAgentPhoneMessage$ = command(
         userInfoExtras,
         event: params.event,
         apiStartTime: params.apiStartTime,
-        selectedModelOverride,
+        modelRoute,
         callbackContext: {
           messageId: params.event.messageId,
           conversationId: params.event.conversationId,

--- a/turbo/apps/api/src/signals/services/zero-agentphone.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-agentphone.service.ts
@@ -1521,20 +1521,15 @@ async function resolveModelRouteForUser(
   userId: string,
   signal: AbortSignal,
 ): Promise<ModelRoutePin | undefined> {
-  const [preference, policies] = await Promise.all([
-    get(userModelPreference({ orgId, userId })),
-    set(listOrgModelPolicies$, { orgId, userId }, signal),
-  ]);
-  const selectedModel = preference.selectedModel;
-  const policy =
-    (selectedModel
-      ? policies.policies.find((candidate) => {
-          return candidate.model === selectedModel;
-        })
-      : undefined) ??
-    policies.policies.find((candidate) => {
-      return candidate.isDefault;
-    });
+  const selectedModel = (await get(userModelPreference({ orgId, userId })))
+    .selectedModel;
+  if (!selectedModel) {
+    return undefined;
+  }
+  const policies = await set(listOrgModelPolicies$, { orgId, userId }, signal);
+  const policy = policies.policies.find((candidate) => {
+    return candidate.model === selectedModel;
+  });
   if (!policy) {
     return undefined;
   }

--- a/turbo/apps/api/src/signals/services/zero-slack-webhooks.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-slack-webhooks.service.ts
@@ -210,7 +210,14 @@ interface RunAgentParams {
   readonly threadTs: string;
   readonly callbackContext: SlackCallbackPayload;
   readonly apiStartTime: number;
-  readonly selectedModelOverride?: string;
+  readonly modelRoute: ModelRoutePin | undefined;
+}
+
+interface ModelRoutePin {
+  readonly modelProviderType: string;
+  readonly modelProviderId: string | null;
+  readonly modelProviderCredentialScope: "org" | "member";
+  readonly selectedModel: string;
 }
 
 type SlackChannelType = "channel" | "dm" | "group_dm";
@@ -994,12 +1001,18 @@ async function runAgentForSlackOrg(
         prompt: params.prompt,
         agentId: params.agentId,
         sessionId: params.sessionId,
+        ...(params.modelRoute?.modelProviderType
+          ? { modelProvider: params.modelRoute.modelProviderType }
+          : {}),
       },
       apiStartTime: params.apiStartTime,
       triggerSource: "slack",
       appendSystemPrompt: buildSlackPrompt(params),
       userInfoExtras: params.userInfoExtras,
-      selectedModelOverride: params.selectedModelOverride,
+      modelProviderId: params.modelRoute?.modelProviderId ?? undefined,
+      modelProviderCredentialScope:
+        params.modelRoute?.modelProviderCredentialScope,
+      selectedModelOverride: params.modelRoute?.selectedModel,
       callbacks: [
         {
           url: `${env("VM0_API_URL")}/api/internal/callbacks/slack/org`,
@@ -1084,6 +1097,38 @@ async function resolveCompatibleThreadSession(args: {
   }
 
   return session.agentSessionId;
+}
+
+async function resolveModelRouteForUser(
+  get: ComputedGetter,
+  set: ComputedSetter,
+  orgId: string,
+  userId: string,
+  signal: AbortSignal,
+): Promise<ModelRoutePin | undefined> {
+  const [preference, policies] = await Promise.all([
+    get(userModelPreference({ orgId, userId })),
+    set(listOrgModelPolicies$, { orgId, userId }, signal),
+  ]);
+  const selectedModel = preference.selectedModel;
+  const policy =
+    (selectedModel
+      ? policies.policies.find((candidate) => {
+          return candidate.model === selectedModel;
+        })
+      : undefined) ??
+    policies.policies.find((candidate) => {
+      return candidate.isDefault;
+    });
+  if (!policy) {
+    return undefined;
+  }
+  return {
+    modelProviderType: policy.defaultProviderType,
+    modelProviderId: policy.modelProviderId,
+    modelProviderCredentialScope: policy.credentialScope,
+    selectedModel: policy.model,
+  };
 }
 
 async function postPreDispatchErrorReply(args: {
@@ -1247,14 +1292,13 @@ async function buildRunAgentParams(
     client: resolved.client,
     userId: args.slackUserId,
   });
-  const selectedModelOverride = (
-    await args.get(
-      userModelPreference({
-        orgId: resolved.installation.orgId,
-        userId: resolved.connection.vm0UserId,
-      }),
-    )
-  ).selectedModel;
+  const modelRoute = await resolveModelRouteForUser(
+    args.get,
+    args.set,
+    resolved.installation.orgId,
+    resolved.connection.vm0UserId,
+    args.signal,
+  );
   const existingSessionId = await resolveCompatibleThreadSession({
     db: args.db,
     channelId: args.channelId,
@@ -1262,7 +1306,7 @@ async function buildRunAgentParams(
     connectionId: resolved.connection.id,
     userId: resolved.connection.vm0UserId,
     agentComposeId: resolved.composeId,
-    selectedModelOverride: selectedModelOverride ?? undefined,
+    selectedModelOverride: modelRoute?.selectedModel,
   });
   const { executionContext } = await fetchConversationContexts(
     resolved.client,
@@ -1295,7 +1339,7 @@ async function buildRunAgentParams(
     threadTs: resolved.threadTs,
     callbackContext,
     apiStartTime: args.apiStartTime,
-    selectedModelOverride: selectedModelOverride ?? undefined,
+    modelRoute,
   };
 }
 

--- a/turbo/apps/api/src/signals/services/zero-telegram-post.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-telegram-post.service.ts
@@ -1683,20 +1683,15 @@ async function resolveModelRouteForUser(
   userId: string,
   signal: AbortSignal,
 ): Promise<ModelRoutePin | undefined> {
-  const [preference, policies] = await Promise.all([
-    get(userModelPreference({ orgId, userId })),
-    set(listOrgModelPolicies$, { orgId, userId }, signal),
-  ]);
-  const selectedModel = preference.selectedModel;
-  const policy =
-    (selectedModel
-      ? policies.policies.find((candidate) => {
-          return candidate.model === selectedModel;
-        })
-      : undefined) ??
-    policies.policies.find((candidate) => {
-      return candidate.isDefault;
-    });
+  const selectedModel = (await get(userModelPreference({ orgId, userId })))
+    .selectedModel;
+  if (!selectedModel) {
+    return undefined;
+  }
+  const policies = await set(listOrgModelPolicies$, { orgId, userId }, signal);
+  const policy = policies.policies.find((candidate) => {
+    return candidate.model === selectedModel;
+  });
   if (!policy) {
     return undefined;
   }

--- a/turbo/apps/api/src/signals/services/zero-telegram-post.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-telegram-post.service.ts
@@ -228,7 +228,14 @@ interface RunAgentParams {
   readonly userInfoExtras: TelegramUserInfoExtras;
   readonly callbackPayload: TelegramCallbackPayload;
   readonly apiStartTime: number;
-  readonly selectedModelOverride: string | undefined;
+  readonly modelRoute: ModelRoutePin | undefined;
+}
+
+interface ModelRoutePin {
+  readonly modelProviderType: string;
+  readonly modelProviderId: string | null;
+  readonly modelProviderCredentialScope: "org" | "member";
+  readonly selectedModel: string;
 }
 
 interface TelegramCallbackPayload {
@@ -1669,13 +1676,36 @@ function buildTelegramPrompt(
   return [headerParts.join("\n"), threadContext].filter(Boolean).join("\n\n");
 }
 
-async function selectedModelOverrideForUser(
+async function resolveModelRouteForUser(
   get: ComputedGetter,
+  set: ComputedSetter,
   orgId: string,
   userId: string,
-): Promise<string | undefined> {
-  const preference = await get(userModelPreference({ orgId, userId }));
-  return preference.selectedModel ?? undefined;
+  signal: AbortSignal,
+): Promise<ModelRoutePin | undefined> {
+  const [preference, policies] = await Promise.all([
+    get(userModelPreference({ orgId, userId })),
+    set(listOrgModelPolicies$, { orgId, userId }, signal),
+  ]);
+  const selectedModel = preference.selectedModel;
+  const policy =
+    (selectedModel
+      ? policies.policies.find((candidate) => {
+          return candidate.model === selectedModel;
+        })
+      : undefined) ??
+    policies.policies.find((candidate) => {
+      return candidate.isDefault;
+    });
+  if (!policy) {
+    return undefined;
+  }
+  return {
+    modelProviderType: policy.defaultProviderType,
+    modelProviderId: policy.modelProviderId,
+    modelProviderCredentialScope: policy.credentialScope,
+    selectedModel: policy.model,
+  };
 }
 
 async function runAgentForTelegram(
@@ -1691,12 +1721,18 @@ async function runAgentForTelegram(
         prompt: args.prompt,
         agentId: args.agentId,
         sessionId: args.sessionId,
+        ...(args.modelRoute?.modelProviderType
+          ? { modelProvider: args.modelRoute.modelProviderType }
+          : {}),
       },
       apiStartTime: args.apiStartTime,
       triggerSource: "telegram",
       appendSystemPrompt: args.appendSystemPrompt,
       userInfoExtras: args.userInfoExtras,
-      selectedModelOverride: args.selectedModelOverride,
+      modelProviderId: args.modelRoute?.modelProviderId ?? undefined,
+      modelProviderCredentialScope:
+        args.modelRoute?.modelProviderCredentialScope,
+      selectedModelOverride: args.modelRoute?.selectedModel,
       callbacks: [
         {
           url: `${env("VM0_API_URL")}/api/internal/callbacks/telegram`,
@@ -1828,7 +1864,7 @@ function buildRunAgentParams(args: {
   readonly context: string;
   readonly prompt: string;
   readonly userInfoExtras: TelegramUserInfoExtras;
-  readonly selectedModelOverride: string | undefined;
+  readonly modelRoute: ModelRoutePin | undefined;
 }): RunAgentParams {
   return {
     auth: {
@@ -1864,7 +1900,7 @@ function buildRunAgentParams(args: {
       isDM: args.source.isDM,
     },
     apiStartTime: args.source.apiStartTime,
-    selectedModelOverride: args.selectedModelOverride,
+    modelRoute: args.modelRoute,
   };
 }
 
@@ -1937,10 +1973,12 @@ async function handleTelegramAgentMessage(args: {
   args.signal.throwIfAborted();
 
   const runPrompt = buildTelegramAgentPrompt(args);
-  const selectedModelOverride = await selectedModelOverrideForUser(
+  const modelRoute = await resolveModelRouteForUser(
     args.get,
+    args.set,
     args.orgId,
     args.userLink.vm0UserId,
+    args.signal,
   );
   args.signal.throwIfAborted();
 
@@ -1955,7 +1993,7 @@ async function handleTelegramAgentMessage(args: {
       context,
       prompt: runPrompt.prompt,
       userInfoExtras: runPrompt.userInfoExtras,
-      selectedModelOverride,
+      modelRoute,
     }),
     args.signal,
   );

--- a/turbo/apps/web/src/lib/zero/slack-org/handlers/adapt-slack-trigger.ts
+++ b/turbo/apps/web/src/lib/zero/slack-org/handlers/adapt-slack-trigger.ts
@@ -17,6 +17,10 @@ interface SlackTriggerContext {
   threadTs?: string;
   callbackContext: SlackOrgCallbackPayload;
   apiStartTime: number;
+  modelProviderType?: string;
+  modelProviderId?: string | null;
+  modelProviderCredentialScope?: string;
+  selectedModel?: string;
 }
 
 /**
@@ -45,6 +49,11 @@ export function adaptSlackTrigger(
     triggerSource: "slack",
     apiStartTime: ctx.apiStartTime,
     userInfoExtras: ctx.userInfoExtras,
+    modelProvider: ctx.modelProviderType,
+    modelProviderId: ctx.modelProviderId ?? undefined,
+    modelProviderCredentialScope: ctx.modelProviderCredentialScope,
+    selectedModelOverride: ctx.selectedModel,
+    explicitModelFirstModelSelection: Boolean(ctx.selectedModel),
     callbacks: [
       {
         url: `${getApiUrl()}/api/internal/callbacks/slack/org`,

--- a/turbo/apps/web/src/lib/zero/slack-org/handlers/run-agent.ts
+++ b/turbo/apps/web/src/lib/zero/slack-org/handlers/run-agent.ts
@@ -5,6 +5,7 @@ import { isApiError } from "@vm0/api-services/errors";
 import { logger } from "../../../shared/logger";
 import type { UserInfoOptions } from "../../integration-prompt";
 import { resolveModelFirstRouteDescriptor } from "../../model-policy/model-first-route-service";
+import { getUserModelPreferenceModel } from "../../model-policy/user-model-preference-service";
 import { createZeroRun } from "../../zero-run-service";
 import { adaptSlackTrigger } from "./adapt-slack-trigger";
 
@@ -44,15 +45,26 @@ interface LogContext {
 async function resolveSlackRunModelRoute(params: {
   orgId: string;
   userId: string;
-}): Promise<{
-  modelProviderType: string;
-  modelProviderId: string | null;
-  modelProviderCredentialScope: string;
-  selectedModel: string;
-}> {
+}): Promise<
+  | {
+      modelProviderType: string;
+      modelProviderId: string | null;
+      modelProviderCredentialScope: string;
+      selectedModel: string;
+    }
+  | undefined
+> {
+  const selectedModel = await getUserModelPreferenceModel(
+    params.orgId,
+    params.userId,
+  );
+  if (!selectedModel) {
+    return undefined;
+  }
   const route = await resolveModelFirstRouteDescriptor({
     orgId: params.orgId,
     userId: params.userId,
+    selectedModel,
   });
   return {
     modelProviderType: route.providerType,
@@ -94,7 +106,7 @@ export async function runAgentForSlackOrg(
         threadTs: params.threadTs,
         callbackContext: params.callbackContext,
         apiStartTime: params.apiStartTime,
-        ...modelRoute,
+        ...(modelRoute ?? {}),
       }),
     );
 

--- a/turbo/apps/web/src/lib/zero/slack-org/handlers/run-agent.ts
+++ b/turbo/apps/web/src/lib/zero/slack-org/handlers/run-agent.ts
@@ -4,6 +4,7 @@ import type { SlackOrgCallbackPayload } from "../../../infra/callback/callback-p
 import { isApiError } from "@vm0/api-services/errors";
 import { logger } from "../../../shared/logger";
 import type { UserInfoOptions } from "../../integration-prompt";
+import { resolveModelFirstRouteDescriptor } from "../../model-policy/model-first-route-service";
 import { createZeroRun } from "../../zero-run-service";
 import { adaptSlackTrigger } from "./adapt-slack-trigger";
 
@@ -40,6 +41,27 @@ interface LogContext {
   userId: string;
 }
 
+async function resolveSlackRunModelRoute(params: {
+  orgId: string;
+  userId: string;
+}): Promise<{
+  modelProviderType: string;
+  modelProviderId: string | null;
+  modelProviderCredentialScope: string;
+  selectedModel: string;
+}> {
+  const route = await resolveModelFirstRouteDescriptor({
+    orgId: params.orgId,
+    userId: params.userId,
+  });
+  return {
+    modelProviderType: route.providerType,
+    modelProviderId: route.modelProviderId,
+    modelProviderCredentialScope: route.credentialScope,
+    selectedModel: route.selectedModel,
+  };
+}
+
 /**
  * Execute an agent run for org-aware Slack integration.
  *
@@ -54,6 +76,10 @@ export async function runAgentForSlackOrg(
   const logContext: LogContext = { composeId, agentName, userId };
 
   try {
+    const modelRoute = await resolveSlackRunModelRoute({
+      orgId: params.orgId,
+      userId: params.userId,
+    });
     const result = await createZeroRun(
       adaptSlackTrigger({
         userId: params.userId,
@@ -68,6 +94,7 @@ export async function runAgentForSlackOrg(
         threadTs: params.threadTs,
         callbackContext: params.callbackContext,
         apiStartTime: params.apiStartTime,
+        ...modelRoute,
       }),
     );
 

--- a/turbo/apps/web/src/lib/zero/telegram/handlers/adapt-telegram-trigger.ts
+++ b/turbo/apps/web/src/lib/zero/telegram/handlers/adapt-telegram-trigger.ts
@@ -20,6 +20,10 @@ interface TelegramTriggerContext {
   userId: string;
   callbackContext: TelegramCallbackPayload;
   apiStartTime: number;
+  modelProviderType?: string;
+  modelProviderId?: string | null;
+  modelProviderCredentialScope?: string;
+  selectedModel?: string;
 }
 
 export function adaptTelegramTrigger(
@@ -46,6 +50,11 @@ export function adaptTelegramTrigger(
     triggerSource: "telegram",
     apiStartTime: ctx.apiStartTime,
     userInfoExtras: ctx.userInfoExtras,
+    modelProvider: ctx.modelProviderType,
+    modelProviderId: ctx.modelProviderId ?? undefined,
+    modelProviderCredentialScope: ctx.modelProviderCredentialScope,
+    selectedModelOverride: ctx.selectedModel,
+    explicitModelFirstModelSelection: Boolean(ctx.selectedModel),
     callbacks: [
       {
         url: `${getApiUrl()}/api/internal/callbacks/telegram`,

--- a/turbo/apps/web/src/lib/zero/telegram/handlers/direct-message.ts
+++ b/turbo/apps/web/src/lib/zero/telegram/handlers/direct-message.ts
@@ -167,6 +167,7 @@ export async function handleTelegramDirectMessage(
     rootMessageId,
     messageThreadId: message.message_thread_id,
     userId: userLink.vm0UserId,
+    orgId: installation.orgId,
     apiStartTime,
     callbackContext: {
       installationId,

--- a/turbo/apps/web/src/lib/zero/telegram/handlers/mention.ts
+++ b/turbo/apps/web/src/lib/zero/telegram/handlers/mention.ts
@@ -181,6 +181,7 @@ export async function handleTelegramMention(
     rootMessageId: rootMessageId ?? null,
     messageThreadId: message.message_thread_id,
     userId: userLink.vm0UserId,
+    orgId: installation.orgId,
     apiStartTime,
     callbackContext: {
       installationId,

--- a/turbo/apps/web/src/lib/zero/telegram/handlers/official.ts
+++ b/turbo/apps/web/src/lib/zero/telegram/handlers/official.ts
@@ -286,6 +286,7 @@ export async function handleOfficialTelegramDirectMessage(
     rootMessageId,
     messageThreadId: message.message_thread_id,
     userId: userLink.vm0UserId,
+    orgId: userLink.orgId,
     apiStartTime,
     callbackContext: {
       installationId: OFFICIAL_TELEGRAM_BOT_ID,
@@ -407,6 +408,7 @@ export async function handleOfficialTelegramMention(
     rootMessageId: rootMessageId ?? null,
     messageThreadId: message.message_thread_id,
     userId: userLink.vm0UserId,
+    orgId: userLink.orgId,
     apiStartTime,
     callbackContext: {
       installationId: OFFICIAL_TELEGRAM_BOT_ID,

--- a/turbo/apps/web/src/lib/zero/telegram/handlers/run-agent.ts
+++ b/turbo/apps/web/src/lib/zero/telegram/handlers/run-agent.ts
@@ -5,6 +5,7 @@ import { RUN_ERROR_GUIDANCE } from "@vm0/api-contracts/contracts/errors";
 import { logger } from "../../../shared/logger";
 import type { TelegramCallbackPayload } from "../../../infra/callback/callback-payloads";
 import type { UserInfoOptions } from "../../integration-prompt";
+import { resolveModelFirstRouteDescriptor } from "../../model-policy/model-first-route-service";
 import { adaptTelegramTrigger } from "./adapt-telegram-trigger";
 
 const log = logger("telegram:run-agent");
@@ -25,6 +26,7 @@ interface RunAgentParams {
   rootMessageId?: string | null;
   messageThreadId?: string | number | null;
   userId: string;
+  orgId: string;
   callbackContext: TelegramCallbackPayload;
   apiStartTime: number;
 }
@@ -33,6 +35,27 @@ interface RunAgentResult {
   status: "accepted" | "queued" | "failed";
   response?: string;
   runId: string | undefined;
+}
+
+async function resolveTelegramRunModelRoute(params: {
+  orgId: string;
+  userId: string;
+}): Promise<{
+  modelProviderType: string;
+  modelProviderId: string | null;
+  modelProviderCredentialScope: string;
+  selectedModel: string;
+}> {
+  const route = await resolveModelFirstRouteDescriptor({
+    orgId: params.orgId,
+    userId: params.userId,
+  });
+  return {
+    modelProviderType: route.providerType,
+    modelProviderId: route.modelProviderId,
+    modelProviderCredentialScope: route.credentialScope,
+    selectedModel: route.selectedModel,
+  };
 }
 
 /**
@@ -46,7 +69,13 @@ export async function runAgentForTelegram(
   params: RunAgentParams,
 ): Promise<RunAgentResult> {
   try {
-    const result = await createZeroRun(adaptTelegramTrigger(params));
+    const modelRoute = await resolveTelegramRunModelRoute({
+      orgId: params.orgId,
+      userId: params.userId,
+    });
+    const result = await createZeroRun(
+      adaptTelegramTrigger({ ...params, ...modelRoute }),
+    );
     const status: "accepted" | "queued" =
       result.status === "queued" ? "queued" : "accepted";
     log.debug(

--- a/turbo/apps/web/src/lib/zero/telegram/handlers/run-agent.ts
+++ b/turbo/apps/web/src/lib/zero/telegram/handlers/run-agent.ts
@@ -6,6 +6,7 @@ import { logger } from "../../../shared/logger";
 import type { TelegramCallbackPayload } from "../../../infra/callback/callback-payloads";
 import type { UserInfoOptions } from "../../integration-prompt";
 import { resolveModelFirstRouteDescriptor } from "../../model-policy/model-first-route-service";
+import { getUserModelPreferenceModel } from "../../model-policy/user-model-preference-service";
 import { adaptTelegramTrigger } from "./adapt-telegram-trigger";
 
 const log = logger("telegram:run-agent");
@@ -40,15 +41,26 @@ interface RunAgentResult {
 async function resolveTelegramRunModelRoute(params: {
   orgId: string;
   userId: string;
-}): Promise<{
-  modelProviderType: string;
-  modelProviderId: string | null;
-  modelProviderCredentialScope: string;
-  selectedModel: string;
-}> {
+}): Promise<
+  | {
+      modelProviderType: string;
+      modelProviderId: string | null;
+      modelProviderCredentialScope: string;
+      selectedModel: string;
+    }
+  | undefined
+> {
+  const selectedModel = await getUserModelPreferenceModel(
+    params.orgId,
+    params.userId,
+  );
+  if (!selectedModel) {
+    return undefined;
+  }
   const route = await resolveModelFirstRouteDescriptor({
     orgId: params.orgId,
     userId: params.userId,
+    selectedModel,
   });
   return {
     modelProviderType: route.providerType,
@@ -74,7 +86,7 @@ export async function runAgentForTelegram(
       userId: params.userId,
     });
     const result = await createZeroRun(
-      adaptTelegramTrigger({ ...params, ...modelRoute }),
+      adaptTelegramTrigger({ ...params, ...(modelRoute ?? {}) }),
     );
     const status: "accepted" | "queued" =
       result.status === "queued" ? "queued" : "accepted";


### PR DESCRIPTION
## Summary
- Pin model provider route details for Slack, Telegram, and AgentPhone triggered runs
- Pass provider type, provider id, credential scope, and selected model into run creation instead of only the model id
- Keep thread session compatibility checks aligned with the pinned selected model

## Verification
- git diff --check
- corepack pnpm --filter api exec tsc --noEmit *(blocked: tsc not found because node_modules is missing)*
- corepack pnpm --filter web exec tsc --noEmit *(blocked: tsc not found because node_modules is missing)*