### PR TITLE
feat: include screenshot in computer use app state

### DIFF
--- a/turbo/apps/cli/src/commands/zero/computer-use/__tests__/computer-use.test.ts
+++ b/turbo/apps/cli/src/commands/zero/computer-use/__tests__/computer-use.test.ts
@@ -8,6 +8,7 @@
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { Command, Help } from "commander";
+import { formatComputerUseResultForConsole } from "../index";
 import { registerZeroCommands } from "../../../../zero";
 
 function buildZeroToken(payload: Record<string, unknown>): string {
@@ -116,5 +117,19 @@ describe("computer-use command visibility", () => {
     expect(subNames).toContain("hosts");
     expect(subNames).toContain("revoke-host");
     expect(subNames).toContain("audit");
+  });
+
+  it("should omit screenshot data URLs from command result console output", () => {
+    const text = formatComputerUseResultForConsole({
+      app: "Safari",
+      text: "snapshot_id=snap_1\nw0 AXWindow",
+      screenshot: "data:image/png;base64,abcdefghijklmnopqrstuvwxyz",
+      screenshotSource: "window",
+    });
+
+    expect(text).toContain("snapshot_id=snap_1");
+    expect(text).toContain("screenshotSource");
+    expect(text).toContain("[omitted 48 character screenshot data URL]");
+    expect(text).not.toContain("abcdefghijklmnopqrstuvwxyz");
   });
 });

--- a/turbo/apps/cli/src/commands/zero/computer-use/index.ts
+++ b/turbo/apps/cli/src/commands/zero/computer-use/index.ts
@@ -141,11 +141,25 @@ function parseLimit(value: string | undefined): number {
   return parsed;
 }
 
+function summarizeScreenshotValue(value: string): string {
+  return `[omitted ${value.length.toString()} character screenshot data URL]`;
+}
+
+export function formatComputerUseResultForConsole(
+  result: Record<string, unknown>,
+): string {
+  const printable: Record<string, unknown> = { ...result };
+  if (typeof printable.screenshot === "string") {
+    printable.screenshot = summarizeScreenshotValue(printable.screenshot);
+  }
+  return JSON.stringify(printable, null, 2);
+}
+
 function resultText(command: ComputerUseCommandResponse): string {
   if (!command.result) {
     return "";
   }
-  return JSON.stringify(command.result, null, 2);
+  return formatComputerUseResultForConsole(command.result);
 }
 
 async function waitForCommand(

--- a/turbo/apps/desktop/src/computer-use-accessibility.ts
+++ b/turbo/apps/desktop/src/computer-use-accessibility.ts
@@ -49,6 +49,23 @@ interface AccessibilityAppStateSnapshot {
   readonly elements: readonly AccessibilityElementSnapshot[];
 }
 
+export interface ComputerUseScreenshotCaptureRequest {
+  readonly app: string;
+  readonly windowNames: readonly string[];
+}
+
+export interface ComputerUseScreenshotCaptureResult {
+  readonly dataUrl: string;
+  readonly source: "window" | "screen";
+  readonly sourceName: string;
+  readonly width: number;
+  readonly height: number;
+}
+
+type ComputerUseScreenshotCapture = (
+  request: ComputerUseScreenshotCaptureRequest,
+) => Promise<ComputerUseScreenshotCaptureResult>;
+
 export interface ComputerUseCommandSuccess {
   readonly status: "succeeded";
   readonly result: Record<string, unknown>;
@@ -60,6 +77,7 @@ export interface ComputerUseCommandFailure {
     readonly code:
       | "permission_denied"
       | "accessibility_unavailable"
+      | "screen_recording_unavailable"
       | "unsupported_command";
     readonly message: string;
   };
@@ -68,6 +86,14 @@ export interface ComputerUseCommandFailure {
 export type ComputerUseCommandExecutionResult =
   | ComputerUseCommandSuccess
   | ComputerUseCommandFailure;
+
+type RunJxa = (script: string) => Promise<string>;
+
+interface ComputerUseCommandExecutionDependencies {
+  readonly captureScreenshot: ComputerUseScreenshotCapture;
+  readonly platform?: NodeJS.Platform;
+  readonly runJxa?: RunJxa;
+}
 
 function payloadString(
   payload: Record<string, unknown>,
@@ -85,8 +111,9 @@ function snapshotId(): string {
 
 function requireAccessibility(
   permissions: ComputerUsePermissionState,
+  platform: NodeJS.Platform,
 ): ComputerUseCommandFailure | null {
-  if (process.platform !== "darwin") {
+  if (platform !== "darwin") {
     return {
       status: "failed",
       error: {
@@ -101,6 +128,21 @@ function requireAccessibility(
       error: {
         code: "permission_denied",
         message: "macOS Accessibility permission is required",
+      },
+    };
+  }
+  return null;
+}
+
+function requireScreenRecording(
+  permissions: ComputerUsePermissionState,
+): ComputerUseCommandFailure | null {
+  if (!permissions.screenRecording) {
+    return {
+      status: "failed",
+      error: {
+        code: "screen_recording_unavailable",
+        message: "macOS Screen Recording permission is required",
       },
     };
   }
@@ -154,6 +196,34 @@ export function renderAccessibilityTree(
     visit(element, 0);
   }
   return lines.join("\n");
+}
+
+function snapshotWindowNames(
+  snapshot: AccessibilityAppStateSnapshot,
+): string[] {
+  return snapshot.elements
+    .map((element) => {
+      return element.name?.trim();
+    })
+    .filter((name): name is string => {
+      return name !== undefined && name.length > 0;
+    });
+}
+
+function buildComputerUseAppStateResult(
+  snapshot: AccessibilityAppStateSnapshot,
+  screenshot: ComputerUseScreenshotCaptureResult,
+): Record<string, unknown> {
+  return {
+    ...snapshot,
+    text: renderAccessibilityTree(snapshot),
+    screenshot: screenshot.dataUrl,
+    screenshotMimeType: "image/png",
+    screenshotSource: screenshot.source,
+    screenshotSourceName: screenshot.sourceName,
+    screenshotWidth: screenshot.width,
+    screenshotHeight: screenshot.height,
+  };
 }
 
 function appStateScript(app: string, id: string): string {
@@ -274,16 +344,30 @@ JSON.stringify(apps);
 
 async function getAppState(
   app: string,
+  runJxaCommand: RunJxa,
+  captureScreenshot: ComputerUseScreenshotCapture,
 ): Promise<ComputerUseCommandExecutionResult> {
   const id = snapshotId();
-  const output = await runJxa(appStateScript(app, id));
+  const output = await runJxaCommand(appStateScript(app, id));
   const snapshot = JSON.parse(output) as AccessibilityAppStateSnapshot;
+  let screenshot: ComputerUseScreenshotCaptureResult;
+  try {
+    screenshot = await captureScreenshot({
+      app,
+      windowNames: snapshotWindowNames(snapshot),
+    });
+  } catch (error) {
+    return {
+      status: "failed",
+      error: {
+        code: "screen_recording_unavailable",
+        message: error instanceof Error ? error.message : String(error),
+      },
+    };
+  }
   return {
     status: "succeeded",
-    result: {
-      ...snapshot,
-      text: renderAccessibilityTree(snapshot),
-    },
+    result: buildComputerUseAppStateResult(snapshot, screenshot),
   };
 }
 
@@ -425,8 +509,12 @@ function payloadNumber(
 export async function executeComputerUseCommand(
   command: ComputerUseCommand,
   permissions: ComputerUsePermissionState,
+  dependencies: ComputerUseCommandExecutionDependencies,
 ): Promise<ComputerUseCommandExecutionResult> {
-  const permissionError = requireAccessibility(permissions);
+  const permissionError = requireAccessibility(
+    permissions,
+    dependencies.platform ?? process.platform,
+  );
   if (permissionError) {
     return permissionError;
   }
@@ -440,7 +528,15 @@ export async function executeComputerUseCommand(
       return missingField("app");
     }
     if (command.kind === "app.state") {
-      return await getAppState(app);
+      const screenRecordingError = requireScreenRecording(permissions);
+      if (screenRecordingError) {
+        return screenRecordingError;
+      }
+      return await getAppState(
+        app,
+        dependencies.runJxa ?? runJxa,
+        dependencies.captureScreenshot,
+      );
     }
     if (command.kind === "app.open") {
       return await openApp(app);

--- a/turbo/apps/desktop/src/computer-use-screenshot.ts
+++ b/turbo/apps/desktop/src/computer-use-screenshot.ts
@@ -1,0 +1,96 @@
+import { desktopCapturer } from "electron";
+import type {
+  ComputerUseScreenshotCaptureRequest,
+  ComputerUseScreenshotCaptureResult,
+} from "./computer-use-accessibility";
+
+const SCREENSHOT_THUMBNAIL_SIZE = Object.freeze({ width: 1600, height: 1200 });
+
+type DesktopCaptureSource = Awaited<
+  ReturnType<typeof desktopCapturer.getSources>
+>[number];
+
+function normalizeSourceName(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function sourceMatchesCandidate(
+  sourceName: string,
+  candidate: string,
+): boolean {
+  const normalizedSource = normalizeSourceName(sourceName);
+  const normalizedCandidate = normalizeSourceName(candidate);
+  return (
+    normalizedSource === normalizedCandidate ||
+    normalizedSource.includes(normalizedCandidate) ||
+    normalizedCandidate.includes(normalizedSource)
+  );
+}
+
+function sourceIsWindow(sourceId: string): boolean {
+  return sourceId.startsWith("window:");
+}
+
+function sourceIsScreen(sourceId: string): boolean {
+  return sourceId.startsWith("screen:");
+}
+
+function selectScreenshotSource(
+  sources: readonly DesktopCaptureSource[],
+  request: ComputerUseScreenshotCaptureRequest,
+): {
+  readonly source: DesktopCaptureSource;
+  readonly kind: "window" | "screen";
+} {
+  const candidates = [request.app, ...request.windowNames].filter(
+    (candidate) => {
+      return candidate.trim().length > 0;
+    },
+  );
+  const matchingWindow = sources.find((source) => {
+    return (
+      sourceIsWindow(source.id) &&
+      candidates.some((candidate) => {
+        return sourceMatchesCandidate(source.name, candidate);
+      })
+    );
+  });
+  if (matchingWindow) {
+    return { source: matchingWindow, kind: "window" };
+  }
+
+  const firstScreen = sources.find((source) => {
+    return sourceIsScreen(source.id);
+  });
+  if (firstScreen) {
+    return { source: firstScreen, kind: "screen" };
+  }
+
+  const [firstSource] = sources;
+  if (!firstSource) {
+    throw new Error("No screenshot sources are available");
+  }
+  return {
+    source: firstSource,
+    kind: sourceIsWindow(firstSource.id) ? "window" : "screen",
+  };
+}
+
+export async function captureComputerUseScreenshot(
+  request: ComputerUseScreenshotCaptureRequest,
+): Promise<ComputerUseScreenshotCaptureResult> {
+  const sources = await desktopCapturer.getSources({
+    types: ["window", "screen"],
+    thumbnailSize: SCREENSHOT_THUMBNAIL_SIZE,
+    fetchWindowIcons: false,
+  });
+  const selected = selectScreenshotSource(sources, request);
+  const size = selected.source.thumbnail.getSize();
+  return {
+    dataUrl: selected.source.thumbnail.toDataURL(),
+    source: selected.kind,
+    sourceName: selected.source.name,
+    width: size.width,
+    height: size.height,
+  };
+}

--- a/turbo/apps/desktop/src/main.ts
+++ b/turbo/apps/desktop/src/main.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 import { app, BrowserWindow, Menu, session, shell } from "electron";
 import { executeComputerUseCommand } from "./computer-use-accessibility";
 import { ComputerUseHostRuntime } from "./computer-use-host";
+import { captureComputerUseScreenshot } from "./computer-use-screenshot";
 import {
   buildComputerUsePageUrl,
   COMPUTER_USE_FEATURE_SWITCH_KEY,
@@ -129,7 +130,9 @@ function startComputerUseRuntime(): void {
     },
     getPermissions: getComputerUsePermissionState,
     executeCommand: (command, permissions) => {
-      return executeComputerUseCommand(command, permissions);
+      return executeComputerUseCommand(command, permissions, {
+        captureScreenshot: captureComputerUseScreenshot,
+      });
     },
   });
   computerUseRuntime.start();

--- a/turbo/apps/desktop/src/window-policy.test.ts
+++ b/turbo/apps/desktop/src/window-policy.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { renderAccessibilityTree } from "./computer-use-accessibility";
+import {
+  executeComputerUseCommand,
+  renderAccessibilityTree,
+} from "./computer-use-accessibility";
 import {
   buildComputerUseRuntimeBody,
   resolveComputerUseApiBaseUrl,
@@ -442,7 +445,7 @@ describe("computer use desktop runtime", () => {
   });
 
   it("renders model-readable accessibility state", () => {
-    const text = renderAccessibilityTree({
+    const snapshot = {
       app: "Safari",
       snapshotId: "snap_1",
       elements: [
@@ -460,10 +463,86 @@ describe("computer use desktop runtime", () => {
           ],
         },
       ],
-    });
+    };
+    const text = renderAccessibilityTree(snapshot);
 
     expect(text).toContain("snapshot_id=snap_1");
     expect(text).toContain('w0 AXWindow "Example"');
     expect(text).toContain('w0.e0 AXButton "Open" actions=AXPress');
+  });
+
+  it("returns screenshot metadata with model-readable app state", async () => {
+    const result = await executeComputerUseCommand(
+      { id: "cmd_1", kind: "app.state", payload: { app: "Safari" } },
+      { accessibility: true, screenRecording: true },
+      {
+        platform: "darwin",
+        runJxa: async () => {
+          return JSON.stringify({
+            app: "Safari",
+            snapshotId: "snap_1",
+            elements: [
+              {
+                id: "w0",
+                role: "AXWindow",
+                name: "Example",
+              },
+            ],
+          });
+        },
+        captureScreenshot: async (request) => {
+          expect(request).toStrictEqual({
+            app: "Safari",
+            windowNames: ["Example"],
+          });
+          return {
+            dataUrl: "data:image/png;base64,abc123",
+            source: "window",
+            sourceName: "Example",
+            width: 800,
+            height: 600,
+          };
+        },
+      },
+    );
+
+    expect(result.status).toBe("succeeded");
+    if (result.status !== "succeeded") {
+      throw new Error("expected app.state to succeed");
+    }
+    expect(result).toMatchObject({
+      result: {
+        app: "Safari",
+        snapshotId: "snap_1",
+        screenshot: "data:image/png;base64,abc123",
+        screenshotMimeType: "image/png",
+        screenshotSource: "window",
+        screenshotSourceName: "Example",
+        screenshotWidth: 800,
+        screenshotHeight: 600,
+      },
+    });
+    expect(result.result.text).toContain('w0 AXWindow "Example"');
+  });
+
+  it("requires screen recording permission for app state screenshots", async () => {
+    const result = await executeComputerUseCommand(
+      { id: "cmd_1", kind: "app.state", payload: { app: "Safari" } },
+      { accessibility: true, screenRecording: false },
+      {
+        platform: "darwin",
+        captureScreenshot: async () => {
+          throw new Error("unexpected screenshot capture");
+        },
+      },
+    );
+
+    expect(result).toStrictEqual({
+      status: "failed",
+      error: {
+        code: "screen_recording_unavailable",
+        message: "macOS Screen Recording permission is required",
+      },
+    });
   });
 });


### PR DESCRIPTION
## Summary

- Capture a screenshot alongside Desktop Computer Use `app.state` accessibility snapshots.
- Return screenshot data plus source metadata with the rendered accessibility tree, while preserving element IDs such as `w0.e0`.
- Require Screen Recording permission for screenshot-backed app state and keep CLI output from dumping screenshot data URLs.

Closes #14130

## Tests

- `pnpm -F @vm0/desktop run check-types`
- `pnpm -F @vm0/cli run check-types`
- `pnpm -F @vm0/desktop run lint`
- `pnpm -F @vm0/cli run lint`
- `pnpm -F @vm0/desktop run build`
- `pnpm -F @vm0/desktop test`
- `pnpm -F @vm0/cli exec vitest src/commands/zero/computer-use/__tests__/computer-use.test.ts`
- `pnpm -F api exec vitest src/signals/routes/__tests__/zero-computer-use.test.ts`
- `pnpm knip`
- pre-commit hook: staged prettier, `knip --cache`, full `turbo run check-types --concurrency=1`, commitlint
