### PR TITLE
chore: share generated firewall guard

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -333,17 +333,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Ensure no generated firewall files are tracked
-        run: |
-          MATCHES=$(git ls-files \
-            'turbo/packages/connectors/src/firewalls/*.generated.ts')
-          if [ -n "$MATCHES" ]; then
-            echo "::error::Generated firewall files must not be committed:"
-            echo "$MATCHES"
-            echo ""
-            echo "These files are produced by @vm0/firewalls-generator on postinstall"
-            echo "(see package .gitignore files). Fix: git rm --cached <files>"
-            exit 1
-          fi
+        run: ./scripts/block-generated-firewalls.sh
 
   # Lint jobs - split into 4 parallel jobs for faster CI
   lint-eslint:

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -67,3 +67,8 @@ pre-commit:
       fail_text: |
         File size check failed. Some staged files exceed the 1MB limit.
         Run 'git diff --cached --name-only' to see staged files.
+    - name: block-generated-firewalls
+      run: ./scripts/block-generated-firewalls.sh
+      fail_text: |
+        Generated firewall files must not be committed.
+        Run 'git rm --cached -- <file>' for each generated firewall file.

--- a/scripts/block-generated-firewalls.sh
+++ b/scripts/block-generated-firewalls.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+generated_firewalls_pathspec="turbo/packages/connectors/src/firewalls/*.generated.ts"
+
+tracked_generated_firewalls="$(git ls-files -- "$generated_firewalls_pathspec")"
+
+if [ -z "$tracked_generated_firewalls" ]; then
+  exit 0
+fi
+
+if [ "${GITHUB_ACTIONS:-}" = "true" ]; then
+  echo "::error::Generated firewall files must not be committed" >&2
+else
+  echo "ERROR: Generated firewall files must not be committed:" >&2
+fi
+
+echo "$tracked_generated_firewalls" | sed 's/^/  /' >&2
+echo "" >&2
+echo "These files are produced by @vm0/firewalls-generator during install/generation." >&2
+echo "Fix: git rm --cached -- <file>" >&2
+
+exit 1


### PR DESCRIPTION
## Summary
- add a shared script that fails when generated connector firewall files are tracked
- reuse the script from the existing CI guard
- add the same guard to the root lefthook pre-commit hook

## Validation
- ./scripts/block-generated-firewalls.sh
- bash -n scripts/block-generated-firewalls.sh
- git diff --check
- lefthook run pre-commit --jobs block-generated-firewalls --force --no-auto-install --no-tty

Closes #14102