### PR TITLE
test: extract runner exit assertion helper

### DIFF
--- a/crates/runner/src/cmd/start/tests/idle_reuse.rs
+++ b/crates/runner/src/cmd/start/tests/idle_reuse.rs
@@ -1,10 +1,11 @@
 use super::super::*;
 use super::support::{
-    context_with_session, minimal_context, mock_run_config, mock_run_config_with_overrides,
-    publish_idle_status, push_job, seed_idle_pool, seed_idle_pool_with_overrides, shutdown,
-    status_idle_sessions, test_profiles, two_profiles, wait_budget_count, wait_cancel_token,
-    wait_idle_pool_len, wait_idle_pool_sessions, wait_parking_state, wait_sandbox_lifecycle_counts,
-    wait_status_idle_empty_with_active_run, wait_status_idle_sessions_and_active_runs,
+    assert_run_exits_within, context_with_session, minimal_context, mock_run_config,
+    mock_run_config_with_overrides, publish_idle_status, push_job, seed_idle_pool,
+    seed_idle_pool_with_overrides, shutdown, status_idle_sessions, test_profiles, two_profiles,
+    wait_budget_count, wait_cancel_token, wait_idle_pool_len, wait_idle_pool_sessions,
+    wait_parking_state, wait_sandbox_lifecycle_counts, wait_status_idle_empty_with_active_run,
+    wait_status_idle_sessions_and_active_runs,
 };
 
 use crate::idle_pool::ParkingState;
@@ -817,12 +818,12 @@ async fn job_completing_during_active_draining_is_not_parked() {
     );
 
     // Draining mode observes jobs.is_empty → auto-Stop → teardown.
-    match tokio::time::timeout(Duration::from_secs(5), run_handle).await {
-        Ok(Ok(Ok(()))) => {}
-        Ok(Ok(Err(e))) => panic!("run() returned error: {e}"),
-        Ok(Err(e)) => panic!("task panicked: {e}"),
-        Err(_) => panic!("natural drain should exit within 5s"),
-    }
+    assert_run_exits_within(
+        run_handle,
+        Duration::from_secs(5),
+        "natural drain should exit within 5s",
+    )
+    .await;
 
     // Leak proof: pool empty, budget fully released.
     assert_eq!(
@@ -899,12 +900,12 @@ async fn soft_drain_resume_opens_parking_before_running_ack() {
     );
 
     env.trigger_stopping().await;
-    match tokio::time::timeout(Duration::from_secs(5), run_handle).await {
-        Ok(Ok(Ok(()))) => {}
-        Ok(Ok(Err(e))) => panic!("run() returned error: {e}"),
-        Ok(Err(e)) => panic!("task panicked: {e}"),
-        Err(_) => panic!("hard shutdown should exit within 5s"),
-    }
+    assert_run_exits_within(
+        run_handle,
+        Duration::from_secs(5),
+        "hard shutdown should exit within 5s",
+    )
+    .await;
 }
 
 /// Regression (G2): on SIGTERM from Running, teardown's
@@ -953,12 +954,12 @@ async fn shutdown_clears_idle_vms_in_status_json() {
     // SIGTERM path: Draining mode is bypassed, so teardown's
     // drain_idle_pool is the only site that can clear idle_vms.
     env.trigger_stopping().await;
-    match tokio::time::timeout(Duration::from_secs(5), run_handle).await {
-        Ok(Ok(Ok(()))) => {}
-        Ok(Ok(Err(e))) => panic!("run() returned error: {e}"),
-        Ok(Err(e)) => panic!("task panicked: {e}"),
-        Err(_) => panic!("hard shutdown should exit within 5s"),
-    }
+    assert_run_exits_within(
+        run_handle,
+        Duration::from_secs(5),
+        "hard shutdown should exit within 5s",
+    )
+    .await;
 
     // Post-shutdown: mode=stopped, idle_vms empty/absent.
     let post: serde_json::Value =

--- a/crates/runner/src/cmd/start/tests/main_loop.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop.rs
@@ -1,9 +1,10 @@
 use super::super::*;
 use super::support::{
-    context_with_session, minimal_context, mock_run_config, mock_run_config_with_api_url,
-    mock_run_config_with_delay, mock_run_config_with_overrides, push_job, shutdown, test_profiles,
-    wait_budget_count, wait_budget_exhausted_reactor, wait_cancel_token, wait_cancel_token_removed,
-    wait_discover_entered, wait_parking_state, wait_status_mode,
+    assert_run_exits_within, context_with_session, minimal_context, mock_run_config,
+    mock_run_config_with_api_url, mock_run_config_with_delay, mock_run_config_with_overrides,
+    push_job, shutdown, test_profiles, wait_budget_count, wait_budget_exhausted_reactor,
+    wait_cancel_token, wait_cancel_token_removed, wait_discover_entered, wait_parking_state,
+    wait_status_mode,
 };
 
 use super::super::signals::{SignalController, SignalHandlerTask, handle_resume_signal};
@@ -259,14 +260,12 @@ async fn shutdown_completes_without_deadlock() {
     // `provider.shutdown()`. Without that drop → deadlock (regression #8898).
     env.drain();
 
-    match tokio::time::timeout(Duration::from_secs(2), run_handle).await {
-        Ok(Ok(Ok(()))) => {}
-        Ok(Ok(Err(e))) => panic!("run() returned error: {e}"),
-        Ok(Err(e)) => panic!("task panicked: {e}"),
-        Err(_) => {
-            panic!("deadlock detected: run() did not finish within 2s (regression #8898)")
-        }
-    }
+    assert_run_exits_within(
+        run_handle,
+        Duration::from_secs(2),
+        "deadlock detected: run() did not finish within 2s (regression #8898)",
+    )
+    .await;
 }
 
 #[tokio::test]
@@ -432,12 +431,12 @@ async fn drain_resume_then_second_drain_drains_idle_pool() {
     );
 
     env.drain();
-    match tokio::time::timeout(Duration::from_secs(5), run_handle).await {
-        Ok(Ok(Ok(()))) => {}
-        Ok(Ok(Err(e))) => panic!("run() returned error: {e}"),
-        Ok(Err(e)) => panic!("task panicked: {e}"),
-        Err(_) => panic!("second drain should exit within 5s"),
-    }
+    assert_run_exits_within(
+        run_handle,
+        Duration::from_secs(5),
+        "second drain should exit within 5s",
+    )
+    .await;
 
     assert_eq!(
         idle_pool.lock().await.len(),
@@ -558,12 +557,12 @@ async fn drain_without_active_jobs_exits_promptly() {
     wait_discover_entered(&env, Duration::from_secs(2)).await;
     env.drain();
 
-    match tokio::time::timeout(Duration::from_secs(2), run_handle).await {
-        Ok(Ok(Ok(()))) => {}
-        Ok(Ok(Err(e))) => panic!("run() returned error: {e}"),
-        Ok(Err(e)) => panic!("task panicked: {e}"),
-        Err(_) => panic!("drain with no active jobs should exit within 2s"),
-    }
+    assert_run_exits_within(
+        run_handle,
+        Duration::from_secs(2),
+        "drain with no active jobs should exit within 2s",
+    )
+    .await;
 }
 
 /// SIGUSR2 on an already-Running runner is a no-op: it does not disturb
@@ -613,12 +612,12 @@ async fn hard_shutdown_cancels_active_jobs() {
     // SIGTERM equivalent: latch hard-shutdown, cancel all in-flight jobs.
     env.trigger_stopping().await;
 
-    match tokio::time::timeout(Duration::from_secs(3), run_handle).await {
-        Ok(Ok(Ok(()))) => {}
-        Ok(Ok(Err(e))) => panic!("run() returned error: {e}"),
-        Ok(Err(e)) => panic!("task panicked: {e}"),
-        Err(_) => panic!("hard shutdown should exit within 3s — got stuck"),
-    }
+    assert_run_exits_within(
+        run_handle,
+        Duration::from_secs(3),
+        "hard shutdown should exit within 3s — got stuck",
+    )
+    .await;
 
     // The cancelled job reports the synthetic "cancelled by user" error.
     let comps = env.handle.completions.lock().unwrap();
@@ -725,12 +724,12 @@ async fn assert_signal_handler_task_end_cancels_active_jobs(
 
     trigger_handler_task_end();
 
-    match tokio::time::timeout(Duration::from_secs(3), run_handle).await {
-        Ok(Ok(Ok(()))) => {}
-        Ok(Ok(Err(e))) => panic!("run() returned error: {e}"),
-        Ok(Err(e)) => panic!("task panicked: {e}"),
-        Err(_) => panic!("signal handler exit should cancel active jobs and stop promptly"),
-    }
+    assert_run_exits_within(
+        run_handle,
+        Duration::from_secs(3),
+        "signal handler exit should cancel active jobs and stop promptly",
+    )
+    .await;
 
     let comps = env.handle.completions.lock().unwrap();
     let c = comps
@@ -763,12 +762,12 @@ async fn drain_then_hard_shutdown_upgrades() {
     // Upgrade to hard shutdown.
     env.trigger_stopping().await;
 
-    match tokio::time::timeout(Duration::from_secs(3), run_handle).await {
-        Ok(Ok(Ok(()))) => {}
-        Ok(Ok(Err(e))) => panic!("run() returned error: {e}"),
-        Ok(Err(e)) => panic!("task panicked: {e}"),
-        Err(_) => panic!("Draining → hard shutdown should exit within 3s"),
-    }
+    assert_run_exits_within(
+        run_handle,
+        Duration::from_secs(3),
+        "Draining → hard shutdown should exit within 3s",
+    )
+    .await;
 }
 
 /// TOCTOU regression: a SIGTERM that iterates `cancel_tokens` *before*
@@ -869,12 +868,12 @@ async fn resume_after_stopping_is_ignored() {
         "mode must remain Stopping after ignored SIGUSR2"
     );
 
-    match tokio::time::timeout(Duration::from_secs(2), run_handle).await {
-        Ok(Ok(Ok(()))) => {}
-        Ok(Ok(Err(e))) => panic!("run() returned error: {e}"),
-        Ok(Err(e)) => panic!("task panicked: {e}"),
-        Err(_) => panic!("hard shutdown should exit within 2s"),
-    }
+    assert_run_exits_within(
+        run_handle,
+        Duration::from_secs(2),
+        "hard shutdown should exit within 2s",
+    )
+    .await;
 }
 
 /// Regression for #10146 / #10223: the main-loop `idle_cleanup` and
@@ -946,12 +945,12 @@ async fn drain_with_jobs_transitions_to_stopping_when_empty() {
 
     // Draining mode should observe jobs.is_empty() and self-send
     // Stopping, leading to teardown and run() exit.
-    match tokio::time::timeout(Duration::from_secs(3), run_handle).await {
-        Ok(Ok(Ok(()))) => {}
-        Ok(Ok(Err(e))) => panic!("run() returned error: {e}"),
-        Ok(Err(e)) => panic!("task panicked: {e}"),
-        Err(_) => panic!("Draining natural drain should exit within 3s"),
-    }
+    assert_run_exits_within(
+        run_handle,
+        Duration::from_secs(3),
+        "Draining natural drain should exit within 3s",
+    )
+    .await;
 
     assert_eq!(
         *env.mode_tx.borrow(),

--- a/crates/runner/src/cmd/start/tests/support/mod.rs
+++ b/crates/runner/src/cmd/start/tests/support/mod.rs
@@ -19,7 +19,8 @@ pub(super) use self::status::{
     wait_status_mode,
 };
 pub(super) use self::wait::{
-    wait_budget_count, wait_budget_exhausted_reactor, wait_cancel_token, wait_cancel_token_removed,
-    wait_discover_entered, wait_idle_cleanup_processed_with_expired_entries, wait_idle_pool_len,
-    wait_idle_pool_sessions, wait_parking_state, wait_sandbox_lifecycle_counts,
+    assert_run_exits_within, wait_budget_count, wait_budget_exhausted_reactor, wait_cancel_token,
+    wait_cancel_token_removed, wait_discover_entered,
+    wait_idle_cleanup_processed_with_expired_entries, wait_idle_pool_len, wait_idle_pool_sessions,
+    wait_parking_state, wait_sandbox_lifecycle_counts,
 };

--- a/crates/runner/src/cmd/start/tests/support/wait.rs
+++ b/crates/runner/src/cmd/start/tests/support/wait.rs
@@ -28,6 +28,19 @@ where
     }
 }
 
+pub(in super::super) async fn assert_run_exits_within(
+    run_handle: tokio::task::JoinHandle<RunnerResult<()>>,
+    timeout: Duration,
+    timeout_msg: &str,
+) {
+    match tokio::time::timeout(timeout, run_handle).await {
+        Ok(Ok(Ok(()))) => {}
+        Ok(Ok(Err(e))) => panic!("run() returned error: {e}"),
+        Ok(Err(e)) => panic!("task panicked: {e}"),
+        Err(_) => panic!("{timeout_msg}"),
+    }
+}
+
 /// Poll until `budget.allocated().2` (running_count) reaches `expected`.
 ///
 /// The active budget lease is dropped after `provider.complete()` in the


### PR DESCRIPTION
## Summary

- add a narrow `assert_run_exits_within` helper for runner start tests
- replace the 11 equivalent `timeout(..., run_handle)` nested match blocks
- leave `shutdown(...)` and non-equivalent timeout patterns unchanged

## Tests

- `CARGO_BUILD_JOBS=1 cargo test --manifest-path crates/Cargo.toml -p runner cmd::start::tests::main_loop`
- `CARGO_BUILD_JOBS=1 cargo test --manifest-path crates/Cargo.toml -p runner cmd::start::tests::idle_reuse`
- `CARGO_BUILD_JOBS=1 cargo test --manifest-path crates/Cargo.toml -p runner`
- `CARGO_BUILD_JOBS=1 cargo clippy --manifest-path crates/Cargo.toml -p runner -- -D warnings`

Closes #14143
