### PR TITLE
fix: restore desktop workspace drag region

### DIFF
--- a/turbo/apps/platform/src/views/css/index.css
+++ b/turbo/apps/platform/src/views/css/index.css
@@ -51,6 +51,10 @@
   display: none;
 }
 
+.zero-workspace-titlebar-drag-region {
+  display: none;
+}
+
 .zero-desktop-no-drag {
   -webkit-app-region: no-drag;
 }
@@ -65,6 +69,37 @@
     flex-shrink: 0;
     height: var(--zero-desktop-titlebar-height);
     -webkit-app-region: drag;
+  }
+
+  .zero-app[data-desktop-shell] .zero-workspace-bg {
+    position: relative;
+  }
+
+  .zero-app[data-desktop-shell] .zero-workspace-titlebar-drag-region {
+    position: absolute;
+    inset: 0 0 auto;
+    z-index: 1;
+    display: block;
+    height: var(--zero-desktop-titlebar-height);
+    -webkit-app-region: drag;
+  }
+
+  .zero-app[data-desktop-shell]
+    .zero-workspace-bg
+    :where(
+      button,
+      a,
+      input,
+      textarea,
+      select,
+      [role="button"],
+      [role="link"],
+      [role="textbox"],
+      [contenteditable]:not([contenteditable="false"])
+    ) {
+    position: relative;
+    z-index: 2;
+    -webkit-app-region: no-drag;
   }
 }
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-layout.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-layout.test.tsx
@@ -240,6 +240,26 @@ describe("sidebar layout - desktop shell text selection scope (SIDEBAR-D-056)", 
         "data-desktop-shell",
       );
     });
+
+    expect(
+      screen.queryByTestId("workspace-titlebar-drag-region"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders a workspace titlebar drag region in desktop shell mode", async () => {
+    mockBaseAPIs();
+    Object.defineProperty(window, "vm0DesktopLocalAgent", {
+      configurable: true,
+      value: {},
+    });
+
+    detachedSetupPage({ context, path: "/" });
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("workspace-titlebar-drag-region"),
+      ).toBeInTheDocument();
+    });
   });
 
   it("syncs collapsed sidebar state to the desktop window chrome bridge", async () => {

--- a/turbo/apps/platform/src/views/zero-page/sidebar-layout.tsx
+++ b/turbo/apps/platform/src/views/zero-page/sidebar-layout.tsx
@@ -294,6 +294,13 @@ function SidebarLayoutInner({ children }: { children: ReactNode }) {
         }}
       />
       <div className="flex flex-1 flex-col min-w-0 min-h-0 zero-workspace-bg">
+        {isDesktopShell && (
+          <div
+            className="zero-workspace-titlebar-drag-region"
+            data-testid="workspace-titlebar-drag-region"
+            aria-hidden="true"
+          />
+        )}
         <InstallBanner />
         <IosInstallModal />
         <MobileTopBar />


### PR DESCRIPTION
## Summary
- add a desktop-only workspace titlebar drag layer from the shared Zero sidebar layout
- keep the layer out of regular web/PWA renders and active only under the desktop shell CSS scope
- keep workspace buttons, links, inputs, and textbox controls above the drag layer and marked as no-drag
- add sidebar layout coverage for desktop-only workspace drag region rendering

Fixes #14358.

## Validation
- git diff --check
- pnpm exec prettier --check apps/platform/src/views/css/index.css apps/platform/src/views/zero-page/sidebar-layout.tsx apps/platform/src/views/zero-page/__tests__/sidebar-layout.test.tsx
- pnpm -F @vm0/app lint
- pnpm -F @vm0/app check-types

## Local test note
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/sidebar-layout.test.tsx still fails locally because the page test harness renders an empty body for this file; this matches the existing local harness issue observed before this change, while CI has been running this file successfully.