### PR TITLE
fix: hide connector empty state for built-in generation

### DIFF
--- a/turbo/apps/cli/src/commands/zero/doctor/__tests__/generate.test.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/__tests__/generate.test.ts
@@ -218,8 +218,8 @@ describe("zero doctor generate command", () => {
 
     const text = output();
     expect(text).toContain("Video generation choices for current agent");
-    expect(text).toContain("Connectors:");
-    expect(text).toContain("No ready video generation connectors found.");
+    expect(text).not.toContain("Connectors:");
+    expect(text).not.toContain("No ready video generation connectors found.");
     expect(text).toContain("Built-in command:");
     expect(text).toContain("Built-in video generation");
     expect(text).toContain(
@@ -235,6 +235,9 @@ describe("zero doctor generate command", () => {
     expect(text).not.toContain("Fallback option:");
     expect(text).not.toContain("Official provider:");
     expect(text).not.toContain("Next actions:");
+    expect(text).not.toContain(
+      "Use --all to see every video generation candidate.",
+    );
   });
 
   it("suggests the built-in presentation command", async () => {
@@ -247,8 +250,8 @@ describe("zero doctor generate command", () => {
 
     const text = output();
     expect(text).toContain("Presentation generation choices for current agent");
-    expect(text).toContain("Connectors:");
-    expect(text).toContain(
+    expect(text).not.toContain("Connectors:");
+    expect(text).not.toContain(
       "No ready presentation generation connectors found.",
     );
     expect(text).toContain("Built-in command:");
@@ -270,8 +273,8 @@ describe("zero doctor generate command", () => {
 
     const text = output();
     expect(text).toContain("Website generation choices for current agent");
-    expect(text).toContain("Connectors:");
-    expect(text).toContain("No ready website generation connectors found.");
+    expect(text).not.toContain("Connectors:");
+    expect(text).not.toContain("No ready website generation connectors found.");
     expect(text).toContain("Built-in command:");
     expect(text).toContain("Built-in website generation");
     expect(text).toContain("Models: gpt-5.5");
@@ -294,8 +297,8 @@ describe("zero doctor generate command", () => {
 
     const text = output();
     expect(text).toContain("Voice generation choices for current agent");
-    expect(text).toContain("Connectors:");
-    expect(text).toContain("No ready voice generation connectors found.");
+    expect(text).not.toContain("Connectors:");
+    expect(text).not.toContain("No ready voice generation connectors found.");
     expect(text).toContain("Built-in command:");
     expect(text).toContain("Built-in voice generation");
     expect(text).toContain("Models: gpt-4o-mini-tts");

--- a/turbo/apps/cli/src/commands/zero/doctor/generate.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/generate.ts
@@ -483,11 +483,16 @@ function renderText(params: {
     console.log("");
   }
 
-  console.log("Connectors:");
-  if (ready.length > 0) {
-    renderRows(ready);
-  } else {
-    console.log(`  No ready ${generationType} generation connectors found.`);
+  const hasBuiltInCommand = getBuiltInCommand(generationType) !== null;
+  const showConnectorSummary =
+    ready.length > 0 || !hasBuiltInCommand || showAll;
+  if (showConnectorSummary) {
+    console.log("Connectors:");
+    if (ready.length > 0) {
+      renderRows(ready);
+    } else {
+      console.log(`  No ready ${generationType} generation connectors found.`);
+    }
   }
 
   renderBuiltInProvider(generationType);
@@ -580,7 +585,11 @@ export const generateCommand = new Command()
         showAll: options.all === true,
       });
 
-      if (!options.all && other.length > 0) {
+      const shouldShowOtherHint =
+        !options.all &&
+        other.length > 0 &&
+        (ready.length > 0 || getBuiltInCommand(generationType) === null);
+      if (shouldShowOtherHint) {
         console.log("");
         console.log(
           chalk.dim(


### PR DESCRIPTION
Summary:
- Hide the doctor generate connector empty-state section when a built-in generation command is available and no ready connector exists.
- Keep connector rows visible when ready connectors exist or when --all is requested.
- Update CLI integration tests for built-in video, presentation, website, and voice generation output.

Tests:
- pnpm format
- pnpm -F @vm0/cli lint
- pnpm -F @vm0/cli check-types
- pnpm -F @vm0/cli exec vitest src/commands/zero/doctor/__tests__/generate.test.ts
- pnpm -F @vm0/cli test
- pnpm knip --workspace @vm0/cli
- pre-commit: pnpm knip --cache; pnpm check-types