### PR TITLE
refactor: migrate sandbox runner processes to supervised exec

### DIFF
--- a/crates/runner/src/cmd/start/tests/budget.rs
+++ b/crates/runner/src/cmd/start/tests/budget.rs
@@ -19,7 +19,7 @@ use super::support::{
 #[tokio::test(start_paused = true)]
 async fn budget_full_skips_then_resumes() {
     let gate = Arc::new(tokio::sync::Notify::new());
-    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::with_wait_exit_gate(
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::with_wait_process_gate(
         Arc::clone(&gate),
     ));
     // Budget for exactly 1 job (2 vcpu, 4096 MB).
@@ -69,7 +69,7 @@ async fn budget_full_skips_then_resumes() {
 #[tokio::test(start_paused = true)]
 async fn budget_exhausted_buffers_discovery_until_budget_frees() {
     let gate = Arc::new(tokio::sync::Notify::new());
-    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::with_wait_exit_gate(
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::with_wait_process_gate(
         Arc::clone(&gate),
     ));
     let (config, env) = mock_run_config_with_overrides(test_profiles(), 2, 4096, 1, overrides);

--- a/crates/runner/src/cmd/start/tests/failure_recovery/create_destroy.rs
+++ b/crates/runner/src/cmd/start/tests/failure_recovery/create_destroy.rs
@@ -33,11 +33,13 @@ async fn active_destroy_panic_still_reports_completion_and_releases_budget() {
 
 /// Test 20: Failed job with session context is not parked.
 ///
-/// When `wait_exit` returns a non-zero exit code, `spawn_job()` skips
+/// When `wait_process` returns a non-zero exit code, `spawn_job()` skips
 /// parking (because `exit_code == 0` is false) and destroys the sandbox.
 #[tokio::test(start_paused = true)]
 async fn failed_job_with_session_not_parked() {
-    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::with_wait_exit_code(1));
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::with_wait_process_code(
+        1,
+    ));
     let (config, env) = mock_run_config_with_overrides(test_profiles(), 4, 8192, 4, overrides);
     let budget = Arc::clone(&config.budget);
     let idle_pool = Arc::clone(&config.idle_pool);
@@ -66,14 +68,14 @@ async fn failed_job_with_session_not_parked() {
 
 /// Test 21: Cancelled job is not parked.
 ///
-/// `wait_exit_gate` blocks the agent execution. The test cancels the job
+/// `wait_process_gate` blocks the agent execution. The test cancels the job
 /// via the cancel token, causing `select!` in the executor to take the
 /// cancellation branch. `job_cancel.is_cancelled()` is true, so
 /// `parkable_session` is `None` → sandbox destroyed.
 #[tokio::test(start_paused = true)]
 async fn cancelled_job_not_parked() {
     let gate = Arc::new(tokio::sync::Notify::new());
-    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::with_wait_exit_gate(
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::with_wait_process_gate(
         gate,
     ));
     let (config, env) = mock_run_config_with_overrides(test_profiles(), 4, 8192, 4, overrides);

--- a/crates/runner/src/cmd/start/tests/failure_recovery/reuse_failure.rs
+++ b/crates/runner/src/cmd/start/tests/failure_recovery/reuse_failure.rs
@@ -92,7 +92,7 @@ async fn unpark_failure_destroys_idle_entry_and_falls_through() {
 #[tokio::test(start_paused = true)]
 async fn unpark_failure_status_switches_from_idle_to_active_while_job_runs() {
     let gate = Arc::new(tokio::sync::Notify::new());
-    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::with_wait_exit_gate(
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::with_wait_process_gate(
         Arc::clone(&gate),
     ));
     let counter = Arc::clone(&overrides);

--- a/crates/runner/src/cmd/start/tests/idle_reuse.rs
+++ b/crates/runner/src/cmd/start/tests/idle_reuse.rs
@@ -531,7 +531,7 @@ async fn device_limit_mismatch_destroys_idle_vm_and_fresh_creates() {
 #[tokio::test(start_paused = true)]
 async fn reuse_take_clears_idle_status_while_job_is_active() {
     let gate = Arc::new(tokio::sync::Notify::new());
-    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::with_wait_exit_gate(
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::with_wait_process_gate(
         Arc::clone(&gate),
     ));
     let (config, env) =
@@ -683,7 +683,7 @@ async fn profile_mismatch_destroys_stale_vm() {
 #[tokio::test(start_paused = true)]
 async fn profile_mismatch_status_switches_from_idle_to_active_while_job_runs() {
     let gate = Arc::new(tokio::sync::Notify::new());
-    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::with_wait_exit_gate(
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::with_wait_process_gate(
         Arc::clone(&gate),
     ));
     let (config, env) = mock_run_config_with_overrides(two_profiles(), 16, 32768, 4, overrides);
@@ -767,7 +767,7 @@ async fn shutdown_drains_idle_pool() {
 #[tokio::test]
 async fn job_completing_during_active_draining_is_not_parked() {
     let gate = Arc::new(tokio::sync::Notify::new());
-    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::with_wait_exit_gate(
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::with_wait_process_gate(
         Arc::clone(&gate),
     ));
     let (config, env) = mock_run_config_with_overrides(test_profiles(), 8, 32768, 4, overrides);
@@ -844,7 +844,7 @@ async fn job_completing_during_active_draining_is_not_parked() {
 #[tokio::test]
 async fn soft_drain_resume_opens_parking_before_running_ack() {
     let gate = Arc::new(tokio::sync::Notify::new());
-    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::with_wait_exit_gate(
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::with_wait_process_gate(
         Arc::clone(&gate),
     ));
     let (config, env) = mock_run_config_with_overrides(test_profiles(), 8, 32768, 4, overrides);

--- a/crates/runner/src/cmd/start/tests/main_loop.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop.rs
@@ -326,7 +326,7 @@ async fn shutdown_drains_memory_prefetch_before_stopped() {
 #[tokio::test]
 async fn drain_then_resume_keeps_jobs_running() {
     let gate = Arc::new(tokio::sync::Notify::new());
-    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::with_wait_exit_gate(
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::with_wait_process_gate(
         Arc::clone(&gate),
     ));
     let (config, env) = mock_run_config_with_overrides(test_profiles(), 8, 32768, 4, overrides);
@@ -358,7 +358,7 @@ async fn drain_then_resume_keeps_jobs_running() {
     assert!(c.error.is_none(), "no cancellation error");
 
     // Runner is back in Running — a second job is claimed (cancel_token
-    // inserted). Don't wait for completion here; the shared wait_exit_gate
+    // inserted). Don't wait for completion here; the shared wait_process_gate
     // would also block this job's exit.
     let run_id_2 = RunId::new_v4();
     push_job(
@@ -388,7 +388,7 @@ async fn drain_then_resume_keeps_jobs_running() {
 #[tokio::test]
 async fn drain_resume_then_second_drain_drains_idle_pool() {
     let gate = Arc::new(tokio::sync::Notify::new());
-    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::with_wait_exit_gate(
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::with_wait_process_gate(
         Arc::clone(&gate),
     ));
     let (config, env) = mock_run_config_with_overrides(test_profiles(), 8, 32768, 4, overrides);
@@ -461,7 +461,7 @@ async fn drain_resume_then_second_drain_drains_idle_pool() {
 #[tokio::test(start_paused = true)]
 async fn heartbeat_fires_while_draining() {
     let gate = Arc::new(tokio::sync::Notify::new());
-    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::with_wait_exit_gate(
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::with_wait_process_gate(
         Arc::clone(&gate),
     ));
     let (config, env) = mock_run_config_with_overrides(test_profiles(), 8, 32768, 4, overrides);
@@ -509,7 +509,7 @@ async fn heartbeat_fires_while_draining() {
 #[tokio::test(start_paused = true)]
 async fn heartbeat_fires_while_budget_exhausted() {
     let gate = Arc::new(tokio::sync::Notify::new());
-    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::with_wait_exit_gate(
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::with_wait_process_gate(
         Arc::clone(&gate),
     ));
     // Budget sized for exactly one `test_profiles()` slot (vcpu=2, mem=4096).
@@ -598,7 +598,7 @@ async fn resume_on_running_is_noop() {
 #[tokio::test]
 async fn hard_shutdown_cancels_active_jobs() {
     let gate = Arc::new(tokio::sync::Notify::new());
-    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::with_wait_exit_gate(
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::with_wait_process_gate(
         gate,
     ));
     let (config, env) = mock_run_config_with_overrides(test_profiles(), 8, 32768, 4, overrides);
@@ -708,7 +708,7 @@ async fn assert_signal_handler_task_end_cancels_active_jobs(
     trigger_handler_task_end: impl FnOnce(),
 ) {
     let gate = Arc::new(tokio::sync::Notify::new());
-    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::with_wait_exit_gate(
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::with_wait_process_gate(
         gate,
     ));
     let (mut config, env) = mock_run_config_with_overrides(test_profiles(), 8, 32768, 4, overrides);
@@ -745,7 +745,7 @@ async fn assert_signal_handler_task_end_cancels_active_jobs(
 #[tokio::test]
 async fn drain_then_hard_shutdown_upgrades() {
     let gate = Arc::new(tokio::sync::Notify::new());
-    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::with_wait_exit_gate(
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::with_wait_process_gate(
         gate,
     ));
     let (config, env) = mock_run_config_with_overrides(test_profiles(), 8, 32768, 4, overrides);
@@ -998,7 +998,7 @@ async fn drain_with_jobs_transitions_to_stopping_when_empty() {
 #[tokio::test]
 async fn draining_auto_stop_preserves_concurrent_resume() {
     let gate = Arc::new(tokio::sync::Notify::new());
-    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::with_wait_exit_gate(
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::with_wait_process_gate(
         Arc::clone(&gate),
     ));
     let (config, env) = mock_run_config_with_overrides(test_profiles(), 8, 32768, 4, overrides);
@@ -1166,7 +1166,7 @@ async fn duplicate_discovery_deduplicated() {
     // Budget for 2 jobs — enough for the duplicate to pass the budget
     // check and reach the cancel_tokens dedup logic.
     let gate = Arc::new(tokio::sync::Notify::new());
-    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::with_wait_exit_gate(
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::with_wait_process_gate(
         Arc::clone(&gate),
     ));
     let (config, env) = mock_run_config_with_overrides(test_profiles(), 8, 32768, 4, overrides);

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -720,8 +720,7 @@ async fn run_in_sandbox(
     // Spawn background task to drain stdout chunks and write to host log file.
     let host_log_path = config.log_paths.system_log(context.run_id);
     let stream_task = handle
-        .stdout_rx
-        .take()
+        .take_stdout_receiver()
         .map(|stdout_rx| tokio::spawn(drain_stdout_to_file(stdout_rx, host_log_path)));
 
     // 6. Wait for exit (or cancellation).

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -15,7 +15,9 @@
 //! user-visible completion signal is not blocked on best-effort uploads.
 
 use std::collections::HashMap;
+use std::io;
 use std::panic::AssertUnwindSafe;
+use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant};
 
@@ -24,9 +26,9 @@ use agent_diagnostics::{
 };
 use futures_util::FutureExt;
 use sandbox::{
-    CopyFileOptions, EXEC_OUTPUT_LIMIT_1_MIB, EXEC_OUTPUT_LIMIT_64_KIB, ExecRequest, Sandbox,
-    SandboxConfig, SandboxFactory, SandboxId, SpawnProcessControl, SpawnProcessOutputMode,
-    SpawnProcessRequest,
+    CopyFileOptions, EXEC_OUTPUT_LIMIT_1_MIB, EXEC_OUTPUT_LIMIT_64_KIB, ExecRequest,
+    ProcessControlMode, ProcessOutputMode, ProcessOutputReceiver, Sandbox, SandboxConfig,
+    SandboxFactory, SandboxId, StartProcessRequest,
 };
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
@@ -690,19 +692,17 @@ async fn run_in_sandbox(
     let agent_cmd = format!("{} 2>&1", guest::RUN_AGENT);
     info!(run_id = %context.run_id, "spawning agent");
 
-    // JOB_TIMEOUT is used for both spawn_process (guest-side kill) and wait_exit
-    // (host-side watchdog) so neither side outlives the other.
+    // JOB_TIMEOUT configures both the guest-side process timeout and the
+    // host-side wait watchdog. They remain separate protocol mechanisms.
     let t = Instant::now();
     let handle = sandbox
-        .spawn_process(&SpawnProcessRequest {
+        .start_process(&StartProcessRequest {
             cmd: &agent_cmd,
             timeout: JOB_TIMEOUT,
             env: &env_refs,
             sudo: false,
-            output: SpawnProcessOutputMode::Stream {
-                guest_log_path: None,
-            },
-            control: SpawnProcessControl::Enabled,
+            output: ProcessOutputMode::stream(),
+            control: ProcessControlMode::Enabled,
         })
         .await;
 
@@ -728,15 +728,10 @@ async fn run_in_sandbox(
     // On cancel we return immediately — the caller (execute_new_sandbox) will
     // call sandbox.stop() + factory.destroy() in its cleanup path.
     let result = tokio::select! {
-        result = sandbox.wait_exit(handle, JOB_TIMEOUT) => result,
+        result = sandbox.wait_process(handle, JOB_TIMEOUT) => result,
         () = cancel.cancelled() => {
             info!(run_id = %context.run_id, "cancel received, aborting sandbox wait");
-            Ok(sandbox::ProcessExit {
-                pid: 0,
-                exit_code: EXIT_SIGKILL,
-                stdout: Vec::new(),
-                stderr: Vec::new(),
-            })
+            Ok(sandbox::ProcessExit::new(0, EXIT_SIGKILL, Vec::new(), Vec::new()))
         }
     };
 
@@ -747,8 +742,16 @@ async fn run_in_sandbox(
         if cancel.is_cancelled() || result.is_err() {
             task.abort();
             let _ = task.await;
-        } else if let Err(e) = task.await {
-            warn!(run_id = %context.run_id, error = %e, "stdout stream task failed");
+        } else {
+            match task.await {
+                Ok(Ok(())) => {}
+                Ok(Err(e)) => {
+                    warn!(run_id = %context.run_id, error = %e, "stdout stream task failed");
+                }
+                Err(e) => {
+                    warn!(run_id = %context.run_id, error = %e, "stdout stream task failed");
+                }
+            }
         }
     }
     let exit = match result {
@@ -771,6 +774,16 @@ async fn run_in_sandbox(
             return Err(e.into());
         }
     };
+    if exit.stream_overflowed {
+        warn!(run_id = %context.run_id, "agent stdout stream overflowed before process exit");
+    }
+    if !exit.diagnostic.is_empty() {
+        warn!(
+            run_id = %context.run_id,
+            diagnostic = %exit.diagnostic,
+            "agent process reported diagnostic"
+        );
+    }
 
     info!(
         run_id = %context.run_id,
@@ -989,11 +1002,21 @@ fn host_dmesg_indicates_oom(dmesg: &str, pid: u32) -> bool {
     false
 }
 
-/// Drain stdout chunks from the vsock receiver and write them to a host file.
+#[derive(Debug, thiserror::Error)]
+enum StdoutDrainError {
+    #[error("failed to open host log file {path}: {source}")]
+    Open { path: PathBuf, source: io::Error },
+    #[error("failed to write stdout chunk to host log {path}: {source}")]
+    Write { path: PathBuf, source: io::Error },
+    #[error("failed to flush stdout log {path}: {source}")]
+    Flush { path: PathBuf, source: io::Error },
+}
+
+/// Drain stdout chunks from the process receiver and write them to a host file.
 async fn drain_stdout_to_file(
-    mut rx: tokio::sync::mpsc::UnboundedReceiver<Vec<u8>>,
-    path: std::path::PathBuf,
-) {
+    mut rx: ProcessOutputReceiver,
+    path: PathBuf,
+) -> Result<(), StdoutDrainError> {
     let file = tokio::fs::OpenOptions::new()
         .create(true)
         .append(true)
@@ -1002,22 +1025,24 @@ async fn drain_stdout_to_file(
     let mut file = match file {
         Ok(f) => f,
         Err(e) => {
-            warn!(error = %e, path = %path.display(), "failed to open host log file for streaming");
-            return;
+            return Err(StdoutDrainError::Open { path, source: e });
         }
     };
     while let Some(chunk) = rx.recv().await {
-        if let Err(e) = tokio::io::AsyncWriteExt::write_all(&mut file, &chunk).await {
-            warn!(error = %e, path = %path.display(), "failed to write stdout chunk to host log");
-            break;
+        if chunk.truncated {
+            warn!(path = %path.display(), "stdout stream chunk was truncated before host log write");
+        }
+        if let Err(e) = tokio::io::AsyncWriteExt::write_all(&mut file, &chunk.bytes).await {
+            return Err(StdoutDrainError::Write { path, source: e });
         }
     }
-    // Flush to ensure the last spawn_blocking write completes before we return.
+    // Flush to ensure the last blocking write completes before we return.
     // tokio::fs::File::poll_write returns Ready before the blocking write finishes,
     // so without flush the caller may observe incomplete file contents.
     if let Err(e) = tokio::io::AsyncWriteExt::flush(&mut file).await {
-        warn!(error = %e, path = %path.display(), "failed to flush stdout log");
+        return Err(StdoutDrainError::Flush { path, source: e });
     }
+    Ok(())
 }
 
 /// Guest log file path prefixes. Each turn creates files named
@@ -2681,7 +2706,7 @@ mod tests {
     // -----------------------------------------------------------------------
 
     use sandbox::{
-        ExecResult, SandboxError, SandboxInitializationPhase, SandboxOperation,
+        ExecResult, ProcessOutputChunk, SandboxError, SandboxInitializationPhase, SandboxOperation,
         SandboxOperationReason,
     };
     use sandbox_mock::MockSandbox;
@@ -3240,12 +3265,22 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("stdout.log");
 
-        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
-        tx.send(b"chunk 1\n".to_vec()).unwrap();
-        tx.send(b"chunk 2\n".to_vec()).unwrap();
+        let (tx, rx) = tokio::sync::mpsc::channel(2);
+        tx.send(ProcessOutputChunk {
+            bytes: b"chunk 1\n".to_vec(),
+            truncated: false,
+        })
+        .await
+        .unwrap();
+        tx.send(ProcessOutputChunk {
+            bytes: b"chunk 2\n".to_vec(),
+            truncated: false,
+        })
+        .await
+        .unwrap();
         drop(tx); // close channel
 
-        drain_stdout_to_file(rx, path.clone()).await;
+        drain_stdout_to_file(rx, path.clone()).await.unwrap();
 
         let content = tokio::fs::read_to_string(&path).await.unwrap();
         assert_eq!(content, "chunk 1\nchunk 2\n");
@@ -3256,21 +3291,23 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("empty.log");
 
-        let (_tx, rx) = tokio::sync::mpsc::unbounded_channel::<Vec<u8>>();
+        let (_tx, rx) = tokio::sync::mpsc::channel::<ProcessOutputChunk>(1);
         drop(_tx);
 
-        drain_stdout_to_file(rx, path.clone()).await;
+        drain_stdout_to_file(rx, path.clone()).await.unwrap();
 
         let content = tokio::fs::read_to_string(&path).await.unwrap();
         assert!(content.is_empty());
     }
 
     #[tokio::test]
-    async fn drain_stdout_invalid_path_does_not_panic() {
-        let (_tx, rx) = tokio::sync::mpsc::unbounded_channel::<Vec<u8>>();
+    async fn drain_stdout_invalid_path_returns_error() {
+        let (_tx, rx) = tokio::sync::mpsc::channel::<ProcessOutputChunk>(1);
         drop(_tx);
-        // /dev/null/impossible cannot be created — should handle gracefully
-        drain_stdout_to_file(rx, std::path::PathBuf::from("/dev/null/impossible/file")).await;
+        let error = drain_stdout_to_file(rx, PathBuf::from("/dev/null/impossible/file"))
+            .await
+            .unwrap_err();
+        assert!(matches!(error, StdoutDrainError::Open { .. }));
     }
 
     // -----------------------------------------------------------------------
@@ -3483,11 +3520,10 @@ mod tests {
         assert_eq!(exit_code, 0);
         assert!(error_msg.is_none());
 
-        let calls = overrides.spawn_process_calls();
+        let calls = overrides.start_process_calls();
         assert_eq!(calls.len(), 1);
-        assert!(calls[0].streams_stdout);
-        assert!(calls[0].guest_log_path.is_none());
-        assert_eq!(calls[0].control, SpawnProcessControl::Enabled);
+        assert_eq!(calls[0].output, ProcessOutputMode::stream());
+        assert_eq!(calls[0].control, ProcessControlMode::Enabled);
     }
 
     #[tokio::test]
@@ -3559,14 +3595,14 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn execute_inner_aborts_drain_task_on_wait_exit_error() {
-        // Simulate wait_exit timeout: stdout channel stays open (sender held
-        // alive by MockSandbox), wait_exit returns error.
+    async fn execute_inner_aborts_drain_task_on_wait_process_error() {
+        // Simulate wait_process timeout: stdout channel stays open (sender held
+        // alive by MockSandbox), wait_process returns error.
         // Without the fix, task.await blocks forever → test times out.
         // With the fix, task is aborted immediately → test completes.
         let dir = tempfile::tempdir().unwrap();
         let config = test_executor_config(dir.path()).await;
-        let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::with_wait_exit_error(
+        let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::with_wait_process_error(
             "wait timeout",
         ));
         let factory = sandbox_mock::MockSandboxFactory::with_overrides(overrides);
@@ -3584,7 +3620,9 @@ mod tests {
     async fn execute_inner_nonzero_without_guest_error_returns_failure_message() {
         let dir = tempfile::tempdir().unwrap();
         let config = test_executor_config(dir.path()).await;
-        let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::with_wait_exit_code(7));
+        let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::with_wait_process_code(
+            7,
+        ));
         let factory = sandbox_mock::MockSandboxFactory::with_overrides(overrides);
 
         let (exit_code, error) =
@@ -3600,7 +3638,9 @@ mod tests {
     async fn execute_inner_nonzero_records_agent_execute_error() {
         let dir = tempfile::tempdir().unwrap();
         let config = test_executor_config(dir.path()).await;
-        let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::with_wait_exit_code(7));
+        let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::with_wait_process_code(
+            7,
+        ));
         let factory = sandbox_mock::MockSandboxFactory::with_overrides(overrides);
         let ctx = minimal_context();
         let mut telemetry = test_telemetry(&config, &ctx);

--- a/crates/sandbox-fc/Cargo.toml
+++ b/crates/sandbox-fc/Cargo.toml
@@ -21,6 +21,7 @@ tokio-util.workspace = true
 tracing.workspace = true
 uuid = { workspace = true, features = ["v4"] }
 vsock-host.workspace = true
+vsock-proto.workspace = true
 which.workspace = true
 
 [dev-dependencies]
@@ -28,7 +29,6 @@ clap = { workspace = true, features = ["derive"] }
 tempfile.workspace = true
 tokio = { workspace = true, features = ["test-util"] }
 tracing-subscriber.workspace = true
-vsock-proto.workspace = true
 
 [lints]
 workspace = true

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -4673,6 +4673,12 @@ mod tests {
             process_timeout_policy(Duration::from_millis(2500)),
             ExecTimeoutPolicy::Duration { timeout_ms: 2500 }
         );
+        assert_eq!(
+            process_timeout_policy(Duration::from_millis(u64::from(u32::MAX) + 1)),
+            ExecTimeoutPolicy::Duration {
+                timeout_ms: u32::MAX
+            }
+        );
     }
 
     #[test]
@@ -4737,6 +4743,49 @@ mod tests {
         assert!(!exit.stderr_truncated);
         assert_eq!(exit.diagnostic, "wait failed");
         assert!(exit.stream_overflowed);
+    }
+
+    #[test]
+    fn supervised_exec_result_to_process_exit_maps_terminal_edge_states() {
+        for (termination, diagnostic, expected_code, expected_stderr) in [
+            (
+                ExecTermination::TimedOut,
+                "",
+                EXEC_TIMEOUT_EXIT_CODE,
+                "Timeout",
+            ),
+            (
+                ExecTermination::Cancelled,
+                "cancel diagnostic",
+                1,
+                "Cancelled\ncancel diagnostic",
+            ),
+            (
+                ExecTermination::StartFailed,
+                "spawn failed",
+                1,
+                "spawn failed",
+            ),
+        ] {
+            let exit = supervised_exec_result_to_process_exit(
+                42,
+                vsock_host::ExecOperationResult {
+                    termination,
+                    duration_ms: 10,
+                    stdout: ExecOwnedCapturedOutput::Discarded,
+                    stderr: ExecOwnedCapturedOutput::Captured {
+                        bytes: Vec::new(),
+                        truncated: false,
+                    },
+                    diagnostic: diagnostic.to_string(),
+                    stream_overflowed: false,
+                },
+            );
+
+            assert_eq!(exit.exit_code, expected_code);
+            assert_eq!(String::from_utf8(exit.stderr).unwrap(), expected_stderr);
+            assert_eq!(exit.diagnostic, diagnostic);
+        }
     }
 
     #[tokio::test]

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -4801,14 +4801,6 @@ mod tests {
             .await
             .unwrap();
 
-        tokio::time::timeout(Duration::from_secs(1), async {
-            while stdout_rx.is_empty() {
-                tokio::task::yield_now().await;
-            }
-        })
-        .await
-        .expect("first stdout chunk was not buffered");
-
         tokio::time::timeout(
             Duration::from_secs(1),
             stream_tx.send(ExecOutputEvent {

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -2992,6 +2992,13 @@ mod tests {
         pid: u32,
     }
 
+    struct ExecProcessControlFixture {
+        host: Arc<VsockHost>,
+        handle: vsock_host::SupervisedExecHandle,
+        guest: UnixStream,
+        exec_seq: u32,
+    }
+
     async fn connect_mock_guest(vsock_path: &str) -> UnixStream {
         let listener_path = format!("{vsock_path}_{}", vsock_proto::VSOCK_PORT);
         let deadline = Instant::now() + Duration::from_secs(5);
@@ -3084,6 +3091,70 @@ mod tests {
         }
     }
 
+    async fn setup_exec_process_control_fixture() -> ExecProcessControlFixture {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let vsock_path = temp_dir
+            .path()
+            .join("exec-process-control")
+            .to_string_lossy()
+            .into_owned();
+        let wait_vsock_path = vsock_path.clone();
+        let host_task = tokio::spawn(async move {
+            VsockHost::wait_for_connection(&wait_vsock_path, Duration::from_secs(5))
+                .await
+                .unwrap()
+        });
+        let mut guest = connect_mock_guest(&vsock_path).await;
+        let mut decoder = Decoder::new();
+        mock_vsock_handshake(&mut guest, &mut decoder).await;
+        let host = Arc::new(host_task.await.unwrap());
+
+        let start_host = Arc::clone(&host);
+        let start_task = tokio::spawn(async move {
+            start_host
+                .start_supervised_exec(SupervisedExecRequest {
+                    timeout: ExecTimeoutPolicy::Duration { timeout_ms: 60_000 },
+                    command: "sleep 60",
+                    env: &[],
+                    sudo: false,
+                    label: "sleep 60",
+                    stdout: ExecOutputPolicy::Discard,
+                    stderr: ExecOutputPolicy::Discard,
+                    expected_exit_codes: &[],
+                    control: SupervisedExecControl::Enabled { sink: true },
+                    stream_queue_capacity: None,
+                    start_timeout: Duration::from_secs(5),
+                })
+                .await
+                .unwrap()
+        });
+        let start = read_vsock_message(&mut guest).await;
+        assert_eq!(start.msg_type, vsock_proto::MSG_EXEC_START);
+        let decoded_start = vsock_proto::decode_exec_start(&start.payload).unwrap();
+        assert_eq!(
+            decoded_start.lifecycle,
+            vsock_proto::ExecLifecyclePolicy::Supervised
+        );
+        assert!(matches!(
+            decoded_start.control,
+            vsock_proto::ExecControlPolicy::Enabled { sink: true, .. }
+        ));
+
+        let pid = 73;
+        let payload = vsock_proto::encode_exec_started(pid).unwrap();
+        let response =
+            vsock_proto::encode(vsock_proto::MSG_EXEC_STARTED, start.seq, &payload).unwrap();
+        guest.write_all(&response).await.unwrap();
+        let handle = start_task.await.unwrap();
+
+        ExecProcessControlFixture {
+            host,
+            handle,
+            guest,
+            exec_seq: start.seq,
+        }
+    }
+
     fn running_process_state() -> (Arc<AtomicU8>, watch::Sender<SandboxState>) {
         process_state(SandboxState::Running)
     }
@@ -3163,6 +3234,28 @@ mod tests {
         stream.write_all(&response).await.unwrap();
     }
 
+    async fn send_exec_control_result(
+        stream: &mut UnixStream,
+        request: RawMessage,
+        status: ProcessControlStatus,
+        diagnostic: &str,
+    ) {
+        assert_eq!(request.msg_type, vsock_proto::MSG_EXEC_CONTROL);
+        let decoded = vsock_proto::decode_exec_control(&request.payload).unwrap();
+        let payload = vsock_proto::encode_exec_control_result(
+            decoded.target_seq,
+            decoded.control_nonce,
+            decoded.message_id,
+            status,
+            diagnostic,
+        )
+        .unwrap();
+        let response =
+            vsock_proto::encode(vsock_proto::MSG_EXEC_CONTROL_RESULT, request.seq, &payload)
+                .unwrap();
+        stream.write_all(&response).await.unwrap();
+    }
+
     async fn send_process_control_error(
         stream: &mut UnixStream,
         request: RawMessage,
@@ -3193,6 +3286,20 @@ mod tests {
     async fn send_process_exit(stream: &mut UnixStream, spawn_seq: u32, pid: u32) {
         let payload = vsock_proto::encode_process_exit(pid, 0, b"", b"");
         let response = vsock_proto::encode(MSG_PROCESS_EXIT, spawn_seq, &payload).unwrap();
+        stream.write_all(&response).await.unwrap();
+    }
+
+    async fn send_exec_exit(stream: &mut UnixStream, exec_seq: u32) {
+        let payload = vsock_proto::encode_exec_result(
+            ExecTermination::Exited { exit_code: 0 },
+            1,
+            vsock_proto::ExecCapturedOutput::Discarded,
+            vsock_proto::ExecCapturedOutput::Discarded,
+            "",
+        )
+        .unwrap();
+        let response =
+            vsock_proto::encode(vsock_proto::MSG_EXEC_RESULT, exec_seq, &payload).unwrap();
         stream.write_all(&response).await.unwrap();
     }
 
@@ -4978,6 +5085,45 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn exec_process_control_guest_status_keeps_policy_open() {
+        let ExecProcessControlFixture {
+            host: _host,
+            handle,
+            mut guest,
+            exec_seq,
+        } = setup_exec_process_control_fixture().await;
+        let control = handle.control_handle().unwrap();
+        let coordinator = ParkCoordinator::new();
+        let (state, state_tx) = running_process_state();
+
+        let control_task = tokio::spawn(FirecrackerSandbox::exec_process_control(
+            coordinator.clone(),
+            state,
+            state_tx.subscribe(),
+            control,
+            "exec-sink-timeout".to_owned(),
+            b"payload".to_vec(),
+            Duration::from_secs(5),
+        ));
+        let request = read_vsock_message(&mut guest).await;
+        send_exec_control_result(
+            &mut guest,
+            request,
+            ProcessControlStatus::SinkTimeout,
+            "guest sink timed out",
+        )
+        .await;
+
+        let error = control_task.await.unwrap().unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::TimedOut);
+        assert_eq!(error.to_string(), "guest sink timed out");
+        assert_eq!(coordinator.state(), CoordinatorState::Open);
+
+        send_exec_exit(&mut guest, exec_seq).await;
+        handle.wait(Duration::from_secs(5)).await.unwrap();
+    }
+
+    #[tokio::test]
     async fn process_control_guest_error_keeps_policy_open() {
         let ProcessControlFixture {
             host: _host,
@@ -5009,6 +5155,48 @@ mod tests {
 
         send_process_exit(&mut guest, spawn_seq, pid).await;
         handle.wait().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn exec_process_control_backend_crash_after_guest_write_keeps_policy_open() {
+        let ExecProcessControlFixture {
+            host: _host,
+            handle,
+            mut guest,
+            exec_seq,
+        } = setup_exec_process_control_fixture().await;
+        let control = handle.control_handle().unwrap();
+        let coordinator = ParkCoordinator::new();
+        let (state, state_tx) = running_process_state();
+
+        let control_task = tokio::spawn(FirecrackerSandbox::exec_process_control(
+            coordinator.clone(),
+            Arc::clone(&state),
+            state_tx.subscribe(),
+            control,
+            "exec-backend-crash".to_owned(),
+            b"payload".to_vec(),
+            Duration::from_secs(5),
+        ));
+        let request = read_vsock_message(&mut guest).await;
+        assert_eq!(request.msg_type, vsock_proto::MSG_EXEC_CONTROL);
+
+        state.store(SandboxState::Crashed as u8, Ordering::Release);
+        state_tx.send(SandboxState::Crashed).unwrap();
+
+        let error = tokio::time::timeout(Duration::from_secs(1), control_task)
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap_err();
+        assert!(
+            error.to_string().contains("firecracker process crashed"),
+            "unexpected error: {error}",
+        );
+        assert_eq!(coordinator.state(), CoordinatorState::Open);
+
+        send_exec_exit(&mut guest, exec_seq).await;
+        handle.wait(Duration::from_secs(5)).await.unwrap();
     }
 
     #[tokio::test]

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -1525,15 +1525,14 @@ fn supervised_stdout_receiver(
     Box<dyn FnOnce() + Send + 'static>,
 ) {
     let (stdout_tx, stdout_rx) = mpsc::channel(queue_capacity.max(1));
-    let (close_tx, mut close_rx) = watch::channel(false);
+    let close = CancellationToken::new();
+    let task_close = close.clone();
 
     tokio::spawn(async move {
         loop {
             tokio::select! {
-                changed = close_rx.changed() => {
-                    if changed.is_err() || *close_rx.borrow() {
-                        break;
-                    }
+                () = task_close.cancelled() => {
+                    break;
                 }
                 event = stream_rx.recv() => {
                     let Some(event) = event else {
@@ -1564,7 +1563,7 @@ fn supervised_stdout_receiver(
     (
         stdout_rx,
         Box::new(move || {
-            close_tx.send_replace(true);
+            close.cancel();
         }),
     )
 }
@@ -4665,6 +4664,48 @@ mod tests {
             .await
             .expect("stdout adapter did not close");
         assert!(received.is_none());
+    }
+
+    #[tokio::test]
+    async fn supervised_stdout_receiver_dropping_cleanup_handle_does_not_close_claimed_stream() {
+        let (stream_tx, stream_rx) = mpsc::channel(4);
+        let (mut stdout_rx, close) = supervised_stdout_receiver(stream_rx, 2);
+
+        stream_tx
+            .send(ExecOutputEvent {
+                stream: ExecOutputStream::Stdout,
+                output_seq: 1,
+                chunk: b"before".to_vec(),
+                truncated: false,
+            })
+            .await
+            .unwrap();
+
+        drop(close);
+
+        stream_tx
+            .send(ExecOutputEvent {
+                stream: ExecOutputStream::Stdout,
+                output_seq: 2,
+                chunk: b"after".to_vec(),
+                truncated: false,
+            })
+            .await
+            .unwrap();
+        drop(stream_tx);
+
+        let first = tokio::time::timeout(Duration::from_secs(1), stdout_rx.recv())
+            .await
+            .expect("first stdout chunk was not forwarded")
+            .expect("stdout stream closed before first chunk");
+        let second = tokio::time::timeout(Duration::from_secs(1), stdout_rx.recv())
+            .await
+            .expect("second stdout chunk was not forwarded")
+            .expect("stdout stream closed before second chunk");
+
+        assert_eq!(first.bytes, b"before");
+        assert_eq!(second.bytes, b"after");
+        assert!(stdout_rx.recv().await.is_none());
     }
 
     #[test]

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -1525,6 +1525,7 @@ fn supervised_stdout_receiver(
     Box<dyn FnOnce() + Send + 'static>,
 ) {
     let (stdout_tx, stdout_rx) = mpsc::channel(queue_capacity.max(1));
+    let stdout_closed = stdout_tx.clone();
     let close = CancellationToken::new();
     let task_close = close.clone();
 
@@ -1533,6 +1534,9 @@ fn supervised_stdout_receiver(
             tokio::select! {
                 biased;
                 () = task_close.cancelled() => {
+                    break;
+                }
+                () = stdout_closed.closed() => {
                     break;
                 }
                 event = stream_rx.recv() => {
@@ -4884,6 +4888,19 @@ mod tests {
         assert_eq!(first.bytes, b"before");
         assert_eq!(second.bytes, b"after");
         assert!(stdout_rx.recv().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn supervised_stdout_receiver_dropping_output_receiver_stops_adapter() {
+        let (stream_tx, stream_rx) = mpsc::channel(1);
+        let (stdout_rx, close) = supervised_stdout_receiver(stream_rx, 1);
+
+        drop(close);
+        drop(stdout_rx);
+
+        tokio::time::timeout(Duration::from_secs(1), stream_tx.closed())
+            .await
+            .expect("stdout adapter kept the supervised stream receiver alive");
     }
 
     #[test]

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -10,15 +10,20 @@ use std::time::Duration;
 use async_trait::async_trait;
 use sandbox::{
     CopyFileOptions, CopyFileResult, ExecRequest, ExecResult, GuestProcessControlHandle,
-    GuestProcessHandle, ProcessControlAck, ProcessExit, Sandbox, SandboxConfig, SandboxError,
+    GuestProcessHandle, GuestProcessWaiter, ProcessControlAck, ProcessControlMode, ProcessExit,
+    ProcessOutputChunk, ProcessOutputMode, Sandbox, SandboxConfig, SandboxError,
     SandboxIdleTransition, SandboxInvalidStateContext, SandboxOperation, SandboxOperationReason,
-    SpawnProcessControl, SpawnProcessRequest,
+    StartProcessRequest,
 };
 use tokio::io::{AsyncBufReadExt, AsyncRead, BufReader};
 use tokio::sync::{mpsc, watch};
 use tokio_util::sync::CancellationToken;
 use tracing::{info, trace, warn};
-use vsock_host::{NormalOperationFence, NormalOperationFenceRejection, VsockHost};
+use vsock_host::{
+    ExecOutputEvent, ExecOwnedCapturedOutput, NormalOperationFence, NormalOperationFenceRejection,
+    SupervisedExecControl, SupervisedExecRequest, VsockHost,
+};
+use vsock_proto::{ExecOutputPolicy, ExecOutputStream, ExecTermination, ExecTimeoutPolicy};
 
 use crate::api::ApiError;
 use nbd_cow::PooledNbdCowDevice;
@@ -40,6 +45,10 @@ use crate::process::{kill_process_group, kill_process_group_by_pid};
 
 /// Timeout for waiting for the guest to connect via vsock after start.
 const VSOCK_CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
+/// Timeout for receiving a process start acknowledgement from the guest.
+const PROCESS_START_ACK_TIMEOUT: Duration = Duration::from_secs(30);
+/// Exit code returned by guest exec timeout handling.
+const EXEC_TIMEOUT_EXIT_CODE: i32 = 124;
 
 /// Timeout for graceful shutdown via vsock.
 const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
@@ -888,6 +897,7 @@ impl FirecrackerSandbox {
         io::Error::other(error)
     }
 
+    #[cfg(test)]
     async fn process_control(
         coordinator: ParkCoordinator,
         state: Arc<AtomicU8>,
@@ -899,6 +909,52 @@ impl FirecrackerSandbox {
     ) -> io::Result<ProcessControlAck> {
         enum ControlOutcome {
             Returned(io::Result<vsock_host::ProcessControlAck>),
+            BackendCrashed,
+        }
+
+        let operation = SandboxOperation::ProcessControl;
+        Self::begin_process_control(&coordinator, || Self::current_state_from(&state)).map_err(
+            |error| {
+                Self::operation_start_io_error(operation, error, Self::current_state_from(&state))
+            },
+        )?;
+
+        let outcome = tokio::select! {
+            result = control.control(
+                &message_id,
+                &payload,
+                timeout,
+            ) => ControlOutcome::Returned(result),
+            () = wait_for_backend_crash(state_rx) => ControlOutcome::BackendCrashed,
+        };
+
+        match outcome {
+            ControlOutcome::Returned(Ok(ack)) => Ok(ProcessControlAck {
+                message_id: ack.message_id,
+            }),
+            ControlOutcome::Returned(Err(error)) => {
+                if Self::current_state_from(&state) == SandboxState::Crashed {
+                    return Err(io::Error::other(Self::backend_crashed_error(operation)));
+                }
+                Err(error)
+            }
+            ControlOutcome::BackendCrashed => {
+                Err(io::Error::other(Self::backend_crashed_error(operation)))
+            }
+        }
+    }
+
+    async fn exec_process_control(
+        coordinator: ParkCoordinator,
+        state: Arc<AtomicU8>,
+        state_rx: watch::Receiver<SandboxState>,
+        control: vsock_host::ExecControlHandle,
+        message_id: String,
+        payload: Vec<u8>,
+        timeout: Duration,
+    ) -> io::Result<ProcessControlAck> {
+        enum ControlOutcome {
+            Returned(io::Result<vsock_host::ExecControlAck>),
             BackendCrashed,
         }
 
@@ -1363,6 +1419,156 @@ fn monitor_process_with_log_readers(
     ProcessMonitorHandle { kill_tx, task }
 }
 
+fn process_timeout_policy(timeout: Duration) -> ExecTimeoutPolicy {
+    if timeout.is_zero() {
+        ExecTimeoutPolicy::None
+    } else {
+        ExecTimeoutPolicy::Duration {
+            timeout_ms: u32::try_from(timeout.as_millis()).unwrap_or(u32::MAX),
+        }
+    }
+}
+
+fn process_stdout_policy(output: ProcessOutputMode) -> ExecOutputPolicy {
+    match output {
+        ProcessOutputMode::Buffered { output_limits } => ExecOutputPolicy::Capture {
+            limit_bytes: output_limits.stdout_limit_bytes,
+        },
+        ProcessOutputMode::Stream {
+            stream_limit_bytes,
+            chunk_limit_bytes,
+            ..
+        } => ExecOutputPolicy::Stream {
+            limit_bytes: stream_limit_bytes,
+            chunk_limit_bytes,
+        },
+    }
+}
+
+fn process_stderr_policy(output: ProcessOutputMode) -> ExecOutputPolicy {
+    match output {
+        ProcessOutputMode::Buffered { output_limits } => ExecOutputPolicy::Capture {
+            limit_bytes: output_limits.stderr_limit_bytes,
+        },
+        ProcessOutputMode::Stream { .. } => ExecOutputPolicy::Discard,
+    }
+}
+
+fn process_stream_queue_capacity(output: ProcessOutputMode) -> Option<usize> {
+    match output {
+        ProcessOutputMode::Buffered { .. } => None,
+        ProcessOutputMode::Stream { queue_capacity, .. } => Some(queue_capacity),
+    }
+}
+
+fn captured_output_bytes(output: ExecOwnedCapturedOutput) -> (Vec<u8>, bool) {
+    match output {
+        ExecOwnedCapturedOutput::Discarded => (Vec::new(), false),
+        ExecOwnedCapturedOutput::Captured { bytes, truncated } => (bytes, truncated),
+    }
+}
+
+fn append_diagnostic(stderr: &mut Vec<u8>, diagnostic: &str) {
+    if diagnostic.is_empty() {
+        return;
+    }
+    if !stderr.is_empty() && !stderr.ends_with(b"\n") {
+        stderr.push(b'\n');
+    }
+    stderr.extend_from_slice(diagnostic.as_bytes());
+}
+
+fn supervised_exec_result_to_process_exit(
+    pid: u32,
+    result: vsock_host::ExecOperationResult,
+) -> ProcessExit {
+    let (stdout, stdout_truncated) = captured_output_bytes(result.stdout);
+    let (mut stderr, stderr_truncated) = captured_output_bytes(result.stderr);
+    let exit_code = match result.termination {
+        ExecTermination::Exited { exit_code } => exit_code,
+        ExecTermination::TimedOut => {
+            if stderr.is_empty() {
+                stderr.extend_from_slice(b"Timeout");
+            }
+            EXEC_TIMEOUT_EXIT_CODE
+        }
+        ExecTermination::Cancelled => {
+            if stderr.is_empty() {
+                stderr.extend_from_slice(b"Cancelled");
+            }
+            append_diagnostic(&mut stderr, &result.diagnostic);
+            1
+        }
+        ExecTermination::StartFailed | ExecTermination::WaitFailed => {
+            append_diagnostic(&mut stderr, &result.diagnostic);
+            1
+        }
+    };
+
+    ProcessExit {
+        pid,
+        exit_code,
+        stdout,
+        stderr,
+        stdout_truncated,
+        stderr_truncated,
+        diagnostic: result.diagnostic,
+        stream_overflowed: result.stream_overflowed,
+    }
+}
+
+fn supervised_stdout_receiver(
+    mut stream_rx: mpsc::Receiver<ExecOutputEvent>,
+    queue_capacity: usize,
+) -> (
+    sandbox::ProcessOutputReceiver,
+    Box<dyn FnOnce() + Send + 'static>,
+) {
+    let (stdout_tx, stdout_rx) = mpsc::channel(queue_capacity.max(1));
+    let (close_tx, mut close_rx) = watch::channel(false);
+
+    tokio::spawn(async move {
+        loop {
+            tokio::select! {
+                changed = close_rx.changed() => {
+                    if changed.is_err() || *close_rx.borrow() {
+                        break;
+                    }
+                }
+                event = stream_rx.recv() => {
+                    let Some(event) = event else {
+                        break;
+                    };
+                    match event.stream {
+                        ExecOutputStream::Stdout => {
+                            let chunk = ProcessOutputChunk {
+                                bytes: event.chunk,
+                                truncated: event.truncated,
+                            };
+                            if stdout_tx.send(chunk).await.is_err() {
+                                break;
+                            }
+                        }
+                        ExecOutputStream::Stderr => {
+                            warn!(
+                                output_seq = event.output_seq,
+                                "discarding unexpected stderr event from stdout-only process stream"
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    });
+
+    (
+        stdout_rx,
+        Box::new(move || {
+            close_tx.send_replace(true);
+        }),
+    )
+}
+
 #[async_trait]
 impl Sandbox for FirecrackerSandbox {
     // -- identity --
@@ -1773,44 +1979,38 @@ impl Sandbox for FirecrackerSandbox {
         .await
     }
 
-    async fn spawn_process(
+    async fn start_process(
         &self,
-        request: &SpawnProcessRequest<'_>,
+        request: &StartProcessRequest<'_>,
     ) -> sandbox::Result<GuestProcessHandle> {
-        let operation = SandboxOperation::SpawnProcess;
+        let operation = SandboxOperation::StartProcess;
         let vsock = self.begin_guest_operation(operation).await?;
 
-        let spawn_future = async move {
-            match request.control {
-                SpawnProcessControl::None => {
-                    vsock
-                        .spawn_process(
-                            request.cmd,
-                            request.timeout_ms(),
-                            request.env,
-                            request.sudo,
-                            request.output.streams_stdout(),
-                            request.output.guest_log_path(),
-                        )
-                        .await
-                }
-                SpawnProcessControl::Enabled => {
-                    vsock
-                        .spawn_process_with_control_sink(
-                            request.cmd,
-                            request.timeout_ms(),
-                            request.env,
-                            request.sudo,
-                            request.output.streams_stdout(),
-                            request.output.guest_log_path(),
-                        )
-                        .await
-                }
-            }
+        let start_future = async move {
+            vsock
+                .start_supervised_exec(SupervisedExecRequest {
+                    timeout: process_timeout_policy(request.timeout),
+                    command: request.cmd,
+                    env: request.env,
+                    sudo: request.sudo,
+                    label: request.cmd,
+                    stdout: process_stdout_policy(request.output),
+                    stderr: process_stderr_policy(request.output),
+                    expected_exit_codes: &[],
+                    control: match request.control {
+                        ProcessControlMode::None => SupervisedExecControl::Disabled,
+                        ProcessControlMode::Enabled => {
+                            SupervisedExecControl::Enabled { sink: true }
+                        }
+                    },
+                    stream_queue_capacity: process_stream_queue_capacity(request.output),
+                    start_timeout: PROCESS_START_ACK_TIMEOUT,
+                })
+                .await
         };
 
         tokio::select! {
-            result = spawn_future => {
+            result = start_future => {
                 let mut handle = match result {
                     Ok(handle) => handle,
                     Err(error) => {
@@ -1819,8 +2019,7 @@ impl Sandbox for FirecrackerSandbox {
                     }
                 };
                 let pid = handle.pid();
-                let process_control = (request.control == SpawnProcessControl::Enabled).then(|| {
-                    let control = handle.control_handle();
+                let process_control = handle.control_handle().map(|control| {
                     let coordinator = self.park_coordinator.clone();
                     let state = Arc::clone(&self.state);
                     let state_rx = self.state_tx.subscribe();
@@ -1830,28 +2029,38 @@ impl Sandbox for FirecrackerSandbox {
                         let state = Arc::clone(&state);
                         let state_rx = state_rx.clone();
                         Box::pin(async move {
-                            Self::process_control(
+                            Self::exec_process_control(
                                 coordinator, state, state_rx, control, message_id, payload, timeout,
                             )
                             .await
                         })
                     })
                 });
-                let stdout_rx = request
-                    .output
-                    .streams_stdout()
-                    .then(|| handle.take_stdout_receiver())
-                    .flatten();
-                let exit = Box::pin(async move {
-                    let event = handle.wait().await?;
-                    Ok(ProcessExit {
-                        pid: event.pid,
-                        exit_code: event.exit_code,
-                        stdout: event.stdout,
-                        stderr: event.stderr,
+                let (stdout_rx, close_stdout) = if request.output.streams_stdout() {
+                    match handle.take_stream_receiver() {
+                        Some(stream_rx) => {
+                            let queue_capacity = process_stream_queue_capacity(request.output)
+                                .unwrap_or(ProcessOutputMode::DEFAULT_QUEUE_CAPACITY);
+                            let (stdout_rx, close_stdout) =
+                                supervised_stdout_receiver(stream_rx, queue_capacity);
+                            (Some(stdout_rx), Some(close_stdout))
+                        }
+                        None => (None, None),
+                    }
+                } else {
+                    (None, None)
+                };
+                let wait = GuestProcessWaiter::new(move |timeout| {
+                    Box::pin(async move {
+                        let result = handle.wait(timeout).await?;
+                        Ok(supervised_exec_result_to_process_exit(pid, result))
                     })
                 });
-                Ok(GuestProcessHandle::new(pid, stdout_rx, process_control, exit))
+                let public_handle = GuestProcessHandle::new(pid, stdout_rx, process_control, wait);
+                Ok(match close_stdout {
+                    Some(close_stdout) => public_handle.with_unclaimed_stdout_cleanup(close_stdout),
+                    None => public_handle,
+                })
             }
             () = wait_for_backend_crash(self.state_tx.subscribe()) => {
                 Err(Self::backend_crashed_error(operation))
@@ -1859,37 +2068,31 @@ impl Sandbox for FirecrackerSandbox {
         }
     }
 
-    async fn wait_exit(
+    async fn wait_process(
         &self,
         mut handle: GuestProcessHandle,
         timeout: Duration,
     ) -> sandbox::Result<ProcessExit> {
-        let operation = SandboxOperation::WaitExit;
-        let mut exit = handle.take_exit_future().ok_or_else(|| {
+        let operation = SandboxOperation::WaitProcess;
+        let waiter = handle.take_waiter().ok_or_else(|| {
             Self::operation_error(
                 operation,
                 std::io::Error::new(
                     std::io::ErrorKind::ConnectionReset,
-                    "spawn_process handle already consumed",
+                    "start_process handle already consumed",
                 ),
                 self.has_backend_crashed(),
             )
         })?;
-        // `wait_exit` consumes the handle; an unclaimed stream receiver can no
+        // `wait_process` consumes the handle; an unclaimed stream receiver can no
         // longer be observed by the caller and would otherwise buffer forever.
-        drop(handle.stdout_rx.take());
+        handle.drop_unclaimed_stdout();
+        let mut wait = waiter.wait(timeout);
 
         tokio::select! {
             biased;
-            result = &mut exit => {
+            result = &mut wait => {
                 result.map_err(|e| Self::operation_error(operation, e, self.has_backend_crashed()))
-            }
-            _ = tokio::time::sleep(timeout) => {
-                Err(Self::operation_error(
-                    operation,
-                    std::io::Error::new(std::io::ErrorKind::TimedOut, "wait_exit timeout"),
-                    self.has_backend_crashed(),
-                ))
             }
             () = wait_for_backend_crash(self.state_tx.subscribe()) => {
                 Err(Self::backend_crashed_error(operation))
@@ -4322,7 +4525,7 @@ mod tests {
     #[test]
     fn operation_error_classifies_io_timeout() {
         let err = FirecrackerSandbox::operation_error(
-            SandboxOperation::WaitExit,
+            SandboxOperation::WaitProcess,
             io::Error::new(io::ErrorKind::TimedOut, "wait timeout"),
             false,
         );
@@ -4342,13 +4545,136 @@ mod tests {
     }
 
     #[test]
+    fn process_timeout_policy_maps_zero_to_none_and_durations_to_millis() {
+        assert_eq!(
+            process_timeout_policy(Duration::ZERO),
+            ExecTimeoutPolicy::None
+        );
+        assert_eq!(
+            process_timeout_policy(Duration::from_millis(2500)),
+            ExecTimeoutPolicy::Duration { timeout_ms: 2500 }
+        );
+    }
+
+    #[test]
+    fn process_output_stream_maps_to_supervised_stdout_only() {
+        let output = ProcessOutputMode::Stream {
+            stream_limit_bytes: 123,
+            chunk_limit_bytes: 45,
+            queue_capacity: 7,
+        };
+
+        assert_eq!(
+            process_stdout_policy(output),
+            ExecOutputPolicy::Stream {
+                limit_bytes: 123,
+                chunk_limit_bytes: 45,
+            }
+        );
+        assert_eq!(process_stderr_policy(output), ExecOutputPolicy::Discard);
+        assert_eq!(process_stream_queue_capacity(output), Some(7));
+    }
+
+    #[test]
+    fn process_output_buffered_maps_to_bounded_capture() {
+        let output = ProcessOutputMode::buffered(sandbox::ExecOutputLimits::separate(11, 13));
+
+        assert_eq!(
+            process_stdout_policy(output),
+            ExecOutputPolicy::Capture { limit_bytes: 11 }
+        );
+        assert_eq!(
+            process_stderr_policy(output),
+            ExecOutputPolicy::Capture { limit_bytes: 13 }
+        );
+        assert_eq!(process_stream_queue_capacity(output), None);
+    }
+
+    #[test]
+    fn supervised_exec_result_to_process_exit_preserves_terminal_metadata() {
+        let exit = supervised_exec_result_to_process_exit(
+            42,
+            vsock_host::ExecOperationResult {
+                termination: ExecTermination::WaitFailed,
+                duration_ms: 10,
+                stdout: ExecOwnedCapturedOutput::Captured {
+                    bytes: b"out".to_vec(),
+                    truncated: true,
+                },
+                stderr: ExecOwnedCapturedOutput::Captured {
+                    bytes: b"err".to_vec(),
+                    truncated: false,
+                },
+                diagnostic: "wait failed".to_string(),
+                stream_overflowed: true,
+            },
+        );
+
+        assert_eq!(exit.pid, 42);
+        assert_eq!(exit.exit_code, 1);
+        assert_eq!(exit.stdout, b"out");
+        assert_eq!(exit.stderr, b"err\nwait failed");
+        assert!(exit.stdout_truncated);
+        assert!(!exit.stderr_truncated);
+        assert_eq!(exit.diagnostic, "wait failed");
+        assert!(exit.stream_overflowed);
+    }
+
+    #[tokio::test]
+    async fn supervised_stdout_receiver_forwards_only_stdout_chunks() {
+        let (stream_tx, stream_rx) = mpsc::channel(4);
+        let (mut stdout_rx, _close) = supervised_stdout_receiver(stream_rx, 2);
+
+        stream_tx
+            .send(ExecOutputEvent {
+                stream: ExecOutputStream::Stderr,
+                output_seq: 1,
+                chunk: b"stderr".to_vec(),
+                truncated: false,
+            })
+            .await
+            .unwrap();
+        stream_tx
+            .send(ExecOutputEvent {
+                stream: ExecOutputStream::Stdout,
+                output_seq: 2,
+                chunk: b"stdout".to_vec(),
+                truncated: true,
+            })
+            .await
+            .unwrap();
+        drop(stream_tx);
+
+        let chunk = tokio::time::timeout(Duration::from_secs(1), stdout_rx.recv())
+            .await
+            .expect("stdout chunk was not forwarded")
+            .expect("stdout stream closed before forwarded chunk");
+        assert_eq!(chunk.bytes, b"stdout");
+        assert!(chunk.truncated);
+        assert!(stdout_rx.recv().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn supervised_stdout_receiver_cleanup_closes_unclaimed_adapter() {
+        let (_stream_tx, stream_rx) = mpsc::channel(1);
+        let (mut stdout_rx, close) = supervised_stdout_receiver(stream_rx, 1);
+
+        close();
+
+        let received = tokio::time::timeout(Duration::from_secs(1), stdout_rx.recv())
+            .await
+            .expect("stdout adapter did not close");
+        assert!(received.is_none());
+    }
+
+    #[test]
     fn operation_error_classifies_observed_backend_crash_for_all_operations() {
         for operation in [
             SandboxOperation::Exec,
             SandboxOperation::WriteFile,
-            SandboxOperation::SpawnProcess,
+            SandboxOperation::StartProcess,
             SandboxOperation::ProcessControl,
-            SandboxOperation::WaitExit,
+            SandboxOperation::WaitProcess,
         ] {
             let err = FirecrackerSandbox::operation_error(
                 operation,
@@ -4365,9 +4691,9 @@ mod tests {
         for operation in [
             SandboxOperation::Exec,
             SandboxOperation::WriteFile,
-            SandboxOperation::SpawnProcess,
+            SandboxOperation::StartProcess,
             SandboxOperation::ProcessControl,
-            SandboxOperation::WaitExit,
+            SandboxOperation::WaitProcess,
         ] {
             let err =
                 FirecrackerSandbox::operation_unavailable_error(operation, SandboxState::Crashed);

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -1531,6 +1531,7 @@ fn supervised_stdout_receiver(
     tokio::spawn(async move {
         loop {
             tokio::select! {
+                biased;
                 () = task_close.cancelled() => {
                     break;
                 }
@@ -1544,8 +1545,16 @@ fn supervised_stdout_receiver(
                                 bytes: event.chunk,
                                 truncated: event.truncated,
                             };
-                            if stdout_tx.send(chunk).await.is_err() {
-                                break;
+                            tokio::select! {
+                                biased;
+                                () = task_close.cancelled() => {
+                                    break;
+                                }
+                                result = stdout_tx.send(chunk) => {
+                                    if result.is_err() {
+                                        break;
+                                    }
+                                }
                             }
                         }
                         ExecOutputStream::Stderr => {
@@ -4664,6 +4673,68 @@ mod tests {
             .await
             .expect("stdout adapter did not close");
         assert!(received.is_none());
+    }
+
+    #[tokio::test]
+    async fn supervised_stdout_receiver_cleanup_interrupts_blocked_forwarder() {
+        let (stream_tx, stream_rx) = mpsc::channel(1);
+        let (mut stdout_rx, close) = supervised_stdout_receiver(stream_rx, 1);
+
+        stream_tx
+            .send(ExecOutputEvent {
+                stream: ExecOutputStream::Stdout,
+                output_seq: 1,
+                chunk: b"first".to_vec(),
+                truncated: false,
+            })
+            .await
+            .unwrap();
+
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while stdout_rx.is_empty() {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("first stdout chunk was not buffered");
+
+        tokio::time::timeout(
+            Duration::from_secs(1),
+            stream_tx.send(ExecOutputEvent {
+                stream: ExecOutputStream::Stdout,
+                output_seq: 2,
+                chunk: b"second".to_vec(),
+                truncated: false,
+            }),
+        )
+        .await
+        .expect("second stdout event was not accepted")
+        .unwrap();
+        tokio::time::timeout(
+            Duration::from_secs(1),
+            stream_tx.send(ExecOutputEvent {
+                stream: ExecOutputStream::Stdout,
+                output_seq: 3,
+                chunk: b"third".to_vec(),
+                truncated: false,
+            }),
+        )
+        .await
+        .expect("third stdout event was not accepted")
+        .unwrap();
+
+        close();
+
+        let first = tokio::time::timeout(Duration::from_secs(1), stdout_rx.recv())
+            .await
+            .expect("first stdout chunk was not received")
+            .expect("stdout stream closed before first chunk");
+        assert_eq!(first.bytes, b"first");
+
+        let closed = tokio::time::timeout(Duration::from_secs(1), stdout_rx.recv())
+            .await
+            .expect("stdout adapter did not close after cleanup");
+        assert!(closed.is_none());
     }
 
     #[tokio::test]

--- a/crates/sandbox-mock/src/lib.rs
+++ b/crates/sandbox-mock/src/lib.rs
@@ -2198,7 +2198,7 @@ mod tests {
             })
             .await
             .unwrap();
-        assert!(buffered.stdout_rx.is_none());
+        assert!(!buffered.has_stdout_receiver());
 
         let streamed = sandbox
             .start_process(&StartProcessRequest {
@@ -2211,7 +2211,7 @@ mod tests {
             })
             .await
             .unwrap();
-        assert!(streamed.stdout_rx.is_some());
+        assert!(streamed.has_stdout_receiver());
 
         assert_eq!(
             overrides.start_process_calls(),

--- a/crates/sandbox-mock/src/lib.rs
+++ b/crates/sandbox-mock/src/lib.rs
@@ -660,6 +660,27 @@ fn apply_exec_output_limits(mut result: ExecResult, limits: ExecOutputLimits) ->
     result
 }
 
+fn validate_start_process_output(output: ProcessOutputMode) -> Result<()> {
+    match output {
+        ProcessOutputMode::Stream {
+            chunk_limit_bytes: 0,
+            ..
+        } => Err(SandboxError::Operation {
+            operation: SandboxOperation::StartProcess,
+            reason: SandboxOperationReason::Other,
+            message: "process stream chunk limit must be positive".to_string(),
+        }),
+        ProcessOutputMode::Stream {
+            queue_capacity: 0, ..
+        } => Err(SandboxError::Operation {
+            operation: SandboxOperation::StartProcess,
+            reason: SandboxOperationReason::Other,
+            message: "process stream queue capacity must be positive".to_string(),
+        }),
+        ProcessOutputMode::Buffered { .. } | ProcessOutputMode::Stream { .. } => Ok(()),
+    }
+}
+
 #[async_trait]
 impl Sandbox for MockSandbox {
     fn id(&self) -> &str {
@@ -866,6 +887,7 @@ impl Sandbox for MockSandbox {
     }
 
     async fn start_process(&self, request: &StartProcessRequest<'_>) -> Result<GuestProcessHandle> {
+        validate_start_process_output(request.output)?;
         if let Some(overrides) = &self.overrides {
             overrides
                 .start_process_calls
@@ -2266,6 +2288,47 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(ack.message_id, "msg-1");
+    }
+
+    #[tokio::test]
+    async fn start_process_rejects_invalid_stream_configuration() {
+        let runtime = MockSandboxRuntime::new();
+        let factory = runtime.create_factory(test_factory_config()).await.unwrap();
+        let sandbox = factory.create(test_sandbox_config()).await.unwrap();
+
+        for output in [
+            ProcessOutputMode::Stream {
+                stream_limit_bytes: 1024,
+                chunk_limit_bytes: 0,
+                queue_capacity: 1,
+            },
+            ProcessOutputMode::Stream {
+                stream_limit_bytes: 1024,
+                chunk_limit_bytes: 16,
+                queue_capacity: 0,
+            },
+        ] {
+            match sandbox
+                .start_process(&StartProcessRequest {
+                    cmd: "agent",
+                    timeout: Duration::from_secs(5),
+                    env: &[],
+                    sudo: false,
+                    output,
+                    control: ProcessControlMode::None,
+                })
+                .await
+            {
+                Ok(_) => panic!("invalid stream configuration should be rejected"),
+                Err(SandboxError::Operation {
+                    operation, reason, ..
+                }) => {
+                    assert_eq!(operation, SandboxOperation::StartProcess);
+                    assert_eq!(reason, SandboxOperationReason::Other);
+                }
+                Err(other) => panic!("expected start_process operation error, got {other:?}"),
+            }
+        }
     }
 
     #[tokio::test]

--- a/crates/sandbox-mock/src/lib.rs
+++ b/crates/sandbox-mock/src/lib.rs
@@ -7,7 +7,7 @@
 //!
 //! For advanced control, create [`MockSandboxOverrides`] and pass it via
 //! [`MockSandboxRuntime::with_overrides`]. This enables pattern-matched exec
-//! results, shared lifecycle behavior queues, custom `wait_exit` exit codes,
+//! results, shared lifecycle behavior queues, custom `wait_process` exit codes,
 //! and durable [`MockLifecycleGate`] gates for lifecycle and cancellation
 //! testing.
 //!
@@ -52,10 +52,9 @@ pub struct ExecMatcher {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct SpawnProcessCall {
-    pub streams_stdout: bool,
-    pub guest_log_path: Option<String>,
-    pub control: SpawnProcessControl,
+pub struct StartProcessCall {
+    pub output: ProcessOutputMode,
+    pub control: ProcessControlMode,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -275,15 +274,15 @@ pub struct MockSandboxOverrides {
     /// Pattern-matched exec results. First matching pattern wins and is
     /// consumed (one-shot).
     exec_matchers: Mutex<Vec<ExecMatcher>>,
-    /// When `Some`, `wait_exit` returns this exit code instead of 0.
-    wait_exit_code: Option<i32>,
-    /// When set, `wait_exit` awaits this [`tokio::sync::Notify`] before
+    /// When `Some`, `wait_process` returns this exit code instead of 0.
+    wait_process_code: Option<i32>,
+    /// When set, `wait_process` awaits this [`tokio::sync::Notify`] before
     /// returning — giving the test a window to cancel the job.
-    wait_exit_gate: Option<Arc<tokio::sync::Notify>>,
-    /// When `Some`, `wait_exit` returns a wait-exit operation error to
+    wait_process_gate: Option<Arc<tokio::sync::Notify>>,
+    /// When `Some`, `wait_process` returns a wait-process operation error to
     /// simulate timeout or crash. The stdout channel sender is also kept alive
     /// in `MockSandbox` so the drain task would block without the fix.
-    wait_exit_error: Option<String>,
+    wait_process_error: Option<String>,
     /// FIFO queue of create results consumed by every factory built with
     /// these overrides. Empty queue → default Ok(()).
     create_results: Mutex<VecDeque<Result<()>>>,
@@ -309,9 +308,9 @@ pub struct MockSandboxOverrides {
     /// FIFO queue of destroy behaviours consumed by every factory built with
     /// these overrides. Empty queue → default successful destroy.
     destroy_behaviors: Mutex<VecDeque<DestroyBehavior>>,
-    /// Recorded spawn_process output modes across all sandboxes built from
+    /// Recorded start_process output modes across all sandboxes built from
     /// this override set.
-    spawn_process_calls: Mutex<Vec<SpawnProcessCall>>,
+    start_process_calls: Mutex<Vec<StartProcessCall>>,
     /// Total `park()` calls across all sandboxes built from this override set.
     park_calls: Mutex<u32>,
     /// Total `unpark()` calls across all sandboxes built from this override set.
@@ -325,9 +324,9 @@ impl MockSandboxOverrides {
     pub fn new() -> Self {
         Self {
             exec_matchers: Mutex::new(Vec::new()),
-            wait_exit_code: None,
-            wait_exit_gate: None,
-            wait_exit_error: None,
+            wait_process_code: None,
+            wait_process_gate: None,
+            wait_process_error: None,
             create_results: Mutex::new(VecDeque::new()),
             create_configs: Mutex::new(Vec::new()),
             start_results: Mutex::new(VecDeque::new()),
@@ -337,35 +336,35 @@ impl MockSandboxOverrides {
             unpark_behaviors: Mutex::new(VecDeque::new()),
             destroy_gate: Mutex::new(None),
             destroy_behaviors: Mutex::new(VecDeque::new()),
-            spawn_process_calls: Mutex::new(Vec::new()),
+            start_process_calls: Mutex::new(Vec::new()),
             park_calls: Mutex::new(0),
             unpark_calls: Mutex::new(0),
             destroy_calls: Mutex::new(0),
         }
     }
 
-    /// Create overrides that make `wait_exit` return a custom exit code.
-    pub fn with_wait_exit_code(code: i32) -> Self {
+    /// Create overrides that make `wait_process` return a custom exit code.
+    pub fn with_wait_process_code(code: i32) -> Self {
         Self {
-            wait_exit_code: Some(code),
+            wait_process_code: Some(code),
             ..Self::new()
         }
     }
 
-    /// Create overrides that block `wait_exit` until the gate is notified.
-    pub fn with_wait_exit_gate(gate: Arc<tokio::sync::Notify>) -> Self {
+    /// Create overrides that block `wait_process` until the gate is notified.
+    pub fn with_wait_process_gate(gate: Arc<tokio::sync::Notify>) -> Self {
         Self {
-            wait_exit_gate: Some(gate),
+            wait_process_gate: Some(gate),
             ..Self::new()
         }
     }
 
-    /// Create overrides that make `wait_exit` return an error (simulating
+    /// Create overrides that make `wait_process` return an error (simulating
     /// timeout or crash). The stdout channel sender is kept alive so the
     /// drain task blocks unless the caller aborts it.
-    pub fn with_wait_exit_error(msg: impl Into<String>) -> Self {
+    pub fn with_wait_process_error(msg: impl Into<String>) -> Self {
         Self {
-            wait_exit_error: Some(msg.into()),
+            wait_process_error: Some(msg.into()),
             ..Self::new()
         }
     }
@@ -508,10 +507,10 @@ impl MockSandboxOverrides {
         *self.destroy_calls.lock_ignoring_poison()
     }
 
-    /// Recorded spawn_process calls across all sandboxes built from this
+    /// Recorded start_process calls across all sandboxes built from this
     /// override set, in call order.
-    pub fn spawn_process_calls(&self) -> Vec<SpawnProcessCall> {
-        self.spawn_process_calls.lock_ignoring_poison().clone()
+    pub fn start_process_calls(&self) -> Vec<StartProcessCall> {
+        self.start_process_calls.lock_ignoring_poison().clone()
     }
 }
 
@@ -555,9 +554,9 @@ pub struct MockSandbox {
     write_file_calls: Mutex<Vec<WriteFileCall>>,
     overrides: Option<Arc<MockSandboxOverrides>>,
     /// Holds the stdout channel sender alive when simulating a non-closing
-    /// channel (e.g. wait_exit_error override). Without this, the sender is
-    /// dropped immediately in `spawn_process` and the drain task exits.
-    stdout_tx: Mutex<Option<tokio::sync::mpsc::UnboundedSender<Vec<u8>>>>,
+    /// channel (e.g. wait_process_error override). Without this, the sender is
+    /// dropped immediately in `start_process` and the drain task exits.
+    stdout_tx: Mutex<Option<tokio::sync::mpsc::Sender<ProcessOutputChunk>>>,
 }
 
 impl MockSandbox {
@@ -866,28 +865,34 @@ impl Sandbox for MockSandbox {
             .unwrap_or(Ok(()))
     }
 
-    async fn spawn_process(&self, request: &SpawnProcessRequest<'_>) -> Result<GuestProcessHandle> {
+    async fn start_process(&self, request: &StartProcessRequest<'_>) -> Result<GuestProcessHandle> {
         if let Some(overrides) = &self.overrides {
             overrides
-                .spawn_process_calls
+                .start_process_calls
                 .lock_ignoring_poison()
-                .push(SpawnProcessCall {
-                    streams_stdout: request.output.streams_stdout(),
-                    guest_log_path: request.output.guest_log_path().map(str::to_owned),
+                .push(StartProcessCall {
+                    output: request.output,
                     control: request.control,
                 });
         }
-        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
-        // When simulating wait_exit error (timeout/crash), keep the sender
+        let (tx, rx) = match request.output {
+            ProcessOutputMode::Stream { queue_capacity, .. } => {
+                let (tx, rx) = tokio::sync::mpsc::channel(queue_capacity.max(1));
+                (Some(tx), Some(rx))
+            }
+            ProcessOutputMode::Buffered { .. } => (None, None),
+        };
+        // When simulating wait_process error (timeout/crash), keep the sender
         // alive so the stdout channel never closes — reproducing the real bug.
         if self
             .overrides
             .as_ref()
-            .is_some_and(|o| o.wait_exit_error.is_some())
+            .is_some_and(|o| o.wait_process_error.is_some())
+            && let Some(tx) = tx
         {
             *self.stdout_tx.lock_ignoring_poison() = Some(tx);
         }
-        let control = (request.control == SpawnProcessControl::Enabled).then(|| {
+        let control = (request.control == ProcessControlMode::Enabled).then(|| {
             GuestProcessControlHandle::new(|message_id, _payload, _timeout| {
                 Box::pin(async move { Ok(ProcessControlAck { message_id }) })
             })
@@ -895,57 +900,49 @@ impl Sandbox for MockSandbox {
 
         Ok(GuestProcessHandle::new(
             1,
-            request.output.streams_stdout().then_some(rx),
+            rx,
             control,
-            Box::pin(std::future::pending::<std::io::Result<ProcessExit>>()),
+            GuestProcessWaiter::new(|_timeout| {
+                Box::pin(std::future::pending::<std::io::Result<ProcessExit>>())
+            }),
         ))
     }
 
-    async fn wait_exit(
+    async fn wait_process(
         &self,
         mut handle: GuestProcessHandle,
         _timeout: Duration,
     ) -> Result<ProcessExit> {
-        let Some(_exit) = handle.take_exit_future() else {
+        let Some(_waiter) = handle.take_waiter() else {
             return Err(SandboxError::Operation {
-                operation: SandboxOperation::WaitExit,
+                operation: SandboxOperation::WaitProcess,
                 reason: SandboxOperationReason::Other,
-                message: "spawn_process handle already consumed".to_string(),
+                message: "start_process handle already consumed".to_string(),
             });
         };
-        // `wait_exit` consumes the handle; an unclaimed stream receiver can no
+        // `wait_process` consumes the handle; an unclaimed stream receiver can no
         // longer be observed by the caller and would otherwise buffer forever.
-        drop(handle.stdout_rx.take());
+        handle.drop_unclaimed_stdout();
 
         if let Some(overrides) = &self.overrides {
             // Block until the test signals (gives a window for cancellation).
-            if let Some(gate) = &overrides.wait_exit_gate {
+            if let Some(gate) = &overrides.wait_process_gate {
                 gate.notified().await;
             }
             // Return error when configured (simulates timeout or crash).
-            if let Some(ref msg) = overrides.wait_exit_error {
+            if let Some(ref msg) = overrides.wait_process_error {
                 return Err(SandboxError::Operation {
-                    operation: SandboxOperation::WaitExit,
+                    operation: SandboxOperation::WaitProcess,
                     reason: SandboxOperationReason::Timeout,
                     message: msg.clone(),
                 });
             }
             // Return override exit code when configured.
-            if let Some(code) = overrides.wait_exit_code {
-                return Ok(ProcessExit {
-                    pid: handle.pid,
-                    exit_code: code,
-                    stdout: Vec::new(),
-                    stderr: Vec::new(),
-                });
+            if let Some(code) = overrides.wait_process_code {
+                return Ok(ProcessExit::new(handle.pid, code, Vec::new(), Vec::new()));
             }
         }
-        Ok(ProcessExit {
-            pid: handle.pid,
-            exit_code: 0,
-            stdout: Vec::new(),
-            stderr: Vec::new(),
-        })
+        Ok(ProcessExit::new(handle.pid, 0, Vec::new(), Vec::new()))
     }
 }
 
@@ -2186,102 +2183,78 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn overrides_record_spawn_process_output_modes_in_order() {
+    async fn overrides_record_start_process_output_modes_in_order() {
         let overrides = Arc::new(MockSandboxOverrides::new());
         let factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));
         let sandbox = factory.create(test_sandbox_config()).await.unwrap();
         let buffered = sandbox
-            .spawn_process(&SpawnProcessRequest {
+            .start_process(&StartProcessRequest {
                 cmd: "agent",
                 timeout: Duration::from_secs(5),
                 env: &[],
                 sudo: false,
-                output: SpawnProcessOutputMode::Buffered,
-                control: SpawnProcessControl::None,
+                output: ProcessOutputMode::buffered(EXEC_OUTPUT_LIMIT_1_MIB),
+                control: ProcessControlMode::None,
             })
             .await
             .unwrap();
         assert!(buffered.stdout_rx.is_none());
 
         let streamed = sandbox
-            .spawn_process(&SpawnProcessRequest {
+            .start_process(&StartProcessRequest {
                 cmd: "agent",
                 timeout: Duration::from_secs(5),
                 env: &[],
                 sudo: false,
-                output: SpawnProcessOutputMode::Stream {
-                    guest_log_path: None,
-                },
-                control: SpawnProcessControl::None,
+                output: ProcessOutputMode::stream(),
+                control: ProcessControlMode::None,
             })
             .await
             .unwrap();
         assert!(streamed.stdout_rx.is_some());
 
-        let tee = sandbox
-            .spawn_process(&SpawnProcessRequest {
-                cmd: "agent",
-                timeout: Duration::from_secs(5),
-                env: &[],
-                sudo: false,
-                output: SpawnProcessOutputMode::Stream {
-                    guest_log_path: Some("/tmp/guest.log"),
-                },
-                control: SpawnProcessControl::None,
-            })
-            .await
-            .unwrap();
-        assert!(tee.stdout_rx.is_some());
-
         assert_eq!(
-            overrides.spawn_process_calls(),
+            overrides.start_process_calls(),
             vec![
-                SpawnProcessCall {
-                    streams_stdout: false,
-                    guest_log_path: None,
-                    control: SpawnProcessControl::None,
+                StartProcessCall {
+                    output: ProcessOutputMode::buffered(EXEC_OUTPUT_LIMIT_1_MIB),
+                    control: ProcessControlMode::None,
                 },
-                SpawnProcessCall {
-                    streams_stdout: true,
-                    guest_log_path: None,
-                    control: SpawnProcessControl::None,
-                },
-                SpawnProcessCall {
-                    streams_stdout: true,
-                    guest_log_path: Some("/tmp/guest.log".to_string()),
-                    control: SpawnProcessControl::None,
+                StartProcessCall {
+                    output: ProcessOutputMode::stream(),
+                    control: ProcessControlMode::None,
                 },
             ]
         );
     }
 
     #[tokio::test]
-    async fn spawn_process_returns_control_handle_when_requested() {
+    async fn start_process_returns_control_handle_when_requested() {
         let runtime = MockSandboxRuntime::new();
         let factory = runtime.create_factory(test_factory_config()).await.unwrap();
         let sandbox = factory.create(test_sandbox_config()).await.unwrap();
 
         let without_control = sandbox
-            .spawn_process(&SpawnProcessRequest {
+            .start_process(&StartProcessRequest {
                 cmd: "agent",
                 timeout: Duration::from_secs(5),
                 env: &[],
                 sudo: false,
-                output: SpawnProcessOutputMode::Buffered,
-                control: SpawnProcessControl::None,
+                output: ProcessOutputMode::buffered(EXEC_OUTPUT_LIMIT_1_MIB),
+                control: ProcessControlMode::None,
             })
             .await
             .unwrap();
         assert!(without_control.control_handle().is_none());
 
         let with_control = sandbox
-            .spawn_process(&SpawnProcessRequest {
+            .start_process(&StartProcessRequest {
                 cmd: "agent",
                 timeout: Duration::from_secs(5),
                 env: &[],
                 sudo: false,
-                output: SpawnProcessOutputMode::Buffered,
-                control: SpawnProcessControl::Enabled,
+                output: ProcessOutputMode::buffered(EXEC_OUTPUT_LIMIT_1_MIB),
+                control: ProcessControlMode::Enabled,
             })
             .await
             .unwrap();
@@ -2296,61 +2269,65 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn wait_exit_rejects_consumed_guest_process_handle() {
+    async fn wait_process_rejects_consumed_guest_process_handle() {
         let runtime = MockSandboxRuntime::new();
         let factory = runtime.create_factory(test_factory_config()).await.unwrap();
         let sandbox = factory.create(test_sandbox_config()).await.unwrap();
         let mut handle = sandbox
-            .spawn_process(&SpawnProcessRequest {
+            .start_process(&StartProcessRequest {
                 cmd: "agent",
                 timeout: Duration::from_secs(5),
                 env: &[],
                 sudo: false,
-                output: SpawnProcessOutputMode::Buffered,
-                control: SpawnProcessControl::None,
+                output: ProcessOutputMode::buffered(EXEC_OUTPUT_LIMIT_1_MIB),
+                control: ProcessControlMode::None,
             })
             .await
             .unwrap();
 
-        let consumed = handle.take_exit_future();
+        let consumed = handle.take_waiter();
         assert!(consumed.is_some());
-        match sandbox.wait_exit(handle, Duration::from_secs(5)).await {
-            Ok(_) => panic!("wait_exit should reject an already consumed handle"),
+        match sandbox.wait_process(handle, Duration::from_secs(5)).await {
+            Ok(_) => panic!("wait_process should reject an already consumed handle"),
             Err(SandboxError::Operation {
                 operation,
                 reason,
                 message,
             }) => {
-                assert_eq!(operation, SandboxOperation::WaitExit);
+                assert_eq!(operation, SandboxOperation::WaitProcess);
                 assert_eq!(reason, SandboxOperationReason::Other);
                 assert!(message.contains("already consumed"));
             }
-            Err(other) => panic!("expected wait_exit operation error, got {other:?}"),
+            Err(other) => panic!("expected wait_process operation error, got {other:?}"),
         }
     }
 
     #[tokio::test]
-    async fn wait_exit_drops_unclaimed_stdout_receiver_before_waiting() {
+    async fn wait_process_drops_unclaimed_stdout_receiver_before_waiting() {
         let gate = Arc::new(tokio::sync::Notify::new());
-        let overrides = Arc::new(MockSandboxOverrides::with_wait_exit_gate(Arc::clone(&gate)));
+        let overrides = Arc::new(MockSandboxOverrides::with_wait_process_gate(Arc::clone(
+            &gate,
+        )));
         let sandbox = MockSandbox::with_overrides("test", overrides);
-        let (stdout_tx, stdout_rx) = tokio::sync::mpsc::unbounded_channel();
+        let (stdout_tx, stdout_rx) = tokio::sync::mpsc::channel(1);
         let handle = GuestProcessHandle::new(
             1,
             Some(stdout_rx),
             None,
-            Box::pin(std::future::pending::<std::io::Result<ProcessExit>>()),
+            GuestProcessWaiter::new(|_timeout| {
+                Box::pin(std::future::pending::<std::io::Result<ProcessExit>>())
+            }),
         );
 
         let wait =
-            tokio::spawn(async move { sandbox.wait_exit(handle, Duration::from_secs(5)).await });
+            tokio::spawn(async move { sandbox.wait_process(handle, Duration::from_secs(5)).await });
         tokio::time::timeout(test_timeout(), async {
             while !stdout_tx.is_closed() {
                 tokio::task::yield_now().await;
             }
         })
         .await
-        .expect("wait_exit should drop an unclaimed stdout receiver before blocking");
+        .expect("wait_process should drop an unclaimed stdout receiver before blocking");
 
         gate.notify_waiters();
         wait.await.unwrap().unwrap();

--- a/crates/sandbox-mock/src/lib.rs
+++ b/crates/sandbox-mock/src/lib.rs
@@ -2321,13 +2321,9 @@ mod tests {
 
         let wait =
             tokio::spawn(async move { sandbox.wait_process(handle, Duration::from_secs(5)).await });
-        tokio::time::timeout(test_timeout(), async {
-            while !stdout_tx.is_closed() {
-                tokio::task::yield_now().await;
-            }
-        })
-        .await
-        .expect("wait_process should drop an unclaimed stdout receiver before blocking");
+        tokio::time::timeout(test_timeout(), stdout_tx.closed())
+            .await
+            .expect("wait_process should drop an unclaimed stdout receiver before blocking");
 
         gate.notify_waiters();
         wait.await.unwrap().unwrap();

--- a/crates/sandbox/src/error.rs
+++ b/crates/sandbox/src/error.rs
@@ -86,12 +86,12 @@ pub enum SandboxOperation {
     Exec,
     /// [`Sandbox::write_file`](crate::Sandbox::write_file).
     WriteFile,
-    /// [`Sandbox::spawn_process`](crate::Sandbox::spawn_process).
-    SpawnProcess,
+    /// [`Sandbox::start_process`](crate::Sandbox::start_process).
+    StartProcess,
     /// [`GuestProcessControlHandle::control`](crate::GuestProcessControlHandle::control).
     ProcessControl,
-    /// [`Sandbox::wait_exit`](crate::Sandbox::wait_exit).
-    WaitExit,
+    /// [`Sandbox::wait_process`](crate::Sandbox::wait_process).
+    WaitProcess,
 }
 
 impl fmt::Display for SandboxOperation {
@@ -99,9 +99,9 @@ impl fmt::Display for SandboxOperation {
         match self {
             Self::Exec => f.write_str("exec"),
             Self::WriteFile => f.write_str("write file"),
-            Self::SpawnProcess => f.write_str("spawn process"),
+            Self::StartProcess => f.write_str("start process"),
             Self::ProcessControl => f.write_str("process control"),
-            Self::WaitExit => f.write_str("wait exit"),
+            Self::WaitProcess => f.write_str("wait process"),
         }
     }
 }

--- a/crates/sandbox/src/lib.rs
+++ b/crates/sandbox/src/lib.rs
@@ -44,6 +44,6 @@ pub use snapshot::{
 pub use types::{
     CopyFileOptions, CopyFileResult, EXEC_OUTPUT_LIMIT_1_MIB, EXEC_OUTPUT_LIMIT_7_MIB,
     EXEC_OUTPUT_LIMIT_64_KIB, ExecOutputLimits, ExecRequest, ExecResult, GuestProcessControlHandle,
-    GuestProcessHandle, ProcessControlAck, ProcessExit, SpawnProcessControl,
-    SpawnProcessOutputMode, SpawnProcessRequest,
+    GuestProcessHandle, GuestProcessWaiter, ProcessControlAck, ProcessControlMode, ProcessExit,
+    ProcessOutputChunk, ProcessOutputMode, ProcessOutputReceiver, StartProcessRequest,
 };

--- a/crates/sandbox/src/sandbox.rs
+++ b/crates/sandbox/src/sandbox.rs
@@ -226,9 +226,8 @@ pub trait Sandbox: Send + Sync + Any {
     ///
     /// `request.output` controls whether stdout is buffered into the final
     /// [`ProcessExit`] or streamed in real time through
-    /// [`GuestProcessHandle::stdout_rx`].
-    /// Callers that take `stdout_rx` are responsible for draining it while the
-    /// process runs.
+    /// [`GuestProcessHandle::take_stdout_receiver`]. Callers that take the
+    /// receiver are responsible for draining it while the process runs.
     async fn start_process(&self, request: &StartProcessRequest<'_>) -> Result<GuestProcessHandle>;
     /// Wait for the process behind `handle` to exit, up to `timeout`.
     ///

--- a/crates/sandbox/src/sandbox.rs
+++ b/crates/sandbox/src/sandbox.rs
@@ -24,8 +24,8 @@
 //! # Operations
 //! Once running, callers invoke [`exec`](Sandbox::exec) /
 //! [`read_file`](Sandbox::read_file) / [`copy_file`](Sandbox::copy_file) /
-//! [`write_file`](Sandbox::write_file) / [`spawn_process`](Sandbox::spawn_process) /
-//! [`wait_exit`](Sandbox::wait_exit) via the host-to-guest IPC channel
+//! [`write_file`](Sandbox::write_file) / [`start_process`](Sandbox::start_process) /
+//! [`wait_process`](Sandbox::wait_process) via the host-to-guest IPC channel
 //! (vsock, in the Firecracker backend). Operations race against a crash
 //! notifier so that a dying backend process surfaces as a specific
 //! "backend crashed" error rather than an opaque IPC timeout.
@@ -39,7 +39,7 @@ use async_trait::async_trait;
 use crate::error::Result;
 use crate::types::{
     CopyFileOptions, CopyFileResult, ExecRequest, ExecResult, GuestProcessHandle, ProcessExit,
-    SpawnProcessRequest,
+    StartProcessRequest,
 };
 
 /// A process-isolation environment that runs guest workloads for the runner.
@@ -65,8 +65,8 @@ use crate::types::{
 /// # Operations
 /// Once running, callers invoke [`exec`](Self::exec) /
 /// [`read_file`](Self::read_file) / [`copy_file`](Self::copy_file) /
-/// [`write_file`](Self::write_file) / [`spawn_process`](Self::spawn_process) /
-/// [`wait_exit`](Self::wait_exit) via the host-to-guest IPC channel
+/// [`write_file`](Self::write_file) / [`start_process`](Self::start_process) /
+/// [`wait_process`](Self::wait_process) via the host-to-guest IPC channel
 /// (vsock, in the Firecracker backend). Operations race against a crash
 /// notifier so that a dying backend process surfaces as a specific
 /// error rather than an opaque IPC timeout.
@@ -163,7 +163,7 @@ pub trait Sandbox: Send + Sync + Any {
     /// Transition the sandbox back to the active state.
     ///
     /// Must be called before any further work is dispatched via `exec` /
-    /// `spawn_process` on a previously parked sandbox. Implementations
+    /// `start_process` on a previously parked sandbox. Implementations
     /// should restore whatever state `park()` altered (resume vCPUs,
     /// balloon deflate, respawn background tickers, etc).
     ///
@@ -190,8 +190,8 @@ pub trait Sandbox: Send + Sync + Any {
     // dying backend process surfaces as a specific error rather than an opaque
     // IPC timeout.
     //
-    // `wait_exit` is the exception: it consumes a `GuestProcessHandle` returned by
-    // `spawn_process` and observes that handle's already-started backend exit
+    // `wait_process` is the exception: it consumes a `GuestProcessHandle` returned by
+    // `start_process` and observes that handle's already-started backend exit
     // operation instead of starting new guest work.
 
     /// Run `request.cmd` in the guest, block until it exits or the
@@ -221,16 +221,15 @@ pub trait Sandbox: Send + Sync + Any {
     /// directories and truncating the file as needed. Returns an error if
     /// the sandbox is not running or if the backing process crashes.
     async fn write_file(&self, path: &str, content: &[u8]) -> Result<()>;
-    /// Spawn `request.cmd` in the guest and return a handle for later
-    /// supervision via [`wait_exit`](Self::wait_exit).
+    /// Start `request.cmd` in the guest and return a handle for later
+    /// supervision via [`wait_process`](Self::wait_process).
     ///
     /// `request.output` controls whether stdout is buffered into the final
     /// [`ProcessExit`] or streamed in real time through
-    /// [`GuestProcessHandle::stdout_rx`], optionally
-    /// teeing streamed chunks into a guest-side file.
+    /// [`GuestProcessHandle::stdout_rx`].
     /// Callers that take `stdout_rx` are responsible for draining it while the
     /// process runs.
-    async fn spawn_process(&self, request: &SpawnProcessRequest<'_>) -> Result<GuestProcessHandle>;
+    async fn start_process(&self, request: &StartProcessRequest<'_>) -> Result<GuestProcessHandle>;
     /// Wait for the process behind `handle` to exit, up to `timeout`.
     ///
     /// Consumes the handle. If `stdout_rx` was not taken before waiting, the
@@ -238,6 +237,9 @@ pub trait Sandbox: Send + Sync + Any {
     /// an error if the backend exit operation is no longer available, if the
     /// backing process crashes before an exit result is delivered, or if the
     /// timeout elapses before the guest process exits.
-    async fn wait_exit(&self, handle: GuestProcessHandle, timeout: Duration)
-    -> Result<ProcessExit>;
+    async fn wait_process(
+        &self,
+        handle: GuestProcessHandle,
+        timeout: Duration,
+    ) -> Result<ProcessExit>;
 }

--- a/crates/sandbox/src/types.rs
+++ b/crates/sandbox/src/types.rs
@@ -278,6 +278,12 @@ impl GuestProcessHandle {
     }
 }
 
+impl Drop for GuestProcessHandle {
+    fn drop(&mut self) {
+        self.drop_unclaimed_stdout();
+    }
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum ProcessOutputMode {
     Buffered {
@@ -467,6 +473,28 @@ mod tests {
         });
 
         handle.drop_unclaimed_stdout();
+
+        assert!(closed.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn guest_process_handle_drop_closes_unclaimed_stdout() {
+        let (_tx, stdout_rx) = tokio::sync::mpsc::channel(1);
+        let closed = Arc::new(AtomicBool::new(false));
+        let close_observed = Arc::clone(&closed);
+        let handle = GuestProcessHandle::new(
+            42,
+            Some(stdout_rx),
+            None,
+            GuestProcessWaiter::new(|_| {
+                Box::pin(async { Ok(ProcessExit::new(42, 0, Vec::new(), Vec::new())) })
+            }),
+        )
+        .with_unclaimed_stdout_cleanup(move || {
+            close_observed.store(true, Ordering::SeqCst);
+        });
+
+        drop(handle);
 
         assert!(closed.load(Ordering::SeqCst));
     }

--- a/crates/sandbox/src/types.rs
+++ b/crates/sandbox/src/types.rs
@@ -58,9 +58,9 @@ impl ExecRequest<'_> {
     }
 }
 
-/// Request for a guest process that can outlive the initial spawn request and
+/// Request for a guest process that can outlive the initial start request and
 /// is supervised through [`GuestProcessHandle`].
-pub struct SpawnProcessRequest<'a> {
+pub struct StartProcessRequest<'a> {
     /// Shell command to run inside the guest.
     pub cmd: &'a str,
     /// Guest-side process timeout.
@@ -70,12 +70,12 @@ pub struct SpawnProcessRequest<'a> {
     /// Run the command with guest-side sudo privileges.
     pub sudo: bool,
     /// Buffered or streamed stdout behavior.
-    pub output: SpawnProcessOutputMode<'a>,
-    /// Optional operation-bound control sink requested for the spawned process.
-    pub control: SpawnProcessControl,
+    pub output: ProcessOutputMode,
+    /// Optional operation-bound control sink requested for the started process.
+    pub control: ProcessControlMode,
 }
 
-impl SpawnProcessRequest<'_> {
+impl StartProcessRequest<'_> {
     /// Return the timeout as whole milliseconds, saturating at `u32::MAX`.
     pub fn timeout_ms(&self) -> u32 {
         duration_ms(self.timeout)
@@ -130,13 +130,47 @@ pub struct CopyFileResult {
     pub bytes_copied: u64,
 }
 
-/// Backend-owned future that resolves when a spawned process exits.
+/// Process stdout stream event delivered to sandbox callers.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct ProcessOutputChunk {
+    /// Output bytes from the guest process stdout stream.
+    pub bytes: Vec<u8>,
+    /// True when this chunk was truncated by the guest stream budget.
+    pub truncated: bool,
+}
+
+/// Bounded receiver for process stdout chunks.
+pub type ProcessOutputReceiver = tokio::sync::mpsc::Receiver<ProcessOutputChunk>;
+
+/// Backend-owned future that resolves when a started process exits.
 ///
 /// Sandbox implementations store this in [`GuestProcessHandle`] so
-/// [`Sandbox::wait_exit`](crate::Sandbox::wait_exit) can consume the exact
-/// backend operation created by [`Sandbox::spawn_process`](crate::Sandbox::spawn_process).
-pub type GuestProcessExitFuture =
+/// [`Sandbox::wait_process`](crate::Sandbox::wait_process) can consume the exact
+/// backend operation created by [`Sandbox::start_process`](crate::Sandbox::start_process).
+pub type GuestProcessWaitFuture =
     Pin<Box<dyn Future<Output = std::io::Result<ProcessExit>> + Send + 'static>>;
+
+type GuestProcessWaitFn = dyn FnOnce(Duration) -> GuestProcessWaitFuture + Send + 'static;
+
+/// Backend-owned process waiter that accepts the host-side wait timeout.
+pub struct GuestProcessWaiter {
+    wait: Box<GuestProcessWaitFn>,
+}
+
+impl GuestProcessWaiter {
+    pub fn new<F>(wait: F) -> Self
+    where
+        F: FnOnce(Duration) -> GuestProcessWaitFuture + Send + 'static,
+    {
+        Self {
+            wait: Box::new(wait),
+        }
+    }
+
+    pub fn wait(self, timeout: Duration) -> GuestProcessWaitFuture {
+        (self.wait)(timeout)
+    }
+}
 
 /// Backend-owned future that resolves when a process-control message is acknowledged.
 pub type GuestProcessControlFuture =
@@ -177,75 +211,113 @@ impl GuestProcessControlHandle {
     }
 }
 
-/// Handle returned by [`Sandbox::spawn_process`](crate::Sandbox::spawn_process).
+/// Handle returned by [`Sandbox::start_process`](crate::Sandbox::start_process).
 ///
 /// The handle owns backend-specific exit state and must be consumed by
-/// [`Sandbox::wait_exit`](crate::Sandbox::wait_exit). When stdout streaming is
+/// [`Sandbox::wait_process`](crate::Sandbox::wait_process). When stdout streaming is
 /// enabled, callers may take [`stdout_rx`](Self::stdout_rx) before waiting; if
 /// they do, they must drain it while the process runs.
 pub struct GuestProcessHandle {
     pub pid: u32,
     /// Receives stdout chunks in real-time when the guest streams them.
     /// `None` when the backend does not support streaming.
-    pub stdout_rx: Option<tokio::sync::mpsc::UnboundedReceiver<Vec<u8>>>,
+    pub stdout_rx: Option<ProcessOutputReceiver>,
     control: Option<GuestProcessControlHandle>,
-    exit: Option<GuestProcessExitFuture>,
+    wait: Option<GuestProcessWaiter>,
+    close_unclaimed_stdout: Option<Box<dyn FnOnce() + Send + 'static>>,
 }
 
 impl GuestProcessHandle {
     /// Construct a guest process handle from backend-owned process state.
     pub fn new(
         pid: u32,
-        stdout_rx: Option<tokio::sync::mpsc::UnboundedReceiver<Vec<u8>>>,
+        stdout_rx: Option<ProcessOutputReceiver>,
         control: Option<GuestProcessControlHandle>,
-        exit: GuestProcessExitFuture,
+        wait: GuestProcessWaiter,
     ) -> Self {
         Self {
             pid,
             stdout_rx,
             control,
-            exit: Some(exit),
+            wait: Some(wait),
+            close_unclaimed_stdout: None,
         }
     }
 
-    /// Return a cloneable control handle when this process was spawned with a
+    /// Register backend cleanup for an unclaimed stdout receiver.
+    pub fn with_unclaimed_stdout_cleanup<F>(mut self, close: F) -> Self
+    where
+        F: FnOnce() + Send + 'static,
+    {
+        self.close_unclaimed_stdout = Some(Box::new(close));
+        self
+    }
+
+    /// Return a cloneable control handle when this process was started with a
     /// control sink.
     pub fn control_handle(&self) -> Option<GuestProcessControlHandle> {
         self.control.clone()
     }
 
-    /// Consume the backend exit future.
+    /// Consume the backend process waiter.
     ///
     /// This is intended for sandbox backend implementations of
-    /// [`Sandbox::wait_exit`](crate::Sandbox::wait_exit); ordinary callers should
+    /// [`Sandbox::wait_process`](crate::Sandbox::wait_process); ordinary callers should
     /// pass the handle to that trait method instead.
-    pub fn take_exit_future(&mut self) -> Option<GuestProcessExitFuture> {
-        self.exit.take()
+    pub fn take_waiter(&mut self) -> Option<GuestProcessWaiter> {
+        self.wait.take()
+    }
+
+    /// Drop a stdout receiver that the caller did not take before waiting.
+    pub fn drop_unclaimed_stdout(&mut self) {
+        if self.stdout_rx.take().is_some()
+            && let Some(close) = self.close_unclaimed_stdout.take()
+        {
+            close();
+        }
     }
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum SpawnProcessOutputMode<'a> {
-    Buffered,
-    Stream { guest_log_path: Option<&'a str> },
+pub enum ProcessOutputMode {
+    Buffered {
+        output_limits: ExecOutputLimits,
+    },
+    Stream {
+        stream_limit_bytes: u32,
+        chunk_limit_bytes: u32,
+        queue_capacity: usize,
+    },
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum SpawnProcessControl {
+pub enum ProcessControlMode {
     None,
     Enabled,
 }
 
-impl<'a> SpawnProcessOutputMode<'a> {
-    pub fn streams_stdout(self) -> bool {
-        matches!(self, Self::Stream { .. })
+impl ProcessOutputMode {
+    /// Default stream byte budget for long-running process logs.
+    pub const DEFAULT_STREAM_LIMIT_BYTES: u32 = 64 * 1024 * 1024;
+    /// Default maximum size of each streamed process stdout chunk.
+    pub const DEFAULT_CHUNK_LIMIT_BYTES: u32 = 8 * 1024;
+    /// Default bounded host queue capacity for process stdout chunks.
+    pub const DEFAULT_QUEUE_CAPACITY: usize = 8192;
+
+    pub const fn buffered(output_limits: ExecOutputLimits) -> Self {
+        Self::Buffered { output_limits }
     }
 
-    pub fn guest_log_path(self) -> Option<&'a str> {
-        match self {
-            Self::Buffered => None,
-            Self::Stream { guest_log_path } => guest_log_path,
+    pub const fn stream() -> Self {
+        Self::Stream {
+            stream_limit_bytes: Self::DEFAULT_STREAM_LIMIT_BYTES,
+            chunk_limit_bytes: Self::DEFAULT_CHUNK_LIMIT_BYTES,
+            queue_capacity: Self::DEFAULT_QUEUE_CAPACITY,
         }
+    }
+
+    pub fn streams_stdout(self) -> bool {
+        matches!(self, Self::Stream { .. })
     }
 }
 
@@ -254,11 +326,31 @@ pub struct ProcessExit {
     pub exit_code: i32,
     pub stdout: Vec<u8>,
     pub stderr: Vec<u8>,
+    pub stdout_truncated: bool,
+    pub stderr_truncated: bool,
+    pub diagnostic: String,
+    pub stream_overflowed: bool,
+}
+
+impl ProcessExit {
+    pub fn new(pid: u32, exit_code: i32, stdout: Vec<u8>, stderr: Vec<u8>) -> Self {
+        Self {
+            pid,
+            exit_code,
+            stdout,
+            stderr,
+            stdout_truncated: false,
+            stderr_truncated: false,
+            diagnostic: String::new(),
+            stream_overflowed: false,
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::{AtomicBool, Ordering};
 
     #[test]
     fn timeout_ms_normal() {
@@ -306,5 +398,76 @@ mod tests {
             output_limits: EXEC_OUTPUT_LIMIT_1_MIB,
         };
         assert_eq!(req.timeout_ms(), u32::MAX);
+    }
+
+    #[test]
+    fn process_output_mode_stream_uses_bounded_defaults() {
+        assert_eq!(
+            ProcessOutputMode::stream(),
+            ProcessOutputMode::Stream {
+                stream_limit_bytes: ProcessOutputMode::DEFAULT_STREAM_LIMIT_BYTES,
+                chunk_limit_bytes: ProcessOutputMode::DEFAULT_CHUNK_LIMIT_BYTES,
+                queue_capacity: ProcessOutputMode::DEFAULT_QUEUE_CAPACITY,
+            }
+        );
+    }
+
+    #[test]
+    fn process_exit_new_defaults_supervised_metadata() {
+        let exit = ProcessExit::new(42, 7, b"out".to_vec(), b"err".to_vec());
+
+        assert_eq!(exit.pid, 42);
+        assert_eq!(exit.exit_code, 7);
+        assert_eq!(exit.stdout, b"out");
+        assert_eq!(exit.stderr, b"err");
+        assert!(!exit.stdout_truncated);
+        assert!(!exit.stderr_truncated);
+        assert!(exit.diagnostic.is_empty());
+        assert!(!exit.stream_overflowed);
+    }
+
+    #[test]
+    fn guest_process_handle_closes_only_unclaimed_stdout() {
+        let (_tx, stdout_rx) = tokio::sync::mpsc::channel(1);
+        let closed = Arc::new(AtomicBool::new(false));
+        let close_observed = Arc::clone(&closed);
+        let mut handle = GuestProcessHandle::new(
+            42,
+            Some(stdout_rx),
+            None,
+            GuestProcessWaiter::new(|_| {
+                Box::pin(async { Ok(ProcessExit::new(42, 0, Vec::new(), Vec::new())) })
+            }),
+        )
+        .with_unclaimed_stdout_cleanup(move || {
+            close_observed.store(true, Ordering::SeqCst);
+        });
+
+        let _claimed_stdout = handle.stdout_rx.take();
+        handle.drop_unclaimed_stdout();
+
+        assert!(!closed.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn guest_process_handle_closes_unclaimed_stdout() {
+        let (_tx, stdout_rx) = tokio::sync::mpsc::channel(1);
+        let closed = Arc::new(AtomicBool::new(false));
+        let close_observed = Arc::clone(&closed);
+        let mut handle = GuestProcessHandle::new(
+            42,
+            Some(stdout_rx),
+            None,
+            GuestProcessWaiter::new(|_| {
+                Box::pin(async { Ok(ProcessExit::new(42, 0, Vec::new(), Vec::new())) })
+            }),
+        )
+        .with_unclaimed_stdout_cleanup(move || {
+            close_observed.store(true, Ordering::SeqCst);
+        });
+
+        handle.drop_unclaimed_stdout();
+
+        assert!(closed.load(Ordering::SeqCst));
     }
 }

--- a/crates/sandbox/src/types.rs
+++ b/crates/sandbox/src/types.rs
@@ -215,13 +215,13 @@ impl GuestProcessControlHandle {
 ///
 /// The handle owns backend-specific exit state and must be consumed by
 /// [`Sandbox::wait_process`](crate::Sandbox::wait_process). When stdout streaming is
-/// enabled, callers may take [`stdout_rx`](Self::stdout_rx) before waiting; if
-/// they do, they must drain it while the process runs.
+/// enabled, callers may use [`take_stdout_receiver`](Self::take_stdout_receiver)
+/// before waiting; if they do, they must drain it while the process runs.
 pub struct GuestProcessHandle {
     pub pid: u32,
     /// Receives stdout chunks in real-time when the guest streams them.
     /// `None` when the backend does not support streaming.
-    pub stdout_rx: Option<ProcessOutputReceiver>,
+    stdout_rx: Option<ProcessOutputReceiver>,
     control: Option<GuestProcessControlHandle>,
     wait: Option<GuestProcessWaiter>,
     close_unclaimed_stdout: Option<Box<dyn FnOnce() + Send + 'static>>,
@@ -242,6 +242,16 @@ impl GuestProcessHandle {
             wait: Some(wait),
             close_unclaimed_stdout: None,
         }
+    }
+
+    /// Return whether this handle currently owns a stdout receiver.
+    pub fn has_stdout_receiver(&self) -> bool {
+        self.stdout_rx.is_some()
+    }
+
+    /// Take the stdout receiver so the caller can drain streamed output.
+    pub fn take_stdout_receiver(&mut self) -> Option<ProcessOutputReceiver> {
+        self.stdout_rx.take()
     }
 
     /// Register backend cleanup for an unclaimed stdout receiver.
@@ -449,7 +459,7 @@ mod tests {
             close_observed.store(true, Ordering::SeqCst);
         });
 
-        let _claimed_stdout = handle.stdout_rx.take();
+        let _claimed_stdout = handle.take_stdout_receiver();
         handle.drop_unclaimed_stdout();
 
         assert!(!closed.load(Ordering::SeqCst));

--- a/crates/sandbox/tests/error.rs
+++ b/crates/sandbox/tests/error.rs
@@ -88,13 +88,13 @@ fn idle_transition_error_exposes_transition() {
 #[test]
 fn display_includes_category_and_message() {
     let err = SandboxError::Operation {
-        operation: SandboxOperation::WaitExit,
+        operation: SandboxOperation::WaitProcess,
         reason: SandboxOperationReason::BackendCrashed,
         message: "firecracker process crashed".into(),
     };
 
     let text = err.to_string();
-    assert!(text.contains("wait exit"), "got: {text}");
+    assert!(text.contains("wait process"), "got: {text}");
     assert!(text.contains("backend crashed"), "got: {text}");
     assert!(text.contains("firecracker process crashed"), "got: {text}");
 }


### PR DESCRIPTION
## Summary

- Rename the sandbox long-running process API to `start_process` / `wait_process` with bounded `ProcessOutputReceiver` chunks and supervised exec metadata on `ProcessExit`.
- Route the Firecracker sandbox process path through `start_supervised_exec`, preserving control, wait timeout cleanup, bounded stdout streaming, diagnostics, and stream overflow visibility.
- Update runner agent launch and host system-log drain to use the new process API, surface drain failures, and keep stderr merging explicit through `2>&1`.

Closes #13749.

## Tests

- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox-mock`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox-fc`
- `cargo test --manifest-path crates/Cargo.toml -p runner executor`
- `cargo test --manifest-path crates/Cargo.toml -p runner cmd::start`
- `CARGO_BUILD_JOBS=1 cargo test --manifest-path crates/Cargo.toml -p vsock-host supervised_exec`
- `CARGO_BUILD_JOBS=1 cargo test --manifest-path crates/Cargo.toml -p vsock-guest supervised_exec`
- `CARGO_BUILD_JOBS=1 cargo clippy --all-targets --all-features` from `crates/`

Note: an initial `vsock-host supervised_exec` compile without `CARGO_BUILD_JOBS=1` hit local memory pressure; the single-job rerun passed.
