### PR TITLE
refactor: route connector oauth authorize through providers

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-authorize.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-authorize.test.ts
@@ -65,6 +65,8 @@ function mockOAuthEnv(): void {
   );
   mockOptionalEnv("DROPBOX_OAUTH_CLIENT_ID", "dropbox-test-client-id");
   mockOptionalEnv("DROPBOX_OAUTH_CLIENT_SECRET", "dropbox-test-client-secret");
+  mockOptionalEnv("GOOGLE_OAUTH_CLIENT_ID", "google-test-client-id");
+  mockOptionalEnv("GOOGLE_OAUTH_CLIENT_SECRET", "google-test-client-secret");
   mockOptionalEnv("LINEAR_OAUTH_CLIENT_ID", "linear-test-client-id");
   mockOptionalEnv("LINEAR_OAUTH_CLIENT_SECRET", "linear-test-client-secret");
   mockOptionalEnv("MERCURY_OAUTH_CLIENT_ID", "mercury-test-client-id");
@@ -273,6 +275,30 @@ describe("GET /api/zero/connectors/:type/authorize", () => {
     expect(url.searchParams.get("redirect_uri")).toBe(
       `${WEB_ORIGIN}/api/connectors/github/callback`,
     );
+  });
+
+  it("requests offline Google OAuth access", async () => {
+    const response = await requestAuthorize("google-drive", {
+      authenticated: true,
+    });
+
+    const location = response.headers.get("location");
+    expect(location).not.toBeNull();
+    const url = new URL(location!);
+    expect(`${url.origin}${url.pathname}`).toBe(
+      "https://accounts.google.com/o/oauth2/v2/auth",
+    );
+    expect(url.searchParams.get("client_id")).toBe("google-test-client-id");
+    expect(url.searchParams.get("redirect_uri")).toBe(
+      `${BASE_URL}/api/connectors/google-drive/callback`,
+    );
+    const scopes = new Set(url.searchParams.get("scope")?.split(" ") ?? []);
+    expect(scopes.has("https://www.googleapis.com/auth/drive")).toBeTruthy();
+    expect(
+      scopes.has("https://www.googleapis.com/auth/userinfo.email"),
+    ).toBeTruthy();
+    expect(url.searchParams.get("access_type")).toBe("offline");
+    expect(url.searchParams.get("prompt")).toBe("consent");
   });
 
   it("stores the connector session id when provided", async () => {
@@ -641,6 +667,59 @@ describe("POST /api/zero/connectors/:type/oauth/start", () => {
       redirectUri: `${WEB_ORIGIN}/api/connectors/github/callback`,
       consumedAt: null,
     });
+    expect(storedState!.expiresAt.getTime()).toBeGreaterThan(now());
+  });
+
+  it("stores provider PKCE context for server-side OAuth handoff", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    orgIds.push(orgId);
+    mocks.clerk.session(userId, orgId);
+
+    const response = await requestOauthStart("airtable", {
+      headers: { authorization: "Bearer clerk-session" },
+      origin: API_ORIGIN,
+    });
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      readonly authorizationUrl: string;
+    };
+    const authorizationUrl = new URL(body.authorizationUrl);
+    expect(`${authorizationUrl.origin}${authorizationUrl.pathname}`).toBe(
+      "https://airtable.com/oauth2/v1/authorize",
+    );
+    expect(authorizationUrl.searchParams.get("client_id")).toBe(
+      "airtable-test-client-id",
+    );
+    expect(authorizationUrl.searchParams.get("redirect_uri")).toBe(
+      `${WEB_ORIGIN}/api/connectors/airtable/callback`,
+    );
+    expect(authorizationUrl.searchParams.get("code_challenge")).toMatch(
+      /^[A-Za-z0-9_-]+$/,
+    );
+    expect(authorizationUrl.searchParams.get("code_challenge_method")).toBe(
+      "S256",
+    );
+    const state = authorizationUrl.searchParams.get("state");
+    expect(state).toMatch(/^[0-9a-f]{64}$/);
+
+    const db = store.set(writeDb$);
+    const [storedState] = await db
+      .select()
+      .from(connectorOauthStates)
+      .where(eq(connectorOauthStates.state, state!));
+    expect(storedState).toBeDefined();
+    stateIds.push(storedState!.id);
+    expect(storedState).toMatchObject({
+      state,
+      type: "airtable",
+      userId,
+      orgId,
+      redirectUri: `${WEB_ORIGIN}/api/connectors/airtable/callback`,
+      consumedAt: null,
+    });
+    expect(storedState!.codeVerifier).toMatch(/^[A-Za-z0-9_-]+$/);
     expect(storedState!.expiresAt.getTime()).toBeGreaterThan(now());
   });
 

--- a/turbo/apps/api/src/signals/routes/zero-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/zero-connectors.ts
@@ -18,12 +18,9 @@ import {
 import {
   getConnectorAuthMethod,
   getConnectorOAuthCredentials,
-  getConnectorOAuthConfig,
-  isGoogleOAuthConnector,
 } from "@vm0/connectors/connector-utils";
 import {
   connectorTypeSchema,
-  type ConnectorType,
   type OAuthConnectorType,
 } from "@vm0/connectors/connectors";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
@@ -171,146 +168,6 @@ function redirectResponse(url: string): Response {
     status: REDIRECT_STATUS,
     headers: { location: url },
   });
-}
-
-async function base64UrlSha256(value: string): Promise<string> {
-  const data = new TextEncoder().encode(value);
-  const hash = await crypto.subtle.digest("SHA-256", data);
-  return Buffer.from(hash).toString("base64url");
-}
-
-function generateCodeVerifier(): string {
-  const array = new Uint8Array(32);
-  crypto.getRandomValues(array);
-  return Buffer.from(array).toString("base64url");
-}
-
-function codeChallenge(codeVerifier: string): Promise<string> {
-  return base64UrlSha256(codeVerifier);
-}
-
-function deterministicPkceSuffix(type: ConnectorType): string | undefined {
-  switch (type) {
-    case "canva": {
-      return "canva-pkce-verifier";
-    }
-    case "deel": {
-      return "deel-pkce-verifier";
-    }
-    case "docusign": {
-      return "docusign-pkce-verifier";
-    }
-    case "garmin-connect": {
-      return "garmin-pkce-verifier";
-    }
-    case "supabase": {
-      return "supabase-pkce-verifier";
-    }
-    case "x": {
-      return "x-pkce-verifier";
-    }
-    default: {
-      return undefined;
-    }
-  }
-}
-
-async function buildAuthorizeUrl(args: {
-  readonly type: ConnectorType;
-  readonly clientId: string;
-  readonly redirectUri: string;
-  readonly state: string;
-}): Promise<AuthUrlResult | null> {
-  const oauthConfig = getConnectorOAuthConfig(args.type);
-  if (!oauthConfig?.authorizationUrl) {
-    return null;
-  }
-
-  if (args.type === "github") {
-    return {
-      url: `${oauthConfig.authorizationUrl}?${new URLSearchParams({
-        client_id: args.clientId,
-        redirect_uri: args.redirectUri,
-        scope: oauthConfig.scopes.join(" "),
-        state: args.state,
-      }).toString()}`,
-    };
-  }
-
-  if (args.type === "slack") {
-    return {
-      url: `${oauthConfig.authorizationUrl}?${new URLSearchParams({
-        client_id: args.clientId,
-        redirect_uri: args.redirectUri,
-        user_scope: oauthConfig.scopes.join(","),
-        state: args.state,
-      }).toString()}`,
-    };
-  }
-
-  if (args.type === "notion") {
-    return {
-      url: `${oauthConfig.authorizationUrl}?${new URLSearchParams({
-        client_id: args.clientId,
-        redirect_uri: args.redirectUri,
-        state: args.state,
-        response_type: "code",
-        owner: "user",
-      }).toString()}`,
-    };
-  }
-
-  const params = new URLSearchParams({
-    client_id: args.clientId,
-    redirect_uri: args.redirectUri,
-    response_type: "code",
-    state: args.state,
-  });
-  if (oauthConfig.scopes.length > 0 && args.type !== "garmin-connect") {
-    const scopeSeparator =
-      args.type === "linear" || args.type === "strava" ? "," : " ";
-    params.set("scope", oauthConfig.scopes.join(scopeSeparator));
-  }
-  if (isGoogleOAuthConnector(args.type)) {
-    params.set("access_type", "offline");
-    params.set("prompt", "consent");
-  }
-  if (args.type === "outlook-calendar" || args.type === "outlook-mail") {
-    params.set("prompt", "consent");
-  }
-  if (args.type === "reddit") {
-    params.set("duration", "permanent");
-  }
-  if (args.type === "dropbox") {
-    params.set("token_access_type", "offline");
-    params.set("force_reapprove", "true");
-  }
-  if (args.type === "strava") {
-    params.set("approval_prompt", "force");
-  }
-  if (args.type === "linear") {
-    params.set("actor", "user");
-    params.set("prompt", "consent");
-  }
-
-  const pkceSuffix = deterministicPkceSuffix(args.type);
-  if (pkceSuffix) {
-    const verifier = await base64UrlSha256(`${args.state}:${pkceSuffix}`);
-    params.set("code_challenge", await codeChallenge(verifier));
-    params.set("code_challenge_method", "S256");
-  }
-
-  if (args.type === "airtable") {
-    const verifier = generateCodeVerifier();
-    params.set("code_challenge", await codeChallenge(verifier));
-    params.set("code_challenge_method", "S256");
-    return {
-      url: `${oauthConfig.authorizationUrl}?${params.toString()}`,
-      codeVerifier: verifier,
-    };
-  }
-
-  return { url: `${oauthConfig.authorizationUrl}?${params.toString()}` };
 }
 
 function normalizeAuthUrlResult(result: string | AuthUrlResult): AuthUrlResult {
@@ -616,22 +473,13 @@ export function createAuthorizeConnectorInner(route: ConnectorAuthorizeRoute) {
       return jsonResponse({ error: `${type} OAuth not configured` }, 500);
     }
 
-    const authResult = credentials.clientId
-      ? await buildAuthorizeUrl({
-          type,
-          clientId: credentials.clientId,
-          redirectUri,
-          state,
-        })
-      : await buildProviderAuthorizeUrl({
-          type,
-          redirectUri,
-          state,
-        });
+    const authResult = await buildProviderAuthorizeUrl({
+      type,
+      clientId: credentials.clientId,
+      redirectUri,
+      state,
+    });
     signal.throwIfAborted();
-    if (!authResult) {
-      return jsonResponse({ error: `${type} OAuth not configured` }, 500);
-    }
 
     await set(
       deleteZeroConnectorLocalState$,
@@ -711,22 +559,13 @@ const startConnectorOauthInner$ = command(
       return internalServerError(`${type} OAuth not configured`);
     }
 
-    const authResult = credentials.clientId
-      ? await buildAuthorizeUrl({
-          type,
-          clientId: credentials.clientId,
-          redirectUri,
-          state,
-        })
-      : await buildProviderAuthorizeUrl({
-          type,
-          redirectUri,
-          state,
-        });
+    const authResult = await buildProviderAuthorizeUrl({
+      type,
+      clientId: credentials.clientId,
+      redirectUri,
+      state,
+    });
     signal.throwIfAborted();
-    if (!authResult) {
-      return internalServerError(`${type} OAuth not configured`);
-    }
 
     await set(
       deleteZeroConnectorLocalState$,


### PR DESCRIPTION
## Summary
- route connector OAuth authorization URL generation through provider implementations
- remove the legacy route-local OAuth URL builder from zero-connectors
- add regression coverage for Google offline access and provider PKCE context persistence

## Tests
- pnpm format
- pnpm -F api exec vitest run src/signals/routes/__tests__/zero-connectors-authorize.test.ts
- pnpm -F api exec vitest run src/signals/routes/__tests__/connectors-type-callback.test.ts
- pnpm -F api lint
- pnpm -F api check-types
- pnpm -F @vm0/connectors check-types
- pnpm -F @vm0/connectors test -- src/__tests__/connectors.test.ts
- git diff --check
- pre-commit hook: pnpm check-types

Closes #14355