### PR TITLE
feat: make desktop shell text selection native

### DIFF
--- a/turbo/apps/platform/src/views/css/index.css
+++ b/turbo/apps/platform/src/views/css/index.css
@@ -159,6 +159,27 @@
     0 2px 12px hsl(220 12% 50% / 0.04), 0 0 0 0.5px hsl(220 12% 50% / 0.02);
 }
 
+/* Desktop shell: avoid accidental selection on app chrome while preserving content/editors. */
+.zero-app[data-desktop-shell] {
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+.zero-app[data-desktop-shell]
+  :where(
+    input,
+    textarea,
+    select,
+    [contenteditable]:not([contenteditable="false"]),
+    [role="textbox"],
+    .zero-chat-bubble-user,
+    .zero-chat-bubble-assistant,
+    .zero-desktop-selectable
+  ) {
+  -webkit-user-select: text;
+  user-select: text;
+}
+
 /* Search bar / text input (matches form inputs: white surface in light theme) */
 .zero-app .zero-search-input {
   background-color: hsl(var(--input));

--- a/turbo/apps/platform/src/views/zero-page/__tests__/desktop-shell-selection.btest.ts
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/desktop-shell-selection.btest.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import "../../css/index.css";
+
+function appendDesktopShell(): HTMLElement {
+  const shell = document.createElement("div");
+  shell.className = "zero-app";
+  shell.dataset.desktopShell = "true";
+  shell.innerHTML = `
+    <nav data-testid="shell-label">Sidebar</nav>
+    <div class="zero-chat-bubble-user" data-testid="user-message">User message</div>
+    <div class="zero-chat-bubble-assistant" data-testid="assistant-message">
+      Assistant message
+      <a href="/" data-testid="assistant-link">link text</a>
+      <code data-testid="assistant-inline-code">inline code</code>
+      <pre data-testid="assistant-code-block">code block</pre>
+    </div>
+    <input data-testid="composer-input" value="Composer text" />
+    <textarea data-testid="notes-textarea">Notes text</textarea>
+    <select data-testid="select-control"><option>Option text</option></select>
+    <div contenteditable="true" data-testid="contenteditable-editor">Editor text</div>
+    <div role="textbox" data-testid="textbox-role">Textbox role</div>
+    <div class="zero-desktop-selectable" data-testid="copyable-region">Copyable region</div>
+  `;
+  document.body.appendChild(shell);
+  return shell;
+}
+
+function getRequiredElement(root: ParentNode, testId: string): HTMLElement {
+  const element = root.querySelector(`[data-testid="${testId}"]`);
+  if (!(element instanceof HTMLElement)) {
+    throw new Error(`Missing ${testId}`);
+  }
+  return element;
+}
+
+describe("desktop shell text selection stylesheet", () => {
+  it("disables selection on the desktop app shell and restores it for content and editors", () => {
+    const shell = appendDesktopShell();
+    try {
+      expect(getComputedStyle(shell).userSelect).toBe("none");
+
+      for (const testId of [
+        "user-message",
+        "assistant-message",
+        "assistant-link",
+        "assistant-inline-code",
+        "assistant-code-block",
+        "composer-input",
+        "notes-textarea",
+        "select-control",
+        "contenteditable-editor",
+        "textbox-role",
+        "copyable-region",
+      ]) {
+        expect(
+          getComputedStyle(getRequiredElement(shell, testId)).userSelect,
+        ).toBe("text");
+      }
+    } finally {
+      shell.remove();
+    }
+  });
+
+  it("does not change web app shell selection without the desktop marker", () => {
+    const shell = document.createElement("div");
+    shell.className = "zero-app";
+    document.body.appendChild(shell);
+    try {
+      expect(getComputedStyle(shell).userSelect).not.toBe("none");
+    } finally {
+      shell.remove();
+    }
+  });
+});

--- a/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-layout.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-layout.test.tsx
@@ -10,7 +10,7 @@
  * - Real (internal): All signals, components, rendering
  */
 
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
@@ -27,6 +27,10 @@ import { setMockTeam } from "../../../mocks/handlers/api-agents.ts";
 const context = testContext();
 
 const DEFAULT_AGENT_ID = "c0000000-0000-4000-a000-000000000001";
+
+afterEach(() => {
+  Reflect.deleteProperty(window, "vm0DesktopLocalAgent");
+});
 
 function mockBaseAPIs() {
   setMockTeam([
@@ -203,6 +207,36 @@ describe("sidebar layout - invite button opens member dialog (SIDEBAR-D-052)", (
       expect(
         screen.getByRole("heading", { name: "Members" }),
       ).toBeInTheDocument();
+    });
+  });
+});
+
+describe("sidebar layout - desktop shell text selection scope (SIDEBAR-D-056)", () => {
+  it("marks the app shell as desktop-only when the local agent bridge is available", async () => {
+    mockBaseAPIs();
+    Object.defineProperty(window, "vm0DesktopLocalAgent", {
+      configurable: true,
+      value: {},
+    });
+
+    detachedSetupPage({ context, path: "/" });
+
+    await waitFor(() => {
+      expect(document.querySelector(".zero-app")).toHaveAttribute(
+        "data-desktop-shell",
+        "true",
+      );
+    });
+  });
+
+  it("leaves the web app shell unmarked when the desktop bridge is unavailable", async () => {
+    mockBaseAPIs();
+    detachedSetupPage({ context, path: "/" });
+
+    await waitFor(() => {
+      expect(document.querySelector(".zero-app")).not.toHaveAttribute(
+        "data-desktop-shell",
+      );
     });
   });
 });


### PR DESCRIPTION
## Summary
- mark the Zero app root as a desktop shell only when the desktop local agent bridge is present
- disable accidental text selection on desktop shell chrome while preserving chat bubbles, editable controls, and explicit copyable regions
- add platform and browser regression coverage for desktop shell detection and CSS selection behavior

## Tests
- `pnpm --dir turbo -F @vm0/app check-types`
- `pnpm --dir turbo -F @vm0/app lint`
- `pnpm --dir turbo -F @vm0/app exec vitest run src/views/zero-page/__tests__/sidebar-layout.test.tsx`
- `pnpm --dir turbo -F @vm0/app exec vitest run --config vitest.browser.config.ts src/views/zero-page/__tests__/desktop-shell-selection.btest.ts`
- pre-commit: `pnpm knip`, `pnpm check-types`

Fixes #14229