### PR TITLE
feat: add desktop pr preview artifact

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -61,8 +61,26 @@ jobs:
       - name: Test desktop
         run: pnpm -F @vm0/desktop test
 
-      - name: Build unsigned macOS artifact
+      - name: Resolve PR preview desktop URL
+        id: preview
+        if: github.event_name == 'pull_request'
         run: |
+          preview_domain="${{ vars.PREVIEW_DOMAIN }}"
+          if [ -z "$preview_domain" ]; then
+            echo "::error::PREVIEW_DOMAIN is required to build the PR preview desktop artifact"
+            exit 1
+          fi
+
+          platform_url="https://pr-${{ github.event.pull_request.number }}-app.${preview_domain}"
+          echo "platform-url=${platform_url}" >> "$GITHUB_OUTPUT"
+          echo "PR preview desktop URL: ${platform_url}"
+
+      - name: Build unsigned production macOS artifact
+        id: build-prod
+        run: |
+          rm -f apps/desktop/desktop-runtime-config.json
+          rm -rf apps/desktop/out
+
           pnpm -F @vm0/desktop build
           pnpm --dir apps/desktop exec electron-forge make --platform darwin --arch arm64
 
@@ -78,9 +96,9 @@ jobs:
           fi
 
           cp "$forge_zip" "$artifact_path"
+          echo "path=$artifact_path" >> "$GITHUB_OUTPUT"
 
-      - name: Verify artifact
-        id: artifact
+      - name: Verify production artifact
         run: |
           artifact_path=apps/desktop/out/Zero-darwin-arm64.zip
           app_dir=apps/desktop/out/Zero-darwin-arm64/Zero.app
@@ -105,6 +123,10 @@ jobs:
             find "$app_dir/Contents/Resources/app/src" -maxdepth 2 -print || true
             exit 1
           fi
+          if [ -e "$app_dir/Contents/Resources/app/desktop-runtime-config.json" ]; then
+            echo "Production artifact should not contain desktop runtime config"
+            exit 1
+          fi
 
           /usr/libexec/PlistBuddy -c "Print :CFBundleExecutable" "$plist" | grep -qx "Zero"
           /usr/libexec/PlistBuddy -c "Print :CFBundleName" "$plist" | grep -qx "Zero"
@@ -120,12 +142,126 @@ jobs:
           unzip -l "$artifact_path" | grep -q "Zero.app/Contents/Resources/icon.icns"
           unzip -l "$artifact_path" | grep -q "Zero.app/Contents/Resources/app/dist/main.js"
           unzip -l "$artifact_path" | grep -q "Zero.app/Contents/Resources/app/assets/icon.png"
-          echo "path=$artifact_path" >> "$GITHUB_OUTPUT"
 
       - name: Upload unsigned macOS artifact
         uses: actions/upload-artifact@v7
         with:
           name: zero-desktop-macos-arm64-unsigned
-          path: turbo/${{ steps.artifact.outputs.path }}
+          path: turbo/${{ steps.build-prod.outputs.path }}
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Build unsigned PR preview macOS artifact
+        id: build-preview
+        if: github.event_name == 'pull_request'
+        env:
+          VM0_DESKTOP_PLATFORM_URL: ${{ steps.preview.outputs.platform-url }}
+        run: |
+          cleanup_runtime_config() {
+            rm -f apps/desktop/desktop-runtime-config.json
+          }
+          trap cleanup_runtime_config EXIT
+
+          rm -rf apps/desktop/out
+          node <<'NODE'
+          const fs = require("node:fs");
+
+          fs.writeFileSync(
+            "apps/desktop/desktop-runtime-config.json",
+            `${JSON.stringify(
+              { platformUrl: process.env.VM0_DESKTOP_PLATFORM_URL },
+              null,
+              2,
+            )}\n`,
+          );
+          NODE
+
+          pnpm -F @vm0/desktop build
+          pnpm --dir apps/desktop exec electron-forge make --platform darwin --arch arm64
+
+          desktop_dir="$PWD/apps/desktop"
+          version=$(node -p "require('./apps/desktop/package.json').version")
+          forge_zip="$desktop_dir/out/make/zip/darwin/arm64/Zero Dev-darwin-arm64-$version.zip"
+          artifact_path="$desktop_dir/out/ZeroDev-darwin-arm64-preview.zip"
+
+          if [ ! -f "$forge_zip" ]; then
+            echo "No Forge preview zip artifact found: $forge_zip"
+            find "$desktop_dir/out" -maxdepth 6 -type f -print || true
+            exit 1
+          fi
+
+          cp "$forge_zip" "$artifact_path"
+          echo "path=$artifact_path" >> "$GITHUB_OUTPUT"
+
+      - name: Verify PR preview artifact
+        if: github.event_name == 'pull_request'
+        env:
+          EXPECTED_PLATFORM_URL: ${{ steps.preview.outputs.platform-url }}
+        run: |
+          artifact_path=apps/desktop/out/ZeroDev-darwin-arm64-preview.zip
+          app_dir="apps/desktop/out/Zero Dev-darwin-arm64/Zero Dev.app"
+          plist="$app_dir/Contents/Info.plist"
+          runtime_config="$app_dir/Contents/Resources/app/desktop-runtime-config.json"
+          if [ ! -f "$artifact_path" ]; then
+            echo "No desktop preview zip artifact found"
+            find apps/desktop/out -maxdepth 5 -type f -print || true
+            exit 1
+          fi
+          if [ ! -d "$app_dir" ]; then
+            echo "No packaged preview app found: $app_dir"
+            find apps/desktop/out -maxdepth 4 -type d -print || true
+            exit 1
+          fi
+          if [ ! -f "$app_dir/Contents/Resources/app/dist/main.js" ]; then
+            echo "No packaged preview app main process bundle found"
+            find "$app_dir/Contents/Resources" -maxdepth 2 -print || true
+            exit 1
+          fi
+          if [ -e "$app_dir/Contents/Resources/app/src" ]; then
+            echo "Packaged preview app should not contain desktop source files"
+            find "$app_dir/Contents/Resources/app/src" -maxdepth 2 -print || true
+            exit 1
+          fi
+          if [ ! -f "$runtime_config" ]; then
+            echo "Packaged preview app should contain desktop runtime config"
+            exit 1
+          fi
+
+          RUNTIME_CONFIG="$runtime_config" node <<'NODE'
+          const fs = require("node:fs");
+
+          const config = JSON.parse(
+            fs.readFileSync(process.env.RUNTIME_CONFIG, "utf8"),
+          );
+          if (config.platformUrl !== process.env.EXPECTED_PLATFORM_URL) {
+            console.error(
+              `Expected ${process.env.EXPECTED_PLATFORM_URL}, received ${config.platformUrl}`,
+            );
+            process.exit(1);
+          }
+          NODE
+
+          /usr/libexec/PlistBuddy -c "Print :CFBundleExecutable" "$plist" | grep -qx "Zero Dev"
+          /usr/libexec/PlistBuddy -c "Print :CFBundleName" "$plist" | grep -qx "Zero Dev"
+          /usr/libexec/PlistBuddy -c "Print :CFBundleDisplayName" "$plist" | grep -qx "Zero Dev"
+          /usr/libexec/PlistBuddy -c "Print :CFBundleIdentifier" "$plist" | grep -qx "ai.vm0.zero.desktop.dev"
+          /usr/libexec/PlistBuddy -c "Print :CFBundleIconFile" "$plist" | grep -qx "icon.icns"
+          /usr/libexec/PlistBuddy -c "Print :CFBundleURLTypes:0:CFBundleURLName" "$plist" | grep -qx "Zero Dev Desktop Auth"
+          /usr/libexec/PlistBuddy -c "Print :CFBundleURLTypes:0:CFBundleURLSchemes:0" "$plist" | grep -qx "ai.vm0.zero.desktop.dev"
+          cmp -s apps/desktop/assets/icon.icns "$app_dir/Contents/Resources/icon.icns"
+          cmp -s apps/platform/public/icons/icon-512.png "$app_dir/Contents/Resources/app/assets/icon.png"
+
+          unzip -l "$artifact_path" | grep -q "Zero Dev.app/Contents/MacOS/Zero Dev"
+          unzip -l "$artifact_path" | grep -q "Zero Dev.app/Contents/Resources/icon.icns"
+          unzip -l "$artifact_path" | grep -q "Zero Dev.app/Contents/Resources/app/dist/main.js"
+          unzip -l "$artifact_path" | grep -q "Zero Dev.app/Contents/Resources/app/assets/icon.png"
+          unzip -l "$artifact_path" | grep -q "Zero Dev.app/Contents/Resources/app/desktop-runtime-config.json"
+
+      - name: Upload unsigned PR preview macOS artifact
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v7
+        with:
+          name: zero-desktop-macos-arm64-preview-unsigned
+          path: turbo/${{ steps.build-preview.outputs.path }}
           if-no-files-found: error
           retention-days: 14

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -87,7 +87,7 @@ jobs:
           desktop_dir="$PWD/apps/desktop"
           version=$(node -p "require('./apps/desktop/package.json').version")
           forge_zip="$desktop_dir/out/make/zip/darwin/arm64/Zero-darwin-arm64-$version.zip"
-          artifact_path="$desktop_dir/out/Zero-darwin-arm64.zip"
+          artifact_path="apps/desktop/out/Zero-darwin-arm64.zip"
 
           if [ ! -f "$forge_zip" ]; then
             echo "No Forge zip artifact found: $forge_zip"
@@ -182,7 +182,7 @@ jobs:
           desktop_dir="$PWD/apps/desktop"
           version=$(node -p "require('./apps/desktop/package.json').version")
           forge_zip="$desktop_dir/out/make/zip/darwin/arm64/Zero Dev-darwin-arm64-$version.zip"
-          artifact_path="$desktop_dir/out/ZeroDev-darwin-arm64-preview.zip"
+          artifact_path="apps/desktop/out/ZeroDev-darwin-arm64-preview.zip"
 
           if [ ! -f "$forge_zip" ]; then
             echo "No Forge preview zip artifact found: $forge_zip"

--- a/.gitignore
+++ b/.gitignore
@@ -200,5 +200,6 @@ tmp/
 *.sarif
 junit.xml
 e2e/results/
+turbo/apps/desktop/desktop-runtime-config.json
 .codex
 .agents/

--- a/turbo/apps/desktop/src/computer-use-host.ts
+++ b/turbo/apps/desktop/src/computer-use-host.ts
@@ -85,15 +85,13 @@ type ComputerUseHostNextResponse =
   | ComputerUseHostNextIdleResponse
   | ComputerUseHostNextCommandResponse;
 
+function replaceHostPrefix(hostname: string, target: string): string {
+  return hostname.replace(/(^|-)(api|app|platform|www)\./, `$1${target}.`);
+}
+
 export function resolveComputerUseApiBaseUrl(platformUrl: URL): string {
   const url = new URL(platformUrl.toString());
-  if (url.hostname === "www.vm0.ai" || url.hostname === "app.vm0.ai") {
-    url.hostname = "api.vm0.ai";
-  } else if (url.hostname.startsWith("staging-app.")) {
-    url.hostname = url.hostname.replace("staging-app.", "staging-api.");
-  } else if (url.hostname.startsWith("app.")) {
-    url.hostname = url.hostname.replace("app.", "api.");
-  }
+  url.hostname = replaceHostPrefix(url.hostname, "api");
   return url.toString().replace(/\/$/, "");
 }
 

--- a/turbo/apps/desktop/src/config.ts
+++ b/turbo/apps/desktop/src/config.ts
@@ -1,6 +1,9 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
 import desktopIdentities from "./desktop-identities.json";
 
 const PRODUCTION_PLATFORM_URL = "https://app.vm0.ai";
+const DESKTOP_RUNTIME_CONFIG_FILE = "desktop-runtime-config.json";
 
 type DesktopEnvironment = "production" | "staging" | "development";
 type DesktopIdentityKind = "production" | "development";
@@ -21,6 +24,55 @@ interface DesktopConfig {
   readonly identity: DesktopIdentity;
   readonly sessionPartition: string;
   readonly allowedAppOrigins: ReadonlySet<string>;
+}
+
+function desktopRuntimeConfigPath(): string {
+  return join(__dirname, "..", DESKTOP_RUNTIME_CONFIG_FILE);
+}
+
+function runtimeConfigPlatformUrl(value: unknown): string {
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    !("platformUrl" in value)
+  ) {
+    throw new Error(
+      `${DESKTOP_RUNTIME_CONFIG_FILE} must contain a platformUrl string`,
+    );
+  }
+
+  const config = value as { readonly platformUrl?: unknown };
+  if (typeof config.platformUrl !== "string") {
+    throw new Error(
+      `${DESKTOP_RUNTIME_CONFIG_FILE} must contain a platformUrl string`,
+    );
+  }
+
+  return config.platformUrl;
+}
+
+function readDesktopRuntimeConfigPlatformUrl(): string | undefined {
+  const configPath = desktopRuntimeConfigPath();
+  if (!existsSync(configPath)) {
+    return undefined;
+  }
+
+  const configValue: unknown = JSON.parse(readFileSync(configPath, "utf8"));
+  return runtimeConfigPlatformUrl(configValue);
+}
+
+function configuredPlatformUrl(
+  rawPlatformUrl: string | undefined,
+): string | undefined {
+  if (rawPlatformUrl !== undefined) {
+    return rawPlatformUrl;
+  }
+
+  if (process.env.VM0_DESKTOP_PLATFORM_URL?.trim()) {
+    return process.env.VM0_DESKTOP_PLATFORM_URL;
+  }
+
+  return readDesktopRuntimeConfigPlatformUrl();
 }
 
 function parsePlatformUrl(rawUrl: string | undefined): URL {
@@ -88,11 +140,10 @@ function allowedOriginsForPlatformUrl(platformUrl: URL): ReadonlySet<string> {
   return origins;
 }
 
-export function resolveDesktopConfig(
-  rawPlatformUrl = process.env.VM0_DESKTOP_PLATFORM_URL,
-): DesktopConfig {
-  const hasExplicitUrl = Boolean(rawPlatformUrl?.trim());
-  const platformUrl = parsePlatformUrl(rawPlatformUrl);
+export function resolveDesktopConfig(rawPlatformUrl?: string): DesktopConfig {
+  const platformUrlSource = configuredPlatformUrl(rawPlatformUrl);
+  const hasExplicitUrl = Boolean(platformUrlSource?.trim());
+  const platformUrl = parsePlatformUrl(platformUrlSource);
   const environment = environmentForPlatformUrl(platformUrl, hasExplicitUrl);
 
   return {

--- a/turbo/apps/desktop/src/desktop-local-agent-api.ts
+++ b/turbo/apps/desktop/src/desktop-local-agent-api.ts
@@ -48,7 +48,7 @@ function replaceHostPrefix(hostname: string, target: string): string {
   return hostname.replace(/(^|-)(api|app|platform|www)\./, `$1${target}.`);
 }
 
-function resolveLocalAgentApiBaseUrl(platformUrl: URL): URL {
+export function resolveLocalAgentApiBaseUrl(platformUrl: URL): URL {
   if (
     platformUrl.hostname === "localhost" ||
     platformUrl.hostname === "127.0.0.1"

--- a/turbo/apps/desktop/src/desktop-local-agent-manager.test.ts
+++ b/turbo/apps/desktop/src/desktop-local-agent-manager.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
-import type { DesktopLocalAgentApiClient } from "./desktop-local-agent-api";
+import type { Session } from "electron";
+import {
+  createDesktopLocalAgentApiClient,
+  type DesktopLocalAgentApiClient,
+} from "./desktop-local-agent-api";
 import { DesktopLocalAgentManager } from "./desktop-local-agent-manager";
 import type { executeLocalAgentBackend } from "./desktop-local-agent-runtime";
 import type {
@@ -94,6 +98,48 @@ function createHarness(
 
   return { manager, startedHosts, closedHosts, completedJobs };
 }
+
+function createCookieSession(): Session {
+  return {
+    cookies: {
+      async get() {
+        return [];
+      },
+    },
+  } as unknown as Session;
+}
+
+describe("DesktopLocalAgentApiClient", () => {
+  it("derives the API backend URL from PR preview platform URLs", async () => {
+    const originalFetch = globalThis.fetch;
+    const calls: string[] = [];
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      calls.push(input.toString());
+      return new Response(
+        JSON.stringify({ hostId: "host-1", hostToken: "token-1" }),
+        { status: 200 },
+      );
+    });
+
+    try {
+      const client = createDesktopLocalAgentApiClient({
+        platformUrl: new URL("https://pr-123-app.vm6.ai"),
+        session: createCookieSession(),
+      });
+
+      await client.startHost({
+        hostName: "Zero Dev",
+        supportedBackends: ["codex"],
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    expect(calls).toStrictEqual([
+      "https://pr-123-api.vm6.ai/api/zero/local-agent/hosts/start",
+    ]);
+  });
+});
 
 describe("DesktopLocalAgentManager", () => {
   it("keeps native access disabled until the feature switch enables it", async () => {

--- a/turbo/apps/desktop/src/desktop-local-agent-manager.test.ts
+++ b/turbo/apps/desktop/src/desktop-local-agent-manager.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
-import type { Session } from "electron";
 import {
-  createDesktopLocalAgentApiClient,
+  resolveLocalAgentApiBaseUrl,
   type DesktopLocalAgentApiClient,
 } from "./desktop-local-agent-api";
 import { DesktopLocalAgentManager } from "./desktop-local-agent-manager";
@@ -99,45 +98,13 @@ function createHarness(
   return { manager, startedHosts, closedHosts, completedJobs };
 }
 
-function createCookieSession(): Session {
-  return {
-    cookies: {
-      async get() {
-        return [];
-      },
-    },
-  } as unknown as Session;
-}
-
 describe("DesktopLocalAgentApiClient", () => {
-  it("derives the API backend URL from PR preview platform URLs", async () => {
-    const originalFetch = globalThis.fetch;
-    const calls: string[] = [];
-    globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
-      calls.push(input.toString());
-      return new Response(
-        JSON.stringify({ hostId: "host-1", hostToken: "token-1" }),
-        { status: 200 },
-      );
-    });
-
-    try {
-      const client = createDesktopLocalAgentApiClient({
-        platformUrl: new URL("https://pr-123-app.vm6.ai"),
-        session: createCookieSession(),
-      });
-
-      await client.startHost({
-        hostName: "Zero Dev",
-        supportedBackends: ["codex"],
-      });
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
-
-    expect(calls).toStrictEqual([
-      "https://pr-123-api.vm6.ai/api/zero/local-agent/hosts/start",
-    ]);
+  it("derives the API backend URL from PR preview platform URLs", () => {
+    expect(
+      resolveLocalAgentApiBaseUrl(
+        new URL("https://pr-123-app.vm6.ai"),
+      ).toString(),
+    ).toBe("https://pr-123-api.vm6.ai/");
   });
 });
 

--- a/turbo/apps/desktop/src/window-policy.test.ts
+++ b/turbo/apps/desktop/src/window-policy.test.ts
@@ -78,6 +78,22 @@ describe("resolveDesktopConfig", () => {
     expect(config.allowedAppOrigins.has("https://api.vm7.ai")).toBe(true);
   });
 
+  it("derives matching origins for PR preview hostnames", () => {
+    const config = resolveDesktopConfig("https://pr-123-app.vm6.ai/");
+
+    expect(config.environment).toBe("development");
+    expect(config.identity).toMatchObject({
+      displayName: "Zero Dev",
+      bundleId: "ai.vm0.zero.desktop.dev",
+      authScheme: "ai.vm0.zero.desktop.dev",
+    });
+    expect([...config.allowedAppOrigins].sort()).toStrictEqual([
+      "https://pr-123-api.vm6.ai",
+      "https://pr-123-app.vm6.ai",
+      "https://pr-123-www.vm6.ai",
+    ]);
+  });
+
   it("does not derive localhost companion origins", () => {
     const config = resolveDesktopConfig("http://localhost:3002");
 
@@ -425,6 +441,9 @@ describe("computer use desktop runtime", () => {
     expect(
       resolveComputerUseApiBaseUrl(new URL("https://staging-app.vm6.ai")),
     ).toBe("https://staging-api.vm6.ai");
+    expect(
+      resolveComputerUseApiBaseUrl(new URL("https://pr-123-app.vm6.ai")),
+    ).toBe("https://pr-123-api.vm6.ai");
   });
 
   it("serializes the Desktop host runtime body", () => {


### PR DESCRIPTION
## Summary

- build the existing production desktop artifact first and keep its artifact name/identity unchanged
- add a PR-only preview desktop artifact that bakes `https://pr-{number}-app.${PREVIEW_DOMAIN}` into packaged runtime config
- use the development desktop identity for preview packages and verify the packaged app contains the preview runtime config
- align Computer Use API host derivation with local-agent host derivation so `pr-123-app.*` targets `pr-123-api.*`

Closes #14158

## Validation

- `pnpm -F @vm0/desktop check-types`
- `pnpm -F @vm0/desktop lint`
- `pnpm -F @vm0/desktop test`
- `pnpm -F @vm0/desktop build`
- `pnpm exec prettier --check --ignore-unknown ../.github/workflows/desktop.yml ../.gitignore apps/desktop/src/config.ts apps/desktop/src/computer-use-host.ts apps/desktop/src/desktop-local-agent-manager.test.ts apps/desktop/src/window-policy.test.ts`
- `pnpm knip --workspace @vm0/desktop`
- `node … | bash -n` for all `run:` scripts in `.github/workflows/desktop.yml`
- pre-commit hook: full `pnpm check-types` and `pnpm knip --cache`

## Notes

Local full typecheck initially needed `pnpm -F @vm0/firewalls-generator generate:weread` because the generated WeRead firewall file is ignored and was missing after syncing `main`; no generated firewall files are committed.
