### PR TITLE
feat: rename AgentPhone Works card to Phone and roll out to everyone

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-agentphone-link.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-agentphone-link.test.ts
@@ -1,10 +1,8 @@
 import { randomUUID } from "node:crypto";
 
 import { zeroIntegrationsAgentPhoneContract } from "@vm0/api-contracts/contracts/zero-integrations-agentphone";
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { agentphoneVerificationSendCooldowns } from "@vm0/db/schema/agentphone-verification-send-cooldown";
 import { agentphoneUserLinks } from "@vm0/db/schema/agentphone-user-link";
-import { userFeatureSwitches } from "@vm0/db/schema/user-feature-switches";
 import { createStore } from "ccstate";
 import { and, eq } from "drizzle-orm";
 import { http, HttpResponse } from "msw";
@@ -37,19 +35,6 @@ const trackPhone = createFixtureTracker(
   },
 );
 
-const trackSwitch = createFixtureTracker(
-  async (fixture: { readonly orgId: string; readonly userId: string }) => {
-    await writeDb
-      .delete(userFeatureSwitches)
-      .where(
-        and(
-          eq(userFeatureSwitches.orgId, fixture.orgId),
-          eq(userFeatureSwitches.userId, fixture.userId),
-        ),
-      );
-  },
-);
-
 const trackVerificationSendCooldown = createFixtureTracker(
   async (fixture: { readonly scope: string; readonly scopeKey: string }) => {
     await writeDb
@@ -72,32 +57,13 @@ function uniquePhone(): string {
   return `+1555${digits}`;
 }
 
-async function enableAgentPhoneUi(
-  orgId: string,
-  userId: string,
-): Promise<void> {
-  await writeDb
-    .insert(userFeatureSwitches)
-    .values({
-      orgId,
-      userId,
-      switches: { [FeatureSwitchKey.AgentPhoneAppUi]: true },
-    })
-    .onConflictDoUpdate({
-      target: [userFeatureSwitches.orgId, userFeatureSwitches.userId],
-      set: { switches: { [FeatureSwitchKey.AgentPhoneAppUi]: true } },
-    });
-  await trackSwitch(Promise.resolve({ orgId, userId }));
-}
-
-async function setupEnabledUser(): Promise<{
+function setupAgentPhoneUser(): {
   readonly userId: string;
   readonly orgId: string;
-}> {
+} {
   const userId = uniqueId("user");
   const orgId = uniqueId("org");
   mocks.clerk.session(userId, orgId);
-  await enableAgentPhoneUi(orgId, userId);
   mockOptionalEnv("AGENTPHONE_AGENT_ID", "agt-test-agentphone");
   mockOptionalEnv("AGENTPHONE_API_BASE_URL", "https://api.agentphone.to");
   mockOptionalEnv("AGENTPHONE_API_KEY", "agentphone-test-key");
@@ -161,27 +127,8 @@ function agentPhoneSendMessage() {
 }
 
 describe("/api/integrations/agentphone/link", () => {
-  it("hides the link API when the AgentPhone UI switch is disabled", async () => {
-    mocks.clerk.session(uniqueId("user"), uniqueId("org"));
-    const client = setupApp({ context })(zeroIntegrationsAgentPhoneContract);
-
-    const response = await accept(
-      client.getLinkStatus({
-        headers: { authorization: "Bearer clerk-session" },
-      }),
-      [403],
-    );
-
-    expect(response.body).toStrictEqual({
-      error: {
-        message: "AgentPhone app UI is not enabled",
-        code: "FORBIDDEN",
-      },
-    });
-  });
-
   it("returns the current linked phone handle", async () => {
-    const user = await setupEnabledUser();
+    const user = setupAgentPhoneUser();
     const phone = uniquePhone();
     await insertAgentPhoneUserLink({
       phoneHandle: phone,
@@ -206,7 +153,7 @@ describe("/api/integrations/agentphone/link", () => {
   });
 
   it("sends a signed verification link and does not silently link the phone", async () => {
-    const user = await setupEnabledUser();
+    const user = setupAgentPhoneUser();
     await trackAgentPhoneVerificationCooldowns({
       ...user,
       phoneHandles: ["+15555551212"],
@@ -244,7 +191,7 @@ describe("/api/integrations/agentphone/link", () => {
   });
 
   it("rate limits consecutive verification texts for the same user", async () => {
-    const user = await setupEnabledUser();
+    const user = setupAgentPhoneUser();
     const firstPhone = uniquePhone();
     const secondPhone = uniquePhone();
     await trackAgentPhoneVerificationCooldowns({
@@ -282,7 +229,7 @@ describe("/api/integrations/agentphone/link", () => {
   });
 
   it("logs provider details when verification text sending is rejected", async () => {
-    const user = await setupEnabledUser();
+    const user = setupAgentPhoneUser();
     const phone = uniquePhone();
     await trackAgentPhoneVerificationCooldowns({
       ...user,
@@ -323,7 +270,7 @@ describe("/api/integrations/agentphone/link", () => {
   });
 
   it("logs fetch failures when verification text sending fails before response", async () => {
-    const user = await setupEnabledUser();
+    const user = setupAgentPhoneUser();
     const phone = uniquePhone();
     await trackAgentPhoneVerificationCooldowns({
       ...user,
@@ -358,7 +305,7 @@ describe("/api/integrations/agentphone/link", () => {
   });
 
   it("rejects empty normalized phone input", async () => {
-    await setupEnabledUser();
+    setupAgentPhoneUser();
     const client = setupApp({ context })(zeroIntegrationsAgentPhoneContract);
 
     const response = await accept(
@@ -375,7 +322,7 @@ describe("/api/integrations/agentphone/link", () => {
   });
 
   it("rejects phone input without an explicit country code", async () => {
-    await setupEnabledUser();
+    setupAgentPhoneUser();
     const client = setupApp({ context })(zeroIntegrationsAgentPhoneContract);
 
     const response = await accept(
@@ -395,7 +342,7 @@ describe("/api/integrations/agentphone/link", () => {
   });
 
   it("rejects a phone handle already linked to another owner", async () => {
-    await setupEnabledUser();
+    setupAgentPhoneUser();
     const phone = uniquePhone();
     await insertAgentPhoneUserLink({
       phoneHandle: phone,
@@ -418,7 +365,7 @@ describe("/api/integrations/agentphone/link", () => {
   });
 
   it("disconnects the authenticated user's linked phone", async () => {
-    const user = await setupEnabledUser();
+    const user = setupAgentPhoneUser();
     const phone = uniquePhone();
     await insertAgentPhoneUserLink({
       phoneHandle: phone,

--- a/turbo/apps/api/src/signals/routes/zero-integrations-agentphone.ts
+++ b/turbo/apps/api/src/signals/routes/zero-integrations-agentphone.ts
@@ -1,6 +1,4 @@
 import { zeroIntegrationsAgentPhoneContract } from "@vm0/api-contracts/contracts/zero-integrations-agentphone";
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
-import { isFeatureEnabled } from "@vm0/core/feature-switch";
 import { agentphoneVerificationSendCooldowns } from "@vm0/db/schema/agentphone-verification-send-cooldown";
 import { agentphoneUserLinks } from "@vm0/db/schema/agentphone-user-link";
 import { command, computed } from "ccstate";
@@ -37,7 +35,6 @@ import {
   type AgentPhoneChannel,
   type AgentPhoneMessageEvent,
 } from "../services/zero-agentphone.service";
-import { userFeatureSwitchOverrides } from "../services/feature-switches.service";
 import { safeJsonParse, settle, tapError } from "../utils";
 
 interface AgentPhoneConfig {
@@ -76,18 +73,6 @@ type VerificationSendCooldownScope = "phone" | "user_org";
 interface VerificationSendCooldownKey {
   readonly scope: VerificationSendCooldownScope;
   readonly scopeKey: string;
-}
-
-function forbidden() {
-  return {
-    status: 403 as const,
-    body: {
-      error: {
-        message: "AgentPhone app UI is not enabled",
-        code: "FORBIDDEN",
-      },
-    },
-  };
 }
 
 function notConfigured() {
@@ -228,29 +213,8 @@ async function sendAgentPhoneVerificationMessage(params: {
 // platform connect page can verify either origin's signature.
 const APPS_API_CONNECT_CHANNEL: AgentPhoneChannel = "sms";
 
-const requireAgentPhoneUi$ = computed(async (get) => {
-  const auth = get(organizationAuthContext$);
-  const overrides = await get(
-    userFeatureSwitchOverrides(auth.orgId, auth.userId),
-  );
-  const enabled = isFeatureEnabled(FeatureSwitchKey.AgentPhoneAppUi, {
-    orgId: auth.orgId,
-    userId: auth.userId,
-    overrides,
-  });
-
-  if (!enabled) {
-    return { ok: false as const, response: forbidden() };
-  }
-
-  return { ok: true as const, auth };
-});
-
 const getLinkStatus$ = computed(async (get) => {
-  const gate = await get(requireAgentPhoneUi$);
-  if (!gate.ok) {
-    return gate.response;
-  }
+  const auth = get(organizationAuthContext$);
 
   const config = getAgentPhoneConfig();
   const [link] = await get(db$)
@@ -258,8 +222,8 @@ const getLinkStatus$ = computed(async (get) => {
     .from(agentphoneUserLinks)
     .where(
       and(
-        eq(agentphoneUserLinks.vm0UserId, gate.auth.userId),
-        eq(agentphoneUserLinks.orgId, gate.auth.orgId),
+        eq(agentphoneUserLinks.vm0UserId, auth.userId),
+        eq(agentphoneUserLinks.orgId, auth.orgId),
       ),
     )
     .limit(1);
@@ -376,11 +340,7 @@ const sendAgentPhoneVerificationText$ = command(
 );
 
 const startLink$ = command(async ({ get, set }, signal: AbortSignal) => {
-  const gate = await get(requireAgentPhoneUi$);
-  signal.throwIfAborted();
-  if (!gate.ok) {
-    return gate.response;
-  }
+  const auth = get(organizationAuthContext$);
 
   const bodyResult = await get(startLinkBody$);
   signal.throwIfAborted();
@@ -411,8 +371,8 @@ const startLink$ = command(async ({ get, set }, signal: AbortSignal) => {
     .from(agentphoneUserLinks)
     .where(
       and(
-        eq(agentphoneUserLinks.vm0UserId, gate.auth.userId),
-        eq(agentphoneUserLinks.orgId, gate.auth.orgId),
+        eq(agentphoneUserLinks.vm0UserId, auth.userId),
+        eq(agentphoneUserLinks.orgId, auth.orgId),
       ),
     )
     .limit(1);
@@ -445,8 +405,8 @@ const startLink$ = command(async ({ get, set }, signal: AbortSignal) => {
   });
 
   const cooldownKeys = agentPhoneCooldownKeys({
-    orgId: gate.auth.orgId,
-    userId: gate.auth.userId,
+    orgId: auth.orgId,
+    userId: auth.userId,
     phoneHandle,
   });
   const sendResult = await set(
@@ -476,18 +436,14 @@ const startLink$ = command(async ({ get, set }, signal: AbortSignal) => {
 });
 
 const unlink$ = command(async ({ get, set }, signal: AbortSignal) => {
-  const gate = await get(requireAgentPhoneUi$);
-  signal.throwIfAborted();
-  if (!gate.ok) {
-    return gate.response;
-  }
+  const auth = get(organizationAuthContext$);
 
   const deleted = await set(writeDb$)
     .delete(agentphoneUserLinks)
     .where(
       and(
-        eq(agentphoneUserLinks.vm0UserId, gate.auth.userId),
-        eq(agentphoneUserLinks.orgId, gate.auth.orgId),
+        eq(agentphoneUserLinks.vm0UserId, auth.userId),
+        eq(agentphoneUserLinks.orgId, auth.orgId),
       ),
     )
     .returning({ id: agentphoneUserLinks.id });

--- a/turbo/apps/platform/src/views/works-page/__tests__/works-page.test.tsx
+++ b/turbo/apps/platform/src/views/works-page/__tests__/works-page.test.tsx
@@ -40,6 +40,16 @@ function renderWorksPage() {
   detachedSetupPage({ context, path: "/works" });
 }
 
+// The /works page renders multiple integration cards that each have a
+// "Connect" button, so card-level assertions must be scoped to the Slack card.
+function getSlackCard(): HTMLElement {
+  const card = screen.getByText("Slack").closest(".zero-card");
+  if (!(card instanceof HTMLElement)) {
+    throw new Error("Slack card not found");
+  }
+  return card;
+}
+
 describe("zero works page - header", () => {
   it("should render page title with agent name", async () => {
     mockSlackAPI();
@@ -135,7 +145,9 @@ describe("zero works page - slack card connected state", () => {
     });
 
     expect(screen.queryByText("Install to Slack")).not.toBeInTheDocument();
-    expect(screen.queryByText("Connect")).not.toBeInTheDocument();
+    expect(
+      within(getSlackCard()).queryByText("Connect"),
+    ).not.toBeInTheDocument();
   });
 
   it("should show default description when installed", async () => {
@@ -200,7 +212,7 @@ describe("zero works page - slack installed but not connected", () => {
     await renderWorksPage();
 
     await waitFor(() => {
-      expect(screen.getByText("Connect")).toBeInTheDocument();
+      expect(within(getSlackCard()).getByText("Connect")).toBeInTheDocument();
     });
   });
 
@@ -209,7 +221,7 @@ describe("zero works page - slack installed but not connected", () => {
     await renderWorksPage();
 
     await waitFor(() => {
-      expect(screen.getByText("Connect")).toBeInTheDocument();
+      expect(within(getSlackCard()).getByText("Connect")).toBeInTheDocument();
     });
 
     expect(screen.queryByText("Connected")).not.toBeInTheDocument();
@@ -330,7 +342,7 @@ describe("zero works page - admin vs non-admin permissions", () => {
     await renderWorksPage();
 
     await waitFor(() => {
-      expect(screen.getByText("Connect")).toBeInTheDocument();
+      expect(within(getSlackCard()).getByText("Connect")).toBeInTheDocument();
     });
 
     expect(screen.queryByLabelText("More options")).not.toBeInTheDocument();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-works-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-works-page.test.tsx
@@ -22,7 +22,6 @@ import {
   zeroIntegrationsSlackContract,
   type SlackOrgStatus,
 } from "@vm0/api-contracts/contracts/zero-integrations-slack";
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { createMockApi } from "../../../mocks/msw-contract.ts";
 import { pathname$ } from "../../../signals/route.ts";
 import { setMockAgentPhoneIntegration } from "../../../mocks/handlers/api-integrations-agentphone.ts";
@@ -136,22 +135,8 @@ describe("works page - telegram integration card", () => {
   });
 });
 
-describe("works page - AgentPhone integration card", () => {
-  it("hides AgentPhone when the feature switch is off", async () => {
-    mockSlackAPI({ isConnected: true, isInstalled: true, isAdmin: true });
-    detachedSetupPage({
-      context,
-      path: "/works",
-      featureSwitches: { [FeatureSwitchKey.AgentPhoneAppUi]: false },
-    });
-
-    await waitFor(() => {
-      expect(screen.getByText("Telegram")).toBeInTheDocument();
-      expect(screen.queryByText("AgentPhone")).not.toBeInTheDocument();
-    });
-  });
-
-  it("shows AgentPhone connection status on the list page", async () => {
+describe("works page - Phone integration card", () => {
+  it("shows Phone connection status on the list page", async () => {
     mockSlackAPI({ isConnected: true, isInstalled: true, isAdmin: true });
     setMockAgentPhoneIntegration({
       linked: true,
@@ -159,44 +144,36 @@ describe("works page - AgentPhone integration card", () => {
       agentPhoneNumber: "+19039853128",
       configured: true,
     });
-    detachedSetupPage({
-      context,
-      path: "/works",
-      featureSwitches: { [FeatureSwitchKey.AgentPhoneAppUi]: true },
-    });
+    detachedSetupPage({ context, path: "/works" });
 
     await waitFor(() => {
-      expect(screen.getByText("AgentPhone")).toBeInTheDocument();
-      expect(screen.getByText("Text Zero at +19039853128")).toBeInTheDocument();
-      expect(screen.queryByText(/Connected as/i)).not.toBeInTheDocument();
+      expect(screen.getByText("Phone")).toBeInTheDocument();
+      expect(screen.getByText("iMessage or SMS to")).toBeInTheDocument();
+      expect(screen.getByText("+1 (903) 985-3128")).toBeInTheDocument();
       expect(
         screen.getByTestId("agentphone-connected-indicator"),
       ).toBeInTheDocument();
       expect(
         screen.getByTestId("agentphone-connected-indicator"),
-      ).toHaveTextContent("Connected (+15555551212)");
-      expect(screen.getByLabelText("AgentPhone options")).toBeInTheDocument();
+      ).toHaveTextContent("+15555551212");
+      expect(screen.getByLabelText("Phone options")).toBeInTheDocument();
     });
   });
 
-  it("starts verification from the list page and refreshes when AgentPhone connects", async () => {
+  it("starts verification from the list page and refreshes when the phone connects", async () => {
     mockSlackAPI({ isConnected: true, isInstalled: true, isAdmin: true });
     setMockAgentPhoneIntegration({
       linked: false,
       agentPhoneNumber: "+19039853128",
       configured: true,
     });
-    detachedSetupPage({
-      context,
-      path: "/works",
-      featureSwitches: { [FeatureSwitchKey.AgentPhoneAppUi]: true },
-    });
+    detachedSetupPage({ context, path: "/works" });
 
     await waitFor(() => {
-      expect(screen.getByLabelText("Connect AgentPhone")).toBeInTheDocument();
+      expect(screen.getByLabelText("Connect phone")).toBeInTheDocument();
     });
 
-    click(screen.getByLabelText("Connect AgentPhone"));
+    click(screen.getByLabelText("Connect phone"));
     const input = await screen.findByTestId("agentphone-phone-input");
     expect(
       screen.getByText(/SMS and MMS replies may not be delivered reliably/u),
@@ -232,7 +209,7 @@ describe("works page - AgentPhone integration card", () => {
     await waitFor(() => {
       expect(
         screen.getByTestId("agentphone-connected-indicator"),
-      ).toHaveTextContent("Connected (+15555551212)");
+      ).toHaveTextContent("+15555551212");
       expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
     });
   });
@@ -244,17 +221,13 @@ describe("works page - AgentPhone integration card", () => {
       agentPhoneNumber: "+19039853128",
       configured: true,
     });
-    detachedSetupPage({
-      context,
-      path: "/works",
-      featureSwitches: { [FeatureSwitchKey.AgentPhoneAppUi]: true },
-    });
+    detachedSetupPage({ context, path: "/works" });
 
     await waitFor(() => {
-      expect(screen.getByLabelText("Connect AgentPhone")).toBeInTheDocument();
+      expect(screen.getByLabelText("Connect phone")).toBeInTheDocument();
     });
 
-    click(screen.getByLabelText("Connect AgentPhone"));
+    click(screen.getByLabelText("Connect phone"));
     const input = await screen.findByTestId("agentphone-phone-input");
     await fill(input, "555-1212");
 
@@ -284,7 +257,7 @@ describe("works page - AgentPhone integration card", () => {
     });
   });
 
-  it("disconnects a linked AgentPhone account from the list page", async () => {
+  it("disconnects a linked phone account from the list page", async () => {
     mockSlackAPI({ isConnected: true, isInstalled: true, isAdmin: true });
     setMockAgentPhoneIntegration({
       linked: true,
@@ -292,23 +265,19 @@ describe("works page - AgentPhone integration card", () => {
       agentPhoneNumber: "+19039853128",
       configured: true,
     });
-    detachedSetupPage({
-      context,
-      path: "/works",
-      featureSwitches: { [FeatureSwitchKey.AgentPhoneAppUi]: true },
-    });
+    detachedSetupPage({ context, path: "/works" });
 
     await waitFor(() => {
       expect(
         screen.getByTestId("agentphone-connected-indicator"),
-      ).toHaveTextContent("Connected (+15555551212)");
+      ).toHaveTextContent("+15555551212");
     });
 
-    click(screen.getByLabelText("AgentPhone options"));
-    click(await screen.findByLabelText("Disconnect AgentPhone"));
+    click(screen.getByLabelText("Phone options"));
+    click(await screen.findByLabelText("Disconnect phone"));
 
     await waitFor(() => {
-      expect(screen.getByLabelText("Connect AgentPhone")).toBeInTheDocument();
+      expect(screen.getByLabelText("Connect phone")).toBeInTheDocument();
       expect(
         screen.queryByTestId("agentphone-connected-indicator"),
       ).not.toBeInTheDocument();

--- a/turbo/apps/platform/src/views/zero-page/agentphone-card.tsx
+++ b/turbo/apps/platform/src/views/zero-page/agentphone-card.tsx
@@ -8,10 +8,12 @@ import {
 import { useLoadableSet } from "ccstate-react/experimental";
 import {
   IconCircleCheck,
+  IconCopy,
   IconDotsVertical,
   IconLoader2,
 } from "@tabler/icons-react";
 import { Button } from "@vm0/ui";
+import { toast } from "@vm0/ui/components/ui/sonner";
 import {
   Popover,
   PopoverContent,
@@ -25,6 +27,12 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@vm0/ui/components/ui/dialog";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@vm0/ui/components/ui/tooltip";
 import { Input } from "@vm0/ui/components/ui/input";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import {
@@ -45,8 +53,51 @@ import {
   waitForAgentPhoneConnection$,
 } from "../../signals/zero-page/zero-agentphone.ts";
 import { AGENTPHONE_SMS_MMS_CONNECT_RISK_MESSAGE } from "../../signals/zero-page/agentphone-connect-params.ts";
+import { writeToClipboard } from "../../signals/zero-page/clipboard.ts";
 import { detach, Reason } from "../../signals/utils.ts";
 import imessageIconImg from "./components/settings/icons/imessage.svg";
+
+/** Render a US/Canada E.164 number as `+1 (NXX) NXX-XXXX`; other formats are
+ *  returned unchanged. */
+function formatAgentPhoneNumber(raw: string): string {
+  const match = /^\+1(\d{3})(\d{3})(\d{4})$/u.exec(raw);
+  if (!match) {
+    return raw;
+  }
+  return `+1 (${match[1]}) ${match[2]}-${match[3]}`;
+}
+
+function PhoneNumberCopyButton({
+  phoneNumber,
+}: {
+  readonly phoneNumber: string;
+}) {
+  const formatted = formatAgentPhoneNumber(phoneNumber);
+
+  return (
+    <button
+      type="button"
+      aria-label={`Copy ${formatted}`}
+      className="inline-flex items-center gap-1 rounded font-medium text-foreground transition-colors hover:text-foreground/70 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
+      onClick={() => {
+        detach(
+          (async () => {
+            const copied = await writeToClipboard(phoneNumber);
+            if (copied) {
+              toast.success("Phone number copied");
+            } else {
+              toast.error("Failed to copy phone number");
+            }
+          })(),
+          Reason.DomCallback,
+        );
+      }}
+    >
+      {formatted}
+      <IconCopy size={13} className="shrink-0 text-muted-foreground" />
+    </button>
+  );
+}
 
 function AgentPhoneVerificationStatus({
   verificationPhone,
@@ -177,7 +228,7 @@ function AgentPhoneConnectDialog() {
     <Dialog open={open} onOpenChange={close}>
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>Connect AgentPhone</DialogTitle>
+          <DialogTitle>Connect phone</DialogTitle>
           <DialogDescription>
             Enter your phone number. We will text a verification link that
             connects this workspace.
@@ -256,9 +307,7 @@ export function AgentPhoneCard() {
   const disconnecting = disconnectLoadable.state === "loading";
   const isConnected = status?.linked ?? false;
   const connectedPhone = status?.linked ? status.phoneHandle : null;
-  const summary = status?.agentPhoneNumber
-    ? `Text Zero at ${status.agentPhoneNumber}`
-    : "Text-message access to Zero";
+  const agentPhoneNumber = status?.agentPhoneNumber ?? null;
 
   return (
     <>
@@ -270,23 +319,37 @@ export function AgentPhoneCard() {
           <div className="flex min-w-0 flex-1 flex-col gap-1">
             <div className="flex min-w-0 items-center gap-2">
               <div className="truncate text-sm font-medium text-foreground">
-                AgentPhone
+                Phone
               </div>
             </div>
             <div className="truncate text-sm text-muted-foreground">
-              {summary}
+              {agentPhoneNumber ? (
+                <span className="inline-flex max-w-full items-center gap-1">
+                  <span className="shrink-0">iMessage or SMS to</span>
+                  <PhoneNumberCopyButton phoneNumber={agentPhoneNumber} />
+                </span>
+              ) : (
+                "Text-message access to Zero"
+              )}
             </div>
           </div>
           {isConnected ? (
-            <span
-              data-testid="agentphone-connected-indicator"
-              className="inline-flex min-w-0 max-w-52 shrink-0 items-center gap-1.5 rounded-lg border border-border bg-background px-1.5 py-1 text-xs font-medium text-secondary-foreground"
-            >
-              <IconCircleCheck className="h-3 w-3 text-green-600" />
-              <span className="min-w-0 truncate" title={connectedPhone ?? ""}>
-                {connectedPhone ? `Connected (${connectedPhone})` : "Connected"}
-              </span>
-            </span>
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span
+                    data-testid="agentphone-connected-indicator"
+                    className="inline-flex min-w-0 max-w-52 shrink-0 items-center gap-1.5 rounded-lg border border-border bg-background px-1.5 py-1 text-xs font-medium text-secondary-foreground"
+                  >
+                    <IconCircleCheck className="h-3 w-3 text-green-600" />
+                    <span className="min-w-0 truncate">
+                      {connectedPhone ?? "Connected"}
+                    </span>
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent>Authorized Sender</TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
           ) : null}
           {status !== null && !isConnected ? (
             <Button
@@ -294,7 +357,7 @@ export function AgentPhoneCard() {
               variant="outline"
               size="sm"
               className="h-8 shrink-0 gap-1.5 rounded-lg"
-              aria-label="Connect AgentPhone"
+              aria-label="Connect phone"
               onClick={() => {
                 setConnectOpen(true);
               }}
@@ -308,7 +371,7 @@ export function AgentPhoneCard() {
                 <button
                   type="button"
                   className="shrink-0 rounded p-1.5 text-muted-foreground hover:bg-muted hover:text-foreground transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-                  aria-label="AgentPhone options"
+                  aria-label="Phone options"
                 >
                   <IconDotsVertical size={16} stroke={1.5} />
                 </button>
@@ -319,7 +382,7 @@ export function AgentPhoneCard() {
               >
                 <button
                   type="button"
-                  aria-label="Disconnect AgentPhone"
+                  aria-label="Disconnect phone"
                   disabled={disconnecting}
                   className="flex w-full items-center gap-2 rounded-md px-3 py-2 text-sm text-left hover:bg-accent hover:text-accent-foreground transition-colors disabled:opacity-50 disabled:pointer-events-none"
                   onClick={() => {

--- a/turbo/apps/platform/src/views/zero-page/zero-works-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-works-page.tsx
@@ -1,10 +1,4 @@
-import {
-  useGet,
-  useSet,
-  useLastLoadable,
-  useLastResolved,
-  useLoadable,
-} from "ccstate-react";
+import { useGet, useSet, useLastLoadable, useLoadable } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import {
@@ -14,7 +8,6 @@ import {
   IconDownload,
   IconSettings,
 } from "@tabler/icons-react";
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { Button } from "@vm0/ui";
 import {
   Popover,
@@ -38,7 +31,6 @@ import {
   setShowUninstallDialog$,
 } from "../../signals/zero-page/zero-slack.ts";
 import { telegramBots$ } from "../../signals/zero-page/zero-telegram.ts";
-import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
 import { detach, Reason } from "../../signals/utils.ts";
 import { Link } from "../router/link.tsx";
 import { ROUTES } from "../../signals/route-paths.ts";
@@ -326,8 +318,6 @@ function TelegramCard() {
 
 export function ZeroWorksPage() {
   const displayNameLoadable = useLoadable(currentChatAgentDisplayName$);
-  const features = useLastResolved(featureSwitch$);
-  const showAgentPhone = features?.[FeatureSwitchKey.AgentPhoneAppUi] ?? false;
   const displayName =
     displayNameLoadable.state === "hasData"
       ? (displayNameLoadable.data ?? "Zero")
@@ -350,7 +340,7 @@ export function ZeroWorksPage() {
         <div className="mx-auto max-w-[900px] flex flex-col gap-4">
           <SlackCard displayName={displayName} />
           <TelegramCard />
-          {showAgentPhone ? <AgentPhoneCard /> : null}
+          <AgentPhoneCard />
         </div>
       </main>
     </div>

--- a/turbo/packages/api-contracts/src/contracts/zero-integrations-agentphone.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-integrations-agentphone.ts
@@ -80,7 +80,6 @@ export const zeroIntegrationsAgentPhoneContract = c.router({
     responses: {
       200: agentPhoneLinkStatusResponseSchema,
       401: apiErrorSchema,
-      403: apiErrorSchema,
     },
     summary: "Check the authenticated user's AgentPhone link status",
   },
@@ -93,7 +92,6 @@ export const zeroIntegrationsAgentPhoneContract = c.router({
       200: agentPhoneStartLinkResponseSchema,
       400: apiErrorSchema,
       401: apiErrorSchema,
-      403: apiErrorSchema,
       429: apiErrorSchema,
       409: apiErrorSchema,
       503: apiErrorSchema,
@@ -108,7 +106,6 @@ export const zeroIntegrationsAgentPhoneContract = c.router({
     responses: {
       204: c.noBody(),
       401: apiErrorSchema,
-      403: apiErrorSchema,
       404: apiErrorSchema,
     },
     summary: "Disconnect the authenticated user's AgentPhone link",

--- a/turbo/packages/connectors/src/feature-switch-key.ts
+++ b/turbo/packages/connectors/src/feature-switch-key.ts
@@ -42,7 +42,6 @@ export enum FeatureSwitchKey {
   AutoSkill = "autoSkill",
   TestOauthConnector = "testOauthConnector",
   ChatHeaderNewButton = "chatHeaderNewButton",
-  AgentPhoneAppUi = "agentPhoneAppUi",
 
   ChatMessageStartButton = "chatMessageStartButton",
   Goal = "goal",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -237,13 +237,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
       "Replace the Invite people button in the agent chat page header with a New button that creates a new chat thread",
     enabled: false,
   },
-  [FeatureSwitchKey.AgentPhoneAppUi]: {
-    maintainer: "linghan@vm0.ai",
-    description:
-      "Show first-class AgentPhone app surfaces: Works card and onboarding entry points.",
-    enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
-  },
   [FeatureSwitchKey.ChatMessageStartButton]: {
     maintainer: "linghan@vm0.ai",
     description:


### PR DESCRIPTION
## Summary

- Renames the **AgentPhone** card on `/works` to **Phone**. The summary now reads `iMessage or SMS to +1 (903) 985-3128` — the number is formatted for readability and is a click-to-copy button.
- The connected indicator now shows the authorized handle directly (e.g. `perfectworks@gmail.com`) with an `Authorized Sender` tooltip on hover, instead of `Connected (...)`.
- Removes the `AgentPhoneAppUi` feature switch entirely. The Phone card and its link API (`getLinkStatus` / `startLink` / `unlink`) are now available to everyone — the staff-org gate and the `403 / FORBIDDEN` responses are gone.

## Changes

- `agentphone-card.tsx`: card title `Phone`; `PhoneNumberCopyButton` with `+1 (NXX) NXX-XXXX` formatting and clipboard copy via `writeToClipboard`; `Authorized Sender` tooltip on the connected indicator; dialog title and aria-labels updated to "phone".
- `zero-works-page.tsx`: render the Phone card unconditionally.
- `feature-switch-key.ts` / `feature-switch.ts`: drop the `AgentPhoneAppUi` key and registry entry.
- `zero-integrations-agentphone.ts`: remove the `requireAgentPhoneUi$` gate and `forbidden()` helper; routes use `organizationAuthContext$` directly.
- `zero-integrations-agentphone.ts` contract: drop the now-unreachable `403` responses.
- Tests updated for the renamed copy and the removed feature switch.

## Test plan

- [x] `apps/platform` works-page tests pass (18/18)
- [x] `apps/platform`, `apps/api`, `packages/{connectors,core,api-contracts}` type-check and lint clean
- [ ] CI: `apps/api` agentphone link integration tests (require a provisioned DB)