### PR TITLE
refactor: consolidate mitm auth state

### DIFF
--- a/crates/runner/mitm-addon/src/auth.py
+++ b/crates/runner/mitm-addon/src/auth.py
@@ -69,7 +69,11 @@ _FORCE_REFRESH_COOLDOWN_SECS = 120.0
 
 
 def _get_auth_state(cache_key: tuple[str, str]) -> _FirewallAuthState:
-    return _auth_state.setdefault(cache_key, _FirewallAuthState())
+    state = _auth_state.get(cache_key)
+    if state is None:
+        state = _FirewallAuthState()
+        _auth_state[cache_key] = state
+    return state
 
 
 def is_billable_firewall(match_info: dict, vm_info: dict) -> bool:

--- a/crates/runner/mitm-addon/src/auth.py
+++ b/crates/runner/mitm-addon/src/auth.py
@@ -12,6 +12,7 @@ import time
 import urllib.error
 import urllib.parse
 import urllib.request
+from dataclasses import dataclass, field
 
 from mitmproxy import ctx, http
 
@@ -34,30 +35,29 @@ class MissingAuthExpiryError(Exception):
 # Vercel bypass secret (still from environment as it's a secret)
 VERCEL_BYPASS = os.environ.get("VERCEL_AUTOMATION_BYPASS_SECRET", "")
 
-# Cache for firewall auth headers: (run_id, api_id) -> {"headers": dict, "expiresAt": float | None}
-#
-# expiresAt is the effective cache expiry returned by the server. For
-# non-billable auth it is just the auth-token expiry and may be None. For
-# billable auth it must be finite because the server folds the credit
-# authorization lease into this timestamp.
-_firewall_header_cache: dict[tuple[str, str], dict] = {}
 
-# Per-key locks to coalesce concurrent fetches for the same (run_id, api_id)
-_cache_locks: dict[tuple[str, str], asyncio.Lock] = {}
+@dataclass
+class _FirewallHeaderCacheEntry:
+    """Cached /firewall/auth response data for a single firewall key."""
 
-# (run_id, api_id) pairs for which the upstream just returned 401 — the next
-# /firewall/auth fetch must force a token refresh regardless of the DB's
-# tokenExpiresAt, since the provider has silently invalidated it (user
-# revoked, admin rotated, clock skew). Consumed + cleared in
-# get_firewall_headers before each fetch. See #9860.
-_force_refresh_markers: set[tuple[str, str]] = set()
+    headers: dict
+    expires_at: object = None
+    resolved_secrets: list = field(default_factory=list)
+    base: str | None = None
+    query: dict | None = None
 
-# Timestamp of the last consumed force-refresh per (run_id, api_id). Used to
-# rate-limit amplification when an upstream persistently returns 401 for a
-# non-token reason (scope mismatch, resource-level reject, IP block).
-# Without this, every 401 would trigger an OAuth refresh call — hitting
-# provider rate limits and potentially tripping abuse detection. See #9860.
-_last_force_refresh_at: dict[tuple[str, str], float] = {}
+
+@dataclass
+class _FirewallAuthState:
+    """Per-(run_id, api_id) auth lifecycle state."""
+
+    cache: _FirewallHeaderCacheEntry | None = None
+    lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+    force_refresh_pending: bool = False
+    last_force_refresh_at: float = 0.0
+
+
+_auth_state: dict[tuple[str, str], _FirewallAuthState] = {}
 
 # Cooldown window for re-marking a force-refresh. Caps amplification at
 # 30 refreshes/hour/key under a persistent non-token 401 loop — safely
@@ -66,6 +66,10 @@ _last_force_refresh_at: dict[tuple[str, str], float] = {}
 # immediately; the cooldown only affects REPEATED forced refreshes, so
 # happy-path recovery is unaffected.
 _FORCE_REFRESH_COOLDOWN_SECS = 120.0
+
+
+def _get_auth_state(cache_key: tuple[str, str]) -> _FirewallAuthState:
+    return _auth_state.setdefault(cache_key, _FirewallAuthState())
 
 
 def is_billable_firewall(match_info: dict, vm_info: dict) -> bool:
@@ -106,7 +110,7 @@ def request_force_refresh(cache_key: tuple[str, str]) -> None:
 
     Design notes for future changes:
 
-    * The consume timestamp in ``_last_force_refresh_at`` is written **before**
+    * The consume timestamp in ``state.last_force_refresh_at`` is written **before**
       ``fetch_firewall_headers`` is awaited in ``get_firewall_headers``, not
       after. Recording after would allow a 401 arriving during the fetch to
       re-add the marker; after the fetch completes and writes the cache, a
@@ -122,23 +126,23 @@ def request_force_refresh(cache_key: tuple[str, str]) -> None:
       freeze the cooldown until wall-clock catches up; on NTP-slewed runners
       this is not a realistic concern.
     """
-    last = _last_force_refresh_at.get(cache_key, 0.0)
-    if time.time() - last >= _FORCE_REFRESH_COOLDOWN_SECS:
-        _force_refresh_markers.add(cache_key)
+    state = _get_auth_state(cache_key)
+    if time.time() - state.last_force_refresh_at >= _FORCE_REFRESH_COOLDOWN_SECS:
+        state.force_refresh_pending = True
+
+
+def clear_cached_firewall_headers(cache_key: tuple[str, str]) -> None:
+    """Invalidate only cached headers while preserving refresh lifecycle state."""
+    state = _auth_state.get(cache_key)
+    if state:
+        state.cache = None
 
 
 def evict_stale_cache_keys(active_run_ids: set[str]) -> None:
     """Remove cache entries for runs no longer in the registry."""
-    stale = [k for k in _firewall_header_cache if k[0] not in active_run_ids]
+    stale = [k for k in _auth_state if k[0] not in active_run_ids]
     for k in stale:
-        _firewall_header_cache.pop(k, None)
-        _cache_locks.pop(k, None)
-    stale_markers = [k for k in _force_refresh_markers if k[0] not in active_run_ids]
-    for k in stale_markers:
-        _force_refresh_markers.discard(k)
-    stale_ts = [k for k in _last_force_refresh_at if k[0] not in active_run_ids]
-    for k in stale_ts:
-        _last_force_refresh_at.pop(k, None)
+        _auth_state.pop(k, None)
 
 
 def get_api_url() -> str:
@@ -372,22 +376,27 @@ def _has_valid_expiry(value: object, now: float | None = None) -> bool:
     return (time.time() if now is None else now) < value
 
 
-def _build_cache_hit(cached: dict, firewall_billable: bool = False) -> dict | None:
+def _build_cache_hit(
+    cached: _FirewallHeaderCacheEntry, firewall_billable: bool = False
+) -> dict | None:
     """Check if a cached entry is still valid and return a cache-hit result."""
-    expires_at = cached.get("expiresAt")
+    expires_at = cached.expires_at
     now = time.time()
     if expires_at is None:
         if firewall_billable:
             return None
     elif not _has_valid_expiry(expires_at, now):
         return None
-    return {
-        "headers": cached["headers"],
-        "resolved_secrets": cached.get("resolvedSecrets", []),
+    hit = {
+        "headers": cached.headers,
+        "resolved_secrets": cached.resolved_secrets,
         "cache_hit": True,
-        **({"base": cached["base"]} if "base" in cached else {}),
-        **({"query": cached["query"]} if "query" in cached else {}),
     }
+    if cached.base is not None:
+        hit["base"] = cached.base
+    if cached.query is not None:
+        hit["query"] = cached.query
+    return hit
 
 
 async def get_firewall_headers(
@@ -414,21 +423,19 @@ async def get_firewall_headers(
     - The expiresAt timestamp from the auth endpoint has passed
     """
     cache_key = (run_id, api_id)
+    state = _get_auth_state(cache_key)
 
     # Fast path: cache hit (no lock needed — single-threaded event loop)
-    cached = _firewall_header_cache.get(cache_key)
-    if cached:
-        hit = _build_cache_hit(cached, firewall_billable=firewall_billable)
+    if state.cache:
+        hit = _build_cache_hit(state.cache, firewall_billable=firewall_billable)
         if hit:
             return hit
 
     # Slow path: acquire per-key lock so only one coroutine fetches
-    lock = _cache_locks.setdefault(cache_key, asyncio.Lock())
-    async with lock:
+    async with state.lock:
         # Double-check: another coroutine may have populated cache while we waited
-        cached = _firewall_header_cache.get(cache_key)
-        if cached:
-            hit = _build_cache_hit(cached, firewall_billable=firewall_billable)
+        if state.cache:
+            hit = _build_cache_hit(state.cache, firewall_billable=firewall_billable)
             if hit:
                 return hit
 
@@ -438,10 +445,10 @@ async def get_firewall_headers(
         # on its double-check above and never reach this path. Record the
         # consume timestamp so request_force_refresh() suppresses re-marking
         # within the cooldown window (guards against 401-amplification).
-        force_refresh = cache_key in _force_refresh_markers
-        _force_refresh_markers.discard(cache_key)
+        force_refresh = state.force_refresh_pending
+        state.force_refresh_pending = False
         if force_refresh:
-            _last_force_refresh_at[cache_key] = time.time()
+            state.last_force_refresh_at = time.time()
 
         result = await fetch_firewall_headers(
             encrypted_secrets,
@@ -461,16 +468,16 @@ async def get_firewall_headers(
             )
         headers = result["headers"]
         resolved_secrets = result.get("resolvedSecrets", [])
-        cache_entry: dict = {
-            "headers": headers,
-            "expiresAt": result.get("expiresAt"),
-            "resolvedSecrets": resolved_secrets,
-        }
+        cache_entry = _FirewallHeaderCacheEntry(
+            headers=headers,
+            expires_at=result.get("expiresAt"),
+            resolved_secrets=resolved_secrets,
+        )
         if result.get("base"):
-            cache_entry["base"] = result["base"]
+            cache_entry.base = result["base"]
         if result.get("query"):
-            cache_entry["query"] = result["query"]
-        _firewall_header_cache[cache_key] = cache_entry
+            cache_entry.query = result["query"]
+        state.cache = cache_entry
         ret: dict = {
             "headers": headers,
             "resolved_secrets": resolved_secrets,

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -34,7 +34,7 @@ import registry
 import response_streaming
 import usage
 from auth import (
-    _firewall_header_cache,
+    clear_cached_firewall_headers,
     handle_firewall_request,
     is_billable_firewall,
     request_force_refresh,
@@ -460,7 +460,7 @@ def response(flow: http.HTTPFlow) -> None:
         api_id = flow.metadata.get("firewall_api_id", "")
         if api_id:
             cache_key = (run_id, api_id)
-            _firewall_header_cache.pop(cache_key, None)
+            clear_cached_firewall_headers(cache_key)
             request_force_refresh(cache_key)
 
     # Log errors to per-job proxy log and mitmproxy console

--- a/crates/runner/mitm-addon/tests/auth_state_helpers.py
+++ b/crates/runner/mitm-addon/tests/auth_state_helpers.py
@@ -3,6 +3,14 @@
 import auth
 
 
+def clear_auth_state() -> None:
+    auth._auth_state.clear()
+
+
+def has_auth_state(cache_key: tuple[str, str]) -> bool:
+    return cache_key in auth._auth_state
+
+
 def set_cached_headers(
     cache_key: tuple[str, str],
     *,

--- a/crates/runner/mitm-addon/tests/auth_state_helpers.py
+++ b/crates/runner/mitm-addon/tests/auth_state_helpers.py
@@ -1,0 +1,44 @@
+"""Helpers for setting up auth state in mitm-addon tests."""
+
+import auth
+
+
+def set_cached_headers(
+    cache_key: tuple[str, str],
+    *,
+    headers: dict,
+    expires_at: object = None,
+    resolved_secrets: list | None = None,
+    base: str | None = None,
+    query: dict | None = None,
+) -> None:
+    auth._get_auth_state(cache_key).cache = auth._FirewallHeaderCacheEntry(
+        headers=headers,
+        expires_at=expires_at,
+        resolved_secrets=resolved_secrets or [],
+        base=base,
+        query=query,
+    )
+
+
+def cached_headers(cache_key: tuple[str, str]) -> auth._FirewallHeaderCacheEntry | None:
+    state = auth._auth_state.get(cache_key)
+    return state.cache if state else None
+
+
+def mark_force_refresh(cache_key: tuple[str, str]) -> None:
+    auth._get_auth_state(cache_key).force_refresh_pending = True
+
+
+def force_refresh_pending(cache_key: tuple[str, str]) -> bool:
+    state = auth._auth_state.get(cache_key)
+    return bool(state and state.force_refresh_pending)
+
+
+def set_last_force_refresh_at(cache_key: tuple[str, str], timestamp: float) -> None:
+    auth._get_auth_state(cache_key).last_force_refresh_at = timestamp
+
+
+def last_force_refresh_at(cache_key: tuple[str, str]) -> float | None:
+    state = auth._auth_state.get(cache_key)
+    return state.last_force_refresh_at if state else None

--- a/crates/runner/mitm-addon/tests/conftest.py
+++ b/crates/runner/mitm-addon/tests/conftest.py
@@ -45,10 +45,7 @@ def _reset_module_state() -> None:
     """
     mitm_addon._request_start_times.clear()
     registry.reset_cache_for_tests()
-    auth._firewall_header_cache.clear()
-    auth._cache_locks.clear()
-    auth._force_refresh_markers.clear()
-    auth._last_force_refresh_at.clear()
+    auth._auth_state.clear()
     _usage_connectors._unregistered_handler_warned.clear()
     usage.counters._pending_write_error_logged = False
 

--- a/crates/runner/mitm-addon/tests/conftest.py
+++ b/crates/runner/mitm-addon/tests/conftest.py
@@ -28,6 +28,7 @@ import auth
 import mitm_addon
 import registry
 import usage
+from tests.auth_state_helpers import clear_auth_state
 from usage.providers import connectors as _usage_connectors
 
 
@@ -45,7 +46,7 @@ def _reset_module_state() -> None:
     """
     mitm_addon._request_start_times.clear()
     registry.reset_cache_for_tests()
-    auth._auth_state.clear()
+    clear_auth_state()
     _usage_connectors._unregistered_handler_warned.clear()
     usage.counters._pending_write_error_logged = False
 

--- a/crates/runner/mitm-addon/tests/test_connectors.py
+++ b/crates/runner/mitm-addon/tests/test_connectors.py
@@ -21,6 +21,13 @@ from matching import (
     match_host,
     match_path_prefix,
 )
+from tests.auth_state_helpers import (
+    cached_headers,
+    force_refresh_pending,
+    last_force_refresh_at,
+    mark_force_refresh,
+    set_cached_headers,
+)
 
 
 def _wrap_firewalls(apis, name="test"):
@@ -1286,15 +1293,13 @@ class TestGetFirewallHeaders:
 
         # Verify the cache was populated
         cache_key = ("run-1", "https://api.github.com")
-        assert cache_key in auth._firewall_header_cache
-        assert auth._firewall_header_cache[cache_key]["headers"] == mock_headers
+        assert cached_headers(cache_key)
+        assert cached_headers(cache_key).headers == mock_headers
 
     async def test_cache_hit_returns_cached(self, headers):
         cache_key = ("run-1", "https://api.github.com")
         cached_headers = {"Authorization": "Bearer cached-token"}
-        auth._firewall_header_cache[cache_key] = {
-            "headers": cached_headers,
-        }
+        set_cached_headers(cache_key, headers=cached_headers)
 
         mock_fetch = AsyncMock()
         with patch.object(auth, "fetch_firewall_headers", mock_fetch):
@@ -1310,10 +1315,11 @@ class TestGetFirewallHeaders:
         """Cached entry with expiresAt in the future should be returned without fetching."""
         cache_key = ("run-1", "api-1")
         cached_headers = {"Authorization": "Bearer valid-token"}
-        auth._firewall_header_cache[cache_key] = {
-            "headers": cached_headers,
-            "expiresAt": time.time() + 3600,  # 1 hour from now
-        }
+        set_cached_headers(
+            cache_key,
+            headers=cached_headers,
+            expires_at=time.time() + 3600,  # 1 hour from now
+        )
 
         mock_fetch = AsyncMock()
         with patch.object(auth, "fetch_firewall_headers", mock_fetch):
@@ -1328,10 +1334,11 @@ class TestGetFirewallHeaders:
     async def test_cache_evicted_when_ttl_expired(self, headers):
         """Cached entry with expiresAt in the past should trigger a re-fetch."""
         cache_key = ("run-1", "api-1")
-        auth._firewall_header_cache[cache_key] = {
-            "headers": {"Authorization": "Bearer stale-token"},
-            "expiresAt": time.time() - 10,  # expired 10 seconds ago
-        }
+        set_cached_headers(
+            cache_key,
+            headers={"Authorization": "Bearer stale-token"},
+            expires_at=time.time() - 10,  # expired 10 seconds ago
+        )
 
         fresh_headers = {"Authorization": "Bearer fresh-token"}
         mock_result = {"headers": fresh_headers, "expiresAt": time.time() + 3600}
@@ -1347,16 +1354,13 @@ class TestGetFirewallHeaders:
         # fetch_firewall_headers wraps urllib; pins the TTL-expiry→re-fetch contract (#9991).
         mock_fetch.assert_called_once()
         # Verify cache was updated with new entry
-        assert auth._firewall_header_cache[cache_key]["headers"] == fresh_headers
+        assert cached_headers(cache_key).headers == fresh_headers
 
     async def test_cache_with_null_expires_at_never_evicts(self, headers):
         """Cached entry with expiresAt=None (non-expiring) should never be evicted by TTL."""
         cache_key = ("run-1", "api-1")
         cached_headers = {"Authorization": "Bearer permanent-token"}
-        auth._firewall_header_cache[cache_key] = {
-            "headers": cached_headers,
-            "expiresAt": None,
-        }
+        set_cached_headers(cache_key, headers=cached_headers, expires_at=None)
 
         mock_fetch = AsyncMock()
         with patch.object(auth, "fetch_firewall_headers", mock_fetch):
@@ -1371,10 +1375,7 @@ class TestGetFirewallHeaders:
     async def test_billable_cache_hit_requires_valid_expiry(self, headers):
         cache_key = ("run-1", "api-1")
         cached_headers = {"Authorization": "Bearer cached-token"}
-        auth._firewall_header_cache[cache_key] = {
-            "headers": cached_headers,
-            "expiresAt": time.time() + 30,
-        }
+        set_cached_headers(cache_key, headers=cached_headers, expires_at=time.time() + 30)
 
         mock_fetch = AsyncMock()
         with patch.object(auth, "fetch_firewall_headers", mock_fetch):
@@ -1398,10 +1399,11 @@ class TestGetFirewallHeaders:
     @pytest.mark.parametrize("expiry", [True, "123", float("inf"), float("nan")])
     async def test_cache_with_invalid_expiry_refetches(self, headers, expiry):
         cache_key = ("run-1", "api-1")
-        auth._firewall_header_cache[cache_key] = {
-            "headers": {"Authorization": "Bearer malformed-token"},
-            "expiresAt": expiry,
-        }
+        set_cached_headers(
+            cache_key,
+            headers={"Authorization": "Bearer malformed-token"},
+            expires_at=expiry,
+        )
         fresh_headers = {"Authorization": "Bearer fresh-token"}
         mock_fetch = AsyncMock(return_value={"headers": fresh_headers, "expiresAt": None})
 
@@ -1416,10 +1418,11 @@ class TestGetFirewallHeaders:
 
     async def test_billable_cache_without_expiry_refetches(self, headers):
         cache_key = ("run-1", "api-1")
-        auth._firewall_header_cache[cache_key] = {
-            "headers": {"Authorization": "Bearer stale-token"},
-            "expiresAt": None,
-        }
+        set_cached_headers(
+            cache_key,
+            headers={"Authorization": "Bearer stale-token"},
+            expires_at=None,
+        )
         fresh_headers = {"Authorization": "Bearer fresh-token"}
         expires_at = time.time() + 30
         mock_fetch = AsyncMock(
@@ -1443,14 +1446,15 @@ class TestGetFirewallHeaders:
         assert headers["cache_hit"] is False
         mock_fetch.assert_called_once()
         assert mock_fetch.call_args.args[8] is True
-        assert auth._firewall_header_cache[cache_key]["expiresAt"] == expires_at
+        assert cached_headers(cache_key).expires_at == expires_at
 
     async def test_billable_cache_with_expired_expiry_refetches(self, headers):
         cache_key = ("run-1", "api-1")
-        auth._firewall_header_cache[cache_key] = {
-            "headers": {"Authorization": "Bearer stale-token"},
-            "expiresAt": time.time() - 1,
-        }
+        set_cached_headers(
+            cache_key,
+            headers={"Authorization": "Bearer stale-token"},
+            expires_at=time.time() - 1,
+        )
         fresh_headers = {"Authorization": "Bearer fresh-token"}
         mock_fetch = AsyncMock(
             return_value={
@@ -1497,12 +1501,13 @@ class TestGetFirewallHeaders:
     async def test_cache_hit_includes_base_when_present(self, headers):
         """Cached entry with 'base' returns it on cache hit."""
         cache_key = ("run-1", "api-1")
-        auth._firewall_header_cache[cache_key] = {
-            "headers": {},
-            "resolvedSecrets": ["WEBHOOK_URL"],
-            "base": "https://discord.com/api/webhooks/123/abc",
-            "expiresAt": None,
-        }
+        set_cached_headers(
+            cache_key,
+            headers={},
+            resolved_secrets=["WEBHOOK_URL"],
+            base="https://discord.com/api/webhooks/123/abc",
+            expires_at=None,
+        )
 
         mock_fetch = AsyncMock()
         with patch.object(auth, "fetch_firewall_headers", mock_fetch):
@@ -1515,11 +1520,12 @@ class TestGetFirewallHeaders:
     async def test_cache_hit_omits_base_when_absent(self, headers):
         """Cached entry without 'base' does not include it in result."""
         cache_key = ("run-1", "api-1")
-        auth._firewall_header_cache[cache_key] = {
-            "headers": {"Authorization": "Bearer tok"},
-            "resolvedSecrets": ["TOKEN"],
-            "expiresAt": None,
-        }
+        set_cached_headers(
+            cache_key,
+            headers={"Authorization": "Bearer tok"},
+            resolved_secrets=["TOKEN"],
+            expires_at=None,
+        )
 
         mock_fetch = AsyncMock()
         with patch.object(auth, "fetch_firewall_headers", mock_fetch):
@@ -1533,7 +1539,7 @@ class TestGetFirewallHeaders:
         force_refresh=True, the marker is cleared, and the consume timestamp
         is recorded so the cooldown can suppress re-marking (#9860)."""
         cache_key = ("run-1", "api-1")
-        auth._force_refresh_markers.add(cache_key)
+        mark_force_refresh(cache_key)
         before = time.time()
 
         mock_fetch = AsyncMock(return_value={"headers": {"Authorization": "Bearer new"}})
@@ -1543,9 +1549,9 @@ class TestGetFirewallHeaders:
         # force_refresh kwarg must be True
         assert mock_fetch.call_args.kwargs["force_refresh"] is True
         # Marker cleared after consumption
-        assert cache_key not in auth._force_refresh_markers
+        assert not force_refresh_pending(cache_key)
         # Consume timestamp recorded for cooldown enforcement
-        assert auth._last_force_refresh_at[cache_key] >= before
+        assert last_force_refresh_at(cache_key) >= before
 
     async def test_force_refresh_absent_passes_false(self, headers):
         """Without a marker, fetch is called with force_refresh=False (#9860)."""
@@ -1555,17 +1561,18 @@ class TestGetFirewallHeaders:
 
         assert mock_fetch.call_args.kwargs["force_refresh"] is False
         # No consume timestamp written when force-refresh didn't happen
-        assert ("run-1", "api-2") not in auth._last_force_refresh_at
+        assert last_force_refresh_at(("run-1", "api-2")) == 0.0
 
     async def test_force_refresh_marker_ignored_on_cache_hit(self, headers):
         """Fast-path cache hit does NOT consume the force-refresh marker —
         marker survives until the next actual fetch (#9860)."""
         cache_key = ("run-1", "api-1")
-        auth._firewall_header_cache[cache_key] = {
-            "headers": {"Authorization": "Bearer cached"},
-            "expiresAt": None,
-        }
-        auth._force_refresh_markers.add(cache_key)
+        set_cached_headers(
+            cache_key,
+            headers={"Authorization": "Bearer cached"},
+            expires_at=None,
+        )
+        mark_force_refresh(cache_key)
 
         mock_fetch = AsyncMock()
         with patch.object(auth, "fetch_firewall_headers", mock_fetch):
@@ -1574,7 +1581,7 @@ class TestGetFirewallHeaders:
         assert result["cache_hit"] is True
         mock_fetch.assert_not_called()
         # Marker preserved for next real fetch
-        assert cache_key in auth._force_refresh_markers
+        assert force_refresh_pending(cache_key)
 
 
 # =========================================================================

--- a/crates/runner/mitm-addon/tests/test_connectors.py
+++ b/crates/runner/mitm-addon/tests/test_connectors.py
@@ -1553,6 +1553,24 @@ class TestGetFirewallHeaders:
         # Consume timestamp recorded for cooldown enforcement
         assert last_force_refresh_at(cache_key) >= before
 
+    async def test_force_refresh_fetch_failure_still_consumes_marker(self, headers):
+        """A failed forced refresh burns the cooldown and does not cache headers."""
+        cache_key = ("run-1", "api-1")
+        mark_force_refresh(cache_key)
+        before = time.time()
+
+        mock_fetch = AsyncMock(side_effect=ConnectionError("server unreachable"))
+        with (
+            patch.object(auth, "fetch_firewall_headers", mock_fetch),
+            pytest.raises(ConnectionError),
+        ):
+            await auth.get_firewall_headers("run-1", "api-1", "iv:tag:data", {}, "tok-xyz")
+
+        assert mock_fetch.call_args.kwargs["force_refresh"] is True
+        assert not force_refresh_pending(cache_key)
+        assert last_force_refresh_at(cache_key) >= before
+        assert cached_headers(cache_key) is None
+
     async def test_force_refresh_absent_passes_false(self, headers):
         """Without a marker, fetch is called with force_refresh=False (#9860)."""
         mock_fetch = AsyncMock(return_value={"headers": {}})

--- a/crates/runner/mitm-addon/tests/test_handlers.py
+++ b/crates/runner/mitm-addon/tests/test_handlers.py
@@ -1583,12 +1583,16 @@ class TestResponseHandler:
         flow.response = tutils.tresp(status_code=401, headers=http.Headers())
 
         cache_key = ("run-conn-cd", "run-conn-cd:0")
+        set_cached_headers(cache_key, headers={"Authorization": "Bearer cached-token"})
         # Simulate: a forced refresh JUST completed a moment ago
         set_last_force_refresh_at(cache_key, time.time())
 
         with mitm_ctx():
             mitm_addon.response(flow)
 
+        # The stale cached headers must still be cleared even when the
+        # cooldown suppresses another forced refresh marker.
+        assert cached_headers(cache_key) is None
         # Marker was suppressed by the cooldown
         assert not force_refresh_pending(cache_key)
 

--- a/crates/runner/mitm-addon/tests/test_handlers.py
+++ b/crates/runner/mitm-addon/tests/test_handlers.py
@@ -1545,6 +1545,27 @@ class TestResponseHandler:
         # refreshes the token regardless of DB tokenExpiresAt (#9860).
         assert force_refresh_pending(cache_key)
 
+    def test_401_without_existing_state_marks_force_refresh(self, real_flow, mitm_ctx, headers):
+        """401 should request a forced refresh even if no cache entry exists yet."""
+        flow = real_flow(with_response=False, host="api.github.com")
+        flow.metadata["vm_run_id"] = "run-conn-new"
+        flow.metadata["vm_client_ip"] = "10.200.0.5"
+        flow.metadata["vm_network_log_path"] = ""
+        flow.metadata["firewall_action"] = "ALLOW"
+        flow.metadata["firewall_base"] = "https://api.github.com"
+        flow.metadata["firewall_api_id"] = "run-conn-new:0"
+        flow.metadata["original_url"] = "https://api.github.com/repos"
+        flow.response = tutils.tresp(status_code=401, headers=http.Headers())
+
+        cache_key = ("run-conn-new", "run-conn-new:0")
+        assert cache_key not in auth._auth_state
+
+        with mitm_ctx():
+            mitm_addon.response(flow)
+
+        assert cached_headers(cache_key) is None
+        assert force_refresh_pending(cache_key)
+
     def test_401_within_cooldown_does_not_re_mark(self, real_flow, mitm_ctx, headers):
         """A second 401 within the force-refresh cooldown window must NOT
         re-mark — otherwise a persistent non-token 401 (scope, resource-

--- a/crates/runner/mitm-addon/tests/test_handlers.py
+++ b/crates/runner/mitm-addon/tests/test_handlers.py
@@ -22,6 +22,12 @@ import mitm_addon
 import registry as registry_cache
 import response_streaming
 import usage
+from tests.auth_state_helpers import (
+    cached_headers,
+    force_refresh_pending,
+    set_cached_headers,
+    set_last_force_refresh_at,
+)
 from usage import (
     create_anthropic_messages_sse_usage_extractor,
     create_openai_responses_sse_usage_extractor,
@@ -1528,18 +1534,16 @@ class TestResponseHandler:
 
         # Pre-populate firewall header cache keyed by api_id
         cache_key = ("run-conn-1", "run-conn-1:0")
-        auth._firewall_header_cache[cache_key] = {
-            "headers": {"Authorization": "Bearer old-token"},
-        }
+        set_cached_headers(cache_key, headers={"Authorization": "Bearer old-token"})
 
         with mitm_ctx():
             mitm_addon.response(flow)
 
         # Cache entry should have been removed
-        assert cache_key not in auth._firewall_header_cache
+        assert cached_headers(cache_key) is None
         # Force-refresh marker must be set so the next /firewall/auth fetch
         # refreshes the token regardless of DB tokenExpiresAt (#9860).
-        assert cache_key in auth._force_refresh_markers
+        assert force_refresh_pending(cache_key)
 
     def test_401_within_cooldown_does_not_re_mark(self, real_flow, mitm_ctx, headers):
         """A second 401 within the force-refresh cooldown window must NOT
@@ -1558,13 +1562,13 @@ class TestResponseHandler:
 
         cache_key = ("run-conn-cd", "run-conn-cd:0")
         # Simulate: a forced refresh JUST completed a moment ago
-        auth._last_force_refresh_at[cache_key] = time.time()
+        set_last_force_refresh_at(cache_key, time.time())
 
         with mitm_ctx():
             mitm_addon.response(flow)
 
         # Marker was suppressed by the cooldown
-        assert cache_key not in auth._force_refresh_markers
+        assert not force_refresh_pending(cache_key)
 
     def test_401_after_cooldown_re_marks(self, real_flow, mitm_ctx, headers):
         """Once the cooldown has elapsed, a subsequent 401 re-marks — the
@@ -1582,13 +1586,16 @@ class TestResponseHandler:
 
         cache_key = ("run-conn-re", "run-conn-re:0")
         # Simulate: last forced refresh happened well before the cooldown window
-        auth._last_force_refresh_at[cache_key] = time.time() - auth._FORCE_REFRESH_COOLDOWN_SECS - 1
+        set_last_force_refresh_at(
+            cache_key,
+            time.time() - auth._FORCE_REFRESH_COOLDOWN_SECS - 1,
+        )
 
         with mitm_ctx():
             mitm_addon.response(flow)
 
         # Cooldown elapsed → marker re-added
-        assert cache_key in auth._force_refresh_markers
+        assert force_refresh_pending(cache_key)
 
     def test_error_status_logs_warning(self, tmp_path, real_flow, headers):
         """Response with status >= 400 writes to per-job proxy log."""
@@ -5537,10 +5544,11 @@ class TestFirewallHeaderCache:
 
     async def test_cache_hit_skips_fetch(self, headers):
         """Cached entry should be returned without fetching."""
-        auth._firewall_header_cache[("run-1", "api-1")] = {
-            "headers": {"Authorization": "Bearer cached"},
-            "expiresAt": time.time() + 3600,
-        }
+        set_cached_headers(
+            ("run-1", "api-1"),
+            headers={"Authorization": "Bearer cached"},
+            expires_at=time.time() + 3600,
+        )
 
         with patch.object(auth, "_fetch_firewall_headers_sync") as mock_fetch:
             result = await auth.get_firewall_headers("run-1", "api-1", "enc", {}, "tok")
@@ -5553,10 +5561,11 @@ class TestFirewallHeaderCache:
 
     async def test_expired_cache_triggers_fetch(self, headers):
         """Expired cache entry should trigger a new fetch."""
-        auth._firewall_header_cache[("run-1", "api-1")] = {
-            "headers": {"Authorization": "Bearer old"},
-            "expiresAt": time.time() - 10,
-        }
+        set_cached_headers(
+            ("run-1", "api-1"),
+            headers={"Authorization": "Bearer old"},
+            expires_at=time.time() - 10,
+        )
 
         def fresh_fetch(*args, **kwargs):
             return {
@@ -5586,15 +5595,12 @@ class TestFirewallHeaderCache:
         ):
             await auth.get_firewall_headers("run-1", "api-1", "enc", {}, "tok")
 
-        assert ("run-1", "api-1") not in auth._firewall_header_cache
+        assert cached_headers(("run-1", "api-1")) is None
 
     def test_registry_eviction_cleans_locks(self, tmp_path, mitm_ctx, headers):
         """When a run is evicted from registry, its locks should be cleaned up too."""
-        auth._firewall_header_cache[("run-old", "api-1")] = {
-            "headers": {},
-            "expiresAt": None,
-        }
-        auth._cache_locks[("run-old", "api-1")] = asyncio.Lock()
+        cache_key = ("run-old", "api-1")
+        set_cached_headers(cache_key, headers={}, expires_at=None)
 
         registry = {"vms": {"10.200.0.1": {"runId": "run-new", "billableFirewalls": []}}}
         reg_path = tmp_path / "registry.json"
@@ -5606,8 +5612,7 @@ class TestFirewallHeaderCache:
             registry_cache.reset_cache_for_tests()
             registry_cache.load_registry(str(reg_path))
 
-        assert ("run-old", "api-1") not in auth._firewall_header_cache
-        assert ("run-old", "api-1") not in auth._cache_locks
+        assert cache_key not in auth._auth_state
 
 
 class TestUsagePendingCounter:

--- a/crates/runner/mitm-addon/tests/test_handlers.py
+++ b/crates/runner/mitm-addon/tests/test_handlers.py
@@ -25,6 +25,7 @@ import usage
 from tests.auth_state_helpers import (
     cached_headers,
     force_refresh_pending,
+    has_auth_state,
     set_cached_headers,
     set_last_force_refresh_at,
 )
@@ -1558,7 +1559,7 @@ class TestResponseHandler:
         flow.response = tutils.tresp(status_code=401, headers=http.Headers())
 
         cache_key = ("run-conn-new", "run-conn-new:0")
-        assert cache_key not in auth._auth_state
+        assert not has_auth_state(cache_key)
 
         with mitm_ctx():
             mitm_addon.response(flow)
@@ -5633,7 +5634,7 @@ class TestFirewallHeaderCache:
             registry_cache.reset_cache_for_tests()
             registry_cache.load_registry(str(reg_path))
 
-        assert cache_key not in auth._auth_state
+        assert not has_auth_state(cache_key)
 
 
 class TestUsagePendingCounter:

--- a/crates/runner/mitm-addon/tests/test_registry.py
+++ b/crates/runner/mitm-addon/tests/test_registry.py
@@ -1,6 +1,5 @@
 """Tests for registry loading, caching, and network logging."""
 
-import asyncio
 import json
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -8,13 +7,20 @@ from unittest.mock import MagicMock, patch
 import auth
 import logging_utils
 import registry
+from tests.auth_state_helpers import (
+    cached_headers,
+    force_refresh_pending,
+    last_force_refresh_at,
+    mark_force_refresh,
+    set_cached_headers,
+    set_last_force_refresh_at,
+)
 
 
 def _reset_cache():
     """Reset the module-level registry cache between tests."""
     registry.reset_cache_for_tests()
-    auth._firewall_header_cache.clear()
-    auth._cache_locks.clear()
+    auth._auth_state.clear()
 
 
 class TestLoadRegistry:
@@ -143,19 +149,19 @@ class TestLoadRegistry:
 
         # Simulate cached headers, locks, markers, and refresh timestamps
         # for run-abc-123
-        auth._firewall_header_cache[("run-abc-123", "api-0")] = {
-            "headers": {"Authorization": "Bearer tok"},
-        }
-        auth._cache_locks[("run-abc-123", "api-0")] = asyncio.Lock()
-        auth._force_refresh_markers.add(("run-abc-123", "api-0"))
-        auth._last_force_refresh_at[("run-abc-123", "api-0")] = 100.0
+        set_cached_headers(
+            ("run-abc-123", "api-0"),
+            headers={"Authorization": "Bearer tok"},
+        )
+        mark_force_refresh(("run-abc-123", "api-0"))
+        set_last_force_refresh_at(("run-abc-123", "api-0"), 100.0)
         # Also cache for run-other (will appear in new registry)
-        auth._firewall_header_cache[("run-other", "api-0")] = {
-            "headers": {"Authorization": "Bearer other"},
-        }
-        auth._cache_locks[("run-other", "api-0")] = asyncio.Lock()
-        auth._force_refresh_markers.add(("run-other", "api-0"))
-        auth._last_force_refresh_at[("run-other", "api-0")] = 200.0
+        set_cached_headers(
+            ("run-other", "api-0"),
+            headers={"Authorization": "Bearer other"},
+        )
+        mark_force_refresh(("run-other", "api-0"))
+        set_last_force_refresh_at(("run-other", "api-0"), 200.0)
 
         # Update registry: remove run-abc-123, add run-other
         new_data = {"vms": {"10.200.0.99": {"runId": "run-other"}}, "updatedAt": 0}
@@ -164,49 +170,42 @@ class TestLoadRegistry:
         registry.load_registry(str(registry_file))  # reload triggers eviction
 
         # run-abc-123 state should be evicted (no longer in registry)
-        assert ("run-abc-123", "api-0") not in auth._firewall_header_cache
-        assert ("run-abc-123", "api-0") not in auth._cache_locks
-        assert ("run-abc-123", "api-0") not in auth._force_refresh_markers
-        assert ("run-abc-123", "api-0") not in auth._last_force_refresh_at
+        assert ("run-abc-123", "api-0") not in auth._auth_state
         # run-other state should remain (still in registry)
-        assert ("run-other", "api-0") in auth._firewall_header_cache
-        assert ("run-other", "api-0") in auth._cache_locks
-        assert ("run-other", "api-0") in auth._force_refresh_markers
-        assert ("run-other", "api-0") in auth._last_force_refresh_at
+        assert cached_headers(("run-other", "api-0"))
+        assert force_refresh_pending(("run-other", "api-0"))
+        assert last_force_refresh_at(("run-other", "api-0")) == 200.0
 
     def test_parse_failure_does_not_evict_header_cache(self, registry_file):
         """Auth cache eviction only runs after a successfully parsed registry reload."""
         registry.load_registry(str(registry_file))
 
-        auth._firewall_header_cache[("run-abc-123", "api-0")] = {
-            "headers": {"Authorization": "Bearer tok"},
-        }
-        auth._cache_locks[("run-abc-123", "api-0")] = asyncio.Lock()
-        auth._force_refresh_markers.add(("run-abc-123", "api-0"))
-        auth._last_force_refresh_at[("run-abc-123", "api-0")] = 100.0
+        set_cached_headers(
+            ("run-abc-123", "api-0"),
+            headers={"Authorization": "Bearer tok"},
+        )
+        mark_force_refresh(("run-abc-123", "api-0"))
+        set_last_force_refresh_at(("run-abc-123", "api-0"), 100.0)
 
         registry_file.write_text("{ broken while preserving cache")
 
         with patch.object(registry.ctx, "log", MagicMock(), create=True):
             registry.load_registry(str(registry_file))
 
-        assert ("run-abc-123", "api-0") in auth._firewall_header_cache
-        assert ("run-abc-123", "api-0") in auth._cache_locks
-        assert ("run-abc-123", "api-0") in auth._force_refresh_markers
-        assert ("run-abc-123", "api-0") in auth._last_force_refresh_at
+        assert cached_headers(("run-abc-123", "api-0"))
+        assert force_refresh_pending(("run-abc-123", "api-0"))
+        assert last_force_refresh_at(("run-abc-123", "api-0")) == 100.0
 
     def test_registry_entries_without_run_id_do_not_keep_header_cache(self, registry_file):
         """Registry entries with missing/empty runId are not active cache owners."""
         registry.load_registry(str(registry_file))
 
-        auth._firewall_header_cache[("", "api-0")] = {"headers": {}}
-        auth._cache_locks[("", "api-0")] = asyncio.Lock()
-        auth._force_refresh_markers.add(("", "api-0"))
-        auth._last_force_refresh_at[("", "api-0")] = 100.0
-        auth._firewall_header_cache[("run-active", "api-0")] = {"headers": {}}
-        auth._cache_locks[("run-active", "api-0")] = asyncio.Lock()
-        auth._force_refresh_markers.add(("run-active", "api-0"))
-        auth._last_force_refresh_at[("run-active", "api-0")] = 200.0
+        set_cached_headers(("", "api-0"), headers={})
+        mark_force_refresh(("", "api-0"))
+        set_last_force_refresh_at(("", "api-0"), 100.0)
+        set_cached_headers(("run-active", "api-0"), headers={})
+        mark_force_refresh(("run-active", "api-0"))
+        set_last_force_refresh_at(("run-active", "api-0"), 200.0)
 
         registry_file.write_text(
             json.dumps(
@@ -223,14 +222,10 @@ class TestLoadRegistry:
 
         registry.load_registry(str(registry_file))
 
-        assert ("", "api-0") not in auth._firewall_header_cache
-        assert ("", "api-0") not in auth._cache_locks
-        assert ("", "api-0") not in auth._force_refresh_markers
-        assert ("", "api-0") not in auth._last_force_refresh_at
-        assert ("run-active", "api-0") in auth._firewall_header_cache
-        assert ("run-active", "api-0") in auth._cache_locks
-        assert ("run-active", "api-0") in auth._force_refresh_markers
-        assert ("run-active", "api-0") in auth._last_force_refresh_at
+        assert ("", "api-0") not in auth._auth_state
+        assert cached_headers(("run-active", "api-0"))
+        assert force_refresh_pending(("run-active", "api-0"))
+        assert last_force_refresh_at(("run-active", "api-0")) == 200.0
 
 
 class TestGetVmInfo:

--- a/crates/runner/mitm-addon/tests/test_registry.py
+++ b/crates/runner/mitm-addon/tests/test_registry.py
@@ -4,12 +4,13 @@ import json
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-import auth
 import logging_utils
 import registry
 from tests.auth_state_helpers import (
     cached_headers,
+    clear_auth_state,
     force_refresh_pending,
+    has_auth_state,
     last_force_refresh_at,
     mark_force_refresh,
     set_cached_headers,
@@ -20,7 +21,7 @@ from tests.auth_state_helpers import (
 def _reset_cache():
     """Reset the module-level registry cache between tests."""
     registry.reset_cache_for_tests()
-    auth._auth_state.clear()
+    clear_auth_state()
 
 
 class TestLoadRegistry:
@@ -170,7 +171,7 @@ class TestLoadRegistry:
         registry.load_registry(str(registry_file))  # reload triggers eviction
 
         # run-abc-123 state should be evicted (no longer in registry)
-        assert ("run-abc-123", "api-0") not in auth._auth_state
+        assert not has_auth_state(("run-abc-123", "api-0"))
         # run-other state should remain (still in registry)
         assert cached_headers(("run-other", "api-0"))
         assert force_refresh_pending(("run-other", "api-0"))
@@ -207,7 +208,7 @@ class TestLoadRegistry:
 
         registry.load_registry(str(registry_file))
 
-        assert ("run-abc-123", "api-0") not in auth._auth_state
+        assert not has_auth_state(("run-abc-123", "api-0"))
 
     def test_registry_entries_without_run_id_do_not_keep_header_cache(self, registry_file):
         """Registry entries with missing/empty runId are not active cache owners."""
@@ -235,7 +236,7 @@ class TestLoadRegistry:
 
         registry.load_registry(str(registry_file))
 
-        assert ("", "api-0") not in auth._auth_state
+        assert not has_auth_state(("", "api-0"))
         assert cached_headers(("run-active", "api-0"))
         assert force_refresh_pending(("run-active", "api-0"))
         assert last_force_refresh_at(("run-active", "api-0")) == 200.0

--- a/crates/runner/mitm-addon/tests/test_registry.py
+++ b/crates/runner/mitm-addon/tests/test_registry.py
@@ -196,6 +196,19 @@ class TestLoadRegistry:
         assert force_refresh_pending(("run-abc-123", "api-0"))
         assert last_force_refresh_at(("run-abc-123", "api-0")) == 100.0
 
+    def test_evicts_marker_only_auth_state_on_run_removal(self, registry_file):
+        """Registry eviction removes auth state even when it has no cached headers."""
+        registry.load_registry(str(registry_file))
+
+        mark_force_refresh(("run-abc-123", "api-0"))
+        set_last_force_refresh_at(("run-abc-123", "api-0"), 100.0)
+
+        registry_file.write_text(json.dumps({"vms": {}, "updatedAt": 0}))
+
+        registry.load_registry(str(registry_file))
+
+        assert ("run-abc-123", "api-0") not in auth._auth_state
+
     def test_registry_entries_without_run_id_do_not_keep_header_cache(self, registry_file):
         """Registry entries with missing/empty runId are not active cache owners."""
         registry.load_registry(str(registry_file))


### PR DESCRIPTION
## Summary

- Consolidate MITM firewall auth lifecycle state into a single per-key `_auth_state` object.
- Keep cached header data nested under `state.cache` so 401 invalidation clears only cached headers while preserving cooldown state.
- Replace direct `_firewall_header_cache` access from `mitm_addon.py` with a named helper and update tests to use the new state model.

Closes #14265.

## Tests

- `python3 -m pytest tests/test_connectors.py tests/test_handlers.py tests/test_registry.py`
- `python3 -m pytest`
- `python3 -m ruff check src tests`
- `python3 -m ruff format --check src tests`

Note: `uv` is not installed in this container, so I used the equivalent `python3 -m` commands after installing the mitm-addon test/lint dependencies locally.
