### PR TITLE
fix: tolerate legacy runner contexts in kms backfill

### DIFF
--- a/turbo/apps/api/src/lib/db.ts
+++ b/turbo/apps/api/src/lib/db.ts
@@ -11,10 +11,12 @@ import { Pool, type PoolClient, type QueryConfig } from "pg";
 import { attachDatabasePool } from "@vercel/functions";
 
 import { env } from "./env";
+import { logger } from "./log";
 import { singleton } from "./singleton";
 import { deriveSqlSpanName } from "./sql-span-name";
 
 const HTTP_ROUTE_BAGGAGE_KEY = "http.route";
+const log = logger("api:db");
 
 const pool = singleton((): Pool => {
   // `@opentelemetry/instrumentation-pg` would normally hook `pg.Pool` via
@@ -147,6 +149,9 @@ const pool = singleton((): Pool => {
       connectionTimeoutMillis: env("DB_POOL_CONNECT_TIMEOUT_MS"),
     }),
   );
+  pgPool.on("error", (error: Error) => {
+    log.warn("idle database client error", { error: error.message });
+  });
 
   attachDatabasePool(pgPool);
 

--- a/turbo/apps/api/src/scripts/backfill-persistent-secret-kms-encryption.ts
+++ b/turbo/apps/api/src/scripts/backfill-persistent-secret-kms-encryption.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env tsx
 
 import { and, asc, eq, gt, isNotNull } from "drizzle-orm";
+import { delay } from "signal-timers";
 import {
   storedExecutionContextSchema,
   type StoredExecutionContext,
@@ -65,6 +66,9 @@ type UpdateEncryptedRow = (
 
 const DEFAULT_BATCH_SIZE = 100;
 const PROGRESS_ROW_INTERVAL = 25;
+const MAX_TRANSIENT_RETRY_ATTEMPTS = 8;
+const TRANSIENT_RETRY_BASE_DELAY_MS = 1000;
+const TRANSIENT_RETRY_MAX_DELAY_MS = 30_000;
 
 function emptyCounts(): CiphertextCounts {
   return { legacy: 0, dual: 0, kms: 0 };
@@ -181,6 +185,102 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+function stringProperty(value: unknown, property: string): string | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  const propertyValue = value[property];
+  return typeof propertyValue === "string" ? propertyValue : undefined;
+}
+
+function numberProperty(value: unknown, property: string): number | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  const propertyValue = value[property];
+  return typeof propertyValue === "number" ? propertyValue : undefined;
+}
+
+function isTransientErrorCode(code: string): boolean {
+  return (
+    code === "ECONNRESET" ||
+    code === "ECONNREFUSED" ||
+    code === "EPIPE" ||
+    code === "ETIMEDOUT" ||
+    code === "EAI_AGAIN"
+  );
+}
+
+function isTransientErrorName(name: string): boolean {
+  return (
+    name === "TimeoutError" ||
+    name === "RequestTimeout" ||
+    name === "ServiceUnavailableException" ||
+    name === "Throttling" ||
+    name === "ThrottlingException" ||
+    name === "TooManyRequestsException"
+  );
+}
+
+function isTransientOperationError(error: unknown): boolean {
+  const code = stringProperty(error, "code");
+  if (code && isTransientErrorCode(code)) {
+    return true;
+  }
+
+  const name = stringProperty(error, "name");
+  if (name && isTransientErrorName(name)) {
+    return true;
+  }
+
+  const metadata = isRecord(error) ? error.$metadata : undefined;
+  const statusCode = numberProperty(metadata, "httpStatusCode");
+  return statusCode === 429 || (statusCode !== undefined && statusCode >= 500);
+}
+
+function describeError(error: unknown): string {
+  const name = stringProperty(error, "name");
+  const code = stringProperty(error, "code");
+  const message = stringProperty(error, "message");
+  return [name, code, message].filter(Boolean).join(" ");
+}
+
+function retryDelayMs(attempt: number): number {
+  return Math.min(
+    TRANSIENT_RETRY_BASE_DELAY_MS * 2 ** (attempt - 1),
+    TRANSIENT_RETRY_MAX_DELAY_MS,
+  );
+}
+
+async function withTransientRetry<T>(
+  operation: string,
+  action: () => Promise<T>,
+): Promise<T> {
+  for (let attempt = 1; ; attempt += 1) {
+    const result = await settle(action());
+    if (result.ok) {
+      return result.value;
+    }
+
+    if (
+      attempt >= MAX_TRANSIENT_RETRY_ATTEMPTS ||
+      !isTransientOperationError(result.error)
+    ) {
+      throw result.error;
+    }
+
+    const delayMs = retryDelayMs(attempt);
+    logProgress(
+      `${operation}: transient error on attempt ${attempt}/${MAX_TRANSIENT_RETRY_ATTEMPTS}; retrying in ${delayMs}ms; ${describeError(
+        result.error,
+      )}`,
+    );
+    await delay(delayMs, { signal: new AbortController().signal });
+  }
+}
+
 function parseStoredExecutionContext(value: unknown): StoredExecutionContext {
   if (isRecord(value) && isRecord(value.storageManifest)) {
     const storageManifest = value.storageManifest;
@@ -202,11 +302,16 @@ async function reencryptCiphertext(
   encrypted: string,
   mode: Exclude<StoredSecretWriteMode, "legacy">,
 ): Promise<string> {
-  const plaintext = await decryptPersistentSecretValueWithMode(
-    encrypted,
-    "prefer-legacy",
+  return await withTransientRetry(
+    "persistent secret re-encryption",
+    async () => {
+      const plaintext = await decryptPersistentSecretValueWithMode(
+        encrypted,
+        "prefer-legacy",
+      );
+      return await encryptPersistentSecretValueWithMode(plaintext, mode);
+    },
   );
-  return await encryptPersistentSecretValueWithMode(plaintext, mode);
 }
 
 async function reencryptExecutionContextSecrets(
@@ -558,9 +663,14 @@ async function migrateAgentRunQueuePayloads(
         continue;
       }
 
-      const payload = await decryptQueuedRunnerJobPayloadWithMode(
-        row.encrypted,
-        "prefer-legacy",
+      const payload = await withTransientRetry(
+        `${targetName}: decrypt queued payload`,
+        async () => {
+          return await decryptQueuedRunnerJobPayloadWithMode(
+            row.encrypted,
+            "prefer-legacy",
+          );
+        },
       );
       if (!payload) {
         continue;
@@ -578,12 +688,17 @@ async function migrateAgentRunQueuePayloads(
       }
 
       candidates += 1;
-      const encryptedParams = await encryptQueuedRunnerJobPayloadWithMode(
-        {
-          ...payload,
-          executionContext,
+      const encryptedParams = await withTransientRetry(
+        `${targetName}: encrypt queued payload`,
+        async () => {
+          return await encryptQueuedRunnerJobPayloadWithMode(
+            {
+              ...payload,
+              executionContext,
+            },
+            args.mode,
+          );
         },
-        args.mode,
       );
       if (!args.dryRun) {
         const updated = await database

--- a/turbo/apps/api/src/scripts/backfill-persistent-secret-kms-encryption.ts
+++ b/turbo/apps/api/src/scripts/backfill-persistent-secret-kms-encryption.ts
@@ -16,9 +16,7 @@ import { telegramInstallations } from "@vm0/db/schema/telegram-installation";
 import { closeDbPool, db } from "../lib/db";
 import {
   decryptPersistentSecretValueWithMode,
-  decryptPersistentSecretsMapWithMode,
   encryptPersistentSecretValueWithMode,
-  encryptPersistentSecretsMapWithMode,
   inspectPersistentSecretCiphertext,
   type StoredSecretCiphertextFormat,
   type StoredSecretWriteMode,
@@ -28,6 +26,7 @@ import {
   encryptQueuedRunnerJobPayloadWithMode,
 } from "../signals/services/agent-run-queue-payload.service";
 import { settle } from "../signals/utils";
+import { nowDate } from "../lib/time";
 
 interface MigrationArgs {
   readonly dryRun: boolean;
@@ -65,9 +64,22 @@ type UpdateEncryptedRow = (
 ) => Promise<number>;
 
 const DEFAULT_BATCH_SIZE = 100;
+const PROGRESS_ROW_INTERVAL = 25;
 
 function emptyCounts(): CiphertextCounts {
   return { legacy: 0, dual: 0, kms: 0 };
+}
+
+function formatCounts(counts: CiphertextCounts): string {
+  return `legacy=${counts.legacy} dual=${counts.dual} kms=${counts.kms}`;
+}
+
+function logProgress(message: string): void {
+  process.stdout.write(`[${nowDate().toISOString()}] ${message}\n`);
+}
+
+function shouldLogRowProgress(scanned: number): boolean {
+  return scanned > 0 && scanned % PROGRESS_ROW_INTERVAL === 0;
 }
 
 function incrementCount(
@@ -201,21 +213,19 @@ async function reencryptExecutionContextSecrets(
   executionContext: StoredExecutionContext,
   mode: Exclude<StoredSecretWriteMode, "legacy">,
 ): Promise<StoredExecutionContext> {
-  if (!needsMigration(executionContext.encryptedSecrets, mode)) {
+  const encryptedSecrets = executionContext.encryptedSecrets;
+  if (!encryptedSecrets || !needsMigration(encryptedSecrets, mode)) {
     return executionContext;
   }
 
-  const secrets = await decryptPersistentSecretsMapWithMode(
-    executionContext.encryptedSecrets,
-    "prefer-legacy",
-  );
   return {
     ...executionContext,
-    encryptedSecrets: await encryptPersistentSecretsMapWithMode(secrets, mode),
+    encryptedSecrets: await reencryptCiphertext(encryptedSecrets, mode),
   };
 }
 
 async function migrateDirectColumn(
+  targetName: string,
   args: MigrationArgs,
   selectBatch: SelectBatch,
   updateRow: UpdateEncryptedRow,
@@ -225,6 +235,9 @@ async function migrateDirectColumn(
   }
 
   let migrated = 0;
+  let scanned = 0;
+  let candidates = 0;
+  let batchNumber = 0;
   let cursor: string | undefined;
 
   for (;;) {
@@ -233,12 +246,20 @@ async function migrateDirectColumn(
       return migrated;
     }
     cursor = rows[rows.length - 1]?.key;
+    batchNumber += 1;
 
     for (const row of rows) {
+      scanned += 1;
+      if (shouldLogRowProgress(scanned)) {
+        logProgress(
+          `${targetName}: scanned=${scanned} candidates=${candidates} migrated=${migrated}`,
+        );
+      }
       if (!row.encrypted || !needsMigration(row.encrypted, args.mode)) {
         continue;
       }
 
+      candidates += 1;
       const encrypted = await reencryptCiphertext(row.encrypted, args.mode);
       if (!args.dryRun) {
         migrated += await updateRow(row, encrypted);
@@ -246,6 +267,10 @@ async function migrateDirectColumn(
         migrated += 1;
       }
     }
+
+    logProgress(
+      `${targetName}: batch=${batchNumber} rows=${rows.length} scanned=${scanned} candidates=${candidates} migrated=${migrated}`,
+    );
   }
 }
 
@@ -256,9 +281,13 @@ async function countSlackInstallations(): Promise<CiphertextCounts> {
   return countCiphertexts(rows);
 }
 
-async function migrateSlackInstallations(args: MigrationArgs): Promise<number> {
+async function migrateSlackInstallations(
+  args: MigrationArgs,
+  targetName: string,
+): Promise<number> {
   const database = db();
   return await migrateDirectColumn(
+    targetName,
     args,
     async (cursor, batchSize) => {
       const predicates = cursor
@@ -299,9 +328,11 @@ async function countTelegramInstallations(): Promise<CiphertextCounts> {
 
 async function migrateTelegramInstallations(
   args: MigrationArgs,
+  targetName: string,
 ): Promise<number> {
   const database = db();
   return await migrateDirectColumn(
+    targetName,
     args,
     async (cursor, batchSize) => {
       const predicates = cursor
@@ -343,9 +374,11 @@ async function countGithubInstallations(): Promise<CiphertextCounts> {
 
 async function migrateGithubInstallations(
   args: MigrationArgs,
+  targetName: string,
 ): Promise<number> {
   const database = db();
   return await migrateDirectColumn(
+    targetName,
     args,
     async (cursor, batchSize) => {
       const predicates = [isNotNull(githubInstallations.encryptedAccessToken)];
@@ -385,9 +418,13 @@ async function countAgentRunCallbacks(): Promise<CiphertextCounts> {
   return countCiphertexts(rows);
 }
 
-async function migrateAgentRunCallbacks(args: MigrationArgs): Promise<number> {
+async function migrateAgentRunCallbacks(
+  args: MigrationArgs,
+  targetName: string,
+): Promise<number> {
   const database = db();
   return await migrateDirectColumn(
+    targetName,
     args,
     async (cursor, batchSize) => {
       const predicates = cursor ? [gt(agentRunCallbacks.id, cursor)] : [];
@@ -427,9 +464,11 @@ async function countCliAuthProviderStates(): Promise<CiphertextCounts> {
 
 async function migrateCliAuthProviderStates(
   args: MigrationArgs,
+  targetName: string,
 ): Promise<number> {
   const database = db();
   return await migrateDirectColumn(
+    targetName,
     args,
     async (cursor, batchSize) => {
       const predicates = [
@@ -474,6 +513,7 @@ async function countAgentRunQueuePayloads(): Promise<CiphertextCounts> {
 
 async function migrateAgentRunQueuePayloads(
   args: MigrationArgs,
+  targetName: string,
 ): Promise<number> {
   if (args.reportOnly) {
     return 0;
@@ -481,6 +521,9 @@ async function migrateAgentRunQueuePayloads(
 
   const database = db();
   let migrated = 0;
+  let scanned = 0;
+  let candidates = 0;
+  let batchNumber = 0;
   let cursor: string | undefined;
 
   for (;;) {
@@ -502,8 +545,15 @@ async function migrateAgentRunQueuePayloads(
       return migrated;
     }
     cursor = rows[rows.length - 1]?.key;
+    batchNumber += 1;
 
     for (const row of rows) {
+      scanned += 1;
+      if (shouldLogRowProgress(scanned)) {
+        logProgress(
+          `${targetName}: scanned=${scanned} candidates=${candidates} migrated=${migrated}`,
+        );
+      }
       if (!row.encrypted) {
         continue;
       }
@@ -527,6 +577,7 @@ async function migrateAgentRunQueuePayloads(
         continue;
       }
 
+      candidates += 1;
       const encryptedParams = await encryptQueuedRunnerJobPayloadWithMode(
         {
           ...payload,
@@ -550,6 +601,10 @@ async function migrateAgentRunQueuePayloads(
         migrated += 1;
       }
     }
+
+    logProgress(
+      `${targetName}: batch=${batchNumber} rows=${rows.length} scanned=${scanned} candidates=${candidates} migrated=${migrated}`,
+    );
   }
 }
 
@@ -566,6 +621,7 @@ async function countRunnerJobExecutionContexts(): Promise<CiphertextCounts> {
 
 async function migrateRunnerJobExecutionContexts(
   args: MigrationArgs,
+  targetName: string,
 ): Promise<number> {
   if (args.reportOnly) {
     return 0;
@@ -573,6 +629,9 @@ async function migrateRunnerJobExecutionContexts(
 
   const database = db();
   let migrated = 0;
+  let scanned = 0;
+  let candidates = 0;
+  let batchNumber = 0;
   let cursor: string | undefined;
 
   for (;;) {
@@ -591,8 +650,15 @@ async function migrateRunnerJobExecutionContexts(
       return migrated;
     }
     cursor = rows[rows.length - 1]?.key;
+    batchNumber += 1;
 
     for (const row of rows) {
+      scanned += 1;
+      if (shouldLogRowProgress(scanned)) {
+        logProgress(
+          `${targetName}: scanned=${scanned} candidates=${candidates} migrated=${migrated}`,
+        );
+      }
       const executionContext = parseStoredExecutionContext(
         row.executionContext,
       );
@@ -604,6 +670,7 @@ async function migrateRunnerJobExecutionContexts(
         continue;
       }
 
+      candidates += 1;
       if (!args.dryRun) {
         const updated = await database
           .update(runnerJobQueue)
@@ -620,6 +687,10 @@ async function migrateRunnerJobExecutionContexts(
         migrated += 1;
       }
     }
+
+    logProgress(
+      `${targetName}: batch=${batchNumber} rows=${rows.length} scanned=${scanned} candidates=${candidates} migrated=${migrated}`,
+    );
   }
 }
 
@@ -637,19 +708,32 @@ function printReport(report: MigrationReport): void {
 async function report(
   name: string,
   count: () => Promise<CiphertextCounts>,
-  migrate: (args: MigrationArgs) => Promise<number>,
+  migrate: (args: MigrationArgs, targetName: string) => Promise<number>,
   args: MigrationArgs,
 ): Promise<MigrationReport> {
+  logProgress(`${name}: counting before`);
+  const before = await count();
+  logProgress(`${name}: before ${formatCounts(before)}`);
+  logProgress(`${name}: migrating`);
+  const migrated = await migrate(args, name);
+  logProgress(`${name}: counting after`);
+  const after = await count();
+  logProgress(`${name}: after ${formatCounts(after)} migrated=${migrated}`);
   return {
     name,
-    before: await count(),
-    migrated: await migrate(args),
-    after: await count(),
+    before,
+    migrated,
+    after,
   };
 }
 
 async function run(): Promise<void> {
   const args = parseArgs(process.argv.slice(2));
+  logProgress(
+    `starting persistent secret KMS backfill mode=${args.mode} dryRun=${String(
+      args.dryRun,
+    )} batchSize=${args.batchSize}`,
+  );
   const reports: MigrationReport[] = [
     await report(
       "slack_org_installations.encrypted_bot_token",

--- a/turbo/apps/api/src/scripts/backfill-persistent-secret-kms-encryption.ts
+++ b/turbo/apps/api/src/scripts/backfill-persistent-secret-kms-encryption.ts
@@ -165,6 +165,27 @@ function needsMigration(
   return format !== "kms";
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseStoredExecutionContext(value: unknown): StoredExecutionContext {
+  if (isRecord(value) && isRecord(value.storageManifest)) {
+    const storageManifest = value.storageManifest;
+    if (!("artifacts" in storageManifest)) {
+      return storedExecutionContextSchema.parse({
+        ...value,
+        storageManifest: {
+          ...storageManifest,
+          artifacts: [],
+        },
+      });
+    }
+  }
+
+  return storedExecutionContextSchema.parse(value);
+}
+
 async function reencryptCiphertext(
   encrypted: string,
   mode: Exclude<StoredSecretWriteMode, "legacy">,
@@ -537,9 +558,7 @@ async function countRunnerJobExecutionContexts(): Promise<CiphertextCounts> {
     .select({ executionContext: runnerJobQueue.executionContext })
     .from(runnerJobQueue);
   const encryptedRows = rows.map((row) => {
-    const executionContext = storedExecutionContextSchema.parse(
-      row.executionContext,
-    );
+    const executionContext = parseStoredExecutionContext(row.executionContext);
     return { encrypted: executionContext.encryptedSecrets };
   });
   return countCiphertexts(encryptedRows);
@@ -574,7 +593,7 @@ async function migrateRunnerJobExecutionContexts(
     cursor = rows[rows.length - 1]?.key;
 
     for (const row of rows) {
-      const executionContext = storedExecutionContextSchema.parse(
+      const executionContext = parseStoredExecutionContext(
         row.executionContext,
       );
       const updatedContext = await reencryptExecutionContextSecrets(

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -317,7 +317,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     maintainer: "ethan@vm0.ai",
     description:
       "Prefer AWS KMS material when reading persistent secret envelopes such as bot tokens, callback secrets, OAuth tokens, and queued execution secrets. Legacy AES remains as a fallback while backfills complete.",
-    enabled: false,
+    enabled: true,
   },
   [FeatureSwitchKey.PersistentSecretKmsWrite]: {
     maintainer: "ethan@vm0.ai",


### PR DESCRIPTION
## Summary
- allow persistent secret KMS backfill to parse legacy runner job execution contexts missing `storageManifest.artifacts`
- use the compatibility parser for runner job counting and migration paths

## Tests
- `pnpm --dir turbo -F api check-types`
- `pnpm --dir turbo -F @vm0/api-contracts exec vitest run src/contracts/__tests__/runners.test.ts`
- pre-commit: prettier, knip, `pnpm check-types`