### PR TITLE
refactor: require oauth config for oauth connectors

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-search.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-search.test.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 
 import { zeroConnectorsSearchContract } from "@vm0/api-contracts/contracts/zero-connectors";
 import {
+  CONNECTOR_TYPE_KEYS,
   CONNECTOR_TYPES,
   type ConnectorType,
 } from "@vm0/connectors/connectors";
@@ -335,9 +336,7 @@ describe("GET /api/zero/connectors/search", () => {
       [200],
     );
 
-    const unflaggedTypes = (
-      Object.keys(CONNECTOR_TYPES) as ConnectorType[]
-    ).filter((type) => {
+    const unflaggedTypes = CONNECTOR_TYPE_KEYS.filter((type) => {
       return Object.values(CONNECTOR_TYPES[type].authMethods).some((method) => {
         return !method.featureFlag;
       });

--- a/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
@@ -21,6 +21,7 @@ import {
   isOAuthRefreshProvider,
 } from "@vm0/connectors/oauth-providers";
 import {
+  CONNECTOR_TYPE_KEYS,
   CONNECTOR_TYPES,
   connectorTypeSchema,
   type ConnectorAuthMethodType,
@@ -1089,7 +1090,7 @@ export function zeroConnectorSearch(args: {
       overrides,
     });
     const keyword = args.keyword?.toLowerCase();
-    return (Object.keys(CONNECTOR_TYPES) as ConnectorType[]).flatMap((type) => {
+    return CONNECTOR_TYPE_KEYS.flatMap((type) => {
       const config = CONNECTOR_TYPES[type];
       const authMethods: ConnectorSearchAuthMethod[] =
         getAvailableConnectorAuthMethods(type, featureStates, {

--- a/turbo/apps/cli/src/commands/zero/connector/status.ts
+++ b/turbo/apps/cli/src/commands/zero/connector/status.ts
@@ -2,7 +2,6 @@ import { Command } from "commander";
 import chalk from "chalk";
 import {
   CONNECTOR_TYPE_KEYS,
-  CONNECTOR_TYPES,
   type ConnectorType,
   connectorTypeSchema,
 } from "@vm0/connectors/connectors";

--- a/turbo/apps/cli/src/commands/zero/connector/status.ts
+++ b/turbo/apps/cli/src/commands/zero/connector/status.ts
@@ -1,6 +1,7 @@
 import { Command } from "commander";
 import chalk from "chalk";
 import {
+  CONNECTOR_TYPE_KEYS,
   CONNECTOR_TYPES,
   type ConnectorType,
   connectorTypeSchema,
@@ -157,7 +158,7 @@ export const statusCommand = new Command()
     withErrorHandler(async (type: string, options: { agent?: string }) => {
       const parseResult = connectorTypeSchema.safeParse(type);
       if (!parseResult.success) {
-        const available = Object.keys(CONNECTOR_TYPES).join(", ");
+        const available = CONNECTOR_TYPE_KEYS.join(", ");
         throw new Error(`Unknown connector type: ${type}`, {
           cause: new Error(`Available connectors: ${available}`),
         });

--- a/turbo/apps/cli/src/commands/zero/doctor/check-connector.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/check-connector.ts
@@ -1,5 +1,6 @@
 import { Command, Option } from "commander";
 import {
+  CONNECTOR_TYPE_KEYS,
   CONNECTOR_TYPES,
   type ConnectorType,
 } from "@vm0/connectors/connectors";
@@ -54,7 +55,7 @@ interface UrlLookupResult {
  * starts with any registered base URL (scheme + host + optional path prefix).
  */
 function resolveConnectorFromUrl(url: string): UrlLookupResult | null {
-  const allTypes = Object.keys(CONNECTOR_TYPES) as ConnectorType[];
+  const allTypes = CONNECTOR_TYPE_KEYS;
 
   // Normalize: strip trailing slash for comparison
   const normalized = url.endsWith("/") ? url.slice(0, -1) : url;

--- a/turbo/apps/cli/src/commands/zero/doctor/generate.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/generate.ts
@@ -6,6 +6,7 @@ import {
   type ConnectorGenerationType,
   type ConnectorType,
 } from "@vm0/connectors/connectors";
+import { getConnectorGenerationTypes } from "@vm0/connectors/connector-utils";
 import type { ConnectorListResponse } from "@vm0/api-contracts/contracts/connector-schemas";
 import { getZeroAgentUserConnectors } from "../../../lib/api/domains/zero-agents";
 import { listZeroConnectors } from "../../../lib/api/domains/zero-connectors";
@@ -255,8 +256,8 @@ function getBuiltInCommand(
 
 function getAvailableGenerationTypes(): DoctorGenerationType[] {
   const available = new Set<ConnectorGenerationType>();
-  for (const config of Object.values(CONNECTOR_TYPES)) {
-    for (const generationType of config.generation ?? []) {
+  for (const type of Object.keys(CONNECTOR_TYPES) as ConnectorType[]) {
+    for (const generationType of getConnectorGenerationTypes(type)) {
       available.add(generationType);
     }
   }
@@ -286,8 +287,8 @@ function getGenerationConnectors(
   return (
     Object.entries(CONNECTOR_TYPES) as Array<[ConnectorType, ConnectorConfig]>
   )
-    .filter(([, config]) => {
-      return config.generation?.includes(generationType) === true;
+    .filter(([type]) => {
+      return getConnectorGenerationTypes(type).includes(generationType);
     })
     .sort(([a], [b]) => {
       return a.localeCompare(b);

--- a/turbo/apps/cli/src/commands/zero/doctor/generate.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/generate.ts
@@ -1,6 +1,7 @@
 import { Command } from "commander";
 import chalk from "chalk";
 import {
+  CONNECTOR_TYPE_KEYS,
   CONNECTOR_TYPES,
   type ConnectorConfig,
   type ConnectorGenerationType,
@@ -256,7 +257,7 @@ function getBuiltInCommand(
 
 function getAvailableGenerationTypes(): DoctorGenerationType[] {
   const available = new Set<ConnectorGenerationType>();
-  for (const type of Object.keys(CONNECTOR_TYPES) as ConnectorType[]) {
+  for (const type of CONNECTOR_TYPE_KEYS) {
     for (const generationType of getConnectorGenerationTypes(type)) {
       available.add(generationType);
     }
@@ -284,9 +285,9 @@ function parseGenerationType(value: string): DoctorGenerationType {
 function getGenerationConnectors(
   generationType: ConnectorGenerationType,
 ): Array<[ConnectorType, ConnectorConfig]> {
-  return (
-    Object.entries(CONNECTOR_TYPES) as Array<[ConnectorType, ConnectorConfig]>
-  )
+  return CONNECTOR_TYPE_KEYS.map((type): [ConnectorType, ConnectorConfig] => {
+    return [type, CONNECTOR_TYPES[type]];
+  })
     .filter(([type]) => {
       return getConnectorGenerationTypes(type).includes(generationType);
     })

--- a/turbo/apps/cli/src/mocks/handlers/api-handlers.ts
+++ b/turbo/apps/cli/src/mocks/handlers/api-handlers.ts
@@ -2,7 +2,6 @@ import { http, HttpResponse } from "msw";
 import {
   CONNECTOR_TYPE_KEYS,
   CONNECTOR_TYPES,
-  type ConnectorType,
 } from "@vm0/connectors/connectors";
 import { getAvailableConnectorAuthMethods } from "@vm0/connectors/connector-utils";
 

--- a/turbo/apps/cli/src/mocks/handlers/api-handlers.ts
+++ b/turbo/apps/cli/src/mocks/handlers/api-handlers.ts
@@ -1,16 +1,16 @@
 import { http, HttpResponse } from "msw";
 import {
+  CONNECTOR_TYPE_KEYS,
   CONNECTOR_TYPES,
   type ConnectorType,
 } from "@vm0/connectors/connectors";
 import { getAvailableConnectorAuthMethods } from "@vm0/connectors/connector-utils";
 
 function defaultAvailableConnectors() {
-  return (Object.keys(CONNECTOR_TYPES) as ConnectorType[])
-    .map((type) => {
-      const authMethods = getAvailableConnectorAuthMethods(type, {});
-      return { type, authMethods };
-    })
+  return CONNECTOR_TYPE_KEYS.map((type) => {
+    const authMethods = getAvailableConnectorAuthMethods(type, {});
+    return { type, authMethods };
+  })
     .filter((item) => {
       return item.authMethods.length > 0;
     })

--- a/turbo/apps/platform/src/mocks/handlers/api-connectors.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-connectors.ts
@@ -8,8 +8,6 @@ import {
 import { zeroCliAuthStripeContract } from "@vm0/api-contracts/contracts/zero-connectors-cli-auth-stripe";
 import { mockApi } from "../msw-contract.ts";
 
-const ALL_CONNECTOR_TYPES = CONNECTOR_TYPE_KEYS;
-
 let mockConnectors: ConnectorResponse[] = [];
 
 type MockStripeCliAuthStartResponse = {
@@ -104,7 +102,7 @@ export const apiConnectorsHandlers = [
   mockApi(zeroConnectorsMainContract.list, ({ respond }) => {
     return respond(200, {
       connectors: mockConnectors,
-      configuredTypes: ALL_CONNECTOR_TYPES,
+      configuredTypes: [...CONNECTOR_TYPE_KEYS],
       connectorProvidedSecretNames: [],
     });
   }),

--- a/turbo/apps/platform/src/mocks/handlers/api-connectors.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-connectors.ts
@@ -1,7 +1,4 @@
-import {
-  CONNECTOR_TYPES,
-  type ConnectorType,
-} from "@vm0/connectors/connectors";
+import { CONNECTOR_TYPE_KEYS } from "@vm0/connectors/connectors";
 import type { ConnectorResponse } from "@vm0/api-contracts/contracts/connector-schemas";
 import {
   zeroConnectorsByTypeContract,
@@ -11,7 +8,7 @@ import {
 import { zeroCliAuthStripeContract } from "@vm0/api-contracts/contracts/zero-connectors-cli-auth-stripe";
 import { mockApi } from "../msw-contract.ts";
 
-const ALL_CONNECTOR_TYPES = Object.keys(CONNECTOR_TYPES) as ConnectorType[];
+const ALL_CONNECTOR_TYPES = CONNECTOR_TYPE_KEYS;
 
 let mockConnectors: ConnectorResponse[] = [];
 

--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -3,6 +3,7 @@ import { delay } from "signal-timers";
 import { toast } from "@vm0/ui/components/ui/sonner";
 import { accept } from "../../../lib/accept.ts";
 import {
+  CONNECTOR_TYPE_KEYS,
   CONNECTOR_TYPES,
   type ConnectorAuthMethodType,
   type ConnectorBrowserVerificationCliAuthConnectorType,
@@ -350,25 +351,23 @@ export const allConnectorTypes$ = computed(async (get) => {
     localBrowserHostList.hosts,
   );
 
-  const items = (Object.keys(CONNECTOR_TYPES) as ConnectorType[])
-    .filter((type) => {
-      return (
-        getAvailableConnectorAuthMethods(type, features, {
-          apiAuthMethodPolicy: {
-            includeForTypes: CONNECTOR_LIST_API_AUTH_METHOD_TYPES,
-          },
-        }).length > 0
-      );
-    })
-    .map((type) => {
-      return buildConnectorTypeStatus({
-        type,
-        connector: connectorMap.get(type) ?? null,
-        features,
-        localAgentOnlineHosts,
-        localBrowserOnlineHosts,
-      });
+  const items = CONNECTOR_TYPE_KEYS.filter((type) => {
+    return (
+      getAvailableConnectorAuthMethods(type, features, {
+        apiAuthMethodPolicy: {
+          includeForTypes: CONNECTOR_LIST_API_AUTH_METHOD_TYPES,
+        },
+      }).length > 0
+    );
+  }).map((type) => {
+    return buildConnectorTypeStatus({
+      type,
+      connector: connectorMap.get(type) ?? null,
+      features,
+      localAgentOnlineHosts,
+      localBrowserOnlineHosts,
     });
+  });
 
   // Sort connected connectors to the top of the list
   items.sort((a, b) => {

--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -15,6 +15,7 @@ import {
   getAvailableConnectorAuthMethods,
   getConnectorAuthMethod,
   getConnectorCliAuthModes,
+  getConnectorTags,
   hasRequiredScopes,
 } from "@vm0/connectors/connector-utils";
 import {
@@ -266,7 +267,7 @@ function buildConnectorTypeStatus(params: {
         : config.label,
     helpText: config.helpText,
     category: config.category,
-    tags: config.tags ?? [],
+    tags: getConnectorTags(params.type),
     connected,
     connector: params.connector,
     availableAuthMethods,

--- a/turbo/apps/platform/src/views/internal-connector-logos.tsx
+++ b/turbo/apps/platform/src/views/internal-connector-logos.tsx
@@ -1,6 +1,6 @@
 import {
+  CONNECTOR_TYPE_KEYS,
   CONNECTOR_TYPES,
-  type ConnectorType,
 } from "@vm0/connectors/connectors";
 import { useGet, useSet } from "ccstate-react";
 import { CONNECTOR_ICONS } from "./zero-page/components/settings/connector-icons.tsx";
@@ -76,7 +76,7 @@ export function InternalConnectorLogos() {
   const size = useGet(iconSize$);
   const sizes = useGet(iconSizes$);
   const setSize = useSet(setIconSize$);
-  const connectorTypes = Object.keys(CONNECTOR_TYPES) as ConnectorType[];
+  const connectorTypes = CONNECTOR_TYPE_KEYS;
 
   return (
     <div style={{ padding: 32, fontFamily: "monospace", background: "#fff" }}>

--- a/turbo/apps/platform/src/views/org/__tests__/org-misc-components.test.tsx
+++ b/turbo/apps/platform/src/views/org/__tests__/org-misc-components.test.tsx
@@ -15,8 +15,8 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
 import {
+  CONNECTOR_TYPE_KEYS,
   CONNECTOR_TYPES,
-  type ConnectorType,
 } from "@vm0/connectors/connectors";
 import {
   type ScheduleResponse,
@@ -60,7 +60,7 @@ describe("internal connector logos - display (ORG-D-118)", () => {
     "lists all connector types with labels and type identifiers",
     async () => {
       detachedSetupPage({ context, path: "/__internal-connector-logos" });
-      const connectorTypes = Object.keys(CONNECTOR_TYPES) as ConnectorType[];
+      const connectorTypes = CONNECTOR_TYPE_KEYS;
       // Verify at least one connector type and its label appears in the document
       // (labels and type keys may appear multiple times due to icon display variants).
       await waitFor(() => {
@@ -86,7 +86,7 @@ describe("internal connector logos - display (ORG-D-119)", () => {
     "heading displays the count of connector types",
     async () => {
       detachedSetupPage({ context, path: "/__internal-connector-logos" });
-      const connectorTypes = Object.keys(CONNECTOR_TYPES);
+      const connectorTypes = CONNECTOR_TYPE_KEYS;
       await waitFor(() => {
         expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent(
           connectorTypes.length.toString(),

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-directed-connect-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-directed-connect-page.test.tsx
@@ -13,6 +13,7 @@ import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { detachedSetupPage, click } from "../../../__tests__/page-helper.ts";
 import {
+  CONNECTOR_TYPE_KEYS,
   CONNECTOR_TYPES,
   type ConnectorType,
 } from "@vm0/connectors/connectors";
@@ -230,9 +231,7 @@ describe("directed connect page", () => {
 
   it("opens api-token dialog for a connector without oauth", async () => {
     // Find a connector type that only has api-token auth
-    const apiTokenOnlyType = (
-      Object.keys(CONNECTOR_TYPES) as ConnectorType[]
-    ).find((type) => {
+    const apiTokenOnlyType = CONNECTOR_TYPE_KEYS.find((type) => {
       const methods = CONNECTOR_TYPES[type].authMethods;
       return "api-token" in methods && !("oauth" in methods);
     });

--- a/turbo/apps/platform/src/views/zero-page/components/settings/connector-icons.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/connector-icons.tsx
@@ -1,5 +1,5 @@
 import {
-  CONNECTOR_TYPES,
+  CONNECTOR_TYPE_KEYS,
   type ConnectorType,
 } from "@vm0/connectors/connectors";
 import { cn } from "@vm0/ui";
@@ -26,7 +26,7 @@ export const CONNECTOR_ICONS: Readonly<Record<ConnectorType, string>> =
         }),
       );
 
-      const connectorKeys = Object.keys(CONNECTOR_TYPES) as ConnectorType[];
+      const connectorKeys = CONNECTOR_TYPE_KEYS;
       const filtered: Record<string, string> = {};
       for (const key of connectorKeys) {
         const iconKey =

--- a/turbo/apps/platform/src/views/zero-page/zero-onboarding.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-onboarding.tsx
@@ -15,7 +15,10 @@ import {
   CONNECTOR_TYPES,
   type ConnectorType,
 } from "@vm0/connectors/connectors";
-import { isGoogleOAuthConnector } from "@vm0/connectors/connector-utils";
+import {
+  getConnectorTags,
+  isGoogleOAuthConnector,
+} from "@vm0/connectors/connector-utils";
 import { ConnectorIcon } from "./components/settings/connector-icons.tsx";
 import {
   zeroWorkspaceName$,
@@ -159,7 +162,7 @@ function SelectConnectorsContent() {
       label: config.label,
       type,
       helpText: config.helpText,
-      tags: config.tags,
+      tags: getConnectorTags(type),
     });
   });
 

--- a/turbo/apps/platform/src/views/zero-page/zero-onboarding.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-onboarding.tsx
@@ -12,6 +12,7 @@ import { AvatarSvgPreview } from "./avatar-svg-preview.tsx";
 import zeroAnimatedSrc from "./assets/zero-animated.webp";
 import { Button, Input } from "@vm0/ui";
 import {
+  CONNECTOR_TYPE_KEYS,
   CONNECTOR_TYPES,
   type ConnectorType,
 } from "@vm0/connectors/connectors";
@@ -152,10 +153,9 @@ function SelectConnectorsContent() {
   const search = useGet(connectorSearch$);
   const setSearch = useSet(setConnectorSearch$);
 
-  const connectorEntries = Object.entries(CONNECTOR_TYPES) as [
-    ConnectorType,
-    (typeof CONNECTOR_TYPES)[ConnectorType],
-  ][];
+  const connectorEntries = CONNECTOR_TYPE_KEYS.map((type) => {
+    return [type, CONNECTOR_TYPES[type]] as const;
+  });
 
   const filtered = connectorEntries.filter(([type, config]) => {
     return matchesConnectorSearch(search, {
@@ -250,12 +250,9 @@ function ConnectStepContent() {
       }),
   );
 
-  const selectedEntries = (
-    Object.entries(CONNECTOR_TYPES) as [
-      ConnectorType,
-      (typeof CONNECTOR_TYPES)[ConnectorType],
-    ][]
-  ).filter(([type]) => {
+  const selectedEntries = CONNECTOR_TYPE_KEYS.map((type) => {
+    return [type, CONNECTOR_TYPES[type]] as const;
+  }).filter(([type]) => {
     return effectiveConnectors.includes(type);
   });
 
@@ -526,12 +523,9 @@ function OrbitIllustration() {
   const selectedConnectors =
     useLastResolved(onboardingEffectiveConnectors$) ?? [];
 
-  const entries = (
-    Object.entries(CONNECTOR_TYPES) as [
-      ConnectorType,
-      (typeof CONNECTOR_TYPES)[ConnectorType],
-    ][]
-  ).filter(([type]) => {
+  const entries = CONNECTOR_TYPE_KEYS.map((type) => {
+    return [type, CONNECTOR_TYPES[type]] as const;
+  }).filter(([type]) => {
     return selectedConnectors.includes(type);
   });
 

--- a/turbo/packages/connectors/src/connector-utils.ts
+++ b/turbo/packages/connectors/src/connector-utils.ts
@@ -7,9 +7,11 @@ import {
   type ConnectorCliAuthConfig,
   type ConnectorCliAuthFlow,
   type ConnectorConfig,
+  type ConnectorGenerationType,
   type ConnectorOAuthClientConfig,
   type ConnectorOAuthConfig,
   type ConnectorType,
+  type OAuthConnectorType,
 } from "./connectors";
 import type { FeatureSwitchKey } from "./feature-switch-key";
 
@@ -51,7 +53,8 @@ export function getConnectorAuthMethod(
 function getConnectorCliAuthConfig(
   type: ConnectorType,
 ): ConnectorCliAuthConfig | undefined {
-  return CONNECTOR_TYPES[type].cliAuth;
+  const config = CONNECTOR_TYPES[type];
+  return "cliAuth" in config ? config.cliAuth : undefined;
 }
 
 /**
@@ -76,6 +79,18 @@ function getConnectorDefaultAuthMethod(
   type: ConnectorType,
 ): ConnectorAuthMethodType | undefined {
   return CONNECTOR_TYPES[type].defaultAuthMethod;
+}
+
+export function getConnectorGenerationTypes(
+  type: ConnectorType,
+): readonly ConnectorGenerationType[] {
+  const config = CONNECTOR_TYPES[type];
+  return "generation" in config ? (config.generation ?? []) : [];
+}
+
+export function getConnectorTags(type: ConnectorType): readonly string[] {
+  const config = CONNECTOR_TYPES[type];
+  return "tags" in config ? (config.tags ?? []) : [];
 }
 
 export type ConnectorFeatureStates =
@@ -397,6 +412,12 @@ export function getConnectorOAuthConfig(
 ): ConnectorOAuthConfig | undefined {
   const config = CONNECTOR_TYPES[type];
   return "oauth" in config ? config.oauth : undefined;
+}
+
+export function getOAuthConnectorConfig(
+  type: OAuthConnectorType,
+): ConnectorOAuthConfig {
+  return CONNECTOR_TYPES[type].oauth;
 }
 
 /**

--- a/turbo/packages/connectors/src/connector-utils.ts
+++ b/turbo/packages/connectors/src/connector-utils.ts
@@ -1,5 +1,6 @@
 import {
   CONNECTOR_AUTH_METHOD_TYPES,
+  CONNECTOR_TYPE_KEYS,
   CONNECTOR_TYPES,
   connectorTypeSchema,
   type ConnectorAuthMethodConfig,
@@ -271,7 +272,7 @@ export function getRuntimeAvailableConnectorTypes(
 ): ConnectorType[] {
   const runtimeAvailable = new Set<ConnectorType>();
 
-  for (const type of Object.keys(CONNECTOR_TYPES) as ConnectorType[]) {
+  for (const type of CONNECTOR_TYPE_KEYS) {
     const defaultAuthMethod = getConnectorDefaultAuthMethod(type);
     if (
       hasConfiguredOAuth(readEnv, type) ||
@@ -316,15 +317,12 @@ export function getConnectorEnvironmentMapping(
  * include connectors with at least one always-available connection flow.
  */
 export function getEligibleConnectorTypes(): string[] {
-  return Object.entries(CONNECTOR_TYPES)
-    .filter(([, config]) => {
-      return Object.values(config.authMethods).some((method) => {
-        return !method.featureFlag;
-      });
-    })
-    .map(([type]) => {
-      return type;
+  return CONNECTOR_TYPE_KEYS.filter((type) => {
+    const config = CONNECTOR_TYPES[type];
+    return Object.values(config.authMethods).some((method) => {
+      return !method.featureFlag;
     });
+  });
 }
 
 /**
@@ -338,7 +336,7 @@ export function getEligibleConnectorTypes(): string[] {
 export function getConnectorDerivedNames(
   secretName: string,
 ): { connectorLabel: string; envVarNames: string[] } | null {
-  const allTypes = Object.keys(CONNECTOR_TYPES) as ConnectorType[];
+  const allTypes = CONNECTOR_TYPE_KEYS;
 
   for (const type of allTypes) {
     const config = CONNECTOR_TYPES[type];
@@ -521,7 +519,7 @@ export function getConnectorManagedSecretNames(
 export function getConnectorTypeForSecretName(
   name: string,
 ): ConnectorType | null {
-  const allTypes = Object.keys(CONNECTOR_TYPES) as ConnectorType[];
+  const allTypes = CONNECTOR_TYPE_KEYS;
   for (const type of allTypes) {
     const config = CONNECTOR_TYPES[type];
     // Check authMethods secrets
@@ -585,7 +583,7 @@ export function deriveApiTokenConnectedTypes(
   userSecretNames: Set<string>,
   userVariableNames?: Set<string>,
 ): ConnectorType[] {
-  const allTypes = Object.keys(CONNECTOR_TYPES) as ConnectorType[];
+  const allTypes = CONNECTOR_TYPE_KEYS;
   const connected: ConnectorType[] = [];
   const varNames = userVariableNames ?? new Set<string>();
 
@@ -793,7 +791,7 @@ export function searchConnectors(
   const keywordTokens = tokenize(trimmed);
 
   const hits: ConnectorSearchResult[] = [];
-  for (const type of Object.keys(CONNECTOR_TYPES) as ConnectorType[]) {
+  for (const type of CONNECTOR_TYPE_KEYS) {
     if (filter && !filter(type)) continue;
     const config = CONNECTOR_TYPES[type];
     const hit = scoreConnector(keywordLower, keywordTokens, type, config);

--- a/turbo/packages/connectors/src/connectors.ts
+++ b/turbo/packages/connectors/src/connectors.ts
@@ -762,8 +762,7 @@ export type ConnectorBrowserVerificationCliAuthConnectorType = {
 }[ConnectorCliAuthConnectorType];
 
 export const CONNECTOR_TYPES = CONNECTOR_TYPES_DEF;
-export const CONNECTOR_TYPE_KEYS = Object.keys(CONNECTOR_TYPES_DEF) as [
-  ConnectorType,
-  ...ConnectorType[],
-];
+export const CONNECTOR_TYPE_KEYS = Object.freeze(
+  Object.keys(CONNECTOR_TYPES_DEF),
+) as readonly [ConnectorType, ...ConnectorType[]];
 export const connectorTypeSchema = z.enum(CONNECTOR_TYPE_KEYS);

--- a/turbo/packages/connectors/src/connectors.ts
+++ b/turbo/packages/connectors/src/connectors.ts
@@ -464,18 +464,23 @@ export const CONNECTOR_DISPLAY_CATEGORY_ORDER: readonly ConnectorDisplayCategory
     "data-automation-infrastructure",
   ];
 
-/**
- * Base configuration shape for all connector types.
- */
-export interface ConnectorConfig {
+type ConnectorAuthMethodsBase = Partial<
+  Record<Exclude<ConnectorAuthMethodType, "oauth">, ConnectorAuthMethodConfig>
+>;
+
+type ConnectorAuthMethodsWithOAuth = ConnectorAuthMethodsBase & {
+  readonly oauth: ConnectorAuthMethodConfig;
+};
+
+type ConnectorAuthMethodsWithoutOAuth = ConnectorAuthMethodsBase & {
+  readonly oauth?: never;
+};
+
+type ConnectorConfigBase = {
   readonly label: string;
   readonly helpText: string;
   readonly category: ConnectorDisplayCategory;
-  readonly authMethods: Partial<
-    Record<ConnectorAuthMethodType, ConnectorAuthMethodConfig>
-  >;
   readonly defaultAuthMethod?: ConnectorAuthMethodType;
-  readonly oauth?: ConnectorOAuthConfig;
   readonly cliAuth?: ConnectorCliAuthConfig;
   /** Environment mapping declaring which env vars this connector provides. */
   readonly environmentMapping: Record<string, string>;
@@ -490,7 +495,20 @@ export interface ConnectorConfig {
    * `environmentMapping` keys, or `authMethods[*].secrets` keys.
    */
   readonly tags?: readonly string[];
-}
+};
+
+/**
+ * Base configuration shape for all connector types.
+ */
+export type ConnectorConfig =
+  | (ConnectorConfigBase & {
+      readonly authMethods: ConnectorAuthMethodsWithOAuth;
+      readonly oauth: ConnectorOAuthConfig;
+    })
+  | (ConnectorConfigBase & {
+      readonly authMethods: ConnectorAuthMethodsWithoutOAuth;
+      readonly oauth?: never;
+    });
 
 /**
  * Connector type configuration
@@ -743,8 +761,7 @@ export type ConnectorBrowserVerificationCliAuthConnectorType = {
     : never;
 }[ConnectorCliAuthConnectorType];
 
-export const CONNECTOR_TYPES: Record<ConnectorType, ConnectorConfig> =
-  CONNECTOR_TYPES_DEF;
+export const CONNECTOR_TYPES = CONNECTOR_TYPES_DEF;
 export const connectorTypeSchema = z.enum(
   Object.keys(CONNECTOR_TYPES_DEF) as [ConnectorType, ...ConnectorType[]],
 );

--- a/turbo/packages/connectors/src/connectors.ts
+++ b/turbo/packages/connectors/src/connectors.ts
@@ -762,6 +762,8 @@ export type ConnectorBrowserVerificationCliAuthConnectorType = {
 }[ConnectorCliAuthConnectorType];
 
 export const CONNECTOR_TYPES = CONNECTOR_TYPES_DEF;
-export const connectorTypeSchema = z.enum(
-  Object.keys(CONNECTOR_TYPES_DEF) as [ConnectorType, ...ConnectorType[]],
-);
+export const CONNECTOR_TYPE_KEYS = Object.keys(CONNECTOR_TYPES_DEF) as [
+  ConnectorType,
+  ...ConnectorType[],
+];
+export const connectorTypeSchema = z.enum(CONNECTOR_TYPE_KEYS);

--- a/turbo/packages/connectors/src/oauth-providers/providers/ahrefs.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/ahrefs.ts
@@ -1,4 +1,4 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
+import { getOAuthConnectorConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -33,11 +33,7 @@ export function buildAhrefsAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): string {
-  const oauthConfig = getConnectorOAuthConfig("ahrefs");
-  if (!oauthConfig) {
-    throw new Error("Ahrefs OAuth config not found");
-  }
-
+  const oauthConfig = getOAuthConnectorConfig("ahrefs");
   const params = new URLSearchParams({
     client_id: clientId,
     redirect_uri: redirectUri,
@@ -58,11 +54,7 @@ export async function exchangeAhrefsCode(
   code: string,
   redirectUri: string,
 ): Promise<AhrefsTokenResult> {
-  const oauthConfig = getConnectorOAuthConfig("ahrefs");
-  if (!oauthConfig) {
-    throw new Error("Ahrefs OAuth config not found");
-  }
-
+  const oauthConfig = getOAuthConnectorConfig("ahrefs");
   const response = await fetch(oauthConfig.tokenUrl, {
     method: "POST",
     headers: {
@@ -121,11 +113,7 @@ export async function refreshAhrefsToken(
   clientSecret: string,
   refreshToken: string,
 ): Promise<AhrefsRefreshResult> {
-  const oauthConfig = getConnectorOAuthConfig("ahrefs");
-  if (!oauthConfig) {
-    throw new Error("Ahrefs OAuth config not found");
-  }
-
+  const oauthConfig = getOAuthConnectorConfig("ahrefs");
   const response = await fetch(oauthConfig.tokenUrl, {
     method: "POST",
     headers: {

--- a/turbo/packages/connectors/src/oauth-providers/providers/airtable.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/airtable.ts
@@ -1,4 +1,4 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
+import { getOAuthConnectorConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -58,11 +58,7 @@ export async function buildAirtableAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): Promise<{ url: string; codeVerifier: string }> {
-  const oauthConfig = getConnectorOAuthConfig("airtable");
-  if (!oauthConfig) {
-    throw new Error("Airtable OAuth config not found");
-  }
-
+  const oauthConfig = getOAuthConnectorConfig("airtable");
   const codeVerifier = generateCodeVerifier();
   const codeChallenge = await computeCodeChallenge(codeVerifier);
 
@@ -93,11 +89,7 @@ export async function exchangeAirtableCode(
   redirectUri: string,
   codeVerifier?: string,
 ): Promise<AirtableTokenResult> {
-  const oauthConfig = getConnectorOAuthConfig("airtable");
-  if (!oauthConfig) {
-    throw new Error("Airtable OAuth config not found");
-  }
-
+  const oauthConfig = getOAuthConnectorConfig("airtable");
   if (!codeVerifier) {
     throw new Error("Airtable requires PKCE code_verifier for token exchange");
   }
@@ -162,11 +154,7 @@ export async function refreshAirtableToken(
   clientSecret: string,
   refreshToken: string,
 ): Promise<AirtableRefreshResult> {
-  const oauthConfig = getConnectorOAuthConfig("airtable");
-  if (!oauthConfig) {
-    throw new Error("Airtable OAuth config not found");
-  }
-
+  const oauthConfig = getOAuthConnectorConfig("airtable");
   const basicAuth = btoa(`${clientId}:${clientSecret}`);
 
   const response = await fetch(oauthConfig.tokenUrl, {

--- a/turbo/packages/connectors/src/oauth-providers/providers/asana.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/asana.ts
@@ -1,4 +1,4 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
+import { getOAuthConnectorConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -30,11 +30,7 @@ export function buildAsanaAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): string {
-  const oauthConfig = getConnectorOAuthConfig("asana");
-  if (!oauthConfig) {
-    throw new Error("Asana OAuth config not found");
-  }
-
+  const oauthConfig = getOAuthConnectorConfig("asana");
   const params = new URLSearchParams({
     client_id: clientId,
     redirect_uri: redirectUri,
@@ -55,11 +51,7 @@ export async function exchangeAsanaCode(
   code: string,
   redirectUri: string,
 ): Promise<AsanaTokenResult> {
-  const oauthConfig = getConnectorOAuthConfig("asana");
-  if (!oauthConfig) {
-    throw new Error("Asana OAuth config not found");
-  }
-
+  const oauthConfig = getOAuthConnectorConfig("asana");
   const response = await fetch(oauthConfig.tokenUrl, {
     method: "POST",
     headers: {
@@ -166,11 +158,7 @@ export async function refreshAsanaToken(
   clientSecret: string,
   refreshToken: string,
 ): Promise<AsanaRefreshResult> {
-  const oauthConfig = getConnectorOAuthConfig("asana");
-  if (!oauthConfig) {
-    throw new Error("Asana OAuth config not found");
-  }
-
+  const oauthConfig = getOAuthConnectorConfig("asana");
   const response = await fetch(oauthConfig.tokenUrl, {
     method: "POST",
     headers: {

--- a/turbo/packages/connectors/src/oauth-providers/providers/canva.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/canva.ts
@@ -1,4 +1,4 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
+import { getOAuthConnectorConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -66,11 +66,7 @@ export async function buildCanvaAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): Promise<string> {
-  const oauthConfig = getConnectorOAuthConfig("canva");
-  if (!oauthConfig) {
-    throw new Error("Canva OAuth config not found");
-  }
-
+  const oauthConfig = getOAuthConnectorConfig("canva");
   const codeVerifier = await deriveCodeVerifier(state);
   const codeChallenge = await computeCodeChallenge(codeVerifier);
 
@@ -97,11 +93,7 @@ export async function refreshCanvaToken(
   clientSecret: string,
   refreshToken: string,
 ): Promise<CanvaRefreshResult> {
-  const oauthConfig = getConnectorOAuthConfig("canva");
-  if (!oauthConfig) {
-    throw new Error("Canva OAuth config not found");
-  }
-
+  const oauthConfig = getOAuthConnectorConfig("canva");
   const credentials = Buffer.from(`${clientId}:${clientSecret}`).toString(
     "base64",
   );
@@ -157,11 +149,7 @@ export async function exchangeCanvaCode(
   redirectUri: string,
   state: string,
 ): Promise<CanvaTokenResult> {
-  const oauthConfig = getConnectorOAuthConfig("canva");
-  if (!oauthConfig) {
-    throw new Error("Canva OAuth config not found");
-  }
-
+  const oauthConfig = getOAuthConnectorConfig("canva");
   const codeVerifier = await deriveCodeVerifier(state);
   const credentials = Buffer.from(`${clientId}:${clientSecret}`).toString(
     "base64",

--- a/turbo/packages/connectors/src/oauth-providers/providers/close.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/close.ts
@@ -1,4 +1,4 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
+import { getOAuthConnectorConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -30,11 +30,7 @@ export function buildCloseAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): string {
-  const oauthConfig = getConnectorOAuthConfig("close");
-  if (!oauthConfig) {
-    throw new Error("Close OAuth config not found");
-  }
-
+  const oauthConfig = getOAuthConnectorConfig("close");
   const params = new URLSearchParams({
     client_id: clientId,
     redirect_uri: redirectUri,
@@ -54,11 +50,7 @@ export async function exchangeCloseCode(
   code: string,
   redirectUri: string,
 ): Promise<CloseTokenResult> {
-  const oauthConfig = getConnectorOAuthConfig("close");
-  if (!oauthConfig) {
-    throw new Error("Close OAuth config not found");
-  }
-
+  const oauthConfig = getOAuthConnectorConfig("close");
   const response = await fetch(oauthConfig.tokenUrl, {
     method: "POST",
     headers: {
@@ -122,11 +114,7 @@ export async function refreshCloseToken(
   clientSecret: string,
   refreshToken: string,
 ): Promise<CloseRefreshResult> {
-  const oauthConfig = getConnectorOAuthConfig("close");
-  if (!oauthConfig) {
-    throw new Error("Close OAuth config not found");
-  }
-
+  const oauthConfig = getOAuthConnectorConfig("close");
   const response = await fetch(oauthConfig.tokenUrl, {
     method: "POST",
     headers: {

--- a/turbo/packages/connectors/src/oauth-providers/providers/deel.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/deel.ts
@@ -1,4 +1,4 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
+import { getOAuthConnectorConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -65,11 +65,7 @@ export async function buildDeelAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): Promise<string> {
-  const oauthConfig = getConnectorOAuthConfig("deel");
-  if (!oauthConfig) {
-    throw new Error("Deel OAuth config not found");
-  }
-
+  const oauthConfig = getOAuthConnectorConfig("deel");
   const codeVerifier = await deriveCodeVerifier(state);
   const codeChallenge = await computeCodeChallenge(codeVerifier);
 
@@ -97,11 +93,7 @@ export async function refreshDeelToken(
   clientSecret: string,
   refreshToken: string,
 ): Promise<DeelRefreshResult> {
-  const oauthConfig = getConnectorOAuthConfig("deel");
-  if (!oauthConfig) {
-    throw new Error("Deel OAuth config not found");
-  }
-
+  const oauthConfig = getOAuthConnectorConfig("deel");
   const credentials = Buffer.from(`${clientId}:${clientSecret}`).toString(
     "base64",
   );
@@ -157,11 +149,7 @@ export async function exchangeDeelCode(
   redirectUri: string,
   state: string,
 ): Promise<DeelTokenResult> {
-  const oauthConfig = getConnectorOAuthConfig("deel");
-  if (!oauthConfig) {
-    throw new Error("Deel OAuth config not found");
-  }
-
+  const oauthConfig = getOAuthConnectorConfig("deel");
   const codeVerifier = await deriveCodeVerifier(state);
   const credentials = Buffer.from(`${clientId}:${clientSecret}`).toString(
     "base64",

--- a/turbo/packages/connectors/src/oauth-providers/providers/docusign.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/docusign.ts
@@ -1,4 +1,4 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
+import { getOAuthConnectorConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -65,11 +65,7 @@ export async function buildDocuSignAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): Promise<string> {
-  const oauthConfig = getConnectorOAuthConfig("docusign");
-  if (!oauthConfig) {
-    throw new Error("DocuSign OAuth config not found");
-  }
-
+  const oauthConfig = getOAuthConnectorConfig("docusign");
   const codeVerifier = await deriveCodeVerifier(state);
   const codeChallenge = await computeCodeChallenge(codeVerifier);
 
@@ -97,11 +93,7 @@ export async function exchangeDocuSignCode(
   redirectUri: string,
   state: string,
 ): Promise<DocuSignTokenResult> {
-  const oauthConfig = getConnectorOAuthConfig("docusign");
-  if (!oauthConfig) {
-    throw new Error("DocuSign OAuth config not found");
-  }
-
+  const oauthConfig = getOAuthConnectorConfig("docusign");
   const codeVerifier = await deriveCodeVerifier(state);
   const basicAuth = Buffer.from(`${clientId}:${clientSecret}`).toString(
     "base64",
@@ -166,11 +158,7 @@ export async function refreshDocuSignToken(
   clientSecret: string,
   refreshToken: string,
 ): Promise<DocuSignRefreshResult> {
-  const oauthConfig = getConnectorOAuthConfig("docusign");
-  if (!oauthConfig) {
-    throw new Error("DocuSign OAuth config not found");
-  }
-
+  const oauthConfig = getOAuthConnectorConfig("docusign");
   const basicAuth = Buffer.from(`${clientId}:${clientSecret}`).toString(
     "base64",
   );

--- a/turbo/packages/connectors/src/oauth-providers/providers/dropbox.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/dropbox.ts
@@ -1,4 +1,4 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
+import { getOAuthConnectorConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -34,11 +34,7 @@ export function buildDropboxAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): string {
-  const oauthConfig = getConnectorOAuthConfig("dropbox");
-  if (!oauthConfig) {
-    throw new Error("Dropbox OAuth config not found");
-  }
-
+  const oauthConfig = getOAuthConnectorConfig("dropbox");
   const params = new URLSearchParams({
     client_id: clientId,
     redirect_uri: redirectUri,
@@ -61,11 +57,7 @@ export async function exchangeDropboxCode(
   code: string,
   redirectUri: string,
 ): Promise<DropboxTokenResult> {
-  const oauthConfig = getConnectorOAuthConfig("dropbox");
-  if (!oauthConfig) {
-    throw new Error("Dropbox OAuth config not found");
-  }
-
+  const oauthConfig = getOAuthConnectorConfig("dropbox");
   const response = await fetch(oauthConfig.tokenUrl, {
     method: "POST",
     headers: {
@@ -124,11 +116,7 @@ export async function refreshDropboxToken(
   clientSecret: string,
   refreshToken: string,
 ): Promise<DropboxRefreshResult> {
-  const oauthConfig = getConnectorOAuthConfig("dropbox");
-  if (!oauthConfig) {
-    throw new Error("Dropbox OAuth config not found");
-  }
-
+  const oauthConfig = getOAuthConnectorConfig("dropbox");
   const response = await fetch(oauthConfig.tokenUrl, {
     method: "POST",
     headers: {

--- a/turbo/packages/connectors/src/oauth-providers/providers/figma.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/figma.ts
@@ -1,4 +1,4 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
+import { getOAuthConnectorConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -32,11 +32,7 @@ export function buildFigmaAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): string {
-  const oauthConfig = getConnectorOAuthConfig("figma");
-  if (!oauthConfig) {
-    throw new Error("Figma OAuth config not found");
-  }
-
+  const oauthConfig = getOAuthConnectorConfig("figma");
   const params = new URLSearchParams({
     client_id: clientId,
     redirect_uri: redirectUri,
@@ -58,11 +54,7 @@ export async function exchangeFigmaCode(
   code: string,
   redirectUri: string,
 ): Promise<FigmaTokenResult> {
-  const oauthConfig = getConnectorOAuthConfig("figma");
-  if (!oauthConfig) {
-    throw new Error("Figma OAuth config not found");
-  }
-
+  const oauthConfig = getOAuthConnectorConfig("figma");
   const credentials = Buffer.from(`${clientId}:${clientSecret}`).toString(
     "base64",
   );
@@ -124,11 +116,7 @@ export async function refreshFigmaToken(
   clientSecret: string,
   refreshToken: string,
 ): Promise<FigmaRefreshResult> {
-  const oauthConfig = getConnectorOAuthConfig("figma");
-  if (!oauthConfig) {
-    throw new Error("Figma OAuth config not found");
-  }
-
+  const oauthConfig = getOAuthConnectorConfig("figma");
   const credentials = Buffer.from(`${clientId}:${clientSecret}`).toString(
     "base64",
   );

--- a/turbo/packages/connectors/src/oauth-providers/providers/garmin-connect.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/garmin-connect.ts
@@ -1,4 +1,4 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
+import { getOAuthConnectorConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -67,11 +67,7 @@ export async function buildGarminConnectAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): Promise<string> {
-  const oauthConfig = getConnectorOAuthConfig("garmin-connect");
-  if (!oauthConfig) {
-    throw new Error("Garmin Connect OAuth config not found");
-  }
-
+  const oauthConfig = getOAuthConnectorConfig("garmin-connect");
   const codeVerifier = await deriveCodeVerifier(state);
   const codeChallenge = await computeCodeChallenge(codeVerifier);
 
@@ -96,11 +92,7 @@ export async function exchangeGarminConnectCode(
   code: string,
   state: string,
 ): Promise<GarminConnectTokenResult> {
-  const oauthConfig = getConnectorOAuthConfig("garmin-connect");
-  if (!oauthConfig) {
-    throw new Error("Garmin Connect OAuth config not found");
-  }
-
+  const oauthConfig = getOAuthConnectorConfig("garmin-connect");
   const codeVerifier = await deriveCodeVerifier(state);
 
   const response = await fetch(oauthConfig.tokenUrl, {
@@ -162,11 +154,7 @@ export async function refreshGarminConnectToken(
   clientSecret: string,
   refreshToken: string,
 ): Promise<GarminConnectRefreshResult> {
-  const oauthConfig = getConnectorOAuthConfig("garmin-connect");
-  if (!oauthConfig) {
-    throw new Error("Garmin Connect OAuth config not found");
-  }
-
+  const oauthConfig = getOAuthConnectorConfig("garmin-connect");
   const response = await fetch(oauthConfig.tokenUrl, {
     method: "POST",
     headers: {

--- a/turbo/packages/connectors/src/oauth-providers/providers/github.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/github.ts
@@ -1,4 +1,4 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
+import { getOAuthConnectorConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -18,11 +18,7 @@ export function buildGitHubAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): string {
-  const oauthConfig = getConnectorOAuthConfig("github");
-  if (!oauthConfig) {
-    throw new Error("GitHub OAuth config not found");
-  }
-
+  const oauthConfig = getOAuthConnectorConfig("github");
   const params = new URLSearchParams({
     client_id: clientId,
     redirect_uri: redirectUri,
@@ -42,11 +38,7 @@ export async function exchangeGitHubCode(
   code: string,
   redirectUri: string,
 ): Promise<{ accessToken: string; scopes: string[] }> {
-  const oauthConfig = getConnectorOAuthConfig("github");
-  if (!oauthConfig) {
-    throw new Error("GitHub OAuth config not found");
-  }
-
+  const oauthConfig = getOAuthConnectorConfig("github");
   const response = await fetch(oauthConfig.tokenUrl, {
     method: "POST",
     headers: {

--- a/turbo/packages/connectors/src/oauth-providers/providers/gmail.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/gmail.ts
@@ -1,4 +1,4 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
+import { getOAuthConnectorConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -28,11 +28,7 @@ export function buildGmailAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): string {
-  const oauthConfig = getConnectorOAuthConfig("gmail");
-  if (!oauthConfig) {
-    throw new Error("Gmail OAuth config not found");
-  }
-
+  const oauthConfig = getOAuthConnectorConfig("gmail");
   const params = new URLSearchParams({
     client_id: clientId,
     redirect_uri: redirectUri,
@@ -56,11 +52,7 @@ export async function exchangeGmailCode(
   code: string,
   redirectUri: string,
 ): Promise<GmailTokenResult> {
-  const oauthConfig = getConnectorOAuthConfig("gmail");
-  if (!oauthConfig) {
-    throw new Error("Gmail OAuth config not found");
-  }
-
+  const oauthConfig = getOAuthConnectorConfig("gmail");
   const response = await fetch(oauthConfig.tokenUrl, {
     method: "POST",
     headers: {

--- a/turbo/packages/connectors/src/oauth-providers/providers/google-oauth.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/google-oauth.ts
@@ -1,9 +1,20 @@
-import type { ConnectorType } from "@vm0/connectors/connectors";
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
+import type { OAuthConnectorType } from "@vm0/connectors/connectors";
+import { getOAuthConnectorConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
 const GOOGLE_USERINFO_URL = "https://www.googleapis.com/oauth2/v2/userinfo";
+
+type GoogleOAuthConnectorType = Extract<
+  OAuthConnectorType,
+  | "gmail"
+  | "google-ads"
+  | "google-calendar"
+  | "google-docs"
+  | "google-drive"
+  | "google-meet"
+  | "google-sheets"
+>;
 
 interface GoogleUserInfo {
   id: string;
@@ -30,16 +41,12 @@ interface GoogleRefreshResult {
  * Requests offline access to obtain a refresh token.
  */
 export function buildGoogleAuthorizationUrl(
-  connectorType: ConnectorType,
+  connectorType: GoogleOAuthConnectorType,
   clientId: string,
   redirectUri: string,
   state: string,
 ): string {
-  const oauthConfig = getConnectorOAuthConfig(connectorType);
-  if (!oauthConfig) {
-    throw new Error(`${connectorType} OAuth config not found`);
-  }
-
+  const oauthConfig = getOAuthConnectorConfig(connectorType);
   const params = new URLSearchParams({
     client_id: clientId,
     redirect_uri: redirectUri,
@@ -58,17 +65,13 @@ export function buildGoogleAuthorizationUrl(
  * Uses the Google userinfo endpoint to identify the user.
  */
 export async function exchangeGoogleOAuthCode(
-  connectorType: ConnectorType,
+  connectorType: GoogleOAuthConnectorType,
   clientId: string,
   clientSecret: string,
   code: string,
   redirectUri: string,
 ): Promise<GoogleTokenResult> {
-  const oauthConfig = getConnectorOAuthConfig(connectorType);
-  if (!oauthConfig) {
-    throw new Error(`${connectorType} OAuth config not found`);
-  }
-
+  const oauthConfig = getOAuthConnectorConfig(connectorType);
   const response = await fetch(oauthConfig.tokenUrl, {
     method: "POST",
     headers: {
@@ -124,16 +127,12 @@ export async function exchangeGoogleOAuthCode(
  * Access token expires_in: 3600s (1 hour). Ref: https://developers.google.com/identity/protocols/oauth2/web-server
  */
 export async function refreshGoogleToken(
-  connectorType: ConnectorType,
+  connectorType: GoogleOAuthConnectorType,
   clientId: string,
   clientSecret: string,
   refreshToken: string,
 ): Promise<GoogleRefreshResult> {
-  const oauthConfig = getConnectorOAuthConfig(connectorType);
-  if (!oauthConfig) {
-    throw new Error(`${connectorType} OAuth config not found`);
-  }
-
+  const oauthConfig = getOAuthConnectorConfig(connectorType);
   const response = await fetch(oauthConfig.tokenUrl, {
     method: "POST",
     headers: {

--- a/turbo/packages/connectors/src/oauth-providers/providers/gumroad.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/gumroad.ts
@@ -1,4 +1,4 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
+import { getOAuthConnectorConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -29,11 +29,7 @@ export function buildGumroadAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): string {
-  const oauthConfig = getConnectorOAuthConfig("gumroad");
-  if (!oauthConfig) {
-    throw new Error("Gumroad OAuth config not found");
-  }
-
+  const oauthConfig = getOAuthConnectorConfig("gumroad");
   const params = new URLSearchParams({
     client_id: clientId,
     redirect_uri: redirectUri,
@@ -51,11 +47,7 @@ export async function exchangeGumroadCode(
   code: string,
   redirectUri: string,
 ): Promise<GumroadTokenResult> {
-  const oauthConfig = getConnectorOAuthConfig("gumroad");
-  if (!oauthConfig) {
-    throw new Error("Gumroad OAuth config not found");
-  }
-
+  const oauthConfig = getOAuthConnectorConfig("gumroad");
   const response = await fetch(oauthConfig.tokenUrl, {
     method: "POST",
     headers: {
@@ -109,11 +101,7 @@ export async function refreshGumroadToken(
   clientSecret: string,
   refreshToken: string,
 ): Promise<GumroadRefreshResult> {
-  const oauthConfig = getConnectorOAuthConfig("gumroad");
-  if (!oauthConfig) {
-    throw new Error("Gumroad OAuth config not found");
-  }
-
+  const oauthConfig = getOAuthConnectorConfig("gumroad");
   const response = await fetch(oauthConfig.tokenUrl, {
     method: "POST",
     headers: {

--- a/turbo/packages/connectors/src/oauth-providers/providers/hubspot.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/hubspot.ts
@@ -1,4 +1,4 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
+import { getOAuthConnectorConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -32,11 +32,7 @@ export function buildHubSpotAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): string {
-  const oauthConfig = getConnectorOAuthConfig("hubspot");
-  if (!oauthConfig) {
-    throw new Error("HubSpot OAuth config not found");
-  }
-
+  const oauthConfig = getOAuthConnectorConfig("hubspot");
   const params = new URLSearchParams({
     client_id: clientId,
     redirect_uri: redirectUri,
@@ -56,11 +52,7 @@ export async function exchangeHubSpotCode(
   code: string,
   redirectUri: string,
 ): Promise<HubSpotTokenResult> {
-  const oauthConfig = getConnectorOAuthConfig("hubspot");
-  if (!oauthConfig) {
-    throw new Error("HubSpot OAuth config not found");
-  }
-
+  const oauthConfig = getOAuthConnectorConfig("hubspot");
   const response = await fetch(oauthConfig.tokenUrl, {
     method: "POST",
     headers: {
@@ -117,11 +109,7 @@ export async function refreshHubSpotToken(
   clientSecret: string,
   refreshToken: string,
 ): Promise<HubSpotRefreshResult> {
-  const oauthConfig = getConnectorOAuthConfig("hubspot");
-  if (!oauthConfig) {
-    throw new Error("HubSpot OAuth config not found");
-  }
-
+  const oauthConfig = getOAuthConnectorConfig("hubspot");
   const response = await fetch(oauthConfig.tokenUrl, {
     method: "POST",
     headers: {

--- a/turbo/packages/connectors/src/oauth-providers/providers/intervals-icu.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/intervals-icu.ts
@@ -1,4 +1,4 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
+import { getOAuthConnectorConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -21,11 +21,7 @@ export function buildIntervalsIcuAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): string {
-  const oauthConfig = getConnectorOAuthConfig("intervals-icu");
-  if (!oauthConfig) {
-    throw new Error("Intervals.icu OAuth config not found");
-  }
-
+  const oauthConfig = getOAuthConnectorConfig("intervals-icu");
   const params = new URLSearchParams({
     client_id: clientId,
     redirect_uri: redirectUri,
@@ -47,11 +43,7 @@ export async function exchangeIntervalsIcuCode(
   clientSecret: string,
   code: string,
 ): Promise<IntervalsIcuTokenResult> {
-  const oauthConfig = getConnectorOAuthConfig("intervals-icu");
-  if (!oauthConfig) {
-    throw new Error("Intervals.icu OAuth config not found");
-  }
-
+  const oauthConfig = getOAuthConnectorConfig("intervals-icu");
   const response = await fetch(oauthConfig.tokenUrl, {
     method: "POST",
     headers: {

--- a/turbo/packages/connectors/src/oauth-providers/providers/linear.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/linear.ts
@@ -1,4 +1,4 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
+import { getOAuthConnectorConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -34,11 +34,7 @@ export function buildLinearAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): string {
-  const oauthConfig = getConnectorOAuthConfig("linear");
-  if (!oauthConfig) {
-    throw new Error("Linear OAuth config not found");
-  }
-
+  const oauthConfig = getOAuthConnectorConfig("linear");
   const params = new URLSearchParams({
     client_id: clientId,
     redirect_uri: redirectUri,
@@ -62,11 +58,7 @@ export async function exchangeLinearCode(
   code: string,
   redirectUri: string,
 ): Promise<LinearTokenResult> {
-  const oauthConfig = getConnectorOAuthConfig("linear");
-  if (!oauthConfig) {
-    throw new Error("Linear OAuth config not found");
-  }
-
+  const oauthConfig = getOAuthConnectorConfig("linear");
   const response = await fetch(oauthConfig.tokenUrl, {
     method: "POST",
     headers: {
@@ -125,11 +117,7 @@ export async function refreshLinearToken(
   clientSecret: string,
   refreshToken: string,
 ): Promise<LinearRefreshResult> {
-  const oauthConfig = getConnectorOAuthConfig("linear");
-  if (!oauthConfig) {
-    throw new Error("Linear OAuth config not found");
-  }
-
+  const oauthConfig = getOAuthConnectorConfig("linear");
   const response = await fetch(oauthConfig.tokenUrl, {
     method: "POST",
     headers: {

--- a/turbo/packages/connectors/src/oauth-providers/providers/mailchimp.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/mailchimp.ts
@@ -1,4 +1,4 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
+import { getOAuthConnectorConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -24,11 +24,7 @@ export function buildMailchimpAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): string {
-  const oauthConfig = getConnectorOAuthConfig("mailchimp");
-  if (!oauthConfig) {
-    throw new Error("Mailchimp OAuth config not found");
-  }
-
+  const oauthConfig = getOAuthConnectorConfig("mailchimp");
   const params = new URLSearchParams({
     response_type: "code",
     client_id: clientId,
@@ -49,11 +45,7 @@ export async function exchangeMailchimpCode(
   code: string,
   redirectUri: string,
 ): Promise<MailchimpTokenResult> {
-  const oauthConfig = getConnectorOAuthConfig("mailchimp");
-  if (!oauthConfig) {
-    throw new Error("Mailchimp OAuth config not found");
-  }
-
+  const oauthConfig = getOAuthConnectorConfig("mailchimp");
   const response = await fetch(oauthConfig.tokenUrl, {
     method: "POST",
     headers: {

--- a/turbo/packages/connectors/src/oauth-providers/providers/mercury.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/mercury.ts
@@ -1,4 +1,4 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
+import { getOAuthConnectorConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -33,11 +33,7 @@ export function buildMercuryAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): string {
-  const oauthConfig = getConnectorOAuthConfig("mercury");
-  if (!oauthConfig) {
-    throw new Error("Mercury OAuth config not found");
-  }
-
+  const oauthConfig = getOAuthConnectorConfig("mercury");
   const params = new URLSearchParams({
     client_id: clientId,
     redirect_uri: redirectUri,
@@ -58,11 +54,7 @@ export async function exchangeMercuryCode(
   code: string,
   redirectUri: string,
 ): Promise<MercuryTokenResult> {
-  const oauthConfig = getConnectorOAuthConfig("mercury");
-  if (!oauthConfig) {
-    throw new Error("Mercury OAuth config not found");
-  }
-
+  const oauthConfig = getOAuthConnectorConfig("mercury");
   const response = await fetch(oauthConfig.tokenUrl, {
     method: "POST",
     headers: {
@@ -121,11 +113,7 @@ export async function refreshMercuryToken(
   clientSecret: string,
   refreshToken: string,
 ): Promise<MercuryRefreshResult> {
-  const oauthConfig = getConnectorOAuthConfig("mercury");
-  if (!oauthConfig) {
-    throw new Error("Mercury OAuth config not found");
-  }
-
+  const oauthConfig = getOAuthConnectorConfig("mercury");
   const response = await fetch(oauthConfig.tokenUrl, {
     method: "POST",
     headers: {

--- a/turbo/packages/connectors/src/oauth-providers/providers/meta-ads.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/meta-ads.ts
@@ -1,4 +1,4 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
+import { getOAuthConnectorConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -27,11 +27,7 @@ export function buildMetaAdsAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): string {
-  const oauthConfig = getConnectorOAuthConfig("meta-ads");
-  if (!oauthConfig) {
-    throw new Error("Meta Ads OAuth config not found");
-  }
-
+  const oauthConfig = getOAuthConnectorConfig("meta-ads");
   const params = new URLSearchParams({
     client_id: clientId,
     redirect_uri: redirectUri,
@@ -53,11 +49,7 @@ export async function exchangeMetaAdsCode(
   code: string,
   redirectUri: string,
 ): Promise<MetaAdsTokenResult> {
-  const oauthConfig = getConnectorOAuthConfig("meta-ads");
-  if (!oauthConfig) {
-    throw new Error("Meta Ads OAuth config not found");
-  }
-
+  const oauthConfig = getOAuthConnectorConfig("meta-ads");
   // Step 1: Exchange code for short-lived token
   const response = await fetch(oauthConfig.tokenUrl, {
     method: "POST",

--- a/turbo/packages/connectors/src/oauth-providers/providers/microsoft-oauth.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/microsoft-oauth.ts
@@ -1,9 +1,14 @@
-import type { ConnectorType } from "@vm0/connectors/connectors";
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
+import type { OAuthConnectorType } from "@vm0/connectors/connectors";
+import { getOAuthConnectorConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
 const MICROSOFT_USERINFO_URL = "https://graph.microsoft.com/v1.0/me";
+
+type MicrosoftOAuthConnectorType = Extract<
+  OAuthConnectorType,
+  "outlook-calendar" | "outlook-mail"
+>;
 
 interface MicrosoftUserInfo {
   id: string;
@@ -30,16 +35,12 @@ interface MicrosoftRefreshResult {
  * Requests offline access to obtain a refresh token.
  */
 export function buildMicrosoftAuthorizationUrl(
-  connectorType: ConnectorType,
+  connectorType: MicrosoftOAuthConnectorType,
   clientId: string,
   redirectUri: string,
   state: string,
 ): string {
-  const oauthConfig = getConnectorOAuthConfig(connectorType);
-  if (!oauthConfig) {
-    throw new Error(`${connectorType} OAuth config not found`);
-  }
-
+  const oauthConfig = getOAuthConnectorConfig(connectorType);
   const params = new URLSearchParams({
     client_id: clientId,
     redirect_uri: redirectUri,
@@ -57,17 +58,13 @@ export function buildMicrosoftAuthorizationUrl(
  * Uses the Microsoft Graph /me endpoint to identify the user.
  */
 export async function exchangeMicrosoftOAuthCode(
-  connectorType: ConnectorType,
+  connectorType: MicrosoftOAuthConnectorType,
   clientId: string,
   clientSecret: string,
   code: string,
   redirectUri: string,
 ): Promise<MicrosoftTokenResult> {
-  const oauthConfig = getConnectorOAuthConfig(connectorType);
-  if (!oauthConfig) {
-    throw new Error(`${connectorType} OAuth config not found`);
-  }
-
+  const oauthConfig = getOAuthConnectorConfig(connectorType);
   const response = await fetch(oauthConfig.tokenUrl, {
     method: "POST",
     headers: {
@@ -123,16 +120,12 @@ export async function exchangeMicrosoftOAuthCode(
  * Access token expires_in: 3600-5400s (~75 min). Ref: https://learn.microsoft.com/en-us/entra/identity-platform/v2-oauth2-auth-code-flow
  */
 export async function refreshMicrosoftToken(
-  connectorType: ConnectorType,
+  connectorType: MicrosoftOAuthConnectorType,
   clientId: string,
   clientSecret: string,
   refreshToken: string,
 ): Promise<MicrosoftRefreshResult> {
-  const oauthConfig = getConnectorOAuthConfig(connectorType);
-  if (!oauthConfig) {
-    throw new Error(`${connectorType} OAuth config not found`);
-  }
-
+  const oauthConfig = getOAuthConnectorConfig(connectorType);
   const response = await fetch(oauthConfig.tokenUrl, {
     method: "POST",
     headers: {

--- a/turbo/packages/connectors/src/oauth-providers/providers/monday.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/monday.ts
@@ -1,4 +1,4 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
+import { getOAuthConnectorConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -32,11 +32,7 @@ export function buildMondayAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): string {
-  const oauthConfig = getConnectorOAuthConfig("monday");
-  if (!oauthConfig) {
-    throw new Error("Monday.com OAuth config not found");
-  }
-
+  const oauthConfig = getOAuthConnectorConfig("monday");
   const params = new URLSearchParams({
     client_id: clientId,
     redirect_uri: redirectUri,
@@ -58,11 +54,7 @@ export async function exchangeMondayCode(
   code: string,
   redirectUri: string,
 ): Promise<MondayTokenResult> {
-  const oauthConfig = getConnectorOAuthConfig("monday");
-  if (!oauthConfig) {
-    throw new Error("Monday.com OAuth config not found");
-  }
-
+  const oauthConfig = getOAuthConnectorConfig("monday");
   const response = await fetch(oauthConfig.tokenUrl, {
     method: "POST",
     headers: {
@@ -120,11 +112,7 @@ export async function refreshMondayToken(
   clientSecret: string,
   refreshToken: string,
 ): Promise<MondayRefreshResult> {
-  const oauthConfig = getConnectorOAuthConfig("monday");
-  if (!oauthConfig) {
-    throw new Error("Monday.com OAuth config not found");
-  }
-
+  const oauthConfig = getOAuthConnectorConfig("monday");
   const response = await fetch(oauthConfig.tokenUrl, {
     method: "POST",
     headers: {

--- a/turbo/packages/connectors/src/oauth-providers/providers/neon.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/neon.ts
@@ -1,4 +1,4 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
+import { getOAuthConnectorConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -33,11 +33,7 @@ export function buildNeonAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): string {
-  const oauthConfig = getConnectorOAuthConfig("neon");
-  if (!oauthConfig) {
-    throw new Error("Neon OAuth config not found");
-  }
-
+  const oauthConfig = getOAuthConnectorConfig("neon");
   const params = new URLSearchParams({
     client_id: clientId,
     response_type: "code",
@@ -59,11 +55,7 @@ export async function exchangeNeonCode(
   code: string,
   redirectUri: string,
 ): Promise<NeonTokenResult> {
-  const oauthConfig = getConnectorOAuthConfig("neon");
-  if (!oauthConfig) {
-    throw new Error("Neon OAuth config not found");
-  }
-
+  const oauthConfig = getOAuthConnectorConfig("neon");
   const response = await fetch(oauthConfig.tokenUrl, {
     method: "POST",
     headers: {
@@ -122,11 +114,7 @@ export async function refreshNeonToken(
   clientSecret: string,
   refreshToken: string,
 ): Promise<NeonRefreshResult> {
-  const oauthConfig = getConnectorOAuthConfig("neon");
-  if (!oauthConfig) {
-    throw new Error("Neon OAuth config not found");
-  }
-
+  const oauthConfig = getOAuthConnectorConfig("neon");
   const response = await fetch(oauthConfig.tokenUrl, {
     method: "POST",
     headers: {

--- a/turbo/packages/connectors/src/oauth-providers/providers/notion.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/notion.ts
@@ -1,4 +1,4 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
+import { getOAuthConnectorConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -37,11 +37,7 @@ export function buildNotionAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): string {
-  const oauthConfig = getConnectorOAuthConfig("notion");
-  if (!oauthConfig) {
-    throw new Error("Notion OAuth config not found");
-  }
-
+  const oauthConfig = getOAuthConnectorConfig("notion");
   const params = new URLSearchParams({
     client_id: clientId,
     redirect_uri: redirectUri,
@@ -64,11 +60,7 @@ export async function exchangeNotionCode(
   code: string,
   redirectUri: string,
 ): Promise<NotionTokenResult> {
-  const oauthConfig = getConnectorOAuthConfig("notion");
-  if (!oauthConfig) {
-    throw new Error("Notion OAuth config not found");
-  }
-
+  const oauthConfig = getOAuthConnectorConfig("notion");
   const response = await fetch(oauthConfig.tokenUrl, {
     method: "POST",
     headers: {
@@ -138,11 +130,7 @@ export async function refreshNotionToken(
   clientSecret: string,
   refreshToken: string,
 ): Promise<NotionRefreshResult> {
-  const oauthConfig = getConnectorOAuthConfig("notion");
-  if (!oauthConfig) {
-    throw new Error("Notion OAuth config not found");
-  }
-
+  const oauthConfig = getOAuthConnectorConfig("notion");
   const response = await fetch(oauthConfig.tokenUrl, {
     method: "POST",
     headers: {

--- a/turbo/packages/connectors/src/oauth-providers/providers/posthog.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/posthog.ts
@@ -1,4 +1,4 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
+import { getOAuthConnectorConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -32,11 +32,7 @@ export function buildPosthogAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): string {
-  const oauthConfig = getConnectorOAuthConfig("posthog");
-  if (!oauthConfig) {
-    throw new Error("PostHog OAuth config not found");
-  }
-
+  const oauthConfig = getOAuthConnectorConfig("posthog");
   const params = new URLSearchParams({
     client_id: clientId,
     redirect_uri: redirectUri,
@@ -57,11 +53,7 @@ export async function exchangePosthogCode(
   code: string,
   redirectUri: string,
 ): Promise<PosthogTokenResult> {
-  const oauthConfig = getConnectorOAuthConfig("posthog");
-  if (!oauthConfig) {
-    throw new Error("PostHog OAuth config not found");
-  }
-
+  const oauthConfig = getOAuthConnectorConfig("posthog");
   const response = await fetch(oauthConfig.tokenUrl, {
     method: "POST",
     headers: {
@@ -119,11 +111,7 @@ export async function refreshPosthogToken(
   clientSecret: string,
   refreshToken: string,
 ): Promise<PosthogRefreshResult> {
-  const oauthConfig = getConnectorOAuthConfig("posthog");
-  if (!oauthConfig) {
-    throw new Error("PostHog OAuth config not found");
-  }
-
+  const oauthConfig = getOAuthConnectorConfig("posthog");
   const response = await fetch(oauthConfig.tokenUrl, {
     method: "POST",
     headers: {

--- a/turbo/packages/connectors/src/oauth-providers/providers/reddit.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/reddit.ts
@@ -1,4 +1,4 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
+import { getOAuthConnectorConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -36,11 +36,7 @@ export function buildRedditAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): string {
-  const oauthConfig = getConnectorOAuthConfig("reddit");
-  if (!oauthConfig) {
-    throw new Error("Reddit OAuth config not found");
-  }
-
+  const oauthConfig = getOAuthConnectorConfig("reddit");
   const params = new URLSearchParams({
     client_id: clientId,
     response_type: "code",
@@ -63,11 +59,7 @@ export async function exchangeRedditCode(
   code: string,
   redirectUri: string,
 ): Promise<RedditTokenResult> {
-  const oauthConfig = getConnectorOAuthConfig("reddit");
-  if (!oauthConfig) {
-    throw new Error("Reddit OAuth config not found");
-  }
-
+  const oauthConfig = getOAuthConnectorConfig("reddit");
   const response = await fetch(oauthConfig.tokenUrl, {
     method: "POST",
     headers: {
@@ -166,11 +158,7 @@ export async function refreshRedditToken(
   clientSecret: string,
   refreshToken: string,
 ): Promise<RedditRefreshResult> {
-  const oauthConfig = getConnectorOAuthConfig("reddit");
-  if (!oauthConfig) {
-    throw new Error("Reddit OAuth config not found");
-  }
-
+  const oauthConfig = getOAuthConnectorConfig("reddit");
   const response = await fetch(oauthConfig.tokenUrl, {
     method: "POST",
     headers: {

--- a/turbo/packages/connectors/src/oauth-providers/providers/sentry.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/sentry.ts
@@ -1,4 +1,4 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
+import { getOAuthConnectorConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -30,11 +30,7 @@ export function buildSentryAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): string {
-  const oauthConfig = getConnectorOAuthConfig("sentry");
-  if (!oauthConfig) {
-    throw new Error("Sentry OAuth config not found");
-  }
-
+  const oauthConfig = getOAuthConnectorConfig("sentry");
   const params = new URLSearchParams({
     client_id: clientId,
     redirect_uri: redirectUri,
@@ -56,11 +52,7 @@ export async function exchangeSentryCode(
   code: string,
   redirectUri: string,
 ): Promise<SentryTokenResult> {
-  const oauthConfig = getConnectorOAuthConfig("sentry");
-  if (!oauthConfig) {
-    throw new Error("Sentry OAuth config not found");
-  }
-
+  const oauthConfig = getOAuthConnectorConfig("sentry");
   const response = await fetch(oauthConfig.tokenUrl, {
     method: "POST",
     headers: {
@@ -132,11 +124,7 @@ export async function refreshSentryToken(
   clientSecret: string,
   refreshToken: string,
 ): Promise<SentryRefreshResult> {
-  const oauthConfig = getConnectorOAuthConfig("sentry");
-  if (!oauthConfig) {
-    throw new Error("Sentry OAuth config not found");
-  }
-
+  const oauthConfig = getOAuthConnectorConfig("sentry");
   const response = await fetch(oauthConfig.tokenUrl, {
     method: "POST",
     headers: {

--- a/turbo/packages/connectors/src/oauth-providers/providers/slack.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/slack.ts
@@ -1,4 +1,4 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
+import { getOAuthConnectorConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -23,11 +23,7 @@ export function buildSlackAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): string {
-  const oauthConfig = getConnectorOAuthConfig("slack");
-  if (!oauthConfig) {
-    throw new Error("Slack OAuth config not found");
-  }
-
+  const oauthConfig = getOAuthConnectorConfig("slack");
   const params = new URLSearchParams({
     client_id: clientId,
     redirect_uri: redirectUri,
@@ -48,11 +44,7 @@ export async function exchangeSlackCode(
   code: string,
   redirectUri: string,
 ): Promise<SlackTokenResult> {
-  const oauthConfig = getConnectorOAuthConfig("slack");
-  if (!oauthConfig) {
-    throw new Error("Slack OAuth config not found");
-  }
-
+  const oauthConfig = getOAuthConnectorConfig("slack");
   const response = await fetch(oauthConfig.tokenUrl, {
     method: "POST",
     headers: {

--- a/turbo/packages/connectors/src/oauth-providers/providers/spotify.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/spotify.ts
@@ -1,4 +1,4 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
+import { getOAuthConnectorConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -32,11 +32,7 @@ export function buildSpotifyAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): string {
-  const oauthConfig = getConnectorOAuthConfig("spotify");
-  if (!oauthConfig) {
-    throw new Error("Spotify OAuth config not found");
-  }
-
+  const oauthConfig = getOAuthConnectorConfig("spotify");
   const params = new URLSearchParams({
     client_id: clientId,
     redirect_uri: redirectUri,
@@ -58,11 +54,7 @@ export async function exchangeSpotifyCode(
   code: string,
   redirectUri: string,
 ): Promise<SpotifyTokenResult> {
-  const oauthConfig = getConnectorOAuthConfig("spotify");
-  if (!oauthConfig) {
-    throw new Error("Spotify OAuth config not found");
-  }
-
+  const oauthConfig = getOAuthConnectorConfig("spotify");
   const basicAuth = Buffer.from(`${clientId}:${clientSecret}`).toString(
     "base64",
   );
@@ -123,11 +115,7 @@ export async function refreshSpotifyToken(
   clientSecret: string,
   refreshToken: string,
 ): Promise<SpotifyRefreshResult> {
-  const oauthConfig = getConnectorOAuthConfig("spotify");
-  if (!oauthConfig) {
-    throw new Error("Spotify OAuth config not found");
-  }
-
+  const oauthConfig = getOAuthConnectorConfig("spotify");
   const basicAuth = Buffer.from(`${clientId}:${clientSecret}`).toString(
     "base64",
   );

--- a/turbo/packages/connectors/src/oauth-providers/providers/strava.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/strava.ts
@@ -1,4 +1,4 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
+import { getOAuthConnectorConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -33,11 +33,7 @@ export function buildStravaAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): string {
-  const oauthConfig = getConnectorOAuthConfig("strava");
-  if (!oauthConfig) {
-    throw new Error("Strava OAuth config not found");
-  }
-
+  const oauthConfig = getOAuthConnectorConfig("strava");
   const params = new URLSearchParams({
     client_id: clientId,
     redirect_uri: redirectUri,
@@ -59,11 +55,7 @@ export async function exchangeStravaCode(
   clientSecret: string,
   code: string,
 ): Promise<StravaTokenResult> {
-  const oauthConfig = getConnectorOAuthConfig("strava");
-  if (!oauthConfig) {
-    throw new Error("Strava OAuth config not found");
-  }
-
+  const oauthConfig = getOAuthConnectorConfig("strava");
   const response = await fetch(oauthConfig.tokenUrl, {
     method: "POST",
     headers: {
@@ -139,11 +131,7 @@ export async function refreshStravaToken(
   clientSecret: string,
   refreshToken: string,
 ): Promise<StravaRefreshResult> {
-  const oauthConfig = getConnectorOAuthConfig("strava");
-  if (!oauthConfig) {
-    throw new Error("Strava OAuth config not found");
-  }
-
+  const oauthConfig = getOAuthConnectorConfig("strava");
   const response = await fetch(oauthConfig.tokenUrl, {
     method: "POST",
     headers: {

--- a/turbo/packages/connectors/src/oauth-providers/providers/stripe.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/stripe.ts
@@ -1,4 +1,4 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
+import { getOAuthConnectorConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -32,11 +32,7 @@ export function buildStripeAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): string {
-  const oauthConfig = getConnectorOAuthConfig("stripe");
-  if (!oauthConfig) {
-    throw new Error("Stripe OAuth config not found");
-  }
-
+  const oauthConfig = getOAuthConnectorConfig("stripe");
   const params = new URLSearchParams({
     client_id: clientId,
     redirect_uri: redirectUri,
@@ -57,11 +53,7 @@ export async function exchangeStripeCode(
   clientSecret: string,
   code: string,
 ): Promise<StripeTokenResult> {
-  const oauthConfig = getConnectorOAuthConfig("stripe");
-  if (!oauthConfig) {
-    throw new Error("Stripe OAuth config not found");
-  }
-
+  const oauthConfig = getOAuthConnectorConfig("stripe");
   const response = await fetch(oauthConfig.tokenUrl, {
     method: "POST",
     headers: {
@@ -122,11 +114,7 @@ export async function refreshStripeToken(
   clientSecret: string,
   refreshToken: string,
 ): Promise<StripeRefreshResult> {
-  const oauthConfig = getConnectorOAuthConfig("stripe");
-  if (!oauthConfig) {
-    throw new Error("Stripe OAuth config not found");
-  }
-
+  const oauthConfig = getOAuthConnectorConfig("stripe");
   const response = await fetch(oauthConfig.tokenUrl, {
     method: "POST",
     headers: {

--- a/turbo/packages/connectors/src/oauth-providers/providers/supabase.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/supabase.ts
@@ -1,4 +1,4 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
+import { getOAuthConnectorConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -65,11 +65,7 @@ export async function buildSupabaseAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): Promise<string> {
-  const oauthConfig = getConnectorOAuthConfig("supabase");
-  if (!oauthConfig) {
-    throw new Error("Supabase OAuth config not found");
-  }
-
+  const oauthConfig = getOAuthConnectorConfig("supabase");
   const codeVerifier = await deriveCodeVerifier(state);
   const codeChallenge = await computeCodeChallenge(codeVerifier);
 
@@ -96,11 +92,7 @@ export async function refreshSupabaseToken(
   clientSecret: string,
   refreshToken: string,
 ): Promise<SupabaseRefreshResult> {
-  const oauthConfig = getConnectorOAuthConfig("supabase");
-  if (!oauthConfig) {
-    throw new Error("Supabase OAuth config not found");
-  }
-
+  const oauthConfig = getOAuthConnectorConfig("supabase");
   const credentials = Buffer.from(`${clientId}:${clientSecret}`).toString(
     "base64",
   );
@@ -157,11 +149,7 @@ export async function exchangeSupabaseCode(
   redirectUri: string,
   state: string,
 ): Promise<SupabaseTokenResult> {
-  const oauthConfig = getConnectorOAuthConfig("supabase");
-  if (!oauthConfig) {
-    throw new Error("Supabase OAuth config not found");
-  }
-
+  const oauthConfig = getOAuthConnectorConfig("supabase");
   const codeVerifier = await deriveCodeVerifier(state);
   const credentials = Buffer.from(`${clientId}:${clientSecret}`).toString(
     "base64",

--- a/turbo/packages/connectors/src/oauth-providers/providers/test-oauth.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/test-oauth.ts
@@ -9,7 +9,7 @@
  * the provider routes themselves 404 in production via isTestEndpointAllowed().
  */
 
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
+import { getOAuthConnectorConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 export {
@@ -129,15 +129,12 @@ function previewBypassHeaders(): Record<string, string> {
 function getAuthorizationUrl(): string {
   return resolveUrl(
     "authorizationUrl",
-    getConnectorOAuthConfig("test-oauth")?.authorizationUrl,
+    getOAuthConnectorConfig("test-oauth").authorizationUrl,
   );
 }
 
 function getTokenUrl(): string {
-  return resolveUrl(
-    "tokenUrl",
-    getConnectorOAuthConfig("test-oauth")?.tokenUrl,
-  );
+  return resolveUrl("tokenUrl", getOAuthConnectorConfig("test-oauth").tokenUrl);
 }
 
 export function buildTestOAuthAuthorizationUrl(

--- a/turbo/packages/connectors/src/oauth-providers/providers/todoist.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/todoist.ts
@@ -1,4 +1,4 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
+import { getOAuthConnectorConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -23,11 +23,7 @@ export function buildTodoistAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): string {
-  const oauthConfig = getConnectorOAuthConfig("todoist");
-  if (!oauthConfig) {
-    throw new Error("Todoist OAuth config not found");
-  }
-
+  const oauthConfig = getOAuthConnectorConfig("todoist");
   const params = new URLSearchParams({
     client_id: clientId,
     scope: oauthConfig.scopes.join(","),
@@ -49,11 +45,7 @@ export async function exchangeTodoistCode(
   code: string,
   redirectUri: string,
 ): Promise<TodoistTokenResult> {
-  const oauthConfig = getConnectorOAuthConfig("todoist");
-  if (!oauthConfig) {
-    throw new Error("Todoist OAuth config not found");
-  }
-
+  const oauthConfig = getOAuthConnectorConfig("todoist");
   const response = await fetch(oauthConfig.tokenUrl, {
     method: "POST",
     headers: {

--- a/turbo/packages/connectors/src/oauth-providers/providers/vercel.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/vercel.ts
@@ -1,4 +1,4 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
+import { getOAuthConnectorConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -42,11 +42,7 @@ export async function exchangeVercelCode(
   code: string,
   redirectUri: string,
 ): Promise<VercelTokenResult> {
-  const oauthConfig = getConnectorOAuthConfig("vercel");
-  if (!oauthConfig) {
-    throw new Error("Vercel OAuth config not found");
-  }
-
+  const oauthConfig = getOAuthConnectorConfig("vercel");
   const response = await fetch(oauthConfig.tokenUrl, {
     method: "POST",
     headers: {

--- a/turbo/packages/connectors/src/oauth-providers/providers/webflow.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/webflow.ts
@@ -1,4 +1,4 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
+import { getOAuthConnectorConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -20,11 +20,7 @@ export function buildWebflowAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): string {
-  const oauthConfig = getConnectorOAuthConfig("webflow");
-  if (!oauthConfig) {
-    throw new Error("Webflow OAuth config not found");
-  }
-
+  const oauthConfig = getOAuthConnectorConfig("webflow");
   const params = new URLSearchParams({
     client_id: clientId,
     response_type: "code",
@@ -46,11 +42,7 @@ export async function exchangeWebflowCode(
   code: string,
   redirectUri: string,
 ): Promise<WebflowTokenResult> {
-  const oauthConfig = getConnectorOAuthConfig("webflow");
-  if (!oauthConfig) {
-    throw new Error("Webflow OAuth config not found");
-  }
-
+  const oauthConfig = getOAuthConnectorConfig("webflow");
   const response = await fetch(oauthConfig.tokenUrl, {
     method: "POST",
     headers: {

--- a/turbo/packages/connectors/src/oauth-providers/providers/x.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/x.ts
@@ -1,4 +1,4 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
+import { getOAuthConnectorConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -66,11 +66,7 @@ export async function buildXAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): Promise<string> {
-  const oauthConfig = getConnectorOAuthConfig("x");
-  if (!oauthConfig) {
-    throw new Error("X OAuth config not found");
-  }
-
+  const oauthConfig = getOAuthConnectorConfig("x");
   const codeVerifier = await deriveCodeVerifier(state);
   const codeChallenge = await computeCodeChallenge(codeVerifier);
 
@@ -97,11 +93,7 @@ export async function refreshXToken(
   clientSecret: string,
   refreshToken: string,
 ): Promise<XRefreshResult> {
-  const oauthConfig = getConnectorOAuthConfig("x");
-  if (!oauthConfig) {
-    throw new Error("X OAuth config not found");
-  }
-
+  const oauthConfig = getOAuthConnectorConfig("x");
   const credentials = Buffer.from(`${clientId}:${clientSecret}`).toString(
     "base64",
   );
@@ -157,11 +149,7 @@ export async function exchangeXCode(
   redirectUri: string,
   state: string,
 ): Promise<XTokenResult> {
-  const oauthConfig = getConnectorOAuthConfig("x");
-  if (!oauthConfig) {
-    throw new Error("X OAuth config not found");
-  }
-
+  const oauthConfig = getOAuthConnectorConfig("x");
   const codeVerifier = await deriveCodeVerifier(state);
   const credentials = Buffer.from(`${clientId}:${clientSecret}`).toString(
     "base64",

--- a/turbo/packages/connectors/src/oauth-providers/providers/xero.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/xero.ts
@@ -1,4 +1,4 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
+import { getOAuthConnectorConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -32,11 +32,7 @@ export function buildXeroAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): string {
-  const oauthConfig = getConnectorOAuthConfig("xero");
-  if (!oauthConfig) {
-    throw new Error("Xero OAuth config not found");
-  }
-
+  const oauthConfig = getOAuthConnectorConfig("xero");
   const params = new URLSearchParams({
     client_id: clientId,
     redirect_uri: redirectUri,
@@ -58,11 +54,7 @@ export async function exchangeXeroCode(
   code: string,
   redirectUri: string,
 ): Promise<XeroTokenResult> {
-  const oauthConfig = getConnectorOAuthConfig("xero");
-  if (!oauthConfig) {
-    throw new Error("Xero OAuth config not found");
-  }
-
+  const oauthConfig = getOAuthConnectorConfig("xero");
   const response = await fetch(oauthConfig.tokenUrl, {
     method: "POST",
     headers: {
@@ -122,11 +114,7 @@ export async function refreshXeroToken(
   clientSecret: string,
   refreshToken: string,
 ): Promise<XeroRefreshResult> {
-  const oauthConfig = getConnectorOAuthConfig("xero");
-  if (!oauthConfig) {
-    throw new Error("Xero OAuth config not found");
-  }
-
+  const oauthConfig = getOAuthConnectorConfig("xero");
   const response = await fetch(oauthConfig.tokenUrl, {
     method: "POST",
     headers: {

--- a/turbo/packages/connectors/src/oauth-providers/providers/zoom.ts
+++ b/turbo/packages/connectors/src/oauth-providers/providers/zoom.ts
@@ -1,4 +1,4 @@
-import { getConnectorOAuthConfig } from "@vm0/connectors/connector-utils";
+import { getOAuthConnectorConfig } from "@vm0/connectors/connector-utils";
 import { z } from "zod";
 import { throwOAuthError } from "./oauth-error";
 
@@ -32,11 +32,7 @@ export function buildZoomAuthorizationUrl(
   redirectUri: string,
   state: string,
 ): string {
-  const oauthConfig = getConnectorOAuthConfig("zoom");
-  if (!oauthConfig) {
-    throw new Error("Zoom OAuth config not found");
-  }
-
+  const oauthConfig = getOAuthConnectorConfig("zoom");
   const params = new URLSearchParams({
     client_id: clientId,
     redirect_uri: redirectUri,
@@ -60,11 +56,7 @@ export async function exchangeZoomCode(
   code: string,
   redirectUri: string,
 ): Promise<ZoomTokenResult> {
-  const oauthConfig = getConnectorOAuthConfig("zoom");
-  if (!oauthConfig) {
-    throw new Error("Zoom OAuth config not found");
-  }
-
+  const oauthConfig = getOAuthConnectorConfig("zoom");
   const basicAuth = Buffer.from(`${clientId}:${clientSecret}`).toString(
     "base64",
   );
@@ -126,11 +118,7 @@ export async function refreshZoomToken(
   clientSecret: string,
   refreshToken: string,
 ): Promise<ZoomRefreshResult> {
-  const oauthConfig = getConnectorOAuthConfig("zoom");
-  if (!oauthConfig) {
-    throw new Error("Zoom OAuth config not found");
-  }
-
+  const oauthConfig = getOAuthConnectorConfig("zoom");
   const basicAuth = Buffer.from(`${clientId}:${clientSecret}`).toString(
     "base64",
   );


### PR DESCRIPTION
## Summary
- make connector config typing require top-level OAuth config whenever an OAuth auth method is declared
- add typed helpers for OAuth config, generation metadata, and tags so callers do not rely on optional exact object properties
- remove redundant runtime OAuth config existence checks from OAuth provider implementations

## Tests
- pnpm -F @vm0/connectors check-types
- pnpm -F api check-types
- pnpm -F @vm0/connectors lint
- pnpm -F @vm0/connectors exec vitest run src/__tests__/connectors.test.ts
- pnpm -F api exec vitest run src/signals/routes/__tests__/zero-connectors-authorize.test.ts src/signals/routes/__tests__/connectors-type-callback.test.ts
- pre-commit hook: prettier, knip, pnpm check-types
