### PR TITLE
refactor: unify guest binary chmod finalization

### DIFF
--- a/crates/runner/src/cmd/build.rs
+++ b/crates/runner/src/cmd/build.rs
@@ -469,32 +469,25 @@ async fn resolve_guest(
                 dest.display()
             ))
         })?;
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            tokio::fs::set_permissions(&dest, std::fs::Permissions::from_mode(0o755))
-                .await
-                .map_err(|e| RunnerError::Internal(format!("chmod {name}: {e}")))?;
-        }
-        return Ok(dest);
-    }
-    if let Some(bytes) = bundled_guest(name) {
+    } else if let Some(bytes) = bundled_guest(name) {
         tokio::fs::write(&dest, bytes)
             .await
             .map_err(|e| RunnerError::Internal(format!("write bundled {name}: {e}")))?;
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            tokio::fs::set_permissions(&dest, std::fs::Permissions::from_mode(0o755))
-                .await
-                .map_err(|e| RunnerError::Internal(format!("chmod {name}: {e}")))?;
-        }
-        return Ok(dest);
+    } else {
+        return Err(RunnerError::Internal(format!(
+            "missing --{} and no bundled binary available",
+            name
+        )));
     }
-    Err(RunnerError::Internal(format!(
-        "missing --{} and no bundled binary available",
-        name
-    )))
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        tokio::fs::set_permissions(&dest, std::fs::Permissions::from_mode(0o755))
+            .await
+            .map_err(|e| RunnerError::Internal(format!("chmod {name}: {e}")))?;
+    }
+    Ok(dest)
 }
 
 /// Build an image (template from R2 cache or local build, snapshot always local).


### PR DESCRIPTION
## Summary

- Materialize guest binaries in `resolve_guest` from either CLI path or bundled bytes before shared finalization.
- Move Unix `chmod 0o755` and `Ok(dest)` into one successful tail path.
- Preserve CLI path priority and existing copy/write/chmod error behavior.

Closes #14255

## Tests

- `cargo fmt --manifest-path crates/Cargo.toml --all`
- `cargo test --manifest-path crates/Cargo.toml -p runner resolve_guest_snapshots_cli_binary_into_temp_dir`
- pre-commit hooks: cargo-fmt, cargo-clippy, cargo-doc
