### PR TITLE
feat: add generated images to built-in websites

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-website-io-generate.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-website-io-generate.test.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { Buffer } from "node:buffer";
 
 import { createStore } from "ccstate";
 import { and, eq, inArray } from "drizzle-orm";
@@ -7,14 +8,21 @@ import { HttpResponse, http } from "msw";
 
 import { createApp } from "../../../app-factory";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import { builtInGenerationJobs } from "@vm0/db/schema/built-in-generation-job";
 import { orgMetadata } from "@vm0/db/schema/org-metadata";
 import { orgMembersMetadata } from "@vm0/db/schema/org-members-metadata";
+import { runUploadedFiles } from "@vm0/db/schema/run-uploaded-file";
 import { userFeatureSwitches } from "@vm0/db/schema/user-feature-switches";
 import { usageEvent } from "@vm0/db/schema/usage-event";
 import { usagePricing } from "@vm0/db/schema/usage-pricing";
 import { testContext } from "../../../__tests__/test-helpers";
 import { server } from "../../../mocks/server";
 import { writeDb$ } from "../../external/db";
+import {
+  IMAGE_IO_MODEL,
+  imagePricingKey,
+  type ImageModel,
+} from "../../services/zero-image-io-generate.service";
 import {
   OPENAI_WEBSITE_GENERATION_URL,
   WEBSITE_USAGE_KIND,
@@ -30,22 +38,53 @@ import {
   createFixtureTracker,
   createZeroRouteMocks,
 } from "./helpers/zero-route-test";
+import { clearAllDetached } from "../../utils";
 
 const context = testContext();
 const store = createStore();
 const mocks = createZeroRouteMocks(context);
+const IMAGE_BYTES = Buffer.from("fake website visual bytes");
+const FAL_GPT_IMAGE_1_URL = "https://fal.run/fal-ai/gpt-image-1/text-to-image";
+const FAL_WEBSITE_MEDIA_URL =
+  "https://fal.media/files/test/website-visual.webp";
 const WEBSITE_PRICING_CATEGORIES = ["tokens.input", "tokens.output"] as const;
+const IMAGE_PRICING_CATEGORIES = [
+  "output_image.low.standard",
+  "output_image.low.large",
+  "output_image.medium.standard",
+  "output_image.medium.large",
+  "output_image.high.standard",
+  "output_image.high.large",
+] as const;
+
+const tokenRequest = Object.freeze({
+  keyName: "test-key",
+  timestamp: 1_700_000_000_000,
+  capability: '{"user:test-user":["subscribe"]}',
+  clientId: "test-user",
+  nonce: "test-nonce",
+  mac: "test-mac",
+});
 
 type WebsitePricingCategory = (typeof WEBSITE_PRICING_CATEGORIES)[number];
+type ImagePricingCategory = (typeof IMAGE_PRICING_CATEGORIES)[number];
 
 interface WebsiteFixture {
   readonly orgId: string;
   readonly userId: string;
   readonly insertedPricingCategories: readonly WebsitePricingCategory[];
+  readonly insertedImagePricingCategories: readonly ImagePricingCategory[];
 }
 
 interface PricingSnapshot {
   readonly category: WebsitePricingCategory;
+  readonly unitPrice: number;
+  readonly unitSize: number;
+}
+
+interface ImagePricingSnapshot {
+  readonly provider: ImageModel;
+  readonly category: ImagePricingCategory;
   readonly unitPrice: number;
   readonly unitSize: number;
 }
@@ -60,10 +99,58 @@ function authHeaders() {
   return { authorization: "Bearer clerk-session" };
 }
 
+function readAcceptedGenerationId(body: unknown, userId: string): string {
+  if (
+    typeof body !== "object" ||
+    body === null ||
+    !("generationId" in body) ||
+    typeof body.generationId !== "string"
+  ) {
+    throw new Error("Expected accepted website generation response");
+  }
+  expect(body).toMatchObject({
+    generationId: body.generationId,
+    type: "website",
+    status: "queued",
+    realtime: {
+      channelName: `user:${userId}`,
+      eventName: `built-in-generation:${body.generationId}`,
+      tokenRequest,
+    },
+  });
+  return body.generationId;
+}
+
+function readGenerationResult(body: unknown): unknown {
+  if (typeof body === "object" && body !== null && "result" in body) {
+    return body.result;
+  }
+  throw new Error("Expected completed generation result");
+}
+
+function commandInput(command: unknown): Record<string, unknown> {
+  if (
+    typeof command === "object" &&
+    command !== null &&
+    "input" in command &&
+    typeof command.input === "object" &&
+    command.input !== null
+  ) {
+    return command.input as Record<string, unknown>;
+  }
+  return {};
+}
+
 function isWebsitePricingCategory(
   value: string,
 ): value is WebsitePricingCategory {
   return WEBSITE_PRICING_CATEGORIES.some((category) => {
+    return category === value;
+  });
+}
+
+function isImagePricingCategory(value: string): value is ImagePricingCategory {
+  return IMAGE_PRICING_CATEGORIES.some((category) => {
     return category === value;
   });
 }
@@ -79,6 +166,23 @@ function expectedCredits(usage: WebsiteUsage, pricing: WebsitePricing): number {
       return total;
     }
     const row = pricing.get(category);
+    if (!row) {
+      return total;
+    }
+    return total + Math.ceil((quantity * row.unitPrice) / row.unitSize);
+  }, 0);
+}
+
+function expectedImageCredits(
+  model: ImageModel,
+  rows: readonly (readonly [ImagePricingCategory, number])[],
+  pricing: ReadonlyMap<string, ImagePricingSnapshot>,
+): number {
+  return rows.reduce((total, [category, quantity]) => {
+    if (quantity <= 0) {
+      return total;
+    }
+    const row = pricing.get(imagePricingKey(model, category));
     if (!row) {
       return total;
     }
@@ -149,6 +253,107 @@ async function ensureWebsitePricing(): Promise<{
   return { pricing, insertedCategories };
 }
 
+async function ensureImagePricing(model: ImageModel = IMAGE_IO_MODEL): Promise<{
+  readonly pricing: ReadonlyMap<string, ImagePricingSnapshot>;
+  readonly insertedCategories: readonly ImagePricingCategory[];
+}> {
+  const writeDb = store.set(writeDb$);
+  const rows = await writeDb
+    .select({
+      category: usagePricing.category,
+      unitPrice: usagePricing.unitPrice,
+      unitSize: usagePricing.unitSize,
+    })
+    .from(usagePricing)
+    .where(
+      and(
+        eq(usagePricing.kind, "image"),
+        eq(usagePricing.provider, model),
+        inArray(usagePricing.category, [...IMAGE_PRICING_CATEGORIES]),
+      ),
+    );
+
+  const pricing = new Map<string, ImagePricingSnapshot>();
+  for (const row of rows) {
+    if (isImagePricingCategory(row.category)) {
+      pricing.set(imagePricingKey(model, row.category), {
+        provider: model,
+        category: row.category,
+        unitPrice: row.unitPrice,
+        unitSize: row.unitSize,
+      });
+    }
+  }
+
+  const defaults: Readonly<
+    Record<ImagePricingCategory, Omit<ImagePricingSnapshot, "provider">>
+  > = {
+    "output_image.low.standard": {
+      category: "output_image.low.standard",
+      unitPrice: 13,
+      unitSize: 1,
+    },
+    "output_image.low.large": {
+      category: "output_image.low.large",
+      unitPrice: 19,
+      unitSize: 1,
+    },
+    "output_image.medium.standard": {
+      category: "output_image.medium.standard",
+      unitPrice: 50,
+      unitSize: 1,
+    },
+    "output_image.medium.large": {
+      category: "output_image.medium.large",
+      unitPrice: 76,
+      unitSize: 1,
+    },
+    "output_image.high.standard": {
+      category: "output_image.high.standard",
+      unitPrice: 200,
+      unitSize: 1,
+    },
+    "output_image.high.large": {
+      category: "output_image.high.large",
+      unitPrice: 300,
+      unitSize: 1,
+    },
+  };
+
+  const insertedCategories: ImagePricingCategory[] = [];
+  for (const category of IMAGE_PRICING_CATEGORIES) {
+    if (!pricing.has(imagePricingKey(model, category))) {
+      const row = defaults[category];
+      const inserted = await writeDb
+        .insert(usagePricing)
+        .values({
+          kind: "image",
+          provider: model,
+          category,
+          unitPrice: row.unitPrice,
+          unitSize: row.unitSize,
+        })
+        .onConflictDoNothing({
+          target: [
+            usagePricing.kind,
+            usagePricing.provider,
+            usagePricing.category,
+          ],
+        })
+        .returning({ category: usagePricing.category });
+      pricing.set(imagePricingKey(model, category), {
+        provider: model,
+        ...row,
+      });
+      if (inserted.length > 0) {
+        insertedCategories.push(category);
+      }
+    }
+  }
+
+  return { pricing, insertedCategories };
+}
+
 async function seedWebsiteFixture(): Promise<WebsiteFixture> {
   const orgId = `org_${randomUUID()}`;
   const userId = `user_${randomUUID()}`;
@@ -176,15 +381,20 @@ async function seedWebsiteFixture(): Promise<WebsiteFixture> {
   });
 
   const pricing = await ensureWebsitePricing();
+  const imagePricing = await ensureImagePricing();
   return {
     orgId,
     userId,
     insertedPricingCategories: pricing.insertedCategories,
+    insertedImagePricingCategories: imagePricing.insertedCategories,
   };
 }
 
 async function deleteWebsiteFixture(fixture: WebsiteFixture): Promise<void> {
   const writeDb = store.set(writeDb$);
+  await writeDb
+    .delete(builtInGenerationJobs)
+    .where(eq(builtInGenerationJobs.orgId, fixture.orgId));
   await writeDb.delete(usageEvent).where(eq(usageEvent.orgId, fixture.orgId));
   await writeDb
     .delete(userFeatureSwitches)
@@ -217,9 +427,26 @@ async function deleteWebsiteFixture(fixture: WebsiteFixture): Promise<void> {
         ),
       );
   }
+  for (const category of fixture.insertedImagePricingCategories) {
+    await writeDb
+      .delete(usagePricing)
+      .where(
+        and(
+          eq(usagePricing.kind, "image"),
+          eq(usagePricing.provider, IMAGE_IO_MODEL),
+          eq(usagePricing.category, category),
+        ),
+      );
+  }
 }
 
-function websitePayloadJson(): string {
+function websitePayloadJson(options?: {
+  readonly visuals?: readonly {
+    readonly placement: "hero" | "feature" | "section";
+    readonly prompt: string;
+    readonly alt: string;
+  }[];
+}): string {
   return JSON.stringify({
     templateId: "launch",
     siteData: {
@@ -276,6 +503,7 @@ function websitePayloadJson(): string {
         cta: { label: "Book a walkthrough", href: "#top" },
       },
       theme: { accent: "cobalt", tone: "light" },
+      visuals: options?.visuals ?? [],
     },
   });
 }
@@ -288,6 +516,9 @@ describe("POST /api/zero/website-io/generate", () => {
     context.mocks.clerk.authenticateRequest.mockResolvedValue({
       isAuthenticated: false,
     });
+    context.mocks.s3.send.mockReset();
+    context.mocks.s3.send.mockResolvedValue({});
+    context.mocks.ably.createTokenRequest.mockResolvedValue(tokenRequest);
   });
 
   it("returns 401 when not authenticated", async () => {
@@ -384,6 +615,7 @@ describe("POST /api/zero/website-io/generate", () => {
       body: JSON.stringify({
         prompt: "A launch site for an observability product",
         template: "launch",
+        imageCount: 0,
         title: "Clearpath Observability",
         audience: "small engineering teams",
       }),
@@ -396,7 +628,13 @@ describe("POST /api/zero/website-io/generate", () => {
       templateLabel: "Launch site",
       slugSuggestion: "clearpath-observability",
       creditsCharged,
+      textCreditsCharged: creditsCharged,
+      imageCreditsCharged: 0,
       model: WEBSITE_IO_MODEL,
+      imageCount: 0,
+      imageModel: IMAGE_IO_MODEL,
+      imageUrls: [],
+      generatedVisuals: [],
       responseId: "resp_website_test",
       usage,
       siteData: {
@@ -419,6 +657,9 @@ describe("POST /api/zero/website-io/generate", () => {
           strict: true,
         }),
       },
+    });
+    expect(observedBody).toMatchObject({
+      input: expect.stringContaining("Create up to 0 visual prompts"),
     });
 
     if (
@@ -466,6 +707,202 @@ describe("POST /api/zero/website-io/generate", () => {
           }),
           category: "tokens.output",
           quantity: usage.outputTokens,
+          status: "processed",
+          billingError: null,
+        }),
+      ]),
+    );
+  });
+
+  it("generates website visuals asynchronously and charges image usage", async () => {
+    const fixture = await track(seedWebsiteFixture());
+    const { pricing } = await ensureWebsitePricing();
+    const { pricing: imagePricing } = await ensureImagePricing();
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    const usage: WebsiteUsage = {
+      inputTokens: 1400,
+      outputTokens: 520,
+      totalTokens: 1920,
+    };
+    const textCreditsCharged = expectedCredits(usage, pricing);
+    const imageCreditsCharged = expectedImageCredits(
+      IMAGE_IO_MODEL,
+      [["output_image.medium.large", 1]],
+      imagePricing,
+    );
+    let observedImageAuthorization: string | null = null;
+    let observedImageBody: unknown = null;
+    server.use(
+      http.post(OPENAI_WEBSITE_GENERATION_URL, () => {
+        return HttpResponse.json({
+          id: "resp_website_visuals",
+          output: [
+            {
+              type: "message",
+              content: [
+                {
+                  type: "output_text",
+                  text: websitePayloadJson({
+                    visuals: [
+                      {
+                        placement: "hero",
+                        prompt:
+                          "A composed operations room with trace paths and calm incident context",
+                        alt: "Abstract observability workspace visual",
+                      },
+                    ],
+                  }),
+                },
+              ],
+            },
+          ],
+          usage: {
+            input_tokens: usage.inputTokens,
+            output_tokens: usage.outputTokens,
+            total_tokens: usage.totalTokens,
+          },
+        });
+      }),
+      http.post(FAL_GPT_IMAGE_1_URL, async ({ request }) => {
+        observedImageAuthorization = request.headers.get("authorization");
+        observedImageBody = await request.json();
+        return HttpResponse.json({
+          images: [
+            {
+              url: FAL_WEBSITE_MEDIA_URL,
+              width: 1536,
+              height: 1024,
+              content_type: "image/webp",
+            },
+          ],
+          prompt: "A calm observability workspace visual.",
+        });
+      }),
+      http.get(FAL_WEBSITE_MEDIA_URL, () => {
+        return new HttpResponse(IMAGE_BYTES, {
+          headers: { "Content-Type": "image/webp" },
+        });
+      }),
+    );
+
+    const app = createApp({ signal: context.signal });
+    const response = await app.request("/api/zero/website-io/generate", {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({
+        prompt: "A launch site for an observability product",
+        template: "launch",
+        imageCount: 1,
+      }),
+    });
+
+    expect(response.status).toBe(202);
+    const generationId = readAcceptedGenerationId(
+      await response.json(),
+      fixture.userId,
+    );
+
+    await clearAllDetached();
+    expect(context.mocks.ably.publish).toHaveBeenCalledWith(
+      `built-in-generation:${generationId}`,
+      expect.objectContaining({
+        generationId,
+        type: "website",
+        status: "completed",
+      }),
+    );
+
+    const statusResponse = await app.request(
+      `/api/zero/built-in-generations/${generationId}`,
+      { headers: authHeaders() },
+    );
+    expect(statusResponse.status).toBe(200);
+    const statusBody: unknown = await statusResponse.json();
+    expect(statusBody).toMatchObject({
+      generationId,
+      type: "website",
+      status: "completed",
+    });
+    const body = readGenerationResult(statusBody);
+    expect(body).toMatchObject({
+      generationId,
+      creditsCharged: textCreditsCharged + imageCreditsCharged,
+      textCreditsCharged,
+      imageCreditsCharged,
+      model: WEBSITE_IO_MODEL,
+      imageCount: 1,
+      imageModel: IMAGE_IO_MODEL,
+      imageUrls: [expect.stringContaining("https://cdn.vm7.io/artifacts/")],
+      generatedVisuals: [
+        expect.objectContaining({
+          placement: "hero",
+          alt: "Abstract observability workspace visual",
+          creditsCharged: imageCreditsCharged,
+        }),
+      ],
+      responseId: "resp_website_visuals",
+      usage,
+    });
+    expect(observedImageAuthorization).toBe("Key test-fal-key");
+    expect(observedImageBody).toMatchObject({
+      image_size: "1536x1024",
+      num_images: 1,
+      quality: "medium",
+      background: "opaque",
+      output_format: "webp",
+      openai_api_key: "test-openai-key",
+      prompt: expect.stringContaining("Clearpath Observability"),
+    });
+    expect(observedImageBody).toMatchObject({
+      prompt: expect.stringContaining("Placement: hero"),
+    });
+
+    const putInputs = context.mocks.s3.send.mock.calls.map((call) => {
+      return commandInput(call[0]);
+    });
+    const imagePutInput = putInputs.find((input) => {
+      return input.ContentType === "image/webp";
+    });
+    if (!imagePutInput) {
+      throw new Error("Expected website image S3 upload");
+    }
+    expect(imagePutInput.Body).toStrictEqual(IMAGE_BYTES);
+    const imageKey = String(imagePutInput.Key);
+    const imageFileId = imageKey.split("/").at(-2);
+    if (!imageFileId) {
+      throw new Error("Expected website image file id in S3 key");
+    }
+
+    const uploadRows = await store
+      .set(writeDb$)
+      .select()
+      .from(runUploadedFiles)
+      .where(eq(runUploadedFiles.externalId, imageFileId));
+    expect(uploadRows).toHaveLength(0);
+
+    const imageUsageRows = await store
+      .set(writeDb$)
+      .select()
+      .from(usageEvent)
+      .where(
+        and(
+          eq(usageEvent.orgId, fixture.orgId),
+          eq(usageEvent.userId, fixture.userId),
+          eq(usageEvent.kind, "image"),
+          eq(usageEvent.provider, IMAGE_IO_MODEL),
+        ),
+      );
+    expect(imageUsageRows).toHaveLength(1);
+    expect(imageUsageRows).toStrictEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          idempotencyKey: builtInGenerationUsageIdempotencyKey({
+            generationId,
+            scope: "website-visual:0",
+            category: "output_image.medium.large",
+          }),
+          category: "output_image.medium.large",
+          quantity: 1,
           status: "processed",
           billingError: null,
         }),

--- a/turbo/apps/api/src/signals/routes/zero-website-io-generate.ts
+++ b/turbo/apps/api/src/signals/routes/zero-website-io-generate.ts
@@ -1,21 +1,60 @@
+import { randomUUID } from "node:crypto";
+
 import { command, type Computed } from "ccstate";
 import { zeroWebsiteIoGenerateContract } from "@vm0/api-contracts/contracts/zero-website-io-generate";
+import type { ZeroBuiltInGenerationRealtimeSubscription } from "@vm0/api-contracts/contracts/zero-built-in-generation";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { isFeatureEnabled } from "@vm0/core/feature-switch";
 
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
 import { bodyResultOf } from "../context/request";
+import { waitUntil } from "../context/wait-until";
+import { createBuiltInGenerationRealtimeSubscription } from "../external/realtime";
 import type { RouteEntry } from "../route";
+import { settle } from "../utils";
 import { userFeatureSwitchOverrides } from "../services/feature-switches.service";
+import {
+  getMissingImagePricing,
+  imagePricing$,
+  type ImagePricing,
+} from "../services/zero-image-io-generate.service";
+import {
+  builtInGenerationRequestWithInternal,
+  completeBuiltInGenerationJob$,
+  createBuiltInGenerationJob$,
+  failBuiltInGenerationJob$,
+  markBuiltInGenerationRunning$,
+} from "../services/zero-built-in-generation.service";
+import {
+  completeRunBuiltInAdmission$,
+  isRunBuiltInAdmissionError,
+  startRunBuiltInAdmission$,
+  type RunBuiltInAdmission,
+} from "../services/zero-run-built-in-admission.service";
 import {
   checkWebsiteCredits$,
   generateWebsite$,
   parseWebsiteOptions,
+  type WebsitePricing,
+  type WebsiteOptions,
   websiteInsufficientCredits,
   websitePricing$,
   websiteServiceUnavailable,
 } from "../services/zero-website-io-generate.service";
+
+interface WebsiteJobArgs {
+  readonly generationId: string;
+  readonly orgId: string;
+  readonly userId: string;
+  readonly runId: string | undefined;
+  readonly admission: RunBuiltInAdmission | null;
+  readonly options: WebsiteOptions;
+  readonly pricing: WebsitePricing;
+  readonly imagePricing: ImagePricing;
+}
+
+type WebsiteJobStatus = "completed" | "failed";
 
 const hostedSitesDisabled = Object.freeze({
   status: 403 as const,
@@ -28,6 +67,34 @@ const hostedSitesDisabled = Object.freeze({
 });
 
 const websiteBody$ = bodyResultOf(zeroWebsiteIoGenerateContract.post);
+
+function websiteRequestRecord(
+  options: WebsiteOptions,
+): Record<string, unknown> {
+  return {
+    prompt: options.prompt,
+    template: options.template,
+    imageCount: options.imageCount,
+    imageModel: options.imageModel,
+    ...(options.audience ? { audience: options.audience } : {}),
+    ...(options.title ? { title: options.title } : {}),
+  };
+}
+
+function acceptedWebsiteResponse(
+  generationId: string,
+  realtime: ZeroBuiltInGenerationRealtimeSubscription,
+) {
+  return {
+    status: 202 as const,
+    body: {
+      generationId,
+      type: "website" as const,
+      status: "queued" as const,
+      realtime,
+    },
+  };
+}
 
 async function hostedSitesEnabled(
   get: <T>(computed: Computed<T>) => T,
@@ -42,6 +109,75 @@ async function hostedSitesEnabled(
     overrides,
   });
 }
+
+const runWebsiteGenerationJob$ = command(
+  async (
+    { set },
+    args: WebsiteJobArgs,
+    signal: AbortSignal,
+  ): Promise<WebsiteJobStatus> => {
+    await set(markBuiltInGenerationRunning$, args.generationId, signal);
+
+    const result = await set(
+      generateWebsite$,
+      {
+        orgId: args.orgId,
+        userId: args.userId,
+        runId: args.runId,
+        options: args.options,
+        pricing: args.pricing,
+        imagePricing: args.imagePricing,
+        generationId: args.generationId,
+      },
+      signal,
+    );
+    if ("status" in result) {
+      await set(
+        failBuiltInGenerationJob$,
+        { generationId: args.generationId, error: result.body.error },
+        signal,
+      );
+      return "failed";
+    }
+
+    await set(
+      completeBuiltInGenerationJob$,
+      { generationId: args.generationId, result },
+      signal,
+    );
+    return "completed";
+  },
+);
+
+const runWebsiteGenerationJobSafely$ = command(
+  async ({ set }, args: WebsiteJobArgs, signal: AbortSignal): Promise<void> => {
+    const result = await settle(set(runWebsiteGenerationJob$, args, signal));
+    signal.throwIfAborted();
+    const admissionStatus: WebsiteJobStatus = result.ok
+      ? result.value
+      : "failed";
+    await set(completeRunBuiltInAdmission$, {
+      admission: args.admission,
+      status: admissionStatus,
+    });
+    signal.throwIfAborted();
+    if (result.ok) {
+      return;
+    }
+
+    await set(
+      failBuiltInGenerationJob$,
+      {
+        generationId: args.generationId,
+        error: {
+          message: "Website generation failed",
+          code: "INTERNAL_SERVER_ERROR",
+        },
+      },
+      signal,
+    );
+  },
+);
 
 const postWebsiteInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   const auth = get(organizationAuthContext$);
@@ -80,10 +216,73 @@ const postWebsiteInner$ = command(async ({ get, set }, signal: AbortSignal) => {
     );
   }
 
+  const imagePricing = options.imageCount > 0 ? await get(imagePricing$) : null;
+  signal.throwIfAborted();
+  const missingImagePricing = imagePricing
+    ? getMissingImagePricing(imagePricing, options.imageModel)
+    : [];
+  if (options.imageCount > 0 && missingImagePricing.length > 0) {
+    return websiteServiceUnavailable(
+      "Website image generation pricing is not configured",
+      "NOT_CONFIGURED",
+    );
+  }
+
   const runId =
     auth.tokenType === "zero" || auth.tokenType === "sandbox"
       ? auth.runId
       : undefined;
+  if (options.imageCount > 0 && imagePricing) {
+    const generationId = randomUUID();
+    const realtime = await createBuiltInGenerationRealtimeSubscription(
+      auth.userId,
+      generationId,
+    );
+    signal.throwIfAborted();
+    const admission = await set(
+      startRunBuiltInAdmission$,
+      { runId, kind: "website" },
+      signal,
+    );
+    if (isRunBuiltInAdmissionError(admission)) {
+      return admission;
+    }
+
+    await set(
+      createBuiltInGenerationJob$,
+      {
+        generationId,
+        type: "website",
+        orgId: auth.orgId,
+        userId: auth.userId,
+        runId,
+        request: builtInGenerationRequestWithInternal(
+          websiteRequestRecord(options),
+          { admissionId: admission?.id },
+        ),
+      },
+      signal,
+    );
+    waitUntil(
+      set(
+        runWebsiteGenerationJobSafely$,
+        {
+          generationId,
+          orgId: auth.orgId,
+          userId: auth.userId,
+          runId,
+          admission,
+          options,
+          pricing,
+          imagePricing,
+        },
+        signal,
+      ),
+    );
+
+    return acceptedWebsiteResponse(generationId, realtime);
+  }
+
   const result = await set(
     generateWebsite$,
     {
@@ -92,6 +291,7 @@ const postWebsiteInner$ = command(async ({ get, set }, signal: AbortSignal) => {
       runId,
       options,
       pricing,
+      imagePricing: null,
     },
     signal,
   );

--- a/turbo/apps/api/src/signals/services/zero-built-in-generation.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-built-in-generation.service.ts
@@ -22,6 +22,7 @@ const BUILT_IN_GENERATION_TIMEOUT_MS_BY_TYPE = {
   image: 15 * 60 * 1000,
   video: 30 * 60 * 1000,
   presentation: 60 * 60 * 1000,
+  website: 60 * 60 * 1000,
 } as const satisfies Record<BuiltInGenerationType, number>;
 
 const BUILT_IN_GENERATION_TIMEOUT_ERROR: BuiltInGenerationError = Object.freeze(

--- a/turbo/apps/api/src/signals/services/zero-run-built-in-admission.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-run-built-in-admission.service.ts
@@ -9,7 +9,12 @@ const RUN_BUILT_IN_MAX_IN_FLIGHT = 3;
 export const RUN_BUILT_IN_MAX_STARTED = 50;
 const RUN_BUILT_IN_ADMISSION_TTL_MS = 30 * 60 * 1000;
 
-type RunBuiltInGenerationKind = "image" | "video" | "presentation" | "voice";
+type RunBuiltInGenerationKind =
+  | "image"
+  | "video"
+  | "presentation"
+  | "website"
+  | "voice";
 
 export interface RunBuiltInAdmission {
   readonly id: string;

--- a/turbo/apps/api/src/signals/services/zero-website-io-generate.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-website-io-generate.service.ts
@@ -9,6 +9,9 @@ import {
   type ZeroWebsiteSiteData,
   type ZeroWebsiteTemplateId,
   type ZeroWebsiteTemplateRequest,
+  type ZeroWebsiteGeneratedVisual,
+  type ZeroWebsiteVisualPlacement,
+  type ZeroWebsiteVisualSpec,
 } from "@vm0/api-contracts/contracts/zero-website-io-generate";
 import { usageEvent } from "@vm0/db/schema/usage-event";
 import { usagePricing } from "@vm0/db/schema/usage-pricing";
@@ -18,9 +21,22 @@ import { env } from "../../lib/env";
 import { logger } from "../../lib/log";
 import { db$, writeDb$ } from "../external/db";
 import { now } from "../../lib/time";
-import { safeJsonParse } from "../utils";
+import { safeJsonParse, settle } from "../utils";
 import { processOrgUsageEvents$ } from "./zero-credit-usage.service";
 import { builtInGenerationUsageIdempotencyKey } from "./built-in-generation-usage-idempotency";
+import {
+  IMAGE_IO_MODEL,
+  generateImageWithProvider,
+  imageModelConfig,
+  imageModelList,
+  normalizeImageModel,
+  parseImageOptions,
+  recordGeneratedImage$,
+  type ImageModel,
+  type ImageOptions,
+  type ImagePricing,
+  type ParsedImageGeneration,
+} from "./zero-image-io-generate.service";
 
 export const OPENAI_WEBSITE_GENERATION_URL =
   "https://api.openai.com/v1/responses";
@@ -28,6 +44,9 @@ export const WEBSITE_IO_MODEL = "gpt-5.5";
 export const WEBSITE_USAGE_KIND = "website";
 
 const WEBSITE_IO_MAX_PROMPT_LENGTH = 32_000;
+const WEBSITE_IO_DEFAULT_IMAGE_COUNT = 1;
+const WEBSITE_IO_MAX_IMAGES = 3;
+const WEBSITE_VISUAL_IMAGE_TIMEOUT_MS = 120_000;
 const WEBSITE_IO_TEMPLATE_LABELS: Readonly<
   Record<ZeroWebsiteTemplateId, string>
 > = {
@@ -46,7 +65,7 @@ const WEBSITE_PRICING_CATEGORIES = [
 ] as const;
 
 type WebsitePricingCategory = (typeof WEBSITE_PRICING_CATEGORIES)[number];
-type ErrorStatus = 400 | 402 | 502 | 503;
+type ErrorStatus = 400 | 402 | 500 | 502 | 503;
 type JsonSchema = Record<string, unknown>;
 
 interface ErrorBody {
@@ -71,9 +90,11 @@ export type WebsitePricing = ReadonlyMap<
   WebsitePricingRow
 >;
 
-interface WebsiteOptions {
+export interface WebsiteOptions {
   readonly prompt: string;
   readonly template: ZeroWebsiteTemplateRequest;
+  readonly imageCount: number;
+  readonly imageModel: ImageModel;
   readonly title: string | undefined;
   readonly audience: string | undefined;
 }
@@ -95,6 +116,13 @@ interface ParsedWebsiteGeneration {
   readonly siteData: ZeroWebsiteSiteData;
   readonly usage: WebsiteUsage;
   readonly responseId: string | undefined;
+}
+
+interface GeneratedWebsiteVisualImage {
+  readonly visualIndex: number;
+  readonly visual: ZeroWebsiteVisualSpec;
+  readonly prompt: string;
+  readonly generation: ParsedImageGeneration;
 }
 
 interface CreditCheckRow extends Record<string, unknown> {
@@ -164,6 +192,29 @@ const FOOTER_SCHEMA: JsonSchema = {
   },
 } as const;
 
+const VISUAL_SCHEMA: JsonSchema = {
+  type: "object",
+  additionalProperties: false,
+  required: ["placement", "prompt", "alt"],
+  properties: {
+    placement: {
+      type: "string",
+      enum: ["hero", "feature", "section"],
+      description:
+        "Where the generated image should appear in the website template.",
+    },
+    prompt: {
+      type: "string",
+      description:
+        "Image generation prompt. Describe a visual scene or abstract composition; avoid visible text.",
+    },
+    alt: {
+      type: "string",
+      description: "Short accessible image description.",
+    },
+  },
+} as const;
+
 const THEME_SCHEMA: JsonSchema = {
   type: "object",
   additionalProperties: false,
@@ -192,6 +243,7 @@ const SITE_DATA_REQUIRED = [
   "stats",
   "footer",
   "theme",
+  "visuals",
 ] as const;
 
 function errorBody(message: string, code: string): ErrorBody {
@@ -256,6 +308,28 @@ function readOptionalString(
   return normalized.length > 0 ? normalized.slice(0, maxLength) : undefined;
 }
 
+function readInteger(
+  body: Record<string, unknown>,
+  key: string,
+): number | ErrorResponse | undefined {
+  const value = body[key];
+  if (value === undefined || value === null || value === "") {
+    return undefined;
+  }
+
+  const parsed =
+    typeof value === "number"
+      ? value
+      : typeof value === "string" && value.trim().length > 0
+        ? Number(value.trim())
+        : Number.NaN;
+  if (!Number.isInteger(parsed)) {
+    return badRequest(`${key} must be an integer`);
+  }
+
+  return parsed;
+}
+
 function isWebsitePricingCategory(
   value: string,
 ): value is WebsitePricingCategory {
@@ -287,9 +361,35 @@ export function parseWebsiteOptions(
     return badRequest(`Unsupported website template: ${template}`);
   }
 
+  const rawImageCount =
+    readInteger(body, "imageCount") ?? readInteger(body, "images");
+  if (typeof rawImageCount === "object") {
+    return rawImageCount;
+  }
+  const imageCount = rawImageCount ?? WEBSITE_IO_DEFAULT_IMAGE_COUNT;
+  if (
+    !Number.isSafeInteger(imageCount) ||
+    imageCount < 0 ||
+    imageCount > WEBSITE_IO_MAX_IMAGES
+  ) {
+    return badRequest(
+      `imageCount must be between 0 and ${WEBSITE_IO_MAX_IMAGES}`,
+    );
+  }
+
+  const rawImageModel = readString(body, "imageModel", IMAGE_IO_MODEL);
+  const imageModel = normalizeImageModel(rawImageModel);
+  if (!imageModel) {
+    return badRequest(
+      `Unsupported image model: ${rawImageModel}. Available models: ${imageModelList()}`,
+    );
+  }
+
   return {
     prompt,
     template: templateResult.data,
+    imageCount,
+    imageModel,
     title: readOptionalString(body, "title", 120),
     audience: readOptionalString(body, "audience", 160),
   };
@@ -391,6 +491,7 @@ function websiteInstructions(): string {
     "Choose profile for portfolio, personal, creator, venue, service, or case-study pages.",
     "Write copy that is specific to the prompt, practical, and ready to publish.",
     "Use short labels, strong section titles, and compact paragraphs.",
+    "For visuals, write concise image prompts that describe scenes or abstract compositions without visible text.",
     "Do not include markdown, HTML, JavaScript, image URLs, external links, legal claims, or unsupported facts.",
     "CTA href values must be same-page anchors such as #contact, #features, #work, or #top.",
   ].join(" ");
@@ -401,6 +502,7 @@ function websiteInput(options: WebsiteOptions): string {
     `Template request: ${options.template}.`,
     "Create 3 to 5 highlights, 2 to 4 content sections, and 0 to 4 stats.",
     "Use theme.accent to choose one of cobalt, green, coral, or mono. Use theme.tone for light or dark.",
+    `Create up to ${options.imageCount} visual prompts. Prefer one hero image, then feature or section images only when they strengthen the page. Use no visual prompts when the requested count is 0.`,
   ];
 
   if (options.title) {
@@ -416,6 +518,7 @@ function websiteInput(options: WebsiteOptions): string {
 
 function websitePayloadSchema(
   templateOptions: readonly ZeroWebsiteTemplateId[],
+  maxVisuals: number,
 ): Record<string, unknown> {
   return {
     type: "object",
@@ -468,6 +571,11 @@ function websitePayloadSchema(
           },
           footer: FOOTER_SCHEMA,
           theme: THEME_SCHEMA,
+          visuals: {
+            type: "array",
+            maxItems: maxVisuals,
+            items: VISUAL_SCHEMA,
+          },
         },
       },
     },
@@ -493,7 +601,7 @@ function createOpenAiWebsiteRequest(
         type: "json_schema",
         name: "website_template_content",
         strict: true,
-        schema: websitePayloadSchema(templateOptions),
+        schema: websitePayloadSchema(templateOptions, options.imageCount),
       },
     },
   };
@@ -633,6 +741,240 @@ function parseWebsiteGenerationResult(
   };
 }
 
+function placementInstruction(placement: ZeroWebsiteVisualPlacement): string {
+  if (placement === "hero") {
+    return "Hero website image with a strong first-viewport subject and crop-safe negative space.";
+  }
+  if (placement === "feature") {
+    return "Feature support image that reinforces product benefits without looking like a UI screenshot.";
+  }
+  return "Section support image with a simple composition that can sit beside editorial website copy.";
+}
+
+function websitePalette(data: ZeroWebsiteSiteData): string {
+  const accent: Readonly<Record<string, string>> = {
+    cobalt: "cobalt blue",
+    green: "deep green",
+    coral: "warm coral",
+    mono: "black and white",
+  };
+  return `${data.theme.tone} tone with ${accent[data.theme.accent]} accent`;
+}
+
+function visualPromptForWebsite(params: {
+  readonly siteData: ZeroWebsiteSiteData;
+  readonly visual: ZeroWebsiteVisualSpec;
+  readonly options: WebsiteOptions;
+}): string {
+  return [
+    `Create a 16:9 website image for "${params.siteData.siteName}".`,
+    `Placement: ${params.visual.placement}. ${placementInstruction(
+      params.visual.placement,
+    )}`,
+    `Visual direction: ${params.visual.prompt}.`,
+    `Website headline: ${params.siteData.headline}.`,
+    `Audience: ${params.options.audience ?? "general website visitors"}.`,
+    `Use a cohesive ${websitePalette(params.siteData)} palette.`,
+    "No visible words, labels, logos, watermarks, UI screenshots, charts with text, or typography.",
+  ].join(" ");
+}
+
+function websiteVisualImageSizeForModel(model: ImageModel): string {
+  const config = imageModelConfig(model);
+  if (config.sizeMode === "standard") {
+    return "1536x1024";
+  }
+  return "1536x864";
+}
+
+function websiteVisualImageOutputFormatForModel(model: ImageModel): string {
+  const formats: readonly string[] = imageModelConfig(model).outputFormats;
+  if (formats.includes("webp")) {
+    return "webp";
+  }
+  if (formats.includes("png")) {
+    return "png";
+  }
+  return formats[0] ?? "png";
+}
+
+function createWebsiteVisualImageOptions(
+  prompt: string,
+  imageModel: ImageModel,
+): ImageOptions | ErrorResponse {
+  return parseImageOptions({
+    prompt,
+    model: imageModel,
+    size: websiteVisualImageSizeForModel(imageModel),
+    quality: "medium",
+    background: "opaque",
+    outputFormat: websiteVisualImageOutputFormatForModel(imageModel),
+    moderation: "auto",
+    safetyTolerance: "4",
+    enhancePrompt: false,
+  });
+}
+
+function loggableError(error: unknown): unknown {
+  return error instanceof Error
+    ? { name: error.name, message: error.message }
+    : String(error);
+}
+
+async function generateWebsiteVisualImage(
+  params: {
+    readonly visualIndex: number;
+    readonly visual: ZeroWebsiteVisualSpec;
+    readonly prompt: string;
+    readonly imageModel: ImageModel;
+  },
+  signal: AbortSignal,
+): Promise<GeneratedWebsiteVisualImage | null> {
+  const startedAt = now();
+  const result = await settle(
+    (async (): Promise<GeneratedWebsiteVisualImage | null> => {
+      const imageOptions = createWebsiteVisualImageOptions(
+        params.prompt,
+        params.imageModel,
+      );
+      if ("status" in imageOptions) {
+        L.warn("Website visual image options could not be used", {
+          visualIndex: params.visualIndex,
+          code: imageOptions.body.error.code,
+          durationMs: now() - startedAt,
+        });
+        return null;
+      }
+
+      const generation = await generateImageWithProvider(
+        imageOptions,
+        AbortSignal.any([
+          signal,
+          AbortSignal.timeout(WEBSITE_VISUAL_IMAGE_TIMEOUT_MS),
+        ]),
+      );
+      signal.throwIfAborted();
+      if ("status" in generation) {
+        L.warn("Website visual image response could not be used", {
+          visualIndex: params.visualIndex,
+          code: generation.body.error.code,
+          durationMs: now() - startedAt,
+        });
+        return null;
+      }
+
+      return {
+        visualIndex: params.visualIndex,
+        visual: params.visual,
+        prompt: params.prompt,
+        generation,
+      };
+    })(),
+  );
+
+  if (!result.ok) {
+    signal.throwIfAborted();
+    L.warn("Website visual image request skipped", {
+      visualIndex: params.visualIndex,
+      error: loggableError(result.error),
+      durationMs: now() - startedAt,
+    });
+    return null;
+  }
+
+  return result.value;
+}
+
+const generateWebsiteVisuals$ = command(
+  async (
+    { set },
+    params: {
+      readonly orgId: string;
+      readonly userId: string;
+      readonly runId: string | undefined;
+      readonly imagePricing: ImagePricing;
+      readonly generation: ParsedWebsiteGeneration;
+      readonly options: WebsiteOptions;
+      readonly generationId: string;
+    },
+    signal: AbortSignal,
+  ): Promise<readonly ZeroWebsiteGeneratedVisual[]> => {
+    const candidates = params.generation.siteData.visuals
+      .slice(0, params.options.imageCount)
+      .filter((visual) => {
+        return visual.prompt.trim().length > 0;
+      });
+    if (candidates.length === 0) {
+      return [];
+    }
+
+    const generatedImages = await Promise.all(
+      candidates.map((visual, visualIndex) => {
+        return generateWebsiteVisualImage(
+          {
+            visualIndex,
+            visual,
+            imageModel: params.options.imageModel,
+            prompt: visualPromptForWebsite({
+              siteData: params.generation.siteData,
+              visual,
+              options: params.options,
+            }),
+          },
+          signal,
+        );
+      }),
+    );
+    signal.throwIfAborted();
+
+    const visuals: ZeroWebsiteGeneratedVisual[] = [];
+    for (const image of generatedImages) {
+      if (!image) {
+        continue;
+      }
+
+      const recordedImageResult = await settle(
+        set(
+          recordGeneratedImage$,
+          {
+            orgId: params.orgId,
+            userId: params.userId,
+            runId: params.runId,
+            pricing: params.imagePricing,
+            generation: image.generation,
+            recordArtifact: false,
+            usageIdempotency: {
+              generationId: params.generationId,
+              scope: `website-visual:${image.visualIndex}`,
+            },
+          },
+          signal,
+        ),
+      );
+      signal.throwIfAborted();
+      if (!recordedImageResult.ok) {
+        L.warn("Website visual image record skipped", {
+          visualIndex: image.visualIndex,
+          error: loggableError(recordedImageResult.error),
+        });
+        continue;
+      }
+      const recordedImage = recordedImageResult.value;
+      visuals.push({
+        placement: image.visual.placement,
+        url: recordedImage.url,
+        alt: image.visual.alt,
+        prompt: image.prompt,
+        imageId: recordedImage.id,
+        filename: recordedImage.filename,
+        creditsCharged: recordedImage.creditsCharged,
+      });
+    }
+
+    return visuals;
+  },
+);
+
 function estimateWebsiteCredits(
   usage: WebsiteUsage,
   pricing: WebsitePricing,
@@ -663,10 +1005,12 @@ export const generateWebsite$ = command(
       readonly runId: string | undefined;
       readonly options: WebsiteOptions;
       readonly pricing: WebsitePricing;
+      readonly imagePricing: ImagePricing | null;
+      readonly generationId?: string;
     },
     signal: AbortSignal,
   ): Promise<ZeroWebsiteIoGenerateResponse | ErrorResponse> => {
-    const generationId = randomUUID();
+    const generationId = params.generationId ?? randomUUID();
     const openAiResponse = await fetch(OPENAI_WEBSITE_GENERATION_URL, {
       method: "POST",
       headers: {
@@ -694,6 +1038,24 @@ export const generateWebsite$ = command(
     if ("status" in generation) {
       return generation;
     }
+
+    const generatedVisuals =
+      params.options.imageCount > 0 && params.imagePricing
+        ? await set(
+            generateWebsiteVisuals$,
+            {
+              orgId: params.orgId,
+              userId: params.userId,
+              runId: params.runId,
+              imagePricing: params.imagePricing,
+              generation,
+              options: params.options,
+              generationId,
+            },
+            signal,
+          )
+        : [];
+    signal.throwIfAborted();
 
     const usageRows = [
       {
@@ -734,14 +1096,31 @@ export const generateWebsite$ = command(
     await set(processOrgUsageEvents$, params.orgId, signal);
     signal.throwIfAborted();
 
+    const generatedVisualList = [...generatedVisuals];
+    const textCreditsCharged = estimateWebsiteCredits(
+      generation.usage,
+      params.pricing,
+    );
+    const imageCreditsCharged = generatedVisualList.reduce((total, visual) => {
+      return total + visual.creditsCharged;
+    }, 0);
+
     return {
       generationId,
       templateId: generation.templateId,
       templateLabel: WEBSITE_IO_TEMPLATE_LABELS[generation.templateId],
       slugSuggestion: slugifySiteName(generation.siteData.siteName),
       siteData: generation.siteData,
-      creditsCharged: estimateWebsiteCredits(generation.usage, params.pricing),
+      creditsCharged: textCreditsCharged + imageCreditsCharged,
+      textCreditsCharged,
+      imageCreditsCharged,
       model: WEBSITE_IO_MODEL,
+      imageCount: generatedVisualList.length,
+      imageModel: params.options.imageModel,
+      imageUrls: generatedVisualList.map((visual) => {
+        return visual.url;
+      }),
+      generatedVisuals: generatedVisualList,
       responseId: generation.responseId,
       usage: generation.usage,
     };

--- a/turbo/apps/cli/src/commands/zero/built-in/generate/__tests__/website.test.ts
+++ b/turbo/apps/cli/src/commands/zero/built-in/generate/__tests__/website.test.ts
@@ -14,18 +14,36 @@ import { server } from "../../../../../mocks/server";
 import { zeroBuiltInCommand } from "../../index";
 
 const WEBSITE_URL = "http://localhost:3000/api/zero/website-io/generate";
+const WEBSITE_GENERATION_ID = "11111111-1111-4111-8111-111111111111";
+const WEBSITE_STATUS_URL = `http://localhost:3000/api/zero/built-in-generations/${WEBSITE_GENERATION_ID}`;
 const HOST_PREPARE_URL =
   "http://localhost:3000/api/zero/host/deployments/prepare";
 const HOST_COMPLETE_URL =
   "http://localhost:3000/api/zero/host/deployments/22222222-2222-4222-8222-222222222222/complete";
 
 const WEBSITE_RESULT = {
-  generationId: "11111111-1111-4111-8111-111111111111",
+  generationId: WEBSITE_GENERATION_ID,
   templateId: "launch",
   templateLabel: "Launch site",
   slugSuggestion: "clearpath-observability",
   creditsCharged: 18,
+  textCreditsCharged: 12,
+  imageCreditsCharged: 6,
   model: "gpt-5.5",
+  imageCount: 1,
+  imageModel: "gpt-image-1",
+  imageUrls: ["http://localhost:3000/f/user-1/image-file-id/image-visual.webp"],
+  generatedVisuals: [
+    {
+      placement: "hero",
+      url: "http://localhost:3000/f/user-1/image-file-id/image-visual.webp",
+      alt: "Abstract observability workspace visual",
+      prompt: "Create a 16:9 website image for Clearpath Observability.",
+      imageId: "image-file-id",
+      filename: "image-visual.webp",
+      creditsCharged: 6,
+    },
+  ],
   responseId: "resp_website",
   usage: {
     inputTokens: 1200,
@@ -78,6 +96,13 @@ const WEBSITE_RESULT = {
       cta: { label: "Book a walkthrough", href: "#top" },
     },
     theme: { accent: "cobalt", tone: "light" },
+    visuals: [
+      {
+        placement: "hero",
+        prompt: "A calm observability workspace visual",
+        alt: "Abstract observability workspace visual",
+      },
+    ],
   },
 };
 
@@ -115,16 +140,50 @@ describe("zero built-in generate website command", () => {
   it("should generate, build, host, and print JSON metadata", async () => {
     const uploadedPaths: string[] = [];
     let prepareBody: PrepareBody | null = null;
+    let statusRequested = false;
     server.use(
       http.post(WEBSITE_URL, async ({ request }) => {
         expect(request.headers.get("authorization")).toBe("Bearer test-token");
         expect(await request.json()).toEqual({
           prompt: "observability launch site",
           template: "launch",
+          imageCount: 1,
           title: "Clearpath",
           audience: "small engineering teams",
         });
-        return HttpResponse.json(WEBSITE_RESULT);
+        return HttpResponse.json(
+          {
+            generationId: WEBSITE_GENERATION_ID,
+            type: "website",
+            status: "queued",
+            realtime: {
+              channelName: "user:user-1",
+              eventName: `built-in-generation:${WEBSITE_GENERATION_ID}`,
+              tokenRequest: {
+                keyName: "test-key",
+                timestamp: 1_700_000_000_000,
+                capability: '{"user:user-1":["subscribe"]}',
+                clientId: "user-1",
+                nonce: "test-nonce",
+                mac: "test-mac",
+              },
+            },
+          },
+          { status: 202 },
+        );
+      }),
+      http.get(WEBSITE_STATUS_URL, ({ request }) => {
+        statusRequested = true;
+        expect(request.headers.get("authorization")).toBe("Bearer test-token");
+        return HttpResponse.json({
+          generationId: WEBSITE_GENERATION_ID,
+          type: "website",
+          status: "completed",
+          result: WEBSITE_RESULT,
+          createdAt: "2026-05-15T00:00:00.000Z",
+          startedAt: "2026-05-15T00:00:01.000Z",
+          completedAt: "2026-05-15T00:00:02.000Z",
+        });
       }),
       http.post(HOST_PREPARE_URL, async ({ request }) => {
         prepareBody = (await request.json()) as PrepareBody;
@@ -195,6 +254,7 @@ describe("zero built-in generate website command", () => {
       "/assets/styles.css",
       "/index.html",
     ]);
+    expect(statusRequested).toBe(true);
 
     const stdout = mockConsoleLog.mock.calls.flat().join("\n");
     const parsed = JSON.parse(stdout) as Record<string, unknown>;
@@ -206,7 +266,12 @@ describe("zero built-in generate website command", () => {
       templateLabel: "Launch site",
       fileCount: 2,
       creditsCharged: 18,
+      textCreditsCharged: 12,
+      imageCreditsCharged: 6,
       model: "gpt-5.5",
+      imageCount: 1,
+      imageModel: "gpt-image-1",
+      imageUrls: WEBSITE_RESULT.imageUrls,
       responseId: "resp_website",
       generationId: "11111111-1111-4111-8111-111111111111",
       usage: WEBSITE_RESULT.usage,

--- a/turbo/apps/cli/src/commands/zero/built-in/generate/website.ts
+++ b/turbo/apps/cli/src/commands/zero/built-in/generate/website.ts
@@ -11,10 +11,13 @@ import { publishStaticSite } from "../../../../lib/host/publish-static-site";
 import { buildGeneratedWebsite } from "../../shared/website-build";
 
 const WEBSITE_TEMPLATES = ["auto", "launch", "profile"] as const;
+const WEBSITE_MAX_IMAGES = 3;
 
 interface WebsiteOptions {
   readonly prompt?: string;
   readonly template: string;
+  readonly images: number;
+  readonly imageModel?: string;
   readonly site?: string;
   readonly title?: string;
   readonly audience?: string;
@@ -31,6 +34,23 @@ function parseTemplate(value: string): string {
     return value;
   }
   throw new InvalidArgumentError("template must be auto, launch, or profile");
+}
+
+function parseImageCount(value: string): number {
+  const imageCount = Number(value);
+  if (!Number.isInteger(imageCount)) {
+    throw new InvalidArgumentError("images must be an integer");
+  }
+  if (
+    !Number.isSafeInteger(imageCount) ||
+    imageCount < 0 ||
+    imageCount > WEBSITE_MAX_IMAGES
+  ) {
+    throw new InvalidArgumentError(
+      `images must be between 0 and ${WEBSITE_MAX_IMAGES}`,
+    );
+  }
+  return imageCount;
 }
 
 function readPrompt(options: WebsiteOptions): string {
@@ -68,6 +88,16 @@ export const websiteCommand = new Command()
     parseTemplate,
     "auto",
   )
+  .option(
+    "--images <count>",
+    `Generated website image count: 0-${WEBSITE_MAX_IMAGES}`,
+    parseImageCount,
+    1,
+  )
+  .option(
+    "--image-model <model>",
+    "Image model for generated visuals (default: gpt-image-1): gpt-image-2, gpt-image-1.5, gpt-image-1, gpt-image-1-mini, flux-pro-1.1, flux-pro-1.1-ultra, qwen-image, or seedream4",
+  )
   .option("--site <slug>", "Hosted site slug; defaults to the generated name")
   .option("--title <text>", "Requested site title or name")
   .option("--audience <text>", "Audience context")
@@ -78,7 +108,7 @@ export const websiteCommand = new Command()
     `
 Examples:
   Generate site:         zero built-in generate website --prompt "A launch site for a developer observability tool"
-  Pick template:         zero built-in generate website --template profile --prompt "Portfolio for a robotics photographer"
+  Pick template:         zero built-in generate website --template profile --images 2 --image-model gpt-image-1.5 --prompt "Portfolio for a robotics photographer"
   Stable hosted slug:    zero built-in generate website --site api-migration-demo --prompt "An internal migration microsite"
   Pipe prompt:           cat brief.txt | zero built-in generate website
 
@@ -88,7 +118,7 @@ Output:
 Notes:
   - Authenticates via ZERO_TOKEN (requires host:write capability)
   - Charges org credits for model-generated website content
-  - Uses OpenAI gpt-5.5 through the Responses API`,
+  - Uses OpenAI gpt-5.5 for website content and fal.ai for generated visuals`,
   )
   .action(
     withErrorHandler(async (options: WebsiteOptions) => {
@@ -99,6 +129,8 @@ Notes:
       const generation = await generateWebWebsite({
         prompt,
         template: options.template,
+        imageCount: options.images,
+        imageModel: options.imageModel,
         title: options.title,
         audience: options.audience,
       });
@@ -113,6 +145,7 @@ Notes:
           outDir,
           templateId: generation.templateId,
           siteData: generation.siteData,
+          generatedVisuals: generation.generatedVisuals,
         });
 
         const site = options.site ?? generation.slugSuggestion;
@@ -143,7 +176,12 @@ Notes:
           fileCount: hosted.fileCount,
           size: hosted.size,
           creditsCharged: generation.creditsCharged,
+          textCreditsCharged: generation.textCreditsCharged,
+          imageCreditsCharged: generation.imageCreditsCharged,
           model: generation.model,
+          imageCount: generation.imageCount,
+          imageModel: generation.imageModel,
+          imageUrls: generation.imageUrls,
           responseId: generation.responseId,
           generationId: generation.generationId,
           usage: generation.usage,
@@ -161,8 +199,16 @@ Notes:
         console.log(chalk.dim(`  Template: ${generation.templateLabel}`));
         console.log(chalk.dim(`  Files: ${hosted.fileCount.toLocaleString()}`));
         console.log(chalk.dim(`  Size: ${formatBytes(hosted.size)}`));
+        console.log(chalk.dim(`  Images: ${generation.imageCount}`));
+        console.log(chalk.dim(`  Image model: ${generation.imageModel}`));
         console.log(
           chalk.dim(`  Credits charged: ${generation.creditsCharged}`),
+        );
+        console.log(
+          chalk.dim(`  Text credits: ${generation.textCreditsCharged}`),
+        );
+        console.log(
+          chalk.dim(`  Image credits: ${generation.imageCreditsCharged}`),
         );
         console.log(chalk.dim(`  Model: ${generation.model}`));
         if (options.keepBuildDir) {

--- a/turbo/apps/cli/src/commands/zero/shared/website-build.ts
+++ b/turbo/apps/cli/src/commands/zero/shared/website-build.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import React, { type ReactNode } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import type {
+  ZeroWebsiteGeneratedVisual,
   ZeroWebsiteSiteData,
   ZeroWebsiteTemplateId,
 } from "@vm0/api-contracts/contracts/zero-website-io-generate";
@@ -14,11 +15,13 @@ interface BuildGeneratedWebsiteOptions {
   readonly outDir: string;
   readonly templateId: ZeroWebsiteTemplateId;
   readonly siteData: ZeroWebsiteSiteData;
+  readonly generatedVisuals?: readonly ZeroWebsiteGeneratedVisual[];
 }
 
 interface WebsiteProps {
   readonly data: ZeroWebsiteSiteData;
   readonly templateId: ZeroWebsiteTemplateId;
+  readonly generatedVisuals: readonly ZeroWebsiteGeneratedVisual[];
 }
 
 interface CtaLinkProps {
@@ -117,10 +120,57 @@ function Stats(props: { readonly data: ZeroWebsiteSiteData }): ReactNode {
   );
 }
 
+function VisualFigure(props: {
+  readonly visual: ZeroWebsiteGeneratedVisual;
+  readonly className: string;
+}): ReactNode {
+  return h(
+    "figure",
+    { className: `website-visual-frame ${props.className}` },
+    h("img", { src: props.visual.url, alt: props.visual.alt }),
+  );
+}
+
+function heroVisual(
+  visuals: readonly ZeroWebsiteGeneratedVisual[],
+): ZeroWebsiteGeneratedVisual | undefined {
+  return (
+    visuals.find((visual) => {
+      return visual.placement === "hero";
+    }) ?? visuals[0]
+  );
+}
+
+function SupportVisuals(props: {
+  readonly visuals: readonly ZeroWebsiteGeneratedVisual[];
+}): ReactNode {
+  const hero = heroVisual(props.visuals);
+  const support = props.visuals.filter((visual) => {
+    return visual !== hero;
+  });
+  if (support.length === 0) {
+    return null;
+  }
+
+  return h(
+    "section",
+    { className: "visual-strip", "aria-label": "Generated visuals" },
+    ...support.map((visual) => {
+      return h(VisualFigure, {
+        key: visual.imageId,
+        visual,
+        className: `visual-${visual.placement}`,
+      });
+    }),
+  );
+}
+
 function LaunchTemplate(props: {
   readonly data: ZeroWebsiteSiteData;
+  readonly generatedVisuals: readonly ZeroWebsiteGeneratedVisual[];
 }): ReactNode {
   const data = props.data;
+  const visual = heroVisual(props.generatedVisuals);
   return h(
     React.Fragment,
     null,
@@ -148,25 +198,31 @@ function LaunchTemplate(props: {
           }),
         ),
       ),
-      h(
-        "div",
-        { className: "hero-panel", "aria-hidden": "true" },
-        h("span", { className: "panel-label" }, data.siteName),
-        h(
-          "div",
-          { className: "panel-stack" },
-          ...data.highlights.slice(0, 3).map((highlight) => {
-            return h(
+      visual
+        ? h(VisualFigure, {
+            visual,
+            className: "hero-visual",
+          })
+        : h(
+            "div",
+            { className: "hero-panel", "aria-hidden": "true" },
+            h("span", { className: "panel-label" }, data.siteName),
+            h(
               "div",
-              { className: "panel-line", key: highlight.title },
-              h("strong", null, highlight.title),
-              h("span", null, highlight.body),
-            );
-          }),
-        ),
-      ),
+              { className: "panel-stack" },
+              ...data.highlights.slice(0, 3).map((highlight) => {
+                return h(
+                  "div",
+                  { className: "panel-line", key: highlight.title },
+                  h("strong", null, highlight.title),
+                  h("span", null, highlight.body),
+                );
+              }),
+            ),
+          ),
     ),
     h(Highlights, { data }),
+    h(SupportVisuals, { visuals: props.generatedVisuals }),
     h(Stats, { data }),
     h(SectionList, { data }),
   );
@@ -174,19 +230,26 @@ function LaunchTemplate(props: {
 
 function ProfileTemplate(props: {
   readonly data: ZeroWebsiteSiteData;
+  readonly generatedVisuals: readonly ZeroWebsiteGeneratedVisual[];
 }): ReactNode {
   const data = props.data;
+  const visual = heroVisual(props.generatedVisuals);
   return h(
     React.Fragment,
     null,
     h(
       "section",
       { className: "hero hero-profile", id: "top" },
-      h(
-        "div",
-        { className: "profile-mark", "aria-hidden": "true" },
-        data.siteName.slice(0, 2).toUpperCase(),
-      ),
+      visual
+        ? h(VisualFigure, {
+            visual,
+            className: "hero-visual profile-visual",
+          })
+        : h(
+            "div",
+            { className: "profile-mark", "aria-hidden": "true" },
+            data.siteName.slice(0, 2).toUpperCase(),
+          ),
       h(
         "div",
         { className: "hero-copy" },
@@ -211,6 +274,7 @@ function ProfileTemplate(props: {
     ),
     h(Stats, { data }),
     h(Highlights, { data }),
+    h(SupportVisuals, { visuals: props.generatedVisuals }),
     h(SectionList, { data }),
   );
 }
@@ -219,8 +283,8 @@ function WebsiteDocument(props: WebsiteProps): ReactNode {
   const { data, templateId } = props;
   const template =
     templateId === "profile"
-      ? h(ProfileTemplate, { data })
-      : h(LaunchTemplate, { data });
+      ? h(ProfileTemplate, { data, generatedVisuals: props.generatedVisuals })
+      : h(LaunchTemplate, { data, generatedVisuals: props.generatedVisuals });
 
   return h(
     "html",
@@ -482,6 +546,45 @@ h1 {
   justify-content: space-between;
 }
 
+.website-visual-frame {
+  margin: 0;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  overflow: hidden;
+  background: var(--surface);
+}
+
+.website-visual-frame img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.hero-visual {
+  align-self: stretch;
+  min-height: 420px;
+  aspect-ratio: 4 / 5;
+}
+
+.profile-visual {
+  width: min(32vw, 360px);
+  min-height: 320px;
+  aspect-ratio: 4 / 5;
+}
+
+.visual-strip {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+  padding: 0 clamp(20px, 5vw, 72px) clamp(36px, 6vw, 72px);
+}
+
+.visual-strip .website-visual-frame {
+  min-height: 260px;
+  aspect-ratio: 16 / 9;
+}
+
 .panel-label {
   color: var(--muted);
   font-size: 0.86rem;
@@ -678,8 +781,16 @@ h1 {
     min-height: 300px;
   }
 
+  .hero-visual,
+  .profile-visual {
+    width: 100%;
+    min-height: 280px;
+    aspect-ratio: 16 / 10;
+  }
+
   .highlights,
-  .stats {
+  .stats,
+  .visual-strip {
     grid-template-columns: 1fr;
   }
 
@@ -709,6 +820,7 @@ export async function buildGeneratedWebsite(
     React.createElement(WebsiteDocument, {
       data: options.siteData,
       templateId: options.templateId,
+      generatedVisuals: options.generatedVisuals ?? [],
     }),
   );
 

--- a/turbo/apps/cli/src/lib/api/domains/web.ts
+++ b/turbo/apps/cli/src/lib/api/domains/web.ts
@@ -17,6 +17,7 @@ const BUILT_IN_GENERATION_WAIT_TIMEOUT_MS_BY_TYPE = {
   image: 15 * 60 * 1000,
   video: 30 * 60 * 1000,
   presentation: 60 * 60 * 1000,
+  website: 60 * 60 * 1000,
 } as const satisfies Record<
   ZeroBuiltInGenerationAcceptedResponse["type"],
   number
@@ -339,6 +340,8 @@ interface GenerateWebPresentationResult {
 interface GenerateWebWebsiteOptions {
   prompt: string;
   template?: string;
+  imageCount?: number;
+  imageModel?: string;
   title?: string;
   audience?: string;
 }
@@ -407,7 +410,8 @@ function isBuiltInGenerationAcceptedResponse(
     value.status === "queued" &&
     (value.type === "image" ||
       value.type === "video" ||
-      value.type === "presentation") &&
+      value.type === "presentation" ||
+      value.type === "website") &&
     isRecord(value.realtime)
   );
 }
@@ -1055,6 +1059,10 @@ export async function generateWebWebsite(
       body: JSON.stringify({
         prompt: options.prompt,
         ...(options.template ? { template: options.template } : {}),
+        ...(options.imageCount !== undefined
+          ? { imageCount: options.imageCount }
+          : {}),
+        ...(options.imageModel ? { imageModel: options.imageModel } : {}),
         ...(options.title ? { title: options.title } : {}),
         ...(options.audience ? { audience: options.audience } : {}),
       }),
@@ -1069,5 +1077,10 @@ export async function generateWebWebsite(
     throw new ApiRequestError(message, code, response.status);
   }
 
-  return (await response.json()) as GenerateWebWebsiteResult;
+  return readBuiltInGenerationResponse<GenerateWebWebsiteResult>({
+    response,
+    baseUrl,
+    token,
+    fallback: "Failed to generate website",
+  });
 }

--- a/turbo/packages/api-contracts/src/contracts/zero-built-in-generation.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-built-in-generation.ts
@@ -10,6 +10,7 @@ export const zeroBuiltInGenerationTypeSchema = z.enum([
   "image",
   "video",
   "presentation",
+  "website",
 ]);
 
 export const zeroBuiltInGenerationStatusSchema = z.enum([

--- a/turbo/packages/api-contracts/src/contracts/zero-website-io-generate.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-website-io-generate.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 
 import { authHeadersSchema, initContract } from "./base";
 import { apiErrorSchema } from "./errors";
+import { zeroBuiltInGenerationAcceptedResponseSchema } from "./zero-built-in-generation";
 
 const c = initContract();
 
@@ -16,6 +17,8 @@ export const zeroWebsiteIoGenerateRequestSchema = z
   .object({
     prompt: z.unknown().optional(),
     template: z.unknown().optional(),
+    imageCount: z.unknown().optional(),
+    imageModel: z.unknown().optional(),
     title: z.unknown().optional(),
     audience: z.unknown().optional(),
   })
@@ -60,6 +63,28 @@ export const zeroWebsiteThemeSchema = z.object({
   tone: z.enum(["light", "dark"]),
 });
 
+export const zeroWebsiteVisualPlacementSchema = z.enum([
+  "hero",
+  "feature",
+  "section",
+]);
+
+export const zeroWebsiteVisualSpecSchema = z.object({
+  placement: zeroWebsiteVisualPlacementSchema,
+  prompt: z.string(),
+  alt: z.string(),
+});
+
+export const zeroWebsiteGeneratedVisualSchema = z.object({
+  placement: zeroWebsiteVisualPlacementSchema,
+  url: z.string(),
+  alt: z.string(),
+  prompt: z.string(),
+  imageId: z.string(),
+  filename: z.string(),
+  creditsCharged: z.number(),
+});
+
 export const zeroWebsiteSiteDataSchema = z.object({
   siteName: z.string(),
   eyebrow: z.string(),
@@ -72,6 +97,7 @@ export const zeroWebsiteSiteDataSchema = z.object({
   stats: z.array(zeroWebsiteStatSchema),
   footer: zeroWebsiteFooterSchema,
   theme: zeroWebsiteThemeSchema,
+  visuals: z.array(zeroWebsiteVisualSpecSchema),
 });
 
 export const zeroWebsiteGenerationPayloadSchema = z.object({
@@ -86,7 +112,13 @@ export const zeroWebsiteIoGenerateResponseSchema = z.object({
   slugSuggestion: z.string(),
   siteData: zeroWebsiteSiteDataSchema,
   creditsCharged: z.number(),
+  textCreditsCharged: z.number(),
+  imageCreditsCharged: z.number(),
   model: z.string(),
+  imageCount: z.number(),
+  imageModel: z.string(),
+  imageUrls: z.array(z.string()),
+  generatedVisuals: z.array(zeroWebsiteGeneratedVisualSchema),
   responseId: z.string().optional(),
   usage: zeroWebsiteIoUsageSchema,
 });
@@ -94,6 +126,13 @@ export const zeroWebsiteIoGenerateResponseSchema = z.object({
 export type ZeroWebsiteTemplateId = z.infer<typeof zeroWebsiteTemplateIdSchema>;
 export type ZeroWebsiteTemplateRequest = z.infer<
   typeof zeroWebsiteTemplateRequestSchema
+>;
+export type ZeroWebsiteVisualPlacement = z.infer<
+  typeof zeroWebsiteVisualPlacementSchema
+>;
+export type ZeroWebsiteVisualSpec = z.infer<typeof zeroWebsiteVisualSpecSchema>;
+export type ZeroWebsiteGeneratedVisual = z.infer<
+  typeof zeroWebsiteGeneratedVisualSchema
 >;
 export type ZeroWebsiteSiteData = z.infer<typeof zeroWebsiteSiteDataSchema>;
 export type ZeroWebsiteGenerationPayload = z.infer<
@@ -114,6 +153,7 @@ export const zeroWebsiteIoGenerateContract = c.router({
     body: zeroWebsiteIoGenerateRequestSchema,
     responses: {
       200: zeroWebsiteIoGenerateResponseSchema,
+      202: zeroBuiltInGenerationAcceptedResponseSchema,
       400: apiErrorSchema,
       401: apiErrorSchema,
       402: apiErrorSchema,

--- a/turbo/packages/db/src/schema/built-in-generation-job.ts
+++ b/turbo/packages/db/src/schema/built-in-generation-job.ts
@@ -13,6 +13,7 @@ export const BUILT_IN_GENERATION_TYPES = [
   "image",
   "video",
   "presentation",
+  "website",
 ] as const;
 export type BuiltInGenerationType = (typeof BUILT_IN_GENERATION_TYPES)[number];
 


### PR DESCRIPTION
## Summary
- add async built-in website generation jobs when generated images are requested
- reuse the image IO provider/storage/billing path and return split text/image credit metadata plus generated visuals
- add CLI --images/--image-model support and render generated visuals in the static website builder

## Tests
- pnpm --dir /tmp/vm4-check-head/turbo format
- pnpm --dir /tmp/vm4-check-head/turbo lint
- pnpm --dir /workspaces/vm4/turbo knip
- pnpm --dir /tmp/vm4-check-head/turbo check-types
- pnpm --dir /tmp/vm4-check-head/turbo -F api exec vitest src/signals/routes/__tests__/zero-website-io-generate.test.ts --run
- pnpm --dir /tmp/vm4-check-head/turbo -F @vm0/cli exec vitest src/commands/zero/built-in/generate/__tests__/website.test.ts --run

Note: the current /workspaces/vm4 install has an unrelated local typecheck issue in @vm0/app ts-rest client types, so full typecheck was verified from a clean worktree containing the same patch.