### PR TITLE
fix: parse guest cpu stat fields strictly

### DIFF
--- a/crates/guest-agent/src/metrics.rs
+++ b/crates/guest-agent/src/metrics.rs
@@ -67,18 +67,14 @@ impl CpuTracker {
 }
 
 fn parse_cpu_stat_line(line: &str) -> Option<(u64, u64)> {
-    if !line.starts_with("cpu ") {
+    let mut fields = line.split_whitespace();
+    if fields.next()? != "cpu" {
         return None;
     }
 
-    let values: Vec<u64> = line
-        .split_whitespace()
-        .skip(1)
-        .map(|v| v.parse())
-        .collect::<Result<_, _>>()
-        .ok()?;
+    let values: Vec<u64> = fields.map(|v| v.parse()).collect::<Result<_, _>>().ok()?;
 
-    // idle = field 3, iowait = field 4
+    // idle and iowait are zero-based fields 3 and 4 after the cpu label.
     let [_, _, _, idle_ticks, iowait_ticks, ..] = values.as_slice() else {
         return None;
     };
@@ -183,6 +179,11 @@ mod tests {
     #[test]
     fn parse_cpu_stat_line_accepts_valid_aggregate_line() {
         assert_eq!(parse_cpu_stat_line("cpu 1 2 3 4 5 6 7 8"), Some((9, 36)));
+    }
+
+    #[test]
+    fn parse_cpu_stat_line_accepts_whitespace_separated_fields() {
+        assert_eq!(parse_cpu_stat_line("cpu\t1 2 3 4 5 6"), Some((9, 21)));
     }
 
     #[test]

--- a/crates/guest-agent/src/metrics.rs
+++ b/crates/guest-agent/src/metrics.rs
@@ -47,24 +47,10 @@ impl CpuTracker {
             Some(l) => l,
             None => return 0.0,
         };
-        if !first_line.starts_with("cpu ") {
-            return 0.0;
-        }
-        let values: Vec<u64> = match first_line
-            .split_whitespace()
-            .skip(1)
-            .map(|v| v.parse())
-            .collect::<Result<_, _>>()
-        {
-            Ok(values) => values,
-            Err(_) => return 0.0,
+        let (idle, total) = match parse_cpu_stat_line(first_line) {
+            Some(cpu_stat) => cpu_stat,
+            None => return 0.0,
         };
-        // idle = field 3, iowait = field 4
-        let [_, _, _, idle_ticks, iowait_ticks, ..] = values.as_slice() else {
-            return 0.0;
-        };
-        let idle = *idle_ticks + *iowait_ticks;
-        let total: u64 = values.iter().sum();
 
         let delta_idle = idle.saturating_sub(self.prev_idle);
         let delta_total = total.saturating_sub(self.prev_total);
@@ -78,6 +64,28 @@ impl CpuTracker {
         let pct = 100.0 * (1.0 - delta_idle as f64 / delta_total as f64);
         (pct * 100.0).round() / 100.0
     }
+}
+
+fn parse_cpu_stat_line(line: &str) -> Option<(u64, u64)> {
+    if !line.starts_with("cpu ") {
+        return None;
+    }
+
+    let values: Vec<u64> = line
+        .split_whitespace()
+        .skip(1)
+        .map(|v| v.parse())
+        .collect::<Result<_, _>>()
+        .ok()?;
+
+    // idle = field 3, iowait = field 4
+    let [_, _, _, idle_ticks, iowait_ticks, ..] = values.as_slice() else {
+        return None;
+    };
+    let idle = *idle_ticks + *iowait_ticks;
+    let total = values.iter().sum();
+
+    Some((idle, total))
 }
 
 /// Parse `/proc/meminfo` to get (used, total) in bytes.
@@ -170,6 +178,26 @@ mod tests {
         assert!((0.0..=100.0).contains(&pct1));
         let pct2 = tracker.get_cpu_percent();
         assert!((0.0..=100.0).contains(&pct2));
+    }
+
+    #[test]
+    fn parse_cpu_stat_line_accepts_valid_aggregate_line() {
+        assert_eq!(parse_cpu_stat_line("cpu 1 2 3 4 5 6 7 8"), Some((9, 36)));
+    }
+
+    #[test]
+    fn parse_cpu_stat_line_rejects_short_line() {
+        assert_eq!(parse_cpu_stat_line("cpu 1 2 3 4"), None);
+    }
+
+    #[test]
+    fn parse_cpu_stat_line_rejects_wrong_prefix() {
+        assert_eq!(parse_cpu_stat_line("cpu0 1 2 3 4 5"), None);
+    }
+
+    #[test]
+    fn parse_cpu_stat_line_rejects_malformed_field() {
+        assert_eq!(parse_cpu_stat_line("cpu 1 2 bad 4 5 6"), None);
     }
 
     #[test]

--- a/crates/guest-agent/src/metrics.rs
+++ b/crates/guest-agent/src/metrics.rs
@@ -50,16 +50,20 @@ impl CpuTracker {
         if !first_line.starts_with("cpu ") {
             return 0.0;
         }
-        let values: Vec<u64> = first_line
+        let values: Vec<u64> = match first_line
             .split_whitespace()
             .skip(1)
-            .filter_map(|v| v.parse().ok())
-            .collect();
-        if values.len() < 5 {
+            .map(|v| v.parse())
+            .collect::<Result<_, _>>()
+        {
+            Ok(values) => values,
+            Err(_) => return 0.0,
+        };
+        // idle = field 3, iowait = field 4
+        let [_, _, _, idle_ticks, iowait_ticks, ..] = values.as_slice() else {
             return 0.0;
-        }
-        // idle = values[3], iowait = values[4]
-        let idle = values.get(3).copied().unwrap_or(0) + values.get(4).copied().unwrap_or(0);
+        };
+        let idle = *idle_ticks + *iowait_ticks;
         let total: u64 = values.iter().sum();
 
         let delta_idle = idle.saturating_sub(self.prev_idle);


### PR DESCRIPTION
## Summary

- Parse guest-agent `/proc/stat` CPU fields all-or-nothing instead of silently dropping malformed fields.
- Replace dead defensive `get(...).unwrap_or(0)` access with slice-pattern extraction of idle and iowait fields.
- Preserve the existing `0.0` fallback for unreadable, malformed, short, or zero-delta CPU samples.

Closes #14145

## Tests

- `cd crates && CARGO_BUILD_JOBS=1 cargo test -p guest-agent --lib cpu_tracker_returns_valid_range`
- `cd crates && CARGO_BUILD_JOBS=1 cargo test -p guest-agent --lib cpu_tracker_multiple_reads_are_consistent`
- `cd crates && CARGO_BUILD_JOBS=1 cargo clippy -p guest-agent --lib -- -D warnings`
- pre-commit hook: `cargo-fmt`, `cargo-clippy`, `cargo-doc`, `commitlint`
