### PR TITLE
fix: preserve Claude failure diagnostics

### DIFF
--- a/crates/agent-diagnostics/src/lib.rs
+++ b/crates/agent-diagnostics/src/lib.rs
@@ -17,6 +17,8 @@ pub struct FailureDiagnostic {
     pub framework: AgentFramework,
     pub cli_exit_code: Option<i32>,
     pub claude_num_turns: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub failure_detail_source: Option<FailureDetailSource>,
     pub session_history_status: SessionHistoryStatus,
     pub prompt_shape: PromptShape,
     pub prompt_bytes: u64,
@@ -36,6 +38,7 @@ impl FailureDiagnostic {
             framework,
             cli_exit_code: None,
             claude_num_turns: None,
+            failure_detail_source: None,
             session_history_status: SessionHistoryStatus::Unknown,
             prompt_shape: prompt.prompt_shape,
             prompt_bytes: prompt.prompt_bytes,
@@ -52,6 +55,15 @@ impl FailureDiagnostic {
     #[must_use]
     pub fn with_claude_num_turns(mut self, claude_num_turns: Option<u64>) -> Self {
         self.claude_num_turns = claude_num_turns;
+        self
+    }
+
+    #[must_use]
+    pub fn with_failure_detail_source(
+        mut self,
+        failure_detail_source: FailureDetailSource,
+    ) -> Self {
+        self.failure_detail_source = Some(failure_detail_source);
         self
     }
 
@@ -86,6 +98,27 @@ impl FailureClass {
             Self::ClaudeZeroTurnNoHistory => "claude_zero_turn_no_history",
             Self::EventUploadFailed => "event_upload_failed",
             Self::CheckpointFailed => "checkpoint_failed",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FailureDetailSource {
+    ClaudeResult,
+    CodexJsonl,
+    Stderr,
+    FallbackExitCode,
+}
+
+impl FailureDetailSource {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::ClaudeResult => "claude_result",
+            Self::CodexJsonl => "codex_jsonl",
+            Self::Stderr => "stderr",
+            Self::FallbackExitCode => "fallback_exit_code",
         }
     }
 }
@@ -217,6 +250,7 @@ mod tests {
         assert_eq!(json["framework"], "claude_code");
         assert_eq!(json["cliExitCode"], 0);
         assert_eq!(json["claudeNumTurns"], 0);
+        assert_eq!(json.get("failureDetailSource"), None);
         assert_eq!(json["sessionHistoryStatus"], "missing");
         assert_eq!(json["promptShape"], "slash_like");
         assert_eq!(json["promptBytes"], 5);
@@ -224,6 +258,42 @@ mod tests {
 
         let round_trip: FailureDiagnostic = serde_json::from_value(json).unwrap();
         assert_eq!(round_trip, diagnostic);
+    }
+
+    #[test]
+    fn failure_diagnostic_serializes_optional_detail_source() {
+        let diagnostic = FailureDiagnostic::new(
+            FailureClass::CliNonzero,
+            AgentFramework::ClaudeCode,
+            PromptMetadata::from_prompt("debug failure"),
+        )
+        .with_cli_exit_code(1)
+        .with_failure_detail_source(FailureDetailSource::ClaudeResult);
+
+        let json = serde_json::to_value(&diagnostic).unwrap();
+        assert_eq!(json["failureDetailSource"], "claude_result");
+
+        let round_trip: FailureDiagnostic = serde_json::from_value(json).unwrap();
+        assert_eq!(round_trip, diagnostic);
+    }
+
+    #[test]
+    fn failure_diagnostic_deserializes_without_optional_detail_source() {
+        let json = serde_json::json!({
+            "schemaVersion": 1,
+            "failureClass": "cli_nonzero",
+            "framework": "claude_code",
+            "cliExitCode": 1,
+            "claudeNumTurns": 1,
+            "sessionHistoryStatus": "present",
+            "promptShape": "plain",
+            "promptBytes": 13,
+            "firstLineBytes": 13
+        });
+
+        let diagnostic: FailureDiagnostic = serde_json::from_value(json).unwrap();
+
+        assert_eq!(diagnostic.failure_detail_source, None);
     }
 
     #[test]

--- a/crates/agent-diagnostics/src/lib.rs
+++ b/crates/agent-diagnostics/src/lib.rs
@@ -17,7 +17,6 @@ pub struct FailureDiagnostic {
     pub framework: AgentFramework,
     pub cli_exit_code: Option<i32>,
     pub claude_num_turns: Option<u64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub failure_detail_source: Option<FailureDetailSource>,
     pub session_history_status: SessionHistoryStatus,
     pub prompt_shape: PromptShape,
@@ -250,7 +249,7 @@ mod tests {
         assert_eq!(json["framework"], "claude_code");
         assert_eq!(json["cliExitCode"], 0);
         assert_eq!(json["claudeNumTurns"], 0);
-        assert_eq!(json.get("failureDetailSource"), None);
+        assert_eq!(json["failureDetailSource"], serde_json::Value::Null);
         assert_eq!(json["sessionHistoryStatus"], "missing");
         assert_eq!(json["promptShape"], "slash_like");
         assert_eq!(json["promptBytes"], 5);

--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -290,8 +290,7 @@ pub async fn execute_cli(
                                 if let Some(diagnostic) =
                                     events::masked_claude_failure_diagnostic(&event, masker)
                                 {
-                                    let subtype =
-                                        diagnostic.subtype.as_deref().unwrap_or("unknown");
+                                    let subtype = diagnostic.subtype.unwrap_or("unknown");
                                     let candidate = CliFailureDiagnostic {
                                         message: diagnostic.message,
                                         source: FailureDetailSource::ClaudeResult,

--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -34,6 +34,7 @@ use crate::http::HttpClient;
 use crate::masker::SecretMasker;
 use crate::paths;
 use crate::timing;
+use agent_diagnostics::FailureDetailSource;
 use event_delivery::{AckedEventPrefix, PreparedEvent};
 use framework::CliFrameworkBehavior;
 use guest_common::telemetry::record_sandbox_op;
@@ -53,6 +54,13 @@ async fn tick_optional_interval(interval: &mut Option<tokio::time::Interval>) {
         }
         None => std::future::pending::<()>().await,
     }
+}
+
+/// Bounded terminal failure detail extracted from CLI stdout JSONL.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CliFailureDiagnostic {
+    pub message: String,
+    pub source: FailureDetailSource,
 }
 
 /// Result returned after the configured CLI process exits.
@@ -94,10 +102,10 @@ pub struct CliExecutionResult {
     /// Best-effort, secret-masked terminal failure diagnostic parsed from CLI
     /// stdout JSONL.
     ///
-    /// Codex reports terminal failures as JSONL events on stdout, not stderr.
-    /// Keeping the diagnostic here lets the guest-agent surface the actual
-    /// failure reason in its final run error.
-    pub failure_diagnostic: Option<String>,
+    /// Some frameworks report terminal failures as JSONL events on stdout, not
+    /// stderr. Keeping the diagnostic here lets the guest-agent surface the
+    /// actual failure reason in its final run error.
+    pub failure_diagnostic: Option<CliFailureDiagnostic>,
 }
 
 /// Execute the CLI process, streaming JSONL events and racing against heartbeat.
@@ -279,6 +287,22 @@ pub async fn execute_cli(
                             // Print Claude Code final result to stdout if applicable.
                             if behavior.handles_claude_result_event(&event) {
                                 claude_result = Some(ClaudeResultSummary::from_event(&event));
+                                if let Some(diagnostic) =
+                                    events::masked_claude_failure_diagnostic(&event, masker)
+                                {
+                                    let subtype =
+                                        diagnostic.subtype.as_deref().unwrap_or("unknown");
+                                    let candidate = CliFailureDiagnostic {
+                                        message: diagnostic.message,
+                                        source: FailureDetailSource::ClaudeResult,
+                                    };
+                                    log_warn!(
+                                        LOG_TAG,
+                                        "Claude JSONL failure result seq={seq} subtype={subtype}: {}",
+                                        candidate.message
+                                    );
+                                    failure_diagnostic = Some(candidate);
+                                }
                                 if let Some(result) = event.get("result").and_then(|v| v.as_str())
                                 {
                                     println!("{result}");
@@ -303,18 +327,21 @@ pub async fn execute_cli(
                                 && let Some(diagnostic) =
                                     events::masked_codex_failure_diagnostic(&event, masker)
                             {
-                                let message = diagnostic.message;
+                                let candidate = CliFailureDiagnostic {
+                                    message: diagnostic.message,
+                                    source: FailureDetailSource::CodexJsonl,
+                                };
                                 log_warn!(
                                     LOG_TAG,
                                     "Codex JSONL failure event seq={seq} type={}: {}",
                                     diagnostic.event_type,
-                                    message
+                                    candidate.message
                                 );
                                 if should_replace_failure_diagnostic(
-                                    failure_diagnostic.as_deref(),
-                                    &message,
+                                    failure_diagnostic.as_ref(),
+                                    &candidate,
                                 ) {
-                                    failure_diagnostic = Some(message);
+                                    failure_diagnostic = Some(candidate);
                                 }
                             }
                             // Capture checkpoint metadata before event payload preparation
@@ -623,33 +650,54 @@ pub async fn execute_cli(
     })
 }
 
-fn should_replace_failure_diagnostic(existing: Option<&str>, candidate: &str) -> bool {
+fn should_replace_failure_diagnostic(
+    existing: Option<&CliFailureDiagnostic>,
+    candidate: &CliFailureDiagnostic,
+) -> bool {
+    if candidate.source != FailureDetailSource::CodexJsonl {
+        return true;
+    }
+
     match existing {
         None => true,
         Some(existing) => {
-            !events::is_generic_codex_failure_diagnostic(candidate)
-                || events::is_generic_codex_failure_diagnostic(existing)
+            !events::is_generic_codex_failure_diagnostic(&candidate.message)
+                || (existing.source == FailureDetailSource::CodexJsonl
+                    && events::is_generic_codex_failure_diagnostic(&existing.message))
         }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::should_replace_failure_diagnostic;
+    use super::{CliFailureDiagnostic, should_replace_failure_diagnostic};
+    use agent_diagnostics::FailureDetailSource;
 
     #[test]
     fn specific_codex_failure_diagnostic_survives_later_generic_event() {
         assert!(!should_replace_failure_diagnostic(
-            Some("You've hit your usage limit."),
-            "turn failed",
+            Some(&CliFailureDiagnostic {
+                message: "You've hit your usage limit.".to_string(),
+                source: FailureDetailSource::CodexJsonl,
+            }),
+            &CliFailureDiagnostic {
+                message: "turn failed".to_string(),
+                source: FailureDetailSource::CodexJsonl,
+            },
         ));
     }
 
     #[test]
     fn specific_codex_failure_diagnostic_replaces_generic_event() {
         assert!(should_replace_failure_diagnostic(
-            Some("error"),
-            "You've hit your usage limit.",
+            Some(&CliFailureDiagnostic {
+                message: "error".to_string(),
+                source: FailureDetailSource::CodexJsonl,
+            }),
+            &CliFailureDiagnostic {
+                message: "You've hit your usage limit.".to_string(),
+                source: FailureDetailSource::CodexJsonl,
+            },
         ));
     }
 }

--- a/crates/guest-agent/src/events.rs
+++ b/crates/guest-agent/src/events.rs
@@ -26,7 +26,7 @@ pub(crate) struct CodexFailureDiagnostic {
 
 #[derive(Debug, PartialEq, Eq)]
 pub(crate) struct ClaudeFailureDiagnostic {
-    pub subtype: Option<String>,
+    pub subtype: Option<&'static str>,
     pub message: String,
 }
 
@@ -145,12 +145,13 @@ fn extract_claude_failure_diagnostic(event: &Value) -> Option<ClaudeFailureDiagn
         return None;
     }
 
-    let subtype = event
-        .get("subtype")
-        .and_then(Value::as_str)
-        .map(ToOwned::to_owned);
+    let raw_subtype = event.get("subtype").and_then(Value::as_str);
+    let subtype = match raw_subtype {
+        Some("error") => Some("error"),
+        _ => None,
+    };
     let is_failure = event.get("is_error").and_then(Value::as_bool) == Some(true)
-        || subtype.as_deref() == Some("error");
+        || raw_subtype == Some("error");
     if !is_failure {
         return None;
     }
@@ -723,7 +724,7 @@ mod tests {
         assert_eq!(
             masked_claude_failure_diagnostic(&event, &SecretMasker::from_raw("")),
             Some(ClaudeFailureDiagnostic {
-                subtype: Some("error".to_string()),
+                subtype: Some("error"),
                 message: "permission denied while running command".to_string(),
             })
         );
@@ -740,7 +741,25 @@ mod tests {
         assert_eq!(
             masked_claude_failure_diagnostic(&event, &SecretMasker::from_raw("")),
             Some(ClaudeFailureDiagnostic {
-                subtype: Some("error".to_string()),
+                subtype: Some("error"),
+                message: "terminal result failed".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn claude_failure_diagnostic_drops_unrecognized_subtype() {
+        let event = serde_json::json!({
+            "type": "result",
+            "subtype": "secret\nsubtype",
+            "is_error": true,
+            "result": "terminal result failed"
+        });
+
+        assert_eq!(
+            masked_claude_failure_diagnostic(&event, &SecretMasker::from_raw("")),
+            Some(ClaudeFailureDiagnostic {
+                subtype: None,
                 message: "terminal result failed".to_string(),
             })
         );

--- a/crates/guest-agent/src/events.rs
+++ b/crates/guest-agent/src/events.rs
@@ -15,12 +15,18 @@ use guest_common::{log_error, log_info};
 use serde_json::{Value, json};
 
 const LOG_TAG: &str = "sandbox:guest-agent";
-const CODEX_FAILURE_DIAGNOSTIC_MAX_BYTES: usize = 4096;
-const CODEX_FAILURE_DIAGNOSTIC_TRUNCATED_SUFFIX: &str = "...[truncated]";
+const FAILURE_DIAGNOSTIC_MAX_BYTES: usize = 4096;
+const FAILURE_DIAGNOSTIC_TRUNCATED_SUFFIX: &str = "...[truncated]";
 
 #[derive(Debug, PartialEq, Eq)]
 pub(crate) struct CodexFailureDiagnostic {
     pub event_type: &'static str,
+    pub message: String,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct ClaudeFailureDiagnostic {
+    pub subtype: Option<String>,
     pub message: String,
 }
 
@@ -87,6 +93,22 @@ pub(crate) fn masked_codex_failure_diagnostic(
     })
 }
 
+/// Extract a secret-masked Claude Code terminal failure diagnostic.
+///
+/// Claude Code reports the terminal run outcome as `type=result`. On failure,
+/// the `result` field carries the concise terminal reason that is otherwise
+/// lost when stderr is empty.
+pub(crate) fn masked_claude_failure_diagnostic(
+    event: &Value,
+    masker: &SecretMasker,
+) -> Option<ClaudeFailureDiagnostic> {
+    let diagnostic = extract_claude_failure_diagnostic(event)?;
+    Some(ClaudeFailureDiagnostic {
+        subtype: diagnostic.subtype,
+        message: mask_and_truncate_diagnostic(&diagnostic.message, masker),
+    })
+}
+
 pub(crate) fn is_generic_codex_failure_diagnostic(message: &str) -> bool {
     matches!(message.trim(), "error" | "turn failed" | "turn interrupted")
 }
@@ -116,6 +138,27 @@ fn extract_codex_failure_diagnostic(event: &Value) -> Option<CodexFailureDiagnos
         }
         _ => None,
     }
+}
+
+fn extract_claude_failure_diagnostic(event: &Value) -> Option<ClaudeFailureDiagnostic> {
+    if event.get("type").and_then(Value::as_str)? != "result" {
+        return None;
+    }
+
+    let subtype = event
+        .get("subtype")
+        .and_then(Value::as_str)
+        .map(ToOwned::to_owned);
+    let is_failure = event.get("is_error").and_then(Value::as_bool) == Some(true)
+        || subtype.as_deref() == Some("error");
+    if !is_failure {
+        return None;
+    }
+
+    Some(ClaudeFailureDiagnostic {
+        subtype,
+        message: raw_message_from_field(event.get("result"))?,
+    })
 }
 
 fn codex_turn_completed_failure_status(event: &Value) -> Option<&'static str> {
@@ -175,20 +218,15 @@ fn escape_log_line_breaks(message: &str) -> String {
 }
 
 fn truncate_diagnostic_message(message: &str) -> String {
-    if message.len() <= CODEX_FAILURE_DIAGNOSTIC_MAX_BYTES {
+    if message.len() <= FAILURE_DIAGNOSTIC_MAX_BYTES {
         return message.to_string();
     }
 
-    let mut end =
-        CODEX_FAILURE_DIAGNOSTIC_MAX_BYTES - CODEX_FAILURE_DIAGNOSTIC_TRUNCATED_SUFFIX.len();
+    let mut end = FAILURE_DIAGNOSTIC_MAX_BYTES - FAILURE_DIAGNOSTIC_TRUNCATED_SUFFIX.len();
     while !message.is_char_boundary(end) {
         end -= 1;
     }
-    format!(
-        "{}{}",
-        &message[..end],
-        CODEX_FAILURE_DIAGNOSTIC_TRUNCATED_SUFFIX
-    )
+    format!("{}{}", &message[..end], FAILURE_DIAGNOSTIC_TRUNCATED_SUFFIX)
 }
 
 /// POST a prepared event payload to the webhook endpoint.
@@ -633,8 +671,8 @@ mod tests {
     #[test]
     fn codex_failure_diagnostic_masks_before_truncating() {
         let prefix = "x".repeat(
-            CODEX_FAILURE_DIAGNOSTIC_MAX_BYTES
-                - CODEX_FAILURE_DIAGNOSTIC_TRUNCATED_SUFFIX.len()
+            FAILURE_DIAGNOSTIC_MAX_BYTES
+                - FAILURE_DIAGNOSTIC_TRUNCATED_SUFFIX.len()
                 - "super".len(),
         );
         let event = serde_json::json!({
@@ -659,18 +697,123 @@ mod tests {
     fn codex_failure_diagnostic_truncates_to_max_bytes() {
         let event = serde_json::json!({
             "type": "error",
-            "message": "x".repeat(CODEX_FAILURE_DIAGNOSTIC_MAX_BYTES + 100)
+            "message": "x".repeat(FAILURE_DIAGNOSTIC_MAX_BYTES + 100)
         });
         let diagnostic = masked_codex_failure_diagnostic(&event, &SecretMasker::from_raw(""))
             .expect("error event should produce a diagnostic");
 
-        assert_eq!(diagnostic.message.len(), CODEX_FAILURE_DIAGNOSTIC_MAX_BYTES);
+        assert_eq!(diagnostic.message.len(), FAILURE_DIAGNOSTIC_MAX_BYTES);
         assert!(
             diagnostic
                 .message
-                .ends_with(CODEX_FAILURE_DIAGNOSTIC_TRUNCATED_SUFFIX),
+                .ends_with(FAILURE_DIAGNOSTIC_TRUNCATED_SUFFIX),
             "diagnostic should end with truncation marker: {diagnostic:?}"
         );
+    }
+
+    #[test]
+    fn claude_error_result_yields_failure_diagnostic() {
+        let event = serde_json::json!({
+            "type": "result",
+            "subtype": "error",
+            "is_error": true,
+            "result": "permission denied while running command"
+        });
+
+        assert_eq!(
+            masked_claude_failure_diagnostic(&event, &SecretMasker::from_raw("")),
+            Some(ClaudeFailureDiagnostic {
+                subtype: Some("error".to_string()),
+                message: "permission denied while running command".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn claude_error_subtype_without_is_error_yields_failure_diagnostic() {
+        let event = serde_json::json!({
+            "type": "result",
+            "subtype": "error",
+            "result": "terminal result failed"
+        });
+
+        assert_eq!(
+            masked_claude_failure_diagnostic(&event, &SecretMasker::from_raw("")),
+            Some(ClaudeFailureDiagnostic {
+                subtype: Some("error".to_string()),
+                message: "terminal result failed".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn claude_success_result_has_no_failure_diagnostic() {
+        let event = serde_json::json!({
+            "type": "result",
+            "subtype": "success",
+            "is_error": false,
+            "result": "Done."
+        });
+
+        assert_eq!(
+            masked_claude_failure_diagnostic(&event, &SecretMasker::from_raw("")),
+            None
+        );
+    }
+
+    #[test]
+    fn claude_error_result_requires_nonempty_result_message() {
+        let event = serde_json::json!({
+            "type": "result",
+            "subtype": "error",
+            "is_error": true,
+            "result": " \n\t "
+        });
+
+        assert_eq!(
+            masked_claude_failure_diagnostic(&event, &SecretMasker::from_raw("")),
+            None
+        );
+    }
+
+    #[test]
+    fn claude_failure_diagnostic_masks_and_escapes_line_breaks() {
+        let event = serde_json::json!({
+            "type": "result",
+            "is_error": true,
+            "result": "first line with supersecret\nsecond\rthird"
+        });
+        let masker = SecretMasker::from_raw("c3VwZXJzZWNyZXQ=");
+
+        assert_eq!(
+            masked_claude_failure_diagnostic(&event, &masker),
+            Some(ClaudeFailureDiagnostic {
+                subtype: None,
+                message: "first line with ***\\nsecond\\rthird".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn claude_failure_diagnostic_truncates_to_max_bytes() {
+        let event = serde_json::json!({
+            "type": "result",
+            "is_error": true,
+            "result": "é".repeat(FAILURE_DIAGNOSTIC_MAX_BYTES)
+        });
+        let diagnostic = masked_claude_failure_diagnostic(&event, &SecretMasker::from_raw(""))
+            .expect("Claude error result should produce a diagnostic");
+
+        assert_eq!(diagnostic.message.len(), FAILURE_DIAGNOSTIC_MAX_BYTES);
+        assert!(
+            diagnostic
+                .message
+                .ends_with(FAILURE_DIAGNOSTIC_TRUNCATED_SUFFIX),
+            "diagnostic should end with truncation marker: {diagnostic:?}"
+        );
+        assert!(diagnostic.message.is_char_boundary(
+            FAILURE_DIAGNOSTIC_MAX_BYTES - FAILURE_DIAGNOSTIC_TRUNCATED_SUFFIX.len()
+        ));
     }
 
     #[test]

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -15,7 +15,8 @@ use guest_agent::paths;
 use guest_agent::telemetry::{Telemetry, UploadMode};
 
 use agent_diagnostics::{
-    AgentFramework, FailureClass, FailureDiagnostic, PromptMetadata, SessionHistoryStatus,
+    AgentFramework, FailureClass, FailureDetailSource, FailureDiagnostic, PromptMetadata,
+    SessionHistoryStatus,
 };
 use guest_common::telemetry::record_sandbox_op;
 use guest_common::{log_error, log_info, log_warn};
@@ -204,19 +205,21 @@ async fn execute(
             last_event_sequence = cli_result.last_event_sequence;
             let cli_exit_code = cli_result.exit_code;
             if cli_exit_code != 0 {
+                let failure_message = cli_failure_message(
+                    cli_exit_code,
+                    &cli_result.stderr_lines,
+                    cli_result.failure_diagnostic.as_ref(),
+                );
                 let diagnostic = cli_result_failure_diagnostic(
                     FailureClass::CliNonzero,
                     cli_exit_code,
                     cli_result.claude_result,
-                );
+                )
+                .with_failure_detail_source(failure_message.source);
                 (
                     cli_exit_code,
                     cli_exit_code,
-                    cli_failure_message(
-                        cli_exit_code,
-                        &cli_result.stderr_lines,
-                        cli_result.failure_diagnostic.as_deref(),
-                    ),
+                    failure_message.message,
                     false,
                     Some(diagnostic),
                 )
@@ -395,25 +398,37 @@ fn write_guest_failure_diagnostic(diagnostic: &FailureDiagnostic) {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct CliFailureMessage {
+    message: String,
+    source: FailureDetailSource,
+}
+
 fn cli_failure_message(
     code: i32,
     stderr_lines: &[String],
-    failure_diagnostic: Option<&str>,
-) -> String {
-    if let Some(message) = failure_diagnostic.and_then(|message| {
-        let message = message.trim();
+    failure_diagnostic: Option<&cli::CliFailureDiagnostic>,
+) -> CliFailureMessage {
+    if let Some((message, source)) = failure_diagnostic.and_then(|diagnostic| {
+        let message = diagnostic.message.trim();
         if message.is_empty() {
             None
         } else {
-            Some(message)
+            Some((message, diagnostic.source))
         }
-    }) && (!is_generic_codex_failure_diagnostic(message) || stderr_lines.is_empty())
+    }) && (!is_generic_stdout_failure_diagnostic(message) || stderr_lines.is_empty())
     {
-        return message.to_string();
+        return CliFailureMessage {
+            message: message.to_string(),
+            source,
+        };
     }
 
     if stderr_lines.is_empty() {
-        return format!("Agent exited with code {code}");
+        return CliFailureMessage {
+            message: format!("Agent exited with code {code}"),
+            source: FailureDetailSource::FallbackExitCode,
+        };
     }
 
     log_info!(LOG_TAG, "Captured {} stderr lines", stderr_lines.len());
@@ -438,10 +453,13 @@ fn cli_failure_message(
         log_warn!(LOG_TAG, "CLI stderr: {line}");
         message_lines.push(line.into_owned());
     }
-    message_lines.join(" ")
+    CliFailureMessage {
+        message: message_lines.join(" "),
+        source: FailureDetailSource::Stderr,
+    }
 }
 
-fn is_generic_codex_failure_diagnostic(message: &str) -> bool {
+fn is_generic_stdout_failure_diagnostic(message: &str) -> bool {
     matches!(message.trim(), "error" | "turn failed" | "turn interrupted")
 }
 
@@ -668,6 +686,13 @@ mod tests {
         }
     }
 
+    fn cli_diagnostic(message: &str, source: FailureDetailSource) -> cli::CliFailureDiagnostic {
+        cli::CliFailureDiagnostic {
+            message: message.to_string(),
+            source,
+        }
+    }
+
     #[test]
     fn cli_failure_message_logs_stderr_to_system_log() {
         let _test_state_guard = lock_test_state();
@@ -683,24 +708,26 @@ mod tests {
             .chain((0..(MAX_LOGGED_CLI_STDERR_LINES - 2)).map(|i| format!("extra line {i}")))
             .collect::<Vec<_>>();
         let msg = cli_failure_message(1, &stderr_lines, None);
+        assert_eq!(msg.source, FailureDetailSource::Stderr);
         assert!(
-            !msg.contains("prefix line"),
+            !msg.message.contains("prefix line"),
             "returned error message should omit older stderr lines"
         );
         assert!(
-            msg.contains("codex stderr includes ***"),
+            msg.message.contains("codex stderr includes ***"),
             "returned error message should preserve stderr"
         );
         assert!(
-            msg.contains("...[truncated]"),
+            msg.message.contains("...[truncated]"),
             "returned error message should truncate long stderr lines"
         );
         assert!(
-            !msg.contains("tail"),
+            !msg.message.contains("tail"),
             "returned error message should not include bytes after the truncation boundary"
         );
         assert!(
-            msg.contains("...[omitted 2 earlier stderr line(s)]"),
+            msg.message
+                .contains("...[omitted 2 earlier stderr line(s)]"),
             "returned error message should report omitted earlier stderr lines"
         );
 
@@ -744,16 +771,17 @@ mod tests {
             .collect::<Vec<_>>();
 
         let msg = cli_failure_message(1, &stderr_lines, None);
+        assert_eq!(msg.source, FailureDetailSource::Stderr);
         assert!(
-            msg.contains(&exact_limit_line),
+            msg.message.contains(&exact_limit_line),
             "returned error message should preserve line at exact size limit"
         );
         assert!(
-            !msg.contains("...[truncated]"),
+            !msg.message.contains("...[truncated]"),
             "returned error message should not truncate line at exact size limit"
         );
         assert!(
-            !msg.contains("omitted"),
+            !msg.message.contains("omitted"),
             "returned error message should not report omitted lines at exact line limit"
         );
 
@@ -778,17 +806,18 @@ mod tests {
         let prefix = "x".repeat(MAX_LOGGED_CLI_STDERR_LINE_BYTES - 1);
         let stderr_line = format!("{prefix}é-tail");
         let msg = cli_failure_message(1, &[stderr_line], None);
+        assert_eq!(msg.source, FailureDetailSource::Stderr);
 
         assert!(
-            msg.contains(&prefix),
+            msg.message.contains(&prefix),
             "returned error message should preserve bytes before the truncation boundary"
         );
         assert!(
-            msg.contains("...[truncated]"),
+            msg.message.contains("...[truncated]"),
             "returned error message should indicate truncation"
         );
         assert!(
-            !msg.contains("é-tail"),
+            !msg.message.contains("é-tail"),
             "returned error message should not split or include the over-boundary character"
         );
 
@@ -809,13 +838,15 @@ mod tests {
         let msg = cli_failure_message(
             1,
             &stderr_lines,
-            Some(
+            Some(&cli_diagnostic(
                 "You've hit your usage limit. Visit https://chatgpt.com/codex/settings/usage to purchase more credits.",
-            ),
+                FailureDetailSource::CodexJsonl,
+            )),
         );
 
+        assert_eq!(msg.source, FailureDetailSource::CodexJsonl);
         assert_eq!(
-            msg,
+            msg.message,
             "You've hit your usage limit. Visit https://chatgpt.com/codex/settings/usage to purchase more credits."
         );
     }
@@ -823,16 +854,51 @@ mod tests {
     #[test]
     fn cli_failure_message_uses_stderr_over_generic_codex_failure_diagnostic() {
         let stderr_lines = vec!["specific stderr failure".to_string()];
-        let msg = cli_failure_message(1, &stderr_lines, Some("turn failed"));
+        let diagnostic = cli_diagnostic("turn failed", FailureDetailSource::CodexJsonl);
+        let msg = cli_failure_message(1, &stderr_lines, Some(&diagnostic));
 
-        assert_eq!(msg, "specific stderr failure");
+        assert_eq!(msg.source, FailureDetailSource::Stderr);
+        assert_eq!(msg.message, "specific stderr failure");
     }
 
     #[test]
     fn cli_failure_message_uses_generic_codex_failure_diagnostic_without_stderr() {
-        let msg = cli_failure_message(1, &[], Some("turn failed"));
+        let diagnostic = cli_diagnostic("turn failed", FailureDetailSource::CodexJsonl);
+        let msg = cli_failure_message(1, &[], Some(&diagnostic));
 
-        assert_eq!(msg, "turn failed");
+        assert_eq!(msg.source, FailureDetailSource::CodexJsonl);
+        assert_eq!(msg.message, "turn failed");
+    }
+
+    #[test]
+    fn cli_failure_message_prefers_claude_result_diagnostic() {
+        let stderr_lines = vec!["background task noise".to_string()];
+        let diagnostic = cli_diagnostic(
+            "permission denied while running command",
+            FailureDetailSource::ClaudeResult,
+        );
+        let msg = cli_failure_message(1, &stderr_lines, Some(&diagnostic));
+
+        assert_eq!(msg.source, FailureDetailSource::ClaudeResult);
+        assert_eq!(msg.message, "permission denied while running command");
+    }
+
+    #[test]
+    fn cli_failure_message_uses_stderr_over_generic_claude_result() {
+        let stderr_lines = vec!["specific stderr failure".to_string()];
+        let diagnostic = cli_diagnostic("error", FailureDetailSource::ClaudeResult);
+        let msg = cli_failure_message(1, &stderr_lines, Some(&diagnostic));
+
+        assert_eq!(msg.source, FailureDetailSource::Stderr);
+        assert_eq!(msg.message, "specific stderr failure");
+    }
+
+    #[test]
+    fn cli_failure_message_marks_exit_code_fallback_source() {
+        let msg = cli_failure_message(7, &[], None);
+
+        assert_eq!(msg.source, FailureDetailSource::FallbackExitCode);
+        assert_eq!(msg.message, "Agent exited with code 7");
     }
 
     #[test]

--- a/crates/guest-agent/tests/claude_result_failure_logging.rs
+++ b/crates/guest-agent/tests/claude_result_failure_logging.rs
@@ -1,0 +1,85 @@
+//! Claude terminal result failures should be visible as bounded CLI diagnostics.
+//!
+//! This test lives in its own binary because `guest_agent::env` and
+//! `guest_agent::paths` cache values in process-wide `LazyLock`s.
+
+mod common;
+
+use agent_diagnostics::FailureDetailSource;
+use guest_agent::http::HttpClient;
+use guest_agent::masker::SecretMasker;
+use std::path::Path;
+use std::time::Duration;
+
+struct SystemLogOverrideGuard;
+
+impl SystemLogOverrideGuard {
+    fn set(path: &Path) -> Self {
+        guest_common::log::set_system_log_file(path);
+        Self
+    }
+}
+
+impl Drop for SystemLogOverrideGuard {
+    fn drop(&mut self) {
+        guest_common::log::clear_system_log_file();
+    }
+}
+
+#[tokio::test]
+async fn claude_error_result_is_written_to_system_log() -> Result<(), Box<dyn std::error::Error>> {
+    let mock = common::build_and_locate_mock()?;
+    let tmp = tempfile::tempdir()?;
+    let system_log_path = tmp.path().join("system.log");
+    let failure_reason = "permission denied while running command";
+
+    unsafe {
+        common::setup_env(
+            &mock,
+            tmp.path(),
+            &format!("printf '{failure_reason}'; exit 2"),
+            3,
+            1,
+        )?;
+    }
+
+    let _system_log = SystemLogOverrideGuard::set(&system_log_path);
+    let masker = SecretMasker::from_raw("");
+    let cli_result = tokio::time::timeout(
+        Duration::from_secs(5),
+        guest_agent::cli::execute_cli(
+            &masker,
+            common::spawn_dummy_heartbeat(),
+            HttpClient::for_current_env()?,
+        ),
+    )
+    .await
+    .expect("execute_cli should return promptly")?;
+
+    assert_eq!(cli_result.exit_code, 2);
+    assert!(cli_result.stderr_lines.is_empty());
+    assert_eq!(
+        cli_result
+            .failure_diagnostic
+            .as_ref()
+            .map(|diagnostic| diagnostic.message.as_str()),
+        Some(failure_reason)
+    );
+    assert_eq!(
+        cli_result
+            .failure_diagnostic
+            .as_ref()
+            .map(|diagnostic| diagnostic.source),
+        Some(FailureDetailSource::ClaudeResult)
+    );
+
+    let system_log = std::fs::read_to_string(&system_log_path)?;
+    assert!(
+        system_log.contains(
+            "Claude JSONL failure result seq=4 subtype=error: permission denied while running command"
+        ),
+        "system log should include Claude JSONL failure reason: {system_log}"
+    );
+
+    Ok(())
+}

--- a/crates/guest-agent/tests/codex_jsonl_failure_logging.rs
+++ b/crates/guest-agent/tests/codex_jsonl_failure_logging.rs
@@ -5,6 +5,7 @@
 
 mod common;
 
+use agent_diagnostics::FailureDetailSource;
 use guest_agent::http::HttpClient;
 use guest_agent::masker::SecretMasker;
 use std::path::{Path, PathBuf};
@@ -51,8 +52,18 @@ async fn codex_jsonl_error_event_is_written_to_system_log() -> Result<(), Box<dy
 
     assert_eq!(cli_result.exit_code, common::CLEAN_EXIT);
     assert_eq!(
-        cli_result.failure_diagnostic.as_deref(),
+        cli_result
+            .failure_diagnostic
+            .as_ref()
+            .map(|diagnostic| diagnostic.message.as_str()),
         Some("Mock error event for fixture testing")
+    );
+    assert_eq!(
+        cli_result
+            .failure_diagnostic
+            .as_ref()
+            .map(|diagnostic| diagnostic.source),
+        Some(FailureDetailSource::CodexJsonl)
     );
     let system_log = std::fs::read_to_string(&system_log_path)?;
     assert!(

--- a/crates/runner/src/cmd/start/job_spawn.rs
+++ b/crates/runner/src/cmd/start/job_spawn.rs
@@ -231,6 +231,8 @@ pub(super) fn spawn_job(
                 (true, _) => info!(run_id = %run_id, exit_code, reused, "job cancelled"),
                 (false, Some(failure)) => {
                     if let Some(diagnostic) = failure.diagnostic.as_ref() {
+                        let failure_detail_source =
+                            diagnostic.failure_detail_source.map(|source| source.as_str());
                         error!(
                             run_id = %run_id,
                             exit_code,
@@ -240,6 +242,7 @@ pub(super) fn spawn_job(
                             failure_framework = diagnostic.framework.as_str(),
                             failure_cli_exit_code = diagnostic.cli_exit_code,
                             failure_claude_num_turns = diagnostic.claude_num_turns,
+                            failure_detail_source,
                             session_history_status = diagnostic.session_history_status.as_str(),
                             prompt_shape = diagnostic.prompt_shape.as_str(),
                             prompt_bytes = diagnostic.prompt_bytes,

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -2834,6 +2834,7 @@ mod tests {
             agent_diagnostics::PromptMetadata::from_prompt("/help"),
         )
         .with_cli_exit_code(1)
+        .with_failure_detail_source(agent_diagnostics::FailureDetailSource::ClaudeResult)
         .with_session_history_status(agent_diagnostics::SessionHistoryStatus::Present);
         sandbox.push_read_file_result(Ok(Some(serde_json::to_vec(&diagnostic).unwrap())));
 


### PR DESCRIPTION
## Summary

- extract bounded, masked diagnostics from Claude terminal `result` failure events
- carry failure detail source through guest-agent diagnostics and runner structured logs
- add tests for Claude result extraction, message/source precedence, and runner diagnostic deserialization

Closes #14162

## Tests

- cargo test --manifest-path crates/Cargo.toml -p agent-diagnostics
- CARGO_BUILD_JOBS=1 cargo test --manifest-path crates/Cargo.toml -p guest-agent --lib --bins
- CARGO_BUILD_JOBS=1 cargo test --manifest-path crates/Cargo.toml -p guest-agent --test claude_result_failure_logging --test codex_jsonl_failure_logging
- CARGO_BUILD_JOBS=1 cargo test --manifest-path crates/Cargo.toml -p runner read_guest_failure_diagnostic_file
- CARGO_BUILD_JOBS=1 cargo test --manifest-path crates/Cargo.toml -p guest-agent
- lefthook pre-commit: cargo-fmt, cargo-clippy, cargo-doc
