### PR TITLE
fix: format external callback errors

### DIFF
--- a/turbo/apps/api/src/lib/telegram-format.ts
+++ b/turbo/apps/api/src/lib/telegram-format.ts
@@ -118,31 +118,14 @@ export function buildTelegramResponse(
 }
 
 /**
- * Build a structured error response for Telegram.
+ * Build an error response for Telegram without adding a title wrapper.
  */
 export function buildTelegramErrorResponse(
   errorDetail: string,
   logsUrl?: string,
   footerText?: string,
 ): string {
-  const header = `❌ <b>Agent Execution Error</b>`;
-  const content = markdownToTelegramHtml(errorDetail);
-  const footers: string[] = [];
-
-  if (logsUrl) {
-    footers.push(
-      mutedTelegramFooter(`<a href="${escapeHtml(logsUrl)}">📋 Audit</a>`),
-    );
-  }
-  if (footerText) {
-    footers.push(mutedTelegramFooter(footerText));
-  }
-
-  if (footers.length === 0) {
-    return `${header}\n\n${content}`;
-  }
-
-  return `${header}\n\n${content}\n\n${footers.join("\n")}`;
+  return buildTelegramResponse(errorDetail, logsUrl, footerText);
 }
 
 /**

--- a/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-slack-org.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-slack-org.test.ts
@@ -514,7 +514,7 @@ describe("POST /api/internal/callbacks/slack/org", () => {
     });
 
     expect(response.status).toBe(200);
-    expect(firstPostMessageCall().text).toContain(
+    expect(firstPostMessageCall().text).toBe(
       "Oops, something went wrong. Please try again later.",
     );
     await expect(findThreadSession(fixture)).resolves.toBeNull();
@@ -532,7 +532,7 @@ describe("POST /api/internal/callbacks/slack/org", () => {
     });
 
     expect(response.status).toBe(200);
-    expect(firstPostMessageCall().text).toContain(
+    expect(firstPostMessageCall().text).toBe(
       "Cannot continue session from checkpoint",
     );
   });

--- a/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-slack-org.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-slack-org.test.ts
@@ -502,7 +502,7 @@ describe("POST /api/internal/callbacks/slack/org", () => {
     expect(blocks).not.toContain("Responded by");
   });
 
-  it("posts failed-run errors without saving a thread session", async () => {
+  it("formats generic failed-run errors without saving a thread session", async () => {
     const fixture = await track(seedFixture());
 
     const response = await postSignedCallback({
@@ -514,8 +514,27 @@ describe("POST /api/internal/callbacks/slack/org", () => {
     });
 
     expect(response.status).toBe(200);
-    expect(firstPostMessageCall().text).toContain("Something broke");
+    expect(firstPostMessageCall().text).toContain(
+      "Oops, something went wrong. Please try again later.",
+    );
     await expect(findThreadSession(fixture)).resolves.toBeNull();
+  });
+
+  it("preserves actionable failed-run errors", async () => {
+    const fixture = await track(seedFixture());
+
+    const response = await postSignedCallback({
+      callbackId: fixture.callbackId,
+      runId: fixture.runId,
+      status: "failed",
+      error: "Cannot continue session from checkpoint",
+      payload: fixture.payload,
+    });
+
+    expect(response.status).toBe(200);
+    expect(firstPostMessageCall().text).toContain(
+      "Cannot continue session from checkpoint",
+    );
   });
 
   it("returns 404 when installation is not found for terminal callbacks", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-telegram.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-telegram.test.ts
@@ -683,7 +683,7 @@ describe("POST /api/internal/callbacks/telegram", () => {
     expect(text).toContain("<i>Responded by Responder · Claude Opus 4.7</i>");
   });
 
-  it("deletes legacy thinking placeholders and renders failed callbacks", async () => {
+  it("deletes legacy thinking placeholders and formats generic failed callbacks like Web", async () => {
     const fixture = await track(seedFixture());
     const telegram = telegramApiMocks();
 
@@ -698,10 +698,29 @@ describe("POST /api/internal/callbacks/telegram", () => {
     expect(response.status).toBe(200);
     expect(telegram.deleteMessages).toHaveLength(1);
     const text = telegram.sentMessages[0]?.text ?? "";
-    expect(text).toContain("<b>Agent Execution Error</b>");
+    expect(text).not.toContain("Agent Execution Error");
     expect(text).toContain(
-      '<a href="https://example.com/connect?agentId=123">连接 Notion</a>',
+      "Oops, something went wrong. Please try again later.",
     );
+    expect(text).not.toContain("连接 Notion");
+  });
+
+  it("preserves actionable failed callback errors like Web", async () => {
+    const fixture = await track(seedFixture());
+    const telegram = telegramApiMocks();
+
+    const response = await postSignedCallback({
+      callbackId: fixture.callbackId,
+      runId: fixture.runId,
+      status: "failed",
+      error: "Cannot continue session from checkpoint",
+      payload: fixture.payload,
+    });
+
+    expect(response.status).toBe(200);
+    const text = telegram.sentMessages[0]?.text ?? "";
+    expect(text).not.toContain("Agent Execution Error");
+    expect(text).toContain("Cannot continue session from checkpoint");
   });
 
   it("does not quote DM replies and replaces the DM thread mapping", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-agentphone-routes.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-agentphone-routes.test.ts
@@ -395,7 +395,18 @@ describe("AgentPhone migrated API routes", () => {
     expect(sendCalls[0]?.body).toContain("/agentphone/connect?");
   });
 
-  it("post /api/internal/callbacks/agentphone formats generic failed run output", async () => {
+  it.each([
+    {
+      scenario: "formats generic failed run output like Web",
+      error: "AgentPhone route failure",
+      expectedBody: "Oops, something went wrong. Please try again later.",
+    },
+    {
+      scenario: "preserves actionable failed run output like Web",
+      error: "Cannot continue session from checkpoint",
+      expectedBody: "Cannot continue session from checkpoint",
+    },
+  ])("post /api/internal/callbacks/agentphone $scenario", async (example) => {
     configureAgentPhoneEnv();
     const userId = uniqueId("user");
     const orgId = uniqueId("org");
@@ -417,7 +428,7 @@ describe("AgentPhone migrated API routes", () => {
       callbackId,
       runId: run.runId,
       status: "failed",
-      error: "AgentPhone route failure",
+      error: example.error,
       payload: {
         messageId: "ap-inbound-callback",
         conversationId: null,
@@ -444,7 +455,7 @@ describe("AgentPhone migrated API routes", () => {
       expect.objectContaining({
         agent_id: "agt-agentphone",
         to_number: phoneHandle,
-        body: "Oops, something went wrong. Please try again later.",
+        body: example.expectedBody,
       }),
     );
   });

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-agentphone-routes.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-agentphone-routes.test.ts
@@ -395,7 +395,7 @@ describe("AgentPhone migrated API routes", () => {
     expect(sendCalls[0]?.body).toContain("/agentphone/connect?");
   });
 
-  it("post /api/internal/callbacks/agentphone sends failed run output back to AgentPhone", async () => {
+  it("post /api/internal/callbacks/agentphone formats generic failed run output", async () => {
     configureAgentPhoneEnv();
     const userId = uniqueId("user");
     const orgId = uniqueId("org");
@@ -444,7 +444,7 @@ describe("AgentPhone migrated API routes", () => {
       expect.objectContaining({
         agent_id: "agt-agentphone",
         to_number: phoneHandle,
-        body: "AgentPhone route failure",
+        body: "Oops, something went wrong. Please try again later.",
       }),
     );
   });

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-telegram-post.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-telegram-post.test.ts
@@ -31,11 +31,13 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { createApp } from "../../../app-factory";
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
 import { clearMockedEnv, mockEnv, mockOptionalEnv } from "../../../lib/env";
+import { computeHmacSignature } from "../../../lib/event-consumer/hmac";
 import { server } from "../../../mocks/server";
 import { writeDb$ } from "../../external/db";
 import { nowDate } from "../../external/time";
 import { decryptSecretValue } from "../../services/crypto.utils";
 import { clearAllDetached } from "../../utils";
+import { seedAgentRunCallback$ } from "./helpers/agent-run-callback";
 import { encryptSecretForTests } from "./helpers/encrypt-secret";
 import {
   createFixtureTracker,
@@ -51,6 +53,7 @@ const NEW_BOT_TOKEN = "123456:new-test-bot-token";
 const OFFICIAL_BOT_TOKEN = "987654:official-bot-token";
 const OFFICIAL_BOT_USERNAME = "official_zero_bot";
 const OFFICIAL_WEBHOOK_SECRET = "official-webhook-secret";
+const CALLBACK_SECRET = "test-callback-secret";
 
 interface TelegramPostFixture {
   readonly orgId: string;
@@ -382,6 +385,31 @@ async function postWebhook(args: {
       },
       body:
         typeof args.body === "string" ? args.body : JSON.stringify(args.body),
+    },
+  );
+}
+
+function callbackHeaders(rawBody: string) {
+  const timestamp = Math.floor(Date.now() / 1000);
+  return {
+    "content-type": "application/json",
+    "X-VM0-Timestamp": String(timestamp),
+    "X-VM0-Signature": computeHmacSignature(
+      rawBody,
+      CALLBACK_SECRET,
+      timestamp,
+    ),
+  };
+}
+
+async function postTelegramCallback(body: Record<string, unknown>) {
+  const rawBody = JSON.stringify(body);
+  return await createApp({ signal: context.signal }).request(
+    "/api/internal/callbacks/telegram",
+    {
+      method: "POST",
+      headers: callbackHeaders(rawBody),
+      body: rawBody,
     },
   );
 }
@@ -1221,6 +1249,81 @@ describe("POST /api/telegram/webhook/:telegramBotId", () => {
       .where(eq(runnerJobQueue.runId, run!.id))
       .limit(1);
     expect(job).toBeDefined();
+  });
+
+  it("formats generic failed callback errors for Telegram replies", async () => {
+    const fixture = await trackFixture(
+      store.set(
+        seedTelegramPostFixture$,
+        { linkTelegramUser: true },
+        context.signal,
+      ),
+    );
+    const telegramMocks = telegramApiMocks();
+
+    const webhookResponse = await postWebhook({
+      telegramBotId: fixture.telegramBotId,
+      secret: fixture.webhookSecret,
+      body: {
+        update_id: 2,
+        message: {
+          message_id: 43,
+          chat: { id: 77_002, type: "private" },
+          from: {
+            id: Number(fixture.telegramUserId),
+            username: "alice",
+            first_name: "Alice",
+          },
+          text: "trigger failed callback",
+        },
+      },
+    });
+    expect(webhookResponse.status).toBe(200);
+    await clearAllDetached();
+
+    const run = await latestRunForFixture(fixture);
+    expect(run?.id).toBeDefined();
+    const { callbackId } = await store.set(
+      seedAgentRunCallback$,
+      {
+        runId: run!.id,
+        url: "http://localhost:3000/api/internal/callbacks/telegram",
+        payload: {
+          installationId: fixture.telegramBotId,
+          chatId: "77002",
+          messageId: "43",
+          rootMessageId: null,
+          userLinkId: await linkedTelegramUserLinkId(fixture),
+          agentId: fixture.composeId,
+          existingSessionId: null,
+          isDM: true,
+        },
+      },
+      context.signal,
+    );
+
+    const response = await postTelegramCallback({
+      callbackId,
+      runId: run!.id,
+      status: "failed",
+      error: "thread/resume failed: rollout is empty",
+      payload: {
+        installationId: fixture.telegramBotId,
+        chatId: "77002",
+        messageId: "43",
+        rootMessageId: null,
+        userLinkId: await linkedTelegramUserLinkId(fixture),
+        agentId: fixture.composeId,
+        existingSessionId: null,
+        isDM: true,
+      },
+    });
+
+    expect(response.status).toBe(200);
+    await clearAllDetached();
+    expect(telegramMocks.sentMessages.at(-1)?.text).toContain(
+      "Oops, something went wrong. Please try again later.",
+    );
   });
 
   it("stores non-addressed group messages without creating a run", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-telegram-post.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-telegram-post.test.ts
@@ -390,7 +390,7 @@ async function postWebhook(args: {
 }
 
 function callbackHeaders(rawBody: string) {
-  const timestamp = Math.floor(Date.now() / 1000);
+  const timestamp = Math.floor(nowDate().getTime() / 1000);
   return {
     "content-type": "application/json",
     "X-VM0-Timestamp": String(timestamp),

--- a/turbo/apps/api/src/signals/routes/internal-callbacks-agentphone.ts
+++ b/turbo/apps/api/src/signals/routes/internal-callbacks-agentphone.ts
@@ -4,8 +4,8 @@ import {
   internalCallbacksAgentPhoneContract,
   type AgentPhoneCallbackPayload,
 } from "@vm0/api-contracts/contracts/internal-callbacks-agentphone";
-import { formatRunErrorForExternalSurface } from "@vm0/api-contracts/contracts/errors";
 import { agentRuns } from "@vm0/db/schema/agent-run";
+import { zeroRuns } from "@vm0/db/schema/zero-run";
 import { eq } from "drizzle-orm";
 
 import {
@@ -22,6 +22,7 @@ import { writeDb$, type Db } from "../external/db";
 import type { RouteEntry } from "../route";
 import { userFeatureSwitchOverrides } from "../services/feature-switches.service";
 import { getRunOutputText } from "../services/run-output.service";
+import { formatRunErrorLikeWebMessage } from "../services/zero-chat-thread.service";
 import {
   formatAgentPhoneAuditLink,
   isAgentPhoneChannel,
@@ -42,7 +43,20 @@ interface RunContext {
   readonly orgId: string;
   readonly sessionId: string;
   readonly lastEventSequence: number | null;
+  readonly chatThreadId: string | null;
 }
+
+interface FormatRunErrorParams {
+  readonly runId: string;
+  readonly chatThreadId: string | null | undefined;
+  readonly errorMessage: string;
+}
+
+type FormatRunError = (params: FormatRunErrorParams) => Promise<string>;
+type GetFeatureOverrides = (
+  orgId: string,
+  userId: string,
+) => Promise<Record<string, boolean>>;
 
 function successResponse(): {
   readonly status: 200;
@@ -98,8 +112,10 @@ async function loadRunContext(args: {
       orgId: agentRuns.orgId,
       sessionId: agentRuns.sessionId,
       lastEventSequence: agentRuns.lastEventSequence,
+      chatThreadId: zeroRuns.chatThreadId,
     })
     .from(agentRuns)
+    .leftJoin(zeroRuns, eq(zeroRuns.id, agentRuns.id))
     .where(eq(agentRuns.id, args.runId))
     .limit(1);
   args.signal.throwIfAborted();
@@ -111,12 +127,15 @@ async function resolveCompletionText(args: {
   readonly status: "completed" | "failed";
   readonly error: string | undefined;
   readonly run: RunContext | undefined;
+  readonly formatRunError: FormatRunError;
   readonly signal: AbortSignal;
 }): Promise<string> {
   if (args.status === "failed") {
-    return formatRunErrorForExternalSurface({
-      code: "INTERNAL_SERVER_ERROR",
-      message: args.error ?? "The agent encountered an error during execution.",
+    return await args.formatRunError({
+      runId: args.runId,
+      chatThreadId: args.run?.chatThreadId,
+      errorMessage:
+        args.error ?? "The agent encountered an error during execution.",
     });
   }
 
@@ -164,10 +183,8 @@ async function handleCompletion(args: {
   readonly status: "completed" | "failed";
   readonly error: string | undefined;
   readonly payload: AgentPhoneCallbackPayload;
-  readonly getFeatureOverrides: (
-    orgId: string,
-    userId: string,
-  ) => Promise<Record<string, boolean>>;
+  readonly getFeatureOverrides: GetFeatureOverrides;
+  readonly formatRunError: FormatRunError;
   readonly signal: AbortSignal;
 }): Promise<
   | { readonly status: 200; readonly body: { readonly success: true } }
@@ -214,6 +231,7 @@ async function handleCompletion(args: {
     status: args.status,
     error: args.error,
     run,
+    formatRunError: args.formatRunError,
     signal: args.signal,
   });
   const logsUrl = run
@@ -323,6 +341,9 @@ const handleAgentPhoneCallback$ = command(
       payload,
       getFeatureOverrides: (orgId, userId) => {
         return get(userFeatureSwitchOverrides(orgId, userId));
+      },
+      formatRunError: (params) => {
+        return get(formatRunErrorLikeWebMessage(params));
       },
       signal,
     });

--- a/turbo/apps/api/src/signals/routes/internal-callbacks-agentphone.ts
+++ b/turbo/apps/api/src/signals/routes/internal-callbacks-agentphone.ts
@@ -4,6 +4,7 @@ import {
   internalCallbacksAgentPhoneContract,
   type AgentPhoneCallbackPayload,
 } from "@vm0/api-contracts/contracts/internal-callbacks-agentphone";
+import { formatRunErrorForExternalSurface } from "@vm0/api-contracts/contracts/errors";
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { eq } from "drizzle-orm";
 
@@ -113,7 +114,10 @@ async function resolveCompletionText(args: {
   readonly signal: AbortSignal;
 }): Promise<string> {
   if (args.status === "failed") {
-    return args.error ?? "The agent encountered an error during execution.";
+    return formatRunErrorForExternalSurface({
+      code: "INTERNAL_SERVER_ERROR",
+      message: args.error ?? "The agent encountered an error during execution.",
+    });
   }
 
   const output = await getRunOutputText(args.runId, {

--- a/turbo/apps/api/src/signals/routes/internal-callbacks-slack-org.ts
+++ b/turbo/apps/api/src/signals/routes/internal-callbacks-slack-org.ts
@@ -6,7 +6,6 @@ import {
   getFrameworkForType,
   modelProviderTypeSchema,
 } from "@vm0/api-contracts/contracts/model-providers";
-import { formatRunErrorForExternalSurface } from "@vm0/api-contracts/contracts/errors";
 import {
   internalCallbacksSlackOrgContract,
   slackOrgCallbackPayloadSchema,
@@ -41,6 +40,7 @@ import { decryptSecretValue } from "../services/crypto.utils";
 import { userFeatureSwitchOverrides } from "../services/feature-switches.service";
 import { getRunOutputText } from "../services/run-output.service";
 import { saveRunSummary$ } from "../services/run-summary.service";
+import { formatRunErrorLikeWebMessage } from "../services/zero-chat-thread.service";
 import { waitUntil } from "../context/wait-until";
 import { tapError } from "../utils";
 
@@ -55,6 +55,7 @@ interface RunContext {
   readonly prompt: string;
   readonly sessionId: string | null;
   readonly lastEventSequence: number | null;
+  readonly chatThreadId: string | null;
 }
 
 interface SlackInstallation {
@@ -120,8 +121,10 @@ async function loadRunContext(args: {
       prompt: agentRuns.prompt,
       sessionId: agentRuns.sessionId,
       lastEventSequence: agentRuns.lastEventSequence,
+      chatThreadId: zeroRuns.chatThreadId,
     })
     .from(agentRuns)
+    .leftJoin(zeroRuns, eq(zeroRuns.id, agentRuns.id))
     .where(eq(agentRuns.id, args.runId))
     .limit(1);
   args.signal.throwIfAborted();
@@ -352,15 +355,11 @@ async function saveOrgThreadSession(args: {
 
 function buildResponseText(args: {
   readonly status: TerminalStatus;
-  readonly error: string | undefined;
+  readonly errorText: string | undefined;
   readonly output: string | undefined;
 }): string {
   if (args.status === "failed") {
-    const error = formatRunErrorForExternalSurface({
-      code: "INTERNAL_SERVER_ERROR",
-      message: args.error ?? "Agent execution failed.",
-    });
-    return `Error: ${error}`;
+    return args.errorText ?? "Agent execution failed.";
   }
   return args.output ?? "Task completed successfully.";
 }
@@ -439,6 +438,11 @@ async function handleCompletion(args: {
     orgId: string,
     userId: string,
   ) => Promise<Record<string, boolean>>;
+  readonly formatRunError: (params: {
+    readonly runId: string;
+    readonly chatThreadId: string | null | undefined;
+    readonly errorMessage: string;
+  }) => Promise<string>;
   readonly saveRunSummary: (
     runId: string,
     prompt: string,
@@ -495,9 +499,19 @@ async function handleCompletion(args: {
     : undefined;
   args.signal.throwIfAborted();
 
+  const errorText =
+    args.status === "failed"
+      ? await args.formatRunError({
+          runId: args.runId,
+          chatThreadId: run?.chatThreadId,
+          errorMessage: args.error ?? "Agent execution failed.",
+        })
+      : undefined;
+  args.signal.throwIfAborted();
+
   const responseText = buildResponseText({
     status: args.status,
-    error: args.error,
+    errorText,
     output,
   });
   const client = createSlackClient(botToken);
@@ -565,6 +579,9 @@ const handleSlackOrgCallback$ = command(
       payload,
       getFeatureOverrides: (orgId, userId) => {
         return get(userFeatureSwitchOverrides(orgId, userId));
+      },
+      formatRunError: (params) => {
+        return get(formatRunErrorLikeWebMessage(params));
       },
       saveRunSummary: (runId, prompt, resultText) => {
         return set(

--- a/turbo/apps/api/src/signals/routes/internal-callbacks-slack-org.ts
+++ b/turbo/apps/api/src/signals/routes/internal-callbacks-slack-org.ts
@@ -6,6 +6,7 @@ import {
   getFrameworkForType,
   modelProviderTypeSchema,
 } from "@vm0/api-contracts/contracts/model-providers";
+import { formatRunErrorForExternalSurface } from "@vm0/api-contracts/contracts/errors";
 import {
   internalCallbacksSlackOrgContract,
   slackOrgCallbackPayloadSchema,
@@ -355,7 +356,11 @@ function buildResponseText(args: {
   readonly output: string | undefined;
 }): string {
   if (args.status === "failed") {
-    return `Error: ${args.error ?? "Agent execution failed."}`;
+    const error = formatRunErrorForExternalSurface({
+      code: "INTERNAL_SERVER_ERROR",
+      message: args.error ?? "Agent execution failed.",
+    });
+    return `Error: ${error}`;
   }
   return args.output ?? "Task completed successfully.";
 }

--- a/turbo/apps/api/src/signals/routes/internal-callbacks-telegram.ts
+++ b/turbo/apps/api/src/signals/routes/internal-callbacks-telegram.ts
@@ -1,7 +1,6 @@
 import { command } from "ccstate";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { isFeatureEnabled } from "@vm0/core/feature-switch";
-import { formatRunErrorForExternalSurface } from "@vm0/api-contracts/contracts/errors";
 import {
   internalCallbacksTelegramContract,
   telegramCallbackPayloadSchema,
@@ -9,17 +8,14 @@ import {
 } from "@vm0/api-contracts/contracts/internal-callbacks-telegram";
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
+import { zeroRuns } from "@vm0/db/schema/zero-run";
 import { eq } from "drizzle-orm";
 
 import {
   callbackPayload$,
   callbackRoute,
 } from "../../lib/callback-route/callback-route";
-import {
-  buildTelegramErrorResponse,
-  buildTelegramResponse,
-  splitMessage,
-} from "../../lib/telegram-format";
+import { buildTelegramResponse, splitMessage } from "../../lib/telegram-format";
 import type { RouteEntry } from "../route";
 import { env } from "../../lib/env";
 import { logger } from "../../lib/log";
@@ -36,6 +32,7 @@ import {
 } from "../external/telegram-official";
 import { userFeatureSwitchOverrides } from "../services/feature-switches.service";
 import { getRunOutputText } from "../services/run-output.service";
+import { formatRunErrorLikeWebMessage } from "../services/zero-chat-thread.service";
 import {
   saveTelegramThreadSession,
   storeTelegramBotMessage,
@@ -51,6 +48,7 @@ interface RunContext {
   readonly orgId: string;
   readonly sessionId: string;
   readonly lastEventSequence: number | null;
+  readonly chatThreadId: string | null;
 }
 
 type TelegramCallbackResult =
@@ -156,7 +154,7 @@ async function deleteThinkingMessageIfPresent(args: {
 function buildCompletionOutput(args: {
   readonly status: "completed" | "failed";
   readonly output: string | undefined;
-  readonly error: string | undefined;
+  readonly errorDetail: string | undefined;
   readonly logsUrl: string | undefined;
   readonly footerText: string | undefined;
 }): { readonly htmlOutput: string; readonly responseText: string | undefined } {
@@ -172,14 +170,10 @@ function buildCompletionOutput(args: {
     };
   }
 
-  const errorDetail = formatRunErrorForExternalSurface({
-    code: "INTERNAL_SERVER_ERROR",
-    message: args.error ?? "The agent encountered an error during execution.",
-  });
   return {
     responseText: undefined,
-    htmlOutput: buildTelegramErrorResponse(
-      errorDetail,
+    htmlOutput: buildTelegramResponse(
+      args.errorDetail ?? "The agent encountered an error during execution.",
       args.logsUrl,
       args.footerText,
     ),
@@ -213,8 +207,10 @@ async function loadRunContext(args: {
       orgId: agentRuns.orgId,
       sessionId: agentRuns.sessionId,
       lastEventSequence: agentRuns.lastEventSequence,
+      chatThreadId: zeroRuns.chatThreadId,
     })
     .from(agentRuns)
+    .leftJoin(zeroRuns, eq(zeroRuns.id, agentRuns.id))
     .where(eq(agentRuns.id, args.runId))
     .limit(1);
   args.signal.throwIfAborted();
@@ -367,6 +363,11 @@ async function handleCompletion(args: {
     orgId: string,
     userId: string,
   ) => Promise<Record<string, boolean>>;
+  readonly formatRunError: (params: {
+    readonly runId: string;
+    readonly chatThreadId: string | null | undefined;
+    readonly errorMessage: string;
+  }) => Promise<string>;
   readonly signal: AbortSignal;
 }): Promise<TelegramCallbackResult> {
   const {
@@ -425,10 +426,20 @@ async function handleCompletion(args: {
     getFeatureOverrides: args.getFeatureOverrides,
     signal: args.signal,
   });
+  const errorDetail =
+    args.status === "failed"
+      ? await args.formatRunError({
+          runId: args.runId,
+          chatThreadId: run?.chatThreadId,
+          errorMessage:
+            args.error ?? "The agent encountered an error during execution.",
+        })
+      : undefined;
+  args.signal.throwIfAborted();
   const { htmlOutput, responseText } = buildCompletionOutput({
     status: args.status,
     output,
-    error: args.error,
+    errorDetail,
     logsUrl,
     footerText,
   });
@@ -509,6 +520,9 @@ const handleTelegramCallback$ = command(
       payload,
       getFeatureOverrides: (orgId, userId) => {
         return get(userFeatureSwitchOverrides(orgId, userId));
+      },
+      formatRunError: (params) => {
+        return get(formatRunErrorLikeWebMessage(params));
       },
       signal,
     });

--- a/turbo/apps/api/src/signals/routes/internal-callbacks-telegram.ts
+++ b/turbo/apps/api/src/signals/routes/internal-callbacks-telegram.ts
@@ -1,6 +1,7 @@
 import { command } from "ccstate";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { isFeatureEnabled } from "@vm0/core/feature-switch";
+import { formatRunErrorForExternalSurface } from "@vm0/api-contracts/contracts/errors";
 import {
   internalCallbacksTelegramContract,
   telegramCallbackPayloadSchema,
@@ -171,8 +172,10 @@ function buildCompletionOutput(args: {
     };
   }
 
-  const errorDetail =
-    args.error ?? "The agent encountered an error during execution.";
+  const errorDetail = formatRunErrorForExternalSurface({
+    code: "INTERNAL_SERVER_ERROR",
+    message: args.error ?? "The agent encountered an error during execution.",
+  });
   return {
     responseText: undefined,
     htmlOutput: buildTelegramErrorResponse(

--- a/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
@@ -11,9 +11,9 @@ import {
   persistedAttachmentSchema,
 } from "@vm0/api-contracts/contracts/chat-threads";
 import {
-  CHAT_RUN_TRANSIENT_ERROR_MESSAGE,
-  formatChatgptCodexUsageLimitError,
+  formatRunErrorForExternalSurface,
   isActionableRunError,
+  isGenericRunErrorForDisplay,
 } from "@vm0/api-contracts/contracts/errors";
 import { modelProviderTypeSchema } from "@vm0/api-contracts/contracts/model-providers";
 import { agentComposes } from "@vm0/db/schema/agent-compose";
@@ -392,21 +392,22 @@ function genericErrorStreakForRun(params: {
   });
 }
 
-export function formatChatRunErrorMessage(params: {
-  readonly chatThreadId: string;
+export function formatRunErrorLikeWebMessage(params: {
+  readonly chatThreadId?: string | null;
   readonly runId: string;
   readonly errorMessage: string;
 }): Computed<Promise<string>> {
   return computed(async (get): Promise<string> => {
     const errorMessage = params.errorMessage.trim() || "Run failed";
-    const chatgptCodexUsageLimitMessage =
-      formatChatgptCodexUsageLimitError(errorMessage);
-    if (chatgptCodexUsageLimitMessage) {
-      return chatgptCodexUsageLimitMessage;
+    const displayErrorMessage = formatRunErrorForExternalSurface({
+      code: "INTERNAL_SERVER_ERROR",
+      message: errorMessage,
+    });
+    if (!isGenericRunErrorForDisplay(errorMessage)) {
+      return displayErrorMessage;
     }
-
-    if (isActionableRunError(errorMessage)) {
-      return errorMessage;
+    if (!params.chatThreadId) {
+      return displayErrorMessage;
     }
 
     const streak = await get(
@@ -419,8 +420,16 @@ export function formatChatRunErrorMessage(params: {
 
     return streak >= REPORT_ERROR_STREAK_THRESHOLD
       ? buildReportableErrorMessage(params.runId)
-      : CHAT_RUN_TRANSIENT_ERROR_MESSAGE;
+      : displayErrorMessage;
   });
+}
+
+export function formatChatRunErrorMessage(params: {
+  readonly chatThreadId: string;
+  readonly runId: string;
+  readonly errorMessage: string;
+}): Computed<Promise<string>> {
+  return formatRunErrorLikeWebMessage(params);
 }
 
 function chatMessageStatus(row: ChatMessageRow): string | undefined {

--- a/turbo/apps/web/src/lib/zero/telegram/__tests__/format.test.ts
+++ b/turbo/apps/web/src/lib/zero/telegram/__tests__/format.test.ts
@@ -178,6 +178,13 @@ describe("buildTelegramResponse", () => {
 });
 
 describe("buildTelegramErrorResponse", () => {
+  it("should not add an error title wrapper", () => {
+    const result = buildTelegramErrorResponse("failed");
+
+    expect(result).toBe("failed");
+    expect(result).not.toContain("Agent Execution Error");
+  });
+
   it("should use the Slack-aligned audit label for error footers", () => {
     const result = buildTelegramErrorResponse(
       "failed",
@@ -199,8 +206,6 @@ describe("buildTelegramErrorResponse", () => {
 
     expect(result).toBe(
       [
-        "❌ <b>Agent Execution Error</b>",
-        "",
         "failed",
         "",
         '<i><a href="https://example.com/logs">📋 Audit</a></i>',

--- a/turbo/apps/web/src/lib/zero/telegram/format.ts
+++ b/turbo/apps/web/src/lib/zero/telegram/format.ts
@@ -160,38 +160,14 @@ export function buildTelegramResponse(
 }
 
 /**
- * Build a structured error response for Telegram.
- *
- * Format:
- *   ❌ Agent Execution Error
- *
- *   <error detail>
- *
- *   📋 Audit
+ * Build an error response for Telegram without adding a title wrapper.
  */
 export function buildTelegramErrorResponse(
   errorDetail: string,
   logsUrl?: string,
   footerText?: string,
 ): string {
-  const header = `❌ <b>Agent Execution Error</b>`;
-  const content = markdownToTelegramHtml(errorDetail);
-  const footers: string[] = [];
-
-  if (logsUrl) {
-    footers.push(
-      mutedTelegramFooter(`<a href="${escapeHtml(logsUrl)}">📋 Audit</a>`),
-    );
-  }
-  if (footerText) {
-    footers.push(mutedTelegramFooter(footerText));
-  }
-
-  if (footers.length === 0) {
-    return `${header}\n\n${content}`;
-  }
-
-  return `${header}\n\n${content}\n\n${footers.join("\n")}`;
+  return buildTelegramResponse(errorDetail, logsUrl, footerText);
 }
 
 /**

--- a/turbo/packages/api-contracts/src/contracts/errors.ts
+++ b/turbo/packages/api-contracts/src/contracts/errors.ts
@@ -139,10 +139,18 @@ export function isActionableRunError(errorMessage: string): boolean {
   });
 }
 
+export function isGenericRunErrorForDisplay(errorMessage: string): boolean {
+  const normalizedErrorMessage = errorMessage.trim() || "Run failed";
+  return (
+    !formatChatgptCodexUsageLimitError(normalizedErrorMessage) &&
+    !isActionableRunError(normalizedErrorMessage)
+  );
+}
+
 /**
- * Plain-text run error copy that matches the Web chat error behavior.
- * Actionable allowlisted errors are shown as-is; generic failures are hidden
- * behind the same transient "Oops" message Web chat uses.
+ * Plain-text run error copy shared by Web chat and external integrations.
+ * Web may wrap generic failures with its report-link affordance after this
+ * shared classification step.
  */
 export function formatRunErrorForExternalSurface(params: {
   readonly code: string;
@@ -155,9 +163,9 @@ export function formatRunErrorForExternalSurface(params: {
     return chatgptCodexUsageLimitMessage;
   }
 
-  return isActionableRunError(errorMessage)
-    ? errorMessage
-    : CHAT_RUN_TRANSIENT_ERROR_MESSAGE;
+  return isGenericRunErrorForDisplay(errorMessage)
+    ? CHAT_RUN_TRANSIENT_ERROR_MESSAGE
+    : errorMessage;
 }
 
 const CHATGPT_CODEX_USAGE_DETAILS_URL =

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -31,6 +31,7 @@ export {
   formatChatgptCodexUsageLimitError,
   formatRunErrorForExternalSurface,
   isActionableRunError,
+  isGenericRunErrorForDisplay,
   RUN_ERROR_GUIDANCE,
   type ApiErrorKey,
   type ApiErrorResponse,


### PR DESCRIPTION
## Summary
- Format failed terminal callback errors for Telegram, Slack, and AgentPhone before sending them to users
- Keep actionable failures visible while converting generic raw runner errors to the standard Oops message
- Add coverage for generic and actionable external callback failures

## Tests
- DATABASE_URL="postgresql://postgres@localhost:5432/vm0_test" pnpm exec vitest run apps/api/src/signals/routes/__tests__/internal-callbacks-slack-org.test.ts
- DATABASE_URL="postgresql://postgres@localhost:5432/vm0_test" pnpm exec vitest run apps/api/src/signals/routes/__tests__/zero-integrations-agentphone-routes.test.ts
- DATABASE_URL="postgresql://postgres@localhost:5432/vm0_test" pnpm exec vitest run apps/api/src/signals/routes/__tests__/zero-integrations-telegram-post.test.ts
- NODE_OPTIONS="--max-old-space-size=6144" pnpm -F api check-types

Note: full `pnpm check-types` reached the api package and OOMed under the default Node heap; rerunning api typecheck with a larger heap passed.