### PR TITLE
fix: revoke desktop local agent hosts on delete

### DIFF
--- a/turbo/apps/desktop/src/desktop-local-agent-api.ts
+++ b/turbo/apps/desktop/src/desktop-local-agent-api.ts
@@ -42,6 +42,10 @@ export interface DesktopLocalAgentApiClient {
     readonly hostToken: string;
     readonly signal?: AbortSignal;
   }) => Promise<void>;
+  readonly deleteHost: (params: {
+    readonly hostId: string;
+    readonly signal?: AbortSignal;
+  }) => Promise<void>;
 }
 
 function replaceHostPrefix(hostname: string, target: string): string {
@@ -212,6 +216,17 @@ export function createDesktopLocalAgentApiClient(params: {
             authorization: `Bearer ${closeParams.hostToken}`,
           },
           signal: closeParams.signal,
+        },
+      );
+      await parseResponse<{ readonly ok: true }>(response);
+    },
+    async deleteHost(deleteParams) {
+      const response = await fetch(
+        `${apiBase}/api/zero/local-agent/hosts/${encodeURIComponent(deleteParams.hostId)}`,
+        {
+          method: "DELETE",
+          headers: await sessionHeaders(),
+          signal: deleteParams.signal,
         },
       );
       await parseResponse<{ readonly ok: true }>(response);

--- a/turbo/apps/desktop/src/desktop-local-agent-manager.test.ts
+++ b/turbo/apps/desktop/src/desktop-local-agent-manager.test.ts
@@ -64,6 +64,7 @@ function createHarness(
   const folders = [...harnessFolders];
   const startedHosts: string[] = [];
   const closedHosts: string[] = [];
+  const deletedHosts: string[] = [];
   const completedJobs: Array<{
     readonly jobId: string;
     readonly status: "succeeded" | "failed";
@@ -92,6 +93,9 @@ function createHarness(
     },
     async closeHost(params) {
       closedHosts.push(params.hostToken);
+    },
+    async deleteHost(params) {
+      deletedHosts.push(params.hostId);
     },
   };
   const manager = new DesktopLocalAgentManager({
@@ -140,6 +144,7 @@ function createHarness(
     manager,
     startedHosts,
     closedHosts,
+    deletedHosts,
     completedJobs,
     folders: harnessFolders,
   };
@@ -168,7 +173,8 @@ describe("DesktopLocalAgentManager", () => {
   });
 
   it("adds a Codex workspace with workspace-write permissions by default", async () => {
-    const { manager, startedHosts, closedHosts, folders } = createHarness();
+    const { manager, startedHosts, closedHosts, deletedHosts, folders } =
+      createHarness();
 
     await manager.setEnabled(true);
     const entry = await manager.add();
@@ -187,10 +193,11 @@ describe("DesktopLocalAgentManager", () => {
 
     await manager.stopAll();
     expect(closedHosts).toStrictEqual(["token-1"]);
+    expect(deletedHosts).toStrictEqual([]);
   });
 
   it("runs multiple configured workspaces independently", async () => {
-    const { manager, startedHosts, closedHosts } = createHarness({
+    const { manager, startedHosts, closedHosts, deletedHosts } = createHarness({
       folders: [createWorkspace("alpha"), createWorkspace("beta")],
     });
 
@@ -213,6 +220,7 @@ describe("DesktopLocalAgentManager", () => {
 
     await manager.stopAll();
     expect(closedHosts).toStrictEqual(["token-1", "token-2"]);
+    expect(deletedHosts).toStrictEqual([]);
   });
 
   it("restores persisted agents as stopped without autostarting them", async () => {
@@ -273,6 +281,90 @@ describe("DesktopLocalAgentManager", () => {
         errorMessage: "Codex not found",
       },
     ]);
+  });
+
+  it("revokes the server host before removing a Desktop local agent", async () => {
+    const folderPath = createWorkspace("alpha");
+    const { manager, closedHosts, deletedHosts } = createHarness({
+      initialEntries: [
+        {
+          id: "agent-1",
+          name: "alpha",
+          folderPath,
+          backend: "codex",
+          permissionMode: "workspace-write",
+          status: "stopped",
+          hostId: "host-1",
+        },
+      ],
+    });
+
+    await manager.setEnabled(true);
+    await manager.remove("agent-1");
+
+    await expect(manager.list()).resolves.toStrictEqual([]);
+    expect(closedHosts).toStrictEqual([]);
+    expect(deletedHosts).toStrictEqual(["host-1"]);
+  });
+
+  it("keeps the local entry visible when server host deletion fails", async () => {
+    const folderPath = createWorkspace("alpha");
+    const deletionAttempts: string[] = [];
+    const { manager } = createHarness({
+      initialEntries: [
+        {
+          id: "agent-1",
+          name: "alpha",
+          folderPath,
+          backend: "codex",
+          permissionMode: "workspace-write",
+          status: "stopped",
+          hostId: "host-1",
+        },
+      ],
+      apiOverrides: {
+        async deleteHost(params) {
+          deletionAttempts.push(params.hostId);
+          throw new Error("Local-agent host not found");
+        },
+      },
+    });
+
+    await manager.setEnabled(true);
+    await expect(manager.remove("agent-1")).rejects.toThrow(
+      "Local-agent host not found",
+    );
+
+    await expect(manager.list()).resolves.toMatchObject([
+      {
+        id: "agent-1",
+        status: "error",
+        errorMessage: "Local-agent host not found",
+      },
+    ]);
+    expect(deletionAttempts).toStrictEqual(["host-1"]);
+  });
+
+  it("removes local-only entries without calling server delete", async () => {
+    const folderPath = createWorkspace("alpha");
+    const { manager, deletedHosts } = createHarness({
+      initialEntries: [
+        {
+          id: "agent-1",
+          name: "alpha",
+          folderPath,
+          backend: "codex",
+          permissionMode: "workspace-write",
+          status: "stopped",
+        },
+      ],
+    });
+
+    await manager.setEnabled(true);
+    await manager.remove("agent-1");
+
+    await expect(manager.list()).resolves.toStrictEqual([]);
+    expect(deletedHosts).toStrictEqual([]);
   });
 
   it("uses the resolved executable path for jobs", async () => {
@@ -336,25 +428,27 @@ describe("DesktopLocalAgentManager", () => {
         });
       },
     );
-    const { manager, closedHosts, completedJobs } = createHarness({
-      executeBackend,
-      apiOverrides: {
-        async claimNextJob() {
-          claimCount += 1;
-          if (claimCount === 1) {
-            return {
-              status: "job",
-              job: {
-                id: "job-1",
-                backend: "codex",
-                prompt: "run task",
-              },
-            };
-          }
-          return { status: "idle" };
+    const { manager, closedHosts, deletedHosts, completedJobs } = createHarness(
+      {
+        executeBackend,
+        apiOverrides: {
+          async claimNextJob() {
+            claimCount += 1;
+            if (claimCount === 1) {
+              return {
+                status: "job",
+                job: {
+                  id: "job-1",
+                  backend: "codex",
+                  prompt: "run task",
+                },
+              };
+            }
+            return { status: "idle" };
+          },
         },
       },
-    });
+    );
 
     await manager.setEnabled(true);
     await manager.add();
@@ -373,5 +467,6 @@ describe("DesktopLocalAgentManager", () => {
       },
     ]);
     expect(closedHosts).toStrictEqual(["token-1"]);
+    expect(deletedHosts).toStrictEqual([]);
   });
 });

--- a/turbo/apps/desktop/src/desktop-local-agent-manager.ts
+++ b/turbo/apps/desktop/src/desktop-local-agent-manager.ts
@@ -276,7 +276,22 @@ export class DesktopLocalAgentManager {
 
   async remove(id: string): Promise<void> {
     this.assertEnabled();
+    await this.ensureLoaded();
+    const entry = this.requireEntry(id);
+    const hostId = entry.hostId;
     await this.stopEntry(id).catch(() => {});
+    if (hostId) {
+      try {
+        await this.deps.api.deleteHost({ hostId });
+      } catch (error) {
+        this.updateEntry(id, {
+          status: "error",
+          errorMessage: errorMessage(error),
+        });
+        await this.persistAndNotify();
+        throw error;
+      }
+    }
     await this.ensureLoaded();
     this.entries = this.entriesOrThrow().filter((entry) => {
       return entry.id !== id;

--- a/turbo/apps/platform/src/signals/desktop-local-agent-page/desktop-local-agent-signals.ts
+++ b/turbo/apps/platform/src/signals/desktop-local-agent-page/desktop-local-agent-signals.ts
@@ -1,5 +1,11 @@
 import { command, computed, state } from "ccstate";
+import {
+  zeroLocalAgentHostsContract,
+  type LocalAgentHost,
+} from "@vm0/api-contracts/contracts/zero-local-agent";
 import { toast } from "@vm0/ui/components/ui/sonner";
+import { accept } from "../../lib/accept.ts";
+import { zeroClient$ } from "../api-client.ts";
 
 type DesktopLocalAgentApi = NonNullable<Window["vm0DesktopLocalAgent"]>;
 export type DesktopLocalAgentEntry = Awaited<
@@ -15,6 +21,7 @@ export type DesktopLocalAgentPermissionMode =
 interface DesktopLocalAgentData {
   readonly entries: readonly DesktopLocalAgentEntry[];
   readonly probes: readonly DesktopLocalAgentBackendProbe[];
+  readonly serverHosts: readonly LocalAgentHost[];
 }
 
 const internalReload$ = state(0);
@@ -41,11 +48,23 @@ export const desktopLocalAgentData$ = computed(
   async (get): Promise<DesktopLocalAgentData> => {
     get(internalReload$);
     const api = desktopLocalAgentApi();
-    const [entries, probes] = await Promise.all([
+    const createClient = get(zeroClient$);
+    const client = createClient(zeroLocalAgentHostsContract);
+    const [entries, probes, serverHostResults] = await Promise.all([
       api.list(),
       api.detectBackends(),
+      Promise.allSettled([accept(client.list(), [200], { toast: false })]),
     ]);
-    return { entries, probes };
+    const [serverHostsResult] = serverHostResults;
+    const serverHosts: readonly LocalAgentHost[] =
+      serverHostsResult?.status === "fulfilled"
+        ? serverHostsResult.value.body.hosts
+        : [];
+    return {
+      entries,
+      probes,
+      serverHosts,
+    };
   },
 );
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/desktop-local-agent-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/desktop-local-agent-page.test.tsx
@@ -1,8 +1,11 @@
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { zeroLocalAgentHostsContract } from "@vm0/api-contracts/contracts/zero-local-agent";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { setupPage } from "../../../__tests__/page-helper.ts";
+import { mockApi } from "../../../mocks/msw-contract.ts";
+import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 
 const context = testContext();
@@ -26,6 +29,24 @@ describe("zero desktop local agent page", () => {
     const setEnabled = vi.fn(() => {
       return Promise.resolve();
     });
+    let serverHostListCalls = 0;
+    server.use(
+      mockApi(zeroLocalAgentHostsContract.list, ({ respond }) => {
+        serverHostListCalls += 1;
+        return respond(200, {
+          hosts: [
+            {
+              id: "host-1",
+              displayName: "alpha",
+              supportedBackends: ["codex"],
+              status: "online",
+              lastSeenAt: "2026-05-19T00:00:00.000Z",
+              createdAt: "2026-05-19T00:00:00.000Z",
+            },
+          ],
+        });
+      }),
+    );
     installDesktopLocalAgentApi({
       setEnabled,
       list() {
@@ -86,6 +107,7 @@ describe("zero desktop local agent page", () => {
     expect(screen.getByText("workspace-write")).toBeInTheDocument();
     expect(screen.getByText("online")).toBeInTheDocument();
     expect(setEnabled).toHaveBeenCalledWith(true);
+    expect(serverHostListCalls).toBeGreaterThan(0);
   });
 
   it("surfaces backend health errors and blocks unavailable backend selection", async () => {


### PR DESCRIPTION
## Summary
- add a Desktop local-agent host DELETE client and call it when removing a Desktop Local Agent with a known hostId
- keep stop/quit semantics close-only while making delete failures preserve the local entry with an error state
- request server local-agent hosts when the Desktop Local Agents page opens, without blocking local entries if that read fails

Closes #14215

## Testing
- pnpm -F @vm0/desktop exec vitest run src/desktop-local-agent-manager.test.ts
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/desktop-local-agent-page.test.tsx
- pnpm -F @vm0/desktop check-types
- pnpm -F @vm0/app check-types
- pnpm -F @vm0/desktop lint
- pnpm -F @vm0/app lint
- pnpm turbo run lint
- pnpm check-types
- pnpm knip
- pnpm exec prettier --check apps/desktop/src/desktop-local-agent-api.ts apps/desktop/src/desktop-local-agent-manager.ts apps/desktop/src/desktop-local-agent-manager.test.ts apps/platform/src/signals/desktop-local-agent-page/desktop-local-agent-signals.ts apps/platform/src/views/zero-page/__tests__/desktop-local-agent-page.test.tsx

## Notes
- Full local `pnpm vitest` was attempted. The targeted tests passed, but the full run hit unrelated existing failures outside this PR scope: `@vm0/connectors` google-ads firewall secret consistency and `web` resolve-model-provider assertions. The API email outbox failure from the full run passed when rerun directly.