### PR TITLE
fix: copy legacy artifact links as cdn urls

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { fireEvent, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { http, HttpResponse } from "msw";
@@ -18,14 +18,63 @@ import {
   PLACEHOLDER,
   sendMessageInUI,
 } from "./chat-test-helpers.ts";
-import { downloadAttachmentUrl } from "../zero-attachment-chips.tsx";
+import {
+  downloadAttachmentUrl,
+  publicAttachmentUrl,
+} from "../zero-attachment-chips.tsx";
 
 const context = testContext();
 const mockApi = createMockApi(context);
 
+beforeEach(() => {
+  vi.stubEnv("VITE_API_URL", "https://www.vm0.ai");
+  vi.stubEnv("PUBLIC_ARTIFACTS_BASE_URL", "https://cdn.vm7.io");
+});
+
 function mockChatAPI() {
   server.use();
 }
+
+describe("publicAttachmentUrl", () => {
+  it("converts legacy platform file URLs to public CDN artifact URLs", () => {
+    expect(
+      publicAttachmentUrl(
+        "https://www.vm0.ai/f/38bPAf83mxpw8vvVYy0M6PPTq2B/65084eb6-1d42-45ae-9038-c80102d7a4c1/kitten.png",
+      ),
+    ).toBe(
+      "https://cdn.vm7.io/artifacts/user_38bPAf83mxpw8vvVYy0M6PPTq2B/65084eb6-1d42-45ae-9038-c80102d7a4c1/kitten.png",
+    );
+  });
+
+  it("converts legacy API file URLs when the configured endpoint is web", () => {
+    expect(
+      publicAttachmentUrl(
+        "https://api.vm0.ai/f/38bPAf83mxpw8vvVYy0M6PPTq2B/65084eb6-1d42-45ae-9038-c80102d7a4c1/kitten.png",
+      ),
+    ).toBe(
+      "https://cdn.vm7.io/artifacts/user_38bPAf83mxpw8vvVYy0M6PPTq2B/65084eb6-1d42-45ae-9038-c80102d7a4c1/kitten.png",
+    );
+  });
+
+  it("converts legacy web file URLs when the configured endpoint is API", () => {
+    vi.stubEnv("VITE_API_URL", "https://api.vm0.ai");
+
+    expect(
+      publicAttachmentUrl(
+        "https://www.vm0.ai/f/38bPAf83mxpw8vvVYy0M6PPTq2B/65084eb6-1d42-45ae-9038-c80102d7a4c1/kitten.png",
+      ),
+    ).toBe(
+      "https://cdn.vm7.io/artifacts/user_38bPAf83mxpw8vvVYy0M6PPTq2B/65084eb6-1d42-45ae-9038-c80102d7a4c1/kitten.png",
+    );
+  });
+
+  it("keeps external legacy-looking file URLs unchanged", () => {
+    const externalUrl =
+      "https://example.com/f/user_123/65084eb6-1d42-45ae-9038-c80102d7a4c1/kitten.png";
+
+    expect(publicAttachmentUrl(externalUrl)).toBe(externalUrl);
+  });
+});
 
 // ---------------------------------------------------------------------------
 // CHAT-D-056: File type icons render based on getFileTypeIcon(filename)
@@ -403,13 +452,19 @@ describe("chat-i-061: backdrop click closes lightbox", () => {
 // ---------------------------------------------------------------------------
 
 describe("chat-i-066: lightbox download fetches blobs", () => {
-  it("fetches legacy file URLs through the compatibility route", async () => {
+  it("fetches legacy platform file URLs through the public artifact CDN", async () => {
+    vi.stubGlobal(
+      "location",
+      new URL("https://tunnel-yuma-vm0-app.vm7.ai/chats/thread-test-1"),
+    );
     const legacyUrl =
       "https://tunnel-yuma-vm0-www.vm7.ai/f/3BennfUepyJwP3OaiYD0rK8CZKs/9c4c6df4-f0ed-4c25-af3a-b58bc40faf0f/image-9c4c6df4.png";
-    let legacyRequests = 0;
+    const cdnUrl =
+      "https://cdn.vm7.io/artifacts/user_3BennfUepyJwP3OaiYD0rK8CZKs/9c4c6df4-f0ed-4c25-af3a-b58bc40faf0f/image-9c4c6df4.png";
+    let cdnRequests = 0;
     server.use(
-      http.get(legacyUrl, () => {
-        legacyRequests += 1;
+      http.get(cdnUrl, () => {
+        cdnRequests += 1;
         return HttpResponse.text("img", {
           headers: { "content-type": "image/png" },
         });
@@ -430,7 +485,7 @@ describe("chat-i-066: lightbox download fetches blobs", () => {
     try {
       await downloadAttachmentUrl(legacyUrl, context.signal, "image.png");
 
-      expect(legacyRequests).toBe(1);
+      expect(cdnRequests).toBe(1);
       expect(createObjectURLSpy).toHaveBeenCalledOnce();
       expect(anchorClickSpy).toHaveBeenCalledOnce();
       expect(revokeObjectURLSpy).toHaveBeenCalledWith("blob:download");

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
@@ -31,6 +31,8 @@ function createMockAuthWindow() {
 }
 
 beforeEach(() => {
+  vi.stubEnv("VITE_API_URL", "https://www.vm0.ai");
+  vi.stubEnv("PUBLIC_ARTIFACTS_BASE_URL", "https://cdn.vm7.io");
   server.use(
     http.get("https://example.com/avatar.png", () => {
       return new HttpResponse("avatar", {
@@ -1395,6 +1397,8 @@ describe("zero chat thread page display - artifacts drawer", () => {
     const user = userEvent.setup();
     const fileUrl =
       "https://www.vm0.ai/f/user_123/3a474c61-ffe4-4e56-b9e7-0185b3dba9f7/chart.png";
+    const publicFileUrl =
+      "https://cdn.vm7.io/artifacts/user_123/3a474c61-ffe4-4e56-b9e7-0185b3dba9f7/chart.png";
     let artifactsRequests = 0;
     const syncBodies: unknown[] = [];
     mockChatLifecycle({
@@ -1498,7 +1502,7 @@ describe("zero chat thread page display - artifacts drawer", () => {
       ).toBeInTheDocument();
     });
     await user.click(screen.getByLabelText("Copy link for chart.png"));
-    expect(writeTextSpy).toHaveBeenCalledWith(fileUrl);
+    expect(writeTextSpy).toHaveBeenCalledWith(publicFileUrl);
 
     await user.click(screen.getByLabelText("Sync chart.png to Google Drive"));
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-interaction.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-interaction.test.tsx
@@ -19,6 +19,8 @@ const context = testContext();
 const THREAD_ID = "thread-test-1";
 
 beforeEach(() => {
+  vi.stubEnv("VITE_API_URL", "https://www.vm0.ai");
+  vi.stubEnv("PUBLIC_ARTIFACTS_BASE_URL", "https://cdn.vm7.io");
   server.use(
     http.get("https://example.com/avatar.png", () => {
       return new HttpResponse("avatar", {
@@ -147,6 +149,8 @@ describe("zero chat thread page - document preview opens global lightbox", () =>
   it("clicking html platform file url preview opens the shared attachment lightbox", async () => {
     const htmlUrl =
       "https://www.vm0.ai/f/user_123/3a474c61-ffe4-4e56-b9e7-0185b3dba9f7/report.html";
+    const publicHtmlUrl =
+      "https://cdn.vm7.io/artifacts/user_123/3a474c61-ffe4-4e56-b9e7-0185b3dba9f7/report.html";
     const writeTextSpy = vi
       .spyOn(navigator.clipboard, "writeText")
       .mockResolvedValue(undefined);
@@ -199,7 +203,7 @@ describe("zero chat thread page - document preview opens global lightbox", () =>
     });
 
     await userEvent.click(screen.getByLabelText("Copy link"));
-    expect(writeTextSpy).toHaveBeenCalledWith(htmlUrl);
+    expect(writeTextSpy).toHaveBeenCalledWith(publicHtmlUrl);
   });
 });
 

--- a/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
@@ -87,8 +87,156 @@ function filenameFromUrl(url: string): string {
   return last && last.length > 0 ? last : "image";
 }
 
+const LEGACY_FILE_PATH_PATTERN = /^\/f\/([^/]+)\/([^/]+)\/([^/]+)$/;
+const ARTIFACT_FILE_PATH_PATTERN = /^\/artifacts\/([^/]+)\/([^/]+)\/([^/]+)$/;
+const CLERK_USER_ID_PREFIX = "user_";
+
+function publicArtifactsBaseUrl(): string | null {
+  const baseUrl = import.meta.env.PUBLIC_ARTIFACTS_BASE_URL;
+  if (!baseUrl || !URL.canParse(baseUrl)) {
+    return null;
+  }
+  return baseUrl.replace(/\/+$/, "");
+}
+
+function hasExplicitUrlOrigin(url: string): boolean {
+  return /^[a-z][a-z\d+\-.]*:\/\//i.test(url);
+}
+
+function browserOrigin(): string | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+  return window.location.origin;
+}
+
+type PlatformHostTarget = "api" | "www";
+
+function rewritePlatformHostname(
+  hostname: string,
+  target: PlatformHostTarget,
+): string {
+  return hostname.replace(/(^|-)(platform|app|www|api)\./, `$1${target}.`);
+}
+
+function addOrigin(origins: Set<string>, baseUrl: string | null) {
+  if (!baseUrl || !URL.canParse(baseUrl)) {
+    return;
+  }
+  origins.add(new URL(baseUrl).origin);
+}
+
+function addPlatformOriginVariants(
+  origins: Set<string>,
+  baseUrl: string | null,
+) {
+  if (!baseUrl || !URL.canParse(baseUrl)) {
+    return;
+  }
+
+  const parsed = new URL(baseUrl);
+  origins.add(parsed.origin);
+
+  for (const target of ["api", "www"] as const) {
+    const variant = new URL(parsed);
+    variant.hostname = rewritePlatformHostname(variant.hostname, target);
+    origins.add(variant.origin);
+  }
+}
+
+function platformFileOrigins(): Set<string> {
+  const origins = new Set<string>();
+  const configuredApiUrl = import.meta.env.VITE_API_URL as string | undefined;
+
+  addPlatformOriginVariants(origins, browserOrigin());
+  addPlatformOriginVariants(origins, configuredApiUrl ?? null);
+  addOrigin(origins, publicArtifactsBaseUrl());
+
+  return origins;
+}
+
+function isPlatformFileUrlHost(parsed: URL, sourceUrl: string): boolean {
+  return (
+    !hasExplicitUrlOrigin(sourceUrl) || platformFileOrigins().has(parsed.origin)
+  );
+}
+
+function storageUserIdSegmentFromFileUrlSegment(userIdSegment: string): string {
+  if (
+    userIdSegment === "user" ||
+    userIdSegment.startsWith(CLERK_USER_ID_PREFIX) ||
+    userIdSegment.startsWith("user-")
+  ) {
+    return userIdSegment;
+  }
+  return `${CLERK_USER_ID_PREFIX}${userIdSegment}`;
+}
+
+function artifactCdnUrl(args: {
+  userIdSegment: string;
+  idSegment: string;
+  filenameSegment: string;
+  hash: string;
+}): string | null {
+  const baseUrl = publicArtifactsBaseUrl();
+  if (!baseUrl) {
+    return null;
+  }
+  return `${baseUrl}/artifacts/${args.userIdSegment}/${args.idSegment}/${args.filenameSegment}${args.hash}`;
+}
+
+function parseFileUrl(url: string): URL | null {
+  const baseUrl = browserOrigin() ?? undefined;
+  if (!URL.canParse(url, baseUrl)) {
+    return null;
+  }
+  return new URL(url, baseUrl);
+}
+
+function normalizedLegacyFileUrl(url: string): string | null {
+  const parsed = parseFileUrl(url);
+  if (!parsed) {
+    return null;
+  }
+  if (!isPlatformFileUrlHost(parsed, url)) {
+    return null;
+  }
+  const match = parsed.pathname.match(LEGACY_FILE_PATH_PATTERN);
+  if (!match) {
+    return null;
+  }
+  const [, userIdSegment, idSegment, filenameSegment] = match;
+  return artifactCdnUrl({
+    userIdSegment: storageUserIdSegmentFromFileUrlSegment(userIdSegment),
+    idSegment,
+    filenameSegment,
+    hash: parsed.hash,
+  });
+}
+
+function normalizedArtifactFileUrl(url: string): string | null {
+  const parsed = parseFileUrl(url);
+  if (!parsed) {
+    return null;
+  }
+  if (!isPlatformFileUrlHost(parsed, url)) {
+    return null;
+  }
+  const match = parsed.pathname.match(ARTIFACT_FILE_PATH_PATTERN);
+  if (!match) {
+    return null;
+  }
+  const [, userIdSegment, idSegment, filenameSegment] = match;
+  return artifactCdnUrl({
+    userIdSegment,
+    idSegment,
+    filenameSegment,
+    hash: parsed.hash,
+  });
+}
+
 export function publicAttachmentUrl(url: string): string {
-  return url;
+  return normalizedLegacyFileUrl(url) ?? normalizedArtifactFileUrl(url) ?? url;
 }
 
 export function getAttachmentRawUrl(url: string): string {

--- a/turbo/apps/web/src/lib/zero/context/__tests__/resolve-model-provider.test.ts
+++ b/turbo/apps/web/src/lib/zero/context/__tests__/resolve-model-provider.test.ts
@@ -88,10 +88,16 @@ describe("resolveModelProviderSecrets — framework gate removed (#11526)", () =
 
   it("falls through to provider resolution for non-claude-code framework when no explicit config", async () => {
     // Pre-#11526 behavior: returned silently with framework gate. Post-#11526:
-    // resolver runs to model-first default materialization. With no VM0 key
-    // seeded for the default Anthropic model, that materialization fails.
+    // resolver runs to model-first default materialization. Use a VM0 model
+    // whose vendor is not seeded elsewhere in the suite so this remains
+    // isolated from parallel key-pool fixtures.
     const userId = uniqueId("codex-noprov");
     const orgId = await setupOrg(userId);
+    await insertOrgModelPolicy({
+      orgId,
+      model: "MiniMax-M2.7",
+      isDefault: true,
+    });
 
     await expect(
       resolveModelProviderSecrets(orgId, userId, "codex", false),
@@ -891,7 +897,7 @@ describe("resolveModelProviderSecrets — model-first policy (#12130)", () => {
     const orgId = await setupOrg(userId);
     await insertOrgModelPolicy({
       orgId,
-      model: "gpt-5.5",
+      model: "MiniMax-M2.7",
       isDefault: true,
       defaultProviderType: "vm0",
       credentialScope: "org",
@@ -905,7 +911,7 @@ describe("resolveModelProviderSecrets — model-first policy (#12130)", () => {
         false,
         undefined,
         undefined,
-        "gpt-5.5",
+        "MiniMax-M2.7",
       ),
     ).rejects.toSatisfy((err: unknown) => {
       return isBadRequest(err);
@@ -917,14 +923,14 @@ describe("resolveModelProviderSecrets — model-first policy (#12130)", () => {
     const orgId = await setupOrg(userId);
     await insertVm0ApiKeys([
       {
-        vendor: "openai",
-        model: "gpt-5.5",
-        apiKey: "vm0-openai-key",
+        vendor: "minimax",
+        model: "MiniMax-M2.7",
+        apiKey: "vm0-minimax-key",
       },
     ]);
     await insertOrgModelPolicy({
       orgId,
-      model: "gpt-5.5",
+      model: "MiniMax-M2.7",
       isDefault: true,
     });
 
@@ -936,7 +942,7 @@ describe("resolveModelProviderSecrets — model-first policy (#12130)", () => {
     );
 
     expect(result.resolvedModelProvider).toBe("vm0");
-    expect(result.selectedModel).toBe("gpt-5.5");
-    expect(result.secrets?.OPENAI_API_KEY).toBe("vm0-openai-key");
+    expect(result.selectedModel).toBe("MiniMax-M2.7");
+    expect(result.secrets?.MINIMAX_API_KEY).toBe("vm0-minimax-key");
   });
 });


### PR DESCRIPTION
## Summary
- convert legacy platform `/f/...` and `/artifacts/...` attachment links to `PUBLIC_ARTIFACTS_BASE_URL` before copy/download
- derive accepted web/api origins from `VITE_API_URL` and the current app origin instead of hardcoding vm0/vm7 domains
- cover copy/download behavior for both web and api legacy hosts
- stabilize model-provider tests against parallel VM0 key-pool fixtures

## Tests
- `pnpm format`
- `pnpm turbo run lint`
- `pnpm check-types`
- `pnpm vitest`
- `pnpm knip`