### PR TITLE
ci: centralize turbo change detection

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -77,12 +77,12 @@ jobs:
       api-changed: ${{ steps.detect.outputs.api-changed }}
       cli-changed: ${{ steps.detect.outputs.cli-changed }}
       platform-changed: ${{ steps.detect.outputs.platform-changed }}
-      e2b-changed: ${{ steps.detect-e2b.outputs.e2b-changed }}
-      migration-changed: ${{ steps.detect-migration.outputs.migration-changed }}
-      crates-changed: ${{ steps.detect-crates.outputs.crates-changed }}
-      ci-changed: ${{ steps.detect-ci.outputs.ci-changed }}
-      e2e-changed: ${{ steps.detect-e2e.outputs.e2e-changed }}
-      api-backend-needed: ${{ steps.detect-api-backend.outputs.api-backend-needed }}
+      e2b-changed: ${{ steps.detect.outputs.e2b-changed }}
+      migration-changed: ${{ steps.detect.outputs.migration-changed }}
+      crates-changed: ${{ steps.detect.outputs.crates-changed }}
+      ci-changed: ${{ steps.detect.outputs.ci-changed }}
+      e2e-changed: ${{ steps.detect.outputs.e2e-changed }}
+      api-backend-needed: ${{ steps.detect.outputs.api-backend-needed }}
       turbo-runner-consumer-needed: ${{ steps.runner-e2e.outputs.turbo-runner-consumer-needed }}
       base-ref: ${{ steps.detect.outputs.base-ref }}
     steps:
@@ -111,6 +111,7 @@ jobs:
           fi
 
           echo "base-ref=$BASE_REF" >> "$GITHUB_OUTPUT"
+          CHANGED_FILES=$(git diff --name-only "$BASE_REF" HEAD)
 
           # Run changed.sh to get all package changes in one go
           CHANGES_JSON=$(./scripts/changed.sh "$BASE_REF")
@@ -136,11 +137,7 @@ jobs:
             fi
           done
 
-      - name: Detect E2B template changes
-        id: detect-e2b
-        run: |
-          BASE_REF="${{ steps.detect.outputs.base-ref }}"
-          if git diff --name-only "$BASE_REF" HEAD | grep -q "^turbo/scripts/e2b/"; then
+          if printf '%s\n' "$CHANGED_FILES" | grep -q "^turbo/scripts/e2b/"; then
             echo "E2B template changes detected"
             echo "e2b-changed=true" >> "$GITHUB_OUTPUT"
           else
@@ -148,11 +145,7 @@ jobs:
             echo "e2b-changed=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Detect migration/schema changes
-        id: detect-migration
-        run: |
-          BASE_REF="${{ steps.detect.outputs.base-ref }}"
-          if git diff --name-only "$BASE_REF" HEAD | grep -qE "^turbo/apps/web/src/db/(migrations|schema)/|^turbo/packages/db/src/schema/"; then
+          if printf '%s\n' "$CHANGED_FILES" | grep -qE "^turbo/apps/web/src/db/(migrations|schema)/|^turbo/packages/db/src/schema/"; then
             echo "Migration or schema changes detected"
             echo "migration-changed=true" >> "$GITHUB_OUTPUT"
           else
@@ -160,11 +153,7 @@ jobs:
             echo "migration-changed=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Detect crates changes
-        id: detect-crates
-        run: |
-          BASE_REF="${{ steps.detect.outputs.base-ref }}"
-          if git diff --name-only "$BASE_REF" HEAD | grep -q "^crates/"; then
+          if printf '%s\n' "$CHANGED_FILES" | grep -q "^crates/"; then
             echo "Crates changes detected"
             echo "crates-changed=true" >> "$GITHUB_OUTPUT"
           else
@@ -172,11 +161,7 @@ jobs:
             echo "crates-changed=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Detect CI workflow changes
-        id: detect-ci
-        run: |
-          BASE_REF="${{ steps.detect.outputs.base-ref }}"
-          if git diff --name-only "$BASE_REF" HEAD | grep -qE "^\.github/workflows/(turbo|crates|runner-image)\.yml$|^\.github/actions/(setup-ssh-tunnel|provision)/|^\.github/scripts/|^ansible/"; then
+          if printf '%s\n' "$CHANGED_FILES" | grep -qE "^\.github/workflows/(turbo|crates|runner-image)\.yml$|^\.github/actions/(setup-ssh-tunnel|provision)/|^\.github/scripts/|^ansible/"; then
             echo "CI workflow changes detected"
             echo "ci-changed=true" >> "$GITHUB_OUTPUT"
           else
@@ -184,11 +169,7 @@ jobs:
             echo "ci-changed=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Detect E2E test changes
-        id: detect-e2e
-        run: |
-          BASE_REF="${{ steps.detect.outputs.base-ref }}"
-          if git diff --name-only "$BASE_REF" HEAD | grep -q "^e2e/"; then
+          if printf '%s\n' "$CHANGED_FILES" | grep -q "^e2e/"; then
             echo "E2E test changes detected"
             echo "e2e-changed=true" >> "$GITHUB_OUTPUT"
           else
@@ -196,11 +177,7 @@ jobs:
             echo "e2e-changed=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Detect web API backend proxy changes
-        id: detect-api-backend
-        run: |
-          BASE_REF="${{ steps.detect.outputs.base-ref }}"
-          if git diff --name-only "$BASE_REF" HEAD | grep -qE "^turbo/apps/web/(next\.config\.js|api-backend-rewrites\.js)$"; then
+          if printf '%s\n' "$CHANGED_FILES" | grep -qE "^turbo/apps/web/(next\.config\.js|api-backend-rewrites\.js)$"; then
             echo "Web API backend proxy changes detected"
             echo "api-backend-needed=true" >> "$GITHUB_OUTPUT"
           else
@@ -214,9 +191,9 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           WEB_CHANGED: ${{ steps.detect.outputs.web-changed }}
           CLI_CHANGED: ${{ steps.detect.outputs.cli-changed }}
-          CRATES_CHANGED: ${{ steps.detect-crates.outputs.crates-changed }}
-          CI_CHANGED: ${{ steps.detect-ci.outputs.ci-changed }}
-          E2E_CHANGED: ${{ steps.detect-e2e.outputs.e2e-changed }}
+          CRATES_CHANGED: ${{ steps.detect.outputs.crates-changed }}
+          CI_CHANGED: ${{ steps.detect.outputs.ci-changed }}
+          E2E_CHANGED: ${{ steps.detect.outputs.e2e-changed }}
         run: .github/scripts/runner-image-context.sh turbo-consumer
 
       - name: Set job-ref


### PR DESCRIPTION
## Summary

- consolidate Turbo workflow path-based change detection into the existing `Detect changes` step
- compute changed files once and reuse them for E2B, migration, crates, CI, E2E, and API-backend outputs
- keep existing CI behavior unchanged; this does not add crates-only skip logic

Refs #14206

## Testing

- `bash -n .github/scripts/*.sh .github/scripts/tests/*.sh && for test_script in .github/scripts/tests/*.sh; do bash "$test_script"; done`
- `git diff --check -- .github/workflows/turbo.yml`
- `actionlint .github/workflows/turbo.yml`
