### PR TITLE
docs: document json selective extractor contract

### DIFF
--- a/crates/runner/mitm-addon/src/usage/json_selective.py
+++ b/crates/runner/mitm-addon/src/usage/json_selective.py
@@ -41,6 +41,13 @@ _UTF8_SURROGATE_MIN = 0xD800
 _UTF8_SURROGATE_MAX = 0xDFFF
 
 
+def _validate_positive_int(name: str, value: int) -> None:
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise TypeError(f"{name} must be an integer")
+    if value <= 0:
+        raise ValueError(f"{name} must be a positive integer")
+
+
 @dataclass(frozen=True)
 class ScalarField:
     """Selected scalar field configuration.
@@ -156,10 +163,14 @@ class JsonSelectiveExtractor:
         ``"number limit exceeded"``. ``max_wildcard_keys`` bounds distinct
         wildcard keys and fails with ``"max wildcard keys exceeded"``.
         """
-        self.scalar_fields = dict(scalar_fields or {})
-        self.array_count_paths = set(array_count_paths or set())
-        self.wildcard_array_count_paths = set(wildcard_array_count_paths or set())
-        self.object_presence_paths = set(object_presence_paths or set())
+        self.scalar_fields = dict(scalar_fields) if scalar_fields is not None else {}
+        self.array_count_paths = set(array_count_paths) if array_count_paths is not None else set()
+        self.wildcard_array_count_paths = (
+            set(wildcard_array_count_paths) if wildcard_array_count_paths is not None else set()
+        )
+        self.object_presence_paths = (
+            set(object_presence_paths) if object_presence_paths is not None else set()
+        )
         self.max_depth = max_depth
         self.max_key_bytes = max_key_bytes
         self.max_number_bytes = max_number_bytes
@@ -775,24 +786,30 @@ def _validate_extractor_config(
     ):
         _validate_positive_int(name, value)
 
+    for scalar_field in scalar_fields.values():
+        if not isinstance(scalar_field, ScalarField):
+            raise TypeError("scalar fields must map to ScalarField")
+
     _validate_exact_paths("scalar field paths", set(scalar_fields))
     _validate_exact_paths("array count paths", array_count_paths)
     _validate_exact_paths("object presence paths", object_presence_paths)
 
-    for pattern in wildcard_array_count_paths:
-        if pattern.count("*") != 1:
+    for path in wildcard_array_count_paths:
+        _validate_path("wildcard array count paths", path)
+        if path.count("*") != 1:
             raise ValueError("wildcard array count paths must contain exactly one '*'")
 
 
 def _validate_exact_paths(name: str, paths: set[Path]) -> None:
     for path in paths:
+        _validate_path(name, path)
         if "*" in path:
             raise ValueError(f"{name} must not contain '*'")
 
 
-def _validate_positive_int(name: str, value: int) -> None:
-    if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
-        raise ValueError(f"{name} must be a positive integer")
+def _validate_path(name: str, path: Path) -> None:
+    if not isinstance(path, tuple) or any(not isinstance(segment, str) for segment in path):
+        raise TypeError(f"{name} must be tuple[str, ...]")
 
 
 def _is_utf8_continuation(b: int) -> bool:

--- a/crates/runner/mitm-addon/src/usage/json_selective.py
+++ b/crates/runner/mitm-addon/src/usage/json_selective.py
@@ -1,7 +1,16 @@
 """Bounded selective JSON extraction.
 
 The scanner keeps only selected scalars and object keys needed to resolve
-selected paths, while skipping unselected values by JSON syntax.
+selected paths, while skipping unselected values by JSON syntax. Callers create
+one extractor per JSON document, call :meth:`JsonSelectiveExtractor.feed` with
+byte chunks, and call :meth:`JsonSelectiveExtractor.finish` once to finalize the
+result.
+
+Paths are tuples of object keys. For example, ``("usage", "input_tokens")``
+matches ``{"usage": {"input_tokens": 1}}``. Wildcards are supported only by
+``wildcard_array_count_paths`` and each wildcard pattern must contain exactly one
+``"*"`` segment. For example, ``("includes", "*")`` records the array lengths
+for keys such as ``includes.users`` and ``includes.tweets``.
 """
 
 import json
@@ -34,12 +43,36 @@ _UTF8_SURROGATE_MAX = 0xDFFF
 
 @dataclass(frozen=True)
 class ScalarField:
+    """Selected scalar field configuration.
+
+    ``kind`` must be ``"string"`` or ``"int"``. ``max_bytes`` is the capture
+    limit for the selected scalar token; exceeding it fails extraction with
+    ``"string limit exceeded"`` or ``"number limit exceeded"``.
+    """
+
     kind: ScalarKind
     max_bytes: int = 4096
+
+    def __post_init__(self) -> None:
+        if self.kind not in ("string", "int"):
+            raise ValueError("scalar field kind must be 'string' or 'int'")
+        _validate_positive_int("scalar field max_bytes", self.max_bytes)
 
 
 @dataclass
 class JsonExtractionResult:
+    """Final extraction result returned by :meth:`JsonSelectiveExtractor.finish`.
+
+    ``complete`` is true only when the JSON document parsed successfully.
+    ``values`` contains selected scalar values, ``array_counts`` contains exact
+    array path lengths, ``wildcard_array_counts`` contains per-wildcard-key array
+    lengths, and ``object_present`` contains observed object paths.
+
+    When ``complete`` is false, all observation containers are empty and
+    ``error`` describes the parse or bound failure. This prevents callers from
+    consuming partial observations.
+    """
+
     complete: bool
     values: dict[Path, object] = field(default_factory=dict)
     array_counts: dict[Path, int] = field(default_factory=dict)
@@ -87,6 +120,21 @@ class _LiteralState:
 
 
 class JsonSelectiveExtractor:
+    """Streaming, bounded JSON extractor for a fixed observation set.
+
+    The extractor observes four kinds of data while parsing:
+
+    - ``scalar_fields`` captures selected string or integer values.
+    - ``array_count_paths`` counts arrays at exact paths.
+    - ``wildcard_array_count_paths`` counts arrays at wildcard paths with one
+      ``"*"`` segment, recording counts by the concrete wildcard key.
+    - ``object_presence_paths`` records exact paths where JSON objects appear.
+
+    Oversized selected scalars fail extraction. Oversized object keys are treated
+    as unknown keys instead, so selected descendants below that key cannot match.
+    Objects that are array elements do not match normal object-path observations.
+    """
+
     def __init__(
         self,
         *,
@@ -99,17 +147,33 @@ class JsonSelectiveExtractor:
         max_number_bytes: int = 128,
         max_wildcard_keys: int = 256,
     ) -> None:
-        self.scalar_fields = scalar_fields or {}
-        self.array_count_paths = array_count_paths or set()
-        self.wildcard_array_count_paths = wildcard_array_count_paths or set()
-        for pattern in self.wildcard_array_count_paths:
-            if pattern.count("*") != 1:
-                raise ValueError("wildcard array count paths must contain exactly one '*'")
-        self.object_presence_paths = object_presence_paths or set()
+        """Create an extractor for selected JSON observations.
+
+        ``max_depth`` bounds nested objects and arrays and fails with
+        ``"max depth exceeded"``. ``max_key_bytes`` bounds object key capture;
+        keys above the limit become unknown keys rather than parser errors.
+        ``max_number_bytes`` bounds number tokens and fails with
+        ``"number limit exceeded"``. ``max_wildcard_keys`` bounds distinct
+        wildcard keys and fails with ``"max wildcard keys exceeded"``.
+        """
+        self.scalar_fields = dict(scalar_fields or {})
+        self.array_count_paths = set(array_count_paths or set())
+        self.wildcard_array_count_paths = set(wildcard_array_count_paths or set())
+        self.object_presence_paths = set(object_presence_paths or set())
         self.max_depth = max_depth
         self.max_key_bytes = max_key_bytes
         self.max_number_bytes = max_number_bytes
         self.max_wildcard_keys = max_wildcard_keys
+        _validate_extractor_config(
+            self.scalar_fields,
+            self.array_count_paths,
+            self.wildcard_array_count_paths,
+            self.object_presence_paths,
+            max_depth=self.max_depth,
+            max_key_bytes=self.max_key_bytes,
+            max_number_bytes=self.max_number_bytes,
+            max_wildcard_keys=self.max_wildcard_keys,
+        )
         self.key_collection_paths = _build_key_collection_paths(
             set(self.scalar_fields)
             | self.array_count_paths
@@ -130,6 +194,12 @@ class JsonSelectiveExtractor:
         self._literal: _LiteralState | None = None
 
     def feed(self, chunk: bytes) -> None:
+        """Consume the next bytes for this JSON document.
+
+        Feed may be called repeatedly before ``finish()``. If the extractor has
+        already recorded an error, later chunks are ignored and cannot recover
+        the parser.
+        """
         if self._error:
             return
         i = 0
@@ -144,6 +214,12 @@ class JsonSelectiveExtractor:
                 i = self._consume_main(chunk, i)
 
     def finish(self) -> JsonExtractionResult:
+        """Finalize the current document and return the extraction result.
+
+        Call once after all chunks have been fed. If parsing is incomplete,
+        invalid, or a configured bound was exceeded, the returned result has
+        ``complete=False`` and empty observation containers.
+        """
         if not self._error and self._number is not None:
             self._finish_number()
 
@@ -678,6 +754,45 @@ class JsonSelectiveExtractor:
 
 def _is_hex_byte(b: int) -> bool:
     return ord("0") <= b <= ord("9") or ord("a") <= b <= ord("f") or ord("A") <= b <= ord("F")
+
+
+def _validate_extractor_config(
+    scalar_fields: dict[Path, ScalarField],
+    array_count_paths: set[Path],
+    wildcard_array_count_paths: set[WildcardPath],
+    object_presence_paths: set[Path],
+    *,
+    max_depth: int,
+    max_key_bytes: int,
+    max_number_bytes: int,
+    max_wildcard_keys: int,
+) -> None:
+    for name, value in (
+        ("max_depth", max_depth),
+        ("max_key_bytes", max_key_bytes),
+        ("max_number_bytes", max_number_bytes),
+        ("max_wildcard_keys", max_wildcard_keys),
+    ):
+        _validate_positive_int(name, value)
+
+    _validate_exact_paths("scalar field paths", set(scalar_fields))
+    _validate_exact_paths("array count paths", array_count_paths)
+    _validate_exact_paths("object presence paths", object_presence_paths)
+
+    for pattern in wildcard_array_count_paths:
+        if pattern.count("*") != 1:
+            raise ValueError("wildcard array count paths must contain exactly one '*'")
+
+
+def _validate_exact_paths(name: str, paths: set[Path]) -> None:
+    for path in paths:
+        if "*" in path:
+            raise ValueError(f"{name} must not contain '*'")
+
+
+def _validate_positive_int(name: str, value: int) -> None:
+    if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+        raise ValueError(f"{name} must be a positive integer")
 
 
 def _is_utf8_continuation(b: int) -> bool:

--- a/crates/runner/mitm-addon/tests/test_json_selective.py
+++ b/crates/runner/mitm-addon/tests/test_json_selective.py
@@ -81,6 +81,66 @@ def _common_extractor() -> JsonSelectiveExtractor:
     )
 
 
+def test_rejects_invalid_scalar_field_kind():
+    with pytest.raises(ValueError, match="kind"):
+        ScalarField("number")
+
+
+@pytest.mark.parametrize("max_bytes", [0, -1, True])
+def test_rejects_invalid_scalar_field_max_bytes(max_bytes):
+    with pytest.raises(ValueError, match="max_bytes"):
+        ScalarField("string", max_bytes=max_bytes)
+
+
+@pytest.mark.parametrize(
+    "bound",
+    ["max_depth", "max_key_bytes", "max_number_bytes", "max_wildcard_keys"],
+)
+def test_rejects_invalid_extractor_bounds(bound):
+    with pytest.raises(ValueError, match=bound):
+        JsonSelectiveExtractor(**{bound: 0})
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"scalar_fields": {("data", "*"): ScalarField("string")}},
+        {"array_count_paths": {("data", "*")}},
+        {"object_presence_paths": {("data", "*")}},
+    ],
+)
+def test_rejects_wildcards_in_exact_observation_paths(kwargs):
+    with pytest.raises(ValueError, match="must not contain"):
+        JsonSelectiveExtractor(**kwargs)
+
+
+def test_constructor_copies_observation_config():
+    scalar_fields = {}
+    array_count_paths = set()
+    wildcard_array_count_paths = {("includes", "*")}
+    object_presence_paths = set()
+
+    extractor = JsonSelectiveExtractor(
+        scalar_fields=scalar_fields,
+        array_count_paths=array_count_paths,
+        wildcard_array_count_paths=wildcard_array_count_paths,
+        object_presence_paths=object_presence_paths,
+    )
+    scalar_fields[("model",)] = ScalarField("string")
+    array_count_paths.add(("data",))
+    wildcard_array_count_paths.add(("extras", "*"))
+    object_presence_paths.add(("data",))
+
+    extractor.feed(b'{"model":"claude","data":[],"includes":{"users":[]},"extras":{"items":[]}}')
+    result = _finish(extractor)
+
+    assert result.complete is True
+    assert result.values == {}
+    assert result.array_counts == {}
+    assert result.wildcard_array_counts == {("includes", "*"): {"users": 0}}
+    assert result.object_present == set()
+
+
 def test_common_extraction_matches_json_loads_across_chunk_sizes():
     payloads = [
         (

--- a/crates/runner/mitm-addon/tests/test_json_selective.py
+++ b/crates/runner/mitm-addon/tests/test_json_selective.py
@@ -86,19 +86,39 @@ def test_rejects_invalid_scalar_field_kind():
         ScalarField("number")
 
 
-@pytest.mark.parametrize("max_bytes", [0, -1, True])
+@pytest.mark.parametrize("max_bytes", [0, -1])
 def test_rejects_invalid_scalar_field_max_bytes(max_bytes):
     with pytest.raises(ValueError, match="max_bytes"):
         ScalarField("string", max_bytes=max_bytes)
 
 
+def test_rejects_bool_scalar_field_max_bytes():
+    with pytest.raises(TypeError, match="max_bytes"):
+        ScalarField("string", max_bytes=True)
+
+
+def test_rejects_invalid_scalar_field_config_value():
+    with pytest.raises(TypeError, match="ScalarField"):
+        JsonSelectiveExtractor(scalar_fields={("model",): "string"})
+
+
 @pytest.mark.parametrize(
-    "bound",
-    ["max_depth", "max_key_bytes", "max_number_bytes", "max_wildcard_keys"],
+    ("bound", "value"),
+    [
+        ("max_depth", 0),
+        ("max_key_bytes", 0),
+        ("max_number_bytes", 0),
+        ("max_wildcard_keys", 0),
+    ],
 )
-def test_rejects_invalid_extractor_bounds(bound):
+def test_rejects_invalid_extractor_bounds(bound, value):
     with pytest.raises(ValueError, match=bound):
-        JsonSelectiveExtractor(**{bound: 0})
+        JsonSelectiveExtractor(**{bound: value})
+
+
+def test_rejects_bool_extractor_bound():
+    with pytest.raises(TypeError, match="max_depth"):
+        JsonSelectiveExtractor(max_depth=True)
 
 
 @pytest.mark.parametrize(
@@ -111,6 +131,34 @@ def test_rejects_invalid_extractor_bounds(bound):
 )
 def test_rejects_wildcards_in_exact_observation_paths(kwargs):
     with pytest.raises(ValueError, match="must not contain"):
+        JsonSelectiveExtractor(**kwargs)
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"scalar_fields": {"model": ScalarField("string")}},
+        {"array_count_paths": {"data"}},
+        {"wildcard_array_count_paths": {"includes"}},
+        {"object_presence_paths": {"data"}},
+    ],
+)
+def test_rejects_non_tuple_observation_paths(kwargs):
+    with pytest.raises(TypeError, match=r"tuple\[str, \.\.\.\]"):
+        JsonSelectiveExtractor(**kwargs)
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"scalar_fields": {(1,): ScalarField("string")}},
+        {"array_count_paths": {(1,)}},
+        {"wildcard_array_count_paths": {("includes", 1)}},
+        {"object_presence_paths": {(1,)}},
+    ],
+)
+def test_rejects_non_string_path_segments(kwargs):
+    with pytest.raises(TypeError, match=r"tuple\[str, \.\.\.\]"):
         JsonSelectiveExtractor(**kwargs)
 
 

--- a/crates/runner/mitm-addon/tests/test_json_selective.py
+++ b/crates/runner/mitm-addon/tests/test_json_selective.py
@@ -116,9 +116,18 @@ def test_rejects_invalid_extractor_bounds(bound, value):
         JsonSelectiveExtractor(**{bound: value})
 
 
-def test_rejects_bool_extractor_bound():
-    with pytest.raises(TypeError, match="max_depth"):
-        JsonSelectiveExtractor(max_depth=True)
+@pytest.mark.parametrize(
+    ("bound", "value"),
+    [
+        ("max_depth", True),
+        ("max_key_bytes", "1024"),
+        ("max_number_bytes", 128.0),
+        ("max_wildcard_keys", None),
+    ],
+)
+def test_rejects_non_integer_extractor_bounds(bound, value):
+    with pytest.raises(TypeError, match=bound):
+        JsonSelectiveExtractor(**{bound: value})
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- Document the public JsonSelectiveExtractor contract, including feed/finish semantics, bounds, wildcard syntax, and fail-closed results.
- Validate public extractor configuration and ScalarField bounds at construction time.
- Copy constructor inputs so later caller mutation cannot change an active extractor.
- Add focused contract tests for validation and input ownership.

Fixes #14268

## Tests

- `cd crates/runner/mitm-addon && python3 -m pytest tests/test_json_selective.py`
- `cd crates/runner/mitm-addon && python3 -m ruff check src tests`
- `cd crates/runner/mitm-addon && python3 -m ruff format --check .`
