### PR TITLE
fix: align integration session model reuse

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-slack-webhooks.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-slack-webhooks.ts
@@ -276,6 +276,7 @@ export const seedSlackThreadSession$ = command(
       readonly fixture: SlackWebhookFixture;
       readonly channelId: string;
       readonly threadTs: string;
+      readonly modelProvider?: string | null;
       readonly selectedModel: string;
     },
     signal: AbortSignal,
@@ -335,7 +336,7 @@ export const seedSlackThreadSession$ = command(
     await db.insert(zeroRuns).values({
       id: run.id,
       triggerSource: "slack",
-      modelProvider: "vm0",
+      modelProvider: args.modelProvider ?? "vm0",
       selectedModel: args.selectedModel,
     });
     signal.throwIfAborted();

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-agentphone-routes.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-agentphone-routes.test.ts
@@ -10,11 +10,21 @@ import { zeroIntegrationsAgentPhoneContract } from "@vm0/api-contracts/contracts
 import { agentRunCallbacks } from "@vm0/db/schema/agent-run-callback";
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { agentSessions } from "@vm0/db/schema/agent-session";
-import { agentComposes } from "@vm0/db/schema/agent-compose";
+import {
+  agentComposes,
+  agentComposeVersions,
+} from "@vm0/db/schema/agent-compose";
 import { agentphoneMessages } from "@vm0/db/schema/agentphone-message";
+import { agentphoneThreadSessions } from "@vm0/db/schema/agentphone-thread-session";
 import { agentphoneUserLinks } from "@vm0/db/schema/agentphone-user-link";
+import { orgMembersMetadata } from "@vm0/db/schema/org-members-metadata";
+import { orgMetadata } from "@vm0/db/schema/org-metadata";
+import { orgModelPolicies } from "@vm0/db/schema/org-model-policy";
 import { runUploadedFiles } from "@vm0/db/schema/run-uploaded-file";
 import { storages, storageVersions } from "@vm0/db/schema/storage";
+import { vm0ApiKeys } from "@vm0/db/schema/vm0-api-key";
+import { zeroAgents } from "@vm0/db/schema/zero-agent";
+import { zeroRuns } from "@vm0/db/schema/zero-run";
 import { createStore } from "ccstate";
 import { and, eq, inArray } from "drizzle-orm";
 import { http, HttpResponse } from "msw";
@@ -51,6 +61,9 @@ interface RunFixture {
   readonly runId: string;
   readonly sessionId: string;
   readonly composeId: string;
+  readonly versionId?: string;
+  readonly orgId: string;
+  readonly userId: string;
 }
 
 const AGENTPHONE_WEBHOOK_SECRET = ["agentphone", "webhook", "secret"].join("-");
@@ -107,19 +120,64 @@ const trackStorageOwner = createFixtureTracker(
 );
 
 const trackRun = createFixtureTracker(async (fixture: RunFixture) => {
-  await writeDb
-    .delete(agentRunCallbacks)
-    .where(eq(agentRunCallbacks.runId, fixture.runId));
-  await writeDb
-    .delete(runUploadedFiles)
-    .where(eq(runUploadedFiles.runId, fixture.runId));
-  await writeDb.delete(agentRuns).where(eq(agentRuns.id, fixture.runId));
+  const runRows = await writeDb
+    .select({ id: agentRuns.id })
+    .from(agentRuns)
+    .where(
+      and(
+        eq(agentRuns.orgId, fixture.orgId),
+        eq(agentRuns.userId, fixture.userId),
+      ),
+    );
+  const runIds = runRows.map((row) => {
+    return row.id;
+  });
+  if (runIds.length > 0) {
+    await writeDb
+      .delete(agentRunCallbacks)
+      .where(inArray(agentRunCallbacks.runId, runIds));
+    await writeDb
+      .delete(runUploadedFiles)
+      .where(inArray(runUploadedFiles.runId, runIds));
+    await writeDb.delete(zeroRuns).where(inArray(zeroRuns.id, runIds));
+    await writeDb.delete(agentRuns).where(inArray(agentRuns.id, runIds));
+  }
   await writeDb
     .delete(agentSessions)
-    .where(eq(agentSessions.id, fixture.sessionId));
+    .where(
+      and(
+        eq(agentSessions.orgId, fixture.orgId),
+        eq(agentSessions.userId, fixture.userId),
+      ),
+    );
+  const composeRows = await writeDb
+    .select({ id: agentComposes.id })
+    .from(agentComposes)
+    .where(
+      and(
+        eq(agentComposes.orgId, fixture.orgId),
+        eq(agentComposes.userId, fixture.userId),
+      ),
+    );
+  const composeIds = composeRows.map((row) => {
+    return row.id;
+  });
+  if (composeIds.length > 0) {
+    await writeDb.delete(zeroAgents).where(inArray(zeroAgents.id, composeIds));
+    await writeDb
+      .delete(agentComposeVersions)
+      .where(inArray(agentComposeVersions.composeId, composeIds));
+    await writeDb
+      .delete(agentComposes)
+      .where(inArray(agentComposes.id, composeIds));
+  }
   await writeDb
-    .delete(agentComposes)
-    .where(eq(agentComposes.id, fixture.composeId));
+    .delete(orgModelPolicies)
+    .where(eq(orgModelPolicies.orgId, fixture.orgId));
+  await writeDb
+    .delete(orgMembersMetadata)
+    .where(eq(orgMembersMetadata.orgId, fixture.orgId));
+  await writeDb.delete(orgMetadata).where(eq(orgMetadata.orgId, fixture.orgId));
 });
 
 function currentSecond(): number {
@@ -284,7 +342,134 @@ async function seedRun(args: {
     status: "failed",
     prompt: "test prompt",
   });
-  return trackRun(Promise.resolve({ runId, sessionId, composeId }));
+  return trackRun(
+    Promise.resolve({
+      runId,
+      sessionId,
+      composeId,
+      orgId: args.orgId,
+      userId: args.userId,
+    }),
+  );
+}
+
+async function seedAgentPhoneModelReuseFixture(args: {
+  readonly userId: string;
+  readonly orgId: string;
+  readonly phoneHandle: string;
+  readonly selectedModel: string;
+  readonly previousModelProvider: string;
+}): Promise<{
+  readonly composeId: string;
+  readonly previousSessionId: string;
+  readonly userLinkId: string;
+}> {
+  const composeId = randomUUID();
+  const versionId = randomUUID();
+  const previousSessionId = randomUUID();
+  const previousRunId = randomUUID();
+  await writeDb.insert(agentComposes).values({
+    id: composeId,
+    userId: args.userId,
+    orgId: args.orgId,
+    name: "agentphone-model-agent",
+  });
+  await writeDb.insert(agentComposeVersions).values({
+    id: versionId,
+    composeId,
+    createdBy: args.userId,
+    content: {
+      version: "1.0",
+      agents: {
+        "agentphone-model-agent": {
+          framework: "claude-code",
+          environment: { ANTHROPIC_API_KEY: "test-key" },
+        },
+      },
+    },
+  });
+  await writeDb
+    .update(agentComposes)
+    .set({ headVersionId: versionId })
+    .where(eq(agentComposes.id, composeId));
+  await writeDb.insert(zeroAgents).values({
+    id: composeId,
+    orgId: args.orgId,
+    owner: args.userId,
+    name: "agentphone-model-agent",
+    displayName: "AgentPhone Model Agent",
+    visibility: "public",
+    customSkills: [],
+  });
+  await writeDb.insert(orgMetadata).values({
+    orgId: args.orgId,
+    defaultAgentId: composeId,
+    credits: 100_000,
+  });
+  await writeDb.insert(orgMembersMetadata).values({
+    orgId: args.orgId,
+    userId: args.userId,
+    timezone: "UTC",
+    selectedModel: args.selectedModel,
+  });
+  await writeDb.insert(vm0ApiKeys).values({
+    vendor: "anthropic",
+    model: args.selectedModel,
+    apiKey: `vm0-key-${args.selectedModel}`,
+  });
+  await writeDb.insert(orgModelPolicies).values({
+    orgId: args.orgId,
+    model: args.selectedModel,
+    isDefault: true,
+    defaultProviderType: "vm0",
+    credentialScope: "org",
+    createdByUserId: args.userId,
+    updatedByUserId: args.userId,
+  });
+
+  const userLinkId = await seedAgentPhoneLink({
+    phoneHandle: args.phoneHandle,
+    userId: args.userId,
+    orgId: args.orgId,
+  });
+  await writeDb.insert(agentSessions).values({
+    id: previousSessionId,
+    userId: args.userId,
+    orgId: args.orgId,
+    agentComposeId: composeId,
+  });
+  await writeDb.insert(agentRuns).values({
+    id: previousRunId,
+    userId: args.userId,
+    orgId: args.orgId,
+    sessionId: previousSessionId,
+    status: "completed",
+    prompt: "previous AgentPhone session",
+  });
+  await writeDb.insert(zeroRuns).values({
+    id: previousRunId,
+    triggerSource: "agentphone",
+    modelProvider: args.previousModelProvider,
+    selectedModel: args.selectedModel,
+  });
+  await writeDb.insert(agentphoneThreadSessions).values({
+    agentphoneUserLinkId: userLinkId,
+    rootMessageId: "dm",
+    agentSessionId: previousSessionId,
+    lastProcessedMessageId: "ap-previous-message",
+  });
+  await trackRun(
+    Promise.resolve({
+      runId: previousRunId,
+      sessionId: previousSessionId,
+      composeId,
+      versionId,
+      orgId: args.orgId,
+      userId: args.userId,
+    }),
+  );
+
+  return { composeId, previousSessionId, userLinkId };
 }
 
 function callbackHeaders(rawBody: string) {
@@ -393,6 +578,137 @@ describe("AgentPhone migrated API routes", () => {
       direction: "inbound",
     });
     expect(sendCalls[0]?.body).toContain("/agentphone/connect?");
+  });
+
+  it("starts a new AgentPhone session when the selected model provider changed", async () => {
+    configureAgentPhoneEnv();
+    const userId = uniqueId("user");
+    const orgId = uniqueId("org");
+    const phoneHandle = uniquePhone();
+    const { previousSessionId } = await seedAgentPhoneModelReuseFixture({
+      userId,
+      orgId,
+      phoneHandle,
+      selectedModel: "claude-sonnet-4-6",
+      previousModelProvider: "openrouter-api-key",
+    });
+    const sendCalls = agentPhoneSendMessage();
+    const app = createApp({ signal: context.signal });
+    const prompt = "provider changed AgentPhone session";
+    const body = {
+      event: "agent.message",
+      channel: "sms",
+      data: {
+        id: "ap-provider-change",
+        agentId: "agt-agentphone",
+        from: phoneHandle,
+        to: "+19039853128",
+        body: prompt,
+      },
+    };
+    const rawBody = JSON.stringify(body);
+    const timestamp = String(currentSecond());
+
+    const response = await app.request("/api/agentphone/webhook", {
+      method: "POST",
+      headers: {
+        "x-webhook-timestamp": timestamp,
+        "x-webhook-signature": signAgentPhoneWebhook(rawBody, timestamp),
+        "x-webhook-id": "webhook-provider-change",
+      },
+      body: rawBody,
+    });
+    expect(response.status).toBe(200);
+    await clearAllDetached();
+
+    expect(sendCalls).toStrictEqual([]);
+    const [run] = await writeDb
+      .select({
+        sessionId: agentRuns.sessionId,
+        continuedFromSessionId: agentRuns.continuedFromSessionId,
+        modelProvider: zeroRuns.modelProvider,
+        selectedModel: zeroRuns.selectedModel,
+      })
+      .from(agentRuns)
+      .innerJoin(zeroRuns, eq(zeroRuns.id, agentRuns.id))
+      .where(eq(agentRuns.prompt, prompt))
+      .limit(1);
+    expect(run).toMatchObject({
+      continuedFromSessionId: null,
+      modelProvider: "vm0",
+      selectedModel: "claude-sonnet-4-6",
+    });
+    expect(run?.sessionId).not.toBe(previousSessionId);
+  });
+
+  it("starts a new AgentPhone session when the default model provider changed", async () => {
+    configureAgentPhoneEnv();
+    const userId = uniqueId("user");
+    const orgId = uniqueId("org");
+    const phoneHandle = uniquePhone();
+    const { previousSessionId } = await seedAgentPhoneModelReuseFixture({
+      userId,
+      orgId,
+      phoneHandle,
+      selectedModel: "claude-sonnet-4-6",
+      previousModelProvider: "openrouter-api-key",
+    });
+    await writeDb
+      .update(orgMembersMetadata)
+      .set({ selectedModel: null })
+      .where(
+        and(
+          eq(orgMembersMetadata.orgId, orgId),
+          eq(orgMembersMetadata.userId, userId),
+        ),
+      );
+    const sendCalls = agentPhoneSendMessage();
+    const app = createApp({ signal: context.signal });
+    const prompt = "default provider changed AgentPhone session";
+    const body = {
+      event: "agent.message",
+      channel: "sms",
+      data: {
+        id: "ap-default-provider-change",
+        agentId: "agt-agentphone",
+        from: phoneHandle,
+        to: "+19039853128",
+        body: prompt,
+      },
+    };
+    const rawBody = JSON.stringify(body);
+    const timestamp = String(currentSecond());
+
+    const response = await app.request("/api/agentphone/webhook", {
+      method: "POST",
+      headers: {
+        "x-webhook-timestamp": timestamp,
+        "x-webhook-signature": signAgentPhoneWebhook(rawBody, timestamp),
+        "x-webhook-id": "webhook-default-provider-change",
+      },
+      body: rawBody,
+    });
+    expect(response.status).toBe(200);
+    await clearAllDetached();
+
+    expect(sendCalls).toStrictEqual([]);
+    const [run] = await writeDb
+      .select({
+        sessionId: agentRuns.sessionId,
+        continuedFromSessionId: agentRuns.continuedFromSessionId,
+        modelProvider: zeroRuns.modelProvider,
+        selectedModel: zeroRuns.selectedModel,
+      })
+      .from(agentRuns)
+      .innerJoin(zeroRuns, eq(zeroRuns.id, agentRuns.id))
+      .where(eq(agentRuns.prompt, prompt))
+      .limit(1);
+    expect(run).toMatchObject({
+      continuedFromSessionId: null,
+      modelProvider: "vm0",
+      selectedModel: "claude-sonnet-4-6",
+    });
+    expect(run?.sessionId).not.toBe(previousSessionId);
   });
 
   it.each([

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-telegram-post.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-telegram-post.test.ts
@@ -212,13 +212,20 @@ const seedTelegramPostFixture$ = command(
     if (args.seedDefaultAgent ?? true) {
       await db
         .insert(orgMetadata)
-        .values({ orgId, defaultAgentId: composeId })
+        .values({ orgId, defaultAgentId: composeId, credits: 100_000 })
         .onConflictDoUpdate({
           target: orgMetadata.orgId,
-          set: { defaultAgentId: composeId },
+          set: { defaultAgentId: composeId, credits: 100_000 },
         });
       signal.throwIfAborted();
     }
+    await db.insert(vm0ApiKeys).values({
+      vendor: "anthropic",
+      model: "claude-sonnet-4-6",
+      apiKey: `vm0-key-${composeId}`,
+      label: composeId,
+    });
+    signal.throwIfAborted();
 
     if (args.installBot ?? true) {
       await db.insert(telegramInstallations).values({
@@ -454,6 +461,7 @@ async function latestZeroRunForFixture(fixture: TelegramPostFixture) {
   const [run] = await db
     .select({
       id: zeroRuns.id,
+      modelProvider: zeroRuns.modelProvider,
       selectedModel: zeroRuns.selectedModel,
     })
     .from(zeroRuns)
@@ -584,6 +592,7 @@ async function seedRunningRun(fixture: TelegramPostFixture): Promise<void> {
 
 async function seedCompletedRun(args: {
   readonly fixture: TelegramPostFixture;
+  readonly modelProvider?: string | null;
   readonly selectedModel: string;
 }): Promise<string> {
   const db = store.set(writeDb$);
@@ -608,6 +617,7 @@ async function seedCompletedRun(args: {
   await db.insert(zeroRuns).values({
     id: run.id,
     triggerSource: "telegram",
+    modelProvider: args.modelProvider ?? null,
     selectedModel: args.selectedModel,
   });
   return sessionId;
@@ -2099,6 +2109,132 @@ describe("POST /api/telegram/webhook/:telegramBotId", () => {
     await expect(latestZeroRunForFixture(fixture)).resolves.toStrictEqual(
       expect.objectContaining({
         selectedModel: "claude-opus-4-7",
+      }),
+    );
+  });
+
+  it("starts a new custom DM session when the selected model provider changed", async () => {
+    const fixture = await trackFixture(
+      store.set(
+        seedTelegramPostFixture$,
+        { linkTelegramUser: true },
+        context.signal,
+      ),
+    );
+    await seedModelPolicies({
+      fixture,
+      selectedModel: "claude-sonnet-4-6",
+    });
+    await seedOrgCredits(fixture, 100_000);
+    const previousSessionId = await seedCompletedRun({
+      fixture,
+      modelProvider: "openrouter-api-key",
+      selectedModel: "claude-sonnet-4-6",
+    });
+    await seedTelegramThreadSession({
+      telegramUserLinkId: await linkedTelegramUserLinkId(fixture),
+      chatId: fixture.telegramUserId!,
+      rootMessageId: "dm",
+      agentSessionId: previousSessionId,
+    });
+    const telegramMocks = telegramApiMocks();
+
+    const response = await postWebhook({
+      telegramBotId: fixture.telegramBotId,
+      secret: fixture.webhookSecret,
+      body: {
+        update_id: 132,
+        message: {
+          message_id: 1321,
+          chat: { id: Number(fixture.telegramUserId), type: "private" },
+          from: {
+            id: Number(fixture.telegramUserId),
+            username: "alice",
+            first_name: "Alice",
+          },
+          text: "provider changed telegram session",
+        },
+      },
+    });
+
+    expect(response.status).toBe(200);
+    await clearAllDetached();
+    expect(telegramMocks.sentMessages).toStrictEqual([]);
+
+    const run = await runForFixturePrompt(
+      fixture,
+      "provider changed telegram session",
+    );
+    expect(run?.prompt).toBe("provider changed telegram session");
+    expect(run?.continuedFromSessionId).toBeNull();
+    expect(run?.sessionId).not.toBe(previousSessionId);
+    await expect(latestZeroRunForFixture(fixture)).resolves.toStrictEqual(
+      expect.objectContaining({
+        modelProvider: "vm0",
+        selectedModel: "claude-sonnet-4-6",
+      }),
+    );
+  });
+
+  it("starts a new custom DM session when the default model provider changed", async () => {
+    const fixture = await trackFixture(
+      store.set(
+        seedTelegramPostFixture$,
+        { linkTelegramUser: true },
+        context.signal,
+      ),
+    );
+    await seedModelPolicies({
+      fixture,
+      selectedModel: null,
+    });
+    await seedOrgCredits(fixture, 100_000);
+    const previousSessionId = await seedCompletedRun({
+      fixture,
+      modelProvider: "openrouter-api-key",
+      selectedModel: "claude-sonnet-4-6",
+    });
+    await seedTelegramThreadSession({
+      telegramUserLinkId: await linkedTelegramUserLinkId(fixture),
+      chatId: fixture.telegramUserId!,
+      rootMessageId: "dm",
+      agentSessionId: previousSessionId,
+    });
+    const telegramMocks = telegramApiMocks();
+
+    const response = await postWebhook({
+      telegramBotId: fixture.telegramBotId,
+      secret: fixture.webhookSecret,
+      body: {
+        update_id: 133,
+        message: {
+          message_id: 1331,
+          chat: { id: Number(fixture.telegramUserId), type: "private" },
+          from: {
+            id: Number(fixture.telegramUserId),
+            username: "alice",
+            first_name: "Alice",
+          },
+          text: "default provider changed telegram session",
+        },
+      },
+    });
+
+    expect(response.status).toBe(200);
+    await clearAllDetached();
+    expect(telegramMocks.sentMessages).toStrictEqual([]);
+
+    const run = await runForFixturePrompt(
+      fixture,
+      "default provider changed telegram session",
+    );
+    expect(run?.prompt).toBe("default provider changed telegram session");
+    expect(run?.continuedFromSessionId).toBeNull();
+    expect(run?.sessionId).not.toBe(previousSessionId);
+    await expect(latestZeroRunForFixture(fixture)).resolves.toStrictEqual(
+      expect.objectContaining({
+        modelProvider: "vm0",
+        selectedModel: "claude-sonnet-4-6",
       }),
     );
   });

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-slack-events.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-slack-events.test.ts
@@ -422,6 +422,167 @@ describe("POST /api/zero/slack/events", () => {
     expect(run?.sessionId).not.toBe(previousSessionId);
   });
 
+  it("starts a new Slack session when the selected model provider changed", async () => {
+    const fixture = await track(
+      store.set(
+        seedSlackWebhookFixture$,
+        { withConnection: true, withDefaultAgent: true },
+        context.signal,
+      ),
+    );
+    expect(fixture.defaultAgentId).toBeTruthy();
+    const db = store.set(writeDb$);
+    await db.insert(vm0ApiKeys).values({
+      vendor: "anthropic",
+      model: "claude-sonnet-4-6",
+      apiKey: "vm0-key-claude-sonnet-4-6",
+    });
+    await db.insert(orgModelPolicies).values({
+      orgId: fixture.orgId,
+      model: "claude-sonnet-4-6",
+      isDefault: true,
+      defaultProviderType: "vm0",
+      credentialScope: "org",
+      createdByUserId: fixture.userId,
+      updatedByUserId: fixture.userId,
+    });
+
+    const channelId = "D-provider";
+    const threadTs = "2450.001";
+    const previousSessionId = await store.set(
+      seedSlackThreadSession$,
+      {
+        fixture,
+        channelId,
+        threadTs,
+        modelProvider: "openrouter-api-key",
+        selectedModel: "claude-sonnet-4-6",
+      },
+      context.signal,
+    );
+    await store.set(
+      setSlackWebhookUserSelectedModel$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        selectedModel: "claude-sonnet-4-6",
+      },
+      context.signal,
+    );
+
+    const prompt = "provider changed in Slack thread";
+    const response = await postEvent({
+      type: "event_callback",
+      team_id: fixture.slackWorkspaceId,
+      event: {
+        type: "message",
+        channel_type: "im",
+        user: fixture.slackUserId,
+        text: prompt,
+        ts: "2450.002",
+        thread_ts: threadTs,
+        channel: channelId,
+      },
+    });
+    await clearAllDetached();
+
+    expect(response.status).toBe(200);
+    const [run] = await db
+      .select({
+        id: agentRuns.id,
+        sessionId: agentRuns.sessionId,
+        continuedFromSessionId: agentRuns.continuedFromSessionId,
+        modelProvider: zeroRuns.modelProvider,
+        selectedModel: zeroRuns.selectedModel,
+      })
+      .from(agentRuns)
+      .innerJoin(zeroRuns, eq(zeroRuns.id, agentRuns.id))
+      .where(eq(agentRuns.prompt, prompt))
+      .limit(1);
+    expect(run).toMatchObject({
+      continuedFromSessionId: null,
+      modelProvider: "vm0",
+      selectedModel: "claude-sonnet-4-6",
+    });
+    expect(run?.sessionId).not.toBe(previousSessionId);
+  });
+
+  it("starts a new Slack session when the default model provider changed", async () => {
+    const fixture = await track(
+      store.set(
+        seedSlackWebhookFixture$,
+        { withConnection: true, withDefaultAgent: true },
+        context.signal,
+      ),
+    );
+    expect(fixture.defaultAgentId).toBeTruthy();
+    const db = store.set(writeDb$);
+    await db.insert(vm0ApiKeys).values({
+      vendor: "anthropic",
+      model: "claude-sonnet-4-6",
+      apiKey: "vm0-key-claude-sonnet-4-6",
+    });
+    await db.insert(orgModelPolicies).values({
+      orgId: fixture.orgId,
+      model: "claude-sonnet-4-6",
+      isDefault: true,
+      defaultProviderType: "vm0",
+      credentialScope: "org",
+      createdByUserId: fixture.userId,
+      updatedByUserId: fixture.userId,
+    });
+
+    const channelId = "D-default-provider";
+    const threadTs = "2451.001";
+    const previousSessionId = await store.set(
+      seedSlackThreadSession$,
+      {
+        fixture,
+        channelId,
+        threadTs,
+        modelProvider: "openrouter-api-key",
+        selectedModel: "claude-sonnet-4-6",
+      },
+      context.signal,
+    );
+
+    const prompt = "default provider changed in Slack thread";
+    const response = await postEvent({
+      type: "event_callback",
+      team_id: fixture.slackWorkspaceId,
+      event: {
+        type: "message",
+        channel_type: "im",
+        user: fixture.slackUserId,
+        text: prompt,
+        ts: "2451.002",
+        thread_ts: threadTs,
+        channel: channelId,
+      },
+    });
+    await clearAllDetached();
+
+    expect(response.status).toBe(200);
+    const [run] = await db
+      .select({
+        id: agentRuns.id,
+        sessionId: agentRuns.sessionId,
+        continuedFromSessionId: agentRuns.continuedFromSessionId,
+        modelProvider: zeroRuns.modelProvider,
+        selectedModel: zeroRuns.selectedModel,
+      })
+      .from(agentRuns)
+      .innerJoin(zeroRuns, eq(zeroRuns.id, agentRuns.id))
+      .where(eq(agentRuns.prompt, prompt))
+      .limit(1);
+    expect(run).toMatchObject({
+      continuedFromSessionId: null,
+      modelProvider: "vm0",
+      selectedModel: "claude-sonnet-4-6",
+    });
+    expect(run?.sessionId).not.toBe(previousSessionId);
+  });
+
   it("routes Slack selected GPT models through the model policy provider", async () => {
     const fixture = await track(
       store.set(

--- a/turbo/apps/api/src/signals/services/integration-model-route.service.ts
+++ b/turbo/apps/api/src/signals/services/integration-model-route.service.ts
@@ -1,0 +1,56 @@
+import type { Getter, Setter } from "ccstate";
+import type { ModelProviderCredentialScope } from "@vm0/api-contracts/contracts/model-providers";
+
+import { listOrgModelPolicies$ } from "./zero-model-policy.service";
+import { userModelPreference } from "./zero-user-data.service";
+
+export interface IntegrationModelRoutePin {
+  readonly modelProviderType: string;
+  readonly modelProviderId: string | null;
+  readonly modelProviderCredentialScope: ModelProviderCredentialScope;
+  readonly selectedModel: string;
+}
+
+export async function resolveIntegrationModelRouteForUser(args: {
+  readonly get: Getter;
+  readonly set: Setter;
+  readonly orgId: string;
+  readonly userId: string;
+  readonly signal: AbortSignal;
+}): Promise<IntegrationModelRoutePin | undefined> {
+  const preference = await args.get(
+    userModelPreference({ orgId: args.orgId, userId: args.userId }),
+  );
+  args.signal.throwIfAborted();
+
+  const policies = await args.set(
+    listOrgModelPolicies$,
+    { orgId: args.orgId, userId: args.userId },
+    args.signal,
+  );
+
+  const preferredPolicy = preference.selectedModel
+    ? policies.policies.find((policy) => {
+        return policy.model === preference.selectedModel;
+      })
+    : undefined;
+  const defaultPolicy = policies.policies.find((policy) => {
+    return policy.id === policies.workspaceDefaultPolicyId;
+  });
+  const routePolicy =
+    preferredPolicy ??
+    defaultPolicy ??
+    policies.policies.find((policy) => {
+      return policy.isDefault;
+    });
+  if (!routePolicy || routePolicy.routeStatus !== "valid") {
+    return undefined;
+  }
+
+  return {
+    modelProviderType: routePolicy.defaultProviderType,
+    modelProviderId: routePolicy.modelProviderId,
+    modelProviderCredentialScope: routePolicy.credentialScope,
+    selectedModel: routePolicy.model,
+  };
+}

--- a/turbo/apps/api/src/signals/services/integration-session-model-compatibility.service.ts
+++ b/turbo/apps/api/src/signals/services/integration-session-model-compatibility.service.ts
@@ -1,0 +1,86 @@
+import {
+  MODEL_PROVIDER_TYPES,
+  areProvidersCompatible,
+  type ModelProviderType,
+} from "@vm0/api-contracts/contracts/model-providers";
+import { agentRuns } from "@vm0/db/schema/agent-run";
+import { zeroRuns } from "@vm0/db/schema/zero-run";
+import { desc, eq } from "drizzle-orm";
+
+import type { Db, ReadonlyDb } from "../external/db";
+
+interface IntegrationSessionModelSignature {
+  readonly modelProvider: string | null;
+  readonly selectedModel: string | null;
+}
+
+interface IntegrationRunModelRoute {
+  readonly modelProviderType: string | null | undefined;
+  readonly selectedModel: string | null | undefined;
+}
+
+function isKnownModelProvider(
+  value: string | null | undefined,
+): value is ModelProviderType {
+  return (
+    value !== null &&
+    value !== undefined &&
+    Object.hasOwn(MODEL_PROVIDER_TYPES, value)
+  );
+}
+
+function areIntegrationSessionModelsCompatible(
+  previous: IntegrationSessionModelSignature,
+  current: IntegrationRunModelRoute,
+): boolean {
+  if (
+    isKnownModelProvider(previous.modelProvider) &&
+    isKnownModelProvider(current.modelProviderType) &&
+    !areProvidersCompatible(previous.modelProvider, current.modelProviderType)
+  ) {
+    return false;
+  }
+
+  return !(
+    previous.selectedModel &&
+    current.selectedModel &&
+    previous.selectedModel !== current.selectedModel
+  );
+}
+
+async function latestIntegrationSessionModelSignature(
+  db: Db | ReadonlyDb,
+  sessionId: string,
+): Promise<IntegrationSessionModelSignature | null> {
+  const [previousRun] = await db
+    .select({
+      modelProvider: zeroRuns.modelProvider,
+      selectedModel: zeroRuns.selectedModel,
+    })
+    .from(agentRuns)
+    .innerJoin(zeroRuns, eq(zeroRuns.id, agentRuns.id))
+    .where(eq(agentRuns.sessionId, sessionId))
+    .orderBy(desc(agentRuns.createdAt))
+    .limit(1);
+
+  return previousRun ?? null;
+}
+
+export async function canReuseIntegrationSessionForModelRoute(args: {
+  readonly db: Db | ReadonlyDb;
+  readonly sessionId: string;
+  readonly modelRoute: IntegrationRunModelRoute | null | undefined;
+}): Promise<boolean> {
+  if (!args.modelRoute) {
+    return true;
+  }
+
+  const previous = await latestIntegrationSessionModelSignature(
+    args.db,
+    args.sessionId,
+  );
+  return (
+    !previous ||
+    areIntegrationSessionModelsCompatible(previous, args.modelRoute)
+  );
+}

--- a/turbo/apps/api/src/signals/services/zero-agentphone.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-agentphone.service.ts
@@ -15,7 +15,6 @@ import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { isFeatureEnabled } from "@vm0/core/feature-switch";
 import { agentComposes } from "@vm0/db/schema/agent-compose";
 import { agentSessions } from "@vm0/db/schema/agent-session";
-import { conversations } from "@vm0/db/schema/conversation";
 import { modelProviders } from "@vm0/db/schema/model-provider";
 import { orgMetadata } from "@vm0/db/schema/org-metadata";
 import { storages, storageVersions } from "@vm0/db/schema/storage";
@@ -39,6 +38,11 @@ import {
   sendAgentPhoneTypingIndicator,
 } from "../external/agentphone-client";
 import { safeUrlParse, settle } from "../utils";
+import { canReuseIntegrationSessionForModelRoute } from "./integration-session-model-compatibility.service";
+import {
+  resolveIntegrationModelRouteForUser,
+  type IntegrationModelRoutePin,
+} from "./integration-model-route.service";
 import { createZeroRun$ } from "./zero-runs-create.service";
 import { userFeatureSwitchOverrides } from "./feature-switches.service";
 import { computeContentHashFromHashes } from "./storage-content-hash.service";
@@ -113,12 +117,7 @@ interface RunAgentResult {
   readonly runId?: string;
 }
 
-interface ModelRoutePin {
-  readonly modelProviderType: string;
-  readonly modelProviderId: string | null;
-  readonly modelProviderCredentialScope: "org" | "member";
-  readonly selectedModel: string;
-}
+type ModelRoutePin = IntegrationModelRoutePin;
 
 type ComputedGetter = Getter;
 type ComputedSetter = Setter;
@@ -775,7 +774,7 @@ async function resolveCompatibleAgentPhoneThreadSession(args: {
   readonly userLinkId: string;
   readonly userId: string;
   readonly agentComposeId: string;
-  readonly selectedModelOverride?: string;
+  readonly modelRoute: ModelRoutePin | undefined;
 }): Promise<ThreadSessionLookup> {
   const session = await lookupAgentPhoneThreadSession(args.db, args.userLinkId);
   if (!session.existingSessionId) {
@@ -785,7 +784,6 @@ async function resolveCompatibleAgentPhoneThreadSession(args: {
   const [agentSession] = await args.db
     .select({
       agentComposeId: agentSessions.agentComposeId,
-      conversationId: agentSessions.conversationId,
     })
     .from(agentSessions)
     .where(
@@ -799,17 +797,13 @@ async function resolveCompatibleAgentPhoneThreadSession(args: {
     return { existingSessionId: undefined, lastProcessedMessageId: undefined };
   }
 
-  if (args.selectedModelOverride && agentSession.conversationId) {
-    const [previousRun] = await args.db
-      .select({ selectedModel: zeroRuns.selectedModel })
-      .from(conversations)
-      .innerJoin(zeroRuns, eq(zeroRuns.id, conversations.runId))
-      .where(eq(conversations.id, agentSession.conversationId))
-      .limit(1);
-    if (
-      previousRun?.selectedModel &&
-      previousRun.selectedModel !== args.selectedModelOverride
-    ) {
+  if (args.modelRoute) {
+    const canReuseSession = await canReuseIntegrationSessionForModelRoute({
+      db: args.db,
+      sessionId: session.existingSessionId,
+      modelRoute: args.modelRoute,
+    });
+    if (!canReuseSession) {
       return {
         existingSessionId: undefined,
         lastProcessedMessageId: undefined,
@@ -1514,33 +1508,6 @@ async function dispatchAgentPhoneCommand(args: {
   }
 }
 
-async function resolveModelRouteForUser(
-  get: ComputedGetter,
-  set: ComputedSetter,
-  orgId: string,
-  userId: string,
-  signal: AbortSignal,
-): Promise<ModelRoutePin | undefined> {
-  const selectedModel = (await get(userModelPreference({ orgId, userId })))
-    .selectedModel;
-  if (!selectedModel) {
-    return undefined;
-  }
-  const policies = await set(listOrgModelPolicies$, { orgId, userId }, signal);
-  const policy = policies.policies.find((candidate) => {
-    return candidate.model === selectedModel;
-  });
-  if (!policy) {
-    return undefined;
-  }
-  return {
-    modelProviderType: policy.defaultProviderType,
-    modelProviderId: policy.modelProviderId,
-    modelProviderCredentialScope: policy.credentialScope,
-    selectedModel: policy.model,
-  };
-}
-
 async function runAgentForAgentPhone(
   set: ComputedSetter,
   args: {
@@ -1721,13 +1688,13 @@ export const handleAgentPhoneMessage$ = command(
     await refreshTypingIfSupported(params.event, signal);
     signal.throwIfAborted();
 
-    const modelRoute = await resolveModelRouteForUser(
+    const modelRoute = await resolveIntegrationModelRouteForUser({
       get,
       set,
-      params.userLink.orgId,
-      params.userLink.vm0UserId,
+      orgId: params.userLink.orgId,
+      userId: params.userLink.vm0UserId,
       signal,
-    );
+    });
     signal.throwIfAborted();
 
     const session = await resolveCompatibleAgentPhoneThreadSession({
@@ -1735,7 +1702,7 @@ export const handleAgentPhoneMessage$ = command(
       userLinkId: params.userLink.id,
       userId: params.userLink.vm0UserId,
       agentComposeId: agent.composeId,
-      selectedModelOverride: modelRoute?.selectedModel,
+      modelRoute,
     });
     signal.throwIfAborted();
 

--- a/turbo/apps/api/src/signals/services/zero-slack-webhooks.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-slack-webhooks.service.ts
@@ -13,16 +13,13 @@ import {
 import { formatRunErrorForExternalSurface } from "@vm0/api-contracts/contracts/errors";
 import { slackOrgCallbackPayloadSchema } from "@vm0/api-contracts/contracts/internal-callbacks-slack-org";
 import { agentSessions } from "@vm0/db/schema/agent-session";
-import { conversations } from "@vm0/db/schema/conversation";
 import { orgMetadata } from "@vm0/db/schema/org-metadata";
-import { orgModelPolicies } from "@vm0/db/schema/org-model-policy";
 import { slackOrgConnections } from "@vm0/db/schema/slack-org-connection";
 import { slackOrgInstallations } from "@vm0/db/schema/slack-org-installation";
 import { slackOrgThreadSessions } from "@vm0/db/schema/slack-org-thread-session";
 import { slackUserAgentPreferences } from "@vm0/db/schema/slack-user-agent-preference";
 import { userCache } from "@vm0/db/schema/user-cache";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
-import { zeroRuns } from "@vm0/db/schema/zero-run";
 import { and, eq } from "drizzle-orm";
 import type { z } from "zod";
 
@@ -69,6 +66,11 @@ import { now, nowDate } from "../external/time";
 import { writeDb$, type Db } from "../external/db";
 import { userFeatureSwitchOverrides } from "./feature-switches.service";
 import { decryptSecretValue } from "./crypto.utils";
+import {
+  resolveIntegrationModelRouteForUser,
+  type IntegrationModelRoutePin,
+} from "./integration-model-route.service";
+import { canReuseIntegrationSessionForModelRoute } from "./integration-session-model-compatibility.service";
 import { zeroComposeList } from "./zero-compose-data.service";
 import { listOrgModelPolicies$ } from "./zero-model-policy.service";
 import {
@@ -219,13 +221,6 @@ interface RunAgentParams {
 }
 
 type SlackChannelType = "channel" | "dm" | "group_dm";
-
-interface SlackModelPin {
-  readonly modelProviderId: string | null;
-  readonly modelProviderType: string | null;
-  readonly modelProviderCredentialScope: ModelProviderCredentialScope | null;
-  readonly selectedModel: string | null;
-}
 
 interface SlackAgentMessageArgs {
   readonly get: ComputedGetter;
@@ -614,65 +609,6 @@ async function slackModelPickerState(
       };
     }),
     currentSelectedModel: preference.selectedModel,
-  };
-}
-
-function parseModelProviderCredentialScope(
-  value: string | null,
-): ModelProviderCredentialScope | null {
-  if (value === null || value === "org" || value === "member") {
-    return value;
-  }
-  throw new Error(`Unknown model provider credential scope "${value}"`);
-}
-
-async function resolveSlackSelectedModelPin(args: {
-  readonly db: Db;
-  readonly orgId: string;
-  readonly userId: string;
-  readonly selectedModel: string | null;
-}): Promise<SlackModelPin> {
-  if (!args.selectedModel) {
-    return {
-      modelProviderId: null,
-      modelProviderType: null,
-      modelProviderCredentialScope: null,
-      selectedModel: null,
-    };
-  }
-
-  const [policy] = await args.db
-    .select({
-      model: orgModelPolicies.model,
-      defaultProviderType: orgModelPolicies.defaultProviderType,
-      credentialScope: orgModelPolicies.credentialScope,
-      modelProviderId: orgModelPolicies.modelProviderId,
-    })
-    .from(orgModelPolicies)
-    .where(
-      and(
-        eq(orgModelPolicies.orgId, args.orgId),
-        eq(orgModelPolicies.model, args.selectedModel),
-      ),
-    )
-    .limit(1);
-
-  if (!policy) {
-    return {
-      modelProviderId: null,
-      modelProviderType: null,
-      modelProviderCredentialScope: null,
-      selectedModel: args.selectedModel,
-    };
-  }
-
-  return {
-    modelProviderId: policy.modelProviderId ?? null,
-    modelProviderType: policy.defaultProviderType,
-    modelProviderCredentialScope: parseModelProviderCredentialScope(
-      policy.credentialScope,
-    ),
-    selectedModel: policy.model,
   };
 }
 
@@ -1109,7 +1045,7 @@ async function resolveCompatibleThreadSession(args: {
   readonly connectionId: string;
   readonly userId: string;
   readonly agentComposeId: string;
-  readonly selectedModelOverride?: string;
+  readonly modelRoute: IntegrationModelRoutePin | undefined;
 }): Promise<string | undefined> {
   const [session] = await args.db
     .select({
@@ -1130,7 +1066,6 @@ async function resolveCompatibleThreadSession(args: {
   const [agentSession] = await args.db
     .select({
       agentComposeId: agentSessions.agentComposeId,
-      conversationId: agentSessions.conversationId,
     })
     .from(agentSessions)
     .where(
@@ -1144,17 +1079,13 @@ async function resolveCompatibleThreadSession(args: {
     return undefined;
   }
 
-  if (args.selectedModelOverride && agentSession.conversationId) {
-    const [previousRun] = await args.db
-      .select({ selectedModel: zeroRuns.selectedModel })
-      .from(conversations)
-      .innerJoin(zeroRuns, eq(zeroRuns.id, conversations.runId))
-      .where(eq(conversations.id, agentSession.conversationId))
-      .limit(1);
-    if (
-      previousRun?.selectedModel &&
-      previousRun.selectedModel !== args.selectedModelOverride
-    ) {
+  if (args.modelRoute) {
+    const canReuseSession = await canReuseIntegrationSessionForModelRoute({
+      db: args.db,
+      sessionId: session.agentSessionId,
+      modelRoute: args.modelRoute,
+    });
+    if (!canReuseSession) {
       return undefined;
     }
   }
@@ -1323,19 +1254,12 @@ async function buildRunAgentParams(
     client: resolved.client,
     userId: args.slackUserId,
   });
-  const selectedModelOverride = (
-    await args.get(
-      userModelPreference({
-        orgId: resolved.installation.orgId,
-        userId: resolved.connection.vm0UserId,
-      }),
-    )
-  ).selectedModel;
-  const modelPin = await resolveSlackSelectedModelPin({
-    db: args.db,
+  const modelRoute = await resolveIntegrationModelRouteForUser({
+    get: args.get,
+    set: args.set,
     orgId: resolved.installation.orgId,
     userId: resolved.connection.vm0UserId,
-    selectedModel: selectedModelOverride,
+    signal: args.signal,
   });
   const existingSessionId = await resolveCompatibleThreadSession({
     db: args.db,
@@ -1344,7 +1268,7 @@ async function buildRunAgentParams(
     connectionId: resolved.connection.id,
     userId: resolved.connection.vm0UserId,
     agentComposeId: resolved.composeId,
-    selectedModelOverride: modelPin.selectedModel ?? undefined,
+    modelRoute,
   });
   const { executionContext } = await fetchConversationContexts(
     resolved.client,
@@ -1377,11 +1301,11 @@ async function buildRunAgentParams(
     threadTs: resolved.threadTs,
     callbackContext,
     apiStartTime: args.apiStartTime,
-    modelProviderId: modelPin.modelProviderId ?? undefined,
+    modelProviderId: modelRoute?.modelProviderId ?? undefined,
     modelProviderCredentialScope:
-      modelPin.modelProviderCredentialScope ?? undefined,
-    modelProviderType: modelPin.modelProviderType ?? undefined,
-    selectedModelOverride: modelPin.selectedModel ?? undefined,
+      modelRoute?.modelProviderCredentialScope ?? undefined,
+    modelProviderType: modelRoute?.modelProviderType ?? undefined,
+    selectedModelOverride: modelRoute?.selectedModel ?? undefined,
   };
 }
 

--- a/turbo/apps/api/src/signals/services/zero-telegram-post.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-telegram-post.service.ts
@@ -14,7 +14,6 @@ import {
   zeroIntegrationsTelegramContract,
 } from "@vm0/api-contracts/contracts/zero-integrations-telegram";
 import { agentComposes } from "@vm0/db/schema/agent-compose";
-import { agentRuns } from "@vm0/db/schema/agent-run";
 import { agentSessions } from "@vm0/db/schema/agent-session";
 import { orgMetadata } from "@vm0/db/schema/org-metadata";
 import {
@@ -27,7 +26,6 @@ import { telegramThreadSessions } from "@vm0/db/schema/telegram-thread-session";
 import { telegramUserAgentPreferences } from "@vm0/db/schema/telegram-user-agent-preference";
 import { telegramUserLinks } from "@vm0/db/schema/telegram-user-link";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
-import { zeroRuns } from "@vm0/db/schema/zero-run";
 import { and, desc, eq } from "drizzle-orm";
 
 import {
@@ -58,6 +56,11 @@ import {
 import { now, nowDate } from "../external/time";
 import { safeUrlParse, settle, tapError } from "../utils";
 import { encryptSecretValue, decryptSecretValue } from "./crypto.utils";
+import {
+  resolveIntegrationModelRouteForUser,
+  type IntegrationModelRoutePin,
+} from "./integration-model-route.service";
+import { canReuseIntegrationSessionForModelRoute } from "./integration-session-model-compatibility.service";
 import { listOrgModelPolicies$ } from "./zero-model-policy.service";
 import { createZeroRun$ } from "./zero-runs-create.service";
 import { telegramIntegrationBotStatus } from "./zero-telegram-data.service";
@@ -233,12 +236,7 @@ interface RunAgentParams {
   readonly modelRoute: ModelRoutePin | undefined;
 }
 
-interface ModelRoutePin {
-  readonly modelProviderType: string;
-  readonly modelProviderId: string | null;
-  readonly modelProviderCredentialScope: "org" | "member";
-  readonly selectedModel: string;
-}
+type ModelRoutePin = IntegrationModelRoutePin;
 
 interface TelegramCallbackPayload {
   readonly installationId: string;
@@ -1449,7 +1447,7 @@ async function lookupTelegramThreadSession(args: {
   readonly userLinkKind: "custom" | "official";
   readonly userId: string;
   readonly composeId: string;
-  readonly selectedModel: string | undefined;
+  readonly modelRoute: ModelRoutePin | undefined;
 }): Promise<{
   readonly existingSessionId: string | undefined;
   readonly lastProcessedMessageId: string | undefined;
@@ -1492,18 +1490,13 @@ async function lookupTelegramThreadSession(args: {
     return { existingSessionId: undefined, lastProcessedMessageId: undefined };
   }
 
-  if (args.selectedModel) {
-    const [previousRun] = await args.db
-      .select({ selectedModel: zeroRuns.selectedModel })
-      .from(agentRuns)
-      .innerJoin(zeroRuns, eq(zeroRuns.id, agentRuns.id))
-      .where(eq(agentRuns.sessionId, thread.agentSessionId))
-      .orderBy(desc(agentRuns.createdAt))
-      .limit(1);
-    if (
-      previousRun?.selectedModel &&
-      previousRun.selectedModel !== args.selectedModel
-    ) {
+  if (args.modelRoute) {
+    const canReuseSession = await canReuseIntegrationSessionForModelRoute({
+      db: args.db,
+      sessionId: thread.agentSessionId,
+      modelRoute: args.modelRoute,
+    });
+    if (!canReuseSession) {
       return {
         existingSessionId: undefined,
         lastProcessedMessageId: undefined,
@@ -1698,33 +1691,6 @@ function buildTelegramPrompt(
   return [headerParts.join("\n"), threadContext].filter(Boolean).join("\n\n");
 }
 
-async function resolveModelRouteForUser(
-  get: ComputedGetter,
-  set: ComputedSetter,
-  orgId: string,
-  userId: string,
-  signal: AbortSignal,
-): Promise<ModelRoutePin | undefined> {
-  const selectedModel = (await get(userModelPreference({ orgId, userId })))
-    .selectedModel;
-  if (!selectedModel) {
-    return undefined;
-  }
-  const policies = await set(listOrgModelPolicies$, { orgId, userId }, signal);
-  const policy = policies.policies.find((candidate) => {
-    return candidate.model === selectedModel;
-  });
-  if (!policy) {
-    return undefined;
-  }
-  return {
-    modelProviderType: policy.defaultProviderType,
-    modelProviderId: policy.modelProviderId,
-    modelProviderCredentialScope: policy.credentialScope,
-    selectedModel: policy.model,
-  };
-}
-
 async function runAgentForTelegram(
   set: ComputedSetter,
   args: RunAgentParams,
@@ -1830,7 +1796,7 @@ async function lookupAgentThreadSession(args: {
   readonly userLinkKind: "custom" | "official";
   readonly userId: string;
   readonly composeId: string;
-  readonly selectedModel: string | undefined;
+  readonly modelRoute: ModelRoutePin | undefined;
 }): Promise<TelegramThreadLookupResult> {
   if (args.rootMessageId === undefined) {
     return { existingSessionId: undefined, lastProcessedMessageId: undefined };
@@ -1843,7 +1809,7 @@ async function lookupAgentThreadSession(args: {
     userLinkKind: args.userLinkKind,
     userId: args.userId,
     composeId: args.composeId,
-    selectedModel: args.selectedModel,
+    modelRoute: args.modelRoute,
   });
 }
 
@@ -1971,13 +1937,13 @@ async function handleTelegramAgentMessage(args: {
   args.signal.throwIfAborted();
 
   const rootMessageId = rootMessageIdForAgentMessage(args);
-  const modelRoute = await resolveModelRouteForUser(
-    args.get,
-    args.set,
-    args.orgId,
-    args.userLink.vm0UserId,
-    args.signal,
-  );
+  const modelRoute = await resolveIntegrationModelRouteForUser({
+    get: args.get,
+    set: args.set,
+    orgId: args.orgId,
+    userId: args.userLink.vm0UserId,
+    signal: args.signal,
+  });
   args.signal.throwIfAborted();
   const session = await lookupAgentThreadSession({
     db: args.db,
@@ -1987,7 +1953,7 @@ async function handleTelegramAgentMessage(args: {
     userLinkKind: args.userLinkKind,
     userId: args.userLink.vm0UserId,
     composeId: args.composeId,
-    selectedModel: modelRoute?.selectedModel,
+    modelRoute,
   });
   args.signal.throwIfAborted();
 

--- a/turbo/apps/web/app/api/zero/slack/events/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/slack/events/__tests__/route.test.ts
@@ -13,6 +13,7 @@ import {
   findTestZeroRun,
   insertOrgModelPolicy,
   insertUserModelPreference,
+  insertVm0ApiKeys,
   setOrgCredits,
   setTestRunModelProvider,
   setTestRunSelectedModel,
@@ -839,6 +840,187 @@ describe("POST /api/zero/slack/events", () => {
         }),
       );
       expect(callbacks[0]?.payload).not.toHaveProperty("existingSessionId");
+    });
+
+    it("starts a new thread session when the selected model provider changed", async () => {
+      mockIsFeatureEnabled.mockReturnValue(true);
+      await setOrgCredits(user.orgId, 100_000);
+
+      const workspaceId = uniqueId("T-ws");
+      const slackUserId = uniqueId("U-slack");
+      const channelId = uniqueId("D-provider");
+      const threadTs = "2401.001";
+      const { composeId, agentId } = await createTestCompose(uniqueId("agent"));
+      await updateOrgDefaultAgent(user.orgId, agentId);
+      await insertVm0ApiKeys([
+        {
+          vendor: "anthropic",
+          model: "claude-sonnet-4-6",
+          apiKey: "vm0-key-claude-sonnet-4-6",
+        },
+      ]);
+      await insertOrgModelPolicy({
+        orgId: user.orgId,
+        model: "claude-sonnet-4-6",
+        isDefault: true,
+        defaultProviderType: "vm0",
+      });
+      await insertUserModelPreference({
+        orgId: user.orgId,
+        userId: user.userId,
+        model: "claude-sonnet-4-6",
+      });
+      await createTestSlackOrgInstallation({
+        workspaceId,
+        orgId: user.orgId,
+      });
+      const { connectionId } = await seedTestSlackOrgConnection({
+        slackUserId,
+        slackWorkspaceId: workspaceId,
+        vm0UserId: user.userId,
+      });
+
+      const previous = await seedTestRun(user.userId, composeId, {
+        prompt: "previous slack provider session",
+        triggerSource: "slack",
+      });
+      const { agentSessionId } = await completeTestRun(
+        user.userId,
+        previous.runId,
+      );
+      await setTestRunModelProvider(previous.runId, "openrouter-api-key");
+      await setTestRunSelectedModel(previous.runId, "claude-sonnet-4-6");
+      await insertTestSlackOrgThreadSession({
+        connectionId,
+        agentSessionId,
+        slackChannelId: channelId,
+        slackThreadTs: threadTs,
+      });
+
+      const prompt = `provider changed ${uniqueId("slack")}`;
+      const request = createSlackEventRequest({
+        type: "event_callback",
+        team_id: workspaceId,
+        event: {
+          type: "message",
+          channel_type: "im",
+          user: slackUserId,
+          text: prompt,
+          ts: "2401.002",
+          thread_ts: threadTs,
+          channel: channelId,
+          event_ts: "2401.002",
+        },
+        event_id: uniqueId("evt"),
+        event_time: Date.now(),
+      });
+
+      const response = await POST(request);
+      expect(response.status).toBe(200);
+      await context.mocks.flushAfter();
+
+      const runs = await findTestRunsByUserAndPromptContaining(
+        user.userId,
+        prompt,
+      );
+      expect(runs).toHaveLength(1);
+      expect(runs[0]?.continuedFromSessionId).toBeNull();
+      expect(runs[0]?.sessionId).not.toBe(agentSessionId);
+      await expect(findTestZeroRun(runs[0]!.id)).resolves.toEqual(
+        expect.objectContaining({
+          modelProvider: "vm0",
+          selectedModel: "claude-sonnet-4-6",
+          triggerSource: "slack",
+        }),
+      );
+    });
+
+    it("starts a new thread session when the default model provider changed", async () => {
+      mockIsFeatureEnabled.mockReturnValue(true);
+      await setOrgCredits(user.orgId, 100_000);
+
+      const workspaceId = uniqueId("T-ws");
+      const slackUserId = uniqueId("U-slack");
+      const channelId = uniqueId("D-default-provider");
+      const threadTs = "2402.001";
+      const { composeId, agentId } = await createTestCompose(uniqueId("agent"));
+      await updateOrgDefaultAgent(user.orgId, agentId);
+      await insertVm0ApiKeys([
+        {
+          vendor: "anthropic",
+          model: "claude-sonnet-4-6",
+          apiKey: "vm0-key-default-claude-sonnet-4-6",
+        },
+      ]);
+      await insertOrgModelPolicy({
+        orgId: user.orgId,
+        model: "claude-sonnet-4-6",
+        isDefault: true,
+        defaultProviderType: "vm0",
+      });
+      await createTestSlackOrgInstallation({
+        workspaceId,
+        orgId: user.orgId,
+      });
+      const { connectionId } = await seedTestSlackOrgConnection({
+        slackUserId,
+        slackWorkspaceId: workspaceId,
+        vm0UserId: user.userId,
+      });
+
+      const previous = await seedTestRun(user.userId, composeId, {
+        prompt: "previous slack default provider session",
+        triggerSource: "slack",
+      });
+      const { agentSessionId } = await completeTestRun(
+        user.userId,
+        previous.runId,
+      );
+      await setTestRunModelProvider(previous.runId, "openrouter-api-key");
+      await setTestRunSelectedModel(previous.runId, "claude-sonnet-4-6");
+      await insertTestSlackOrgThreadSession({
+        connectionId,
+        agentSessionId,
+        slackChannelId: channelId,
+        slackThreadTs: threadTs,
+      });
+
+      const prompt = `default provider changed ${uniqueId("slack")}`;
+      const request = createSlackEventRequest({
+        type: "event_callback",
+        team_id: workspaceId,
+        event: {
+          type: "message",
+          channel_type: "im",
+          user: slackUserId,
+          text: prompt,
+          ts: "2402.002",
+          thread_ts: threadTs,
+          channel: channelId,
+          event_ts: "2402.002",
+        },
+        event_id: uniqueId("evt"),
+        event_time: Date.now(),
+      });
+
+      const response = await POST(request);
+      expect(response.status).toBe(200);
+      await context.mocks.flushAfter();
+
+      const runs = await findTestRunsByUserAndPromptContaining(
+        user.userId,
+        prompt,
+      );
+      expect(runs).toHaveLength(1);
+      expect(runs[0]?.continuedFromSessionId).toBeNull();
+      expect(runs[0]?.sessionId).not.toBe(agentSessionId);
+      await expect(findTestZeroRun(runs[0]!.id)).resolves.toEqual(
+        expect.objectContaining({
+          modelProvider: "vm0",
+          selectedModel: "claude-sonnet-4-6",
+          triggerSource: "slack",
+        }),
+      );
     });
   });
 


### PR DESCRIPTION
## Summary
- Add shared API-side integration model route resolution from user preference or workspace default policy, plus provider/model compatibility checks before reusing an integration session.
- Route Telegram, Slack, and AgentPhone API runs through the same model route used for reuse decisions, so provider or model changes start a new session instead of continuing the old one.
- Add API coverage for selected-provider and default-provider changes across Telegram, Slack, and AgentPhone; add web Slack coverage for the same provider-change cases. Web only has the Slack run webhook for this path; Telegram and AgentPhone run webhooks are API-side.

## Tests
- `pnpm -F api exec vitest src/signals/routes/__tests__/zero-integrations-telegram-post.test.ts --run`
- `pnpm -F api exec vitest src/signals/routes/__tests__/zero-slack-events.test.ts --run`
- `pnpm -F api exec vitest src/signals/routes/__tests__/zero-integrations-agentphone-routes.test.ts --run`
- `pnpm -F web exec vitest app/api/zero/slack/events/__tests__/route.test.ts --run`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F web lint`
- `pnpm -F web check-types`
- `pnpm knip --workspace api`
- `pnpm knip --workspace web`
- `pnpm exec prettier --check apps/api/src/signals/services/integration-model-route.service.ts apps/api/src/signals/services/integration-session-model-compatibility.service.ts apps/api/src/signals/services/zero-telegram-post.service.ts apps/api/src/signals/services/zero-agentphone.service.ts apps/api/src/signals/services/zero-slack-webhooks.service.ts apps/api/src/signals/routes/__tests__/helpers/zero-slack-webhooks.ts apps/api/src/signals/routes/__tests__/zero-slack-events.test.ts apps/api/src/signals/routes/__tests__/zero-integrations-agentphone-routes.test.ts apps/api/src/signals/routes/__tests__/zero-integrations-telegram-post.test.ts apps/web/app/api/zero/slack/events/__tests__/route.test.ts`

## Notes
- The amend pre-commit hook also passed changed-file prettier, `pnpm knip --cache`, and full `pnpm check-types`.
- I did not rerun the full API suite after the latest amend. Earlier, `pnpm -F api test` had one full-suite-only local failure in `cron-drain-email-outbox`; that test passed standalone after migrations.