### PR TITLE
feat: enable google ads connector for staff

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/settings/__tests__/google-ads-connector.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/__tests__/google-ads-connector.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import { setupPage } from "../../../../__tests__/page-helper.ts";
+import { testContext } from "../../../__tests__/test-helpers.ts";
+import { allConnectorTypes$ } from "../connectors.ts";
+
+const context = testContext();
+
+describe("google ads connector", () => {
+  it("is hidden when the Google Ads connector feature switch is disabled", async () => {
+    await setupPage({
+      context,
+      path: "/",
+      withoutRender: true,
+      featureSwitches: { [FeatureSwitchKey.GoogleAdsConnector]: false },
+    });
+
+    const connectors = await context.store.get(allConnectorTypes$);
+
+    expect(
+      connectors.some((connector) => {
+        return connector.type === "google-ads";
+      }),
+    ).toBeFalsy();
+  });
+
+  it("shows Google Ads without an experimental label when the feature switch is enabled", async () => {
+    await setupPage({
+      context,
+      path: "/",
+      withoutRender: true,
+      featureSwitches: { [FeatureSwitchKey.GoogleAdsConnector]: true },
+    });
+
+    const connectors = await context.store.get(allConnectorTypes$);
+    const googleAds = connectors.find((connector) => {
+      return connector.type === "google-ads";
+    });
+
+    expect(googleAds?.label).toBe("Google Ads");
+    expect(googleAds?.availableAuthMethods).toStrictEqual(["oauth"]);
+  });
+});

--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -250,15 +250,16 @@ function buildConnectorTypeStatus(params: {
     },
   );
   const hasApiToken = availableAuthMethods.includes("api-token");
-  const hasFeatureFlaggedMethod = availableAuthMethods.some((authMethod) => {
-    return !!getConnectorAuthMethod(params.type, authMethod)?.featureFlag;
+  const showExperimentalLabel = availableAuthMethods.some((authMethod) => {
+    const method = getConnectorAuthMethod(params.type, authMethod);
+    return !!method?.featureFlag && method.showExperimentalLabel !== false;
   });
   const connected = params.connector !== null;
 
   return {
     type: params.type,
     label:
-      hasFeatureFlaggedMethod &&
+      showExperimentalLabel &&
       !hasApiToken &&
       !isHostBackedConnector(params.type)
         ? `[Experimental] ${config.label}`

--- a/turbo/packages/connectors/src/connectors.ts
+++ b/turbo/packages/connectors/src/connectors.ts
@@ -240,6 +240,8 @@ export interface ConnectorAuthMethodConfig {
   helpText?: string;
   /** When set, this auth method is only available while the feature is enabled. */
   featureFlag?: FeatureSwitchKey;
+  /** When false, feature-gated UI surfaces should not add an experimental label. */
+  showExperimentalLabel?: boolean;
   secrets: Record<string, ConnectorSecretConfig>;
 }
 

--- a/turbo/packages/connectors/src/connectors/google-ads.ts
+++ b/turbo/packages/connectors/src/connectors/google-ads.ts
@@ -14,6 +14,7 @@ export const googleAds = {
     authMethods: {
       oauth: {
         featureFlag: FeatureSwitchKey.GoogleAdsConnector,
+        showExperimentalLabel: false,
         label: "OAuth (Recommended)",
         helpText: "Sign in with Google to grant Google Ads access.",
         secrets: {

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -116,6 +116,7 @@ describe("getAllFeatureStates", () => {
       orgId: "org_3ANttyrbWYJk6JKRSTRLEsbsDLe",
     });
     expect(staffOrgStates[FeatureSwitchKey.Lab]).toBe(true);
+    expect(staffOrgStates[FeatureSwitchKey.GoogleAdsConnector]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.PwaOfflineCache]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ChatHeaderNewButton]).toBe(false);
     expect(staffOrgStates[FeatureSwitchKey.ChatMessageStartButton]).toBe(false);
@@ -125,6 +126,7 @@ describe("getAllFeatureStates", () => {
       orgId: "org_nonexistent",
     });
     expect(otherOrgStates[FeatureSwitchKey.Lab]).toBe(false);
+    expect(otherOrgStates[FeatureSwitchKey.GoogleAdsConnector]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.PwaOfflineCache]).toBe(false);
   });
 

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -128,6 +128,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     maintainer: "ethan@vm0.ai",
     description: "Enable the Google Ads connector",
     enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.MetaAdsConnector]: {
     maintainer: "ethan@vm0.ai",


### PR DESCRIPTION
## Summary
- enable the Google Ads connector feature switch for staff orgs
- keep Google Ads feature-gated while removing the experimental label from its connector card
- add coverage for staff rollout state and connector list behavior

## Tests
- pnpm format
- pnpm -F @vm0/core exec vitest run src/__tests__/feature-switch.test.ts
- pnpm -F @vm0/connectors exec vitest run src/__tests__/connectors.test.ts
- pnpm -F @vm0/app exec vitest run src/signals/zero-page/settings/__tests__/google-ads-connector.test.ts
- pnpm -F @vm0/connectors check-types
- pnpm -F @vm0/core check-types
- pnpm -F @vm0/app check-types
- pnpm -F @vm0/connectors lint
- pnpm -F @vm0/core lint
- pnpm -F @vm0/app lint
- pre-commit hook: pnpm knip --cache; pnpm check-types