### PR TITLE
fix: avoid stale firewall auth cache writes

### DIFF
--- a/crates/runner/mitm-addon/src/auth.py
+++ b/crates/runner/mitm-addon/src/auth.py
@@ -485,8 +485,8 @@ async def get_firewall_headers(
         # A 401 can request a forced refresh while this non-forced fetch is
         # in flight. Return the current result to this request, but do not let
         # it repopulate shared cache ahead of the pending forced refresh.
-        should_cache = force_refresh or not state.force_refresh_pending
-        if should_cache:
+        marker_appeared_during_non_forced_fetch = not force_refresh and state.force_refresh_pending
+        if not marker_appeared_during_non_forced_fetch:
             state.cache = cache_entry
 
         ret: dict = {

--- a/crates/runner/mitm-addon/src/auth.py
+++ b/crates/runner/mitm-addon/src/auth.py
@@ -481,7 +481,14 @@ async def get_firewall_headers(
             cache_entry.base = result["base"]
         if result.get("query"):
             cache_entry.query = result["query"]
-        state.cache = cache_entry
+
+        # A 401 can request a forced refresh while this non-forced fetch is
+        # in flight. Return the current result to this request, but do not let
+        # it repopulate shared cache ahead of the pending forced refresh.
+        should_cache = force_refresh or not state.force_refresh_pending
+        if should_cache:
+            state.cache = cache_entry
+
         ret: dict = {
             "headers": headers,
             "resolved_secrets": resolved_secrets,

--- a/crates/runner/mitm-addon/tests/test_connectors.py
+++ b/crates/runner/mitm-addon/tests/test_connectors.py
@@ -1631,6 +1631,54 @@ class TestGetFirewallHeaders:
         assert last_force_refresh_at(cache_key) >= before_forced
         assert cached_headers(cache_key).headers == forced_headers
 
+    async def test_waiting_request_force_refreshes_after_in_flight_marker(self, headers):
+        """A same-key waiter must not reuse headers from the stale-prone leader fetch."""
+        cache_key = ("run-1", "api-1")
+        first_fetch_entered = asyncio.Event()
+        allow_first_fetch_return = asyncio.Event()
+        force_refresh_values = []
+
+        async def fetch_with_blocked_leader(*args, force_refresh=False):
+            force_refresh_values.append(force_refresh)
+            if not force_refresh:
+                first_fetch_entered.set()
+                await allow_first_fetch_return.wait()
+                return {
+                    "headers": {"Authorization": "Bearer maybe-stale"},
+                    "expiresAt": time.time() + 3600,
+                }
+            return {
+                "headers": {"Authorization": "Bearer refreshed"},
+                "expiresAt": time.time() + 3600,
+            }
+
+        with patch.object(auth, "fetch_firewall_headers", side_effect=fetch_with_blocked_leader):
+            leader = asyncio.create_task(
+                auth.get_firewall_headers("run-1", "api-1", "iv:tag:data", {}, "tok-xyz")
+            )
+            waiter = None
+            try:
+                await asyncio.wait_for(first_fetch_entered.wait(), timeout=5)
+                waiter = asyncio.create_task(
+                    auth.get_firewall_headers("run-1", "api-1", "iv:tag:data", {}, "tok-xyz")
+                )
+                auth.request_force_refresh(cache_key)
+                allow_first_fetch_return.set()
+                leader_result, waiter_result = await asyncio.gather(leader, waiter)
+            finally:
+                allow_first_fetch_return.set()
+                for task in (leader, waiter):
+                    if task is not None and not task.done():
+                        task.cancel()
+                        with suppress(asyncio.CancelledError):
+                            await task
+
+        assert force_refresh_values == [False, True]
+        assert leader_result["headers"] == {"Authorization": "Bearer maybe-stale"}
+        assert waiter_result["headers"] == {"Authorization": "Bearer refreshed"}
+        assert cached_headers(cache_key).headers == {"Authorization": "Bearer refreshed"}
+        assert not force_refresh_pending(cache_key)
+
     async def test_force_refresh_absent_passes_false(self, headers):
         """Without a marker, fetch is called with force_refresh=False (#9860)."""
         mock_fetch = AsyncMock(return_value={"headers": {}})

--- a/crates/runner/mitm-addon/tests/test_connectors.py
+++ b/crates/runner/mitm-addon/tests/test_connectors.py
@@ -1571,6 +1571,58 @@ class TestGetFirewallHeaders:
         assert last_force_refresh_at(cache_key) >= before
         assert cached_headers(cache_key) is None
 
+    async def test_non_forced_fetch_does_not_cache_if_marker_appears_in_flight(self, headers):
+        """A 401 marker during a non-forced fetch must win over the cache write."""
+        cache_key = ("run-1", "api-1")
+        fetch_entered = asyncio.Event()
+        allow_fetch_return = asyncio.Event()
+        first_force_refresh_values = []
+
+        async def delayed_fetch(*args, force_refresh=False):
+            first_force_refresh_values.append(force_refresh)
+            fetch_entered.set()
+            await allow_fetch_return.wait()
+            return {
+                "headers": {"Authorization": "Bearer maybe-stale"},
+                "expiresAt": time.time() + 3600,
+            }
+
+        with patch.object(auth, "fetch_firewall_headers", side_effect=delayed_fetch):
+            task = asyncio.create_task(
+                auth.get_firewall_headers("run-1", "api-1", "iv:tag:data", {}, "tok-xyz")
+            )
+            await fetch_entered.wait()
+            auth.request_force_refresh(cache_key)
+            allow_fetch_return.set()
+            result = await task
+
+        assert first_force_refresh_values == [False]
+        assert result["headers"] == {"Authorization": "Bearer maybe-stale"}
+        assert result["cache_hit"] is False
+        assert cached_headers(cache_key) is None
+        assert force_refresh_pending(cache_key)
+
+        forced_headers = {"Authorization": "Bearer refreshed"}
+        forced_fetch = AsyncMock(
+            return_value={
+                "headers": forced_headers,
+                "expiresAt": time.time() + 3600,
+            }
+        )
+        before_forced = time.time()
+
+        with patch.object(auth, "fetch_firewall_headers", forced_fetch):
+            forced_result = await auth.get_firewall_headers(
+                "run-1", "api-1", "iv:tag:data", {}, "tok-xyz"
+            )
+
+        assert forced_fetch.call_args.kwargs["force_refresh"] is True
+        assert forced_result["headers"] == forced_headers
+        assert forced_result["cache_hit"] is False
+        assert not force_refresh_pending(cache_key)
+        assert last_force_refresh_at(cache_key) >= before_forced
+        assert cached_headers(cache_key).headers == forced_headers
+
     async def test_force_refresh_absent_passes_false(self, headers):
         """Without a marker, fetch is called with force_refresh=False (#9860)."""
         mock_fetch = AsyncMock(return_value={"headers": {}})

--- a/crates/runner/mitm-addon/tests/test_connectors.py
+++ b/crates/runner/mitm-addon/tests/test_connectors.py
@@ -5,6 +5,7 @@ import io
 import json
 import time
 import urllib.error
+from contextlib import suppress
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 from urllib.parse import urlparse
@@ -1591,10 +1592,17 @@ class TestGetFirewallHeaders:
             task = asyncio.create_task(
                 auth.get_firewall_headers("run-1", "api-1", "iv:tag:data", {}, "tok-xyz")
             )
-            await fetch_entered.wait()
-            auth.request_force_refresh(cache_key)
-            allow_fetch_return.set()
-            result = await task
+            try:
+                await asyncio.wait_for(fetch_entered.wait(), timeout=5)
+                auth.request_force_refresh(cache_key)
+                allow_fetch_return.set()
+                result = await task
+            finally:
+                allow_fetch_return.set()
+                if not task.done():
+                    task.cancel()
+                    with suppress(asyncio.CancelledError):
+                        await task
 
         assert first_force_refresh_values == [False]
         assert result["headers"] == {"Authorization": "Bearer maybe-stale"}

--- a/crates/runner/mitm-addon/tests/test_connectors.py
+++ b/crates/runner/mitm-addon/tests/test_connectors.py
@@ -5,7 +5,6 @@ import io
 import json
 import time
 import urllib.error
-from contextlib import suppress
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 from urllib.parse import urlparse
@@ -51,6 +50,13 @@ def _grant_all(firewalls, unknown_policy="deny"):
             "unknownPolicy": unknown_policy,
         }
     return result
+
+
+async def _cancel_pending_task(task: asyncio.Task | None) -> None:
+    if task is None or task.done():
+        return
+    task.cancel()
+    _ = await asyncio.gather(task, return_exceptions=True)
 
 
 # =========================================================================
@@ -1599,10 +1605,7 @@ class TestGetFirewallHeaders:
                 result = await task
             finally:
                 allow_fetch_return.set()
-                if not task.done():
-                    task.cancel()
-                    with suppress(asyncio.CancelledError):
-                        await task
+                await _cancel_pending_task(task)
 
         assert first_force_refresh_values == [False]
         assert result["headers"] == {"Authorization": "Bearer maybe-stale"}
@@ -1668,10 +1671,7 @@ class TestGetFirewallHeaders:
             finally:
                 allow_first_fetch_return.set()
                 for task in (leader, waiter):
-                    if task is not None and not task.done():
-                        task.cancel()
-                        with suppress(asyncio.CancelledError):
-                            await task
+                    await _cancel_pending_task(task)
 
         assert force_refresh_values == [False, True]
         assert leader_result["headers"] == {"Authorization": "Bearer maybe-stale"}


### PR DESCRIPTION
## Summary

Fixes #14310.

- Skip caching non-forced firewall auth fetch results when a 401 force-refresh marker appears while the fetch is in flight.
- Preserve the pending marker so the next real cache miss consumes it with `force_refresh=true`.
- Add deterministic asyncio-event coverage for the race and the follow-up forced fetch.

## Tests

- `python3 -m pytest tests/test_connectors.py::TestGetFirewallHeaders::test_non_forced_fetch_does_not_cache_if_marker_appears_in_flight -q`
- `python3 -m pytest tests/test_connectors.py::TestGetFirewallHeaders -q`
- `python3 -m pytest tests/test_connectors.py tests/test_handlers.py -q`
- `python3 -m ruff check src tests`
- `python3 -m ruff format --check .`
