### PR TITLE
refactor: limit provider handlers to oauth connectors

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/cli-auth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cli-auth.test.ts
@@ -1485,6 +1485,39 @@ describe("CLI auth routes", () => {
       });
     });
 
+    it("rejects connector types that do not use OAuth", async () => {
+      const userId = trackUser(`user_${randomUUID()}`);
+      const orgId = trackOrg(`org_${randomUUID()}`);
+      await seedOrgMembership({ orgId, userId, slug: "connector-non-oauth" });
+      mockTestUser({ userId, orgId });
+      const client = setupApp({ context })(cliAuthTestConnectorContract);
+
+      const response = await acceptResponse<{ readonly error: string }>(
+        client.create({
+          query: {},
+          body: {
+            connectorName: "computer",
+            accessToken: "computer-access-token",
+          },
+        }),
+        400,
+      );
+
+      expect(response.body).toStrictEqual({
+        error: "computer connector does not use OAuth",
+      });
+      await expect(
+        readConnectorState({ orgId, userId, type: "computer" }),
+      ).resolves.toBeNull();
+      await expect(
+        findConnectorSecret({
+          orgId,
+          userId,
+          name: "COMPUTER_CONNECTOR_AUTHTOKEN",
+        }),
+      ).resolves.toBeUndefined();
+    });
+
     it("seeds OAuth connector token state for the test user org", async () => {
       const userId = trackUser(`user_${randomUUID()}`);
       const orgId = trackOrg(`org_${randomUUID()}`);
@@ -1542,39 +1575,6 @@ describe("CLI auth routes", () => {
           name: "TEST_OAUTH_REFRESH_TOKEN",
         }),
       ).resolves.toBe("test-oauth-refresh-token");
-
-      const computerResponse = await acceptResponse<TestConnectorResponseBody>(
-        client.create({
-          query: {},
-          body: {
-            connectorName: "computer",
-            accessToken: "computer-access-token",
-          },
-        }),
-        200,
-      );
-
-      expect(computerResponse.body).toStrictEqual({
-        ok: true,
-        connectorType: "computer",
-        orgId,
-      });
-      await expect(
-        readConnectorState({ orgId, userId, type: "computer" }),
-      ).resolves.toMatchObject({
-        authMethod: "oauth",
-        externalId: "e2e-test-computer",
-        externalUsername: "e2e-computer",
-        externalEmail: "e2e-computer@test.vm0.ai",
-        tokenExpiresAt: null,
-      });
-      await expect(
-        findConnectorSecret({
-          orgId,
-          userId,
-          name: "COMPUTER_CONNECTOR_AUTHTOKEN",
-        }),
-      ).resolves.toBe("computer-access-token");
     });
 
     it("resolves a custom test user email through Clerk", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/connectors-type-callback.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors-type-callback.test.ts
@@ -3,7 +3,7 @@ import { randomUUID } from "node:crypto";
 import {
   CONNECTOR_TYPES,
   type ConnectorOAuthClientConfig,
-  type ConnectorOAuthProviderType,
+  type OAuthConnectorType,
 } from "@vm0/connectors/connectors";
 import { PROVIDER_HANDLERS } from "@vm0/connectors/oauth-providers";
 import { connectors } from "@vm0/db/schema/connector";
@@ -68,8 +68,6 @@ const SENTRY_TOKEN_URL = "https://sentry.io/oauth/token/";
 const INTERVALS_ICU_TOKEN_URL = "https://intervals.icu/api/oauth/token";
 const XERO_TOKEN_URL = "https://identity.xero.com/connect/token";
 const XERO_USERINFO_URL = "https://identity.xero.com/connect/userinfo";
-
-type OAuthConnectorType = ConnectorOAuthProviderType;
 
 function callbackUrl(
   type: string,

--- a/turbo/apps/api/src/signals/routes/__tests__/connectors-type-callback.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors-type-callback.test.ts
@@ -3,7 +3,7 @@ import { randomUUID } from "node:crypto";
 import {
   CONNECTOR_TYPES,
   type ConnectorOAuthClientConfig,
-  type ConnectorType,
+  type ConnectorOAuthProviderType,
 } from "@vm0/connectors/connectors";
 import { PROVIDER_HANDLERS } from "@vm0/connectors/oauth-providers";
 import { connectors } from "@vm0/db/schema/connector";
@@ -69,7 +69,7 @@ const INTERVALS_ICU_TOKEN_URL = "https://intervals.icu/api/oauth/token";
 const XERO_TOKEN_URL = "https://identity.xero.com/connect/token";
 const XERO_USERINFO_URL = "https://identity.xero.com/connect/userinfo";
 
-type OAuthConnectorType = Exclude<ConnectorType, "computer">;
+type OAuthConnectorType = ConnectorOAuthProviderType;
 
 function callbackUrl(
   type: string,

--- a/turbo/apps/api/src/signals/routes/cli-auth-test.ts
+++ b/turbo/apps/api/src/signals/routes/cli-auth-test.ts
@@ -7,7 +7,10 @@ import {
   cliAuthTestTokenContract,
 } from "@vm0/api-contracts/contracts/cli-auth-test";
 import { connectorTypeSchema } from "@vm0/connectors/connectors";
-import { PROVIDER_HANDLERS } from "@vm0/connectors/oauth-providers";
+import {
+  isConnectorOAuthProviderType,
+  PROVIDER_HANDLERS,
+} from "@vm0/connectors/oauth-providers";
 import { agentComposes } from "@vm0/db/schema/agent-compose";
 import { deviceCodes } from "@vm0/db/schema/device-codes";
 import { modelProviders } from "@vm0/db/schema/model-provider";
@@ -208,10 +211,11 @@ const createTestConnector$ = command(
       return stringError(400, "Test user has no org — run test-token first");
     }
 
-    const refreshSecretName =
-      connectorType === "computer"
-        ? undefined
-        : PROVIDER_HANDLERS[connectorType].getRefreshSecretName?.();
+    if (!isConnectorOAuthProviderType(connectorType)) {
+      return stringError(400, `${connectorType} connector does not use OAuth`);
+    }
+    const handler = PROVIDER_HANDLERS[connectorType];
+    const refreshSecretName = handler.getRefreshSecretName?.();
     await set(
       upsertOAuthConnector$,
       {

--- a/turbo/apps/api/src/signals/routes/cli-auth-test.ts
+++ b/turbo/apps/api/src/signals/routes/cli-auth-test.ts
@@ -8,7 +8,7 @@ import {
 } from "@vm0/api-contracts/contracts/cli-auth-test";
 import { connectorTypeSchema } from "@vm0/connectors/connectors";
 import {
-  isConnectorOAuthProviderType,
+  isOAuthConnectorType,
   PROVIDER_HANDLERS,
 } from "@vm0/connectors/oauth-providers";
 import { agentComposes } from "@vm0/db/schema/agent-compose";
@@ -211,7 +211,7 @@ const createTestConnector$ = command(
       return stringError(400, "Test user has no org — run test-token first");
     }
 
-    if (!isConnectorOAuthProviderType(connectorType)) {
+    if (!isOAuthConnectorType(connectorType)) {
       return stringError(400, `${connectorType} connector does not use OAuth`);
     }
     const handler = PROVIDER_HANDLERS[connectorType];

--- a/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
+++ b/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
@@ -13,7 +13,7 @@ import {
 } from "@vm0/connectors/connectors";
 import {
   exchangeProviderCode,
-  isConnectorOAuthProviderType,
+  isOAuthConnectorType,
   PROVIDER_HANDLERS,
   type OAuthTokenResult,
 } from "@vm0/connectors/oauth-providers";
@@ -423,7 +423,7 @@ const callbackConnectorInner$ = command(
         "Computer connector does not use OAuth",
       );
     }
-    if (!isConnectorOAuthProviderType(connectorType)) {
+    if (!isOAuthConnectorType(connectorType)) {
       return redirectWithError(
         origin,
         params.type,

--- a/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
+++ b/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
@@ -8,10 +8,12 @@ import {
 } from "@vm0/connectors/connector-utils";
 import {
   connectorTypeSchema,
+  type ConnectorOAuthProviderType,
   type ConnectorType,
 } from "@vm0/connectors/connectors";
 import {
   exchangeProviderCode,
+  isConnectorOAuthProviderType,
   PROVIDER_HANDLERS,
   type OAuthTokenResult,
 } from "@vm0/connectors/oauth-providers";
@@ -39,7 +41,7 @@ const PKCE_COOKIE_NAME = "connector_oauth_pkce";
 const OAUTH_CONTEXT_COOKIE_NAME = "connector_oauth_context";
 const REDIRECT_STATUS = 307;
 
-type OAuthConnectorType = Exclude<ConnectorType, "computer">;
+type OAuthConnectorType = ConnectorOAuthProviderType;
 type StoredOAuthState = typeof connectorOauthStates.$inferSelect;
 
 type CallbackIdentity = {
@@ -420,6 +422,13 @@ const callbackConnectorInner$ = command(
         origin,
         params.type,
         "Computer connector does not use OAuth",
+      );
+    }
+    if (!isConnectorOAuthProviderType(connectorType)) {
+      return redirectWithError(
+        origin,
+        params.type,
+        `${params.type} connector does not use OAuth`,
       );
     }
 

--- a/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
+++ b/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
@@ -8,8 +8,8 @@ import {
 } from "@vm0/connectors/connector-utils";
 import {
   connectorTypeSchema,
-  type ConnectorOAuthProviderType,
   type ConnectorType,
+  type OAuthConnectorType,
 } from "@vm0/connectors/connectors";
 import {
   exchangeProviderCode,
@@ -41,7 +41,6 @@ const PKCE_COOKIE_NAME = "connector_oauth_pkce";
 const OAUTH_CONTEXT_COOKIE_NAME = "connector_oauth_context";
 const REDIRECT_STATUS = 307;
 
-type OAuthConnectorType = ConnectorOAuthProviderType;
 type StoredOAuthState = typeof connectorOauthStates.$inferSelect;
 
 type CallbackIdentity = {

--- a/turbo/apps/api/src/signals/routes/zero-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/zero-connectors.ts
@@ -23,8 +23,8 @@ import {
 } from "@vm0/connectors/connector-utils";
 import {
   connectorTypeSchema,
-  type ConnectorOAuthProviderType,
   type ConnectorType,
+  type OAuthConnectorType,
 } from "@vm0/connectors/connectors";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import {
@@ -330,7 +330,7 @@ function missingOAuthProviderHandlerResponse(type: string) {
 }
 
 async function buildProviderAuthorizeUrl(args: {
-  readonly type: ConnectorOAuthProviderType;
+  readonly type: OAuthConnectorType;
   readonly clientId?: string;
   readonly redirectUri: string;
   readonly state: string;

--- a/turbo/apps/api/src/signals/routes/zero-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/zero-connectors.ts
@@ -29,7 +29,7 @@ import {
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import {
   buildProviderAuthUrl,
-  isConnectorOAuthProviderType,
+  isOAuthConnectorType,
   PROVIDER_HANDLERS,
   type AuthUrlResult,
 } from "@vm0/connectors/oauth-providers";
@@ -595,7 +595,7 @@ export function createAuthorizeConnectorInner(route: ConnectorAuthorizeRoute) {
     if (!getConnectorAuthMethod(type, "oauth")) {
       return connectorDoesNotUseOAuthResponse(type);
     }
-    if (!isConnectorOAuthProviderType(type)) {
+    if (!isOAuthConnectorType(type)) {
       return missingOAuthProviderHandlerResponse(type);
     }
 
@@ -696,7 +696,7 @@ const startConnectorOauthInner$ = command(
     if (!getConnectorAuthMethod(type, "oauth")) {
       return badRequestMessage(`${type} connector does not use OAuth`);
     }
-    if (!isConnectorOAuthProviderType(type)) {
+    if (!isOAuthConnectorType(type)) {
       return internalServerError(
         `${type} OAuth provider handler not configured`,
       );

--- a/turbo/apps/api/src/signals/routes/zero-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/zero-connectors.ts
@@ -23,11 +23,13 @@ import {
 } from "@vm0/connectors/connector-utils";
 import {
   connectorTypeSchema,
+  type ConnectorOAuthProviderType,
   type ConnectorType,
 } from "@vm0/connectors/connectors";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import {
   buildProviderAuthUrl,
+  isConnectorOAuthProviderType,
   PROVIDER_HANDLERS,
   type AuthUrlResult,
 } from "@vm0/connectors/oauth-providers";
@@ -316,8 +318,19 @@ function normalizeAuthUrlResult(result: string | AuthUrlResult): AuthUrlResult {
   return typeof result === "string" ? { url: result } : result;
 }
 
+function connectorDoesNotUseOAuthResponse(type: string) {
+  return jsonResponse({ error: `${type} connector does not use OAuth` }, 400);
+}
+
+function missingOAuthProviderHandlerResponse(type: string) {
+  return jsonResponse(
+    { error: `${type} OAuth provider handler not configured` },
+    500,
+  );
+}
+
 async function buildProviderAuthorizeUrl(args: {
-  readonly type: Exclude<ConnectorType, "computer">;
+  readonly type: ConnectorOAuthProviderType;
   readonly clientId?: string;
   readonly redirectUri: string;
   readonly state: string;
@@ -580,10 +593,10 @@ export function createAuthorizeConnectorInner(route: ConnectorAuthorizeRoute) {
     }
 
     if (!getConnectorAuthMethod(type, "oauth")) {
-      return jsonResponse(
-        { error: `${type} connector does not use OAuth` },
-        400,
-      );
+      return connectorDoesNotUseOAuthResponse(type);
+    }
+    if (!isConnectorOAuthProviderType(type)) {
+      return missingOAuthProviderHandlerResponse(type);
     }
 
     if (!auth.orgId) {
@@ -682,6 +695,11 @@ const startConnectorOauthInner$ = command(
 
     if (!getConnectorAuthMethod(type, "oauth")) {
       return badRequestMessage(`${type} connector does not use OAuth`);
+    }
+    if (!isConnectorOAuthProviderType(type)) {
+      return internalServerError(
+        `${type} OAuth provider handler not configured`,
+      );
     }
 
     if (!auth.orgId) {

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -35,7 +35,10 @@ import {
   getConnectorFirewall,
   isFirewallConnectorType,
 } from "@vm0/connectors/firewalls";
-import { PROVIDER_HANDLERS } from "@vm0/connectors/oauth-providers";
+import {
+  getConnectorOAuthProviderHandler,
+  providerSupportsRefresh,
+} from "@vm0/connectors/oauth-providers";
 import { getModelProviderOAuthHandler } from "@vm0/connectors/oauth-providers/model-provider-registry";
 import {
   expandHostWildcardsInBaseUrl,
@@ -1473,11 +1476,8 @@ async function loadOauthConnectorContext(
       }
     }
 
-    if (connectorType === "computer") {
-      continue;
-    }
-    const handler = PROVIDER_HANDLERS[connectorType];
-    if (!handler.refreshToken) {
+    const handler = getConnectorOAuthProviderHandler(connectorType);
+    if (!handler || !providerSupportsRefresh(handler)) {
       continue;
     }
     const secretName = handler.getSecretName();

--- a/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
@@ -6,7 +6,8 @@ import { connectorTypeSchema } from "@vm0/connectors/connectors";
 import { basicAuthTemplateRe } from "@vm0/connectors/firewall-types";
 import type { FeatureSwitchContext } from "@vm0/core/feature-switch";
 import {
-  PROVIDER_HANDLERS,
+  getConnectorOAuthProviderHandler,
+  providerSupportsRefresh,
   refreshProviderToken,
   type ProviderEnv,
 } from "@vm0/connectors/oauth-providers";
@@ -265,10 +266,7 @@ function resolveRefreshMetadata(
 function connectorProviderHandler(
   connectorType: string,
 ): ConnectorProviderHandler | null {
-  if (!Object.hasOwn(PROVIDER_HANDLERS, connectorType)) {
-    return null;
-  }
-  return PROVIDER_HANDLERS[connectorType as keyof typeof PROVIDER_HANDLERS];
+  return getConnectorOAuthProviderHandler(connectorType) ?? null;
 }
 
 function providerHandler(
@@ -615,10 +613,7 @@ function prepareRefreshTokenContext(
   }
 
   const handler = connectorProviderHandler(args.connectorType);
-  if (
-    !handler?.getRefreshSecretName ||
-    (!handler.refreshToken && !handler.refreshTokenWithArgs)
-  ) {
+  if (!handler?.getRefreshSecretName || !providerSupportsRefresh(handler)) {
     return null;
   }
   const typeResult = connectorTypeSchema.safeParse(args.connectorType);

--- a/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
@@ -24,8 +24,8 @@ import {
   CONNECTOR_TYPES,
   connectorTypeSchema,
   type ConnectorAuthMethodType,
-  type ConnectorOAuthProviderType,
   type ConnectorType,
+  type OAuthConnectorType,
 } from "@vm0/connectors/connectors";
 import {
   getAllFeatureStates,
@@ -811,7 +811,7 @@ export const upsertOAuthConnector$ = command(
     args: {
       readonly orgId: string;
       readonly userId: string;
-      readonly type: ConnectorOAuthProviderType;
+      readonly type: OAuthConnectorType;
       readonly accessToken: string;
       readonly userInfo: ExternalUserInfo;
       readonly oauthScopes: readonly string[];

--- a/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
@@ -16,11 +16,15 @@ import {
   getScopeDiff,
   isConnectorAuthMethodAvailable,
 } from "@vm0/connectors/connector-utils";
-import { PROVIDER_HANDLERS } from "@vm0/connectors/oauth-providers";
+import {
+  PROVIDER_HANDLERS,
+  providerSupportsRefresh,
+} from "@vm0/connectors/oauth-providers";
 import {
   CONNECTOR_TYPES,
   connectorTypeSchema,
   type ConnectorAuthMethodType,
+  type ConnectorOAuthProviderType,
   type ConnectorType,
 } from "@vm0/connectors/connectors";
 import {
@@ -69,7 +73,6 @@ type StoredConnectorRow = {
 
 const oauthScopesSchema = z.array(z.string());
 const DEFAULT_ACCESS_TOKEN_EXPIRES_IN_SECS = 3600;
-const COMPUTER_CONNECTOR_AUTH_TOKEN_SECRET = "COMPUTER_CONNECTOR_AUTHTOKEN";
 const COMPUTER_CONNECTOR_SECRET_NAMES = [
   "COMPUTER_CONNECTOR_BRIDGE_TOKEN",
   "COMPUTER_CONNECTOR_DOMAIN_ID",
@@ -85,13 +88,6 @@ interface ExternalUserInfo {
 
 function parseOauthScopes(value: string | null): string[] | null {
   return value ? oauthScopesSchema.parse(JSON.parse(value)) : null;
-}
-
-function getSecretNameForConnector(type: ConnectorType): string {
-  if (type === "computer") {
-    return COMPUTER_CONNECTOR_AUTH_TOKEN_SECRET;
-  }
-  return PROVIDER_HANDLERS[type].getSecretName();
 }
 
 function storedConnectorRowToResponse(
@@ -797,13 +793,10 @@ async function upsertConnectorSecret(
 }
 
 function connectorTokenExpiresAt(args: {
-  readonly type: ConnectorType;
+  readonly isRefreshable: boolean;
   readonly expiresIn: number | undefined;
 }): Date | null {
-  const isRefreshable =
-    args.type !== "computer" &&
-    Boolean(PROVIDER_HANDLERS[args.type].refreshToken);
-  const fallbackSecs = isRefreshable
+  const fallbackSecs = args.isRefreshable
     ? DEFAULT_ACCESS_TOKEN_EXPIRES_IN_SECS
     : null;
   const expiresInSecs = args.expiresIn ?? fallbackSecs;
@@ -818,7 +811,7 @@ export const upsertOAuthConnector$ = command(
     args: {
       readonly orgId: string;
       readonly userId: string;
-      readonly type: ConnectorType;
+      readonly type: ConnectorOAuthProviderType;
       readonly accessToken: string;
       readonly userInfo: ExternalUserInfo;
       readonly oauthScopes: readonly string[];
@@ -832,8 +825,9 @@ export const upsertOAuthConnector$ = command(
     readonly created: boolean;
   }> => {
     const writeDb = set(writeDb$);
+    const handler = PROVIDER_HANDLERS[args.type];
     const tokenExpiresAt = connectorTokenExpiresAt({
-      type: args.type,
+      isRefreshable: providerSupportsRefresh(handler),
       expiresIn: args.expiresIn,
     });
     const apiTokenFields = getApiTokenFieldsByType(args.type);
@@ -855,7 +849,7 @@ export const upsertOAuthConnector$ = command(
     await upsertConnectorSecret(writeDb, {
       orgId: args.orgId,
       userId: args.userId,
-      name: getSecretNameForConnector(args.type),
+      name: handler.getSecretName(),
       value: args.accessToken,
       description: `OAuth token for ${args.type} connector`,
       featureSwitchContext,

--- a/turbo/apps/web/src/__tests__/api-test-helpers/connectors.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers/connectors.ts
@@ -1,4 +1,7 @@
-import type { ConnectorType } from "@vm0/connectors/connectors";
+import type {
+  ConnectorOAuthProviderType,
+  ConnectorType,
+} from "@vm0/connectors/connectors";
 import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { createTestOAuthConnectorRecord } from "../db-test-seeders/connectors";
 import { createTestSecret } from "./secrets";
@@ -53,7 +56,7 @@ async function createTestApiTokenConnector(options?: {
  * callback flow completes.
  */
 async function createTestOAuthConnector(options?: {
-  type?: Exclude<ConnectorType, "computer">;
+  type?: ConnectorOAuthProviderType;
   accessToken?: string;
   externalUsername?: string;
   externalId?: string | null;
@@ -83,21 +86,34 @@ async function createTestOAuthConnector(options?: {
  *
  * @param options - Connector configuration
  */
-export async function createTestConnector(options?: {
-  type?: Exclude<ConnectorType, "computer">;
-  authMethod?: "oauth" | "api-token";
-  accessToken?: string;
-  /** Secret name for api-token (e.g. "FIGMA_TOKEN"). Required for api-token. */
-  secretName?: string;
-  externalUsername?: string;
-  externalId?: string | null;
-  externalEmail?: string | null;
-  oauthScopes?: string[];
-  userId?: string;
-}): Promise<void> {
-  const authMethod = options?.authMethod ?? "oauth";
+type CreateTestConnectorOptions =
+  | {
+      type?: ConnectorOAuthProviderType;
+      authMethod?: "oauth";
+      accessToken?: string;
+      externalUsername?: string;
+      externalId?: string | null;
+      externalEmail?: string | null;
+      oauthScopes?: string[];
+      userId?: string;
+    }
+  | {
+      type?: ConnectorType;
+      authMethod: "api-token";
+      accessToken?: string;
+      /** Secret name for api-token (e.g. "FIGMA_TOKEN"). Required for api-token. */
+      secretName?: string;
+      externalUsername?: string;
+      externalId?: string | null;
+      externalEmail?: string | null;
+      oauthScopes?: string[];
+      userId?: string;
+    };
 
-  if (authMethod === "api-token") {
+export async function createTestConnector(
+  options?: CreateTestConnectorOptions,
+): Promise<void> {
+  if (options?.authMethod === "api-token") {
     await createTestApiTokenConnector(options);
   } else {
     await createTestOAuthConnector(options);

--- a/turbo/apps/web/src/__tests__/api-test-helpers/connectors.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers/connectors.ts
@@ -1,6 +1,6 @@
 import type {
-  ConnectorOAuthProviderType,
   ConnectorType,
+  OAuthConnectorType,
 } from "@vm0/connectors/connectors";
 import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
 import { createTestOAuthConnectorRecord } from "../db-test-seeders/connectors";
@@ -56,7 +56,7 @@ async function createTestApiTokenConnector(options?: {
  * callback flow completes.
  */
 async function createTestOAuthConnector(options?: {
-  type?: ConnectorOAuthProviderType;
+  type?: OAuthConnectorType;
   accessToken?: string;
   externalUsername?: string;
   externalId?: string | null;
@@ -88,7 +88,7 @@ async function createTestOAuthConnector(options?: {
  */
 type CreateTestConnectorOptions =
   | {
-      type?: ConnectorOAuthProviderType;
+      type?: OAuthConnectorType;
       authMethod?: "oauth";
       accessToken?: string;
       externalUsername?: string;

--- a/turbo/apps/web/src/__tests__/db-test-seeders/connectors.ts
+++ b/turbo/apps/web/src/__tests__/db-test-seeders/connectors.ts
@@ -1,4 +1,7 @@
-import type { ConnectorType } from "@vm0/connectors/connectors";
+import type {
+  ConnectorOAuthProviderType,
+  ConnectorType,
+} from "@vm0/connectors/connectors";
 import { initServices } from "../../lib/init-services";
 import { connectors } from "@vm0/db/schema/connector";
 import { userConnectors } from "@vm0/db/schema/user-connector";
@@ -71,7 +74,7 @@ export async function insertTestConnectorSecret(
 export async function createTestOAuthConnectorRecord(options: {
   orgId: string;
   userId: string;
-  type: Exclude<ConnectorType, "computer">;
+  type: ConnectorOAuthProviderType;
   accessToken: string;
   externalId: string;
   externalUsername: string;

--- a/turbo/apps/web/src/__tests__/db-test-seeders/connectors.ts
+++ b/turbo/apps/web/src/__tests__/db-test-seeders/connectors.ts
@@ -1,6 +1,6 @@
 import type {
-  ConnectorOAuthProviderType,
   ConnectorType,
+  OAuthConnectorType,
 } from "@vm0/connectors/connectors";
 import { initServices } from "../../lib/init-services";
 import { connectors } from "@vm0/db/schema/connector";
@@ -74,7 +74,7 @@ export async function insertTestConnectorSecret(
 export async function createTestOAuthConnectorRecord(options: {
   orgId: string;
   userId: string;
-  type: ConnectorOAuthProviderType;
+  type: OAuthConnectorType;
   accessToken: string;
   externalId: string;
   externalUsername: string;

--- a/turbo/apps/web/src/lib/zero/connector/connector-service.ts
+++ b/turbo/apps/web/src/lib/zero/connector/connector-service.ts
@@ -20,7 +20,7 @@ import { logger } from "../../shared/logger";
 import { getSecretValue, upsertSecretByOrg } from "../secret/secret-service";
 import {
   getConnectorOAuthProviderHandler,
-  isConnectorOAuthProviderType,
+  isOAuthConnectorType,
   PROVIDER_HANDLERS,
   providerEnvFromObject,
   providerSupportsRefresh,
@@ -69,7 +69,7 @@ function isConnectorOAuthHandler(
 function getRequiredConnectorOAuthHandler(
   type: ConnectorType,
 ): ConnectorProviderHandler {
-  if (!isConnectorOAuthProviderType(type)) {
+  if (!isOAuthConnectorType(type)) {
     throw new Error(`${type} connector does not use OAuth`);
   }
   return PROVIDER_HANDLERS[type];

--- a/turbo/apps/web/src/lib/zero/connector/connector-service.ts
+++ b/turbo/apps/web/src/lib/zero/connector/connector-service.ts
@@ -20,8 +20,6 @@ import { logger } from "../../shared/logger";
 import { getSecretValue, upsertSecretByOrg } from "../secret/secret-service";
 import {
   getConnectorOAuthProviderHandler,
-  isOAuthConnectorType,
-  PROVIDER_HANDLERS,
   providerEnvFromObject,
   providerSupportsRefresh,
   refreshProviderToken,
@@ -64,15 +62,6 @@ function isConnectorOAuthHandler(
   handler: OAuthHandler,
 ): handler is ConnectorProviderHandler {
   return "buildAuthUrl" in handler && "exchangeCode" in handler;
-}
-
-function getRequiredConnectorOAuthHandler(
-  type: ConnectorType,
-): ConnectorProviderHandler {
-  if (!isOAuthConnectorType(type)) {
-    throw new Error(`${type} connector does not use OAuth`);
-  }
-  return PROVIDER_HANDLERS[type];
 }
 
 function supportsOAuthRefresh(
@@ -471,8 +460,8 @@ export async function revokeConnectorToken(
 ): Promise<void> {
   if (type === "computer") return;
 
-  const handler = getRequiredConnectorOAuthHandler(type);
-  if (!handler.revokeToken) return;
+  const handler = getConnectorOAuthProviderHandler(type);
+  if (!handler?.revokeToken) return;
 
   const env = providerEnvFromObject(globalThis.services.env);
   const clientId = handler.getClientId(env);
@@ -548,8 +537,8 @@ export async function deleteConnector(
     );
 
     if (existing.authMethod === "oauth" && type !== "computer") {
-      const handler = getRequiredConnectorOAuthHandler(type);
-      const refreshSecretName = handler.getRefreshSecretName?.();
+      const refreshSecretName =
+        getConnectorOAuthProviderHandler(type)?.getRefreshSecretName?.();
       if (refreshSecretName) {
         secretNames.push(refreshSecretName);
       }

--- a/turbo/apps/web/src/lib/zero/connector/connector-service.ts
+++ b/turbo/apps/web/src/lib/zero/connector/connector-service.ts
@@ -19,8 +19,11 @@ import { notFound, badRequest } from "@vm0/api-services/errors";
 import { logger } from "../../shared/logger";
 import { getSecretValue, upsertSecretByOrg } from "../secret/secret-service";
 import {
+  getConnectorOAuthProviderHandler,
+  isConnectorOAuthProviderType,
   PROVIDER_HANDLERS,
   providerEnvFromObject,
+  providerSupportsRefresh,
   refreshProviderToken,
 } from "@vm0/connectors/oauth-providers";
 import type {
@@ -43,6 +46,9 @@ import { publishUserSignal } from "../../infra/realtime/client";
 export type OAuthSecretSource = "connector" | "model-provider";
 
 type OAuthHandler = ConnectorProviderHandler | ModelProviderOAuthHandler;
+type RefreshableOAuthHandler = OAuthHandler & {
+  getRefreshSecretName(): string;
+};
 
 function getOAuthHandler(
   handlerKey: string,
@@ -51,13 +57,35 @@ function getOAuthHandler(
   if (sourceType === "model-provider") {
     return getModelProviderOAuthHandler(handlerKey);
   }
-  return PROVIDER_HANDLERS[handlerKey as keyof typeof PROVIDER_HANDLERS];
+  return getConnectorOAuthProviderHandler(handlerKey);
 }
 
 function isConnectorOAuthHandler(
   handler: OAuthHandler,
 ): handler is ConnectorProviderHandler {
   return "buildAuthUrl" in handler && "exchangeCode" in handler;
+}
+
+function getRequiredConnectorOAuthHandler(
+  type: ConnectorType,
+): ConnectorProviderHandler {
+  if (!isConnectorOAuthProviderType(type)) {
+    throw new Error(`${type} connector does not use OAuth`);
+  }
+  return PROVIDER_HANDLERS[type];
+}
+
+function supportsOAuthRefresh(
+  handler: OAuthHandler | undefined,
+  sourceType: OAuthSecretSource,
+): handler is RefreshableOAuthHandler {
+  if (!handler?.getRefreshSecretName) {
+    return false;
+  }
+  if (sourceType === "model-provider") {
+    return Boolean(handler.refreshToken || handler.refreshTokenWithArgs);
+  }
+  return isConnectorOAuthHandler(handler) && providerSupportsRefresh(handler);
 }
 
 interface OAuthClientCredentials {
@@ -443,7 +471,7 @@ export async function revokeConnectorToken(
 ): Promise<void> {
   if (type === "computer") return;
 
-  const handler = PROVIDER_HANDLERS[type as Exclude<ConnectorType, "computer">];
+  const handler = getRequiredConnectorOAuthHandler(type);
   if (!handler.revokeToken) return;
 
   const env = providerEnvFromObject(globalThis.services.env);
@@ -520,8 +548,7 @@ export async function deleteConnector(
     );
 
     if (existing.authMethod === "oauth" && type !== "computer") {
-      const handler =
-        PROVIDER_HANDLERS[type as Exclude<ConnectorType, "computer">];
+      const handler = getRequiredConnectorOAuthHandler(type);
       const refreshSecretName = handler.getRefreshSecretName?.();
       if (refreshSecretName) {
         secretNames.push(refreshSecretName);
@@ -590,7 +617,7 @@ export async function deleteConnector(
 
 /**
  * Generic connector access token refresh.
- * Looks up the connector's handler from PROVIDER_HANDLERS, calls its refreshToken
+ * Looks up the connector's OAuth handler, calls its refreshToken
  * method, persists new tokens, and updates the in-memory secrets map.
  *
  * `sourceType` selects which DB rows to read/write:
@@ -615,10 +642,7 @@ export async function refreshConnectorAccessToken(
 ): Promise<string | null> {
   const sourceType: OAuthSecretSource = options.sourceType ?? "connector";
   const handler = getOAuthHandler(connectorType, sourceType);
-  if (
-    !handler?.getRefreshSecretName ||
-    (!handler.refreshToken && !handler.refreshTokenWithArgs)
-  ) {
+  if (!supportsOAuthRefresh(handler, sourceType)) {
     return null;
   }
   if (sourceType === "model-provider" && !options.metadataKey) {

--- a/turbo/apps/web/src/lib/zero/context/resolve-connectors.ts
+++ b/turbo/apps/web/src/lib/zero/context/resolve-connectors.ts
@@ -6,7 +6,10 @@ import {
 import { and, eq } from "drizzle-orm";
 import { logger } from "../../shared/logger";
 import { connectors } from "@vm0/db/schema/connector";
-import { PROVIDER_HANDLERS } from "@vm0/connectors/oauth-providers";
+import {
+  getConnectorOAuthProviderHandler,
+  providerSupportsRefresh,
+} from "@vm0/connectors/oauth-providers";
 import { getSecretValues } from "../secret/secret-service";
 
 const log = logger("zero:build-context");
@@ -108,9 +111,8 @@ export async function resolveOauthConnectorSecrets(
   // reference either form.
   const secretConnectorMap: Record<string, string> = {};
   for (const { type } of allowedConnectors) {
-    if (!(type in PROVIDER_HANDLERS)) continue;
-    const handler = PROVIDER_HANDLERS[type as keyof typeof PROVIDER_HANDLERS];
-    if (!handler.refreshToken) continue;
+    const handler = getConnectorOAuthProviderHandler(type);
+    if (!handler || !providerSupportsRefresh(handler)) continue;
 
     const secretName = handler.getSecretName();
     secretConnectorMap[secretName] = type;

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -21,7 +21,7 @@ import {
 } from "../connector-utils";
 import { FeatureSwitchKey } from "../feature-switch-key";
 import {
-  isConnectorOAuthProviderType,
+  isOAuthConnectorType,
   PROVIDER_HANDLERS,
 } from "../oauth-providers/provider-registry";
 
@@ -124,7 +124,7 @@ describe("PROVIDER_HANDLERS", () => {
     expect(providerHandlerTypes).toEqual(oauthConnectorTypes);
 
     for (const type of connectorTypeSchema.options) {
-      expect(isConnectorOAuthProviderType(type)).toBe(
+      expect(isOAuthConnectorType(type)).toBe(
         oauthConnectorTypes.includes(type),
       );
     }

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { connectorTypeSchema } from "../connectors";
+import { CONNECTOR_TYPES, connectorTypeSchema } from "../connectors";
 import {
   getApiTokenFieldStorageType,
   getAvailableConnectorAuthMethods,
@@ -20,6 +20,10 @@ import {
   resolveConnectorOAuthClientCredentials,
 } from "../connector-utils";
 import { FeatureSwitchKey } from "../feature-switch-key";
+import {
+  isConnectorOAuthProviderType,
+  PROVIDER_HANDLERS,
+} from "../oauth-providers/provider-registry";
 
 describe("hasRequiredScopes", () => {
   it("returns true for non-OAuth connector type", () => {
@@ -105,6 +109,25 @@ describe("connector auth method config", () => {
     expect(getApiTokenFieldStorageType("zendesk", "UNKNOWN_FIELD")).toBe(
       "secret",
     );
+  });
+});
+
+describe("PROVIDER_HANDLERS", () => {
+  it("contains exactly the connector types that declare OAuth auth", () => {
+    const oauthConnectorTypes = connectorTypeSchema.options
+      .filter((type) => {
+        return "oauth" in CONNECTOR_TYPES[type].authMethods;
+      })
+      .sort();
+    const providerHandlerTypes = Object.keys(PROVIDER_HANDLERS).sort();
+
+    expect(providerHandlerTypes).toEqual(oauthConnectorTypes);
+
+    for (const type of connectorTypeSchema.options) {
+      expect(isConnectorOAuthProviderType(type)).toBe(
+        oauthConnectorTypes.includes(type),
+      );
+    }
   });
 });
 

--- a/turbo/packages/connectors/src/connectors.ts
+++ b/turbo/packages/connectors/src/connectors.ts
@@ -721,6 +721,11 @@ const CONNECTOR_TYPES_DEF = {
 } as const satisfies Record<string, ConnectorConfig>;
 
 export type ConnectorType = keyof typeof CONNECTOR_TYPES_DEF;
+export type ConnectorOAuthProviderType = {
+  [Type in ConnectorType]: "oauth" extends keyof (typeof CONNECTOR_TYPES_DEF)[Type]["authMethods"]
+    ? Type
+    : never;
+}[ConnectorType];
 export type ConnectorCliAuthConnectorType = {
   [Type in ConnectorType]: "cli-auth" extends keyof (typeof CONNECTOR_TYPES_DEF)[Type]["authMethods"]
     ? Type

--- a/turbo/packages/connectors/src/connectors.ts
+++ b/turbo/packages/connectors/src/connectors.ts
@@ -721,7 +721,7 @@ const CONNECTOR_TYPES_DEF = {
 } as const satisfies Record<string, ConnectorConfig>;
 
 export type ConnectorType = keyof typeof CONNECTOR_TYPES_DEF;
-export type ConnectorOAuthProviderType = {
+export type OAuthConnectorType = {
   [Type in ConnectorType]: "oauth" extends keyof (typeof CONNECTOR_TYPES_DEF)[Type]["authMethods"]
     ? Type
     : never;

--- a/turbo/packages/connectors/src/oauth-providers/provider-registry.ts
+++ b/turbo/packages/connectors/src/oauth-providers/provider-registry.ts
@@ -131,16 +131,14 @@ export const PROVIDER_HANDLERS = {
 
 export type ConnectorOAuthProviderHandler = ProviderHandler;
 
-export function isConnectorOAuthProviderType(
-  type: string,
-): type is OAuthConnectorType {
+export function isOAuthConnectorType(type: string): type is OAuthConnectorType {
   return Object.hasOwn(PROVIDER_HANDLERS, type);
 }
 
 export function getConnectorOAuthProviderHandler(
   type: string,
 ): ConnectorOAuthProviderHandler | undefined {
-  if (!isConnectorOAuthProviderType(type)) {
+  if (!isOAuthConnectorType(type)) {
     return undefined;
   }
   return PROVIDER_HANDLERS[type];

--- a/turbo/packages/connectors/src/oauth-providers/provider-registry.ts
+++ b/turbo/packages/connectors/src/oauth-providers/provider-registry.ts
@@ -1,4 +1,7 @@
-import type { ConnectorType } from "@vm0/connectors/connectors";
+import type {
+  ConnectorOAuthProviderType,
+  ConnectorType,
+} from "@vm0/connectors/connectors";
 import { getRuntimeAvailableConnectorTypes as getRuntimeAvailableConnectorTypesFromEnv } from "@vm0/connectors/connector-utils";
 import {
   type AuthUrlResult,
@@ -10,229 +13,56 @@ import {
   exchangeProviderCode,
   refreshProviderToken,
   providerEnvFromObject,
+  providerSupportsRefresh,
   type OAuthTokenResult,
   type ProviderHandler,
   type ProviderEnv,
 } from "./provider-types";
-import { agentmailHandler } from "./providers/agentmail-handler";
-import { amplitudeHandler } from "./providers/amplitude-handler";
-import { anthropicManagedAgentsHandler } from "./providers/anthropic-managed-agents-handler";
 import { ahrefsHandler } from "./providers/ahrefs-handler";
-import { agoraHandler } from "./providers/agora-handler";
 import { airtableHandler } from "./providers/airtable-handler";
-import { apolloHandler } from "./providers/apollo-handler";
-import { apifyHandler } from "./providers/apify-handler";
-import { pikaHandler } from "./providers/pika-handler";
-import { axiomHandler } from "./providers/axiom-handler";
 import { asanaHandler } from "./providers/asana-handler";
-import { attioHandler } from "./providers/attio-handler";
-import { atlassianHandler } from "./providers/atlassian-handler";
-import { atlascloudHandler } from "./providers/atlascloud-handler";
-import { aviationstackHandler } from "./providers/aviationstack-handler";
-import { bentomlHandler } from "./providers/bentoml-handler";
-import { bitrixHandler } from "./providers/bitrix-handler";
-import { braveSearchHandler } from "./providers/brave-search-handler";
-import { brexHandler } from "./providers/brex-handler";
-import { brevoHandler } from "./providers/brevo-handler";
-import { brightDataHandler } from "./providers/bright-data-handler";
-import { browserbaseHandler } from "./providers/browserbase-handler";
-import { browserUseHandler } from "./providers/browser-use-handler";
-import { browserlessHandler } from "./providers/browserless-handler";
-import { bufferHandler } from "./providers/buffer-handler";
-import { builtwithHandler } from "./providers/builtwith-handler";
-import { calComHandler } from "./providers/cal-com-handler";
-import { calendlyHandler } from "./providers/calendly-handler";
 import { canvaHandler } from "./providers/canva-handler";
-import { chatwootHandler } from "./providers/chatwoot-handler";
-import { checkrHandler } from "./providers/checkr-handler";
-import { cladoHandler } from "./providers/clado-handler";
-import { clerkHandler } from "./providers/clerk-handler";
-import { clickupHandler } from "./providers/clickup-handler";
-import { cloudflareHandler } from "./providers/cloudflare-handler";
-import { cloudinaryHandler } from "./providers/cloudinary-handler";
 import { closeHandler } from "./providers/close-handler";
-import { codaHandler } from "./providers/coda-handler";
-import { cronlyticHandler } from "./providers/cronlytic-handler";
-import { customerIoHandler } from "./providers/customer-io-handler";
 import { deelHandler } from "./providers/deel-handler";
-import { discordHandler } from "./providers/discord-handler";
-import { discordWebhookHandler } from "./providers/discord-webhook-handler";
-import { deepseekHandler } from "./providers/deepseek-handler";
-import { doubaoHandler } from "./providers/doubao-handler";
-import { difyHandler } from "./providers/dify-handler";
-import { devtoHandler } from "./providers/devto-handler";
-import { diffbotHandler } from "./providers/diffbot-handler";
-import { dopplerHandler } from "./providers/doppler-handler";
-import { infisicalHandler } from "./providers/infisical-handler";
 import { docusignHandler } from "./providers/docusign-handler";
-import { db9Handler } from "./providers/db9-handler";
-import { drive9Handler } from "./providers/drive9-handler";
 import { dropboxHandler } from "./providers/dropbox-handler";
-import { dropboxSignHandler } from "./providers/dropbox-sign-handler";
-import { duffelHandler } from "./providers/duffel-handler";
-import { e2bHandler } from "./providers/e2b-handler";
-import { elevenlabsHandler } from "./providers/elevenlabs-handler";
-import { etsyHandler } from "./providers/etsy-handler";
-import { exaHandler } from "./providers/exa-handler";
-import { exploriumHandler } from "./providers/explorium-handler";
-import { faireHandler } from "./providers/faire-handler";
-import { falHandler } from "./providers/fal-handler";
 import { figmaHandler } from "./providers/figma-handler";
-import { firefliesHandler } from "./providers/fireflies-handler";
-import { firecrawlHandler } from "./providers/firecrawl-handler";
-import { freshdeskHandler } from "./providers/freshdesk-handler";
-import { gammaHandler } from "./providers/gamma-handler";
 import { garminConnectHandler } from "./providers/garmin-connect-handler";
-import { geminiHandler } from "./providers/gemini-handler";
-import { gitlabHandler } from "./providers/gitlab-handler";
-import { granolaHandler } from "./providers/granola-handler";
-import { greenhouseHandler } from "./providers/greenhouse-handler";
-import { groqHandler } from "./providers/groq-handler";
 import { gumroadHandler } from "./providers/gumroad-handler";
 import { githubHandler } from "./providers/github-handler";
-import { heygenHandler } from "./providers/heygen-handler";
-import { heliconeHandler } from "./providers/helicone-handler";
-import { huggingFaceHandler } from "./providers/hugging-face-handler";
-import { humeHandler } from "./providers/hume-handler";
-import { hunterHandler } from "./providers/hunter-handler";
-import { htmlcsstoimageHandler } from "./providers/htmlcsstoimage-handler";
-import { hubspotHandler } from "./providers/hubspot-handler";
-import { imgurHandler } from "./providers/imgur-handler";
-import { instagramHandler } from "./providers/instagram-handler";
 import { gmailHandler } from "./providers/gmail-handler";
+import { hubspotHandler } from "./providers/hubspot-handler";
 import { googleAdsHandler } from "./providers/google-ads-handler";
-import { googleMapsHandler } from "./providers/google-maps-handler";
 import { googleCalendarHandler } from "./providers/google-calendar-handler";
 import { googleDocsHandler } from "./providers/google-docs-handler";
 import { googleDriveHandler } from "./providers/google-drive-handler";
 import { googleMeetHandler } from "./providers/google-meet-handler";
 import { googleSheetsHandler } from "./providers/google-sheets-handler";
-import { instantlyHandler } from "./providers/instantly-handler";
-import { intercomHandler } from "./providers/intercom-handler";
-import { jamHandler } from "./providers/jam-handler";
-import { jiraHandler } from "./providers/jira-handler";
-import { jotformHandler } from "./providers/jotform-handler";
-import { klaviyoHandler } from "./providers/klaviyo-handler";
-import { kommoHandler } from "./providers/kommo-handler";
-import { larkHandler } from "./providers/lark-handler";
-import { langfuseHandler } from "./providers/langfuse-handler";
-import { langsmithHandler } from "./providers/langsmith-handler";
-import { lineHandler } from "./providers/line-handler";
 import { linearHandler } from "./providers/linear-handler";
-import { localBrowserHandler } from "./providers/local-browser-handler";
-import { loopsHandler } from "./providers/loops-handler";
-import { lumaHandler } from "./providers/luma-handler";
-import { lumaAiHandler } from "./providers/luma-ai-handler";
-import { mailsacHandler } from "./providers/mailsac-handler";
-import { makeHandler } from "./providers/make-handler";
-import { manusHandler } from "./providers/manus-handler";
-import { mapboxHandler } from "./providers/mapbox-handler";
-import { mathpixHandler } from "./providers/mathpix-handler";
-import { mem0Handler } from "./providers/mem0-handler";
-import { supermemoryHandler } from "./providers/supermemory-handler";
-import { metabaseHandler } from "./providers/metabase-handler";
-import { mossHandler } from "./providers/moss-handler";
+import { mailchimpHandler } from "./providers/mailchimp-handler";
 import { mercuryHandler } from "./providers/mercury-handler";
-import { minioHandler } from "./providers/minio-handler";
-import { minimaxHandler } from "./providers/minimax-handler";
-import { miroHandler } from "./providers/miro-handler";
-import { mixpanelHandler } from "./providers/mixpanel-handler";
 import { mondayHandler } from "./providers/monday-handler";
-import { msg9Handler } from "./providers/msg9-handler";
 import { neonHandler } from "./providers/neon-handler";
 import { notionHandler } from "./providers/notion-handler";
-import { nyneHandler } from "./providers/nyne-handler";
-import { onyxHandler } from "./providers/onyx-handler";
-import { openaiHandler } from "./providers/openai-handler";
-import { openrouterHandler } from "./providers/openrouter-handler";
-import { openweatherHandler } from "./providers/openweather-handler";
-import { railwayHandler } from "./providers/railway-handler";
-import { railwayProjectHandler } from "./providers/railway-project-handler";
+import { outlookCalendarHandler } from "./providers/outlook-calendar-handler";
+import { outlookMailHandler } from "./providers/outlook-mail-handler";
 import { redditHandler } from "./providers/reddit-handler";
-import { reapHandler } from "./providers/reap-handler";
-import { reductoHandler } from "./providers/reducto-handler";
-import { localAgentHandler } from "./providers/local-agent-handler";
-import { reporteiHandler } from "./providers/reportei-handler";
-import { segmentHandler } from "./providers/segment-handler";
-import { serpapiHandler } from "./providers/serpapi-handler";
-import { runwayHandler } from "./providers/runway-handler";
-import { salesforceHandler } from "./providers/salesforce-handler";
-import { shopifyHandler } from "./providers/shopify-handler";
-import { shortioHandler } from "./providers/shortio-handler";
-import { stabilityAiHandler } from "./providers/stability-ai-handler";
-import { strapiHandler } from "./providers/strapi-handler";
-import { streakHandler } from "./providers/streak-handler";
-import { supadataHandler } from "./providers/supadata-handler";
-import { tavilyHandler } from "./providers/tavily-handler";
-import { tldvHandler } from "./providers/tldv-handler";
-import { togetherHandler } from "./providers/together-handler";
-import { twentyHandler } from "./providers/twenty-handler";
-import { typeformHandler } from "./providers/typeform-handler";
-import { youtubeHandler } from "./providers/youtube-handler";
-import { zapierHandler } from "./providers/zapier-handler";
-import { zapsignHandler } from "./providers/zapsign-handler";
-import { zendeskHandler } from "./providers/zendesk-handler";
+import { intervalsIcuHandler } from "./providers/intervals-icu-handler";
+import { sentryHandler } from "./providers/sentry-handler";
 import { slackHandler } from "./providers/slack-handler";
 import { stravaHandler } from "./providers/strava-handler";
 import { stripeHandler } from "./providers/stripe-handler";
-import { intervalsIcuHandler } from "./providers/intervals-icu-handler";
-import { sentryHandler } from "./providers/sentry-handler";
-import { vercelHandler } from "./providers/vercel-handler";
-import { xHandler } from "./providers/x-handler";
-import { supabaseHandler } from "./providers/supabase-handler";
-import { mailchimpHandler } from "./providers/mailchimp-handler";
 import { todoistHandler } from "./providers/todoist-handler";
+import { vercelHandler } from "./providers/vercel-handler";
 import { webflowHandler } from "./providers/webflow-handler";
-import { wereadHandler } from "./providers/weread-handler";
-import { outlookCalendarHandler } from "./providers/outlook-calendar-handler";
-import { outlookMailHandler } from "./providers/outlook-mail-handler";
+import { supabaseHandler } from "./providers/supabase-handler";
 import { metaAdsHandler } from "./providers/meta-ads-handler";
 import { posthogHandler } from "./providers/posthog-handler";
-import { prismaPostgresHandler } from "./providers/prisma-postgres-handler";
-import { pdf4meHandler } from "./providers/pdf4me-handler";
-import { pandadocHandler } from "./providers/pandadoc-handler";
-import { pdfcoHandler } from "./providers/pdfco-handler";
-import { perplexityHandler } from "./providers/perplexity-handler";
-import { pineconeHandler } from "./providers/pinecone-handler";
-import { pipedriveHandler } from "./providers/pipedrive-handler";
-import { pushinatorHandler } from "./providers/pushinator-handler";
-import { plainHandler } from "./providers/plain-handler";
-import { plausibleHandler } from "./providers/plausible-handler";
-import { podchaserHandler } from "./providers/podchaser-handler";
-import { productlaneHandler } from "./providers/productlane-handler";
-import { qdrantHandler } from "./providers/qdrant-handler";
-import { qiitaHandler } from "./providers/qiita-handler";
-import { replicateHandler } from "./providers/replicate-handler";
-import { resendHandler } from "./providers/resend-handler";
-import { revenuecatHandler } from "./providers/revenuecat-handler";
-import { scrapeninjaHandler } from "./providers/scrapeninja-handler";
-import { similarwebHandler } from "./providers/similarweb-handler";
-import { spongeHandler } from "./providers/sponge-handler";
-import { sproutgigsHandler } from "./providers/sproutgigs-handler";
 import { spotifyHandler } from "./providers/spotify-handler";
-import { workosHandler } from "./providers/workos-handler";
-import { wrikeHandler } from "./providers/wrike-handler";
+import { xHandler } from "./providers/x-handler";
 import { xeroHandler } from "./providers/xero-handler";
-import { pdforgeHandler } from "./providers/pdforge-handler";
-import { slackWebhookHandler } from "./providers/slack-webhook-handler";
-import { v0Handler } from "./providers/v0-handler";
-import { wixHandler } from "./providers/wix-handler";
-import { zepHandler } from "./providers/zep-handler";
-import { zeptomailHandler } from "./providers/zeptomail-handler";
 import { zoomHandler } from "./providers/zoom-handler";
-import { n8nHandler } from "./providers/n8n-handler";
 import { testOauthHandler } from "./providers/test-oauth-handler";
-import { wandbHandler } from "./providers/wandb-handler";
-import { altium365Handler } from "./providers/altium-365-handler";
-import { browserstackHandler } from "./providers/browserstack-handler";
-import { sendgridHandler } from "./providers/sendgrid-handler";
-import { servicenowHandler } from "./providers/servicenow-handler";
-import { testrailHandler } from "./providers/testrail-handler";
-import { twilioHandler } from "./providers/twilio-handler";
-import { squareHandler } from "./providers/square-handler";
-import { gongHandler } from "./providers/gong-handler";
-import { ironcladHandler } from "./providers/ironclad-handler";
-import { snowflakeHandler } from "./providers/snowflake-handler";
 
 export type {
   AuthUrlResult,
@@ -247,233 +77,74 @@ export {
   buildProviderAuthUrl,
   exchangeProviderCode,
   providerEnvFromObject,
+  providerSupportsRefresh,
   refreshProviderToken,
 };
 
-export const PROVIDER_HANDLERS: Record<
-  Exclude<ConnectorType, "computer">,
-  ProviderHandler
-> = {
-  agentmail: agentmailHandler,
-  amplitude: amplitudeHandler,
-  "anthropic-managed-agents": anthropicManagedAgentsHandler,
+export const PROVIDER_HANDLERS = {
   ahrefs: ahrefsHandler,
-  agora: agoraHandler,
   airtable: airtableHandler,
-  apollo: apolloHandler,
-  apify: apifyHandler,
-  pika: pikaHandler,
-  axiom: axiomHandler,
   asana: asanaHandler,
-  attio: attioHandler,
-  atlassian: atlassianHandler,
-  atlascloud: atlascloudHandler,
-  bentoml: bentomlHandler,
-  bitrix: bitrixHandler,
-  "brave-search": braveSearchHandler,
-  brex: brexHandler,
-  brevo: brevoHandler,
-  "bright-data": brightDataHandler,
-  browserbase: browserbaseHandler,
-  "browser-use": browserUseHandler,
-  browserless: browserlessHandler,
-  buffer: bufferHandler,
-  "cal-com": calComHandler,
-  calendly: calendlyHandler,
   canva: canvaHandler,
-  chatwoot: chatwootHandler,
-  checkr: checkrHandler,
-  clerk: clerkHandler,
-  clickup: clickupHandler,
-  cloudflare: cloudflareHandler,
-  cloudinary: cloudinaryHandler,
   close: closeHandler,
-  coda: codaHandler,
-  cronlytic: cronlyticHandler,
-  "customer-io": customerIoHandler,
   deel: deelHandler,
-  discord: discordHandler,
-  "discord-webhook": discordWebhookHandler,
-  deepseek: deepseekHandler,
-  doubao: doubaoHandler,
-  dify: difyHandler,
-  devto: devtoHandler,
-  doppler: dopplerHandler,
-  infisical: infisicalHandler,
   docusign: docusignHandler,
-  db9: db9Handler,
-  drive9: drive9Handler,
   dropbox: dropboxHandler,
-  "dropbox-sign": dropboxSignHandler,
-  duffel: duffelHandler,
-  e2b: e2bHandler,
-  elevenlabs: elevenlabsHandler,
-  etsy: etsyHandler,
-  exa: exaHandler,
-  explorium: exploriumHandler,
-  faire: faireHandler,
-  fal: falHandler,
   figma: figmaHandler,
-  fireflies: firefliesHandler,
-  firecrawl: firecrawlHandler,
-  freshdesk: freshdeskHandler,
-  gamma: gammaHandler,
   "garmin-connect": garminConnectHandler,
-  gemini: geminiHandler,
-  gitlab: gitlabHandler,
-  granola: granolaHandler,
-  greenhouse: greenhouseHandler,
-  groq: groqHandler,
   gumroad: gumroadHandler,
   github: githubHandler,
   gmail: gmailHandler,
-  heygen: heygenHandler,
-  helicone: heliconeHandler,
-  "hugging-face": huggingFaceHandler,
-  hume: humeHandler,
-  htmlcsstoimage: htmlcsstoimageHandler,
   hubspot: hubspotHandler,
-  imgur: imgurHandler,
-  instantly: instantlyHandler,
-  instagram: instagramHandler,
   "google-ads": googleAdsHandler,
   "google-calendar": googleCalendarHandler,
   "google-docs": googleDocsHandler,
   "google-drive": googleDriveHandler,
   "google-meet": googleMeetHandler,
   "google-sheets": googleSheetsHandler,
-  lark: larkHandler,
-  langfuse: langfuseHandler,
-  langsmith: langsmithHandler,
-  line: lineHandler,
   linear: linearHandler,
-  loops: loopsHandler,
-  luma: lumaHandler,
-  "luma-ai": lumaAiHandler,
-  mailsac: mailsacHandler,
-  make: makeHandler,
-  manus: manusHandler,
-  mem0: mem0Handler,
-  supermemory: supermemoryHandler,
-  metabase: metabaseHandler,
-  moss: mossHandler,
   mailchimp: mailchimpHandler,
   mercury: mercuryHandler,
-  minio: minioHandler,
-  minimax: minimaxHandler,
-  miro: miroHandler,
-  mixpanel: mixpanelHandler,
   monday: mondayHandler,
-  msg9: msg9Handler,
   neon: neonHandler,
   notion: notionHandler,
-  onyx: onyxHandler,
-  openai: openaiHandler,
   "outlook-calendar": outlookCalendarHandler,
   "outlook-mail": outlookMailHandler,
-  railway: railwayHandler,
-  "railway-project": railwayProjectHandler,
   reddit: redditHandler,
-  reap: reapHandler,
-  "local-browser": localBrowserHandler,
-  "local-agent": localAgentHandler,
-  reportei: reporteiHandler,
-  segment: segmentHandler,
-  serpapi: serpapiHandler,
-  intercom: intercomHandler,
-  jam: jamHandler,
-  jira: jiraHandler,
-  jotform: jotformHandler,
-  klaviyo: klaviyoHandler,
-  kommo: kommoHandler,
   "intervals-icu": intervalsIcuHandler,
   sentry: sentryHandler,
   slack: slackHandler,
-  strapi: strapiHandler,
   strava: stravaHandler,
   stripe: stripeHandler,
   todoist: todoistHandler,
   vercel: vercelHandler,
   webflow: webflowHandler,
-  weread: wereadHandler,
   supabase: supabaseHandler,
   "meta-ads": metaAdsHandler,
   posthog: posthogHandler,
-  "prisma-postgres": prismaPostgresHandler,
-  pandadoc: pandadocHandler,
-  pdf4me: pdf4meHandler,
-  pdfco: pdfcoHandler,
-  perplexity: perplexityHandler,
-  pinecone: pineconeHandler,
-  pipedrive: pipedriveHandler,
-  plain: plainHandler,
-  plausible: plausibleHandler,
-  podchaser: podchaserHandler,
-  productlane: productlaneHandler,
-  pushinator: pushinatorHandler,
-  qdrant: qdrantHandler,
-  qiita: qiitaHandler,
-  replicate: replicateHandler,
-  resend: resendHandler,
-  revenuecat: revenuecatHandler,
-  scrapeninja: scrapeninjaHandler,
-  similarweb: similarwebHandler,
-  sponge: spongeHandler,
-  sproutgigs: sproutgigsHandler,
   spotify: spotifyHandler,
-  workos: workosHandler,
-  wrike: wrikeHandler,
   x: xHandler,
   xero: xeroHandler,
-  zep: zepHandler,
-  zeptomail: zeptomailHandler,
-  runway: runwayHandler,
-  salesforce: salesforceHandler,
-  shopify: shopifyHandler,
-  shortio: shortioHandler,
-  "stability-ai": stabilityAiHandler,
-  streak: streakHandler,
-  supadata: supadataHandler,
-  tavily: tavilyHandler,
-  tldv: tldvHandler,
-  together: togetherHandler,
-  twenty: twentyHandler,
-  typeform: typeformHandler,
-  youtube: youtubeHandler,
-  zapier: zapierHandler,
-  zapsign: zapsignHandler,
-  zendesk: zendeskHandler,
   zoom: zoomHandler,
-  pdforge: pdforgeHandler,
-  "slack-webhook": slackWebhookHandler,
-  v0: v0Handler,
-  wix: wixHandler,
-  n8n: n8nHandler,
   "test-oauth": testOauthHandler,
-  wandb: wandbHandler,
-  "altium-365": altium365Handler,
-  browserstack: browserstackHandler,
-  sendgrid: sendgridHandler,
-  servicenow: servicenowHandler,
-  testrail: testrailHandler,
-  twilio: twilioHandler,
-  square: squareHandler,
-  gong: gongHandler,
-  ironclad: ironcladHandler,
-  snowflake: snowflakeHandler,
-  aviationstack: aviationstackHandler,
-  builtwith: builtwithHandler,
-  clado: cladoHandler,
-  diffbot: diffbotHandler,
-  "google-maps": googleMapsHandler,
-  hunter: hunterHandler,
-  mapbox: mapboxHandler,
-  mathpix: mathpixHandler,
-  nyne: nyneHandler,
-  openrouter: openrouterHandler,
-  openweather: openweatherHandler,
-  reducto: reductoHandler,
-};
+} satisfies Record<ConnectorOAuthProviderType, ProviderHandler>;
+
+export type ConnectorOAuthProviderHandler = ProviderHandler;
+
+export function isConnectorOAuthProviderType(
+  type: string,
+): type is ConnectorOAuthProviderType {
+  return Object.hasOwn(PROVIDER_HANDLERS, type);
+}
+
+export function getConnectorOAuthProviderHandler(
+  type: string,
+): ConnectorOAuthProviderHandler | undefined {
+  if (!isConnectorOAuthProviderType(type)) {
+    return undefined;
+  }
+  return PROVIDER_HANDLERS[type];
+}
 
 /**
  * Returns connector types the current runtime environment can offer as

--- a/turbo/packages/connectors/src/oauth-providers/provider-registry.ts
+++ b/turbo/packages/connectors/src/oauth-providers/provider-registry.ts
@@ -1,6 +1,6 @@
 import type {
-  ConnectorOAuthProviderType,
   ConnectorType,
+  OAuthConnectorType,
 } from "@vm0/connectors/connectors";
 import { getRuntimeAvailableConnectorTypes as getRuntimeAvailableConnectorTypesFromEnv } from "@vm0/connectors/connector-utils";
 import {
@@ -127,13 +127,13 @@ export const PROVIDER_HANDLERS = {
   xero: xeroHandler,
   zoom: zoomHandler,
   "test-oauth": testOauthHandler,
-} satisfies Record<ConnectorOAuthProviderType, ProviderHandler>;
+} satisfies Record<OAuthConnectorType, ProviderHandler>;
 
 export type ConnectorOAuthProviderHandler = ProviderHandler;
 
 export function isConnectorOAuthProviderType(
   type: string,
-): type is ConnectorOAuthProviderType {
+): type is OAuthConnectorType {
   return Object.hasOwn(PROVIDER_HANDLERS, type);
 }
 

--- a/turbo/packages/connectors/src/oauth-providers/provider-types.ts
+++ b/turbo/packages/connectors/src/oauth-providers/provider-types.ts
@@ -111,6 +111,10 @@ export interface ModelProviderRefreshHandler {
   refreshTokenWithArgs?(args: OAuthRefreshArgs): Promise<OAuthRefreshResult>;
 }
 
+export function providerSupportsRefresh(handler: ProviderHandler): boolean {
+  return Boolean(handler.refreshToken || handler.refreshTokenWithArgs);
+}
+
 export async function buildProviderAuthUrl(
   handler: ProviderHandler,
   args: OAuthAuthorizeArgs,


### PR DESCRIPTION
## Summary
- restrict `PROVIDER_HANDLERS` to connector types that declare OAuth auth
- add `OAuthConnectorType` and registry helpers for typed OAuth handler access
- update API/web OAuth call sites to narrow runtime connector types before using provider handlers
- add regression coverage that registry keys exactly match OAuth connector config

Fixes #14168

## Verification
- `pnpm -F @vm0/connectors check-types`
- `pnpm -F api check-types`
- `pnpm -F web check-types`
- `pnpm -F @vm0/connectors exec vitest run src/__tests__/connectors.test.ts`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-connectors-authorize.test.ts src/signals/routes/__tests__/connectors-type-callback.test.ts src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts`
- `pnpm -F web exec vitest run src/lib/zero/__tests__/build-zero-context.test.ts src/lib/zero/__tests__/handler-key-bridge.test.ts src/lib/zero/__tests__/secret-connector-map-filter.test.ts`
- pre-commit hook: prettier, knip, monorepo `pnpm check-types`
