### PR TITLE
fix: align telegram api endpoints with web behavior

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-telegram-upload-complete.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-telegram-upload-complete.test.ts
@@ -261,6 +261,39 @@ describe("POST /api/zero/integrations/telegram/upload-file/complete", () => {
     expect(response.body.error.code).toBe("NOT_FOUND");
   });
 
+  it("returns 403 when authenticated without an organization context", async () => {
+    const userId = `user_${randomUUID().slice(0, 8)}`;
+    const orgId = `org_${randomUUID().slice(0, 8)}`;
+    const runId = `run_${randomUUID()}`;
+    context.mocks.clerk.users.getOrganizationMembershipList.mockResolvedValue({
+      data: [],
+    });
+    const client = setupApp({ context })(
+      integrationsTelegramUploadCompleteContract,
+    );
+
+    const response = await accept(
+      client.complete({
+        body: {
+          uploadId: randomUUID(),
+          botId: uniqueBotId(),
+          chatId: "-1001234567890",
+        },
+        headers: {
+          authorization: `Bearer ${zeroToken({ userId, orgId, runId })}`,
+        },
+      }),
+      [403],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Organization context is required",
+        code: "FORBIDDEN",
+      },
+    });
+  });
+
   it("returns 400 when Telegram rejects the sendDocument call", async () => {
     const fixture = await seedSendableContext();
     fixtures.push(fixture);

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-telegram-upload-init.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-telegram-upload-init.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from "vitest";
 import { integrationsTelegramUploadInitContract } from "@vm0/api-contracts/contracts/integrations";
 
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { mockEnv } from "../../../lib/env";
 import { now } from "../../../lib/time";
 import { signSandboxJwtForTests } from "../../auth/tokens";
 import {
@@ -66,6 +67,8 @@ describe("POST /api/zero/integrations/telegram/upload-file/init", () => {
   });
 
   it("returns a presigned upload URL and final file URL", async () => {
+    mockEnv("S3_ENDPOINT", "http://internal-s3.test");
+    mockEnv("S3_PUBLIC_ENDPOINT", "https://public-s3.test");
     const userId = `user_${randomUUID().slice(0, 8)}`;
     const orgId = `org_${randomUUID().slice(0, 8)}`;
     const runId = `run_${randomUUID()}`;
@@ -106,6 +109,9 @@ describe("POST /api/zero/integrations/telegram/upload-file/init", () => {
     expect(cmd.input.Bucket).toBe("test-user-artifacts");
     expect(cmd.input.Key).toBe(
       `artifacts/${userId}/${response.body.uploadId}/daily_report.pdf`,
+    );
+    expect(context.mocks.s3.clientConfig).toHaveBeenCalledWith(
+      expect.objectContaining({ endpoint: "https://public-s3.test" }),
     );
   });
 

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-telegram-data.service.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-telegram-data.service.test.ts
@@ -109,6 +109,8 @@ describe("zeroTelegramBots service", () => {
         orgId,
         ownerUserId: userId,
         telegramBotId: ownerBotId,
+        composeName: "compose-owned-agent",
+        agentName: "zero-owned-agent",
       },
       context.signal,
     );
@@ -157,6 +159,11 @@ describe("zeroTelegramBots service", () => {
       return bot.id === ownerBotId;
     });
     expect(ownerBot?.isOwner).toBeTruthy();
+    expect(ownerBot?.isConnected).toBeTruthy();
+    expect(ownerBot?.agent).toStrictEqual({
+      id: ownerInstall.composeId,
+      name: "compose-owned-agent",
+    });
     expect(ownerBot?.connectedUser).toStrictEqual({
       telegramUserId: "tg_owner",
       telegramUsername: "owner_tg",
@@ -166,6 +173,38 @@ describe("zeroTelegramBots service", () => {
       return bot.id === otherBotId;
     });
     expect(otherBot?.isOwner).toBeFalsy();
+    expect(otherBot?.isConnected).toBeFalsy();
+  });
+
+  it("marks a custom bot token invalid when getMe returns a different bot id", async () => {
+    const orgId = newOrgId();
+    const userId = newUserId();
+    const builder = makeTelegramFixtureBuilder(orgId);
+    builder.userIds.push(userId);
+    const botId = newTelegramBotId();
+
+    context.mocks.telegram.getMe.mockResolvedValue({
+      id: Number(botId) + 1,
+      is_bot: true,
+      first_name: "Wrong Bot",
+      username: "wrong_bot",
+    });
+
+    const installation = await store.set(
+      seedTelegramInstallation$,
+      { orgId, ownerUserId: userId, telegramBotId: botId },
+      context.signal,
+    );
+    builder.composeIds.push(installation.composeId);
+    builder.telegramBotIds.push(installation.telegramBotId);
+    trackFixture(freezeTelegramFixture(builder));
+
+    const bots = await store.get(zeroTelegramBots({ orgId, userId }));
+
+    const customBot = bots.find((bot) => {
+      return bot.id === botId;
+    });
+    expect(customBot?.tokenStatus).toBe("invalid");
   });
 
   it("returns the official bot with configured=false when env is unset", async () => {

--- a/turbo/apps/api/src/signals/routes/zero-integrations-telegram-upload-complete.ts
+++ b/turbo/apps/api/src/signals/routes/zero-integrations-telegram-upload-complete.ts
@@ -7,7 +7,7 @@ import {
 import { env } from "../../lib/env";
 import { buildArtifactPrefix, buildFileUrl } from "../../lib/file-url";
 import { inferMimetype } from "../../lib/mimetype";
-import { organizationAuthContext$ } from "../auth/auth-context";
+import { authContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
 import { bodyResultOf } from "../context/request";
 import { listS3Objects } from "../external/s3";
@@ -39,6 +39,16 @@ const uploadedFileNotFound = Object.freeze({
     error: Object.freeze({
       message: "Uploaded file not found",
       code: "NOT_FOUND",
+    }),
+  }),
+});
+
+const organizationContextRequired = Object.freeze({
+  status: 403 as const,
+  body: Object.freeze({
+    error: Object.freeze({
+      message: "Organization context is required",
+      code: "FORBIDDEN",
     }),
   }),
 });
@@ -91,7 +101,10 @@ function telegramErrorResponse(
 }
 
 const completeInner$ = command(async ({ get, set }, signal: AbortSignal) => {
-  const auth = get(organizationAuthContext$);
+  const auth = get(authContext$);
+  if (!auth.orgId) {
+    return organizationContextRequired;
+  }
   const orgId = auth.orgId;
   const userId = auth.userId;
   const runId =
@@ -177,8 +190,6 @@ const completeInner$ = command(async ({ get, set }, signal: AbortSignal) => {
 });
 
 const telegramWriteAuth = {
-  requireOrganization: true,
-  missingOrganizationStatus: 401,
   requiredCapability: "telegram:write",
 } as const;
 

--- a/turbo/apps/api/src/signals/routes/zero-integrations-telegram-upload-init.ts
+++ b/turbo/apps/api/src/signals/routes/zero-integrations-telegram-upload-init.ts
@@ -28,7 +28,13 @@ const initInner$ = command(async ({ get }, signal: AbortSignal) => {
   const s3Key = buildArtifactKey(auth.userId, uploadId, sanitized);
   const bucket = env("R2_USER_ARTIFACTS_BUCKET_NAME");
   const uploadUrl = await get(
-    generatePresignedPutUrl(bucket, s3Key, contentType, PUT_URL_TTL_SECONDS),
+    generatePresignedPutUrl(
+      bucket,
+      s3Key,
+      contentType,
+      PUT_URL_TTL_SECONDS,
+      true,
+    ),
   );
   signal.throwIfAborted();
 

--- a/turbo/apps/api/src/signals/services/zero-telegram-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-telegram-data.service.ts
@@ -15,7 +15,6 @@ import { telegramInstallations } from "@vm0/db/schema/telegram-installation";
 import { telegramOfficialUserLinks } from "@vm0/db/schema/telegram-official-user-link";
 import { telegramUserLinks } from "@vm0/db/schema/telegram-user-link";
 import { telegramUserAgentPreferences } from "@vm0/db/schema/telegram-user-agent-preference";
-import { zeroAgents } from "@vm0/db/schema/zero-agent";
 import { and, desc, eq } from "drizzle-orm";
 
 import { env } from "../../lib/env";
@@ -209,38 +208,8 @@ export function zeroTelegramBots(args: {
       );
 
     const customBots: TelegramBotListItem[] = await Promise.all(
-      installations.map(async (installation) => {
-        const [tokenStatus, userLink] = await Promise.all([
-          resolveTokenStatus(installation.encryptedBotToken),
-          get(
-            telegramUserLink({
-              botId: installation.telegramBotId,
-              userId: args.userId,
-            }),
-          ),
-        ]);
-
-        let agent: { id: string; name: string } | null = null;
-        const [agentRow] = await db
-          .select({ id: zeroAgents.id, name: zeroAgents.name })
-          .from(agentComposes)
-          .innerJoin(zeroAgents, eq(agentComposes.id, zeroAgents.id))
-          .where(eq(agentComposes.id, installation.defaultComposeId))
-          .limit(1);
-        if (agentRow) {
-          agent = { id: agentRow.id, name: agentRow.name };
-        }
-
-        return {
-          id: installation.telegramBotId,
-          username: installation.botUsername ?? null,
-          avatarUrl: buildTelegramBotAvatarUrl(installation.telegramBotId),
-          agent,
-          isOwner: installation.ownerUserId === args.userId,
-          isConnected: tokenStatus === "valid",
-          connectedUser: userLink,
-          tokenStatus,
-        };
+      installations.map((installation) => {
+        return get(customTelegramBot({ installation, userId: args.userId }));
       }),
     );
 
@@ -693,14 +662,6 @@ export function telegramBotToken(args: {
       botUsername: row.botUsername ?? null,
     };
   });
-}
-
-async function resolveTokenStatus(
-  encryptedBotToken: string,
-): Promise<"valid" | "invalid" | "unknown"> {
-  const token = decryptSecretValue(encryptedBotToken);
-  const settled = await settle(getMe(token));
-  return settled.ok ? ("valid" as const) : ("unknown" as const);
 }
 
 function isInvalidTelegramTokenError(error: unknown): boolean {


### PR DESCRIPTION
## Summary
- Align `/api/zero/integrations/telegram/bots` custom bot status with the web implementation: connected state comes from the user link, agent data comes from the compose, and token status validates the Telegram bot id.
- Generate Telegram upload init presigned URLs with the public S3 endpoint, matching the web route.
- Match the web upload-complete response for authenticated requests without org context by returning 403 `Organization context is required`.

## Tests
- `pnpm --filter api exec vitest src/signals/routes/__tests__/zero-telegram-data.service.test.ts src/signals/routes/__tests__/zero-integrations-telegram-upload-init.test.ts src/signals/routes/__tests__/zero-integrations-telegram-upload-complete.test.ts --run`
- `pnpm --filter api lint`
- `pnpm exec prettier --write apps/api/src/signals/services/zero-telegram-data.service.ts apps/api/src/signals/routes/zero-integrations-telegram-upload-init.ts apps/api/src/signals/routes/zero-integrations-telegram-upload-complete.ts apps/api/src/signals/routes/__tests__/zero-telegram-data.service.test.ts apps/api/src/signals/routes/__tests__/zero-integrations-telegram-upload-init.test.ts apps/api/src/signals/routes/__tests__/zero-integrations-telegram-upload-complete.test.ts`

## Notes
- Ran `scripts/prepare.sh` after tests initially failed due missing generated firewall files.
- `pnpm --filter api check-types` and the pre-commit root `pnpm check-types` currently fail on existing unrelated ts-rest type errors such as `Property 'body' does not exist on type 'never'` across `apps/platform`/API test files; no errors were reported from the files changed here before the broader failure.
