### PR TITLE
test: hide runner discover notify

### DIFF
--- a/crates/runner/src/cmd/start/tests/budget.rs
+++ b/crates/runner/src/cmd/start/tests/budget.rs
@@ -75,7 +75,7 @@ async fn budget_exhausted_buffers_discovery_until_budget_frees() {
     let (config, env) = mock_run_config_with_overrides(test_profiles(), 2, 4096, 1, overrides);
     let budget = Arc::clone(&config.budget);
     let run_handle = tokio::spawn(run(config));
-    env.handle.discover_entered.notified().await;
+    wait_discover_entered(&env, Duration::from_secs(5)).await;
 
     let id1 = RunId::new_v4();
     push_job(&env, id1, "vm0/default", Some(minimal_context(id1)));
@@ -84,12 +84,12 @@ async fn budget_exhausted_buffers_discovery_until_budget_frees() {
 
     let id2 = RunId::new_v4();
     push_job(&env, id2, "vm0/default", Some(minimal_context(id2)));
-    tokio::time::timeout(
-        Duration::from_millis(100),
-        env.handle.discover_entered.notified(),
-    )
-    .await
-    .expect_err("discovery must not be polled while budget is exhausted");
+    assert!(
+        !env.handle
+            .wait_discover_entered(Duration::from_millis(100))
+            .await,
+        "discovery must not be polled while budget is exhausted"
+    );
     assert!(
         !env.cancel_tokens.lock().await.contains_key(&id2),
         "queued job must not be claimed while budget is exhausted",

--- a/crates/runner/src/cmd/start/tests/idle_reuse.rs
+++ b/crates/runner/src/cmd/start/tests/idle_reuse.rs
@@ -3,9 +3,9 @@ use super::support::{
     assert_run_exits_within, context_with_session, minimal_context, mock_run_config,
     mock_run_config_with_overrides, publish_idle_status, push_job, seed_idle_pool,
     seed_idle_pool_with_overrides, shutdown, status_idle_sessions, test_profiles, two_profiles,
-    wait_budget_count, wait_cancel_token, wait_idle_pool_len, wait_idle_pool_sessions,
-    wait_parking_state, wait_sandbox_lifecycle_counts, wait_status_idle_empty_with_active_run,
-    wait_status_idle_sessions_and_active_runs,
+    wait_budget_count, wait_cancel_token, wait_discover_entered, wait_idle_pool_len,
+    wait_idle_pool_sessions, wait_parking_state, wait_sandbox_lifecycle_counts,
+    wait_status_idle_empty_with_active_run, wait_status_idle_sessions_and_active_runs,
 };
 
 use crate::idle_pool::ParkingState;
@@ -200,12 +200,7 @@ async fn park_triggers_immediate_heartbeat() {
     let run_handle = tokio::spawn(run(config));
 
     // Snapshot the heartbeat count once the provider is parked in discovery.
-    tokio::time::timeout(
-        Duration::from_secs(5),
-        env.handle.discover_entered.notified(),
-    )
-    .await
-    .expect("runner should enter discovery before the heartbeat baseline is captured");
+    wait_discover_entered(&env, Duration::from_secs(5)).await;
     let before = env.handle.heartbeat_count();
 
     let run_id = RunId::new_v4();

--- a/crates/runner/src/cmd/start/tests/main_loop.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop.rs
@@ -42,12 +42,7 @@ async fn running_reaps_completed_jobs_without_budget_exhaustion() {
     let (config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
     let run_handle = tokio::spawn(run(config));
 
-    tokio::time::timeout(
-        Duration::from_secs(2),
-        env.handle.discover_entered.notified(),
-    )
-    .await
-    .expect("run() did not enter discover_fut select! within 2s");
+    wait_discover_entered(&env, Duration::from_secs(2)).await;
 
     let run_id = RunId::new_v4();
     push_job(&env, run_id, "vm0/default", Some(minimal_context(run_id)));
@@ -795,12 +790,7 @@ async fn claim_after_stopping_sent_cancels_new_job() {
     // The 2s timeout gives a clear diagnostic if the "loop parks on
     // discover" invariant ever regresses, rather than hanging until
     // the outer test harness kills us.
-    tokio::time::timeout(
-        Duration::from_secs(2),
-        env.handle.discover_entered.notified(),
-    )
-    .await
-    .expect("run() did not enter discover_fut select! within 2s");
+    wait_discover_entered(&env, Duration::from_secs(2)).await;
 
     // Flip the watch value to Stopping without firing changed().
     env.parking_gate.close();
@@ -850,12 +840,7 @@ async fn resume_after_stopping_is_ignored() {
     // `trigger_stopping`, which fires `changed()`), but the same barrier
     // is still the right "main loop is idle" signal — and deterministic
     // under coverage CI, unlike the 50 ms sleep this replaces.
-    tokio::time::timeout(
-        Duration::from_secs(2),
-        env.handle.discover_entered.notified(),
-    )
-    .await
-    .expect("run() did not enter discover_fut select! within 2s");
+    wait_discover_entered(&env, Duration::from_secs(2)).await;
 
     // Enter Stopping first.
     env.trigger_stopping().await;
@@ -894,12 +879,7 @@ async fn heartbeat_tick_defers_past_first_select_poll() {
     let (config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
     let run_handle = tokio::spawn(run(config));
 
-    tokio::time::timeout(
-        Duration::from_secs(2),
-        env.handle.discover_entered.notified(),
-    )
-    .await
-    .expect("run() did not enter discover_fut select! within 2s");
+    wait_discover_entered(&env, Duration::from_secs(2)).await;
 
     // `minimal_context` → no session → completion path does not trigger
     // `park_notify`, so any heartbeat observed here came from the

--- a/crates/runner/src/cmd/start/tests/support/wait.rs
+++ b/crates/runner/src/cmd/start/tests/support/wait.rs
@@ -182,9 +182,10 @@ pub(in super::super) async fn wait_cancel_token_removed(
 }
 
 pub(in super::super) async fn wait_discover_entered(env: &MockRunEnv, timeout: Duration) {
-    tokio::time::timeout(timeout, env.handle.discover_entered.notified())
-        .await
-        .expect("run() did not enter discover_fut select! within timeout");
+    assert!(
+        env.handle.wait_discover_entered(timeout).await,
+        "run() did not enter discover_fut select! within {timeout:?}"
+    );
 }
 
 pub(in super::super) async fn wait_budget_exhausted_reactor(env: &MockRunEnv, timeout: Duration) {

--- a/crates/runner/src/provider/mock.rs
+++ b/crates/runner/src/provider/mock.rs
@@ -60,9 +60,10 @@ pub struct MockJobProvider {
     /// point (lock + optional `poll_delay` complete, about to park on
     /// `rx.recv()`). Tests that need to order actions against that state —
     /// e.g. a silent `send_if_modified` that must land *after* the main loop
-    /// has entered its `discover_fut` select — await `notified()` instead of
-    /// sleeping. `notify_one` queues a permit, so a test that waits after
-    /// the signal fired still wakes immediately.
+    /// has entered its `discover_fut` select — call
+    /// [`MockProviderHandle::wait_discover_entered`] instead of sleeping.
+    /// `notify_one` queues a permit, so a test that waits after the signal
+    /// fired still wakes immediately.
     discover_entered: Arc<Notify>,
     /// Fired by `complete()` after a completion is appended to `completions`.
     /// `wait_completion` subscribes to this before checking the vec, so any
@@ -85,8 +86,8 @@ pub struct MockProviderHandle {
     pub discover_tx: mpsc::UnboundedSender<JobCandidate>,
     pub completions: Arc<StdMutex<Vec<Completion>>>,
     pub heartbeats: Arc<StdMutex<Vec<HeartbeatState>>>,
-    /// See [`MockJobProvider::discover_entered`].
-    pub discover_entered: Arc<Notify>,
+    /// See [`Self::wait_discover_entered`].
+    discover_entered: Arc<Notify>,
     /// See [`MockJobProvider::completion_notify`].
     completion_notify: Arc<Notify>,
     /// See [`MockJobProvider::discover_poll_started`].
@@ -187,6 +188,13 @@ impl MockProviderHandle {
         }
     }
 
+    /// Wait until `discover()` has reached its inner await point.
+    pub async fn wait_discover_entered(&self, timeout: Duration) -> bool {
+        tokio::time::timeout(timeout, self.discover_entered.notified())
+            .await
+            .is_ok()
+    }
+
     /// Wait until `discover()` has been polled at least once and its optional
     /// poll-delay timer has been created.
     pub async fn wait_discover_poll_started(&self, timeout: Duration) -> bool {
@@ -252,7 +260,7 @@ impl JobProvider for MockJobProvider {
         // Signal tests that the future has reached its await point — the
         // main loop has polled `discover_fut`, the discovery Mutex is held,
         // and we are about to park on `rx.recv()`. Tests ordering actions
-        // against this state use `handle.discover_entered.notified()`.
+        // against this state use `handle.wait_discover_entered(...)`.
         self.discover_entered.notify_one();
         tokio::select! {
             result = rx.recv() => result,


### PR DESCRIPTION
## Summary

- add `MockProviderHandle::wait_discover_entered` and stop exposing the raw `discover_entered` `Notify`
- route positive runner discovery barriers through the existing `wait_discover_entered` support helper
- keep the budget-exhausted negative assertion as a boolean handle wait instead of raw `Notify` plumbing

Closes #14144

## Tests

- `cargo fmt --manifest-path crates/Cargo.toml -p runner`
- `CARGO_BUILD_JOBS=1 cargo test --manifest-path crates/Cargo.toml -p runner cmd::start::tests::main_loop`
- `CARGO_BUILD_JOBS=1 cargo test --manifest-path crates/Cargo.toml -p runner cmd::start::tests::idle_reuse`
- `CARGO_BUILD_JOBS=1 cargo test --manifest-path crates/Cargo.toml -p runner cmd::start::tests::budget`
- `CARGO_BUILD_JOBS=1 cargo clippy --manifest-path crates/Cargo.toml -p runner -- -D warnings`
- `CARGO_BUILD_JOBS=1 cargo test --manifest-path crates/Cargo.toml -p runner`
- `git diff --check`
