### PR TITLE
ci: fetch full history for turbo ts detection

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -69,7 +69,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          fetch-depth: 2
+          fetch-depth: 0
 
       - name: Detect Turbo TypeScript check need
         id: detect


### PR DESCRIPTION
## Summary

- Fix detect-turbo-ts-checks failing in pull_request workflows when the event base SHA is not present in a shallow checkout.
- Use full checkout history for the lightweight detection job, matching the existing prepare job that also runs git merge-base against the PR base SHA.

## Tests

- git diff --check
- python3 YAML parse for .github/workflows/turbo.yml
- local merge-base/diff check with failing base SHA d9b2caf5183879554f8a59f45827fda7c6887c36
