### PR TITLE
fix: polish desktop sidebar titlebar

### DIFF
--- a/turbo/apps/desktop/src/desktop-window-chrome-electron.ts
+++ b/turbo/apps/desktop/src/desktop-window-chrome-electron.ts
@@ -1,0 +1,56 @@
+import type { IpcMainInvokeEvent } from "electron";
+import { BrowserWindow, ipcMain } from "electron";
+import { DESKTOP_WINDOW_CHROME_CHANNELS } from "./desktop-window-chrome-ipc-channels";
+import { applyDesktopWindowTrafficLightLayout } from "./desktop-window-chrome";
+
+interface DesktopWindowChromeIpcOptions {
+  readonly allowedAppOrigins: ReadonlySet<string>;
+  readonly platform: NodeJS.Platform;
+}
+
+function isAllowedAppPage(
+  rawUrl: string,
+  allowedAppOrigins: ReadonlySet<string>,
+): boolean {
+  try {
+    return allowedAppOrigins.has(new URL(rawUrl).origin);
+  } catch {
+    return false;
+  }
+}
+
+function assertAppPage(
+  event: IpcMainInvokeEvent,
+  allowedAppOrigins: ReadonlySet<string>,
+): void {
+  if (!isAllowedAppPage(event.senderFrame?.url ?? "", allowedAppOrigins)) {
+    throw new Error("Desktop window chrome is unavailable on this page");
+  }
+}
+
+function booleanArg(value: unknown): boolean {
+  if (typeof value !== "boolean") {
+    throw new Error("Expected sidebar collapsed state");
+  }
+  return value;
+}
+
+export function installDesktopWindowChromeIpc(
+  options: DesktopWindowChromeIpcOptions,
+): void {
+  ipcMain.handle(
+    DESKTOP_WINDOW_CHROME_CHANNELS.setSidebarCollapsed,
+    (event: IpcMainInvokeEvent, value: unknown) => {
+      assertAppPage(event, options.allowedAppOrigins);
+      const window = BrowserWindow.fromWebContents(event.sender);
+      if (!window || window.isDestroyed()) {
+        return;
+      }
+      applyDesktopWindowTrafficLightLayout(
+        window,
+        options.platform,
+        booleanArg(value) ? "collapsed" : "expanded",
+      );
+    },
+  );
+}

--- a/turbo/apps/desktop/src/desktop-window-chrome-ipc-channels.ts
+++ b/turbo/apps/desktop/src/desktop-window-chrome-ipc-channels.ts
@@ -1,0 +1,3 @@
+export const DESKTOP_WINDOW_CHROME_CHANNELS = {
+  setSidebarCollapsed: "desktop-window-chrome:set-sidebar-collapsed",
+} as const;

--- a/turbo/apps/desktop/src/desktop-window-chrome.ts
+++ b/turbo/apps/desktop/src/desktop-window-chrome.ts
@@ -3,7 +3,7 @@ type DesktopWindowChromeOptions = Pick<
   "titleBarStyle" | "trafficLightPosition"
 >;
 
-export type DesktopWindowTrafficLightLayout = "expanded" | "collapsed";
+type DesktopWindowTrafficLightLayout = "expanded" | "collapsed";
 
 const EXPANDED_TRAFFIC_LIGHT_POSITION: Electron.Point = { x: 16, y: 18 };
 const COLLAPSED_TRAFFIC_LIGHT_POSITION: Electron.Point = { x: 8, y: 18 };

--- a/turbo/apps/desktop/src/desktop-window-chrome.ts
+++ b/turbo/apps/desktop/src/desktop-window-chrome.ts
@@ -3,6 +3,31 @@ type DesktopWindowChromeOptions = Pick<
   "titleBarStyle" | "trafficLightPosition"
 >;
 
+export type DesktopWindowTrafficLightLayout = "expanded" | "collapsed";
+
+const EXPANDED_TRAFFIC_LIGHT_POSITION: Electron.Point = { x: 16, y: 18 };
+const COLLAPSED_TRAFFIC_LIGHT_POSITION: Electron.Point = { x: 8, y: 18 };
+
+export function desktopWindowTrafficLightPosition(
+  layout: DesktopWindowTrafficLightLayout,
+): Electron.Point {
+  if (layout === "collapsed") {
+    return COLLAPSED_TRAFFIC_LIGHT_POSITION;
+  }
+  return EXPANDED_TRAFFIC_LIGHT_POSITION;
+}
+
+export function applyDesktopWindowTrafficLightLayout(
+  window: Pick<Electron.BrowserWindow, "setWindowButtonPosition">,
+  platform: NodeJS.Platform,
+  layout: DesktopWindowTrafficLightLayout,
+): void {
+  if (platform !== "darwin") {
+    return;
+  }
+  window.setWindowButtonPosition(desktopWindowTrafficLightPosition(layout));
+}
+
 export function buildDesktopWindowChromeOptions(
   platform: NodeJS.Platform,
 ): DesktopWindowChromeOptions {
@@ -12,6 +37,6 @@ export function buildDesktopWindowChromeOptions(
 
   return {
     titleBarStyle: "hiddenInset",
-    trafficLightPosition: { x: 16, y: 18 },
+    trafficLightPosition: desktopWindowTrafficLightPosition("expanded"),
   };
 }

--- a/turbo/apps/desktop/src/desktop-window-lifecycle.test.ts
+++ b/turbo/apps/desktop/src/desktop-window-lifecycle.test.ts
@@ -2,7 +2,11 @@ import {
   shouldHideMainWindowOnClose,
   showAndFocusWindow,
 } from "./desktop-window-lifecycle";
-import { buildDesktopWindowChromeOptions } from "./desktop-window-chrome";
+import {
+  applyDesktopWindowTrafficLightLayout,
+  buildDesktopWindowChromeOptions,
+  desktopWindowTrafficLightPosition,
+} from "./desktop-window-chrome";
 
 describe("desktop window lifecycle", () => {
   it("uses integrated macOS window chrome", () => {
@@ -14,6 +18,28 @@ describe("desktop window lifecycle", () => {
 
   it("keeps non-macOS window chrome default", () => {
     expect(buildDesktopWindowChromeOptions("linux")).toStrictEqual({});
+  });
+
+  it("uses a left-aligned traffic light position for the collapsed sidebar", () => {
+    expect(desktopWindowTrafficLightPosition("collapsed")).toStrictEqual({
+      x: 8,
+      y: 18,
+    });
+  });
+
+  it("updates traffic lights on macOS only", () => {
+    const window = {
+      setWindowButtonPosition: vi.fn(),
+    };
+
+    applyDesktopWindowTrafficLightLayout(window, "darwin", "collapsed");
+    expect(window.setWindowButtonPosition).toHaveBeenCalledWith({
+      x: 8,
+      y: 18,
+    });
+
+    applyDesktopWindowTrafficLightLayout(window, "linux", "expanded");
+    expect(window.setWindowButtonPosition).toHaveBeenCalledOnce();
   });
 
   it("hides the main window on macOS close unless the app is quitting", () => {

--- a/turbo/apps/desktop/src/main.ts
+++ b/turbo/apps/desktop/src/main.ts
@@ -46,6 +46,7 @@ import {
   shouldHideMainWindowOnClose,
   showAndFocusWindow,
 } from "./desktop-window-lifecycle";
+import { installDesktopWindowChromeIpc } from "./desktop-window-chrome-electron";
 import { buildDesktopWindowChromeOptions } from "./desktop-window-chrome";
 import { buildSignedOutPageUrl } from "./signed-out-page";
 import { decideWindowOpen, isAllowedAppNavigation } from "./window-policy";
@@ -519,6 +520,10 @@ if (!hasSingleInstanceLock) {
     applyDockIcon();
     applyApplicationMenu();
     registerDesktopAuthProtocol();
+    installDesktopWindowChromeIpc({
+      allowedAppOrigins: config.allowedAppOrigins,
+      platform: process.platform,
+    });
     installDesktopLocalAgent();
     installComputerUse();
     queueDesktopAuthCallbackArgv(process.argv);

--- a/turbo/apps/desktop/src/preload.ts
+++ b/turbo/apps/desktop/src/preload.ts
@@ -1,6 +1,7 @@
 import { contextBridge, ipcRenderer } from "electron";
 import { COMPUTER_USE_CHANNELS } from "./computer-use-ipc-channels";
 import { DESKTOP_LOCAL_AGENT_CHANNELS } from "./desktop-local-agent-ipc-channels";
+import { DESKTOP_WINDOW_CHROME_CHANNELS } from "./desktop-window-chrome-ipc-channels";
 import type {
   ComputerUseApprovalAction,
   DesktopComputerUseState,
@@ -82,5 +83,18 @@ const desktopComputerUseApi = {
   },
 };
 
+const desktopWindowChromeApi = {
+  setSidebarCollapsed(collapsed: boolean): Promise<void> {
+    return ipcRenderer.invoke(
+      DESKTOP_WINDOW_CHROME_CHANNELS.setSidebarCollapsed,
+      collapsed,
+    );
+  },
+};
+
 contextBridge.exposeInMainWorld("vm0DesktopLocalAgent", desktopLocalAgentApi);
 contextBridge.exposeInMainWorld("vm0DesktopComputerUse", desktopComputerUseApi);
+contextBridge.exposeInMainWorld(
+  "vm0DesktopWindowChrome",
+  desktopWindowChromeApi,
+);

--- a/turbo/apps/platform/src/global.d.ts
+++ b/turbo/apps/platform/src/global.d.ts
@@ -115,6 +115,10 @@ interface DesktopComputerUseApi {
   readonly subscribe: (callback: () => void) => () => void;
 }
 
+interface DesktopWindowChromeApi {
+  readonly setSidebarCollapsed: (collapsed: boolean) => Promise<void>;
+}
+
 interface DesktopLocalAgentApi {
   readonly setEnabled: (enabled: boolean) => Promise<void>;
   readonly list: () => Promise<DesktopLocalAgentEntry[]>;
@@ -134,6 +138,7 @@ declare global {
     _vm0: VM0Global | undefined;
     vm0DesktopLocalAgent?: DesktopLocalAgentApi;
     vm0DesktopComputerUse?: DesktopComputerUseApi;
+    vm0DesktopWindowChrome?: DesktopWindowChromeApi;
     /**
      * Set inline in `index.html` at the start of `<head>` parsing. Used by
      * `captureFirstSkeletonHide` to measure total time from page entry to

--- a/turbo/apps/platform/src/views/css/index.css
+++ b/turbo/apps/platform/src/views/css/index.css
@@ -47,8 +47,7 @@
   padding-top: calc(0.375rem + var(--sat));
 }
 
-.zero-desktop-titlebar-drag-region,
-.zero-desktop-workspace-drag-region {
+.zero-desktop-titlebar-drag-region {
   display: none;
 }
 
@@ -61,8 +60,7 @@
     padding-top: 0;
   }
 
-  .zero-app[data-desktop-shell] .zero-desktop-titlebar-drag-region,
-  .zero-app[data-desktop-shell] .zero-desktop-workspace-drag-region {
+  .zero-app[data-desktop-shell] .zero-desktop-titlebar-drag-region {
     display: block;
     flex-shrink: 0;
     height: var(--zero-desktop-titlebar-height);

--- a/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-layout.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-layout.test.tsx
@@ -10,7 +10,7 @@
  * - Real (internal): All signals, components, rendering
  */
 
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
@@ -30,6 +30,8 @@ const DEFAULT_AGENT_ID = "c0000000-0000-4000-a000-000000000001";
 
 afterEach(() => {
   Reflect.deleteProperty(window, "vm0DesktopLocalAgent");
+  Reflect.deleteProperty(window, "vm0DesktopComputerUse");
+  Reflect.deleteProperty(window, "vm0DesktopWindowChrome");
 });
 
 function mockBaseAPIs() {
@@ -237,6 +239,36 @@ describe("sidebar layout - desktop shell text selection scope (SIDEBAR-D-056)", 
       expect(document.querySelector(".zero-app")).not.toHaveAttribute(
         "data-desktop-shell",
       );
+    });
+  });
+
+  it("syncs collapsed sidebar state to the desktop window chrome bridge", async () => {
+    const user = userEvent.setup();
+    const setSidebarCollapsed = vi.fn(() => {
+      return Promise.resolve();
+    });
+    mockBaseAPIs();
+    Object.defineProperty(window, "vm0DesktopWindowChrome", {
+      configurable: true,
+      value: { setSidebarCollapsed },
+    });
+
+    detachedSetupPage({ context, path: "/agents" });
+
+    await waitFor(() => {
+      expect(setSidebarCollapsed).toHaveBeenCalledWith(false);
+    });
+
+    await user.keyboard("{Control>}b{/Control}");
+
+    await waitFor(() => {
+      expect(setSidebarCollapsed).toHaveBeenCalledWith(true);
+    });
+
+    await user.keyboard("{Control>}b{/Control}");
+
+    await waitFor(() => {
+      expect(setSidebarCollapsed).toHaveBeenCalledWith(false);
     });
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/sidebar-layout.tsx
+++ b/turbo/apps/platform/src/views/zero-page/sidebar-layout.tsx
@@ -272,7 +272,10 @@ function SidebarLayoutInner({ children }: { children: ReactNode }) {
   const expanded = useGet(sidebarExpanded$);
   const setExpanded = useSet(setSidebarExpanded$);
   const isDesktopShell =
-    typeof window !== "undefined" && window.vm0DesktopLocalAgent !== undefined;
+    typeof window !== "undefined" &&
+    (window.vm0DesktopLocalAgent !== undefined ||
+      window.vm0DesktopComputerUse !== undefined ||
+      window.vm0DesktopWindowChrome !== undefined);
 
   return (
     <div
@@ -291,10 +294,6 @@ function SidebarLayoutInner({ children }: { children: ReactNode }) {
         }}
       />
       <div className="flex flex-1 flex-col min-w-0 min-h-0 zero-workspace-bg">
-        <div
-          className="zero-desktop-workspace-drag-region"
-          aria-hidden="true"
-        />
         <InstallBanner />
         <IosInstallModal />
         <MobileTopBar />

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -67,6 +67,30 @@ export { AccountDropdown } from "./zero-sidebar-account.tsx";
 
 type NavIcon = (props: { size?: number; className?: string }) => ReactNode;
 
+function syncDesktopTrafficLights(collapsed: boolean): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+  const promise = window.vm0DesktopWindowChrome?.setSidebarCollapsed(collapsed);
+  if (promise) {
+    detach(promise, Reason.DomCallback);
+  }
+}
+
+function syncCollapsedDesktopTrafficLightsRef(element: HTMLDivElement | null) {
+  if (!element) {
+    return;
+  }
+  syncDesktopTrafficLights(true);
+}
+
+function syncExpandedDesktopTrafficLightsRef(element: HTMLDivElement | null) {
+  if (!element) {
+    return;
+  }
+  syncDesktopTrafficLights(false);
+}
+
 interface ManageNavItem {
   readonly id: SidebarNavId;
   readonly activeKeys: readonly RouteKey[];
@@ -256,7 +280,11 @@ function CollapsedSidebar() {
   }
   return (
     <aside className="zero-nav zero-collapsed-sidebar box-border hidden md:flex h-full w-16 shrink-0 flex-col border-r-[0.7px] border-sidebar-border bg-sidebar px-2 transition-all duration-300">
-      <div className="zero-desktop-titlebar-drag-region" aria-hidden="true" />
+      <div
+        ref={syncCollapsedDesktopTrafficLightsRef}
+        className="zero-desktop-titlebar-drag-region"
+        aria-hidden="true"
+      />
       <CollapsedExpandButton />
       <CollapsedNavList />
       <CollapsedFooter />
@@ -418,7 +446,11 @@ function ExpandedHeader() {
   const onCollapse = useSidebarCollapseToggle();
   return (
     <div className="zero-sidebar-header shrink-0 px-2 pb-0">
-      <div className="zero-desktop-titlebar-drag-region" aria-hidden="true" />
+      <div
+        ref={syncExpandedDesktopTrafficLightsRef}
+        className="zero-desktop-titlebar-drag-region"
+        aria-hidden="true"
+      />
       <div className="zero-desktop-no-drag flex items-center justify-between gap-2 rounded-lg py-0.5">
         <div className="min-w-0 flex-1">
           <ZeroOrgSwitcher />


### PR DESCRIPTION
## Summary
- remove the desktop-only workspace top drag spacer so main content starts at the top
- keep titlebar spacing scoped to the sidebar and shift macOS traffic lights left when collapsed
- expose a small desktop window chrome bridge for sidebar collapsed state

## Validation
- pnpm -F @vm0/desktop check-types
- pnpm -F @vm0/app check-types
- pnpm -F @vm0/desktop lint
- pnpm -F @vm0/app lint
- pnpm -F @vm0/desktop test
- pnpm -F @vm0/app build
- pnpm -F @vm0/desktop make

## Notes
- Local targeted sidebar-layout vitest still fails to mount the page in this environment; all existing tests in that file fail with an empty body, so CI remains the authoritative run.