### PR TITLE
docs: document process-control-ipc protocol

### DIFF
--- a/crates/process-control-ipc/src/lib.rs
+++ b/crates/process-control-ipc/src/lib.rs
@@ -1,8 +1,61 @@
-//! Local process-control IPC channel.
+#![deny(missing_docs)]
+
+//! Local process-control IPC channel for a guest operation control sink.
 //!
-//! This crate is intentionally std-only. `vsock-guest` uses it from blocking
-//! worker threads, while `guest-agent` can use it without introducing another
-//! async protocol implementation.
+//! This crate defines the local, blocking protocol used after `vsock-guest`
+//! exposes an operation-control endpoint and `guest-agent` connects back to it.
+//! The transport is a Linux abstract Unix stream socket. Endpoint names are
+//! abstract-socket names, not filesystem paths.
+//!
+//! The endpoint is bootstrapped through [`BOOTSTRAP_ENV`]. `vsock-guest`
+//! creates the endpoint name with [`endpoint_name`], binds it with
+//! [`bind_abstract_listener`], accepts a single control sink connection, and
+//! then drives request/response exchange. `guest-agent` reads the endpoint name
+//! from the environment, connects with [`connect_abstract`], sends a hello
+//! frame, then reads requests and writes responses.
+//!
+//! ## Frame format
+//!
+//! Every frame uses this envelope:
+//!
+//! ```text
+//! [4B body_len][1B version][1B kind][payload]
+//! ```
+//!
+//! All integer fields are big-endian. `body_len` is the byte length of
+//! `[version][kind][payload]`; it does not include the 4-byte `body_len` field.
+//! The current version byte is `1`.
+//!
+//! Frame kinds:
+//!
+//! | Kind | Name     | Payload |
+//! |------|----------|---------|
+//! | 0x01 | hello    | empty |
+//! | 0x02 | request  | `[2B message_id_len][message_id][4B payload_len][payload]` |
+//! | 0x03 | response | `[2B message_id_len][message_id][1B status][2B diagnostic_len][diagnostic]` |
+//!
+//! Response status values:
+//!
+//! | Status | Name     | Meaning |
+//! |--------|----------|---------|
+//! | 0x00   | accepted | sink handled the request |
+//! | 0x01   | rejected | sink understood the request but declined it |
+//! | 0x02   | error    | sink failed while processing the request |
+//!
+//! ## Expected sequence
+//!
+//! ```text
+//! vsock-guest: bind_abstract_listener -> accept_with_timeout -> read_hello
+//! guest-agent:                         connect_abstract     -> write_hello
+//! vsock-guest: write_request
+//! guest-agent: read_request -> write_response
+//! vsock-guest: read_response
+//! ```
+//!
+//! The request and response exchange can repeat on the connected stream until
+//! either endpoint closes it. Message ids are non-empty UTF-8 strings. Request
+//! payloads are bounded by [`MAX_CONTROL_PAYLOAD_BYTES`], and response
+//! diagnostics are bounded by [`MAX_DIAGNOSTIC_BYTES`].
 
 use std::io::{self, Read, Write};
 use std::mem::{MaybeUninit, size_of};
@@ -10,9 +63,26 @@ use std::os::fd::{AsRawFd, FromRawFd, IntoRawFd, OwnedFd};
 use std::os::unix::net::{UnixListener, UnixStream};
 use std::time::{Duration, Instant};
 
+/// Environment variable carrying the operation-control abstract socket name.
+///
+/// `vsock-guest` sets this value to the output of [`endpoint_name`] when it
+/// starts a guest operation that supports a local control sink. `guest-agent`
+/// reads it during startup and connects to that abstract socket. Child agent
+/// CLI processes must not inherit this variable.
 pub const BOOTSTRAP_ENV: &str = "VM0_PROCESS_CONTROL_ENDPOINT";
 
+/// Maximum request payload size carried by a local control request frame.
+///
+/// [`write_request`] returns `InvalidInput` when a request payload exceeds this
+/// limit. [`read_request`] returns `InvalidData` when an incoming request frame
+/// declares a payload larger than this limit.
 pub const MAX_CONTROL_PAYLOAD_BYTES: usize = 1024 * 1024;
+
+/// Maximum diagnostic string size carried by a local control response frame.
+///
+/// [`write_response`] returns `InvalidInput` when a response diagnostic exceeds
+/// this limit. [`read_response`] returns `InvalidData` when an incoming response
+/// frame declares a diagnostic larger than this limit.
 pub const MAX_DIAGNOSTIC_BYTES: usize = 8 * 1024;
 const MAX_MESSAGE_ID_BYTES: usize = u16::MAX as usize;
 const MAX_FRAME_BYTES: usize = 1 + 1 + 2 + MAX_MESSAGE_ID_BYTES + 4 + MAX_CONTROL_PAYLOAD_BYTES;
@@ -26,26 +96,71 @@ const RESPONSE_ACCEPTED: u8 = 0x00;
 const RESPONSE_REJECTED: u8 = 0x01;
 const RESPONSE_ERROR: u8 = 0x02;
 
+/// Request forwarded from `vsock-guest` to the connected control sink.
+///
+/// The request payload is opaque to this crate. This crate only frames it,
+/// enforces the payload size limit, and preserves the message id used to match
+/// the response.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ControlRequest {
+    /// Non-empty UTF-8 message id used to correlate the response.
+    ///
+    /// On the wire this is encoded as `[2B message_id_len][message_id]`.
     pub message_id: String,
+
+    /// Opaque request payload bytes.
+    ///
+    /// On the wire this is encoded after the message id as
+    /// `[4B payload_len][payload]`.
     pub payload: Vec<u8>,
 }
 
+/// Response returned by the connected control sink.
+///
+/// `vsock-guest` maps this local response into the outer host/guest
+/// control-result protocol.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ControlResponse {
+    /// Message id copied from the corresponding [`ControlRequest`].
     pub message_id: String,
+
+    /// Local sink outcome.
     pub status: ControlResponseStatus,
+
+    /// Optional diagnostic text for rejected or failed requests.
+    ///
+    /// The diagnostic may be empty and is bounded by [`MAX_DIAGNOSTIC_BYTES`].
     pub diagnostic: String,
 }
 
+/// Local control sink response status.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ControlResponseStatus {
+    /// The control sink accepted and handled the request.
+    ///
+    /// `vsock-guest` maps this to the outer delivered status.
     Accepted,
+
+    /// The control sink understood the request but declined it as an
+    /// application-level outcome.
+    ///
+    /// `vsock-guest` maps this to the outer rejected status without treating
+    /// the sink connection as broken.
     Rejected,
+
+    /// The control sink failed while processing the request.
+    ///
+    /// `vsock-guest` maps this to the outer sink-error status. This status is
+    /// distinct from local transport or frame parsing errors, which are
+    /// returned as `io::Error` by the read/write helpers.
     Error,
 }
 
+/// Build the abstract socket name for an operation-control endpoint.
+///
+/// The name includes the guest operation sequence number and a hexadecimal
+/// encoding of the 16-byte control nonce. The returned string is suitable for
+/// [`bind_abstract_listener`], [`connect_abstract`], and [`BOOTSTRAP_ENV`].
 pub fn endpoint_name(seq: u32, nonce: &[u8; 16]) -> String {
     let mut out = format!("vm0-process-control-{seq}-");
     for byte in nonce {
@@ -54,6 +169,16 @@ pub fn endpoint_name(seq: u32, nonce: &[u8; 16]) -> String {
     out
 }
 
+/// Bind a Linux abstract Unix listener for an operation-control endpoint name.
+///
+/// `name` is an abstract socket name, not a filesystem path. The resulting
+/// listener is suitable for [`accept_with_timeout`].
+///
+/// # Errors
+///
+/// Returns `InvalidInput` when `name` is empty, contains a NUL byte, or does
+/// not fit in `sockaddr_un.sun_path`. Socket creation, bind, and listen
+/// failures are returned as operating-system `io::Error` values.
 pub fn bind_abstract_listener(name: &str) -> io::Result<UnixListener> {
     let fd = create_unix_socket()?;
     let addr = abstract_sockaddr(name)?;
@@ -78,6 +203,17 @@ pub fn bind_abstract_listener(name: &str) -> io::Result<UnixListener> {
     Ok(unsafe { UnixListener::from_raw_fd(fd.into_raw_fd()) })
 }
 
+/// Connect to a Linux abstract Unix operation-control endpoint.
+///
+/// `name` is an abstract socket name, not a filesystem path. A newly connected
+/// guest-agent side stream must send [`write_hello`] before the server side
+/// treats the sink as connected.
+///
+/// # Errors
+///
+/// Returns `InvalidInput` when `name` is empty, contains a NUL byte, or does
+/// not fit in `sockaddr_un.sun_path`. Socket creation and connect failures are
+/// returned as operating-system `io::Error` values.
 pub fn connect_abstract(name: &str) -> io::Result<UnixStream> {
     let fd = create_unix_socket()?;
     let addr = abstract_sockaddr(name)?;
@@ -97,6 +233,15 @@ pub fn connect_abstract(name: &str) -> io::Result<UnixStream> {
     Ok(unsafe { UnixStream::from_raw_fd(fd.into_raw_fd()) })
 }
 
+/// Accept one stream from an operation-control listener before `timeout` elapses.
+///
+/// The listener is expected to come from [`bind_abstract_listener`].
+///
+/// # Errors
+///
+/// Returns `InvalidInput` if the timeout deadline overflows. Returns
+/// `TimedOut` if no connection is accepted before the deadline. Poll and accept
+/// failures are returned as operating-system `io::Error` values.
 pub fn accept_with_timeout(listener: &UnixListener, timeout: Duration) -> io::Result<UnixStream> {
     let deadline = Instant::now()
         .checked_add(timeout)
@@ -133,10 +278,26 @@ pub fn accept_with_timeout(listener: &UnixListener, timeout: Duration) -> io::Re
     }
 }
 
+/// Write the required hello frame to a connected stream.
+///
+/// The hello frame has kind `0x01` and an empty payload. `guest-agent` writes
+/// this immediately after connecting, and `vsock-guest` reads it before marking
+/// the sink connected.
+///
+/// # Errors
+///
+/// Stream write failures are returned as standard library `io::Error` values.
 pub fn write_hello(stream: &mut UnixStream) -> io::Result<()> {
     write_frame(stream, FRAME_HELLO, &[])
 }
 
+/// Read and validate the required hello frame from a connected stream.
+///
+/// # Errors
+///
+/// Returns `InvalidData` if the next frame is not a hello frame with an empty
+/// payload, has an invalid length, or has an unsupported frame version. Stream
+/// read failures are returned as standard library `io::Error` values.
 pub fn read_hello(stream: &mut UnixStream) -> io::Result<()> {
     let frame = read_frame(stream)?;
     if frame.kind != FRAME_HELLO || !frame.payload.is_empty() {
@@ -148,6 +309,19 @@ pub fn read_hello(stream: &mut UnixStream) -> io::Result<()> {
     Ok(())
 }
 
+/// Write a request frame to a connected control sink stream.
+///
+/// The request payload layout is:
+///
+/// ```text
+/// [2B message_id_len][message_id][4B payload_len][payload]
+/// ```
+///
+/// # Errors
+///
+/// Returns `InvalidInput` if the message id is empty, the message id does not
+/// fit in `u16`, or the payload exceeds [`MAX_CONTROL_PAYLOAD_BYTES`]. Stream
+/// write failures are returned as standard library `io::Error` values.
 pub fn write_request(stream: &mut UnixStream, request: &ControlRequest) -> io::Result<()> {
     let message_id = request.message_id.as_bytes();
     if message_id.is_empty() || message_id.len() > MAX_MESSAGE_ID_BYTES {
@@ -170,6 +344,15 @@ pub fn write_request(stream: &mut UnixStream, request: &ControlRequest) -> io::R
     write_frame(stream, FRAME_REQUEST, &payload)
 }
 
+/// Read and decode a request frame from a connected control sink stream.
+///
+/// # Errors
+///
+/// Returns `InvalidData` if the next frame is not a request frame or if the
+/// frame envelope or request payload is malformed, truncated, contains invalid
+/// UTF-8, contains trailing bytes, or declares a payload larger than
+/// [`MAX_CONTROL_PAYLOAD_BYTES`]. Stream read failures are returned as standard
+/// library `io::Error` values.
 pub fn read_request(stream: &mut UnixStream) -> io::Result<ControlRequest> {
     let frame = read_frame(stream)?;
     if frame.kind != FRAME_REQUEST {
@@ -181,6 +364,19 @@ pub fn read_request(stream: &mut UnixStream) -> io::Result<ControlRequest> {
     decode_request(&frame.payload)
 }
 
+/// Write a response frame to a connected control sink stream.
+///
+/// The response payload layout is:
+///
+/// ```text
+/// [2B message_id_len][message_id][1B status][2B diagnostic_len][diagnostic]
+/// ```
+///
+/// # Errors
+///
+/// Returns `InvalidInput` if the message id is empty, the message id does not
+/// fit in `u16`, or the diagnostic exceeds [`MAX_DIAGNOSTIC_BYTES`]. Stream
+/// write failures are returned as standard library `io::Error` values.
 pub fn write_response(stream: &mut UnixStream, response: &ControlResponse) -> io::Result<()> {
     let message_id = response.message_id.as_bytes();
     let diagnostic = response.diagnostic.as_bytes();
@@ -209,6 +405,15 @@ pub fn write_response(stream: &mut UnixStream, response: &ControlResponse) -> io
     write_frame(stream, FRAME_RESPONSE, &payload)
 }
 
+/// Read and decode a response frame from a connected control sink stream.
+///
+/// # Errors
+///
+/// Returns `InvalidData` if the next frame is not a response frame or if the
+/// frame envelope or response payload is malformed, truncated, contains invalid
+/// UTF-8, contains trailing bytes, contains an unknown status byte, or declares
+/// a diagnostic larger than [`MAX_DIAGNOSTIC_BYTES`]. Stream read failures are
+/// returned as standard library `io::Error` values.
 pub fn read_response(stream: &mut UnixStream) -> io::Result<ControlResponse> {
     let frame = read_frame(stream)?;
     if frame.kind != FRAME_RESPONSE {


### PR DESCRIPTION
## Summary

- Expand `process-control-ipc` crate rustdoc into an authoritative local IPC protocol reference.
- Document every public constant, type, field, enum variant, and function in the crate.
- Add a crate-local `#![deny(missing_docs)]` guard to prevent this protocol API from regressing.

Closes #14251

## Testing

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo doc --manifest-path crates/Cargo.toml -p process-control-ipc --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p process-control-ipc`
- `CARGO_BUILD_JOBS=1 cargo doc --workspace --all-features --no-deps`

## Notes

The initial pre-commit hook run executed `cargo clippy --all-targets --all-features` successfully, but its parallel `cargo doc --workspace --all-features --no-deps` job hit an OOM while writing generated docs. The same workspace doc command passed when rerun with `CARGO_BUILD_JOBS=1`, so the commit was created after the equivalent doc check succeeded.