### PR TITLE
fix: resolve desktop local agent executables

### DIFF
--- a/turbo/apps/desktop/src/desktop-local-agent-manager.test.ts
+++ b/turbo/apps/desktop/src/desktop-local-agent-manager.test.ts
@@ -1,10 +1,16 @@
-import { describe, expect, it, vi } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   resolveLocalAgentApiBaseUrl,
   type DesktopLocalAgentApiClient,
 } from "./desktop-local-agent-api";
 import { DesktopLocalAgentManager } from "./desktop-local-agent-manager";
-import type { executeLocalAgentBackend } from "./desktop-local-agent-runtime";
+import type {
+  executeLocalAgentBackend,
+  preflightLocalAgentBackend,
+} from "./desktop-local-agent-runtime";
 import type {
   DesktopLocalAgentBackendProbe,
   DesktopLocalAgentEntry,
@@ -15,26 +21,47 @@ const CODEX_PROBES: DesktopLocalAgentBackendProbe[] = [
     backend: "codex",
     command: "codex",
     available: true,
+    executablePath: "/opt/homebrew/bin/codex",
     version: "codex 1.0.0",
   },
   {
     backend: "claude-code",
     command: "claude",
     available: true,
+    executablePath: "/opt/homebrew/bin/claude",
     version: "claude 1.0.0",
   },
 ];
+
+let tempRoots: string[] = [];
+
+afterEach(() => {
+  for (const tempRoot of tempRoots) {
+    rmSync(tempRoot, { recursive: true, force: true });
+  }
+  tempRoots = [];
+});
+
+function createWorkspace(name: string): string {
+  const tempRoot = mkdtempSync(path.join(tmpdir(), "desktop-agent-"));
+  const workspacePath = path.join(tempRoot, name);
+  mkdirSync(workspacePath, { recursive: true });
+  tempRoots.push(tempRoot);
+  return workspacePath;
+}
 
 function createHarness(
   options: {
     readonly folders?: readonly string[];
     readonly initialEntries?: readonly DesktopLocalAgentEntry[];
     readonly apiOverrides?: Partial<DesktopLocalAgentApiClient>;
+    readonly preflightBackend?: typeof preflightLocalAgentBackend;
     readonly executeBackend?: typeof executeLocalAgentBackend;
   } = {},
 ) {
   let entries = [...(options.initialEntries ?? [])];
-  const folders = [...(options.folders ?? ["/workspace/alpha"])];
+  const harnessFolders = options.folders ?? [createWorkspace("alpha")];
+  const folders = [...harnessFolders];
   const startedHosts: string[] = [];
   const closedHosts: string[] = [];
   const completedJobs: Array<{
@@ -84,6 +111,20 @@ function createHarness(
     detectBackends: vi.fn(async () => {
       return CODEX_PROBES;
     }),
+    preflightBackend:
+      options.preflightBackend ??
+      vi.fn(async (backend) => {
+        return {
+          backend,
+          command: backend === "codex" ? "codex" : "claude",
+          executablePath:
+            backend === "codex"
+              ? "/opt/homebrew/bin/codex"
+              : "/opt/homebrew/bin/claude",
+          runtimePath: "/opt/homebrew/bin:/usr/bin:/bin",
+          version: `${backend} 1.0.0`,
+        };
+      }),
     executeBackend:
       options.executeBackend ??
       vi.fn(async () => {
@@ -95,7 +136,13 @@ function createHarness(
       .mockReturnValueOnce("agent-2"),
   });
 
-  return { manager, startedHosts, closedHosts, completedJobs };
+  return {
+    manager,
+    startedHosts,
+    closedHosts,
+    completedJobs,
+    folders: harnessFolders,
+  };
 }
 
 describe("DesktopLocalAgentApiClient", () => {
@@ -121,7 +168,7 @@ describe("DesktopLocalAgentManager", () => {
   });
 
   it("adds a Codex workspace with workspace-write permissions by default", async () => {
-    const { manager, startedHosts, closedHosts } = createHarness();
+    const { manager, startedHosts, closedHosts, folders } = createHarness();
 
     await manager.setEnabled(true);
     const entry = await manager.add();
@@ -129,11 +176,12 @@ describe("DesktopLocalAgentManager", () => {
     expect(entry).toMatchObject({
       id: "agent-1",
       name: "alpha",
-      folderPath: "/workspace/alpha",
+      folderPath: folders[0],
       backend: "codex",
       permissionMode: "workspace-write",
       status: "online",
       hostId: "host-1",
+      executablePath: "/opt/homebrew/bin/codex",
     });
     expect(startedHosts).toStrictEqual(["alpha"]);
 
@@ -143,7 +191,7 @@ describe("DesktopLocalAgentManager", () => {
 
   it("runs multiple configured workspaces independently", async () => {
     const { manager, startedHosts, closedHosts } = createHarness({
-      folders: ["/workspace/alpha", "/workspace/beta"],
+      folders: [createWorkspace("alpha"), createWorkspace("beta")],
     });
 
     await manager.setEnabled(true);
@@ -168,12 +216,13 @@ describe("DesktopLocalAgentManager", () => {
   });
 
   it("restores persisted agents as stopped without autostarting them", async () => {
+    const folderPath = createWorkspace("alpha");
     const { manager, startedHosts } = createHarness({
       initialEntries: [
         {
           id: "agent-1",
           name: "alpha",
-          folderPath: "/workspace/alpha",
+          folderPath,
           backend: "codex",
           permissionMode: "workspace-write",
           status: "online",
@@ -189,7 +238,7 @@ describe("DesktopLocalAgentManager", () => {
       {
         id: "agent-1",
         name: "alpha",
-        folderPath: "/workspace/alpha",
+        folderPath,
         backend: "codex",
         permissionMode: "workspace-write",
         status: "stopped",
@@ -198,6 +247,74 @@ describe("DesktopLocalAgentManager", () => {
       },
     ]);
     expect(startedHosts).toStrictEqual([]);
+  });
+
+  it("does not advertise a host when backend preflight fails", async () => {
+    const preflightBackend = vi.fn<typeof preflightLocalAgentBackend>(
+      async () => {
+        throw new Error("Codex not found");
+      },
+    );
+    const { manager, startedHosts } = createHarness({ preflightBackend });
+
+    await manager.setEnabled(true);
+    const entry = await manager.add({ backend: "codex" });
+
+    expect(entry).toMatchObject({
+      id: "agent-1",
+      status: "error",
+      errorMessage: "Codex not found",
+    });
+    expect(startedHosts).toStrictEqual([]);
+    await expect(manager.list()).resolves.toMatchObject([
+      {
+        id: "agent-1",
+        status: "error",
+        errorMessage: "Codex not found",
+      },
+    ]);
+  });
+
+  it("uses the resolved executable path for jobs", async () => {
+    let claimCount = 0;
+    const executeBackend = vi.fn<typeof executeLocalAgentBackend>(async () => {
+      return { output: "ok", exitCode: 0 };
+    });
+    const { manager } = createHarness({
+      executeBackend,
+      apiOverrides: {
+        async claimNextJob() {
+          claimCount += 1;
+          if (claimCount === 1) {
+            return {
+              status: "job",
+              job: {
+                id: "job-1",
+                backend: "codex",
+                prompt: "run task",
+              },
+            };
+          }
+          return { status: "idle" };
+        },
+      },
+    });
+
+    await manager.setEnabled(true);
+    await manager.add();
+    await vi.waitFor(() => {
+      expect(executeBackend).toHaveBeenCalled();
+    });
+
+    expect(executeBackend).toHaveBeenCalledWith(
+      expect.objectContaining({
+        backend: "codex",
+        executablePath: "/opt/homebrew/bin/codex",
+        runtimePath: "/opt/homebrew/bin:/usr/bin:/bin",
+      }),
+    );
+
+    await manager.stopAll();
   });
 
   it("fails an active job before closing the host when stopped", async () => {

--- a/turbo/apps/desktop/src/desktop-local-agent-manager.ts
+++ b/turbo/apps/desktop/src/desktop-local-agent-manager.ts
@@ -1,9 +1,12 @@
+import { constants as fsConstants } from "node:fs";
+import fs from "node:fs/promises";
 import path from "node:path";
 import type { DesktopLocalAgentApiClient } from "./desktop-local-agent-api";
 import {
   defaultPermissionMode,
   type detectLocalAgentBackends,
   type executeLocalAgentBackend,
+  type preflightLocalAgentBackend,
 } from "./desktop-local-agent-runtime";
 import type {
   DesktopLocalAgentAddOptions,
@@ -27,6 +30,7 @@ interface DesktopLocalAgentManagerDependencies {
   readonly selectFolder: () => Promise<string | null>;
   readonly openFolder: (folderPath: string) => Promise<void>;
   readonly detectBackends: typeof detectLocalAgentBackends;
+  readonly preflightBackend: typeof preflightLocalAgentBackend;
   readonly executeBackend: typeof executeLocalAgentBackend;
   readonly now?: () => number;
   readonly randomId?: () => string;
@@ -115,6 +119,7 @@ function uniqueName(
 export class DesktopLocalAgentManager {
   private entries: DesktopLocalAgentEntry[] | null = null;
   private readonly runningAgents = new Map<string, RunningAgent>();
+  private readonly backendRuntimePaths = new Map<string, string>();
   private nativeEnabled = false;
 
   constructor(private readonly deps: DesktopLocalAgentManagerDependencies) {}
@@ -187,6 +192,14 @@ export class DesktopLocalAgentManager {
     await this.persistAndNotify();
 
     try {
+      await fs.access(entry.folderPath, fsConstants.R_OK | fsConstants.X_OK);
+      const backendRuntime = await this.deps.preflightBackend(entry.backend);
+      this.updateEntry(id, {
+        executablePath: backendRuntime.executablePath,
+      });
+      this.backendRuntimePaths.set(id, backendRuntime.runtimePath);
+      await this.persistAndNotify();
+
       const controller = new AbortController();
       const supportedBackends = [entry.backend];
       const host = await this.deps.api.startHost({
@@ -215,6 +228,7 @@ export class DesktopLocalAgentManager {
       void promise;
       return cloneEntry(this.requireEntry(id));
     } catch (error) {
+      this.backendRuntimePaths.delete(id);
       this.updateEntry(id, {
         status: "error",
         errorMessage: errorMessage(error),
@@ -245,6 +259,7 @@ export class DesktopLocalAgentManager {
     await running.promise.catch(() => {});
     await this.closeRunningHost(running);
     this.runningAgents.delete(id);
+    this.backendRuntimePaths.delete(id);
     this.updateEntry(id, { status: "stopped", errorMessage: undefined });
     await this.persistAndNotify();
     return cloneEntry(this.requireEntry(id));
@@ -317,6 +332,8 @@ export class DesktopLocalAgentManager {
     } catch (error) {
       if (!signal.aborted) {
         this.runningAgents.delete(params.id);
+        this.backendRuntimePaths.delete(params.id);
+        await this.closeRunningHostToken(params.hostToken);
         this.updateEntry(params.id, {
           status: "error",
           errorMessage: errorMessage(error),
@@ -339,6 +356,8 @@ export class DesktopLocalAgentManager {
       prompt: params.prompt,
       workdir: params.entry.folderPath,
       permissionMode: params.entry.permissionMode,
+      executablePath: params.entry.executablePath,
+      runtimePath: this.backendRuntimePaths.get(params.entry.id),
       signal: params.signal,
     });
     await this.completeJob({
@@ -347,6 +366,9 @@ export class DesktopLocalAgentManager {
       result,
       signal: params.signal.aborted ? undefined : params.signal,
     });
+    if (result.backendHealthy === false) {
+      throw new Error(result.error ?? "Local agent backend is unavailable");
+    }
   }
 
   private async completeJob(params: {
@@ -387,9 +409,11 @@ export class DesktopLocalAgentManager {
   }
 
   private async closeRunningHost(running: RunningAgent): Promise<void> {
-    await this.deps.api
-      .closeHost({ hostToken: running.hostToken })
-      .catch(() => {});
+    await this.closeRunningHostToken(running.hostToken);
+  }
+
+  private async closeRunningHostToken(hostToken: string): Promise<void> {
+    await this.deps.api.closeHost({ hostToken }).catch(() => {});
   }
 
   private async ensureLoaded(): Promise<void> {

--- a/turbo/apps/desktop/src/desktop-local-agent-runtime.test.ts
+++ b/turbo/apps/desktop/src/desktop-local-agent-runtime.test.ts
@@ -1,0 +1,152 @@
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  detectLocalAgentBackends,
+  executeLocalAgentBackend,
+  preflightLocalAgentBackend,
+} from "./desktop-local-agent-runtime";
+
+let tempRoots: string[] = [];
+
+afterEach(() => {
+  for (const tempRoot of tempRoots) {
+    rmSync(tempRoot, { recursive: true, force: true });
+  }
+  tempRoots = [];
+});
+
+function createTempRoot(): string {
+  const tempRoot = mkdtempSync(path.join(tmpdir(), "desktop-runtime-"));
+  tempRoots.push(tempRoot);
+  return tempRoot;
+}
+
+function createExecutable(
+  directory: string,
+  name: string,
+  script: string,
+): string {
+  mkdirSync(directory, { recursive: true });
+  const executablePath = path.join(directory, name);
+  writeFileSync(executablePath, script, "utf8");
+  chmodSync(executablePath, 0o755);
+  return executablePath;
+}
+
+function codexScript(loginExitCode: number): string {
+  return `#!/bin/sh
+if [ "$1" = "--version" ]; then
+  echo "codex-cli test"
+  exit 0
+fi
+if [ "$1" = "login" ] && [ "$2" = "status" ]; then
+  exit ${loginExitCode}
+fi
+if [ "$1" = "exec" ]; then
+  echo "ran $*"
+  exit 0
+fi
+echo "unexpected $*" >&2
+exit 2
+`;
+}
+
+describe("desktop local agent runtime", () => {
+  it("finds Codex in a common install directory when GUI PATH is limited", async () => {
+    const tempRoot = createTempRoot();
+    const binDir = path.join(tempRoot, "opt/homebrew/bin");
+    const codexPath = createExecutable(binDir, "codex", codexScript(0));
+
+    const probes = await detectLocalAgentBackends({
+      env: {
+        HOME: tempRoot,
+        PATH: "/usr/bin:/bin:/usr/sbin:/sbin",
+      },
+      commonExecutableDirectories: [binDir],
+    });
+
+    expect(probes).toEqual([
+      expect.objectContaining({
+        backend: "codex",
+        command: "codex",
+        available: true,
+        executablePath: codexPath,
+        version: "codex-cli test",
+      }),
+      expect.objectContaining({
+        backend: "claude-code",
+        command: "claude",
+        available: false,
+        errorMessage: "Claude Code not found",
+      }),
+    ]);
+  });
+
+  it("preflights and executes Codex using the resolved executable path", async () => {
+    const tempRoot = createTempRoot();
+    const binDir = path.join(tempRoot, "opt/homebrew/bin");
+    createExecutable(binDir, "codex", codexScript(0));
+
+    const runtime = await preflightLocalAgentBackend("codex", {
+      env: {
+        HOME: tempRoot,
+        PATH: "/usr/bin:/bin:/usr/sbin:/sbin",
+      },
+      commonExecutableDirectories: [binDir],
+    });
+    const result = await executeLocalAgentBackend({
+      backend: "codex",
+      prompt: "hello",
+      workdir: tempRoot,
+      permissionMode: "workspace-write",
+      executablePath: runtime.executablePath,
+      runtimePath: runtime.runtimePath,
+    });
+
+    expect(runtime.executablePath).toBe(path.join(binDir, "codex"));
+    expect(result).toMatchObject({
+      output: "ran exec --sandbox workspace-write hello",
+      exitCode: 0,
+    });
+  });
+
+  it("reports spawn ENOENT as an unhealthy backend", async () => {
+    const tempRoot = createTempRoot();
+    const result = await executeLocalAgentBackend({
+      backend: "codex",
+      prompt: "hello",
+      workdir: tempRoot,
+      permissionMode: "workspace-write",
+      executablePath: path.join(tempRoot, "missing-codex"),
+      runtimePath: tempRoot,
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.backendHealthy).toBe(false);
+    expect(result.error).toContain("ENOENT");
+  });
+
+  it("reports an unauthenticated Codex backend during preflight", async () => {
+    const tempRoot = createTempRoot();
+    const binDir = path.join(tempRoot, "opt/homebrew/bin");
+    createExecutable(binDir, "codex", codexScript(1));
+
+    await expect(
+      preflightLocalAgentBackend("codex", {
+        env: {
+          HOME: tempRoot,
+          PATH: "/usr/bin:/bin:/usr/sbin:/sbin",
+        },
+        commonExecutableDirectories: [binDir],
+      }),
+    ).rejects.toThrow("Codex not logged in");
+  });
+});

--- a/turbo/apps/desktop/src/desktop-local-agent-runtime.ts
+++ b/turbo/apps/desktop/src/desktop-local-agent-runtime.ts
@@ -1,4 +1,7 @@
 import { spawn } from "node:child_process";
+import { constants as fsConstants } from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
 import type {
   DesktopLocalAgentBackend,
   DesktopLocalAgentBackendProbe,
@@ -9,12 +12,53 @@ import type {
 const BACKEND_COMMANDS: ReadonlyArray<{
   readonly backend: DesktopLocalAgentBackend;
   readonly command: string;
+  readonly label: string;
 }> = [
-  { backend: "codex", command: "codex" },
-  { backend: "claude-code", command: "claude" },
+  { backend: "codex", command: "codex", label: "Codex" },
+  { backend: "claude-code", command: "claude", label: "Claude Code" },
 ];
 
+const COMMON_EXECUTABLE_DIRECTORIES = [
+  "/opt/homebrew/bin",
+  "/usr/local/bin",
+  "~/.local/bin",
+  "~/.cargo/bin",
+] as const;
 const MAX_OUTPUT_BYTES = 256 * 1024;
+const PROBE_TIMEOUT_MS = 2_000;
+
+interface CommandOutput {
+  readonly exitCode: number;
+  readonly output: string;
+  readonly error?: string;
+}
+
+interface ResolveOptions {
+  readonly env?: NodeJS.ProcessEnv;
+  readonly commonExecutableDirectories?: readonly string[];
+}
+
+interface DesktopLocalAgentBackendRuntime {
+  readonly backend: DesktopLocalAgentBackend;
+  readonly command: string;
+  readonly executablePath: string;
+  readonly runtimePath: string;
+  readonly version?: string;
+}
+
+function backendCommand(backend: DesktopLocalAgentBackend): {
+  readonly backend: DesktopLocalAgentBackend;
+  readonly command: string;
+  readonly label: string;
+} {
+  const match = BACKEND_COMMANDS.find((candidate) => {
+    return candidate.backend === backend;
+  });
+  if (!match) {
+    throw new Error(`Unsupported local agent backend: ${backend}`);
+  }
+  return match;
+}
 
 function firstLine(output: string): string | undefined {
   const line = output
@@ -34,6 +78,326 @@ function appendLimited(current: string, chunk: Buffer): string {
     return next;
   }
   return next.slice(-MAX_OUTPUT_BYTES);
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function errorCode(error: Error): string | undefined {
+  if ("code" in error && typeof error.code === "string") {
+    return error.code;
+  }
+  return undefined;
+}
+
+function pathValue(env: NodeJS.ProcessEnv): string {
+  return typeof env.PATH === "string" ? env.PATH : "";
+}
+
+function splitPath(value: string | undefined): string[] {
+  if (!value) {
+    return [];
+  }
+  return value
+    .split(path.delimiter)
+    .map((entry) => {
+      return entry.trim();
+    })
+    .filter((entry) => {
+      return entry.length > 0;
+    });
+}
+
+function mergePathValues(values: readonly (string | undefined)[]): string {
+  const entries = new Set<string>();
+  for (const value of values) {
+    for (const entry of splitPath(value)) {
+      entries.add(entry);
+    }
+  }
+  return [...entries].join(path.delimiter);
+}
+
+function expandHome(value: string, env: NodeJS.ProcessEnv): string | undefined {
+  if (value === "~") {
+    return typeof env.HOME === "string" ? env.HOME : undefined;
+  }
+  if (value.startsWith("~/")) {
+    return typeof env.HOME === "string"
+      ? path.join(env.HOME, value.slice(2))
+      : undefined;
+  }
+  return value;
+}
+
+function commonExecutableDirectories(
+  env: NodeJS.ProcessEnv,
+  directories: readonly string[] | undefined,
+): string[] {
+  return (directories ?? COMMON_EXECUTABLE_DIRECTORIES)
+    .map((directory) => {
+      return expandHome(directory, env);
+    })
+    .filter((directory): directory is string => {
+      return typeof directory === "string" && directory.length > 0;
+    });
+}
+
+async function isExecutable(filePath: string): Promise<boolean> {
+  try {
+    await fs.access(filePath, fsConstants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function findExecutableInPath(
+  command: string,
+  pathList: string,
+): Promise<string | undefined> {
+  for (const directory of splitPath(pathList)) {
+    const candidate = path.join(directory, command);
+    if (await isExecutable(candidate)) {
+      return candidate;
+    }
+  }
+  return undefined;
+}
+
+async function findExecutableInDirectories(
+  command: string,
+  directories: readonly string[],
+): Promise<string | undefined> {
+  for (const directory of directories) {
+    const candidate = path.join(directory, command);
+    if (await isExecutable(candidate)) {
+      return candidate;
+    }
+  }
+  return undefined;
+}
+
+function loginShell(env: NodeJS.ProcessEnv): string | undefined {
+  return typeof env.SHELL === "string" && env.SHELL.length > 0
+    ? env.SHELL
+    : undefined;
+}
+
+function shellProbeScript(command: string): string {
+  return `resolved="$(command -v ${command} || true)"; printf '%s\\n%s\\n' "$resolved" "$PATH"`;
+}
+
+function runCommand(params: {
+  readonly command: string;
+  readonly args: readonly string[];
+  readonly env: NodeJS.ProcessEnv;
+  readonly runtimePath?: string;
+  readonly timeoutMs: number;
+  readonly timeoutMessage: string;
+}): Promise<CommandOutput> {
+  return new Promise((resolve) => {
+    const child = spawn(params.command, [...params.args], {
+      env: {
+        ...params.env,
+        ...(params.runtimePath ? { PATH: params.runtimePath } : {}),
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    let output = "";
+    let settled = false;
+    const finish = (result: CommandOutput): void => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timer);
+      resolve(result);
+    };
+
+    const timer = setTimeout(() => {
+      child.kill();
+      finish({
+        exitCode: 1,
+        output,
+        error: params.timeoutMessage,
+      });
+    }, params.timeoutMs);
+
+    child.stdout?.on("data", (chunk: Buffer) => {
+      output = appendLimited(output, chunk);
+    });
+    child.stderr?.on("data", (chunk: Buffer) => {
+      output = appendLimited(output, chunk);
+    });
+    child.on("error", (error: Error) => {
+      finish({
+        exitCode: 1,
+        output,
+        error: error.message,
+      });
+    });
+    child.on("close", (code) => {
+      finish({
+        exitCode: code ?? 1,
+        output,
+      });
+    });
+  });
+}
+
+async function resolveFromLoginShell(
+  command: string,
+  env: NodeJS.ProcessEnv,
+): Promise<{
+  readonly executablePath?: string;
+  readonly runtimePath?: string;
+}> {
+  const shell = loginShell(env);
+  if (!shell) {
+    return {};
+  }
+
+  const result = await runCommand({
+    command: shell,
+    args: ["-lc", shellProbeScript(command)],
+    env,
+    timeoutMs: PROBE_TIMEOUT_MS,
+    timeoutMessage: "Login shell lookup timed out",
+  });
+  if (result.exitCode !== 0) {
+    return {};
+  }
+
+  const lines = result.output.replace(/\r\n/g, "\n").split("\n");
+  const executablePath = lines[0]?.trim();
+  const runtimePath = lines[1]?.trim();
+  return {
+    ...(executablePath &&
+    path.isAbsolute(executablePath) &&
+    (await isExecutable(executablePath))
+      ? { executablePath }
+      : {}),
+    ...(runtimePath ? { runtimePath } : {}),
+  };
+}
+
+async function resolveLocalAgentBackend(
+  backend: DesktopLocalAgentBackend,
+  options: ResolveOptions = {},
+): Promise<DesktopLocalAgentBackendRuntime> {
+  const env = options.env ?? process.env;
+  const definition = backendCommand(backend);
+  const processPath = pathValue(env);
+  const shellResolution = await resolveFromLoginShell(definition.command, env);
+  const commonDirectories = commonExecutableDirectories(
+    env,
+    options.commonExecutableDirectories,
+  );
+  const executablePath =
+    (await findExecutableInPath(definition.command, processPath)) ??
+    shellResolution.executablePath ??
+    (await findExecutableInDirectories(definition.command, commonDirectories));
+  if (!executablePath) {
+    throw new Error(`${definition.label} not found`);
+  }
+
+  const runtimePath = mergePathValues([
+    path.dirname(executablePath),
+    shellResolution.runtimePath,
+    processPath,
+    commonDirectories.join(path.delimiter),
+  ]);
+  const versionResult = await runCommand({
+    command: executablePath,
+    args: ["--version"],
+    env,
+    runtimePath,
+    timeoutMs: PROBE_TIMEOUT_MS,
+    timeoutMessage: `${definition.label} version check timed out`,
+  });
+  if (versionResult.exitCode !== 0) {
+    throw new Error(
+      firstLine(versionResult.output) ??
+        versionResult.error ??
+        `${definition.label} version check failed`,
+    );
+  }
+
+  return {
+    backend,
+    command: definition.command,
+    executablePath,
+    runtimePath,
+    version: firstLine(versionResult.output),
+  };
+}
+
+async function assertBackendAuthenticated(
+  runtime: DesktopLocalAgentBackendRuntime,
+  env: NodeJS.ProcessEnv,
+): Promise<void> {
+  if (runtime.backend !== "codex") {
+    return;
+  }
+
+  const result = await runCommand({
+    command: runtime.executablePath,
+    args: ["login", "status"],
+    env,
+    runtimePath: runtime.runtimePath,
+    timeoutMs: PROBE_TIMEOUT_MS,
+    timeoutMessage: "Codex login status timed out",
+  });
+  if (result.exitCode !== 0) {
+    throw new Error("Codex not logged in");
+  }
+}
+
+export async function preflightLocalAgentBackend(
+  backend: DesktopLocalAgentBackend,
+  options: ResolveOptions = {},
+): Promise<DesktopLocalAgentBackendRuntime> {
+  const env = options.env ?? process.env;
+  const runtime = await resolveLocalAgentBackend(backend, options);
+  await assertBackendAuthenticated(runtime, env);
+  return runtime;
+}
+
+async function probeBackend(
+  backend: DesktopLocalAgentBackend,
+  options: ResolveOptions,
+): Promise<DesktopLocalAgentBackendProbe> {
+  const definition = backendCommand(backend);
+  try {
+    const runtime = await resolveLocalAgentBackend(backend, options);
+    return {
+      backend,
+      command: definition.command,
+      available: true,
+      executablePath: runtime.executablePath,
+      version: runtime.version,
+    };
+  } catch (error) {
+    return {
+      backend,
+      command: definition.command,
+      available: false,
+      errorMessage: errorMessage(error),
+    };
+  }
+}
+
+export function detectLocalAgentBackends(
+  options: ResolveOptions = {},
+): Promise<DesktopLocalAgentBackendProbe[]> {
+  return Promise.all(
+    BACKEND_COMMANDS.map(({ backend }) => {
+      return probeBackend(backend, options);
+    }),
+  );
 }
 
 function unsupportedPermission(
@@ -82,103 +446,81 @@ export function defaultPermissionMode(
   return backend === "codex" ? "workspace-write" : "default";
 }
 
-function executionCommand(params: {
+function executionArgs(params: {
   readonly backend: DesktopLocalAgentBackend;
   readonly prompt: string;
   readonly permissionMode: DesktopLocalAgentPermissionMode;
-}): { readonly command: string; readonly args: readonly string[] } {
+}): readonly string[] {
   if (params.backend === "claude-code") {
+    return [
+      "-p",
+      ...claudePermissionArgs(params.permissionMode),
+      params.prompt,
+    ];
+  }
+  return ["exec", ...codexPermissionArgs(params.permissionMode), params.prompt];
+}
+
+async function runtimeForExecution(params: {
+  readonly backend: DesktopLocalAgentBackend;
+  readonly executablePath?: string;
+  readonly runtimePath?: string;
+}): Promise<DesktopLocalAgentBackendRuntime> {
+  const definition = backendCommand(params.backend);
+  if (params.executablePath) {
     return {
-      command: "claude",
-      args: [
-        "-p",
-        ...claudePermissionArgs(params.permissionMode),
-        params.prompt,
-      ],
+      backend: params.backend,
+      command: definition.command,
+      executablePath: params.executablePath,
+      runtimePath:
+        params.runtimePath ??
+        mergePathValues([
+          path.dirname(params.executablePath),
+          pathValue(process.env),
+        ]),
     };
   }
-  return {
-    command: "codex",
-    args: [
-      "exec",
-      ...codexPermissionArgs(params.permissionMode),
-      params.prompt,
-    ],
-  };
+  return preflightLocalAgentBackend(params.backend);
 }
 
-function probeBackend(
-  backend: DesktopLocalAgentBackend,
-  command: string,
-): Promise<DesktopLocalAgentBackendProbe> {
-  return new Promise((resolve) => {
-    const child = spawn(command, ["--version"], {
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-
-    let output = "";
-    let settled = false;
-    const finish = (probe: DesktopLocalAgentBackendProbe): void => {
-      if (settled) {
-        return;
-      }
-      settled = true;
-      clearTimeout(timer);
-      resolve(probe);
-    };
-
-    const timer = setTimeout(() => {
-      child.kill();
-      finish({ backend, command, available: false });
-    }, 2_000);
-
-    child.stdout?.on("data", (chunk: Buffer) => {
-      output += chunk.toString("utf8");
-    });
-    child.stderr?.on("data", (chunk: Buffer) => {
-      output += chunk.toString("utf8");
-    });
-    child.on("error", () => {
-      finish({ backend, command, available: false });
-    });
-    child.on("close", (code) => {
-      finish({
-        backend,
-        command,
-        available: code === 0,
-        version: code === 0 ? firstLine(output) : undefined,
-      });
-    });
-  });
-}
-
-export function detectLocalAgentBackends(): Promise<
-  DesktopLocalAgentBackendProbe[]
-> {
-  return Promise.all(
-    BACKEND_COMMANDS.map(({ backend, command }) => {
-      return probeBackend(backend, command);
-    }),
-  );
-}
-
-export function executeLocalAgentBackend(params: {
+export async function executeLocalAgentBackend(params: {
   readonly backend: DesktopLocalAgentBackend;
   readonly prompt: string;
   readonly workdir: string;
   readonly permissionMode: DesktopLocalAgentPermissionMode;
+  readonly executablePath?: string;
+  readonly runtimePath?: string;
   readonly signal?: AbortSignal;
 }): Promise<DesktopLocalAgentExecutionResult> {
-  const { command, args } = executionCommand({
+  let runtime: DesktopLocalAgentBackendRuntime;
+  try {
+    runtime = await runtimeForExecution({
+      backend: params.backend,
+      executablePath: params.executablePath,
+      runtimePath: params.runtimePath,
+    });
+  } catch (error) {
+    return {
+      output: "",
+      error: errorMessage(error),
+      exitCode: 1,
+      backendHealthy: false,
+    };
+  }
+
+  const args = executionArgs({
     backend: params.backend,
     prompt: params.prompt,
     permissionMode: params.permissionMode,
   });
 
   return new Promise((resolve) => {
-    const child = spawn(command, [...args], {
+    const child = spawn(runtime.executablePath, [...args], {
       cwd: params.workdir,
-      env: process.env,
+      env: {
+        ...process.env,
+        PATH: runtime.runtimePath,
+      },
       stdio: ["ignore", "pipe", "pipe"],
     });
 
@@ -216,11 +558,14 @@ export function executeLocalAgentBackend(params: {
     child.stderr?.on("data", (chunk: Buffer) => {
       stderr = appendLimited(stderr, chunk);
     });
-    child.on("error", (error) => {
+    child.on("error", (error: Error) => {
+      const code = errorCode(error);
       finish({
         output: stdout,
         error: error.message,
         exitCode: 1,
+        backendHealthy:
+          code === "ENOENT" || code === "EACCES" ? false : undefined,
       });
     });
     child.on("close", (code) => {

--- a/turbo/apps/desktop/src/desktop-local-agent-types.ts
+++ b/turbo/apps/desktop/src/desktop-local-agent-types.ts
@@ -22,7 +22,9 @@ export interface DesktopLocalAgentBackendProbe {
   readonly backend: DesktopLocalAgentBackend;
   readonly command: string;
   readonly available: boolean;
+  readonly executablePath?: string;
   readonly version?: string;
+  readonly errorMessage?: string;
 }
 
 export interface DesktopLocalAgentEntry {
@@ -32,6 +34,7 @@ export interface DesktopLocalAgentEntry {
   readonly backend: DesktopLocalAgentBackend;
   readonly permissionMode: DesktopLocalAgentPermissionMode;
   readonly status: DesktopLocalAgentStatus;
+  readonly executablePath?: string;
   readonly hostId?: string;
   readonly lastHeartbeatAt?: string;
   readonly errorMessage?: string;
@@ -61,4 +64,5 @@ export interface DesktopLocalAgentExecutionResult {
   readonly output: string;
   readonly error?: string;
   readonly exitCode: number;
+  readonly backendHealthy?: boolean;
 }

--- a/turbo/apps/desktop/src/main.ts
+++ b/turbo/apps/desktop/src/main.ts
@@ -22,6 +22,7 @@ import { DesktopLocalAgentManager } from "./desktop-local-agent-manager";
 import {
   detectLocalAgentBackends,
   executeLocalAgentBackend,
+  preflightLocalAgentBackend,
 } from "./desktop-local-agent-runtime";
 import { createDesktopLocalAgentStore } from "./desktop-local-agent-store";
 import {
@@ -81,6 +82,7 @@ function createDesktopLocalAgentManager(): DesktopLocalAgentManager {
     selectFolder: selectLocalAgentFolder,
     openFolder: openLocalAgentFolder,
     detectBackends: detectLocalAgentBackends,
+    preflightBackend: preflightLocalAgentBackend,
     executeBackend: executeLocalAgentBackend,
     onChange: notifyDesktopLocalAgentsChanged,
   });

--- a/turbo/apps/platform/src/global.d.ts
+++ b/turbo/apps/platform/src/global.d.ts
@@ -29,7 +29,9 @@ interface DesktopLocalAgentBackendProbe {
   readonly backend: DesktopLocalAgentBackend;
   readonly command: string;
   readonly available: boolean;
+  readonly executablePath?: string;
   readonly version?: string;
+  readonly errorMessage?: string;
 }
 
 interface DesktopLocalAgentEntry {
@@ -39,6 +41,7 @@ interface DesktopLocalAgentEntry {
   readonly backend: DesktopLocalAgentBackend;
   readonly permissionMode: DesktopLocalAgentPermissionMode;
   readonly status: DesktopLocalAgentStatus;
+  readonly executablePath?: string;
   readonly hostId?: string;
   readonly lastHeartbeatAt?: string;
   readonly errorMessage?: string;

--- a/turbo/apps/platform/src/signals/desktop-local-agent-page/desktop-local-agent-signals.ts
+++ b/turbo/apps/platform/src/signals/desktop-local-agent-page/desktop-local-agent-signals.ts
@@ -80,6 +80,12 @@ export const setDesktopLocalAgentPermissionMode$ = command(
   },
 );
 
+export const refreshDesktopLocalAgentData$ = command(({ set }) => {
+  set(internalReload$, (previous) => {
+    return previous + 1;
+  });
+});
+
 export const setupDesktopLocalAgentBridge$ = command(
   async ({ set }, signal: AbortSignal) => {
     const api = desktopLocalAgentApi();
@@ -132,8 +138,10 @@ export const addDesktopLocalAgent$ = command(
     });
     signal.throwIfAborted();
     set(internalDialogOpen$, false);
-    if (entry) {
+    if (entry?.status === "online") {
       toast.success(`${entry.name} started`);
+    } else if (entry) {
+      toast.error(entry.errorMessage ?? `${entry.name} could not start`);
     }
     set(internalReload$, (previous) => {
       return previous + 1;

--- a/turbo/apps/platform/src/views/zero-page/__tests__/desktop-local-agent-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/desktop-local-agent-page.test.tsx
@@ -1,4 +1,5 @@
 import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { setupPage } from "../../../__tests__/page-helper.ts";
@@ -47,6 +48,7 @@ describe("zero desktop local agent page", () => {
             backend: "codex",
             command: "codex",
             available: true,
+            executablePath: "/opt/homebrew/bin/codex",
             version: "codex 1.0.0",
           },
         ]);
@@ -84,5 +86,85 @@ describe("zero desktop local agent page", () => {
     expect(screen.getByText("workspace-write")).toBeInTheDocument();
     expect(screen.getByText("online")).toBeInTheDocument();
     expect(setEnabled).toHaveBeenCalledWith(true);
+  });
+
+  it("surfaces backend health errors and blocks unavailable backend selection", async () => {
+    installDesktopLocalAgentApi({
+      setEnabled() {
+        return Promise.resolve();
+      },
+      list() {
+        return Promise.resolve([
+          {
+            id: "agent-1",
+            name: "alpha",
+            folderPath: "/workspace/alpha",
+            backend: "codex",
+            permissionMode: "workspace-write",
+            status: "error",
+            errorMessage: "Codex not found",
+          },
+        ]);
+      },
+      detectBackends() {
+        return Promise.resolve([
+          {
+            backend: "codex",
+            command: "codex",
+            available: false,
+            errorMessage: "Codex not found",
+          },
+          {
+            backend: "claude-code",
+            command: "claude",
+            available: false,
+            errorMessage: "Claude Code not found",
+          },
+        ]);
+      },
+      add() {
+        return Promise.resolve(null);
+      },
+      start() {
+        return Promise.reject(new Error("not used"));
+      },
+      stop() {
+        return Promise.reject(new Error("not used"));
+      },
+      remove() {
+        return Promise.resolve();
+      },
+      openFolder() {
+        return Promise.resolve();
+      },
+      subscribe() {
+        return () => {};
+      },
+    });
+
+    await setupPage({
+      context,
+      path: "/local-agents",
+      featureSwitches: {
+        [FeatureSwitchKey.DesktopLocalAgent]: true,
+      },
+    });
+
+    await expect(screen.findByText("alpha")).resolves.toBeInTheDocument();
+    expect(screen.getByText("Codex not found")).toBeInTheDocument();
+
+    const user = userEvent.setup();
+    await user.click(screen.getByText("Add local agent"));
+
+    await expect(screen.findAllByText("Codex not found")).resolves.toHaveLength(
+      2,
+    );
+    const selectFolderButton = screen
+      .getByText("Select folder")
+      .closest("button");
+    if (!selectFolderButton) {
+      throw new Error("Expected Select folder button");
+    }
+    expect(selectFolderButton).toBeDisabled();
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/desktop-local-agent-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/desktop-local-agent-page.tsx
@@ -7,6 +7,7 @@ import {
   IconLoader2,
   IconPlayerPlay,
   IconPlayerStop,
+  IconRefresh,
   IconTrash,
 } from "@tabler/icons-react";
 import { Button } from "@vm0/ui/components/ui/button";
@@ -41,6 +42,7 @@ import {
   desktopLocalAgentDialogOpen$,
   desktopLocalAgentPermissionMode$,
   desktopLocalAgentSelectedBackend$,
+  refreshDesktopLocalAgentData$,
   runDesktopLocalAgentAction$,
   setDesktopLocalAgentDialogOpen$,
   setDesktopLocalAgentPermissionMode$,
@@ -138,6 +140,9 @@ function StatusBadge({ entry }: { readonly entry: DesktopLocalAgentEntry }) {
 function BackendSelect() {
   const backend = useGet(desktopLocalAgentSelectedBackend$);
   const probes = useLastResolved(desktopLocalAgentData$)?.probes ?? [];
+  const selectedProbe = probes.find((candidate) => {
+    return candidate.backend === backend;
+  });
   const setBackend = useSet(setDesktopLocalAgentSelectedBackend$);
   return (
     <div className="flex flex-col gap-2">
@@ -162,7 +167,11 @@ function BackendSelect() {
               return candidate.backend === value;
             });
             return (
-              <SelectItem key={value} value={value}>
+              <SelectItem
+                key={value}
+                value={value}
+                disabled={probe?.available === false}
+              >
                 {BACKEND_LABELS[value]}
                 {probe?.available === false ? " (not detected)" : ""}
               </SelectItem>
@@ -170,6 +179,11 @@ function BackendSelect() {
           })}
         </SelectContent>
       </Select>
+      {selectedProbe?.available === false ? (
+        <p className="text-xs text-destructive">
+          {selectedProbe.errorMessage ?? `${BACKEND_LABELS[backend]} not found`}
+        </p>
+      ) : null}
     </div>
   );
 }
@@ -214,6 +228,12 @@ function AddLocalAgentDialog() {
   const [submitLoadable, submit] = useLoadableSet(addDesktopLocalAgent$);
   const submitting = submitLoadable.state === "loading";
   const setOpen = useSet(setDesktopLocalAgentDialogOpen$);
+  const backend = useGet(desktopLocalAgentSelectedBackend$);
+  const probes = useLastResolved(desktopLocalAgentData$)?.probes ?? [];
+  const selectedProbe = probes.find((candidate) => {
+    return candidate.backend === backend;
+  });
+  const backendUnavailable = selectedProbe?.available === false;
   const pageSignal = useGet(pageSignal$);
   return (
     <Dialog open={open} onOpenChange={setOpen}>
@@ -242,7 +262,7 @@ function AddLocalAgentDialog() {
             onClick={() => {
               detach(submit(pageSignal), Reason.DomCallback);
             }}
-            disabled={submitting}
+            disabled={submitting || backendUnavailable}
           >
             {submitting ? (
               <IconLoader2 size={16} className="animate-spin" />
@@ -282,7 +302,14 @@ function DesktopLocalAgentRow({
       <TableCell>{BACKEND_LABELS[entry.backend]}</TableCell>
       <TableCell>{entry.permissionMode}</TableCell>
       <TableCell>
-        <StatusBadge entry={entry} />
+        <div className="flex flex-col items-start gap-1">
+          <StatusBadge entry={entry} />
+          {entry.errorMessage ? (
+            <span className="max-w-[180px] text-xs text-destructive">
+              {entry.errorMessage}
+            </span>
+          ) : null}
+        </div>
       </TableCell>
       <TableCell>
         <code className="text-xs">{entry.hostId ?? "-"}</code>
@@ -391,6 +418,7 @@ function DesktopLocalAgentTable() {
 function DesktopLocalAgentPageHeader() {
   const setOpen = useSet(setDesktopLocalAgentDialogOpen$);
   const setBackend = useSet(setDesktopLocalAgentSelectedBackend$);
+  const refresh = useSet(refreshDesktopLocalAgentData$);
   const probes = useLastResolved(desktopLocalAgentData$)?.probes ?? [];
   return (
     <header className="hidden md:block shrink-0 bg-transparent px-4 sm:px-6 pt-10 pb-4">
@@ -404,15 +432,27 @@ function DesktopLocalAgentPageHeader() {
             Desktop-managed workspaces for Codex and Claude Code
           </p>
         </div>
-        <Button
-          onClick={() => {
-            setBackend(defaultBackendForProbes(probes));
-            setOpen(true);
-          }}
-        >
-          <IconFolderPlus size={16} />
-          Add local agent
-        </Button>
+        <div className="flex items-center gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            aria-label="Refresh local agent health"
+            onClick={() => {
+              refresh();
+            }}
+          >
+            <IconRefresh size={16} />
+          </Button>
+          <Button
+            onClick={() => {
+              setBackend(defaultBackendForProbes(probes));
+              setOpen(true);
+            }}
+          >
+            <IconFolderPlus size={16} />
+            Add local agent
+          </Button>
+        </div>
       </div>
     </header>
   );


### PR DESCRIPTION
## Summary
- resolve Desktop Local Agent backends to absolute executable paths across process PATH, login shell PATH, and common macOS/user install directories
- preflight workspace access, executable version checks, and Codex login status before advertising a local-agent host as online
- surface backend health errors in the local-agent UI, disable unavailable backend selection, and add a refresh action

Closes #14193

## Testing
- pnpm format
- pnpm lint
- pnpm check-types
- pnpm knip
- pnpm -F web db:migrate
- pnpm -F @vm0/desktop exec vitest run src/desktop-local-agent-runtime.test.ts src/desktop-local-agent-manager.test.ts
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/desktop-local-agent-page.test.tsx

## Local full-suite note
- pnpm vitest was run locally; it still fails outside this change on existing google-ads firewall placeholder consistency and local model-provider secret environment assertions. The Desktop Local Agent target suites above pass.