### PR TITLE
fix: restore desktop traffic lights after expanding sidebar

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-layout.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-layout.test.tsx
@@ -256,19 +256,21 @@ describe("sidebar layout - desktop shell text selection scope (SIDEBAR-D-056)", 
     detachedSetupPage({ context, path: "/agents" });
 
     await waitFor(() => {
-      expect(setSidebarCollapsed).toHaveBeenCalledWith(false);
+      expect(setSidebarCollapsed).toHaveBeenLastCalledWith(false);
     });
 
+    setSidebarCollapsed.mockClear();
     await user.keyboard("{Control>}b{/Control}");
 
     await waitFor(() => {
-      expect(setSidebarCollapsed).toHaveBeenCalledWith(true);
+      expect(setSidebarCollapsed).toHaveBeenLastCalledWith(true);
     });
 
+    setSidebarCollapsed.mockClear();
     await user.keyboard("{Control>}b{/Control}");
 
     await waitFor(() => {
-      expect(setSidebarCollapsed).toHaveBeenCalledWith(false);
+      expect(setSidebarCollapsed).toHaveBeenLastCalledWith(false);
     });
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -91,6 +91,21 @@ function syncExpandedDesktopTrafficLightsRef(element: HTMLDivElement | null) {
   syncDesktopTrafficLights(false);
 }
 
+function DesktopTrafficLightStateSync() {
+  const off = useGet(sidebarOff$);
+  return (
+    <div
+      ref={
+        off
+          ? syncCollapsedDesktopTrafficLightsRef
+          : syncExpandedDesktopTrafficLightsRef
+      }
+      hidden
+      aria-hidden="true"
+    />
+  );
+}
+
 interface ManageNavItem {
   readonly id: SidebarNavId;
   readonly activeKeys: readonly RouteKey[];
@@ -280,11 +295,7 @@ function CollapsedSidebar() {
   }
   return (
     <aside className="zero-nav zero-collapsed-sidebar box-border hidden md:flex h-full w-16 shrink-0 flex-col border-r-[0.7px] border-sidebar-border bg-sidebar px-2 transition-all duration-300">
-      <div
-        ref={syncCollapsedDesktopTrafficLightsRef}
-        className="zero-desktop-titlebar-drag-region"
-        aria-hidden="true"
-      />
+      <div className="zero-desktop-titlebar-drag-region" aria-hidden="true" />
       <CollapsedExpandButton />
       <CollapsedNavList />
       <CollapsedFooter />
@@ -446,11 +457,7 @@ function ExpandedHeader() {
   const onCollapse = useSidebarCollapseToggle();
   return (
     <div className="zero-sidebar-header shrink-0 px-2 pb-0">
-      <div
-        ref={syncExpandedDesktopTrafficLightsRef}
-        className="zero-desktop-titlebar-drag-region"
-        aria-hidden="true"
-      />
+      <div className="zero-desktop-titlebar-drag-region" aria-hidden="true" />
       <div className="zero-desktop-no-drag flex items-center justify-between gap-2 rounded-lg py-0.5">
         <div className="min-w-0 flex-1">
           <ZeroOrgSwitcher />
@@ -688,6 +695,7 @@ function ExpandedFooterAccountInsights() {
 export function ZeroSidebar() {
   return (
     <>
+      <DesktopTrafficLightStateSync />
       <CollapsedSidebar />
       <ExpandedSidebar />
       <ManagePinnedAgentsDialogContainer />


### PR DESCRIPTION
## Summary
- sync desktop traffic-light position from sidebar collapsed state instead of mounted header refs
- keep collapsed and expanded drag regions layout-only
- strengthen the sidebar bridge test so expanding must emit a fresh restore call

## Validation
- git diff --check
- pnpm exec prettier --check apps/platform/src/views/zero-page/zero-sidebar.tsx apps/platform/src/views/zero-page/__tests__/sidebar-layout.test.tsx
- pnpm -F @vm0/app lint
- pnpm -F @vm0/app check-types

## Note
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/sidebar-layout.test.tsx still fails locally because the test harness renders an empty body for the existing page tests; the failure is not specific to this traffic-light change.