### PR TITLE
fix: integrate desktop titlebar chrome

### DIFF
--- a/turbo/apps/desktop/src/desktop-window-chrome.ts
+++ b/turbo/apps/desktop/src/desktop-window-chrome.ts
@@ -1,0 +1,17 @@
+type DesktopWindowChromeOptions = Pick<
+  Electron.BrowserWindowConstructorOptions,
+  "titleBarStyle" | "trafficLightPosition"
+>;
+
+export function buildDesktopWindowChromeOptions(
+  platform: NodeJS.Platform,
+): DesktopWindowChromeOptions {
+  if (platform !== "darwin") {
+    return {};
+  }
+
+  return {
+    titleBarStyle: "hiddenInset",
+    trafficLightPosition: { x: 16, y: 18 },
+  };
+}

--- a/turbo/apps/desktop/src/desktop-window-lifecycle.test.ts
+++ b/turbo/apps/desktop/src/desktop-window-lifecycle.test.ts
@@ -2,8 +2,20 @@ import {
   shouldHideMainWindowOnClose,
   showAndFocusWindow,
 } from "./desktop-window-lifecycle";
+import { buildDesktopWindowChromeOptions } from "./desktop-window-chrome";
 
 describe("desktop window lifecycle", () => {
+  it("uses integrated macOS window chrome", () => {
+    expect(buildDesktopWindowChromeOptions("darwin")).toStrictEqual({
+      titleBarStyle: "hiddenInset",
+      trafficLightPosition: { x: 16, y: 18 },
+    });
+  });
+
+  it("keeps non-macOS window chrome default", () => {
+    expect(buildDesktopWindowChromeOptions("linux")).toStrictEqual({});
+  });
+
   it("hides the main window on macOS close unless the app is quitting", () => {
     expect(
       shouldHideMainWindowOnClose({ platform: "darwin", isQuitting: false }),

--- a/turbo/apps/desktop/src/main.ts
+++ b/turbo/apps/desktop/src/main.ts
@@ -38,6 +38,7 @@ import {
   shouldHideMainWindowOnClose,
   showAndFocusWindow,
 } from "./desktop-window-lifecycle";
+import { buildDesktopWindowChromeOptions } from "./desktop-window-chrome";
 import { buildSignedOutPageUrl } from "./signed-out-page";
 import { decideWindowOpen, isAllowedAppNavigation } from "./window-policy";
 
@@ -284,6 +285,7 @@ function browserWindowOptions() {
     title: config.identity.displayName,
     backgroundColor: "#19191b",
     icon: appIconPath(),
+    ...buildDesktopWindowChromeOptions(process.platform),
     webPreferences: {
       nodeIntegration: false,
       contextIsolation: true,

--- a/turbo/apps/platform/src/views/css/index.css
+++ b/turbo/apps/platform/src/views/css/index.css
@@ -40,6 +40,34 @@
 :root {
   --sat: env(safe-area-inset-top, 0px);
   --sab: env(safe-area-inset-bottom, 0px);
+  --zero-desktop-titlebar-height: 48px;
+}
+
+.zero-sidebar-header {
+  padding-top: calc(0.375rem + var(--sat));
+}
+
+.zero-desktop-titlebar-drag-region,
+.zero-desktop-workspace-drag-region {
+  display: none;
+}
+
+.zero-desktop-no-drag {
+  -webkit-app-region: no-drag;
+}
+
+@media (min-width: 768px) {
+  .zero-app[data-desktop-shell] .zero-sidebar-header {
+    padding-top: 0;
+  }
+
+  .zero-app[data-desktop-shell] .zero-desktop-titlebar-drag-region,
+  .zero-app[data-desktop-shell] .zero-desktop-workspace-drag-region {
+    display: block;
+    flex-shrink: 0;
+    height: var(--zero-desktop-titlebar-height);
+    -webkit-app-region: drag;
+  }
 }
 
 /* Landing tagline carousel: smooth vertical fade-in */

--- a/turbo/apps/platform/src/views/zero-page/sidebar-layout.tsx
+++ b/turbo/apps/platform/src/views/zero-page/sidebar-layout.tsx
@@ -271,9 +271,14 @@ function SidebarLayoutInner({ children }: { children: ReactNode }) {
   const setShowAboutPage = useSet(setZeroShowAboutPage$);
   const expanded = useGet(sidebarExpanded$);
   const setExpanded = useSet(setSidebarExpanded$);
+  const isDesktopShell =
+    typeof window !== "undefined" && window.vm0DesktopLocalAgent !== undefined;
 
   return (
-    <div className="zero-app flex h-dvh w-full bg-background">
+    <div
+      data-desktop-shell={isDesktopShell ? "true" : undefined}
+      className="zero-app flex h-dvh w-full bg-background"
+    >
       <OrgManageDialogMount />
       <QueueDrawer />
       <ZeroSidebar />
@@ -286,6 +291,10 @@ function SidebarLayoutInner({ children }: { children: ReactNode }) {
         }}
       />
       <div className="flex flex-1 flex-col min-w-0 min-h-0 zero-workspace-bg">
+        <div
+          className="zero-desktop-workspace-drag-region"
+          aria-hidden="true"
+        />
         <InstallBanner />
         <IosInstallModal />
         <MobileTopBar />

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -242,7 +242,8 @@ function CollapsedSidebar() {
     return null;
   }
   return (
-    <aside className="zero-nav box-border hidden md:flex h-full w-16 shrink-0 flex-col border-r-[0.7px] border-sidebar-border bg-sidebar px-2 transition-all duration-300">
+    <aside className="zero-nav zero-collapsed-sidebar box-border hidden md:flex h-full w-16 shrink-0 flex-col border-r-[0.7px] border-sidebar-border bg-sidebar px-2 transition-all duration-300">
+      <div className="zero-desktop-titlebar-drag-region" aria-hidden="true" />
       <CollapsedExpandButton />
       <CollapsedNavList />
       <CollapsedFooter />
@@ -403,11 +404,9 @@ function ExpandedSidebar() {
 function ExpandedHeader() {
   const onCollapse = useSidebarCollapseToggle();
   return (
-    <div
-      className="shrink-0 px-2 pb-0"
-      style={{ paddingTop: "calc(0.375rem + var(--sat))" }}
-    >
-      <div className="flex items-center justify-between gap-2 rounded-lg py-0.5">
+    <div className="zero-sidebar-header shrink-0 px-2 pb-0">
+      <div className="zero-desktop-titlebar-drag-region" aria-hidden="true" />
+      <div className="zero-desktop-no-drag flex items-center justify-between gap-2 rounded-lg py-0.5">
         <div className="min-w-0 flex-1">
           <ZeroOrgSwitcher />
         </div>


### PR DESCRIPTION
## Summary
- hide the macOS desktop title bar while keeping native traffic lights positioned in the sidebar chrome
- add desktop-shell-only drag strips above the sidebar and workspace so the frameless window remains movable
- keep the new spacing gated behind the Electron preload bridge so normal Web UI does not gain extra top padding

## Testing
- pnpm -F @vm0/desktop check-types
- pnpm -F @vm0/app check-types
- pnpm -F @vm0/desktop lint
- pnpm -F @vm0/app lint
- pnpm -F @vm0/desktop test
- pnpm -F @vm0/app build
- pnpm -F @vm0/desktop package