### PR TITLE
perf(mitm-addon): compile firewall matcher artifacts

### DIFF
--- a/crates/runner/mitm-addon/src/matching.py
+++ b/crates/runner/mitm-addon/src/matching.py
@@ -24,6 +24,63 @@ class _BaseUrlParts(NamedTuple):
     path: str
 
 
+class SegmentLiteral(NamedTuple):
+    value: str
+
+
+class SegmentParam(NamedTuple):
+    prefix: str
+    name: str
+    suffix: str
+    greedy: str
+
+
+class SegmentError(NamedTuple):
+    reason: str
+
+
+ParsedSegment = SegmentLiteral | SegmentParam | SegmentError
+
+
+class CompiledPathPattern(NamedTuple):
+    segments: tuple[ParsedSegment, ...]
+
+
+class _CompiledBase(NamedTuple):
+    raw: str
+    parts: _BaseUrlParts
+    has_params: bool
+    host_segments: tuple[ParsedSegment, ...]
+    path_segments: tuple[ParsedSegment, ...]
+
+
+class _CompiledRule(NamedTuple):
+    method: str
+    raw: str
+    path: CompiledPathPattern
+
+
+class _CompiledPermission(NamedTuple):
+    name: str
+    rules: tuple[_CompiledRule, ...]
+
+
+class _CompiledApi(NamedTuple):
+    raw_api_entry: dict
+    base: _CompiledBase
+    permissions: tuple[_CompiledPermission, ...]
+    has_malformed_rules: bool
+
+
+class _CompiledFirewall(NamedTuple):
+    name: str
+    apis: tuple[_CompiledApi, ...]
+
+
+class CompiledFirewallSet(NamedTuple):
+    firewalls: tuple[_CompiledFirewall, ...]
+
+
 def _split_base_match_url(
     value: str,
     *,
@@ -51,6 +108,52 @@ def _split_base_match_url(
     )
 
 
+def _parse_segment(seg: str) -> ParsedSegment:
+    """Parse a single host or path segment into an immutable result."""
+    open_count = seg.count("{")
+    close_count = seg.count("}")
+
+    if open_count == 0 and close_count == 0:
+        return SegmentLiteral(seg)
+    if open_count != close_count:
+        return SegmentError(f'unbalanced brace in segment "{seg}" — {_SEGMENT_ERROR_HINT}')
+
+    open1 = seg.find("{")
+    close1 = seg.find("}")
+    if close1 < open1:
+        return SegmentError(f'unbalanced brace in segment "{seg}" — {_SEGMENT_ERROR_HINT}')
+
+    if open_count >= _MULTI_PARAM_BRACE_COUNT:
+        open2 = seg.find("{", close1 + 1)
+        if close1 + 1 == open2:
+            return SegmentError(
+                f'adjacent parameters in segment "{seg}" — only one parameter '
+                f"per segment is allowed; {_SEGMENT_ERROR_HINT}"
+            )
+        return SegmentError(
+            f'literal-separated parameters in segment "{seg}" — only one parameter '
+            f"per segment is allowed; {_SEGMENT_ERROR_HINT}"
+        )
+
+    prefix = seg[:open1]
+    content = seg[open1 + 1 : close1]
+    suffix = seg[close1 + 1 :]
+
+    if "{" in prefix or "}" in prefix or "{" in suffix or "}" in suffix:
+        return SegmentError(f'unbalanced brace in segment "{seg}" — {_SEGMENT_ERROR_HINT}')
+
+    greedy = ""
+    name = content
+    if len(content) > 0 and content[-1] in ("+", "*"):
+        greedy = content[-1]
+        name = content[:-1]
+
+    if len(name) == 0:
+        return SegmentError(f'empty parameter name in segment "{seg}" — {_SEGMENT_ERROR_HINT}')
+
+    return SegmentParam(prefix, name, suffix, greedy)
+
+
 def parse_segment(seg: str) -> dict:
     """Parse a single host or path segment into literal / param / error.
 
@@ -64,72 +167,18 @@ def parse_segment(seg: str) -> dict:
        "greedy": "" | "+" | "*"}
       {"kind": "error", "reason": str}
     """
-    open_count = seg.count("{")
-    close_count = seg.count("}")
-
-    if open_count == 0 and close_count == 0:
-        return {"kind": "literal", "value": seg}
-    if open_count != close_count:
+    parsed = _parse_segment(seg)
+    if isinstance(parsed, SegmentLiteral):
+        return {"kind": "literal", "value": parsed.value}
+    if isinstance(parsed, SegmentParam):
         return {
-            "kind": "error",
-            "reason": f'unbalanced brace in segment "{seg}" — {_SEGMENT_ERROR_HINT}',
+            "kind": "param",
+            "prefix": parsed.prefix,
+            "name": parsed.name,
+            "suffix": parsed.suffix,
+            "greedy": parsed.greedy,
         }
-
-    open1 = seg.find("{")
-    close1 = seg.find("}")
-    if close1 < open1:
-        return {
-            "kind": "error",
-            "reason": f'unbalanced brace in segment "{seg}" — {_SEGMENT_ERROR_HINT}',
-        }
-
-    if open_count >= _MULTI_PARAM_BRACE_COUNT:
-        open2 = seg.find("{", close1 + 1)
-        if close1 + 1 == open2:
-            return {
-                "kind": "error",
-                "reason": (
-                    f'adjacent parameters in segment "{seg}" — only one parameter '
-                    f"per segment is allowed; {_SEGMENT_ERROR_HINT}"
-                ),
-            }
-        return {
-            "kind": "error",
-            "reason": (
-                f'literal-separated parameters in segment "{seg}" — only one parameter '
-                f"per segment is allowed; {_SEGMENT_ERROR_HINT}"
-            ),
-        }
-
-    prefix = seg[:open1]
-    content = seg[open1 + 1 : close1]
-    suffix = seg[close1 + 1 :]
-
-    if "{" in prefix or "}" in prefix or "{" in suffix or "}" in suffix:
-        return {
-            "kind": "error",
-            "reason": f'unbalanced brace in segment "{seg}" — {_SEGMENT_ERROR_HINT}',
-        }
-
-    greedy = ""
-    name = content
-    if len(content) > 0 and content[-1] in ("+", "*"):
-        greedy = content[-1]
-        name = content[:-1]
-
-    if len(name) == 0:
-        return {
-            "kind": "error",
-            "reason": f'empty parameter name in segment "{seg}" — {_SEGMENT_ERROR_HINT}',
-        }
-
-    return {
-        "kind": "param",
-        "prefix": prefix,
-        "name": name,
-        "suffix": suffix,
-        "greedy": greedy,
-    }
+    return {"kind": "error", "reason": parsed.reason}
 
 
 def _match_segment_literal(runtime: str, prefix: str, suffix: str) -> str | None:
@@ -387,6 +436,300 @@ def match_path(path: str, pattern: str) -> dict | None:
     return params
 
 
+def _compile_segments(segments: list[str] | tuple[str, ...]) -> tuple[ParsedSegment, ...] | None:
+    parsed = tuple(_parse_segment(seg) for seg in segments)
+    if any(isinstance(seg, SegmentError) for seg in parsed):
+        return None
+    return parsed
+
+
+def compile_path_pattern(pattern: str) -> CompiledPathPattern | None:
+    """Compile a URL path pattern for repeated matching."""
+    segments = _compile_segments(tuple(s for s in pattern.split("/") if s))
+    if segments is None:
+        return None
+    return CompiledPathPattern(segments)
+
+
+def _match_compiled_path_segments(
+    path_segs: list[str],
+    pattern_segs: tuple[ParsedSegment, ...],
+) -> dict | None:
+    params: dict[str, str] = {}
+    pi = 0
+
+    for parsed in pattern_segs:
+        if isinstance(parsed, SegmentLiteral):
+            if pi >= len(path_segs) or path_segs[pi] != parsed.value:
+                return None
+            pi += 1
+            continue
+
+        if isinstance(parsed, SegmentError):
+            return None
+
+        if parsed.greedy == "+":
+            if pi >= len(path_segs):
+                return None
+            params[parsed.name] = "/".join(path_segs[pi:])
+            return params
+        if parsed.greedy == "*":
+            params[parsed.name] = "/".join(path_segs[pi:])
+            return params
+        if pi >= len(path_segs):
+            return None
+
+        runtime = path_segs[pi]
+        if parsed.prefix == "" and parsed.suffix == "":
+            params[parsed.name] = runtime
+        else:
+            captured = _match_segment_literal(runtime, parsed.prefix, parsed.suffix)
+            if captured is None:
+                return None
+            params[parsed.name] = captured
+        pi += 1
+
+    if pi != len(path_segs):
+        return None
+    return params
+
+
+def match_compiled_path(path: str, pattern: CompiledPathPattern) -> dict | None:
+    """Match a URL path against a compiled rule path pattern."""
+    return _match_compiled_path_segments([s for s in path.split("/") if s], pattern.segments)
+
+
+def _match_compiled_path_prefix(
+    path_segs: list[str],
+    pattern_segs: tuple[ParsedSegment, ...],
+) -> tuple[dict, int] | None:
+    params: dict[str, str] = {}
+    pi = 0
+
+    for parsed in pattern_segs:
+        if isinstance(parsed, SegmentLiteral):
+            if pi >= len(path_segs) or path_segs[pi] != parsed.value:
+                return None
+            pi += 1
+            continue
+
+        if isinstance(parsed, SegmentError):
+            return None
+        if pi >= len(path_segs):
+            return None
+
+        runtime = path_segs[pi]
+        if parsed.prefix == "" and parsed.suffix == "":
+            params[parsed.name] = runtime
+        else:
+            captured = _match_segment_literal(runtime, parsed.prefix, parsed.suffix)
+            if captured is None:
+                return None
+            params[parsed.name] = captured
+        pi += 1
+
+    return params, pi
+
+
+def _match_compiled_host(
+    host: str,
+    pattern_segs_reversed: tuple[ParsedSegment, ...],
+) -> dict | None:
+    host_segs_orig = host.split(".")
+    host_segs_lower = [s.lower() for s in host_segs_orig]
+    host_segs_orig = list(reversed(host_segs_orig))
+    host_segs_lower = list(reversed(host_segs_lower))
+
+    params: dict[str, str] = {}
+    hi = 0
+    for parsed in pattern_segs_reversed:
+        if isinstance(parsed, SegmentLiteral):
+            if hi >= len(host_segs_lower) or host_segs_lower[hi] != parsed.value.lower():
+                return None
+            hi += 1
+            continue
+
+        if isinstance(parsed, SegmentError):
+            return None
+
+        if parsed.greedy == "+":
+            if hi >= len(host_segs_orig):
+                return None
+            remaining = list(reversed(host_segs_orig[hi:]))
+            params[parsed.name] = ".".join(remaining)
+            return params
+        if parsed.greedy == "*":
+            remaining = list(reversed(host_segs_orig[hi:]))
+            params[parsed.name] = ".".join(remaining)
+            return params
+        if hi >= len(host_segs_orig):
+            return None
+        if parsed.prefix == "" and parsed.suffix == "":
+            params[parsed.name] = host_segs_lower[hi]
+        else:
+            captured = _match_segment_literal(
+                host_segs_lower[hi],
+                parsed.prefix.lower(),
+                parsed.suffix.lower(),
+            )
+            if captured is None:
+                return None
+            params[parsed.name] = captured
+        hi += 1
+
+    if hi != len(host_segs_orig):
+        return None
+    return params
+
+
+def _compile_base(raw_base: str) -> _CompiledBase | None:
+    base = raw_base.rstrip("/")
+    if not base:
+        return None
+
+    has_params = "{" in base
+    parts = _split_base_match_url(base, allow_query_fragment=False)
+    if parts is None:
+        return None
+
+    host_segments: tuple[ParsedSegment, ...] = ()
+    path_segments: tuple[ParsedSegment, ...] = ()
+    if has_params:
+        compiled_host = _compile_segments(tuple(reversed(parts.authority.split("."))))
+        if compiled_host is None:
+            return None
+        host_segments = compiled_host
+        compiled_path = _compile_segments(tuple(s for s in parts.path.split("/") if s))
+        if compiled_path is None:
+            return None
+        path_segments = compiled_path
+
+    return _CompiledBase(base, parts, has_params, host_segments, path_segments)
+
+
+def _match_compiled_base_url_parts(
+    url_parts: _BaseUrlParts,
+    base: _CompiledBase,
+) -> tuple[str, dict] | None:
+    if not base.has_params:
+        if url_parts.scheme.lower() != base.parts.scheme.lower():
+            return None
+        if url_parts.authority.lower() != base.parts.authority.lower():
+            return None
+
+        base_path = base.parts.path
+        if base_path and not url_parts.path.startswith(base_path):
+            return None
+        rest = url_parts.path[len(base_path) :] if base_path else url_parts.path
+        if rest and rest[0] != "/":
+            return None
+        rel_path = rest or "/"
+        return rel_path, {}
+
+    if url_parts.scheme.lower() != base.parts.scheme.lower():
+        return None
+
+    host_params = _match_compiled_host(url_parts.authority, base.host_segments)
+    if host_params is None:
+        return None
+
+    base_path = base.parts.path
+    clean_url_path = url_parts.path
+    if base_path and base_path != "/":
+        url_path_segs = [s for s in clean_url_path.split("/") if s]
+        path_result = _match_compiled_path_prefix(url_path_segs, base.path_segments)
+        if path_result is None:
+            return None
+        path_params, consumed = path_result
+        remaining_segs = url_path_segs[consumed:]
+        rel_path = "/" + "/".join(remaining_segs) if remaining_segs else "/"
+        all_params = {**host_params, **path_params}
+    else:
+        rel_path = clean_url_path or "/"
+        all_params = host_params
+
+    return rel_path, all_params
+
+
+def _compile_rule(rule_str: str) -> _CompiledRule | None:
+    parts = rule_str.split(" ", 1)
+    if len(parts) != _RULE_TOKEN_COUNT:
+        return None
+    pattern = compile_path_pattern(parts[1])
+    if pattern is None:
+        return None
+    return _CompiledRule(parts[0].upper(), rule_str, pattern)
+
+
+def compile_firewalls(vm_firewalls: list | None) -> CompiledFirewallSet | None:
+    """Compile raw firewall config into immutable matcher-side data."""
+    if not vm_firewalls:
+        return None
+
+    compiled_firewalls: list[_CompiledFirewall] = []
+    for fw_entry in vm_firewalls:
+        if not isinstance(fw_entry, dict):
+            continue
+
+        raw_apis = fw_entry.get("apis", [])
+        if not isinstance(raw_apis, list):
+            continue
+
+        compiled_apis: list[_CompiledApi] = []
+        for api_entry in raw_apis:
+            if not isinstance(api_entry, dict):
+                continue
+            raw_base = api_entry.get("base", "")
+            if not isinstance(raw_base, str):
+                continue
+            base = _compile_base(raw_base)
+            if base is None:
+                continue
+
+            compiled_permissions: list[_CompiledPermission] = []
+            has_malformed_rules = False
+            permissions = api_entry.get("permissions")
+            if isinstance(permissions, list):
+                for perm in permissions:
+                    if not isinstance(perm, dict):
+                        has_malformed_rules = True
+                        continue
+                    raw_rules = perm.get("rules", [])
+                    if not isinstance(raw_rules, list):
+                        raw_rules = []
+                        has_malformed_rules = True
+
+                    compiled_rules: list[_CompiledRule] = []
+                    for rule_str in raw_rules:
+                        if not isinstance(rule_str, str):
+                            has_malformed_rules = True
+                            continue
+                        rule = _compile_rule(rule_str)
+                        if rule is None:
+                            has_malformed_rules = True
+                            continue
+                        compiled_rules.append(rule)
+
+                    compiled_permissions.append(
+                        _CompiledPermission(perm.get("name", ""), tuple(compiled_rules))
+                    )
+            elif permissions is not None:
+                has_malformed_rules = True
+
+            compiled_apis.append(
+                _CompiledApi(api_entry, base, tuple(compiled_permissions), has_malformed_rules)
+            )
+
+        if compiled_apis:
+            compiled_firewalls.append(
+                _CompiledFirewall(fw_entry.get("name", ""), tuple(compiled_apis))
+            )
+
+    if not compiled_firewalls:
+        return None
+    return CompiledFirewallSet(tuple(compiled_firewalls))
+
+
 class FirewallAllow(NamedTuple):
     """Permission matched — inject auth headers."""
 
@@ -435,6 +778,108 @@ def _get_unknown_policy(
     if grant is None:
         return "allow"
     return grant.get("unknownPolicy", "allow")
+
+
+def match_compiled_firewall_request(
+    url: str,
+    method: str,
+    compiled_firewalls: CompiledFirewallSet | None,
+    network_policies: dict | None = None,
+) -> FirewallAllow | FirewallBlock | None:
+    """Match request against precompiled firewall permissions."""
+    if not compiled_firewalls:
+        return None
+
+    url_parts = _split_base_match_url(url)
+    if url_parts is None:
+        return None
+
+    if network_policies is None:
+        network_policies = {}
+
+    blocked_base = None
+    blocked_name = ""
+    blocked_rel_path = "/"
+    first_matched_api_entry = None
+    first_matched_base_params: dict = {}
+
+    upper_method = method.upper()
+
+    denied_match: tuple[str, str, str, str] | None = None
+    denied_perm_names: list[str] = []
+    malformed_match: tuple[str, str, str, str] | None = None
+
+    for fw_entry in compiled_firewalls.firewalls:
+        block_set = _build_block_set(fw_entry.name, network_policies)
+
+        for api_entry in fw_entry.apis:
+            base_result = _match_compiled_base_url_parts(url_parts, api_entry.base)
+            if base_result is None:
+                continue
+
+            rel_path, base_params = base_result
+
+            if blocked_base is None:
+                blocked_base = api_entry.base.raw
+                blocked_name = fw_entry.name
+                blocked_rel_path = rel_path
+                first_matched_api_entry = api_entry.raw_api_entry
+                first_matched_base_params = base_params
+            if api_entry.has_malformed_rules and malformed_match is None:
+                malformed_match = (api_entry.base.raw, fw_entry.name, upper_method, rel_path)
+
+            if not api_entry.permissions:
+                continue
+
+            rel_path_segs = [s for s in rel_path.split("/") if s]
+            for perm in api_entry.permissions:
+                for rule in perm.rules:
+                    if rule.method not in ("ANY", upper_method):
+                        continue
+
+                    params = _match_compiled_path_segments(rel_path_segs, rule.path.segments)
+                    if params is not None:
+                        all_params = {**base_params, **params}
+
+                        if perm.name not in block_set:
+                            return FirewallAllow(
+                                api_entry.raw_api_entry,
+                                {
+                                    "name": fw_entry.name,
+                                    "permission": perm.name,
+                                    "params": all_params,
+                                    "rule": rule.raw,
+                                    "rel_path": rel_path,
+                                },
+                            )
+                        if perm.name not in denied_perm_names:
+                            denied_perm_names.append(perm.name)
+                        if denied_match is None:
+                            denied_match = (
+                                api_entry.base.raw,
+                                fw_entry.name,
+                                upper_method,
+                                rel_path,
+                            )
+
+    if blocked_base is not None:
+        if denied_match is not None:
+            return FirewallBlock(*denied_match, tuple(denied_perm_names))
+        if malformed_match is not None:
+            return FirewallBlock(*malformed_match, ())
+        if _get_unknown_policy(blocked_name, network_policies) == "allow":
+            return FirewallAllow(
+                first_matched_api_entry,
+                {
+                    "name": blocked_name,
+                    "permission": "",
+                    "params": first_matched_base_params,
+                    "rule": "",
+                    "rel_path": blocked_rel_path,
+                },
+            )
+        return FirewallBlock(blocked_base, blocked_name, upper_method, blocked_rel_path, ())
+    return None
 
 
 def match_firewall_request(

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -40,7 +40,7 @@ from auth import (
     request_force_refresh,
 )
 from logging_utils import add_firewall_metadata, log_network_entry, log_proxy_entry
-from matching import FirewallAllow, FirewallBlock, match_firewall_request
+from matching import FirewallAllow, FirewallBlock, match_compiled_firewall_request
 from url_utils import get_original_url
 
 # HTTP status boundaries used in response-phase classification.
@@ -150,11 +150,12 @@ async def request(flow: http.HTTPFlow) -> None:
         return
 
     # Look up VM info from registry
-    vm_info = registry.get_vm_info(client_ip, get_registry_path())
+    vm_context = registry.get_vm_context(client_ip, get_registry_path())
 
-    if not vm_info:
+    if not vm_context:
         # Not a registered VM, pass through without proxying
         return
+    vm_info, compiled_firewalls = vm_context
 
     run_id = vm_info.get("runId", "")
 
@@ -198,13 +199,12 @@ async def request(flow: http.HTTPFlow) -> None:
 
         # --- Step 2: Firewall match with permission check ---
         # Match base URL, then check permission rules before injecting auth headers.
-        vm_firewalls = vm_info.get("firewalls")
-        if vm_firewalls:
+        if compiled_firewalls:
             network_policies = vm_info.get("networkPolicies") or {}
-            result = match_firewall_request(
+            result = match_compiled_firewall_request(
                 original_url,
                 flow.request.method,
-                vm_firewalls,
+                compiled_firewalls,
                 network_policies,
             )
             if isinstance(result, FirewallBlock):

--- a/crates/runner/mitm-addon/src/registry.py
+++ b/crates/runner/mitm-addon/src/registry.py
@@ -6,9 +6,11 @@ from pathlib import Path
 from mitmproxy import ctx
 
 from auth import evict_stale_cache_keys
+from matching import CompiledFirewallSet, compile_firewalls
 
 # Cache for proxy registry (invalidated by file stat change).
 _registry_cache: dict = {}
+_registry_compiled_cache: dict[str, CompiledFirewallSet] = {}
 _registry_cache_key: tuple[int, int] = (0, 0)
 # One-shot guard for stat-path failures: no cache key is available in that
 # branch, so we fall back to a flag (mirrors counters.py:_pending_write_error_logged).
@@ -20,15 +22,28 @@ _registry_load_error_logged = False
 
 def reset_cache_for_tests() -> None:
     """Reset module cache state between tests."""
-    global _registry_cache, _registry_cache_key, _registry_load_error_logged
+    global _registry_cache, _registry_compiled_cache, _registry_cache_key
+    global _registry_load_error_logged
     _registry_cache = {}
+    _registry_compiled_cache = {}
     _registry_cache_key = (0, 0)
     _registry_load_error_logged = False
 
 
+def _compile_registry(new_registry: dict) -> dict[str, CompiledFirewallSet]:
+    compiled: dict[str, CompiledFirewallSet] = {}
+    for client_ip, vm in new_registry.items():
+        firewalls = vm.get("firewalls") if isinstance(vm, dict) else None
+        compiled_firewalls = compile_firewalls(firewalls)
+        if compiled_firewalls is not None:
+            compiled[client_ip] = compiled_firewalls
+    return compiled
+
+
 def load_registry(registry_path: str) -> dict:
     """Load the proxy registry from file, with stat-based cache invalidation."""
-    global _registry_cache, _registry_cache_key, _registry_load_error_logged
+    global _registry_cache, _registry_compiled_cache, _registry_cache_key
+    global _registry_load_error_logged
 
     path = Path(registry_path)
     try:
@@ -46,12 +61,14 @@ def load_registry(registry_path: str) -> dict:
     try:
         with path.open() as f:
             new_registry = json.load(f).get("vms", {})
+        new_compiled_registry = _compile_registry(new_registry)
 
         # Evict cache entries for runs no longer in the registry.
         active_run_ids = {run_id for vm in new_registry.values() if (run_id := vm.get("runId"))}
         evict_stale_cache_keys(active_run_ids)
 
         _registry_cache = new_registry
+        _registry_compiled_cache = new_compiled_registry
         _registry_load_error_logged = False
     except Exception as e:
         if not _registry_load_error_logged:
@@ -67,3 +84,14 @@ def load_registry(registry_path: str) -> dict:
 def get_vm_info(client_ip: str, registry_path: str) -> dict | None:
     """Look up VM info by client IP address."""
     return load_registry(registry_path).get(client_ip)
+
+
+def get_vm_context(
+    client_ip: str,
+    registry_path: str,
+) -> tuple[dict, CompiledFirewallSet | None] | None:
+    """Look up raw VM info with its compiled firewall matcher sidecar."""
+    vm_info = load_registry(registry_path).get(client_ip)
+    if vm_info is None:
+        return None
+    return vm_info, _registry_compiled_cache.get(client_ip)

--- a/crates/runner/mitm-addon/src/usage/providers/connectors/x_billing.py
+++ b/crates/runner/mitm-addon/src/usage/providers/connectors/x_billing.py
@@ -53,7 +53,7 @@ sheet for drift.
 import json
 import re
 
-from matching import match_path
+from matching import CompiledPathPattern, compile_path_pattern, match_compiled_path
 
 from .x_tlds import IANA_TLDS
 
@@ -203,15 +203,18 @@ _PATH_OVERRIDES: list[tuple[str, str, str, str]] = [
 
 def _build_override_index(
     overrides: list[tuple[str, str, str, str]],
-) -> dict[tuple[str, str], list[tuple[str, str]]]:
+) -> dict[tuple[str, str], list[tuple[CompiledPathPattern, str]]]:
     """Group overrides by ``(scope, method)`` so :func:`classify_bucket`
     only walks patterns under the matching scope/method instead of the
     full list.  Insertion order is preserved inside each bucket, which
     keeps first-match-wins semantics from the source list.
     """
-    index: dict[tuple[str, str], list[tuple[str, str]]] = {}
+    index: dict[tuple[str, str], list[tuple[CompiledPathPattern, str]]] = {}
     for scope, method, pattern, bucket in overrides:
-        index.setdefault((scope, method), []).append((pattern, bucket))
+        compiled_pattern = compile_path_pattern(pattern)
+        if compiled_pattern is None:
+            raise ValueError(f"invalid X billing override path pattern: {scope} {method} {pattern}")
+        index.setdefault((scope, method), []).append((compiled_pattern, bucket))
     return index
 
 
@@ -230,7 +233,7 @@ def classify_bucket(permission: str, method: str, path: str) -> str | None:
     case.
     """
     for pattern, bucket in _OVERRIDE_INDEX.get((permission, method.upper()), ()):
-        if match_path(path, pattern) is not None:
+        if match_compiled_path(path, pattern) is not None:
             return bucket
     return _PERMISSION_TO_BUCKET.get(permission)
 

--- a/crates/runner/mitm-addon/tests/test_connectors.py
+++ b/crates/runner/mitm-addon/tests/test_connectors.py
@@ -3554,6 +3554,144 @@ class TestCompiledFirewallMatching:
             "path": "a/b/c",
         }
 
+    def test_matches_raw_for_static_base_boundary_and_query(self):
+        fws = _wrap_firewalls(
+            [
+                {
+                    "base": "https://api.anthropic.com/v1/messages",
+                    "auth": {"headers": {"Authorization": "Bearer token"}},
+                    "permissions": [
+                        {"name": "messages", "rules": ["ANY /{path*}"]},
+                    ],
+                }
+            ],
+            name="anthropic",
+        )
+        compiled_firewalls = self._compiled(fws)
+        policies = {"anthropic": {"allow": ["messages"], "deny": [], "unknownPolicy": "deny"}}
+
+        url = "https://api.anthropic.com/v1/messages?beta=1"
+        raw = matching.match_firewall_request(url, "GET", fws, policies)
+        compiled = matching.match_compiled_firewall_request(
+            url,
+            "GET",
+            compiled_firewalls,
+            policies,
+        )
+        self._assert_same_result(raw, compiled)
+        assert isinstance(compiled, FirewallAllow)
+        assert compiled.match_info["rel_path"] == "/"
+
+        url = "https://api.anthropic.com/v1/messages_fake"
+        raw = matching.match_firewall_request(url, "GET", fws, policies)
+        compiled = matching.match_compiled_firewall_request(
+            url,
+            "GET",
+            compiled_firewalls,
+            policies,
+        )
+        self._assert_same_result(raw, compiled)
+        assert compiled is None
+
+    def test_matches_raw_for_parameterized_host_nonstandard_port_rejection(self):
+        fws = _wrap_firewalls(
+            [
+                {
+                    "base": "https://api-{region}.example.com",
+                    "auth": {"headers": {"Authorization": "Bearer token"}},
+                    "permissions": [
+                        {"name": "read", "rules": ["GET /items"]},
+                    ],
+                }
+            ],
+            name="example",
+        )
+        url = "https://api-us.example.com:8443/items"
+        policies = {"example": {"allow": ["read"], "deny": [], "unknownPolicy": "deny"}}
+
+        raw = matching.match_firewall_request(url, "GET", fws, policies)
+        compiled = matching.match_compiled_firewall_request(
+            url,
+            "GET",
+            self._compiled(fws),
+            policies,
+        )
+
+        self._assert_same_result(raw, compiled)
+        assert compiled is None
+
+    def test_matches_raw_for_unknown_policy_when_api_has_no_permissions(self):
+        fws = _wrap_firewalls(
+            [
+                {
+                    "base": "https://api.example.com",
+                    "auth": {"headers": {"Authorization": "Bearer token"}},
+                    "permissions": [],
+                }
+            ],
+            name="example",
+        )
+        compiled_firewalls = self._compiled(fws)
+        url = "https://api.example.com/items"
+
+        allow_policies = {"example": {"allow": [], "deny": [], "unknownPolicy": "allow"}}
+        raw = matching.match_firewall_request(url, "GET", fws, allow_policies)
+        compiled = matching.match_compiled_firewall_request(
+            url,
+            "GET",
+            compiled_firewalls,
+            allow_policies,
+        )
+        self._assert_same_result(raw, compiled)
+        assert isinstance(compiled, FirewallAllow)
+        assert compiled.match_info["permission"] == ""
+
+        ask_policies = {"example": {"allow": [], "deny": [], "unknownPolicy": "ask"}}
+        raw = matching.match_firewall_request(url, "GET", fws, ask_policies)
+        compiled = matching.match_compiled_firewall_request(
+            url,
+            "GET",
+            compiled_firewalls,
+            ask_policies,
+        )
+        self._assert_same_result(raw, compiled)
+        assert isinstance(compiled, FirewallBlock)
+
+    def test_matches_raw_for_ask_permission_block(self):
+        fws = _wrap_firewalls(
+            [
+                {
+                    "base": "https://api.github.com",
+                    "auth": {"headers": {"Authorization": "Bearer token"}},
+                    "permissions": [
+                        {"name": "repo-read", "rules": ["GET /repos/{owner}/{repo}"]},
+                    ],
+                }
+            ],
+            name="github",
+        )
+        policies = {
+            "github": {
+                "allow": [],
+                "ask": ["repo-read"],
+                "deny": [],
+                "unknownPolicy": "allow",
+            }
+        }
+        url = "https://api.github.com/repos/org/repo"
+
+        raw = matching.match_firewall_request(url, "GET", fws, policies)
+        compiled = matching.match_compiled_firewall_request(
+            url,
+            "GET",
+            self._compiled(fws),
+            policies,
+        )
+
+        self._assert_same_result(raw, compiled)
+        assert isinstance(compiled, FirewallBlock)
+        assert compiled.permissions == ("repo-read",)
+
     def test_preserves_raw_rule_order_for_any_before_exact_method(self):
         api_entry = {
             "base": "https://api.github.com",

--- a/crates/runner/mitm-addon/tests/test_connectors.py
+++ b/crates/runner/mitm-addon/tests/test_connectors.py
@@ -3492,7 +3492,8 @@ class TestThreeLevelMatching:
         assert isinstance(result, FirewallAllow)
         assert result.match_info["permission"] == "repo-read"
 
-        # Second API: no permissions defined, base matches → unknown → ALLOW (unknownPolicy: allow)
+        # Second API: no permissions defined, base matches → unknown
+        # → ALLOW (unknownPolicy: allow)
         result = matching.match_firewall_request(
             "https://uploads.github.com/anything",
             "POST",
@@ -3501,3 +3502,300 @@ class TestThreeLevelMatching:
         )
         assert isinstance(result, FirewallAllow)
         assert result.match_info["permission"] == ""
+
+
+class TestCompiledFirewallMatching:
+    def _compiled(self, firewalls):
+        compiled = matching.compile_firewalls(firewalls)
+        assert compiled is not None
+        return compiled
+
+    def _assert_same_result(self, raw, compiled):
+        assert type(compiled) is type(raw)
+        if isinstance(raw, FirewallAllow):
+            assert isinstance(compiled, FirewallAllow)
+            assert compiled.api_entry is raw.api_entry
+            assert compiled.match_info == raw.match_info
+            return
+        if isinstance(raw, FirewallBlock):
+            assert compiled == raw
+            return
+        assert compiled is raw
+
+    def test_matches_raw_for_mixed_base_and_greedy_rule(self):
+        fws = _wrap_firewalls(
+            [
+                {
+                    "base": "https://api-{region}.example.com/v1/{org}",
+                    "auth": {"headers": {"Authorization": "Bearer token"}},
+                    "permissions": [
+                        {"name": "upload", "rules": ["POST /upload/{path+}"]},
+                    ],
+                }
+            ],
+            name="storage",
+        )
+        url = "https://api-us.example.com/v1/acme/upload/a/b/c"
+        policies = {"storage": {"allow": ["upload"], "deny": [], "unknownPolicy": "deny"}}
+
+        raw = matching.match_firewall_request(url, "POST", fws, policies)
+        compiled = matching.match_compiled_firewall_request(
+            url,
+            "POST",
+            self._compiled(fws),
+            policies,
+        )
+
+        self._assert_same_result(raw, compiled)
+        assert isinstance(compiled, FirewallAllow)
+        assert compiled.match_info["params"] == {
+            "region": "us",
+            "org": "acme",
+            "path": "a/b/c",
+        }
+
+    def test_preserves_raw_rule_order_for_any_before_exact_method(self):
+        api_entry = {
+            "base": "https://api.github.com",
+            "auth": {"headers": {"Authorization": "Bearer token"}},
+            "permissions": [
+                {
+                    "name": "repo-read",
+                    "rules": [
+                        "ANY /repos/{owner}/{repo}",
+                        "GET /repos/{owner}/{repo}",
+                    ],
+                }
+            ],
+        }
+        fws = _wrap_firewalls([api_entry], name="github")
+        policies = {"github": {"allow": ["repo-read"], "deny": [], "unknownPolicy": "deny"}}
+
+        result = matching.match_compiled_firewall_request(
+            "https://api.github.com/repos/org/repo",
+            "GET",
+            self._compiled(fws),
+            policies,
+        )
+
+        assert isinstance(result, FirewallAllow)
+        assert result.api_entry is api_entry
+        assert result.match_info["rule"] == "ANY /repos/{owner}/{repo}"
+
+    def test_later_allowed_permission_still_wins_after_earlier_denied_match(self):
+        fws = _wrap_firewalls(
+            [
+                {
+                    "base": "https://api.github.com",
+                    "auth": {"headers": {"Authorization": "Bearer token"}},
+                    "permissions": [
+                        {"name": "repo-read", "rules": ["GET /repos/{owner}/{repo}"]},
+                        {"name": "repo-admin", "rules": ["GET /repos/{owner}/{repo}"]},
+                    ],
+                }
+            ],
+            name="github",
+        )
+        policies = {
+            "github": {
+                "allow": ["repo-admin"],
+                "deny": ["repo-read"],
+                "unknownPolicy": "deny",
+            }
+        }
+        url = "https://api.github.com/repos/org/repo"
+
+        raw = matching.match_firewall_request(url, "GET", fws, policies)
+        compiled = matching.match_compiled_firewall_request(
+            url,
+            "GET",
+            self._compiled(fws),
+            policies,
+        )
+
+        self._assert_same_result(raw, compiled)
+        assert isinstance(compiled, FirewallAllow)
+        assert compiled.match_info["permission"] == "repo-admin"
+
+    def test_denied_permission_names_keep_encounter_order_and_deduplicate(self):
+        fws = _wrap_firewalls(
+            [
+                {
+                    "base": "https://api.github.com",
+                    "auth": {"headers": {"Authorization": "Bearer token"}},
+                    "permissions": [
+                        {
+                            "name": "repo-read",
+                            "rules": [
+                                "GET /repos/{owner}/{repo}",
+                                "ANY /repos/{owner}/{repo}",
+                            ],
+                        },
+                        {"name": "repo-admin", "rules": ["GET /repos/{owner}/{repo}"]},
+                    ],
+                }
+            ],
+            name="github",
+        )
+        policies = {
+            "github": {
+                "allow": [],
+                "deny": ["repo-read", "repo-admin"],
+                "unknownPolicy": "deny",
+            }
+        }
+        url = "https://api.github.com/repos/org/repo"
+
+        raw = matching.match_firewall_request(url, "GET", fws, policies)
+        compiled = matching.match_compiled_firewall_request(
+            url,
+            "GET",
+            self._compiled(fws),
+            policies,
+        )
+
+        self._assert_same_result(raw, compiled)
+        assert isinstance(compiled, FirewallBlock)
+        assert compiled.permissions == ("repo-read", "repo-admin")
+
+    def test_malformed_rule_fails_closed_without_allowing_permission(self):
+        fws = _wrap_firewalls(
+            [
+                {
+                    "base": "https://api.github.com",
+                    "auth": {"headers": {"Authorization": "Bearer token"}},
+                    "permissions": [
+                        {"name": "repo-read", "rules": ["GET /repos/{a}literal{b}"]},
+                    ],
+                }
+            ],
+            name="github",
+        )
+        policies = {"github": {"allow": ["repo-read"], "deny": [], "unknownPolicy": "deny"}}
+
+        result = matching.match_compiled_firewall_request(
+            "https://api.github.com/repos/org/repo",
+            "GET",
+            self._compiled(fws),
+            policies,
+        )
+
+        assert isinstance(result, FirewallBlock)
+        assert result.permissions == ()
+
+    def test_malformed_rule_blocks_unknown_policy_allow(self):
+        fws = _wrap_firewalls(
+            [
+                {
+                    "base": "https://api.github.com",
+                    "auth": {"headers": {"Authorization": "Bearer token"}},
+                    "permissions": [
+                        {"name": "repo-read", "rules": ["GET /repos/{a}literal{b}"]},
+                    ],
+                }
+            ],
+            name="github",
+        )
+        policies = {"github": {"allow": ["repo-read"], "deny": [], "unknownPolicy": "allow"}}
+
+        result = matching.match_compiled_firewall_request(
+            "https://api.github.com/repos/org/repo",
+            "GET",
+            self._compiled(fws),
+            policies,
+        )
+
+        assert isinstance(result, FirewallBlock)
+        assert result.permissions == ()
+
+    def test_valid_later_permission_can_still_allow_after_malformed_rule(self):
+        fws = _wrap_firewalls(
+            [
+                {
+                    "base": "https://api.github.com",
+                    "auth": {"headers": {"Authorization": "Bearer token"}},
+                    "permissions": [
+                        {"name": "bad", "rules": ["GET /repos/{a}literal{b}"]},
+                        {"name": "repo-read", "rules": ["GET /repos/{owner}/{repo}"]},
+                    ],
+                }
+            ],
+            name="github",
+        )
+        policies = {
+            "github": {
+                "allow": ["bad", "repo-read"],
+                "deny": [],
+                "unknownPolicy": "allow",
+            }
+        }
+
+        result = matching.match_compiled_firewall_request(
+            "https://api.github.com/repos/org/repo",
+            "GET",
+            self._compiled(fws),
+            policies,
+        )
+
+        assert isinstance(result, FirewallAllow)
+        assert result.match_info["permission"] == "repo-read"
+
+    def test_malformed_rules_shape_fails_closed_without_compile_error(self):
+        fws = _wrap_firewalls(
+            [
+                {
+                    "base": "https://api.github.com",
+                    "auth": {"headers": {"Authorization": "Bearer token"}},
+                    "permissions": [
+                        {"name": "repo-read", "rules": None},
+                    ],
+                }
+            ],
+            name="github",
+        )
+        policies = {"github": {"allow": ["repo-read"], "deny": [], "unknownPolicy": "deny"}}
+
+        result = matching.match_compiled_firewall_request(
+            "https://api.github.com/repos/org/repo",
+            "GET",
+            self._compiled(fws),
+            policies,
+        )
+
+        assert isinstance(result, FirewallBlock)
+        assert result.permissions == ()
+
+    def test_malformed_api_list_shape_is_skipped_without_compile_error(self):
+        assert matching.compile_firewalls([{"name": "github", "apis": None}]) is None
+
+    def test_request_url_is_parsed_once_for_multiple_api_entries(self):
+        fws = _wrap_firewalls(
+            [
+                {"base": "https://one.example.com", "permissions": []},
+                {
+                    "base": "https://api.example.com",
+                    "permissions": [
+                        {"name": "read", "rules": ["GET /items/{id}"]},
+                    ],
+                },
+                {"base": "https://three.example.com", "permissions": []},
+            ],
+            name="example",
+        )
+        compiled_firewalls = self._compiled(fws)
+        policies = {"example": {"allow": ["read"], "deny": [], "unknownPolicy": "deny"}}
+
+        with patch.object(
+            matching,
+            "_split_base_match_url",
+            wraps=matching._split_base_match_url,
+        ) as spy:
+            result = matching.match_compiled_firewall_request(
+                "https://api.example.com/items/123",
+                "GET",
+                compiled_firewalls,
+                policies,
+            )
+
+        assert isinstance(result, FirewallAllow)
+        assert spy.call_count == 1

--- a/crates/runner/mitm-addon/tests/test_connectors.py
+++ b/crates/runner/mitm-addon/tests/test_connectors.py
@@ -3554,6 +3554,59 @@ class TestCompiledFirewallMatching:
             "path": "a/b/c",
         }
 
+    def test_matches_raw_for_greedy_host_base_params(self):
+        fws = _wrap_firewalls(
+            [
+                {
+                    "base": "https://{sub+}.example.com",
+                    "auth": {"headers": {"Authorization": "Bearer token"}},
+                    "permissions": [
+                        {"name": "read", "rules": ["GET /items/{id}"]},
+                    ],
+                },
+                {
+                    "base": "https://{sub*}.example.org",
+                    "auth": {"headers": {"Authorization": "Bearer token"}},
+                    "permissions": [
+                        {"name": "empty-read", "rules": ["GET /items/{id}"]},
+                    ],
+                },
+            ],
+            name="example",
+        )
+        compiled_firewalls = self._compiled(fws)
+        policies = {
+            "example": {
+                "allow": ["read", "empty-read"],
+                "deny": [],
+                "unknownPolicy": "deny",
+            }
+        }
+
+        url = "https://a.b.example.com/items/123"
+        raw = matching.match_firewall_request(url, "GET", fws, policies)
+        compiled = matching.match_compiled_firewall_request(
+            url,
+            "GET",
+            compiled_firewalls,
+            policies,
+        )
+        self._assert_same_result(raw, compiled)
+        assert isinstance(compiled, FirewallAllow)
+        assert compiled.match_info["params"] == {"sub": "a.b", "id": "123"}
+
+        url = "https://example.org/items/123"
+        raw = matching.match_firewall_request(url, "GET", fws, policies)
+        compiled = matching.match_compiled_firewall_request(
+            url,
+            "GET",
+            compiled_firewalls,
+            policies,
+        )
+        self._assert_same_result(raw, compiled)
+        assert isinstance(compiled, FirewallAllow)
+        assert compiled.match_info["params"] == {"sub": "", "id": "123"}
+
     def test_matches_raw_for_static_base_boundary_and_query(self):
         fws = _wrap_firewalls(
             [
@@ -3691,6 +3744,50 @@ class TestCompiledFirewallMatching:
         self._assert_same_result(raw, compiled)
         assert isinstance(compiled, FirewallBlock)
         assert compiled.permissions == ("repo-read",)
+
+    def test_later_allowed_firewall_wins_after_earlier_unknown_match(self):
+        fws = [
+            {
+                "name": "broad",
+                "apis": [
+                    {
+                        "base": "https://api.example.com",
+                        "auth": {"headers": {"Authorization": "Bearer broad"}},
+                        "permissions": [],
+                    }
+                ],
+            },
+            {
+                "name": "specific",
+                "apis": [
+                    {
+                        "base": "https://api.example.com",
+                        "auth": {"headers": {"Authorization": "Bearer specific"}},
+                        "permissions": [
+                            {"name": "items-read", "rules": ["GET /items/{id}"]},
+                        ],
+                    }
+                ],
+            },
+        ]
+        policies = {
+            "broad": {"allow": [], "deny": [], "unknownPolicy": "deny"},
+            "specific": {"allow": ["items-read"], "deny": [], "unknownPolicy": "deny"},
+        }
+        url = "https://api.example.com/items/123"
+
+        raw = matching.match_firewall_request(url, "GET", fws, policies)
+        compiled = matching.match_compiled_firewall_request(
+            url,
+            "GET",
+            self._compiled(fws),
+            policies,
+        )
+
+        self._assert_same_result(raw, compiled)
+        assert isinstance(compiled, FirewallAllow)
+        assert compiled.match_info["name"] == "specific"
+        assert compiled.match_info["permission"] == "items-read"
 
     def test_preserves_raw_rule_order_for_any_before_exact_method(self):
         api_entry = {

--- a/crates/runner/mitm-addon/tests/test_registry.py
+++ b/crates/runner/mitm-addon/tests/test_registry.py
@@ -343,6 +343,39 @@ class TestGetVmContext:
             matching.FirewallAllow,
         )
 
+    def test_successful_registry_change_without_firewalls_clears_compiled_context(self, tmp_path):
+        path = tmp_path / "registry.json"
+        _write_firewall_registry(path)
+        first_context = registry.get_vm_context("10.200.0.1", str(path))
+        assert first_context is not None
+        _, first_compiled = first_context
+        assert first_compiled is not None
+
+        path.write_text(
+            json.dumps(
+                {
+                    "vms": {
+                        "10.200.0.1": {
+                            "runId": "run-abc-123",
+                            "networkPolicies": {
+                                "example": {
+                                    "allow": [],
+                                    "deny": [],
+                                    "unknownPolicy": "allow",
+                                }
+                            },
+                        }
+                    },
+                    "updatedAt": 1700000000001,
+                }
+            )
+        )
+
+        second_context = registry.get_vm_context("10.200.0.1", str(path))
+        assert second_context is not None
+        _, second_compiled = second_context
+        assert second_compiled is None
+
     def test_parse_failure_preserves_compiled_context(self, tmp_path):
         path = tmp_path / "registry.json"
         _write_firewall_registry(path)

--- a/crates/runner/mitm-addon/tests/test_registry.py
+++ b/crates/runner/mitm-addon/tests/test_registry.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 
 import auth
 import logging_utils
+import matching
 import registry
 
 
@@ -15,6 +16,39 @@ def _reset_cache():
     registry.reset_cache_for_tests()
     auth._firewall_header_cache.clear()
     auth._cache_locks.clear()
+
+
+def _write_firewall_registry(path, *, rule="/items"):
+    data = {
+        "vms": {
+            "10.200.0.1": {
+                "runId": "run-abc-123",
+                "firewalls": [
+                    {
+                        "name": "example",
+                        "apis": [
+                            {
+                                "base": "https://api.example.com",
+                                "auth": {"headers": {"Authorization": "Bearer token"}},
+                                "permissions": [
+                                    {"name": "read", "rules": [f"GET {rule}"]},
+                                ],
+                            }
+                        ],
+                    }
+                ],
+                "networkPolicies": {
+                    "example": {
+                        "allow": ["read"],
+                        "deny": [],
+                        "unknownPolicy": "deny",
+                    }
+                },
+            }
+        },
+        "updatedAt": 1700000000000,
+    }
+    path.write_text(json.dumps(data))
 
 
 class TestLoadRegistry:
@@ -247,6 +281,119 @@ class TestGetVmInfo:
         info = registry.get_vm_info("192.168.1.1", str(registry_file))
 
         assert info is None
+
+
+class TestGetVmContext:
+    def setup_method(self):
+        _reset_cache()
+
+    def test_returns_raw_info_and_compiled_firewall(self, tmp_path):
+        path = tmp_path / "registry.json"
+        _write_firewall_registry(path)
+
+        context = registry.get_vm_context("10.200.0.1", str(path))
+
+        assert context is not None
+        vm_info, compiled_firewalls = context
+        assert vm_info["runId"] == "run-abc-123"
+        assert registry.get_vm_info("10.200.0.1", str(path)) is vm_info
+        assert compiled_firewalls is not None
+
+        result = matching.match_compiled_firewall_request(
+            "https://api.example.com/items",
+            "GET",
+            compiled_firewalls,
+            vm_info["networkPolicies"],
+        )
+        assert isinstance(result, matching.FirewallAllow)
+        assert result.api_entry is vm_info["firewalls"][0]["apis"][0]
+
+    def test_compiled_context_updates_after_successful_registry_change(self, tmp_path):
+        path = tmp_path / "registry.json"
+        _write_firewall_registry(path, rule="/items")
+        first_context = registry.get_vm_context("10.200.0.1", str(path))
+        assert first_context is not None
+        first_vm_info, first_compiled = first_context
+        assert first_compiled is not None
+
+        _write_firewall_registry(path, rule="/other-resource")
+        second_context = registry.get_vm_context("10.200.0.1", str(path))
+        assert second_context is not None
+        second_vm_info, second_compiled = second_context
+
+        assert second_vm_info is not first_vm_info
+        assert second_compiled is not None
+        assert second_compiled is not first_compiled
+        assert isinstance(
+            matching.match_compiled_firewall_request(
+                "https://api.example.com/items",
+                "GET",
+                second_compiled,
+                second_vm_info["networkPolicies"],
+            ),
+            matching.FirewallBlock,
+        )
+        assert isinstance(
+            matching.match_compiled_firewall_request(
+                "https://api.example.com/other-resource",
+                "GET",
+                second_compiled,
+                second_vm_info["networkPolicies"],
+            ),
+            matching.FirewallAllow,
+        )
+
+    def test_parse_failure_preserves_compiled_context(self, tmp_path):
+        path = tmp_path / "registry.json"
+        _write_firewall_registry(path)
+        context = registry.get_vm_context("10.200.0.1", str(path))
+        assert context is not None
+        vm_info, compiled_firewalls = context
+        assert compiled_firewalls is not None
+
+        path.write_text("{ broken")
+        with patch.object(registry.ctx, "log", MagicMock(), create=True):
+            preserved_context = registry.get_vm_context("10.200.0.1", str(path))
+
+        assert preserved_context is not None
+        preserved_vm_info, preserved_compiled = preserved_context
+        assert preserved_vm_info is vm_info
+        assert preserved_compiled is compiled_firewalls
+        assert isinstance(
+            matching.match_compiled_firewall_request(
+                "https://api.example.com/items",
+                "GET",
+                preserved_compiled,
+                preserved_vm_info["networkPolicies"],
+            ),
+            matching.FirewallAllow,
+        )
+
+    def test_missing_file_preserves_compiled_context(self, tmp_path):
+        path = tmp_path / "registry.json"
+        _write_firewall_registry(path)
+        context = registry.get_vm_context("10.200.0.1", str(path))
+        assert context is not None
+        vm_info, compiled_firewalls = context
+        assert compiled_firewalls is not None
+
+        path.unlink()
+        with patch.object(registry.ctx, "log", MagicMock(), create=True):
+            preserved_context = registry.get_vm_context("10.200.0.1", str(path))
+
+        assert preserved_context is not None
+        preserved_vm_info, preserved_compiled = preserved_context
+        assert preserved_vm_info is vm_info
+        assert preserved_compiled is compiled_firewalls
+        assert isinstance(
+            matching.match_compiled_firewall_request(
+                "https://api.example.com/items",
+                "GET",
+                preserved_compiled,
+                preserved_vm_info["networkPolicies"],
+            ),
+            matching.FirewallAllow,
+        )
 
 
 class TestLogNetworkEntry:

--- a/crates/runner/mitm-addon/tests/test_x_billing.py
+++ b/crates/runner/mitm-addon/tests/test_x_billing.py
@@ -22,6 +22,8 @@ from usage.providers.connectors.x_billing import (
     _INCLUDES_TO_BUCKET,
     _PATH_OVERRIDES,
     _PERMISSION_TO_BUCKET,
+    _build_override_index,
+    classify_bucket,
     refine_bucket_with_body,
 )
 from usage.providers.connectors.x_tlds import IANA_TLD_VERSION, IANA_TLDS
@@ -329,6 +331,21 @@ class TestFirewallConsistency:
         )
         assert not unreviewed, drift_msg
         assert not obsolete, drift_msg
+
+
+class TestOverrideClassification:
+    def test_path_overrides_match_compiled_patterns(self):
+        assert classify_bucket("tweet.read", "GET", "/2/tweets/123/retweeted_by") == "user.read"
+        assert classify_bucket("tweet.read", "GET", "/2/tweets/123") == "posts.read"
+        assert classify_bucket("like.write", "DELETE", "/2/users/1/likes/2") == "interaction.delete"
+
+    def test_invalid_static_override_path_fails_fast(self):
+        with pytest.raises(ValueError, match="invalid X billing override path pattern"):
+            _build_override_index(
+                [
+                    ("tweet.read", "GET", "/2/tweets/{id}literal{other}", "user.read"),
+                ]
+            )
 
 
 class TestSeedConsistency:


### PR DESCRIPTION
## Summary
- compile firewall base, rule, and segment artifacts once per successful registry version
- switch request-time firewall checks and X billing path overrides to compiled matchers while preserving raw order and match metadata
- add regression coverage for ordering, deny aggregation, malformed registry shapes, cache preservation, and X overrides

## Testing
- `PYTHONPATH=/tmp/vm0-mitm-addon-deps /usr/bin/python3 -m ruff check src tests`
- `PYTHONPATH=/tmp/vm0-mitm-addon-deps /usr/bin/python3 -m pytest`

Closes #14266
Refs #14264