### PR TITLE
fix: surface web chat upload failures

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/chat-message.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-message.ts
@@ -24,6 +24,7 @@ export { chatThreads$, reloadChatThreads$ } from "../agent-chat.ts";
 export {
   zeroChatAttachments$,
   uploadZeroAttachment$,
+  zeroChatAttachmentUploadSummary$,
   restoreZeroAttachments$,
   removeZeroAttachment$,
   zeroDragOver$,

--- a/turbo/apps/platform/src/signals/chat-page/resolve-draft-attachments.ts
+++ b/turbo/apps/platform/src/signals/chat-page/resolve-draft-attachments.ts
@@ -90,9 +90,35 @@ export function collectSuccessfulAttachmentInfos(
   });
 }
 
+function attachmentUploadFailureMessage(
+  attachments: readonly ZeroChatAttachment[],
+  results: readonly PromiseSettledResult<AttachmentFileInfo | null>[],
+): string | null {
+  const failedFilenames = results.flatMap((result, index) => {
+    const attachment = attachments[index];
+    if (!attachment) {
+      return [];
+    }
+    if (result.status === "rejected" || result.value === null) {
+      return [attachment.filename];
+    }
+    return [];
+  });
+
+  if (failedFilenames.length === 0) {
+    return null;
+  }
+
+  if (failedFilenames.length === 1) {
+    return `Failed to upload ${failedFilenames[0]}. Remove it and try again.`;
+  }
+
+  return "Failed to upload one or more attachments. Remove them and try again.";
+}
+
 /**
  * Resolves a draft's pending attachments (waits for uploads to finish,
- * filters out cancelled/failed entries) and shapes the result into both the
+ * rejects failed entries) and shapes the result into both the
  * outbound `AttachFile[]` for the send contract and the optimistic-UI
  * `PagedChatMessage["attachFiles"]` shape.
  *
@@ -123,6 +149,14 @@ export const prepareUserMessageFromDraft$ = command(
       }),
     );
     signal.throwIfAborted();
+
+    const uploadFailureMessage = attachmentUploadFailureMessage(
+      allAttachments,
+      allInfos,
+    );
+    if (uploadFailureMessage) {
+      throw new Error(uploadFailureMessage);
+    }
 
     const ready = collectSuccessfulAttachmentInfos(allAttachments, allInfos);
 

--- a/turbo/apps/platform/src/signals/zero-page/chat-draft.ts
+++ b/turbo/apps/platform/src/signals/zero-page/chat-draft.ts
@@ -1,10 +1,11 @@
 import { command, computed, state, type Command, type Computed } from "ccstate";
-import { resetSignal } from "../utils.ts";
+import { resetSignal, tapError } from "../utils.ts";
 import { currentChatThreadId$ } from "../agent-chat.ts";
 import { zeroClient$ } from "../api-client.ts";
 import { accept } from "../../lib/accept.ts";
 import type { PersistedAttachment } from "@vm0/api-contracts/contracts/chat-threads";
 import { zeroUploadsContract } from "@vm0/api-contracts/contracts/zero-uploads";
+import { toast } from "@vm0/ui/components/ui/sonner";
 
 // ---------------------------------------------------------------------------
 // Attachment types (moved from zero-chat.ts)
@@ -120,6 +121,11 @@ export interface ZeroChatAttachment {
   upload$: Command<Promise<void>, [AbortSignal]>;
 }
 
+export interface AttachmentUploadSummary {
+  attachmentCount: number;
+  readyCount: number;
+}
+
 function createChatAttachment(file: File): ZeroChatAttachment {
   const contentType = inferUploadContentType(file);
   const resetSignal$ = resetSignal();
@@ -199,6 +205,7 @@ export interface DraftSignals {
   input$: Computed<string>;
   setInput$: Command<void, [string]>;
   attachments$: Computed<ZeroChatAttachment[]>;
+  attachmentUploadSummary$: Computed<Promise<AttachmentUploadSummary>>;
   uploadAttachment$: Command<Promise<void>, [File, AbortSignal]>;
   restoreAttachments$: Command<void, [PersistedAttachment[]]>;
   removeAttachment$: Command<void, [ZeroChatAttachment]>;
@@ -259,6 +266,23 @@ export function createDraftSignals(): DraftSignals {
     return get(internalAttachments$);
   });
 
+  const attachmentUploadSummary$ = computed(
+    async (get): Promise<AttachmentUploadSummary> => {
+      const attachments = get(internalAttachments$);
+      const infos = await Promise.all(
+        attachments.map((attachment) => {
+          return get(attachment.fileInfo$);
+        }),
+      );
+      return {
+        attachmentCount: attachments.length,
+        readyCount: infos.filter((info) => {
+          return info !== null;
+        }).length,
+      };
+    },
+  );
+
   const uploadAttachment$ = command(
     async ({ set }, file: File, signal: AbortSignal) => {
       const attachment = createChatAttachment(file);
@@ -266,7 +290,14 @@ export function createDraftSignals(): DraftSignals {
         return [...prev, attachment];
       });
 
-      await set(attachment.upload$, signal);
+      await tapError(set(attachment.upload$, signal), () => {
+        set(internalAttachments$, (prev) => {
+          return prev.filter((a) => {
+            return a !== attachment;
+          });
+        });
+        toast.error(`Failed to upload ${file.name}`);
+      });
     },
   );
 
@@ -321,6 +352,7 @@ export function createDraftSignals(): DraftSignals {
     input$,
     setInput$,
     attachments$,
+    attachmentUploadSummary$,
     uploadAttachment$,
     restoreAttachments$,
     removeAttachment$,
@@ -364,6 +396,13 @@ const zeroChatInput$ = computed((get) => {
 export const zeroChatAttachments$ = computed((get) => {
   const draft = get(currentDraft$);
   return draft ? get(draft.attachments$) : [];
+});
+
+export const zeroChatAttachmentUploadSummary$ = computed(async (get) => {
+  const draft = get(currentDraft$);
+  return draft
+    ? await get(draft.attachmentUploadSummary$)
+    : { attachmentCount: 0, readyCount: 0 };
 });
 
 export const uploadZeroAttachment$ = command(

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-draft.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-draft.test.tsx
@@ -210,7 +210,7 @@ describe("chat draft persistence across thread navigation", () => {
     });
   });
 
-  it("should toast and keep the chip when prepare returns an error", async () => {
+  it("should toast and remove the chip when prepare returns an error", async () => {
     const user = userEvent.setup();
     mockThreads();
     server.use(
@@ -243,11 +243,13 @@ describe("chat draft persistence across thread navigation", () => {
     await user.upload(fileInput, file);
 
     await waitFor(() => {
-      expect(toast.error).toHaveBeenCalledWith(
-        expect.stringContaining("File too large"),
-      );
+      expect(toast.error).toHaveBeenCalledWith("Failed to upload huge.png");
     });
-    expect(screen.getByLabelText("Remove huge.png")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(
+        screen.queryByLabelText("Remove huge.png"),
+      ).not.toBeInTheDocument();
+    });
   });
 
   it("should infer office content type when the browser file type is empty", async () => {
@@ -375,7 +377,7 @@ describe("chat draft persistence across thread navigation", () => {
     },
   );
 
-  it("should keep the chip when the R2 put fails", async () => {
+  it("should toast and remove the chip when the R2 put fails", async () => {
     const user = userEvent.setup();
     mockThreads();
     server.use(
@@ -409,8 +411,12 @@ describe("chat draft persistence across thread navigation", () => {
     await user.upload(fileInput, file);
 
     await waitFor(() => {
-      expect(screen.getByLabelText("Remove fail.png")).toBeInTheDocument();
+      expect(toast.error).toHaveBeenCalledWith("Failed to upload fail.png");
     });
-    expect(toast.error).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(
+        screen.queryByLabelText("Remove fail.png"),
+      ).not.toBeInTheDocument();
+    });
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
@@ -851,89 +851,101 @@ describe("chat-i-065: new-thread send includes structured attachFiles", () => {
     });
   });
 
-  it("posts only fulfilled uploaded attachments when another upload fails", async () => {
+  it("surfaces and removes failed uploads before sending remaining attachments", async () => {
     const user = userEvent.setup();
     const okUploadUrl = "https://mock-upload.example.com/ok.txt";
     const failedUploadUrl = "https://mock-upload.example.com/failed.txt";
     let capturedAttachFiles: unknown = "not-called";
+    const toastErrorSpy = vi.spyOn(toast, "error").mockImplementation(() => {
+      return "" as ReturnType<typeof toast.error>;
+    });
 
-    server.use(
-      mockApi(zeroUploadsContract.prepare, ({ body, respond }) => {
-        if (body.filename === "ok.txt") {
+    try {
+      server.use(
+        mockApi(zeroUploadsContract.prepare, ({ body, respond }) => {
+          if (body.filename === "ok.txt") {
+            return respond(200, {
+              id: "upload-ok",
+              filename: body.filename,
+              contentType: body.contentType,
+              size: body.size,
+              uploadUrl: okUploadUrl,
+              url: "https://example.com/ok.txt",
+            });
+          }
+
           return respond(200, {
-            id: "upload-ok",
+            id: "upload-failed",
             filename: body.filename,
             contentType: body.contentType,
             size: body.size,
-            uploadUrl: okUploadUrl,
-            url: "https://example.com/ok.txt",
+            uploadUrl: failedUploadUrl,
+            url: "https://example.com/failed.txt",
           });
-        }
+        }),
+        http.put(okUploadUrl, () => {
+          return new HttpResponse(null, { status: 200 });
+        }),
+        http.put(failedUploadUrl, () => {
+          return new HttpResponse(null, { status: 500 });
+        }),
+      );
+      mockChatLifecycle();
+      server.use(
+        mockApi(chatMessagesContract.send, ({ body, respond }) => {
+          capturedAttachFiles = body.attachFiles;
+          return respond(201, {
+            runId: "run-new-2",
+            threadId: "thread-test-2",
+            status: "pending",
+            createdAt: "2026-03-10T00:00:00Z",
+          });
+        }),
+      );
 
-        return respond(200, {
-          id: "upload-failed",
-          filename: body.filename,
-          contentType: body.contentType,
-          size: body.size,
-          uploadUrl: failedUploadUrl,
-          url: "https://example.com/failed.txt",
-        });
-      }),
-      http.put(okUploadUrl, () => {
-        return new HttpResponse(null, { status: 200 });
-      }),
-      http.put(failedUploadUrl, () => {
-        return new HttpResponse(null, { status: 500 });
-      }),
-    );
-    mockChatLifecycle();
-    server.use(
-      mockApi(chatMessagesContract.send, ({ body, respond }) => {
-        capturedAttachFiles = body.attachFiles;
-        return respond(201, {
-          runId: "run-new-2",
-          threadId: "thread-test-2",
-          status: "pending",
-          createdAt: "2026-03-10T00:00:00Z",
-        });
-      }),
-    );
+      detachedSetupPage({
+        context,
+        path: "/agents/c0000000-0000-4000-a000-000000000001/chat",
+      });
 
-    detachedSetupPage({
-      context,
-      path: "/agents/c0000000-0000-4000-a000-000000000001/chat",
-    });
+      await waitFor(() => {
+        expect(screen.getByPlaceholderText(PLACEHOLDER)).toBeInTheDocument();
+      });
 
-    await waitFor(() => {
-      expect(screen.getByPlaceholderText(PLACEHOLDER)).toBeInTheDocument();
-    });
-
-    const fileInput =
-      document.querySelector<HTMLInputElement>('input[type="file"]');
-    await user.upload(fileInput!, [
-      new File(["ok"], "ok.txt", { type: "text/plain" }),
-      new File(["failed"], "failed.txt", { type: "text/plain" }),
-    ]);
-
-    await waitFor(() => {
-      expect(screen.getByLabelText("Remove ok.txt")).toBeInTheDocument();
-      expect(screen.getByLabelText("Remove failed.txt")).toBeInTheDocument();
-    });
-
-    const textarea = screen.getByPlaceholderText(
-      PLACEHOLDER,
-    ) as HTMLTextAreaElement;
-    await sendMessageInUI(user, textarea, "Please review");
-
-    await waitFor(() => {
-      expect(capturedAttachFiles).toStrictEqual([
-        {
-          id: "upload-ok",
-          filename: "ok.txt",
-          contentType: "text/plain",
-          size: 2,
-        },
+      const fileInput =
+        document.querySelector<HTMLInputElement>('input[type="file"]');
+      await user.upload(fileInput!, [
+        new File(["ok"], "ok.txt", { type: "text/plain" }),
+        new File(["failed"], "failed.txt", { type: "text/plain" }),
       ]);
-    });
+
+      await waitFor(() => {
+        expect(toastErrorSpy).toHaveBeenCalledWith(
+          "Failed to upload failed.txt",
+        );
+      });
+      await waitFor(() => {
+        expect(screen.queryByTitle("failed.txt")).not.toBeInTheDocument();
+        expect(screen.getByLabelText("Remove ok.txt")).toBeInTheDocument();
+      });
+
+      const textarea = screen.getByPlaceholderText(
+        PLACEHOLDER,
+      ) as HTMLTextAreaElement;
+      await sendMessageInUI(user, textarea, "Please review");
+
+      await waitFor(() => {
+        expect(capturedAttachFiles).toStrictEqual([
+          {
+            id: "upload-ok",
+            filename: "ok.txt",
+            contentType: "text/plain",
+            size: 2,
+          },
+        ]);
+      });
+    } finally {
+      toastErrorSpy.mockRestore();
+    }
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -5,6 +5,7 @@ import type { ChangeEvent, ClipboardEvent, DragEvent } from "react";
 import {
   useGet,
   useSet,
+  useLoadable,
   useLastLoadable,
   useLastResolved,
 } from "ccstate-react";
@@ -63,6 +64,7 @@ import { isVisualAttachment } from "../../signals/chat-page/resolve-draft-attach
 import type { Command, Computed } from "ccstate";
 import {
   zeroChatAttachments$ as singletonAttachments$,
+  zeroChatAttachmentUploadSummary$ as singletonAttachmentUploadSummary$,
   uploadZeroAttachment$ as singletonUpload$,
   restoreZeroAttachments$ as singletonRestore$,
   removeZeroAttachment$ as singletonRemove$,
@@ -322,12 +324,18 @@ function resolveComposerCanSend({
   draftCanSend,
   input,
   visibleAttachmentCount,
+  uploadsReady,
 }: {
   draftCanSend: boolean;
   input: string;
   visibleAttachmentCount: number;
+  uploadsReady: boolean;
 }): boolean {
-  return draftCanSend && (input.trim() !== "" || visibleAttachmentCount > 0);
+  return (
+    uploadsReady &&
+    draftCanSend &&
+    (input.trim() !== "" || visibleAttachmentCount > 0)
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -867,6 +875,9 @@ function useResolvedComposerSignals(
   const attachments = useGet(
     draft ? draft.attachments$ : singletonAttachments$,
   );
+  const attachmentUploadSummary = useLoadable(
+    draft ? draft.attachmentUploadSummary$ : singletonAttachmentUploadSummary$,
+  );
   const canSendSingleton = useGet(singletonCanSend$);
   const canSend = draft
     ? input.trim() !== "" || attachments.length > 0
@@ -894,6 +905,7 @@ function useResolvedComposerSignals(
   return {
     canSend,
     attachments,
+    attachmentUploadSummary,
     uploadAttachment,
     restoreAttachments,
     removeAttachment,
@@ -1084,6 +1096,7 @@ export function ZeroChatComposer({
   const {
     canSend: draftCanSend,
     attachments,
+    attachmentUploadSummary,
     uploadAttachment,
     restoreAttachments,
     removeAttachment,
@@ -1105,6 +1118,10 @@ export function ZeroChatComposer({
     draftCanSend,
     input,
     visibleAttachmentCount: visibleAttachments.length,
+    uploadsReady:
+      attachmentUploadSummary.state === "hasData" &&
+      attachmentUploadSummary.data.readyCount ===
+        attachmentUploadSummary.data.attachmentCount,
   });
   const canSubmit = canSend && !submitBlocker;
 


### PR DESCRIPTION
## Summary

- show a toast when a web chat attachment upload fails and remove the failed attachment from the draft
- disable sending while selected attachments are still uploading so pending uploads cannot be silently omitted
- reject failed/null attachment resolution at send preparation as a race-condition guard
- update the attachment chip integration test to cover failed upload surfacing and removal

Closes #14349

## Test plan

- pnpm -C turbo -F @vm0/app exec vitest src/views/zero-page/__tests__/zero-attachment-chips.test.tsx --run
- pnpm -C turbo -F @vm0/app check-types
- pnpm -C turbo -F @vm0/app lint
- pre-commit: prettier, knip, turbo check-types

Note: after pulling latest main, local node_modules was missing @aws-sdk/client-kms; pnpm -C turbo install synced dependencies before the full pre-commit check passed.