### PR TITLE
refactor: inline oauth provider credential handling

### DIFF
--- a/turbo/packages/connectors/src/oauth-providers/provider-types.ts
+++ b/turbo/packages/connectors/src/oauth-providers/provider-types.ts
@@ -83,41 +83,16 @@ export interface OAuthRevokeArgs {
 
 export type RevokeTokenFn = (args: OAuthRevokeArgs) => Promise<void>;
 
-type ClientIdBuildAuthUrlFn = (
-  clientId: string,
-  redirectUri: string,
-  state: string,
-) => string | AuthUrlResult | Promise<string | AuthUrlResult>;
-
-type ClientCredentialExchangeCodeFn = (
-  clientId: string,
-  clientSecret: string,
-  code: string,
-  redirectUri: string,
-  state?: string,
-  codeVerifier?: string,
-) => Promise<OAuthTokenResult>;
-
-type ClientCredentialRefreshTokenFn = (
-  clientId: string,
-  clientSecret: string,
-  refreshToken: string,
-) => Promise<OAuthRefreshResult>;
-
-type ClientCredentialRevokeTokenFn = (
-  clientId: string,
-  clientSecret: string,
-  accessToken: string,
-) => Promise<void>;
-
-function requireOAuthClientId(args: { readonly clientId?: string }): string {
+export function requireOAuthClientId(args: {
+  readonly clientId?: string;
+}): string {
   if (!args.clientId) {
     throw new Error("OAuth provider requires a client ID");
   }
   return args.clientId;
 }
 
-function requireOAuthClientCredentials(args: {
+export function requireOAuthClientCredentials(args: {
   readonly clientId?: string;
   readonly clientSecret?: string;
 }): { readonly clientId: string; readonly clientSecret: string } {
@@ -125,49 +100,6 @@ function requireOAuthClientCredentials(args: {
     throw new Error("OAuth provider requires client credentials");
   }
   return { clientId: args.clientId, clientSecret: args.clientSecret };
-}
-
-export function adaptClientIdAuthUrl(
-  buildAuthUrl: ClientIdBuildAuthUrlFn,
-): BuildAuthUrlFn {
-  return (args) => {
-    const clientId = requireOAuthClientId(args);
-    return buildAuthUrl(clientId, args.redirectUri, args.state);
-  };
-}
-
-export function adaptClientCredentialCodeExchange(
-  exchangeCode: ClientCredentialExchangeCodeFn,
-): ExchangeCodeFn {
-  return (args) => {
-    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
-    return exchangeCode(
-      clientId,
-      clientSecret,
-      args.code,
-      args.redirectUri,
-      args.state,
-      args.codeVerifier,
-    );
-  };
-}
-
-export function adaptClientCredentialTokenRefresh(
-  refreshToken: ClientCredentialRefreshTokenFn,
-): RefreshTokenFn {
-  return (args) => {
-    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
-    return refreshToken(clientId, clientSecret, args.refreshToken);
-  };
-}
-
-export function adaptClientCredentialTokenRevocation(
-  revokeToken: ClientCredentialRevokeTokenFn,
-): RevokeTokenFn {
-  return (args) => {
-    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
-    return revokeToken(clientId, clientSecret, args.accessToken);
-  };
 }
 
 export interface OAuthProvider {

--- a/turbo/packages/connectors/src/oauth-providers/providers/ahrefs-handler.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/ahrefs-handler.ts
@@ -1,7 +1,6 @@
 import {
-  adaptClientCredentialCodeExchange,
-  adaptClientCredentialTokenRefresh,
-  adaptClientIdAuthUrl,
+  requireOAuthClientCredentials,
+  requireOAuthClientId,
   type OAuthConnectorProvider,
 } from "../provider-types";
 import {
@@ -11,28 +10,32 @@ import {
   refreshAhrefsToken,
 } from "./ahrefs";
 export const ahrefsHandler: OAuthConnectorProvider = {
-  buildAuthUrl: adaptClientIdAuthUrl(buildAhrefsAuthorizationUrl),
-  exchangeCode: adaptClientCredentialCodeExchange(
-    async (clientId, clientSecret, code, redirectUri) => {
-      const result = await exchangeAhrefsCode(
-        clientId,
-        clientSecret,
-        code,
-        redirectUri,
-      );
-      return {
-        accessToken: result.accessToken,
-        refreshToken: result.refreshToken,
-        expiresIn: result.expiresIn,
-        scopes: result.scopes,
-        userInfo: {
-          id: result.userInfo.id,
-          username: result.userInfo.name,
-          email: result.userInfo.email,
-        },
-      };
-    },
-  ),
+  buildAuthUrl: (args) => {
+    const clientId = requireOAuthClientId(args);
+    return buildAhrefsAuthorizationUrl(clientId, args.redirectUri, args.state);
+  },
+  exchangeCode: async (args) => {
+    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const code = args.code;
+    const redirectUri = args.redirectUri;
+    const result = await exchangeAhrefsCode(
+      clientId,
+      clientSecret,
+      code,
+      redirectUri,
+    );
+    return {
+      accessToken: result.accessToken,
+      refreshToken: result.refreshToken,
+      expiresIn: result.expiresIn,
+      scopes: result.scopes,
+      userInfo: {
+        id: result.userInfo.id,
+        username: result.userInfo.name,
+        email: result.userInfo.email,
+      },
+    };
+  },
   getClientId: (e) => {
     return e.AHREFS_OAUTH_CLIENT_ID;
   },
@@ -43,5 +46,8 @@ export const ahrefsHandler: OAuthConnectorProvider = {
   getRefreshSecretName: () => {
     return "AHREFS_REFRESH_TOKEN";
   },
-  refreshToken: adaptClientCredentialTokenRefresh(refreshAhrefsToken),
+  refreshToken: (args) => {
+    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    return refreshAhrefsToken(clientId, clientSecret, args.refreshToken);
+  },
 };

--- a/turbo/packages/connectors/src/oauth-providers/providers/airtable-handler.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/airtable-handler.ts
@@ -1,7 +1,6 @@
 import {
-  adaptClientCredentialCodeExchange,
-  adaptClientCredentialTokenRefresh,
-  adaptClientIdAuthUrl,
+  requireOAuthClientCredentials,
+  requireOAuthClientId,
   type OAuthConnectorProvider,
 } from "../provider-types";
 import {
@@ -11,29 +10,38 @@ import {
   refreshAirtableToken,
 } from "./airtable";
 export const airtableHandler: OAuthConnectorProvider = {
-  buildAuthUrl: adaptClientIdAuthUrl(buildAirtableAuthorizationUrl),
-  exchangeCode: adaptClientCredentialCodeExchange(
-    async (clientId, clientSecret, code, redirectUri, _state, codeVerifier) => {
-      const result = await exchangeAirtableCode(
-        clientId,
-        clientSecret,
-        code,
-        redirectUri,
-        codeVerifier,
-      );
-      return {
-        accessToken: result.accessToken,
-        refreshToken: result.refreshToken,
-        expiresIn: result.expiresIn,
-        scopes: result.scopes,
-        userInfo: {
-          id: result.userInfo.id,
-          username: result.userInfo.username,
-          email: result.userInfo.email,
-        },
-      };
-    },
-  ),
+  buildAuthUrl: (args) => {
+    const clientId = requireOAuthClientId(args);
+    return buildAirtableAuthorizationUrl(
+      clientId,
+      args.redirectUri,
+      args.state,
+    );
+  },
+  exchangeCode: async (args) => {
+    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const code = args.code;
+    const redirectUri = args.redirectUri;
+    const codeVerifier = args.codeVerifier;
+    const result = await exchangeAirtableCode(
+      clientId,
+      clientSecret,
+      code,
+      redirectUri,
+      codeVerifier,
+    );
+    return {
+      accessToken: result.accessToken,
+      refreshToken: result.refreshToken,
+      expiresIn: result.expiresIn,
+      scopes: result.scopes,
+      userInfo: {
+        id: result.userInfo.id,
+        username: result.userInfo.username,
+        email: result.userInfo.email,
+      },
+    };
+  },
   getClientId: (e) => {
     return e.AIRTABLE_OAUTH_CLIENT_ID;
   },
@@ -44,5 +52,8 @@ export const airtableHandler: OAuthConnectorProvider = {
   getRefreshSecretName: () => {
     return "AIRTABLE_REFRESH_TOKEN";
   },
-  refreshToken: adaptClientCredentialTokenRefresh(refreshAirtableToken),
+  refreshToken: (args) => {
+    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    return refreshAirtableToken(clientId, clientSecret, args.refreshToken);
+  },
 };

--- a/turbo/packages/connectors/src/oauth-providers/providers/asana-handler.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/asana-handler.ts
@@ -1,7 +1,6 @@
 import {
-  adaptClientCredentialCodeExchange,
-  adaptClientCredentialTokenRefresh,
-  adaptClientIdAuthUrl,
+  requireOAuthClientCredentials,
+  requireOAuthClientId,
   type OAuthConnectorProvider,
 } from "../provider-types";
 import {
@@ -11,28 +10,32 @@ import {
   refreshAsanaToken,
 } from "./asana";
 export const asanaHandler: OAuthConnectorProvider = {
-  buildAuthUrl: adaptClientIdAuthUrl(buildAsanaAuthorizationUrl),
-  exchangeCode: adaptClientCredentialCodeExchange(
-    async (clientId, clientSecret, code, redirectUri) => {
-      const result = await exchangeAsanaCode(
-        clientId,
-        clientSecret,
-        code,
-        redirectUri,
-      );
-      return {
-        accessToken: result.accessToken,
-        refreshToken: result.refreshToken,
-        expiresIn: result.expiresIn,
-        scopes: result.scopes,
-        userInfo: {
-          id: result.userInfo.id,
-          username: result.userInfo.username,
-          email: result.userInfo.email,
-        },
-      };
-    },
-  ),
+  buildAuthUrl: (args) => {
+    const clientId = requireOAuthClientId(args);
+    return buildAsanaAuthorizationUrl(clientId, args.redirectUri, args.state);
+  },
+  exchangeCode: async (args) => {
+    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const code = args.code;
+    const redirectUri = args.redirectUri;
+    const result = await exchangeAsanaCode(
+      clientId,
+      clientSecret,
+      code,
+      redirectUri,
+    );
+    return {
+      accessToken: result.accessToken,
+      refreshToken: result.refreshToken,
+      expiresIn: result.expiresIn,
+      scopes: result.scopes,
+      userInfo: {
+        id: result.userInfo.id,
+        username: result.userInfo.username,
+        email: result.userInfo.email,
+      },
+    };
+  },
   getClientId: (e) => {
     return e.ASANA_OAUTH_CLIENT_ID;
   },
@@ -43,5 +46,8 @@ export const asanaHandler: OAuthConnectorProvider = {
   getRefreshSecretName: () => {
     return "ASANA_REFRESH_TOKEN";
   },
-  refreshToken: adaptClientCredentialTokenRefresh(refreshAsanaToken),
+  refreshToken: (args) => {
+    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    return refreshAsanaToken(clientId, clientSecret, args.refreshToken);
+  },
 };

--- a/turbo/packages/connectors/src/oauth-providers/providers/canva-handler.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/canva-handler.ts
@@ -1,7 +1,6 @@
 import {
-  adaptClientCredentialCodeExchange,
-  adaptClientCredentialTokenRefresh,
-  adaptClientIdAuthUrl,
+  requireOAuthClientCredentials,
+  requireOAuthClientId,
   type OAuthConnectorProvider,
 } from "../provider-types";
 import {
@@ -11,34 +10,37 @@ import {
   refreshCanvaToken,
 } from "./canva";
 export const canvaHandler: OAuthConnectorProvider = {
-  buildAuthUrl: adaptClientIdAuthUrl(buildCanvaAuthorizationUrl),
-  exchangeCode: adaptClientCredentialCodeExchange(
-    async (clientId, clientSecret, code, redirectUri, state) => {
-      if (!state) {
-        throw new Error(
-          "Canva PKCE requires state for code_verifier derivation",
-        );
-      }
-      const result = await exchangeCanvaCode(
-        clientId,
-        clientSecret,
-        code,
-        redirectUri,
-        state,
-      );
-      return {
-        accessToken: result.accessToken,
-        refreshToken: result.refreshToken,
-        expiresIn: result.expiresIn,
-        scopes: result.scopes,
-        userInfo: {
-          id: result.userInfo.id,
-          username: result.userInfo.username,
-          email: result.userInfo.email,
-        },
-      };
-    },
-  ),
+  buildAuthUrl: (args) => {
+    const clientId = requireOAuthClientId(args);
+    return buildCanvaAuthorizationUrl(clientId, args.redirectUri, args.state);
+  },
+  exchangeCode: async (args) => {
+    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const code = args.code;
+    const redirectUri = args.redirectUri;
+    const state = args.state;
+    if (!state) {
+      throw new Error("Canva PKCE requires state for code_verifier derivation");
+    }
+    const result = await exchangeCanvaCode(
+      clientId,
+      clientSecret,
+      code,
+      redirectUri,
+      state,
+    );
+    return {
+      accessToken: result.accessToken,
+      refreshToken: result.refreshToken,
+      expiresIn: result.expiresIn,
+      scopes: result.scopes,
+      userInfo: {
+        id: result.userInfo.id,
+        username: result.userInfo.username,
+        email: result.userInfo.email,
+      },
+    };
+  },
   getClientId: (e) => {
     return e.CANVA_OAUTH_CLIENT_ID;
   },
@@ -49,5 +51,8 @@ export const canvaHandler: OAuthConnectorProvider = {
   getRefreshSecretName: () => {
     return "CANVA_REFRESH_TOKEN";
   },
-  refreshToken: adaptClientCredentialTokenRefresh(refreshCanvaToken),
+  refreshToken: (args) => {
+    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    return refreshCanvaToken(clientId, clientSecret, args.refreshToken);
+  },
 };

--- a/turbo/packages/connectors/src/oauth-providers/providers/close-handler.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/close-handler.ts
@@ -1,7 +1,6 @@
 import {
-  adaptClientCredentialCodeExchange,
-  adaptClientCredentialTokenRefresh,
-  adaptClientIdAuthUrl,
+  requireOAuthClientCredentials,
+  requireOAuthClientId,
   type OAuthConnectorProvider,
 } from "../provider-types";
 import {
@@ -11,28 +10,32 @@ import {
   refreshCloseToken,
 } from "./close";
 export const closeHandler: OAuthConnectorProvider = {
-  buildAuthUrl: adaptClientIdAuthUrl(buildCloseAuthorizationUrl),
-  exchangeCode: adaptClientCredentialCodeExchange(
-    async (clientId, clientSecret, code, redirectUri) => {
-      const result = await exchangeCloseCode(
-        clientId,
-        clientSecret,
-        code,
-        redirectUri,
-      );
-      return {
-        accessToken: result.accessToken,
-        refreshToken: result.refreshToken,
-        expiresIn: result.expiresIn,
-        scopes: result.scopes,
-        userInfo: {
-          id: result.userInfo.id,
-          username: result.userInfo.email,
-          email: result.userInfo.email,
-        },
-      };
-    },
-  ),
+  buildAuthUrl: (args) => {
+    const clientId = requireOAuthClientId(args);
+    return buildCloseAuthorizationUrl(clientId, args.redirectUri, args.state);
+  },
+  exchangeCode: async (args) => {
+    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const code = args.code;
+    const redirectUri = args.redirectUri;
+    const result = await exchangeCloseCode(
+      clientId,
+      clientSecret,
+      code,
+      redirectUri,
+    );
+    return {
+      accessToken: result.accessToken,
+      refreshToken: result.refreshToken,
+      expiresIn: result.expiresIn,
+      scopes: result.scopes,
+      userInfo: {
+        id: result.userInfo.id,
+        username: result.userInfo.email,
+        email: result.userInfo.email,
+      },
+    };
+  },
   getClientId: (e) => {
     return e.CLOSE_OAUTH_CLIENT_ID;
   },
@@ -43,5 +46,8 @@ export const closeHandler: OAuthConnectorProvider = {
   getRefreshSecretName: () => {
     return "CLOSE_REFRESH_TOKEN";
   },
-  refreshToken: adaptClientCredentialTokenRefresh(refreshCloseToken),
+  refreshToken: (args) => {
+    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    return refreshCloseToken(clientId, clientSecret, args.refreshToken);
+  },
 };

--- a/turbo/packages/connectors/src/oauth-providers/providers/deel-handler.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/deel-handler.ts
@@ -1,7 +1,6 @@
 import {
-  adaptClientCredentialCodeExchange,
-  adaptClientCredentialTokenRefresh,
-  adaptClientIdAuthUrl,
+  requireOAuthClientCredentials,
+  requireOAuthClientId,
   type OAuthConnectorProvider,
 } from "../provider-types";
 import {
@@ -11,34 +10,37 @@ import {
   refreshDeelToken,
 } from "./deel";
 export const deelHandler: OAuthConnectorProvider = {
-  buildAuthUrl: adaptClientIdAuthUrl(buildDeelAuthorizationUrl),
-  exchangeCode: adaptClientCredentialCodeExchange(
-    async (clientId, clientSecret, code, redirectUri, state) => {
-      if (!state) {
-        throw new Error(
-          "Deel PKCE requires state for code_verifier derivation",
-        );
-      }
-      const result = await exchangeDeelCode(
-        clientId,
-        clientSecret,
-        code,
-        redirectUri,
-        state,
-      );
-      return {
-        accessToken: result.accessToken,
-        refreshToken: result.refreshToken,
-        expiresIn: result.expiresIn,
-        scopes: result.scopes,
-        userInfo: {
-          id: result.userInfo.id,
-          username: result.userInfo.username,
-          email: result.userInfo.email,
-        },
-      };
-    },
-  ),
+  buildAuthUrl: (args) => {
+    const clientId = requireOAuthClientId(args);
+    return buildDeelAuthorizationUrl(clientId, args.redirectUri, args.state);
+  },
+  exchangeCode: async (args) => {
+    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const code = args.code;
+    const redirectUri = args.redirectUri;
+    const state = args.state;
+    if (!state) {
+      throw new Error("Deel PKCE requires state for code_verifier derivation");
+    }
+    const result = await exchangeDeelCode(
+      clientId,
+      clientSecret,
+      code,
+      redirectUri,
+      state,
+    );
+    return {
+      accessToken: result.accessToken,
+      refreshToken: result.refreshToken,
+      expiresIn: result.expiresIn,
+      scopes: result.scopes,
+      userInfo: {
+        id: result.userInfo.id,
+        username: result.userInfo.username,
+        email: result.userInfo.email,
+      },
+    };
+  },
   getClientId: (e) => {
     return e.DEEL_OAUTH_CLIENT_ID;
   },
@@ -49,5 +51,8 @@ export const deelHandler: OAuthConnectorProvider = {
   getRefreshSecretName: () => {
     return "DEEL_REFRESH_TOKEN";
   },
-  refreshToken: adaptClientCredentialTokenRefresh(refreshDeelToken),
+  refreshToken: (args) => {
+    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    return refreshDeelToken(clientId, clientSecret, args.refreshToken);
+  },
 };

--- a/turbo/packages/connectors/src/oauth-providers/providers/docusign-handler.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/docusign-handler.ts
@@ -1,7 +1,6 @@
 import {
-  adaptClientCredentialCodeExchange,
-  adaptClientCredentialTokenRefresh,
-  adaptClientIdAuthUrl,
+  requireOAuthClientCredentials,
+  requireOAuthClientId,
   type OAuthConnectorProvider,
 } from "../provider-types";
 import {
@@ -11,34 +10,43 @@ import {
   refreshDocuSignToken,
 } from "./docusign";
 export const docusignHandler: OAuthConnectorProvider = {
-  buildAuthUrl: adaptClientIdAuthUrl(buildDocuSignAuthorizationUrl),
-  exchangeCode: adaptClientCredentialCodeExchange(
-    async (clientId, clientSecret, code, redirectUri, state) => {
-      if (!state) {
-        throw new Error(
-          "DocuSign PKCE requires state for code_verifier derivation",
-        );
-      }
-      const result = await exchangeDocuSignCode(
-        clientId,
-        clientSecret,
-        code,
-        redirectUri,
-        state,
+  buildAuthUrl: (args) => {
+    const clientId = requireOAuthClientId(args);
+    return buildDocuSignAuthorizationUrl(
+      clientId,
+      args.redirectUri,
+      args.state,
+    );
+  },
+  exchangeCode: async (args) => {
+    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const code = args.code;
+    const redirectUri = args.redirectUri;
+    const state = args.state;
+    if (!state) {
+      throw new Error(
+        "DocuSign PKCE requires state for code_verifier derivation",
       );
-      return {
-        accessToken: result.accessToken,
-        refreshToken: result.refreshToken,
-        expiresIn: result.expiresIn,
-        scopes: result.scopes,
-        userInfo: {
-          id: result.userInfo.id,
-          username: result.userInfo.username,
-          email: result.userInfo.email,
-        },
-      };
-    },
-  ),
+    }
+    const result = await exchangeDocuSignCode(
+      clientId,
+      clientSecret,
+      code,
+      redirectUri,
+      state,
+    );
+    return {
+      accessToken: result.accessToken,
+      refreshToken: result.refreshToken,
+      expiresIn: result.expiresIn,
+      scopes: result.scopes,
+      userInfo: {
+        id: result.userInfo.id,
+        username: result.userInfo.username,
+        email: result.userInfo.email,
+      },
+    };
+  },
   getClientId: (e) => {
     return e.DOCUSIGN_OAUTH_CLIENT_ID;
   },
@@ -49,5 +57,8 @@ export const docusignHandler: OAuthConnectorProvider = {
   getRefreshSecretName: () => {
     return "DOCUSIGN_REFRESH_TOKEN";
   },
-  refreshToken: adaptClientCredentialTokenRefresh(refreshDocuSignToken),
+  refreshToken: (args) => {
+    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    return refreshDocuSignToken(clientId, clientSecret, args.refreshToken);
+  },
 };

--- a/turbo/packages/connectors/src/oauth-providers/providers/dropbox-handler.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/dropbox-handler.ts
@@ -1,7 +1,6 @@
 import {
-  adaptClientCredentialCodeExchange,
-  adaptClientCredentialTokenRefresh,
-  adaptClientIdAuthUrl,
+  requireOAuthClientCredentials,
+  requireOAuthClientId,
   type OAuthConnectorProvider,
 } from "../provider-types";
 import {
@@ -11,28 +10,32 @@ import {
   refreshDropboxToken,
 } from "./dropbox";
 export const dropboxHandler: OAuthConnectorProvider = {
-  buildAuthUrl: adaptClientIdAuthUrl(buildDropboxAuthorizationUrl),
-  exchangeCode: adaptClientCredentialCodeExchange(
-    async (clientId, clientSecret, code, redirectUri) => {
-      const result = await exchangeDropboxCode(
-        clientId,
-        clientSecret,
-        code,
-        redirectUri,
-      );
-      return {
-        accessToken: result.accessToken,
-        refreshToken: result.refreshToken,
-        expiresIn: result.expiresIn,
-        scopes: result.scopes,
-        userInfo: {
-          id: result.userInfo.id,
-          username: result.userInfo.username,
-          email: result.userInfo.email,
-        },
-      };
-    },
-  ),
+  buildAuthUrl: (args) => {
+    const clientId = requireOAuthClientId(args);
+    return buildDropboxAuthorizationUrl(clientId, args.redirectUri, args.state);
+  },
+  exchangeCode: async (args) => {
+    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const code = args.code;
+    const redirectUri = args.redirectUri;
+    const result = await exchangeDropboxCode(
+      clientId,
+      clientSecret,
+      code,
+      redirectUri,
+    );
+    return {
+      accessToken: result.accessToken,
+      refreshToken: result.refreshToken,
+      expiresIn: result.expiresIn,
+      scopes: result.scopes,
+      userInfo: {
+        id: result.userInfo.id,
+        username: result.userInfo.username,
+        email: result.userInfo.email,
+      },
+    };
+  },
   getClientId: (e) => {
     return e.DROPBOX_OAUTH_CLIENT_ID;
   },
@@ -43,5 +46,8 @@ export const dropboxHandler: OAuthConnectorProvider = {
   getRefreshSecretName: () => {
     return "DROPBOX_REFRESH_TOKEN";
   },
-  refreshToken: adaptClientCredentialTokenRefresh(refreshDropboxToken),
+  refreshToken: (args) => {
+    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    return refreshDropboxToken(clientId, clientSecret, args.refreshToken);
+  },
 };

--- a/turbo/packages/connectors/src/oauth-providers/providers/figma-handler.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/figma-handler.ts
@@ -1,7 +1,6 @@
 import {
-  adaptClientCredentialCodeExchange,
-  adaptClientCredentialTokenRefresh,
-  adaptClientIdAuthUrl,
+  requireOAuthClientCredentials,
+  requireOAuthClientId,
   type OAuthConnectorProvider,
 } from "../provider-types";
 import {
@@ -11,28 +10,32 @@ import {
   refreshFigmaToken,
 } from "./figma";
 export const figmaHandler: OAuthConnectorProvider = {
-  buildAuthUrl: adaptClientIdAuthUrl(buildFigmaAuthorizationUrl),
-  exchangeCode: adaptClientCredentialCodeExchange(
-    async (clientId, clientSecret, code, redirectUri) => {
-      const result = await exchangeFigmaCode(
-        clientId,
-        clientSecret,
-        code,
-        redirectUri,
-      );
-      return {
-        accessToken: result.accessToken,
-        refreshToken: result.refreshToken,
-        expiresIn: result.expiresIn,
-        scopes: result.scopes,
-        userInfo: {
-          id: result.userInfo.id,
-          username: result.userInfo.name,
-          email: result.userInfo.email,
-        },
-      };
-    },
-  ),
+  buildAuthUrl: (args) => {
+    const clientId = requireOAuthClientId(args);
+    return buildFigmaAuthorizationUrl(clientId, args.redirectUri, args.state);
+  },
+  exchangeCode: async (args) => {
+    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const code = args.code;
+    const redirectUri = args.redirectUri;
+    const result = await exchangeFigmaCode(
+      clientId,
+      clientSecret,
+      code,
+      redirectUri,
+    );
+    return {
+      accessToken: result.accessToken,
+      refreshToken: result.refreshToken,
+      expiresIn: result.expiresIn,
+      scopes: result.scopes,
+      userInfo: {
+        id: result.userInfo.id,
+        username: result.userInfo.name,
+        email: result.userInfo.email,
+      },
+    };
+  },
   getClientId: (e) => {
     return e.FIGMA_OAUTH_CLIENT_ID;
   },
@@ -43,5 +46,8 @@ export const figmaHandler: OAuthConnectorProvider = {
   getRefreshSecretName: () => {
     return "FIGMA_REFRESH_TOKEN";
   },
-  refreshToken: adaptClientCredentialTokenRefresh(refreshFigmaToken),
+  refreshToken: (args) => {
+    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    return refreshFigmaToken(clientId, clientSecret, args.refreshToken);
+  },
 };

--- a/turbo/packages/connectors/src/oauth-providers/providers/garmin-connect-handler.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/garmin-connect-handler.ts
@@ -1,7 +1,6 @@
 import {
-  adaptClientCredentialCodeExchange,
-  adaptClientCredentialTokenRefresh,
-  adaptClientIdAuthUrl,
+  requireOAuthClientCredentials,
+  requireOAuthClientId,
   type OAuthConnectorProvider,
 } from "../provider-types";
 import {
@@ -11,33 +10,41 @@ import {
   refreshGarminConnectToken,
 } from "./garmin-connect";
 export const garminConnectHandler: OAuthConnectorProvider = {
-  buildAuthUrl: adaptClientIdAuthUrl(buildGarminConnectAuthorizationUrl),
-  exchangeCode: adaptClientCredentialCodeExchange(
-    async (clientId, clientSecret, code, _redirectUri, state) => {
-      if (!state) {
-        throw new Error(
-          "Garmin Connect PKCE requires state for code_verifier derivation",
-        );
-      }
-      const result = await exchangeGarminConnectCode(
-        clientId,
-        clientSecret,
-        code,
-        state,
+  buildAuthUrl: (args) => {
+    const clientId = requireOAuthClientId(args);
+    return buildGarminConnectAuthorizationUrl(
+      clientId,
+      args.redirectUri,
+      args.state,
+    );
+  },
+  exchangeCode: async (args) => {
+    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const code = args.code;
+    const state = args.state;
+    if (!state) {
+      throw new Error(
+        "Garmin Connect PKCE requires state for code_verifier derivation",
       );
-      return {
-        accessToken: result.accessToken,
-        refreshToken: result.refreshToken,
-        expiresIn: result.expiresIn,
-        scopes: result.scopes,
-        userInfo: {
-          id: result.userInfo.id,
-          username: result.userInfo.username,
-          email: result.userInfo.email,
-        },
-      };
-    },
-  ),
+    }
+    const result = await exchangeGarminConnectCode(
+      clientId,
+      clientSecret,
+      code,
+      state,
+    );
+    return {
+      accessToken: result.accessToken,
+      refreshToken: result.refreshToken,
+      expiresIn: result.expiresIn,
+      scopes: result.scopes,
+      userInfo: {
+        id: result.userInfo.id,
+        username: result.userInfo.username,
+        email: result.userInfo.email,
+      },
+    };
+  },
   getClientId: (e) => {
     return e.GARMIN_CONNECT_OAUTH_CLIENT_ID;
   },
@@ -48,5 +55,8 @@ export const garminConnectHandler: OAuthConnectorProvider = {
   getRefreshSecretName: () => {
     return "GARMIN_CONNECT_REFRESH_TOKEN";
   },
-  refreshToken: adaptClientCredentialTokenRefresh(refreshGarminConnectToken),
+  refreshToken: (args) => {
+    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    return refreshGarminConnectToken(clientId, clientSecret, args.refreshToken);
+  },
 };

--- a/turbo/packages/connectors/src/oauth-providers/providers/github-handler.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/github-handler.ts
@@ -1,7 +1,6 @@
 import {
-  adaptClientCredentialCodeExchange,
-  adaptClientCredentialTokenRevocation,
-  adaptClientIdAuthUrl,
+  requireOAuthClientCredentials,
+  requireOAuthClientId,
   type OAuthConnectorProvider,
 } from "../provider-types";
 import {
@@ -12,19 +11,23 @@ import {
   revokeGitHubGrant,
 } from "./github";
 export const githubHandler: OAuthConnectorProvider = {
-  buildAuthUrl: adaptClientIdAuthUrl(buildGitHubAuthorizationUrl),
-  exchangeCode: adaptClientCredentialCodeExchange(
-    async (clientId, clientSecret, code, redirectUri) => {
-      const { accessToken, scopes } = await exchangeGitHubCode(
-        clientId,
-        clientSecret,
-        code,
-        redirectUri,
-      );
-      const userInfo = await fetchGitHubUserInfo(accessToken);
-      return { accessToken, scopes, userInfo };
-    },
-  ),
+  buildAuthUrl: (args) => {
+    const clientId = requireOAuthClientId(args);
+    return buildGitHubAuthorizationUrl(clientId, args.redirectUri, args.state);
+  },
+  exchangeCode: async (args) => {
+    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const code = args.code;
+    const redirectUri = args.redirectUri;
+    const { accessToken, scopes } = await exchangeGitHubCode(
+      clientId,
+      clientSecret,
+      code,
+      redirectUri,
+    );
+    const userInfo = await fetchGitHubUserInfo(accessToken);
+    return { accessToken, scopes, userInfo };
+  },
   getClientId: (e) => {
     return e.GH_OAUTH_CLIENT_ID;
   },
@@ -32,5 +35,8 @@ export const githubHandler: OAuthConnectorProvider = {
     return e.GH_OAUTH_CLIENT_SECRET;
   },
   getSecretName: getGitHubSecretName,
-  revokeToken: adaptClientCredentialTokenRevocation(revokeGitHubGrant),
+  revokeToken: (args) => {
+    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    return revokeGitHubGrant(clientId, clientSecret, args.accessToken);
+  },
 };

--- a/turbo/packages/connectors/src/oauth-providers/providers/gmail-handler.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/gmail-handler.ts
@@ -1,7 +1,6 @@
 import {
-  adaptClientCredentialCodeExchange,
-  adaptClientCredentialTokenRefresh,
-  adaptClientIdAuthUrl,
+  requireOAuthClientCredentials,
+  requireOAuthClientId,
   type OAuthConnectorProvider,
 } from "../provider-types";
 import {
@@ -11,28 +10,32 @@ import {
 } from "./gmail";
 import { refreshGoogleToken } from "./google-oauth";
 export const gmailHandler: OAuthConnectorProvider = {
-  buildAuthUrl: adaptClientIdAuthUrl(buildGmailAuthorizationUrl),
-  exchangeCode: adaptClientCredentialCodeExchange(
-    async (clientId, clientSecret, code, redirectUri) => {
-      const result = await exchangeGmailCode(
-        clientId,
-        clientSecret,
-        code,
-        redirectUri,
-      );
-      return {
-        accessToken: result.accessToken,
-        refreshToken: result.refreshToken,
-        expiresIn: result.expiresIn,
-        scopes: result.scopes,
-        userInfo: {
-          id: result.userInfo.id,
-          username: result.userInfo.name,
-          email: result.userInfo.email,
-        },
-      };
-    },
-  ),
+  buildAuthUrl: (args) => {
+    const clientId = requireOAuthClientId(args);
+    return buildGmailAuthorizationUrl(clientId, args.redirectUri, args.state);
+  },
+  exchangeCode: async (args) => {
+    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const code = args.code;
+    const redirectUri = args.redirectUri;
+    const result = await exchangeGmailCode(
+      clientId,
+      clientSecret,
+      code,
+      redirectUri,
+    );
+    return {
+      accessToken: result.accessToken,
+      refreshToken: result.refreshToken,
+      expiresIn: result.expiresIn,
+      scopes: result.scopes,
+      userInfo: {
+        id: result.userInfo.id,
+        username: result.userInfo.name,
+        email: result.userInfo.email,
+      },
+    };
+  },
   getClientId: (e) => {
     return e.GOOGLE_OAUTH_CLIENT_ID;
   },
@@ -43,9 +46,9 @@ export const gmailHandler: OAuthConnectorProvider = {
   getRefreshSecretName: () => {
     return "GMAIL_REFRESH_TOKEN";
   },
-  refreshToken: adaptClientCredentialTokenRefresh(
-    (clientId, clientSecret, refreshToken) => {
-      return refreshGoogleToken("gmail", clientId, clientSecret, refreshToken);
-    },
-  ),
+  refreshToken: (args) => {
+    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const refreshToken = args.refreshToken;
+    return refreshGoogleToken("gmail", clientId, clientSecret, refreshToken);
+  },
 };

--- a/turbo/packages/connectors/src/oauth-providers/providers/google-ads-handler.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/google-ads-handler.ts
@@ -1,7 +1,6 @@
 import {
-  adaptClientCredentialCodeExchange,
-  adaptClientCredentialTokenRefresh,
-  adaptClientIdAuthUrl,
+  requireOAuthClientCredentials,
+  requireOAuthClientId,
   type OAuthConnectorProvider,
 } from "../provider-types";
 import {
@@ -10,36 +9,40 @@ import {
   refreshGoogleToken,
 } from "./google-oauth";
 export const googleAdsHandler: OAuthConnectorProvider = {
-  buildAuthUrl: adaptClientIdAuthUrl((clientId, redirectUri, state) => {
+  buildAuthUrl: (args) => {
+    const clientId = requireOAuthClientId(args);
+    const redirectUri = args.redirectUri;
+    const state = args.state;
     return buildGoogleAuthorizationUrl(
       "google-ads",
       clientId,
       redirectUri,
       state,
     );
-  }),
-  exchangeCode: adaptClientCredentialCodeExchange(
-    async (clientId, clientSecret, code, redirectUri) => {
-      const result = await exchangeGoogleOAuthCode(
-        "google-ads",
-        clientId,
-        clientSecret,
-        code,
-        redirectUri,
-      );
-      return {
-        accessToken: result.accessToken,
-        refreshToken: result.refreshToken,
-        expiresIn: result.expiresIn,
-        scopes: result.scopes,
-        userInfo: {
-          id: result.userInfo.id,
-          username: result.userInfo.name,
-          email: result.userInfo.email,
-        },
-      };
-    },
-  ),
+  },
+  exchangeCode: async (args) => {
+    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const code = args.code;
+    const redirectUri = args.redirectUri;
+    const result = await exchangeGoogleOAuthCode(
+      "google-ads",
+      clientId,
+      clientSecret,
+      code,
+      redirectUri,
+    );
+    return {
+      accessToken: result.accessToken,
+      refreshToken: result.refreshToken,
+      expiresIn: result.expiresIn,
+      scopes: result.scopes,
+      userInfo: {
+        id: result.userInfo.id,
+        username: result.userInfo.name,
+        email: result.userInfo.email,
+      },
+    };
+  },
   getClientId: (e) => {
     return e.GOOGLE_OAUTH_CLIENT_ID;
   },
@@ -52,14 +55,14 @@ export const googleAdsHandler: OAuthConnectorProvider = {
   getRefreshSecretName: () => {
     return "GOOGLE_ADS_REFRESH_TOKEN";
   },
-  refreshToken: adaptClientCredentialTokenRefresh(
-    (clientId, clientSecret, refreshToken) => {
-      return refreshGoogleToken(
-        "google-ads",
-        clientId,
-        clientSecret,
-        refreshToken,
-      );
-    },
-  ),
+  refreshToken: (args) => {
+    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const refreshToken = args.refreshToken;
+    return refreshGoogleToken(
+      "google-ads",
+      clientId,
+      clientSecret,
+      refreshToken,
+    );
+  },
 };

--- a/turbo/packages/connectors/src/oauth-providers/providers/google-calendar-handler.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/google-calendar-handler.ts
@@ -1,7 +1,6 @@
 import {
-  adaptClientCredentialCodeExchange,
-  adaptClientCredentialTokenRefresh,
-  adaptClientIdAuthUrl,
+  requireOAuthClientCredentials,
+  requireOAuthClientId,
   type OAuthConnectorProvider,
 } from "../provider-types";
 import {
@@ -10,36 +9,40 @@ import {
   refreshGoogleToken,
 } from "./google-oauth";
 export const googleCalendarHandler: OAuthConnectorProvider = {
-  buildAuthUrl: adaptClientIdAuthUrl((clientId, redirectUri, state) => {
+  buildAuthUrl: (args) => {
+    const clientId = requireOAuthClientId(args);
+    const redirectUri = args.redirectUri;
+    const state = args.state;
     return buildGoogleAuthorizationUrl(
       "google-calendar",
       clientId,
       redirectUri,
       state,
     );
-  }),
-  exchangeCode: adaptClientCredentialCodeExchange(
-    async (clientId, clientSecret, code, redirectUri) => {
-      const result = await exchangeGoogleOAuthCode(
-        "google-calendar",
-        clientId,
-        clientSecret,
-        code,
-        redirectUri,
-      );
-      return {
-        accessToken: result.accessToken,
-        refreshToken: result.refreshToken,
-        expiresIn: result.expiresIn,
-        scopes: result.scopes,
-        userInfo: {
-          id: result.userInfo.id,
-          username: result.userInfo.name,
-          email: result.userInfo.email,
-        },
-      };
-    },
-  ),
+  },
+  exchangeCode: async (args) => {
+    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const code = args.code;
+    const redirectUri = args.redirectUri;
+    const result = await exchangeGoogleOAuthCode(
+      "google-calendar",
+      clientId,
+      clientSecret,
+      code,
+      redirectUri,
+    );
+    return {
+      accessToken: result.accessToken,
+      refreshToken: result.refreshToken,
+      expiresIn: result.expiresIn,
+      scopes: result.scopes,
+      userInfo: {
+        id: result.userInfo.id,
+        username: result.userInfo.name,
+        email: result.userInfo.email,
+      },
+    };
+  },
   getClientId: (e) => {
     return e.GOOGLE_OAUTH_CLIENT_ID;
   },
@@ -52,14 +55,14 @@ export const googleCalendarHandler: OAuthConnectorProvider = {
   getRefreshSecretName: () => {
     return "GOOGLE_CALENDAR_REFRESH_TOKEN";
   },
-  refreshToken: adaptClientCredentialTokenRefresh(
-    (clientId, clientSecret, refreshToken) => {
-      return refreshGoogleToken(
-        "google-calendar",
-        clientId,
-        clientSecret,
-        refreshToken,
-      );
-    },
-  ),
+  refreshToken: (args) => {
+    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const refreshToken = args.refreshToken;
+    return refreshGoogleToken(
+      "google-calendar",
+      clientId,
+      clientSecret,
+      refreshToken,
+    );
+  },
 };

--- a/turbo/packages/connectors/src/oauth-providers/providers/google-docs-handler.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/google-docs-handler.ts
@@ -1,7 +1,6 @@
 import {
-  adaptClientCredentialCodeExchange,
-  adaptClientCredentialTokenRefresh,
-  adaptClientIdAuthUrl,
+  requireOAuthClientCredentials,
+  requireOAuthClientId,
   type OAuthConnectorProvider,
 } from "../provider-types";
 import {
@@ -10,36 +9,40 @@ import {
   refreshGoogleToken,
 } from "./google-oauth";
 export const googleDocsHandler: OAuthConnectorProvider = {
-  buildAuthUrl: adaptClientIdAuthUrl((clientId, redirectUri, state) => {
+  buildAuthUrl: (args) => {
+    const clientId = requireOAuthClientId(args);
+    const redirectUri = args.redirectUri;
+    const state = args.state;
     return buildGoogleAuthorizationUrl(
       "google-docs",
       clientId,
       redirectUri,
       state,
     );
-  }),
-  exchangeCode: adaptClientCredentialCodeExchange(
-    async (clientId, clientSecret, code, redirectUri) => {
-      const result = await exchangeGoogleOAuthCode(
-        "google-docs",
-        clientId,
-        clientSecret,
-        code,
-        redirectUri,
-      );
-      return {
-        accessToken: result.accessToken,
-        refreshToken: result.refreshToken,
-        expiresIn: result.expiresIn,
-        scopes: result.scopes,
-        userInfo: {
-          id: result.userInfo.id,
-          username: result.userInfo.name,
-          email: result.userInfo.email,
-        },
-      };
-    },
-  ),
+  },
+  exchangeCode: async (args) => {
+    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const code = args.code;
+    const redirectUri = args.redirectUri;
+    const result = await exchangeGoogleOAuthCode(
+      "google-docs",
+      clientId,
+      clientSecret,
+      code,
+      redirectUri,
+    );
+    return {
+      accessToken: result.accessToken,
+      refreshToken: result.refreshToken,
+      expiresIn: result.expiresIn,
+      scopes: result.scopes,
+      userInfo: {
+        id: result.userInfo.id,
+        username: result.userInfo.name,
+        email: result.userInfo.email,
+      },
+    };
+  },
   getClientId: (e) => {
     return e.GOOGLE_OAUTH_CLIENT_ID;
   },
@@ -52,14 +55,14 @@ export const googleDocsHandler: OAuthConnectorProvider = {
   getRefreshSecretName: () => {
     return "GOOGLE_DOCS_REFRESH_TOKEN";
   },
-  refreshToken: adaptClientCredentialTokenRefresh(
-    (clientId, clientSecret, refreshToken) => {
-      return refreshGoogleToken(
-        "google-docs",
-        clientId,
-        clientSecret,
-        refreshToken,
-      );
-    },
-  ),
+  refreshToken: (args) => {
+    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const refreshToken = args.refreshToken;
+    return refreshGoogleToken(
+      "google-docs",
+      clientId,
+      clientSecret,
+      refreshToken,
+    );
+  },
 };

--- a/turbo/packages/connectors/src/oauth-providers/providers/google-drive-handler.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/google-drive-handler.ts
@@ -1,7 +1,6 @@
 import {
-  adaptClientCredentialCodeExchange,
-  adaptClientCredentialTokenRefresh,
-  adaptClientIdAuthUrl,
+  requireOAuthClientCredentials,
+  requireOAuthClientId,
   type OAuthConnectorProvider,
 } from "../provider-types";
 import {
@@ -10,36 +9,40 @@ import {
   refreshGoogleToken,
 } from "./google-oauth";
 export const googleDriveHandler: OAuthConnectorProvider = {
-  buildAuthUrl: adaptClientIdAuthUrl((clientId, redirectUri, state) => {
+  buildAuthUrl: (args) => {
+    const clientId = requireOAuthClientId(args);
+    const redirectUri = args.redirectUri;
+    const state = args.state;
     return buildGoogleAuthorizationUrl(
       "google-drive",
       clientId,
       redirectUri,
       state,
     );
-  }),
-  exchangeCode: adaptClientCredentialCodeExchange(
-    async (clientId, clientSecret, code, redirectUri) => {
-      const result = await exchangeGoogleOAuthCode(
-        "google-drive",
-        clientId,
-        clientSecret,
-        code,
-        redirectUri,
-      );
-      return {
-        accessToken: result.accessToken,
-        refreshToken: result.refreshToken,
-        expiresIn: result.expiresIn,
-        scopes: result.scopes,
-        userInfo: {
-          id: result.userInfo.id,
-          username: result.userInfo.name,
-          email: result.userInfo.email,
-        },
-      };
-    },
-  ),
+  },
+  exchangeCode: async (args) => {
+    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const code = args.code;
+    const redirectUri = args.redirectUri;
+    const result = await exchangeGoogleOAuthCode(
+      "google-drive",
+      clientId,
+      clientSecret,
+      code,
+      redirectUri,
+    );
+    return {
+      accessToken: result.accessToken,
+      refreshToken: result.refreshToken,
+      expiresIn: result.expiresIn,
+      scopes: result.scopes,
+      userInfo: {
+        id: result.userInfo.id,
+        username: result.userInfo.name,
+        email: result.userInfo.email,
+      },
+    };
+  },
   getClientId: (e) => {
     return e.GOOGLE_OAUTH_CLIENT_ID;
   },
@@ -52,14 +55,14 @@ export const googleDriveHandler: OAuthConnectorProvider = {
   getRefreshSecretName: () => {
     return "GOOGLE_DRIVE_REFRESH_TOKEN";
   },
-  refreshToken: adaptClientCredentialTokenRefresh(
-    (clientId, clientSecret, refreshToken) => {
-      return refreshGoogleToken(
-        "google-drive",
-        clientId,
-        clientSecret,
-        refreshToken,
-      );
-    },
-  ),
+  refreshToken: (args) => {
+    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const refreshToken = args.refreshToken;
+    return refreshGoogleToken(
+      "google-drive",
+      clientId,
+      clientSecret,
+      refreshToken,
+    );
+  },
 };

--- a/turbo/packages/connectors/src/oauth-providers/providers/google-meet-handler.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/google-meet-handler.ts
@@ -1,7 +1,6 @@
 import {
-  adaptClientCredentialCodeExchange,
-  adaptClientCredentialTokenRefresh,
-  adaptClientIdAuthUrl,
+  requireOAuthClientCredentials,
+  requireOAuthClientId,
   type OAuthConnectorProvider,
 } from "../provider-types";
 import {
@@ -10,36 +9,40 @@ import {
   refreshGoogleToken,
 } from "./google-oauth";
 export const googleMeetHandler: OAuthConnectorProvider = {
-  buildAuthUrl: adaptClientIdAuthUrl((clientId, redirectUri, state) => {
+  buildAuthUrl: (args) => {
+    const clientId = requireOAuthClientId(args);
+    const redirectUri = args.redirectUri;
+    const state = args.state;
     return buildGoogleAuthorizationUrl(
       "google-meet",
       clientId,
       redirectUri,
       state,
     );
-  }),
-  exchangeCode: adaptClientCredentialCodeExchange(
-    async (clientId, clientSecret, code, redirectUri) => {
-      const result = await exchangeGoogleOAuthCode(
-        "google-meet",
-        clientId,
-        clientSecret,
-        code,
-        redirectUri,
-      );
-      return {
-        accessToken: result.accessToken,
-        refreshToken: result.refreshToken,
-        expiresIn: result.expiresIn,
-        scopes: result.scopes,
-        userInfo: {
-          id: result.userInfo.id,
-          username: result.userInfo.name,
-          email: result.userInfo.email,
-        },
-      };
-    },
-  ),
+  },
+  exchangeCode: async (args) => {
+    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const code = args.code;
+    const redirectUri = args.redirectUri;
+    const result = await exchangeGoogleOAuthCode(
+      "google-meet",
+      clientId,
+      clientSecret,
+      code,
+      redirectUri,
+    );
+    return {
+      accessToken: result.accessToken,
+      refreshToken: result.refreshToken,
+      expiresIn: result.expiresIn,
+      scopes: result.scopes,
+      userInfo: {
+        id: result.userInfo.id,
+        username: result.userInfo.name,
+        email: result.userInfo.email,
+      },
+    };
+  },
   getClientId: (e) => {
     return e.GOOGLE_OAUTH_CLIENT_ID;
   },
@@ -52,14 +55,14 @@ export const googleMeetHandler: OAuthConnectorProvider = {
   getRefreshSecretName: () => {
     return "GOOGLE_MEET_REFRESH_TOKEN";
   },
-  refreshToken: adaptClientCredentialTokenRefresh(
-    (clientId, clientSecret, refreshToken) => {
-      return refreshGoogleToken(
-        "google-meet",
-        clientId,
-        clientSecret,
-        refreshToken,
-      );
-    },
-  ),
+  refreshToken: (args) => {
+    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const refreshToken = args.refreshToken;
+    return refreshGoogleToken(
+      "google-meet",
+      clientId,
+      clientSecret,
+      refreshToken,
+    );
+  },
 };

--- a/turbo/packages/connectors/src/oauth-providers/providers/google-sheets-handler.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/google-sheets-handler.ts
@@ -1,7 +1,6 @@
 import {
-  adaptClientCredentialCodeExchange,
-  adaptClientCredentialTokenRefresh,
-  adaptClientIdAuthUrl,
+  requireOAuthClientCredentials,
+  requireOAuthClientId,
   type OAuthConnectorProvider,
 } from "../provider-types";
 import {
@@ -10,36 +9,40 @@ import {
   refreshGoogleToken,
 } from "./google-oauth";
 export const googleSheetsHandler: OAuthConnectorProvider = {
-  buildAuthUrl: adaptClientIdAuthUrl((clientId, redirectUri, state) => {
+  buildAuthUrl: (args) => {
+    const clientId = requireOAuthClientId(args);
+    const redirectUri = args.redirectUri;
+    const state = args.state;
     return buildGoogleAuthorizationUrl(
       "google-sheets",
       clientId,
       redirectUri,
       state,
     );
-  }),
-  exchangeCode: adaptClientCredentialCodeExchange(
-    async (clientId, clientSecret, code, redirectUri) => {
-      const result = await exchangeGoogleOAuthCode(
-        "google-sheets",
-        clientId,
-        clientSecret,
-        code,
-        redirectUri,
-      );
-      return {
-        accessToken: result.accessToken,
-        refreshToken: result.refreshToken,
-        expiresIn: result.expiresIn,
-        scopes: result.scopes,
-        userInfo: {
-          id: result.userInfo.id,
-          username: result.userInfo.name,
-          email: result.userInfo.email,
-        },
-      };
-    },
-  ),
+  },
+  exchangeCode: async (args) => {
+    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const code = args.code;
+    const redirectUri = args.redirectUri;
+    const result = await exchangeGoogleOAuthCode(
+      "google-sheets",
+      clientId,
+      clientSecret,
+      code,
+      redirectUri,
+    );
+    return {
+      accessToken: result.accessToken,
+      refreshToken: result.refreshToken,
+      expiresIn: result.expiresIn,
+      scopes: result.scopes,
+      userInfo: {
+        id: result.userInfo.id,
+        username: result.userInfo.name,
+        email: result.userInfo.email,
+      },
+    };
+  },
   getClientId: (e) => {
     return e.GOOGLE_OAUTH_CLIENT_ID;
   },
@@ -52,14 +55,14 @@ export const googleSheetsHandler: OAuthConnectorProvider = {
   getRefreshSecretName: () => {
     return "GOOGLE_SHEETS_REFRESH_TOKEN";
   },
-  refreshToken: adaptClientCredentialTokenRefresh(
-    (clientId, clientSecret, refreshToken) => {
-      return refreshGoogleToken(
-        "google-sheets",
-        clientId,
-        clientSecret,
-        refreshToken,
-      );
-    },
-  ),
+  refreshToken: (args) => {
+    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const refreshToken = args.refreshToken;
+    return refreshGoogleToken(
+      "google-sheets",
+      clientId,
+      clientSecret,
+      refreshToken,
+    );
+  },
 };

--- a/turbo/packages/connectors/src/oauth-providers/providers/gumroad-handler.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/gumroad-handler.ts
@@ -1,7 +1,6 @@
 import {
-  adaptClientCredentialCodeExchange,
-  adaptClientCredentialTokenRefresh,
-  adaptClientIdAuthUrl,
+  requireOAuthClientCredentials,
+  requireOAuthClientId,
   type OAuthConnectorProvider,
 } from "../provider-types";
 import {
@@ -11,28 +10,32 @@ import {
   refreshGumroadToken,
 } from "./gumroad";
 export const gumroadHandler: OAuthConnectorProvider = {
-  buildAuthUrl: adaptClientIdAuthUrl(buildGumroadAuthorizationUrl),
-  exchangeCode: adaptClientCredentialCodeExchange(
-    async (clientId, clientSecret, code, redirectUri) => {
-      const result = await exchangeGumroadCode(
-        clientId,
-        clientSecret,
-        code,
-        redirectUri,
-      );
-      return {
-        accessToken: result.accessToken,
-        refreshToken: result.refreshToken,
-        expiresIn: result.expiresIn,
-        scopes: result.scopes,
-        userInfo: {
-          id: result.userInfo.id,
-          username: result.userInfo.username,
-          email: result.userInfo.email,
-        },
-      };
-    },
-  ),
+  buildAuthUrl: (args) => {
+    const clientId = requireOAuthClientId(args);
+    return buildGumroadAuthorizationUrl(clientId, args.redirectUri, args.state);
+  },
+  exchangeCode: async (args) => {
+    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const code = args.code;
+    const redirectUri = args.redirectUri;
+    const result = await exchangeGumroadCode(
+      clientId,
+      clientSecret,
+      code,
+      redirectUri,
+    );
+    return {
+      accessToken: result.accessToken,
+      refreshToken: result.refreshToken,
+      expiresIn: result.expiresIn,
+      scopes: result.scopes,
+      userInfo: {
+        id: result.userInfo.id,
+        username: result.userInfo.username,
+        email: result.userInfo.email,
+      },
+    };
+  },
   getClientId: (e) => {
     return e.GUMROAD_OAUTH_CLIENT_ID;
   },
@@ -43,5 +46,8 @@ export const gumroadHandler: OAuthConnectorProvider = {
   getRefreshSecretName: () => {
     return "GUMROAD_REFRESH_TOKEN";
   },
-  refreshToken: adaptClientCredentialTokenRefresh(refreshGumroadToken),
+  refreshToken: (args) => {
+    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    return refreshGumroadToken(clientId, clientSecret, args.refreshToken);
+  },
 };

--- a/turbo/packages/connectors/src/oauth-providers/providers/hubspot-handler.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/hubspot-handler.ts
@@ -1,7 +1,6 @@
 import {
-  adaptClientCredentialCodeExchange,
-  adaptClientCredentialTokenRefresh,
-  adaptClientIdAuthUrl,
+  requireOAuthClientCredentials,
+  requireOAuthClientId,
   type OAuthConnectorProvider,
 } from "../provider-types";
 import {
@@ -11,28 +10,32 @@ import {
   refreshHubSpotToken,
 } from "./hubspot";
 export const hubspotHandler: OAuthConnectorProvider = {
-  buildAuthUrl: adaptClientIdAuthUrl(buildHubSpotAuthorizationUrl),
-  exchangeCode: adaptClientCredentialCodeExchange(
-    async (clientId, clientSecret, code, redirectUri) => {
-      const result = await exchangeHubSpotCode(
-        clientId,
-        clientSecret,
-        code,
-        redirectUri,
-      );
-      return {
-        accessToken: result.accessToken,
-        refreshToken: result.refreshToken,
-        expiresIn: result.expiresIn,
-        scopes: result.scopes,
-        userInfo: {
-          id: result.userInfo.id,
-          username: result.userInfo.hubDomain,
-          email: result.userInfo.email,
-        },
-      };
-    },
-  ),
+  buildAuthUrl: (args) => {
+    const clientId = requireOAuthClientId(args);
+    return buildHubSpotAuthorizationUrl(clientId, args.redirectUri, args.state);
+  },
+  exchangeCode: async (args) => {
+    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const code = args.code;
+    const redirectUri = args.redirectUri;
+    const result = await exchangeHubSpotCode(
+      clientId,
+      clientSecret,
+      code,
+      redirectUri,
+    );
+    return {
+      accessToken: result.accessToken,
+      refreshToken: result.refreshToken,
+      expiresIn: result.expiresIn,
+      scopes: result.scopes,
+      userInfo: {
+        id: result.userInfo.id,
+        username: result.userInfo.hubDomain,
+        email: result.userInfo.email,
+      },
+    };
+  },
   getClientId: (e) => {
     return e.HUBSPOT_OAUTH_CLIENT_ID;
   },
@@ -43,5 +46,8 @@ export const hubspotHandler: OAuthConnectorProvider = {
   getRefreshSecretName: () => {
     return "HUBSPOT_REFRESH_TOKEN";
   },
-  refreshToken: adaptClientCredentialTokenRefresh(refreshHubSpotToken),
+  refreshToken: (args) => {
+    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    return refreshHubSpotToken(clientId, clientSecret, args.refreshToken);
+  },
 };

--- a/turbo/packages/connectors/src/oauth-providers/providers/intervals-icu-handler.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/intervals-icu-handler.ts
@@ -1,6 +1,6 @@
 import {
-  adaptClientCredentialCodeExchange,
-  adaptClientIdAuthUrl,
+  requireOAuthClientCredentials,
+  requireOAuthClientId,
   type OAuthConnectorProvider,
 } from "../provider-types";
 import {
@@ -9,26 +9,29 @@ import {
   getIntervalsIcuSecretName,
 } from "./intervals-icu";
 export const intervalsIcuHandler: OAuthConnectorProvider = {
-  buildAuthUrl: adaptClientIdAuthUrl(buildIntervalsIcuAuthorizationUrl),
-  exchangeCode: adaptClientCredentialCodeExchange(
-    async (clientId, clientSecret, code) => {
-      const result = await exchangeIntervalsIcuCode(
-        clientId,
-        clientSecret,
-        code,
-      );
-      return {
-        accessToken: result.accessToken,
-        refreshToken: null,
-        scopes: result.scopes,
-        userInfo: {
-          id: result.userInfo.id,
-          username: result.userInfo.username,
-          email: result.userInfo.email,
-        },
-      };
-    },
-  ),
+  buildAuthUrl: (args) => {
+    const clientId = requireOAuthClientId(args);
+    return buildIntervalsIcuAuthorizationUrl(
+      clientId,
+      args.redirectUri,
+      args.state,
+    );
+  },
+  exchangeCode: async (args) => {
+    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const code = args.code;
+    const result = await exchangeIntervalsIcuCode(clientId, clientSecret, code);
+    return {
+      accessToken: result.accessToken,
+      refreshToken: null,
+      scopes: result.scopes,
+      userInfo: {
+        id: result.userInfo.id,
+        username: result.userInfo.username,
+        email: result.userInfo.email,
+      },
+    };
+  },
   getClientId: (e) => {
     return e.INTERVALS_ICU_OAUTH_CLIENT_ID;
   },

--- a/turbo/packages/connectors/src/oauth-providers/providers/linear-handler.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/linear-handler.ts
@@ -1,8 +1,6 @@
 import {
-  adaptClientCredentialCodeExchange,
-  adaptClientCredentialTokenRefresh,
-  adaptClientCredentialTokenRevocation,
-  adaptClientIdAuthUrl,
+  requireOAuthClientCredentials,
+  requireOAuthClientId,
   type OAuthConnectorProvider,
 } from "../provider-types";
 import {
@@ -13,28 +11,32 @@ import {
   revokeLinearToken,
 } from "./linear";
 export const linearHandler: OAuthConnectorProvider = {
-  buildAuthUrl: adaptClientIdAuthUrl(buildLinearAuthorizationUrl),
-  exchangeCode: adaptClientCredentialCodeExchange(
-    async (clientId, clientSecret, code, redirectUri) => {
-      const result = await exchangeLinearCode(
-        clientId,
-        clientSecret,
-        code,
-        redirectUri,
-      );
-      return {
-        accessToken: result.accessToken,
-        refreshToken: result.refreshToken,
-        expiresIn: result.expiresIn,
-        scopes: result.scopes,
-        userInfo: {
-          id: result.userInfo.id,
-          username: result.userInfo.name,
-          email: result.userInfo.email,
-        },
-      };
-    },
-  ),
+  buildAuthUrl: (args) => {
+    const clientId = requireOAuthClientId(args);
+    return buildLinearAuthorizationUrl(clientId, args.redirectUri, args.state);
+  },
+  exchangeCode: async (args) => {
+    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const code = args.code;
+    const redirectUri = args.redirectUri;
+    const result = await exchangeLinearCode(
+      clientId,
+      clientSecret,
+      code,
+      redirectUri,
+    );
+    return {
+      accessToken: result.accessToken,
+      refreshToken: result.refreshToken,
+      expiresIn: result.expiresIn,
+      scopes: result.scopes,
+      userInfo: {
+        id: result.userInfo.id,
+        username: result.userInfo.name,
+        email: result.userInfo.email,
+      },
+    };
+  },
   getClientId: (e) => {
     return e.LINEAR_OAUTH_CLIENT_ID;
   },
@@ -45,6 +47,12 @@ export const linearHandler: OAuthConnectorProvider = {
   getRefreshSecretName: () => {
     return "LINEAR_REFRESH_TOKEN";
   },
-  refreshToken: adaptClientCredentialTokenRefresh(refreshLinearToken),
-  revokeToken: adaptClientCredentialTokenRevocation(revokeLinearToken),
+  refreshToken: (args) => {
+    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    return refreshLinearToken(clientId, clientSecret, args.refreshToken);
+  },
+  revokeToken: (args) => {
+    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    return revokeLinearToken(clientId, clientSecret, args.accessToken);
+  },
 };

--- a/turbo/packages/connectors/src/oauth-providers/providers/mailchimp-handler.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/mailchimp-handler.ts
@@ -1,6 +1,6 @@
 import {
-  adaptClientCredentialCodeExchange,
-  adaptClientIdAuthUrl,
+  requireOAuthClientCredentials,
+  requireOAuthClientId,
   type OAuthConnectorProvider,
 } from "../provider-types";
 import {
@@ -9,27 +9,35 @@ import {
   getMailchimpSecretName,
 } from "./mailchimp";
 export const mailchimpHandler: OAuthConnectorProvider = {
-  buildAuthUrl: adaptClientIdAuthUrl(buildMailchimpAuthorizationUrl),
-  exchangeCode: adaptClientCredentialCodeExchange(
-    async (clientId, clientSecret, code, redirectUri) => {
-      const result = await exchangeMailchimpCode(
-        clientId,
-        clientSecret,
-        code,
-        redirectUri,
-      );
-      return {
-        accessToken: result.accessToken,
-        refreshToken: null,
-        scopes: result.scopes,
-        userInfo: {
-          id: result.userInfo.id,
-          username: result.userInfo.username,
-          email: result.userInfo.email,
-        },
-      };
-    },
-  ),
+  buildAuthUrl: (args) => {
+    const clientId = requireOAuthClientId(args);
+    return buildMailchimpAuthorizationUrl(
+      clientId,
+      args.redirectUri,
+      args.state,
+    );
+  },
+  exchangeCode: async (args) => {
+    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const code = args.code;
+    const redirectUri = args.redirectUri;
+    const result = await exchangeMailchimpCode(
+      clientId,
+      clientSecret,
+      code,
+      redirectUri,
+    );
+    return {
+      accessToken: result.accessToken,
+      refreshToken: null,
+      scopes: result.scopes,
+      userInfo: {
+        id: result.userInfo.id,
+        username: result.userInfo.username,
+        email: result.userInfo.email,
+      },
+    };
+  },
   getClientId: (e) => {
     return e.MAILCHIMP_OAUTH_CLIENT_ID;
   },

--- a/turbo/packages/connectors/src/oauth-providers/providers/mercury-handler.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/mercury-handler.ts
@@ -1,7 +1,6 @@
 import {
-  adaptClientCredentialCodeExchange,
-  adaptClientCredentialTokenRefresh,
-  adaptClientIdAuthUrl,
+  requireOAuthClientCredentials,
+  requireOAuthClientId,
   type OAuthConnectorProvider,
 } from "../provider-types";
 import {
@@ -11,28 +10,32 @@ import {
   refreshMercuryToken,
 } from "./mercury";
 export const mercuryHandler: OAuthConnectorProvider = {
-  buildAuthUrl: adaptClientIdAuthUrl(buildMercuryAuthorizationUrl),
-  exchangeCode: adaptClientCredentialCodeExchange(
-    async (clientId, clientSecret, code, redirectUri) => {
-      const result = await exchangeMercuryCode(
-        clientId,
-        clientSecret,
-        code,
-        redirectUri,
-      );
-      return {
-        accessToken: result.accessToken,
-        refreshToken: result.refreshToken,
-        expiresIn: result.expiresIn,
-        scopes: result.scopes,
-        userInfo: {
-          id: result.userInfo.id,
-          username: result.userInfo.username,
-          email: result.userInfo.email,
-        },
-      };
-    },
-  ),
+  buildAuthUrl: (args) => {
+    const clientId = requireOAuthClientId(args);
+    return buildMercuryAuthorizationUrl(clientId, args.redirectUri, args.state);
+  },
+  exchangeCode: async (args) => {
+    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const code = args.code;
+    const redirectUri = args.redirectUri;
+    const result = await exchangeMercuryCode(
+      clientId,
+      clientSecret,
+      code,
+      redirectUri,
+    );
+    return {
+      accessToken: result.accessToken,
+      refreshToken: result.refreshToken,
+      expiresIn: result.expiresIn,
+      scopes: result.scopes,
+      userInfo: {
+        id: result.userInfo.id,
+        username: result.userInfo.username,
+        email: result.userInfo.email,
+      },
+    };
+  },
   getClientId: (e) => {
     return e.MERCURY_OAUTH_CLIENT_ID;
   },
@@ -43,5 +46,8 @@ export const mercuryHandler: OAuthConnectorProvider = {
   getRefreshSecretName: () => {
     return "MERCURY_REFRESH_TOKEN";
   },
-  refreshToken: adaptClientCredentialTokenRefresh(refreshMercuryToken),
+  refreshToken: (args) => {
+    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    return refreshMercuryToken(clientId, clientSecret, args.refreshToken);
+  },
 };

--- a/turbo/packages/connectors/src/oauth-providers/providers/meta-ads-handler.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/meta-ads-handler.ts
@@ -1,6 +1,6 @@
 import {
-  adaptClientCredentialCodeExchange,
-  adaptClientIdAuthUrl,
+  requireOAuthClientCredentials,
+  requireOAuthClientId,
   type OAuthConnectorProvider,
 } from "../provider-types";
 import {
@@ -9,28 +9,32 @@ import {
   getMetaAdsSecretName,
 } from "./meta-ads";
 export const metaAdsHandler: OAuthConnectorProvider = {
-  buildAuthUrl: adaptClientIdAuthUrl(buildMetaAdsAuthorizationUrl),
-  exchangeCode: adaptClientCredentialCodeExchange(
-    async (clientId, clientSecret, code, redirectUri) => {
-      const result = await exchangeMetaAdsCode(
-        clientId,
-        clientSecret,
-        code,
-        redirectUri,
-      );
-      return {
-        accessToken: result.accessToken,
-        refreshToken: result.refreshToken,
-        expiresIn: result.expiresIn,
-        scopes: result.scopes,
-        userInfo: {
-          id: result.userInfo.id,
-          username: result.userInfo.username,
-          email: result.userInfo.email,
-        },
-      };
-    },
-  ),
+  buildAuthUrl: (args) => {
+    const clientId = requireOAuthClientId(args);
+    return buildMetaAdsAuthorizationUrl(clientId, args.redirectUri, args.state);
+  },
+  exchangeCode: async (args) => {
+    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const code = args.code;
+    const redirectUri = args.redirectUri;
+    const result = await exchangeMetaAdsCode(
+      clientId,
+      clientSecret,
+      code,
+      redirectUri,
+    );
+    return {
+      accessToken: result.accessToken,
+      refreshToken: result.refreshToken,
+      expiresIn: result.expiresIn,
+      scopes: result.scopes,
+      userInfo: {
+        id: result.userInfo.id,
+        username: result.userInfo.username,
+        email: result.userInfo.email,
+      },
+    };
+  },
   getClientId: (e) => {
     return e.META_ADS_OAUTH_CLIENT_ID;
   },

--- a/turbo/packages/connectors/src/oauth-providers/providers/monday-handler.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/monday-handler.ts
@@ -1,7 +1,6 @@
 import {
-  adaptClientCredentialCodeExchange,
-  adaptClientCredentialTokenRefresh,
-  adaptClientIdAuthUrl,
+  requireOAuthClientCredentials,
+  requireOAuthClientId,
   type OAuthConnectorProvider,
 } from "../provider-types";
 import {
@@ -11,28 +10,32 @@ import {
   refreshMondayToken,
 } from "./monday";
 export const mondayHandler: OAuthConnectorProvider = {
-  buildAuthUrl: adaptClientIdAuthUrl(buildMondayAuthorizationUrl),
-  exchangeCode: adaptClientCredentialCodeExchange(
-    async (clientId, clientSecret, code, redirectUri) => {
-      const result = await exchangeMondayCode(
-        clientId,
-        clientSecret,
-        code,
-        redirectUri,
-      );
-      return {
-        accessToken: result.accessToken,
-        refreshToken: result.refreshToken,
-        expiresIn: result.expiresIn,
-        scopes: result.scopes,
-        userInfo: {
-          id: result.userInfo.id,
-          username: result.userInfo.username,
-          email: result.userInfo.email,
-        },
-      };
-    },
-  ),
+  buildAuthUrl: (args) => {
+    const clientId = requireOAuthClientId(args);
+    return buildMondayAuthorizationUrl(clientId, args.redirectUri, args.state);
+  },
+  exchangeCode: async (args) => {
+    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const code = args.code;
+    const redirectUri = args.redirectUri;
+    const result = await exchangeMondayCode(
+      clientId,
+      clientSecret,
+      code,
+      redirectUri,
+    );
+    return {
+      accessToken: result.accessToken,
+      refreshToken: result.refreshToken,
+      expiresIn: result.expiresIn,
+      scopes: result.scopes,
+      userInfo: {
+        id: result.userInfo.id,
+        username: result.userInfo.username,
+        email: result.userInfo.email,
+      },
+    };
+  },
   getClientId: (e) => {
     return e.MONDAY_OAUTH_CLIENT_ID;
   },
@@ -43,5 +46,8 @@ export const mondayHandler: OAuthConnectorProvider = {
   getRefreshSecretName: () => {
     return "MONDAY_REFRESH_TOKEN";
   },
-  refreshToken: adaptClientCredentialTokenRefresh(refreshMondayToken),
+  refreshToken: (args) => {
+    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    return refreshMondayToken(clientId, clientSecret, args.refreshToken);
+  },
 };

--- a/turbo/packages/connectors/src/oauth-providers/providers/neon-handler.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/neon-handler.ts
@@ -1,7 +1,6 @@
 import {
-  adaptClientCredentialCodeExchange,
-  adaptClientCredentialTokenRefresh,
-  adaptClientIdAuthUrl,
+  requireOAuthClientCredentials,
+  requireOAuthClientId,
   type OAuthConnectorProvider,
 } from "../provider-types";
 import {
@@ -11,28 +10,32 @@ import {
   refreshNeonToken,
 } from "./neon";
 export const neonHandler: OAuthConnectorProvider = {
-  buildAuthUrl: adaptClientIdAuthUrl(buildNeonAuthorizationUrl),
-  exchangeCode: adaptClientCredentialCodeExchange(
-    async (clientId, clientSecret, code, redirectUri) => {
-      const result = await exchangeNeonCode(
-        clientId,
-        clientSecret,
-        code,
-        redirectUri,
-      );
-      return {
-        accessToken: result.accessToken,
-        refreshToken: result.refreshToken,
-        expiresIn: result.expiresIn,
-        scopes: result.scopes,
-        userInfo: {
-          id: result.userInfo.id,
-          username: result.userInfo.username,
-          email: result.userInfo.email,
-        },
-      };
-    },
-  ),
+  buildAuthUrl: (args) => {
+    const clientId = requireOAuthClientId(args);
+    return buildNeonAuthorizationUrl(clientId, args.redirectUri, args.state);
+  },
+  exchangeCode: async (args) => {
+    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const code = args.code;
+    const redirectUri = args.redirectUri;
+    const result = await exchangeNeonCode(
+      clientId,
+      clientSecret,
+      code,
+      redirectUri,
+    );
+    return {
+      accessToken: result.accessToken,
+      refreshToken: result.refreshToken,
+      expiresIn: result.expiresIn,
+      scopes: result.scopes,
+      userInfo: {
+        id: result.userInfo.id,
+        username: result.userInfo.username,
+        email: result.userInfo.email,
+      },
+    };
+  },
   getClientId: (e) => {
     return e.NEON_OAUTH_CLIENT_ID;
   },
@@ -43,5 +46,8 @@ export const neonHandler: OAuthConnectorProvider = {
   getRefreshSecretName: () => {
     return "NEON_REFRESH_TOKEN";
   },
-  refreshToken: adaptClientCredentialTokenRefresh(refreshNeonToken),
+  refreshToken: (args) => {
+    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    return refreshNeonToken(clientId, clientSecret, args.refreshToken);
+  },
 };

--- a/turbo/packages/connectors/src/oauth-providers/providers/notion-handler.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/notion-handler.ts
@@ -1,7 +1,6 @@
 import {
-  adaptClientCredentialCodeExchange,
-  adaptClientCredentialTokenRefresh,
-  adaptClientIdAuthUrl,
+  requireOAuthClientCredentials,
+  requireOAuthClientId,
   type OAuthConnectorProvider,
 } from "../provider-types";
 import {
@@ -11,24 +10,28 @@ import {
   refreshNotionToken,
 } from "./notion";
 export const notionHandler: OAuthConnectorProvider = {
-  buildAuthUrl: adaptClientIdAuthUrl(buildNotionAuthorizationUrl),
-  exchangeCode: adaptClientCredentialCodeExchange(
-    async (clientId, clientSecret, code, redirectUri) => {
-      const result = await exchangeNotionCode(
-        clientId,
-        clientSecret,
-        code,
-        redirectUri,
-      );
-      return {
-        accessToken: result.accessToken,
-        refreshToken: result.refreshToken,
-        expiresIn: result.expiresIn,
-        scopes: result.scopes,
-        userInfo: result.userInfo,
-      };
-    },
-  ),
+  buildAuthUrl: (args) => {
+    const clientId = requireOAuthClientId(args);
+    return buildNotionAuthorizationUrl(clientId, args.redirectUri, args.state);
+  },
+  exchangeCode: async (args) => {
+    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const code = args.code;
+    const redirectUri = args.redirectUri;
+    const result = await exchangeNotionCode(
+      clientId,
+      clientSecret,
+      code,
+      redirectUri,
+    );
+    return {
+      accessToken: result.accessToken,
+      refreshToken: result.refreshToken,
+      expiresIn: result.expiresIn,
+      scopes: result.scopes,
+      userInfo: result.userInfo,
+    };
+  },
   getClientId: (e) => {
     return e.NOTION_OAUTH_CLIENT_ID;
   },
@@ -39,5 +42,8 @@ export const notionHandler: OAuthConnectorProvider = {
   getRefreshSecretName: () => {
     return "NOTION_REFRESH_TOKEN";
   },
-  refreshToken: adaptClientCredentialTokenRefresh(refreshNotionToken),
+  refreshToken: (args) => {
+    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    return refreshNotionToken(clientId, clientSecret, args.refreshToken);
+  },
 };

--- a/turbo/packages/connectors/src/oauth-providers/providers/outlook-calendar-handler.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/outlook-calendar-handler.ts
@@ -1,7 +1,6 @@
 import {
-  adaptClientCredentialCodeExchange,
-  adaptClientCredentialTokenRefresh,
-  adaptClientIdAuthUrl,
+  requireOAuthClientCredentials,
+  requireOAuthClientId,
   type OAuthConnectorProvider,
 } from "../provider-types";
 import {
@@ -10,36 +9,40 @@ import {
   refreshMicrosoftToken,
 } from "./microsoft-oauth";
 export const outlookCalendarHandler: OAuthConnectorProvider = {
-  buildAuthUrl: adaptClientIdAuthUrl((clientId, redirectUri, state) => {
+  buildAuthUrl: (args) => {
+    const clientId = requireOAuthClientId(args);
+    const redirectUri = args.redirectUri;
+    const state = args.state;
     return buildMicrosoftAuthorizationUrl(
       "outlook-calendar",
       clientId,
       redirectUri,
       state,
     );
-  }),
-  exchangeCode: adaptClientCredentialCodeExchange(
-    async (clientId, clientSecret, code, redirectUri) => {
-      const result = await exchangeMicrosoftOAuthCode(
-        "outlook-calendar",
-        clientId,
-        clientSecret,
-        code,
-        redirectUri,
-      );
-      return {
-        accessToken: result.accessToken,
-        refreshToken: result.refreshToken,
-        expiresIn: result.expiresIn,
-        scopes: result.scopes,
-        userInfo: {
-          id: result.userInfo.id,
-          username: result.userInfo.name,
-          email: result.userInfo.email,
-        },
-      };
-    },
-  ),
+  },
+  exchangeCode: async (args) => {
+    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const code = args.code;
+    const redirectUri = args.redirectUri;
+    const result = await exchangeMicrosoftOAuthCode(
+      "outlook-calendar",
+      clientId,
+      clientSecret,
+      code,
+      redirectUri,
+    );
+    return {
+      accessToken: result.accessToken,
+      refreshToken: result.refreshToken,
+      expiresIn: result.expiresIn,
+      scopes: result.scopes,
+      userInfo: {
+        id: result.userInfo.id,
+        username: result.userInfo.name,
+        email: result.userInfo.email,
+      },
+    };
+  },
   getClientId: (e) => {
     return e.MICROSOFT_OAUTH_CLIENT_ID;
   },
@@ -52,14 +55,14 @@ export const outlookCalendarHandler: OAuthConnectorProvider = {
   getRefreshSecretName: () => {
     return "OUTLOOK_CALENDAR_REFRESH_TOKEN";
   },
-  refreshToken: adaptClientCredentialTokenRefresh(
-    (clientId, clientSecret, refreshToken) => {
-      return refreshMicrosoftToken(
-        "outlook-calendar",
-        clientId,
-        clientSecret,
-        refreshToken,
-      );
-    },
-  ),
+  refreshToken: (args) => {
+    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const refreshToken = args.refreshToken;
+    return refreshMicrosoftToken(
+      "outlook-calendar",
+      clientId,
+      clientSecret,
+      refreshToken,
+    );
+  },
 };

--- a/turbo/packages/connectors/src/oauth-providers/providers/outlook-mail-handler.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/outlook-mail-handler.ts
@@ -1,7 +1,6 @@
 import {
-  adaptClientCredentialCodeExchange,
-  adaptClientCredentialTokenRefresh,
-  adaptClientIdAuthUrl,
+  requireOAuthClientCredentials,
+  requireOAuthClientId,
   type OAuthConnectorProvider,
 } from "../provider-types";
 import {
@@ -10,36 +9,40 @@ import {
   refreshMicrosoftToken,
 } from "./microsoft-oauth";
 export const outlookMailHandler: OAuthConnectorProvider = {
-  buildAuthUrl: adaptClientIdAuthUrl((clientId, redirectUri, state) => {
+  buildAuthUrl: (args) => {
+    const clientId = requireOAuthClientId(args);
+    const redirectUri = args.redirectUri;
+    const state = args.state;
     return buildMicrosoftAuthorizationUrl(
       "outlook-mail",
       clientId,
       redirectUri,
       state,
     );
-  }),
-  exchangeCode: adaptClientCredentialCodeExchange(
-    async (clientId, clientSecret, code, redirectUri) => {
-      const result = await exchangeMicrosoftOAuthCode(
-        "outlook-mail",
-        clientId,
-        clientSecret,
-        code,
-        redirectUri,
-      );
-      return {
-        accessToken: result.accessToken,
-        refreshToken: result.refreshToken,
-        expiresIn: result.expiresIn,
-        scopes: result.scopes,
-        userInfo: {
-          id: result.userInfo.id,
-          username: result.userInfo.name,
-          email: result.userInfo.email,
-        },
-      };
-    },
-  ),
+  },
+  exchangeCode: async (args) => {
+    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const code = args.code;
+    const redirectUri = args.redirectUri;
+    const result = await exchangeMicrosoftOAuthCode(
+      "outlook-mail",
+      clientId,
+      clientSecret,
+      code,
+      redirectUri,
+    );
+    return {
+      accessToken: result.accessToken,
+      refreshToken: result.refreshToken,
+      expiresIn: result.expiresIn,
+      scopes: result.scopes,
+      userInfo: {
+        id: result.userInfo.id,
+        username: result.userInfo.name,
+        email: result.userInfo.email,
+      },
+    };
+  },
   getClientId: (e) => {
     return e.MICROSOFT_OAUTH_CLIENT_ID;
   },
@@ -52,14 +55,14 @@ export const outlookMailHandler: OAuthConnectorProvider = {
   getRefreshSecretName: () => {
     return "OUTLOOK_MAIL_REFRESH_TOKEN";
   },
-  refreshToken: adaptClientCredentialTokenRefresh(
-    (clientId, clientSecret, refreshToken) => {
-      return refreshMicrosoftToken(
-        "outlook-mail",
-        clientId,
-        clientSecret,
-        refreshToken,
-      );
-    },
-  ),
+  refreshToken: (args) => {
+    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const refreshToken = args.refreshToken;
+    return refreshMicrosoftToken(
+      "outlook-mail",
+      clientId,
+      clientSecret,
+      refreshToken,
+    );
+  },
 };

--- a/turbo/packages/connectors/src/oauth-providers/providers/posthog-handler.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/posthog-handler.ts
@@ -1,7 +1,6 @@
 import {
-  adaptClientCredentialCodeExchange,
-  adaptClientCredentialTokenRefresh,
-  adaptClientIdAuthUrl,
+  requireOAuthClientCredentials,
+  requireOAuthClientId,
   type OAuthConnectorProvider,
 } from "../provider-types";
 import {
@@ -11,28 +10,32 @@ import {
   refreshPosthogToken,
 } from "./posthog";
 export const posthogHandler: OAuthConnectorProvider = {
-  buildAuthUrl: adaptClientIdAuthUrl(buildPosthogAuthorizationUrl),
-  exchangeCode: adaptClientCredentialCodeExchange(
-    async (clientId, clientSecret, code, redirectUri) => {
-      const result = await exchangePosthogCode(
-        clientId,
-        clientSecret,
-        code,
-        redirectUri,
-      );
-      return {
-        accessToken: result.accessToken,
-        refreshToken: result.refreshToken,
-        expiresIn: result.expiresIn,
-        scopes: result.scopes,
-        userInfo: {
-          id: result.userInfo.id,
-          username: result.userInfo.name,
-          email: result.userInfo.email,
-        },
-      };
-    },
-  ),
+  buildAuthUrl: (args) => {
+    const clientId = requireOAuthClientId(args);
+    return buildPosthogAuthorizationUrl(clientId, args.redirectUri, args.state);
+  },
+  exchangeCode: async (args) => {
+    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const code = args.code;
+    const redirectUri = args.redirectUri;
+    const result = await exchangePosthogCode(
+      clientId,
+      clientSecret,
+      code,
+      redirectUri,
+    );
+    return {
+      accessToken: result.accessToken,
+      refreshToken: result.refreshToken,
+      expiresIn: result.expiresIn,
+      scopes: result.scopes,
+      userInfo: {
+        id: result.userInfo.id,
+        username: result.userInfo.name,
+        email: result.userInfo.email,
+      },
+    };
+  },
   getClientId: (e) => {
     return e.POSTHOG_OAUTH_CLIENT_ID;
   },
@@ -43,5 +46,8 @@ export const posthogHandler: OAuthConnectorProvider = {
   getRefreshSecretName: () => {
     return "POSTHOG_REFRESH_TOKEN";
   },
-  refreshToken: adaptClientCredentialTokenRefresh(refreshPosthogToken),
+  refreshToken: (args) => {
+    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    return refreshPosthogToken(clientId, clientSecret, args.refreshToken);
+  },
 };

--- a/turbo/packages/connectors/src/oauth-providers/providers/reddit-handler.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/reddit-handler.ts
@@ -1,7 +1,6 @@
 import {
-  adaptClientCredentialCodeExchange,
-  adaptClientCredentialTokenRefresh,
-  adaptClientIdAuthUrl,
+  requireOAuthClientCredentials,
+  requireOAuthClientId,
   type OAuthConnectorProvider,
 } from "../provider-types";
 import {
@@ -11,28 +10,32 @@ import {
   refreshRedditToken,
 } from "./reddit";
 export const redditHandler: OAuthConnectorProvider = {
-  buildAuthUrl: adaptClientIdAuthUrl(buildRedditAuthorizationUrl),
-  exchangeCode: adaptClientCredentialCodeExchange(
-    async (clientId, clientSecret, code, redirectUri) => {
-      const result = await exchangeRedditCode(
-        clientId,
-        clientSecret,
-        code,
-        redirectUri,
-      );
-      return {
-        accessToken: result.accessToken,
-        refreshToken: result.refreshToken,
-        expiresIn: result.expiresIn,
-        scopes: result.scopes,
-        userInfo: {
-          id: result.userInfo.id,
-          username: result.userInfo.username,
-          email: result.userInfo.email,
-        },
-      };
-    },
-  ),
+  buildAuthUrl: (args) => {
+    const clientId = requireOAuthClientId(args);
+    return buildRedditAuthorizationUrl(clientId, args.redirectUri, args.state);
+  },
+  exchangeCode: async (args) => {
+    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const code = args.code;
+    const redirectUri = args.redirectUri;
+    const result = await exchangeRedditCode(
+      clientId,
+      clientSecret,
+      code,
+      redirectUri,
+    );
+    return {
+      accessToken: result.accessToken,
+      refreshToken: result.refreshToken,
+      expiresIn: result.expiresIn,
+      scopes: result.scopes,
+      userInfo: {
+        id: result.userInfo.id,
+        username: result.userInfo.username,
+        email: result.userInfo.email,
+      },
+    };
+  },
   getClientId: (e) => {
     return e.REDDIT_OAUTH_CLIENT_ID;
   },
@@ -43,5 +46,8 @@ export const redditHandler: OAuthConnectorProvider = {
   getRefreshSecretName: () => {
     return "REDDIT_REFRESH_TOKEN";
   },
-  refreshToken: adaptClientCredentialTokenRefresh(refreshRedditToken),
+  refreshToken: (args) => {
+    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    return refreshRedditToken(clientId, clientSecret, args.refreshToken);
+  },
 };

--- a/turbo/packages/connectors/src/oauth-providers/providers/sentry-handler.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/sentry-handler.ts
@@ -1,7 +1,6 @@
 import {
-  adaptClientCredentialCodeExchange,
-  adaptClientCredentialTokenRefresh,
-  adaptClientIdAuthUrl,
+  requireOAuthClientCredentials,
+  requireOAuthClientId,
   type OAuthConnectorProvider,
 } from "../provider-types";
 import {
@@ -11,28 +10,32 @@ import {
   refreshSentryToken,
 } from "./sentry";
 export const sentryHandler: OAuthConnectorProvider = {
-  buildAuthUrl: adaptClientIdAuthUrl(buildSentryAuthorizationUrl),
-  exchangeCode: adaptClientCredentialCodeExchange(
-    async (clientId, clientSecret, code, redirectUri) => {
-      const result = await exchangeSentryCode(
-        clientId,
-        clientSecret,
-        code,
-        redirectUri,
-      );
-      return {
-        accessToken: result.accessToken,
-        refreshToken: result.refreshToken,
-        expiresIn: result.expiresIn,
-        scopes: result.scopes,
-        userInfo: {
-          id: result.userInfo.id,
-          username: result.userInfo.name,
-          email: result.userInfo.email,
-        },
-      };
-    },
-  ),
+  buildAuthUrl: (args) => {
+    const clientId = requireOAuthClientId(args);
+    return buildSentryAuthorizationUrl(clientId, args.redirectUri, args.state);
+  },
+  exchangeCode: async (args) => {
+    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const code = args.code;
+    const redirectUri = args.redirectUri;
+    const result = await exchangeSentryCode(
+      clientId,
+      clientSecret,
+      code,
+      redirectUri,
+    );
+    return {
+      accessToken: result.accessToken,
+      refreshToken: result.refreshToken,
+      expiresIn: result.expiresIn,
+      scopes: result.scopes,
+      userInfo: {
+        id: result.userInfo.id,
+        username: result.userInfo.name,
+        email: result.userInfo.email,
+      },
+    };
+  },
   getClientId: (e) => {
     return e.SENTRY_OAUTH_CLIENT_ID;
   },
@@ -43,5 +46,8 @@ export const sentryHandler: OAuthConnectorProvider = {
   getRefreshSecretName: () => {
     return "SENTRY_REFRESH_TOKEN";
   },
-  refreshToken: adaptClientCredentialTokenRefresh(refreshSentryToken),
+  refreshToken: (args) => {
+    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    return refreshSentryToken(clientId, clientSecret, args.refreshToken);
+  },
 };

--- a/turbo/packages/connectors/src/oauth-providers/providers/slack-handler.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/slack-handler.ts
@@ -1,7 +1,6 @@
 import {
-  adaptClientCredentialCodeExchange,
-  adaptClientCredentialTokenRevocation,
-  adaptClientIdAuthUrl,
+  requireOAuthClientCredentials,
+  requireOAuthClientId,
   type OAuthConnectorProvider,
 } from "../provider-types";
 import {
@@ -12,30 +11,34 @@ import {
   revokeSlackToken,
 } from "./slack";
 export const slackHandler: OAuthConnectorProvider = {
-  buildAuthUrl: adaptClientIdAuthUrl(buildSlackAuthorizationUrl),
-  exchangeCode: adaptClientCredentialCodeExchange(
-    async (clientId, clientSecret, code, redirectUri) => {
-      const slackResult = await exchangeSlackCode(
-        clientId,
-        clientSecret,
-        code,
-        redirectUri,
-      );
-      const slackUser = await fetchSlackUserInfo(
-        slackResult.userId,
-        slackResult.accessToken,
-      );
-      return {
-        accessToken: slackResult.accessToken,
-        scopes: slackResult.scopes,
-        userInfo: {
-          id: slackUser.id,
-          username: slackUser.username,
-          email: slackUser.email,
-        },
-      };
-    },
-  ),
+  buildAuthUrl: (args) => {
+    const clientId = requireOAuthClientId(args);
+    return buildSlackAuthorizationUrl(clientId, args.redirectUri, args.state);
+  },
+  exchangeCode: async (args) => {
+    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const code = args.code;
+    const redirectUri = args.redirectUri;
+    const slackResult = await exchangeSlackCode(
+      clientId,
+      clientSecret,
+      code,
+      redirectUri,
+    );
+    const slackUser = await fetchSlackUserInfo(
+      slackResult.userId,
+      slackResult.accessToken,
+    );
+    return {
+      accessToken: slackResult.accessToken,
+      scopes: slackResult.scopes,
+      userInfo: {
+        id: slackUser.id,
+        username: slackUser.username,
+        email: slackUser.email,
+      },
+    };
+  },
   getClientId: (e) => {
     return e.SLACK_CLIENT_ID;
   },
@@ -43,5 +46,8 @@ export const slackHandler: OAuthConnectorProvider = {
     return e.SLACK_CLIENT_SECRET;
   },
   getSecretName: getSlackSecretName,
-  revokeToken: adaptClientCredentialTokenRevocation(revokeSlackToken),
+  revokeToken: (args) => {
+    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    return revokeSlackToken(clientId, clientSecret, args.accessToken);
+  },
 };

--- a/turbo/packages/connectors/src/oauth-providers/providers/spotify-handler.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/spotify-handler.ts
@@ -1,7 +1,6 @@
 import {
-  adaptClientCredentialCodeExchange,
-  adaptClientCredentialTokenRefresh,
-  adaptClientIdAuthUrl,
+  requireOAuthClientCredentials,
+  requireOAuthClientId,
   type OAuthConnectorProvider,
 } from "../provider-types";
 import {
@@ -11,28 +10,32 @@ import {
   refreshSpotifyToken,
 } from "./spotify";
 export const spotifyHandler: OAuthConnectorProvider = {
-  buildAuthUrl: adaptClientIdAuthUrl(buildSpotifyAuthorizationUrl),
-  exchangeCode: adaptClientCredentialCodeExchange(
-    async (clientId, clientSecret, code, redirectUri) => {
-      const result = await exchangeSpotifyCode(
-        clientId,
-        clientSecret,
-        code,
-        redirectUri,
-      );
-      return {
-        accessToken: result.accessToken,
-        refreshToken: result.refreshToken,
-        expiresIn: result.expiresIn,
-        scopes: result.scopes,
-        userInfo: {
-          id: result.userInfo.id,
-          username: result.userInfo.username,
-          email: result.userInfo.email,
-        },
-      };
-    },
-  ),
+  buildAuthUrl: (args) => {
+    const clientId = requireOAuthClientId(args);
+    return buildSpotifyAuthorizationUrl(clientId, args.redirectUri, args.state);
+  },
+  exchangeCode: async (args) => {
+    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const code = args.code;
+    const redirectUri = args.redirectUri;
+    const result = await exchangeSpotifyCode(
+      clientId,
+      clientSecret,
+      code,
+      redirectUri,
+    );
+    return {
+      accessToken: result.accessToken,
+      refreshToken: result.refreshToken,
+      expiresIn: result.expiresIn,
+      scopes: result.scopes,
+      userInfo: {
+        id: result.userInfo.id,
+        username: result.userInfo.username,
+        email: result.userInfo.email,
+      },
+    };
+  },
   getClientId: (e) => {
     return e.SPOTIFY_OAUTH_CLIENT_ID;
   },
@@ -43,5 +46,8 @@ export const spotifyHandler: OAuthConnectorProvider = {
   getRefreshSecretName: () => {
     return "SPOTIFY_REFRESH_TOKEN";
   },
-  refreshToken: adaptClientCredentialTokenRefresh(refreshSpotifyToken),
+  refreshToken: (args) => {
+    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    return refreshSpotifyToken(clientId, clientSecret, args.refreshToken);
+  },
 };

--- a/turbo/packages/connectors/src/oauth-providers/providers/strava-handler.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/strava-handler.ts
@@ -1,7 +1,6 @@
 import {
-  adaptClientCredentialCodeExchange,
-  adaptClientCredentialTokenRefresh,
-  adaptClientIdAuthUrl,
+  requireOAuthClientCredentials,
+  requireOAuthClientId,
   type OAuthConnectorProvider,
 } from "../provider-types";
 import {
@@ -11,23 +10,26 @@ import {
   refreshStravaToken,
 } from "./strava";
 export const stravaHandler: OAuthConnectorProvider = {
-  buildAuthUrl: adaptClientIdAuthUrl(buildStravaAuthorizationUrl),
-  exchangeCode: adaptClientCredentialCodeExchange(
-    async (clientId, clientSecret, code) => {
-      const result = await exchangeStravaCode(clientId, clientSecret, code);
-      return {
-        accessToken: result.accessToken,
-        refreshToken: result.refreshToken,
-        expiresIn: result.expiresIn,
-        scopes: result.scopes,
-        userInfo: {
-          id: result.userInfo.id,
-          username: result.userInfo.username,
-          email: result.userInfo.email,
-        },
-      };
-    },
-  ),
+  buildAuthUrl: (args) => {
+    const clientId = requireOAuthClientId(args);
+    return buildStravaAuthorizationUrl(clientId, args.redirectUri, args.state);
+  },
+  exchangeCode: async (args) => {
+    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const code = args.code;
+    const result = await exchangeStravaCode(clientId, clientSecret, code);
+    return {
+      accessToken: result.accessToken,
+      refreshToken: result.refreshToken,
+      expiresIn: result.expiresIn,
+      scopes: result.scopes,
+      userInfo: {
+        id: result.userInfo.id,
+        username: result.userInfo.username,
+        email: result.userInfo.email,
+      },
+    };
+  },
   getClientId: (e) => {
     return e.STRAVA_OAUTH_CLIENT_ID;
   },
@@ -38,5 +40,8 @@ export const stravaHandler: OAuthConnectorProvider = {
   getRefreshSecretName: () => {
     return "STRAVA_REFRESH_TOKEN";
   },
-  refreshToken: adaptClientCredentialTokenRefresh(refreshStravaToken),
+  refreshToken: (args) => {
+    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    return refreshStravaToken(clientId, clientSecret, args.refreshToken);
+  },
 };

--- a/turbo/packages/connectors/src/oauth-providers/providers/stripe-handler.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/stripe-handler.ts
@@ -1,7 +1,6 @@
 import {
-  adaptClientCredentialCodeExchange,
-  adaptClientCredentialTokenRefresh,
-  adaptClientIdAuthUrl,
+  requireOAuthClientCredentials,
+  requireOAuthClientId,
   type OAuthConnectorProvider,
 } from "../provider-types";
 import {
@@ -11,22 +10,25 @@ import {
   refreshStripeToken,
 } from "./stripe";
 export const stripeHandler: OAuthConnectorProvider = {
-  buildAuthUrl: adaptClientIdAuthUrl(buildStripeAuthorizationUrl),
-  exchangeCode: adaptClientCredentialCodeExchange(
-    async (clientId, clientSecret, code) => {
-      const result = await exchangeStripeCode(clientId, clientSecret, code);
-      return {
-        accessToken: result.accessToken,
-        refreshToken: result.refreshToken,
-        scopes: result.scopes,
-        userInfo: {
-          id: result.userInfo.id,
-          username: result.userInfo.username,
-          email: result.userInfo.email,
-        },
-      };
-    },
-  ),
+  buildAuthUrl: (args) => {
+    const clientId = requireOAuthClientId(args);
+    return buildStripeAuthorizationUrl(clientId, args.redirectUri, args.state);
+  },
+  exchangeCode: async (args) => {
+    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const code = args.code;
+    const result = await exchangeStripeCode(clientId, clientSecret, code);
+    return {
+      accessToken: result.accessToken,
+      refreshToken: result.refreshToken,
+      scopes: result.scopes,
+      userInfo: {
+        id: result.userInfo.id,
+        username: result.userInfo.username,
+        email: result.userInfo.email,
+      },
+    };
+  },
   getClientId: (e) => {
     return e.STRIPE_OAUTH_CLIENT_ID;
   },
@@ -37,5 +39,8 @@ export const stripeHandler: OAuthConnectorProvider = {
   getRefreshSecretName: () => {
     return "STRIPE_REFRESH_TOKEN";
   },
-  refreshToken: adaptClientCredentialTokenRefresh(refreshStripeToken),
+  refreshToken: (args) => {
+    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    return refreshStripeToken(clientId, clientSecret, args.refreshToken);
+  },
 };

--- a/turbo/packages/connectors/src/oauth-providers/providers/supabase-handler.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/supabase-handler.ts
@@ -1,7 +1,6 @@
 import {
-  adaptClientCredentialCodeExchange,
-  adaptClientCredentialTokenRefresh,
-  adaptClientIdAuthUrl,
+  requireOAuthClientCredentials,
+  requireOAuthClientId,
   type OAuthConnectorProvider,
 } from "../provider-types";
 import {
@@ -11,34 +10,43 @@ import {
   refreshSupabaseToken,
 } from "./supabase";
 export const supabaseHandler: OAuthConnectorProvider = {
-  buildAuthUrl: adaptClientIdAuthUrl(buildSupabaseAuthorizationUrl),
-  exchangeCode: adaptClientCredentialCodeExchange(
-    async (clientId, clientSecret, code, redirectUri, state) => {
-      if (!state) {
-        throw new Error(
-          "Supabase PKCE requires state for code_verifier derivation",
-        );
-      }
-      const result = await exchangeSupabaseCode(
-        clientId,
-        clientSecret,
-        code,
-        redirectUri,
-        state,
+  buildAuthUrl: (args) => {
+    const clientId = requireOAuthClientId(args);
+    return buildSupabaseAuthorizationUrl(
+      clientId,
+      args.redirectUri,
+      args.state,
+    );
+  },
+  exchangeCode: async (args) => {
+    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const code = args.code;
+    const redirectUri = args.redirectUri;
+    const state = args.state;
+    if (!state) {
+      throw new Error(
+        "Supabase PKCE requires state for code_verifier derivation",
       );
-      return {
-        accessToken: result.accessToken,
-        refreshToken: result.refreshToken,
-        expiresIn: result.expiresIn,
-        scopes: result.scopes,
-        userInfo: {
-          id: result.userInfo.id,
-          username: result.userInfo.username,
-          email: result.userInfo.email,
-        },
-      };
-    },
-  ),
+    }
+    const result = await exchangeSupabaseCode(
+      clientId,
+      clientSecret,
+      code,
+      redirectUri,
+      state,
+    );
+    return {
+      accessToken: result.accessToken,
+      refreshToken: result.refreshToken,
+      expiresIn: result.expiresIn,
+      scopes: result.scopes,
+      userInfo: {
+        id: result.userInfo.id,
+        username: result.userInfo.username,
+        email: result.userInfo.email,
+      },
+    };
+  },
   getClientId: (e) => {
     return e.SUPABASE_OAUTH_CLIENT_ID;
   },
@@ -49,5 +57,8 @@ export const supabaseHandler: OAuthConnectorProvider = {
   getRefreshSecretName: () => {
     return "SUPABASE_REFRESH_TOKEN";
   },
-  refreshToken: adaptClientCredentialTokenRefresh(refreshSupabaseToken),
+  refreshToken: (args) => {
+    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    return refreshSupabaseToken(clientId, clientSecret, args.refreshToken);
+  },
 };

--- a/turbo/packages/connectors/src/oauth-providers/providers/test-oauth-handler.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/test-oauth-handler.ts
@@ -1,7 +1,6 @@
 import {
-  adaptClientCredentialCodeExchange,
-  adaptClientCredentialTokenRefresh,
-  adaptClientIdAuthUrl,
+  requireOAuthClientCredentials,
+  requireOAuthClientId,
   type OAuthConnectorProvider,
 } from "../provider-types";
 import {
@@ -15,25 +14,33 @@ import {
   TEST_OAUTH_REFRESH_SECRET_NAME,
 } from "./test-oauth";
 export const testOauthHandler: OAuthConnectorProvider = {
-  buildAuthUrl: adaptClientIdAuthUrl(buildTestOAuthAuthorizationUrl),
-  exchangeCode: adaptClientCredentialCodeExchange(
-    async (clientId, clientSecret, code, redirectUri) => {
-      const token = await exchangeTestOAuthCode(
-        clientId,
-        clientSecret,
-        code,
-        redirectUri,
-      );
-      const user = await fetchTestOAuthUserInfo(token.accessToken);
-      return {
-        accessToken: token.accessToken,
-        refreshToken: token.refreshToken,
-        expiresIn: token.expiresIn,
-        scopes: token.scopes,
-        userInfo: user,
-      };
-    },
-  ),
+  buildAuthUrl: (args) => {
+    const clientId = requireOAuthClientId(args);
+    return buildTestOAuthAuthorizationUrl(
+      clientId,
+      args.redirectUri,
+      args.state,
+    );
+  },
+  exchangeCode: async (args) => {
+    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const code = args.code;
+    const redirectUri = args.redirectUri;
+    const token = await exchangeTestOAuthCode(
+      clientId,
+      clientSecret,
+      code,
+      redirectUri,
+    );
+    const user = await fetchTestOAuthUserInfo(token.accessToken);
+    return {
+      accessToken: token.accessToken,
+      refreshToken: token.refreshToken,
+      expiresIn: token.expiresIn,
+      scopes: token.scopes,
+      userInfo: user,
+    };
+  },
   getClientId: () => {
     return TEST_OAUTH_CLIENT_ID;
   },
@@ -46,18 +53,18 @@ export const testOauthHandler: OAuthConnectorProvider = {
   getRefreshSecretName: () => {
     return TEST_OAUTH_REFRESH_SECRET_NAME;
   },
-  refreshToken: adaptClientCredentialTokenRefresh(
-    async (clientId, clientSecret, refreshToken) => {
-      const result = await refreshTestOAuthToken(
-        clientId,
-        clientSecret,
-        refreshToken,
-      );
-      return {
-        accessToken: result.accessToken,
-        refreshToken: result.refreshToken,
-        expiresIn: result.expiresIn,
-      };
-    },
-  ),
+  refreshToken: async (args) => {
+    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const refreshToken = args.refreshToken;
+    const result = await refreshTestOAuthToken(
+      clientId,
+      clientSecret,
+      refreshToken,
+    );
+    return {
+      accessToken: result.accessToken,
+      refreshToken: result.refreshToken,
+      expiresIn: result.expiresIn,
+    };
+  },
 };

--- a/turbo/packages/connectors/src/oauth-providers/providers/todoist-handler.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/todoist-handler.ts
@@ -1,6 +1,6 @@
 import {
-  adaptClientCredentialCodeExchange,
-  adaptClientIdAuthUrl,
+  requireOAuthClientCredentials,
+  requireOAuthClientId,
   type OAuthConnectorProvider,
 } from "../provider-types";
 import {
@@ -9,27 +9,31 @@ import {
   getTodoistSecretName,
 } from "./todoist";
 export const todoistHandler: OAuthConnectorProvider = {
-  buildAuthUrl: adaptClientIdAuthUrl(buildTodoistAuthorizationUrl),
-  exchangeCode: adaptClientCredentialCodeExchange(
-    async (clientId, clientSecret, code, redirectUri) => {
-      const result = await exchangeTodoistCode(
-        clientId,
-        clientSecret,
-        code,
-        redirectUri,
-      );
-      return {
-        accessToken: result.accessToken,
-        refreshToken: null,
-        scopes: result.scopes,
-        userInfo: {
-          id: result.userInfo.id,
-          username: result.userInfo.username,
-          email: result.userInfo.email,
-        },
-      };
-    },
-  ),
+  buildAuthUrl: (args) => {
+    const clientId = requireOAuthClientId(args);
+    return buildTodoistAuthorizationUrl(clientId, args.redirectUri, args.state);
+  },
+  exchangeCode: async (args) => {
+    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const code = args.code;
+    const redirectUri = args.redirectUri;
+    const result = await exchangeTodoistCode(
+      clientId,
+      clientSecret,
+      code,
+      redirectUri,
+    );
+    return {
+      accessToken: result.accessToken,
+      refreshToken: null,
+      scopes: result.scopes,
+      userInfo: {
+        id: result.userInfo.id,
+        username: result.userInfo.username,
+        email: result.userInfo.email,
+      },
+    };
+  },
   getClientId: (e) => {
     return e.TODOIST_OAUTH_CLIENT_ID;
   },

--- a/turbo/packages/connectors/src/oauth-providers/providers/vercel-handler.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/vercel-handler.ts
@@ -1,6 +1,6 @@
 import {
-  adaptClientCredentialCodeExchange,
-  adaptClientIdAuthUrl,
+  requireOAuthClientCredentials,
+  requireOAuthClientId,
   type OAuthConnectorProvider,
 } from "../provider-types";
 import {
@@ -9,26 +9,30 @@ import {
   getVercelSecretName,
 } from "./vercel";
 export const vercelHandler: OAuthConnectorProvider = {
-  buildAuthUrl: adaptClientIdAuthUrl(buildVercelAuthorizationUrl),
-  exchangeCode: adaptClientCredentialCodeExchange(
-    async (clientId, clientSecret, code, redirectUri) => {
-      const result = await exchangeVercelCode(
-        clientId,
-        clientSecret,
-        code,
-        redirectUri,
-      );
-      return {
-        accessToken: result.accessToken,
-        scopes: [],
-        userInfo: {
-          id: result.userInfo.id,
-          username: result.userInfo.username,
-          email: result.userInfo.email,
-        },
-      };
-    },
-  ),
+  buildAuthUrl: (args) => {
+    const clientId = requireOAuthClientId(args);
+    return buildVercelAuthorizationUrl(clientId, args.redirectUri, args.state);
+  },
+  exchangeCode: async (args) => {
+    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const code = args.code;
+    const redirectUri = args.redirectUri;
+    const result = await exchangeVercelCode(
+      clientId,
+      clientSecret,
+      code,
+      redirectUri,
+    );
+    return {
+      accessToken: result.accessToken,
+      scopes: [],
+      userInfo: {
+        id: result.userInfo.id,
+        username: result.userInfo.username,
+        email: result.userInfo.email,
+      },
+    };
+  },
   getClientId: (e) => {
     return e.VERCEL_OAUTH_CLIENT_ID;
   },

--- a/turbo/packages/connectors/src/oauth-providers/providers/webflow-handler.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/webflow-handler.ts
@@ -1,6 +1,6 @@
 import {
-  adaptClientCredentialCodeExchange,
-  adaptClientIdAuthUrl,
+  requireOAuthClientCredentials,
+  requireOAuthClientId,
   type OAuthConnectorProvider,
 } from "../provider-types";
 import {
@@ -9,27 +9,31 @@ import {
   getWebflowSecretName,
 } from "./webflow";
 export const webflowHandler: OAuthConnectorProvider = {
-  buildAuthUrl: adaptClientIdAuthUrl(buildWebflowAuthorizationUrl),
-  exchangeCode: adaptClientCredentialCodeExchange(
-    async (clientId, clientSecret, code, redirectUri) => {
-      const result = await exchangeWebflowCode(
-        clientId,
-        clientSecret,
-        code,
-        redirectUri,
-      );
-      return {
-        accessToken: result.accessToken,
-        refreshToken: null,
-        scopes: result.scopes,
-        userInfo: {
-          id: result.userInfo.id,
-          username: result.userInfo.username,
-          email: result.userInfo.email,
-        },
-      };
-    },
-  ),
+  buildAuthUrl: (args) => {
+    const clientId = requireOAuthClientId(args);
+    return buildWebflowAuthorizationUrl(clientId, args.redirectUri, args.state);
+  },
+  exchangeCode: async (args) => {
+    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const code = args.code;
+    const redirectUri = args.redirectUri;
+    const result = await exchangeWebflowCode(
+      clientId,
+      clientSecret,
+      code,
+      redirectUri,
+    );
+    return {
+      accessToken: result.accessToken,
+      refreshToken: null,
+      scopes: result.scopes,
+      userInfo: {
+        id: result.userInfo.id,
+        username: result.userInfo.username,
+        email: result.userInfo.email,
+      },
+    };
+  },
   getClientId: (e) => {
     return e.WEBFLOW_OAUTH_CLIENT_ID;
   },

--- a/turbo/packages/connectors/src/oauth-providers/providers/x-handler.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/x-handler.ts
@@ -1,7 +1,6 @@
 import {
-  adaptClientCredentialCodeExchange,
-  adaptClientCredentialTokenRefresh,
-  adaptClientIdAuthUrl,
+  requireOAuthClientCredentials,
+  requireOAuthClientId,
   type OAuthConnectorProvider,
 } from "../provider-types";
 import {
@@ -11,32 +10,37 @@ import {
   refreshXToken,
 } from "./x";
 export const xHandler: OAuthConnectorProvider = {
-  buildAuthUrl: adaptClientIdAuthUrl(buildXAuthorizationUrl),
-  exchangeCode: adaptClientCredentialCodeExchange(
-    async (clientId, clientSecret, code, redirectUri, state) => {
-      if (!state) {
-        throw new Error("X PKCE requires state for code_verifier derivation");
-      }
-      const result = await exchangeXCode(
-        clientId,
-        clientSecret,
-        code,
-        redirectUri,
-        state,
-      );
-      return {
-        accessToken: result.accessToken,
-        refreshToken: result.refreshToken,
-        expiresIn: result.expiresIn,
-        scopes: result.scopes,
-        userInfo: {
-          id: result.userInfo.id,
-          username: result.userInfo.username,
-          email: result.userInfo.email,
-        },
-      };
-    },
-  ),
+  buildAuthUrl: (args) => {
+    const clientId = requireOAuthClientId(args);
+    return buildXAuthorizationUrl(clientId, args.redirectUri, args.state);
+  },
+  exchangeCode: async (args) => {
+    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const code = args.code;
+    const redirectUri = args.redirectUri;
+    const state = args.state;
+    if (!state) {
+      throw new Error("X PKCE requires state for code_verifier derivation");
+    }
+    const result = await exchangeXCode(
+      clientId,
+      clientSecret,
+      code,
+      redirectUri,
+      state,
+    );
+    return {
+      accessToken: result.accessToken,
+      refreshToken: result.refreshToken,
+      expiresIn: result.expiresIn,
+      scopes: result.scopes,
+      userInfo: {
+        id: result.userInfo.id,
+        username: result.userInfo.username,
+        email: result.userInfo.email,
+      },
+    };
+  },
   getClientId: (e) => {
     return e.X_OAUTH_CLIENT_ID;
   },
@@ -47,5 +51,8 @@ export const xHandler: OAuthConnectorProvider = {
   getRefreshSecretName: () => {
     return "X_REFRESH_TOKEN";
   },
-  refreshToken: adaptClientCredentialTokenRefresh(refreshXToken),
+  refreshToken: (args) => {
+    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    return refreshXToken(clientId, clientSecret, args.refreshToken);
+  },
 };

--- a/turbo/packages/connectors/src/oauth-providers/providers/xero-handler.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/xero-handler.ts
@@ -1,7 +1,6 @@
 import {
-  adaptClientCredentialCodeExchange,
-  adaptClientCredentialTokenRefresh,
-  adaptClientIdAuthUrl,
+  requireOAuthClientCredentials,
+  requireOAuthClientId,
   type OAuthConnectorProvider,
 } from "../provider-types";
 import {
@@ -11,28 +10,32 @@ import {
   refreshXeroToken,
 } from "./xero";
 export const xeroHandler: OAuthConnectorProvider = {
-  buildAuthUrl: adaptClientIdAuthUrl(buildXeroAuthorizationUrl),
-  exchangeCode: adaptClientCredentialCodeExchange(
-    async (clientId, clientSecret, code, redirectUri) => {
-      const result = await exchangeXeroCode(
-        clientId,
-        clientSecret,
-        code,
-        redirectUri,
-      );
-      return {
-        accessToken: result.accessToken,
-        refreshToken: result.refreshToken,
-        expiresIn: result.expiresIn,
-        scopes: result.scopes,
-        userInfo: {
-          id: result.userInfo.id,
-          username: result.userInfo.username,
-          email: result.userInfo.email,
-        },
-      };
-    },
-  ),
+  buildAuthUrl: (args) => {
+    const clientId = requireOAuthClientId(args);
+    return buildXeroAuthorizationUrl(clientId, args.redirectUri, args.state);
+  },
+  exchangeCode: async (args) => {
+    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const code = args.code;
+    const redirectUri = args.redirectUri;
+    const result = await exchangeXeroCode(
+      clientId,
+      clientSecret,
+      code,
+      redirectUri,
+    );
+    return {
+      accessToken: result.accessToken,
+      refreshToken: result.refreshToken,
+      expiresIn: result.expiresIn,
+      scopes: result.scopes,
+      userInfo: {
+        id: result.userInfo.id,
+        username: result.userInfo.username,
+        email: result.userInfo.email,
+      },
+    };
+  },
   getClientId: (e) => {
     return e.XERO_OAUTH_CLIENT_ID;
   },
@@ -43,5 +46,8 @@ export const xeroHandler: OAuthConnectorProvider = {
   getRefreshSecretName: () => {
     return "XERO_REFRESH_TOKEN";
   },
-  refreshToken: adaptClientCredentialTokenRefresh(refreshXeroToken),
+  refreshToken: (args) => {
+    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    return refreshXeroToken(clientId, clientSecret, args.refreshToken);
+  },
 };

--- a/turbo/packages/connectors/src/oauth-providers/providers/zoom-handler.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/zoom-handler.ts
@@ -1,7 +1,6 @@
 import {
-  adaptClientCredentialCodeExchange,
-  adaptClientCredentialTokenRefresh,
-  adaptClientIdAuthUrl,
+  requireOAuthClientCredentials,
+  requireOAuthClientId,
   type OAuthConnectorProvider,
 } from "../provider-types";
 import {
@@ -11,28 +10,32 @@ import {
   refreshZoomToken,
 } from "./zoom";
 export const zoomHandler: OAuthConnectorProvider = {
-  buildAuthUrl: adaptClientIdAuthUrl(buildZoomAuthorizationUrl),
-  exchangeCode: adaptClientCredentialCodeExchange(
-    async (clientId, clientSecret, code, redirectUri) => {
-      const result = await exchangeZoomCode(
-        clientId,
-        clientSecret,
-        code,
-        redirectUri,
-      );
-      return {
-        accessToken: result.accessToken,
-        refreshToken: result.refreshToken,
-        expiresIn: result.expiresIn,
-        scopes: result.scopes,
-        userInfo: {
-          id: result.userInfo.id,
-          username: result.userInfo.username,
-          email: result.userInfo.email,
-        },
-      };
-    },
-  ),
+  buildAuthUrl: (args) => {
+    const clientId = requireOAuthClientId(args);
+    return buildZoomAuthorizationUrl(clientId, args.redirectUri, args.state);
+  },
+  exchangeCode: async (args) => {
+    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    const code = args.code;
+    const redirectUri = args.redirectUri;
+    const result = await exchangeZoomCode(
+      clientId,
+      clientSecret,
+      code,
+      redirectUri,
+    );
+    return {
+      accessToken: result.accessToken,
+      refreshToken: result.refreshToken,
+      expiresIn: result.expiresIn,
+      scopes: result.scopes,
+      userInfo: {
+        id: result.userInfo.id,
+        username: result.userInfo.username,
+        email: result.userInfo.email,
+      },
+    };
+  },
   getClientId: (e) => {
     return e.ZOOM_OAUTH_CLIENT_ID;
   },
@@ -43,5 +46,8 @@ export const zoomHandler: OAuthConnectorProvider = {
   getRefreshSecretName: () => {
     return "ZOOM_REFRESH_TOKEN";
   },
-  refreshToken: adaptClientCredentialTokenRefresh(refreshZoomToken),
+  refreshToken: (args) => {
+    const { clientId, clientSecret } = requireOAuthClientCredentials(args);
+    return refreshZoomToken(clientId, clientSecret, args.refreshToken);
+  },
 };


### PR DESCRIPTION
## Summary
- remove OAuth provider adapter helpers from provider-types
- inline provider credential validation in OAuth provider handlers
- keep existing OAuth authorize, exchange, refresh, and revoke behavior unchanged

## Tests
- pnpm -F @vm0/connectors check-types
- pnpm -F @vm0/connectors lint
- pnpm -F @vm0/connectors test -- src/__tests__/connectors.test.ts
- pnpm -F api check-types
- pnpm -F web check-types
- git diff --check
- pre-commit hook: turbo run check-types --concurrency=1