### PR TITLE
feat: make computer use host connection manual

### DIFF
--- a/turbo/apps/desktop/src/computer-use-electron.ts
+++ b/turbo/apps/desktop/src/computer-use-electron.ts
@@ -13,6 +13,7 @@ interface ComputerUseIpcOptions {
 
 interface ComputerUseNativeApi {
   readonly getState: () => DesktopComputerUseState;
+  readonly start: () => Promise<DesktopComputerUseState>;
   readonly requestAccessibilityPermission: () => DesktopComputerUseState;
   readonly decideCommand: (
     action: ComputerUseApprovalAction,
@@ -60,6 +61,10 @@ export function installComputerUseIpc(
   ipcMain.handle(COMPUTER_USE_CHANNELS.getState, (event) => {
     assertComputerUsePage(event);
     return api.getState();
+  });
+  ipcMain.handle(COMPUTER_USE_CHANNELS.start, async (event) => {
+    assertComputerUsePage(event);
+    return api.start();
   });
   ipcMain.handle(
     COMPUTER_USE_CHANNELS.requestAccessibilityPermission,

--- a/turbo/apps/desktop/src/computer-use-host.test.ts
+++ b/turbo/apps/desktop/src/computer-use-host.test.ts
@@ -1,0 +1,146 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  ComputerUseHostRuntime,
+  type ComputerUseHostFetch,
+} from "./computer-use-host";
+
+function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(body), {
+    headers: { "content-type": "application/json" },
+    ...init,
+  });
+}
+
+function createRuntime(
+  options: {
+    readonly sessionFetch?: ComputerUseHostFetch;
+    readonly hostFetch?: ComputerUseHostFetch;
+  } = {},
+) {
+  const sessionFetch =
+    options.sessionFetch ??
+    vi.fn<ComputerUseHostFetch>(async () => {
+      return jsonResponse({ hostId: "host-1", hostToken: "token-1" });
+    });
+  const hostFetch =
+    options.hostFetch ??
+    vi.fn<ComputerUseHostFetch>(async () => {
+      return jsonResponse({ status: "idle" });
+    });
+  const runtime = new ComputerUseHostRuntime({
+    platformUrl: new URL("https://app.vm0.ai"),
+    displayName: "Zero Desktop",
+    appVersion: "1.2.3",
+    sessionFetch,
+    hostFetch,
+    getPermissions() {
+      return { accessibility: true, screenRecording: false };
+    },
+    async executeCommand() {
+      return { status: "succeeded", result: {} };
+    },
+  });
+  return { runtime, sessionFetch, hostFetch };
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("ComputerUseHostRuntime", () => {
+  it("does not register a host until manually started", async () => {
+    vi.useFakeTimers();
+    const { runtime, sessionFetch, hostFetch } = createRuntime();
+
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(runtime.getState().status).toBe("idle");
+    expect(sessionFetch).not.toHaveBeenCalled();
+    expect(hostFetch).not.toHaveBeenCalled();
+  });
+
+  it("registers the host on manual start without requiring Screen Recording", async () => {
+    const sessionFetch = vi.fn<ComputerUseHostFetch>(async () => {
+      return jsonResponse({ hostId: "host-1", hostToken: "token-1" });
+    });
+    const { runtime, hostFetch } = createRuntime({ sessionFetch });
+
+    await runtime.start();
+
+    expect(sessionFetch).toHaveBeenCalledOnce();
+    const call = sessionFetch.mock.calls[0];
+    if (!call) {
+      throw new Error("Expected Computer Use host registration request");
+    }
+    const [url, init] = call;
+    expect(url).toBe("https://api.vm0.ai/api/zero/computer-use/hosts/start");
+    expect(init?.method).toBe("POST");
+    expect(JSON.parse(String(init?.body))).toMatchObject({
+      hostName: "Zero Desktop",
+      appVersion: "1.2.3",
+      permissions: {
+        accessibility: true,
+        screenRecording: false,
+      },
+    });
+    expect(runtime.getState()).toMatchObject({
+      status: "online",
+      hostId: "host-1",
+      lastError: null,
+    });
+    expect(hostFetch).not.toHaveBeenCalled();
+
+    runtime.stop();
+  });
+
+  it("uses the host bearer token for polling after registration", async () => {
+    vi.useFakeTimers();
+    const sessionFetch = vi.fn<ComputerUseHostFetch>(async () => {
+      return jsonResponse({ hostId: "host-1", hostToken: "token-1" });
+    });
+    const hostFetch = vi.fn<ComputerUseHostFetch>(async (url) => {
+      if (url.endsWith("/api/zero/computer-use/heartbeat")) {
+        return jsonResponse({ ok: true, hostId: "host-1" });
+      }
+      return jsonResponse({ status: "idle" });
+    });
+    const { runtime } = createRuntime({ sessionFetch, hostFetch });
+
+    await runtime.start();
+    await vi.advanceTimersByTimeAsync(2_000);
+
+    const heartbeatCall = hostFetch.mock.calls.find(([url]) => {
+      return url.endsWith("/api/zero/computer-use/heartbeat");
+    });
+    if (!heartbeatCall) {
+      throw new Error("Expected Computer Use heartbeat request");
+    }
+    const headers = new Headers(heartbeatCall[1]?.headers);
+    expect(headers.get("authorization")).toBe("Bearer token-1");
+    expect(headers.get("cookie")).toBeNull();
+    expect(sessionFetch.mock.calls[0]?.[0]).toBe(
+      "https://api.vm0.ai/api/zero/computer-use/hosts/start",
+    );
+
+    runtime.stop();
+  });
+
+  it("stops after a 401 registration response so retry stays manual", async () => {
+    vi.useFakeTimers();
+    const sessionFetch = vi.fn<ComputerUseHostFetch>(async () => {
+      return new Response("{}", { status: 401 });
+    });
+    const { runtime } = createRuntime({ sessionFetch });
+
+    await runtime.start();
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(sessionFetch).toHaveBeenCalledOnce();
+    expect(runtime.getState()).toMatchObject({
+      status: "unauthenticated",
+      hostId: null,
+      lastError:
+        "Desktop host could not authenticate with the API session. Sign in and retry.",
+    });
+  });
+});

--- a/turbo/apps/desktop/src/computer-use-host.ts
+++ b/turbo/apps/desktop/src/computer-use-host.ts
@@ -12,11 +12,9 @@ import type {
   ComputerUseRuntimeAuditEvent,
 } from "./computer-use-types";
 
-const START_RETRY_MS = 15_000;
 const ONLINE_POLL_MS = 2_000;
-const ERROR_RETRY_MS = 10_000;
 
-type ComputerUseHostFetch = (
+export type ComputerUseHostFetch = (
   input: string,
   init?: RequestInit,
 ) => Promise<Response>;
@@ -25,7 +23,8 @@ interface ComputerUseHostRuntimeOptions {
   readonly platformUrl: URL;
   readonly displayName: string;
   readonly appVersion: string;
-  readonly fetch: ComputerUseHostFetch;
+  readonly sessionFetch: ComputerUseHostFetch;
+  readonly hostFetch: ComputerUseHostFetch;
   readonly getPermissions: () => ComputerUsePermissionState;
   readonly executeCommand: (
     command: ComputerUseCommand,
@@ -86,7 +85,8 @@ export class ComputerUseHostRuntime {
   private readonly apiBaseUrl: string;
   private readonly displayName: string;
   private readonly appVersion: string;
-  private readonly fetch: ComputerUseHostFetch;
+  private readonly sessionFetch: ComputerUseHostFetch;
+  private readonly hostFetchRequest: ComputerUseHostFetch;
   private readonly getPermissions: () => ComputerUsePermissionState;
   private readonly executeCommand: ComputerUseHostRuntimeOptions["executeCommand"];
   private readonly onChange: () => void;
@@ -109,7 +109,8 @@ export class ComputerUseHostRuntime {
     this.apiBaseUrl = resolveComputerUseApiBaseUrl(options.platformUrl);
     this.displayName = options.displayName;
     this.appVersion = options.appVersion;
-    this.fetch = options.fetch;
+    this.sessionFetch = options.sessionFetch;
+    this.hostFetchRequest = options.hostFetch;
     this.getPermissions = options.getPermissions;
     this.executeCommand = options.executeCommand;
     this.onChange = options.onChange ?? (() => {});
@@ -117,12 +118,12 @@ export class ComputerUseHostRuntime {
     this.clearScheduledTimeout = options.clearTimeout ?? clearTimeout;
   }
 
-  start(): void {
+  async start(): Promise<void> {
     if (this.running) {
       return;
     }
     this.running = true;
-    this.schedule(0);
+    await this.tick();
   }
 
   stop(): void {
@@ -138,7 +139,7 @@ export class ComputerUseHostRuntime {
   }
 
   async decideCommand(args: ComputerUseApprovalAction): Promise<void> {
-    const response = await this.fetch(
+    const response = await this.sessionFetch(
       `${this.apiBaseUrl}/api/zero/computer-use/commands/${encodeURIComponent(args.commandId)}/approval`,
       {
         method: "POST",
@@ -183,13 +184,15 @@ export class ComputerUseHostRuntime {
   }
 
   private async tick(): Promise<void> {
-    let nextDelay = ONLINE_POLL_MS;
+    let nextDelay: number | null = ONLINE_POLL_MS;
     try {
       if (!this.hostToken) {
         nextDelay = await this.startHost();
       } else {
         if (await this.heartbeat()) {
           await this.claimAndExecuteCommand();
+        } else {
+          nextDelay = null;
         }
       }
     } catch (error) {
@@ -197,15 +200,19 @@ export class ComputerUseHostRuntime {
         status: "error",
         lastError: error instanceof Error ? error.message : String(error),
       });
-      nextDelay = ERROR_RETRY_MS;
+      nextDelay = null;
     } finally {
-      this.schedule(nextDelay);
+      if (nextDelay === null) {
+        this.running = false;
+      } else {
+        this.schedule(nextDelay);
+      }
     }
   }
 
-  private async startHost(): Promise<number> {
+  private async startHost(): Promise<number | null> {
     this.setState({ status: "connecting", lastError: null });
-    const response = await this.fetch(
+    const response = await this.sessionFetch(
       `${this.apiBaseUrl}/api/zero/computer-use/hosts/start`,
       {
         method: "POST",
@@ -214,12 +221,19 @@ export class ComputerUseHostRuntime {
       },
     );
     if (response.status === 401) {
-      this.setState({ status: "unauthenticated" });
-      return START_RETRY_MS;
+      this.setState({
+        status: "unauthenticated",
+        lastError:
+          "Desktop host could not authenticate with the API session. Sign in and retry.",
+      });
+      return null;
     }
     if (response.status === 403) {
-      this.setState({ status: "disabled" });
-      return START_RETRY_MS;
+      this.setState({
+        status: "disabled",
+        lastError: "Computer Use is disabled for this account.",
+      });
+      return null;
     }
     if (!response.ok) {
       throw new Error(`Failed to start Computer Use host: ${response.status}`);
@@ -243,7 +257,12 @@ export class ComputerUseHostRuntime {
     });
     if (response.status === 401) {
       this.hostToken = null;
-      this.setState({ status: "unauthenticated", hostId: null });
+      this.setState({
+        status: "unauthenticated",
+        hostId: null,
+        lastError:
+          "Desktop host could not authenticate with the API session. Sign in and retry.",
+      });
       return false;
     }
     if (!response.ok) {
@@ -270,7 +289,7 @@ export class ComputerUseHostRuntime {
     url.searchParams.set("hostId", hostId);
     url.searchParams.set("limit", "25");
 
-    const response = await this.fetch(url.toString(), { method: "GET" });
+    const response = await this.sessionFetch(url.toString(), { method: "GET" });
     if (response.status === 401 || response.status === 403) {
       this.setState({ pendingApprovals: [], recentAuditEvents: [] });
       return;
@@ -334,7 +353,7 @@ export class ComputerUseHostRuntime {
     if (!this.hostToken) {
       throw new Error("Computer Use host token is not available");
     }
-    return this.fetch(`${this.apiBaseUrl}${path}`, {
+    return this.hostFetchRequest(`${this.apiBaseUrl}${path}`, {
       ...init,
       headers: {
         "content-type": "application/json",

--- a/turbo/apps/desktop/src/computer-use-ipc-channels.ts
+++ b/turbo/apps/desktop/src/computer-use-ipc-channels.ts
@@ -1,5 +1,6 @@
 export const COMPUTER_USE_CHANNELS = {
   getState: "computer-use:get-state",
+  start: "computer-use:start",
   requestAccessibilityPermission: "computer-use:request-accessibility",
   openAccessibilitySettings: "computer-use:open-accessibility-settings",
   openScreenRecordingSettings: "computer-use:open-screen-recording-settings",

--- a/turbo/apps/desktop/src/desktop-computer-use-api.test.ts
+++ b/turbo/apps/desktop/src/desktop-computer-use-api.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDesktopComputerUseSessionFetch } from "./desktop-computer-use-api";
+import type { DesktopSessionCookieSource } from "./desktop-session-cookies";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("createDesktopComputerUseSessionFetch", () => {
+  it("forwards desktop session cookies to Computer Use host registration", async () => {
+    const cookieUrls: string[] = [];
+    const session: DesktopSessionCookieSource = {
+      cookies: {
+        async get(filter) {
+          cookieUrls.push(filter.url);
+          if (filter.url === "https://app.vm0.ai/") {
+            return [{ name: "app_session", value: "app-cookie" }];
+          }
+          if (
+            filter.url ===
+            "https://api.vm0.ai/api/zero/computer-use/hosts/start"
+          ) {
+            return [{ name: "api_session", value: "api-cookie" }];
+          }
+          return [];
+        },
+      },
+    };
+    const fetchMock = vi.fn(
+      async (
+        _input: string | URL | Request,
+        _init?: RequestInit,
+      ): Promise<Response> => {
+        return jsonResponse({});
+      },
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const sessionFetch = createDesktopComputerUseSessionFetch({
+      platformUrl: new URL("https://app.vm0.ai"),
+      session,
+    });
+    await sessionFetch("https://api.vm0.ai/api/zero/computer-use/hosts/start", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+    });
+
+    expect(cookieUrls).toStrictEqual([
+      "https://app.vm0.ai/",
+      "https://api.vm0.ai/api/zero/computer-use/hosts/start",
+    ]);
+    const call = fetchMock.mock.calls[0];
+    if (!call) {
+      throw new Error("Expected fetch to be called");
+    }
+    const init = call[1];
+    if (!init) {
+      throw new Error("Expected fetch init");
+    }
+    const headers = new Headers(init.headers);
+    expect(headers.get("content-type")).toBe("application/json");
+    expect(headers.get("cookie")).toBe(
+      "app_session=app-cookie; api_session=api-cookie",
+    );
+  });
+});
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    headers: { "content-type": "application/json" },
+  });
+}

--- a/turbo/apps/desktop/src/desktop-computer-use-api.ts
+++ b/turbo/apps/desktop/src/desktop-computer-use-api.ts
@@ -1,0 +1,20 @@
+import type { ComputerUseHostFetch } from "./computer-use-host";
+import {
+  headersWithSessionCookies,
+  type DesktopSessionCookieSource,
+} from "./desktop-session-cookies";
+
+export function createDesktopComputerUseSessionFetch(params: {
+  readonly platformUrl: URL;
+  readonly session: DesktopSessionCookieSource;
+}): ComputerUseHostFetch {
+  return async (input, init) => {
+    const requestUrl = new URL(input);
+    const headers = await headersWithSessionCookies(
+      params.session,
+      [params.platformUrl, requestUrl],
+      init?.headers,
+    );
+    return fetch(input, { ...init, headers });
+  };
+}

--- a/turbo/apps/desktop/src/desktop-local-agent-api.ts
+++ b/turbo/apps/desktop/src/desktop-local-agent-api.ts
@@ -4,6 +4,7 @@ import type {
   DesktopLocalAgentHostStartResponse,
   DesktopLocalAgentJobNextResponse,
 } from "./desktop-local-agent-types";
+import { headersWithSessionCookies } from "./desktop-session-cookies";
 
 interface ApiErrorBody {
   readonly error?: {
@@ -105,20 +106,6 @@ function bearerHeaders(hostToken: string): HeadersInit {
   };
 }
 
-async function cookieHeaderForSession(
-  electronSession: Session,
-  urls: readonly URL[],
-): Promise<string> {
-  const pairs = new Map<string, string>();
-  for (const url of urls) {
-    const cookies = await electronSession.cookies.get({ url: url.toString() });
-    for (const cookie of cookies) {
-      pairs.set(cookie.name, `${cookie.name}=${cookie.value}`);
-    }
-  }
-  return [...pairs.values()].join("; ");
-}
-
 function optionalJsonBody(body: object): string {
   return JSON.stringify(body);
 }
@@ -131,14 +118,11 @@ export function createDesktopLocalAgentApiClient(params: {
   const apiBase = normalizeBaseUrl(apiBaseUrl);
 
   const sessionHeaders = async (): Promise<HeadersInit> => {
-    const cookie = await cookieHeaderForSession(params.session, [
-      params.platformUrl,
-      apiBaseUrl,
-    ]);
-    return {
-      "content-type": "application/json",
-      ...(cookie.length > 0 ? { cookie } : {}),
-    };
+    return headersWithSessionCookies(
+      params.session,
+      [params.platformUrl, apiBaseUrl],
+      { "content-type": "application/json" },
+    );
   };
 
   return {

--- a/turbo/apps/desktop/src/desktop-session-cookies.ts
+++ b/turbo/apps/desktop/src/desktop-session-cookies.ts
@@ -1,0 +1,39 @@
+export interface DesktopSessionCookie {
+  readonly name: string;
+  readonly value: string;
+}
+
+export interface DesktopSessionCookieSource {
+  readonly cookies: {
+    readonly get: (filter: {
+      readonly url: string;
+    }) => Promise<readonly DesktopSessionCookie[]>;
+  };
+}
+
+async function cookieHeaderForSession(
+  electronSession: DesktopSessionCookieSource,
+  urls: readonly URL[],
+): Promise<string> {
+  const pairs = new Map<string, string>();
+  for (const url of urls) {
+    const cookies = await electronSession.cookies.get({ url: url.toString() });
+    for (const cookie of cookies) {
+      pairs.set(cookie.name, `${cookie.name}=${cookie.value}`);
+    }
+  }
+  return [...pairs.values()].join("; ");
+}
+
+export async function headersWithSessionCookies(
+  electronSession: DesktopSessionCookieSource,
+  urls: readonly URL[],
+  headersInit?: HeadersInit,
+): Promise<Headers> {
+  const headers = new Headers(headersInit);
+  const cookie = await cookieHeaderForSession(electronSession, urls);
+  if (cookie.length > 0) {
+    headers.set("cookie", cookie);
+  }
+  return headers;
+}

--- a/turbo/apps/desktop/src/main.ts
+++ b/turbo/apps/desktop/src/main.ts
@@ -20,6 +20,7 @@ import {
 } from "./computer-use-permissions";
 import { resolveDesktopConfig } from "./config";
 import { createDesktopLocalAgentApiClient } from "./desktop-local-agent-api";
+import { createDesktopComputerUseSessionFetch } from "./desktop-computer-use-api";
 import {
   installDesktopLocalAgentIpc,
   notifyDesktopLocalAgentsChanged,
@@ -126,28 +127,31 @@ function getComputerUseBridgeState(): DesktopComputerUseState {
   };
 }
 
-function startComputerUseRuntime(): void {
-  if (computerUseRuntime) {
-    return;
-  }
-
+async function startComputerUseRuntime(): Promise<DesktopComputerUseState> {
   const desktopSession = session.fromPartition(config.sessionPartition);
-  computerUseRuntime = new ComputerUseHostRuntime({
-    platformUrl: config.platformUrl,
-    displayName: config.identity.displayName,
-    appVersion: app.getVersion(),
-    fetch: (input, init) => {
-      return desktopSession.fetch(input, init);
-    },
-    getPermissions: getComputerUsePermissionState,
-    executeCommand: (command, permissions) => {
-      return executeComputerUseCommand(command, permissions, {
-        captureScreenshot: captureComputerUseScreenshot,
-      });
-    },
-    onChange: notifyDesktopComputerUseChanged,
-  });
-  computerUseRuntime.start();
+  if (!computerUseRuntime) {
+    computerUseRuntime = new ComputerUseHostRuntime({
+      platformUrl: config.platformUrl,
+      displayName: config.identity.displayName,
+      appVersion: app.getVersion(),
+      sessionFetch: createDesktopComputerUseSessionFetch({
+        platformUrl: config.platformUrl,
+        session: desktopSession,
+      }),
+      hostFetch: (input, init) => {
+        return fetch(input, init);
+      },
+      getPermissions: getComputerUsePermissionState,
+      executeCommand: (command, permissions) => {
+        return executeComputerUseCommand(command, permissions, {
+          captureScreenshot: captureComputerUseScreenshot,
+        });
+      },
+      onChange: notifyDesktopComputerUseChanged,
+    });
+  }
+  await computerUseRuntime.start();
+  return getComputerUseBridgeState();
 }
 
 async function decideComputerUseCommand(
@@ -170,6 +174,7 @@ function installComputerUse(): void {
   installComputerUseIpc(
     {
       getState: getComputerUseBridgeState,
+      start: startComputerUseRuntime,
       requestAccessibilityPermission: requestComputerUsePermission,
       decideCommand: decideComputerUseCommand,
     },
@@ -522,7 +527,6 @@ if (!hasSingleInstanceLock) {
     installDesktopLocalAgent();
     installComputerUse();
     queueDesktopAuthCallbackArgv(process.argv);
-    startComputerUseRuntime();
 
     const pendingCode = pendingDesktopAuthCode;
     pendingDesktopAuthCode = null;

--- a/turbo/apps/desktop/src/preload.ts
+++ b/turbo/apps/desktop/src/preload.ts
@@ -53,6 +53,9 @@ const desktopComputerUseApi = {
   getState(): Promise<DesktopComputerUseState> {
     return ipcRenderer.invoke(COMPUTER_USE_CHANNELS.getState);
   },
+  start(): Promise<DesktopComputerUseState> {
+    return ipcRenderer.invoke(COMPUTER_USE_CHANNELS.start);
+  },
   requestAccessibilityPermission(): Promise<DesktopComputerUseState> {
     return ipcRenderer.invoke(
       COMPUTER_USE_CHANNELS.requestAccessibilityPermission,

--- a/turbo/apps/platform/src/global.d.ts
+++ b/turbo/apps/platform/src/global.d.ts
@@ -106,6 +106,7 @@ interface DesktopComputerUseApprovalAction {
 
 interface DesktopComputerUseApi {
   readonly getState: () => Promise<DesktopComputerUseState>;
+  readonly start: () => Promise<DesktopComputerUseState>;
   readonly requestAccessibilityPermission: () => Promise<DesktopComputerUseState>;
   readonly openAccessibilitySettings: () => Promise<void>;
   readonly openScreenRecordingSettings: () => Promise<void>;

--- a/turbo/apps/platform/src/signals/desktop-computer-use-page/desktop-computer-use-signals.ts
+++ b/turbo/apps/platform/src/signals/desktop-computer-use-page/desktop-computer-use-signals.ts
@@ -45,6 +45,16 @@ export const refreshDesktopComputerUse$ = command(({ set }) => {
   });
 });
 
+export const startDesktopComputerUse$ = command(
+  async ({ set }, signal: AbortSignal) => {
+    await desktopComputerUseApi().start();
+    signal.throwIfAborted();
+    set(internalReload$, (previous) => {
+      return previous + 1;
+    });
+  },
+);
+
 export const requestDesktopComputerUseAccessibilityPermission$ = command(
   async ({ set }, signal: AbortSignal) => {
     await desktopComputerUseApi().requestAccessibilityPermission();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/desktop-computer-use-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/desktop-computer-use-page.test.tsx
@@ -58,6 +58,25 @@ function computerUseState(): TestDesktopComputerUseState {
   };
 }
 
+function idleComputerUseState(): TestDesktopComputerUseState {
+  return {
+    ...computerUseState(),
+    permissions: {
+      accessibility: true,
+      screenRecording: false,
+    },
+    host: {
+      status: "idle",
+      hostId: null,
+      lastHeartbeatAt: null,
+      lastCommandAt: null,
+      lastError: null,
+      pendingApprovals: [],
+      recentAuditEvents: [],
+    },
+  };
+}
+
 function buttonByText(text: string, index = 0): HTMLButtonElement {
   const button = screen.getAllByText(text)[index]?.closest("button");
   expect(button).toBeInstanceOf(HTMLButtonElement);
@@ -77,6 +96,9 @@ describe("zero desktop Computer Use page", () => {
     });
     installDesktopComputerUseApi({
       getState() {
+        return Promise.resolve(state);
+      },
+      start() {
         return Promise.resolve(state);
       },
       requestAccessibilityPermission() {
@@ -141,6 +163,9 @@ describe("zero desktop Computer Use page", () => {
       getState() {
         return Promise.resolve(state);
       },
+      start() {
+        return Promise.resolve(state);
+      },
       requestAccessibilityPermission,
       openAccessibilitySettings,
       openScreenRecordingSettings,
@@ -183,6 +208,113 @@ describe("zero desktop Computer Use page", () => {
 
     await waitFor(() => {
       expect(openScreenRecordingSettings).toHaveBeenCalledOnce();
+    });
+  });
+
+  it("starts the desktop host manually without making Refresh a start action", async () => {
+    const user = userEvent.setup();
+    const onlineState = computerUseState();
+    let state = idleComputerUseState();
+    const start = vi.fn(() => {
+      state = onlineState;
+      return Promise.resolve(state);
+    });
+    installDesktopComputerUseApi({
+      getState() {
+        return Promise.resolve(state);
+      },
+      start,
+      requestAccessibilityPermission() {
+        return Promise.resolve(state);
+      },
+      openAccessibilitySettings() {
+        return Promise.resolve();
+      },
+      openScreenRecordingSettings() {
+        return Promise.resolve();
+      },
+      decideCommand() {
+        return Promise.resolve(state);
+      },
+      subscribe() {
+        return () => {};
+      },
+    });
+
+    await setupPage({
+      context,
+      path: "/computer-use",
+      featureSwitches: {
+        [FeatureSwitchKey.ComputerUse]: true,
+      },
+    });
+
+    await screen.findByRole("heading", { name: "Computer Use" });
+    expect(screen.getByText("Host is not connected.")).toBeInTheDocument();
+
+    await user.click(buttonByText("Refresh"));
+    expect(start).not.toHaveBeenCalled();
+
+    await user.click(buttonByText("Start Computer Use"));
+    await waitFor(() => {
+      expect(start).toHaveBeenCalledOnce();
+    });
+    await expect(screen.findByText("host-1")).resolves.toBeInTheDocument();
+  });
+
+  it("shows an actionable unauthenticated state with manual retry", async () => {
+    const user = userEvent.setup();
+    const state = {
+      ...idleComputerUseState(),
+      host: {
+        ...idleComputerUseState().host,
+        status: "unauthenticated" as const,
+        lastError:
+          "Desktop host could not authenticate with the API session. Sign in and retry.",
+      },
+    };
+    const start = vi.fn(() => {
+      return Promise.resolve(state);
+    });
+    installDesktopComputerUseApi({
+      getState() {
+        return Promise.resolve(state);
+      },
+      start,
+      requestAccessibilityPermission() {
+        return Promise.resolve(state);
+      },
+      openAccessibilitySettings() {
+        return Promise.resolve();
+      },
+      openScreenRecordingSettings() {
+        return Promise.resolve();
+      },
+      decideCommand() {
+        return Promise.resolve(state);
+      },
+      subscribe() {
+        return () => {};
+      },
+    });
+
+    await setupPage({
+      context,
+      path: "/computer-use",
+      featureSwitches: {
+        [FeatureSwitchKey.ComputerUse]: true,
+      },
+    });
+
+    await expect(
+      screen.findByText(
+        "Desktop host could not authenticate with the API session. Sign in to Zero Desktop, then retry.",
+      ),
+    ).resolves.toBeInTheDocument();
+
+    await user.click(buttonByText("Retry connection"));
+    await waitFor(() => {
+      expect(start).toHaveBeenCalledOnce();
     });
   });
 

--- a/turbo/apps/platform/src/views/zero-page/desktop-computer-use-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/desktop-computer-use-page.tsx
@@ -6,6 +6,7 @@ import {
   IconDeviceDesktop,
   IconExternalLink,
   IconLoader2,
+  IconPlayerPlay,
   IconRefresh,
   IconShieldCheck,
 } from "@tabler/icons-react";
@@ -27,6 +28,7 @@ import {
   openDesktopComputerUseScreenRecordingSettings$,
   refreshDesktopComputerUse$,
   requestDesktopComputerUseAccessibilityPermission$,
+  startDesktopComputerUse$,
   type DesktopComputerUseState,
 } from "../../signals/desktop-computer-use-page/desktop-computer-use-signals.ts";
 
@@ -167,6 +169,29 @@ function PermissionPanel({
 }
 
 function RuntimePanel({ state }: { readonly state: DesktopComputerUseState }) {
+  const pageSignal = useGet(pageSignal$);
+  const [startLoadable, startComputerUse] = useLoadableSet(
+    startDesktopComputerUse$,
+  );
+  const canStart =
+    state.supported &&
+    (state.host.status === "idle" ||
+      state.host.status === "unauthenticated" ||
+      state.host.status === "error");
+  const startPending =
+    startLoadable.state === "loading" || state.host.status === "connecting";
+  const statusCopy =
+    state.host.status === "idle"
+      ? "Host is not connected."
+      : state.host.status === "connecting"
+        ? "Connecting this desktop to the Computer Use command queue."
+        : state.host.status === "online"
+          ? "Host is connected and polling for Computer Use commands."
+          : state.host.status === "unauthenticated"
+            ? "Desktop host could not authenticate with the API session. Sign in to Zero Desktop, then retry."
+            : state.host.status === "disabled"
+              ? "Computer Use is disabled for this account."
+              : "Host connection failed. Retry when the desktop session is available.";
   const rows = [
     ["Host", state.host.hostId ?? "-"],
     ["Last heartbeat", formatDateTime(state.host.lastHeartbeatAt)],
@@ -175,14 +200,37 @@ function RuntimePanel({ state }: { readonly state: DesktopComputerUseState }) {
   ] as const;
   return (
     <section className="zero-border bg-card rounded-xl overflow-hidden">
-      <div className="flex items-center justify-between gap-4 border-b px-5 py-4">
+      <div className="flex flex-col gap-4 border-b px-5 py-4 sm:flex-row sm:items-center sm:justify-between">
         <div>
           <h2 className="text-sm font-semibold text-foreground">Runtime</h2>
-          <p className="mt-1 text-sm text-muted-foreground">
-            Desktop host status for the Computer Use command queue.
+          <p className="mt-1 max-w-[640px] text-sm text-muted-foreground">
+            {statusCopy}
           </p>
         </div>
-        <StatusBadge status={state.host.status} title={state.host.lastError} />
+        <div className="flex shrink-0 flex-wrap items-center gap-2">
+          {canStart ? (
+            <Button
+              size="sm"
+              disabled={startPending}
+              onClick={() => {
+                detach(startComputerUse(pageSignal), Reason.DomCallback);
+              }}
+            >
+              {startPending ? (
+                <IconLoader2 size={15} className="animate-spin" />
+              ) : (
+                <IconPlayerPlay size={15} />
+              )}
+              {state.host.status === "idle"
+                ? "Start Computer Use"
+                : "Retry connection"}
+            </Button>
+          ) : null}
+          <StatusBadge
+            status={state.host.status}
+            title={state.host.lastError}
+          />
+        </div>
       </div>
       <dl className="grid grid-cols-1 divide-y text-sm sm:grid-cols-2 sm:divide-x sm:divide-y-0">
         {rows.map(([label, value]) => {


### PR DESCRIPTION
## Summary

- stop auto-starting the desktop Computer Use host on app launch and add an explicit start IPC/preload/platform action
- register Computer Use hosts with desktop session cookies while keeping heartbeat/claim/complete on bearer-token auth
- add Runtime panel Start/Retry controls with actionable unauthenticated copy
- cover manual start, no-auto-start, session-cookie forwarding, bearer polling, and UI retry behavior

## Verification

- pnpm --filter web db:migrate
- pnpm -F @vm0/desktop exec vitest run src/computer-use-host.test.ts src/desktop-computer-use-api.test.ts
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/desktop-computer-use-page.test.tsx
- pnpm -F @vm0/desktop test
- pnpm -F @vm0/desktop check-types
- pnpm -F @vm0/app check-types
- pnpm -F @vm0/desktop lint
- pnpm -F @vm0/app lint
- pnpm -F @vm0/desktop build
- pnpm knip --cache
- pre-commit hook: prettier, knip, turbo run check-types --concurrency=1

Closes #14281