### PR TITLE
fix: align slack api parity with web

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-slack-status.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-slack-status.test.ts
@@ -131,6 +131,36 @@ describe("GET /api/zero/integrations/slack", () => {
     expect(response.body.workspaceName).toBe("Test Org Workspace");
   });
 
+  it("returns empty environment details when no default agent version is configured", async () => {
+    const orgId = `org_${randomUUID()}`;
+    const userId = `user_${randomUUID()}`;
+    const fixture = await track(
+      store.set(seedSlackOrgInstallation$, { orgId }, context.signal),
+    );
+    await store.set(
+      seedSlackOrgConnection$,
+      { slackWorkspaceId: fixture.slackWorkspaceId, vm0UserId: userId },
+      context.signal,
+    );
+    mocks.clerk.session(userId, orgId);
+
+    const client = setupApp({ context })(zeroIntegrationsSlackContract);
+
+    const response = await accept(
+      client.getStatus({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body.environment).toStrictEqual({
+      requiredSecrets: [],
+      requiredVars: [],
+      missingSecrets: [],
+      missingVars: [],
+    });
+  });
+
   it("returns isAdmin=true for admin members", async () => {
     const orgId = `org_${randomUUID()}`;
     const userId = `user_${randomUUID()}`;

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-slack-interactive.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-slack-interactive.test.ts
@@ -275,6 +275,42 @@ describe("POST /api/zero/slack/interactive", () => {
     });
   });
 
+  it("persists the selected agent when channel confirmation fails", async () => {
+    const fixture = await track(
+      store.set(
+        seedSlackWebhookFixture$,
+        {
+          withConnection: true,
+          withDefaultAgent: true,
+          withSwitchAgent: true,
+        },
+        context.signal,
+      ),
+    );
+    expect(fixture.switchAgentId).toBeTruthy();
+    context.mocks.slack.chat.postEphemeral.mockRejectedValueOnce(
+      new Error("ephemeral failed"),
+    );
+
+    const response = await postInteractive(
+      agentPickerSubmission({
+        workspaceId: fixture.slackWorkspaceId,
+        slackUserId: fixture.slackUserId,
+        selectedValue: fixture.switchAgentId ?? "",
+        channelId: "C-test",
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(
+      store.set(
+        findSlackAgentPreference$,
+        { orgId: fixture.orgId, userId: fixture.userId },
+        context.signal,
+      ),
+    ).resolves.toBe(fixture.switchAgentId);
+  });
+
   it("persists the selected model and opens the home switch modal", async () => {
     const fixture = await track(
       store.set(

--- a/turbo/apps/api/src/signals/routes/zero-integrations-slack.ts
+++ b/turbo/apps/api/src/signals/routes/zero-integrations-slack.ts
@@ -67,8 +67,21 @@ const slackDownloadFileContract = c.router({
   },
 });
 
+type SlackEnvironment = NonNullable<
+  z.infer<typeof slackOrgStatusSchema>["environment"]
+>;
+
+function emptySlackEnvironment(): SlackEnvironment {
+  return {
+    requiredSecrets: [],
+    requiredVars: [],
+    missingSecrets: [],
+    missingVars: [],
+  };
+}
+
 const getSlackEnvironment$ = computed(
-  async (get): Promise<z.infer<typeof slackOrgStatusSchema>["environment"]> => {
+  async (get): Promise<SlackEnvironment> => {
     const auth = get(organizationAuthContext$);
     const db = get(db$);
 
@@ -81,7 +94,7 @@ const getSlackEnvironment$ = computed(
       .limit(1);
 
     if (!meta?.defaultAgentId) {
-      return undefined;
+      return emptySlackEnvironment();
     }
 
     const [compose] = await db
@@ -91,7 +104,7 @@ const getSlackEnvironment$ = computed(
       .limit(1);
 
     if (!compose?.headVersionId) {
-      return undefined;
+      return emptySlackEnvironment();
     }
 
     const [version] = await db
@@ -101,7 +114,7 @@ const getSlackEnvironment$ = computed(
       .limit(1);
 
     if (!version) {
-      return undefined;
+      return emptySlackEnvironment();
     }
 
     const grouped = extractAndGroupVariables(version.content);
@@ -161,25 +174,22 @@ const getSlackStatusInner$ = computed(async (get) => {
     }),
   );
 
-  const environment = status.isConnected
-    ? await get(getSlackEnvironment$)
-    : undefined;
-
+  const statusFields = status.isConnected
+    ? {
+        workspaceName: status.workspaceName,
+        defaultAgentName: status.defaultAgentName,
+        agentOrgSlug: status.agentOrgSlug,
+        environment: await get(getSlackEnvironment$),
+      }
+    : {
+        installUrl: status.installUrl,
+        connectUrl: status.connectUrl,
+      };
   const body: z.infer<typeof slackOrgStatusSchema> = {
     isConnected: status.isConnected,
     isInstalled: status.isInstalled,
     isAdmin: status.isAdmin,
-    ...(status.isConnected
-      ? {
-          workspaceName: status.workspaceName,
-          defaultAgentName: status.defaultAgentName,
-          agentOrgSlug: status.agentOrgSlug,
-          ...(environment !== undefined && { environment }),
-        }
-      : {
-          installUrl: status.installUrl,
-          connectUrl: status.connectUrl,
-        }),
+    ...statusFields,
     ...(status.scopeMismatch !== null && {
       scopeMismatch: status.scopeMismatch,
       reinstallUrl: status.reinstallUrl,

--- a/turbo/apps/api/src/signals/services/zero-slack-webhooks.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-slack-webhooks.service.ts
@@ -1654,11 +1654,16 @@ async function postEphemeralMessage(args: {
   readonly slackUserId: string;
   readonly text: string;
 }): Promise<void> {
-  await createSlackClient(args.botToken).chat.postEphemeral({
-    channel: args.channel,
-    user: args.slackUserId,
-    text: args.text,
-  });
+  const result = await settle(
+    createSlackClient(args.botToken).chat.postEphemeral({
+      channel: args.channel,
+      user: args.slackUserId,
+      text: args.text,
+    }),
+  );
+  if (!result.ok) {
+    L.warn("Failed to post ephemeral message", { error: result.error });
+  }
 }
 
 async function resolveOrgDefaultName(db: Db, orgId: string): Promise<string> {


### PR DESCRIPTION
## Summary
- align Slack integration status so connected API responses always include environment details like the web route
- make Slack interactive ephemeral confirmation best-effort, matching the web route behavior after agent/model switches
- add API route coverage for the parity cases

## Tests
- pnpm format
- pnpm -F api lint
- pnpm -F api check-types
- pnpm -F api exec vitest run src/signals/routes/__tests__/zero-integrations-slack-status.test.ts src/signals/routes/__tests__/zero-slack-interactive.test.ts
- pnpm knip --workspace api
- pnpm -F api exec vitest run --fileParallelism=false <all API Slack route tests> (16 files / 185 tests)
- pnpm -F web exec vitest run --fileParallelism=false <all web Slack route tests> (12 files / 192 tests)
- pre-commit: pnpm check-types, pnpm knip