### PR TITLE
fix: restore desktop window after close

### DIFF
--- a/turbo/apps/desktop/src/desktop-window-lifecycle.test.ts
+++ b/turbo/apps/desktop/src/desktop-window-lifecycle.test.ts
@@ -1,0 +1,58 @@
+import {
+  shouldHideMainWindowOnClose,
+  showAndFocusWindow,
+} from "./desktop-window-lifecycle";
+
+describe("desktop window lifecycle", () => {
+  it("hides the main window on macOS close unless the app is quitting", () => {
+    expect(
+      shouldHideMainWindowOnClose({ platform: "darwin", isQuitting: false }),
+    ).toBe(true);
+    expect(
+      shouldHideMainWindowOnClose({ platform: "darwin", isQuitting: true }),
+    ).toBe(false);
+    expect(
+      shouldHideMainWindowOnClose({ platform: "linux", isQuitting: false }),
+    ).toBe(false);
+  });
+
+  it("restores, shows, and focuses a hidden minimized window", () => {
+    const window = {
+      isMinimized: vi.fn(() => {
+        return true;
+      }),
+      isVisible: vi.fn(() => {
+        return false;
+      }),
+      restore: vi.fn(),
+      show: vi.fn(),
+      focus: vi.fn(),
+    };
+
+    showAndFocusWindow(window);
+
+    expect(window.restore).toHaveBeenCalledOnce();
+    expect(window.show).toHaveBeenCalledOnce();
+    expect(window.focus).toHaveBeenCalledOnce();
+  });
+
+  it("focuses an already visible window without changing visibility", () => {
+    const window = {
+      isMinimized: vi.fn(() => {
+        return false;
+      }),
+      isVisible: vi.fn(() => {
+        return true;
+      }),
+      restore: vi.fn(),
+      show: vi.fn(),
+      focus: vi.fn(),
+    };
+
+    showAndFocusWindow(window);
+
+    expect(window.restore).not.toHaveBeenCalled();
+    expect(window.show).not.toHaveBeenCalled();
+    expect(window.focus).toHaveBeenCalledOnce();
+  });
+});

--- a/turbo/apps/desktop/src/desktop-window-lifecycle.ts
+++ b/turbo/apps/desktop/src/desktop-window-lifecycle.ts
@@ -1,0 +1,24 @@
+interface FocusableWindow {
+  readonly isMinimized: () => boolean;
+  readonly isVisible: () => boolean;
+  readonly restore: () => void;
+  readonly show: () => void;
+  readonly focus: () => void;
+}
+
+export function shouldHideMainWindowOnClose(params: {
+  readonly platform: NodeJS.Platform;
+  readonly isQuitting: boolean;
+}): boolean {
+  return params.platform === "darwin" && !params.isQuitting;
+}
+
+export function showAndFocusWindow(window: FocusableWindow): void {
+  if (window.isMinimized()) {
+    window.restore();
+  }
+  if (!window.isVisible()) {
+    window.show();
+  }
+  window.focus();
+}

--- a/turbo/apps/desktop/src/main.ts
+++ b/turbo/apps/desktop/src/main.ts
@@ -33,6 +33,10 @@ import {
   parseDesktopAuthCallback,
   parseDesktopAuthCallbackArgv,
 } from "./desktop-auth";
+import {
+  shouldHideMainWindowOnClose,
+  showAndFocusWindow,
+} from "./desktop-window-lifecycle";
 import { buildSignedOutPageUrl } from "./signed-out-page";
 import { decideWindowOpen, isAllowedAppNavigation } from "./window-policy";
 
@@ -45,6 +49,7 @@ const signedOutPageUrl = buildSignedOutPageUrl(desktopAuthStartUrl);
 let mainWindow: BrowserWindow | null = null;
 let pendingDesktopAuthCode: string | null = null;
 let desktopLocalAgentManager: DesktopLocalAgentManager | null = null;
+let appIsQuitting = false;
 let quittingAfterLocalAgentStop = false;
 const desktopAuthStartGate = createDesktopAuthStartGate();
 let computerUseRuntime: ComputerUseHostRuntime | null = null;
@@ -374,7 +379,7 @@ async function createMainWindow(initialUrl?: string): Promise<BrowserWindow> {
     if (initialUrl) {
       await mainWindow.loadURL(initialUrl);
     }
-    mainWindow.focus();
+    showAndFocusWindow(mainWindow);
     return mainWindow;
   }
 
@@ -387,6 +392,17 @@ async function createMainWindow(initialUrl?: string): Promise<BrowserWindow> {
   });
 
   mainWindow = window;
+  window.on("close", (event) => {
+    if (
+      shouldHideMainWindowOnClose({
+        platform: process.platform,
+        isQuitting: appIsQuitting,
+      })
+    ) {
+      event.preventDefault();
+      window.hide();
+    }
+  });
   window.on("closed", () => {
     if (mainWindow === window) {
       mainWindow = null;
@@ -476,9 +492,7 @@ if (!hasSingleInstanceLock) {
       return;
     }
 
-    if (mainWindow && !mainWindow.isDestroyed()) {
-      mainWindow.focus();
-    }
+    void createMainWindow();
   });
 
   app.on("open-url", (event, url) => {
@@ -490,6 +504,7 @@ if (!hasSingleInstanceLock) {
   });
 
   app.on("before-quit", (event) => {
+    appIsQuitting = true;
     const manager = desktopLocalAgentManager;
     if (
       !manager ||
@@ -523,9 +538,7 @@ if (!hasSingleInstanceLock) {
     );
 
     app.on("activate", () => {
-      if (BrowserWindow.getAllWindows().length === 0) {
-        void createMainWindow();
-      }
+      void createMainWindow();
     });
   });
 


### PR DESCRIPTION
## Summary

- Hide the macOS Zero Desktop main window on close instead of destroying it.
- Restore/show/focus the hidden main window from Dock activation and second-instance launches.
- Keep real app quit behavior intact so Desktop Local Agent shutdown still runs before exit.
- Add unit coverage for the window lifecycle helper.

Closes #14198

## Validation

- `pnpm -F @vm0/desktop check-types`
- `pnpm -F @vm0/desktop lint`
- `pnpm -F @vm0/desktop test`
- `pnpm -F @vm0/desktop build`
- `env -u VM0_DESKTOP_PLATFORM_URL pnpm -F @vm0/desktop make`