### PR TITLE
fix(api): re-throw non-abort errors in clearAllDetached

### DIFF
--- a/turbo/apps/api/src/signals/services/zero-voice-chat.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-voice-chat.service.ts
@@ -499,6 +499,19 @@ function readVoiceChatItems(
   });
 }
 
+const PG_FOREIGN_KEY_VIOLATION = "23503";
+
+function isForeignKeyViolation(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+  const { cause } = error;
+  if (typeof cause !== "object" || cause === null || !("code" in cause)) {
+    return false;
+  }
+  return cause.code === PG_FOREIGN_KEY_VIOLATION;
+}
+
 export const appendVoiceChatItem$ = command(
   async (
     { set },
@@ -515,20 +528,34 @@ export const appendVoiceChatItem$ = command(
     | ErrorResponse<404, "NOT_FOUND">
   > => {
     const writeDb = set(writeDb$);
-    const [inserted] = await writeDb
-      .insert(voiceChatItems)
-      .values({
-        sessionId: args.sessionId,
-        role: args.role,
-        content: args.content,
-        taskId: args.taskId ?? null,
-        realtimeItemId: args.realtimeItemId ?? null,
-      })
-      .onConflictDoNothing({
-        target: [voiceChatItems.sessionId, voiceChatItems.realtimeItemId],
-      })
-      .returning();
+    const insertResult = await settle(
+      writeDb
+        .insert(voiceChatItems)
+        .values({
+          sessionId: args.sessionId,
+          role: args.role,
+          content: args.content,
+          taskId: args.taskId ?? null,
+          realtimeItemId: args.realtimeItemId ?? null,
+        })
+        .onConflictDoNothing({
+          target: [voiceChatItems.sessionId, voiceChatItems.realtimeItemId],
+        })
+        .returning(),
+    );
     signal.throwIfAborted();
+
+    // A voice-chat session can be deleted while detached reasoner work is
+    // still in flight. A vanished parent row surfaces as an FK violation
+    // rather than a conflict — treat it as not-found instead of letting the
+    // background task crash.
+    if (!insertResult.ok) {
+      if (isForeignKeyViolation(insertResult.error)) {
+        return notFound("Voice-chat session not found");
+      }
+      throw insertResult.error;
+    }
+    const [inserted] = insertResult.value;
 
     if (inserted) {
       return { item: inserted, inserted: true };

--- a/turbo/apps/api/src/signals/utils.ts
+++ b/turbo/apps/api/src/signals/utils.ts
@@ -166,7 +166,12 @@ export function detach(
   mechanism: Mechanism,
   description?: string,
 ): void {
-  const silenced = promise.then(
+  // Attach a rejection handler the moment work is detached so a background
+  // failure is logged and never escalates to an unhandledRejection. The
+  // original promise is what gets tracked: clearAllDetached re-awaits it in
+  // afterEach so a non-abort rejection fails the test instead of passing
+  // silently behind this catch.
+  void promise.then(
     () => {},
     (error: unknown) => {
       if (!isAbortError(error)) {
@@ -176,26 +181,39 @@ export function detach(
   );
 
   if (IN_VITEST) {
-    tracker().collected.add(silenced);
-    tracker().mechanisms.set(silenced, mechanism);
+    tracker().collected.add(promise);
+    tracker().mechanisms.set(promise, mechanism);
     if (description) {
-      tracker().descriptions.set(silenced, description);
+      tracker().descriptions.set(promise, description);
     }
   }
 }
 
 export async function clearAllDetached(): Promise<void> {
-  if (!IN_VITEST) {
-    tracker().collected.clear();
-    tracker().mechanisms.clear();
-    tracker().descriptions.clear();
-    return;
-  }
-
-  for (const promise of tracker().collected) {
-    await promise;
-  }
+  const pending = [...tracker().collected];
   tracker().collected.clear();
   tracker().mechanisms.clear();
   tracker().descriptions.clear();
+
+  if (!IN_VITEST) {
+    return;
+  }
+
+  // Await every detached promise so background work cannot leak into the next
+  // test. Only AbortError is swallowed — any other rejection is re-thrown so a
+  // failing waitUntil task fails the test that scheduled it.
+  const errors: unknown[] = [];
+  for (const promise of pending) {
+    await promise.then(
+      () => {},
+      (error: unknown) => {
+        if (!isAbortError(error)) {
+          errors.push(error);
+        }
+      },
+    );
+  }
+  if (errors.length > 0) {
+    throw errors[0];
+  }
 }


### PR DESCRIPTION
## Summary

Two related fixes:

**1. `clearAllDetached` swallowed background-work failures.** `detach` registered the `silenced` `.then()` wrapper in the vitest tracker. That wrapper always resolves, so `clearAllDetached` — which `afterEach` awaits — could never observe a rejection. A failing `waitUntil` task was drained but its error was swallowed, letting the test pass green. Now `detach` tracks the **original** promise and `clearAllDetached` re-throws any non-`AbortError`, so `afterEach` only swallows `AbortError`.

**2. The bug that fix surfaced.** A detached reasoner tick (`triggerVoiceChatReasoning$`) can run after its voice-chat session has been deleted. `appendVoiceChatItem$` did an unguarded `insert into voice_chat_items`, so a vanished session crashed the background task with an FK violation. The insert is now wrapped in `settle()` and a foreign-key violation is treated as not-found — matching the pattern already used by the agent webhook handlers.

> Note: `apps/platform` has the same latent issue in its `clearAllDetached` (`throwIfNotAbort` wired to the never-rejecting `silencePromise`). Not touched here.

## Validation

Full `apps/api` suite (3242 tests / 249 files), differential vs unmodified `main`:

- Fix #1 alone surfaced exactly **1** new failure — `zero-voice-chat-posts.test.ts` — and no other regressions.
- Fix #2 resolves it: `zero-voice-chat-posts.test.ts` (39 tests) and all other voice-chat suites (7 files / 85 tests) now pass.
- The other 6 failures seen locally are pre-existing environment/timezone/flake issues that pass in CI.

## Test plan

- [ ] `test-api` CI job is green
